### PR TITLE
Upgrade to Rust 1.78

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -3,5 +3,10 @@ doc-valid-idents = [
   "CodeQL",
   "IPython",
   "NumPy",
+  "LibCST",
+  "SCREAMING_SNAKE_CASE",
+  "SQLAlchemy",
+  "McCabe",
+  "FastAPI",
   "..",
 ]

--- a/crates/ruff/src/args.rs
+++ b/crates/ruff/src/args.rs
@@ -338,7 +338,7 @@ pub struct CheckCommand {
     /// The name of the file when passing it through stdin.
     #[arg(long, help_heading = "Miscellaneous")]
     pub stdin_filename: Option<PathBuf>,
-    /// List of mappings from file extension to language (one of `"python"`, `"ipynb"`, `"pyi"`). For
+    /// List of mappings from file extension to language (one of `python`, `ipynb`, `pyi`). For
     /// example, to treat `.ipy` files as IPython notebooks, use `--extension ipy:ipynb`.
     #[arg(long, value_delimiter = ',')]
     pub extension: Option<Vec<ExtensionPair>>,
@@ -466,7 +466,7 @@ pub struct FormatCommand {
     /// The name of the file when passing it through stdin.
     #[arg(long, help_heading = "Miscellaneous")]
     pub stdin_filename: Option<PathBuf>,
-    /// List of mappings from file extension to language (one of [`"python"`, `"ipynb"`, `"pyi"`]). For
+    /// List of mappings from file extension to language (one of `python`, `ipynb`, `pyi`). For
     /// example, to treat `.ipy` files as IPython notebooks, use `--extension ipy:ipynb`.
     #[arg(long, value_delimiter = ',')]
     pub extension: Option<Vec<ExtensionPair>>,

--- a/crates/ruff/src/args.rs
+++ b/crates/ruff/src/args.rs
@@ -338,7 +338,7 @@ pub struct CheckCommand {
     /// The name of the file when passing it through stdin.
     #[arg(long, help_heading = "Miscellaneous")]
     pub stdin_filename: Option<PathBuf>,
-    /// List of mappings from file extension to language (one of ["python", "ipynb", "pyi"]). For
+    /// List of mappings from file extension to language (one of `"python"`, `"ipynb"`, `"pyi"`). For
     /// example, to treat `.ipy` files as IPython notebooks, use `--extension ipy:ipynb`.
     #[arg(long, value_delimiter = ',')]
     pub extension: Option<Vec<ExtensionPair>>,
@@ -466,7 +466,7 @@ pub struct FormatCommand {
     /// The name of the file when passing it through stdin.
     #[arg(long, help_heading = "Miscellaneous")]
     pub stdin_filename: Option<PathBuf>,
-    /// List of mappings from file extension to language (one of ["python", "ipynb", "pyi"]). For
+    /// List of mappings from file extension to language (one of [`"python"`, `"ipynb"`, `"pyi"`]). For
     /// example, to treat `.ipy` files as IPython notebooks, use `--extension ipy:ipynb`.
     #[arg(long, value_delimiter = ',')]
     pub extension: Option<Vec<ExtensionPair>>,

--- a/crates/ruff_formatter/src/buffer.rs
+++ b/crates/ruff_formatter/src/buffer.rs
@@ -344,7 +344,7 @@ pub struct RemoveSoftLinesBuffer<'a, Context> {
 
     /// Caches the interned elements after the soft line breaks have been removed.
     ///
-    /// The `key` is the [Interned] element as it has been passed to [Self::write_element] or the child of another
+    /// The `key` is the [Interned] element as it has been passed to [`Self::write_element`] or the child of another
     /// [Interned] element. The `value` is the matching document of the key where all soft line breaks have been removed.
     ///
     /// It's fine to not snapshot the cache. The worst that can happen is that it holds on interned elements

--- a/crates/ruff_formatter/src/diagnostics.rs
+++ b/crates/ruff_formatter/src/diagnostics.rs
@@ -18,10 +18,10 @@ pub enum FormatError {
     InvalidDocument(InvalidDocumentError),
 
     /// Formatting failed because some content encountered a situation where a layout
-    /// choice by an enclosing [crate::Format] resulted in a poor layout for a child [crate::Format].
+    /// choice by an enclosing [`crate::Format`] resulted in a poor layout for a child [`crate::Format`].
     ///
-    /// It's up to an enclosing [crate::Format] to handle the error and pick another layout.
-    /// This error should not be raised if there's no outer [crate::Format] handling the poor layout error,
+    /// It's up to an enclosing [`crate::Format`] to handle the error and pick another layout.
+    /// This error should not be raised if there's no outer [`crate::Format`] handling the poor layout error,
     /// avoiding that formatting of the whole document fails.
     PoorLayout,
 }

--- a/crates/ruff_formatter/src/format_element.rs
+++ b/crates/ruff_formatter/src/format_element.rs
@@ -19,10 +19,10 @@ use ruff_text_size::TextSize;
 /// Use the helper functions like [`crate::builders::space`], [`crate::builders::soft_line_break`] etc. defined in this file to create elements.
 #[derive(Clone, Eq, PartialEq)]
 pub enum FormatElement {
-    /// A space token, see [crate::builders::space] for documentation.
+    /// A space token, see [`crate::builders::space`] for documentation.
     Space,
 
-    /// A new line, see [crate::builders::soft_line_break], [crate::builders::hard_line_break], and [crate::builders::soft_line_break_or_space] for documentation.
+    /// A new line, see [`crate::builders::soft_line_break`], [`crate::builders::hard_line_break`], and [`crate::builders::soft_line_break_or_space`] for documentation.
     Line(LineMode),
 
     /// Forces the parent group to print in expanded mode.
@@ -108,13 +108,13 @@ impl std::fmt::Debug for FormatElement {
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum LineMode {
-    /// See [crate::builders::soft_line_break_or_space] for documentation.
+    /// See [`crate::builders::soft_line_break_or_space`] for documentation.
     SoftOrSpace,
-    /// See [crate::builders::soft_line_break] for documentation.
+    /// See [`crate::builders::soft_line_break`] for documentation.
     Soft,
-    /// See [crate::builders::hard_line_break] for documentation.
+    /// See [`crate::builders::hard_line_break`] for documentation.
     Hard,
-    /// See [crate::builders::empty_line] for documentation.
+    /// See [`crate::builders::empty_line`] for documentation.
     Empty,
 }
 

--- a/crates/ruff_formatter/src/format_element/tag.rs
+++ b/crates/ruff_formatter/src/format_element/tag.rs
@@ -9,14 +9,14 @@ use std::num::NonZeroU8;
 /// will be applied to all elements in between the start/end tags.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum Tag {
-    /// Indents the content one level deeper, see [crate::builders::indent] for documentation and examples.
+    /// Indents the content one level deeper, see [`crate::builders::indent`] for documentation and examples.
     StartIndent,
     EndIndent,
 
-    /// Variant of [TagKind::Indent] that indents content by a number of spaces. For example, `Align(2)`
+    /// Variant of [`TagKind::Indent`] that indents content by a number of spaces. For example, `Align(2)`
     /// indents any content following a line break by an additional two spaces.
     ///
-    /// Nesting (Aligns)[TagKind::Align] has the effect that all except the most inner align are handled as (Indent)[TagKind::Indent].
+    /// Nesting (Aligns)[`TagKind::Align`] has the effect that all except the most inner align are handled as (Indent)[`TagKind::Indent`].
     StartAlign(Align),
     EndAlign,
 
@@ -29,7 +29,7 @@ pub enum Tag {
     /// - on a single line: Omitting `LineMode::Soft` line breaks and printing spaces for `LineMode::SoftOrSpace`
     /// - on multiple lines: Printing all line breaks
     ///
-    /// See [crate::builders::group] for documentation and examples.
+    /// See [`crate::builders::group`] for documentation and examples.
     StartGroup(Group),
     EndGroup,
 
@@ -44,22 +44,22 @@ pub enum Tag {
     EndConditionalGroup,
 
     /// Allows to specify content that gets printed depending on whatever the enclosing group
-    /// is printed on a single line or multiple lines. See [crate::builders::if_group_breaks] for examples.
+    /// is printed on a single line or multiple lines. See [`crate::builders::if_group_breaks`] for examples.
     StartConditionalContent(Condition),
     EndConditionalContent,
 
-    /// Optimized version of [Tag::StartConditionalContent] for the case where some content
+    /// Optimized version of [`Tag::StartConditionalContent`] for the case where some content
     /// should be indented if the specified group breaks.
     StartIndentIfGroupBreaks(GroupId),
     EndIndentIfGroupBreaks,
 
     /// Concatenates multiple elements together with a given separator printed in either
     /// flat or expanded mode to fill the print width. Expect that the content is a list of alternating
-    /// [element, separator] See [crate::Formatter::fill].
+    /// [element, separator] See [`crate::Formatter::fill`].
     StartFill,
     EndFill,
 
-    /// Entry inside of a [Tag::StartFill]
+    /// Entry inside of a [`Tag::StartFill`]
     StartEntry,
     EndEntry,
 
@@ -77,7 +77,7 @@ pub enum Tag {
     /// Special semantic element marking the content with a label.
     /// This does not directly influence how the content will be printed.
     ///
-    /// See [crate::builders::labelled] for documentation.
+    /// See [`crate::builders::labelled`] for documentation.
     StartLabelled(LabelId),
     EndLabelled,
 

--- a/crates/ruff_formatter/src/printer/queue.rs
+++ b/crates/ruff_formatter/src/printer/queue.rs
@@ -189,27 +189,6 @@ impl<'a, 'print> Queue<'a> for FitsQueue<'a, 'print> {
     }
 }
 
-/// Iterator that calls [`Queue::pop`] until it reaches the end of the document.
-///
-/// The iterator traverses into the content of any [`FormatElement::Interned`].
-pub(super) struct QueueIterator<'a, 'q, Q: Queue<'a>> {
-    queue: &'q mut Q,
-    lifetime: PhantomData<&'a ()>,
-}
-
-impl<'a, Q> Iterator for QueueIterator<'a, '_, Q>
-where
-    Q: Queue<'a>,
-{
-    type Item = &'a FormatElement;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        self.queue.pop()
-    }
-}
-
-impl<'a, Q> FusedIterator for QueueIterator<'a, '_, Q> where Q: Queue<'a> {}
-
 pub(super) struct QueueContentIterator<'a, 'q, Q: Queue<'a>> {
     queue: &'q mut Q,
     kind: TagKind,

--- a/crates/ruff_formatter/src/printer/stack.rs
+++ b/crates/ruff_formatter/src/printer/stack.rs
@@ -8,9 +8,6 @@ pub(super) trait Stack<T> {
 
     /// Returns the last element if any
     fn top(&self) -> Option<&T>;
-
-    /// Returns `true` if the stack is empty
-    fn is_empty(&self) -> bool;
 }
 
 impl<T> Stack<T> for Vec<T> {
@@ -24,10 +21,6 @@ impl<T> Stack<T> for Vec<T> {
 
     fn top(&self) -> Option<&T> {
         self.last()
-    }
-
-    fn is_empty(&self) -> bool {
-        self.is_empty()
     }
 }
 
@@ -79,10 +72,6 @@ where
         self.stack
             .last()
             .or_else(|| self.original.as_slice().last())
-    }
-
-    fn is_empty(&self) -> bool {
-        self.stack.is_empty() && self.original.len() == 0
     }
 }
 

--- a/crates/ruff_linter/src/directives.rs
+++ b/crates/ruff_linter/src/directives.rs
@@ -273,7 +273,7 @@ pub(crate) struct TodoComment<'a> {
     pub(crate) directive: TodoDirective<'a>,
     /// The comment's actual [`TextRange`].
     pub(crate) range: TextRange,
-    /// The comment range's position in [`Indexer`].`comment_ranges()`
+    /// The comment range's position in [`Indexer::comment_ranges`]
     pub(crate) range_index: usize,
 }
 

--- a/crates/ruff_linter/src/directives.rs
+++ b/crates/ruff_linter/src/directives.rs
@@ -273,7 +273,7 @@ pub(crate) struct TodoComment<'a> {
     pub(crate) directive: TodoDirective<'a>,
     /// The comment's actual [`TextRange`].
     pub(crate) range: TextRange,
-    /// The comment range's position in [`Indexer`].comment_ranges()
+    /// The comment range's position in [`Indexer`].`comment_ranges()`
     pub(crate) range_index: usize,
 }
 

--- a/crates/ruff_linter/src/line_width.rs
+++ b/crates/ruff_linter/src/line_width.rs
@@ -56,7 +56,7 @@ impl CacheKey for LineLength {
 pub enum ParseLineWidthError {
     /// The string could not be parsed as a valid [u16]
     ParseError(ParseIntError),
-    /// The [u16] value of the string is not a valid [LineLength]
+    /// The [u16] value of the string is not a valid [`LineLength`]
     TryFromIntError(LineLengthFromIntError),
 }
 

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/fixes.rs
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/fixes.rs
@@ -531,7 +531,7 @@ pub(crate) fn fix_unnecessary_double_cast_or_process(
                 .find(|argument| argument.keyword.is_none())
             {
                 let mut arg = arg.clone();
-                arg.comma = first.comma.clone();
+                arg.comma.clone_from(&first.comma);
                 arg.whitespace_after_arg = first.whitespace_after_arg.clone();
                 iter::once(arg)
                     .chain(rest.iter().cloned())

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/fix_with.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/fix_with.rs
@@ -67,8 +67,8 @@ pub(crate) fn fix_multiple_with_statements(
 
     outer_with.items.append(&mut inner_with.items);
     if outer_with.lpar.is_none() {
-        outer_with.lpar = inner_with.lpar.clone();
-        outer_with.rpar = inner_with.rpar.clone();
+        outer_with.lpar.clone_from(&inner_with.lpar);
+        outer_with.rpar.clone_from(&inner_with.rpar);
     }
     outer_with.body = inner_with.body.clone();
 

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/logical_lines/redundant_backslash.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/logical_lines/redundant_backslash.rs
@@ -60,7 +60,7 @@ pub(crate) fn redundant_backslash(
                     let start = locator.line_start(token.start());
                     start_index = continuation_lines
                         .binary_search(&start)
-                        .map_or_else(|err_index| err_index, |ok_index| ok_index);
+                        .unwrap_or_else(|err_index| err_index);
                 }
                 parens += 1;
             }
@@ -70,7 +70,7 @@ pub(crate) fn redundant_backslash(
                     let end = locator.line_start(token.start());
                     let end_index = continuation_lines
                         .binary_search(&end)
-                        .map_or_else(|err_index| err_index, |ok_index| ok_index);
+                        .unwrap_or_else(|err_index| err_index);
                     for continuation_line in &continuation_lines[start_index..end_index] {
                         let backslash_end = locator.line_end(*continuation_line);
                         let backslash_start = backslash_end - TextSize::new(1);

--- a/crates/ruff_linter/src/rules/ruff/rules/sequence_sorting.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/sequence_sorting.rs
@@ -48,7 +48,7 @@ impl SortingStyle {
 /// an "isort-style sort".
 ///
 /// An isort-style sort sorts items first according to their casing:
-/// `SCREAMING_SNAKE_CASE` names (conventionally used for global constants)
+/// SCREAMING_SNAKE_CASE names (conventionally used for global constants)
 /// come first, followed by CamelCase names (conventionally used for
 /// classes), followed by anything else. Within each category,
 /// a [natural sort](https://en.wikipedia.org/wiki/Natural_sort_order)

--- a/crates/ruff_python_ast/src/nodes.rs
+++ b/crates/ruff_python_ast/src/nodes.rs
@@ -1006,7 +1006,7 @@ impl ConversionFlag {
 pub struct DebugText {
     /// The text between the `{` and the expression node.
     pub leading: String,
-    /// The text between the expression and the conversion, the format_spec, or the `}`, depending on what's present in the source
+    /// The text between the expression and the conversion, the `format_spec`, or the `}`, depending on what's present in the source
     pub trailing: String,
 }
 

--- a/crates/ruff_python_formatter/src/comments/map.rs
+++ b/crates/ruff_python_formatter/src/comments/map.rs
@@ -246,7 +246,7 @@ impl<K: std::hash::Hash + Eq, V> MultiMap<K, V> {
     /// Returns `true` if `key` has any *leading*, *dangling*, or *trailing* parts.
     #[allow(unused)]
     pub(super) fn has(&self, key: &K) -> bool {
-        self.index.get(key).is_some()
+        self.index.contains_key(key)
     }
 
     /// Returns the *leading*, *dangling*, and *trailing* parts of `key`.
@@ -382,16 +382,16 @@ where
 
 #[derive(Clone, Debug)]
 struct InOrderEntry {
-    /// Index into the [MultiMap::parts] vector where the leading parts of this entry start
+    /// Index into the [`MultiMap::parts`] vector where the leading parts of this entry start
     leading_start: PartIndex,
 
-    /// Index into the [MultiMap::parts] vector where the dangling parts (and, thus, the leading parts end) start.
+    /// Index into the [`MultiMap::parts`] vector where the dangling parts (and, thus, the leading parts end) start.
     dangling_start: PartIndex,
 
-    /// Index into the [MultiMap::parts] vector where the trailing parts (and, thus, the dangling parts end) of this entry start
+    /// Index into the [`MultiMap::parts`] vector where the trailing parts (and, thus, the dangling parts end) of this entry start
     trailing_start: Option<PartIndex>,
 
-    /// Index into the [MultiMap::parts] vector where the trailing parts of this entry end
+    /// Index into the [`MultiMap::parts`] vector where the trailing parts of this entry end
     trailing_end: Option<PartIndex>,
 
     _count: Count<InOrderEntry>,
@@ -505,7 +505,7 @@ impl InOrderEntry {
 
 #[derive(Clone, Debug)]
 struct OutOfOrderEntry {
-    /// Index into the [MultiMap::out_of_order] vector at which offset the leaading vec is stored.
+    /// Index into the [`MultiMap::out_of_order`] vector at which offset the leaading vec is stored.
     leading_index: usize,
     _count: Count<OutOfOrderEntry>,
 }

--- a/crates/ruff_python_formatter/src/comments/mod.rs
+++ b/crates/ruff_python_formatter/src/comments/mod.rs
@@ -195,9 +195,9 @@ type CommentsMap<'a> = MultiMap<NodeRefEqualityKey<'a>, SourceComment>;
 /// Cloning `comments` is cheap as it only involves bumping a reference counter.
 #[derive(Debug, Clone)]
 pub(crate) struct Comments<'a> {
-    /// The implementation uses an [Rc] so that [Comments] has a lifetime independent from the [crate::Formatter].
-    /// Independent lifetimes are necessary to support the use case where a (formattable object)[crate::Format]
-    /// iterates over all comments, and writes them into the [crate::Formatter] (mutably borrowing the [crate::Formatter] and in turn its context).
+    /// The implementation uses an [Rc] so that [Comments] has a lifetime independent from the [`crate::Formatter`].
+    /// Independent lifetimes are necessary to support the use case where a (formattable object)[`crate::Format`]
+    /// iterates over all comments, and writes them into the [`crate::Formatter`] (mutably borrowing the [`crate::Formatter`] and in turn its context).
     ///
     /// ```block
     /// for leading in f.context().comments().leading_comments(node) {

--- a/crates/ruff_python_formatter/src/expression/expr_attribute.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_attribute.rs
@@ -4,7 +4,7 @@ use ruff_python_ast::{Expr, ExprAttribute, ExprNumberLiteral, Number};
 use ruff_python_trivia::{find_only_token_in_range, SimpleTokenKind};
 use ruff_text_size::{Ranged, TextRange};
 
-use crate::comments::{dangling_comments, SourceComment};
+use crate::comments::dangling_comments;
 use crate::expression::parentheses::{
     is_expression_parenthesized, NeedsParentheses, OptionalParentheses, Parentheses,
 };
@@ -122,15 +122,6 @@ impl FormatNodeRule<ExprAttribute> for FormatExprAttribute {
         } else {
             write!(f, [format_inner])
         }
-    }
-
-    fn fmt_dangling_comments(
-        &self,
-        _dangling_comments: &[SourceComment],
-        _f: &mut PyFormatter,
-    ) -> FormatResult<()> {
-        // handle in `fmt_fields`
-        Ok(())
     }
 }
 

--- a/crates/ruff_python_formatter/src/expression/expr_bin_op.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_bin_op.rs
@@ -1,7 +1,6 @@
 use ruff_python_ast::AnyNodeRef;
 use ruff_python_ast::ExprBinOp;
 
-use crate::comments::SourceComment;
 use crate::expression::binary_like::BinaryLike;
 use crate::expression::has_parentheses;
 use crate::expression::parentheses::{NeedsParentheses, OptionalParentheses};
@@ -15,15 +14,6 @@ impl FormatNodeRule<ExprBinOp> for FormatExprBinOp {
     #[inline]
     fn fmt_fields(&self, item: &ExprBinOp, f: &mut PyFormatter) -> FormatResult<()> {
         BinaryLike::Binary(item).fmt(f)
-    }
-
-    fn fmt_dangling_comments(
-        &self,
-        _dangling_comments: &[SourceComment],
-        _f: &mut PyFormatter,
-    ) -> FormatResult<()> {
-        // Handled inside of `fmt_fields`
-        Ok(())
     }
 }
 

--- a/crates/ruff_python_formatter/src/expression/expr_bytes_literal.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_bytes_literal.rs
@@ -1,7 +1,6 @@
 use ruff_python_ast::AnyNodeRef;
 use ruff_python_ast::ExprBytesLiteral;
 
-use crate::comments::SourceComment;
 use crate::expression::parentheses::{
     in_parentheses_only_group, NeedsParentheses, OptionalParentheses,
 };
@@ -20,15 +19,6 @@ impl FormatNodeRule<ExprBytesLiteral> for FormatExprBytesLiteral {
             _ => in_parentheses_only_group(&FormatStringContinuation::new(&AnyString::Bytes(item)))
                 .fmt(f),
         }
-    }
-
-    fn fmt_dangling_comments(
-        &self,
-        _dangling_comments: &[SourceComment],
-        _f: &mut PyFormatter,
-    ) -> FormatResult<()> {
-        // Handled as part of `fmt_fields`
-        Ok(())
     }
 }
 

--- a/crates/ruff_python_formatter/src/expression/expr_call.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_call.rs
@@ -2,7 +2,7 @@ use ruff_formatter::FormatRuleWithOptions;
 use ruff_python_ast::AnyNodeRef;
 use ruff_python_ast::{Expr, ExprCall};
 
-use crate::comments::{dangling_comments, SourceComment};
+use crate::comments::dangling_comments;
 use crate::expression::parentheses::{
     is_expression_parenthesized, NeedsParentheses, OptionalParentheses, Parentheses,
 };
@@ -73,14 +73,6 @@ impl FormatNodeRule<ExprCall> for FormatExprCall {
         } else {
             fmt_func.fmt(f)
         }
-    }
-
-    fn fmt_dangling_comments(
-        &self,
-        _dangling_comments: &[SourceComment],
-        _f: &mut PyFormatter,
-    ) -> FormatResult<()> {
-        Ok(())
     }
 }
 

--- a/crates/ruff_python_formatter/src/expression/expr_compare.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_compare.rs
@@ -2,7 +2,6 @@ use ruff_formatter::{FormatOwnedWithRule, FormatRefWithRule};
 use ruff_python_ast::AnyNodeRef;
 use ruff_python_ast::{CmpOp, ExprCompare};
 
-use crate::comments::SourceComment;
 use crate::expression::binary_like::BinaryLike;
 use crate::expression::has_parentheses;
 use crate::expression::parentheses::{NeedsParentheses, OptionalParentheses};
@@ -16,16 +15,6 @@ impl FormatNodeRule<ExprCompare> for FormatExprCompare {
     #[inline]
     fn fmt_fields(&self, item: &ExprCompare, f: &mut PyFormatter) -> FormatResult<()> {
         BinaryLike::Compare(item).fmt(f)
-    }
-
-    fn fmt_dangling_comments(
-        &self,
-        dangling_comments: &[SourceComment],
-        _f: &mut PyFormatter,
-    ) -> FormatResult<()> {
-        // Node can not have dangling comments
-        debug_assert!(dangling_comments.is_empty());
-        Ok(())
     }
 }
 

--- a/crates/ruff_python_formatter/src/expression/expr_dict.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_dict.rs
@@ -64,15 +64,6 @@ impl FormatNodeRule<ExprDict> for FormatExprDict {
             .with_dangling_comments(open_parenthesis_comments)
             .fmt(f)
     }
-
-    fn fmt_dangling_comments(
-        &self,
-        _dangling_comments: &[SourceComment],
-        _f: &mut PyFormatter,
-    ) -> FormatResult<()> {
-        // Handled by `fmt_fields`
-        Ok(())
-    }
 }
 
 impl NeedsParentheses for ExprDict {

--- a/crates/ruff_python_formatter/src/expression/expr_dict_comp.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_dict_comp.rs
@@ -3,7 +3,7 @@ use ruff_python_ast::AnyNodeRef;
 use ruff_python_ast::ExprDictComp;
 use ruff_text_size::Ranged;
 
-use crate::comments::{dangling_comments, SourceComment};
+use crate::comments::dangling_comments;
 use crate::expression::parentheses::{parenthesized, NeedsParentheses, OptionalParentheses};
 use crate::prelude::*;
 
@@ -57,15 +57,6 @@ impl FormatNodeRule<ExprDictComp> for FormatExprDictComp {
             )
             .with_dangling_comments(open_parenthesis_comments)]
         )
-    }
-
-    fn fmt_dangling_comments(
-        &self,
-        _dangling_node_comments: &[SourceComment],
-        _f: &mut PyFormatter,
-    ) -> FormatResult<()> {
-        // Handled as part of `fmt_fields`
-        Ok(())
     }
 }
 

--- a/crates/ruff_python_formatter/src/expression/expr_f_string.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_f_string.rs
@@ -2,7 +2,6 @@ use ruff_python_ast::{AnyNodeRef, ExprFString};
 use ruff_source_file::Locator;
 use ruff_text_size::Ranged;
 
-use crate::comments::SourceComment;
 use crate::expression::parentheses::{
     in_parentheses_only_group, NeedsParentheses, OptionalParentheses,
 };
@@ -28,15 +27,6 @@ impl FormatNodeRule<ExprFString> for FormatExprFString {
                     .fmt(f)
             }
         }
-    }
-
-    fn fmt_dangling_comments(
-        &self,
-        _dangling_node_comments: &[SourceComment],
-        _f: &mut PyFormatter,
-    ) -> FormatResult<()> {
-        // Handled as part of `fmt_fields`
-        Ok(())
     }
 }
 

