### PR TITLE
`ruff server`: Support setting to prioritize project configuration over editor configuration

### DIFF
--- a/crates/ruff_server/src/session/settings.rs
+++ b/crates/ruff_server/src/session/settings.rs
@@ -38,6 +38,7 @@ pub(crate) struct ResolvedEditorSettings {
     pub(super) ignore: Option<Vec<RuleSelector>>,
     pub(super) exclude: Option<Vec<String>>,
     pub(super) line_length: Option<LineLength>,
+    pub(super) prioritize_file_configuration: bool,
 }
 
 /// This is a direct representation of the settings schema sent by the client.
@@ -52,6 +53,7 @@ pub(crate) struct ClientSettings {
     code_action: Option<CodeActionOptions>,
     exclude: Option<Vec<String>>,
     line_length: Option<LineLength>,
+    prioritize_file_configuration: Option<bool>,
 }
 
 /// This is a direct representation of the workspace settings schema,
@@ -251,6 +253,11 @@ impl ResolvedClientSettings {
                     Some(settings.exclude.as_ref()?.clone())
                 }),
                 line_length: Self::resolve_optional(all_settings, |settings| settings.line_length),
+                prioritize_file_configuration: Self::resolve_or(
+                    all_settings,
+                    |settings| settings.prioritize_file_configuration,
+                    false,
+                ),
             },
         }
     }
@@ -383,6 +390,7 @@ mod tests {
                 ),
                 exclude: None,
                 line_length: None,
+                prioritize_file_configuration: None,
             },
             workspace_settings: [
                 WorkspaceSettings {
@@ -429,6 +437,7 @@ mod tests {
                         ),
                         exclude: None,
                         line_length: None,
+                        prioritize_file_configuration: None,
                     },
                     workspace: Url {
                         scheme: "file",
@@ -488,6 +497,7 @@ mod tests {
                         ),
                         exclude: None,
                         line_length: None,
+                        prioritize_file_configuration: None,
                     },
                     workspace: Url {
                         scheme: "file",
@@ -538,7 +548,8 @@ mod tests {
                     extend_select: None,
                     ignore: None,
                     exclude: None,
-                    line_length: None
+                    line_length: None,
+                    prioritize_file_configuration: false,
                 }
             }
         );
@@ -566,7 +577,8 @@ mod tests {
                     extend_select: None,
                     ignore: None,
                     exclude: None,
-                    line_length: None
+                    line_length: None,
+                    prioritize_file_configuration: false,
                 }
             }
         );
@@ -620,6 +632,7 @@ mod tests {
                             80,
                         ),
                     ),
+                    prioritize_file_configuration: None,
                 },
             ),
         }
@@ -648,7 +661,8 @@ mod tests {
                     extend_select: None,
                     ignore: Some(vec![RuleSelector::from_str("RUF001").unwrap()]),
                     exclude: Some(vec!["third_party".into()]),
-                    line_length: Some(LineLength::try_from(80).unwrap())
+                    line_length: Some(LineLength::try_from(80).unwrap()),
+                    prioritize_file_configuration: false,
                 }
             }
         );

--- a/crates/ruff_server/src/session/settings.rs
+++ b/crates/ruff_server/src/session/settings.rs
@@ -38,7 +38,7 @@ pub(crate) struct ResolvedEditorSettings {
     pub(super) ignore: Option<Vec<RuleSelector>>,
     pub(super) exclude: Option<Vec<String>>,
     pub(super) line_length: Option<LineLength>,
-    pub(super) resolution_strategy: ConfigResolutionStrategy,
+    pub(super) configuration_resolution_strategy: ConfigResolutionStrategy,
 }
 
 /// Determines how multiple conflicting configurations should be resolved - in this
@@ -68,7 +68,7 @@ pub(crate) struct ClientSettings {
     code_action: Option<CodeActionOptions>,
     exclude: Option<Vec<String>>,
     line_length: Option<LineLength>,
-    resolution_strategy: Option<ConfigResolutionStrategy>,
+    configuration_resolution_strategy: Option<ConfigResolutionStrategy>,
 }
 
 /// This is a direct representation of the workspace settings schema,
@@ -268,9 +268,9 @@ impl ResolvedClientSettings {
                     Some(settings.exclude.as_ref()?.clone())
                 }),
                 line_length: Self::resolve_optional(all_settings, |settings| settings.line_length),
-                resolution_strategy: Self::resolve_or(
+                configuration_resolution_strategy: Self::resolve_or(
                     all_settings,
-                    |settings| settings.resolution_strategy,
+                    |settings| settings.configuration_resolution_strategy,
                     ConfigResolutionStrategy::Default,
                 ),
             },
@@ -405,7 +405,7 @@ mod tests {
                 ),
                 exclude: None,
                 line_length: None,
-                resolution_strategy: None,
+                configuration_resolution_strategy: None,
             },
             workspace_settings: [
                 WorkspaceSettings {
@@ -452,7 +452,7 @@ mod tests {
                         ),
                         exclude: None,
                         line_length: None,
-                        resolution_strategy: None,
+                        configuration_resolution_strategy: None,
                     },
                     workspace: Url {
                         scheme: "file",
@@ -512,7 +512,7 @@ mod tests {
                         ),
                         exclude: None,
                         line_length: None,
-                        resolution_strategy: None,
+                        configuration_resolution_strategy: None,
                     },
                     workspace: Url {
                         scheme: "file",
@@ -564,7 +564,7 @@ mod tests {
                     ignore: None,
                     exclude: None,
                     line_length: None,
-                    resolution_strategy: ConfigResolutionStrategy::Default,
+                    configuration_resolution_strategy: ConfigResolutionStrategy::Default,
                 }
             }
         );
