### PR TITLE
Modify diagnostic ranges for shell-related `bandit` rules

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_bandit/snapshots/ruff_linter__rules__flake8_bandit__tests__S602_S602.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_bandit/snapshots/ruff_linter__rules__flake8_bandit__tests__S602_S602.py.snap
@@ -1,117 +1,115 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_bandit/mod.rs
 ---
-S602.py:4:15: S602 `subprocess` call with `shell=True` seems safe, but may be changed in the future; consider rewriting without `shell`
+S602.py:4:1: S602 `subprocess` call with `shell=True` seems safe, but may be changed in the future; consider rewriting without `shell`
   |
 3 | # Check different Popen wrappers are checked.
 4 | Popen("true", shell=True)
-  |               ^^^^^^^^^^ S602
+  | ^^^^^ S602
 5 | call("true", shell=True)
 6 | check_call("true", shell=True)
   |
 
-S602.py:5:14: S602 `subprocess` call with `shell=True` seems safe, but may be changed in the future; consider rewriting without `shell`
+S602.py:5:1: S602 `subprocess` call with `shell=True` seems safe, but may be changed in the future; consider rewriting without `shell`
   |
 3 | # Check different Popen wrappers are checked.
 4 | Popen("true", shell=True)
 5 | call("true", shell=True)
-  |              ^^^^^^^^^^ S602
+  | ^^^^ S602
 6 | check_call("true", shell=True)
 7 | check_output("true", shell=True)
   |
 
-S602.py:6:20: S602 `subprocess` call with `shell=True` seems safe, but may be changed in the future; consider rewriting without `shell`
+S602.py:6:1: S602 `subprocess` call with `shell=True` seems safe, but may be changed in the future; consider rewriting without `shell`
   |
 4 | Popen("true", shell=True)
 5 | call("true", shell=True)
 6 | check_call("true", shell=True)
-  |                    ^^^^^^^^^^ S602
+  | ^^^^^^^^^^ S602
 7 | check_output("true", shell=True)
 8 | run("true", shell=True)
   |
 
-S602.py:7:22: S602 `subprocess` call with `shell=True` seems safe, but may be changed in the future; consider rewriting without `shell`
+S602.py:7:1: S602 `subprocess` call with `shell=True` seems safe, but may be changed in the future; consider rewriting without `shell`
   |
 5 | call("true", shell=True)
 6 | check_call("true", shell=True)
 7 | check_output("true", shell=True)
-  |                      ^^^^^^^^^^ S602
+  | ^^^^^^^^^^^^ S602
 8 | run("true", shell=True)
   |
 
-S602.py:8:13: S602 `subprocess` call with `shell=True` seems safe, but may be changed in the future; consider rewriting without `shell`
+S602.py:8:1: S602 `subprocess` call with `shell=True` seems safe, but may be changed in the future; consider rewriting without `shell`
    |
  6 | check_call("true", shell=True)
  7 | check_output("true", shell=True)
  8 | run("true", shell=True)
-   |             ^^^^^^^^^^ S602
+   | ^^^ S602
  9 | 
 10 | # Check values that truthy values are treated as true.
    |
 
-S602.py:11:15: S602 `subprocess` call with truthy `shell` seems safe, but may be changed in the future; consider rewriting without `shell`
+S602.py:11:1: S602 `subprocess` call with truthy `shell` seems safe, but may be changed in the future; consider rewriting without `shell`
    |
 10 | # Check values that truthy values are treated as true.
 11 | Popen("true", shell=1)
-   |               ^^^^^^^ S602
+   | ^^^^^ S602
 12 | Popen("true", shell=[1])
 13 | Popen("true", shell={1: 1})
    |
 
-S602.py:12:15: S602 `subprocess` call with truthy `shell` seems safe, but may be changed in the future; consider rewriting without `shell`
+S602.py:12:1: S602 `subprocess` call with truthy `shell` seems safe, but may be changed in the future; consider rewriting without `shell`
    |
 10 | # Check values that truthy values are treated as true.
 11 | Popen("true", shell=1)
 12 | Popen("true", shell=[1])
