### PR TITLE
Change `hardcoded-tmp-directory-extend` example to follow the schema

### DIFF
--- a/crates/ruff_workspace/src/options.rs
+++ b/crates/ruff_workspace/src/options.rs
@@ -1024,7 +1024,7 @@ pub struct Flake8BanditOptions {
     #[option(
         default = "[]",
         value_type = "list[str]",
-        example = "extend-hardcoded-tmp-directory = [\"/foo/bar\"]"
+        example = "hardcoded-tmp-directory-extend = [\"/foo/bar\"]"
     )]
     pub hardcoded_tmp_directory_extend: Option<Vec<String>>,
 


### PR DESCRIPTION
## Summary
Change `hardcoded-tmp-directory-extend` example to follow the schema:
https://github.com/astral-sh/ruff/blob/1e91a0991828382f24e9306894ca23a186ed9635/ruff.schema.json#L896-L901
<!-- What's the purpose of the change? What does it do, and why? -->
