### PR TITLE
Remove commented out inline tests

### DIFF
--- a/crates/ruff_python_parser/resources/inline/err/assert_invalid_msg_expr.py
+++ b/crates/ruff_python_parser/resources/inline/err/assert_invalid_msg_expr.py
@@ -1,0 +1,4 @@
+assert False, *x
+assert False, assert x
+assert False, yield x
+assert False, x := 1

--- a/crates/ruff_python_parser/resources/inline/err/assert_invalid_test_expr.py
+++ b/crates/ruff_python_parser/resources/inline/err/assert_invalid_test_expr.py
@@ -1,0 +1,4 @@
+assert *x
+assert assert x
+assert yield x
+assert x := 1

--- a/crates/ruff_python_parser/resources/inline/err/raise_stmt_invalid_cause.py
+++ b/crates/ruff_python_parser/resources/inline/err/raise_stmt_invalid_cause.py
@@ -1,0 +1,3 @@
+raise x from *y
+raise x from yield y
+raise x from y := 1

--- a/crates/ruff_python_parser/resources/inline/err/raise_stmt_invalid_exc.py
+++ b/crates/ruff_python_parser/resources/inline/err/raise_stmt_invalid_exc.py
@@ -1,0 +1,3 @@
+raise *x
+raise yield x
+raise x := 1

