### PR TITLE
Avoid error handling duplication for starred, yield, lambda expressions

### DIFF
--- a/crates/ruff_python_parser/src/error.rs
+++ b/crates/ruff_python_parser/src/error.rs
@@ -107,6 +107,8 @@ pub enum ParseErrorType {
     UnparenthesizedNamedExpression,
     /// An unparenthesized tuple expression was found where it is not allowed.
     UnparenthesizedTupleExpression,
+    /// An unparenthesized lambda expression was found where it is not allowed.
+    InvalidLambdaExpressionUsage,
 
     /// An invalid expression was found in the assignment `target`.
     InvalidAssignmentTarget,
@@ -207,6 +209,9 @@ impl std::fmt::Display for ParseErrorType {
             }
             ParseErrorType::UnparenthesizedTupleExpression => {
                 write!(f, "unparenthesized tuple expression cannot be used here")
+            }
+            ParseErrorType::InvalidLambdaExpressionUsage => {
+                write!(f, "`lambda` expression cannot be used here")
             }
             ParseErrorType::StarredExpressionUsage => {
                 write!(f, "starred expression cannot be used here")

--- a/crates/ruff_python_parser/src/error.rs
+++ b/crates/ruff_python_parser/src/error.rs
@@ -109,6 +109,8 @@ pub enum ParseErrorType {
     UnparenthesizedTupleExpression,
     /// An unparenthesized lambda expression was found where it is not allowed.
     InvalidLambdaExpressionUsage,
+    /// An invalid usage of a yield expression was found.
+    InvalidYieldExpressionUsage,
 
     /// An invalid expression was found in the assignment `target`.
     InvalidAssignmentTarget,
@@ -209,6 +211,9 @@ impl std::fmt::Display for ParseErrorType {
             }
             ParseErrorType::UnparenthesizedTupleExpression => {
                 write!(f, "unparenthesized tuple expression cannot be used here")
+            }
+            ParseErrorType::InvalidYieldExpressionUsage => {
+                write!(f, "yield expression cannot be used here")
             }
             ParseErrorType::InvalidLambdaExpressionUsage => {
                 write!(f, "`lambda` expression cannot be used here")

--- a/crates/ruff_python_parser/src/error.rs
+++ b/crates/ruff_python_parser/src/error.rs
@@ -107,7 +107,7 @@ pub enum ParseErrorType {
     UnparenthesizedNamedExpression,
     /// An unparenthesized tuple expression was found where it is not allowed.
     UnparenthesizedTupleExpression,
-    /// An unparenthesized lambda expression was found where it is not allowed.
+    /// An invalid usage of a lambda expression was found.
     InvalidLambdaExpressionUsage,
     /// An invalid usage of a yield expression was found.
     InvalidYieldExpressionUsage,

--- a/crates/ruff_python_parser/src/parser/mod.rs
+++ b/crates/ruff_python_parser/src/parser/mod.rs
@@ -16,6 +16,8 @@ use crate::{
     Mode, ParseError, ParseErrorType, Tok, TokenKind,
 };
 
+use self::expression::AllowStarredExpression;
+
 mod expression;
 mod helpers;
 mod pattern;
@@ -177,7 +179,7 @@ impl<'src> Parser<'src> {
     pub(crate) fn parse_program(mut self) -> Program {
         let ast = if self.mode == Mode::Expression {
             let start = self.node_start();
-            let parsed_expr = self.parse_expression_list();
+            let parsed_expr = self.parse_expression_list(AllowStarredExpression::No);
             let mut progress = ParserProgress::default();
 
             // TODO: How should error recovery work here? Just truncate after the expression?

--- a/crates/ruff_python_parser/src/parser/statement.rs
+++ b/crates/ruff_python_parser/src/parser/statement.rs
@@ -14,6 +14,7 @@ use crate::parser::{
 use crate::token_set::TokenSet;
 use crate::{Mode, ParseErrorType, Tok, TokenKind};
 
+use super::expression::AllowStarredExpression;
 use super::Parenthesized;
 
 /// Tokens that can appear after an expression.
@@ -253,7 +254,10 @@ impl<'src> Parser<'src> {
         let targets = self.parse_comma_separated_list_into_vec(
             RecoveryContextKind::DeleteTargets,
             |parser| {
-                let mut target = parser.parse_conditional_expression_or_higher();
+                // Allow starred expression to raise a better error message for
+                // an invalid delete target later.
+                let mut target =
+                    parser.parse_conditional_expression_or_higher(AllowStarredExpression::Yes);
                 helpers::set_expr_ctx(&mut target.expr, ExprContext::Del);
 
                 if !helpers::is_valid_del_target(&target.expr) {
@@ -329,7 +333,7 @@ impl<'src> Parser<'src> {
             // raise *x
             // raise yield x
             // raise x := 1
-            let exc = self.parse_expression_list();
+            let exc = self.parse_expression_list(AllowStarredExpression::No);
 
             if let Some(ast::ExprTuple {
                 parenthesized: false,
@@ -352,7 +356,7 @@ impl<'src> Parser<'src> {
             // raise x from *y
             // raise x from yield y
             // raise x from y := 1
-            let cause = self.parse_expression_list();
+            let cause = self.parse_expression_list(AllowStarredExpression::No);
 
             if let Some(ast::ExprTuple {
                 parenthesized: false,
@@ -654,7 +658,7 @@ impl<'src> Parser<'src> {
         // assert assert x
         // assert yield x
         // assert x := 1
-        let test = self.parse_conditional_expression_or_higher();
+        let test = self.parse_conditional_expression_or_higher(AllowStarredExpression::No);
 
         let msg = if self.eat(TokenKind::Comma) {
             if self.at_expr() {
@@ -664,7 +668,10 @@ impl<'src> Parser<'src> {
                 // assert False, assert x
                 // assert False, yield x
                 // assert False, x := 1
-                Some(Box::new(self.parse_conditional_expression_or_higher().expr))
+                Some(Box::new(
+                    self.parse_conditional_expression_or_higher(AllowStarredExpression::No)
+                        .expr,
+                ))
             } else {
                 // test_err assert_empty_msg
                 // assert x,
@@ -800,7 +807,7 @@ impl<'src> Parser<'src> {
 
         self.expect(TokenKind::Equal);
 
-        let value = self.parse_conditional_expression_or_higher();
+        let value = self.parse_conditional_expression_or_higher(AllowStarredExpression::No);
 
         ast::StmtTypeAlias {
             name: Box::new(name),
@@ -826,13 +833,13 @@ impl<'src> Parser<'src> {
     /// See: <https://docs.python.org/3/reference/simple_stmts.html#grammar-token-python-grammar-assignment_stmt>
     fn parse_assign_statement(&mut self, target: ParsedExpr, start: TextSize) -> ast::StmtAssign {
         let mut targets = vec![target.expr];
-        let mut value = self.parse_expression_list();
+        let mut value = self.parse_expression_list(AllowStarredExpression::Yes);
 
         if self.at(TokenKind::Equal) {
             self.parse_list(RecoveryContextKind::AssignmentTargets, |parser| {
                 parser.bump(TokenKind::Equal);
 
-                let mut parsed_expr = parser.parse_expression_list();
+                let mut parsed_expr = parser.parse_expression_list(AllowStarredExpression::Yes);
 
                 std::mem::swap(&mut value, &mut parsed_expr);
 
@@ -885,7 +892,7 @@ impl<'src> Parser<'src> {
 
         // Annotation is actually just an `expression` but we use `expressions`
         // for better error recovery in case tuple isn't parenthesized.
-        let annotation = self.parse_expression_list();
+        let annotation = self.parse_expression_list(AllowStarredExpression::No);
 
         if matches!(
             annotation.expr,
@@ -902,7 +909,7 @@ impl<'src> Parser<'src> {
 
         let value = self
             .eat(TokenKind::Equal)
-            .then(|| Box::new(self.parse_expression_list().expr));
+            .then(|| Box::new(self.parse_expression_list(AllowStarredExpression::Yes).expr));
 
         ast::StmtAnnAssign {
             target: Box::new(target.expr),
@@ -938,7 +945,7 @@ impl<'src> Parser<'src> {
 
         helpers::set_expr_ctx(&mut target.expr, ExprContext::Store);
 
-        let value = self.parse_expression_list();
+        let value = self.parse_expression_list(AllowStarredExpression::Yes);
 
         ast::StmtAugAssign {
             target: Box::new(target.expr),
@@ -953,7 +960,7 @@ impl<'src> Parser<'src> {
         let if_start = self.node_start();
         self.bump(TokenKind::If);
 
-        let test = self.parse_named_expression_or_higher();
+        let test = self.parse_named_expression_or_higher(AllowStarredExpression::No);
         self.expect(TokenKind::Colon);
 
         let body = self.parse_body(Clause::If);
@@ -974,7 +981,7 @@ impl<'src> Parser<'src> {
                 let elif_start = p.node_start();
                 p.bump(TokenKind::Elif);
 
-                let test = p.parse_named_expression_or_higher();
+                let test = p.parse_named_expression_or_higher(AllowStarredExpression::No);
                 p.expect(TokenKind::Colon);
 
                 let body = p.parse_body(Clause::ElIf);
@@ -1026,7 +1033,7 @@ impl<'src> Parser<'src> {
             let type_ = if p.at(TokenKind::Colon) && !is_star {
                 None
             } else {
-                let parsed_expr = p.parse_expression_list();
+                let parsed_expr = p.parse_expression_list(AllowStarredExpression::No);
                 if matches!(
                     parsed_expr.expr,
                     Expr::Tuple(ast::ExprTuple {
@@ -1099,14 +1106,14 @@ impl<'src> Parser<'src> {
         self.bump(TokenKind::For);
 
         let saved_context = self.set_ctx(ParserCtxFlags::FOR_TARGET);
-        let mut target = self.parse_expression_list();
+        let mut target = self.parse_expression_list(AllowStarredExpression::Yes);
         self.restore_ctx(ParserCtxFlags::FOR_TARGET, saved_context);
 
         helpers::set_expr_ctx(&mut target.expr, ExprContext::Store);
 
         self.expect(TokenKind::In);
 
-        let iter = self.parse_expression_list();
+        let iter = self.parse_expression_list(AllowStarredExpression::Yes);
 
         self.expect(TokenKind::Colon);
 
@@ -1134,7 +1141,7 @@ impl<'src> Parser<'src> {
         let while_start = self.node_start();
         self.bump(TokenKind::While);
 
-        let test = self.parse_named_expression_or_higher();
+        let test = self.parse_named_expression_or_higher(AllowStarredExpression::No);
         self.expect(TokenKind::Colon);
 
         let body = self.parse_body(Clause::While);
@@ -1171,7 +1178,7 @@ impl<'src> Parser<'src> {
         parameters.range = self.node_range(parameters_start);
 
         let returns = self.eat(TokenKind::Rarrow).then(|| {
-            let returns = self.parse_expression_list();
+            let returns = self.parse_expression_list(AllowStarredExpression::No);
             if !returns.is_parenthesized && matches!(returns.expr, Expr::Tuple(_)) {
                 self.add_error(
                     ParseErrorType::OtherError(
@@ -1545,7 +1552,7 @@ impl<'src> Parser<'src> {
     fn parse_with_item(&mut self, state: WithItemParsingState) -> ParsedWithItem {
         let start = self.node_start();
 
-        let parsed_expr = self.parse_conditional_expression_or_higher();
+        let parsed_expr = self.parse_conditional_expression_or_higher(AllowStarredExpression::Yes);
         let mut used_ambiguous_lpar = false;
 
         // While parsing a with item after an ambiguous `(` token, we need to check
@@ -1656,7 +1663,7 @@ impl<'src> Parser<'src> {
     fn parse_with_item_optional_vars(&mut self) -> ParsedExpr {
         self.bump(TokenKind::As);
 
-        let mut target = self.parse_conditional_expression_or_higher();
+        let mut target = self.parse_conditional_expression_or_higher(AllowStarredExpression::Yes);
 
         // This has the same semantics as an assignment target.
         if !helpers::is_valid_assignment_target(&target.expr) {
@@ -1681,14 +1688,12 @@ impl<'src> Parser<'src> {
         self.bump(TokenKind::Match);
 
         let subject_start = self.node_start();
-        let subject = self.parse_named_expression_or_higher();
+        let subject = self.parse_named_expression_or_higher(AllowStarredExpression::No);
         let subject = if self.at(TokenKind::Comma) {
-            let tuple = self.parse_tuple_expression(
-                subject.expr,
-                subject_start,
-                Parenthesized::No,
-                Parser::parse_named_expression_or_higher,
-            );
+            let tuple =
+                self.parse_tuple_expression(subject.expr, subject_start, Parenthesized::No, |p| {
+                    p.parse_named_expression_or_higher(AllowStarredExpression::No)
+                });
 
             Expr::Tuple(tuple).into()
         } else {
@@ -1752,9 +1757,12 @@ impl<'src> Parser<'src> {
         self.bump(TokenKind::Case);
         let pattern = self.parse_match_patterns();
 
-        let guard = self
-            .eat(TokenKind::If)
-            .then(|| Box::new(self.parse_named_expression_or_higher().expr));
+        let guard = self.eat(TokenKind::If).then(|| {
+            Box::new(
+                self.parse_named_expression_or_higher(AllowStarredExpression::No)
+                    .expr,
+            )
+        });
 
         self.expect(TokenKind::Colon);
         let body = self.parse_body(Clause::Match);
@@ -1812,7 +1820,7 @@ impl<'src> Parser<'src> {
             let decorator_start = self.node_start();
             self.bump(TokenKind::At);
 
-            let parsed_expr = self.parse_named_expression_or_higher();
+            let parsed_expr = self.parse_named_expression_or_higher(AllowStarredExpression::No);
             decorators.push(ast::Decorator {
                 expression: parsed_expr.expr,
                 range: self.node_range(decorator_start),
@@ -1887,7 +1895,10 @@ impl<'src> Parser<'src> {
         // this is the `lambda`'s body, don't try to parse as an annotation.
         let annotation = if function_kind == FunctionKind::FunctionDef && self.eat(TokenKind::Colon)
         {
-            Some(Box::new(self.parse_conditional_expression_or_higher().expr))
+            Some(Box::new(
+                self.parse_conditional_expression_or_higher(AllowStarredExpression::Yes)
+                    .expr,
+            ))
         } else {
             None
         };
@@ -1906,9 +1917,12 @@ impl<'src> Parser<'src> {
         let start = self.node_start();
         let parameter = self.parse_parameter(function_kind);
 
-        let default = self
-            .eat(TokenKind::Equal)
-            .then(|| Box::new(self.parse_conditional_expression_or_higher().expr));
+        let default = self.eat(TokenKind::Equal).then(|| {
+            Box::new(
+                self.parse_conditional_expression_or_higher(AllowStarredExpression::No)
+                    .expr,
+            )
+        });
 
         ast::ParameterWithDefault {
             range: self.node_range(start),
@@ -2053,9 +2067,12 @@ impl<'src> Parser<'src> {
             })
         } else {
             let name = self.parse_identifier();
-            let bound = self
-                .eat(TokenKind::Colon)
-                .then(|| Box::new(self.parse_conditional_expression_or_higher().expr));
+            let bound = self.eat(TokenKind::Colon).then(|| {
+                Box::new(
+                    self.parse_conditional_expression_or_higher(AllowStarredExpression::No)
+                        .expr,
+                )
+            });
 
             ast::TypeParam::TypeVar(ast::TypeParamTypeVar {
                 range: self.node_range(start),

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__arguments__double_starred.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__arguments__double_starred.py.snap
@@ -181,7 +181,7 @@ Module(
 
   |
 1 | call(**yield x)
-  |        ^^^^^^^ Syntax Error: Unparenthesized yield expression cannot be used here
+  |        ^^^^^^^ Syntax Error: yield expression cannot be used here
 2 | call(** *x)
 3 | call(***x)
   |

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__arguments__invalid_expression.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__arguments__invalid_expression.py.snap
@@ -187,7 +187,7 @@ Module(
 2 | call(x := 1 = 1)
 3 | 
 4 | call(yield x)
-  |      ^^^^^^^ Syntax Error: unparenthesized yield expression cannot be used here
+  |      ^^^^^^^ Syntax Error: yield expression cannot be used here
 5 | call(yield from x)
   |
 
@@ -195,5 +195,5 @@ Module(
   |
 4 | call(yield x)
 5 | call(yield from x)
-  |      ^^^^^^^^^^^^ Syntax Error: unparenthesized yield expression cannot be used here
+  |      ^^^^^^^^^^^^ Syntax Error: yield expression cannot be used here
   |

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__arguments__invalid_keyword_expression.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__arguments__invalid_keyword_expression.py.snap
@@ -197,7 +197,7 @@ Module(
 
   |
 1 | call(x = yield y)
-  |          ^^^^^^^ Syntax Error: Unparenthesized yield expression cannot be used here
+  |          ^^^^^^^ Syntax Error: yield expression cannot be used here
 2 | call(x = yield from y)
 3 | call(x = *y)
   |
@@ -206,7 +206,7 @@ Module(
   |
 1 | call(x = yield y)
 2 | call(x = yield from y)
-  |          ^^^^^^^^^^^^ Syntax Error: Unparenthesized yield expression cannot be used here
+  |          ^^^^^^^^^^^^ Syntax Error: yield expression cannot be used here
 3 | call(x = *y)
 4 | call(x = (*y))
   |

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__arguments__starred.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__arguments__starred.py.snap
@@ -168,3 +168,19 @@ Module(
 2 | call(*yield x)
 3 | call(*yield from x)
   |
+
+
+  |
+1 | call(*data for data in iter)
+2 | call(*yield x)
+  |       ^^^^^^^ Syntax Error: yield expression cannot be used here
+3 | call(*yield from x)
+  |
+
+
+  |
+1 | call(*data for data in iter)
+2 | call(*yield x)
+3 | call(*yield from x)
+  |       ^^^^^^^^^^^^ Syntax Error: yield expression cannot be used here
+  |

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__await__recover.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__await__recover.py.snap
@@ -274,7 +274,7 @@ Module(
    |
 11 | # Invalid expression as per precedence
 12 | await yield x
-   |       ^^^^^^^ Syntax Error: `yield` expression cannot be used here
+   |       ^^^^^^^ Syntax Error: yield expression cannot be used here
 13 | await lambda x: x
 14 | await +x
    |

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__bin_op__invalid_rhs_expression.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__bin_op__invalid_rhs_expression.py.snap
@@ -112,5 +112,5 @@ Module(
 1 | x + lambda y: y
 2 | 
 3 | x - yield y
-  |     ^^^^^^^ Syntax Error: `yield` expression cannot be used here
+  |     ^^^^^^^ Syntax Error: yield expression cannot be used here
   |

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__bool_op__invalid_rhs_expression.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__bool_op__invalid_rhs_expression.py.snap
@@ -116,5 +116,5 @@ Module(
 1 | x and lambda y: y
 2 | 
 3 | x or yield y
-  |      ^^^^^^^ Syntax Error: `yield` expression cannot be used here
+  |      ^^^^^^^ Syntax Error: yield expression cannot be used here
   |

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__compare__invalid_rhs_expression.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__compare__invalid_rhs_expression.py.snap
@@ -120,5 +120,5 @@ Module(
 1 | x not in lambda y: y
 2 | 
 3 | x == yield y
-  |      ^^^^^^^ Syntax Error: `yield` expression cannot be used here
+  |      ^^^^^^^ Syntax Error: yield expression cannot be used here
   |

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__dict__comprehension.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__dict__comprehension.py.snap
@@ -766,7 +766,7 @@ Module(
  7 | # Invalid iter
  8 | {x: y for x in *y}
  9 | {x: y for x in yield y}
-   |                ^^^^^^^ Syntax Error: unparenthesized yield expression cannot be used here
+   |                ^^^^^^^ Syntax Error: yield expression cannot be used here
 10 | {x: y for x in yield from y}
 11 | {x: y for x in lambda y: y}
    |
@@ -776,7 +776,7 @@ Module(
  8 | {x: y for x in *y}
  9 | {x: y for x in yield y}
 10 | {x: y for x in yield from y}
-   |                ^^^^^^^^^^^^ Syntax Error: unparenthesized yield expression cannot be used here
+   |                ^^^^^^^^^^^^ Syntax Error: yield expression cannot be used here
 11 | {x: y for x in lambda y: y}
    |
 
@@ -804,7 +804,7 @@ Module(
 13 | # Invalid if
 14 | {x: y for x in data if *y}
 15 | {x: y for x in data if yield y}
-   |                        ^^^^^^^ Syntax Error: unparenthesized yield expression cannot be used here
+   |                        ^^^^^^^ Syntax Error: yield expression cannot be used here
 16 | {x: y for x in data if yield from y}
 17 | {x: y for x in data if lambda y: y}
    |
@@ -814,7 +814,7 @@ Module(
 14 | {x: y for x in data if *y}
 15 | {x: y for x in data if yield y}
 16 | {x: y for x in data if yield from y}
-   |                        ^^^^^^^^^^^^ Syntax Error: unparenthesized yield expression cannot be used here
+   |                        ^^^^^^^^^^^^ Syntax Error: yield expression cannot be used here
 17 | {x: y for x in data if lambda y: y}
    |
 

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__dict__comprehension.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__dict__comprehension.py.snap
@@ -785,7 +785,7 @@ Module(
  9 | {x: y for x in yield y}
 10 | {x: y for x in yield from y}
 11 | {x: y for x in lambda y: y}
-   |                ^^^^^^^^^^^ Syntax Error: unparenthesized lambda expression cannot be used here
+   |                ^^^^^^^^^^^ Syntax Error: `lambda` expression cannot be used here
 12 | 
 13 | # Invalid if
    |
@@ -823,5 +823,5 @@ Module(
 15 | {x: y for x in data if yield y}
 16 | {x: y for x in data if yield from y}
 17 | {x: y for x in data if lambda y: y}
-   |                        ^^^^^^^^^^^ Syntax Error: unparenthesized lambda expression cannot be used here
+   |                        ^^^^^^^^^^^ Syntax Error: `lambda` expression cannot be used here
    |

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__dict__recover.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__dict__recover.py.snap
@@ -491,5 +491,13 @@ Module(
 22 | # Star expression not allowed here
 23 | {*x: y, z: a, *b: c}
 24 | {x: *y, z: *a}
+   |     ^^ Syntax Error: starred expression cannot be used here
+   |
+
+
+   |
+22 | # Star expression not allowed here
+23 | {*x: y, z: a, *b: c}
+24 | {x: *y, z: *a}
    |            ^^ Syntax Error: starred expression cannot be used here
    |

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__if__recover.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__if__recover.py.snap
@@ -309,7 +309,7 @@ Module(
 1 | # Invalid test expression
 2 | x if *expr else y
 3 | x if lambda x: x else y
-  |      ^^^^^^^^^^^ Syntax Error: unparenthesized lambda expression cannot be used here
+  |      ^^^^^^^^^^^ Syntax Error: `lambda` expression cannot be used here
 4 | x if yield x else y
 5 | x if yield from x else y
   |

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__if__recover.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__if__recover.py.snap
@@ -319,7 +319,7 @@ Module(
 2 | x if *expr else y
 3 | x if lambda x: x else y
 4 | x if yield x else y
-  |      ^^^^^^^ Syntax Error: unparenthesized yield expression cannot be used here
+  |      ^^^^^^^ Syntax Error: yield expression cannot be used here
 5 | x if yield from x else y
   |
 
@@ -328,7 +328,7 @@ Module(
 3 | x if lambda x: x else y
 4 | x if yield x else y
 5 | x if yield from x else y
-  |      ^^^^^^^^^^^^ Syntax Error: unparenthesized yield expression cannot be used here
+  |      ^^^^^^^^^^^^ Syntax Error: yield expression cannot be used here
 6 | 
 7 | # Invalid orelse expression
   |
@@ -347,7 +347,7 @@ Module(
  7 | # Invalid orelse expression
  8 | x if expr else *orelse
  9 | x if expr else yield y
-   |                ^^^^^^^ Syntax Error: unparenthesized yield expression cannot be used here
+   |                ^^^^^^^ Syntax Error: yield expression cannot be used here
 10 | x if expr else yield from y
    |
 
@@ -356,5 +356,5 @@ Module(
  8 | x if expr else *orelse
  9 | x if expr else yield y
 10 | x if expr else yield from y
-   |                ^^^^^^^^^^^^ Syntax Error: unparenthesized yield expression cannot be used here
+   |                ^^^^^^^^^^^^ Syntax Error: yield expression cannot be used here
    |

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__list__comprehension.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__list__comprehension.py.snap
@@ -754,7 +754,7 @@ Module(
 12 | [x for x in yield y]
 13 | [x for x in yield from y]
 14 | [x for x in lambda y: y]
-   |             ^^^^^^^^^^^ Syntax Error: unparenthesized lambda expression cannot be used here
+   |             ^^^^^^^^^^^ Syntax Error: `lambda` expression cannot be used here
 15 | 
 16 | # Invalid if
    |
@@ -792,5 +792,5 @@ Module(
 18 | [x for x in data if yield y]
 19 | [x for x in data if yield from y]
 20 | [x for x in data if lambda y: y]
-   |                     ^^^^^^^^^^^ Syntax Error: unparenthesized lambda expression cannot be used here
+   |                     ^^^^^^^^^^^ Syntax Error: `lambda` expression cannot be used here
    |

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__list__comprehension.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__list__comprehension.py.snap
@@ -735,7 +735,7 @@ Module(
 10 | # Invalid iter
 11 | [x for x in *y]
 12 | [x for x in yield y]
-   |             ^^^^^^^ Syntax Error: unparenthesized yield expression cannot be used here
+   |             ^^^^^^^ Syntax Error: yield expression cannot be used here
 13 | [x for x in yield from y]
 14 | [x for x in lambda y: y]
    |
@@ -745,7 +745,7 @@ Module(
 11 | [x for x in *y]
 12 | [x for x in yield y]
 13 | [x for x in yield from y]
-   |             ^^^^^^^^^^^^ Syntax Error: unparenthesized yield expression cannot be used here
+   |             ^^^^^^^^^^^^ Syntax Error: yield expression cannot be used here
 14 | [x for x in lambda y: y]
    |
 
@@ -773,7 +773,7 @@ Module(
 16 | # Invalid if
 17 | [x for x in data if *y]
 18 | [x for x in data if yield y]
-   |                     ^^^^^^^ Syntax Error: unparenthesized yield expression cannot be used here
+   |                     ^^^^^^^ Syntax Error: yield expression cannot be used here
 19 | [x for x in data if yield from y]
 20 | [x for x in data if lambda y: y]
    |
@@ -783,7 +783,7 @@ Module(
 17 | [x for x in data if *y]
 18 | [x for x in data if yield y]
 19 | [x for x in data if yield from y]
-   |                     ^^^^^^^^^^^^ Syntax Error: unparenthesized yield expression cannot be used here
+   |                     ^^^^^^^^^^^^ Syntax Error: yield expression cannot be used here
 20 | [x for x in data if lambda y: y]
    |
 

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__set__comprehension.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__set__comprehension.py.snap
@@ -754,7 +754,7 @@ Module(
 12 | {x for x in yield y}
 13 | {x for x in yield from y}
 14 | {x for x in lambda y: y}
-   |             ^^^^^^^^^^^ Syntax Error: unparenthesized lambda expression cannot be used here
+   |             ^^^^^^^^^^^ Syntax Error: `lambda` expression cannot be used here
 15 | 
 16 | # Invalid if
    |
@@ -792,5 +792,5 @@ Module(
 18 | {x for x in data if yield y}
 19 | {x for x in data if yield from y}
 20 | {x for x in data if lambda y: y}
-   |                     ^^^^^^^^^^^ Syntax Error: unparenthesized lambda expression cannot be used here
+   |                     ^^^^^^^^^^^ Syntax Error: `lambda` expression cannot be used here
    |

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__set__comprehension.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__set__comprehension.py.snap
@@ -735,7 +735,7 @@ Module(
 10 | # Invalid iter
 11 | {x for x in *y}
 12 | {x for x in yield y}
-   |             ^^^^^^^ Syntax Error: unparenthesized yield expression cannot be used here
+   |             ^^^^^^^ Syntax Error: yield expression cannot be used here
 13 | {x for x in yield from y}
 14 | {x for x in lambda y: y}
    |
@@ -745,7 +745,7 @@ Module(
 11 | {x for x in *y}
 12 | {x for x in yield y}
 13 | {x for x in yield from y}
-   |             ^^^^^^^^^^^^ Syntax Error: unparenthesized yield expression cannot be used here
+   |             ^^^^^^^^^^^^ Syntax Error: yield expression cannot be used here
 14 | {x for x in lambda y: y}
    |
 
@@ -773,7 +773,7 @@ Module(
 16 | # Invalid if
 17 | {x for x in data if *y}
 18 | {x for x in data if yield y}
-   |                     ^^^^^^^ Syntax Error: unparenthesized yield expression cannot be used here
+   |                     ^^^^^^^ Syntax Error: yield expression cannot be used here
 19 | {x for x in data if yield from y}
 20 | {x for x in data if lambda y: y}
    |
@@ -783,7 +783,7 @@ Module(
 17 | {x for x in data if *y}
 18 | {x for x in data if yield y}
 19 | {x for x in data if yield from y}
-   |                     ^^^^^^^^^^^^ Syntax Error: unparenthesized yield expression cannot be used here
+   |                     ^^^^^^^^^^^^ Syntax Error: yield expression cannot be used here
 20 | {x for x in data if lambda y: y}
    |
 

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__yield_from__starred_expression.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__yield_from__starred_expression.py.snap
@@ -89,5 +89,5 @@ Module(
   |
 3 | yield from *x
 4 | yield from *x, y
-  |            ^^^^^ Syntax Error: unparenthesized tuple cannot be used here
+  |            ^^ Syntax Error: starred expression cannot be used here
   |

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@lambda_body_with_yield_expr.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@lambda_body_with_yield_expr.py.snap
@@ -109,7 +109,7 @@ Module(
 
   |
 1 | lambda x: yield y
-  |           ^^^^^^^ Syntax Error: unparenthesized yield expression cannot be used here
+  |           ^^^^^^^ Syntax Error: yield expression cannot be used here
 2 | lambda x: yield from y
   |
 
@@ -117,5 +117,5 @@ Module(
   |
 1 | lambda x: yield y
 2 | lambda x: yield from y
-  |           ^^^^^^^^^^^^ Syntax Error: unparenthesized yield expression cannot be used here
+  |           ^^^^^^^^^^^^ Syntax Error: yield expression cannot be used here
   |

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@return_stmt_invalid_expr.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@return_stmt_invalid_expr.py.snap
@@ -147,6 +147,25 @@ Module(
 
 
   |
+1 | return *
+2 | return yield x
+  |        ^^^^^^^ Syntax Error: yield expression cannot be used here
+3 | return yield from x
+4 | return x := 1
+  |
+
+
+  |
+1 | return *
+2 | return yield x
+3 | return yield from x
+  |        ^^^^^^^^^^^^ Syntax Error: yield expression cannot be used here
+4 | return x := 1
+5 | return *x and y
+  |
+
+
+  |
 2 | return yield x
 3 | return yield from x
 4 | return x := 1


### PR DESCRIPTION
## Summary

This PR updates the error handling logic for certain expressions in a way to either perform it automatically or provide an option for the user. The expression in discussion here are `lambda`, starred and `yield` expression.

### Problem

The current parser allows these expressions at arbitrary context. This is because the mentioned expressions are parsed using `parse_lhs_expression` which is part of other higher level grammar rules. This means that the caller needs to validate the parsed expression and report an error if it isn't allowed in that context. This can get quite cumbersome to do so as it needs to be done for all of the call sites for following methods:

1. `parse_expression_list`: 14 references
2. `parse_star_expression_list`: 4 references
3. `parse_star_expression_or_higher`: 8 references
4. `parse_named_expression_or_higher`: 10 references
5. `parse_conditional_expression_or_higher`: 25 references
6. `parse_simple_expression`: 4 references

The numbers corresponding to the methods are the number of references as of today. This list is also in the correct hierarchy of grammar precedence. For example, `parse_expression_list` calls into `parse_conditional_expression_or_higher` but not the other way around.

### Solution

We'll take the above expression one at a time to understand the solution:

#### Lambda expression

Lambda expressions are only allowed in `expression` grammar rule which corresponds to `parse_conditional_expression_or_higher`. This means that this expression is only allowed when using either of the following functions:

1. `parse_expression_list`
2. `parse_star_expression_list`
3. `parse_star_expression_or_higher`
4. `parse_named_expression_or_higher`
5. `parse_conditional_expression_or_higher`

The solution is to move the error handling in `parse_simple_expression` and parameterize it where any of the above listed function would always use `AllowLambdaExpression::Yes`.

#### Starred expression

There are two grammar rules related to starred expression:
1. `star_expression` which corresponds to `parse_star_expression_or_higher`
2. `starred_expression` which is parsed in LHS parsing

Remember that LHS parsing isn't accessed directly but only via any of the above listed functions in the problem section. Now, starred expressions are allowed in a lot of places but sometimes in a limited capacity. For example, an assignment target can have a starred expression but only if it is a name node (`*x`).

The solution here is to adopt the one used in star pattern matching which is to use a parameter. The following functions are parameterized:
1. `parse_expression_list`
2. `parse_named_expression_or_higher`
3. `parse_conditional_expression_or_higher`

Now, `parse_star_expression_list` and `parse_star_expression_or_higher` aren't parameterized because they handle the `star_expression` grammar which means that the caller wants to parse a starred expression but with a limited precedence.

#### Yield expression

Yield expressions are only allowed in the following context:
1. Top level as yield statement
2. Parenthesized
3. F-string expression
4. Assignment (including annotated and augmented) value

We could parameterize it similar to starred expression but that seems like a waste given the limited number of locations they're allowed.

The solution is to add a `parse_yield_expression_or_else` method which parses a yield expression if the parser is at `yield` token or else calls the given method to parse the expression. The call site would like:

```rs
// (yield_expr | named_expression)
self.try_parse_yield_expression()
  .unwrap_or_else(|| self.parse_named_expression_or_higher())

// (yield_expr | star_expressions)
self.try_parse_yield_expression()
  .unwrap_or_else(|| self.parse_star_expression_list())
```

An added benefit for this is that the call site looks exactly like the grammar.

## Review

* The reviewer would mainly just look at the de-duplication logic.
* The reviewer doesn't really need to verify the call sites as they're verified by existing test cases. For nodes which aren't yet tested, they will be done so in their own PR.

## Test Plan

Run existing test cases and verify the snapshot updates.

Additional test cases will be added when working on specific nodes.
