### PR TITLE
Remove debug print when resolving client settings in `ruff server`

### DIFF
--- a/crates/ruff_server/src/session.rs
+++ b/crates/ruff_server/src/session.rs
@@ -96,12 +96,10 @@ impl Session {
     }
 
     pub(crate) fn take_snapshot(&self, url: &Url) -> Option<DocumentSnapshot> {
-        let resolved_settings = self.workspaces.client_settings(url, &self.global_settings);
-        tracing::info!("Resolved settings for document {url}: {resolved_settings:?}");
         Some(DocumentSnapshot {
             configuration: self.workspaces.configuration(url)?.clone(),
             resolved_client_capabilities: self.resolved_client_capabilities.clone(),
-            client_settings: resolved_settings,
+            client_settings: self.workspaces.client_settings(url, &self.global_settings),
             document_ref: self.workspaces.snapshot(url)?,
             position_encoding: self.position_encoding,
             url: url.clone(),


### PR DESCRIPTION
This was a statement used as part of the test plan in #10764 that was erroneously committed in 8aa31f4c7421d51e6aa4c4c71f271703d0ea51a5.