### PR TITLE
Display the AST even with syntax errors

### DIFF
--- a/crates/ruff_wasm/src/lib.rs
+++ b/crates/ruff_wasm/src/lib.rs
@@ -18,7 +18,7 @@ use ruff_python_codegen::Stylist;
 use ruff_python_formatter::{format_module_ast, pretty_comments, PyFormatContext, QuoteStyle};
 use ruff_python_index::{CommentRangesBuilder, Indexer};
 use ruff_python_parser::lexer::LexResult;
-use ruff_python_parser::{parse_tokens, tokenize_all, AsMode, Mode};
+use ruff_python_parser::{parse_tokens, tokenize_all, AsMode, Mode, Program};
 use ruff_python_trivia::CommentRanges;
 use ruff_source_file::{Locator, SourceLocation};
 use ruff_text_size::Ranged;
@@ -250,9 +250,9 @@ impl Workspace {
 
     /// Parses the content and returns its AST
     pub fn parse(&self, contents: &str) -> Result<String, Error> {
-        let parsed = ruff_python_parser::parse(contents, Mode::Module).map_err(into_error)?;
+        let program = Program::parse_str(contents, Mode::Module);
 
-        Ok(format!("{parsed:#?}"))
+        Ok(format!("{:#?}", program.into_ast()))
     }
 
     pub fn tokens(&self, contents: &str) -> Result<String, Error> {


### PR DESCRIPTION
## Summary

This PR updates the playground to display the AST even if it contains a syntax error. This could be useful for development and also to give a quick preview of what error recovery looks like.

Note that not all recovery is correct but this allows us to iterate quickly on what can be improved.

## Test Plan

Build the playground locally and test it.

<img width="1688" alt="Screenshot 2024-04-25 at 21 02 22" src="https://github.com/astral-sh/ruff/assets/67177269/2b94934c-4f2c-4a9a-9693-3d8460ed9d0b">
