### PR TITLE
[red-knot] record dependencies when resolving across imports

### DIFF
--- a/crates/red_knot/src/db.rs
+++ b/crates/red_knot/src/db.rs
@@ -155,12 +155,12 @@ pub(crate) mod tests {
             file_to_module(self, file_id)
         }
 
-        fn infer_symbol_type(&self, file_id: FileId, symbol_id: SymbolId) -> Type {
-            infer_symbol_type(self, file_id, symbol_id)
-        }
-
         fn path_to_module(&self, path: &Path) -> Option<Module> {
             path_to_module(self, path)
+        }
+
+        fn infer_symbol_type(&self, file_id: FileId, symbol_id: SymbolId) -> Type {
+            infer_symbol_type(self, file_id, symbol_id)
         }
 
         fn symbol_table(&self, file_id: FileId) -> Arc<SymbolTable> {

--- a/crates/red_knot/src/db.rs
+++ b/crates/red_knot/src/db.rs
@@ -32,13 +32,13 @@ pub trait SemanticDb: SourceDb {
 
     fn symbol_table(&self, file_id: FileId) -> Arc<SymbolTable>;
 
+    fn infer_symbol_type(&self, file_id: FileId, symbol_id: SymbolId) -> Type;
+
     // mutations
 
     fn add_module(&mut self, path: &Path) -> Option<(Module, Vec<Arc<ModuleData>>)>;
 
     fn set_module_search_paths(&mut self, paths: Vec<ModuleSearchPath>);
-
-    fn infer_symbol_type(&mut self, file_id: FileId, symbol_id: SymbolId) -> Type;
 }
 
 pub trait Db: SemanticDb {}
@@ -155,6 +155,10 @@ pub(crate) mod tests {
             file_to_module(self, file_id)
         }
 
+        fn infer_symbol_type(&self, file_id: FileId, symbol_id: SymbolId) -> Type {
+            infer_symbol_type(self, file_id, symbol_id)
+        }
+
         fn path_to_module(&self, path: &Path) -> Option<Module> {
             path_to_module(self, path)
         }
@@ -169,10 +173,6 @@ pub(crate) mod tests {
 
         fn set_module_search_paths(&mut self, paths: Vec<ModuleSearchPath>) {
             set_module_search_paths(self, paths);
-        }
-
-        fn infer_symbol_type(&mut self, file_id: FileId, symbol_id: SymbolId) -> Type {
-            infer_symbol_type(self, file_id, symbol_id)
         }
     }
 }

--- a/crates/red_knot/src/program/mod.rs
+++ b/crates/red_knot/src/program/mod.rs
@@ -111,6 +111,10 @@ impl SemanticDb for Program {
         symbol_table(self, file_id)
     }
 
+    fn infer_symbol_type(&self, file_id: FileId, symbol_id: SymbolId) -> Type {
+        infer_symbol_type(self, file_id, symbol_id)
+    }
+
     // Mutations
 
     fn add_module(&mut self, path: &Path) -> Option<(Module, Vec<Arc<ModuleData>>)> {
@@ -119,10 +123,6 @@ impl SemanticDb for Program {
 
     fn set_module_search_paths(&mut self, paths: Vec<ModuleSearchPath>) {
         set_module_search_paths(self, paths);
-    }
-
-    fn infer_symbol_type(&mut self, file_id: FileId, symbol_id: SymbolId) -> Type {
-        infer_symbol_type(self, file_id, symbol_id)
     }
 }
 

--- a/crates/red_knot/src/types/infer.rs
+++ b/crates/red_knot/src/types/infer.rs
@@ -6,8 +6,6 @@ use crate::types::Type;
 use crate::FileId;
 use ruff_python_ast::AstNode;
 
-// TODO this should not take a &mut db, it should be a query, not a mutation. This means we'll need
-// to use interior mutability in TypeStore instead, and avoid races in populating the cache.
 #[tracing::instrument(level = "trace", skip(db))]
 pub fn infer_symbol_type<Db>(db: &Db, file_id: FileId, symbol_id: SymbolId) -> Type
 where


### PR DESCRIPTION
## Summary

Record dependencies when resolving type of a symbol that depends on type of another symbol.

If a symbol in another module can't be resolved, then we record a dependency on the entire module (if it changes, maybe then the type can be resolved, so we would need to invalidate.)

Also corrects unnecessary mutable references to db/jar/type_store. (I know this was done in another outstanding PR too, but it was bugging me so I did it here too; I don't mind rebasing if the other one lands first.)

## Test Plan

cargo test
