### PR TITLE
Add tests for yield and yield from expressions

### DIFF
--- a/crates/ruff_python_parser/resources/invalid/expressions/yield/named_expression.py
+++ b/crates/ruff_python_parser/resources/invalid/expressions/yield/named_expression.py
@@ -1,0 +1,4 @@
+# Unparenthesized named expressions are not allowed
+yield x := 1
+
+yield 1, x := 2, 3

--- a/crates/ruff_python_parser/resources/invalid/expressions/yield/star_expression.py
+++ b/crates/ruff_python_parser/resources/invalid/expressions/yield/star_expression.py
@@ -1,0 +1,4 @@
+# Cannot use starred expression here
+yield (*x)
+
+yield *x and y, z

--- a/crates/ruff_python_parser/resources/invalid/expressions/yield_from/starred_expression.py
+++ b/crates/ruff_python_parser/resources/invalid/expressions/yield_from/starred_expression.py
@@ -1,0 +1,4 @@
+# Yield from doesn't allow top-level starred expression unlike yield
+
+yield from *x
+yield from *x, y

--- a/crates/ruff_python_parser/resources/invalid/expressions/yield_from/unparenthesized.py
+++ b/crates/ruff_python_parser/resources/invalid/expressions/yield_from/unparenthesized.py
@@ -1,0 +1,9 @@
+# Unparenthesized named expression
+yield from x := 1
+
+# Unparenthesized tuple expression
+yield from x, y
+
+# This is a tuple expression parsing
+#          vvvvvvvvvvvvv
+yield from (x, *x and y)

--- a/crates/ruff_python_parser/resources/valid/expressions/yield.py
+++ b/crates/ruff_python_parser/resources/valid/expressions/yield.py
@@ -1,11 +1,16 @@
-yield *y
+yield
 yield x
 yield x + 1
-yield a and b
-yield f()
+yield x and y
+yield call()
 yield [1, 2]
 yield {3, 4}
-yield {i: 5}
-yield 7, 8
-yield (9, 10)
-yield 1 == 1
+yield {x: 5}
+yield x, y
+yield (x, y)
+yield x == y
+yield (x := 1)
+yield *y
+yield x, *y
+yield *x,
+yield *x | y

--- a/crates/ruff_python_parser/resources/valid/expressions/yield_from.py
+++ b/crates/ruff_python_parser/resources/valid/expressions/yield_from.py
@@ -1,9 +1,11 @@
 yield from x
 yield from x + 1
-yield from a and b
-yield from f()
+yield from x and y
+yield from call()
 yield from [1, 2]
 yield from {3, 4}
