### PR TITLE
fix obsolete name in resolve_qualified_name docs

### DIFF
--- a/crates/ruff_python_semantic/src/model.rs
+++ b/crates/ruff_python_semantic/src/model.rs
@@ -680,7 +680,7 @@ impl<'a> SemanticModel<'a> {
     /// print(python_version)
     /// ```
     ///
-    /// ...then `resolve_call_path(${python_version})` will resolve to `sys.version_info`.
+    /// ...then `resolve_qualified_name(${python_version})` will resolve to `sys.version_info`.
     pub fn resolve_qualified_name<'name, 'expr: 'name>(
         &self,
         value: &'expr Expr,


### PR DESCRIPTION
`resolve_call_path` was renamed to `resolve_qualified_name` in a6d892b1f4b45bfed918f3240218d5fcd39d3099, but the doc block for the function wasn't updated to match.