### PR TITLE
Expand tildes when resolving Ruff server configuration file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2373,6 +2373,7 @@ dependencies = [
  "rustc-hash",
  "serde",
  "serde_json",
+ "shellexpand",
  "tracing",
  "walkdir",
 ]

--- a/crates/ruff_server/Cargo.toml
+++ b/crates/ruff_server/Cargo.toml
@@ -30,12 +30,13 @@ crossbeam = { workspace = true }
 jod-thread = { workspace = true }
 lsp-server = { workspace = true }
 lsp-types = { workspace = true }
+regex = { workspace = true }
 rustc-hash = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+shellexpand = { workspace = true }
 tracing = { workspace = true }
 walkdir = { workspace = true }
-regex = { workspace = true }
 
 [dev-dependencies]
 insta = { workspace = true }

--- a/crates/ruff_server/src/session/settings.rs
+++ b/crates/ruff_server/src/session/settings.rs
@@ -1,9 +1,10 @@
-use std::{ffi::OsString, ops::Deref, path::PathBuf, str::FromStr};
+use std::{ops::Deref, path::PathBuf, str::FromStr};
 
 use lsp_types::Url;
-use ruff_linter::{line_width::LineLength, RuleSelector};
 use rustc_hash::FxHashMap;
 use serde::Deserialize;
+
+use ruff_linter::{line_width::LineLength, RuleSelector};
 
 /// Maps a workspace URI to its associated client settings. Used during server initialization.
 pub(crate) type WorkspaceSettingsMap = FxHashMap<Url, ClientSettings>;
@@ -234,7 +235,8 @@ impl ResolvedClientSettings {
                     settings
                         .configuration
                         .as_ref()
-                        .map(|config_path| OsString::from(config_path.clone()).into())
+                        .and_then(|config_path| shellexpand::full(config_path).ok())
+                        .map(|config_path| PathBuf::from(config_path.as_ref()))
                 }),
                 lint_preview: Self::resolve_optional(all_settings, |settings| {
                     settings.lint.as_ref()?.preview
@@ -341,8 +343,9 @@ impl Default for InitializationOptions {
 #[cfg(test)]
 mod tests {
     use insta::assert_debug_snapshot;
-    use ruff_linter::registry::Linter;
     use serde::de::DeserializeOwned;
+
+    use ruff_linter::registry::Linter;
 
     use super::*;
 

--- a/crates/ruff_server/src/session/workspace/ruff_settings.rs
+++ b/crates/ruff_server/src/session/workspace/ruff_settings.rs
@@ -165,7 +165,7 @@ impl<'a> ConfigurationTransformer for EditorConfigurationTransformer<'a> {
             ..Default::default()
         };
 
-        // Merge in the editor-specified configuration file, if it exists
+        // Merge in the editor-specified configuration file, if it exists.
         let editor_configuration = if let Some(config_file_path) = configuration {
             match open_configuration_file(&config_file_path, project_root) {
                 Ok(config_from_file) => editor_configuration.combine(config_from_file),


### PR DESCRIPTION
## Summary

Users can now include tildes and environment variables in the provided path, just like with `--config`.

Closes #11277.

## Test Plan

Set the configuration path to `"ruff.configuration": "~/x.toml"`; verified that the server attempted to read from `/Users/crmarsh/x.toml`.

![Screenshot 2024-05-04 at 1 31 43 PM](https://github.com/astral-sh/ruff/assets/1309177/ea9829cd-6d8a-4818-a47c-dcff9219e996)
