### PR TITLE
Remove example from `tab-indentation`

### DIFF
--- a/crates/ruff_linter/src/rules/pycodestyle/rules/tab_indentation.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/tab_indentation.rs
@@ -11,18 +11,6 @@ use ruff_text_size::{TextRange, TextSize};
 /// According to [PEP 8], spaces are preferred over tabs (unless used to remain
 /// consistent with code that is already indented with tabs).
 ///
-/// ## Example
-/// ```python
-/// if True:
-/// 	a = 1
-/// ```
-///
-/// Use instead:
-/// ```python
-/// if True:
-///     a = 1
-/// ```
-///
 /// ## Formatter compatibility
 /// We recommend against using this rule alongside the [formatter]. The
 /// formatter enforces consistent indentation, making the rule redundant.

--- a/scripts/check_docs_formatted.py
+++ b/scripts/check_docs_formatted.py
@@ -74,7 +74,6 @@ KNOWN_FORMATTING_VIOLATIONS = [
     "redundant-backslash",
     "shebang-leading-whitespace",
     "surrounding-whitespace",
-    "tab-indentation",
     "too-few-spaces-before-inline-comment",
     "too-many-blank-lines",
     "too-many-boolean-expressions",


### PR DESCRIPTION
## Summary

I think the example is more confusing than helpful, since there's no visual difference between the tab and space here (even if it rendered properly).

Closes https://github.com/astral-sh/ruff/issues/11460#issuecomment-2118397278.