### PR TITLE
Move sub-crates to workspace dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,28 @@ authors = ["Charlie Marsh <charlie.r.marsh@gmail.com>"]
 license = "MIT"
 
 [workspace.dependencies]
+ruff = { path = "crates/ruff" }
+ruff_cache = { path = "crates/ruff_cache" }
+ruff_diagnostics = { path = "crates/ruff_diagnostics" }
+ruff_formatter = { path = "crates/ruff_formatter" }
+ruff_index = { path = "crates/ruff_index" }
+ruff_linter = { path = "crates/ruff_linter" }
+ruff_macros = { path = "crates/ruff_macros" }
+ruff_notebook = { path = "crates/ruff_notebook" }
+ruff_python_ast = { path = "crates/ruff_python_ast" }
+ruff_python_codegen = { path = "crates/ruff_python_codegen" }
+ruff_python_formatter = { path = "crates/ruff_python_formatter" }
+ruff_python_index = { path = "crates/ruff_python_index" }
+ruff_python_literal = { path = "crates/ruff_python_literal" }
+ruff_python_parser = { path = "crates/ruff_python_parser" }
+ruff_python_semantic = { path = "crates/ruff_python_semantic" }
+ruff_python_stdlib = { path = "crates/ruff_python_stdlib" }
+ruff_python_trivia = { path = "crates/ruff_python_trivia" }
+ruff_server = { path = "crates/ruff_server" }
+ruff_source_file = { path = "crates/ruff_source_file" }
+ruff_text_size = { path = "crates/ruff_text_size" }
+ruff_workspace = { path = "crates/ruff_workspace" }
+
 aho-corasick = { version = "1.1.3" }
 annotate-snippets = { version = "0.9.2", features = ["color"] }
 anyhow = { version = "1.0.80" }

--- a/crates/red_knot/Cargo.toml
+++ b/crates/red_knot/Cargo.toml
@@ -12,11 +12,11 @@ license.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ruff_python_parser = { path = "../ruff_python_parser" }
-ruff_python_ast = { path = "../ruff_python_ast" }
-ruff_text_size = { path = "../ruff_text_size" }
-ruff_index = { path = "../ruff_index" }
-ruff_notebook = { path = "../ruff_notebook" }
+ruff_python_parser = { workspace = true }
+ruff_python_ast = { workspace = true }
+ruff_text_size = { workspace = true }
+ruff_index = { workspace = true }
+ruff_notebook = { workspace = true }
 
 anyhow = { workspace = true }
 bitflags = { workspace = true }

--- a/crates/ruff/Cargo.toml
+++ b/crates/ruff/Cargo.toml
@@ -13,17 +13,17 @@ readme = "../../README.md"
 default-run = "ruff"
 
 [dependencies]
-ruff_cache = { path = "../ruff_cache" }
-ruff_diagnostics = { path = "../ruff_diagnostics" }
-ruff_linter = { path = "../ruff_linter", features = ["clap"] }
-ruff_macros = { path = "../ruff_macros" }
-ruff_notebook = { path = "../ruff_notebook" }
-ruff_python_ast = { path = "../ruff_python_ast" }
-ruff_python_formatter = { path = "../ruff_python_formatter" }
-ruff_server = { path = "../ruff_server" }
-ruff_source_file = { path = "../ruff_source_file" }
-ruff_text_size = { path = "../ruff_text_size" }
-ruff_workspace = { path = "../ruff_workspace" }
+ruff_cache = { workspace = true }
+ruff_diagnostics = { workspace = true }
+ruff_linter = { workspace = true, features = ["clap"] }
+ruff_macros = { workspace = true }
+ruff_notebook = { workspace = true }
+ruff_python_ast = { workspace = true }
+ruff_python_formatter = { workspace = true }
+ruff_server = { workspace = true }
+ruff_source_file = { workspace = true }
+ruff_text_size = { workspace = true }
+ruff_workspace = { workspace = true }
 
 anyhow = { workspace = true }
 argfile = { workspace = true }
@@ -60,7 +60,7 @@ wild = { workspace = true }
 
 [dev-dependencies]
 # Enable test rules during development
