### PR TITLE
red-knot: Cache symbol tables

### DIFF
--- a/crates/red_knot/src/db.rs
+++ b/crates/red_knot/src/db.rs
@@ -5,6 +5,7 @@ use crate::files::FileId;
 use crate::module::{Module, ModuleData, ModuleName, ModuleResolver, ModuleSearchPath};
 use crate::parse::{Parsed, ParsedStorage};
 use crate::source::{Source, SourceStorage};
+use crate::symbols::{SymbolTable, SymbolTablesStorage};
 
 pub trait SourceDb {
     // queries
@@ -20,6 +21,8 @@ pub trait SourceDb {
 pub trait SemanticDb: SourceDb {
     // queries
     fn resolve_module(&self, name: ModuleName) -> Option<Module>;
+
+    fn symbol_table(&self, file_id: FileId) -> Arc<SymbolTable>;
 
     // mutations
     fn path_to_module(&mut self, path: &Path) -> Option<Module>;
@@ -40,6 +43,7 @@ pub struct SourceJar {
 #[derive(Debug, Default)]
 pub struct SemanticJar {
     pub module_resolver: ModuleResolver,
+    pub symbol_tables: SymbolTablesStorage,
 }
 
 /// Gives access to a specific jar in the database.
@@ -72,6 +76,7 @@ pub(crate) mod tests {
     };
     use crate::parse::{parse, Parsed};
     use crate::source::{source_text, Source};
+    use crate::symbols::{symbol_table, SymbolTable};
     use std::path::Path;
     use std::sync::Arc;
 
@@ -127,6 +132,10 @@ pub(crate) mod tests {
     impl SemanticDb for TestDb {
         fn resolve_module(&self, name: ModuleName) -> Option<Module> {
             resolve_module(self, name)
+        }
+
+        fn symbol_table(&self, file_id: FileId) -> Arc<SymbolTable> {
+            symbol_table(self, file_id)
         }
 
         fn path_to_module(&mut self, path: &Path) -> Option<Module> {

--- a/crates/red_knot/src/main.rs
+++ b/crates/red_knot/src/main.rs
@@ -6,7 +6,7 @@ use tracing_subscriber::layer::{Context, Filter, SubscriberExt};
 use tracing_subscriber::{Layer, Registry};
 use tracing_tree::time::Uptime;
 
-use red_knot::db::{HasJar, SourceDb, SourceJar};
+use red_knot::db::{HasJar, SemanticDb, SourceJar};
 use red_knot::module::{ModuleSearchPath, ModuleSearchPathKind};
 use red_knot::program::Program;
 use red_knot::{files, Workspace};
@@ -67,11 +67,9 @@ fn main() -> anyhow::Result<()> {
         //     }
         // }
 
-        let _parsed = program.parse(file);
-        let _parsed = program.parse(file);
-        let parsed = program.parse(file);
+        let symbols = program.symbol_table(file);
 
-        dbg!(&parsed);
+        dbg!(&symbols);
 
         // If this is an open file
         if workspace.is_file_open(file) {

--- a/crates/red_knot/src/program/mod.rs
+++ b/crates/red_knot/src/program/mod.rs
@@ -9,6 +9,7 @@ use crate::module::{
 };
 use crate::parse::{parse, Parsed, ParsedStorage};
 use crate::source::{source_text, Source, SourceStorage};
+use crate::symbols::{symbol_table, SymbolTable, SymbolTablesStorage};
 
 #[derive(Debug)]
 pub struct Program {
@@ -26,6 +27,7 @@ impl Program {
             },
             semantic: SemanticJar {
                 module_resolver: ModuleResolver::new(module_search_paths),
+                symbol_tables: SymbolTablesStorage::default(),
             },
             files,
         }
@@ -63,6 +65,10 @@ impl SourceDb for Program {
 impl SemanticDb for Program {
     fn resolve_module(&self, name: ModuleName) -> Option<Module> {
         resolve_module(self, name)
+    }
+
+    fn symbol_table(&self, file_id: FileId) -> Arc<SymbolTable> {
+        symbol_table(self, file_id)
     }
 
     // Mutations


### PR DESCRIPTION
## Summary

This PR adds a new `db.symbol_table(file_id)` method that allows querying the symbol table for a file (that gets cached). 

## Test Plan

`cargo build`
