### PR TITLE
[flake8_comprehensions] add sum/min/max to unnecessary comprehension check (C419)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_comprehensions/C419.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_comprehensions/C419.py
@@ -13,9 +13,6 @@ all(x.id for x in bar)
 all(x.id for x in bar)
 any(x.id for x in bar)
 all((x.id for x in bar))
-# no lint if shadowed
-def all(x): pass
-all([x.id for x in bar])
 # we don't lint on these in stable yet
 sum([x.val for x in bar])
 min([x.val for x in bar])

--- a/crates/ruff_linter/resources/test/fixtures/flake8_comprehensions/C419.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_comprehensions/C419.py
@@ -7,18 +7,19 @@ all(  # first comment
     [x.id for x in bar],  # second comment
 )  # third comment
 any({x.id for x in bar})
-sum([x.val for x in bar])
-min([x.val for x in bar])
-max([x.val for x in bar])
 
 # OK
 all(x.id for x in bar)
 all(x.id for x in bar)
 any(x.id for x in bar)
 all((x.id for x in bar))
-sum(x.val for x in bar)
-min(x.val for x in bar)
-max(x.val for x in bar)
+# no lint if shadowed
+def all(x): pass
+all([x.id for x in bar])
+# we don't lint on these in stable yet
+sum([x.val for x in bar])
+min([x.val for x in bar])
+max([x.val for x in bar])
 
 
 async def f() -> bool:

--- a/crates/ruff_linter/resources/test/fixtures/flake8_comprehensions/C419.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_comprehensions/C419.py
@@ -7,12 +7,18 @@ all(  # first comment
     [x.id for x in bar],  # second comment
 )  # third comment
 any({x.id for x in bar})
+sum([x.val for x in bar])
+min([x.val for x in bar])
+max([x.val for x in bar])
 
 # OK
 all(x.id for x in bar)
 all(x.id for x in bar)
 any(x.id for x in bar)
 all((x.id for x in bar))
+sum(x.val for x in bar)
+min(x.val for x in bar)
+max(x.val for x in bar)
 
 
 async def f() -> bool:

--- a/crates/ruff_linter/resources/test/fixtures/flake8_comprehensions/C419_1.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_comprehensions/C419_1.py
@@ -1,0 +1,8 @@
+sum([x.val for x in bar])
+min([x.val for x in bar])
+max([x.val for x in bar])
+
+# Ok
+sum(x.val for x in bar)
+min(x.val for x in bar)
+max(x.val for x in bar)

--- a/crates/ruff_linter/resources/test/fixtures/flake8_comprehensions/C419_2.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_comprehensions/C419_2.py
@@ -1,0 +1,3 @@
+# no lint if shadowed
+def all(x): pass
+all([x.id for x in bar])

--- a/crates/ruff_linter/src/checkers/ast/analyze/expression.rs
+++ b/crates/ruff_linter/src/checkers/ast/analyze/expression.rs
@@ -705,8 +705,8 @@ pub(crate) fn expression(expr: &Expr, checker: &mut Checker) {
                     args,
                 );
             }
