### PR TITLE
Use `UnaryOp` parameter in unary expression parsing

### DIFF
--- a/crates/ruff_linter/src/rules/pycodestyle/rules/logical_lines/missing_whitespace_around_operator.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/logical_lines/missing_whitespace_around_operator.rs
@@ -186,7 +186,9 @@ pub(crate) fn missing_whitespace_around_operator(
             );
 
             NeedsSpace::from(!slash_in_func)
-        } else if kind.is_unary() || matches!(kind, TokenKind::Star | TokenKind::DoubleStar) {
+        } else if kind.is_unary_arithmetic_operator()
+            || matches!(kind, TokenKind::Star | TokenKind::DoubleStar)
+        {
             let is_binary = {
                 let prev_kind = prev_token.kind();
 

--- a/crates/ruff_python_parser/src/parser/pattern.rs
+++ b/crates/ruff_python_parser/src/parser/pattern.rs
@@ -478,30 +478,34 @@ impl<'src> Parser<'src> {
                     },
                 })
             }
-            // The `+` is only for better error recovery.
-            TokenKind::Minus | TokenKind::Plus
-                if matches!(
-                    self.peek(),
-                    TokenKind::Int | TokenKind::Float | TokenKind::Complex
-                ) =>
-            {
-                let unary_expr = self.parse_unary_expression(ExpressionContext::default());
+            kind => {
+                // The `+` is only for better error recovery.
+                if let Some(unary_arithmetic_op) = kind.as_unary_arithmetic_opeartor() {
+                    if matches!(
+                        self.peek(),
+                        TokenKind::Int | TokenKind::Float | TokenKind::Complex
+                    ) {
+                        let unary_expr = self.parse_unary_expression(
+                            unary_arithmetic_op,
+                            ExpressionContext::default(),
+                        );
 
-                if unary_expr.op.is_u_add() {
-                    self.add_error(
-                        ParseErrorType::OtherError(
-                            "Unary '+' is not allowed as a literal pattern".to_string(),
-                        ),
-                        &unary_expr,
-                    );
+                        if unary_expr.op.is_u_add() {
+                            self.add_error(
+                                ParseErrorType::OtherError(
+                                    "Unary '+' is not allowed as a literal pattern".to_string(),
+                                ),
+                                &unary_expr,
+                            );
+                        }
+
+                        return Pattern::MatchValue(ast::PatternMatchValue {
+                            value: Box::new(Expr::UnaryOp(unary_expr)),
+                            range: self.node_range(start),
+                        });
+                    }
                 }
 
-                Pattern::MatchValue(ast::PatternMatchValue {
-                    value: Box::new(Expr::UnaryOp(unary_expr)),
-                    range: self.node_range(start),
-                })
-            }
-            kind => {
                 // Upon encountering an unexpected token, return a `Pattern::MatchValue` containing
                 // an empty `Expr::Name`.
                 let invalid_node = if kind.is_keyword() {

--- a/crates/ruff_python_parser/src/token.rs
+++ b/crates/ruff_python_parser/src/token.rs
@@ -541,11 +541,6 @@ impl TokenKind {
     }
 
     #[inline]
-    pub const fn is_unary(&self) -> bool {
-        matches!(self, TokenKind::Plus | TokenKind::Minus)
-    }
-
-    #[inline]
     pub const fn is_keyword(&self) -> bool {
         matches!(
             self,
@@ -697,6 +692,52 @@ impl TokenKind {
     #[inline]
     pub const fn is_soft_keyword(&self) -> bool {
         matches!(self, TokenKind::Match | TokenKind::Case)
+    }
+
+    /// Returns `true` if the current token is a unary arithmetic operator.
+    ///
+    /// Use [`TokenKind::is_unary_opeartor`] to check for any unary operator.
+    #[inline]
+    pub const fn is_unary_arithmetic_operator(&self) -> bool {
+        matches!(self, TokenKind::Plus | TokenKind::Minus)
+    }
+
+    /// Returns the [`UnaryOp`] that corresponds to this token kind, if it is an arithmetic unary
+    /// operator, otherwise return [None].
+    ///
+    /// Use [`TokenKind::as_unary_opeartor`] to match against any unary operator.
+    #[inline]
+    pub const fn as_unary_arithmetic_opeartor(&self) -> Option<UnaryOp> {
+        Some(match self {
+            TokenKind::Plus => UnaryOp::UAdd,
+            TokenKind::Minus => UnaryOp::USub,
+            _ => return None,
+        })
+    }
+
+    /// Returns `true` if the current token is a unary operator.
+    ///
+    /// Use [`TokenKind::is_unary_arithmetic_operator`] to check for only an arithmetic unary
+    /// operator.
+    #[inline]
+    pub const fn is_unary_opeartor(&self) -> bool {
+        self.as_unary_opeartor().is_some()
+    }
+
+    /// Returns the [`UnaryOp`] that corresponds to this token kind, if it is a unary operator,
+    /// otherwise return [None].
+    ///
+    /// Use [`TokenKind::as_unary_arithmetic_opeartor`] to match against only an arithmetic unary
+    /// operator.
+    #[inline]
+    pub const fn as_unary_opeartor(&self) -> Option<UnaryOp> {
+        Some(match self {
+            TokenKind::Plus => UnaryOp::UAdd,
+            TokenKind::Minus => UnaryOp::USub,
+            TokenKind::Tilde => UnaryOp::Invert,
+            TokenKind::Not => UnaryOp::Not,
+            _ => return None,
+        })
     }
 
     /// Returns `true` if the current token is a comparison operator. This function requires the
@@ -911,34 +952,24 @@ impl TryFrom<TokenKind> for Operator {
     }
 }
 
-impl TryFrom<&Tok> for UnaryOp {
-    type Error = String;
-
-    fn try_from(value: &Tok) -> Result<Self, Self::Error> {
-        TokenKind::from_token(value).try_into()
-    }
-}
-
-impl TryFrom<TokenKind> for UnaryOp {
-    type Error = String;
-
-    fn try_from(value: TokenKind) -> Result<Self, Self::Error> {
-        Ok(match value {
-            TokenKind::Plus => UnaryOp::UAdd,
-            TokenKind::Minus => UnaryOp::USub,
-            TokenKind::Tilde => UnaryOp::Invert,
-            TokenKind::Not => UnaryOp::Not,
-            _ => return Err(format!("unexpected token: {value:?}")),
-        })
-    }
-}
-
 impl From<BoolOp> for TokenKind {
     #[inline]
     fn from(op: BoolOp) -> Self {
         match op {
             BoolOp::And => TokenKind::And,
             BoolOp::Or => TokenKind::Or,
+        }
+    }
+}
+
+impl From<UnaryOp> for TokenKind {
+    #[inline]
+    fn from(op: UnaryOp) -> Self {
+        match op {
+            UnaryOp::Invert => TokenKind::Tilde,
+            UnaryOp::Not => TokenKind::Not,
+            UnaryOp::UAdd => TokenKind::Plus,
+            UnaryOp::USub => TokenKind::Minus,
         }
     }
 }


### PR DESCRIPTION
## Summary

Part of #10752 

This PR updates unary expression parsing to take in the `UnaryOp` as a parameter.

## Test Plan

Make sure the unary expression parsing logic is still correct by running the test suite, fuzz testing it and running it against a dozen or so open-source repositories.
