### PR TITLE
[`flake8-blind-expect`] Allow raise from in `BLE001`

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_blind_except/BLE.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_blind_except/BLE.py
@@ -124,3 +124,8 @@ try:
     pass
 except Exception:
     error("...", exc_info=True)
+
+try:
+    ...
+except Exception as e:
+    raise ValueError from e

--- a/crates/ruff_linter/src/rules/flake8_blind_except/rules/blind_except.rs
+++ b/crates/ruff_linter/src/rules/flake8_blind_except/rules/blind_except.rs
@@ -87,18 +87,25 @@ pub(crate) fn blind_except(
     if !matches!(builtin_exception_type, "BaseException" | "Exception") {
         return;
     }
-
     // If the exception is re-raised, don't flag an error.
     if body.iter().any(|stmt| {
-        if let Stmt::Raise(ast::StmtRaise { exc, .. }) = stmt {
-            if let Some(exc) = exc {
-                if let Expr::Name(ast::ExprName { id, .. }) = exc.as_ref() {
+        if let Stmt::Raise(ast::StmtRaise { exc, cause, .. }) = stmt {
+            if let Some(cause) = cause {
+                if let Expr::Name(ast::ExprName { id, .. }) = cause.as_ref() {
                     name.is_some_and(|name| id == name)
                 } else {
                     false
                 }
             } else {
-                true
+                if let Some(exc) = exc {
+                    if let Expr::Name(ast::ExprName { id, .. }) = exc.as_ref() {
+                        name.is_some_and(|name| id == name)
+                    } else {
+                        false
+                    }
+                } else {
+                    true
+                }
             }
         } else {
             false


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

This allows `raise from` in BLE001.

```python
try:
    ...
except Exception as e:
    raise ValueError from e
```

Fixes #10806

## Test Plan

Test case added.
