### PR TITLE
ENH: Bump `ruff` dependency versions to support the latest release of `v0.4.0` and Python 3.12

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,7 +55,7 @@ repos:
         pass_filenames: false # This makes it a lot faster
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.3.7
+    rev: v0.4.0
     hooks:
       - id: ruff-format
       - id: ruff

--- a/scripts/benchmarks/poetry.lock
+++ b/scripts/benchmarks/poetry.lock
@@ -128,14 +128,14 @@ files = [
 
 [[package]]
 name = "dill"
-version = "0.3.7"
+version = "0.3.8"
 description = "serialize all of Python"
 category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "dill-0.3.7-py3-none-any.whl", hash = "sha256:76b122c08ef4ce2eedcd4d1abd8e641114bfc6c2867f49f3c41facf65bf19f5e"},
-    {file = "dill-0.3.7.tar.gz", hash = "sha256:cc1c8b182eb3013e24bd475ff2e9295af86c1a38eb1aff128dac8962a9ce3c03"},
+    {file = "dill-0.3.8-py3-none-any.whl", hash = "sha256:c36ca9ffb54365bdd2f8eb3eff7d2a21237f8452b57ace88b1ac615b7e815bd7"},
+    {file = "dill-0.3.8.tar.gz", hash = "sha256:3ebe3c479ad625c4553aca177444d89b486b1d84982eeacded644afc0cf797ca"},
 ]
 
 [package.extras]


### PR DESCRIPTION
## Summary

With the release of [`v0.4.0`](https://github.com/astral-sh/ruff/releases/tag/v0.4.0) of `ruff`, I noticed that some of `ruff`'s dependencies were not updated to their latest versions.  The [`ruff-pre-commit`](https://github.com/astral-sh/ruff-pre-commit) package released [`v0.4.0`](https://github.com/astral-sh/ruff-pre-commit/releases/tag/v0.4.0) at the same time `ruff` was updated, but `ruff` still referenced `v0.3.7` of the package, not the newly updated version.  I updated the `ruff-pre-commit` reference to be `v0.4.0`.

In a similar light, I noticed that the version of the [`dill`](https://github.com/uqfoundation/dill) package being used was not the latest version.  I bumped `dill` from version `0.3.7` to `0.3.8`, which now [fully supports Python 3.12](https://github.com/uqfoundation/dill/releases/tag/0.3.8).

## Related Issues

Resolves #11024