### PR TITLE
Give renovate more time in which to file PRs

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -4,7 +4,7 @@
   suppressNotifications: ["prEditedNotification"],
   extends: ["config:recommended"],
   labels: ["internal"],
-  schedule: ["before 4am on Monday"],
+  schedule: ["on Monday"],
   separateMajorMinor: false,
   enabledManagers: ["github-actions", "pre-commit", "cargo", "pep621", "npm"],
   cargo: {


### PR DESCRIPTION
## Summary

It looks like renovate is currently rate-limiting us so that we can only have a few PRs open at a time, which means that giving it a 4-hour window to open all our weekly update PRs isn't really long enough

## Test Plan

I used renovate's CLI tool to validate the configuration:

```
(renovate-improve)⚡ % npx --yes --package renovate -- renovate-config-validator                                                        ~/dev/ruff
(node:78682) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
 INFO: Validating .github/renovate.json5
 INFO: Config validated successfully
```