### PR TITLE
Rename `AnyStringKind` -> `AnyStringFlags`

### DIFF
--- a/crates/ruff_linter/src/directives.rs
+++ b/crates/ruff_linter/src/directives.rs
@@ -131,7 +131,7 @@ fn extract_noqa_line_for(lxr: &[LexResult], locator: &Locator, indexer: &Indexer
 
             // For multi-line strings, we expect `noqa` directives on the last line of the
             // string.
-            Tok::String { kind, .. } if kind.is_triple_quoted() => {
+            Tok::String { flags, .. } if flags.is_triple_quoted() => {
                 if locator.contains_line_break(*range) {
                     string_mappings.push(TextRange::new(
                         locator.line_start(range.start()),

--- a/crates/ruff_linter/src/rules/flake8_quotes/helpers.rs
+++ b/crates/ruff_linter/src/rules/flake8_quotes/helpers.rs
@@ -1,10 +1,10 @@
-use ruff_python_ast::AnyStringKind;
+use ruff_python_ast::AnyStringFlags;
 use ruff_text_size::TextLen;
 
-/// Returns the raw contents of the string given the string's contents and kind.
+/// Returns the raw contents of the string given the string's contents and flags.
 /// This is a string without the prefix and quotes.
-pub(super) fn raw_contents(contents: &str, kind: AnyStringKind) -> &str {
-    &contents[kind.opener_len().to_usize()..(contents.text_len() - kind.closer_len()).to_usize()]
+pub(super) fn raw_contents(contents: &str, flags: AnyStringFlags) -> &str {
+    &contents[flags.opener_len().to_usize()..(contents.text_len() - flags.closer_len()).to_usize()]
 }
 
 /// Return `true` if the haystack contains an escaped quote.

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/invalid_escape_sequence.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/invalid_escape_sequence.rs
@@ -66,22 +66,22 @@ pub(crate) fn invalid_escape_sequence(
     token: &Tok,
     token_range: TextRange,
 ) {
-    let (token_source_code, string_start_location, kind) = match token {
-        Tok::FStringMiddle { kind, .. } => {
-            if kind.is_raw_string() {
+    let (token_source_code, string_start_location, flags) = match token {
+        Tok::FStringMiddle { flags, .. } => {
+            if flags.is_raw_string() {
                 return;
             }
             let Some(f_string_range) = indexer.fstring_ranges().innermost(token_range.start())
             else {
                 return;
             };
-            (locator.slice(token_range), f_string_range.start(), kind)
+            (locator.slice(token_range), f_string_range.start(), flags)
         }
-        Tok::String { kind, .. } => {
-            if kind.is_raw_string() {
+        Tok::String { flags, .. } => {
+            if flags.is_raw_string() {
                 return;
             }
-            (locator.slice(token_range), token_range.start(), kind)
+            (locator.slice(token_range), token_range.start(), flags)
         }
         _ => return,
     };
@@ -208,7 +208,7 @@ pub(crate) fn invalid_escape_sequence(
                 invalid_escape_char.range(),
             );
 
-            if kind.is_u_string() {
+            if flags.is_u_string() {
                 // Replace the Unicode prefix with `r`.
                 diagnostic.set_fix(Fix::safe_edit(Edit::replacement(
                     "r".to_string(),

--- a/crates/ruff_linter/src/rules/pylint/rules/bad_string_format_type.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/bad_string_format_type.rs
@@ -1,6 +1,6 @@
 use std::str::FromStr;
 
-use ruff_python_ast::{self as ast, AnyStringKind, Expr};
+use ruff_python_ast::{self as ast, AnyStringFlags, Expr};
 use ruff_python_literal::cformat::{CFormatPart, CFormatSpec, CFormatStrOrBytes, CFormatString};
 use ruff_python_parser::{lexer, AsMode, Tok};
 use ruff_text_size::{Ranged, TextRange};
@@ -214,12 +214,12 @@ fn is_valid_dict(formats: &[CFormatStrOrBytes<String>], items: &[ast::DictItem])
 pub(crate) fn bad_string_format_type(checker: &mut Checker, expr: &Expr, right: &Expr) {
     // Grab each string segment (in case there's an implicit concatenation).
     let content = checker.locator().slice(expr);
-    let mut strings: Vec<(TextRange, AnyStringKind)> = vec![];
+    let mut strings: Vec<(TextRange, AnyStringFlags)> = vec![];
     for (tok, range) in
         lexer::lex_starts_at(content, checker.source_type.as_mode(), expr.start()).flatten()
     {
         match tok {
-            Tok::String { kind, .. } => strings.push((range, kind)),
+            Tok::String { flags, .. } => strings.push((range, flags)),
             // Break as soon as we find the modulo symbol.
             Tok::Percent => break,
             _ => {}

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/printf_string_formatting.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/printf_string_formatting.rs
@@ -4,7 +4,7 @@ use std::str::FromStr;
 use ruff_diagnostics::{Diagnostic, Edit, Fix, FixAvailability, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::whitespace::indentation;
-use ruff_python_ast::{self as ast, AnyStringKind, Expr};
+use ruff_python_ast::{self as ast, AnyStringFlags, Expr};
 use ruff_python_codegen::Stylist;
 use ruff_python_literal::cformat::{
     CConversionFlags, CFormatPart, CFormatPrecision, CFormatQuantity, CFormatString,
@@ -347,7 +347,7 @@ fn convertible(format_string: &CFormatString, params: &Expr) -> bool {
 /// UP031
 pub(crate) fn printf_string_formatting(checker: &mut Checker, expr: &Expr, right: &Expr) {
     // Grab each string segment (in case there's an implicit concatenation).
-    let mut strings: Vec<(TextRange, AnyStringKind)> = vec![];
+    let mut strings: Vec<(TextRange, AnyStringFlags)> = vec![];
     let mut extension = None;
     for (tok, range) in lexer::lex_starts_at(
         checker.locator().slice(expr),
@@ -357,7 +357,7 @@ pub(crate) fn printf_string_formatting(checker: &mut Checker, expr: &Expr, right
     .flatten()
     {
         match tok {
-            Tok::String { kind, .. } => strings.push((range, kind)),
+            Tok::String { flags, .. } => strings.push((range, flags)),
             // If we hit a right paren, we have to preserve it.
             Tok::Rpar => extension = Some(range),
             // Break as soon as we find the modulo symbol.
@@ -375,10 +375,10 @@ pub(crate) fn printf_string_formatting(checker: &mut Checker, expr: &Expr, right
     let mut num_positional_arguments = 0;
     let mut num_keyword_arguments = 0;
     let mut format_strings = Vec::with_capacity(strings.len());
-    for (range, kind) in &strings {
+    for (range, flags) in &strings {
         let string = checker.locator().slice(*range);
         let string = &string
-            [usize::from(kind.opener_len())..(string.len() - usize::from(kind.closer_len()))];
+            [usize::from(flags.opener_len())..(string.len() - usize::from(flags.closer_len()))];
 
         // Parse the format string (e.g. `"%s"`) into a list of `PercentFormat`.
         let Ok(format_string) = CFormatString::from_str(string) else {
@@ -401,7 +401,7 @@ pub(crate) fn printf_string_formatting(checker: &mut Checker, expr: &Expr, right
         }
 
         // Convert the `%`-format string to a `.format` string.
-        format_strings.push(kind.format_string_contents(&percent_to_format(&format_string)));
+        format_strings.push(flags.format_string_contents(&percent_to_format(&format_string)));
     }
 
     // Parse the parameters.

--- a/crates/ruff_python_ast/src/nodes.rs
+++ b/crates/ruff_python_ast/src/nodes.rs
@@ -2650,7 +2650,7 @@ impl AnyStringFlags {
 
 impl fmt::Debug for AnyStringFlags {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("StringKind")
+        f.debug_struct("AnyStringFlags")
             .field("prefix", &self.prefix())
             .field("triple_quoted", &self.is_triple_quoted())
             .field("quote_style", &self.quote_style())

--- a/crates/ruff_python_codegen/src/stylist.rs
+++ b/crates/ruff_python_codegen/src/stylist.rs
@@ -50,8 +50,8 @@ impl<'a> Stylist<'a> {
 fn detect_quote(tokens: &[LexResult]) -> Quote {
     for (token, _) in tokens.iter().flatten() {
         match token {
-            Tok::String { kind, .. } if !kind.is_triple_quoted() => return kind.quote_style(),
-            Tok::FStringStart(kind) => return kind.quote_style(),
+            Tok::String { flags, .. } if !flags.is_triple_quoted() => return flags.quote_style(),
+            Tok::FStringStart(flags) => return flags.quote_style(),
             _ => continue,
         }
     }

--- a/crates/ruff_python_formatter/src/other/f_string.rs
+++ b/crates/ruff_python_formatter/src/other/f_string.rs
@@ -1,5 +1,5 @@
 use ruff_formatter::write;
-use ruff_python_ast::{AnyStringKind, FString};
+use ruff_python_ast::{AnyStringFlags, FString};
 use ruff_source_file::Locator;
 
 use crate::prelude::*;
@@ -56,7 +56,9 @@ impl Format<PyFormatContext<'_>> for FormatFString<'_> {
             return result;
         }
 
-        let string_kind = normalizer.choose_quotes(self.value.into(), &locator).kind();
+        let string_kind = normalizer
+            .choose_quotes(self.value.into(), &locator)
+            .flags();
 
         let context = FStringContext::new(
             string_kind,
@@ -83,17 +85,17 @@ impl Format<PyFormatContext<'_>> for FormatFString<'_> {
 
 #[derive(Clone, Copy, Debug)]
 pub(crate) struct FStringContext {
-    kind: AnyStringKind,
+    flags: AnyStringFlags,
     layout: FStringLayout,
 }
 
 impl FStringContext {
-    const fn new(kind: AnyStringKind, layout: FStringLayout) -> Self {
-        Self { kind, layout }
+    const fn new(flags: AnyStringFlags, layout: FStringLayout) -> Self {
+        Self { flags, layout }
     }
 
-    pub(crate) fn kind(self) -> AnyStringKind {
-        self.kind
+    pub(crate) fn flags(self) -> AnyStringFlags {
+        self.flags
     }
 
     pub(crate) const fn layout(self) -> FStringLayout {

--- a/crates/ruff_python_formatter/src/other/f_string_element.rs
+++ b/crates/ruff_python_formatter/src/other/f_string_element.rs
@@ -56,7 +56,7 @@ impl<'a> FormatFStringLiteralElement<'a> {
 impl Format<PyFormatContext<'_>> for FormatFStringLiteralElement<'_> {
     fn fmt(&self, f: &mut PyFormatter) -> FormatResult<()> {
         let literal_content = f.context().locator().slice(self.element.range());
-        let normalized = normalize_string(literal_content, 0, self.context.kind(), true);
+        let normalized = normalize_string(literal_content, 0, self.context.flags(), true);
         match &normalized {
             Cow::Borrowed(_) => source_text_slice(self.element.range()).fmt(f),
             Cow::Owned(normalized) => text(normalized).fmt(f),
@@ -102,7 +102,7 @@ impl FStringExpressionElementContext {
             // But, if the original source code already contained a newline, they'll be preserved.
             //
             // The Python version is irrelevant in this case.
-            && !(self.parent_context.kind().is_triple_quoted() && self.has_format_spec)
+            && !(self.parent_context.flags().is_triple_quoted() && self.has_format_spec)
     }
 }
 

--- a/crates/ruff_python_formatter/src/string/any.rs
+++ b/crates/ruff_python_formatter/src/string/any.rs
@@ -3,8 +3,8 @@ use std::iter::FusedIterator;
 use memchr::memchr2;
 
 use ruff_python_ast::{
-    self as ast, AnyNodeRef, AnyStringKind, Expr, ExprBytesLiteral, ExprFString, ExprStringLiteral,
-    ExpressionRef, StringLiteral,
+    self as ast, AnyNodeRef, AnyStringFlags, Expr, ExprBytesLiteral, ExprFString,
+    ExprStringLiteral, ExpressionRef, StringLiteral,
 };
 use ruff_source_file::Locator;
 use ruff_text_size::{Ranged, TextRange};
@@ -72,7 +72,7 @@ impl<'a> AnyString<'a> {
             AnyString::String(_) | AnyString::Bytes(_) => {
                 self.parts(Quoting::default())
                     .next()
-                    .is_some_and(|part| part.kind().is_triple_quoted())
+                    .is_some_and(|part| part.flags().is_triple_quoted())
                     && memchr2(b'\n', b'\r', source[self.range()].as_bytes()).is_some()
             }
             AnyString::FString(fstring) => {
@@ -176,7 +176,7 @@ pub(super) enum AnyStringPart<'a> {
 }
 
 impl AnyStringPart<'_> {
-    fn kind(&self) -> AnyStringKind {
+    fn flags(&self) -> AnyStringFlags {
         match self {
             Self::String { part, .. } => part.flags.into(),
             Self::Bytes(bytes_literal) => bytes_literal.flags.into(),

--- a/crates/ruff_python_formatter/src/string/docstring.rs
+++ b/crates/ruff_python_formatter/src/string/docstring.rs
@@ -127,7 +127,7 @@ pub(crate) fn format(normalized: &NormalizedString, f: &mut PyFormatter) -> Form
     let mut lines = docstring.split('\n').peekable();
 
     // Start the string
-    let kind = normalized.kind();
+    let kind = normalized.flags();
     let quotes = StringQuotes::from(kind);
     write!(f, [kind.prefix(), quotes])?;
     // We track where in the source docstring we are (in source code byte offsets)
@@ -1573,7 +1573,7 @@ fn docstring_format_source(
 /// that avoids `content""""` and `content\"""`. This does only applies to un-escaped backslashes,
 /// so `content\\ """` doesn't need a space while `content\\\ """` does.
 fn needs_chaperone_space(normalized: &NormalizedString, trim_end: &str) -> bool {
-    trim_end.ends_with(normalized.kind().quote_style().as_char())
+    trim_end.ends_with(normalized.flags().quote_style().as_char())
         || trim_end.chars().rev().take_while(|c| *c == '\\').count() % 2 == 1
 }
 

--- a/crates/ruff_python_formatter/src/string/mod.rs
+++ b/crates/ruff_python_formatter/src/string/mod.rs
@@ -2,7 +2,7 @@ pub(crate) use any::AnyString;
 pub(crate) use normalize::{normalize_string, NormalizedString, StringNormalizer};
 use ruff_formatter::format_args;
 use ruff_python_ast::str::Quote;
-use ruff_python_ast::{self as ast, AnyStringKind, AnyStringPrefix};
+use ruff_python_ast::{self as ast, AnyStringFlags, AnyStringPrefix};
 use ruff_text_size::{Ranged, TextRange};
 
 use crate::comments::{leading_comments, trailing_comments};
@@ -87,8 +87,8 @@ impl Format<PyFormatContext<'_>> for StringQuotes {
     }
 }
 
-impl From<AnyStringKind> for StringQuotes {
-    fn from(value: AnyStringKind) -> Self {
+impl From<AnyStringFlags> for StringQuotes {
+    fn from(value: AnyStringFlags) -> Self {
         Self {
             triple: value.is_triple_quoted(),
             quote_char: value.quote_style(),
@@ -119,7 +119,7 @@ impl From<Quote> for QuoteStyle {
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct StringPart {
-    kind: AnyStringKind,
+    flags: AnyStringFlags,
     range: TextRange,
 }
 
@@ -131,13 +131,13 @@ impl Ranged for StringPart {
 
 impl StringPart {
     /// Use the `kind()` method to retrieve information about the
-    fn kind(self) -> AnyStringKind {
-        self.kind
+    fn flags(self) -> AnyStringFlags {
+        self.flags
     }
 
     /// Returns the range of the string's content in the source (minus prefix and quotes).
     fn content_range(self) -> TextRange {
-        let kind = self.kind();
+        let kind = self.flags();
         TextRange::new(
             self.start() + kind.opener_len(),
             self.end() - kind.closer_len(),
@@ -149,7 +149,7 @@ impl From<&ast::StringLiteral> for StringPart {
     fn from(value: &ast::StringLiteral) -> Self {
         Self {
             range: value.range,
-            kind: value.flags.into(),
+            flags: value.flags.into(),
         }
     }
 }
@@ -158,7 +158,7 @@ impl From<&ast::BytesLiteral> for StringPart {
     fn from(value: &ast::BytesLiteral) -> Self {
         Self {
             range: value.range,
-            kind: value.flags.into(),
+            flags: value.flags.into(),
         }
     }
 }
@@ -167,7 +167,7 @@ impl From<&ast::FString> for StringPart {
     fn from(value: &ast::FString) -> Self {
         Self {
             range: value.range,
-            kind: value.flags.into(),
+            flags: value.flags.into(),
         }
     }
 }

--- a/crates/ruff_python_index/src/multiline_ranges.rs
+++ b/crates/ruff_python_index/src/multiline_ranges.rs
@@ -46,8 +46,8 @@ pub(crate) struct MultilineRangesBuilder {
 
 impl MultilineRangesBuilder {
     pub(crate) fn visit_token(&mut self, token: &Tok, range: TextRange) {
-        if let Tok::String { kind, .. } | Tok::FStringMiddle { kind, .. } = token {
-            if kind.is_triple_quoted() {
+        if let Tok::String { flags, .. } | Tok::FStringMiddle { flags, .. } = token {
+            if flags.is_triple_quoted() {
                 self.ranges.push(range);
             }
         }

--- a/crates/ruff_python_parser/src/lexer/fstring.rs
+++ b/crates/ruff_python_parser/src/lexer/fstring.rs
@@ -1,9 +1,9 @@
-use ruff_python_ast::AnyStringKind;
+use ruff_python_ast::AnyStringFlags;
 
 /// The context representing the current f-string that the lexer is in.
 #[derive(Debug)]
 pub(crate) struct FStringContext {
-    kind: AnyStringKind,
+    flags: AnyStringFlags,
 
     /// The level of nesting for the lexer when it entered the current f-string.
     /// The nesting level includes all kinds of parentheses i.e., round, square,
@@ -17,18 +17,18 @@ pub(crate) struct FStringContext {
 }
 
 impl FStringContext {
-    pub(crate) const fn new(kind: AnyStringKind, nesting: u32) -> Self {
-        debug_assert!(kind.is_f_string());
+    pub(crate) const fn new(flags: AnyStringFlags, nesting: u32) -> Self {
+        debug_assert!(flags.is_f_string());
         Self {
-            kind,
+            flags,
             nesting,
             format_spec_depth: 0,
         }
     }
 
-    pub(crate) const fn kind(&self) -> AnyStringKind {
-        debug_assert!(self.kind.is_f_string());
-        self.kind
+    pub(crate) const fn flags(&self) -> AnyStringFlags {
+        debug_assert!(self.flags.is_f_string());
+        self.flags
     }
 
     pub(crate) const fn nesting(&self) -> u32 {
@@ -37,14 +37,14 @@ impl FStringContext {
 
     /// Returns the quote character for the current f-string.
     pub(crate) const fn quote_char(&self) -> char {
-        self.kind.quote_style().as_char()
+        self.flags.quote_style().as_char()
     }
 
     /// Returns the triple quotes for the current f-string if it is a triple-quoted
     /// f-string, `None` otherwise.
     pub(crate) const fn triple_quotes(&self) -> Option<&'static str> {
         if self.is_triple_quoted() {
-            Some(self.kind.quote_str())
+            Some(self.flags.quote_str())
         } else {
             None
         }
@@ -52,12 +52,12 @@ impl FStringContext {
 
     /// Returns `true` if the current f-string is a raw f-string.
     pub(crate) fn is_raw_string(&self) -> bool {
-        self.kind.is_raw_string()
+        self.flags.is_raw_string()
     }
 
     /// Returns `true` if the current f-string is a triple-quoted f-string.
     pub(crate) const fn is_triple_quoted(&self) -> bool {
-        self.kind.is_triple_quoted()
+        self.flags.is_triple_quoted()
     }
 
     /// Calculates the number of open parentheses for the current f-string

--- a/crates/ruff_python_parser/src/parser/expression.rs
+++ b/crates/ruff_python_parser/src/parser/expression.rs
@@ -1231,17 +1231,17 @@ impl<'src> Parser<'src> {
     ///
     /// See: <https://docs.python.org/3.13/reference/lexical_analysis.html#string-and-bytes-literals>
     fn parse_string_or_byte_literal(&mut self) -> StringType {
-        let (Tok::String { value, kind }, range) = self.bump(TokenKind::String) else {
+        let (Tok::String { value, flags }, range) = self.bump(TokenKind::String) else {
             unreachable!()
         };
 
-        match parse_string_literal(value, kind, range) {
+        match parse_string_literal(value, flags, range) {
             Ok(string) => string,
             Err(error) => {
                 let location = error.location();
                 self.add_error(ParseErrorType::Lexical(error.into_error()), location);
 
-                if kind.is_byte_string() {
+                if flags.is_byte_string() {
                     // test_err invalid_byte_literal
                     // b'123a𝐁c'
                     // rb"a𝐁c123"
@@ -1249,7 +1249,7 @@ impl<'src> Parser<'src> {
                     StringType::Bytes(ast::BytesLiteral {
                         value: Box::new([]),
                         range,
-                        flags: ast::BytesLiteralFlags::from(kind).with_invalid(),
+                        flags: ast::BytesLiteralFlags::from(flags).with_invalid(),
                     })
                 } else {
                     // test_err invalid_string_literal
@@ -1258,7 +1258,7 @@ impl<'src> Parser<'src> {
                     StringType::Str(ast::StringLiteral {
                         value: "".into(),
                         range,
-                        flags: ast::StringLiteralFlags::from(kind).with_invalid(),
+                        flags: ast::StringLiteralFlags::from(flags).with_invalid(),
                     })
                 }
             }
@@ -1306,12 +1306,12 @@ impl<'src> Parser<'src> {
                     FStringElement::Expression(parser.parse_fstring_expression_element())
                 }
                 TokenKind::FStringMiddle => {
-                    let (Tok::FStringMiddle { value, kind, .. }, range) = parser.next_token()
+                    let (Tok::FStringMiddle { value, flags, .. }, range) = parser.next_token()
                     else {
                         unreachable!()
                     };
                     FStringElement::Literal(
-                        parse_fstring_literal_element(value, kind, range).unwrap_or_else(
+                        parse_fstring_literal_element(value, flags, range).unwrap_or_else(
                             |lex_error| {
                                 // test_err invalid_fstring_literal_element
                                 // f'hello \N{INVALID} world'

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__empty_fstrings.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__empty_fstrings.snap
@@ -5,7 +5,7 @@ expression: lex_source(source)
 [
     (
         FStringStart(
-            StringKind {
+            AnyStringFlags {
                 prefix: Format(
                     Regular,
                 ),
@@ -22,7 +22,7 @@ expression: lex_source(source)
     (
         String {
             value: "",
-            flags: StringKind {
+            flags: AnyStringFlags {
                 prefix: Regular(
                     Empty,
                 ),
@@ -34,7 +34,7 @@ expression: lex_source(source)
     ),
     (
         FStringStart(
-            StringKind {
+            AnyStringFlags {
                 prefix: Format(
                     Regular,
                 ),
@@ -50,7 +50,7 @@ expression: lex_source(source)
     ),
     (
         FStringStart(
-            StringKind {
+            AnyStringFlags {
                 prefix: Format(
                     Regular,
                 ),
@@ -67,7 +67,7 @@ expression: lex_source(source)
     (
         String {
             value: "",
-            flags: StringKind {
+            flags: AnyStringFlags {
                 prefix: Regular(
                     Empty,
                 ),
@@ -79,7 +79,7 @@ expression: lex_source(source)
     ),
     (
         FStringStart(
-            StringKind {
+            AnyStringFlags {
                 prefix: Format(
                     Regular,
                 ),
@@ -95,7 +95,7 @@ expression: lex_source(source)
     ),
     (
         FStringStart(
-            StringKind {
+            AnyStringFlags {
                 prefix: Format(
                     Regular,
                 ),

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__empty_fstrings.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__empty_fstrings.snap
@@ -22,7 +22,7 @@ expression: lex_source(source)
     (
         String {
             value: "",
-            kind: StringKind {
+            flags: StringKind {
                 prefix: Regular(
                     Empty,
                 ),
@@ -67,7 +67,7 @@ expression: lex_source(source)
     (
         String {
             value: "",
-            kind: StringKind {
+            flags: StringKind {
                 prefix: Regular(
                     Empty,
                 ),

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__escape_unicode_name.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__escape_unicode_name.snap
@@ -6,7 +6,7 @@ expression: lex_source(source)
     (
         String {
             value: "\\N{EN SPACE}",
-            kind: StringKind {
+            flags: StringKind {
                 prefix: Regular(
                     Empty,
                 ),

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__escape_unicode_name.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__escape_unicode_name.snap
@@ -6,7 +6,7 @@ expression: lex_source(source)
     (
         String {
             value: "\\N{EN SPACE}",
-            flags: StringKind {
+            flags: AnyStringFlags {
                 prefix: Regular(
                     Empty,
                 ),

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring.snap
@@ -18,7 +18,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: "normal ",
-            kind: StringKind {
+            flags: StringKind {
                 prefix: Format(
                     Regular,
                 ),
@@ -45,7 +45,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: " {another} ",
-            kind: StringKind {
+            flags: StringKind {
                 prefix: Format(
                     Regular,
                 ),
@@ -72,7 +72,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: " {",
-            kind: StringKind {
+            flags: StringKind {
                 prefix: Format(
                     Regular,
                 ),
@@ -99,7 +99,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: "}",
-            kind: StringKind {
+            flags: StringKind {
                 prefix: Format(
                     Regular,
                 ),

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring.snap
@@ -5,7 +5,7 @@ expression: lex_source(source)
 [
     (
         FStringStart(
-            StringKind {
+            AnyStringFlags {
                 prefix: Format(
                     Regular,
                 ),
@@ -18,7 +18,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: "normal ",
-            flags: StringKind {
+            flags: AnyStringFlags {
                 prefix: Format(
                     Regular,
                 ),
@@ -45,7 +45,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: " {another} ",
-            flags: StringKind {
+            flags: AnyStringFlags {
                 prefix: Format(
                     Regular,
                 ),
@@ -72,7 +72,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: " {",
-            flags: StringKind {
+            flags: AnyStringFlags {
                 prefix: Format(
                     Regular,
                 ),
@@ -99,7 +99,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: "}",
-            flags: StringKind {
+            flags: AnyStringFlags {
                 prefix: Format(
                     Regular,
                 ),

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_comments.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_comments.snap
@@ -18,7 +18,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: "\n# not a comment ",
-            kind: StringKind {
+            flags: StringKind {
                 prefix: Format(
                     Regular,
                 ),
@@ -59,7 +59,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: " # not a comment\n",
-            kind: StringKind {
+            flags: StringKind {
                 prefix: Format(
                     Regular,
                 ),

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_comments.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_comments.snap
@@ -5,7 +5,7 @@ expression: lex_source(source)
 [
     (
         FStringStart(
-            StringKind {
+            AnyStringFlags {
                 prefix: Format(
                     Regular,
                 ),
@@ -18,7 +18,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: "\n# not a comment ",
-            flags: StringKind {
+            flags: AnyStringFlags {
                 prefix: Format(
                     Regular,
                 ),
@@ -59,7 +59,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: " # not a comment\n",
-            flags: StringKind {
+            flags: AnyStringFlags {
                 prefix: Format(
                     Regular,
                 ),

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_conversion.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_conversion.snap
@@ -42,7 +42,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: " ",
-            kind: StringKind {
+            flags: StringKind {
                 prefix: Format(
                     Regular,
                 ),
@@ -83,7 +83,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: " ",
-            kind: StringKind {
+            flags: StringKind {
                 prefix: Format(
                     Regular,
                 ),
@@ -110,7 +110,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: ".3f!r",
-            kind: StringKind {
+            flags: StringKind {
                 prefix: Format(
                     Regular,
                 ),
@@ -127,7 +127,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: " {x!r}",
-            kind: StringKind {
+            flags: StringKind {
                 prefix: Format(
                     Regular,
                 ),

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_conversion.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_conversion.snap
@@ -5,7 +5,7 @@ expression: lex_source(source)
 [
     (
         FStringStart(
-            StringKind {
+            AnyStringFlags {
                 prefix: Format(
                     Regular,
                 ),
@@ -42,7 +42,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: " ",
-            flags: StringKind {
+            flags: AnyStringFlags {
                 prefix: Format(
                     Regular,
                 ),
@@ -83,7 +83,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: " ",
-            flags: StringKind {
+            flags: AnyStringFlags {
                 prefix: Format(
                     Regular,
                 ),
@@ -110,7 +110,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: ".3f!r",
-            flags: StringKind {
+            flags: AnyStringFlags {
                 prefix: Format(
                     Regular,
                 ),
@@ -127,7 +127,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: " {x!r}",
-            flags: StringKind {
+            flags: AnyStringFlags {
                 prefix: Format(
                     Regular,
                 ),

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_escape.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_escape.snap
@@ -5,7 +5,7 @@ expression: lex_source(source)
 [
     (
         FStringStart(
-            StringKind {
+            AnyStringFlags {
                 prefix: Format(
                     Regular,
                 ),
@@ -18,7 +18,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: "\\",
-            flags: StringKind {
+            flags: AnyStringFlags {
                 prefix: Format(
                     Regular,
                 ),
@@ -45,7 +45,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: "\\\"\\",
-            flags: StringKind {
+            flags: AnyStringFlags {
                 prefix: Format(
                     Regular,
                 ),
@@ -76,7 +76,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: " \\\"\\\"\\\n end",
-            flags: StringKind {
+            flags: AnyStringFlags {
                 prefix: Format(
                     Regular,
                 ),

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_escape.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_escape.snap
@@ -18,7 +18,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: "\\",
-            kind: StringKind {
+            flags: StringKind {
                 prefix: Format(
                     Regular,
                 ),
@@ -45,7 +45,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: "\\\"\\",
-            kind: StringKind {
+            flags: StringKind {
                 prefix: Format(
                     Regular,
                 ),
@@ -76,7 +76,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: " \\\"\\\"\\\n end",
-            kind: StringKind {
+            flags: StringKind {
                 prefix: Format(
                     Regular,
                 ),

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_escape_braces.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_escape_braces.snap
@@ -18,7 +18,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: "\\",
-            kind: StringKind {
+            flags: StringKind {
                 prefix: Format(
                     Regular,
                 ),
@@ -61,7 +61,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: "\\\\",
-            kind: StringKind {
+            flags: StringKind {
                 prefix: Format(
                     Regular,
                 ),
@@ -104,7 +104,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: "\\{foo}",
-            kind: StringKind {
+            flags: StringKind {
                 prefix: Format(
                     Regular,
                 ),
@@ -133,7 +133,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: "\\\\{foo}",
-            kind: StringKind {
+            flags: StringKind {
                 prefix: Format(
                     Regular,
                 ),

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_escape_braces.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_escape_braces.snap
@@ -5,7 +5,7 @@ expression: lex_source(source)
 [
     (
         FStringStart(
-            StringKind {
+            AnyStringFlags {
                 prefix: Format(
                     Regular,
                 ),
@@ -18,7 +18,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: "\\",
-            flags: StringKind {
+            flags: AnyStringFlags {
                 prefix: Format(
                     Regular,
                 ),
@@ -48,7 +48,7 @@ expression: lex_source(source)
     ),
     (
         FStringStart(
-            StringKind {
+            AnyStringFlags {
                 prefix: Format(
                     Regular,
                 ),
@@ -61,7 +61,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: "\\\\",
-            flags: StringKind {
+            flags: AnyStringFlags {
                 prefix: Format(
                     Regular,
                 ),
@@ -91,7 +91,7 @@ expression: lex_source(source)
     ),
     (
         FStringStart(
-            StringKind {
+            AnyStringFlags {
                 prefix: Format(
                     Regular,
                 ),
@@ -104,7 +104,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: "\\{foo}",
-            flags: StringKind {
+            flags: AnyStringFlags {
                 prefix: Format(
                     Regular,
                 ),
@@ -120,7 +120,7 @@ expression: lex_source(source)
     ),
     (
         FStringStart(
-            StringKind {
+            AnyStringFlags {
                 prefix: Format(
                     Regular,
                 ),
@@ -133,7 +133,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: "\\\\{foo}",
-            flags: StringKind {
+            flags: AnyStringFlags {
                 prefix: Format(
                     Regular,
                 ),

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_escape_raw.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_escape_raw.snap
@@ -20,7 +20,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: "\\",
-            kind: StringKind {
+            flags: StringKind {
                 prefix: Format(
                     Raw {
                         uppercase_r: false,
@@ -49,7 +49,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: "\\\"\\",
-            kind: StringKind {
+            flags: StringKind {
                 prefix: Format(
                     Raw {
                         uppercase_r: false,
@@ -82,7 +82,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: " \\\"\\\"\\\n end",
-            kind: StringKind {
+            flags: StringKind {
                 prefix: Format(
                     Raw {
                         uppercase_r: false,

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_escape_raw.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_escape_raw.snap
@@ -5,7 +5,7 @@ expression: lex_source(source)
 [
     (
         FStringStart(
-            StringKind {
+            AnyStringFlags {
                 prefix: Format(
                     Raw {
                         uppercase_r: false,
@@ -20,7 +20,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: "\\",
-            flags: StringKind {
+            flags: AnyStringFlags {
                 prefix: Format(
                     Raw {
                         uppercase_r: false,
@@ -49,7 +49,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: "\\\"\\",
-            flags: StringKind {
+            flags: AnyStringFlags {
                 prefix: Format(
                     Raw {
                         uppercase_r: false,
@@ -82,7 +82,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: " \\\"\\\"\\\n end",
-            flags: StringKind {
+            flags: AnyStringFlags {
                 prefix: Format(
                     Raw {
                         uppercase_r: false,

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_expression_multiline.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_expression_multiline.snap
@@ -5,7 +5,7 @@ expression: lex_source(source)
 [
     (
         FStringStart(
-            StringKind {
+            AnyStringFlags {
                 prefix: Format(
                     Regular,
                 ),
@@ -18,7 +18,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: "first ",
-            flags: StringKind {
+            flags: AnyStringFlags {
                 prefix: Format(
                     Regular,
                 ),
@@ -71,7 +71,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: " second",
-            flags: StringKind {
+            flags: AnyStringFlags {
                 prefix: Format(
                     Regular,
                 ),

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_expression_multiline.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_expression_multiline.snap
@@ -18,7 +18,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: "first ",
-            kind: StringKind {
+            flags: StringKind {
                 prefix: Format(
                     Regular,
                 ),
@@ -71,7 +71,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: " second",
-            kind: StringKind {
+            flags: StringKind {
                 prefix: Format(
                     Regular,
                 ),

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_multiline.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_multiline.snap
@@ -5,7 +5,7 @@ expression: lex_source(source)
 [
     (
         FStringStart(
-            StringKind {
+            AnyStringFlags {
                 prefix: Format(
                     Regular,
                 ),
@@ -18,7 +18,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: "\nhello\n    world\n",
-            flags: StringKind {
+            flags: AnyStringFlags {
                 prefix: Format(
                     Regular,
                 ),
@@ -34,7 +34,7 @@ expression: lex_source(source)
     ),
     (
         FStringStart(
-            StringKind {
+            AnyStringFlags {
                 prefix: Format(
                     Regular,
                 ),
@@ -47,7 +47,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: "\n    world\nhello\n",
-            flags: StringKind {
+            flags: AnyStringFlags {
                 prefix: Format(
                     Regular,
                 ),
@@ -63,7 +63,7 @@ expression: lex_source(source)
     ),
     (
         FStringStart(
-            StringKind {
+            AnyStringFlags {
                 prefix: Format(
                     Regular,
                 ),
@@ -76,7 +76,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: "some ",
-            flags: StringKind {
+            flags: AnyStringFlags {
                 prefix: Format(
                     Regular,
                 ),
@@ -92,7 +92,7 @@ expression: lex_source(source)
     ),
     (
         FStringStart(
-            StringKind {
+            AnyStringFlags {
                 prefix: Format(
                     Regular,
                 ),
@@ -105,7 +105,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: "multiline\nallowed ",
-            flags: StringKind {
+            flags: AnyStringFlags {
                 prefix: Format(
                     Regular,
                 ),
@@ -140,7 +140,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: " string",
-            flags: StringKind {
+            flags: AnyStringFlags {
                 prefix: Format(
                     Regular,
                 ),

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_multiline.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_multiline.snap
@@ -18,7 +18,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: "\nhello\n    world\n",
-            kind: StringKind {
+            flags: StringKind {
                 prefix: Format(
                     Regular,
                 ),
@@ -47,7 +47,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: "\n    world\nhello\n",
-            kind: StringKind {
+            flags: StringKind {
                 prefix: Format(
                     Regular,
                 ),
@@ -76,7 +76,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: "some ",
-            kind: StringKind {
+            flags: StringKind {
                 prefix: Format(
                     Regular,
                 ),
@@ -105,7 +105,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: "multiline\nallowed ",
-            kind: StringKind {
+            flags: StringKind {
                 prefix: Format(
                     Regular,
                 ),
@@ -140,7 +140,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: " string",
-            kind: StringKind {
+            flags: StringKind {
                 prefix: Format(
                     Regular,
                 ),

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_named_unicode.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_named_unicode.snap
@@ -18,7 +18,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: "\\N{BULLET} normal \\Nope \\N",
-            kind: StringKind {
+            flags: StringKind {
                 prefix: Format(
                     Regular,
                 ),

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_named_unicode.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_named_unicode.snap
@@ -5,7 +5,7 @@ expression: lex_source(source)
 [
     (
         FStringStart(
-            StringKind {
+            AnyStringFlags {
                 prefix: Format(
                     Regular,
                 ),
@@ -18,7 +18,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: "\\N{BULLET} normal \\Nope \\N",
-            flags: StringKind {
+            flags: AnyStringFlags {
                 prefix: Format(
                     Regular,
                 ),

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_named_unicode_raw.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_named_unicode_raw.snap
@@ -20,7 +20,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: "\\N",
-            kind: StringKind {
+            flags: StringKind {
                 prefix: Format(
                     Raw {
                         uppercase_r: false,
@@ -49,7 +49,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: " normal",
-            kind: StringKind {
+            flags: StringKind {
                 prefix: Format(
                     Raw {
                         uppercase_r: false,

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_named_unicode_raw.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_named_unicode_raw.snap
@@ -5,7 +5,7 @@ expression: lex_source(source)
 [
     (
         FStringStart(
-            StringKind {
+            AnyStringFlags {
                 prefix: Format(
                     Raw {
                         uppercase_r: false,
@@ -20,7 +20,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: "\\N",
-            flags: StringKind {
+            flags: AnyStringFlags {
                 prefix: Format(
                     Raw {
                         uppercase_r: false,
@@ -49,7 +49,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: " normal",
-            flags: StringKind {
+            flags: AnyStringFlags {
                 prefix: Format(
                     Raw {
                         uppercase_r: false,

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_nested.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_nested.snap
@@ -18,7 +18,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: "foo ",
-            kind: StringKind {
+            flags: StringKind {
                 prefix: Format(
                     Regular,
                 ),
@@ -47,7 +47,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: "bar ",
-            kind: StringKind {
+            flags: StringKind {
                 prefix: Format(
                     Regular,
                 ),
@@ -116,7 +116,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: " baz",
-            kind: StringKind {
+            flags: StringKind {
                 prefix: Format(
                     Regular,
                 ),
@@ -145,7 +145,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: "foo ",
-            kind: StringKind {
+            flags: StringKind {
                 prefix: Format(
                     Regular,
                 ),
@@ -174,7 +174,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: "bar",
-            kind: StringKind {
+            flags: StringKind {
                 prefix: Format(
                     Regular,
                 ),
@@ -195,7 +195,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: " some ",
-            kind: StringKind {
+            flags: StringKind {
                 prefix: Format(
                     Regular,
                 ),
@@ -224,7 +224,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: "another",
-            kind: StringKind {
+            flags: StringKind {
                 prefix: Format(
                     Regular,
                 ),

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_nested.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_nested.snap
@@ -5,7 +5,7 @@ expression: lex_source(source)
 [
     (
         FStringStart(
-            StringKind {
+            AnyStringFlags {
                 prefix: Format(
                     Regular,
                 ),
@@ -18,7 +18,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: "foo ",
-            flags: StringKind {
+            flags: AnyStringFlags {
                 prefix: Format(
                     Regular,
                 ),
@@ -34,7 +34,7 @@ expression: lex_source(source)
     ),
     (
         FStringStart(
-            StringKind {
+            AnyStringFlags {
                 prefix: Format(
                     Regular,
                 ),
@@ -47,7 +47,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: "bar ",
-            flags: StringKind {
+            flags: AnyStringFlags {
                 prefix: Format(
                     Regular,
                 ),
@@ -73,7 +73,7 @@ expression: lex_source(source)
     ),
     (
         FStringStart(
-            StringKind {
+            AnyStringFlags {
                 prefix: Format(
                     Regular,
                 ),
@@ -116,7 +116,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: " baz",
-            flags: StringKind {
+            flags: AnyStringFlags {
                 prefix: Format(
                     Regular,
                 ),
@@ -132,7 +132,7 @@ expression: lex_source(source)
     ),
     (
         FStringStart(
-            StringKind {
+            AnyStringFlags {
                 prefix: Format(
                     Regular,
                 ),
@@ -145,7 +145,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: "foo ",
-            flags: StringKind {
+            flags: AnyStringFlags {
                 prefix: Format(
                     Regular,
                 ),
@@ -161,7 +161,7 @@ expression: lex_source(source)
     ),
     (
         FStringStart(
-            StringKind {
+            AnyStringFlags {
                 prefix: Format(
                     Regular,
                 ),
@@ -174,7 +174,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: "bar",
-            flags: StringKind {
+            flags: AnyStringFlags {
                 prefix: Format(
                     Regular,
                 ),
@@ -195,7 +195,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: " some ",
-            flags: StringKind {
+            flags: AnyStringFlags {
                 prefix: Format(
                     Regular,
                 ),
@@ -211,7 +211,7 @@ expression: lex_source(source)
     ),
     (
         FStringStart(
-            StringKind {
+            AnyStringFlags {
                 prefix: Format(
                     Regular,
                 ),
@@ -224,7 +224,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: "another",
-            flags: StringKind {
+            flags: AnyStringFlags {
                 prefix: Format(
                     Regular,
                 ),

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_parentheses.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_parentheses.snap
@@ -42,7 +42,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: "{}",
-            kind: StringKind {
+            flags: StringKind {
                 prefix: Format(
                     Regular,
                 ),
@@ -71,7 +71,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: " ",
-            kind: StringKind {
+            flags: StringKind {
                 prefix: Format(
                     Regular,
                 ),
@@ -108,7 +108,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: "{",
-            kind: StringKind {
+            flags: StringKind {
                 prefix: Format(
                     Regular,
                 ),
@@ -129,7 +129,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: "}",
-            kind: StringKind {
+            flags: StringKind {
                 prefix: Format(
                     Regular,
                 ),
@@ -158,7 +158,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: "{{}}",
-            kind: StringKind {
+            flags: StringKind {
                 prefix: Format(
                     Regular,
                 ),
@@ -187,7 +187,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: " ",
-            kind: StringKind {
+            flags: StringKind {
                 prefix: Format(
                     Regular,
                 ),
@@ -208,7 +208,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: " {} {",
-            kind: StringKind {
+            flags: StringKind {
                 prefix: Format(
                     Regular,
                 ),
@@ -229,7 +229,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: "} {{}}  ",
-            kind: StringKind {
+            flags: StringKind {
                 prefix: Format(
                     Regular,
                 ),

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_parentheses.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_parentheses.snap
@@ -5,7 +5,7 @@ expression: lex_source(source)
 [
     (
         FStringStart(
-            StringKind {
+            AnyStringFlags {
                 prefix: Format(
                     Regular,
                 ),
@@ -29,7 +29,7 @@ expression: lex_source(source)
     ),
     (
         FStringStart(
-            StringKind {
+            AnyStringFlags {
                 prefix: Format(
                     Regular,
                 ),
@@ -42,7 +42,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: "{}",
-            flags: StringKind {
+            flags: AnyStringFlags {
                 prefix: Format(
                     Regular,
                 ),
@@ -58,7 +58,7 @@ expression: lex_source(source)
     ),
     (
         FStringStart(
-            StringKind {
+            AnyStringFlags {
                 prefix: Format(
                     Regular,
                 ),
@@ -71,7 +71,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: " ",
-            flags: StringKind {
+            flags: AnyStringFlags {
                 prefix: Format(
                     Regular,
                 ),
@@ -95,7 +95,7 @@ expression: lex_source(source)
     ),
     (
         FStringStart(
-            StringKind {
+            AnyStringFlags {
                 prefix: Format(
                     Regular,
                 ),
@@ -108,7 +108,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: "{",
-            flags: StringKind {
+            flags: AnyStringFlags {
                 prefix: Format(
                     Regular,
                 ),
@@ -129,7 +129,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: "}",
-            flags: StringKind {
+            flags: AnyStringFlags {
                 prefix: Format(
                     Regular,
                 ),
@@ -145,7 +145,7 @@ expression: lex_source(source)
     ),
     (
         FStringStart(
-            StringKind {
+            AnyStringFlags {
                 prefix: Format(
                     Regular,
                 ),
@@ -158,7 +158,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: "{{}}",
-            flags: StringKind {
+            flags: AnyStringFlags {
                 prefix: Format(
                     Regular,
                 ),
@@ -174,7 +174,7 @@ expression: lex_source(source)
     ),
     (
         FStringStart(
-            StringKind {
+            AnyStringFlags {
                 prefix: Format(
                     Regular,
                 ),
@@ -187,7 +187,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: " ",
-            flags: StringKind {
+            flags: AnyStringFlags {
                 prefix: Format(
                     Regular,
                 ),
@@ -208,7 +208,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: " {} {",
-            flags: StringKind {
+            flags: AnyStringFlags {
                 prefix: Format(
                     Regular,
                 ),
@@ -229,7 +229,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: "} {{}}  ",
-            flags: StringKind {
+            flags: AnyStringFlags {
                 prefix: Format(
                     Regular,
                 ),

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_prefix.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_prefix.snap
@@ -5,7 +5,7 @@ expression: lex_source(source)
 [
     (
         FStringStart(
-            StringKind {
+            AnyStringFlags {
                 prefix: Format(
                     Regular,
                 ),
@@ -21,7 +21,7 @@ expression: lex_source(source)
     ),
     (
         FStringStart(
-            StringKind {
+            AnyStringFlags {
                 prefix: Format(
                     Regular,
                 ),
@@ -37,7 +37,7 @@ expression: lex_source(source)
     ),
     (
         FStringStart(
-            StringKind {
+            AnyStringFlags {
                 prefix: Format(
                     Raw {
                         uppercase_r: false,
@@ -55,7 +55,7 @@ expression: lex_source(source)
     ),
     (
         FStringStart(
-            StringKind {
+            AnyStringFlags {
                 prefix: Format(
                     Raw {
                         uppercase_r: false,
@@ -73,7 +73,7 @@ expression: lex_source(source)
     ),
     (
         FStringStart(
-            StringKind {
+            AnyStringFlags {
                 prefix: Format(
                     Raw {
                         uppercase_r: true,
@@ -91,7 +91,7 @@ expression: lex_source(source)
     ),
     (
         FStringStart(
-            StringKind {
+            AnyStringFlags {
                 prefix: Format(
                     Raw {
                         uppercase_r: true,
@@ -109,7 +109,7 @@ expression: lex_source(source)
     ),
     (
         FStringStart(
-            StringKind {
+            AnyStringFlags {
                 prefix: Format(
                     Raw {
                         uppercase_r: false,
@@ -127,7 +127,7 @@ expression: lex_source(source)
     ),
     (
         FStringStart(
-            StringKind {
+            AnyStringFlags {
                 prefix: Format(
                     Raw {
                         uppercase_r: false,
@@ -145,7 +145,7 @@ expression: lex_source(source)
     ),
     (
         FStringStart(
-            StringKind {
+            AnyStringFlags {
                 prefix: Format(
                     Raw {
                         uppercase_r: true,
@@ -163,7 +163,7 @@ expression: lex_source(source)
     ),
     (
         FStringStart(
-            StringKind {
+            AnyStringFlags {
                 prefix: Format(
                     Raw {
                         uppercase_r: true,

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_single_quote_escape_mac_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_single_quote_escape_mac_eol.snap
@@ -5,7 +5,7 @@ expression: fstring_single_quote_escape_eol(MAC_EOL)
 [
     (
         FStringStart(
-            StringKind {
+            AnyStringFlags {
                 prefix: Format(
                     Regular,
                 ),
@@ -18,7 +18,7 @@ expression: fstring_single_quote_escape_eol(MAC_EOL)
     (
         FStringMiddle {
             value: "text \\\r more text",
-            flags: StringKind {
+            flags: AnyStringFlags {
                 prefix: Format(
                     Regular,
                 ),

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_single_quote_escape_mac_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_single_quote_escape_mac_eol.snap
@@ -18,7 +18,7 @@ expression: fstring_single_quote_escape_eol(MAC_EOL)
     (
         FStringMiddle {
             value: "text \\\r more text",
-            kind: StringKind {
+            flags: StringKind {
                 prefix: Format(
                     Regular,
                 ),

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_single_quote_escape_unix_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_single_quote_escape_unix_eol.snap
@@ -5,7 +5,7 @@ expression: fstring_single_quote_escape_eol(UNIX_EOL)
 [
     (
         FStringStart(
-            StringKind {
+            AnyStringFlags {
                 prefix: Format(
                     Regular,
                 ),
@@ -18,7 +18,7 @@ expression: fstring_single_quote_escape_eol(UNIX_EOL)
     (
         FStringMiddle {
             value: "text \\\n more text",
-            flags: StringKind {
+            flags: AnyStringFlags {
                 prefix: Format(
                     Regular,
                 ),

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_single_quote_escape_unix_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_single_quote_escape_unix_eol.snap
@@ -18,7 +18,7 @@ expression: fstring_single_quote_escape_eol(UNIX_EOL)
     (
         FStringMiddle {
             value: "text \\\n more text",
-            kind: StringKind {
+            flags: StringKind {
                 prefix: Format(
                     Regular,
                 ),

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_single_quote_escape_windows_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_single_quote_escape_windows_eol.snap
@@ -5,7 +5,7 @@ expression: fstring_single_quote_escape_eol(WINDOWS_EOL)
 [
     (
         FStringStart(
-            StringKind {
+            AnyStringFlags {
                 prefix: Format(
                     Regular,
                 ),
@@ -18,7 +18,7 @@ expression: fstring_single_quote_escape_eol(WINDOWS_EOL)
     (
         FStringMiddle {
             value: "text \\\r\n more text",
-            flags: StringKind {
+            flags: AnyStringFlags {
                 prefix: Format(
                     Regular,
                 ),

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_single_quote_escape_windows_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_single_quote_escape_windows_eol.snap
@@ -18,7 +18,7 @@ expression: fstring_single_quote_escape_eol(WINDOWS_EOL)
     (
         FStringMiddle {
             value: "text \\\r\n more text",
-            kind: StringKind {
+            flags: StringKind {
                 prefix: Format(
                     Regular,
                 ),

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_with_format_spec.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_with_format_spec.snap
@@ -36,7 +36,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: " ",
-            kind: StringKind {
+            flags: StringKind {
                 prefix: Format(
                     Regular,
                 ),
@@ -77,7 +77,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: ".3f",
-            kind: StringKind {
+            flags: StringKind {
                 prefix: Format(
                     Regular,
                 ),
@@ -94,7 +94,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: " ",
-            kind: StringKind {
+            flags: StringKind {
                 prefix: Format(
                     Regular,
                 ),
@@ -121,7 +121,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: ".",
-            kind: StringKind {
+            flags: StringKind {
                 prefix: Format(
                     Regular,
                 ),
@@ -148,7 +148,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: "f",
-            kind: StringKind {
+            flags: StringKind {
                 prefix: Format(
                     Regular,
                 ),
@@ -165,7 +165,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: " ",
-            kind: StringKind {
+            flags: StringKind {
                 prefix: Format(
                     Regular,
                 ),
@@ -182,7 +182,7 @@ expression: lex_source(source)
     (
         String {
             value: "",
-            kind: StringKind {
+            flags: StringKind {
                 prefix: Regular(
                     Empty,
                 ),
@@ -199,7 +199,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: "*^",
-            kind: StringKind {
+            flags: StringKind {
                 prefix: Format(
                     Regular,
                 ),
@@ -248,7 +248,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: " ",
-            kind: StringKind {
+            flags: StringKind {
                 prefix: Format(
                     Regular,
                 ),

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_with_format_spec.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_with_format_spec.snap
@@ -5,7 +5,7 @@ expression: lex_source(source)
 [
     (
         FStringStart(
-            StringKind {
+            AnyStringFlags {
                 prefix: Format(
                     Regular,
                 ),
@@ -36,7 +36,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: " ",
-            flags: StringKind {
+            flags: AnyStringFlags {
                 prefix: Format(
                     Regular,
                 ),
@@ -77,7 +77,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: ".3f",
-            flags: StringKind {
+            flags: AnyStringFlags {
                 prefix: Format(
                     Regular,
                 ),
@@ -94,7 +94,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: " ",
-            flags: StringKind {
+            flags: AnyStringFlags {
                 prefix: Format(
                     Regular,
                 ),
@@ -121,7 +121,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: ".",
-            flags: StringKind {
+            flags: AnyStringFlags {
                 prefix: Format(
                     Regular,
                 ),
@@ -148,7 +148,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: "f",
-            flags: StringKind {
+            flags: AnyStringFlags {
                 prefix: Format(
                     Regular,
                 ),
@@ -165,7 +165,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: " ",
-            flags: StringKind {
+            flags: AnyStringFlags {
                 prefix: Format(
                     Regular,
                 ),
@@ -182,7 +182,7 @@ expression: lex_source(source)
     (
         String {
             value: "",
-            flags: StringKind {
+            flags: AnyStringFlags {
                 prefix: Regular(
                     Empty,
                 ),
@@ -199,7 +199,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: "*^",
-            flags: StringKind {
+            flags: AnyStringFlags {
                 prefix: Format(
                     Regular,
                 ),
@@ -248,7 +248,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: " ",
-            flags: StringKind {
+            flags: AnyStringFlags {
                 prefix: Format(
                     Regular,
                 ),

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_with_ipy_escape_command.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_with_ipy_escape_command.snap
@@ -5,7 +5,7 @@ expression: lex_source(source)
 [
     (
         FStringStart(
-            StringKind {
+            AnyStringFlags {
                 prefix: Format(
                     Regular,
                 ),
@@ -18,7 +18,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: "foo ",
-            flags: StringKind {
+            flags: AnyStringFlags {
                 prefix: Format(
                     Regular,
                 ),
@@ -49,7 +49,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: " bar",
-            flags: StringKind {
+            flags: AnyStringFlags {
                 prefix: Format(
                     Regular,
                 ),

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_with_ipy_escape_command.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_with_ipy_escape_command.snap
@@ -18,7 +18,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: "foo ",
-            kind: StringKind {
+            flags: StringKind {
                 prefix: Format(
                     Regular,
                 ),
@@ -49,7 +49,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: " bar",
-            kind: StringKind {
+            flags: StringKind {
                 prefix: Format(
                     Regular,
                 ),

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_with_lambda_expression.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_with_lambda_expression.snap
@@ -5,7 +5,7 @@ expression: lex_source(source)
 [
     (
         FStringStart(
-            StringKind {
+            AnyStringFlags {
                 prefix: Format(
                     Regular,
                 ),
@@ -61,7 +61,7 @@ expression: lex_source(source)
     ),
     (
         FStringStart(
-            StringKind {
+            AnyStringFlags {
                 prefix: Format(
                     Regular,
                 ),

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_with_multiline_format_spec.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_with_multiline_format_spec.snap
@@ -5,7 +5,7 @@ expression: lex_source(source)
 [
     (
         FStringStart(
-            StringKind {
+            AnyStringFlags {
                 prefix: Format(
                     Regular,
                 ),
@@ -18,7 +18,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: "__",
-            flags: StringKind {
+            flags: AnyStringFlags {
                 prefix: Format(
                     Regular,
                 ),
@@ -49,7 +49,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: "d\n",
-            flags: StringKind {
+            flags: AnyStringFlags {
                 prefix: Format(
                     Regular,
                 ),
@@ -66,7 +66,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: "__",
-            flags: StringKind {
+            flags: AnyStringFlags {
                 prefix: Format(
                     Regular,
                 ),
@@ -86,7 +86,7 @@ expression: lex_source(source)
     ),
     (
         FStringStart(
-            StringKind {
+            AnyStringFlags {
                 prefix: Format(
                     Regular,
                 ),
@@ -99,7 +99,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: "__",
-            flags: StringKind {
+            flags: AnyStringFlags {
                 prefix: Format(
                     Regular,
                 ),
@@ -130,7 +130,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: "a\n        b\n          c\n",
-            flags: StringKind {
+            flags: AnyStringFlags {
                 prefix: Format(
                     Regular,
                 ),
@@ -147,7 +147,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: "__",
-            flags: StringKind {
+            flags: AnyStringFlags {
                 prefix: Format(
                     Regular,
                 ),
@@ -167,7 +167,7 @@ expression: lex_source(source)
     ),
     (
         FStringStart(
-            StringKind {
+            AnyStringFlags {
                 prefix: Format(
                     Regular,
                 ),
@@ -180,7 +180,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: "__",
-            flags: StringKind {
+            flags: AnyStringFlags {
                 prefix: Format(
                     Regular,
                 ),
@@ -211,7 +211,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: "d",
-            flags: StringKind {
+            flags: AnyStringFlags {
                 prefix: Format(
                     Regular,
                 ),
@@ -232,7 +232,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: "__",
-            flags: StringKind {
+            flags: AnyStringFlags {
                 prefix: Format(
                     Regular,
                 ),
@@ -252,7 +252,7 @@ expression: lex_source(source)
     ),
     (
         FStringStart(
-            StringKind {
+            AnyStringFlags {
                 prefix: Format(
                     Regular,
                 ),
@@ -265,7 +265,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: "__",
-            flags: StringKind {
+            flags: AnyStringFlags {
                 prefix: Format(
                     Regular,
                 ),
@@ -296,7 +296,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: "a",
-            flags: StringKind {
+            flags: AnyStringFlags {
                 prefix: Format(
                     Regular,
                 ),
@@ -327,7 +327,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: "__",
-            flags: StringKind {
+            flags: AnyStringFlags {
                 prefix: Format(
                     Regular,
                 ),

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_with_multiline_format_spec.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_with_multiline_format_spec.snap
@@ -18,7 +18,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: "__",
-            kind: StringKind {
+            flags: StringKind {
                 prefix: Format(
                     Regular,
                 ),
@@ -49,7 +49,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: "d\n",
-            kind: StringKind {
+            flags: StringKind {
                 prefix: Format(
                     Regular,
                 ),
@@ -66,7 +66,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: "__",
-            kind: StringKind {
+            flags: StringKind {
                 prefix: Format(
                     Regular,
                 ),
@@ -99,7 +99,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: "__",
-            kind: StringKind {
+            flags: StringKind {
                 prefix: Format(
                     Regular,
                 ),
@@ -130,7 +130,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: "a\n        b\n          c\n",
-            kind: StringKind {
+            flags: StringKind {
                 prefix: Format(
                     Regular,
                 ),
@@ -147,7 +147,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: "__",
-            kind: StringKind {
+            flags: StringKind {
                 prefix: Format(
                     Regular,
                 ),
@@ -180,7 +180,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: "__",
-            kind: StringKind {
+            flags: StringKind {
                 prefix: Format(
                     Regular,
                 ),
@@ -211,7 +211,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: "d",
-            kind: StringKind {
+            flags: StringKind {
                 prefix: Format(
                     Regular,
                 ),
@@ -232,7 +232,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: "__",
-            kind: StringKind {
+            flags: StringKind {
                 prefix: Format(
                     Regular,
                 ),
@@ -265,7 +265,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: "__",
-            kind: StringKind {
+            flags: StringKind {
                 prefix: Format(
                     Regular,
                 ),
@@ -296,7 +296,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: "a",
-            kind: StringKind {
+            flags: StringKind {
                 prefix: Format(
                     Regular,
                 ),
@@ -327,7 +327,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: "__",
-            kind: StringKind {
+            flags: StringKind {
                 prefix: Format(
                     Regular,
                 ),

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_with_named_expression.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_with_named_expression.snap
@@ -5,7 +5,7 @@ expression: lex_source(source)
 [
     (
         FStringStart(
-            StringKind {
+            AnyStringFlags {
                 prefix: Format(
                     Regular,
                 ),
@@ -32,7 +32,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: "=10",
-            flags: StringKind {
+            flags: AnyStringFlags {
                 prefix: Format(
                     Regular,
                 ),
@@ -49,7 +49,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: " ",
-            flags: StringKind {
+            flags: AnyStringFlags {
                 prefix: Format(
                     Regular,
                 ),
@@ -94,7 +94,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: " ",
-            flags: StringKind {
+            flags: AnyStringFlags {
                 prefix: Format(
                     Regular,
                 ),
@@ -149,7 +149,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: " ",
-            flags: StringKind {
+            flags: AnyStringFlags {
                 prefix: Format(
                     Regular,
                 ),

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_with_named_expression.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_with_named_expression.snap
@@ -32,7 +32,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: "=10",
-            kind: StringKind {
+            flags: StringKind {
                 prefix: Format(
                     Regular,
                 ),
@@ -49,7 +49,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: " ",
-            kind: StringKind {
+            flags: StringKind {
                 prefix: Format(
                     Regular,
                 ),
@@ -94,7 +94,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: " ",
-            kind: StringKind {
+            flags: StringKind {
                 prefix: Format(
                     Regular,
                 ),
@@ -149,7 +149,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: " ",
-            kind: StringKind {
+            flags: StringKind {
                 prefix: Format(
                     Regular,
                 ),

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_with_nul_char.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_with_nul_char.snap
@@ -18,7 +18,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: "\\0",
-            kind: StringKind {
+            flags: StringKind {
                 prefix: Format(
                     Regular,
                 ),

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_with_nul_char.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_with_nul_char.snap
@@ -5,7 +5,7 @@ expression: lex_source(source)
 [
     (
         FStringStart(
-            StringKind {
+            AnyStringFlags {
                 prefix: Format(
                     Regular,
                 ),
@@ -18,7 +18,7 @@ expression: lex_source(source)
     (
         FStringMiddle {
             value: "\\0",
-            flags: StringKind {
+            flags: AnyStringFlags {
                 prefix: Format(
                     Regular,
                 ),

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__non_logical_newline_in_string_continuation.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__non_logical_newline_in_string_continuation.snap
@@ -14,7 +14,7 @@ expression: lex_source(source)
     (
         String {
             value: "a",
-            flags: StringKind {
+            flags: AnyStringFlags {
                 prefix: Regular(
                     Empty,
                 ),
@@ -31,7 +31,7 @@ expression: lex_source(source)
     (
         String {
             value: "b",
-            flags: StringKind {
+            flags: AnyStringFlags {
                 prefix: Regular(
                     Empty,
                 ),
@@ -52,7 +52,7 @@ expression: lex_source(source)
     (
         String {
             value: "c",
-            flags: StringKind {
+            flags: AnyStringFlags {
                 prefix: Regular(
                     Empty,
                 ),
@@ -65,7 +65,7 @@ expression: lex_source(source)
     (
         String {
             value: "d",
-            flags: StringKind {
+            flags: AnyStringFlags {
                 prefix: Regular(
                     Empty,
                 ),

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__non_logical_newline_in_string_continuation.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__non_logical_newline_in_string_continuation.snap
@@ -14,7 +14,7 @@ expression: lex_source(source)
     (
         String {
             value: "a",
-            kind: StringKind {
+            flags: StringKind {
                 prefix: Regular(
                     Empty,
                 ),
@@ -31,7 +31,7 @@ expression: lex_source(source)
     (
         String {
             value: "b",
-            kind: StringKind {
+            flags: StringKind {
                 prefix: Regular(
                     Empty,
                 ),
@@ -52,7 +52,7 @@ expression: lex_source(source)
     (
         String {
             value: "c",
-            kind: StringKind {
+            flags: StringKind {
                 prefix: Regular(
                     Empty,
                 ),
@@ -65,7 +65,7 @@ expression: lex_source(source)
     (
         String {
             value: "d",
-            kind: StringKind {
+            flags: StringKind {
                 prefix: Regular(
                     Empty,
                 ),

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__string.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__string.snap
@@ -6,7 +6,7 @@ expression: lex_source(source)
     (
         String {
             value: "double",
-            kind: StringKind {
+            flags: StringKind {
                 prefix: Regular(
                     Empty,
                 ),
@@ -19,7 +19,7 @@ expression: lex_source(source)
     (
         String {
             value: "single",
-            kind: StringKind {
+            flags: StringKind {
                 prefix: Regular(
                     Empty,
                 ),
@@ -32,7 +32,7 @@ expression: lex_source(source)
     (
         String {
             value: "can\\'t",
-            kind: StringKind {
+            flags: StringKind {
                 prefix: Regular(
                     Empty,
                 ),
@@ -45,7 +45,7 @@ expression: lex_source(source)
     (
         String {
             value: "\\\\\\\"",
-            kind: StringKind {
+            flags: StringKind {
                 prefix: Regular(
                     Empty,
                 ),
@@ -58,7 +58,7 @@ expression: lex_source(source)
     (
         String {
             value: "\\t\\r\\n",
-            kind: StringKind {
+            flags: StringKind {
                 prefix: Regular(
                     Empty,
                 ),
@@ -71,7 +71,7 @@ expression: lex_source(source)
     (
         String {
             value: "\\g",
-            kind: StringKind {
+            flags: StringKind {
                 prefix: Regular(
                     Empty,
                 ),
@@ -84,7 +84,7 @@ expression: lex_source(source)
     (
         String {
             value: "raw\\'",
-            kind: StringKind {
+            flags: StringKind {
                 prefix: Regular(
                     Raw {
                         uppercase: false,
@@ -99,7 +99,7 @@ expression: lex_source(source)
     (
         String {
             value: "\\420",
-            kind: StringKind {
+            flags: StringKind {
                 prefix: Regular(
                     Empty,
                 ),
@@ -112,7 +112,7 @@ expression: lex_source(source)
     (
         String {
             value: "\\200\\0a",
-            kind: StringKind {
+            flags: StringKind {
                 prefix: Regular(
                     Empty,
                 ),

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__string.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__string.snap
@@ -6,7 +6,7 @@ expression: lex_source(source)
     (
         String {
             value: "double",
-            flags: StringKind {
+            flags: AnyStringFlags {
                 prefix: Regular(
                     Empty,
                 ),
@@ -19,7 +19,7 @@ expression: lex_source(source)
     (
         String {
             value: "single",
-            flags: StringKind {
+            flags: AnyStringFlags {
                 prefix: Regular(
                     Empty,
                 ),
@@ -32,7 +32,7 @@ expression: lex_source(source)
     (
         String {
             value: "can\\'t",
-            flags: StringKind {
+            flags: AnyStringFlags {
                 prefix: Regular(
                     Empty,
                 ),
@@ -45,7 +45,7 @@ expression: lex_source(source)
     (
         String {
             value: "\\\\\\\"",
-            flags: StringKind {
+            flags: AnyStringFlags {
                 prefix: Regular(
                     Empty,
                 ),
@@ -58,7 +58,7 @@ expression: lex_source(source)
     (
         String {
             value: "\\t\\r\\n",
-            flags: StringKind {
+            flags: AnyStringFlags {
                 prefix: Regular(
                     Empty,
                 ),
@@ -71,7 +71,7 @@ expression: lex_source(source)
     (
         String {
             value: "\\g",
-            flags: StringKind {
+            flags: AnyStringFlags {
                 prefix: Regular(
                     Empty,
                 ),
@@ -84,7 +84,7 @@ expression: lex_source(source)
     (
         String {
             value: "raw\\'",
-            flags: StringKind {
+            flags: AnyStringFlags {
                 prefix: Regular(
                     Raw {
                         uppercase: false,
@@ -99,7 +99,7 @@ expression: lex_source(source)
     (
         String {
             value: "\\420",
-            flags: StringKind {
+            flags: AnyStringFlags {
                 prefix: Regular(
                     Empty,
                 ),
@@ -112,7 +112,7 @@ expression: lex_source(source)
     (
         String {
             value: "\\200\\0a",
-            flags: StringKind {
+            flags: AnyStringFlags {
                 prefix: Regular(
                     Empty,
                 ),

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__string_continuation_with_mac_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__string_continuation_with_mac_eol.snap
@@ -6,7 +6,7 @@ expression: string_continuation_with_eol(MAC_EOL)
     (
         String {
             value: "abc\\\rdef",
-            kind: StringKind {
+            flags: StringKind {
                 prefix: Regular(
                     Empty,
                 ),

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__string_continuation_with_mac_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__string_continuation_with_mac_eol.snap
@@ -6,7 +6,7 @@ expression: string_continuation_with_eol(MAC_EOL)
     (
         String {
             value: "abc\\\rdef",
-            flags: StringKind {
+            flags: AnyStringFlags {
                 prefix: Regular(
                     Empty,
                 ),

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__string_continuation_with_unix_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__string_continuation_with_unix_eol.snap
@@ -6,7 +6,7 @@ expression: string_continuation_with_eol(UNIX_EOL)
     (
         String {
             value: "abc\\\ndef",
-            flags: StringKind {
+            flags: AnyStringFlags {
                 prefix: Regular(
                     Empty,
                 ),

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__string_continuation_with_unix_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__string_continuation_with_unix_eol.snap
@@ -6,7 +6,7 @@ expression: string_continuation_with_eol(UNIX_EOL)
     (
         String {
             value: "abc\\\ndef",
-            kind: StringKind {
+            flags: StringKind {
                 prefix: Regular(
                     Empty,
                 ),

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__string_continuation_with_windows_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__string_continuation_with_windows_eol.snap
@@ -6,7 +6,7 @@ expression: string_continuation_with_eol(WINDOWS_EOL)
     (
         String {
             value: "abc\\\r\ndef",
-            flags: StringKind {
+            flags: AnyStringFlags {
                 prefix: Regular(
                     Empty,
                 ),

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__string_continuation_with_windows_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__string_continuation_with_windows_eol.snap
@@ -6,7 +6,7 @@ expression: string_continuation_with_eol(WINDOWS_EOL)
     (
         String {
             value: "abc\\\r\ndef",
-            kind: StringKind {
+            flags: StringKind {
                 prefix: Regular(
                     Empty,
                 ),

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__triple_quoted_mac_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__triple_quoted_mac_eol.snap
@@ -6,7 +6,7 @@ expression: triple_quoted_eol(MAC_EOL)
     (
         String {
             value: "\r test string\r ",
-            flags: StringKind {
+            flags: AnyStringFlags {
                 prefix: Regular(
                     Empty,
                 ),

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__triple_quoted_mac_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__triple_quoted_mac_eol.snap
@@ -6,7 +6,7 @@ expression: triple_quoted_eol(MAC_EOL)
     (
         String {
             value: "\r test string\r ",
-            kind: StringKind {
+            flags: StringKind {
                 prefix: Regular(
                     Empty,
                 ),

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__triple_quoted_unix_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__triple_quoted_unix_eol.snap
@@ -6,7 +6,7 @@ expression: triple_quoted_eol(UNIX_EOL)
     (
         String {
             value: "\n test string\n ",
-            kind: StringKind {
+            flags: StringKind {
                 prefix: Regular(
                     Empty,
                 ),

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__triple_quoted_unix_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__triple_quoted_unix_eol.snap
@@ -6,7 +6,7 @@ expression: triple_quoted_eol(UNIX_EOL)
     (
         String {
             value: "\n test string\n ",
-            flags: StringKind {
+            flags: AnyStringFlags {
                 prefix: Regular(
                     Empty,
                 ),

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__triple_quoted_windows_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__triple_quoted_windows_eol.snap
@@ -6,7 +6,7 @@ expression: triple_quoted_eol(WINDOWS_EOL)
     (
         String {
             value: "\r\n test string\r\n ",
-            flags: StringKind {
+            flags: AnyStringFlags {
                 prefix: Regular(
                     Empty,
                 ),

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__triple_quoted_windows_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__triple_quoted_windows_eol.snap
@@ -6,7 +6,7 @@ expression: triple_quoted_eol(WINDOWS_EOL)
     (
         String {
             value: "\r\n test string\r\n ",
-            kind: StringKind {
+            flags: StringKind {
                 prefix: Regular(
                     Empty,
                 ),

--- a/crates/ruff_python_parser/src/string.rs
+++ b/crates/ruff_python_parser/src/string.rs
@@ -2,7 +2,7 @@
 
 use bstr::ByteSlice;
 
-use ruff_python_ast::{self as ast, AnyStringKind, Expr};
+use ruff_python_ast::{self as ast, AnyStringFlags, Expr};
 use ruff_text_size::{Ranged, TextRange, TextSize};
 
 use crate::lexer::{LexicalError, LexicalErrorType};
@@ -44,8 +44,8 @@ struct StringParser {
     source: Box<str>,
     /// Current position of the parser in the source.
     cursor: usize,
-    /// The kind of string.
-    kind: AnyStringKind,
+    /// The flags corresponding to the string.
+    flags: AnyStringFlags,
     /// The location of the first character in the source from the start of the file.
     offset: TextSize,
     /// The range of the string literal.
@@ -53,11 +53,11 @@ struct StringParser {
 }
 
 impl StringParser {
-    fn new(source: Box<str>, kind: AnyStringKind, offset: TextSize, range: TextRange) -> Self {
+    fn new(source: Box<str>, flags: AnyStringFlags, offset: TextSize, range: TextRange) -> Self {
         Self {
             source,
             cursor: 0,
-            kind,
+            flags,
             offset,
             range,
         }
@@ -214,9 +214,9 @@ impl StringParser {
             'v' => '\x0b',
             o @ '0'..='7' => self.parse_octet(o as u8),
             'x' => self.parse_unicode_literal(2)?,
-            'u' if !self.kind.is_byte_string() => self.parse_unicode_literal(4)?,
-            'U' if !self.kind.is_byte_string() => self.parse_unicode_literal(8)?,
-            'N' if !self.kind.is_byte_string() => self.parse_unicode_name()?,
+            'u' if !self.flags.is_byte_string() => self.parse_unicode_literal(4)?,
+            'U' if !self.flags.is_byte_string() => self.parse_unicode_literal(8)?,
+            'N' if !self.flags.is_byte_string() => self.parse_unicode_name()?,
             // Special cases where the escape sequence is not a single character
             '\n' => return Ok(None),
             '\r' => {
@@ -282,7 +282,7 @@ impl StringParser {
                 // raise a syntax error as is done by the CPython parser. It might
                 // be supported in the future, refer to point 3: https://peps.python.org/pep-0701/#rejected-ideas
                 b'\\' => {
-                    if !self.kind.is_raw_string() && self.peek_byte().is_some() {
+                    if !self.flags.is_raw_string() && self.peek_byte().is_some() {
                         match self.parse_escaped_char()? {
                             None => {}
                             Some(EscapedChar::Literal(c)) => value.push(c),
@@ -330,12 +330,12 @@ impl StringParser {
             ));
         }
 
-        if self.kind.is_raw_string() {
+        if self.flags.is_raw_string() {
             // For raw strings, no escaping is necessary.
             return Ok(StringType::Bytes(ast::BytesLiteral {
                 value: self.source.into_boxed_bytes(),
                 range: self.range,
-                flags: self.kind.into(),
+                flags: self.flags.into(),
             }));
         }
 
@@ -344,7 +344,7 @@ impl StringParser {
             return Ok(StringType::Bytes(ast::BytesLiteral {
                 value: self.source.into_boxed_bytes(),
                 range: self.range,
-                flags: self.kind.into(),
+                flags: self.flags.into(),
             }));
         };
 
@@ -381,17 +381,17 @@ impl StringParser {
         Ok(StringType::Bytes(ast::BytesLiteral {
             value: value.into_boxed_slice(),
             range: self.range,
-            flags: self.kind.into(),
+            flags: self.flags.into(),
         }))
     }
 
     fn parse_string(mut self) -> Result<StringType, LexicalError> {
-        if self.kind.is_raw_string() {
+        if self.flags.is_raw_string() {
             // For raw strings, no escaping is necessary.
             return Ok(StringType::Str(ast::StringLiteral {
                 value: self.source,
                 range: self.range,
-                flags: self.kind.into(),
+                flags: self.flags.into(),
             }));
         }
 
@@ -400,7 +400,7 @@ impl StringParser {
             return Ok(StringType::Str(ast::StringLiteral {
                 value: self.source,
                 range: self.range,
-                flags: self.kind.into(),
+                flags: self.flags.into(),
             }));
         };
 
@@ -437,12 +437,12 @@ impl StringParser {
         Ok(StringType::Str(ast::StringLiteral {
             value: value.into_boxed_str(),
             range: self.range,
-            flags: self.kind.into(),
+            flags: self.flags.into(),
         }))
     }
 
     fn parse(self) -> Result<StringType, LexicalError> {
-        if self.kind.is_byte_string() {
+        if self.flags.is_byte_string() {
             self.parse_bytes()
         } else {
             self.parse_string()
@@ -452,19 +452,19 @@ impl StringParser {
 
 pub(crate) fn parse_string_literal(
     source: Box<str>,
-    kind: AnyStringKind,
+    flags: AnyStringFlags,
     range: TextRange,
 ) -> Result<StringType, LexicalError> {
-    StringParser::new(source, kind, range.start() + kind.opener_len(), range).parse()
+    StringParser::new(source, flags, range.start() + flags.opener_len(), range).parse()
 }
 
 // TODO(dhruvmanila): Move this to the new parser
 pub(crate) fn parse_fstring_literal_element(
     source: Box<str>,
-    kind: AnyStringKind,
+    flags: AnyStringFlags,
     range: TextRange,
 ) -> Result<ast::FStringLiteralElement, LexicalError> {
-    StringParser::new(source, kind, range.start(), range).parse_fstring_middle()
+    StringParser::new(source, flags, range.start(), range).parse_fstring_middle()
 }
 
 #[cfg(test)]

--- a/crates/ruff_python_parser/src/string.rs
+++ b/crates/ruff_python_parser/src/string.rs
@@ -44,7 +44,7 @@ struct StringParser {
     source: Box<str>,
     /// Current position of the parser in the source.
     cursor: usize,
-    /// The flags corresponding to the string.
+    /// Flags that can be used to query information about the string.
     flags: AnyStringFlags,
     /// The location of the first character in the source from the start of the file.
     offset: TextSize,

--- a/crates/ruff_python_parser/src/token.rs
+++ b/crates/ruff_python_parser/src/token.rs
@@ -5,7 +5,7 @@
 //!
 //! [CPython source]: https://github.com/python/cpython/blob/dfc2e065a2e71011017077e549cd2f9bf4944c54/Grammar/Tokens
 
-use ruff_python_ast::{AnyStringKind, BoolOp, Int, IpyEscapeKind, Operator, UnaryOp};
+use ruff_python_ast::{AnyStringFlags, BoolOp, Int, IpyEscapeKind, Operator, UnaryOp};
 use std::fmt;
 
 use crate::Mode;
@@ -44,11 +44,11 @@ pub enum Tok {
         value: Box<str>,
         /// Flags that can be queried to determine the quote style
         /// and prefixes of the string
-        kind: AnyStringKind,
+        flags: AnyStringFlags,
     },
     /// Token value for the start of an f-string. This includes the `f`/`F`/`fr` prefix
     /// and the opening quote(s).
-    FStringStart(AnyStringKind),
+    FStringStart(AnyStringFlags),
     /// Token value that includes the portion of text inside the f-string that's not
     /// part of the expression part and isn't an opening or closing brace.
     FStringMiddle {
@@ -56,7 +56,7 @@ pub enum Tok {
         value: Box<str>,
         /// Flags that can be queried to determine the quote style
         /// and prefixes of the string
-        kind: AnyStringKind,
+        flags: AnyStringFlags,
     },
     /// Token value for the end of an f-string. This includes the closing quote.
     FStringEnd,
@@ -245,8 +245,8 @@ impl fmt::Display for Tok {
             Int { value } => write!(f, "{value}"),
             Float { value } => write!(f, "{value}"),
             Complex { real, imag } => write!(f, "{real}j{imag}"),
-            String { value, kind } => {
-                write!(f, "{}", kind.format_string_contents(value))
+            String { value, flags } => {
+                write!(f, "{}", flags.format_string_contents(value))
             }
             FStringStart(_) => f.write_str("FStringStart"),
             FStringMiddle { value, .. } => f.write_str(value),


### PR DESCRIPTION
## Summary

This PR renames `AnyStringKind` to `AnyStringFlags` and `AnyStringFlags` to `AnyStringFlagsInner`.

The main motivation is to have consistent usage of "kind" and "flags". For each string kind, it's "flags" like `StringLiteralFlags`, `BytesLiteralFlags`, and `FStringFlags` but it was `AnyStringKind` for the "any" variant.
