### PR TITLE
Implement `as_str` & `Display` for all operator enums

### DIFF
--- a/crates/ruff_python_ast/src/nodes.rs
+++ b/crates/ruff_python_ast/src/nodes.rs
@@ -2735,6 +2735,15 @@ pub enum BoolOp {
     Or,
 }
 
+impl BoolOp {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            BoolOp::And => "and",
+            BoolOp::Or => "or",
+        }
+    }
+}
+
 /// See also [operator](https://docs.python.org/3/library/ast.html#ast.operator)
 #[derive(Clone, Debug, PartialEq, is_macro::Is, Copy, Hash, Eq)]
 pub enum Operator {
@@ -2753,6 +2762,26 @@ pub enum Operator {
     FloorDiv,
 }
 
+impl Operator {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Operator::Add => "+",
+            Operator::Sub => "-",
+            Operator::Mult => "*",
+            Operator::MatMult => "@",
+            Operator::Div => "/",
+            Operator::Mod => "%",
+            Operator::Pow => "**",
+            Operator::LShift => "<<",
+            Operator::RShift => ">>",
+            Operator::BitOr => "|",
+            Operator::BitXor => "^",
+            Operator::BitAnd => "&",
+            Operator::FloorDiv => "//",
+        }
+    }
+}
+
 /// See also [unaryop](https://docs.python.org/3/library/ast.html#ast.unaryop)
 #[derive(Clone, Debug, PartialEq, is_macro::Is, Copy, Hash, Eq)]
 pub enum UnaryOp {
@@ -2760,6 +2789,17 @@ pub enum UnaryOp {
     Not,
     UAdd,
     USub,
+}
+
+impl UnaryOp {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            UnaryOp::Invert => "~",
+            UnaryOp::Not => "not",
+            UnaryOp::UAdd => "+",
+            UnaryOp::USub => "-",
+        }
+    }
 }
 
 /// See also [cmpop](https://docs.python.org/3/library/ast.html#ast.cmpop)
@@ -2775,6 +2815,23 @@ pub enum CmpOp {
     IsNot,
     In,
     NotIn,
+}
+
+impl CmpOp {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            CmpOp::Eq => "==",
+            CmpOp::NotEq => "!=",
+            CmpOp::Lt => "<",
+            CmpOp::LtE => "<=",
+            CmpOp::Gt => ">",
+            CmpOp::GtE => ">=",
+            CmpOp::Is => "is",
+            CmpOp::IsNot => "is not",
+            CmpOp::In => "in",
+            CmpOp::NotIn => "not in",
+        }
+    }
 }
 
 /// See also [comprehension](https://docs.python.org/3/library/ast.html#ast.comprehension)
@@ -3281,23 +3338,6 @@ impl Deref for TypeParams {
 }
 
 pub type Suite = Vec<Stmt>;
-
-impl CmpOp {
-    pub fn as_str(&self) -> &'static str {
-        match self {
-            CmpOp::Eq => "==",
-            CmpOp::NotEq => "!=",
-            CmpOp::Lt => "<",
-            CmpOp::LtE => "<=",
-            CmpOp::Gt => ">",
-            CmpOp::GtE => ">=",
-            CmpOp::Is => "is",
-            CmpOp::IsNot => "is not",
-            CmpOp::In => "in",
-            CmpOp::NotIn => "not in",
-        }
-    }
-}
 
 impl Parameters {
     pub fn empty(range: TextRange) -> Self {

--- a/crates/ruff_python_ast/src/nodes.rs
+++ b/crates/ruff_python_ast/src/nodes.rs
@@ -2736,11 +2736,17 @@ pub enum BoolOp {
 }
 
 impl BoolOp {
-    pub fn as_str(&self) -> &'static str {
+    pub const fn as_str(&self) -> &'static str {
         match self {
             BoolOp::And => "and",
             BoolOp::Or => "or",
         }
+    }
+}
+
+impl fmt::Display for BoolOp {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
     }
 }
 
@@ -2763,7 +2769,7 @@ pub enum Operator {
 }
 
 impl Operator {
-    pub fn as_str(&self) -> &'static str {
+    pub const fn as_str(&self) -> &'static str {
         match self {
             Operator::Add => "+",
             Operator::Sub => "-",
@@ -2782,6 +2788,12 @@ impl Operator {
     }
 }
 
+impl fmt::Display for Operator {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
 /// See also [unaryop](https://docs.python.org/3/library/ast.html#ast.unaryop)
 #[derive(Clone, Debug, PartialEq, is_macro::Is, Copy, Hash, Eq)]
 pub enum UnaryOp {
@@ -2792,13 +2804,19 @@ pub enum UnaryOp {
 }
 
 impl UnaryOp {
-    pub fn as_str(&self) -> &'static str {
+    pub const fn as_str(&self) -> &'static str {
         match self {
             UnaryOp::Invert => "~",
             UnaryOp::Not => "not",
             UnaryOp::UAdd => "+",
             UnaryOp::USub => "-",
         }
+    }
+}
+
+impl fmt::Display for UnaryOp {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
     }
 }
 
@@ -2818,7 +2836,7 @@ pub enum CmpOp {
 }
 
 impl CmpOp {
-    pub fn as_str(&self) -> &'static str {
+    pub const fn as_str(&self) -> &'static str {
         match self {
             CmpOp::Eq => "==",
             CmpOp::NotEq => "!=",
@@ -2831,6 +2849,12 @@ impl CmpOp {
             CmpOp::In => "in",
             CmpOp::NotIn => "not in",
         }
+    }
+}
+
+impl fmt::Display for CmpOp {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
     }
 }
 


### PR DESCRIPTION
## Summary

This PR adds the `as_str` implementation for all the operator methods. It already exists for `CmpOp` which is being [used in the linter](https://github.com/astral-sh/ruff/blob/ffcd77860c316bfe5709551389eb52e5feb702f6/crates/ruff_linter/src/rules/flake8_simplify/rules/key_in_dict.rs#L117) and it makes sense to implement it for the rest as well. This will also be utilized in error messages for the new parser.

**Question:** Is it ok to implement the `Display` trait for these enums? I think it's fine. Edit: I've implemented them.
