### PR TITLE
[`pylint`] Detect `pathlib.Path.open` calls in `unspecified-encoding` (`PLW1514`) 

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pylint/unspecified_encoding.py
+++ b/crates/ruff_linter/resources/test/fixtures/pylint/unspecified_encoding.py
@@ -70,16 +70,20 @@ open(
     # comment
 )
 
-# Pathlib
+# pathlib
 from pathlib import Path
 
 # Errors.
 Path("foo.txt").open()
 Path("foo.txt").open("w")
+text = Path("foo.txt").read_text()
+Path("foo.txt").write_text(text)
 
 # Non-errors.
 Path("foo.txt").open(encoding="utf-8")
 Path("foo.txt").open("wb")
+text = Path("foo.txt").read_text(encoding="utf-8")
+Path("foo.txt").write_text(text, encoding="utf-8")
 
 # Violation but not detectable
 x = Path("foo.txt")

--- a/crates/ruff_linter/resources/test/fixtures/pylint/unspecified_encoding.py
+++ b/crates/ruff_linter/resources/test/fixtures/pylint/unspecified_encoding.py
@@ -82,8 +82,14 @@ Path("foo.txt").write_text(text)
 # Non-errors.
 Path("foo.txt").open(encoding="utf-8")
 Path("foo.txt").open("wb")
+Path("foo.txt").open(*args)
+Path("foo.txt").open(**kwargs)
 text = Path("foo.txt").read_text(encoding="utf-8")
+text = Path("foo.txt").read_text(*args)
+text = Path("foo.txt").read_text(**kwargs)
 Path("foo.txt").write_text(text, encoding="utf-8")
+Path("foo.txt").write_text(text, *args)
+Path("foo.txt").write_text(text, **kwargs)
 
 # Violation but not detectable
 x = Path("foo.txt")

--- a/crates/ruff_linter/resources/test/fixtures/pylint/unspecified_encoding.py
+++ b/crates/ruff_linter/resources/test/fixtures/pylint/unspecified_encoding.py
@@ -69,3 +69,18 @@ open(
     (("test.txt")),
     # comment
 )
+
+# Pathlib
+from pathlib import Path
+
+# Errors.
+Path("foo.txt").open()
+Path("foo.txt").open("w")
+
+# Non-errors.
+Path("foo.txt").open(encoding="utf-8")
+Path("foo.txt").open("wb")
+
+# Violation but not detectable
+x = Path("foo.txt")
+x.open()

--- a/crates/ruff_linter/src/rules/pylint/rules/unspecified_encoding.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/unspecified_encoding.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use std::fmt::{Display, Formatter};
 
 use ast::StringLiteralFlags;
 use ruff_diagnostics::{AlwaysFixableViolation, Diagnostic, Fix};
@@ -121,17 +122,19 @@ impl<'a> Segments<'a> {
         }
         None
     }
+}
 
-    fn to_string(&self) -> String {
+impl Display for Segments<'_> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
             Segments::Regular(segments) => {
-                if segments[0] == "" {
-                    segments[1..].join(".")
+                if segments[0].is_empty() {
+                    f.write_str(&segments[1..].join("."))
                 } else {
-                    segments.join(".")
+                    f.write_str(&segments.join("."))
                 }
             }
-            Segments::Pathlib(attr) => format!("pathlib.Path.{attr}"),
+            Segments::Pathlib(attr) => f.write_str(&format!("pathlib.Path.{attr}")),
         }
     }
 }

--- a/crates/ruff_linter/src/rules/pylint/rules/unspecified_encoding.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/unspecified_encoding.rs
@@ -210,7 +210,7 @@ fn is_binary_mode(expr: &Expr) -> Option<bool> {
 }
 
 /// Returns `true` if the given call lacks an explicit `encoding`.
