### PR TITLE
Flag mutable defaults based on mutable annotations

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_bugbear/B006_9.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_bugbear/B006_9.py
@@ -1,0 +1,13 @@
+LIST = []
+
+
+def foo(a: list = LIST):  # B006
+    raise NotImplementedError("")
+
+
+def foo(a: list = None):  # OK
+    raise NotImplementedError("")
+
+
+def foo(a: list | None = LIST):  # OK
+    raise NotImplementedError("")

--- a/crates/ruff_linter/src/rules/flake8_bugbear/mod.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/mod.rs
@@ -42,6 +42,7 @@ mod tests {
     #[test_case(Rule::MutableArgumentDefault, Path::new("B006_6.py"))]
     #[test_case(Rule::MutableArgumentDefault, Path::new("B006_7.py"))]
     #[test_case(Rule::MutableArgumentDefault, Path::new("B006_8.py"))]
+    #[test_case(Rule::MutableArgumentDefault, Path::new("B006_9.py"))]
     #[test_case(Rule::MutableArgumentDefault, Path::new("B006_B008.py"))]
     #[test_case(Rule::NoExplicitStacklevel, Path::new("B028.py"))]
     #[test_case(Rule::RaiseLiteral, Path::new("B016.py"))]

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/mutable_argument_default.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/mutable_argument_default.rs
@@ -6,7 +6,9 @@ use ruff_python_ast::{self as ast, Expr, Parameter, ParameterWithDefault};
 use ruff_python_codegen::{Generator, Stylist};
 use ruff_python_index::Indexer;
 use ruff_python_semantic::analyze::function_type::is_stub;
-use ruff_python_semantic::analyze::typing::{is_immutable_annotation, is_mutable_expr};
+use ruff_python_semantic::analyze::typing::{
+    is_immutable_annotation, is_immutable_expr, is_mutable_annotation, is_mutable_expr,
+};
 use ruff_python_semantic::SemanticModel;
 use ruff_python_trivia::{indentation_at_offset, textwrap};
 use ruff_source_file::Locator;
@@ -108,10 +110,19 @@ pub(crate) fn mutable_argument_default(checker: &mut Checker, function_def: &ast
             .map(|target| QualifiedName::from_dotted_name(target))
             .collect();
 
-        if is_mutable_expr(default, checker.semantic())
+        // Either the expression _or_ the annotation must be mutable.
+        if (is_mutable_expr(default, checker.semantic())
             && !parameter.annotation.as_ref().is_some_and(|expr| {
                 is_immutable_annotation(expr, checker.semantic(), extend_immutable_calls.as_slice())
-            })
+            }))
+            || (parameter.annotation.as_ref().is_some_and(|annotation| {
+                is_mutable_annotation(annotation, checker.semantic())
+                    && !is_immutable_expr(
+                        default,
+                        checker.semantic(),
+                        extend_immutable_calls.as_slice(),
+                    )
+            }))
         {
             let mut diagnostic = Diagnostic::new(MutableArgumentDefault, default.range());
 

--- a/crates/ruff_linter/src/rules/flake8_bugbear/snapshots/ruff_linter__rules__flake8_bugbear__tests__B006_B006_9.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/snapshots/ruff_linter__rules__flake8_bugbear__tests__B006_B006_9.py.snap
@@ -1,0 +1,20 @@
+---
+source: crates/ruff_linter/src/rules/flake8_bugbear/mod.rs
+---
+B006_9.py:4:19: B006 [*] Do not use mutable data structures for argument defaults
+  |
+4 | def foo(a: list = LIST):  # B006
+  |                   ^^^^ B006
+5 |     raise NotImplementedError("")
+  |
+  = help: Replace with `None`; initialize within function
+
+ℹ Unsafe fix
+1 1 | LIST = []
+2 2 | 
+3 3 | 
+4   |-def foo(a: list = LIST):  # B006
+  4 |+def foo(a: list = None):  # B006
+5 5 |     raise NotImplementedError("")
+6 6 | 
+7 7 |


### PR DESCRIPTION
## Summary

We'll now flag `def foo(a: list = LIST): ...` as a mutable default based on the annotation. (If it _is_ immutable, the annotation should be `Sequence`.)

I want to see what the ecosystem checks look like here. It might be too noisy.

Closes #11030.
