### PR TITLE
`ruff server`: Fix multiple issues with Neovim and Helix

### DIFF
--- a/crates/ruff_server/resources/test/fixtures/settings/global_only.json
+++ b/crates/ruff_server/resources/test/fixtures/settings/global_only.json
@@ -1,17 +1,15 @@
 {
-    "settings": {
-        "codeAction": {
-            "disableRuleComment": {
-                "enable": false
-            }
-        },
-        "lint": {
-            "ignore": ["RUF001"],
-            "run": "onSave"
-        },
-        "fixAll": false,
-        "logLevel": "warn",
-        "lineLength": 80,
-        "exclude": ["third_party"]
-    }
+    "codeAction": {
+        "disableRuleComment": {
+            "enable": false
+        }
+    },
+    "lint": {
+        "ignore": ["RUF001"],
+        "run": "onSave"
+    },
+    "fixAll": false,
+    "logLevel": "warn",
+    "lineLength": 80,
+    "exclude": ["third_party"]
 }

--- a/crates/ruff_server/src/lint.rs
+++ b/crates/ruff_server/src/lint.rs
@@ -119,12 +119,14 @@ pub(crate) fn check(
 
     let mut diagnostics = Diagnostics::default();
 
-    // Populate all cell URLs with an empty diagnostic list.
-    // This ensures that cells without diagnostics still get updated.
+    // Populates all relevant URLs with an empty diagnostic list.
+    // This ensures that documents without diagnostics still get updated.
     if let Some(notebook) = query.as_notebook() {
         for url in notebook.urls() {
             diagnostics.entry(url.clone()).or_default();
         }
+    } else {
+        diagnostics.entry(query.make_key().into_url()).or_default();
     }
 
     let lsp_diagnostics = data

--- a/crates/ruff_server/src/server.rs
+++ b/crates/ruff_server/src/server.rs
@@ -66,11 +66,6 @@ impl Server {
 
         crate::message::init_messenger(connection.make_sender());
 
-        tracing::info!(
-            "Initialization options: {:?}",
-            init_params.initialization_options
-        );
-
         let AllSettings {
             global_settings,
             mut workspace_settings,
@@ -93,9 +88,10 @@ impl Server {
 
         let workspaces = init_params
             .workspace_folders
-            .and_then(|folders| (!folders.is_empty()).then(|| folders.into_iter().map(|folder| {
+            .filter(|folders| !folders.is_empty())
+            .map(|folders| folders.into_iter().map(|folder| {
                 workspace_for_path(folder.uri.to_file_path().unwrap())
-            }).collect()))
+            }).collect())
             .or_else(|| {
                 tracing::warn!("No workspace(s) were provided during initialization. Using the current working directory as a default workspace...");
                 let uri = types::Url::from_file_path(std::env::current_dir().ok()?).ok()?;

--- a/crates/ruff_server/src/session.rs
+++ b/crates/ruff_server/src/session.rs
@@ -67,7 +67,7 @@ impl Session {
         Some(DocumentSnapshot {
             resolved_client_capabilities: self.resolved_client_capabilities.clone(),
             client_settings: self.index.client_settings(&key, &self.global_settings),
-            document_ref: self.index.make_document_ref(key)?,
+            document_ref: self.index.make_document_ref(key, &self.global_settings)?,
             position_encoding: self.position_encoding,
         })
     }

--- a/crates/ruff_server/src/session/settings.rs
+++ b/crates/ruff_server/src/session/settings.rs
@@ -130,7 +130,8 @@ enum InitializationOptions {
         workspace_settings: Vec<WorkspaceSettings>,
     },
     GlobalOnly {
-        settings: Option<ClientSettings>,
+        #[serde(flatten)]
+        settings: ClientSettings,
     },
 }
 
@@ -157,7 +158,7 @@ impl AllSettings {
 
     fn from_init_options(options: InitializationOptions) -> Self {
         let (global_settings, workspace_settings) = match options {
-            InitializationOptions::GlobalOnly { settings } => (settings.unwrap_or_default(), None),
+            InitializationOptions::GlobalOnly { settings } => (settings, None),
             InitializationOptions::HasWorkspaces {
                 global_settings,
                 workspace_settings,
@@ -341,7 +342,9 @@ impl ResolvedClientSettings {
 
 impl Default for InitializationOptions {
     fn default() -> Self {
-        Self::GlobalOnly { settings: None }
+        Self::GlobalOnly {
+            settings: ClientSettings::default(),
+        }
     }
 }
 
@@ -626,52 +629,50 @@ mod tests {
 
         assert_debug_snapshot!(options, @r###"
         GlobalOnly {
-            settings: Some(
-                ClientSettings {
-                    configuration: None,
-                    fix_all: Some(
-                        false,
-                    ),
-                    organize_imports: None,
-                    lint: Some(
-                        LintOptions {
-                            enable: None,
-                            preview: None,
-                            select: None,
-                            extend_select: None,
-                            ignore: Some(
-                                [
-                                    "RUF001",
-                                ],
-                            ),
-                        },
-                    ),
-                    format: None,
-                    code_action: Some(
-                        CodeActionOptions {
-                            disable_rule_comment: Some(
-                                CodeActionParameters {
-                                    enable: Some(
-                                        false,
-                                    ),
-                                },
-                            ),
-                            fix_violation: None,
-                        },
-                    ),
-                    exclude: Some(
-                        [
-                            "third_party",
-                        ],
-                    ),
-                    line_length: Some(
-                        LineLength(
-                            80,
+            settings: ClientSettings {
+                configuration: None,
+                fix_all: Some(
+                    false,
+                ),
+                organize_imports: None,
+                lint: Some(
+                    LintOptions {
+                        enable: None,
+                        preview: None,
+                        select: None,
+                        extend_select: None,
+                        ignore: Some(
+                            [
+                                "RUF001",
+                            ],
                         ),
+                    },
+                ),
+                format: None,
+                code_action: Some(
+                    CodeActionOptions {
+                        disable_rule_comment: Some(
+                            CodeActionParameters {
+                                enable: Some(
+                                    false,
+                                ),
+                            },
+                        ),
+                        fix_violation: None,
+                    },
+                ),
+                exclude: Some(
+                    [
+                        "third_party",
+                    ],
+                ),
+                line_length: Some(
+                    LineLength(
+                        80,
                     ),
-                    configuration_preference: None,
-                },
-            ),
+                ),
+                configuration_preference: None,
+            },
         }
         "###);
     }


### PR DESCRIPTION
## Summary

Fixes https://github.com/astral-sh/ruff/issues/11236.

This PR fixes several issues, most of which relate to non-VS Code editors (Helix and Neovim).

1. Global-only initialization options are now correctly deserialized from Neovim and Helix
2. Empty diagnostics are now published correctly for Neovim and Helix.
3. A workspace folder is created at the current working directory if the initialization parameters send an empty list of workspace folders.
4. The server now gracefully handles opening files outside of any known workspace, and will use global fallback settings taken from client editor settings and a user settings TOML, if it exists.

## Test Plan

I've tested to confirm that each issue has been fixed.

* Global-only initialization options are now correctly deserialized from Neovim and Helix + the server gracefully handles opening files outside of any known workspace

https://github.com/astral-sh/ruff/assets/19577865/4f33477f-20c8-4e50-8214-6608b1a1ea6b

* Empty diagnostics are now published correctly for Neovim and Helix

https://github.com/astral-sh/ruff/assets/19577865/c93f56a0-f75d-466f-9f40-d77f99cf0637

* A workspace folder is created at the current working directory if the initialization parameters send an empty list of workspace folders.


https://github.com/astral-sh/ruff/assets/19577865/b4b2e818-4b0d-40ce-961d-5831478cc726

