### PR TITLE
Add a script to fuzz the parser (courtesy of `pysource-codegen`)

### DIFF
--- a/crates/ruff_python_parser/scripts/fuzz_parser.py
+++ b/crates/ruff_python_parser/scripts/fuzz_parser.py
@@ -1,0 +1,214 @@
+"""
+Run the parser on randomly generated (but syntactically valid) Python source-code files.
+
+The following dependencies must be installed into a Python environment to run the script:
+- `pysource-codegen`
+- `pysource-minimize`
+- `termcolor`
+- A released version of `ruff` itself (only necessary if you pass the `--only-new-bugs` flag)
+
+Example invocations of the script:
+- Run the fuzzer using seeds 0, 1, 2, 78 and 93` to generate the code:
+  `python crates/ruff_python_parser/scripts/fuzz_parser.py 0-2 78 93`
+- Run the fuzzer concurrently using seeds in range 0-10 inclusive,
+  but only reporting bugs that are new on your branch:
+  `python crates/ruff_python_parser/scripts/fuzz_parser.py 0-10 --new-bugs-only`
+- Run the fuzzer concurrently on 10,000 different Python source-code files,
+  and only print a summary at the end:
+  `python crates/ruff_python_parser/scripts/fuzz_parser.py 1-10000 --quiet
+"""
+
+from __future__ import annotations
+
+import argparse
+import concurrent.futures
+import subprocess
+from dataclasses import dataclass, KW_ONLY
+from typing import NewType
+
+from pysource_codegen import generate as generate_random_code
+from pysource_minimize import minimize as minimize_repro
+from termcolor import colored
+
+MinimizedSourceCode = NewType("MinimizedSourceCode", str)
+Seed = NewType("Seed", int)
+
+
+def run_ruff(executable_args: list[str], code: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        executable_args + ["check", "--select=E999", "--no-cache", "-"],
+        capture_output=True,
+        text=True,
+        input=code,
+    )
+
+
+def contains_bug(code: str, *, only_new_bugs: bool = False) -> bool:
+    """Return True if the code triggers a parser error and False otherwise.
+
+    If `only_new_bugs` is set to `True`,
+    the function also runs an installed version of Ruff on the same source code,
+    and only returns `True` if the bug appears on the branch you have currently
+    checked out but *not* in the latest release.
+    """
+    new_result = run_ruff(["cargo", "run", "--release", "--"], code)
+    if not only_new_bugs:
+        return new_result.returncode != 0
+    if new_result.returncode == 0:
+        return False
+    old_result = run_ruff(["ruff"], code)
+    return old_result.returncode == 0
+
+
+@dataclass
+class FuzzResult:
+    seed: Seed
+    maybe_bug: MinimizedSourceCode | None
+
+    def print_description(self) -> None:
+        if self.maybe_bug:
+            print(colored(f"Ran fuzzer on seed {self.seed}", "red"))
+            print(colored("The following code triggers a bug:", "red"))
+            print()
+            print(self.maybe_bug)
+            print()
+        else:
+            print(colored(f"Ran fuzzer successfully on seed {self.seed}", "green"))
+
+
+def fuzz_code(seed: Seed, only_new_bugs: bool) -> FuzzResult:
+    """If we found a bug, return the minimized example.
+    If we didn't, return `None`.
+    """
+    code = generate_random_code(seed)
+    if contains_bug(code, only_new_bugs=only_new_bugs):
+        try:
+            new_code = minimize_repro(code, contains_bug)
+        except ValueError:
+            # `pysource_minimize.minimize()` sometimes raises `ValueError` internally.
+            # Just ignore it if so, and use the original generated code;
+            # minimizing the repro is a nice-to-have, but isn't crucial.
+            new_code = code
+        return FuzzResult(seed, MinimizedSourceCode(new_code))
+    return FuzzResult(seed, None)
+
+
+def run_fuzzer_concurrently(args: ResolvedCliArgs) -> list[FuzzResult]:
+    print(
+        f"Concurrently running the fuzzer on "
+        f"{len(args.seeds)} randomly generated source-code files..."
+    )
+    bugs: list[FuzzResult] = []
+    with concurrent.futures.ProcessPoolExecutor() as executor:
+        fuzz_result_futures = [
+            executor.submit(fuzz_code, seed, args.only_new_bugs) for seed in args.seeds
+        ]
+        for future in concurrent.futures.as_completed(fuzz_result_futures):
+            fuzz_result = future.result()
+            if not args.quiet:
+                fuzz_result.print_description()
+            if fuzz_result.maybe_bug:
+                bugs.append(fuzz_result)
+    return bugs
+
+
+def run_fuzzer_sequentially(args: ResolvedCliArgs) -> list[FuzzResult]:
+    print(
+        f"Sequentially running the fuzzer on "
+        f"{len(args.seeds)} randomly generated source-code files..."
+    )
+    bugs: list[FuzzResult] = []
+    for seed in args.seeds:
+        fuzz_result = fuzz_code(seed, only_new_bugs=args.only_new_bugs)
+        if not args.quiet:
+            fuzz_result.print_description()
+        if fuzz_result.maybe_bug:
+            bugs.append(fuzz_result)
+    return bugs
+
+
+def main(args: ResolvedCliArgs) -> None:
+    if args.only_new_bugs:
+        ruff_version = (
+            subprocess.run(
+                ["ruff", "--version"], text=True, capture_output=True, check=True
+            )
+            .stdout.strip()
+            .split(" ")[1]
+        )
+        print(
+            f"As you have selected `--only-new-bugs`, "
+            f"bugs will only be reported if they appear on your current branch "
+            f"but do *not* appear in `ruff=={ruff_version}"
+        )
+    if len(args.seeds) <= 5:
+        bugs = run_fuzzer_sequentially(args)
+    else:
+        bugs = run_fuzzer_concurrently(args)
+    if bugs:
+        print(colored("Bugs found in the following seeds:", "red"))
+        print(*(str(bug.seed) for bug in bugs))
+    else:
+        print(colored("No bugs found!", "green"))
+
+
+def parse_seed_argument(arg: str) -> int | range:
+    """Helper for argument parsing"""
+    if "-" in arg:
+        start, end = arg.split("-")
+        return range(int(start), int(end) + 1)
+    return int(arg)
+
+
+@dataclass
+class ResolvedCliArgs:
+    seeds: list[Seed]
+    _: KW_ONLY
+    only_new_bugs: bool
+    quiet: bool
+
+
+def parse_args() -> ResolvedCliArgs:
+    """Parse command-line arguments"""
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawTextHelpFormatter
+    )
+    parser.add_argument(
+        "seeds",
+        type=parse_seed_argument,
+        nargs="+",
+        help="Either a single seed, or an inclusive range of seeds in the format `0-5`",
+    )
+    parser.add_argument(
+        "--only-new-bugs",
+        action="store_true",
+        help=(
+            "Only report bugs if they exist on the current branch, "
+            "but *didn't* exist on the released version of Ruff "
+            "installed into the Python environment we're running in"
+        ),
+    )
+    parser.add_argument(
+        "--quiet",
+        action="store_true",
+        help="Print fewer things to the terminal while running the fuzzer",
+    )
+    args = parser.parse_args()
+    seed_arguments: list[range | int] = args.seeds
+    seen_seeds: set[int] = set()
+    for arg in seed_arguments:
+        if isinstance(arg, int):
+            seen_seeds.add(arg)
+        else:
+            seen_seeds.update(arg)
+    return ResolvedCliArgs(
+        sorted(map(Seed, seen_seeds)),
+        only_new_bugs=args.only_new_bugs,
+        quiet=args.quiet,
+    )
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    main(args)


