### PR TITLE
Delete unused methods from `Parameters`

### DIFF
--- a/crates/ruff_linter/src/rules/pycodestyle/rules/lambda_assignment.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/lambda_assignment.rs
@@ -196,9 +196,7 @@ fn function(
         value: Some(Box::new(body.clone())),
         range: TextRange::default(),
     });
-    let parameters = parameters
-        .cloned()
-        .unwrap_or_else(|| Parameters::empty(TextRange::default()));
+    let parameters = parameters.cloned().unwrap_or_default();
     if let Some(annotation) = annotation {
         if let Some((arg_types, return_type)) = extract_types(annotation, semantic) {
             // A `lambda` expression can only have positional and positional-only

--- a/crates/ruff_linter/src/rules/pylint/rules/no_self_use.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/no_self_use.rs
@@ -1,8 +1,8 @@
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
+use ruff_python_ast as ast;
 use ruff_python_ast::identifier::Identifier;
 use ruff_python_ast::name::QualifiedName;
-use ruff_python_ast::{self as ast, ParameterWithDefault};
 use ruff_python_semantic::{
     analyze::{function_type, visibility},
     Scope, ScopeId, ScopeKind,
@@ -102,9 +102,8 @@ pub(crate) fn no_self_use(
         .posonlyargs
         .iter()
         .chain(&parameters.args)
-        .chain(&parameters.kwonlyargs)
         .next()
-        .map(ParameterWithDefault::as_parameter)
+        .map(|param| &param.parameter)
     else {
         return;
     };

--- a/crates/ruff_python_ast/src/nodes.rs
+++ b/crates/ruff_python_ast/src/nodes.rs
@@ -3183,7 +3183,7 @@ pub struct Decorator {
 ///
 /// NOTE: This type differs from the original Python AST. See: [arguments](https://docs.python.org/3/library/ast.html#ast.arguments).
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Default)]
 pub struct Parameters {
     pub range: TextRange,
     pub posonlyargs: Vec<ParameterWithDefault>,
@@ -3407,48 +3407,6 @@ impl Deref for TypeParams {
 }
 
 pub type Suite = Vec<Stmt>;
-
-impl Parameters {
-    pub fn empty(range: TextRange) -> Self {
-        Self {
-            range,
-            posonlyargs: Vec::new(),
-            args: Vec::new(),
-            vararg: None,
-            kwonlyargs: Vec::new(),
-            kwarg: None,
-        }
-    }
-}
-
-impl ParameterWithDefault {
-    pub fn as_parameter(&self) -> &Parameter {
-        &self.parameter
-    }
-}
-
-impl Parameters {
-    pub fn defaults(&self) -> impl std::iter::Iterator<Item = &Expr> {
-        self.posonlyargs
-            .iter()
-            .chain(self.args.iter())
-            .filter_map(|arg| arg.default.as_ref().map(std::convert::AsRef::as_ref))
-    }
-
-    #[allow(clippy::type_complexity)]
-    pub fn split_kwonlyargs(&self) -> (Vec<&Parameter>, Vec<(&Parameter, &Expr)>) {
-        let mut args = Vec::new();
-        let mut with_defaults = Vec::new();
-        for arg in &self.kwonlyargs {
-            if let Some(ref default) = arg.default {
-                with_defaults.push((arg.as_parameter(), &**default));
-            } else {
-                args.push(arg.as_parameter());
-            }
-        }
-        (args, with_defaults)
-    }
-}
 
 /// The kind of escape command as defined in [IPython Syntax] in the IPython codebase.
 ///

--- a/crates/ruff_python_parser/src/parser/statement.rs
+++ b/crates/ruff_python_parser/src/parser/statement.rs
@@ -6,7 +6,7 @@ use rustc_hash::FxHashSet;
 use ruff_python_ast::{
     self as ast, ExceptHandler, Expr, ExprContext, IpyEscapeKind, Operator, Stmt, WithItem,
 };
-use ruff_text_size::{Ranged, TextRange, TextSize};
+use ruff_text_size::{Ranged, TextSize};
 
 use crate::parser::expression::{GeneratorExpressionInParentheses, ParsedExpr, EXPR_SET};
 use crate::parser::progress::ParserProgress;
@@ -2861,7 +2861,7 @@ impl<'src> Parser<'src> {
         // the parser will drop the previous ones. Another thing is the vararg and kwarg
         // uses `Parameter` (not `ParameterWithDefault`) which means that the parser cannot
         // recover well from `*args=(1, 2)`.
-        let mut parameters = ast::Parameters::empty(TextRange::default());
+        let mut parameters = ast::Parameters::default();
 
         let mut seen_default_param = false; // `a=10`
         let mut seen_positional_only_separator = false; // `/`


### PR DESCRIPTION
## Summary

I was reading through `nodes.rs`, and wondered what the `Parameters::defaults()` and `Parameters::split_kwonlyargs()` methods were used for (especially the second one, which seemed complex!). Turns out, we don't use them at all -- so this PR gets rid of them.

While I was here, I also:
- Got rid of `ParameterWithDefault::as_parameter()`. This has a single callsite, but it's less code just to use a simple closure at that callsite, so it doesn't seem to be worth a convenience method to me.
- Got rid of `Parameters::empty()`, and derived `Parameters::default()` instead. The only difference between the two is that `Parameters::empty()` currently requires you to pass in a `TextRange` instance -- but we only use the method twice across our codebase currently, and in both instances, we construct it with `Parameters::empty(TextRange::default())`. 

## Test Plan

`cargo test`
