### PR TITLE
`ruff server`: Write a setup guide for Neovim

### DIFF
--- a/crates/ruff_server/README.md
+++ b/crates/ruff_server/README.md
@@ -9,8 +9,8 @@ files in your editor's workspace, and will refresh its in-memory configuration w
 
 We have specific setup instructions depending on your editor. If you don't see your editor on this list and would like a setup guide, please open an issue.
 
-* Visual Studio Code: install the [Ruff extension from the VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=charliermarsh.ruff). The language server used by the extension will be, by default, the one in your actively-installed `ruff` binary. If you don't have `ruff` installed and haven't provided a path to the extension, it comes with a bundled `ruff` version that it will use instead. Since the new Ruff language server has not yet been stabilized, you will need to use the pre-release version of the extension and enable the `Experimental Server` setting.
-* NeoVim: see the [NeoVim setup guide](docs/setup/NEOVIM.md).
+- Visual Studio Code: install the [Ruff extension from the VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=charliermarsh.ruff). The language server used by the extension will be, by default, the one in your actively-installed `ruff` binary. If you don't have `ruff` installed and haven't provided a path to the extension, it comes with a bundled `ruff` version that it will use instead. Since the new Ruff language server has not yet been stabilized, you will need to use the pre-release version of the extension and enable the `Experimental Server` setting.
+- NeoVim: see the [NeoVim setup guide](docs/setup/NEOVIM.md).
 
 ### Contributing
 

--- a/crates/ruff_server/README.md
+++ b/crates/ruff_server/README.md
@@ -10,7 +10,7 @@ files in your editor's workspace, and will refresh its in-memory configuration w
 We have specific setup instructions depending on your editor. If you don't see your editor on this list and would like a setup guide, please open an issue.
 
 - Visual Studio Code: install the [Ruff extension from the VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=charliermarsh.ruff). The language server used by the extension will be, by default, the one in your actively-installed `ruff` binary. If you don't have `ruff` installed and haven't provided a path to the extension, it comes with a bundled `ruff` version that it will use instead. Since the new Ruff language server has not yet been stabilized, you will need to use the pre-release version of the extension and enable the `Experimental Server` setting.
-- NeoVim: see the [NeoVim setup guide](docs/setup/NEOVIM.md).
+- Neovim: see the [Neovim setup guide](docs/setup/NEOVIM.md).
 
 ### Contributing
 

