### PR TITLE
[redknot] add module type and attribute lookup for some types

### DIFF
--- a/crates/red_knot/src/lint.rs
+++ b/crates/red_knot/src/lint.rs
@@ -94,6 +94,7 @@ pub(crate) fn lint_semantic(db: &dyn LintDb, file_id: FileId) -> QueryResult<Dia
 
         lint_unresolved_imports(&context)?;
         lint_bad_overrides(&context)?;
+        lint_unspecified_encoding(&context)?;
 
         Ok(Diagnostics::from(context.diagnostics.take()))
     })
@@ -189,6 +190,13 @@ fn lint_bad_overrides(context: &SemanticLintContext) -> QueryResult<()> {
         }
     }
     Ok(())
+}
+
+fn lint_unspecified_encoding(context: &SemanticLintContext) -> QueryResult<()> {
+    // fix the inference of an import 'definition' by adding a module type
+    //
+    // obtain the type of each definition's rhs
+    todo!()
 }
 
 pub struct SemanticLintContext<'a> {

--- a/crates/red_knot/src/lint.rs
+++ b/crates/red_knot/src/lint.rs
@@ -192,10 +192,25 @@ fn lint_bad_overrides(context: &SemanticLintContext) -> QueryResult<()> {
     Ok(())
 }
 
-fn lint_unspecified_encoding(_context: &SemanticLintContext) -> QueryResult<()> {
-    // fix the inference of an import 'definition' by adding a module type
-    //
-    // obtain the type of each definition's rhs
+fn lint_unspecified_encoding(context: &SemanticLintContext) -> QueryResult<()> {
+    let symbols = context.symbols();
+    for (symbol_id, definition) in symbols.all_definitions() {
+        if !matches!(definition, Definition::Assignment(_)) {
+            // FIXME: only looks at definitions that are assignments, not all function calls
+            continue;
+        }
+        let ty = infer_definition_type(
+            context.db.upcast(),
+            GlobalSymbolId {
+                file_id: context.file_id,
+                symbol_id,
+            },
+            definition.clone(),
+        )?;
+        let symbol = symbol_id.symbol(symbols);
+        println!("{symbol:?} : {ty:?}");
+        todo!("if is a specific global symbol (e.g. tempfile.TemporaryFile) check that it has a specific argument (e.g. an encoding kwarg)");
+    }
     todo!("lint_unspecified_encoding: todo")
 }
 

--- a/crates/red_knot/src/lint.rs
+++ b/crates/red_knot/src/lint.rs
@@ -94,7 +94,6 @@ pub(crate) fn lint_semantic(db: &dyn LintDb, file_id: FileId) -> QueryResult<Dia
 
         lint_unresolved_imports(&context)?;
         lint_bad_overrides(&context)?;
-        lint_unspecified_encoding(&context)?;
 
         Ok(Diagnostics::from(context.diagnostics.take()))
     })
@@ -190,34 +189,6 @@ fn lint_bad_overrides(context: &SemanticLintContext) -> QueryResult<()> {
         }
     }
     Ok(())
-}
-
-fn lint_unspecified_encoding(context: &SemanticLintContext) -> QueryResult<()> {
-    // symbol we want to match against
-    let target = resolve_global_symbol(
-        context.db.upcast(),
-        ModuleName::new("tempfile"),
-        "TemporaryFile",
-    )?;
-
-    for (symbol_id, definition) in context.symbols().all_definitions() {
-        if !matches!(definition, Definition::Assignment(_)) {
-            // FIXME: only looks at definitions that are assignments, not all function calls
-            continue;
-        }
-        let ty = infer_definition_type(
-            context.db.upcast(),
-            GlobalSymbolId {
-                file_id: context.file_id,
-                symbol_id,
-            },
-            definition.clone(),
-        )?;
-        let symbol = symbol_id.symbol(context.symbols());
-        println!("{symbol:?} : {ty:?}");
-        todo!("if is a specific global symbol (e.g. tempfile.TemporaryFile) check that it has a specific argument (e.g. an encoding kwarg)");
-    }
-    todo!("lint_unspecified_encoding: todo")
 }
 
 pub struct SemanticLintContext<'a> {