--- a/crates/ruff_python_parser/src/parser/statement.rs
+++ b/crates/ruff_python_parser/src/parser/statement.rs
@@ -335,7 +335,6 @@ impl<'src> Parser<'src> {
         let exc = if self.at(TokenKind::Newline) {
             None
         } else {
-            // TODO(dhruvmanila): Disallow starred and yield expression
             // test_err raise_stmt_invalid_exc
             // raise *x
             // raise yield x
@@ -358,7 +357,6 @@ impl<'src> Parser<'src> {
         };
 
         let cause = (exc.is_some() && self.eat(TokenKind::From)).then(|| {
-            // TODO(dhruvmanila): Disallow starred and yield expression
             // test_err raise_stmt_invalid_cause
             // raise x from *y
             // raise x from yield y
@@ -659,7 +657,6 @@ impl<'src> Parser<'src> {
         // test_err assert_empty_test
         // assert
 
-        // TODO(dhruvmanila): Disallow starred and yield expression
         // test_err assert_invalid_test_expr
         // assert *x
         // assert assert x
@@ -669,7 +666,6 @@ impl<'src> Parser<'src> {
 
         let msg = if self.eat(TokenKind::Comma) {
             if self.at_expr() {
-                // TODO(dhruvmanila): Disallow starred and yield expression
                 // test_err assert_invalid_msg_expr
                 // assert False, *x
                 // assert False, assert x

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@assert_invalid_msg_expr.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@assert_invalid_msg_expr.py.snap
@@ -1,0 +1,169 @@
+---
+source: crates/ruff_python_parser/tests/fixtures.rs
+input_file: crates/ruff_python_parser/resources/inline/err/assert_invalid_msg_expr.py
+---
+## AST
+
+```
+Module(
+    ModModule {
+        range: 0..83,
+        body: [
+            Assert(
+                StmtAssert {
+                    range: 0..16,
+                    test: BooleanLiteral(
+                        ExprBooleanLiteral {
+                            range: 7..12,
+                            value: false,
+                        },
+                    ),
+                    msg: Some(
+                        Starred(
+                            ExprStarred {
+                                range: 14..16,
+                                value: Name(
+                                    ExprName {
+                                        range: 15..16,
+                                        id: "x",
+                                        ctx: Load,
+                                    },
+                                ),
+                                ctx: Load,
+                            },
+                        ),
+                    ),
+                },
+            ),
+            Assert(
+                StmtAssert {
+                    range: 17..30,
+                    test: BooleanLiteral(
+                        ExprBooleanLiteral {
+                            range: 24..29,
+                            value: false,
+                        },
+                    ),
+                    msg: None,
+                },
+            ),
+            Assert(
+                StmtAssert {
+                    range: 31..39,
+                    test: Name(
+                        ExprName {
+                            range: 38..39,
+                            id: "x",
+                            ctx: Load,
+                        },
+                    ),
+                    msg: None,
+                },
+            ),
+            Assert(
+                StmtAssert {
+                    range: 40..61,
+                    test: BooleanLiteral(
+                        ExprBooleanLiteral {
+                            range: 47..52,
+                            value: false,
+                        },
+                    ),
+                    msg: Some(
+                        Yield(
+                            ExprYield {
+                                range: 54..61,
+                                value: Some(
+                                    Name(
+                                        ExprName {
+                                            range: 60..61,
+                                            id: "x",
+                                            ctx: Load,
+                                        },
+                                    ),
+                                ),
+                            },
+                        ),
+                    ),
+                },
+            ),
+            Assert(
+                StmtAssert {
+                    range: 62..77,
+                    test: BooleanLiteral(
+                        ExprBooleanLiteral {
+                            range: 69..74,
+                            value: false,
+                        },
+                    ),
+                    msg: Some(
+                        Name(
+                            ExprName {
+                                range: 76..77,
+                                id: "x",
+                                ctx: Load,
+                            },
+                        ),
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 81..82,
+                    value: NumberLiteral(
+                        ExprNumberLiteral {
+                            range: 81..82,
+                            value: Int(
+                                1,
+                            ),
+                        },
+                    ),
+                },
+            ),
+        ],
+    },
+)
+```
+## Errors
+
+  |
+1 | assert False, *x
+  |               ^^ Syntax Error: starred expression cannot be used here
+2 | assert False, assert x
+3 | assert False, yield x
+  |
+
+
+  |
+1 | assert False, *x
+2 | assert False, assert x
+  |               ^^^^^^ Syntax Error: Expected an expression
+3 | assert False, yield x
+4 | assert False, x := 1
+  |
+
+
+  |
+1 | assert False, *x
+2 | assert False, assert x
+  | ^^^^^^^^^^^^^^^^^^^^ Syntax Error: use `;` to separate simple statements
+3 | assert False, yield x
+4 | assert False, x := 1
+  |
+
+
+  |
+1 | assert False, *x
+2 | assert False, assert x
+3 | assert False, yield x
+  |               ^^^^^^^ Syntax Error: yield expression cannot be used here
+4 | assert False, x := 1
+  |
+
+
+  |
+2 | assert False, assert x
+3 | assert False, yield x
+4 | assert False, x := 1
+  |                 ^^ Syntax Error: Expected a statement
+  |

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@assert_invalid_test_expr.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@assert_invalid_test_expr.py.snap
@@ -1,0 +1,148 @@
+---
+source: crates/ruff_python_parser/tests/fixtures.rs
+input_file: crates/ruff_python_parser/resources/inline/err/assert_invalid_test_expr.py
+---
+## AST
+
+```
+Module(
+    ModModule {
+        range: 0..55,
+        body: [
+            Assert(
+                StmtAssert {
+                    range: 0..9,
+                    test: Starred(
+                        ExprStarred {
+                            range: 7..9,
+                            value: Name(
+                                ExprName {
+                                    range: 8..9,
+                                    id: "x",
+                                    ctx: Load,
+                                },
+                            ),
+                            ctx: Load,
+                        },
+                    ),
+                    msg: None,
+                },
+            ),
+            Assert(
+                StmtAssert {
+                    range: 10..23,
+                    test: Name(
+                        ExprName {
+                            range: 17..23,
+                            id: "assert",
+                            ctx: Load,
+                        },
+                    ),
+                    msg: None,
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 24..25,
+                    value: Name(
+                        ExprName {
+                            range: 24..25,
+                            id: "x",
+                            ctx: Load,
+                        },
+                    ),
+                },
+            ),
+            Assert(
+                StmtAssert {
+                    range: 26..40,
+                    test: Yield(
+                        ExprYield {
+                            range: 33..40,
+                            value: Some(
+                                Name(
+                                    ExprName {
+                                        range: 39..40,
+                                        id: "x",
+                                        ctx: Load,
+                                    },
+                                ),
+                            ),
+                        },
+                    ),
+                    msg: None,
+                },
+            ),
+            Assert(
+                StmtAssert {
+                    range: 41..49,
+                    test: Name(
+                        ExprName {
+                            range: 48..49,
+                            id: "x",
+                            ctx: Load,
+                        },
+                    ),
+                    msg: None,
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 53..54,
+                    value: NumberLiteral(
+                        ExprNumberLiteral {
+                            range: 53..54,
+                            value: Int(
+                                1,
+                            ),
+                        },
+                    ),
+                },
+            ),
+        ],
+    },
+)
+```
+## Errors
+
+  |
+1 | assert *x
+  |        ^^ Syntax Error: starred expression cannot be used here
+2 | assert assert x
+3 | assert yield x
+  |
+
+
+  |
+1 | assert *x
+2 | assert assert x
+  |        ^^^^^^ Syntax Error: Expected an identifier, but found a keyword 'assert' that cannot be used here
+3 | assert yield x
+4 | assert x := 1
+  |
+
+
+  |
+1 | assert *x
+2 | assert assert x
+  | ^^^^^^^^^^^^^^^ Syntax Error: use `;` to separate simple statements
+3 | assert yield x
+4 | assert x := 1
+  |
+
+
+  |
+1 | assert *x
+2 | assert assert x
+3 | assert yield x
+  |        ^^^^^^^ Syntax Error: yield expression cannot be used here
+4 | assert x := 1
+  |
+
+
+  |
+2 | assert assert x
+3 | assert yield x
+4 | assert x := 1
+  |          ^^ Syntax Error: Expected a statement
+  |

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@raise_stmt_invalid_cause.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@raise_stmt_invalid_cause.py.snap
@@ -1,0 +1,134 @@
+---
+source: crates/ruff_python_parser/tests/fixtures.rs
+input_file: crates/ruff_python_parser/resources/inline/err/raise_stmt_invalid_cause.py
+---
+## AST
+
+```
+Module(
+    ModModule {
+        range: 0..57,
+        body: [
+            Raise(
+                StmtRaise {
+                    range: 0..15,
+                    exc: Some(
+                        Name(
+                            ExprName {
+                                range: 6..7,
+                                id: "x",
+                                ctx: Load,
+                            },
+                        ),
+                    ),
+                    cause: Some(
+                        Starred(
+                            ExprStarred {
+                                range: 13..15,
+                                value: Name(
+                                    ExprName {
+                                        range: 14..15,
+                                        id: "y",
+                                        ctx: Load,
+                                    },
+                                ),
+                                ctx: Load,
+                            },
+                        ),
+                    ),
+                },
+            ),
+            Raise(
+                StmtRaise {
+                    range: 16..36,
+                    exc: Some(
+                        Name(
+                            ExprName {
+                                range: 22..23,
+                                id: "x",
+                                ctx: Load,
+                            },
+                        ),
+                    ),
+                    cause: Some(
+                        Yield(
+                            ExprYield {
+                                range: 29..36,
+                                value: Some(
+                                    Name(
+                                        ExprName {
+                                            range: 35..36,
+                                            id: "y",
+                                            ctx: Load,
+                                        },
+                                    ),
+                                ),
+                            },
+                        ),
+                    ),
+                },
+            ),
+            Raise(
+                StmtRaise {
+                    range: 37..51,
+                    exc: Some(
+                        Name(
+                            ExprName {
+                                range: 43..44,
+                                id: "x",
+                                ctx: Load,
+                            },
+                        ),
+                    ),
+                    cause: Some(
+                        Name(
+                            ExprName {
+                                range: 50..51,
+                                id: "y",
+                                ctx: Load,
+                            },
+                        ),
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 55..56,
+                    value: NumberLiteral(
+                        ExprNumberLiteral {
+                            range: 55..56,
+                            value: Int(
+                                1,
+                            ),
+                        },
+                    ),
+                },
+            ),
+        ],
+    },
+)
+```
+## Errors
+
+  |
+1 | raise x from *y
+  |              ^^ Syntax Error: starred expression cannot be used here
+2 | raise x from yield y
+3 | raise x from y := 1
+  |
+
+
+  |
+1 | raise x from *y
+2 | raise x from yield y
+  |              ^^^^^^^ Syntax Error: yield expression cannot be used here
+3 | raise x from y := 1
+  |
+
+
+  |
+1 | raise x from *y
+2 | raise x from yield y
+3 | raise x from y := 1
+  |                ^^ Syntax Error: Expected a statement
+  |

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@raise_stmt_invalid_exc.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@raise_stmt_invalid_exc.py.snap
@@ -1,0 +1,110 @@
+---
+source: crates/ruff_python_parser/tests/fixtures.rs
+input_file: crates/ruff_python_parser/resources/inline/err/raise_stmt_invalid_exc.py
+---
+## AST
+
+```
+Module(
+    ModModule {
+        range: 0..36,
+        body: [
+            Raise(
+                StmtRaise {
+                    range: 0..8,
+                    exc: Some(
+                        Starred(
+                            ExprStarred {
+                                range: 6..8,
+                                value: Name(
+                                    ExprName {
+                                        range: 7..8,
+                                        id: "x",
+                                        ctx: Load,
+                                    },
+                                ),
+                                ctx: Load,
+                            },
+                        ),
+                    ),
+                    cause: None,
+                },
+            ),
+            Raise(
+                StmtRaise {
+                    range: 9..22,
+                    exc: Some(
+                        Yield(
+                            ExprYield {
+                                range: 15..22,
+                                value: Some(
+                                    Name(
+                                        ExprName {
+                                            range: 21..22,
+                                            id: "x",
+                                            ctx: Load,
+                                        },
+                                    ),
+                                ),
+                            },
+                        ),
+                    ),
+                    cause: None,
+                },
+            ),
+            Raise(
+                StmtRaise {
+                    range: 23..30,
+                    exc: Some(
+                        Name(
+                            ExprName {
+                                range: 29..30,
+                                id: "x",
+                                ctx: Load,
+                            },
+                        ),
+                    ),
+                    cause: None,
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 34..35,
+                    value: NumberLiteral(
+                        ExprNumberLiteral {
+                            range: 34..35,
+                            value: Int(
+                                1,
+                            ),
+                        },
+                    ),
+                },
+            ),
+        ],
+    },
+)
+```
+## Errors
+
+  |
+1 | raise *x
+  |       ^^ Syntax Error: starred expression cannot be used here
+2 | raise yield x
+3 | raise x := 1
+  |
+
+
+  |
+1 | raise *x
+2 | raise yield x
+  |       ^^^^^^^ Syntax Error: yield expression cannot be used here
+3 | raise x := 1
+  |
+
+
+  |
+1 | raise *x
+2 | raise yield x
+3 | raise x := 1
+  |         ^^ Syntax Error: Expected a statement
+  |


### PR DESCRIPTION
## Summary

This PR removes a couple of inline tests TODO which was a leftover from #10809 