### PR TITLE
[red-knot] per-module arenas

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1809,6 +1809,7 @@ dependencies = [
  "ctrlc",
  "dashmap",
  "hashbrown 0.14.3",
+ "indexmap",
  "log",
  "notify",
  "parking_lot",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ hexf-parse = { version = "0.2.1" }
 ignore = { version = "0.4.22" }
 imara-diff = { version = "0.1.5" }
 imperative = { version = "1.0.4" }
+indexmap = { version = "2.2.6" }
 indicatif = { version = "0.17.8" }
 indoc = { version = "2.0.4" }
 insta = { version = "1.35.1", feature = ["filters", "glob"] }

--- a/crates/red_knot/Cargo.toml
+++ b/crates/red_knot/Cargo.toml
@@ -25,6 +25,7 @@ ctrlc = "3.4.4"
 crossbeam-channel = { workspace = true }
 dashmap = { workspace = true }
 hashbrown = { workspace = true }
+indexmap = { workspace = true }
 log = { workspace = true }
 notify = { workspace = true }
 parking_lot = { workspace = true }

--- a/crates/red_knot/src/db.rs
+++ b/crates/red_knot/src/db.rs
@@ -7,6 +7,7 @@ use crate::module::{Module, ModuleData, ModuleName, ModuleResolver, ModuleSearch
 use crate::parse::{Parsed, ParsedStorage};
 use crate::source::{Source, SourceStorage};
 use crate::symbols::{SymbolTable, SymbolTablesStorage};
+use crate::types::TypeStore;
 
 pub trait SourceDb {
     // queries
@@ -48,6 +49,7 @@ pub struct SourceJar {
 pub struct SemanticJar {
     pub module_resolver: ModuleResolver,
     pub symbol_tables: SymbolTablesStorage,
+    pub type_store: TypeStore,
 }
 
 /// Gives access to a specific jar in the database.

--- a/crates/red_knot/src/lib.rs
+++ b/crates/red_knot/src/lib.rs
@@ -25,6 +25,7 @@ pub mod watch;
 pub(crate) type FxDashMap<K, V> = dashmap::DashMap<K, V, BuildHasherDefault<FxHasher>>;
 #[allow(unused)]
 pub(crate) type FxDashSet<V> = dashmap::DashSet<V, BuildHasherDefault<FxHasher>>;
+pub(crate) type FxIndexSet<V> = indexmap::set::IndexSet<V, BuildHasherDefault<FxHasher>>;
 
 #[derive(Debug)]
 pub struct Workspace {

--- a/crates/red_knot/src/module.rs
+++ b/crates/red_knot/src/module.rs
@@ -573,12 +573,6 @@ impl PackageKind {
     }
 }
 
-/// Give back an arbitrary `Module` id not backed by the db; for tests only
-#[cfg(test)]
-pub fn test_module(id: u32) -> Module {
-    Module(id)
-}
-
 #[cfg(test)]
 mod tests {
     use crate::db::tests::TestDb;

--- a/crates/red_knot/src/module.rs
+++ b/crates/red_knot/src/module.rs
@@ -573,6 +573,12 @@ impl PackageKind {
     }
 }
 
+/// Give back an arbitrary `Module` id not backed by the db; for tests only
+#[cfg(test)]
+pub fn test_module(id: u32) -> Module {
+    Module(id)
+}
+
 #[cfg(test)]
 mod tests {
     use crate::db::tests::TestDb;

--- a/crates/red_knot/src/program/mod.rs
+++ b/crates/red_knot/src/program/mod.rs
@@ -49,6 +49,8 @@ impl Program {
             self.source.sources.remove(&change.id);
             self.source.parsed.remove(&change.id);
             self.source.lint_syntax.remove(&change.id);
+            // TODO: remove all dependent modules as well
+            self.semantic.type_store.remove_module(&change.id);
         }
     }
 }

--- a/crates/red_knot/src/program/mod.rs
+++ b/crates/red_knot/src/program/mod.rs
@@ -11,6 +11,7 @@ use crate::module::{
 use crate::parse::{parse, Parsed, ParsedStorage};
 use crate::source::{source_text, Source, SourceStorage};
 use crate::symbols::{symbol_table, SymbolTable, SymbolTablesStorage};
+use crate::types::TypeStore;
 
 #[derive(Debug)]
 pub struct Program {
@@ -30,6 +31,7 @@ impl Program {
             semantic: SemanticJar {
                 module_resolver: ModuleResolver::new(module_search_paths),
                 symbol_tables: SymbolTablesStorage::default(),
+                type_store: TypeStore::default(),
             },
             files,
         }

--- a/crates/red_knot/src/types.rs
+++ b/crates/red_knot/src/types.rs
@@ -33,6 +33,10 @@ impl Type {
     }
 }
 
+// TODO: currently calling `get_function` et al and holding on to the `FunctionTypeRef` will lock a
+// shard of this dashmap, for as long as you hold the reference. This may be a problem. We could
+// switch to having all the arenas hold Arc, or we could see if we can split up ModuleTypeStore,
+// and/or give it inner mutability and finer-grained internal locking.
 #[derive(Debug, Default)]
 pub(crate) struct TypeStore {
     modules: FxDashMap<Module, ModuleTypeStore>,

--- a/crates/red_knot/src/types.rs
+++ b/crates/red_knot/src/types.rs
@@ -444,8 +444,36 @@ mod tests {
                 FxIndexSet::from_iter(elems.iter().copied())
             );
         } else {
-            panic!("not a function");
+            panic!("not a union");
         }
         assert_eq!(format!("{}", union.display(&store)), "(C1 | C2)");
+    }
+
+    #[test]
+    fn add_intersection() {
+        let mut store = TypeStore::default();
+        let module = test_module(0);
+        let c1 = store.add_class(module, "C1");
+        let c2 = store.add_class(module, "C2");
+        let c3 = store.add_class(module, "C3");
+        let pos = vec![c1, c2];
+        let neg = vec![c3];
+        let intersection = store.add_intersection(module, &pos, &neg);
+        if let Type::Intersection(id) = intersection {
+            assert_eq!(
+                store.get_intersection(id).positive,
+                FxIndexSet::from_iter(pos.iter().copied())
+            );
+            assert_eq!(
+                store.get_intersection(id).negative,
+                FxIndexSet::from_iter(neg.iter().copied())
+            );
+        } else {
+            panic!("not an intersection");
+        }
+        assert_eq!(
+            format!("{}", intersection.display(&store)),
+            "(C1 & C2 & ~C3)"
+        );
     }
 }

--- a/crates/red_knot/src/types.rs
+++ b/crates/red_knot/src/types.rs
@@ -43,6 +43,10 @@ pub struct TypeStore {
 }
 
 impl TypeStore {
+    pub fn remove_module(&mut self, file_id: &FileId) {
+        self.modules.remove(file_id);
+    }
+
     fn add_or_get_module(&mut self, file_id: FileId) -> ModuleStoreRefMut {
         self.modules
             .entry(file_id)


### PR DESCRIPTION
I got this all working and solved the API lifetime issues without Arc, by means of a new set of `XTypeRef` structs.

The remaining potential performance issue is that anytime you hold on to any of the new `XTypeRef` structs, you lock a shard of the `TypeStore::modules` dashmap to writes (because you are holding a reference into it). So it will be important to minimize the use and scope of these type-refs. I think we can do this to some degree by caching type judgments using just type IDs. I also think for CLI use when we want to be highly parallel, we can be smart about ordering (check all module bodies first, then check function bodies when module level types are all populated) to minimize write contention. Also, if needed we can break up `ModuleTypeStore`, or use inner mutability and internal locking to have finer-grained locking within it.

I went with this version instead of rewriting to have the type arenas hold Arc to the types, because I am not totally convinced the Arc version will be better. With Arc every "read" turns into a write to the atomic reference count, which introduces overhead (which is really useless overhead for us, since ultimately we rely on the arenas for garbage collection). And so we will introduce contention on the atomic reference count even for reads of highly-used types. So for both versions we will have to be careful with our use of references. I think the Arc-free version is lower overhead and sets us up better for future optimization of the locking strategy, once we have more working code to optimize against.

Even if I turn out to be wrong about the above and eventually we decide to use Arc, I'd rather go with this for now and move on to type evaluation, and make the Arc change later when we can evaluate the effects better.