### PR TITLE
[UP031] When encountering `"%s" % var` offer unsafe fix

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP031_0.py
+++ b/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP031_0.py
@@ -129,3 +129,10 @@ t1 = (x,)
 t2 = (x,y)
 "%s" % t2
 # UP031: deref t2 to n-tuple, this is a bug
+
+# UP031 (no longer false negatives)
+'Hello %s' % bar
+
+'Hello %s' % bar.baz
+
+'Hello %s' % bar['bop']

--- a/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP031_0.py
+++ b/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP031_0.py
@@ -118,19 +118,7 @@ path = "%s-%s-%s.pem" % (
     hexlify(cert.fingerprint(hashes.SHA256())).decode("ascii")[0:8], # fingerprint prefix
 )
 
-s = set([x, y])
-"%s" % s
-# UP031: deref s to non-tuple, offer fix
-
-t1 = (x,)
-"%s" % t1
-# UP031: deref t1 to 1-tuple, offer fix
-
-t2 = (x,y)
-"%s" % t2
-# UP031: deref t2 to n-tuple, this is a bug
-
-# UP031 (no longer false negatives)
+# UP031 (no longer false negatives; now offer potentially unsafe fixes)
 'Hello %s' % bar
 
 'Hello %s' % bar.baz

--- a/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP031_0.py
+++ b/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP031_0.py
@@ -117,3 +117,15 @@ path = "%s-%s-%s.pem" % (
     cert.not_valid_after.date().isoformat().replace("-", ""), # expiration date
     hexlify(cert.fingerprint(hashes.SHA256())).decode("ascii")[0:8], # fingerprint prefix
 )
+
+s = set([x, y])
+"%s" % s
+# UP031: deref s to non-tuple, offer fix
+
+t1 = (x,)
+"%s" % t1
+# UP031: deref t1 to 1-tuple, offer fix
+
+t2 = (x,y)
+"%s" % t2
+# UP031: deref t2 to n-tuple, this is a bug

--- a/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP031_1.py
+++ b/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP031_1.py
@@ -32,13 +32,3 @@ pytest.param('"%8s" % (None,)', id="unsafe width-string conversion"),
 "%(1)s" % {1: 2, "1": 2}
 
 "%(and)s" % {"and": 2}
-
-# OK (arguably false negatives)
-'Hello %s' % bar
-
-'Hello %s' % bar.baz
-
-'Hello %s' % bar['bop']
-
-"%s" % zzz
-# OK: unable to deref zzz

--- a/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP031_1.py
+++ b/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP031_1.py
@@ -39,3 +39,6 @@ pytest.param('"%8s" % (None,)', id="unsafe width-string conversion"),
 'Hello %s' % bar.baz
 
 'Hello %s' % bar['bop']
+
+"%s" % zzz
+# OK: unable to deref zzz

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/printf_string_formatting.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/printf_string_formatting.rs
@@ -63,6 +63,8 @@ use crate::rules::pyupgrade::helpers::curly_escape;
 /// print("%s" % val)  # "1"
 /// print("{}".format(val))  # "(1,)"
 /// ```
+/// In most cases, where `val` is not a literal that our analysis can locate,
+/// no fix will be offered (but in these specific examples, a fix exists).
 ///
 /// ## References
 /// - [Python documentation: `printf`-style String Formatting](https://docs.python.org/3/library/stdtypes.html#old-string-formatting)

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/printf_string_formatting.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/printf_string_formatting.rs
@@ -39,10 +39,10 @@ use crate::rules::pyupgrade::helpers::curly_escape;
 /// "{}, {}".format("Hello", "World")  # "Hello, World"
 /// ```
 ///
-/// ## Known problems
-/// This rule is unable to offer a fix in cases where the format string
-/// contains a single, generic format specifier (e.g. `%s`), and the right-hand side
-/// is an ambiguous expression.
+/// ## Fix safety
+/// In cases where the format string contains a single generic format specifier
+/// (e.g. `%s`), and the right-hand side is an ambiguous expression,
+/// we cannot offer a safe fix.
 ///
 /// For example, given:
 /// ```python
