### PR TITLE
Remove invalid named expr test from formatter

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/named_expr.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/named_expr.py
@@ -71,8 +71,6 @@ for x in (y := [1, 2, 3]):
 async for x in (y := [1, 2, 3]):
     pass
 
-del (x := 1)
-
 try:
     pass
 except (e := Exception):

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__named_expr.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__named_expr.py.snap
@@ -77,8 +77,6 @@ for x in (y := [1, 2, 3]):
 async for x in (y := [1, 2, 3]):
     pass
 
-del (x := 1)
-
 try:
     pass
 except (e := Exception):
@@ -180,8 +178,6 @@ for x in (y := [1, 2, 3]):
 async for x in (y := [1, 2, 3]):
     pass
 
-del (x := 1)
-
 try:
     pass
 except (e := Exception):
@@ -207,6 +203,3 @@ def f():
 async def f():
     await (x := 1)
 ```
-
-
-


### PR DESCRIPTION
## Summary

This PR removes a test case from the formatter which uses a named expression as `del` target. This is an invalid syntax in the new parser.