-   |               ^^^^^^^^^ S602
+   | ^^^^^ S602
 13 | Popen("true", shell={1: 1})
 14 | Popen("true", shell=(1,))
    |
 
-S602.py:13:15: S602 `subprocess` call with truthy `shell` seems safe, but may be changed in the future; consider rewriting without `shell`
+S602.py:13:1: S602 `subprocess` call with truthy `shell` seems safe, but may be changed in the future; consider rewriting without `shell`
    |
 11 | Popen("true", shell=1)
 12 | Popen("true", shell=[1])
 13 | Popen("true", shell={1: 1})
-   |               ^^^^^^^^^^^^ S602
+   | ^^^^^ S602
 14 | Popen("true", shell=(1,))
    |
 
-S602.py:14:15: S602 `subprocess` call with truthy `shell` seems safe, but may be changed in the future; consider rewriting without `shell`
+S602.py:14:1: S602 `subprocess` call with truthy `shell` seems safe, but may be changed in the future; consider rewriting without `shell`
    |
 12 | Popen("true", shell=[1])
 13 | Popen("true", shell={1: 1})
 14 | Popen("true", shell=(1,))
-   |               ^^^^^^^^^^ S602
+   | ^^^^^ S602
 15 | 
 16 | # Check command argument looks unsafe.
    |
 
-S602.py:18:19: S602 `subprocess` call with `shell=True` identified, security issue
+S602.py:18:1: S602 `subprocess` call with `shell=True` identified, security issue
    |
 16 | # Check command argument looks unsafe.
 17 | var_string = "true"
 18 | Popen(var_string, shell=True)
-   |                   ^^^^^^^^^^ S602
+   | ^^^^^ S602
 19 | Popen([var_string], shell=True)
 20 | Popen([var_string, ""], shell=True)
    |
 
-S602.py:19:21: S602 `subprocess` call with `shell=True` identified, security issue
+S602.py:19:1: S602 `subprocess` call with `shell=True` identified, security issue
    |
 17 | var_string = "true"
 18 | Popen(var_string, shell=True)
 19 | Popen([var_string], shell=True)
-   |                     ^^^^^^^^^^ S602
+   | ^^^^^ S602
 20 | Popen([var_string, ""], shell=True)
    |
 
-S602.py:20:25: S602 `subprocess` call with `shell=True` identified, security issue
+S602.py:20:1: S602 `subprocess` call with `shell=True` identified, security issue
    |
 18 | Popen(var_string, shell=True)
 19 | Popen([var_string], shell=True)
 20 | Popen([var_string, ""], shell=True)
-   |                         ^^^^^^^^^^ S602
+   | ^^^^^ S602
    |
-
-

--- a/crates/ruff_linter/src/rules/flake8_bandit/snapshots/ruff_linter__rules__flake8_bandit__tests__S603_S603.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_bandit/snapshots/ruff_linter__rules__flake8_bandit__tests__S603_S603.py.snap
@@ -1,106 +1,104 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_bandit/mod.rs
 ---
-S603.py:4:15: S603 `subprocess` call: check for execution of untrusted input
+S603.py:4:1: S603 `subprocess` call: check for execution of untrusted input
   |
 3 | # Different Popen wrappers are checked.
 4 | Popen("true", shell=False)
-  |               ^^^^^^^^^^^ S603
+  | ^^^^^ S603
 5 | call("true", shell=False)
 6 | check_call("true", shell=False)
   |
 
-S603.py:5:14: S603 `subprocess` call: check for execution of untrusted input
+S603.py:5:1: S603 `subprocess` call: check for execution of untrusted input
   |
 3 | # Different Popen wrappers are checked.
 4 | Popen("true", shell=False)
 5 | call("true", shell=False)
-  |              ^^^^^^^^^^^ S603
+  | ^^^^ S603
 6 | check_call("true", shell=False)
 7 | check_output("true", shell=False)
   |
 
-S603.py:6:20: S603 `subprocess` call: check for execution of untrusted input
+S603.py:6:1: S603 `subprocess` call: check for execution of untrusted input
   |
 4 | Popen("true", shell=False)
 5 | call("true", shell=False)
 6 | check_call("true", shell=False)
