### PR TITLE
[red-knot] Resolve and check dependencies

### DIFF
--- a/crates/red_knot/src/db.rs
+++ b/crates/red_knot/src/db.rs
@@ -26,10 +26,13 @@ pub trait SemanticDb: SourceDb {
     // queries
     fn resolve_module(&self, name: ModuleName) -> Option<Module>;
 
+    fn file_to_module(&self, file_id: FileId) -> Option<Module>;
+
+    fn path_to_module(&self, path: &Path) -> Option<Module>;
+
     fn symbol_table(&self, file_id: FileId) -> Arc<SymbolTable>;
 
     // mutations
-    fn path_to_module(&mut self, path: &Path) -> Option<Module>;
 
     fn add_module(&mut self, path: &Path) -> Option<(Module, Vec<Arc<ModuleData>>)>;
 
@@ -80,8 +83,8 @@ pub(crate) mod tests {
     use crate::files::{FileId, Files};
     use crate::lint::{lint_syntax, Diagnostics};
     use crate::module::{
-        add_module, path_to_module, resolve_module, set_module_search_paths, Module, ModuleData,
-        ModuleName, ModuleSearchPath,
+        add_module, file_to_module, path_to_module, resolve_module, set_module_search_paths,
+        Module, ModuleData, ModuleName, ModuleSearchPath,
     };
     use crate::parse::{parse, Parsed};
     use crate::source::{source_text, Source};
@@ -148,12 +151,16 @@ pub(crate) mod tests {
             resolve_module(self, name)
         }
 
-        fn symbol_table(&self, file_id: FileId) -> Arc<SymbolTable> {
-            symbol_table(self, file_id)
+        fn file_to_module(&self, file_id: FileId) -> Option<Module> {
+            file_to_module(self, file_id)
         }
 
-        fn path_to_module(&mut self, path: &Path) -> Option<Module> {
+        fn path_to_module(&self, path: &Path) -> Option<Module> {
             path_to_module(self, path)
+        }
+
+        fn symbol_table(&self, file_id: FileId) -> Arc<SymbolTable> {
+            symbol_table(self, file_id)
         }
 
         fn add_module(&mut self, path: &Path) -> Option<(Module, Vec<Arc<ModuleData>>)> {

--- a/crates/red_knot/src/files.rs
+++ b/crates/red_knot/src/files.rs
@@ -23,7 +23,7 @@ pub struct Files {
 }
 
 impl Files {
-    #[tracing::instrument(level = "debug", skip(path))]
+    #[tracing::instrument(level = "debug", skip(self))]
     pub fn intern(&self, path: &Path) -> FileId {
         self.inner.write().intern(path)
     }
@@ -32,7 +32,7 @@ impl Files {
         self.inner.read().try_get(path)
     }
 
-    #[tracing::instrument(level = "debug")]
+    #[tracing::instrument(level = "debug", skip(self))]
     pub fn path(&self, id: FileId) -> Arc<Path> {
         self.inner.read().path(id)
     }

--- a/crates/red_knot/src/lib.rs
+++ b/crates/red_knot/src/lib.rs
@@ -1,4 +1,5 @@
 use std::hash::BuildHasherDefault;
+use std::ops::Deref;
 use std::path::{Path, PathBuf};
 
 use rustc_hash::{FxHashSet, FxHasher};
@@ -79,5 +80,23 @@ impl Name {
 
     pub fn as_str(&self) -> &str {
         self.0.as_str()
+    }
+}
+
+impl Deref for Name {
+    type Target = str;
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        self.as_str()
+    }
+}
+
+impl<T> From<T> for Name
+where
+    T: Into<smol_str::SmolStr>,
+{
+    fn from(value: T) -> Self {
+        Self(value.into())
     }
 }

--- a/crates/red_knot/src/main.rs
+++ b/crates/red_knot/src/main.rs
@@ -151,7 +151,7 @@ impl MainLoop {
                         .unwrap();
 
                     rayon::in_place_scope(|scope| {
-                        let scheduler = RayonCheckScheduler { program, scope };
+                        let scheduler = RayonCheckScheduler::new(program, scope);
 
                         let result = program.check(&scheduler, run_cancellation_token);
                         match result {
@@ -422,6 +422,7 @@ fn setup_tracing() {
             .with_indent_lines(true)
             .with_indent_amount(2)
             .with_bracketed_fields(true)
+            .with_thread_ids(true)
             .with_targets(true)
             .with_writer(|| Box::new(std::io::stderr()))
             .with_timer(Uptime::default())

--- a/crates/red_knot/src/program/check.rs
+++ b/crates/red_knot/src/program/check.rs
@@ -1,5 +1,5 @@
 use crate::cancellation::CancellationToken;
-use crate::db::SourceDb;
+use crate::db::{SemanticDb, SourceDb};
 use crate::files::FileId;
 use crate::lint::Diagnostics;
 use crate::program::Program;
@@ -41,7 +41,30 @@ impl Program {
     ) -> Result<Diagnostics, CheckError> {
         context.cancelled_ok()?;
 
-        // TODO schedule the dependencies.
+        let symbol_table = self.symbol_table(file);
+        let dependencies = symbol_table.dependencies();
+
+        if !dependencies.is_empty() {
+            let module_name = self.file_to_module(file).map(|module| module.name(self));
+
+            // TODO scheduling all dependencies here is wasteful if we don't infer any types on them
+            //  but I think that's unlikely, so it is okay?
+            //  Anyway, we need to figure out a way to retrieve the dependencies of a module
+            //  from the persistent cache. So maybe it should be a separate query after all.
+            for dependency in dependencies {
+                let dependency_name = dependency.module_name(module_name.as_ref());
+
+                if let Some(dependency_name) = dependency_name {
+                    // TODO The resolver doesn't support native dependencies yet.
+                    if let Some(dependency) = self.resolve_module(dependency_name) {
+                        if dependency.path(self).root().kind().is_first_party() {
+                            context.schedule_check_file(dependency.path(self).file());
+                        }
+                    }
+                }
+            }
+        }
+
         let mut diagnostics = Vec::new();
 
         if self.workspace().is_file_open(file) {
@@ -72,8 +95,8 @@ pub trait CheckScheduler {
 
 /// Scheduler that runs checks on a rayon thread pool.
 pub struct RayonCheckScheduler<'program, 'scope_ref, 'scope> {
-    pub program: &'program Program,
-    pub scope: &'scope_ref rayon::Scope<'scope>,
+    program: &'program Program,
+    scope: &'scope_ref rayon::Scope<'scope>,
 }
 
 impl<'program, 'scope_ref, 'scope> RayonCheckScheduler<'program, 'scope_ref, 'scope> {

--- a/crates/red_knot/src/program/mod.rs
+++ b/crates/red_knot/src/program/mod.rs
@@ -7,8 +7,8 @@ use crate::db::{Db, HasJar, SemanticDb, SemanticJar, SourceDb, SourceJar};
 use crate::files::{FileId, Files};
 use crate::lint::{lint_syntax, Diagnostics, LintSyntaxStorage};
 use crate::module::{
-    add_module, path_to_module, resolve_module, set_module_search_paths, Module, ModuleData,
-    ModuleName, ModuleResolver, ModuleSearchPath,
+    add_module, file_to_module, path_to_module, resolve_module, set_module_search_paths, Module,
+    ModuleData, ModuleName, ModuleResolver, ModuleSearchPath,
 };
 use crate::parse::{parse, Parsed, ParsedStorage};
 use crate::source::{source_text, Source, SourceStorage};
@@ -99,14 +99,19 @@ impl SemanticDb for Program {
         resolve_module(self, name)
     }
 
+    fn file_to_module(&self, file_id: FileId) -> Option<Module> {
+        file_to_module(self, file_id)
+    }
+
+    fn path_to_module(&self, path: &Path) -> Option<Module> {
+        path_to_module(self, path)
+    }
+
     fn symbol_table(&self, file_id: FileId) -> Arc<SymbolTable> {
         symbol_table(self, file_id)
     }
 
     // Mutations
-    fn path_to_module(&mut self, path: &Path) -> Option<Module> {
-        path_to_module(self, path)
-    }
 
     fn add_module(&mut self, path: &Path) -> Option<(Module, Vec<Arc<ModuleData>>)> {
         add_module(self, path)

--- a/crates/red_knot/src/symbols.rs
+++ b/crates/red_knot/src/symbols.rs
@@ -16,7 +16,7 @@ use crate::ast_ids::TypedNodeKey;
 use crate::cache::KeyValueCache;
 use crate::db::{HasJar, SemanticDb, SemanticJar};
 use crate::files::FileId;
-use crate::module::ModuleName;
+use crate::module::{Module, ModuleName};
 use crate::Name;
 
 #[allow(unreachable_pub)]
@@ -128,11 +128,14 @@ pub(crate) enum Dependency {
 }
 
 impl Dependency {
-    pub(crate) fn module_name(&self, relative_to: Option<&ModuleName>) -> Option<ModuleName> {
+    pub(crate) fn module_name<Db>(&self, db: &Db, relative_to: Option<Module>) -> Option<ModuleName>
+    where
+        Db: SemanticDb + HasJar<SemanticJar>,
+    {
         match self {
             Dependency::Module(name) => Some(ModuleName::new(name.as_str())),
             Dependency::Relative { level, module } => {
-                relative_to?.relative(*level, module.as_ref().map(|name| name.as_str()))
+                relative_to?.relative_name(db, *level, module.as_deref())
             }
         }
     }

--- a/crates/red_knot/src/types/infer.rs
+++ b/crates/red_knot/src/types/infer.rs
@@ -35,7 +35,7 @@ where
         }) => {
             // TODO relative imports
             assert!(matches!(level, 0));
-            let module_name = ModuleName::new(module.as_ref().expect("TODO relative imports"));
+            let module_name = ModuleName::new(&module.as_ref().expect("TODO relative imports"));
             if let Some(module) = db.resolve_module(module_name) {
                 let remote_file_id = module.path(db).file();
                 let remote_symbols = db.symbol_table(remote_file_id);

--- a/crates/red_knot/src/types/infer.rs
+++ b/crates/red_knot/src/types/infer.rs
@@ -35,7 +35,7 @@ where
         }) => {
             // TODO relative imports
             assert!(matches!(level, 0));
-            let module_name = ModuleName::new(&module.as_ref().expect("TODO relative imports"));
+            let module_name = ModuleName::new(module.as_ref().expect("TODO relative imports"));
             if let Some(module) = db.resolve_module(module_name) {
                 let remote_file_id = module.path(db).file();
                 let remote_symbols = db.symbol_table(remote_file_id);


### PR DESCRIPTION
## Summary

Discover a modules dependencies and schedule them for checking. 

This does not yet support native dependencies of which we don't have access to the source.

## Test Plan

I created a `test.py` and ran `red_knot test.py`. The test.py imports `match.py`. 

I can see from the logs that `match.py` is correctly scheduled for checking. Cyclic dependencies work too. 
Red knot won't emit any diagnostics for `match.py` because it isn't an open file. 