--- a/crates/ruff_python_formatter/src/expression/expr_generator.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_generator.rs
@@ -2,7 +2,6 @@ use ruff_formatter::{format_args, write, FormatRuleWithOptions};
 use ruff_python_ast::AnyNodeRef;
 use ruff_python_ast::ExprGenerator;
 
-use crate::comments::SourceComment;
 use crate::expression::parentheses::{parenthesized, NeedsParentheses, OptionalParentheses};
 use crate::prelude::*;
 
@@ -75,15 +74,6 @@ impl FormatNodeRule<ExprGenerator> for FormatExprGenerator {
                 .with_dangling_comments(dangling)]
             )
         }
-    }
-
-    fn fmt_dangling_comments(
-        &self,
-        _dangling_comments: &[SourceComment],
-        _f: &mut PyFormatter,
-    ) -> FormatResult<()> {
-        // Handled as part of `fmt_fields`
-        Ok(())
     }
 }
 

--- a/crates/ruff_python_formatter/src/expression/expr_lambda.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_lambda.rs
@@ -3,7 +3,7 @@ use ruff_python_ast::AnyNodeRef;
 use ruff_python_ast::ExprLambda;
 use ruff_text_size::Ranged;
 
-use crate::comments::{dangling_comments, SourceComment};
+use crate::comments::dangling_comments;
 use crate::expression::parentheses::{NeedsParentheses, OptionalParentheses};
 use crate::other::parameters::ParametersParentheses;
 use crate::prelude::*;
