### PR TITLE
Add tests for await expression

### DIFF
--- a/crates/ruff_python_parser/resources/invalid/expressions/await/no_expression_0.py
+++ b/crates/ruff_python_parser/resources/invalid/expressions/await/no_expression_0.py
@@ -1,0 +1,4 @@
+# No expression after `await`, an expression on another line
+await
+
+x + y

--- a/crates/ruff_python_parser/resources/invalid/expressions/await/no_expression_1.py
+++ b/crates/ruff_python_parser/resources/invalid/expressions/await/no_expression_1.py
@@ -1,0 +1,5 @@
+# No expression after `await`, a statement on another line
+await
+
+def foo():
+    pass

--- a/crates/ruff_python_parser/resources/invalid/expressions/await/recover.py
+++ b/crates/ruff_python_parser/resources/invalid/expressions/await/recover.py
@@ -1,0 +1,17 @@
+# The parser parses all of the following expressions but reports an error for
+# invalid expressions.
+
+# Nested await
+await await x
+
+# Starred expressions
+await *x
+await (*x)
+
+# Invalid expression as per precedence
+await yield x
+await lambda x: x
+await +x
+await -x
+await ~x
+await not x

--- a/crates/ruff_python_parser/resources/valid/expressions/await.py
+++ b/crates/ruff_python_parser/resources/valid/expressions/await.py
@@ -9,3 +9,7 @@ await 7, 8
 await (9, 10)
 await 1 == 1
 await x if True else None
+await (*x,)
+await (lambda x: x)
+await x ** -x
+await x ** await y

--- a/crates/ruff_python_parser/src/parser/expression.rs
+++ b/crates/ruff_python_parser/src/parser/expression.rs
@@ -1929,20 +1929,18 @@ impl<'src> Parser<'src> {
         }
     }
 