@@ -63,8 +63,6 @@ use crate::rules::pyupgrade::helpers::curly_escape;
 /// print("%s" % val)  # "1"
 /// print("{}".format(val))  # "(1,)"
 /// ```
-/// In most cases, where `val` is not a literal that our analysis can locate,
-/// no fix will be offered (but in these specific examples, a fix exists).
 ///
 /// ## References
 /// - [Python documentation: `printf`-style String Formatting](https://docs.python.org/3/library/stdtypes.html#old-string-formatting)

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/printf_string_formatting.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/printf_string_formatting.rs
@@ -28,6 +28,16 @@ use crate::rules::pyupgrade::helpers::curly_escape;
 /// the newer `str.format` and f-strings constructs over `printf`-style string
 /// formatting.
 ///
+/// ## Example
+/// ```python
+/// "%s, %s" % ("Hello", "World")  # "Hello, World"
+/// ```
+///
+/// Use instead:
+/// ```python
+/// "{}, {}".format("Hello", "World")  # "Hello, World"
+/// ```
+///
 /// ## Known problems
 /// This rule is unable to offer a fix in cases where the format string
 /// contains a single, generic format specifier (e.g. `%s`), and the right-hand side
@@ -51,16 +61,6 @@ use crate::rules::pyupgrade::helpers::curly_escape;
 /// val = (1,)
 /// print("%s" % val)  # "1"
 /// print("{}".format(val))  # "(1,)"
-/// ```
-///
-/// ## Example
-/// ```python
-/// "%s, %s" % ("Hello", "World")  # "Hello, World"
-/// ```
-///
-/// Use instead:
-/// ```python
-/// "{}, {}".format("Hello", "World")  # "Hello, World"
 /// ```
 ///
 /// ## References

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/printf_string_formatting.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/printf_string_formatting.rs
@@ -325,20 +325,19 @@ fn clean_params_variable<'a>(checker: &mut Checker, right: &Expr) -> Option<Cow<
             }
             // 1-tuple
             Expr::Tuple(ast::ExprTuple { elts, .. }) if 1 == elts.len() => {
-                return Some(Cow::Owned(format!("({}[0])", rt)));
+                return Some(Cow::Owned(format!("({rt}[0])")));
             }
             // non-tuple
             _ => {
-                return Some(Cow::Owned(format!("({})", rt)));
+                return Some(Cow::Owned(format!("({rt})")));
             }
         }
     }
     // when find_binding_value doesn't work, fall back to offering a fix only for non-tuples
     if analyze::typing::is_tuple(binding, semantic) {
         return None;
-    } else {
-        return Some(Cow::Owned(format!("({})", rt)));
     }
+    return Some(Cow::Owned(format!("({rt})")));
 }
 
 /// Returns `true` if the sequence of [`PercentFormatPart`] indicate that an

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/printf_string_formatting.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/printf_string_formatting.rs
@@ -10,7 +10,6 @@ use ruff_python_literal::cformat::{
     CConversionFlags, CFormatPart, CFormatPrecision, CFormatQuantity, CFormatString,
 };
 use ruff_python_parser::{lexer, AsMode, Tok};
-use ruff_python_semantic::analyze;
 use ruff_python_stdlib::identifiers::is_identifier;
 use ruff_source_file::Locator;
 use ruff_text_size::{Ranged, TextRange};
@@ -289,55 +288,6 @@ fn clean_params_dictionary(right: &Expr, locator: &Locator, stylist: &Stylist) -
     Some(contents)
 }
 
