### PR TITLE
Add tests for type alias statement

### DIFF
--- a/crates/ruff_python_parser/resources/inline/err/type_alias_incomplete_stmt.py
+++ b/crates/ruff_python_parser/resources/inline/err/type_alias_incomplete_stmt.py
@@ -1,0 +1,3 @@
+type
+type x
+type x =

--- a/crates/ruff_python_parser/resources/inline/err/type_alias_invalid_value_expr.py
+++ b/crates/ruff_python_parser/resources/inline/err/type_alias_invalid_value_expr.py
@@ -1,0 +1,4 @@
+type x = *y
+type x = yield y
+type x = yield from y
+type x = x := 1

--- a/crates/ruff_python_parser/resources/inline/err/type_param_invalid_bound_expr.py
+++ b/crates/ruff_python_parser/resources/inline/err/type_param_invalid_bound_expr.py
@@ -1,0 +1,4 @@
+type X[T: *int] = int
+type X[T: yield x] = int
+type X[T: yield from x] = int
+type X[T: x := int] = int

--- a/crates/ruff_python_parser/resources/inline/err/type_param_missing_bound.py
+++ b/crates/ruff_python_parser/resources/inline/err/type_param_missing_bound.py
@@ -1,0 +1,2 @@
+type X[T: ] = int
+type X[T1: , T2] = int

--- a/crates/ruff_python_parser/resources/inline/err/type_param_param_spec_bound.py
+++ b/crates/ruff_python_parser/resources/inline/err/type_param_param_spec_bound.py
@@ -1,0 +1,1 @@
+type X[**T: int] = int

--- a/crates/ruff_python_parser/resources/inline/err/type_param_type_var_tuple_bound.py
+++ b/crates/ruff_python_parser/resources/inline/err/type_param_type_var_tuple_bound.py
@@ -1,0 +1,1 @@
+type X[*T: int] = int

