### PR TITLE
Rephrase rationale for `pytest-incorrect-pytest-import`

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_pytest_style/rules/imports.rs
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/rules/imports.rs
@@ -8,8 +8,8 @@ use ruff_text_size::Ranged;
 /// Checks for incorrect import of pytest.
 ///
 /// ## Why is this bad?
-/// `pytest` should be imported as `import pytest` and its members should be accessed in the form of
-/// `pytest.xxx.yyy` for consistency and to make it easier for linting tools to analyze the code.
+/// For consistency, `pytest` should be imported as `import pytest` and its members should be
+/// accessed in the form of `pytest.xxx.yyy` for consistency
 ///
 /// ## Example
 /// ```python
@@ -27,7 +27,7 @@ pub struct PytestIncorrectPytestImport;
 impl Violation for PytestIncorrectPytestImport {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Found incorrect import of pytest, use simple `import pytest` instead")
+        format!("Incorrect import of `pytest`; use `import pytest` instead")
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/snapshots/ruff_linter__rules__flake8_pytest_style__tests__PT013.snap
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/snapshots/ruff_linter__rules__flake8_pytest_style__tests__PT013.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_pytest_style/mod.rs
 ---
-PT013.py:11:1: PT013 Found incorrect import of pytest, use simple `import pytest` instead
+PT013.py:11:1: PT013 Incorrect import of `pytest`; use `import pytest` instead
    |
  9 | # Error
 10 | 
@@ -11,7 +11,7 @@ PT013.py:11:1: PT013 Found incorrect import of pytest, use simple `import pytest
 13 | from pytest import fixture as other_name
    |
 
-PT013.py:12:1: PT013 Found incorrect import of pytest, use simple `import pytest` instead
+PT013.py:12:1: PT013 Incorrect import of `pytest`; use `import pytest` instead
    |
 11 | import pytest as other_name
 12 | from pytest import fixture
@@ -19,12 +19,10 @@ PT013.py:12:1: PT013 Found incorrect import of pytest, use simple `import pytest
 13 | from pytest import fixture as other_name
    |
 
-PT013.py:13:1: PT013 Found incorrect import of pytest, use simple `import pytest` instead
+PT013.py:13:1: PT013 Incorrect import of `pytest`; use `import pytest` instead
    |
 11 | import pytest as other_name
 12 | from pytest import fixture
 13 | from pytest import fixture as other_name
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PT013
    |
-
-


### PR DESCRIPTION
## Summary

Closes https://github.com/astral-sh/ruff/issues/11247.
