### PR TITLE
Fix a few typos found by codespell

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/ruff/RUF100_0.py
+++ b/crates/ruff_linter/resources/test/fixtures/ruff/RUF100_0.py
@@ -103,7 +103,7 @@ def f():
 
 
 def f():
-    # Invalid - nonexistant error code with multibyte character
+    # Invalid - nonexistent error code with multibyte character
     d = 1  # noqa: F841, E50
     e = 1  # noqa: E50
 

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__ruf100_0.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__ruf100_0.snap
@@ -287,7 +287,7 @@ RUF100_0.py:93:92: RUF100 [*] Unused `noqa` directive (unused: `F401`)
 RUF100_0.py:107:12: RUF100 [*] Unused `noqa` directive (unknown: `E50`)
     |
 105 | def f():
-106 |     # Invalid - nonexistant error code with multibyte character
+106 |     # Invalid - nonexistent error code with multibyte character
 107 |     d = 1  # noqa: F841, E50
     |            ^^^^^^^^^^^^^^^^^ RUF100
 108 |     e = 1  # noqa: E50
@@ -297,7 +297,7 @@ RUF100_0.py:107:12: RUF100 [*] Unused `noqa` directive (unknown: `E50`)
 ℹ Safe fix
 104 104 | 
 105 105 | def f():
-106 106 |     # Invalid - nonexistant error code with multibyte character
+106 106 |     # Invalid - nonexistent error code with multibyte character
 107     |-    d = 1  # noqa: F841, E50
     107 |+    d = 1  # noqa: F841
 108 108 |     e = 1  # noqa: E50
@@ -306,7 +306,7 @@ RUF100_0.py:107:12: RUF100 [*] Unused `noqa` directive (unknown: `E50`)
 
 RUF100_0.py:108:5: F841 [*] Local variable `e` is assigned to but never used
     |
-106 |     # Invalid - nonexistant error code with multibyte character
+106 |     # Invalid - nonexistent error code with multibyte character
 107 |     d = 1  # noqa: F841, E50
 108 |     e = 1  # noqa: E50
     |     ^ F841
@@ -315,7 +315,7 @@ RUF100_0.py:108:5: F841 [*] Local variable `e` is assigned to but never used
 
 ℹ Unsafe fix
 105 105 | def f():
-106 106 |     # Invalid - nonexistant error code with multibyte character
+106 106 |     # Invalid - nonexistent error code with multibyte character
 107 107 |     d = 1  # noqa: F841, E50
 108     |-    e = 1  # noqa: E50
 109 108 | 
@@ -324,7 +324,7 @@ RUF100_0.py:108:5: F841 [*] Local variable `e` is assigned to but never used
 
 RUF100_0.py:108:12: RUF100 [*] Unused `noqa` directive (unknown: `E50`)
     |
-106 |     # Invalid - nonexistant error code with multibyte character
+106 |     # Invalid - nonexistent error code with multibyte character
 107 |     d = 1  # noqa: F841, E50
 108 |     e = 1  # noqa: E50
     |            ^^^^^^^^^^^ RUF100
@@ -333,7 +333,7 @@ RUF100_0.py:108:12: RUF100 [*] Unused `noqa` directive (unknown: `E50`)
 
 ℹ Safe fix
 105 105 | def f():
-106 106 |     # Invalid - nonexistant error code with multibyte character
+106 106 |     # Invalid - nonexistent error code with multibyte character
 107 107 |     d = 1  # noqa: F841, E50
 108     |-    e = 1  # noqa: E50
     108 |+    e = 1

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__ruf100_0_prefix.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__ruf100_0_prefix.snap
@@ -267,7 +267,7 @@ RUF100_0.py:93:92: RUF100 [*] Unused `noqa` directive (unused: `F401`)
 RUF100_0.py:107:12: RUF100 [*] Unused `noqa` directive (unknown: `E50`)
     |
 105 | def f():
-106 |     # Invalid - nonexistant error code with multibyte character
+106 |     # Invalid - nonexistent error code with multibyte character
 107 |     d = 1  # noqa: F841, E50
     |            ^^^^^^^^^^^^^^^^^ RUF100
 108 |     e = 1  # noqa: E50