--- a/crates/red_knot/src/lint.rs
+++ b/crates/red_knot/src/lint.rs
@@ -193,8 +193,14 @@ fn lint_bad_overrides(context: &SemanticLintContext) -> QueryResult<()> {
 }
 
 fn lint_unspecified_encoding(context: &SemanticLintContext) -> QueryResult<()> {
-    let symbols = context.symbols();
-    for (symbol_id, definition) in symbols.all_definitions() {
+    // symbol we want to match against
+    let target = resolve_global_symbol(
+        context.db.upcast(),
+        ModuleName::new("tempfile"),
+        "TemporaryFile",
+    )?;
+
+    for (symbol_id, definition) in context.symbols().all_definitions() {
         if !matches!(definition, Definition::Assignment(_)) {
             // FIXME: only looks at definitions that are assignments, not all function calls
             continue;
@@ -207,7 +213,7 @@ fn lint_unspecified_encoding(context: &SemanticLintContext) -> QueryResult<()> {
             },
             definition.clone(),
         )?;
-        let symbol = symbol_id.symbol(symbols);
+        let symbol = symbol_id.symbol(context.symbols());
         println!("{symbol:?} : {ty:?}");
         todo!("if is a specific global symbol (e.g. tempfile.TemporaryFile) check that it has a specific argument (e.g. an encoding kwarg)");
     }

--- a/crates/red_knot/src/lint.rs
+++ b/crates/red_knot/src/lint.rs
@@ -192,11 +192,11 @@ fn lint_bad_overrides(context: &SemanticLintContext) -> QueryResult<()> {
     Ok(())
 }
 
-fn lint_unspecified_encoding(context: &SemanticLintContext) -> QueryResult<()> {
+fn lint_unspecified_encoding(_context: &SemanticLintContext) -> QueryResult<()> {
     // fix the inference of an import 'definition' by adding a module type
     //
     // obtain the type of each definition's rhs
-    todo!()
+    todo!("lint_unspecified_encoding: todo")
 }
 
 pub struct SemanticLintContext<'a> {

--- a/crates/red_knot/src/types.rs
+++ b/crates/red_knot/src/types.rs
@@ -52,26 +52,15 @@ impl Type {
         matches!(self, Type::Unknown)
     }
 
-    // NOTE: naming? `get_member_type`
-    pub fn get_member(&self, db: &dyn SemanticDb, name: &Name) -> QueryResult<Type> {
-        // NOTE: maybe make this a trait that each TypeID implements?
+    pub fn get_member(&self, db: &dyn SemanticDb, name: &Name) -> QueryResult<Option<Type>> {
         match self {
             Type::Any => todo!("attribute lookup on Any type"),
             Type::Never => todo!("attribute lookup on Never type"),
             Type::Unknown => todo!("attribute lookup on Unknown type"),
             Type::Unbound => todo!("attribute lookup on Unbound type"),
             Type::Function(_) => todo!("attribute lookup on Function type"),
-            Type::Module(module_id) => module_id
-                .get_member(db, name)
-                // FIXME: don't want to unwrap here; need to add a QueryError ctor for the case
-                // where the get_member result is Ok(None)
-                .map(Option::unwrap),
-            Type::Class(class_id) => class_id
-                .get_own_class_member(db, name)
-                .or_else(|_| class_id.get_super_class_member(db, name))
-                // FIXME: don't want to unwrap here; need to add a QueryError ctor for the case
-                // where the get_member result is Ok(None)
-                .map(Option::unwrap),
+            Type::Module(module_id) => module_id.get_member(db, name),
+            Type::Class(class_id) => class_id.get_member(db, name),
             Type::Instance(_) => {
                 // TODO MRO? get_own_instance_member, get_instance_member
                 todo!("attribute lookup on Instance type")

--- a/crates/red_knot/src/types.rs
+++ b/crates/red_knot/src/types.rs
@@ -387,19 +387,15 @@ pub struct ModuleTypeId {
 }
 
 impl ModuleTypeId {
-    // NOTE: following example of `ClasstypeId::class` but instead of making a `ModuleTypeRef`
-    // return the `ModuleStoreRef` directly
     fn module(self, db: &dyn SemanticDb) -> QueryResult<ModuleStoreRef> {
         let jar: &SemanticJar = db.jar()?;
         Ok(jar.type_store.add_or_get_module(self.file_id).downgrade())
     }
 
-    // NOTE: following example of `ClassTypeId::name` but returning `ModuleName` instead of `Name`
     pub(crate) fn name(self, db: &dyn SemanticDb) -> QueryResult<ModuleName> {
         self.module.name(db)
     }
 
-    // NOTE: following examples of `ClassTypeId::get_*member`
     fn get_member(self, db: &dyn SemanticDb, name: &Name) -> QueryResult<Option<Type>> {
         if let Some(symbol_id) = resolve_global_symbol(db, self.name(db)?, name)? {
             Ok(Some(infer_symbol_type(db, symbol_id)?))

--- a/crates/red_knot/src/types.rs
+++ b/crates/red_knot/src/types.rs
@@ -68,8 +68,9 @@ impl Type {
             Type::Union(union_id) => {
                 let jar: &SemanticJar = db.jar()?;
                 let union_ref = jar.type_store.get_union(*union_id);
-                // TODO return a type IFF at least one of the unioned-types have the member; return
-                // the union over those member types
+                // TODO perform the get_member on each type in the union
+                // TODO return the union of those results
+                // TODO if any of those results is `None` then include Unknown in the result union
                 todo!("attribute lookup on Union type")
             }
             Type::Intersection(_) => {

--- a/crates/red_knot/src/types.rs
+++ b/crates/red_knot/src/types.rs
@@ -25,6 +25,8 @@ pub enum Type {
     Unbound,
     /// a specific function object
     Function(FunctionTypeId),
+    /// a specific module object
+    Module(ModuleTypeId),
     /// a specific class object
     Class(ClassTypeId),
     /// the set of Python objects with the given class in their __class__'s method resolution order
@@ -337,6 +339,11 @@ impl FunctionTypeId {
 }
 
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
+pub struct ModuleTypeId {
+    file_id: FileId,
+}
+
+#[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
 pub struct ClassTypeId {
     file_id: FileId,
     class_id: ModuleClassTypeId,
@@ -529,6 +536,8 @@ impl std::fmt::Display for DisplayType<'_> {
             Type::Never => f.write_str("Never"),
             Type::Unknown => f.write_str("Unknown"),
             Type::Unbound => f.write_str("Unbound"),
+            Type::Module(module_id) => {
+            }
             // TODO functions and classes should display using a fully qualified name
             Type::Class(class_id) => {
                 f.write_str("Literal[")?;

--- a/crates/red_knot/src/types.rs
+++ b/crates/red_knot/src/types.rs
@@ -2,6 +2,7 @@
 use crate::ast_ids::NodeKey;
 use crate::db::{QueryResult, SemanticDb, SemanticJar};
 use crate::files::FileId;
+use crate::module::Module;
 use crate::symbols::{symbol_table, GlobalSymbolId, ScopeId, ScopeKind, SymbolId};
 use crate::{FxDashMap, FxIndexSet, Name};
 use ruff_index::{newtype_index, IndexVec};
@@ -340,6 +341,7 @@ impl FunctionTypeId {
 
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
 pub struct ModuleTypeId {
+    module: Module,
     file_id: FileId,
 }
 

--- a/crates/red_knot/src/types.rs
+++ b/crates/red_knot/src/types.rs
@@ -67,7 +67,7 @@ impl Type {
             }
             Type::Union(union_id) => {
                 let jar: &SemanticJar = db.jar()?;
-                let _TODO_union_ref = jar.type_store.get_union(*union_id);
+                let _todo_union_ref = jar.type_store.get_union(*union_id);
                 // TODO perform the get_member on each type in the union
                 // TODO return the union of those results
                 // TODO if any of those results is `None` then include Unknown in the result union

--- a/crates/red_knot/src/types.rs
+++ b/crates/red_knot/src/types.rs
@@ -564,7 +564,8 @@ impl std::fmt::Display for DisplayType<'_> {
             Type::Unknown => f.write_str("Unknown"),
             Type::Unbound => f.write_str("Unbound"),
             Type::Module(module_id) => {
-                todo!("Display for DisplayType for Type::Module: {module_id:?}")
+                // NOTE: something like this?: "<module 'module-name' from 'path-from-fileid'>"
+                todo!("{module_id:?}")
             }
             // TODO functions and classes should display using a fully qualified name
             Type::Class(class_id) => {

--- a/crates/red_knot/src/types.rs
+++ b/crates/red_knot/src/types.rs
@@ -52,6 +52,7 @@ impl Type {
         matches!(self, Type::Unknown)
     }
 
+    // NOTE: naming? `get_member_type`
     pub fn get_member(&self, db: &dyn SemanticDb, name: &Name) -> QueryResult<Type> {
         // NOTE: maybe make this a trait that each TypeID implements?
         match self {

--- a/crates/red_knot/src/types.rs
+++ b/crates/red_knot/src/types.rs
@@ -60,7 +60,7 @@ impl Type {
             Type::Unbound => todo!("attribute lookup on Unbound type"),
             Type::Function(_) => todo!("attribute lookup on Function type"),
             Type::Module(module_id) => module_id.get_member(db, name),
-            Type::Class(class_id) => class_id.get_member(db, name),
+            Type::Class(class_id) => class_id.get_class_member(db, name),
             Type::Instance(_) => {
                 // TODO MRO? get_own_instance_member, get_instance_member
                 todo!("attribute lookup on Instance type")
@@ -448,13 +448,13 @@ impl ClassTypeId {
         }
     }
 
-    /// Get own class member or fallback to super-class member.
-    fn get_member(self, db: &dyn SemanticDb, name: &Name) -> QueryResult<Option<Type>> {
+    /// Get own class member or fall back to super-class member.
+    fn get_class_member(self, db: &dyn SemanticDb, name: &Name) -> QueryResult<Option<Type>> {
         self.get_own_class_member(db, name)
             .or_else(|_| self.get_super_class_member(db, name))
     }
 
-    // TODO: get_own_instance_member, get_class_member, get_instance_member
+    // TODO: get_own_instance_member, get_instance_member
 }
 
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]

--- a/crates/red_knot/src/types.rs
+++ b/crates/red_knot/src/types.rs
@@ -51,6 +51,44 @@ impl Type {
     pub const fn is_unknown(&self) -> bool {
         matches!(self, Type::Unknown)
     }
+
+    pub fn get_member(&self, db: &dyn SemanticDb, name: &Name) -> QueryResult<Type> {
+        // NOTE: maybe make this a trait that each TypeID implements?
+        match self {
+            Type::Any => todo!("attribute lookup on Any type"),
+            Type::Never => todo!("attribute lookup on Never type"),
+            Type::Unknown => todo!("attribute lookup on Unknown type"),
+            Type::Unbound => todo!("attribute lookup on Unbound type"),
+            Type::Function(_) => todo!("attribute lookup on Function type"),
+            Type::Module(module_id) => module_id
+                .get_member(db, name)
+                // FIXME: don't want to unwrap here; need to add a QueryError ctor for the case
+                // where the get_member result is Ok(None)
+                .map(Option::unwrap),
+            Type::Class(class_id) => class_id
+                .get_own_class_member(db, name)
+                .or_else(|_| class_id.get_super_class_member(db, name))
+                // FIXME: don't want to unwrap here; need to add a QueryError ctor for the case
+                // where the get_member result is Ok(None)
+                .map(Option::unwrap),
+            Type::Instance(_) => {
+                // TODO MRO? get_own_instance_member, get_instance_member
+                todo!("attribute lookup on Instance type")
+            }
+            Type::Union(union_id) => {
+                let jar: &SemanticJar = db.jar()?;
+                let union_ref = jar.type_store.get_union(*union_id);
+                // TODO return a type FF at least one of the unioned-types have the member; return
+                // the union over those member types
+                todo!("attribute lookup on Union type")
+            }
+            Type::Intersection(_) => {
+                // TODO return a type IFF all of the intersected-types have the member; but what
+                // type?
+                todo!("attribute lookup on Intersection type")
+            }
+        }
+    }
 }
 
 impl From<FunctionTypeId> for Type {

--- a/crates/red_knot/src/types.rs
+++ b/crates/red_knot/src/types.rs
@@ -458,6 +458,12 @@ impl ClassTypeId {
         }
     }
 
+    /// Get own class member or fallback to super-class member.
+    fn get_member(self, db: &dyn SemanticDb, name: &Name) -> QueryResult<Option<Type>> {
+        self.get_own_class_member(db, name)
+            .or_else(|_| self.get_super_class_member(db, name))
+    }
+
     // TODO: get_own_instance_member, get_class_member, get_instance_member
 }
 

--- a/crates/red_knot/src/types.rs
+++ b/crates/red_knot/src/types.rs
@@ -68,7 +68,7 @@ impl Type {
             Type::Union(union_id) => {
                 let jar: &SemanticJar = db.jar()?;
                 let union_ref = jar.type_store.get_union(*union_id);
-                // TODO return a type FF at least one of the unioned-types have the member; return
+                // TODO return a type IFF at least one of the unioned-types have the member; return
                 // the union over those member types
                 todo!("attribute lookup on Union type")
             }

--- a/crates/red_knot/src/types.rs
+++ b/crates/red_knot/src/types.rs
@@ -74,8 +74,8 @@ impl Type {
                 todo!("attribute lookup on Union type")
             }
             Type::Intersection(_) => {
-                // TODO return a type IFF all of the intersected-types have the member; but what
-                // type?
+                // TODO perform the get_member on each type in the intersection
+                // TODO return the intersection of those results
                 todo!("attribute lookup on Intersection type")
             }
         }

--- a/crates/red_knot/src/types.rs
+++ b/crates/red_knot/src/types.rs
@@ -67,7 +67,7 @@ impl Type {
             }
             Type::Union(union_id) => {
                 let jar: &SemanticJar = db.jar()?;
-                let union_ref = jar.type_store.get_union(*union_id);
+                let _TODO_union_ref = jar.type_store.get_union(*union_id);
                 // TODO perform the get_member on each type in the union
                 // TODO return the union of those results
                 // TODO if any of those results is `None` then include Unknown in the result union

--- a/crates/red_knot/src/types.rs
+++ b/crates/red_knot/src/types.rs
@@ -355,7 +355,7 @@ impl ModuleTypeId {
         Ok(jar.type_store.add_or_get_module(self.file_id).downgrade())
     }
 
-    // NOTE: following example of `ClassTypeId::name` but returning `ModuleName` insead of `Name`
+    // NOTE: following example of `ClassTypeId::name` but returning `ModuleName` instead of `Name`
     pub(crate) fn name(self, db: &dyn SemanticDb) -> QueryResult<ModuleName> {
         self.module.name(db)
     }
@@ -564,6 +564,7 @@ impl std::fmt::Display for DisplayType<'_> {
             Type::Unknown => f.write_str("Unknown"),
             Type::Unbound => f.write_str("Unbound"),
             Type::Module(module_id) => {
+                todo!("Display for DisplayType for Type::Module: {module_id:?}")
             }
             // TODO functions and classes should display using a fully qualified name
             Type::Class(class_id) => {

--- a/crates/red_knot/src/types/infer.rs
+++ b/crates/red_knot/src/types/infer.rs
@@ -127,7 +127,7 @@ pub fn infer_definition_type(
             // TODO handle unpacking assignment correctly
             infer_expr_type(db, file_id, &node.value)
         }
-        x => todo!("other kinds of definitions: {x:?}"),
+        _ => todo!("other kinds of definitions"),
     }
 }
 

--- a/crates/red_knot/src/types/infer.rs
+++ b/crates/red_knot/src/types/infer.rs
@@ -8,7 +8,8 @@ use crate::db::{QueryResult, SemanticDb, SemanticJar};
 use crate::module::ModuleName;
 use crate::parse::parse;
 use crate::symbols::{
-    resolve_global_symbol, symbol_table, Definition, GlobalSymbolId, ImportFromDefinition,
+    resolve_global_symbol, symbol_table, Definition, GlobalSymbolId, ImportDefinition,
+    ImportFromDefinition,
 };
 use crate::types::Type;
 use crate::FileId;
@@ -59,6 +60,11 @@ pub fn infer_definition_type(
             } else {
                 Ok(Type::Unknown)
             }
+        }
+        Definition::Import(ImportDefinition { module }) => {
+            // TODO what is the type of a module
+            let _ = module;
+            Ok(Type::Unknown)
         }
         Definition::ClassDef(node_key) => {
             if let Some(ty) = type_store.get_cached_node_type(file_id, node_key.erased()) {

--- a/crates/red_knot/src/types/infer.rs
+++ b/crates/red_knot/src/types/infer.rs
@@ -124,10 +124,20 @@ pub fn infer_definition_type(
             let parsed = parse(db.upcast(), file_id)?;
             let ast = parsed.ast();
             let node = node_key.resolve_unwrap(ast.as_any_node_ref());
-            // TODO handle unpacking assignment correctly
+            // TODO handle unpacking assignment correctly (here and for AnnotatedAssignment case, below)
             infer_expr_type(db, file_id, &node.value)
         }
-        _ => todo!("other kinds of definitions"),
+        Definition::AnnotatedAssignment(node_key) => {
+            let parsed = parse(db.upcast(), file_id)?;
+            let ast = parsed.ast();
+            let node = node_key.resolve_unwrap(ast.as_any_node_ref());
+            // TODO actually look at the annotation
+            let Some(value) = &node.value else {
+                return Ok(Type::Unknown);
+            };
+            // TODO handle unpacking assignment correctly (here and for Assignment case, above)
+            infer_expr_type(db, file_id, value)
+        }
     }
 }
 

--- a/crates/red_knot/src/types/infer.rs
+++ b/crates/red_knot/src/types/infer.rs
@@ -12,7 +12,7 @@ use crate::symbols::{
     ImportFromDefinition,
 };
 use crate::types::{ModuleTypeId, Type};
-use crate::FileId;
+use crate::{FileId, Name};
 
 // FIXME: Figure out proper dead-lock free synchronisation now that this takes `&db` instead of `&mut db`.
 #[tracing::instrument(level = "trace", skip(db))]
@@ -142,6 +142,11 @@ fn infer_expr_type(db: &dyn SemanticDb, file_id: FileId, expr: &ast::Expr) -> Qu
             } else {
                 Ok(Type::Unknown)
             }
+        }
+        ast::Expr::Attribute(ast::ExprAttribute { value, attr, .. }) => {
+            let value_type = infer_expr_type(db, file_id, value)?;
+            let attr_name = &Name::new(&attr.id);
+            value_type.get_member(db, attr_name)
         }
         _ => todo!("full expression type resolution"),
     }

--- a/crates/red_knot/src/types/infer.rs
+++ b/crates/red_knot/src/types/infer.rs
@@ -47,6 +47,15 @@ pub fn infer_definition_type(
     let file_id = symbol.file_id;
 
     match definition {
+        Definition::Import(ImportDefinition {
+            module: module_name,
+        }) => {
+            if let Some(module) = resolve_module(db, module_name.clone())? {
+                Ok(Type::Module(ModuleTypeId { module, file_id }))
+            } else {
+                Ok(Type::Unknown)
+            }
+        }
         Definition::ImportFrom(ImportFromDefinition {
             module,
             name,
@@ -57,15 +66,6 @@ pub fn infer_definition_type(
             let module_name = ModuleName::new(module.as_ref().expect("TODO relative imports"));
             if let Some(remote_symbol) = resolve_global_symbol(db, module_name, &name)? {
                 infer_symbol_type(db, remote_symbol)
-            } else {
-                Ok(Type::Unknown)
-            }
-        }
-        Definition::Import(ImportDefinition {
-            module: module_name,
-        }) => {
-            if let Some(module) = resolve_module(db, module_name.clone())? {
-                Ok(Type::Module(ModuleTypeId { module, file_id }))
             } else {
                 Ok(Type::Unknown)
             }

--- a/crates/red_knot/src/types/infer.rs
+++ b/crates/red_knot/src/types/infer.rs
@@ -148,15 +148,6 @@ fn infer_expr_type(db: &dyn SemanticDb, file_id: FileId, expr: &ast::Expr) -> Qu
             let attr_name = &Name::new(&attr.id);
             value_type.get_member(db, attr_name)
         }
-        ast::Expr::Call(ast::ExprCall { func, .. }) => {
-            let func_type = infer_expr_type(db, file_id, func)?;
-            // TODO: check that func_type is a function type, else type error? are we doing
-            // type-checking here?
-            //
-            // TODO: infer each type of `arguments` and check that it matches the corresponding
-            // argument type of the function? if one doesn't match, type error
-            todo!("extract result of function type {func_type:?}")
-        }
         _ => todo!("full expression type resolution"),
     }
 }

--- a/crates/red_knot/src/types/infer.rs
+++ b/crates/red_knot/src/types/infer.rs
@@ -146,7 +146,9 @@ fn infer_expr_type(db: &dyn SemanticDb, file_id: FileId, expr: &ast::Expr) -> Qu
         ast::Expr::Attribute(ast::ExprAttribute { value, attr, .. }) => {
             let value_type = infer_expr_type(db, file_id, value)?;
             let attr_name = &Name::new(&attr.id);
-            value_type.get_member(db, attr_name)
+            value_type
+                .get_member(db, attr_name)
+                .map(|ty| ty.unwrap_or(Type::Unknown))
         }
         _ => todo!("full expression type resolution"),
     }

--- a/crates/red_knot/src/types/infer.rs
+++ b/crates/red_knot/src/types/infer.rs
@@ -11,7 +11,7 @@ use crate::symbols::{
     resolve_global_symbol, symbol_table, Definition, GlobalSymbolId, ImportDefinition,
     ImportFromDefinition,
 };
-use crate::types::{self as types, Type};
+use crate::types::{ModuleTypeId, Type};
 use crate::FileId;
 
 // FIXME: Figure out proper dead-lock free synchronisation now that this takes `&db` instead of `&mut db`.
@@ -65,7 +65,7 @@ pub fn infer_definition_type(
             module: module_name,
         }) => {
             if let Some(module) = resolve_module(db, module_name.clone())? {
-                Ok(Type::Module(types::ModuleTypeId { module, file_id }))
+                Ok(Type::Module(ModuleTypeId { module, file_id }))
             } else {
                 Ok(Type::Unknown)
             }

--- a/crates/red_knot/src/types/infer.rs
+++ b/crates/red_knot/src/types/infer.rs
@@ -11,7 +11,7 @@ use crate::symbols::{
     resolve_global_symbol, symbol_table, Definition, GlobalSymbolId, ImportDefinition,
     ImportFromDefinition,
 };
-use crate::types::Type;
+use crate::types::{self as types, Type};
 use crate::FileId;
 
 // FIXME: Figure out proper dead-lock free synchronisation now that this takes `&db` instead of `&mut db`.
@@ -62,9 +62,9 @@ pub fn infer_definition_type(
             }
         }
         Definition::Import(ImportDefinition { module }) => {
-            // TODO what is the type of a module
-            let _ = module;
-            Ok(Type::Unknown)
+            // FIXME: do we need to trigger a parse of the module here?
+            // FIXME: should the module type contain ModuleStoreRef?
+            Ok(Type::Module(types::ModuleTypeId { file_id }))
         }
         Definition::ClassDef(node_key) => {
             if let Some(ty) = type_store.get_cached_node_type(file_id, node_key.erased()) {

--- a/crates/red_knot/src/types/infer.rs
+++ b/crates/red_knot/src/types/infer.rs
@@ -148,6 +148,15 @@ fn infer_expr_type(db: &dyn SemanticDb, file_id: FileId, expr: &ast::Expr) -> Qu
             let attr_name = &Name::new(&attr.id);
             value_type.get_member(db, attr_name)
         }
+        ast::Expr::Call(ast::ExprCall { func, .. }) => {
+            let func_type = infer_expr_type(db, file_id, func)?;
+            // TODO: check that func_type is a function type, else type error? are we doing
+            // type-checking here?
+            //
+            // TODO: infer each type of `arguments` and check that it matches the corresponding
+            // argument type of the function? if one doesn't match, type error
+            todo!("extract result of function type {func_type:?}")
+        }
         _ => todo!("full expression type resolution"),
     }
 }

--- a/crates/red_knot/src/types/infer.rs
+++ b/crates/red_knot/src/types/infer.rs
@@ -123,7 +123,7 @@ pub fn infer_definition_type(
             // TODO handle unpacking assignment correctly
             infer_expr_type(db, file_id, &node.value)
         }
-        _ => todo!("other kinds of definitions"),
+        x => todo!("other kinds of definitions: {x:?}"),
     }
 }
 


### PR DESCRIPTION
* Add a module type, `ModuleTypeId`
* Add an attribute lookup method `get_member` for `Type`
  * Only implemented for `ModuleTypeId` and `ClassTypeId`
  * [x] Should this be a trait?
    *Answer: no*
  * [x] Uses `unwrap`, but we should remove that. Maybe add a new variant to `QueryError`?
    *Answer: Return `Option<Type>` as is done elsewhere*
* Add `infer_definition_type` case for `Import`
* Add `infer_expr_type` case for `Attribute`
* Add a test to exercise these
* [x] remove all NOTE/FIXME/TODO after discussing with reviewers