@@ -593,7 +593,7 @@ mod tests {
                     ignore: None,
                     exclude: None,
                     line_length: None,
-                    resolution_strategy: ConfigResolutionStrategy::Default,
+                    configuration_resolution_strategy: ConfigResolutionStrategy::Default,
                 }
             }
         );
@@ -647,7 +647,7 @@ mod tests {
                             80,
                         ),
                     ),
-                    resolution_strategy: None,
+                    configuration_resolution_strategy: None,
                 },
             ),
         }
@@ -677,7 +677,7 @@ mod tests {
                     ignore: Some(vec![RuleSelector::from_str("RUF001").unwrap()]),
                     exclude: Some(vec!["third_party".into()]),
                     line_length: Some(LineLength::try_from(80).unwrap()),
-                    resolution_strategy: ConfigResolutionStrategy::Default,
+                    configuration_resolution_strategy: ConfigResolutionStrategy::Default,
                 }
             }
         );

--- a/crates/ruff_server/src/session/workspace/ruff_settings.rs
+++ b/crates/ruff_server/src/session/workspace/ruff_settings.rs
@@ -14,7 +14,7 @@ use std::{
 };
 use walkdir::{DirEntry, WalkDir};
 
-use crate::session::settings::ResolvedEditorSettings;
+use crate::session::settings::{ConfigResolutionStrategy, ResolvedEditorSettings};
 
 #[derive(Default)]
 pub(crate) struct RuffSettings {
@@ -117,7 +117,7 @@ impl<'a> ConfigurationTransformer for EditorConfigurationTransformer<'a> {
             ignore,
             exclude,
             line_length,
-            prioritize_file_configuration: prioritize_workspace_settings,
+            resolution_strategy,
         } = self.0.clone();
 
         let project_root = self.1;
@@ -150,10 +150,13 @@ impl<'a> ConfigurationTransformer for EditorConfigurationTransformer<'a> {
             ..Default::default()
         };
 
-        if prioritize_workspace_settings {
-            project_configuration.combine(editor_configuration)
-        } else {
-            editor_configuration.combine(project_configuration)
+        match resolution_strategy {
+            ConfigResolutionStrategy::Default => {
+                editor_configuration.combine(project_configuration)
+            }
+            ConfigResolutionStrategy::PrioritizeWorkspace => {
+                project_configuration.combine(editor_configuration)
+            }
         }
     }
 }

--- a/crates/ruff_server/src/session/workspace/ruff_settings.rs
+++ b/crates/ruff_server/src/session/workspace/ruff_settings.rs
@@ -117,7 +117,7 @@ impl<'a> ConfigurationTransformer for EditorConfigurationTransformer<'a> {
             ignore,
             exclude,
             line_length,
-            resolution_strategy,
+            configuration_resolution_strategy,
         } = self.0.clone();
 
         let project_root = self.1;
@@ -150,7 +150,7 @@ impl<'a> ConfigurationTransformer for EditorConfigurationTransformer<'a> {
             ..Default::default()
         };
 
-        match resolution_strategy {
+        match configuration_resolution_strategy {
             ConfigResolutionStrategy::Default => {
                 editor_configuration.combine(project_configuration)
             }

--- a/crates/ruff_server/src/session/workspace/ruff_settings.rs
+++ b/crates/ruff_server/src/session/workspace/ruff_settings.rs
@@ -117,6 +117,7 @@ impl<'a> ConfigurationTransformer for EditorConfigurationTransformer<'a> {
             ignore,
             exclude,
             line_length,
+            prioritize_file_configuration: prioritize_workspace_settings,
         } = self.0.clone();
 
         let project_root = self.1;
@@ -149,6 +150,10 @@ impl<'a> ConfigurationTransformer for EditorConfigurationTransformer<'a> {
             ..Default::default()
         };
 
-        editor_configuration.combine(project_configuration)
+        if prioritize_workspace_settings {
+            project_configuration.combine(editor_configuration)
+        } else {
+            editor_configuration.combine(project_configuration)
+        }
     }
 }


### PR DESCRIPTION
## Summary

This is intended to address https://github.com/astral-sh/ruff-vscode/issues/425, and is a follow-up to https://github.com/astral-sh/ruff/pull/11062.

A new client setting is now supported by the server, `prioritizeFileConfiguration`. This is a boolean setting (default: `false`) that, if set to `true`, will instruct the configuration resolver to prioritize file configuration (aka discovered TOML files) over configuration passed in by the editor.

A corresponding extension PR has been opened, which makes this setting available for VS Code: https://github.com/astral-sh/ruff-vscode/pull/457.

## Test Plan

To test this with VS Code, you'll need to check out [the VS Code PR](https://github.com/astral-sh/ruff-vscode/pull/457) that adds this setting.

The test process is similar to https://github.com/astral-sh/ruff/pull/11062, but in scenarios where the editor configuration would take priority over file configuration, file configuration should take priority.
