### PR TITLE
Add tests for `raise` statement

### DIFF
--- a/crates/ruff_python_parser/resources/inline/err/raise_stmt_unparenthesized_tuple_cause.py
+++ b/crates/ruff_python_parser/resources/inline/err/raise_stmt_unparenthesized_tuple_cause.py
@@ -1,0 +1,2 @@
+raise x from y,
+raise x from y, z

--- a/crates/ruff_python_parser/resources/inline/err/raise_stmt_unparenthesized_tuple_exc.py
+++ b/crates/ruff_python_parser/resources/inline/err/raise_stmt_unparenthesized_tuple_exc.py
@@ -1,0 +1,3 @@
+raise x,
+raise x, y
+raise x, y from z

--- a/crates/ruff_python_parser/resources/valid/statement/raise.py
+++ b/crates/ruff_python_parser/resources/valid/statement/raise.py
@@ -1,5 +1,18 @@
+# raise
 raise
 raise a
+raise (a, b)
 raise 1 < 2
 raise a and b
-raise a from b
+raise lambda x: y
+raise await x
+raise x if True else y
+
+# raise ... from ...
+raise x from a
+raise x from (a, b)
+raise x from 1 < 2
+raise x from a and b
+raise x from lambda x: y
+raise x from await x
+raise x from x if True else y

