### PR TITLE
Consider soft keywords for `E27` rules

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pycodestyle/E27.py
+++ b/crates/ruff_linter/resources/test/fixtures/pycodestyle/E27.py
@@ -63,3 +63,16 @@ if (a and
 #: Okay
 def f():
 	return 1
+
+# Soft keywords
+
+#: E271
+type  Number = int
+
+#: E273
+type	Number = int
+
+#: E275
+match(foo):
+    case(1):
+        pass

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/logical_lines/missing_whitespace_after_keyword.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/logical_lines/missing_whitespace_after_keyword.rs
@@ -52,7 +52,7 @@ pub(crate) fn missing_whitespace_after_keyword(
         let tok0_kind = tok0.kind();
         let tok1_kind = tok1.kind();
 
-        if tok0_kind.is_non_soft_keyword()
+        if tok0_kind.is_keyword()
             && !(tok0_kind.is_singleton()
                 || matches!(tok0_kind, TokenKind::Async | TokenKind::Await)
                 || tok0_kind == TokenKind::Except && tok1_kind == TokenKind::Star

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/logical_lines/mod.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/logical_lines/mod.rs
@@ -445,7 +445,7 @@ impl LogicalLinesBuilder {
 
         if matches!(kind, TokenKind::Comma | TokenKind::Semi | TokenKind::Colon) {
             line.flags.insert(TokenFlags::PUNCTUATION);
-        } else if kind.is_non_soft_keyword() {
+        } else if kind.is_keyword() {
             line.flags.insert(TokenFlags::KEYWORD);
         }
 

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/logical_lines/whitespace_around_keywords.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/logical_lines/whitespace_around_keywords.rs
@@ -127,8 +127,8 @@ pub(crate) fn whitespace_around_keywords(line: &LogicalLine, context: &mut Logic
     let mut after_keyword = false;
 
     for token in line.tokens() {
-        let is_non_soft_keyword = token.kind().is_non_soft_keyword();
-        if is_non_soft_keyword {
+        let is_keyword = token.kind().is_keyword();
+        if is_keyword {
             if !after_keyword {
                 match line.leading_whitespace(token) {
                     (Whitespace::Tab, offset) => {
@@ -184,6 +184,6 @@ pub(crate) fn whitespace_around_keywords(line: &LogicalLine, context: &mut Logic
             }
         }
 
-        after_keyword = is_non_soft_keyword;
+        after_keyword = is_keyword;
     }
 }

--- a/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E271_E27.py.snap
+++ b/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E271_E27.py.snap
@@ -190,4 +190,22 @@ E27.py:35:14: E271 [*] Multiple spaces after keyword
 37 37 | from w import(e, f)
 38 38 | #: E275
 
+E27.py:70:5: E271 [*] Multiple spaces after keyword
+   |
+69 | #: E271
+70 | type  Number = int
+   |     ^^ E271
+71 | 
+72 | #: E273
+   |
+   = help: Replace with single space
 
+ℹ Safe fix
+67 67 | # Soft keywords
+68 68 | 
+69 69 | #: E271
+70    |-type  Number = int
+   70 |+type Number = int
+71 71 | 
+72 72 | #: E273
+73 73 | type	Number = int

--- a/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E273_E27.py.snap
+++ b/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E273_E27.py.snap
@@ -106,4 +106,22 @@ E27.py:30:10: E273 [*] Tab after keyword
 32 32 | from u import (a, b)
 33 33 | from v import c, d
 
+E27.py:73:5: E273 [*] Tab after keyword
+   |
+72 | #: E273
+73 | type    Number = int
+   |     ^^^^ E273
+74 | 
+75 | #: E275
+   |
+   = help: Replace with single space
 
+ℹ Safe fix
+70 70 | type  Number = int
+71 71 | 
+72 72 | #: E273
+73    |-type	Number = int
+   73 |+type Number = int
+74 74 | 
+75 75 | #: E275
+76 76 | match(foo):

--- a/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E275_E27.py.snap
+++ b/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E275_E27.py.snap
@@ -106,4 +106,39 @@ E27.py:54:5: E275 [*] Missing whitespace after keyword
 56 56 | def f():
 57 57 |     print((yield))
 
+E27.py:76:1: E275 [*] Missing whitespace after keyword
+   |
+75 | #: E275
+76 | match(foo):
+   | ^^^^^ E275
+77 |     case(1):
+78 |         pass
+   |
+   = help: Added missing whitespace after keyword
 
+ℹ Safe fix
+73 73 | type	Number = int
+74 74 | 
+75 75 | #: E275
+76    |-match(foo):
+   76 |+match (foo):
+77 77 |     case(1):
+78 78 |         pass
+
+E27.py:77:5: E275 [*] Missing whitespace after keyword
+   |
+75 | #: E275
+76 | match(foo):
+77 |     case(1):
+   |     ^^^^ E275
+78 |         pass
+   |
+   = help: Added missing whitespace after keyword
+
+ℹ Safe fix
+74 74 | 
+75 75 | #: E275
+76 76 | match(foo):
+77    |-    case(1):
+   77 |+    case (1):
+78 78 |         pass


### PR DESCRIPTION
## Summary

This is a follow-up PR to #11445 update the `E27` rules to consider soft keywords as well.

## Test Plan

Add test cases consisting of soft keywords and update the snapshot.
