### PR TITLE
Locate ruff executable in 'bin' directory as installed by 'pip install --target'.

### DIFF
--- a/python/ruff/__main__.py
+++ b/python/ruff/__main__.py
@@ -8,15 +8,9 @@ def find_ruff_bin() -> str:
 
     ruff_exe = "ruff" + sysconfig.get_config_var("EXE")
 
-    path = os.path.join(sysconfig.get_path("scripts"), ruff_exe)
-    if os.path.isfile(path):
-        return path
-
-    # search in bin adjacent to package root (pip install --target)
-    pkg_root = os.path.dirname(os.path.dirname(__file__))
-    path = os.path.join(pkg_root, "bin", ruff_exe)
-    if os.path.isfile(path):
-        return path
+    scripts_path = os.path.join(sysconfig.get_path("scripts"), ruff_exe)
+    if os.path.isfile(scripts_path):
+        return scripts_path
 
     if sys.version_info >= (3, 10):
         user_scheme = sysconfig.get_preferred_scheme("user")
@@ -27,11 +21,19 @@ def find_ruff_bin() -> str:
     else:
         user_scheme = "posix_user"
 
-    path = os.path.join(sysconfig.get_path("scripts", scheme=user_scheme), ruff_exe)
-    if os.path.isfile(path):
-        return path
+    user_path = os.path.join(
+        sysconfig.get_path("scripts", scheme=user_scheme), ruff_exe
+    )
+    if os.path.isfile(user_path):
+        return user_path
 
-    raise FileNotFoundError(path)
+    # Search in `bin` adjacent to package root (as created by `pip install --target`).
+    pkg_root = os.path.dirname(os.path.dirname(__file__))
+    target_path = os.path.join(pkg_root, "bin", ruff_exe)
+    if os.path.isfile(target_path):
+        return target_path
+
+    raise FileNotFoundError(scripts_path)
 
 
 if __name__ == "__main__":

--- a/python/ruff/__main__.py
+++ b/python/ruff/__main__.py
@@ -12,6 +12,12 @@ def find_ruff_bin() -> str:
     if os.path.isfile(path):
         return path
 
+    # search in bin adjacent to package root (pip install --target)
+    pkg_root = os.path.dirname(os.path.dirname(__file__))
+    path = os.path.join(pkg_root, "bin", ruff_exe)
+    if os.path.isfile(path):
+        return path
+
     if sys.version_info >= (3, 10):
         user_scheme = sysconfig.get_preferred_scheme("user")
     elif os.name == "nt":


### PR DESCRIPTION
Fixes #11246

<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

This change adds an intermediate additional search path for `find_ruff_bin`.

I would have added this path as the last one, except that the last one is the one reported to the user, so I made this one second to last.

## Test Plan

It's shown to work with this command:

```
 ~ @ pip-run git+https://github.com/jaraco/ruff@feature/honor-install-target-bin -- -m ruff --version
ruff 0.4.4
```

I tried running the same command on Windows, which should work in theory, but building ruff from source on Windows is complicated. Even after installing Rust, ruff fails to build when `libmimalloc-sys` fails to build because `gcc` isn't installed (and the error message points to a [broken anchor](https://github.com/rust-lang/cc-rs#compile-time-requirements)). I was really hoping Rust would get us away from the Windows as second-class-citizen model :(.
