### PR TITLE
Add tests for top level statement parsing

### DIFF
--- a/crates/ruff_python_parser/resources/inline/err/multiple_clauses_on_same_line.py
+++ b/crates/ruff_python_parser/resources/inline/err/multiple_clauses_on_same_line.py
@@ -1,0 +1,6 @@
+if True: pass elif False: pass else: pass
+if True: pass; elif False: pass; else: pass
+for x in iter: break else: pass
+for x in iter: break; else: pass
+try: pass except exc: pass else: pass finally: pass
+try: pass; except exc: pass; else: pass; finally: pass

--- a/crates/ruff_python_parser/resources/inline/err/simple_and_compound_stmt_on_same_line.py
+++ b/crates/ruff_python_parser/resources/inline/err/simple_and_compound_stmt_on_same_line.py
@@ -1,0 +1,1 @@
+a; if b: pass; b

--- a/crates/ruff_python_parser/resources/inline/err/simple_and_compound_stmt_on_same_line_in_block.py
+++ b/crates/ruff_python_parser/resources/inline/err/simple_and_compound_stmt_on_same_line_in_block.py
@@ -1,0 +1,2 @@
+if True: pass if False: pass
+if True: pass; if False: pass

--- a/crates/ruff_python_parser/resources/inline/err/simple_stmts_on_same_line.py
+++ b/crates/ruff_python_parser/resources/inline/err/simple_stmts_on_same_line.py
@@ -1,0 +1,3 @@
+a b
+a + b c + d
+break; continue pass; continue break

--- a/crates/ruff_python_parser/resources/inline/err/simple_stmts_on_same_line_in_block.py
+++ b/crates/ruff_python_parser/resources/inline/err/simple_stmts_on_same_line_in_block.py
@@ -1,0 +1,1 @@
+if True: break; continue pass; continue break

--- a/crates/ruff_python_parser/resources/inline/ok/simple_stmts_in_block.py
+++ b/crates/ruff_python_parser/resources/inline/ok/simple_stmts_in_block.py
@@ -1,0 +1,5 @@
+if True: pass
+if True: pass;
+if True: pass; continue
+if True: pass; continue;
+x = 1

--- a/crates/ruff_python_parser/resources/inline/ok/simple_stmts_with_semicolons.py
+++ b/crates/ruff_python_parser/resources/inline/ok/simple_stmts_with_semicolons.py
@@ -1,0 +1,1 @@
+return; import a; from x import y; z; type T = int

