### PR TITLE
Avoid allocations for isort module names

### DIFF
--- a/crates/ruff_linter/src/checkers/ast/analyze/definitions.rs
+++ b/crates/ruff_linter/src/checkers/ast/analyze/definitions.rs
@@ -109,7 +109,7 @@ pub(crate) fn definitions(checker: &mut Checker) {
     };
 
     let definitions = std::mem::take(&mut checker.semantic.definitions);
-    let mut overloaded_name: Option<String> = None;
+    let mut overloaded_name: Option<&str> = None;
     for ContextualizedDefinition {
         definition,
         visibility,
@@ -127,7 +127,7 @@ pub(crate) fn definitions(checker: &mut Checker) {
             if !overloaded_name.is_some_and(|overloaded_name| {
                 flake8_annotations::helpers::is_overload_impl(
                     definition,
-                    &overloaded_name,
+                    overloaded_name,
                     &checker.semantic,
                 )
             }) {

--- a/crates/ruff_linter/src/checkers/ast/analyze/statement.rs
+++ b/crates/ruff_linter/src/checkers/ast/analyze/statement.rs
@@ -877,7 +877,7 @@ pub(crate) fn statement(stmt: &Stmt, checker: &mut Checker) {
                         if !matches!(checker.semantic.current_scope().kind, ScopeKind::Module) {
                             checker.diagnostics.push(Diagnostic::new(
                                 pyflakes::rules::UndefinedLocalWithNestedImportStarUsage {
-                                    name: helpers::format_import_from(level, module),
+                                    name: helpers::format_import_from(level, module).to_string(),
                                 },
                                 stmt.range(),
                             ));
@@ -886,7 +886,7 @@ pub(crate) fn statement(stmt: &Stmt, checker: &mut Checker) {
                     if checker.enabled(Rule::UndefinedLocalWithImportStar) {
                         checker.diagnostics.push(Diagnostic::new(
                             pyflakes::rules::UndefinedLocalWithImportStar {
-                                name: helpers::format_import_from(level, module),
+                                name: helpers::format_import_from(level, module).to_string(),
                             },
                             stmt.range(),
                         ));

--- a/crates/ruff_linter/src/rules/flake8_annotations/helpers.rs
+++ b/crates/ruff_linter/src/rules/flake8_annotations/helpers.rs
@@ -17,10 +17,13 @@ use crate::importer::{ImportRequest, Importer};
 use crate::settings::types::PythonVersion;
 
 /// Return the name of the function, if it's overloaded.
-pub(crate) fn overloaded_name(definition: &Definition, semantic: &SemanticModel) -> Option<String> {
+pub(crate) fn overloaded_name<'a>(
+    definition: &'a Definition,
+    semantic: &SemanticModel,
+) -> Option<&'a str> {
     let function = definition.as_function_def()?;
     if visibility::is_overload(&function.decorator_list, semantic) {
-        Some(function.name.to_string())
+        Some(function.name.as_str())
     } else {
         None
     }

--- a/crates/ruff_linter/src/rules/isort/types.rs
+++ b/crates/ruff_linter/src/rules/isort/types.rs
@@ -29,28 +29,37 @@ pub(crate) struct CommentSet<'a> {
     pub(crate) inline: Vec<Cow<'a, str>>,
 }
 
-pub(crate) trait Importable {
-    fn module_name(&self) -> String;
-    fn module_base(&self) -> String;
+pub(crate) trait Importable<'a> {
+    fn module_name(&self) -> Cow<'a, str>;
+
+    fn module_base(&self) -> Cow<'a, str> {
+        match self.module_name() {
+            Cow::Borrowed(module_name) => Cow::Borrowed(
+                module_name
+                    .split('.')
+                    .next()
+                    .expect("module to include at least one segment"),
+            ),
+            Cow::Owned(module_name) => Cow::Owned(
+                module_name
+                    .split('.')
+                    .next()
+                    .expect("module to include at least one segment")
+                    .to_owned(),
+            ),
+        }
+    }
 }
 
-impl Importable for AliasData<'_> {
-    fn module_name(&self) -> String {
-        self.name.to_string()
-    }
-
-    fn module_base(&self) -> String {
-        self.module_name().split('.').next().unwrap().to_string()
+impl<'a> Importable<'a> for AliasData<'a> {
+    fn module_name(&self) -> Cow<'a, str> {
+        Cow::Borrowed(self.name)
     }
 }
 
-impl Importable for ImportFromData<'_> {
-    fn module_name(&self) -> String {
+impl<'a> Importable<'a> for ImportFromData<'a> {
+    fn module_name(&self) -> Cow<'a, str> {
         format_import_from(self.level, self.module)
-    }
-
-    fn module_base(&self) -> String {
-        self.module_name().split('.').next().unwrap().to_string()
     }
 }
 


### PR DESCRIPTION
## Summary

Random refactor I noticed when investigating the F401 changes. We don't need to allocate in most cases here.