-  |                    ^^^^^^^^^^^ S603
+  | ^^^^^^^^^^ S603
 7 | check_output("true", shell=False)
 8 | run("true", shell=False)
   |
 
-S603.py:7:22: S603 `subprocess` call: check for execution of untrusted input
+S603.py:7:1: S603 `subprocess` call: check for execution of untrusted input
   |
 5 | call("true", shell=False)
 6 | check_call("true", shell=False)
 7 | check_output("true", shell=False)
-  |                      ^^^^^^^^^^^ S603
+  | ^^^^^^^^^^^^ S603
 8 | run("true", shell=False)
   |
 
-S603.py:8:13: S603 `subprocess` call: check for execution of untrusted input
+S603.py:8:1: S603 `subprocess` call: check for execution of untrusted input
    |
  6 | check_call("true", shell=False)
  7 | check_output("true", shell=False)
  8 | run("true", shell=False)
-   |             ^^^^^^^^^^^ S603
+   | ^^^ S603
  9 | 
 10 | # Values that falsey values are treated as false.
    |
 
-S603.py:11:15: S603 `subprocess` call: check for execution of untrusted input
+S603.py:11:1: S603 `subprocess` call: check for execution of untrusted input
    |
 10 | # Values that falsey values are treated as false.
 11 | Popen("true", shell=0)
-   |               ^^^^^^^ S603
+   | ^^^^^ S603
 12 | Popen("true", shell=[])
 13 | Popen("true", shell={})
    |
 
-S603.py:12:15: S603 `subprocess` call: check for execution of untrusted input
+S603.py:12:1: S603 `subprocess` call: check for execution of untrusted input
    |
 10 | # Values that falsey values are treated as false.
 11 | Popen("true", shell=0)
 12 | Popen("true", shell=[])
-   |               ^^^^^^^^ S603
+   | ^^^^^ S603
 13 | Popen("true", shell={})
 14 | Popen("true", shell=None)
    |
 
-S603.py:13:15: S603 `subprocess` call: check for execution of untrusted input
+S603.py:13:1: S603 `subprocess` call: check for execution of untrusted input
    |
 11 | Popen("true", shell=0)
 12 | Popen("true", shell=[])
 13 | Popen("true", shell={})
-   |               ^^^^^^^^ S603
+   | ^^^^^ S603
 14 | Popen("true", shell=None)
    |
 
-S603.py:14:15: S603 `subprocess` call: check for execution of untrusted input
+S603.py:14:1: S603 `subprocess` call: check for execution of untrusted input
    |
 12 | Popen("true", shell=[])
 13 | Popen("true", shell={})
 14 | Popen("true", shell=None)
-   |               ^^^^^^^^^^ S603
+   | ^^^^^ S603
 15 | 
 16 | # Unknown values are treated as falsey.
    |
 
-S603.py:17:15: S603 `subprocess` call: check for execution of untrusted input
+S603.py:17:1: S603 `subprocess` call: check for execution of untrusted input
    |
 16 | # Unknown values are treated as falsey.
 17 | Popen("true", shell=True if True else False)
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ S603
+   | ^^^^^ S603
 18 | 
 19 | # No value is also caught.
    |
 
-S603.py:20:7: S603 `subprocess` call: check for execution of untrusted input
+S603.py:20:1: S603 `subprocess` call: check for execution of untrusted input
    |
 19 | # No value is also caught.
 20 | Popen("true")
-   |       ^^^^^^ S603
+   | ^^^^^ S603
    |
-
-

--- a/crates/ruff_linter/src/rules/flake8_bandit/snapshots/ruff_linter__rules__flake8_bandit__tests__S604_S604.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_bandit/snapshots/ruff_linter__rules__flake8_bandit__tests__S604_S604.py.snap
@@ -1,10 +1,8 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_bandit/mod.rs
 ---
-S604.py:5:5: S604 Function call with `shell=True` parameter identified, security issue
+S604.py:5:1: S604 Function call with `shell=True` parameter identified, security issue
   |
 5 | foo(shell=True)
