### PR TITLE
Add automation for updating our vendored typeshed stubs

### DIFF
--- a/.github/workflows/sync_typeshed.yaml
+++ b/.github/workflows/sync_typeshed.yaml
@@ -1,0 +1,80 @@
+name: Sync typeshed
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Run on the 1st and the 15th of every month:
+    - cron: "0 0 1,15 * *"
+
+env:
+  FORCE_COLOR: 1
+  GH_TOKEN: ${{ github.token }}
+
+jobs:
+  sync:
+    name: Sync typeshed
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    # Don't run the cron job on forks:
+    if: ${{ github.repository == 'astral-sh/ruff' || github.event_name != 'schedule' }}
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        name: Checkout Ruff
+        with:
+          path: ruff
+      - uses: actions/checkout@v4
+        name: Checkout typeshed
+        with:
+          repository: python/typeshed
+          path: typeshed
+      - name: Setup git
+        run: |
+          git config --global user.name typeshedbot
+          git config --global user.email '<>'
+      - name: Sync typeshed
+        id: sync
+        run: |
+          rm -rf ruff/crates/red_knot/vendor/typeshed
+          mkdir ruff/crates/red_knot/vendor/typeshed
+          cp typeshed/README.md ruff/crates/red_knot/vendor/typeshed
+          cp typeshed/LICENSE ruff/crates/red_knot/vendor/typeshed
+          cp -r typeshed/stdlib ruff/crates/red_knot/vendor/typeshed/stdlib
+          rm -rf ruff/crates/red_knot/vendor/typeshed/stdlib/@tests
+          git -C typeshed rev-parse HEAD > ruff/crates/red_knot/vendor/typeshed/source_commit.txt
+      - name: Commit the changes
+        id: commit
+        if: ${{ steps.sync.outcome == 'success' }}
+        run: |
+          cd ruff
+          git checkout -b typeshedbot/sync-typeshed
+          git add .
+          git diff --staged --quiet || git commit -m "Sync typeshed. Source commit: https://github.com/python/typeshed/commit/$(git -C ../typeshed rev-parse HEAD)"
+      - name: Create a PR
+        if: ${{ steps.sync.outcome == 'success' && steps.commit.outcome == 'success' }}
+        run: |
+          cd ruff
+          git push --force origin typeshedbot/sync-typeshed
+          gh pr list --repo $GITHUB_REPOSITORY --head typeshedbot/sync-typeshed --json id --jq length | grep 1 && exit 0 # exit if there is existing pr
+          gh pr create --title "Sync vendored typeshed stubs" --body "Close and reopen this PR to trigger CI" --label "linter"
+
+  create-issue-on-failure:
+    name: Create an issue if the typeshed sync failed
+    runs-on: ubuntu-latest
+    needs: [sync]
+    if: ${{ github.repository == 'astral-sh/ruff' && always() && github.event_name == 'schedule' && needs.sync.result == 'failure' }}
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            await github.rest.issues.create({
+              owner: "astral-sh",
+              repo: "ruff",
+              title: `Automated typeshed sync failed on ${new Date().toDateString()}`,
+              body: "Runs are listed here: https://github.com/astral-sh/ruff/actions/workflows/sync_typeshed.yaml",
+            })

--- a/.github/workflows/sync_typeshed.yaml
+++ b/.github/workflows/sync_typeshed.yaml
@@ -58,7 +58,7 @@ jobs:
           cd ruff
           git push --force origin typeshedbot/sync-typeshed
           gh pr list --repo $GITHUB_REPOSITORY --head typeshedbot/sync-typeshed --json id --jq length | grep 1 && exit 0 # exit if there is existing pr
-          gh pr create --title "Sync vendored typeshed stubs" --body "Close and reopen this PR to trigger CI" --label "linter"
+          gh pr create --title "Sync vendored typeshed stubs" --body "Close and reopen this PR to trigger CI" --label "internal"
 
   create-issue-on-failure:
     name: Create an issue if the typeshed sync failed

--- a/crates/red_knot/README.md
+++ b/crates/red_knot/README.md
@@ -6,13 +6,4 @@ The Red Knot crate contains code working towards multifile analysis, type infere
 
 Red Knot vendors [typeshed](https://github.com/python/typeshed)'s stubs for the standard library. The vendored stubs can be found in `crates/red_knot/vendor/typeshed`. The file `crates/red_knot/vendor/typeshed/source_commit.txt` tells you the typeshed commit that our vendored stdlib stubs currently correspond to.
 
-Updating the vendored stubs is currently done manually. On a Unix machine, follow the following steps (if you have a typeshed clone in a `typeshed` directory, and a Ruff clone in a `ruff` directory):
-
-```shell
-rm -rf ruff/crates/red_knot/vendor/typeshed
-mkdir ruff/crates/red_knot/vendor/typeshed
-cp typeshed/README.md ruff/crates/red_knot/vendor/typeshed
-cp typeshed/LICENSE ruff/crates/red_knot/vendor/typeshed
-cp -r typeshed/stdlib ruff/crates/red_knot/vendor/typeshed/stdlib
-git -C typeshed rev-parse HEAD > ruff/crates/red_knot/vendor/typeshed/source_commit.txt
-```
+The typeshed stubs are updated every two weeks via an automated PR using the `sync_typeshed.yaml` workflow in the `.github/workflows` directory. This workflow can also be triggered at any time via [workflow dispatch](https://docs.github.com/en/actions/using-workflows/manually-running-a-workflow#running-a-workflow).


### PR DESCRIPTION
## Summary

This PR adds a workflow that will create an automated PR every two weeks to update our vendored typeshed stubs. Two notes:
- In order for a GitHub Action to be able to create automated PRs, we will need to tick this checkbox in our repo settings:

  ---
  ![image](https://github.com/astral-sh/ruff/assets/66076021/7ca99c44-5cde-47af-8b9d-c00fc356d7ff)
  
  ---
  
- CI will not be triggered on these automated PRs unless the PR is closed and reopened by a maintainer. I think there are workarounds for this limitation, but we haven't succeeded in figuring out how to do them properly at typeshed or mypy, where we also have workflows to trigger automated PRs.


## Test Plan

A GitHub workflow cannot be tested unless it is run, and a workflow cannot be run unless it is already merged to the `main` branch of a repository. So, that's what I did -- with my Ruff fork! I temporarily merged this PR to the `main` branch of my Ruff fork, and ran the workflow. You can see a demo PR here that was automatically created by running this workflow from my fork: https://github.com/AlexWaygood/ruff/pull/9