### PR TITLE
`ruff server`: An empty code action filter no longer returns notebook source actions

### DIFF
--- a/crates/ruff_server/src/server/api/requests/code_action.rs
+++ b/crates/ruff_server/src/server/api/requests/code_action.rs
@@ -49,21 +49,17 @@ impl super::BackgroundDocumentRequestHandler for CodeActions {
             && supported_code_actions.contains(&SupportedCodeAction::SourceFixAll)
         {
             response.push(fix_all(&snapshot).with_failure_code(ErrorCode::InternalError)?);
-        }
-
-        if snapshot.client_settings().organize_imports()
-            && supported_code_actions.contains(&SupportedCodeAction::SourceOrganizeImports)
-        {
-            response.push(organize_imports(&snapshot).with_failure_code(ErrorCode::InternalError)?);
-        }
-
-        if snapshot.client_settings().fix_all()
+        } else if snapshot.client_settings().fix_all()
             && supported_code_actions.contains(&SupportedCodeAction::NotebookSourceFixAll)
         {
             response.push(notebook_fix_all(&snapshot).with_failure_code(ErrorCode::InternalError)?);
         }
 
         if snapshot.client_settings().organize_imports()
+            && supported_code_actions.contains(&SupportedCodeAction::SourceOrganizeImports)
+        {
+            response.push(organize_imports(&snapshot).with_failure_code(ErrorCode::InternalError)?);
+        } else if snapshot.client_settings().organize_imports()
             && supported_code_actions.contains(&SupportedCodeAction::NotebookSourceOrganizeImports)
         {
             response.push(

--- a/crates/ruff_server/src/server/api/requests/code_action.rs
+++ b/crates/ruff_server/src/server/api/requests/code_action.rs
@@ -45,26 +45,27 @@ impl super::BackgroundDocumentRequestHandler for CodeActions {
             response.extend(noqa_comments(&snapshot, &fixes));
         }
 
-        if snapshot.client_settings().fix_all()
-            && supported_code_actions.contains(&SupportedCodeAction::SourceFixAll)
-        {
-            response.push(fix_all(&snapshot).with_failure_code(ErrorCode::InternalError)?);
-        } else if snapshot.client_settings().fix_all()
-            && supported_code_actions.contains(&SupportedCodeAction::NotebookSourceFixAll)
-        {
-            response.push(notebook_fix_all(&snapshot).with_failure_code(ErrorCode::InternalError)?);
+        if snapshot.client_settings().fix_all() {
+            if supported_code_actions.contains(&SupportedCodeAction::SourceFixAll) {
+                response.push(fix_all(&snapshot).with_failure_code(ErrorCode::InternalError)?);
+            } else if supported_code_actions.contains(&SupportedCodeAction::NotebookSourceFixAll) {
+                response
+                    .push(notebook_fix_all(&snapshot).with_failure_code(ErrorCode::InternalError)?);
+            }
         }
 
-        if snapshot.client_settings().organize_imports()
-            && supported_code_actions.contains(&SupportedCodeAction::SourceOrganizeImports)
-        {
-            response.push(organize_imports(&snapshot).with_failure_code(ErrorCode::InternalError)?);
-        } else if snapshot.client_settings().organize_imports()
-            && supported_code_actions.contains(&SupportedCodeAction::NotebookSourceOrganizeImports)
-        {
-            response.push(
-                notebook_organize_imports(&snapshot).with_failure_code(ErrorCode::InternalError)?,
-            );
+        if snapshot.client_settings().organize_imports() {
+            if supported_code_actions.contains(&SupportedCodeAction::SourceOrganizeImports) {
+                response
+                    .push(organize_imports(&snapshot).with_failure_code(ErrorCode::InternalError)?);
+            } else if supported_code_actions
+                .contains(&SupportedCodeAction::NotebookSourceOrganizeImports)
+            {
+                response.push(
+                    notebook_organize_imports(&snapshot)
+                        .with_failure_code(ErrorCode::InternalError)?,
+                );
+            }
         }
 
         Ok(Some(response))


### PR DESCRIPTION
## Summary

Fixes #11516

`ruff server` was sending both regular source actions and notebook source actions back when passed an empty action filter. This PR makes a few small changes so that notebook source actions are not sent when regular source actions are sent, which means that an empty filter will only return regular source actions.

## Test Plan

I confirmed that duplicate code actions no longer appeared in Neovim, using a configuration similar to the one from the original issue.

<img width="509" alt="Screenshot 2024-05-23 at 11 48 48 PM" src="https://github.com/astral-sh/ruff/assets/19577865/9a5d6907-dd41-48bd-b015-8a344c5e0b3f">
