### PR TITLE
[`pycodestyle`] Do not trigger `E3` rules on defs following a function/method with a dummy body

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pycodestyle/E30.py
+++ b/crates/ruff_linter/resources/test/fixtures/pycodestyle/E30.py
@@ -633,6 +633,17 @@ class B: ...
 # end
 
 
+# E302
+@overload
+def fn(a: int) -> int: ...
+@overload
+def fn(a: str) -> str: ...
+
+def fn(a: int | str) -> int | str:
+    ...
+# end
+
+
 # E303
 def fn():
     _ = None

--- a/crates/ruff_linter/resources/test/fixtures/pycodestyle/E30.py
+++ b/crates/ruff_linter/resources/test/fixtures/pycodestyle/E30.py
@@ -445,6 +445,39 @@ def test():
 # end
 
 
+# no error
+class Foo:
+    """Demo."""
+
+    @overload
+    def bar(self, x: int) -> int: ...
+    @overload
+    def bar(self, x: str) -> str: ...
+    def bar(self, x: int | str) -> int | str:
+        return x
+# end
+
+
+# no error
+@overload
+def foo(x: int) -> int: ...
+@overload
+def foo(x: str) -> str: ...
+def foo(x: int | str) -> int | str:
+    if not isinstance(x, (int, str)):
+        raise TypeError
+    return x
+# end
+
+
+# no error
+def foo(self, x: int) -> int: ...
+def bar(self, x: str) -> str: ...
+def baz(self, x: int | str) -> int | str:
+    return x
+# end
+
+
 # E301
 class Class(object):
 

--- a/crates/ruff_linter/resources/test/fixtures/pycodestyle/E30.py
+++ b/crates/ruff_linter/resources/test/fixtures/pycodestyle/E30.py
@@ -522,6 +522,20 @@ class Class:
 # end
 
 
+# E301
+class Foo:
+    """Demo."""
+
+    @overload
+    def bar(self, x: int) -> int: ...
+    @overload
+    def bar(self, x: str) -> str:
+        ...
+    def bar(self, x: int | str) -> int | str:
+        return x
+# end
+
+
 # E302
 """Main module."""
 def fn():
@@ -610,6 +624,12 @@ class Test:
 		
 	def method2():
 		return 22
