### PR TITLE
Fix Typo for `extend-aliases` Option

### DIFF
--- a/crates/ruff_workspace/src/options.rs
+++ b/crates/ruff_workspace/src/options.rs
@@ -1307,7 +1307,7 @@ impl Flake8ImplicitStrConcatOptions {
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct Flake8ImportConventionsOptions {
     /// The conventional aliases for imports. These aliases can be extended by
-    /// the `extend_aliases` option.
+    /// the `extend-aliases` option.
     #[option(
         default = r#"{"altair": "alt", "matplotlib": "mpl", "matplotlib.pyplot": "plt", "numpy": "np", "pandas": "pd", "seaborn": "sns", "tensorflow": "tf", "tkinter":  "tk", "holoviews": "hv", "panel": "pn", "plotly.express": "px", "polars": "pl", "pyarrow": "pa"}"#,
         value_type = "dict[str, str]",

--- a/ruff.schema.json
+++ b/ruff.schema.json
@@ -1054,7 +1054,7 @@
       "type": "object",
       "properties": {
         "aliases": {
-          "description": "The conventional aliases for imports. These aliases can be extended by the `extend_aliases` option.",
+          "description": "The conventional aliases for imports. These aliases can be extended by the `extend-aliases` option.",
           "type": [
             "object",
             "null"


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Fix documentation typo where `extend-aliases` is referred to as `extend_aliases`, the later being invalid.

## Test Plan

None, typo fix.
