### PR TITLE
[red-knot] Remove `Clone` from `Files`

### DIFF
--- a/crates/red_knot/src/db.rs
+++ b/crates/red_knot/src/db.rs
@@ -57,6 +57,7 @@ pub trait ParallelDatabase: Database + Send {
     /// We should avoid creating snapshots while running a query because we might want to adopt Salsa in the future (if we can figure out persistent caching).
     /// Unfortunately, the infrastructure doesn't provide an automated way of knowing when a query is run, that's
     /// why we have to "enforce" this constraint manually.
+    #[must_use]
     fn snapshot(&self) -> Snapshot<Self>;
 }
 

--- a/crates/red_knot/src/files.rs
+++ b/crates/red_knot/src/files.rs
@@ -15,9 +15,9 @@ type Map<K, V> = hashbrown::HashMap<K, V, ()>;
 pub struct FileId;
 
 // TODO we'll need a higher level virtual file system abstraction that allows testing if a file exists
-// or retrieving its content (ideally lazily and in a way that the memory can be retained later)
-// I suspect that we'll end up with a FileSystem trait and our own Path abstraction.
-#[derive(Clone, Default)]
+//  or retrieving its content (ideally lazily and in a way that the memory can be retained later)
+//  I suspect that we'll end up with a FileSystem trait and our own Path abstraction.
+#[derive(Default)]
 pub struct Files {
     inner: Arc<RwLock<FilesInner>>,
 }
@@ -35,6 +35,16 @@ impl Files {
     #[tracing::instrument(level = "debug", skip(self))]
     pub fn path(&self, id: FileId) -> Arc<Path> {
         self.inner.read().path(id)
+    }
+
+    /// Snapshots files for a new database snapshot.
+    ///
+    /// This method should not be used outside a database snapshot.
+    #[must_use]
+    pub fn snapshot(&self) -> Files {
+        Files {
+            inner: self.inner.clone(),
+        }
     }
 }
 
@@ -63,7 +73,7 @@ struct FilesInner {
     by_path: Map<FileId, ()>,
     // TODO should we use a map here to reclaim the space for removed files?
     // TODO I think we should use our own path abstraction here to avoid having to normalize paths
-    // and dealing with non-utf paths everywhere.
+    //  and dealing with non-utf paths everywhere.
     by_id: IndexVec<FileId, Arc<Path>>,
 }
 


### PR DESCRIPTION
## Summary

This PR removes the `Clone` implementation on `Files` and replaces it with a `snapshot` function similar to `Database`. 

The main motivation for this change is that I think it's important that we prevent that `Files` (or any other `Database` state) can change while we're creating a persistent cache, because that could potentially lead to partial caches. 

What I have in mind is that we enforce a `&mut` reference when creating the cache (maybe not for the entire period, e.g. maybe only for creating the cacheable data structure, but we release the `&mut` before serializing the data structure to disk). 
Taking a `&mut` guarantees us that there's no other system (e.g. a file watcher) quietly mutating `Files` while we try to persist its state to disk. 

The guarantee is not as strong as in the `Database` case where the `Snapshot` type prohibits access to the wrapped `Database` because we need a `Files` instance to create a snapshoted `Program`. I hope that the fact that
the type doesn't implement `Clone` and a, in the future, usage of `Arc::make_mut().unwrap` should be protection enough ;)

## Test Plan

`cargo test`
