### PR TITLE
[red-knot] Add "cheap" `program.snapshot` 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -502,6 +502,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -525,6 +538,15 @@ name = "crossbeam-epoch"
 version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df0346b5d5e76ac2fe4e327c5fd1118d6be7c51dfb18f9b7922923f287471e35"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1804,7 +1826,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bitflags 2.5.0",
- "crossbeam-channel",
+ "crossbeam",
  "ctrlc",
  "dashmap",
  "hashbrown 0.14.5",
@@ -2341,7 +2363,7 @@ name = "ruff_server"
 version = "0.2.2"
 dependencies = [
  "anyhow",
- "crossbeam-channel",
+ "crossbeam",
  "insta",
  "jod-thread",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ console_error_panic_hook = { version = "0.1.7" }
 console_log = { version = "1.0.0" }
 countme = { version = "3.0.1" }
 criterion = { version = "0.5.1", default-features = false }
-crossbeam-channel = { version = "0.5.12" }
+crossbeam = { version = "0.8.4" }
 dashmap = { version = "5.5.3" }
 dirs = { version = "5.0.0" }
 drop_bomb = { version = "0.1.5" }

--- a/crates/red_knot/Cargo.toml
+++ b/crates/red_knot/Cargo.toml
@@ -22,7 +22,7 @@ ruff_notebook = { path = "../ruff_notebook" }
 anyhow = { workspace = true }
 bitflags = { workspace = true }
 ctrlc = "3.4.4"
-crossbeam-channel = { workspace = true }
+crossbeam = { workspace = true }
 dashmap = { workspace = true }
 hashbrown = { workspace = true }
 indexmap = { workspace = true }

--- a/crates/red_knot/src/cancellation.rs
+++ b/crates/red_knot/src/cancellation.rs
@@ -1,35 +1,25 @@
-use std::sync::{Arc, Condvar, Mutex};
+use std::sync::atomic::AtomicBool;
+use std::sync::Arc;
 
 #[derive(Debug, Clone, Default)]
 pub struct CancellationTokenSource {
-    signal: Arc<(Mutex<bool>, Condvar)>,
+    signal: Arc<AtomicBool>,
 }
 
 impl CancellationTokenSource {
     pub fn new() -> Self {
         Self {
-            signal: Arc::new((Mutex::new(false), Condvar::default())),
+            signal: Arc::new(AtomicBool::new(false)),
         }
     }
 
     #[tracing::instrument(level = "trace", skip_all)]
     pub fn cancel(&self) {
-        let (cancelled, condvar) = &*self.signal;
-
-        let mut cancelled = cancelled.lock().unwrap();
-
-        if *cancelled {
-            return;
-        }
-
-        *cancelled = true;
-        condvar.notify_all();
+        self.signal.store(true, std::sync::atomic::Ordering::SeqCst);
     }
 
     pub fn is_cancelled(&self) -> bool {
-        let (cancelled, _) = &*self.signal;
-
-        *cancelled.lock().unwrap()
+        self.signal.load(std::sync::atomic::Ordering::SeqCst)
     }
 
     pub fn token(&self) -> CancellationToken {
@@ -41,26 +31,12 @@ impl CancellationTokenSource {
 
 #[derive(Clone, Debug)]
 pub struct CancellationToken {
-    signal: Arc<(Mutex<bool>, Condvar)>,
+    signal: Arc<AtomicBool>,
 }
 
 impl CancellationToken {
     /// Returns `true` if cancellation has been requested.
     pub fn is_cancelled(&self) -> bool {
-        let (cancelled, _) = &*self.signal;
-
-        *cancelled.lock().unwrap()
-    }
-
-    pub fn wait(&self) {
-        let (bool, condvar) = &*self.signal;
-
-        let lock = condvar
-            .wait_while(bool.lock().unwrap(), |bool| !*bool)
-            .unwrap();
-
-        debug_assert!(*lock);
-
-        drop(lock);
+        self.signal.load(std::sync::atomic::Ordering::SeqCst)
     }
 }

--- a/crates/red_knot/src/cancellation.rs
+++ b/crates/red_knot/src/cancellation.rs
@@ -1,6 +1,6 @@
 use std::sync::{Arc, Condvar, Mutex};
 
-#[derive(Debug, Default)]
+#[derive(Debug, Clone, Default)]
 pub struct CancellationTokenSource {
     signal: Arc<(Mutex<bool>, Condvar)>,
 }

--- a/crates/red_knot/src/db.rs
+++ b/crates/red_knot/src/db.rs
@@ -53,7 +53,10 @@ pub trait ParallelDatabase: Database + Send {
     /// create a snapshot when scheduling the check of an entire program).
     ///
     /// ## Salsa compatibility
-    /// Salsa prohibits creating a snapshot inside a query and so should we for better Salsa compatibility .
+    /// Salsa prohibits creating a snapshot while running a local query (it's fine if other workers run a query) [[source](https://github.com/salsa-rs/salsa/issues/80)].
+    /// We should avoid creating snapshots while running a query because we might want to adopt Salsa in the future (if we can figure out persistent caching).
+    /// Unfortunately, the infrastructure doesn't provide an automated way of knowing when a query is run, that's
+    /// why we have to "enforce" this constraint manually.
     fn snapshot(&self) -> Snapshot<Self>;
 }
 

--- a/crates/red_knot/src/db/jars.rs
+++ b/crates/red_knot/src/db/jars.rs
@@ -1,4 +1,4 @@
-use crate::db::QueryResult;
+use crate::db::query::QueryResult;
 
 /// Gives access to a specific jar in the database.
 ///
@@ -21,11 +21,16 @@ pub trait HasJar<T> {
 }
 
 pub trait HasJars {
-    type Jars;
+    type Jars: Default;
 
-    fn jars(&self) -> &QueryResult<Self::Jars>;
+    /// Gives access to the underlying jars but tests if the queries have been cancelled.
+    ///
+    /// Returns `Err(QueryError::Cancelled)` if the queries have been cancelled.
+    fn jars(&self) -> QueryResult<&Self::Jars>;
 
+    /// Gives access to the underlying jars without testing if the queries have been cancelled.
     fn jars_unwrap(&self) -> &Self::Jars;
 
+    /// Gives mutable access to the underlying jars.
     fn jars_mut(&mut self) -> &mut Self::Jars;
 }

--- a/crates/red_knot/src/db/jars.rs
+++ b/crates/red_knot/src/db/jars.rs
@@ -20,16 +20,17 @@ pub trait HasJar<T> {
     fn jar_mut(&mut self) -> &mut T;
 }
 
+/// Gives access to the jars in a database.
 pub trait HasJars {
+    /// A type storing the jars.
+    ///
+    /// Most commonly, this is a tuple where each jar is a tuple element.
     type Jars: Default;
 
     /// Gives access to the underlying jars but tests if the queries have been cancelled.
     ///
     /// Returns `Err(QueryError::Cancelled)` if the queries have been cancelled.
     fn jars(&self) -> QueryResult<&Self::Jars>;
-
-    /// Gives access to the underlying jars without testing if the queries have been cancelled.
-    fn jars_unwrap(&self) -> &Self::Jars;
 
     /// Gives mutable access to the underlying jars.
     fn jars_mut(&mut self) -> &mut Self::Jars;

--- a/crates/red_knot/src/db/jars.rs
+++ b/crates/red_knot/src/db/jars.rs
@@ -1,0 +1,31 @@
+use crate::db::QueryResult;
+
+/// Gives access to a specific jar in the database.
+///
+/// Nope, the terminology isn't borrowed from Java but from Salsa <https://salsa-rs.github.io/salsa/>,
+/// which is an analogy to storing the salsa in different jars.
+///
+/// The basic idea is that each crate can define its own jar and the jars can be combined to a single
+/// database in the top level crate. Each crate also defines its own `Database` trait. The combination of
+/// `Database` trait and the jar allows to write queries in isolation without having to know how they get composed at the upper levels.
+///
+/// Salsa further defines a `HasIngredient` trait which slices the jar to a specific storage (e.g. a specific cache).
+/// We don't need this just jet because we write our queries by hand. We may want a similar trait if we decide
+/// to use a macro to generate the queries.
+pub trait HasJar<T> {
+    /// Gives a read-only reference to the jar.
+    fn jar(&self) -> QueryResult<&T>;
+
+    /// Gives a mutable reference to the jar.
+    fn jar_mut(&mut self) -> &mut T;
+}
+
+pub trait HasJars {
+    type Jars;
+
+    fn jars(&self) -> &QueryResult<Self::Jars>;
+
+    fn jars_unwrap(&self) -> &Self::Jars;
+
+    fn jars_mut(&mut self) -> &mut Self::Jars;
+}

--- a/crates/red_knot/src/db/query.rs
+++ b/crates/red_knot/src/db/query.rs
@@ -1,0 +1,18 @@
+use std::fmt::{Display, Formatter};
+
+#[derive(Debug, Clone, Copy)]
+pub enum QueryError {
+    Cancelled,
+}
+
+impl Display for QueryError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            QueryError::Cancelled => f.write_str("query was cancelled"),
+        }
+    }
+}
+
+impl std::error::Error for QueryError {}
+
+pub type QueryResult<T> = Result<T, QueryError>;

--- a/crates/red_knot/src/db/query.rs
+++ b/crates/red_knot/src/db/query.rs
@@ -1,5 +1,6 @@
 use std::fmt::{Display, Formatter};
 
+/// Reason why a db query operation failed.
 #[derive(Debug, Clone, Copy)]
 pub enum QueryError {
     /// The query was cancelled because the DB was mutated or the query was cancelled by the host (e.g. on a file change or when pressing CTRL+C).

--- a/crates/red_knot/src/db/query.rs
+++ b/crates/red_knot/src/db/query.rs
@@ -2,6 +2,7 @@ use std::fmt::{Display, Formatter};
 
 #[derive(Debug, Clone, Copy)]
 pub enum QueryError {
+    /// The query was cancelled because the DB was mutated or the query was cancelled by the host (e.g. on a file change or when pressing CTRL+C).
     Cancelled,
 }
 

--- a/crates/red_knot/src/db/runtime.rs
+++ b/crates/red_knot/src/db/runtime.rs
@@ -1,0 +1,41 @@
+use crate::cancellation::CancellationTokenSource;
+use crate::db::{QueryError, QueryResult};
+
+/// Holds the data agnostic state of the database.
+#[derive(Debug, Default)]
+pub struct DbRuntime {
+    /// The cancellation token source used to signal other works that the queries should be aborted and
+    /// exit at the next possible point.
+    cancellation_token: CancellationTokenSource,
+}
+
+impl DbRuntime {
+    pub(super) fn snapshot(&self) -> Self {
+        Self {
+            cancellation_token: self.cancellation_token.clone(),
+        }
+    }
+
+    /// Cancels the pending queries of other workers. The current worker cannot have any pending
+    /// queries because we're holding a mutable reference to the runtime.
+    pub(super) fn cancel_other_workers(&mut self) {
+        self.cancellation_token.cancel();
+        // Set a new cancellation token so that we're in a non-cancelled state again when running the next
+        // query.
+        self.cancellation_token = CancellationTokenSource::default();
+    }
+
+    /// Returns `Ok` if the queries have not been cancelled and `Err(QueryError::Cancelled)` otherwise.
+    pub(super) fn cancelled(&self) -> QueryResult<()> {
+        if self.cancellation_token.is_cancelled() {
+            Err(QueryError::Cancelled)
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Returns `true` if the queries have been cancelled.
+    pub(super) fn is_cancelled(&self) -> bool {
+        self.cancellation_token.is_cancelled()
+    }
+}

--- a/crates/red_knot/src/db/runtime.rs
+++ b/crates/red_knot/src/db/runtime.rs
@@ -1,7 +1,7 @@
 use crate::cancellation::CancellationTokenSource;
 use crate::db::{QueryError, QueryResult};
 
-/// Holds the data agnostic state of the database.
+/// Holds the jar agnostic state of the database.
 #[derive(Debug, Default)]
 pub struct DbRuntime {
     /// The cancellation token source used to signal other works that the queries should be aborted and

--- a/crates/red_knot/src/db/storage.rs
+++ b/crates/red_knot/src/db/storage.rs
@@ -1,49 +1,62 @@
+use std::fmt::Formatter;
 use std::sync::Arc;
 
 use crossbeam::sync::WaitGroup;
 
-use crate::cancellation::CancellationTokenSource;
-use crate::db::jars::HasJars;
-use crate::db::query::{QueryError, QueryResult};
+use crate::db::query::QueryResult;
+use crate::db::runtime::DbRuntime;
+use crate::db::{HasJars, ParallelDatabase};
 
-pub struct JarStorage<T>
+pub struct JarsStorage<T>
 where
-    T: HasJars,
+    T: HasJars + Sized,
 {
-    db: T,
-}
-
-#[derive(Clone, Debug)]
-pub struct SharedStorage<T>
-where
-    T: HasJars,
-{
-    // It's important that the wait group is declared after `jars` to ensure that `jars` is dropped first.
+    // It's important that `jars_wait_group` is declared after `jars` to ensure that `jars` is dropped first.
     // See https://doc.rust-lang.org/reference/destructors.html
     jars: Arc<T::Jars>,
 
-    /// Used to count the references to `jars`. Allows implementing [`jars_mut`] without requiring to clone `jars`.
-    jars_references: WaitGroup,
+    /// Used to count the references to `jars`. Allows implementing `jars_mut` without requiring to clone `jars`.
+    jars_wait_group: WaitGroup,
 
-    cancellation_token_source: CancellationTokenSource,
+    runtime: DbRuntime,
 }
 
-impl<T> SharedStorage<T>
+impl<Db> JarsStorage<Db>
 where
-    T: HasJars,
+    Db: HasJars,
 {
-    pub(super) fn jars(&self) -> QueryResult<&T::Jars> {
-        self.err_if_cancelled()?;
+    pub(super) fn new() -> Self {
+        Self {
+            jars: Arc::new(Db::Jars::default()),
+            jars_wait_group: WaitGroup::default(),
+            runtime: DbRuntime::default(),
+        }
+    }
+
+    #[must_use]
+    pub fn snapshot(&self) -> JarsStorage<Db>
+    where
+        Db: ParallelDatabase,
+    {
+        Self {
+            jars: self.jars.clone(),
+            jars_wait_group: self.jars_wait_group.clone(),
+            runtime: self.runtime.snapshot(),
+        }
+    }
+
+    pub(crate) fn jars(&self) -> QueryResult<&Db::Jars> {
+        self.runtime.cancelled()?;
         Ok(&self.jars)
     }
 
-    pub(super) fn jars_mut(&mut self) -> &mut T::Jars {
-        // Cancel all pending queries.
-        self.cancellation_token_source.cancel();
+    pub(crate) fn jars_unwrap(&self) -> &Db::Jars {
+        &self.jars
+    }
 
-        let existing_wait = std::mem::take(&mut self.jars_references);
-        existing_wait.wait();
-        self.cancellation_token_source = CancellationTokenSource::new();
+    pub(crate) fn jars_mut(&mut self) -> &mut Db::Jars {
+        // We have a mutable ref here, so no more workers can be spawned between calling this function and taking the mut ref below.
+        self.cancel_other_workers();
 
         // Now all other references to `self.jars` should have been released. We can now safely return a mutable reference
         // to the Arc's content.
@@ -53,11 +66,44 @@ where
         jars
     }
 
-    pub(super) fn err_if_cancelled(&self) -> QueryResult<()> {
-        if self.cancellation_token_source.is_cancelled() {
-            Err(QueryError::Cancelled)
-        } else {
-            Ok(())
-        }
+    pub(crate) fn runtime(&self) -> &DbRuntime {
+        &self.runtime
+    }
+
+    pub(crate) fn runtime_mut(&mut self) -> &mut DbRuntime {
+        // Note: This method may need to use a similar trick to `jars_mut` if `DbRuntime` is ever to store data that is shared between workers.
+        &mut self.runtime
+    }
+
+    #[tracing::instrument(level = "trace", skip(self))]
+    fn cancel_other_workers(&mut self) {
+        self.runtime.cancel_other_workers();
+
+        // Wait for all other works to complete.
+        let existing_wait = std::mem::take(&mut self.jars_wait_group);
+        existing_wait.wait();
+    }
+}
+
+impl<Db> Default for JarsStorage<Db>
+where
+    Db: HasJars,
+{
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<T> std::fmt::Debug for JarsStorage<T>
+where
+    T: HasJars,
+    <T as HasJars>::Jars: std::fmt::Debug,
+{
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SharedStorage")
+            .field("jars", &self.jars)
+            .field("jars_wait_group", &self.jars_wait_group)
+            .field("runtime", &self.runtime)
+            .finish()
     }
 }

--- a/crates/red_knot/src/db/storage.rs
+++ b/crates/red_knot/src/db/storage.rs
@@ -1,0 +1,63 @@
+use std::sync::Arc;
+
+use crossbeam::sync::WaitGroup;
+
+use crate::cancellation::CancellationTokenSource;
+use crate::db::jars::HasJars;
+use crate::db::query::{QueryError, QueryResult};
+
+pub struct JarStorage<T>
+where
+    T: HasJars,
+{
+    db: T,
+}
+
+#[derive(Clone, Debug)]
+pub struct SharedStorage<T>
+where
+    T: HasJars,
+{
+    // It's important that the wait group is declared after `jars` to ensure that `jars` is dropped first.
+    // See https://doc.rust-lang.org/reference/destructors.html
+    jars: Arc<T::Jars>,
+
+    /// Used to count the references to `jars`. Allows implementing [`jars_mut`] without requiring to clone `jars`.
+    jars_references: WaitGroup,
+
+    cancellation_token_source: CancellationTokenSource,
+}
+
+impl<T> SharedStorage<T>
+where
+    T: HasJars,
+{
+    pub(super) fn jars(&self) -> QueryResult<&T::Jars> {
+        self.err_if_cancelled()?;
+        Ok(&self.jars)
+    }
+
+    pub(super) fn jars_mut(&mut self) -> &mut T::Jars {
+        // Cancel all pending queries.
+        self.cancellation_token_source.cancel();
+
+        let existing_wait = std::mem::take(&mut self.jars_references);
+        existing_wait.wait();
+        self.cancellation_token_source = CancellationTokenSource::new();
+
+        // Now all other references to `self.jars` should have been released. We can now safely return a mutable reference
+        // to the Arc's content.
+        let jars =
+            Arc::get_mut(&mut self.jars).expect("All references to jars should have been released");
+
+        jars
+    }
+
+    pub(super) fn err_if_cancelled(&self) -> QueryResult<()> {
+        if self.cancellation_token_source.is_cancelled() {
+            Err(QueryError::Cancelled)
+        } else {
+            Ok(())
+        }
+    }
+}

--- a/crates/red_knot/src/lib.rs
+++ b/crates/red_knot/src/lib.rs
@@ -27,7 +27,7 @@ pub(crate) type FxDashMap<K, V> = dashmap::DashMap<K, V, BuildHasherDefault<FxHa
 pub(crate) type FxDashSet<V> = dashmap::DashSet<V, BuildHasherDefault<FxHasher>>;
 pub(crate) type FxIndexSet<V> = indexmap::set::IndexSet<V, BuildHasherDefault<FxHasher>>;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Workspace {
     /// TODO this should be a resolved path. We should probably use a newtype wrapper that guarantees that
     /// PATH is a UTF-8 path and is normalized.

--- a/crates/red_knot/src/lint.rs
+++ b/crates/red_knot/src/lint.rs
@@ -6,7 +6,7 @@ use ruff_python_ast::visitor::Visitor;
 use ruff_python_ast::{ModModule, StringLiteral};
 
 use crate::cache::KeyValueCache;
-use crate::db::{HasJar, SemanticDb, SemanticJar, SourceDb, SourceJar};
+use crate::db::{HasJar, QueryResult, SemanticDb, SemanticJar, SourceDb, SourceJar};
 use crate::files::FileId;
 use crate::parse::Parsed;
 use crate::source::Source;
@@ -14,19 +14,19 @@ use crate::symbols::{Definition, SymbolId, SymbolTable};
 use crate::types::Type;
 
 #[tracing::instrument(level = "debug", skip(db))]
-pub(crate) fn lint_syntax<Db>(db: &Db, file_id: FileId) -> Diagnostics
+pub(crate) fn lint_syntax<Db>(db: &Db, file_id: FileId) -> QueryResult<Diagnostics>
 where
     Db: SourceDb + HasJar<SourceJar>,
 {
-    let storage = &db.jar().lint_syntax;
+    let storage = &db.jar()?.lint_syntax;
 
     storage.get(&file_id, |file_id| {
         let mut diagnostics = Vec::new();
 
-        let source = db.source(*file_id);
+        let source = db.source(*file_id)?;
         lint_lines(source.text(), &mut diagnostics);
 
-        let parsed = db.parse(*file_id);
+        let parsed = db.parse(*file_id)?;
 
         if parsed.errors().is_empty() {
             let ast = parsed.ast();
@@ -41,7 +41,7 @@ where
             diagnostics.extend(parsed.errors().iter().map(std::string::ToString::to_string));
         }
 
-        Diagnostics::from(diagnostics)
+        Ok(Diagnostics::from(diagnostics))
     })
 }
 
@@ -63,16 +63,16 @@ fn lint_lines(source: &str, diagnostics: &mut Vec<String>) {
 }
 
 #[tracing::instrument(level = "debug", skip(db))]
-pub(crate) fn lint_semantic<Db>(db: &Db, file_id: FileId) -> Diagnostics
+pub(crate) fn lint_semantic<Db>(db: &Db, file_id: FileId) -> QueryResult<Diagnostics>
 where
     Db: SemanticDb + HasJar<SemanticJar>,
 {
-    let storage = &db.jar().lint_semantic;
+    let storage = &db.jar()?.lint_semantic;
 
     storage.get(&file_id, |file_id| {
-        let source = db.source(*file_id);
-        let parsed = db.parse(*file_id);
-        let symbols = db.symbol_table(*file_id);
+        let source = db.source(*file_id)?;
+        let parsed = db.parse(*file_id)?;
+        let symbols = db.symbol_table(*file_id)?;
 
         let context = SemanticLintContext {
             file_id: *file_id,
@@ -83,25 +83,25 @@ where
             diagnostics: RefCell::new(Vec::new()),
         };
 
-        lint_unresolved_imports(&context);
+        lint_unresolved_imports(&context)?;
 
-        Diagnostics::from(context.diagnostics.take())
+        Ok(Diagnostics::from(context.diagnostics.take()))
     })
 }
 
-fn lint_unresolved_imports(context: &SemanticLintContext) {
+fn lint_unresolved_imports(context: &SemanticLintContext) -> QueryResult<()> {
     // TODO: Consider iterating over the dependencies (imports) only instead of all definitions.
     for (symbol, definition) in context.symbols().all_definitions() {
         match definition {
             Definition::Import(import) => {
-                let ty = context.eval_symbol(symbol);
+                let ty = context.infer_symbol_type(symbol)?;
 
                 if ty.is_unknown() {
                     context.push_diagnostic(format!("Unresolved module {}", import.module));
                 }
             }
             Definition::ImportFrom(import) => {
-                let ty = context.eval_symbol(symbol);
+                let ty = context.infer_symbol_type(symbol)?;
 
                 if ty.is_unknown() {
                     let module_name = import.module().map(Deref::deref).unwrap_or_default();
@@ -126,6 +126,8 @@ fn lint_unresolved_imports(context: &SemanticLintContext) {
             _ => {}
         }
     }
+
+    Ok(())
 }
 
 pub struct SemanticLintContext<'a> {
@@ -154,7 +156,7 @@ impl<'a> SemanticLintContext<'a> {
         &self.symbols
     }
 
-    pub fn eval_symbol(&self, symbol_id: SymbolId) -> Type {
+    pub fn infer_symbol_type(&self, symbol_id: SymbolId) -> QueryResult<Type> {
         self.db.infer_symbol_type(self.file_id, symbol_id)
     }
 

--- a/crates/red_knot/src/lint.rs
+++ b/crates/red_knot/src/lint.rs
@@ -23,10 +23,13 @@ where
 {
     let storage = &db.jar()?.lint_syntax;
 
-    for i in 0..10 {
-        db.cancelled()?;
-        format!("Sleep {i}");
-        std::thread::sleep(Duration::from_secs(1));
+    #[allow(clippy::print_stdout)]
+    if std::env::var("RED_KNOT_SLOW_LINT").is_ok() {
+        for i in 0..10 {
+            db.cancelled()?;
+            println!("RED_KNOT_SLOW_LINT is set, sleeping for {i}/10 seconds");
+            std::thread::sleep(Duration::from_secs(1));
+        }
     }
 
     storage.get(&file_id, |file_id| {

--- a/crates/red_knot/src/main.rs
+++ b/crates/red_knot/src/main.rs
@@ -283,8 +283,8 @@ impl Orchestrator {
                         }
                     }
                 },
-                default(std::time::Duration::from_millis(100)) => {
-                    // No more file changes after 100 ms, send the changes and schedule a new analysis
+                default(std::time::Duration::from_millis(10)) => {
+                    // No more file changes after 10 ms, send the changes and schedule a new analysis
                     self.sender.send(MainLoopMessage::ApplyChanges(aggregated_changes)).unwrap();
                     self.sender.send(MainLoopMessage::CheckProgram { revision: self.revision}).unwrap();
                     return;

--- a/crates/red_knot/src/main.rs
+++ b/crates/red_knot/src/main.rs
@@ -13,8 +13,7 @@ use tracing_subscriber::layer::{Context, Filter, SubscriberExt};
 use tracing_subscriber::{Layer, Registry};
 use tracing_tree::time::Uptime;
 
-use red_knot::cancellation::CancellationTokenSource;
-use red_knot::db::{HasJar, QueryError, SourceDb, SourceJar};
+use red_knot::db::{HasJar, ParallelDatabase, QueryError, SemanticDb, SourceDb, SourceJar};
 use red_knot::files::FileId;
 use red_knot::module::{ModuleSearchPath, ModuleSearchPathKind};
 use red_knot::program::check::RayonCheckScheduler;
@@ -52,7 +51,8 @@ fn main() -> anyhow::Result<()> {
         workspace.root().to_path_buf(),
         ModuleSearchPathKind::FirstParty,
     );
-    let mut program = Program::new(workspace, vec![workspace_search_path]);
+    let mut program = Program::new(workspace);
+    program.set_module_search_paths(vec![workspace_search_path]);
 
     let entry_id = program.file_id(entry_point);
     program.workspace_mut().open_file(entry_id);
@@ -102,10 +102,9 @@ impl MainLoop {
         let (main_loop_sender, main_loop_receiver) = crossbeam_channel::bounded(1);
 
         let mut orchestrator = Orchestrator {
-            pending_analysis: None,
             receiver: orchestrator_receiver,
             sender: main_loop_sender.clone(),
-            aggregated_changes: AggregatedChanges::default(),
+            revision: 0,
         };
 
         std::thread::spawn(move || {
@@ -138,34 +137,32 @@ impl MainLoop {
             tracing::trace!("Main Loop: Tick");
 
             match message {
-                MainLoopMessage::CheckProgram => {
-                    // Remove mutability from program.
-                    let program = &*program;
-                    let run_cancellation_token_source = CancellationTokenSource::new();
-                    let run_cancellation_token = run_cancellation_token_source.token();
-                    let sender = &self.orchestrator_sender;
+                MainLoopMessage::CheckProgram { revision } => {
+                    let program = program.snapshot();
+                    let sender = self.orchestrator_sender.clone();
 
-                    sender
-                        .send(OrchestratorMessage::CheckProgramStarted {
-                            cancellation_token: run_cancellation_token_source,
-                        })
-                        .unwrap();
+                    // Spawn a new task that checks the program. This needs to be done in a separate thread
+                    // to prevent blocking the main loop here.
+                    rayon::spawn(move || {
+                        rayon::in_place_scope(|scope| {
+                            let scheduler = RayonCheckScheduler::new(&program, scope);
 
-                    rayon::in_place_scope(|scope| {
-                        let scheduler = RayonCheckScheduler::new(program, scope);
-
-                        let result = program.check(&scheduler, run_cancellation_token);
-                        match result {
-                            Ok(result) => sender
-                                .send(OrchestratorMessage::CheckProgramCompleted(result))
-                                .unwrap(),
-                            Err(QueryError::Cancelled) => sender
-                                .send(OrchestratorMessage::CheckProgramCancelled)
-                                .unwrap(),
-                        }
+                            match program.check(&scheduler) {
+                                Ok(result) => {
+                                    sender
+                                        .send(OrchestratorMessage::CheckProgramCompleted {
+                                            diagnostics: result,
+                                            revision,
+                                        })
+                                        .unwrap();
+                                }
+                                Err(QueryError::Cancelled) => {}
+                            }
+                        });
                     });
                 }
                 MainLoopMessage::ApplyChanges(changes) => {
+                    // Automatically cancels any pending queries and waits for them to complete.
                     program.apply_changes(changes.iter());
                 }
                 MainLoopMessage::CheckCompleted(diagnostics) => {
@@ -212,13 +209,11 @@ impl MainLoopCancellationToken {
 }
 
 struct Orchestrator {
-    aggregated_changes: AggregatedChanges,
-    pending_analysis: Option<PendingAnalysisState>,
-
     /// Sends messages to the main loop.
     sender: crossbeam_channel::Sender<MainLoopMessage>,
     /// Receives messages from the main loop.
     receiver: crossbeam_channel::Receiver<OrchestratorMessage>,
+    revision: usize,
 }
 
 impl Orchestrator {
@@ -226,51 +221,33 @@ impl Orchestrator {
         while let Ok(message) = self.receiver.recv() {
             match message {
                 OrchestratorMessage::Run => {
-                    self.pending_analysis = None;
-                    self.sender.send(MainLoopMessage::CheckProgram).unwrap();
-                }
-
-                OrchestratorMessage::CheckProgramStarted { cancellation_token } => {
-                    debug_assert!(self.pending_analysis.is_none());
-
-                    self.pending_analysis = Some(PendingAnalysisState { cancellation_token });
-                }
-
-                OrchestratorMessage::CheckProgramCompleted(diagnostics) => {
-                    self.pending_analysis
-                        .take()
-                        .expect("Expected a pending analysis.");
-
                     self.sender
-                        .send(MainLoopMessage::CheckCompleted(diagnostics))
+                        .send(MainLoopMessage::CheckProgram {
+                            revision: self.revision,
+                        })
                         .unwrap();
                 }
 
-                OrchestratorMessage::CheckProgramCancelled => {
-                    self.pending_analysis
-                        .take()
-                        .expect("Expected a pending analysis.");
-
-                    self.debounce_changes();
+                OrchestratorMessage::CheckProgramCompleted {
+                    diagnostics,
+                    revision,
+                } => {
+                    // Only take the diagnostics if they are for the latest revision.
+                    if self.revision == revision {
+                        self.sender
+                            .send(MainLoopMessage::CheckCompleted(diagnostics))
+                            .unwrap();
+                    } else {
+                        tracing::debug!("Discarding diagnostics for outdated revision {revision} (current: {}).", self.revision);
+                    }
                 }
 
                 OrchestratorMessage::FileChanges(changes) => {
                     // Request cancellation, but wait until all analysis tasks have completed to
                     // avoid stale messages in the next main loop.
-                    let pending = if let Some(pending_state) = self.pending_analysis.as_ref() {
-                        pending_state.cancellation_token.cancel();
-                        true
-                    } else {
-                        false
-                    };
 
-                    self.aggregated_changes.extend(changes);
-
-                    // If there are no pending analysis tasks, apply the file changes. Otherwise
-                    // keep running until all file checks have completed.
-                    if !pending {
-                        self.debounce_changes();
-                    }
+                    self.revision += 1;
+                    self.debounce_changes(changes);
                 }
                 OrchestratorMessage::Shutdown => {
                     return self.shutdown();
@@ -279,8 +256,9 @@ impl Orchestrator {
         }
     }
 
-    fn debounce_changes(&mut self) {
-        debug_assert!(self.pending_analysis.is_none());
+    fn debounce_changes(&self, changes: Vec<FileChange>) {
+        let mut aggregated_changes = AggregatedChanges::default();
+        aggregated_changes.extend(changes);
 
         loop {
             // Consume possibly incoming file change messages before running a new analysis, but don't wait for more than 100ms.
@@ -291,10 +269,12 @@ impl Orchestrator {
                             return self.shutdown();
                         }
                         Ok(OrchestratorMessage::FileChanges(file_changes)) => {
-                            self.aggregated_changes.extend(file_changes);
+                            aggregated_changes.extend(file_changes);
                         }
 
-                        Ok(OrchestratorMessage::CheckProgramStarted {..}| OrchestratorMessage::CheckProgramCompleted(_) | OrchestratorMessage::CheckProgramCancelled) => unreachable!("No program check should be running while debouncing changes."),
+                        Ok(OrchestratorMessage::CheckProgramCompleted { .. })=> {
+                            // disregard any outdated completion message.
+                        }
                         Ok(OrchestratorMessage::Run) => unreachable!("The orchestrator is already running."),
 
                         Err(_) => {
@@ -305,8 +285,8 @@ impl Orchestrator {
                 },
                 default(std::time::Duration::from_millis(100)) => {
                     // No more file changes after 100 ms, send the changes and schedule a new analysis
-                    self.sender.send(MainLoopMessage::ApplyChanges(std::mem::take(&mut self.aggregated_changes))).unwrap();
-                    self.sender.send(MainLoopMessage::CheckProgram).unwrap();
+                    self.sender.send(MainLoopMessage::ApplyChanges(aggregated_changes)).unwrap();
+                    self.sender.send(MainLoopMessage::CheckProgram { revision: self.revision}).unwrap();
                     return;
                 }
             }
@@ -319,15 +299,10 @@ impl Orchestrator {
     }
 }
 
-#[derive(Debug)]
-struct PendingAnalysisState {
-    cancellation_token: CancellationTokenSource,
-}
-
 /// Message sent from the orchestrator to the main loop.
 #[derive(Debug)]
 enum MainLoopMessage {
-    CheckProgram,
+    CheckProgram { revision: usize },
     CheckCompleted(Vec<String>),
     ApplyChanges(AggregatedChanges),
     Exit,
@@ -338,11 +313,10 @@ enum OrchestratorMessage {
     Run,
     Shutdown,
 
-    CheckProgramStarted {
-        cancellation_token: CancellationTokenSource,
+    CheckProgramCompleted {
+        diagnostics: Vec<String>,
+        revision: usize,
     },
-    CheckProgramCompleted(Vec<String>),
-    CheckProgramCancelled,
 
     FileChanges(Vec<FileChange>),
 }

--- a/crates/red_knot/src/parse.rs
+++ b/crates/red_knot/src/parse.rs
@@ -6,7 +6,7 @@ use ruff_python_parser::{Mode, ParseError};
 use ruff_text_size::{Ranged, TextRange};
 
 use crate::cache::KeyValueCache;
-use crate::db::{HasJar, SourceDb, SourceJar};
+use crate::db::{HasJar, QueryResult, SourceDb, SourceJar};
 use crate::files::FileId;
 
 #[derive(Debug, Clone, PartialEq)]
@@ -64,16 +64,16 @@ impl Parsed {
 }
 
 #[tracing::instrument(level = "debug", skip(db))]
-pub(crate) fn parse<Db>(db: &Db, file_id: FileId) -> Parsed
+pub(crate) fn parse<Db>(db: &Db, file_id: FileId) -> QueryResult<Parsed>
 where
     Db: SourceDb + HasJar<SourceJar>,
 {
-    let parsed = db.jar();
+    let parsed = db.jar()?;
 
     parsed.parsed.get(&file_id, |file_id| {
-        let source = db.source(*file_id);
+        let source = db.source(*file_id)?;
 
-        Parsed::from_text(source.text())
+        Ok(Parsed::from_text(source.text()))
     })
 }
 

--- a/crates/red_knot/src/program/check.rs
+++ b/crates/red_knot/src/program/check.rs
@@ -3,7 +3,7 @@ use std::num::NonZeroUsize;
 use rayon::{current_num_threads, yield_local};
 use rustc_hash::FxHashSet;
 
-use crate::db::{ParallelDatabase, QueryError, QueryResult, SemanticDb, SourceDb};
+use crate::db::{Database, QueryError, QueryResult, SemanticDb, SourceDb};
 use crate::files::FileId;
 use crate::lint::Diagnostics;
 use crate::program::Program;

--- a/crates/red_knot/src/program/mod.rs
+++ b/crates/red_knot/src/program/mod.rs
@@ -3,7 +3,7 @@ pub mod check;
 use std::path::Path;
 use std::sync::Arc;
 
-use crate::db::{Db, HasJar, SemanticDb, SemanticJar, SourceDb, SourceJar};
+use crate::db::{Db, HasJar, QueryResult, SemanticDb, SemanticJar, SourceDb, SourceJar};
 use crate::files::{FileId, Files};
 use crate::lint::{
     lint_semantic, lint_syntax, Diagnostics, LintSemanticStorage, LintSyntaxStorage,
@@ -85,41 +85,41 @@ impl SourceDb for Program {
         self.files.path(file_id)
     }
 
-    fn source(&self, file_id: FileId) -> Source {
+    fn source(&self, file_id: FileId) -> QueryResult<Source> {
         source_text(self, file_id)
     }
 
-    fn parse(&self, file_id: FileId) -> Parsed {
+    fn parse(&self, file_id: FileId) -> QueryResult<Parsed> {
         parse(self, file_id)
     }
 
-    fn lint_syntax(&self, file_id: FileId) -> Diagnostics {
+    fn lint_syntax(&self, file_id: FileId) -> QueryResult<Diagnostics> {
         lint_syntax(self, file_id)
     }
 }
 
 impl SemanticDb for Program {
-    fn resolve_module(&self, name: ModuleName) -> Option<Module> {
+    fn resolve_module(&self, name: ModuleName) -> QueryResult<Option<Module>> {
         resolve_module(self, name)
     }
 
-    fn file_to_module(&self, file_id: FileId) -> Option<Module> {
+    fn file_to_module(&self, file_id: FileId) -> QueryResult<Option<Module>> {
         file_to_module(self, file_id)
     }
 
-    fn path_to_module(&self, path: &Path) -> Option<Module> {
+    fn path_to_module(&self, path: &Path) -> QueryResult<Option<Module>> {
         path_to_module(self, path)
     }
 
-    fn symbol_table(&self, file_id: FileId) -> Arc<SymbolTable> {
+    fn symbol_table(&self, file_id: FileId) -> QueryResult<Arc<SymbolTable>> {
         symbol_table(self, file_id)
     }
 
-    fn infer_symbol_type(&self, file_id: FileId, symbol_id: SymbolId) -> Type {
+    fn infer_symbol_type(&self, file_id: FileId, symbol_id: SymbolId) -> QueryResult<Type> {
         infer_symbol_type(self, file_id, symbol_id)
     }
 
-    fn lint_semantic(&self, file_id: FileId) -> Diagnostics {
+    fn lint_semantic(&self, file_id: FileId) -> QueryResult<Diagnostics> {
         lint_semantic(self, file_id)
     }
 
@@ -136,8 +136,8 @@ impl SemanticDb for Program {
 impl Db for Program {}
 
 impl HasJar<SourceJar> for Program {
-    fn jar(&self) -> &SourceJar {
-        &self.source
+    fn jar(&self) -> QueryResult<&SourceJar> {
+        Ok(&self.source)
     }
 
     fn jar_mut(&mut self) -> &mut SourceJar {
@@ -146,8 +146,8 @@ impl HasJar<SourceJar> for Program {
 }
 
 impl HasJar<SemanticJar> for Program {
-    fn jar(&self) -> &SemanticJar {
-        &self.semantic
+    fn jar(&self) -> QueryResult<&SemanticJar> {
+        Ok(&self.semantic)
     }
 
     fn jar_mut(&mut self) -> &mut SemanticJar {

--- a/crates/red_knot/src/program/mod.rs
+++ b/crates/red_knot/src/program/mod.rs
@@ -1,45 +1,35 @@
-pub mod check;
-
 use std::path::Path;
 use std::sync::Arc;
 
-use crate::db::{Db, HasJar, QueryResult, SemanticDb, SemanticJar, SourceDb, SourceJar};
-use crate::files::{FileId, Files};
-use crate::lint::{
-    lint_semantic, lint_syntax, Diagnostics, LintSemanticStorage, LintSyntaxStorage,
+use crate::db::{
+    Database, Db, DbRuntime, HasJar, HasJars, JarsStorage, ParallelDatabase, QueryResult,
+    SemanticDb, SemanticJar, Snapshot, SourceDb, SourceJar,
 };
+use crate::files::{FileId, Files};
+use crate::lint::{lint_semantic, lint_syntax, Diagnostics};
 use crate::module::{
     add_module, file_to_module, path_to_module, resolve_module, set_module_search_paths, Module,
-    ModuleData, ModuleName, ModuleResolver, ModuleSearchPath,
+    ModuleData, ModuleName, ModuleSearchPath,
 };
-use crate::parse::{parse, Parsed, ParsedStorage};
-use crate::source::{source_text, Source, SourceStorage};
-use crate::symbols::{symbol_table, SymbolId, SymbolTable, SymbolTablesStorage};
-use crate::types::{infer_symbol_type, Type, TypeStore};
+use crate::parse::{parse, Parsed};
+use crate::source::{source_text, Source};
+use crate::symbols::{symbol_table, SymbolId, SymbolTable};
+use crate::types::{infer_symbol_type, Type};
 use crate::Workspace;
+
+pub mod check;
 
 #[derive(Debug)]
 pub struct Program {
+    jars: JarsStorage<Program>,
     files: Files,
-    source: SourceJar,
-    semantic: SemanticJar,
     workspace: Workspace,
 }
 
 impl Program {
-    pub fn new(workspace: Workspace, module_search_paths: Vec<ModuleSearchPath>) -> Self {
+    pub fn new(workspace: Workspace) -> Self {
         Self {
-            source: SourceJar {
-                sources: SourceStorage::default(),
-                parsed: ParsedStorage::default(),
-                lint_syntax: LintSyntaxStorage::default(),
-            },
-            semantic: SemanticJar {
-                module_resolver: ModuleResolver::new(module_search_paths),
-                symbol_tables: SymbolTablesStorage::default(),
-                type_store: TypeStore::default(),
-                lint_semantic: LintSemanticStorage::default(),
-            },
+            jars: JarsStorage::default(),
             files: Files::default(),
             workspace,
         }
@@ -49,17 +39,19 @@ impl Program {
     where
         I: IntoIterator<Item = FileChange>,
     {
+        let files = self.files.clone();
+        let (source, semantic) = self.jars_mut();
         for change in changes {
-            self.semantic
-                .module_resolver
-                .remove_module(&self.file_path(change.id));
-            self.semantic.symbol_tables.remove(&change.id);
-            self.source.sources.remove(&change.id);
-            self.source.parsed.remove(&change.id);
-            self.source.lint_syntax.remove(&change.id);
+            let file_path = files.path(change.id);
+
+            semantic.module_resolver.remove_module(&file_path);
+            semantic.symbol_tables.remove(&change.id);
+            source.sources.remove(&change.id);
+            source.parsed.remove(&change.id);
+            source.lint_syntax.remove(&change.id);
             // TODO: remove all dependent modules as well
-            self.semantic.type_store.remove_module(change.id);
-            self.semantic.lint_semantic.remove(&change.id);
+            semantic.type_store.remove_module(change.id);
+            semantic.lint_semantic.remove(&change.id);
         }
     }
 
@@ -135,23 +127,59 @@ impl SemanticDb for Program {
 
 impl Db for Program {}
 
+impl Database for Program {
+    fn runtime(&self) -> &DbRuntime {
+        self.jars.runtime()
+    }
+
+    fn runtime_mut(&mut self) -> &mut DbRuntime {
+        self.jars.runtime_mut()
+    }
+}
+
+impl ParallelDatabase for Program {
+    fn snapshot(&self) -> Snapshot<Self> {
+        Snapshot::new(Self {
+            jars: self.jars.snapshot(),
+            files: self.files.clone(),
+            workspace: self.workspace.clone(),
+        })
+    }
+}
+
+impl HasJars for Program {
+    type Jars = (SourceJar, SemanticJar);
+
+    fn jars(&self) -> QueryResult<&Self::Jars> {
+        self.jars.jars()
+    }
+
+    fn jars_unwrap(&self) -> &Self::Jars {
+        self.jars.jars_unwrap()
+    }
+
+    fn jars_mut(&mut self) -> &mut Self::Jars {
+        self.jars.jars_mut()
+    }
+}
+
 impl HasJar<SourceJar> for Program {
     fn jar(&self) -> QueryResult<&SourceJar> {
-        Ok(&self.source)
+        Ok(&self.jars()?.0)
     }
 
     fn jar_mut(&mut self) -> &mut SourceJar {
-        &mut self.source
+        &mut self.jars_mut().0
     }
 }
 
 impl HasJar<SemanticJar> for Program {
     fn jar(&self) -> QueryResult<&SemanticJar> {
-        Ok(&self.semantic)
+        Ok(&self.jars()?.1)
     }
 
     fn jar_mut(&mut self) -> &mut SemanticJar {
-        &mut self.semantic
+        &mut self.jars_mut().1
     }
 }
 

--- a/crates/red_knot/src/program/mod.rs
+++ b/crates/red_knot/src/program/mod.rs
@@ -154,10 +154,6 @@ impl HasJars for Program {
         self.jars.jars()
     }
 
-    fn jars_unwrap(&self) -> &Self::Jars {
-        self.jars.jars_unwrap()
-    }
-
     fn jars_mut(&mut self) -> &mut Self::Jars {
         self.jars.jars_mut()
     }

--- a/crates/red_knot/src/source.rs
+++ b/crates/red_knot/src/source.rs
@@ -1,5 +1,5 @@
 use crate::cache::KeyValueCache;
-use crate::db::{HasJar, SourceDb, SourceJar};
+use crate::db::{HasJar, QueryResult, SourceDb, SourceJar};
 use ruff_notebook::Notebook;
 use ruff_python_ast::PySourceType;
 use std::ops::{Deref, DerefMut};
@@ -8,11 +8,11 @@ use std::sync::Arc;
 use crate::files::FileId;
 
 #[tracing::instrument(level = "debug", skip(db))]
-pub(crate) fn source_text<Db>(db: &Db, file_id: FileId) -> Source
+pub(crate) fn source_text<Db>(db: &Db, file_id: FileId) -> QueryResult<Source>
 where
     Db: SourceDb + HasJar<SourceJar>,
 {
-    let sources = &db.jar().sources;
+    let sources = &db.jar()?.sources;
 
     sources.get(&file_id, |file_id| {
         let path = db.file_path(*file_id);
@@ -43,7 +43,7 @@ where
             }
         };
 
-        Source { kind }
+        Ok(Source { kind })
     })
 }
 

--- a/crates/red_knot/src/symbols.rs
+++ b/crates/red_knot/src/symbols.rs
@@ -16,22 +16,22 @@ use ruff_python_ast::visitor::preorder::PreorderVisitor;
 
 use crate::ast_ids::TypedNodeKey;
 use crate::cache::KeyValueCache;
-use crate::db::{HasJar, SemanticDb, SemanticJar};
+use crate::db::{HasJar, QueryResult, SemanticDb, SemanticJar};
 use crate::files::FileId;
 use crate::module::ModuleName;
 use crate::Name;
 
 #[allow(unreachable_pub)]
 #[tracing::instrument(level = "debug", skip(db))]
-pub fn symbol_table<Db>(db: &Db, file_id: FileId) -> Arc<SymbolTable>
+pub fn symbol_table<Db>(db: &Db, file_id: FileId) -> QueryResult<Arc<SymbolTable>>
 where
     Db: SemanticDb + HasJar<SemanticJar>,
 {
-    let jar = db.jar();
+    let jar = db.jar()?;
 
     jar.symbol_tables.get(&file_id, |_| {
-        let parsed = db.parse(file_id);
-        Arc::from(SymbolTable::from_ast(parsed.ast()))
+        let parsed = db.parse(file_id)?;
+        Ok(Arc::from(SymbolTable::from_ast(parsed.ast())))
     })
 }
 

--- a/crates/ruff_server/Cargo.toml
+++ b/crates/ruff_server/Cargo.toml
@@ -26,7 +26,7 @@ ruff_text_size = { path = "../ruff_text_size" }
 ruff_workspace = { path = "../ruff_workspace" }
 
 anyhow = { workspace = true }
-crossbeam-channel = { workspace = true }
+crossbeam = { workspace = true }
 jod-thread = { workspace = true }
 libc = { workspace = true }
 lsp-server = { workspace = true }

--- a/crates/ruff_server/src/server/client.rs
+++ b/crates/ruff_server/src/server/client.rs
@@ -6,7 +6,7 @@ use serde_json::Value;
 
 use super::schedule::Task;
 
-pub(crate) type ClientSender = crossbeam_channel::Sender<lsp_server::Message>;
+pub(crate) type ClientSender = crossbeam::channel::Sender<lsp_server::Message>;
 
 type ResponseBuilder<'s> = Box<dyn FnOnce(lsp_server::Response) -> Task<'s>>;
 

--- a/crates/ruff_server/src/server/schedule.rs
+++ b/crates/ruff_server/src/server/schedule.rs
@@ -1,6 +1,6 @@
 use std::num::NonZeroUsize;
 
-use crossbeam_channel::Sender;
+use crossbeam::channel::Sender;
 
 use crate::session::Session;
 

--- a/crates/ruff_server/src/server/schedule/thread/pool.rs
+++ b/crates/ruff_server/src/server/schedule/thread/pool.rs
@@ -21,7 +21,7 @@ use std::{
     },
 };
 
-use crossbeam_channel::{Receiver, Sender};
+use crossbeam::channel::{Receiver, Sender};
 
 use super::{Builder, JoinHandle, ThreadPriority};
 
@@ -52,7 +52,7 @@ impl Pool {
         let threads = usize::from(threads);
 
         // Channel buffer capacity is between 2 and 4, depending on the pool size.
-        let (job_sender, job_receiver) = crossbeam_channel::bounded(std::cmp::min(threads * 2, 4));
+        let (job_sender, job_receiver) = crossbeam::channel::bounded(std::cmp::min(threads * 2, 4));
         let extant_tasks = Arc::new(AtomicUsize::new(0));
 
         let mut handles = Vec::with_capacity(threads);


### PR DESCRIPTION
## Summary

This PR implements a snapshotting mechanism for `Database` and makes query cancellation a `Database` concept. The motivation for this change is the LSP where the main loop in the LSP uses `spawn` to schedule some work on its thread pool. `sapwn` requires that all arguments have a `'static` lifetime. That means passing a `&Program` as we've done in the CLI main loop won't be possible. 

To solve this, this PR introduces a `program.snapshot` method that returns an owned but read-only database instance. The LSP can safely pass the snapshot to its worker thread because it satisfies the `'static` lifetime requirement. 

The main challenge of the `snapshot` function is that we don't want to create a deep-clone of the database including the `jars` state because:

* a deep-clone of the caches is very expensive
* it would mean that caching is restricted to a single thread. However, we want to share a single cache between all threads.

Getting cheap "clones" is achieved by wrapping the `jars` state in an `Arc`. However, this introduces a new problem. Now, mutating is expensive because `Arc`s are read-only by default. Solving this, requires introducing cancellation.

The implementation makes use of the fact that mutating an `Arc` in place is possible if the `Arc` has exactly one reference. The `Database` now stores its own cancellation token and calling a mutation method on the storage (or database) automatically requests cancellation of all queries and waits until all other references to `jars` are dropped. It is then possible to safely take the mutable reference from the `Arc`.

Waiting is implemented using a [`WaitGroup`](https://docs.rs/crossbeam/latest/crossbeam/sync/struct.WaitGroup.html). The WaitGroup is stored in the `Jars` storage, and its counter is incremented whenever a `Snapshot` is created and automatically decremented when a `Snapshot` drops. 

The last missing piece is to ensure that queries stop "soonish" when cancellation is requested. This is achieved by changing the `db.jar()` method to return a `QueryResult`. It returns `Err(QueryError::Cancelled)` in case cancellation has been requested. This requires that we change the return type of each query to `QueryResult` because they won't have a result when they're cancelled. 
Checking cancellation in the `jars` method has the advantage that it is automatically tested by each query that uses caching because the method is needed to retrieve the query storage. Queries have the possibility to manually test for cancellation if needed by calling `db.cancelled()?`, but that should only be necessary for long operations that never issue a new query. 


## Catch unwind

An alternative to `QueryResult` is to panic with a specific error and catch that error in a catch unwind boundary. This is what salsa does. I decided to use a `Result` instead to make cancellation more explicit. I think that it is important to be aware that a request can be cancelled because it means that we need to ensure to never write "partial" results into the cache, and if we do, have a way to undo the change in case the query gets cancelled to leave the cache in a clean state. 

## Test plan

I ran the linter and used `touch` to trigger a re-run. This PR adds a new `RED_KNOT_SLOW_LINT` that adds an artificial slowdown to `lint_syntax` for testing cancellation. 

## Attribution

The ideas here are heavily inspired by Salsa and sometimes applied 1:1. 

