### PR TITLE
Disallow dotted name in `from ... import` statement

### DIFF
--- a/crates/ruff_python_parser/resources/inline/err/from_import_dotted_names.py
+++ b/crates/ruff_python_parser/resources/inline/err/from_import_dotted_names.py
@@ -1,0 +1,3 @@
+from x import a.
+from x import a.b
+from x import a, b.c, d, e.f, g

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@from_import_dotted_names.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@from_import_dotted_names.py.snap
@@ -1,0 +1,175 @@
+---
+source: crates/ruff_python_parser/tests/fixtures.rs
+input_file: crates/ruff_python_parser/resources/inline/err/from_import_dotted_names.py
+---
+## AST
+
+```
+Module(
+    ModModule {
+        range: 0..67,
+        body: [
+            ImportFrom(
+                StmtImportFrom {
+                    range: 0..16,
+                    module: Some(
+                        Identifier {
+                            id: "x",
+                            range: 5..6,
+                        },
+                    ),
+                    names: [
+                        Alias {
+                            range: 14..15,
+                            name: Identifier {
+                                id: "a",
+                                range: 14..15,
+                            },
+                            asname: None,
+                        },
+                    ],
+                    level: Some(
+                        0,
+                    ),
+                },
+            ),
+            ImportFrom(
+                StmtImportFrom {
+                    range: 17..34,
+                    module: Some(
+                        Identifier {
+                            id: "x",
+                            range: 22..23,
+                        },
+                    ),
+                    names: [
+                        Alias {
+                            range: 31..32,
+                            name: Identifier {
+                                id: "a",
+                                range: 31..32,
+                            },
+                            asname: None,
+                        },
+                        Alias {
+                            range: 33..34,
+                            name: Identifier {
+                                id: "b",
+                                range: 33..34,
+                            },
+                            asname: None,
+                        },
+                    ],
+                    level: Some(
+                        0,
+                    ),
+                },
+            ),
+            ImportFrom(
+                StmtImportFrom {
+                    range: 35..66,
+                    module: Some(
+                        Identifier {
+                            id: "x",
+                            range: 40..41,
+                        },
+                    ),
+                    names: [
+                        Alias {
+                            range: 49..50,
+                            name: Identifier {
+                                id: "a",
+                                range: 49..50,
+                            },
+                            asname: None,
+                        },
+                        Alias {
+                            range: 52..53,
+                            name: Identifier {
+                                id: "b",
+                                range: 52..53,
+                            },
+                            asname: None,
+                        },
+                        Alias {
+                            range: 54..55,
+                            name: Identifier {
+                                id: "c",
+                                range: 54..55,
+                            },
+                            asname: None,
+                        },
+                        Alias {
+                            range: 57..58,
+                            name: Identifier {
+                                id: "d",
+                                range: 57..58,
+                            },
+                            asname: None,
+                        },
+                        Alias {
+                            range: 60..61,
+                            name: Identifier {
+                                id: "e",
+                                range: 60..61,
+                            },
+                            asname: None,
+                        },
+                        Alias {
+                            range: 62..63,
+                            name: Identifier {
+                                id: "f",
+                                range: 62..63,
+                            },
+                            asname: None,
+                        },
+                        Alias {
+                            range: 65..66,
+                            name: Identifier {
+                                id: "g",
+                                range: 65..66,
+                            },
+                            asname: None,
+                        },
+                    ],
+                    level: Some(
+                        0,
+                    ),
+                },
+            ),
+        ],
+    },
+)
+```
+## Errors
+
+  |
+1 | from x import a.
+  |                ^ Syntax Error: Expected ',', found '.'
+2 | from x import a.b
+3 | from x import a, b.c, d, e.f, g
+  |
+
+
+  |
+1 | from x import a.
+2 | from x import a.b
+  |                ^ Syntax Error: Expected ',', found '.'
+3 | from x import a, b.c, d, e.f, g
+  |
+
+
+  |
+1 | from x import a.
+2 | from x import a.b
+3 | from x import a, b.c, d, e.f, g
+  |                   ^ Syntax Error: Expected ',', found '.'
+  |
+
+
+  |
+1 | from x import a.
+2 | from x import a.b
+3 | from x import a, b.c, d, e.f, g
+  |                           ^ Syntax Error: Expected ',', found '.'
+  |


### PR DESCRIPTION
## Summary

Dotted names aren't allowed in `from ... import` statement. They're only allowed in `import` statement.

### Alternative

Another solution would be to parse the dotted name, check if there's a `.` in the parsed string and raise an error.

I choose not to do this because it didn't make sense to do `contains` for every import name.

## Test Plan

Add invalid syntax test cases to verify the logic.