-ruff_linter = { path = "../ruff_linter", features = ["clap", "test-rules"] }
+ruff_linter = { workspace = true, features = ["clap", "test-rules"] }
 # Avoid writing colored snapshots when running tests from the terminal
 colored = { workspace = true, features = ["no-color"] }
 insta = { workspace = true, features = ["filters", "json"] }

--- a/crates/ruff_benchmark/Cargo.toml
+++ b/crates/ruff_benchmark/Cargo.toml
@@ -38,14 +38,14 @@ serde_json = { workspace = true }
 url = { workspace = true }
 ureq = { workspace = true }
 criterion = { workspace = true, default-features = false }
-codspeed-criterion-compat = { workspace = true, default-features = false, optional = true}
+codspeed-criterion-compat = { workspace = true, default-features = false, optional = true }
 
 [dev-dependencies]
-ruff_linter = { path = "../ruff_linter" }
-ruff_python_ast = { path = "../ruff_python_ast" }
-ruff_python_formatter = { path = "../ruff_python_formatter" }
-ruff_python_index = { path = "../ruff_python_index" }
-ruff_python_parser = { path = "../ruff_python_parser" }
+ruff_linter = { workspace = true }
+ruff_python_ast = { workspace = true }
+ruff_python_formatter = { workspace = true }
+ruff_python_index = { workspace = true }
+ruff_python_parser = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/ruff_cache/Cargo.toml
+++ b/crates/ruff_cache/Cargo.toml
@@ -19,7 +19,7 @@ filetime = { workspace = true }
 seahash = { workspace = true }
 
 [dev-dependencies]
-ruff_macros = { path = "../ruff_macros" }
+ruff_macros = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/ruff_dev/Cargo.toml
+++ b/crates/ruff_dev/Cargo.toml
@@ -11,18 +11,18 @@ repository = { workspace = true }
 license = { workspace = true }
 
 [dependencies]
-ruff = { path = "../ruff" }
-ruff_diagnostics = { path = "../ruff_diagnostics" }
-ruff_formatter = { path = "../ruff_formatter" }
-ruff_linter = { path = "../ruff_linter", features = ["schemars"] }
-ruff_notebook = { path = "../ruff_notebook" }
-ruff_python_ast = { path = "../ruff_python_ast" }
-ruff_python_codegen = { path = "../ruff_python_codegen" }
-ruff_python_formatter = { path = "../ruff_python_formatter" }
-ruff_python_parser = { path = "../ruff_python_parser" }
-ruff_python_stdlib = { path = "../ruff_python_stdlib" }
-ruff_python_trivia = { path = "../ruff_python_trivia" }
-ruff_workspace = { path = "../ruff_workspace", features = ["schemars"] }
+ruff = { workspace = true }
+ruff_diagnostics = { workspace = true }
+ruff_formatter = { workspace = true }
+ruff_linter = { workspace = true, features = ["schemars"] }
+ruff_notebook = { workspace = true }
+ruff_python_ast = { workspace = true }
+ruff_python_codegen = { workspace = true }
+ruff_python_formatter = { workspace = true }
+ruff_python_parser = { workspace = true }
+ruff_python_stdlib = { workspace = true }
+ruff_python_trivia = { workspace = true }
+ruff_workspace = { workspace = true, features = ["schemars"] }
 
 anyhow = { workspace = true }
 clap = { workspace = true, features = ["wrap_help"] }

--- a/crates/ruff_diagnostics/Cargo.toml
+++ b/crates/ruff_diagnostics/Cargo.toml
@@ -14,7 +14,7 @@ license = { workspace = true }
 doctest = false
 
 [dependencies]
-ruff_text_size = { path = "../ruff_text_size" }
+ruff_text_size = { workspace = true }
 
 anyhow = { workspace = true }
 log = { workspace = true }

--- a/crates/ruff_formatter/Cargo.toml
+++ b/crates/ruff_formatter/Cargo.toml
@@ -11,9 +11,9 @@ repository = { workspace = true }
 license = { workspace = true }
 
 [dependencies]
-ruff_cache = { path = "../ruff_cache" }
-ruff_macros = { path = "../ruff_macros" }
-ruff_text_size = { path = "../ruff_text_size" }
+ruff_cache = { workspace = true }
+ruff_macros = { workspace = true }
+ruff_text_size = { workspace = true }
 
 drop_bomb = { workspace = true }
 rustc-hash = { workspace = true }

