### PR TITLE
Fix link to license in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 [![image](https://img.shields.io/pypi/v/ruff.svg)](https://pypi.python.org/pypi/ruff)
-[![image](https://img.shields.io/pypi/l/ruff.svg)](https://pypi.python.org/pypi/ruff)
+[![image](https://img.shields.io/pypi/l/ruff.svg)](LICENSE)
 [![image](https://img.shields.io/pypi/pyversions/ruff.svg)](https://pypi.python.org/pypi/ruff)
 [![Actions status](https://github.com/astral-sh/ruff/workflows/CI/badge.svg)](https://github.com/astral-sh/ruff/actions)
 [![Discord](https://img.shields.io/badge/Discord-%235865F2.svg?logo=discord&logoColor=white)](https://discord.com/invite/astral-sh)
@@ -498,7 +498,7 @@ If you're using Ruff, consider adding the Ruff badge to your project's `README.m
 
 ## License
 
-MIT
+This repository is licensed under the [MIT License](LICENSE)
 
 <div align="center">
   <a target="_blank" href="https://astral.sh" style="background:none">


### PR DESCRIPTION
## Summary

Updated the readme file, so the license shields.io tag appeared in the README file would actually take users to the LICENSE file
