### PR TITLE
Reword `future-rewritable-type-annotation` (`FA100`) message

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_future_annotations/rules/future_rewritable_type_annotation.rs
+++ b/crates/ruff_linter/src/rules/flake8_future_annotations/rules/future_rewritable_type_annotation.rs
@@ -72,7 +72,7 @@ impl Violation for FutureRewritableTypeAnnotation {
     #[derive_message_formats]
     fn message(&self) -> String {
         let FutureRewritableTypeAnnotation { name } = self;
-        format!("Add `from __future__ import annotations` to rewrite `{name}` more succinctly")
+        format!("Add `from __future__ import annotations` to simplify `{name}`")
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_future_annotations/rules/future_rewritable_type_annotation.rs
+++ b/crates/ruff_linter/src/rules/flake8_future_annotations/rules/future_rewritable_type_annotation.rs
@@ -72,7 +72,7 @@ impl Violation for FutureRewritableTypeAnnotation {
     #[derive_message_formats]
     fn message(&self) -> String {
         let FutureRewritableTypeAnnotation { name } = self;
-        format!("Missing `from __future__ import annotations`, but uses `{name}`")
+        format!("Add `from __future__ import annotations` to rewrite `{name}` more succinctly")
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_future_annotations/snapshots/ruff_linter__rules__flake8_future_annotations__tests__edge_case.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_future_annotations/snapshots/ruff_linter__rules__flake8_future_annotations__tests__edge_case.py.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_future_annotations/mod.rs
 ---
-edge_case.py:5:13: FA100 Missing `from __future__ import annotations`, but uses `typing.List`
+edge_case.py:5:13: FA100 Add `from __future__ import annotations` to rewrite `typing.List` more succinctly
   |
 5 | def main(_: List[int]) -> None:
   |             ^^^^ FA100
@@ -9,12 +9,10 @@ edge_case.py:5:13: FA100 Missing `from __future__ import annotations`, but uses 
 7 |     a_list.append("hello")
   |
 
-edge_case.py:6:13: FA100 Missing `from __future__ import annotations`, but uses `typing.List`
+edge_case.py:6:13: FA100 Add `from __future__ import annotations` to rewrite `typing.List` more succinctly
   |
 5 | def main(_: List[int]) -> None:
 6 |     a_list: t.List[str] = []
   |             ^^^^^^ FA100
 7 |     a_list.append("hello")
   |
-
-

--- a/crates/ruff_linter/src/rules/flake8_future_annotations/snapshots/ruff_linter__rules__flake8_future_annotations__tests__edge_case.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_future_annotations/snapshots/ruff_linter__rules__flake8_future_annotations__tests__edge_case.py.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_future_annotations/mod.rs
 ---
-edge_case.py:5:13: FA100 Add `from __future__ import annotations` to rewrite `typing.List` more succinctly
+edge_case.py:5:13: FA100 Add `from __future__ import annotations` to simplify `typing.List`
   |
 5 | def main(_: List[int]) -> None:
   |             ^^^^ FA100
@@ -9,7 +9,7 @@ edge_case.py:5:13: FA100 Add `from __future__ import annotations` to rewrite `ty
 7 |     a_list.append("hello")
   |
 
-edge_case.py:6:13: FA100 Add `from __future__ import annotations` to rewrite `typing.List` more succinctly
+edge_case.py:6:13: FA100 Add `from __future__ import annotations` to simplify `typing.List`
   |
 5 | def main(_: List[int]) -> None:
 6 |     a_list: t.List[str] = []

--- a/crates/ruff_linter/src/rules/flake8_future_annotations/snapshots/ruff_linter__rules__flake8_future_annotations__tests__from_typing_import.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_future_annotations/snapshots/ruff_linter__rules__flake8_future_annotations__tests__from_typing_import.py.snap
@@ -1,12 +1,10 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_future_annotations/mod.rs
 ---
-from_typing_import.py:5:13: FA100 Missing `from __future__ import annotations`, but uses `typing.List`
+from_typing_import.py:5:13: FA100 Add `from __future__ import annotations` to rewrite `typing.List` more succinctly
   |
 4 | def main() -> None:
 5 |     a_list: List[str] = []
   |             ^^^^ FA100
 6 |     a_list.append("hello")
   |
-
-

--- a/crates/ruff_linter/src/rules/flake8_future_annotations/snapshots/ruff_linter__rules__flake8_future_annotations__tests__from_typing_import.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_future_annotations/snapshots/ruff_linter__rules__flake8_future_annotations__tests__from_typing_import.py.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_future_annotations/mod.rs
 ---
-from_typing_import.py:5:13: FA100 Add `from __future__ import annotations` to rewrite `typing.List` more succinctly
+from_typing_import.py:5:13: FA100 Add `from __future__ import annotations` to simplify `typing.List`
   |
 4 | def main() -> None:
 5 |     a_list: List[str] = []

--- a/crates/ruff_linter/src/rules/flake8_future_annotations/snapshots/ruff_linter__rules__flake8_future_annotations__tests__from_typing_import_many.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_future_annotations/snapshots/ruff_linter__rules__flake8_future_annotations__tests__from_typing_import_many.py.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_future_annotations/mod.rs
 ---
-from_typing_import_many.py:5:13: FA100 Missing `from __future__ import annotations`, but uses `typing.List`
+from_typing_import_many.py:5:13: FA100 Add `from __future__ import annotations` to rewrite `typing.List` more succinctly
   |
 4 | def main() -> None:
 5 |     a_list: List[Optional[str]] = []
@@ -10,7 +10,7 @@ from_typing_import_many.py:5:13: FA100 Missing `from __future__ import annotatio
 7 |     a_dict = cast(Dict[int | None, Union[int, Set[bool]]], {})
   |
 
-from_typing_import_many.py:5:18: FA100 Missing `from __future__ import annotations`, but uses `typing.Optional`
+from_typing_import_many.py:5:18: FA100 Add `from __future__ import annotations` to rewrite `typing.Optional` more succinctly
   |
 4 | def main() -> None:
 5 |     a_list: List[Optional[str]] = []
@@ -18,5 +18,3 @@ from_typing_import_many.py:5:18: FA100 Missing `from __future__ import annotatio
 6 |     a_list.append("hello")
 7 |     a_dict = cast(Dict[int | None, Union[int, Set[bool]]], {})
   |
-
-

--- a/crates/ruff_linter/src/rules/flake8_future_annotations/snapshots/ruff_linter__rules__flake8_future_annotations__tests__from_typing_import_many.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_future_annotations/snapshots/ruff_linter__rules__flake8_future_annotations__tests__from_typing_import_many.py.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_future_annotations/mod.rs
 ---
-from_typing_import_many.py:5:13: FA100 Add `from __future__ import annotations` to rewrite `typing.List` more succinctly
+from_typing_import_many.py:5:13: FA100 Add `from __future__ import annotations` to simplify `typing.List`
   |
 4 | def main() -> None:
 5 |     a_list: List[Optional[str]] = []
@@ -10,7 +10,7 @@ from_typing_import_many.py:5:13: FA100 Add `from __future__ import annotations` 
 7 |     a_dict = cast(Dict[int | None, Union[int, Set[bool]]], {})
   |
 
-from_typing_import_many.py:5:18: FA100 Add `from __future__ import annotations` to rewrite `typing.Optional` more succinctly
+from_typing_import_many.py:5:18: FA100 Add `from __future__ import annotations` to simplify `typing.Optional`
   |
 4 | def main() -> None:
 5 |     a_list: List[Optional[str]] = []

--- a/crates/ruff_linter/src/rules/flake8_future_annotations/snapshots/ruff_linter__rules__flake8_future_annotations__tests__import_typing.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_future_annotations/snapshots/ruff_linter__rules__flake8_future_annotations__tests__import_typing.py.snap
@@ -1,12 +1,10 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_future_annotations/mod.rs
 ---
-import_typing.py:5:13: FA100 Missing `from __future__ import annotations`, but uses `typing.List`
+import_typing.py:5:13: FA100 Add `from __future__ import annotations` to rewrite `typing.List` more succinctly
   |
 4 | def main() -> None:
 5 |     a_list: typing.List[str] = []
   |             ^^^^^^^^^^^ FA100
 6 |     a_list.append("hello")
   |
-
-

--- a/crates/ruff_linter/src/rules/flake8_future_annotations/snapshots/ruff_linter__rules__flake8_future_annotations__tests__import_typing.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_future_annotations/snapshots/ruff_linter__rules__flake8_future_annotations__tests__import_typing.py.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_future_annotations/mod.rs
 ---
-import_typing.py:5:13: FA100 Add `from __future__ import annotations` to rewrite `typing.List` more succinctly
+import_typing.py:5:13: FA100 Add `from __future__ import annotations` to simplify `typing.List`
   |
 4 | def main() -> None:
 5 |     a_list: typing.List[str] = []

--- a/crates/ruff_linter/src/rules/flake8_future_annotations/snapshots/ruff_linter__rules__flake8_future_annotations__tests__import_typing_as.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_future_annotations/snapshots/ruff_linter__rules__flake8_future_annotations__tests__import_typing_as.py.snap
@@ -1,12 +1,10 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_future_annotations/mod.rs
 ---
-import_typing_as.py:5:13: FA100 Missing `from __future__ import annotations`, but uses `typing.List`
+import_typing_as.py:5:13: FA100 Add `from __future__ import annotations` to rewrite `typing.List` more succinctly
   |
 4 | def main() -> None:
 5 |     a_list: t.List[str] = []
   |             ^^^^^^ FA100
 6 |     a_list.append("hello")
   |
-
-

--- a/crates/ruff_linter/src/rules/flake8_future_annotations/snapshots/ruff_linter__rules__flake8_future_annotations__tests__import_typing_as.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_future_annotations/snapshots/ruff_linter__rules__flake8_future_annotations__tests__import_typing_as.py.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_future_annotations/mod.rs
 ---
-import_typing_as.py:5:13: FA100 Add `from __future__ import annotations` to rewrite `typing.List` more succinctly
+import_typing_as.py:5:13: FA100 Add `from __future__ import annotations` to simplify `typing.List`
   |
 4 | def main() -> None:
 5 |     a_list: t.List[str] = []


### PR DESCRIPTION
## Summary

Changes `future-rewritable-type-annotation` (`FA100`) message to be less confusing. Uses phrasing from the rule documentation to be consistent. For example,

```
from_typing_import.py:5:13: FA100 Add `from __future__ import annotations` to rewrite `typing.List` more succinctly
```

Closes #10573.

## Test Plan

`cargo nextest run`
