### PR TITLE
Treat all `singledispatch` arguments as runtime-required

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_type_checking/singledispatch.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_type_checking/singledispatch.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from functools import singledispatch
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from numpy import asarray
@@ -31,4 +32,25 @@ def _(a: spmatrix) -> spmatrix:
 
 
 def _(a: DataFrame) -> DataFrame:
+    return a
+
+
+@singledispatch
+def process_path(a: int | str, p: Path) -> int:
+    """Convert arg to array or leaves it as sparse matrix."""
+    msg = f"Unhandled type {type(a)}"
+    raise NotImplementedError(msg)
+
+
+@process_path.register
+def _(a: int, p: Path) -> int:
+    return asarray(a)
+
+
+@process_path.register
+def _(a: str, p: Path) -> int:
+    return a
+
+
+def _(a: DataFrame, p: Path) -> DataFrame:
     return a

--- a/crates/ruff_linter/src/checkers/ast/mod.rs
+++ b/crates/ruff_linter/src/checkers/ast/mod.rs
@@ -661,7 +661,7 @@ impl<'a> Visitor<'a> for Checker<'a> {
                     AnnotationContext::from_function(function_def, &self.semantic, self.settings);
 
                 // The first parameter may be a single dispatch.
-                let mut singledispatch =
+                let singledispatch =
                     flake8_type_checking::helpers::is_singledispatch_implementation(
                         function_def,
                         self.semantic(),
@@ -677,7 +677,6 @@ impl<'a> Visitor<'a> for Checker<'a> {
                     if let Some(expr) = parameter.annotation() {
                         if singledispatch && !parameter.is_variadic() {
                             self.visit_runtime_required_annotation(expr);
-                            singledispatch = false;
                         } else {
                             match annotation {
                                 AnnotationContext::RuntimeRequired => {

--- a/crates/ruff_linter/src/rules/flake8_type_checking/snapshots/ruff_linter__rules__flake8_type_checking__tests__typing-only-third-party-import_singledispatch.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_type_checking/snapshots/ruff_linter__rules__flake8_type_checking__tests__typing-only-third-party-import_singledispatch.py.snap
@@ -1,27 +1,25 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_type_checking/mod.rs
 ---
-singledispatch.py:10:20: TCH002 [*] Move third-party import `pandas.DataFrame` into a type-checking block
+singledispatch.py:11:20: TCH002 [*] Move third-party import `pandas.DataFrame` into a type-checking block
    |
- 8 | from numpy.typing import ArrayLike
- 9 | from scipy.sparse import spmatrix
-10 | from pandas import DataFrame
+ 9 | from numpy.typing import ArrayLike
+10 | from scipy.sparse import spmatrix
+11 | from pandas import DataFrame
    |                    ^^^^^^^^^ TCH002
-11 | 
-12 | if TYPE_CHECKING:
+12 | 
+13 | if TYPE_CHECKING:
    |
    = help: Move into type-checking block
 
 ℹ Unsafe fix
-7  7  | from numpy import asarray
-8  8  | from numpy.typing import ArrayLike
-9  9  | from scipy.sparse import spmatrix
-10    |-from pandas import DataFrame
-11 10 | 
-12 11 | if TYPE_CHECKING:
-   12 |+    from pandas import DataFrame
-13 13 |     from numpy import ndarray
-14 14 | 
+8  8  | from numpy import asarray
+9  9  | from numpy.typing import ArrayLike
+10 10 | from scipy.sparse import spmatrix
+11    |-from pandas import DataFrame
+12 11 | 
+13 12 | if TYPE_CHECKING:
+   13 |+    from pandas import DataFrame
+14 14 |     from numpy import ndarray
 15 15 | 
-
-
+16 16 |


### PR DESCRIPTION
## Summary

It turns out that `singledispatch` does end up evaluating all arguments, even though only the first is used to dispatch.

Closes https://github.com/astral-sh/ruff/issues/11520.
