### PR TITLE
[flake8-bugbear] Document explicitly disabling strict zip (`B905`)

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/zip_without_explicit_strict.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/zip_without_explicit_strict.rs
@@ -17,7 +17,8 @@ use crate::fix::edits::add_argument;
 /// iterable. This can lead to subtle bugs.
 ///
 /// Use the `strict` parameter to raise a `ValueError` if the iterables are of
-/// non-uniform length.
+/// non-uniform length. If the iterables are intentionally different lengths the
+/// parameter should be explicitly set to False.
 ///
 /// ## Example
 /// ```python


### PR DESCRIPTION
Occasionally you intentionally have iterables of differing lengths. The rule permits this by explicitly adding `strict=False`, but this was not documented.

<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

The rule does not currently document how to avoid it when having differing length iterables is intentional. This PR adds that to the rule documentation.

## Test Plan

<!-- How was it tested? -->

Small documentation change, untested.