### PR TITLE
Use within-scope shadowed bindings in `asyncio-dangling-task`

### DIFF
--- a/crates/ruff_linter/src/rules/ruff/rules/asyncio_dangling_task.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/asyncio_dangling_task.rs
@@ -139,8 +139,7 @@ pub(crate) fn asyncio_dangling_binding(
         // else:
         //     task = asyncio.create_task(make_request())
         // ```
-        for binding_id in
-            std::iter::successors(Some(binding_id), |id| semantic.shadowed_binding(*id))
+        for binding_id in std::iter::successors(Some(binding_id), |id| scope.shadowed_binding(*id))
         {
             let binding = semantic.binding(binding_id);
             if binding.is_used()

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF006_RUF006.py.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF006_RUF006.py.snap
@@ -41,6 +41,16 @@ RUF006.py:97:5: RUF006 Store a reference to the return value of `loop.create_tas
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ RUF006
    |
 
+RUF006.py:152:13: RUF006 Store a reference to the return value of `asyncio.create_task`
+    |
+150 | async def f(x: bool):
+151 |     if x:
+152 |         t = asyncio.create_task(asyncio.sleep(1))
+    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ RUF006
+153 |     else:
+154 |         t = None
+    |
+
 RUF006.py:170:5: RUF006 Store a reference to the return value of `loop.create_task`
     |
 168 | def f():
@@ -60,5 +70,3 @@ RUF006.py:175:5: RUF006 Store a reference to the return value of `loop.create_ta
 176 | 
 177 | # OK
     |
-
-


### PR DESCRIPTION
## Summary

I think this is using the wrong shadowing, as seen by the change in the test fixture.
