### PR TITLE
Remove num-cpus dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1458,16 +1458,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_cpus"
-version = "1.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
-dependencies = [
- "hermit-abi",
- "libc",
-]
-
-[[package]]
 name = "number_prefix"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1974,7 +1964,6 @@ dependencies = [
  "log",
  "mimalloc",
  "notify",
- "num_cpus",
  "path-absolutize",
  "rayon",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,6 @@ memchr = { version = "2.7.1" }
 mimalloc = { version = "0.1.39" }
 natord = { version = "1.0.9" }
 notify = { version = "6.1.1" }
-num_cpus = { version = "1.16.0" }
 once_cell = { version = "1.19.0" }
 path-absolutize = { version = "3.1.1" }
 path-slash = { version = "0.2.1" }

--- a/crates/ruff/Cargo.toml
+++ b/crates/ruff/Cargo.toml
@@ -41,7 +41,6 @@ is-macro = { workspace = true }
 itertools = { workspace = true }
 log = { workspace = true }
 notify = { workspace = true }
-num_cpus = { workspace = true }
 path-absolutize = { workspace = true, features = ["once_cell_cache"] }
 rayon = { workspace = true }
 regex = { workspace = true }

--- a/crates/ruff/src/lib.rs
+++ b/crates/ruff/src/lib.rs
@@ -214,13 +214,14 @@ fn format(args: FormatCommand, global_options: GlobalConfigArgs) -> Result<ExitS
 
 fn server(args: ServerCommand, log_level: LogLevel) -> Result<ExitStatus> {
     let ServerCommand { preview } = args;
+
+    let four = NonZeroUsize::new(4).unwrap();
+
     // by default, we set the number of worker threads to `num_cpus`, with a maximum of 4.
-    let worker_threads = num_cpus::get().max(4);
-    commands::server::run_server(
-        preview,
-        NonZeroUsize::try_from(worker_threads).expect("a non-zero worker thread count"),
-        log_level,
-    )
+    let worker_threads = std::thread::available_parallelism()
+        .unwrap_or(four)
+        .max(four);
+    commands::server::run_server(preview, worker_threads, log_level)
 }
 
 pub fn check(args: CheckCommand, global_options: GlobalConfigArgs) -> Result<ExitStatus> {


### PR DESCRIPTION
## Summary

Use the `std::thread::available_parallelism` function over `num_cpus` to reduce our dependencies.

## Test Plan

`cargo test`
