### PR TITLE
Remove leftover marker tokens

### DIFF
--- a/crates/ruff_python_parser/src/token.rs
+++ b/crates/ruff_python_parser/src/token.rs
@@ -8,8 +8,6 @@
 use ruff_python_ast::{AnyStringFlags, BoolOp, Int, IpyEscapeKind, Operator, UnaryOp};
 use std::fmt;
 
-use crate::Mode;
-
 /// The set of tokens the Python source code can be tokenized in.
 #[derive(Clone, Debug, PartialEq, is_macro::Is)]
 pub enum Tok {
@@ -222,22 +220,12 @@ pub enum Tok {
     Yield,
 
     Unknown,
-    // RustPython specific.
-    StartModule,
-    StartExpression,
 }
 
 impl Tok {
     #[inline]
     pub fn kind(&self) -> TokenKind {
         TokenKind::from_token(self)
-    }
-
-    pub fn start_marker(mode: Mode) -> Self {
-        match mode {
-            Mode::Module | Mode::Ipython => Tok::StartModule,
-            Mode::Expression => Tok::StartExpression,
-        }
     }
 }
 
@@ -261,8 +249,6 @@ impl fmt::Display for Tok {
             NonLogicalNewline => f.write_str("NonLogicalNewline"),
             Indent => f.write_str("Indent"),
             Dedent => f.write_str("Dedent"),
-            StartModule => f.write_str("StartProgram"),
-            StartExpression => f.write_str("StartExpression"),
             EndOfFile => f.write_str("EOF"),
             Question => f.write_str("?"),
             Exclamation => f.write_str("!"),
@@ -537,10 +523,6 @@ pub enum TokenKind {
     Yield,
 
     Unknown,
-    // RustPython specific.
-    StartModule,
-    StartInteractive,
-    StartExpression,
 }
 
 impl TokenKind {
@@ -900,8 +882,6 @@ impl TokenKind {
             Tok::With => TokenKind::With,
             Tok::Yield => TokenKind::Yield,
             Tok::Unknown => TokenKind::Unknown,
-            Tok::StartModule => TokenKind::StartModule,
-            Tok::StartExpression => TokenKind::StartExpression,
         }
     }
 }
@@ -965,9 +945,6 @@ impl fmt::Display for TokenKind {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let value = match self {
             TokenKind::Unknown => "Unknown",
-            TokenKind::StartModule => "StartModule",
-            TokenKind::StartExpression => "StartExpression",
-            TokenKind::StartInteractive => "StartInteractive",
             TokenKind::Newline => "newline",
             TokenKind::NonLogicalNewline => "NonLogicalNewline",
             TokenKind::Indent => "indent",

--- a/crates/ruff_python_parser/src/token.rs
+++ b/crates/ruff_python_parser/src/token.rs
@@ -5,8 +5,9 @@
 //!
 //! [CPython source]: https://github.com/python/cpython/blob/dfc2e065a2e71011017077e549cd2f9bf4944c54/Grammar/Tokens
 
-use ruff_python_ast::{AnyStringFlags, BoolOp, Int, IpyEscapeKind, Operator, UnaryOp};
 use std::fmt;
+
+use ruff_python_ast::{AnyStringFlags, BoolOp, Int, IpyEscapeKind, Operator, UnaryOp};
 
 /// The set of tokens the Python source code can be tokenized in.
 #[derive(Clone, Debug, PartialEq, is_macro::Is)]
@@ -59,7 +60,9 @@ pub enum Tok {
     /// Token value for the end of an f-string. This includes the closing quote.
     FStringEnd,
     /// Token value for IPython escape commands. These are recognized by the lexer
-    /// only when the mode is [`Mode::Ipython`].
+    /// only when the mode is [`Ipython`].
+    ///
+    /// [`Ipython`]: crate::Mode::Ipython
     IpyEscapeCommand {
         /// The magic command value.
         value: Box<str>,
@@ -78,7 +81,9 @@ pub enum Tok {
     /// Token value for a dedent.
     Dedent,
     EndOfFile,
-    /// Token value for a question mark `?`. This is only used in [`Mode::Ipython`].
+    /// Token value for a question mark `?`. This is only used in [`Ipython`].
+    ///
+    /// [`Ipython`]: crate::Mode::Ipython
     Question,
     /// Token value for a exclamation mark `!`.
     Exclamation,


### PR DESCRIPTION
## Summary

This PR removes the leftover marker tokens from the LALRPOP to hand-written parser migration.