### PR DESCRIPTION
## Summary

This PR adds a script that can be used to fuzz the parser against randomly generated, syntactically correct Python source-code files.

## Test Plan

I reverted the `crates/ruff_python_parser` directory back to how it was as of https://github.com/astral-sh/ruff/commit/13ffb5bc1936493816f01fb5583359e3d8fffca7 (in order to deliberately reintroduce some parser bugs), then ran the script several times with various invocations. Example output with the bugs reintroduced:

<details>

```
(ruff) (add-fuzzing-script)⚡ % python crates/ruff_python_parser/scripts/fuzz.py 0-6 50 100-200                                                                                                         ~/dev/ruff
Concurrently running the fuzzer on 109 randomly generated source-code files...
Ran fuzzer successfully on seed 5
Ran fuzzer successfully on seed 1
Ran fuzzer successfully on seed 104
Ran fuzzer successfully on seed 0
Ran fuzzer successfully on seed 2
Ran fuzzer successfully on seed 3
Ran fuzzer successfully on seed 105
Ran fuzzer successfully on seed 101
Ran fuzzer successfully on seed 4
Ran fuzzer successfully on seed 103
Ran fuzzer successfully on seed 102
Ran fuzzer successfully on seed 100
Ran fuzzer successfully on seed 50
Ran fuzzer successfully on seed 106
Ran fuzzer successfully on seed 107
Ran fuzzer successfully on seed 116
Ran fuzzer successfully on seed 109
Ran fuzzer successfully on seed 108
Ran fuzzer successfully on seed 111
Ran fuzzer successfully on seed 114
Ran fuzzer successfully on seed 110
Ran fuzzer successfully on seed 118
Ran fuzzer successfully on seed 117
Ran fuzzer successfully on seed 113
Ran fuzzer successfully on seed 112
Ran fuzzer successfully on seed 119
Ran fuzzer successfully on seed 115
Ran fuzzer successfully on seed 120
Ran fuzzer successfully on seed 121
Ran fuzzer successfully on seed 124
Ran fuzzer successfully on seed 126
Ran fuzzer successfully on seed 122
Ran fuzzer successfully on seed 125
Ran fuzzer successfully on seed 129
Ran fuzzer successfully on seed 131
Ran fuzzer successfully on seed 127
Ran fuzzer successfully on seed 123
Ran fuzzer successfully on seed 133
Ran fuzzer successfully on seed 130
Ran fuzzer successfully on seed 135
Ran fuzzer successfully on seed 132
Ran fuzzer successfully on seed 128
Ran fuzzer successfully on seed 136
Ran fuzzer successfully on seed 138
Ran fuzzer successfully on seed 137
Ran fuzzer successfully on seed 134
Ran fuzzer successfully on seed 139
Ran fuzzer successfully on seed 140
Ran fuzzer successfully on seed 143
Ran fuzzer successfully on seed 142
Ran fuzzer successfully on seed 141
Ran fuzzer successfully on seed 150
Ran fuzzer successfully on seed 145
Ran fuzzer successfully on seed 144
Ran fuzzer successfully on seed 147
Ran fuzzer successfully on seed 148
Ran fuzzer successfully on seed 153
Ran fuzzer successfully on seed 154
Ran fuzzer successfully on seed 149
Ran fuzzer successfully on seed 151
Ran fuzzer successfully on seed 158
Ran fuzzer successfully on seed 160
Ran fuzzer successfully on seed 156
Ran fuzzer successfully on seed 159
Ran fuzzer successfully on seed 155
Ran fuzzer successfully on seed 157
Ran fuzzer successfully on seed 161
Ran fuzzer successfully on seed 163
Ran fuzzer successfully on seed 162
Ran fuzzer successfully on seed 165
Ran fuzzer successfully on seed 164
Ran fuzzer successfully on seed 166
Ran fuzzer successfully on seed 170
Ran fuzzer successfully on seed 167
Ran fuzzer successfully on seed 168
Ran fuzzer successfully on seed 171
Ran fuzzer successfully on seed 169
Ran fuzzer successfully on seed 175
Ran fuzzer successfully on seed 172
Ran fuzzer successfully on seed 173
Ran fuzzer successfully on seed 180
Ran fuzzer successfully on seed 174
Ran fuzzer successfully on seed 178
Ran fuzzer successfully on seed 181
Ran fuzzer successfully on seed 182
Ran fuzzer successfully on seed 177
Ran fuzzer successfully on seed 183
Ran fuzzer successfully on seed 179
Ran fuzzer successfully on seed 176
Ran fuzzer successfully on seed 186
Ran fuzzer successfully on seed 188
Ran fuzzer successfully on seed 190
Ran fuzzer successfully on seed 187
Ran fuzzer successfully on seed 184
Ran fuzzer successfully on seed 189
Ran fuzzer successfully on seed 194
Ran fuzzer successfully on seed 185
Ran fuzzer successfully on seed 193
Ran fuzzer successfully on seed 195
Ran fuzzer successfully on seed 192
Ran fuzzer successfully on seed 191
Ran fuzzer successfully on seed 197
Ran fuzzer successfully on seed 199
Ran fuzzer successfully on seed 196
Ran fuzzer successfully on seed 198
Ran fuzzer on seed 6
The following code triggers a bug:

for name_3[name_1 > name_2] in name_4:
    pass

Ran fuzzer on seed 146
The following code triggers a bug:

with (name_3 async for name_1 in name_0) if name_5 else name_2:
    pass

Ran fuzzer on seed 152
The following code triggers a bug:

for name_2[name_4 not in name_5] in ():
    pass

Ran fuzzer on seed 200
The following code triggers a bug:

with (name_4 if name_2 else name_5) and name_0:
    pass

Bugs found in the following seeds:
6 146 152 200
```

</details>

Screenshot to show how it looks with colour:

<details>

![image](https://github.com/astral-sh/ruff/assets/66076021/9d637796-a5f5-4c44-99c4-817ab86bee99)

</details>