### PR TITLE
`ruff server`: fix Neovim setup guide command

### DIFF
--- a/crates/ruff_server/docs/setup/NEOVIM.md
+++ b/crates/ruff_server/docs/setup/NEOVIM.md
@@ -7,7 +7,7 @@
 1. Finally, add this to your `init.lua`:
 
 ```lua
-require('lspconfig').ruff.setup()
+require('lspconfig').ruff.setup {}
 ```
 
 See [`nvim-lspconfig`'s server configuration guide](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#ruff) for more details


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Fixes the Neovim setup guide command for `ruff server`. Note that
`lspconfig.*.setup` expects a table as its first argument, even if it is empty,
as a `nil` value causes an error.
