### PR TITLE
[red-knot] Unresolved imports lint rule

### DIFF
--- a/crates/red_knot/src/cancellation.rs
+++ b/crates/red_knot/src/cancellation.rs
@@ -12,7 +12,7 @@ impl CancellationTokenSource {
         }
     }
 
-    #[tracing::instrument(level = "trace")]
+    #[tracing::instrument(level = "trace", skip_all)]
     pub fn cancel(&self) {
         let (cancelled, condvar) = &*self.signal;
 

--- a/crates/red_knot/src/lib.rs
+++ b/crates/red_knot/src/lib.rs
@@ -1,3 +1,4 @@
+use std::fmt::Formatter;
 use std::hash::BuildHasherDefault;
 use std::ops::Deref;
 use std::path::{Path, PathBuf};
@@ -98,5 +99,11 @@ where
 {
     fn from(value: T) -> Self {
         Self(value.into())
+    }
+}
+
+impl std::fmt::Display for Name {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
     }
 }

--- a/crates/red_knot/src/lint.rs
+++ b/crates/red_knot/src/lint.rs
@@ -90,6 +90,7 @@ where
 }
 
 fn lint_unresolved_imports(context: &SemanticLintContext) {
+    // TODO: Consider iterating over the dependencies (imports) only instead of all definitions.
     for (symbol, definition) in context.symbols().all_definitions() {
         match definition {
             Definition::Import(import) => {
@@ -103,17 +104,19 @@ fn lint_unresolved_imports(context: &SemanticLintContext) {
                 let ty = context.eval_symbol(symbol);
 
                 if ty.is_unknown() {
-                    let message = if let Some(module) = import.module() {
+                    let module_name = import.module().map(Deref::deref).unwrap_or_default();
+                    let message = if import.level() > 0 {
                         format!(
-                            "Unresolved relative import '{}' from '{}{module}'",
+                            "Unresolved relative import '{}' from {}{}",
                             import.name(),
-                            ".".repeat(import.level() as usize)
+                            ".".repeat(import.level() as usize),
+                            module_name
                         )
                     } else {
                         format!(
-                            "Unresolved import '{}' from {}",
+                            "Unresolved import '{}' from '{}'",
                             import.name(),
-                            ".".repeat(import.level() as usize)
+                            module_name
                         )
                     };
 

--- a/crates/red_knot/src/module.rs
+++ b/crates/red_knot/src/module.rs
@@ -49,7 +49,7 @@ impl Module {
         Db: HasJar<SemanticJar>,
     {
         let (level, module) = match dependency {
-            Dependency::Module(module) => return Some(ModuleName::new(module)),
+            Dependency::Module(module) => return Some(module.clone()),
             Dependency::Relative { level, module } => (*level, module.as_deref()),
         };
 
@@ -1012,7 +1012,7 @@ mod tests {
                 &db,
                 &Dependency::Relative {
                     level: NonZeroU32::new(1).unwrap(),
-                    module: None
+                    module: None,
                 }
             )
         );

--- a/crates/red_knot/src/program/check.rs
+++ b/crates/red_knot/src/program/check.rs
@@ -1,12 +1,14 @@
+use std::num::NonZeroUsize;
+
+use rayon::max_num_threads;
+use rustc_hash::FxHashSet;
+
 use crate::cancellation::CancellationToken;
 use crate::db::{SemanticDb, SourceDb};
 use crate::files::FileId;
 use crate::lint::Diagnostics;
 use crate::program::Program;
 use crate::symbols::Dependency;
-use rayon::max_num_threads;
-use rustc_hash::FxHashSet;
-use std::num::NonZeroUsize;
 
 impl Program {
     /// Checks all open files in the workspace and its dependencies.
@@ -77,6 +79,7 @@ impl Program {
 
         if self.workspace().is_file_open(file) {
             diagnostics.extend_from_slice(&self.lint_syntax(file));
+            diagnostics.extend_from_slice(&self.lint_semantic(file));
         }
 
         Ok(Diagnostics::from(diagnostics))

--- a/crates/red_knot/src/types/infer.rs
+++ b/crates/red_knot/src/types/infer.rs
@@ -8,8 +8,7 @@ use crate::symbols::{Definition, ImportFromDefinition, SymbolId};
 use crate::types::Type;
 use crate::FileId;
 
-// TODO this should not take a &mut db, it should be a query, not a mutation. This means we'll need
-// to use interior mutability in TypeStore instead, and avoid races in populating the cache.
+// FIXME: Figure out proper dead-lock free synchronisation now that this takes `&db` instead of `&mut db`.
 #[tracing::instrument(level = "trace", skip(db))]
 pub fn infer_symbol_type<Db>(db: &Db, file_id: FileId, symbol_id: SymbolId) -> Type
 where


### PR DESCRIPTION
## Summary

This PR is based on https://github.com/astral-sh/ruff/pull/11157/ and https://github.com/astral-sh/ruff/pull/11148

It implements a very basic check for detecting unknown imports. It doesn't do anything fancy but it demonstrates the cross-module resolution infrastructure. 

The `lint_semantic` isn't yet correctly retriggered when a dependency changes. That's something we have to follow up with.

## Test Plan

I imported the `test` function from `match.py`. No lint error. I imported the non existing `test2` function from `match.py` and it shows a diagnostic. 
