### PR TITLE
[pyflakes] Identify f-string without a placeholder in concatenated strings (F541)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pyflakes/F541.py
+++ b/crates/ruff_linter/resources/test/fixtures/pyflakes/F541.py
@@ -42,3 +42,8 @@ f"{{{{x}}}}"
 (""f""r"")
 f"{v:{f"0.2f"}}"
 f"\{{x}}"
+
+(
+    f"no placeholder"
+    f"placeholder: {a}"
+)

--- a/crates/ruff_linter/src/rules/pyflakes/rules/f_string_missing_placeholders.rs
+++ b/crates/ruff_linter/src/rules/pyflakes/rules/f_string_missing_placeholders.rs
@@ -47,16 +47,15 @@ impl AlwaysFixableViolation for FStringMissingPlaceholders {
 
 /// F541
 pub(crate) fn f_string_missing_placeholders(checker: &mut Checker, expr: &ast::ExprFString) {
-    if expr.value.f_strings().any(|f_string| {
-        f_string
+    for f_string in expr.value.f_strings() {
+        if f_string
             .elements
             .iter()
             .any(ast::FStringElement::is_expression)
-    }) {
-        return;
-    }
+        {
+            return;
+        }
 
-    for f_string in expr.value.f_strings() {
         let first_char = checker
             .locator()
             .slice(TextRange::at(f_string.start(), TextSize::new(1)));

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F541_F541.py.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F541_F541.py.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/ruff_linter/src/rules/pyflakes/mod.rs
+assertion_line: 180
 ---
 F541.py:6:5: F541 [*] f-string without any placeholders
   |
@@ -374,6 +375,7 @@ F541.py:42:4: F541 [*] f-string without any placeholders
    42 |+("" ""r"")
 43 43 | f"{v:{f"0.2f"}}"
 44 44 | f"\{{x}}"
+45 45 | 
 
 F541.py:43:7: F541 [*] f-string without any placeholders
    |
@@ -392,6 +394,8 @@ F541.py:43:7: F541 [*] f-string without any placeholders
 43    |-f"{v:{f"0.2f"}}"
    43 |+f"{v:{"0.2f"}}"
 44 44 | f"\{{x}}"
+45 45 | 
+46 46 | (
 
 F541.py:44:1: F541 [*] f-string without any placeholders
    |
@@ -399,6 +403,8 @@ F541.py:44:1: F541 [*] f-string without any placeholders
 43 | f"{v:{f"0.2f"}}"
 44 | f"\{{x}}"
    | ^^^^^^^^^ F541
+45 | 
+46 | (
    |
    = help: Remove extraneous `f` prefix
 
@@ -408,5 +414,25 @@ F541.py:44:1: F541 [*] f-string without any placeholders
 43 43 | f"{v:{f"0.2f"}}"
 44    |-f"\{{x}}"
    44 |+"\{x}"
+45 45 | 
+46 46 | (
+47 47 |     f"no placeholder"
 
+F541.py:47:5: F541 [*] f-string without any placeholders
+   |
+46 | (
+47 |     f"no placeholder"
+   |     ^^^^^^^^^^^^^^^^^ F541
+48 |     f"placeholder: {a}"
+49 | )
+   |
+   = help: Remove extraneous `f` prefix
 
+ℹ Safe fix
+44 44 | f"\{{x}}"
+45 45 | 
+46 46 | (
+47    |-    f"no placeholder"
+   47 |+    "no placeholder"
+48 48 |     f"placeholder: {a}"
+49 49 | )


### PR DESCRIPTION
Prior to this change, an f-string without a placeholder that was
implicitly concatenated with another f-string that _did_ have a
placeholder would not be identified by F541. This happened because the
escape hatch at the start of the check would exit early if *any* of the
strings being concatenated were valid, allowing a good string to hide a
bad one.

This change moves the check inside the loop so it is evaluated against
each (and therefore every) sub-string.

Fixes #10885