### PR TITLE
Add tests for simple target in annotated assign stmt

### DIFF
--- a/crates/ruff_python_parser/resources/inline/ok/ann_assign_stmt_simple_target.py
+++ b/crates/ruff_python_parser/resources/inline/ok/ann_assign_stmt_simple_target.py
@@ -1,0 +1,4 @@
+a: int  # simple
+(a): int
+a.b: int
+a[0]: int

--- a/crates/ruff_python_parser/src/lalrpop/python.lalrpop
+++ b/crates/ruff_python_parser/src/lalrpop/python.lalrpop
@@ -145,7 +145,7 @@ ExpressionStatement: ast::Stmt = {
         ))
     },
     <location:@L> <target:Test<"all">> ":" <annotation:Test<"all">> <rhs:AssignSuffix?> <end_location:@R> =>? {
-        let simple = target.expr.is_name_expr();
+        let simple = target.expr.is_name_expr() && !target.is_parenthesized();
         invalid::assignment_target(&target.expr)?;
         Ok(ast::Stmt::AnnAssign(
             ast::StmtAnnAssign {

--- a/crates/ruff_python_parser/src/lalrpop/python.rs
+++ b/crates/ruff_python_parser/src/lalrpop/python.rs
@@ -1,5 +1,5 @@
 // auto-generated: "lalrpop 0.20.0"
-// sha3: 19d8a130ba177ffe72627037ce6cf93d642d4698a48d58f49622191534f77fb4
+// sha3: defe105edf1f7227b0c0a1e2d525aa628159fe6145aef96c6c99b18ac93faebb
 use ruff_text_size::{Ranged, TextLen, TextRange, TextSize};
 use ruff_python_ast::{self as ast, Int, IpyEscapeKind, AnyStringKind};
 use super::{
@@ -32761,7 +32761,7 @@ fn __action28<
 ) -> Result<ast::Stmt,__lalrpop_util::ParseError<TextSize,token::Tok,LexicalError>>
 {
     {
-        let simple = target.expr.is_name_expr();
+        let simple = target.expr.is_name_expr() && !target.is_parenthesized();
         invalid::assignment_target(&target.expr)?;
         Ok(ast::Stmt::AnnAssign(
             ast::StmtAnnAssign {

--- a/crates/ruff_python_parser/src/parser/statement.rs
+++ b/crates/ruff_python_parser/src/parser/statement.rs
@@ -1069,6 +1069,11 @@ impl<'src> Parser<'src> {
 
         helpers::set_expr_ctx(&mut target.expr, ExprContext::Store);
 
+        // test_ok ann_assign_stmt_simple_target
+        // a: int  # simple
+        // (a): int
+        // a.b: int
+        // a[0]: int
         let simple = target.is_name_expr() && !target.is_parenthesized;
 
         // test_err ann_assign_stmt_invalid_annotation

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@ann_assign_stmt_simple_target.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@ann_assign_stmt_simple_target.py.snap
@@ -1,0 +1,123 @@
+---
+source: crates/ruff_python_parser/tests/fixtures.rs
+input_file: crates/ruff_python_parser/resources/inline/ok/ann_assign_stmt_simple_target.py
+---
+## AST
+
+```
+Module(
+    ModModule {
+        range: 0..45,
+        body: [
+            AnnAssign(
+                StmtAnnAssign {
+                    range: 0..6,
+                    target: Name(
+                        ExprName {
+                            range: 0..1,
+                            id: "a",
+                            ctx: Store,
+                        },
+                    ),
+                    annotation: Name(
+                        ExprName {
+                            range: 3..6,
+                            id: "int",
+                            ctx: Load,
+                        },
+                    ),
+                    value: None,
+                    simple: true,
+                },
+            ),
+            AnnAssign(
+                StmtAnnAssign {
+                    range: 17..25,
+                    target: Name(
+                        ExprName {
+                            range: 18..19,
+                            id: "a",
+                            ctx: Store,
+                        },
+                    ),
+                    annotation: Name(
+                        ExprName {
+                            range: 22..25,
+                            id: "int",
+                            ctx: Load,
+                        },
+                    ),
+                    value: None,
+                    simple: false,
+                },
+            ),
+            AnnAssign(
+                StmtAnnAssign {
+                    range: 26..34,
+                    target: Attribute(
+                        ExprAttribute {
+                            range: 26..29,
+                            value: Name(
+                                ExprName {
+                                    range: 26..27,
+                                    id: "a",
+                                    ctx: Load,
+                                },
+                            ),
+                            attr: Identifier {
+                                id: "b",
+                                range: 28..29,
+                            },
+                            ctx: Store,
+                        },
+                    ),
+                    annotation: Name(
+                        ExprName {
+                            range: 31..34,
+                            id: "int",
+                            ctx: Load,
+                        },
+                    ),
+                    value: None,
+                    simple: false,
+                },
+            ),
+            AnnAssign(
+                StmtAnnAssign {
+                    range: 35..44,
+                    target: Subscript(
+                        ExprSubscript {
+                            range: 35..39,
+                            value: Name(
+                                ExprName {
+                                    range: 35..36,
+                                    id: "a",
+                                    ctx: Load,
+                                },
+                            ),
+                            slice: NumberLiteral(
+                                ExprNumberLiteral {
+                                    range: 37..38,
+                                    value: Int(
+                                        0,
+                                    ),
+                                },
+                            ),
+                            ctx: Store,
+                        },
+                    ),
+                    annotation: Name(
+                        ExprName {
+                            range: 41..44,
+                            id: "int",
+                            ctx: Load,
+                        },
+                    ),
+                    value: None,
+                    simple: false,
+                },
+            ),
+        ],
+    },
+)
+```


### PR DESCRIPTION
> `simple` is a boolean integer set to `True` for a [Name](https://docs.python.org/3/library/ast.html#ast.Name) node in `target` that do not appear in between parenthesis and are hence pure names and not expressions.

Reference: https://docs.python.org/3/library/ast.html#ast.AnnAssign