### PR TITLE
Add decorator types to function type

### DIFF
--- a/crates/red_knot/src/types/infer.rs
+++ b/crates/red_knot/src/types/infer.rs
@@ -80,7 +80,18 @@ where
                     .resolve(ast.as_any_node_ref())
                     .expect("node key should resolve");
 
-                let ty = type_store.add_function(file_id, &node.name.id).into();
+                let decorator_tys: Vec<_> = node
+                    .decorator_list
+                    .iter()
+                    .map(|decorator| {
+                        infer_expr_type(db, file_id, &decorator.expression)
+                            .expect("decorator expression type should be inferrable")
+                    })
+                    .collect();
+
+                let ty = type_store
+                    .add_function(file_id, &node.name.id, decorator_tys)
+                    .into();
                 type_store.cache_node_type(file_id, *node_key.erased(), ty);
                 ty
             }

--- a/crates/red_knot/src/types/infer.rs
+++ b/crates/red_knot/src/types/infer.rs
@@ -80,14 +80,11 @@ where
                     .resolve(ast.as_any_node_ref())
                     .expect("node key should resolve");
 
-                let decorator_tys: Vec<_> = node
+                let decorator_tys = node
                     .decorator_list
                     .iter()
-                    .map(|decorator| {
-                        infer_expr_type(db, file_id, &decorator.expression)
-                            .expect("decorator expression type should be inferable")
-                    })
-                    .collect();
+                    .map(|decorator| infer_expr_type(db, file_id, &decorator.expression))
+                    .collect::<QueryResult<_>>()?;
 
                 let ty = type_store
                     .add_function(file_id, &node.name.id, decorator_tys)

--- a/crates/red_knot/src/types/infer.rs
+++ b/crates/red_knot/src/types/infer.rs
@@ -85,7 +85,7 @@ where
                     .iter()
                     .map(|decorator| {
                         infer_expr_type(db, file_id, &decorator.expression)
-                            .expect("decorator expression type should be inferrable")
+                            .expect("decorator expression type should be inferable")
                     })
                     .collect();
 


### PR DESCRIPTION
* Add `decorators: Vec<Type>` to `FunctionType` struct
* Thread decorators through two `add_function` definitions
* Populate decorators at the callsite in `infer_symbol_type`
* Small test