### PR TITLE
Move most of token-based rules to use `TokenKind`

### DIFF
--- a/crates/ruff_linter/src/checkers/tokens.rs
+++ b/crates/ruff_linter/src/checkers/tokens.rs
@@ -86,8 +86,8 @@ pub(crate) fn check_tokens(
         Rule::InvalidCharacterNul,
         Rule::InvalidCharacterZeroWidthSpace,
     ]) {
-        for (tok, range) in tokens.iter().flatten() {
-            pylint::rules::invalid_string_characters(&mut diagnostics, tok, *range, locator);
+        for (token, range) in tokens.kinds() {
+            pylint::rules::invalid_string_characters(&mut diagnostics, token, range, locator);
         }
     }
 
@@ -98,7 +98,7 @@ pub(crate) fn check_tokens(
     ]) {
         pycodestyle::rules::compound_statements(
             &mut diagnostics,
-            tokens,
+            tokens.kinds(),
             locator,
             indexer,
             source_type,
@@ -112,7 +112,7 @@ pub(crate) fn check_tokens(
     ]) {
         flake8_implicit_str_concat::rules::implicit(
             &mut diagnostics,
-            tokens,
+            tokens.kinds(),
             settings,
             locator,
             indexer,
@@ -124,7 +124,7 @@ pub(crate) fn check_tokens(
         Rule::TrailingCommaOnBareTuple,
         Rule::ProhibitedTrailingComma,
     ]) {
-        flake8_commas::rules::trailing_commas(&mut diagnostics, tokens, locator, indexer);
+        flake8_commas::rules::trailing_commas(&mut diagnostics, tokens.kinds(), locator, indexer);
     }
 
     if settings.rules.enabled(Rule::ExtraneousParentheses) {
@@ -172,7 +172,7 @@ pub(crate) fn check_tokens(
     }
 
     if settings.rules.enabled(Rule::TooManyNewlinesAtEndOfFile) {
-        pycodestyle::rules::too_many_newlines_at_end_of_file(&mut diagnostics, tokens);
+        pycodestyle::rules::too_many_newlines_at_end_of_file(&mut diagnostics, tokens.kinds());
     }
 
     diagnostics.retain(|diagnostic| settings.rules.enabled(diagnostic.kind.rule()));

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/too_many_newlines_at_end_of_file.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/too_many_newlines_at_end_of_file.rs
@@ -1,7 +1,6 @@
 use ruff_diagnostics::{AlwaysFixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
-use ruff_python_parser::lexer::LexResult;
-use ruff_python_parser::Tok;
+use ruff_python_parser::{TokenKind, TokenKindIter};
 use ruff_text_size::{TextRange, TextSize};
 
 /// ## What it does
@@ -57,23 +56,23 @@ impl AlwaysFixableViolation for TooManyNewlinesAtEndOfFile {
 /// W391
 pub(crate) fn too_many_newlines_at_end_of_file(
     diagnostics: &mut Vec<Diagnostic>,
-    lxr: &[LexResult],
+    tokens: TokenKindIter,
 ) {
     let mut num_trailing_newlines = 0u32;
     let mut start: Option<TextSize> = None;
     let mut end: Option<TextSize> = None;
 
     // Count the number of trailing newlines.
-    for (tok, range) in lxr.iter().rev().flatten() {
-        match tok {
-            Tok::NonLogicalNewline | Tok::Newline => {
+    for (token, range) in tokens.rev() {
+        match token {
+            TokenKind::NonLogicalNewline | TokenKind::Newline => {
                 if num_trailing_newlines == 0 {
                     end = Some(range.end());
                 }
                 start = Some(range.end());
                 num_trailing_newlines += 1;
             }
-            Tok::Dedent => continue,
+            TokenKind::Dedent => continue,
             _ => {
                 break;
             }

--- a/crates/ruff_linter/src/rules/pylint/rules/invalid_string_characters.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/invalid_string_characters.rs
@@ -4,7 +4,7 @@ use ruff_diagnostics::AlwaysFixableViolation;
 use ruff_diagnostics::Edit;
 use ruff_diagnostics::{Diagnostic, DiagnosticKind, Fix};
 use ruff_macros::{derive_message_formats, violation};
-use ruff_python_parser::Tok;
+use ruff_python_parser::TokenKind;
 use ruff_source_file::Locator;
 
 /// ## What it does
@@ -174,14 +174,14 @@ impl AlwaysFixableViolation for InvalidCharacterZeroWidthSpace {
 /// PLE2510, PLE2512, PLE2513, PLE2514, PLE2515
 pub(crate) fn invalid_string_characters(
     diagnostics: &mut Vec<Diagnostic>,
-    tok: &Tok,
+    token: TokenKind,
     range: TextRange,
     locator: &Locator,
 ) {
-    let text = match tok {
+    let text = match token {
         // We can't use the `value` field since it's decoded and e.g. for f-strings removed a curly
         // brace that escaped another curly brace, which would gives us wrong column information.
-        Tok::String { .. } | Tok::FStringMiddle { .. } => locator.slice(range),
+        TokenKind::String | TokenKind::FStringMiddle => locator.slice(range),
         _ => return,
     };
 


### PR DESCRIPTION
## Summary

This PR moves the following rules to use `TokenKind` instead of `Tok`:
* `PLE2510`, `PLE2512`, `PLE2513`, `PLE2514`, `PLE2515`
* `E701`, `E702`, `E703`
* `ISC001`, `ISC002`
* `COM812`, `COM818`, `COM819`
* `W391`

I've paused here because the next set of rules (`pyupgrade::rules::extraneous_parentheses`) indexes into the token slice but we only have an iterator implementation. So, I want to isolate that change to make sure the logic is still the same when I move to using the iterator approach.

This is part of #11401 

## Test Plan

`cargo test`
