### PR TITLE
Avoid panic in invalid pattern recovery

### DIFF
--- a/crates/ruff_python_parser/resources/invalid/statements/match/invalid_lhs_or_rhs_pattern.py
+++ b/crates/ruff_python_parser/resources/invalid/statements/match/invalid_lhs_or_rhs_pattern.py
@@ -15,6 +15,8 @@ match invalid_lhs_pattern:
         pass
     case -1j + 2j:
         pass
+    case Foo(a as b) + 1j:
+        pass
 
 match invalid_rhs_pattern:
     case 1 + Foo():
@@ -30,6 +32,8 @@ match invalid_rhs_pattern:
     case 6 + {True: 1}:
         pass
     case 1 + 2:
+        pass
+    case 1 + Foo(a as b):
         pass
 
 match invalid_lhs_rhs_pattern:

--- a/crates/ruff_python_parser/resources/invalid/statements/match/invalid_mapping_pattern.py
+++ b/crates/ruff_python_parser/resources/invalid/statements/match/invalid_mapping_pattern.py
@@ -18,3 +18,6 @@ match subject:
         pass
     case {**rest1, None: 1, **rest2}:
         pass
+
+match subject:
+    case {Foo(a as b): 1}: ...

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@statements__match__as_pattern_0.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@statements__match__as_pattern_0.py.snap
@@ -11,7 +11,7 @@ Module(
         body: [
             Match(
                 StmtMatch {
-                    range: 0..147,
+                    range: 0..197,
                     subject: Name(
                         ExprName {
                             range: 6..13,
@@ -21,79 +21,59 @@ Module(
                     ),
                     cases: [
                         MatchCase {
-                            range: 127..147,
-                            pattern: MatchAs(
-                                PatternMatchAs {
-                                    range: 133..139,
-                                    pattern: Some(
-                                        MatchAs(
-                                            PatternMatchAs {
-                                                range: 133..134,
-                                                pattern: None,
-                                                name: Some(
-                                                    Identifier {
-                                                        id: "x",
-                                                        range: 133..134,
-                                                    },
-                                                ),
-                                            },
-                                        ),
-                                    ),
-                                    name: Some(
-                                        Identifier {
-                                            id: "y",
-                                            range: 138..139,
+                            range: 127..197,
+                            pattern: MatchClass(
+                                PatternMatchClass {
+                                    range: 132..146,
+                                    cls: Name(
+                                        ExprName {
+                                            range: 133..139,
+                                            id: "",
+                                            ctx: Invalid,
                                         },
                                     ),
+                                    arguments: PatternArguments {
+                                        range: 140..146,
+                                        patterns: [
+                                            MatchAs(
+                                                PatternMatchAs {
+                                                    range: 141..142,
+                                                    pattern: None,
+                                                    name: Some(
+                                                        Identifier {
+                                                            id: "a",
+                                                            range: 141..142,
+                                                        },
+                                                    ),
+                                                },
+                                            ),
+                                            MatchAs(
+                                                PatternMatchAs {
+                                                    range: 144..145,
+                                                    pattern: None,
+                                                    name: Some(
+                                                        Identifier {
+                                                            id: "b",
+                                                            range: 144..145,
+                                                        },
+                                                    ),
+                                                },
+                                            ),
+                                        ],
+                                        keywords: [],
+                                    },
                                 },
                             ),
                             guard: None,
                             body: [
-                                AnnAssign(
-                                    StmtAnnAssign {
-                                        range: 140..147,
-                                        target: Tuple(
-                                            ExprTuple {
-                                                range: 140..146,
-                                                elts: [
-                                                    Name(
-                                                        ExprName {
-                                                            range: 141..142,
-                                                            id: "a",
-                                                            ctx: Store,
-                                                        },
-                                                    ),
-                                                    Name(
-                                                        ExprName {
-                                                            range: 144..145,
-                                                            id: "b",
-                                                            ctx: Store,
-                                                        },
-                                                    ),
-                                                ],
-                                                ctx: Store,
-                                                parenthesized: true,
-                                            },
-                                        ),
-                                        annotation: Name(
-                                            ExprName {
-                                                range: 147..147,
-                                                id: "",
-                                                ctx: Invalid,
-                                            },
-                                        ),
-                                        value: None,
-                                        simple: false,
+                                Pass(
+                                    StmtPass {
+                                        range: 193..197,
                                     },
                                 ),
                             ],
                         },
                     ],
-                },
-            ),
-            Pass(
-                StmtPass {
-                    range: 193..197,
                 },
             ),
         ],
@@ -106,32 +86,7 @@ Module(
 3 |     #            class pattern
 4 |     #            v
 5 |     case (x as y)(a, b):
-  |                  ^ Syntax Error: Expected ':', found '('
+  |           ^^^^^^ Syntax Error: Invalid value for a class pattern
 6 |     #     ^^^^^^
 7 |     #    as-pattern
-  |
-
-
-  |
-3 |     #            class pattern
-4 |     #            v
-5 |     case (x as y)(a, b):
-  |                         ^ Syntax Error: Expected an expression
-6 |     #     ^^^^^^
-7 |     #    as-pattern
-8 |         pass
-  |
-
-
-  |
-6 |     #     ^^^^^^
-7 |     #    as-pattern
-8 |         pass
-  | ^^^^^^^^ Syntax Error: Expected dedent, found indent
-  |
-
-
-  |
-7 |     #    as-pattern
-8 |         pass
   |

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@statements__match__as_pattern_1.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@statements__match__as_pattern_1.py.snap
@@ -11,7 +11,7 @@ Module(
         body: [
             Match(
                 StmtMatch {
-                    range: 0..159,
+                    range: 0..209,
                     subject: Name(
                         ExprName {
                             range: 6..13,
@@ -21,71 +21,44 @@ Module(
                     ),
                     cases: [
                         MatchCase {
-                            range: 140..159,
-                            pattern: MatchAs(
-                                PatternMatchAs {
-                                    range: 146..152,
-                                    pattern: Some(
-                                        MatchAs(
-                                            PatternMatchAs {
-                                                range: 146..147,
-                                                pattern: None,
-                                                name: Some(
-                                                    Identifier {
-                                                        id: "x",
-                                                        range: 146..147,
+                            range: 140..209,
+                            pattern: MatchValue(
+                                PatternMatchValue {
+                                    range: 145..158,
+                                    value: BinOp(
+                                        ExprBinOp {
+                                            range: 145..158,
+                                            left: Name(
+                                                ExprName {
+                                                    range: 146..152,
+                                                    id: "",
+                                                    ctx: Invalid,
+                                                },
+                                            ),
+                                            op: Add,
+                                            right: NumberLiteral(
+                                                ExprNumberLiteral {
+                                                    range: 156..158,
+                                                    value: Complex {
+                                                        real: 0.0,
+                                                        imag: 1.0,
                                                     },
-                                                ),
-                                            },
-                                        ),
-                                    ),
-                                    name: Some(
-                                        Identifier {
-                                            id: "y",
-                                            range: 151..152,
+                                                },
+                                            ),
                                         },
                                     ),
                                 },
                             ),
                             guard: None,
                             body: [
-                                AnnAssign(
-                                    StmtAnnAssign {
-                                        range: 154..159,
-                                        target: UnaryOp(
-                                            ExprUnaryOp {
-                                                range: 154..158,
-                                                op: UAdd,
-                                                operand: NumberLiteral(
-                                                    ExprNumberLiteral {
-                                                        range: 156..158,
-                                                        value: Complex {
-                                                            real: 0.0,
-                                                            imag: 1.0,
-                                                        },
-                                                    },
-                                                ),
-                                            },
-                                        ),
-                                        annotation: Name(
-                                            ExprName {
-                                                range: 159..159,
-                                                id: "",
-                                                ctx: Invalid,
-                                            },
-                                        ),
-                                        value: None,
-                                        simple: false,
+                                Pass(
+                                    StmtPass {
+                                        range: 205..209,
                                     },
                                 ),
                             ],
                         },
                     ],
-                },
-            ),
-            Pass(
-                StmtPass {
-                    range: 205..209,
                 },
             ),
         ],
@@ -98,32 +71,7 @@ Module(
 3 |     #             complex literal pattern
 4 |     #             v
 5 |     case (x as y) + 1j:
-  |                   ^ Syntax Error: Expected ':', found '+'
+  |           ^^^^^^ Syntax Error: Expected a real number in complex literal pattern
 6 |     #     ^^^^^^
 7 |     #    as-pattern
-  |
-
-
-  |
-3 |     #             complex literal pattern
-4 |     #             v
-5 |     case (x as y) + 1j:
-  |                        ^ Syntax Error: Expected an expression
-6 |     #     ^^^^^^
-7 |     #    as-pattern
-8 |         pass
-  |
-
-
-  |
-6 |     #     ^^^^^^
-7 |     #    as-pattern
-8 |         pass
-  | ^^^^^^^^ Syntax Error: Expected dedent, found indent
-  |
-
-
-  |
-7 |     #    as-pattern
-8 |         pass
   |

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@statements__match__invalid_lhs_or_rhs_pattern.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@statements__match__invalid_lhs_or_rhs_pattern.py.snap
@@ -7,11 +7,11 @@ input_file: crates/ruff_python_parser/resources/invalid/statements/match/invalid
 ```
 Module(
     ModModule {
-        range: 0..616,
+        range: 0..695,
         body: [
             Match(
                 StmtMatch {
-                    range: 0..292,
+                    range: 0..332,
                     subject: Name(
                         ExprName {
                             range: 6..25,
@@ -394,31 +394,87 @@ Module(
                                 ),
                             ],
                         },
+                        MatchCase {
+                            range: 297..332,
+                            pattern: MatchValue(
+                                PatternMatchValue {
+                                    range: 302..318,
+                                    value: BinOp(
+                                        ExprBinOp {
+                                            range: 302..318,
+                                            left: Call(
+                                                ExprCall {
+                                                    range: 302..313,
+                                                    func: Name(
+                                                        ExprName {
+                                                            range: 302..305,
+                                                            id: "Foo",
+                                                            ctx: Load,
+                                                        },
+                                                    ),
+                                                    arguments: Arguments {
+                                                        range: 305..313,
+                                                        args: [
+                                                            Name(
+                                                                ExprName {
+                                                                    range: 306..312,
+                                                                    id: "",
+                                                                    ctx: Invalid,
+                                                                },
+                                                            ),
+                                                        ],
+                                                        keywords: [],
+                                                    },
+                                                },
+                                            ),
+                                            op: Add,
+                                            right: NumberLiteral(
+                                                ExprNumberLiteral {
+                                                    range: 316..318,
+                                                    value: Complex {
+                                                        real: 0.0,
+                                                        imag: 1.0,
+                                                    },
+                                                },
+                                            ),
+                                        },
+                                    ),
+                                },
+                            ),
+                            guard: None,
+                            body: [
+                                Pass(
+                                    StmtPass {
+                                        range: 328..332,
+                                    },
+                                ),
+                            ],
+                        },
                     ],
                 },
             ),
             Match(
                 StmtMatch {
-                    range: 294..546,
+                    range: 334..625,
                     subject: Name(
                         ExprName {
-                            range: 300..319,
+                            range: 340..359,
                             id: "invalid_rhs_pattern",
                             ctx: Load,
                         },
                     ),
                     cases: [
                         MatchCase {
-                            range: 325..353,
+                            range: 365..393,
                             pattern: MatchValue(
                                 PatternMatchValue {
-                                    range: 330..339,
+                                    range: 370..379,
                                     value: BinOp(
                                         ExprBinOp {
-                                            range: 330..339,
+                                            range: 370..379,
                                             left: NumberLiteral(
                                                 ExprNumberLiteral {
-                                                    range: 330..331,
+                                                    range: 370..371,
                                                     value: Int(
                                                         1,
                                                     ),
@@ -427,16 +483,16 @@ Module(
                                             op: Add,
                                             right: Call(
                                                 ExprCall {
-                                                    range: 334..339,
+                                                    range: 374..379,
                                                     func: Name(
                                                         ExprName {
-                                                            range: 334..337,
+                                                            range: 374..377,
                                                             id: "Foo",
                                                             ctx: Load,
                                                         },
                                                     ),
                                                     arguments: Arguments {
-                                                        range: 337..339,
+                                                        range: 377..379,
                                                         args: [],
                                                         keywords: [],
                                                     },
@@ -450,22 +506,22 @@ Module(
                             body: [
                                 Pass(
                                     StmtPass {
-                                        range: 349..353,
+                                        range: 389..393,
                                     },
                                 ),
                             ],
                         },
                         MatchCase {
-                            range: 358..382,
+                            range: 398..422,
                             pattern: MatchValue(
                                 PatternMatchValue {
-                                    range: 363..368,
+                                    range: 403..408,
                                     value: BinOp(
                                         ExprBinOp {
-                                            range: 363..368,
+                                            range: 403..408,
                                             left: NumberLiteral(
                                                 ExprNumberLiteral {
-                                                    range: 363..364,
+                                                    range: 403..404,
                                                     value: Int(
                                                         2,
                                                     ),
@@ -474,7 +530,7 @@ Module(
                                             op: Add,
                                             right: Name(
                                                 ExprName {
-                                                    range: 367..368,
+                                                    range: 407..408,
                                                     id: "x",
                                                     ctx: Store,
                                                 },
@@ -487,22 +543,22 @@ Module(
                             body: [
                                 Pass(
                                     StmtPass {
-                                        range: 378..382,
+                                        range: 418..422,
                                     },
                                 ),
                             ],
                         },
                         MatchCase {
-                            range: 387..411,
+                            range: 427..451,
                             pattern: MatchValue(
                                 PatternMatchValue {
-                                    range: 392..397,
+                                    range: 432..437,
                                     value: BinOp(
                                         ExprBinOp {
-                                            range: 392..397,
+                                            range: 432..437,
                                             left: NumberLiteral(
                                                 ExprNumberLiteral {
-                                                    range: 392..393,
+                                                    range: 432..433,
                                                     value: Int(
                                                         3,
                                                     ),
@@ -511,7 +567,7 @@ Module(
                                             op: Add,
                                             right: Name(
                                                 ExprName {
-                                                    range: 396..397,
+                                                    range: 436..437,
                                                     id: "_",
                                                     ctx: Store,
                                                 },
@@ -524,22 +580,22 @@ Module(
                             body: [
                                 Pass(
                                     StmtPass {
-                                        range: 407..411,
+                                        range: 447..451,
                                     },
                                 ),
                             ],
                         },
                         MatchCase {
-                            range: 416..446,
+                            range: 456..486,
                             pattern: MatchValue(
                                 PatternMatchValue {
-                                    range: 421..432,
+                                    range: 461..472,
                                     value: BinOp(
                                         ExprBinOp {
-                                            range: 421..432,
+                                            range: 461..472,
                                             left: NumberLiteral(
                                                 ExprNumberLiteral {
-                                                    range: 421..422,
+                                                    range: 461..462,
                                                     value: Int(
                                                         4,
                                                     ),
@@ -548,10 +604,10 @@ Module(
                                             op: Add,
                                             right: BinOp(
                                                 ExprBinOp {
-                                                    range: 426..431,
+                                                    range: 466..471,
                                                     left: NumberLiteral(
                                                         ExprNumberLiteral {
-                                                            range: 426..427,
+                                                            range: 466..467,
                                                             value: Int(
                                                                 1,
                                                             ),
@@ -560,7 +616,7 @@ Module(
                                                     op: BitOr,
                                                     right: NumberLiteral(
                                                         ExprNumberLiteral {
-                                                            range: 430..431,
+                                                            range: 470..471,
                                                             value: Int(
                                                                 2,
                                                             ),
@@ -576,22 +632,22 @@ Module(
                             body: [
                                 Pass(
                                     StmtPass {
-                                        range: 442..446,
+                                        range: 482..486,
                                     },
                                 ),
                             ],
                         },
                         MatchCase {
-                            range: 451..480,
+                            range: 491..520,
                             pattern: MatchValue(
                                 PatternMatchValue {
-                                    range: 456..466,
+                                    range: 496..506,
                                     value: BinOp(
                                         ExprBinOp {
-                                            range: 456..466,
+                                            range: 496..506,
                                             left: NumberLiteral(
                                                 ExprNumberLiteral {
-                                                    range: 456..457,
+                                                    range: 496..497,
                                                     value: Int(
                                                         5,
                                                     ),
@@ -600,11 +656,11 @@ Module(
                                             op: Add,
                                             right: List(
                                                 ExprList {
-                                                    range: 460..466,
+                                                    range: 500..506,
                                                     elts: [
                                                         NumberLiteral(
                                                             ExprNumberLiteral {
-                                                                range: 461..462,
+                                                                range: 501..502,
                                                                 value: Int(
                                                                     1,
                                                                 ),
@@ -612,7 +668,7 @@ Module(
                                                         ),
                                                         NumberLiteral(
                                                             ExprNumberLiteral {
-                                                                range: 464..465,
+                                                                range: 504..505,
                                                                 value: Int(
                                                                     2,
                                                                 ),
@@ -630,22 +686,22 @@ Module(
                             body: [
                                 Pass(
                                     StmtPass {
-                                        range: 476..480,
+                                        range: 516..520,
                                     },
                                 ),
                             ],
                         },
                         MatchCase {
-                            range: 485..517,
+                            range: 525..557,
                             pattern: MatchValue(
                                 PatternMatchValue {
-                                    range: 490..503,
+                                    range: 530..543,
                                     value: BinOp(
                                         ExprBinOp {
-                                            range: 490..503,
+                                            range: 530..543,
                                             left: NumberLiteral(
                                                 ExprNumberLiteral {
-                                                    range: 490..491,
+                                                    range: 530..531,
                                                     value: Int(
                                                         6,
                                                     ),
@@ -654,12 +710,12 @@ Module(
                                             op: Add,
                                             right: Dict(
                                                 ExprDict {
-                                                    range: 494..503,
+                                                    range: 534..543,
                                                     keys: [
                                                         Some(
                                                             BooleanLiteral(
                                                                 ExprBooleanLiteral {
-                                                                    range: 495..499,
+                                                                    range: 535..539,
                                                                     value: true,
                                                                 },
                                                             ),
@@ -668,7 +724,7 @@ Module(
                                                     values: [
                                                         NumberLiteral(
                                                             ExprNumberLiteral {
-                                                                range: 501..502,
+                                                                range: 541..542,
                                                                 value: Int(
                                                                     1,
                                                                 ),
@@ -685,22 +741,22 @@ Module(
                             body: [
                                 Pass(
                                     StmtPass {
-                                        range: 513..517,
+                                        range: 553..557,
                                     },
                                 ),
                             ],
                         },
                         MatchCase {
-                            range: 522..546,
+                            range: 562..586,
                             pattern: MatchValue(
                                 PatternMatchValue {
-                                    range: 527..532,
+                                    range: 567..572,
                                     value: BinOp(
                                         ExprBinOp {
-                                            range: 527..532,
+                                            range: 567..572,
                                             left: NumberLiteral(
                                                 ExprNumberLiteral {
-                                                    range: 527..528,
+                                                    range: 567..568,
                                                     value: Int(
                                                         1,
                                                     ),
@@ -709,7 +765,7 @@ Module(
                                             op: Add,
                                             right: NumberLiteral(
                                                 ExprNumberLiteral {
-                                                    range: 531..532,
+                                                    range: 571..572,
                                                     value: Int(
                                                         2,
                                                     ),
@@ -723,7 +779,62 @@ Module(
                             body: [
                                 Pass(
                                     StmtPass {
-                                        range: 542..546,
+                                        range: 582..586,
+                                    },
+                                ),
+                            ],
+                        },
+                        MatchCase {
+                            range: 591..625,
+                            pattern: MatchValue(
+                                PatternMatchValue {
+                                    range: 596..611,
+                                    value: BinOp(
+                                        ExprBinOp {
+                                            range: 596..611,
+                                            left: NumberLiteral(
+                                                ExprNumberLiteral {
+                                                    range: 596..597,
+                                                    value: Int(
+                                                        1,
+                                                    ),
+                                                },
+                                            ),
+                                            op: Add,
+                                            right: Call(
+                                                ExprCall {
+                                                    range: 600..611,
+                                                    func: Name(
+                                                        ExprName {
+                                                            range: 600..603,
+                                                            id: "Foo",
+                                                            ctx: Load,
+                                                        },
+                                                    ),
+                                                    arguments: Arguments {
+                                                        range: 603..611,
+                                                        args: [
+                                                            Name(
+                                                                ExprName {
+                                                                    range: 604..610,
+                                                                    id: "",
+                                                                    ctx: Invalid,
+                                                                },
+                                                            ),
+                                                        ],
+                                                        keywords: [],
+                                                    },
+                                                },
+                                            ),
+                                        },
+                                    ),
+                                },
+                            ),
+                            guard: None,
+                            body: [
+                                Pass(
+                                    StmtPass {
+                                        range: 621..625,
                                     },
                                 ),
                             ],
@@ -733,35 +844,35 @@ Module(
             ),
             Match(
                 StmtMatch {
-                    range: 548..615,
+                    range: 627..694,
                     subject: Name(
                         ExprName {
-                            range: 554..577,
+                            range: 633..656,
                             id: "invalid_lhs_rhs_pattern",
                             ctx: Load,
                         },
                     ),
                     cases: [
                         MatchCase {
-                            range: 583..615,
+                            range: 662..694,
                             pattern: MatchValue(
                                 PatternMatchValue {
-                                    range: 588..601,
+                                    range: 667..680,
                                     value: BinOp(
                                         ExprBinOp {
-                                            range: 588..601,
+                                            range: 667..680,
                                             left: Call(
                                                 ExprCall {
-                                                    range: 588..593,
+                                                    range: 667..672,
                                                     func: Name(
                                                         ExprName {
-                                                            range: 588..591,
+                                                            range: 667..670,
                                                             id: "Foo",
                                                             ctx: Load,
                                                         },
                                                     ),
                                                     arguments: Arguments {
-                                                        range: 591..593,
+                                                        range: 670..672,
                                                         args: [],
                                                         keywords: [],
                                                     },
@@ -770,16 +881,16 @@ Module(
                                             op: Add,
                                             right: Call(
                                                 ExprCall {
-                                                    range: 596..601,
+                                                    range: 675..680,
                                                     func: Name(
                                                         ExprName {
-                                                            range: 596..599,
+                                                            range: 675..678,
                                                             id: "Bar",
                                                             ctx: Load,
                                                         },
                                                     ),
                                                     arguments: Arguments {
-                                                        range: 599..601,
+                                                        range: 678..680,
                                                         args: [],
                                                         keywords: [],
                                                     },
@@ -793,7 +904,7 @@ Module(
                             body: [
                                 Pass(
                                     StmtPass {
-                                        range: 611..615,
+                                        range: 690..694,
                                     },
                                 ),
                             ],
@@ -882,88 +993,108 @@ Module(
 16 |     case -1j + 2j:
    |          ^^^ Syntax Error: Expected a real number in complex literal pattern
 17 |         pass
+18 |     case Foo(a as b) + 1j:
    |
 
 
    |
-19 | match invalid_rhs_pattern:
-20 |     case 1 + Foo():
+16 |     case -1j + 2j:
+17 |         pass
+18 |     case Foo(a as b) + 1j:
+   |          ^^^^^^^^^^^ Syntax Error: Expected a real number in complex literal pattern
+19 |         pass
+   |
+
+
+   |
+21 | match invalid_rhs_pattern:
+22 |     case 1 + Foo():
    |              ^^^^^ Syntax Error: Expected an imaginary number in complex literal pattern
-21 |         pass
-22 |     case 2 + x:
-   |
-
-
-   |
-20 |     case 1 + Foo():
-21 |         pass
-22 |     case 2 + x:
-   |              ^ Syntax Error: Expected an imaginary number in complex literal pattern
 23 |         pass
-24 |     case 3 + _:
+24 |     case 2 + x:
    |
 
 
    |
-22 |     case 2 + x:
+22 |     case 1 + Foo():
 23 |         pass
-24 |     case 3 + _:
+24 |     case 2 + x:
    |              ^ Syntax Error: Expected an imaginary number in complex literal pattern
 25 |         pass
-26 |     case 4 + (1 | 2):
+26 |     case 3 + _:
    |
 
 
    |
-24 |     case 3 + _:
+24 |     case 2 + x:
 25 |         pass
-26 |     case 4 + (1 | 2):
+26 |     case 3 + _:
+   |              ^ Syntax Error: Expected an imaginary number in complex literal pattern
+27 |         pass
+28 |     case 4 + (1 | 2):
+   |
+
+
+   |
+26 |     case 3 + _:
+27 |         pass
+28 |     case 4 + (1 | 2):
    |               ^^^^^ Syntax Error: Expected an imaginary number in complex literal pattern
-27 |         pass
-28 |     case 5 + [1, 2]:
+29 |         pass
+30 |     case 5 + [1, 2]:
    |
 
 
    |
-26 |     case 4 + (1 | 2):
-27 |         pass
-28 |     case 5 + [1, 2]:
+28 |     case 4 + (1 | 2):
+29 |         pass
+30 |     case 5 + [1, 2]:
    |              ^^^^^^ Syntax Error: Expected an imaginary number in complex literal pattern
-29 |         pass
-30 |     case 6 + {True: 1}:
+31 |         pass
+32 |     case 6 + {True: 1}:
    |
 
 
    |
-28 |     case 5 + [1, 2]:
-29 |         pass
-30 |     case 6 + {True: 1}:
+30 |     case 5 + [1, 2]:
+31 |         pass
+32 |     case 6 + {True: 1}:
    |              ^^^^^^^^^ Syntax Error: Expected an imaginary number in complex literal pattern
-31 |         pass
-32 |     case 1 + 2:
-   |
-
-
-   |
-30 |     case 6 + {True: 1}:
-31 |         pass
-32 |     case 1 + 2:
-   |              ^ Syntax Error: Expected an imaginary number in complex literal pattern
 33 |         pass
+34 |     case 1 + 2:
    |
 
 
    |
-35 | match invalid_lhs_rhs_pattern:
-36 |     case Foo() + Bar():
+32 |     case 6 + {True: 1}:
+33 |         pass
+34 |     case 1 + 2:
+   |              ^ Syntax Error: Expected an imaginary number in complex literal pattern
+35 |         pass
+36 |     case 1 + Foo(a as b):
+   |
+
+
+   |
+34 |     case 1 + 2:
+35 |         pass
+36 |     case 1 + Foo(a as b):
+   |              ^^^^^^^^^^^ Syntax Error: Expected an imaginary number in complex literal pattern
+37 |         pass
+   |
+
+
+   |
+39 | match invalid_lhs_rhs_pattern:
+40 |     case Foo() + Bar():
    |          ^^^^^ Syntax Error: Expected a real number in complex literal pattern
-37 |         pass
+41 |         pass
    |
 
 
    |
-35 | match invalid_lhs_rhs_pattern:
-36 |     case Foo() + Bar():
+39 | match invalid_lhs_rhs_pattern:
+40 |     case Foo() + Bar():
    |                  ^^^^^ Syntax Error: Expected an imaginary number in complex literal pattern
-37 |         pass
+41 |         pass
    |

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@statements__match__invalid_mapping_pattern.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@statements__match__invalid_mapping_pattern.py.snap
@@ -7,7 +7,7 @@ input_file: crates/ruff_python_parser/resources/invalid/statements/match/invalid
 ```
 Module(
     ModModule {
-        range: 0..463,
+        range: 0..509,
         body: [
             Match(
                 StmtMatch {
@@ -373,6 +373,84 @@ Module(
                     ],
                 },
             ),
+            Match(
+                StmtMatch {
+                    range: 464..509,
+                    subject: Name(
+                        ExprName {
+                            range: 470..477,
+                            id: "subject",
+                            ctx: Load,
+                        },
+                    ),
+                    cases: [
+                        MatchCase {
+                            range: 483..509,
+                            pattern: MatchMapping(
+                                PatternMatchMapping {
+                                    range: 488..504,
+                                    keys: [
+                                        Call(
+                                            ExprCall {
+                                                range: 489..500,
+                                                func: Name(
+                                                    ExprName {
+                                                        range: 489..492,
+                                                        id: "Foo",
+                                                        ctx: Load,
+                                                    },
+                                                ),
+                                                arguments: Arguments {
+                                                    range: 492..500,
+                                                    args: [
+                                                        Name(
+                                                            ExprName {
+                                                                range: 493..499,
+                                                                id: "",
+                                                                ctx: Invalid,
+                                                            },
+                                                        ),
+                                                    ],
+                                                    keywords: [],
+                                                },
+                                            },
+                                        ),
+                                    ],
+                                    patterns: [
+                                        MatchValue(
+                                            PatternMatchValue {
+                                                range: 502..503,
+                                                value: NumberLiteral(
+                                                    ExprNumberLiteral {
+                                                        range: 502..503,
+                                                        value: Int(
+                                                            1,
+                                                        ),
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ],
+                                    rest: None,
+                                },
+                            ),
+                            guard: None,
+                            body: [
+                                Expr(
+                                    StmtExpr {
+                                        range: 506..509,
+                                        value: EllipsisLiteral(
+                                            ExprEllipsisLiteral {
+                                                range: 506..509,
+                                            },
+                                        ),
+                                    },
+                                ),
+                            ],
+                        },
+                    ],
+                },
+            ),
         ],
     },
 )
@@ -492,4 +570,11 @@ Module(
 19 |     case {**rest1, None: 1, **rest2}:
    |                             ^^^^^^^ Syntax Error: Only one double star pattern is allowed
 20 |         pass
+   |
+
+
+   |
+22 | match subject:
+23 |     case {Foo(a as b): 1}: ...
+   |           ^^^^^^^^^^^ Syntax Error: Invalid mapping pattern key
    |


### PR DESCRIPTION
## Summary

This PR avoids the panic when trying to recover from an invalid pattern.

The panic occurs because there's no way to represent `x as y` syntax as a Python expression. There were few cases which were not accounted for when working on this. 

The cases where it would panic are the ones where only a subset of pattern is valid in a position but all patterns are valid in a nested position of the mentioned top-level pattern. 

For example, consider a mapping pattern and the following points:
* Key position can only be a `MatchValue` and `MatchSingleton`
* `MatchClass` can contain a `MatchAs` as an argument
* `MatchAs` pattern with both pattern and name (`a as b`) cannot be converted to a valid expression

Considering this, if a mapping pattern has a class pattern with an `as` pattern as one of it's argument, the parser would panic.

```py
match subject:
	case {Foo(a as b): 1}: ...
#        ^^^^^^^^^^^^^^^^ mapping pattern
#         ^^^^^^^^^^^     mapping pattern key, class pattern
#             ^^^^^^      as pattern with both pattern and name
```

The same case is for complex literal patterns as well.

I'm not sure what the recovery should look like but for now it's better to avoid the panic and create an invalid expression node in it's place.

## Test Plan

Add new test cases and update the snapshots.