-  |     ^^^^^^^^^^ S604
+  | ^^^ S604
   |
-
-

--- a/crates/ruff_linter/src/rules/flake8_bandit/snapshots/ruff_linter__rules__flake8_bandit__tests__S605_S605.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_bandit/snapshots/ruff_linter__rules__flake8_bandit__tests__S605_S605.py.snap
@@ -1,165 +1,165 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_bandit/mod.rs
 ---
-S605.py:8:11: S605 Starting a process with a shell: seems safe, but may be changed in the future; consider rewriting without `shell`
+S605.py:8:1: S605 Starting a process with a shell: seems safe, but may be changed in the future; consider rewriting without `shell`
    |
  7 | # Check all shell functions.
  8 | os.system("true")
-   |           ^^^^^^ S605
+   | ^^^^^^^^^ S605
  9 | os.popen("true")
 10 | os.popen2("true")
    |
 
-S605.py:9:10: S605 Starting a process with a shell: seems safe, but may be changed in the future; consider rewriting without `shell`
+S605.py:9:1: S605 Starting a process with a shell: seems safe, but may be changed in the future; consider rewriting without `shell`
    |
  7 | # Check all shell functions.
  8 | os.system("true")
  9 | os.popen("true")
-   |          ^^^^^^ S605
+   | ^^^^^^^^ S605
 10 | os.popen2("true")
 11 | os.popen3("true")
    |
 
-S605.py:10:11: S605 Starting a process with a shell: seems safe, but may be changed in the future; consider rewriting without `shell`
+S605.py:10:1: S605 Starting a process with a shell: seems safe, but may be changed in the future; consider rewriting without `shell`
    |
  8 | os.system("true")
  9 | os.popen("true")
 10 | os.popen2("true")
-   |           ^^^^^^ S605
+   | ^^^^^^^^^ S605
 11 | os.popen3("true")
 12 | os.popen4("true")
    |
 
-S605.py:11:11: S605 Starting a process with a shell: seems safe, but may be changed in the future; consider rewriting without `shell`
+S605.py:11:1: S605 Starting a process with a shell: seems safe, but may be changed in the future; consider rewriting without `shell`
    |
  9 | os.popen("true")
 10 | os.popen2("true")
 11 | os.popen3("true")
-   |           ^^^^^^ S605
+   | ^^^^^^^^^ S605
 12 | os.popen4("true")
 13 | popen2.popen2("true")
    |
 
-S605.py:12:11: S605 Starting a process with a shell: seems safe, but may be changed in the future; consider rewriting without `shell`
+S605.py:12:1: S605 Starting a process with a shell: seems safe, but may be changed in the future; consider rewriting without `shell`
    |
 10 | os.popen2("true")
 11 | os.popen3("true")
 12 | os.popen4("true")
-   |           ^^^^^^ S605
+   | ^^^^^^^^^ S605
 13 | popen2.popen2("true")
 14 | popen2.popen3("true")
    |
 
-S605.py:13:15: S605 Starting a process with a shell: seems safe, but may be changed in the future; consider rewriting without `shell`
+S605.py:13:1: S605 Starting a process with a shell: seems safe, but may be changed in the future; consider rewriting without `shell`
    |
 11 | os.popen3("true")
 12 | os.popen4("true")
 13 | popen2.popen2("true")
-   |               ^^^^^^ S605
+   | ^^^^^^^^^^^^^ S605
 14 | popen2.popen3("true")
 15 | popen2.popen4("true")
    |
 
-S605.py:14:15: S605 Starting a process with a shell: seems safe, but may be changed in the future; consider rewriting without `shell`
+S605.py:14:1: S605 Starting a process with a shell: seems safe, but may be changed in the future; consider rewriting without `shell`
    |
 12 | os.popen4("true")
 13 | popen2.popen2("true")
 14 | popen2.popen3("true")
-   |               ^^^^^^ S605
+   | ^^^^^^^^^^^^^ S605
 15 | popen2.popen4("true")
 16 | popen2.Popen3("true")
    |
 
