### PR TITLE
Create a newtype wrapper around `Vec<FStringElement>`

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/hardcoded_bind_all_interfaces.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/hardcoded_bind_all_interfaces.rs
@@ -57,7 +57,7 @@ pub(crate) fn hardcoded_bind_all_interfaces(checker: &mut Checker, string: Strin
                         }
                     }
                     ast::FStringPart::FString(f_string) => {
-                        for literal in f_string.literals() {
+                        for literal in f_string.elements.literals() {
                             if &**literal == "0.0.0.0" {
                                 checker.diagnostics.push(Diagnostic::new(
                                     HardcodedBindAllInterfaces,

--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/hardcoded_tmp_directory.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/hardcoded_tmp_directory.rs
@@ -64,7 +64,7 @@ pub(crate) fn hardcoded_tmp_directory(checker: &mut Checker, string: StringLike)
                         check(checker, literal, literal.range());
                     }
                     ast::FStringPart::FString(f_string) => {
-                        for literal in f_string.literals() {
+                        for literal in f_string.elements.literals() {
                             check(checker, literal, literal.range());
                         }
                     }

--- a/crates/ruff_linter/src/rules/flake8_datetimez/rules/call_datetime_strptime_without_zone.rs
+++ b/crates/ruff_linter/src/rules/flake8_datetimez/rules/call_datetime_strptime_without_zone.rs
@@ -118,7 +118,11 @@ pub(crate) fn call_datetime_strptime_without_zone(checker: &mut Checker, call: &
                             }
                         }
                         ast::FStringPart::FString(f_string) => {
-                            if f_string.literals().any(|literal| literal.contains("%z")) {
+                            if f_string
+                                .elements
+                                .literals()
+                                .any(|literal| literal.contains("%z"))
+                            {
                                 return;
                             }
                         }

--- a/crates/ruff_linter/src/rules/flake8_quotes/rules/avoidable_escaped_quote.rs
+++ b/crates/ruff_linter/src/rules/flake8_quotes/rules/avoidable_escaped_quote.rs
@@ -192,6 +192,7 @@ impl Visitor<'_> for AvoidableEscapedQuoteChecker<'_> {
         // f"'normal' {f'\'nested\' {x} "double quotes"'} normal"
         // ```
         if !f_string
+            .elements
             .literals()
             .any(|literal| contains_quote(literal, opposite_quote_char))
         {
@@ -269,7 +270,7 @@ fn check_f_string(
     let opposite_quote_char = quotes_settings.inline_quotes.opposite().as_char();
 
     let mut edits = vec![];
-    for literal in f_string.literals() {
+    for literal in f_string.elements.literals() {
         let content = locator.slice(literal);
         if !contains_escaped_quote(content, quote_char) {
             continue;

--- a/crates/ruff_linter/src/rules/flake8_quotes/rules/unnecessary_escaped_quote.rs
+++ b/crates/ruff_linter/src/rules/flake8_quotes/rules/unnecessary_escaped_quote.rs
@@ -124,7 +124,7 @@ fn check_f_string(locator: &Locator, f_string: &ast::FString) -> Option<Diagnost
     let opposite_quote_char = flags.quote_style().opposite().as_char();
 
     let mut edits = vec![];
-    for literal in f_string.literals() {
+    for literal in f_string.elements.literals() {
         let content = locator.slice(literal);
         if !contains_escaped_quote(content, opposite_quote_char) {
             continue;

--- a/crates/ruff_linter/src/rules/flynt/rules/static_join_to_fstring.rs
+++ b/crates/ruff_linter/src/rules/flynt/rules/static_join_to_fstring.rs
@@ -96,7 +96,7 @@ fn build_fstring(joiner: &str, joinees: &[Expr]) -> Option<Expr> {
     }
 
     let node = ast::FString {
-        elements: f_string_elements,
+        elements: f_string_elements.into(),
         range: TextRange::default(),
         flags: FStringFlags::default(),
     };

--- a/crates/ruff_linter/src/rules/ruff/rules/ambiguous_unicode_character.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/ambiguous_unicode_character.rs
@@ -206,7 +206,7 @@ pub(crate) fn ambiguous_unicode_character_string(checker: &mut Checker, string_l
             }
             ast::StringLikePart::Bytes(_) => {}
             ast::StringLikePart::FString(f_string) => {
-                for literal in f_string.literals() {
+                for literal in f_string.elements.literals() {
                     let text = checker.locator().slice(literal);
                     ambiguous_unicode_character(
                         &mut checker.diagnostics,

--- a/crates/ruff_linter/src/rules/ruff/rules/missing_fstring_syntax.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/missing_fstring_syntax.rs
@@ -168,7 +168,7 @@ fn should_be_fstring(
 
     for f_string in value.f_strings() {
         let mut has_name = false;
-        for element in f_string.expressions() {
+        for element in f_string.elements.expressions() {
             if let ast::Expr::Name(ast::ExprName { id, .. }) = element.expression.as_ref() {
                 if arg_names.contains(id.as_str()) {
                     return false;

--- a/crates/ruff_linter/src/rules/tryceratops/rules/raise_vanilla_args.rs
+++ b/crates/ruff_linter/src/rules/tryceratops/rules/raise_vanilla_args.rs
@@ -97,7 +97,7 @@ fn contains_message(expr: &Expr) -> bool {
                         }
                     }
                     ast::FStringPart::FString(f_string) => {
-                        for literal in f_string.literals() {
+                        for literal in f_string.elements.literals() {
                             if literal.chars().any(char::is_whitespace) {
                                 return true;
                             }

--- a/crates/ruff_python_ast/src/node.rs
+++ b/crates/ruff_python_ast/src/node.rs
@@ -2814,7 +2814,7 @@ impl AstNode for ast::FStringFormatSpec {
     where
         V: PreorderVisitor<'a> + ?Sized,
     {
-        for element in &self.elements {
+        for element in self.elements.iter() {
             visitor.visit_f_string_element(element);
         }
     }
@@ -2864,7 +2864,7 @@ impl AstNode for ast::FStringExpressionElement {
         visitor.visit_expr(expression);
 
         if let Some(format_spec) = format_spec {
-            for spec_part in &format_spec.elements {
+            for spec_part in format_spec.elements.iter() {
                 visitor.visit_f_string_element(spec_part);
             }
         }
@@ -4800,7 +4800,7 @@ impl AstNode for ast::FString {
             flags: _,
         } = self;
 
-        for fstring_element in elements {
+        for fstring_element in elements.iter() {
             visitor.visit_f_string_element(fstring_element);
         }
     }

--- a/crates/ruff_python_ast/src/visitor.rs
+++ b/crates/ruff_python_ast/src/visitor.rs
@@ -739,7 +739,7 @@ pub fn walk_pattern_keyword<'a, V: Visitor<'a> + ?Sized>(
 }
 
 pub fn walk_f_string<'a, V: Visitor<'a> + ?Sized>(visitor: &mut V, f_string: &'a FString) {
-    for f_string_element in &f_string.elements {
+    for f_string_element in f_string.elements.iter() {
         visitor.visit_f_string_element(f_string_element);
     }
 }
@@ -756,7 +756,7 @@ pub fn walk_f_string_element<'a, V: Visitor<'a> + ?Sized>(
     {
         visitor.visit_expr(expression);
         if let Some(format_spec) = format_spec {
-            for spec_element in &format_spec.elements {
+            for spec_element in format_spec.elements.iter() {
                 visitor.visit_f_string_element(spec_element);
             }
         }

--- a/crates/ruff_python_ast/src/visitor/transformer.rs
+++ b/crates/ruff_python_ast/src/visitor/transformer.rs
@@ -746,7 +746,7 @@ pub fn walk_pattern_keyword<V: Transformer + ?Sized>(
 }
 
 pub fn walk_f_string<V: Transformer + ?Sized>(visitor: &V, f_string: &mut FString) {
-    for element in &mut f_string.elements {
+    for element in f_string.elements.iter_mut() {
         visitor.visit_f_string_element(element);
     }
 }
@@ -763,7 +763,7 @@ pub fn walk_f_string_element<V: Transformer + ?Sized>(
     {
         visitor.visit_expr(expression);
         if let Some(format_spec) = format_spec {
-            for spec_element in &mut format_spec.elements {
+            for spec_element in format_spec.elements.iter_mut() {
                 visitor.visit_f_string_element(spec_element);
             }
         }

--- a/crates/ruff_python_formatter/src/other/f_string.rs
+++ b/crates/ruff_python_formatter/src/other/f_string.rs
@@ -128,6 +128,7 @@ impl FStringLayout {
         //
         // Reference: https://prettier.io/docs/en/next/rationale.html#template-literals
         if f_string
+            .elements
             .expressions()
             .any(|expr| memchr::memchr2(b'\n', b'\r', locator.slice(expr).as_bytes()).is_some())
         {

--- a/crates/ruff_python_parser/src/parser/expression.rs
+++ b/crates/ruff_python_parser/src/parser/expression.rs
@@ -6,8 +6,8 @@ use bitflags::bitflags;
 use rustc_hash::FxHashSet;
 
 use ruff_python_ast::{
-    self as ast, BoolOp, CmpOp, ConversionFlag, Expr, ExprContext, FStringElement, IpyEscapeKind,
-    Number, Operator, UnaryOp,
+    self as ast, BoolOp, CmpOp, ConversionFlag, Expr, ExprContext, FStringElement, FStringElements,
+    IpyEscapeKind, Number, Operator, UnaryOp,
 };
 use ruff_text_size::{Ranged, TextLen, TextRange, TextSize};
 
@@ -1297,8 +1297,8 @@ impl<'src> Parser<'src> {
     /// # Panics
     ///
     /// If the parser isn't positioned at a `{` or `FStringMiddle` token.
-    fn parse_fstring_elements(&mut self) -> Vec<FStringElement> {
-        let mut elements = vec![];
+    fn parse_fstring_elements(&mut self) -> FStringElements {
+        let mut elements = FStringElements::default();
 
         self.parse_list(RecoveryContextKind::FStringElements, |parser| {
             let element = match parser.current_token_kind() {


### PR DESCRIPTION
## Summary

This PR adds a newtype wrapper around `Vec<FStringElement>` that derefs to a `&Vec<FStringElement>`.

Both f-string and format specifier are made up of `Vec<FStringElement>`. By creating a newtype wrapper around it, we can share the methods for both parent types.
