### PR TITLE
Salsa based red-knot prototype

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -463,6 +463,11 @@ name = "countme"
 version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7704b5fdd17b18ae31c4c1da5a2e0305a2bf17b5249300a9ee9ed7b72114c636"
+dependencies = [
+ "dashmap",
+ "once_cell",
+ "rustc-hash",
+]
 
 [[package]]
 name = "crc32fast"
@@ -1810,9 +1815,11 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bitflags 2.5.0",
+ "countme",
  "crossbeam",
  "ctrlc",
  "dashmap",
+ "filetime",
  "hashbrown 0.14.5",
  "indexmap",
  "notify",
@@ -1828,6 +1835,7 @@ dependencies = [
  "smol_str",
  "tempfile",
  "tracing",
+ "tracing-log",
  "tracing-subscriber",
  "tracing-tree",
 ]
@@ -2538,7 +2546,7 @@ checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
 [[package]]
 name = "salsa-2022"
 version = "0.1.0"
-source = "git+https://github.com/salsa-rs/salsa.git?rev=f5aec4abefb4c5e67cba6d8ea91c216bc2838f10#f5aec4abefb4c5e67cba6d8ea91c216bc2838f10"
+source = "git+https://github.com/salsa-rs/salsa.git?rev=05b4e3ebdcdc47730cdd359e7e97fb2470527279#05b4e3ebdcdc47730cdd359e7e97fb2470527279"
 dependencies = [
  "arc-swap",
  "crossbeam",
@@ -2556,7 +2564,7 @@ dependencies = [
 [[package]]
 name = "salsa-2022-macros"
 version = "0.1.0"
-source = "git+https://github.com/salsa-rs/salsa.git?rev=f5aec4abefb4c5e67cba6d8ea91c216bc2838f10#f5aec4abefb4c5e67cba6d8ea91c216bc2838f10"
+source = "git+https://github.com/salsa-rs/salsa.git?rev=05b4e3ebdcdc47730cdd359e7e97fb2470527279#05b4e3ebdcdc47730cdd359e7e97fb2470527279"
 dependencies = [
  "eyre",
  "heck 0.4.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1835,7 +1835,6 @@ dependencies = [
  "smol_str",
  "tempfile",
  "tracing",
- "tracing-log",
  "tracing-subscriber",
  "tracing-tree",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,6 +134,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
 
 [[package]]
+name = "arc-swap"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
+
+[[package]]
 name = "argfile"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -350,10 +356,10 @@ version = "4.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "528131438037fd55894f62d6e9f068b8f45ac57ffa77517819645d10aed04f64"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -594,7 +600,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.10.0",
- "syn",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -605,7 +611,7 @@ checksum = "a668eda54683121533a393014d8692171709ff57a7d61f187b6e782719f8933f"
 dependencies = [
  "darling_core",
  "quote",
- "syn",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -729,6 +735,16 @@ checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "eyre"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd915d99f24784cdc19fd37ef22b97e3ff0ae756c7e492e9fbfe897d61e2aec"
+dependencies = [
+ "indenter",
+ "once_cell",
 ]
 
 [[package]]
@@ -869,6 +885,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashlink"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8094feaf31ff591f651a2664fb9cfd92bba7a60ce3197265e9482ebe753c8f7"
+dependencies = [
+ "hashbrown 0.14.5",
+]
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -969,6 +1000,12 @@ dependencies = [
  "phf",
  "rust-stemmers",
 ]
+
+[[package]]
+name = "indenter"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
 name = "indexmap"
@@ -1075,7 +1112,7 @@ dependencies = [
  "Inflector",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -1192,7 +1229,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2ae40017ac09cd2c6a53504cb3c871c7f2b41466eac5bc66ba63f39073b467b"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -1637,7 +1674,7 @@ checksum = "52a40bc70c2c58040d2d8b167ba9a5ff59fc9dab7ad44771cfde3dcfde7a09c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -1787,6 +1824,7 @@ dependencies = [
  "ruff_python_parser",
  "ruff_text_size",
  "rustc-hash",
+ "salsa-2022",
  "smol_str",
  "tempfile",
  "tracing",
@@ -1876,7 +1914,7 @@ dependencies = [
  "pmutil",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -2125,7 +2163,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "ruff_python_trivia",
- "syn",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -2498,6 +2536,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
 
 [[package]]
+name = "salsa-2022"
+version = "0.1.0"
+source = "git+https://github.com/salsa-rs/salsa.git?rev=f5aec4abefb4c5e67cba6d8ea91c216bc2838f10#f5aec4abefb4c5e67cba6d8ea91c216bc2838f10"
+dependencies = [
+ "arc-swap",
+ "crossbeam",
+ "crossbeam-utils",
+ "dashmap",
+ "hashlink",
+ "indexmap",
+ "log",
+ "parking_lot",
+ "rustc-hash",
+ "salsa-2022-macros",
+ "smallvec",
+]
+
+[[package]]
+name = "salsa-2022-macros"
+version = "0.1.0"
+source = "git+https://github.com/salsa-rs/salsa.git?rev=f5aec4abefb4c5e67cba6d8ea91c216bc2838f10#f5aec4abefb4c5e67cba6d8ea91c216bc2838f10"
+dependencies = [
+ "eyre",
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2527,7 +2595,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -2576,7 +2644,7 @@ checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -2587,7 +2655,7 @@ checksum = "330f01ce65a3a5fe59a60c82f3c9a024b573b8a6e875bd233fe5f934e71d54e3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -2609,7 +2677,7 @@ checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -2650,7 +2718,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -2746,11 +2814,11 @@ version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7993a8e3a9e88a00351486baae9522c91b123a088f76469e5bd5cc17198ea87"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "rustversion",
- "syn",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -2758,6 +2826,17 @@ name = "subtle"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "syn"
@@ -2823,7 +2902,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -2834,7 +2913,7 @@ checksum = "5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.66",
  "test-case-core",
 ]
 
@@ -2855,7 +2934,7 @@ checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -2967,7 +3046,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -3197,7 +3276,7 @@ checksum = "9881bea7cbe687e36c9ab3b778c36cd0487402e270304e8b1296d5085303c1a2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -3282,7 +3361,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.66",
  "wasm-bindgen-shared",
 ]
 
@@ -3316,7 +3395,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.66",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3349,7 +3428,7 @@ checksum = "b7f89739351a2e03cb94beb799d47fb2cac01759b40ec441f7de39b00cbf7ef0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -3618,7 +3697,7 @@ checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.66",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2021"
-rust-version = "1.74"
+rust-version = "1.73"
 homepage = "https://docs.astral.sh/ruff"
 documentation = "https://docs.astral.sh/ruff"
 repository = "https://github.com/astral-sh/ruff"

--- a/crates/red_knot/Cargo.toml
+++ b/crates/red_knot/Cargo.toml
@@ -34,7 +34,6 @@ rustc-hash = { workspace = true }
 salsa = { git = "https://github.com/salsa-rs/salsa.git", package = "salsa-2022", rev = "05b4e3ebdcdc47730cdd359e7e97fb2470527279" }
 smol_str = { version = "0.2.1" }
 tracing = { workspace = true }
-tracing-log = { version = "0.2.0" }
 tracing-subscriber = { workspace = true }
 tracing-tree = { workspace = true }
 

--- a/crates/red_knot/Cargo.toml
+++ b/crates/red_knot/Cargo.toml
@@ -29,6 +29,7 @@ notify = { workspace = true }
 parking_lot = { workspace = true }
 rayon = { workspace = true }
 rustc-hash = { workspace = true }
+salsa = { git = "https://github.com/salsa-rs/salsa.git", package = "salsa-2022", rev = "f5aec4abefb4c5e67cba6d8ea91c216bc2838f10" }
 smol_str = { version = "0.2.1" }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/crates/red_knot/Cargo.toml
+++ b/crates/red_knot/Cargo.toml
@@ -20,23 +20,27 @@ ruff_notebook = { workspace = true }
 
 anyhow = { workspace = true }
 bitflags = { workspace = true }
+countme = { workspace = true, features = ["enable"] }
 crossbeam = { workspace = true }
 ctrlc = { version = "3.4.4" }
 dashmap = { workspace = true }
+filetime = { workspace = true }
 hashbrown = { workspace = true }
 indexmap = { workspace = true }
 notify = { workspace = true }
 parking_lot = { workspace = true }
 rayon = { workspace = true }
 rustc-hash = { workspace = true }
-salsa = { git = "https://github.com/salsa-rs/salsa.git", package = "salsa-2022", rev = "f5aec4abefb4c5e67cba6d8ea91c216bc2838f10" }
+salsa = { git = "https://github.com/salsa-rs/salsa.git", package = "salsa-2022", rev = "05b4e3ebdcdc47730cdd359e7e97fb2470527279" }
 smol_str = { version = "0.2.1" }
 tracing = { workspace = true }
+tracing-log = { version = "0.2.0" }
 tracing-subscriber = { workspace = true }
 tracing-tree = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }
+
 
 [lints]
 workspace = true

--- a/crates/red_knot/src/ast_ids.rs
+++ b/crates/red_knot/src/ast_ids.rs
@@ -266,7 +266,7 @@ enum DeferredNode<'a> {
     ClassDefinition(&'a StmtClassDef),
 }
 
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+#[derive(Copy, Clone, Debug)]
 pub struct TypedNodeKey<N: AstNode> {
     /// The type erased node key.
     inner: NodeKey,
@@ -301,6 +301,20 @@ impl<N: AstNode> TypedNodeKey<N> {
 
     pub fn erased(&self) -> &NodeKey {
         &self.inner
+    }
+}
+
+impl<N: AstNode> PartialEq for TypedNodeKey<N> {
+    fn eq(&self, other: &Self) -> bool {
+        self.inner == other.inner
+    }
+}
+
+impl<N: AstNode> Eq for TypedNodeKey<N> {}
+
+impl<N: AstNode> Hash for TypedNodeKey<N> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.inner.hash(state);
     }
 }
 

--- a/crates/red_knot/src/lib.rs
+++ b/crates/red_knot/src/lib.rs
@@ -18,6 +18,7 @@ pub mod module;
 mod parse;
 pub mod program;
 mod semantic;
+mod salsa_db;
 pub mod source;
 pub mod watch;
 

--- a/crates/red_knot/src/module.rs
+++ b/crates/red_knot/src/module.rs
@@ -115,7 +115,8 @@ impl ModuleName {
         Self(smol_str::SmolStr::new(name))
     }
 
-    fn from_relative_path(path: &Path) -> Option<Self> {
+    // TODO(Micha): Make private again when the Salsa db module resolution logic lives next to this module again.
+    pub(crate) fn from_relative_path(path: &Path) -> Option<Self> {
         let path = if path.ends_with("__init__.py") || path.ends_with("__init__.pyi") {
             path.parent()?
         } else {

--- a/crates/red_knot/src/module.rs
+++ b/crates/red_knot/src/module.rs
@@ -660,13 +660,13 @@ where
 }
 
 #[derive(Debug)]
-struct ResolvedPackage {
-    path: PathBuf,
-    kind: PackageKind,
+pub struct ResolvedPackage {
+    pub path: PathBuf,
+    pub kind: PackageKind,
 }
 
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]
-enum PackageKind {
+pub enum PackageKind {
     /// A root package or module. E.g. `foo` in `foo.bar.baz` or just `foo`.
     Root,
 
@@ -682,7 +682,7 @@ enum PackageKind {
 }
 
 impl PackageKind {
-    const fn is_regular_package(self) -> bool {
+    pub const fn is_regular_package(self) -> bool {
         matches!(self, PackageKind::Regular)
     }
 }

--- a/crates/red_knot/src/salsa_db.rs
+++ b/crates/red_knot/src/salsa_db.rs
@@ -1,46 +1,211 @@
 #![allow(unreachable_pub)]
+#![allow(unused)]
 
+use std::fmt::Formatter;
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use parking_lot::lock_api::RwLockUpgradableReadGuard;
-use parking_lot::RwLock;
+use countme::Count;
+use dashmap::mapref::entry::Entry;
+use filetime::FileTime;
 use rustc_hash::FxHashMap;
-use salsa::Event;
-use tracing::warn;
+use salsa::database::AsSalsaDatabase;
+use salsa::{DebugWithDb, Event};
+use tracing::{debug, debug_span, warn, Level};
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::{Layer, Registry};
+use tracing_tree::time::Uptime;
 
 use ruff_python_ast::visitor::preorder::{PreorderVisitor, TraversalSignal};
-use ruff_python_ast::visitor::{preorder, Visitor};
+use ruff_python_ast::visitor::{preorder, walk_stmt, Visitor};
 use ruff_python_ast::{AnyNodeRef, Expr, Mod, ModModule, Stmt, StmtExpr};
 use ruff_python_parser::Mode;
 use ruff_text_size::{Ranged, TextRange};
 
 use crate::ast_ids::AstIds;
 use crate::files::{FileId, Files};
-use crate::module::ModuleName;
+use crate::module::{ModuleKind, ModuleSearchPath};
+use crate::salsa_db::source::{File, SourceText};
+use crate::FxDashMap;
 
-// TODO salsa recommends to have one jar per crate and call it `Jar`. We're not doing this here
-// because I don't want that many crates just yet.
-#[salsa::input(jar=SourceJar)]
-pub struct SourceText {
-    file: FileId,
+use self::source::{Db as SourceDb, Jar as SourceJar};
 
-    #[return_ref]
-    text: String,
-}
+pub mod source {
+    use std::path::PathBuf;
+    use std::sync::Arc;
 
-#[salsa::tracked(jar=SourceJar)]
-pub struct Parsed {
-    // TODO should this be an arc to avoid some lifetime awkwardness for call-sites.
-    #[return_ref]
-    pub ast: ModModule,
+    use countme::Count;
+    use dashmap::mapref::entry::Entry;
+    use filetime::FileTime;
 
-    #[return_ref]
-    pub imports: Vec<String>,
+    use ruff_python_ast::{Mod, ModModule, Stmt, StmtExpr};
+    use ruff_python_parser::Mode;
+    use ruff_text_size::{Ranged, TextRange};
 
-    // TODO use an accumulator for this?
-    #[return_ref]
-    pub errors: Vec<ruff_python_parser::ParseError>,
+    use crate::FxDashMap;
+
+    #[salsa::input(jar=Jar)]
+    pub struct File {
+        #[return_ref]
+        pub path: PathBuf,
+
+        pub permissions: u32,
+        pub last_modified_time: FileTime,
+        _count: Count<File>,
+    }
+
+    impl File {
+        #[tracing::instrument(level = "debug", skip(db))]
+        pub fn touch(&self, db: &mut dyn Db) {
+            let path = self.path(db);
+            let metadata = path.metadata().unwrap();
+            let last_modified = filetime::FileTime::from_last_modification_time(&metadata);
+
+            self.set_last_modified_time(db).to(last_modified);
+        }
+    }
+
+    #[salsa::tracked(jar=Jar)]
+    impl File {
+        #[salsa::tracked]
+        pub fn source(self, db: &dyn Db) -> SourceText {
+            let _ = self.last_modified_time(db); // Read the last modified date to trigger a re-run when the file changes.
+            let text = std::fs::read_to_string(self.path(db)).unwrap_or_default();
+
+            SourceText {
+                text: Arc::new(text),
+                count: Count::default(),
+            }
+        }
+    }
+
+    #[derive(Debug, Clone, Default)]
+    pub struct Files {
+        inner: Arc<FilesInner>,
+    }
+
+    impl Files {
+        pub(super) fn resolve(&self, db: &dyn Db, path: PathBuf) -> File {
+            match self.inner.by_path.entry(path.clone()) {
+                Entry::Occupied(entry) => {
+                    let file = entry.get();
+                    *file
+                }
+                Entry::Vacant(entry) => {
+                    let metadata = path.metadata();
+                    let (last_modified, permissions) = if let Ok(metadata) = metadata {
+                        let last_modified =
+                            filetime::FileTime::from_last_modification_time(&metadata);
+                        #[cfg(unix)]
+                        let permissions = if cfg!(unix) {
+                            use std::os::unix::fs::PermissionsExt;
+                            metadata.permissions().mode()
+                        } else {
+                            0
+                        };
+
+                        (last_modified, permissions)
+                    } else {
+                        (FileTime::zero(), 0)
+                    };
+
+                    // TODO: How to set the durability?
+
+                    let file = File::new(db, path, permissions, last_modified, Count::default());
+                    entry.insert(file);
+
+                    file
+                }
+            }
+        }
+    }
+
+    #[derive(Debug, Default)]
+    struct FilesInner {
+        by_path: FxDashMap<PathBuf, File>,
+    }
+
+    // TODO salsa recommends to have one jar per crate and call it `Jar`. We're not doing this here
+    // because I don't want that many crates just yet.
+    #[derive(Debug, Clone, Eq, PartialEq)]
+    pub struct SourceText {
+        pub text: Arc<String>,
+        count: Count<SourceText>,
+    }
+
+    impl SourceText {
+        pub fn text(&self) -> &str {
+            self.text.as_str()
+        }
+    }
+
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct Parsed {
+        inner: Arc<ParsedInner>,
+    }
+
+    impl Parsed {
+        pub fn ast(&self) -> &ModModule {
+            &self.inner.ast
+        }
+
+        pub fn errors(&self) -> &[ruff_python_parser::ParseError] {
+            &self.inner.errors
+        }
+    }
+
+    #[derive(Debug, PartialEq)]
+    struct ParsedInner {
+        // TODO should this be an arc to avoid some lifetime awkwardness for call-sites.
+        pub ast: ModModule,
+
+        // TODO use an accumulator for this?
+        pub errors: Vec<ruff_python_parser::ParseError>,
+    }
+
+    #[tracing::instrument(level = "debug", skip(db))]
+    #[salsa::tracked(jar=Jar, no_eq)]
+    pub fn parse(db: &dyn Db, file: File) -> Parsed {
+        let source = file.source(db);
+        let text = source.text();
+
+        let result = ruff_python_parser::parse(text, Mode::Module);
+
+        let (module, errors) = match result {
+            Ok(Mod::Module(module)) => (module, vec![]),
+            Ok(Mod::Expression(expression)) => (
+                ModModule {
+                    range: expression.range(),
+                    body: vec![Stmt::Expr(StmtExpr {
+                        range: expression.range(),
+                        value: expression.body,
+                    })],
+                },
+                vec![],
+            ),
+            Err(errors) => (
+                ModModule {
+                    range: TextRange::default(),
+                    body: Vec::new(),
+                },
+                vec![errors],
+            ),
+        };
+
+        Parsed {
+            inner: Arc::new(ParsedInner {
+                ast: module,
+                errors,
+            }),
+        }
+    }
+
+    #[salsa::jar(db=Db)]
+    pub struct Jar(File, File_source, parse);
+
+    pub trait Db: salsa::DbWithJar<Jar> {
+        fn file(&self, path: PathBuf) -> File;
+    }
 }
 
 #[salsa::tracked(jar=SemanticJar)]
@@ -55,28 +220,90 @@ pub struct PhysicalLinesCheck {
     pub diagnostics: Vec<String>,
 }
 
-#[salsa::jar(db=SourceDb)]
-pub struct SourceJar(SourceText, Parsed, parse);
+#[salsa::input(jar=SemanticJar, singleton)]
+pub struct ModuleSearchPaths {
+    #[return_ref]
+    paths: Vec<ModuleSearchPath>,
+}
+
+#[salsa::interned(jar=SemanticJar)]
+pub struct ModuleName {
+    name: smol_str::SmolStr,
+}
+
+impl ModuleName {
+    pub fn components(&self, db: &dyn SemanticDb) -> Vec<String> {
+        let name = self.name(db);
+        name.split(".").map(String::from).collect()
+    }
+}
+
+// TODO should this be tracked or not?
+// I think yes, so that we can reference to it using ids.
+#[salsa::tracked(jar=SemanticJar)]
+pub struct Module {
+    name: ModuleName,
+    file: File,
+}
+
+#[salsa::tracked(jar=SemanticJar)]
+pub struct Symbol {
+    #[id]
+    #[returned_ref]
+    pub name: smol_str::SmolStr,
+
+    count: Count<Symbol>,
+}
+
+#[derive(Eq, PartialEq, Default)]
+pub struct SymbolTable {
+    symbols: FxHashMap<smol_str::SmolStr, Symbol>,
+}
+
+impl SymbolTable {
+    fn insert(&mut self, name: smol_str::SmolStr, symbol: Symbol) {
+        self.symbols.insert(name, symbol);
+    }
+}
+
+impl std::fmt::Debug for SymbolTable {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        self.symbols.fmt(f)
+    }
+}
+
+impl<Db> DebugWithDb<Db> for SymbolTable
+where
+    Db: AsSalsaDatabase + SemanticDb,
+{
+    fn fmt(&self, f: &mut Formatter<'_>, db: &Db) -> std::fmt::Result {
+        let mut map = f.debug_map();
+
+        for (name, symbol) in &self.symbols {
+            map.entry(name, &symbol.debug(db));
+        }
+        map.finish()
+    }
+}
 
 #[salsa::jar(db=SemanticDb)]
 pub struct SemanticJar(
     SyntaxCheck,
     PhysicalLinesCheck,
+    ModuleSearchPaths,
+    Symbol,
     Module,
+    ModuleName,
     dependencies,
+    symbol_table,
     check_syntax,
     check_physical_lines,
     ast_ids,
+    resolve_module,
 );
 
-pub trait SourceDb: salsa::DbWithJar<SourceJar> {
-    fn source_text(&self, file_id: FileId) -> std::io::Result<SourceText>;
-
-    fn files(&self) -> &Files;
-}
-
-pub trait SemanticDb: SourceDb + salsa::DbWithJar<SemanticJar> {
-    fn upcast(&self) -> &dyn SourceDb;
+pub trait SemanticDb: source::Db + salsa::DbWithJar<SemanticJar> {
+    fn upcast(&self) -> &dyn source::Db;
 }
 
 pub trait Db: SemanticDb {
@@ -87,42 +314,22 @@ pub trait Db: SemanticDb {
 pub struct Database {
     storage: salsa::Storage<Self>,
 
-    // can define additional fields
-    // TODO how to reuse file ids across runs? Do we want this to be part of salsa or shout the id
-    //   mapping happen out side because we don't want to read them from disk every time?
-    sources: Arc<RwLock<FxHashMap<FileId, SourceText>>>,
-    files: Files,
+    files: source::Files,
 }
 
 impl Database {
-    pub fn new(files: Files) -> Self {
+    pub fn new() -> Self {
         Self {
-            sources: Arc::new(RwLock::new(FxHashMap::default())),
-            files,
+            files: source::Files::default(),
             storage: Default::default(),
         }
     }
 }
 
 impl SourceDb for Database {
-    fn source_text(&self, file_id: FileId) -> std::io::Result<SourceText> {
-        let lock = self.sources.upgradable_read();
-        if let Some(source) = lock.get(&file_id) {
-            return Ok(*source);
-        }
-
-        let mut upgraded = RwLockUpgradableReadGuard::upgrade(lock);
-
-        let path = self.files.path(file_id);
-        let file = SourceText::new(self, file_id, std::fs::read_to_string(path)?);
-
-        upgraded.insert(file_id, file);
-
-        Ok(file)
-    }
-
-    fn files(&self) -> &Files {
-        &self.files
+    #[tracing::instrument(level = "debug", skip(self))]
+    fn file(&self, path: PathBuf) -> File {
+        self.files.resolve(self, path)
     }
 }
 
@@ -140,7 +347,7 @@ impl Db for Database {
 
 impl salsa::Database for Database {
     fn salsa_event(&self, event: Event) {
-        tracing::debug!("{:#?}", event);
+        let _ = debug_span!("event", "{:?}", event.debug(self));
     }
 }
 
@@ -149,128 +356,238 @@ impl salsa::ParallelDatabase for Database {
         salsa::Snapshot::new(Database {
             storage: self.storage.snapshot(),
 
-            sources: self.sources.clone(),
             // This is ok, because files is an arc
-            files: self.files.snapshot(),
+            files: self.files.clone(),
         })
     }
 }
 
-#[salsa::tracked(jar=SourceJar)]
-pub fn parse(db: &dyn SourceDb, source: SourceText) -> Parsed {
-    let text = source.text(db);
-
-    let result = ruff_python_parser::parse(text, Mode::Module);
-
-    let (module, errors) = match result {
-        Ok(Mod::Module(module)) => (module, vec![]),
-        Ok(Mod::Expression(expression)) => (
-            ModModule {
-                range: expression.range(),
-                body: vec![Stmt::Expr(StmtExpr {
-                    range: expression.range(),
-                    value: expression.body,
-                })],
-            },
-            vec![],
-        ),
-        Err(errors) => (
-            ModModule {
-                range: TextRange::default(),
-                body: Vec::new(),
-            },
-            vec![errors],
-        ),
-    };
-
-    // Okay, there's actually no input mapping for tracked structs, ugh.
-    Parsed::new(db, module, Vec::new(), errors)
-}
-
+#[tracing::instrument(level = "debug", skip(db))]
 #[salsa::tracked(jar=SemanticJar)]
-pub fn dependencies(db: &dyn SemanticDb, source_text: SourceText) -> Arc<Vec<Dependency>> {
-    let parsed = parse(db.upcast(), source_text);
+pub fn dependencies(db: &dyn SemanticDb, file: File) -> Arc<Vec<Module>> {
+    struct DependenciesVisitor<'a> {
+        db: &'a dyn SemanticDb,
+        module_path: PathBuf,
+        dependencies: Vec<Module>,
+    }
+
+    // TODO support package imports
+    impl PreorderVisitor<'_> for DependenciesVisitor<'_> {
+        fn enter_node(&mut self, node: AnyNodeRef) -> TraversalSignal {
+            // Don't traverse into expressions
+            if node.is_expression() {
+                return TraversalSignal::Skip;
+            }
+
+            TraversalSignal::Traverse
+        }
+
+        fn visit_stmt(&mut self, stmt: &Stmt) {
+            match stmt {
+                Stmt::Import(import) => {
+                    for alias in &import.names {
+                        if let Some(module) = resolve_module_by_name(self.db, &alias.name) {
+                            self.dependencies.push(module);
+                        }
+                    }
+                }
+
+                Stmt::ImportFrom(from) => {
+                    if let Some(module) = &from.module {
+                        assert_eq!(from.level, 0, "Relative imports not supported");
+
+                        if let Some(module) = resolve_module_by_name(self.db, module) {
+                            self.dependencies.push(module);
+                        }
+                    } else {
+                        warn!("Relative imports are not supported");
+                    }
+                }
+                _ => {}
+            }
+            preorder::walk_stmt(self, stmt);
+        }
+    }
+
+    let parsed = source::parse(db.upcast(), file);
 
     let mut visitor = DependenciesVisitor {
-        module_path: db
-            .files()
-            .path(source_text.file(db.upcast()))
+        db,
+        module_path: file
+            .path(db.upcast())
             .parent()
             .map_or_else(PathBuf::new, std::borrow::ToOwned::to_owned),
         dependencies: Vec::new(),
     };
 
     // TODO change the visitor so that `visit_mod` accepts a `ModRef` node that we can construct from module.
-    visitor.visit_body(&parsed.ast(db.upcast()).body);
+    visitor.visit_body(&parsed.ast().body);
 
     Arc::new(visitor.dependencies)
 
     // TODO we should extract the names of dependencies during parsing to avoid an extra traversal here.
 }
 
-struct DependenciesVisitor {
-    module_path: PathBuf,
-    dependencies: Vec<Dependency>,
-}
-
-impl DependenciesVisitor {
-    fn push_dependency(&mut self, path: PathBuf) {
-        // TODO handle error case by pushing a diagnostic?
-        let joined = self.module_path.join(path);
-        if let Ok(normalized) = joined.canonicalize() {
-            self.dependencies.push(Dependency { path: normalized });
-        } else {
-            warn!("Could not canonicalize path: {:?}", joined);
-        }
-    }
-}
-
-// TODO support package imports
-impl PreorderVisitor<'_> for DependenciesVisitor {
-    fn enter_node(&mut self, node: AnyNodeRef) -> TraversalSignal {
-        // Don't traverse into expressions
-        if node.is_expression() {
-            return TraversalSignal::Skip;
-        }
-
-        TraversalSignal::Traverse
-    }
-
-    fn visit_stmt(&mut self, stmt: &Stmt) {
-        match stmt {
-            Stmt::Import(import) => {
-                for alias in &import.names {
-                    let path: PathBuf = alias.name.split('.').collect();
-
-                    self.push_dependency(path.with_extension("py"));
-                }
-            }
-
-            Stmt::ImportFrom(from) => {
-                if let Some(module) = &from.module {
-                    let path: PathBuf = module.split('.').collect();
-                    self.push_dependency(path.with_extension("py"));
-                } else {
-                    let path: PathBuf = (0..from.level).map(|_| "..").collect();
-                    self.push_dependency(path.with_extension("py"));
-                }
-            }
-            _ => {}
-        }
-        preorder::walk_stmt(self, stmt);
-    }
-}
-
-#[derive(Eq, PartialEq, Hash, Clone, Debug)]
-pub struct Dependency {
-    // A relative path from the current module to the dependency
-    pub path: PathBuf,
-}
-
-// TODO it's unclear to me if the function should accept a parsed or a source text?
-//   Is it best practice to inline as many db calls or should we ask the caller to do the db calls?
+#[tracing::instrument(level = "debug", skip(db))]
 #[salsa::tracked(jar=SemanticJar)]
-pub fn check_syntax(db: &dyn SemanticDb, parsed: Parsed) -> SyntaxCheck {
+fn symbol_table(db: &dyn SemanticDb, file_id: File) -> Arc<SymbolTable> {
+    struct SymbolTableVisitor<'db> {
+        symbols: SymbolTable,
+        db: &'db dyn SemanticDb,
+    }
+
+    impl PreorderVisitor<'_> for SymbolTableVisitor<'_> {
+        fn visit_stmt(&mut self, stmt: &'_ Stmt) {
+            match stmt {
+                Stmt::Assign(assign) => {
+                    for target in &assign.targets {
+                        if let Expr::Name(name) = &target {
+                            let name = smol_str::SmolStr::new(&name.id);
+                            self.symbols
+                                .insert(name.clone(), Symbol::new(self.db, name, Count::default()));
+                        }
+                    }
+                }
+                _ => {}
+            }
+
+            preorder::walk_stmt(self, stmt);
+        }
+    }
+
+    let parsed = source::parse(db.upcast(), file_id);
+    let mut visitor = SymbolTableVisitor {
+        db,
+        symbols: SymbolTable::default(),
+    };
+
+    visitor.visit_body(&parsed.ast().body);
+
+    Arc::new(visitor.symbols)
+}
+
+fn resolve_module_by_name(db: &dyn SemanticDb, name: &str) -> Option<Module> {
+    let module_name = ModuleName::new(db, name.into());
+
+    resolve_module(db, module_name)
+}
+
+#[tracing::instrument(level = "debug", skip(db))]
+#[salsa::tracked(jar=SemanticJar)]
+fn resolve_module(db: &dyn SemanticDb, name: ModuleName) -> Option<Module> {
+    let search_paths = ModuleSearchPaths::get(db);
+
+    for search_path in search_paths.paths(db) {
+        let mut components = name.components(db).into_iter();
+        let module_name = components.next_back()?;
+
+        match resolve_package(db, search_path, components) {
+            Ok(resolved_package) => {
+                let mut package_path = resolved_package.path;
+
+                package_path.push(module_name);
+
+                // Must be a `__init__.pyi` or `__init__.py` or it isn't a package.
+                let kind = if package_path.is_dir() {
+                    package_path.push("__init__");
+                    ModuleKind::Package
+                } else {
+                    ModuleKind::Module
+                };
+
+                // TODO Implement full https://peps.python.org/pep-0561/#type-checker-module-resolution-order resolution
+                let stub = package_path.with_extension("pyi");
+                let stub_file = db.file(stub.clone());
+
+                if stub.is_file() {
+                    return Some(Module::new(db, name, stub_file));
+                }
+
+                let module = package_path.with_extension("py");
+                let module_file = db.file(module.clone());
+
+                if module.is_file() {
+                    return Some(Module::new(db, name, module_file));
+                }
+
+                // For regular packages, don't search the next search path. All files of that
+                // package must be in the same location
+                if resolved_package.kind.is_regular_package() {
+                    return None;
+                }
+            }
+            Err(parent_kind) => {
+                if parent_kind.is_regular_package() {
+                    // For regular packages, don't search the next search path.
+                    return None;
+                }
+            }
+        }
+    }
+    None
+}
+
+fn resolve_package<'a, I>(
+    db: &dyn SemanticDb,
+    module_search_path: &ModuleSearchPath,
+    components: I,
+) -> Result<crate::module::ResolvedPackage, crate::module::PackageKind>
+where
+    I: Iterator<Item = String>,
+{
+    let mut package_path = module_search_path.path().to_path_buf();
+
+    // `true` if inside a folder that is a namespace package (has no `__init__.py`).
+    // Namespace packages are special because they can be spread across multiple search paths.
+    // https://peps.python.org/pep-0420/
+    let mut in_namespace_package = false;
+
+    // `true` if resolving a sub-package. For example, `true` when resolving `bar` of `foo.bar`.
+    let mut in_sub_package = false;
+
+    // For `foo.bar.baz`, test that `foo` and `baz` both contain a `__init__.py`.
+    for folder in components {
+        package_path.push(folder);
+
+        let has_init_py = package_path.join("__init__.py").is_file()
+            || package_path.join("__init__.pyi").is_file();
+
+        if has_init_py {
+            in_namespace_package = false;
+        } else if package_path.is_dir() {
+            // A directory without an `__init__.py` is a namespace package, continue with the next folder.
+            in_namespace_package = true;
+        } else if in_namespace_package {
+            // Package not found but it is part of a namespace package.
+            return Err(crate::module::PackageKind::Namespace);
+        } else if in_sub_package {
+            // A regular sub package wasn't found.
+            return Err(crate::module::PackageKind::Regular);
+        } else {
+            // We couldn't find `foo` for `foo.bar.baz`, search the next search path.
+            return Err(crate::module::PackageKind::Root);
+        }
+
+        in_sub_package = true;
+    }
+
+    let kind = if in_namespace_package {
+        crate::module::PackageKind::Namespace
+    } else if in_sub_package {
+        crate::module::PackageKind::Regular
+    } else {
+        crate::module::PackageKind::Root
+    };
+
+    Ok(crate::module::ResolvedPackage {
+        kind,
+        path: package_path,
+    })
+}
+
+#[tracing::instrument(level = "debug", skip(db))]
+#[salsa::tracked(jar=SemanticJar)]
+pub fn check_syntax(db: &dyn SemanticDb, file: File) -> SyntaxCheck {
     // TODO I haven't looked into how many rules are pure syntax checks.
     //   It may be necessary to at least give access to a simplified semantic model.
     struct SyntaxChecker {
@@ -287,17 +604,22 @@ pub fn check_syntax(db: &dyn SemanticDb, parsed: Parsed) -> SyntaxCheck {
         }
     }
 
+    let parsed = source::parse(db.upcast(), file);
+
     let mut visitor = SyntaxChecker {
         diagnostics: Vec::new(),
     };
-    visitor.visit_body(&parsed.ast(db.upcast()).body);
+
+    visitor.visit_body(&parsed.ast().body);
 
     SyntaxCheck::new(db, visitor.diagnostics)
 }
 
+#[tracing::instrument(level = "debug", skip(db))]
 #[salsa::tracked(jar=SemanticJar)]
-pub fn check_physical_lines(db: &dyn SemanticDb, source_text: SourceText) -> PhysicalLinesCheck {
-    let text = source_text.text(db.upcast());
+pub fn check_physical_lines(db: &dyn SemanticDb, file: File) -> PhysicalLinesCheck {
+    let source = file.source(db.upcast());
+    let text = source.text();
 
     let mut diagnostics = Vec::new();
     let mut line_number = 0u32;
@@ -311,16 +633,116 @@ pub fn check_physical_lines(db: &dyn SemanticDb, source_text: SourceText) -> Phy
     PhysicalLinesCheck::new(db, diagnostics)
 }
 
+#[tracing::instrument(level = "debug", skip(db))]
 #[salsa::tracked(jar=SemanticJar)]
-pub fn ast_ids(db: &dyn SemanticDb, source: SourceText) -> Arc<AstIds> {
-    let parsed = parse(db.upcast(), source);
-    let ast = parsed.ast(db.upcast());
+pub fn ast_ids(db: &dyn SemanticDb, file: File) -> Arc<AstIds> {
+    let parsed = source::parse(db.upcast(), file);
 
-    Arc::new(AstIds::from_module(ast))
+    Arc::new(AstIds::from_module(parsed.ast()))
 }
 
-#[salsa::interned(jar=SemanticJar)]
-struct Module {
-    name: ModuleName,
-    path: PathBuf,
+#[cfg(test)]
+mod tests {
+    use salsa::storage::HasJar;
+    use salsa::DebugWithDb;
+    use tracing::{debug, Level};
+    use tracing_subscriber::fmt::time;
+    use tracing_subscriber::fmt::writer::MakeWriterExt;
+    use tracing_subscriber::prelude::__tracing_subscriber_SubscriberExt;
+    use tracing_subscriber::Registry;
+    use tracing_tree::time::Uptime;
+
+    use crate::module::ModuleSearchPathKind;
+    use crate::salsa_db::source::Db;
+
+    use super::{
+        dependencies, source, symbol_table, Database, ModuleSearchPath, ModuleSearchPaths, Symbol,
+    };
+
+    #[test]
+    fn inputs() {
+        countme::enable(true);
+        setup_tracing();
+        // log::set_max_level(LevelFilter::Trace);
+        // log::set_logger()
+
+        let tempdir = tempfile::tempdir().unwrap();
+        let main = tempdir.path().join("main.py");
+        let foo = tempdir.path().join("foo.py");
+
+        std::fs::write(&main, "import foo;\nx = 1").unwrap();
+        std::fs::write(&foo, "x = 10").unwrap();
+
+        let mut db = Database::new();
+        ModuleSearchPaths::new(
+            &mut db,
+            vec![ModuleSearchPath::new(
+                tempdir.path().to_owned(),
+                ModuleSearchPathKind::FirstParty,
+            )],
+        );
+
+        let main_file = db.file(main.clone());
+
+        dependencies(&db, main_file);
+        debug!("{:#?}", &symbol_table(&db, main_file).debug(&db));
+
+        std::fs::write(&main, "print('Hello, Micha!')").unwrap();
+
+        main_file.touch(&mut db);
+
+        // let (source_jar, _): (&mut SourceJar, _) = db.jar_mut();
+        // source_jar.0.reset()
+
+        assert_eq!("print('Hello, Micha!')", main_file.source(&db).text());
+
+        debug!("{:#?}", &symbol_table(&db, main_file).debug(&db));
+
+        // The file never gets collected.
+        main_file.touch(&mut db);
+
+        // TODO: Is there a way to remove a file?
+
+        // There's only one source alive. I guess that makes sense because we never read the content of `foo.py`.
+
+        eprintln!("{}", countme::get_all());
+    }
+
+    fn setup_tracing() {
+        // tracing_log::LogTracer::init().unwrap();
+
+        // let subscriber = Registry::default().with(
+        //     tracing_tree::HierarchicalLayer::default()
+        //         .with_indent_lines(true)
+        //         .with_indent_amount(2)
+        //         .with_bracketed_fields(true)
+        //         .with_thread_ids(true)
+        //         .with_targets(true)
+        //         // .with_writer(|| Box::new(std::io::stderr()))
+        //         .with_timer(Uptime::default()),
+        // );
+        //
+        let subscriber = tracing_subscriber::fmt()
+            // Use a more compact, abbreviated log format
+            .compact()
+            .with_span_events(
+                tracing_subscriber::fmt::format::FmtSpan::ENTER
+                    | tracing_subscriber::fmt::format::FmtSpan::CLOSE,
+            )
+            // Display source code file paths
+            .with_file(false)
+            // Display source code line numbers
+            .with_line_number(true)
+            // Display the thread ID an event was recorded on
+            .with_thread_ids(false)
+            .with_timer(time())
+            // Don't display the event's target (module path)
+            .with_target(true)
+            .with_max_level(Level::TRACE)
+            .with_writer(std::io::stderr)
+            // Build the subscriber
+            .finish();
+
+        tracing::subscriber::set_global_default(subscriber).unwrap();
+    }
 }

--- a/crates/red_knot/src/salsa_db.rs
+++ b/crates/red_knot/src/salsa_db.rs
@@ -1,327 +1,33 @@
 #![allow(unreachable_pub)]
-#![allow(unused)]
+#![allow(clippy::used_underscore_binding)]
 
-use std::fmt::Formatter;
 use std::path::PathBuf;
-use std::sync::Arc;
 
-use countme::Count;
-use dashmap::mapref::entry::Entry;
-use filetime::FileTime;
-use rustc_hash::FxHashMap;
-use salsa::database::AsSalsaDatabase;
-use salsa::{DebugWithDb, Event};
-use tracing::{debug, debug_span, warn, Level};
-use tracing_subscriber::layer::SubscriberExt;
-use tracing_subscriber::{Layer, Registry};
-use tracing_tree::time::Uptime;
+use salsa::{DebugWithDb, Event, Storage};
+use tracing::{debug_span, warn};
 
-use ruff_python_ast::visitor::preorder::{PreorderVisitor, TraversalSignal};
-use ruff_python_ast::visitor::{preorder, walk_stmt, Visitor};
-use ruff_python_ast::{AnyNodeRef, Expr, Mod, ModModule, Stmt, StmtExpr};
-use ruff_python_parser::Mode;
-use ruff_text_size::{Ranged, TextRange};
+use crate::db::Upcast;
+use crate::salsa_db::source::File;
 
-use crate::ast_ids::AstIds;
-use crate::files::{FileId, Files};
-use crate::module::{ModuleKind, ModuleSearchPath};
-use crate::salsa_db::source::{File, SourceText};
-use crate::FxDashMap;
+use self::source::Db as SourceDb;
 
-use self::source::{Db as SourceDb, Jar as SourceJar};
+pub mod lint;
+pub mod semantic;
+pub mod source;
 
-pub mod source {
-    use std::path::PathBuf;
-    use std::sync::Arc;
-
-    use countme::Count;
-    use dashmap::mapref::entry::Entry;
-    use filetime::FileTime;
-
-    use ruff_python_ast::{Mod, ModModule, Stmt, StmtExpr};
-    use ruff_python_parser::Mode;
-    use ruff_text_size::{Ranged, TextRange};
-
-    use crate::FxDashMap;
-
-    #[salsa::input(jar=Jar)]
-    pub struct File {
-        #[return_ref]
-        pub path: PathBuf,
-
-        pub permissions: u32,
-        pub last_modified_time: FileTime,
-        _count: Count<File>,
-    }
-
-    impl File {
-        #[tracing::instrument(level = "debug", skip(db))]
-        pub fn touch(&self, db: &mut dyn Db) {
-            let path = self.path(db);
-            let metadata = path.metadata().unwrap();
-            let last_modified = filetime::FileTime::from_last_modification_time(&metadata);
-
-            self.set_last_modified_time(db).to(last_modified);
-        }
-    }
-
-    #[salsa::tracked(jar=Jar)]
-    impl File {
-        #[salsa::tracked]
-        pub fn source(self, db: &dyn Db) -> SourceText {
-            let _ = self.last_modified_time(db); // Read the last modified date to trigger a re-run when the file changes.
-            let text = std::fs::read_to_string(self.path(db)).unwrap_or_default();
-
-            SourceText {
-                text: Arc::new(text),
-                count: Count::default(),
-            }
-        }
-    }
-
-    #[derive(Debug, Clone, Default)]
-    pub struct Files {
-        inner: Arc<FilesInner>,
-    }
-
-    impl Files {
-        pub(super) fn resolve(&self, db: &dyn Db, path: PathBuf) -> File {
-            match self.inner.by_path.entry(path.clone()) {
-                Entry::Occupied(entry) => {
-                    let file = entry.get();
-                    *file
-                }
-                Entry::Vacant(entry) => {
-                    let metadata = path.metadata();
-                    let (last_modified, permissions) = if let Ok(metadata) = metadata {
-                        let last_modified =
-                            filetime::FileTime::from_last_modification_time(&metadata);
-                        #[cfg(unix)]
-                        let permissions = if cfg!(unix) {
-                            use std::os::unix::fs::PermissionsExt;
-                            metadata.permissions().mode()
-                        } else {
-                            0
-                        };
-
-                        (last_modified, permissions)
-                    } else {
-                        (FileTime::zero(), 0)
-                    };
-
-                    // TODO: How to set the durability?
-
-                    let file = File::new(db, path, permissions, last_modified, Count::default());
-                    entry.insert(file);
-
-                    file
-                }
-            }
-        }
-    }
-
-    #[derive(Debug, Default)]
-    struct FilesInner {
-        by_path: FxDashMap<PathBuf, File>,
-    }
-
-    // TODO salsa recommends to have one jar per crate and call it `Jar`. We're not doing this here
-    // because I don't want that many crates just yet.
-    #[derive(Debug, Clone, Eq, PartialEq)]
-    pub struct SourceText {
-        pub text: Arc<String>,
-        count: Count<SourceText>,
-    }
-
-    impl SourceText {
-        pub fn text(&self) -> &str {
-            self.text.as_str()
-        }
-    }
-
-    #[derive(Debug, Clone, PartialEq)]
-    pub struct Parsed {
-        inner: Arc<ParsedInner>,
-    }
-
-    impl Parsed {
-        pub fn ast(&self) -> &ModModule {
-            &self.inner.ast
-        }
-
-        pub fn errors(&self) -> &[ruff_python_parser::ParseError] {
-            &self.inner.errors
-        }
-    }
-
-    #[derive(Debug, PartialEq)]
-    struct ParsedInner {
-        // TODO should this be an arc to avoid some lifetime awkwardness for call-sites.
-        pub ast: ModModule,
-
-        // TODO use an accumulator for this?
-        pub errors: Vec<ruff_python_parser::ParseError>,
-    }
-
-    #[tracing::instrument(level = "debug", skip(db))]
-    #[salsa::tracked(jar=Jar, no_eq)]
-    pub fn parse(db: &dyn Db, file: File) -> Parsed {
-        let source = file.source(db);
-        let text = source.text();
-
-        let result = ruff_python_parser::parse(text, Mode::Module);
-
-        let (module, errors) = match result {
-            Ok(Mod::Module(module)) => (module, vec![]),
-            Ok(Mod::Expression(expression)) => (
-                ModModule {
-                    range: expression.range(),
-                    body: vec![Stmt::Expr(StmtExpr {
-                        range: expression.range(),
-                        value: expression.body,
-                    })],
-                },
-                vec![],
-            ),
-            Err(errors) => (
-                ModModule {
-                    range: TextRange::default(),
-                    body: Vec::new(),
-                },
-                vec![errors],
-            ),
-        };
-
-        Parsed {
-            inner: Arc::new(ParsedInner {
-                ast: module,
-                errors,
-            }),
-        }
-    }
-
-    #[salsa::jar(db=Db)]
-    pub struct Jar(File, File_source, parse);
-
-    pub trait Db: salsa::DbWithJar<Jar> {
-        fn file(&self, path: PathBuf) -> File;
-    }
-}
-
-#[salsa::tracked(jar=SemanticJar)]
-pub struct SyntaxCheck {
-    #[returned_ref]
-    pub diagnostics: Vec<String>,
-}
-
-#[salsa::tracked(jar=SemanticJar)]
-pub struct PhysicalLinesCheck {
-    #[returned_ref]
-    pub diagnostics: Vec<String>,
-}
-
-#[salsa::input(jar=SemanticJar, singleton)]
-pub struct ModuleSearchPaths {
-    #[return_ref]
-    paths: Vec<ModuleSearchPath>,
-}
-
-#[salsa::interned(jar=SemanticJar)]
-pub struct ModuleName {
-    name: smol_str::SmolStr,
-}
-
-impl ModuleName {
-    pub fn components(&self, db: &dyn SemanticDb) -> Vec<String> {
-        let name = self.name(db);
-        name.split(".").map(String::from).collect()
-    }
-}
-
-// TODO should this be tracked or not?
-// I think yes, so that we can reference to it using ids.
-#[salsa::tracked(jar=SemanticJar)]
-pub struct Module {
-    name: ModuleName,
-    file: File,
-}
-
-#[salsa::tracked(jar=SemanticJar)]
-pub struct Symbol {
-    #[id]
-    #[returned_ref]
-    pub name: smol_str::SmolStr,
-
-    count: Count<Symbol>,
-}
-
-#[derive(Eq, PartialEq, Default)]
-pub struct SymbolTable {
-    symbols: FxHashMap<smol_str::SmolStr, Symbol>,
-}
-
-impl SymbolTable {
-    fn insert(&mut self, name: smol_str::SmolStr, symbol: Symbol) {
-        self.symbols.insert(name, symbol);
-    }
-}
-
-impl std::fmt::Debug for SymbolTable {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        self.symbols.fmt(f)
-    }
-}
-
-impl<Db> DebugWithDb<Db> for SymbolTable
-where
-    Db: AsSalsaDatabase + SemanticDb,
-{
-    fn fmt(&self, f: &mut Formatter<'_>, db: &Db) -> std::fmt::Result {
-        let mut map = f.debug_map();
-
-        for (name, symbol) in &self.symbols {
-            map.entry(name, &symbol.debug(db));
-        }
-        map.finish()
-    }
-}
-
-#[salsa::jar(db=SemanticDb)]
-pub struct SemanticJar(
-    SyntaxCheck,
-    PhysicalLinesCheck,
-    ModuleSearchPaths,
-    Symbol,
-    Module,
-    ModuleName,
-    dependencies,
-    symbol_table,
-    check_syntax,
-    check_physical_lines,
-    ast_ids,
-    resolve_module,
-);
-
-pub trait SemanticDb: source::Db + salsa::DbWithJar<SemanticJar> {
-    fn upcast(&self) -> &dyn source::Db;
-}
-
-pub trait Db: SemanticDb {
-    fn upcast(&self) -> &dyn SemanticDb;
-}
-
-#[salsa::db(self::SourceJar, self::SemanticJar)]
+#[salsa::db(source::Jar, lint::Jar, semantic::Jar)]
 pub struct Database {
-    storage: salsa::Storage<Self>,
+    storage: Storage<Self>,
 
     files: source::Files,
 }
 
 impl Database {
+    #[allow(unused)]
     pub fn new() -> Self {
         Self {
             files: source::Files::default(),
-            storage: Default::default(),
+            storage: Storage::default(),
         }
     }
 }
@@ -333,17 +39,21 @@ impl SourceDb for Database {
     }
 }
 
-impl SemanticDb for Database {
-    fn upcast(&self) -> &dyn SourceDb {
+impl semantic::Db for Database {}
+
+impl Upcast<dyn source::Db> for Database {
+    fn upcast(&self) -> &(dyn source::Db + 'static) {
         self
     }
 }
 
-impl Db for Database {
-    fn upcast(&self) -> &dyn SemanticDb {
+impl Upcast<dyn semantic::Db> for Database {
+    fn upcast(&self) -> &(dyn semantic::Db + 'static) {
         self
     }
 }
+
+impl lint::Db for Database {}
 
 impl salsa::Database for Database {
     fn salsa_event(&self, event: Event) {
@@ -362,319 +72,87 @@ impl salsa::ParallelDatabase for Database {
     }
 }
 
-#[tracing::instrument(level = "debug", skip(db))]
-#[salsa::tracked(jar=SemanticJar)]
-pub fn dependencies(db: &dyn SemanticDb, file: File) -> Arc<Vec<Module>> {
-    struct DependenciesVisitor<'a> {
-        db: &'a dyn SemanticDb,
-        module_path: PathBuf,
-        dependencies: Vec<Module>,
-    }
-
-    // TODO support package imports
-    impl PreorderVisitor<'_> for DependenciesVisitor<'_> {
-        fn enter_node(&mut self, node: AnyNodeRef) -> TraversalSignal {
-            // Don't traverse into expressions
-            if node.is_expression() {
-                return TraversalSignal::Skip;
-            }
-
-            TraversalSignal::Traverse
-        }
-
-        fn visit_stmt(&mut self, stmt: &Stmt) {
-            match stmt {
-                Stmt::Import(import) => {
-                    for alias in &import.names {
-                        if let Some(module) = resolve_module_by_name(self.db, &alias.name) {
-                            self.dependencies.push(module);
-                        }
-                    }
-                }
-
-                Stmt::ImportFrom(from) => {
-                    if let Some(module) = &from.module {
-                        assert_eq!(from.level, 0, "Relative imports not supported");
-
-                        if let Some(module) = resolve_module_by_name(self.db, module) {
-                            self.dependencies.push(module);
-                        }
-                    } else {
-                        warn!("Relative imports are not supported");
-                    }
-                }
-                _ => {}
-            }
-            preorder::walk_stmt(self, stmt);
-        }
-    }
-
-    let parsed = source::parse(db.upcast(), file);
-
-    let mut visitor = DependenciesVisitor {
-        db,
-        module_path: file
-            .path(db.upcast())
-            .parent()
-            .map_or_else(PathBuf::new, std::borrow::ToOwned::to_owned),
-        dependencies: Vec::new(),
-    };
-
-    // TODO change the visitor so that `visit_mod` accepts a `ModRef` node that we can construct from module.
-    visitor.visit_body(&parsed.ast().body);
-
-    Arc::new(visitor.dependencies)
-
-    // TODO we should extract the names of dependencies during parsing to avoid an extra traversal here.
-}
-
-#[tracing::instrument(level = "debug", skip(db))]
-#[salsa::tracked(jar=SemanticJar)]
-fn symbol_table(db: &dyn SemanticDb, file_id: File) -> Arc<SymbolTable> {
-    struct SymbolTableVisitor<'db> {
-        symbols: SymbolTable,
-        db: &'db dyn SemanticDb,
-    }
-
-    impl PreorderVisitor<'_> for SymbolTableVisitor<'_> {
-        fn visit_stmt(&mut self, stmt: &'_ Stmt) {
-            match stmt {
-                Stmt::Assign(assign) => {
-                    for target in &assign.targets {
-                        if let Expr::Name(name) = &target {
-                            let name = smol_str::SmolStr::new(&name.id);
-                            self.symbols
-                                .insert(name.clone(), Symbol::new(self.db, name, Count::default()));
-                        }
-                    }
-                }
-                _ => {}
-            }
-
-            preorder::walk_stmt(self, stmt);
-        }
-    }
-
-    let parsed = source::parse(db.upcast(), file_id);
-    let mut visitor = SymbolTableVisitor {
-        db,
-        symbols: SymbolTable::default(),
-    };
-
-    visitor.visit_body(&parsed.ast().body);
-
-    Arc::new(visitor.symbols)
-}
-
-fn resolve_module_by_name(db: &dyn SemanticDb, name: &str) -> Option<Module> {
-    let module_name = ModuleName::new(db, name.into());
-
-    resolve_module(db, module_name)
-}
-
-#[tracing::instrument(level = "debug", skip(db))]
-#[salsa::tracked(jar=SemanticJar)]
-fn resolve_module(db: &dyn SemanticDb, name: ModuleName) -> Option<Module> {
-    let search_paths = ModuleSearchPaths::get(db);
-
-    for search_path in search_paths.paths(db) {
-        let mut components = name.components(db).into_iter();
-        let module_name = components.next_back()?;
-
-        match resolve_package(db, search_path, components) {
-            Ok(resolved_package) => {
-                let mut package_path = resolved_package.path;
-
-                package_path.push(module_name);
-
-                // Must be a `__init__.pyi` or `__init__.py` or it isn't a package.
-                let kind = if package_path.is_dir() {
-                    package_path.push("__init__");
-                    ModuleKind::Package
-                } else {
-                    ModuleKind::Module
-                };
-
-                // TODO Implement full https://peps.python.org/pep-0561/#type-checker-module-resolution-order resolution
-                let stub = package_path.with_extension("pyi");
-                let stub_file = db.file(stub.clone());
-
-                if stub.is_file() {
-                    return Some(Module::new(db, name, stub_file));
-                }
-
-                let module = package_path.with_extension("py");
-                let module_file = db.file(module.clone());
-
-                if module.is_file() {
-                    return Some(Module::new(db, name, module_file));
-                }
-
-                // For regular packages, don't search the next search path. All files of that
-                // package must be in the same location
-                if resolved_package.kind.is_regular_package() {
-                    return None;
-                }
-            }
-            Err(parent_kind) => {
-                if parent_kind.is_regular_package() {
-                    // For regular packages, don't search the next search path.
-                    return None;
-                }
-            }
-        }
-    }
-    None
-}
-
-fn resolve_package<'a, I>(
-    db: &dyn SemanticDb,
-    module_search_path: &ModuleSearchPath,
-    components: I,
-) -> Result<crate::module::ResolvedPackage, crate::module::PackageKind>
-where
-    I: Iterator<Item = String>,
-{
-    let mut package_path = module_search_path.path().to_path_buf();
-
-    // `true` if inside a folder that is a namespace package (has no `__init__.py`).
-    // Namespace packages are special because they can be spread across multiple search paths.
-    // https://peps.python.org/pep-0420/
-    let mut in_namespace_package = false;
-
-    // `true` if resolving a sub-package. For example, `true` when resolving `bar` of `foo.bar`.
-    let mut in_sub_package = false;
-
-    // For `foo.bar.baz`, test that `foo` and `baz` both contain a `__init__.py`.
-    for folder in components {
-        package_path.push(folder);
-
-        let has_init_py = package_path.join("__init__.py").is_file()
-            || package_path.join("__init__.pyi").is_file();
-
-        if has_init_py {
-            in_namespace_package = false;
-        } else if package_path.is_dir() {
-            // A directory without an `__init__.py` is a namespace package, continue with the next folder.
-            in_namespace_package = true;
-        } else if in_namespace_package {
-            // Package not found but it is part of a namespace package.
-            return Err(crate::module::PackageKind::Namespace);
-        } else if in_sub_package {
-            // A regular sub package wasn't found.
-            return Err(crate::module::PackageKind::Regular);
-        } else {
-            // We couldn't find `foo` for `foo.bar.baz`, search the next search path.
-            return Err(crate::module::PackageKind::Root);
-        }
-
-        in_sub_package = true;
-    }
-
-    let kind = if in_namespace_package {
-        crate::module::PackageKind::Namespace
-    } else if in_sub_package {
-        crate::module::PackageKind::Regular
-    } else {
-        crate::module::PackageKind::Root
-    };
-
-    Ok(crate::module::ResolvedPackage {
-        kind,
-        path: package_path,
-    })
-}
-
-#[tracing::instrument(level = "debug", skip(db))]
-#[salsa::tracked(jar=SemanticJar)]
-pub fn check_syntax(db: &dyn SemanticDb, file: File) -> SyntaxCheck {
-    // TODO I haven't looked into how many rules are pure syntax checks.
-    //   It may be necessary to at least give access to a simplified semantic model.
-    struct SyntaxChecker {
-        diagnostics: Vec<String>,
-    }
-
-    impl Visitor<'_> for SyntaxChecker {
-        fn visit_expr(&mut self, expr: &'_ Expr) {
-            if let Expr::Name(name) = expr {
-                if &name.id == "a" {
-                    self.diagnostics.push("Use of name a".to_string());
-                }
-            }
-        }
-    }
-
-    let parsed = source::parse(db.upcast(), file);
-
-    let mut visitor = SyntaxChecker {
-        diagnostics: Vec::new(),
-    };
-
-    visitor.visit_body(&parsed.ast().body);
-
-    SyntaxCheck::new(db, visitor.diagnostics)
-}
-
-#[tracing::instrument(level = "debug", skip(db))]
-#[salsa::tracked(jar=SemanticJar)]
-pub fn check_physical_lines(db: &dyn SemanticDb, file: File) -> PhysicalLinesCheck {
-    let source = file.source(db.upcast());
-    let text = source.text();
-
-    let mut diagnostics = Vec::new();
-    let mut line_number = 0u32;
-    for line in text.lines() {
-        if line.chars().count() > 88 {
-            diagnostics.push(format!("Line {} too long", line_number + 1));
-        }
-        line_number += 1;
-    }
-
-    PhysicalLinesCheck::new(db, diagnostics)
-}
-
-#[tracing::instrument(level = "debug", skip(db))]
-#[salsa::tracked(jar=SemanticJar)]
-pub fn ast_ids(db: &dyn SemanticDb, file: File) -> Arc<AstIds> {
-    let parsed = source::parse(db.upcast(), file);
-
-    Arc::new(AstIds::from_module(parsed.ast()))
-}
-
 #[cfg(test)]
 mod tests {
-    use salsa::storage::HasJar;
-    use salsa::DebugWithDb;
+    use salsa::{DebugWithDb, Event, Storage};
+    use std::path::PathBuf;
     use tracing::{debug, Level};
     use tracing_subscriber::fmt::time;
-    use tracing_subscriber::fmt::writer::MakeWriterExt;
-    use tracing_subscriber::prelude::__tracing_subscriber_SubscriberExt;
-    use tracing_subscriber::Registry;
-    use tracing_tree::time::Uptime;
 
-    use crate::module::ModuleSearchPathKind;
-    use crate::salsa_db::source::Db;
+    use crate::db::Upcast;
+    use crate::salsa_db::semantic::{dependencies, symbol_table};
+    use crate::salsa_db::source::{Db, File};
 
-    use super::{
-        dependencies, source, symbol_table, Database, ModuleSearchPath, ModuleSearchPaths, Symbol,
+    use super::lint;
+    use super::semantic;
+    use super::semantic::module::{
+        set_module_search_paths, ModuleSearchPath, ModuleSearchPathKind,
     };
+    use super::source;
+    use super::Database;
 
+    #[salsa::db(source::Jar, lint::Jar, semantic::Jar)]
+    pub struct TestDb {
+        storage: salsa::Storage<Self>,
+
+        files: source::Files,
+        events: std::sync::Mutex<Vec<salsa::Event>>,
+    }
+
+    impl TestDb {
+        pub fn new() -> Self {
+            Self {
+                files: source::Files::default(),
+                storage: Storage::default(),
+                events: std::sync::Mutex::new(Vec::new()),
+            }
+        }
+    }
+
+    impl source::Db for TestDb {
+        #[tracing::instrument(level = "debug", skip(self))]
+        fn file(&self, path: PathBuf) -> File {
+            self.files.resolve(self, path)
+        }
+    }
+
+    impl semantic::Db for TestDb {}
+
+    impl Upcast<dyn source::Db> for TestDb {
+        fn upcast(&self) -> &(dyn source::Db + 'static) {
+            self
+        }
+    }
+
+    impl Upcast<dyn semantic::Db> for TestDb {
+        fn upcast(&self) -> &(dyn semantic::Db + 'static) {
+            self
+        }
+    }
+
+    impl lint::Db for TestDb {}
+
+    impl salsa::Database for TestDb {
+        fn salsa_event(&self, event: Event) {
+            self.events.lock().unwrap().push(event);
+        }
+    }
+
+    #[allow(clippy::print_stderr)]
     #[test]
     fn inputs() {
         countme::enable(true);
         setup_tracing();
-        // log::set_max_level(LevelFilter::Trace);
-        // log::set_logger()
 
         let tempdir = tempfile::tempdir().unwrap();
         let main = tempdir.path().join("main.py");
         let foo = tempdir.path().join("foo.py");
 
         std::fs::write(&main, "import foo;\nx = 1").unwrap();
-        std::fs::write(&foo, "x = 10").unwrap();
+        std::fs::write(foo, "x = 10").unwrap();
 
         let mut db = Database::new();
-        ModuleSearchPaths::new(
+        set_module_search_paths(
             &mut db,
             vec![ModuleSearchPath::new(
                 tempdir.path().to_owned(),
@@ -709,19 +187,6 @@ mod tests {
     }
 
     fn setup_tracing() {
-        // tracing_log::LogTracer::init().unwrap();
-
-        // let subscriber = Registry::default().with(
-        //     tracing_tree::HierarchicalLayer::default()
-        //         .with_indent_lines(true)
-        //         .with_indent_amount(2)
-        //         .with_bracketed_fields(true)
-        //         .with_thread_ids(true)
-        //         .with_targets(true)
-        //         // .with_writer(|| Box::new(std::io::stderr()))
-        //         .with_timer(Uptime::default()),
-        // );
-        //
         let subscriber = tracing_subscriber::fmt()
             // Use a more compact, abbreviated log format
             .compact()

--- a/crates/red_knot/src/salsa_db.rs
+++ b/crates/red_knot/src/salsa_db.rs
@@ -1,0 +1,326 @@
+#![allow(unreachable_pub)]
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use parking_lot::lock_api::RwLockUpgradableReadGuard;
+use parking_lot::RwLock;
+use rustc_hash::FxHashMap;
+use salsa::Event;
+use tracing::warn;
+
+use ruff_python_ast::visitor::preorder::{PreorderVisitor, TraversalSignal};
+use ruff_python_ast::visitor::{preorder, Visitor};
+use ruff_python_ast::{AnyNodeRef, Expr, Mod, ModModule, Stmt, StmtExpr};
+use ruff_python_parser::Mode;
+use ruff_text_size::{Ranged, TextRange};
+
+use crate::ast_ids::AstIds;
+use crate::files::{FileId, Files};
+use crate::module::ModuleName;
+
+// TODO salsa recommends to have one jar per crate and call it `Jar`. We're not doing this here
+// because I don't want that many crates just yet.
+#[salsa::input(jar=SourceJar)]
+pub struct SourceText {
+    file: FileId,
+
+    #[return_ref]
+    text: String,
+}
+
+#[salsa::tracked(jar=SourceJar)]
+pub struct Parsed {
+    // TODO should this be an arc to avoid some lifetime awkwardness for call-sites.
+    #[return_ref]
+    pub ast: ModModule,
+
+    #[return_ref]
+    pub imports: Vec<String>,
+
+    // TODO use an accumulator for this?
+    #[return_ref]
+    pub errors: Vec<ruff_python_parser::ParseError>,
+}
+
+#[salsa::tracked(jar=SemanticJar)]
+pub struct SyntaxCheck {
+    #[returned_ref]
+    pub diagnostics: Vec<String>,
+}
+
+#[salsa::tracked(jar=SemanticJar)]
+pub struct PhysicalLinesCheck {
+    #[returned_ref]
+    pub diagnostics: Vec<String>,
+}
+
+#[salsa::jar(db=SourceDb)]
+pub struct SourceJar(SourceText, Parsed, parse);
+
+#[salsa::jar(db=SemanticDb)]
+pub struct SemanticJar(
+    SyntaxCheck,
+    PhysicalLinesCheck,
+    Module,
+    dependencies,
+    check_syntax,
+    check_physical_lines,
+    ast_ids,
+);
+
+pub trait SourceDb: salsa::DbWithJar<SourceJar> {
+    fn source_text(&self, file_id: FileId) -> std::io::Result<SourceText>;
+
+    fn files(&self) -> &Files;
+}
+
+pub trait SemanticDb: SourceDb + salsa::DbWithJar<SemanticJar> {
+    fn upcast(&self) -> &dyn SourceDb;
+}
+
+pub trait Db: SemanticDb {
+    fn upcast(&self) -> &dyn SemanticDb;
+}
+
+#[salsa::db(self::SourceJar, self::SemanticJar)]
+pub struct Database {
+    storage: salsa::Storage<Self>,
+
+    // can define additional fields
+    // TODO how to reuse file ids across runs? Do we want this to be part of salsa or shout the id
+    //   mapping happen out side because we don't want to read them from disk every time?
+    sources: Arc<RwLock<FxHashMap<FileId, SourceText>>>,
+    files: Files,
+}
+
+impl Database {
+    pub fn new(files: Files) -> Self {
+        Self {
+            sources: Arc::new(RwLock::new(FxHashMap::default())),
+            files,
+            storage: Default::default(),
+        }
+    }
+}
+
+impl SourceDb for Database {
+    fn source_text(&self, file_id: FileId) -> std::io::Result<SourceText> {
+        let lock = self.sources.upgradable_read();
+        if let Some(source) = lock.get(&file_id) {
+            return Ok(*source);
+        }
+
+        let mut upgraded = RwLockUpgradableReadGuard::upgrade(lock);
+
+        let path = self.files.path(file_id);
+        let file = SourceText::new(self, file_id, std::fs::read_to_string(path)?);
+
+        upgraded.insert(file_id, file);
+
+        Ok(file)
+    }
+
+    fn files(&self) -> &Files {
+        &self.files
+    }
+}
+
+impl SemanticDb for Database {
+    fn upcast(&self) -> &dyn SourceDb {
+        self
+    }
+}
+
+impl Db for Database {
+    fn upcast(&self) -> &dyn SemanticDb {
+        self
+    }
+}
+
+impl salsa::Database for Database {
+    fn salsa_event(&self, event: Event) {
+        tracing::debug!("{:#?}", event);
+    }
+}
+
+impl salsa::ParallelDatabase for Database {
+    fn snapshot(&self) -> salsa::Snapshot<Self> {
+        salsa::Snapshot::new(Database {
+            storage: self.storage.snapshot(),
+
+            sources: self.sources.clone(),
+            // This is ok, because files is an arc
+            files: self.files.snapshot(),
+        })
+    }
+}
+
+#[salsa::tracked(jar=SourceJar)]
+pub fn parse(db: &dyn SourceDb, source: SourceText) -> Parsed {
+    let text = source.text(db);
+
+    let result = ruff_python_parser::parse(text, Mode::Module);
+
+    let (module, errors) = match result {
+        Ok(Mod::Module(module)) => (module, vec![]),
+        Ok(Mod::Expression(expression)) => (
+            ModModule {
+                range: expression.range(),
+                body: vec![Stmt::Expr(StmtExpr {
+                    range: expression.range(),
+                    value: expression.body,
+                })],
+            },
+            vec![],
+        ),
+        Err(errors) => (
+            ModModule {
+                range: TextRange::default(),
+                body: Vec::new(),
+            },
+            vec![errors],
+        ),
+    };
+
+    // Okay, there's actually no input mapping for tracked structs, ugh.
+    Parsed::new(db, module, Vec::new(), errors)
+}
+
+#[salsa::tracked(jar=SemanticJar)]
+pub fn dependencies(db: &dyn SemanticDb, source_text: SourceText) -> Arc<Vec<Dependency>> {
+    let parsed = parse(db.upcast(), source_text);
+
+    let mut visitor = DependenciesVisitor {
+        module_path: db
+            .files()
+            .path(source_text.file(db.upcast()))
+            .parent()
+            .map_or_else(PathBuf::new, std::borrow::ToOwned::to_owned),
+        dependencies: Vec::new(),
+    };
+
+    // TODO change the visitor so that `visit_mod` accepts a `ModRef` node that we can construct from module.
+    visitor.visit_body(&parsed.ast(db.upcast()).body);
+
+    Arc::new(visitor.dependencies)
+
+    // TODO we should extract the names of dependencies during parsing to avoid an extra traversal here.
+}
+
+struct DependenciesVisitor {
+    module_path: PathBuf,
+    dependencies: Vec<Dependency>,
+}
+
+impl DependenciesVisitor {
+    fn push_dependency(&mut self, path: PathBuf) {
+        // TODO handle error case by pushing a diagnostic?
+        let joined = self.module_path.join(path);
+        if let Ok(normalized) = joined.canonicalize() {
+            self.dependencies.push(Dependency { path: normalized });
+        } else {
+            warn!("Could not canonicalize path: {:?}", joined);
+        }
+    }
+}
+
+// TODO support package imports
+impl PreorderVisitor<'_> for DependenciesVisitor {
+    fn enter_node(&mut self, node: AnyNodeRef) -> TraversalSignal {
+        // Don't traverse into expressions
+        if node.is_expression() {
+            return TraversalSignal::Skip;
+        }
+
+        TraversalSignal::Traverse
+    }
+
+    fn visit_stmt(&mut self, stmt: &Stmt) {
+        match stmt {
+            Stmt::Import(import) => {
+                for alias in &import.names {
+                    let path: PathBuf = alias.name.split('.').collect();
+
+                    self.push_dependency(path.with_extension("py"));
+                }
+            }
+
+            Stmt::ImportFrom(from) => {
+                if let Some(module) = &from.module {
+                    let path: PathBuf = module.split('.').collect();
+                    self.push_dependency(path.with_extension("py"));
+                } else {
+                    let path: PathBuf = (0..from.level).map(|_| "..").collect();
+                    self.push_dependency(path.with_extension("py"));
+                }
+            }
+            _ => {}
+        }
+        preorder::walk_stmt(self, stmt);
+    }
+}
+
+#[derive(Eq, PartialEq, Hash, Clone, Debug)]
+pub struct Dependency {
+    // A relative path from the current module to the dependency
+    pub path: PathBuf,
+}
+
+// TODO it's unclear to me if the function should accept a parsed or a source text?
+//   Is it best practice to inline as many db calls or should we ask the caller to do the db calls?
+#[salsa::tracked(jar=SemanticJar)]
+pub fn check_syntax(db: &dyn SemanticDb, parsed: Parsed) -> SyntaxCheck {
+    // TODO I haven't looked into how many rules are pure syntax checks.
+    //   It may be necessary to at least give access to a simplified semantic model.
+    struct SyntaxChecker {
+        diagnostics: Vec<String>,
+    }
+
+    impl Visitor<'_> for SyntaxChecker {
+        fn visit_expr(&mut self, expr: &'_ Expr) {
+            if let Expr::Name(name) = expr {
+                if &name.id == "a" {
+                    self.diagnostics.push("Use of name a".to_string());
+                }
+            }
+        }
+    }
+
+    let mut visitor = SyntaxChecker {
+        diagnostics: Vec::new(),
+    };
+    visitor.visit_body(&parsed.ast(db.upcast()).body);
+
+    SyntaxCheck::new(db, visitor.diagnostics)
+}
+
+#[salsa::tracked(jar=SemanticJar)]
+pub fn check_physical_lines(db: &dyn SemanticDb, source_text: SourceText) -> PhysicalLinesCheck {
+    let text = source_text.text(db.upcast());
+
+    let mut diagnostics = Vec::new();
+    let mut line_number = 0u32;
+    for line in text.lines() {
+        if line.chars().count() > 88 {
+            diagnostics.push(format!("Line {} too long", line_number + 1));
+        }
+        line_number += 1;
+    }
+
+    PhysicalLinesCheck::new(db, diagnostics)
+}
+
+#[salsa::tracked(jar=SemanticJar)]
+pub fn ast_ids(db: &dyn SemanticDb, source: SourceText) -> Arc<AstIds> {
+    let parsed = parse(db.upcast(), source);
+    let ast = parsed.ast(db.upcast());
+
+    Arc::new(AstIds::from_module(ast))
+}
+
+#[salsa::interned(jar=SemanticJar)]
+struct Module {
+    name: ModuleName,
+    path: PathBuf,
+}

--- a/crates/red_knot/src/salsa_db/lint.rs
+++ b/crates/red_knot/src/salsa_db/lint.rs
@@ -1,0 +1,74 @@
+use crate::db::Upcast;
+use crate::salsa_db::source::File;
+use crate::salsa_db::{semantic, source};
+use ruff_python_ast::visitor::Visitor;
+use ruff_python_ast::Expr;
+use tracing::warn;
+
+#[salsa::tracked(jar=Jar)]
+pub struct SyntaxCheck {
+    #[returned_ref]
+    pub diagnostics: Vec<String>,
+}
+
+#[salsa::tracked(jar=Jar)]
+pub struct PhysicalLinesCheck {
+    #[returned_ref]
+    pub diagnostics: Vec<String>,
+}
+
+#[tracing::instrument(level = "debug", skip(db))]
+#[salsa::tracked(jar=Jar)]
+pub fn check_syntax(db: &dyn Db, file: File) -> SyntaxCheck {
+    // TODO I haven't looked into how many rules are pure syntax checks.
+    //   It may be necessary to at least give access to a simplified semantic model.
+    struct SyntaxChecker {
+        diagnostics: Vec<String>,
+    }
+
+    impl Visitor<'_> for SyntaxChecker {
+        fn visit_expr(&mut self, expr: &'_ Expr) {
+            if let Expr::Name(name) = expr {
+                if &name.id == "a" {
+                    self.diagnostics.push("Use of name a".to_string());
+                }
+            }
+        }
+    }
+
+    let parsed = source::parse(db.upcast(), file);
+
+    let mut visitor = SyntaxChecker {
+        diagnostics: Vec::new(),
+    };
+
+    visitor.visit_body(&parsed.ast().body);
+
+    SyntaxCheck::new(db, visitor.diagnostics)
+}
+
+#[tracing::instrument(level = "debug", skip(db))]
+#[salsa::tracked(jar=Jar)]
+pub fn check_physical_lines(db: &dyn Db, file: File) -> PhysicalLinesCheck {
+    let source = file.source(db.upcast());
+    let text = source.text();
+
+    let mut diagnostics = Vec::new();
+    for (line_number, line) in text.lines().enumerate() {
+        if line.chars().count() > 88 {
+            diagnostics.push(format!("Line {} too long", line_number + 1));
+        }
+    }
+
+    PhysicalLinesCheck::new(db, diagnostics)
+}
+
+#[salsa::jar(db=Db)]
+pub struct Jar(
+    PhysicalLinesCheck,
+    SyntaxCheck,
+    check_physical_lines,
+    check_syntax,
+);
+
+pub trait Db: semantic::Db + salsa::DbWithJar<Jar> + Upcast<dyn semantic::Db> {}

--- a/crates/red_knot/src/salsa_db/lint.rs
+++ b/crates/red_knot/src/salsa_db/lint.rs
@@ -77,7 +77,7 @@ pub fn check_syntax(db: &dyn Db, file: File) -> SyntaxCheck {
         diagnostics: Vec::new(),
     };
 
-    visitor.visit_body(&parsed.ast().body);
+    visitor.visit_body(&parsed.syntax().body);
 
     SyntaxCheck::new(visitor.diagnostics)
 }

--- a/crates/red_knot/src/salsa_db/semantic.rs
+++ b/crates/red_knot/src/salsa_db/semantic.rs
@@ -2,7 +2,7 @@ use std::num::NonZeroU32;
 use std::sync::Arc;
 
 use countme::Count;
-use tracing::warn;
+use tracing::{debug, warn};
 
 use ruff_python_ast as ast;
 use ruff_python_ast::visitor::preorder;
@@ -101,7 +101,7 @@ pub fn global_symbol_type_by_name(db: &dyn Db, module: File, name: &str) -> Opti
 }
 
 #[tracing::instrument(level = "debug", skip(db))]
-#[salsa::tracked(jar=Jar, return_ref)]
+#[salsa::tracked(jar=Jar, return_ref, no_eq)]
 pub fn semantic_index(db: &dyn Db, file: File) -> SemanticIndex {
     let root_scope_id = SymbolTable::root_scope_id();
     let mut indexer = SemanticIndexer {

--- a/crates/red_knot/src/salsa_db/semantic.rs
+++ b/crates/red_knot/src/salsa_db/semantic.rs
@@ -98,7 +98,7 @@ pub fn dependencies(db: &dyn Db, file: File) -> Arc<[ModuleName]> {
                     if let Some(level) = NonZeroU32::new(from.level) {
                         // FIXME how to handle dependencies if the current file isn't a module?
                         //  e.g. what if the current file is a jupyter notebook. We should still be able to resolve files somehow.
-                        if let Some(resolved_module) = self.resolved_module {
+                        if let Some(resolved_module) = &self.resolved_module {
                             if let Some(dependency) = resolved_module.resolve_dependency(
                                 self.db,
                                 &Dependency::Relative {
@@ -191,7 +191,6 @@ pub struct Jar(
     ModuleSearchPaths,
     Symbol,
     Module,
-    ResolvedModule,
     dependencies,
     symbol_table,
     ast_ids,

--- a/crates/red_knot/src/salsa_db/semantic.rs
+++ b/crates/red_knot/src/salsa_db/semantic.rs
@@ -132,7 +132,7 @@ pub fn dependencies(db: &dyn Db, file: File) -> Arc<[ModuleName]> {
     };
 
     // TODO change the visitor so that `visit_mod` accepts a `ModRef` node that we can construct from module.
-    visitor.visit_body(&parsed.ast().body);
+    visitor.visit_body(&parsed.syntax().body);
 
     Arc::from(visitor.dependencies)
 
@@ -173,7 +173,7 @@ pub fn symbol_table(db: &dyn Db, file_id: File) -> Arc<SymbolTable> {
         symbols: SymbolTable::default(),
     };
 
-    visitor.visit_body(&parsed.ast().body);
+    visitor.visit_body(&parsed.syntax().body);
 
     Arc::new(visitor.symbols)
 }
@@ -183,7 +183,7 @@ pub fn symbol_table(db: &dyn Db, file_id: File) -> Arc<SymbolTable> {
 pub fn ast_ids(db: &dyn Db, file: File) -> Arc<AstIds> {
     let parsed = source::parse(db.upcast(), file);
 
-    Arc::new(AstIds::from_module(parsed.ast()))
+    Arc::new(AstIds::from_module(parsed.syntax()))
 }
 
 #[salsa::jar(db=Db)]

--- a/crates/red_knot/src/salsa_db/semantic.rs
+++ b/crates/red_knot/src/salsa_db/semantic.rs
@@ -1,0 +1,202 @@
+use std::fmt::Formatter;
+use std::num::NonZeroU32;
+use std::sync::Arc;
+
+use countme::Count;
+use rustc_hash::FxHashMap;
+use salsa::database::AsSalsaDatabase;
+use salsa::DebugWithDb;
+use tracing::warn;
+
+use ruff_python_ast::visitor::preorder;
+use ruff_python_ast::visitor::preorder::{PreorderVisitor, TraversalSignal};
+use ruff_python_ast::{AnyNodeRef, Expr, Stmt};
+
+use crate::ast_ids::AstIds;
+use crate::db::Upcast;
+use crate::module::ModuleName;
+use crate::salsa_db::semantic::module::{
+    file_to_module, Module, ModuleSearchPaths, ResolvedModule,
+};
+use crate::salsa_db::source;
+use crate::salsa_db::source::File;
+use crate::symbols::Dependency;
+
+pub use self::module::resolve_module;
+
+pub mod module;
+
+#[salsa::tracked(jar=Jar)]
+pub struct Symbol {
+    #[id]
+    #[returned_ref]
+    pub name: smol_str::SmolStr,
+
+    count: Count<Symbol>,
+}
+
+#[derive(Eq, PartialEq, Default)]
+pub struct SymbolTable {
+    symbols: FxHashMap<smol_str::SmolStr, Symbol>,
+}
+
+impl SymbolTable {
+    fn insert(&mut self, name: smol_str::SmolStr, symbol: Symbol) {
+        self.symbols.insert(name, symbol);
+    }
+}
+
+impl std::fmt::Debug for SymbolTable {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        self.symbols.fmt(f)
+    }
+}
+
+impl<Db> DebugWithDb<Db> for SymbolTable
+where
+    Db: AsSalsaDatabase + self::Db,
+{
+    fn fmt(&self, f: &mut Formatter<'_>, db: &Db) -> std::fmt::Result {
+        let mut map = f.debug_map();
+
+        for (name, symbol) in &self.symbols {
+            map.entry(name, &symbol.debug(db));
+        }
+        map.finish()
+    }
+}
+
+#[tracing::instrument(level = "debug", skip(db))]
+#[salsa::tracked(jar=Jar)]
+pub fn dependencies(db: &dyn Db, file: File) -> Arc<[ModuleName]> {
+    struct DependenciesVisitor<'a> {
+        db: &'a dyn Db,
+        resolved_module: Option<ResolvedModule>,
+        dependencies: Vec<ModuleName>,
+    }
+
+    // TODO support package imports
+    impl PreorderVisitor<'_> for DependenciesVisitor<'_> {
+        fn enter_node(&mut self, node: AnyNodeRef) -> TraversalSignal {
+            // Don't traverse into expressions
+            if node.is_expression() {
+                return TraversalSignal::Skip;
+            }
+
+            TraversalSignal::Traverse
+        }
+
+        fn visit_stmt(&mut self, stmt: &Stmt) {
+            match stmt {
+                Stmt::Import(import) => {
+                    for alias in &import.names {
+                        self.dependencies.push(ModuleName::new(&alias.name));
+                    }
+                }
+
+                Stmt::ImportFrom(from) => {
+                    if let Some(level) = NonZeroU32::new(from.level) {
+                        // FIXME how to handle dependencies if the current file isn't a module?
+                        //  e.g. what if the current file is a jupyter notebook. We should still be able to resolve files somehow.
+                        if let Some(resolved_module) = self.resolved_module {
+                            if let Some(dependency) = resolved_module.resolve_dependency(
+                                self.db,
+                                &Dependency::Relative {
+                                    module: from
+                                        .module
+                                        .as_ref()
+                                        .map(|module| ModuleName::new(module)),
+                                    level,
+                                },
+                            ) {
+                                self.dependencies.push(dependency);
+                            };
+                        }
+                    } else {
+                        let module = from.module.as_ref().unwrap();
+                        self.dependencies.push(ModuleName::new(module));
+                    }
+                }
+                _ => {}
+            }
+            preorder::walk_stmt(self, stmt);
+        }
+    }
+
+    let parsed = source::parse(db.upcast(), file);
+
+    let mut visitor = DependenciesVisitor {
+        db,
+        resolved_module: file_to_module(db, file),
+        dependencies: Vec::new(),
+    };
+
+    // TODO change the visitor so that `visit_mod` accepts a `ModRef` node that we can construct from module.
+    visitor.visit_body(&parsed.ast().body);
+
+    Arc::from(visitor.dependencies)
+
+    // TODO we should extract the names of dependencies during parsing to avoid an extra traversal here.
+}
+
+#[tracing::instrument(level = "debug", skip(db))]
+#[salsa::tracked(jar=Jar)]
+pub fn symbol_table(db: &dyn Db, file_id: File) -> Arc<SymbolTable> {
+    struct SymbolTableVisitor<'db> {
+        symbols: SymbolTable,
+        db: &'db dyn Db,
+    }
+
+    impl PreorderVisitor<'_> for SymbolTableVisitor<'_> {
+        fn visit_stmt(&mut self, stmt: &'_ Stmt) {
+            #[allow(clippy::single_match)]
+            match stmt {
+                Stmt::Assign(assign) => {
+                    for target in &assign.targets {
+                        if let Expr::Name(name) = &target {
+                            let name = smol_str::SmolStr::new(&name.id);
+                            self.symbols
+                                .insert(name.clone(), Symbol::new(self.db, name, Count::default()));
+                        }
+                    }
+                }
+                _ => {}
+            }
+
+            preorder::walk_stmt(self, stmt);
+        }
+    }
+
+    let parsed = source::parse(db.upcast(), file_id);
+    let mut visitor = SymbolTableVisitor {
+        db,
+        symbols: SymbolTable::default(),
+    };
+
+    visitor.visit_body(&parsed.ast().body);
+
+    Arc::new(visitor.symbols)
+}
+
+#[tracing::instrument(level = "debug", skip(db))]
+#[salsa::tracked(jar=Jar)]
+pub fn ast_ids(db: &dyn Db, file: File) -> Arc<AstIds> {
+    let parsed = source::parse(db.upcast(), file);
+
+    Arc::new(AstIds::from_module(parsed.ast()))
+}
+
+#[salsa::jar(db=Db)]
+pub struct Jar(
+    ModuleSearchPaths,
+    Symbol,
+    Module,
+    ResolvedModule,
+    dependencies,
+    symbol_table,
+    ast_ids,
+    resolve_module,
+    file_to_module,
+);
+
+pub trait Db: source::Db + salsa::DbWithJar<Jar> + Upcast<dyn source::Db> {}

--- a/crates/red_knot/src/salsa_db/semantic/ast_ids.rs
+++ b/crates/red_knot/src/salsa_db/semantic/ast_ids.rs
@@ -1,0 +1,371 @@
+use super::{Db, Jar};
+use crate::ast_ids::NodeKey;
+use ruff_index::{newtype_index, IndexVec};
+use ruff_python_ast::visitor::preorder;
+use ruff_python_ast::visitor::preorder::PreorderVisitor;
+use ruff_python_ast::{
+    Expr, ModModule, Stmt, StmtAnnAssign, StmtAssign, StmtClassDef, StmtFunctionDef,
+};
+use ruff_python_parser::Parsed;
+use rustc_hash::FxHashMap;
+use std::collections::VecDeque;
+use std::ops::Deref;
+use std::sync::Arc;
+
+use crate::salsa_db::source::{parse, File};
+
+#[tracing::instrument(level = "debug", skip(db))]
+#[salsa::tracked(jar=Jar, no_eq, return_ref)]
+pub fn ast_ids(db: &dyn Db, file: File) -> AstIds {
+    let parsed = parse(db.upcast(), file);
+
+    AstIds::from_parsed(&parsed)
+}
+
+pub struct AstIds {
+    expressions: IndexVec<ExpressionId, AstNodeRef<Expr>>,
+
+    /// Maps expressions to their expression id. Uses `NodeKey` because it avoids cloning [`Parsed`].
+    expressions_map: FxHashMap<NodeKey, ExpressionId>,
+
+    statements: IndexVec<StatementId, AstNodeRef<Stmt>>,
+
+    statements_map: FxHashMap<NodeKey, StatementId>,
+}
+
+impl AstIds {
+    fn from_parsed(parsed: &Arc<Parsed<ModModule>>) -> Self {
+        let mut builder = AstIdsBuilder {
+            parsed: parsed.clone(),
+            expressions: IndexVec::new(),
+            expressions_map: FxHashMap::default(),
+            statements: IndexVec::new(),
+            statements_map: FxHashMap::default(),
+            deferred: VecDeque::new(),
+        };
+
+        builder.visit_body(&parsed.syntax().body);
+
+        while let Some(deferred) = builder.deferred.pop_front() {
+            builder.visit_body(deferred);
+        }
+
+        builder.finish()
+    }
+
+    #[allow(unused)]
+    pub fn functions(&self) -> impl Iterator<Item = (FunctionId, &StmtFunctionDef)> {
+        self.statements
+            .iter_enumerated()
+            .filter_map(|(index, stmt)| Some((FunctionId(index), stmt.as_function_def_stmt()?)))
+    }
+
+    #[allow(unused)]
+    pub fn classes(&self) -> impl Iterator<Item = (ClassId, &StmtClassDef)> {
+        self.statements
+            .iter_enumerated()
+            .filter_map(|(index, stmt)| Some((ClassId(index), stmt.as_class_def_stmt()?)))
+    }
+}
+
+#[allow(clippy::missing_fields_in_debug)]
+impl std::fmt::Debug for AstIds {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AstIds")
+            .field("expressions", &self.expressions)
+            .field("statements", &self.statements)
+            .finish()
+    }
+}
+
+impl PartialEq for AstIds {
+    fn eq(&self, other: &Self) -> bool {
+        self.expressions == other.expressions && self.statements == other.statements
+    }
+}
+
+#[newtype_index]
+pub struct ExpressionId;
+
+#[newtype_index]
+pub struct StatementId;
+
+pub trait AstIdNode {
+    type Id;
+
+    /// Resolves the AST id of the node.
+    ///
+    /// ## Panics
+    /// May panic if the node does not belong to the AST of `file` or it returns an incorrect node.
+    fn ast_id(&self, db: &dyn Db, file: File) -> Self::Id;
+
+    /// Resolves the AST node for `id`.
+    ///
+    /// ## Panics
+    /// May panic if the `id` does not belong to the AST of `file` or it returns an incorrect node.
+    #[allow(unused)]
+    fn lookup(db: &dyn Db, file: File, id: Self::Id) -> &Self;
+}
+
+impl AstIdNode for Expr {
+    type Id = ExpressionId;
+
+    fn ast_id(&self, db: &dyn Db, file: File) -> Self::Id {
+        let ast_ids = ast_ids(db, file);
+        ast_ids.expressions_map[&NodeKey::from_node(self.into())]
+    }
+
+    fn lookup(db: &dyn Db, file: File, id: Self::Id) -> &Self {
+        let ast_ids = ast_ids(db, file);
+        &ast_ids.expressions[id]
+    }
+}
+
+impl AstIdNode for Stmt {
+    type Id = StatementId;
+
+    fn ast_id(&self, db: &dyn Db, file: File) -> Self::Id {
+        let ast_ids = ast_ids(db, file);
+        ast_ids.statements_map[&NodeKey::from_node(self.into())]
+    }
+
+    fn lookup(db: &dyn Db, file: File, id: Self::Id) -> &Self {
+        let ast_ids = ast_ids(db, file);
+        &ast_ids.statements[id]
+    }
+}
+
+#[derive(Debug, Eq, PartialEq, Copy, Clone, Hash)]
+pub struct FunctionId(StatementId);
+
+impl AstIdNode for StmtFunctionDef {
+    type Id = FunctionId;
+
+    fn ast_id(&self, db: &dyn Db, file: File) -> Self::Id {
+        let ast_ids = ast_ids(db, file);
+        FunctionId(ast_ids.statements_map[&NodeKey::from_node(self.into())])
+    }
+
+    fn lookup(db: &dyn Db, file: File, id: Self::Id) -> &Self {
+        let ast_ids = ast_ids(db, file);
+        ast_ids.statements[id.0].as_function_def_stmt().unwrap()
+    }
+}
+
+#[derive(Debug, Eq, PartialEq, Copy, Clone, Hash)]
+pub struct ClassId(StatementId);
+
+impl AstIdNode for StmtClassDef {
+    type Id = ClassId;
+
+    fn ast_id(&self, db: &dyn Db, file: File) -> Self::Id {
+        let ast_ids = ast_ids(db, file);
+        ClassId(ast_ids.statements_map[&NodeKey::from_node(self.into())])
+    }
+
+    fn lookup(db: &dyn Db, file: File, id: Self::Id) -> &Self {
+        let ast_ids = ast_ids(db, file);
+        ast_ids.statements[id.0].as_class_def_stmt().unwrap()
+    }
+}
+
+#[derive(Debug, Eq, PartialEq, Copy, Clone, Hash)]
+pub struct AssignmentId(StatementId);
+
+impl AstIdNode for StmtAssign {
+    type Id = AssignmentId;
+
+    fn ast_id(&self, db: &dyn Db, file: File) -> Self::Id {
+        let ast_ids = ast_ids(db, file);
+        AssignmentId(ast_ids.statements_map[&NodeKey::from_node(self.into())])
+    }
+
+    fn lookup(db: &dyn Db, file: File, id: Self::Id) -> &Self {
+        let ast_ids = ast_ids(db, file);
+        ast_ids.statements[id.0].as_assign_stmt().unwrap()
+    }
+}
+
+#[derive(Debug, Eq, PartialEq, Copy, Clone)]
+pub struct AnnotatedAssignmentId(StatementId);
+
+impl AstIdNode for StmtAnnAssign {
+    type Id = AnnotatedAssignmentId;
+
+    fn ast_id(&self, db: &dyn Db, file: File) -> Self::Id {
+        let ast_ids = ast_ids(db, file);
+        AnnotatedAssignmentId(ast_ids.statements_map[&NodeKey::from_node(self.into())])
+    }
+
+    fn lookup(db: &dyn Db, file: File, id: Self::Id) -> &Self {
+        let ast_ids = ast_ids(db, file);
+        ast_ids.statements[id.0].as_ann_assign_stmt().unwrap()
+    }
+}
+
+#[derive(Debug)]
+struct AstIdsBuilder<'a> {
+    parsed: Arc<Parsed<ModModule>>,
+    expressions: IndexVec<ExpressionId, AstNodeRef<Expr>>,
+    expressions_map: FxHashMap<NodeKey, ExpressionId>,
+    statements: IndexVec<StatementId, AstNodeRef<Stmt>>,
+    statements_map: FxHashMap<NodeKey, StatementId>,
+
+    deferred: VecDeque<&'a [Stmt]>,
+}
+
+impl AstIdsBuilder<'_> {
+    fn finish(mut self) -> AstIds {
+        self.expressions.shrink_to_fit();
+        self.expressions_map.shrink_to_fit();
+        self.statements.shrink_to_fit();
+        self.statements_map.shrink_to_fit();
+
+        AstIds {
+            expressions: self.expressions,
+            expressions_map: self.expressions_map,
+            statements: self.statements,
+            statements_map: self.statements_map,
+        }
+    }
+}
+
+#[allow(unsafe_code)]
+impl<'a> PreorderVisitor<'a> for AstIdsBuilder<'a> {
+    fn visit_stmt(&mut self, stmt: &'a Stmt) {
+        let statement_id = self
+            .statements
+            .push(unsafe { AstNodeRef::new(self.parsed.clone(), stmt) });
+        self.statements_map
+            .insert(NodeKey::from_node(stmt.into()), statement_id);
+
+        match stmt {
+            Stmt::FunctionDef(StmtFunctionDef {
+                parameters,
+                body,
+                decorator_list,
+                returns,
+                type_params,
+                is_async: _,
+                name: _,
+                range: _,
+            }) => {
+                for decorator in decorator_list {
+                    self.visit_decorator(decorator);
+                }
+
+                if let Some(type_params) = type_params {
+                    self.visit_type_params(type_params);
+                }
+
+                self.visit_parameters(parameters);
+
+                for expr in returns {
+                    self.visit_annotation(expr);
+                }
+
+                self.deferred.push_back(body);
+            }
+
+            Stmt::ClassDef(StmtClassDef {
+                arguments,
+                body,
+                decorator_list,
+                type_params,
+                name: _,
+                range: _,
+            }) => {
+                for decorator in decorator_list {
+                    self.visit_decorator(decorator);
+                }
+
+                if let Some(type_params) = type_params {
+                    self.visit_type_params(type_params);
+                }
+
+                if let Some(arguments) = arguments {
+                    self.visit_arguments(arguments);
+                }
+
+                self.deferred.push_back(body);
+            }
+
+            _ => preorder::walk_stmt(self, stmt),
+        }
+    }
+
+    fn visit_expr(&mut self, expr: &'a Expr) {
+        let expression_id = self
+            .expressions
+            .push(unsafe { AstNodeRef::new(self.parsed.clone(), expr) });
+
+        self.expressions_map
+            .insert(NodeKey::from_node(expr.into()), expression_id);
+
+        preorder::walk_expr(self, expr);
+    }
+}
+
+#[derive(Clone)]
+struct AstNodeRef<T> {
+    _parsed: Arc<Parsed<ModModule>>,
+    node: std::ptr::NonNull<T>,
+}
+
+impl<T> AstNodeRef<T> {
+    /// Creates a new `AstNodeRef` that reference `node`. The `parsed` is the parsed module to which
+    /// the `AstNodeRef` belongs.
+    ///
+    /// The function is marked as `unsafe` because it is the caller's responsibility to ensure that
+    /// `node` is part of `parsed`'s AST. Dereferencing the value if that's not the case is UB
+    /// because it can then point to a no longer valid memory location.
+    #[allow(unsafe_code)]
+    unsafe fn new(parsed: Arc<Parsed<ModModule>>, node: &T) -> Self {
+        Self {
+            _parsed: parsed,
+            node: std::ptr::NonNull::from(node),
+        }
+    }
+
+    pub fn node(&self) -> &T {
+        // SAFETY: Holding on to `parsed` ensures that the AST to which `node` belongs is still alive
+        // and not moved.
+        #[allow(unsafe_code)]
+        unsafe {
+            self.node.as_ref()
+        }
+    }
+}
+
+impl<T> Deref for AstNodeRef<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        self.node()
+    }
+}
+
+impl<T> std::fmt::Debug for AstNodeRef<T>
+where
+    T: std::fmt::Debug,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("AstNodeRef").field(&self.node()).finish()
+    }
+}
+
+impl<T> PartialEq for AstNodeRef<T>
+where
+    T: PartialEq,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.node() == other.node()
+    }
+}
+
+impl<T> Eq for AstNodeRef<T> where T: Eq {}
+
+#[allow(unsafe_code)]
+unsafe impl<T> Send for AstNodeRef<T> where T: Send {}
+#[allow(unsafe_code)]
+unsafe impl<T> Sync for AstNodeRef<T> where T: Sync {}

--- a/crates/red_knot/src/salsa_db/semantic/ast_ids.rs
+++ b/crates/red_knot/src/salsa_db/semantic/ast_ids.rs
@@ -4,7 +4,8 @@ use ruff_index::{newtype_index, IndexVec};
 use ruff_python_ast::visitor::preorder;
 use ruff_python_ast::visitor::preorder::PreorderVisitor;
 use ruff_python_ast::{
-    Expr, ModModule, Stmt, StmtAnnAssign, StmtAssign, StmtClassDef, StmtFunctionDef,
+    Expr, ModModule, Stmt, StmtAnnAssign, StmtAssign, StmtClassDef, StmtFunctionDef, StmtImport,
+    StmtImportFrom,
 };
 use ruff_python_parser::Parsed;
 use rustc_hash::FxHashMap;
@@ -186,7 +187,7 @@ impl AstIdNode for StmtAssign {
     }
 }
 
-#[derive(Debug, Eq, PartialEq, Copy, Clone)]
+#[derive(Debug, Eq, PartialEq, Copy, Clone, Hash)]
 pub struct AnnotatedAssignmentId(StatementId);
 
 impl AstIdNode for StmtAnnAssign {
@@ -200,6 +201,40 @@ impl AstIdNode for StmtAnnAssign {
     fn lookup(db: &dyn Db, file: File, id: Self::Id) -> &Self {
         let ast_ids = ast_ids(db, file);
         ast_ids.statements[id.0].as_ann_assign_stmt().unwrap()
+    }
+}
+
+#[derive(Debug, Eq, PartialEq, Copy, Clone, Hash)]
+pub struct ImportId(StatementId);
+
+impl AstIdNode for StmtImport {
+    type Id = ImportId;
+
+    fn ast_id(&self, db: &dyn Db, file: File) -> Self::Id {
+        let ast_ids = ast_ids(db, file);
+        ImportId(ast_ids.statements_map[&NodeKey::from_node(self.into())])
+    }
+
+    fn lookup(db: &dyn Db, file: File, id: Self::Id) -> &Self {
+        let ast_ids = ast_ids(db, file);
+        ast_ids.statements[id.0].as_import_stmt().unwrap()
+    }
+}
+
+#[derive(Debug, Eq, PartialEq, Copy, Clone, Hash)]
+pub struct ImportFromId(StatementId);
+
+impl AstIdNode for StmtImportFrom {
+    type Id = ImportFromId;
+
+    fn ast_id(&self, db: &dyn Db, file: File) -> Self::Id {
+        let ast_ids = ast_ids(db, file);
+        ImportFromId(ast_ids.statements_map[&NodeKey::from_node(self.into())])
+    }
+
+    fn lookup(db: &dyn Db, file: File, id: Self::Id) -> &Self {
+        let ast_ids = ast_ids(db, file);
+        ast_ids.statements[id.0].as_import_from_stmt().unwrap()
     }
 }
 

--- a/crates/red_knot/src/salsa_db/semantic/definition.rs
+++ b/crates/red_knot/src/salsa_db/semantic/definition.rs
@@ -1,13 +1,10 @@
-use crate::module::ModuleName;
 use crate::salsa_db::semantic::ast_ids::{
-    AnnotatedAssignmentId, AssignmentId, ClassId, FunctionId,
+    AnnotatedAssignmentId, AssignmentId, ClassId, FunctionId, ImportFromId, ImportId,
 };
-
-use crate::Name;
 
 // TODO: I think we should instead reference the node for `ImportDefinition` and `ImportFromDefinition` too
 // or it will be impossible to render nice diagnostics in an error message.
-#[derive(Debug, Eq, PartialEq, Clone)]
+#[derive(Debug, Eq, PartialEq, Copy, Clone, Hash)]
 pub enum Definition {
     // For the import cases, we don't need reference to any arbitrary AST subtrees (annotations,
     // RHS), and referencing just the import statement node is imprecise (a single import statement
@@ -57,28 +54,14 @@ impl From<AnnotatedAssignmentId> for Definition {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub struct ImportDefinition {
-    pub module: ModuleName,
+    pub import: ImportId,
+    pub name: u32,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub struct ImportFromDefinition {
-    pub module: Option<ModuleName>,
-    pub name: Name,
-    pub level: u32,
-}
-
-impl ImportFromDefinition {
-    pub fn module(&self) -> Option<&ModuleName> {
-        self.module.as_ref()
-    }
-
-    pub fn name(&self) -> &Name {
-        &self.name
-    }
-
-    pub fn level(&self) -> u32 {
-        self.level
-    }
+    pub import: ImportFromId,
+    pub name: u32,
 }

--- a/crates/red_knot/src/salsa_db/semantic/definition.rs
+++ b/crates/red_knot/src/salsa_db/semantic/definition.rs
@@ -1,0 +1,84 @@
+use crate::module::ModuleName;
+use crate::salsa_db::semantic::ast_ids::{
+    AnnotatedAssignmentId, AssignmentId, ClassId, FunctionId,
+};
+
+use crate::Name;
+
+// TODO: I think we should instead reference the node for `ImportDefinition` and `ImportFromDefinition` too
+// or it will be impossible to render nice diagnostics in an error message.
+#[derive(Debug, Eq, PartialEq, Clone)]
+pub enum Definition {
+    // For the import cases, we don't need reference to any arbitrary AST subtrees (annotations,
+    // RHS), and referencing just the import statement node is imprecise (a single import statement
+    // can assign many symbols, we'd have to re-search for the one we care about), so we just copy
+    // the small amount of information we need from the AST.
+    Import(ImportDefinition),
+    ImportFrom(ImportFromDefinition),
+    Function(FunctionId),
+    Class(ClassId),
+    Assignment(AssignmentId),
+    AnnotatedAssignment(AnnotatedAssignmentId),
+}
+
+impl From<ImportDefinition> for Definition {
+    fn from(value: ImportDefinition) -> Self {
+        Definition::Import(value)
+    }
+}
+
+impl From<ImportFromDefinition> for Definition {
+    fn from(value: ImportFromDefinition) -> Self {
+        Definition::ImportFrom(value)
+    }
+}
+
+impl From<FunctionId> for Definition {
+    fn from(value: FunctionId) -> Self {
+        Definition::Function(value)
+    }
+}
+
+impl From<ClassId> for Definition {
+    fn from(value: ClassId) -> Self {
+        Definition::Class(value)
+    }
+}
+
+impl From<AssignmentId> for Definition {
+    fn from(value: AssignmentId) -> Self {
+        Definition::Assignment(value)
+    }
+}
+
+impl From<AnnotatedAssignmentId> for Definition {
+    fn from(value: AnnotatedAssignmentId) -> Self {
+        Definition::AnnotatedAssignment(value)
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ImportDefinition {
+    pub module: ModuleName,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ImportFromDefinition {
+    pub module: Option<ModuleName>,
+    pub name: Name,
+    pub level: u32,
+}
+
+impl ImportFromDefinition {
+    pub fn module(&self) -> Option<&ModuleName> {
+        self.module.as_ref()
+    }
+
+    pub fn name(&self) -> &Name {
+        &self.name
+    }
+
+    pub fn level(&self) -> u32 {
+        self.level
+    }
+}

--- a/crates/red_knot/src/salsa_db/semantic/flow_graph.rs
+++ b/crates/red_knot/src/salsa_db/semantic/flow_graph.rs
@@ -1,0 +1,222 @@
+use std::iter::FusedIterator;
+use std::sync::Arc;
+
+use ruff_index::{newtype_index, IndexVec};
+
+use crate::salsa_db::semantic::ast_ids::ExpressionId;
+use crate::salsa_db::semantic::definition::Definition;
+use crate::salsa_db::semantic::symbol_table::SymbolId;
+use crate::salsa_db::semantic::{semantic_index, Db, Jar};
+use crate::salsa_db::source::File;
+
+#[allow(unused)]
+#[tracing::instrument(level = "debug", skip(db))]
+#[salsa::tracked(jar=Jar)]
+pub fn flow_graph(db: &dyn Db, file: File) -> Arc<FlowGraph> {
+    semantic_index(db, file).flow_graph.clone()
+}
+
+#[newtype_index]
+pub struct FlowNodeId;
+
+#[derive(Debug, Eq, PartialEq)]
+pub(crate) enum FlowNode {
+    Start,
+    Definition(DefinitionFlowNode),
+    Branch(BranchFlowNode),
+    Phi(PhiFlowNode),
+}
+
+/// A Definition node represents a point in control flow where a symbol is defined
+#[derive(Debug, Eq, PartialEq)]
+pub(crate) struct DefinitionFlowNode {
+    symbol_id: SymbolId,
+    definition: Definition,
+    predecessor: FlowNodeId,
+}
+
+/// A Branch node represents a branch in control flow
+#[derive(Debug, Eq, PartialEq)]
+pub(crate) struct BranchFlowNode {
+    predecessor: FlowNodeId,
+}
+
+/// A Phi node represents a join point where control flow paths come together
+#[derive(Debug, Eq, PartialEq)]
+pub(crate) struct PhiFlowNode {
+    first_predecessor: FlowNodeId,
+    second_predecessor: FlowNodeId,
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub struct FlowGraph {
+    flow_nodes_by_id: IndexVec<FlowNodeId, FlowNode>,
+    expressions_to_flow: IndexVec<ExpressionId, FlowNodeId>,
+}
+
+impl FlowGraph {
+    pub fn start() -> FlowNodeId {
+        FlowNodeId::from_usize(0)
+    }
+
+    #[allow(unused)]
+    pub fn for_expr(&self, expr: ExpressionId) -> FlowNodeId {
+        self.expressions_to_flow[expr]
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct FlowGraphBuilder {
+    flow_graph: FlowGraph,
+}
+
+impl FlowGraphBuilder {
+    pub(crate) fn new() -> Self {
+        let mut graph = FlowGraph {
+            flow_nodes_by_id: IndexVec::default(),
+            expressions_to_flow: IndexVec::default(),
+        };
+        graph.flow_nodes_by_id.push(FlowNode::Start);
+        Self { flow_graph: graph }
+    }
+
+    pub(crate) fn add(&mut self, node: FlowNode) -> FlowNodeId {
+        self.flow_graph.flow_nodes_by_id.push(node)
+    }
+
+    pub(crate) fn add_definition(
+        &mut self,
+        symbol_id: SymbolId,
+        definition: Definition,
+        predecessor: FlowNodeId,
+    ) -> FlowNodeId {
+        self.add(FlowNode::Definition(DefinitionFlowNode {
+            symbol_id,
+            definition,
+            predecessor,
+        }))
+    }
+
+    pub(crate) fn add_branch(&mut self, predecessor: FlowNodeId) -> FlowNodeId {
+        self.add(FlowNode::Branch(BranchFlowNode { predecessor }))
+    }
+
+    pub(crate) fn add_phi(
+        &mut self,
+        first_predecessor: FlowNodeId,
+        second_predecessor: FlowNodeId,
+    ) -> FlowNodeId {
+        self.add(FlowNode::Phi(PhiFlowNode {
+            first_predecessor,
+            second_predecessor,
+        }))
+    }
+
+    pub(crate) fn record_expr(&mut self, expression_id: ExpressionId, node_id: FlowNodeId) {
+        debug_assert_eq!(
+            self.flow_graph.expressions_to_flow.push(node_id),
+            expression_id
+        );
+    }
+
+    pub(crate) fn finish(self) -> FlowGraph {
+        self.flow_graph
+    }
+}
+
+pub enum ReachableDefinition {
+    Definition(Definition),
+    Undefined,
+}
+
+#[derive(Debug)]
+pub struct ReachableDefinitionsIterator<'a> {
+    flow_graph: &'a FlowGraph,
+    symbol_id: SymbolId,
+    pending: Vec<FlowNodeId>,
+}
+
+impl<'a> ReachableDefinitionsIterator<'a> {
+    #[allow(unused)]
+    pub fn new(flow_graph: &'a FlowGraph, symbol_id: SymbolId, start_node_id: FlowNodeId) -> Self {
+        Self {
+            flow_graph,
+            symbol_id,
+            pending: vec![start_node_id],
+        }
+    }
+}
+
+impl Iterator for ReachableDefinitionsIterator<'_> {
+    type Item = ReachableDefinition;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            let flow_node_id = self.pending.pop()?;
+            match &self.flow_graph.flow_nodes_by_id[flow_node_id] {
+                FlowNode::Start => return Some(ReachableDefinition::Undefined),
+                FlowNode::Definition(def_node) => {
+                    if def_node.symbol_id == self.symbol_id {
+                        return Some(ReachableDefinition::Definition(def_node.definition.clone()));
+                    }
+                    self.pending.push(def_node.predecessor);
+                }
+                FlowNode::Branch(branch_node) => {
+                    self.pending.push(branch_node.predecessor);
+                }
+                FlowNode::Phi(phi_node) => {
+                    self.pending.push(phi_node.first_predecessor);
+                    self.pending.push(phi_node.second_predecessor);
+                }
+            }
+        }
+    }
+}
+
+impl FusedIterator for ReachableDefinitionsIterator<'_> {}
+
+impl std::fmt::Display for FlowGraph {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        writeln!(f, "flowchart TD")?;
+        for (id, node) in self.flow_nodes_by_id.iter_enumerated() {
+            write!(f, "  id{}", id.as_u32())?;
+            match node {
+                FlowNode::Start => writeln!(f, r"[\Start/]")?,
+                FlowNode::Definition(def_node) => {
+                    writeln!(f, r"(Define symbol {})", def_node.symbol_id.as_u32())?;
+                    writeln!(
+                        f,
+                        r"  id{}-->id{}",
+                        def_node.predecessor.as_u32(),
+                        id.as_u32()
+                    )?;
+                }
+                FlowNode::Branch(branch_node) => {
+                    writeln!(f, r"{{Branch}}")?;
+                    writeln!(
+                        f,
+                        r"  id{}-->id{}",
+                        branch_node.predecessor.as_u32(),
+                        id.as_u32()
+                    )?;
+                }
+                FlowNode::Phi(phi_node) => {
+                    writeln!(f, r"((Phi))")?;
+                    writeln!(
+                        f,
+                        r"  id{}-->id{}",
+                        phi_node.second_predecessor.as_u32(),
+                        id.as_u32()
+                    )?;
+                    writeln!(
+                        f,
+                        r"  id{}-->id{}",
+                        phi_node.first_predecessor.as_u32(),
+                        id.as_u32()
+                    )?;
+                }
+            }
+        }
+        Ok(())
+    }
+}

--- a/crates/red_knot/src/salsa_db/semantic/module.rs
+++ b/crates/red_knot/src/salsa_db/semantic/module.rs
@@ -3,8 +3,8 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use crate::module::ModuleName;
+use crate::salsa_db::semantic::symbol_table::Dependency;
 use crate::salsa_db::source::File;
-use crate::symbols::Dependency;
 
 use super::Db;
 use super::Jar;
@@ -412,12 +412,12 @@ impl PackageKind {
 
 #[cfg(test)]
 mod tests {
+    use crate::salsa_db::semantic::symbol_table::Dependency;
     use crate::salsa_db::source::Db;
     use salsa::DebugWithDb;
     use std::num::NonZeroU32;
 
     use crate::salsa_db::tests::TestDb;
-    use crate::symbols::Dependency;
 
     use super::{
         path_to_module, resolve_module_name, set_module_search_paths, ModuleKind, ModuleName,

--- a/crates/red_knot/src/salsa_db/semantic/module.rs
+++ b/crates/red_knot/src/salsa_db/semantic/module.rs
@@ -1,0 +1,874 @@
+use std::fmt::Formatter;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use crate::module::ModuleName;
+use crate::salsa_db::source::File;
+use crate::symbols::Dependency;
+
+use super::Db;
+use super::Jar;
+
+/// ID uniquely identifying a module.
+#[salsa::interned(jar=Jar)]
+pub struct Module {
+    #[return_ref]
+    name: ModuleName,
+}
+
+#[salsa::tracked(jar=Jar)]
+pub struct ResolvedModule {
+    #[id]
+    #[return_ref]
+    name: ModuleName,
+    kind: ModuleKind,
+    search_path: ModuleSearchPath,
+    file: File,
+}
+
+impl ResolvedModule {
+    pub fn resolve_dependency(self, db: &dyn Db, dependency: &Dependency) -> Option<ModuleName> {
+        let (level, module) = match dependency {
+            // FIXME use clone here
+            Dependency::Module(module) => return Some(ModuleName::new(module)),
+            Dependency::Relative { level, module } => (*level, module.as_deref()),
+        };
+
+        let mut components = self.name(db).components().peekable();
+
+        let start = match self.kind(db) {
+            // `.` resolves to the enclosing package
+            ModuleKind::Module => 0,
+            // `.` resolves to the current package
+            ModuleKind::Package => 1,
+        };
+
+        // Skip over the relative parts.
+        for _ in start..level.get() {
+            components.next_back()?;
+        }
+
+        let mut name = String::new();
+
+        for part in components.chain(module) {
+            if !name.is_empty() {
+                name.push('.');
+            }
+
+            name.push_str(part);
+        }
+
+        if name.is_empty() {
+            None
+        } else {
+            Some(ModuleName::new(&name))
+        }
+    }
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+pub enum ModuleKind {
+    Module,
+
+    /// A python package (a `__init__.py` or `__init__.pyi` file)
+    Package,
+}
+
+/// A search path in which to search modules.
+/// Corresponds to a path in [`sys.path`](https://docs.python.org/3/library/sys_path_init.html) at runtime.
+///
+/// Cloning a search path is cheap because it's an `Arc`.
+#[derive(Clone, PartialEq, Eq)]
+pub struct ModuleSearchPath {
+    inner: Arc<ModuleSearchPathInner>,
+}
+
+impl ModuleSearchPath {
+    #[allow(unused)]
+    pub fn new(path: PathBuf, kind: ModuleSearchPathKind) -> Self {
+        Self {
+            inner: Arc::new(ModuleSearchPathInner { path, kind }),
+        }
+    }
+
+    #[allow(unused)]
+    pub fn kind(&self) -> ModuleSearchPathKind {
+        self.inner.kind
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.inner.path
+    }
+}
+
+impl std::fmt::Debug for ModuleSearchPath {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        self.inner.fmt(f)
+    }
+}
+
+#[derive(Debug, Eq, PartialEq)]
+struct ModuleSearchPathInner {
+    path: PathBuf,
+    kind: ModuleSearchPathKind,
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+#[allow(unused)]
+pub enum ModuleSearchPathKind {
+    // Project dependency
+    FirstParty,
+
+    // e.g. site packages
+    ThirdParty,
+
+    // e.g. built-in modules, typeshed
+    #[allow(unused)]
+    StandardLibrary,
+}
+
+impl ModuleSearchPathKind {
+    #[allow(unused)]
+    pub const fn is_first_party(self) -> bool {
+        matches!(self, Self::FirstParty)
+    }
+}
+/// ID uniquely identifying a module.
+#[salsa::input(jar=Jar, singleton)]
+pub struct ModuleSearchPaths {
+    #[return_ref]
+    pub paths: Vec<ModuleSearchPath>,
+}
+
+pub fn module_search_paths(db: &dyn Db) -> &[ModuleSearchPath] {
+    ModuleSearchPaths::get(db).paths(db).as_slice()
+}
+
+/// Changes the module search paths to `search_paths`.
+#[allow(unused)]
+pub fn set_module_search_paths(db: &mut dyn Db, search_paths: Vec<ModuleSearchPath>) {
+    if let Some(existing) = ModuleSearchPaths::try_get(db) {
+        existing.set_paths(db).to(search_paths);
+    } else {
+        ModuleSearchPaths::new(db, search_paths);
+    }
+}
+
+#[allow(unused)]
+pub fn resolve_module_name(db: &dyn Db, name: ModuleName) -> Option<ResolvedModule> {
+    resolve_module(db, Module::new(db, name))
+}
+
+/// Resolves a module name to a module id
+#[tracing::instrument(level = "debug", skip(db))]
+#[salsa::tracked(jar=Jar)]
+pub fn resolve_module(db: &dyn Db, module: Module) -> Option<ResolvedModule> {
+    let name = module.name(db);
+
+    let (root_path, resolved_file, kind) = resolve_module_path(db, name)?;
+
+    let normalized = resolved_file
+        .path(db.upcast())
+        .canonicalize()
+        .map(|path| db.file(path))
+        .unwrap_or_else(|_| resolved_file);
+
+    Some(ResolvedModule::new(
+        db,
+        name.clone(),
+        kind,
+        root_path,
+        normalized,
+    ))
+}
+
+/// Resolves the module id for the given path.
+///
+/// Returns `None` if the path is not a module in `sys.path`.
+#[tracing::instrument(level = "debug", skip(db))]
+pub fn path_to_module(db: &dyn Db, path: &Path) -> Option<ResolvedModule> {
+    let file = db.file(path.to_path_buf());
+    file_to_module(db, file)
+}
+
+/// Resolves the module id for the file with the given id.
+#[tracing::instrument(level = "debug", skip(db))]
+#[salsa::tracked(jar=Jar)]
+pub fn file_to_module(db: &dyn Db, file: File) -> Option<ResolvedModule> {
+    let path = file.path(db.upcast());
+    debug_assert!(path.is_absolute());
+
+    let (root_path, relative_path) = module_search_paths(db).iter().find_map(|root| {
+        let relative_path = path.strip_prefix(root.path()).ok()?;
+        Some((root.clone(), relative_path))
+    })?;
+
+    let module_name = ModuleName::from_relative_path(relative_path)?;
+
+    // Resolve the module name to see if Python would resolve the name to the same path.
+    // If it doesn't, then that means that multiple modules have the same in different
+    // root paths, but that the module corresponding to the past path is in a lower priority path,
+    // in which case we ignore it.
+    let module = resolve_module(db, Module::new(db, module_name))?;
+
+    if module.search_path(db) == root_path {
+        let normalized = path
+            .canonicalize()
+            .map(|path| db.file(path))
+            .unwrap_or(file);
+
+        if normalized != module.file(db) {
+            // This path is for a module with the same name but with a different precedence. For example:
+            // ```
+            // src/foo.py
+            // src/foo/__init__.py
+            // ```
+            // The module name of `src/foo.py` is `foo`, but the module loaded by Python is `src/foo/__init__.py`.
+            // That means we need to ignore `src/foo.py` even though it resolves to the same module name.
+            return None;
+        }
+
+        Some(module)
+    } else {
+        // This path is for a module with the same name but in a module search path with a lower priority.
+        // Ignore it.
+        None
+    }
+}
+
+fn resolve_module_path(
+    db: &dyn Db,
+    name: &ModuleName,
+) -> Option<(ModuleSearchPath, File, ModuleKind)> {
+    let search_paths = module_search_paths(db);
+
+    for search_path in search_paths {
+        let mut components = name.components();
+        let module_name = components.next_back()?;
+
+        match resolve_package(db, search_path, components) {
+            Ok(resolved_package) => {
+                let mut package_path = resolved_package.path;
+
+                package_path.push(module_name);
+
+                // Must be a `__init__.pyi` or `__init__.py` or it isn't a package.
+                let kind = if package_path.is_dir() {
+                    package_path.push("__init__");
+                    ModuleKind::Package
+                } else {
+                    ModuleKind::Module
+                };
+
+                // TODO Implement full https://peps.python.org/pep-0561/#type-checker-module-resolution-order resolution
+                let stub = db.file(package_path.with_extension("pyi"));
+
+                if stub.exists(db.upcast()) {
+                    return Some((search_path.clone(), stub, kind));
+                }
+
+                let module = db.file(package_path.with_extension("py"));
+
+                if module.exists(db.upcast()) {
+                    return Some((search_path.clone(), module, kind));
+                }
+
+                // For regular packages, don't search the next search path. All files of that
+                // package must be in the same location
+                if resolved_package.kind.is_regular_package() {
+                    return None;
+                }
+            }
+            Err(parent_kind) => {
+                if parent_kind.is_regular_package() {
+                    // For regular packages, don't search the next search path.
+                    return None;
+                }
+            }
+        }
+    }
+
+    None
+}
+
+fn resolve_package<'a, I>(
+    db: &dyn Db,
+    module_search_path: &ModuleSearchPath,
+    components: I,
+) -> Result<ResolvedPackage, PackageKind>
+where
+    I: Iterator<Item = &'a str>,
+{
+    let mut package_path = module_search_path.path().to_path_buf();
+
+    // `true` if inside a folder that is a namespace package (has no `__init__.py`).
+    // Namespace packages are special because they can be spread across multiple search paths.
+    // https://peps.python.org/pep-0420/
+    let mut in_namespace_package = false;
+
+    // `true` if resolving a sub-package. For example, `true` when resolving `bar` of `foo.bar`.
+    let mut in_sub_package = false;
+
+    // For `foo.bar.baz`, test that `foo` and `baz` both contain a `__init__.py`.
+    for folder in components {
+        package_path.push(folder);
+
+        let has_init_py = db
+            .file(package_path.join("__init__.py"))
+            .exists(db.upcast())
+            || db
+                .file(package_path.join("__init__.pyi"))
+                .exists(db.upcast());
+
+        if has_init_py {
+            in_namespace_package = false;
+        } else if package_path.is_dir() {
+            // A directory without an `__init__.py` is a namespace package, continue with the next folder.
+            in_namespace_package = true;
+        } else if in_namespace_package {
+            // Package not found but it is part of a namespace package.
+            return Err(PackageKind::Namespace);
+        } else if in_sub_package {
+            // A regular sub package wasn't found.
+            return Err(PackageKind::Regular);
+        } else {
+            // We couldn't find `foo` for `foo.bar.baz`, search the next search path.
+            return Err(PackageKind::Root);
+        }
+
+        in_sub_package = true;
+    }
+
+    let kind = if in_namespace_package {
+        PackageKind::Namespace
+    } else if in_sub_package {
+        PackageKind::Regular
+    } else {
+        PackageKind::Root
+    };
+
+    Ok(ResolvedPackage {
+        kind,
+        path: package_path,
+    })
+}
+
+#[derive(Debug)]
+pub struct ResolvedPackage {
+    pub path: PathBuf,
+    pub kind: PackageKind,
+}
+
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+pub enum PackageKind {
+    /// A root package or module. E.g. `foo` in `foo.bar.baz` or just `foo`.
+    Root,
+
+    /// A regular sub-package where the parent contains an `__init__.py`. For example `bar` in `foo.bar` when the `foo` directory contains an `__init__.py`.
+    Regular,
+
+    /// A sub-package in a namespace package. A namespace package is a package without an `__init__.py`.
+    ///
+    /// For example, `bar` in `foo.bar` if the `foo` directory contains no `__init__.py`.
+    Namespace,
+}
+
+impl PackageKind {
+    pub const fn is_regular_package(self) -> bool {
+        matches!(self, PackageKind::Regular)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::salsa_db::source::Db;
+    use salsa::DebugWithDb;
+    use std::num::NonZeroU32;
+
+    use crate::salsa_db::tests::TestDb;
+    use crate::symbols::Dependency;
+
+    use super::{
+        path_to_module, resolve_module_name, set_module_search_paths, ModuleKind, ModuleName,
+        ModuleSearchPath, ModuleSearchPathKind,
+    };
+
+    struct TestCase {
+        temp_dir: tempfile::TempDir,
+        db: TestDb,
+
+        src: ModuleSearchPath,
+        site_packages: ModuleSearchPath,
+    }
+
+    fn create_resolver() -> std::io::Result<TestCase> {
+        let temp_dir = tempfile::tempdir()?;
+
+        let src = temp_dir.path().join("src");
+        let site_packages = temp_dir.path().join("site_packages");
+
+        std::fs::create_dir(&src)?;
+        std::fs::create_dir(&site_packages)?;
+
+        let src = ModuleSearchPath::new(src.canonicalize()?, ModuleSearchPathKind::FirstParty);
+        let site_packages = ModuleSearchPath::new(
+            site_packages.canonicalize()?,
+            ModuleSearchPathKind::ThirdParty,
+        );
+
+        let roots = vec![src.clone(), site_packages.clone()];
+
+        let mut db = TestDb::new();
+        set_module_search_paths(&mut db, roots);
+
+        Ok(TestCase {
+            temp_dir,
+            db,
+            src,
+            site_packages,
+        })
+    }
+
+    #[test]
+    fn first_party_module() -> anyhow::Result<()> {
+        let TestCase {
+            db,
+            src,
+            temp_dir: _temp_dir,
+            ..
+        } = create_resolver()?;
+
+        let foo_path = src.path().join("foo.py");
+        std::fs::write(&foo_path, "print('Hello, world!')")?;
+
+        let foo_module = resolve_module_name(&db, ModuleName::new("foo")).unwrap();
+
+        assert_eq!(
+            Some(foo_module),
+            resolve_module_name(&db, ModuleName::new("foo"))
+        );
+
+        assert_eq!(&ModuleName::new("foo"), foo_module.name(&db));
+        assert_eq!(src, foo_module.search_path(&db));
+        assert_eq!(ModuleKind::Module, foo_module.kind(&db));
+        assert_eq!(&foo_path, foo_module.file(&db).path(&db));
+
+        assert_eq!(Some(foo_module), path_to_module(&db, &foo_path));
+
+        Ok(())
+    }
+
+    #[test]
+    fn resolve_package() -> anyhow::Result<()> {
+        let TestCase {
+            src,
+            db,
+            temp_dir: _temp_dir,
+            ..
+        } = create_resolver()?;
+
+        let foo_dir = src.path().join("foo");
+        let foo_path = foo_dir.join("__init__.py");
+        std::fs::create_dir(&foo_dir)?;
+        std::fs::write(&foo_path, "print('Hello, world!')")?;
+
+        let foo_module = resolve_module_name(&db, ModuleName::new("foo")).unwrap();
+
+        assert_eq!(&ModuleName::new("foo"), foo_module.name(&db));
+        assert_eq!(src, foo_module.search_path(&db));
+        assert_eq!(&foo_path, foo_module.file(&db).path(&db));
+
+        assert_eq!(Some(foo_module), path_to_module(&db, &foo_path));
+
+        // Resolving by directory doesn't resolve to the init file.
+        assert_eq!(None, path_to_module(&db, &foo_dir));
+
+        Ok(())
+    }
+
+    #[test]
+    fn package_priority_over_module() -> anyhow::Result<()> {
+        let TestCase {
+            db,
+            temp_dir: _temp_dir,
+            src,
+            ..
+        } = create_resolver()?;
+
+        let foo_dir = src.path().join("foo");
+        let foo_init = foo_dir.join("__init__.py");
+        std::fs::create_dir(&foo_dir)?;
+        std::fs::write(&foo_init, "print('Hello, world!')")?;
+
+        let foo_py = src.path().join("foo.py");
+        std::fs::write(&foo_py, "print('Hello, world!')")?;
+
+        let foo_module = resolve_module_name(&db, ModuleName::new("foo")).unwrap();
+
+        assert_eq!(src, foo_module.search_path(&db));
+        assert_eq!(&foo_init, foo_module.file(&db).path(&db));
+        assert_eq!(ModuleKind::Package, foo_module.kind(&db));
+
+        assert_eq!(Some(foo_module), path_to_module(&db, &foo_init));
+        assert_eq!(None, path_to_module(&db, &foo_py));
+
+        Ok(())
+    }
+
+    #[test]
+    fn typing_stub_over_module() -> anyhow::Result<()> {
+        let TestCase {
+            db,
+            src,
+            temp_dir: _temp_dir,
+            ..
+        } = create_resolver()?;
+
+        let foo_stub = src.path().join("foo.pyi");
+        let foo_py = src.path().join("foo.py");
+        std::fs::write(&foo_stub, "x: int")?;
+        std::fs::write(&foo_py, "print('Hello, world!')")?;
+
+        let foo = resolve_module_name(&db, ModuleName::new("foo")).unwrap();
+
+        assert_eq!(src, foo.search_path(&db));
+        assert_eq!(&foo_stub, foo.file(&db).path(&db));
+
+        assert_eq!(Some(foo), path_to_module(&db, &foo_stub));
+        assert_eq!(None, path_to_module(&db, &foo_py));
+
+        Ok(())
+    }
+
+    #[test]
+    fn sub_packages() -> anyhow::Result<()> {
+        let TestCase {
+            db,
+            src,
+            temp_dir: _temp_dir,
+            ..
+        } = create_resolver()?;
+
+        let foo = src.path().join("foo");
+        let bar = foo.join("bar");
+        let baz = bar.join("baz.py");
+
+        std::fs::create_dir_all(&bar)?;
+        std::fs::write(foo.join("__init__.py"), "")?;
+        std::fs::write(bar.join("__init__.py"), "")?;
+        std::fs::write(&baz, "print('Hello, world!')")?;
+
+        let baz_module = resolve_module_name(&db, ModuleName::new("foo.bar.baz")).unwrap();
+
+        assert_eq!(src, baz_module.search_path(&db));
+        assert_eq!(&baz, baz_module.file(&db).path(&db));
+
+        assert_eq!(Some(baz_module), path_to_module(&db, &baz));
+
+        Ok(())
+    }
+
+    #[test]
+    fn namespace_package() -> anyhow::Result<()> {
+        let TestCase {
+            db,
+            temp_dir: _,
+            src,
+            site_packages,
+        } = create_resolver()?;
+
+        // From [PEP420](https://peps.python.org/pep-0420/#nested-namespace-packages).
+        // But uses `src` for `project1` and `site_packages2` for `project2`.
+        // ```
+        // src
+        //   parent
+        //     child
+        //       one.py
+        // site_packages
+        //   parent
+        //     child
+        //       two.py
+        // ```
+
+        let parent1 = src.path().join("parent");
+        let child1 = parent1.join("child");
+        let one = child1.join("one.py");
+
+        std::fs::create_dir_all(child1)?;
+        std::fs::write(&one, "print('Hello, world!')")?;
+
+        let parent2 = site_packages.path().join("parent");
+        let child2 = parent2.join("child");
+        let two = child2.join("two.py");
+
+        std::fs::create_dir_all(&child2)?;
+        std::fs::write(&two, "print('Hello, world!')")?;
+
+        let one_module = resolve_module_name(&db, ModuleName::new("parent.child.one")).unwrap();
+
+        assert_eq!(Some(one_module), path_to_module(&db, &one));
+
+        let two_module = resolve_module_name(&db, ModuleName::new("parent.child.two")).unwrap();
+        assert_eq!(Some(two_module), path_to_module(&db, &two));
+
+        Ok(())
+    }
+
+    #[test]
+    fn regular_package_in_namespace_package() -> anyhow::Result<()> {
+        let TestCase {
+            db,
+            temp_dir: _,
+            src,
+            site_packages,
+        } = create_resolver()?;
+
+        // Adopted test case from the [PEP420 examples](https://peps.python.org/pep-0420/#nested-namespace-packages).
+        // The `src/parent/child` package is a regular package. Therefore, `site_packages/parent/child/two.py` should not be resolved.
+        // ```
+        // src
+        //   parent
+        //     child
+        //       one.py
+        // site_packages
+        //   parent
+        //     child
+        //       two.py
+        // ```
+
+        let parent1 = src.path().join("parent");
+        let child1 = parent1.join("child");
+        let one = child1.join("one.py");
+
+        std::fs::create_dir_all(&child1)?;
+        std::fs::write(child1.join("__init__.py"), "print('Hello, world!')")?;
+        std::fs::write(&one, "print('Hello, world!')")?;
+
+        let parent2 = site_packages.path().join("parent");
+        let child2 = parent2.join("child");
+        let two = child2.join("two.py");
+
+        std::fs::create_dir_all(&child2)?;
+        std::fs::write(two, "print('Hello, world!')")?;
+
+        let one_module = resolve_module_name(&db, ModuleName::new("parent.child.one")).unwrap();
+
+        assert_eq!(Some(one_module), path_to_module(&db, &one));
+
+        assert_eq!(
+            None,
+            resolve_module_name(&db, ModuleName::new("parent.child.two"))
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn module_search_path_priority() -> anyhow::Result<()> {
+        let TestCase {
+            db,
+            src,
+            site_packages,
+            temp_dir: _temp_dir,
+        } = create_resolver()?;
+
+        let foo_src = src.path().join("foo.py");
+        let foo_site_packages = site_packages.path().join("foo.py");
+
+        std::fs::write(&foo_src, "")?;
+        std::fs::write(&foo_site_packages, "")?;
+
+        let foo_module = resolve_module_name(&db, ModuleName::new("foo")).unwrap();
+
+        assert_eq!(src, foo_module.search_path(&db));
+        assert_eq!(&foo_src, foo_module.file(&db).path(&db));
+
+        assert_eq!(Some(foo_module), path_to_module(&db, &foo_src));
+        assert_eq!(None, path_to_module(&db, &foo_site_packages));
+
+        Ok(())
+    }
+
+    #[test]
+    #[cfg(target_family = "unix")]
+    fn symlink() -> anyhow::Result<()> {
+        let TestCase {
+            db,
+            src,
+            temp_dir: _temp_dir,
+            ..
+        } = create_resolver()?;
+
+        let foo = src.path().join("foo.py");
+        let bar = src.path().join("bar.py");
+
+        std::fs::write(&foo, "")?;
+        std::os::unix::fs::symlink(&foo, &bar)?;
+
+        let foo_module = resolve_module_name(&db, ModuleName::new("foo")).unwrap();
+        let bar_module = resolve_module_name(&db, ModuleName::new("bar")).unwrap();
+
+        assert_ne!(foo_module, bar_module);
+
+        assert_eq!(src, foo_module.search_path(&db));
+        assert_eq!(&foo, foo_module.file(&db).path(&db));
+
+        // Bar has a different name but it should point to the same file.
+
+        assert_eq!(src, bar_module.search_path(&db));
+        assert_eq!(foo_module.file(&db), bar_module.file(&db));
+        assert_eq!(&foo, bar_module.file(&db).path(&db));
+
+        assert_eq!(Some(foo_module), path_to_module(&db, &foo));
+        assert_eq!(Some(bar_module), path_to_module(&db, &bar));
+
+        Ok(())
+    }
+
+    #[test]
+    fn resolve_dependency() -> anyhow::Result<()> {
+        let TestCase {
+            src,
+            db,
+            temp_dir: _temp_dir,
+            ..
+        } = create_resolver()?;
+
+        let foo_dir = src.path().join("foo");
+        let foo_path = foo_dir.join("__init__.py");
+        let bar_path = foo_dir.join("bar.py");
+
+        std::fs::create_dir(&foo_dir)?;
+        std::fs::write(foo_path, "from .bar import test")?;
+        std::fs::write(bar_path, "test = 'Hello world'")?;
+
+        let foo_module = resolve_module_name(&db, ModuleName::new("foo")).unwrap();
+        let bar_module = resolve_module_name(&db, ModuleName::new("foo.bar")).unwrap();
+
+        // `from . import bar` in `foo/__init__.py` resolves to `foo`
+        assert_eq!(
+            Some(ModuleName::new("foo")),
+            foo_module.resolve_dependency(
+                &db,
+                &Dependency::Relative {
+                    level: NonZeroU32::new(1).unwrap(),
+                    module: None,
+                }
+            )
+        );
+
+        // `from baz import bar` in `foo/__init__.py` should resolve to `baz.py`
+        assert_eq!(
+            Some(ModuleName::new("baz")),
+            foo_module.resolve_dependency(
+                &db,
+                &Dependency::Module(crate::module::ModuleName::new("baz"))
+            )
+        );
+
+        // from .bar import test in `foo/__init__.py` should resolve to `foo/bar.py`
+        assert_eq!(
+            Some(ModuleName::new("foo.bar")),
+            foo_module.resolve_dependency(
+                &db,
+                &Dependency::Relative {
+                    level: NonZeroU32::new(1).unwrap(),
+                    module: Some(crate::module::ModuleName::new("bar"))
+                }
+            )
+        );
+
+        // from .. import test in `foo/__init__.py` resolves to `` which is not a module
+        assert_eq!(
+            None,
+            foo_module.resolve_dependency(
+                &db,
+                &Dependency::Relative {
+                    level: NonZeroU32::new(2).unwrap(),
+                    module: None
+                }
+            )
+        );
+
+        // `from . import test` in `foo/bar.py` resolves to `foo`
+        assert_eq!(
+            Some(ModuleName::new("foo")),
+            bar_module.resolve_dependency(
+                &db,
+                &Dependency::Relative {
+                    level: NonZeroU32::new(1).unwrap(),
+                    module: None
+                }
+            )
+        );
+
+        // `from baz import test` in `foo/bar.py` resolves to `baz`
+        assert_eq!(
+            Some(ModuleName::new("baz")),
+            bar_module.resolve_dependency(
+                &db,
+                &Dependency::Module(crate::module::ModuleName::new("baz"))
+            )
+        );
+
+        // `from .baz import test` in `foo/bar.py` resolves to `foo.baz`.
+        assert_eq!(
+            Some(ModuleName::new("foo.baz")),
+            bar_module.resolve_dependency(
+                &db,
+                &Dependency::Relative {
+                    level: NonZeroU32::new(1).unwrap(),
+                    module: Some(crate::module::ModuleName::new("baz"))
+                }
+            )
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn cache_invalidation() -> anyhow::Result<()> {
+        let TestCase {
+            mut db,
+            temp_dir: _,
+            src,
+            site_packages,
+        } = create_resolver()?;
+
+        let parent1 = src.path().join("parent");
+        let one = parent1.join("one.py");
+
+        std::fs::create_dir_all(&parent1)?;
+        std::fs::write(&one, "print('Hello, world!')")?;
+
+        let parent2 = site_packages.path().join("parent");
+        let two = parent2.join("two.py");
+
+        std::fs::create_dir_all(&parent2)?;
+        std::fs::write(&two, "print('Hello, world!')")?;
+
+        let one_module = resolve_module_name(&db, ModuleName::new("parent.one")).unwrap();
+
+        assert_eq!(Some(one_module), path_to_module(&db, &one));
+
+        let two_module = resolve_module_name(&db, ModuleName::new("parent.two")).unwrap();
+        assert_eq!(Some(two_module), path_to_module(&db, &two));
+
+        // Add an `__init__.py` to the `site_packages/parent` folder, which makes it a non-namespace package and
+        // should invalidate `two_module`.
+
+        let parent1_init = parent1.join("__init__.py");
+        std::fs::write(&parent1_init, "")?;
+
+        let init_file = db.file(parent1_init);
+        init_file.touch(&mut db);
+        init_file.debug(&db);
+
+        assert_eq!(
+            None,
+            resolve_module_name(&db, ModuleName::new("parent.two"))
+        );
+        assert_eq!(None, path_to_module(&db, &two));
+
+        Ok(())
+    }
+}

--- a/crates/red_knot/src/salsa_db/semantic/symbol_table.rs
+++ b/crates/red_knot/src/salsa_db/semantic/symbol_table.rs
@@ -21,7 +21,7 @@ use crate::Name;
 #[tracing::instrument(level = "debug", skip(db))]
 #[salsa::tracked(jar=Jar)]
 pub fn symbol_table(db: &dyn Db, file: File) -> Arc<SymbolTable> {
-    semantic_index(db, file).symbol_table.clone()
+    dbg!(semantic_index(db, file).symbol_table.clone())
 }
 
 type Map<K, V> = hashbrown::HashMap<K, V, ()>;

--- a/crates/red_knot/src/salsa_db/semantic/symbol_table.rs
+++ b/crates/red_knot/src/salsa_db/semantic/symbol_table.rs
@@ -1,0 +1,542 @@
+#![allow(dead_code)]
+
+use std::collections::hash_map::{Entry, Values};
+use std::hash::{Hash, Hasher};
+use std::iter::{Copied, DoubleEndedIterator, FusedIterator};
+use std::num::NonZeroU32;
+use std::sync::Arc;
+
+use bitflags::bitflags;
+use rustc_hash::{FxHashMap, FxHasher};
+
+use ruff_index::{newtype_index, IndexVec};
+
+use crate::module::ModuleName;
+use crate::salsa_db::semantic::ast_ids::{ClassId, FunctionId};
+use crate::salsa_db::semantic::definition::Definition;
+use crate::salsa_db::semantic::{semantic_index, Db, Jar};
+use crate::salsa_db::source::File;
+use crate::Name;
+
+#[tracing::instrument(level = "debug", skip(db))]
+#[salsa::tracked(jar=Jar)]
+pub fn symbol_table(db: &dyn Db, file: File) -> Arc<SymbolTable> {
+    semantic_index(db, file).symbol_table.clone()
+}
+
+type Map<K, V> = hashbrown::HashMap<K, V, ()>;
+
+#[newtype_index]
+pub struct ScopeId;
+
+impl ScopeId {
+    pub fn scope(self, table: &SymbolTable) -> &Scope {
+        &table.scopes_by_id[self]
+    }
+}
+
+#[newtype_index]
+pub struct SymbolId;
+
+impl SymbolId {
+    pub fn symbol(self, table: &SymbolTable) -> &Symbol {
+        &table.symbols_by_id[self]
+    }
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum ScopeKind {
+    Module,
+    Annotation,
+    Class,
+    Function,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct Scope {
+    name: Name,
+    kind: ScopeKind,
+    parent: Option<ScopeId>,
+    children: Vec<ScopeId>,
+    /// the definition (e.g. class or function) that created this scope
+    definition: Option<Definition>,
+    /// the symbol (e.g. class or function) that owns this scope
+    defining_symbol: Option<SymbolId>,
+    // TODO: Avoid storing the name by using the existing hashbrown trick.
+    //  It will require a custom Eq implementation on `SymbolTable` that ignores `symbols_by_name` and `children`.
+    //  Both these fields don't need to be compared because they are redundant (`symbols_by_name`: `Symbol::scope` already tracks the hierarchy, `children`: `Scope::parent` already tracks the hierarchy).
+    symbols_by_name: FxHashMap<Name, SymbolId>,
+}
+
+impl Scope {
+    pub fn name(&self) -> &str {
+        self.name.as_str()
+    }
+
+    pub fn kind(&self) -> ScopeKind {
+        self.kind
+    }
+
+    pub fn definition(&self) -> Option<&Definition> {
+        self.definition.as_ref()
+    }
+
+    pub fn defining_symbol(&self) -> Option<SymbolId> {
+        self.defining_symbol
+    }
+}
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub(crate) enum Kind {
+    FreeVar,
+    CellVar,
+    CellVarAssigned,
+    ExplicitGlobal,
+    ImplicitGlobal,
+}
+
+bitflags! {
+    #[derive(Copy, Clone, Debug, PartialEq, Eq)]
+    pub struct SymbolFlags: u8 {
+        const IS_USED         = 1 << 0;
+        const IS_DEFINED      = 1 << 1;
+        /// TODO: This flag is not yet set by anything
+        const MARKED_GLOBAL   = 1 << 2;
+        /// TODO: This flag is not yet set by anything
+        const MARKED_NONLOCAL = 1 << 3;
+    }
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub struct Symbol {
+    name: Name,
+    flags: SymbolFlags,
+    scope_id: ScopeId,
+    // kind: Kind,
+}
+
+impl Symbol {
+    pub fn name(&self) -> &str {
+        self.name.as_str()
+    }
+
+    pub fn scope_id(&self) -> ScopeId {
+        self.scope_id
+    }
+
+    /// Is the symbol used in its containing scope?
+    pub fn is_used(&self) -> bool {
+        self.flags.contains(SymbolFlags::IS_USED)
+    }
+
+    /// Is the symbol defined in its containing scope?
+    pub fn is_defined(&self) -> bool {
+        self.flags.contains(SymbolFlags::IS_DEFINED)
+    }
+
+    // TODO: implement Symbol.kind 2-pass analysis to categorize as: free-var, cell-var,
+    // explicit-global, implicit-global and implement Symbol.kind by modifying the preorder
+    // traversal code
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum Dependency {
+    Module(ModuleName),
+    Relative {
+        level: NonZeroU32,
+        module: Option<ModuleName>,
+    },
+}
+
+#[derive(Copy, Clone, Eq, PartialEq, Debug, Hash)]
+pub enum NodeWithScopeId {
+    Class(ClassId),
+    Function(FunctionId),
+}
+
+/// Table of all symbols in all scopes for a module.
+#[derive(Debug, PartialEq, Eq)]
+pub struct SymbolTable {
+    scopes_by_id: IndexVec<ScopeId, Scope>,
+    symbols_by_id: IndexVec<SymbolId, Symbol>,
+    /// the definitions for each symbol
+    defs: FxHashMap<SymbolId, Vec<Definition>>,
+    /// map of AST node (e.g. class/function def) to sub-scope it creates
+    scopes_by_node: FxHashMap<NodeWithScopeId, ScopeId>,
+    /// dependencies of this module
+    dependencies: Vec<Dependency>,
+}
+
+impl SymbolTable {
+    pub fn dependencies(&self) -> &[Dependency] {
+        &self.dependencies
+    }
+
+    pub const fn root_scope_id() -> ScopeId {
+        ScopeId::from_usize(0)
+    }
+
+    pub fn root_scope(&self) -> &Scope {
+        &self.scopes_by_id[SymbolTable::root_scope_id()]
+    }
+
+    pub fn symbol_ids_for_scope(&self, scope_id: ScopeId) -> Copied<Values<Name, SymbolId>> {
+        self.scopes_by_id[scope_id]
+            .symbols_by_name
+            .values()
+            .copied()
+    }
+
+    pub fn symbols_for_scope(
+        &self,
+        scope_id: ScopeId,
+    ) -> SymbolIterator<Copied<Values<Name, SymbolId>>> {
+        SymbolIterator {
+            table: self,
+            ids: self.symbol_ids_for_scope(scope_id),
+        }
+    }
+
+    pub fn root_symbol_ids(&self) -> Copied<Values<Name, SymbolId>> {
+        self.symbol_ids_for_scope(SymbolTable::root_scope_id())
+    }
+
+    pub fn root_symbols(&self) -> SymbolIterator<Copied<Values<Name, SymbolId>>> {
+        self.symbols_for_scope(SymbolTable::root_scope_id())
+    }
+
+    pub fn child_scope_ids_of(&self, scope_id: ScopeId) -> &[ScopeId] {
+        &self.scopes_by_id[scope_id].children
+    }
+
+    pub fn child_scopes_of(&self, scope_id: ScopeId) -> ScopeIterator<&[ScopeId]> {
+        ScopeIterator {
+            table: self,
+            ids: self.child_scope_ids_of(scope_id),
+        }
+    }
+
+    pub fn root_child_scope_ids(&self) -> &[ScopeId] {
+        self.child_scope_ids_of(SymbolTable::root_scope_id())
+    }
+
+    pub fn root_child_scopes(&self) -> ScopeIterator<&[ScopeId]> {
+        self.child_scopes_of(SymbolTable::root_scope_id())
+    }
+
+    pub fn symbol_id_by_name(&self, scope_id: ScopeId, name: &str) -> Option<SymbolId> {
+        let scope = &self.scopes_by_id[scope_id];
+        let name = Name::new(name);
+        Some(*scope.symbols_by_name.get(&name)?)
+    }
+
+    pub fn symbol_by_name(&self, scope_id: ScopeId, name: &str) -> Option<&Symbol> {
+        Some(&self.symbols_by_id[self.symbol_id_by_name(scope_id, name)?])
+    }
+
+    pub fn root_symbol_id_by_name(&self, name: &str) -> Option<SymbolId> {
+        self.symbol_id_by_name(SymbolTable::root_scope_id(), name)
+    }
+
+    pub fn root_symbol_by_name(&self, name: &str) -> Option<&Symbol> {
+        self.symbol_by_name(SymbolTable::root_scope_id(), name)
+    }
+
+    pub fn scope_id_of_symbol(&self, symbol_id: SymbolId) -> ScopeId {
+        self.symbols_by_id[symbol_id].scope_id
+    }
+
+    pub fn scope_of_symbol(&self, symbol_id: SymbolId) -> &Scope {
+        &self.scopes_by_id[self.scope_id_of_symbol(symbol_id)]
+    }
+
+    pub fn parent_scopes(
+        &self,
+        scope_id: ScopeId,
+    ) -> ScopeIterator<impl Iterator<Item = ScopeId> + '_> {
+        ScopeIterator {
+            table: self,
+            ids: std::iter::successors(Some(scope_id), |scope| self.scopes_by_id[*scope].parent),
+        }
+    }
+
+    pub fn parent_scope(&self, scope_id: ScopeId) -> Option<ScopeId> {
+        self.scopes_by_id[scope_id].parent
+    }
+
+    pub fn scope_id_for_node(&self, node: NodeWithScopeId) -> ScopeId {
+        self.scopes_by_node[&node]
+    }
+
+    pub fn definitions(&self, symbol_id: SymbolId) -> &[Definition] {
+        self.defs
+            .get(&symbol_id)
+            .map(std::vec::Vec::as_slice)
+            .unwrap_or_default()
+    }
+
+    pub fn all_definitions(&self) -> impl Iterator<Item = (SymbolId, &Definition)> + '_ {
+        self.defs
+            .iter()
+            .flat_map(|(sym_id, defs)| defs.iter().map(move |def| (*sym_id, def)))
+    }
+
+    fn hash_name(name: &str) -> u64 {
+        let mut hasher = FxHasher::default();
+        name.hash(&mut hasher);
+        hasher.finish()
+    }
+}
+
+pub struct SymbolIterator<'a, I> {
+    table: &'a SymbolTable,
+    ids: I,
+}
+
+impl<'a, I> Iterator for SymbolIterator<'a, I>
+where
+    I: Iterator<Item = SymbolId>,
+{
+    type Item = &'a Symbol;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let id = self.ids.next()?;
+        Some(&self.table.symbols_by_id[id])
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.ids.size_hint()
+    }
+}
+
+impl<'a, I> FusedIterator for SymbolIterator<'a, I> where
+    I: Iterator<Item = SymbolId> + FusedIterator
+{
+}
+
+impl<'a, I> DoubleEndedIterator for SymbolIterator<'a, I>
+where
+    I: Iterator<Item = SymbolId> + DoubleEndedIterator,
+{
+    fn next_back(&mut self) -> Option<Self::Item> {
+        let id = self.ids.next_back()?;
+        Some(&self.table.symbols_by_id[id])
+    }
+}
+
+// TODO maybe get rid of this and just do all data access via methods on ScopeId?
+pub struct ScopeIterator<'a, I> {
+    table: &'a SymbolTable,
+    ids: I,
+}
+
+/// iterate (`ScopeId`, `Scope`) pairs for given `ScopeId` iterator
+impl<'a, I> Iterator for ScopeIterator<'a, I>
+where
+    I: Iterator<Item = ScopeId>,
+{
+    type Item = (ScopeId, &'a Scope);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let id = self.ids.next()?;
+        Some((id, &self.table.scopes_by_id[id]))
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.ids.size_hint()
+    }
+}
+
+impl<'a, I> FusedIterator for ScopeIterator<'a, I> where I: Iterator<Item = ScopeId> + FusedIterator {}
+
+impl<'a, I> DoubleEndedIterator for ScopeIterator<'a, I>
+where
+    I: Iterator<Item = ScopeId> + DoubleEndedIterator,
+{
+    fn next_back(&mut self) -> Option<Self::Item> {
+        let id = self.ids.next_back()?;
+        Some((id, &self.table.scopes_by_id[id]))
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct SymbolTableBuilder {
+    symbol_table: SymbolTable,
+}
+
+impl SymbolTableBuilder {
+    pub(crate) fn new() -> Self {
+        let mut table = SymbolTable {
+            scopes_by_id: IndexVec::new(),
+            symbols_by_id: IndexVec::new(),
+            defs: FxHashMap::default(),
+            scopes_by_node: FxHashMap::default(),
+            dependencies: Vec::new(),
+        };
+        table.scopes_by_id.push(Scope {
+            name: Name::new("<module>"),
+            kind: ScopeKind::Module,
+            parent: None,
+            children: Vec::new(),
+            definition: None,
+            defining_symbol: None,
+            symbols_by_name: FxHashMap::default(),
+        });
+        Self {
+            symbol_table: table,
+        }
+    }
+
+    pub(crate) fn finish(self) -> SymbolTable {
+        self.symbol_table
+    }
+
+    pub(crate) fn add_or_update_symbol(
+        &mut self,
+        scope_id: ScopeId,
+        name: &str,
+        flags: SymbolFlags,
+    ) -> SymbolId {
+        let scope = &mut self.symbol_table.scopes_by_id[scope_id];
+        let name = Name::new(name);
+
+        let entry = scope.symbols_by_name.entry(name.clone());
+
+        match entry {
+            Entry::Occupied(entry) => {
+                if let Some(symbol) = self.symbol_table.symbols_by_id.get_mut(*entry.get()) {
+                    symbol.flags.insert(flags);
+                };
+                *entry.get()
+            }
+            Entry::Vacant(entry) => {
+                let id = self.symbol_table.symbols_by_id.push(Symbol {
+                    name,
+                    flags,
+                    scope_id,
+                });
+                entry.insert(id);
+                id
+            }
+        }
+    }
+
+    pub(crate) fn add_definition(&mut self, symbol_id: SymbolId, definition: Definition) {
+        self.symbol_table
+            .defs
+            .entry(symbol_id)
+            .or_default()
+            .push(definition);
+    }
+
+    pub(crate) fn add_child_scope(
+        &mut self,
+        parent_scope_id: ScopeId,
+        name: &str,
+        kind: ScopeKind,
+        definition: Option<Definition>,
+        defining_symbol: Option<SymbolId>,
+    ) -> ScopeId {
+        let new_scope_id = self.symbol_table.scopes_by_id.push(Scope {
+            name: Name::new(name),
+            kind,
+            parent: Some(parent_scope_id),
+            children: Vec::new(),
+            definition,
+            defining_symbol,
+            symbols_by_name: FxHashMap::default(),
+        });
+        let parent_scope = &mut self.symbol_table.scopes_by_id[parent_scope_id];
+        parent_scope.children.push(new_scope_id);
+        new_scope_id
+    }
+
+    pub(crate) fn record_scope_for_node(&mut self, node: NodeWithScopeId, scope_id: ScopeId) {
+        self.symbol_table.scopes_by_node.insert(node, scope_id);
+    }
+
+    pub(crate) fn add_dependency(&mut self, dependency: Dependency) {
+        self.symbol_table.dependencies.push(dependency);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ScopeKind, SymbolFlags, SymbolTable, SymbolTableBuilder};
+
+    #[test]
+    fn insert_same_name_symbol_twice() {
+        let mut builder = SymbolTableBuilder::new();
+        let root_scope_id = SymbolTable::root_scope_id();
+        let symbol_id_1 =
+            builder.add_or_update_symbol(root_scope_id, "foo", SymbolFlags::IS_DEFINED);
+        let symbol_id_2 = builder.add_or_update_symbol(root_scope_id, "foo", SymbolFlags::IS_USED);
+        let table = builder.finish();
+
+        assert_eq!(symbol_id_1, symbol_id_2);
+        assert!(symbol_id_1.symbol(&table).is_used(), "flags must merge");
+        assert!(symbol_id_1.symbol(&table).is_defined(), "flags must merge");
+    }
+
+    #[test]
+    fn insert_different_named_symbols() {
+        let mut builder = SymbolTableBuilder::new();
+        let root_scope_id = SymbolTable::root_scope_id();
+        let symbol_id_1 = builder.add_or_update_symbol(root_scope_id, "foo", SymbolFlags::empty());
+        let symbol_id_2 = builder.add_or_update_symbol(root_scope_id, "bar", SymbolFlags::empty());
+
+        assert_ne!(symbol_id_1, symbol_id_2);
+    }
+
+    #[test]
+    fn add_child_scope_with_symbol() {
+        let mut builder = SymbolTableBuilder::new();
+        let root_scope_id = SymbolTable::root_scope_id();
+        let foo_symbol_top =
+            builder.add_or_update_symbol(root_scope_id, "foo", SymbolFlags::empty());
+        let c_scope = builder.add_child_scope(root_scope_id, "C", ScopeKind::Class, None, None);
+        let foo_symbol_inner = builder.add_or_update_symbol(c_scope, "foo", SymbolFlags::empty());
+
+        assert_ne!(foo_symbol_top, foo_symbol_inner);
+    }
+
+    #[test]
+    fn scope_from_id() {
+        let table = SymbolTableBuilder::new().finish();
+        let root_scope_id = SymbolTable::root_scope_id();
+        let scope = root_scope_id.scope(&table);
+
+        assert_eq!(scope.name.as_str(), "<module>");
+        assert_eq!(scope.kind, ScopeKind::Module);
+    }
+
+    #[test]
+    fn symbol_from_id() {
+        let mut builder = SymbolTableBuilder::new();
+        let root_scope_id = SymbolTable::root_scope_id();
+        let foo_symbol_id =
+            builder.add_or_update_symbol(root_scope_id, "foo", SymbolFlags::empty());
+        let table = builder.finish();
+        let symbol = foo_symbol_id.symbol(&table);
+
+        assert_eq!(symbol.name(), "foo");
+    }
+
+    #[test]
+    fn bigger_symbol_table() {
+        let mut builder = SymbolTableBuilder::new();
+        let root_scope_id = SymbolTable::root_scope_id();
+        let foo_symbol_id =
+            builder.add_or_update_symbol(root_scope_id, "foo", SymbolFlags::empty());
+        builder.add_or_update_symbol(root_scope_id, "bar", SymbolFlags::empty());
+        builder.add_or_update_symbol(root_scope_id, "baz", SymbolFlags::empty());
+        builder.add_or_update_symbol(root_scope_id, "qux", SymbolFlags::empty());
+        let table = builder.finish();
+
+        let foo_symbol_id_2 = table
+            .root_symbol_id_by_name("foo")
+            .expect("foo symbol to be found");
+
+        assert_eq!(foo_symbol_id_2, foo_symbol_id);
+    }
+}

--- a/crates/red_knot/src/salsa_db/semantic/types.rs
+++ b/crates/red_knot/src/salsa_db/semantic/types.rs
@@ -1,0 +1,736 @@
+use rustc_hash::FxHashMap;
+
+use ruff_index::{newtype_index, IndexVec};
+use ruff_python_ast::{
+    AstNode, StmtAnnAssign, StmtAssign, StmtClassDef, StmtFunctionDef, StmtImport, StmtImportFrom,
+};
+
+use crate::ast_ids::NodeKey;
+use crate::module::ModuleName;
+use crate::salsa_db::semantic::ast_ids::{
+    ast_ids, AnnotatedAssignmentId, AssignmentId, AstIdNode, ClassId, ExpressionId, FunctionId,
+};
+use crate::salsa_db::semantic::definition::{Definition, ImportDefinition, ImportFromDefinition};
+use crate::salsa_db::semantic::flow_graph::ReachableDefinition;
+use crate::salsa_db::semantic::module::resolve_module_name;
+use crate::salsa_db::semantic::symbol_table::{symbol_table, NodeWithScopeId, ScopeId, SymbolId};
+use crate::salsa_db::semantic::types::infer::infer_types;
+use crate::salsa_db::semantic::{
+    global_symbol_type, global_symbol_type_by_name, Db, GlobalId, GlobalSymbolId, Jar,
+};
+use crate::salsa_db::source::File;
+use crate::{FxIndexSet, Name};
+
+pub mod infer;
+
+#[salsa::tracked(jar=Jar, return_ref)]
+pub(crate) fn typing_scopes(db: &dyn Db, file: File) -> TypingScopes {
+    let ast_ids = ast_ids(db, file);
+
+    let functions = ast_ids
+        .functions()
+        .map(|(id, _)| (id, FunctionTypingScope::new(db, file, id)))
+        .collect();
+    let classes = ast_ids
+        .classes()
+        .map(|(id, _)| (id, ClassTypingScope::new(db, file, id)))
+        .collect();
+
+    TypingScopes { functions, classes }
+}
+
+#[salsa::tracked(jar=Jar)]
+pub struct FunctionTypingScope {
+    file: File,
+    #[id]
+    id: FunctionId,
+}
+
+impl FunctionTypingScope {
+    pub fn node(self, db: &dyn Db) -> &StmtFunctionDef {
+        StmtFunctionDef::lookup(db, self.file(db), self.id(db))
+    }
+}
+
+#[salsa::tracked(jar=Jar)]
+pub struct ClassTypingScope {
+    file: File,
+    #[id]
+    id: ClassId,
+}
+
+impl ClassTypingScope {
+    pub fn node(self, db: &dyn Db) -> &StmtClassDef {
+        StmtClassDef::lookup(db, self.file(db), self.id(db))
+    }
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub(crate) struct TypingScopes {
+    functions: FxHashMap<FunctionId, FunctionTypingScope>,
+    classes: FxHashMap<ClassId, ClassTypingScope>,
+}
+
+impl std::ops::Index<FunctionId> for TypingScopes {
+    type Output = FunctionTypingScope;
+
+    fn index(&self, index: FunctionId) -> &Self::Output {
+        &self.functions[&index]
+    }
+}
+
+impl std::ops::Index<ClassId> for TypingScopes {
+    type Output = ClassTypingScope;
+
+    fn index(&self, index: ClassId) -> &Self::Output {
+        &self.classes[&index]
+    }
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+pub enum TypingScope {
+    Function(FunctionTypingScope),
+    Class(ClassTypingScope),
+    Module(File),
+}
+
+impl TypingScope {
+    pub fn for_symbol(db: &dyn Db, symbol: GlobalSymbolId) -> TypingScope {
+        let symbols = symbol_table(db, symbol.file());
+        let scope = symbols.scope_id_of_symbol(symbol.local());
+
+        Self::for_symbol_scope(db, GlobalId::new(symbol.file(), scope))
+    }
+
+    pub fn for_expression(db: &dyn Db, expression_id: GlobalId<ExpressionId>) -> TypingScope {
+        let symbols = symbol_table(db, expression_id.file());
+
+        let expression_scope = symbols.scope_id_of_expression(expression_id.local());
+        TypingScope::for_symbol_scope(db, GlobalId::new(expression_id.file(), expression_scope))
+    }
+
+    fn for_symbol_scope(db: &dyn Db, scope_id: GlobalId<ScopeId>) -> TypingScope {
+        let typing_scopes = typing_scopes(db, scope_id.file());
+        let symbols = symbol_table(db, scope_id.file());
+        let scope = symbols.scope(scope_id.local());
+
+        let mut ancestors = std::iter::once((scope_id.local(), scope))
+            .chain(symbols.parent_scopes(scope_id.local()));
+
+        let typing_scope = ancestors.find_map(|(_, scope)| match scope.definition()? {
+            Definition::Function(function) => Some(typing_scopes[*function].into()),
+            Definition::Class(class) => Some(typing_scopes[*class].into()),
+            _ => None,
+        });
+        typing_scope.unwrap_or(TypingScope::Module(scope_id.file()))
+    }
+
+    fn file(self, db: &dyn Db) -> File {
+        match self {
+            TypingScope::Function(function) => function.file(db),
+            TypingScope::Class(class) => class.file(db),
+            TypingScope::Module(file) => file,
+        }
+    }
+}
+
+impl From<FunctionTypingScope> for TypingScope {
+    fn from(value: FunctionTypingScope) -> Self {
+        TypingScope::Function(value)
+    }
+}
+
+impl From<ClassTypingScope> for TypingScope {
+    fn from(value: ClassTypingScope) -> Self {
+        TypingScope::Class(value)
+    }
+}
+
+impl From<File> for TypingScope {
+    fn from(value: File) -> Self {
+        TypingScope::Module(value)
+    }
+}
+
+/// unique ID for a type
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+pub enum Type {
+    /// the dynamic or gradual type: a statically-unknown set of values
+    Any,
+    /// the empty set of values
+    Never,
+    /// unknown type (no annotation)
+    /// equivalent to Any, or to object in strict mode
+    Unknown,
+    /// name is not bound to any value
+    Unbound,
+    /// a specific function object
+    Function(GlobalTypeId<FunctionTypeId>),
+    // TODO should this be `ResolvedModule`? It would require that `ResolvedModule` is interned.
+    /// a specific module object
+    Module(GlobalTypeId<ModuleTypeId>),
+    /// a specific class object
+    Class(GlobalTypeId<ClassTypeId>),
+    /// the set of Python objects with the given class in their __class__'s method resolution order
+    Instance(GlobalTypeId<ClassTypeId>),
+    Union(GlobalTypeId<UnionTypeId>),
+    Intersection(GlobalTypeId<IntersectionTypeId>),
+    IntLiteral(i64),
+    // TODO protocols, callable types, overloads, generics, type vars
+}
+
+impl Type {
+    fn display<'a>(self, context: &'a TypingContext<'a>) -> DisplayType<'a> {
+        DisplayType { ty: self, context }
+    }
+
+    pub const fn is_unbound(&self) -> bool {
+        matches!(self, Type::Unbound)
+    }
+
+    pub const fn is_unknown(&self) -> bool {
+        matches!(self, Type::Unknown)
+    }
+
+    // FIXME: The main issue here is that `.member()` can call into `infer_module` or `infer_class`
+    //  which may be running right now. This is a problem because it can lead to cycles
+    pub fn member(&self, context: &TypingContext, name: &Name) -> Option<Type> {
+        match self {
+            Type::Any => todo!("attribute lookup on Any type"),
+            Type::Never => todo!("attribute lookup on Never type"),
+            Type::Unknown => todo!("attribute lookup on Unknown type"),
+            Type::Unbound => todo!("attribute lookup on Unbound type"),
+            Type::Function(_) => todo!("attribute lookup on Function type"),
+            Type::Module(module_id) => module_id.ty(context).member(context, name),
+            Type::Class(class_id) => class_id.ty(context).member(context, name),
+            Type::Instance(_) => {
+                // TODO MRO? get_own_instance_member, get_instance_member
+                todo!("attribute lookup on Instance type")
+            }
+            Type::Union(union_id) => {
+                let _union = union_id.ty(context);
+                // TODO perform the get_member on each type in the union
+                // TODO return the union of those results
+                // TODO if any of those results is `None` then include Unknown in the result union
+                todo!("attribute lookup on Union type")
+            }
+            Type::Intersection(_) => {
+                // TODO perform the get_member on each type in the intersection
+                // TODO return the intersection of those results
+                todo!("attribute lookup on Intersection type")
+            }
+            Type::IntLiteral(_) => {
+                // TODO raise error
+                Some(Type::Unknown)
+            }
+        }
+    }
+}
+
+#[derive(Copy, Clone)]
+struct DisplayType<'a> {
+    ty: Type,
+    context: &'a TypingContext<'a>,
+}
+
+impl std::fmt::Display for DisplayType<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.ty {
+            Type::Any => f.write_str("Any"),
+            Type::Never => f.write_str("Never"),
+            Type::Unknown => f.write_str("Unknown"),
+            Type::Unbound => f.write_str("Unbound"),
+            Type::Module(module_id) => {
+                // NOTE: something like this?: "<module 'module-name' from 'path-from-fileid'>"
+                todo!("{module_id:?}")
+            }
+            // TODO functions and classes should display using a fully qualified name
+            Type::Class(class_id) => {
+                f.write_str("Literal[")?;
+                f.write_str(class_id.ty(self.context).name())?;
+                f.write_str("]")
+            }
+            Type::Instance(class_id) => f.write_str(class_id.ty(self.context).name()),
+            Type::Function(func_id) => f.write_str(func_id.ty(self.context).name()),
+            Type::Union(union_id) => union_id.ty(self.context).display(f, self.context),
+            Type::Intersection(int_id) => int_id.ty(self.context).display(f, self.context),
+            Type::IntLiteral(n) => write!(f, "Literal[{n}]"),
+        }
+    }
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+pub struct GlobalTypeId<T>
+where
+    T: LocalTypeId,
+{
+    scope: TypingScope,
+    local_id: T,
+}
+
+impl<T: LocalTypeId> GlobalTypeId<T> {
+    pub fn new(scope: TypingScope, local_id: T) -> Self {
+        Self { scope, local_id }
+    }
+
+    fn scope(&self) -> TypingScope {
+        self.scope
+    }
+
+    fn local_id(&self) -> T {
+        self.local_id
+    }
+
+    fn ty<'a>(&self, context: &TypingContext<'a>) -> &'a T::Ty {
+        let types = context.types(self.scope());
+
+        self.local_id.ty(&types)
+    }
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+pub struct ModuleTypeId;
+
+impl LocalTypeId for ModuleTypeId {
+    type Ty = ModuleType;
+
+    fn ty<'a>(&self, types: &'a TypeInference) -> &'a Self::Ty {
+        types.module.as_ref().unwrap()
+    }
+
+    fn intern(ty: Self::Ty, types: &mut TypeInference) -> Self {
+        assert_eq!(types.module.as_ref(), None);
+        types.module = Some(ty);
+
+        ModuleTypeId
+    }
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub struct ModuleType {
+    file: File,
+}
+
+impl ModuleType {
+    fn new(file: File) -> Self {
+        Self { file }
+    }
+
+    fn member(&self, context: &TypingContext, name: &Name) -> Option<Type> {
+        let symbol_table = symbol_table(context.db, self.scope().file(context.db));
+        let symbol_id = symbol_table.root_symbol_id_by_name(name)?;
+
+        Some(global_symbol_type(
+            context.db,
+            GlobalSymbolId::new(self.file, symbol_id),
+        ))
+    }
+
+    fn scope(&self) -> TypingScope {
+        self.file.into()
+    }
+}
+
+#[newtype_index]
+pub struct FunctionTypeId;
+
+impl LocalTypeId for FunctionTypeId {
+    type Ty = FunctionType;
+
+    fn ty<'a>(&self, types: &'a TypeInference) -> &'a Self::Ty {
+        &types.functions[*self]
+    }
+
+    fn intern(ty: Self::Ty, types: &mut TypeInference) -> Self {
+        types.functions.push(ty)
+    }
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub struct FunctionType {
+    /// name of the function at definition
+    name: Name,
+    /// types of all decorators on this function
+    decorators: Vec<Type>,
+
+    typing_scope: FunctionTypingScope,
+}
+
+impl FunctionType {
+    fn name(&self) -> &str {
+        self.name.as_str()
+    }
+
+    pub(crate) fn decorators(&self) -> &[Type] {
+        self.decorators.as_slice()
+    }
+}
+
+#[newtype_index]
+pub struct ClassTypeId;
+
+impl LocalTypeId for ClassTypeId {
+    type Ty = ClassType;
+
+    fn ty<'a>(&self, types: &'a TypeInference) -> &'a Self::Ty {
+        &types.classes[*self]
+    }
+
+    fn intern(ty: Self::Ty, types: &mut TypeInference) -> Self {
+        types.classes.push(ty)
+    }
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub struct ClassType {
+    /// Name of the class at definition
+    name: Name,
+
+    /// Types of all class bases
+    bases: Vec<Type>,
+
+    typing_scope: ClassTypingScope,
+}
+
+impl ClassType {
+    fn name(&self) -> &str {
+        self.name.as_str()
+    }
+
+    fn bases(&self) -> &[Type] {
+        self.bases.as_slice()
+    }
+
+    pub fn member(&self, context: &TypingContext, name: &Name) -> Option<Type> {
+        let file = self.typing_scope.file(context.db());
+        let symbol_table = symbol_table(context.db(), file);
+        let scope_id = symbol_table
+            .scope_id_for_node(NodeWithScopeId::Class(self.typing_scope.id(context.db())));
+
+        let symbol_id = symbol_table.symbol_id_by_name(scope_id, name)?;
+
+        Some(global_symbol_type(
+            context.db,
+            GlobalSymbolId::new(file, symbol_id),
+        ))
+    }
+}
+
+#[newtype_index]
+pub struct UnionTypeId;
+
+impl LocalTypeId for UnionTypeId {
+    type Ty = UnionType;
+
+    fn ty<'a>(&self, types: &'a TypeInference) -> &'a Self::Ty {
+        &types.unions[*self]
+    }
+
+    fn intern(ty: Self::Ty, types: &mut TypeInference) -> Self {
+        types.unions.push(ty)
+    }
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub struct UnionType {
+    // the union type includes values in any of these types
+    elements: FxIndexSet<Type>,
+}
+
+impl UnionType {
+    fn display(
+        &self,
+        f: &mut std::fmt::Formatter<'_>,
+        context: &TypingContext,
+    ) -> std::fmt::Result {
+        f.write_str("(")?;
+        let mut first = true;
+        for ty in &self.elements {
+            if !first {
+                f.write_str(" | ")?;
+            };
+            first = false;
+            write!(f, "{}", ty.display(context))?;
+        }
+        f.write_str(")")
+    }
+}
+
+#[newtype_index]
+pub struct IntersectionTypeId;
+
+impl LocalTypeId for IntersectionTypeId {
+    type Ty = IntersectionType;
+
+    fn ty<'a>(&self, types: &'a TypeInference) -> &'a Self::Ty {
+        &types.intersections[*self]
+    }
+
+    fn intern(ty: Self::Ty, types: &mut TypeInference) -> Self {
+        types.intersections.push(ty)
+    }
+}
+
+// Negation types aren't expressible in annotations, and are most likely to arise from type
+// narrowing along with intersections (e.g. `if not isinstance(...)`), so we represent them
+// directly in intersections rather than as a separate type. This sacrifices some efficiency in the
+// case where a Not appears outside an intersection (unclear when that could even happen, but we'd
+// have to represent it as a single-element intersection if it did) in exchange for better
+// efficiency in the within-intersection case.
+#[derive(Debug, Eq, PartialEq)]
+pub struct IntersectionType {
+    // the intersection type includes only values in all of these types
+    positive: FxIndexSet<Type>,
+    // the intersection type does not include any value in any of these types
+    negative: FxIndexSet<Type>,
+}
+
+impl IntersectionType {
+    fn display(
+        &self,
+        f: &mut std::fmt::Formatter<'_>,
+        context: &TypingContext,
+    ) -> std::fmt::Result {
+        f.write_str("(")?;
+        let mut first = true;
+        for (neg, ty) in self
+            .positive
+            .iter()
+            .map(|ty| (false, ty))
+            .chain(self.negative.iter().map(|ty| (true, ty)))
+        {
+            if !first {
+                f.write_str(" & ")?;
+            };
+            first = false;
+            if neg {
+                f.write_str("~")?;
+            };
+            write!(f, "{}", ty.display(context))?;
+        }
+        f.write_str(")")
+    }
+}
+
+pub trait LocalTypeId: Copy {
+    type Ty;
+
+    /// Resolves the type of the data from `types_store`
+    ///
+    /// ## Panics
+    /// May panic if `self` is from another scope than `types_store` or returns an invalid type.
+    fn ty<'a>(&self, types: &'a TypeInference) -> &'a Self::Ty;
+
+    fn intern(ty: Self::Ty, types: &mut TypeInference) -> Self;
+}
+
+pub struct TypingContext<'a> {
+    db: &'a dyn Db,
+    local: Option<(TypingScope, &'a TypeInference)>,
+}
+
+impl<'a> TypingContext<'a> {
+    pub fn local(db: &'a dyn Db, local_scope: TypingScope, types: &'a TypeInference) -> Self {
+        Self {
+            db,
+            local: Some((local_scope, types)),
+        }
+    }
+
+    pub fn global(db: &'a dyn Db) -> Self {
+        Self { db, local: None }
+    }
+
+    pub fn db(&self) -> &'a dyn Db {
+        self.db
+    }
+
+    pub fn types(&self, scope: TypingScope) -> &'a TypeInference {
+        if let Some((local_scope, types)) = self.local {
+            if local_scope == scope {
+                return types;
+            }
+        }
+
+        infer_types(self.db, scope)
+    }
+
+    fn infer_definitions(
+        &self,
+        mut definitions: impl Iterator<Item = ReachableDefinition>,
+        symbol_scope: GlobalId<ScopeId>,
+    ) -> DefinitionType {
+        let Some(first) = definitions.next() else {
+            return DefinitionType::Type(Type::Unknown);
+        };
+
+        let typing_scope = TypingScope::for_symbol_scope(self.db(), symbol_scope);
+        let types = self.types(typing_scope);
+
+        if let Some(second) = definitions.next() {
+            let elements: FxIndexSet<_> = [first, second]
+                .into_iter()
+                .chain(definitions)
+                .map(|definition| self.infer_definition(definition, types, symbol_scope.file()))
+                .collect();
+
+            // The fact that the interner is local to a body means that we can't reuse the same union type
+            // across different call sites. But that's something we aren't doing yet anyway. Our interner doesn't
+            // deduplicate union types that are identical.
+            DefinitionType::Union {
+                ty: UnionType { elements },
+                scope: typing_scope,
+            }
+        } else {
+            DefinitionType::Type(self.infer_definition(first, types, symbol_scope.file()))
+        }
+    }
+
+    /// Infers the type of a location definition.
+    fn infer_definition(
+        &self,
+        definition: ReachableDefinition,
+        definition_types: &TypeInference,
+        file: File,
+    ) -> Type {
+        let ReachableDefinition::Definition(definition) = definition else {
+            return Type::Unbound;
+        };
+
+        // FIXME
+        //   Uff, how to get back to the type inference scope from a definition?
+        //   because the definition could be from the outside scope
+        let node = match definition {
+            Definition::Import(ImportDefinition { import, name }) => {
+                let import = StmtImport::lookup(self.db, file, import);
+                let name = &import.names[name as usize];
+
+                return if let Some(module) =
+                    resolve_module_name(self.db, ModuleName::new(&name.name))
+                {
+                    // TODO: It feels hacky to resolve the module ID out of the blue like this.
+                    Type::Module(GlobalTypeId::new(
+                        TypingScope::Module(module.file()),
+                        ModuleTypeId,
+                    ))
+                } else {
+                    Type::Unknown
+                };
+            }
+            Definition::ImportFrom(ImportFromDefinition { import, name }) => {
+                let import = StmtImportFrom::lookup(self.db, file, import);
+                let name = &import.names[name as usize];
+
+                // TODO relative imports
+                assert!(matches!(import.level, 0));
+                let module_name = import.module.as_ref().expect("TODO relative imports");
+                let Some(module) = resolve_module_name(self.db, ModuleName::new(module_name))
+                else {
+                    return Type::Unknown;
+                };
+
+                return global_symbol_type_by_name(self.db, module.file(), &name.name)
+                    .unwrap_or(Type::Unknown);
+            }
+            Definition::Function(function) => function.into(),
+            Definition::Class(class) => class.into(),
+            Definition::Assignment(assignment) => assignment.into(),
+            Definition::AnnotatedAssignment(assignment) => assignment.into(),
+        };
+
+        definition_types
+            .local_definitions
+            .get(&node)
+            .copied()
+            .unwrap_or(Type::Unbound)
+    }
+}
+
+#[derive(Debug, Eq, PartialEq, Default)]
+pub struct TypeInference {
+    module: Option<ModuleType>,
+    functions: IndexVec<FunctionTypeId, FunctionType>,
+    classes: IndexVec<ClassTypeId, ClassType>,
+    unions: IndexVec<UnionTypeId, UnionType>,
+    intersections: IndexVec<IntersectionTypeId, IntersectionType>,
+
+    local_definitions: FxHashMap<LocalDefinitionKey, Type>,
+    public_symbol_types: FxHashMap<SymbolId, Type>,
+    expression_types: FxHashMap<ExpressionId, Type>,
+}
+
+impl TypeInference {
+    fn shrink_to_fit(&mut self) {
+        self.functions.shrink_to_fit();
+        self.classes.shrink_to_fit();
+        self.unions.shrink_to_fit();
+        self.intersections.shrink_to_fit();
+
+        self.public_symbol_types.shrink_to_fit();
+        self.expression_types.shrink_to_fit();
+        self.local_definitions.shrink_to_fit();
+    }
+
+    pub fn symbol_ty(&self, id: SymbolId) -> Type {
+        self.public_symbol_types
+            .get(&id)
+            .copied()
+            .unwrap_or(Type::Unknown)
+    }
+
+    pub fn expression_ty(&self, id: ExpressionId) -> Type {
+        self.expression_types
+            .get(&id)
+            .copied()
+            .unwrap_or(Type::Unknown)
+    }
+}
+
+enum DefinitionType {
+    Union { ty: UnionType, scope: TypingScope },
+    Type(Type),
+}
+
+impl DefinitionType {
+    fn into_type(self, types: &mut TypeInference) -> Type {
+        match self {
+            DefinitionType::Union { ty, scope } => {
+                let union_id = UnionTypeId::intern(ty, types);
+                Type::Union(GlobalTypeId::new(scope, union_id))
+            }
+            DefinitionType::Type(ty) => ty,
+        }
+    }
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+enum LocalDefinitionKey {
+    Function(FunctionId),
+    Class(ClassId),
+    Assignment(AssignmentId),
+    AnnotatedAssignmentId(AnnotatedAssignmentId),
+}
+
+impl From<FunctionId> for LocalDefinitionKey {
+    fn from(value: FunctionId) -> Self {
+        Self::Function(value)
+    }
+}
+
+impl From<ClassId> for LocalDefinitionKey {
+    fn from(value: ClassId) -> Self {
+        Self::Class(value)
+    }
+}
+
+impl From<AssignmentId> for LocalDefinitionKey {
+    fn from(value: AssignmentId) -> Self {
+        Self::Assignment(value)
+    }
+}
+
+impl From<AnnotatedAssignmentId> for LocalDefinitionKey {
+    fn from(value: AnnotatedAssignmentId) -> Self {
+        Self::AnnotatedAssignmentId(value)
+    }
+}

--- a/crates/red_knot/src/salsa_db/semantic/types/infer.rs
+++ b/crates/red_knot/src/salsa_db/semantic/types/infer.rs
@@ -1,0 +1,343 @@
+use std::sync::Arc;
+
+use ruff_python_ast::visitor::Visitor;
+use ruff_python_ast::{
+    visitor, Expr, ExprAttribute, ExprNumberLiteral, ModModule, Number, Stmt, StmtAnnAssign,
+    StmtAssign, StmtClassDef, StmtFunctionDef, StmtImport, StmtImportFrom,
+};
+
+use crate::ast_ids::NodeKey;
+use crate::salsa_db::semantic::ast_ids::{AstIdNode, ExpressionId};
+use crate::salsa_db::semantic::flow_graph::{flow_graph, FlowGraph, ReachableDefinition};
+use crate::salsa_db::semantic::symbol_table::{
+    symbol_table, NodeWithScopeId, ScopeId, SymbolTable,
+};
+use crate::salsa_db::semantic::types::{
+    typing_scopes, ClassType, ClassTypeId, ClassTypingScope, FunctionType, FunctionTypeId,
+    FunctionTypingScope, GlobalTypeId, LocalTypeId, ModuleType, Type, TypeInference, TypingContext,
+    TypingScope, TypingScopes,
+};
+use crate::salsa_db::semantic::{Db, GlobalId, Jar};
+use crate::salsa_db::source::{parse, File};
+use crate::Name;
+
+pub fn infer_expression_type(db: &dyn Db, expression_id: GlobalId<ExpressionId>) -> Type {
+    let typing_scope = TypingScope::for_expression(db, expression_id);
+    let types = infer_types(db, typing_scope);
+
+    types.expression_ty(expression_id.local())
+}
+
+pub fn infer_types(db: &dyn Db, scope: TypingScope) -> &TypeInference {
+    match scope {
+        TypingScope::Function(function) => infer_function_body(db, function),
+        TypingScope::Class(class) => infer_class_body(db, class),
+        TypingScope::Module(file) => infer_module_body(db, file),
+    }
+}
+
+#[salsa::tracked(jar=Jar, return_ref)]
+pub fn infer_function_body(db: &dyn Db, scope: FunctionTypingScope) -> TypeInference {
+    let function = scope.node(db);
+
+    let mut builder = TypeInferenceBuilder::new(db, scope.into());
+    builder.lower_function_body(&function);
+    builder.finish()
+}
+
+#[salsa::tracked(jar=Jar, return_ref)]
+pub fn infer_class_body(db: &dyn Db, scope: ClassTypingScope) -> TypeInference {
+    let class = scope.node(db);
+
+    let mut builder = TypeInferenceBuilder::new(db, scope.into());
+    builder.lower_class_body(&class);
+    builder.finish()
+}
+
+#[salsa::tracked(jar=Jar, return_ref)]
+pub fn infer_module_body(db: &dyn Db, file: File) -> TypeInference {
+    let parsed = parse(db.upcast(), file);
+
+    let mut builder = TypeInferenceBuilder::new(db, file.into());
+    builder.lower_module(&parsed.syntax());
+    dbg!(builder.finish())
+}
+
+struct TypeInferenceBuilder<'a> {
+    db: &'a dyn Db,
+    typing_scope: TypingScope,
+    file: File,
+    enclosing_scope: ScopeId,
+
+    symbol_table: Arc<SymbolTable>,
+    control_flow_graph: Arc<FlowGraph>,
+    typing_scopes: &'a TypingScopes,
+
+    // TODO: This is going to be somewhat slow because we need to map the AST node to the expression id for
+    //   every expression in the body. That's a lot of hash map lookups.
+    //  We can't use an `IndexVec` here because a) expression ids are per module and b) the type inference
+    //  builder visits the expressions in evaluation order and not in pre-order.
+    result: TypeInference,
+}
+
+impl<'a> TypeInferenceBuilder<'a> {
+    fn new(db: &'a dyn Db, scope: TypingScope) -> Self {
+        let file = scope.file(db);
+        let symbol_table = symbol_table(db, file);
+        let control_flow_graph = flow_graph(db, file);
+
+        let symbol_scope = match scope {
+            TypingScope::Function(function) => {
+                symbol_table.scope_id_for_node(NodeWithScopeId::Function(function.id(db)))
+            }
+            TypingScope::Class(class) => {
+                symbol_table.scope_id_for_node(NodeWithScopeId::Class(class.id(db)))
+            }
+            TypingScope::Module(file) => SymbolTable::root_scope_id(),
+        };
+
+        let builder = TypeInferenceBuilder {
+            db,
+            typing_scope: scope,
+            file,
+            enclosing_scope: symbol_scope,
+
+            symbol_table,
+            control_flow_graph,
+            typing_scopes: typing_scopes(db, file),
+
+            result: TypeInference::default(),
+        };
+        builder
+    }
+
+    fn typing_context(&self) -> TypingContext {
+        TypingContext::local(self.db, self.typing_scope, &self.result)
+    }
+
+    fn lower_module(&mut self, module: &ModModule) {
+        self.result.module = Some(ModuleType::new(self.typing_scope.file(self.db)));
+
+        self.visit_body(&module.body);
+    }
+
+    fn lower_class_body(&mut self, class: &StmtClassDef) {
+        self.visit_body(&class.body);
+    }
+
+    fn lower_function_body(&mut self, function: &StmtFunctionDef) {
+        self.visit_body(&function.body);
+    }
+
+    fn lower_import(&mut self, _import: &StmtImport) {
+
+        // No op, handled inside of `infer_definition`
+    }
+
+    fn lower_import_from(&mut self, _import_from: &StmtImportFrom) {
+        // no-op handled inside of `infer_definition`
+    }
+
+    fn lower_class_definition(&mut self, class_def: &StmtClassDef) {
+        let bases = class_def
+            .bases()
+            .iter()
+            .map(|base| self.infer_expression(base))
+            .collect();
+
+        let class_id = class_def.ast_id(self.db, self.file);
+
+        // TODO decorators
+
+        let class_type = ClassTypeId::intern(
+            ClassType {
+                name: Name::new(&class_def.name.id),
+                bases,
+                typing_scope: self.typing_scopes[class_id],
+            },
+            &mut self.result,
+        );
+
+        let ty = Type::Class(GlobalTypeId::new(self.typing_scope, class_type));
+
+        self.result.local_definitions.insert(class_id.into(), ty);
+    }
+
+    fn lower_function_definition(&mut self, function_def: &StmtFunctionDef) {
+        let decorators = function_def
+            .decorator_list
+            .iter()
+            .map(|decorator| self.infer_expression(&decorator.expression))
+            .collect();
+
+        // TODO lower parameters, return type, etc.
+
+        let function_id = function_def.ast_id(self.db, self.file);
+        let function_type = FunctionTypeId::intern(
+            FunctionType {
+                name: Name::new(&function_def.name.id),
+                typing_scope: self.typing_scopes[function_id],
+                decorators,
+            },
+            &mut self.result,
+        );
+
+        self.result.local_definitions.insert(
+            function_id.into(),
+            Type::Function(GlobalTypeId::new(self.typing_scope, function_type)),
+        );
+    }
+
+    fn lower_assignment(&mut self, assignment: &StmtAssign) {
+        let value_ty = self.infer_expression(&assignment.value);
+
+        for target in &assignment.targets {
+            self.result
+                .expression_types
+                .insert(target.ast_id(self.db, self.file), value_ty);
+        }
+
+        let assignment_id = assignment.ast_id(self.db, self.file);
+        self.result
+            .local_definitions
+            .insert(assignment_id.into(), value_ty);
+    }
+
+    fn lower_annotated_assignment(&mut self, assignment: &StmtAnnAssign) {
+        // TODO actually look at the annotation
+        let value_ty = if let Some(value) = &assignment.value {
+            self.infer_expression(value)
+        } else {
+            Type::Unknown
+        };
+
+        self.result
+            .expression_types
+            .insert(assignment.target.ast_id(self.db, self.file), value_ty);
+
+        let assignment_id = assignment.ast_id(self.db, self.file);
+
+        self.result
+            .local_definitions
+            .insert(assignment_id.into(), value_ty);
+    }
+
+    fn infer_expression(&mut self, expr: &Expr) -> Type {
+        let id = expr.ast_id(self.db, self.file);
+
+        let ty = match expr {
+            Expr::NumberLiteral(ExprNumberLiteral { value, .. }) => {
+                match value {
+                    Number::Int(n) => {
+                        // TODO support big int literals
+                        n.as_i64().map(Type::IntLiteral).unwrap_or(Type::Unknown)
+                    }
+                    // TODO builtins.float or builtins.complex
+                    _ => Type::Unknown,
+                }
+            }
+            Expr::Name(name) => {
+                let Some((scope, symbol)) = self
+                    .symbol_table
+                    .ancestors(self.enclosing_scope)
+                    .find_map(|(scope_id, _)| {
+                        Some((
+                            scope_id,
+                            self.symbol_table.symbol_id_by_name(scope_id, &name.id)?,
+                        ))
+                    })
+                else {
+                    return Type::Unknown;
+                };
+
+                let definition_type = self.typing_context().infer_definitions(
+                    self.control_flow_graph.reachable_definitions(symbol, id),
+                    GlobalId::new(self.file, scope),
+                );
+
+                definition_type.into_type(&mut self.result)
+            }
+            Expr::Attribute(ExprAttribute { value, attr, .. }) => {
+                let value_type = self.infer_expression(value);
+                let attr_name = &Name::new(&attr.id);
+                value_type
+                    .member(&self.typing_context(), attr_name)
+                    .unwrap_or(Type::Unknown)
+            }
+            _ => todo!("full expression type resolution"),
+        };
+
+        let existing = self.result.expression_types.insert(id, ty);
+        debug_assert_eq!(existing, None);
+
+        ty
+    }
+
+    fn finish(mut self) -> TypeInference {
+        let symbol_table = &self.symbol_table;
+        let mut public_symbol_types = std::mem::take(&mut self.result.public_symbol_types);
+
+        for symbol in symbol_table.symbol_ids_for_scope(self.enclosing_scope) {
+            let definition_type = self.typing_context().infer_definitions(
+                symbol_table
+                    .definitions(symbol)
+                    .iter()
+                    .map(|definition| ReachableDefinition::Definition(*definition)),
+                GlobalId::new(self.file, self.enclosing_scope),
+            );
+
+            public_symbol_types.insert(symbol, definition_type.into_type(&mut self.result));
+        }
+
+        self.result.public_symbol_types = public_symbol_types;
+        self.result.shrink_to_fit();
+
+        self.result
+    }
+}
+
+impl Visitor<'_> for TypeInferenceBuilder<'_> {
+    fn visit_stmt(&mut self, stmt: &Stmt) {
+        match stmt {
+            Stmt::FunctionDef(function_def) => {
+                self.lower_function_definition(function_def);
+            }
+            Stmt::ClassDef(class_def) => {
+                self.lower_class_definition(class_def);
+            }
+            Stmt::Assign(assignment) => self.lower_assignment(assignment),
+
+            Stmt::AnnAssign(assignment) => self.lower_annotated_assignment(assignment),
+            Stmt::Return(_) | Stmt::Delete(_) | Stmt::AugAssign(_) => {}
+            Stmt::Expr(expression) => {
+                self.infer_expression(&expression.value);
+            }
+            Stmt::Import(import) => self.lower_import(import),
+            Stmt::ImportFrom(import_from) => self.lower_import_from(import_from),
+
+            Stmt::TypeAlias(_)
+            | Stmt::For(_)
+            | Stmt::While(_)
+            | Stmt::If(_)
+            | Stmt::With(_)
+            | Stmt::Match(_)
+            | Stmt::Raise(_)
+            | Stmt::Try(_)
+            | Stmt::Assert(_)
+            | Stmt::Global(_)
+            | Stmt::Nonlocal(_)
+            | Stmt::Pass(_)
+            | Stmt::Break(_)
+            | Stmt::Continue(_)
+            | Stmt::IpyEscapeCommand(_) => {
+                visitor::walk_stmt(self, stmt);
+            }
+        }
+    }
+
+    fn visit_expr(&mut self, expr: &Expr) {
+        self.infer_expression(expr);
+
+        // No need to walk the expression here because the type inference will do the walking itself.
+    }
+}

--- a/crates/red_knot/src/salsa_db/source.rs
+++ b/crates/red_knot/src/salsa_db/source.rs
@@ -1,0 +1,253 @@
+use std::fmt::Formatter;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use countme::Count;
+use dashmap::mapref::entry::Entry;
+use filetime::FileTime;
+
+use ruff_python_ast::{Mod, ModModule, Stmt, StmtExpr};
+use ruff_python_parser::Mode;
+use ruff_text_size::{Ranged, TextRange};
+
+use crate::FxDashMap;
+
+/// A file can be considered unchanged for as long as it has the same revision.
+///
+/// The value of the revision itself has no meaning other than to encode the version of the file.
+/// Therefore, it's not possible to identify which revision is newer by comparing the values.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum FileRevision {
+    LastModified(FileTime),
+    #[allow(unused)]
+    ContentHash(u128),
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+pub enum FileStatus {
+    Exists,
+    /// The file was deleted, didn't exist to begin with or the path isn't a file.
+    Deleted,
+}
+
+#[salsa::input(jar=Jar)]
+pub struct File {
+    #[return_ref]
+    pub path: PathBuf,
+
+    pub permissions: u32,
+
+    pub revision: FileRevision,
+
+    pub status: FileStatus,
+
+    #[allow(unused)]
+    count: Count<File>,
+}
+
+impl File {
+    /// Updates the metadata of the file.
+    #[tracing::instrument(level = "debug", skip(db))]
+    pub fn touch(self, db: &mut dyn Db) {
+        let path = self.path(db);
+
+        if let Ok(metadata) = path.metadata() {
+            let last_modified = FileTime::from_last_modification_time(&metadata);
+            #[cfg(unix)]
+            let permissions = if cfg!(unix) {
+                use std::os::unix::fs::PermissionsExt;
+                metadata.permissions().mode()
+            } else {
+                0
+            };
+
+            self.set_revision(db)
+                .to(FileRevision::LastModified(last_modified));
+            self.set_permissions(db).to(permissions);
+            self.set_status(db).to(FileStatus::Exists);
+        } else {
+            self.delete(db);
+        }
+    }
+
+    pub fn delete(self, db: &mut dyn Db) {
+        self.set_status(db).to(FileStatus::Deleted);
+        self.set_permissions(db).to(0);
+        self.set_revision(db)
+            .to(FileRevision::LastModified(FileTime::zero()));
+    }
+
+    pub fn exists(self, db: &dyn Db) -> bool {
+        self.status(db) == FileStatus::Exists
+    }
+}
+
+#[salsa::tracked(jar=Jar)]
+impl File {
+    #[salsa::tracked]
+    pub fn source(self, db: &dyn Db) -> SourceText {
+        // Read the revision to force a re-run of this query when the file gets updated.
+        let _ = self.revision(db);
+        let text = std::fs::read_to_string(self.path(db)).unwrap_or_default();
+
+        SourceText {
+            text: Arc::from(text),
+            count: Count::default(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct Files {
+    inner: Arc<FilesInner>,
+}
+
+impl Files {
+    pub(super) fn resolve(&self, db: &dyn Db, path: PathBuf) -> File {
+        match self.inner.by_path.entry(path.clone()) {
+            Entry::Occupied(entry) => {
+                let file = entry.get();
+                *file
+            }
+            Entry::Vacant(entry) => {
+                let metadata = path.metadata();
+
+                let file = if let Ok(metadata) = metadata {
+                    let (last_modified, permissions, file_status) = if metadata.is_file() {
+                        let last_modified = FileTime::from_last_modification_time(&metadata);
+                        #[cfg(unix)]
+                        let permissions = if cfg!(unix) {
+                            use std::os::unix::fs::PermissionsExt;
+                            metadata.permissions().mode()
+                        } else {
+                            0
+                        };
+
+                        (last_modified, permissions, FileStatus::Exists)
+                    } else {
+                        (FileTime::zero(), 0, FileStatus::Deleted)
+                    };
+
+                    File::new(
+                        db,
+                        path,
+                        permissions,
+                        FileRevision::LastModified(last_modified),
+                        file_status,
+                        Count::default(),
+                    )
+                } else {
+                    File::new(
+                        db,
+                        path,
+                        0,
+                        FileRevision::LastModified(FileTime::zero()),
+                        FileStatus::Deleted,
+                        Count::default(),
+                    )
+                };
+
+                // TODO: Set a higher durability for std files.
+
+                entry.insert(file);
+
+                file
+            }
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+struct FilesInner {
+    by_path: FxDashMap<PathBuf, File>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct SourceText {
+    pub text: Arc<str>,
+    count: Count<SourceText>,
+}
+
+impl SourceText {
+    pub fn text(&self) -> &str {
+        &self.text
+    }
+}
+
+#[derive(Clone, PartialEq)]
+pub struct Parsed {
+    inner: Arc<ParsedInner>,
+}
+
+impl Parsed {
+    pub fn ast(&self) -> &ModModule {
+        &self.inner.ast
+    }
+
+    #[allow(unused)]
+    pub fn errors(&self) -> &[ruff_python_parser::ParseError] {
+        &self.inner.errors
+    }
+}
+
+impl std::fmt::Debug for Parsed {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Parsed")
+            .field("ast", &self.inner.ast)
+            .field("errors", &self.inner.errors)
+            .finish()
+    }
+}
+
+#[derive(Debug, PartialEq)]
+struct ParsedInner {
+    // TODO should this be an arc to avoid some lifetime awkwardness for call-sites.
+    pub ast: ModModule,
+
+    // TODO use an accumulator for this?
+    pub errors: Vec<ruff_python_parser::ParseError>,
+}
+
+#[tracing::instrument(level = "debug", skip(db))]
+#[salsa::tracked(jar=Jar, no_eq)]
+pub fn parse(db: &dyn Db, file: File) -> Parsed {
+    let source = file.source(db);
+    let text = source.text();
+
+    let result = ruff_python_parser::parse(text, Mode::Module);
+
+    let (module, errors) = match result {
+        Ok(Mod::Module(module)) => (module, vec![]),
+        Ok(Mod::Expression(expression)) => (
+            ModModule {
+                range: expression.range(),
+                body: vec![Stmt::Expr(StmtExpr {
+                    range: expression.range(),
+                    value: expression.body,
+                })],
+            },
+            vec![],
+        ),
+        Err(errors) => (
+            ModModule {
+                range: TextRange::default(),
+                body: Vec::new(),
+            },
+            vec![errors],
+        ),
+    };
+
+    Parsed {
+        inner: Arc::new(ParsedInner {
+            ast: module,
+            errors,
+        }),
+    }
+}
+
+#[salsa::jar(db=Db)]
+pub struct Jar(File, File_source, parse);
+
+pub trait Db: salsa::DbWithJar<Jar> {
+    fn file(&self, path: PathBuf) -> File;
+}

--- a/crates/ruff_index/src/vec.rs
+++ b/crates/ruff_index/src/vec.rs
@@ -69,6 +69,10 @@ impl<I: Idx, T> IndexVec<I, T> {
     pub fn next_index(&self) -> I {
         I::new(self.raw.len())
     }
+
+    pub fn shrink_to_fit(&mut self) {
+        self.raw.shrink_to_fit();
+    }
 }
 
 impl<I, T> Debug for IndexVec<I, T>


### PR DESCRIPTION
This is a prototype that uses Salsa for our red-knot prototype :laughing: 

The PR implements cross-module type inference invalidation based on Salsa. What makes this hard is that 

1. Salsa query arguments need to be ingredients. That means we can no longer pass arbitrary arguments to queries. 
2. Salsa limits invalidation if the result of a query compares equal to the value it returned previously. We need to remodel our query return values to make best use of that and avoid that e.g. all types invalidate on a single whitespace change (the thing we return from types should be location-independent


I'll go through the important data models jar by jar. 


## Source

The source jar gives access to files, the text of a file, and a file's AST.

**File**

https://github.com/astral-sh/ruff/blob/946493cc301c6a5cee8389bcbdb141bcfbeaba4a/crates/red_knot/src/salsa_db/source.rs#L31-L44

The file stores the basic metadata about a file but doesn't store the file's content. This is mainly because of persistent caching. Restoring the database from disk requires that we restore all files. If the source is stored on the file, we would have to read the content of every file, and that would be very expensive (we want the source validation to happen lazily). That's why the file only stores basic metadata. 

Note: We may decide long-term to have a configuration option that allows users to select if they want to use `mtime` or the file's has for change detection. In that case, I think we would have a `source: Option<String>` on file so that the `source_text` query avoids re-reading the file from disk. 

Files are salsa inputs. Salsa doesn't know how to compute files. Instead, we need to tell salsa which files exist and when they change. That's why files are resolved using `db.file(path)` where we perform our own mapping from `Path -> File` (Salsa inputs have no identity other than their instance).


**`SourceText`**

The `source_text(file: File) -> SourceText` query allows retrieving a file's source text. The source text isn't very exciting. It just stores the file's content. 

https://github.com/astral-sh/ruff/blob/946493cc301c6a5cee8389bcbdb141bcfbeaba4a/crates/red_knot/src/salsa_db/source.rs#L163-L167

Some notes about the implementation:

* The query calls `file.revision()` (equal to the file's `mtime`) to inform Salsa that the query should rerun whenever the file is modified. It actually doesn't need the value. 
* It might happen that the file has been deleted between calling `db.file(path)` and `source_text(db, file)`. In that case, we just assume that the file is empty. That's the best we can do without dealing with awkward results in all caller paths. 


**`parse`**

https://github.com/astral-sh/ruff/blob/946493cc301c6a5cee8389bcbdb141bcfbeaba4a/crates/red_knot/src/salsa_db/source.rs#L175-L183

The `parse` query is almost boring. It retrieves the file text and calls the parser. We opt out of Salsa's `eq` optimization because the parse tree is guaranteed to change whenever the source text changes (and our AST doesn't implement `Eq` because of floats).


## Semantic

This is where it gets interesting. 

**`AstIds`**

https://github.com/astral-sh/ruff/blob/176267f00b0162dee7545dea4ad14daf24f4897d/crates/red_knot/src/salsa_db/semantic/ast_ids.rs#L18-L24

`AstIds` are a location-independent representation that allows mapping from `Id -> AstNode` and from `AstNode -> Id`. The implementation tries to assign stable IDs by first giving IDs to the module-level statements and expressions, and only then traversing into the function or class level. 

```python
a = 10 # statement-id: 0

def test(a): # statement-id: 1
	if a: # statement-id: 4
		pass # statement-id 5

print(a) # statement-id: 2

class Test: # statement-id: 3
	pass # statement-id: 6
```

This way, IDs of top level statements remain unchanged when only making changes to a function's body. Having stable top-level IDs is important because they are referred to from other modules.

### symbols, cfg

**`semantic_index`**

https://github.com/astral-sh/ruff/blob/176267f00b0162dee7545dea4ad14daf24f4897d/crates/red_knot/src/salsa_db/semantic.rs#L103-L123

The `semantic_index` query computes a single file's symbol table and control flow graph. It shouldn't be used directly because the `semantic_index` changes every time the AST changes.

**`symbol_table`**

https://github.com/astral-sh/ruff/blob/176267f00b0162dee7545dea4ad14daf24f4897d/crates/red_knot/src/salsa_db/semantic/symbol_table.rs#L21-L25

The query itself just calls into `semantic_index`. The trick here is that the symbol table itself doesn't contain any data that references the AST. Instead, all data uses `AstIds`. What this query enables is that Salsa can avoid running queries that depend on the `symbol_table` if the constructed symbol table hasn't changed. For example, a comment only change doesn't invalidate the symbol table. 

**`flow_graph`**

https://github.com/astral-sh/ruff/blob/176267f00b0162dee7545dea4ad14daf24f4897d/crates/red_knot/src/salsa_db/semantic/flow_graph.rs#L12-L17

We apply the same trick for the control flow graph

### Typing


**`typing_scopes`**

Typing is where the code changes the most. The existing implementation does type inference per expression. I don't think that `type_inference` per expression will be fast in Salsa because storing a query result has some overhead. Salsa is also limited to at most `u32` results per query. I think large projects could reach that limit, especially when the server runs for a long time. 

That's why this PR changes inference to happen per `TypingScope` instead. For now, a typing scope is either a `Module`, `Function`, or `Class`. So this PR infers all types per module, class, or function (but the module doesn't traverse into function or class bodies).

The reason why we don't perform type inference on a module scope is to get more fine-grained dependency tracking across files. The type checking of a dependency must only be rerun if the types of the scope where the symbol is defined depend on changes. If the types remain unchanged (for example because the public interface isn't changing), then type checking doesn't need to re-run.

The first step to make this possible is to create a `FunctionTypingScope` and `ClassTypingScope`s for every `Function` and `Class` in the file and store them in Salsa to use them as query arguments. 

https://github.com/astral-sh/ruff/blob/176267f00b0162dee7545dea4ad14daf24f4897d/crates/red_knot/src/salsa_db/semantic/types.rs#L26-L40


**`infer_*_body`**

The other important queries are `infer_module_body`, `infer_function_body`, and `infer_class_body`. They perform type inference for a single module, function or class, but without traversing into nested classes or functions. 

https://github.com/astral-sh/ruff/blob/176267f00b0162dee7545dea4ad14daf24f4897d/crates/red_knot/src/salsa_db/semantic/types/infer.rs#L39-L64


Doing type-checking per block introduces some complexity. Mainly that getting the type data for a `TypeId` not just requires knowing the file from which the data needs to be read, but also from which typing scope. There's even an extra complexity. There are cases where we want to to resolve the type for a `type_id`. But we may only just be building up that typing table. I solved this by introducing `TypingContext` and passing that to `TypeId::ty`. The `TypingContext` can have an override so that queries for a specific typing-scope are directly resolved without calling into the database. 

https://github.com/astral-sh/ruff/blob/176267f00b0162dee7545dea4ad14daf24f4897d/crates/red_knot/src/salsa_db/semantic/types.rs#L527-L556

**Public API**

The public API for types should be limited to:

https://github.com/astral-sh/ruff/blob/176267f00b0162dee7545dea4ad14daf24f4897d/crates/red_knot/src/salsa_db/semantic/types/infer.rs#L24-L29

https://github.com/astral-sh/ruff/blob/176267f00b0162dee7545dea4ad14daf24f4897d/crates/red_knot/src/salsa_db/semantic.rs#L79-L101

### Module Resolver

The module resolver remains mostly unchanged, although I did some renaming. 

**`Module`**

I think the naming could be better. `Module` is mainly a `ModuleName` but interned into salsa so that it can be used as a query argument. 

https://github.com/astral-sh/ruff/blob/4c7033700dd3f7c954254de5f1c980a860c7e079/crates/red_knot/src/salsa_db/semantic/module.rs#L13-L17

I didn't want to intern `ModuleName` directly because I think there are places where we want to use it without the need for having it in Salsa. But maybe that's the wrong call and we should just intern `ModuleName` directly. 

**`resolve_module`**

The main query remains `resolve_module`

https://github.com/astral-sh/ruff/blob/4c7033700dd3f7c954254de5f1c980a860c7e079/crates/red_knot/src/salsa_db/semantic/module.rs#L193-L214

What changed is that it now accepts a `Module` and returns an `Option<ResolvedModule>`. Again, I'm open to suggestion for better naming. The idea is that a `ResolvedModule` represents to what a module name resolves. I'm consider renaming it to `ResolvedModulePath` because I think that's really what it is.

I think the implementation became much simpler because the module resolver now uses `File` and `File::exists` internally. This has the advantage that Salsa will automatically invalidate the `resolve_module` result if a relevant file gets added or removed. 

**`file_to_module`**

https://github.com/astral-sh/ruff/blob/4c7033700dd3f7c954254de5f1c980a860c7e079/crates/red_knot/src/salsa_db/semantic/module.rs#L228

Resolves a `file` to a `Option<ResolvedModule>` if it is a module and to `None` otherwise. This is mostly unchanged.

**`module_search_paths` and `set_module_search_paths`**

https://github.com/astral-sh/ruff/blob/4c7033700dd3f7c954254de5f1c980a860c7e079/crates/red_knot/src/salsa_db/semantic/module.rs#L178-L185

These queries shouldn't exist long term but it was a "quick" way to allow setting the module search paths without supporting settings. I'll adapt this to @AlexWaygood's most recent changes by having a `set_module_resolver_settings` short term (that has fields for the different lookup paths). The long term goal is that the module resolver queries the settings and constructs the search paths from the settings (it probably should remain a query)