### PR TITLE
`ruff server`: Support a custom TOML configuration file

### DIFF
--- a/crates/ruff_server/src/session/settings.rs
+++ b/crates/ruff_server/src/session/settings.rs
@@ -1,4 +1,4 @@
-use std::{ops::Deref, str::FromStr};
+use std::{ffi::OsString, ops::Deref, path::PathBuf, str::FromStr};
 
 use lsp_types::Url;
 use ruff_linter::{line_width::LineLength, RuleSelector};
@@ -31,6 +31,7 @@ pub(crate) struct ResolvedClientSettings {
 #[derive(Clone, Debug)]
 #[cfg_attr(test, derive(PartialEq, Eq))]
 pub(crate) struct ResolvedEditorSettings {
+    pub(super) configuration: Option<PathBuf>,
     pub(super) lint_preview: Option<bool>,
     pub(super) format_preview: Option<bool>,
     pub(super) select: Option<Vec<RuleSelector>>,
@@ -62,6 +63,7 @@ pub(crate) enum ConfigurationPreference {
 #[cfg_attr(test, derive(PartialEq, Eq))]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct ClientSettings {
+    configuration: Option<String>,
     fix_all: Option<bool>,
     organize_imports: Option<bool>,
     lint: Option<LintOptions>,
@@ -229,6 +231,12 @@ impl ResolvedClientSettings {
                 true,
             ),
             editor_settings: ResolvedEditorSettings {
+                configuration: Self::resolve_optional(all_settings, |settings| {
+                    settings
+                        .configuration
+                        .as_ref()
+                        .map(|config_path| OsString::from(config_path.clone()).into())
+                }),
                 lint_preview: Self::resolve_optional(all_settings, |settings| {
                     settings.lint.as_ref()?.preview
                 }),
@@ -357,6 +365,7 @@ mod tests {
         assert_debug_snapshot!(options, @r###"
         HasWorkspaces {
             global_settings: ClientSettings {
+                configuration: None,
                 fix_all: Some(
                     false,
                 ),
@@ -411,6 +420,7 @@ mod tests {
             workspace_settings: [
                 WorkspaceSettings {
                     settings: ClientSettings {
+                        configuration: None,
                         fix_all: Some(
                             true,
                         ),
@@ -469,6 +479,7 @@ mod tests {
                 },
                 WorkspaceSettings {
                     settings: ClientSettings {
+                        configuration: None,
                         fix_all: Some(
                             true,
                         ),
@@ -555,6 +566,7 @@ mod tests {
                 disable_rule_comment_enable: false,
                 fix_violation_enable: false,
                 editor_settings: ResolvedEditorSettings {
+                    configuration: None,
                     lint_preview: Some(true),
                     format_preview: None,
                     select: Some(vec![
@@ -584,6 +596,7 @@ mod tests {
                 disable_rule_comment_enable: true,
                 fix_violation_enable: false,
                 editor_settings: ResolvedEditorSettings {
+                    configuration: None,
                     lint_preview: Some(false),
                     format_preview: None,
                     select: Some(vec![
@@ -608,6 +621,7 @@ mod tests {
         GlobalOnly {
             settings: Some(
                 ClientSettings {
+                    configuration: None,
                     fix_all: Some(
                         false,
                     ),
@@ -671,6 +685,7 @@ mod tests {
                 disable_rule_comment_enable: false,
                 fix_violation_enable: true,
                 editor_settings: ResolvedEditorSettings {
+                    configuration: None,
                     lint_preview: None,
                     format_preview: None,
                     select: None,

--- a/crates/ruff_server/src/session/settings.rs
+++ b/crates/ruff_server/src/session/settings.rs
@@ -45,14 +45,15 @@ pub(crate) struct ResolvedEditorSettings {
 /// Determines how multiple conflicting configurations should be resolved - in this
 /// case, the configuration from the client settings and configuration from local
 /// `.toml` files (aka 'workspace' configuration).
-#[derive(Clone, Copy, Debug, Deserialize, Default)]
-#[cfg_attr(test, derive(PartialEq, Eq))]
+#[derive(Clone, Copy, Debug, Deserialize, Default, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub(crate) enum ConfigurationPreference {
-    /// Configuration set in the editor takes priority over workspace configuration set in `.toml` files.
+    /// Configuration set in the editor takes priority over configuration set in `.toml` files.
+    /// If a custom configuration file is provided, local configuration will be ignored.
     #[default]
     EditorFirst,
     /// Configuration set in `.toml` files takes priority over configuration set in the editor.
+    /// If a custom configuration file is set, it will be ignored in favor of local project configuration.
     FilesystemFirst,
     /// `.toml` files are ignored completely, and only the editor configuration is used.
     EditorOnly,

--- a/crates/ruff_server/src/session/settings.rs
+++ b/crates/ruff_server/src/session/settings.rs
@@ -49,11 +49,9 @@ pub(crate) struct ResolvedEditorSettings {
 #[serde(rename_all = "camelCase")]
 pub(crate) enum ConfigurationPreference {
     /// Configuration set in the editor takes priority over configuration set in `.toml` files.
-    /// If a custom configuration file is provided, local configuration will be ignored.
     #[default]
     EditorFirst,
     /// Configuration set in `.toml` files takes priority over configuration set in the editor.
-    /// If a custom configuration file is set, it will be ignored in favor of local project configuration.
     FilesystemFirst,
     /// `.toml` files are ignored completely, and only the editor configuration is used.
     EditorOnly,

--- a/crates/ruff_server/src/session/workspace/ruff_settings.rs
+++ b/crates/ruff_server/src/session/workspace/ruff_settings.rs
@@ -123,7 +123,7 @@ impl<'a> ConfigurationTransformer for EditorConfigurationTransformer<'a> {
 
         let project_root = self.1;
 
-        let mut editor_configuration = Configuration {
+        let editor_configuration = Configuration {
             lint: LintConfiguration {
                 preview: lint_preview.map(PreviewMode::from),
                 rule_selections: vec![RuleSelection {
@@ -153,8 +153,12 @@ impl<'a> ConfigurationTransformer for EditorConfigurationTransformer<'a> {
 
         if let Some(config_file_path) = configuration {
             match open_configuration_file(&config_file_path, project_root) {
+                // if a custom configuration file was given and the configuration preference is
+                // _not_ filesystem-first, return early with the combined editor configuration.
                 Ok(config_from_file) => {
-                    editor_configuration = editor_configuration.combine(config_from_file);
+                    if configuration_preference != ConfigurationPreference::FilesystemFirst {
+                        return editor_configuration.combine(config_from_file);
+                    }
                 }
                 Err(err) => tracing::error!("Unable to find custom configuration file {err}"),
             }

--- a/crates/ruff_server/src/session/workspace/ruff_settings.rs
+++ b/crates/ruff_server/src/session/workspace/ruff_settings.rs
@@ -151,18 +151,18 @@ impl<'a> ConfigurationTransformer for EditorConfigurationTransformer<'a> {
             ..Default::default()
         };
 
-        if let Some(config_file_path) = configuration {
+        // Merge in the editor-specified configuration file, if it exists
+        let editor_configuration = if let Some(config_file_path) = configuration {
             match open_configuration_file(&config_file_path, project_root) {
-                // if a custom configuration file was given and the configuration preference is
-                // _not_ filesystem-first, return early with the combined editor configuration.
-                Ok(config_from_file) => {
-                    if configuration_preference != ConfigurationPreference::FilesystemFirst {
-                        return editor_configuration.combine(config_from_file);
-                    }
+                Ok(config_from_file) => editor_configuration.combine(config_from_file),
+                Err(err) => {
+                    tracing::error!("Unable to find editor-specified configuration file {err}");
+                    editor_configuration
                 }
-                Err(err) => tracing::error!("Unable to find custom configuration file {err}"),
             }
-        }
+        } else {
+            editor_configuration
+        };
 
         match configuration_preference {
             ConfigurationPreference::EditorFirst => {


### PR DESCRIPTION
## Summary

Closes #10985.

The server now supports a custom TOML configuration file as a client setting. The setting must be an absolute path to a file. If the file is called `pyproject.toml`, the server will attempt to parse it as a pyproject file - otherwise, it will attempt to parse it as a `ruff.toml` file, even if the file has a name besides `ruff.toml`.

If an option is set in both the custom TOML configuration file and in the client settings directly, the latter will be used.

## Test Plan

1. Create a `ruff.toml` file outside of the workspace you are testing. Set an option that is different from the one in the configuration for your test workspace.
2. Set the path to the configuration in NeoVim:
```lua
require('lspconfig').ruff.setup {
    init_options = {
      settings = {
        configuration = "absolute/path/to/your/configuration"
      }
    }
}
```
3. Confirm that the option in the configuration file is used, regardless of what the option is set to in the workspace configuration.
4. Add the same option, with a different value, to the NeoVim configuration directly. For example:
```lua
require('lspconfig').ruff.setup {
    init_options = {
      settings = {
        configuration = "absolute/path/to/your/configuration",
        lint = {
          select = []
        }
      }
    }
}
```
5. Confirm that the option set in client settings is used, regardless of the value in either the custom configuration file or in the workspace configuration.