### PR TITLE
Fix automatic configuration reloading for text and notebook documents

### DIFF
--- a/crates/ruff_server/src/server.rs
+++ b/crates/ruff_server/src/server.rs
@@ -173,8 +173,12 @@ impl Server {
                             watchers: vec![
                                 FileSystemWatcher {
                                     glob_pattern: types::GlobPattern::String(
-                                        "**/.?ruff.toml".into(),
+                                        "**/.ruff.toml".into(),
                                     ),
+                                    kind: None,
+                                },
+                                FileSystemWatcher {
+                                    glob_pattern: types::GlobPattern::String("**/ruff.toml".into()),
                                     kind: None,
                                 },
                                 FileSystemWatcher {

--- a/crates/ruff_server/src/session.rs
+++ b/crates/ruff_server/src/session.rs
@@ -72,6 +72,16 @@ impl Session {
         })
     }
 
+    /// Iterates over the LSP URLs for all open text documents. These URLs are valid file paths.
+    pub(super) fn text_document_urls(&self) -> impl Iterator<Item = lsp_types::Url> + '_ {
+        self.index.text_document_urls()
+    }
+
+    /// Iterates over the LSP URLs for all open notebook documents. These URLs are valid file paths.
+    pub(super) fn notebook_document_urls(&self) -> impl Iterator<Item = lsp_types::Url> + '_ {
+        self.index.notebook_document_urls()
+    }
+
     /// Updates a text document at the associated `key`.
     ///
     /// The document key must point to a text document, or this will throw an error.


### PR DESCRIPTION
## Summary

Recent changes made in the [Jupyter Notebook feature PR](https://github.com/astral-sh/ruff/pull/11206) caused automatic configuration reloading to stop working. This was because we would check for paths to reload using the changed path, when we should have been using the parent path of the changed path (to get the directory it was changed in).

Additionally, this PR fixes an issue where `ruff.toml` and `.ruff.toml` files were not being automatically reloaded.

Finally, this PR improves configuration reloading by actively publishing diagnostics for notebook documents (which won't be affected by the workspace refresh since they don't use pull diagnostics). It will also publish diagnostics for text documents if pull diagnostics aren't supported.

## Test Plan
To test this, open an existing configuration file in a codebase, and make modifications that will affect one or more open Python / Jupyter Notebook files. You should observe that the diagnostics for both kinds of files update automatically when the file changes are saved.

Here's a test video showing what a successful test should look like:


https://github.com/astral-sh/ruff/assets/19577865/7172b598-d6de-4965-b33c-6cb8b911ef6c