@@ -62,15 +62,6 @@ impl FormatNodeRule<ExprLambda> for FormatExprLambda {
         }
 
         write!(f, [body.format()])
-    }
-
-    fn fmt_dangling_comments(
-        &self,
-        _dangling_comments: &[SourceComment],
-        _f: &mut PyFormatter,
-    ) -> FormatResult<()> {
-        // Override. Dangling comments are handled in `fmt_fields`.
-        Ok(())
     }
 }
 

--- a/crates/ruff_python_formatter/src/expression/expr_list.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_list.rs
@@ -3,7 +3,6 @@ use ruff_python_ast::AnyNodeRef;
 use ruff_python_ast::ExprList;
 use ruff_text_size::Ranged;
 
-use crate::comments::SourceComment;
 use crate::expression::parentheses::{
     empty_parenthesized, parenthesized, NeedsParentheses, OptionalParentheses,
 };
@@ -36,15 +35,6 @@ impl FormatNodeRule<ExprList> for FormatExprList {
         parenthesized("[", &items, "]")
             .with_dangling_comments(dangling)
             .fmt(f)
-    }
-
-    fn fmt_dangling_comments(
-        &self,
-        _dangling_comments: &[SourceComment],
-        _f: &mut PyFormatter,
-    ) -> FormatResult<()> {
-        // Handled as part of `fmt_fields`
-        Ok(())
     }
 }
 

