### PR TITLE
[red-knot] Remove `<Db: SemanticDb>` contraints in favor of dynamic dispatch

### DIFF
--- a/crates/red_knot/src/main.rs
+++ b/crates/red_knot/src/main.rs
@@ -11,8 +11,8 @@ use tracing_subscriber::layer::{Context, Filter, SubscriberExt};
 use tracing_subscriber::{Layer, Registry};
 use tracing_tree::time::Uptime;
 
-use red_knot::db::{HasJar, ParallelDatabase, QueryError, SemanticDb, SourceDb, SourceJar};
-use red_knot::module::{ModuleSearchPath, ModuleSearchPathKind};
+use red_knot::db::{HasJar, ParallelDatabase, QueryError, SourceDb, SourceJar};
+use red_knot::module::{set_module_search_paths, ModuleSearchPath, ModuleSearchPathKind};
 use red_knot::program::check::ExecutionMode;
 use red_knot::program::{FileWatcherChange, Program};
 use red_knot::watch::FileWatcher;
@@ -49,7 +49,7 @@ fn main() -> anyhow::Result<()> {
         ModuleSearchPathKind::FirstParty,
     );
     let mut program = Program::new(workspace);
-    program.set_module_search_paths(vec![workspace_search_path]);
+    set_module_search_paths(&mut program, vec![workspace_search_path]);
 
     let entry_id = program.file_id(entry_point);
     program.workspace_mut().open_file(entry_id);

--- a/crates/red_knot/src/source.rs
+++ b/crates/red_knot/src/source.rs
@@ -1,18 +1,17 @@
-use crate::cache::KeyValueCache;
-use crate::db::{HasJar, QueryResult, SourceDb, SourceJar};
-use ruff_notebook::Notebook;
-use ruff_python_ast::PySourceType;
 use std::ops::{Deref, DerefMut};
 use std::sync::Arc;
 
+use ruff_notebook::Notebook;
+use ruff_python_ast::PySourceType;
+
+use crate::cache::KeyValueCache;
+use crate::db::{QueryResult, SourceDb};
 use crate::files::FileId;
 
 #[tracing::instrument(level = "debug", skip(db))]
