### PR TITLE
Resolve classes and functions relative to script name

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_bugbear/B008_extended.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_bugbear/B008_extended.py
@@ -23,3 +23,15 @@ def okay(data: custom.ImmutableTypeA = foo()):
 
 def error_due_to_missing_import(data: List[str] = Depends(None)):
     ...
+
+
+class Class:
+    pass
+
+
+def okay(obj=Class()):
+    ...
+
+
+def error(obj=OtherClass()):
+    ...

--- a/crates/ruff_linter/src/checkers/ast/analyze/statement.rs
+++ b/crates/ruff_linter/src/checkers/ast/analyze/statement.rs
@@ -609,7 +609,8 @@ pub(crate) fn statement(stmt: &Stmt, checker: &mut Checker) {
                     pylint::rules::manual_from_import(checker, stmt, alias, names);
                 }
                 if checker.enabled(Rule::ImportSelf) {
-                    if let Some(diagnostic) = pylint::rules::import_self(alias, checker.module_path)
+                    if let Some(diagnostic) =
+                        pylint::rules::import_self(alias, checker.module.qualified_name())
                     {
                         checker.diagnostics.push(diagnostic);
                     }
@@ -773,9 +774,11 @@ pub(crate) fn statement(stmt: &Stmt, checker: &mut Checker) {
                 flake8_bandit::rules::suspicious_imports(checker, stmt);
             }
             if checker.enabled(Rule::BannedApi) {
-                if let Some(module) =
-                    helpers::resolve_imported_module_path(level, module, checker.module_path)
-                {
+                if let Some(module) = helpers::resolve_imported_module_path(
+                    level,
+                    module,
+                    checker.module.qualified_name(),
+                ) {
                     flake8_tidy_imports::rules::banned_api(
                         checker,
                         &flake8_tidy_imports::matchers::NameMatchPolicy::MatchNameOrParent(
@@ -802,9 +805,11 @@ pub(crate) fn statement(stmt: &Stmt, checker: &mut Checker) {
                 }
             }
             if checker.enabled(Rule::BannedModuleLevelImports) {
-                if let Some(module) =
-                    helpers::resolve_imported_module_path(level, module, checker.module_path)
-                {
+                if let Some(module) = helpers::resolve_imported_module_path(
+                    level,
+                    module,
+                    checker.module.qualified_name(),
+                ) {
                     flake8_tidy_imports::rules::banned_module_level_imports(
                         checker,
                         &flake8_tidy_imports::matchers::NameMatchPolicy::MatchNameOrParent(
@@ -891,7 +896,7 @@ pub(crate) fn statement(stmt: &Stmt, checker: &mut Checker) {
                         stmt,
                         level,
                         module,
-                        checker.module_path,
+                        checker.module.qualified_name(),
                         checker.settings.flake8_tidy_imports.ban_relative_imports,
                     ) {
                         checker.diagnostics.push(diagnostic);
@@ -990,9 +995,12 @@ pub(crate) fn statement(stmt: &Stmt, checker: &mut Checker) {
                 }
             }
             if checker.enabled(Rule::ImportSelf) {
-                if let Some(diagnostic) =
-                    pylint::rules::import_from_self(level, module, names, checker.module_path)
-                {
+                if let Some(diagnostic) = pylint::rules::import_from_self(
+                    level,
+                    module,
+                    names,
+                    checker.module.qualified_name(),
+                ) {
                     checker.diagnostics.push(diagnostic);
                 }
             }

--- a/crates/ruff_linter/src/checkers/ast/mod.rs
+++ b/crates/ruff_linter/src/checkers/ast/mod.rs
@@ -2282,6 +2282,11 @@ pub(crate) fn check_ast(
         } else {
             ModuleKind::Module
         },
+        name: if let Some(module_path) = &module_path {
+            module_path.last().map(String::as_str)
+        } else {
+            path.file_stem().and_then(std::ffi::OsStr::to_str)
+        },
         source: if let Some(module_path) = module_path.as_ref() {
             ModuleSource::Path(module_path)
         } else {

--- a/crates/ruff_linter/src/rules/flake8_bugbear/mod.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/mod.rs
@@ -114,6 +114,7 @@ mod tests {
                         "fastapi.Depends".to_string(),
                         "fastapi.Query".to_string(),
                         "custom.ImmutableTypeA".to_string(),
+                        "B008_extended.Class".to_string(),
                     ],
                 },
                 ..LinterSettings::for_rule(Rule::FunctionCallInDefaultArgument)

--- a/crates/ruff_linter/src/rules/flake8_bugbear/snapshots/ruff_linter__rules__flake8_bugbear__tests__extend_immutable_calls_arg_default.snap
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/snapshots/ruff_linter__rules__flake8_bugbear__tests__extend_immutable_calls_arg_default.snap
@@ -8,4 +8,9 @@ B008_extended.py:24:51: B008 Do not perform function call `Depends` in argument 
 25 |     ...
    |
 
-
+B008_extended.py:36:15: B008 Do not perform function call `OtherClass` in argument defaults; instead, perform the call within the function, or read the default from a module-level singleton variable
+   |
+36 | def error(obj=OtherClass()):
+   |               ^^^^^^^^^^^^ B008
+37 |     ...
+   |

--- a/crates/ruff_python_semantic/src/definition.rs
+++ b/crates/ruff_python_semantic/src/definition.rs
@@ -51,6 +51,7 @@ pub struct Module<'a> {
     pub kind: ModuleKind,
     pub source: ModuleSource<'a>,
     pub python_ast: &'a [Stmt],
+    pub name: Option<&'a str>,
 }
 
 impl<'a> Module<'a> {
@@ -64,11 +65,8 @@ impl<'a> Module<'a> {
     }
 
     /// Return the name of the module.
-    pub fn name(&self) -> Option<&'a str> {
-        match self.source {
-            ModuleSource::Path(path) => path.last().map(Deref::deref),
-            ModuleSource::File(file) => file.file_stem().and_then(std::ffi::OsStr::to_str),
-        }
+    pub const fn name(&self) -> Option<&'a str> {
+        self.name
     }
 }
 

--- a/crates/ruff_python_semantic/src/model.rs
+++ b/crates/ruff_python_semantic/src/model.rs
@@ -836,9 +836,8 @@ impl<'a> SemanticModel<'a> {
                     )
                 } else {
                     // Otherwise, if we're in (e.g.) a script, use the module name.
-                    // let name = self.module.name()?;
                     Some(
-                        std::iter::once("foo")
+                        std::iter::once(self.module.name()?)
                             .chain(
                                 UnqualifiedName::from_expr(value)?
                                     .segments()

--- a/crates/ruff_python_semantic/src/model.rs
+++ b/crates/ruff_python_semantic/src/model.rs
@@ -28,7 +28,7 @@ use crate::Imported;
 /// A semantic model for a Python module, to enable querying the module's semantic information.
 pub struct SemanticModel<'a> {
     typing_modules: &'a [String],
-    module_path: Option<&'a [String]>,
+    module: Module<'a>,
 
     /// Stack of all AST nodes in the program.
     nodes: Nodes<'a>,
@@ -134,7 +134,7 @@ impl<'a> SemanticModel<'a> {
     pub fn new(typing_modules: &'a [String], path: &Path, module: Module<'a>) -> Self {
         Self {
             typing_modules,
-            module_path: module.path(),
+            module,
             nodes: Nodes::default(),
             node_id: None,
             branches: Branches::default(),
@@ -791,7 +791,11 @@ impl<'a> SemanticModel<'a> {
                     .first()
                     .map_or(false, |segment| *segment == ".")
                 {
-                    from_relative_import(self.module_path?, qualified_name.segments(), tail)?
+                    from_relative_import(
+                        self.module.qualified_name()?,
+                        qualified_name.segments(),
+                        tail,
+                    )?
                 } else {
                     qualified_name
                         .segments()
@@ -817,14 +821,33 @@ impl<'a> SemanticModel<'a> {
                 }
             }
             BindingKind::ClassDefinition(_) | BindingKind::FunctionDefinition(_) => {
-                let value_name = UnqualifiedName::from_expr(value)?;
-                let resolved: QualifiedName = self
-                    .module_path?
-                    .iter()
-                    .map(String::as_str)
-                    .chain(value_name.segments().iter().copied())
-                    .collect();
-                Some(resolved)
+                // If we have a fully-qualified path for the module, use it.
+                if let Some(path) = self.module.qualified_name() {
+                    Some(
+                        path.iter()
+                            .map(String::as_str)
+                            .chain(
+                                UnqualifiedName::from_expr(value)?
+                                    .segments()
+                                    .iter()
+                                    .copied(),
+                            )
+                            .collect(),
+                    )
+                } else {
+                    // Otherwise, if we're in (e.g.) a script, use the module name.
+                    let name = self.module.name()?;
+                    Some(
+                        std::iter::once(name)
+                            .chain(
+                                UnqualifiedName::from_expr(value)?
+                                    .segments()
+                                    .iter()
+                                    .copied(),
+                            )
+                            .collect(),
+                    )
+                }
             }
             _ => None,
         }

--- a/crates/ruff_python_semantic/src/model.rs
+++ b/crates/ruff_python_semantic/src/model.rs
@@ -836,9 +836,9 @@ impl<'a> SemanticModel<'a> {
                     )
                 } else {
                     // Otherwise, if we're in (e.g.) a script, use the module name.
-                    let name = self.module.name()?;
+                    // let name = self.module.name()?;
                     Some(
-                        std::iter::once(name)
+                        std::iter::once("foo")
                             .chain(
                                 UnqualifiedName::from_expr(value)?
                                     .segments()


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

If the user is analyzing a script (i.e., we have no module path), it seems reasonable to use the script name when trying to identify paths to objects defined _within_ the script.

Closes https://github.com/astral-sh/ruff/issues/10960.

## Test Plan

Ran:

```shell
check --isolated --select=B008 \
    --config 'lint.flake8-bugbear.extend-immutable-calls=["test.A"]' \
    test.py
```

On:

```python
class A: pass

def f(a=A()):
    pass
```