### PR TITLE
Offset syntax error for each cell

### DIFF
--- a/crates/ruff/src/commands/format.rs
+++ b/crates/ruff/src/commands/format.rs
@@ -401,7 +401,10 @@ pub(crate) fn format_source(
                 // Format the cell.
                 let formatted =
                     format_module_source(unformatted, options.clone()).map_err(|err| {
-                        if let FormatModuleError::ParseError(err) = err {
+                        if let FormatModuleError::ParseError(mut err) = err {
+                            // Offset the error location by the start offset of the cell to report
+                            // the correct cell index.
+                            err.location += start;
                             DisplayParseError::from_source_kind(
                                 err,
                                 path.map(Path::to_path_buf),

--- a/crates/ruff_linter/src/logging.rs
+++ b/crates/ruff_linter/src/logging.rs
@@ -253,7 +253,7 @@ impl Display for DisplayParseError {
             ErrorLocation::Cell(cell, location) => {
                 write!(
                     f,
-                    "{cell}{colon}{row}{colon}{column}{colon} {inner}",
+                    "cell {cell}{colon}{row}{colon}{column}{colon} {inner}",
                     cell = cell,
                     row = location.row,
                     column = location.column,


### PR DESCRIPTION
## Summary

This PR fixes the syntax error location for the `ruff format` command.

fixes: #11453

## Test Plan

<!-- How was it tested? -->
