### PR TITLE
Configure Renovate to ignore ESLint 9

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -52,6 +52,13 @@
       matchPackagePatterns: ["strum"],
       description: "Weekly update of strum dependencies",
     },
+    {
+      groupName: "ESLint",
+      matchManagers: ["npm"],
+      matchPackageNames: ["eslint"],
+      allowedVersions: "<9",
+      description: "Constraint ESLint to version 8 until TypeScript-eslint supports ESLint 9", // https://github.com/typescript-eslint/typescript-eslint/issues/8211
+    },
   ],
   vulnerabilityAlerts: {
     commitMessageSuffix: "",


### PR DESCRIPTION
## Summary

^

## Test Plan

❯ npx --yes --package renovate -- renovate-config-validator --strict
 INFO: Validating .github/renovate.json5
 INFO: Config validated successfully

