### PR TITLE
[`ruff`] Fix panic in unused `# noqa` removal with multi-byte space (`RUF100`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/ruff/RUF100_0.py
+++ b/crates/ruff_linter/resources/test/fixtures/ruff/RUF100_0.py
@@ -105,3 +105,4 @@ def f():
 def f():
     # Invalid - nonexistant error code with multibyte character
     d = 1  #noqa: F841, E50
+    e = 1  #noqa: E50

--- a/crates/ruff_linter/resources/test/fixtures/ruff/RUF100_0.py
+++ b/crates/ruff_linter/resources/test/fixtures/ruff/RUF100_0.py
@@ -100,3 +100,8 @@ def f():
 
     Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
     """  # noqa
+
+
+def f():
+    # Invalid - nonexistant error code with multibyte character
+    d = 1  #noqa: F841, E50

--- a/crates/ruff_linter/src/fix/edits.rs
+++ b/crates/ruff_linter/src/fix/edits.rs
@@ -97,10 +97,17 @@ pub(crate) fn delete_comment(range: TextRange, locator: &Locator) -> Edit {
     }
     // Ex) `x = 1  # noqa here`
     else {
-        Edit::deletion(
-            range.start() + "# ".text_len(),
-            range.end() + trailing_space_len,
-        )
+        if suffix.is_empty() {
+            // if there's no comment after the deleted noqa, delete the entire range
+            let full_line_end = locator.full_line_end(line_range.end());
+            Edit::deletion(line_range.start() - leading_space_len, full_line_end)
+        } else {
+            // if there is something after the deleted noqa, keep it in a comment
+            Edit::range_replacement(
+                "# ".to_string(),
+                TextRange::new(range.start(), range.end() + trailing_space_len),
+            )
+        }
     }
 }
 

--- a/crates/ruff_linter/src/fix/edits.rs
+++ b/crates/ruff_linter/src/fix/edits.rs
@@ -83,6 +83,7 @@ pub(crate) fn delete_comment(range: TextRange, locator: &Locator) -> Edit {
     }
     // Ex) `x = 1  # noqa`
     else if range.end() + trailing_space_len == line_range.end() {
+        // Replace `x = 1  # noqa` with `x = 1`.
         Edit::deletion(range.start() - leading_space_len, line_range.end())
     }
     // Ex) `x = 1  # noqa  # type: ignore`
@@ -93,21 +94,16 @@ pub(crate) fn delete_comment(range: TextRange, locator: &Locator) -> Edit {
         ))
         .starts_with('#')
     {
+        // Replace `# noqa  # type: ignore` with `# type: ignore`.
         Edit::deletion(range.start(), range.end() + trailing_space_len)
     }
     // Ex) `x = 1  # noqa here`
     else {
-        if suffix.is_empty() {
-            // if there's no comment after the deleted noqa, delete the entire range
-            let full_line_end = locator.full_line_end(line_range.end());
-            Edit::deletion(line_range.start() - leading_space_len, full_line_end)
-        } else {
-            // if there is something after the deleted noqa, keep it in a comment
-            Edit::range_replacement(
-                "# ".to_string(),
-                TextRange::new(range.start(), range.end() + trailing_space_len),
-            )
-        }
+        // Replace `# noqa here` with `# here`.
+        Edit::range_replacement(
+            "# ".to_string(),
+            TextRange::new(range.start(), range.end() + trailing_space_len),
+        )
     }
 }
 

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__ruf100_0.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__ruf100_0.snap
@@ -290,6 +290,7 @@ RUF100_0.py:107:12: RUF100 [*] Unused `noqa` directive (unknown: `E50`)
 106 |     # Invalid - nonexistant error code with multibyte character
 107 |     d = 1  #noqa: F841, E50
     |            ^^^^^^^^^^^^^^^^ RUF100
+108 |     e = 1  #noqa: E50
     |
     = help: Remove unused `noqa` directive
 
@@ -299,3 +300,35 @@ RUF100_0.py:107:12: RUF100 [*] Unused `noqa` directive (unknown: `E50`)
 106 106 |     # Invalid - nonexistant error code with multibyte character
 107     |-    d = 1  #noqa: F841, E50
     107 |+    d = 1  # noqa: F841
+108 108 |     e = 1  #noqa: E50
+
+RUF100_0.py:108:5: F841 [*] Local variable `e` is assigned to but never used
+    |
+106 |     # Invalid - nonexistant error code with multibyte character
+107 |     d = 1  #noqa: F841, E50
+108 |     e = 1  #noqa: E50
+    |     ^ F841
+    |
+    = help: Remove assignment to unused variable `e`
+
+ℹ Unsafe fix
+105 105 | def f():
+106 106 |     # Invalid - nonexistant error code with multibyte character
+107 107 |     d = 1  #noqa: F841, E50
+108     |-    e = 1  #noqa: E50
+
+RUF100_0.py:108:12: RUF100 [*] Unused `noqa` directive (unknown: `E50`)
+    |
+106 |     # Invalid - nonexistant error code with multibyte character
+107 |     d = 1  #noqa: F841, E50
+108 |     e = 1  #noqa: E50
+    |            ^^^^^^^^^^ RUF100
+    |
+    = help: Remove unused `noqa` directive
+
+ℹ Safe fix
+105 105 | def f():
+106 106 |     # Invalid - nonexistant error code with multibyte character
+107 107 |     d = 1  #noqa: F841, E50
+108     |-    e = 1  #noqa: E50
+    108 |+    e = 1

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__ruf100_0.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__ruf100_0.snap
@@ -284,4 +284,18 @@ RUF100_0.py:93:92: RUF100 [*] Unused `noqa` directive (unused: `F401`)
 95 95 | 
 96 96 | def f():
 
+RUF100_0.py:107:12: RUF100 [*] Unused `noqa` directive (unknown: `E50`)
+    |
+105 | def f():
+106 |     # Invalid - nonexistant error code with multibyte character
+107 |     d = 1  #noqa: F841, E50
+    |            ^^^^^^^^^^^^^^^^ RUF100
+    |
+    = help: Remove unused `noqa` directive
 
+ℹ Safe fix
+104 104 | 
+105 105 | def f():
+106 106 |     # Invalid - nonexistant error code with multibyte character
+107     |-    d = 1  #noqa: F841, E50
+    107 |+    d = 1  # noqa: F841

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__ruf100_0_prefix.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__ruf100_0_prefix.snap
@@ -270,6 +270,7 @@ RUF100_0.py:107:12: RUF100 [*] Unused `noqa` directive (unknown: `E50`)
 106 |     # Invalid - nonexistant error code with multibyte character
 107 |     d = 1  #noqa: F841, E50
     |            ^^^^^^^^^^^^^^^^ RUF100
+108 |     e = 1  #noqa: E50
     |
     = help: Remove unused `noqa` directive
 
@@ -279,3 +280,35 @@ RUF100_0.py:107:12: RUF100 [*] Unused `noqa` directive (unknown: `E50`)
 106 106 |     # Invalid - nonexistant error code with multibyte character
 107     |-    d = 1  #noqa: F841, E50
     107 |+    d = 1  # noqa: F841
+108 108 |     e = 1  #noqa: E50
+
+RUF100_0.py:108:5: F841 [*] Local variable `e` is assigned to but never used
+    |
+106 |     # Invalid - nonexistant error code with multibyte character
+107 |     d = 1  #noqa: F841, E50
+108 |     e = 1  #noqa: E50
+    |     ^ F841
+    |
+    = help: Remove assignment to unused variable `e`
+
+ℹ Unsafe fix
+105 105 | def f():
+106 106 |     # Invalid - nonexistant error code with multibyte character
+107 107 |     d = 1  #noqa: F841, E50
+108     |-    e = 1  #noqa: E50
+
+RUF100_0.py:108:12: RUF100 [*] Unused `noqa` directive (unknown: `E50`)
+    |
+106 |     # Invalid - nonexistant error code with multibyte character
+107 |     d = 1  #noqa: F841, E50
+108 |     e = 1  #noqa: E50
+    |            ^^^^^^^^^^ RUF100
+    |
+    = help: Remove unused `noqa` directive
+
+ℹ Safe fix
+105 105 | def f():
+106 106 |     # Invalid - nonexistant error code with multibyte character
+107 107 |     d = 1  #noqa: F841, E50
+108     |-    e = 1  #noqa: E50
+    108 |+    e = 1

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__ruf100_0_prefix.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__ruf100_0_prefix.snap
@@ -264,4 +264,18 @@ RUF100_0.py:93:92: RUF100 [*] Unused `noqa` directive (unused: `F401`)
 95 95 | 
 96 96 | def f():
 
+RUF100_0.py:107:12: RUF100 [*] Unused `noqa` directive (unknown: `E50`)
+    |
+105 | def f():
+106 |     # Invalid - nonexistant error code with multibyte character
+107 |     d = 1  #noqa: F841, E50
+    |            ^^^^^^^^^^^^^^^^ RUF100
+    |
+    = help: Remove unused `noqa` directive
 
+ℹ Safe fix
+104 104 | 
+105 105 | def f():
+106 106 |     # Invalid - nonexistant error code with multibyte character
+107     |-    d = 1  #noqa: F841, E50
+    107 |+    d = 1  # noqa: F841


### PR DESCRIPTION
## Summary

Currently, [this line](https://github.com/astral-sh/ruff/blob/716688d44ecda5d4648b7a31556bb77afe6cbbc6/crates/ruff_linter/src/fix/edits.rs#L101) assumes that the `noqa` comment begins with an octothorpe followed by a space. (`# `) With anyone's random code, this of course is not always true.

When there's a multi-byte character after the leading octothorpe, such as [`\u0085`](https://www.fileformat.info/info/unicode/char/85/index.htm), we try slicing from within the character, causing a panic.

To fix this, the logic has been changed to remove unused `noqa` directives and keep any trailing comments, or removing the whole comment if the comment is just the unused `noqa`

Fixes #10097.

## Test Plan

`cargo test`
