### PR TITLE
Use speculative parsing for `match` statement

### DIFF
--- a/crates/ruff_python_parser/src/parser/expression.rs
+++ b/crates/ruff_python_parser/src/parser/expression.rs
@@ -37,6 +37,7 @@ const LITERAL_SET: TokenSet = TokenSet::new([
 
 /// Tokens that represents either an expression or the start of one.
 pub(super) const EXPR_SET: TokenSet = TokenSet::new([
+    TokenKind::Case,
     TokenKind::Name,
     TokenKind::Minus,
     TokenKind::Plus,
@@ -574,7 +575,7 @@ impl<'src> Parser<'src> {
             TokenKind::Lbrace => self.parse_set_or_dict_like_expression(),
 
             kind => {
-                if kind.is_keyword() || kind.is_soft_keyword() {
+                if kind.is_keyword() {
                     Expr::Name(self.parse_name())
                 } else {
                     self.add_error(

--- a/crates/ruff_python_parser/src/parser/statement.rs
+++ b/crates/ruff_python_parser/src/parser/statement.rs
@@ -127,15 +127,15 @@ impl<'src> Parser<'src> {
                     // it's followed by an unexpected token.
 
                     match self.classify_match_token() {
-                        MatchTokenType::Keyword => {
+                        MatchTokenKind::Keyword => {
                             return Stmt::Match(self.parse_match_statement());
                         }
-                        MatchTokenType::KeywordOrIdentifier => {
+                        MatchTokenKind::KeywordOrIdentifier => {
                             if let Some(match_stmt) = self.try_parse_match_statement() {
                                 return Stmt::Match(match_stmt);
                             }
                         }
-                        MatchTokenType::Identifier => {}
+                        MatchTokenKind::Identifier => {}
                     }
                 }
 
@@ -3511,13 +3511,13 @@ impl<'src> Parser<'src> {
     /// # Panics
     ///
     /// If the parser isn't positioned at a `match` token.
-    fn classify_match_token(&mut self) -> MatchTokenType {
+    fn classify_match_token(&mut self) -> MatchTokenKind {
         assert_eq!(self.current_token_kind(), TokenKind::Match);
 
         let (first, second) = self.tokens.peek2();
 
         match first {
-            TokenKind::Not if second == TokenKind::In => MatchTokenType::Identifier,
+            TokenKind::Not if second == TokenKind::In => MatchTokenKind::Identifier,
             TokenKind::Name
             | TokenKind::Int
             | TokenKind::Float
@@ -3528,17 +3528,17 @@ impl<'src> Parser<'src> {
             | TokenKind::Tilde
             | TokenKind::Await
             | TokenKind::Yield
-            | TokenKind::Lambda => MatchTokenType::Keyword,
+            | TokenKind::Lambda => MatchTokenKind::Keyword,
             TokenKind::Lpar
             | TokenKind::Lsqb
             | TokenKind::Star
             | TokenKind::Plus
-            | TokenKind::Minus => MatchTokenType::KeywordOrIdentifier,
+            | TokenKind::Minus => MatchTokenKind::KeywordOrIdentifier,
             _ => {
                 if first.is_soft_keyword() || first.is_singleton() {
-                    MatchTokenType::Keyword
+                    MatchTokenKind::Keyword
                 } else {
-                    MatchTokenType::Identifier
+                    MatchTokenKind::Identifier
                 }
             }
         }
@@ -3640,7 +3640,7 @@ impl Display for Clause {
 /// The `match` token is a soft keyword which means, depending on the context, it can be used as a
 /// keyword or an identifier.
 #[derive(Debug, Clone, Copy)]
-enum MatchTokenType {
+enum MatchTokenKind {
     /// The `match` token is used as a keyword.
     ///
     /// For example:

--- a/crates/ruff_python_parser/src/parser/statement.rs
+++ b/crates/ruff_python_parser/src/parser/statement.rs
@@ -2405,9 +2405,7 @@ impl<'src> Parser<'src> {
                     range: self.node_range(start),
                 })
             }
-            TokenKind::Newline
-                if matches!(self.tokens.peek2(), (TokenKind::Indent, TokenKind::Case)) =>
-            {
+            TokenKind::Newline if matches!(self.peek2(), (TokenKind::Indent, TokenKind::Case)) => {
                 // `match` is a keyword
                 self.add_error(
                     ParseErrorType::ExpectedToken {
@@ -3514,7 +3512,7 @@ impl<'src> Parser<'src> {
     fn classify_match_token(&mut self) -> MatchTokenKind {
         assert_eq!(self.current_token_kind(), TokenKind::Match);
 
-        let (first, second) = self.tokens.peek2();
+        let (first, second) = self.peek2();
 
         match first {
             TokenKind::Not if second == TokenKind::In => MatchTokenKind::Identifier,

--- a/crates/ruff_python_parser/src/parser/statement.rs
+++ b/crates/ruff_python_parser/src/parser/statement.rs
@@ -3526,9 +3526,6 @@ impl<'src> Parser<'src> {
             | TokenKind::FStringStart
             | TokenKind::Lbrace
             | TokenKind::Tilde
-            | TokenKind::None
-            | TokenKind::True
-            | TokenKind::False
             | TokenKind::Await
             | TokenKind::Yield
             | TokenKind::Lambda => MatchTokenType::Keyword,
@@ -3538,7 +3535,7 @@ impl<'src> Parser<'src> {
             | TokenKind::Plus
             | TokenKind::Minus => MatchTokenType::KeywordOrIdentifier,
             _ => {
-                if first.is_soft_keyword() {
+                if first.is_soft_keyword() || first.is_singleton() {
                     MatchTokenType::Keyword
                 } else {
                     MatchTokenType::Identifier

--- a/crates/ruff_python_parser/src/parser/statement.rs
+++ b/crates/ruff_python_parser/src/parser/statement.rs
@@ -3524,6 +3524,7 @@ impl<'src> Parser<'src> {
             | TokenKind::FStringStart
             | TokenKind::Lbrace
             | TokenKind::Tilde
+            | TokenKind::Ellipsis
             | TokenKind::Await
             | TokenKind::Yield
             | TokenKind::Lambda => MatchTokenKind::Keyword,

--- a/crates/ruff_python_parser/src/parser/statement.rs
+++ b/crates/ruff_python_parser/src/parser/statement.rs
@@ -3491,6 +3491,11 @@ impl<'src> Parser<'src> {
             | TokenKind::FStringStart
             | TokenKind::Lbrace
             | TokenKind::Tilde
+            | TokenKind::None
+            | TokenKind::True
+            | TokenKind::False
+            | TokenKind::Await
+            | TokenKind::Yield
             | TokenKind::Lambda => MatchTokenType::Keyword,
             TokenKind::Lpar
             | TokenKind::Lsqb


### PR DESCRIPTION
## Summary

This PR adds support for parsing `match` statement based on whether `match` is used as a keyword or an identifier.

The logic is as follows:
1. Use two token lookahead to classify the kind of `match` token based on the table down below
2. If we can't determine whether it's a keyword or an identifier, we'll use speculative parsing
3. Assume that `match` is a keyword and parse the subject expression
4. Then, based on certain heuristic, determine if our assumption is correct or not

For (4), the heuristics are:
1. If the current token is `:`, then it's a keyword
2. If the current token is a newline, then
	1. If the following two tokens are `Indent` and `Case`, it's a keyword
	2. Otherwise, it's an identifier
3. Otherwise, it's an identifier

In the above heuristic, the (2) condition is so that the parser can correctly identify the following as a `match` statement in case of a missing `:`:
```py
match foo
	case _:
		pass
```

### Classification table

Here, the token is the one following the `match` token. We use two token lookahead for `not in` because using the `in` keyword we can classify it as an identifier or a keyword.

Token                      | Keyword | Identifier | Either |
--                         | --      | --         | --     |
Name                       | ✅      |            |        |
Int                        | ✅      |            |        |
Float                      | ✅      |            |        |
Complex                    | ✅      |            |        |
String                     | ✅      |            |        |
FStringStart               | ✅      |            |        |
FStringMiddle              | -       | -          | -      |
FStringEnd                 | -       | -          | -      |
IpyEscapeCommand           | -       | -          | -      |
Newline                    |         | ✅         |        |
Indent                     | -       | -          | -      |
Dedent                     | -       | -          | -      |
EndOfFile                  |         | ✅         |        |
`?`                        | -       | -          | -      |
`!`                        |         | ✅         |        |
`(`                        |         |            | ✅     |
`)`                        |         | ✅         |        |
`[`                        |         |            | ✅     |
`]`                        |         | ✅         |        |
`{`                        | ✅      |            |        |
`}`                        |         | ✅         |        |
`:`                        |         | ✅         |        |
`,`                        |         | ✅         |        |
`;`                        |         | ✅         |        |
`.`                        |         | ✅         |        |
`*`                        |         |            | ✅     |
`+`                        |         |            | ✅     |
`-`                        |         |            | ✅     |
Other binary operators     |         | ✅         |        |
`~`                        | ✅      |            |        |
`not`                      | ✅      |            |        |
`not in`                   |         | ✅         |        |
Boolean operators          |         | ✅         |        |
Comparison operators       |         | ✅         |        |
Augmented assign operators |         | ✅         |        |
`...`                      | ✅      |            |        |
`lambda`                   | ✅      |            |        |
`await`                    | ✅      |            |        |
`yield`                    | ✅      |            |        |
Other keywords             |         | ✅         |        |
Soft keywords              | ✅      |            |        |
Singletons                 | ✅      |            |        |