--- a/crates/ruff_index/Cargo.toml
+++ b/crates/ruff_index/Cargo.toml
@@ -14,7 +14,7 @@ license = { workspace = true }
 doctest = false
 
 [dependencies]
-ruff_macros = { path = "../ruff_macros" }
+ruff_macros = { workspace = true }
 
 [dev-dependencies]
 static_assertions = { workspace = true }

--- a/crates/ruff_linter/Cargo.toml
+++ b/crates/ruff_linter/Cargo.toml
@@ -13,20 +13,20 @@ license = { workspace = true }
 [lib]
 
 [dependencies]
-ruff_cache = { path = "../ruff_cache" }
-ruff_diagnostics = { path = "../ruff_diagnostics", features = ["serde"] }
-ruff_notebook = { path = "../ruff_notebook" }
-ruff_macros = { path = "../ruff_macros" }
-ruff_python_ast = { path = "../ruff_python_ast", features = ["serde"] }
-ruff_python_codegen = { path = "../ruff_python_codegen" }
-ruff_python_index = { path = "../ruff_python_index" }
-ruff_python_literal = { path = "../ruff_python_literal" }
-ruff_python_semantic = { path = "../ruff_python_semantic" }
-ruff_python_stdlib = { path = "../ruff_python_stdlib" }
-ruff_python_trivia = { path = "../ruff_python_trivia" }
-ruff_python_parser = { path = "../ruff_python_parser" }
-ruff_source_file = { path = "../ruff_source_file", features = ["serde"] }
-ruff_text_size = { path = "../ruff_text_size" }
+ruff_cache = { workspace = true }
+ruff_diagnostics = { workspace = true, features = ["serde"] }
+ruff_notebook = { workspace = true }
+ruff_macros = { workspace = true }
+ruff_python_ast = { workspace = true, features = ["serde"] }
+ruff_python_codegen = { workspace = true }
+ruff_python_index = { workspace = true }
+ruff_python_literal = { workspace = true }
+ruff_python_semantic = { workspace = true }
+ruff_python_stdlib = { workspace = true }
+ruff_python_trivia = { workspace = true }
+ruff_python_parser = { workspace = true }
+ruff_source_file = { workspace = true, features = ["serde"] }
+ruff_text_size = { workspace = true }
 
 aho-corasick = { workspace = true }
 annotate-snippets = { workspace = true, features = ["color"] }

--- a/crates/ruff_macros/Cargo.toml
+++ b/crates/ruff_macros/Cargo.toml
@@ -15,7 +15,7 @@ proc-macro = true
 doctest = false
 
 [dependencies]
-ruff_python_trivia = { path = "../ruff_python_trivia" }
+ruff_python_trivia = { workspace = true }
 
 proc-macro2 = { workspace = true }
 quote = { workspace = true }

--- a/crates/ruff_notebook/Cargo.toml
+++ b/crates/ruff_notebook/Cargo.toml
@@ -14,9 +14,9 @@ license = { workspace = true }
 doctest = false
 
 [dependencies]
-ruff_diagnostics = { path = "../ruff_diagnostics" }
-ruff_source_file = { path = "../ruff_source_file", features = ["serde"] }
-ruff_text_size = { path = "../ruff_text_size" }
+ruff_diagnostics = { workspace = true }
+ruff_source_file = { workspace = true, features = ["serde"] }
+ruff_text_size = { workspace = true }
 
 anyhow = { workspace = true }
 itertools = { workspace = true }

--- a/crates/ruff_python_ast/Cargo.toml
+++ b/crates/ruff_python_ast/Cargo.toml
@@ -13,9 +13,9 @@ license = { workspace = true }
 [lib]
 
 [dependencies]
-ruff_python_trivia = { path = "../ruff_python_trivia" }
-ruff_source_file = { path = "../ruff_source_file" }
-ruff_text_size = { path = "../ruff_text_size" }
+ruff_python_trivia = { workspace = true }
+ruff_source_file = { workspace = true }
+ruff_text_size = { workspace = true }
 
 aho-corasick = { workspace = true }
 bitflags = { workspace = true }

