### PR TITLE
[`flake8-simplify`] Avoid raising `SIM911` for non-`zip` attribute calls

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_simplify/SIM911.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_simplify/SIM911.py
@@ -21,3 +21,5 @@ for k, v in zip(d2.keys(), d2.values()):  # SIM911
     ...
 
 items = zip(x.keys(), x.values())  # OK
+
+items.bar = zip(x.keys(), x.values())  # OK


### PR DESCRIPTION
## Summary

The `matches!` macro here is slightly off and allows _all_ attribute calls through.

Closes https://github.com/astral-sh/ruff/issues/11125.
