### PR TITLE
Add missing functions to NumPy 2.0 migration rule

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/numpy/NPY201.py
+++ b/crates/ruff_linter/resources/test/fixtures/numpy/NPY201.py
@@ -106,3 +106,11 @@ def func():
     np.who()
 
     np.row_stack(([1,2], [3,4]))
+
+    np.alltrue([True, True])
+
+    np.anytrue([True, False])
+
+    np.cumproduct([1, 2, 3])
+
+    np.product([1, 2, 3])

--- a/crates/ruff_linter/src/rules/numpy/rules/numpy_2_0_deprecation.rs
+++ b/crates/ruff_linter/src/rules/numpy/rules/numpy_2_0_deprecation.rs
@@ -184,6 +184,12 @@ pub(crate) fn numpy_2_0_deprecation(checker: &mut Checker, expr: &Expr) {
                     guideline: Some("`add_newdoc_ufunc` is an internal function."),
                 },
             }),
+            ["numpy", "alltrue"] => Some(Replacement {
+                existing: "alltrue",
+                details: Details::AutoPurePython {
+                    python_expr: "all",
+                },
+            }),
             ["numpy", "asfarray"] => Some(Replacement {
                 existing: "asfarray",
                 details: Details::Manual {
@@ -231,6 +237,14 @@ pub(crate) fn numpy_2_0_deprecation(checker: &mut Checker, expr: &Expr) {
                 details: Details::AutoImport {
                     path: "numpy",
                     name: "complex128",
+                    compatibility: Compatibility::BackwardsCompatible,
+                },
+            }),
+            ["numpy", "cumproduct"] => Some(Replacement {
+                existing: "cumproduct",
+                details: Details::AutoImport {
+                    path: "numpy",
+                    name: "cumprod",
                     compatibility: Compatibility::BackwardsCompatible,
                 },
             }),
@@ -420,6 +434,14 @@ pub(crate) fn numpy_2_0_deprecation(checker: &mut Checker, expr: &Expr) {
                     compatibility: Compatibility::BackwardsCompatible,
                 },
             }),
+            ["numpy", "product"] => Some(Replacement {
+                existing: "product",
+                details: Details::AutoImport {
+                    path: "numpy",
+                    name: "prod",
+                    compatibility: Compatibility::BackwardsCompatible,
+                },
+            }),
             ["numpy", "PZERO"] => Some(Replacement {
                 existing: "PZERO",
                 details: Details::AutoPurePython { python_expr: "0.0" },
@@ -490,6 +512,12 @@ pub(crate) fn numpy_2_0_deprecation(checker: &mut Checker, expr: &Expr) {
                     path: "numpy",
                     name: "bytes_",
                     compatibility: Compatibility::BackwardsCompatible,
+                },
+            }),
+            ["numpy", "sometrue"] => Some(Replacement {
+                existing: "sometrue",
+                details: Details::AutoPurePython {
+                    python_expr: "any",
                 },
             }),
             ["numpy", "source"] => Some(Replacement {

--- a/crates/ruff_linter/src/rules/numpy/snapshots/ruff_linter__rules__numpy__tests__numpy2-deprecation_NPY201.py.snap
+++ b/crates/ruff_linter/src/rules/numpy/snapshots/ruff_linter__rules__numpy__tests__numpy2-deprecation_NPY201.py.snap
@@ -854,6 +854,8 @@ NPY201.py:108:5: NPY201 [*] `np.row_stack` will be removed in NumPy 2.0. Use `nu
 107 | 
 108 |     np.row_stack(([1,2], [3,4]))
     |     ^^^^^^^^^^^^ NPY201
+109 | 
+110 |     np.alltrue([True, True])
     |
     = help: Replace with `numpy.vstack`
 
@@ -863,5 +865,65 @@ NPY201.py:108:5: NPY201 [*] `np.row_stack` will be removed in NumPy 2.0. Use `nu
 107 107 | 
 108     |-    np.row_stack(([1,2], [3,4]))
     108 |+    np.vstack(([1,2], [3,4]))
+109 109 | 
+110 110 |     np.alltrue([True, True])
+111 111 | 
+
+NPY201.py:110:5: NPY201 [*] `np.alltrue` will be removed in NumPy 2.0. Use `all` instead.
+    |
+108 |     np.row_stack(([1,2], [3,4]))
+109 | 
+110 |     np.alltrue([True, True])
+    |     ^^^^^^^^^^ NPY201
+111 | 
+112 |     np.anytrue([True, False])
+    |
+    = help: Replace with `all`
+
+ℹ Safe fix
+107 107 | 
+108 108 |     np.row_stack(([1,2], [3,4]))
+109 109 | 
+110     |-    np.alltrue([True, True])
+    110 |+    all([True, True])
+111 111 | 
+112 112 |     np.anytrue([True, False])
+113 113 | 
+
+NPY201.py:114:5: NPY201 [*] `np.cumproduct` will be removed in NumPy 2.0. Use `numpy.cumprod` instead.
+    |
+112 |     np.anytrue([True, False])
+113 | 
+114 |     np.cumproduct([1, 2, 3])
+    |     ^^^^^^^^^^^^^ NPY201
+115 | 
+116 |     np.product([1, 2, 3])
+    |
+    = help: Replace with `numpy.cumprod`
+
+ℹ Safe fix
+111 111 | 
+112 112 |     np.anytrue([True, False])
+113 113 | 
+114     |-    np.cumproduct([1, 2, 3])
+    114 |+    np.cumprod([1, 2, 3])
+115 115 | 
+116 116 |     np.product([1, 2, 3])
+
+NPY201.py:116:5: NPY201 [*] `np.product` will be removed in NumPy 2.0. Use `numpy.prod` instead.
+    |
+114 |     np.cumproduct([1, 2, 3])
+115 | 
+116 |     np.product([1, 2, 3])
+    |     ^^^^^^^^^^ NPY201
+    |
+    = help: Replace with `numpy.prod`
+
+ℹ Safe fix
+113 113 | 
+114 114 |     np.cumproduct([1, 2, 3])
+115 115 | 
+116     |-    np.product([1, 2, 3])
+    116 |+    np.prod([1, 2, 3])
 
 


### PR DESCRIPTION
Hi! 

I left out some of the functions in the migration rule which became removed in NumPy 2.0:
- `np.alltrue`
- `np.anytrue`
- `np.cumproduct`
- `np.product`

Addressing: https://github.com/numpy/numpy/issues/26493