### PR TITLE
Accept non-aliased (but correct) import in unconventional-import-alias

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_import_conventions/defaults.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_import_conventions/defaults.py
@@ -21,6 +21,7 @@ def unconventional_aliases():
     import tkinter as tkr
     import networkx as nxy
 
+
 def conventional_aliases():
     import altair as alt
     import matplotlib.pyplot as plt

--- a/crates/ruff_linter/resources/test/fixtures/flake8_import_conventions/same_name.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_import_conventions/same_name.py
@@ -1,0 +1,10 @@
+def no_alias():
+    from django.conf import settings
+
+
+def conventional_alias():
+    from django.conf import settings as settings
+
+
+def unconventional_alias():
+    from django.conf import settings as s

--- a/crates/ruff_linter/src/rules/flake8_import_conventions/mod.rs
+++ b/crates/ruff_linter/src/rules/flake8_import_conventions/mod.rs
@@ -27,7 +27,7 @@ mod tests {
 
     #[test]
     fn custom() -> Result<()> {
-        let mut aliases = super::settings::default_aliases();
+        let mut aliases = default_aliases();
         aliases.extend(FxHashMap::from_iter([
             ("dask.array".to_string(), "da".to_string()),
             ("dask.dataframe".to_string(), "dd".to_string()),
@@ -126,7 +126,7 @@ mod tests {
 
     #[test]
     fn override_defaults() -> Result<()> {
-        let mut aliases = super::settings::default_aliases();
+        let mut aliases = default_aliases();
         aliases.extend(FxHashMap::from_iter([(
             "numpy".to_string(),
             "nmp".to_string(),
@@ -149,7 +149,7 @@ mod tests {
 
     #[test]
     fn from_imports() -> Result<()> {
-        let mut aliases = super::settings::default_aliases();
+        let mut aliases = default_aliases();
         aliases.extend(FxHashMap::from_iter([
             ("xml.dom.minidom".to_string(), "md".to_string()),
             (
@@ -178,6 +178,28 @@ mod tests {
         let diagnostics = test_path(
             Path::new("flake8_import_conventions/tricky.py"),
             &LinterSettings::for_rule(Rule::UnconventionalImportAlias),
+        )?;
+        assert_messages!(diagnostics);
+        Ok(())
+    }
+
+    #[test]
+    fn same_name() -> Result<()> {
+        let mut aliases = default_aliases();
+        aliases.extend(FxHashMap::from_iter([(
+            "django.conf.settings".to_string(),
+            "settings".to_string(),
+        )]));
+        let diagnostics = test_path(
+            Path::new("flake8_import_conventions/same_name.py"),
+            &LinterSettings {
+                flake8_import_conventions: super::settings::Settings {
+                    aliases,
+                    banned_aliases: FxHashMap::default(),
+                    banned_from: FxHashSet::default(),
+                },
+                ..LinterSettings::for_rule(Rule::UnconventionalImportAlias)
+            },
         )?;
         assert_messages!(diagnostics);
         Ok(())

--- a/crates/ruff_linter/src/rules/flake8_import_conventions/rules/unconventional_import_alias.rs
+++ b/crates/ruff_linter/src/rules/flake8_import_conventions/rules/unconventional_import_alias.rs
@@ -66,7 +66,7 @@ pub(crate) fn unconventional_import_alias(
     let expected_alias = conventions.get(qualified_name.as_str())?;
 
     let name = binding.name(checker.locator());
-    if binding.is_alias() && name == expected_alias {
+    if name == expected_alias {
         return None;
     }
 

--- a/crates/ruff_linter/src/rules/flake8_import_conventions/snapshots/ruff_linter__rules__flake8_import_conventions__tests__defaults.snap
+++ b/crates/ruff_linter/src/rules/flake8_import_conventions/snapshots/ruff_linter__rules__flake8_import_conventions__tests__defaults.snap
@@ -256,7 +256,7 @@ defaults.py:21:23: ICN001 [*] `tkinter` should be imported as `tk`
    21 |+    import tkinter as tk
 22 22 |     import networkx as nxy
 23 23 | 
-24 24 | def conventional_aliases():
+24 24 | 
 
 defaults.py:22:24: ICN001 [*] `networkx` should be imported as `nx`
    |
@@ -264,8 +264,6 @@ defaults.py:22:24: ICN001 [*] `networkx` should be imported as `nx`
 21 |     import tkinter as tkr
 22 |     import networkx as nxy
    |                        ^^^ ICN001
-23 | 
-24 | def conventional_aliases():
    |
    = help: Alias `networkx` to `nx`
 
@@ -276,7 +274,5 @@ defaults.py:22:24: ICN001 [*] `networkx` should be imported as `nx`
 22    |-    import networkx as nxy
    22 |+    import networkx as nx
 23 23 | 
-24 24 | def conventional_aliases():
-25 25 |     import altair as alt
-
-
+24 24 | 
+25 25 | def conventional_aliases():

--- a/crates/ruff_linter/src/rules/flake8_import_conventions/snapshots/ruff_linter__rules__flake8_import_conventions__tests__same_name.snap
+++ b/crates/ruff_linter/src/rules/flake8_import_conventions/snapshots/ruff_linter__rules__flake8_import_conventions__tests__same_name.snap
@@ -1,0 +1,17 @@
+---
+source: crates/ruff_linter/src/rules/flake8_import_conventions/mod.rs
+---
+same_name.py:10:41: ICN001 [*] `django.conf.settings` should be imported as `settings`
+   |
+ 9 | def unconventional_alias():
+10 |     from django.conf import settings as s
+   |                                         ^ ICN001
+   |
+   = help: Alias `django.conf.settings` to `settings`
+
+ℹ Unsafe fix
+7  7  | 
+8  8  | 
+9  9  | def unconventional_alias():
+10    |-    from django.conf import settings as s
+   10 |+    from django.conf import settings as settings


### PR DESCRIPTION
## Summary

Given:

```toml
[tool.ruff.lint.flake8-import-conventions.aliases]
"django.conf.settings" = "settings"
```

We should accept `from django.conf import settings`.

Closes https://github.com/astral-sh/ruff/issues/10599.
