### PR TITLE
[`flake8-logging-format`] Fix the autofix title in `logging-warn` (`G010`)

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_logging_format/snapshots/ruff_linter__rules__flake8_logging_format__tests__G010.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_logging_format/snapshots/ruff_linter__rules__flake8_logging_format__tests__G010.py.snap
@@ -10,7 +10,7 @@ G010.py:6:9: G010 [*] Logging statement uses `warn` instead of `warning`
 7 | log.warn("Hello world!")  # This shouldn't be considered as a logger candidate
 8 | logger.warn("Hello world!")
   |
-  = help: Convert to `warn`
+  = help: Convert to `warning`
 
 ℹ Safe fix
 3 3 | 
@@ -31,7 +31,7 @@ G010.py:8:8: G010 [*] Logging statement uses `warn` instead of `warning`
  9 | 
 10 | logging . warn("Hello World!")
    |
-   = help: Convert to `warn`
+   = help: Convert to `warning`
 
 ℹ Safe fix
 5 5 | 
@@ -52,7 +52,7 @@ G010.py:10:11: G010 [*] Logging statement uses `warn` instead of `warning`
 11 | 
 12 | from logging import warn, warning, exception
    |
-   = help: Convert to `warn`
+   = help: Convert to `warning`
 
 ℹ Safe fix
 7  7  | log.warn("Hello world!")  # This shouldn't be considered as a logger candidate
@@ -72,7 +72,7 @@ G010.py:13:1: G010 [*] Logging statement uses `warn` instead of `warning`
 14 | warning("foo")
 15 | exception("foo")
    |
-   = help: Convert to `warn`
+   = help: Convert to `warning`
 
 ℹ Safe fix
 10 10 | logging . warn("Hello World!")

--- a/crates/ruff_linter/src/rules/flake8_logging_format/violations.rs
+++ b/crates/ruff_linter/src/rules/flake8_logging_format/violations.rs
@@ -383,7 +383,7 @@ impl AlwaysFixableViolation for LoggingWarn {
     }
 
     fn fix_title(&self) -> String {
-        "Convert to `warn`".to_string()
+        "Convert to `warning`".to_string()
     }
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Rule `logging-warn` (`G010`) prescribes a change from `warn` to `warning` and has a corresponding autofix, but the autofix is mistakenly titled ```"Convert to `warn`"``` instead of ```"Convert to `warning`"``` (the latter is what the autofix actually does). Seems to be a plain typo.

## Test Plan

I apologize for not being able to properly test this at the moment, the change was made by grepping the repo and fixing the typo in code as well as in the `.snap` file.
