### PR TITLE
(📚) fix docs for `invalid-X-returns`

### DIFF
--- a/crates/ruff_linter/src/rules/pylint/rules/invalid_hash_return.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/invalid_hash_return.rs
@@ -12,10 +12,10 @@ use ruff_text_size::Ranged;
 use crate::checkers::ast::Checker;
 
 /// ## What it does
-/// Checks for `__hash__` implementations that return a type other than `integer`.
+/// Checks for `__hash__` implementations that return a value other than an integer.
 ///
 /// ## Why is this bad?
-/// The `__hash__` method should return an `integer`. Returning a different
+/// The `__hash__` method should return an integer. Returning a different
 /// type may cause unexpected behavior.
 ///
 /// Note: `bool` is a subclass of `int`, so it's technically valid for `__hash__` to

--- a/crates/ruff_linter/src/rules/pylint/rules/invalid_index_return.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/invalid_index_return.rs
@@ -12,10 +12,10 @@ use ruff_text_size::Ranged;
 use crate::checkers::ast::Checker;
 
 /// ## What it does
-/// Checks for `__index__` implementations that return a type other than `integer`.
+/// Checks for `__index__` implementations that return a value other than an integer.
 ///
 /// ## Why is this bad?
-/// The `__index__` method should return an `integer`. Returning a different
+/// The `__index__` method should return an integer. Returning a different
 /// type may cause unexpected behavior.
 ///
 /// Note: `bool` is a subclass of `int`, so it's technically valid for `__index__` to

--- a/crates/ruff_linter/src/rules/pylint/rules/invalid_length_return.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/invalid_length_return.rs
@@ -13,10 +13,10 @@ use crate::checkers::ast::Checker;
 
 /// ## What it does
 /// Checks for `__len__` implementations that return values other than a non-negative
-/// `integer`.
+/// integer.
 ///
 /// ## Why is this bad?
-/// The `__len__` method should return a non-negative `integer`. Returning a different
+/// The `__len__` method should return a non-negative integer. Returning a different
 /// value may cause unexpected behavior.
 ///
 /// Note: `bool` is a subclass of `int`, so it's technically valid for `__len__` to


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

There is no class `integer` in python, nor is there a type `integer`, so I updated the docs to remove the backticks on these references, such that it is the representation of an integer, and not a reference.

## Test Plan

<!-- How was it tested? -->
