### PR TITLE
Add `--output-format` to `ruff config` CLI

### DIFF
--- a/crates/ruff/src/args.rs
+++ b/crates/ruff/src/args.rs
@@ -111,7 +111,13 @@ pub enum Command {
         output_format: HelpFormat,
     },
     /// List or describe the available configuration options.
-    Config { option: Option<String> },
+    Config {
+        /// Config key to show
+        option: Option<String>,
+        /// Output format
+        #[arg(long, value_enum, default_value = "text")]
+        output_format: HelpFormat,
+    },
     /// List all supported upstream linters.
     Linter {
         /// Output format

--- a/crates/ruff/src/commands/config.rs
+++ b/crates/ruff/src/commands/config.rs
@@ -1,19 +1,27 @@
 use anyhow::{anyhow, Result};
 
+use crate::args::HelpFormat;
+
 use ruff_workspace::options::Options;
 use ruff_workspace::options_base::OptionsMetadata;
 
 #[allow(clippy::print_stdout)]
-pub(crate) fn config(key: Option<&str>) -> Result<()> {
+pub(crate) fn config(key: Option<&str>, format: HelpFormat) -> Result<()> {
     match key {
         None => print!("{}", Options::metadata()),
         Some(key) => match Options::metadata().find(key) {
             None => {
                 return Err(anyhow!("Unknown option: {key}"));
             }
-            Some(entry) => {
-                print!("{entry}");
-            }
+            Some(entry) => match format {
+                HelpFormat::Text => {
+                    print!("{entry}");
+                }
+
+                HelpFormat::Json => {
+                    println!("{}", &serde_json::to_string_pretty(&entry)?);
+                }
+            },
         },
     }
     Ok(())

--- a/crates/ruff/src/commands/config.rs
+++ b/crates/ruff/src/commands/config.rs
@@ -8,7 +8,18 @@ use ruff_workspace::options_base::OptionsMetadata;
 #[allow(clippy::print_stdout)]
 pub(crate) fn config(key: Option<&str>, format: HelpFormat) -> Result<()> {
     match key {
-        None => print!("{}", Options::metadata()),
+        None => {
+            let metadata = Options::metadata();
+            match format {
+                HelpFormat::Text => {
+                    println!("{metadata}");
+                }
+
+                HelpFormat::Json => {
+                    println!("{}", &serde_json::to_string_pretty(&metadata)?);
+                }
+            }
+        }
         Some(key) => match Options::metadata().find(key) {
             None => {
                 return Err(anyhow!("Unknown option: {key}"));

--- a/crates/ruff/src/lib.rs
+++ b/crates/ruff/src/lib.rs
@@ -180,8 +180,11 @@ pub fn run(
             }
             Ok(ExitStatus::Success)
         }
-        Command::Config { option } => {
-            commands::config::config(option.as_deref())?;
+        Command::Config {
+            option,
+            output_format,
+        } => {
+            commands::config::config(option.as_deref(), output_format)?;
             Ok(ExitStatus::Success)
         }
         Command::Linter { output_format } => {

--- a/crates/ruff/tests/config.rs
+++ b/crates/ruff/tests/config.rs
@@ -1,0 +1,55 @@
+//! Tests for the `ruff config` subcommand.
+use std::process::Command;
+
+use insta_cmd::{assert_cmd_snapshot, get_cargo_bin};
+
+const BIN_NAME: &str = "ruff";
+
+#[test]
+fn lint_select() {
+    assert_cmd_snapshot!(
+        Command::new(get_cargo_bin(BIN_NAME)).arg("config").arg("lint.select"), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    A list of rule codes or prefixes to enable. Prefixes can specify exact
+    rules (like `F841`), entire categories (like `F`), or anything in
+    between.
+
+    When breaking ties between enabled and disabled rules (via `select` and
+    `ignore`, respectively), more specific prefixes override less
+    specific prefixes.
+
+    Default value: ["E4", "E7", "E9", "F"]
+    Type: list[RuleSelector]
+    Example usage:
+    ```toml
+    # On top of the defaults (`E4`, E7`, `E9`, and `F`), enable flake8-bugbear (`B`) and flake8-quotes (`Q`).
+    select = ["E4", "E7", "E9", "F", "B", "Q"]
+    ```
+
+    ----- stderr -----
+    "###
+    );
+}
+
+#[test]
+fn lint_select_json() {
+    assert_cmd_snapshot!(
+        Command::new(get_cargo_bin(BIN_NAME)).arg("config").arg("lint.select").arg("--output-format").arg("json"), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    {
+      "doc": "A list of rule codes or prefixes to enable. Prefixes can specify exact\nrules (like `F841`), entire categories (like `F`), or anything in\nbetween.\n\nWhen breaking ties between enabled and disabled rules (via `select` and\n`ignore`, respectively), more specific prefixes override less\nspecific prefixes.",
+      "default": "[\"E4\", \"E7\", \"E9\", \"F\"]",
+      "value_type": "list[RuleSelector]",
+      "scope": null,
+      "example": "# On top of the defaults (`E4`, E7`, `E9`, and `F`), enable flake8-bugbear (`B`) and flake8-quotes (`Q`).\nselect = [\"E4\", \"E7\", \"E9\", \"F\", \"B\", \"Q\"]",
+      "deprecated": null
+    }
+
+    ----- stderr -----
+    "###
+    );
+}

--- a/crates/ruff_workspace/src/options_base.rs
+++ b/crates/ruff_workspace/src/options_base.rs
@@ -1,3 +1,5 @@
+use serde::Serialize;
+
 use std::fmt::{Debug, Display, Formatter};
 
 /// Visits [`OptionsMetadata`].
@@ -39,7 +41,7 @@ where
 }
 
 /// Metadata of an option that can either be a [`OptionField`] or [`OptionSet`].
-#[derive(Clone, PartialEq, Eq, Debug)]
+#[derive(Clone, PartialEq, Eq, Debug, Serialize)]
 pub enum OptionEntry {
     /// A single option.
     Field(OptionField),
@@ -61,9 +63,11 @@ impl Display for OptionEntry {
 ///
 /// It extracts the options by calling the [`OptionsMetadata::record`] of a type implementing
 /// [`OptionsMetadata`].
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Copy, Clone, Eq, PartialEq, Serialize)]
 pub struct OptionSet {
+    #[serde(skip_serializing)]
     record: fn(&mut dyn Visit),
+    #[serde(skip_serializing)]
     doc: fn() -> Option<&'static str>,
 }
 
@@ -331,7 +335,7 @@ impl Debug for OptionSet {
     }
 }
 
-#[derive(Debug, Eq, PartialEq, Clone)]
+#[derive(Debug, Eq, PartialEq, Clone, Serialize)]
 pub struct OptionField {
     pub doc: &'static str,
     /// Ex) `"false"`
@@ -344,7 +348,7 @@ pub struct OptionField {
     pub deprecated: Option<Deprecated>,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
 pub struct Deprecated {
     pub since: Option<&'static str>,
     pub message: Option<&'static str>,


### PR DESCRIPTION
This is useful for extracting the defaults in order to construct equivalent configs by external scripts.  This is my first non-hello-world rust code, comments and suggested tests appreciated.

## Summary

We already have `ruff linter --output-format json`, this provides `ruff config x --output-format json` as well.  I plan to use this to construct an equivalent config snippet to include in some managed repos, so when we update their version of ruff and it adds new lints, they get a PR that includes the commented-out new lints.

Note that the no-args form of `ruff config` ignores output-format currently, but probably should obey it (although array-of-strings doesn't seem that useful, looking for input on format).

## Test Plan

I could use a hand coming up with a typical way to write automated tests for this.

```sh-session
(.venv) [timhatch:ruff ]$ ./target/debug/ruff config lint.select
A list of rule codes or prefixes to enable. Prefixes can specify exact
rules (like `F841`), entire categories (like `F`), or anything in
between.

When breaking ties between enabled and disabled rules (via `select` and
`ignore`, respectively), more specific prefixes override less
specific prefixes.

Default value: ["E4", "E7", "E9", "F"]
Type: list[RuleSelector]
Example usage:
``toml
# On top of the defaults (`E4`, E7`, `E9`, and `F`), enable flake8-bugbear (`B`) and flake8-quotes (`Q`).
select = ["E4", "E7", "E9", "F", "B", "Q"]
``
(.venv) [timhatch:ruff ]$ ./target/debug/ruff config lint.select --output-format json
{
  "Field": {
    "doc": "A list of rule codes or prefixes to enable. Prefixes can specify exact\nrules (like `F841`), entire categories (like `F`), or anything in\nbetween.\n\nWhen breaking ties between enabled and disabled rules (via `select` and\n`ignore`, respectively), more specific prefixes override less\nspecific prefixes.",
    "default": "[\"E4\", \"E7\", \"E9\", \"F\"]",
    "value_type": "list[RuleSelector]",
    "scope": null,
    "example": "# On top of the defaults (`E4`, E7`, `E9`, and `F`), enable flake8-bugbear (`B`) and flake8-quotes (`Q`).\nselect = [\"E4\", \"E7\", \"E9\", \"F\", \"B\", \"Q\"]",
    "deprecated": null
  }
}
```