### PR TITLE
`ruff server` now supports commands for auto-fixing, organizing imports, and formatting

### DIFF
--- a/crates/ruff_server/src/edit.rs
+++ b/crates/ruff_server/src/edit.rs
@@ -4,11 +4,15 @@ mod document;
 mod range;
 mod replacement;
 
+use std::collections::HashMap;
+
 pub use document::Document;
 pub(crate) use document::DocumentVersion;
 use lsp_types::PositionEncodingKind;
 pub(crate) use range::{RangeExt, ToRangeExt};
 pub(crate) use replacement::Replacement;
+
+use crate::session::ResolvedClientCapabilities;
 
 /// A convenient enumeration for supported text encodings. Can be converted to [`lsp_types::PositionEncodingKind`].
 // Please maintain the order from least to greatest priority for the derived `Ord` impl.
@@ -23,6 +27,14 @@ pub enum PositionEncoding {
 
     /// Ruff's preferred encoding
     UTF8,
+}
+
+/// Tracks multi-document edits to eventually merge into a `WorkspaceEdit`.
+/// Compatible with clients that don't support `workspace.workspaceEdit.documentChanges`.
+#[derive(Debug)]
+pub(crate) enum WorkspaceEditTracker {
+    DocumentChanges(Vec<lsp_types::TextDocumentEdit>),
+    Changes(HashMap<lsp_types::Url, Vec<lsp_types::TextEdit>>),
 }
 
 impl From<PositionEncoding> for lsp_types::PositionEncodingKind {
@@ -48,5 +60,72 @@ impl TryFrom<&lsp_types::PositionEncodingKind> for PositionEncoding {
         } else {
             return Err(());
         })
+    }
+}
+
+impl WorkspaceEditTracker {
+    pub(crate) fn new(client_capabilities: &ResolvedClientCapabilities) -> Self {
+        if client_capabilities.document_changes {
+            Self::DocumentChanges(Vec::default())
+        } else {
+            Self::Changes(HashMap::default())
+        }
+    }
+
+    /// Sets the edits made to a specific document. This should only be called
+    /// once for each document `uri`, and will fail if this is called for the same `uri`
+    /// multiple times.
+    pub(crate) fn set_edits_for_document(
+        &mut self,
+        uri: lsp_types::Url,
+        version: DocumentVersion,
+        edits: Vec<lsp_types::TextEdit>,
+    ) -> crate::Result<()> {
+        match self {
+            Self::DocumentChanges(document_edits) => {
+                if document_edits
+                    .iter()
+                    .any(|document| document.text_document.uri == uri)
+                {
+                    return Err(anyhow::anyhow!(
+                        "Attempted to add edits for a document that was already edited"
+                    ));
+                }
+                document_edits.push(lsp_types::TextDocumentEdit {
+                    text_document: lsp_types::OptionalVersionedTextDocumentIdentifier {
+                        uri,
+                        version: Some(version),
+                    },
+                    edits: edits.into_iter().map(lsp_types::OneOf::Left).collect(),
+                });
+                Ok(())
+            }
+            Self::Changes(changes) => {
+                if changes.get(&uri).is_some() {
+                    return Err(anyhow::anyhow!(
+                        "Attempted to add edits for a document that was already edited"
+                    ));
+                }
+                changes.insert(uri, edits);
+                Ok(())
+            }
+        }
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        match self {
+            Self::DocumentChanges(document_edits) => document_edits.is_empty(),
+            Self::Changes(changes) => changes.is_empty(),
+        }
+    }
+
+    pub(crate) fn into_workspace_edit(self) -> lsp_types::WorkspaceEdit {
+        match self {
+            Self::DocumentChanges(document_edits) => lsp_types::WorkspaceEdit {
+                document_changes: Some(lsp_types::DocumentChanges::Edits(document_edits)),
+                ..Default::default()
+            },
+            Self::Changes(changes) => lsp_types::WorkspaceEdit::new(changes),
+        }
     }
 }

