### PR TITLE
`ruff server`: Introduce settings for directly configuring the linter and formatter

### DIFF
--- a/crates/ruff_linter/src/line_width.rs
+++ b/crates/ruff_linter/src/line_width.rs
@@ -32,12 +32,6 @@ impl LineLength {
     pub fn text_len(&self) -> TextSize {
         TextSize::from(u32::from(self.value()))
     }
-
-    pub fn from_u16_for_testing_only(length: u16) -> Self {
-        assert!(length >= 1);
-        assert!(length <= 320);
-        Self(length.try_into().unwrap())
-    }
 }
 
 impl Default for LineLength {

--- a/crates/ruff_linter/src/line_width.rs
+++ b/crates/ruff_linter/src/line_width.rs
@@ -32,6 +32,12 @@ impl LineLength {
     pub fn text_len(&self) -> TextSize {
         TextSize::from(u32::from(self.value()))
     }
+
+    pub fn from_u16_for_testing_only(length: u16) -> Self {
+        assert!(length >= 1);
+        assert!(length <= 320);
+        Self(length.try_into().unwrap())
+    }
 }
 
 impl Default for LineLength {

--- a/crates/ruff_server/resources/test/fixtures/settings/global_only.json
+++ b/crates/ruff_server/resources/test/fixtures/settings/global_only.json
@@ -6,9 +6,12 @@
             }
         },
         "lint": {
+            "ignore": ["RUF001"],
             "run": "onSave"
         },
         "fixAll": false,
-        "logLevel": "warn"
+        "logLevel": "warn",
+        "lineLength": 80,
+        "exclude": ["third_party"]
     }
 }

