### PR TITLE
Make associativity a property of operator precedence

### DIFF
--- a/crates/ruff_python_parser/src/parser/statement.rs
+++ b/crates/ruff_python_parser/src/parser/statement.rs
@@ -16,7 +16,7 @@ use crate::parser::{
 use crate::token_set::TokenSet;
 use crate::{Mode, ParseErrorType, Tok, TokenKind};
 
-use super::expression::{ExpressionContext, Precedence};
+use super::expression::{ExpressionContext, OperatorPrecedence};
 use super::Parenthesized;
 
 /// Tokens that represent compound statements.
@@ -2173,9 +2173,9 @@ impl<'src> Parser<'src> {
                 // with (a | b) << c | d: ...
                 // # Postfix should still be parsed first
                 // with (a)[0] + b * c: ...
-                self.parse_expression_with_precedence_recursive(
+                self.parse_binary_expression_or_higher_recursive(
                     lhs.into(),
-                    Precedence::Initial,
+                    OperatorPrecedence::Initial,
                     ExpressionContext::default(),
                     start,
                 )


### PR DESCRIPTION
## Summary

This PR does a few things but the main change is that is makes associativity a property of operator precedence.

1. Rename `Precedence` -> `OperatorPrecedence`
2. Rename `parse_expression_with_precedence` -> `parse_binary_expression_or_higher`
3. Move `current_binding_power` to `OperatorPrecedence::try_from_tokens` [^1]
4. Add a `OperatorPrecedence::is_right_associative` method
5. Move from `increment_precedence` to using `<=` / `<` to check if the parsing loop needs to stop [^2]

[^1]: Another alternative would be to have two separate methods to avoid lookahead as it's required only for once case (`not in`). So, `try_from_current_token(current).or_else(|| try_from_next_token(current, peek))`
[^2]: This will allow us to easily make the refactors mentioned in #10752 

## Test Plan

Make sure the precedence parsing algorithm is still correct by running the test suite, fuzz testing it and running it against a dozen or so open-source repositories.
