### PR TITLE
Replace most usages of `lex_starts_at` with `Tokens`

### DIFF
--- a/crates/ruff_linter/src/checkers/ast/analyze/expression.rs
+++ b/crates/ruff_linter/src/checkers/ast/analyze/expression.rs
@@ -1157,7 +1157,7 @@ pub(crate) fn expression(expr: &Expr, checker: &mut Checker) {
                     }
                 }
                 if checker.enabled(Rule::PrintfStringFormatting) {
-                    pyupgrade::rules::printf_string_formatting(checker, expr, right);
+                    pyupgrade::rules::printf_string_formatting(checker, format_string, right);
                 }
                 if checker.enabled(Rule::BadStringFormatCharacter) {
                     pylint::rules::bad_string_format_character::percent(

--- a/crates/ruff_linter/src/checkers/ast/analyze/statement.rs
+++ b/crates/ruff_linter/src/checkers/ast/analyze/statement.rs
@@ -762,7 +762,7 @@ pub(crate) fn statement(stmt: &Stmt, checker: &mut Checker) {
                 pyupgrade::rules::deprecated_c_element_tree(checker, stmt);
             }
             if checker.enabled(Rule::DeprecatedImport) {
-                pyupgrade::rules::deprecated_import(checker, stmt, names, module, level);
+                pyupgrade::rules::deprecated_import(checker, import_from);
             }
             if checker.enabled(Rule::UnnecessaryBuiltinImport) {
                 if let Some(module) = module {

--- a/crates/ruff_linter/src/checkers/ast/mod.rs
+++ b/crates/ruff_linter/src/checkers/ast/mod.rs
@@ -253,7 +253,7 @@ impl<'a> Checker<'a> {
             locator,
             stylist,
             indexer,
-            importer: Importer::new(program.suite(), locator, stylist),
+            importer: Importer::new(program.suite(), program.tokens(), locator, stylist),
             semantic: SemanticModel::new(&settings.typing_modules, path, module),
             visit: deferred::Visit::default(),
             analyze: deferred::Analyze::default(),

--- a/crates/ruff_linter/src/checkers/ast/mod.rs
+++ b/crates/ruff_linter/src/checkers/ast/mod.rs
@@ -253,7 +253,7 @@ impl<'a> Checker<'a> {
             locator,
             stylist,
             indexer,
-            importer: Importer::new(program.suite(), program.tokens(), locator, stylist),
+            importer: Importer::new(program, locator, stylist),
             semantic: SemanticModel::new(&settings.typing_modules, path, module),
             visit: deferred::Visit::default(),
             analyze: deferred::Analyze::default(),

--- a/crates/ruff_linter/src/checkers/imports.rs
+++ b/crates/ruff_linter/src/checkers/imports.rs
@@ -7,6 +7,7 @@ use ruff_python_ast::statement_visitor::StatementVisitor;
 use ruff_python_ast::{PySourceType, Suite};
 use ruff_python_codegen::Stylist;
 use ruff_python_index::Indexer;
+use ruff_python_parser::Tokens;
 use ruff_source_file::Locator;
 
 use crate::directives::IsortDirectives;
@@ -18,6 +19,7 @@ use crate::settings::LinterSettings;
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn check_imports(
     python_ast: &Suite,
+    tokens: &Tokens,
     locator: &Locator,
     indexer: &Indexer,
     directives: &IsortDirectives,
@@ -50,6 +52,7 @@ pub(crate) fn check_imports(
                     settings,
                     package,
                     source_type,
+                    tokens,
                 ) {
                     diagnostics.push(diagnostic);
                 }
@@ -59,6 +62,7 @@ pub(crate) fn check_imports(
     if settings.rules.enabled(Rule::MissingRequiredImport) {
         diagnostics.extend(isort::rules::add_required_imports(
             python_ast,
+            tokens,
             locator,
             stylist,
             settings,

--- a/crates/ruff_linter/src/importer/insertion.rs
+++ b/crates/ruff_linter/src/importer/insertion.rs
@@ -2,7 +2,7 @@
 use std::ops::Add;
 
 use ruff_python_ast::{PySourceType, Stmt};
-use ruff_python_parser::{lexer, AsMode, Tok};
+use ruff_python_parser::{lexer, AsMode, Tok, TokenKind, Tokens};
 use ruff_text_size::{Ranged, TextSize};
 
 use ruff_diagnostics::Edit;
@@ -145,7 +145,7 @@ impl<'a> Insertion<'a> {
         mut location: TextSize,
         locator: &Locator<'a>,
         stylist: &Stylist,
-        source_type: PySourceType,
+        tokens: &Tokens,
     ) -> Insertion<'a> {
         enum Awaiting {
             Colon(u32),
@@ -154,40 +154,38 @@ impl<'a> Insertion<'a> {
         }
 
         let mut state = Awaiting::Colon(0);
-        for (tok, range) in
-            lexer::lex_starts_at(locator.after(location), source_type.as_mode(), location).flatten()
-        {
+        for token in tokens.after(location) {
             match state {
                 // Iterate until we find the colon indicating the start of the block body.
-                Awaiting::Colon(depth) => match tok {
-                    Tok::Colon if depth == 0 => {
+                Awaiting::Colon(depth) => match token.kind() {
+                    TokenKind::Colon if depth == 0 => {
                         state = Awaiting::Newline;
                     }
-                    Tok::Lpar | Tok::Lbrace | Tok::Lsqb => {
+                    TokenKind::Lpar | TokenKind::Lbrace | TokenKind::Lsqb => {
                         state = Awaiting::Colon(depth.saturating_add(1));
                     }
-                    Tok::Rpar | Tok::Rbrace | Tok::Rsqb => {
+                    TokenKind::Rpar | TokenKind::Rbrace | TokenKind::Rsqb => {
                         state = Awaiting::Colon(depth.saturating_sub(1));
                     }
                     _ => {}
                 },
                 // Once we've seen the colon, we're looking for a newline; otherwise, there's no
                 // block body (e.g. `if True: pass`).
-                Awaiting::Newline => match tok {
-                    Tok::Comment(..) => {}
-                    Tok::Newline => {
+                Awaiting::Newline => match token.kind() {
+                    TokenKind::Comment(..) => {}
+                    TokenKind::Newline => {
                         state = Awaiting::Indent;
                     }
                     _ => {
-                        location = range.start();
+                        location = token.start();
                         break;
                     }
                 },
                 // Once we've seen the newline, we're looking for the indentation of the block body.
-                Awaiting::Indent => match tok {
-                    Tok::Comment(..) => {}
-                    Tok::NonLogicalNewline => {}
-                    Tok::Indent => {
+                Awaiting::Indent => match token.kind() {
+                    TokenKind::Comment(..) => {}
+                    TokenKind::NonLogicalNewline => {}
+                    TokenKind::Indent => {
                         // This is like:
                         // ```python
                         // if True:
@@ -196,13 +194,13 @@ impl<'a> Insertion<'a> {
                         // Where `range` is the indentation before the `pass` token.
                         return Insertion::indented(
                             "",
-                            range.start(),
+                            token.start(),
                             stylist.line_ending().as_str(),
-                            locator.slice(range),
+                            locator.slice(token),
                         );
                     }
                     _ => {
-                        location = range.start();
+                        location = token.start();
                         break;
                     }
                 },
@@ -442,10 +440,10 @@ x = 1
     #[test]
     fn start_of_block() {
         fn insert(contents: &str, offset: TextSize) -> Insertion {
-            let tokens = ruff_python_parser::tokenize(contents, Mode::Module);
+            let program = ruff_python_parser::parse_module(contents).unwrap();
             let locator = Locator::new(contents);
-            let stylist = Stylist::from_tokens(&tokens, &locator);
-            Insertion::start_of_block(offset, &locator, &stylist, PySourceType::default())
+            let stylist = Stylist::from_tokens(&program, &locator);
+            Insertion::start_of_block(offset, &locator, &stylist, program.tokens())
         }
 
         let contents = "if True: pass";

--- a/crates/ruff_linter/src/linter.rs
+++ b/crates/ruff_linter/src/linter.rs
@@ -167,8 +167,7 @@ pub fn check_path(
                 }
                 if use_imports {
                     let import_diagnostics = check_imports(
-                        program.suite(),
-                        program.tokens(),
+                        &program,
                         locator,
                         indexer,
                         &directives.isort,

--- a/crates/ruff_linter/src/linter.rs
+++ b/crates/ruff_linter/src/linter.rs
@@ -168,6 +168,7 @@ pub fn check_path(
                 if use_imports {
                     let import_diagnostics = check_imports(
                         program.suite(),
+                        program.tokens(),
                         locator,
                         indexer,
                         &directives.isort,

--- a/crates/ruff_linter/src/rules/flake8_type_checking/rules/typing_only_runtime_import.rs
+++ b/crates/ruff_linter/src/rules/flake8_type_checking/rules/typing_only_runtime_import.rs
@@ -491,7 +491,6 @@ fn fix_imports(checker: &Checker, node_id: NodeId, imports: &[ImportBinding]) ->
             },
             at,
             checker.semantic(),
-            checker.source_type,
         )?
         .into_edits();
 

--- a/crates/ruff_linter/src/rules/isort/annotate.rs
+++ b/crates/ruff_linter/src/rules/isort/annotate.rs
@@ -1,4 +1,5 @@
-use ruff_python_ast::{self as ast, PySourceType, Stmt};
+use ruff_python_ast::{self as ast, Stmt};
+use ruff_python_parser::Tokens;
 use ruff_text_size::{Ranged, TextRange};
 
 use ruff_source_file::Locator;
@@ -13,7 +14,7 @@ pub(crate) fn annotate_imports<'a>(
     comments: Vec<Comment<'a>>,
     locator: &Locator<'a>,
     split_on_trailing_comma: bool,
-    source_type: PySourceType,
+    tokens: &Tokens,
 ) -> Vec<AnnotatedImport<'a>> {
     let mut comments_iter = comments.into_iter().peekable();
 
@@ -120,7 +121,7 @@ pub(crate) fn annotate_imports<'a>(
                         names: aliases,
                         level: *level,
                         trailing_comma: if split_on_trailing_comma {
-                            trailing_comma(import, locator, source_type)
+                            trailing_comma(import, tokens)
                         } else {
                             TrailingComma::default()
                         },

--- a/crates/ruff_linter/src/rules/isort/mod.rs
+++ b/crates/ruff_linter/src/rules/isort/mod.rs
@@ -12,6 +12,7 @@ use normalize::normalize_imports;
 use order::order_imports;
 use ruff_python_ast::PySourceType;
 use ruff_python_codegen::Stylist;
+use ruff_python_parser::Tokens;
 use ruff_source_file::Locator;
 use settings::Settings;
 use types::EitherImport::{Import, ImportFrom};
@@ -72,6 +73,7 @@ pub(crate) fn format_imports(
     source_type: PySourceType,
     target_version: PythonVersion,
     settings: &Settings,
+    tokens: &Tokens,
 ) -> String {
     let trailer = &block.trailer;
     let block = annotate_imports(
@@ -79,7 +81,7 @@ pub(crate) fn format_imports(
         comments,
         locator,
         settings.split_on_trailing_comma,
-        source_type,
+        tokens,
     );
 
     // Normalize imports (i.e., deduplicate, aggregate `from` imports).

--- a/crates/ruff_linter/src/rules/isort/rules/add_required_imports.rs
+++ b/crates/ruff_linter/src/rules/isort/rules/add_required_imports.rs
@@ -4,7 +4,7 @@ use ruff_diagnostics::{AlwaysFixableViolation, Diagnostic, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::is_docstring_stmt;
 use ruff_python_ast::imports::{Alias, AnyImport, FutureImport, Import, ImportFrom};
-use ruff_python_ast::{self as ast, PySourceType, Stmt, Suite};
+use ruff_python_ast::{self as ast, ModModule, PySourceType, Stmt, Suite};
 use ruff_python_codegen::Stylist;
 use ruff_python_parser::{parse_module, Program, Tokens};
 use ruff_source_file::Locator;
@@ -87,14 +87,13 @@ fn includes_import(stmt: &Stmt, target: &AnyImport) -> bool {
 #[allow(clippy::too_many_arguments)]
 fn add_required_import(
     required_import: &AnyImport,
-    python_ast: &Suite,
-    tokens: &Tokens,
+    program: &Program<ModModule>,
     locator: &Locator,
     stylist: &Stylist,
     source_type: PySourceType,
 ) -> Option<Diagnostic> {
     // Don't add imports to semantically-empty files.
-    if python_ast.iter().all(is_docstring_stmt) {
+    if program.suite().iter().all(is_docstring_stmt) {
         return None;
     }
 
@@ -104,7 +103,8 @@ fn add_required_import(
     }
 
     // If the import is already present in a top-level block, don't add it.
-    if python_ast
+    if program
+        .suite()
         .iter()
         .any(|stmt| includes_import(stmt, required_import))
     {
@@ -117,16 +117,14 @@ fn add_required_import(
         TextRange::default(),
     );
     diagnostic.set_fix(Fix::safe_edit(
-        Importer::new(python_ast, tokens, locator, stylist)
-            .add_import(required_import, TextSize::default()),
+        Importer::new(program, locator, stylist).add_import(required_import, TextSize::default()),
     ));
     Some(diagnostic)
 }
 
 /// I002
 pub(crate) fn add_required_imports(
-    python_ast: &Suite,
-    tokens: &Tokens,
+    program: &Program<ModModule>,
     locator: &Locator,
     stylist: &Stylist,
     settings: &LinterSettings,
@@ -167,8 +165,7 @@ pub(crate) fn add_required_imports(
                                 },
                                 level: *level,
                             }),
-                            python_ast,
-                            tokens,
+                            program,
                             locator,
                             stylist,
                             source_type,
@@ -185,8 +182,7 @@ pub(crate) fn add_required_imports(
                                     as_name: name.asname.as_deref(),
                                 },
                             }),
-                            python_ast,
-                            tokens,
+                            program,
                             locator,
                             stylist,
                             source_type,

--- a/crates/ruff_linter/src/rules/isort/rules/add_required_imports.rs
+++ b/crates/ruff_linter/src/rules/isort/rules/add_required_imports.rs
@@ -6,7 +6,7 @@ use ruff_python_ast::helpers::is_docstring_stmt;
 use ruff_python_ast::imports::{Alias, AnyImport, FutureImport, Import, ImportFrom};
 use ruff_python_ast::{self as ast, PySourceType, Stmt, Suite};
 use ruff_python_codegen::Stylist;
-use ruff_python_parser::{parse_module, Program};
+use ruff_python_parser::{parse_module, Program, Tokens};
 use ruff_source_file::Locator;
 use ruff_text_size::{TextRange, TextSize};
 
@@ -88,6 +88,7 @@ fn includes_import(stmt: &Stmt, target: &AnyImport) -> bool {
 fn add_required_import(
     required_import: &AnyImport,
     python_ast: &Suite,
+    tokens: &Tokens,
     locator: &Locator,
     stylist: &Stylist,
     source_type: PySourceType,
@@ -116,7 +117,7 @@ fn add_required_import(
         TextRange::default(),
     );
     diagnostic.set_fix(Fix::safe_edit(
-        Importer::new(python_ast, locator, stylist)
+        Importer::new(python_ast, tokens, locator, stylist)
             .add_import(required_import, TextSize::default()),
     ));
     Some(diagnostic)
@@ -125,6 +126,7 @@ fn add_required_import(
 /// I002
 pub(crate) fn add_required_imports(
     python_ast: &Suite,
+    tokens: &Tokens,
     locator: &Locator,
     stylist: &Stylist,
     settings: &LinterSettings,
@@ -166,6 +168,7 @@ pub(crate) fn add_required_imports(
                                 level: *level,
                             }),
                             python_ast,
+                            tokens,
                             locator,
                             stylist,
                             source_type,
@@ -183,6 +186,7 @@ pub(crate) fn add_required_imports(
                                 },
                             }),
                             python_ast,
+                            tokens,
                             locator,
                             stylist,
                             source_type,

--- a/crates/ruff_linter/src/rules/isort/rules/organize_imports.rs
+++ b/crates/ruff_linter/src/rules/isort/rules/organize_imports.rs
@@ -8,6 +8,7 @@ use ruff_python_ast::whitespace::trailing_lines_end;
 use ruff_python_ast::{PySourceType, Stmt};
 use ruff_python_codegen::Stylist;
 use ruff_python_index::Indexer;
+use ruff_python_parser::Tokens;
 use ruff_python_trivia::{leading_indentation, textwrap::indent, PythonWhitespace};
 use ruff_source_file::{Locator, UniversalNewlines};
 use ruff_text_size::{Ranged, TextRange};
@@ -88,6 +89,7 @@ pub(crate) fn organize_imports(
     settings: &LinterSettings,
     package: Option<&Path>,
     source_type: PySourceType,
+    tokens: &Tokens,
 ) -> Option<Diagnostic> {
     let indentation = locator.slice(extract_indentation_range(&block.imports, locator));
     let indentation = leading_indentation(indentation);
@@ -128,6 +130,7 @@ pub(crate) fn organize_imports(
         source_type,
         settings.target_version,
         &settings.isort,
+        tokens,
     );
 
     // Expand the span the entire range, including leading and trailing space.

--- a/crates/ruff_linter/src/rules/pyflakes/rules/unused_variable.rs
+++ b/crates/ruff_linter/src/rules/pyflakes/rules/unused_variable.rs
@@ -4,8 +4,8 @@ use ruff_diagnostics::{Diagnostic, Edit, Fix, FixAvailability, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::contains_effect;
 use ruff_python_ast::parenthesize::parenthesized_range;
-use ruff_python_ast::{self as ast, PySourceType, Stmt};
-use ruff_python_parser::{lexer, AsMode, Tok};
+use ruff_python_ast::{self as ast, Stmt};
+use ruff_python_parser::{TokenKind, Tokens};
 use ruff_python_semantic::{Binding, Scope};
 use ruff_source_file::Locator;
 use ruff_text_size::{Ranged, TextRange, TextSize};
@@ -65,22 +65,13 @@ impl Violation for UnusedVariable {
 }
 
 /// Return the [`TextRange`] of the token before the next match of the predicate
-fn match_token_before<F>(
-    location: TextSize,
-    locator: &Locator,
-    source_type: PySourceType,
-    f: F,
-) -> Option<TextRange>
+fn match_token_before<F>(tokens: &Tokens, location: TextSize, f: F) -> Option<TextRange>
 where
-    F: Fn(Tok) -> bool,
+    F: Fn(TokenKind) -> bool,
 {
-    let contents = locator.after(location);
-    for ((_, range), (tok, _)) in lexer::lex_starts_at(contents, source_type.as_mode(), location)
-        .flatten()
-        .tuple_windows()
-    {
-        if f(tok) {
-            return Some(range);
+    for (prev, current) in tokens.after(location).iter().tuple_windows() {
+        if f(current.kind()) {
+            return Some(prev.range());
         }
     }
     None
@@ -88,55 +79,31 @@ where
 
 /// Return the [`TextRange`] of the token after the next match of the predicate, skipping over
 /// any bracketed expressions.
-fn match_token_after<F>(
-    location: TextSize,
-    locator: &Locator,
-    source_type: PySourceType,
-    f: F,
-) -> Option<TextRange>
+fn match_token_after<F>(tokens: &Tokens, location: TextSize, f: F) -> Option<TextRange>
 where
-    F: Fn(Tok) -> bool,
+    F: Fn(TokenKind) -> bool,
 {
-    let contents = locator.after(location);
-
     // Track the bracket depth.
-    let mut par_count = 0u32;
-    let mut sqb_count = 0u32;
-    let mut brace_count = 0u32;
+    let mut nesting = 0u32;
 
-    for ((tok, _), (_, range)) in lexer::lex_starts_at(contents, source_type.as_mode(), location)
-        .flatten()
-        .tuple_windows()
-    {
-        match tok {
-            Tok::Lpar => {
-                par_count = par_count.saturating_add(1);
+    for (current, next) in tokens.after(location).iter().tuple_windows() {
+        match current.kind() {
+            TokenKind::Lpar | TokenKind::Lsqb | TokenKind::Lbrace => {
+                nesting = nesting.saturating_add(1);
             }
-            Tok::Lsqb => {
-                sqb_count = sqb_count.saturating_add(1);
-            }
-            Tok::Lbrace => {
-                brace_count = brace_count.saturating_add(1);
-            }
-            Tok::Rpar => {
-                par_count = par_count.saturating_sub(1);
-            }
-            Tok::Rsqb => {
-                sqb_count = sqb_count.saturating_sub(1);
-            }
-            Tok::Rbrace => {
-                brace_count = brace_count.saturating_sub(1);
+            TokenKind::Rpar | TokenKind::Rsqb | TokenKind::Rbrace => {
+                nesting = nesting.saturating_sub(1);
             }
             _ => {}
         }
 
         // If we're in nested brackets, continue.
-        if par_count > 0 || sqb_count > 0 || brace_count > 0 {
+        if nesting > 0 {
             continue;
         }
 
-        if f(tok) {
-            return Some(range);
+        if f(current.kind()) {
+            return Some(next.range());
         }
     }
     None
@@ -144,61 +111,34 @@ where
 
 /// Return the [`TextRange`] of the token matching the predicate or the first mismatched
 /// bracket, skipping over any bracketed expressions.
-fn match_token_or_closing_brace<F>(
-    location: TextSize,
-    locator: &Locator,
-    source_type: PySourceType,
-    f: F,
-) -> Option<TextRange>
+fn match_token_or_closing_brace<F>(tokens: &Tokens, location: TextSize, f: F) -> Option<TextRange>
 where
-    F: Fn(Tok) -> bool,
+    F: Fn(TokenKind) -> bool,
 {
-    let contents = locator.after(location);
+    // Track the nesting level.
+    let mut nesting = 0u32;
 
-    // Track the bracket depth.
-    let mut par_count = 0u32;
-    let mut sqb_count = 0u32;
-    let mut brace_count = 0u32;
-
-    for (tok, range) in lexer::lex_starts_at(contents, source_type.as_mode(), location).flatten() {
-        match tok {
-            Tok::Lpar => {
-                par_count = par_count.saturating_add(1);
+    for token in tokens.after(location) {
+        match token.kind() {
+            TokenKind::Lpar | TokenKind::Lsqb | TokenKind::Lbrace => {
+                nesting = nesting.saturating_add(1);
             }
-            Tok::Lsqb => {
-                sqb_count = sqb_count.saturating_add(1);
-            }
-            Tok::Lbrace => {
-                brace_count = brace_count.saturating_add(1);
-            }
-            Tok::Rpar => {
-                if par_count == 0 {
-                    return Some(range);
+            TokenKind::Rpar | TokenKind::Rsqb | TokenKind::Rbrace => {
+                if nesting == 0 {
+                    return Some(token.range());
                 }
-                par_count = par_count.saturating_sub(1);
-            }
-            Tok::Rsqb => {
-                if sqb_count == 0 {
-                    return Some(range);
-                }
-                sqb_count = sqb_count.saturating_sub(1);
-            }
-            Tok::Rbrace => {
-                if brace_count == 0 {
-                    return Some(range);
-                }
-                brace_count = brace_count.saturating_sub(1);
+                nesting = nesting.saturating_sub(1);
             }
             _ => {}
         }
 
         // If we're in nested brackets, continue.
-        if par_count > 0 || sqb_count > 0 || brace_count > 0 {
+        if nesting > 0 {
             continue;
         }
 
-        if f(tok) {
-            return Some(range);
+        if f(token.kind()) {
+            return Some(token.range());
         }
     }
     None
@@ -231,13 +171,11 @@ fn remove_unused_variable(binding: &Binding, checker: &Checker) -> Option<Fix> {
                     )
                     .unwrap_or(target.range())
                     .start();
-                    let end = match_token_after(
-                        target.end(),
-                        checker.locator(),
-                        checker.source_type,
-                        |tok| tok == Tok::Equal,
-                    )?
-                    .start();
+                    let end =
+                        match_token_after(checker.program().tokens(), target.end(), |token| {
+                            token == TokenKind::Equal
+                        })?
+                        .start();
                     let edit = Edit::deletion(start, end);
                     Some(Fix::unsafe_edit(edit))
                 } else {
@@ -269,11 +207,10 @@ fn remove_unused_variable(binding: &Binding, checker: &Checker) -> Option<Fix> {
                 // If the expression is complex (`x = foo()`), remove the assignment,
                 // but preserve the right-hand side.
                 let start = statement.start();
-                let end =
-                    match_token_after(start, checker.locator(), checker.source_type, |tok| {
-                        tok == Tok::Equal
-                    })?
-                    .start();
+                let end = match_token_after(checker.program().tokens(), start, |token| {
+                    token == TokenKind::Equal
+                })?
+                .start();
                 let edit = Edit::deletion(start, end);
                 Some(Fix::unsafe_edit(edit))
             } else {
@@ -293,21 +230,18 @@ fn remove_unused_variable(binding: &Binding, checker: &Checker) -> Option<Fix> {
                 if optional_vars.range() == binding.range() {
                     // Find the first token before the `as` keyword.
                     let start = match_token_before(
+                        checker.program().tokens(),
                         item.context_expr.start(),
-                        checker.locator(),
-                        checker.source_type,
-                        |tok| tok == Tok::As,
+                        |token| token == TokenKind::As,
                     )?
                     .end();
 
                     // Find the first colon, comma, or closing bracket after the `as` keyword.
-                    let end = match_token_or_closing_brace(
-                        start,
-                        checker.locator(),
-                        checker.source_type,
-                        |tok| tok == Tok::Colon || tok == Tok::Comma,
-                    )?
-                    .start();
+                    let end =
+                        match_token_or_closing_brace(checker.program().tokens(), start, |token| {
+                            token == TokenKind::Colon || token == TokenKind::Comma
+                        })?
+                        .start();
 
                     let edit = Edit::deletion(start, end);
                     return Some(Fix::unsafe_edit(edit));

--- a/crates/ruff_linter/src/rules/pyupgrade/fixes.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/fixes.rs
@@ -1,52 +1,49 @@
-use ruff_python_parser::{lexer, Mode, Tok};
+use ruff_python_ast::{Alias, StmtImportFrom};
+use ruff_python_parser::{lexer, Mode, Tok, TokenKind, Tokens};
 use ruff_source_file::Locator;
-use ruff_text_size::{TextRange, TextSize};
+use ruff_text_size::{Ranged, TextRange, TextSize};
 
 /// Remove any imports matching `members` from an import-from statement.
-pub(crate) fn remove_import_members(contents: &str, members: &[&str]) -> String {
-    let mut names: Vec<TextRange> = vec![];
-    let mut commas: Vec<TextRange> = vec![];
-    let mut removal_indices: Vec<usize> = vec![];
-
-    // Find all Tok::Name tokens that are not preceded by Tok::As, and all
-    // Tok::Comma tokens.
-    let mut prev_tok = None;
-    for (tok, range) in lexer::lex(contents, Mode::Module)
-        .flatten()
-        .skip_while(|(tok, _)| !matches!(tok, Tok::Import))
-    {
-        if let Tok::Name { name } = &tok {
-            if matches!(prev_tok, Some(Tok::As)) {
-                // Adjust the location to take the alias into account.
-                let last_range = names.last_mut().unwrap();
-                *last_range = TextRange::new(last_range.start(), range.end());
+pub(crate) fn remove_import_members(
+    locator: &Locator<'_>,
+    import_from_stmt: &StmtImportFrom,
+    tokens: &Tokens,
+    members_to_remove: &[&str],
+) -> String {
+    let commas: Vec<TextRange> = tokens
+        .tokens_in_range(import_from_stmt.range())
+        .iter()
+        .skip_while(|token| token.kind() != TokenKind::Import)
+        .filter_map(|token| {
+            if token.kind() == TokenKind::Comma {
+                Some(token.range())
             } else {
-                if members.contains(&&**name) {
-                    removal_indices.push(names.len());
-                }
-                names.push(range);
+                None
             }
-        } else if matches!(tok, Tok::Comma) {
-            commas.push(range);
-        }
-        prev_tok = Some(tok);
-    }
+        })
+        .collect();
 
     // Reconstruct the source code by skipping any names that are in `members`.
-    let locator = Locator::new(contents);
-    let mut output = String::with_capacity(contents.len());
+    let mut output = String::with_capacity(import_from_stmt.range().len().to_usize());
     let mut last_pos = TextSize::default();
     let mut is_first = true;
-    for index in 0..names.len() {
-        if !removal_indices.contains(&index) {
+
+    for (index, member) in import_from_stmt.names.iter().enumerate() {
+        if !members_to_remove.contains(&member.name.as_str()) {
             is_first = false;
             continue;
         }
 
         let range = if is_first {
-            TextRange::new(names[index].start(), names[index + 1].start())
+            TextRange::new(
+                import_from_stmt.names[index].start(),
+                import_from_stmt.names[index + 1].start(),
+            )
         } else {
-            TextRange::new(commas[index - 1].start(), names[index].end())
+            TextRange::new(
+                commas[index - 1].start(),
+                import_from_stmt.names[index].end(),
+            )
         };
 
         // Add all contents from `last_pos` to `fix.location`.
@@ -68,13 +65,32 @@ pub(crate) fn remove_import_members(contents: &str, members: &[&str]) -> String 
 
 #[cfg(test)]
 mod tests {
-    use crate::rules::pyupgrade::fixes::remove_import_members;
+    use ruff_python_parser::parse_module;
+    use ruff_source_file::Locator;
+
+    use super::remove_import_members;
+
+    fn test_helper(source: &str, members_to_remove: &[&str]) -> String {
+        let program = parse_module(source).unwrap();
+        let import_from_stmt = program
+            .suite()
+            .first()
+            .expect("source should have one statement")
+            .as_import_from_stmt()
+            .expect("first statement should be an import from statement");
+        remove_import_members(
+            &Locator::new(source),
+            import_from_stmt,
+            program.tokens(),
+            members_to_remove,
+        )
+    }
 
     #[test]
     fn once() {
         let source = r"from foo import bar, baz, bop, qux as q";
         let expected = r"from foo import bar, baz, qux as q";
-        let actual = remove_import_members(source, &["bop"]);
+        let actual = test_helper(source, &["bop"]);
         assert_eq!(expected, actual);
     }
 
@@ -82,7 +98,7 @@ mod tests {
     fn twice() {
         let source = r"from foo import bar, baz, bop, qux as q";
         let expected = r"from foo import bar, qux as q";
-        let actual = remove_import_members(source, &["baz", "bop"]);
+        let actual = test_helper(source, &["baz", "bop"]);
         assert_eq!(expected, actual);
     }
 
@@ -90,7 +106,7 @@ mod tests {
     fn aliased() {
         let source = r"from foo import bar, baz, bop as boop, qux as q";
         let expected = r"from foo import bar, baz, qux as q";
-        let actual = remove_import_members(source, &["bop"]);
+        let actual = test_helper(source, &["bop"]);
         assert_eq!(expected, actual);
     }
 
@@ -98,7 +114,7 @@ mod tests {
     fn parenthesized() {
         let source = r"from foo import (bar, baz, bop, qux as q)";
         let expected = r"from foo import (bar, baz, qux as q)";
-        let actual = remove_import_members(source, &["bop"]);
+        let actual = test_helper(source, &["bop"]);
         assert_eq!(expected, actual);
     }
 
@@ -106,7 +122,7 @@ mod tests {
     fn last_import() {
         let source = r"from foo import bar, baz, bop, qux as q";
         let expected = r"from foo import bar, baz, bop";
-        let actual = remove_import_members(source, &["qux"]);
+        let actual = test_helper(source, &["qux"]);
         assert_eq!(expected, actual);
     }
 
@@ -114,7 +130,7 @@ mod tests {
     fn first_import() {
         let source = r"from foo import bar, baz, bop, qux as q";
         let expected = r"from foo import baz, bop, qux as q";
-        let actual = remove_import_members(source, &["bar"]);
+        let actual = test_helper(source, &["bar"]);
         assert_eq!(expected, actual);
     }
 
@@ -122,7 +138,7 @@ mod tests {
     fn first_two_imports() {
         let source = r"from foo import bar, baz, bop, qux as q";
         let expected = r"from foo import bop, qux as q";
-        let actual = remove_import_members(source, &["bar", "baz"]);
+        let actual = test_helper(source, &["bar", "baz"]);
         assert_eq!(expected, actual);
     }
 
@@ -138,7 +154,7 @@ mod tests {
     bop,
     qux as q
 )";
-        let actual = remove_import_members(source, &["bar", "baz"]);
+        let actual = test_helper(source, &["bar", "baz"]);
         assert_eq!(expected, actual);
     }
 
@@ -155,7 +171,7 @@ mod tests {
     baz,
     qux as q,
 )";
-        let actual = remove_import_members(source, &["bop"]);
+        let actual = test_helper(source, &["bop"]);
         assert_eq!(expected, actual);
     }
 
@@ -171,7 +187,7 @@ mod tests {
     bar,
     qux as q,
 )";
-        let actual = remove_import_members(source, &["baz", "bop"]);
+        let actual = test_helper(source, &["baz", "bop"]);
         assert_eq!(expected, actual);
     }
 
@@ -191,7 +207,7 @@ mod tests {
     # This comment should be retained.
     qux as q,
 )";
-        let actual = remove_import_members(source, &["bop"]);
+        let actual = test_helper(source, &["bop"]);
         assert_eq!(expected, actual);
     }
 
@@ -211,7 +227,7 @@ mod tests {
     bop,
     qux as q,
 )";
-        let actual = remove_import_members(source, &["bar"]);
+        let actual = test_helper(source, &["bar"]);
         assert_eq!(expected, actual);
     }
 }

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/deprecated_import.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/deprecated_import.rs
@@ -1,10 +1,11 @@
 use itertools::Itertools;
-use ruff_python_ast::{Alias, Stmt};
+use ruff_python_ast::{Alias, Stmt, StmtImportFrom};
 
 use ruff_diagnostics::{Diagnostic, Edit, Fix, FixAvailability, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::whitespace::indentation;
 use ruff_python_codegen::Stylist;
+use ruff_python_parser::Tokens;
 use ruff_source_file::Locator;
 use ruff_text_size::Ranged;
 
@@ -362,29 +363,29 @@ const TYPING_EXTENSIONS_TO_COLLECTIONS_ABC_312: &[&str] = &["Buffer"];
 const TYPING_EXTENSIONS_TO_TYPES_312: &[&str] = &["get_original_bases"];
 
 struct ImportReplacer<'a> {
-    stmt: &'a Stmt,
+    import_from_stmt: &'a StmtImportFrom,
     module: &'a str,
-    members: &'a [Alias],
     locator: &'a Locator<'a>,
     stylist: &'a Stylist<'a>,
+    tokens: &'a Tokens,
     version: PythonVersion,
 }
 
 impl<'a> ImportReplacer<'a> {
     const fn new(
-        stmt: &'a Stmt,
+        import_from_stmt: &'a StmtImportFrom,
         module: &'a str,
-        members: &'a [Alias],
         locator: &'a Locator<'a>,
         stylist: &'a Stylist<'a>,
+        tokens: &'a Tokens,
         version: PythonVersion,
     ) -> Self {
         Self {
-            stmt,
+            import_from_stmt,
             module,
-            members,
             locator,
             stylist,
+            tokens,
             version,
         }
     }
@@ -394,7 +395,7 @@ impl<'a> ImportReplacer<'a> {
         let mut operations = vec![];
         if self.module == "typing" {
             if self.version >= PythonVersion::Py39 {
-                for member in self.members {
+                for member in &self.import_from_stmt.names {
                     if let Some(target) = TYPING_TO_RENAME_PY39.iter().find_map(|(name, target)| {
                         if &member.name == *name {
                             Some(*target)
@@ -563,7 +564,7 @@ impl<'a> ImportReplacer<'a> {
             let fix = Some(matched);
             Some((operation, fix))
         } else {
-            let indentation = indentation(self.locator, self.stmt);
+            let indentation = indentation(self.locator, self.import_from_stmt);
 
             // If we have matched _and_ unmatched names, but the import is not on its own
             // line, we can't add a statement after it. For example, if we have
@@ -583,7 +584,9 @@ impl<'a> ImportReplacer<'a> {
 
             let matched = ImportReplacer::format_import_from(&matched_names, target);
             let unmatched = fixes::remove_import_members(
-                self.locator.slice(self.stmt.range()),
+                self.locator,
+                self.import_from_stmt,
+                self.tokens,
                 &matched_names
                     .iter()
                     .map(|name| name.name.as_str())
@@ -611,7 +614,7 @@ impl<'a> ImportReplacer<'a> {
     fn partition_imports(&self, candidates: &[&str]) -> (Vec<&Alias>, Vec<&Alias>) {
         let mut matched_names = vec![];
         let mut unmatched_names = vec![];
-        for name in self.members {
+        for name in &self.import_from_stmt.names {
             if candidates.contains(&name.name.as_str()) {
                 matched_names.push(name);
             } else {
@@ -638,21 +641,19 @@ impl<'a> ImportReplacer<'a> {
 }
 
 /// UP035
-pub(crate) fn deprecated_import(
-    checker: &mut Checker,
-    stmt: &Stmt,
-    names: &[Alias],
-    module: Option<&str>,
-    level: u32,
-) {
+pub(crate) fn deprecated_import(checker: &mut Checker, import_from_stmt: &StmtImportFrom) {
     // Avoid relative and star imports.
-    if level > 0 {
+    if import_from_stmt.level > 0 {
         return;
     }
-    if names.first().is_some_and(|name| &name.name == "*") {
+    if import_from_stmt
+        .names
+        .first()
+        .is_some_and(|name| &name.name == "*")
+    {
         return;
     }
-    let Some(module) = module else {
+    let Some(module) = import_from_stmt.module.as_deref() else {
         return;
     };
 
@@ -660,13 +661,12 @@ pub(crate) fn deprecated_import(
         return;
     }
 
-    let members: Vec<Alias> = names.iter().map(Clone::clone).collect();
     let fixer = ImportReplacer::new(
-        stmt,
+        import_from_stmt,
         module,
-        &members,
         checker.locator(),
         checker.stylist(),
+        checker.program().tokens(),
         checker.settings.target_version,
     );
 
@@ -675,12 +675,12 @@ pub(crate) fn deprecated_import(
             DeprecatedImport {
                 deprecation: Deprecation::WithoutRename(operation),
             },
-            stmt.range(),
+            import_from_stmt.range(),
         );
         if let Some(content) = fix {
             diagnostic.set_fix(Fix::safe_edit(Edit::range_replacement(
                 content,
-                stmt.range(),
+                import_from_stmt.range(),
             )));
         }
         checker.diagnostics.push(diagnostic);
@@ -691,7 +691,7 @@ pub(crate) fn deprecated_import(
             DeprecatedImport {
                 deprecation: Deprecation::WithRename(operation),
             },
-            stmt.range(),
+            import_from_stmt.range(),
         );
         checker.diagnostics.push(diagnostic);
     }

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/f_strings.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/f_strings.rs
@@ -11,7 +11,7 @@ use ruff_python_ast::{self as ast, Expr, Keyword};
 use ruff_python_literal::format::{
     FieldName, FieldNamePart, FieldType, FormatPart, FormatString, FromTemplate,
 };
-use ruff_python_parser::{lexer, Mode, Tok};
+use ruff_python_parser::{lexer, Mode, Tok, TokenKind};
 use ruff_source_file::Locator;
 use ruff_text_size::{Ranged, TextRange};
 
@@ -409,15 +409,17 @@ pub(crate) fn f_strings(checker: &mut Checker, call: &ast::ExprCall, summary: &F
     };
 
     let mut patches: Vec<(TextRange, FStringConversion)> = vec![];
-    let mut lex = lexer::lex_starts_at(
-        checker.locator().slice(call.func.range()),
-        Mode::Expression,
-        call.start(),
-    )
-    .flatten();
+    let mut tokens = checker
+        .program()
+        .tokens()
+        .tokens_in_range(call.func.range())
+        .iter();
     let end = loop {
-        match lex.next() {
-            Some((Tok::Dot, range)) => {
+        let Some(token) = tokens.next() else {
+            unreachable!("Should break from the `Tok::Dot` arm");
+        };
+        match token.kind() {
+            TokenKind::Dot => {
                 // ```
                 // (
                 //     "a"
@@ -429,10 +431,11 @@ pub(crate) fn f_strings(checker: &mut Checker, call: &ast::ExprCall, summary: &F
                 //
                 // We know that the expression is a string literal, so we can safely assume that the
                 // dot is the start of an attribute access.
-                break range.start();
+                break token.start();
             }
-            Some((Tok::String { .. }, range)) => {
-                match FStringConversion::try_convert(range, &mut summary, checker.locator()) {
+            TokenKind::String => {
+                match FStringConversion::try_convert(token.range(), &mut summary, checker.locator())
+                {
                     // If the format string contains side effects that would need to be repeated,
                     // we can't convert it to an f-string.
                     Ok(FStringConversion::SideEffects) => return,
@@ -440,11 +443,10 @@ pub(crate) fn f_strings(checker: &mut Checker, call: &ast::ExprCall, summary: &F
                     // expression.
                     Err(_) => return,
                     // Otherwise, push the conversion to be processed later.
-                    Ok(conversion) => patches.push((range, conversion)),
+                    Ok(conversion) => patches.push((token.range(), conversion)),
                 }
             }
-            Some(_) => continue,
-            None => unreachable!("Should break from the `Tok::Dot` arm"),
+            _ => {}
         }
     };
     if patches.is_empty() {

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/printf_string_formatting.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/printf_string_formatting.rs
@@ -8,7 +8,7 @@ use ruff_python_codegen::Stylist;
 use ruff_python_literal::cformat::{
     CConversionFlags, CFormatPart, CFormatPrecision, CFormatQuantity, CFormatString,
 };
-use ruff_python_parser::{lexer, AsMode, Tok};
+use ruff_python_parser::{lexer, AsMode, Tok, TokenKind};
 use ruff_python_stdlib::identifiers::is_identifier;
 use ruff_source_file::Locator;
 use ruff_text_size::{Ranged, TextRange};
@@ -344,38 +344,20 @@ fn convertible(format_string: &CFormatString, params: &Expr) -> bool {
 }
 
 /// UP031
-pub(crate) fn printf_string_formatting(checker: &mut Checker, expr: &Expr, right: &Expr) {
-    // Grab each string segment (in case there's an implicit concatenation).
-    let mut strings: Vec<(TextRange, AnyStringFlags)> = vec![];
-    let mut extension = None;
-    for (tok, range) in lexer::lex_starts_at(
-        checker.locator().slice(expr),
-        checker.source_type.as_mode(),
-        expr.start(),
-    )
-    .flatten()
-    {
-        match tok {
-            Tok::String { flags, .. } => strings.push((range, flags)),
-            // If we hit a right paren, we have to preserve it.
-            Tok::Rpar => extension = Some(range),
-            // Break as soon as we find the modulo symbol.
-            Tok::Percent => break,
-            _ => continue,
-        }
-    }
-
-    // If there are no string segments, abort.
-    if strings.is_empty() {
-        return;
-    }
-
-    // Parse each string segment.
+pub(crate) fn printf_string_formatting(
+    checker: &mut Checker,
+    string_expr: &ast::ExprStringLiteral,
+    right: &Expr,
+) {
     let mut num_positional_arguments = 0;
     let mut num_keyword_arguments = 0;
-    let mut format_strings = Vec::with_capacity(strings.len());
-    for (range, flags) in &strings {
-        let string = checker.locator().slice(*range);
+    let mut format_strings: Vec<(TextRange, String)> =
+        Vec::with_capacity(string_expr.value.count());
+
+    // Parse each string segment.
+    for string_literal in &string_expr.value {
+        let string = checker.locator().slice(string_literal);
+        let flags = AnyStringFlags::from(string_literal.flags);
         let string = &string
             [usize::from(flags.opener_len())..(string.len() - usize::from(flags.closer_len()))];
 
@@ -400,7 +382,10 @@ pub(crate) fn printf_string_formatting(checker: &mut Checker, expr: &Expr, right
         }
 
         // Convert the `%`-format string to a `.format` string.
-        format_strings.push(flags.format_string_contents(&percent_to_format(&format_string)));
+        format_strings.push((
+            string_literal.range(),
+            flags.format_string_contents(&percent_to_format(&format_string)),
+        ));
     }
 
     // Parse the parameters.
@@ -448,41 +433,55 @@ pub(crate) fn printf_string_formatting(checker: &mut Checker, expr: &Expr, right
 
     // Reconstruct the string.
     let mut contents = String::new();
-    let mut prev = None;
-    for ((range, _), format_string) in strings.iter().zip(format_strings) {
+    let mut prev_end = None;
+    for (range, format_string) in format_strings.into_iter() {
         // Add the content before the string segment.
-        match prev {
+        match prev_end {
             None => {
                 contents.push_str(
                     checker
                         .locator()
-                        .slice(TextRange::new(expr.start(), range.start())),
+                        .slice(TextRange::new(string_expr.start(), range.start())),
                 );
             }
-            Some(prev) => {
-                contents.push_str(checker.locator().slice(TextRange::new(prev, range.start())));
+            Some(prev_end) => {
+                contents.push_str(
+                    checker
+                        .locator()
+                        .slice(TextRange::new(prev_end, range.start())),
+                );
             }
         }
         // Add the string itself.
         contents.push_str(&format_string);
-        prev = Some(range.end());
+        prev_end = Some(range.end());
     }
 
-    if let Some(range) = extension {
-        contents.push_str(
-            checker
-                .locator()
-                .slice(TextRange::new(prev.unwrap(), range.end())),
-        );
+    if let Some(prev_end) = prev_end {
+        for token in checker.program().tokens().after(prev_end) {
+            match token.kind() {
+                // If we hit a right paren, we have to preserve it.
+                TokenKind::Rpar => {
+                    contents.push_str(
+                        checker
+                            .locator()
+                            .slice(TextRange::new(prev_end, token.end())),
+                    );
+                }
+                // Break as soon as we find the modulo symbol.
+                TokenKind::Percent => break,
+                _ => {}
+            }
+        }
     }
 
     // Add the `.format` call.
     contents.push_str(&format!(".format{params_string}"));
 
-    let mut diagnostic = Diagnostic::new(PrintfStringFormatting, expr.range());
+    let mut diagnostic = Diagnostic::new(PrintfStringFormatting, string_expr.range());
     diagnostic.set_fix(Fix::unsafe_edit(Edit::range_replacement(
         contents,
-        expr.range(),
+        string_expr.range(),
     )));
     checker.diagnostics.push(diagnostic);
 }

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/printf_string_formatting.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/printf_string_formatting.rs
@@ -352,7 +352,7 @@ pub(crate) fn printf_string_formatting(
     let mut num_positional_arguments = 0;
     let mut num_keyword_arguments = 0;
     let mut format_strings: Vec<(TextRange, String)> =
-        Vec::with_capacity(string_expr.value.count());
+        Vec::with_capacity(string_expr.value.as_slice().len());
 
     // Parse each string segment.
     for string_literal in &string_expr.value {

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/redundant_open_modes.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/redundant_open_modes.rs
@@ -4,8 +4,8 @@ use anyhow::{anyhow, Result};
 
 use ruff_diagnostics::{AlwaysFixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
-use ruff_python_ast::{self as ast, Expr, PySourceType};
-use ruff_python_parser::{lexer, AsMode};
+use ruff_python_ast::{self as ast, Expr};
+use ruff_python_parser::{TokenKind, Tokens};
 use ruff_source_file::Locator;
 use ruff_text_size::{Ranged, TextSize};
 
@@ -76,12 +76,12 @@ pub(crate) fn redundant_open_modes(checker: &mut Checker, call: &ast::ExprCall) 
                     }) = &keyword.value
                     {
                         if let Ok(mode) = OpenMode::from_str(mode_param_value.to_str()) {
-                            checker.diagnostics.push(create_check(
+                            checker.diagnostics.push(create_diagnostic(
                                 call,
                                 &keyword.value,
                                 mode.replacement_value(),
                                 checker.locator(),
-                                checker.source_type,
+                                checker.program().tokens(),
                             ));
                         }
                     }
@@ -91,12 +91,12 @@ pub(crate) fn redundant_open_modes(checker: &mut Checker, call: &ast::ExprCall) 
         Some(mode_param) => {
             if let Expr::StringLiteral(ast::ExprStringLiteral { value, .. }) = &mode_param {
                 if let Ok(mode) = OpenMode::from_str(value.to_str()) {
-                    checker.diagnostics.push(create_check(
+                    checker.diagnostics.push(create_diagnostic(
                         call,
                         mode_param,
                         mode.replacement_value(),
                         checker.locator(),
-                        checker.source_type,
+                        checker.program().tokens(),
                     ));
                 }
             }
@@ -146,18 +146,18 @@ impl OpenMode {
     }
 }
 
-fn create_check<T: Ranged>(
-    expr: &T,
+fn create_diagnostic(
+    call: &ast::ExprCall,
     mode_param: &Expr,
     replacement_value: Option<&str>,
     locator: &Locator,
-    source_type: PySourceType,
+    tokens: &Tokens,
 ) -> Diagnostic {
     let mut diagnostic = Diagnostic::new(
         RedundantOpenModes {
             replacement: replacement_value.map(ToString::to_string),
         },
-        expr.range(),
+        call.range(),
     );
 
     if let Some(content) = replacement_value {
@@ -167,51 +167,54 @@ fn create_check<T: Ranged>(
         )));
     } else {
         diagnostic.try_set_fix(|| {
-            create_remove_param_fix(locator, expr, mode_param, source_type).map(Fix::safe_edit)
+            create_remove_param_fix(locator, call, mode_param, tokens).map(Fix::safe_edit)
         });
     }
 
     diagnostic
 }
 
-fn create_remove_param_fix<T: Ranged>(
+fn create_remove_param_fix(
     locator: &Locator,
-    expr: &T,
+    call: &ast::ExprCall,
     mode_param: &Expr,
-    source_type: PySourceType,
+    tokens: &Tokens,
 ) -> Result<Edit> {
-    let content = locator.slice(expr);
     // Find the last comma before mode_param and create a deletion fix
     // starting from the comma and ending after mode_param.
     let mut fix_start: Option<TextSize> = None;
     let mut fix_end: Option<TextSize> = None;
     let mut is_first_arg: bool = false;
     let mut delete_first_arg: bool = false;
-    for (tok, range) in lexer::lex_starts_at(content, source_type.as_mode(), expr.start()).flatten()
-    {
-        if range.start() == mode_param.start() {
+
+    for token in tokens.tokens_in_range(call.range()) {
+        if token.start() == mode_param.start() {
             if is_first_arg {
                 delete_first_arg = true;
                 continue;
             }
-            fix_end = Some(range.end());
+            fix_end = Some(token.end());
             break;
         }
-        if delete_first_arg && tok.is_name() {
-            fix_end = Some(range.start());
-            break;
-        }
-        if tok.is_lpar() {
-            is_first_arg = true;
-            fix_start = Some(range.end());
-        }
-        if tok.is_comma() {
-            is_first_arg = false;
-            if !delete_first_arg {
-                fix_start = Some(range.start());
+        match token.kind() {
+            TokenKind::Name if delete_first_arg => {
+                fix_end = Some(token.start());
+                break;
             }
+            TokenKind::Lpar => {
+                is_first_arg = true;
+                fix_start = Some(token.end());
+            }
+            TokenKind::Comma => {
+                is_first_arg = false;
+                if !delete_first_arg {
+                    fix_start = Some(token.start());
+                }
+            }
+            _ => {}
         }
     }
+
     match (fix_start, fix_end) {
         (Some(start), Some(end)) => Ok(Edit::deletion(start, end)),
         _ => Err(anyhow::anyhow!(

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/unnecessary_encode_utf8.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/unnecessary_encode_utf8.rs
@@ -1,7 +1,7 @@
 use ruff_diagnostics::{AlwaysFixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
-use ruff_python_ast::{self as ast, Arguments, Expr, Keyword, PySourceType};
-use ruff_python_parser::{lexer, AsMode, Tok};
+use ruff_python_ast::{self as ast, Arguments, Expr, Keyword};
+use ruff_python_parser::{TokenKind, Tokens};
 use ruff_source_file::Locator;
 use ruff_text_size::{Ranged, TextRange};
 
@@ -117,33 +117,26 @@ fn match_encoding_arg(arguments: &Arguments) -> Option<EncodingArg> {
 }
 
 /// Return a [`Fix`] replacing the call to encode with a byte string.
-fn replace_with_bytes_literal(
-    locator: &Locator,
-    call: &ast::ExprCall,
-    source_type: PySourceType,
-) -> Fix {
+fn replace_with_bytes_literal(locator: &Locator, call: &ast::ExprCall, tokens: &Tokens) -> Fix {
     // Build up a replacement string by prefixing all string tokens with `b`.
-    let contents = locator.slice(call);
-    let mut replacement = String::with_capacity(contents.len() + 1);
+    let mut replacement = String::with_capacity(call.range() + 1);
     let mut prev = call.start();
-    for (tok, range) in
-        lexer::lex_starts_at(contents, source_type.as_mode(), call.start()).flatten()
-    {
-        match tok {
-            Tok::Dot => break,
-            Tok::String { .. } => {
-                replacement.push_str(locator.slice(TextRange::new(prev, range.start())));
-                let string = locator.slice(range);
+    for token in tokens.tokens_in_range(call.range()) {
+        match token.kind() {
+            TokenKind::Dot => break,
+            TokenKind::String => {
+                replacement.push_str(locator.slice(TextRange::new(prev, token.start())));
+                let string = locator.slice(token);
                 replacement.push_str(&format!(
                     "b{}",
                     &string.trim_start_matches('u').trim_start_matches('U')
                 ));
             }
             _ => {
-                replacement.push_str(locator.slice(TextRange::new(prev, range.end())));
+                replacement.push_str(locator.slice(TextRange::new(prev, token.end())));
             }
         }
-        prev = range.end();
+        prev = token.end();
     }
 
     Fix::safe_edit(Edit::range_replacement(
@@ -172,7 +165,7 @@ pub(crate) fn unnecessary_encode_utf8(checker: &mut Checker, call: &ast::ExprCal
                     diagnostic.set_fix(replace_with_bytes_literal(
                         checker.locator(),
                         call,
-                        checker.source_type,
+                        checker.program().tokens(),
                     ));
                     checker.diagnostics.push(diagnostic);
                 } else if let EncodingArg::Keyword(kwarg) = encoding_arg {

--- a/crates/ruff_linter/src/rules/ruff/rules/sort_dunder_all.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/sort_dunder_all.rs
@@ -216,6 +216,7 @@ fn create_fix(
                 range,
                 kind,
                 locator,
+                checker.program().tokens(),
                 string_items,
             )?;
             assert_eq!(value.len(), elts.len());

--- a/crates/ruff_linter/src/rules/ruff/rules/sort_dunder_slots.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/sort_dunder_slots.rs
@@ -210,6 +210,7 @@ impl<'a> StringLiteralDisplay<'a> {
                     self.range(),
                     *sequence_kind,
                     locator,
+                    checker.program().tokens(),
                     elements,
                 )?;
                 assert_eq!(analyzed_sequence.len(), self.elts.len());

--- a/crates/ruff_python_ast/src/nodes.rs
+++ b/crates/ruff_python_ast/src/nodes.rs
@@ -1718,6 +1718,14 @@ impl StringLiteralValue {
         self.iter().fold(0, |acc, part| acc + part.value.len())
     }
 
+    /// Returns the number of string literals in this value.
+    pub fn count(&self) -> usize {
+        match &self.inner {
+            StringLiteralValueInner::Single(_) => 1,
+            StringLiteralValueInner::Concatenated(value) => value.strings.len(),
+        }
+    }
+
     /// Returns an iterator over the [`char`]s of each string literal part.
     pub fn chars(&self) -> impl Iterator<Item = char> + '_ {
         self.iter().flat_map(|part| part.value.chars())

--- a/crates/ruff_python_ast/src/nodes.rs
+++ b/crates/ruff_python_ast/src/nodes.rs
@@ -1718,14 +1718,6 @@ impl StringLiteralValue {
         self.iter().fold(0, |acc, part| acc + part.value.len())
     }
 
-    /// Returns the number of string literals in this value.
-    pub fn count(&self) -> usize {
-        match &self.inner {
-            StringLiteralValueInner::Single(_) => 1,
-            StringLiteralValueInner::Concatenated(value) => value.strings.len(),
-        }
-    }
-
     /// Returns an iterator over the [`char`]s of each string literal part.
     pub fn chars(&self) -> impl Iterator<Item = char> + '_ {
         self.iter().flat_map(|part| part.value.chars())

--- a/crates/ruff_python_parser/src/lib.rs
+++ b/crates/ruff_python_parser/src/lib.rs
@@ -76,7 +76,7 @@ use crate::parser::Parser;
 use itertools::Itertools;
 use ruff_python_ast::{Expr, Mod, ModExpression, ModModule, PySourceType, Suite};
 use ruff_python_trivia::CommentRanges;
-use ruff_text_size::{Ranged, TextRange};
+use ruff_text_size::{Ranged, TextRange, TextSize};
 
 mod error;
 pub mod lexer;
@@ -416,6 +416,15 @@ impl Tokens {
             return &[];
         };
         &self[start..=start + end]
+    }
+
+    /// Returns a slice of tokens after the given [`TextSize`] offset.
+    ///
+    /// If the given offset lies within a token, the returned slice will start from the token after
+    /// that. In other words, the returned slice will not include the token containing the offset.
+    pub fn after(&self, offset: TextSize) -> &[Token] {
+        let start = self.partition_point(|token| token.start() < offset);
+        &self[start..]
     }
 }
 


### PR DESCRIPTION
## Summary

Part of #11401 

This PR refactors most usages of `lex_starts_at` to use the `Tokens` struct available on the `Program`.

This PR also introduces the following two APIs:
1. `count` (on `StringLiteralValue`) to return the number of string literal parts in the string expression
2. `after` (on `Tokens`) to return the token slice after the given `TextSize` offset

## Test Plan

I don't really have a way to test this currently and so I'll have to wait until all changes are made so that the code compiles.
