### PR TITLE
The linter and code actions can now be disabled in client settings for `ruff server`

### DIFF
--- a/crates/ruff_server/src/server/api/requests/code_action.rs
+++ b/crates/ruff_server/src/server/api/requests/code_action.rs
@@ -29,18 +29,24 @@ impl super::BackgroundDocumentRequestHandler for CodeActions {
 
         let supported_code_actions = supported_code_actions(params.context.only.clone());
 
-        if supported_code_actions.contains(&SupportedCodeAction::QuickFix) {
+        if snapshot.client_settings().fix_violation()
+            && supported_code_actions.contains(&SupportedCodeAction::QuickFix)
+        {
             response.extend(
                 quick_fix(&snapshot, params.context.diagnostics.clone())
                     .with_failure_code(ErrorCode::InternalError)?,
             );
         }
 
-        if supported_code_actions.contains(&SupportedCodeAction::SourceFixAll) {
+        if snapshot.client_settings().fix_all()
+            && supported_code_actions.contains(&SupportedCodeAction::SourceFixAll)
+        {
             response.push(fix_all(&snapshot).with_failure_code(ErrorCode::InternalError)?);
         }
 
-        if supported_code_actions.contains(&SupportedCodeAction::SourceOrganizeImports) {
+        if snapshot.client_settings().organize_imports()
+            && supported_code_actions.contains(&SupportedCodeAction::SourceOrganizeImports)
+        {
             response.push(organize_imports(&snapshot).with_failure_code(ErrorCode::InternalError)?);
         }
 

--- a/crates/ruff_server/src/server/api/requests/diagnostic.rs
+++ b/crates/ruff_server/src/server/api/requests/diagnostic.rs
@@ -19,11 +19,15 @@ impl super::BackgroundDocumentRequestHandler for DocumentDiagnostic {
         _notifier: Notifier,
         _params: types::DocumentDiagnosticParams,
     ) -> Result<DocumentDiagnosticReportResult> {
-        let diagnostics = crate::lint::check(
-            snapshot.document(),
-            &snapshot.configuration().linter,
-            snapshot.encoding(),
-        );
+        let diagnostics = if snapshot.client_settings().lint() {
+            crate::lint::check(
+                snapshot.document(),
+                &snapshot.configuration().linter,
+                snapshot.encoding(),
+            )
+        } else {
+            vec![]
+        };
 
         Ok(DocumentDiagnosticReportResult::Report(
             types::DocumentDiagnosticReport::Full(RelatedFullDocumentDiagnosticReport {

--- a/crates/ruff_server/src/session.rs
+++ b/crates/ruff_server/src/session.rs
@@ -36,7 +36,6 @@ pub(crate) struct Session {
 pub(crate) struct DocumentSnapshot {
     configuration: Arc<RuffConfiguration>,
     resolved_client_capabilities: Arc<ResolvedClientCapabilities>,
-    #[allow(dead_code)]
     client_settings: settings::ResolvedClientSettings,
     document_ref: DocumentRef,
     position_encoding: PositionEncoding,
@@ -217,6 +216,10 @@ impl DocumentSnapshot {
 
     pub(crate) fn resolved_client_capabilities(&self) -> &ResolvedClientCapabilities {
         &self.resolved_client_capabilities
+    }
+
+    pub(crate) fn client_settings(&self) -> &ResolvedClientSettings {
+        &self.client_settings
     }
 
     pub(crate) fn document(&self) -> &DocumentRef {

--- a/crates/ruff_server/src/session/settings.rs
+++ b/crates/ruff_server/src/session/settings.rs
@@ -12,12 +12,13 @@ pub(crate) type WorkspaceSettingsMap = FxHashMap<Url, ClientSettings>;
 /// sends them.
 #[derive(Debug)]
 #[cfg_attr(test, derive(PartialEq, Eq))]
-// TODO(jane): Remove dead code warning
-#[allow(dead_code, clippy::struct_excessive_bools)]
+#[allow(clippy::struct_excessive_bools)]
 pub(crate) struct ResolvedClientSettings {
     fix_all: bool,
     organize_imports: bool,
     lint_enable: bool,
+    // TODO(jane): Remove once noqa auto-fix is implemented
+    #[allow(dead_code)]
     disable_rule_comment_enable: bool,
     fix_violation_enable: bool,
 }
@@ -193,6 +194,24 @@ impl ResolvedClientSettings {
             .map(Deref::deref)
             .find_map(get)
             .unwrap_or(default)
+    }
+}
+
+impl ResolvedClientSettings {
+    pub(crate) fn fix_all(&self) -> bool {
+        self.fix_all
+    }
+
+    pub(crate) fn organize_imports(&self) -> bool {
+        self.organize_imports
+    }
+
+    pub(crate) fn lint(&self) -> bool {
+        self.lint_enable
+    }
+
+    pub(crate) fn fix_violation(&self) -> bool {
+        self.fix_violation_enable
     }
 }
 


### PR DESCRIPTION
## Summary

This is a follow-up to https://github.com/astral-sh/ruff/pull/10764. Support for diagnostics, quick fixes, and source actions can now be disabled via client settings.

## Test Plan

### Manual Testing

Set up your workspace as described in the test plan in https://github.com/astral-sh/ruff/pull/10764, up to step 2. You don't need to add a debug statement.
The configuration for `folder_a` and `folder_b` should be as follows:
`folder_a`:
```json
{
    "ruff.codeAction.fixViolation": {
        "enable": true
    }
}
```

`folder_b`
```json
{
    "ruff.codeAction.fixViolation": {
        "enable": false
    }
}
```
Finally, open up your VS Code User Settings and un-check the `Ruff > Fix All` setting.

1. Open a Python file in `folder_a` that has existing problems. The problems should be highlighted, and quick fix should be available. `source.fixAll` should not be available as a source action.
2. Open a Python file in `folder_b` that has existing problems. The problems should be highlighted, but quick fixes should not be available for any of them. `source.fixAll` should not be available as a source action.
3. Open up your VS Code Workspace Settings (second tab under the search bar) and un-check `Ruff > Lint: Enable`
4. Both files you tested in steps 1 and 2 should now lack any visible diagnostics. `source.organizeImports` should still be available as a source action.