### PR TITLE
Select fewer ruff rules when linting Python files in `scripts/`

### DIFF
--- a/scripts/check_ecosystem.py
+++ b/scripts/check_ecosystem.py
@@ -444,7 +444,7 @@ async def main(
 
                     if matches is None:
                         # Handle case where there are no regex matches e.g.
-                        # +                 "?application=AIRFLOW&authenticator=TEST_AUTH&role=TEST_ROLE&warehouse=TEST_WAREHOUSE" # noqa: E501, ERA001
+                        # +                 "?application=AIRFLOW&authenticator=TEST_AUTH&role=TEST_ROLE&warehouse=TEST_WAREHOUSE" # noqa: E501
                         # Which was found in local testing
                         continue
 

--- a/scripts/pyproject.toml
+++ b/scripts/pyproject.toml
@@ -11,17 +11,19 @@ line-length = 88
 line-length = 88
 
 [tool.ruff.lint]
-select = ["ALL"]
-ignore = [
-  "C901",  # McCabe complexity
-  "D",     # pydocstyle
-  "PL",    # pylint
-  "S",     # bandit
-  "G",     # flake8-logging
-  "T",     # flake8-print
-  "FBT",   # flake8-boolean-trap
-  "PERF",  # perflint
-  "ANN401",
+select = [
+  "E",   # pycodestyle (error)
+  "F",   # pyflakes
+  "B",   # bugbear
+  "B9",
+  "C4",  # flake8-comprehensions
+  "SIM", # flake8-simplify
+  "I",   # isort
+  "UP",  # pyupgrade
+  "PIE", # flake8-pie
+  "PGH", # pygrep-hooks
+  "PYI", # flake8-pyi
+  "RUF",
 ]
 
 [tool.ruff.lint.isort]


### PR DESCRIPTION
Several of the rules we currently have selected are too pedantic for my tastes (and some I frankly disagree with!)