### PR TITLE
Bump soft keyword as name token

### DIFF
--- a/crates/ruff_python_parser/src/parser/expression.rs
+++ b/crates/ruff_python_parser/src/parser/expression.rs
@@ -471,7 +471,7 @@ impl<'src> Parser<'src> {
 
         if self.current_token_kind().is_soft_keyword() {
             let id = self.src_text(range).to_string();
-            self.bump_any();
+            self.bump_soft_keyword_as_name();
             return ast::Identifier { id, range };
         }
 
@@ -1343,7 +1343,7 @@ impl<'src> Parser<'src> {
                 // `Invalid` tokens are created when there's a lexical error, so
                 // we ignore it here to avoid creating unexpected token errors
                 TokenKind::Unknown => {
-                    parser.next_token();
+                    parser.bump_any();
                     return;
                 }
                 tok => {


### PR DESCRIPTION
## Summary

This PR updates various `bump` methods to allow parser to bump the soft keyword as a name token.

This is required because the token vector should store the resolved token. Otherwise, the token vector and the AST are out of sync.

The process is as follows:
* One common method to bump the given kind for the parser which is `do_bump`
* This calls in the `bump` method on the token source
* The token source adds the given token kind and bump itself to the next non-trivia token
* While doing this bump, it still adds the trivia tokens to the token vector

The end result is that the parser informs the token source to add the given kind to the token vector and move on to the next token.

Here, we can then introduce a `bump_soft_keyword_as_name` method which asserts that the current token is a soft keyword and bumps it as a name token instead. The `parse_identifier` method then calls the new method instead.
