### PR TITLE
Docs: mention `lint.typing-modules` in `TCH001`, `TCH002`, `TCH003`

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_type_checking/rules/typing_only_runtime_import.rs
+++ b/crates/ruff_linter/src/rules/flake8_type_checking/rules/typing_only_runtime_import.rs
@@ -67,6 +67,7 @@ use crate::rules::isort::{categorize, ImportSection, ImportType};
 /// - `lint.flake8-type-checking.quote-annotations`
 /// - `lint.flake8-type-checking.runtime-evaluated-base-classes`
 /// - `lint.flake8-type-checking.runtime-evaluated-decorators`
+/// - `lint.typing-modules`
 ///
 /// ## References
 /// - [PEP 536](https://peps.python.org/pep-0563/#runtime-annotation-resolution-and-type-checking)
@@ -140,6 +141,7 @@ impl Violation for TypingOnlyFirstPartyImport {
 /// - `lint.flake8-type-checking.quote-annotations`
 /// - `lint.flake8-type-checking.runtime-evaluated-base-classes`
 /// - `lint.flake8-type-checking.runtime-evaluated-decorators`
+/// - `lint.typing-modules`
 ///
 /// ## References
 /// - [PEP 536](https://peps.python.org/pep-0563/#runtime-annotation-resolution-and-type-checking)
@@ -213,6 +215,7 @@ impl Violation for TypingOnlyThirdPartyImport {
 /// - `lint.flake8-type-checking.quote-annotations`
 /// - `lint.flake8-type-checking.runtime-evaluated-base-classes`
 /// - `lint.flake8-type-checking.runtime-evaluated-decorators`
+/// - `lint.typing-modules`
 ///
 /// ## References
 /// - [PEP 536](https://peps.python.org/pep-0563/#runtime-annotation-resolution-and-type-checking)


### PR DESCRIPTION
## Summary

Mention `lint.typing-modules` in `TCH001`, `TCH002`, `TCH003`; close #11142.