### PR TITLE
Fix `ruff server` hanging after Neovim closes

### DIFF
--- a/crates/ruff_server/src/server.rs
+++ b/crates/ruff_server/src/server.rs
@@ -114,9 +114,6 @@ impl Server {
                 self.worker_threads,
             )?;
             self.connection.close()?;
-            // Note: when we start routing tracing through the LSP,
-            // this should be replaced with a log directly to `stderr`.
-            tracing::info!("Server has shut down successfully");
             Ok(())
         })?
         .join()


### PR DESCRIPTION
## Summary

A follow-up to https://github.com/astral-sh/ruff/pull/11222. `ruff server` stalls during shutdown with Neovim because after it receives an exit notification and closes the I/O thread, it attempts to log a success message to `stderr`. Removing this log statement fixes this issue.

## Test Plan

Track the instances of `ruff` in the OS task manager as you open and close Neovim. A new instance should appear when Neovim starts and it should disappear once Neovim is closed.