-S605.py:15:15: S605 Starting a process with a shell: seems safe, but may be changed in the future; consider rewriting without `shell`
+S605.py:15:1: S605 Starting a process with a shell: seems safe, but may be changed in the future; consider rewriting without `shell`
    |
 13 | popen2.popen2("true")
 14 | popen2.popen3("true")
 15 | popen2.popen4("true")
-   |               ^^^^^^ S605
+   | ^^^^^^^^^^^^^ S605
 16 | popen2.Popen3("true")
 17 | popen2.Popen4("true")
    |
 
-S605.py:16:15: S605 Starting a process with a shell: seems safe, but may be changed in the future; consider rewriting without `shell`
+S605.py:16:1: S605 Starting a process with a shell: seems safe, but may be changed in the future; consider rewriting without `shell`
    |
 14 | popen2.popen3("true")
 15 | popen2.popen4("true")
 16 | popen2.Popen3("true")
-   |               ^^^^^^ S605
+   | ^^^^^^^^^^^^^ S605
 17 | popen2.Popen4("true")
 18 | commands.getoutput("true")
    |
 
-S605.py:17:15: S605 Starting a process with a shell: seems safe, but may be changed in the future; consider rewriting without `shell`
+S605.py:17:1: S605 Starting a process with a shell: seems safe, but may be changed in the future; consider rewriting without `shell`
    |
 15 | popen2.popen4("true")
 16 | popen2.Popen3("true")
 17 | popen2.Popen4("true")
-   |               ^^^^^^ S605
+   | ^^^^^^^^^^^^^ S605
 18 | commands.getoutput("true")
 19 | commands.getstatusoutput("true")
    |
 
-S605.py:18:20: S605 Starting a process with a shell: seems safe, but may be changed in the future; consider rewriting without `shell`
+S605.py:18:1: S605 Starting a process with a shell: seems safe, but may be changed in the future; consider rewriting without `shell`
    |
 16 | popen2.Popen3("true")
 17 | popen2.Popen4("true")
 18 | commands.getoutput("true")
-   |                    ^^^^^^ S605
+   | ^^^^^^^^^^^^^^^^^^ S605
 19 | commands.getstatusoutput("true")
 20 | subprocess.getoutput("true")
    |
 
-S605.py:19:26: S605 Starting a process with a shell: seems safe, but may be changed in the future; consider rewriting without `shell`
+S605.py:19:1: S605 Starting a process with a shell: seems safe, but may be changed in the future; consider rewriting without `shell`
    |
 17 | popen2.Popen4("true")
 18 | commands.getoutput("true")
 19 | commands.getstatusoutput("true")
-   |                          ^^^^^^ S605
+   | ^^^^^^^^^^^^^^^^^^^^^^^^ S605
 20 | subprocess.getoutput("true")
 21 | subprocess.getstatusoutput("true")
    |
 
-S605.py:20:22: S605 Starting a process with a shell: seems safe, but may be changed in the future; consider rewriting without `shell`
+S605.py:20:1: S605 Starting a process with a shell: seems safe, but may be changed in the future; consider rewriting without `shell`
    |
 18 | commands.getoutput("true")
 19 | commands.getstatusoutput("true")
 20 | subprocess.getoutput("true")
-   |                      ^^^^^^ S605
+   | ^^^^^^^^^^^^^^^^^^^^ S605
 21 | subprocess.getstatusoutput("true")
    |
 
-S605.py:21:28: S605 Starting a process with a shell: seems safe, but may be changed in the future; consider rewriting without `shell`
+S605.py:21:1: S605 Starting a process with a shell: seems safe, but may be changed in the future; consider rewriting without `shell`
    |
 19 | commands.getstatusoutput("true")
 20 | subprocess.getoutput("true")
 21 | subprocess.getstatusoutput("true")
-   |                            ^^^^^^ S605
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^ S605
    |
 
-S605.py:26:11: S605 Starting a process with a shell, possible injection detected
+S605.py:26:1: S605 Starting a process with a shell, possible injection detected
    |
 24 | # Check command argument looks unsafe.
 25 | var_string = "true"
 26 | os.system(var_string)
