### PR TITLE
Recover from unexpected token at end of expr

### DIFF
--- a/crates/ruff_python_parser/src/error.rs
+++ b/crates/ruff_python_parser/src/error.rs
@@ -174,6 +174,8 @@ pub enum ParseErrorType {
     UnexpectedTokenAfterAsync(TokenKind),
     /// Ipython escape command was found
     UnexpectedIpythonEscapeCommand,
+    /// An unexpected token was found at the end of an expression parsing
+    UnexpectedExpressionToken,
 
     /// An f-string error containing the [`FStringErrorType`].
     FStringError(FStringErrorType),
@@ -299,6 +301,9 @@ impl std::fmt::Display for ParseErrorType {
             }
             ParseErrorType::FStringError(ref fstring_error) => {
                 write!(f, "f-string: {fstring_error}")
+            }
+            ParseErrorType::UnexpectedExpressionToken => {
+                write!(f, "Unexpected token at the end of an expression")
             }
             // RustPython specific.
             ParseErrorType::Eof => write!(f, "Got unexpected EOF"),

--- a/crates/ruff_python_parser/src/parser/snapshots/ruff_python_parser__parser__tests__expr_mode_invalid_syntax1.snap
+++ b/crates/ruff_python_parser/src/parser/snapshots/ruff_python_parser__parser__tests__expr_mode_invalid_syntax1.snap
@@ -1,0 +1,8 @@
+---
+source: crates/ruff_python_parser/src/parser/tests.rs
+expression: error
+---
+ParseError {
+    error: UnexpectedExpressionToken,
+    location: 6..12,
+}

--- a/crates/ruff_python_parser/src/parser/snapshots/ruff_python_parser__parser__tests__expr_mode_invalid_syntax2.snap
+++ b/crates/ruff_python_parser/src/parser/snapshots/ruff_python_parser__parser__tests__expr_mode_invalid_syntax2.snap
@@ -1,0 +1,8 @@
+---
+source: crates/ruff_python_parser/src/parser/tests.rs
+expression: error
+---
+ParseError {
+    error: UnexpectedExpressionToken,
+    location: 7..13,
+}

--- a/crates/ruff_python_parser/src/parser/snapshots/ruff_python_parser__parser__tests__expr_mode_invalid_syntax3.snap
+++ b/crates/ruff_python_parser/src/parser/snapshots/ruff_python_parser__parser__tests__expr_mode_invalid_syntax3.snap
@@ -1,0 +1,8 @@
+---
+source: crates/ruff_python_parser/src/parser/tests.rs
+expression: error
+---
+ParseError {
+    error: UnexpectedExpressionToken,
+    location: 7..13,
+}

--- a/crates/ruff_python_parser/src/parser/snapshots/ruff_python_parser__parser__tests__expr_mode_valid_syntax.snap
+++ b/crates/ruff_python_parser/src/parser/snapshots/ruff_python_parser__parser__tests__expr_mode_valid_syntax.snap
@@ -1,0 +1,11 @@
+---
+source: crates/ruff_python_parser/src/parser/tests.rs
+expression: expr
+---
+Name(
+    ExprName {
+        range: 0..5,
+        id: "first",
+        ctx: Load,
+    },
+)

--- a/crates/ruff_python_parser/src/parser/tests.rs
+++ b/crates/ruff_python_parser/src/parser/tests.rs
@@ -1,4 +1,4 @@
-use crate::{lex, parse, parse_suite, parse_tokens, Mode};
+use crate::{lex, parse, parse_expression, parse_suite, parse_tokens, Mode};
 
 // TODO(dhruvmanila): Remove `set_new_parser`
 
@@ -10,6 +10,56 @@ fn test_modes() {
 
     assert!(parse(source, Mode::Expression).is_ok());
     assert!(parse(source, Mode::Module).is_ok());
+}
+
+#[test]
+fn test_expr_mode_invalid_syntax1() {
+    crate::set_new_parser(true);
+
+    let source = "first second";
+    let error = parse_expression(source).unwrap_err();
+
+    insta::assert_debug_snapshot!(error);
+}
+
+#[test]
+fn test_expr_mode_invalid_syntax2() {
+    crate::set_new_parser(true);
+
+    let source = r"first
+
+second
+";
+    let error = parse_expression(source).unwrap_err();
+
+    insta::assert_debug_snapshot!(error);
+}
+
+#[test]
+fn test_expr_mode_invalid_syntax3() {
+    crate::set_new_parser(true);
+
+    let source = r"first
+
+second
+
+third
+";
+    let error = parse_expression(source).unwrap_err();
+
+    insta::assert_debug_snapshot!(error);
+}
+
+#[test]
+fn test_expr_mode_valid_syntax() {
+    crate::set_new_parser(true);
+
+    let source = "first
+
+";
+    let expr = parse_expression(source).unwrap();
+
+    insta::assert_debug_snapshot!(expr);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

This fixes a bug in the parser when `Mode::Expression` is used where the parser didn't recover from unexpected token after the expression.

The current solution isn't ideal as the parser will drop all the remaining tokens after the initial expression has been parsed. This is to avoid panicking especially in the context of forward annotation like:

```python
x: Literal["foo", "bar baz"]
```

Here, the parser is being given the `bar baz` as the source to be parsed using `Mode::Expression`. The parser will parse `bar` as a name expression and then stop because the expression ends there. But, it seems like there's more tokens remaining. This specific case could potentially be recovered by using a `ExprTuple` and raising a "missing comma" error but I've avoided that complexity for now.

## Test Plan

Add new test cases for `Mode::Expression` and verified the snapshots.
