### PR TITLE
`ruff server` respects `per-file-ignores` configuration

### DIFF
--- a/crates/ruff_server/src/server/api/diagnostics.rs
+++ b/crates/ruff_server/src/server/api/diagnostics.rs
@@ -6,6 +6,7 @@ pub(super) fn generate_diagnostics(snapshot: &DocumentSnapshot) -> Vec<lsp_types
     if snapshot.client_settings().lint() {
         crate::lint::check(
             snapshot.document(),
+            snapshot.url(),
             snapshot.settings().linter(),
             snapshot.encoding(),
         )

--- a/crates/ruff_server/src/server/api/requests/code_action_resolve.rs
+++ b/crates/ruff_server/src/server/api/requests/code_action_resolve.rs
@@ -95,17 +95,18 @@ pub(super) fn resolve_edit_for_fix_all(
     tracker.set_edits_for_document(
         url.clone(),
         version,
-        fix_all_edit(document, linter_settings, encoding)?,
+        fix_all_edit(document, url, linter_settings, encoding)?,
     )?;
     Ok(tracker.into_workspace_edit())
 }
 
 pub(super) fn fix_all_edit(
     document: &crate::edit::Document,
+    document_url: &types::Url,
     linter_settings: &LinterSettings,
     encoding: PositionEncoding,
 ) -> crate::Result<Vec<types::TextEdit>> {
-    crate::fix::fix_all(document, linter_settings, encoding)
+    crate::fix::fix_all(document, document_url, linter_settings, encoding)
 }
 
 pub(super) fn resolve_edit_for_organize_imports(
@@ -120,13 +121,14 @@ pub(super) fn resolve_edit_for_organize_imports(
     tracker.set_edits_for_document(
         url.clone(),
         version,
-        organize_imports_edit(document, linter_settings, encoding)?,
+        organize_imports_edit(document, url, linter_settings, encoding)?,
     )?;
     Ok(tracker.into_workspace_edit())
 }
 
 pub(super) fn organize_imports_edit(
     document: &crate::edit::Document,
+    document_url: &types::Url,
     linter_settings: &LinterSettings,
     encoding: PositionEncoding,
 ) -> crate::Result<Vec<types::TextEdit>> {
@@ -138,5 +140,5 @@ pub(super) fn organize_imports_edit(
     .into_iter()
     .collect();
 
-    crate::fix::fix_all(document, &linter_settings, encoding)
+    crate::fix::fix_all(document, document_url, &linter_settings, encoding)
 }

--- a/crates/ruff_server/src/server/api/requests/execute_command.rs
+++ b/crates/ruff_server/src/server/api/requests/execute_command.rs
@@ -64,6 +64,7 @@ impl super::SyncRequestHandler for ExecuteCommand {
                 Command::FixAll => {
                     let edits = super::code_action_resolve::fix_all_edit(
                         snapshot.document(),
+                        snapshot.url(),
                         snapshot.settings().linter(),
                         snapshot.encoding(),
                     )
@@ -83,6 +84,7 @@ impl super::SyncRequestHandler for ExecuteCommand {
                 Command::OrganizeImports => {
                     let edits = super::code_action_resolve::organize_imports_edit(
                         snapshot.document(),
+                        snapshot.url(),
                         snapshot.settings().linter(),
                         snapshot.encoding(),
                     )


### PR DESCRIPTION
## Summary

Fixes #11185
Fixes #11214 

Document path and package information is now forwarded to the Ruff linter, which allows `per-file-ignores` to correctly match against the file name. This also fixes an issue where the import sorting rule didn't distinguish between third-party and first-party packages since we didn't pass in the package root.

## Test Plan

`per-file-ignores` should ignore files as expected. One quick way to check is by adding this to your `pyproject.toml`:
```toml
[tool.ruff.lint.per-file-ignores]
"__init__.py" = ["ALL"]
```

Then, confirm that no diagnostics appear when you add code to an `__init__.py` file (besides syntax errors).

The import sorting fix can be verified by failing to reproduce the original issue - an `I001` diagnostic should not appear in `other_module.py`.