### PR TITLE
Ignore list-copy recommendations for async `for` loops

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/perflint/PERF401.py
+++ b/crates/ruff_linter/resources/test/fixtures/perflint/PERF401.py
@@ -72,3 +72,18 @@ def f():
     result = Foo()
     for i in items:
         result.append(i)  # Ok
+
+
+def f():
+    items = [1, 2, 3, 4]
+    result = []
+    async for i in items:
+        if i % 2:
+            result.append(i)  # PERF401
+
+
+def f():
+    items = [1, 2, 3, 4]
+    result = []
+    async for i in items:
+        result.append(i)  # PERF401

--- a/crates/ruff_linter/resources/test/fixtures/perflint/PERF402.py
+++ b/crates/ruff_linter/resources/test/fixtures/perflint/PERF402.py
@@ -43,3 +43,10 @@ def f():
 
     for path in ("foo", "bar"):
         sys.path.append(path)  # OK
+
+
+def f():
+    items = [1, 2, 3, 4]
+    result = []
+    async for i in items:
+        result.append(i)  # PERF402

--- a/crates/ruff_linter/src/checkers/ast/analyze/statement.rs
+++ b/crates/ruff_linter/src/checkers/ast/analyze/statement.rs
@@ -1323,10 +1323,10 @@ pub(crate) fn statement(stmt: &Stmt, checker: &mut Checker) {
                 pylint::rules::dict_iter_missing_items(checker, target, iter);
             }
             if checker.enabled(Rule::ManualListComprehension) {
-                perflint::rules::manual_list_comprehension(checker, target, body);
+                perflint::rules::manual_list_comprehension(checker, for_stmt);
             }
             if checker.enabled(Rule::ManualListCopy) {
-                perflint::rules::manual_list_copy(checker, target, body);
+                perflint::rules::manual_list_copy(checker, for_stmt);
             }
             if checker.enabled(Rule::ManualDictComprehension) {
                 perflint::rules::manual_dict_comprehension(checker, target, body);

--- a/crates/ruff_linter/src/rules/perflint/rules/manual_list_copy.rs
+++ b/crates/ruff_linter/src/rules/perflint/rules/manual_list_copy.rs
@@ -45,12 +45,16 @@ impl Violation for ManualListCopy {
 }
 
 /// PERF402
-pub(crate) fn manual_list_copy(checker: &mut Checker, target: &Expr, body: &[Stmt]) {
-    let Expr::Name(ast::ExprName { id, .. }) = target else {
+pub(crate) fn manual_list_copy(checker: &mut Checker, for_stmt: &ast::StmtFor) {
+    if for_stmt.is_async {
+        return;
+    }
+
+    let Expr::Name(ast::ExprName { id, .. }) = &*for_stmt.target else {
         return;
     };
 
-    let [stmt] = body else {
+    let [stmt] = &*for_stmt.body else {
         return;
     };
 

--- a/crates/ruff_linter/src/rules/perflint/snapshots/ruff_linter__rules__perflint__tests__PERF401_PERF401.py.snap
+++ b/crates/ruff_linter/src/rules/perflint/snapshots/ruff_linter__rules__perflint__tests__PERF401_PERF401.py.snap
@@ -17,4 +17,18 @@ PERF401.py:13:9: PERF401 Use a list comprehension to create a transformed list
    |         ^^^^^^^^^^^^^^^^^^^^ PERF401
    |
 
+PERF401.py:82:13: PERF401 Use an async list comprehension to create a transformed list
+   |
+80 |     async for i in items:
+81 |         if i % 2:
+82 |             result.append(i)  # PERF401
+   |             ^^^^^^^^^^^^^^^^ PERF401
+   |
 
+PERF401.py:89:9: PERF401 Use an async list comprehension to create a transformed list
+   |
+87 |     result = []
+88 |     async for i in items:
+89 |         result.append(i)  # PERF401
+   |         ^^^^^^^^^^^^^^^^ PERF401
+   |


### PR DESCRIPTION
## Summary

Removes these from `PERF402`, but adds them to `PERF401`, with a custom message to use an `async` comprehension.

Closes https://github.com/astral-sh/ruff/issues/10787.