--- a/crates/ruff_python_parser/src/error.rs
+++ b/crates/ruff_python_parser/src/error.rs
@@ -133,8 +133,6 @@ pub enum ParseErrorType {
     InvalidAugmentedAssignmentTarget,
     /// An invalid expression was found in the delete `target`.
     InvalidDeleteTarget,
-    /// Multiple simple statements were found in the same line without a `;` separating them.
-    SimpleStmtsInSameLine,
     /// An unexpected indentation was found during parsing.
     UnexpectedIndentation,
     /// The statement being parsed cannot be `async`.
@@ -145,12 +143,15 @@ pub enum ParseErrorType {
     PositionalFollowsKeywordUnpacking,
     /// An iterable argument unpacking `*args` follows keyword argument unpacking `**kwargs`.
     UnpackedArgumentError,
-    /// A simple statement and a compound statement was found in the same line.
-    SimpleStmtAndCompoundStmtInSameLine,
     /// An invalid usage of iterable unpacking in a comprehension was found.
     IterableUnpackingInComprehension,
     /// An invalid usage of a starred expression was found.
     StarredExpressionUsage,
+
+    /// Multiple simple statements were found in the same line without a `;` separating them.
+    SimpleStatementsOnSameLine,
+    /// A simple statement and a compound statement was found in the same line.
+    SimpleAndCompoundStatementOnSameLine,
 
     /// An invalid `match` case pattern was found.
     InvalidMatchPatternLiteral { pattern: TokenKind },
@@ -196,12 +197,15 @@ impl std::fmt::Display for ParseErrorType {
                 write!(f, "expected {expected:?}, found {found:?}")
             }
             ParseErrorType::Lexical(ref lex_error) => write!(f, "{lex_error}"),
-            ParseErrorType::SimpleStmtsInSameLine => {
-                write!(f, "use `;` to separate simple statements")
+            ParseErrorType::SimpleStatementsOnSameLine => {
+                write!(
+                    f,
+                    "Simple statements must be separated by newlines or semicolons"
+                )
             }
-            ParseErrorType::SimpleStmtAndCompoundStmtInSameLine => write!(
+            ParseErrorType::SimpleAndCompoundStatementOnSameLine => write!(
                 f,
-                "compound statements not allowed in the same line as simple statements"
+                "Compound statements are not allowed on the same line as simple statements"
             ),
             ParseErrorType::UnexpectedAsyncToken(kind) => {
                 write!(

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@ann_assign_stmt_type_alias_annotation.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@ann_assign_stmt_type_alias_annotation.py.snap
@@ -103,20 +103,6 @@ Module(
 
   |
 1 | a: type X = int
-  | ^^^^^^^ Syntax Error: use `;` to separate simple statements
-2 | lambda: type X = int
-  |
-
-
-  |
-1 | a: type X = int
 2 | lambda: type X = int
   |         ^^^^ Syntax Error: Expected an expression
-  |
-
-
-  |
-1 | a: type X = int
-2 | lambda: type X = int
-  | ^^^^^^^^^^^^ Syntax Error: use `;` to separate simple statements
   |

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@assert_invalid_msg_expr.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@assert_invalid_msg_expr.py.snap
@@ -146,15 +146,6 @@ Module(
   |
 1 | assert False, *x
 2 | assert False, assert x
-  | ^^^^^^^^^^^^^^^^^^^^ Syntax Error: use `;` to separate simple statements
-3 | assert False, yield x
-4 | assert False, x := 1
-  |
-
-
-  |
-1 | assert False, *x
-2 | assert False, assert x
 3 | assert False, yield x
   |               ^^^^^^^ Syntax Error: yield expression cannot be used here
 4 | assert False, x := 1

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@assert_invalid_test_expr.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@assert_invalid_test_expr.py.snap
@@ -125,7 +125,7 @@ Module(
   |
 1 | assert *x
 2 | assert assert x
-  | ^^^^^^^^^^^^^^^ Syntax Error: use `;` to separate simple statements
+  |               ^ Syntax Error: Simple statements must be separated by newlines or semicolons
 3 | assert yield x
 4 | assert x := 1
   |

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@async_unexpected_token.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@async_unexpected_token.py.snap
@@ -221,6 +221,15 @@ Module(
 5 | # TODO(dhruvmanila): Here, `match` is actually a Name token because
 6 | # of the soft keyword # transformer
 7 | async match test:
+  |             ^^^^ Syntax Error: Simple statements must be separated by newlines or semicolons
+8 |     case _: ...
+  |
+
+
+  |
+5 | # TODO(dhruvmanila): Here, `match` is actually a Name token because
+6 | # of the soft keyword # transformer
+7 | async match test:
   |                  ^ Syntax Error: Expected an expression
 8 |     case _: ...
   |

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@class_def_unclosed_type_param_list.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@class_def_unclosed_type_param_list.py.snap
@@ -113,8 +113,8 @@ Module(
   |
 1 | class Foo[T1, *T2(a, b):
 2 |     pass
-  |     ^^^^ Syntax Error: use `;` to separate simple statements
 3 | x = 10
+  | ^ Syntax Error: Simple statements must be separated by newlines or semicolons
   |
 
 

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@dotted_name_multiple_dots.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@dotted_name_multiple_dots.py.snap
@@ -84,12 +84,5 @@ Module(
   |
 1 | import a..b
 2 | import a...b
-  | ^^^^^^^^^^^ Syntax Error: use `;` to separate simple statements
-  |
-
-
-  |
-1 | import a..b
-2 | import a...b
-  |         ^^^^ Syntax Error: use `;` to separate simple statements
+  |            ^ Syntax Error: Simple statements must be separated by newlines or semicolons
   |

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__arguments__unclosed_0.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__arguments__unclosed_0.py.snap
@@ -75,15 +75,6 @@ Module(
 
 
   |
-1 | / call(
-2 | | 
-3 | | def foo():
-  | |___^ Syntax Error: compound statements not allowed in the same line as simple statements
-4 |       pass
-  |
-
-
-  |
 3 | def foo():
 4 |     pass
   |          Syntax Error: unexpected EOF while parsing

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__arguments__unclosed_1.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__arguments__unclosed_1.py.snap
@@ -83,15 +83,6 @@ Module(
 
 
   |
-1 | / call(x
-2 | | 
-3 | | def foo():
-  | |___^ Syntax Error: compound statements not allowed in the same line as simple statements
-4 |       pass
-  |
-
-
-  |
 3 | def foo():
 4 |     pass
   |          Syntax Error: unexpected EOF while parsing

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__arguments__unclosed_2.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__arguments__unclosed_2.py.snap
@@ -83,15 +83,6 @@ Module(
 
 
   |
-1 | / call(x,
-2 | | 
-3 | | def foo():
-  | |___^ Syntax Error: compound statements not allowed in the same line as simple statements
-4 |       pass
-  |
-
-
-  |
 3 | def foo():
 4 |     pass
   |          Syntax Error: unexpected EOF while parsing

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__attribute__invalid_member.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__attribute__invalid_member.py.snap
@@ -116,7 +116,7 @@ Module(
 
   |
 1 | x.1
-  | ^^^ Syntax Error: use `;` to separate simple statements
+  |  ^^ Syntax Error: Simple statements must be separated by newlines or semicolons
 2 | x.1.0
 3 | x.[0]
   |
@@ -125,7 +125,7 @@ Module(
   |
 1 | x.1
 2 | x.1.0
-  | ^^^ Syntax Error: use `;` to separate simple statements
+  |  ^^ Syntax Error: Simple statements must be separated by newlines or semicolons
 3 | x.[0]
   |
 
@@ -133,7 +133,7 @@ Module(
   |
 1 | x.1
 2 | x.1.0
-  |  ^^^^ Syntax Error: use `;` to separate simple statements
+  |    ^^ Syntax Error: Simple statements must be separated by newlines or semicolons
 3 | x.[0]
   |
 

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__attribute__multiple_dots.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__attribute__multiple_dots.py.snap
@@ -132,7 +132,7 @@ Module(
   |
 1 | extra..dot
 2 | multiple....dots
-  | ^^^^^^^^^^^ Syntax Error: use `;` to separate simple statements
+  |         ^^^ Syntax Error: Simple statements must be separated by newlines or semicolons
 3 | multiple.....dots
   |
 
@@ -141,7 +141,7 @@ Module(
 1 | extra..dot
 2 | multiple....dots
 3 | multiple.....dots
-  | ^^^^^^^^^^^ Syntax Error: use `;` to separate simple statements
+  |         ^^^ Syntax Error: Simple statements must be separated by newlines or semicolons
   |
 
 

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__compare__invalid_order.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__compare__invalid_order.py.snap
@@ -150,7 +150,7 @@ Module(
   |
 6 | # Same here as well, `not` without `in` is considered to be a unary operator
 7 | x not is y
-  | ^^^^^ Syntax Error: use `;` to separate simple statements
+  |   ^^^ Syntax Error: Simple statements must be separated by newlines or semicolons
   |
 
 
@@ -164,5 +164,5 @@ Module(
   |
 6 | # Same here as well, `not` without `in` is considered to be a unary operator
 7 | x not is y
-  |   ^^^^^^^^ Syntax Error: use `;` to separate simple statements
+  |          ^ Syntax Error: Simple statements must be separated by newlines or semicolons
   |

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__compare__missing_rhs_1.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__compare__missing_rhs_1.py.snap
@@ -75,7 +75,7 @@ Module(
   |
 1 | # Without the `in`, this is considered to be a unary `not`
 2 | x not
-  | ^^^^^ Syntax Error: use `;` to separate simple statements
+  |   ^^^ Syntax Error: Simple statements must be separated by newlines or semicolons
 3 | 
 4 | 1 + 2
   |

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__dict__missing_closing_brace_2.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__dict__missing_closing_brace_2.py.snap
@@ -84,15 +84,6 @@ Module(
 
 
   |
-1 | / {x: 1,
-2 | | 
-3 | | def foo():
-  | |___^ Syntax Error: compound statements not allowed in the same line as simple statements
-4 |       pass
-  |
-
-
-  |
 3 | def foo():
 4 |     pass
   |          Syntax Error: unexpected EOF while parsing

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__list__missing_closing_bracket_3.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__list__missing_closing_bracket_3.py.snap
@@ -82,17 +82,6 @@ Module(
 
 
   |
-2 |   # token starts a statement.
-3 |   
-4 | / [1, 2
-5 | | 
-6 | | def foo():
-  | |___^ Syntax Error: compound statements not allowed in the same line as simple statements
-7 |       pass
-  |
-
-
-  |
 6 | def foo():
 7 |     pass
   |          Syntax Error: unexpected EOF while parsing

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__named__missing_expression_2.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__named__missing_expression_2.py.snap
@@ -89,26 +89,6 @@ Module(
 
 
   |
-1 |   # Missing expression, instead there's a function definition
-2 |   
-3 | / (x :=
-4 | | 
-5 | | def foo():
-  | |_______^ Syntax Error: use `;` to separate simple statements
-6 |       pass
-  |
-
-
-  |
-3 | (x :=
-4 | 
-5 | def foo():
-  |     ^^^^^ Syntax Error: invalid annotated assignment target
-6 |     pass
-  |
-
-
-  |
 5 | def foo():
 6 |     pass
   |     ^^^^ Syntax Error: Expected an identifier, but found a keyword 'pass' that cannot be used here

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__parenthesized__generator.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__parenthesized__generator.py.snap
@@ -133,13 +133,6 @@ Module(
   |
 1 | (*x for x in y)
 2 | (x := 1, for x in y)
-  | ^^^^^^^^^^^^ Syntax Error: compound statements not allowed in the same line as simple statements
-  |
-
-
-  |
-1 | (*x for x in y)
-2 | (x := 1, for x in y)
   |                    ^ Syntax Error: expected Colon, found Rpar
   |
 

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__parenthesized__missing_closing_paren_3.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__parenthesized__missing_closing_paren_3.py.snap
@@ -83,17 +83,6 @@ Module(
 
 
   |
-2 |   # token starts a statement.
-3 |   
-4 | / (1, 2
-5 | | 
-6 | | def foo():
-  | |___^ Syntax Error: compound statements not allowed in the same line as simple statements
-7 |       pass
-  |
-
-
-  |
 6 | def foo():
 7 |     pass
   |          Syntax Error: unexpected EOF while parsing

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__parenthesized__tuple.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__parenthesized__tuple.py.snap
@@ -290,15 +290,6 @@ Module(
    |
  9 | # Missing comma
 10 | (1 2)
-   | ^^^^ Syntax Error: use `;` to separate simple statements
-11 | 
-12 | # Dictionary element in a list
-   |
-
-
-   |
- 9 | # Missing comma
-10 | (1 2)
    |     ^ Syntax Error: Expected a statement
 11 | 
 12 | # Dictionary element in a list

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__set__missing_closing_curly_brace_3.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__set__missing_closing_curly_brace_3.py.snap
@@ -81,17 +81,6 @@ Module(
 
 
   |
-2 |   # token starts a statement.
-3 |   
-4 | / {1, 2
-5 | | 
-6 | | def foo():
-  | |___^ Syntax Error: compound statements not allowed in the same line as simple statements
-7 |       pass
-  |
-
-
-  |
 6 | def foo():
 7 |     pass
   |          Syntax Error: unexpected EOF while parsing

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__subscript__unclosed_slice_1.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__subscript__unclosed_slice_1.py.snap
@@ -99,24 +99,6 @@ Module(
 
 
   |
-1 | / x[::
-2 | | 
-3 | | def foo():
-  | |_______^ Syntax Error: use `;` to separate simple statements
-4 |       pass
-  |
-
-
-  |
-1 | x[::
-2 | 
-3 | def foo():
-  |     ^^^^^ Syntax Error: invalid annotated assignment target
-4 |     pass
-  |
-
-
-  |
 3 | def foo():
 4 |     pass
   |     ^^^^ Syntax Error: Expected an identifier, but found a keyword 'pass' that cannot be used here

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@from_import_missing_rpar.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@from_import_missing_rpar.py.snap
@@ -143,20 +143,11 @@ Module(
 
 
   |
-1 | / from x import (a, b
-2 | | 1 + 1
-  | |_^ Syntax Error: use `;` to separate simple statements
-3 |   from x import (a, b,
-4 |   2 + 2
-  |
-
-
-  |
-1 |   from x import (a, b
-2 | / 1 + 1
-3 | | from x import (a, b,
-  | |____^ Syntax Error: use `;` to separate simple statements
-4 |   2 + 2
+1 | from x import (a, b
+2 | 1 + 1
+3 | from x import (a, b,
+  | ^^^^ Syntax Error: Simple statements must be separated by newlines or semicolons
+4 | 2 + 2
   |
 
 
@@ -165,15 +156,6 @@ Module(
 3 | from x import (a, b,
 4 | 2 + 2
   | ^ Syntax Error: Expected an import name or a ')'
-  |
-
-
-  |
-1 |   from x import (a, b
-2 |   1 + 1
-3 | / from x import (a, b,
-4 | | 2 + 2
-  | |_^ Syntax Error: use `;` to separate simple statements
   |
 
 

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@function_def_unclosed_parameter_list.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@function_def_unclosed_parameter_list.py.snap
@@ -202,11 +202,10 @@ Module(
 
 
   |
-1 | def foo(a: int, b:
 2 | def foo():
 3 |     return 42
-  |     ^^^^^^^^^ Syntax Error: compound statements not allowed in the same line as simple statements
 4 | def foo(a: int, b: str
+  | ^^^ Syntax Error: Compound statements are not allowed on the same line as simple statements
 5 | x = 10
   |
 

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@function_def_unclosed_type_param_list.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@function_def_unclosed_type_param_list.py.snap
@@ -148,8 +148,8 @@ Module(
   |
 1 | def foo[T1, *T2(a, b):
 2 |     return a + b
-  |     ^^^^^^^^^^^^ Syntax Error: use `;` to separate simple statements
 3 | x = 10
+  | ^ Syntax Error: Simple statements must be separated by newlines or semicolons
   |
 
 

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@global_stmt_expression.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@global_stmt_expression.py.snap
@@ -49,9 +49,3 @@ Module(
 1 | global x + 1
   |          ^ Syntax Error: expected Comma, found Plus
   |
-
-
-  |
-1 | global x + 1
-  | ^^^^^^^^^^ Syntax Error: use `;` to separate simple statements
-  |

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@import_stmt_parenthesized_names.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@import_stmt_parenthesized_names.py.snap
@@ -76,20 +76,6 @@ Module(
 
   |
 1 | import (a)
-  | ^^^^^^^^ Syntax Error: use `;` to separate simple statements
-2 | import (a, b)
-  |
-
-
-  |
-1 | import (a)
 2 | import (a, b)
   |        ^ Syntax Error: Expected an import name
-  |
-
-
-  |
-1 | import (a)
-2 | import (a, b)
-  | ^^^^^^^^ Syntax Error: use `;` to separate simple statements
   |

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@import_stmt_star_import.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@import_stmt_star_import.py.snap
@@ -97,13 +97,6 @@ Module(
 
   |
 1 | import *
-  | ^^^^^^^^ Syntax Error: use `;` to separate simple statements
-2 | import x, *, y
-  |
-
-
-  |
-1 | import *
   |         ^ Syntax Error: Expected an expression
 2 | import x, *, y
   |
@@ -126,7 +119,7 @@ Module(
   |
 1 | import *
 2 | import x, *, y
-  | ^^^^^^^^^^^ Syntax Error: use `;` to separate simple statements
+  |           ^ Syntax Error: Simple statements must be separated by newlines or semicolons
   |
 
 

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@match_stmt_no_newline_before_case.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@match_stmt_no_newline_before_case.py.snap
@@ -63,3 +63,9 @@ Module(
 1 | match foo: case _: ...
   |            ^^^^ Syntax Error: expected Newline, found Name
   |
+
+
+  |
+1 | match foo: case _: ...
+  |                 ^ Syntax Error: Simple statements must be separated by newlines or semicolons
+  |

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@multiple_clauses_on_same_line.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@multiple_clauses_on_same_line.py.snap
@@ -1,0 +1,388 @@
+---
+source: crates/ruff_python_parser/tests/fixtures.rs
+input_file: crates/ruff_python_parser/resources/inline/err/multiple_clauses_on_same_line.py
+---
+## AST
+
+```
+Module(
+    ModModule {
+        range: 0..258,
+        body: [
+            If(
+                StmtIf {
+                    range: 0..41,
+                    test: BooleanLiteral(
+                        ExprBooleanLiteral {
+                            range: 3..7,
+                            value: true,
+                        },
+                    ),
+                    body: [
+                        Pass(
+                            StmtPass {
+                                range: 9..13,
+                            },
+                        ),
+                    ],
+                    elif_else_clauses: [
+                        ElifElseClause {
+                            range: 14..30,
+                            test: Some(
+                                BooleanLiteral(
+                                    ExprBooleanLiteral {
+                                        range: 19..24,
+                                        value: false,
+                                    },
+                                ),
+                            ),
+                            body: [
+                                Pass(
+                                    StmtPass {
+                                        range: 26..30,
+                                    },
+                                ),
+                            ],
+                        },
+                        ElifElseClause {
+                            range: 31..41,
+                            test: None,
+                            body: [
+                                Pass(
+                                    StmtPass {
+                                        range: 37..41,
+                                    },
+                                ),
+                            ],
+                        },
+                    ],
+                },
+            ),
+            If(
+                StmtIf {
+                    range: 42..85,
+                    test: BooleanLiteral(
+                        ExprBooleanLiteral {
+                            range: 45..49,
+                            value: true,
+                        },
+                    ),
+                    body: [
+                        Pass(
+                            StmtPass {
+                                range: 51..55,
+                            },
+                        ),
+                    ],
+                    elif_else_clauses: [
+                        ElifElseClause {
+                            range: 57..73,
+                            test: Some(
+                                BooleanLiteral(
+                                    ExprBooleanLiteral {
+                                        range: 62..67,
+                                        value: false,
+                                    },
+                                ),
+                            ),
+                            body: [
+                                Pass(
+                                    StmtPass {
+                                        range: 69..73,
+                                    },
+                                ),
+                            ],
+                        },
+                        ElifElseClause {
+                            range: 75..85,
+                            test: None,
+                            body: [
+                                Pass(
+                                    StmtPass {
+                                        range: 81..85,
+                                    },
+                                ),
+                            ],
+                        },
+                    ],
+                },
+            ),
+            For(
+                StmtFor {
+                    range: 86..117,
+                    is_async: false,
+                    target: Name(
+                        ExprName {
+                            range: 90..91,
+                            id: "x",
+                            ctx: Store,
+                        },
+                    ),
+                    iter: Name(
+                        ExprName {
+                            range: 95..99,
+                            id: "iter",
+                            ctx: Load,
+                        },
+                    ),
+                    body: [
+                        Break(
+                            StmtBreak {
+                                range: 101..106,
+                            },
+                        ),
+                    ],
+                    orelse: [
+                        Pass(
+                            StmtPass {
+                                range: 113..117,
+                            },
+                        ),
+                    ],
+                },
+            ),
+            For(
+                StmtFor {
+                    range: 118..150,
+                    is_async: false,
+                    target: Name(
+                        ExprName {
+                            range: 122..123,
+                            id: "x",
+                            ctx: Store,
+                        },
+                    ),
+                    iter: Name(
+                        ExprName {
+                            range: 127..131,
+                            id: "iter",
+                            ctx: Load,
+                        },
+                    ),
+                    body: [
+                        Break(
+                            StmtBreak {
+                                range: 133..138,
+                            },
+                        ),
+                    ],
+                    orelse: [
+                        Pass(
+                            StmtPass {
+                                range: 146..150,
+                            },
+                        ),
+                    ],
+                },
+            ),
+            Try(
+                StmtTry {
+                    range: 151..202,
+                    body: [
+                        Pass(
+                            StmtPass {
+                                range: 156..160,
+                            },
+                        ),
+                    ],
+                    handlers: [
+                        ExceptHandler(
+                            ExceptHandlerExceptHandler {
+                                range: 161..177,
+                                type_: Some(
+                                    Name(
+                                        ExprName {
+                                            range: 168..171,
+                                            id: "exc",
+                                            ctx: Load,
+                                        },
+                                    ),
+                                ),
+                                name: None,
+                                body: [
+                                    Pass(
+                                        StmtPass {
+                                            range: 173..177,
+                                        },
+                                    ),
+                                ],
+                            },
+                        ),
+                    ],
+                    orelse: [
+                        Pass(
+                            StmtPass {
+                                range: 184..188,
+                            },
+                        ),
+                    ],
+                    finalbody: [
+                        Pass(
+                            StmtPass {
+                                range: 198..202,
+                            },
+                        ),
+                    ],
+                    is_star: false,
+                },
+            ),
+            Try(
+                StmtTry {
+                    range: 203..257,
+                    body: [
+                        Pass(
+                            StmtPass {
+                                range: 208..212,
+                            },
+                        ),
+                    ],
+                    handlers: [
+                        ExceptHandler(
+                            ExceptHandlerExceptHandler {
+                                range: 214..230,
+                                type_: Some(
+                                    Name(
+                                        ExprName {
+                                            range: 221..224,
+                                            id: "exc",
+                                            ctx: Load,
+                                        },
+                                    ),
+                                ),
+                                name: None,
+                                body: [
+                                    Pass(
+                                        StmtPass {
+                                            range: 226..230,
+                                        },
+                                    ),
+                                ],
+                            },
+                        ),
+                    ],
+                    orelse: [
+                        Pass(
+                            StmtPass {
+                                range: 238..242,
+                            },
+                        ),
+                    ],
+                    finalbody: [
+                        Pass(
+                            StmtPass {
+                                range: 253..257,
+                            },
+                        ),
+                    ],
+                    is_star: false,
+                },
+            ),
+        ],
+    },
+)
+```
+## Errors
+
+  |
+1 | if True: pass elif False: pass else: pass
+  |               ^^^^ Syntax Error: expected Newline, found Elif
+2 | if True: pass; elif False: pass; else: pass
+3 | for x in iter: break else: pass
+  |
+
+
+  |
+1 | if True: pass elif False: pass else: pass
+  |                                ^^^^ Syntax Error: expected Newline, found Else
+2 | if True: pass; elif False: pass; else: pass
+3 | for x in iter: break else: pass
+  |
+
+
+  |
+1 | if True: pass elif False: pass else: pass
+2 | if True: pass; elif False: pass; else: pass
+  |                ^^^^ Syntax Error: expected Newline, found Elif
+3 | for x in iter: break else: pass
+4 | for x in iter: break; else: pass
+  |
+
+
+  |
+1 | if True: pass elif False: pass else: pass
+2 | if True: pass; elif False: pass; else: pass
+  |                                  ^^^^ Syntax Error: expected Newline, found Else
+3 | for x in iter: break else: pass
+4 | for x in iter: break; else: pass
+  |
+
+
+  |
+1 | if True: pass elif False: pass else: pass
+2 | if True: pass; elif False: pass; else: pass
+3 | for x in iter: break else: pass
+  |                      ^^^^ Syntax Error: expected Newline, found Else
+4 | for x in iter: break; else: pass
+5 | try: pass except exc: pass else: pass finally: pass
+  |
+
+
+  |
+2 | if True: pass; elif False: pass; else: pass
+3 | for x in iter: break else: pass
+4 | for x in iter: break; else: pass
+  |                       ^^^^ Syntax Error: expected Newline, found Else
+5 | try: pass except exc: pass else: pass finally: pass
+6 | try: pass; except exc: pass; else: pass; finally: pass
+  |
+
+
+  |
+3 | for x in iter: break else: pass
+4 | for x in iter: break; else: pass
+5 | try: pass except exc: pass else: pass finally: pass
+  |           ^^^^^^ Syntax Error: expected Newline, found Except
+6 | try: pass; except exc: pass; else: pass; finally: pass
+  |
+
+
+  |
+3 | for x in iter: break else: pass
+4 | for x in iter: break; else: pass
+5 | try: pass except exc: pass else: pass finally: pass
+  |                            ^^^^ Syntax Error: expected Newline, found Else
+6 | try: pass; except exc: pass; else: pass; finally: pass
+  |
+
+
+  |
+3 | for x in iter: break else: pass
+4 | for x in iter: break; else: pass
+5 | try: pass except exc: pass else: pass finally: pass
+  |                                       ^^^^^^^ Syntax Error: expected Newline, found Finally
+6 | try: pass; except exc: pass; else: pass; finally: pass
+  |
+
+
+  |
+4 | for x in iter: break; else: pass
+5 | try: pass except exc: pass else: pass finally: pass
+6 | try: pass; except exc: pass; else: pass; finally: pass
+  |            ^^^^^^ Syntax Error: expected Newline, found Except
+  |
+
+
+  |
+4 | for x in iter: break; else: pass
+5 | try: pass except exc: pass else: pass finally: pass
+6 | try: pass; except exc: pass; else: pass; finally: pass
+  |                              ^^^^ Syntax Error: expected Newline, found Else
+  |
+
+
+  |
+4 | for x in iter: break; else: pass
+5 | try: pass except exc: pass else: pass finally: pass
+6 | try: pass; except exc: pass; else: pass; finally: pass
+  |                                          ^^^^^^^ Syntax Error: expected Newline, found Finally
+  |

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@nonlocal_stmt_expression.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@nonlocal_stmt_expression.py.snap
@@ -49,9 +49,3 @@ Module(
 1 | nonlocal x + 1
   |            ^ Syntax Error: expected Comma, found Plus
   |
-
-
-  |
-1 | nonlocal x + 1
-  | ^^^^^^^^^^^^ Syntax Error: use `;` to separate simple statements
-  |

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@params_var_keyword_with_default.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@params_var_keyword_with_default.py.snap
@@ -154,7 +154,7 @@ Module(
 
   |
 1 | def foo(a, **kwargs={'b': 1, 'c': 2}): ...
-  |                                     ^ Syntax Error: Expected a statement
+  |                                     ^ Syntax Error: expected Newline, found Rpar
   |
 
 

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@params_var_positional_with_default.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@params_var_positional_with_default.py.snap
@@ -114,7 +114,7 @@ Module(
 
   |
 1 | def foo(a, *args=(1, 2)): ...
-  |                        ^ Syntax Error: Expected a statement
+  |                        ^ Syntax Error: expected Newline, found Rpar
   |
 
 

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@simple_and_compound_stmt_on_same_line.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@simple_and_compound_stmt_on_same_line.py.snap
@@ -1,0 +1,65 @@
+---
+source: crates/ruff_python_parser/tests/fixtures.rs
+input_file: crates/ruff_python_parser/resources/inline/err/simple_and_compound_stmt_on_same_line.py
+---
+## AST
+
+```
+Module(
+    ModModule {
+        range: 0..17,
+        body: [
+            Expr(
+                StmtExpr {
+                    range: 0..1,
+                    value: Name(
+                        ExprName {
+                            range: 0..1,
+                            id: "a",
+                            ctx: Load,
+                        },
+                    ),
+                },
+            ),
+            If(
+                StmtIf {
+                    range: 3..16,
+                    test: Name(
+                        ExprName {
+                            range: 6..7,
+                            id: "b",
+                            ctx: Load,
+                        },
+                    ),
+                    body: [
+                        Pass(
+                            StmtPass {
+                                range: 9..13,
+                            },
+                        ),
+                        Expr(
+                            StmtExpr {
+                                range: 15..16,
+                                value: Name(
+                                    ExprName {
+                                        range: 15..16,
+                                        id: "b",
+                                        ctx: Load,
+                                    },
+                                ),
+                            },
+                        ),
+                    ],
+                    elif_else_clauses: [],
+                },
+            ),
+        ],
+    },
+)
+```
+## Errors
+
+  |
+1 | a; if b: pass; b
+  |    ^^ Syntax Error: Compound statements are not allowed on the same line as simple statements
+  |

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@simple_and_compound_stmt_on_same_line_in_block.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@simple_and_compound_stmt_on_same_line_in_block.py.snap
@@ -1,0 +1,105 @@
+---
+source: crates/ruff_python_parser/tests/fixtures.rs
+input_file: crates/ruff_python_parser/resources/inline/err/simple_and_compound_stmt_on_same_line_in_block.py
+---
+## AST
+
+```
+Module(
+    ModModule {
+        range: 0..59,
+        body: [
+            If(
+                StmtIf {
+                    range: 0..13,
+                    test: BooleanLiteral(
+                        ExprBooleanLiteral {
+                            range: 3..7,
+                            value: true,
+                        },
+                    ),
+                    body: [
+                        Pass(
+                            StmtPass {
+                                range: 9..13,
+                            },
+                        ),
+                    ],
+                    elif_else_clauses: [],
+                },
+            ),
+            If(
+                StmtIf {
+                    range: 14..28,
+                    test: BooleanLiteral(
+                        ExprBooleanLiteral {
+                            range: 17..22,
+                            value: false,
+                        },
+                    ),
+                    body: [
+                        Pass(
+                            StmtPass {
+                                range: 24..28,
+                            },
+                        ),
+                    ],
+                    elif_else_clauses: [],
+                },
+            ),
+            If(
+                StmtIf {
+                    range: 29..42,
+                    test: BooleanLiteral(
+                        ExprBooleanLiteral {
+                            range: 32..36,
+                            value: true,
+                        },
+                    ),
+                    body: [
+                        Pass(
+                            StmtPass {
+                                range: 38..42,
+                            },
+                        ),
+                    ],
+                    elif_else_clauses: [],
+                },
+            ),
+            If(
+                StmtIf {
+                    range: 44..58,
+                    test: BooleanLiteral(
+                        ExprBooleanLiteral {
+                            range: 47..52,
+                            value: false,
+                        },
+                    ),
+                    body: [
+                        Pass(
+                            StmtPass {
+                                range: 54..58,
+                            },
+                        ),
+                    ],
+                    elif_else_clauses: [],
+                },
+            ),
+        ],
+    },
+)
+```
+## Errors
+
+  |
+1 | if True: pass if False: pass
+  |               ^^ Syntax Error: Compound statements are not allowed on the same line as simple statements
+2 | if True: pass; if False: pass
+  |
+
+
+  |
+1 | if True: pass if False: pass
+2 | if True: pass; if False: pass
+  |                ^^ Syntax Error: Compound statements are not allowed on the same line as simple statements
+  |

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@simple_stmts_on_same_line.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@simple_stmts_on_same_line.py.snap
@@ -1,0 +1,146 @@
+---
+source: crates/ruff_python_parser/tests/fixtures.rs
+input_file: crates/ruff_python_parser/resources/inline/err/simple_stmts_on_same_line.py
+---
+## AST
+
+```
+Module(
+    ModModule {
+        range: 0..53,
+        body: [
+            Expr(
+                StmtExpr {
+                    range: 0..1,
+                    value: Name(
+                        ExprName {
+                            range: 0..1,
+                            id: "a",
+                            ctx: Load,
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 2..3,
+                    value: Name(
+                        ExprName {
+                            range: 2..3,
+                            id: "b",
+                            ctx: Load,
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 4..9,
+                    value: BinOp(
+                        ExprBinOp {
+                            range: 4..9,
+                            left: Name(
+                                ExprName {
+                                    range: 4..5,
+                                    id: "a",
+                                    ctx: Load,
+                                },
+                            ),
+                            op: Add,
+                            right: Name(
+                                ExprName {
+                                    range: 8..9,
+                                    id: "b",
+                                    ctx: Load,
+                                },
+                            ),
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 10..15,
+                    value: BinOp(
+                        ExprBinOp {
+                            range: 10..15,
+                            left: Name(
+                                ExprName {
+                                    range: 10..11,
+                                    id: "c",
+                                    ctx: Load,
+                                },
+                            ),
+                            op: Add,
+                            right: Name(
+                                ExprName {
+                                    range: 14..15,
+                                    id: "d",
+                                    ctx: Load,
+                                },
+                            ),
+                        },
+                    ),
+                },
+            ),
+            Break(
+                StmtBreak {
+                    range: 16..21,
+                },
+            ),
+            Continue(
+                StmtContinue {
+                    range: 23..31,
+                },
+            ),
+            Pass(
+                StmtPass {
+                    range: 32..36,
+                },
+            ),
+            Continue(
+                StmtContinue {
+                    range: 38..46,
+                },
+            ),
+            Break(
+                StmtBreak {
+                    range: 47..52,
+                },
+            ),
+        ],
+    },
+)
+```
+## Errors
+
+  |
+1 | a b
+  |   ^ Syntax Error: Simple statements must be separated by newlines or semicolons
+2 | a + b c + d
+3 | break; continue pass; continue break
+  |
+
+
+  |
+1 | a b
+2 | a + b c + d
+  |       ^ Syntax Error: Simple statements must be separated by newlines or semicolons
+3 | break; continue pass; continue break
+  |
+
+
+  |
+1 | a b
+2 | a + b c + d
+3 | break; continue pass; continue break
+  |                 ^^^^ Syntax Error: Simple statements must be separated by newlines or semicolons
+  |
+
+
+  |
+1 | a b
+2 | a + b c + d
+3 | break; continue pass; continue break
+  |                                ^^^^^ Syntax Error: Simple statements must be separated by newlines or semicolons
+  |

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@simple_stmts_on_same_line_in_block.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@simple_stmts_on_same_line_in_block.py.snap
@@ -1,0 +1,66 @@
+---
+source: crates/ruff_python_parser/tests/fixtures.rs
+input_file: crates/ruff_python_parser/resources/inline/err/simple_stmts_on_same_line_in_block.py
+---
+## AST
+
+```
+Module(
+    ModModule {
+        range: 0..46,
+        body: [
+            If(
+                StmtIf {
+                    range: 0..45,
+                    test: BooleanLiteral(
+                        ExprBooleanLiteral {
+                            range: 3..7,
+                            value: true,
+                        },
+                    ),
+                    body: [
+                        Break(
+                            StmtBreak {
+                                range: 9..14,
+                            },
+                        ),
+                        Continue(
+                            StmtContinue {
+                                range: 16..24,
+                            },
+                        ),
+                        Pass(
+                            StmtPass {
+                                range: 25..29,
+                            },
+                        ),
+                        Continue(
+                            StmtContinue {
+                                range: 31..39,
+                            },
+                        ),
+                        Break(
+                            StmtBreak {
+                                range: 40..45,
+                            },
+                        ),
+                    ],
+                    elif_else_clauses: [],
+                },
+            ),
+        ],
+    },
+)
+```
+## Errors
+
+  |
+1 | if True: break; continue pass; continue break
+  |                          ^^^^ Syntax Error: Simple statements must be separated by newlines or semicolons
+  |
+
+
+  |
+1 | if True: break; continue pass; continue break
+  |                                         ^^^^^ Syntax Error: Simple statements must be separated by newlines or semicolons
+  |

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@statements__function_type_parameters.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@statements__function_type_parameters.py.snap
@@ -383,7 +383,7 @@ Module(
 17 | def multiple_trailing_commas[A,,](): ...
 18 | 
 19 | def multiple_commas_and_recovery[A,,100](): ...
-   |                                        ^ Syntax Error: Expected a statement
+   |                                        ^ Syntax Error: expected Newline, found Rsqb
    |
 
 

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@statements__match__as_pattern_3.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@statements__match__as_pattern_3.py.snap
@@ -118,7 +118,7 @@ Module(
 2 |     #     Not in the mapping start token set, so the list parsing bails
 3 |     #     v
 4 |     case {(x as y): 1}:
-  |                      ^ Syntax Error: expected Dedent, found Rbrace
+  |                      ^ Syntax Error: expected Newline, found Rbrace
 5 |         pass
   |
 

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@type_alias_incomplete_stmt.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@type_alias_incomplete_stmt.py.snap
@@ -74,7 +74,7 @@ Module(
   |
 1 | type
 2 | type x
-  | ^^^^^^ Syntax Error: use `;` to separate simple statements
+  |      ^ Syntax Error: Simple statements must be separated by newlines or semicolons
 3 | type x =
   |
 

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@unterminated_fstring_newline_recovery.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@unterminated_fstring_newline_recovery.py.snap
@@ -322,24 +322,12 @@ Module(
 
 
   |
-1 |   f"hello
-2 |   1 + 1
-3 | / f"hello {x
-4 | | 2 + 2
-  | |_^ Syntax Error: use `;` to separate simple statements
-5 |   f"hello {x:
-6 |   3 + 3
-  |
-
-
-  |
-2 |   1 + 1
-3 |   f"hello {x
-4 | / 2 + 2
-5 | | f"hello {x:
-  | |__^ Syntax Error: use `;` to separate simple statements
-6 |   3 + 3
-7 |   f"hello {x}
+3 | f"hello {x
+4 | 2 + 2
+5 | f"hello {x:
+  | ^^ Syntax Error: Simple statements must be separated by newlines or semicolons
+6 | 3 + 3
+7 | f"hello {x}
   |
 
 
@@ -354,23 +342,11 @@ Module(
 
 
   |
-3 |   f"hello {x
-4 |   2 + 2
-5 | / f"hello {x:
-6 | | 3 + 3
-  | |_^ Syntax Error: use `;` to separate simple statements
-7 |   f"hello {x}
-8 |   4 + 4
-  |
-
-
-  |
-4 |   2 + 2
-5 |   f"hello {x:
-6 | / 3 + 3
-7 | | f"hello {x}
-  | |__^ Syntax Error: use `;` to separate simple statements
-8 |   4 + 4
+5 | f"hello {x:
+6 | 3 + 3
+7 | f"hello {x}
+  | ^^ Syntax Error: Simple statements must be separated by newlines or semicolons
+8 | 4 + 4
   |
 
 
@@ -388,15 +364,6 @@ Module(
 7 | f"hello {x}
 8 | 4 + 4
   | ^ Syntax Error: Expected an f-string element or the end of the f-string
-  |
-
-
-  |
-5 |   f"hello {x:
-6 |   3 + 3
-7 | / f"hello {x}
-8 | | 4 + 4
-  | |_^ Syntax Error: use `;` to separate simple statements
   |
 
 

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@simple_stmts_in_block.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@simple_stmts_in_block.py.snap
@@ -1,0 +1,123 @@
+---
+source: crates/ruff_python_parser/tests/fixtures.rs
+input_file: crates/ruff_python_parser/resources/inline/ok/simple_stmts_in_block.py
+---
+## AST
+
+```
+Module(
+    ModModule {
+        range: 0..84,
+        body: [
+            If(
+                StmtIf {
+                    range: 0..13,
+                    test: BooleanLiteral(
+                        ExprBooleanLiteral {
+                            range: 3..7,
+                            value: true,
+                        },
+                    ),
+                    body: [
+                        Pass(
+                            StmtPass {
+                                range: 9..13,
+                            },
+                        ),
+                    ],
+                    elif_else_clauses: [],
+                },
+            ),
+            If(
+                StmtIf {
+                    range: 14..27,
+                    test: BooleanLiteral(
+                        ExprBooleanLiteral {
+                            range: 17..21,
+                            value: true,
+                        },
+                    ),
+                    body: [
+                        Pass(
+                            StmtPass {
+                                range: 23..27,
+                            },
+                        ),
+                    ],
+                    elif_else_clauses: [],
+                },
+            ),
+            If(
+                StmtIf {
+                    range: 29..52,
+                    test: BooleanLiteral(
+                        ExprBooleanLiteral {
+                            range: 32..36,
+                            value: true,
+                        },
+                    ),
+                    body: [
+                        Pass(
+                            StmtPass {
+                                range: 38..42,
+                            },
+                        ),
+                        Continue(
+                            StmtContinue {
+                                range: 44..52,
+                            },
+                        ),
+                    ],
+                    elif_else_clauses: [],
+                },
+            ),
+            If(
+                StmtIf {
+                    range: 53..76,
+                    test: BooleanLiteral(
+                        ExprBooleanLiteral {
+                            range: 56..60,
+                            value: true,
+                        },
+                    ),
+                    body: [
+                        Pass(
+                            StmtPass {
+                                range: 62..66,
+                            },
+                        ),
+                        Continue(
+                            StmtContinue {
+                                range: 68..76,
+                            },
+                        ),
+                    ],
+                    elif_else_clauses: [],
+                },
+            ),
+            Assign(
+                StmtAssign {
+                    range: 78..83,
+                    targets: [
+                        Name(
+                            ExprName {
+                                range: 78..79,
+                                id: "x",
+                                ctx: Store,
+                            },
+                        ),
+                    ],
+                    value: NumberLiteral(
+                        ExprNumberLiteral {
+                            range: 82..83,
+                            value: Int(
+                                1,
+                            ),
+                        },
+                    ),
+                },
+            ),
+        ],
+    },
+)
+```

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@simple_stmts_with_semicolons.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@simple_stmts_with_semicolons.py.snap
@@ -1,0 +1,92 @@
+---
+source: crates/ruff_python_parser/tests/fixtures.rs
+input_file: crates/ruff_python_parser/resources/inline/ok/simple_stmts_with_semicolons.py
+---
+## AST
+
+```
+Module(
+    ModModule {
+        range: 0..51,
+        body: [
+            Return(
+                StmtReturn {
+                    range: 0..6,
+                    value: None,
+                },
+            ),
+            Import(
+                StmtImport {
+                    range: 8..16,
+                    names: [
+                        Alias {
+                            range: 15..16,
+                            name: Identifier {
+                                id: "a",
+                                range: 15..16,
+                            },
+                            asname: None,
+                        },
+                    ],
+                },
+            ),
+            ImportFrom(
+                StmtImportFrom {
+                    range: 18..33,
+                    module: Some(
+                        Identifier {
+                            id: "x",
+                            range: 23..24,
+                        },
+                    ),
+                    names: [
+                        Alias {
+                            range: 32..33,
+                            name: Identifier {
+                                id: "y",
+                                range: 32..33,
+                            },
+                            asname: None,
+                        },
+                    ],
+                    level: Some(
+                        0,
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 35..36,
+                    value: Name(
+                        ExprName {
+                            range: 35..36,
+                            id: "z",
+                            ctx: Load,
+                        },
+                    ),
+                },
+            ),
+            TypeAlias(
+                StmtTypeAlias {
+                    range: 38..50,
+                    name: Name(
+                        ExprName {
+                            range: 43..44,
+                            id: "T",
+                            ctx: Store,
+                        },
+                    ),
+                    type_params: None,
+                    value: Name(
+                        ExprName {
+                            range: 47..50,
+                            id: "int",
+                            ctx: Load,
+                        },
+                    ),
+                },
+            ),
+        ],
+    },
+)
+```


### PR DESCRIPTION
## Summary

This PR adds test cases for top level statement parsing functions. This mainly tests the following:
1. Simple statements on same line with and without semicolons
2. Simple and compound statement on same line with and without semicolon
3. Compound statement and their respective clause on same line with and without semicolon (for example, `if True: pass else: pass`)

This PR also makes the following changes:
1. Use the current token change to highlight the above errors. Previously, it would use a combined range of previous statement _and_ current token.
2. Improved messages for the above errors.

For (1), you'll notice that some of the errors disappeared. The reason is that they now overlap with an existing error.
