### PR TITLE
[`pyflakes`] Improve `invalid-print-syntax` documentation

### DIFF
--- a/crates/ruff_linter/src/rules/pyflakes/rules/invalid_print_syntax.rs
+++ b/crates/ruff_linter/src/rules/pyflakes/rules/invalid_print_syntax.rs
@@ -11,8 +11,9 @@ use crate::checkers::ast::Checker;
 ///
 /// ## Why is this bad?
 /// In Python 2, the `print` statement can be used with the `>>` syntax to
-/// print to a file-like object. This `print >> sys.stderr` syntax is
-/// deprecated in Python 3.
+/// print to a file-like object. This `print >> sys.stderr` syntax no
+/// longer exists in Python 3, where `print` is only a function, not a
+/// statement.
 ///
 /// Instead, use the `file` keyword argument to the `print` function, the
 /// `sys.stderr.write` function, or the `logging` module.


### PR DESCRIPTION
This syntax wasn't "deprecated" in Python 3; it was removed.

I started looking at this rule because I was curious how Ruff could even
detect this without a Python 2 parser. Then I realized that
"print >> f, x" is actually valid Python 3 syntax: it creates a tuple
containing a right-shifted version of the print function.