### PR TITLE
Add convenience methods for iterating over all parameter nodes in a function

### DIFF
--- a/crates/ruff_linter/src/checkers/ast/mod.rs
+++ b/crates/ruff_linter/src/checkers/ast/mod.rs
@@ -31,7 +31,7 @@ use std::path::Path;
 use itertools::Itertools;
 use log::debug;
 use ruff_python_ast::{
-    self as ast, AnyParameter, Comprehension, ElifElseClause, ExceptHandler, Expr, ExprContext,
+    self as ast, AnyParameterRef, Comprehension, ElifElseClause, ExceptHandler, Expr, ExprContext,
     FStringElement, Keyword, MatchCase, Parameter, Parameters, Pattern, Stmt, Suite, UnaryOp,
 };
 use ruff_text_size::{Ranged, TextRange, TextSize};
@@ -604,7 +604,7 @@ impl<'a> Visitor<'a> for Checker<'a> {
                     self.visit_type_params(type_params);
                 }
 
-                for parameter in parameters.iter_all_params() {
+                for parameter in parameters.iter() {
                     if let Some(expr) = parameter.annotation() {
                         if singledispatch && !parameter.is_variadic() {
                             self.visit_runtime_required_annotation(expr);
@@ -1440,7 +1440,7 @@ impl<'a> Visitor<'a> for Checker<'a> {
         // Step 1: Binding.
         // Bind, but intentionally avoid walking default expressions, as we handle them
         // upstream.
-        for parameter in parameters.iter_all_params().map(AnyParameter::as_parameter) {
+        for parameter in parameters.iter().map(AnyParameterRef::as_parameter) {
             self.visit_parameter(parameter);
         }
 

--- a/crates/ruff_linter/src/checkers/ast/mod.rs
+++ b/crates/ruff_linter/src/checkers/ast/mod.rs
@@ -31,8 +31,8 @@ use std::path::Path;
 use itertools::Itertools;
 use log::debug;
 use ruff_python_ast::{
-    self as ast, Comprehension, ElifElseClause, ExceptHandler, Expr, ExprContext, FStringElement,
-    Keyword, MatchCase, Parameter, ParameterWithDefault, Parameters, Pattern, Stmt, Suite, UnaryOp,
+    self as ast, AnyParameter, Comprehension, ElifElseClause, ExceptHandler, Expr, ExprContext,
+    FStringElement, Keyword, MatchCase, Parameter, Parameters, Pattern, Stmt, Suite, UnaryOp,
 };
 use ruff_text_size::{Ranged, TextRange, TextSize};
 
@@ -604,15 +604,11 @@ impl<'a> Visitor<'a> for Checker<'a> {
                     self.visit_type_params(type_params);
                 }
 
-                for parameter_with_default in parameters
-                    .posonlyargs
-                    .iter()
-                    .chain(&parameters.args)
-                    .chain(&parameters.kwonlyargs)
-                {
-                    if let Some(expr) = &parameter_with_default.parameter.annotation {
-                        if singledispatch {
+                for parameter in parameters.iter_all_params() {
+                    if let Some(expr) = parameter.annotation() {
+                        if singledispatch && !parameter.is_variadic() {
                             self.visit_runtime_required_annotation(expr);
+                            singledispatch = false;
                         } else {
                             match annotation {
                                 AnnotationContext::RuntimeRequired => {
@@ -625,41 +621,10 @@ impl<'a> Visitor<'a> for Checker<'a> {
                                     self.visit_annotation(expr);
                                 }
                             }
-                        };
+                        }
                     }
-                    if let Some(expr) = &parameter_with_default.default {
+                    if let Some(expr) = parameter.default() {
                         self.visit_expr(expr);
-                    }
-                    singledispatch = false;
-                }
-                if let Some(arg) = &parameters.vararg {
-                    if let Some(expr) = &arg.annotation {
-                        match annotation {
-                            AnnotationContext::RuntimeRequired => {
-                                self.visit_runtime_required_annotation(expr);
-                            }
-                            AnnotationContext::RuntimeEvaluated => {
-                                self.visit_runtime_evaluated_annotation(expr);
-                            }
-                            AnnotationContext::TypingOnly => {
-                                self.visit_annotation(expr);
-                            }
-                        }
-                    }
-                }
-                if let Some(arg) = &parameters.kwarg {
-                    if let Some(expr) = &arg.annotation {
-                        match annotation {
-                            AnnotationContext::RuntimeRequired => {
-                                self.visit_runtime_required_annotation(expr);
-                            }
-                            AnnotationContext::RuntimeEvaluated => {
-                                self.visit_runtime_evaluated_annotation(expr);
-                            }
-                            AnnotationContext::TypingOnly => {
-                                self.visit_annotation(expr);
-                            }
-                        }
                     }
                 }
                 for expr in returns {
@@ -1043,19 +1008,11 @@ impl<'a> Visitor<'a> for Checker<'a> {
             ) => {
                 // Visit the default arguments, but avoid the body, which will be deferred.
                 if let Some(parameters) = parameters {
-                    for ParameterWithDefault {
-                        default,
-                        parameter: _,
-                        range: _,
-                    } in parameters
-                        .posonlyargs
-                        .iter()
-                        .chain(&parameters.args)
-                        .chain(&parameters.kwonlyargs)
+                    for default in parameters
+                        .iter_non_variadic_params()
+                        .filter_map(|param| param.default.as_deref())
                     {
-                        if let Some(expr) = &default {
-                            self.visit_expr(expr);
-                        }
+                        self.visit_expr(default);
                     }
                 }
 
@@ -1483,20 +1440,8 @@ impl<'a> Visitor<'a> for Checker<'a> {
         // Step 1: Binding.
         // Bind, but intentionally avoid walking default expressions, as we handle them
         // upstream.
-        for parameter_with_default in &parameters.posonlyargs {
-            self.visit_parameter(&parameter_with_default.parameter);
-        }
-        for parameter_with_default in &parameters.args {
-            self.visit_parameter(&parameter_with_default.parameter);
-        }
-        if let Some(arg) = &parameters.vararg {
-            self.visit_parameter(arg);
-        }
-        for parameter_with_default in &parameters.kwonlyargs {
-            self.visit_parameter(&parameter_with_default.parameter);
-        }
-        if let Some(arg) = &parameters.kwarg {
-            self.visit_parameter(arg);
+        for parameter in parameters.iter_all_params().map(AnyParameter::as_parameter) {
+            self.visit_parameter(parameter);
         }
 
         // Step 4: Analysis

--- a/crates/ruff_linter/src/checkers/ast/mod.rs
+++ b/crates/ruff_linter/src/checkers/ast/mod.rs
@@ -604,7 +604,7 @@ impl<'a> Visitor<'a> for Checker<'a> {
                     self.visit_type_params(type_params);
                 }
 
-                for parameter in parameters.iter() {
+                for parameter in &**parameters {
                     if let Some(expr) = parameter.annotation() {
                         if singledispatch && !parameter.is_variadic() {
                             self.visit_runtime_required_annotation(expr);

--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/hardcoded_password_default.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/hardcoded_password_default.rs
@@ -74,11 +74,7 @@ pub(crate) fn hardcoded_password_default(checker: &mut Checker, parameters: &Par
         parameter,
         default,
         range: _,
-    } in parameters
-        .posonlyargs
-        .iter()
-        .chain(&parameters.args)
-        .chain(&parameters.kwonlyargs)
+    } in parameters.iter_non_variadic_params()
     {
         let Some(default) = default else {
             continue;

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/function_call_in_argument_default.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/function_call_in_argument_default.rs
@@ -139,11 +139,7 @@ pub(crate) fn function_call_in_argument_default(checker: &mut Checker, parameter
         default,
         parameter,
         range: _,
-    } in parameters
-        .posonlyargs
-        .iter()
-        .chain(&parameters.args)
-        .chain(&parameters.kwonlyargs)
+    } in parameters.iter_non_variadic_params()
     {
         if let Some(expr) = &default {
             if !parameter.annotation.as_ref().is_some_and(|expr| {

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/loop_variable_overrides_iterator.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/loop_variable_overrides_iterator.rs
@@ -105,11 +105,7 @@ impl<'a> Visitor<'a> for NameFinder<'a> {
                         parameter,
                         default: _,
                         range: _,
-                    } in parameters
-                        .posonlyargs
-                        .iter()
-                        .chain(&parameters.args)
-                        .chain(&parameters.kwonlyargs)
+                    } in parameters.iter_non_variadic_params()
                     {
                         self.names.remove(parameter.name.as_str());
                     }

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/mutable_argument_default.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/mutable_argument_default.rs
@@ -89,12 +89,7 @@ pub(crate) fn mutable_argument_default(checker: &mut Checker, function_def: &ast
         parameter,
         default,
         range: _,
-    } in function_def
-        .parameters
-        .posonlyargs
-        .iter()
-        .chain(&function_def.parameters.args)
-        .chain(&function_def.parameters.kwonlyargs)
+    } in function_def.parameters.iter_non_variadic_params()
     {
         let Some(default) = default else {
             continue;

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_map.rs
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_map.rs
@@ -107,10 +107,7 @@ pub(crate) fn unnecessary_map(
             if parameters.as_ref().is_some_and(|parameters| {
                 late_binding(parameters, body)
                     || parameters
-                        .posonlyargs
-                        .iter()
-                        .chain(&parameters.args)
-                        .chain(&parameters.kwonlyargs)
+                        .iter_non_variadic_params()
                         .any(|param| param.default.is_some())
                     || parameters.vararg.is_some()
                     || parameters.kwarg.is_some()
@@ -152,10 +149,7 @@ pub(crate) fn unnecessary_map(
             if parameters.as_ref().is_some_and(|parameters| {
                 late_binding(parameters, body)
                     || parameters
-                        .posonlyargs
-                        .iter()
-                        .chain(&parameters.args)
-                        .chain(&parameters.kwonlyargs)
+                        .iter_non_variadic_params()
                         .any(|param| param.default.is_some())
                     || parameters.vararg.is_some()
                     || parameters.kwarg.is_some()
@@ -207,10 +201,7 @@ pub(crate) fn unnecessary_map(
             if parameters.as_ref().is_some_and(|parameters| {
                 late_binding(parameters, body)
                     || parameters
-                        .posonlyargs
-                        .iter()
-                        .chain(&parameters.args)
-                        .chain(&parameters.kwonlyargs)
+                        .iter_non_variadic_params()
                         .any(|param| param.default.is_some())
                     || parameters.vararg.is_some()
                     || parameters.kwarg.is_some()

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/no_return_argument_annotation.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/no_return_argument_annotation.rs
@@ -2,7 +2,7 @@ use std::fmt;
 
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
-use ruff_python_ast::{AnyParameter, Parameters};
+use ruff_python_ast::{AnyParameterRef, Parameters};
 use ruff_text_size::Ranged;
 
 use crate::checkers::ast::Checker;
@@ -60,10 +60,7 @@ pub(crate) fn no_return_argument_annotation(checker: &mut Checker, parameters: &
     // Ex) def func(*, arg: NoReturn): ...
     // Ex) def func(*args: NoReturn): ...
     // Ex) def func(**kwargs: NoReturn): ...
-    for annotation in parameters
-        .iter_all_params()
-        .filter_map(AnyParameter::annotation)
-    {
+    for annotation in parameters.iter().filter_map(AnyParameterRef::annotation) {
         if checker.semantic().match_typing_expr(annotation, "NoReturn") {
             checker.diagnostics.push(Diagnostic::new(
                 NoReturnArgumentAnnotationInStub {

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/no_return_argument_annotation.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/no_return_argument_annotation.rs
@@ -2,7 +2,7 @@ use std::fmt;
 
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
-use ruff_python_ast::{Expr, Parameters};
+use ruff_python_ast::{AnyParameter, Parameters};
 use ruff_text_size::Ranged;
 
 use crate::checkers::ast::Checker;
@@ -58,43 +58,24 @@ pub(crate) fn no_return_argument_annotation(checker: &mut Checker, parameters: &
     // Ex) def func(arg: NoReturn): ...
     // Ex) def func(arg: NoReturn, /): ...
     // Ex) def func(*, arg: NoReturn): ...
-    for annotation in parameters
-        .posonlyargs
-        .iter()
-        .chain(&parameters.args)
-        .chain(&parameters.kwonlyargs)
-        .filter_map(|arg| arg.parameter.annotation.as_ref())
-    {
-        check_no_return_argument_annotation(checker, annotation);
-    }
-
     // Ex) def func(*args: NoReturn): ...
-    if let Some(arg) = &parameters.vararg {
-        if let Some(annotation) = &arg.annotation {
-            check_no_return_argument_annotation(checker, annotation);
-        }
-    }
-
     // Ex) def func(**kwargs: NoReturn): ...
-    if let Some(arg) = &parameters.kwarg {
-        if let Some(annotation) = &arg.annotation {
-            check_no_return_argument_annotation(checker, annotation);
-        }
-    }
-}
-
-fn check_no_return_argument_annotation(checker: &mut Checker, annotation: &Expr) {
-    if checker.semantic().match_typing_expr(annotation, "NoReturn") {
-        checker.diagnostics.push(Diagnostic::new(
-            NoReturnArgumentAnnotationInStub {
-                module: if checker.settings.target_version >= Py311 {
-                    TypingModule::Typing
-                } else {
-                    TypingModule::TypingExtensions
+    for annotation in parameters
+        .iter_all_params()
+        .filter_map(AnyParameter::annotation)
+    {
+        if checker.semantic().match_typing_expr(annotation, "NoReturn") {
+            checker.diagnostics.push(Diagnostic::new(
+                NoReturnArgumentAnnotationInStub {
+                    module: if checker.settings.target_version >= Py311 {
+                        TypingModule::Typing
+                    } else {
+                        TypingModule::TypingExtensions
+                    },
                 },
-            },
-            annotation.range(),
-        ));
+                annotation.range(),
+            ));
+        }
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/redundant_numeric_union.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/redundant_numeric_union.rs
@@ -1,6 +1,6 @@
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
-use ruff_python_ast::{AnyParameter, Expr, Parameters};
+use ruff_python_ast::{AnyParameterRef, Expr, Parameters};
 use ruff_python_semantic::analyze::typing::traverse_union;
 use ruff_text_size::Ranged;
 
@@ -61,10 +61,7 @@ impl Violation for RedundantNumericUnion {
 
 /// PYI041
 pub(crate) fn redundant_numeric_union(checker: &mut Checker, parameters: &Parameters) {
-    for annotation in parameters
-        .iter_all_params()
-        .filter_map(AnyParameter::annotation)
-    {
+    for annotation in parameters.iter().filter_map(AnyParameterRef::annotation) {
         check_annotation(checker, annotation);
     }
 }

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/redundant_numeric_union.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/redundant_numeric_union.rs
@@ -1,6 +1,6 @@
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
-use ruff_python_ast::{Expr, Parameters};
+use ruff_python_ast::{AnyParameter, Expr, Parameters};
 use ruff_python_semantic::analyze::typing::traverse_union;
 use ruff_text_size::Ranged;
 
@@ -62,23 +62,8 @@ impl Violation for RedundantNumericUnion {
 /// PYI041
 pub(crate) fn redundant_numeric_union(checker: &mut Checker, parameters: &Parameters) {
     for annotation in parameters
-        .args
-        .iter()
-        .chain(parameters.posonlyargs.iter())
-        .chain(parameters.kwonlyargs.iter())
-        .filter_map(|arg| arg.parameter.annotation.as_ref())
-    {
-        check_annotation(checker, annotation);
-    }
-
-    // If annotations on `args` or `kwargs` are flagged by this rule, the annotations themselves
-    // are not accurate, but check them anyway. It's possible that flagging them will help the user
-    // realize they're incorrect.
-    for annotation in parameters
-        .vararg
-        .iter()
-        .chain(parameters.kwarg.iter())
-        .filter_map(|arg| arg.annotation.as_ref())
+        .iter_all_params()
+        .filter_map(AnyParameter::annotation)
     {
         check_annotation(checker, annotation);
     }

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/simple_defaults.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/simple_defaults.rs
@@ -495,11 +495,7 @@ pub(crate) fn typed_argument_simple_defaults(checker: &mut Checker, parameters: 
         parameter,
         default,
         range: _,
-    } in parameters
-        .posonlyargs
-        .iter()
-        .chain(&parameters.args)
-        .chain(&parameters.kwonlyargs)
+    } in parameters.iter_non_variadic_params()
     {
         let Some(default) = default else {
             continue;
@@ -530,11 +526,7 @@ pub(crate) fn argument_simple_defaults(checker: &mut Checker, parameters: &Param
         parameter,
         default,
         range: _,
-    } in parameters
-        .posonlyargs
-        .iter()
-        .chain(&parameters.args)
-        .chain(&parameters.kwonlyargs)
+    } in parameters.iter_non_variadic_params()
     {
         let Some(default) = default else {
             continue;

--- a/crates/ruff_linter/src/rules/flake8_unused_arguments/rules/unused_arguments.rs
+++ b/crates/ruff_linter/src/rules/flake8_unused_arguments/rules/unused_arguments.rs
@@ -1,5 +1,3 @@
-use std::iter;
-
 use regex::Regex;
 use ruff_python_ast as ast;
 use ruff_python_ast::{Parameter, Parameters};
@@ -224,19 +222,20 @@ fn function(
     diagnostics: &mut Vec<Diagnostic>,
 ) {
     let args = parameters
-        .posonlyargs
-        .iter()
-        .chain(&parameters.args)
-        .chain(&parameters.kwonlyargs)
+        .iter_non_variadic_params()
         .map(|parameter_with_default| &parameter_with_default.parameter)
         .chain(
-            iter::once::<Option<&Parameter>>(parameters.vararg.as_deref())
-                .flatten()
+            parameters
+                .vararg
+                .as_deref()
+                .into_iter()
                 .skip(usize::from(ignore_variadic_names)),
         )
         .chain(
-            iter::once::<Option<&Parameter>>(parameters.kwarg.as_deref())
-                .flatten()
+            parameters
+                .kwarg
+                .as_deref()
+                .into_iter()
                 .skip(usize::from(ignore_variadic_names)),
         );
     call(
@@ -260,20 +259,21 @@ fn method(
     diagnostics: &mut Vec<Diagnostic>,
 ) {
     let args = parameters
-        .posonlyargs
-        .iter()
-        .chain(&parameters.args)
-        .chain(&parameters.kwonlyargs)
+        .iter_non_variadic_params()
         .skip(1)
         .map(|parameter_with_default| &parameter_with_default.parameter)
         .chain(
-            iter::once::<Option<&Parameter>>(parameters.vararg.as_deref())
-                .flatten()
+            parameters
+                .vararg
+                .as_deref()
+                .into_iter()
                 .skip(usize::from(ignore_variadic_names)),
         )
         .chain(
-            iter::once::<Option<&Parameter>>(parameters.kwarg.as_deref())
-                .flatten()
+            parameters
+                .kwarg
+                .as_deref()
+                .into_iter()
                 .skip(usize::from(ignore_variadic_names)),
         );
     call(

--- a/crates/ruff_linter/src/rules/pep8_naming/rules/invalid_first_argument_name.rs
+++ b/crates/ruff_linter/src/rules/pep8_naming/rules/invalid_first_argument_name.rs
@@ -257,15 +257,9 @@ fn rename_parameter(
 ) -> Result<Option<Fix>> {
     // Don't fix if another parameter has the valid name.
     if parameters
-        .posonlyargs
-        .iter()
-        .chain(&parameters.args)
-        .chain(&parameters.kwonlyargs)
+        .iter_all_params()
         .skip(1)
-        .map(|parameter_with_default| &parameter_with_default.parameter)
-        .chain(parameters.vararg.as_deref())
-        .chain(parameters.kwarg.as_deref())
-        .any(|parameter| &parameter.name == function_type.valid_first_argument_name())
+        .any(|parameter| parameter.name() == function_type.valid_first_argument_name())
     {
         return Ok(None);
     }

--- a/crates/ruff_linter/src/rules/pep8_naming/rules/invalid_first_argument_name.rs
+++ b/crates/ruff_linter/src/rules/pep8_naming/rules/invalid_first_argument_name.rs
@@ -257,7 +257,7 @@ fn rename_parameter(
 ) -> Result<Option<Fix>> {
     // Don't fix if another parameter has the valid name.
     if parameters
-        .iter_all_params()
+        .iter()
         .skip(1)
         .any(|parameter| parameter.name() == function_type.valid_first_argument_name())
     {

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/lambda_assignment.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/lambda_assignment.rs
@@ -199,8 +199,8 @@ fn function(
     let parameters = parameters.cloned().unwrap_or_default();
     if let Some(annotation) = annotation {
         if let Some((arg_types, return_type)) = extract_types(annotation, semantic) {
-            // A `lambda` expression can only have positional and positional-only
-            // arguments. The order is always positional-only first, then positional.
+            // A `lambda` expression can only have positional-only and positional-or-keyword
+            // arguments. The order is always positional-only first, then positional-or-keyword.
             let new_posonlyargs = parameters
                 .posonlyargs
                 .iter()

--- a/crates/ruff_linter/src/rules/pydocstyle/rules/sections.rs
+++ b/crates/ruff_linter/src/rules/pydocstyle/rules/sections.rs
@@ -1755,23 +1755,19 @@ fn missing_args(checker: &mut Checker, docstring: &Docstring, docstrings_args: &
 
     // Look for arguments that weren't included in the docstring.
     let mut missing_arg_names: FxHashSet<String> = FxHashSet::default();
+
+    // If this is a non-static method, skip `cls` or `self`.
     for ParameterWithDefault {
         parameter,
         default: _,
         range: _,
     } in function
         .parameters
-        .posonlyargs
-        .iter()
-        .chain(&function.parameters.args)
-        .chain(&function.parameters.kwonlyargs)
-        .skip(
-            // If this is a non-static method, skip `cls` or `self`.
-            usize::from(
-                docstring.definition.is_method()
-                    && !is_staticmethod(&function.decorator_list, checker.semantic()),
-            ),
-        )
+        .iter_non_variadic_params()
+        .skip(usize::from(
+            docstring.definition.is_method()
+                && !is_staticmethod(&function.decorator_list, checker.semantic()),
+        ))
     {
         let arg_name = parameter.name.as_str();
         if !arg_name.starts_with('_') && !docstrings_args.contains(arg_name) {

--- a/crates/ruff_linter/src/rules/pylint/rules/property_with_parameters.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/property_with_parameters.rs
@@ -49,12 +49,7 @@ pub(crate) fn property_with_parameters(
     checker: &mut Checker,
     stmt: &Stmt,
     decorator_list: &[Decorator],
-    Parameters {
-        posonlyargs,
-        args,
-        kwonlyargs,
-        ..
-    }: &Parameters,
+    parameters: &Parameters,
 ) {
     let semantic = checker.semantic();
     if !decorator_list
@@ -63,7 +58,14 @@ pub(crate) fn property_with_parameters(
     {
         return;
     }
-    if (posonlyargs.len() + args.len() + kwonlyargs.len()) > 1 {
+    if parameters
+        .posonlyargs
+        .iter()
+        .chain(&parameters.args)
+        .chain(&parameters.kwonlyargs)
+        .count()
+        > 1
+    {
         checker
             .diagnostics
             .push(Diagnostic::new(PropertyWithParameters, stmt.identifier()));

--- a/crates/ruff_linter/src/rules/pylint/rules/property_with_parameters.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/property_with_parameters.rs
@@ -49,7 +49,12 @@ pub(crate) fn property_with_parameters(
     checker: &mut Checker,
     stmt: &Stmt,
     decorator_list: &[Decorator],
-    parameters: &Parameters,
+    Parameters {
+        posonlyargs,
+        args,
+        kwonlyargs,
+        ..
+    }: &Parameters,
 ) {
     let semantic = checker.semantic();
     if !decorator_list
@@ -58,14 +63,7 @@ pub(crate) fn property_with_parameters(
     {
         return;
     }
-    if parameters
-        .posonlyargs
-        .iter()
-        .chain(&parameters.args)
-        .chain(&parameters.kwonlyargs)
-        .count()
-        > 1
-    {
+    if (posonlyargs.len() + args.len() + kwonlyargs.len()) > 1 {
         checker
             .diagnostics
             .push(Diagnostic::new(PropertyWithParameters, stmt.identifier()));

--- a/crates/ruff_linter/src/rules/pylint/rules/too_many_arguments.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/too_many_arguments.rs
@@ -61,10 +61,7 @@ impl Violation for TooManyArguments {
 pub(crate) fn too_many_arguments(checker: &mut Checker, function_def: &ast::StmtFunctionDef) {
     let num_arguments = function_def
         .parameters
-        .args
-        .iter()
-        .chain(&function_def.parameters.kwonlyargs)
-        .chain(&function_def.parameters.posonlyargs)
+        .iter_non_variadic_params()
         .filter(|arg| {
             !checker
                 .settings

--- a/crates/ruff_linter/src/rules/pylint/rules/too_many_positional.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/too_many_positional.rs
@@ -62,14 +62,14 @@ pub(crate) fn too_many_positional(checker: &mut Checker, function_def: &ast::Stm
     // Count the number of positional arguments.
     let num_positional_args = function_def
         .parameters
-        .args
+        .posonlyargs
         .iter()
-        .chain(&function_def.parameters.posonlyargs)
-        .filter(|arg| {
+        .chain(&function_def.parameters.args)
+        .filter(|param| {
             !checker
                 .settings
                 .dummy_variable_rgx
-                .is_match(&arg.parameter.name)
+                .is_match(&param.parameter.name)
         })
         .count();
 

--- a/crates/ruff_linter/src/rules/ruff/rules/implicit_optional.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/implicit_optional.rs
@@ -167,11 +167,7 @@ pub(crate) fn implicit_optional(checker: &mut Checker, parameters: &Parameters) 
         parameter,
         default,
         range: _,
-    } in parameters
-        .posonlyargs
-        .iter()
-        .chain(&parameters.args)
-        .chain(&parameters.kwonlyargs)
+    } in parameters.iter_non_variadic_params()
     {
         let Some(default) = default else { continue };
         if !default.is_none_literal_expr() {

--- a/crates/ruff_python_ast/src/helpers.rs
+++ b/crates/ruff_python_ast/src/helpers.rs
@@ -348,39 +348,18 @@ pub fn any_over_stmt(stmt: &Stmt, func: &dyn Fn(&Expr) -> bool) -> bool {
             returns,
             ..
         }) => {
-            parameters
-                .posonlyargs
-                .iter()
-                .chain(parameters.args.iter().chain(parameters.kwonlyargs.iter()))
-                .any(|parameter| {
-                    parameter
-                        .default
-                        .as_ref()
-                        .is_some_and(|expr| any_over_expr(expr, func))
-                        || parameter
-                            .parameter
-                            .annotation
-                            .as_ref()
-                            .is_some_and(|expr| any_over_expr(expr, func))
-                })
-                || parameters.vararg.as_ref().is_some_and(|parameter| {
-                    parameter
-                        .annotation
-                        .as_ref()
-                        .is_some_and(|expr| any_over_expr(expr, func))
-                })
-                || parameters.kwarg.as_ref().is_some_and(|parameter| {
-                    parameter
-                        .annotation
-                        .as_ref()
-                        .is_some_and(|expr| any_over_expr(expr, func))
-                })
-                || type_params.as_ref().is_some_and(|type_params| {
-                    type_params
-                        .iter()
-                        .any(|type_param| any_over_type_param(type_param, func))
-                })
-                || body.iter().any(|stmt| any_over_stmt(stmt, func))
+            parameters.iter_all_params().any(|param| {
+                param
+                    .default()
+                    .is_some_and(|default| any_over_expr(default, func))
+                    || param
+                        .annotation()
+                        .is_some_and(|annotation| any_over_expr(annotation, func))
+            }) || type_params.as_ref().is_some_and(|type_params| {
+                type_params
+                    .iter()
+                    .any(|type_param| any_over_type_param(type_param, func))
+            }) || body.iter().any(|stmt| any_over_stmt(stmt, func))
                 || decorator_list
                     .iter()
                     .any(|decorator| any_over_expr(&decorator.expression, func))

--- a/crates/ruff_python_ast/src/helpers.rs
+++ b/crates/ruff_python_ast/src/helpers.rs
@@ -348,7 +348,7 @@ pub fn any_over_stmt(stmt: &Stmt, func: &dyn Fn(&Expr) -> bool) -> bool {
             returns,
             ..
         }) => {
-            parameters.iter_all_params().any(|param| {
+            parameters.iter().any(|param| {
                 param
                     .default()
                     .is_some_and(|default| any_over_expr(default, func))

--- a/crates/ruff_python_ast/src/node.rs
+++ b/crates/ruff_python_ast/src/node.rs
@@ -4222,7 +4222,7 @@ impl AstNode for Parameters {
     where
         V: PreorderVisitor<'a> + ?Sized,
     {
-        for parameter in self.iter() {
+        for parameter in self {
             match parameter {
                 AnyParameterRef::NonVariadic(parameter_with_default) => {
                     visitor.visit_parameter_with_default(parameter_with_default);

--- a/crates/ruff_python_ast/src/nodes.rs
+++ b/crates/ruff_python_ast/src/nodes.rs
@@ -3177,7 +3177,7 @@ pub struct Decorator {
 
 /// Enumeration of the two kinds of parameter
 #[derive(Debug, PartialEq, Clone, Copy)]
-pub enum AnyParameter<'a> {
+pub enum AnyParameterRef<'a> {
     /// Variadic parameters cannot have default values,
     /// e.g. both `*args` and `**kwargs` in the following function:
     ///
@@ -3195,7 +3195,7 @@ pub enum AnyParameter<'a> {
     NonVariadic(&'a ParameterWithDefault),
 }
 
-impl<'a> AnyParameter<'a> {
+impl<'a> AnyParameterRef<'a> {
     pub const fn as_parameter(self) -> &'a Parameter {
         match self {
             Self::NonVariadic(param) => &param.parameter,
@@ -3223,7 +3223,7 @@ impl<'a> AnyParameter<'a> {
     }
 }
 
-impl Ranged for AnyParameter<'_> {
+impl Ranged for AnyParameterRef<'_> {
     fn range(&self) -> TextRange {
         match self {
             Self::NonVariadic(param) => param.range,
@@ -3271,19 +3271,19 @@ impl Parameters {
     }
 
     /// Returns an iterator over all parameters included in this [`Parameters`] node.
-    pub fn iter_all_params(&self) -> impl Iterator<Item = AnyParameter> {
+    pub fn iter(&self) -> impl Iterator<Item = AnyParameterRef> {
         self.posonlyargs
             .iter()
             .chain(&self.args)
-            .map(AnyParameter::NonVariadic)
-            .chain(self.vararg.as_deref().map(AnyParameter::Variadic))
-            .chain(self.kwonlyargs.iter().map(AnyParameter::NonVariadic))
-            .chain(self.kwarg.as_deref().map(AnyParameter::Variadic))
+            .map(AnyParameterRef::NonVariadic)
+            .chain(self.vararg.as_deref().map(AnyParameterRef::Variadic))
+            .chain(self.kwonlyargs.iter().map(AnyParameterRef::NonVariadic))
+            .chain(self.kwarg.as_deref().map(AnyParameterRef::Variadic))
     }
 
     /// Returns `true` if a parameter with the given name is included in this [`Parameters`].
     pub fn includes(&self, name: &str) -> bool {
-        self.iter_all_params().any(|param| param.name() == name)
+        self.iter().any(|param| param.name() == name)
     }
 
     /// Returns `true` if the [`Parameters`] is empty.

--- a/crates/ruff_python_ast/src/nodes.rs
+++ b/crates/ruff_python_ast/src/nodes.rs
@@ -3281,6 +3281,15 @@ impl Parameters {
             .chain(self.kwarg.as_deref().map(AnyParameterRef::Variadic))
     }
 
+    /// Returns the total number of parameters included in this [`Parameters`] node.
+    pub fn len(&self) -> usize {
+        self.posonlyargs.len()
+            + self.args.len()
+            + usize::from(self.vararg.is_some())
+            + self.kwonlyargs.len()
+            + usize::from(self.kwarg.is_some())
+    }
+
     /// Returns `true` if a parameter with the given name is included in this [`Parameters`].
     pub fn includes(&self, name: &str) -> bool {
         self.iter().any(|param| param.name() == name)

--- a/crates/ruff_python_ast/src/visitor.rs
+++ b/crates/ruff_python_ast/src/visitor.rs
@@ -4,7 +4,7 @@ pub mod preorder;
 pub mod transformer;
 
 use crate::{
-    self as ast, Alias, AnyParameter, Arguments, BoolOp, BytesLiteral, CmpOp, Comprehension,
+    self as ast, Alias, AnyParameterRef, Arguments, BoolOp, BytesLiteral, CmpOp, Comprehension,
     Decorator, ElifElseClause, ExceptHandler, Expr, ExprContext, FString, FStringElement,
     FStringPart, Keyword, MatchCase, Operator, Parameter, Parameters, Pattern, PatternArguments,
     PatternKeyword, Stmt, StringLiteral, TypeParam, TypeParamParamSpec, TypeParamTypeVar,
@@ -614,7 +614,7 @@ pub fn walk_parameters<'a, V: Visitor<'a> + ?Sized>(visitor: &mut V, parameters:
         visitor.visit_expr(default);
     }
 
-    for parameter in parameters.iter_all_params().map(AnyParameter::as_parameter) {
+    for parameter in parameters.iter().map(AnyParameterRef::as_parameter) {
         visitor.visit_parameter(parameter);
     }
 }

--- a/crates/ruff_python_formatter/src/other/parameters.rs
+++ b/crates/ruff_python_formatter/src/other/parameters.rs
@@ -240,11 +240,7 @@ impl FormatNodeRule<Parameters> for FormatParameters {
             Ok(())
         });
 
-        let num_parameters = posonlyargs.len()
-            + args.len()
-            + usize::from(vararg.is_some())
-            + kwonlyargs.len()
-            + usize::from(kwarg.is_some());
+        let num_parameters = item.len();
 
         if self.parentheses == ParametersParentheses::Never {
             write!(f, [group(&format_inner), dangling_comments(dangling)])

--- a/crates/ruff_python_parser/src/parser/statement.rs
+++ b/crates/ruff_python_parser/src/parser/statement.rs
@@ -3371,14 +3371,8 @@ impl<'src> Parser<'src> {
     ///
     /// Report errors for all the duplicate names found.
     fn validate_parameters(&mut self, parameters: &ast::Parameters) {
-        let mut all_arg_names = FxHashSet::with_capacity_and_hasher(
-            parameters.posonlyargs.len()
-                + parameters.args.len()
-                + usize::from(parameters.vararg.is_some())
-                + parameters.kwonlyargs.len()
-                + usize::from(parameters.kwarg.is_some()),
-            BuildHasherDefault::default(),
-        );
+        let mut all_arg_names =
+            FxHashSet::with_capacity_and_hasher(parameters.len(), BuildHasherDefault::default());
 
         for parameter in parameters.iter() {
             let range = parameter.name().range();

--- a/crates/ruff_python_parser/src/parser/statement.rs
+++ b/crates/ruff_python_parser/src/parser/statement.rs
@@ -3380,7 +3380,7 @@ impl<'src> Parser<'src> {
             BuildHasherDefault::default(),
         );
 
-        for parameter in parameters.iter_all_params() {
+        for parameter in parameters.iter() {
             let range = parameter.name().range();
             let param_name = parameter.name().as_str();
             if !all_arg_names.insert(param_name) {

--- a/crates/ruff_python_parser/src/parser/statement.rs
+++ b/crates/ruff_python_parser/src/parser/statement.rs
@@ -3374,7 +3374,7 @@ impl<'src> Parser<'src> {
         let mut all_arg_names =
             FxHashSet::with_capacity_and_hasher(parameters.len(), BuildHasherDefault::default());
 
-        for parameter in parameters.iter() {
+        for parameter in parameters {
             let range = parameter.name().range();
             let param_name = parameter.name().as_str();
             if !all_arg_names.insert(param_name) {

--- a/crates/ruff_python_parser/src/parser/statement.rs
+++ b/crates/ruff_python_parser/src/parser/statement.rs
@@ -3380,25 +3380,12 @@ impl<'src> Parser<'src> {
             BuildHasherDefault::default(),
         );
 
-        let posonlyargs = parameters.posonlyargs.iter();
-        let args = parameters.args.iter();
-        let kwonlyargs = parameters.kwonlyargs.iter();
-
-        let vararg = parameters.vararg.as_deref();
-        let kwarg = parameters.kwarg.as_deref();
-
-        for arg in posonlyargs
-            .chain(args)
-            .chain(kwonlyargs)
-            .map(|arg| &arg.parameter)
-            .chain(vararg)
-            .chain(kwarg)
-        {
-            let range = arg.name.range;
-            let arg_name = arg.name.as_str();
-            if !all_arg_names.insert(arg_name) {
+        for parameter in parameters.iter_all_params() {
+            let range = parameter.name().range();
+            let param_name = parameter.name().as_str();
+            if !all_arg_names.insert(param_name) {
                 self.add_error(
-                    ParseErrorType::DuplicateParameter(arg_name.to_string()),
+                    ParseErrorType::DuplicateParameter(param_name.to_string()),
                     range,
                 );
             }

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@params_duplicate_names.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@params_duplicate_names.py.snap
@@ -141,6 +141,12 @@ Module(
 
   |
 1 | def foo(a, a=10, *a, a, a: str, **a): ...
+  |                   ^ Syntax Error: Duplicate parameter "a"
+  |
+
+
+  |
+1 | def foo(a, a=10, *a, a, a: str, **a): ...
   |                      ^ Syntax Error: Duplicate parameter "a"
   |
 
@@ -148,12 +154,6 @@ Module(
   |
 1 | def foo(a, a=10, *a, a, a: str, **a): ...
   |                         ^ Syntax Error: Duplicate parameter "a"
-  |
-
-
-  |
-1 | def foo(a, a=10, *a, a, a: str, **a): ...
-  |                   ^ Syntax Error: Duplicate parameter "a"
   |
 
 

--- a/crates/ruff_python_semantic/src/analyze/typing.rs
+++ b/crates/ruff_python_semantic/src/analyze/typing.rs
@@ -736,10 +736,7 @@ fn find_parameter<'a>(
     binding: &Binding,
 ) -> Option<&'a ParameterWithDefault> {
     parameters
-        .args
-        .iter()
-        .chain(parameters.posonlyargs.iter())
-        .chain(parameters.kwonlyargs.iter())
+        .iter_non_variadic_params()
         .find(|arg| arg.parameter.name.range() == binding.range())
 }
 


### PR DESCRIPTION
## Summary

A pretty common pattern in our linter rules is the need to iterate over all parameters in a function. That ends up looking pretty verbose currently -- something like this:

```rs
for parameter in parameters
    .posonlyargs
    .iter()
    .chain(&parameters.args)
    .map(|param| param.parameter)
    .chain(parameters.vararg.as_deref())
    .chain(parameters.kwonlyargs.iter().map(|param| param.parameter))
    .chain(parameters.kwarg.as_deref())
{
    do_the_check()
}
```

It's also pretty easy to get this pattern subtly incorrect: for example, several of our rules currently incorrectly do `parameters.args.iter().chain(&parameters.posonlyargs)`, but positional-only parameters always precede positional-or-keyword parameters in Python.

This PR adds two convenience methods to the `ast::Parameters` struct in `ruff_python_ast/src/nodes.rs`, to make iterating over all parameters more ergonomic. `iter_non_variadic_params()` iterates over just the non-variadic parameters (`posonlyargs`, `args` and `kwonlyargs`), and `iter_all_params()` iterates over all parameters in a function, including any variadic paramerers (`vararg` and `kwarg`). Using these convenience methods in our linter rules significantly reduces duplication.

## Test Plan

`cargo test`. One parser snapshot changes slightly, but I think it's for the better: the syntax errors are now reported in the order that they appear in the source code. Previously, they were reported out of order.
