### PR TITLE
Use empty range when there's "gap" in token source

### DIFF
--- a/crates/ruff_python_parser/resources/inline/err/node_range_with_gaps.py
+++ b/crates/ruff_python_parser/resources/inline/err/node_range_with_gaps.py
@@ -1,0 +1,3 @@
+def foo # comment
+def bar(): ...
+def baz

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@node_range_with_gaps.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@node_range_with_gaps.py.snap
@@ -1,0 +1,122 @@
+---
+source: crates/ruff_python_parser/tests/fixtures.rs
+input_file: crates/ruff_python_parser/resources/inline/err/node_range_with_gaps.py
+---
+## AST
+
+```
+Module(
+    ModModule {
+        range: 0..41,
+        body: [
+            FunctionDef(
+                StmtFunctionDef {
+                    range: 0..7,
+                    is_async: false,
+                    decorator_list: [],
+                    name: Identifier {
+                        id: "foo",
+                        range: 4..7,
+                    },
+                    type_params: None,
+                    parameters: Parameters {
+                        range: 7..7,
+                        posonlyargs: [],
+                        args: [],
+                        vararg: None,
+                        kwonlyargs: [],
+                        kwarg: None,
+                    },
+                    returns: None,
+                    body: [],
+                },
+            ),
+            FunctionDef(
+                StmtFunctionDef {
+                    range: 18..32,
+                    is_async: false,
+                    decorator_list: [],
+                    name: Identifier {
+                        id: "bar",
+                        range: 22..25,
+                    },
+                    type_params: None,
+                    parameters: Parameters {
+                        range: 25..27,
+                        posonlyargs: [],
+                        args: [],
+                        vararg: None,
+                        kwonlyargs: [],
+                        kwarg: None,
+                    },
+                    returns: None,
+                    body: [
+                        Expr(
+                            StmtExpr {
+                                range: 29..32,
+                                value: EllipsisLiteral(
+                                    ExprEllipsisLiteral {
+                                        range: 29..32,
+                                    },
+                                ),
+                            },
+                        ),
+                    ],
+                },
+            ),
+            FunctionDef(
+                StmtFunctionDef {
+                    range: 33..40,
+                    is_async: false,
+                    decorator_list: [],
+                    name: Identifier {
+                        id: "baz",
+                        range: 37..40,
+                    },
+                    type_params: None,
+                    parameters: Parameters {
+                        range: 40..40,
+                        posonlyargs: [],
+                        args: [],
+                        vararg: None,
+                        kwonlyargs: [],
+                        kwarg: None,
+                    },
+                    returns: None,
+                    body: [],
+                },
+            ),
+        ],
+    },
+)
+```
+## Errors
+
+  |
+1 | def foo # comment
+  |                  ^ Syntax Error: Expected '(', found newline
+2 | def bar(): ...
+3 | def baz
+  |
+
+
+  |
+1 | def foo # comment
+2 | def bar(): ...
+  | ^^^ Syntax Error: Expected ')', found 'def'
+3 | def baz
+  |
+
+
+  |
+1 | def foo # comment
+2 | def bar(): ...
+3 | def baz
+  |        ^ Syntax Error: Expected '(', found newline
+  |
+
+
+  |
+2 | def bar(): ...
+3 | def baz
+  |

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@unterminated_fstring_newline_recovery.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@unterminated_fstring_newline_recovery.py.snap
@@ -167,7 +167,7 @@ Module(
                                                         conversion: None,
                                                         format_spec: Some(
                                                             FStringFormatSpec {
-                                                                range: 43..43,
+                                                                range: 42..42,
                                                                 elements: [],
                                                             },
                                                         ),


### PR DESCRIPTION
## Summary

This fixes a bug where the parser would panic when there is a "gap" in
the token source.

What's a gap?

The reason it's `<=` instead of just `==` is because there could be whitespaces between
the two tokens. For example:

```python
#     last token end
#     | current token (newline) start
#     v v
def foo \n
#      ^
#      assume there's trailing whitespace here
```

Or, there could tokens that are considered "trivia" and thus aren't emitted by the token
source. These are comments and non-logical newlines. For example:

```python
#     last token end
#     v
def foo # comment\n
#                ^ current token (newline) start
```

In either of the above cases, there's a "gap" between the end of the last token and start
of the current token.

## Test Plan

Add test cases and update the snapshots.
