### PR TITLE
Renovate: group all `strum` dependencies together

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -46,6 +46,12 @@
       matchPackagePatterns: ["monaco"],
       description: "Weekly update of the Monaco editor",
     },
+    {
+      groupName: "strum",
+      matchManagers: ["cargo"],
+      matchPackagePatterns: ["strum"],
+      description: "Weekly update of strum dependencies",
+    },
   ],
   vulnerabilityAlerts: {
     commitMessageSuffix: "",


### PR DESCRIPTION
If renovate tries to update these individually, we get errors like the ones we're seeing in #10708 and #10707