### PR TITLE
Consider match-case stmts for `C901`, `PLR0912`, and `PLR0915`

### DIFF
--- a/crates/ruff_linter/src/rules/mccabe/rules/function_is_too_complex.rs
+++ b/crates/ruff_linter/src/rules/mccabe/rules/function_is_too_complex.rs
@@ -96,7 +96,6 @@ fn get_complexity_number(stmts: &[Stmt]) -> usize {
                 complexity += get_complexity_number(orelse);
             }
             Stmt::Match(ast::StmtMatch { cases, .. }) => {
-                complexity += 1;
                 for case in cases {
                     complexity += 1;
                     complexity += get_complexity_number(&case.body);
@@ -442,7 +441,7 @@ def f():
             print('bar')
 ";
         let stmts = parse_suite(source)?;
-        assert_eq!(get_complexity_number(&stmts), 4);
+        assert_eq!(get_complexity_number(&stmts), 3);
         Ok(())
     }
 }

--- a/crates/ruff_linter/src/rules/mccabe/rules/function_is_too_complex.rs
+++ b/crates/ruff_linter/src/rules/mccabe/rules/function_is_too_complex.rs
@@ -98,6 +98,7 @@ fn get_complexity_number(stmts: &[Stmt]) -> usize {
             Stmt::Match(ast::StmtMatch { cases, .. }) => {
                 complexity += 1;
                 for case in cases {
+                    complexity += 1;
                     complexity += get_complexity_number(&case.body);
                 }
             }
@@ -427,6 +428,21 @@ def with_lock():
 ";
         let stmts = parse_suite(source)?;
         assert_eq!(get_complexity_number(&stmts), 2);
+        Ok(())
+    }
+
+    #[test]
+    fn match_case() -> Result<()> {
+        let source = r"
+def f():
+    match a:
+        case 30:
+            print('foo')
+        case _:
+            print('bar')
+";
+        let stmts = parse_suite(source)?;
+        assert_eq!(get_complexity_number(&stmts), 4);
         Ok(())
     }
 }

--- a/crates/ruff_linter/src/rules/pylint/rules/too_many_branches.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/too_many_branches.rs
@@ -176,10 +176,11 @@ fn num_branches(stmts: &[Stmt]) -> usize {
                         .sum::<usize>()
             }
             Stmt::Match(ast::StmtMatch { cases, .. }) => {
-                1 + cases
-                    .iter()
-                    .map(|case| num_branches(&case.body))
-                    .sum::<usize>()
+                1 + cases.len()
+                    + cases
+                        .iter()
+                        .map(|case| num_branches(&case.body))
+                        .sum::<usize>()
             }
             // The `with` statement is not considered a branch but the statements inside the `with` should be counted.
             Stmt::With(ast::StmtWith { body, .. }) => num_branches(body),
@@ -275,6 +276,19 @@ else:
         pass
 ";
         test_helper(source, 4)?;
+        Ok(())
+    }
+
+    #[test]
+    fn match_case() -> Result<()> {
+        let source: &str = r"
+match x: # 3
+    case 0:
+        pass
+    case 1:
+        pass
+";
+        test_helper(source, 3)?;
         Ok(())
     }
 

--- a/crates/ruff_linter/src/rules/pylint/rules/too_many_branches.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/too_many_branches.rs
@@ -176,7 +176,7 @@ fn num_branches(stmts: &[Stmt]) -> usize {
                         .sum::<usize>()
             }
             Stmt::Match(ast::StmtMatch { cases, .. }) => {
-                1 + cases.len()
+                cases.len()
                     + cases
                         .iter()
                         .map(|case| num_branches(&case.body))
@@ -282,13 +282,13 @@ else:
     #[test]
     fn match_case() -> Result<()> {
         let source: &str = r"
-match x: # 3
+match x: # 2
     case 0:
         pass
     case 1:
         pass
 ";
-        test_helper(source, 3)?;
+        test_helper(source, 2)?;
         Ok(())
     }
 

--- a/crates/ruff_linter/src/rules/pylint/rules/too_many_statements.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/too_many_statements.rs
@@ -90,6 +90,7 @@ fn num_statements(stmts: &[Stmt]) -> usize {
             Stmt::Match(ast::StmtMatch { cases, .. }) => {
                 count += 1;
                 for case in cases {
+                    count += 1;
                     count += num_statements(&case.body);
                 }
             }
@@ -230,6 +231,21 @@ def f():
 ";
         let stmts = parse_suite(source)?;
         assert_eq!(num_statements(&stmts), 9);
+        Ok(())
+    }
+
+    #[test]
+    fn match_case() -> Result<()> {
+        let source: &str = r"
+def f():
+    match x:
+        case 3:
+            pass
+        case _:
+            pass
+";
+        let stmts = parse_suite(source)?;
+        assert_eq!(num_statements(&stmts), 6);
         Ok(())
     }
 


### PR DESCRIPTION
Resolves #11421

## Summary

Instead of counting match/case as one statement, consider each `case` as a conditional. 

## Test Plan

`cargo test`
