### PR TITLE
Add checkpoint logic for the parser

### DIFF
--- a/crates/ruff_python_parser/src/lexer.rs
+++ b/crates/ruff_python_parser/src/lexer.rs
@@ -1326,7 +1326,7 @@ impl<'src> Lexer<'src> {
         std::mem::take(&mut self.value)
     }
 
-    /// Creates a checkpoint to which it can later return to using [`Self::rewind`].
+    /// Creates a checkpoint to which the lexer can later return to using [`Self::rewind`].
     pub(crate) fn checkpoint(&self) -> LexerCheckpoint<'src> {
         LexerCheckpoint {
             value: self.value.clone(),
@@ -1337,6 +1337,7 @@ impl<'src> Lexer<'src> {
             indentations_checkpoint: self.indentations.checkpoint(),
             pending_indentation: self.pending_indentation,
             fstrings_checkpoint: self.fstrings.checkpoint(),
+            errors_position: self.errors.len(),
         }
     }
 
@@ -1350,6 +1351,7 @@ impl<'src> Lexer<'src> {
         self.indentations.rewind(checkpoint.indentations_checkpoint);
         self.pending_indentation = checkpoint.pending_indentation;
         self.fstrings.rewind(checkpoint.fstrings_checkpoint);
+        self.errors.truncate(checkpoint.errors_position);
     }
 
     pub fn finish(self) -> Vec<LexicalError> {
@@ -1568,6 +1570,7 @@ pub(crate) struct LexerCheckpoint<'src> {
     indentations_checkpoint: IndentationsCheckpoint,
     pending_indentation: Option<Indentation>,
     fstrings_checkpoint: FStringsCheckpoint,
+    errors_position: usize,
 }
 
 #[derive(Copy, Clone, Debug)]


### PR DESCRIPTION
## Summary

This PR adds the checkpoint logic to the parser and token source. It also updates the lexer checkpoint to contain the error position.
