### PR TITLE
Drop support for `root_uri` as an initialization parameter in `ruff_server`

### DIFF
--- a/crates/ruff_server/src/server.rs
+++ b/crates/ruff_server/src/server.rs
@@ -52,9 +52,8 @@ impl Server {
         let workspaces = init_params
             .workspace_folders
             .map(|folders| folders.into_iter().map(|folder| folder.uri).collect())
-            .or_else(|| init_params.root_uri.map(|u| vec![u]))
             .or_else(|| {
-                tracing::debug!("No root URI or workspace(s) were provided during initialization. Using the current working directory as a default workspace...");
+                tracing::debug!("No workspace(s) were provided during initialization. Using the current working directory as a default workspace...");
                 Some(vec![types::Url::from_file_path(std::env::current_dir().ok()?).ok()?])
             })
             .ok_or_else(|| {


### PR DESCRIPTION
## Summary

Needed for https://github.com/astral-sh/ruff/pull/10686.

We no longer support `root_uri` as an initialization parameter, relying solely on `workspace_folders` to find the working directories. This means that the minimum supported LSP version is now `0.3.6`.

## Test Plan

When opening a folder in VS Code, you shouldn't see any errors in the log which say `No workspace(s) were provided(...)`.