--- a/crates/ruff_python_formatter/src/expression/expr_list_comp.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_list_comp.rs
@@ -2,8 +2,6 @@ use ruff_formatter::{format_args, write, FormatResult};
 use ruff_python_ast::AnyNodeRef;
 use ruff_python_ast::ExprListComp;
 
-use crate::comments::SourceComment;
-
 use crate::expression::parentheses::{parenthesized, NeedsParentheses, OptionalParentheses};
 use crate::prelude::*;
 
@@ -40,15 +38,6 @@ impl FormatNodeRule<ExprListComp> for FormatExprListComp {
             )
             .with_dangling_comments(dangling)]
         )
-    }
-
-    fn fmt_dangling_comments(
-        &self,
-        _dangling_comments: &[SourceComment],
-        _f: &mut PyFormatter,
-    ) -> FormatResult<()> {
-        // Handled as part of `fmt_fields`
-        Ok(())
     }
 }
 

--- a/crates/ruff_python_formatter/src/expression/expr_name.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_name.rs
@@ -2,7 +2,6 @@ use ruff_formatter::write;
 use ruff_python_ast::AnyNodeRef;
 use ruff_python_ast::ExprName;
 
-use crate::comments::SourceComment;
 use crate::expression::parentheses::{NeedsParentheses, OptionalParentheses};
 use crate::prelude::*;
 
@@ -17,16 +16,6 @@ impl FormatNodeRule<ExprName> for FormatExprName {
             ctx: _,
         } = item;
         write!(f, [source_text_slice(*range)])
-    }
-
-    fn fmt_dangling_comments(
-        &self,
-        dangling_comments: &[SourceComment],
-        _f: &mut PyFormatter,
-    ) -> FormatResult<()> {
-        // Node cannot have dangling comments
-        debug_assert!(dangling_comments.is_empty());
-        Ok(())
     }
 }
 

--- a/crates/ruff_python_formatter/src/expression/expr_named.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_named.rs
@@ -2,7 +2,7 @@ use ruff_formatter::{format_args, write};
 use ruff_python_ast::AnyNodeRef;
 use ruff_python_ast::ExprNamed;
 
-use crate::comments::{dangling_comments, SourceComment};
+use crate::comments::dangling_comments;
 use crate::expression::parentheses::{
     in_parentheses_only_soft_line_break_or_space, NeedsParentheses, OptionalParentheses,
 };
@@ -41,15 +41,6 @@ impl FormatNodeRule<ExprNamed> for FormatExprNamed {
         }
 
         write!(f, [value.format()])
-    }
-
-    fn fmt_dangling_comments(
-        &self,
-        _dangling_comments: &[SourceComment],
-        _f: &mut PyFormatter,
-    ) -> FormatResult<()> {
-        // Handled by `fmt_fields`
-        Ok(())
     }
 }
 

--- a/crates/ruff_python_formatter/src/expression/expr_set.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_set.rs
@@ -2,7 +2,6 @@ use ruff_python_ast::AnyNodeRef;
 use ruff_python_ast::ExprSet;
 use ruff_text_size::Ranged;
 
-use crate::comments::SourceComment;
 use crate::expression::parentheses::{parenthesized, NeedsParentheses, OptionalParentheses};
 use crate::prelude::*;
 
@@ -27,15 +26,6 @@ impl FormatNodeRule<ExprSet> for FormatExprSet {
         parenthesized("{", &joined, "}")
             .with_dangling_comments(dangling)
             .fmt(f)
-    }
-
-    fn fmt_dangling_comments(
-        &self,
-        _dangling_comments: &[SourceComment],
-        _f: &mut PyFormatter,
-    ) -> FormatResult<()> {
-        // Handled as part of `fmt_fields`
-        Ok(())
     }
 }
 

