### PR TITLE
Allow `NoReturn`-like functions for `__str__`, `__len__`, etc.

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pylint/invalid_return_type_bytes.py
+++ b/crates/ruff_linter/resources/test/fixtures/pylint/invalid_return_type_bytes.py
@@ -21,12 +21,6 @@ class BytesNoReturn:
         print("ruff")  # [invalid-bytes-return]
 
 
-class BytesWrongRaise:
-    def __bytes__(self):
-        print("raise some error")
-        raise NotImplementedError  # [invalid-bytes-return]
-
-
 # TODO: Once Ruff has better type checking
 def return_bytes():
     return "some string"
@@ -62,4 +56,10 @@ class Bytes4:
 
 class Bytes5:
     def __bytes__(self):
+        raise NotImplementedError
+
+
+class Bytes6:
+    def __bytes__(self):
+        print("raise some error")
         raise NotImplementedError

--- a/crates/ruff_linter/resources/test/fixtures/pylint/invalid_return_type_length.py
+++ b/crates/ruff_linter/resources/test/fixtures/pylint/invalid_return_type_length.py
@@ -26,12 +26,6 @@ class LengthNegative:
         return -42  # [invalid-length-return]
 
 
-class LengthWrongRaise:
-    def __len__(self):
-        print("raise some error")
-        raise NotImplementedError  # [invalid-length-return]
-
-
 # TODO: Once Ruff has better type checking
 def return_int():
     return "3"
@@ -67,4 +61,10 @@ class Length4:
 
 class Length5:
     def __len__(self):
+        raise NotImplementedError
+
+
+class Length6:
+    def __len__(self):
+        print("raise some error")
         raise NotImplementedError

--- a/crates/ruff_linter/resources/test/fixtures/pylint/invalid_return_type_str.py
+++ b/crates/ruff_linter/resources/test/fixtures/pylint/invalid_return_type_str.py
@@ -47,3 +47,14 @@ class Str2:
 
 class Str3:
     def __str__(self): ...
+
+
+class Str4:
+    def __str__(self):
+        raise RuntimeError("__str__ not allowed")
+
+
+class Str5:
+    def __str__(self):
+        if x > 0:
+            raise RuntimeError("__str__ not allowed")

--- a/crates/ruff_linter/resources/test/fixtures/pylint/invalid_return_type_str.py
+++ b/crates/ruff_linter/resources/test/fixtures/pylint/invalid_return_type_str.py
@@ -55,6 +55,6 @@ class Str4:
 
 
 class Str5:
-    def __str__(self):
+    def __str__(self):  # PLE0307 (returns None if x <= 0)
         if x > 0:
             raise RuntimeError("__str__ not allowed")

--- a/crates/ruff_linter/src/rules/pylint/rules/invalid_bytes_return.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/invalid_bytes_return.rs
@@ -5,6 +5,7 @@ use ruff_python_ast::identifier::Identifier;
 use ruff_python_ast::visitor::Visitor;
 use ruff_python_ast::{self as ast};
 use ruff_python_semantic::analyze::function_type::is_stub;
+use ruff_python_semantic::analyze::terminal::Terminal;
 use ruff_python_semantic::analyze::type_inference::{PythonType, ResolvedPythonType};
 use ruff_text_size::Ranged;
 
@@ -43,7 +44,7 @@ impl Violation for InvalidBytesReturnType {
     }
 }
 