+# end
+
+
+# E302
+class A:...
+class B: ...
 # end
 
 

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/blank_lines.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/blank_lines.rs
@@ -763,7 +763,11 @@ impl<'a> BlankLinesChecker<'a> {
                     if matches!(state.fn_status, Status::Outside) {
                         state.fn_status = Status::Inside(logical_line.indent_length);
                     }
-                    state.follows = Follows::Def;
+                    state.follows = if logical_line.last_token == TokenKind::Ellipsis {
+                        Follows::DummyDef
+                    } else {
+                        Follows::Def
+                    };
                 }
                 LogicalLineKind::Comment => {}
                 LogicalLineKind::Import => {
@@ -775,10 +779,6 @@ impl<'a> BlankLinesChecker<'a> {
                 LogicalLineKind::Other => {
                     state.follows = Follows::Other;
                 }
-            }
-
-            if logical_line.last_token == TokenKind::Ellipsis {
-                state.follows = Follows::DummyDef;
             }
 
             if logical_line.is_docstring {

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/blank_lines.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/blank_lines.rs
@@ -643,6 +643,13 @@ enum Follows {
 }
 
 impl Follows {
+    // Allow a function/method to follow a function/method with a dummy body.
+    const fn follows_def_with_dummy_body(self) -> bool {
+        matches!(self, Follows::DummyDef)
+    }
+}
+
+impl Follows {
     const fn is_any_def(self) -> bool {
         matches!(self, Follows::Def | Follows::DummyDef)
     }
@@ -814,8 +821,7 @@ impl<'a> BlankLinesChecker<'a> {
             && matches!(line.kind,  LogicalLineKind::Function | LogicalLineKind::Decorator)
             // Allow groups of one-liners.
             && !(state.follows.is_any_def() && line.last_token != TokenKind::Colon)
-            // Allow a function/method to follow a function/method with a dummy body.
-            && !matches!(state.follows, Follows::DummyDef)
+            && !state.follows.follows_def_with_dummy_body()
             && matches!(state.class_status, Status::Inside(_))
             // The class/parent method's docstring can directly precede the def.
             // Allow following a decorator (if there is an error it will be triggered on the first decorator).
@@ -867,8 +873,7 @@ impl<'a> BlankLinesChecker<'a> {
             && !matches!(state.follows, Follows::Decorator)
             // Allow groups of one-liners.
             && !(state.follows.is_any_def() && line.last_token != TokenKind::Colon)
-            // Allow a function/method to follow a function/method with a dummy body.
-            && !matches!(state.follows, Follows::DummyDef)
+            && !state.follows.follows_def_with_dummy_body()
             // Only trigger on non-indented classes and functions (for example functions within an if are ignored)
             && line.indent_length == 0
             // Only apply to functions or classes.
@@ -1035,8 +1040,7 @@ impl<'a> BlankLinesChecker<'a> {
             && prev_indent_length.is_some_and(|prev_indent_length| prev_indent_length >= line.indent_length)
             // Allow groups of one-liners.
             && !(state.follows.is_any_def() && line.last_token != TokenKind::Colon)
-            // Allow a function/method to follow a function/method with a dummy body.
-            && !matches!(state.follows, Follows::DummyDef)
+            && !state.follows.follows_def_with_dummy_body()
             // Blank lines in stub files are only used for grouping. Don't enforce blank lines.
             && !self.source_type.is_stub()
         {

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/blank_lines.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/blank_lines.rs
@@ -873,7 +873,7 @@ impl<'a> BlankLinesChecker<'a> {
             && !matches!(state.follows, Follows::Decorator)
             // Allow groups of one-liners.
             && !(state.follows.is_any_def() && line.last_token != TokenKind::Colon)
-            && !state.follows.follows_def_with_dummy_body()
+            && !(state.follows.follows_def_with_dummy_body() && line.preceding_blank_lines == 0)
             // Only trigger on non-indented classes and functions (for example functions within an if are ignored)
             && line.indent_length == 0
             // Only apply to functions or classes.

--- a/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E301_E30.py.snap
+++ b/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E301_E30.py.snap
@@ -1,83 +1,81 @@
 ---
 source: crates/ruff_linter/src/rules/pycodestyle/mod.rs
 ---
-E30.py:453:5: E301 [*] Expected 1 blank line, found 0
-    |
-451 |     def func1():
-452 |         pass
-453 |     def func2():
-    |     ^^^ E301
-454 |         pass
-455 | # end
-    |
-    = help: Add missing blank line
-
-ℹ Safe fix
-450 450 | 
-451 451 |     def func1():
-452 452 |         pass
-    453 |+
-453 454 |     def func2():
-454 455 |         pass
-455 456 | # end
-
-E30.py:464:5: E301 [*] Expected 1 blank line, found 0
-    |
-462 |         pass
-463 |     # comment
-464 |     def fn2():
-    |     ^^^ E301
-465 |         pass
-466 | # end
-    |
-    = help: Add missing blank line
-
-ℹ Safe fix
-460 460 | 
-461 461 |     def fn1():
-462 462 |         pass
-    463 |+
-463 464 |     # comment
-464 465 |     def fn2():
-465 466 |         pass
-
-E30.py:474:5: E301 [*] Expected 1 blank line, found 0
-    |
-473 |     columns = []
-474 |     @classmethod
-    |     ^ E301
-475 |     def cls_method(cls) -> None:
-476 |         pass
-    |
-    = help: Add missing blank line
-
-ℹ Safe fix
-471 471 |     """Class for minimal repo."""
-472 472 | 
-473 473 |     columns = []
-    474 |+
-474 475 |     @classmethod
-475 476 |     def cls_method(cls) -> None:
-476 477 |         pass
-
 E30.py:486:5: E301 [*] Expected 1 blank line, found 0
     |
-484 |     def method(cls) -> None:
+484 |     def func1():
 485 |         pass
-486 |     @classmethod
-    |     ^ E301
-487 |     def cls_method(cls) -> None:
-488 |         pass
+486 |     def func2():
+    |     ^^^ E301
+487 |         pass
+488 | # end
     |
     = help: Add missing blank line
 
 ℹ Safe fix
 483 483 | 
-484 484 |     def method(cls) -> None:
+484 484 |     def func1():
 485 485 |         pass
     486 |+
-486 487 |     @classmethod
-487 488 |     def cls_method(cls) -> None:
-488 489 |         pass
+486 487 |     def func2():
+487 488 |         pass
+488 489 | # end
 
+E30.py:497:5: E301 [*] Expected 1 blank line, found 0
+    |
+495 |         pass
+496 |     # comment
+497 |     def fn2():
+    |     ^^^ E301
+498 |         pass
+499 | # end
+    |
+    = help: Add missing blank line
 
+ℹ Safe fix
+493 493 | 
+494 494 |     def fn1():
+495 495 |         pass
+    496 |+
+496 497 |     # comment
+497 498 |     def fn2():
+498 499 |         pass
+
+E30.py:507:5: E301 [*] Expected 1 blank line, found 0
+    |
+506 |     columns = []
+507 |     @classmethod
+    |     ^ E301
+508 |     def cls_method(cls) -> None:
+509 |         pass
+    |
+    = help: Add missing blank line
+
+ℹ Safe fix
+504 504 |     """Class for minimal repo."""
+505 505 | 
+506 506 |     columns = []
+    507 |+
+507 508 |     @classmethod
+508 509 |     def cls_method(cls) -> None:
+509 510 |         pass
+
+E30.py:519:5: E301 [*] Expected 1 blank line, found 0
+    |
+517 |     def method(cls) -> None:
+518 |         pass
+519 |     @classmethod
+    |     ^ E301
+520 |     def cls_method(cls) -> None:
+521 |         pass
+    |
+    = help: Add missing blank line
+
+ℹ Safe fix
+516 516 | 
+517 517 |     def method(cls) -> None:
+518 518 |         pass
+    519 |+
+519 520 |     @classmethod
+520 521 |     def cls_method(cls) -> None:
+521 522 |         pass

--- a/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E301_E30.py.snap
+++ b/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E301_E30.py.snap
@@ -79,3 +79,23 @@ E30.py:519:5: E301 [*] Expected 1 blank line, found 0
 519 520 |     @classmethod
 520 521 |     def cls_method(cls) -> None:
 521 522 |         pass
+
+E30.py:534:5: E301 [*] Expected 1 blank line, found 0
+    |
+532 |     def bar(self, x: str) -> str:
+533 |         ...
+534 |     def bar(self, x: int | str) -> int | str:
+    |     ^^^ E301
+535 |         return x
+536 | # end
+    |
+    = help: Add missing blank line
+
+ℹ Safe fix
+531 531 |     @overload
+532 532 |     def bar(self, x: str) -> str:
+533 533 |         ...
+    534 |+
+534 535 |     def bar(self, x: int | str) -> int | str:
+535 536 |         return x
+536 537 | # end

--- a/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E302_E30.py.snap
+++ b/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E302_E30.py.snap
@@ -1,187 +1,185 @@
 ---
 source: crates/ruff_linter/src/rules/pycodestyle/mod.rs
 ---
-E30.py:494:1: E302 [*] Expected 2 blank lines, found 0
+E30.py:527:1: E302 [*] Expected 2 blank lines, found 0
     |
-492 | # E302
-493 | """Main module."""
-494 | def fn():
+525 | # E302
+526 | """Main module."""
+527 | def fn():
     | ^^^ E302
-495 |     pass
-496 | # end
-    |
-    = help: Add missing blank line(s)
-
-ℹ Safe fix
-491 491 | 
-492 492 | # E302
-493 493 | """Main module."""
-    494 |+
-    495 |+
-494 496 | def fn():
-495 497 |     pass
-496 498 | # end
-
-E30.py:501:1: E302 [*] Expected 2 blank lines, found 0
-    |
-499 | # E302
-500 | import sys
-501 | def get_sys_path():
-    | ^^^ E302
-502 |     return sys.path
-503 | # end
-    |
-    = help: Add missing blank line(s)
-
-ℹ Safe fix
-498 498 | 
-499 499 | # E302
-500 500 | import sys
-    501 |+
-    502 |+
-501 503 | def get_sys_path():
-502 504 |     return sys.path
-503 505 | # end
-
-E30.py:510:1: E302 [*] Expected 2 blank lines, found 1
-    |
-508 |     pass
-509 | 
-510 | def b():
-    | ^^^ E302
-511 |     pass
-512 | # end
-    |
-    = help: Add missing blank line(s)
-
-ℹ Safe fix
-507 507 | def a():
-508 508 |     pass
-509 509 | 
-    510 |+
-510 511 | def b():
-511 512 |     pass
-512 513 | # end
-
-E30.py:521:1: E302 [*] Expected 2 blank lines, found 1
-    |
-519 | # comment
-520 | 
-521 | def b():
-    | ^^^ E302
-522 |     pass
-523 | # end
-    |
-    = help: Add missing blank line(s)
-
-ℹ Safe fix
-518 518 | 
-519 519 | # comment
-520 520 | 
-    521 |+
-521 522 | def b():
-522 523 |     pass
-523 524 | # end
-
-E30.py:530:1: E302 [*] Expected 2 blank lines, found 1
-    |
 528 |     pass
-529 | 
-530 | async def b():
-    | ^^^^^ E302
-531 |     pass
-532 | # end
+529 | # end
     |
     = help: Add missing blank line(s)
 
 ℹ Safe fix
-527 527 | def a():
-528 528 |     pass
-529 529 | 
-    530 |+
-530 531 | async def b():
-531 532 |     pass
-532 533 | # end
+524 524 | 
+525 525 | # E302
+526 526 | """Main module."""
+    527 |+
+    528 |+
+527 529 | def fn():
+528 530 |     pass
+529 531 | # end
 
-E30.py:539:1: E302 [*] Expected 2 blank lines, found 1
+E30.py:534:1: E302 [*] Expected 2 blank lines, found 0
     |
-537 |     pass
-538 | 
-539 | async  def x(y: int = 1):
-    | ^^^^^ E302
-540 |     pass
-541 | # end
-    |
-    = help: Add missing blank line(s)
-
-ℹ Safe fix
-536 536 | async  def x():
-537 537 |     pass
-538 538 | 
-    539 |+
-539 540 | async  def x(y: int = 1):
-540 541 |     pass
-541 542 | # end
-
-E30.py:547:1: E302 [*] Expected 2 blank lines, found 0
-    |
-545 | def bar():
-546 |     pass
-547 | def baz(): pass
+532 | # E302
+533 | import sys
+534 | def get_sys_path():
     | ^^^ E302
-548 | # end
+535 |     return sys.path
+536 | # end
     |
     = help: Add missing blank line(s)
 
 ℹ Safe fix
-544 544 | # E302
-545 545 | def bar():
-546 546 |     pass
-    547 |+
-    548 |+
-547 549 | def baz(): pass
-548 550 | # end
-549 551 | 
+531 531 | 
+532 532 | # E302
+533 533 | import sys
+    534 |+
+    535 |+
+534 536 | def get_sys_path():
+535 537 |     return sys.path
+536 538 | # end
 
-E30.py:553:1: E302 [*] Expected 2 blank lines, found 0
+E30.py:543:1: E302 [*] Expected 2 blank lines, found 1
     |
-551 | # E302
-552 | def bar(): pass
-553 | def baz():
+541 |     pass
+542 | 
+543 | def b():
     | ^^^ E302
-554 |     pass
-555 | # end
+544 |     pass
+545 | # end
     |
     = help: Add missing blank line(s)
 
 ℹ Safe fix
-550 550 | 
-551 551 | # E302
-552 552 | def bar(): pass
-    553 |+
+540 540 | def a():
+541 541 |     pass
+542 542 | 
+    543 |+
+543 544 | def b():
+544 545 |     pass
+545 546 | # end
+
+E30.py:554:1: E302 [*] Expected 2 blank lines, found 1
+    |
+552 | # comment
+553 | 
+554 | def b():
+    | ^^^ E302
+555 |     pass
+556 | # end
+    |
+    = help: Add missing blank line(s)
+
+ℹ Safe fix
+551 551 | 
+552 552 | # comment
+553 553 | 
     554 |+
-553 555 | def baz():
-554 556 |     pass
-555 557 | # end
+554 555 | def b():
+555 556 |     pass
+556 557 | # end
 
 E30.py:563:1: E302 [*] Expected 2 blank lines, found 1
     |
-562 | # comment
-563 | @decorator
-    | ^ E302
-564 | def g():
-565 |     pass
+561 |     pass
+562 | 
+563 | async def b():
+    | ^^^^^ E302
+564 |     pass
+565 | # end
     |
     = help: Add missing blank line(s)
 
 ℹ Safe fix
-559 559 | def f():
-560 560 |     pass
-561 561 | 
-    562 |+
+560 560 | def a():
+561 561 |     pass
+562 562 | 
     563 |+
-562 564 | # comment
-563 565 | @decorator
-564 566 | def g():
+563 564 | async def b():
+564 565 |     pass
+565 566 | # end
 
+E30.py:572:1: E302 [*] Expected 2 blank lines, found 1
+    |
+570 |     pass
+571 | 
+572 | async  def x(y: int = 1):
+    | ^^^^^ E302
+573 |     pass
+574 | # end
+    |
+    = help: Add missing blank line(s)
 
+ℹ Safe fix
+569 569 | async  def x():
+570 570 |     pass
+571 571 | 
+    572 |+
+572 573 | async  def x(y: int = 1):
+573 574 |     pass
+574 575 | # end
+
+E30.py:580:1: E302 [*] Expected 2 blank lines, found 0
+    |
+578 | def bar():
+579 |     pass
+580 | def baz(): pass
+    | ^^^ E302
+581 | # end
+    |
+    = help: Add missing blank line(s)
+
+ℹ Safe fix
+577 577 | # E302
+578 578 | def bar():
+579 579 |     pass
+    580 |+
+    581 |+
+580 582 | def baz(): pass
+581 583 | # end
+582 584 | 
+
+E30.py:586:1: E302 [*] Expected 2 blank lines, found 0
+    |
+584 | # E302
+585 | def bar(): pass
+586 | def baz():
+    | ^^^ E302
+587 |     pass
+588 | # end
+    |
+    = help: Add missing blank line(s)
+
+ℹ Safe fix
+583 583 | 
+584 584 | # E302
+585 585 | def bar(): pass
+    586 |+
+    587 |+
+586 588 | def baz():
+587 589 |     pass
+588 590 | # end
+
+E30.py:596:1: E302 [*] Expected 2 blank lines, found 1
+    |
+595 | # comment
+596 | @decorator
+    | ^ E302
+597 | def g():
+598 |     pass
+    |
+    = help: Add missing blank line(s)
+
+ℹ Safe fix
+592 592 | def f():
+593 593 |     pass
+594 594 | 
+    595 |+
+    596 |+
+595 597 | # comment
+596 598 | @decorator
+597 599 | def g():

--- a/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E302_E30.py.snap
+++ b/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E302_E30.py.snap
@@ -1,185 +1,205 @@
 ---
 source: crates/ruff_linter/src/rules/pycodestyle/mod.rs
 ---
-E30.py:527:1: E302 [*] Expected 2 blank lines, found 0
+E30.py:541:1: E302 [*] Expected 2 blank lines, found 0
     |
-525 | # E302
-526 | """Main module."""
-527 | def fn():
+539 | # E302
+540 | """Main module."""
+541 | def fn():
     | ^^^ E302
-528 |     pass
-529 | # end
+542 |     pass
+543 | # end
     |
     = help: Add missing blank line(s)
 
 ℹ Safe fix
-524 524 | 
-525 525 | # E302
-526 526 | """Main module."""
-    527 |+
-    528 |+
-527 529 | def fn():
-528 530 |     pass
-529 531 | # end
+538 538 | 
+539 539 | # E302
+540 540 | """Main module."""
+    541 |+
+    542 |+
+541 543 | def fn():
+542 544 |     pass
+543 545 | # end
 
-E30.py:534:1: E302 [*] Expected 2 blank lines, found 0
+E30.py:548:1: E302 [*] Expected 2 blank lines, found 0
     |
-532 | # E302
-533 | import sys
-534 | def get_sys_path():
+546 | # E302
+547 | import sys
+548 | def get_sys_path():
     | ^^^ E302
-535 |     return sys.path
-536 | # end
+549 |     return sys.path
+550 | # end
     |
     = help: Add missing blank line(s)
 
 ℹ Safe fix
-531 531 | 
-532 532 | # E302
-533 533 | import sys
-    534 |+
-    535 |+
-534 536 | def get_sys_path():
-535 537 |     return sys.path
-536 538 | # end
+545 545 | 
+546 546 | # E302
+547 547 | import sys
+    548 |+
+    549 |+
+548 550 | def get_sys_path():
+549 551 |     return sys.path
+550 552 | # end
 
-E30.py:543:1: E302 [*] Expected 2 blank lines, found 1
+E30.py:557:1: E302 [*] Expected 2 blank lines, found 1
     |
-541 |     pass
-542 | 
-543 | def b():
-    | ^^^ E302
-544 |     pass
-545 | # end
-    |
-    = help: Add missing blank line(s)
-
-ℹ Safe fix
-540 540 | def a():
-541 541 |     pass
-542 542 | 
-    543 |+
-543 544 | def b():
-544 545 |     pass
-545 546 | # end
-
-E30.py:554:1: E302 [*] Expected 2 blank lines, found 1
-    |
-552 | # comment
-553 | 
-554 | def b():
-    | ^^^ E302
 555 |     pass
-556 | # end
-    |
-    = help: Add missing blank line(s)
-
-ℹ Safe fix
-551 551 | 
-552 552 | # comment
-553 553 | 
-    554 |+
-554 555 | def b():
-555 556 |     pass
-556 557 | # end
-
-E30.py:563:1: E302 [*] Expected 2 blank lines, found 1
-    |
-561 |     pass
-562 | 
-563 | async def b():
-    | ^^^^^ E302
-564 |     pass
-565 | # end
-    |
-    = help: Add missing blank line(s)
-
-ℹ Safe fix
-560 560 | def a():
-561 561 |     pass
-562 562 | 
-    563 |+
-563 564 | async def b():
-564 565 |     pass
-565 566 | # end
-
-E30.py:572:1: E302 [*] Expected 2 blank lines, found 1
-    |
-570 |     pass
-571 | 
-572 | async  def x(y: int = 1):
-    | ^^^^^ E302
-573 |     pass
-574 | # end
-    |
-    = help: Add missing blank line(s)
-
-ℹ Safe fix
-569 569 | async  def x():
-570 570 |     pass
-571 571 | 
-    572 |+
-572 573 | async  def x(y: int = 1):
-573 574 |     pass
-574 575 | # end
-
-E30.py:580:1: E302 [*] Expected 2 blank lines, found 0
-    |
-578 | def bar():
-579 |     pass
-580 | def baz(): pass
+556 | 
+557 | def b():
     | ^^^ E302
-581 | # end
+558 |     pass
+559 | # end
     |
     = help: Add missing blank line(s)
 
 ℹ Safe fix
-577 577 | # E302
-578 578 | def bar():
-579 579 |     pass
-    580 |+
-    581 |+
-580 582 | def baz(): pass
-581 583 | # end
-582 584 | 
+554 554 | def a():
+555 555 |     pass
+556 556 | 
+    557 |+
+557 558 | def b():
+558 559 |     pass
+559 560 | # end
 
-E30.py:586:1: E302 [*] Expected 2 blank lines, found 0
+E30.py:568:1: E302 [*] Expected 2 blank lines, found 1
     |
-584 | # E302
-585 | def bar(): pass
-586 | def baz():
+566 | # comment
+567 | 
+568 | def b():
     | ^^^ E302
+569 |     pass
+570 | # end
+    |
+    = help: Add missing blank line(s)
+
+ℹ Safe fix
+565 565 | 
+566 566 | # comment
+567 567 | 
+    568 |+
+568 569 | def b():
+569 570 |     pass
+570 571 | # end
+
+E30.py:577:1: E302 [*] Expected 2 blank lines, found 1
+    |
+575 |     pass
+576 | 
+577 | async def b():
+    | ^^^^^ E302
+578 |     pass
+579 | # end
+    |
+    = help: Add missing blank line(s)
+
+ℹ Safe fix
+574 574 | def a():
+575 575 |     pass
+576 576 | 
+    577 |+
+577 578 | async def b():
+578 579 |     pass
+579 580 | # end
+
+E30.py:586:1: E302 [*] Expected 2 blank lines, found 1
+    |
+584 |     pass
+585 | 
+586 | async  def x(y: int = 1):
+    | ^^^^^ E302
 587 |     pass
 588 | # end
     |
     = help: Add missing blank line(s)
 
 ℹ Safe fix
-583 583 | 
-584 584 | # E302
-585 585 | def bar(): pass
+583 583 | async  def x():
+584 584 |     pass
+585 585 | 
     586 |+
-    587 |+
-586 588 | def baz():
-587 589 |     pass
-588 590 | # end
+586 587 | async  def x(y: int = 1):
+587 588 |     pass
+588 589 | # end
 
-E30.py:596:1: E302 [*] Expected 2 blank lines, found 1
+E30.py:594:1: E302 [*] Expected 2 blank lines, found 0
     |
-595 | # comment
-596 | @decorator
-    | ^ E302
-597 | def g():
-598 |     pass
+592 | def bar():
+593 |     pass
+594 | def baz(): pass
+    | ^^^ E302
+595 | # end
     |
     = help: Add missing blank line(s)
 
 ℹ Safe fix
-592 592 | def f():
+591 591 | # E302
+592 592 | def bar():
 593 593 |     pass
-594 594 | 
+    594 |+
     595 |+
-    596 |+
-595 597 | # comment
-596 598 | @decorator
-597 599 | def g():
+594 596 | def baz(): pass
+595 597 | # end
+596 598 | 
+
+E30.py:600:1: E302 [*] Expected 2 blank lines, found 0
+    |
+598 | # E302
+599 | def bar(): pass
+600 | def baz():
+    | ^^^ E302
+601 |     pass
+602 | # end
+    |
+    = help: Add missing blank line(s)
+
+ℹ Safe fix
+597 597 | 
+598 598 | # E302
+599 599 | def bar(): pass
+    600 |+
+    601 |+
+600 602 | def baz():
+601 603 |     pass
+602 604 | # end
+
+E30.py:610:1: E302 [*] Expected 2 blank lines, found 1
+    |
+609 | # comment
+610 | @decorator
+    | ^ E302
+611 | def g():
+612 |     pass
+    |
+    = help: Add missing blank line(s)
+
+ℹ Safe fix
+606 606 | def f():
+607 607 |     pass
+608 608 | 
+    609 |+
+    610 |+
+609 611 | # comment
+610 612 | @decorator
+611 613 | def g():
+
+E30.py:632:1: E302 [*] Expected 2 blank lines, found 0
+    |
+630 | # E302
+631 | class A:...
+632 | class B: ...
+    | ^^^^^ E302
+633 | # end
+    |
+    = help: Add missing blank line(s)
+
+ℹ Safe fix
+629 629 | 
+630 630 | # E302
+631 631 | class A:...
+    632 |+
+    633 |+
+632 634 | class B: ...
+633 635 | # end
+634 636 |

--- a/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E302_E30.py.snap
+++ b/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E302_E30.py.snap
@@ -202,4 +202,24 @@ E30.py:632:1: E302 [*] Expected 2 blank lines, found 0
     633 |+
 632 634 | class B: ...
 633 635 | # end
-634 636 |
+634 636 | 
+
+E30.py:642:1: E302 [*] Expected 2 blank lines, found 1
+    |
+640 | def fn(a: str) -> str: ...
+641 | 
+642 | def fn(a: int | str) -> int | str:
+    | ^^^ E302
+643 |     ...
+644 | # end
+    |
+    = help: Add missing blank line(s)
+
+ℹ Safe fix
+639 639 | @overload
+640 640 | def fn(a: str) -> str: ...
+641 641 | 
+    642 |+
+642 643 | def fn(a: int | str) -> int | str:
+643 644 |     ...
+644 645 | # end

--- a/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E303_E30.py.snap
+++ b/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E303_E30.py.snap
@@ -1,248 +1,248 @@
 ---
 source: crates/ruff_linter/src/rules/pycodestyle/mod.rs
 ---
-E30.py:578:2: E303 [*] Too many blank lines (2)
+E30.py:611:2: E303 [*] Too many blank lines (2)
     |
-578 |     def method2():
+611 |     def method2():
     |     ^^^ E303
-579 |         return 22
-580 | # end
+612 |         return 22
+613 | # end
     |
     = help: Remove extraneous blank line(s)
 
 ℹ Safe fix
-574 574 | 	def method1():
-575 575 | 		return 1
-576 576 | 		
-577     |-		
-578 577 | 	def method2():
-579 578 | 		return 22
-580 579 | # end
+607 607 | 	def method1():
+608 608 | 		return 1
+609 609 | 		
+610     |-		
+611 610 | 	def method2():
+612 611 | 		return 22
+613 612 | # end
 
-E30.py:588:5: E303 [*] Too many blank lines (2)
+E30.py:621:5: E303 [*] Too many blank lines (2)
     |
-588 |     # arbitrary comment
+621 |     # arbitrary comment
     |     ^^^^^^^^^^^^^^^^^^^ E303
-589 | 
-590 |     def inner():  # E306 not expected (pycodestyle detects E306)
+622 | 
+623 |     def inner():  # E306 not expected (pycodestyle detects E306)
     |
     = help: Remove extraneous blank line(s)
 
 ℹ Safe fix
-584 584 | def fn():
-585 585 |     _ = None
-586 586 | 
-587     |-
-588 587 |     # arbitrary comment
-589 588 | 
-590 589 |     def inner():  # E306 not expected (pycodestyle detects E306)
+617 617 | def fn():
+618 618 |     _ = None
+619 619 | 
+620     |-
+621 620 |     # arbitrary comment
+622 621 | 
+623 622 |     def inner():  # E306 not expected (pycodestyle detects E306)
 
-E30.py:600:5: E303 [*] Too many blank lines (2)
+E30.py:633:5: E303 [*] Too many blank lines (2)
     |
-600 |     # arbitrary comment
+633 |     # arbitrary comment
     |     ^^^^^^^^^^^^^^^^^^^ E303
-601 |     def inner():  # E306 not expected (pycodestyle detects E306)
-602 |         pass
+634 |     def inner():  # E306 not expected (pycodestyle detects E306)
+635 |         pass
     |
     = help: Remove extraneous blank line(s)
 
 ℹ Safe fix
-596 596 | def fn():
-597 597 |     _ = None
-598 598 | 
-599     |-
-600 599 |     # arbitrary comment
-601 600 |     def inner():  # E306 not expected (pycodestyle detects E306)
-602 601 |         pass
+629 629 | def fn():
+630 630 |     _ = None
+631 631 | 
+632     |-
+633 632 |     # arbitrary comment
+634 633 |     def inner():  # E306 not expected (pycodestyle detects E306)
+635 634 |         pass
 
-E30.py:611:1: E303 [*] Too many blank lines (3)
+E30.py:644:1: E303 [*] Too many blank lines (3)
     |
-611 | print()
+644 | print()
     | ^^^^^ E303
-612 | # end
+645 | # end
     |
     = help: Remove extraneous blank line(s)
 
 ℹ Safe fix
-607 607 | print()
-608 608 | 
-609 609 | 
-610     |-
-611 610 | print()
-612 611 | # end
-613 612 | 
+640 640 | print()
+641 641 | 
+642 642 | 
+643     |-
+644 643 | print()
+645 644 | # end
+646 645 | 
 
-E30.py:620:1: E303 [*] Too many blank lines (3)
+E30.py:653:1: E303 [*] Too many blank lines (3)
     |
-620 | # comment
+653 | # comment
     | ^^^^^^^^^ E303
-621 | 
-622 | print()
+654 | 
+655 | print()
     |
     = help: Remove extraneous blank line(s)
 
 ℹ Safe fix
-616 616 | print()
-617 617 | 
-618 618 | 
-619     |-
-620 619 | # comment
-621 620 | 
-622 621 | print()
+649 649 | print()
+650 650 | 
+651 651 | 
+652     |-
+653 652 | # comment
+654 653 | 
+655 654 | print()
 
-E30.py:631:5: E303 [*] Too many blank lines (2)
+E30.py:664:5: E303 [*] Too many blank lines (2)
     |
-631 |     # comment
+664 |     # comment
     |     ^^^^^^^^^ E303
     |
     = help: Remove extraneous blank line(s)
 
 ℹ Safe fix
-627 627 | def a():
-628 628 |     print()
-629 629 | 
-630     |-
-631 630 |     # comment
-632 631 | 
-633 632 | 
-
-E30.py:634:5: E303 [*] Too many blank lines (2)
-    |
-634 |     # another comment
-    |     ^^^^^^^^^^^^^^^^^ E303
-635 | 
-636 |     print()
-    |
-    = help: Remove extraneous blank line(s)
-
-ℹ Safe fix
-630 630 | 
-631 631 |     # comment
-632 632 | 
-633     |-
-634 633 |     # another comment
-635 634 | 
-636 635 |     print()
-
-E30.py:645:1: E303 [*] Too many blank lines (3)
-    |
-645 | / """This class docstring comes on line 5.
-646 | | It gives error E303: too many blank lines (3)
-647 | | """
-    | |___^ E303
-648 |   # end
-    |
-    = help: Remove extraneous blank line(s)
-
-ℹ Safe fix
-641 641 | #!python
-642 642 | 
-643 643 | 
-644     |-
-645 644 | """This class docstring comes on line 5.
-646 645 | It gives error E303: too many blank lines (3)
-647 646 | """
-
-E30.py:657:5: E303 [*] Too many blank lines (2)
-    |
-657 |     def b(self):
-    |     ^^^ E303
-658 |         pass
-659 | # end
-    |
-    = help: Remove extraneous blank line(s)
-
-ℹ Safe fix
-653 653 |     def a(self):
-654 654 |         pass
-655 655 | 
-656     |-
-657 656 |     def b(self):
-658 657 |         pass
-659 658 | # end
+660 660 | def a():
+661 661 |     print()
+662 662 | 
+663     |-
+664 663 |     # comment
+665 664 | 
+666 665 | 
 
 E30.py:667:5: E303 [*] Too many blank lines (2)
     |
-667 |     a = 2
-    |     ^ E303
-668 | # end
+667 |     # another comment
+    |     ^^^^^^^^^^^^^^^^^ E303
+668 | 
+669 |     print()
     |
     = help: Remove extraneous blank line(s)
 
 ℹ Safe fix
-663 663 | if True:
-664 664 |     a = 1
+663 663 | 
+664 664 |     # comment
 665 665 | 
 666     |-
-667 666 |     a = 2
-668 667 | # end
-669 668 | 
+667 666 |     # another comment
+668 667 | 
+669 668 |     print()
 
-E30.py:675:5: E303 [*] Too many blank lines (2)
+E30.py:678:1: E303 [*] Too many blank lines (3)
     |
-675 |     # comment
+678 | / """This class docstring comes on line 5.
+679 | | It gives error E303: too many blank lines (3)
+680 | | """
+    | |___^ E303
+681 |   # end
+    |
+    = help: Remove extraneous blank line(s)
+
+ℹ Safe fix
+674 674 | #!python
+675 675 | 
+676 676 | 
+677     |-
+678 677 | """This class docstring comes on line 5.
+679 678 | It gives error E303: too many blank lines (3)
+680 679 | """
+
+E30.py:690:5: E303 [*] Too many blank lines (2)
+    |
+690 |     def b(self):
+    |     ^^^ E303
+691 |         pass
+692 | # end
+    |
+    = help: Remove extraneous blank line(s)
+
+ℹ Safe fix
+686 686 |     def a(self):
+687 687 |         pass
+688 688 | 
+689     |-
+690 689 |     def b(self):
+691 690 |         pass
+692 691 | # end
+
+E30.py:700:5: E303 [*] Too many blank lines (2)
+    |
+700 |     a = 2
+    |     ^ E303
+701 | # end
+    |
+    = help: Remove extraneous blank line(s)
+
+ℹ Safe fix
+696 696 | if True:
+697 697 |     a = 1
+698 698 | 
+699     |-
+700 699 |     a = 2
+701 700 | # end
+702 701 | 
+
+E30.py:708:5: E303 [*] Too many blank lines (2)
+    |
+708 |     # comment
     |     ^^^^^^^^^ E303
     |
     = help: Remove extraneous blank line(s)
 
 ℹ Safe fix
-671 671 | # E303
-672 672 | class Test:
-673 673 | 
-674     |-
-675 674 |     # comment
-676 675 | 
-677 676 | 
+704 704 | # E303
+705 705 | class Test:
+706 706 | 
+707     |-
+708 707 |     # comment
+709 708 | 
+710 709 | 
 
-E30.py:678:5: E303 [*] Too many blank lines (2)
+E30.py:711:5: E303 [*] Too many blank lines (2)
     |
-678 |     # another comment
+711 |     # another comment
     |     ^^^^^^^^^^^^^^^^^ E303
-679 | 
-680 |     def test(self): pass
+712 | 
+713 |     def test(self): pass
     |
     = help: Remove extraneous blank line(s)
 
 ℹ Safe fix
-674 674 | 
-675 675 |     # comment
-676 676 | 
-677     |-
-678 677 |     # another comment
-679 678 | 
-680 679 |     def test(self): pass
+707 707 | 
+708 708 |     # comment
+709 709 | 
+710     |-
+711 710 |     # another comment
+712 711 | 
+713 712 |     def test(self): pass
 
-E30.py:692:5: E303 [*] Too many blank lines (2)
+E30.py:725:5: E303 [*] Too many blank lines (2)
     |
-692 |     def b(self):
+725 |     def b(self):
     |     ^^^ E303
-693 |         pass
-694 | # end
+726 |         pass
+727 | # end
     |
     = help: Remove extraneous blank line(s)
 
 ℹ Safe fix
-688 688 | 
-689 689 | # wrongly indented comment
-690 690 | 
-691     |-
-692 691 |     def b(self):
-693 692 |         pass
-694 693 | # end
+721 721 | 
+722 722 | # wrongly indented comment
+723 723 | 
+724     |-
+725 724 |     def b(self):
+726 725 |         pass
+727 726 | # end
 
-E30.py:702:5: E303 [*] Too many blank lines (2)
+E30.py:735:5: E303 [*] Too many blank lines (2)
     |
-702 |     pass
+735 |     pass
     |     ^^^^ E303
-703 | # end
+736 | # end
     |
     = help: Remove extraneous blank line(s)
 
 ℹ Safe fix
-698 698 | def fn():
-699 699 |     pass
-700 700 | 
-701     |- 
-702 701 |     pass
-703 702 | # end
-704 703 |
+731 731 | def fn():
+732 732 |     pass
+733 733 | 
+734     |- 
+735 734 |     pass
+736 735 | # end
+737 736 |

--- a/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E303_E30.py.snap
+++ b/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E303_E30.py.snap
@@ -1,248 +1,248 @@
 ---
 source: crates/ruff_linter/src/rules/pycodestyle/mod.rs
 ---
-E30.py:611:2: E303 [*] Too many blank lines (2)
+E30.py:625:2: E303 [*] Too many blank lines (2)
     |
-611 |     def method2():
+625 |     def method2():
     |     ^^^ E303
-612 |         return 22
-613 | # end
+626 |         return 22
+627 | # end
     |
     = help: Remove extraneous blank line(s)
 
 ℹ Safe fix
-607 607 | 	def method1():
-608 608 | 		return 1
-609 609 | 		
-610     |-		
-611 610 | 	def method2():
-612 611 | 		return 22
-613 612 | # end
+621 621 | 	def method1():
+622 622 | 		return 1
+623 623 | 		
+624     |-		
+625 624 | 	def method2():
+626 625 | 		return 22
+627 626 | # end
 
-E30.py:621:5: E303 [*] Too many blank lines (2)
+E30.py:641:5: E303 [*] Too many blank lines (2)
     |
-621 |     # arbitrary comment
+641 |     # arbitrary comment
     |     ^^^^^^^^^^^^^^^^^^^ E303
-622 | 
-623 |     def inner():  # E306 not expected (pycodestyle detects E306)
+642 | 
+643 |     def inner():  # E306 not expected (pycodestyle detects E306)
     |
     = help: Remove extraneous blank line(s)
 
 ℹ Safe fix
-617 617 | def fn():
-618 618 |     _ = None
-619 619 | 
-620     |-
-621 620 |     # arbitrary comment
-622 621 | 
-623 622 |     def inner():  # E306 not expected (pycodestyle detects E306)
+637 637 | def fn():
+638 638 |     _ = None
+639 639 | 
+640     |-
+641 640 |     # arbitrary comment
+642 641 | 
+643 642 |     def inner():  # E306 not expected (pycodestyle detects E306)
 
-E30.py:633:5: E303 [*] Too many blank lines (2)
+E30.py:653:5: E303 [*] Too many blank lines (2)
     |
-633 |     # arbitrary comment
+653 |     # arbitrary comment
     |     ^^^^^^^^^^^^^^^^^^^ E303
-634 |     def inner():  # E306 not expected (pycodestyle detects E306)
-635 |         pass
+654 |     def inner():  # E306 not expected (pycodestyle detects E306)
+655 |         pass
     |
     = help: Remove extraneous blank line(s)
 
 ℹ Safe fix
-629 629 | def fn():
-630 630 |     _ = None
-631 631 | 
-632     |-
-633 632 |     # arbitrary comment
-634 633 |     def inner():  # E306 not expected (pycodestyle detects E306)
-635 634 |         pass
-
-E30.py:644:1: E303 [*] Too many blank lines (3)
-    |
-644 | print()
-    | ^^^^^ E303
-645 | # end
-    |
-    = help: Remove extraneous blank line(s)
-
-ℹ Safe fix
-640 640 | print()
-641 641 | 
-642 642 | 
-643     |-
-644 643 | print()
-645 644 | # end
-646 645 | 
-
-E30.py:653:1: E303 [*] Too many blank lines (3)
-    |
-653 | # comment
-    | ^^^^^^^^^ E303
-654 | 
-655 | print()
-    |
-    = help: Remove extraneous blank line(s)
-
-ℹ Safe fix
-649 649 | print()
-650 650 | 
+649 649 | def fn():
+650 650 |     _ = None
 651 651 | 
 652     |-
-653 652 | # comment
-654 653 | 
-655 654 | print()
+653 652 |     # arbitrary comment
+654 653 |     def inner():  # E306 not expected (pycodestyle detects E306)
+655 654 |         pass
 
-E30.py:664:5: E303 [*] Too many blank lines (2)
+E30.py:664:1: E303 [*] Too many blank lines (3)
     |
-664 |     # comment
-    |     ^^^^^^^^^ E303
+664 | print()
+    | ^^^^^ E303
+665 | # end
     |
     = help: Remove extraneous blank line(s)
 
 ℹ Safe fix
-660 660 | def a():
-661 661 |     print()
+660 660 | print()
+661 661 | 
 662 662 | 
 663     |-
-664 663 |     # comment
-665 664 | 
+664 663 | print()
+665 664 | # end
 666 665 | 
 
-E30.py:667:5: E303 [*] Too many blank lines (2)
+E30.py:673:1: E303 [*] Too many blank lines (3)
     |
-667 |     # another comment
-    |     ^^^^^^^^^^^^^^^^^ E303
-668 | 
-669 |     print()
-    |
-    = help: Remove extraneous blank line(s)
-
-ℹ Safe fix
-663 663 | 
-664 664 |     # comment
-665 665 | 
-666     |-
-667 666 |     # another comment
-668 667 | 
-669 668 |     print()
-
-E30.py:678:1: E303 [*] Too many blank lines (3)
-    |
-678 | / """This class docstring comes on line 5.
-679 | | It gives error E303: too many blank lines (3)
-680 | | """
-    | |___^ E303
-681 |   # end
+673 | # comment
+    | ^^^^^^^^^ E303
+674 | 
+675 | print()
     |
     = help: Remove extraneous blank line(s)
 
 ℹ Safe fix
-674 674 | #!python
-675 675 | 
-676 676 | 
-677     |-
-678 677 | """This class docstring comes on line 5.
-679 678 | It gives error E303: too many blank lines (3)
-680 679 | """
+669 669 | print()
+670 670 | 
+671 671 | 
+672     |-
+673 672 | # comment
+674 673 | 
+675 674 | print()
 
-E30.py:690:5: E303 [*] Too many blank lines (2)
+E30.py:684:5: E303 [*] Too many blank lines (2)
     |
-690 |     def b(self):
-    |     ^^^ E303
-691 |         pass
-692 | # end
-    |
-    = help: Remove extraneous blank line(s)
-
-ℹ Safe fix
-686 686 |     def a(self):
-687 687 |         pass
-688 688 | 
-689     |-
-690 689 |     def b(self):
-691 690 |         pass
-692 691 | # end
-
-E30.py:700:5: E303 [*] Too many blank lines (2)
-    |
-700 |     a = 2
-    |     ^ E303
-701 | # end
-    |
-    = help: Remove extraneous blank line(s)
-
-ℹ Safe fix
-696 696 | if True:
-697 697 |     a = 1
-698 698 | 
-699     |-
-700 699 |     a = 2
-701 700 | # end
-702 701 | 
-
-E30.py:708:5: E303 [*] Too many blank lines (2)
-    |
-708 |     # comment
+684 |     # comment
     |     ^^^^^^^^^ E303
     |
     = help: Remove extraneous blank line(s)
 
 ℹ Safe fix
-704 704 | # E303
-705 705 | class Test:
-706 706 | 
-707     |-
-708 707 |     # comment
-709 708 | 
-710 709 | 
+680 680 | def a():
+681 681 |     print()
+682 682 | 
+683     |-
+684 683 |     # comment
+685 684 | 
+686 685 | 
 
-E30.py:711:5: E303 [*] Too many blank lines (2)
+E30.py:687:5: E303 [*] Too many blank lines (2)
     |
-711 |     # another comment
+687 |     # another comment
     |     ^^^^^^^^^^^^^^^^^ E303
-712 | 
-713 |     def test(self): pass
+688 | 
+689 |     print()
     |
     = help: Remove extraneous blank line(s)
 
 ℹ Safe fix
-707 707 | 
-708 708 |     # comment
-709 709 | 
-710     |-
-711 710 |     # another comment
-712 711 | 
-713 712 |     def test(self): pass
+683 683 | 
+684 684 |     # comment
+685 685 | 
+686     |-
+687 686 |     # another comment
+688 687 | 
+689 688 |     print()
 
-E30.py:725:5: E303 [*] Too many blank lines (2)
+E30.py:698:1: E303 [*] Too many blank lines (3)
     |
-725 |     def b(self):
+698 | / """This class docstring comes on line 5.
+699 | | It gives error E303: too many blank lines (3)
+700 | | """
+    | |___^ E303
+701 |   # end
+    |
+    = help: Remove extraneous blank line(s)
+
+ℹ Safe fix
+694 694 | #!python
+695 695 | 
+696 696 | 
+697     |-
+698 697 | """This class docstring comes on line 5.
+699 698 | It gives error E303: too many blank lines (3)
+700 699 | """
+
+E30.py:710:5: E303 [*] Too many blank lines (2)
+    |
+710 |     def b(self):
     |     ^^^ E303
-726 |         pass
-727 | # end
+711 |         pass
+712 | # end
     |
     = help: Remove extraneous blank line(s)
 
 ℹ Safe fix
-721 721 | 
-722 722 | # wrongly indented comment
-723 723 | 
-724     |-
-725 724 |     def b(self):
-726 725 |         pass
-727 726 | # end
+706 706 |     def a(self):
+707 707 |         pass
+708 708 | 
+709     |-
+710 709 |     def b(self):
+711 710 |         pass
+712 711 | # end
 
-E30.py:735:5: E303 [*] Too many blank lines (2)
+E30.py:720:5: E303 [*] Too many blank lines (2)
     |
-735 |     pass
+720 |     a = 2
+    |     ^ E303
+721 | # end
+    |
+    = help: Remove extraneous blank line(s)
+
+ℹ Safe fix
+716 716 | if True:
+717 717 |     a = 1
+718 718 | 
+719     |-
+720 719 |     a = 2
+721 720 | # end
+722 721 | 
+
+E30.py:728:5: E303 [*] Too many blank lines (2)
+    |
+728 |     # comment
+    |     ^^^^^^^^^ E303
+    |
+    = help: Remove extraneous blank line(s)
+
+ℹ Safe fix
+724 724 | # E303
+725 725 | class Test:
+726 726 | 
+727     |-
+728 727 |     # comment
+729 728 | 
+730 729 | 
+
+E30.py:731:5: E303 [*] Too many blank lines (2)
+    |
+731 |     # another comment
+    |     ^^^^^^^^^^^^^^^^^ E303
+732 | 
+733 |     def test(self): pass
+    |
+    = help: Remove extraneous blank line(s)
+
+ℹ Safe fix
+727 727 | 
+728 728 |     # comment
+729 729 | 
+730     |-
+731 730 |     # another comment
+732 731 | 
+733 732 |     def test(self): pass
+
+E30.py:745:5: E303 [*] Too many blank lines (2)
+    |
+745 |     def b(self):
+    |     ^^^ E303
+746 |         pass
+747 | # end
+    |
+    = help: Remove extraneous blank line(s)
+
+ℹ Safe fix
+741 741 | 
+742 742 | # wrongly indented comment
+743 743 | 
+744     |-
+745 744 |     def b(self):
+746 745 |         pass
+747 746 | # end
+
+E30.py:755:5: E303 [*] Too many blank lines (2)
+    |
+755 |     pass
     |     ^^^^ E303
-736 | # end
+756 | # end
     |
     = help: Remove extraneous blank line(s)
 
 ℹ Safe fix
-731 731 | def fn():
-732 732 |     pass
-733 733 | 
-734     |- 
-735 734 |     pass
-736 735 | # end
-737 736 |
+751 751 | def fn():
+752 752 |     pass
+753 753 | 
+754     |- 
+755 754 |     pass
+756 755 | # end
+757 756 |

--- a/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E303_E30.py.snap
+++ b/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E303_E30.py.snap
@@ -19,230 +19,230 @@ E30.py:625:2: E303 [*] Too many blank lines (2)
 626 625 | 		return 22
 627 626 | # end
 
-E30.py:641:5: E303 [*] Too many blank lines (2)
+E30.py:652:5: E303 [*] Too many blank lines (2)
     |
-641 |     # arbitrary comment
+652 |     # arbitrary comment
     |     ^^^^^^^^^^^^^^^^^^^ E303
-642 | 
-643 |     def inner():  # E306 not expected (pycodestyle detects E306)
-    |
-    = help: Remove extraneous blank line(s)
-
-ℹ Safe fix
-637 637 | def fn():
-638 638 |     _ = None
-639 639 | 
-640     |-
-641 640 |     # arbitrary comment
-642 641 | 
-643 642 |     def inner():  # E306 not expected (pycodestyle detects E306)
-
-E30.py:653:5: E303 [*] Too many blank lines (2)
-    |
-653 |     # arbitrary comment
-    |     ^^^^^^^^^^^^^^^^^^^ E303
+653 | 
 654 |     def inner():  # E306 not expected (pycodestyle detects E306)
-655 |         pass
     |
     = help: Remove extraneous blank line(s)
 
 ℹ Safe fix
-649 649 | def fn():
-650 650 |     _ = None
-651 651 | 
-652     |-
-653 652 |     # arbitrary comment
+648 648 | def fn():
+649 649 |     _ = None
+650 650 | 
+651     |-
+652 651 |     # arbitrary comment
+653 652 | 
 654 653 |     def inner():  # E306 not expected (pycodestyle detects E306)
-655 654 |         pass
 
-E30.py:664:1: E303 [*] Too many blank lines (3)
+E30.py:664:5: E303 [*] Too many blank lines (2)
     |
-664 | print()
-    | ^^^^^ E303
-665 | # end
+664 |     # arbitrary comment
+    |     ^^^^^^^^^^^^^^^^^^^ E303
+665 |     def inner():  # E306 not expected (pycodestyle detects E306)
+666 |         pass
     |
     = help: Remove extraneous blank line(s)
 
 ℹ Safe fix
-660 660 | print()
-661 661 | 
+660 660 | def fn():
+661 661 |     _ = None
 662 662 | 
 663     |-
-664 663 | print()
-665 664 | # end
-666 665 | 
+664 663 |     # arbitrary comment
+665 664 |     def inner():  # E306 not expected (pycodestyle detects E306)
+666 665 |         pass
 
-E30.py:673:1: E303 [*] Too many blank lines (3)
+E30.py:675:1: E303 [*] Too many blank lines (3)
     |
-673 | # comment
-    | ^^^^^^^^^ E303
-674 | 
 675 | print()
+    | ^^^^^ E303
+676 | # end
     |
     = help: Remove extraneous blank line(s)
 
 ℹ Safe fix
-669 669 | print()
-670 670 | 
-671 671 | 
-672     |-
-673 672 | # comment
-674 673 | 
+671 671 | print()
+672 672 | 
+673 673 | 
+674     |-
 675 674 | print()
+676 675 | # end
+677 676 | 
 
-E30.py:684:5: E303 [*] Too many blank lines (2)
+E30.py:684:1: E303 [*] Too many blank lines (3)
     |
-684 |     # comment
-    |     ^^^^^^^^^ E303
+684 | # comment
+    | ^^^^^^^^^ E303
+685 | 
+686 | print()
     |
     = help: Remove extraneous blank line(s)
 
 ℹ Safe fix
-680 680 | def a():
-681 681 |     print()
+680 680 | print()
+681 681 | 
 682 682 | 
 683     |-
-684 683 |     # comment
+684 683 | # comment
 685 684 | 
-686 685 | 
+686 685 | print()
 
-E30.py:687:5: E303 [*] Too many blank lines (2)
+E30.py:695:5: E303 [*] Too many blank lines (2)
     |
-687 |     # another comment
-    |     ^^^^^^^^^^^^^^^^^ E303
-688 | 
-689 |     print()
-    |
-    = help: Remove extraneous blank line(s)
-
-ℹ Safe fix
-683 683 | 
-684 684 |     # comment
-685 685 | 
-686     |-
-687 686 |     # another comment
-688 687 | 
-689 688 |     print()
-
-E30.py:698:1: E303 [*] Too many blank lines (3)
-    |
-698 | / """This class docstring comes on line 5.
-699 | | It gives error E303: too many blank lines (3)
-700 | | """
-    | |___^ E303
-701 |   # end
-    |
-    = help: Remove extraneous blank line(s)
-
-ℹ Safe fix
-694 694 | #!python
-695 695 | 
-696 696 | 
-697     |-
-698 697 | """This class docstring comes on line 5.
-699 698 | It gives error E303: too many blank lines (3)
-700 699 | """
-
-E30.py:710:5: E303 [*] Too many blank lines (2)
-    |
-710 |     def b(self):
-    |     ^^^ E303
-711 |         pass
-712 | # end
-    |
-    = help: Remove extraneous blank line(s)
-
-ℹ Safe fix
-706 706 |     def a(self):
-707 707 |         pass
-708 708 | 
-709     |-
-710 709 |     def b(self):
-711 710 |         pass
-712 711 | # end
-
-E30.py:720:5: E303 [*] Too many blank lines (2)
-    |
-720 |     a = 2
-    |     ^ E303
-721 | # end
-    |
-    = help: Remove extraneous blank line(s)
-
-ℹ Safe fix
-716 716 | if True:
-717 717 |     a = 1
-718 718 | 
-719     |-
-720 719 |     a = 2
-721 720 | # end
-722 721 | 
-
-E30.py:728:5: E303 [*] Too many blank lines (2)
-    |
-728 |     # comment
+695 |     # comment
     |     ^^^^^^^^^ E303
     |
     = help: Remove extraneous blank line(s)
 
 ℹ Safe fix
-724 724 | # E303
-725 725 | class Test:
-726 726 | 
-727     |-
-728 727 |     # comment
-729 728 | 
-730 729 | 
+691 691 | def a():
+692 692 |     print()
+693 693 | 
+694     |-
+695 694 |     # comment
+696 695 | 
+697 696 | 
+
+E30.py:698:5: E303 [*] Too many blank lines (2)
+    |
+698 |     # another comment
+    |     ^^^^^^^^^^^^^^^^^ E303
+699 | 
+700 |     print()
+    |
+    = help: Remove extraneous blank line(s)
+
+ℹ Safe fix
+694 694 | 
+695 695 |     # comment
+696 696 | 
+697     |-
+698 697 |     # another comment
+699 698 | 
+700 699 |     print()
+
+E30.py:709:1: E303 [*] Too many blank lines (3)
+    |
+709 | / """This class docstring comes on line 5.
+710 | | It gives error E303: too many blank lines (3)
+711 | | """
+    | |___^ E303
+712 |   # end
+    |
+    = help: Remove extraneous blank line(s)
+
+ℹ Safe fix
+705 705 | #!python
+706 706 | 
+707 707 | 
+708     |-
+709 708 | """This class docstring comes on line 5.
+710 709 | It gives error E303: too many blank lines (3)
+711 710 | """
+
+E30.py:721:5: E303 [*] Too many blank lines (2)
+    |
+721 |     def b(self):
+    |     ^^^ E303
+722 |         pass
+723 | # end
+    |
+    = help: Remove extraneous blank line(s)
+
+ℹ Safe fix
+717 717 |     def a(self):
+718 718 |         pass
+719 719 | 
+720     |-
+721 720 |     def b(self):
+722 721 |         pass
+723 722 | # end
 
 E30.py:731:5: E303 [*] Too many blank lines (2)
     |
-731 |     # another comment
-    |     ^^^^^^^^^^^^^^^^^ E303
-732 | 
-733 |     def test(self): pass
+731 |     a = 2
+    |     ^ E303
+732 | # end
     |
     = help: Remove extraneous blank line(s)
 
 ℹ Safe fix
-727 727 | 
-728 728 |     # comment
+727 727 | if True:
+728 728 |     a = 1
 729 729 | 
 730     |-
-731 730 |     # another comment
-732 731 | 
-733 732 |     def test(self): pass
+731 730 |     a = 2
+732 731 | # end
+733 732 | 
 
-E30.py:745:5: E303 [*] Too many blank lines (2)
+E30.py:739:5: E303 [*] Too many blank lines (2)
     |
-745 |     def b(self):
+739 |     # comment
+    |     ^^^^^^^^^ E303
+    |
+    = help: Remove extraneous blank line(s)
+
+ℹ Safe fix
+735 735 | # E303
+736 736 | class Test:
+737 737 | 
+738     |-
+739 738 |     # comment
+740 739 | 
+741 740 | 
+
+E30.py:742:5: E303 [*] Too many blank lines (2)
+    |
+742 |     # another comment
+    |     ^^^^^^^^^^^^^^^^^ E303
+743 | 
+744 |     def test(self): pass
+    |
+    = help: Remove extraneous blank line(s)
+
+ℹ Safe fix
+738 738 | 
+739 739 |     # comment
+740 740 | 
+741     |-
+742 741 |     # another comment
+743 742 | 
+744 743 |     def test(self): pass
+
+E30.py:756:5: E303 [*] Too many blank lines (2)
+    |
+756 |     def b(self):
     |     ^^^ E303
-746 |         pass
-747 | # end
+757 |         pass
+758 | # end
     |
     = help: Remove extraneous blank line(s)
 
 ℹ Safe fix
-741 741 | 
-742 742 | # wrongly indented comment
-743 743 | 
-744     |-
-745 744 |     def b(self):
-746 745 |         pass
-747 746 | # end
+752 752 | 
+753 753 | # wrongly indented comment
+754 754 | 
+755     |-
+756 755 |     def b(self):
+757 756 |         pass
+758 757 | # end
 
-E30.py:755:5: E303 [*] Too many blank lines (2)
+E30.py:766:5: E303 [*] Too many blank lines (2)
     |
-755 |     pass
+766 |     pass
     |     ^^^^ E303
-756 | # end
+767 | # end
     |
     = help: Remove extraneous blank line(s)
 
 ℹ Safe fix
-751 751 | def fn():
-752 752 |     pass
-753 753 | 
-754     |- 
-755 754 |     pass
-756 755 | # end
-757 756 |
+762 762 | def fn():
+763 763 |     pass
+764 764 | 
+765     |- 
+766 765 |     pass
+767 766 | # end
+768 767 |

--- a/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E304_E30.py.snap
+++ b/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E304_E30.py.snap
@@ -1,65 +1,63 @@
 ---
 source: crates/ruff_linter/src/rules/pycodestyle/mod.rs
 ---
-E30.py:709:1: E304 [*] Blank lines found after function decorator (1)
+E30.py:742:1: E304 [*] Blank lines found after function decorator (1)
     |
-707 | @decorator
-708 | 
-709 | def function():
+740 | @decorator
+741 | 
+742 | def function():
     | ^^^ E304
-710 |     pass
-711 | # end
+743 |     pass
+744 | # end
     |
     = help: Remove extraneous blank line(s)
 
 ℹ Safe fix
-705 705 | 
-706 706 | # E304
-707 707 | @decorator
-708     |-
-709 708 | def function():
-710 709 |     pass
-711 710 | # end
+738 738 | 
+739 739 | # E304
+740 740 | @decorator
+741     |-
+742 741 | def function():
+743 742 |     pass
+744 743 | # end
 
-E30.py:718:1: E304 [*] Blank lines found after function decorator (1)
+E30.py:751:1: E304 [*] Blank lines found after function decorator (1)
     |
-717 | # comment    E304 not expected
-718 | def function():
+750 | # comment    E304 not expected
+751 | def function():
     | ^^^ E304
-719 |     pass
-720 | # end
+752 |     pass
+753 | # end
     |
     = help: Remove extraneous blank line(s)
 
 ℹ Safe fix
-713 713 | 
-714 714 | # E304
-715 715 | @decorator
-716     |-
-717 716 | # comment    E304 not expected
-718 717 | def function():
-719 718 |     pass
+746 746 | 
+747 747 | # E304
+748 748 | @decorator
+749     |-
+750 749 | # comment    E304 not expected
+751 750 | def function():
+752 751 |     pass
 
-E30.py:730:1: E304 [*] Blank lines found after function decorator (2)
+E30.py:763:1: E304 [*] Blank lines found after function decorator (2)
     |
-729 | # second comment  E304 not expected
-730 | def function():
+762 | # second comment  E304 not expected
+763 | def function():
     | ^^^ E304
-731 |     pass
-732 | # end
+764 |     pass
+765 | # end
     |
     = help: Remove extraneous blank line(s)
 
 ℹ Safe fix
-722 722 | 
-723 723 | # E304
-724 724 | @decorator
-725     |-
-726 725 | # comment  E304 not expected
-727     |-
-728     |-
-729 726 | # second comment  E304 not expected
-730 727 | def function():
-731 728 |     pass
-
-
+755 755 | 
+756 756 | # E304
+757 757 | @decorator
+758     |-
+759 758 | # comment  E304 not expected
+760     |-
+761     |-
+762 759 | # second comment  E304 not expected
+763 760 | def function():
+764 761 |     pass

--- a/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E304_E30.py.snap
+++ b/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E304_E30.py.snap
@@ -1,63 +1,63 @@
 ---
 source: crates/ruff_linter/src/rules/pycodestyle/mod.rs
 ---
-E30.py:742:1: E304 [*] Blank lines found after function decorator (1)
+E30.py:762:1: E304 [*] Blank lines found after function decorator (1)
     |
-740 | @decorator
-741 | 
-742 | def function():
+760 | @decorator
+761 | 
+762 | def function():
     | ^^^ E304
-743 |     pass
-744 | # end
+763 |     pass
+764 | # end
     |
     = help: Remove extraneous blank line(s)
 
 ℹ Safe fix
-738 738 | 
-739 739 | # E304
-740 740 | @decorator
-741     |-
-742 741 | def function():
-743 742 |     pass
-744 743 | # end
-
-E30.py:751:1: E304 [*] Blank lines found after function decorator (1)
-    |
-750 | # comment    E304 not expected
-751 | def function():
-    | ^^^ E304
-752 |     pass
-753 | # end
-    |
-    = help: Remove extraneous blank line(s)
-
-ℹ Safe fix
-746 746 | 
-747 747 | # E304
-748 748 | @decorator
-749     |-
-750 749 | # comment    E304 not expected
-751 750 | def function():
-752 751 |     pass
-
-E30.py:763:1: E304 [*] Blank lines found after function decorator (2)
-    |
-762 | # second comment  E304 not expected
-763 | def function():
-    | ^^^ E304
-764 |     pass
-765 | # end
-    |
-    = help: Remove extraneous blank line(s)
-
-ℹ Safe fix
-755 755 | 
-756 756 | # E304
-757 757 | @decorator
-758     |-
-759 758 | # comment  E304 not expected
-760     |-
+758 758 | 
+759 759 | # E304
+760 760 | @decorator
 761     |-
-762 759 | # second comment  E304 not expected
-763 760 | def function():
-764 761 |     pass
+762 761 | def function():
+763 762 |     pass
+764 763 | # end
+
+E30.py:771:1: E304 [*] Blank lines found after function decorator (1)
+    |
+770 | # comment    E304 not expected
+771 | def function():
+    | ^^^ E304
+772 |     pass
+773 | # end
+    |
+    = help: Remove extraneous blank line(s)
+
+ℹ Safe fix
+766 766 | 
+767 767 | # E304
+768 768 | @decorator
+769     |-
+770 769 | # comment    E304 not expected
+771 770 | def function():
+772 771 |     pass
+
+E30.py:783:1: E304 [*] Blank lines found after function decorator (2)
+    |
+782 | # second comment  E304 not expected
+783 | def function():
+    | ^^^ E304
+784 |     pass
+785 | # end
+    |
+    = help: Remove extraneous blank line(s)
+
+ℹ Safe fix
+775 775 | 
+776 776 | # E304
+777 777 | @decorator
+778     |-
+779 778 | # comment  E304 not expected
+780     |-
+781     |-
+782 779 | # second comment  E304 not expected
+783 780 | def function():
+784 781 |     pass

--- a/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E304_E30.py.snap
+++ b/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E304_E30.py.snap
@@ -1,63 +1,63 @@
 ---
 source: crates/ruff_linter/src/rules/pycodestyle/mod.rs
 ---
-E30.py:762:1: E304 [*] Blank lines found after function decorator (1)
+E30.py:773:1: E304 [*] Blank lines found after function decorator (1)
     |
-760 | @decorator
-761 | 
-762 | def function():
+771 | @decorator
+772 | 
+773 | def function():
     | ^^^ E304
-763 |     pass
-764 | # end
+774 |     pass
+775 | # end
     |
     = help: Remove extraneous blank line(s)
 
 ℹ Safe fix
-758 758 | 
-759 759 | # E304
-760 760 | @decorator
-761     |-
-762 761 | def function():
-763 762 |     pass
-764 763 | # end
+769 769 | 
+770 770 | # E304
+771 771 | @decorator
+772     |-
+773 772 | def function():
+774 773 |     pass
+775 774 | # end
 
-E30.py:771:1: E304 [*] Blank lines found after function decorator (1)
+E30.py:782:1: E304 [*] Blank lines found after function decorator (1)
     |
-770 | # comment    E304 not expected
-771 | def function():
+781 | # comment    E304 not expected
+782 | def function():
     | ^^^ E304
-772 |     pass
-773 | # end
+783 |     pass
+784 | # end
     |
     = help: Remove extraneous blank line(s)
 
 ℹ Safe fix
-766 766 | 
-767 767 | # E304
-768 768 | @decorator
-769     |-
-770 769 | # comment    E304 not expected
-771 770 | def function():
-772 771 |     pass
-
-E30.py:783:1: E304 [*] Blank lines found after function decorator (2)
-    |
-782 | # second comment  E304 not expected
-783 | def function():
-    | ^^^ E304
-784 |     pass
-785 | # end
-    |
-    = help: Remove extraneous blank line(s)
-
-ℹ Safe fix
-775 775 | 
-776 776 | # E304
-777 777 | @decorator
-778     |-
-779 778 | # comment  E304 not expected
+777 777 | 
+778 778 | # E304
+779 779 | @decorator
 780     |-
-781     |-
-782 779 | # second comment  E304 not expected
-783 780 | def function():
-784 781 |     pass
+781 780 | # comment    E304 not expected
+782 781 | def function():
+783 782 |     pass
+
+E30.py:794:1: E304 [*] Blank lines found after function decorator (2)
+    |
+793 | # second comment  E304 not expected
+794 | def function():
+    | ^^^ E304
+795 |     pass
+796 | # end
+    |
+    = help: Remove extraneous blank line(s)
+
+ℹ Safe fix
+786 786 | 
+787 787 | # E304
+788 788 | @decorator
+789     |-
+790 789 | # comment  E304 not expected
+791     |-
+792     |-
+793 790 | # second comment  E304 not expected
+794 791 | def function():
+795 792 |     pass

--- a/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E305_E30.py.snap
+++ b/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E305_E30.py.snap
@@ -1,102 +1,100 @@
 ---
 source: crates/ruff_linter/src/rules/pycodestyle/mod.rs
 ---
-E30.py:742:1: E305 [*] Expected 2 blank lines after class or function definition, found (1)
+E30.py:775:1: E305 [*] Expected 2 blank lines after class or function definition, found (1)
     |
-741 |     # another comment
-742 | fn()
+774 |     # another comment
+775 | fn()
     | ^^ E305
-743 | # end
+776 | # end
     |
     = help: Add missing blank line(s)
 
 ℹ Safe fix
-739 739 |     # comment
-740 740 | 
-741 741 |     # another comment
-    742 |+
-    743 |+
-742 744 | fn()
-743 745 | # end
-744 746 | 
+772 772 |     # comment
+773 773 | 
+774 774 |     # another comment
+    775 |+
+    776 |+
+775 777 | fn()
+776 778 | # end
+777 779 | 
 
-E30.py:753:1: E305 [*] Expected 2 blank lines after class or function definition, found (1)
+E30.py:786:1: E305 [*] Expected 2 blank lines after class or function definition, found (1)
     |
-752 |     # another comment
-753 | a = 1
+785 |     # another comment
+786 | a = 1
     | ^ E305
-754 | # end
+787 | # end
     |
     = help: Add missing blank line(s)
 
 ℹ Safe fix
-750 750 |     # comment
-751 751 | 
-752 752 |     # another comment
-    753 |+
-    754 |+
-753 755 | a = 1
-754 756 | # end
-755 757 | 
+783 783 |     # comment
+784 784 | 
+785 785 |     # another comment
+    786 |+
+    787 |+
+786 788 | a = 1
+787 789 | # end
+788 790 | 
 
-E30.py:765:1: E305 [*] Expected 2 blank lines after class or function definition, found (1)
+E30.py:798:1: E305 [*] Expected 2 blank lines after class or function definition, found (1)
     |
-763 |     # another comment
-764 | 
-765 | try:
+796 |     # another comment
+797 | 
+798 | try:
     | ^^^ E305
-766 |     fn()
-767 | except Exception:
+799 |     fn()
+800 | except Exception:
     |
     = help: Add missing blank line(s)
 
 ℹ Safe fix
-762 762 | 
-763 763 |     # another comment
-764 764 | 
-    765 |+
-765 766 | try:
-766 767 |     fn()
-767 768 | except Exception:
+795 795 | 
+796 796 |     # another comment
+797 797 | 
+    798 |+
+798 799 | try:
+799 800 |     fn()
+800 801 | except Exception:
 
-E30.py:777:1: E305 [*] Expected 2 blank lines after class or function definition, found (1)
+E30.py:810:1: E305 [*] Expected 2 blank lines after class or function definition, found (1)
     |
-776 | # Two spaces before comments, too.
-777 | if a():
+809 | # Two spaces before comments, too.
+810 | if a():
     | ^^ E305
-778 |     a()
-779 | # end
+811 |     a()
+812 | # end
     |
     = help: Add missing blank line(s)
 
 ℹ Safe fix
-774 774 |     print()
-775 775 | 
-776 776 | # Two spaces before comments, too.
-    777 |+
-    778 |+
-777 779 | if a():
-778 780 |     a()
-779 781 | # end
+807 807 |     print()
+808 808 | 
+809 809 | # Two spaces before comments, too.
+    810 |+
+    811 |+
+810 812 | if a():
+811 813 |     a()
+812 814 | # end
 
-E30.py:790:1: E305 [*] Expected 2 blank lines after class or function definition, found (1)
+E30.py:823:1: E305 [*] Expected 2 blank lines after class or function definition, found (1)
     |
-788 |     blah, blah
-789 | 
-790 | if __name__ == '__main__':
+821 |     blah, blah
+822 | 
+823 | if __name__ == '__main__':
     | ^^ E305
-791 |     main()
-792 | # end
+824 |     main()
+825 | # end
     |
     = help: Add missing blank line(s)
 
 ℹ Safe fix
-787 787 | def main():
-788 788 |     blah, blah
-789 789 | 
-    790 |+
-790 791 | if __name__ == '__main__':
-791 792 |     main()
-792 793 | # end
-
-
+820 820 | def main():
+821 821 |     blah, blah
+822 822 | 
+    823 |+
+823 824 | if __name__ == '__main__':
+824 825 |     main()
+825 826 | # end

--- a/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E305_E30.py.snap
+++ b/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E305_E30.py.snap
@@ -1,30 +1,11 @@
 ---
 source: crates/ruff_linter/src/rules/pycodestyle/mod.rs
 ---
-E30.py:795:1: E305 [*] Expected 2 blank lines after class or function definition, found (1)
-    |
-794 |     # another comment
-795 | fn()
-    | ^^ E305
-796 | # end
-    |
-    = help: Add missing blank line(s)
-
-ℹ Safe fix
-792 792 |     # comment
-793 793 | 
-794 794 |     # another comment
-    795 |+
-    796 |+
-795 797 | fn()
-796 798 | # end
-797 799 | 
-
 E30.py:806:1: E305 [*] Expected 2 blank lines after class or function definition, found (1)
     |
 805 |     # another comment
-806 | a = 1
-    | ^ E305
+806 | fn()
+    | ^^ E305
 807 | # end
     |
     = help: Add missing blank line(s)
@@ -35,66 +16,85 @@ E30.py:806:1: E305 [*] Expected 2 blank lines after class or function definition
 805 805 |     # another comment
     806 |+
     807 |+
-806 808 | a = 1
+806 808 | fn()
 807 809 | # end
 808 810 | 
 
-E30.py:818:1: E305 [*] Expected 2 blank lines after class or function definition, found (1)
+E30.py:817:1: E305 [*] Expected 2 blank lines after class or function definition, found (1)
     |
 816 |     # another comment
-817 | 
-818 | try:
-    | ^^^ E305
-819 |     fn()
-820 | except Exception:
+817 | a = 1
+    | ^ E305
+818 | # end
     |
     = help: Add missing blank line(s)
 
 ℹ Safe fix
+814 814 |     # comment
 815 815 | 
 816 816 |     # another comment
-817 817 | 
+    817 |+
     818 |+
-818 819 | try:
-819 820 |     fn()
-820 821 | except Exception:
+817 819 | a = 1
+818 820 | # end
+819 821 | 
 
-E30.py:830:1: E305 [*] Expected 2 blank lines after class or function definition, found (1)
+E30.py:829:1: E305 [*] Expected 2 blank lines after class or function definition, found (1)
     |
-829 | # Two spaces before comments, too.
-830 | if a():
-    | ^^ E305
-831 |     a()
-832 | # end
+827 |     # another comment
+828 | 
+829 | try:
+    | ^^^ E305
+830 |     fn()
+831 | except Exception:
     |
     = help: Add missing blank line(s)
 
 ℹ Safe fix
-827 827 |     print()
+826 826 | 
+827 827 |     # another comment
 828 828 | 
-829 829 | # Two spaces before comments, too.
-    830 |+
-    831 |+
-830 832 | if a():
-831 833 |     a()
-832 834 | # end
+    829 |+
+829 830 | try:
+830 831 |     fn()
+831 832 | except Exception:
 
-E30.py:843:1: E305 [*] Expected 2 blank lines after class or function definition, found (1)
+E30.py:841:1: E305 [*] Expected 2 blank lines after class or function definition, found (1)
     |
-841 |     blah, blah
-842 | 
-843 | if __name__ == '__main__':
+840 | # Two spaces before comments, too.
+841 | if a():
     | ^^ E305
-844 |     main()
-845 | # end
+842 |     a()
+843 | # end
     |
     = help: Add missing blank line(s)
 
 ℹ Safe fix
-840 840 | def main():
-841 841 |     blah, blah
-842 842 | 
-    843 |+
-843 844 | if __name__ == '__main__':
-844 845 |     main()
-845 846 | # end
+838 838 |     print()
+839 839 | 
+840 840 | # Two spaces before comments, too.
+    841 |+
+    842 |+
+841 843 | if a():
+842 844 |     a()
+843 845 | # end
+
+E30.py:854:1: E305 [*] Expected 2 blank lines after class or function definition, found (1)
+    |
+852 |     blah, blah
+853 | 
+854 | if __name__ == '__main__':
+    | ^^ E305
+855 |     main()
+856 | # end
+    |
+    = help: Add missing blank line(s)
+
+ℹ Safe fix
+851 851 | def main():
+852 852 |     blah, blah
+853 853 | 
+    854 |+
+854 855 | if __name__ == '__main__':
+855 856 |     main()
+856 857 | # end

--- a/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E305_E30.py.snap
+++ b/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E305_E30.py.snap
@@ -1,100 +1,100 @@
 ---
 source: crates/ruff_linter/src/rules/pycodestyle/mod.rs
 ---
-E30.py:775:1: E305 [*] Expected 2 blank lines after class or function definition, found (1)
+E30.py:795:1: E305 [*] Expected 2 blank lines after class or function definition, found (1)
     |
-774 |     # another comment
-775 | fn()
+794 |     # another comment
+795 | fn()
     | ^^ E305
-776 | # end
+796 | # end
     |
     = help: Add missing blank line(s)
 
 ℹ Safe fix
-772 772 |     # comment
-773 773 | 
-774 774 |     # another comment
-    775 |+
-    776 |+
-775 777 | fn()
-776 778 | # end
-777 779 | 
+792 792 |     # comment
+793 793 | 
+794 794 |     # another comment
+    795 |+
+    796 |+
+795 797 | fn()
+796 798 | # end
+797 799 | 
 
-E30.py:786:1: E305 [*] Expected 2 blank lines after class or function definition, found (1)
+E30.py:806:1: E305 [*] Expected 2 blank lines after class or function definition, found (1)
     |
-785 |     # another comment
-786 | a = 1
+805 |     # another comment
+806 | a = 1
     | ^ E305
-787 | # end
+807 | # end
     |
     = help: Add missing blank line(s)
 
 ℹ Safe fix
-783 783 |     # comment
-784 784 | 
-785 785 |     # another comment
-    786 |+
-    787 |+
-786 788 | a = 1
-787 789 | # end
-788 790 | 
+803 803 |     # comment
+804 804 | 
+805 805 |     # another comment
+    806 |+
+    807 |+
+806 808 | a = 1
+807 809 | # end
+808 810 | 
 
-E30.py:798:1: E305 [*] Expected 2 blank lines after class or function definition, found (1)
+E30.py:818:1: E305 [*] Expected 2 blank lines after class or function definition, found (1)
     |
-796 |     # another comment
-797 | 
-798 | try:
+816 |     # another comment
+817 | 
+818 | try:
     | ^^^ E305
-799 |     fn()
-800 | except Exception:
+819 |     fn()
+820 | except Exception:
     |
     = help: Add missing blank line(s)
 
 ℹ Safe fix
-795 795 | 
-796 796 |     # another comment
-797 797 | 
-    798 |+
-798 799 | try:
-799 800 |     fn()
-800 801 | except Exception:
+815 815 | 
+816 816 |     # another comment
+817 817 | 
+    818 |+
+818 819 | try:
+819 820 |     fn()
+820 821 | except Exception:
 
-E30.py:810:1: E305 [*] Expected 2 blank lines after class or function definition, found (1)
+E30.py:830:1: E305 [*] Expected 2 blank lines after class or function definition, found (1)
     |
-809 | # Two spaces before comments, too.
-810 | if a():
+829 | # Two spaces before comments, too.
+830 | if a():
     | ^^ E305
-811 |     a()
-812 | # end
+831 |     a()
+832 | # end
     |
     = help: Add missing blank line(s)
 
 ℹ Safe fix
-807 807 |     print()
-808 808 | 
-809 809 | # Two spaces before comments, too.
-    810 |+
-    811 |+
-810 812 | if a():
-811 813 |     a()
-812 814 | # end
+827 827 |     print()
+828 828 | 
+829 829 | # Two spaces before comments, too.
+    830 |+
+    831 |+
+830 832 | if a():
+831 833 |     a()
+832 834 | # end
 
-E30.py:823:1: E305 [*] Expected 2 blank lines after class or function definition, found (1)
+E30.py:843:1: E305 [*] Expected 2 blank lines after class or function definition, found (1)
     |
-821 |     blah, blah
-822 | 
-823 | if __name__ == '__main__':
+841 |     blah, blah
+842 | 
+843 | if __name__ == '__main__':
     | ^^ E305
-824 |     main()
-825 | # end
+844 |     main()
+845 | # end
     |
     = help: Add missing blank line(s)
 
 ℹ Safe fix
-820 820 | def main():
-821 821 |     blah, blah
-822 822 | 
-    823 |+
-823 824 | if __name__ == '__main__':
-824 825 |     main()
-825 826 | # end
+840 840 | def main():
+841 841 |     blah, blah
+842 842 | 
+    843 |+
+843 844 | if __name__ == '__main__':
+844 845 |     main()
+845 846 | # end

--- a/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E306_E30.py.snap
+++ b/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E306_E30.py.snap
@@ -1,221 +1,221 @@
 ---
 source: crates/ruff_linter/src/rules/pycodestyle/mod.rs
 ---
-E30.py:831:5: E306 [*] Expected 1 blank line before a nested definition, found 0
+E30.py:851:5: E306 [*] Expected 1 blank line before a nested definition, found 0
     |
-829 | def a():
-830 |     x = 1
-831 |     def b():
+849 | def a():
+850 |     x = 1
+851 |     def b():
     |     ^^^ E306
-832 |         pass
-833 | # end
+852 |         pass
+853 | # end
     |
     = help: Add missing blank line
 
 ℹ Safe fix
-828 828 | # E306:3:5
-829 829 | def a():
-830 830 |     x = 1
-    831 |+
-831 832 |     def b():
-832 833 |         pass
-833 834 | # end
+848 848 | # E306:3:5
+849 849 | def a():
+850 850 |     x = 1
+    851 |+
+851 852 |     def b():
+852 853 |         pass
+853 854 | # end
 
-E30.py:839:5: E306 [*] Expected 1 blank line before a nested definition, found 0
+E30.py:859:5: E306 [*] Expected 1 blank line before a nested definition, found 0
     |
-837 | async def a():
-838 |     x = 1
-839 |     def b():
+857 | async def a():
+858 |     x = 1
+859 |     def b():
     |     ^^^ E306
-840 |         pass
-841 | # end
+860 |         pass
+861 | # end
     |
     = help: Add missing blank line
 
 ℹ Safe fix
-836 836 | #: E306:3:5
-837 837 | async def a():
-838 838 |     x = 1
-    839 |+
-839 840 |     def b():
-840 841 |         pass
-841 842 | # end
+856 856 | #: E306:3:5
+857 857 | async def a():
+858 858 |     x = 1
+    859 |+
+859 860 |     def b():
+860 861 |         pass
+861 862 | # end
 
-E30.py:847:5: E306 [*] Expected 1 blank line before a nested definition, found 0
+E30.py:867:5: E306 [*] Expected 1 blank line before a nested definition, found 0
     |
-845 | def a():
-846 |     x = 2
-847 |     def b():
+865 | def a():
+866 |     x = 2
+867 |     def b():
     |     ^^^ E306
-848 |         x = 1
-849 |         def c():
+868 |         x = 1
+869 |         def c():
     |
     = help: Add missing blank line
 
 ℹ Safe fix
-844 844 | #: E306:3:5 E306:5:9
-845 845 | def a():
-846 846 |     x = 2
-    847 |+
-847 848 |     def b():
-848 849 |         x = 1
-849 850 |         def c():
+864 864 | #: E306:3:5 E306:5:9
+865 865 | def a():
+866 866 |     x = 2
+    867 |+
+867 868 |     def b():
+868 869 |         x = 1
+869 870 |         def c():
 
-E30.py:849:9: E306 [*] Expected 1 blank line before a nested definition, found 0
+E30.py:869:9: E306 [*] Expected 1 blank line before a nested definition, found 0
     |
-847 |     def b():
-848 |         x = 1
-849 |         def c():
+867 |     def b():
+868 |         x = 1
+869 |         def c():
     |         ^^^ E306
-850 |             pass
-851 | # end
+870 |             pass
+871 | # end
     |
     = help: Add missing blank line
 
 ℹ Safe fix
-846 846 |     x = 2
-847 847 |     def b():
-848 848 |         x = 1
-    849 |+
-849 850 |         def c():
-850 851 |             pass
-851 852 | # end
-
-E30.py:857:5: E306 [*] Expected 1 blank line before a nested definition, found 0
-    |
-855 | def a():
-856 |     x = 1
-857 |     class C:
-    |     ^^^^^ E306
-858 |         pass
-859 |     x = 2
-    |
-    = help: Add missing blank line
-
-ℹ Safe fix
-854 854 | # E306:3:5 E306:6:5
-855 855 | def a():
-856 856 |     x = 1
-    857 |+
-857 858 |     class C:
-858 859 |         pass
-859 860 |     x = 2
-
-E30.py:860:5: E306 [*] Expected 1 blank line before a nested definition, found 0
-    |
-858 |         pass
-859 |     x = 2
-860 |     def b():
-    |     ^^^ E306
-861 |         pass
-862 | # end
-    |
-    = help: Add missing blank line
-
-ℹ Safe fix
-857 857 |     class C:
-858 858 |         pass
-859 859 |     x = 2
-    860 |+
-860 861 |     def b():
-861 862 |         pass
-862 863 | # end
-
-E30.py:869:5: E306 [*] Expected 1 blank line before a nested definition, found 0
-    |
-867 |     def bar():
-868 |         pass
-869 |     def baz(): pass
-    |     ^^^ E306
-870 | # end
-    |
-    = help: Add missing blank line
-
-ℹ Safe fix
-866 866 | def foo():
-867 867 |     def bar():
-868 868 |         pass
+866 866 |     x = 2
+867 867 |     def b():
+868 868 |         x = 1
     869 |+
-869 870 |     def baz(): pass
-870 871 | # end
-871 872 | 
+869 870 |         def c():
+870 871 |             pass
+871 872 | # end
 
-E30.py:876:5: E306 [*] Expected 1 blank line before a nested definition, found 0
+E30.py:877:5: E306 [*] Expected 1 blank line before a nested definition, found 0
     |
-874 | def foo():
-875 |     def bar(): pass
-876 |     def baz():
-    |     ^^^ E306
-877 |         pass
-878 | # end
-    |
-    = help: Add missing blank line
-
-ℹ Safe fix
-873 873 | # E306:3:5
-874 874 | def foo():
-875 875 |     def bar(): pass
-    876 |+
-876 877 |     def baz():
-877 878 |         pass
-878 879 | # end
-
-E30.py:884:5: E306 [*] Expected 1 blank line before a nested definition, found 0
-    |
-882 | def a():
-883 |     x = 2
-884 |     @decorator
-    |     ^ E306
-885 |     def b():
-886 |         pass
-    |
-    = help: Add missing blank line
-
-ℹ Safe fix
-881 881 | # E306
-882 882 | def a():
-883 883 |     x = 2
-    884 |+
-884 885 |     @decorator
-885 886 |     def b():
-886 887 |         pass
-
-E30.py:893:5: E306 [*] Expected 1 blank line before a nested definition, found 0
-    |
-891 | def a():
-892 |     x = 2
-893 |     @decorator
-    |     ^ E306
-894 |     async def b():
-895 |         pass
-    |
-    = help: Add missing blank line
-
-ℹ Safe fix
-890 890 | # E306
-891 891 | def a():
-892 892 |     x = 2
-    893 |+
-893 894 |     @decorator
-894 895 |     async def b():
-895 896 |         pass
-
-E30.py:902:5: E306 [*] Expected 1 blank line before a nested definition, found 0
-    |
-900 | def a():
-901 |     x = 2
-902 |     async def b():
+875 | def a():
+876 |     x = 1
+877 |     class C:
     |     ^^^^^ E306
-903 |         pass
-904 | # end
+878 |         pass
+879 |     x = 2
     |
     = help: Add missing blank line
 
 ℹ Safe fix
-899 899 | # E306
-900 900 | def a():
-901 901 |     x = 2
-    902 |+
-902 903 |     async def b():
-903 904 |         pass
-904 905 | # end
+874 874 | # E306:3:5 E306:6:5
+875 875 | def a():
+876 876 |     x = 1
+    877 |+
+877 878 |     class C:
+878 879 |         pass
+879 880 |     x = 2
+
+E30.py:880:5: E306 [*] Expected 1 blank line before a nested definition, found 0
+    |
+878 |         pass
+879 |     x = 2
+880 |     def b():
+    |     ^^^ E306
+881 |         pass
+882 | # end
+    |
+    = help: Add missing blank line
+
+ℹ Safe fix
+877 877 |     class C:
+878 878 |         pass
+879 879 |     x = 2
+    880 |+
+880 881 |     def b():
+881 882 |         pass
+882 883 | # end
+
+E30.py:889:5: E306 [*] Expected 1 blank line before a nested definition, found 0
+    |
+887 |     def bar():
+888 |         pass
+889 |     def baz(): pass
+    |     ^^^ E306
+890 | # end
+    |
+    = help: Add missing blank line
+
+ℹ Safe fix
+886 886 | def foo():
+887 887 |     def bar():
+888 888 |         pass
+    889 |+
+889 890 |     def baz(): pass
+890 891 | # end
+891 892 | 
+
+E30.py:896:5: E306 [*] Expected 1 blank line before a nested definition, found 0
+    |
+894 | def foo():
+895 |     def bar(): pass
+896 |     def baz():
+    |     ^^^ E306
+897 |         pass
+898 | # end
+    |
+    = help: Add missing blank line
+
+ℹ Safe fix
+893 893 | # E306:3:5
+894 894 | def foo():
+895 895 |     def bar(): pass
+    896 |+
+896 897 |     def baz():
+897 898 |         pass
+898 899 | # end
+
+E30.py:904:5: E306 [*] Expected 1 blank line before a nested definition, found 0
+    |
+902 | def a():
+903 |     x = 2
+904 |     @decorator
+    |     ^ E306
+905 |     def b():
+906 |         pass
+    |
+    = help: Add missing blank line
+
+ℹ Safe fix
+901 901 | # E306
+902 902 | def a():
+903 903 |     x = 2
+    904 |+
+904 905 |     @decorator
+905 906 |     def b():
+906 907 |         pass
+
+E30.py:913:5: E306 [*] Expected 1 blank line before a nested definition, found 0
+    |
+911 | def a():
+912 |     x = 2
+913 |     @decorator
+    |     ^ E306
+914 |     async def b():
+915 |         pass
+    |
+    = help: Add missing blank line
+
+ℹ Safe fix
+910 910 | # E306
+911 911 | def a():
+912 912 |     x = 2
+    913 |+
+913 914 |     @decorator
+914 915 |     async def b():
+915 916 |         pass
+
+E30.py:922:5: E306 [*] Expected 1 blank line before a nested definition, found 0
+    |
+920 | def a():
+921 |     x = 2
+922 |     async def b():
+    |     ^^^^^ E306
+923 |         pass
+924 | # end
+    |
+    = help: Add missing blank line
+
+ℹ Safe fix
+919 919 | # E306
+920 920 | def a():
+921 921 |     x = 2
+    922 |+
+922 923 |     async def b():
+923 924 |         pass
+924 925 | # end

--- a/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E306_E30.py.snap
+++ b/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E306_E30.py.snap
@@ -1,223 +1,221 @@
 ---
 source: crates/ruff_linter/src/rules/pycodestyle/mod.rs
 ---
-E30.py:798:5: E306 [*] Expected 1 blank line before a nested definition, found 0
+E30.py:831:5: E306 [*] Expected 1 blank line before a nested definition, found 0
     |
-796 | def a():
-797 |     x = 1
-798 |     def b():
+829 | def a():
+830 |     x = 1
+831 |     def b():
     |     ^^^ E306
-799 |         pass
-800 | # end
+832 |         pass
+833 | # end
     |
     = help: Add missing blank line
 
 ℹ Safe fix
-795 795 | # E306:3:5
-796 796 | def a():
-797 797 |     x = 1
-    798 |+
-798 799 |     def b():
-799 800 |         pass
-800 801 | # end
+828 828 | # E306:3:5
+829 829 | def a():
+830 830 |     x = 1
+    831 |+
+831 832 |     def b():
+832 833 |         pass
+833 834 | # end
 
-E30.py:806:5: E306 [*] Expected 1 blank line before a nested definition, found 0
+E30.py:839:5: E306 [*] Expected 1 blank line before a nested definition, found 0
     |
-804 | async def a():
-805 |     x = 1
-806 |     def b():
+837 | async def a():
+838 |     x = 1
+839 |     def b():
     |     ^^^ E306
-807 |         pass
-808 | # end
+840 |         pass
+841 | # end
     |
     = help: Add missing blank line
 
 ℹ Safe fix
-803 803 | #: E306:3:5
-804 804 | async def a():
-805 805 |     x = 1
-    806 |+
-806 807 |     def b():
-807 808 |         pass
-808 809 | # end
+836 836 | #: E306:3:5
+837 837 | async def a():
+838 838 |     x = 1
+    839 |+
+839 840 |     def b():
+840 841 |         pass
+841 842 | # end
 
-E30.py:814:5: E306 [*] Expected 1 blank line before a nested definition, found 0
+E30.py:847:5: E306 [*] Expected 1 blank line before a nested definition, found 0
     |
-812 | def a():
-813 |     x = 2
-814 |     def b():
+845 | def a():
+846 |     x = 2
+847 |     def b():
     |     ^^^ E306
-815 |         x = 1
-816 |         def c():
+848 |         x = 1
+849 |         def c():
     |
     = help: Add missing blank line
 
 ℹ Safe fix
-811 811 | #: E306:3:5 E306:5:9
-812 812 | def a():
-813 813 |     x = 2
-    814 |+
-814 815 |     def b():
-815 816 |         x = 1
-816 817 |         def c():
+844 844 | #: E306:3:5 E306:5:9
+845 845 | def a():
+846 846 |     x = 2
+    847 |+
+847 848 |     def b():
+848 849 |         x = 1
+849 850 |         def c():
 
-E30.py:816:9: E306 [*] Expected 1 blank line before a nested definition, found 0
+E30.py:849:9: E306 [*] Expected 1 blank line before a nested definition, found 0
     |
-814 |     def b():
-815 |         x = 1
-816 |         def c():
+847 |     def b():
+848 |         x = 1
+849 |         def c():
     |         ^^^ E306
-817 |             pass
-818 | # end
+850 |             pass
+851 | # end
     |
     = help: Add missing blank line
 
 ℹ Safe fix
-813 813 |     x = 2
-814 814 |     def b():
-815 815 |         x = 1
-    816 |+
-816 817 |         def c():
-817 818 |             pass
-818 819 | # end
+846 846 |     x = 2
+847 847 |     def b():
+848 848 |         x = 1
+    849 |+
+849 850 |         def c():
+850 851 |             pass
+851 852 | # end
 
-E30.py:824:5: E306 [*] Expected 1 blank line before a nested definition, found 0
+E30.py:857:5: E306 [*] Expected 1 blank line before a nested definition, found 0
     |
-822 | def a():
-823 |     x = 1
-824 |     class C:
+855 | def a():
+856 |     x = 1
+857 |     class C:
     |     ^^^^^ E306
-825 |         pass
-826 |     x = 2
+858 |         pass
+859 |     x = 2
     |
     = help: Add missing blank line
 
 ℹ Safe fix
-821 821 | # E306:3:5 E306:6:5
-822 822 | def a():
-823 823 |     x = 1
-    824 |+
-824 825 |     class C:
-825 826 |         pass
-826 827 |     x = 2
-
-E30.py:827:5: E306 [*] Expected 1 blank line before a nested definition, found 0
-    |
-825 |         pass
-826 |     x = 2
-827 |     def b():
-    |     ^^^ E306
-828 |         pass
-829 | # end
-    |
-    = help: Add missing blank line
-
-ℹ Safe fix
-824 824 |     class C:
-825 825 |         pass
-826 826 |     x = 2
-    827 |+
-827 828 |     def b():
-828 829 |         pass
-829 830 | # end
-
-E30.py:836:5: E306 [*] Expected 1 blank line before a nested definition, found 0
-    |
-834 |     def bar():
-835 |         pass
-836 |     def baz(): pass
-    |     ^^^ E306
-837 | # end
-    |
-    = help: Add missing blank line
-
-ℹ Safe fix
-833 833 | def foo():
-834 834 |     def bar():
-835 835 |         pass
-    836 |+
-836 837 |     def baz(): pass
-837 838 | # end
-838 839 | 
-
-E30.py:843:5: E306 [*] Expected 1 blank line before a nested definition, found 0
-    |
-841 | def foo():
-842 |     def bar(): pass
-843 |     def baz():
-    |     ^^^ E306
-844 |         pass
-845 | # end
-    |
-    = help: Add missing blank line
-
-ℹ Safe fix
-840 840 | # E306:3:5
-841 841 | def foo():
-842 842 |     def bar(): pass
-    843 |+
-843 844 |     def baz():
-844 845 |         pass
-845 846 | # end
-
-E30.py:851:5: E306 [*] Expected 1 blank line before a nested definition, found 0
-    |
-849 | def a():
-850 |     x = 2
-851 |     @decorator
-    |     ^ E306
-852 |     def b():
-853 |         pass
-    |
-    = help: Add missing blank line
-
-ℹ Safe fix
-848 848 | # E306
-849 849 | def a():
-850 850 |     x = 2
-    851 |+
-851 852 |     @decorator
-852 853 |     def b():
-853 854 |         pass
+854 854 | # E306:3:5 E306:6:5
+855 855 | def a():
+856 856 |     x = 1
+    857 |+
+857 858 |     class C:
+858 859 |         pass
+859 860 |     x = 2
 
 E30.py:860:5: E306 [*] Expected 1 blank line before a nested definition, found 0
     |
-858 | def a():
+858 |         pass
 859 |     x = 2
-860 |     @decorator
-    |     ^ E306
-861 |     async def b():
-862 |         pass
+860 |     def b():
+    |     ^^^ E306
+861 |         pass
+862 | # end
     |
     = help: Add missing blank line
 
 ℹ Safe fix
-857 857 | # E306
-858 858 | def a():
+857 857 |     class C:
+858 858 |         pass
 859 859 |     x = 2
     860 |+
-860 861 |     @decorator
-861 862 |     async def b():
-862 863 |         pass
+860 861 |     def b():
+861 862 |         pass
+862 863 | # end
 
 E30.py:869:5: E306 [*] Expected 1 blank line before a nested definition, found 0
     |
-867 | def a():
-868 |     x = 2
-869 |     async def b():
-    |     ^^^^^ E306
-870 |         pass
-871 | # end
+867 |     def bar():
+868 |         pass
+869 |     def baz(): pass
+    |     ^^^ E306
+870 | # end
     |
     = help: Add missing blank line
 
 ℹ Safe fix
-866 866 | # E306
-867 867 | def a():
-868 868 |     x = 2
+866 866 | def foo():
+867 867 |     def bar():
+868 868 |         pass
     869 |+
-869 870 |     async def b():
-870 871 |         pass
-871 872 | # end
+869 870 |     def baz(): pass
+870 871 | # end
+871 872 | 
 
+E30.py:876:5: E306 [*] Expected 1 blank line before a nested definition, found 0
+    |
+874 | def foo():
+875 |     def bar(): pass
+876 |     def baz():
+    |     ^^^ E306
+877 |         pass
+878 | # end
+    |
+    = help: Add missing blank line
 
+ℹ Safe fix
+873 873 | # E306:3:5
+874 874 | def foo():
+875 875 |     def bar(): pass
+    876 |+
+876 877 |     def baz():
+877 878 |         pass
+878 879 | # end
+
+E30.py:884:5: E306 [*] Expected 1 blank line before a nested definition, found 0
+    |
+882 | def a():
+883 |     x = 2
+884 |     @decorator
+    |     ^ E306
+885 |     def b():
+886 |         pass
+    |
+    = help: Add missing blank line
+
+ℹ Safe fix
+881 881 | # E306
+882 882 | def a():
+883 883 |     x = 2
+    884 |+
+884 885 |     @decorator
+885 886 |     def b():
+886 887 |         pass
+
+E30.py:893:5: E306 [*] Expected 1 blank line before a nested definition, found 0
+    |
+891 | def a():
+892 |     x = 2
+893 |     @decorator
+    |     ^ E306
+894 |     async def b():
+895 |         pass
+    |
+    = help: Add missing blank line
+
+ℹ Safe fix
+890 890 | # E306
+891 891 | def a():
+892 892 |     x = 2
+    893 |+
+893 894 |     @decorator
+894 895 |     async def b():
+895 896 |         pass
+
+E30.py:902:5: E306 [*] Expected 1 blank line before a nested definition, found 0
+    |
+900 | def a():
+901 |     x = 2
+902 |     async def b():
+    |     ^^^^^ E306
+903 |         pass
+904 | # end
+    |
+    = help: Add missing blank line
+
+ℹ Safe fix
+899 899 | # E306
+900 900 | def a():
+901 901 |     x = 2
+    902 |+
+902 903 |     async def b():
+903 904 |         pass
+904 905 | # end

--- a/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E306_E30.py.snap
+++ b/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E306_E30.py.snap
@@ -1,221 +1,221 @@
 ---
 source: crates/ruff_linter/src/rules/pycodestyle/mod.rs
 ---
-E30.py:851:5: E306 [*] Expected 1 blank line before a nested definition, found 0
+E30.py:862:5: E306 [*] Expected 1 blank line before a nested definition, found 0
     |
-849 | def a():
-850 |     x = 1
-851 |     def b():
+860 | def a():
+861 |     x = 1
+862 |     def b():
     |     ^^^ E306
-852 |         pass
-853 | # end
+863 |         pass
+864 | # end
     |
     = help: Add missing blank line
 
 ℹ Safe fix
-848 848 | # E306:3:5
-849 849 | def a():
-850 850 |     x = 1
-    851 |+
-851 852 |     def b():
-852 853 |         pass
-853 854 | # end
+859 859 | # E306:3:5
+860 860 | def a():
+861 861 |     x = 1
+    862 |+
+862 863 |     def b():
+863 864 |         pass
+864 865 | # end
 
-E30.py:859:5: E306 [*] Expected 1 blank line before a nested definition, found 0
+E30.py:870:5: E306 [*] Expected 1 blank line before a nested definition, found 0
     |
-857 | async def a():
-858 |     x = 1
-859 |     def b():
+868 | async def a():
+869 |     x = 1
+870 |     def b():
     |     ^^^ E306
-860 |         pass
-861 | # end
+871 |         pass
+872 | # end
     |
     = help: Add missing blank line
 
 ℹ Safe fix
-856 856 | #: E306:3:5
-857 857 | async def a():
-858 858 |     x = 1
-    859 |+
-859 860 |     def b():
-860 861 |         pass
-861 862 | # end
+867 867 | #: E306:3:5
+868 868 | async def a():
+869 869 |     x = 1
+    870 |+
+870 871 |     def b():
+871 872 |         pass
+872 873 | # end
 
-E30.py:867:5: E306 [*] Expected 1 blank line before a nested definition, found 0
+E30.py:878:5: E306 [*] Expected 1 blank line before a nested definition, found 0
     |
-865 | def a():
-866 |     x = 2
-867 |     def b():
+876 | def a():
+877 |     x = 2
+878 |     def b():
     |     ^^^ E306
-868 |         x = 1
-869 |         def c():
+879 |         x = 1
+880 |         def c():
     |
     = help: Add missing blank line
 
 ℹ Safe fix
-864 864 | #: E306:3:5 E306:5:9
-865 865 | def a():
-866 866 |     x = 2
-    867 |+
-867 868 |     def b():
-868 869 |         x = 1
-869 870 |         def c():
+875 875 | #: E306:3:5 E306:5:9
+876 876 | def a():
+877 877 |     x = 2
+    878 |+
+878 879 |     def b():
+879 880 |         x = 1
+880 881 |         def c():
 
-E30.py:869:9: E306 [*] Expected 1 blank line before a nested definition, found 0
+E30.py:880:9: E306 [*] Expected 1 blank line before a nested definition, found 0
     |
-867 |     def b():
-868 |         x = 1
-869 |         def c():
+878 |     def b():
+879 |         x = 1
+880 |         def c():
     |         ^^^ E306
-870 |             pass
-871 | # end
-    |
-    = help: Add missing blank line
-
-ℹ Safe fix
-866 866 |     x = 2
-867 867 |     def b():
-868 868 |         x = 1
-    869 |+
-869 870 |         def c():
-870 871 |             pass
-871 872 | # end
-
-E30.py:877:5: E306 [*] Expected 1 blank line before a nested definition, found 0
-    |
-875 | def a():
-876 |     x = 1
-877 |     class C:
-    |     ^^^^^ E306
-878 |         pass
-879 |     x = 2
-    |
-    = help: Add missing blank line
-
-ℹ Safe fix
-874 874 | # E306:3:5 E306:6:5
-875 875 | def a():
-876 876 |     x = 1
-    877 |+
-877 878 |     class C:
-878 879 |         pass
-879 880 |     x = 2
-
-E30.py:880:5: E306 [*] Expected 1 blank line before a nested definition, found 0
-    |
-878 |         pass
-879 |     x = 2
-880 |     def b():
-    |     ^^^ E306
-881 |         pass
+881 |             pass
 882 | # end
     |
     = help: Add missing blank line
 
 ℹ Safe fix
-877 877 |     class C:
-878 878 |         pass
-879 879 |     x = 2
+877 877 |     x = 2
+878 878 |     def b():
+879 879 |         x = 1
     880 |+
-880 881 |     def b():
-881 882 |         pass
+880 881 |         def c():
+881 882 |             pass
 882 883 | # end
 
-E30.py:889:5: E306 [*] Expected 1 blank line before a nested definition, found 0
+E30.py:888:5: E306 [*] Expected 1 blank line before a nested definition, found 0
     |
-887 |     def bar():
-888 |         pass
-889 |     def baz(): pass
-    |     ^^^ E306
-890 | # end
-    |
-    = help: Add missing blank line
-
-ℹ Safe fix
-886 886 | def foo():
-887 887 |     def bar():
-888 888 |         pass
-    889 |+
-889 890 |     def baz(): pass
-890 891 | # end
-891 892 | 
-
-E30.py:896:5: E306 [*] Expected 1 blank line before a nested definition, found 0
-    |
-894 | def foo():
-895 |     def bar(): pass
-896 |     def baz():
-    |     ^^^ E306
-897 |         pass
-898 | # end
-    |
-    = help: Add missing blank line
-
-ℹ Safe fix
-893 893 | # E306:3:5
-894 894 | def foo():
-895 895 |     def bar(): pass
-    896 |+
-896 897 |     def baz():
-897 898 |         pass
-898 899 | # end
-
-E30.py:904:5: E306 [*] Expected 1 blank line before a nested definition, found 0
-    |
-902 | def a():
-903 |     x = 2
-904 |     @decorator
-    |     ^ E306
-905 |     def b():
-906 |         pass
-    |
-    = help: Add missing blank line
-
-ℹ Safe fix
-901 901 | # E306
-902 902 | def a():
-903 903 |     x = 2
-    904 |+
-904 905 |     @decorator
-905 906 |     def b():
-906 907 |         pass
-
-E30.py:913:5: E306 [*] Expected 1 blank line before a nested definition, found 0
-    |
-911 | def a():
-912 |     x = 2
-913 |     @decorator
-    |     ^ E306
-914 |     async def b():
-915 |         pass
-    |
-    = help: Add missing blank line
-
-ℹ Safe fix
-910 910 | # E306
-911 911 | def a():
-912 912 |     x = 2
-    913 |+
-913 914 |     @decorator
-914 915 |     async def b():
-915 916 |         pass
-
-E30.py:922:5: E306 [*] Expected 1 blank line before a nested definition, found 0
-    |
-920 | def a():
-921 |     x = 2
-922 |     async def b():
+886 | def a():
+887 |     x = 1
+888 |     class C:
     |     ^^^^^ E306
-923 |         pass
-924 | # end
+889 |         pass
+890 |     x = 2
     |
     = help: Add missing blank line
 
 ℹ Safe fix
-919 919 | # E306
-920 920 | def a():
-921 921 |     x = 2
-    922 |+
-922 923 |     async def b():
-923 924 |         pass
-924 925 | # end
+885 885 | # E306:3:5 E306:6:5
+886 886 | def a():
+887 887 |     x = 1
+    888 |+
+888 889 |     class C:
+889 890 |         pass
+890 891 |     x = 2
+
+E30.py:891:5: E306 [*] Expected 1 blank line before a nested definition, found 0
+    |
+889 |         pass
+890 |     x = 2
+891 |     def b():
+    |     ^^^ E306
+892 |         pass
+893 | # end
+    |
+    = help: Add missing blank line
+
+ℹ Safe fix
+888 888 |     class C:
+889 889 |         pass
+890 890 |     x = 2
+    891 |+
+891 892 |     def b():
+892 893 |         pass
+893 894 | # end
+
+E30.py:900:5: E306 [*] Expected 1 blank line before a nested definition, found 0
+    |
+898 |     def bar():
+899 |         pass
+900 |     def baz(): pass
+    |     ^^^ E306
+901 | # end
+    |
+    = help: Add missing blank line
+
+ℹ Safe fix
+897 897 | def foo():
+898 898 |     def bar():
+899 899 |         pass
+    900 |+
+900 901 |     def baz(): pass
+901 902 | # end
+902 903 | 
+
+E30.py:907:5: E306 [*] Expected 1 blank line before a nested definition, found 0
+    |
+905 | def foo():
+906 |     def bar(): pass
+907 |     def baz():
+    |     ^^^ E306
+908 |         pass
+909 | # end
+    |
+    = help: Add missing blank line
+
+ℹ Safe fix
+904 904 | # E306:3:5
+905 905 | def foo():
+906 906 |     def bar(): pass
+    907 |+
+907 908 |     def baz():
+908 909 |         pass
+909 910 | # end
+
+E30.py:915:5: E306 [*] Expected 1 blank line before a nested definition, found 0
+    |
+913 | def a():
+914 |     x = 2
+915 |     @decorator
+    |     ^ E306
+916 |     def b():
+917 |         pass
+    |
+    = help: Add missing blank line
+
+ℹ Safe fix
+912 912 | # E306
+913 913 | def a():
+914 914 |     x = 2
+    915 |+
+915 916 |     @decorator
+916 917 |     def b():
+917 918 |         pass
+
+E30.py:924:5: E306 [*] Expected 1 blank line before a nested definition, found 0
+    |
+922 | def a():
+923 |     x = 2
+924 |     @decorator
+    |     ^ E306
+925 |     async def b():
+926 |         pass
+    |
+    = help: Add missing blank line
+
+ℹ Safe fix
+921 921 | # E306
+922 922 | def a():
+923 923 |     x = 2
+    924 |+
+924 925 |     @decorator
+925 926 |     async def b():
+926 927 |         pass
+
+E30.py:933:5: E306 [*] Expected 1 blank line before a nested definition, found 0
+    |
+931 | def a():
+932 |     x = 2
+933 |     async def b():
+    |     ^^^^^ E306
+934 |         pass
+935 | # end
+    |
+    = help: Add missing blank line
+
+ℹ Safe fix
+930 930 | # E306
+931 931 | def a():
+932 932 |     x = 2
+    933 |+
+933 934 |     async def b():
+934 935 |         pass
+935 936 | # end


### PR DESCRIPTION
## Summary

Closes #10211

This PR keeps track of functions with a dummy body, and does not trigger `E301`, `E302` or `E306` on defs following functions with a dummy body.

## Test Plan

The code snippets from the issue have been added to the fixture.
On that note, so far the test cases for the `E3` rules have been grouped by rule, since it made things easier when checking the results by hand. However it now makes it harder to review the snapshots (here nothing really changed, only line numbers), so I can add the new tests at the end of the fixture file if that makes things easier.