### PR TITLE
Fix S310 `suspicious-url-open-usage` description

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/suspicious_function_call.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/suspicious_function_call.rs
@@ -344,7 +344,7 @@ impl Violation for SuspiciousMarkSafeUsage {
 }
 
 /// ## What it does
-/// Checks for uses of URL open functions that use unexpected schemes.
+/// Checks for instances where URL open functions are used with unexpected schemes.
 ///
 /// ## Why is this bad?
 /// Some URL open functions allow the use of `file:` or custom schemes (for use

--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/suspicious_function_call.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/suspicious_function_call.rs
@@ -344,7 +344,7 @@ impl Violation for SuspiciousMarkSafeUsage {
 }
 
 /// ## What it does
-/// Checks for uses of URL open functions that unexpected schemes.
+/// Checks for uses of URL open functions that use unexpected schemes.
 ///
 /// ## Why is this bad?
 /// Some URL open functions allow the use of `file:` or custom schemes (for use


### PR DESCRIPTION
## Summary

The "What it does" section of the docstring is missing a verb, this PR adds it.