### PR TITLE
Respect `per-file-ignores` for `RUF100` on blanket `# noqa`

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/ruff/ruff_per_file_ignores.py
+++ b/crates/ruff_linter/resources/test/fixtures/ruff/ruff_per_file_ignores.py
@@ -1,2 +1,3 @@
 import os
 import foo  # noqa: F401
+import bar  # noqa

--- a/crates/ruff_linter/src/checkers/noqa.rs
+++ b/crates/ruff_linter/src/checkers/noqa.rs
@@ -111,6 +111,7 @@ pub(crate) fn check_noqa(
             FileExemption::All => true,
             FileExemption::Codes(codes) => codes.contains(&Rule::UnusedNOQA.noqa_code()),
         })
+        && !per_file_ignores.contains(Rule::UnusedNOQA)
     {
         for line in noqa_directives.lines() {
             match &line.directive {
@@ -129,7 +130,7 @@ pub(crate) fn check_noqa(
                     let mut unknown_codes = vec![];
                     let mut unmatched_codes = vec![];
                     let mut valid_codes = vec![];
-                    let mut self_ignore = per_file_ignores.contains(Rule::UnusedNOQA);
+                    let mut self_ignore = false;
                     for code in directive.codes() {
                         let code = get_redirect_target(code).unwrap_or(code);
                         if Rule::UnusedNOQA.noqa_code() == code {


### PR DESCRIPTION
## Summary

If `RUF100` was included in a per-file-ignore, we respected it on cases like `# noqa: F401`, but not the blanket variant (`# noqa`).

Closes https://github.com/astral-sh/ruff/issues/10906.