--- a/crates/ruff_python_formatter/src/expression/expr_set_comp.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_set_comp.rs
@@ -2,8 +2,6 @@ use ruff_formatter::{format_args, write, Buffer, FormatResult};
 use ruff_python_ast::AnyNodeRef;
 use ruff_python_ast::ExprSetComp;
 
-use crate::comments::SourceComment;
-
 use crate::expression::parentheses::{parenthesized, NeedsParentheses, OptionalParentheses};
 use crate::prelude::*;
 
@@ -40,15 +38,6 @@ impl FormatNodeRule<ExprSetComp> for FormatExprSetComp {
             )
             .with_dangling_comments(dangling)]
         )
-    }
-
-    fn fmt_dangling_comments(
-        &self,
-        _dangling_comments: &[SourceComment],
-        _f: &mut PyFormatter,
-    ) -> FormatResult<()> {
-        // Handled as part of `fmt_fields`
-        Ok(())
     }
 }
 

--- a/crates/ruff_python_formatter/src/expression/expr_slice.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_slice.rs
@@ -146,15 +146,6 @@ impl FormatNodeRule<ExprSlice> for FormatExprSlice {
         }
         Ok(())
     }
-
-    fn fmt_dangling_comments(
-        &self,
-        _dangling_node_comments: &[SourceComment],
-        _f: &mut PyFormatter,
-    ) -> FormatResult<()> {
-        // Handled as part of `fmt_fields`
-        Ok(())
-    }
 }
 
 /// We're in a slice, so we know there's a first colon, but with have to look into the source

--- a/crates/ruff_python_formatter/src/expression/expr_starred.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_starred.rs
@@ -2,7 +2,7 @@ use ruff_formatter::write;
 use ruff_python_ast::AnyNodeRef;
 use ruff_python_ast::ExprStarred;
 
-use crate::comments::{dangling_comments, SourceComment};
+use crate::comments::dangling_comments;
 
 use crate::expression::parentheses::{NeedsParentheses, OptionalParentheses};
 use crate::prelude::*;
@@ -22,14 +22,6 @@ impl FormatNodeRule<ExprStarred> for FormatExprStarred {
         let dangling = comments.dangling(item);
 
         write!(f, [token("*"), dangling_comments(dangling), value.format()])
-    }
-
-    fn fmt_dangling_comments(
-        &self,
-        _dangling_comments: &[SourceComment],
-        _f: &mut PyFormatter,
-    ) -> FormatResult<()> {
-        Ok(())
     }
 }
 

--- a/crates/ruff_python_formatter/src/expression/expr_string_literal.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_string_literal.rs
@@ -1,7 +1,6 @@
 use ruff_formatter::FormatRuleWithOptions;
 use ruff_python_ast::{AnyNodeRef, ExprStringLiteral};
 
-use crate::comments::SourceComment;
 use crate::expression::parentheses::{
     in_parentheses_only_group, NeedsParentheses, OptionalParentheses,
 };
@@ -60,14 +59,6 @@ impl FormatNodeRule<ExprStringLiteral> for FormatExprStringLiteral {
             }
             .fmt(f),
         }
-    }
-
-    fn fmt_dangling_comments(
-        &self,
-        _dangling_comments: &[SourceComment],
-        _f: &mut PyFormatter,
-    ) -> FormatResult<()> {
-        Ok(())
     }
 }
 

--- a/crates/ruff_python_formatter/src/expression/expr_subscript.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_subscript.rs
@@ -2,7 +2,6 @@ use ruff_formatter::{write, FormatRuleWithOptions};
 use ruff_python_ast::{AnyNodeRef, AstNode};
 use ruff_python_ast::{Expr, ExprSubscript};
 
-use crate::comments::SourceComment;
 use crate::expression::expr_tuple::TupleParentheses;
 use crate::expression::parentheses::{
     is_expression_parenthesized, parenthesized, NeedsParentheses, OptionalParentheses, Parentheses,
@@ -78,15 +77,6 @@ impl FormatNodeRule<ExprSubscript> for FormatExprSubscript {
         } else {
             write!(f, [format_inner])
         }
-    }
-
-    fn fmt_dangling_comments(
-        &self,
-        _dangling_comments: &[SourceComment],
-        _f: &mut PyFormatter,
-    ) -> FormatResult<()> {
-        // Handled inside of `fmt_fields`
-        Ok(())
     }
 }
 

--- a/crates/ruff_python_formatter/src/expression/expr_tuple.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_tuple.rs
@@ -4,7 +4,6 @@ use ruff_python_ast::ExprTuple;
 use ruff_text_size::{Ranged, TextRange};
 
 use crate::builders::parenthesize_if_expands;
-use crate::comments::SourceComment;
 use crate::expression::parentheses::{
     empty_parenthesized, optional_parentheses, parenthesized, NeedsParentheses, OptionalParentheses,
 };
@@ -202,15 +201,6 @@ impl FormatNodeRule<ExprTuple> for FormatExprTuple {
                 }
             },
         }
-    }
-
-    fn fmt_dangling_comments(
-        &self,
-        _dangling_comments: &[SourceComment],
-        _f: &mut PyFormatter,
-    ) -> FormatResult<()> {
-        // Handled in `fmt_fields`
-        Ok(())
     }
 }
 

--- a/crates/ruff_python_formatter/src/expression/expr_unary_op.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_unary_op.rs
@@ -2,7 +2,7 @@ use ruff_python_ast::AnyNodeRef;
 use ruff_python_ast::ExprUnaryOp;
 use ruff_python_ast::UnaryOp;
 
-use crate::comments::{trailing_comments, SourceComment};
+use crate::comments::trailing_comments;
 use crate::expression::parentheses::{
     is_expression_parenthesized, NeedsParentheses, OptionalParentheses, Parentheses,
 };
@@ -65,14 +65,6 @@ impl FormatNodeRule<ExprUnaryOp> for FormatExprUnaryOp {
         } else {
             operand.format().fmt(f)
         }
-    }
-
-    fn fmt_dangling_comments(
-        &self,
-        _dangling_comments: &[SourceComment],
-        _f: &mut PyFormatter,
-    ) -> FormatResult<()> {
-        Ok(())
     }
 }
 

--- a/crates/ruff_python_formatter/src/lib.rs
+++ b/crates/ruff_python_formatter/src/lib.rs
@@ -12,8 +12,7 @@ use ruff_python_trivia::CommentRanges;
 use ruff_source_file::Locator;
 
 use crate::comments::{
-    dangling_comments, has_skip_comment, leading_comments, trailing_comments, Comments,
-    SourceComment,
+    has_skip_comment, leading_comments, trailing_comments, Comments, SourceComment,
 };
 pub use crate::context::PyFormatContext;
 pub use crate::options::{
@@ -75,6 +74,8 @@ where
 
             self.fmt_fields(node, f)?;
 
+            debug_assert!(node_comments.dangling.iter().all(SourceComment::is_formatted), "The node has dangling comments that need to be formatted manually. Add the special dangling comments handling to `fmt_fields`.");
+
             write!(
                 f,
                 [
@@ -87,26 +88,6 @@ where
 
     /// Formats the node's fields.
     fn fmt_fields(&self, item: &N, f: &mut PyFormatter) -> FormatResult<()>;
-
-    /// Formats the [dangling comments](comments#dangling-comments) of the node.
-    ///
-    /// You should override this method if the node handled by this rule can have dangling comments because the
-    /// default implementation formats the dangling comments at the end of the node, which isn't ideal but ensures that
-    /// no comments are dropped.
-    ///
-    /// A node can have dangling comments if all its children are tokens or if all node children are optional.
-    fn fmt_dangling_comments(
-        &self,
-        dangling_node_comments: &[SourceComment],
-        f: &mut PyFormatter,
-    ) -> FormatResult<()> {
-        debug_assert!(
-            dangling_node_comments.is_empty(),
-            "The node has dangling comments that need to be formatted manually. Add the special dangling comments handling to `fmt_fields` and override `fmt_dangling_comments` with an empty implementation that returns `Ok(())`."
-        );
-
-        dangling_comments(dangling_node_comments).fmt(f)
-    }
 
     fn is_suppressed(
         &self,

--- a/crates/ruff_python_formatter/src/module/mod_module.rs
+++ b/crates/ruff_python_formatter/src/module/mod_module.rs
@@ -2,7 +2,6 @@ use ruff_formatter::write;
 use ruff_python_ast::ModModule;
 use ruff_python_trivia::lines_after;
 
-use crate::comments::SourceComment;
 use crate::prelude::*;
 use crate::statement::suite::SuiteKind;
 use crate::FormatNodeRule;
@@ -33,15 +32,5 @@ impl FormatNodeRule<ModModule> for FormatModModule {
                 ]
             )
         }
-    }
-
-    fn fmt_dangling_comments(
-        &self,
-        dangling_comments: &[SourceComment],
-        _f: &mut PyFormatter,
-    ) -> FormatResult<()> {
-        // Node can't have dangling comments.
-        debug_assert!(dangling_comments.is_empty());
-        Ok(())
     }
 }

