### PR TITLE
Limit commutative non-augmented-assignments to primitive data types

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pylint/non_augmented_assignment.py
+++ b/crates/ruff_linter/resources/test/fixtures/pylint/non_augmented_assignment.py
@@ -55,3 +55,4 @@ a_list[0] = a_list[:] * 3
 index = a_number = a_number + 1
 a_number = index = a_number + 1
 index = index * index + 10
+some_string = "a very long start to the string" + some_string


### PR DESCRIPTION
## Summary

I think this is the best we can do without type inference. At least it will still catch some common cases.

Closes #10911.
