### PR TITLE
Limit `bitwise_or` precedence for starred expression with error

### DIFF
--- a/crates/ruff_python_parser/resources/valid/expressions/dictionary.py
+++ b/crates/ruff_python_parser/resources/valid/expressions/dictionary.py
@@ -31,6 +31,8 @@
 {"a": "b", **c, "d": "e"}
 {1: 2, **{'nested': 'dict'}}
 {x * 1: y ** 2, **call()}
+# Here, `not` isn't allowed but parentheses resets the precedence
+{**(not x)}
 
 # Random expressions
 {1: x if True else y}

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__dict__double_star.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__dict__double_star.py.snap
@@ -50,57 +50,57 @@ Module(
             ),
             Expr(
                 StmtExpr {
-                    range: 136..161,
-                    value: If(
-                        ExprIf {
-                            range: 136..161,
-                            test: BooleanLiteral(
-                                ExprBooleanLiteral {
-                                    range: 150..154,
-                                    value: true,
-                                },
-                            ),
-                            body: Dict(
-                                ExprDict {
-                                    range: 136..146,
-                                    keys: [
-                                        Some(
-                                            Name(
-                                                ExprName {
-                                                    range: 137..138,
-                                                    id: "a",
-                                                    ctx: Load,
-                                                },
-                                            ),
+                    range: 136..162,
+                    value: Dict(
+                        ExprDict {
+                            range: 136..162,
+                            keys: [
+                                Some(
+                                    Name(
+                                        ExprName {
+                                            range: 137..138,
+                                            id: "a",
+                                            ctx: Load,
+                                        },
+                                    ),
+                                ),
+                                None,
+                            ],
+                            values: [
+                                NumberLiteral(
+                                    ExprNumberLiteral {
+                                        range: 140..141,
+                                        value: Int(
+                                            1,
                                         ),
-                                        None,
-                                    ],
-                                    values: [
-                                        NumberLiteral(
-                                            ExprNumberLiteral {
-                                                range: 140..141,
-                                                value: Int(
-                                                    1,
-                                                ),
+                                    },
+                                ),
+                                If(
+                                    ExprIf {
+                                        range: 145..161,
+                                        test: BooleanLiteral(
+                                            ExprBooleanLiteral {
+                                                range: 150..154,
+                                                value: true,
                                             },
                                         ),
-                                        Name(
+                                        body: Name(
                                             ExprName {
                                                 range: 145..146,
                                                 id: "x",
                                                 ctx: Load,
                                             },
                                         ),
-                                    ],
-                                },
-                            ),
-                            orelse: Name(
-                                ExprName {
-                                    range: 160..161,
-                                    id: "y",
-                                    ctx: Load,
-                                },
-                            ),
+                                        orelse: Name(
+                                            ExprName {
+                                                range: 160..161,
+                                                id: "y",
+                                                ctx: Load,
+                                            },
+                                        ),
+                                    },
+                                ),
+                            ],
                         },
                     ),
                 },
@@ -189,15 +189,6 @@ Module(
                                     ),
                                 ),
                                 None,
-                                Some(
-                                    Name(
-                                        ExprName {
-                                            range: 199..200,
-                                            id: "y",
-                                            ctx: Load,
-                                        },
-                                    ),
-                                ),
                             ],
                             values: [
                                 NumberLiteral(
@@ -208,18 +199,26 @@ Module(
                                         ),
                                     },
                                 ),
-                                Name(
-                                    ExprName {
-                                        range: 194..195,
-                                        id: "x",
-                                        ctx: Load,
-                                    },
-                                ),
-                                Name(
-                                    ExprName {
-                                        range: 200..200,
-                                        id: "",
-                                        ctx: Invalid,
+                                BoolOp(
+                                    ExprBoolOp {
+                                        range: 194..200,
+                                        op: Or,
+                                        values: [
+                                            Name(
+                                                ExprName {
+                                                    range: 194..195,
+                                                    id: "x",
+                                                    ctx: Load,
+                                                },
+                                            ),
+                                            Name(
+                                                ExprName {
+                                                    range: 199..200,
+                                                    id: "y",
+                                                    ctx: Load,
+                                                },
+                                            ),
+                                        ],
                                     },
                                 ),
                             ],
@@ -238,15 +237,6 @@ Module(
                                 Some(
                                     Name(
                                         ExprName {
-                                            range: 211..212,
-                                            id: "y",
-                                            ctx: Load,
-                                        },
-                                    ),
-                                ),
-                                Some(
-                                    Name(
-                                        ExprName {
                                             range: 214..215,
                                             id: "b",
                                             ctx: Load,
@@ -255,18 +245,26 @@ Module(
                                 ),
                             ],
                             values: [
-                                Name(
-                                    ExprName {
-                                        range: 205..206,
-                                        id: "x",
-                                        ctx: Load,
-                                    },
-                                ),
-                                Name(
-                                    ExprName {
-                                        range: 212..212,
-                                        id: "",
-                                        ctx: Invalid,
+                                BoolOp(
+                                    ExprBoolOp {
+                                        range: 205..212,
+                                        op: And,
+                                        values: [
+                                            Name(
+                                                ExprName {
+                                                    range: 205..206,
+                                                    id: "x",
+                                                    ctx: Load,
+                                                },
+                                            ),
+                                            Name(
+                                                ExprName {
+                                                    range: 211..212,
+                                                    id: "y",
+                                                    ctx: Load,
+                                                },
+                                            ),
+                                        ],
                                     },
                                 ),
                                 NumberLiteral(
@@ -352,29 +350,30 @@ Module(
                             range: 242..252,
                             keys: [
                                 None,
-                                Some(
-                                    Name(
-                                        ExprName {
-                                            range: 250..251,
-                                            id: "y",
-                                            ctx: Load,
-                                        },
-                                    ),
-                                ),
                             ],
                             values: [
-                                Name(
-                                    ExprName {
-                                        range: 245..246,
-                                        id: "x",
-                                        ctx: Load,
-                                    },
-                                ),
-                                Name(
-                                    ExprName {
-                                        range: 251..251,
-                                        id: "",
-                                        ctx: Invalid,
+                                Compare(
+                                    ExprCompare {
+                                        range: 245..251,
+                                        left: Name(
+                                            ExprName {
+                                                range: 245..246,
+                                                id: "x",
+                                                ctx: Load,
+                                            },
+                                        ),
+                                        ops: [
+                                            In,
+                                        ],
+                                        comparators: [
+                                            Name(
+                                                ExprName {
+                                                    range: 250..251,
+                                                    id: "y",
+                                                    ctx: Load,
+                                                },
+                                            ),
+                                        ],
                                     },
                                 ),
                             ],
@@ -390,35 +389,30 @@ Module(
                             range: 253..267,
                             keys: [
                                 None,
-                                Some(
-                                    UnaryOp(
-                                        ExprUnaryOp {
-                                            range: 258..264,
-                                            op: Not,
-                                            operand: Name(
+                            ],
+                            values: [
+                                Compare(
+                                    ExprCompare {
+                                        range: 256..266,
+                                        left: Name(
+                                            ExprName {
+                                                range: 256..257,
+                                                id: "x",
+                                                ctx: Load,
+                                            },
+                                        ),
+                                        ops: [
+                                            NotIn,
+                                        ],
+                                        comparators: [
+                                            Name(
                                                 ExprName {
-                                                    range: 262..264,
-                                                    id: "in",
+                                                    range: 265..266,
+                                                    id: "y",
                                                     ctx: Load,
                                                 },
                                             ),
-                                        },
-                                    ),
-                                ),
-                            ],
-                            values: [
-                                Name(
-                                    ExprName {
-                                        range: 256..257,
-                                        id: "x",
-                                        ctx: Load,
-                                    },
-                                ),
-                                Name(
-                                    ExprName {
-                                        range: 265..266,
-                                        id: "y",
-                                        ctx: Load,
+                                        ],
                                     },
                                 ),
                             ],
@@ -434,29 +428,30 @@ Module(
                             range: 268..277,
                             keys: [
                                 None,
-                                Some(
-                                    Name(
-                                        ExprName {
-                                            range: 275..276,
-                                            id: "y",
-                                            ctx: Load,
-                                        },
-                                    ),
-                                ),
                             ],
                             values: [
-                                Name(
-                                    ExprName {
-                                        range: 271..272,
-                                        id: "x",
-                                        ctx: Load,
-                                    },
-                                ),
-                                Name(
-                                    ExprName {
-                                        range: 276..276,
-                                        id: "",
-                                        ctx: Invalid,
+                                Compare(
+                                    ExprCompare {
+                                        range: 271..276,
+                                        left: Name(
+                                            ExprName {
+                                                range: 271..272,
+                                                id: "x",
+                                                ctx: Load,
+                                            },
+                                        ),
+                                        ops: [
+                                            Lt,
+                                        ],
+                                        comparators: [
+                                            Name(
+                                                ExprName {
+                                                    range: 275..276,
+                                                    id: "y",
+                                                    ctx: Load,
+                                                },
+                                            ),
+                                        ],
                                     },
                                 ),
                             ],
@@ -493,28 +488,9 @@ Module(
   |
 4 | {**x := 1}
 5 | {a: 1, **x if True else y}
-  |            ^^ Syntax Error: expected Comma, found If
+  |          ^^^^^^^^^^^^^^^^ Syntax Error: conditional expression cannot be used here
 6 | {**lambda x: x, b: 2}
 7 | {a: 1, **x or y}
-  |
-
-
-  |
-4 | {**x := 1}
-5 | {a: 1, **x if True else y}
-  |                          ^ Syntax Error: Expected a statement
-6 | {**lambda x: x, b: 2}
-7 | {a: 1, **x or y}
-  |
-
-
-  |
-4 | {**x := 1}
-5 | {a: 1, **x if True else y}
-  |                           ^ Syntax Error: Expected a statement
-6 | {**lambda x: x, b: 2}
-7 | {a: 1, **x or y}
-8 | {**x and y, b: 2}
   |
 
 
@@ -532,17 +508,7 @@ Module(
 5 | {a: 1, **x if True else y}
 6 | {**lambda x: x, b: 2}
 7 | {a: 1, **x or y}
-  |            ^^ Syntax Error: expected Comma, found Or
-8 | {**x and y, b: 2}
-9 | {a: 1, **not x, b: 2}
-  |
-
-
-  |
-5 | {a: 1, **x if True else y}
-6 | {**lambda x: x, b: 2}
-7 | {a: 1, **x or y}
-  |                ^ Syntax Error: expected Colon, found Rbrace
+  |          ^^^^^^ Syntax Error: boolean expression cannot be used here
 8 | {**x and y, b: 2}
 9 | {a: 1, **not x, b: 2}
   |
@@ -552,17 +518,7 @@ Module(
  6 | {**lambda x: x, b: 2}
  7 | {a: 1, **x or y}
  8 | {**x and y, b: 2}
-   |      ^^^ Syntax Error: expected Comma, found And
- 9 | {a: 1, **not x, b: 2}
-10 | {**x in y}
-   |
-
-
-   |
- 6 | {**lambda x: x, b: 2}
- 7 | {a: 1, **x or y}
- 8 | {**x and y, b: 2}
-   |           ^ Syntax Error: expected Colon, found Comma
+   |    ^^^^^^^ Syntax Error: boolean expression cannot be used here
  9 | {a: 1, **not x, b: 2}
 10 | {**x in y}
    |
@@ -572,7 +528,7 @@ Module(
  7 | {a: 1, **x or y}
  8 | {**x and y, b: 2}
  9 | {a: 1, **not x, b: 2}
-   |          ^^^^^ Syntax Error: unary `not` expression cannot be used here
+   |          ^^^^^ Syntax Error: boolean expression cannot be used here
 10 | {**x in y}
 11 | {**x not in y}
    |
@@ -582,17 +538,7 @@ Module(
  8 | {**x and y, b: 2}
  9 | {a: 1, **not x, b: 2}
 10 | {**x in y}
-   |      ^^ Syntax Error: Expected an expression or a '}'
-11 | {**x not in y}
-12 | {**x < y}
-   |
-
-
-   |
- 8 | {**x and y, b: 2}
- 9 | {a: 1, **not x, b: 2}
-10 | {**x in y}
-   |          ^ Syntax Error: expected Colon, found Rbrace
+   |    ^^^^^^ Syntax Error: comparison expression cannot be used here
 11 | {**x not in y}
 12 | {**x < y}
    |
@@ -602,25 +548,7 @@ Module(
  9 | {a: 1, **not x, b: 2}
 10 | {**x in y}
 11 | {**x not in y}
-   |      ^^^ Syntax Error: expected Comma, found Not
-12 | {**x < y}
-   |
-
-
-   |
- 9 | {a: 1, **not x, b: 2}
-10 | {**x in y}
-11 | {**x not in y}
-   |          ^^ Syntax Error: Expected an identifier, but found a keyword 'in' that cannot be used here
-12 | {**x < y}
-   |
-
-
-   |
- 9 | {a: 1, **not x, b: 2}
-10 | {**x in y}
-11 | {**x not in y}
-   |             ^ Syntax Error: expected Colon, found Name
+   |    ^^^^^^^^^^ Syntax Error: comparison expression cannot be used here
 12 | {**x < y}
    |
 
@@ -629,13 +557,5 @@ Module(
 10 | {**x in y}
 11 | {**x not in y}
 12 | {**x < y}
-   |      ^ Syntax Error: expected Comma, found Less
-   |
-
-
-   |
-10 | {**x in y}
-11 | {**x not in y}
-12 | {**x < y}
-   |         ^ Syntax Error: expected Colon, found Rbrace
+   |    ^^^^^ Syntax Error: comparison expression cannot be used here
    |

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__list__star_expression_precedence.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__list__star_expression_precedence.py.snap
@@ -51,21 +51,31 @@ Module(
                             elts: [
                                 Starred(
                                     ExprStarred {
-                                        range: 95..97,
-                                        value: Name(
-                                            ExprName {
-                                                range: 96..97,
-                                                id: "x",
-                                                ctx: Load,
+                                        range: 95..102,
+                                        value: Compare(
+                                            ExprCompare {
+                                                range: 96..102,
+                                                left: Name(
+                                                    ExprName {
+                                                        range: 96..97,
+                                                        id: "x",
+                                                        ctx: Load,
+                                                    },
+                                                ),
+                                                ops: [
+                                                    In,
+                                                ],
+                                                comparators: [
+                                                    Name(
+                                                        ExprName {
+                                                            range: 101..102,
+                                                            id: "y",
+                                                            ctx: Load,
+                                                        },
+                                                    ),
+                                                ],
                                             },
                                         ),
-                                        ctx: Load,
-                                    },
-                                ),
-                                Name(
-                                    ExprName {
-                                        range: 101..102,
-                                        id: "y",
                                         ctx: Load,
                                     },
                                 ),
@@ -130,21 +140,29 @@ Module(
                             elts: [
                                 Starred(
                                     ExprStarred {
-                                        range: 120..122,
-                                        value: Name(
-                                            ExprName {
-                                                range: 121..122,
-                                                id: "x",
-                                                ctx: Load,
+                                        range: 120..128,
+                                        value: BoolOp(
+                                            ExprBoolOp {
+                                                range: 121..128,
+                                                op: And,
+                                                values: [
+                                                    Name(
+                                                        ExprName {
+                                                            range: 121..122,
+                                                            id: "x",
+                                                            ctx: Load,
+                                                        },
+                                                    ),
+                                                    Name(
+                                                        ExprName {
+                                                            range: 127..128,
+                                                            id: "y",
+                                                            ctx: Load,
+                                                        },
+                                                    ),
+                                                ],
                                             },
                                         ),
-                                        ctx: Load,
-                                    },
-                                ),
-                                Name(
-                                    ExprName {
-                                        range: 127..128,
-                                        id: "y",
                                         ctx: Load,
                                     },
                                 ),
@@ -170,21 +188,29 @@ Module(
                             elts: [
                                 Starred(
                                     ExprStarred {
-                                        range: 134..136,
-                                        value: Name(
-                                            ExprName {
-                                                range: 135..136,
-                                                id: "x",
-                                                ctx: Load,
+                                        range: 134..141,
+                                        value: BoolOp(
+                                            ExprBoolOp {
+                                                range: 135..141,
+                                                op: Or,
+                                                values: [
+                                                    Name(
+                                                        ExprName {
+                                                            range: 135..136,
+                                                            id: "x",
+                                                            ctx: Load,
+                                                        },
+                                                    ),
+                                                    Name(
+                                                        ExprName {
+                                                            range: 140..141,
+                                                            id: "y",
+                                                            ctx: Load,
+                                                        },
+                                                    ),
+                                                ],
                                             },
                                         ),
-                                        ctx: Load,
-                                    },
-                                ),
-                                Name(
-                                    ExprName {
-                                        range: 140..141,
-                                        id: "y",
                                         ctx: Load,
                                     },
                                 ),
@@ -203,48 +229,40 @@ Module(
             ),
             Expr(
                 StmtExpr {
-                    range: 146..167,
-                    value: Tuple(
-                        ExprTuple {
-                            range: 146..167,
+                    range: 146..168,
+                    value: List(
+                        ExprList {
+                            range: 146..168,
                             elts: [
-                                If(
-                                    ExprIf {
-                                        range: 146..164,
-                                        test: BooleanLiteral(
-                                            ExprBooleanLiteral {
-                                                range: 153..157,
-                                                value: true,
+                                Starred(
+                                    ExprStarred {
+                                        range: 147..164,
+                                        value: If(
+                                            ExprIf {
+                                                range: 148..164,
+                                                test: BooleanLiteral(
+                                                    ExprBooleanLiteral {
+                                                        range: 153..157,
+                                                        value: true,
+                                                    },
+                                                ),
+                                                body: Name(
+                                                    ExprName {
+                                                        range: 148..149,
+                                                        id: "x",
+                                                        ctx: Load,
+                                                    },
+                                                ),
+                                                orelse: Name(
+                                                    ExprName {
+                                                        range: 163..164,
+                                                        id: "y",
+                                                        ctx: Load,
+                                                    },
+                                                ),
                                             },
                                         ),
-                                        body: List(
-                                            ExprList {
-                                                range: 146..149,
-                                                elts: [
-                                                    Starred(
-                                                        ExprStarred {
-                                                            range: 147..149,
-                                                            value: Name(
-                                                                ExprName {
-                                                                    range: 148..149,
-                                                                    id: "x",
-                                                                    ctx: Load,
-                                                                },
-                                                            ),
-                                                            ctx: Load,
-                                                        },
-                                                    ),
-                                                ],
-                                                ctx: Load,
-                                            },
-                                        ),
-                                        orelse: Name(
-                                            ExprName {
-                                                range: 163..164,
-                                                id: "y",
-                                                ctx: Load,
-                                            },
-                                        ),
+                                        ctx: Load,
                                     },
                                 ),
                                 Name(
@@ -256,7 +274,6 @@ Module(
                                 ),
                             ],
                             ctx: Load,
-                            parenthesized: false,
                         },
                     ),
                 },
@@ -382,7 +399,7 @@ Module(
   |
 3 | [(*x), y]
 4 | [*x in y, z]
-  |     ^^ Syntax Error: Expected an expression or a ']'
+  |   ^^^^^^ Syntax Error: comparison expression cannot be used here
 5 | [*not x, z]
 6 | [*x and y, z]
   |
@@ -392,7 +409,7 @@ Module(
 3 | [(*x), y]
 4 | [*x in y, z]
 5 | [*not x, z]
-  |   ^^^^^ Syntax Error: unary `not` expression cannot be used here
+  |   ^^^^^ Syntax Error: boolean expression cannot be used here
 6 | [*x and y, z]
 7 | [*x or y, z]
   |
@@ -402,7 +419,7 @@ Module(
 4 | [*x in y, z]
 5 | [*not x, z]
 6 | [*x and y, z]
-  |     ^^^ Syntax Error: expected Comma, found And
+  |   ^^^^^^^ Syntax Error: boolean expression cannot be used here
 7 | [*x or y, z]
 8 | [*x if True else y, z]
   |
@@ -412,7 +429,7 @@ Module(
 5 | [*not x, z]
 6 | [*x and y, z]
 7 | [*x or y, z]
-  |     ^^ Syntax Error: expected Comma, found Or
+  |   ^^^^^^ Syntax Error: boolean expression cannot be used here
 8 | [*x if True else y, z]
 9 | [*lambda x: x, z]
   |
@@ -422,27 +439,7 @@ Module(
  6 | [*x and y, z]
  7 | [*x or y, z]
  8 | [*x if True else y, z]
-   |     ^^ Syntax Error: Expected an expression or a ']'
- 9 | [*lambda x: x, z]
-10 | [*x := 2, z]
-   |
-
-
-   |
- 6 | [*x and y, z]
- 7 | [*x or y, z]
- 8 | [*x if True else y, z]
-   |                      ^ Syntax Error: Expected a statement
- 9 | [*lambda x: x, z]
-10 | [*x := 2, z]
-   |
-
-
-   |
- 6 | [*x and y, z]
- 7 | [*x or y, z]
- 8 | [*x if True else y, z]
-   |                       ^ Syntax Error: Expected a statement
+   |   ^^^^^^^^^^^^^^^^ Syntax Error: conditional expression cannot be used here
  9 | [*lambda x: x, z]
 10 | [*x := 2, z]
    |

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__parenthesized__tuple_starred_expr.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__parenthesized__tuple_starred_expr.py.snap
@@ -11,39 +11,39 @@ Module(
         body: [
             Expr(
                 StmtExpr {
-                    range: 161..176,
+                    range: 161..182,
                     value: Tuple(
                         ExprTuple {
-                            range: 161..176,
+                            range: 161..182,
                             elts: [
-                                Compare(
-                                    ExprCompare {
-                                        range: 161..169,
-                                        left: Starred(
-                                            ExprStarred {
-                                                range: 162..164,
-                                                value: Name(
+                                Starred(
+                                    ExprStarred {
+                                        range: 162..169,
+                                        value: Compare(
+                                            ExprCompare {
+                                                range: 163..169,
+                                                left: Name(
                                                     ExprName {
                                                         range: 163..164,
                                                         id: "x",
                                                         ctx: Load,
                                                     },
                                                 ),
-                                                ctx: Load,
+                                                ops: [
+                                                    In,
+                                                ],
+                                                comparators: [
+                                                    Name(
+                                                        ExprName {
+                                                            range: 168..169,
+                                                            id: "y",
+                                                            ctx: Load,
+                                                        },
+                                                    ),
+                                                ],
                                             },
                                         ),
-                                        ops: [
-                                            In,
-                                        ],
-                                        comparators: [
-                                            Name(
-                                                ExprName {
-                                                    range: 168..169,
-                                                    id: "y",
-                                                    ctx: Load,
-                                                },
-                                            ),
-                                        ],
+                                        ctx: Load,
                                     },
                                 ),
                                 Name(
@@ -55,12 +55,29 @@ Module(
                                 ),
                                 Starred(
                                     ExprStarred {
-                                        range: 174..176,
-                                        value: Name(
-                                            ExprName {
-                                                range: 175..176,
-                                                id: "x",
-                                                ctx: Load,
+                                        range: 174..181,
+                                        value: Compare(
+                                            ExprCompare {
+                                                range: 175..181,
+                                                left: Name(
+                                                    ExprName {
+                                                        range: 175..176,
+                                                        id: "x",
+                                                        ctx: Load,
+                                                    },
+                                                ),
+                                                ops: [
+                                                    In,
+                                                ],
+                                                comparators: [
+                                                    Name(
+                                                        ExprName {
+                                                            range: 180..181,
+                                                            id: "y",
+                                                            ctx: Load,
+                                                        },
+                                                    ),
+                                                ],
                                             },
                                         ),
                                         ctx: Load,
@@ -68,19 +85,7 @@ Module(
                                 ),
                             ],
                             ctx: Load,
-                            parenthesized: false,
-                        },
-                    ),
-                },
-            ),
-            Expr(
-                StmtExpr {
-                    range: 180..181,
-                    value: Name(
-                        ExprName {
-                            range: 180..181,
-                            id: "y",
-                            ctx: Load,
+                            parenthesized: true,
                         },
                     ),
                 },
@@ -146,37 +151,37 @@ Module(
             ),
             Expr(
                 StmtExpr {
-                    range: 203..225,
+                    range: 203..226,
                     value: Tuple(
                         ExprTuple {
-                            range: 203..225,
+                            range: 203..226,
                             elts: [
-                                BoolOp(
-                                    ExprBoolOp {
-                                        range: 203..212,
-                                        op: And,
-                                        values: [
-                                            Starred(
-                                                ExprStarred {
-                                                    range: 204..206,
-                                                    value: Name(
+                                Starred(
+                                    ExprStarred {
+                                        range: 204..212,
+                                        value: BoolOp(
+                                            ExprBoolOp {
+                                                range: 205..212,
+                                                op: And,
+                                                values: [
+                                                    Name(
                                                         ExprName {
                                                             range: 205..206,
                                                             id: "x",
                                                             ctx: Load,
                                                         },
                                                     ),
-                                                    ctx: Load,
-                                                },
-                                            ),
-                                            Name(
-                                                ExprName {
-                                                    range: 211..212,
-                                                    id: "y",
-                                                    ctx: Load,
-                                                },
-                                            ),
-                                        ],
+                                                    Name(
+                                                        ExprName {
+                                                            range: 211..212,
+                                                            id: "y",
+                                                            ctx: Load,
+                                                        },
+                                                    ),
+                                                ],
+                                            },
+                                        ),
+                                        ctx: Load,
                                     },
                                 ),
                                 Name(
@@ -188,64 +193,72 @@ Module(
                                 ),
                                 Starred(
                                     ExprStarred {
-                                        range: 217..219,
-                                        value: Name(
-                                            ExprName {
-                                                range: 218..219,
-                                                id: "x",
-                                                ctx: Load,
+                                        range: 217..225,
+                                        value: BoolOp(
+                                            ExprBoolOp {
+                                                range: 218..225,
+                                                op: And,
+                                                values: [
+                                                    Name(
+                                                        ExprName {
+                                                            range: 218..219,
+                                                            id: "x",
+                                                            ctx: Load,
+                                                        },
+                                                    ),
+                                                    Name(
+                                                        ExprName {
+                                                            range: 224..225,
+                                                            id: "y",
+                                                            ctx: Load,
+                                                        },
+                                                    ),
+                                                ],
                                             },
                                         ),
                                         ctx: Load,
                                     },
                                 ),
-                                Name(
-                                    ExprName {
-                                        range: 224..225,
-                                        id: "y",
-                                        ctx: Load,
-                                    },
-                                ),
                             ],
                             ctx: Load,
-                            parenthesized: false,
+                            parenthesized: true,
                         },
                     ),
                 },
             ),
             Expr(
                 StmtExpr {
-                    range: 227..247,
+                    range: 227..248,
                     value: Tuple(
                         ExprTuple {
-                            range: 227..247,
+                            range: 227..248,
                             elts: [
-                                BoolOp(
-                                    ExprBoolOp {
-                                        range: 227..235,
-                                        op: Or,
-                                        values: [
-                                            Starred(
-                                                ExprStarred {
-                                                    range: 228..230,
-                                                    value: Name(
+                                Starred(
+                                    ExprStarred {
+                                        range: 228..235,
+                                        value: BoolOp(
+                                            ExprBoolOp {
+                                                range: 229..235,
+                                                op: Or,
+                                                values: [
+                                                    Name(
                                                         ExprName {
                                                             range: 229..230,
                                                             id: "x",
                                                             ctx: Load,
                                                         },
                                                     ),
-                                                    ctx: Load,
-                                                },
-                                            ),
-                                            Name(
-                                                ExprName {
-                                                    range: 234..235,
-                                                    id: "y",
-                                                    ctx: Load,
-                                                },
-                                            ),
-                                        ],
+                                                    Name(
+                                                        ExprName {
+                                                            range: 234..235,
+                                                            id: "y",
+                                                            ctx: Load,
+                                                        },
+                                                    ),
+                                                ],
+                                            },
+                                        ),
+                                        ctx: Load,
                                     },
                                 ),
                                 Name(
@@ -257,67 +270,75 @@ Module(
                                 ),
                                 Starred(
                                     ExprStarred {
-                                        range: 240..242,
-                                        value: Name(
-                                            ExprName {
-                                                range: 241..242,
-                                                id: "x",
-                                                ctx: Load,
+                                        range: 240..247,
+                                        value: BoolOp(
+                                            ExprBoolOp {
+                                                range: 241..247,
+                                                op: Or,
+                                                values: [
+                                                    Name(
+                                                        ExprName {
+                                                            range: 241..242,
+                                                            id: "x",
+                                                            ctx: Load,
+                                                        },
+                                                    ),
+                                                    Name(
+                                                        ExprName {
+                                                            range: 246..247,
+                                                            id: "y",
+                                                            ctx: Load,
+                                                        },
+                                                    ),
+                                                ],
                                             },
                                         ),
                                         ctx: Load,
                                     },
                                 ),
-                                Name(
-                                    ExprName {
-                                        range: 246..247,
-                                        id: "y",
-                                        ctx: Load,
-                                    },
-                                ),
                             ],
                             ctx: Load,
-                            parenthesized: false,
+                            parenthesized: true,
                         },
                     ),
                 },
             ),
             Expr(
                 StmtExpr {
-                    range: 249..274,
+                    range: 249..290,
                     value: Tuple(
                         ExprTuple {
-                            range: 249..274,
+                            range: 249..290,
                             elts: [
-                                If(
-                                    ExprIf {
-                                        range: 249..267,
-                                        test: BooleanLiteral(
-                                            ExprBooleanLiteral {
-                                                range: 256..260,
-                                                value: true,
-                                            },
-                                        ),
-                                        body: Starred(
-                                            ExprStarred {
-                                                range: 250..252,
-                                                value: Name(
+                                Starred(
+                                    ExprStarred {
+                                        range: 250..267,
+                                        value: If(
+                                            ExprIf {
+                                                range: 251..267,
+                                                test: BooleanLiteral(
+                                                    ExprBooleanLiteral {
+                                                        range: 256..260,
+                                                        value: true,
+                                                    },
+                                                ),
+                                                body: Name(
                                                     ExprName {
                                                         range: 251..252,
                                                         id: "x",
                                                         ctx: Load,
                                                     },
                                                 ),
-                                                ctx: Load,
+                                                orelse: Name(
+                                                    ExprName {
+                                                        range: 266..267,
+                                                        id: "y",
+                                                        ctx: Load,
+                                                    },
+                                                ),
                                             },
                                         ),
-                                        orelse: Name(
-                                            ExprName {
-                                                range: 266..267,
-                                                id: "y",
-                                                ctx: Load,
-                                            },
-                                        ),
+                                        ctx: Load,
                                     },
                                 ),
                                 Name(
@@ -329,12 +350,30 @@ Module(
                                 ),
                                 Starred(
                                     ExprStarred {
-                                        range: 272..274,
-                                        value: Name(
-                                            ExprName {
-                                                range: 273..274,
-                                                id: "x",
-                                                ctx: Load,
+                                        range: 272..289,
+                                        value: If(
+                                            ExprIf {
+                                                range: 273..289,
+                                                test: BooleanLiteral(
+                                                    ExprBooleanLiteral {
+                                                        range: 278..282,
+                                                        value: true,
+                                                    },
+                                                ),
+                                                body: Name(
+                                                    ExprName {
+                                                        range: 273..274,
+                                                        id: "x",
+                                                        ctx: Load,
+                                                    },
+                                                ),
+                                                orelse: Name(
+                                                    ExprName {
+                                                        range: 288..289,
+                                                        id: "y",
+                                                        ctx: Load,
+                                                    },
+                                                ),
                                             },
                                         ),
                                         ctx: Load,
@@ -342,41 +381,9 @@ Module(
                                 ),
                             ],
                             ctx: Load,
-                            parenthesized: false,
+                            parenthesized: true,
                         },
                     ),
-                },
-            ),
-            If(
-                StmtIf {
-                    range: 275..289,
-                    test: BooleanLiteral(
-                        ExprBooleanLiteral {
-                            range: 278..282,
-                            value: true,
-                        },
-                    ),
-                    body: [],
-                    elif_else_clauses: [
-                        ElifElseClause {
-                            range: 283..289,
-                            test: None,
-                            body: [
-                                Expr(
-                                    StmtExpr {
-                                        range: 288..289,
-                                        value: Name(
-                                            ExprName {
-                                                range: 288..289,
-                                                id: "y",
-                                                ctx: Load,
-                                            },
-                                        ),
-                                    },
-                                ),
-                            ],
-                        },
-                    ],
                 },
             ),
             Expr(
@@ -552,33 +559,38 @@ Module(
             ),
             Expr(
                 StmtExpr {
-                    range: 367..369,
-                    value: Starred(
-                        ExprStarred {
-                            range: 367..369,
-                            value: Name(
-                                ExprName {
-                                    range: 368..369,
-                                    id: "x",
-                                    ctx: Load,
-                                },
-                            ),
-                            ctx: Load,
-                        },
-                    ),
-                },
-            ),
-            Expr(
-                StmtExpr {
-                    range: 373..381,
+                    range: 367..386,
                     value: Tuple(
                         ExprTuple {
-                            range: 373..381,
+                            range: 367..386,
                             elts: [
-                                Name(
-                                    ExprName {
-                                        range: 373..374,
-                                        id: "y",
+                                Starred(
+                                    ExprStarred {
+                                        range: 367..374,
+                                        value: Compare(
+                                            ExprCompare {
+                                                range: 368..374,
+                                                left: Name(
+                                                    ExprName {
+                                                        range: 368..369,
+                                                        id: "x",
+                                                        ctx: Load,
+                                                    },
+                                                ),
+                                                ops: [
+                                                    In,
+                                                ],
+                                                comparators: [
+                                                    Name(
+                                                        ExprName {
+                                                            range: 373..374,
+                                                            id: "y",
+                                                            ctx: Load,
+                                                        },
+                                                    ),
+                                                ],
+                                            },
+                                        ),
                                         ctx: Load,
                                     },
                                 ),
@@ -591,12 +603,29 @@ Module(
                                 ),
                                 Starred(
                                     ExprStarred {
-                                        range: 379..381,
-                                        value: Name(
-                                            ExprName {
-                                                range: 380..381,
-                                                id: "x",
-                                                ctx: Load,
+                                        range: 379..386,
+                                        value: Compare(
+                                            ExprCompare {
+                                                range: 380..386,
+                                                left: Name(
+                                                    ExprName {
+                                                        range: 380..381,
+                                                        id: "x",
+                                                        ctx: Load,
+                                                    },
+                                                ),
+                                                ops: [
+                                                    In,
+                                                ],
+                                                comparators: [
+                                                    Name(
+                                                        ExprName {
+                                                            range: 385..386,
+                                                            id: "y",
+                                                            ctx: Load,
+                                                        },
+                                                    ),
+                                                ],
                                             },
                                         ),
                                         ctx: Load,
@@ -605,18 +634,6 @@ Module(
                             ],
                             ctx: Load,
                             parenthesized: false,
-                        },
-                    ),
-                },
-            ),
-            Expr(
-                StmtExpr {
-                    range: 385..386,
-                    value: Name(
-                        ExprName {
-                            range: 385..386,
-                            id: "y",
-                            ctx: Load,
                         },
                     ),
                 },
@@ -682,33 +699,36 @@ Module(
             ),
             Expr(
                 StmtExpr {
-                    range: 405..407,
-                    value: Starred(
-                        ExprStarred {
-                            range: 405..407,
-                            value: Name(
-                                ExprName {
-                                    range: 406..407,
-                                    id: "x",
-                                    ctx: Load,
-                                },
-                            ),
-                            ctx: Load,
-                        },
-                    ),
-                },
-            ),
-            Expr(
-                StmtExpr {
-                    range: 412..426,
+                    range: 405..426,
                     value: Tuple(
                         ExprTuple {
-                            range: 412..426,
+                            range: 405..426,
                             elts: [
-                                Name(
-                                    ExprName {
-                                        range: 412..413,
-                                        id: "y",
+                                Starred(
+                                    ExprStarred {
+                                        range: 405..413,
+                                        value: BoolOp(
+                                            ExprBoolOp {
+                                                range: 406..413,
+                                                op: And,
+                                                values: [
+                                                    Name(
+                                                        ExprName {
+                                                            range: 406..407,
+                                                            id: "x",
+                                                            ctx: Load,
+                                                        },
+                                                    ),
+                                                    Name(
+                                                        ExprName {
+                                                            range: 412..413,
+                                                            id: "y",
+                                                            ctx: Load,
+                                                        },
+                                                    ),
+                                                ],
+                                            },
+                                        ),
                                         ctx: Load,
                                     },
                                 ),
@@ -721,21 +741,29 @@ Module(
                                 ),
                                 Starred(
                                     ExprStarred {
-                                        range: 418..420,
-                                        value: Name(
-                                            ExprName {
-                                                range: 419..420,
-                                                id: "x",
-                                                ctx: Load,
+                                        range: 418..426,
+                                        value: BoolOp(
+                                            ExprBoolOp {
+                                                range: 419..426,
+                                                op: And,
+                                                values: [
+                                                    Name(
+                                                        ExprName {
+                                                            range: 419..420,
+                                                            id: "x",
+                                                            ctx: Load,
+                                                        },
+                                                    ),
+                                                    Name(
+                                                        ExprName {
+                                                            range: 425..426,
+                                                            id: "y",
+                                                            ctx: Load,
+                                                        },
+                                                    ),
+                                                ],
                                             },
                                         ),
-                                        ctx: Load,
-                                    },
-                                ),
-                                Name(
-                                    ExprName {
-                                        range: 425..426,
-                                        id: "y",
                                         ctx: Load,
                                     },
                                 ),
@@ -748,33 +776,36 @@ Module(
             ),
             Expr(
                 StmtExpr {
-                    range: 427..429,
-                    value: Starred(
-                        ExprStarred {
-                            range: 427..429,
-                            value: Name(
-                                ExprName {
-                                    range: 428..429,
-                                    id: "x",
-                                    ctx: Load,
-                                },
-                            ),
-                            ctx: Load,
-                        },
-                    ),
-                },
-            ),
-            Expr(
-                StmtExpr {
-                    range: 433..446,
+                    range: 427..446,
                     value: Tuple(
                         ExprTuple {
-                            range: 433..446,
+                            range: 427..446,
                             elts: [
-                                Name(
-                                    ExprName {
-                                        range: 433..434,
-                                        id: "y",
+                                Starred(
+                                    ExprStarred {
+                                        range: 427..434,
+                                        value: BoolOp(
+                                            ExprBoolOp {
+                                                range: 428..434,
+                                                op: Or,
+                                                values: [
+                                                    Name(
+                                                        ExprName {
+                                                            range: 428..429,
+                                                            id: "x",
+                                                            ctx: Load,
+                                                        },
+                                                    ),
+                                                    Name(
+                                                        ExprName {
+                                                            range: 433..434,
+                                                            id: "y",
+                                                            ctx: Load,
+                                                        },
+                                                    ),
+                                                ],
+                                            },
+                                        ),
                                         ctx: Load,
                                     },
                                 ),
@@ -787,21 +818,29 @@ Module(
                                 ),
                                 Starred(
                                     ExprStarred {
-                                        range: 439..441,
-                                        value: Name(
-                                            ExprName {
-                                                range: 440..441,
-                                                id: "x",
-                                                ctx: Load,
+                                        range: 439..446,
+                                        value: BoolOp(
+                                            ExprBoolOp {
+                                                range: 440..446,
+                                                op: Or,
+                                                values: [
+                                                    Name(
+                                                        ExprName {
+                                                            range: 440..441,
+                                                            id: "x",
+                                                            ctx: Load,
+                                                        },
+                                                    ),
+                                                    Name(
+                                                        ExprName {
+                                                            range: 445..446,
+                                                            id: "y",
+                                                            ctx: Load,
+                                                        },
+                                                    ),
+                                                ],
                                             },
                                         ),
-                                        ctx: Load,
-                                    },
-                                ),
-                                Name(
-                                    ExprName {
-                                        range: 445..446,
-                                        id: "y",
                                         ctx: Load,
                                     },
                                 ),
@@ -814,113 +853,85 @@ Module(
             ),
             Expr(
                 StmtExpr {
-                    range: 447..449,
-                    value: Starred(
-                        ExprStarred {
-                            range: 447..449,
-                            value: Name(
-                                ExprName {
-                                    range: 448..449,
-                                    id: "x",
-                                    ctx: Load,
-                                },
-                            ),
+                    range: 447..486,
+                    value: Tuple(
+                        ExprTuple {
+                            range: 447..486,
+                            elts: [
+                                Starred(
+                                    ExprStarred {
+                                        range: 447..464,
+                                        value: If(
+                                            ExprIf {
+                                                range: 448..464,
+                                                test: BooleanLiteral(
+                                                    ExprBooleanLiteral {
+                                                        range: 453..457,
+                                                        value: true,
+                                                    },
+                                                ),
+                                                body: Name(
+                                                    ExprName {
+                                                        range: 448..449,
+                                                        id: "x",
+                                                        ctx: Load,
+                                                    },
+                                                ),
+                                                orelse: Name(
+                                                    ExprName {
+                                                        range: 463..464,
+                                                        id: "y",
+                                                        ctx: Load,
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                        ctx: Load,
+                                    },
+                                ),
+                                Name(
+                                    ExprName {
+                                        range: 466..467,
+                                        id: "z",
+                                        ctx: Load,
+                                    },
+                                ),
+                                Starred(
+                                    ExprStarred {
+                                        range: 469..486,
+                                        value: If(
+                                            ExprIf {
+                                                range: 470..486,
+                                                test: BooleanLiteral(
+                                                    ExprBooleanLiteral {
+                                                        range: 475..479,
+                                                        value: true,
+                                                    },
+                                                ),
+                                                body: Name(
+                                                    ExprName {
+                                                        range: 470..471,
+                                                        id: "x",
+                                                        ctx: Load,
+                                                    },
+                                                ),
+                                                orelse: Name(
+                                                    ExprName {
+                                                        range: 485..486,
+                                                        id: "y",
+                                                        ctx: Load,
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                        ctx: Load,
+                                    },
+                                ),
+                            ],
                             ctx: Load,
+                            parenthesized: false,
                         },
                     ),
-                },
-            ),
-            If(
-                StmtIf {
-                    range: 450..471,
-                    test: BooleanLiteral(
-                        ExprBooleanLiteral {
-                            range: 453..457,
-                            value: true,
-                        },
-                    ),
-                    body: [],
-                    elif_else_clauses: [
-                        ElifElseClause {
-                            range: 458..471,
-                            test: None,
-                            body: [
-                                Expr(
-                                    StmtExpr {
-                                        range: 463..471,
-                                        value: Tuple(
-                                            ExprTuple {
-                                                range: 463..471,
-                                                elts: [
-                                                    Name(
-                                                        ExprName {
-                                                            range: 463..464,
-                                                            id: "y",
-                                                            ctx: Load,
-                                                        },
-                                                    ),
-                                                    Name(
-                                                        ExprName {
-                                                            range: 466..467,
-                                                            id: "z",
-                                                            ctx: Load,
-                                                        },
-                                                    ),
-                                                    Starred(
-                                                        ExprStarred {
-                                                            range: 469..471,
-                                                            value: Name(
-                                                                ExprName {
-                                                                    range: 470..471,
-                                                                    id: "x",
-                                                                    ctx: Load,
-                                                                },
-                                                            ),
-                                                            ctx: Load,
-                                                        },
-                                                    ),
-                                                ],
-                                                ctx: Load,
-                                                parenthesized: false,
-                                            },
-                                        ),
-                                    },
-                                ),
-                            ],
-                        },
-                    ],
-                },
-            ),
-            If(
-                StmtIf {
-                    range: 472..486,
-                    test: BooleanLiteral(
-                        ExprBooleanLiteral {
-                            range: 475..479,
-                            value: true,
-                        },
-                    ),
-                    body: [],
-                    elif_else_clauses: [
-                        ElifElseClause {
-                            range: 480..486,
-                            test: None,
-                            body: [
-                                Expr(
-                                    StmtExpr {
-                                        range: 485..486,
-                                        value: Name(
-                                            ExprName {
-                                                range: 485..486,
-                                                id: "y",
-                                                ctx: Load,
-                                            },
-                                        ),
-                                    },
-                                ),
-                            ],
-                        },
-                    ],
                 },
             ),
             Expr(
@@ -1104,7 +1115,7 @@ Module(
 2 | # Test the first and any other element as the there are two separate calls.
 3 | 
 4 | (*x in y, z, *x in y)
-  |  ^^ Syntax Error: starred expression cannot be used here
+  |   ^^^^^^ Syntax Error: comparison expression cannot be used here
 5 | (*not x, z, *not x)
 6 | (*x and y, z, *x and y)
   |
@@ -1114,38 +1125,16 @@ Module(
 2 | # Test the first and any other element as the there are two separate calls.
 3 | 
 4 | (*x in y, z, *x in y)
-  |     ^^ Syntax Error: expected Rpar, found In
+  |               ^^^^^^ Syntax Error: comparison expression cannot be used here
 5 | (*not x, z, *not x)
 6 | (*x and y, z, *x and y)
   |
 
 
   |
-2 | # Test the first and any other element as the there are two separate calls.
-3 | 
 4 | (*x in y, z, *x in y)
-  |                 ^^ Syntax Error: Expected a statement
 5 | (*not x, z, *not x)
-6 | (*x and y, z, *x and y)
-  |
-
-
-  |
-2 | # Test the first and any other element as the there are two separate calls.
-3 | 
-4 | (*x in y, z, *x in y)
-  |                     ^ Syntax Error: Expected a statement
-5 | (*not x, z, *not x)
-6 | (*x and y, z, *x and y)
-  |
-
-
-  |
-2 | # Test the first and any other element as the there are two separate calls.
-3 | 
-4 | (*x in y, z, *x in y)
-  |                      ^ Syntax Error: Expected a statement
-5 | (*not x, z, *not x)
+  |   ^^^^^ Syntax Error: boolean expression cannot be used here
 6 | (*x and y, z, *x and y)
 7 | (*x or y, z, *x or y)
   |
@@ -1154,16 +1143,7 @@ Module(
   |
 4 | (*x in y, z, *x in y)
 5 | (*not x, z, *not x)
-  |   ^^^^^ Syntax Error: unary `not` expression cannot be used here
-6 | (*x and y, z, *x and y)
-7 | (*x or y, z, *x or y)
-  |
-
-
-  |
-4 | (*x in y, z, *x in y)
-5 | (*not x, z, *not x)
-  |              ^^^^^ Syntax Error: unary `not` expression cannot be used here
+  |              ^^^^^ Syntax Error: boolean expression cannot be used here
 6 | (*x and y, z, *x and y)
 7 | (*x or y, z, *x or y)
   |
@@ -1173,7 +1153,7 @@ Module(
 4 | (*x in y, z, *x in y)
 5 | (*not x, z, *not x)
 6 | (*x and y, z, *x and y)
-  |  ^^ Syntax Error: starred expression cannot be used here
+  |   ^^^^^^^ Syntax Error: boolean expression cannot be used here
 7 | (*x or y, z, *x or y)
 8 | (*x if True else y, z, *x if True else y)
   |
@@ -1183,38 +1163,17 @@ Module(
 4 | (*x in y, z, *x in y)
 5 | (*not x, z, *not x)
 6 | (*x and y, z, *x and y)
-  |     ^^^ Syntax Error: expected Rpar, found And
+  |                ^^^^^^^ Syntax Error: boolean expression cannot be used here
 7 | (*x or y, z, *x or y)
 8 | (*x if True else y, z, *x if True else y)
   |
 
 
   |
-4 | (*x in y, z, *x in y)
 5 | (*not x, z, *not x)
 6 | (*x and y, z, *x and y)
-  |                  ^^^ Syntax Error: expected Comma, found And
 7 | (*x or y, z, *x or y)
-8 | (*x if True else y, z, *x if True else y)
-  |
-
-
-  |
-4 | (*x in y, z, *x in y)
-5 | (*not x, z, *not x)
-6 | (*x and y, z, *x and y)
-  |                       ^ Syntax Error: Expected a statement
-7 | (*x or y, z, *x or y)
-8 | (*x if True else y, z, *x if True else y)
-  |
-
-
-  |
-4 | (*x in y, z, *x in y)
-5 | (*not x, z, *not x)
-6 | (*x and y, z, *x and y)
-  |                        ^ Syntax Error: Expected a statement
-7 | (*x or y, z, *x or y)
+  |   ^^^^^^ Syntax Error: boolean expression cannot be used here
 8 | (*x if True else y, z, *x if True else y)
 9 | (*lambda x: x, z, *lambda x: x)
   |
@@ -1224,48 +1183,17 @@ Module(
 5 | (*not x, z, *not x)
 6 | (*x and y, z, *x and y)
 7 | (*x or y, z, *x or y)
-  |  ^^ Syntax Error: starred expression cannot be used here
-8 | (*x if True else y, z, *x if True else y)
-9 | (*lambda x: x, z, *lambda x: x)
-  |
-
-
-  |
-5 | (*not x, z, *not x)
-6 | (*x and y, z, *x and y)
-7 | (*x or y, z, *x or y)
-  |     ^^ Syntax Error: expected Rpar, found Or
-8 | (*x if True else y, z, *x if True else y)
-9 | (*lambda x: x, z, *lambda x: x)
-  |
-
-
-  |
-5 | (*not x, z, *not x)
-6 | (*x and y, z, *x and y)
-7 | (*x or y, z, *x or y)
-  |                 ^^ Syntax Error: expected Comma, found Or
-8 | (*x if True else y, z, *x if True else y)
-9 | (*lambda x: x, z, *lambda x: x)
-  |
-
-
-  |
-5 | (*not x, z, *not x)
-6 | (*x and y, z, *x and y)
-7 | (*x or y, z, *x or y)
-  |                     ^ Syntax Error: Expected a statement
+  |               ^^^^^^ Syntax Error: boolean expression cannot be used here
 8 | (*x if True else y, z, *x if True else y)
 9 | (*lambda x: x, z, *lambda x: x)
   |
 
 
    |
- 5 | (*not x, z, *not x)
  6 | (*x and y, z, *x and y)
  7 | (*x or y, z, *x or y)
-   |                      ^ Syntax Error: Expected a statement
  8 | (*x if True else y, z, *x if True else y)
+   |   ^^^^^^^^^^^^^^^^ Syntax Error: conditional expression cannot be used here
  9 | (*lambda x: x, z, *lambda x: x)
 10 | (*x := 2, z, *x := 2)
    |
@@ -1275,67 +1203,7 @@ Module(
  6 | (*x and y, z, *x and y)
  7 | (*x or y, z, *x or y)
  8 | (*x if True else y, z, *x if True else y)
-   |  ^^ Syntax Error: starred expression cannot be used here
- 9 | (*lambda x: x, z, *lambda x: x)
-10 | (*x := 2, z, *x := 2)
-   |
-
-
-   |
- 6 | (*x and y, z, *x and y)
- 7 | (*x or y, z, *x or y)
- 8 | (*x if True else y, z, *x if True else y)
-   |     ^^ Syntax Error: expected Rpar, found If
- 9 | (*lambda x: x, z, *lambda x: x)
-10 | (*x := 2, z, *x := 2)
-   |
-
-
-   |
- 6 | (*x and y, z, *x and y)
- 7 | (*x or y, z, *x or y)
- 8 | (*x if True else y, z, *x if True else y)
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Syntax Error: compound statements not allowed in the same line as simple statements
- 9 | (*lambda x: x, z, *lambda x: x)
-10 | (*x := 2, z, *x := 2)
-   |
-
-
-   |
- 6 | (*x and y, z, *x and y)
- 7 | (*x or y, z, *x or y)
- 8 | (*x if True else y, z, *x if True else y)
-   |                                   ^^^^ Syntax Error: expected Colon, found Else
- 9 | (*lambda x: x, z, *lambda x: x)
-10 | (*x := 2, z, *x := 2)
-   |
-
-
-   |
- 6 | (*x and y, z, *x and y)
- 7 | (*x or y, z, *x or y)
- 8 | (*x if True else y, z, *x if True else y)
-   |                                        ^ Syntax Error: expected Colon, found Name
- 9 | (*lambda x: x, z, *lambda x: x)
-10 | (*x := 2, z, *x := 2)
-   |
-
-
-   |
- 6 | (*x and y, z, *x and y)
- 7 | (*x or y, z, *x or y)
- 8 | (*x if True else y, z, *x if True else y)
-   |                                         ^ Syntax Error: Expected a statement
- 9 | (*lambda x: x, z, *lambda x: x)
-10 | (*x := 2, z, *x := 2)
-   |
-
-
-   |
- 6 | (*x and y, z, *x and y)
- 7 | (*x or y, z, *x or y)
- 8 | (*x if True else y, z, *x if True else y)
-   |                                          ^ Syntax Error: Expected a statement
+   |                         ^^^^^^^^^^^^^^^^ Syntax Error: conditional expression cannot be used here
  9 | (*lambda x: x, z, *lambda x: x)
 10 | (*x := 2, z, *x := 2)
    |
@@ -1405,7 +1273,7 @@ Module(
    |
 13 | # Non-parenthesized
 14 | *x in y, z, *x in y
-   |    ^^ Syntax Error: Expected a statement
+   |  ^^^^^^ Syntax Error: comparison expression cannot be used here
 15 | *not x, z, *not x
 16 | *x and y, z, *x and y
    |
@@ -1414,7 +1282,7 @@ Module(
    |
 13 | # Non-parenthesized
 14 | *x in y, z, *x in y
-   |                ^^ Syntax Error: Expected a statement
+   |              ^^^^^^ Syntax Error: comparison expression cannot be used here
 15 | *not x, z, *not x
 16 | *x and y, z, *x and y
    |
@@ -1424,7 +1292,7 @@ Module(
 13 | # Non-parenthesized
 14 | *x in y, z, *x in y
 15 | *not x, z, *not x
-   |  ^^^^^ Syntax Error: unary `not` expression cannot be used here
+   |  ^^^^^ Syntax Error: boolean expression cannot be used here
 16 | *x and y, z, *x and y
 17 | *x or y, z, *x or y
    |
@@ -1434,7 +1302,7 @@ Module(
 13 | # Non-parenthesized
 14 | *x in y, z, *x in y
 15 | *not x, z, *not x
-   |             ^^^^^ Syntax Error: unary `not` expression cannot be used here
+   |             ^^^^^ Syntax Error: boolean expression cannot be used here
 16 | *x and y, z, *x and y
 17 | *x or y, z, *x or y
    |
@@ -1444,7 +1312,7 @@ Module(
 14 | *x in y, z, *x in y
 15 | *not x, z, *not x
 16 | *x and y, z, *x and y
-   |    ^^^ Syntax Error: Expected a statement
+   |  ^^^^^^^ Syntax Error: boolean expression cannot be used here
 17 | *x or y, z, *x or y
 18 | *x if True else y, z, *x if True else y
    |
@@ -1454,7 +1322,7 @@ Module(
 14 | *x in y, z, *x in y
 15 | *not x, z, *not x
 16 | *x and y, z, *x and y
-   |                 ^^^ Syntax Error: expected Comma, found And
+   |               ^^^^^^^ Syntax Error: boolean expression cannot be used here
 17 | *x or y, z, *x or y
 18 | *x if True else y, z, *x if True else y
    |
@@ -1464,7 +1332,7 @@ Module(
 15 | *not x, z, *not x
 16 | *x and y, z, *x and y
 17 | *x or y, z, *x or y
-   |    ^^ Syntax Error: Expected a statement
+   |  ^^^^^^ Syntax Error: boolean expression cannot be used here
 18 | *x if True else y, z, *x if True else y
 19 | *lambda x: x, z, *lambda x: x
    |
@@ -1474,7 +1342,7 @@ Module(
 15 | *not x, z, *not x
 16 | *x and y, z, *x and y
 17 | *x or y, z, *x or y
-   |                ^^ Syntax Error: expected Comma, found Or
+   |              ^^^^^^ Syntax Error: boolean expression cannot be used here
 18 | *x if True else y, z, *x if True else y
 19 | *lambda x: x, z, *lambda x: x
    |
@@ -1484,17 +1352,7 @@ Module(
 16 | *x and y, z, *x and y
 17 | *x or y, z, *x or y
 18 | *x if True else y, z, *x if True else y
-   | ^^^^^ Syntax Error: compound statements not allowed in the same line as simple statements
-19 | *lambda x: x, z, *lambda x: x
-20 | *x := 2, z, *x := 2
-   |
-
-
-   |
-16 | *x and y, z, *x and y
-17 | *x or y, z, *x or y
-18 | *x if True else y, z, *x if True else y
-   |            ^^^^ Syntax Error: expected Colon, found Else
+   |  ^^^^^^^^^^^^^^^^ Syntax Error: conditional expression cannot be used here
 19 | *lambda x: x, z, *lambda x: x
 20 | *x := 2, z, *x := 2
    |
@@ -1504,27 +1362,7 @@ Module(
 16 | *x and y, z, *x and y
 17 | *x or y, z, *x or y
 18 | *x if True else y, z, *x if True else y
-   |                 ^ Syntax Error: expected Colon, found Name
-19 | *lambda x: x, z, *lambda x: x
-20 | *x := 2, z, *x := 2
-   |
-
-
-   |
-16 | *x and y, z, *x and y
-17 | *x or y, z, *x or y
-18 | *x if True else y, z, *x if True else y
-   |                                  ^^^^ Syntax Error: expected Colon, found Else
-19 | *lambda x: x, z, *lambda x: x
-20 | *x := 2, z, *x := 2
-   |
-
-
-   |
-16 | *x and y, z, *x and y
-17 | *x or y, z, *x or y
-18 | *x if True else y, z, *x if True else y
-   |                                       ^ Syntax Error: expected Colon, found Name
+   |                        ^^^^^^^^^^^^^^^^ Syntax Error: conditional expression cannot be used here
 19 | *lambda x: x, z, *lambda x: x
 20 | *x := 2, z, *x := 2
    |

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__set__star_expression_precedence.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__set__star_expression_precedence.py.snap
@@ -50,21 +50,31 @@ Module(
                             elts: [
                                 Starred(
                                     ExprStarred {
-                                        range: 94..96,
-                                        value: Name(
-                                            ExprName {
-                                                range: 95..96,
-                                                id: "x",
-                                                ctx: Load,
+                                        range: 94..101,
+                                        value: Compare(
+                                            ExprCompare {
+                                                range: 95..101,
+                                                left: Name(
+                                                    ExprName {
+                                                        range: 95..96,
+                                                        id: "x",
+                                                        ctx: Load,
+                                                    },
+                                                ),
+                                                ops: [
+                                                    In,
+                                                ],
+                                                comparators: [
+                                                    Name(
+                                                        ExprName {
+                                                            range: 100..101,
+                                                            id: "y",
+                                                            ctx: Load,
+                                                        },
+                                                    ),
+                                                ],
                                             },
                                         ),
-                                        ctx: Load,
-                                    },
-                                ),
-                                Name(
-                                    ExprName {
-                                        range: 100..101,
-                                        id: "y",
                                         ctx: Load,
                                     },
                                 ),
@@ -127,21 +137,29 @@ Module(
                             elts: [
                                 Starred(
                                     ExprStarred {
-                                        range: 119..121,
-                                        value: Name(
-                                            ExprName {
-                                                range: 120..121,
-                                                id: "x",
-                                                ctx: Load,
+                                        range: 119..127,
+                                        value: BoolOp(
+                                            ExprBoolOp {
+                                                range: 120..127,
+                                                op: And,
+                                                values: [
+                                                    Name(
+                                                        ExprName {
+                                                            range: 120..121,
+                                                            id: "x",
+                                                            ctx: Load,
+                                                        },
+                                                    ),
+                                                    Name(
+                                                        ExprName {
+                                                            range: 126..127,
+                                                            id: "y",
+                                                            ctx: Load,
+                                                        },
+                                                    ),
+                                                ],
                                             },
                                         ),
-                                        ctx: Load,
-                                    },
-                                ),
-                                Name(
-                                    ExprName {
-                                        range: 126..127,
-                                        id: "y",
                                         ctx: Load,
                                     },
                                 ),
@@ -166,21 +184,29 @@ Module(
                             elts: [
                                 Starred(
                                     ExprStarred {
-                                        range: 133..135,
-                                        value: Name(
-                                            ExprName {
-                                                range: 134..135,
-                                                id: "x",
-                                                ctx: Load,
+                                        range: 133..140,
+                                        value: BoolOp(
+                                            ExprBoolOp {
+                                                range: 134..140,
+                                                op: Or,
+                                                values: [
+                                                    Name(
+                                                        ExprName {
+                                                            range: 134..135,
+                                                            id: "x",
+                                                            ctx: Load,
+                                                        },
+                                                    ),
+                                                    Name(
+                                                        ExprName {
+                                                            range: 139..140,
+                                                            id: "y",
+                                                            ctx: Load,
+                                                        },
+                                                    ),
+                                                ],
                                             },
                                         ),
-                                        ctx: Load,
-                                    },
-                                ),
-                                Name(
-                                    ExprName {
-                                        range: 139..140,
-                                        id: "y",
                                         ctx: Load,
                                     },
                                 ),
@@ -198,47 +224,40 @@ Module(
             ),
             Expr(
                 StmtExpr {
-                    range: 145..166,
-                    value: Tuple(
-                        ExprTuple {
-                            range: 145..166,
+                    range: 145..167,
+                    value: Set(
+                        ExprSet {
+                            range: 145..167,
                             elts: [
-                                If(
-                                    ExprIf {
-                                        range: 145..163,
-                                        test: BooleanLiteral(
-                                            ExprBooleanLiteral {
-                                                range: 152..156,
-                                                value: true,
+                                Starred(
+                                    ExprStarred {
+                                        range: 146..163,
+                                        value: If(
+                                            ExprIf {
+                                                range: 147..163,
+                                                test: BooleanLiteral(
+                                                    ExprBooleanLiteral {
+                                                        range: 152..156,
+                                                        value: true,
+                                                    },
+                                                ),
+                                                body: Name(
+                                                    ExprName {
+                                                        range: 147..148,
+                                                        id: "x",
+                                                        ctx: Load,
+                                                    },
+                                                ),
+                                                orelse: Name(
+                                                    ExprName {
+                                                        range: 162..163,
+                                                        id: "y",
+                                                        ctx: Load,
+                                                    },
+                                                ),
                                             },
                                         ),
-                                        body: Set(
-                                            ExprSet {
-                                                range: 145..148,
-                                                elts: [
-                                                    Starred(
-                                                        ExprStarred {
-                                                            range: 146..148,
-                                                            value: Name(
-                                                                ExprName {
-                                                                    range: 147..148,
-                                                                    id: "x",
-                                                                    ctx: Load,
-                                                                },
-                                                            ),
-                                                            ctx: Load,
-                                                        },
-                                                    ),
-                                                ],
-                                            },
-                                        ),
-                                        orelse: Name(
-                                            ExprName {
-                                                range: 162..163,
-                                                id: "y",
-                                                ctx: Load,
-                                            },
-                                        ),
+                                        ctx: Load,
                                     },
                                 ),
                                 Name(
@@ -249,8 +268,6 @@ Module(
                                     },
                                 ),
                             ],
-                            ctx: Load,
-                            parenthesized: false,
                         },
                     ),
                 },
@@ -374,7 +391,7 @@ Module(
   |
 3 | {(*x), y}
 4 | {*x in y, z}
-  |     ^^ Syntax Error: Expected an expression or a '}'
+  |   ^^^^^^ Syntax Error: comparison expression cannot be used here
 5 | {*not x, z}
 6 | {*x and y, z}
   |
@@ -384,7 +401,7 @@ Module(
 3 | {(*x), y}
 4 | {*x in y, z}
 5 | {*not x, z}
-  |   ^^^^^ Syntax Error: unary `not` expression cannot be used here
+  |   ^^^^^ Syntax Error: boolean expression cannot be used here
 6 | {*x and y, z}
 7 | {*x or y, z}
   |
@@ -394,7 +411,7 @@ Module(
 4 | {*x in y, z}
 5 | {*not x, z}
 6 | {*x and y, z}
-  |     ^^^ Syntax Error: expected Comma, found And
+  |   ^^^^^^^ Syntax Error: boolean expression cannot be used here
 7 | {*x or y, z}
 8 | {*x if True else y, z}
   |
@@ -404,7 +421,7 @@ Module(
 5 | {*not x, z}
 6 | {*x and y, z}
 7 | {*x or y, z}
-  |     ^^ Syntax Error: expected Comma, found Or
+  |   ^^^^^^ Syntax Error: boolean expression cannot be used here
 8 | {*x if True else y, z}
 9 | {*lambda x: x, z}
   |
@@ -414,27 +431,7 @@ Module(
  6 | {*x and y, z}
  7 | {*x or y, z}
  8 | {*x if True else y, z}
-   |     ^^ Syntax Error: Expected an expression or a '}'
- 9 | {*lambda x: x, z}
-10 | {*x := 2, z}
-   |
-
-
-   |
- 6 | {*x and y, z}
- 7 | {*x or y, z}
- 8 | {*x if True else y, z}
-   |                      ^ Syntax Error: Expected a statement
- 9 | {*lambda x: x, z}
-10 | {*x := 2, z}
-   |
-
-
-   |
- 6 | {*x and y, z}
- 7 | {*x or y, z}
- 8 | {*x if True else y, z}
-   |                       ^ Syntax Error: Expected a statement
+   |   ^^^^^^^^^^^^^^^^ Syntax Error: conditional expression cannot be used here
  9 | {*lambda x: x, z}
 10 | {*x := 2, z}
    |

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@expressions__dictionary.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@expressions__dictionary.py.snap
@@ -7,7 +7,7 @@ input_file: crates/ruff_python_parser/resources/valid/expressions/dictionary.py
 ```
 Module(
     ModModule {
-        range: 0..544,
+        range: 0..622,
         body: [
             Expr(
                 StmtExpr {
@@ -878,15 +878,43 @@ Module(
             ),
             Expr(
                 StmtExpr {
-                    range: 416..437,
+                    range: 460..471,
                     value: Dict(
                         ExprDict {
-                            range: 416..437,
+                            range: 460..471,
+                            keys: [
+                                None,
+                            ],
+                            values: [
+                                UnaryOp(
+                                    ExprUnaryOp {
+                                        range: 464..469,
+                                        op: Not,
+                                        operand: Name(
+                                            ExprName {
+                                                range: 468..469,
+                                                id: "x",
+                                                ctx: Load,
+                                            },
+                                        ),
+                                    },
+                                ),
+                            ],
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 494..515,
+                    value: Dict(
+                        ExprDict {
+                            range: 494..515,
                             keys: [
                                 Some(
                                     NumberLiteral(
                                         ExprNumberLiteral {
-                                            range: 417..418,
+                                            range: 495..496,
                                             value: Int(
                                                 1,
                                             ),
@@ -897,23 +925,23 @@ Module(
                             values: [
                                 If(
                                     ExprIf {
-                                        range: 420..436,
+                                        range: 498..514,
                                         test: BooleanLiteral(
                                             ExprBooleanLiteral {
-                                                range: 425..429,
+                                                range: 503..507,
                                                 value: true,
                                             },
                                         ),
                                         body: Name(
                                             ExprName {
-                                                range: 420..421,
+                                                range: 498..499,
                                                 id: "x",
                                                 ctx: Load,
                                             },
                                         ),
                                         orelse: Name(
                                             ExprName {
-                                                range: 435..436,
+                                                range: 513..514,
                                                 id: "y",
                                                 ctx: Load,
                                             },
@@ -927,29 +955,29 @@ Module(
             ),
             Expr(
                 StmtExpr {
-                    range: 438..497,
+                    range: 516..575,
                     value: DictComp(
                         ExprDictComp {
-                            range: 438..497,
+                            range: 516..575,
                             key: If(
                                 ExprIf {
-                                    range: 439..455,
+                                    range: 517..533,
                                     test: BooleanLiteral(
                                         ExprBooleanLiteral {
-                                            range: 444..448,
+                                            range: 522..526,
                                             value: true,
                                         },
                                     ),
                                     body: Name(
                                         ExprName {
-                                            range: 439..440,
+                                            range: 517..518,
                                             id: "x",
                                             ctx: Load,
                                         },
                                     ),
                                     orelse: Name(
                                         ExprName {
-                                            range: 454..455,
+                                            range: 532..533,
                                             id: "y",
                                             ctx: Load,
                                         },
@@ -958,37 +986,37 @@ Module(
                             ),
                             value: Name(
                                 ExprName {
-                                    range: 457..458,
+                                    range: 535..536,
                                     id: "y",
                                     ctx: Load,
                                 },
                             ),
                             generators: [
                                 Comprehension {
-                                    range: 459..477,
+                                    range: 537..555,
                                     target: Name(
                                         ExprName {
-                                            range: 463..464,
+                                            range: 541..542,
                                             id: "x",
                                             ctx: Store,
                                         },
                                     ),
                                     iter: Call(
                                         ExprCall {
-                                            range: 468..477,
+                                            range: 546..555,
                                             func: Name(
                                                 ExprName {
-                                                    range: 468..473,
+                                                    range: 546..551,
                                                     id: "range",
                                                     ctx: Load,
                                                 },
                                             ),
                                             arguments: Arguments {
-                                                range: 473..477,
+                                                range: 551..555,
                                                 args: [
                                                     NumberLiteral(
                                                         ExprNumberLiteral {
-                                                            range: 474..476,
+                                                            range: 552..554,
                                                             value: Int(
                                                                 10,
                                                             ),
@@ -1003,30 +1031,30 @@ Module(
                                     is_async: false,
                                 },
                                 Comprehension {
-                                    range: 478..496,
+                                    range: 556..574,
                                     target: Name(
                                         ExprName {
-                                            range: 482..483,
+                                            range: 560..561,
                                             id: "y",
                                             ctx: Store,
                                         },
                                     ),
                                     iter: Call(
                                         ExprCall {
-                                            range: 487..496,
+                                            range: 565..574,
                                             func: Name(
                                                 ExprName {
-                                                    range: 487..492,
+                                                    range: 565..570,
                                                     id: "range",
                                                     ctx: Load,
                                                 },
                                             ),
                                             arguments: Arguments {
-                                                range: 492..496,
+                                                range: 570..574,
                                                 args: [
                                                     NumberLiteral(
                                                         ExprNumberLiteral {
-                                                            range: 493..495,
+                                                            range: 571..573,
                                                             value: Int(
                                                                 10,
                                                             ),
@@ -1047,19 +1075,19 @@ Module(
             ),
             Expr(
                 StmtExpr {
-                    range: 498..522,
+                    range: 576..600,
                     value: Dict(
                         ExprDict {
-                            range: 498..522,
+                            range: 576..600,
                             keys: [
                                 Some(
                                     Set(
                                         ExprSet {
-                                            range: 499..505,
+                                            range: 577..583,
                                             elts: [
                                                 NumberLiteral(
                                                     ExprNumberLiteral {
-                                                        range: 500..501,
+                                                        range: 578..579,
                                                         value: Int(
                                                             1,
                                                         ),
@@ -1067,7 +1095,7 @@ Module(
                                                 ),
                                                 NumberLiteral(
                                                     ExprNumberLiteral {
-                                                        range: 503..504,
+                                                        range: 581..582,
                                                         value: Int(
                                                             2,
                                                         ),
@@ -1080,7 +1108,7 @@ Module(
                                 Some(
                                     Name(
                                         ExprName {
-                                            range: 510..511,
+                                            range: 588..589,
                                             id: "x",
                                             ctx: Load,
                                         },
@@ -1090,7 +1118,7 @@ Module(
                             values: [
                                 NumberLiteral(
                                     ExprNumberLiteral {
-                                        range: 507..508,
+                                        range: 585..586,
                                         value: Int(
                                             3,
                                         ),
@@ -1098,12 +1126,12 @@ Module(
                                 ),
                                 Dict(
                                     ExprDict {
-                                        range: 513..520,
+                                        range: 591..598,
                                         keys: [
                                             Some(
                                                 NumberLiteral(
                                                     ExprNumberLiteral {
-                                                        range: 514..515,
+                                                        range: 592..593,
                                                         value: Int(
                                                             1,
                                                         ),
@@ -1114,7 +1142,7 @@ Module(
                                         values: [
                                             NumberLiteral(
                                                 ExprNumberLiteral {
-                                                    range: 517..518,
+                                                    range: 595..596,
                                                     value: Int(
                                                         2,
                                                     ),
@@ -1130,15 +1158,15 @@ Module(
             ),
             Expr(
                 StmtExpr {
-                    range: 523..543,
+                    range: 601..621,
                     value: Dict(
                         ExprDict {
-                            range: 523..543,
+                            range: 601..621,
                             keys: [
                                 Some(
                                     Name(
                                         ExprName {
-                                            range: 525..526,
+                                            range: 603..604,
                                             id: "x",
                                             ctx: Load,
                                         },
@@ -1147,7 +1175,7 @@ Module(
                                 Some(
                                     Name(
                                         ExprName {
-                                            range: 535..536,
+                                            range: 613..614,
                                             id: "z",
                                             ctx: Load,
                                         },
@@ -1157,14 +1185,14 @@ Module(
                             values: [
                                 Name(
                                     ExprName {
-                                        range: 530..531,
+                                        range: 608..609,
                                         id: "y",
                                         ctx: Load,
                                     },
                                 ),
                                 Name(
                                     ExprName {
-                                        range: 540..541,
+                                        range: 618..619,
                                         id: "a",
                                         ctx: Load,
                                     },


### PR DESCRIPTION
## Summary

This PR updates handling the error handling for `bitwise_or` grammar rule.

**tldr,**
* Remove `parse_expression_with_bitwise_or_precedence`
* Add a new `validate_expression_with_bitwise_or_precedence`
* Use the validation method wherever the precedence is `bitwise_or`

Previously, there was a `parse_expression_with_bitwise_or_precedence` parser method which would parse the expression with `bitwise_or` precedence using the Pratt Parsing technique. There are two things to understand with the current implementation of Pratt parser:

1. The parsing of LHS expression doesn't take into account the previous precedence. This is important to disallow expression as per the precedence. This has been fixed in #10679.
2. The precedence parsing **stops** when the precedence of the current operator is less than the precedence of the previous operator. Note that it doesn't report an error.

With (2) and `yield` expression, we are in a bit of a pickle. So, `yield` is both a statement and an expression. The grammar has `yield_stmt` and `yield_expr`. But, our AST doesn't have a node to represent the yield statement. This means the parser always parse it using the expression method. This creates a problem. For reference, the grammar for yield statement and expression is:

```
yield_stmt: yield_expr

yield_expr:
    | 'yield' 'from' expression 
    | 'yield' [star_expressions]

star_expression:
	| '*' bitwise_or
	| expression
```

And, for some more context, the different between `expression` and `star_expression` is that for the later, the precedence of a starred expression is bitwise OR. The `expression` grammar doesn't allow starred expression but we parse it and then later report an error.

Now, for the following example:

```py
yield *x and y
```

How should the AST look like? Should it be `(yield *x) and y` or `yield *(x and y)`? This is a yield statement and so it consumes the entire expression. If not, this would become a boolean expression with LHS being `yield *x` and RHS being `y`.

Another problem here is about error reporting. The above is not a valid syntax as starred comparison expression isn't allowed in that context. There are two solutions to this:
1. Keep the `parse_expression_with_bitwise_or_precedence` and use the current token to validate the expression. Remember that this happens because the Pratt Parser stops at the `and` token due to the precedence. The AST would still output a comparison expression.
2. Remove `parse_expression_with_bitwise_or_precedence`, parse **all** starred expression with the highest precedence, and add a validation step for wherever it is required the precedence to be bitwise OR. This would keep the AST as a yield expression as is in the code. **This is the chosen solution in this PR.**

This also helps in keeping our AST match the program whereas previously, as the Pratt Parsing would stop, the final AST would look a bit different. This can be observed with the updated AST snapshots in this PR.

## Test Plan

Update the snapshots with the new error handling.
