### PR TITLE
fixes invalid rule from hyphen

### DIFF
--- a/scripts/add_rule.py
+++ b/scripts/add_rule.py
@@ -137,7 +137,8 @@ pub(crate) fn {rule_name_snake}(checker: &mut Checker) {{}}
             lines.append(line)
 
         variant = pascal_case(linter)
-        rule = f"""rules::{linter.split(" ")[0]}::rules::{name}"""
+        linter_name = linter.split(" ")[0].replace("-", "_")
+        rule = f"""rules::{linter_name}::rules::{name}"""
         lines.append(
             " " * 8 + f"""({variant}, "{code}") => (RuleGroup::Preview, {rule}),\n""",
         )


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

When using `add_rule.py`, it produces the following line in `codes.rs`
```
        (Flake8Async, "102") => (RuleGroup::Stable, rules::flake8-async::rules::BlockingOsCallInAsyncFunction),
```

Causing a syntax error.

This PR resolves that issue so that the script can be used again.

## Test Plan

Tested manually in new rule creation