--- a/crates/ruff_server/src/lint.rs
+++ b/crates/ruff_server/src/lint.rs
@@ -35,7 +35,7 @@ pub(crate) struct DiagnosticFix {
     pub(crate) fixed_diagnostic: lsp_types::Diagnostic,
     pub(crate) title: String,
     pub(crate) code: String,
-    pub(crate) document_edits: Vec<lsp_types::TextDocumentEdit>,
+    pub(crate) edits: Vec<lsp_types::TextEdit>,
 }
 
 pub(crate) fn check(
@@ -90,11 +90,9 @@ pub(crate) fn check(
         .collect()
 }
 
-pub(crate) fn fixes_for_diagnostics<'d>(
-    document: &'d crate::edit::Document,
-    url: &'d lsp_types::Url,
+pub(crate) fn fixes_for_diagnostics(
+    document: &crate::edit::Document,
     encoding: PositionEncoding,
-    version: crate::edit::DocumentVersion,
     diagnostics: Vec<lsp_types::Diagnostic>,
 ) -> crate::Result<Vec<DiagnosticFix>> {
     diagnostics
@@ -118,14 +116,6 @@ pub(crate) fn fixes_for_diagnostics<'d>(
                         .to_range(document.contents(), document.index(), encoding),
                     new_text: edit.content().unwrap_or_default().to_string(),
                 });
-
-            let document_edits = vec![lsp_types::TextDocumentEdit {
-                text_document: lsp_types::OptionalVersionedTextDocumentIdentifier::new(
-                    url.clone(),
-                    version,
-                ),
-                edits: edits.map(lsp_types::OneOf::Left).collect(),
-            }];
             Ok(Some(DiagnosticFix {
                 fixed_diagnostic,
                 code: associated_data.code,
@@ -133,7 +123,7 @@ pub(crate) fn fixes_for_diagnostics<'d>(
                     .kind
                     .suggestion
                     .unwrap_or(associated_data.kind.name),
-                document_edits,
+                edits: edits.collect(),
             }))
         })
         .filter_map(crate::Result::transpose)

--- a/crates/ruff_server/src/server/api/requests.rs
+++ b/crates/ruff_server/src/server/api/requests.rs
@@ -1,16 +1,18 @@
 mod code_action;
 mod code_action_resolve;
 mod diagnostic;
+mod execute_command;
 mod format;
 mod format_range;
 
 use super::{
     define_document_url,
-    traits::{BackgroundDocumentRequestHandler, RequestHandler},
+    traits::{BackgroundDocumentRequestHandler, RequestHandler, SyncRequestHandler},
 };
 pub(super) use code_action::CodeActions;
 pub(super) use code_action_resolve::CodeActionResolve;
 pub(super) use diagnostic::DocumentDiagnostic;
+pub(super) use execute_command::ExecuteCommand;
 pub(super) use format::Format;
 pub(super) use format_range::FormatRange;
 

--- a/crates/ruff_server/src/server/api/requests/code_action.rs
+++ b/crates/ruff_server/src/server/api/requests/code_action.rs
@@ -53,20 +53,14 @@ fn quick_fix(
 ) -> crate::Result<impl Iterator<Item = CodeActionOrCommand> + '_> {
     let document = snapshot.document();
 
