### PR TITLE
Avoid `TCH005` for `if` stmt with `elif`/`else` block

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_type_checking/TCH005.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_type_checking/TCH005.py
@@ -43,3 +43,13 @@ from typing_extensions import TYPE_CHECKING
 
 if TYPE_CHECKING:
     pass  # TCH005
+
+# https://github.com/astral-sh/ruff/issues/11368
+if TYPE_CHECKING:
+    pass
+else:
+    pass
+if TYPE_CHECKING:
+    pass
+elif test:
+    pass

--- a/crates/ruff_linter/src/checkers/ast/analyze/statement.rs
+++ b/crates/ruff_linter/src/checkers/ast/analyze/statement.rs
@@ -2,7 +2,6 @@ use ruff_diagnostics::Diagnostic;
 use ruff_python_ast::helpers;
 use ruff_python_ast::types::Node;
 use ruff_python_ast::{self as ast, Expr, Stmt};
-use ruff_python_semantic::analyze::typing;
 use ruff_python_semantic::ScopeKind;
 use ruff_text_size::Ranged;
 
@@ -1098,9 +1097,7 @@ pub(crate) fn statement(stmt: &Stmt, checker: &mut Checker) {
                 pylint::rules::too_many_nested_blocks(checker, stmt);
             }
             if checker.enabled(Rule::EmptyTypeCheckingBlock) {
-                if typing::is_type_checking_block(if_, &checker.semantic) {
-                    flake8_type_checking::rules::empty_type_checking_block(checker, if_);
-                }
+                flake8_type_checking::rules::empty_type_checking_block(checker, if_);
             }
             if checker.enabled(Rule::IfTuple) {
                 pyflakes::rules::if_tuple(checker, if_);

--- a/crates/ruff_linter/src/rules/flake8_type_checking/rules/empty_type_checking_block.rs
+++ b/crates/ruff_linter/src/rules/flake8_type_checking/rules/empty_type_checking_block.rs
@@ -2,6 +2,7 @@ use ruff_python_ast as ast;
 
 use ruff_diagnostics::{AlwaysFixableViolation, Diagnostic, Fix};
 use ruff_macros::{derive_message_formats, violation};
+use ruff_python_semantic::analyze::typing;
 use ruff_text_size::Ranged;
 
 use crate::checkers::ast::Checker;
@@ -47,6 +48,14 @@ impl AlwaysFixableViolation for EmptyTypeCheckingBlock {
 
 /// TCH005
 pub(crate) fn empty_type_checking_block(checker: &mut Checker, stmt: &ast::StmtIf) {
+    if !typing::is_type_checking_block(stmt, checker.semantic()) {
+        return;
+    }
+
+    if !stmt.elif_else_clauses.is_empty() {
+        return;
+    }
+
     let [stmt] = stmt.body.as_slice() else {
         return;
     };

--- a/crates/ruff_linter/src/rules/flake8_type_checking/snapshots/ruff_linter__rules__flake8_type_checking__tests__empty-type-checking-block_TCH005.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_type_checking/snapshots/ruff_linter__rules__flake8_type_checking__tests__empty-type-checking-block_TCH005.py.snap
@@ -101,6 +101,8 @@ TCH005.py:45:5: TCH005 [*] Found empty type-checking block
 44 | if TYPE_CHECKING:
 45 |     pass  # TCH005
    |     ^^^^ TCH005
+46 | 
+47 | # https://github.com/astral-sh/ruff/issues/11368
    |
    = help: Delete empty type-checking block
 
@@ -110,5 +112,6 @@ TCH005.py:45:5: TCH005 [*] Found empty type-checking block
 43 43 | 
 44    |-if TYPE_CHECKING:
 45    |-    pass  # TCH005
-
-
+46 44 | 
+47 45 | # https://github.com/astral-sh/ruff/issues/11368
+48 46 | if TYPE_CHECKING:


### PR DESCRIPTION
## Summary

This PR fixes a bug where the auto-fix for `TCH005` would delete the entire `if` statement.

The fix in this PR is to not consider it a violation if there are any `elif`/`else` blocks. This also matches the behavior of the original plugin.

fixes: #11368 

## Test plan

Add test cases.