### PR TITLE
[red-knot] Use `FileId` in module resolver to map from file to module

### DIFF
--- a/crates/red_knot/src/program/mod.rs
+++ b/crates/red_knot/src/program/mod.rs
@@ -39,12 +39,9 @@ impl Program {
     where
         I: IntoIterator<Item = FileChange>,
     {
-        let files = self.files.clone();
         let (source, semantic, lint) = self.jars_mut();
         for change in changes {
-            let file_path = files.path(change.id);
-
-            semantic.module_resolver.remove_module(&file_path);
+            semantic.module_resolver.remove_module(change.id);
             semantic.symbol_tables.remove(&change.id);
             source.sources.remove(&change.id);
             source.parsed.remove(&change.id);


### PR DESCRIPTION
## Summary

We generally try to use ids instead of owned values because they're cheap to store. 

I noticed that I missed an opportunity to use an id in `ModuleResolver` where we store a map from `path` to `Module`, but that should really be a mapping from `FileId` to `ModuleId`. 

## Test Plan

`cargo test`
