### PR TITLE
Read user configuration from `~/.config/ruff/ruff.toml` on macOS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2504,7 +2504,6 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "colored",
- "dirs 5.0.1",
  "etcetera",
  "glob",
  "globset",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -755,6 +755,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "etcetera"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
+dependencies = [
+ "cfg-if",
+ "home",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "eyre"
 version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2494,6 +2505,7 @@ dependencies = [
  "anyhow",
  "colored",
  "dirs 5.0.1",
+ "etcetera",
  "glob",
  "globset",
  "ignore",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,6 @@ countme = { version = "3.0.1" }
 criterion = { version = "0.5.1", default-features = false }
 crossbeam = { version = "0.8.4" }
 dashmap = { version = "5.5.3" }
-dirs = { version = "5.0.0" }
 drop_bomb = { version = "0.1.5" }
 env_logger = { version = "0.11.0" }
 etcetera = { version = "0.8.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ dashmap = { version = "5.5.3" }
 dirs = { version = "5.0.0" }
 drop_bomb = { version = "0.1.5" }
 env_logger = { version = "0.11.0" }
+etcetera = { version = "0.8.0" }
 fern = { version = "0.6.1" }
 filetime = { version = "0.2.23" }
 glob = { version = "0.3.1" }

--- a/crates/ruff_workspace/Cargo.toml
+++ b/crates/ruff_workspace/Cargo.toml
@@ -23,7 +23,6 @@ ruff_macros = { workspace = true }
 
 anyhow = { workspace = true }
 colored = { workspace = true }
-etcetera = { workspace = true }
 ignore = { workspace = true }
 is-macro = { workspace = true }
 itertools = { workspace = true }
@@ -41,6 +40,9 @@ serde = { workspace = true }
 shellexpand = { workspace = true }
 strum = { workspace = true }
 toml = { workspace = true }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+etcetera = { workspace = true }
 
 [dev-dependencies]
 # Enable test rules during development

--- a/crates/ruff_workspace/Cargo.toml
+++ b/crates/ruff_workspace/Cargo.toml
@@ -23,7 +23,6 @@ ruff_macros = { workspace = true }
 
 anyhow = { workspace = true }
 colored = { workspace = true }
-dirs = { workspace = true }
 etcetera = { workspace = true }
 ignore = { workspace = true }
 is-macro = { workspace = true }

--- a/crates/ruff_workspace/Cargo.toml
+++ b/crates/ruff_workspace/Cargo.toml
@@ -24,6 +24,7 @@ ruff_macros = { workspace = true }
 anyhow = { workspace = true }
 colored = { workspace = true }
 dirs = { workspace = true }
+etcetera = { workspace = true }
 ignore = { workspace = true }
 is-macro = { workspace = true }
 itertools = { workspace = true }

--- a/crates/ruff_workspace/src/pyproject.rs
+++ b/crates/ruff_workspace/src/pyproject.rs
@@ -114,10 +114,11 @@ pub fn find_user_settings_toml() -> Option<PathBuf> {
 
     // On macOS, we used to support reading from `/Users/Alice/Library/Application Support`.
     if cfg!(target_os = "macos") {
-        let deprecated_config_dir = dirs::config_dir()?.join("ruff");
+        let strategy = etcetera::base_strategy::Apple::new().ok()?;
+        let config_dir = strategy.data_dir().join("ruff");
 
         for file in [".ruff.toml", "ruff.toml", "pyproject.toml"] {
-            let path = deprecated_config_dir.join(file);
+            let path = config_dir.join(file);
             if path.is_file() {
                 warn_user_once!(
                     "Reading configuration from `~/Library/Application Support` is deprecated. Please move your configuration to `{}/{file}`.",

--- a/crates/ruff_workspace/src/pyproject.rs
+++ b/crates/ruff_workspace/src/pyproject.rs
@@ -3,7 +3,6 @@
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
-use etcetera::BaseStrategy;
 use log::debug;
 use pep440_rs::VersionSpecifiers;
 use serde::{Deserialize, Serialize};
@@ -100,7 +99,10 @@ pub fn find_settings_toml<P: AsRef<Path>>(path: P) -> Result<Option<PathBuf>> {
 
 /// Find the path to the user-specific `pyproject.toml` or `ruff.toml`, if it
 /// exists.
+#[cfg(not(target_arch = "wasm32"))]
 pub fn find_user_settings_toml() -> Option<PathBuf> {
+    use etcetera::BaseStrategy;
+
     let strategy = etcetera::base_strategy::choose_base_strategy().ok()?;
     let config_dir = strategy.config_dir().join("ruff");
 
@@ -129,6 +131,11 @@ pub fn find_user_settings_toml() -> Option<PathBuf> {
         }
     }
 
+    None
+}
+
+#[cfg(target_arch = "wasm32")]
+pub fn find_user_settings_toml() -> Option<PathBuf> {
     None
 }
 

--- a/crates/ruff_workspace/src/pyproject.rs
+++ b/crates/ruff_workspace/src/pyproject.rs
@@ -8,7 +8,6 @@ use pep440_rs::VersionSpecifiers;
 use serde::{Deserialize, Serialize};
 
 use ruff_linter::settings::types::PythonVersion;
-use ruff_linter::warn_user_once;
 
 use crate::options::Options;
 
@@ -102,6 +101,7 @@ pub fn find_settings_toml<P: AsRef<Path>>(path: P) -> Result<Option<PathBuf>> {
 #[cfg(not(target_arch = "wasm32"))]
 pub fn find_user_settings_toml() -> Option<PathBuf> {
     use etcetera::BaseStrategy;
+    use ruff_linter::warn_user_once;
 
     let strategy = etcetera::base_strategy::choose_base_strategy().ok()?;
     let config_dir = strategy.config_dir().join("ruff");
@@ -117,10 +117,10 @@ pub fn find_user_settings_toml() -> Option<PathBuf> {
     // On macOS, we used to support reading from `/Users/Alice/Library/Application Support`.
     if cfg!(target_os = "macos") {
         let strategy = etcetera::base_strategy::Apple::new().ok()?;
-        let config_dir = strategy.data_dir().join("ruff");
+        let deprecated_config_dir = strategy.data_dir().join("ruff");
 
         for file in [".ruff.toml", "ruff.toml", "pyproject.toml"] {
-            let path = config_dir.join(file);
+            let path = deprecated_config_dir.join(file);
             if path.is_file() {
                 warn_user_once!(
                     "Reading configuration from `~/Library/Application Support` is deprecated. Please move your configuration to `{}/{file}`.",

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -612,16 +612,20 @@ Ruff doesn't currently support INI files, like `setup.cfg` or `tox.ini`.
 
 ## How can I change Ruff's default configuration?
 
-When no configuration file is found, Ruff will look for a user-specific `pyproject.toml` or
-`ruff.toml` file as a last resort. This behavior is similar to Flake8's `~/.config/flake8`.
+When no configuration file is found, Ruff will look for a user-specific `ruff.toml` file as a
+last resort. This behavior is similar to Flake8's `~/.config/flake8`.
 
-On macOS, Ruff expects that file to be located at `/Users/Alice/Library/Application Support/ruff/ruff.toml`.
+On macOS and Linux, Ruff expects that file to be located at `~/.config/ruff/ruff.toml`,
+and respects the `XDG_CONFIG_HOME` specification.
 
-On Linux, Ruff expects that file to be located at `/home/alice/.config/ruff/ruff.toml`.
+On Windows, Ruff expects that file to be located at `~\AppData\Roaming\ruff\ruff.toml`.
 
-On Windows, Ruff expects that file to be located at `C:\Users\Alice\AppData\Roaming\ruff\ruff.toml`.
+!!! note
+  Prior to `v0.5.0`, Ruff would read user-specific configuration from
+  `~/Library/Application Support/ruff/ruff.toml` on macOS. While Ruff will still respect
+  such configuration files, the use of `~/Library/ Application Support` is considered deprecated.
 
-For more, see the [`dirs`](https://docs.rs/dirs/4.0.0/dirs/fn.config_dir.html) crate.
+For more, see the [`etcetera`](https://crates.io/crates/etcetera) crate.
 
 ## Ruff tried to fix something — but it broke my code. What's going on?
 


### PR DESCRIPTION
## Summary

This PR moves Ruff's user-specific configuration from `~/Library/Application Support/ruff/ruff.toml` to `~/.config/ruff/ruff.toml`.

Many other tools do this. On my machine alone: dagger, zed, gatsby, gh, wandb, etc.

I also polled Twitter and it won in a landslide:

![Screenshot 2024-04-23 at 4 07 19 PM](https://github.com/astral-sh/ruff/assets/1309177/d2840968-f310-4501-85a8-6994c4e7085b)

Let's ship this in v0.5.0, along with a deprecation warning (so we'll continue to respect `~/Library/Application Support/ruff/ruff.toml`, but log a warning).

Closes https://github.com/astral-sh/ruff/issues/10739.

## Test Plan

- Created a file with an unused import.
- Ran `cargo check foo.py`.
- Verified that the deprecated configuration was loaded and respected, with a warning:

```
warning: Reading configuration from `~/Library/Application Support` is deprecated. Please move your configuration to `/Users/crmarsh/.config/ruff/ruff/ruff.toml`.
[2024-04-23][16:09:10][ruff::resolve][DEBUG] Using configuration file (via cwd) at: /Users/crmarsh/Library/Application Support/ruff/ruff.toml
```

- Created `~/.config/ruff/ruff.toml`.
- Verified that the new configuration was loaded:
```
[2024-04-23][16:10:23][ruff::resolve][DEBUG] Using configuration file (via cwd) at: /Users/crmarsh/.config/ruff/ruff.toml
```
