### PR TITLE
Add `RUFF_OUTPUT_FILE` environment variable support

### DIFF
--- a/crates/ruff/src/args.rs
+++ b/crates/ruff/src/args.rs
@@ -190,7 +190,7 @@ pub struct CheckCommand {
     pub output_format: Option<SerializationFormat>,
 
     /// Specify file to write the linter output to (default: stdout).
-    #[arg(short, long)]
+    #[arg(short, long, env = "RUFF_OUTPUT_FILE")]
     pub output_file: Option<PathBuf>,
     /// The minimum Python version that should be supported.
     #[arg(long, value_enum)]

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -601,7 +601,8 @@ Options:
           concise, full, json, json-lines, junit, grouped, github, gitlab,
           pylint, azure, sarif]
   -o, --output-file <OUTPUT_FILE>
-          Specify file to write the linter output to (default: stdout)
+          Specify file to write the linter output to (default: stdout) [env:
+          RUFF_OUTPUT_FILE=]
       --target-version <TARGET_VERSION>
           The minimum Python version that should be supported [possible values:
           py37, py38, py39, py310, py311, py312]


### PR DESCRIPTION
## Summary

I've added support for configuring the `ruff check` output file via the environment variable `RUFF_OUTPUT_FILE` akin to #1731.

This is super useful when, e.g., generating a [GitLab code quality report](https://docs.gitlab.com/ee/ci/testing/code_quality.html#implement-a-custom-tool) while running Ruff as a pre-commit hook. Usually, `ruff check` should print its human-readable output to `stdout`, but when run through `pre-commit` _in a GitLab CI job_ it should write its output in `gitlab` format to a file. So, to override these two settings only during CI, environment variables come handy, and `RUFF_OUTPUT_FORMAT` already exists but `RUFF_OUTPUT_FILE` has been missing.

A (simplified) GitLab CI job config for this scenario might look like this:

```yaml
pre-commit:
  stage: test
  image: python
  variables:
    RUFF_OUTPUT_FILE: gl-code-quality-report.json
    RUFF_OUTPUT_FORMAT: gitlab
  before_script:
    - pip install pre-commit
  script:
    - pre-commit run --all-files --show-diff-on-failure
  artifacts:
    reports:
      codequality: gl-code-quality-report.json
```

## Test Plan

I tested it manually.