### PR TITLE
Use `macos-12` to build release wheels

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -58,7 +58,7 @@ jobs:
           path: dist
 
   macos-x86_64:
-    runs-on: macos-latest
+    runs-on: macos-12
     steps:
       - uses: actions/checkout@v4
         with:
@@ -98,7 +98,7 @@ jobs:
             *.sha256
 
   macos-universal:
-    runs-on: macos-latest
+    runs-on: macos-12
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Summary

GitHub has started to change `macos-latest` to `macos-14`. But executables built on `macos-14` don't work on macOS 11 (see: https://github.com/astral-sh/uv/issues/3261). This PR explicitly uses `macos-12` instead (which is what we _intended_ to be using anyway).
