### PR TITLE
[`pyupgrade`] Show violations without auto-fix for `UP031`

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP031_0.py
+++ b/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP031_0.py
@@ -126,6 +126,20 @@ path = "%s-%s-%s.pem" % (
 
 'Hello %s' % bar['bop']
 
+# Not a valid type annotation but this test shouldn't result in a panic.
+# Refer: https://github.com/astral-sh/ruff/issues/11736
+x: "'%s + %s' % (1, 2)"
+
+# See: https://github.com/astral-sh/ruff/issues/12421
+print("%.2X" % 1)
+print("%.02X" % 1)
+print("%02X" % 1)
+print("%.00002X" % 1)
+print("%.20X" % 1)
+
+print("%2X" % 1)
+print("%02X" % 1)
+
 # UP031 (no longer false negatives, but offer no fix because of more complex syntax)
 
 "%d.%d" % (a, b)
@@ -155,17 +169,3 @@ path = "%s-%s-%s.pem" % (
 "%(1)s" % {1: 2, "1": 2}
 
 "%(and)s" % {"and": 2}
-
-# Not a valid type annotation but this test shouldn't result in a panic.
-# Refer: https://github.com/astral-sh/ruff/issues/11736
-x: "'%s + %s' % (1, 2)"
-
-# See: https://github.com/astral-sh/ruff/issues/12421
-print("%.2X" % 1)
-print("%.02X" % 1)
-print("%02X" % 1)
-print("%.00002X" % 1)
-print("%.20X" % 1)
-
-print("%2X" % 1)
-print("%02X" % 1)

--- a/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP031_0.py
+++ b/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP031_0.py
@@ -126,6 +126,36 @@ path = "%s-%s-%s.pem" % (
 
 'Hello %s' % bar['bop']
 
+# UP031 (no longer false negatives, but offer no fix because of more complex syntax)
+
+"%d.%d" % (a, b)
+
+"%*s" % (5, "hi")
+
+"%d" % (flt,)
+
+"%c" % (some_string,)
+
+"%.2r" % (1.25)
+
+"%.*s" % (5, "hi")
+
+"%i" % (flt,)
+
+"%()s" % {"": "empty"}
+
+"%s" % {"k": "v"}
+
+"%()s" % {"": "bar"}
+
+"%(1)s" % {"1": "bar"}
+
+"%(a)s" % {"a": 1, "a": 2}
+
+"%(1)s" % {1: 2, "1": 2}
+
+"%(and)s" % {"and": 2}
+
 # Not a valid type annotation but this test shouldn't result in a panic.
 # Refer: https://github.com/astral-sh/ruff/issues/11736
 x: "'%s + %s' % (1, 2)"

--- a/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP031_1.py
+++ b/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP031_1.py
@@ -1,34 +1,8 @@
 # OK
 b"%s" % (b"bytestring",)
 
-"%*s" % (5, "hi")
-
-"%d" % (flt,)
-
-"%c" % (some_string,)
-
 "%4%" % ()
-
-"%.2r" % (1.25)
 
 i % 3
 
-"%.*s" % (5, "hi")
-
-"%i" % (flt,)
-
-"%()s" % {"": "empty"}
-
-"%s" % {"k": "v"}
-
-"%(1)s" % {"1": "bar"}
-
-"%(a)s" % {"a": 1, "a": 2}
-
 pytest.param('"%8s" % (None,)', id="unsafe width-string conversion"),
-
-"%()s" % {"": "bar"}
-
-"%(1)s" % {1: 2, "1": 2}
-
-"%(and)s" % {"and": 2}

--- a/crates/ruff_linter/src/rules/pyupgrade/mod.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/mod.rs
@@ -103,7 +103,7 @@ mod tests {
     #[test_case(Rule::PrintfStringFormatting, Path::new("UP031_0.py"))]
     fn preview(rule_code: Rule, path: &Path) -> Result<()> {
         let diagnostics = test_path(
-            &Path::new("pyupgrade").join(path),
+            Path::new("pyupgrade").join(path),
             &settings::LinterSettings {
                 preview: PreviewMode::Enabled,
                 ..settings::LinterSettings::for_rule(rule_code)

--- a/crates/ruff_linter/src/rules/pyupgrade/mod.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/mod.rs
@@ -14,7 +14,7 @@ mod tests {
 
     use crate::registry::Rule;
     use crate::rules::pyupgrade;
-    use crate::settings::types::PythonVersion;
+    use crate::settings::types::{PreviewMode, PythonVersion};
     use crate::test::test_path;
     use crate::{assert_messages, settings};
 
@@ -97,6 +97,19 @@ mod tests {
             &settings::LinterSettings::for_rule(rule_code),
         )?;
         assert_messages!(snapshot, diagnostics);
+        Ok(())
+    }
+
+    #[test_case(Rule::PrintfStringFormatting, Path::new("UP031_0.py"))]
+    fn preview(rule_code: Rule, path: &Path) -> Result<()> {
+        let diagnostics = test_path(
+            &Path::new("pyupgrade").join(path),
+            &settings::LinterSettings {
+                preview: PreviewMode::Enabled,
+                ..settings::LinterSettings::for_rule(rule_code)
+            },
+        )?;
+        assert_messages!(diagnostics);
         Ok(())
     }
 

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/printf_string_formatting.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/printf_string_formatting.rs
@@ -81,7 +81,7 @@ impl Violation for PrintfStringFormatting {
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Use format specifiers or f-strings instead of percent format")
+        format!("Use format specifiers instead of percent format")
     }
 
     fn fix_title(&self) -> Option<String> {
@@ -389,7 +389,7 @@ pub(crate) fn printf_string_formatting(
         if !convertible(&format_string, right) {
             checker
                 .diagnostics
-                .push(Diagnostic::new(PrintfStringFormatting, expr.range()));
+                .push(Diagnostic::new(PrintfStringFormatting, string_expr.range()));
             return;
         }
 
@@ -450,7 +450,7 @@ pub(crate) fn printf_string_formatting(
             else {
                 checker
                     .diagnostics
-                    .push(Diagnostic::new(PrintfStringFormatting, expr.range()));
+                    .push(Diagnostic::new(PrintfStringFormatting, string_expr.range()));
                 return;
             };
             Cow::Owned(params_string)

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/printf_string_formatting.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/printf_string_formatting.rs
@@ -40,10 +40,11 @@ use crate::rules::pyupgrade::helpers::curly_escape;
 /// ```
 ///
 /// ```python
-/// f"{'Hello'}, {'World'}" # "Hello, World"
+/// f"{'Hello'}, {'World'}"  # "Hello, World"
 /// ```
 ///
 /// ## Fix safety
+///
 /// In cases where the format string contains a single generic format specifier
 /// (e.g. `%s`), and the right-hand side is an ambiguous expression,
 /// we cannot offer a safe fix.

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/printf_string_formatting.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/printf_string_formatting.rs
@@ -28,11 +28,13 @@ use crate::rules::pyupgrade::helpers::curly_escape;
 /// formatting.
 ///
 /// ## Example
+///
 /// ```python
 /// "%s, %s" % ("Hello", "World")  # "Hello, World"
 /// ```
 ///
 /// Use instead:
+///
 /// ```python
 /// "{}, {}".format("Hello", "World")  # "Hello, World"
 /// ```
@@ -47,6 +49,7 @@ use crate::rules::pyupgrade::helpers::curly_escape;
 /// we cannot offer a safe fix.
 ///
 /// For example, given:
+///
 /// ```python
 /// "%s" % val
 /// ```

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/printf_string_formatting.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/printf_string_formatting.rs
@@ -387,9 +387,11 @@ pub(crate) fn printf_string_formatting(
             return;
         };
         if !convertible(&format_string, right) {
-            checker
-                .diagnostics
-                .push(Diagnostic::new(PrintfStringFormatting, string_expr.range()));
+            if checker.settings.preview.is_enabled() {
+                checker
+                    .diagnostics
+                    .push(Diagnostic::new(PrintfStringFormatting, string_expr.range()));
+            }
             return;
         }
 
@@ -448,9 +450,11 @@ pub(crate) fn printf_string_formatting(
             let Some(params_string) =
                 clean_params_dictionary(right, checker.locator(), checker.stylist())
             else {
-                checker
-                    .diagnostics
-                    .push(Diagnostic::new(PrintfStringFormatting, string_expr.range()));
+                if checker.settings.preview.is_enabled() {
+                    checker
+                        .diagnostics
+                        .push(Diagnostic::new(PrintfStringFormatting, string_expr.range()));
+                }
                 return;
             };
             Cow::Owned(params_string)

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP031_0.py.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP031_0.py.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff_linter/src/rules/pyupgrade/mod.rs
 ---
-UP031_0.py:4:7: UP031 [*] Use format specifiers or f-strings instead of percent format
+UP031_0.py:4:7: UP031 [*] Use format specifiers instead of percent format
   |
 3 | # UP031
 4 | print('%s %s' % (a, b))
@@ -21,7 +21,7 @@ UP031_0.py:4:7: UP031 [*] Use format specifiers or f-strings instead of percent 
 6 6 | print('%s%s' % (a, b))
 7 7 | 
 
-UP031_0.py:6:7: UP031 [*] Use format specifiers or f-strings instead of percent format
+UP031_0.py:6:7: UP031 [*] Use format specifiers instead of percent format
   |
 4 | print('%s %s' % (a, b))
 5 | 
@@ -42,7 +42,7 @@ UP031_0.py:6:7: UP031 [*] Use format specifiers or f-strings instead of percent 
 8 8 | print("trivial" % ())
 9 9 | 
 
-UP031_0.py:8:7: UP031 [*] Use format specifiers or f-strings instead of percent format
+UP031_0.py:8:7: UP031 [*] Use format specifiers instead of percent format
    |
  6 | print('%s%s' % (a, b))
  7 | 
@@ -63,7 +63,7 @@ UP031_0.py:8:7: UP031 [*] Use format specifiers or f-strings instead of percent 
 10 10 | print("%s" % ("simple",))
 11 11 | 
 
-UP031_0.py:10:7: UP031 [*] Use format specifiers or f-strings instead of percent format
+UP031_0.py:10:7: UP031 [*] Use format specifiers instead of percent format
    |
  8 | print("trivial" % ())
  9 | 
@@ -84,7 +84,7 @@ UP031_0.py:10:7: UP031 [*] Use format specifiers or f-strings instead of percent
 12 12 | print("%s" % ("%s" % ("nested",),))
 13 13 | 
 
-UP031_0.py:12:7: UP031 [*] Use format specifiers or f-strings instead of percent format
+UP031_0.py:12:7: UP031 [*] Use format specifiers instead of percent format
    |
 10 | print("%s" % ("simple",))
 11 | 
@@ -105,7 +105,7 @@ UP031_0.py:12:7: UP031 [*] Use format specifiers or f-strings instead of percent
 14 14 | print("%s%% percent" % (15,))
 15 15 | 
 
-UP031_0.py:12:15: UP031 [*] Use format specifiers or f-strings instead of percent format
+UP031_0.py:12:15: UP031 [*] Use format specifiers instead of percent format
    |
 10 | print("%s" % ("simple",))
 11 | 
@@ -126,7 +126,7 @@ UP031_0.py:12:15: UP031 [*] Use format specifiers or f-strings instead of percen
 14 14 | print("%s%% percent" % (15,))
 15 15 | 
 
-UP031_0.py:14:7: UP031 [*] Use format specifiers or f-strings instead of percent format
+UP031_0.py:14:7: UP031 [*] Use format specifiers instead of percent format
    |
 12 | print("%s" % ("%s" % ("nested",),))
 13 | 
@@ -147,7 +147,7 @@ UP031_0.py:14:7: UP031 [*] Use format specifiers or f-strings instead of percent
 16 16 | print("%f" % (15,))
 17 17 | 
 
-UP031_0.py:16:7: UP031 [*] Use format specifiers or f-strings instead of percent format
+UP031_0.py:16:7: UP031 [*] Use format specifiers instead of percent format
    |
 14 | print("%s%% percent" % (15,))
 15 | 
@@ -168,7 +168,7 @@ UP031_0.py:16:7: UP031 [*] Use format specifiers or f-strings instead of percent
 18 18 | print("%.f" % (15,))
 19 19 | 
 
-UP031_0.py:18:7: UP031 [*] Use format specifiers or f-strings instead of percent format
+UP031_0.py:18:7: UP031 [*] Use format specifiers instead of percent format
    |
 16 | print("%f" % (15,))
 17 | 
@@ -189,7 +189,7 @@ UP031_0.py:18:7: UP031 [*] Use format specifiers or f-strings instead of percent
 20 20 | print("%.3f" % (15,))
 21 21 | 
 
-UP031_0.py:20:7: UP031 [*] Use format specifiers or f-strings instead of percent format
+UP031_0.py:20:7: UP031 [*] Use format specifiers instead of percent format
    |
 18 | print("%.f" % (15,))
 19 | 
@@ -210,7 +210,7 @@ UP031_0.py:20:7: UP031 [*] Use format specifiers or f-strings instead of percent
 22 22 | print("%3f" % (15,))
 23 23 | 
 
-UP031_0.py:22:7: UP031 [*] Use format specifiers or f-strings instead of percent format
+UP031_0.py:22:7: UP031 [*] Use format specifiers instead of percent format
    |
 20 | print("%.3f" % (15,))
 21 | 
@@ -231,7 +231,7 @@ UP031_0.py:22:7: UP031 [*] Use format specifiers or f-strings instead of percent
 24 24 | print("%-5f" % (5,))
 25 25 | 
 
-UP031_0.py:24:7: UP031 [*] Use format specifiers or f-strings instead of percent format
+UP031_0.py:24:7: UP031 [*] Use format specifiers instead of percent format
    |
 22 | print("%3f" % (15,))
 23 | 
@@ -252,7 +252,7 @@ UP031_0.py:24:7: UP031 [*] Use format specifiers or f-strings instead of percent
 26 26 | print("%9f" % (5,))
 27 27 | 
 
-UP031_0.py:26:7: UP031 [*] Use format specifiers or f-strings instead of percent format
+UP031_0.py:26:7: UP031 [*] Use format specifiers instead of percent format
    |
 24 | print("%-5f" % (5,))
 25 | 
@@ -273,7 +273,7 @@ UP031_0.py:26:7: UP031 [*] Use format specifiers or f-strings instead of percent
 28 28 | print("%#o" % (123,))
 29 29 | 
 
-UP031_0.py:28:7: UP031 [*] Use format specifiers or f-strings instead of percent format
+UP031_0.py:28:7: UP031 [*] Use format specifiers instead of percent format
    |
 26 | print("%9f" % (5,))
 27 | 
@@ -294,14 +294,14 @@ UP031_0.py:28:7: UP031 [*] Use format specifiers or f-strings instead of percent
 30 30 | print("brace {} %s" % (1,))
 31 31 | 
 
-UP031_0.py:30:7: UP031 [*] Use format specifiers or f-strings instead of percent format
+UP031_0.py:30:7: UP031 [*] Use format specifiers instead of percent format
    |
 28 | print("%#o" % (123,))
 29 | 
 30 | print("brace {} %s" % (1,))
    |       ^^^^^^^^^^^^^^^^^^^^ UP031
 31 | 
-32 | print(
+32 | print((
    |
    = help: Replace with format specifiers
 
@@ -312,845 +312,1007 @@ UP031_0.py:30:7: UP031 [*] Use format specifiers or f-strings instead of percent
 30    |-print("brace {} %s" % (1,))
    30 |+print("brace {{}} {}".format(1))
 31 31 | 
-32 32 | print(
-33 33 |   "%s" % (
+32 32 | print((
+33 33 |     "foo %s "
 
-UP031_0.py:33:3: UP031 [*] Use format specifiers or f-strings instead of percent format
+UP031_0.py:33:5: UP031 [*] Use format specifiers instead of percent format
    |
-32 |   print(
-33 |     "%s" % (
-   |  ___^
-34 | |     "trailing comma",
-35 | |         )
-   | |_________^ UP031
-36 |   )
+32 |   print((
+33 |       "foo %s "
+   |  _____^
+34 | |     "bar %s" % (x, y)
+   | |_____________________^ UP031
+35 |   ))
    |
    = help: Replace with format specifiers
 
 ℹ Unsafe fix
 30 30 | print("brace {} %s" % (1,))
 31 31 | 
-32 32 | print(
-33    |-  "%s" % (
-   33 |+  "{}".format(
-34 34 |     "trailing comma",
-35 35 |         )
-36 36 | )
+32 32 | print((
+33    |-    "foo %s "
+34    |-    "bar %s" % (x, y)
+   33 |+    "foo {} "
+   34 |+    "bar {}".format(x, y)
+35 35 | ))
+36 36 | 
+37 37 | print(
 
-UP031_0.py:38:7: UP031 [*] Use format specifiers or f-strings instead of percent format
+UP031_0.py:38:3: UP031 [*] Use format specifiers instead of percent format
    |
-36 | )
-37 | 
-38 | print("foo %s " % (x,))
+37 |   print(
+38 |     "%s" % (
+   |  ___^
+39 | |     "trailing comma",
+40 | |         )
+   | |_________^ UP031
+41 |   )
+   |
+   = help: Replace with format specifiers
+
+ℹ Unsafe fix
+35 35 | ))
+36 36 | 
+37 37 | print(
+38    |-  "%s" % (
+   38 |+  "{}".format(
+39 39 |     "trailing comma",
+40 40 |         )
+41 41 | )
+
+UP031_0.py:43:7: UP031 [*] Use format specifiers instead of percent format
+   |
+41 | )
+42 | 
+43 | print("foo %s " % (x,))
    |       ^^^^^^^^^^^^^^^^ UP031
-39 | 
-40 | print("%(k)s" % {"k": "v"})
+44 | 
+45 | print("%(k)s" % {"k": "v"})
    |
    = help: Replace with format specifiers
 
 ℹ Unsafe fix
-35 35 |         )
-36 36 | )
-37 37 | 
-38    |-print("foo %s " % (x,))
-   38 |+print("foo {} ".format(x))
-39 39 | 
-40 40 | print("%(k)s" % {"k": "v"})
-41 41 | 
-
-UP031_0.py:40:7: UP031 [*] Use format specifiers or f-strings instead of percent format
-   |
-38 | print("foo %s " % (x,))
-39 | 
-40 | print("%(k)s" % {"k": "v"})
-   |       ^^^^^^^^^^^^^^^^^^^^ UP031
-41 | 
-42 | print("%(k)s" % {
-   |
-   = help: Replace with format specifiers
-
-ℹ Unsafe fix
-37 37 | 
-38 38 | print("foo %s " % (x,))
-39 39 | 
-40    |-print("%(k)s" % {"k": "v"})
-   40 |+print("{k}".format(k="v"))
-41 41 | 
-42 42 | print("%(k)s" % {
-43 43 |     "k": "v",
-
-UP031_0.py:42:7: UP031 [*] Use format specifiers or f-strings instead of percent format
-   |
-40 |   print("%(k)s" % {"k": "v"})
-41 |   
-42 |   print("%(k)s" % {
-   |  _______^
-43 | |     "k": "v",
-44 | |     "i": "j"
-45 | | })
-   | |_^ UP031
-46 |   
-47 |   print("%(to_list)s" % {"to_list": []})
-   |
-   = help: Replace with format specifiers
-
-ℹ Unsafe fix
-39 39 | 
-40 40 | print("%(k)s" % {"k": "v"})
-41 41 | 
-42    |-print("%(k)s" % {
-43    |-    "k": "v",
-44    |-    "i": "j"
-45    |-})
-   42 |+print("{k}".format(
-   43 |+    k="v",
-   44 |+    i="j",
-   45 |+))
+40 40 |         )
+41 41 | )
+42 42 | 
+43    |-print("foo %s " % (x,))
+   43 |+print("foo {} ".format(x))
+44 44 | 
+45 45 | print("%(k)s" % {"k": "v"})
 46 46 | 
-47 47 | print("%(to_list)s" % {"to_list": []})
-48 48 | 
 
-UP031_0.py:47:7: UP031 [*] Use format specifiers or f-strings instead of percent format
+UP031_0.py:45:7: UP031 [*] Use format specifiers instead of percent format
    |
-45 | })
+43 | print("foo %s " % (x,))
+44 | 
+45 | print("%(k)s" % {"k": "v"})
+   |       ^^^^^^^^^^^^^^^^^^^^ UP031
 46 | 
-47 | print("%(to_list)s" % {"to_list": []})
+47 | print("%(k)s" % {
+   |
+   = help: Replace with format specifiers
+
+ℹ Unsafe fix
+42 42 | 
+43 43 | print("foo %s " % (x,))
+44 44 | 
+45    |-print("%(k)s" % {"k": "v"})
+   45 |+print("{k}".format(k="v"))
+46 46 | 
+47 47 | print("%(k)s" % {
+48 48 |     "k": "v",
+
+UP031_0.py:47:7: UP031 [*] Use format specifiers instead of percent format
+   |
+45 |   print("%(k)s" % {"k": "v"})
+46 |   
+47 |   print("%(k)s" % {
+   |  _______^
+48 | |     "k": "v",
+49 | |     "i": "j"
+50 | | })
+   | |_^ UP031
+51 |   
+52 |   print("%(to_list)s" % {"to_list": []})
+   |
+   = help: Replace with format specifiers
+
+ℹ Unsafe fix
+44 44 | 
+45 45 | print("%(k)s" % {"k": "v"})
+46 46 | 
+47    |-print("%(k)s" % {
+48    |-    "k": "v",
+49    |-    "i": "j"
+50    |-})
+   47 |+print("{k}".format(
+   48 |+    k="v",
+   49 |+    i="j",
+   50 |+))
+51 51 | 
+52 52 | print("%(to_list)s" % {"to_list": []})
+53 53 | 
+
+UP031_0.py:52:7: UP031 [*] Use format specifiers instead of percent format
+   |
+50 | })
+51 | 
+52 | print("%(to_list)s" % {"to_list": []})
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ UP031
-48 | 
-49 | print("%(k)s" % {"k": "v", "i": 1, "j": []})
+53 | 
+54 | print("%(k)s" % {"k": "v", "i": 1, "j": []})
    |
    = help: Replace with format specifiers
 
 ℹ Unsafe fix
-44 44 |     "i": "j"
-45 45 | })
-46 46 | 
-47    |-print("%(to_list)s" % {"to_list": []})
-   47 |+print("{to_list}".format(to_list=[]))
-48 48 | 
-49 49 | print("%(k)s" % {"k": "v", "i": 1, "j": []})
-50 50 | 
+49 49 |     "i": "j"
+50 50 | })
+51 51 | 
+52    |-print("%(to_list)s" % {"to_list": []})
+   52 |+print("{to_list}".format(to_list=[]))
+53 53 | 
+54 54 | print("%(k)s" % {"k": "v", "i": 1, "j": []})
+55 55 | 
 
-UP031_0.py:49:7: UP031 [*] Use format specifiers or f-strings instead of percent format
+UP031_0.py:54:7: UP031 [*] Use format specifiers instead of percent format
    |
-47 | print("%(to_list)s" % {"to_list": []})
-48 | 
-49 | print("%(k)s" % {"k": "v", "i": 1, "j": []})
+52 | print("%(to_list)s" % {"to_list": []})
+53 | 
+54 | print("%(k)s" % {"k": "v", "i": 1, "j": []})
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ UP031
-50 | 
-51 | print("%(ab)s" % {"a" "b": 1})
+55 | 
+56 | print("%(ab)s" % {"a" "b": 1})
    |
    = help: Replace with format specifiers
 
 ℹ Unsafe fix
-46 46 | 
-47 47 | print("%(to_list)s" % {"to_list": []})
-48 48 | 
-49    |-print("%(k)s" % {"k": "v", "i": 1, "j": []})
-   49 |+print("{k}".format(k="v", i=1, j=[]))
-50 50 | 
-51 51 | print("%(ab)s" % {"a" "b": 1})
-52 52 | 
+51 51 | 
+52 52 | print("%(to_list)s" % {"to_list": []})
+53 53 | 
+54    |-print("%(k)s" % {"k": "v", "i": 1, "j": []})
+   54 |+print("{k}".format(k="v", i=1, j=[]))
+55 55 | 
+56 56 | print("%(ab)s" % {"a" "b": 1})
+57 57 | 
 
-UP031_0.py:51:7: UP031 [*] Use format specifiers or f-strings instead of percent format
+UP031_0.py:56:7: UP031 [*] Use format specifiers instead of percent format
    |
-49 | print("%(k)s" % {"k": "v", "i": 1, "j": []})
-50 | 
-51 | print("%(ab)s" % {"a" "b": 1})
+54 | print("%(k)s" % {"k": "v", "i": 1, "j": []})
+55 | 
+56 | print("%(ab)s" % {"a" "b": 1})
    |       ^^^^^^^^^^^^^^^^^^^^^^^ UP031
-52 | 
-53 | print("%(a)s" % {"a"  :  1})
+57 | 
+58 | print("%(a)s" % {"a"  :  1})
    |
    = help: Replace with format specifiers
 
 ℹ Unsafe fix
-48 48 | 
-49 49 | print("%(k)s" % {"k": "v", "i": 1, "j": []})
-50 50 | 
-51    |-print("%(ab)s" % {"a" "b": 1})
-   51 |+print("{ab}".format(ab=1))
-52 52 | 
-53 53 | print("%(a)s" % {"a"  :  1})
-54 54 | 
-
-UP031_0.py:53:7: UP031 [*] Use format specifiers or f-strings instead of percent format
-   |
-51 | print("%(ab)s" % {"a" "b": 1})
-52 | 
-53 | print("%(a)s" % {"a"  :  1})
-   |       ^^^^^^^^^^^^^^^^^^^^^ UP031
-54 | 
-55 | print((
-   |
-   = help: Replace with format specifiers
-
-ℹ Unsafe fix
-50 50 | 
-51 51 | print("%(ab)s" % {"a" "b": 1})
-52 52 | 
-53    |-print("%(a)s" % {"a"  :  1})
-   53 |+print("{a}".format(a=1))
-54 54 | 
-55 55 | print((
-56 56 |     "foo %s "
-
-UP031_0.py:56:5: UP031 [*] Use format specifiers or f-strings instead of percent format
-   |
-55 |   print((
-56 |       "foo %s "
-   |  _____^
-57 | |     "bar %s" % (x, y)
-   | |_____________________^ UP031
-58 |   ))
-   |
-   = help: Replace with format specifiers
-
-ℹ Unsafe fix
-53 53 | print("%(a)s" % {"a"  :  1})
-54 54 | 
-55 55 | print((
-56    |-    "foo %s "
-57    |-    "bar %s" % (x, y)
-   56 |+    "foo {} "
-   57 |+    "bar {}".format(x, y)
-58 58 | ))
+53 53 | 
+54 54 | print("%(k)s" % {"k": "v", "i": 1, "j": []})
+55 55 | 
+56    |-print("%(ab)s" % {"a" "b": 1})
+   56 |+print("{ab}".format(ab=1))
+57 57 | 
+58 58 | print("%(a)s" % {"a"  :  1})
 59 59 | 
-60 60 | print(
 
-UP031_0.py:61:5: UP031 [*] Use format specifiers or f-strings instead of percent format
+UP031_0.py:58:7: UP031 [*] Use format specifiers instead of percent format
    |
-60 |   print(
-61 |       "foo %(foo)s "
+56 | print("%(ab)s" % {"a" "b": 1})
+57 | 
+58 | print("%(a)s" % {"a"  :  1})
+   |       ^^^^^^^^^^^^^^^^^^^^^ UP031
+   |
+   = help: Replace with format specifiers
+
+ℹ Unsafe fix
+55 55 | 
+56 56 | print("%(ab)s" % {"a" "b": 1})
+57 57 | 
+58    |-print("%(a)s" % {"a"  :  1})
+   58 |+print("{a}".format(a=1))
+59 59 | 
+60 60 | 
+61 61 | print(
+
+UP031_0.py:62:5: UP031 [*] Use format specifiers instead of percent format
+   |
+61 |   print(
+62 |       "foo %(foo)s "
    |  _____^
-62 | |     "bar %(bar)s" % {"foo": x, "bar": y}
+63 | |     "bar %(bar)s" % {"foo": x, "bar": y}
    | |________________________________________^ UP031
-63 |   )
+64 |   )
    |
    = help: Replace with format specifiers
 
 ℹ Unsafe fix
-58 58 | ))
 59 59 | 
-60 60 | print(
-61    |-    "foo %(foo)s "
-62    |-    "bar %(bar)s" % {"foo": x, "bar": y}
-   61 |+    "foo {foo} "
-   62 |+    "bar {bar}".format(foo=x, bar=y)
-63 63 | )
-64 64 | 
-65 65 | bar = {"bar": y}
+60 60 | 
+61 61 | print(
+62    |-    "foo %(foo)s "
+63    |-    "bar %(bar)s" % {"foo": x, "bar": y}
+   62 |+    "foo {foo} "
+   63 |+    "bar {bar}".format(foo=x, bar=y)
+64 64 | )
+65 65 | 
+66 66 | bar = {"bar": y}
 
-UP031_0.py:67:5: UP031 [*] Use format specifiers or f-strings instead of percent format
+UP031_0.py:68:5: UP031 [*] Use format specifiers instead of percent format
    |
-65 |   bar = {"bar": y}
-66 |   print(
-67 |       "foo %(foo)s "
+66 |   bar = {"bar": y}
+67 |   print(
+68 |       "foo %(foo)s "
    |  _____^
-68 | |     "bar %(bar)s" % {"foo": x, **bar}
+69 | |     "bar %(bar)s" % {"foo": x, **bar}
    | |_____________________________________^ UP031
-69 |   )
+70 |   )
    |
    = help: Replace with format specifiers
 
 ℹ Unsafe fix
-64 64 | 
-65 65 | bar = {"bar": y}
-66 66 | print(
-67    |-    "foo %(foo)s "
-68    |-    "bar %(bar)s" % {"foo": x, **bar}
-   67 |+    "foo {foo} "
-   68 |+    "bar {bar}".format(foo=x, **bar)
-69 69 | )
-70 70 | 
-71 71 | print("%s \N{snowman}" % (a,))
+65 65 | 
+66 66 | bar = {"bar": y}
+67 67 | print(
+68    |-    "foo %(foo)s "
+69    |-    "bar %(bar)s" % {"foo": x, **bar}
+   68 |+    "foo {foo} "
+   69 |+    "bar {bar}".format(foo=x, **bar)
+70 70 | )
+71 71 | 
+72 72 | print("%s \N{snowman}" % (a,))
 
-UP031_0.py:71:7: UP031 [*] Use format specifiers or f-strings instead of percent format
+UP031_0.py:72:7: UP031 [*] Use format specifiers instead of percent format
    |
-69 | )
-70 | 
-71 | print("%s \N{snowman}" % (a,))
+70 | )
+71 | 
+72 | print("%s \N{snowman}" % (a,))
    |       ^^^^^^^^^^^^^^^^^^^^^^^ UP031
-72 | 
-73 | print("%(foo)s \N{snowman}" % {"foo": 1})
+73 | 
+74 | print("%(foo)s \N{snowman}" % {"foo": 1})
    |
    = help: Replace with format specifiers
 
 ℹ Unsafe fix
-68 68 |     "bar %(bar)s" % {"foo": x, **bar}
-69 69 | )
-70 70 | 
-71    |-print("%s \N{snowman}" % (a,))
-   71 |+print("{} \N{snowman}".format(a))
-72 72 | 
-73 73 | print("%(foo)s \N{snowman}" % {"foo": 1})
-74 74 | 
+69 69 |     "bar %(bar)s" % {"foo": x, **bar}
+70 70 | )
+71 71 | 
+72    |-print("%s \N{snowman}" % (a,))
+   72 |+print("{} \N{snowman}".format(a))
+73 73 | 
+74 74 | print("%(foo)s \N{snowman}" % {"foo": 1})
+75 75 | 
 
-UP031_0.py:73:7: UP031 [*] Use format specifiers or f-strings instead of percent format
+UP031_0.py:74:7: UP031 [*] Use format specifiers instead of percent format
    |
-71 | print("%s \N{snowman}" % (a,))
-72 | 
-73 | print("%(foo)s \N{snowman}" % {"foo": 1})
+72 | print("%s \N{snowman}" % (a,))
+73 | 
+74 | print("%(foo)s \N{snowman}" % {"foo": 1})
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ UP031
-74 | 
-75 | print(("foo %s " "bar %s") % (x, y))
+75 | 
+76 | print(("foo %s " "bar %s") % (x, y))
    |
    = help: Replace with format specifiers
 
 ℹ Unsafe fix
-70 70 | 
-71 71 | print("%s \N{snowman}" % (a,))
-72 72 | 
-73    |-print("%(foo)s \N{snowman}" % {"foo": 1})
-   73 |+print("{foo} \N{snowman}".format(foo=1))
-74 74 | 
-75 75 | print(("foo %s " "bar %s") % (x, y))
-76 76 | 
+71 71 | 
+72 72 | print("%s \N{snowman}" % (a,))
+73 73 | 
+74    |-print("%(foo)s \N{snowman}" % {"foo": 1})
+   74 |+print("{foo} \N{snowman}".format(foo=1))
+75 75 | 
+76 76 | print(("foo %s " "bar %s") % (x, y))
+77 77 | 
 
-UP031_0.py:75:7: UP031 [*] Use format specifiers or f-strings instead of percent format
+UP031_0.py:76:7: UP031 [*] Use format specifiers instead of percent format
    |
-73 | print("%(foo)s \N{snowman}" % {"foo": 1})
-74 | 
-75 | print(("foo %s " "bar %s") % (x, y))
+74 | print("%(foo)s \N{snowman}" % {"foo": 1})
+75 | 
+76 | print(("foo %s " "bar %s") % (x, y))
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ UP031
-76 | 
-77 | # Single-value expressions
+77 | 
+78 | # Single-value expressions
    |
    = help: Replace with format specifiers
 
 ℹ Unsafe fix
-72 72 | 
-73 73 | print("%(foo)s \N{snowman}" % {"foo": 1})
-74 74 | 
-75    |-print(("foo %s " "bar %s") % (x, y))
-   75 |+print(("foo {} " "bar {}").format(x, y))
-76 76 | 
-77 77 | # Single-value expressions
-78 78 | print('Hello %s' % "World")
+73 73 | 
+74 74 | print("%(foo)s \N{snowman}" % {"foo": 1})
+75 75 | 
+76    |-print(("foo %s " "bar %s") % (x, y))
+   76 |+print(("foo {} " "bar {}").format(x, y))
+77 77 | 
+78 78 | # Single-value expressions
+79 79 | print('Hello %s' % "World")
 
-UP031_0.py:78:7: UP031 [*] Use format specifiers or f-strings instead of percent format
+UP031_0.py:79:7: UP031 [*] Use format specifiers instead of percent format
    |
-77 | # Single-value expressions
-78 | print('Hello %s' % "World")
+78 | # Single-value expressions
+79 | print('Hello %s' % "World")
    |       ^^^^^^^^^^^^^^^^^^^^ UP031
-79 | print('Hello %s' % f"World")
-80 | print('Hello %s (%s)' % bar)
+80 | print('Hello %s' % f"World")
+81 | print('Hello %s (%s)' % bar)
    |
    = help: Replace with format specifiers
 
 ℹ Unsafe fix
-75 75 | print(("foo %s " "bar %s") % (x, y))
-76 76 | 
-77 77 | # Single-value expressions
-78    |-print('Hello %s' % "World")
-   78 |+print('Hello {}'.format("World"))
-79 79 | print('Hello %s' % f"World")
-80 80 | print('Hello %s (%s)' % bar)
-81 81 | print('Hello %s (%s)' % bar.baz)
+76 76 | print(("foo %s " "bar %s") % (x, y))
+77 77 | 
+78 78 | # Single-value expressions
+79    |-print('Hello %s' % "World")
+   79 |+print('Hello {}'.format("World"))
+80 80 | print('Hello %s' % f"World")
+81 81 | print('Hello %s (%s)' % bar)
+82 82 | print('Hello %s (%s)' % bar.baz)
 
-UP031_0.py:79:7: UP031 [*] Use format specifiers or f-strings instead of percent format
+UP031_0.py:80:7: UP031 [*] Use format specifiers instead of percent format
    |
-77 | # Single-value expressions
-78 | print('Hello %s' % "World")
-79 | print('Hello %s' % f"World")
+78 | # Single-value expressions
+79 | print('Hello %s' % "World")
+80 | print('Hello %s' % f"World")
    |       ^^^^^^^^^^^^^^^^^^^^^ UP031
-80 | print('Hello %s (%s)' % bar)
-81 | print('Hello %s (%s)' % bar.baz)
+81 | print('Hello %s (%s)' % bar)
+82 | print('Hello %s (%s)' % bar.baz)
    |
    = help: Replace with format specifiers
 
 ℹ Unsafe fix
-76 76 | 
-77 77 | # Single-value expressions
-78 78 | print('Hello %s' % "World")
-79    |-print('Hello %s' % f"World")
-   79 |+print('Hello {}'.format(f"World"))
-80 80 | print('Hello %s (%s)' % bar)
-81 81 | print('Hello %s (%s)' % bar.baz)
-82 82 | print('Hello %s (%s)' % bar['bop'])
+77 77 | 
+78 78 | # Single-value expressions
+79 79 | print('Hello %s' % "World")
+80    |-print('Hello %s' % f"World")
+   80 |+print('Hello {}'.format(f"World"))
+81 81 | print('Hello %s (%s)' % bar)
+82 82 | print('Hello %s (%s)' % bar.baz)
+83 83 | print('Hello %s (%s)' % bar['bop'])
 
-UP031_0.py:80:7: UP031 [*] Use format specifiers or f-strings instead of percent format
+UP031_0.py:81:7: UP031 [*] Use format specifiers instead of percent format
    |
-78 | print('Hello %s' % "World")
-79 | print('Hello %s' % f"World")
-80 | print('Hello %s (%s)' % bar)
+79 | print('Hello %s' % "World")
+80 | print('Hello %s' % f"World")
+81 | print('Hello %s (%s)' % bar)
    |       ^^^^^^^^^^^^^^^^^^^^^ UP031
-81 | print('Hello %s (%s)' % bar.baz)
-82 | print('Hello %s (%s)' % bar['bop'])
+82 | print('Hello %s (%s)' % bar.baz)
+83 | print('Hello %s (%s)' % bar['bop'])
    |
    = help: Replace with format specifiers
 
 ℹ Unsafe fix
-77 77 | # Single-value expressions
-78 78 | print('Hello %s' % "World")
-79 79 | print('Hello %s' % f"World")
-80    |-print('Hello %s (%s)' % bar)
-   80 |+print('Hello {} ({})'.format(*bar))
-81 81 | print('Hello %s (%s)' % bar.baz)
-82 82 | print('Hello %s (%s)' % bar['bop'])
-83 83 | print('Hello %(arg)s' % bar)
+78 78 | # Single-value expressions
+79 79 | print('Hello %s' % "World")
+80 80 | print('Hello %s' % f"World")
+81    |-print('Hello %s (%s)' % bar)
+   81 |+print('Hello {} ({})'.format(*bar))
+82 82 | print('Hello %s (%s)' % bar.baz)
+83 83 | print('Hello %s (%s)' % bar['bop'])
+84 84 | print('Hello %(arg)s' % bar)
 
-UP031_0.py:81:7: UP031 [*] Use format specifiers or f-strings instead of percent format
+UP031_0.py:82:7: UP031 [*] Use format specifiers instead of percent format
    |
-79 | print('Hello %s' % f"World")
-80 | print('Hello %s (%s)' % bar)
-81 | print('Hello %s (%s)' % bar.baz)
+80 | print('Hello %s' % f"World")
+81 | print('Hello %s (%s)' % bar)
+82 | print('Hello %s (%s)' % bar.baz)
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^ UP031
-82 | print('Hello %s (%s)' % bar['bop'])
-83 | print('Hello %(arg)s' % bar)
+83 | print('Hello %s (%s)' % bar['bop'])
+84 | print('Hello %(arg)s' % bar)
    |
    = help: Replace with format specifiers
 
 ℹ Unsafe fix
-78 78 | print('Hello %s' % "World")
-79 79 | print('Hello %s' % f"World")
-80 80 | print('Hello %s (%s)' % bar)
-81    |-print('Hello %s (%s)' % bar.baz)
-   81 |+print('Hello {} ({})'.format(*bar.baz))
-82 82 | print('Hello %s (%s)' % bar['bop'])
-83 83 | print('Hello %(arg)s' % bar)
-84 84 | print('Hello %(arg)s' % bar.baz)
+79 79 | print('Hello %s' % "World")
+80 80 | print('Hello %s' % f"World")
+81 81 | print('Hello %s (%s)' % bar)
+82    |-print('Hello %s (%s)' % bar.baz)
+   82 |+print('Hello {} ({})'.format(*bar.baz))
+83 83 | print('Hello %s (%s)' % bar['bop'])
+84 84 | print('Hello %(arg)s' % bar)
+85 85 | print('Hello %(arg)s' % bar.baz)
 
-UP031_0.py:82:7: UP031 [*] Use format specifiers or f-strings instead of percent format
+UP031_0.py:83:7: UP031 [*] Use format specifiers instead of percent format
    |
-80 | print('Hello %s (%s)' % bar)
-81 | print('Hello %s (%s)' % bar.baz)
-82 | print('Hello %s (%s)' % bar['bop'])
+81 | print('Hello %s (%s)' % bar)
+82 | print('Hello %s (%s)' % bar.baz)
+83 | print('Hello %s (%s)' % bar['bop'])
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ UP031
-83 | print('Hello %(arg)s' % bar)
-84 | print('Hello %(arg)s' % bar.baz)
+84 | print('Hello %(arg)s' % bar)
+85 | print('Hello %(arg)s' % bar.baz)
    |
    = help: Replace with format specifiers
 
 ℹ Unsafe fix
-79 79 | print('Hello %s' % f"World")
-80 80 | print('Hello %s (%s)' % bar)
-81 81 | print('Hello %s (%s)' % bar.baz)
-82    |-print('Hello %s (%s)' % bar['bop'])
-   82 |+print('Hello {} ({})'.format(*bar['bop']))
-83 83 | print('Hello %(arg)s' % bar)
-84 84 | print('Hello %(arg)s' % bar.baz)
-85 85 | print('Hello %(arg)s' % bar['bop'])
+80 80 | print('Hello %s' % f"World")
+81 81 | print('Hello %s (%s)' % bar)
+82 82 | print('Hello %s (%s)' % bar.baz)
+83    |-print('Hello %s (%s)' % bar['bop'])
+   83 |+print('Hello {} ({})'.format(*bar['bop']))
+84 84 | print('Hello %(arg)s' % bar)
+85 85 | print('Hello %(arg)s' % bar.baz)
+86 86 | print('Hello %(arg)s' % bar['bop'])
 
-UP031_0.py:83:7: UP031 [*] Use format specifiers or f-strings instead of percent format
+UP031_0.py:84:7: UP031 [*] Use format specifiers instead of percent format
    |
-81 | print('Hello %s (%s)' % bar.baz)
-82 | print('Hello %s (%s)' % bar['bop'])
-83 | print('Hello %(arg)s' % bar)
+82 | print('Hello %s (%s)' % bar.baz)
+83 | print('Hello %s (%s)' % bar['bop'])
+84 | print('Hello %(arg)s' % bar)
    |       ^^^^^^^^^^^^^^^^^^^^^ UP031
-84 | print('Hello %(arg)s' % bar.baz)
-85 | print('Hello %(arg)s' % bar['bop'])
+85 | print('Hello %(arg)s' % bar.baz)
+86 | print('Hello %(arg)s' % bar['bop'])
    |
    = help: Replace with format specifiers
 
 ℹ Unsafe fix
-80 80 | print('Hello %s (%s)' % bar)
-81 81 | print('Hello %s (%s)' % bar.baz)
-82 82 | print('Hello %s (%s)' % bar['bop'])
-83    |-print('Hello %(arg)s' % bar)
-   83 |+print('Hello {arg}'.format(**bar))
-84 84 | print('Hello %(arg)s' % bar.baz)
-85 85 | print('Hello %(arg)s' % bar['bop'])
-86 86 | 
+81 81 | print('Hello %s (%s)' % bar)
+82 82 | print('Hello %s (%s)' % bar.baz)
+83 83 | print('Hello %s (%s)' % bar['bop'])
+84    |-print('Hello %(arg)s' % bar)
+   84 |+print('Hello {arg}'.format(**bar))
+85 85 | print('Hello %(arg)s' % bar.baz)
+86 86 | print('Hello %(arg)s' % bar['bop'])
+87 87 | 
 
-UP031_0.py:84:7: UP031 [*] Use format specifiers or f-strings instead of percent format
+UP031_0.py:85:7: UP031 [*] Use format specifiers instead of percent format
    |
-82 | print('Hello %s (%s)' % bar['bop'])
-83 | print('Hello %(arg)s' % bar)
-84 | print('Hello %(arg)s' % bar.baz)
+83 | print('Hello %s (%s)' % bar['bop'])
+84 | print('Hello %(arg)s' % bar)
+85 | print('Hello %(arg)s' % bar.baz)
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^ UP031
-85 | print('Hello %(arg)s' % bar['bop'])
+86 | print('Hello %(arg)s' % bar['bop'])
    |
    = help: Replace with format specifiers
 
 ℹ Unsafe fix
-81 81 | print('Hello %s (%s)' % bar.baz)
-82 82 | print('Hello %s (%s)' % bar['bop'])
-83 83 | print('Hello %(arg)s' % bar)
-84    |-print('Hello %(arg)s' % bar.baz)
-   84 |+print('Hello {arg}'.format(**bar.baz))
-85 85 | print('Hello %(arg)s' % bar['bop'])
-86 86 | 
-87 87 | # Hanging modulos
+82 82 | print('Hello %s (%s)' % bar.baz)
+83 83 | print('Hello %s (%s)' % bar['bop'])
+84 84 | print('Hello %(arg)s' % bar)
+85    |-print('Hello %(arg)s' % bar.baz)
+   85 |+print('Hello {arg}'.format(**bar.baz))
+86 86 | print('Hello %(arg)s' % bar['bop'])
+87 87 | 
+88 88 | # Hanging modulos
 
-UP031_0.py:85:7: UP031 [*] Use format specifiers or f-strings instead of percent format
+UP031_0.py:86:7: UP031 [*] Use format specifiers instead of percent format
    |
-83 | print('Hello %(arg)s' % bar)
-84 | print('Hello %(arg)s' % bar.baz)
-85 | print('Hello %(arg)s' % bar['bop'])
+84 | print('Hello %(arg)s' % bar)
+85 | print('Hello %(arg)s' % bar.baz)
+86 | print('Hello %(arg)s' % bar['bop'])
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ UP031
-86 | 
-87 | # Hanging modulos
+87 | 
+88 | # Hanging modulos
    |
    = help: Replace with format specifiers
 
 ℹ Unsafe fix
-82 82 | print('Hello %s (%s)' % bar['bop'])
-83 83 | print('Hello %(arg)s' % bar)
-84 84 | print('Hello %(arg)s' % bar.baz)
-85    |-print('Hello %(arg)s' % bar['bop'])
-   85 |+print('Hello {arg}'.format(**bar['bop']))
-86 86 | 
-87 87 | # Hanging modulos
-88 88 | (
+83 83 | print('Hello %s (%s)' % bar['bop'])
+84 84 | print('Hello %(arg)s' % bar)
+85 85 | print('Hello %(arg)s' % bar.baz)
+86    |-print('Hello %(arg)s' % bar['bop'])
+   86 |+print('Hello {arg}'.format(**bar['bop']))
+87 87 | 
+88 88 | # Hanging modulos
+89 89 | (
 
-UP031_0.py:88:1: UP031 [*] Use format specifiers or f-strings instead of percent format
+UP031_0.py:89:1: UP031 [*] Use format specifiers instead of percent format
    |
-87 |   # Hanging modulos
-88 | / (
-89 | |     "foo %s "
-90 | |     "bar %s"
-91 | | ) % (x, y)
+88 |   # Hanging modulos
+89 | / (
+90 | |     "foo %s "
+91 | |     "bar %s"
+92 | | ) % (x, y)
    | |__________^ UP031
-92 |   
-93 |   (
+93 |   
+94 |   (
    |
    = help: Replace with format specifiers
 
 ℹ Unsafe fix
-86 86 | 
-87 87 | # Hanging modulos
-88 88 | (
-89    |-    "foo %s "
-90    |-    "bar %s"
-91    |-) % (x, y)
-   89 |+    "foo {} "
-   90 |+    "bar {}"
-   91 |+).format(x, y)
-92 92 | 
-93 93 | (
-94 94 |     "foo %(foo)s "
+87 87 | 
+88 88 | # Hanging modulos
+89 89 | (
+90    |-    "foo %s "
+91    |-    "bar %s"
+92    |-) % (x, y)
+   90 |+    "foo {} "
+   91 |+    "bar {}"
+   92 |+).format(x, y)
+93 93 | 
+94 94 | (
+95 95 |     "foo %(foo)s "
 
-UP031_0.py:93:1: UP031 [*] Use format specifiers or f-strings instead of percent format
+UP031_0.py:94:1: UP031 [*] Use format specifiers instead of percent format
    |
-91 |   ) % (x, y)
-92 |   
-93 | / (
-94 | |     "foo %(foo)s "
-95 | |     "bar %(bar)s"
-96 | | ) % {"foo": x, "bar": y}
+92 |   ) % (x, y)
+93 |   
+94 | / (
+95 | |     "foo %(foo)s "
+96 | |     "bar %(bar)s"
+97 | | ) % {"foo": x, "bar": y}
    | |________________________^ UP031
-97 |   
-98 |   (
+98 |   
+99 |   (
    |
    = help: Replace with format specifiers
 
 ℹ Unsafe fix
-91 91 | ) % (x, y)
-92 92 | 
-93 93 | (
-94    |-    "foo %(foo)s "
-95    |-    "bar %(bar)s"
-96    |-) % {"foo": x, "bar": y}
-   94 |+    "foo {foo} "
-   95 |+    "bar {bar}"
-   96 |+).format(foo=x, bar=y)
-97 97 | 
-98 98 | (
-99 99 |     """foo %s"""
+92 92 | ) % (x, y)
+93 93 | 
+94 94 | (
+95    |-    "foo %(foo)s "
+96    |-    "bar %(bar)s"
+97    |-) % {"foo": x, "bar": y}
+   95 |+    "foo {foo} "
+   96 |+    "bar {bar}"
+   97 |+).format(foo=x, bar=y)
+98 98 | 
+99 99 | (
+100 100 |     """foo %s"""
 
-UP031_0.py:99:5: UP031 [*] Use format specifiers or f-strings instead of percent format
+UP031_0.py:100:5: UP031 [*] Use format specifiers instead of percent format
     |
- 98 |   (
- 99 |       """foo %s"""
+ 99 |   (
+100 |       """foo %s"""
     |  _____^
-100 | |     % (x,)
+101 | |     % (x,)
     | |__________^ UP031
-101 |   )
+102 |   )
     |
     = help: Replace with format specifiers
 
 ℹ Unsafe fix
-96  96  | ) % {"foo": x, "bar": y}
-97  97  | 
-98  98  | (
-99      |-    """foo %s"""
-100     |-    % (x,)
-    99  |+    """foo {}""".format(x)
-101 100 | )
-102 101 | 
-103 102 | (
+97  97  | ) % {"foo": x, "bar": y}
+98  98  | 
+99  99  | (
+100     |-    """foo %s"""
+101     |-    % (x,)
+    100 |+    """foo {}""".format(x)
+102 101 | )
+103 102 | 
+104 103 | (
 
-UP031_0.py:104:5: UP031 [*] Use format specifiers or f-strings instead of percent format
+UP031_0.py:105:5: UP031 [*] Use format specifiers instead of percent format
     |
-103 |   (
-104 |       """
+104 |   (
+105 |       """
     |  _____^
-105 | |     foo %s
-106 | |     """
-107 | |     % (x,)
+106 | |     foo %s
+107 | |     """
+108 | |     % (x,)
     | |__________^ UP031
-108 |   )
+109 |   )
     |
     = help: Replace with format specifiers
 
 ℹ Unsafe fix
-102 102 | 
-103 103 | (
-104 104 |     """
-105     |-    foo %s
-106     |-    """
-107     |-    % (x,)
-    105 |+    foo {}
-    106 |+    """.format(x)
-108 107 | )
-109 108 | 
-110 109 | "%s" % (
+103 103 | 
+104 104 | (
+105 105 |     """
+106     |-    foo %s
+107     |-    """
+108     |-    % (x,)
+    106 |+    foo {}
+    107 |+    """.format(x)
+109 108 | )
+110 109 | 
+111 110 | "%s" % (
 
-UP031_0.py:110:1: UP031 [*] Use format specifiers or f-strings instead of percent format
+UP031_0.py:111:1: UP031 [*] Use format specifiers instead of percent format
     |
-108 |   )
-109 |   
-110 | / "%s" % (
-111 | |     x,  # comment
-112 | | )
+109 |   )
+110 |   
+111 | / "%s" % (
+112 | |     x,  # comment
+113 | | )
     | |_^ UP031
     |
     = help: Replace with format specifiers
 
 ℹ Unsafe fix
-107 107 |     % (x,)
-108 108 | )
-109 109 | 
-110     |-"%s" % (
-    110 |+"{}".format(
-111 111 |     x,  # comment
-112 112 | )
-113 113 | 
-
-UP031_0.py:115:8: UP031 [*] Use format specifiers or f-strings instead of percent format
-    |
-115 |   path = "%s-%s-%s.pem" % (
-    |  ________^
-116 | |     safe_domain_name(cn), # common name, which should be filename safe because it is IDNA-encoded, but in case of a malformed cert make sure it's ok to use as a filename
-117 | |     cert.not_valid_after.date().isoformat().replace("-", ""), # expiration date
-118 | |     hexlify(cert.fingerprint(hashes.SHA256())).decode("ascii")[0:8], # fingerprint prefix
-119 | | )
-    | |_^ UP031
-120 |   
-121 |   # UP031 (no longer false negatives; now offer potentially unsafe fixes)
-    |
-    = help: Replace with format specifiers
-
-ℹ Unsafe fix
-112 112 | )
-113 113 | 
+108 108 |     % (x,)
+109 109 | )
+110 110 | 
+111     |-"%s" % (
+    111 |+"{}".format(
+112 112 |     x,  # comment
+113 113 | )
 114 114 | 
-115     |-path = "%s-%s-%s.pem" % (
-    115 |+path = "{}-{}-{}.pem".format(
-116 116 |     safe_domain_name(cn), # common name, which should be filename safe because it is IDNA-encoded, but in case of a malformed cert make sure it's ok to use as a filename
-117 117 |     cert.not_valid_after.date().isoformat().replace("-", ""), # expiration date
-118 118 |     hexlify(cert.fingerprint(hashes.SHA256())).decode("ascii")[0:8], # fingerprint prefix
 
-UP031_0.py:122:1: UP031 [*] Use format specifiers or f-strings instead of percent format
+UP031_0.py:116:8: UP031 [*] Use format specifiers instead of percent format
     |
-121 | # UP031 (no longer false negatives; now offer potentially unsafe fixes)
-122 | 'Hello %s' % bar
+116 |   path = "%s-%s-%s.pem" % (
+    |  ________^
+117 | |     safe_domain_name(cn), # common name, which should be filename safe because it is IDNA-encoded, but in case of a malformed cert make sure it's ok to use as a filename
+118 | |     cert.not_valid_after.date().isoformat().replace("-", ""), # expiration date
+119 | |     hexlify(cert.fingerprint(hashes.SHA256())).decode("ascii")[0:8], # fingerprint prefix
+120 | | )
+    | |_^ UP031
+121 |   
+122 |   # UP031 (no longer false negatives; now offer potentially unsafe fixes)
+    |
+    = help: Replace with format specifiers
+
+ℹ Unsafe fix
+113 113 | )
+114 114 | 
+115 115 | 
+116     |-path = "%s-%s-%s.pem" % (
+    116 |+path = "{}-{}-{}.pem".format(
+117 117 |     safe_domain_name(cn), # common name, which should be filename safe because it is IDNA-encoded, but in case of a malformed cert make sure it's ok to use as a filename
+118 118 |     cert.not_valid_after.date().isoformat().replace("-", ""), # expiration date
+119 119 |     hexlify(cert.fingerprint(hashes.SHA256())).decode("ascii")[0:8], # fingerprint prefix
+
+UP031_0.py:123:1: UP031 [*] Use format specifiers instead of percent format
+    |
+122 | # UP031 (no longer false negatives; now offer potentially unsafe fixes)
+123 | 'Hello %s' % bar
     | ^^^^^^^^^^^^^^^^ UP031
-123 | 
-124 | 'Hello %s' % bar.baz
+124 | 
+125 | 'Hello %s' % bar.baz
     |
     = help: Replace with format specifiers
 
 ℹ Unsafe fix
-119 119 | )
-120 120 | 
-121 121 | # UP031 (no longer false negatives; now offer potentially unsafe fixes)
-122     |-'Hello %s' % bar
-    122 |+'Hello {}'.format(bar)
-123 123 | 
-124 124 | 'Hello %s' % bar.baz
-125 125 | 
+120 120 | )
+121 121 | 
+122 122 | # UP031 (no longer false negatives; now offer potentially unsafe fixes)
+123     |-'Hello %s' % bar
+    123 |+'Hello {}'.format(bar)
+124 124 | 
+125 125 | 'Hello %s' % bar.baz
+126 126 | 
 
-UP031_0.py:124:1: UP031 [*] Use format specifiers or f-strings instead of percent format
+UP031_0.py:125:1: UP031 [*] Use format specifiers instead of percent format
     |
-122 | 'Hello %s' % bar
-123 | 
-124 | 'Hello %s' % bar.baz
+123 | 'Hello %s' % bar
+124 | 
+125 | 'Hello %s' % bar.baz
     | ^^^^^^^^^^^^^^^^^^^^ UP031
-125 | 
-126 | 'Hello %s' % bar['bop']
+126 | 
+127 | 'Hello %s' % bar['bop']
     |
     = help: Replace with format specifiers
 
 ℹ Unsafe fix
-121 121 | # UP031 (no longer false negatives; now offer potentially unsafe fixes)
-122 122 | 'Hello %s' % bar
-123 123 | 
-124     |-'Hello %s' % bar.baz
-    124 |+'Hello {}'.format(bar.baz)
-125 125 | 
-126 126 | 'Hello %s' % bar['bop']
-127 127 | 
+122 122 | # UP031 (no longer false negatives; now offer potentially unsafe fixes)
+123 123 | 'Hello %s' % bar
+124 124 | 
+125     |-'Hello %s' % bar.baz
+    125 |+'Hello {}'.format(bar.baz)
+126 126 | 
+127 127 | 'Hello %s' % bar['bop']
+128 128 | 
 
-UP031_0.py:126:1: UP031 [*] Use format specifiers or f-strings instead of percent format
+UP031_0.py:127:1: UP031 [*] Use format specifiers instead of percent format
     |
-124 | 'Hello %s' % bar.baz
-125 | 
-126 | 'Hello %s' % bar['bop']
+125 | 'Hello %s' % bar.baz
+126 | 
+127 | 'Hello %s' % bar['bop']
     | ^^^^^^^^^^^^^^^^^^^^^^^ UP031
-127 | 
-128 | # UP031 (no longer false negatives, but offer no fix because of more complex syntax)
+128 | 
+129 | # Not a valid type annotation but this test shouldn't result in a panic.
     |
     = help: Replace with format specifiers
 
 ℹ Unsafe fix
-123 123 | 
-124 124 | 'Hello %s' % bar.baz
-125 125 | 
-126     |-'Hello %s' % bar['bop']
-    126 |+'Hello {}'.format(bar['bop'])
-127 127 | 
-128 128 | # UP031 (no longer false negatives, but offer no fix because of more complex syntax)
-129 129 | 
+124 124 | 
+125 125 | 'Hello %s' % bar.baz
+126 126 | 
+127     |-'Hello %s' % bar['bop']
+    127 |+'Hello {}'.format(bar['bop'])
+128 128 | 
+129 129 | # Not a valid type annotation but this test shouldn't result in a panic.
+130 130 | # Refer: https://github.com/astral-sh/ruff/issues/11736
 
-UP031_0.py:130:1: UP031 Use format specifiers or f-strings instead of percent format
+UP031_0.py:131:5: UP031 [*] Use format specifiers instead of percent format
     |
-128 | # UP031 (no longer false negatives, but offer no fix because of more complex syntax)
-129 | 
-130 | "%d.%d" % (a, b)
-    | ^^^^^^^^^^^^^^^^ UP031
-131 | 
-132 | "%*s" % (5, "hi")
+129 | # Not a valid type annotation but this test shouldn't result in a panic.
+130 | # Refer: https://github.com/astral-sh/ruff/issues/11736
+131 | x: "'%s + %s' % (1, 2)"
+    |     ^^^^^^^^^^^^^^^^^^ UP031
+132 | 
+133 | # See: https://github.com/astral-sh/ruff/issues/12421
     |
     = help: Replace with format specifiers
 
-UP031_0.py:132:1: UP031 Use format specifiers or f-strings instead of percent format
+ℹ Unsafe fix
+128 128 | 
+129 129 | # Not a valid type annotation but this test shouldn't result in a panic.
+130 130 | # Refer: https://github.com/astral-sh/ruff/issues/11736
+131     |-x: "'%s + %s' % (1, 2)"
+    131 |+x: "'{} + {}'.format(1, 2)"
+132 132 | 
+133 133 | # See: https://github.com/astral-sh/ruff/issues/12421
+134 134 | print("%.2X" % 1)
+
+UP031_0.py:134:7: UP031 [*] Use format specifiers instead of percent format
     |
-130 | "%d.%d" % (a, b)
-131 | 
-132 | "%*s" % (5, "hi")
-    | ^^^^^^^^^^^^^^^^^ UP031
-133 | 
-134 | "%d" % (flt,)
+133 | # See: https://github.com/astral-sh/ruff/issues/12421
+134 | print("%.2X" % 1)
+    |       ^^^^^^^^^^ UP031
+135 | print("%.02X" % 1)
+136 | print("%02X" % 1)
     |
     = help: Replace with format specifiers
 
-UP031_0.py:134:1: UP031 Use format specifiers or f-strings instead of percent format
+ℹ Unsafe fix
+131 131 | x: "'%s + %s' % (1, 2)"
+132 132 | 
+133 133 | # See: https://github.com/astral-sh/ruff/issues/12421
+134     |-print("%.2X" % 1)
+    134 |+print("{:02X}".format(1))
+135 135 | print("%.02X" % 1)
+136 136 | print("%02X" % 1)
+137 137 | print("%.00002X" % 1)
+
+UP031_0.py:135:7: UP031 [*] Use format specifiers instead of percent format
     |
-132 | "%*s" % (5, "hi")
-133 | 
-134 | "%d" % (flt,)
-    | ^^^^^^^^^^^^^ UP031
-135 | 
-136 | "%c" % (some_string,)
+133 | # See: https://github.com/astral-sh/ruff/issues/12421
+134 | print("%.2X" % 1)
+135 | print("%.02X" % 1)
+    |       ^^^^^^^^^^^ UP031
+136 | print("%02X" % 1)
+137 | print("%.00002X" % 1)
     |
     = help: Replace with format specifiers
 
-UP031_0.py:136:1: UP031 Use format specifiers or f-strings instead of percent format
+ℹ Unsafe fix
+132 132 | 
+133 133 | # See: https://github.com/astral-sh/ruff/issues/12421
+134 134 | print("%.2X" % 1)
+135     |-print("%.02X" % 1)
+    135 |+print("{:02X}".format(1))
+136 136 | print("%02X" % 1)
+137 137 | print("%.00002X" % 1)
+138 138 | print("%.20X" % 1)
+
+UP031_0.py:136:7: UP031 [*] Use format specifiers instead of percent format
     |
-134 | "%d" % (flt,)
-135 | 
-136 | "%c" % (some_string,)
-    | ^^^^^^^^^^^^^^^^^^^^^ UP031
-137 | 
-138 | "%.2r" % (1.25)
+134 | print("%.2X" % 1)
+135 | print("%.02X" % 1)
+136 | print("%02X" % 1)
+    |       ^^^^^^^^^^ UP031
+137 | print("%.00002X" % 1)
+138 | print("%.20X" % 1)
     |
     = help: Replace with format specifiers
 
-UP031_0.py:138:1: UP031 Use format specifiers or f-strings instead of percent format
+ℹ Unsafe fix
+133 133 | # See: https://github.com/astral-sh/ruff/issues/12421
+134 134 | print("%.2X" % 1)
+135 135 | print("%.02X" % 1)
+136     |-print("%02X" % 1)
+    136 |+print("{:02X}".format(1))
+137 137 | print("%.00002X" % 1)
+138 138 | print("%.20X" % 1)
+139 139 | 
+
+UP031_0.py:137:7: UP031 [*] Use format specifiers instead of percent format
     |
-136 | "%c" % (some_string,)
-137 | 
-138 | "%.2r" % (1.25)
-    | ^^^^^^^^^^^^^^^ UP031
+135 | print("%.02X" % 1)
+136 | print("%02X" % 1)
+137 | print("%.00002X" % 1)
+    |       ^^^^^^^^^^^^^^ UP031
+138 | print("%.20X" % 1)
+    |
+    = help: Replace with format specifiers
+
+ℹ Unsafe fix
+134 134 | print("%.2X" % 1)
+135 135 | print("%.02X" % 1)
+136 136 | print("%02X" % 1)
+137     |-print("%.00002X" % 1)
+    137 |+print("{:02X}".format(1))
+138 138 | print("%.20X" % 1)
+139 139 | 
+140 140 | print("%2X" % 1)
+
+UP031_0.py:138:7: UP031 [*] Use format specifiers instead of percent format
+    |
+136 | print("%02X" % 1)
+137 | print("%.00002X" % 1)
+138 | print("%.20X" % 1)
+    |       ^^^^^^^^^^^ UP031
 139 | 
-140 | "%.*s" % (5, "hi")
+140 | print("%2X" % 1)
     |
     = help: Replace with format specifiers
 
-UP031_0.py:140:1: UP031 Use format specifiers or f-strings instead of percent format
+ℹ Unsafe fix
+135 135 | print("%.02X" % 1)
+136 136 | print("%02X" % 1)
+137 137 | print("%.00002X" % 1)
+138     |-print("%.20X" % 1)
+    138 |+print("{:020X}".format(1))
+139 139 | 
+140 140 | print("%2X" % 1)
+141 141 | print("%02X" % 1)
+
+UP031_0.py:140:7: UP031 [*] Use format specifiers instead of percent format
     |
-138 | "%.2r" % (1.25)
+138 | print("%.20X" % 1)
 139 | 
-140 | "%.*s" % (5, "hi")
-    | ^^^^^^^^^^^^^^^^^^ UP031
-141 | 
-142 | "%i" % (flt,)
+140 | print("%2X" % 1)
+    |       ^^^^^^^^^ UP031
+141 | print("%02X" % 1)
     |
     = help: Replace with format specifiers
 
-UP031_0.py:142:1: UP031 Use format specifiers or f-strings instead of percent format
+ℹ Unsafe fix
+137 137 | print("%.00002X" % 1)
+138 138 | print("%.20X" % 1)
+139 139 | 
+140     |-print("%2X" % 1)
+    140 |+print("{:2X}".format(1))
+141 141 | print("%02X" % 1)
+142 142 | 
+143 143 | # UP031 (no longer false negatives, but offer no fix because of more complex syntax)
+
+UP031_0.py:141:7: UP031 [*] Use format specifiers instead of percent format
     |
-140 | "%.*s" % (5, "hi")
-141 | 
-142 | "%i" % (flt,)
-    | ^^^^^^^^^^^^^ UP031
-143 | 
-144 | "%()s" % {"": "empty"}
+140 | print("%2X" % 1)
+141 | print("%02X" % 1)
+    |       ^^^^^^^^^^ UP031
+142 | 
+143 | # UP031 (no longer false negatives, but offer no fix because of more complex syntax)
     |
     = help: Replace with format specifiers
 
-UP031_0.py:144:1: UP031 Use format specifiers or f-strings instead of percent format
+ℹ Unsafe fix
+138 138 | print("%.20X" % 1)
+139 139 | 
+140 140 | print("%2X" % 1)
+141     |-print("%02X" % 1)
+    141 |+print("{:02X}".format(1))
+142 142 | 
+143 143 | # UP031 (no longer false negatives, but offer no fix because of more complex syntax)
+144 144 | 
+
+UP031_0.py:145:1: UP031 Use format specifiers instead of percent format
     |
-142 | "%i" % (flt,)
-143 | 
-144 | "%()s" % {"": "empty"}
-    | ^^^^^^^^^^^^^^^^^^^^^^ UP031
-145 | 
-146 | "%s" % {"k": "v"}
+143 | # UP031 (no longer false negatives, but offer no fix because of more complex syntax)
+144 | 
+145 | "%d.%d" % (a, b)
+    | ^^^^^^^ UP031
+146 | 
+147 | "%*s" % (5, "hi")
     |
     = help: Replace with format specifiers
 
-UP031_0.py:146:1: UP031 Use format specifiers or f-strings instead of percent format
+UP031_0.py:147:1: UP031 Use format specifiers instead of percent format
     |
-144 | "%()s" % {"": "empty"}
-145 | 
-146 | "%s" % {"k": "v"}
-    | ^^^^^^^^^^^^^^^^^ UP031
-147 | 
-148 | "%()s" % {"": "bar"}
-    |
-    = help: Replace with format specifiers
-
-UP031_0.py:148:1: UP031 Use format specifiers or f-strings instead of percent format
-    |
-146 | "%s" % {"k": "v"}
-147 | 
-148 | "%()s" % {"": "bar"}
-    | ^^^^^^^^^^^^^^^^^^^^ UP031
-149 | 
-150 | "%(1)s" % {"1": "bar"}
+145 | "%d.%d" % (a, b)
+146 | 
+147 | "%*s" % (5, "hi")
+    | ^^^^^ UP031
+148 | 
+149 | "%d" % (flt,)
     |
     = help: Replace with format specifiers
 
-UP031_0.py:150:1: UP031 Use format specifiers or f-strings instead of percent format
+UP031_0.py:149:1: UP031 Use format specifiers instead of percent format
     |
-148 | "%()s" % {"": "bar"}
-149 | 
-150 | "%(1)s" % {"1": "bar"}
-    | ^^^^^^^^^^^^^^^^^^^^^^ UP031
-151 | 
-152 | "%(a)s" % {"a": 1, "a": 2}
-    |
-    = help: Replace with format specifiers
-
-UP031_0.py:152:1: UP031 Use format specifiers or f-strings instead of percent format
-    |
-150 | "%(1)s" % {"1": "bar"}
-151 | 
-152 | "%(a)s" % {"a": 1, "a": 2}
-    | ^^^^^^^^^^^^^^^^^^^^^^^^^^ UP031
-153 | 
-154 | "%(1)s" % {1: 2, "1": 2}
+147 | "%*s" % (5, "hi")
+148 | 
+149 | "%d" % (flt,)
+    | ^^^^ UP031
+150 | 
+151 | "%c" % (some_string,)
     |
     = help: Replace with format specifiers
 
-UP031_0.py:154:1: UP031 Use format specifiers or f-strings instead of percent format
+UP031_0.py:151:1: UP031 Use format specifiers instead of percent format
     |
-152 | "%(a)s" % {"a": 1, "a": 2}
-153 | 
-154 | "%(1)s" % {1: 2, "1": 2}
-    | ^^^^^^^^^^^^^^^^^^^^^^^^ UP031
-155 | 
-156 | "%(and)s" % {"and": 2}
+149 | "%d" % (flt,)
+150 | 
+151 | "%c" % (some_string,)
+    | ^^^^ UP031
+152 | 
+153 | "%.2r" % (1.25)
     |
     = help: Replace with format specifiers
 
-UP031_0.py:156:1: UP031 Use format specifiers or f-strings instead of percent format
+UP031_0.py:153:1: UP031 Use format specifiers instead of percent format
     |
-154 | "%(1)s" % {1: 2, "1": 2}
-155 | 
-156 | "%(and)s" % {"and": 2}
-    | ^^^^^^^^^^^^^^^^^^^^^^ UP031
+151 | "%c" % (some_string,)
+152 | 
+153 | "%.2r" % (1.25)
+    | ^^^^^^ UP031
+154 | 
+155 | "%.*s" % (5, "hi")
+    |
+    = help: Replace with format specifiers
+
+UP031_0.py:155:1: UP031 Use format specifiers instead of percent format
+    |
+153 | "%.2r" % (1.25)
+154 | 
+155 | "%.*s" % (5, "hi")
+    | ^^^^^^ UP031
+156 | 
+157 | "%i" % (flt,)
+    |
+    = help: Replace with format specifiers
+
+UP031_0.py:157:1: UP031 Use format specifiers instead of percent format
+    |
+155 | "%.*s" % (5, "hi")
+156 | 
+157 | "%i" % (flt,)
+    | ^^^^ UP031
+158 | 
+159 | "%()s" % {"": "empty"}
+    |
+    = help: Replace with format specifiers
+
+UP031_0.py:159:1: UP031 Use format specifiers instead of percent format
+    |
+157 | "%i" % (flt,)
+158 | 
+159 | "%()s" % {"": "empty"}
+    | ^^^^^^ UP031
+160 | 
+161 | "%s" % {"k": "v"}
+    |
+    = help: Replace with format specifiers
+
+UP031_0.py:161:1: UP031 Use format specifiers instead of percent format
+    |
+159 | "%()s" % {"": "empty"}
+160 | 
+161 | "%s" % {"k": "v"}
+    | ^^^^ UP031
+162 | 
+163 | "%()s" % {"": "bar"}
+    |
+    = help: Replace with format specifiers
+
+UP031_0.py:163:1: UP031 Use format specifiers instead of percent format
+    |
+161 | "%s" % {"k": "v"}
+162 | 
+163 | "%()s" % {"": "bar"}
+    | ^^^^^^ UP031
+164 | 
+165 | "%(1)s" % {"1": "bar"}
+    |
+    = help: Replace with format specifiers
+
+UP031_0.py:165:1: UP031 Use format specifiers instead of percent format
+    |
+163 | "%()s" % {"": "bar"}
+164 | 
+165 | "%(1)s" % {"1": "bar"}
+    | ^^^^^^^ UP031
+166 | 
+167 | "%(a)s" % {"a": 1, "a": 2}
+    |
+    = help: Replace with format specifiers
+
+UP031_0.py:167:1: UP031 Use format specifiers instead of percent format
+    |
+165 | "%(1)s" % {"1": "bar"}
+166 | 
+167 | "%(a)s" % {"a": 1, "a": 2}
+    | ^^^^^^^ UP031
+168 | 
+169 | "%(1)s" % {1: 2, "1": 2}
+    |
+    = help: Replace with format specifiers
+
+UP031_0.py:169:1: UP031 Use format specifiers instead of percent format
+    |
+167 | "%(a)s" % {"a": 1, "a": 2}
+168 | 
+169 | "%(1)s" % {1: 2, "1": 2}
+    | ^^^^^^^ UP031
+170 | 
+171 | "%(and)s" % {"and": 2}
+    |
+    = help: Replace with format specifiers
+
+UP031_0.py:171:1: UP031 Use format specifiers instead of percent format
+    |
+169 | "%(1)s" % {1: 2, "1": 2}
+170 | 
+171 | "%(and)s" % {"and": 2}
+    | ^^^^^^^^^ UP031
     |
     = help: Replace with format specifiers

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP031_0.py.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP031_0.py.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff_linter/src/rules/pyupgrade/mod.rs
 ---
-UP031_0.py:4:7: UP031 [*] Use format specifiers instead of percent format
+UP031_0.py:4:7: UP031 [*] Use format specifiers or f-strings instead of percent format
   |
 3 | # UP031
 4 | print('%s %s' % (a, b))
@@ -21,7 +21,7 @@ UP031_0.py:4:7: UP031 [*] Use format specifiers instead of percent format
 6 6 | print('%s%s' % (a, b))
 7 7 | 
 
-UP031_0.py:6:7: UP031 [*] Use format specifiers instead of percent format
+UP031_0.py:6:7: UP031 [*] Use format specifiers or f-strings instead of percent format
   |
 4 | print('%s %s' % (a, b))
 5 | 
@@ -42,7 +42,7 @@ UP031_0.py:6:7: UP031 [*] Use format specifiers instead of percent format
 8 8 | print("trivial" % ())
 9 9 | 
 
-UP031_0.py:8:7: UP031 [*] Use format specifiers instead of percent format
+UP031_0.py:8:7: UP031 [*] Use format specifiers or f-strings instead of percent format
    |
  6 | print('%s%s' % (a, b))
  7 | 
@@ -63,7 +63,7 @@ UP031_0.py:8:7: UP031 [*] Use format specifiers instead of percent format
 10 10 | print("%s" % ("simple",))
 11 11 | 
 
-UP031_0.py:10:7: UP031 [*] Use format specifiers instead of percent format
+UP031_0.py:10:7: UP031 [*] Use format specifiers or f-strings instead of percent format
    |
  8 | print("trivial" % ())
  9 | 
@@ -84,7 +84,7 @@ UP031_0.py:10:7: UP031 [*] Use format specifiers instead of percent format
 12 12 | print("%s" % ("%s" % ("nested",),))
 13 13 | 
 
-UP031_0.py:12:7: UP031 [*] Use format specifiers instead of percent format
+UP031_0.py:12:7: UP031 [*] Use format specifiers or f-strings instead of percent format
    |
 10 | print("%s" % ("simple",))
 11 | 
@@ -105,7 +105,7 @@ UP031_0.py:12:7: UP031 [*] Use format specifiers instead of percent format
 14 14 | print("%s%% percent" % (15,))
 15 15 | 
 
-UP031_0.py:12:15: UP031 [*] Use format specifiers instead of percent format
+UP031_0.py:12:15: UP031 [*] Use format specifiers or f-strings instead of percent format
    |
 10 | print("%s" % ("simple",))
 11 | 
@@ -126,7 +126,7 @@ UP031_0.py:12:15: UP031 [*] Use format specifiers instead of percent format
 14 14 | print("%s%% percent" % (15,))
 15 15 | 
 
-UP031_0.py:14:7: UP031 [*] Use format specifiers instead of percent format
+UP031_0.py:14:7: UP031 [*] Use format specifiers or f-strings instead of percent format
    |
 12 | print("%s" % ("%s" % ("nested",),))
 13 | 
@@ -147,7 +147,7 @@ UP031_0.py:14:7: UP031 [*] Use format specifiers instead of percent format
 16 16 | print("%f" % (15,))
 17 17 | 
 
-UP031_0.py:16:7: UP031 [*] Use format specifiers instead of percent format
+UP031_0.py:16:7: UP031 [*] Use format specifiers or f-strings instead of percent format
    |
 14 | print("%s%% percent" % (15,))
 15 | 
@@ -168,7 +168,7 @@ UP031_0.py:16:7: UP031 [*] Use format specifiers instead of percent format
 18 18 | print("%.f" % (15,))
 19 19 | 
 
-UP031_0.py:18:7: UP031 [*] Use format specifiers instead of percent format
+UP031_0.py:18:7: UP031 [*] Use format specifiers or f-strings instead of percent format
    |
 16 | print("%f" % (15,))
 17 | 
@@ -189,7 +189,7 @@ UP031_0.py:18:7: UP031 [*] Use format specifiers instead of percent format
 20 20 | print("%.3f" % (15,))
 21 21 | 
 
-UP031_0.py:20:7: UP031 [*] Use format specifiers instead of percent format
+UP031_0.py:20:7: UP031 [*] Use format specifiers or f-strings instead of percent format
    |
 18 | print("%.f" % (15,))
 19 | 
@@ -210,7 +210,7 @@ UP031_0.py:20:7: UP031 [*] Use format specifiers instead of percent format
 22 22 | print("%3f" % (15,))
 23 23 | 
 
-UP031_0.py:22:7: UP031 [*] Use format specifiers instead of percent format
+UP031_0.py:22:7: UP031 [*] Use format specifiers or f-strings instead of percent format
    |
 20 | print("%.3f" % (15,))
 21 | 
@@ -231,7 +231,7 @@ UP031_0.py:22:7: UP031 [*] Use format specifiers instead of percent format
 24 24 | print("%-5f" % (5,))
 25 25 | 
 
-UP031_0.py:24:7: UP031 [*] Use format specifiers instead of percent format
+UP031_0.py:24:7: UP031 [*] Use format specifiers or f-strings instead of percent format
    |
 22 | print("%3f" % (15,))
 23 | 
@@ -252,7 +252,7 @@ UP031_0.py:24:7: UP031 [*] Use format specifiers instead of percent format
 26 26 | print("%9f" % (5,))
 27 27 | 
 
-UP031_0.py:26:7: UP031 [*] Use format specifiers instead of percent format
+UP031_0.py:26:7: UP031 [*] Use format specifiers or f-strings instead of percent format
    |
 24 | print("%-5f" % (5,))
 25 | 
@@ -273,7 +273,7 @@ UP031_0.py:26:7: UP031 [*] Use format specifiers instead of percent format
 28 28 | print("%#o" % (123,))
 29 29 | 
 
-UP031_0.py:28:7: UP031 [*] Use format specifiers instead of percent format
+UP031_0.py:28:7: UP031 [*] Use format specifiers or f-strings instead of percent format
    |
 26 | print("%9f" % (5,))
 27 | 
@@ -294,14 +294,14 @@ UP031_0.py:28:7: UP031 [*] Use format specifiers instead of percent format
 30 30 | print("brace {} %s" % (1,))
 31 31 | 
 
-UP031_0.py:30:7: UP031 [*] Use format specifiers instead of percent format
+UP031_0.py:30:7: UP031 [*] Use format specifiers or f-strings instead of percent format
    |
 28 | print("%#o" % (123,))
 29 | 
 30 | print("brace {} %s" % (1,))
    |       ^^^^^^^^^^^^^^^^^^^^ UP031
 31 | 
-32 | print((
+32 | print(
    |
    = help: Replace with format specifiers
 
@@ -312,848 +312,845 @@ UP031_0.py:30:7: UP031 [*] Use format specifiers instead of percent format
 30    |-print("brace {} %s" % (1,))
    30 |+print("brace {{}} {}".format(1))
 31 31 | 
-32 32 | print((
-33 33 |     "foo %s "
+32 32 | print(
+33 33 |   "%s" % (
 
-UP031_0.py:33:5: UP031 [*] Use format specifiers instead of percent format
+UP031_0.py:33:3: UP031 [*] Use format specifiers or f-strings instead of percent format
    |
-32 |   print((
-33 |       "foo %s "
-   |  _____^
-34 | |     "bar %s" % (x, y)
-   | |_____________________^ UP031
-35 |   ))
+32 |   print(
+33 |     "%s" % (
+   |  ___^
+34 | |     "trailing comma",
+35 | |         )
+   | |_________^ UP031
+36 |   )
    |
    = help: Replace with format specifiers
 
 ℹ Unsafe fix
 30 30 | print("brace {} %s" % (1,))
 31 31 | 
-32 32 | print((
-33    |-    "foo %s "
-34    |-    "bar %s" % (x, y)
-   33 |+    "foo {} "
-   34 |+    "bar {}".format(x, y)
-35 35 | ))
-36 36 | 
-37 37 | print(
+32 32 | print(
+33    |-  "%s" % (
+   33 |+  "{}".format(
+34 34 |     "trailing comma",
+35 35 |         )
+36 36 | )
 
-UP031_0.py:38:3: UP031 [*] Use format specifiers instead of percent format
+UP031_0.py:38:7: UP031 [*] Use format specifiers or f-strings instead of percent format
    |
-37 |   print(
-38 |     "%s" % (
-   |  ___^
-39 | |     "trailing comma",
-40 | |         )
-   | |_________^ UP031
-41 |   )
-   |
-   = help: Replace with format specifiers
-
-ℹ Unsafe fix
-35 35 | ))
-36 36 | 
-37 37 | print(
-38    |-  "%s" % (
-   38 |+  "{}".format(
-39 39 |     "trailing comma",
-40 40 |         )
-41 41 | )
-
-UP031_0.py:43:7: UP031 [*] Use format specifiers instead of percent format
-   |
-41 | )
-42 | 
-43 | print("foo %s " % (x,))
+36 | )
+37 | 
+38 | print("foo %s " % (x,))
    |       ^^^^^^^^^^^^^^^^ UP031
-44 | 
-45 | print("%(k)s" % {"k": "v"})
+39 | 
+40 | print("%(k)s" % {"k": "v"})
    |
    = help: Replace with format specifiers
 
 ℹ Unsafe fix
-40 40 |         )
-41 41 | )
-42 42 | 
-43    |-print("foo %s " % (x,))
-   43 |+print("foo {} ".format(x))
-44 44 | 
-45 45 | print("%(k)s" % {"k": "v"})
-46 46 | 
+35 35 |         )
+36 36 | )
+37 37 | 
+38    |-print("foo %s " % (x,))
+   38 |+print("foo {} ".format(x))
+39 39 | 
+40 40 | print("%(k)s" % {"k": "v"})
+41 41 | 
 
-UP031_0.py:45:7: UP031 [*] Use format specifiers instead of percent format
+UP031_0.py:40:7: UP031 [*] Use format specifiers or f-strings instead of percent format
    |
-43 | print("foo %s " % (x,))
-44 | 
-45 | print("%(k)s" % {"k": "v"})
+38 | print("foo %s " % (x,))
+39 | 
+40 | print("%(k)s" % {"k": "v"})
    |       ^^^^^^^^^^^^^^^^^^^^ UP031
-46 | 
-47 | print("%(k)s" % {
+41 | 
+42 | print("%(k)s" % {
    |
    = help: Replace with format specifiers
 
 ℹ Unsafe fix
-42 42 | 
-43 43 | print("foo %s " % (x,))
-44 44 | 
-45    |-print("%(k)s" % {"k": "v"})
-   45 |+print("{k}".format(k="v"))
-46 46 | 
-47 47 | print("%(k)s" % {
-48 48 |     "k": "v",
+37 37 | 
+38 38 | print("foo %s " % (x,))
+39 39 | 
+40    |-print("%(k)s" % {"k": "v"})
+   40 |+print("{k}".format(k="v"))
+41 41 | 
+42 42 | print("%(k)s" % {
+43 43 |     "k": "v",
 
-UP031_0.py:47:7: UP031 [*] Use format specifiers instead of percent format
+UP031_0.py:42:7: UP031 [*] Use format specifiers or f-strings instead of percent format
    |
-45 |   print("%(k)s" % {"k": "v"})
-46 |   
-47 |   print("%(k)s" % {
+40 |   print("%(k)s" % {"k": "v"})
+41 |   
+42 |   print("%(k)s" % {
    |  _______^
-48 | |     "k": "v",
-49 | |     "i": "j"
-50 | | })
+43 | |     "k": "v",
+44 | |     "i": "j"
+45 | | })
    | |_^ UP031
-51 |   
-52 |   print("%(to_list)s" % {"to_list": []})
+46 |   
+47 |   print("%(to_list)s" % {"to_list": []})
    |
    = help: Replace with format specifiers
 
 ℹ Unsafe fix
-44 44 | 
-45 45 | print("%(k)s" % {"k": "v"})
+39 39 | 
+40 40 | print("%(k)s" % {"k": "v"})
+41 41 | 
+42    |-print("%(k)s" % {
+43    |-    "k": "v",
+44    |-    "i": "j"
+45    |-})
+   42 |+print("{k}".format(
+   43 |+    k="v",
+   44 |+    i="j",
+   45 |+))
 46 46 | 
-47    |-print("%(k)s" % {
-48    |-    "k": "v",
-49    |-    "i": "j"
-50    |-})
-   47 |+print("{k}".format(
-   48 |+    k="v",
-   49 |+    i="j",
-   50 |+))
-51 51 | 
-52 52 | print("%(to_list)s" % {"to_list": []})
-53 53 | 
+47 47 | print("%(to_list)s" % {"to_list": []})
+48 48 | 
 
-UP031_0.py:52:7: UP031 [*] Use format specifiers instead of percent format
+UP031_0.py:47:7: UP031 [*] Use format specifiers or f-strings instead of percent format
    |
-50 | })
-51 | 
-52 | print("%(to_list)s" % {"to_list": []})
+45 | })
+46 | 
+47 | print("%(to_list)s" % {"to_list": []})
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ UP031
-53 | 
-54 | print("%(k)s" % {"k": "v", "i": 1, "j": []})
+48 | 
+49 | print("%(k)s" % {"k": "v", "i": 1, "j": []})
    |
    = help: Replace with format specifiers
 
 ℹ Unsafe fix
-49 49 |     "i": "j"
-50 50 | })
-51 51 | 
-52    |-print("%(to_list)s" % {"to_list": []})
-   52 |+print("{to_list}".format(to_list=[]))
-53 53 | 
-54 54 | print("%(k)s" % {"k": "v", "i": 1, "j": []})
-55 55 | 
+44 44 |     "i": "j"
+45 45 | })
+46 46 | 
+47    |-print("%(to_list)s" % {"to_list": []})
+   47 |+print("{to_list}".format(to_list=[]))
+48 48 | 
+49 49 | print("%(k)s" % {"k": "v", "i": 1, "j": []})
+50 50 | 
 
-UP031_0.py:54:7: UP031 [*] Use format specifiers instead of percent format
+UP031_0.py:49:7: UP031 [*] Use format specifiers or f-strings instead of percent format
    |
-52 | print("%(to_list)s" % {"to_list": []})
-53 | 
-54 | print("%(k)s" % {"k": "v", "i": 1, "j": []})
+47 | print("%(to_list)s" % {"to_list": []})
+48 | 
+49 | print("%(k)s" % {"k": "v", "i": 1, "j": []})
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ UP031
-55 | 
-56 | print("%(ab)s" % {"a" "b": 1})
+50 | 
+51 | print("%(ab)s" % {"a" "b": 1})
    |
    = help: Replace with format specifiers
 
 ℹ Unsafe fix
-51 51 | 
-52 52 | print("%(to_list)s" % {"to_list": []})
-53 53 | 
-54    |-print("%(k)s" % {"k": "v", "i": 1, "j": []})
-   54 |+print("{k}".format(k="v", i=1, j=[]))
-55 55 | 
-56 56 | print("%(ab)s" % {"a" "b": 1})
-57 57 | 
+46 46 | 
+47 47 | print("%(to_list)s" % {"to_list": []})
+48 48 | 
+49    |-print("%(k)s" % {"k": "v", "i": 1, "j": []})
+   49 |+print("{k}".format(k="v", i=1, j=[]))
+50 50 | 
+51 51 | print("%(ab)s" % {"a" "b": 1})
+52 52 | 
 
-UP031_0.py:56:7: UP031 [*] Use format specifiers instead of percent format
+UP031_0.py:51:7: UP031 [*] Use format specifiers or f-strings instead of percent format
    |
-54 | print("%(k)s" % {"k": "v", "i": 1, "j": []})
-55 | 
-56 | print("%(ab)s" % {"a" "b": 1})
+49 | print("%(k)s" % {"k": "v", "i": 1, "j": []})
+50 | 
+51 | print("%(ab)s" % {"a" "b": 1})
    |       ^^^^^^^^^^^^^^^^^^^^^^^ UP031
-57 | 
-58 | print("%(a)s" % {"a"  :  1})
+52 | 
+53 | print("%(a)s" % {"a"  :  1})
    |
    = help: Replace with format specifiers
 
 ℹ Unsafe fix
-53 53 | 
-54 54 | print("%(k)s" % {"k": "v", "i": 1, "j": []})
-55 55 | 
-56    |-print("%(ab)s" % {"a" "b": 1})
-   56 |+print("{ab}".format(ab=1))
-57 57 | 
-58 58 | print("%(a)s" % {"a"  :  1})
-59 59 | 
+48 48 | 
+49 49 | print("%(k)s" % {"k": "v", "i": 1, "j": []})
+50 50 | 
+51    |-print("%(ab)s" % {"a" "b": 1})
+   51 |+print("{ab}".format(ab=1))
+52 52 | 
+53 53 | print("%(a)s" % {"a"  :  1})
+54 54 | 
 
-UP031_0.py:58:7: UP031 [*] Use format specifiers instead of percent format
+UP031_0.py:53:7: UP031 [*] Use format specifiers or f-strings instead of percent format
    |
-56 | print("%(ab)s" % {"a" "b": 1})
-57 | 
-58 | print("%(a)s" % {"a"  :  1})
+51 | print("%(ab)s" % {"a" "b": 1})
+52 | 
+53 | print("%(a)s" % {"a"  :  1})
    |       ^^^^^^^^^^^^^^^^^^^^^ UP031
+54 | 
+55 | print((
    |
    = help: Replace with format specifiers
 
 ℹ Unsafe fix
-55 55 | 
-56 56 | print("%(ab)s" % {"a" "b": 1})
-57 57 | 
-58    |-print("%(a)s" % {"a"  :  1})
-   58 |+print("{a}".format(a=1))
-59 59 | 
-60 60 | 
-61 61 | print(
+50 50 | 
+51 51 | print("%(ab)s" % {"a" "b": 1})
+52 52 | 
+53    |-print("%(a)s" % {"a"  :  1})
+   53 |+print("{a}".format(a=1))
+54 54 | 
+55 55 | print((
+56 56 |     "foo %s "
 
-UP031_0.py:62:5: UP031 [*] Use format specifiers instead of percent format
+UP031_0.py:56:5: UP031 [*] Use format specifiers or f-strings instead of percent format
    |
-61 |   print(
-62 |       "foo %(foo)s "
+55 |   print((
+56 |       "foo %s "
    |  _____^
-63 | |     "bar %(bar)s" % {"foo": x, "bar": y}
+57 | |     "bar %s" % (x, y)
+   | |_____________________^ UP031
+58 |   ))
+   |
+   = help: Replace with format specifiers
+
+ℹ Unsafe fix
+53 53 | print("%(a)s" % {"a"  :  1})
+54 54 | 
+55 55 | print((
+56    |-    "foo %s "
+57    |-    "bar %s" % (x, y)
+   56 |+    "foo {} "
+   57 |+    "bar {}".format(x, y)
+58 58 | ))
+59 59 | 
+60 60 | print(
+
+UP031_0.py:61:5: UP031 [*] Use format specifiers or f-strings instead of percent format
+   |
+60 |   print(
+61 |       "foo %(foo)s "
+   |  _____^
+62 | |     "bar %(bar)s" % {"foo": x, "bar": y}
    | |________________________________________^ UP031
-64 |   )
+63 |   )
    |
    = help: Replace with format specifiers
 
 ℹ Unsafe fix
+58 58 | ))
 59 59 | 
-60 60 | 
-61 61 | print(
-62    |-    "foo %(foo)s "
-63    |-    "bar %(bar)s" % {"foo": x, "bar": y}
-   62 |+    "foo {foo} "
-   63 |+    "bar {bar}".format(foo=x, bar=y)
-64 64 | )
-65 65 | 
-66 66 | bar = {"bar": y}
+60 60 | print(
+61    |-    "foo %(foo)s "
+62    |-    "bar %(bar)s" % {"foo": x, "bar": y}
+   61 |+    "foo {foo} "
+   62 |+    "bar {bar}".format(foo=x, bar=y)
+63 63 | )
+64 64 | 
+65 65 | bar = {"bar": y}
 
-UP031_0.py:68:5: UP031 [*] Use format specifiers instead of percent format
+UP031_0.py:67:5: UP031 [*] Use format specifiers or f-strings instead of percent format
    |
-66 |   bar = {"bar": y}
-67 |   print(
-68 |       "foo %(foo)s "
+65 |   bar = {"bar": y}
+66 |   print(
+67 |       "foo %(foo)s "
    |  _____^
-69 | |     "bar %(bar)s" % {"foo": x, **bar}
+68 | |     "bar %(bar)s" % {"foo": x, **bar}
    | |_____________________________________^ UP031
-70 |   )
+69 |   )
    |
    = help: Replace with format specifiers
 
 ℹ Unsafe fix
-65 65 | 
-66 66 | bar = {"bar": y}
-67 67 | print(
-68    |-    "foo %(foo)s "
-69    |-    "bar %(bar)s" % {"foo": x, **bar}
-   68 |+    "foo {foo} "
-   69 |+    "bar {bar}".format(foo=x, **bar)
-70 70 | )
-71 71 | 
-72 72 | print("%s \N{snowman}" % (a,))
+64 64 | 
+65 65 | bar = {"bar": y}
+66 66 | print(
+67    |-    "foo %(foo)s "
+68    |-    "bar %(bar)s" % {"foo": x, **bar}
+   67 |+    "foo {foo} "
+   68 |+    "bar {bar}".format(foo=x, **bar)
+69 69 | )
+70 70 | 
+71 71 | print("%s \N{snowman}" % (a,))
 
-UP031_0.py:72:7: UP031 [*] Use format specifiers instead of percent format
+UP031_0.py:71:7: UP031 [*] Use format specifiers or f-strings instead of percent format
    |
-70 | )
-71 | 
-72 | print("%s \N{snowman}" % (a,))
+69 | )
+70 | 
+71 | print("%s \N{snowman}" % (a,))
    |       ^^^^^^^^^^^^^^^^^^^^^^^ UP031
-73 | 
-74 | print("%(foo)s \N{snowman}" % {"foo": 1})
+72 | 
+73 | print("%(foo)s \N{snowman}" % {"foo": 1})
    |
    = help: Replace with format specifiers
 
 ℹ Unsafe fix
-69 69 |     "bar %(bar)s" % {"foo": x, **bar}
-70 70 | )
-71 71 | 
-72    |-print("%s \N{snowman}" % (a,))
-   72 |+print("{} \N{snowman}".format(a))
-73 73 | 
-74 74 | print("%(foo)s \N{snowman}" % {"foo": 1})
-75 75 | 
+68 68 |     "bar %(bar)s" % {"foo": x, **bar}
+69 69 | )
+70 70 | 
+71    |-print("%s \N{snowman}" % (a,))
+   71 |+print("{} \N{snowman}".format(a))
+72 72 | 
+73 73 | print("%(foo)s \N{snowman}" % {"foo": 1})
+74 74 | 
 
-UP031_0.py:74:7: UP031 [*] Use format specifiers instead of percent format
+UP031_0.py:73:7: UP031 [*] Use format specifiers or f-strings instead of percent format
    |
-72 | print("%s \N{snowman}" % (a,))
-73 | 
-74 | print("%(foo)s \N{snowman}" % {"foo": 1})
+71 | print("%s \N{snowman}" % (a,))
+72 | 
+73 | print("%(foo)s \N{snowman}" % {"foo": 1})
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ UP031
-75 | 
-76 | print(("foo %s " "bar %s") % (x, y))
+74 | 
+75 | print(("foo %s " "bar %s") % (x, y))
    |
    = help: Replace with format specifiers
 
 ℹ Unsafe fix
-71 71 | 
-72 72 | print("%s \N{snowman}" % (a,))
-73 73 | 
-74    |-print("%(foo)s \N{snowman}" % {"foo": 1})
-   74 |+print("{foo} \N{snowman}".format(foo=1))
-75 75 | 
-76 76 | print(("foo %s " "bar %s") % (x, y))
-77 77 | 
+70 70 | 
+71 71 | print("%s \N{snowman}" % (a,))
+72 72 | 
+73    |-print("%(foo)s \N{snowman}" % {"foo": 1})
+   73 |+print("{foo} \N{snowman}".format(foo=1))
+74 74 | 
+75 75 | print(("foo %s " "bar %s") % (x, y))
+76 76 | 
 
-UP031_0.py:76:7: UP031 [*] Use format specifiers instead of percent format
+UP031_0.py:75:7: UP031 [*] Use format specifiers or f-strings instead of percent format
    |
-74 | print("%(foo)s \N{snowman}" % {"foo": 1})
-75 | 
-76 | print(("foo %s " "bar %s") % (x, y))
+73 | print("%(foo)s \N{snowman}" % {"foo": 1})
+74 | 
+75 | print(("foo %s " "bar %s") % (x, y))
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ UP031
-77 | 
-78 | # Single-value expressions
+76 | 
+77 | # Single-value expressions
    |
    = help: Replace with format specifiers
 
 ℹ Unsafe fix
-73 73 | 
-74 74 | print("%(foo)s \N{snowman}" % {"foo": 1})
-75 75 | 
-76    |-print(("foo %s " "bar %s") % (x, y))
-   76 |+print(("foo {} " "bar {}").format(x, y))
-77 77 | 
-78 78 | # Single-value expressions
-79 79 | print('Hello %s' % "World")
+72 72 | 
+73 73 | print("%(foo)s \N{snowman}" % {"foo": 1})
+74 74 | 
+75    |-print(("foo %s " "bar %s") % (x, y))
+   75 |+print(("foo {} " "bar {}").format(x, y))
+76 76 | 
+77 77 | # Single-value expressions
+78 78 | print('Hello %s' % "World")
 
-UP031_0.py:79:7: UP031 [*] Use format specifiers instead of percent format
+UP031_0.py:78:7: UP031 [*] Use format specifiers or f-strings instead of percent format
    |
-78 | # Single-value expressions
-79 | print('Hello %s' % "World")
+77 | # Single-value expressions
+78 | print('Hello %s' % "World")
    |       ^^^^^^^^^^^^^^^^^^^^ UP031
-80 | print('Hello %s' % f"World")
-81 | print('Hello %s (%s)' % bar)
+79 | print('Hello %s' % f"World")
+80 | print('Hello %s (%s)' % bar)
    |
    = help: Replace with format specifiers
 
 ℹ Unsafe fix
-76 76 | print(("foo %s " "bar %s") % (x, y))
-77 77 | 
-78 78 | # Single-value expressions
-79    |-print('Hello %s' % "World")
-   79 |+print('Hello {}'.format("World"))
-80 80 | print('Hello %s' % f"World")
-81 81 | print('Hello %s (%s)' % bar)
-82 82 | print('Hello %s (%s)' % bar.baz)
+75 75 | print(("foo %s " "bar %s") % (x, y))
+76 76 | 
+77 77 | # Single-value expressions
+78    |-print('Hello %s' % "World")
+   78 |+print('Hello {}'.format("World"))
+79 79 | print('Hello %s' % f"World")
+80 80 | print('Hello %s (%s)' % bar)
+81 81 | print('Hello %s (%s)' % bar.baz)
 
-UP031_0.py:80:7: UP031 [*] Use format specifiers instead of percent format
+UP031_0.py:79:7: UP031 [*] Use format specifiers or f-strings instead of percent format
    |
-78 | # Single-value expressions
-79 | print('Hello %s' % "World")
-80 | print('Hello %s' % f"World")
+77 | # Single-value expressions
+78 | print('Hello %s' % "World")
+79 | print('Hello %s' % f"World")
    |       ^^^^^^^^^^^^^^^^^^^^^ UP031
-81 | print('Hello %s (%s)' % bar)
-82 | print('Hello %s (%s)' % bar.baz)
+80 | print('Hello %s (%s)' % bar)
+81 | print('Hello %s (%s)' % bar.baz)
    |
    = help: Replace with format specifiers
 
 ℹ Unsafe fix
-77 77 | 
-78 78 | # Single-value expressions
-79 79 | print('Hello %s' % "World")
-80    |-print('Hello %s' % f"World")
-   80 |+print('Hello {}'.format(f"World"))
-81 81 | print('Hello %s (%s)' % bar)
-82 82 | print('Hello %s (%s)' % bar.baz)
-83 83 | print('Hello %s (%s)' % bar['bop'])
+76 76 | 
+77 77 | # Single-value expressions
+78 78 | print('Hello %s' % "World")
+79    |-print('Hello %s' % f"World")
+   79 |+print('Hello {}'.format(f"World"))
+80 80 | print('Hello %s (%s)' % bar)
+81 81 | print('Hello %s (%s)' % bar.baz)
+82 82 | print('Hello %s (%s)' % bar['bop'])
 
-UP031_0.py:81:7: UP031 [*] Use format specifiers instead of percent format
+UP031_0.py:80:7: UP031 [*] Use format specifiers or f-strings instead of percent format
    |
-79 | print('Hello %s' % "World")
-80 | print('Hello %s' % f"World")
-81 | print('Hello %s (%s)' % bar)
+78 | print('Hello %s' % "World")
+79 | print('Hello %s' % f"World")
+80 | print('Hello %s (%s)' % bar)
    |       ^^^^^^^^^^^^^^^^^^^^^ UP031
-82 | print('Hello %s (%s)' % bar.baz)
-83 | print('Hello %s (%s)' % bar['bop'])
+81 | print('Hello %s (%s)' % bar.baz)
+82 | print('Hello %s (%s)' % bar['bop'])
    |
    = help: Replace with format specifiers
 
 ℹ Unsafe fix
-78 78 | # Single-value expressions
-79 79 | print('Hello %s' % "World")
-80 80 | print('Hello %s' % f"World")
-81    |-print('Hello %s (%s)' % bar)
-   81 |+print('Hello {} ({})'.format(*bar))
-82 82 | print('Hello %s (%s)' % bar.baz)
-83 83 | print('Hello %s (%s)' % bar['bop'])
-84 84 | print('Hello %(arg)s' % bar)
+77 77 | # Single-value expressions
+78 78 | print('Hello %s' % "World")
+79 79 | print('Hello %s' % f"World")
+80    |-print('Hello %s (%s)' % bar)
+   80 |+print('Hello {} ({})'.format(*bar))
+81 81 | print('Hello %s (%s)' % bar.baz)
+82 82 | print('Hello %s (%s)' % bar['bop'])
+83 83 | print('Hello %(arg)s' % bar)
 
-UP031_0.py:82:7: UP031 [*] Use format specifiers instead of percent format
+UP031_0.py:81:7: UP031 [*] Use format specifiers or f-strings instead of percent format
    |
-80 | print('Hello %s' % f"World")
-81 | print('Hello %s (%s)' % bar)
-82 | print('Hello %s (%s)' % bar.baz)
+79 | print('Hello %s' % f"World")
+80 | print('Hello %s (%s)' % bar)
+81 | print('Hello %s (%s)' % bar.baz)
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^ UP031
-83 | print('Hello %s (%s)' % bar['bop'])
-84 | print('Hello %(arg)s' % bar)
+82 | print('Hello %s (%s)' % bar['bop'])
+83 | print('Hello %(arg)s' % bar)
    |
    = help: Replace with format specifiers
 
 ℹ Unsafe fix
-79 79 | print('Hello %s' % "World")
-80 80 | print('Hello %s' % f"World")
-81 81 | print('Hello %s (%s)' % bar)
-82    |-print('Hello %s (%s)' % bar.baz)
-   82 |+print('Hello {} ({})'.format(*bar.baz))
-83 83 | print('Hello %s (%s)' % bar['bop'])
-84 84 | print('Hello %(arg)s' % bar)
-85 85 | print('Hello %(arg)s' % bar.baz)
+78 78 | print('Hello %s' % "World")
+79 79 | print('Hello %s' % f"World")
+80 80 | print('Hello %s (%s)' % bar)
+81    |-print('Hello %s (%s)' % bar.baz)
+   81 |+print('Hello {} ({})'.format(*bar.baz))
+82 82 | print('Hello %s (%s)' % bar['bop'])
+83 83 | print('Hello %(arg)s' % bar)
+84 84 | print('Hello %(arg)s' % bar.baz)
 
-UP031_0.py:83:7: UP031 [*] Use format specifiers instead of percent format
+UP031_0.py:82:7: UP031 [*] Use format specifiers or f-strings instead of percent format
    |
-81 | print('Hello %s (%s)' % bar)
-82 | print('Hello %s (%s)' % bar.baz)
-83 | print('Hello %s (%s)' % bar['bop'])
+80 | print('Hello %s (%s)' % bar)
+81 | print('Hello %s (%s)' % bar.baz)
+82 | print('Hello %s (%s)' % bar['bop'])
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ UP031
-84 | print('Hello %(arg)s' % bar)
-85 | print('Hello %(arg)s' % bar.baz)
+83 | print('Hello %(arg)s' % bar)
+84 | print('Hello %(arg)s' % bar.baz)
    |
    = help: Replace with format specifiers
 
 ℹ Unsafe fix
-80 80 | print('Hello %s' % f"World")
-81 81 | print('Hello %s (%s)' % bar)
-82 82 | print('Hello %s (%s)' % bar.baz)
-83    |-print('Hello %s (%s)' % bar['bop'])
-   83 |+print('Hello {} ({})'.format(*bar['bop']))
-84 84 | print('Hello %(arg)s' % bar)
-85 85 | print('Hello %(arg)s' % bar.baz)
-86 86 | print('Hello %(arg)s' % bar['bop'])
+79 79 | print('Hello %s' % f"World")
+80 80 | print('Hello %s (%s)' % bar)
+81 81 | print('Hello %s (%s)' % bar.baz)
+82    |-print('Hello %s (%s)' % bar['bop'])
+   82 |+print('Hello {} ({})'.format(*bar['bop']))
+83 83 | print('Hello %(arg)s' % bar)
+84 84 | print('Hello %(arg)s' % bar.baz)
+85 85 | print('Hello %(arg)s' % bar['bop'])
 
-UP031_0.py:84:7: UP031 [*] Use format specifiers instead of percent format
+UP031_0.py:83:7: UP031 [*] Use format specifiers or f-strings instead of percent format
    |
-82 | print('Hello %s (%s)' % bar.baz)
-83 | print('Hello %s (%s)' % bar['bop'])
-84 | print('Hello %(arg)s' % bar)
+81 | print('Hello %s (%s)' % bar.baz)
+82 | print('Hello %s (%s)' % bar['bop'])
+83 | print('Hello %(arg)s' % bar)
    |       ^^^^^^^^^^^^^^^^^^^^^ UP031
-85 | print('Hello %(arg)s' % bar.baz)
-86 | print('Hello %(arg)s' % bar['bop'])
+84 | print('Hello %(arg)s' % bar.baz)
+85 | print('Hello %(arg)s' % bar['bop'])
    |
    = help: Replace with format specifiers
 
 ℹ Unsafe fix
-81 81 | print('Hello %s (%s)' % bar)
-82 82 | print('Hello %s (%s)' % bar.baz)
-83 83 | print('Hello %s (%s)' % bar['bop'])
-84    |-print('Hello %(arg)s' % bar)
-   84 |+print('Hello {arg}'.format(**bar))
-85 85 | print('Hello %(arg)s' % bar.baz)
-86 86 | print('Hello %(arg)s' % bar['bop'])
-87 87 | 
+80 80 | print('Hello %s (%s)' % bar)
+81 81 | print('Hello %s (%s)' % bar.baz)
+82 82 | print('Hello %s (%s)' % bar['bop'])
+83    |-print('Hello %(arg)s' % bar)
+   83 |+print('Hello {arg}'.format(**bar))
+84 84 | print('Hello %(arg)s' % bar.baz)
+85 85 | print('Hello %(arg)s' % bar['bop'])
+86 86 | 
 
-UP031_0.py:85:7: UP031 [*] Use format specifiers instead of percent format
+UP031_0.py:84:7: UP031 [*] Use format specifiers or f-strings instead of percent format
    |
-83 | print('Hello %s (%s)' % bar['bop'])
-84 | print('Hello %(arg)s' % bar)
-85 | print('Hello %(arg)s' % bar.baz)
+82 | print('Hello %s (%s)' % bar['bop'])
+83 | print('Hello %(arg)s' % bar)
+84 | print('Hello %(arg)s' % bar.baz)
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^ UP031
-86 | print('Hello %(arg)s' % bar['bop'])
+85 | print('Hello %(arg)s' % bar['bop'])
    |
    = help: Replace with format specifiers
 
 ℹ Unsafe fix
-82 82 | print('Hello %s (%s)' % bar.baz)
-83 83 | print('Hello %s (%s)' % bar['bop'])
-84 84 | print('Hello %(arg)s' % bar)
-85    |-print('Hello %(arg)s' % bar.baz)
-   85 |+print('Hello {arg}'.format(**bar.baz))
-86 86 | print('Hello %(arg)s' % bar['bop'])
-87 87 | 
-88 88 | # Hanging modulos
+81 81 | print('Hello %s (%s)' % bar.baz)
+82 82 | print('Hello %s (%s)' % bar['bop'])
+83 83 | print('Hello %(arg)s' % bar)
+84    |-print('Hello %(arg)s' % bar.baz)
+   84 |+print('Hello {arg}'.format(**bar.baz))
+85 85 | print('Hello %(arg)s' % bar['bop'])
+86 86 | 
+87 87 | # Hanging modulos
 
-UP031_0.py:86:7: UP031 [*] Use format specifiers instead of percent format
+UP031_0.py:85:7: UP031 [*] Use format specifiers or f-strings instead of percent format
    |
-84 | print('Hello %(arg)s' % bar)
-85 | print('Hello %(arg)s' % bar.baz)
-86 | print('Hello %(arg)s' % bar['bop'])
+83 | print('Hello %(arg)s' % bar)
+84 | print('Hello %(arg)s' % bar.baz)
+85 | print('Hello %(arg)s' % bar['bop'])
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ UP031
-87 | 
-88 | # Hanging modulos
+86 | 
+87 | # Hanging modulos
    |
    = help: Replace with format specifiers
 
 ℹ Unsafe fix
-83 83 | print('Hello %s (%s)' % bar['bop'])
-84 84 | print('Hello %(arg)s' % bar)
-85 85 | print('Hello %(arg)s' % bar.baz)
-86    |-print('Hello %(arg)s' % bar['bop'])
-   86 |+print('Hello {arg}'.format(**bar['bop']))
-87 87 | 
-88 88 | # Hanging modulos
-89 89 | (
+82 82 | print('Hello %s (%s)' % bar['bop'])
+83 83 | print('Hello %(arg)s' % bar)
+84 84 | print('Hello %(arg)s' % bar.baz)
+85    |-print('Hello %(arg)s' % bar['bop'])
+   85 |+print('Hello {arg}'.format(**bar['bop']))
+86 86 | 
+87 87 | # Hanging modulos
+88 88 | (
 
-UP031_0.py:89:1: UP031 [*] Use format specifiers instead of percent format
+UP031_0.py:88:1: UP031 [*] Use format specifiers or f-strings instead of percent format
    |
-88 |   # Hanging modulos
-89 | / (
-90 | |     "foo %s "
-91 | |     "bar %s"
-92 | | ) % (x, y)
+87 |   # Hanging modulos
+88 | / (
+89 | |     "foo %s "
+90 | |     "bar %s"
+91 | | ) % (x, y)
    | |__________^ UP031
-93 |   
-94 |   (
+92 |   
+93 |   (
    |
    = help: Replace with format specifiers
 
 ℹ Unsafe fix
-87 87 | 
-88 88 | # Hanging modulos
-89 89 | (
-90    |-    "foo %s "
-91    |-    "bar %s"
-92    |-) % (x, y)
-   90 |+    "foo {} "
-   91 |+    "bar {}"
-   92 |+).format(x, y)
-93 93 | 
-94 94 | (
-95 95 |     "foo %(foo)s "
+86 86 | 
+87 87 | # Hanging modulos
+88 88 | (
+89    |-    "foo %s "
+90    |-    "bar %s"
+91    |-) % (x, y)
+   89 |+    "foo {} "
+   90 |+    "bar {}"
+   91 |+).format(x, y)
+92 92 | 
+93 93 | (
+94 94 |     "foo %(foo)s "
 
-UP031_0.py:94:1: UP031 [*] Use format specifiers instead of percent format
+UP031_0.py:93:1: UP031 [*] Use format specifiers or f-strings instead of percent format
    |
-92 |   ) % (x, y)
-93 |   
-94 | / (
-95 | |     "foo %(foo)s "
-96 | |     "bar %(bar)s"
-97 | | ) % {"foo": x, "bar": y}
+91 |   ) % (x, y)
+92 |   
+93 | / (
+94 | |     "foo %(foo)s "
+95 | |     "bar %(bar)s"
+96 | | ) % {"foo": x, "bar": y}
    | |________________________^ UP031
-98 |   
-99 |   (
+97 |   
+98 |   (
    |
    = help: Replace with format specifiers
 
 ℹ Unsafe fix
-92 92 | ) % (x, y)
-93 93 | 
-94 94 | (
-95    |-    "foo %(foo)s "
-96    |-    "bar %(bar)s"
-97    |-) % {"foo": x, "bar": y}
-   95 |+    "foo {foo} "
-   96 |+    "bar {bar}"
-   97 |+).format(foo=x, bar=y)
-98 98 | 
-99 99 | (
-100 100 |     """foo %s"""
+91 91 | ) % (x, y)
+92 92 | 
+93 93 | (
+94    |-    "foo %(foo)s "
+95    |-    "bar %(bar)s"
+96    |-) % {"foo": x, "bar": y}
+   94 |+    "foo {foo} "
+   95 |+    "bar {bar}"
+   96 |+).format(foo=x, bar=y)
+97 97 | 
+98 98 | (
+99 99 |     """foo %s"""
 
-UP031_0.py:100:5: UP031 [*] Use format specifiers instead of percent format
+UP031_0.py:99:5: UP031 [*] Use format specifiers or f-strings instead of percent format
     |
- 99 |   (
-100 |       """foo %s"""
+ 98 |   (
+ 99 |       """foo %s"""
     |  _____^
-101 | |     % (x,)
+100 | |     % (x,)
     | |__________^ UP031
-102 |   )
+101 |   )
     |
     = help: Replace with format specifiers
 
 ℹ Unsafe fix
-97  97  | ) % {"foo": x, "bar": y}
-98  98  | 
-99  99  | (
-100     |-    """foo %s"""
-101     |-    % (x,)
-    100 |+    """foo {}""".format(x)
-102 101 | )
-103 102 | 
-104 103 | (
+96  96  | ) % {"foo": x, "bar": y}
+97  97  | 
+98  98  | (
+99      |-    """foo %s"""
+100     |-    % (x,)
+    99  |+    """foo {}""".format(x)
+101 100 | )
+102 101 | 
+103 102 | (
 
-UP031_0.py:105:5: UP031 [*] Use format specifiers instead of percent format
+UP031_0.py:104:5: UP031 [*] Use format specifiers or f-strings instead of percent format
     |
-104 |   (
-105 |       """
+103 |   (
+104 |       """
     |  _____^
-106 | |     foo %s
-107 | |     """
-108 | |     % (x,)
+105 | |     foo %s
+106 | |     """
+107 | |     % (x,)
     | |__________^ UP031
-109 |   )
+108 |   )
     |
     = help: Replace with format specifiers
 
 ℹ Unsafe fix
-103 103 | 
-104 104 | (
-105 105 |     """
-106     |-    foo %s
-107     |-    """
-108     |-    % (x,)
-    106 |+    foo {}
-    107 |+    """.format(x)
-109 108 | )
-110 109 | 
-111 110 | "%s" % (
+102 102 | 
+103 103 | (
+104 104 |     """
+105     |-    foo %s
+106     |-    """
+107     |-    % (x,)
+    105 |+    foo {}
+    106 |+    """.format(x)
+108 107 | )
+109 108 | 
+110 109 | "%s" % (
 
-UP031_0.py:111:1: UP031 [*] Use format specifiers instead of percent format
+UP031_0.py:110:1: UP031 [*] Use format specifiers or f-strings instead of percent format
     |
-109 |   )
-110 |   
-111 | / "%s" % (
-112 | |     x,  # comment
-113 | | )
+108 |   )
+109 |   
+110 | / "%s" % (
+111 | |     x,  # comment
+112 | | )
     | |_^ UP031
     |
     = help: Replace with format specifiers
 
 ℹ Unsafe fix
-108 108 |     % (x,)
-109 109 | )
-110 110 | 
-111     |-"%s" % (
-    111 |+"{}".format(
-112 112 |     x,  # comment
-113 113 | )
-114 114 | 
+107 107 |     % (x,)
+108 108 | )
+109 109 | 
+110     |-"%s" % (
+    110 |+"{}".format(
+111 111 |     x,  # comment
+112 112 | )
+113 113 | 
 
-UP031_0.py:116:8: UP031 [*] Use format specifiers instead of percent format
+UP031_0.py:115:8: UP031 [*] Use format specifiers or f-strings instead of percent format
     |
-116 |   path = "%s-%s-%s.pem" % (
+115 |   path = "%s-%s-%s.pem" % (
     |  ________^
-117 | |     safe_domain_name(cn), # common name, which should be filename safe because it is IDNA-encoded, but in case of a malformed cert make sure it's ok to use as a filename
-118 | |     cert.not_valid_after.date().isoformat().replace("-", ""), # expiration date
-119 | |     hexlify(cert.fingerprint(hashes.SHA256())).decode("ascii")[0:8], # fingerprint prefix
-120 | | )
+116 | |     safe_domain_name(cn), # common name, which should be filename safe because it is IDNA-encoded, but in case of a malformed cert make sure it's ok to use as a filename
+117 | |     cert.not_valid_after.date().isoformat().replace("-", ""), # expiration date
+118 | |     hexlify(cert.fingerprint(hashes.SHA256())).decode("ascii")[0:8], # fingerprint prefix
+119 | | )
     | |_^ UP031
-121 |   
-122 |   # UP031 (no longer false negatives; now offer potentially unsafe fixes)
+120 |   
+121 |   # UP031 (no longer false negatives; now offer potentially unsafe fixes)
     |
     = help: Replace with format specifiers
 
 ℹ Unsafe fix
-113 113 | )
+112 112 | )
+113 113 | 
 114 114 | 
-115 115 | 
-116     |-path = "%s-%s-%s.pem" % (
-    116 |+path = "{}-{}-{}.pem".format(
-117 117 |     safe_domain_name(cn), # common name, which should be filename safe because it is IDNA-encoded, but in case of a malformed cert make sure it's ok to use as a filename
-118 118 |     cert.not_valid_after.date().isoformat().replace("-", ""), # expiration date
-119 119 |     hexlify(cert.fingerprint(hashes.SHA256())).decode("ascii")[0:8], # fingerprint prefix
+115     |-path = "%s-%s-%s.pem" % (
+    115 |+path = "{}-{}-{}.pem".format(
+116 116 |     safe_domain_name(cn), # common name, which should be filename safe because it is IDNA-encoded, but in case of a malformed cert make sure it's ok to use as a filename
+117 117 |     cert.not_valid_after.date().isoformat().replace("-", ""), # expiration date
+118 118 |     hexlify(cert.fingerprint(hashes.SHA256())).decode("ascii")[0:8], # fingerprint prefix
 
-UP031_0.py:123:1: UP031 [*] Use format specifiers instead of percent format
+UP031_0.py:122:1: UP031 [*] Use format specifiers or f-strings instead of percent format
     |
-122 | # UP031 (no longer false negatives; now offer potentially unsafe fixes)
-123 | 'Hello %s' % bar
+121 | # UP031 (no longer false negatives; now offer potentially unsafe fixes)
+122 | 'Hello %s' % bar
     | ^^^^^^^^^^^^^^^^ UP031
-124 | 
-125 | 'Hello %s' % bar.baz
+123 | 
+124 | 'Hello %s' % bar.baz
     |
     = help: Replace with format specifiers
 
 ℹ Unsafe fix
-120 120 | )
-121 121 | 
-122 122 | # UP031 (no longer false negatives; now offer potentially unsafe fixes)
-123     |-'Hello %s' % bar
-    123 |+'Hello {}'.format(bar)
-124 124 | 
-125 125 | 'Hello %s' % bar.baz
-126 126 | 
+119 119 | )
+120 120 | 
+121 121 | # UP031 (no longer false negatives; now offer potentially unsafe fixes)
+122     |-'Hello %s' % bar
+    122 |+'Hello {}'.format(bar)
+123 123 | 
+124 124 | 'Hello %s' % bar.baz
+125 125 | 
 
-UP031_0.py:125:1: UP031 [*] Use format specifiers instead of percent format
+UP031_0.py:124:1: UP031 [*] Use format specifiers or f-strings instead of percent format
     |
-123 | 'Hello %s' % bar
-124 | 
-125 | 'Hello %s' % bar.baz
+122 | 'Hello %s' % bar
+123 | 
+124 | 'Hello %s' % bar.baz
     | ^^^^^^^^^^^^^^^^^^^^ UP031
-126 | 
-127 | 'Hello %s' % bar['bop']
+125 | 
+126 | 'Hello %s' % bar['bop']
     |
     = help: Replace with format specifiers
 
 ℹ Unsafe fix
-122 122 | # UP031 (no longer false negatives; now offer potentially unsafe fixes)
-123 123 | 'Hello %s' % bar
-124 124 | 
-125     |-'Hello %s' % bar.baz
-    125 |+'Hello {}'.format(bar.baz)
-126 126 | 
-127 127 | 'Hello %s' % bar['bop']
-128 128 | 
+121 121 | # UP031 (no longer false negatives; now offer potentially unsafe fixes)
+122 122 | 'Hello %s' % bar
+123 123 | 
+124     |-'Hello %s' % bar.baz
+    124 |+'Hello {}'.format(bar.baz)
+125 125 | 
+126 126 | 'Hello %s' % bar['bop']
+127 127 | 
 
-UP031_0.py:127:1: UP031 [*] Use format specifiers instead of percent format
+UP031_0.py:126:1: UP031 [*] Use format specifiers or f-strings instead of percent format
     |
-125 | 'Hello %s' % bar.baz
-126 | 
-127 | 'Hello %s' % bar['bop']
+124 | 'Hello %s' % bar.baz
+125 | 
+126 | 'Hello %s' % bar['bop']
     | ^^^^^^^^^^^^^^^^^^^^^^^ UP031
-128 | 
-129 | # Not a valid type annotation but this test shouldn't result in a panic.
+127 | 
+128 | # UP031 (no longer false negatives, but offer no fix because of more complex syntax)
     |
     = help: Replace with format specifiers
 
 ℹ Unsafe fix
-124 124 | 
-125 125 | 'Hello %s' % bar.baz
-126 126 | 
-127     |-'Hello %s' % bar['bop']
-    127 |+'Hello {}'.format(bar['bop'])
-128 128 | 
-129 129 | # Not a valid type annotation but this test shouldn't result in a panic.
-130 130 | # Refer: https://github.com/astral-sh/ruff/issues/11736
+123 123 | 
+124 124 | 'Hello %s' % bar.baz
+125 125 | 
+126     |-'Hello %s' % bar['bop']
+    126 |+'Hello {}'.format(bar['bop'])
+127 127 | 
+128 128 | # UP031 (no longer false negatives, but offer no fix because of more complex syntax)
+129 129 | 
 
-UP031_0.py:131:5: UP031 [*] Use format specifiers instead of percent format
+UP031_0.py:130:1: UP031 Use format specifiers or f-strings instead of percent format
     |
-129 | # Not a valid type annotation but this test shouldn't result in a panic.
-130 | # Refer: https://github.com/astral-sh/ruff/issues/11736
-131 | x: "'%s + %s' % (1, 2)"
-    |     ^^^^^^^^^^^^^^^^^^ UP031
-132 | 
-133 | # See: https://github.com/astral-sh/ruff/issues/12421
-    |
-    = help: Replace with format specifiers
-
-ℹ Unsafe fix
-128 128 | 
-129 129 | # Not a valid type annotation but this test shouldn't result in a panic.
-130 130 | # Refer: https://github.com/astral-sh/ruff/issues/11736
-131     |-x: "'%s + %s' % (1, 2)"
-    131 |+x: "'{} + {}'.format(1, 2)"
-132 132 | 
-133 133 | # See: https://github.com/astral-sh/ruff/issues/12421
-134 134 | print("%.2X" % 1)
-
-UP031_0.py:134:7: UP031 [*] Use format specifiers instead of percent format
-    |
-133 | # See: https://github.com/astral-sh/ruff/issues/12421
-134 | print("%.2X" % 1)
-    |       ^^^^^^^^^^ UP031
-135 | print("%.02X" % 1)
-136 | print("%02X" % 1)
+128 | # UP031 (no longer false negatives, but offer no fix because of more complex syntax)
+129 | 
+130 | "%d.%d" % (a, b)
+    | ^^^^^^^^^^^^^^^^ UP031
+131 | 
+132 | "%*s" % (5, "hi")
     |
     = help: Replace with format specifiers
 
-ℹ Unsafe fix
-131 131 | x: "'%s + %s' % (1, 2)"
-132 132 | 
-133 133 | # See: https://github.com/astral-sh/ruff/issues/12421
-134     |-print("%.2X" % 1)
-    134 |+print("{:02X}".format(1))
-135 135 | print("%.02X" % 1)
-136 136 | print("%02X" % 1)
-137 137 | print("%.00002X" % 1)
-
-UP031_0.py:135:7: UP031 [*] Use format specifiers instead of percent format
+UP031_0.py:132:1: UP031 Use format specifiers or f-strings instead of percent format
     |
-133 | # See: https://github.com/astral-sh/ruff/issues/12421
-134 | print("%.2X" % 1)
-135 | print("%.02X" % 1)
-    |       ^^^^^^^^^^^ UP031
-136 | print("%02X" % 1)
-137 | print("%.00002X" % 1)
+130 | "%d.%d" % (a, b)
+131 | 
+132 | "%*s" % (5, "hi")
+    | ^^^^^^^^^^^^^^^^^ UP031
+133 | 
+134 | "%d" % (flt,)
     |
     = help: Replace with format specifiers
 
-ℹ Unsafe fix
-132 132 | 
-133 133 | # See: https://github.com/astral-sh/ruff/issues/12421
-134 134 | print("%.2X" % 1)
-135     |-print("%.02X" % 1)
-    135 |+print("{:02X}".format(1))
-136 136 | print("%02X" % 1)
-137 137 | print("%.00002X" % 1)
-138 138 | print("%.20X" % 1)
-
-UP031_0.py:136:7: UP031 [*] Use format specifiers instead of percent format
+UP031_0.py:134:1: UP031 Use format specifiers or f-strings instead of percent format
     |
-134 | print("%.2X" % 1)
-135 | print("%.02X" % 1)
-136 | print("%02X" % 1)
-    |       ^^^^^^^^^^ UP031
-137 | print("%.00002X" % 1)
-138 | print("%.20X" % 1)
+132 | "%*s" % (5, "hi")
+133 | 
+134 | "%d" % (flt,)
+    | ^^^^^^^^^^^^^ UP031
+135 | 
+136 | "%c" % (some_string,)
     |
     = help: Replace with format specifiers
 
-ℹ Unsafe fix
-133 133 | # See: https://github.com/astral-sh/ruff/issues/12421
-134 134 | print("%.2X" % 1)
-135 135 | print("%.02X" % 1)
-136     |-print("%02X" % 1)
-    136 |+print("{:02X}".format(1))
-137 137 | print("%.00002X" % 1)
-138 138 | print("%.20X" % 1)
-139 139 | 
-
-UP031_0.py:137:7: UP031 [*] Use format specifiers instead of percent format
+UP031_0.py:136:1: UP031 Use format specifiers or f-strings instead of percent format
     |
-135 | print("%.02X" % 1)
-136 | print("%02X" % 1)
-137 | print("%.00002X" % 1)
-    |       ^^^^^^^^^^^^^^ UP031
-138 | print("%.20X" % 1)
+134 | "%d" % (flt,)
+135 | 
+136 | "%c" % (some_string,)
+    | ^^^^^^^^^^^^^^^^^^^^^ UP031
+137 | 
+138 | "%.2r" % (1.25)
     |
     = help: Replace with format specifiers
 
-ℹ Unsafe fix
-134 134 | print("%.2X" % 1)
-135 135 | print("%.02X" % 1)
-136 136 | print("%02X" % 1)
-137     |-print("%.00002X" % 1)
-    137 |+print("{:02X}".format(1))
-138 138 | print("%.20X" % 1)
-139 139 | 
-140 140 | print("%2X" % 1)
-
-UP031_0.py:138:7: UP031 [*] Use format specifiers instead of percent format
+UP031_0.py:138:1: UP031 Use format specifiers or f-strings instead of percent format
     |
-136 | print("%02X" % 1)
-137 | print("%.00002X" % 1)
-138 | print("%.20X" % 1)
-    |       ^^^^^^^^^^^ UP031
+136 | "%c" % (some_string,)
+137 | 
+138 | "%.2r" % (1.25)
+    | ^^^^^^^^^^^^^^^ UP031
 139 | 
-140 | print("%2X" % 1)
+140 | "%.*s" % (5, "hi")
     |
     = help: Replace with format specifiers
 
-ℹ Unsafe fix
-135 135 | print("%.02X" % 1)
-136 136 | print("%02X" % 1)
-137 137 | print("%.00002X" % 1)
-138     |-print("%.20X" % 1)
-    138 |+print("{:020X}".format(1))
-139 139 | 
-140 140 | print("%2X" % 1)
-141 141 | print("%02X" % 1)
-
-UP031_0.py:140:7: UP031 [*] Use format specifiers instead of percent format
+UP031_0.py:140:1: UP031 Use format specifiers or f-strings instead of percent format
     |
-138 | print("%.20X" % 1)
+138 | "%.2r" % (1.25)
 139 | 
-140 | print("%2X" % 1)
-    |       ^^^^^^^^^ UP031
-141 | print("%02X" % 1)
+140 | "%.*s" % (5, "hi")
+    | ^^^^^^^^^^^^^^^^^^ UP031
+141 | 
+142 | "%i" % (flt,)
     |
     = help: Replace with format specifiers
 
-ℹ Unsafe fix
-137 137 | print("%.00002X" % 1)
-138 138 | print("%.20X" % 1)
-139 139 | 
-140     |-print("%2X" % 1)
-    140 |+print("{:2X}".format(1))
-141 141 | print("%02X" % 1)
-
-UP031_0.py:141:7: UP031 [*] Use format specifiers instead of percent format
+UP031_0.py:142:1: UP031 Use format specifiers or f-strings instead of percent format
     |
-140 | print("%2X" % 1)
-141 | print("%02X" % 1)
-    |       ^^^^^^^^^^ UP031
+140 | "%.*s" % (5, "hi")
+141 | 
+142 | "%i" % (flt,)
+    | ^^^^^^^^^^^^^ UP031
+143 | 
+144 | "%()s" % {"": "empty"}
     |
     = help: Replace with format specifiers
 
-ℹ Unsafe fix
-138 138 | print("%.20X" % 1)
-139 139 | 
-140 140 | print("%2X" % 1)
-141     |-print("%02X" % 1)
-    141 |+print("{:02X}".format(1))
+UP031_0.py:144:1: UP031 Use format specifiers or f-strings instead of percent format
+    |
+142 | "%i" % (flt,)
+143 | 
+144 | "%()s" % {"": "empty"}
+    | ^^^^^^^^^^^^^^^^^^^^^^ UP031
+145 | 
+146 | "%s" % {"k": "v"}
+    |
+    = help: Replace with format specifiers
+
+UP031_0.py:146:1: UP031 Use format specifiers or f-strings instead of percent format
+    |
+144 | "%()s" % {"": "empty"}
+145 | 
+146 | "%s" % {"k": "v"}
+    | ^^^^^^^^^^^^^^^^^ UP031
+147 | 
+148 | "%()s" % {"": "bar"}
+    |
+    = help: Replace with format specifiers
+
+UP031_0.py:148:1: UP031 Use format specifiers or f-strings instead of percent format
+    |
+146 | "%s" % {"k": "v"}
+147 | 
+148 | "%()s" % {"": "bar"}
+    | ^^^^^^^^^^^^^^^^^^^^ UP031
+149 | 
+150 | "%(1)s" % {"1": "bar"}
+    |
+    = help: Replace with format specifiers
+
+UP031_0.py:150:1: UP031 Use format specifiers or f-strings instead of percent format
+    |
+148 | "%()s" % {"": "bar"}
+149 | 
+150 | "%(1)s" % {"1": "bar"}
+    | ^^^^^^^^^^^^^^^^^^^^^^ UP031
+151 | 
+152 | "%(a)s" % {"a": 1, "a": 2}
+    |
+    = help: Replace with format specifiers
+
+UP031_0.py:152:1: UP031 Use format specifiers or f-strings instead of percent format
+    |
+150 | "%(1)s" % {"1": "bar"}
+151 | 
+152 | "%(a)s" % {"a": 1, "a": 2}
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^ UP031
+153 | 
+154 | "%(1)s" % {1: 2, "1": 2}
+    |
+    = help: Replace with format specifiers
+
+UP031_0.py:154:1: UP031 Use format specifiers or f-strings instead of percent format
+    |
+152 | "%(a)s" % {"a": 1, "a": 2}
+153 | 
+154 | "%(1)s" % {1: 2, "1": 2}
+    | ^^^^^^^^^^^^^^^^^^^^^^^^ UP031
+155 | 
+156 | "%(and)s" % {"and": 2}
+    |
+    = help: Replace with format specifiers
+
+UP031_0.py:156:1: UP031 Use format specifiers or f-strings instead of percent format
+    |
+154 | "%(1)s" % {1: 2, "1": 2}
+155 | 
+156 | "%(and)s" % {"and": 2}
+    | ^^^^^^^^^^^^^^^^^^^^^^ UP031
+    |
+    = help: Replace with format specifiers

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__preview.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__preview.snap
@@ -1163,4 +1163,156 @@ UP031_0.py:141:7: UP031 [*] Use format specifiers instead of percent format
     141 |+print("{:02X}".format(1))
 142 142 | 
 143 143 | # UP031 (no longer false negatives, but offer no fix because of more complex syntax)
-144 144 |
+144 144 | 
+
+UP031_0.py:145:1: UP031 Use format specifiers instead of percent format
+    |
+143 | # UP031 (no longer false negatives, but offer no fix because of more complex syntax)
+144 | 
+145 | "%d.%d" % (a, b)
+    | ^^^^^^^ UP031
+146 | 
+147 | "%*s" % (5, "hi")
+    |
+    = help: Replace with format specifiers
+
+UP031_0.py:147:1: UP031 Use format specifiers instead of percent format
+    |
+145 | "%d.%d" % (a, b)
+146 | 
+147 | "%*s" % (5, "hi")
+    | ^^^^^ UP031
+148 | 
+149 | "%d" % (flt,)
+    |
+    = help: Replace with format specifiers
+
+UP031_0.py:149:1: UP031 Use format specifiers instead of percent format
+    |
+147 | "%*s" % (5, "hi")
+148 | 
+149 | "%d" % (flt,)
+    | ^^^^ UP031
+150 | 
+151 | "%c" % (some_string,)
+    |
+    = help: Replace with format specifiers
+
+UP031_0.py:151:1: UP031 Use format specifiers instead of percent format
+    |
+149 | "%d" % (flt,)
+150 | 
+151 | "%c" % (some_string,)
+    | ^^^^ UP031
+152 | 
+153 | "%.2r" % (1.25)
+    |
+    = help: Replace with format specifiers
+
+UP031_0.py:153:1: UP031 Use format specifiers instead of percent format
+    |
+151 | "%c" % (some_string,)
+152 | 
+153 | "%.2r" % (1.25)
+    | ^^^^^^ UP031
+154 | 
+155 | "%.*s" % (5, "hi")
+    |
+    = help: Replace with format specifiers
+
+UP031_0.py:155:1: UP031 Use format specifiers instead of percent format
+    |
+153 | "%.2r" % (1.25)
+154 | 
+155 | "%.*s" % (5, "hi")
+    | ^^^^^^ UP031
+156 | 
+157 | "%i" % (flt,)
+    |
+    = help: Replace with format specifiers
+
+UP031_0.py:157:1: UP031 Use format specifiers instead of percent format
+    |
+155 | "%.*s" % (5, "hi")
+156 | 
+157 | "%i" % (flt,)
+    | ^^^^ UP031
+158 | 
+159 | "%()s" % {"": "empty"}
+    |
+    = help: Replace with format specifiers
+
+UP031_0.py:159:1: UP031 Use format specifiers instead of percent format
+    |
+157 | "%i" % (flt,)
+158 | 
+159 | "%()s" % {"": "empty"}
+    | ^^^^^^ UP031
+160 | 
+161 | "%s" % {"k": "v"}
+    |
+    = help: Replace with format specifiers
+
+UP031_0.py:161:1: UP031 Use format specifiers instead of percent format
+    |
+159 | "%()s" % {"": "empty"}
+160 | 
+161 | "%s" % {"k": "v"}
+    | ^^^^ UP031
+162 | 
+163 | "%()s" % {"": "bar"}
+    |
+    = help: Replace with format specifiers
+
+UP031_0.py:163:1: UP031 Use format specifiers instead of percent format
+    |
+161 | "%s" % {"k": "v"}
+162 | 
+163 | "%()s" % {"": "bar"}
+    | ^^^^^^ UP031
+164 | 
+165 | "%(1)s" % {"1": "bar"}
+    |
+    = help: Replace with format specifiers
+
+UP031_0.py:165:1: UP031 Use format specifiers instead of percent format
+    |
+163 | "%()s" % {"": "bar"}
+164 | 
+165 | "%(1)s" % {"1": "bar"}
+    | ^^^^^^^ UP031
+166 | 
+167 | "%(a)s" % {"a": 1, "a": 2}
+    |
+    = help: Replace with format specifiers
+
+UP031_0.py:167:1: UP031 Use format specifiers instead of percent format
+    |
+165 | "%(1)s" % {"1": "bar"}
+166 | 
+167 | "%(a)s" % {"a": 1, "a": 2}
+    | ^^^^^^^ UP031
+168 | 
+169 | "%(1)s" % {1: 2, "1": 2}
+    |
+    = help: Replace with format specifiers
+
+UP031_0.py:169:1: UP031 Use format specifiers instead of percent format
+    |
+167 | "%(a)s" % {"a": 1, "a": 2}
+168 | 
+169 | "%(1)s" % {1: 2, "1": 2}
+    | ^^^^^^^ UP031
+170 | 
+171 | "%(and)s" % {"and": 2}
+    |
+    = help: Replace with format specifiers
+
+UP031_0.py:171:1: UP031 Use format specifiers instead of percent format
+    |
+169 | "%(1)s" % {1: 2, "1": 2}
+170 | 
+171 | "%(and)s" % {"and": 2}
+    | ^^^^^^^^^ UP031
+    |
+    = help: Replace with format specifiers


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

This shows violations of the `UP031` rule which can't be auto-fixed, so that they can be fixed manually (similar to the pylint `consider-using-f-strings` rule)

## Test Plan

<!-- How was it tested? -->

Updated fixtures.
