### PR TITLE
`ruff server` now supports the `source.organizeImports` source action

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_annotations/settings.rs
+++ b/crates/ruff_linter/src/rules/flake8_annotations/settings.rs
@@ -4,7 +4,7 @@ use crate::display_settings;
 use ruff_macros::CacheKey;
 use std::fmt::{Display, Formatter};
 
-#[derive(Debug, Default, CacheKey)]
+#[derive(Debug, Clone, Default, CacheKey)]
 #[allow(clippy::struct_excessive_bools)]
 pub struct Settings {
     pub mypy_init_return: bool,

--- a/crates/ruff_linter/src/rules/flake8_bandit/settings.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/settings.rs
@@ -10,7 +10,7 @@ pub fn default_tmp_dirs() -> Vec<String> {
         .to_vec()
 }
 
-#[derive(Debug, CacheKey)]
+#[derive(Debug, Clone, CacheKey)]
 pub struct Settings {
     pub hardcoded_tmp_directory: Vec<String>,
     pub check_typed_exception: bool,

--- a/crates/ruff_linter/src/rules/flake8_boolean_trap/settings.rs
+++ b/crates/ruff_linter/src/rules/flake8_boolean_trap/settings.rs
@@ -6,7 +6,7 @@ use ruff_macros::CacheKey;
 
 use crate::display_settings;
 
-#[derive(Debug, CacheKey, Default)]
+#[derive(Debug, Clone, CacheKey, Default)]
 pub struct Settings {
     pub extend_allowed_calls: Vec<String>,
 }

--- a/crates/ruff_linter/src/rules/flake8_bugbear/settings.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/settings.rs
@@ -4,7 +4,7 @@ use crate::display_settings;
 use ruff_macros::CacheKey;
 use std::fmt::{Display, Formatter};
 
-#[derive(Debug, Default, CacheKey)]
+#[derive(Debug, Clone, Default, CacheKey)]
 pub struct Settings {
     pub extend_immutable_calls: Vec<String>,
 }

--- a/crates/ruff_linter/src/rules/flake8_builtins/settings.rs
+++ b/crates/ruff_linter/src/rules/flake8_builtins/settings.rs
@@ -4,7 +4,7 @@ use crate::display_settings;
 use ruff_macros::CacheKey;
 use std::fmt::{Display, Formatter};
 
-#[derive(Debug, Default, CacheKey)]
+#[derive(Debug, Clone, Default, CacheKey)]
 pub struct Settings {
     pub builtins_ignorelist: Vec<String>,
 }

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/settings.rs
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/settings.rs
@@ -4,7 +4,7 @@ use crate::display_settings;
 use ruff_macros::CacheKey;
 use std::fmt::{Display, Formatter};
 
-#[derive(Debug, Default, CacheKey)]
+#[derive(Debug, Clone, Default, CacheKey)]
 pub struct Settings {
     pub allow_dict_calls_with_keyword_arguments: bool,
 }

--- a/crates/ruff_linter/src/rules/flake8_copyright/settings.rs
+++ b/crates/ruff_linter/src/rules/flake8_copyright/settings.rs
@@ -7,7 +7,7 @@ use std::fmt::{Display, Formatter};
 use crate::display_settings;
 use ruff_macros::CacheKey;
 
-#[derive(Debug, CacheKey)]
+#[derive(Debug, Clone, CacheKey)]
 pub struct Settings {
     pub notice_rgx: Regex,
     pub author: Option<String>,

--- a/crates/ruff_linter/src/rules/flake8_errmsg/settings.rs
+++ b/crates/ruff_linter/src/rules/flake8_errmsg/settings.rs
@@ -4,7 +4,7 @@ use crate::display_settings;
 use ruff_macros::CacheKey;
 use std::fmt::{Display, Formatter};
 
-#[derive(Debug, Default, CacheKey)]
+#[derive(Debug, Clone, Default, CacheKey)]
 pub struct Settings {
     pub max_string_length: usize,
 }

--- a/crates/ruff_linter/src/rules/flake8_gettext/settings.rs
+++ b/crates/ruff_linter/src/rules/flake8_gettext/settings.rs
@@ -2,7 +2,7 @@ use crate::display_settings;
 use ruff_macros::CacheKey;
 use std::fmt::{Display, Formatter};
 
-#[derive(Debug, CacheKey)]
+#[derive(Debug, Clone, CacheKey)]
 pub struct Settings {
     pub functions_names: Vec<String>,
 }

--- a/crates/ruff_linter/src/rules/flake8_implicit_str_concat/settings.rs
+++ b/crates/ruff_linter/src/rules/flake8_implicit_str_concat/settings.rs
@@ -4,7 +4,7 @@ use crate::display_settings;
 use ruff_macros::CacheKey;
 use std::fmt::{Display, Formatter};
 
-#[derive(Debug, CacheKey)]
+#[derive(Debug, Clone, CacheKey)]
 pub struct Settings {
     pub allow_multiline: bool,
 }

--- a/crates/ruff_linter/src/rules/flake8_import_conventions/settings.rs
+++ b/crates/ruff_linter/src/rules/flake8_import_conventions/settings.rs
@@ -57,7 +57,7 @@ impl FromIterator<String> for BannedAliases {
     }
 }
 
-#[derive(Debug, CacheKey)]
+#[derive(Debug, Clone, CacheKey)]
 pub struct Settings {
     pub aliases: FxHashMap<String, String>,
     pub banned_aliases: FxHashMap<String, BannedAliases>,

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/settings.rs
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/settings.rs
@@ -24,7 +24,7 @@ pub fn default_broad_exceptions() -> Vec<IdentifierPattern> {
     .to_vec()
 }
 
-#[derive(Debug, CacheKey)]
+#[derive(Debug, Clone, CacheKey)]
 pub struct Settings {
     pub fixture_parentheses: bool,
     pub parametrize_names_type: types::ParametrizeNameType,

--- a/crates/ruff_linter/src/rules/flake8_quotes/settings.rs
+++ b/crates/ruff_linter/src/rules/flake8_quotes/settings.rs
@@ -31,7 +31,7 @@ impl From<ruff_python_ast::str::Quote> for Quote {
     }
 }
 
-#[derive(Debug, CacheKey)]
+#[derive(Debug, Clone, CacheKey)]
 pub struct Settings {
     pub inline_quotes: Quote,
     pub multiline_quotes: Quote,

--- a/crates/ruff_linter/src/rules/flake8_self/settings.rs
+++ b/crates/ruff_linter/src/rules/flake8_self/settings.rs
@@ -17,7 +17,7 @@ pub const IGNORE_NAMES: [&str; 7] = [
     "_value_",
 ];
 
-#[derive(Debug, CacheKey)]
+#[derive(Debug, Clone, CacheKey)]
 pub struct Settings {
     pub ignore_names: Vec<String>,
 }

--- a/crates/ruff_linter/src/rules/flake8_tidy_imports/settings.rs
+++ b/crates/ruff_linter/src/rules/flake8_tidy_imports/settings.rs
@@ -39,7 +39,7 @@ impl Display for Strictness {
     }
 }
 
-#[derive(Debug, CacheKey, Default)]
+#[derive(Debug, Clone, CacheKey, Default)]
 pub struct Settings {
     pub ban_relative_imports: Strictness,
     pub banned_api: FxHashMap<String, ApiBan>,

--- a/crates/ruff_linter/src/rules/flake8_type_checking/settings.rs
+++ b/crates/ruff_linter/src/rules/flake8_type_checking/settings.rs
@@ -4,7 +4,7 @@ use crate::display_settings;
 use ruff_macros::CacheKey;
 use std::fmt::{Display, Formatter};
 
-#[derive(Debug, CacheKey)]
+#[derive(Debug, Clone, CacheKey)]
 pub struct Settings {
     pub strict: bool,
     pub exempt_modules: Vec<String>,

--- a/crates/ruff_linter/src/rules/flake8_unused_arguments/settings.rs
+++ b/crates/ruff_linter/src/rules/flake8_unused_arguments/settings.rs
@@ -4,7 +4,7 @@ use crate::display_settings;
 use ruff_macros::CacheKey;
 use std::fmt::{Display, Formatter};
 
-#[derive(Debug, Default, CacheKey)]
+#[derive(Debug, Clone, Default, CacheKey)]
 pub struct Settings {
     pub ignore_variadic_names: bool,
 }

--- a/crates/ruff_linter/src/rules/isort/categorize.rs
+++ b/crates/ruff_linter/src/rules/isort/categorize.rs
@@ -270,7 +270,7 @@ pub(crate) fn categorize_imports<'a>(
     block_by_type
 }
 
-#[derive(Debug, Default, CacheKey)]
+#[derive(Debug, Clone, Default, CacheKey)]
 pub struct KnownModules {
     /// A map of known modules to their section.
     known: Vec<(glob::Pattern, ImportSection)>,

--- a/crates/ruff_linter/src/rules/isort/settings.rs
+++ b/crates/ruff_linter/src/rules/isort/settings.rs
@@ -44,7 +44,7 @@ impl Display for RelativeImportsOrder {
     }
 }
 
-#[derive(Debug, CacheKey)]
+#[derive(Debug, Clone, CacheKey)]
 #[allow(clippy::struct_excessive_bools)]
 pub struct Settings {
     pub required_imports: BTreeSet<String>,

--- a/crates/ruff_linter/src/rules/mccabe/settings.rs
+++ b/crates/ruff_linter/src/rules/mccabe/settings.rs
@@ -4,7 +4,7 @@ use crate::display_settings;
 use ruff_macros::CacheKey;
 use std::fmt::{Display, Formatter};
 
-#[derive(Debug, CacheKey)]
+#[derive(Debug, Clone, CacheKey)]
 pub struct Settings {
     pub max_complexity: usize,
 }

--- a/crates/ruff_linter/src/rules/pep8_naming/settings.rs
+++ b/crates/ruff_linter/src/rules/pep8_naming/settings.rs
@@ -11,7 +11,7 @@ use ruff_macros::CacheKey;
 
 use crate::display_settings;
 
-#[derive(Debug, CacheKey)]
+#[derive(Debug, Clone, CacheKey)]
 pub struct Settings {
     pub ignore_names: IgnoreNames,
     pub classmethod_decorators: Vec<String>,
@@ -85,7 +85,7 @@ static DEFAULTS: &[&str] = &[
     "maxDiff",
 ];
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum IgnoreNames {
     Default,
     UserProvided {

--- a/crates/ruff_linter/src/rules/pycodestyle/settings.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/settings.rs
@@ -6,7 +6,7 @@ use std::fmt;
 
 use crate::line_width::LineLength;
 
-#[derive(Debug, Default, CacheKey)]
+#[derive(Debug, Clone, Default, CacheKey)]
 pub struct Settings {
     pub max_line_length: LineLength,
     pub max_doc_length: Option<LineLength>,

--- a/crates/ruff_linter/src/rules/pydocstyle/settings.rs
+++ b/crates/ruff_linter/src/rules/pydocstyle/settings.rs
@@ -83,7 +83,7 @@ impl fmt::Display for Convention {
     }
 }
 
-#[derive(Debug, Default, CacheKey)]
+#[derive(Debug, Clone, Default, CacheKey)]
 pub struct Settings {
     pub convention: Option<Convention>,
     pub ignore_decorators: BTreeSet<String>,

--- a/crates/ruff_linter/src/rules/pyflakes/settings.rs
+++ b/crates/ruff_linter/src/rules/pyflakes/settings.rs
@@ -4,7 +4,7 @@ use crate::display_settings;
 use ruff_macros::CacheKey;
 use std::fmt;
 
-#[derive(Debug, Default, CacheKey)]
+#[derive(Debug, Clone, Default, CacheKey)]
 pub struct Settings {
     pub extend_generics: Vec<String>,
 }

--- a/crates/ruff_linter/src/rules/pylint/settings.rs
+++ b/crates/ruff_linter/src/rules/pylint/settings.rs
@@ -48,7 +48,7 @@ impl fmt::Display for ConstantType {
     }
 }
 
-#[derive(Debug, CacheKey)]
+#[derive(Debug, Clone, CacheKey)]
 pub struct Settings {
     pub allow_magic_value_types: Vec<ConstantType>,
     pub allow_dunder_method_names: FxHashSet<String>,

--- a/crates/ruff_linter/src/rules/pyupgrade/settings.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/settings.rs
@@ -4,7 +4,7 @@ use crate::display_settings;
 use ruff_macros::CacheKey;
 use std::fmt;
 
-#[derive(Debug, Default, CacheKey)]
+#[derive(Debug, Clone, Default, CacheKey)]
 pub struct Settings {
     pub keep_runtime_typing: bool,
 }

--- a/crates/ruff_linter/src/settings/fix_safety_table.rs
+++ b/crates/ruff_linter/src/settings/fix_safety_table.rs
@@ -14,7 +14,7 @@ use crate::{
 
 /// A table to keep track of which rules fixes should have
 /// their safety overridden.
-#[derive(Debug, CacheKey, Default)]
+#[derive(Debug, Clone, CacheKey, Default)]
 pub struct FixSafetyTable {
     forced_safe: RuleSet,
     forced_unsafe: RuleSet,

--- a/crates/ruff_linter/src/settings/mod.rs
+++ b/crates/ruff_linter/src/settings/mod.rs
@@ -206,7 +206,7 @@ macro_rules! display_settings {
     };
 }
 
-#[derive(Debug, CacheKey)]
+#[derive(Debug, Clone, CacheKey)]
 pub struct LinterSettings {
     pub exclude: FilePatternSet,
     pub extension: ExtensionMapping,

--- a/crates/ruff_linter/src/settings/rule_table.rs
+++ b/crates/ruff_linter/src/settings/rule_table.rs
@@ -6,7 +6,7 @@ use ruff_macros::CacheKey;
 use crate::registry::{Rule, RuleSet, RuleSetIterator};
 
 /// A table to keep track of which rules are enabled and whether they should be fixed.
-#[derive(Debug, CacheKey, Default)]
+#[derive(Debug, Clone, CacheKey, Default)]
 pub struct RuleTable {
     /// Maps rule codes to a boolean indicating if the rule should be fixed.
     enabled: RuleSet,

--- a/crates/ruff_linter/src/settings/types.rs
+++ b/crates/ruff_linter/src/settings/types.rs
@@ -590,7 +590,7 @@ impl Display for RequiredVersion {
 /// pattern matching.
 pub type IdentifierPattern = glob::Pattern;
 
-#[derive(Debug, CacheKey, Default)]
+#[derive(Debug, Clone, CacheKey, Default)]
 pub struct PerFileIgnores {
     // Ordered as (absolute path matcher, basename matcher, rules)
     ignores: Vec<(GlobMatcher, GlobMatcher, RuleSet)>,

--- a/crates/ruff_server/src/server.rs
+++ b/crates/ruff_server/src/server.rs
@@ -271,7 +271,7 @@ impl SupportedCodeAction {
         [
             Self::QuickFix,
             Self::SourceFixAll,
-            // Self::SourceOrganizeImports,
+            Self::SourceOrganizeImports,
         ]
         .into_iter()
     }

--- a/crates/ruff_server/src/server/api/requests/code_action.rs
+++ b/crates/ruff_server/src/server/api/requests/code_action.rs
@@ -26,11 +26,11 @@ impl super::BackgroundDocumentRequestHandler for CodeActions {
     ) -> Result<Option<types::CodeActionResponse>> {
         let mut response: types::CodeActionResponse = types::CodeActionResponse::default();
 
-        let supported_code_actions = supported_code_actions(params.context.only);
+        let supported_code_actions = supported_code_actions(params.context.only.clone());
 
         if supported_code_actions.contains(&SupportedCodeAction::QuickFix) {
             response.extend(
-                quick_fix(&snapshot, params.context.diagnostics)
+                quick_fix(&snapshot, params.context.diagnostics.clone())
                     .with_failure_code(ErrorCode::InternalError)?,
             );
         }
@@ -126,7 +126,7 @@ fn organize_imports(snapshot: &DocumentSnapshot) -> crate::Result<CodeActionOrCo
             Some(resolve_edit_for_organize_imports(
                 document,
                 snapshot.url(),
-                snapshot.configuration().linter.clone(),
+                &snapshot.configuration().linter,
                 snapshot.encoding(),
             )?),
             None,

--- a/crates/ruff_server/src/server/api/requests/code_action.rs
+++ b/crates/ruff_server/src/server/api/requests/code_action.rs
@@ -9,7 +9,7 @@ use lsp_types::{self as types, request as req};
 use rustc_hash::FxHashSet;
 use types::{CodeActionKind, CodeActionOrCommand};
 
-use super::code_action_resolve::resolve_edit_for_fix_all;
+use super::code_action_resolve::{resolve_edit_for_fix_all, resolve_edit_for_organize_imports};
 
 pub(crate) struct CodeActions;
 
@@ -40,7 +40,7 @@ impl super::BackgroundDocumentRequestHandler for CodeActions {
         }
 
         if supported_code_actions.contains(&SupportedCodeAction::SourceOrganizeImports) {
-            todo!("Implement the `source.organizeImports` code action");
+            response.push(organize_imports(&snapshot).with_failure_code(ErrorCode::InternalError)?);
         }
 
         Ok(Some(response))
@@ -106,6 +106,34 @@ fn fix_all(snapshot: &DocumentSnapshot) -> crate::Result<CodeActionOrCommand> {
         data,
         ..Default::default()
     };
+    Ok(types::CodeActionOrCommand::CodeAction(action))
+}
+
+fn organize_imports(snapshot: &DocumentSnapshot) -> crate::Result<CodeActionOrCommand> {
+    let mut action = types::CodeAction {
+        title: format!("{DIAGNOSTIC_NAME}: Organize imports"),
+        kind: Some(types::CodeActionKind::SOURCE_ORGANIZE_IMPORTS),
+        // This will be resolved later
+        edit: None,
+        data: Some(serde_json::to_value(snapshot.url()).expect("document url to serialize")),
+        ..Default::default()
+    };
+
+    if !snapshot
+        .resolved_client_capabilities()
+        .code_action_deferred_edit_resolution
+    {
+        let document = snapshot.document();
+
+        // We need to resolve the `edit` field now if we can't defer resolution to later
+        action.edit = Some(resolve_edit_for_organize_imports(
+            document,
+            snapshot.url(),
+            snapshot.configuration().linter.clone(),
+            snapshot.encoding(),
+        )?);
+    }
+
     Ok(types::CodeActionOrCommand::CodeAction(action))
 }
 

--- a/crates/ruff_server/src/server/api/requests/code_action_resolve.rs
+++ b/crates/ruff_server/src/server/api/requests/code_action_resolve.rs
@@ -7,6 +7,7 @@ use crate::session::DocumentSnapshot;
 use crate::PositionEncoding;
 use lsp_server::ErrorCode;
 use lsp_types::{self as types, request as req};
+use ruff_linter::codes::Rule;
 use ruff_linter::settings::LinterSettings;
 
 pub(crate) struct CodeActionResolve;
@@ -94,8 +95,8 @@ pub(super) fn resolve_edit_for_organize_imports(
     encoding: PositionEncoding,
 ) -> crate::Result<types::WorkspaceEdit> {
     linter_settings.rules = [
-        ruff_linter::registry::Rule::from_code("I001").unwrap(),
-        ruff_linter::registry::Rule::from_code("I002").unwrap(),
+        Rule::UnusedImport,          // I001
+        Rule::MissingRequiredImport, // I002
     ]
     .into_iter()
     .collect();


### PR DESCRIPTION
## Summary

This builds on top of the work in https://github.com/astral-sh/ruff/pull/10597 to support `Ruff: Organize imports` as an available source action.

To do this, we have to support `Clone`-ing for linter settings, since we need to modify them in place to select import-related diagnostics specifically (`I001` and `I002`).

## Test Plan

https://github.com/astral-sh/ruff/assets/19577865/04282d01-dfda-4ac5-aa8f-6a92d5f85bfd