-   |           ^^^^^^^^^^ S605
+   | ^^^^^^^^^ S605
 27 | os.system([var_string])
 28 | os.system([var_string, ""])
    |
 
-S605.py:27:11: S605 Starting a process with a shell, possible injection detected
+S605.py:27:1: S605 Starting a process with a shell, possible injection detected
    |
 25 | var_string = "true"
 26 | os.system(var_string)
 27 | os.system([var_string])
-   |           ^^^^^^^^^^^^ S605
+   | ^^^^^^^^^ S605
 28 | os.system([var_string, ""])
    |
 
-S605.py:28:11: S605 Starting a process with a shell, possible injection detected
+S605.py:28:1: S605 Starting a process with a shell, possible injection detected
    |
 26 | os.system(var_string)
 27 | os.system([var_string])
 28 | os.system([var_string, ""])
-   |           ^^^^^^^^^^^^^^^^ S605
+   | ^^^^^^^^^ S605
    |

--- a/crates/ruff_linter/src/rules/flake8_bandit/snapshots/ruff_linter__rules__flake8_bandit__tests__S609_S609.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_bandit/snapshots/ruff_linter__rules__flake8_bandit__tests__S609_S609.py.snap
@@ -1,41 +1,39 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_bandit/mod.rs
 ---
-S609.py:4:1: S609 Possible wildcard injection in call due to `*` usage
+S609.py:4:10: S609 Possible wildcard injection in call due to `*` usage
   |
 2 | import subprocess
 3 | 
 4 | os.popen("chmod +w foo*")
-  | ^^^^^^^^ S609
+  |          ^^^^^^^^^^^^^^^ S609
 5 | subprocess.Popen("/bin/chown root: *", shell=True)
 6 | subprocess.Popen(["/usr/local/bin/rsync", "*", "some_where:"], shell=True)
   |
 
-S609.py:5:1: S609 Possible wildcard injection in call due to `*` usage
+S609.py:5:18: S609 Possible wildcard injection in call due to `*` usage
   |
 4 | os.popen("chmod +w foo*")
 5 | subprocess.Popen("/bin/chown root: *", shell=True)
-  | ^^^^^^^^^^^^^^^^ S609
+  |                  ^^^^^^^^^^^^^^^^^^^^ S609
 6 | subprocess.Popen(["/usr/local/bin/rsync", "*", "some_where:"], shell=True)
 7 | subprocess.Popen("/usr/local/bin/rsync * no_injection_here:")
   |
 
-S609.py:6:1: S609 Possible wildcard injection in call due to `*` usage
+S609.py:6:18: S609 Possible wildcard injection in call due to `*` usage
   |
 4 | os.popen("chmod +w foo*")
 5 | subprocess.Popen("/bin/chown root: *", shell=True)
 6 | subprocess.Popen(["/usr/local/bin/rsync", "*", "some_where:"], shell=True)
-  | ^^^^^^^^^^^^^^^^ S609
+  |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ S609
 7 | subprocess.Popen("/usr/local/bin/rsync * no_injection_here:")
 8 | os.system("tar cf foo.tar bar/*")
   |
 
-S609.py:8:1: S609 Possible wildcard injection in call due to `*` usage
+S609.py:8:11: S609 Possible wildcard injection in call due to `*` usage
   |
 6 | subprocess.Popen(["/usr/local/bin/rsync", "*", "some_where:"], shell=True)
 7 | subprocess.Popen("/usr/local/bin/rsync * no_injection_here:")
 8 | os.system("tar cf foo.tar bar/*")
-  | ^^^^^^^^^ S609
+  |           ^^^^^^^^^^^^^^^^^^^^^^ S609
   |
-
-


### PR DESCRIPTION
## Summary

The rules that flag shell calls now center on the function name, rather than the shell argument (which isn't really relevant -- especially it it's falsy). The rules that center on _specific arguments_ (e.g., a wildcard in a string) now highlight the argument.

Closes https://github.com/astral-sh/ruff/issues/9994.
