### PR TITLE
Tell renovate not to try to update GitHub runners

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -34,7 +34,7 @@
     {
       // This package rule disables updates for GitHub runners:
       // we'd only pin them to a specific version
-      /// if there was a deliberate reason to do so
+      // if there was a deliberate reason to do so
       groupName: "GitHub runners",
       matchManagers: ["github-actions"],
       matchDatasources: ["github-runners"],

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -27,8 +27,19 @@
       // Group upload/download artifact updates, the versions are dependent
       groupName: "Artifact GitHub Actions dependencies",
       matchManagers: ["github-actions"],
+      matchDatasources: ["gitea-tags", "github-tags"],
       matchPackagePatterns: ["actions/.*-artifact"],
       description: "Weekly update of artifact-related GitHub Actions dependencies",
+    },
+    {
+      // This package rule disables updates for GitHub runners:
+      // we'd only pin them to a specific version
+      /// if there was a deliberate reason to do so
+      groupName: "GitHub runners",
+      matchManagers: ["github-actions"],
+      matchDatasources: ["github-runners"],
+      description: "Disable PRs updating GitHub runners (e.g. 'runs-on: macos-14')",
+      enabled: false,
     },
     {
       groupName: "pre-commit dependencies",


### PR DESCRIPTION
## Summary

If we've pinned a GitHub runner to a specific version (e.g. `macos-12` rather than `macos-latest`, we've probably done so for a specific reason, so PRs like https://github.com/astral-sh/ruff/pull/11300 are just annoying. The fix for this is a bit obscure, but it appears the way to do it is to setup a package rule that only matches renovate updates which use the `github-runners` datasource, and then set `enabled: false` in that package rule.

Docs:
- https://docs.renovatebot.com/configuration-options/#matchdatasources
- https://docs.renovatebot.com/configuration-options/#enabled

## Test Plan

```
% npx --yes --package renovate -- renovate-config-validator --strict                                               ~/dev/ruff
(node:57154) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
 INFO: Validating .github/renovate.json5
 INFO: Config validated successfully
```