+    /// Parses an `await` expression.
+    ///
+    /// # Panics
+    ///
+    /// If the parser isn't positioned at an `await` token.
+    ///
     /// See: <https://docs.python.org/3/reference/expressions.html#await-expression>
     fn parse_await_expression(&mut self) -> ast::ExprAwait {
         let start = self.node_start();
         self.bump(TokenKind::Await);
-        let parsed_expr = self.parse_expression_with_precedence(Precedence::Await);
 
-        if matches!(parsed_expr.expr, Expr::Starred(_)) {
-            self.add_error(
-                ParseErrorType::OtherError(
-                    "starred expression is not allowed in an `await` statement".to_string(),
-                ),
-                &parsed_expr,
-            );
-        }
+        let parsed_expr = self.parse_expression_with_precedence(Precedence::Await);
 
         ast::ExprAwait {
             value: Box::new(parsed_expr.expr),

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__await__no_expression_0.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__await__no_expression_0.py.snap
@@ -1,0 +1,66 @@
+---
+source: crates/ruff_python_parser/tests/fixtures.rs
+input_file: crates/ruff_python_parser/resources/invalid/expressions/await/no_expression_0.py
+---
+## AST
+
+```
+Module(
+    ModModule {
+        range: 0..73,
+        body: [
+            Expr(
+                StmtExpr {
+                    range: 61..66,
+                    value: Await(
+                        ExprAwait {
+                            range: 61..66,
+                            value: Name(
+                                ExprName {
+                                    range: 66..66,
+                                    id: "",
+                                    ctx: Invalid,
+                                },
+                            ),
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 68..73,
+                    value: BinOp(
+                        ExprBinOp {
+                            range: 68..73,
+                            left: Name(
+                                ExprName {
+                                    range: 68..69,
+                                    id: "x",
+                                    ctx: Load,
+                                },
+                            ),
+                            op: Add,
+                            right: Name(
+                                ExprName {
+                                    range: 72..73,
+                                    id: "y",
+                                    ctx: Load,
+                                },
+                            ),
+                        },
+                    ),
+                },
+            ),
+        ],
+    },
+)
+```
+## Errors
+
+  |
+1 | # No expression after `await`, an expression on another line
+2 | await
+  |      ^ Syntax Error: Expected an expression
+3 | 
+4 | x + y
+  |

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__await__no_expression_1.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__await__no_expression_1.py.snap
@@ -1,0 +1,70 @@
+---
+source: crates/ruff_python_parser/tests/fixtures.rs
+input_file: crates/ruff_python_parser/resources/invalid/expressions/await/no_expression_1.py
+---
+## AST
+
+```
+Module(
+    ModModule {
+        range: 0..85,
+        body: [
+            Expr(
+                StmtExpr {
+                    range: 59..64,
+                    value: Await(
+                        ExprAwait {
+                            range: 59..64,
+                            value: Name(
+                                ExprName {
+                                    range: 64..64,
+                                    id: "",
+                                    ctx: Invalid,
+                                },
+                            ),
+                        },
+                    ),
+                },
+            ),
+            FunctionDef(
+                StmtFunctionDef {
+                    range: 66..85,
+                    is_async: false,
+                    decorator_list: [],
+                    name: Identifier {
+                        id: "foo",
+                        range: 70..73,
+                    },
+                    type_params: None,
+                    parameters: Parameters {
+                        range: 73..75,
+                        posonlyargs: [],
+                        args: [],
+                        vararg: None,
+                        kwonlyargs: [],
+                        kwarg: None,
+                    },
+                    returns: None,
+                    body: [
+                        Pass(
+                            StmtPass {
+                                range: 81..85,
+                            },
+                        ),
+                    ],
+                },
+            ),
+        ],
+    },
+)
+```
+## Errors
+
+  |
+1 | # No expression after `await`, a statement on another line
+2 | await
+  |      ^ Syntax Error: Expected an expression
+3 | 
+4 | def foo():
+5 |     pass
+  |

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__await__recover.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__await__recover.py.snap
@@ -1,0 +1,327 @@
+---
+source: crates/ruff_python_parser/tests/fixtures.rs
+input_file: crates/ruff_python_parser/resources/invalid/expressions/await/recover.py
+---
+## AST
+
+```
+Module(
+    ModModule {
+        range: 0..284,
+        body: [
+            Expr(
+                StmtExpr {
+                    range: 117..130,
+                    value: Await(
+                        ExprAwait {
+                            range: 117..130,
+                            value: Await(
+                                ExprAwait {
+                                    range: 123..130,
+                                    value: Name(
+                                        ExprName {
+                                            range: 129..130,
+                                            id: "x",
+                                            ctx: Load,
+                                        },
+                                    ),
+                                },
+                            ),
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 154..162,
+                    value: Await(
+                        ExprAwait {
+                            range: 154..162,
+                            value: Starred(
+                                ExprStarred {
+                                    range: 160..162,
+                                    value: Name(
+                                        ExprName {
+                                            range: 161..162,
+                                            id: "x",
+                                            ctx: Load,
+                                        },
+                                    ),
+                                    ctx: Load,
+                                },
+                            ),
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 163..173,
+                    value: Await(
+                        ExprAwait {
+                            range: 163..173,
+                            value: Starred(
+                                ExprStarred {
+                                    range: 170..172,
+                                    value: Name(
+                                        ExprName {
+                                            range: 171..172,
+                                            id: "x",
+                                            ctx: Load,
+                                        },
+                                    ),
+                                    ctx: Load,
+                                },
+                            ),
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 214..227,
+                    value: Await(
+                        ExprAwait {
+                            range: 214..227,
+                            value: Yield(
+                                ExprYield {
+                                    range: 220..227,
+                                    value: Some(
+                                        Name(
+                                            ExprName {
+                                                range: 226..227,
+                                                id: "x",
+                                                ctx: Load,
+                                            },
+                                        ),
+                                    ),
+                                },
+                            ),
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 228..245,
+                    value: Await(
+                        ExprAwait {
+                            range: 228..245,
+                            value: Lambda(
+                                ExprLambda {
+                                    range: 234..245,
+                                    parameters: Some(
+                                        Parameters {
+                                            range: 241..242,
+                                            posonlyargs: [],
+                                            args: [
+                                                ParameterWithDefault {
+                                                    range: 241..242,
+                                                    parameter: Parameter {
+                                                        range: 241..242,
+                                                        name: Identifier {
+                                                            id: "x",
+                                                            range: 241..242,
+                                                        },
+                                                        annotation: None,
+                                                    },
+                                                    default: None,
+                                                },
+                                            ],
+                                            vararg: None,
+                                            kwonlyargs: [],
+                                            kwarg: None,
+                                        },
+                                    ),
+                                    body: Name(
+                                        ExprName {
+                                            range: 244..245,
+                                            id: "x",
+                                            ctx: Load,
+                                        },
+                                    ),
+                                },
+                            ),
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 246..254,
+                    value: Await(
+                        ExprAwait {
+                            range: 246..254,
+                            value: UnaryOp(
+                                ExprUnaryOp {
+                                    range: 252..254,
+                                    op: UAdd,
+                                    operand: Name(
+                                        ExprName {
+                                            range: 253..254,
+                                            id: "x",
+                                            ctx: Load,
+                                        },
+                                    ),
+                                },
+                            ),
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 255..263,
+                    value: Await(
+                        ExprAwait {
+                            range: 255..263,
+                            value: UnaryOp(
+                                ExprUnaryOp {
+                                    range: 261..263,
+                                    op: USub,
+                                    operand: Name(
+                                        ExprName {
+                                            range: 262..263,
+                                            id: "x",
+                                            ctx: Load,
+                                        },
+                                    ),
+                                },
+                            ),
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 264..272,
+                    value: Await(
+                        ExprAwait {
+                            range: 264..272,
+                            value: UnaryOp(
+                                ExprUnaryOp {
+                                    range: 270..272,
+                                    op: Invert,
+                                    operand: Name(
+                                        ExprName {
+                                            range: 271..272,
+                                            id: "x",
+                                            ctx: Load,
+                                        },
+                                    ),
+                                },
+                            ),
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 273..284,
+                    value: Await(
+                        ExprAwait {
+                            range: 273..284,
+                            value: UnaryOp(
+                                ExprUnaryOp {
+                                    range: 279..284,
+                                    op: Not,
+                                    operand: Name(
+                                        ExprName {
+                                            range: 283..284,
+                                            id: "x",
+                                            ctx: Load,
+                                        },
+                                    ),
+                                },
+                            ),
+                        },
+                    ),
+                },
+            ),
+        ],
+    },
+)
+```
+## Errors
+
+  |
+4 | # Nested await
+5 | await await x
+  |       ^^^^^^^ Syntax Error: `await` expression cannot be used here
+6 | 
+7 | # Starred expressions
+  |
+
+
+  |
+7 | # Starred expressions
+8 | await *x
+  |       ^^ Syntax Error: starred expression cannot be used here
+9 | await (*x)
+  |
+
+
+   |
+ 7 | # Starred expressions
+ 8 | await *x
+ 9 | await (*x)
+   |        ^^ Syntax Error: starred expression cannot be used here
+10 | 
+11 | # Invalid expression as per precedence
+   |
+
+
+   |
+11 | # Invalid expression as per precedence
+12 | await yield x
+   |       ^^^^^^^ Syntax Error: `yield` expression cannot be used here
+13 | await lambda x: x
+14 | await +x
+   |
+
+
+   |
+11 | # Invalid expression as per precedence
+12 | await yield x
+13 | await lambda x: x
+   |       ^^^^^^^^^^^ Syntax Error: `lambda` expression cannot be used here
+14 | await +x
+15 | await -x
+   |
+
+
+   |
+12 | await yield x
+13 | await lambda x: x
+14 | await +x
+   |       ^^ Syntax Error: unary `+` expression cannot be used here
+15 | await -x
+16 | await ~x
+   |
+
+
+   |
+13 | await lambda x: x
+14 | await +x
+15 | await -x
+   |       ^^ Syntax Error: unary `-` expression cannot be used here
+16 | await ~x
+17 | await not x
+   |
+
+
+   |
+14 | await +x
+15 | await -x
+16 | await ~x
+   |       ^^ Syntax Error: unary `~` expression cannot be used here
+17 | await not x
+   |
+
+
+   |
+15 | await -x
+16 | await ~x
+17 | await not x
+   |       ^^^^^ Syntax Error: boolean `not` expression cannot be used here
+   |

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@expressions__await.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@expressions__await.py.snap
@@ -7,7 +7,7 @@ input_file: crates/ruff_python_parser/resources/valid/expressions/await.py
 ```
 Module(
     ModModule {
-        range: 0..147,
+        range: 0..211,
         body: [
             Expr(
                 StmtExpr {
@@ -352,6 +352,154 @@ Module(
                             orelse: NoneLiteral(
                                 ExprNoneLiteral {
                                     range: 142..146,
+                                },
+                            ),
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 147..158,
+                    value: Await(
+                        ExprAwait {
+                            range: 147..158,
+                            value: Tuple(
+                                ExprTuple {
+                                    range: 153..158,
+                                    elts: [
+                                        Starred(
+                                            ExprStarred {
+                                                range: 154..156,
+                                                value: Name(
+                                                    ExprName {
+                                                        range: 155..156,
+                                                        id: "x",
+                                                        ctx: Load,
+                                                    },
+                                                ),
+                                                ctx: Load,
+                                            },
+                                        ),
+                                    ],
+                                    ctx: Load,
+                                    parenthesized: true,
+                                },
+                            ),
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 159..178,
+                    value: Await(
+                        ExprAwait {
+                            range: 159..178,
+                            value: Lambda(
+                                ExprLambda {
+                                    range: 166..177,
+                                    parameters: Some(
+                                        Parameters {
+                                            range: 173..174,
+                                            posonlyargs: [],
+                                            args: [
+                                                ParameterWithDefault {
+                                                    range: 173..174,
+                                                    parameter: Parameter {
+                                                        range: 173..174,
+                                                        name: Identifier {
+                                                            id: "x",
+                                                            range: 173..174,
+                                                        },
+                                                        annotation: None,
+                                                    },
+                                                    default: None,
+                                                },
+                                            ],
+                                            vararg: None,
+                                            kwonlyargs: [],
+                                            kwarg: None,
+                                        },
+                                    ),
+                                    body: Name(
+                                        ExprName {
+                                            range: 176..177,
+                                            id: "x",
+                                            ctx: Load,
+                                        },
+                                    ),
+                                },
+                            ),
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 179..192,
+                    value: BinOp(
+                        ExprBinOp {
+                            range: 179..192,
+                            left: Await(
+                                ExprAwait {
+                                    range: 179..186,
+                                    value: Name(
+                                        ExprName {
+                                            range: 185..186,
+                                            id: "x",
+                                            ctx: Load,
+                                        },
+                                    ),
+                                },
+                            ),
+                            op: Pow,
+                            right: UnaryOp(
+                                ExprUnaryOp {
+                                    range: 190..192,
+                                    op: USub,
+                                    operand: Name(
+                                        ExprName {
+                                            range: 191..192,
+                                            id: "x",
+                                            ctx: Load,
+                                        },
+                                    ),
+                                },
+                            ),
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 193..211,
+                    value: BinOp(
+                        ExprBinOp {
+                            range: 193..211,
+                            left: Await(
+                                ExprAwait {
+                                    range: 193..200,
+                                    value: Name(
+                                        ExprName {
+                                            range: 199..200,
+                                            id: "x",
+                                            ctx: Load,
+                                        },
+                                    ),
+                                },
+                            ),
+                            op: Pow,
+                            right: Await(
+                                ExprAwait {
+                                    range: 204..211,
+                                    value: Name(
+                                        ExprName {
+                                            range: 210..211,
+                                            id: "y",
+                                            ctx: Load,
+                                        },
+                                    ),
                                 },
                             ),
                         },


### PR DESCRIPTION
## Summary

This PR adds test cases for `await` expression.

For context, the grammar is:

```ebnf
factor:
    | '+' factor 
    | '-' factor 
    | '~' factor 
    | power

power:
    | await_primary '**' factor 
    | await_primary

await_primary:
    | 'await' primary 
    | primary
```
