### PR TITLE
Respect `Q00*` ignores in `flake8-quotes` rules

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_quotes/doubles_all.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_quotes/doubles_all.py
@@ -1,0 +1,7 @@
+"""This is a docstring."""
+
+this_is_an_inline_string = "double quote string"
+
+this_is_a_multiline_string = """
+double quote string
+"""

--- a/crates/ruff_linter/src/rules/flake8_quotes/mod.rs
+++ b/crates/ruff_linter/src/rules/flake8_quotes/mod.rs
@@ -195,4 +195,61 @@ mod tests {
         assert_messages!(snapshot, diagnostics);
         Ok(())
     }
+
+    #[test_case(Path::new("doubles_all.py"))]
+    fn only_inline(path: &Path) -> Result<()> {
+        let snapshot = format!("only_inline_{}", path.to_string_lossy());
+        let diagnostics = test_path(
+            Path::new("flake8_quotes").join(path).as_path(),
+            &LinterSettings {
+                flake8_quotes: super::settings::Settings {
+                    inline_quotes: Quote::Single,
+                    multiline_quotes: Quote::Single,
+                    docstring_quotes: Quote::Single,
+                    avoid_escape: true,
+                },
+                ..LinterSettings::for_rules(vec![Rule::BadQuotesInlineString])
+            },
+        )?;
+        assert_messages!(snapshot, diagnostics);
+        Ok(())
+    }
+
+    #[test_case(Path::new("doubles_all.py"))]
+    fn only_multiline(path: &Path) -> Result<()> {
+        let snapshot = format!("only_multiline_{}", path.to_string_lossy());
+        let diagnostics = test_path(
+            Path::new("flake8_quotes").join(path).as_path(),
+            &LinterSettings {
+                flake8_quotes: super::settings::Settings {
+                    inline_quotes: Quote::Single,
+                    multiline_quotes: Quote::Single,
+                    docstring_quotes: Quote::Single,
+                    avoid_escape: true,
+                },
+                ..LinterSettings::for_rules(vec![Rule::BadQuotesMultilineString])
+            },
+        )?;
+        assert_messages!(snapshot, diagnostics);
+        Ok(())
+    }
+
+    #[test_case(Path::new("doubles_all.py"))]
+    fn only_docstring(path: &Path) -> Result<()> {
+        let snapshot = format!("only_docstring_{}", path.to_string_lossy());
+        let diagnostics = test_path(
+            Path::new("flake8_quotes").join(path).as_path(),
+            &LinterSettings {
+                flake8_quotes: super::settings::Settings {
+                    inline_quotes: Quote::Single,
+                    multiline_quotes: Quote::Single,
+                    docstring_quotes: Quote::Single,
+                    avoid_escape: true,
+                },
+                ..LinterSettings::for_rules(vec![Rule::BadQuotesDocstring])
+            },
+        )?;
+        assert_messages!(snapshot, diagnostics);
+        Ok(())
+    }
 }

--- a/crates/ruff_linter/src/rules/flake8_quotes/snapshots/ruff_linter__rules__flake8_quotes__tests__only_docstring_doubles_all.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_quotes/snapshots/ruff_linter__rules__flake8_quotes__tests__only_docstring_doubles_all.py.snap
@@ -1,0 +1,18 @@
+---
+source: crates/ruff_linter/src/rules/flake8_quotes/mod.rs
+---
+doubles_all.py:1:1: Q002 [*] Double quote docstring found but single quotes preferred
+  |
+1 | """This is a docstring."""
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^ Q002
+2 | 
+3 | this_is_an_inline_string = "double quote string"
+  |
+  = help: Replace double quotes docstring with single quotes
+
+ℹ Safe fix
+1   |-"""This is a docstring."""
+  1 |+'''This is a docstring.'''
+2 2 | 
+3 3 | this_is_an_inline_string = "double quote string"
+4 4 |

--- a/crates/ruff_linter/src/rules/flake8_quotes/snapshots/ruff_linter__rules__flake8_quotes__tests__only_inline_doubles_all.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_quotes/snapshots/ruff_linter__rules__flake8_quotes__tests__only_inline_doubles_all.py.snap
@@ -1,0 +1,22 @@
+---
+source: crates/ruff_linter/src/rules/flake8_quotes/mod.rs
+---
+doubles_all.py:3:28: Q000 [*] Double quotes found but single quotes preferred
+  |
+1 | """This is a docstring."""
+2 | 
+3 | this_is_an_inline_string = "double quote string"
+  |                            ^^^^^^^^^^^^^^^^^^^^^ Q000
+4 | 
+5 | this_is_a_multiline_string = """
+  |
+  = help: Replace double quotes with single quotes
+
+ℹ Safe fix
+1 1 | """This is a docstring."""
+2 2 | 
+3   |-this_is_an_inline_string = "double quote string"
+  3 |+this_is_an_inline_string = 'double quote string'
+4 4 | 
+5 5 | this_is_a_multiline_string = """
+6 6 | double quote string

--- a/crates/ruff_linter/src/rules/flake8_quotes/snapshots/ruff_linter__rules__flake8_quotes__tests__only_multiline_doubles_all.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_quotes/snapshots/ruff_linter__rules__flake8_quotes__tests__only_multiline_doubles_all.py.snap
@@ -1,0 +1,24 @@
+---
+source: crates/ruff_linter/src/rules/flake8_quotes/mod.rs
+---
+doubles_all.py:5:30: Q001 [*] Double quote multiline found but single quotes preferred
+  |
+3 |   this_is_an_inline_string = "double quote string"
+4 |   
+5 |   this_is_a_multiline_string = """
+  |  ______________________________^
+6 | | double quote string
+7 | | """
+  | |___^ Q001
+  |
+  = help: Replace double multiline quotes with single quotes
+
+ℹ Safe fix
+2 2 | 
+3 3 | this_is_an_inline_string = "double quote string"
+4 4 | 
+5   |-this_is_a_multiline_string = """
+  5 |+this_is_a_multiline_string = '''
+6 6 | double quote string
+7   |-"""
+  7 |+'''


### PR DESCRIPTION
## Summary

We lost the per-rule ignores when these were migrated to the AST, so if _any_ `Q` rule is enabled, they're now all enabled.

Closes https://github.com/astral-sh/ruff/issues/10724.

## Test Plan

Ran:

```shell
ruff check . --isolated --select Q --ignore Q000
ruff check . --isolated --select Q --ignore Q001
ruff check . --isolated --select Q --ignore Q002
ruff check . --isolated --select Q --ignore Q000,Q001
ruff check . --isolated --select Q --ignore Q000,Q002
ruff check . --isolated --select Q --ignore Q001,Q002
```

...against:

```python
'''
bad docsting
'''
a = 'single'
b = '''
bad multi line
'''
```