-/// (In the case where the format string has only a single %-placeholder) and the righthand operand
-/// to % is a variable, try to offer a fix.
-///
-/// If the variable is not a tuple, then offer `({})`.
-/// ```python
-/// x = set(["hi", "hello"])
-/// print("%s" % x)
-/// print("{}".format(x))
-/// ```
-///
-/// If the variable is a 1-tuple, then offer `({}[0])`.
-/// ```python
-/// x = (1,)
-/// print("%s" % x)
-/// print("{}".format(x[0]))
-/// ```
-///
-/// If the variable is an n-tuple, the user has a bug in their code. Offer no fix.
-fn clean_params_variable<'a>(checker: &mut Checker, right: &Expr) -> Option<Cow<'a, str>> {
-    let Expr::Name(ast::ExprName { id, .. }) = right else {
-        return None;
-    };
-    let semantic = checker.semantic();
-    let binding_id = semantic.lookup_symbol(id.as_str())?;
-    let binding = semantic.binding(binding_id);
-    let rt = checker.locator().slice(right);
-    if let Some(expr) = analyze::typing::find_binding_value(binding, semantic) {
-        match expr {
-            // n-tuple
-            Expr::Tuple(ast::ExprTuple { elts, .. }) if 1 < elts.len() => {
-                return None;
-            }
-            // 1-tuple
-            Expr::Tuple(ast::ExprTuple { elts, .. }) if 1 == elts.len() => {
-                return Some(Cow::Owned(format!("({rt}[0])")));
-            }
-            // non-tuple
-            _ => {
-                return Some(Cow::Owned(format!("({rt})")));
-            }
-        }
-    }
-    // when find_binding_value doesn't work, fall back to offering a fix only for non-tuples
-    if analyze::typing::is_tuple(binding, semantic) {
-        return None;
-    }
-    return Some(Cow::Owned(format!("({rt})")));
-}
-
 /// Returns `true` if the sequence of [`PercentFormatPart`] indicate that an
 /// [`Expr`] can be converted.
 fn convertible(format_string: &CFormatString, params: &Expr) -> bool {
@@ -476,17 +426,18 @@ pub(crate) fn printf_string_formatting(checker: &mut Checker, expr: &Expr, right
                 // If we have multiple fields, but no named fields, assume the right-hand side is a
                 // tuple.
                 Cow::Owned(format!("(*{})", checker.locator().slice(right)))
-            } else if let Some(cow) = clean_params_variable(checker, right) {
-                // With only one field, if we have a variable we can try to deref it to handle a
-                // few cases.
-                cow
             } else {
-                // Otherwise we might have an attribute/subscript/call or a variable that we were
-                // unable to deref, so emit a diagnostic with no fix.
-                checker
-                    .diagnostics
-                    .push(Diagnostic::new(PrintfStringFormatting, expr.range()));
-                return;
+                // Otherwise, if we have a single field, we can't make any assumptions about the
+                // right-hand side. It _could_ be a tuple, but it could also be a single value,
+                // and we can't differentiate between them.
+                // For example:
+                // ```python
+                // x = (1,)
+                // print("%s" % x)
+                // print("{}".format(x))
+                // ```
+                // So we offer an unsafe fix:
+                Cow::Owned(format!("({})", checker.locator().slice(right)))
             }
         }
         Expr::Tuple(_) => clean_params_tuple(right, checker.locator()),

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/printf_string_formatting.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/printf_string_formatting.rs
@@ -483,7 +483,10 @@ pub(crate) fn printf_string_formatting(checker: &mut Checker, expr: &Expr, right
                 cow
             } else {
                 // Otherwise we might have an attribute/subscript/call or a variable that we were
-                // unable to deref.
+                // unable to deref, so emit a diagnostic with no fix.
+                checker
+                    .diagnostics
+                    .push(Diagnostic::new(PrintfStringFormatting, expr.range()));
                 return;
             }
         }

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/printf_string_formatting.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/printf_string_formatting.rs
@@ -19,7 +19,8 @@ use crate::checkers::ast::Checker;
 use crate::rules::pyupgrade::helpers::curly_escape;
 
 /// ## What it does