@@ -277,7 +277,7 @@ RUF100_0.py:107:12: RUF100 [*] Unused `noqa` directive (unknown: `E50`)
 ℹ Safe fix
 104 104 | 
 105 105 | def f():
-106 106 |     # Invalid - nonexistant error code with multibyte character
+106 106 |     # Invalid - nonexistent error code with multibyte character
 107     |-    d = 1  # noqa: F841, E50
     107 |+    d = 1  # noqa: F841
 108 108 |     e = 1  # noqa: E50
@@ -286,7 +286,7 @@ RUF100_0.py:107:12: RUF100 [*] Unused `noqa` directive (unknown: `E50`)
 
 RUF100_0.py:108:5: F841 [*] Local variable `e` is assigned to but never used
     |
-106 |     # Invalid - nonexistant error code with multibyte character
+106 |     # Invalid - nonexistent error code with multibyte character
 107 |     d = 1  # noqa: F841, E50
 108 |     e = 1  # noqa: E50
     |     ^ F841
@@ -295,7 +295,7 @@ RUF100_0.py:108:5: F841 [*] Local variable `e` is assigned to but never used
 
 ℹ Unsafe fix
 105 105 | def f():
-106 106 |     # Invalid - nonexistant error code with multibyte character
+106 106 |     # Invalid - nonexistent error code with multibyte character
 107 107 |     d = 1  # noqa: F841, E50
 108     |-    e = 1  # noqa: E50
 109 108 | 
@@ -304,7 +304,7 @@ RUF100_0.py:108:5: F841 [*] Local variable `e` is assigned to but never used
 
 RUF100_0.py:108:12: RUF100 [*] Unused `noqa` directive (unknown: `E50`)
     |
-106 |     # Invalid - nonexistant error code with multibyte character
+106 |     # Invalid - nonexistent error code with multibyte character
 107 |     d = 1  # noqa: F841, E50
 108 |     e = 1  # noqa: E50
     |            ^^^^^^^^^^^ RUF100
@@ -313,7 +313,7 @@ RUF100_0.py:108:12: RUF100 [*] Unused `noqa` directive (unknown: `E50`)
 
 ℹ Safe fix
 105 105 | def f():
-106 106 |     # Invalid - nonexistant error code with multibyte character
+106 106 |     # Invalid - nonexistent error code with multibyte character
 107 107 |     d = 1  # noqa: F841, E50
 108     |-    e = 1  # noqa: E50
     108 |+    e = 1

