### PR TITLE
[red-knot] Adjust node sizes test so red-knot can pass CI

### DIFF
--- a/crates/red_knot/src/db.rs
+++ b/crates/red_knot/src/db.rs
@@ -44,7 +44,7 @@ pub struct SemanticJar {
 
 /// Gives access to a specific jar in the database.
 ///
-/// Nope, the terminology isn't borrowed from Java but from Salsa (https://salsa-rs.github.io/salsa/),
+/// Nope, the terminology isn't borrowed from Java but from Salsa <https://salsa-rs.github.io/salsa/>,
 /// which is an analogy to storing the salsa in different jars.
 ///
 /// The basic idea is that each crate can define its own jar and the jars can be combined to a single

--- a/crates/ruff_python_ast/src/nodes.rs
+++ b/crates/ruff_python_ast/src/nodes.rs
@@ -4206,7 +4206,7 @@ mod tests {
         assert_eq!(std::mem::size_of::<ExprSetComp>(), 40);
         assert_eq!(std::mem::size_of::<ExprSlice>(), 32);
         assert_eq!(std::mem::size_of::<ExprStarred>(), 24);
-        assert_eq!(std::mem::size_of::<ExprStringLiteral>(), 48);
+        assert_eq!(std::mem::size_of::<ExprStringLiteral>(), 56);
         assert_eq!(std::mem::size_of::<ExprSubscript>(), 32);
         assert_eq!(std::mem::size_of::<ExprTuple>(), 40);
         assert_eq!(std::mem::size_of::<ExprUnaryOp>(), 24);


### PR DESCRIPTION
This is needed because of the AST changes from `OnceCell` to `OnceLock`.

If we decide we don't need AST to be Sync/Send, we can revert this along with those changes; just want green CI for now.

Also adjust a URL in doc comments so `cargo docs` doesn't complain about it.