--- a/crates/ruff_python_ast_integration_tests/Cargo.toml
+++ b/crates/ruff_python_ast_integration_tests/Cargo.toml
@@ -12,10 +12,10 @@ license.workspace = true
 [dependencies]
 
 [dev-dependencies]
-ruff_python_parser = { path = "../ruff_python_parser" }
-ruff_python_ast = { path = "../ruff_python_ast" }
-ruff_python_trivia = { path = "../ruff_python_trivia" }
-ruff_text_size = { path = "../ruff_text_size" }
+ruff_python_parser = { workspace = true }
+ruff_python_ast = { workspace = true }
+ruff_python_trivia = { workspace = true }
+ruff_text_size = { workspace = true }
 
 insta = { workspace = true }
 

--- a/crates/ruff_python_codegen/Cargo.toml
+++ b/crates/ruff_python_codegen/Cargo.toml
@@ -14,10 +14,10 @@ license = { workspace = true }
 doctest = false
 
 [dependencies]
-ruff_python_ast = { path = "../ruff_python_ast" }
-ruff_python_literal = { path = "../ruff_python_literal" }
-ruff_python_parser = { path = "../ruff_python_parser" }
-ruff_source_file = { path = "../ruff_source_file" }
+ruff_python_ast = { workspace = true }
+ruff_python_literal = { workspace = true }
+ruff_python_parser = { workspace = true }
+ruff_source_file = { workspace = true }
 
 once_cell = { workspace = true }
 

--- a/crates/ruff_python_formatter/Cargo.toml
+++ b/crates/ruff_python_formatter/Cargo.toml
@@ -14,15 +14,15 @@ license = { workspace = true }
 doctest = false
 
 [dependencies]
-ruff_cache = { path = "../ruff_cache" }
-ruff_formatter = { path = "../ruff_formatter" }
-ruff_macros = { path = "../ruff_macros" }
-ruff_python_trivia = { path = "../ruff_python_trivia" }
-ruff_source_file = { path = "../ruff_source_file" }
-ruff_python_ast = { path = "../ruff_python_ast" }
-ruff_python_index = { path = "../ruff_python_index" }
-ruff_python_parser = { path = "../ruff_python_parser" }
-ruff_text_size = { path = "../ruff_text_size" }
+ruff_cache = { workspace = true }
+ruff_formatter = { workspace = true }
+ruff_macros = { workspace = true }
+ruff_python_trivia = { workspace = true }
+ruff_source_file = { workspace = true }
+ruff_python_ast = { workspace = true }
+ruff_python_index = { workspace = true }
+ruff_python_parser = { workspace = true }
+ruff_text_size = { workspace = true }
 
 anyhow = { workspace = true }
 clap = { workspace = true }
@@ -41,7 +41,7 @@ tracing = { workspace = true }
 unicode-width = { workspace = true }
 
 [dev-dependencies]
-ruff_formatter = { path = "../ruff_formatter" }
+ruff_formatter = { workspace = true }
 
 insta = { workspace = true, features = ["glob"] }
 regex = { workspace = true }

--- a/crates/ruff_python_index/Cargo.toml
+++ b/crates/ruff_python_index/Cargo.toml
@@ -14,11 +14,11 @@ license = { workspace = true }
 doctest = false
 
 [dependencies]
-ruff_python_ast = { path = "../ruff_python_ast" }
-ruff_python_parser = { path = "../ruff_python_parser" }
-ruff_python_trivia = { path = "../ruff_python_trivia" }
-ruff_source_file = { path = "../ruff_source_file" }
-ruff_text_size = { path = "../ruff_text_size" }
+ruff_python_ast = { workspace = true }
+ruff_python_parser = { workspace = true }
+ruff_python_trivia = { workspace = true }
+ruff_source_file = { workspace = true }
+ruff_text_size = { workspace = true }
 
 [dev-dependencies]
 

--- a/crates/ruff_python_literal/Cargo.toml
+++ b/crates/ruff_python_literal/Cargo.toml
@@ -15,7 +15,7 @@ license = { workspace = true }
 doctest = false
 
 [dependencies]
