### PR TITLE
Improve IPython escape command parsing logic

### DIFF
--- a/crates/ruff_python_parser/src/error.rs
+++ b/crates/ruff_python_parser/src/error.rs
@@ -172,6 +172,8 @@ pub enum ParseErrorType {
     UnexpectedIndentation,
     /// The statement being parsed cannot be `async`.
     UnexpectedTokenAfterAsync(TokenKind),
+    /// Ipython escape command was found
+    UnexpectedIpythonEscapeCommand,
 
     /// An f-string error containing the [`FStringErrorType`].
     FStringError(FStringErrorType),
@@ -291,6 +293,9 @@ impl std::fmt::Display for ParseErrorType {
             }
             ParseErrorType::DuplicateKeywordArgumentError(arg_name) => {
                 write!(f, "Duplicate keyword argument {arg_name:?}")
+            }
+            ParseErrorType::UnexpectedIpythonEscapeCommand => {
+                f.write_str("IPython escape commands are only allowed in `Mode::Ipython`")
             }
             ParseErrorType::FStringError(ref fstring_error) => {
                 write!(f, "f-string: {fstring_error}")

--- a/crates/ruff_python_parser/src/parser/mod.rs
+++ b/crates/ruff_python_parser/src/parser/mod.rs
@@ -148,6 +148,7 @@ const EXPR_SET: TokenSet = TokenSet::new([
     TokenKind::Not,
     TokenKind::Yield,
     TokenKind::FStringStart,
+    TokenKind::IpyEscapeCommand,
 ])
 .union(LITERAL_SET);
 

--- a/crates/ruff_python_parser/src/parser/tests.rs
+++ b/crates/ruff_python_parser/src/parser/tests.rs
@@ -1,7 +1,11 @@
 use crate::{lex, parse, parse_suite, parse_tokens, Mode};
 
+// TODO(dhruvmanila): Remove `set_new_parser`
+
 #[test]
 fn test_modes() {
+    crate::set_new_parser(true);
+
     let source = "a[0][1][2][3][4]";
 
     assert!(parse(source, Mode::Expression).is_ok());
@@ -10,6 +14,8 @@ fn test_modes() {
 
 #[test]
 fn test_unicode_aliases() {
+    crate::set_new_parser(true);
+
     // https://github.com/RustPython/RustPython/issues/4566
     let source = r#"x = "\N{BACKSPACE}another cool trick""#;
     let parse_ast = parse_suite(source).unwrap();
@@ -19,6 +25,8 @@ fn test_unicode_aliases() {
 
 #[test]
 fn test_ipython_escape_commands() {
+    crate::set_new_parser(true);
+
     let parse_ast = parse(
         r"
 # Normal Python code
@@ -95,6 +103,8 @@ foo.bar[0].baz[2].egg??
 
 #[test]
 fn test_ipython_escape_command_parse_error() {
+    crate::set_new_parser(true);
+
     let source = r"
 a = 1
 %timeit a == 1

--- a/crates/ruff_python_parser/src/token.rs
+++ b/crates/ruff_python_parser/src/token.rs
@@ -373,7 +373,7 @@ pub enum TokenKind {
     /// Token value for the end of an f-string. This includes the closing quote.
     FStringEnd,
     /// Token value for a IPython escape command.
-    EscapeCommand,
+    IpyEscapeCommand,
     /// Token value for a comment. These are filtered out of the token stream prior to parsing.
     Comment,
     /// Token value for a newline.
@@ -752,7 +752,7 @@ impl TokenKind {
             Tok::FStringStart(_) => TokenKind::FStringStart,
             Tok::FStringMiddle { .. } => TokenKind::FStringMiddle,
             Tok::FStringEnd => TokenKind::FStringEnd,
-            Tok::IpyEscapeCommand { .. } => TokenKind::EscapeCommand,
+            Tok::IpyEscapeCommand { .. } => TokenKind::IpyEscapeCommand,
             Tok::Comment(_) => TokenKind::Comment,
             Tok::Newline => TokenKind::Newline,
             Tok::NonLogicalNewline => TokenKind::NonLogicalNewline,
@@ -942,7 +942,7 @@ impl fmt::Display for TokenKind {
             TokenKind::FStringStart => "FStringStart",
             TokenKind::FStringMiddle => "FStringMiddle",
             TokenKind::FStringEnd => "FStringEnd",
-            TokenKind::EscapeCommand => "IPython escape command",
+            TokenKind::IpyEscapeCommand => "IPython escape command",
             TokenKind::Comment => "comment",
             TokenKind::Question => "'?'",
             TokenKind::Exclamation => "'!'",


### PR DESCRIPTION
## Summary

This PR reviews the logic for IPython escape command parsing and makes the required changes to almost match the old parsing logic.

~One change I've not incorporated is the `unparse_expr`. The new parser can use `src_text` directly but this means that any whitespace is preserved~ Migrated the `unparse_expr` logic

## Test plan

Use the new parser for testing escape commands and verify that there are no snapshot changes.