### PR TITLE
Fix `cargo build --release`

### DIFF
--- a/crates/red_knot/src/cache.rs
+++ b/crates/red_knot/src/cache.rs
@@ -146,7 +146,13 @@ pub struct ReleaseStatistics;
 
 impl ReleaseStatistics {
     #[inline]
-    pub fn to_statistics(&self) -> Option<Statistics> {
+    pub const fn hit(&self) {}
+
+    #[inline]
+    pub const fn miss(&self) {}
+
+    #[inline]
+    pub const fn to_statistics(&self) -> Option<Statistics> {
         None
     }
 }


### PR DESCRIPTION
## Summary

`cargo build --release` currently fails to compile on `main`:

<details>

```
error[E0599]: no method named `hit` found for struct `ReleaseStatistics` in the current scope
   --> crates/red_knot/src/cache.rs:22:29
    |
22  |             self.statistics.hit();
    |                             ^^^ method not found in `ReleaseStatistics`
...
145 | pub struct ReleaseStatistics;
    | ---------------------------- method `hit` not found for this struct

error[E0599]: no method named `miss` found for struct `ReleaseStatistics` in the current scope
   --> crates/red_knot/src/cache.rs:25:29
    |
25  |             self.statistics.miss();
    |                             ^^^^ method not found in `ReleaseStatistics`
...
145 | pub struct ReleaseStatistics;
    | ---------------------------- method `miss` not found for this struct

error[E0599]: no method named `hit` found for struct `ReleaseStatistics` in the current scope
   --> crates/red_knot/src/cache.rs:36:33
    |
36  |                 self.statistics.hit();
    |                                 ^^^ method not found in `ReleaseStatistics`
...
145 | pub struct ReleaseStatistics;
    | ---------------------------- method `hit` not found for this struct

error[E0599]: no method named `miss` found for struct `ReleaseStatistics` in the current scope
   --> crates/red_knot/src/cache.rs:41:33
    |
41  |                 self.statistics.miss();
    |                                 ^^^^ method not found in `ReleaseStatistics`
...
145 | pub struct ReleaseStatistics;
    | ---------------------------- method `miss` not found for this struct
```

</details>

This is because in a release build, `CacheStatistics` is a type alias for `ReleaseStatistics`, and `ReleaseStatistics` doesn't have `hit()` or `miss()` methods. (In a debug build, `CacheStatistics` is a type alias for `DebugStatistics`, which _does_ have those methods.)

Possibly we could make this less likely to happen in the future by making both structs implement a common trait instead of using type aliases that vary depending on whether it's a debug build or not? For now, though, this PR just brings the two structs in sync w.r.t. the methods they expose.

## Test Plan

`cargo build --release` now once again compiles for me locally
