### PR TITLE
Update token-based rules to use `Tokens`

### DIFF
--- a/crates/ruff_linter/src/linter.rs
+++ b/crates/ruff_linter/src/linter.rs
@@ -103,7 +103,7 @@ pub fn check_path(
         .any(|rule_code| rule_code.lint_source().is_tokens())
     {
         diagnostics.extend(check_tokens(
-            &program,
+            program.tokens(),
             path,
             locator,
             indexer,

--- a/crates/ruff_linter/src/rules/flake8_commas/rules/trailing_commas.rs
+++ b/crates/ruff_linter/src/rules/flake8_commas/rules/trailing_commas.rs
@@ -2,7 +2,7 @@ use ruff_diagnostics::{AlwaysFixableViolation, Violation};
 use ruff_diagnostics::{Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_index::Indexer;
-use ruff_python_parser::{TokenKind, TokenKindIter};
+use ruff_python_parser::{TokenKind, Tokens};
 use ruff_source_file::Locator;
 use ruff_text_size::{Ranged, TextRange};
 
@@ -27,31 +27,31 @@ enum TokenType {
 
 /// Simplified token specialized for the task.
 #[derive(Copy, Clone)]
-struct Token {
+struct RuleToken {
     ty: TokenType,
     range: TextRange,
 }
 
-impl Ranged for Token {
+impl Ranged for RuleToken {
     fn range(&self) -> TextRange {
         self.range
     }
 }
 
-impl Token {
+impl RuleToken {
     fn new(ty: TokenType, range: TextRange) -> Self {
         Self { ty, range }
     }
 
-    fn irrelevant() -> Token {
-        Token {
+    fn irrelevant() -> RuleToken {
+        RuleToken {
             ty: TokenType::Irrelevant,
             range: TextRange::default(),
         }
     }
 }
 
-impl From<(TokenKind, TextRange)> for Token {
+impl From<(TokenKind, TextRange)> for RuleToken {
     fn from((tok, range): (TokenKind, TextRange)) -> Self {
         let ty = match tok {
             TokenKind::Name => TokenType::Named,
@@ -226,13 +226,13 @@ impl AlwaysFixableViolation for ProhibitedTrailingComma {
 /// COM812, COM818, COM819
 pub(crate) fn trailing_commas(
     diagnostics: &mut Vec<Diagnostic>,
-    tokens: TokenKindIter,
+    tokens: &Tokens,
     locator: &Locator,
     indexer: &Indexer,
 ) {
     let mut fstrings = 0u32;
-    let tokens = tokens.filter_map(|(token, tok_range)| {
-        match token {
+    let rule_tokens = tokens.up_to_first_unknown().iter().filter_map(|token| {
+        match token.kind() {
             // Completely ignore comments -- they just interfere with the logic.
             TokenKind::Comment => None,
             // F-strings are handled as `String` token type with the complete range
@@ -247,15 +247,15 @@ pub(crate) fn trailing_commas(
                 if fstrings == 0 {
                     indexer
                         .fstring_ranges()
-                        .outermost(tok_range.start())
-                        .map(|range| Token::new(TokenType::String, range))
+                        .outermost(token.start())
+                        .map(|range| RuleToken::new(TokenType::String, range))
                 } else {
                     None
                 }
             }
             _ => {
                 if fstrings == 0 {
-                    Some(Token::from((token, tok_range)))
+                    Some(RuleToken::from(token.as_tuple()))
                 } else {
                     None
                 }
@@ -263,12 +263,12 @@ pub(crate) fn trailing_commas(
         }
     });
 
-    let mut prev = Token::irrelevant();
-    let mut prev_prev = Token::irrelevant();
+    let mut prev = RuleToken::irrelevant();
+    let mut prev_prev = RuleToken::irrelevant();
 
     let mut stack = vec![Context::new(ContextType::No)];
 
-    for token in tokens {
+    for token in rule_tokens {
         if prev.ty == TokenType::NonLogicalNewline && token.ty == TokenType::NonLogicalNewline {
             // Collapse consecutive newlines to the first one -- trailing commas are
             // added before the first newline.
@@ -301,9 +301,9 @@ pub(crate) fn trailing_commas(
 }
 
 fn check_token(
-    token: Token,
-    prev: Token,
-    prev_prev: Token,
+    token: RuleToken,
+    prev: RuleToken,
+    prev_prev: RuleToken,
     context: Context,
     locator: &Locator,
 ) -> Option<Diagnostic> {
@@ -387,9 +387,9 @@ fn check_token(
 }
 
 fn update_context(
-    token: Token,
-    prev: Token,
-    prev_prev: Token,
+    token: RuleToken,
+    prev: RuleToken,
+    prev_prev: RuleToken,
     stack: &mut Vec<Context>,
 ) -> Context {
     let new_context = match token.ty {

--- a/crates/ruff_linter/src/rules/flake8_implicit_str_concat/rules/implicit.rs
+++ b/crates/ruff_linter/src/rules/flake8_implicit_str_concat/rules/implicit.rs
@@ -4,9 +4,9 @@ use ruff_diagnostics::{Diagnostic, Edit, Fix, FixAvailability, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::str::{leading_quote, trailing_quote};
 use ruff_python_index::Indexer;
-use ruff_python_parser::{TokenKind, TokenKindIter};
+use ruff_python_parser::{TokenKind, Tokens};
 use ruff_source_file::Locator;
-use ruff_text_size::TextRange;
+use ruff_text_size::{Ranged, TextRange};
 
 use crate::settings::LinterSettings;
 
@@ -92,37 +92,39 @@ impl Violation for MultiLineImplicitStringConcatenation {
 /// ISC001, ISC002
 pub(crate) fn implicit(
     diagnostics: &mut Vec<Diagnostic>,
-    tokens: TokenKindIter,
+    tokens: &Tokens,
     settings: &LinterSettings,
     locator: &Locator,
     indexer: &Indexer,
 ) {
-    for ((a_tok, a_range), (b_tok, b_range)) in tokens
-        .filter(|(token, _)| {
-            *token != TokenKind::Comment
+    for (a_token, b_token) in tokens
+        .up_to_first_unknown()
+        .iter()
+        .filter(|token| {
+            token.kind() != TokenKind::Comment
                 && (settings.flake8_implicit_str_concat.allow_multiline
-                    || *token != TokenKind::NonLogicalNewline)
+                    || token.kind() != TokenKind::NonLogicalNewline)
         })
         .tuple_windows()
     {
-        let (a_range, b_range) = match (a_tok, b_tok) {
-            (TokenKind::String, TokenKind::String) => (a_range, b_range),
+        let (a_range, b_range) = match (a_token.kind(), b_token.kind()) {
+            (TokenKind::String, TokenKind::String) => (a_token.range(), b_token.range()),
             (TokenKind::String, TokenKind::FStringStart) => {
-                match indexer.fstring_ranges().innermost(b_range.start()) {
-                    Some(b_range) => (a_range, b_range),
+                match indexer.fstring_ranges().innermost(a_token.start()) {
+                    Some(b_range) => (a_token.range(), b_range),
                     None => continue,
                 }
             }
             (TokenKind::FStringEnd, TokenKind::String) => {
-                match indexer.fstring_ranges().innermost(a_range.start()) {
-                    Some(a_range) => (a_range, b_range),
+                match indexer.fstring_ranges().innermost(a_token.start()) {
+                    Some(a_range) => (a_range, b_token.range()),
                     None => continue,
                 }
             }
             (TokenKind::FStringEnd, TokenKind::FStringStart) => {
                 match (
-                    indexer.fstring_ranges().innermost(a_range.start()),
-                    indexer.fstring_ranges().innermost(b_range.start()),
+                    indexer.fstring_ranges().innermost(a_token.start()),
+                    indexer.fstring_ranges().innermost(b_token.start()),
                 ) {
                     (Some(a_range), Some(b_range)) => (a_range, b_range),
                     _ => continue,

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/compound_statements.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/compound_statements.rs
@@ -1,7 +1,9 @@
+use std::slice::Iter;
+
 use ruff_notebook::CellOffsets;
 use ruff_python_ast::PySourceType;
-use ruff_python_parser::{TokenKind, TokenKindIter};
-use ruff_text_size::{TextRange, TextSize};
+use ruff_python_parser::{Token, TokenKind, Tokens};
+use ruff_text_size::{Ranged, TextRange, TextSize};
 
 use ruff_diagnostics::{AlwaysFixableViolation, Violation};
 use ruff_diagnostics::{Diagnostic, Edit, Fix};
@@ -99,7 +101,7 @@ impl AlwaysFixableViolation for UselessSemicolon {
 /// E701, E702, E703
 pub(crate) fn compound_statements(
     diagnostics: &mut Vec<Diagnostic>,
-    mut tokens: TokenKindIter,
+    tokens: &Tokens,
     locator: &Locator,
     indexer: &Indexer,
     source_type: PySourceType,
@@ -125,33 +127,26 @@ pub(crate) fn compound_statements(
     // This is used to allow `class C: ...`-style definitions in stubs.
     let mut allow_ellipsis = false;
 
-    // Track the bracket depth.
-    let mut par_count = 0u32;
-    let mut sqb_count = 0u32;
-    let mut brace_count = 0u32;
+    // Track the nesting level.
+    let mut nesting = 0u32;
 
     // Track indentation.
     let mut indent = 0u32;
 
-    while let Some((token, range)) = tokens.next() {
-        match token {
-            TokenKind::Lpar => {
-                par_count = par_count.saturating_add(1);
+    // Use an iterator to allow passing it around.
+    let mut token_iter = tokens.up_to_first_unknown().iter();
+
+    loop {
+        let Some(token) = token_iter.next() else {
+            break;
+        };
+
+        match token.kind() {
+            TokenKind::Lpar | TokenKind::Lsqb | TokenKind::Lbrace => {
+                nesting = nesting.saturating_add(1);
             }
-            TokenKind::Rpar => {
-                par_count = par_count.saturating_sub(1);
-            }
-            TokenKind::Lsqb => {
-                sqb_count = sqb_count.saturating_add(1);
-            }
-            TokenKind::Rsqb => {
-                sqb_count = sqb_count.saturating_sub(1);
-            }
-            TokenKind::Lbrace => {
-                brace_count = brace_count.saturating_add(1);
-            }
-            TokenKind::Rbrace => {
-                brace_count = brace_count.saturating_sub(1);
+            TokenKind::Rpar | TokenKind::Rsqb | TokenKind::Rbrace => {
+                nesting = nesting.saturating_sub(1);
             }
             TokenKind::Ellipsis => {
                 if allow_ellipsis {
@@ -168,28 +163,27 @@ pub(crate) fn compound_statements(
             _ => {}
         }
 
-        if par_count > 0 || sqb_count > 0 || brace_count > 0 {
+        if nesting > 0 {
             continue;
         }
 
-        match token {
+        match token.kind() {
             TokenKind::Newline => {
-                if let Some((start, end)) = semi {
+                if let Some(range) = semi {
                     if !(source_type.is_ipynb()
                         && indent == 0
                         && cell_offsets
-                            .and_then(|cell_offsets| cell_offsets.containing_range(range.start()))
+                            .and_then(|cell_offsets| cell_offsets.containing_range(token.start()))
                             .is_some_and(|cell_range| {
-                                !has_non_trivia_tokens_till(tokens.clone(), cell_range.end())
+                                !has_non_trivia_tokens_till(token_iter.clone(), cell_range.end())
                             }))
                     {
-                        let mut diagnostic =
-                            Diagnostic::new(UselessSemicolon, TextRange::new(start, end));
+                        let mut diagnostic = Diagnostic::new(UselessSemicolon, range);
                         diagnostic.set_fix(Fix::safe_edit(Edit::deletion(
                             indexer
-                                .preceded_by_continuations(start, locator)
-                                .unwrap_or(start),
-                            end,
+                                .preceded_by_continuations(range.start(), locator)
+                                .unwrap_or(range.start()),
+                            range.end(),
                         )));
                         diagnostics.push(diagnostic);
                     }
@@ -225,14 +219,14 @@ pub(crate) fn compound_statements(
                     || while_.is_some()
                     || with.is_some()
                 {
-                    colon = Some((range.start(), range.end()));
+                    colon = Some(token.range());
 
                     // Allow `class C: ...`-style definitions.
                     allow_ellipsis = true;
                 }
             }
             TokenKind::Semi => {
-                semi = Some((range.start(), range.end()));
+                semi = Some(token.range());
                 allow_ellipsis = false;
             }
             TokenKind::Comment
@@ -240,22 +234,16 @@ pub(crate) fn compound_statements(
             | TokenKind::Dedent
             | TokenKind::NonLogicalNewline => {}
             _ => {
-                if let Some((start, end)) = semi {
-                    diagnostics.push(Diagnostic::new(
-                        MultipleStatementsOnOneLineSemicolon,
-                        TextRange::new(start, end),
-                    ));
+                if let Some(range) = semi {
+                    diagnostics.push(Diagnostic::new(MultipleStatementsOnOneLineSemicolon, range));
 
                     // Reset.
                     semi = None;
                     allow_ellipsis = false;
                 }
 
-                if let Some((start, end)) = colon {
-                    diagnostics.push(Diagnostic::new(
-                        MultipleStatementsOnOneLineColon,
-                        TextRange::new(start, end),
-                    ));
+                if let Some(range) = colon {
+                    diagnostics.push(Diagnostic::new(MultipleStatementsOnOneLineColon, range));
 
                     // Reset.
                     colon = None;
@@ -276,7 +264,7 @@ pub(crate) fn compound_statements(
             }
         }
 
-        match token {
+        match token.kind() {
             TokenKind::Lambda => {
                 // Reset.
                 colon = None;
@@ -294,40 +282,40 @@ pub(crate) fn compound_statements(
                 with = None;
             }
             TokenKind::Case => {
-                case = Some((range.start(), range.end()));
+                case = Some(token.range());
             }
             TokenKind::If => {
-                if_ = Some((range.start(), range.end()));
+                if_ = Some(token.range());
             }
             TokenKind::While => {
-                while_ = Some((range.start(), range.end()));
+                while_ = Some(token.range());
             }
             TokenKind::For => {
-                for_ = Some((range.start(), range.end()));
+                for_ = Some(token.range());
             }
             TokenKind::Try => {
-                try_ = Some((range.start(), range.end()));
+                try_ = Some(token.range());
             }
             TokenKind::Except => {
-                except = Some((range.start(), range.end()));
+                except = Some(token.range());
             }
             TokenKind::Finally => {
-                finally = Some((range.start(), range.end()));
+                finally = Some(token.range());
             }
             TokenKind::Elif => {
-                elif = Some((range.start(), range.end()));
+                elif = Some(token.range());
             }
             TokenKind::Else => {
-                else_ = Some((range.start(), range.end()));
+                else_ = Some(token.range());
             }
             TokenKind::Class => {
-                class = Some((range.start(), range.end()));
+                class = Some(token.range());
             }
             TokenKind::With => {
-                with = Some((range.start(), range.end()));
+                with = Some(token.range());
             }
             TokenKind::Match => {
-                match_ = Some((range.start(), range.end()));
+                match_ = Some(token.range());
             }
             _ => {}
         };
@@ -336,13 +324,13 @@ pub(crate) fn compound_statements(
 
 /// Returns `true` if there are any non-trivia tokens from the given token
 /// iterator till the given end offset.
-fn has_non_trivia_tokens_till(tokens: TokenKindIter, cell_end: TextSize) -> bool {
-    for (token, tok_range) in tokens {
-        if tok_range.start() >= cell_end {
+fn has_non_trivia_tokens_till(tokens: Iter<'_, Token>, cell_end: TextSize) -> bool {
+    for token in tokens {
+        if token.start() >= cell_end {
             return false;
         }
         if !matches!(
-            token,
+            token.kind(),
             TokenKind::Newline
                 | TokenKind::Comment
                 | TokenKind::EndOfFile

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/too_many_newlines_at_end_of_file.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/too_many_newlines_at_end_of_file.rs
@@ -1,6 +1,6 @@
 use ruff_diagnostics::{AlwaysFixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
-use ruff_python_parser::{TokenKind, TokenKindIter};
+use ruff_python_parser::{TokenKind, Tokens};
 use ruff_text_size::{TextRange, TextSize};
 
 /// ## What it does
@@ -54,22 +54,19 @@ impl AlwaysFixableViolation for TooManyNewlinesAtEndOfFile {
 }
 
 /// W391
-pub(crate) fn too_many_newlines_at_end_of_file(
-    diagnostics: &mut Vec<Diagnostic>,
-    tokens: TokenKindIter,
-) {
+pub(crate) fn too_many_newlines_at_end_of_file(diagnostics: &mut Vec<Diagnostic>, tokens: &Tokens) {
     let mut num_trailing_newlines = 0u32;
     let mut start: Option<TextSize> = None;
     let mut end: Option<TextSize> = None;
 
     // Count the number of trailing newlines.
-    for (token, range) in tokens.rev() {
-        match token {
+    for token in tokens.up_to_first_unknown().iter().rev() {
+        match token.kind() {
             TokenKind::NonLogicalNewline | TokenKind::Newline => {
                 if num_trailing_newlines == 0 {
-                    end = Some(range.end());
+                    end = Some(token.end());
                 }
-                start = Some(range.end());
+                start = Some(token.end());
                 num_trailing_newlines += 1;
             }
             TokenKind::Dedent => continue,

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/extraneous_parentheses.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/extraneous_parentheses.rs
@@ -1,5 +1,7 @@
-use ruff_python_parser::{TokenKind, TokenKindIter};
-use ruff_text_size::TextRange;
+use std::slice::Iter;
+
+use ruff_python_parser::{Token, TokenKind, Tokens};
+use ruff_text_size::{Ranged, TextRange};
 
 use ruff_diagnostics::{AlwaysFixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
@@ -36,17 +38,17 @@ impl AlwaysFixableViolation for ExtraneousParentheses {
 }
 
 // See: https://github.com/asottile/pyupgrade/blob/97ed6fb3cf2e650d4f762ba231c3f04c41797710/pyupgrade/_main.py#L148
-fn match_extraneous_parentheses(tokens: &mut TokenKindIter) -> Option<(TextRange, TextRange)> {
+fn match_extraneous_parentheses(mut tokens: Iter<'_, Token>) -> Option<(TextRange, TextRange)> {
     // Store the location of the extraneous opening parenthesis.
     let start_range = loop {
-        let (token, range) = tokens.next()?;
+        let token = tokens.next()?;
 
-        match token {
+        match token.kind() {
             TokenKind::Comment | TokenKind::NonLogicalNewline => {
                 continue;
             }
             TokenKind::Lpar => {
-                break range;
+                break token.range();
             }
             _ => {
                 return None;
@@ -62,22 +64,28 @@ fn match_extraneous_parentheses(tokens: &mut TokenKindIter) -> Option<(TextRange
 
     // Store the location of the extraneous closing parenthesis.
     let end_range = loop {
-        let (token, range) = tokens.next()?;
+        let token = tokens.next()?;
 
-        // If we find a comma or a yield at depth 1 or 2, it's a tuple or coroutine.
-        if depth == 1 && matches!(token, TokenKind::Comma | TokenKind::Yield) {
-            return None;
-        } else if matches!(token, TokenKind::Lpar | TokenKind::Lbrace | TokenKind::Lsqb) {
-            depth = depth.saturating_add(1);
-        } else if matches!(token, TokenKind::Rpar | TokenKind::Rbrace | TokenKind::Rsqb) {
-            depth = depth.saturating_sub(1);
+        match token.kind() {
+            // If we find a comma or a yield at depth 1 or 2, it's a tuple or coroutine.
+            TokenKind::Comma | TokenKind::Yield if depth == 1 => return None,
+            TokenKind::Lpar | TokenKind::Lbrace | TokenKind::Lsqb => {
+                depth = depth.saturating_add(1)
+            }
+            TokenKind::Rpar | TokenKind::Rbrace | TokenKind::Rsqb => {
+                depth = depth.saturating_sub(1)
+            }
+            _ => {}
         }
 
         if depth == 0 {
-            break range;
+            break token.range();
         }
 
-        if !matches!(token, TokenKind::Comment | TokenKind::NonLogicalNewline) {
+        if !matches!(
+            token.kind(),
+            TokenKind::Comment | TokenKind::NonLogicalNewline
+        ) {
             empty_tuple = false;
         }
     };
@@ -88,9 +96,9 @@ fn match_extraneous_parentheses(tokens: &mut TokenKindIter) -> Option<(TextRange
 
     // Find the next non-coding token.
     let token = loop {
-        let (token, _) = tokens.next()?;
+        let token = tokens.next()?;
 
-        match token {
+        match token.kind() {
             TokenKind::Comment | TokenKind::NonLogicalNewline => continue,
             _ => {
                 break token;
@@ -98,7 +106,7 @@ fn match_extraneous_parentheses(tokens: &mut TokenKindIter) -> Option<(TextRange
         }
     };
 
-    if matches!(token, TokenKind::Rpar) {
+    if matches!(token.kind(), TokenKind::Rpar) {
         Some((start_range, end_range))
     } else {
         None
@@ -108,15 +116,16 @@ fn match_extraneous_parentheses(tokens: &mut TokenKindIter) -> Option<(TextRange
 /// UP034
 pub(crate) fn extraneous_parentheses(
     diagnostics: &mut Vec<Diagnostic>,
-    mut tokens: TokenKindIter,
+    tokens: &Tokens,
     locator: &Locator,
 ) {
-    while let Some((token, _)) = tokens.next() {
-        if !matches!(token, TokenKind::Lpar) {
+    let mut token_iter = tokens.up_to_first_unknown().iter();
+    while let Some(token) = token_iter.next() {
+        if !matches!(token.kind(), TokenKind::Lpar) {
             continue;
         }
 
-        let Some((start_range, end_range)) = match_extraneous_parentheses(&mut tokens) else {
+        let Some((start_range, end_range)) = match_extraneous_parentheses(&mut token_iter) else {
             continue;
         };
 

--- a/crates/ruff_python_parser/src/lexer.rs
+++ b/crates/ruff_python_parser/src/lexer.rs
@@ -1362,16 +1362,21 @@ impl Token {
         Self { kind, range }
     }
 
+    /// Returns the token kind.
     #[inline]
     pub const fn kind(&self) -> TokenKind {
         self.kind
     }
 
-    pub(crate) const fn is_comment(self) -> bool {
-        matches!(self.kind, TokenKind::Comment)
+    /// Returns the token as a tuple of (kind, range).
+    #[inline]
+    pub const fn as_tuple(&self) -> (TokenKind, TextRange) {
+        (self.kind, self.range)
     }
 
-    pub(crate) const fn is_trivia(self) -> bool {
+    /// Returns `true` if this is a trivia token.
+    #[inline]
+    pub const fn is_trivia(self) -> bool {
         matches!(self.kind, TokenKind::Comment | TokenKind::NonLogicalNewline)
     }
 }


### PR DESCRIPTION
## Summary

This PR updates the token-based rules to use the `Tokens` struct instead of the iterator approach used earlier.

This also adds a new method on `Tokens`:
* `as_tuple` which returns a tuple of `(TokenKind, TextRange)`
