### PR TITLE
Respect per-file-ignores for RUF100 with no other diagnostics

### DIFF
--- a/crates/ruff_linter/src/linter.rs
+++ b/crates/ruff_linter/src/linter.rs
@@ -265,7 +265,13 @@ pub fn check_path(
     }
 
     // Ignore diagnostics based on per-file-ignores.
-    let per_file_ignores = if !diagnostics.is_empty() && !settings.per_file_ignores.is_empty() {
+    let per_file_ignores = if (!diagnostics.is_empty()
+        || settings
+            .rules
+            .iter_enabled()
+            .any(|rule_code| rule_code.lint_source().is_noqa()))
+        && !settings.per_file_ignores.is_empty()
+    {
         fs::ignores_from_path(path, &settings.per_file_ignores)
     } else {
         RuleSet::empty()

--- a/crates/ruff_linter/src/rules/ruff/mod.rs
+++ b/crates/ruff_linter/src/rules/ruff/mod.rs
@@ -253,6 +253,24 @@ mod tests {
     }
 
     #[test]
+    fn ruff_per_file_ignores_empty() -> Result<()> {
+        let diagnostics = test_path(
+            Path::new("ruff/ruff_per_file_ignores.py"),
+            &settings::LinterSettings {
+                per_file_ignores: CompiledPerFileIgnoreList::resolve(vec![PerFileIgnore::new(
+                    "ruff_per_file_ignores.py".to_string(),
+                    &["RUF100".parse().unwrap()],
+                    None,
+                )])
+                .unwrap(),
+                ..settings::LinterSettings::for_rules(vec![Rule::UnusedNOQA])
+            },
+        )?;
+        assert_messages!(diagnostics);
+        Ok(())
+    }
+
+    #[test]
     fn flake8_noqa() -> Result<()> {
         let diagnostics = test_path(
             Path::new("ruff/flake8_noqa.py"),

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__ruff_per_file_ignores_empty.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__ruff_per_file_ignores_empty.snap
@@ -1,0 +1,4 @@
+---
+source: crates/ruff_linter/src/rules/ruff/mod.rs
+---
+


### PR DESCRIPTION
## Summary

The existing test didn't cover the case in which there are _no_ other diagnostics in the file.

Closes https://github.com/astral-sh/ruff/issues/10906.