### PR TITLE
feat: distinguish * and ** in globs

### DIFF
--- a/crates/ruff/tests/snapshots/show_settings__display_default_settings.snap
+++ b/crates/ruff/tests/snapshots/show_settings__display_default_settings.snap
@@ -58,8 +58,8 @@ file_resolver.extend_exclude = [
 ]
 file_resolver.force_exclude = false
 file_resolver.include = [
-	"*.py",
-	"*.pyi",
+	"**/*.py",
+	"**/*.pyi",
 	"**/pyproject.toml",
 ]
 file_resolver.extend_include = []

--- a/crates/ruff_linter/src/rules/pep8_naming/settings.rs
+++ b/crates/ruff_linter/src/rules/pep8_naming/settings.rs
@@ -4,7 +4,7 @@ use std::error::Error;
 use std::fmt;
 use std::fmt::Formatter;
 
-use globset::{Glob, GlobSet, GlobSetBuilder};
+use globset::{GlobBuilder, GlobSet, GlobSetBuilder};
 
 use ruff_cache::{CacheKey, CacheKeyHasher};
 use ruff_macros::CacheKey;
@@ -113,12 +113,22 @@ impl IgnoreNames {
         // defaults
         if let Some(names) = ignore_names {
             for name in names {
-                builder.add(Glob::new(&name).map_err(SettingsError::InvalidIgnoreName)?);
+                builder.add(
+                    GlobBuilder::new(&name)
+                        .literal_separator(true)
+                        .build()
+                        .map_err(SettingsError::InvalidIgnoreName)?,
+                );
                 literals.push(name);
             }
         } else {
             for name in DEFAULTS {
-                builder.add(Glob::new(name).unwrap());
+                builder.add(
+                    GlobBuilder::new(name)
+                        .literal_separator(true)
+                        .build()
+                        .unwrap(),
+                );
                 literals.push((*name).to_string());
             }
         }
@@ -126,7 +136,12 @@ impl IgnoreNames {
         // Add the ignored names from the `extend-ignore-names` option.
         if let Some(names) = extend_ignore_names {
             for name in names {
-                builder.add(Glob::new(&name).map_err(SettingsError::InvalidIgnoreName)?);
+                builder.add(
+                    GlobBuilder::new(&name)
+                        .literal_separator(true)
+                        .build()
+                        .map_err(SettingsError::InvalidIgnoreName)?,
+                );
                 literals.push(name);
             }
         }
@@ -166,7 +181,12 @@ impl IgnoreNames {
         let mut literals = Vec::new();
 
         for name in patterns {
-            builder.add(Glob::new(&name).map_err(SettingsError::InvalidIgnoreName)?);
+            builder.add(
+                GlobBuilder::new(&name)
+                    .literal_separator(true)
+                    .build()
+                    .map_err(SettingsError::InvalidIgnoreName)?,
+            );
             literals.push(name);
         }
 

--- a/crates/ruff_workspace/src/settings.rs
+++ b/crates/ruff_workspace/src/settings.rs
@@ -135,8 +135,8 @@ pub(crate) static EXCLUDE: &[FilePattern] = &[
 ];
 
 pub(crate) static INCLUDE: &[FilePattern] = &[
-    FilePattern::Builtin("*.py"),
-    FilePattern::Builtin("*.pyi"),
+    FilePattern::Builtin("**/*.py"),
+    FilePattern::Builtin("**/*.pyi"),
     FilePattern::Builtin("**/pyproject.toml"),
 ];
 


### PR DESCRIPTION
## Summary

Set `literal_separator` to `true` for globs.

## Motivation

By default, the `globset` crate matches files in a fairly straightforward way, which results in `foo/*.py` matching `foo/hello.py` as well as `foo/bar/hello.py`.

This commit changes this by setting the `literal_separator` option to `true`, which ensures that `*` and `?` never match a path separator. This would align Ruff's behaviour with the [gitignore specification](https://git-scm.com/docs/gitignore#_pattern_format).

- Resolves: #6262

## Test Plan

So far, `cargo test` work, but please advise if you would like me to add new tests specifically for this change (and please point me in the right direction).