-ruff_python_ast = { path = "../ruff_python_ast" }
+ruff_python_ast = { workspace = true }
 
 bitflags = { workspace = true }
 hexf-parse = { workspace = true }

--- a/crates/ruff_python_parser/Cargo.toml
+++ b/crates/ruff_python_parser/Cargo.toml
@@ -13,8 +13,8 @@ license = { workspace = true }
 [lib]
 
 [dependencies]
-ruff_python_ast = { path = "../ruff_python_ast" }
-ruff_text_size = { path = "../ruff_text_size" }
+ruff_python_ast = { workspace = true }
+ruff_text_size = { workspace = true }
 
 anyhow = { workspace = true }
 bitflags = { workspace = true }
@@ -29,7 +29,7 @@ unicode_names2 = { workspace = true }
 unicode-normalization = { workspace = true }
 
 [dev-dependencies]
-ruff_source_file = { path = "../ruff_source_file" }
+ruff_source_file = { workspace = true }
 
 annotate-snippets = { workspace = true }
 insta = { workspace = true, features = ["glob"] }

--- a/crates/ruff_python_semantic/Cargo.toml
+++ b/crates/ruff_python_semantic/Cargo.toml
@@ -14,18 +14,18 @@ license = { workspace = true }
 doctest = false
 
 [dependencies]
-ruff_index = { path = "../ruff_index" }
-ruff_python_ast = { path = "../ruff_python_ast" }
-ruff_python_stdlib = { path = "../ruff_python_stdlib" }
-ruff_source_file = { path = "../ruff_source_file" }
-ruff_text_size = { path = "../ruff_text_size" }
+ruff_index = { workspace = true }
+ruff_python_ast = { workspace = true }
+ruff_python_stdlib = { workspace = true }
+ruff_source_file = { workspace = true }
+ruff_text_size = { workspace = true }
 
 bitflags = { workspace = true }
 is-macro = { workspace = true }
 rustc-hash = { workspace = true }
 
 [dev-dependencies]
-ruff_python_parser = { path = "../ruff_python_parser" }
+ruff_python_parser = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/ruff_python_trivia/Cargo.toml
+++ b/crates/ruff_python_trivia/Cargo.toml
@@ -13,8 +13,8 @@ license = { workspace = true }
 [lib]
 
 [dependencies]
-ruff_text_size = { path = "../ruff_text_size" }
-ruff_source_file = { path = "../ruff_source_file" }
+ruff_text_size = { workspace = true }
+ruff_source_file = { workspace = true }
 
 itertools = { workspace = true }
 unicode-ident = { workspace = true }

--- a/crates/ruff_python_trivia_integration_tests/Cargo.toml
+++ b/crates/ruff_python_trivia_integration_tests/Cargo.toml
@@ -12,11 +12,11 @@ license.workspace = true
 [dependencies]
 
 [dev-dependencies]
-ruff_python_index = { path = "../ruff_python_index" }
-ruff_python_parser = { path = "../ruff_python_parser" }
-ruff_python_trivia = { path = "../ruff_python_trivia" }
-ruff_source_file = { path = "../ruff_source_file" }
-ruff_text_size = { path = "../ruff_text_size" }
+ruff_python_index = { workspace = true }
+ruff_python_parser = { workspace = true }
+ruff_python_trivia = { workspace = true }
+ruff_source_file = { workspace = true }
+ruff_text_size = { workspace = true }
 
 insta = { workspace = true }
 

--- a/crates/ruff_server/Cargo.toml
+++ b/crates/ruff_server/Cargo.toml
@@ -13,17 +13,17 @@ license = { workspace = true }
 [lib]
 
 [dependencies]
