### PR TITLE
Use crossbeam-channel instead of crossbeam

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -496,19 +496,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8"
-dependencies = [
- "crossbeam-channel",
- "crossbeam-deque",
- "crossbeam-epoch",
- "crossbeam-queue",
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-channel"
 version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -532,15 +519,6 @@ name = "crossbeam-epoch"
 version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-queue"
-version = "0.3.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df0346b5d5e76ac2fe4e327c5fd1118d6be7c51dfb18f9b7922923f287471e35"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -2255,7 +2233,7 @@ name = "ruff_server"
 version = "0.2.2"
 dependencies = [
  "anyhow",
- "crossbeam",
+ "crossbeam-channel",
  "insta",
  "jod-thread",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ console_error_panic_hook = { version = "0.1.7" }
 console_log = { version = "1.0.0" }
 countme = { version = "3.0.1" }
 criterion = { version = "0.5.1", default-features = false }
-crossbeam = { version = "0.8.4" }
+crossbeam-channel = { version = "0.5.12" }
 dirs = { version = "5.0.0" }
 drop_bomb = { version = "0.1.5" }
 env_logger = { version = "0.11.0" }

--- a/crates/ruff_server/Cargo.toml
+++ b/crates/ruff_server/Cargo.toml
@@ -26,7 +26,7 @@ ruff_text_size = { path = "../ruff_text_size" }
 ruff_workspace = { path = "../ruff_workspace" }
 
 anyhow = { workspace = true }
-crossbeam = { workspace = true }
+crossbeam-channel = { workspace = true }
 jod-thread = { workspace = true }
 libc = { workspace = true }
 lsp-server = { workspace = true }

--- a/crates/ruff_server/src/server/client.rs
+++ b/crates/ruff_server/src/server/client.rs
@@ -6,7 +6,7 @@ use serde_json::Value;
 
 use super::schedule::Task;
 
-pub(crate) type ClientSender = crossbeam::channel::Sender<lsp_server::Message>;
+pub(crate) type ClientSender = crossbeam_channel::Sender<lsp_server::Message>;
 
 type ResponseBuilder<'s> = Box<dyn FnOnce(lsp_server::Response) -> Task<'s>>;
 

--- a/crates/ruff_server/src/server/schedule.rs
+++ b/crates/ruff_server/src/server/schedule.rs
@@ -1,6 +1,6 @@
 use std::num::NonZeroUsize;
 
-use crossbeam::channel::Sender;
+use crossbeam_channel::Sender;
 
 use crate::session::Session;
 

--- a/crates/ruff_server/src/server/schedule/thread/pool.rs
+++ b/crates/ruff_server/src/server/schedule/thread/pool.rs
@@ -21,7 +21,7 @@ use std::{
     },
 };
 
-use crossbeam::channel::{Receiver, Sender};
+use crossbeam_channel::{Receiver, Sender};
 
 use super::{Builder, JoinHandle, ThreadPriority};
 
@@ -52,7 +52,7 @@ impl Pool {
         let threads = usize::from(threads);
 
         // Channel buffer capacity is between 2 and 4, depending on the pool size.
-        let (job_sender, job_receiver) = crossbeam::channel::bounded(std::cmp::min(threads * 2, 4));
+        let (job_sender, job_receiver) = crossbeam_channel::bounded(std::cmp::min(threads * 2, 4));
         let extant_tasks = Arc::new(AtomicUsize::new(0));
 
         let mut handles = Vec::with_capacity(threads);


### PR DESCRIPTION
## Summary

We only use crossbeam channels, but none of the other crossbeam functionalities. 

That's why this PR replaces the `crossbeam` dependency with `crossbeam-channel` to reduce the number of our dependencies.

## Test Plan

`cargo test`