-            if checker.enabled(Rule::UnnecessaryComprehensionAnyAll) {
-                flake8_comprehensions::rules::unnecessary_comprehension_any_all(
+            if checker.enabled(Rule::UnnecessaryComprehensionInCall) {
+                flake8_comprehensions::rules::unnecessary_comprehension_in_call(
                     checker, expr, func, args, keywords,
                 );
             }

--- a/crates/ruff_linter/src/codes.rs
+++ b/crates/ruff_linter/src/codes.rs
@@ -398,7 +398,7 @@ pub fn code_to_rule(linter: Linter, code: &str) -> Option<(RuleGroup, Rule)> {
         (Flake8Comprehensions, "16") => (RuleGroup::Stable, rules::flake8_comprehensions::rules::UnnecessaryComprehension),
         (Flake8Comprehensions, "17") => (RuleGroup::Stable, rules::flake8_comprehensions::rules::UnnecessaryMap),
         (Flake8Comprehensions, "18") => (RuleGroup::Stable, rules::flake8_comprehensions::rules::UnnecessaryLiteralWithinDictCall),
-        (Flake8Comprehensions, "19") => (RuleGroup::Stable, rules::flake8_comprehensions::rules::UnnecessaryComprehensionAnyAll),
+        (Flake8Comprehensions, "19") => (RuleGroup::Stable, rules::flake8_comprehensions::rules::UnnecessaryComprehensionInCall),
 
         // flake8-debugger
         (Flake8Debugger, "0") => (RuleGroup::Stable, rules::flake8_debugger::rules::Debugger),

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/fixes.rs
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/fixes.rs
@@ -793,7 +793,7 @@ pub(crate) fn fix_unnecessary_map(
 }
 
 /// (C419) Convert `[i for i in a]` into `i for i in a`
-pub(crate) fn fix_unnecessary_comprehension_any_all(
+pub(crate) fn fix_unnecessary_comprehension_in_call(
     expr: &Expr,
     locator: &Locator,
     stylist: &Stylist,

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/mod.rs
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/mod.rs
@@ -12,6 +12,7 @@ mod tests {
 
     use crate::assert_messages;
     use crate::registry::Rule;
+    use crate::settings::types::PreviewMode;
     use crate::settings::LinterSettings;
     use crate::test::test_path;
 
@@ -38,6 +39,24 @@ mod tests {
         let diagnostics = test_path(
             Path::new("flake8_comprehensions").join(path).as_path(),
             &LinterSettings::for_rule(rule_code),
+        )?;
+        assert_messages!(snapshot, diagnostics);
+        Ok(())
+    }
+
+    #[test_case(Rule::UnnecessaryComprehensionInCall, Path::new("C419_1.py"))]
+    fn preview_rules(rule_code: Rule, path: &Path) -> Result<()> {
+        let snapshot = format!(
+            "preview__{}_{}",
+            rule_code.noqa_code(),
+            path.to_string_lossy()
+        );
+        let diagnostics = test_path(
+            Path::new("flake8_comprehensions").join(path).as_path(),
+            &LinterSettings {
+                preview: PreviewMode::Enabled,
+                ..LinterSettings::for_rule(rule_code)
+            },
         )?;
         assert_messages!(snapshot, diagnostics);
         Ok(())

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/mod.rs
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/mod.rs
@@ -20,6 +20,7 @@ mod tests {
     #[test_case(Rule::UnnecessaryCollectionCall, Path::new("C408.py"))]
     #[test_case(Rule::UnnecessaryComprehension, Path::new("C416.py"))]
     #[test_case(Rule::UnnecessaryComprehensionInCall, Path::new("C419.py"))]
+    #[test_case(Rule::UnnecessaryComprehensionInCall, Path::new("C419_2.py"))]
     #[test_case(Rule::UnnecessaryDoubleCastOrProcess, Path::new("C414.py"))]
     #[test_case(Rule::UnnecessaryGeneratorDict, Path::new("C402.py"))]
     #[test_case(Rule::UnnecessaryGeneratorList, Path::new("C400.py"))]

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/mod.rs
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/mod.rs
@@ -18,7 +18,7 @@ mod tests {
     #[test_case(Rule::UnnecessaryCallAroundSorted, Path::new("C413.py"))]
     #[test_case(Rule::UnnecessaryCollectionCall, Path::new("C408.py"))]
     #[test_case(Rule::UnnecessaryComprehension, Path::new("C416.py"))]
-    #[test_case(Rule::UnnecessaryComprehensionAnyAll, Path::new("C419.py"))]
+    #[test_case(Rule::UnnecessaryComprehensionInCall, Path::new("C419.py"))]
     #[test_case(Rule::UnnecessaryDoubleCastOrProcess, Path::new("C414.py"))]
     #[test_case(Rule::UnnecessaryGeneratorDict, Path::new("C402.py"))]
     #[test_case(Rule::UnnecessaryGeneratorList, Path::new("C400.py"))]

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/rules/mod.rs
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/rules/mod.rs
@@ -1,7 +1,7 @@
 pub(crate) use unnecessary_call_around_sorted::*;
 pub(crate) use unnecessary_collection_call::*;
 pub(crate) use unnecessary_comprehension::*;
-pub(crate) use unnecessary_comprehension_any_all::*;
+pub(crate) use unnecessary_comprehension_in_call::*;
 pub(crate) use unnecessary_double_cast_or_process::*;
 pub(crate) use unnecessary_generator_dict::*;
 pub(crate) use unnecessary_generator_list::*;
@@ -21,7 +21,7 @@ mod helpers;
 mod unnecessary_call_around_sorted;
 mod unnecessary_collection_call;
 mod unnecessary_comprehension;
-mod unnecessary_comprehension_any_all;
+mod unnecessary_comprehension_in_call;
 mod unnecessary_double_cast_or_process;
 mod unnecessary_generator_dict;
 mod unnecessary_generator_list;

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_comprehension_in_call.rs
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_comprehension_in_call.rs
@@ -53,7 +53,7 @@ use crate::rules::flake8_comprehensions::fixes;
 /// any(x.id for x in bar)
 /// all(x.id for x in bar)
 /// sum(x.val for x in bar)
-/// min(x.val for x in bar])
+/// min(x.val for x in bar)
 /// max(x.val for x in bar)
 /// ```
 ///

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_comprehension_in_call.rs
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_comprehension_in_call.rs
@@ -15,7 +15,7 @@ use crate::rules::flake8_comprehensions::fixes;
 ///
 /// ## Why is this bad?
 /// Many builtin functions (this rule currently covers `any`, `all`, `min`, `max`, and `sum`) take
-/// any iterable, including a generator. Converting a generator to a list by way of a list
+/// any iterable, including a generator. Constructing a temporary list by way of a list
 /// comprehension is unnecessary and wastes memory for large iterables by fully materializing a
 /// list rather than handling values one at a time.
 ///
@@ -33,11 +33,13 @@ use crate::rules::flake8_comprehensions::fixes;
 /// 212 ns ± 0.892 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
 /// ```
 ///
-/// This performance difference is due to short-circuiting. If the entire iterable has to be
-/// traversed, the comprehension version may even be a bit faster (list allocation overhead is not
-/// necessarily greater than generator overhead). So applying this rule simplifies the code and
-/// will usually save memory, but in the absence of short-circuiting it may not improve (and may
-/// even slightly regress, though the difference will be small) performance.
+/// This performance improvement is due to short-circuiting. If the entire iterable has to be
+/// traversed, the comprehension version may even be a bit faster: list allocation overhead is not
+/// necessarily greater than generator overhead.
+///
+/// Applying this rule simplifies the code and will usually save memory, but in the absence of
+/// short-circuiting it may not improve performance. (It may even slightly regress performance,
+/// though the difference will usually be small.)
 ///
 /// ## Examples
 /// ```python

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_comprehension_in_call.rs
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_comprehension_in_call.rs
@@ -89,10 +89,13 @@ pub(crate) fn unnecessary_comprehension_in_call(
     if !keywords.is_empty() {
         return;
     }
+
     let Expr::Name(ast::ExprName { id, .. }) = func else {
         return;
     };
-    if !matches!(id.as_str(), "all" | "any" | "sum" | "min" | "max") {
+    if !(matches!(id.as_str(), "any" | "all")
+        || (checker.settings.preview.is_enabled() && matches!(id.as_str(), "sum" | "min" | "max")))
+    {
         return;
     }
     let [arg] = args else {

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_comprehension_in_call.rs
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_comprehension_in_call.rs
@@ -15,9 +15,9 @@ use crate::rules::flake8_comprehensions::fixes;
 ///
 /// ## Why is this bad?
 /// Many builtin functions (this rule currently covers `any`, `all`, `min`, `max`, and `sum`) take
-/// any iterable, including a generator. Constructing a temporary list by way of a list
-/// comprehension is unnecessary and wastes memory for large iterables by fully materializing a
-/// list rather than handling values one at a time.
+/// any iterable, including a generator. Constructing a temporary list via list comprehension is
+/// unnecessary and wastes memory for large iterables by fully materializing a list rather than
+/// handling values one at a time.
 ///
 /// `any` and `all` can also short-circuit iteration, saving a lot of time. The unnecessary
 /// comprehension forces a full iteration of the input iterable, giving up the benefits of

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_comprehension_in_call.rs
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_comprehension_in_call.rs
@@ -16,8 +16,7 @@ use crate::rules::flake8_comprehensions::fixes;
 /// ## Why is this bad?
 /// Many builtin functions (this rule currently covers `any`, `all`, `min`, `max`, and `sum`) take
 /// any iterable, including a generator. Constructing a temporary list via list comprehension is
-/// unnecessary and wastes memory for large iterables by fully materializing a list rather than
-/// handling values one at a time.
+/// unnecessary and wastes memory for large iterables.
 ///
 /// `any` and `all` can also short-circuit iteration, saving a lot of time. The unnecessary
 /// comprehension forces a full iteration of the input iterable, giving up the benefits of

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/snapshots/ruff_linter__rules__flake8_comprehensions__tests__C419_C419.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/snapshots/ruff_linter__rules__flake8_comprehensions__tests__C419_C419.py.snap
@@ -75,7 +75,7 @@ C419.py:7:5: C419 [*] Unnecessary list comprehension
   7 |+    x.id for x in bar  # second comment
 8 8 | )  # third comment
 9 9 | any({x.id for x in bar})
-10 10 | sum([x.val for x in bar])
+10 10 | 
 
 C419.py:9:5: C419 [*] Unnecessary list comprehension
    |
@@ -83,8 +83,8 @@ C419.py:9:5: C419 [*] Unnecessary list comprehension
  8 | )  # third comment
  9 | any({x.id for x in bar})
    |     ^^^^^^^^^^^^^^^^^^^ C419
-10 | sum([x.val for x in bar])
-11 | min([x.val for x in bar])
+10 | 
+11 | # OK
    |
    = help: Remove unnecessary list comprehension
 
@@ -94,131 +94,69 @@ C419.py:9:5: C419 [*] Unnecessary list comprehension
 8  8  | )  # third comment
 9     |-any({x.id for x in bar})
    9  |+any(x.id for x in bar)
-10 10 | sum([x.val for x in bar])
-11 11 | min([x.val for x in bar])
-12 12 | max([x.val for x in bar])
+10 10 | 
+11 11 | # OK
+12 12 | all(x.id for x in bar)
 
-C419.py:10:5: C419 [*] Unnecessary list comprehension
+C419.py:31:5: C419 [*] Unnecessary list comprehension
    |
- 8 | )  # third comment
- 9 | any({x.id for x in bar})
-10 | sum([x.val for x in bar])
-   |     ^^^^^^^^^^^^^^^^^^^^ C419
-11 | min([x.val for x in bar])
-12 | max([x.val for x in bar])
-   |
-   = help: Remove unnecessary list comprehension
-
-ℹ Unsafe fix
-7  7  |     [x.id for x in bar],  # second comment
-8  8  | )  # third comment
-9  9  | any({x.id for x in bar})
-10    |-sum([x.val for x in bar])
-   10 |+sum(x.val for x in bar)
-11 11 | min([x.val for x in bar])
-12 12 | max([x.val for x in bar])
-13 13 | 
-
-C419.py:11:5: C419 [*] Unnecessary list comprehension
-   |
- 9 | any({x.id for x in bar})
-10 | sum([x.val for x in bar])
-11 | min([x.val for x in bar])
-   |     ^^^^^^^^^^^^^^^^^^^^ C419
-12 | max([x.val for x in bar])
-   |
-   = help: Remove unnecessary list comprehension
-
-ℹ Unsafe fix
-8  8  | )  # third comment
-9  9  | any({x.id for x in bar})
-10 10 | sum([x.val for x in bar])
-11    |-min([x.val for x in bar])
-   11 |+min(x.val for x in bar)
-12 12 | max([x.val for x in bar])
-13 13 | 
-14 14 | # OK
-
-C419.py:12:5: C419 [*] Unnecessary list comprehension
-   |
-10 | sum([x.val for x in bar])
-11 | min([x.val for x in bar])
-12 | max([x.val for x in bar])
-   |     ^^^^^^^^^^^^^^^^^^^^ C419
-13 | 
-14 | # OK
-   |
-   = help: Remove unnecessary list comprehension
-
-ℹ Unsafe fix
-9  9  | any({x.id for x in bar})
-10 10 | sum([x.val for x in bar])
-11 11 | min([x.val for x in bar])
-12    |-max([x.val for x in bar])
-   12 |+max(x.val for x in bar)
-13 13 | 
-14 14 | # OK
-15 15 | all(x.id for x in bar)
-
-C419.py:30:5: C419 [*] Unnecessary list comprehension
-   |
-28 |   # Special comment handling
-29 |   any(
-30 |       [  # lbracket comment
+29 |   # Special comment handling
+30 |   any(
+31 |       [  # lbracket comment
    |  _____^
-31 | |         # second line comment
-32 | |         i.bit_count()
-33 | |         # random middle comment
-34 | |         for i in range(5)  # rbracket comment
-35 | |     ]  # rpar comment
+32 | |         # second line comment
+33 | |         i.bit_count()
+34 | |         # random middle comment
+35 | |         for i in range(5)  # rbracket comment
+36 | |     ]  # rpar comment
    | |_____^ C419
-36 |       # trailing comment
-37 |   )
+37 |       # trailing comment
+38 |   )
    |
    = help: Remove unnecessary list comprehension
 
 ℹ Unsafe fix
-27 27 | 
-28 28 | # Special comment handling
-29 29 | any(
-30    |-    [  # lbracket comment
-31    |-        # second line comment
-32    |-        i.bit_count()
-   30 |+    # lbracket comment
-   31 |+    # second line comment
-   32 |+    i.bit_count()
-33 33 |         # random middle comment
-34    |-        for i in range(5)  # rbracket comment
-35    |-    ]  # rpar comment
-   34 |+        for i in range(5)  # rbracket comment  # rpar comment
-36 35 |     # trailing comment
-37 36 | )
-38 37 | 
+28 28 | 
+29 29 | # Special comment handling
+30 30 | any(
+31    |-    [  # lbracket comment
+32    |-        # second line comment
+33    |-        i.bit_count()
+   31 |+    # lbracket comment
+   32 |+    # second line comment
+   33 |+    i.bit_count()
+34 34 |         # random middle comment
+35    |-        for i in range(5)  # rbracket comment
+36    |-    ]  # rpar comment
+   35 |+        for i in range(5)  # rbracket comment  # rpar comment
+37 36 |     # trailing comment
+38 37 | )
+39 38 | 
 
-C419.py:41:5: C419 [*] Unnecessary list comprehension
+C419.py:42:5: C419 [*] Unnecessary list comprehension
    |
-39 |   # Weird case where the function call, opening bracket, and comment are all
-40 |   # on the same line.
-41 |   any([  # lbracket comment
+40 |   # Weird case where the function call, opening bracket, and comment are all
+41 |   # on the same line.
+42 |   any([  # lbracket comment
    |  _____^
-42 | |         # second line comment
-43 | |         i.bit_count() for i in range(5)  # rbracket comment
-44 | |     ]  # rpar comment
+43 | |         # second line comment
+44 | |         i.bit_count() for i in range(5)  # rbracket comment
+45 | |     ]  # rpar comment
    | |_____^ C419
-45 |   )
+46 |   )
    |
    = help: Remove unnecessary list comprehension
 
 ℹ Unsafe fix
-38 38 | 
-39 39 | # Weird case where the function call, opening bracket, and comment are all
-40 40 | # on the same line.
-41    |-any([  # lbracket comment
-42    |-        # second line comment
-43    |-        i.bit_count() for i in range(5)  # rbracket comment
-44    |-    ]  # rpar comment
-   41 |+any(
-   42 |+# lbracket comment
-   43 |+# second line comment
-   44 |+i.bit_count() for i in range(5)  # rbracket comment  # rpar comment
-45 45 | )
+39 39 | 
+40 40 | # Weird case where the function call, opening bracket, and comment are all
+41 41 | # on the same line.
+42    |-any([  # lbracket comment
+43    |-        # second line comment
+44    |-        i.bit_count() for i in range(5)  # rbracket comment
+45    |-    ]  # rpar comment
+   42 |+any(
+   43 |+# lbracket comment
+   44 |+# second line comment
+   45 |+i.bit_count() for i in range(5)  # rbracket comment  # rpar comment
+46 46 | )

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/snapshots/ruff_linter__rules__flake8_comprehensions__tests__C419_C419.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/snapshots/ruff_linter__rules__flake8_comprehensions__tests__C419_C419.py.snap
@@ -98,65 +98,65 @@ C419.py:9:5: C419 [*] Unnecessary list comprehension
 11 11 | # OK
 12 12 | all(x.id for x in bar)
 
-C419.py:31:5: C419 [*] Unnecessary list comprehension
+C419.py:28:5: C419 [*] Unnecessary list comprehension
    |
-29 |   # Special comment handling
-30 |   any(
-31 |       [  # lbracket comment
+26 |   # Special comment handling
+27 |   any(
+28 |       [  # lbracket comment
    |  _____^
-32 | |         # second line comment
-33 | |         i.bit_count()
-34 | |         # random middle comment
-35 | |         for i in range(5)  # rbracket comment
-36 | |     ]  # rpar comment
+29 | |         # second line comment
+30 | |         i.bit_count()
+31 | |         # random middle comment
+32 | |         for i in range(5)  # rbracket comment
+33 | |     ]  # rpar comment
    | |_____^ C419
-37 |       # trailing comment
-38 |   )
+34 |       # trailing comment
+35 |   )
    |
    = help: Remove unnecessary list comprehension
 
 ℹ Unsafe fix
-28 28 | 
-29 29 | # Special comment handling
-30 30 | any(
-31    |-    [  # lbracket comment
-32    |-        # second line comment
-33    |-        i.bit_count()
-   31 |+    # lbracket comment
-   32 |+    # second line comment
-   33 |+    i.bit_count()
-34 34 |         # random middle comment
-35    |-        for i in range(5)  # rbracket comment
-36    |-    ]  # rpar comment
-   35 |+        for i in range(5)  # rbracket comment  # rpar comment
-37 36 |     # trailing comment
-38 37 | )
-39 38 | 
+25 25 | 
+26 26 | # Special comment handling
+27 27 | any(
+28    |-    [  # lbracket comment
+29    |-        # second line comment
+30    |-        i.bit_count()
+   28 |+    # lbracket comment
+   29 |+    # second line comment
+   30 |+    i.bit_count()
+31 31 |         # random middle comment
+32    |-        for i in range(5)  # rbracket comment
+33    |-    ]  # rpar comment
+   32 |+        for i in range(5)  # rbracket comment  # rpar comment
+34 33 |     # trailing comment
+35 34 | )
+36 35 | 
 
-C419.py:42:5: C419 [*] Unnecessary list comprehension
+C419.py:39:5: C419 [*] Unnecessary list comprehension
    |
-40 |   # Weird case where the function call, opening bracket, and comment are all
-41 |   # on the same line.
-42 |   any([  # lbracket comment
+37 |   # Weird case where the function call, opening bracket, and comment are all
+38 |   # on the same line.
+39 |   any([  # lbracket comment
    |  _____^
-43 | |         # second line comment
-44 | |         i.bit_count() for i in range(5)  # rbracket comment
-45 | |     ]  # rpar comment
+40 | |         # second line comment
+41 | |         i.bit_count() for i in range(5)  # rbracket comment
+42 | |     ]  # rpar comment
    | |_____^ C419
-46 |   )
+43 |   )
    |
    = help: Remove unnecessary list comprehension
 
 ℹ Unsafe fix
-39 39 | 
-40 40 | # Weird case where the function call, opening bracket, and comment are all
-41 41 | # on the same line.
-42    |-any([  # lbracket comment
-43    |-        # second line comment
-44    |-        i.bit_count() for i in range(5)  # rbracket comment
-45    |-    ]  # rpar comment
-   42 |+any(
-   43 |+# lbracket comment
-   44 |+# second line comment
-   45 |+i.bit_count() for i in range(5)  # rbracket comment  # rpar comment
-46 46 | )
+36 36 | 
+37 37 | # Weird case where the function call, opening bracket, and comment are all
+38 38 | # on the same line.
+39    |-any([  # lbracket comment
+40    |-        # second line comment
+41    |-        i.bit_count() for i in range(5)  # rbracket comment
+42    |-    ]  # rpar comment
+   39 |+any(
+   40 |+# lbracket comment
+   41 |+# second line comment
+   42 |+i.bit_count() for i in range(5)  # rbracket comment  # rpar comment
+43 43 | )

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/snapshots/ruff_linter__rules__flake8_comprehensions__tests__C419_C419.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/snapshots/ruff_linter__rules__flake8_comprehensions__tests__C419_C419.py.snap
@@ -75,7 +75,7 @@ C419.py:7:5: C419 [*] Unnecessary list comprehension
   7 |+    x.id for x in bar  # second comment
 8 8 | )  # third comment
 9 9 | any({x.id for x in bar})
-10 10 | 
+10 10 | sum([x.val for x in bar])
 
 C419.py:9:5: C419 [*] Unnecessary list comprehension
    |
@@ -83,8 +83,8 @@ C419.py:9:5: C419 [*] Unnecessary list comprehension
  8 | )  # third comment
  9 | any({x.id for x in bar})
    |     ^^^^^^^^^^^^^^^^^^^ C419
-10 | 
-11 | # OK
+10 | sum([x.val for x in bar])
+11 | min([x.val for x in bar])
    |
    = help: Remove unnecessary list comprehension
 
@@ -94,71 +94,131 @@ C419.py:9:5: C419 [*] Unnecessary list comprehension
 8  8  | )  # third comment
 9     |-any({x.id for x in bar})
    9  |+any(x.id for x in bar)
-10 10 | 
-11 11 | # OK
-12 12 | all(x.id for x in bar)
+10 10 | sum([x.val for x in bar])
+11 11 | min([x.val for x in bar])
+12 12 | max([x.val for x in bar])
 
-C419.py:24:5: C419 [*] Unnecessary list comprehension
+C419.py:10:5: C419 [*] Unnecessary list comprehension
    |
-22 |   # Special comment handling
-23 |   any(
-24 |       [  # lbracket comment
-   |  _____^
-25 | |         # second line comment
-26 | |         i.bit_count()
-27 | |         # random middle comment
-28 | |         for i in range(5)  # rbracket comment
-29 | |     ]  # rpar comment
-   | |_____^ C419
-30 |       # trailing comment
-31 |   )
+ 8 | )  # third comment
+ 9 | any({x.id for x in bar})
+10 | sum([x.val for x in bar])
+   |     ^^^^^^^^^^^^^^^^^^^^ C419
+11 | min([x.val for x in bar])
+12 | max([x.val for x in bar])
    |
    = help: Remove unnecessary list comprehension
 
 ℹ Unsafe fix
-21 21 | 
-22 22 | # Special comment handling
-23 23 | any(
-24    |-    [  # lbracket comment
-25    |-        # second line comment
-26    |-        i.bit_count()
-   24 |+    # lbracket comment
-   25 |+    # second line comment
-   26 |+    i.bit_count()
-27 27 |         # random middle comment
-28    |-        for i in range(5)  # rbracket comment
-29    |-    ]  # rpar comment
-   28 |+        for i in range(5)  # rbracket comment  # rpar comment
-30 29 |     # trailing comment
-31 30 | )
-32 31 | 
+7  7  |     [x.id for x in bar],  # second comment
+8  8  | )  # third comment
+9  9  | any({x.id for x in bar})
+10    |-sum([x.val for x in bar])
+   10 |+sum(x.val for x in bar)
+11 11 | min([x.val for x in bar])
+12 12 | max([x.val for x in bar])
+13 13 | 
 
-C419.py:35:5: C419 [*] Unnecessary list comprehension
+C419.py:11:5: C419 [*] Unnecessary list comprehension
    |
-33 |   # Weird case where the function call, opening bracket, and comment are all
-34 |   # on the same line.
-35 |   any([  # lbracket comment
-   |  _____^
-36 | |         # second line comment
-37 | |         i.bit_count() for i in range(5)  # rbracket comment
-38 | |     ]  # rpar comment
-   | |_____^ C419
-39 |   )
+ 9 | any({x.id for x in bar})
+10 | sum([x.val for x in bar])
+11 | min([x.val for x in bar])
+   |     ^^^^^^^^^^^^^^^^^^^^ C419
+12 | max([x.val for x in bar])
    |
    = help: Remove unnecessary list comprehension
 
 ℹ Unsafe fix
-32 32 | 
-33 33 | # Weird case where the function call, opening bracket, and comment are all
-34 34 | # on the same line.
-35    |-any([  # lbracket comment
-36    |-        # second line comment
-37    |-        i.bit_count() for i in range(5)  # rbracket comment
-38    |-    ]  # rpar comment
-   35 |+any(
-   36 |+# lbracket comment
-   37 |+# second line comment
-   38 |+i.bit_count() for i in range(5)  # rbracket comment  # rpar comment
-39 39 | )
+8  8  | )  # third comment
+9  9  | any({x.id for x in bar})
+10 10 | sum([x.val for x in bar])
+11    |-min([x.val for x in bar])
+   11 |+min(x.val for x in bar)
+12 12 | max([x.val for x in bar])
+13 13 | 
+14 14 | # OK
 
+C419.py:12:5: C419 [*] Unnecessary list comprehension
+   |
+10 | sum([x.val for x in bar])
+11 | min([x.val for x in bar])
+12 | max([x.val for x in bar])
+   |     ^^^^^^^^^^^^^^^^^^^^ C419
+13 | 
+14 | # OK
+   |
+   = help: Remove unnecessary list comprehension
 
+ℹ Unsafe fix
+9  9  | any({x.id for x in bar})
+10 10 | sum([x.val for x in bar])
+11 11 | min([x.val for x in bar])
+12    |-max([x.val for x in bar])
+   12 |+max(x.val for x in bar)
+13 13 | 
+14 14 | # OK
+15 15 | all(x.id for x in bar)
+
+C419.py:30:5: C419 [*] Unnecessary list comprehension
+   |
+28 |   # Special comment handling
+29 |   any(
+30 |       [  # lbracket comment
+   |  _____^
+31 | |         # second line comment
+32 | |         i.bit_count()
+33 | |         # random middle comment
+34 | |         for i in range(5)  # rbracket comment
+35 | |     ]  # rpar comment
+   | |_____^ C419
+36 |       # trailing comment
+37 |   )
+   |
+   = help: Remove unnecessary list comprehension
+
+ℹ Unsafe fix
+27 27 | 
+28 28 | # Special comment handling
+29 29 | any(
+30    |-    [  # lbracket comment
+31    |-        # second line comment
+32    |-        i.bit_count()
+   30 |+    # lbracket comment
+   31 |+    # second line comment
+   32 |+    i.bit_count()
+33 33 |         # random middle comment
+34    |-        for i in range(5)  # rbracket comment
+35    |-    ]  # rpar comment
+   34 |+        for i in range(5)  # rbracket comment  # rpar comment
+36 35 |     # trailing comment
+37 36 | )
+38 37 | 
+
+C419.py:41:5: C419 [*] Unnecessary list comprehension
+   |
+39 |   # Weird case where the function call, opening bracket, and comment are all
+40 |   # on the same line.
+41 |   any([  # lbracket comment
+   |  _____^
+42 | |         # second line comment
+43 | |         i.bit_count() for i in range(5)  # rbracket comment
+44 | |     ]  # rpar comment
+   | |_____^ C419
+45 |   )
+   |
+   = help: Remove unnecessary list comprehension
+
+ℹ Unsafe fix
+38 38 | 
+39 39 | # Weird case where the function call, opening bracket, and comment are all
+40 40 | # on the same line.
+41    |-any([  # lbracket comment
+42    |-        # second line comment
+43    |-        i.bit_count() for i in range(5)  # rbracket comment
+44    |-    ]  # rpar comment
+   41 |+any(
+   42 |+# lbracket comment
+   43 |+# second line comment
+   44 |+i.bit_count() for i in range(5)  # rbracket comment  # rpar comment
+45 45 | )

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/snapshots/ruff_linter__rules__flake8_comprehensions__tests__C419_C419_2.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/snapshots/ruff_linter__rules__flake8_comprehensions__tests__C419_C419_2.py.snap
@@ -1,0 +1,4 @@
+---
+source: crates/ruff_linter/src/rules/flake8_comprehensions/mod.rs
+---
+

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/snapshots/ruff_linter__rules__flake8_comprehensions__tests__preview__C419_C419_1.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/snapshots/ruff_linter__rules__flake8_comprehensions__tests__preview__C419_C419_1.py.snap
@@ -1,0 +1,55 @@
+---
+source: crates/ruff_linter/src/rules/flake8_comprehensions/mod.rs
+---
+C419_1.py:1:5: C419 [*] Unnecessary list comprehension
+  |
+1 | sum([x.val for x in bar])
+  |     ^^^^^^^^^^^^^^^^^^^^ C419
+2 | min([x.val for x in bar])
+3 | max([x.val for x in bar])
+  |
+  = help: Remove unnecessary list comprehension
+
+ℹ Unsafe fix
+1   |-sum([x.val for x in bar])
+  1 |+sum(x.val for x in bar)
+2 2 | min([x.val for x in bar])
+3 3 | max([x.val for x in bar])
+4 4 | 
+
+C419_1.py:2:5: C419 [*] Unnecessary list comprehension
+  |
+1 | sum([x.val for x in bar])
+2 | min([x.val for x in bar])
+  |     ^^^^^^^^^^^^^^^^^^^^ C419
+3 | max([x.val for x in bar])
+  |
+  = help: Remove unnecessary list comprehension
+
+ℹ Unsafe fix
+1 1 | sum([x.val for x in bar])
+2   |-min([x.val for x in bar])
+  2 |+min(x.val for x in bar)
+3 3 | max([x.val for x in bar])
+4 4 | 
+5 5 | # Ok
+
+C419_1.py:3:5: C419 [*] Unnecessary list comprehension
+  |
+1 | sum([x.val for x in bar])
+2 | min([x.val for x in bar])
+3 | max([x.val for x in bar])
+  |     ^^^^^^^^^^^^^^^^^^^^ C419
+4 | 
+5 | # Ok
+  |
+  = help: Remove unnecessary list comprehension
+
+ℹ Unsafe fix
+1 1 | sum([x.val for x in bar])
+2 2 | min([x.val for x in bar])
+3   |-max([x.val for x in bar])
+  3 |+max(x.val for x in bar)
+4 4 | 
+5 5 | # Ok
+6 6 | sum(x.val for x in bar)


### PR DESCRIPTION
Fixes #3259 

## Summary

Renames `UnnecessaryComprehensionAnyAll` to `UnnecessaryComprehensionInCall` and extends the check to `sum`, `min`, and `max`, in addition to `any` and `all`.

## Test Plan

Updated snapshot test.

Built docs locally and verified the docs for this rule still render correctly.