--- a/crates/ruff_python_formatter/src/other/arguments.rs
+++ b/crates/ruff_python_formatter/src/other/arguments.rs
@@ -3,7 +3,6 @@ use ruff_python_ast::{ArgOrKeyword, Arguments, Expr};
 use ruff_python_trivia::{PythonWhitespace, SimpleTokenKind, SimpleTokenizer};
 use ruff_text_size::{Ranged, TextLen, TextRange, TextSize};
 
-use crate::comments::SourceComment;
 use crate::expression::expr_generator::GeneratorExpParentheses;
 use crate::expression::is_expression_huggable;
 use crate::expression::parentheses::{empty_parenthesized, parenthesized, Parentheses};
@@ -111,15 +110,6 @@ impl FormatNodeRule<Arguments> for FormatArguments {
                     .with_dangling_comments(dangling_comments)
             ]
         )
-    }
-
-    fn fmt_dangling_comments(
-        &self,
-        _dangling_comments: &[SourceComment],
-        _f: &mut PyFormatter,
-    ) -> FormatResult<()> {
-        // Handled in `fmt_fields`
-        Ok(())
     }
 }
 

--- a/crates/ruff_python_formatter/src/other/comprehension.rs
+++ b/crates/ruff_python_formatter/src/other/comprehension.rs
@@ -3,7 +3,7 @@ use ruff_python_ast::{Comprehension, Expr};
 use ruff_python_trivia::{find_only_token_in_range, SimpleTokenKind};
 use ruff_text_size::{Ranged, TextRange};
 
-use crate::comments::{leading_comments, trailing_comments, SourceComment};
+use crate::comments::{leading_comments, trailing_comments};
 use crate::expression::expr_tuple::TupleParentheses;
 use crate::prelude::*;
 
@@ -113,15 +113,6 @@ impl FormatNodeRule<Comprehension> for FormatComprehension {
 
             write!(f, [soft_line_break_or_space(), joined])?;
         }
-        Ok(())
-    }
-
-    fn fmt_dangling_comments(
-        &self,
-        _dangling_comments: &[SourceComment],
-        _f: &mut PyFormatter,
-    ) -> FormatResult<()> {
-        // dangling comments are formatted as part of fmt_fields
         Ok(())
     }
 }

--- a/crates/ruff_python_formatter/src/other/except_handler_except_handler.rs
+++ b/crates/ruff_python_formatter/src/other/except_handler_except_handler.rs
@@ -2,7 +2,6 @@ use ruff_formatter::write;
 use ruff_formatter::FormatRuleWithOptions;
 use ruff_python_ast::ExceptHandlerExceptHandler;
 
-use crate::comments::SourceComment;
 use crate::expression::maybe_parenthesize_expression;
 use crate::expression::parentheses::Parenthesize;
 use crate::prelude::*;
@@ -88,14 +87,5 @@ impl FormatNodeRule<ExceptHandlerExceptHandler> for FormatExceptHandlerExceptHan
                 clause_body(body, dangling_comments),
             ]
         )
-    }
-
-    fn fmt_dangling_comments(
-        &self,
-        _dangling_comments: &[SourceComment],
-        _f: &mut PyFormatter,
-    ) -> FormatResult<()> {
-        // dangling comments are formatted as part of fmt_fields
-        Ok(())
     }
 }

--- a/crates/ruff_python_formatter/src/other/match_case.rs
+++ b/crates/ruff_python_formatter/src/other/match_case.rs
@@ -3,7 +3,6 @@ use ruff_python_ast::AstNode;
 use ruff_python_ast::MatchCase;
 
 use crate::builders::parenthesize_if_expands;
-use crate::comments::SourceComment;
 use crate::expression::parentheses::{NeedsParentheses, OptionalParentheses, Parentheses};
 use crate::prelude::*;
 use crate::statement::clause::{clause_body, clause_header, ClauseHeader};
@@ -67,14 +66,5 @@ impl FormatNodeRule<MatchCase> for FormatMatchCase {
                 clause_body(body, dangling_item_comments),
             ]
         )
-    }
-
-    fn fmt_dangling_comments(
-        &self,
-        _dangling_comments: &[SourceComment],
-        _f: &mut PyFormatter,
-    ) -> FormatResult<()> {
-        // Handled as part of `fmt_fields`
-        Ok(())
     }
 }

--- a/crates/ruff_python_formatter/src/other/parameters.rs
+++ b/crates/ruff_python_formatter/src/other/parameters.rs
@@ -277,15 +277,6 @@ impl FormatNodeRule<Parameters> for FormatParameters {
             )
         }
     }
-
-    fn fmt_dangling_comments(
-        &self,
-        _dangling_comments: &[SourceComment],
-        _f: &mut PyFormatter,
-    ) -> FormatResult<()> {
-        // Handled in `fmt_fields`
-        Ok(())
-    }
 }
 
 struct CommentsAroundText<'a> {

--- a/crates/ruff_python_formatter/src/other/with_item.rs
+++ b/crates/ruff_python_formatter/src/other/with_item.rs
@@ -1,7 +1,6 @@
 use ruff_formatter::{write, FormatRuleWithOptions};
 use ruff_python_ast::WithItem;
 
-use crate::comments::SourceComment;
 use crate::expression::maybe_parenthesize_expression;
 use crate::expression::parentheses::{
     is_expression_parenthesized, parenthesized, Parentheses, Parenthesize,
@@ -173,14 +172,6 @@ impl FormatNodeRule<WithItem> for FormatWithItem {
             }
         }
 
-        Ok(())
-    }
-
-    fn fmt_dangling_comments(
-        &self,
-        _dangling_comments: &[SourceComment],
-        _f: &mut PyFormatter,
-    ) -> FormatResult<()> {
         Ok(())
     }
 }

--- a/crates/ruff_python_formatter/src/pattern/pattern_arguments.rs
+++ b/crates/ruff_python_formatter/src/pattern/pattern_arguments.rs
@@ -4,7 +4,6 @@ use ruff_python_ast::{Pattern, PatternArguments};
 use ruff_python_trivia::{SimpleTokenKind, SimpleTokenizer};
 use ruff_text_size::{Ranged, TextRange, TextSize};
 
-use crate::comments::SourceComment;
 use crate::expression::parentheses::{empty_parenthesized, parenthesized, Parentheses};
 use crate::prelude::*;
 
@@ -71,14 +70,6 @@ impl FormatNodeRule<PatternArguments> for FormatPatternArguments {
             [parenthesized("(", &group(&all_arguments), ")")
                 .with_dangling_comments(dangling_comments)]
         )
-    }
-
-    fn fmt_dangling_comments(
-        &self,
-        _dangling_comments: &[SourceComment],
-        _f: &mut PyFormatter,
-    ) -> FormatResult<()> {
-        Ok(())
     }
 }
 

--- a/crates/ruff_python_formatter/src/pattern/pattern_match_as.rs
+++ b/crates/ruff_python_formatter/src/pattern/pattern_match_as.rs
@@ -2,7 +2,7 @@ use ruff_formatter::write;
 use ruff_python_ast::AnyNodeRef;
 use ruff_python_ast::PatternMatchAs;
 
-use crate::comments::{dangling_comments, SourceComment};
+use crate::comments::dangling_comments;
 use crate::expression::parentheses::{NeedsParentheses, OptionalParentheses};
 use crate::prelude::*;
 
@@ -47,14 +47,6 @@ impl FormatNodeRule<PatternMatchAs> for FormatPatternMatchAs {
             debug_assert!(pattern.is_none());
             token("_").fmt(f)
         }
-    }
-
-    fn fmt_dangling_comments(
-        &self,
-        _dangling_comments: &[SourceComment],
-        _f: &mut PyFormatter,
-    ) -> FormatResult<()> {
-        Ok(())
     }
 }
 

