### PR TITLE
perf: `RuleTable::any_enabled`

### DIFF
--- a/crates/ruff_linter/src/registry/rule_set.rs
+++ b/crates/ruff_linter/src/registry/rule_set.rs
@@ -234,6 +234,7 @@ impl RuleSet {
     /// assert!(set.contains(Rule::AmbiguousFunctionName));
     /// assert!(!set.contains(Rule::BreakOutsideLoop));
     /// ```
+    #[inline]
     pub const fn contains(&self, rule: Rule) -> bool {
         let rule = rule as u16;
         let index = rule as usize / Self::SLICE_BITS as usize;
@@ -241,6 +242,20 @@ impl RuleSet {
         let mask = 1 << shift;
 
         self.0[index] & mask != 0
+    }
+
+    /// Returns `true` if any of the rules in `rules` are in this set.
+    #[inline]
+    pub const fn any(&self, rules: &[Rule]) -> bool {
+        let mut any = false;
+        let mut i = 0;
+
+        while i < rules.len() {
+            any |= self.contains(rules[i]);
+            i += 1;
+        }
+
+        any
     }
 
     /// Returns an iterator over the rules in this set.

--- a/crates/ruff_linter/src/settings/rule_table.rs
+++ b/crates/ruff_linter/src/settings/rule_table.rs
@@ -31,7 +31,7 @@ impl RuleTable {
     /// Returns whether any of the given rules should be checked.
     #[inline]
     pub const fn any_enabled(&self, rules: &[Rule]) -> bool {
-        self.enabled.intersects(&RuleSet::from_rules(rules))
+        self.enabled.any(rules)
     }
 
     /// Returns whether violations of the given rule should be fixed.


### PR DESCRIPTION
## Summary

This PR improves the performance of `RuleTable::any_enabled` which is called frequently in expression checking to determine if a specific set of rules is enabled. 

The old implementation used `enabled.intersects(RuleSet::from_iter(rules))` to test if the enabled set and the tested rules overlap. 
This worked fine when we had few rules but is now becoming a performance bottleneck when bumping `RuleSet` from 13 to 14 usizes because each call zero initializes a 14 * 8=112 bytes large array on the stack, sets the rule indexes and then computes if the sets overlap. 

The new implementation avoids constructing a `RuleSet` using `from_iter` based on the assumption that we mainly query `any_enabled` with a few rules. This avoids writing 112 bytes on each call.

This should make the `any_enabled` check independent of the size of the `RuleSet`. 

## Test Plan

`cargo test`
