### PR TITLE
Add a new CI job to fuzz the parser

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,6 +23,8 @@ jobs:
     name: "Determine changes"
     runs-on: ubuntu-latest
     outputs:
+      # Flag that is raised when any code that affects parser is changed
+      parser: ${{ steps.changed.outputs.parser_any_changed }}
       # Flag that is raised when any code that affects linter is changed
       linter: ${{ steps.changed.outputs.linter_any_changed }}
       # Flag that is raised when any code that affects formatter is changed
@@ -39,6 +41,17 @@ jobs:
         id: changed
         with:
           files_yaml: |
+            parser:
+              - Cargo.toml
+              - Cargo.lock
+              - crates/ruff_python_trivia/**
+              - crates/ruff_source_file/**
+              - crates/ruff_text_size/**
+              - crates/ruff_python_ast/**
+              - crates/ruff_python_parser/**
+              - scripts/fuzz-parser/**
+              - .github/workflows/ci.yaml
+
             linter:
               - Cargo.toml
               - Cargo.lock
@@ -199,6 +212,38 @@ jobs:
         with:
           tool: cargo-fuzz@0.11.2
       - run: cargo fuzz build -s none
+
+  fuzz-parser:
+    name: "Fuzz the parser"
+    runs-on: ubuntu-latest
+    needs:
+      - cargo-test-linux
+      - determine_changes
+    if: ${{ needs.determine_changes.outputs.parser == 'true' }}
+    timeout-minutes: 20
+    env:
+      FORCE_COLOR: 1
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+      - name: Install uv
+        run: curl -LsSf https://astral.sh/uv/install.sh | sh
+      - name: Install Python requirements
+        run: uv pip install -r scripts/fuzz-parser/requirements.txt --system
+      - uses: actions/download-artifact@v4
+        name: Download Ruff binary to test
+        id: download-cached-binary
+        with:
+          name: ruff
+          path: ruff-to-test
+      - name: Fuzz
+        run: |
+          # Make executable, since artifact download doesn't preserve this
+          chmod +x ${{ steps.download-cached-binary.outputs.download-path }}/ruff
+
+          python scripts/fuzz-parser/fuzz.py 0-1_000 --test-executable ${{ steps.download-cached-binary.outputs.download-path }}/ruff
 
   scripts:
     name: "test scripts"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -243,7 +243,7 @@ jobs:
           # Make executable, since artifact download doesn't preserve this
           chmod +x ${{ steps.download-cached-binary.outputs.download-path }}/ruff
 
-          python scripts/fuzz-parser/fuzz.py 0-1_000 --test-executable ${{ steps.download-cached-binary.outputs.download-path }}/ruff
+          python scripts/fuzz-parser/fuzz.py 0-500 --test-executable ${{ steps.download-cached-binary.outputs.download-path }}/ruff
 
   scripts:
     name: "test scripts"

--- a/scripts/fuzz-parser/fuzz.py
+++ b/scripts/fuzz-parser/fuzz.py
@@ -74,9 +74,12 @@ class FuzzResult:
             print(colored("The following code triggers a bug:", "red"))
             print()
             print(self.maybe_bug)
-            print()
+            print(flush=True)
         else:
-            print(colored(f"Ran fuzzer successfully on seed {self.seed}", "green"))
+            print(
+                colored(f"Ran fuzzer successfully on seed {self.seed}", "green"),
+                flush=True,
+            )
 
 
 def fuzz_code(


### PR DESCRIPTION
## Summary

This PR adds a new CI job that tests the parser by running the new `scripts/fuzz-parser` script. The job runs the parser over 1,000 randomly generated (but all syntactically valid) Python source files. For any files that the parser fails to parse, the script minimises the generated source code into a minimal reproducible example. On completion of the script, if any bugs were encountered, the script fails with exit code 1.

## How many seeds should we pass to the script?

This PR currently passes 1,001 seeds to the script for it to test. In an ideal world, we'd obviously run it over a larger range of seeds, but I think 1,001 seeds is enough for it to serve as a useful regression test (I discovered the bug that was fixed in #11009 on seed 6 with an early version of the `fuzz-parser` script).

The new job takes around ten minutes to run in CI. That's quicker than the ecosystem job if the ecosystem job runs both the formatter and linter ecosystem checks, but it's slower than the ecosystem job if that job runs only the linter ecosystem checks. If we think 10 minutes is too long for this job, we could pass a smaller range of seeds to the script in CI.

One way we could get the "best of both worlds" might be to pass it a small range of seeds for CI on PRs (500?) but have a nightly job that passes a large range of seeds (5,000? 10,000?). We could have a bot that automatically opens an issue when the nightly job fails -- we do something like this at typeshed: https://github.com/python/typeshed/issues/11801