### PR TITLE
Update prev token end before token bump

### DIFF
--- a/crates/ruff_python_parser/src/parser/expression.rs
+++ b/crates/ruff_python_parser/src/parser/expression.rs
@@ -479,7 +479,7 @@ impl<'src> Parser<'src> {
             // Non-soft keyword
             self.add_error(
                 ParseErrorType::OtherError(format!(
-                    "Expected an identifier, but found a keyword '{}' that cannot be used here",
+                    "Expected an identifier, but found a keyword {} that cannot be used here",
                     self.current_token_kind()
                 )),
                 range,

--- a/crates/ruff_python_parser/src/parser/mod.rs
+++ b/crates/ruff_python_parser/src/parser/mod.rs
@@ -321,12 +321,8 @@ impl<'src> Parser<'src> {
 
     /// Moves the parser to the next token.
     fn do_bump(&mut self, kind: TokenKind) {
-        self.tokens.bump(kind);
-
-        self.current_token_id.increment();
-
         if !matches!(
-            self.tokens.current_kind(),
+            self.current_token_kind(),
             // TODO explore including everything up to the dedent as part of the body.
             TokenKind::Dedent
             // Don't include newlines in the body
@@ -337,6 +333,9 @@ impl<'src> Parser<'src> {
         ) {
             self.prev_token_end = self.current_token_range().end();
         }
+
+        self.tokens.bump(kind);
+        self.current_token_id.increment();
     }
 
     /// Returns the next token kind without consuming it.


### PR DESCRIPTION
## Summary

This PR fixes a bug where the parser would bump the token before updating the `prev_token_end`. The order should be reversed.