-/// Checks for `printf`-style string formatting.
+/// Checks for `printf`-style string formatting, and offers to replace it with
+/// `str.format` calls.
 ///
 /// ## Why is this bad?
 /// `printf`-style string formatting has a number of quirks, and leads to less
@@ -28,27 +29,28 @@ use crate::rules::pyupgrade::helpers::curly_escape;
 /// formatting.
 ///
 /// ## Known problems
-/// This rule is unable to detect cases in which the format string contains
-/// a single, generic format specifier (e.g. `%s`), and the right-hand side
+/// This rule is unable to offer a fix in cases where the format string
+/// contains a single, generic format specifier (e.g. `%s`), and the right-hand side
 /// is an ambiguous expression.
 ///
 /// For example, given:
 /// ```python
-/// "%s" % value
+/// "%s" % val
 /// ```
 ///
-/// `value` could be a single-element tuple, _or_ it could be a single value.
-/// Both of these would resolve to the same formatted string when using
-/// `printf`-style formatting, but _not_ when using f-strings:
+/// `val` could be a single-element tuple, _or_ a single value (not
+/// contained in a tuple). Both of these would resolve to the same
+/// formatted string when using `printf`-style formatting, but
+/// resolve differently when using f-strings:
 ///
 /// ```python
-/// value = 1
-/// print("%s" % value)  # "1"
-/// print("{}".format(value))  # "1"
+/// val = 1
+/// print("%s" % val)  # "1"
+/// print("{}".format(val))  # "1"
 ///
-/// value = (1,)
-/// print("%s" % value)  # "1"
-/// print("{}".format(value))  # "(1,)"
+/// val = (1,)
+/// print("%s" % val)  # "1"
+/// print("{}".format(val))  # "(1,)"
 /// ```
 ///
 /// ## Example

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP031_0.py.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP031_0.py.snap
@@ -926,6 +926,8 @@ UP031_0.py:115:8: UP031 [*] Use format specifiers instead of percent format
 118 | |     hexlify(cert.fingerprint(hashes.SHA256())).decode("ascii")[0:8], # fingerprint prefix
 119 | | )
     | |_^ UP031
+120 |   
+121 |   s = set([x, y])
     |
     = help: Replace with format specifiers
 
@@ -939,4 +941,89 @@ UP031_0.py:115:8: UP031 [*] Use format specifiers instead of percent format
 117 117 |     cert.not_valid_after.date().isoformat().replace("-", ""), # expiration date
 118 118 |     hexlify(cert.fingerprint(hashes.SHA256())).decode("ascii")[0:8], # fingerprint prefix
 
+UP031_0.py:122:1: UP031 [*] Use format specifiers instead of percent format
+    |
+121 | s = set([x, y])
+122 | "%s" % s
+    | ^^^^^^^^ UP031
+123 | # UP031: deref s to non-tuple, offer fix
+    |
+    = help: Replace with format specifiers
 
