### PR TITLE
Use `test_ok` for inline tests, merge test report

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,5 +8,7 @@ crates/ruff_linter/resources/test/fixtures/pycodestyle/W391_3.py text eol=crlf
 crates/ruff_python_formatter/resources/test/fixtures/ruff/docstring_code_examples_crlf.py text eol=crlf
 crates/ruff_python_formatter/tests/snapshots/format@docstring_code_examples_crlf.py.snap text eol=crlf
 
+crates/ruff_python_parser/resources/inline linguist-generated=true
+
 ruff.schema.json linguist-generated=true text=auto eol=lf
 *.md.snap linguist-language=Markdown

--- a/crates/ruff_python_parser/CONTRIBUTING.md
+++ b/crates/ruff_python_parser/CONTRIBUTING.md
@@ -13,7 +13,7 @@ Test that the parser successfully parses the input with no syntax errors. They'r
 written in the following format:
 
 ```rs
-// test this_is_the_test_name
+// test_ok this_is_the_test_name
 // def foo():
 //     pass
 println!("some rust code");
@@ -28,14 +28,14 @@ in the following format:
 println!("some rust code");
 ```
 
-Note that the difference between the two is the `test` and `test_err` keywords.
+Note that the difference between the two is the `test_ok` and `test_err` keywords.
 The comment block must be independent of any other comment blocks. For example, the
 following is not extracted:
 
 ```rs
 // Some random comment
 //
-// test this_is_the_test_name
+// test_ok this_is_the_test_name
 // def foo():
 //     pass
 println!("some rust code");

--- a/crates/ruff_python_parser/src/parser/expression.rs
+++ b/crates/ruff_python_parser/src/parser/expression.rs
@@ -2294,7 +2294,7 @@ impl<'src> Parser<'src> {
         self.bump(TokenKind::Lambda);
 
         let parameters = if self.at(TokenKind::Colon) {
-            // test lambda_with_no_parameters
+            // test_ok lambda_with_no_parameters
             // lambda: 1
             None
         } else {
@@ -2303,7 +2303,7 @@ impl<'src> Parser<'src> {
 
         self.expect(TokenKind::Colon);
 
-        // test lambda_with_valid_body
+        // test_ok lambda_with_valid_body
         // lambda x: x
         // lambda x: x if True else y
         // lambda x: await x

--- a/crates/ruff_python_parser/src/parser/mod.rs
+++ b/crates/ruff_python_parser/src/parser/mod.rs
@@ -958,7 +958,7 @@ impl RecoveryContextKind {
                     // When the parser is parsing f-string elements inside format spec,
                     // the terminator would be `}`.
 
-                    // test fstring_format_spec_terminator
+                    // test_ok fstring_format_spec_terminator
                     // f"hello {x:} world"
                     // f"hello {x:.3f} world"
                     TokenKind::Rbrace,

--- a/crates/ruff_python_parser/src/parser/statement.rs
+++ b/crates/ruff_python_parser/src/parser/statement.rs
@@ -456,7 +456,7 @@ impl<'src> Parser<'src> {
             None
         };
 
-        // test from_import_no_space
+        // test_ok from_import_no_space
         // from.import x
         // from...import x
         self.expect(TokenKind::Import);
@@ -580,7 +580,7 @@ impl<'src> Parser<'src> {
             dotted_name.push_str(&self.parse_identifier());
         }
 
-        // test dotted_name_normalized_spaces
+        // test_ok dotted_name_normalized_spaces
         // import a.b.c
         // import a .  b  . c
         ast::Identifier {
@@ -714,7 +714,7 @@ impl<'src> Parser<'src> {
             self.add_error(ParseErrorType::EmptyGlobalNames, self.current_token_range());
         }
 
-        // test global_stmt
+        // test_ok global_stmt
         // global x
         // global x, y, z
         ast::StmtGlobal {
@@ -755,7 +755,7 @@ impl<'src> Parser<'src> {
             );
         }
 
-        // test nonlocal_stmt
+        // test_ok nonlocal_stmt
         // nonlocal x
         // nonlocal x, y, z
         ast::StmtNonlocal {


### PR DESCRIPTION
## Summary

This PR makes two quality of life improvements for parser's inline test implementation:
1. Rename `test` to `test_ok` to explicitly specify that this is a valid syntax test
2. Merge the reporting of "ok" and "err" test cases and unreferenced test cases

The output of (2) now looks like:

```
---- generate_inline_tests stdout ----
Error: Unreferenced test files found for which no comment exists:
  crates/ruff_python_parser/resources/inline/err/something_else.py
Please delete these files manually

Following files were not up-to date and has been updated:
  crates/ruff_python_parser/resources/inline/err/renamed_it.py
Re-run the tests with `cargo test` to update the test snapshots

```

## Test Plan

1. Add two random test cases:

	```rs
	// test_ok something
	// x = 1
	
	// test_err something_else
	// [1, 2
	```

2. Run the generation step:

	```console
	cargo test --package ruff_python_parser --test generate_inline_tests
	```

3. Rename `something_else` to `renamed_it` and run the generation step again to see the above output