-fn is_violation(call: &ast::ExprCall, segments: &QualifiedNameWrapper) -> bool {
+fn is_violation(call: &ast::ExprCall, qualified_name: &QualifiedNameWrapper) -> bool {
     // If we have something like `*args`, which might contain the encoding argument, abort.
     if call.arguments.args.iter().any(Expr::is_starred_expr) {
         return false;
@@ -224,7 +224,7 @@ fn is_violation(call: &ast::ExprCall, segments: &QualifiedNameWrapper) -> bool {
     {
         return false;
     }
-    match segments {
+    match qualified_name {
         QualifiedNameWrapper::Regular(qualified_name) => match qualified_name.segments() {
             ["" | "codecs" | "_io", "open"] => {
                 if let Some(mode_arg) = call.arguments.find_argument("mode", 1) {

--- a/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLW1514_unspecified_encoding.py.snap
+++ b/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLW1514_unspecified_encoding.py.snap
@@ -360,6 +360,7 @@ unspecified_encoding.py:77:1: PLW1514 [*] `pathlib.Path.open` in text mode witho
 77 | Path("foo.txt").open()
    | ^^^^^^^^^^^^^^^^^^^^ PLW1514
 78 | Path("foo.txt").open("w")
+79 | text = Path("foo.txt").read_text()
    |
    = help: Add explicit `encoding` argument
 
@@ -370,8 +371,8 @@ unspecified_encoding.py:77:1: PLW1514 [*] `pathlib.Path.open` in text mode witho
 77    |-Path("foo.txt").open()
    77 |+Path("foo.txt").open(encoding="locale")
 78 78 | Path("foo.txt").open("w")
-79 79 | 
-80 80 | # Non-errors.
+79 79 | text = Path("foo.txt").read_text()
+80 80 | Path("foo.txt").write_text(text)
 
 unspecified_encoding.py:78:1: PLW1514 [*] `pathlib.Path.open` in text mode without explicit `encoding` argument
    |
@@ -379,8 +380,8 @@ unspecified_encoding.py:78:1: PLW1514 [*] `pathlib.Path.open` in text mode witho
 77 | Path("foo.txt").open()
 78 | Path("foo.txt").open("w")
    | ^^^^^^^^^^^^^^^^^^^^ PLW1514
-79 | 
-80 | # Non-errors.
+79 | text = Path("foo.txt").read_text()
+80 | Path("foo.txt").write_text(text)
    |
    = help: Add explicit `encoding` argument
 
@@ -390,6 +391,47 @@ unspecified_encoding.py:78:1: PLW1514 [*] `pathlib.Path.open` in text mode witho
 77 77 | Path("foo.txt").open()
 78    |-Path("foo.txt").open("w")
    78 |+Path("foo.txt").open("w", encoding="locale")
-79 79 | 
-80 80 | # Non-errors.
-81 81 | Path("foo.txt").open(encoding="utf-8")
+79 79 | text = Path("foo.txt").read_text()
+80 80 | Path("foo.txt").write_text(text)
+81 81 | 
+
+unspecified_encoding.py:79:8: PLW1514 [*] `pathlib.Path.read_text` without explicit `encoding` argument
+   |
+77 | Path("foo.txt").open()
+78 | Path("foo.txt").open("w")
+79 | text = Path("foo.txt").read_text()
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^^ PLW1514
+80 | Path("foo.txt").write_text(text)
+   |
+   = help: Add explicit `encoding` argument
+
+ℹ Unsafe fix
+76 76 | # Errors.
+77 77 | Path("foo.txt").open()
+78 78 | Path("foo.txt").open("w")
+79    |-text = Path("foo.txt").read_text()
+   79 |+text = Path("foo.txt").read_text(encoding="locale")
+80 80 | Path("foo.txt").write_text(text)
+81 81 | 
+82 82 | # Non-errors.
+
+unspecified_encoding.py:80:1: PLW1514 [*] `pathlib.Path.write_text` without explicit `encoding` argument
+   |
+78 | Path("foo.txt").open("w")
+79 | text = Path("foo.txt").read_text()
+80 | Path("foo.txt").write_text(text)
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^ PLW1514
+81 | 
+82 | # Non-errors.
+   |
+   = help: Add explicit `encoding` argument
+
+ℹ Unsafe fix
+77 77 | Path("foo.txt").open()
+78 78 | Path("foo.txt").open("w")
+79 79 | text = Path("foo.txt").read_text()
+80    |-Path("foo.txt").write_text(text)
+   80 |+Path("foo.txt").write_text(text, encoding="locale")
+81 81 | 
+82 82 | # Non-errors.
+83 83 | Path("foo.txt").open(encoding="utf-8")

--- a/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLW1514_unspecified_encoding.py.snap
+++ b/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLW1514_unspecified_encoding.py.snap
@@ -352,5 +352,44 @@ unspecified_encoding.py:68:1: PLW1514 [*] `open` in text mode without explicit `
    69 |+    (("test.txt")), encoding="locale",
 70 70 |     # comment
 71 71 | )
+72 72 | 
 
+unspecified_encoding.py:77:1: PLW1514 [*] `pathlib.Path.open` in text mode without explicit `encoding` argument
+   |
+76 | # Errors.
+77 | Path("foo.txt").open()
+   | ^^^^^^^^^^^^^^^^^^^^ PLW1514
+78 | Path("foo.txt").open("w")
+   |
+   = help: Add explicit `encoding` argument
 
+ℹ Unsafe fix
+74 74 | from pathlib import Path
+75 75 | 
+76 76 | # Errors.
+77    |-Path("foo.txt").open()
+   77 |+Path("foo.txt").open(encoding="locale")
+78 78 | Path("foo.txt").open("w")
+79 79 | 
+80 80 | # Non-errors.
+
+unspecified_encoding.py:78:1: PLW1514 [*] `pathlib.Path.open` in text mode without explicit `encoding` argument
+   |
+76 | # Errors.
+77 | Path("foo.txt").open()
+78 | Path("foo.txt").open("w")
+   | ^^^^^^^^^^^^^^^^^^^^ PLW1514
+79 | 
+80 | # Non-errors.
+   |
+   = help: Add explicit `encoding` argument
+
+ℹ Unsafe fix
+75 75 | 
+76 76 | # Errors.
+77 77 | Path("foo.txt").open()
+78    |-Path("foo.txt").open("w")
+   78 |+Path("foo.txt").open("w", encoding="locale")
+79 79 | 
+80 80 | # Non-errors.
+81 81 | Path("foo.txt").open(encoding="utf-8")

--- a/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLW1514_unspecified_encoding.py.snap
+++ b/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLW1514_unspecified_encoding.py.snap
@@ -354,7 +354,7 @@ unspecified_encoding.py:68:1: PLW1514 [*] `open` in text mode without explicit `
 71 71 | )
 72 72 | 
 
-unspecified_encoding.py:77:1: PLW1514 [*] `pathlib.Path.open` in text mode without explicit `encoding` argument
+unspecified_encoding.py:77:1: PLW1514 [*] `pathlib.Path(...).open` in text mode without explicit `encoding` argument
    |
 76 | # Errors.
 77 | Path("foo.txt").open()
@@ -374,7 +374,7 @@ unspecified_encoding.py:77:1: PLW1514 [*] `pathlib.Path.open` in text mode witho
 79 79 | text = Path("foo.txt").read_text()
 80 80 | Path("foo.txt").write_text(text)
 
-unspecified_encoding.py:78:1: PLW1514 [*] `pathlib.Path.open` in text mode without explicit `encoding` argument
+unspecified_encoding.py:78:1: PLW1514 [*] `pathlib.Path(...).open` in text mode without explicit `encoding` argument
    |
 76 | # Errors.
 77 | Path("foo.txt").open()
@@ -395,7 +395,7 @@ unspecified_encoding.py:78:1: PLW1514 [*] `pathlib.Path.open` in text mode witho
 80 80 | Path("foo.txt").write_text(text)
 81 81 | 
 
-unspecified_encoding.py:79:8: PLW1514 [*] `pathlib.Path.read_text` without explicit `encoding` argument
+unspecified_encoding.py:79:8: PLW1514 [*] `pathlib.Path(...).read_text` without explicit `encoding` argument
    |
 77 | Path("foo.txt").open()
 78 | Path("foo.txt").open("w")
@@ -415,7 +415,7 @@ unspecified_encoding.py:79:8: PLW1514 [*] `pathlib.Path.read_text` without expli
 81 81 | 
 82 82 | # Non-errors.
 
-unspecified_encoding.py:80:1: PLW1514 [*] `pathlib.Path.write_text` without explicit `encoding` argument
+unspecified_encoding.py:80:1: PLW1514 [*] `pathlib.Path(...).write_text` without explicit `encoding` argument
    |
 78 | Path("foo.txt").open("w")
 79 | text = Path("foo.txt").read_text()

--- a/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__unspecified_encoding_python39_or_lower.snap
+++ b/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__unspecified_encoding_python39_or_lower.snap
@@ -473,5 +473,51 @@ unspecified_encoding.py:68:1: PLW1514 [*] `open` in text mode without explicit `
    70 |+    (("test.txt")), encoding=locale.getpreferredencoding(False),
 70 71 |     # comment
 71 72 | )
+72 73 | 
 
+unspecified_encoding.py:77:1: PLW1514 [*] `pathlib.Path.open` in text mode without explicit `encoding` argument
+   |
+76 | # Errors.
+77 | Path("foo.txt").open()
+   | ^^^^^^^^^^^^^^^^^^^^ PLW1514
+78 | Path("foo.txt").open("w")
+   |
+   = help: Add explicit `encoding` argument
 
+ℹ Unsafe fix
+72 72 | 
+73 73 | # Pathlib
+74 74 | from pathlib import Path
+   75 |+import locale
+75 76 | 
+76 77 | # Errors.
+77    |-Path("foo.txt").open()
+   78 |+Path("foo.txt").open(encoding=locale.getpreferredencoding(False))
+78 79 | Path("foo.txt").open("w")
+79 80 | 
+80 81 | # Non-errors.
+
+unspecified_encoding.py:78:1: PLW1514 [*] `pathlib.Path.open` in text mode without explicit `encoding` argument
+   |
+76 | # Errors.
+77 | Path("foo.txt").open()
+78 | Path("foo.txt").open("w")
+   | ^^^^^^^^^^^^^^^^^^^^ PLW1514
+79 | 
+80 | # Non-errors.
+   |
+   = help: Add explicit `encoding` argument
+
+ℹ Unsafe fix
+72 72 | 
+73 73 | # Pathlib
+74 74 | from pathlib import Path
+   75 |+import locale
+75 76 | 
+76 77 | # Errors.
+77 78 | Path("foo.txt").open()
+78    |-Path("foo.txt").open("w")
+   79 |+Path("foo.txt").open("w", encoding=locale.getpreferredencoding(False))
+79 80 | 
+80 81 | # Non-errors.
+81 82 | Path("foo.txt").open(encoding="utf-8")

--- a/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__unspecified_encoding_python39_or_lower.snap
+++ b/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__unspecified_encoding_python39_or_lower.snap
@@ -481,12 +481,13 @@ unspecified_encoding.py:77:1: PLW1514 [*] `pathlib.Path.open` in text mode witho
 77 | Path("foo.txt").open()
    | ^^^^^^^^^^^^^^^^^^^^ PLW1514
 78 | Path("foo.txt").open("w")
+79 | text = Path("foo.txt").read_text()
    |
    = help: Add explicit `encoding` argument
 
 ℹ Unsafe fix
 72 72 | 
-73 73 | # Pathlib
+73 73 | # pathlib
 74 74 | from pathlib import Path
    75 |+import locale
 75 76 | 
@@ -494,8 +495,8 @@ unspecified_encoding.py:77:1: PLW1514 [*] `pathlib.Path.open` in text mode witho
 77    |-Path("foo.txt").open()
    78 |+Path("foo.txt").open(encoding=locale.getpreferredencoding(False))
 78 79 | Path("foo.txt").open("w")
-79 80 | 
-80 81 | # Non-errors.
+79 80 | text = Path("foo.txt").read_text()
+80 81 | Path("foo.txt").write_text(text)
 
 unspecified_encoding.py:78:1: PLW1514 [*] `pathlib.Path.open` in text mode without explicit `encoding` argument
    |
@@ -503,14 +504,14 @@ unspecified_encoding.py:78:1: PLW1514 [*] `pathlib.Path.open` in text mode witho
 77 | Path("foo.txt").open()
 78 | Path("foo.txt").open("w")
    | ^^^^^^^^^^^^^^^^^^^^ PLW1514
-79 | 
-80 | # Non-errors.
+79 | text = Path("foo.txt").read_text()
+80 | Path("foo.txt").write_text(text)
    |
    = help: Add explicit `encoding` argument
 
 ℹ Unsafe fix
 72 72 | 
-73 73 | # Pathlib
+73 73 | # pathlib
 74 74 | from pathlib import Path
    75 |+import locale
 75 76 | 
@@ -518,6 +519,58 @@ unspecified_encoding.py:78:1: PLW1514 [*] `pathlib.Path.open` in text mode witho
 77 78 | Path("foo.txt").open()
 78    |-Path("foo.txt").open("w")
    79 |+Path("foo.txt").open("w", encoding=locale.getpreferredencoding(False))
-79 80 | 
-80 81 | # Non-errors.
-81 82 | Path("foo.txt").open(encoding="utf-8")
+79 80 | text = Path("foo.txt").read_text()
+80 81 | Path("foo.txt").write_text(text)
+81 82 | 
+
+unspecified_encoding.py:79:8: PLW1514 [*] `pathlib.Path.read_text` without explicit `encoding` argument
+   |
+77 | Path("foo.txt").open()
+78 | Path("foo.txt").open("w")
+79 | text = Path("foo.txt").read_text()
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^^ PLW1514
+80 | Path("foo.txt").write_text(text)
+   |
+   = help: Add explicit `encoding` argument
+
+ℹ Unsafe fix
+72 72 | 
+73 73 | # pathlib
+74 74 | from pathlib import Path
+   75 |+import locale
+75 76 | 
+76 77 | # Errors.
+77 78 | Path("foo.txt").open()
+78 79 | Path("foo.txt").open("w")
+79    |-text = Path("foo.txt").read_text()
+   80 |+text = Path("foo.txt").read_text(encoding=locale.getpreferredencoding(False))
+80 81 | Path("foo.txt").write_text(text)
+81 82 | 
+82 83 | # Non-errors.
+
+unspecified_encoding.py:80:1: PLW1514 [*] `pathlib.Path.write_text` without explicit `encoding` argument
+   |
+78 | Path("foo.txt").open("w")
+79 | text = Path("foo.txt").read_text()
+80 | Path("foo.txt").write_text(text)
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^ PLW1514
+81 | 
+82 | # Non-errors.
+   |
+   = help: Add explicit `encoding` argument
+
+ℹ Unsafe fix
+72 72 | 
+73 73 | # pathlib
+74 74 | from pathlib import Path
+   75 |+import locale
+75 76 | 
+76 77 | # Errors.
+77 78 | Path("foo.txt").open()
+78 79 | Path("foo.txt").open("w")
+79 80 | text = Path("foo.txt").read_text()
+80    |-Path("foo.txt").write_text(text)
+   81 |+Path("foo.txt").write_text(text, encoding=locale.getpreferredencoding(False))
+81 82 | 
+82 83 | # Non-errors.
+83 84 | Path("foo.txt").open(encoding="utf-8")

--- a/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__unspecified_encoding_python39_or_lower.snap
+++ b/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__unspecified_encoding_python39_or_lower.snap
@@ -475,7 +475,7 @@ unspecified_encoding.py:68:1: PLW1514 [*] `open` in text mode without explicit `
 71 72 | )
 72 73 | 
 
-unspecified_encoding.py:77:1: PLW1514 [*] `pathlib.Path.open` in text mode without explicit `encoding` argument
+unspecified_encoding.py:77:1: PLW1514 [*] `pathlib.Path(...).open` in text mode without explicit `encoding` argument
    |
 76 | # Errors.
 77 | Path("foo.txt").open()
@@ -498,7 +498,7 @@ unspecified_encoding.py:77:1: PLW1514 [*] `pathlib.Path.open` in text mode witho
 79 80 | text = Path("foo.txt").read_text()
 80 81 | Path("foo.txt").write_text(text)
 
-unspecified_encoding.py:78:1: PLW1514 [*] `pathlib.Path.open` in text mode without explicit `encoding` argument
+unspecified_encoding.py:78:1: PLW1514 [*] `pathlib.Path(...).open` in text mode without explicit `encoding` argument
    |
 76 | # Errors.
 77 | Path("foo.txt").open()
@@ -523,7 +523,7 @@ unspecified_encoding.py:78:1: PLW1514 [*] `pathlib.Path.open` in text mode witho
 80 81 | Path("foo.txt").write_text(text)
 81 82 | 
 
-unspecified_encoding.py:79:8: PLW1514 [*] `pathlib.Path.read_text` without explicit `encoding` argument
+unspecified_encoding.py:79:8: PLW1514 [*] `pathlib.Path(...).read_text` without explicit `encoding` argument
    |
 77 | Path("foo.txt").open()
 78 | Path("foo.txt").open("w")
@@ -548,7 +548,7 @@ unspecified_encoding.py:79:8: PLW1514 [*] `pathlib.Path.read_text` without expli
 81 82 | 
 82 83 | # Non-errors.
 
-unspecified_encoding.py:80:1: PLW1514 [*] `pathlib.Path.write_text` without explicit `encoding` argument
+unspecified_encoding.py:80:1: PLW1514 [*] `pathlib.Path(...).write_text` without explicit `encoding` argument
    |
 78 | Path("foo.txt").open("w")
 79 | text = Path("foo.txt").read_text()


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Resolves #11263

Detect `pathlib.Path.open` calls which do not specify a file encoding.

## Test Plan

Test cases added to fixture.