--- a/crates/ruff_python_formatter/src/pattern/pattern_match_class.rs
+++ b/crates/ruff_python_formatter/src/pattern/pattern_match_class.rs
@@ -2,7 +2,7 @@ use ruff_formatter::write;
 use ruff_python_ast::AnyNodeRef;
 use ruff_python_ast::PatternMatchClass;
 
-use crate::comments::{dangling_comments, SourceComment};
+use crate::comments::dangling_comments;
 use crate::expression::parentheses::{NeedsParentheses, OptionalParentheses};
 use crate::prelude::*;
 
@@ -28,14 +28,6 @@ impl FormatNodeRule<PatternMatchClass> for FormatPatternMatchClass {
                 arguments.format()
             ]
         )
-    }
-
-    fn fmt_dangling_comments(
-        &self,
-        _dangling_comments: &[SourceComment],
-        _f: &mut PyFormatter,
-    ) -> FormatResult<()> {
-        Ok(())
     }
 }
 

--- a/crates/ruff_python_formatter/src/pattern/pattern_match_mapping.rs
+++ b/crates/ruff_python_formatter/src/pattern/pattern_match_mapping.rs
@@ -90,15 +90,6 @@ impl FormatNodeRule<PatternMatchMapping> for FormatPatternMatchMapping {
             .with_dangling_comments(open_parenthesis_comments)
             .fmt(f)
     }
-
-    fn fmt_dangling_comments(
-        &self,
-        _dangling_comments: &[SourceComment],
-        _f: &mut PyFormatter,
-    ) -> FormatResult<()> {
-        // Handled by `fmt_fields`
-        Ok(())
-    }
 }
 
 impl NeedsParentheses for PatternMatchMapping {

--- a/crates/ruff_python_formatter/src/pattern/pattern_match_sequence.rs
+++ b/crates/ruff_python_formatter/src/pattern/pattern_match_sequence.rs
@@ -1,4 +1,3 @@
-use crate::comments::SourceComment;
 use ruff_formatter::{format_args, Format, FormatResult};
 use ruff_python_ast::AnyNodeRef;
 use ruff_python_ast::PatternMatchSequence;
@@ -55,15 +54,6 @@ impl FormatNodeRule<PatternMatchSequence> for FormatPatternMatchSequence {
                 .fmt(f),
             SequenceType::TupleNoParens => optional_parentheses(&items).fmt(f),
         }
-    }
-
-    fn fmt_dangling_comments(
-        &self,
-        _dangling_node_comments: &[SourceComment],
-        _f: &mut PyFormatter,
-    ) -> FormatResult<()> {
-        // Handled as part of `fmt_fields`
-        Ok(())
     }
 }
 

--- a/crates/ruff_python_formatter/src/pattern/pattern_match_star.rs
+++ b/crates/ruff_python_formatter/src/pattern/pattern_match_star.rs
@@ -2,7 +2,7 @@ use ruff_formatter::write;
 use ruff_python_ast::AnyNodeRef;
 use ruff_python_ast::PatternMatchStar;
 
-use crate::comments::{dangling_comments, SourceComment};
+use crate::comments::dangling_comments;
 use crate::expression::parentheses::{NeedsParentheses, OptionalParentheses};
 use crate::prelude::*;
 
@@ -22,15 +22,6 @@ impl FormatNodeRule<PatternMatchStar> for FormatPatternMatchStar {
             Some(name) => write!(f, [name.format()]),
             None => write!(f, [token("_")]),
         }
-    }
-
-    fn fmt_dangling_comments(
-        &self,
-        _dangling_comments: &[SourceComment],
-        _f: &mut PyFormatter,
-    ) -> FormatResult<()> {
-        // Handled by `fmt_fields`
-        Ok(())
     }
 }
 

--- a/crates/ruff_python_formatter/src/statement/stmt_class_def.rs
+++ b/crates/ruff_python_formatter/src/statement/stmt_class_def.rs
@@ -157,15 +157,6 @@ impl FormatNodeRule<StmtClassDef> for FormatStmtClassDef {
 
         Ok(())
     }
-
-    fn fmt_dangling_comments(
-        &self,
-        _dangling_comments: &[SourceComment],
-        _f: &mut PyFormatter,
-    ) -> FormatResult<()> {
-        // handled in fmt_fields
-        Ok(())
-    }
 }
 
 pub(super) struct FormatDecorators<'a> {

--- a/crates/ruff_python_formatter/src/statement/stmt_delete.rs
+++ b/crates/ruff_python_formatter/src/statement/stmt_delete.rs
@@ -54,15 +54,6 @@ impl FormatNodeRule<StmtDelete> for FormatStmtDelete {
         }
     }
 
-    fn fmt_dangling_comments(
-        &self,
-        _dangling_comments: &[SourceComment],
-        _f: &mut PyFormatter,
-    ) -> FormatResult<()> {
-        // Handled in `fmt_fields`
-        Ok(())
-    }
-
     fn is_suppressed(
         &self,
         trailing_comments: &[SourceComment],

--- a/crates/ruff_python_formatter/src/statement/stmt_for.rs
+++ b/crates/ruff_python_formatter/src/statement/stmt_for.rs
@@ -2,7 +2,6 @@ use ruff_formatter::{format_args, write};
 use ruff_python_ast::{Expr, Stmt, StmtFor};
 use ruff_text_size::Ranged;
 
-use crate::comments::SourceComment;
 use crate::expression::expr_tuple::TupleParentheses;
 use crate::expression::maybe_parenthesize_expression;
 use crate::expression::parentheses::Parenthesize;
@@ -91,15 +90,6 @@ impl FormatNodeRule<StmtFor> for FormatStmtFor {
             )?;
         }
 
-        Ok(())
-    }
-
-    fn fmt_dangling_comments(
-        &self,
-        _dangling_comments: &[SourceComment],
-        _f: &mut PyFormatter,
-    ) -> FormatResult<()> {
-        // Handled in `fmt_fields`
         Ok(())
     }
 }

--- a/crates/ruff_python_formatter/src/statement/stmt_function_def.rs
+++ b/crates/ruff_python_formatter/src/statement/stmt_function_def.rs
@@ -4,7 +4,6 @@ use ruff_python_ast::{NodeKind, StmtFunctionDef};
 use crate::comments::format::{
     empty_lines_after_leading_comments, empty_lines_before_trailing_comments,
 };
-use crate::comments::SourceComment;
 use crate::expression::maybe_parenthesize_expression;
 use crate::expression::parentheses::{Parentheses, Parenthesize};
 use crate::prelude::*;
@@ -89,15 +88,6 @@ impl FormatNodeRule<StmtFunctionDef> for FormatStmtFunctionDef {
         // ```
         empty_lines_before_trailing_comments(f, comments.trailing(item), NodeKind::StmtFunctionDef)
             .fmt(f)
-    }
-
-    fn fmt_dangling_comments(
-        &self,
-        _dangling_comments: &[SourceComment],
-        _f: &mut PyFormatter,
-    ) -> FormatResult<()> {
-        // Handled in `fmt_fields`
-        Ok(())
     }
 }
 

--- a/crates/ruff_python_formatter/src/statement/stmt_if.rs
+++ b/crates/ruff_python_formatter/src/statement/stmt_if.rs
@@ -3,7 +3,6 @@ use ruff_python_ast::AnyNodeRef;
 use ruff_python_ast::{ElifElseClause, StmtIf};
 use ruff_text_size::Ranged;
 
-use crate::comments::SourceComment;
 use crate::expression::maybe_parenthesize_expression;
 use crate::expression::parentheses::Parenthesize;
 use crate::prelude::*;
@@ -46,15 +45,6 @@ impl FormatNodeRule<StmtIf> for FormatStmtIf {
             last_node = clause.body.last().unwrap().into();
         }
 
-        Ok(())
-    }
-
-    fn fmt_dangling_comments(
-        &self,
-        _dangling_comments: &[SourceComment],
-        _f: &mut PyFormatter,
-    ) -> FormatResult<()> {
-        // Handled by `fmt_fields`
         Ok(())
     }
 }

--- a/crates/ruff_python_formatter/src/statement/stmt_import_from.rs
+++ b/crates/ruff_python_formatter/src/statement/stmt_import_from.rs
@@ -73,15 +73,6 @@ impl FormatNodeRule<StmtImportFrom> for FormatStmtImportFrom {
         }
     }
 
