### PR TITLE
Fix starts at logic for the parser flow

### DIFF
--- a/crates/ruff_python_parser/src/token_source.rs
+++ b/crates/ruff_python_parser/src/token_source.rs
@@ -1,4 +1,4 @@
-use ruff_text_size::TextRange;
+use ruff_text_size::{TextRange, TextSize};
 
 use crate::lexer::{Lexer, LexicalError, Token, TokenValue};
 use crate::{Mode, TokenKind};
@@ -18,14 +18,20 @@ pub(crate) struct TokenSource<'src> {
 impl<'src> TokenSource<'src> {
     /// Create a new token source for the given lexer.
     pub(crate) fn new(lexer: Lexer<'src>) -> Self {
-        Self {
+        TokenSource {
             lexer,
             tokens: vec![],
         }
     }
 
-    pub(crate) fn from_source(source: &'src str, mode: Mode) -> Self {
-        Self::new(Lexer::new(source, mode))
+    /// Create a new token source from the given source code which starts at the given offset.
+    pub(crate) fn from_source(source: &'src str, mode: Mode, start_offset: TextSize) -> Self {
+        let lexer = Lexer::new(source, mode, start_offset);
+        let mut source = TokenSource::new(lexer);
+
+        // Initialize the token source so that the current token is set correctly.
+        source.next_token();
+        source
     }
 
     /// Returns the kind of the current token.


### PR DESCRIPTION
## Summary

This PR fixes the parser flow for the starts at functionality.

The parser APIs are as follows:
* `Parser::new`
* `Parser::new_starts_at`

The `TokenSource` and `Lexer` will have the same function signature where they also accepts a start offset. This makes the APIs easier to reason about and avoids adding both variants for the token source and the lexer.

The `*_starts_at` APIs now expect the entire source code and the lexer will skip that many bytes as the offset. This will match the `*_starts_at` naming as well.

The high level APIs which are part of the public interface will be updated to take in a range instead of the offset. Internally, we'll slice the source code up to the end range and pass this sub-string and the start range value to the parser. This change will be done at the end as it affects all the downstream calls as well.

So, all in all, the final APIs will be:
```rs
pub fn parse(source: &str, mode: Mode) -> Program {
	Parser::new(source, mode).parse_program()
}

pub fn parse_range(source: &str, mode: Mode, range: TextRange) -> Program {
	let source = source[..range.end().to_usize()];
	Parser::new_starts_at(source, mode, range.start()).parse_program()
}
```

Both the above APIs expect the entire source code. This is so that the caller doesn't need to worry about slicing the correct part of the source code.
