### PR TITLE
red-knot: Add tracing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1819,6 +1819,8 @@ dependencies = [
  "tempfile",
  "textwrap",
  "tracing",
+ "tracing-subscriber",
+ "tracing-tree",
 ]
 
 [[package]]

--- a/crates/red_knot/Cargo.toml
+++ b/crates/red_knot/Cargo.toml
@@ -27,6 +27,8 @@ rustc-hash = { workspace = true }
 smallvec = { workspace = true }
 smol_str = "0.2.1"
 tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+tracing-tree = { workspace = true }
 
 [dev-dependencies]
 textwrap = "0.16.1"

--- a/crates/red_knot/src/files.rs
+++ b/crates/red_knot/src/files.rs
@@ -23,6 +23,7 @@ pub struct Files {
 }
 
 impl Files {
+    #[tracing::instrument(level = "trace", skip(path))]
     pub fn intern(&self, path: &Path) -> FileId {
         self.inner.write().intern(path)
     }

--- a/crates/red_knot/src/module.rs
+++ b/crates/red_knot/src/module.rs
@@ -164,6 +164,7 @@ pub struct ModuleData {
 /// Resolves a module name to a module id
 /// TODO: This would not work with Salsa because `ModuleName` isn't an ingredient and, therefore, cannot be used as part of a query.
 ///  For this to work with salsa, it would be necessary to intern all `ModuleName`s.
+#[tracing::instrument(level = "trace", skip(db))]
 pub fn resolve_module<Db>(db: &Db, name: ModuleName) -> Option<Module>
 where
     Db: SemanticDb + HasJar<SemanticJar>,

--- a/crates/red_knot/src/parse.rs
+++ b/crates/red_knot/src/parse.rs
@@ -63,6 +63,7 @@ impl Parsed {
     }
 }
 
+#[tracing::instrument(level = "trace", skip(db))]
 pub(crate) fn parse<Db>(db: &Db, file_id: FileId) -> Parsed
 where
     Db: SourceDb + HasJar<SourceJar>,

--- a/crates/red_knot/src/source.rs
+++ b/crates/red_knot/src/source.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 
 use crate::files::FileId;
 
+#[tracing::instrument(level = "trace", skip(db))]
 pub(crate) fn source_text<Db>(db: &Db, file_id: FileId) -> Source
 where
     Db: SourceDb + HasJar<SourceJar>,


### PR DESCRIPTION
## Summary

Setup a tracing subscriber for red-knot. I think that will become handy when debugging queries:

## Test Plan

Example output

```
┐red_knot::files::intern{self={}}
┘
   0.000170s DEBUG red_knot start analysis for workspace
┐red_knot::parse::parse{file_id=FileId(0)}
├─┐red_knot::source::source_text{file_id=FileId(0)}
├─┘
┘
┐red_knot::parse::parse{file_id=FileId(0)}
┘
┐red_knot::parse::parse{file_id=FileId(0)}
┘
```
