### PR TITLE
[`pygrep_hooks`] Move `blanket-noqa` to noqa checker (`PGH004`)

### DIFF
--- a/crates/ruff_linter/src/checkers/noqa.rs
+++ b/crates/ruff_linter/src/checkers/noqa.rs
@@ -14,6 +14,7 @@ use crate::noqa;
 use crate::noqa::{Directive, FileExemption, NoqaDirectives, NoqaMapping};
 use crate::registry::{AsRule, Rule, RuleSet};
 use crate::rule_redirects::get_redirect_target;
+use crate::rules::pygrep_hooks;
 use crate::rules::ruff::rules::{UnusedCodes, UnusedNOQA};
 use crate::settings::LinterSettings;
 
@@ -201,6 +202,10 @@ pub(crate) fn check_noqa(
                 }
             }
         }
+    }
+
+    if settings.rules.enabled(Rule::BlanketNOQA) {
+        pygrep_hooks::rules::blanket_noqa(diagnostics, &noqa_directives, locator);
     }
 
     ignored_diagnostics.sort_unstable();

--- a/crates/ruff_linter/src/checkers/tokens.rs
+++ b/crates/ruff_linter/src/checkers/tokens.rs
@@ -45,10 +45,6 @@ pub(crate) fn check_tokens(
             .check_lines(tokens, &mut diagnostics);
     }
 
-    if settings.rules.enabled(Rule::BlanketNOQA) {
-        pygrep_hooks::rules::blanket_noqa(&mut diagnostics, indexer, locator);
-    }
-
     if settings.rules.enabled(Rule::BlanketTypeIgnore) {
         pygrep_hooks::rules::blanket_type_ignore(&mut diagnostics, indexer, locator);
     }

--- a/crates/ruff_linter/src/registry.rs
+++ b/crates/ruff_linter/src/registry.rs
@@ -246,7 +246,7 @@ impl Rule {
     pub const fn lint_source(&self) -> LintSource {
         match self {
             Rule::InvalidPyprojectToml => LintSource::PyprojectToml,
-            Rule::UnusedNOQA => LintSource::Noqa,
+            Rule::BlanketNOQA | Rule::UnusedNOQA => LintSource::Noqa,
             Rule::BidirectionalUnicode
             | Rule::BlankLineWithWhitespace
             | Rule::DocLineTooLong
@@ -256,7 +256,6 @@ impl Rule {
             | Rule::MixedSpacesAndTabs
             | Rule::TrailingWhitespace => LintSource::PhysicalLines,
             Rule::AmbiguousUnicodeCharacterComment
-            | Rule::BlanketNOQA
             | Rule::BlanketTypeIgnore
             | Rule::BlankLineAfterDecorator
             | Rule::BlankLineBetweenMethods


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Move `blanket-noqa` rule from the token checker to the noqa checker. This allows us to make use of the line directives already computed in the noqa checker.

## Test Plan

Verified test results are unchanged.