-pub(crate) fn source_text<Db>(db: &Db, file_id: FileId) -> QueryResult<Source>
-where
-    Db: SourceDb + HasJar<SourceJar>,
-{
-    let sources = &db.jar()?.sources;
+pub(crate) fn source_text(db: &dyn SourceDb, file_id: FileId) -> QueryResult<Source> {
+    let jar = db.jar()?;
+    let sources = &jar.sources;
 
     sources.get(&file_id, |file_id| {
         let path = db.file_path(*file_id);

--- a/crates/red_knot/src/types/infer.rs
+++ b/crates/red_knot/src/types/infer.rs
@@ -1,34 +1,35 @@
 #![allow(dead_code)]
 
+use ruff_python_ast as ast;
 use ruff_python_ast::AstNode;
 
-use crate::db::{HasJar, QueryResult, SemanticDb, SemanticJar};
-use crate::module::ModuleName;
-use crate::symbols::{ClassDefinition, Definition, ImportFromDefinition, SymbolId};
+use crate::db::{QueryResult, SemanticDb, SemanticJar};
+
+use crate::module::{resolve_module, ModuleName};
+use crate::parse::parse;
+use crate::symbols::{symbol_table, ClassDefinition, Definition, ImportFromDefinition, SymbolId};
 use crate::types::Type;
 use crate::FileId;
-use ruff_python_ast as ast;
 
 // FIXME: Figure out proper dead-lock free synchronisation now that this takes `&db` instead of `&mut db`.
 #[tracing::instrument(level = "trace", skip(db))]
-pub fn infer_symbol_type<Db>(db: &Db, file_id: FileId, symbol_id: SymbolId) -> QueryResult<Type>
-where
-    Db: SemanticDb + HasJar<SemanticJar>,
-{
-    let symbols = db.symbol_table(file_id)?;
+pub fn infer_symbol_type(
+    db: &dyn SemanticDb,
+    file_id: FileId,
+    symbol_id: SymbolId,
+) -> QueryResult<Type> {
+    let symbols = symbol_table(db, file_id)?;
     let defs = symbols.definitions(symbol_id);
 
-    if let Some(ty) = db
-        .jar()?
-        .type_store
-        .get_cached_symbol_type(file_id, symbol_id)
-    {
+    let jar: &SemanticJar = db.jar()?;
+    let type_store = &jar.type_store;
+
+    if let Some(ty) = type_store.get_cached_symbol_type(file_id, symbol_id) {
         return Ok(ty);
     }
 
     // TODO handle multiple defs, conditional defs...
     assert_eq!(defs.len(), 1);
-    let type_store = &db.jar()?.type_store;
 
     let ty = match &defs[0] {
         Definition::ImportFrom(ImportFromDefinition {
@@ -39,11 +40,11 @@ where
             // TODO relative imports
             assert!(matches!(level, 0));
             let module_name = ModuleName::new(module.as_ref().expect("TODO relative imports"));
-            if let Some(module) = db.resolve_module(module_name)? {
+            if let Some(module) = resolve_module(db, module_name)? {
                 let remote_file_id = module.path(db)?.file();
-                let remote_symbols = db.symbol_table(remote_file_id)?;
+                let remote_symbols = symbol_table(db, remote_file_id)?;
                 if let Some(remote_symbol_id) = remote_symbols.root_symbol_id_by_name(name) {
-                    db.infer_symbol_type(remote_file_id, remote_symbol_id)?
+                    infer_symbol_type(db, remote_file_id, remote_symbol_id)?
                 } else {
                     Type::Unknown
                 }
@@ -55,7 +56,7 @@ where
             if let Some(ty) = type_store.get_cached_node_type(file_id, node_key.erased()) {
                 ty
             } else {
-                let parsed = db.parse(file_id)?;
+                let parsed = parse(db.upcast(), file_id)?;
                 let ast = parsed.ast();
                 let node = node_key.resolve_unwrap(ast.as_any_node_ref());
 
@@ -75,7 +76,7 @@ where
             if let Some(ty) = type_store.get_cached_node_type(file_id, node_key.erased()) {
                 ty
             } else {
-                let parsed = db.parse(file_id)?;
+                let parsed = parse(db.upcast(), file_id)?;
                 let ast = parsed.ast();
                 let node = node_key
                     .resolve(ast.as_any_node_ref())
@@ -95,7 +96,7 @@ where
             }
         }
         Definition::Assignment(node_key) => {
-            let parsed = db.parse(file_id)?;
+            let parsed = parse(db.upcast(), file_id)?;
             let ast = parsed.ast();
             let node = node_key.resolve_unwrap(ast.as_any_node_ref());
             // TODO handle unpacking assignment correctly
@@ -110,16 +111,13 @@ where
     Ok(ty)
 }
 
-fn infer_expr_type<Db>(db: &Db, file_id: FileId, expr: &ast::Expr) -> QueryResult<Type>
-where
-    Db: SemanticDb + HasJar<SemanticJar>,
-{
+fn infer_expr_type(db: &dyn SemanticDb, file_id: FileId, expr: &ast::Expr) -> QueryResult<Type> {
     // TODO cache the resolution of the type on the node
-    let symbols = db.symbol_table(file_id)?;
+    let symbols = symbol_table(db, file_id)?;
     match expr {
         ast::Expr::Name(name) => {
             if let Some(symbol_id) = symbols.root_symbol_id_by_name(&name.id) {
-                db.infer_symbol_type(file_id, symbol_id)
+                infer_symbol_type(db, file_id, symbol_id)
             } else {
                 Ok(Type::Unknown)
             }
@@ -131,9 +129,12 @@ where
 #[cfg(test)]
 mod tests {
     use crate::db::tests::TestDb;
-    use crate::db::{HasJar, SemanticDb, SemanticJar};
-    use crate::module::{ModuleName, ModuleSearchPath, ModuleSearchPathKind};
-    use crate::types::Type;
+    use crate::db::{HasJar, SemanticJar};
+    use crate::module::{
+        resolve_module, set_module_search_paths, ModuleName, ModuleSearchPath, ModuleSearchPathKind,
+    };
+    use crate::symbols::symbol_table;
+    use crate::types::{infer_symbol_type, Type};
     use crate::Name;
 
     // TODO with virtual filesystem we shouldn't have to write files to disk for these
@@ -156,7 +157,7 @@ mod tests {
         let roots = vec![src.clone()];
 
         let mut db = TestDb::default();
-        db.set_module_search_paths(roots);
+        set_module_search_paths(&mut db, roots);
 
         Ok(TestCase { temp_dir, db, src })
     }
@@ -170,17 +171,16 @@ mod tests {
         let b_path = case.src.path().join("b.py");
         std::fs::write(a_path, "from b import C as D; E = D")?;
         std::fs::write(b_path, "class C: pass")?;
-        let a_file = db
-            .resolve_module(ModuleName::new("a"))?
+        let a_file = resolve_module(db, ModuleName::new("a"))?
             .expect("module should be found")
             .path(db)?
             .file();
-        let a_syms = db.symbol_table(a_file)?;
+        let a_syms = symbol_table(db, a_file)?;
         let e_sym = a_syms
             .root_symbol_id_by_name("E")
             .expect("E symbol should be found");
 
-        let ty = db.infer_symbol_type(a_file, e_sym)?;
+        let ty = infer_symbol_type(db, a_file, e_sym)?;
 
         let jar = HasJar::<SemanticJar>::jar(db)?;
         assert!(matches!(ty, Type::Class(_)));
@@ -196,17 +196,16 @@ mod tests {
 
         let path = case.src.path().join("mod.py");
         std::fs::write(path, "class Base: pass\nclass Sub(Base): pass")?;
-        let file = db
-            .resolve_module(ModuleName::new("mod"))?
+        let file = resolve_module(db, ModuleName::new("mod"))?
             .expect("module should be found")
             .path(db)?
             .file();
-        let syms = db.symbol_table(file)?;
+        let syms = symbol_table(db, file)?;
         let sym = syms
             .root_symbol_id_by_name("Sub")
             .expect("Sub symbol should be found");
 
-        let ty = db.infer_symbol_type(file, sym)?;
+        let ty = infer_symbol_type(db, file, sym)?;
 
         let Type::Class(class_id) = ty else {
             panic!("Sub is not a Class")
@@ -232,17 +231,16 @@ mod tests {
 
         let path = case.src.path().join("mod.py");
         std::fs::write(path, "class C:\n  def f(self): pass")?;
-        let file = db
-            .resolve_module(ModuleName::new("mod"))?
+        let file = resolve_module(db, ModuleName::new("mod"))?
             .expect("module should be found")
             .path(db)?
             .file();
-        let syms = db.symbol_table(file)?;
+        let syms = symbol_table(db, file)?;
         let sym = syms
             .root_symbol_id_by_name("C")
             .expect("C symbol should be found");
 
-        let ty = db.infer_symbol_type(file, sym)?;
+        let ty = infer_symbol_type(db, file, sym)?;
 
         let Type::Class(class_id) = ty else {
             panic!("C is not a Class");


### PR DESCRIPTION
## Summary

We used to have a mixture of functions/methods that accept `&dyn Db + HasJar` and methods that were generic over `Db`. 

The problem with this approach is that calling a method that accepted a `Db: HasJar` wasn't possible when only holding a reference to a `&dyn Db` or it required repeating the `HasJar` constraint. 

This PR aligns our traits with Salsa by:

* Introducing a new `DbWithJar<Jar>` trait. The trait itself is empty, but it requires the type to implement `HasJar<Jar>` and `Database` 
* Make `DbWithJar` a base trait for all the `Db` traits (`SourceDb`, `SemanticDb`, `LintDb` etc)
* Change all methods to take `db: &dyn SemanticDb` as the argument. This simplifies the function signatures a lot 


The last change isn't strictly related and maybe I should have done it as a separate PR. However, it removes the 
query and mutation methods from the database traits because we can just call the functions directly. This aligns our API with salsa20202. 

I've mixed feelings about it. It is nice, because it reduces repetition. However, it does reduce discoverability because you can no longer write
`db.` to discover all queries/mutations. 

## Test Plan

`cargo build`