--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/fstring.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/fstring.py
@@ -224,7 +224,7 @@ f"""aaaaaaaaaaaaaaaa bbbbbbbbbbbbbbbbbb ccccccccccc {
 f"""fooooooooooooooooooo barrrrrrrrrrrrrrrrrrr {
         xxxxxxxxxxxxxxx:.3f} aaaaaaaaaaaaaaaaa { xxxxxxxxxxxxxxxxxxxx } bbbbbbbbbbbb"""
 
-# Throw in a random comment in it but surpise, this is not a comment but just a text
+# Throw in a random comment in it but surprise, this is not a comment but just a text
 # which is part of the format specifier
 aaaaaaaaaaa = f"""asaaaaaaaaaaaaaaaa {
         aaaaaaaaaaaa + bbbbbbbbbbbb + ccccccccccccccc + dddddddd:.3f

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__fstring.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__fstring.py.snap
@@ -230,7 +230,7 @@ f"""aaaaaaaaaaaaaaaa bbbbbbbbbbbbbbbbbb ccccccccccc {
 f"""fooooooooooooooooooo barrrrrrrrrrrrrrrrrrr {
         xxxxxxxxxxxxxxx:.3f} aaaaaaaaaaaaaaaaa { xxxxxxxxxxxxxxxxxxxx } bbbbbbbbbbbb"""
 
-# Throw in a random comment in it but surpise, this is not a comment but just a text
+# Throw in a random comment in it but surprise, this is not a comment but just a text
 # which is part of the format specifier
 aaaaaaaaaaa = f"""asaaaaaaaaaaaaaaaa {
         aaaaaaaaaaaa + bbbbbbbbbbbb + ccccccccccccccc + dddddddd:.3f
@@ -571,7 +571,7 @@ f"""fooooooooooooooooooo barrrrrrrrrrrrrrrrrrr {xxxxxxxxxxxxxxx:.3f} aaaaaaaaaaa
     xxxxxxxxxxxxxxxxxxxx
 } bbbbbbbbbbbb"""
 
-# Throw in a random comment in it but surpise, this is not a comment but just a text
+# Throw in a random comment in it but surprise, this is not a comment but just a text
 # which is part of the format specifier
 aaaaaaaaaaa = f"""asaaaaaaaaaaaaaaaa {aaaaaaaaaaaa + bbbbbbbbbbbb + ccccccccccccccc + dddddddd:.3f
      # comment
@@ -890,7 +890,7 @@ f"""aaaaaaaaaaaaaaaa bbbbbbbbbbbbbbbbbb ccccccccccc {
 f"""fooooooooooooooooooo barrrrrrrrrrrrrrrrrrr {
         xxxxxxxxxxxxxxx:.3f} aaaaaaaaaaaaaaaaa { xxxxxxxxxxxxxxxxxxxx } bbbbbbbbbbbb"""
 
-# Throw in a random comment in it but surpise, this is not a comment but just a text
+# Throw in a random comment in it but surprise, this is not a comment but just a text
 # which is part of the format specifier
 aaaaaaaaaaa = f"""asaaaaaaaaaaaaaaaa {
         aaaaaaaaaaaa + bbbbbbbbbbbb + ccccccccccccccc + dddddddd:.3f
@@ -1206,7 +1206,7 @@ hello {
 +    xxxxxxxxxxxxxxxxxxxx
 +} bbbbbbbbbbbb"""
  
- # Throw in a random comment in it but surpise, this is not a comment but just a text
+ # Throw in a random comment in it but surprise, this is not a comment but just a text
  # which is part of the format specifier
 -aaaaaaaaaaa = f"""asaaaaaaaaaaaaaaaa {
 -        aaaaaaaaaaaa + bbbbbbbbbbbb + ccccccccccccccc + dddddddd:.3f

--- a/crates/ruff_python_parser/resources/invalid/statements/function_type_parameters.py
+++ b/crates/ruff_python_parser/resources/invalid/statements/function_type_parameters.py
@@ -3,7 +3,7 @@
 # That's because the parser has no way of feeding the error recovery back to the lexer,
 # so they don't agree on the state of the world which can lead to all kind of errors further down in the file.
 # This is not just a problem with parentheses but also with the transformation made by the
-# `SoftKeywordTransformer` because the `Parser` and `Transfomer` may not agree if they're
+# `SoftKeywordTransformer` because the `Parser` and `Transformer` may not agree if they're
 # currently in a position where the `type` keyword is allowed or not.
 # That roughly means that any kind of recovery can lead to unrelated syntax errors
 # on following lines.

--- a/crates/ruff_python_parser/src/parser/expression.rs
+++ b/crates/ruff_python_parser/src/parser/expression.rs
@@ -2326,7 +2326,7 @@ impl Ranged for ParsedExpr {
 /// See: <https://docs.python.org/3/reference/expressions.html#operator-precedence>
 #[derive(Debug, Ord, Eq, PartialEq, PartialOrd, Copy, Clone)]
 pub(super) enum OperatorPrecedence {
-    /// The initital precedence when parsing an expression.
+    /// The initial precedence when parsing an expression.
     Initial,
     /// Precedence of boolean `or` operator.
     Or,


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Just fix typos.

While `alpha-numeric` is not really a misspelling:
- it is missing from mainstream curated dictionaries, all of them suggest `alphanumeric`;
- it is less used than `alphanumeric` (more than ⨉10 less) according to the Google [Ngram Viewer](https://books.google.com/ngrams/graph?content=alpha-numeric%2Calphanumeric&year_start=1900&year_end=2019&corpus=en-2019);
- it is [missing from SCOWL](http://app.aspell.net/lookup?dict=en_US-large;words=alpha-numeric).

## Test Plan

CI jobs.