### PR TITLE
[red-knot] @override lint rule

### DIFF
--- a/crates/red_knot/src/module.rs
+++ b/crates/red_knot/src/module.rs
@@ -231,11 +231,6 @@ pub struct ModuleData {
 // Queries
 //////////////////////////////////////////////////////
 
-#[tracing::instrument(level = "debug", skip(db))]
-pub fn module_to_file(db: &dyn SemanticDb, module: Module) -> QueryResult<FileId> {
-    Ok(module.path(db)?.file())
-}
-
 /// Resolves a module name to a module id
 /// TODO: This would not work with Salsa because `ModuleName` isn't an ingredient and, therefore, cannot be used as part of a query.
 ///  For this to work with salsa, it would be necessary to intern all `ModuleName`s.

--- a/crates/red_knot/src/module.rs
+++ b/crates/red_knot/src/module.rs
@@ -231,6 +231,11 @@ pub struct ModuleData {
 // Queries
 //////////////////////////////////////////////////////
 
+#[tracing::instrument(level = "debug", skip(db))]
+pub fn module_to_file(db: &dyn SemanticDb, module: Module) -> QueryResult<FileId> {
+    Ok(module.path(db)?.file())
+}
+
 /// Resolves a module name to a module id
 /// TODO: This would not work with Salsa because `ModuleName` isn't an ingredient and, therefore, cannot be used as part of a query.
 ///  For this to work with salsa, it would be necessary to intern all `ModuleName`s.

--- a/crates/red_knot/src/symbols.rs
+++ b/crates/red_knot/src/symbols.rs
@@ -18,7 +18,7 @@ use crate::ast_ids::{NodeKey, TypedNodeKey};
 use crate::cache::KeyValueCache;
 use crate::db::{QueryResult, SemanticDb, SemanticJar};
 use crate::files::FileId;
-use crate::module::{module_to_file, resolve_module, ModuleName};
+use crate::module::{resolve_module, ModuleName};
 use crate::parse::parse;
 use crate::Name;
 
@@ -41,7 +41,7 @@ pub fn resolve_global_symbol(
     let Some(typing_module) = resolve_module(db, module)? else {
         return Ok(None);
     };
-    let typing_file = module_to_file(db, typing_module)?;
+    let typing_file = typing_module.path(db)?.file();
     let typing_table = symbol_table(db, typing_file)?;
     let Some(typing_override) = typing_table.root_symbol_id_by_name(name) else {
         return Ok(None);

--- a/crates/red_knot/src/symbols.rs
+++ b/crates/red_knot/src/symbols.rs
@@ -52,7 +52,7 @@ pub fn resolve_global_symbol(
     }))
 }
 
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct GlobalSymbolId {
     pub(crate) file_id: FileId,
     pub(crate) symbol_id: SymbolId,

--- a/crates/red_knot/src/symbols.rs
+++ b/crates/red_knot/src/symbols.rs
@@ -14,15 +14,14 @@ use ruff_index::{newtype_index, IndexVec};
 use ruff_python_ast as ast;
 use ruff_python_ast::visitor::preorder::PreorderVisitor;
 
-use crate::ast_ids::TypedNodeKey;
+use crate::ast_ids::{NodeKey, TypedNodeKey};
 use crate::cache::KeyValueCache;
 use crate::db::{QueryResult, SemanticDb, SemanticJar};
 use crate::files::FileId;
-use crate::module::ModuleName;
+use crate::module::{module_to_file, resolve_module, ModuleName};
 use crate::parse::parse;
 use crate::Name;
 
-#[allow(unreachable_pub)]
 #[tracing::instrument(level = "debug", skip(db))]
 pub fn symbol_table(db: &dyn SemanticDb, file_id: FileId) -> QueryResult<Arc<SymbolTable>> {
     let jar: &SemanticJar = db.jar()?;
@@ -31,6 +30,32 @@ pub fn symbol_table(db: &dyn SemanticDb, file_id: FileId) -> QueryResult<Arc<Sym
         let parsed = parse(db.upcast(), file_id)?;
         Ok(Arc::from(SymbolTable::from_ast(parsed.ast())))
     })
+}
+
+#[tracing::instrument(level = "debug", skip(db))]
+pub fn resolve_global_symbol(
+    db: &dyn SemanticDb,
+    module: ModuleName,
+    name: &str,
+) -> QueryResult<Option<GlobalSymbolId>> {
+    let Some(typing_module) = resolve_module(db, module)? else {
+        return Ok(None);
+    };
+    let typing_file = module_to_file(db, typing_module)?;
+    let typing_table = symbol_table(db, typing_file)?;
+    let Some(typing_override) = typing_table.root_symbol_id_by_name(name) else {
+        return Ok(None);
+    };
+    Ok(Some(GlobalSymbolId {
+        file_id: typing_file,
+        symbol_id: typing_override,
+    }))
+}
+
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub struct GlobalSymbolId {
+    pub(crate) file_id: FileId,
+    pub(crate) symbol_id: SymbolId,
 }
 
 type Map<K, V> = hashbrown::HashMap<K, V, ()>;
