### PR TITLE
Update CONTRIBUTING.md to reflect the new parser

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -638,7 +638,7 @@ Otherwise, follow the instructions from the linux section.
 utils with it:
 
 - `cargo dev print-ast <file>`: Print the AST of a python file using Ruff's
-    [custom Python parser](https://github.com/astral-sh/ruff/tree/main/crates/ruff_python_parser).
+    [Python parser](https://github.com/astral-sh/ruff/tree/main/crates/ruff_python_parser).
     For `if True: pass # comment`, you can see the syntax tree, the byte offsets for start and
     stop of each node and also how the `:` token, the comment and whitespace are not represented
     anymore:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -637,11 +637,11 @@ Otherwise, follow the instructions from the linux section.
 `cargo dev` is a shortcut for `cargo run --package ruff_dev --bin ruff_dev`. You can run some useful
 utils with it:
 
-- `cargo dev print-ast <file>`: Print the AST of a python file using the
-    [RustPython parser](https://github.com/astral-sh/ruff/tree/main/crates/ruff_python_parser) that is
-    mainly used in Ruff. For `if True: pass # comment`, you can see the syntax tree, the byte offsets
-    for start and stop of each node and also how the `:` token, the comment and whitespace are not
-    represented anymore:
+- `cargo dev print-ast <file>`: Print the AST of a python file using Ruff's
+    [custom Python parser](https://github.com/astral-sh/ruff/tree/main/crates/ruff_python_parser).
+    For `if True: pass # comment`, you can see the syntax tree, the byte offsets for start and
+    stop of each node and also how the `:` token, the comment and whitespace are not represented
+    anymore:
 
 ```text
 [


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

CONTRIBUTING.md says that `cargo dev print-ast` uses the old RuffPython parser, even though, as far as I can tell, it uses the shiny new parser. This PR fixes this.

## Test Plan

CI jobs should do the trick -- I didn't modify any code.