### PR TITLE
docs: `Lint` -> `Format` in formatter.md

### DIFF
--- a/docs/formatter.md
+++ b/docs/formatter.md
@@ -12,7 +12,7 @@ directories, and formats all discovered Python files:
 
 ```shell
 ruff format                   # Format all files in the current directory.
-ruff format path/to/code/     # Lint all files in `path/to/code` (and any subdirectories).
+ruff format path/to/code/     # Format all files in `path/to/code` (and any subdirectories).
 ruff format path/to/file.py   # Format a single file.
 ```
 


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Since #10217 the [formatter docs](https://docs.astral.sh/ruff/formatter/) contained

```
ruff format                   # Format all files in the current directory.
ruff format path/to/code/     # Lint all files in `path/to/code` (and any subdirectories).
ruff format path/to/file.py   # Format a single file.
```

I believe the `Lint` here is a copy-paste typo from the [linter docs](https://docs.astral.sh/ruff/linter/).

## Test Plan

N/A