-yield from {i: 5}
-yield from (9, 10)
-yield from 1 == 1
+yield from {x: 5}
+yield from (x, y)
+yield from x == y
+yield from (x := 1)
+yield from (x, *x | y)

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__yield__named_expression.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__yield__named_expression.py.snap
@@ -1,0 +1,116 @@
+---
+source: crates/ruff_python_parser/tests/fixtures.rs
+input_file: crates/ruff_python_parser/resources/invalid/expressions/yield/named_expression.py
+---
+## AST
+
+```
+Module(
+    ModModule {
+        range: 0..85,
+        body: [
+            Expr(
+                StmtExpr {
+                    range: 52..59,
+                    value: Yield(
+                        ExprYield {
+                            range: 52..59,
+                            value: Some(
+                                Name(
+                                    ExprName {
+                                        range: 58..59,
+                                        id: "x",
+                                        ctx: Load,
+                                    },
+                                ),
+                            ),
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 63..64,
+                    value: NumberLiteral(
+                        ExprNumberLiteral {
+                            range: 63..64,
+                            value: Int(
+                                1,
+                            ),
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 66..84,
+                    value: Yield(
+                        ExprYield {
+                            range: 66..84,
+                            value: Some(
+                                Tuple(
+                                    ExprTuple {
+                                        range: 72..84,
+                                        elts: [
+                                            NumberLiteral(
+                                                ExprNumberLiteral {
+                                                    range: 72..73,
+                                                    value: Int(
+                                                        1,
+                                                    ),
+                                                },
+                                            ),
+                                            Name(
+                                                ExprName {
+                                                    range: 75..76,
+                                                    id: "x",
+                                                    ctx: Load,
+                                                },
+                                            ),
+                                            NumberLiteral(
+                                                ExprNumberLiteral {
+                                                    range: 80..81,
+                                                    value: Int(
+                                                        2,
+                                                    ),
+                                                },
+                                            ),
+                                            NumberLiteral(
+                                                ExprNumberLiteral {
+                                                    range: 83..84,
+                                                    value: Int(
+                                                        3,
+                                                    ),
+                                                },
+                                            ),
+                                        ],
+                                        ctx: Load,
+                                        parenthesized: false,
+                                    },
+                                ),
+                            ),
+                        },
+                    ),
+                },
+            ),
+        ],
+    },
+)
+```
+## Errors
+
+  |
+1 | # Unparenthesized named expressions are not allowed
+2 | yield x := 1
+  |         ^^ Syntax Error: Expected a statement
+3 | 
+4 | yield 1, x := 2, 3
+  |
+
+
+  |
+2 | yield x := 1
+3 | 
+4 | yield 1, x := 2, 3
+  |            ^^ Syntax Error: expected Comma, found ColonEqual
+  |

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__yield__star_expression.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__yield__star_expression.py.snap
@@ -1,0 +1,113 @@
+---
+source: crates/ruff_python_parser/tests/fixtures.rs
+input_file: crates/ruff_python_parser/resources/invalid/expressions/yield/star_expression.py
+---
+## AST
+
+```
+Module(
+    ModModule {
+        range: 0..67,
+        body: [
+            Expr(
+                StmtExpr {
+                    range: 37..47,
+                    value: Yield(
+                        ExprYield {
+                            range: 37..47,
+                            value: Some(
+                                Starred(
+                                    ExprStarred {
+                                        range: 44..46,
+                                        value: Name(
+                                            ExprName {
+                                                range: 45..46,
+                                                id: "x",
+                                                ctx: Load,
+                                            },
+                                        ),
+                                        ctx: Load,
+                                    },
+                                ),
+                            ),
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 49..66,
+                    value: Yield(
+                        ExprYield {
+                            range: 49..66,
+                            value: Some(
+                                Tuple(
+                                    ExprTuple {
+                                        range: 55..66,
+                                        elts: [
+                                            Starred(
+                                                ExprStarred {
+                                                    range: 55..63,
+                                                    value: BoolOp(
+                                                        ExprBoolOp {
+                                                            range: 56..63,
+                                                            op: And,
+                                                            values: [
+                                                                Name(
+                                                                    ExprName {
+                                                                        range: 56..57,
+                                                                        id: "x",
+                                                                        ctx: Load,
+                                                                    },
+                                                                ),
+                                                                Name(
+                                                                    ExprName {
+                                                                        range: 62..63,
+                                                                        id: "y",
+                                                                        ctx: Load,
+                                                                    },
+                                                                ),
+                                                            ],
+                                                        },
+                                                    ),
+                                                    ctx: Load,
+                                                },
+                                            ),
+                                            Name(
+                                                ExprName {
+                                                    range: 65..66,
+                                                    id: "z",
+                                                    ctx: Load,
+                                                },
+                                            ),
+                                        ],
+                                        ctx: Load,
+                                        parenthesized: false,
+                                    },
+                                ),
+                            ),
+                        },
+                    ),
+                },
+            ),
+        ],
+    },
+)
+```
+## Errors
+
+  |
+1 | # Cannot use starred expression here
+2 | yield (*x)
+  |        ^^ Syntax Error: starred expression cannot be used here
+3 | 
+4 | yield *x and y, z
+  |
+
+
+  |
+2 | yield (*x)
+3 | 
+4 | yield *x and y, z
+  |        ^^^^^^^ Syntax Error: boolean expression cannot be used here
+  |

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__yield_from__starred_expression.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__yield_from__starred_expression.py.snap
@@ -1,0 +1,93 @@
+---
+source: crates/ruff_python_parser/tests/fixtures.rs
+input_file: crates/ruff_python_parser/resources/invalid/expressions/yield_from/starred_expression.py
+---
+## AST
+
+```
+Module(
+    ModModule {
+        range: 0..100,
+        body: [
+            Expr(
+                StmtExpr {
+                    range: 70..83,
+                    value: YieldFrom(
+                        ExprYieldFrom {
+                            range: 70..83,
+                            value: Starred(
+                                ExprStarred {
+                                    range: 81..83,
+                                    value: Name(
+                                        ExprName {
+                                            range: 82..83,
+                                            id: "x",
+                                            ctx: Load,
+                                        },
+                                    ),
+                                    ctx: Load,
+                                },
+                            ),
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 84..100,
+                    value: YieldFrom(
+                        ExprYieldFrom {
+                            range: 84..100,
+                            value: Tuple(
+                                ExprTuple {
+                                    range: 95..100,
+                                    elts: [
+                                        Starred(
+                                            ExprStarred {
+                                                range: 95..97,
+                                                value: Name(
+                                                    ExprName {
+                                                        range: 96..97,
+                                                        id: "x",
+                                                        ctx: Load,
+                                                    },
+                                                ),
+                                                ctx: Load,
+                                            },
+                                        ),
+                                        Name(
+                                            ExprName {
+                                                range: 99..100,
+                                                id: "y",
+                                                ctx: Load,
+                                            },
+                                        ),
+                                    ],
+                                    ctx: Load,
+                                    parenthesized: false,
+                                },
+                            ),
+                        },
+                    ),
+                },
+            ),
+        ],
+    },
+)
+```
+## Errors
+
+  |
+1 | # Yield from doesn't allow top-level starred expression unlike yield
+2 | 
+3 | yield from *x
+  |            ^^ Syntax Error: starred expression cannot be used here
+4 | yield from *x, y
+  |
+
+
+  |
+3 | yield from *x
+4 | yield from *x, y
+  |            ^^^^^ Syntax Error: unparenthesized tuple cannot be used here
+  |

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__yield_from__unparenthesized.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__yield_from__unparenthesized.py.snap
@@ -1,0 +1,158 @@
+---
+source: crates/ruff_python_parser/tests/fixtures.rs
+input_file: crates/ruff_python_parser/resources/invalid/expressions/yield_from/unparenthesized.py
+---
+## AST
+
+```
+Module(
+    ModModule {
+        range: 0..192,
+        body: [
+            Expr(
+                StmtExpr {
+                    range: 35..47,
+                    value: YieldFrom(
+                        ExprYieldFrom {
+                            range: 35..47,
+                            value: Name(
+                                ExprName {
+                                    range: 46..47,
+                                    id: "x",
+                                    ctx: Load,
+                                },
+                            ),
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 51..52,
+                    value: NumberLiteral(
+                        ExprNumberLiteral {
+                            range: 51..52,
+                            value: Int(
+                                1,
+                            ),
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 89..104,
+                    value: YieldFrom(
+                        ExprYieldFrom {
+                            range: 89..104,
+                            value: Tuple(
+                                ExprTuple {
+                                    range: 100..104,
+                                    elts: [
+                                        Name(
+                                            ExprName {
+                                                range: 100..101,
+                                                id: "x",
+                                                ctx: Load,
+                                            },
+                                        ),
+                                        Name(
+                                            ExprName {
+                                                range: 103..104,
+                                                id: "y",
+                                                ctx: Load,
+                                            },
+                                        ),
+                                    ],
+                                    ctx: Load,
+                                    parenthesized: false,
+                                },
+                            ),
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 168..192,
+                    value: YieldFrom(
+                        ExprYieldFrom {
+                            range: 168..192,
+                            value: Tuple(
+                                ExprTuple {
+                                    range: 179..192,
+                                    elts: [
+                                        Name(
+                                            ExprName {
+                                                range: 180..181,
+                                                id: "x",
+                                                ctx: Load,
+                                            },
+                                        ),
+                                        Starred(
+                                            ExprStarred {
+                                                range: 183..191,
+                                                value: BoolOp(
+                                                    ExprBoolOp {
+                                                        range: 184..191,
+                                                        op: And,
+                                                        values: [
+                                                            Name(
+                                                                ExprName {
+                                                                    range: 184..185,
+                                                                    id: "x",
+                                                                    ctx: Load,
+                                                                },
+                                                            ),
+                                                            Name(
+                                                                ExprName {
+                                                                    range: 190..191,
+                                                                    id: "y",
+                                                                    ctx: Load,
+                                                                },
+                                                            ),
+                                                        ],
+                                                    },
+                                                ),
+                                                ctx: Load,
+                                            },
+                                        ),
+                                    ],
+                                    ctx: Load,
+                                    parenthesized: true,
+                                },
+                            ),
+                        },
+                    ),
+                },
+            ),
+        ],
+    },
+)
+```
+## Errors
+
+  |
+1 | # Unparenthesized named expression
+2 | yield from x := 1
+  |              ^^ Syntax Error: Expected a statement
+3 | 
+4 | # Unparenthesized tuple expression
+  |
+
+
+  |
+4 | # Unparenthesized tuple expression
+5 | yield from x, y
+  |            ^^^^ Syntax Error: unparenthesized tuple cannot be used here
+6 | 
+7 | # This is a tuple expression parsing
+  |
+
+
+  |
+7 | # This is a tuple expression parsing
+8 | #          vvvvvvvvvvvvv
+9 | yield from (x, *x and y)
+  |                 ^^^^^^^ Syntax Error: boolean expression cannot be used here
+  |

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@expressions__yield.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@expressions__yield.py.snap
@@ -7,43 +7,29 @@ input_file: crates/ruff_python_parser/resources/valid/expressions/yield.py
 ```
 Module(
     ModModule {
-        range: 0..129,
+        range: 0..188,
         body: [
             Expr(
                 StmtExpr {
-                    range: 0..8,
+                    range: 0..5,
                     value: Yield(
                         ExprYield {
-                            range: 0..8,
-                            value: Some(
-                                Starred(
-                                    ExprStarred {
-                                        range: 6..8,
-                                        value: Name(
-                                            ExprName {
-                                                range: 7..8,
-                                                id: "y",
-                                                ctx: Load,
-                                            },
-                                        ),
-                                        ctx: Load,
-                                    },
-                                ),
-                            ),
+                            range: 0..5,
+                            value: None,
                         },
                     ),
                 },
             ),
             Expr(
                 StmtExpr {
-                    range: 9..16,
+                    range: 6..13,
                     value: Yield(
                         ExprYield {
-                            range: 9..16,
+                            range: 6..13,
                             value: Some(
                                 Name(
                                     ExprName {
-                                        range: 15..16,
+                                        range: 12..13,
                                         id: "x",
                                         ctx: Load,
                                     },
@@ -55,17 +41,17 @@ Module(
             ),
             Expr(
                 StmtExpr {
-                    range: 17..28,
+                    range: 14..25,
                     value: Yield(
                         ExprYield {
-                            range: 17..28,
+                            range: 14..25,
                             value: Some(
                                 BinOp(
                                     ExprBinOp {
-                                        range: 23..28,
+                                        range: 20..25,
                                         left: Name(
                                             ExprName {
-                                                range: 23..24,
+                                                range: 20..21,
                                                 id: "x",
                                                 ctx: Load,
                                             },
@@ -73,7 +59,7 @@ Module(
                                         op: Add,
                                         right: NumberLiteral(
                                             ExprNumberLiteral {
-                                                range: 27..28,
+                                                range: 24..25,
                                                 value: Int(
                                                     1,
                                                 ),
@@ -88,27 +74,27 @@ Module(
             ),
             Expr(
                 StmtExpr {
-                    range: 29..42,
+                    range: 26..39,
                     value: Yield(
                         ExprYield {
-                            range: 29..42,
+                            range: 26..39,
                             value: Some(
                                 BoolOp(
                                     ExprBoolOp {
-                                        range: 35..42,
+                                        range: 32..39,
                                         op: And,
                                         values: [
                                             Name(
                                                 ExprName {
-                                                    range: 35..36,
-                                                    id: "a",
+                                                    range: 32..33,
+                                                    id: "x",
                                                     ctx: Load,
                                                 },
                                             ),
                                             Name(
                                                 ExprName {
-                                                    range: 41..42,
-                                                    id: "b",
+                                                    range: 38..39,
+                                                    id: "y",
                                                     ctx: Load,
                                                 },
                                             ),
@@ -122,18 +108,18 @@ Module(
             ),
             Expr(
                 StmtExpr {
-                    range: 43..52,
+                    range: 40..52,
                     value: Yield(
                         ExprYield {
-                            range: 43..52,
+                            range: 40..52,
                             value: Some(
                                 Call(
                                     ExprCall {
-                                        range: 49..52,
+                                        range: 46..52,
                                         func: Name(
                                             ExprName {
-                                                range: 49..50,
-                                                id: "f",
+                                                range: 46..50,
+                                                id: "call",
                                                 ctx: Load,
                                             },
                                         ),
@@ -235,7 +221,7 @@ Module(
                                                 Name(
                                                     ExprName {
                                                         range: 86..87,
-                                                        id: "i",
+                                                        id: "x",
                                                         ctx: Load,
                                                     },
                                                 ),
@@ -269,20 +255,18 @@ Module(
                                     ExprTuple {
                                         range: 98..102,
                                         elts: [
-                                            NumberLiteral(
-                                                ExprNumberLiteral {
+                                            Name(
+                                                ExprName {
                                                     range: 98..99,
-                                                    value: Int(
-                                                        7,
-                                                    ),
+                                                    id: "x",
+                                                    ctx: Load,
                                                 },
                                             ),
-                                            NumberLiteral(
-                                                ExprNumberLiteral {
+                                            Name(
+                                                ExprName {
                                                     range: 101..102,
-                                                    value: Int(
-                                                        8,
-                                                    ),
+                                                    id: "y",
+                                                    ctx: Load,
                                                 },
                                             ),
                                         ],
@@ -297,29 +281,27 @@ Module(
             ),
             Expr(
                 StmtExpr {
-                    range: 103..116,
+                    range: 103..115,
                     value: Yield(
                         ExprYield {
-                            range: 103..116,
+                            range: 103..115,
                             value: Some(
                                 Tuple(
                                     ExprTuple {
-                                        range: 109..116,
+                                        range: 109..115,
                                         elts: [
-                                            NumberLiteral(
-                                                ExprNumberLiteral {
+                                            Name(
+                                                ExprName {
                                                     range: 110..111,
-                                                    value: Int(
-                                                        9,
-                                                    ),
+                                                    id: "x",
+                                                    ctx: Load,
                                                 },
                                             ),
-                                            NumberLiteral(
-                                                ExprNumberLiteral {
-                                                    range: 113..115,
-                                                    value: Int(
-                                                        10,
-                                                    ),
+                                            Name(
+                                                ExprName {
+                                                    range: 113..114,
+                                                    id: "y",
+                                                    ctx: Load,
                                                 },
                                             ),
                                         ],
@@ -334,35 +316,203 @@ Module(
             ),
             Expr(
                 StmtExpr {
-                    range: 117..129,
+                    range: 116..128,
                     value: Yield(
                         ExprYield {
-                            range: 117..129,
+                            range: 116..128,
                             value: Some(
                                 Compare(
                                     ExprCompare {
-                                        range: 123..129,
-                                        left: NumberLiteral(
-                                            ExprNumberLiteral {
-                                                range: 123..124,
-                                                value: Int(
-                                                    1,
-                                                ),
+                                        range: 122..128,
+                                        left: Name(
+                                            ExprName {
+                                                range: 122..123,
+                                                id: "x",
+                                                ctx: Load,
                                             },
                                         ),
                                         ops: [
                                             Eq,
                                         ],
                                         comparators: [
-                                            NumberLiteral(
-                                                ExprNumberLiteral {
-                                                    range: 128..129,
-                                                    value: Int(
-                                                        1,
-                                                    ),
+                                            Name(
+                                                ExprName {
+                                                    range: 127..128,
+                                                    id: "y",
+                                                    ctx: Load,
                                                 },
                                             ),
                                         ],
+                                    },
+                                ),
+                            ),
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 129..143,
+                    value: Yield(
+                        ExprYield {
+                            range: 129..143,
+                            value: Some(
+                                Named(
+                                    ExprNamed {
+                                        range: 136..142,
+                                        target: Name(
+                                            ExprName {
+                                                range: 136..137,
+                                                id: "x",
+                                                ctx: Store,
+                                            },
+                                        ),
+                                        value: NumberLiteral(
+                                            ExprNumberLiteral {
+                                                range: 141..142,
+                                                value: Int(
+                                                    1,
+                                                ),
+                                            },
+                                        ),
+                                    },
+                                ),
+                            ),
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 144..152,
+                    value: Yield(
+                        ExprYield {
+                            range: 144..152,
+                            value: Some(
+                                Starred(
+                                    ExprStarred {
+                                        range: 150..152,
+                                        value: Name(
+                                            ExprName {
+                                                range: 151..152,
+                                                id: "y",
+                                                ctx: Load,
+                                            },
+                                        ),
+                                        ctx: Load,
+                                    },
+                                ),
+                            ),
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 153..164,
+                    value: Yield(
+                        ExprYield {
+                            range: 153..164,
+                            value: Some(
+                                Tuple(
+                                    ExprTuple {
+                                        range: 159..164,
+                                        elts: [
+                                            Name(
+                                                ExprName {
+                                                    range: 159..160,
+                                                    id: "x",
+                                                    ctx: Load,
+                                                },
+                                            ),
+                                            Starred(
+                                                ExprStarred {
+                                                    range: 162..164,
+                                                    value: Name(
+                                                        ExprName {
+                                                            range: 163..164,
+                                                            id: "y",
+                                                            ctx: Load,
+                                                        },
+                                                    ),
+                                                    ctx: Load,
+                                                },
+                                            ),
+                                        ],
+                                        ctx: Load,
+                                        parenthesized: false,
+                                    },
+                                ),
+                            ),
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 165..174,
+                    value: Yield(
+                        ExprYield {
+                            range: 165..174,
+                            value: Some(
+                                Tuple(
+                                    ExprTuple {
+                                        range: 171..174,
+                                        elts: [
+                                            Starred(
+                                                ExprStarred {
+                                                    range: 171..173,
+                                                    value: Name(
+                                                        ExprName {
+                                                            range: 172..173,
+                                                            id: "x",
+                                                            ctx: Load,
+                                                        },
+                                                    ),
+                                                    ctx: Load,
+                                                },
+                                            ),
+                                        ],
+                                        ctx: Load,
+                                        parenthesized: false,
+                                    },
+                                ),
+                            ),
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 175..187,
+                    value: Yield(
+                        ExprYield {
+                            range: 175..187,
+                            value: Some(
+                                Starred(
+                                    ExprStarred {
+                                        range: 181..187,
+                                        value: BinOp(
+                                            ExprBinOp {
+                                                range: 182..187,
+                                                left: Name(
+                                                    ExprName {
+                                                        range: 182..183,
+                                                        id: "x",
+                                                        ctx: Load,
+                                                    },
+                                                ),
+                                                op: BitOr,
+                                                right: Name(
+                                                    ExprName {
+                                                        range: 186..187,
+                                                        id: "y",
+                                                        ctx: Load,
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                        ctx: Load,
                                     },
                                 ),
                             ),

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@expressions__yield_from.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@expressions__yield_from.py.snap
@@ -7,7 +7,7 @@ input_file: crates/ruff_python_parser/resources/valid/expressions/yield_from.py
 ```
 Module(
     ModModule {
-        range: 0..154,
+        range: 0..199,
         body: [
             Expr(
                 StmtExpr {
@@ -71,14 +71,14 @@ Module(
                                         Name(
                                             ExprName {
                                                 range: 41..42,
-                                                id: "a",
+                                                id: "x",
                                                 ctx: Load,
                                             },
                                         ),
                                         Name(
                                             ExprName {
                                                 range: 47..48,
-                                                id: "b",
+                                                id: "y",
                                                 ctx: Load,
                                             },
                                         ),
@@ -91,22 +91,22 @@ Module(
             ),
             Expr(
                 StmtExpr {
-                    range: 49..63,
+                    range: 49..66,
                     value: YieldFrom(
                         ExprYieldFrom {
-                            range: 49..63,
+                            range: 49..66,
                             value: Call(
                                 ExprCall {
-                                    range: 60..63,
+                                    range: 60..66,
                                     func: Name(
                                         ExprName {
-                                            range: 60..61,
-                                            id: "f",
+                                            range: 60..64,
+                                            id: "call",
                                             ctx: Load,
                                         },
                                     ),
                                     arguments: Arguments {
-                                        range: 61..63,
+                                        range: 64..66,
                                         args: [],
                                         keywords: [],
                                     },
@@ -118,17 +118,17 @@ Module(
             ),
             Expr(
                 StmtExpr {
-                    range: 64..81,
+                    range: 67..84,
                     value: YieldFrom(
                         ExprYieldFrom {
-                            range: 64..81,
+                            range: 67..84,
                             value: List(
                                 ExprList {
-                                    range: 75..81,
+                                    range: 78..84,
                                     elts: [
                                         NumberLiteral(
                                             ExprNumberLiteral {
-                                                range: 76..77,
+                                                range: 79..80,
                                                 value: Int(
                                                     1,
                                                 ),
@@ -136,7 +136,7 @@ Module(
                                         ),
                                         NumberLiteral(
                                             ExprNumberLiteral {
-                                                range: 79..80,
+                                                range: 82..83,
                                                 value: Int(
                                                     2,
                                                 ),
@@ -152,17 +152,17 @@ Module(
             ),
             Expr(
                 StmtExpr {
-                    range: 82..99,
+                    range: 85..102,
                     value: YieldFrom(
                         ExprYieldFrom {
-                            range: 82..99,
+                            range: 85..102,
                             value: Set(
                                 ExprSet {
-                                    range: 93..99,
+                                    range: 96..102,
                                     elts: [
                                         NumberLiteral(
                                             ExprNumberLiteral {
-                                                range: 94..95,
+                                                range: 97..98,
                                                 value: Int(
                                                     3,
                                                 ),
@@ -170,7 +170,7 @@ Module(
                                         ),
                                         NumberLiteral(
                                             ExprNumberLiteral {
-                                                range: 97..98,
+                                                range: 100..101,
                                                 value: Int(
                                                     4,
                                                 ),
@@ -185,19 +185,19 @@ Module(
             ),
             Expr(
                 StmtExpr {
-                    range: 100..117,
+                    range: 103..120,
                     value: YieldFrom(
                         ExprYieldFrom {
-                            range: 100..117,
+                            range: 103..120,
                             value: Dict(
                                 ExprDict {
-                                    range: 111..117,
+                                    range: 114..120,
                                     keys: [
                                         Some(
                                             Name(
                                                 ExprName {
-                                                    range: 112..113,
-                                                    id: "i",
+                                                    range: 115..116,
+                                                    id: "x",
                                                     ctx: Load,
                                                 },
                                             ),
@@ -206,7 +206,7 @@ Module(
                                     values: [
                                         NumberLiteral(
                                             ExprNumberLiteral {
-                                                range: 115..116,
+                                                range: 118..119,
                                                 value: Int(
                                                     5,
                                                 ),
@@ -221,28 +221,26 @@ Module(
             ),
             Expr(
                 StmtExpr {
-                    range: 118..136,
+                    range: 121..138,
                     value: YieldFrom(
                         ExprYieldFrom {
-                            range: 118..136,
+                            range: 121..138,
                             value: Tuple(
                                 ExprTuple {
-                                    range: 129..136,
+                                    range: 132..138,
                                     elts: [
-                                        NumberLiteral(
-                                            ExprNumberLiteral {
-                                                range: 130..131,
-                                                value: Int(
-                                                    9,
-                                                ),
+                                        Name(
+                                            ExprName {
+                                                range: 133..134,
+                                                id: "x",
+                                                ctx: Load,
                                             },
                                         ),
-                                        NumberLiteral(
-                                            ExprNumberLiteral {
-                                                range: 133..135,
-                                                value: Int(
-                                                    10,
-                                                ),
+                                        Name(
+                                            ExprName {
+                                                range: 136..137,
+                                                id: "y",
+                                                ctx: Load,
                                             },
                                         ),
                                     ],
@@ -256,34 +254,114 @@ Module(
             ),
             Expr(
                 StmtExpr {
-                    range: 137..154,
+                    range: 139..156,
                     value: YieldFrom(
                         ExprYieldFrom {
-                            range: 137..154,
+                            range: 139..156,
                             value: Compare(
                                 ExprCompare {
-                                    range: 148..154,
-                                    left: NumberLiteral(
-                                        ExprNumberLiteral {
-                                            range: 148..149,
-                                            value: Int(
-                                                1,
-                                            ),
+                                    range: 150..156,
+                                    left: Name(
+                                        ExprName {
+                                            range: 150..151,
+                                            id: "x",
+                                            ctx: Load,
                                         },
                                     ),
                                     ops: [
                                         Eq,
                                     ],
                                     comparators: [
-                                        NumberLiteral(
-                                            ExprNumberLiteral {
-                                                range: 153..154,
-                                                value: Int(
-                                                    1,
-                                                ),
+                                        Name(
+                                            ExprName {
+                                                range: 155..156,
+                                                id: "y",
+                                                ctx: Load,
                                             },
                                         ),
                                     ],
+                                },
+                            ),
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 157..176,
+                    value: YieldFrom(
+                        ExprYieldFrom {
+                            range: 157..176,
+                            value: Named(
+                                ExprNamed {
+                                    range: 169..175,
+                                    target: Name(
+                                        ExprName {
+                                            range: 169..170,
+                                            id: "x",
+                                            ctx: Store,
+                                        },
+                                    ),
+                                    value: NumberLiteral(
+                                        ExprNumberLiteral {
+                                            range: 174..175,
+                                            value: Int(
+                                                1,
+                                            ),
+                                        },
+                                    ),
+                                },
+                            ),
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 177..199,
+                    value: YieldFrom(
+                        ExprYieldFrom {
+                            range: 177..199,
+                            value: Tuple(
+                                ExprTuple {
+                                    range: 188..199,
+                                    elts: [
+                                        Name(
+                                            ExprName {
+                                                range: 189..190,
+                                                id: "x",
+                                                ctx: Load,
+                                            },
+                                        ),
+                                        Starred(
+                                            ExprStarred {
+                                                range: 192..198,
+                                                value: BinOp(
+                                                    ExprBinOp {
+                                                        range: 193..198,
+                                                        left: Name(
+                                                            ExprName {
+                                                                range: 193..194,
+                                                                id: "x",
+                                                                ctx: Load,
+                                                            },
+                                                        ),
+                                                        op: BitOr,
+                                                        right: Name(
+                                                            ExprName {
+                                                                range: 197..198,
+                                                                id: "y",
+                                                                ctx: Load,
+                                                            },
+                                                        ),
+                                                    },
+                                                ),
+                                                ctx: Load,
+                                            },
+                                        ),
+                                    ],
+                                    ctx: Load,
+                                    parenthesized: true,
                                 },
                             ),
                         },


### PR DESCRIPTION
## Summary

This PR adds test cases for `yield` and `yield from` expression. There's some context in #10657 regarding the problems faced in yield expression parsing.
