### PR TITLE
linter: Enable test-rules for test build

### DIFF
--- a/crates/ruff_linter/src/codes.rs
+++ b/crates/ruff_linter/src/codes.rs
@@ -971,32 +971,32 @@ pub fn code_to_rule(linter: Linter, code: &str) -> Option<(RuleGroup, Rule)> {
         (Ruff, "100") => (RuleGroup::Stable, rules::ruff::rules::UnusedNOQA),
         (Ruff, "101") => (RuleGroup::Preview, rules::ruff::rules::RedirectedNOQA),
         (Ruff, "200") => (RuleGroup::Stable, rules::ruff::rules::InvalidPyprojectToml),
-        #[cfg(feature = "test-rules")]
+        #[cfg(any(feature = "test-rules", test))]
         (Ruff, "900") => (RuleGroup::Stable, rules::ruff::rules::StableTestRule),
-        #[cfg(feature = "test-rules")]
+        #[cfg(any(feature = "test-rules", test))]
         (Ruff, "901") => (RuleGroup::Stable, rules::ruff::rules::StableTestRuleSafeFix),
-        #[cfg(feature = "test-rules")]
+        #[cfg(any(feature = "test-rules", test))]
         (Ruff, "902") => (RuleGroup::Stable, rules::ruff::rules::StableTestRuleUnsafeFix),
-        #[cfg(feature = "test-rules")]
+        #[cfg(any(feature = "test-rules", test))]
         (Ruff, "903") => (RuleGroup::Stable, rules::ruff::rules::StableTestRuleDisplayOnlyFix),
-        #[cfg(feature = "test-rules")]
+        #[cfg(any(feature = "test-rules", test))]
         (Ruff, "911") => (RuleGroup::Preview, rules::ruff::rules::PreviewTestRule),
-        #[cfg(feature = "test-rules")]
+        #[cfg(any(feature = "test-rules", test))]
         #[allow(deprecated)]
         (Ruff, "912") => (RuleGroup::Nursery, rules::ruff::rules::NurseryTestRule),
-        #[cfg(feature = "test-rules")]
+        #[cfg(any(feature = "test-rules", test))]
         (Ruff, "920") => (RuleGroup::Deprecated, rules::ruff::rules::DeprecatedTestRule),
-        #[cfg(feature = "test-rules")]
+        #[cfg(any(feature = "test-rules", test))]
         (Ruff, "921") => (RuleGroup::Deprecated, rules::ruff::rules::AnotherDeprecatedTestRule),
-        #[cfg(feature = "test-rules")]
+        #[cfg(any(feature = "test-rules", test))]
         (Ruff, "930") => (RuleGroup::Removed, rules::ruff::rules::RemovedTestRule),
-        #[cfg(feature = "test-rules")]
+        #[cfg(any(feature = "test-rules", test))]
         (Ruff, "931") => (RuleGroup::Removed, rules::ruff::rules::AnotherRemovedTestRule),
-        #[cfg(feature = "test-rules")]
+        #[cfg(any(feature = "test-rules", test))]
         (Ruff, "940") => (RuleGroup::Removed, rules::ruff::rules::RedirectedFromTestRule),
-        #[cfg(feature = "test-rules")]
+        #[cfg(any(feature = "test-rules", test))]
         (Ruff, "950") => (RuleGroup::Stable, rules::ruff::rules::RedirectedToTestRule),
-        #[cfg(feature = "test-rules")]
+        #[cfg(any(feature = "test-rules", test))]
         (Ruff, "960") => (RuleGroup::Removed, rules::ruff::rules::RedirectedFromPrefixTestRule),
 
 

--- a/crates/ruff_linter/src/linter.rs
+++ b/crates/ruff_linter/src/linter.rs
@@ -33,7 +33,7 @@ use crate::message::Message;
 use crate::noqa::add_noqa;
 use crate::registry::{AsRule, Rule, RuleSet};
 use crate::rules::pycodestyle;
-#[cfg(feature = "test-rules")]
+#[cfg(any(feature = "test-rules", test))]
 use crate::rules::ruff::rules::test_rules::{self, TestRule, TEST_RULES};
 use crate::settings::types::UnsafeFixes;
 use crate::settings::{flags, LinterSettings};
@@ -218,7 +218,7 @@ pub fn check_path(
     }
 
     // Raise violations for internal test rules
-    #[cfg(feature = "test-rules")]
+    #[cfg(any(feature = "test-rules", test))]
     {
         for test_rule in TEST_RULES {
             if !settings.rules.enabled(*test_rule) {

--- a/crates/ruff_linter/src/rule_redirects.rs
+++ b/crates/ruff_linter/src/rule_redirects.rs
@@ -104,10 +104,10 @@ static REDIRECTS: Lazy<HashMap<&'static str, &'static str>> = Lazy::new(|| {
         ("PGH001", "S307"),
         ("PGH002", "G010"),
         // Test redirect by exact code
-        #[cfg(feature = "test-rules")]
+        #[cfg(any(feature = "test-rules", test))]
         ("RUF940", "RUF950"),
         // Test redirect by prefix
-        #[cfg(feature = "test-rules")]
+        #[cfg(any(feature = "test-rules", test))]
         ("RUF96", "RUF95"),
         // See: https://github.com/astral-sh/ruff/issues/10791
         ("PLW0117", "PLW0177"),

--- a/crates/ruff_linter/src/rule_selector.rs
+++ b/crates/ruff_linter/src/rule_selector.rs
@@ -323,7 +323,7 @@ mod schema {
                     })
                     .filter(|_rule| {
                         // Filter out all test-only rules
-                        #[cfg(feature = "test-rules")]
+                        #[cfg(any(feature = "test-rules", test))]
                         #[allow(clippy::used_underscore_binding)]
                         if _rule.starts_with("RUF9") {
                             return false;

--- a/crates/ruff_linter/src/rules/ruff/rules/mod.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/mod.rs
@@ -21,7 +21,7 @@ pub(crate) use redirected_noqa::*;
 pub(crate) use sort_dunder_all::*;
 pub(crate) use sort_dunder_slots::*;
 pub(crate) use static_key_dict_comprehension::*;
-#[cfg(feature = "test-rules")]
+#[cfg(any(feature = "test-rules", test))]
 pub(crate) use test_rules::*;
 pub(crate) use unnecessary_dict_comprehension_for_iterable::*;
 pub(crate) use unnecessary_iterable_allocation_for_first_element::*;
@@ -56,7 +56,7 @@ mod sort_dunder_all;
 mod sort_dunder_slots;
 mod static_key_dict_comprehension;
 mod suppression_comment_visitor;
-#[cfg(feature = "test-rules")]
+#[cfg(any(feature = "test-rules", test))]
 pub(crate) mod test_rules;
 mod unnecessary_dict_comprehension_for_iterable;
 mod unnecessary_iterable_allocation_for_first_element;


### PR DESCRIPTION
## Summary

`ruff_linter__rules__ruff__tests__RUF101_RUF101` started failing because it relies on the `test-rules` feature to be enabled in `ruff_linter`. 

This PR enables the `test-rules` when building for tests or when the feature is enabled. 

## Test Plan

`cargo test -p ruff_linter` passes
