### PR TITLE
`ruff server` refreshes diagnostics for open files when file configuration is changed

### DIFF
--- a/crates/ruff_server/src/server/api.rs
+++ b/crates/ruff_server/src/server/api.rs
@@ -123,8 +123,8 @@ fn local_notification_task<'a, N: traits::SyncNotificationHandler>(
     notif: server::Notification,
 ) -> super::Result<Task<'a>> {
     let (id, params) = cast_notification::<N>(notif)?;
-    Ok(Task::local(move |session, notifier, _, _| {
-        if let Err(err) = N::run(session, notifier, params) {
+    Ok(Task::local(move |session, notifier, requester, _| {
+        if let Err(err) = N::run(session, notifier, requester, params) {
             tracing::error!("An error occurred while running {id}: {err}");
             show_err_msg!("Ruff encountered a problem. Check the logs for more details.");
         }

--- a/crates/ruff_server/src/server/api/notifications/cancel.rs
+++ b/crates/ruff_server/src/server/api/notifications/cancel.rs
@@ -1,4 +1,4 @@
-use crate::server::client::Notifier;
+use crate::server::client::{Notifier, Requester};
 use crate::server::Result;
 use crate::session::Session;
 use lsp_types as types;
@@ -15,6 +15,7 @@ impl super::SyncNotificationHandler for Cancel {
     fn run(
         _session: &mut Session,
         _notifier: Notifier,
+        _requester: &mut Requester,
         _params: types::CancelParams,
     ) -> Result<()> {
         // TODO(jane): Handle this once we have task cancellation in the scheduler.

--- a/crates/ruff_server/src/server/api/notifications/did_change.rs
+++ b/crates/ruff_server/src/server/api/notifications/did_change.rs
@@ -1,5 +1,5 @@
 use crate::server::api::LSPResult;
-use crate::server::client::Notifier;
+use crate::server::client::{Notifier, Requester};
 use crate::server::Result;
 use crate::session::Session;
 use lsp_types as types;
@@ -16,6 +16,7 @@ impl super::SyncNotificationHandler for DidChange {
     fn run(
         session: &mut Session,
         _notifier: Notifier,
+        _requester: &mut Requester,
         types::DidChangeTextDocumentParams {
             text_document:
                 types::VersionedTextDocumentIdentifier {

--- a/crates/ruff_server/src/server/api/notifications/did_change_configuration.rs
+++ b/crates/ruff_server/src/server/api/notifications/did_change_configuration.rs
@@ -1,4 +1,4 @@
-use crate::server::client::Notifier;
+use crate::server::client::{Notifier, Requester};
 use crate::server::Result;
 use crate::session::Session;
 use lsp_types as types;
@@ -14,6 +14,7 @@ impl super::SyncNotificationHandler for DidChangeConfiguration {
     fn run(
         _session: &mut Session,
         _notifier: Notifier,
+        _requester: &mut Requester,
         _params: types::DidChangeConfigurationParams,
     ) -> Result<()> {
         // TODO(jane): get this wired up after the pre-release

--- a/crates/ruff_server/src/server/api/notifications/did_change_watched_files.rs
+++ b/crates/ruff_server/src/server/api/notifications/did_change_watched_files.rs
@@ -25,7 +25,7 @@ impl super::SyncNotificationHandler for DidChangeWatchedFiles {
                 .with_failure_code(lsp_server::ErrorCode::InternalError)?;
         }
 
-        if !params.changes.is_empty() {
+        if session.resolved_client_capabilities().workspace_refresh && !params.changes.is_empty() {
             requester
                 .request::<types::request::WorkspaceDiagnosticRefresh>((), |()| Task::nothing())
                 .with_failure_code(lsp_server::ErrorCode::InternalError)?;

--- a/crates/ruff_server/src/server/api/notifications/did_change_workspace.rs
+++ b/crates/ruff_server/src/server/api/notifications/did_change_workspace.rs
@@ -1,5 +1,5 @@
 use crate::server::api::LSPResult;
-use crate::server::client::Notifier;
+use crate::server::client::{Notifier, Requester};
 use crate::server::Result;
 use crate::session::Session;
 use lsp_types as types;
@@ -15,6 +15,7 @@ impl super::SyncNotificationHandler for DidChangeWorkspace {
     fn run(
         session: &mut Session,
         _notifier: Notifier,
+        _requester: &mut Requester,
         params: types::DidChangeWorkspaceFoldersParams,
     ) -> Result<()> {
         for new in params.event.added {

--- a/crates/ruff_server/src/server/api/notifications/did_close.rs
+++ b/crates/ruff_server/src/server/api/notifications/did_close.rs
@@ -1,5 +1,5 @@
 use crate::server::api::LSPResult;
-use crate::server::client::Notifier;
+use crate::server::client::{Notifier, Requester};
 use crate::server::Result;
 use crate::session::Session;
 use lsp_types as types;
@@ -16,6 +16,7 @@ impl super::SyncNotificationHandler for DidClose {
     fn run(
         session: &mut Session,
         _notifier: Notifier,
+        _requester: &mut Requester,
         types::DidCloseTextDocumentParams {
             text_document: types::TextDocumentIdentifier { uri },
         }: types::DidCloseTextDocumentParams,

--- a/crates/ruff_server/src/server/api/notifications/did_open.rs
+++ b/crates/ruff_server/src/server/api/notifications/did_open.rs
@@ -1,4 +1,4 @@
-use crate::server::client::Notifier;
+use crate::server::client::{Notifier, Requester};
 use crate::server::Result;
 use crate::session::Session;
 use lsp_types as types;
@@ -15,6 +15,7 @@ impl super::SyncNotificationHandler for DidOpen {
     fn run(
         session: &mut Session,
         _notifier: Notifier,
+        _requester: &mut Requester,
         types::DidOpenTextDocumentParams {
             text_document:
                 types::TextDocumentItem {

--- a/crates/ruff_server/src/server/api/traits.rs
+++ b/crates/ruff_server/src/server/api/traits.rs
@@ -56,6 +56,7 @@ pub(super) trait SyncNotificationHandler: NotificationHandler {
     fn run(
         session: &mut Session,
         notifier: Notifier,
+        requester: &mut Requester,
         params: <<Self as NotificationHandler>::NotificationType as LSPNotification>::Params,
     ) -> super::Result<()>;
 }

--- a/crates/ruff_server/src/session/capabilities.rs
+++ b/crates/ruff_server/src/session/capabilities.rs
@@ -35,12 +35,18 @@ impl ResolvedClientCapabilities {
             .and_then(|workspace_edit| workspace_edit.document_changes)
             .unwrap_or_default();
 
+        let workspace_refresh = true;
+
+        // TODO(jane): Once the bug involving workspace.diagnostic(s) deserialization has been fixed,
+        // uncomment this.
+        /*
         let workspace_refresh = client_capabilities
             .workspace
             .as_ref()
             .and_then(|workspace| workspace.diagnostic.as_ref())
             .and_then(|diagnostic| diagnostic.refresh_support)
             .unwrap_or_default();
+        */
 
         Self {
             code_action_deferred_edit_resolution: code_action_data_support

--- a/crates/ruff_server/src/session/capabilities.rs
+++ b/crates/ruff_server/src/session/capabilities.rs
@@ -1,10 +1,12 @@
 use lsp_types::ClientCapabilities;
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
+#[allow(clippy::struct_excessive_bools)]
 pub(crate) struct ResolvedClientCapabilities {
     pub(crate) code_action_deferred_edit_resolution: bool,
     pub(crate) apply_edit: bool,
     pub(crate) document_changes: bool,
+    pub(crate) workspace_refresh: bool,
 }
 
 impl ResolvedClientCapabilities {
@@ -33,11 +35,19 @@ impl ResolvedClientCapabilities {
             .and_then(|workspace_edit| workspace_edit.document_changes)
             .unwrap_or_default();
 
+        let workspace_refresh = client_capabilities
+            .workspace
+            .as_ref()
+            .and_then(|workspace| workspace.diagnostic.as_ref())
+            .and_then(|diagnostic| diagnostic.refresh_support)
+            .unwrap_or_default();
+
         Self {
             code_action_deferred_edit_resolution: code_action_data_support
                 && code_action_edit_resolution,
             apply_edit,
             document_changes,
+            workspace_refresh,
         }
     }
 }


### PR DESCRIPTION
## Summary

The server now requests a [workspace diagnostic refresh](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#diagnostic_refresh) when a configuration file gets changed. This means that diagnostics for all open files will be automatically re-requested by the client on a config change.

## Test Plan

You can test this by opening several files in VS Code, setting `select` in your file configuration to `[]`, and observing that the diagnostics go away once the file is saved (besides any `Pylance` diagnostics). Restore it to what it was before, and you should see the diagnostics automatically return once a save happens.