--- a/crates/ruff_python_parser/src/error.rs
+++ b/crates/ruff_python_parser/src/error.rs
@@ -99,6 +99,11 @@ pub enum ParseErrorType {
     /// An empty nonlocal names list was found during parsing, e.g `nonlocal`.
     EmptyNonlocalNames,
 
+    /// An unparenthesized named expression was found where it is not allowed.
+    UnparenthesizedNamedExpression,
+    /// An unparenthesized tuple expression was found where it is not allowed.
+    UnparenthesizedTupleExpression,
+
     /// An invalid expression was found in the assignment `target`.
     InvalidAssignmentTarget,
     /// An invalid expression was found in the named assignment `target`.
@@ -127,8 +132,6 @@ pub enum ParseErrorType {
     SimpleStmtAndCompoundStmtInSameLine,
     /// An invalid usage of iterable unpacking in a comprehension was found.
     IterableUnpackingInComprehension,
-    /// An unparenthesized named expression was found where it is not allowed.
-    UnparenthesizedNamedExpression,
     /// An invalid usage of a starred expression was found.
     StarredExpressionUsage,
 
@@ -197,6 +200,9 @@ impl std::fmt::Display for ParseErrorType {
             }
             ParseErrorType::UnparenthesizedNamedExpression => {
                 write!(f, "unparenthesized named expression cannot be used here")
+            }
+            ParseErrorType::UnparenthesizedTupleExpression => {
+                write!(f, "unparenthesized tuple expression cannot be used here")
             }
             ParseErrorType::StarredExpressionUsage => {
                 write!(f, "starred expression cannot be used here")

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@raise_stmt_unparenthesized_tuple_cause.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@raise_stmt_unparenthesized_tuple_cause.py.snap
@@ -1,0 +1,100 @@
+---
+source: crates/ruff_python_parser/tests/fixtures.rs
+input_file: crates/ruff_python_parser/resources/inline/err/raise_stmt_unparenthesized_tuple_cause.py
+---
+## AST
+
+```
+Module(
+    ModModule {
+        range: 0..34,
+        body: [
+            Raise(
+                StmtRaise {
+                    range: 0..15,
+                    exc: Some(
+                        Name(
+                            ExprName {
+                                range: 6..7,
+                                id: "x",
+                                ctx: Load,
+                            },
+                        ),
+                    ),
+                    cause: Some(
+                        Tuple(
+                            ExprTuple {
+                                range: 13..15,
+                                elts: [
+                                    Name(
+                                        ExprName {
+                                            range: 13..14,
+                                            id: "y",
+                                            ctx: Load,
+                                        },
+                                    ),
+                                ],
+                                ctx: Load,
+                                parenthesized: false,
+                            },
+                        ),
+                    ),
+                },
+            ),
+            Raise(
+                StmtRaise {
+                    range: 16..33,
+                    exc: Some(
+                        Name(
+                            ExprName {
+                                range: 22..23,
+                                id: "x",
+                                ctx: Load,
+                            },
+                        ),
+                    ),
+                    cause: Some(
+                        Tuple(
+                            ExprTuple {
+                                range: 29..33,
+                                elts: [
+                                    Name(
+                                        ExprName {
+                                            range: 29..30,
+                                            id: "y",
+                                            ctx: Load,
+                                        },
+                                    ),
+                                    Name(
+                                        ExprName {
+                                            range: 32..33,
+                                            id: "z",
+                                            ctx: Load,
+                                        },
+                                    ),
+                                ],
+                                ctx: Load,
+                                parenthesized: false,
+                            },
+                        ),
+                    ),
+                },
+            ),
+        ],
+    },
+)
+```
+## Errors
+
+  |
+1 | raise x from y,
+  |              ^^ Syntax Error: unparenthesized tuple expression cannot be used here
+2 | raise x from y, z
+  |
+
+
+  |
+1 | raise x from y,
+2 | raise x from y, z
+  |              ^^^^ Syntax Error: unparenthesized tuple expression cannot be used here
+  |

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@raise_stmt_unparenthesized_tuple_exc.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@raise_stmt_unparenthesized_tuple_exc.py.snap
@@ -1,0 +1,133 @@
+---
+source: crates/ruff_python_parser/tests/fixtures.rs
+input_file: crates/ruff_python_parser/resources/inline/err/raise_stmt_unparenthesized_tuple_exc.py
+---
+## AST
+
+```
+Module(
+    ModModule {
+        range: 0..38,
+        body: [
+            Raise(
+                StmtRaise {
+                    range: 0..8,
+                    exc: Some(
+                        Tuple(
+                            ExprTuple {
+                                range: 6..8,
+                                elts: [
+                                    Name(
+                                        ExprName {
+                                            range: 6..7,
+                                            id: "x",
+                                            ctx: Load,
+                                        },
+                                    ),
+                                ],
+                                ctx: Load,
+                                parenthesized: false,
+                            },
+                        ),
+                    ),
+                    cause: None,
+                },
+            ),
+            Raise(
+                StmtRaise {
+                    range: 9..19,
+                    exc: Some(
+                        Tuple(
+                            ExprTuple {
+                                range: 15..19,
+                                elts: [
+                                    Name(
+                                        ExprName {
+                                            range: 15..16,
+                                            id: "x",
+                                            ctx: Load,
+                                        },
+                                    ),
+                                    Name(
+                                        ExprName {
+                                            range: 18..19,
+                                            id: "y",
+                                            ctx: Load,
+                                        },
+                                    ),
+                                ],
+                                ctx: Load,
+                                parenthesized: false,
+                            },
+                        ),
+                    ),
+                    cause: None,
+                },
+            ),
+            Raise(
+                StmtRaise {
+                    range: 20..37,
+                    exc: Some(
+                        Tuple(
+                            ExprTuple {
+                                range: 26..30,
+                                elts: [
+                                    Name(
+                                        ExprName {
+                                            range: 26..27,
+                                            id: "x",
+                                            ctx: Load,
+                                        },
+                                    ),
+                                    Name(
+                                        ExprName {
+                                            range: 29..30,
+                                            id: "y",
+                                            ctx: Load,
+                                        },
+                                    ),
+                                ],
+                                ctx: Load,
+                                parenthesized: false,
+                            },
+                        ),
+                    ),
+                    cause: Some(
+                        Name(
+                            ExprName {
+                                range: 36..37,
+                                id: "z",
+                                ctx: Load,
+                            },
+                        ),
+                    ),
+                },
+            ),
+        ],
+    },
+)
+```
+## Errors
+
+  |
+1 | raise x,
+  |       ^^ Syntax Error: unparenthesized tuple expression cannot be used here
+2 | raise x, y
+3 | raise x, y from z
+  |
+
+
+  |
+1 | raise x,
+2 | raise x, y
+  |       ^^^^ Syntax Error: unparenthesized tuple expression cannot be used here
+3 | raise x, y from z
+  |
+
+
+  |
+1 | raise x,
+2 | raise x, y
+3 | raise x, y from z
+  |       ^^^^ Syntax Error: unparenthesized tuple expression cannot be used here
+  |

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@statement__raise.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@statement__raise.py.snap
@@ -7,22 +7,22 @@ input_file: crates/ruff_python_parser/resources/valid/statement/raise.py
 ```
 Module(
     ModModule {
-        range: 0..54,
+        range: 0..289,
         body: [
             Raise(
                 StmtRaise {
-                    range: 0..5,
+                    range: 8..13,
                     exc: None,
                     cause: None,
                 },
             ),
             Raise(
                 StmtRaise {
-                    range: 6..13,
+                    range: 14..21,
                     exc: Some(
                         Name(
                             ExprName {
-                                range: 12..13,
+                                range: 20..21,
                                 id: "a",
                                 ctx: Load,
                             },
@@ -33,14 +33,45 @@ Module(
             ),
             Raise(
                 StmtRaise {
-                    range: 14..25,
+                    range: 22..34,
+                    exc: Some(
+                        Tuple(
+                            ExprTuple {
+                                range: 28..34,
+                                elts: [
+                                    Name(
+                                        ExprName {
+                                            range: 29..30,
+                                            id: "a",
+                                            ctx: Load,
+                                        },
+                                    ),
+                                    Name(
+                                        ExprName {
+                                            range: 32..33,
+                                            id: "b",
+                                            ctx: Load,
+                                        },
+                                    ),
+                                ],
+                                ctx: Load,
+                                parenthesized: true,
+                            },
+                        ),
+                    ),
+                    cause: None,
+                },
+            ),
+            Raise(
+                StmtRaise {
+                    range: 35..46,
                     exc: Some(
                         Compare(
                             ExprCompare {
-                                range: 20..25,
+                                range: 41..46,
                                 left: NumberLiteral(
                                     ExprNumberLiteral {
-                                        range: 20..21,
+                                        range: 41..42,
                                         value: Int(
                                             1,
                                         ),
@@ -52,7 +83,7 @@ Module(
                                 comparators: [
                                     NumberLiteral(
                                         ExprNumberLiteral {
-                                            range: 24..25,
+                                            range: 45..46,
                                             value: Int(
                                                 2,
                                             ),
@@ -67,23 +98,23 @@ Module(
             ),
             Raise(
                 StmtRaise {
-                    range: 26..39,
+                    range: 47..60,
                     exc: Some(
                         BoolOp(
                             ExprBoolOp {
-                                range: 32..39,
+                                range: 53..60,
                                 op: And,
                                 values: [
                                     Name(
                                         ExprName {
-                                            range: 32..33,
+                                            range: 53..54,
                                             id: "a",
                                             ctx: Load,
                                         },
                                     ),
                                     Name(
                                         ExprName {
-                                            range: 38..39,
+                                            range: 59..60,
                                             id: "b",
                                             ctx: Load,
                                         },
@@ -97,12 +128,108 @@ Module(
             ),
             Raise(
                 StmtRaise {
-                    range: 40..54,
+                    range: 61..78,
+                    exc: Some(
+                        Lambda(
+                            ExprLambda {
+                                range: 67..78,
+                                parameters: Some(
+                                    Parameters {
+                                        range: 74..75,
+                                        posonlyargs: [],
+                                        args: [
+                                            ParameterWithDefault {
+                                                range: 74..75,
+                                                parameter: Parameter {
+                                                    range: 74..75,
+                                                    name: Identifier {
+                                                        id: "x",
+                                                        range: 74..75,
+                                                    },
+                                                    annotation: None,
+                                                },
+                                                default: None,
+                                            },
+                                        ],
+                                        vararg: None,
+                                        kwonlyargs: [],
+                                        kwarg: None,
+                                    },
+                                ),
+                                body: Name(
+                                    ExprName {
+                                        range: 77..78,
+                                        id: "y",
+                                        ctx: Load,
+                                    },
+                                ),
+                            },
+                        ),
+                    ),
+                    cause: None,
+                },
+            ),
+            Raise(
+                StmtRaise {
+                    range: 79..92,
+                    exc: Some(
+                        Await(
+                            ExprAwait {
+                                range: 85..92,
+                                value: Name(
+                                    ExprName {
+                                        range: 91..92,
+                                        id: "x",
+                                        ctx: Load,
+                                    },
+                                ),
+                            },
+                        ),
+                    ),
+                    cause: None,
+                },
+            ),
+            Raise(
+                StmtRaise {
+                    range: 93..115,
+                    exc: Some(
+                        If(
+                            ExprIf {
+                                range: 99..115,
+                                test: BooleanLiteral(
+                                    ExprBooleanLiteral {
+                                        range: 104..108,
+                                        value: true,
+                                    },
+                                ),
+                                body: Name(
+                                    ExprName {
+                                        range: 99..100,
+                                        id: "x",
+                                        ctx: Load,
+                                    },
+                                ),
+                                orelse: Name(
+                                    ExprName {
+                                        range: 114..115,
+                                        id: "y",
+                                        ctx: Load,
+                                    },
+                                ),
+                            },
+                        ),
+                    ),
+                    cause: None,
+                },
+            ),
+            Raise(
+                StmtRaise {
+                    range: 138..152,
                     exc: Some(
                         Name(
                             ExprName {
-                                range: 46..47,
-                                id: "a",
+                                range: 144..145,
+                                id: "x",
                                 ctx: Load,
                             },
                         ),
@@ -110,9 +237,248 @@ Module(
                     cause: Some(
                         Name(
                             ExprName {
-                                range: 53..54,
-                                id: "b",
+                                range: 151..152,
+                                id: "a",
                                 ctx: Load,
+                            },
+                        ),
+                    ),
+                },
+            ),
+            Raise(
+                StmtRaise {
+                    range: 153..172,
+                    exc: Some(
+                        Name(
+                            ExprName {
+                                range: 159..160,
+                                id: "x",
+                                ctx: Load,
+                            },
+                        ),
+                    ),
+                    cause: Some(
+                        Tuple(
+                            ExprTuple {
+                                range: 166..172,
+                                elts: [
+                                    Name(
+                                        ExprName {
+                                            range: 167..168,
+                                            id: "a",
+                                            ctx: Load,
+                                        },
+                                    ),
+                                    Name(
+                                        ExprName {
+                                            range: 170..171,
+                                            id: "b",
+                                            ctx: Load,
+                                        },
+                                    ),
+                                ],
+                                ctx: Load,
+                                parenthesized: true,
+                            },
+                        ),
+                    ),
+                },
+            ),
+            Raise(
+                StmtRaise {
+                    range: 173..191,
+                    exc: Some(
+                        Name(
+                            ExprName {
+                                range: 179..180,
+                                id: "x",
+                                ctx: Load,
+                            },
+                        ),
+                    ),
+                    cause: Some(
+                        Compare(
+                            ExprCompare {
+                                range: 186..191,
+                                left: NumberLiteral(
+                                    ExprNumberLiteral {
+                                        range: 186..187,
+                                        value: Int(
+                                            1,
+                                        ),
+                                    },
+                                ),
+                                ops: [
+                                    Lt,
+                                ],
+                                comparators: [
+                                    NumberLiteral(
+                                        ExprNumberLiteral {
+                                            range: 190..191,
+                                            value: Int(
+                                                2,
+                                            ),
+                                        },
+                                    ),
+                                ],
+                            },
+                        ),
+                    ),
+                },
+            ),
+            Raise(
+                StmtRaise {
+                    range: 192..212,
+                    exc: Some(
+                        Name(
+                            ExprName {
+                                range: 198..199,
+                                id: "x",
+                                ctx: Load,
+                            },
+                        ),
+                    ),
+                    cause: Some(
+                        BoolOp(
+                            ExprBoolOp {
+                                range: 205..212,
+                                op: And,
+                                values: [
+                                    Name(
+                                        ExprName {
+                                            range: 205..206,
+                                            id: "a",
+                                            ctx: Load,
+                                        },
+                                    ),
+                                    Name(
+                                        ExprName {
+                                            range: 211..212,
+                                            id: "b",
+                                            ctx: Load,
+                                        },
+                                    ),
+                                ],
+                            },
+                        ),
+                    ),
+                },
+            ),
+            Raise(
+                StmtRaise {
+                    range: 213..237,
+                    exc: Some(
+                        Name(
+                            ExprName {
+                                range: 219..220,
+                                id: "x",
+                                ctx: Load,
+                            },
+                        ),
+                    ),
+                    cause: Some(
+                        Lambda(
+                            ExprLambda {
+                                range: 226..237,
+                                parameters: Some(
+                                    Parameters {
+                                        range: 233..234,
+                                        posonlyargs: [],
+                                        args: [
+                                            ParameterWithDefault {
+                                                range: 233..234,
+                                                parameter: Parameter {
+                                                    range: 233..234,
+                                                    name: Identifier {
+                                                        id: "x",
+                                                        range: 233..234,
+                                                    },
+                                                    annotation: None,
+                                                },
+                                                default: None,
+                                            },
+                                        ],
+                                        vararg: None,
+                                        kwonlyargs: [],
+                                        kwarg: None,
+                                    },
+                                ),
+                                body: Name(
+                                    ExprName {
+                                        range: 236..237,
+                                        id: "y",
+                                        ctx: Load,
+                                    },
+                                ),
+                            },
+                        ),
+                    ),
+                },
+            ),
+            Raise(
+                StmtRaise {
+                    range: 238..258,
+                    exc: Some(
+                        Name(
+                            ExprName {
+                                range: 244..245,
+                                id: "x",
+                                ctx: Load,
+                            },
+                        ),
+                    ),
+                    cause: Some(
+                        Await(
+                            ExprAwait {
+                                range: 251..258,
+                                value: Name(
+                                    ExprName {
+                                        range: 257..258,
+                                        id: "x",
+                                        ctx: Load,
+                                    },
+                                ),
+                            },
+                        ),
+                    ),
+                },
+            ),
+            Raise(
+                StmtRaise {
+                    range: 259..288,
+                    exc: Some(
+                        Name(
+                            ExprName {
+                                range: 265..266,
+                                id: "x",
+                                ctx: Load,
+                            },
+                        ),
+                    ),
+                    cause: Some(
+                        If(
+                            ExprIf {
+                                range: 272..288,
+                                test: BooleanLiteral(
+                                    ExprBooleanLiteral {
+                                        range: 277..281,
+                                        value: true,
+                                    },
+                                ),
+                                body: Name(
+                                    ExprName {
+                                        range: 272..273,
+                                        id: "x",
+                                        ctx: Load,
+                                    },
+                                ),
+                                orelse: Name(
+                                    ExprName {
+                                        range: 287..288,
+                                        id: "y",
+                                        ctx: Load,
+                                    },
+                                ),
                             },
                         ),
                     ),


### PR DESCRIPTION
## Summary

This PR adds test cases for `raise` statement.

There's one TODO around not allowing yield and starred expression which I want to solve holistically. Otherwise, both expression and statement parsing will be filled with error reporting.