### PR TITLE
Enable ruff-specific source actions

### DIFF
--- a/crates/ruff_server/src/server.rs
+++ b/crates/ruff_server/src/server.rs
@@ -224,7 +224,8 @@ impl Server {
                 CodeActionOptions {
                     code_action_kinds: Some(
                         SupportedCodeAction::all()
-                            .flat_map(|action| action.kinds().into_iter())
+                            .flat_map(|action| action.kinds().iter())
+                            .cloned()
                             .collect(),
                     ),
                     work_done_progress_options: WorkDoneProgressOptions {
@@ -285,14 +286,18 @@ pub(crate) enum SupportedCodeAction {
 
 impl SupportedCodeAction {
     /// Returns the possible LSP code action kind(s) that map to this code action.
-    fn kinds(self) -> Vec<CodeActionKind> {
+    fn kinds(self) -> &'static [CodeActionKind] {
+        static QUICKFIX: [CodeActionKind; 1] = [CodeActionKind::QUICKFIX];
+        static SOURCE_FIX_ALL: [CodeActionKind; 2] =
+            [CodeActionKind::SOURCE_FIX_ALL, crate::SOURCE_FIX_ALL_RUFF];
+        static SOURCE_ORGANIZE_IMPORTS: [CodeActionKind; 2] = [
+            CodeActionKind::SOURCE_ORGANIZE_IMPORTS,
+            crate::SOURCE_ORGANIZE_IMPORTS_RUFF,
+        ];
         match self {
-            Self::QuickFix => vec![CodeActionKind::QUICKFIX],
-            Self::SourceFixAll => vec![CodeActionKind::SOURCE_FIX_ALL, crate::SOURCE_FIX_ALL_RUFF],
-            Self::SourceOrganizeImports => vec![
-                CodeActionKind::SOURCE_ORGANIZE_IMPORTS,
-                crate::SOURCE_ORGANIZE_IMPORTS_RUFF,
-            ],
+            Self::QuickFix => &QUICKFIX,
+            Self::SourceFixAll => &SOURCE_FIX_ALL,
+            Self::SourceOrganizeImports => &SOURCE_ORGANIZE_IMPORTS,
         }
     }
 

--- a/crates/ruff_server/src/server.rs
+++ b/crates/ruff_server/src/server.rs
@@ -225,7 +225,6 @@ impl Server {
                     code_action_kinds: Some(
                         SupportedCodeAction::all()
                             .map(SupportedCodeAction::to_kind)
-                            .cloned()
                             .collect(),
                     ),
                     work_done_progress_options: WorkDoneProgressOptions {
@@ -286,14 +285,11 @@ pub(crate) enum SupportedCodeAction {
 
 impl SupportedCodeAction {
     /// Returns the LSP code action kind that map to this code action.
-    fn to_kind(self) -> &'static CodeActionKind {
-        static QUICK_FIX: CodeActionKind = CodeActionKind::QUICKFIX;
-        static SOURCE_FIX_ALL: CodeActionKind = crate::SOURCE_FIX_ALL_RUFF;
-        static SOURCE_ORGANIZE_IMPORTS: CodeActionKind = crate::SOURCE_ORGANIZE_IMPORTS_RUFF;
+    fn to_kind(self) -> CodeActionKind {
         match self {
-            Self::QuickFix => &QUICK_FIX,
-            Self::SourceFixAll => &SOURCE_FIX_ALL,
-            Self::SourceOrganizeImports => &SOURCE_ORGANIZE_IMPORTS,
+            Self::QuickFix => CodeActionKind::QUICKFIX,
+            Self::SourceFixAll => crate::SOURCE_FIX_ALL_RUFF,
+            Self::SourceOrganizeImports => crate::SOURCE_ORGANIZE_IMPORTS_RUFF,
         }
     }
 

--- a/crates/ruff_server/src/server/api/requests/code_action.rs
+++ b/crates/ruff_server/src/server/api/requests/code_action.rs
@@ -41,14 +41,13 @@ impl super::BackgroundDocumentRequestHandler for CodeActions {
         if snapshot.client_settings().fix_all()
             && supported_code_actions.contains(&SupportedCodeAction::SourceFixAll)
         {
-            response.extend(fix_all(&snapshot).with_failure_code(ErrorCode::InternalError)?);
+            response.push(fix_all(&snapshot).with_failure_code(ErrorCode::InternalError)?);
         }
 
         if snapshot.client_settings().organize_imports()
             && supported_code_actions.contains(&SupportedCodeAction::SourceOrganizeImports)
         {
-            response
-                .extend(organize_imports(&snapshot).with_failure_code(ErrorCode::InternalError)?);
+            response.push(organize_imports(&snapshot).with_failure_code(ErrorCode::InternalError)?);
         }
 
         Ok(Some(response))
@@ -88,7 +87,7 @@ fn quick_fix(
         .collect()
 }
 
-fn fix_all(snapshot: &DocumentSnapshot) -> crate::Result<Vec<CodeActionOrCommand>> {
+fn fix_all(snapshot: &DocumentSnapshot) -> crate::Result<CodeActionOrCommand> {
     let document = snapshot.document();
 
     let (edit, data) = if snapshot
@@ -113,21 +112,17 @@ fn fix_all(snapshot: &DocumentSnapshot) -> crate::Result<Vec<CodeActionOrCommand
             None,
         )
     };
-    Ok(SupportedCodeAction::SourceFixAll
-        .kinds()
-        .into_iter()
-        .map(move |kind| types::CodeAction {
-            title: format!("{DIAGNOSTIC_NAME}: Fix all auto-fixable problems"),
-            kind: Some(kind),
-            edit: edit.clone(),
-            data: data.clone(),
-            ..Default::default()
-        })
-        .map(CodeActionOrCommand::CodeAction)
-        .collect())
+
+    Ok(CodeActionOrCommand::CodeAction(types::CodeAction {
+        title: format!("{DIAGNOSTIC_NAME}: Fix all auto-fixable problems"),
+        kind: Some(crate::SOURCE_FIX_ALL_RUFF),
+        edit: edit.clone(),
+        data: data.clone(),
+        ..Default::default()
+    }))
 }
 
-fn organize_imports(snapshot: &DocumentSnapshot) -> crate::Result<Vec<CodeActionOrCommand>> {
+fn organize_imports(snapshot: &DocumentSnapshot) -> crate::Result<CodeActionOrCommand> {
     let document = snapshot.document();
 
     let (edit, data) = if snapshot
@@ -152,18 +147,14 @@ fn organize_imports(snapshot: &DocumentSnapshot) -> crate::Result<Vec<CodeAction
             None,
         )
     };
-    Ok(SupportedCodeAction::SourceOrganizeImports
-        .kinds()
-        .into_iter()
-        .map(move |kind| types::CodeAction {
-            title: format!("{DIAGNOSTIC_NAME}: Organize imports"),
-            kind: Some(kind),
-            edit: edit.clone(),
-            data: data.clone(),
-            ..Default::default()
-        })
-        .map(CodeActionOrCommand::CodeAction)
-        .collect())
+
+    Ok(CodeActionOrCommand::CodeAction(types::CodeAction {
+        title: format!("{DIAGNOSTIC_NAME}: Organize imports"),
+        kind: Some(crate::SOURCE_ORGANIZE_IMPORTS_RUFF),
+        edit: edit.clone(),
+        data: data.clone(),
+        ..Default::default()
+    }))
 }
 
 /// If `action_filter` is `None`, this returns [`SupportedCodeActionKind::all()`]. Otherwise,

--- a/crates/ruff_server/src/server/api/requests/code_action.rs
+++ b/crates/ruff_server/src/server/api/requests/code_action.rs
@@ -166,14 +166,8 @@ fn supported_code_actions(
         return SupportedCodeAction::all().collect();
     };
 
-    SupportedCodeAction::all()
-        .filter(move |action| {
-            action_filter.iter().any(|filter| {
-                action
-                    .kinds()
-                    .iter()
-                    .any(|kind| kind.as_str().starts_with(filter.as_str()))
-            })
-        })
+    action_filter
+        .into_iter()
+        .flat_map(SupportedCodeAction::from_kind)
         .collect()
 }

--- a/crates/ruff_server/src/server/api/requests/code_action.rs
+++ b/crates/ruff_server/src/server/api/requests/code_action.rs
@@ -116,8 +116,8 @@ fn fix_all(snapshot: &DocumentSnapshot) -> crate::Result<CodeActionOrCommand> {
     Ok(CodeActionOrCommand::CodeAction(types::CodeAction {
         title: format!("{DIAGNOSTIC_NAME}: Fix all auto-fixable problems"),
         kind: Some(crate::SOURCE_FIX_ALL_RUFF),
-        edit: edit.clone(),
-        data: data.clone(),
+        edit,
+        data,
         ..Default::default()
     }))
 }
@@ -151,8 +151,8 @@ fn organize_imports(snapshot: &DocumentSnapshot) -> crate::Result<CodeActionOrCo
     Ok(CodeActionOrCommand::CodeAction(types::CodeAction {
         title: format!("{DIAGNOSTIC_NAME}: Organize imports"),
         kind: Some(crate::SOURCE_ORGANIZE_IMPORTS_RUFF),
-        edit: edit.clone(),
-        data: data.clone(),
+        edit,
+        data,
         ..Default::default()
     }))
 }

--- a/crates/ruff_server/src/server/api/requests/code_action_resolve.rs
+++ b/crates/ruff_server/src/server/api/requests/code_action_resolve.rs
@@ -30,16 +30,23 @@ impl super::BackgroundDocumentRequestHandler for CodeActionResolve {
     ) -> Result<types::CodeAction> {
         let document = snapshot.document();
 
-        let action_kind = SupportedCodeAction::from_kind(
+        let code_actions = SupportedCodeAction::from_kind(
             action
                 .kind
                 .clone()
                 .ok_or(anyhow::anyhow!("No kind was given for code action"))
                 .with_failure_code(ErrorCode::InvalidParams)?,
         )
-        .next()
-        .ok_or(anyhow::anyhow!("Code action was of an invalid kind"))
-        .with_failure_code(ErrorCode::InvalidParams)?;
+        .collect::<Vec<_>>();
+
+        // Ensure that the code action maps to _exactly one_ supported code action
+        let [action_kind] = code_actions.as_slice() else {
+            return Err(anyhow::anyhow!(
+                "Code action resolver did not expect code action kind {:?}",
+                action.kind.as_ref().unwrap()
+            ))
+            .with_failure_code(ErrorCode::InvalidParams);
+        };
 
         action.edit = match action_kind {
             SupportedCodeAction::SourceFixAll => Some(

--- a/crates/ruff_server/src/server/api/requests/code_action_resolve.rs
+++ b/crates/ruff_server/src/server/api/requests/code_action_resolve.rs
@@ -30,14 +30,16 @@ impl super::BackgroundDocumentRequestHandler for CodeActionResolve {
     ) -> Result<types::CodeAction> {
         let document = snapshot.document();
 
-        let action_kind: SupportedCodeAction = action
-            .kind
-            .clone()
-            .ok_or(anyhow::anyhow!("No kind was given for code action"))
-            .with_failure_code(ErrorCode::InvalidParams)?
-            .try_into()
-            .map_err(|()| anyhow::anyhow!("Code action was of an invalid kind"))
-            .with_failure_code(ErrorCode::InvalidParams)?;
+        let action_kind = SupportedCodeAction::from_kind(
+            action
+                .kind
+                .clone()
+                .ok_or(anyhow::anyhow!("No kind was given for code action"))
+                .with_failure_code(ErrorCode::InvalidParams)?,
+        )
+        .next()
+        .ok_or(anyhow::anyhow!("Code action was of an invalid kind"))
+        .with_failure_code(ErrorCode::InvalidParams)?;
 
         action.edit = match action_kind {
             SupportedCodeAction::SourceFixAll => Some(


### PR DESCRIPTION
## Summary

Fixes #10780.

The server now send code actions to the client with a Ruff-specific kind, `source.*.ruff`. The kind filtering logic has also been reworked to support this.

## Test Plan

Add this to your `settings.json` in VS Code:

```json
{
  "[python]": {
    "editor.codeActionsOnSave": {
      "source.organizeImports.ruff": "explicit",
    },
  }
}
```

Imports should be automatically organized when you manually save with `Ctrl/Cmd+S`.