--- a/crates/ruff_server/README.md
+++ b/crates/ruff_server/README.md
@@ -5,6 +5,13 @@ listen for requests from the client, (in this case, the code editor of your choi
 crates to create real-time diagnostics or formatted code, which is then sent back to the client. It also tracks configuration
 files in your editor's workspace, and will refresh its in-memory configuration whenever those files are modified.
 
+### Setup
+
+We have specific setup instructions depending on your editor. If you don't see your editor on this list and would like a setup guide, please open an issue.
+
+* Visual Studio Code: install the [Ruff extension from the VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=charliermarsh.ruff). The language server used by the extension will be, by default, the one in your actively-installed `ruff` binary. If you don't have `ruff` installed and haven't provided a path to the extension, it comes with a bundled `ruff` version that it will use instead. Since the new Ruff language server has not yet been stabilized, you will need to use the pre-release version of the extension and enable the `Experimental Server` setting.
+* NeoVim: see the [NeoVim setup guide](docs/setup/NEOVIM.md).
+
 ### Contributing
 
 If you're interested in contributing to `ruff server` - well, first of all, thank you! Second of all, you might find the [**contribution guide**](CONTRIBUTING.md) to be a useful resource. Finally, don't hesitate to reach out on our [**Discord**](https://discord.com/invite/astral-sh) if you have questions.

--- a/crates/ruff_server/README.md
+++ b/crates/ruff_server/README.md
@@ -9,8 +9,8 @@ files in your editor's workspace, and will refresh its in-memory configuration w
 
 We have specific setup instructions depending on your editor. If you don't see your editor on this list and would like a setup guide, please open an issue.
 
-- Visual Studio Code: install the [Ruff extension from the VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=charliermarsh.ruff). The language server used by the extension will be, by default, the one in your actively-installed `ruff` binary. If you don't have `ruff` installed and haven't provided a path to the extension, it comes with a bundled `ruff` version that it will use instead. Since the new Ruff language server has not yet been stabilized, you will need to use the pre-release version of the extension and enable the `Experimental Server` setting.
-- Neovim: see the [Neovim setup guide](docs/setup/NEOVIM.md).
+- Visual Studio Code: Install the [Ruff extension from the VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=charliermarsh.ruff). The language server used by the extension will be, by default, the one in your actively-installed `ruff` binary. If you don't have `ruff` installed and haven't provided a path to the extension, it comes with a bundled `ruff` version that it will use instead. Since the new Ruff language server has not yet been stabilized, you will need to use the pre-release version of the extension and enable the `Experimental Server` setting.
+- Neovim: See the [Neovim setup guide](docs/setup/NEOVIM.md).
 
 ### Contributing
 

--- a/crates/ruff_server/docs/setup/NEOVIM.md
+++ b/crates/ruff_server/docs/setup/NEOVIM.md
@@ -3,14 +3,14 @@
 ### Using `nvim-lspconfig`
 
 1. Install [`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig).
-2. Setup `nvim-lspconfig` with the [suggested configuration](https://github.com/neovim/nvim-lspconfig/tree/master#suggested-configuration).
-3. Finally, add this to your `init.lua`:
+1. Setup `nvim-lspconfig` with the [suggested configuration](https://github.com/neovim/nvim-lspconfig/tree/master#suggested-configuration).
+1. Finally, add this to your `init.lua`:
 
 ```lua
 require'lspconfig'.ruff.setup{}
 ```
 
-See [`nvim-lspconfig`'s server configuration guide](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#ruff) for more details 
+See [`nvim-lspconfig`'s server configuration guide](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#ruff) for more details
 on how to configure the server from there.
 
 **Important note**: If you have the older language server (`ruff-lsp`) configured in NeoVim, make sure to disable it to prevent any conflicts.
@@ -18,6 +18,7 @@ on how to configure the server from there.
 #### Tips
 
 If you're using Ruff alongside another LSP (like Pyright), you may want to defer to that LSP for certain capabilities, like `textDocument/hover`:
+
 ```lua
 local on_attach = function(client, bufnr)
   if client.name == 'ruff' then
@@ -32,6 +33,7 @@ require('lspconfig').ruff.setup {
 ```
 
 If you'd like to use Ruff exclusively for linting, formatting, and import organization, you can disable those capabilities for Pyright:
+
 ```lua
 require('lspconfig').pyright.setup {
   settings = {

--- a/crates/ruff_server/docs/setup/NEOVIM.md
+++ b/crates/ruff_server/docs/setup/NEOVIM.md
@@ -1,6 +1,6 @@
-## Neovim Setup Guide for `ruff server`
+# Neovim Setup Guide for `ruff server`
 
-### Using `nvim-lspconfig`
+## Using `nvim-lspconfig`
 
 1. Install [`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig).
 1. Setup `nvim-lspconfig` with the [suggested configuration](https://github.com/neovim/nvim-lspconfig/tree/master#suggested-configuration).
@@ -17,7 +17,7 @@ on how to configure the server from there.
 >
 > If you have the older language server (`ruff-lsp`) configured in NeoVim, make sure to disable it to prevent any conflicts.
 
-#### Tips
+### Tips
 
 If you're using Ruff alongside another LSP (like Pyright), you may want to defer to that LSP for certain capabilities, like `textDocument/hover`:
 

--- a/crates/ruff_server/docs/setup/NEOVIM.md
+++ b/crates/ruff_server/docs/setup/NEOVIM.md
@@ -7,7 +7,7 @@
 1. Finally, add this to your `init.lua`:
 
 ```lua
-require'lspconfig'.ruff.setup{}
+require('lspconfig').ruff.setup()
 ```
 
 See [`nvim-lspconfig`'s server configuration guide](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#ruff) for more details
@@ -15,7 +15,7 @@ on how to configure the server from there.
 
 > \[!IMPORTANT\]
 >
-> If you have the older language server (`ruff-lsp`) configured in NeoVim, make sure to disable it to prevent any conflicts.
+> If you have the older language server (`ruff-lsp`) configured in Neovim, make sure to disable it to prevent any conflicts.
 
 #### Tips
 

--- a/crates/ruff_server/docs/setup/NEOVIM.md
+++ b/crates/ruff_server/docs/setup/NEOVIM.md
@@ -1,0 +1,50 @@
+## NeoVim Setup Guide for `ruff server`
+
+### Using `nvim-lspconfig`
+
+1. Install [`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig).
+2. Setup `nvim-lspconfig` with the [suggested configuration](https://github.com/neovim/nvim-lspconfig/tree/master#suggested-configuration).
+3. Finally, add this to your `init.lua`:
+
+```lua
+require'lspconfig'.ruff.setup{}
+```
+
+See [`nvim-lspconfig`'s server configuration guide](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#ruff) for more details 
+on how to configure the server from there.
+
+**Important note**: If you have the older language server (`ruff-lsp`) configured in NeoVim, make sure to disable it to prevent any conflicts.
+
+#### Tips
+
+If you're using Ruff alongside another LSP (like Pyright), you may want to defer to that LSP for certain capabilities, like `textDocument/hover`:
+```lua
+local on_attach = function(client, bufnr)
+  if client.name == 'ruff' then
+    -- Disable hover in favor of Pyright
+    client.server_capabilities.hoverProvider = false
+  end
+end
+
+require('lspconfig').ruff.setup {
+  on_attach = on_attach,
+}
+```
+
+If you'd like to use Ruff exclusively for linting, formatting, and import organization, you can disable those capabilities for Pyright:
+```lua
+require('lspconfig').pyright.setup {
+  settings = {
+    pyright = {
+      -- Using Ruff's import organizer
+      disableOrganizeImports = true,
+    },
+    python = {
+      analysis = {
+        -- Ignore all files for analysis to exclusively use Ruff for linting
+        ignore = { '*' },
+      },
+    },
+  },
+}
+```

--- a/crates/ruff_server/docs/setup/NEOVIM.md
+++ b/crates/ruff_server/docs/setup/NEOVIM.md
@@ -13,7 +13,9 @@ require'lspconfig'.ruff.setup{}
 See [`nvim-lspconfig`'s server configuration guide](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#ruff) for more details
 on how to configure the server from there.
 
-**Important note**: If you have the older language server (`ruff-lsp`) configured in Neovim, make sure to disable it to prevent any conflicts.
+> [!IMPORTANT]
+>
+> If you have the older language server (`ruff-lsp`) configured in NeoVim, make sure to disable it to prevent any conflicts.
 
 #### Tips
 

--- a/crates/ruff_server/docs/setup/NEOVIM.md
+++ b/crates/ruff_server/docs/setup/NEOVIM.md
@@ -13,7 +13,7 @@ require'lspconfig'.ruff.setup{}
 See [`nvim-lspconfig`'s server configuration guide](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#ruff) for more details
 on how to configure the server from there.
 
-> [!IMPORTANT]
+> \[!IMPORTANT\]
 >
 > If you have the older language server (`ruff-lsp`) configured in NeoVim, make sure to disable it to prevent any conflicts.
 

--- a/crates/ruff_server/docs/setup/NEOVIM.md
+++ b/crates/ruff_server/docs/setup/NEOVIM.md
@@ -1,4 +1,4 @@
-## NeoVim Setup Guide for `ruff server`
+## Neovim Setup Guide for `ruff server`
 
 ### Using `nvim-lspconfig`
 
@@ -13,7 +13,7 @@ require'lspconfig'.ruff.setup{}
 See [`nvim-lspconfig`'s server configuration guide](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#ruff) for more details
 on how to configure the server from there.
 
-**Important note**: If you have the older language server (`ruff-lsp`) configured in NeoVim, make sure to disable it to prevent any conflicts.
+**Important note**: If you have the older language server (`ruff-lsp`) configured in Neovim, make sure to disable it to prevent any conflicts.
 
 #### Tips
 

--- a/crates/ruff_server/docs/setup/NEOVIM.md
+++ b/crates/ruff_server/docs/setup/NEOVIM.md
@@ -1,6 +1,6 @@
-# Neovim Setup Guide for `ruff server`
+## Neovim Setup Guide for `ruff server`
 
-## Using `nvim-lspconfig`
+### Using `nvim-lspconfig`
 
 1. Install [`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig).
 1. Setup `nvim-lspconfig` with the [suggested configuration](https://github.com/neovim/nvim-lspconfig/tree/master#suggested-configuration).
@@ -17,7 +17,7 @@ on how to configure the server from there.
 >
 > If you have the older language server (`ruff-lsp`) configured in NeoVim, make sure to disable it to prevent any conflicts.
 
-### Tips
+#### Tips
 
 If you're using Ruff alongside another LSP (like Pyright), you may want to defer to that LSP for certain capabilities, like `textDocument/hover`:
 


### PR DESCRIPTION
## Summary

A setup guide has been written for NeoVim under a new `crates/ruff_server/docs/setup` folder, where future setup guides will also go. This setup guide was adapted from the [`ruff-lsp` guide](https://github.com/astral-sh/ruff-lsp?tab=readme-ov-file#example-neovim).