@@ -65,7 +90,12 @@ pub(crate) enum ScopeKind {
 pub(crate) struct Scope {
     name: Name,
     kind: ScopeKind,
-    child_scopes: Vec<ScopeId>,
+    parent: Option<ScopeId>,
+    children: Vec<ScopeId>,
+    /// the definition (e.g. class or function) that created this scope
+    definition: Option<Definition>,
+    /// the symbol (e.g. class or function) that owns this scope
+    defining_symbol: Option<SymbolId>,
     /// symbol IDs, hashed by symbol name
     symbols_by_name: Map<SymbolId, ()>,
 }
@@ -77,6 +107,14 @@ impl Scope {
 
     pub(crate) fn kind(&self) -> ScopeKind {
         self.kind
+    }
+
+    pub(crate) fn definition(&self) -> Option<Definition> {
+        self.definition.clone()
+    }
+
+    pub(crate) fn defining_symbol(&self) -> Option<SymbolId> {
+        self.defining_symbol
     }
 }
 
@@ -114,6 +152,10 @@ impl Symbol {
         self.name.as_str()
     }
 
+    pub(crate) fn scope_id(&self) -> ScopeId {
+        self.scope_id
+    }
+
     /// Is the symbol used in its containing scope?
     pub(crate) fn is_used(&self) -> bool {
         self.flags.contains(SymbolFlags::IS_USED)
@@ -132,6 +174,7 @@ impl Symbol {
 // TODO storing TypedNodeKey for definitions means we have to search to find them again in the AST;
 // this is at best O(log n). If looking up definitions is a bottleneck we should look for
 // alternatives here.
+// TODO intern Definitions in SymbolTable and reference using IDs?
 #[derive(Clone, Debug)]
 pub(crate) enum Definition {
     // For the import cases, we don't need reference to any arbitrary AST subtrees (annotations,
@@ -140,7 +183,7 @@ pub(crate) enum Definition {
     // the small amount of information we need from the AST.
     Import(ImportDefinition),
     ImportFrom(ImportFromDefinition),
-    ClassDef(ClassDefinition),
+    ClassDef(TypedNodeKey<ast::StmtClassDef>),
     FunctionDef(TypedNodeKey<ast::StmtFunctionDef>),
     Assignment(TypedNodeKey<ast::StmtAssign>),
     AnnotatedAssignment(TypedNodeKey<ast::StmtAnnAssign>),
@@ -173,12 +216,6 @@ impl ImportFromDefinition {
     }
 }
 
-#[derive(Clone, Debug)]
-pub(crate) struct ClassDefinition {
-    pub(crate) node_key: TypedNodeKey<ast::StmtClassDef>,
-    pub(crate) scope_id: ScopeId,
-}
-
 #[derive(Debug, Clone)]
 pub enum Dependency {
     Module(ModuleName),
@@ -193,7 +230,11 @@ pub enum Dependency {
 pub struct SymbolTable {
     scopes_by_id: IndexVec<ScopeId, Scope>,
     symbols_by_id: IndexVec<SymbolId, Symbol>,
+    /// the definitions for each symbol
     defs: FxHashMap<SymbolId, Vec<Definition>>,
+    /// map of AST node (e.g. class/function def) to sub-scope it creates
+    scopes_by_node: FxHashMap<NodeKey, ScopeId>,
+    /// dependencies of this module
     dependencies: Vec<Dependency>,
 }
 
@@ -214,12 +255,16 @@ impl SymbolTable {
             scopes_by_id: IndexVec::new(),
             symbols_by_id: IndexVec::new(),
             defs: FxHashMap::default(),
+            scopes_by_node: FxHashMap::default(),
             dependencies: Vec::new(),
         };
         table.scopes_by_id.push(Scope {
             name: Name::new("<module>"),
             kind: ScopeKind::Module,
-            child_scopes: Vec::new(),
+            parent: None,
+            children: Vec::new(),
+            definition: None,
+            defining_symbol: None,
             symbols_by_name: Map::default(),
         });
         table
@@ -260,7 +305,7 @@ impl SymbolTable {
     }
 
     pub(crate) fn child_scope_ids_of(&self, scope_id: ScopeId) -> &[ScopeId] {
-        &self.scopes_by_id[scope_id].child_scopes
+        &self.scopes_by_id[scope_id].children
     }
 
     pub(crate) fn child_scopes_of(&self, scope_id: ScopeId) -> ScopeIterator<&[ScopeId]> {
@@ -303,6 +348,32 @@ impl SymbolTable {
         self.symbol_by_name(SymbolTable::root_scope_id(), name)
     }
 
+    pub(crate) fn scope_id_of_symbol(&self, symbol_id: SymbolId) -> ScopeId {
+        self.symbols_by_id[symbol_id].scope_id
+    }
+
+    pub(crate) fn scope_of_symbol(&self, symbol_id: SymbolId) -> &Scope {
+        &self.scopes_by_id[self.scope_id_of_symbol(symbol_id)]
+    }
+
+    pub(crate) fn parent_scopes(
+        &self,
+        scope_id: ScopeId,
+    ) -> ScopeIterator<impl Iterator<Item = ScopeId> + '_> {
+        ScopeIterator {
+            table: self,
+            ids: std::iter::successors(Some(scope_id), |scope| self.scopes_by_id[*scope].parent),
+        }
+    }
+
+    pub(crate) fn parent_scope(&self, scope_id: ScopeId) -> Option<ScopeId> {
+        self.scopes_by_id[scope_id].parent
+    }
+
+    pub(crate) fn scope_id_for_node(&self, node_key: &NodeKey) -> ScopeId {
+        self.scopes_by_node[node_key]
+    }
+
     pub(crate) fn definitions(&self, symbol_id: SymbolId) -> &[Definition] {
         self.defs
             .get(&symbol_id)
@@ -316,7 +387,7 @@ impl SymbolTable {
             .flat_map(|(sym_id, defs)| defs.iter().map(move |def| (*sym_id, def)))
     }
 
-    fn add_or_update_symbol(
+    pub(crate) fn add_or_update_symbol(
         &mut self,
         scope_id: ScopeId,
         name: &str,
@@ -357,15 +428,20 @@ impl SymbolTable {
         parent_scope_id: ScopeId,
         name: &str,
         kind: ScopeKind,
+        definition: Option<Definition>,
+        defining_symbol: Option<SymbolId>,
     ) -> ScopeId {
         let new_scope_id = self.scopes_by_id.push(Scope {
             name: Name::new(name),
             kind,
-            child_scopes: Vec::new(),
+            parent: Some(parent_scope_id),
+            children: Vec::new(),
+            definition,
+            defining_symbol,
             symbols_by_name: Map::default(),
         });
         let parent_scope = &mut self.scopes_by_id[parent_scope_id];
-        parent_scope.child_scopes.push(new_scope_id);
+        parent_scope.children.push(new_scope_id);
         new_scope_id
     }
 
@@ -412,20 +488,22 @@ where
     }
 }
 
+// TODO maybe get rid of this and just do all data access via methods on ScopeId?
 pub(crate) struct ScopeIterator<'a, I> {
     table: &'a SymbolTable,
     ids: I,
 }
 
+/// iterate (`ScopeId`, `Scope`) pairs for given `ScopeId` iterator
 impl<'a, I> Iterator for ScopeIterator<'a, I>
 where
     I: Iterator<Item = ScopeId>,
 {
-    type Item = &'a Scope;
+    type Item = (ScopeId, &'a Scope);
 
     fn next(&mut self) -> Option<Self::Item> {
         let id = self.ids.next()?;
-        Some(&self.table.scopes_by_id[id])
+        Some((id, &self.table.scopes_by_id[id]))
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
@@ -441,7 +519,7 @@ where
 {
     fn next_back(&mut self) -> Option<Self::Item> {
         let id = self.ids.next_back()?;
-        Some(&self.table.scopes_by_id[id])
+        Some((id, &self.table.scopes_by_id[id]))
     }
 }
 
@@ -472,8 +550,16 @@ impl SymbolTableBuilder {
         symbol_id
     }
 
-    fn push_scope(&mut self, name: &str, kind: ScopeKind) -> ScopeId {
-        let scope_id = self.table.add_child_scope(self.cur_scope(), name, kind);
+    fn push_scope(
+        &mut self,
+        name: &str,
+        kind: ScopeKind,
+        definition: Option<Definition>,
+        defining_symbol: Option<SymbolId>,
+    ) -> ScopeId {
+        let scope_id =
+            self.table
+                .add_child_scope(self.cur_scope(), name, kind, definition, defining_symbol);
         self.scopes.push(scope_id);
         scope_id
     }
@@ -491,14 +577,20 @@ impl SymbolTableBuilder {
             .expect("Scope stack should never be empty")
     }
 
+    fn record_scope_for_node(&mut self, node_key: NodeKey, scope_id: ScopeId) {
+        self.table.scopes_by_node.insert(node_key, scope_id);
+    }
+
     fn with_type_params(
         &mut self,
         name: &str,
         params: &Option<Box<ast::TypeParams>>,
+        definition: Option<Definition>,
+        defining_symbol: Option<SymbolId>,
         nested: impl FnOnce(&mut Self) -> ScopeId,
     ) -> ScopeId {
         if let Some(type_params) = params {
-            self.push_scope(name, ScopeKind::Annotation);
+            self.push_scope(name, ScopeKind::Annotation, definition, defining_symbol);
             for type_param in &type_params.type_params {
                 let name = match type_param {
                     ast::TypeParam::TypeVar(ast::TypeParamTypeVar { name, .. }) => name,
@@ -539,27 +631,50 @@ impl PreorderVisitor<'_> for SymbolTableBuilder {
         // TODO need to capture more definition statements here
         match stmt {
             ast::Stmt::ClassDef(node) => {
-                let scope_id = self.with_type_params(&node.name, &node.type_params, |builder| {
-                    let scope_id = builder.push_scope(&node.name, ScopeKind::Class);
-                    ast::visitor::preorder::walk_stmt(builder, stmt);
-                    builder.pop_scope();
-                    scope_id
-                });
-                let def = Definition::ClassDef(ClassDefinition {
-                    node_key: TypedNodeKey::from_node(node),
-                    scope_id,
-                });
-                self.add_or_update_symbol_with_def(&node.name, def);
+                let node_key = TypedNodeKey::from_node(node);
+                let def = Definition::ClassDef(node_key.clone());
+                let symbol_id = self.add_or_update_symbol_with_def(&node.name, def.clone());
+                let scope_id = self.with_type_params(
+                    &node.name,
+                    &node.type_params,
+                    Some(def.clone()),
+                    Some(symbol_id),
+                    |builder| {
+                        let scope_id = builder.push_scope(
+                            &node.name,
+                            ScopeKind::Class,
+                            Some(def.clone()),
+                            Some(symbol_id),
+                        );
+                        ast::visitor::preorder::walk_stmt(builder, stmt);
+                        builder.pop_scope();
+                        scope_id
+                    },
+                );
+                self.record_scope_for_node(*node_key.erased(), scope_id);
             }
             ast::Stmt::FunctionDef(node) => {
-                let def = Definition::FunctionDef(TypedNodeKey::from_node(node));
-                self.add_or_update_symbol_with_def(&node.name, def);
-                self.with_type_params(&node.name, &node.type_params, |builder| {
-                    let scope_id = builder.push_scope(&node.name, ScopeKind::Function);
-                    ast::visitor::preorder::walk_stmt(builder, stmt);
-                    builder.pop_scope();
-                    scope_id
-                });
+                let node_key = TypedNodeKey::from_node(node);
+                let def = Definition::FunctionDef(node_key.clone());
+                let symbol_id = self.add_or_update_symbol_with_def(&node.name, def.clone());
+                let scope_id = self.with_type_params(
+                    &node.name,
+                    &node.type_params,
+                    Some(def.clone()),
+                    Some(symbol_id),
+                    |builder| {
+                        let scope_id = builder.push_scope(
+                            &node.name,
+                            ScopeKind::Function,
+                            Some(def.clone()),
+                            Some(symbol_id),
+                        );
+                        ast::visitor::preorder::walk_stmt(builder, stmt);
+                        builder.pop_scope();
+                        scope_id
+                    },
+                );
+                self.record_scope_for_node(*node_key.erased(), scope_id);
             }
             ast::Stmt::Import(ast::StmtImport { names, .. }) => {
                 for alias in names {
@@ -933,7 +1048,7 @@ mod tests {
         let mut table = SymbolTable::new();
         let root_scope_id = SymbolTable::root_scope_id();
         let foo_symbol_top = table.add_or_update_symbol(root_scope_id, "foo", SymbolFlags::empty());
-        let c_scope = table.add_child_scope(root_scope_id, "C", ScopeKind::Class);
+        let c_scope = table.add_child_scope(root_scope_id, "C", ScopeKind::Class, None, None);
         let foo_symbol_inner = table.add_or_update_symbol(c_scope, "foo", SymbolFlags::empty());
         assert_ne!(foo_symbol_top, foo_symbol_inner);
     }

--- a/crates/red_knot/src/types.rs
+++ b/crates/red_knot/src/types.rs
@@ -1,17 +1,15 @@
 #![allow(dead_code)]
-
+use crate::ast_ids::NodeKey;
+use crate::db::{QueryResult, SemanticDb};
+use crate::files::FileId;
+use crate::symbols::{symbol_table, GlobalSymbolId, ScopeId, ScopeKind, SymbolId};
+use crate::{FxDashMap, FxIndexSet, Name};
+use ruff_index::{newtype_index, IndexVec};
 use rustc_hash::FxHashMap;
 
-pub(crate) use infer::infer_symbol_type;
-use ruff_index::{newtype_index, IndexVec};
-
-use crate::ast_ids::NodeKey;
-use crate::db::{QueryResult, SemanticDb, SemanticJar};
-use crate::files::FileId;
-use crate::symbols::{symbol_table, ScopeId, SymbolId};
-use crate::{FxDashMap, FxIndexSet, Name};
-
 pub(crate) mod infer;
+
+pub(crate) use infer::{infer_definition_type, infer_symbol_type, type_store};
 
 /// unique ID for a type
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
@@ -82,10 +80,10 @@ impl TypeStore {
         self.modules.remove(&file_id);
     }
 
-    pub fn cache_symbol_type(&self, file_id: FileId, symbol_id: SymbolId, ty: Type) {
-        self.add_or_get_module(file_id)
+    pub fn cache_symbol_type(&self, symbol: GlobalSymbolId, ty: Type) {
+        self.add_or_get_module(symbol.file_id)
             .symbol_types
-            .insert(symbol_id, ty);
+            .insert(symbol.symbol_id, ty);
     }
 
     pub fn cache_node_type(&self, file_id: FileId, node_key: NodeKey, ty: Type) {
@@ -94,10 +92,10 @@ impl TypeStore {
             .insert(node_key, ty);
     }
 
-    pub fn get_cached_symbol_type(&self, file_id: FileId, symbol_id: SymbolId) -> Option<Type> {
-        self.try_get_module(file_id)?
+    pub fn get_cached_symbol_type(&self, symbol: GlobalSymbolId) -> Option<Type> {
+        self.try_get_module(symbol.file_id)?
             .symbol_types
-            .get(&symbol_id)
+            .get(&symbol.symbol_id)
             .copied()
     }
 
@@ -122,9 +120,16 @@ impl TypeStore {
         self.modules.get(&file_id)
     }
 
-    fn add_function(&self, file_id: FileId, name: &str, decorators: Vec<Type>) -> FunctionTypeId {
+    fn add_function(
+        &self,
+        file_id: FileId,
+        name: &str,
+        symbol_id: SymbolId,
+        scope_id: ScopeId,
+        decorators: Vec<Type>,
+    ) -> FunctionTypeId {
         self.add_or_get_module(file_id)
-            .add_function(name, decorators)
+            .add_function(name, symbol_id, scope_id, decorators)
     }
 
     fn add_class(
@@ -257,6 +262,79 @@ pub struct FunctionTypeId {
     func_id: ModuleFunctionTypeId,
 }
 
+impl FunctionTypeId {
+    pub(crate) fn function(self, db: &dyn SemanticDb) -> QueryResult<FunctionTypeRef> {
+        Ok(type_store(db)?.get_function(self))
+    }
+
+    pub(crate) fn name(self, db: &dyn SemanticDb) -> QueryResult<Name> {
+        Ok(self.function(db)?.name().into())
+    }
+
+    pub(crate) fn global_symbol(self, db: &dyn SemanticDb) -> QueryResult<GlobalSymbolId> {
+        Ok(GlobalSymbolId {
+            file_id: self.file(),
+            symbol_id: self.symbol(db)?,
+        })
+    }
+
+    pub(crate) fn file(self) -> FileId {
+        self.file_id
+    }
+
+    pub(crate) fn symbol(self, db: &dyn SemanticDb) -> QueryResult<SymbolId> {
+        let FunctionType { symbol_id, .. } = *type_store(db)?.get_function(self);
+        Ok(symbol_id)
+    }
+
+    pub(crate) fn get_containing_class(
+        self,
+        db: &dyn SemanticDb,
+    ) -> QueryResult<Option<ClassTypeId>> {
+        let table = symbol_table(db, self.file_id)?;
+        let FunctionType { symbol_id, .. } = *type_store(db)?.get_function(self);
+        let scope_id = symbol_id.symbol(&table).scope_id();
+        let scope = scope_id.scope(&table);
+        if !matches!(scope.kind(), ScopeKind::Class) {
+            return Ok(None);
+        };
+        let Some(def) = scope.definition() else {
+            return Ok(None);
+        };
+        let Some(symbol_id) = scope.defining_symbol() else {
+            return Ok(None);
+        };
+        let Type::Class(class) = infer_definition_type(
+            db,
+            GlobalSymbolId {
+                file_id: self.file_id,
+                symbol_id,
+            },
+            def,
+        )?
+        else {
+            return Ok(None);
+        };
+        Ok(Some(class))
+    }
+
+    pub(crate) fn has_decorator(
+        self,
+        db: &dyn SemanticDb,
+        decorator_symbol: GlobalSymbolId,
+    ) -> QueryResult<bool> {
+        for deco_ty in self.function(db)?.decorators() {
+            let Type::Function(deco_func) = deco_ty else {
+                continue;
+            };
+            if deco_func.global_symbol(db)? == decorator_symbol {
+                return Ok(true);
+            }
+        }
+        Ok(false)
+    }
+}
+
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
 pub struct ClassTypeId {
     file_id: FileId,
@@ -264,14 +342,43 @@ pub struct ClassTypeId {
 }
 
 impl ClassTypeId {
-    fn get_own_class_member(self, db: &dyn SemanticDb, name: &Name) -> QueryResult<Option<Type>> {
-        let jar: &SemanticJar = db.jar()?;
+    pub(crate) fn name(self, db: &dyn SemanticDb) -> QueryResult<Name> {
+        let class = type_store(db)?.get_class(self);
+        Ok(class.name().into())
+    }
 
+    pub(crate) fn get_super_class_member(
+        self,
+        db: &dyn SemanticDb,
+        name: &Name,
+    ) -> QueryResult<Option<Type>> {
+        // TODO we should linearize the MRO instead of doing this recursively
+        let class = type_store(db)?.get_class(self);
+        for base in class.bases() {
+            if let Type::Class(base) = base {
+                if let Some(own_member) = base.get_own_class_member(db, name)? {
+                    return Ok(Some(own_member));
+                }
+                if let Some(base_member) = base.get_super_class_member(db, name)? {
+                    return Ok(Some(base_member));
+                }
+            }
+        }
+        Ok(None)
+    }
+
+    fn get_own_class_member(self, db: &dyn SemanticDb, name: &Name) -> QueryResult<Option<Type>> {
         // TODO: this should distinguish instance-only members (e.g. `x: int`) and not return them
-        let ClassType { scope_id, .. } = *jar.type_store.get_class(self);
+        let ClassType { scope_id, .. } = *type_store(db)?.get_class(self);
         let table = symbol_table(db, self.file_id)?;
         if let Some(symbol_id) = table.symbol_id_by_name(scope_id, name) {
-            Ok(Some(infer_symbol_type(db, self.file_id, symbol_id)?))
+            Ok(Some(infer_symbol_type(
+                db,
+                GlobalSymbolId {
+                    file_id: self.file_id,
+                    symbol_id,
+                },
+            )?))
         } else {
             Ok(None)
         }
@@ -334,9 +441,17 @@ impl ModuleTypeStore {
         }
     }
 
-    fn add_function(&mut self, name: &str, decorators: Vec<Type>) -> FunctionTypeId {
+    fn add_function(
+        &mut self,
+        name: &str,
+        symbol_id: SymbolId,
+        scope_id: ScopeId,
+        decorators: Vec<Type>,
+    ) -> FunctionTypeId {
         let func_id = self.functions.push(FunctionType {
             name: Name::new(name),
+            symbol_id,
+            scope_id,
             decorators,
         });
         FunctionTypeId {
@@ -436,7 +551,7 @@ pub(crate) struct ClassType {
     /// Name of the class at definition
     name: Name,
     /// `ScopeId` of the class body
-    pub(crate) scope_id: ScopeId,
+    scope_id: ScopeId,
     /// Types of all class bases
     bases: Vec<Type>,
 }
@@ -453,7 +568,13 @@ impl ClassType {
 
 #[derive(Debug)]
 pub(crate) struct FunctionType {
+    /// name of the function at definition
     name: Name,
+    /// symbol which this function is a definition of
+    symbol_id: SymbolId,
+    /// scope of this function's body
+    scope_id: ScopeId,
+    /// types of all decorators on this function
     decorators: Vec<Type>,
 }
 
@@ -462,7 +583,11 @@ impl FunctionType {
         self.name.as_str()
     }
 
-    fn decorators(&self) -> &[Type] {
+    fn scope_id(&self) -> ScopeId {
+        self.scope_id
+    }
+
+    pub(crate) fn decorators(&self) -> &[Type] {
         self.decorators.as_slice()
     }
 }
@@ -493,12 +618,12 @@ impl UnionType {
 // directly in intersections rather than as a separate type. This sacrifices some efficiency in the
 // case where a Not appears outside an intersection (unclear when that could even happen, but we'd
 // have to represent it as a single-element intersection if it did) in exchange for better
-// efficiency in the not-within-intersection case.
+// efficiency in the within-intersection case.
 #[derive(Debug)]
 pub(crate) struct IntersectionType {
     // the intersection type includes only values in all of these types
     positive: FxIndexSet<Type>,
-    // negated elements of the intersection, e.g.
+    // the intersection type does not include any value in any of these types
     negative: FxIndexSet<Type>,
 }
 
@@ -530,7 +655,7 @@ mod tests {
     use std::path::Path;
 
     use crate::files::Files;
-    use crate::symbols::SymbolTable;
+    use crate::symbols::{SymbolFlags, SymbolTable};
     use crate::types::{Type, TypeStore};
     use crate::FxIndexSet;
 
@@ -550,7 +675,20 @@ mod tests {
         let store = TypeStore::default();
         let files = Files::default();
         let file_id = files.intern(Path::new("/foo"));
-        let id = store.add_function(file_id, "func", vec![Type::Unknown]);
+        let mut table = SymbolTable::new();
+        let func_symbol = table.add_or_update_symbol(
+            SymbolTable::root_scope_id(),
+            "func",
+            SymbolFlags::IS_DEFINED,
+        );
+
+        let id = store.add_function(
+            file_id,
+            "func",
+            func_symbol,
+            SymbolTable::root_scope_id(),
+            vec![Type::Unknown],
+        );
         assert_eq!(store.get_function(id).name(), "func");
         assert_eq!(store.get_function(id).decorators(), vec![Type::Unknown]);
         let func = Type::Function(id);

--- a/crates/red_knot/src/types/infer.rs
+++ b/crates/red_knot/src/types/infer.rs
@@ -10,14 +10,8 @@ use crate::parse::parse;
 use crate::symbols::{
     resolve_global_symbol, symbol_table, Definition, GlobalSymbolId, ImportFromDefinition,
 };
-use crate::types::{Type, TypeStore};
+use crate::types::Type;
 use crate::FileId;
-
-#[tracing::instrument(level = "trace", skip(db))]
-pub fn type_store(db: &dyn SemanticDb) -> QueryResult<&TypeStore> {
-    let jar: &SemanticJar = db.jar()?;
-    Ok(&jar.type_store)
-}
 
 // FIXME: Figure out proper dead-lock free synchronisation now that this takes `&db` instead of `&mut db`.
 #[tracing::instrument(level = "trace", skip(db))]


### PR DESCRIPTION
## Summary

Lots of TODOs and things to clean up here, but it demonstrates the working lint rule.

## Test Plan

```
➜ cat main.py
from typing import override
from base import B

class C(B):
    @override
    def method(self): pass

➜ cat base.py
class B: pass

➜ cat typing.py
def override(func):
    return func
```

(We provide our own `typing.py` since we don't have typeshed vendored or type stub support yet.)

```
➜ ./target/debug/red_knot main.py
...
1   0.012086s TRACE red_knot Main Loop: Tick
[crates/red_knot/src/main.rs:157:21] diagnostics = [
    "Method C.method is decorated with `typing.override` but does not override any base class method",
]
```

If we add `def method(self): pass` to class `B` in `base.py` and run red_knot again, there is no lint error.