-    let fixes = fixes_for_diagnostics(
-        document,
-        snapshot.url(),
-        snapshot.encoding(),
-        document.version(),
-        diagnostics,
-    )?;
+    let fixes = fixes_for_diagnostics(document, snapshot.encoding(), diagnostics)?;
 
     Ok(fixes.into_iter().map(|fix| {
         types::CodeActionOrCommand::CodeAction(types::CodeAction {
             title: format!("{DIAGNOSTIC_NAME} ({}): {}", fix.code, fix.title),
             kind: Some(types::CodeActionKind::QUICKFIX),
             edit: Some(types::WorkspaceEdit {
-                document_changes: Some(types::DocumentChanges::Edits(fix.document_edits.clone())),
+                changes: Some([(snapshot.url().clone(), fix.edits)].into_iter().collect()),
                 ..Default::default()
             }),
             diagnostics: Some(vec![fix.fixed_diagnostic.clone()]),

--- a/crates/ruff_server/src/server/api/requests/code_action.rs
+++ b/crates/ruff_server/src/server/api/requests/code_action.rs
@@ -1,3 +1,4 @@
+use crate::edit::WorkspaceEditTracker;
 use crate::lint::fixes_for_diagnostics;
 use crate::server::api::LSPResult;
 use crate::server::SupportedCodeAction;
@@ -50,24 +51,34 @@ impl super::BackgroundDocumentRequestHandler for CodeActions {
 fn quick_fix(
     snapshot: &DocumentSnapshot,
     diagnostics: Vec<types::Diagnostic>,
-) -> crate::Result<impl Iterator<Item = CodeActionOrCommand> + '_> {
+) -> crate::Result<Vec<CodeActionOrCommand>> {
     let document = snapshot.document();
 
     let fixes = fixes_for_diagnostics(document, snapshot.encoding(), diagnostics)?;
 
-    Ok(fixes.into_iter().map(|fix| {
-        types::CodeActionOrCommand::CodeAction(types::CodeAction {
-            title: format!("{DIAGNOSTIC_NAME} ({}): {}", fix.code, fix.title),
-            kind: Some(types::CodeActionKind::QUICKFIX),
-            edit: Some(types::WorkspaceEdit {
-                changes: Some([(snapshot.url().clone(), fix.edits)].into_iter().collect()),
+    fixes
+        .into_iter()
+        .map(|fix| {
+            let mut tracker = WorkspaceEditTracker::new(snapshot.resolved_client_capabilities());
+
+            tracker.set_edits_for_document(
+                snapshot.url().clone(),
+                document.version(),
+                fix.edits,
+            )?;
+
+            Ok(types::CodeActionOrCommand::CodeAction(types::CodeAction {
+                title: format!("{DIAGNOSTIC_NAME} ({}): {}", fix.code, fix.title),
+                kind: Some(types::CodeActionKind::QUICKFIX),
+                edit: Some(tracker.into_workspace_edit()),
+                diagnostics: Some(vec![fix.fixed_diagnostic.clone()]),
+                data: Some(
+                    serde_json::to_value(snapshot.url()).expect("document url to serialize"),
+                ),
                 ..Default::default()
-            }),
-            diagnostics: Some(vec![fix.fixed_diagnostic.clone()]),
-            data: Some(serde_json::to_value(snapshot.url()).expect("document url to serialize")),
-            ..Default::default()
+            }))
         })
-    }))
+        .collect()
 }
 
 fn fix_all(snapshot: &DocumentSnapshot) -> crate::Result<CodeActionOrCommand> {
@@ -86,9 +97,11 @@ fn fix_all(snapshot: &DocumentSnapshot) -> crate::Result<CodeActionOrCommand> {
         (
             Some(resolve_edit_for_fix_all(
                 document,
+                snapshot.resolved_client_capabilities(),
                 snapshot.url(),
                 &snapshot.configuration().linter,
                 snapshot.encoding(),
+                document.version(),
             )?),
             None,
         )
@@ -119,9 +132,11 @@ fn organize_imports(snapshot: &DocumentSnapshot) -> crate::Result<CodeActionOrCo
         (
             Some(resolve_edit_for_organize_imports(
                 document,
+                snapshot.resolved_client_capabilities(),
                 snapshot.url(),
                 &snapshot.configuration().linter,
                 snapshot.encoding(),
+                document.version(),
             )?),
             None,
         )

--- a/crates/ruff_server/src/server/api/requests/code_action_resolve.rs
+++ b/crates/ruff_server/src/server/api/requests/code_action_resolve.rs
@@ -79,7 +79,7 @@ pub(super) fn resolve_edit_for_fix_all(
         changes: Some(
             [(
                 url.clone(),
-                crate::fix::fix_all(document, linter_settings, encoding)?,
+                fix_all_edit(document, linter_settings, encoding)?,
             )]
             .into_iter()
             .collect(),
@@ -88,12 +88,38 @@ pub(super) fn resolve_edit_for_fix_all(
     })
 }
 
+pub(super) fn fix_all_edit(
+    document: &crate::edit::Document,
+    linter_settings: &LinterSettings,
+    encoding: PositionEncoding,
+) -> crate::Result<Vec<types::TextEdit>> {
+    crate::fix::fix_all(document, linter_settings, encoding)
+}
+
 pub(super) fn resolve_edit_for_organize_imports(
     document: &crate::edit::Document,
     url: &types::Url,
     linter_settings: &ruff_linter::settings::LinterSettings,
     encoding: PositionEncoding,
 ) -> crate::Result<types::WorkspaceEdit> {
+    Ok(types::WorkspaceEdit {
+        changes: Some(
+            [(
+                url.clone(),
+                organize_imports_edit(document, linter_settings, encoding)?,
+            )]
+            .into_iter()
+            .collect(),
+        ),
+        ..Default::default()
+    })
+}
+
+pub(super) fn organize_imports_edit(
+    document: &crate::edit::Document,
+    linter_settings: &LinterSettings,
+    encoding: PositionEncoding,
+) -> crate::Result<Vec<types::TextEdit>> {
     let mut linter_settings = linter_settings.clone();
     linter_settings.rules = [
         Rule::UnsortedImports,       // I001
@@ -102,15 +128,5 @@ pub(super) fn resolve_edit_for_organize_imports(
     .into_iter()
     .collect();
 
-    Ok(types::WorkspaceEdit {
-        changes: Some(
-            [(
-                url.clone(),
-                crate::fix::fix_all(document, &linter_settings, encoding)?,
-            )]
-            .into_iter()
-            .collect(),
-        ),
-        ..Default::default()
-    })
+    crate::fix::fix_all(document, &linter_settings, encoding)
 }

--- a/crates/ruff_server/src/server/api/requests/execute_command.rs
+++ b/crates/ruff_server/src/server/api/requests/execute_command.rs
@@ -1,6 +1,5 @@
 use std::collections::HashMap;
 
-use crate::edit::DocumentVersion;
 use crate::server;
 use crate::server::api::LSPResult;
 use crate::server::client;
@@ -22,8 +21,6 @@ pub(crate) struct ExecuteCommand;
 #[derive(Deserialize)]
 struct TextDocumentArgument {
     uri: types::Url,
-    #[allow(dead_code)] // needed for deserialization
-    version: DocumentVersion,
 }
 
 impl super::RequestHandler for ExecuteCommand {

--- a/crates/ruff_server/src/server/api/requests/execute_command.rs
+++ b/crates/ruff_server/src/server/api/requests/execute_command.rs
@@ -1,14 +1,15 @@
 use std::{collections::HashMap, str::FromStr};
 
-use crate::server;
 use crate::server::api::LSPResult;
 use crate::server::client;
 use crate::server::schedule::Task;
 use crate::session::Session;
 use crate::DIAGNOSTIC_NAME;
+use crate::{edit::DocumentVersion, server};
 use lsp_server::ErrorCode;
 use lsp_types::{self as types, request as req};
 use serde::Deserialize;
+use types::TextDocumentEdit;
 
 #[derive(Debug)]
 enum Command {
@@ -22,6 +23,13 @@ pub(crate) struct ExecuteCommand;
 #[derive(Deserialize)]
 struct TextDocumentArgument {
     uri: types::Url,
+    version: DocumentVersion,
+}
+
+#[derive(Debug)]
+enum EditTracker {
+    DocumentChanges(Vec<types::TextDocumentEdit>),
+    Changes(HashMap<types::Url, Vec<types::TextEdit>>),
 }
 
 impl super::RequestHandler for ExecuteCommand {
@@ -43,16 +51,14 @@ impl super::SyncRequestHandler for ExecuteCommand {
             return Err(anyhow::anyhow!("Cannot execute the '{}' command: the client does not support `workspace/applyEdit`", command.label())).with_failure_code(ErrorCode::InternalError);
         }
 
-        let mut changes = HashMap::new();
+        let mut edit_tracker =
+            EditTracker::new(session.resolved_client_capabilities().document_changes);
         for arg in params.arguments {
-            let document_arg: TextDocumentArgument =
+            let TextDocumentArgument { uri, version } =
                 serde_json::from_value(arg).with_failure_code(ErrorCode::InvalidParams)?;
             let snapshot = session
-                .take_snapshot(&document_arg.uri)
-                .ok_or(anyhow::anyhow!(
-                    "Document snapshot not available for {}",
-                    document_arg.uri
-                ))
+                .take_snapshot(&uri)
+                .ok_or(anyhow::anyhow!("Document snapshot not available for {uri}",))
                 .with_failure_code(ErrorCode::InternalError)?;
             match command {
                 Command::FixAll => {
@@ -62,12 +68,12 @@ impl super::SyncRequestHandler for ExecuteCommand {
                         snapshot.encoding(),
                     )
                     .with_failure_code(ErrorCode::InternalError)?;
-                    changes.insert(document_arg.uri, edits);
+                    edit_tracker.add_edits_for_document(uri, version, edits);
                 }
                 Command::Format => {
                     let response = super::format::format_document(&snapshot)?;
                     if let Some(edits) = response {
-                        changes.insert(document_arg.uri, edits);
+                        edit_tracker.add_edits_for_document(uri, version, edits);
                     }
                 }
                 Command::OrganizeImports => {
@@ -77,16 +83,16 @@ impl super::SyncRequestHandler for ExecuteCommand {
                         snapshot.encoding(),
                     )
                     .with_failure_code(ErrorCode::InternalError)?;
-                    changes.insert(document_arg.uri, edits);
+                    edit_tracker.add_edits_for_document(uri, version, edits);
                 }
             }
         }
 
-        if !changes.is_empty() {
+        if !edit_tracker.is_empty() {
             apply_edit(
                 requester,
                 command.label(),
-                types::WorkspaceEdit::new(changes),
+                edit_tracker.into_workspace_edit(),
             )
             .with_failure_code(ErrorCode::InternalError)?;
         }
@@ -115,6 +121,71 @@ impl FromStr for Command {
             "ruff.applyOrganizeImports" => Self::OrganizeImports,
             _ => return Err(anyhow::anyhow!("Invalid command `{name}`")),
         })
+    }
+}
+
+impl EditTracker {
+    fn new(document_changes_supported: bool) -> Self {
+        if document_changes_supported {
+            Self::DocumentChanges(Vec::default())
+        } else {
+            Self::Changes(HashMap::default())
+        }
+    }
+
+    fn add_edits_for_document(
+        &mut self,
+        uri: types::Url,
+        version: DocumentVersion,
+        new_edits: Vec<types::TextEdit>,
+    ) {
+        match self {
+            Self::DocumentChanges(document_edits) => {
+                if let Some(existing_edits) = document_edits
+                    .iter_mut()
+                    .find(|document| document.text_document.uri == uri)
+                {
+                    // A single task should only ever be operating on one version of a document. To operate on multiple simultaneous document versions
+                    // is a logic error.
+                    debug_assert_eq!(existing_edits.text_document.version, Some(version));
+                    existing_edits
+                        .edits
+                        .extend(new_edits.into_iter().map(types::OneOf::Left));
+                } else {
+                    document_edits.push(TextDocumentEdit {
+                        text_document: types::OptionalVersionedTextDocumentIdentifier {
+                            uri,
+                            version: Some(version),
+                        },
+                        edits: new_edits.into_iter().map(types::OneOf::Left).collect(),
+                    });
+                }
+            }
+            Self::Changes(changes) => {
+                if let Some(existing_edits) = changes.get_mut(&uri) {
+                    existing_edits.extend(new_edits);
+                } else {
+                    changes.insert(uri, new_edits);
+                }
+            }
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        match self {
+            Self::DocumentChanges(document_edits) => document_edits.is_empty(),
+            Self::Changes(changes) => changes.is_empty(),
+        }
+    }
+
+    fn into_workspace_edit(self) -> types::WorkspaceEdit {
+        match self {
+            Self::DocumentChanges(document_edits) => types::WorkspaceEdit {
+                document_changes: Some(types::DocumentChanges::Edits(document_edits)),
+                ..Default::default()
+            },
+            Self::Changes(changes) => types::WorkspaceEdit::new(changes),
+        }
     }
 }
 

--- a/crates/ruff_server/src/server/api/requests/execute_command.rs
+++ b/crates/ruff_server/src/server/api/requests/execute_command.rs
@@ -1,0 +1,143 @@
+use std::collections::HashMap;
+
+use crate::edit::DocumentVersion;
+use crate::server;
+use crate::server::api::LSPResult;
+use crate::server::client;
+use crate::server::schedule::Task;
+use crate::session::Session;
+use crate::DIAGNOSTIC_NAME;
+use lsp_server::ErrorCode;
+use lsp_types::{self as types, request as req};
+use serde::Deserialize;
+
+enum Command {
+    Format,
+    FixAll,
+    OrganizeImports,
+}
+
+pub(crate) struct ExecuteCommand;
+
+#[derive(Deserialize)]
+struct TextDocumentArgument {
+    uri: types::Url,
+    #[allow(dead_code)] // needed for deserialization
+    version: DocumentVersion,
+}
+
+impl super::RequestHandler for ExecuteCommand {
+    type RequestType = req::ExecuteCommand;
+}
+
+impl super::SyncRequestHandler for ExecuteCommand {
+    fn run(
+        session: &mut Session,
+        _notifier: client::Notifier,
+        requester: &mut client::Requester,
+        params: types::ExecuteCommandParams,
+    ) -> server::Result<Option<serde_json::Value>> {
+        let Some(command) = Command::from_str(&params.command) else {
+            return Err(anyhow::anyhow!("")).with_failure_code(ErrorCode::InvalidParams);
+        };
+
+        let mut changes = HashMap::new();
+        let documents =
+            args_as_text_documents(params.arguments).with_failure_code(ErrorCode::InvalidParams)?;
+        for document in documents {
+            let snapshot = session
+                .take_snapshot(&document.uri)
+                .ok_or(anyhow::anyhow!(
+                    "Document snapshot not available for {}",
+                    document.uri
+                ))
+                .with_failure_code(ErrorCode::InternalError)?;
+            match command {
+                Command::FixAll => {
+                    let edits = super::code_action_resolve::fix_all_edit(
+                        snapshot.document(),
+                        &snapshot.configuration().linter,
+                        snapshot.encoding(),
+                    )
+                    .with_failure_code(ErrorCode::InternalError)?;
+                    changes.insert(document.uri, edits);
+                }
+                Command::Format => {
+                    let response = super::format::format_document(&snapshot)?;
+                    if let Some(edits) = response {
+                        changes.insert(document.uri, edits);
+                    }
+                }
+                Command::OrganizeImports => {
+                    let edits = super::code_action_resolve::organize_imports_edit(
+                        snapshot.document(),
+                        &snapshot.configuration().linter,
+                        snapshot.encoding(),
+                    )
+                    .with_failure_code(ErrorCode::InternalError)?;
+                    changes.insert(document.uri, edits);
+                }
+            }
+        }
+
+        if !changes.is_empty() {
+            apply_edit(
+                requester,
+                command.label(),
+                types::WorkspaceEdit::new(changes),
+            )
+            .with_failure_code(ErrorCode::InternalError)?;
+        }
+
+        Ok(None)
+    }
+}
+
+impl Command {
+    fn from_str(command: &str) -> Option<Command> {
+        Some(match command {
+            "ruff.applyAutofix" => Self::FixAll,
+            "ruff.applyFormat" => Self::Format,
+            "ruff.applyOrganizeImports" => Self::OrganizeImports,
+            _ => return None,
+        })
+    }
+
+    fn label(&self) -> &str {
+        match self {
+            Self::FixAll => "Fix all auto-fixable problems",
+            Self::Format => "Format document",
+            Self::OrganizeImports => "Format imports",
+        }
+    }
+}
+
+fn args_as_text_documents(
+    args: Vec<serde_json::Value>,
+) -> crate::Result<Vec<TextDocumentArgument>> {
+    args.into_iter()
+        .map(|value| Ok(serde_json::from_value(value)?))
+        .collect()
+}
+
+fn apply_edit(
+    requester: &mut client::Requester,
+    label: &str,
+    edit: types::WorkspaceEdit,
+) -> crate::Result<()> {
+    requester.request::<req::ApplyWorkspaceEdit>(
+        types::ApplyWorkspaceEditParams {
+            label: Some(format!("{DIAGNOSTIC_NAME}: {label}")),
+            edit,
+        },
+        |response| {
+            if !response.applied {
+                let reason = response
+                    .failure_reason
+                    .unwrap_or_else(|| String::from("unspecified reason"));
+                tracing::error!("Failed to apply workspace edit: {}", reason);
+            }
+            Task::nothing()
+        },
+    )
+}

--- a/crates/ruff_server/src/server/api/requests/execute_command.rs
+++ b/crates/ruff_server/src/server/api/requests/execute_command.rs
@@ -78,6 +78,10 @@ impl super::SyncRequestHandler for ExecuteCommand {
         }
 
         if !changes.is_empty() {
+            // check if we can apply a workspace edit
+            if !session.resolved_client_capabilities().apply_edit {
+                return Err(anyhow::anyhow!("Cannot send workspace edit to client: the client does not support `workspace/applyEdit`")).with_failure_code(ErrorCode::InternalError);
+            }
             apply_edit(
                 requester,
                 command.label(),

--- a/crates/ruff_server/src/server/api/requests/execute_command.rs
+++ b/crates/ruff_server/src/server/api/requests/execute_command.rs
@@ -27,7 +27,7 @@ struct TextDocumentArgument {
 }
 
 #[derive(Debug)]
-enum EditTracker {
+enum CommandEditTracker {
     DocumentChanges(Vec<types::TextDocumentEdit>),
     Changes(HashMap<types::Url, Vec<types::TextEdit>>),
 }
@@ -52,7 +52,7 @@ impl super::SyncRequestHandler for ExecuteCommand {
         }
 
         let mut edit_tracker =
-            EditTracker::new(session.resolved_client_capabilities().document_changes);
+            CommandEditTracker::new(session.resolved_client_capabilities().document_changes);
         for arg in params.arguments {
             let TextDocumentArgument { uri, version } =
                 serde_json::from_value(arg).with_failure_code(ErrorCode::InvalidParams)?;
@@ -130,7 +130,7 @@ impl FromStr for Command {
     }
 }
 
-impl EditTracker {
+impl CommandEditTracker {
     fn new(document_changes_supported: bool) -> Self {
         if document_changes_supported {
             Self::DocumentChanges(Vec::default())

--- a/crates/ruff_server/src/server/api/requests/format.rs
+++ b/crates/ruff_server/src/server/api/requests/format.rs
@@ -19,31 +19,35 @@ impl super::BackgroundDocumentRequestHandler for Format {
         _notifier: Notifier,
         _params: types::DocumentFormattingParams,
     ) -> Result<super::FormatResponse> {
-        let doc = snapshot.document();
-        let source = doc.contents();
-        let formatted = crate::format::format(doc, &snapshot.configuration().formatter)
-            .with_failure_code(lsp_server::ErrorCode::InternalError)?;
-        // fast path - if the code is the same, return early
-        if formatted == source {
-            return Ok(None);
-        }
-        let formatted_index: LineIndex = LineIndex::from_source_text(&formatted);
-
-        let unformatted_index = doc.index();
-
-        let Replacement {
-            source_range,
-            modified_range: formatted_range,
-        } = Replacement::between(
-            source,
-            unformatted_index.line_starts(),
-            &formatted,
-            formatted_index.line_starts(),
-        );
-
-        Ok(Some(vec![TextEdit {
-            range: source_range.to_range(source, unformatted_index, snapshot.encoding()),
-            new_text: formatted[formatted_range].to_owned(),
-        }]))
+        format_document(&snapshot)
     }
+}
+
+pub(super) fn format_document(snapshot: &DocumentSnapshot) -> Result<super::FormatResponse> {
+    let doc = snapshot.document();
+    let source = doc.contents();
+    let formatted = crate::format::format(doc, &snapshot.configuration().formatter)
+        .with_failure_code(lsp_server::ErrorCode::InternalError)?;
+    // fast path - if the code is the same, return early
+    if formatted == source {
+        return Ok(None);
+    }
+    let formatted_index: LineIndex = LineIndex::from_source_text(&formatted);
+
+    let unformatted_index = doc.index();
+
+    let Replacement {
+        source_range,
+        modified_range: formatted_range,
+    } = Replacement::between(
+        source,
+        unformatted_index.line_starts(),
+        &formatted,
+        formatted_index.line_starts(),
+    );
+
+    Ok(Some(vec![TextEdit {
+        range: source_range.to_range(source, unformatted_index, snapshot.encoding()),
+        new_text: formatted[formatted_range].to_owned(),
+    }]))
 }

--- a/crates/ruff_server/src/server/api/traits.rs
+++ b/crates/ruff_server/src/server/api/traits.rs
@@ -1,6 +1,6 @@
 //! A stateful LSP implementation that calls into the Ruff API.
 
-use crate::server::client::Notifier;
+use crate::server::client::{Notifier, Requester};
 use crate::session::{DocumentSnapshot, Session};
 
 use lsp_types::notification::Notification as LSPNotification;
@@ -20,6 +20,7 @@ pub(super) trait SyncRequestHandler: RequestHandler {
     fn run(
         session: &mut Session,
         notifier: Notifier,
+        requester: &mut Requester,
         params: <<Self as RequestHandler>::RequestType as Request>::Params,
     ) -> super::Result<<<Self as RequestHandler>::RequestType as Request>::Result>;
 }

--- a/crates/ruff_server/src/server/schedule.rs
+++ b/crates/ruff_server/src/server/schedule.rs
@@ -80,10 +80,13 @@ impl<'s> Scheduler<'s> {
     pub(super) fn dispatch(&mut self, task: task::Task<'s>) {
         match task {
             Task::Sync(SyncTask { func }) => {
+                let notifier = self.client.notifier();
+                let responder = self.client.responder();
                 func(
                     self.session,
-                    self.client.notifier(),
-                    self.client.responder(),
+                    notifier,
+                    &mut self.client.requester,
+                    responder,
                 );
             }
             Task::Background(BackgroundTaskBuilder {

--- a/crates/ruff_server/src/session.rs
+++ b/crates/ruff_server/src/session.rs
@@ -15,7 +15,7 @@ use rustc_hash::FxHashMap;
 use crate::edit::{Document, DocumentVersion};
 use crate::PositionEncoding;
 
-use self::capabilities::ResolvedClientCapabilities;
+pub(crate) use self::capabilities::ResolvedClientCapabilities;
 use self::settings::ResolvedClientSettings;
 pub(crate) use self::settings::{AllSettings, ClientSettings};
 

--- a/crates/ruff_server/src/session.rs
+++ b/crates/ruff_server/src/session.rs
@@ -140,6 +140,10 @@ impl Session {
         Ok(())
     }
 
+    pub(crate) fn resolved_client_capabilities(&self) -> &ResolvedClientCapabilities {
+        &self.resolved_client_capabilities
+    }
+
     pub(crate) fn encoding(&self) -> PositionEncoding {
         self.position_encoding
     }

--- a/crates/ruff_server/src/session/capabilities.rs
+++ b/crates/ruff_server/src/session/capabilities.rs
@@ -3,6 +3,7 @@ use lsp_types::ClientCapabilities;
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub(crate) struct ResolvedClientCapabilities {
     pub(crate) code_action_deferred_edit_resolution: bool,
+    pub(crate) apply_edit: bool,
 }
 
 impl ResolvedClientCapabilities {
@@ -17,9 +18,17 @@ impl ResolvedClientCapabilities {
         let code_action_edit_resolution = code_action_settings
             .and_then(|code_action_settings| code_action_settings.resolve_support.as_ref())
             .is_some_and(|resolve_support| resolve_support.properties.contains(&"edit".into()));
+
+        let apply_edit = client_capabilities
+            .workspace
+            .as_ref()
+            .and_then(|workspace| workspace.apply_edit)
+            .unwrap_or_default();
+
         Self {
             code_action_deferred_edit_resolution: code_action_data_support
                 && code_action_edit_resolution,
+            apply_edit,
         }
     }
 }

--- a/crates/ruff_server/src/session/capabilities.rs
+++ b/crates/ruff_server/src/session/capabilities.rs
@@ -4,6 +4,7 @@ use lsp_types::ClientCapabilities;
 pub(crate) struct ResolvedClientCapabilities {
     pub(crate) code_action_deferred_edit_resolution: bool,
     pub(crate) apply_edit: bool,
+    pub(crate) document_changes: bool,
 }
 
 impl ResolvedClientCapabilities {
@@ -25,10 +26,18 @@ impl ResolvedClientCapabilities {
             .and_then(|workspace| workspace.apply_edit)
             .unwrap_or_default();
 
+        let document_changes = client_capabilities
+            .workspace
+            .as_ref()
+            .and_then(|workspace| workspace.workspace_edit.as_ref())
+            .and_then(|workspace_edit| workspace_edit.document_changes)
+            .unwrap_or_default();
+
         Self {
             code_action_deferred_edit_resolution: code_action_data_support
                 && code_action_edit_resolution,
             apply_edit,
+            document_changes,
         }
     }
 }


### PR DESCRIPTION
## Summary

This builds off of the work in https://github.com/astral-sh/ruff/pull/10652 to implement a command executor, backwards compatible with the commands from the previous LSP (`ruff.applyAutofix`, `ruff.applyFormat` and `ruff.applyOrganizeImports`). 

This involved a lot of refactoring and tweaks to the code action resolution code - the most notable change is that workspace edits are specified in a slightly different way, using the more general `changes` field instead of the `document_changes` field (which isn't supported on all LSP clients). Additionally, the API for synchronous request handlers has been updated to include access to the `Requester`, which we use to send a `workspace/applyEdit` request to the client.

## Test Plan


https://github.com/astral-sh/ruff/assets/19577865/7932e30f-d944-4e35-b828-1d81aa56c087


