### PR TITLE
Red Knot - Add symbol flags

### DIFF
--- a/crates/red_knot/src/symbols.rs
+++ b/crates/red_knot/src/symbols.rs
@@ -870,6 +870,12 @@ mod tests {
             assert_eq!(ann_scope.kind(), ScopeKind::Annotation);
             assert_eq!(ann_scope.name(), "C");
             assert_eq!(names(table.symbols_for_scope(ann_scope_id)), vec!["T"]);
+            assert!(
+                table
+                    .symbol_by_name(ann_scope_id, "T")
+                    .is_some_and(|s| s.is_defined() && !s.is_used()),
+                "type parameters are defined by the scope that introduces them"
+            );
             let scopes = table.child_scope_ids_of(ann_scope_id);
             assert_eq!(scopes.len(), 1);
             let func_scope_id = scopes[0];

--- a/crates/red_knot/src/symbols.rs
+++ b/crates/red_knot/src/symbols.rs
@@ -502,10 +502,10 @@ impl SymbolTableBuilder {
 impl PreorderVisitor<'_> for SymbolTableBuilder {
     fn visit_expr(&mut self, expr: &ast::Expr) {
         if let ast::Expr::Name(ast::ExprName { id, ctx, .. }) = expr {
-            self.add_symbol(id);
+            self.add_or_update_symbol(id, SymbolFlags::empty());
             if matches!(ctx, ast::ExprContext::Store | ast::ExprContext::Del) {
                 if let Some(curdef) = self.current_definition.clone() {
-                    self.add_symbol_with_def(id, curdef);
+                    self.add_or_update_symbol_with_def(id, curdef);
                 }
             }
         }

--- a/crates/red_knot/src/symbols.rs
+++ b/crates/red_knot/src/symbols.rs
@@ -502,7 +502,13 @@ impl SymbolTableBuilder {
 impl PreorderVisitor<'_> for SymbolTableBuilder {
     fn visit_expr(&mut self, expr: &ast::Expr) {
         if let ast::Expr::Name(ast::ExprName { id, ctx, .. }) = expr {
-            self.add_or_update_symbol(id, SymbolFlags::empty());
+            let flags = match ctx {
+                ast::ExprContext::Load => SymbolFlags::IS_USED,
+                ast::ExprContext::Store => SymbolFlags::IS_DEFINED,
+                ast::ExprContext::Del => SymbolFlags::IS_DEFINED,
+                ast::ExprContext::Invalid => SymbolFlags::empty(),
+            };
+            self.add_or_update_symbol(id, flags);
             if matches!(ctx, ast::ExprContext::Store | ast::ExprContext::Del) {
                 if let Some(curdef) = self.current_definition.clone() {
                     self.add_or_update_symbol_with_def(id, curdef);

--- a/crates/red_knot/src/symbols.rs
+++ b/crates/red_knot/src/symbols.rs
@@ -489,7 +489,7 @@ impl SymbolTableBuilder {
                     ast::TypeParam::ParamSpec(ast::TypeParamParamSpec { name, .. }) => name,
                     ast::TypeParam::TypeVarTuple(ast::TypeParamTypeVarTuple { name, .. }) => name,
                 };
-                self.add_or_update_symbol(name, SymbolFlags::IS_USED);
+                self.add_or_update_symbol(name, SymbolFlags::IS_DEFINED);
             }
         }
         nested(self);

--- a/crates/red_knot/src/symbols.rs
+++ b/crates/red_knot/src/symbols.rs
@@ -104,8 +104,7 @@ bitflags! {
 pub(crate) struct Symbol {
     name: Name,
     flags: SymbolFlags,
-    /// Not yet implemented
-    kind: Kind,
+    // kind: Kind,
 }
 
 impl Symbol {

--- a/crates/red_knot/src/symbols.rs
+++ b/crates/red_knot/src/symbols.rs
@@ -91,7 +91,7 @@ pub(crate) enum Kind {
 }
 
 bitflags! {
-    #[derive(Debug)]
+    #[derive(Copy,Clone,Debug)]
     pub(crate) struct SymbolFlags: u8 {
         const IS_USED         = 1 << 0;
         const IS_DEFINED      = 1 << 1;
@@ -509,7 +509,7 @@ impl PreorderVisitor<'_> for SymbolTableBuilder {
                 ast::ExprContext::Invalid => SymbolFlags::empty(),
             };
             self.add_or_update_symbol(id, flags);
-            if matches!(ctx, ast::ExprContext::Store | ast::ExprContext::Del) {
+            if flags.contains(SymbolFlags::IS_DEFINED) {
                 if let Some(curdef) = self.current_definition.clone() {
                     self.add_or_update_symbol_with_def(id, curdef);
                 }

--- a/crates/red_knot/src/symbols.rs
+++ b/crates/red_knot/src/symbols.rs
@@ -712,6 +712,13 @@ mod tests {
                     .len(),
                 1
             );
+            assert!(
+                table.root_symbol_id_by_name("foo").is_some_and(|sid| {
+                    let s = sid.symbol(&table);
+                    s.is_defined() || !s.is_used()
+                }),
+                "symbols that are defined get the defined flag"
+            );
         }
 
         #[test]

--- a/crates/red_knot/src/symbols.rs
+++ b/crates/red_knot/src/symbols.rs
@@ -895,7 +895,7 @@ mod tests {
     fn symbol_from_id() {
         let mut table = SymbolTable::new();
         let root_scope_id = SymbolTable::root_scope_id();
-        let foo_symbol_id = table.add_symbol_to_scope(root_scope_id, "foo");
+        let foo_symbol_id = table.add_symbol_to_scope(root_scope_id, "foo", SymbolFlags::empty());
         let symbol = foo_symbol_id.symbol(&table);
         assert_eq!(symbol.name.as_str(), "foo");
     }

--- a/crates/red_knot/src/symbols.rs
+++ b/crates/red_knot/src/symbols.rs
@@ -321,9 +321,9 @@ impl SymbolTable {
 
         match entry {
             RawEntryMut::Occupied(entry) => {
-                self.symbols_by_id.get_mut(*entry.key()).map(|symbol| {
+                if let Some(symbol) = self.symbols_by_id.get_mut(*entry.key()) {
                     symbol.flags.insert(flags);
-                });
+                };
                 *entry.key()
             }
             RawEntryMut::Vacant(entry) => {

--- a/crates/red_knot/src/symbols.rs
+++ b/crates/red_knot/src/symbols.rs
@@ -95,7 +95,9 @@ bitflags! {
     pub(crate) struct SymbolFlags: u8 {
         const IS_USED         = 1 << 0;
         const IS_DEFINED      = 1 << 1;
+        /// TODO: This flag is not yet set by anything
         const MARKED_GLOBAL   = 1 << 2;
+        /// TODO: This flag is not yet set by anything
         const MARKED_NONLOCAL = 1 << 3;
     }
 }

--- a/crates/red_knot/src/symbols.rs
+++ b/crates/red_knot/src/symbols.rs
@@ -104,7 +104,8 @@ bitflags! {
 pub(crate) struct Symbol {
     name: Name,
     flags: SymbolFlags,
-    //kind: Kind, // TODO: might not be a field at all if we can determine from flags
+    /// Not yet implemented
+    kind: Kind,
 }
 
 impl Symbol {
@@ -122,7 +123,9 @@ impl Symbol {
         self.flags.contains(SymbolFlags::IS_DEFINED)
     }
 
-    // TODO: 2nd pass analysis to categorize as: free-var, cell-var, explicit-global, implicit-global
+    // TODO: implement Symbol.kind 2-pass analysis to categorize as: free-var, cell-var,
+    // explicit-global, implicit-global and implement Symbol.kind by modifying the preorder
+    // traversal code
 }
 
 // TODO storing TypedNodeKey for definitions means we have to search to find them again in the AST;

--- a/crates/red_knot/src/symbols.rs
+++ b/crates/red_knot/src/symbols.rs
@@ -86,6 +86,7 @@ impl Scope {
 pub(crate) enum Kind {
     FreeVar,
     CellVar,
+    CellVarAssigned,
     ExplicitGlobal,
     ImplicitGlobal,
 }

--- a/crates/red_knot/src/symbols.rs
+++ b/crates/red_knot/src/symbols.rs
@@ -738,6 +738,13 @@ mod tests {
                     .len(),
                 1
             );
+            assert!(
+                table.root_symbol_id_by_name("foo").is_some_and(|sid| {
+                    let s = sid.symbol(&table);
+                    !s.is_defined() && s.is_used()
+                }),
+                "a symbol used but not defined in a scope should have only the used flag"
+            );
         }
 
         #[test]

--- a/crates/red_knot/src/symbols.rs
+++ b/crates/red_knot/src/symbols.rs
@@ -83,7 +83,7 @@ impl Scope {
 }
 
 #[derive(Debug)]
-pub(crate) enum Disposition {
+pub(crate) enum Kind {
     FreeVar,
     CellVar,
     ExplicitGlobal,
@@ -104,7 +104,7 @@ bitflags! {
 pub(crate) struct Symbol {
     name: Name,
     flags: SymbolFlags,
-    //disposition: Disposition, // TODO: might not be a field at all if we can determine from flags
+    //kind: Kind, // TODO: might not be a field at all if we can determine from flags
 }
 
 impl Symbol {

--- a/crates/red_knot/src/symbols.rs
+++ b/crates/red_knot/src/symbols.rs
@@ -864,9 +864,11 @@ mod tests {
     fn insert_same_name_symbol_twice() {
         let mut table = SymbolTable::new();
         let root_scope_id = SymbolTable::root_scope_id();
-        let symbol_id_1 = table.add_or_update_symbol(root_scope_id, "foo", SymbolFlags::empty());
-        let symbol_id_2 = table.add_or_update_symbol(root_scope_id, "foo", SymbolFlags::empty());
+        let symbol_id_1 = table.add_or_update_symbol(root_scope_id, "foo", SymbolFlags::IS_DEFINED);
+        let symbol_id_2 = table.add_or_update_symbol(root_scope_id, "foo", SymbolFlags::IS_USED);
         assert_eq!(symbol_id_1, symbol_id_2);
+        assert!(symbol_id_1.symbol(&table).is_used(), "flags must merge");
+        assert!(symbol_id_1.symbol(&table).is_defined(), "flags must merge");
     }
 
     #[test]

--- a/crates/red_knot/src/symbols.rs
+++ b/crates/red_knot/src/symbols.rs
@@ -82,6 +82,14 @@ impl Scope {
     }
 }
 
+#[derive(Debug)]
+pub(crate) enum Disposition {
+    FreeVar,
+    CellVar,
+    ExplicitGlobal,
+    ImplicitGlobal,
+}
+
 bitflags! {
     #[derive(Debug)]
     pub(crate) struct SymbolFlags: u8 {
@@ -96,6 +104,7 @@ bitflags! {
 pub(crate) struct Symbol {
     name: Name,
     flags: SymbolFlags,
+    //disposition: Disposition, // TODO: might not be a field at all if we can determine from flags
 }
 
 impl Symbol {
@@ -112,6 +121,8 @@ impl Symbol {
     pub(crate) fn is_defined(&self) -> bool {
         self.flags.contains(SymbolFlags::IS_DEFINED)
     }
+
+    // TODO: 2nd pass analysis to categorize as: free-var, cell-var, explicit-global, implicit-global
 }
 
 // TODO storing TypedNodeKey for definitions means we have to search to find them again in the AST;


### PR DESCRIPTION
* Adds `Symbol.flag` bitfield. Populates it from (the three renamed) `add_or_update_symbol*` methods.
* Currently there are these flags supported:
  * `IS_DEFINED` is set in a scope where a variable is defined.
  * `IS_USED` is set in a scope where a variable is referenced. (To have both this and `IS_DEFINED` would require two separate appearances of a variable in the same scope-- one def and one use.)
  * `MARKED_GLOBAL` and `MARKED_NONLOCAL` are **not yet implemented**. (*TODO: While traversing, if you find these declarations, add these flags to the variable.*)
* Adds `Symbol.kind` field (commented) and the data structure which will populate it: `Kind` which is an enum of freevar, cellvar, implicit_global, and implicit_local. **Not yet populated**. (*TODO: a second pass over the scope (or the ast?) will observe the `MARKED_GLOBAL` and `MARKED_NONLOCAL` flags to populate this field. When that's added, we'll uncomment the field.*)
* Adds a few tests that the `IS_DEFINED` and `IS_USED` fields are correctly set and/or merged:
  * Unit test that subsequent calls to `add_or_update_symbol` will merge the flag arguments.
  * Unit test that in the statement `x = foo`, the variable `foo` is considered used but not defined.
  * Unit test that in the statement `from bar import foo`, the variable `foo` is considered defined but not used.