-/// E0308
+/// PLE0308
 pub(crate) fn invalid_bytes_return(checker: &mut Checker, function_def: &ast::StmtFunctionDef) {
     if function_def.name.as_str() != "__bytes__" {
         return;
@@ -57,18 +58,28 @@ pub(crate) fn invalid_bytes_return(checker: &mut Checker, function_def: &ast::St
         return;
     }
 
+    // Determine the terminal behavior (i.e., implicit return, no return, etc.).
+    let terminal = Terminal::from_function(function_def);
+
+    // If every control flow path raises an exception, ignore the function.
+    if terminal == Terminal::Raise {
+        return;
+    }
+
+    // If there are no return statements, add a diagnostic.
+    if terminal == Terminal::Implicit {
+        checker.diagnostics.push(Diagnostic::new(
+            InvalidBytesReturnType,
+            function_def.identifier(),
+        ));
+        return;
+    }
+
     let returns = {
         let mut visitor = ReturnStatementVisitor::default();
         visitor.visit_body(&function_def.body);
         visitor.returns
     };
-
-    if returns.is_empty() {
-        checker.diagnostics.push(Diagnostic::new(
-            InvalidBytesReturnType,
-            function_def.identifier(),
-        ));
-    }
 
     for stmt in returns {
         if let Some(value) = stmt.value.as_deref() {

--- a/crates/ruff_linter/src/rules/pylint/rules/invalid_length_return.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/invalid_length_return.rs
@@ -5,6 +5,7 @@ use ruff_python_ast::identifier::Identifier;
 use ruff_python_ast::visitor::Visitor;
 use ruff_python_ast::{self as ast, Expr};
 use ruff_python_semantic::analyze::function_type::is_stub;
+use ruff_python_semantic::analyze::terminal::Terminal;
 use ruff_python_semantic::analyze::type_inference::{NumberLike, PythonType, ResolvedPythonType};
 use ruff_text_size::Ranged;
 
@@ -63,18 +64,28 @@ pub(crate) fn invalid_length_return(checker: &mut Checker, function_def: &ast::S
         return;
     }
 
+    // Determine the terminal behavior (i.e., implicit return, no return, etc.).
+    let terminal = Terminal::from_function(function_def);
+
+    // If every control flow path raises an exception, ignore the function.
+    if terminal == Terminal::Raise {
+        return;
+    }
+
+    // If there are no return statements, add a diagnostic.
+    if terminal == Terminal::Implicit {
+        checker.diagnostics.push(Diagnostic::new(
+            InvalidLengthReturnType,
+            function_def.identifier(),
+        ));
+        return;
+    }
+
     let returns = {
         let mut visitor = ReturnStatementVisitor::default();
         visitor.visit_body(&function_def.body);
         visitor.returns
     };
-
-    if returns.is_empty() {
-        checker.diagnostics.push(Diagnostic::new(
-            InvalidLengthReturnType,
-            function_def.identifier(),
-        ));
-    }
 
     for stmt in returns {
         if let Some(value) = stmt.value.as_deref() {

--- a/crates/ruff_linter/src/rules/pylint/rules/invalid_str_return.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/invalid_str_return.rs
@@ -5,6 +5,7 @@ use ruff_python_ast::identifier::Identifier;
 use ruff_python_ast::visitor::Visitor;
 use ruff_python_ast::{self as ast};
 use ruff_python_semantic::analyze::function_type::is_stub;
+use ruff_python_semantic::analyze::terminal::Terminal;
 use ruff_python_semantic::analyze::type_inference::{PythonType, ResolvedPythonType};
 use ruff_text_size::Ranged;
 
@@ -57,18 +58,28 @@ pub(crate) fn invalid_str_return(checker: &mut Checker, function_def: &ast::Stmt
         return;
     }
 
+    // Determine the terminal behavior (i.e., implicit return, no return, etc.).
+    let terminal = Terminal::from_function(function_def);
+
+    // If every control flow path raises an exception, ignore the function.
+    if terminal == Terminal::Raise {
+        return;
+    }
+
+    // If there are no return statements, add a diagnostic.
+    if terminal == Terminal::Implicit {
+        checker.diagnostics.push(Diagnostic::new(
+            InvalidStrReturnType,
+            function_def.identifier(),
+        ));
+        return;
+    }
+
     let returns = {
         let mut visitor = ReturnStatementVisitor::default();
         visitor.visit_body(&function_def.body);
         visitor.returns
     };
-
-    if returns.is_empty() {
-        checker.diagnostics.push(Diagnostic::new(
-            InvalidStrReturnType,
-            function_def.identifier(),
-        ));
-    }
 
     for stmt in returns {
         if let Some(value) = stmt.value.as_deref() {

--- a/crates/ruff_linter/src/rules/pylint/rules/non_slot_assignment.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/non_slot_assignment.rs
@@ -59,7 +59,7 @@ impl Violation for NonSlotAssignment {
     }
 }
 
-/// E0237
+/// PLE0237
 pub(crate) fn non_slot_assignment(checker: &mut Checker, class_def: &ast::StmtClassDef) {
     let semantic = checker.semantic();
 

--- a/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLE0303_invalid_return_type_length.py.snap
+++ b/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLE0303_invalid_return_type_length.py.snap
@@ -40,12 +40,3 @@ invalid_return_type_length.py:26:16: PLE0303 `__len__` does not return a non-neg
 26 |         return -42  # [invalid-length-return]
    |                ^^^ PLE0303
    |
-
-invalid_return_type_length.py:30:9: PLE0303 `__len__` does not return a non-negative integer
-   |
-29 | class LengthWrongRaise:
-30 |     def __len__(self):
-   |         ^^^^^^^ PLE0303
-31 |         print("raise some error")
-32 |         raise NotImplementedError  # [invalid-length-return]
-   |

--- a/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLE0307_invalid_return_type_str.py.snap
+++ b/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLE0307_invalid_return_type_str.py.snap
@@ -36,7 +36,7 @@ invalid_return_type_str.py:21:16: PLE0307 `__str__` does not return `str`
 invalid_return_type_str.py:58:9: PLE0307 `__str__` does not return `str`
    |
 57 | class Str5:
-58 |     def __str__(self):
+58 |     def __str__(self):  # PLE0307 (returns None if x <= 0)
    |         ^^^^^^^ PLE0307
 59 |         if x > 0:
 60 |             raise RuntimeError("__str__ not allowed")

--- a/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLE0307_invalid_return_type_str.py.snap
+++ b/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLE0307_invalid_return_type_str.py.snap
@@ -32,3 +32,12 @@ invalid_return_type_str.py:21:16: PLE0307 `__str__` does not return `str`
 21 |         return False
    |                ^^^^^ PLE0307
    |
+
+invalid_return_type_str.py:58:9: PLE0307 `__str__` does not return `str`
+   |
+57 | class Str5:
+58 |     def __str__(self):
+   |         ^^^^^^^ PLE0307
+59 |         if x > 0:
+60 |             raise RuntimeError("__str__ not allowed")
+   |

--- a/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLE0308_invalid_return_type_bytes.py.snap
+++ b/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLE0308_invalid_return_type_bytes.py.snap
@@ -32,12 +32,3 @@ invalid_return_type_bytes.py:20:9: PLE0308 `__bytes__` does not return `bytes`
    |         ^^^^^^^^^ PLE0308
 21 |         print("ruff")  # [invalid-bytes-return]
    |
-
-invalid_return_type_bytes.py:25:9: PLE0308 `__bytes__` does not return `bytes`
-   |
-24 | class BytesWrongRaise:
-25 |     def __bytes__(self):
-   |         ^^^^^^^^^ PLE0308
-26 |         print("raise some error")
-27 |         raise NotImplementedError  # [invalid-bytes-return]
-   |


### PR DESCRIPTION
## Summary

If the method always raises, we shouldn't raise a diagnostic for "returning a value of the wrong type".

Closes https://github.com/astral-sh/ruff/issues/11016.
