### PR TITLE
[`refurb`] Ignore methods in `reimplemented-operator` (`FURB118`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/refurb/FURB118.py
+++ b/crates/ruff_linter/resources/test/fixtures/refurb/FURB118.py
@@ -73,3 +73,10 @@ def op_add4(x, y=1):
 def op_add5(x, y):
     print("op_add5")
     return x + y
+
+
+# OK
+class Class:
+    @staticmethod
+    def add(x, y):
+        return x + y

--- a/crates/ruff_linter/src/rules/flake8_unused_arguments/rules/unused_arguments.rs
+++ b/crates/ruff_linter/src/rules/flake8_unused_arguments/rules/unused_arguments.rs
@@ -322,7 +322,7 @@ pub(crate) fn unused_arguments(
         return;
     }
 
-    let Some(parent) = &checker.semantic().first_non_type_parent_scope(scope) else {
+    let Some(parent) = checker.semantic().first_non_type_parent_scope(scope) else {
         return;
     };
 

--- a/crates/ruff_linter/src/rules/pep8_naming/rules/invalid_first_argument_name.rs
+++ b/crates/ruff_linter/src/rules/pep8_naming/rules/invalid_first_argument_name.rs
@@ -190,7 +190,7 @@ pub(crate) fn invalid_first_argument_name(
         panic!("Expected ScopeKind::Function")
     };
 
-    let Some(parent) = &checker.semantic().first_non_type_parent_scope(scope) else {
+    let Some(parent) = checker.semantic().first_non_type_parent_scope(scope) else {
         return;
     };
 

--- a/crates/ruff_linter/src/rules/pylint/rules/bad_staticmethod_argument.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/bad_staticmethod_argument.rs
@@ -64,7 +64,7 @@ pub(crate) fn bad_staticmethod_argument(
         ..
     } = func;
 
-    let Some(parent) = &checker.semantic().first_non_type_parent_scope(scope) else {
+    let Some(parent) = checker.semantic().first_non_type_parent_scope(scope) else {
         return;
     };
 

--- a/crates/ruff_linter/src/rules/pylint/rules/no_self_use.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/no_self_use.rs
@@ -49,7 +49,7 @@ pub(crate) fn no_self_use(
     scope: &Scope,
     diagnostics: &mut Vec<Diagnostic>,
 ) {
-    let Some(parent) = &checker.semantic().first_non_type_parent_scope(scope) else {
+    let Some(parent) = checker.semantic().first_non_type_parent_scope(scope) else {
         return;
     };
 

--- a/crates/ruff_linter/src/rules/pylint/rules/singledispatch_method.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/singledispatch_method.rs
@@ -74,7 +74,7 @@ pub(crate) fn singledispatch_method(
         ..
     } = func;
 
-    let Some(parent) = &checker.semantic().first_non_type_parent_scope(scope) else {
+    let Some(parent) = checker.semantic().first_non_type_parent_scope(scope) else {
         return;
     };
 

--- a/crates/ruff_linter/src/rules/pylint/rules/singledispatchmethod_function.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/singledispatchmethod_function.rs
@@ -72,7 +72,7 @@ pub(crate) fn singledispatchmethod_function(
         ..
     } = func;
 
-    let Some(parent) = &checker.semantic().first_non_type_parent_scope(scope) else {
+    let Some(parent) = checker.semantic().first_non_type_parent_scope(scope) else {
         return;
     };
 

--- a/crates/ruff_linter/src/rules/pylint/rules/super_without_brackets.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/super_without_brackets.rs
@@ -83,7 +83,7 @@ pub(crate) fn super_without_brackets(checker: &mut Checker, func: &Expr) {
         return;
     };
 
-    let Some(parent) = &checker.semantic().first_non_type_parent_scope(scope) else {
+    let Some(parent) = checker.semantic().first_non_type_parent_scope(scope) else {
         return;
     };
 

--- a/crates/ruff_linter/src/rules/refurb/rules/reimplemented_operator.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/reimplemented_operator.rs
@@ -69,6 +69,13 @@ impl Violation for ReimplementedOperator {
 
 /// FURB118
 pub(crate) fn reimplemented_operator(checker: &mut Checker, target: &FunctionLike) {
+    // Ignore methods.
+    if target.kind() == FunctionLikeKind::Function {
+        if checker.semantic().current_scope().kind.is_class() {
+            return;
+        }
+    }
+
     let Some(params) = target.parameters() else {
         return;
     };

--- a/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__FURB118_FURB118.py.snap
+++ b/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__FURB118_FURB118.py.snap
@@ -793,13 +793,3 @@ FURB118.py:40:1: FURB118 Use `operator.add` instead of defining a function
    | |________________^ FURB118
    |
    = help: Replace with `operator.add`
-
-FURB118.py:45:5: FURB118 Use `operator.add` instead of defining a function
-   |
-44 |   class Adder:
-45 |       def add(x, y):
-   |  _____^
-46 | |         return x + y
-   | |____________________^ FURB118
-   |
-   = help: Replace with `operator.add`


### PR DESCRIPTION
## Summary

This rule does more harm than good when applied to methods.

Closes https://github.com/astral-sh/ruff/issues/10898.

Closes https://github.com/astral-sh/ruff/issues/11045.
