### PR TITLE
[`pylint`] Also emit `PLR0206` for properties with variadic parameters

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pylint/property_with_parameters.py
+++ b/crates/ruff_linter/resources/test/fixtures/pylint/property_with_parameters.py
@@ -28,3 +28,13 @@ class MyClassBase(metaclass=ABCMeta):
     @abstractmethod
     def example(self, value):
         """Setter."""
+
+
+class VariadicParameters:
+    @property
+    def attribute_var_args(self, *args):  # [property-with-parameters]
+        return sum(args)
+
+    @property
+    def attribute_var_kwargs(self, **kwargs):  #[property-with-parameters]
+        return {key: value * 2 for key, value in kwargs.items()}

--- a/crates/ruff_linter/src/rules/pylint/rules/property_with_parameters.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/property_with_parameters.rs
@@ -51,20 +51,13 @@ pub(crate) fn property_with_parameters(
     decorator_list: &[Decorator],
     parameters: &Parameters,
 ) {
-    let semantic = checker.semantic();
-    if !decorator_list
-        .iter()
-        .any(|decorator| semantic.match_builtin_expr(&decorator.expression, "property"))
-    {
+    if parameters.len() <= 1 {
         return;
     }
-    if parameters
-        .posonlyargs
+    let semantic = checker.semantic();
+    if decorator_list
         .iter()
-        .chain(&parameters.args)
-        .chain(&parameters.kwonlyargs)
-        .count()
-        > 1
+        .any(|decorator| semantic.match_builtin_expr(&decorator.expression, "property"))
     {
         checker
             .diagnostics

--- a/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLR0206_property_with_parameters.py.snap
+++ b/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLR0206_property_with_parameters.py.snap
@@ -26,4 +26,19 @@ property_with_parameters.py:15:9: PLR0206 Cannot have defined parameters for pro
 16 |         return param + param1
    |
 
+property_with_parameters.py:35:9: PLR0206 Cannot have defined parameters for properties
+   |
+33 | class VariadicParameters:
+34 |     @property
+35 |     def attribute_var_args(self, *args):  # [property-with-parameters]
+   |         ^^^^^^^^^^^^^^^^^^ PLR0206
+36 |         return sum(args)
+   |
 
+property_with_parameters.py:39:9: PLR0206 Cannot have defined parameters for properties
+   |
+38 |     @property
+39 |     def attribute_var_kwargs(self, **kwargs):  #[property-with-parameters]
+   |         ^^^^^^^^^^^^^^^^^^^^ PLR0206
+40 |         return {key: value * 2 for key, value in kwargs.items()}
+   |


### PR DESCRIPTION
## Summary

Currently this rule checks the number of nonvariadic parameters a property has, but doesn't check how many variadic parameters the property has. That makes little sense to me: if a property has variadic non-self parameters, that seems just as invalid as if a property has nonvariadic non-self parameters.

This PR changes the rule so that it checks the total number of parameters the property has, rather than just the number of nonvariadic parameters. Following the new APIs added in https://github.com/astral-sh/ruff/commit/87929ad5f1306cb889cbc85ddfdb9404d9b5c6ad, this has the nice side effect of also simplifying the code slightly.

This means that we diverge from pylint's behaviour a little more in how we implement this rule, but we were already doing something slightly different. It looks like pylint for some reason only checks the number of positional-or-keyword nonvariadic parameters in a property function, and ignores the number of positional-only or keyword-only nonvariadic parameters: <https://github.com/pylint-dev/pylint/blob/524f2561eda21b5593ab1c69963442031817883d/pylint/checkers/classes/class_checker.py#L1414>. I don't understand why they would do that; I think that's buggy behaviour from pylint there.

## Test Plan

`cargo test`. I added some new fixtures.
