### PR TITLE
Clarify motivation for E713 and E714

### DIFF
--- a/crates/ruff_linter/src/rules/pycodestyle/rules/not_tests.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/not_tests.rs
@@ -9,10 +9,10 @@ use crate::checkers::ast::Checker;
 use crate::registry::Rule;
 
 /// ## What it does
-/// Checks for negative comparison using `not {foo} in {bar}`.
+/// Checks for membership tests using `not {element} in {collection}`.
 ///
 /// ## Why is this bad?
-/// Negative comparison should be done using `not in`.
+/// Testing membership with `{element} not in {collection}` is more readable.
 ///
 /// ## Example
 /// ```python
@@ -42,10 +42,11 @@ impl AlwaysFixableViolation for NotInTest {
 }
 
 /// ## What it does
-/// Checks for negative comparison using `not {foo} is {bar}`.
+/// Checks for identity comparisons using `not {foo} is {bar}`.
 ///
 /// ## Why is this bad?
-/// Negative comparison should be done using `is not`.
+/// According to [PEP8], testing for an object's identity with `is not` is more
+/// readable.
 ///
 /// ## Example
 /// ```python
@@ -60,6 +61,8 @@ impl AlwaysFixableViolation for NotInTest {
 ///     pass
 /// Z = X.B is not Y
 /// ```
+///
+/// [PEP8]: https://peps.python.org/pep-0008/#programming-recommendations
 #[violation]
 pub struct NotIsTest;
 


### PR DESCRIPTION
The wording 'negative comparison' is a rather vague description of the 'is not' operation and does not describe what the 'not in' operation does (potentially copied from 'is not'). This was replaced with more precise language to describe the operators taken from the official python docs[1].

Both rules didn't have a strong reasoning besides 'it's bad, use the other'. The origin of these rules seems to be PEP8[2] which prefers 'is not' over 'not ... is' for readability. This is now reflected in the description.

[1]: https://docs.python.org/3/reference/expressions.html#membership-test-operations
[2]: https://peps.python.org/pep-0008/#programming-recommendations