-ruff_diagnostics = { path = "../ruff_diagnostics" }
-ruff_formatter = { path = "../ruff_formatter" }
-ruff_linter = { path = "../ruff_linter" }
-ruff_python_ast = { path = "../ruff_python_ast" }
-ruff_python_codegen = { path = "../ruff_python_codegen" }
-ruff_python_formatter = { path = "../ruff_python_formatter" }
-ruff_python_index = { path = "../ruff_python_index" }
-ruff_python_parser = { path = "../ruff_python_parser" }
-ruff_source_file = { path = "../ruff_source_file" }
-ruff_text_size = { path = "../ruff_text_size" }
-ruff_workspace = { path = "../ruff_workspace" }
+ruff_diagnostics = { workspace = true }
+ruff_formatter = { workspace = true }
+ruff_linter = { workspace = true }
+ruff_python_ast = { workspace = true }
+ruff_python_codegen = { workspace = true }
+ruff_python_formatter = { workspace = true }
+ruff_python_index = { workspace = true }
+ruff_python_parser = { workspace = true }
+ruff_source_file = { workspace = true }
+ruff_text_size = { workspace = true }
+ruff_workspace = { workspace = true }
 
 anyhow = { workspace = true }
 crossbeam = { workspace = true }

--- a/crates/ruff_source_file/Cargo.toml
+++ b/crates/ruff_source_file/Cargo.toml
@@ -13,7 +13,7 @@ license = { workspace = true }
 [lib]
 
 [dependencies]
-ruff_text_size = { path = "../ruff_text_size" }
+ruff_text_size = { workspace = true }
 
 memchr = { workspace = true }
 once_cell = { workspace = true }

--- a/crates/ruff_wasm/Cargo.toml
+++ b/crates/ruff_wasm/Cargo.toml
@@ -19,17 +19,17 @@ doctest = false
 default = ["console_error_panic_hook"]
 
 [dependencies]
-ruff_linter = { path = "../ruff_linter" }
-ruff_python_ast = { path = "../ruff_python_ast" }
-ruff_python_codegen = { path = "../ruff_python_codegen" }
-ruff_formatter = { path = "../ruff_formatter" }
-ruff_python_formatter = { path = "../ruff_python_formatter" }
-ruff_python_index = { path = "../ruff_python_index" }
-ruff_python_parser = { path = "../ruff_python_parser" }
-ruff_source_file = { path = "../ruff_source_file" }
-ruff_text_size = { path = "../ruff_text_size" }
-ruff_python_trivia = { path = "../ruff_python_trivia" }
-ruff_workspace = { path = "../ruff_workspace" }
+ruff_linter = { workspace = true }
+ruff_python_ast = { workspace = true }
+ruff_python_codegen = { workspace = true }
+ruff_formatter = { workspace = true }
+ruff_python_formatter = { workspace = true }
+ruff_python_index = { workspace = true }
+ruff_python_parser = { workspace = true }
+ruff_source_file = { workspace = true }
+ruff_text_size = { workspace = true }
+ruff_python_trivia = { workspace = true }
+ruff_workspace = { workspace = true }
 
 console_error_panic_hook = { workspace = true, optional = true }
 console_log = { workspace = true }

--- a/crates/ruff_workspace/Cargo.toml
+++ b/crates/ruff_workspace/Cargo.toml
@@ -13,13 +13,13 @@ license = { workspace = true }
 [lib]
 
 [dependencies]
-ruff_linter = { path = "../ruff_linter" }
-ruff_formatter = { path = "../ruff_formatter" }
-ruff_python_formatter = { path = "../ruff_python_formatter", features = ["serde"] }
-ruff_python_ast = { path = "../ruff_python_ast" }
-ruff_source_file = { path = "../ruff_source_file" }
-ruff_cache = { path = "../ruff_cache" }
-ruff_macros = { path = "../ruff_macros" }
+ruff_linter = { workspace = true }
+ruff_formatter = { workspace = true }
+ruff_python_formatter = { workspace = true, features = ["serde"] }
+ruff_python_ast = { workspace = true }
+ruff_source_file = { workspace = true }
+ruff_cache = { workspace = true }
+ruff_macros = { workspace = true }
 
 anyhow = { workspace = true }
 colored = { workspace = true }
@@ -44,7 +44,7 @@ toml = { workspace = true }
 
 [dev-dependencies]
 # Enable test rules during development
-ruff_linter = { path = "../ruff_linter", features = ["clap", "test-rules"] }
+ruff_linter = { workspace = true, features = ["clap", "test-rules"] }
 tempfile = { workspace = true }
 
 [package.metadata.cargo-shear]


### PR DESCRIPTION
## Summary

This matches the setup we use in `uv` and allows for consistency in the `Cargo.toml` files.
