### PR TITLE
`ruff server`: Editor settings are used by default if no file-based configuration exists

### DIFF
--- a/crates/ruff_server/src/session/workspace/ruff_settings.rs
+++ b/crates/ruff_server/src/session/workspace/ruff_settings.rs
@@ -89,7 +89,15 @@ impl RuffSettingsIndex {
                 )
                 .ok()
             })
-            .unwrap_or_default();
+            .unwrap_or_else(|| {
+                let default_configuration = ruff_workspace::configuration::Configuration::default();
+                EditorConfigurationTransformer(editor_settings, root)
+                    .transform(default_configuration)
+                    .into_settings(root)
+                    .expect(
+                        "editor configuration should merge successfully with default configuration",
+                    )
+            });
 
         Self {
             index,


### PR DESCRIPTION
## Summary

Fixes https://github.com/astral-sh/ruff/issues/11258.

This PR fixes the settings resolver to match the expected behavior when file-based configuration is not available.

## Test Plan

In a workspace with no file-based configuration, set a setting in your editor and confirm that this setting is used instead of the default.
