### PR TITLE
[red knot] Introduce `LintDb`

### DIFF
--- a/crates/red_knot/src/lint.rs
+++ b/crates/red_knot/src/lint.rs
@@ -7,9 +7,7 @@ use ruff_python_ast::visitor::Visitor;
 use ruff_python_ast::{ModModule, StringLiteral};
 
 use crate::cache::KeyValueCache;
-use crate::db::{
-    HasJar, ParallelDatabase, QueryResult, SemanticDb, SemanticJar, SourceDb, SourceJar,
-};
+use crate::db::{HasJar, LintDb, LintJar, QueryResult, SemanticDb};
 use crate::files::FileId;
 use crate::parse::Parsed;
 use crate::source::Source;
@@ -19,7 +17,7 @@ use crate::types::Type;
 #[tracing::instrument(level = "debug", skip(db))]
 pub(crate) fn lint_syntax<Db>(db: &Db, file_id: FileId) -> QueryResult<Diagnostics>
 where
-    Db: SourceDb + HasJar<SourceJar> + ParallelDatabase,
+    Db: LintDb + HasJar<LintJar>,
 {
     let storage = &db.jar()?.lint_syntax;
 
@@ -77,7 +75,7 @@ fn lint_lines(source: &str, diagnostics: &mut Vec<String>) {
 #[tracing::instrument(level = "debug", skip(db))]
 pub(crate) fn lint_semantic<Db>(db: &Db, file_id: FileId) -> QueryResult<Diagnostics>
 where
-    Db: SemanticDb + HasJar<SemanticJar>,
+    Db: LintDb + HasJar<LintJar>,
 {
     let storage = &db.jar()?.lint_semantic;
 

--- a/crates/red_knot/src/program/check.rs
+++ b/crates/red_knot/src/program/check.rs
@@ -3,7 +3,7 @@ use std::num::NonZeroUsize;
 use rayon::{current_num_threads, yield_local};
 use rustc_hash::FxHashSet;
 
-use crate::db::{Database, QueryError, QueryResult, SemanticDb, SourceDb};
+use crate::db::{Database, LintDb, QueryError, QueryResult, SemanticDb};
 use crate::files::FileId;
 use crate::lint::Diagnostics;
 use crate::program::Program;


### PR DESCRIPTION
## Summary

This PR introduces a new `LintDb` and moves the `lint_syntax` and `lint_semantic` methods to the new trait. 

The reason for splitting out a new `LintDb` is that I see the following crates long term (at least)

* `red_knot_query`: Infrastructure for a query based compiler
* `red_knot_source`: Exposes the base queries to read a file and parse it.
* `red_knot_formatter`: Exposes format queries (I don't know how they will look and what we want to cache). Uses `red_knot_source` so that we can re-use parse trees between lint and format
* `red_knot_semantic` or `red_knot_analysis`: Contains the `SemanticDb` exposing the semantic model and type inference (I'm not yet sure where I would put type checking)
* `red_knot_lint`: Implements the lint queries. Is based on both `red_knot_source` and `red_knot_semantic`. Idealyly, we would have a way to split lint rules into sub-crates, but I'm not yet sure how that would work. 


## Test Plan

`cargo test`
