### PR TITLE
Allow renovate to create more PRs at once

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -6,6 +6,7 @@
   labels: ["internal"],
   schedule: ["on Monday"],
   separateMajorMinor: false,
+  prHourlyLimit: 10,
   enabledManagers: ["github-actions", "pre-commit", "cargo", "pep621", "npm"],
   cargo: {
     // See https://docs.renovatebot.com/configuration-options/#rangestrategy


### PR DESCRIPTION
## Summary

By default, apparently renovate will only create 2 PRs an hour, on the assumption that more than that would be overwhelming (especially when onboarding a repository to renovate): https://docs.renovatebot.com/configuration-options/#prhourlylimit. That's not really what we want here, though.

## Test Plan

I validated the config using renovate's CLI tool:

```
(renovate-rate-limiting)⚡ % npx --yes --package renovate -- renovate-config-validator                                                  ~/dev/ruff
(node:80789) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
 INFO: Validating .github/renovate.json5
 INFO: Config validated successfully
```