### PR TITLE
Preserve comma with starred expr in subscript

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/slice.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/slice.py
@@ -110,3 +110,14 @@ self.assertEqual(
     suite._tests[0].id().split(".")[0],
     os.path.basename(os.getcwd()),
 )
+
+# PEP 646 introduced starred expression in indexes
+# https://peps.python.org/pep-0646/#change-1-star-expressions-in-indexes
+data[*x]
+data[*x,]
+data[
+    *x,
+]
+data[  # comment 1
+     *x,  # comment 2
+]  # comment 3

--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/function.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/function.py
@@ -427,3 +427,9 @@ def function_with_one_argument_and_a_keyword_separator(
     *, argument: str
 ) -> ReallyReallyReallyReallyReallyReallyReallyReallyLongName:
     pass
+
+
+# PEP 646 introduced type var tuple in parameter annotation
+# https://peps.python.org/pep-0646/#change-2-args-as-a-typevartuple
+def function_with_variadic_generics(*args: *tuple[int]): ...
+def function_with_variadic_generics(*args: *tuple[int],): ...

--- a/crates/ruff_python_formatter/src/expression/expr_tuple.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_tuple.rs
@@ -1,13 +1,14 @@
-use ruff_formatter::{format_args, write, FormatRuleWithOptions};
+use ruff_formatter::{format_args, FormatRuleWithOptions};
 use ruff_python_ast::AnyNodeRef;
 use ruff_python_ast::ExprTuple;
-use ruff_text_size::Ranged;
+use ruff_text_size::{Ranged, TextRange};
 
 use crate::builders::parenthesize_if_expands;
 use crate::comments::SourceComment;
 use crate::expression::parentheses::{
     empty_parenthesized, optional_parentheses, parenthesized, NeedsParentheses, OptionalParentheses,
 };
+use crate::other::commas::has_trailing_comma;
 use crate::prelude::*;
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Default)]
@@ -138,7 +139,27 @@ impl FormatNodeRule<ExprTuple> for FormatExprTuple {
             }
             [single] => match self.parentheses {
                 TupleParentheses::Preserve if !is_parenthesized => {
-                    write!(f, [single.format(), token(",")])
+                    single.format().fmt(f)?;
+                    // The `TupleParentheses::Preserve` is only set by subscript expression
+                    // formatting. With PEP 646, a single element starred expression in the slice
+                    // position of a subscript expression is actually a tuple expression. For
+                    // example:
+                    //
+                    // ```python
+                    // data[*x]
+                    // #    ^^ single element tuple expression without a trailing comma
+                    //
+                    // data[*x,]
+                    // #    ^^^ single element tuple expression with a trailing comma
+                    // ```
+                    //
+                    //
+                    // This means that the formatter should only add a trailing comma if there is
+                    // one already.
+                    if has_trailing_comma(TextRange::new(single.end(), item.end()), f.context()) {
+                        token(",").fmt(f)?;
+                    }
+                    Ok(())
                 }
                 _ =>
                 // A single element tuple always needs parentheses and a trailing comma, except when inside of a subscript

--- a/crates/ruff_python_formatter/src/other/commas.rs
+++ b/crates/ruff_python_formatter/src/other/commas.rs
@@ -9,20 +9,23 @@ use crate::MagicTrailingComma;
 /// should be respected).
 pub(crate) fn has_magic_trailing_comma(range: TextRange, context: &PyFormatContext) -> bool {
     match context.options().magic_trailing_comma() {
-        MagicTrailingComma::Respect => {
-            let first_token = SimpleTokenizer::new(context.source(), range)
-                .skip_trivia()
-                // Skip over any closing parentheses belonging to the expression
-                .find(|token| token.kind() != SimpleTokenKind::RParen);
-
-            matches!(
-                first_token,
-                Some(SimpleToken {
-                    kind: SimpleTokenKind::Comma,
-                    ..
-                })
-            )
-        }
+        MagicTrailingComma::Respect => has_trailing_comma(range, context),
         MagicTrailingComma::Ignore => false,
     }
+}
+
+/// Returns `true` if the range ends with a trailing comma.
+pub(crate) fn has_trailing_comma(range: TextRange, context: &PyFormatContext) -> bool {
+    let first_token = SimpleTokenizer::new(context.source(), range)
+        .skip_trivia()
+        // Skip over any closing parentheses belonging to the expression
+        .find(|token| token.kind() != SimpleTokenKind::RParen);
+
+    matches!(
+        first_token,
+        Some(SimpleToken {
+            kind: SimpleTokenKind::Comma,
+            ..
+        })
+    )
 }

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__slice.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__slice.py.snap
@@ -116,6 +116,17 @@ self.assertEqual(
     suite._tests[0].id().split(".")[0],
     os.path.basename(os.getcwd()),
 )
+
+# PEP 646 introduced starred expression in indexes
+# https://peps.python.org/pep-0646/#change-1-star-expressions-in-indexes
+data[*x]
+data[*x,]
+data[
+    *x,
+]
+data[  # comment 1
+     *x,  # comment 2
+]  # comment 3
 ```
 
 ## Output
@@ -231,7 +242,13 @@ self.assertEqual(
     suite._tests[0].id().split(".")[0],
     os.path.basename(os.getcwd()),
 )
+
+# PEP 646 introduced starred expression in indexes
+# https://peps.python.org/pep-0646/#change-1-star-expressions-in-indexes
+data[*x]
+data[*x,]
+data[*x,]
+data[  # comment 1
+    *x,  # comment 2
+]  # comment 3
 ```
-
-
-

--- a/crates/ruff_python_formatter/tests/snapshots/format@statement__function.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@statement__function.py.snap
@@ -433,6 +433,12 @@ def function_with_one_argument_and_a_keyword_separator(
     *, argument: str
 ) -> ReallyReallyReallyReallyReallyReallyReallyReallyLongName:
     pass
+
+
+# PEP 646 introduced type var tuple in parameter annotation
+# https://peps.python.org/pep-0646/#change-2-args-as-a-typevartuple
+def function_with_variadic_generics(*args: *tuple[int]): ...
+def function_with_variadic_generics(*args: *tuple[int],): ...
 ```
 
 ## Output
@@ -1014,4 +1020,12 @@ def function_with_one_argument_and_a_keyword_separator(
     *, argument: str
 ) -> ReallyReallyReallyReallyReallyReallyReallyReallyLongName:
     pass
+
+
+# PEP 646 introduced type var tuple in parameter annotation
+# https://peps.python.org/pep-0646/#change-2-args-as-a-typevartuple
+def function_with_variadic_generics(*args: *tuple[int]): ...
+def function_with_variadic_generics(
+    *args: *tuple[int],
+): ...
 ```


### PR DESCRIPTION
## Summary

There have been some grammar changes in [PEP 646] which were not accounted for in the old parser. The new parser has been updated with the correct AST. This is the case when there's a starred expression inside a subscript expression like the following example:

```python
data[*x]
```

This gives us the AST where the slice element is actually a tuple expression with one element (starred expression) instead of just a starred expression. Now, the formatter's current behavior is to always add a trailing comma in a tuple with a single element.

This PR updates the formatter to use the "preserve" behavior in trailing comma as well. So, trailing comma will not be added in the above example and if there's a trailing comma in the above example, it'll be preserved. This retains the current behavior without the AST change.

[PEP 646]: https://peps.python.org/pep-0646/#change-1-star-expressions-in-indexes

## Test Plan

Run `cargo insta test -p ruff_python_formatter` and make sure there are no changes.