+ℹ Unsafe fix
+119 119 | )
+120 120 | 
+121 121 | s = set([x, y])
+122     |-"%s" % s
+    122 |+"{}".format(s)
+123 123 | # UP031: deref s to non-tuple, offer fix
+124 124 | 
+125 125 | t1 = (x,)
+
+UP031_0.py:126:1: UP031 [*] Use format specifiers instead of percent format
+    |
+125 | t1 = (x,)
+126 | "%s" % t1
+    | ^^^^^^^^^ UP031
+127 | # UP031: deref t1 to 1-tuple, offer fix
+    |
+    = help: Replace with format specifiers
+
+ℹ Unsafe fix
+123 123 | # UP031: deref s to non-tuple, offer fix
+124 124 | 
+125 125 | t1 = (x,)
+126     |-"%s" % t1
+    126 |+"{}".format(t1[0])
+127 127 | # UP031: deref t1 to 1-tuple, offer fix
+128 128 | 
+129 129 | t2 = (x,y)
+
+UP031_0.py:130:1: UP031 Use format specifiers instead of percent format
+    |
+129 | t2 = (x,y)
+130 | "%s" % t2
+    | ^^^^^^^^^ UP031
+131 | # UP031: deref t2 to n-tuple, this is a bug
+    |
+    = help: Replace with format specifiers
+
+UP031_0.py:134:1: UP031 [*] Use format specifiers instead of percent format
+    |
+133 | # UP031 (no longer false negatives)
+134 | 'Hello %s' % bar
+    | ^^^^^^^^^^^^^^^^ UP031
+135 | 
+136 | 'Hello %s' % bar.baz
+    |
+    = help: Replace with format specifiers
+
+ℹ Unsafe fix
+131 131 | # UP031: deref t2 to n-tuple, this is a bug
+132 132 | 
+133 133 | # UP031 (no longer false negatives)
+134     |-'Hello %s' % bar
+    134 |+'Hello {}'.format(bar)
+135 135 | 
+136 136 | 'Hello %s' % bar.baz
+137 137 | 
+
+UP031_0.py:136:1: UP031 Use format specifiers instead of percent format
+    |
+134 | 'Hello %s' % bar
+135 | 
+136 | 'Hello %s' % bar.baz
+    | ^^^^^^^^^^^^^^^^^^^^ UP031
+137 | 
+138 | 'Hello %s' % bar['bop']
+    |
+    = help: Replace with format specifiers
+
+UP031_0.py:138:1: UP031 Use format specifiers instead of percent format
+    |
+136 | 'Hello %s' % bar.baz
+137 | 
+138 | 'Hello %s' % bar['bop']
+    | ^^^^^^^^^^^^^^^^^^^^^^^ UP031
+    |
+    = help: Replace with format specifiers

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP031_0.py.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP031_0.py.snap
@@ -927,7 +927,7 @@ UP031_0.py:115:8: UP031 [*] Use format specifiers instead of percent format
 119 | | )
     | |_^ UP031
 120 |   
-121 |   s = set([x, y])
+121 |   # UP031 (no longer false negatives; now offer potentially unsafe fixes)
     |
     = help: Replace with format specifiers
 
@@ -943,87 +943,56 @@ UP031_0.py:115:8: UP031 [*] Use format specifiers instead of percent format
 
 UP031_0.py:122:1: UP031 [*] Use format specifiers instead of percent format
     |
-121 | s = set([x, y])
-122 | "%s" % s
-    | ^^^^^^^^ UP031
-123 | # UP031: deref s to non-tuple, offer fix
+121 | # UP031 (no longer false negatives; now offer potentially unsafe fixes)
+122 | 'Hello %s' % bar
+    | ^^^^^^^^^^^^^^^^ UP031
+123 | 
+124 | 'Hello %s' % bar.baz
     |
     = help: Replace with format specifiers
 
 ℹ Unsafe fix
 119 119 | )
 120 120 | 
-121 121 | s = set([x, y])
-122     |-"%s" % s
-    122 |+"{}".format(s)
-123 123 | # UP031: deref s to non-tuple, offer fix
-124 124 | 
-125 125 | t1 = (x,)
+121 121 | # UP031 (no longer false negatives; now offer potentially unsafe fixes)
+122     |-'Hello %s' % bar
+    122 |+'Hello {}'.format(bar)
+123 123 | 
+124 124 | 'Hello %s' % bar.baz
+125 125 | 
+
+UP031_0.py:124:1: UP031 [*] Use format specifiers instead of percent format
+    |
+122 | 'Hello %s' % bar
+123 | 
+124 | 'Hello %s' % bar.baz
+    | ^^^^^^^^^^^^^^^^^^^^ UP031
+125 | 
+126 | 'Hello %s' % bar['bop']
+    |
+    = help: Replace with format specifiers
+
+ℹ Unsafe fix
+121 121 | # UP031 (no longer false negatives; now offer potentially unsafe fixes)
+122 122 | 'Hello %s' % bar
+123 123 | 
+124     |-'Hello %s' % bar.baz
+    124 |+'Hello {}'.format(bar.baz)
+125 125 | 
+126 126 | 'Hello %s' % bar['bop']
 
 UP031_0.py:126:1: UP031 [*] Use format specifiers instead of percent format
     |
