### PR TITLE
Handle single element cases in PYI016

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI016.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI016.py
@@ -84,3 +84,6 @@ field24: typing.Union[int, typing.Union[int, int]]  # PYI016: Duplicate union me
 # duplicates of the outer `int`), but not three times (which would indicate that
 # we incorrectly re-checked the nested union).
 field25: typing.Union[int, int | int]  # PYI016: Duplicate union member `int`
+
+# Single element unions should also be accounted for
+field26: typing.Union[int, typing.Union[int]]  # PYI016: Duplicate union member `int`

--- a/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI016.pyi
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI016.pyi
@@ -84,3 +84,6 @@ field24: typing.Union[int, typing.Union[int, int]]  # PYI016: Duplicate union me
 # duplicates of the outer `int`), but not three times (which would indicate that
 # we incorrectly re-checked the nested union).
 field25: typing.Union[int, int | int]  # PYI016: Duplicate union member `int`
+
+# Single element unions should also be accounted for
+field26: typing.Union[int, typing.Union[int]]  # PYI016: Duplicate union member `int`

--- a/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI016_PYI016.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI016_PYI016.py.snap
@@ -514,6 +514,8 @@ PYI016.py:86:28: PYI016 [*] Duplicate union member `int`
 85 | # we incorrectly re-checked the nested union).
 86 | field25: typing.Union[int, int | int]  # PYI016: Duplicate union member `int`
    |                            ^^^ PYI016
+87 | 
+88 | # Single element unions should also be accounted for
    |
    = help: Remove duplicate union member `int`
 
@@ -523,6 +525,9 @@ PYI016.py:86:28: PYI016 [*] Duplicate union member `int`
 85 85 | # we incorrectly re-checked the nested union).
 86    |-field25: typing.Union[int, int | int]  # PYI016: Duplicate union member `int`
    86 |+field25: typing.Union[int, int]  # PYI016: Duplicate union member `int`
+87 87 | 
+88 88 | # Single element unions should also be accounted for
+89 89 | field26: typing.Union[int, typing.Union[int]]  # PYI016: Duplicate union member `int`
 
 PYI016.py:86:34: PYI016 [*] Duplicate union member `int`
    |
@@ -530,6 +535,8 @@ PYI016.py:86:34: PYI016 [*] Duplicate union member `int`
 85 | # we incorrectly re-checked the nested union).
 86 | field25: typing.Union[int, int | int]  # PYI016: Duplicate union member `int`
    |                                  ^^^ PYI016
+87 | 
+88 | # Single element unions should also be accounted for
    |
    = help: Remove duplicate union member `int`
 
@@ -539,5 +546,14 @@ PYI016.py:86:34: PYI016 [*] Duplicate union member `int`
 85 85 | # we incorrectly re-checked the nested union).
 86    |-field25: typing.Union[int, int | int]  # PYI016: Duplicate union member `int`
    86 |+field25: typing.Union[int, int]  # PYI016: Duplicate union member `int`
+87 87 | 
+88 88 | # Single element unions should also be accounted for
+89 89 | field26: typing.Union[int, typing.Union[int]]  # PYI016: Duplicate union member `int`
 
-
+PYI016.py:89:41: PYI016 Duplicate union member `int`
+   |
+88 | # Single element unions should also be accounted for
+89 | field26: typing.Union[int, typing.Union[int]]  # PYI016: Duplicate union member `int`
+   |                                         ^^^ PYI016
+   |
+   = help: Remove duplicate union member `int`

--- a/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI016_PYI016.pyi.snap
+++ b/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI016_PYI016.pyi.snap
@@ -514,6 +514,8 @@ PYI016.pyi:86:28: PYI016 [*] Duplicate union member `int`
 85 | # we incorrectly re-checked the nested union).
 86 | field25: typing.Union[int, int | int]  # PYI016: Duplicate union member `int`
    |                            ^^^ PYI016
+87 | 
+88 | # Single element unions should also be accounted for
    |
    = help: Remove duplicate union member `int`
 
@@ -523,6 +525,9 @@ PYI016.pyi:86:28: PYI016 [*] Duplicate union member `int`
 85 85 | # we incorrectly re-checked the nested union).
 86    |-field25: typing.Union[int, int | int]  # PYI016: Duplicate union member `int`
    86 |+field25: typing.Union[int, int]  # PYI016: Duplicate union member `int`
+87 87 | 
+88 88 | # Single element unions should also be accounted for
+89 89 | field26: typing.Union[int, typing.Union[int]]  # PYI016: Duplicate union member `int`
 
 PYI016.pyi:86:34: PYI016 [*] Duplicate union member `int`
    |
@@ -530,6 +535,8 @@ PYI016.pyi:86:34: PYI016 [*] Duplicate union member `int`
 85 | # we incorrectly re-checked the nested union).
 86 | field25: typing.Union[int, int | int]  # PYI016: Duplicate union member `int`
    |                                  ^^^ PYI016
+87 | 
+88 | # Single element unions should also be accounted for
    |
    = help: Remove duplicate union member `int`
 
@@ -539,5 +546,14 @@ PYI016.pyi:86:34: PYI016 [*] Duplicate union member `int`
 85 85 | # we incorrectly re-checked the nested union).
 86    |-field25: typing.Union[int, int | int]  # PYI016: Duplicate union member `int`
    86 |+field25: typing.Union[int, int]  # PYI016: Duplicate union member `int`
+87 87 | 
+88 88 | # Single element unions should also be accounted for
+89 89 | field26: typing.Union[int, typing.Union[int]]  # PYI016: Duplicate union member `int`
 
-
+PYI016.pyi:89:41: PYI016 Duplicate union member `int`
+   |
+88 | # Single element unions should also be accounted for
+89 | field26: typing.Union[int, typing.Union[int]]  # PYI016: Duplicate union member `int`
+   |                                         ^^^ PYI016
+   |
+   = help: Remove duplicate union member `int`

--- a/crates/ruff_python_semantic/src/analyze/typing.rs
+++ b/crates/ruff_python_semantic/src/analyze/typing.rs
@@ -399,12 +399,17 @@ where
         // Ex) Union[x, y]
         if let Expr::Subscript(ast::ExprSubscript { value, slice, .. }) = expr {
             if semantic.match_typing_expr(value, "Union") {
-                if let Expr::Tuple(ast::ExprTuple { elts, .. }) = slice.as_ref() {
-                    // Traverse each element of the tuple within the union recursively to handle cases
-                    // such as `Union[..., Union[...]]
-                    elts.iter()
-                        .for_each(|elt| inner(func, semantic, elt, Some(expr)));
-                    return;
+                match slice.as_ref() {
+                    Expr::Tuple(ast::ExprTuple { elts, .. }) => {
+                        // Traverse each element of the tuple within the union recursively to handle cases
+                        // such as `Union[..., Union[...]]
+                        elts.iter()
+                            .for_each(|elt| inner(func, semantic, elt, Some(expr)));
+                        return;
+                    }
+                    other => {
+                        inner(func, semantic, other, Some(expr));
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary

For code like:

```python
from typing import Union
x: Union[int, Union[int]]
```

`PYI016` was not being raised, since the iterator was only matching on `Tuple`s inside the `Union[]`.

Same as https://github.com/PyCQA/flake8-pyi/issues/484

## Test Plan

`cargo test`