### PR TITLE
Reduce size of Stmt from 144 to 120 bytes

### DIFF
--- a/crates/ruff_linter/src/checkers/ast/analyze/statement.rs
+++ b/crates/ruff_linter/src/checkers/ast/analyze/statement.rs
@@ -158,7 +158,7 @@ pub(crate) fn statement(stmt: &Stmt, checker: &mut Checker) {
                     decorator_list,
                     returns.as_ref().map(AsRef::as_ref),
                     parameters,
-                    type_params.as_ref(),
+                    type_params.as_deref(),
                 );
             }
             if checker.source_type.is_stub() {

--- a/crates/ruff_python_ast/src/nodes.rs
+++ b/crates/ruff_python_ast/src/nodes.rs
@@ -181,7 +181,7 @@ pub struct StmtFunctionDef {
     pub is_async: bool,
     pub decorator_list: Vec<Decorator>,
     pub name: Identifier,
-    pub type_params: Option<TypeParams>,
+    pub type_params: Option<Box<TypeParams>>,
     pub parameters: Box<Parameters>,
     pub returns: Option<Box<Expr>>,
     pub body: Vec<Stmt>,
@@ -4171,8 +4171,8 @@ mod tests {
     #[test]
     #[cfg(target_pointer_width = "64")]
     fn size() {
-        assert!(std::mem::size_of::<Stmt>() <= 144);
-        assert!(std::mem::size_of::<StmtFunctionDef>() <= 144);
+        assert!(std::mem::size_of::<Stmt>() <= 120);
+        assert!(std::mem::size_of::<StmtFunctionDef>() <= 120);
         assert!(std::mem::size_of::<StmtClassDef>() <= 104);
         assert!(std::mem::size_of::<StmtTry>() <= 112);
         assert!(std::mem::size_of::<Mod>() <= 32);

--- a/crates/ruff_python_formatter/src/statement/clause.rs
+++ b/crates/ruff_python_formatter/src/statement/clause.rs
@@ -108,7 +108,7 @@ impl<'a> ClauseHeader<'a> {
                 returns,
                 body: _,
             }) => {
-                if let Some(type_params) = type_params.as_ref() {
+                if let Some(type_params) = type_params.as_deref() {
                     visit(type_params, visitor);
                 }
                 visit(parameters.as_ref(), visitor);

--- a/crates/ruff_python_parser/src/parser/statement.rs
+++ b/crates/ruff_python_parser/src/parser/statement.rs
@@ -1738,7 +1738,7 @@ impl<'src> Parser<'src> {
 
         ast::StmtFunctionDef {
             name,
-            type_params,
+            type_params: type_params.map(Box::new),
             parameters: Box::new(parameters),
             body,
             decorator_list,


### PR DESCRIPTION
## Summary

I happened to notice that we box `TypeParams` on `StmtClassDef` but not on `StmtFunctionDef` and wondered why, since `StmtFunctionDef` is bigger and sets the size of `Stmt`.

@charliermarsh found that at the time we started boxing type params on classes, classes were the largest statement type (see #6275), but that's no longer true.

So boxing type-params also on functions reduces the overall size of `Stmt`.

## Test Plan

The `<=` size tests are a bit irritating (since their failure doesn't tell you the actual size), but I manually confirmed that the size is actually 120 now.