### PR TITLE
Add a daily workflow to fuzz the parser with randomly selected seeds

### DIFF
--- a/.github/workflows/daily_fuzz.yaml
+++ b/.github/workflows/daily_fuzz.yaml
@@ -1,0 +1,72 @@
+name: Daily parser fuzz
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *"
+  pull_request:
+    paths:
+      - ".github/workflows/daily_fuzz.yaml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+env:
+  CARGO_INCREMENTAL: 0
+  CARGO_NET_RETRY: 10
+  CARGO_TERM_COLOR: always
+  RUSTUP_MAX_RETRIES: 10
+  PACKAGE_NAME: ruff
+  FORCE_COLOR: 1
+
+jobs:
+  fuzz:
+    name: Fuzz
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    # Don't run the cron job on forks:
+    if: ${{ github.repository == 'astral-sh/ruff' || github.event_name != 'schedule' }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install uv
+        run: curl -LsSf https://astral.sh/uv/install.sh | sh
+      - name: Install Python requirements
+        run: uv pip install -r scripts/fuzz-parser/requirements.txt --system
+      - name: "Install Rust toolchain"
+        run: rustup show
+      - name: "Install mold"
+        uses: rui314/setup-mold@v1
+      - uses: Swatinem/rust-cache@v2
+      - name: Build ruff
+        # A debug build means the script runs slower once it gets started,
+        # but this is outweighed by the fact that a release build takes *much* longer to compile in CI
+        run: cargo build --locked
+      - name: Fuzz
+        run: python scripts/fuzz-parser/fuzz.py $(shuf -i 0-1000000 -n 1000) --test-executable target/debug/ruff
+
+  create-issue-on-failure:
+    name: Create an issue if the daily fuzz surfaced any bugs
+    runs-on: ubuntu-latest
+    needs: fuzz
+    if: ${{ github.repository == 'astral-sh/ruff' && always() && github.event_name == 'schedule' && needs.fuzz == 'failure' }}
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            await github.rest.issues.create({
+              owner: "astral-sh",
+              repo: "ruff",
+              title: `Daily parser fuzz failed on ${new Date().toDateString()}`,
+              body: "Runs listed here: https://github.com/astral-sh/ruff/actions/workflows/daily_fuzz.yml",
+              labels: ["bug", "parser", "fuzzer"],
+            })

--- a/.github/workflows/daily_fuzz.yaml
+++ b/.github/workflows/daily_fuzz.yaml
@@ -55,7 +55,7 @@ jobs:
     name: Create an issue if the daily fuzz surfaced any bugs
     runs-on: ubuntu-latest
     needs: fuzz
-    if: ${{ github.repository == 'astral-sh/ruff' && always() && github.event_name == 'schedule' && needs.fuzz == 'failure' }}
+    if: ${{ github.repository == 'astral-sh/ruff' && always() && github.event_name == 'schedule' && needs.fuzz.result == 'failure' }}
     permissions:
       issues: write
     steps:

--- a/.github/workflows/daily_fuzz.yaml
+++ b/.github/workflows/daily_fuzz.yaml
@@ -49,7 +49,7 @@ jobs:
         # but this is outweighed by the fact that a release build takes *much* longer to compile in CI
         run: cargo build --locked
       - name: Fuzz
-        run: python scripts/fuzz-parser/fuzz.py $(shuf -i 0-1000000 -n 1000) --test-executable target/debug/ruff
+        run: python scripts/fuzz-parser/fuzz.py $(shuf -i 0-9999999999999999999 -n 1000) --test-executable target/debug/ruff
 
   create-issue-on-failure:
     name: Create an issue if the daily fuzz surfaced any bugs

--- a/scripts/fuzz-parser/fuzz.py
+++ b/scripts/fuzz-parser/fuzz.py
@@ -298,11 +298,12 @@ def parse_args() -> ResolvedCliArgs:
 
     if not args.test_executable:
         print(
-            "Running `cargo build --release` since no test executable was specified..."
+            "Running `cargo build --release` since no test executable was specified...",
+            flush=True,
         )
         try:
             subprocess.run(
-                ["cargo", "build", "--release", "--color", "always"],
+                ["cargo", "build", "--release", "--locked", "--color", "always"],
                 check=True,
                 capture_output=True,
                 text=True,

--- a/scripts/fuzz-parser/fuzz.py
+++ b/scripts/fuzz-parser/fuzz.py
@@ -77,7 +77,7 @@ class FuzzResult:
             if self.maybe_bug
             else colored(f"Ran fuzzer successfully on seed {self.seed}", "green")
         )
-        print(f"{msg:<55} {progress:>15}", flush=True)
+        print(f"{msg:<60} {progress:>15}", flush=True)
         if self.maybe_bug:
             print(colored("The following code triggers a bug:", "red"))
             print()


### PR DESCRIPTION
## Summary

In https://github.com/astral-sh/ruff/commit/f5c7a62aa65decb9e286bd65ba17f1a3bd1f91e6, we added a new CI job to fuzz the parser. The job runs on all PRs touching the parser, and deliberately only runs the fuzzer with the same seeds each time, so that it can function as a regression test: any bugs surfaced by that job can be guaranteed to be *new* bugs that we know didn't exist on `main`. (A given seed is always guaranteed to lead to the same file being generated by `pysource-codegen`.)

This PR adds a second CI job that runs once a day and runs the fuzzer on a _randomly selected_ set of 1,000 seeds. This is less useful as a regression test, as any bugs surfaced by this CI job will not necessarily be _new_ bugs. Theoretically, however, randomly selecting the seeds could be a more successful way of discovering bugs in the parser.

If the daily job fails, a bot will automatically open an issue reporting the failure. Here's an example at typeshed of what the issue would look like (we use a similar daily job at typeshed): https://github.com/python/typeshed/issues/11837.

## Is this useful?

This PR is a proof-of-concept, but I'm not sure how useful this job would actually be. While this could theoretically help us find more bugs in the parser, I think it's likely that most bugs surfaced by this fuzzer would be encountered in the 500 seeds run as part of the CI job that we already run on PRs affecting the parser and pushes to `main`. If someone's working on a big parser change that they want to test to destruction, they can run the script with a larger set of random seeds locally. I'm putting this PR up in case it's helpful, but I'll fully defer to the parser experts on the team as to whether it's something we want to go ahead with or not; I'm pretty undecided.

## Test Plan

The new job should run as part of this PR.
