### PR TITLE
README: add Apache Superset to project list

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ times faster than any individual tool.
 Ruff is extremely actively developed and used in major open-source projects like:
 
 - [Apache Airflow](https://github.com/apache/airflow)
+- [Apache Superset](https://github.com/apache/superset)
 - [FastAPI](https://github.com/tiangolo/fastapi)
 - [Hugging Face](https://github.com/huggingface/transformers)
 - [Pandas](https://github.com/pandas-dev/pandas)


### PR DESCRIPTION
## Summary

Stoked to have found` ruff` and migrated over - quick testimonial ->

> Our smooth and fast migration to ruff allowed us to deprecate 4+ other disjointed tools (pycln, pyupgrade, black, isort, flake8) that each had their own CLI subcommands, different enabling/disabling semantics, and pre-commit hooks. I can't wait to add pylint to the list. It's such a no brainer to replace all this with the Ferrari of linters.`--add-no-qa` and `--ignore-noqa` are so convenient, but `--fix` takes it home!