### PR TITLE
Revert "Simplify arithmetic operation in logical lines checker (#11346)"

### DIFF
--- a/crates/ruff_linter/src/checkers/logical_lines.rs
+++ b/crates/ruff_linter/src/checkers/logical_lines.rs
@@ -24,7 +24,7 @@ pub(crate) fn expand_indent(line: &str, indent_width: IndentWidth) -> usize {
     let tab_size = indent_width.as_usize();
     for c in line.bytes() {
         match c {
-            b'\t' => indent += tab_size,
+            b'\t' => indent = (indent / tab_size) * tab_size + tab_size,
             b' ' => indent += 1,
             _ => break,
         }


### PR DESCRIPTION
## Summary

I merged this, but I think it might not be the same behavior? See my comment at: https://github.com/astral-sh/ruff/pull/11346#discussion_r1594848224