### PR TITLE
Report error for `yield` and `starred` in bitwise or parsing

### DIFF
--- a/crates/ruff_python_parser/src/parser/expression.rs
+++ b/crates/ruff_python_parser/src/parser/expression.rs
@@ -343,6 +343,8 @@ impl<'src> Parser<'src> {
             }) => "boolean",
             Expr::If(_) => "conditional",
             Expr::Lambda(_) => "lambda",
+            Expr::Yield(_) | Expr::YieldFrom(_) => "yield",
+            Expr::Starred(_) => "starred",
             _ => return parsed_expr,
         };
 


### PR DESCRIPTION
## Summary

Small follow-up for #10657 to report error for yield and starred expressions in bitwise or parsing.