-125 | t1 = (x,)
-126 | "%s" % t1
-    | ^^^^^^^^^ UP031
-127 | # UP031: deref t1 to 1-tuple, offer fix
-    |
-    = help: Replace with format specifiers
-
-ℹ Unsafe fix
-123 123 | # UP031: deref s to non-tuple, offer fix
-124 124 | 
-125 125 | t1 = (x,)
-126     |-"%s" % t1
-    126 |+"{}".format(t1[0])
-127 127 | # UP031: deref t1 to 1-tuple, offer fix
-128 128 | 
-129 129 | t2 = (x,y)
-
-UP031_0.py:130:1: UP031 Use format specifiers instead of percent format
-    |
-129 | t2 = (x,y)
-130 | "%s" % t2
-    | ^^^^^^^^^ UP031
-131 | # UP031: deref t2 to n-tuple, this is a bug
-    |
-    = help: Replace with format specifiers
-
-UP031_0.py:134:1: UP031 [*] Use format specifiers instead of percent format
-    |
-133 | # UP031 (no longer false negatives)
-134 | 'Hello %s' % bar
-    | ^^^^^^^^^^^^^^^^ UP031
-135 | 
-136 | 'Hello %s' % bar.baz
-    |
-    = help: Replace with format specifiers
-
-ℹ Unsafe fix
-131 131 | # UP031: deref t2 to n-tuple, this is a bug
-132 132 | 
-133 133 | # UP031 (no longer false negatives)
-134     |-'Hello %s' % bar
-    134 |+'Hello {}'.format(bar)
-135 135 | 
-136 136 | 'Hello %s' % bar.baz
-137 137 | 
-
-UP031_0.py:136:1: UP031 Use format specifiers instead of percent format
-    |
-134 | 'Hello %s' % bar
-135 | 
-136 | 'Hello %s' % bar.baz
-    | ^^^^^^^^^^^^^^^^^^^^ UP031
-137 | 
-138 | 'Hello %s' % bar['bop']
-    |
-    = help: Replace with format specifiers
-
-UP031_0.py:138:1: UP031 Use format specifiers instead of percent format
-    |
-136 | 'Hello %s' % bar.baz
-137 | 
-138 | 'Hello %s' % bar['bop']
+124 | 'Hello %s' % bar.baz
+125 | 
+126 | 'Hello %s' % bar['bop']
     | ^^^^^^^^^^^^^^^^^^^^^^^ UP031
     |
     = help: Replace with format specifiers
+
+ℹ Unsafe fix
+123 123 | 
+124 124 | 'Hello %s' % bar.baz
+125 125 | 
+126     |-'Hello %s' % bar['bop']
+    126 |+'Hello {}'.format(bar['bop'])


### PR DESCRIPTION
Resolves #10187

<details>
<summary>Old PR description; accurate through commit e86dd7d; probably best to leave this fold closed</summary>

## Description of change

In the case of a printf-style format string with only one %-placeholder and a variable at right (e.g.  `"%s" % var`):

* The new behavior attempts to dereference the variable and then match on the bound expression to distinguish between a 1-tuple (fix), n-tuple (bug :bug:), or a non-tuple (fix). Dereferencing is via `analyze::typing::find_binding_value`.
* If the variable cannot be dereferenced, then the type-analysis routine is called to distinguish only tuple (no-fix) or non-tuple (fix). Type analysis is via `analyze::typing::is_tuple`.
* If any of the above fails, the rule still fires, but no fix is offered.

## Alternatives

* If the reviewers think that singling out the 1-tuple case is too complicated, I will remove that.
* The ecosystem results show that no new fixes are detected. So I could probably delete all the variable dereferencing code and code that tries to generate fixes, tbh.

