### PR TITLE
Change more usages of `SemanticModel::is_builtin` to use `resolve_builtin_symbol` or `match_builtin_expr`

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_collection_call.rs
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_collection_call.rs
@@ -65,10 +65,10 @@ pub(crate) fn unnecessary_collection_call(
     if !call.arguments.args.is_empty() {
         return;
     }
-    let Some(func) = call.func.as_name_expr() else {
+    let Some(builtin) = checker.semantic().resolve_builtin_symbol(&call.func) else {
         return;
     };
-    let collection = match func.id.as_str() {
+    let collection = match builtin {
         "dict"
             if call.arguments.keywords.is_empty()
                 || (!settings.allow_dict_calls_with_keyword_arguments
@@ -87,13 +87,10 @@ pub(crate) fn unnecessary_collection_call(
         }
         _ => return,
     };
-    if !checker.semantic().is_builtin(func.id.as_str()) {
-        return;
-    }
 
     let mut diagnostic = Diagnostic::new(
         UnnecessaryCollectionCall {
-            obj_type: func.id.to_string(),
+            obj_type: builtin.to_string(),
         },
         call.range(),
     );

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_comprehension_in_call.rs
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_comprehension_in_call.rs
@@ -90,15 +90,6 @@ pub(crate) fn unnecessary_comprehension_in_call(
     if !keywords.is_empty() {
         return;
     }
-
-    let Expr::Name(ast::ExprName { id, .. }) = func else {
-        return;
-    };
-    if !(matches!(id.as_str(), "any" | "all")
-        || (checker.settings.preview.is_enabled() && matches!(id.as_str(), "sum" | "min" | "max")))
-    {
-        return;
-    }
     let [arg] = args else {
         return;
     };
@@ -110,7 +101,13 @@ pub(crate) fn unnecessary_comprehension_in_call(
     if contains_await(elt) {
         return;
     }
-    if !checker.semantic().is_builtin(id) {
+    let Some(builtin_function) = checker.semantic().resolve_builtin_symbol(func) else {
+        return;
+    };
+    if !(matches!(builtin_function, "any" | "all")
+        || (checker.settings.preview.is_enabled()
+            && matches!(builtin_function, "sum" | "min" | "max")))
+    {
         return;
     }
 

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_map.rs
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_map.rs
@@ -73,21 +73,17 @@ pub(crate) fn unnecessary_map(
     func: &Expr,
     args: &[Expr],
 ) {
-    let Some(func) = func.as_name_expr() else {
+    let Some(builtin_name) = checker.semantic().resolve_builtin_symbol(func) else {
         return;
     };
 
-    let object_type = match func.id.as_str() {
+    let object_type = match builtin_name {
         "map" => ObjectType::Generator,
         "list" => ObjectType::List,
         "set" => ObjectType::Set,
         "dict" => ObjectType::Dict,
         _ => return,
     };
-
-    if !checker.semantic().is_builtin(&func.id) {
-        return;
-    }
 
     match object_type {
         ObjectType::Generator => {

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_subscript_reversal.rs
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_subscript_reversal.rs
@@ -44,15 +44,6 @@ pub(crate) fn unnecessary_subscript_reversal(checker: &mut Checker, call: &ast::
     let Some(first_arg) = call.arguments.args.first() else {
         return;
     };
-    let Some(func) = call.func.as_name_expr() else {
-        return;
-    };
-    if !matches!(func.id.as_str(), "reversed" | "set" | "sorted") {
-        return;
-    }
-    if !checker.semantic().is_builtin(&func.id) {
-        return;
-    }
     let Expr::Subscript(ast::ExprSubscript { slice, .. }) = first_arg else {
         return;
     };
@@ -89,9 +80,15 @@ pub(crate) fn unnecessary_subscript_reversal(checker: &mut Checker, call: &ast::
     if *val != 1 {
         return;
     };
+    let Some(function_name) = checker.semantic().resolve_builtin_symbol(&call.func) else {
+        return;
+    };
+    if !matches!(function_name, "reversed" | "set" | "sorted") {
+        return;
+    }
     checker.diagnostics.push(Diagnostic::new(
         UnnecessarySubscriptReversal {
-            func: func.id.to_string(),
+            func: function_name.to_string(),
         },
         call.range(),
     ));

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/redundant_literal_union.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/redundant_literal_union.rs
@@ -129,8 +129,7 @@ impl fmt::Display for ExprType {
 /// Return the [`ExprType`] of an [`Expr]` if it is a builtin type (e.g. `int`, `bool`, `float`,
 /// `str`, `bytes`, or `complex`).
 fn match_builtin_type(expr: &Expr, semantic: &SemanticModel) -> Option<ExprType> {
-    let name = expr.as_name_expr()?;
-    let result = match name.id.as_str() {
+    let result = match semantic.resolve_builtin_symbol(expr)? {
         "int" => ExprType::Int,
         "bool" => ExprType::Bool,
         "str" => ExprType::Str,
@@ -139,9 +138,6 @@ fn match_builtin_type(expr: &Expr, semantic: &SemanticModel) -> Option<ExprType>
         "complex" => ExprType::Complex,
         _ => return None,
     };
-    if !semantic.is_builtin(name.id.as_str()) {
-        return None;
-    }
     Some(result)
 }
 

--- a/crates/ruff_linter/src/rules/numpy/snapshots/ruff_linter__rules__numpy__tests__numpy-deprecated-type-alias_NPY001.py.snap
+++ b/crates/ruff_linter/src/rules/numpy/snapshots/ruff_linter__rules__numpy__tests__numpy-deprecated-type-alias_NPY001.py.snap
@@ -144,7 +144,7 @@ NPY001.py:20:16: NPY001 [*] Type alias `np.int` is deprecated, replace with buil
 22 22 | # Regression test for: https://github.com/astral-sh/ruff/issues/6952
 23 23 | from numpy import float
 
-NPY001.py:25:1: NPY001 Type alias `np.float` is deprecated, replace with builtin type
+NPY001.py:25:1: NPY001 [*] Type alias `np.float` is deprecated, replace with builtin type
    |
 23 | from numpy import float
 24 | 
@@ -153,4 +153,11 @@ NPY001.py:25:1: NPY001 Type alias `np.float` is deprecated, replace with builtin
    |
    = help: Replace `np.float` with builtin type
 
-
+ℹ Safe fix
+21 21 | 
+22 22 | # Regression test for: https://github.com/astral-sh/ruff/issues/6952
+23 23 | from numpy import float
+   24 |+import builtins
+24 25 | 
+25    |-float(1)
+   26 |+builtins.float(1)

--- a/crates/ruff_linter/src/rules/pylint/rules/comparison_with_itself.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/comparison_with_itself.rs
@@ -95,22 +95,22 @@ pub(crate) fn comparison_with_itself(
                 }
 
                 // Both calls must be to the same function.
-                let Expr::Name(left_func) = left_call.func.as_ref() else {
+                let semantic = checker.semantic();
+                let Some(left_name) = semantic.resolve_builtin_symbol(&left_call.func) else {
                     continue;
                 };
-                let Expr::Name(right_func) = right_call.func.as_ref() else {
+                let Some(right_name) = semantic.resolve_builtin_symbol(&right_call.func) else {
                     continue;
                 };
-                if left_func.id != right_func.id {
+                if left_name != right_name {
                     continue;
                 }
 
                 // The call must be to pure function, like `id`.
                 if matches!(
-                    left_func.id.as_str(),
+                    left_name,
                     "id" | "len" | "type" | "int" | "bool" | "str" | "repr" | "bytes"
-                ) && checker.semantic().is_builtin(&left_func.id)
-                {
+                ) {
                     let actual = format!(
                         "{} {} {}",
                         checker.locator().slice(left),

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/native_literals.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/native_literals.rs
@@ -150,26 +150,23 @@ pub(crate) fn native_literals(
         range: _,
     } = call;
 
-    let Expr::Name(ast::ExprName { ref id, .. }) = func.as_ref() else {
-        return;
-    };
-
     if !keywords.is_empty() || args.len() > 1 {
         return;
     }
 
-    let Ok(literal_type) = LiteralType::from_str(id.as_str()) else {
+    let semantic = checker.semantic();
+
+    let Some(builtin) = semantic.resolve_builtin_symbol(func) else {
         return;
     };
 
-    if !checker.semantic().is_builtin(id) {
+    let Ok(literal_type) = LiteralType::from_str(builtin) else {
         return;
-    }
+    };
 
     // There's no way to rewrite, e.g., `f"{f'{str()}'}"` within a nested f-string.
-    if checker.semantic().in_f_string() {
-        if checker
-            .semantic()
+    if semantic.in_f_string() {
+        if semantic
             .current_expressions()
             .filter(|expr| expr.is_f_string_expr())
             .count()

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/use_pep604_isinstance.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/use_pep604_isinstance.rs
@@ -87,32 +87,32 @@ pub(crate) fn use_pep604_isinstance(
     func: &Expr,
     args: &[Expr],
 ) {
-    if let Expr::Name(ast::ExprName { id, .. }) = func {
-        let Some(kind) = CallKind::from_name(id) else {
-            return;
-        };
-        if !checker.semantic().is_builtin(id) {
-            return;
-        };
-        if let Some(types) = args.get(1) {
-            if let Expr::Tuple(ast::ExprTuple { elts, .. }) = &types {
-                // Ex) `()`
-                if elts.is_empty() {
-                    return;
-                }
-
-                // Ex) `(*args,)`
-                if elts.iter().any(Expr::is_starred_expr) {
-                    return;
-                }
-
-                let mut diagnostic = Diagnostic::new(NonPEP604Isinstance { kind }, expr.range());
-                diagnostic.set_fix(Fix::unsafe_edit(Edit::range_replacement(
-                    checker.generator().expr(&pep_604_union(elts)),
-                    types.range(),
-                )));
-                checker.diagnostics.push(diagnostic);
-            }
-        }
+    let Some(types) = args.get(1) else {
+        return;
+    };
+    let Expr::Tuple(ast::ExprTuple { elts, .. }) = types else {
+        return;
+    };
+    // Ex) `()`
+    if elts.is_empty() {
+        return;
     }
+    // Ex) `(*args,)`
+    if elts.iter().any(Expr::is_starred_expr) {
+        return;
+    }
+    let Some(builtin_function_name) = checker.semantic().resolve_builtin_symbol(func) else {
+        return;
+    };
+    let Some(kind) = CallKind::from_name(builtin_function_name) else {
+        return;
+    };
+    checker.diagnostics.push(
+        Diagnostic::new(NonPEP604Isinstance { kind }, expr.range()).with_fix(Fix::unsafe_edit(
+            Edit::range_replacement(
+                checker.generator().expr(&pep_604_union(elts)),
+                types.range(),
+            ),
+        )),
+    );
 }

--- a/crates/ruff_linter/src/rules/refurb/rules/isinstance_type_none.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/isinstance_type_none.rs
@@ -48,19 +48,15 @@ impl Violation for IsinstanceTypeNone {
 
 /// FURB168
 pub(crate) fn isinstance_type_none(checker: &mut Checker, call: &ast::ExprCall) {
-    let Expr::Name(ast::ExprName { id, .. }) = call.func.as_ref() else {
-        return;
-    };
-    if id.as_str() != "isinstance" {
-        return;
-    }
-    if !checker.semantic().is_builtin(id) {
-        return;
-    }
     let Some(types) = call.arguments.find_positional(1) else {
         return;
     };
-
+    if !checker
+        .semantic()
+        .match_builtin_expr(&call.func, "isinstance")
+    {
+        return;
+    }
     if is_none(types) {
         let Some(Expr::Name(ast::ExprName {
             id: object_name, ..

--- a/crates/ruff_linter/src/rules/refurb/rules/type_none_comparison.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/type_none_comparison.rs
@@ -134,13 +134,10 @@ fn type_call_arg<'a>(expr: &'a Expr, semantic: &'a SemanticModel) -> Option<&'a 
     if arguments.len() != 1 {
         return None;
     }
-
     // The function itself must be the builtin `type`.
-    let ast::ExprName { id, .. } = func.as_name_expr()?;
-    if id.as_str() != "type" || !semantic.is_builtin(id) {
+    if !semantic.match_builtin_expr(func, "type") {
         return None;
     }
-
     arguments.find_positional(0)
 }
 

--- a/crates/ruff_linter/src/rules/ruff/rules/explicit_f_string_type_conversion.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/explicit_f_string_type_conversion.rs
@@ -100,15 +100,11 @@ pub(crate) fn explicit_f_string_type_conversion(checker: &mut Checker, f_string:
             continue;
         }
 
-        let Expr::Name(ast::ExprName { id, .. }) = func.as_ref() else {
-            continue;
-        };
-
-        if !matches!(id.as_str(), "str" | "repr" | "ascii") {
-            continue;
-        };
-
-        if !checker.semantic().is_builtin(id) {
+        if !checker
+            .semantic()
+            .resolve_builtin_symbol(func)
+            .is_some_and(|builtin| matches!(builtin, "str" | "repr" | "ascii"))
+        {
             continue;
         }
 

--- a/crates/ruff_linter/src/rules/ruff/rules/pairwise_over_zipped.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/pairwise_over_zipped.rs
@@ -96,17 +96,18 @@ fn match_slice_info(expr: &Expr) -> Option<SliceInfo> {
 
 /// RUF007
 pub(crate) fn pairwise_over_zipped(checker: &mut Checker, func: &Expr, args: &[Expr]) {
-    let Expr::Name(ast::ExprName { id, .. }) = func else {
-        return;
-    };
-
     // Require exactly two positional arguments.
     let [first, second] = args else {
         return;
     };
 
+    // Require second argument to be a `Subscript`.
+    if !second.is_subscript_expr() {
+        return;
+    }
+
     // Require the function to be the builtin `zip`.
-    if !(id == "zip" && checker.semantic().is_builtin(id)) {
+    if !checker.semantic().match_builtin_expr(func, "zip") {
         return;
     }
 
@@ -124,10 +125,6 @@ pub(crate) fn pairwise_over_zipped(checker: &mut Checker, func: &Expr, args: &[E
         return;
     };
 
-    // Require second argument to be a `Subscript`.
-    if !second.is_subscript_expr() {
-        return;
-    }
     let Some(second_arg_info) = match_slice_info(second) else {
         return;
     };

--- a/crates/ruff_linter/src/rules/ruff/rules/unnecessary_iterable_allocation_for_first_element.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/unnecessary_iterable_allocation_for_first_element.rs
@@ -170,17 +170,12 @@ fn match_iteration_target(expr: &Expr, semantic: &SemanticModel) -> Option<Itera
             arguments: Arguments { args, .. },
             ..
         }) => {
-            let ast::ExprName { id, .. } = func.as_name_expr()?;
-
-            if !matches!(id.as_str(), "tuple" | "list") {
-                return None;
-            }
-
             let [arg] = &**args else {
                 return None;
             };
 
-            if !semantic.is_builtin(id.as_str()) {
+            let builtin_function_name = semantic.resolve_builtin_symbol(func)?;
+            if !matches!(builtin_function_name, "tuple" | "list") {
                 return None;
             }
 
@@ -216,7 +211,9 @@ fn match_iteration_target(expr: &Expr, semantic: &SemanticModel) -> Option<Itera
                 },
                 Expr::Call(ast::ExprCall { func, .. }) => IterationTarget {
                     range: arg.range(),
-                    iterable: is_func_builtin_iterator(func, semantic),
+                    iterable: semantic
+                        .resolve_builtin_symbol(func)
+                        .is_some_and(is_iterator),
                 },
                 _ => IterationTarget {
                     range: arg.range(),
@@ -250,8 +247,10 @@ fn match_iteration_target(expr: &Expr, semantic: &SemanticModel) -> Option<Itera
                 return None;
             };
 
-            let iterable = if value.is_call_expr() {
-                is_func_builtin_iterator(&value.as_call_expr()?.func, semantic)
+            let iterable = if let ast::Expr::Call(ast::ExprCall { func, .. }) = &**value {
+                semantic
+                    .resolve_builtin_symbol(func)
+                    .is_some_and(is_iterator)
             } else {
                 false
             };
@@ -289,11 +288,4 @@ fn match_simple_comprehension(elt: &Expr, generators: &[Comprehension]) -> Optio
     }
 
     Some(generator.iter.range())
-}
-
-/// Returns `true` if the function is a builtin iterator.
-fn is_func_builtin_iterator(func: &Expr, semantic: &SemanticModel) -> bool {
-    func.as_name_expr().map_or(false, |func_name| {
-        is_iterator(func_name.id.as_str()) && semantic.is_builtin(func_name.id.as_str())
-    })
 }


### PR DESCRIPTION
## Summary

This PR switches more callsites of `SemanticModel::is_builtin` to move over to the new methods I introduced in #10919, which are more concise and more accurate. I missed these calls in the first PR.

## Test Plan

`cargo test`. I haven't introduced any new tests in this PR, because I added quite a few in #10919, and this is just doing the same thing as that PR. One existing violation in the test fixtures becomes newly fixable, though.