### PR TITLE
Fix last example of flake8-bugbear rule `B023` "function uses loop variable"

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/function_uses_loop_variable.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/function_uses_loop_variable.rs
@@ -34,7 +34,7 @@ use crate::checkers::ast::Checker;
 /// ```python
 /// from functools import partial
 ///
-/// adders = [partial(lambda x, i: x + i, i) for i in range(3)]
+/// adders = [partial(lambda x, i: x + i, i=i) for i in range(3)]
 /// values = [adder(1) for adder in adders]  # [1, 2, 3]
 /// ```
 ///


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Hi! :wave: 

Thanks for sharing ruff as software libre — it helps me keep Python code quality up with pre-commit, both locally and CI :pray: 

While studying the examples at https://docs.astral.sh/ruff/rules/function-uses-loop-variable/#example I noticed that the last of the examples had a bug: prior to this fix, `ì` was passed to the lambda for `x` rather than for `i` — the two are mixed-up. The reason it's easy to overlook is because addition is an commutative operation and so `x + i` and `i + x` give the same result (and least with integers), despite the mix-up. For proof, let me demo the relevant part with before and after:

```python
In [1]: from functools import partial

In [2]: [partial(lambda x, i: (x, i), i)(123) for i in range(3)]
Out[2]: [(0, 123), (1, 123), (2, 123)]

In [3]: [partial(lambda x, i: (x, i), i=i)(123) for i in range(3)]
Out[3]: [(123, 0), (123, 1), (123, 2)]
```

Does that make sense?

## Test Plan

<!-- How was it tested? -->
Was manually tested using IPython.


CC @r4f @grandchild