### PR TITLE
Insert blank lines before comments in E305

### DIFF
--- a/crates/ruff_linter/src/rules/pycodestyle/rules/blank_lines.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/blank_lines.rs
@@ -1009,10 +1009,10 @@ impl<'a> BlankLinesChecker<'a> {
                 )));
             } else {
                 diagnostic.set_fix(Fix::safe_edit(Edit::insertion(
-                    self.stylist
-                        .line_ending()
-                        .repeat(BLANK_LINES_TOP_LEVEL as usize),
-                    self.locator.line_start(line.first_token_range.start()),
+                    self.stylist.line_ending().repeat(
+                        (BLANK_LINES_TOP_LEVEL - line.preceding_blank_lines.count()) as usize,
+                    ),
+                    self.locator.line_start(state.last_non_comment_line_end),
                 )));
             }
 

--- a/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E305_E30.py.snap
+++ b/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E305_E30.py.snap
@@ -11,14 +11,13 @@ E30.py:806:1: E305 [*] Expected 2 blank lines after class or function definition
     = help: Add missing blank line(s)
 
 ℹ Safe fix
-803 803 |     # comment
-804 804 | 
-805 805 |     # another comment
-    806 |+
-    807 |+
-806 808 | fn()
-807 809 | # end
-808 810 | 
+800 800 | def fn():
+801 801 |     print()
+802 802 | 
+    803 |+
+803 804 |     # comment
+804 805 | 
+805 806 |     # another comment
 
 E30.py:817:1: E305 [*] Expected 2 blank lines after class or function definition, found (1)
     |
@@ -30,14 +29,13 @@ E30.py:817:1: E305 [*] Expected 2 blank lines after class or function definition
     = help: Add missing blank line(s)
 
 ℹ Safe fix
-814 814 |     # comment
-815 815 | 
-816 816 |     # another comment
-    817 |+
-    818 |+
-817 819 | a = 1
-818 820 | # end
-819 821 | 
+811 811 | class Class():
+812 812 |     pass
+813 813 | 
+    814 |+
+814 815 |     # comment
+815 816 | 
+816 817 |     # another comment
 
 E30.py:829:1: E305 [*] Expected 2 blank lines after class or function definition, found (1)
     |
@@ -70,14 +68,13 @@ E30.py:841:1: E305 [*] Expected 2 blank lines after class or function definition
     = help: Add missing blank line(s)
 
 ℹ Safe fix
+837 837 | def a():
 838 838 |     print()
 839 839 | 
-840 840 | # Two spaces before comments, too.
-    841 |+
-    842 |+
-841 843 | if a():
-842 844 |     a()
-843 845 | # end
+    840 |+
+840 841 | # Two spaces before comments, too.
+841 842 | if a():
+842 843 |     a()
 
 E30.py:854:1: E305 [*] Expected 2 blank lines after class or function definition, found (1)
     |

--- a/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__blank_lines_E305_notebook.snap
+++ b/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__blank_lines_E305_notebook.snap
@@ -12,11 +12,10 @@ E30.ipynb:55:1: E305 [*] Expected 2 blank lines after class or function definiti
    = help: Add missing blank line(s)
 
 ℹ Safe fix
-52 52 |     # comment
-53 53 | 
-54 54 |     # another comment
-   55 |+
-   56 |+
-55 57 | fn()
-56 58 | # end
-57 59 | # E306:3:5
+49 49 | def fn():
+50 50 |     print()
+51 51 | 
+   52 |+
+52 53 |     # comment
+53 54 | 
+54 55 |     # another comment


### PR DESCRIPTION
## Summary

Given:

```python
class A:
    pass

# ====== Cool constants ========
BANANA = 100
APPLE = 200
```

We now insert the blank line _before_ the comment, rather than inserting two blank lines _after_ the comment.

Closes https://github.com/astral-sh/ruff/issues/11508.