-    fn fmt_dangling_comments(
-        &self,
-        _dangling_comments: &[SourceComment],
-        _f: &mut PyFormatter,
-    ) -> FormatResult<()> {
-        // Handled in `fmt_fields`
-        Ok(())
-    }
-
     fn is_suppressed(
         &self,
         trailing_comments: &[SourceComment],

--- a/crates/ruff_python_formatter/src/statement/stmt_match.rs
+++ b/crates/ruff_python_formatter/src/statement/stmt_match.rs
@@ -1,7 +1,7 @@
 use ruff_formatter::{format_args, write};
 use ruff_python_ast::StmtMatch;
 
-use crate::comments::{leading_alternate_branch_comments, SourceComment};
+use crate::comments::leading_alternate_branch_comments;
 use crate::context::{NodeLevel, WithNodeLevel};
 use crate::expression::maybe_parenthesize_expression;
 use crate::expression::parentheses::Parenthesize;
@@ -61,15 +61,6 @@ impl FormatNodeRule<StmtMatch> for FormatStmtMatch {
             last_case = case;
         }
 
-        Ok(())
-    }
-
-    fn fmt_dangling_comments(
-        &self,
-        _dangling_comments: &[SourceComment],
-        _f: &mut PyFormatter,
-    ) -> FormatResult<()> {
-        // Handled as part of `fmt_fields`
         Ok(())
     }
 }

--- a/crates/ruff_python_formatter/src/statement/stmt_try.rs
+++ b/crates/ruff_python_formatter/src/statement/stmt_try.rs
@@ -93,15 +93,6 @@ impl FormatNodeRule<StmtTry> for FormatStmtTry {
 
         write!(f, [comments::dangling_comments(dangling_comments)])
     }
-
-    fn fmt_dangling_comments(
-        &self,
-        _dangling_comments: &[SourceComment],
-        _f: &mut PyFormatter,
-    ) -> FormatResult<()> {
-        // dangling comments are formatted as part of AnyStatementTry::fmt
-        Ok(())
-    }
 }
 
 fn format_case<'a>(

--- a/crates/ruff_python_formatter/src/statement/stmt_while.rs
+++ b/crates/ruff_python_formatter/src/statement/stmt_while.rs
@@ -3,7 +3,6 @@ use ruff_python_ast::AstNode;
 use ruff_python_ast::{Stmt, StmtWhile};
 use ruff_text_size::Ranged;
 
-use crate::comments::SourceComment;
 use crate::expression::maybe_parenthesize_expression;
 use crate::expression::parentheses::Parenthesize;
 use crate::prelude::*;
@@ -68,15 +67,6 @@ impl FormatNodeRule<StmtWhile> for FormatStmtWhile {
             )?;
         }
 
-        Ok(())
-    }
-
-    fn fmt_dangling_comments(
-        &self,
-        _dangling_comments: &[SourceComment],
-        _f: &mut PyFormatter,
-    ) -> FormatResult<()> {
-        // Handled in `fmt_fields`
         Ok(())
     }
 }

--- a/crates/ruff_python_formatter/src/statement/stmt_with.rs
+++ b/crates/ruff_python_formatter/src/statement/stmt_with.rs
@@ -128,15 +128,6 @@ impl FormatNodeRule<StmtWith> for FormatStmtWith {
             ]
         )
     }
-
-    fn fmt_dangling_comments(
-        &self,
-        _dangling_comments: &[SourceComment],
-        _f: &mut PyFormatter,
-    ) -> FormatResult<()> {
-        // Handled in `fmt_fields`
-        Ok(())
-    }
 }
 
 #[derive(Clone, Copy, Debug)]

--- a/crates/ruff_python_formatter/src/string/docstring.rs
+++ b/crates/ruff_python_formatter/src/string/docstring.rs
@@ -218,7 +218,7 @@ fn contains_unescaped_newline(haystack: &str) -> bool {
     let mut rest = haystack;
 
     while let Some(index) = memchr::memchr(b'\\', rest.as_bytes()) {
-        rest = &rest[index + 1..].trim_whitespace_start();
+        rest = rest[index + 1..].trim_whitespace_start();
 
         if rest.starts_with('\n') {
             return true;

--- a/crates/ruff_python_formatter/src/type_param/type_params.rs
+++ b/crates/ruff_python_formatter/src/type_param/type_params.rs
@@ -4,7 +4,6 @@ use ruff_python_ast::TypeParams;
 use ruff_text_size::Ranged;
 
 use crate::builders::PyFormatterExtensions;
-use crate::comments::SourceComment;
 use crate::expression::parentheses::parenthesized;
 use crate::prelude::*;
 
@@ -33,14 +32,5 @@ impl FormatNodeRule<TypeParams> for FormatTypeParams {
         parenthesized("[", &items, "]")
             .with_dangling_comments(dangling_comments)
             .fmt(f)
-    }
-
-    fn fmt_dangling_comments(
-        &self,
-        _dangling_comments: &[SourceComment],
-        _f: &mut PyFormatter,
-    ) -> FormatResult<()> {
-        // Handled in `fmt_fields`
-        Ok(())
     }
 }

--- a/crates/ruff_python_semantic/src/scope.rs
+++ b/crates/ruff_python_semantic/src/scope.rs
@@ -185,7 +185,7 @@ pub enum ScopeKind<'a> {
     Function(&'a ast::StmtFunctionDef),
     Generator,
     Module,
-    /// A Python 3.12+ ["annotation scope"](https://docs.python.org/3/reference/executionmodel.html#annotation-scopes)
+    /// A Python 3.12+ [annotation scope](https://docs.python.org/3/reference/executionmodel.html#annotation-scopes)
     Type,
     Lambda(&'a ast::ExprLambda),
 }

--- a/crates/ruff_server/src/edit/document.rs
+++ b/crates/ruff_server/src/edit/document.rs
@@ -56,7 +56,7 @@ impl Document {
         {
             tracing::debug!("Fast path - replacing entire document");
             self.modify(|contents, version| {
-                *contents = text.clone();
+                contents.clone_from(text);
                 *version = new_version;
             });
             return;

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -610,8 +610,8 @@ Options:
           Enable preview mode; checks will include unstable rules and fixes.
           Use `--no-preview` to disable
       --extension <EXTENSION>
-          List of mappings from file extension to language (one of ["python",
-          "ipynb", "pyi"]). For example, to treat `.ipy` files as IPython
+          List of mappings from file extension to language (one of `"python"`,
+          `"ipynb"`, `"pyi"`). For example, to treat `.ipy` files as IPython
           notebooks, use `--extension ipy:ipynb`
       --statistics
           Show counts for every rule with at least one violation
@@ -715,8 +715,8 @@ Options:
           status code and the difference between the current file and how the
           formatted file would look like
       --extension <EXTENSION>
-          List of mappings from file extension to language (one of ["python",
-          "ipynb", "pyi"]). For example, to treat `.ipy` files as IPython
+          List of mappings from file extension to language (one of [`"python"`,
+          `"ipynb"`, `"pyi"`]). For example, to treat `.ipy` files as IPython
           notebooks, use `--extension ipy:ipynb`
       --target-version <TARGET_VERSION>
           The minimum Python version that should be supported [possible values:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -610,8 +610,8 @@ Options:
           Enable preview mode; checks will include unstable rules and fixes.
           Use `--no-preview` to disable
       --extension <EXTENSION>
-          List of mappings from file extension to language (one of `"python"`,
-          `"ipynb"`, `"pyi"`). For example, to treat `.ipy` files as IPython
+          List of mappings from file extension to language (one of `python`,
+          `ipynb`, `pyi`). For example, to treat `.ipy` files as IPython
           notebooks, use `--extension ipy:ipynb`
       --statistics
           Show counts for every rule with at least one violation
@@ -715,8 +715,8 @@ Options:
           status code and the difference between the current file and how the
           formatted file would look like
       --extension <EXTENSION>
-          List of mappings from file extension to language (one of [`"python"`,
-          `"ipynb"`, `"pyi"`]). For example, to treat `.ipy` files as IPython
+          List of mappings from file extension to language (one of `python`,
+          `ipynb`, `pyi`). For example, to treat `.ipy` files as IPython
           notebooks, use `--extension ipy:ipynb`
       --target-version <TARGET_VERSION>
           The minimum Python version that should be supported [possible values:

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.77"
+channel = "1.78"


### PR DESCRIPTION
## Summary

Sets the local toolchain to 1.78. This PR does not update the minimal required rust version.

## Test Plan

`cargo test`