--- a/crates/ruff_server/resources/test/fixtures/settings/vs_code_initialization_options.json
+++ b/crates/ruff_server/resources/test/fixtures/settings/vs_code_initialization_options.json
@@ -53,6 +53,7 @@
             },
             "lint": {
                 "enable": true,
+                "preview": false,
                 "run": "onType",
                 "args": [
                     "--preview"
@@ -85,6 +86,8 @@
         },
         "lint": {
             "enable": true,
+            "preview": true,
+            "select": ["F", "I"],
             "run": "onType",
             "args": [
                 "--preview"

--- a/crates/ruff_server/src/session/settings.rs
+++ b/crates/ruff_server/src/session/settings.rs
@@ -27,6 +27,9 @@ pub(crate) struct ResolvedClientSettings {
     editor_settings: ResolvedEditorSettings,
 }
 
+/// Contains the resolved values of 'editor settings' - Ruff configuration for the linter/formatter that was passed in via
+/// LSP client settings. These fields are optional because we don't want to override file-based linter/formatting settings
+/// if these were un-set.
 #[derive(Debug, Default)]
 #[cfg_attr(test, derive(PartialEq, Eq))]
 #[allow(dead_code)] // TODO(jane): Remove once editor settings resolution is implemented

--- a/crates/ruff_server/src/session/settings.rs
+++ b/crates/ruff_server/src/session/settings.rs
@@ -265,6 +265,7 @@ impl ResolvedClientSettings {
     /// Attempts to resolve a setting using a list of available client settings as sources.
     /// Client settings that come earlier in the list take priority. This function is for fields
     /// that do not have a default value and should be left unset.
+    /// Use [`ResolvedClientSettings::resolve_or`] for settings that should have default values.
     fn resolve_optional<T>(
         all_settings: &[&ClientSettings],
         get: impl Fn(&ClientSettings) -> Option<T>,
@@ -275,6 +276,8 @@ impl ResolvedClientSettings {
     /// Attempts to resolve a setting using a list of available client settings as sources.
     /// Client settings that come earlier in the list take priority. `default` will be returned
     /// if none of the settings specify the requested setting.
+    /// Use [`ResolvedClientSettings::resolve_optional`] if the setting should be optional instead
+    /// of having a default value.
     fn resolve_or<T>(
         all_settings: &[&ClientSettings],
         get: impl Fn(&ClientSettings) -> Option<T>,

--- a/crates/ruff_server/src/session/settings.rs
+++ b/crates/ruff_server/src/session/settings.rs
@@ -47,9 +47,9 @@ pub(crate) struct ResolvedEditorSettings {
 pub(crate) struct ClientSettings {
     fix_all: Option<bool>,
     organize_imports: Option<bool>,
-    lint: Option<Lint>,
-    format: Option<Format>,
-    code_action: Option<CodeAction>,
+    lint: Option<LintOptions>,
+    format: Option<FormatOptions>,
+    code_action: Option<CodeActionOptions>,
     exclude: Option<Vec<String>>,
     line_length: Option<LineLength>,
 }
@@ -69,7 +69,7 @@ struct WorkspaceSettings {
 #[derive(Debug, Deserialize)]
 #[cfg_attr(test, derive(PartialEq, Eq))]
 #[serde(rename_all = "camelCase")]
-struct Lint {
+struct LintOptions {
     enable: Option<bool>,
     preview: Option<bool>,
     select: Option<Vec<String>>,
@@ -80,22 +80,22 @@ struct Lint {
 #[derive(Debug, Default, Deserialize)]
 #[cfg_attr(test, derive(PartialEq, Eq))]
 #[serde(rename_all = "camelCase")]
-struct Format {
+struct FormatOptions {
     preview: Option<bool>,
 }
 
 #[derive(Debug, Default, Deserialize)]
 #[cfg_attr(test, derive(PartialEq, Eq))]
 #[serde(rename_all = "camelCase")]
-struct CodeAction {
-    disable_rule_comment: Option<CodeActionSettings>,
-    fix_violation: Option<CodeActionSettings>,
+struct CodeActionOptions {
+    disable_rule_comment: Option<CodeActionParameters>,
+    fix_violation: Option<CodeActionParameters>,
 }
 
 #[derive(Debug, Deserialize)]
 #[cfg_attr(test, derive(PartialEq, Eq))]
 #[serde(rename_all = "camelCase")]
-struct CodeActionSettings {
+struct CodeActionParameters {
     enable: Option<bool>,
 }
 

--- a/crates/ruff_server/src/session/settings.rs
+++ b/crates/ruff_server/src/session/settings.rs
@@ -347,7 +347,7 @@ mod tests {
                     true,
                 ),
                 lint: Some(
-                    Lint {
+                    LintOptions {
                         enable: Some(
                             true,
                         ),
@@ -365,21 +365,21 @@ mod tests {
                     },
                 ),
                 format: Some(
-                    Format {
+                    FormatOptions {
                         preview: None,
                     },
                 ),
                 code_action: Some(
-                    CodeAction {
+                    CodeActionOptions {
                         disable_rule_comment: Some(
-                            CodeActionSettings {
+                            CodeActionParameters {
                                 enable: Some(
                                     false,
                                 ),
                             },
                         ),
                         fix_violation: Some(
-                            CodeActionSettings {
+                            CodeActionParameters {
                                 enable: Some(
                                     false,
                                 ),
@@ -400,7 +400,7 @@ mod tests {
                             true,
                         ),
                         lint: Some(
-                            Lint {
+                            LintOptions {
                                 enable: Some(
                                     true,
                                 ),
@@ -411,21 +411,21 @@ mod tests {
                             },
                         ),
                         format: Some(
-                            Format {
+                            FormatOptions {
                                 preview: None,
                             },
                         ),
                         code_action: Some(
-                            CodeAction {
+                            CodeActionOptions {
                                 disable_rule_comment: Some(
-                                    CodeActionSettings {
+                                    CodeActionParameters {
                                         enable: Some(
                                             false,
                                         ),
                                     },
                                 ),
                                 fix_violation: Some(
-                                    CodeActionSettings {
+                                    CodeActionParameters {
                                         enable: Some(
                                             false,
                                         ),
@@ -457,7 +457,7 @@ mod tests {
                             true,
                         ),
                         lint: Some(
-                            Lint {
+                            LintOptions {
                                 enable: Some(
                                     true,
                                 ),
@@ -470,21 +470,21 @@ mod tests {
                             },
                         ),
                         format: Some(
-                            Format {
+                            FormatOptions {
                                 preview: None,
                             },
                         ),
                         code_action: Some(
-                            CodeAction {
+                            CodeActionOptions {
                                 disable_rule_comment: Some(
-                                    CodeActionSettings {
+                                    CodeActionParameters {
                                         enable: Some(
                                             true,
                                         ),
                                     },
                                 ),
                                 fix_violation: Some(
-                                    CodeActionSettings {
+                                    CodeActionParameters {
                                         enable: Some(
                                             false,
                                         ),
@@ -591,7 +591,7 @@ mod tests {
                     ),
                     organize_imports: None,
                     lint: Some(
-                        Lint {
+                        LintOptions {
                             enable: None,
                             preview: None,
                             select: None,
@@ -605,9 +605,9 @@ mod tests {
                     ),
                     format: None,
                     code_action: Some(
-                        CodeAction {
+                        CodeActionOptions {
                             disable_rule_comment: Some(
-                                CodeActionSettings {
+                                CodeActionParameters {
                                     enable: Some(
                                         false,
                                     ),

--- a/crates/ruff_server/src/session/settings.rs
+++ b/crates/ruff_server/src/session/settings.rs
@@ -311,6 +311,7 @@ impl Default for InitializationOptions {
 #[cfg(test)]
 mod tests {
     use insta::assert_debug_snapshot;
+    use ruff_linter::registry::Linter;
     use serde::de::DeserializeOwned;
 
     use super::*;
@@ -344,6 +345,22 @@ mod tests {
                         enable: Some(
                             true,
                         ),
+                        preview: Some(
+                            true,
+                        ),
+                        select: Some(
+                            [
+                                "F",
+                                "I",
+                            ],
+                        ),
+                        extend_select: None,
+                        ignore: None,
+                    },
+                ),
+                format: Some(
+                    Format {
+                        preview: None,
                     },
                 ),
                 code_action: Some(
@@ -364,6 +381,8 @@ mod tests {
                         ),
                     },
                 ),
+                exclude: None,
+                line_length: None,
             },
             workspace_settings: [
                 WorkspaceSettings {
@@ -379,6 +398,15 @@ mod tests {
                                 enable: Some(
                                     true,
                                 ),
+                                preview: None,
+                                select: None,
+                                extend_select: None,
+                                ignore: None,
+                            },
+                        ),
+                        format: Some(
+                            Format {
+                                preview: None,
                             },
                         ),
                         code_action: Some(
@@ -399,6 +427,8 @@ mod tests {
                                 ),
                             },
                         ),
+                        exclude: None,
+                        line_length: None,
                     },
                     workspace: Url {
                         scheme: "file",
@@ -425,6 +455,17 @@ mod tests {
                                 enable: Some(
                                     true,
                                 ),
+                                preview: Some(
+                                    false,
+                                ),
+                                select: None,
+                                extend_select: None,
+                                ignore: None,
+                            },
+                        ),
+                        format: Some(
+                            Format {
+                                preview: None,
                             },
                         ),
                         code_action: Some(
@@ -445,6 +486,8 @@ mod tests {
                                 ),
                             },
                         ),
+                        exclude: None,
+                        line_length: None,
                     },
                     workspace: Url {
                         scheme: "file",
@@ -485,7 +528,18 @@ mod tests {
                 lint_enable: true,
                 disable_rule_comment_enable: false,
                 fix_violation_enable: false,
-                editor_settings: ResolvedEditorSettings::default(),
+                editor_settings: ResolvedEditorSettings {
+                    lint_preview: Some(true),
+                    format_preview: None,
+                    select: Some(vec![
+                        RuleSelector::Linter(Linter::Pyflakes),
+                        RuleSelector::Linter(Linter::Isort)
+                    ]),
+                    extend_select: None,
+                    ignore: None,
+                    exclude: None,
+                    line_length: None
+                }
             }
         );
         let url = Url::parse("file:///Users/test/projects/scipy").expect("url should parse");
@@ -502,7 +556,18 @@ mod tests {
                 lint_enable: true,
                 disable_rule_comment_enable: true,
                 fix_violation_enable: false,
-                editor_settings: ResolvedEditorSettings::default()
+                editor_settings: ResolvedEditorSettings {
+                    lint_preview: Some(false),
+                    format_preview: None,
+                    select: Some(vec![
+                        RuleSelector::Linter(Linter::Pyflakes),
+                        RuleSelector::Linter(Linter::Isort)
+                    ]),
+                    extend_select: None,
+                    ignore: None,
+                    exclude: None,
+                    line_length: None
+                }
             }
         );
     }
@@ -522,8 +587,17 @@ mod tests {
                     lint: Some(
                         Lint {
                             enable: None,
+                            preview: None,
+                            select: None,
+                            extend_select: None,
+                            ignore: Some(
+                                [
+                                    "RUF001",
+                                ],
+                            ),
                         },
                     ),
+                    format: None,
                     code_action: Some(
                         CodeAction {
                             disable_rule_comment: Some(
@@ -535,6 +609,16 @@ mod tests {
                             ),
                             fix_violation: None,
                         },
+                    ),
+                    exclude: Some(
+                        [
+                            "third_party",
+                        ],
+                    ),
+                    line_length: Some(
+                        LineLength(
+                            80,
+                        ),
                     ),
                 },
             ),
@@ -557,7 +641,15 @@ mod tests {
                 lint_enable: true,
                 disable_rule_comment_enable: false,
                 fix_violation_enable: true,
-                editor_settings: ResolvedEditorSettings::default()
+                editor_settings: ResolvedEditorSettings {
+                    lint_preview: None,
+                    format_preview: None,
+                    select: None,
+                    extend_select: None,
+                    ignore: Some(vec![RuleSelector::from_str("RUF001").unwrap()]),
+                    exclude: Some(vec![PathBuf::from_str("third_party").unwrap()]),
+                    line_length: Some(LineLength::from_u16_for_testing_only(80u16))
+                }
             }
         );
     }

--- a/crates/ruff_server/src/session/settings.rs
+++ b/crates/ruff_server/src/session/settings.rs
@@ -648,7 +648,7 @@ mod tests {
                     extend_select: None,
                     ignore: Some(vec![RuleSelector::from_str("RUF001").unwrap()]),
                     exclude: Some(vec![PathBuf::from_str("third_party").unwrap()]),
-                    line_length: Some(LineLength::from_u16_for_testing_only(80u16))
+                    line_length: Some(LineLength::try_from(80).unwrap())
                 }
             }
         );

--- a/crates/ruff_server/src/session/settings.rs
+++ b/crates/ruff_server/src/session/settings.rs
@@ -1,7 +1,7 @@
-use std::{ffi::OsString, ops::Deref, path::PathBuf};
+use std::{ffi::OsString, ops::Deref, path::PathBuf, str::FromStr};
 
 use lsp_types::Url;
-use ruff_linter::{codes::Rule, line_width::LineLength};
+use ruff_linter::{line_width::LineLength, RuleSelector};
 use rustc_hash::FxHashMap;
 use serde::Deserialize;
 
@@ -33,9 +33,9 @@ pub(crate) struct ResolvedClientSettings {
 pub(crate) struct ResolvedEditorSettings {
     lint_preview: Option<bool>,
     format_preview: Option<bool>,
-    select: Option<Vec<Rule>>,
-    extend_select: Option<Vec<Rule>>,
-    ignore: Option<Vec<Rule>>,
+    select: Option<Vec<RuleSelector>>,
+    extend_select: Option<Vec<RuleSelector>>,
+    ignore: Option<Vec<RuleSelector>>,
     exclude: Option<Vec<PathBuf>>,
     line_length: Option<LineLength>,
 }
@@ -224,7 +224,7 @@ impl ResolvedClientSettings {
                         .select
                         .as_ref()?
                         .iter()
-                        .map(|rule| Rule::from_code(rule).ok())
+                        .map(|rule| RuleSelector::from_str(rule).ok())
                         .collect()
                 }),
                 extend_select: Self::resolve_optional(all_settings, |settings| {
@@ -234,7 +234,7 @@ impl ResolvedClientSettings {
                         .extend_select
                         .as_ref()?
                         .iter()
-                        .map(|rule| Rule::from_code(rule).ok())
+                        .map(|rule| RuleSelector::from_str(rule).ok())
                         .collect()
                 }),
                 ignore: Self::resolve_optional(all_settings, |settings| {
@@ -244,7 +244,7 @@ impl ResolvedClientSettings {
                         .ignore
                         .as_ref()?
                         .iter()
-                        .map(|rule| Rule::from_code(rule).ok())
+                        .map(|rule| RuleSelector::from_str(rule).ok())
                         .collect()
                 }),
                 exclude: Self::resolve_optional(all_settings, |settings| {


### PR DESCRIPTION
## Summary

The following client settings have been introduced to the language server:
* `lint.preview`
* `format.preview`
* `lint.select`
* `lint.extendSelect`
* `lint.ignore`
* `exclude`
* `lineLength`

`exclude` and `lineLength` apply to both the linter and formatter.

This does not actually use the settings yet, but makes them available for future use.

## Test Plan

Snapshot tests have been updated.