### PR TITLE
Avoid `PLE0237` for property with setter

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pylint/non_slot_assignment.py
+++ b/crates/ruff_linter/resources/test/fixtures/pylint/non_slot_assignment.py
@@ -66,3 +66,19 @@ class StudentF(object):
 
     def setup(self):
         pass
+
+
+# https://github.com/astral-sh/ruff/issues/11358
+class Foo:
+    __slots__ = ("bar",)
+
+    def __init__(self):
+        self.qux = 2
+
+    @property
+    def qux(self):
+        return self.bar * 2
+
+    @qux.setter
+    def qux(self, value):
+        self.bar = value / 2

--- a/crates/ruff_linter/src/rules/pylint/rules/non_slot_assignment.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/non_slot_assignment.rs
@@ -147,6 +147,28 @@ fn is_attributes_not_in_slots(body: &[Stmt]) -> Vec<AttributeAssignment> {
         return vec![];
     }
 
+    // And, collect all the property name with setter.
+    for statement in body {
+        let Stmt::FunctionDef(ast::StmtFunctionDef { decorator_list, .. }) = statement else {
+            continue;
+        };
+
+        for decorator in decorator_list {
+            let Some(ast::ExprAttribute { value, attr, .. }) =
+                decorator.expression.as_attribute_expr()
+            else {
+                continue;
+            };
+
+            if attr == "setter" {
+                let Some(ast::ExprName { id, .. }) = value.as_name_expr() else {
+                    continue;
+                };
+                slots.insert(id.as_str());
+            }
+        }
+    }
+
     // Second, find any assignments that aren't included in `__slots__`.
     let mut assignments = vec![];
     for statement in body {


### PR DESCRIPTION
## Summary

Should this consider the decorator only if the name is actually a property or is the logic in this PR correct?

fixes: #11358

## Test Plan

Add test case.