## Changes to existing behavior

**All the previous rule-firings and fixes are unchanged except for** the "false negatives" in `crates/ruff_linter/resources/test/fixtures/pyupgrade/UP031_1.py`. Those previous "false negatives" are now true positives and so I moved them to `crates/ruff_linter/resources/test/fixtures/pyupgrade/UP031_0.py`.

<details>
<summary>Existing false negatives that are now true positives</summary>

```
crates/ruff_linter/resources/test/fixtures/pyupgrade/UP031_0.py:134:1: UP031 Use format specifiers instead of percent format
    |
133 | # UP031 (no longer false negatives)
134 | 'Hello %s' % bar
    | ^^^^^^^^^^^^^^^^ UP031
135 |
136 | 'Hello %s' % bar.baz
    |
    = help: Replace with format specifiers

crates/ruff_linter/resources/test/fixtures/pyupgrade/UP031_0.py:136:1: UP031 Use format specifiers instead of percent format
    |
134 | 'Hello %s' % bar
135 |
136 | 'Hello %s' % bar.baz
    | ^^^^^^^^^^^^^^^^^^^^ UP031
137 |
138 | 'Hello %s' % bar['bop']
    |
    = help: Replace with format specifiers

crates/ruff_linter/resources/test/fixtures/pyupgrade/UP031_0.py:138:1: UP031 Use format specifiers instead of percent format
    |
136 | 'Hello %s' % bar.baz
137 |
138 | 'Hello %s' % bar['bop']
    | ^^^^^^^^^^^^^^^^^^^^^^^ UP031
    |
    = help: Replace with format specifiers
```
One of them newly offers a fix.
```
 # UP031 (no longer false negatives)
-'Hello %s' % bar
+'Hello {}'.format(bar)
```
This fix occurs because the new code dereferences `bar` to where it was defined earlier in the file as a non-tuple:
```python
bar = {"bar": y}
```

---

</details>

## Behavior requiring new tests

Additionally, we now handle a few cases that we didn't previously test. These cases are when a string has a single %-placeholder and the righthand operand to the modulo operator is a variable **which can be dereferenced.** One of those was shown in the previous section (the "dereference non-tuple" case).

<details>
<summary>New cases handled</summary>

```
crates/ruff_linter/resources/test/fixtures/pyupgrade/UP031_0.py:126:1: UP031 [*] Use format specifiers instead of percent format
    |
125 | t1 = (x,)
126 | "%s" % t1
    | ^^^^^^^^^ UP031
127 | # UP031: deref t1 to 1-tuple, offer fix
    |
    = help: Replace with format specifiers

crates/ruff_linter/resources/test/fixtures/pyupgrade/UP031_0.py:130:1: UP031 Use format specifiers instead of percent format
    |
129 | t2 = (x,y)
130 | "%s" % t2
    | ^^^^^^^^^ UP031
131 | # UP031: deref t2 to n-tuple, this is a bug
    |
    = help: Replace with format specifiers
```
One of these offers a fix.
```
 t1 = (x,)
-"%s" % t1
+"{}".format(t1[0])
 # UP031: deref t1 to 1-tuple, offer fix
```
The other doesn't offer a fix because it's a bug.

---

</details>

---

</details>


## Changes to existing behavior

In the case of a string with a single %-placeholder and a single ambiguous righthand argument to the modulo operator, (e.g. `"%s" % var`) the rule now fires and offers a fix. We explain about this in the "fix safety" section of the updated documentation.


## Documentation changes

I swapped the order of the "known problems" and the "examples" sections so that the examples which describe the rule are first, before the exceptions to the rule are described. I also tweaked the language to be more explicit, as I had trouble understanding the documentation at first. The "known problems" section is now "fix safety" but the content is largely similar.

The diff of the documentation changes looks a little difficult unless you look at the individual commits. 