### PR TITLE
Use lookahead to resolve `type` soft keyword

### DIFF
--- a/crates/ruff_python_parser/src/parser/mod.rs
+++ b/crates/ruff_python_parser/src/parser/mod.rs
@@ -343,6 +343,11 @@ impl<'src> Parser<'src> {
         self.tokens.peek()
     }
 
+    /// Returns the next two token kinds without consuming it.
+    fn peek2(&mut self) -> (TokenKind, TokenKind) {
+        self.tokens.peek2()
+    }
+
     /// Returns the current token kind.
     #[inline]
     fn current_token_kind(&self) -> TokenKind {

--- a/crates/ruff_python_parser/src/parser/statement.rs
+++ b/crates/ruff_python_parser/src/parser/statement.rs
@@ -263,7 +263,7 @@ impl<'src> Parser<'src> {
                     let (first, second) = self.tokens.peek2();
 
                     if (first == TokenKind::Name || first.is_soft_keyword())
-                        && matches!(second, TokenKind::Lpar | TokenKind::Equal)
+                        && matches!(second, TokenKind::Lsqb | TokenKind::Equal)
                     {
                         return Stmt::TypeAlias(self.parse_type_alias_statement());
                     }

--- a/crates/ruff_python_parser/src/parser/statement.rs
+++ b/crates/ruff_python_parser/src/parser/statement.rs
@@ -260,7 +260,7 @@ impl<'src> Parser<'src> {
                 if token == TokenKind::Type {
                     // Type is considered a soft keyword, so we will treat it as an identifier if
                     // it's followed by an unexpected token.
-                    let (first, second) = self.tokens.peek2();
+                    let (first, second) = self.peek2();
 
                     if (first == TokenKind::Name || first.is_soft_keyword())
                         && matches!(second, TokenKind::Lsqb | TokenKind::Equal)

--- a/crates/ruff_python_parser/src/token_source.rs
+++ b/crates/ruff_python_parser/src/token_source.rs
@@ -51,11 +51,24 @@ impl<'src> TokenSource<'src> {
     }
 
     /// Returns the next non-trivia token without consuming it.
+    ///
+    /// Use [`TokenSource::peek2`] to get the next two tokens.
     pub(crate) fn peek(&mut self) -> TokenKind {
         let checkpoint = self.lexer.checkpoint();
         let next = self.next_non_trivia_token();
         self.lexer.rewind(checkpoint);
         next
+    }
+
+    /// Returns the next two non-trivia tokens without consuming it.
+    ///
+    /// Use [`TokenSource::peek`] to only get the next token.
+    pub(crate) fn peek2(&mut self) -> (TokenKind, TokenKind) {
+        let checkpoint = self.lexer.checkpoint();
+        let first = self.next_non_trivia_token();
+        let second = self.next_non_trivia_token();
+        self.lexer.rewind(checkpoint);
+        (first, second)
     }
 
     /// Bumps the token source to the next non-trivia token.


### PR DESCRIPTION
## Summary

This PR updates the `type` alias statement parsing to use lookahead to resolve whether it's used as a keyword or as an identifier depending on the context.

The strategy here is that the first token should be either a name or a soft keyword and the second can be either a `[` or `=`. Remember that `type type = int` is valid where the first `type` is a keyword while the second `type` is an identifier.