--- a/crates/ruff_python_parser/src/parser/statement.rs
+++ b/crates/ruff_python_parser/src/parser/statement.rs
@@ -790,6 +790,11 @@ impl<'src> Parser<'src> {
 
         self.expect(TokenKind::Equal);
 
+        // test_err type_alias_incomplete_stmt
+        // type
+        // type x
+        // type x =
+
         // test_err type_alias_invalid_value_expr
         // type x = *y
         // type x = yield y
@@ -2091,12 +2096,18 @@ impl<'src> Parser<'src> {
 
         if self.eat(TokenKind::Star) {
             let name = self.parse_identifier();
+
+            // test_err type_param_type_var_tuple_bound
+            // type X[*T: int] = int
             ast::TypeParam::TypeVarTuple(ast::TypeParamTypeVarTuple {
                 range: self.node_range(start),
                 name,
             })
         } else if self.eat(TokenKind::DoubleStar) {
             let name = self.parse_identifier();
+
+            // test_err type_param_param_spec_bound
+            // type X[**T: int] = int
             ast::TypeParam::ParamSpec(ast::TypeParamParamSpec {
                 range: self.node_range(start),
                 name,

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@type_alias_incomplete_stmt.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@type_alias_incomplete_stmt.py.snap
@@ -1,0 +1,87 @@
+---
+source: crates/ruff_python_parser/tests/fixtures.rs
+input_file: crates/ruff_python_parser/resources/inline/err/type_alias_incomplete_stmt.py
+---
+## AST
+
+```
+Module(
+    ModModule {
+        range: 0..21,
+        body: [
+            Expr(
+                StmtExpr {
+                    range: 0..4,
+                    value: Name(
+                        ExprName {
+                            range: 0..4,
+                            id: "type",
+                            ctx: Load,
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 5..9,
+                    value: Name(
+                        ExprName {
+                            range: 5..9,
+                            id: "type",
+                            ctx: Load,
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 10..11,
+                    value: Name(
+                        ExprName {
+                            range: 10..11,
+                            id: "x",
+                            ctx: Load,
+                        },
+                    ),
+                },
+            ),
+            TypeAlias(
+                StmtTypeAlias {
+                    range: 12..20,
+                    name: Name(
+                        ExprName {
+                            range: 17..18,
+                            id: "x",
+                            ctx: Store,
+                        },
+                    ),
+                    type_params: None,
+                    value: Name(
+                        ExprName {
+                            range: 20..20,
+                            id: "",
+                            ctx: Invalid,
+                        },
+                    ),
+                },
+            ),
+        ],
+    },
+)
+```
+## Errors
+
+  |
+1 | type
+2 | type x
+  | ^^^^^^ Syntax Error: use `;` to separate simple statements
+3 | type x =
+  |
+
+
+  |
+1 | type
+2 | type x
+3 | type x =
+  |         ^ Syntax Error: Expected an expression
+  |

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@type_alias_invalid_value_expr.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@type_alias_invalid_value_expr.py.snap
@@ -1,0 +1,160 @@
+---
+source: crates/ruff_python_parser/tests/fixtures.rs
+input_file: crates/ruff_python_parser/resources/inline/err/type_alias_invalid_value_expr.py
+---
+## AST
+
+```
+Module(
+    ModModule {
+        range: 0..67,
+        body: [
+            TypeAlias(
+                StmtTypeAlias {
+                    range: 0..11,
+                    name: Name(
+                        ExprName {
+                            range: 5..6,
+                            id: "x",
+                            ctx: Store,
+                        },
+                    ),
+                    type_params: None,
+                    value: Starred(
+                        ExprStarred {
+                            range: 9..11,
+                            value: Name(
+                                ExprName {
+                                    range: 10..11,
+                                    id: "y",
+                                    ctx: Load,
+                                },
+                            ),
+                            ctx: Load,
+                        },
+                    ),
+                },
+            ),
+            TypeAlias(
+                StmtTypeAlias {
+                    range: 12..28,
+                    name: Name(
+                        ExprName {
+                            range: 17..18,
+                            id: "x",
+                            ctx: Store,
+                        },
+                    ),
+                    type_params: None,
+                    value: Yield(
+                        ExprYield {
+                            range: 21..28,
+                            value: Some(
+                                Name(
+                                    ExprName {
+                                        range: 27..28,
+                                        id: "y",
+                                        ctx: Load,
+                                    },
+                                ),
+                            ),
+                        },
+                    ),
+                },
+            ),
+            TypeAlias(
+                StmtTypeAlias {
+                    range: 29..50,
+                    name: Name(
+                        ExprName {
+                            range: 34..35,
+                            id: "x",
+                            ctx: Store,
+                        },
+                    ),
+                    type_params: None,
+                    value: YieldFrom(
+                        ExprYieldFrom {
+                            range: 38..50,
+                            value: Name(
+                                ExprName {
+                                    range: 49..50,
+                                    id: "y",
+                                    ctx: Load,
+                                },
+                            ),
+                        },
+                    ),
+                },
+            ),
+            TypeAlias(
+                StmtTypeAlias {
+                    range: 51..61,
+                    name: Name(
+                        ExprName {
+                            range: 56..57,
+                            id: "x",
+                            ctx: Store,
+                        },
+                    ),
+                    type_params: None,
+                    value: Name(
+                        ExprName {
+                            range: 60..61,
+                            id: "x",
+                            ctx: Load,
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 65..66,
+                    value: NumberLiteral(
+                        ExprNumberLiteral {
+                            range: 65..66,
+                            value: Int(
+                                1,
+                            ),
+                        },
+                    ),
+                },
+            ),
+        ],
+    },
+)
+```
+## Errors
+
+  |
+1 | type x = *y
+  |          ^^ Syntax Error: starred expression cannot be used here
+2 | type x = yield y
+3 | type x = yield from y
+  |
+
+
+  |
+1 | type x = *y
+2 | type x = yield y
+  |          ^^^^^^^ Syntax Error: yield expression cannot be used here
+3 | type x = yield from y
+4 | type x = x := 1
+  |
+
+
+  |
+1 | type x = *y
+2 | type x = yield y
+3 | type x = yield from y
+  |          ^^^^^^^^^^^^ Syntax Error: yield expression cannot be used here
+4 | type x = x := 1
+  |
+
+
+  |
+2 | type x = yield y
+3 | type x = yield from y
+4 | type x = x := 1
+  |            ^^ Syntax Error: Expected a statement
+  |

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@type_param_invalid_bound_expr.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@type_param_invalid_bound_expr.py.snap
@@ -1,0 +1,253 @@
+---
+source: crates/ruff_python_parser/tests/fixtures.rs
+input_file: crates/ruff_python_parser/resources/inline/err/type_param_invalid_bound_expr.py
+---
+## AST
+
+```
+Module(
+    ModModule {
+        range: 0..103,
+        body: [
+            TypeAlias(
+                StmtTypeAlias {
+                    range: 0..21,
+                    name: Name(
+                        ExprName {
+                            range: 5..6,
+                            id: "X",
+                            ctx: Store,
+                        },
+                    ),
+                    type_params: Some(
+                        TypeParams {
+                            range: 6..15,
+                            type_params: [
+                                TypeVar(
+                                    TypeParamTypeVar {
+                                        range: 7..14,
+                                        name: Identifier {
+                                            id: "T",
+                                            range: 7..8,
+                                        },
+                                        bound: Some(
+                                            Starred(
+                                                ExprStarred {
+                                                    range: 10..14,
+                                                    value: Name(
+                                                        ExprName {
+                                                            range: 11..14,
+                                                            id: "int",
+                                                            ctx: Load,
+                                                        },
+                                                    ),
+                                                    ctx: Load,
+                                                },
+                                            ),
+                                        ),
+                                    },
+                                ),
+                            ],
+                        },
+                    ),
+                    value: Name(
+                        ExprName {
+                            range: 18..21,
+                            id: "int",
+                            ctx: Load,
+                        },
+                    ),
+                },
+            ),
+            TypeAlias(
+                StmtTypeAlias {
+                    range: 22..46,
+                    name: Name(
+                        ExprName {
+                            range: 27..28,
+                            id: "X",
+                            ctx: Store,
+                        },
+                    ),
+                    type_params: Some(
+                        TypeParams {
+                            range: 28..40,
+                            type_params: [
+                                TypeVar(
+                                    TypeParamTypeVar {
+                                        range: 29..39,
+                                        name: Identifier {
+                                            id: "T",
+                                            range: 29..30,
+                                        },
+                                        bound: Some(
+                                            Yield(
+                                                ExprYield {
+                                                    range: 32..39,
+                                                    value: Some(
+                                                        Name(
+                                                            ExprName {
+                                                                range: 38..39,
+                                                                id: "x",
+                                                                ctx: Load,
+                                                            },
+                                                        ),
+                                                    ),
+                                                },
+                                            ),
+                                        ),
+                                    },
+                                ),
+                            ],
+                        },
+                    ),
+                    value: Name(
+                        ExprName {
+                            range: 43..46,
+                            id: "int",
+                            ctx: Load,
+                        },
+                    ),
+                },
+            ),
+            TypeAlias(
+                StmtTypeAlias {
+                    range: 47..76,
+                    name: Name(
+                        ExprName {
+                            range: 52..53,
+                            id: "X",
+                            ctx: Store,
+                        },
+                    ),
+                    type_params: Some(
+                        TypeParams {
+                            range: 53..70,
+                            type_params: [
+                                TypeVar(
+                                    TypeParamTypeVar {
+                                        range: 54..69,
+                                        name: Identifier {
+                                            id: "T",
+                                            range: 54..55,
+                                        },
+                                        bound: Some(
+                                            YieldFrom(
+                                                ExprYieldFrom {
+                                                    range: 57..69,
+                                                    value: Name(
+                                                        ExprName {
+                                                            range: 68..69,
+                                                            id: "x",
+                                                            ctx: Load,
+                                                        },
+                                                    ),
+                                                },
+                                            ),
+                                        ),
+                                    },
+                                ),
+                            ],
+                        },
+                    ),
+                    value: Name(
+                        ExprName {
+                            range: 73..76,
+                            id: "int",
+                            ctx: Load,
+                        },
+                    ),
+                },
+            ),
+            TypeAlias(
+                StmtTypeAlias {
+                    range: 77..102,
+                    name: Name(
+                        ExprName {
+                            range: 82..83,
+                            id: "X",
+                            ctx: Store,
+                        },
+                    ),
+                    type_params: Some(
+                        TypeParams {
+                            range: 83..96,
+                            type_params: [
+                                TypeVar(
+                                    TypeParamTypeVar {
+                                        range: 84..88,
+                                        name: Identifier {
+                                            id: "T",
+                                            range: 84..85,
+                                        },
+                                        bound: Some(
+                                            Name(
+                                                ExprName {
+                                                    range: 87..88,
+                                                    id: "x",
+                                                    ctx: Load,
+                                                },
+                                            ),
+                                        ),
+                                    },
+                                ),
+                                TypeVar(
+                                    TypeParamTypeVar {
+                                        range: 92..95,
+                                        name: Identifier {
+                                            id: "int",
+                                            range: 92..95,
+                                        },
+                                        bound: None,
+                                    },
+                                ),
+                            ],
+                        },
+                    ),
+                    value: Name(
+                        ExprName {
+                            range: 99..102,
+                            id: "int",
+                            ctx: Load,
+                        },
+                    ),
+                },
+            ),
+        ],
+    },
+)
+```
+## Errors
+
+  |
+1 | type X[T: *int] = int
+  |           ^^^^ Syntax Error: starred expression cannot be used here
+2 | type X[T: yield x] = int
+3 | type X[T: yield from x] = int
+  |
+
+
+  |
+1 | type X[T: *int] = int
+2 | type X[T: yield x] = int
+  |           ^^^^^^^ Syntax Error: yield expression cannot be used here
+3 | type X[T: yield from x] = int
+4 | type X[T: x := int] = int
+  |
+
+
+  |
+1 | type X[T: *int] = int
+2 | type X[T: yield x] = int
+3 | type X[T: yield from x] = int
+  |           ^^^^^^^^^^^^ Syntax Error: yield expression cannot be used here
+4 | type X[T: x := int] = int
+  |
+
+
+  |
+2 | type X[T: yield x] = int
+3 | type X[T: yield from x] = int
+4 | type X[T: x := int] = int
+  |             ^^ Syntax Error: expected Comma, found ColonEqual
+  |

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@type_param_missing_bound.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@type_param_missing_bound.py.snap
@@ -1,0 +1,111 @@
+---
+source: crates/ruff_python_parser/tests/fixtures.rs
+input_file: crates/ruff_python_parser/resources/inline/err/type_param_missing_bound.py
+---
+## AST
+
+```
+Module(
+    ModModule {
+        range: 0..41,
+        body: [
+            TypeAlias(
+                StmtTypeAlias {
+                    range: 0..17,
+                    name: Name(
+                        ExprName {
+                            range: 5..6,
+                            id: "X",
+                            ctx: Store,
+                        },
+                    ),
+                    type_params: Some(
+                        TypeParams {
+                            range: 6..11,
+                            type_params: [
+                                TypeVar(
+                                    TypeParamTypeVar {
+                                        range: 7..9,
+                                        name: Identifier {
+                                            id: "T",
+                                            range: 7..8,
+                                        },
+                                        bound: None,
+                                    },
+                                ),
+                            ],
+                        },
+                    ),
+                    value: Name(
+                        ExprName {
+                            range: 14..17,
+                            id: "int",
+                            ctx: Load,
+                        },
+                    ),
+                },
+            ),
+            TypeAlias(
+                StmtTypeAlias {
+                    range: 18..40,
+                    name: Name(
+                        ExprName {
+                            range: 23..24,
+                            id: "X",
+                            ctx: Store,
+                        },
+                    ),
+                    type_params: Some(
+                        TypeParams {
+                            range: 24..34,
+                            type_params: [
+                                TypeVar(
+                                    TypeParamTypeVar {
+                                        range: 25..28,
+                                        name: Identifier {
+                                            id: "T1",
+                                            range: 25..27,
+                                        },
+                                        bound: None,
+                                    },
+                                ),
+                                TypeVar(
+                                    TypeParamTypeVar {
+                                        range: 31..33,
+                                        name: Identifier {
+                                            id: "T2",
+                                            range: 31..33,
+                                        },
+                                        bound: None,
+                                    },
+                                ),
+                            ],
+                        },
+                    ),
+                    value: Name(
+                        ExprName {
+                            range: 37..40,
+                            id: "int",
+                            ctx: Load,
+                        },
+                    ),
+                },
+            ),
+        ],
+    },
+)
+```
+## Errors
+
+  |
+1 | type X[T: ] = int
+  |           ^ Syntax Error: Expected an expression
+2 | type X[T1: , T2] = int
+  |
+
+
+  |
+1 | type X[T: ] = int
+2 | type X[T1: , T2] = int
+  |            ^ Syntax Error: Expected an expression
+  |

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@type_param_param_spec_bound.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@type_param_param_spec_bound.py.snap
@@ -1,0 +1,92 @@
+---
+source: crates/ruff_python_parser/tests/fixtures.rs
+input_file: crates/ruff_python_parser/resources/inline/err/type_param_param_spec_bound.py
+---
+## AST
+
+```
+Module(
+    ModModule {
+        range: 0..23,
+        body: [
+            TypeAlias(
+                StmtTypeAlias {
+                    range: 0..10,
+                    name: Name(
+                        ExprName {
+                            range: 5..6,
+                            id: "X",
+                            ctx: Store,
+                        },
+                    ),
+                    type_params: Some(
+                        TypeParams {
+                            range: 6..10,
+                            type_params: [
+                                ParamSpec(
+                                    TypeParamParamSpec {
+                                        range: 7..10,
+                                        name: Identifier {
+                                            id: "T",
+                                            range: 9..10,
+                                        },
+                                    },
+                                ),
+                            ],
+                        },
+                    ),
+                    value: Name(
+                        ExprName {
+                            range: 10..10,
+                            id: "",
+                            ctx: Invalid,
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 12..15,
+                    value: Name(
+                        ExprName {
+                            range: 12..15,
+                            id: "int",
+                            ctx: Load,
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 19..22,
+                    value: Name(
+                        ExprName {
+                            range: 19..22,
+                            id: "int",
+                            ctx: Load,
+                        },
+                    ),
+                },
+            ),
+        ],
+    },
+)
+```
+## Errors
+
+  |
+1 | type X[**T: int] = int
+  |           ^ Syntax Error: expected Rsqb, found Colon
+  |
+
+
+  |
+1 | type X[**T: int] = int
+  |                ^ Syntax Error: Expected a statement
+  |
+
+
+  |
+1 | type X[**T: int] = int
+  |                  ^ Syntax Error: Expected a statement
+  |

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@type_param_type_var_tuple_bound.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@type_param_type_var_tuple_bound.py.snap
@@ -1,0 +1,92 @@
+---
+source: crates/ruff_python_parser/tests/fixtures.rs
+input_file: crates/ruff_python_parser/resources/inline/err/type_param_type_var_tuple_bound.py
+---
+## AST
+
+```
+Module(
+    ModModule {
+        range: 0..22,
+        body: [
+            TypeAlias(
+                StmtTypeAlias {
+                    range: 0..9,
+                    name: Name(
+                        ExprName {
+                            range: 5..6,
+                            id: "X",
+                            ctx: Store,
+                        },
+                    ),
+                    type_params: Some(
+                        TypeParams {
+                            range: 6..9,
+                            type_params: [
+                                TypeVarTuple(
+                                    TypeParamTypeVarTuple {
+                                        range: 7..9,
+                                        name: Identifier {
+                                            id: "T",
+                                            range: 8..9,
+                                        },
+                                    },
+                                ),
+                            ],
+                        },
+                    ),
+                    value: Name(
+                        ExprName {
+                            range: 9..9,
+                            id: "",
+                            ctx: Invalid,
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 11..14,
+                    value: Name(
+                        ExprName {
+                            range: 11..14,
+                            id: "int",
+                            ctx: Load,
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 18..21,
+                    value: Name(
+                        ExprName {
+                            range: 18..21,
+                            id: "int",
+                            ctx: Load,
+                        },
+                    ),
+                },
+            ),
+        ],
+    },
+)
+```
+## Errors
+
+  |
+1 | type X[*T: int] = int
+  |          ^ Syntax Error: expected Rsqb, found Colon
+  |
+
+
+  |
+1 | type X[*T: int] = int
+  |               ^ Syntax Error: Expected a statement
+  |
+
+
+  |
+1 | type X[*T: int] = int
+  |                 ^ Syntax Error: Expected a statement
+  |


### PR DESCRIPTION
## Summary

This PR adds test cases for a type alias statement.

This doesn't really contain a lot of test cases because for most of them the lexer converts the `type` keyword to a `Name` token. They can be added when we remove the soft keyword transformer and move that logic in the parser.

