### PR TITLE
Remove unnecessary check for RUF020 enabled

### DIFF
--- a/crates/ruff_linter/src/checkers/ast/analyze/expression.rs
+++ b/crates/ruff_linter/src/checkers/ast/analyze/expression.rs
@@ -78,7 +78,6 @@ pub(crate) fn expression(expr: &Expr, checker: &mut Checker) {
                 Rule::DuplicateUnionMember,
                 Rule::RedundantLiteralUnion,
                 Rule::UnnecessaryTypeUnion,
-                Rule::NeverUnion,
             ]) {
                 // Avoid duplicate checks if the parent is a union, since these rules already
                 // traverse nested unions.


### PR DESCRIPTION
## Summary

In #9218 `Rule::NeverUnion` was partially removed from a `checker.any_enabled` call. This makes the change consistent.

## Test Plan

`cargo test`
