### PR TITLE
Remove `is_current_token_postfix`

### DIFF
--- a/crates/ruff_python_parser/src/parser/mod.rs
+++ b/crates/ruff_python_parser/src/parser/mod.rs
@@ -634,13 +634,6 @@ impl<'src> Parser<'src> {
 
         false
     }
-
-    fn is_current_token_postfix(&self) -> bool {
-        matches!(
-            self.current_token_kind(),
-            TokenKind::Lpar | TokenKind::Lsqb | TokenKind::Dot
-        )
-    }
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]


### PR DESCRIPTION
## Summary

This PR removes the `is_current_token_postifx` method and instead directly calls the `parse_postifx_expression`. The condition was required because postfix expression parsing would reset the `is_parenthesized` field on the `ParsedExpr`. Now, we'll make that explicit.
