### PR TITLE
Use `TokenKind` in `doc_lines_from_tokens`

### DIFF
--- a/crates/ruff_linter/src/linter.rs
+++ b/crates/ruff_linter/src/linter.rs
@@ -93,7 +93,7 @@ pub fn check_path(
     let use_doc_lines = settings.rules.enabled(Rule::DocLineTooLong);
     let mut doc_lines = vec![];
     if use_doc_lines {
-        doc_lines.extend(doc_lines_from_tokens(&tokens));
+        doc_lines.extend(doc_lines_from_tokens(tokens.kinds()));
     }
 
     // Run the token-based rules.


### PR DESCRIPTION
## Summary

This PR updates the `doc_lines_from_tokens` function to use `TokenKind` instead of `Tok`.

This is part of #11401 

## Test Plan

`cargo test`
