### PR TITLE
[`refurb`] Advoid `operator.itemgetter` suggestion for single-item tuple

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/refurb/FURB118.py
+++ b/crates/ruff_linter/resources/test/fixtures/refurb/FURB118.py
@@ -10,7 +10,7 @@ op_mult = lambda x, y: x * y
 op_matmutl = lambda x, y: x @ y
 op_truediv = lambda x, y: x / y
 op_mod = lambda x, y: x % y
-op_pow = lambda x, y: x**y
+op_pow = lambda x, y: x ** y
 op_lshift = lambda x, y: x << y
 op_rshift = lambda x, y: x >> y
 op_bitor = lambda x, y: x | y
@@ -59,6 +59,7 @@ op_itemgetter = lambda x, y: (x[0], y[0])
 op_itemgetter = lambda x, y: (x[0], y[0])
 op_itemgetter = lambda x: ()
 op_itemgetter = lambda x: (*x[0], x[1])
+op_itemgetter = lambda x: (x[0],)
 
 
 def op_neg3(x, y):

--- a/crates/ruff_linter/src/rules/refurb/rules/reimplemented_operator.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/reimplemented_operator.rs
@@ -233,7 +233,7 @@ fn itemgetter_op_tuple(
     let [arg] = params.args.as_slice() else {
         return None;
     };
-    if expr.elts.is_empty() {
+    if expr.elts.is_empty() || expr.elts.len() == 1 {
         return None;
     }
     Some(Operator {

--- a/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__FURB118_FURB118.py.snap
+++ b/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__FURB118_FURB118.py.snap
@@ -187,7 +187,7 @@ FURB118.py:10:14: FURB118 [*] Use `operator.matmul` instead of defining a lambda
    11 |+op_matmutl = operator.matmul
 11 12 | op_truediv = lambda x, y: x / y
 12 13 | op_mod = lambda x, y: x % y
-13 14 | op_pow = lambda x, y: x**y
+13 14 | op_pow = lambda x, y: x ** y
 
 FURB118.py:11:14: FURB118 [*] Use `operator.truediv` instead of defining a lambda
    |
@@ -196,7 +196,7 @@ FURB118.py:11:14: FURB118 [*] Use `operator.truediv` instead of defining a lambd
 11 | op_truediv = lambda x, y: x / y
    |              ^^^^^^^^^^^^^^^^^^ FURB118
 12 | op_mod = lambda x, y: x % y
-13 | op_pow = lambda x, y: x**y
+13 | op_pow = lambda x, y: x ** y
    |
    = help: Replace with `operator.truediv`
 
@@ -213,7 +213,7 @@ FURB118.py:11:14: FURB118 [*] Use `operator.truediv` instead of defining a lambd
 11    |-op_truediv = lambda x, y: x / y
    12 |+op_truediv = operator.truediv
 12 13 | op_mod = lambda x, y: x % y
-13 14 | op_pow = lambda x, y: x**y
+13 14 | op_pow = lambda x, y: x ** y
 14 15 | op_lshift = lambda x, y: x << y
 
 FURB118.py:12:10: FURB118 [*] Use `operator.mod` instead of defining a lambda
@@ -222,7 +222,7 @@ FURB118.py:12:10: FURB118 [*] Use `operator.mod` instead of defining a lambda
 11 | op_truediv = lambda x, y: x / y
 12 | op_mod = lambda x, y: x % y
    |          ^^^^^^^^^^^^^^^^^^ FURB118
-13 | op_pow = lambda x, y: x**y
+13 | op_pow = lambda x, y: x ** y
 14 | op_lshift = lambda x, y: x << y
    |
    = help: Replace with `operator.mod`
@@ -239,7 +239,7 @@ FURB118.py:12:10: FURB118 [*] Use `operator.mod` instead of defining a lambda
 11 12 | op_truediv = lambda x, y: x / y
 12    |-op_mod = lambda x, y: x % y
    13 |+op_mod = operator.mod
-13 14 | op_pow = lambda x, y: x**y
+13 14 | op_pow = lambda x, y: x ** y
 14 15 | op_lshift = lambda x, y: x << y
 15 16 | op_rshift = lambda x, y: x >> y
 
@@ -247,8 +247,8 @@ FURB118.py:13:10: FURB118 [*] Use `operator.pow` instead of defining a lambda
    |
 11 | op_truediv = lambda x, y: x / y
 12 | op_mod = lambda x, y: x % y
-13 | op_pow = lambda x, y: x**y
-   |          ^^^^^^^^^^^^^^^^^ FURB118
+13 | op_pow = lambda x, y: x ** y
+   |          ^^^^^^^^^^^^^^^^^^^ FURB118
 14 | op_lshift = lambda x, y: x << y
 15 | op_rshift = lambda x, y: x >> y
    |
@@ -264,7 +264,7 @@ FURB118.py:13:10: FURB118 [*] Use `operator.pow` instead of defining a lambda
 10 11 | op_matmutl = lambda x, y: x @ y
 11 12 | op_truediv = lambda x, y: x / y
 12 13 | op_mod = lambda x, y: x % y
-13    |-op_pow = lambda x, y: x**y
+13    |-op_pow = lambda x, y: x ** y
    14 |+op_pow = operator.pow
 14 15 | op_lshift = lambda x, y: x << y
 15 16 | op_rshift = lambda x, y: x >> y
@@ -273,7 +273,7 @@ FURB118.py:13:10: FURB118 [*] Use `operator.pow` instead of defining a lambda
 FURB118.py:14:13: FURB118 [*] Use `operator.lshift` instead of defining a lambda
    |
 12 | op_mod = lambda x, y: x % y
-13 | op_pow = lambda x, y: x**y
+13 | op_pow = lambda x, y: x ** y
 14 | op_lshift = lambda x, y: x << y
    |             ^^^^^^^^^^^^^^^^^^^ FURB118
 15 | op_rshift = lambda x, y: x >> y
@@ -290,7 +290,7 @@ FURB118.py:14:13: FURB118 [*] Use `operator.lshift` instead of defining a lambda
 --------------------------------------------------------------------------------
 11 12 | op_truediv = lambda x, y: x / y
 12 13 | op_mod = lambda x, y: x % y
-13 14 | op_pow = lambda x, y: x**y
+13 14 | op_pow = lambda x, y: x ** y
 14    |-op_lshift = lambda x, y: x << y
    15 |+op_lshift = operator.lshift
 15 16 | op_rshift = lambda x, y: x >> y
@@ -299,7 +299,7 @@ FURB118.py:14:13: FURB118 [*] Use `operator.lshift` instead of defining a lambda
 
 FURB118.py:15:13: FURB118 [*] Use `operator.rshift` instead of defining a lambda
    |
-13 | op_pow = lambda x, y: x**y
+13 | op_pow = lambda x, y: x ** y
 14 | op_lshift = lambda x, y: x << y
 15 | op_rshift = lambda x, y: x >> y
    |             ^^^^^^^^^^^^^^^^^^^ FURB118
@@ -316,7 +316,7 @@ FURB118.py:15:13: FURB118 [*] Use `operator.rshift` instead of defining a lambda
 4  5  | op_pos = lambda x: +x
 --------------------------------------------------------------------------------
 12 13 | op_mod = lambda x, y: x % y
-13 14 | op_pow = lambda x, y: x**y
+13 14 | op_pow = lambda x, y: x ** y
 14 15 | op_lshift = lambda x, y: x << y
 15    |-op_rshift = lambda x, y: x >> y
    16 |+op_rshift = operator.rshift
@@ -342,7 +342,7 @@ FURB118.py:16:12: FURB118 [*] Use `operator.or_` instead of defining a lambda
 3  4  | op_not = lambda x: not x
 4  5  | op_pos = lambda x: +x
 --------------------------------------------------------------------------------
-13 14 | op_pow = lambda x, y: x**y
+13 14 | op_pow = lambda x, y: x ** y
 14 15 | op_lshift = lambda x, y: x << y
 15 16 | op_rshift = lambda x, y: x >> y
 16    |-op_bitor = lambda x, y: x | y


### PR DESCRIPTION
## Summary

The `operator.itemgetter` behavior changes where there's more than one argument, such that `operator.itemgetter(0)` yields `r[0]`, rather than `(r[0],)`.

Closes https://github.com/astral-sh/ruff/issues/11075.
