### PR TITLE
Use project-relative path when calculating gitlab message fingerprint

### DIFF
--- a/crates/ruff_linter/src/message/gitlab.rs
+++ b/crates/ruff_linter/src/message/gitlab.rs
@@ -82,12 +82,12 @@ impl Serialize for SerializedMessages<'_> {
                 |project_dir| relativize_path_to(message.filename(), project_dir),
             );
 
-            let mut message_fingerprint = fingerprint(message, 0);
+            let mut message_fingerprint = fingerprint(message, &path, 0);
 
             // Make sure that we do not get a fingerprint that is already in use
             // by adding in the previously generated one.
             while fingerprints.contains(&message_fingerprint) {
-                message_fingerprint = fingerprint(message, message_fingerprint);
+                message_fingerprint = fingerprint(message, &path, message_fingerprint);
             }
             fingerprints.insert(message_fingerprint);
 
@@ -109,12 +109,12 @@ impl Serialize for SerializedMessages<'_> {
 }
 
 /// Generate a unique fingerprint to identify a violation.
-fn fingerprint(message: &Message, salt: u64) -> u64 {
+fn fingerprint(message: &Message, project_path: &str, salt: u64) -> u64 {
     let Message {
         kind,
         range: _,
         fix: _fix,
-        file,
+        file: _,
         noqa_offset: _,
     } = message;
 
@@ -122,7 +122,7 @@ fn fingerprint(message: &Message, salt: u64) -> u64 {
 
     salt.hash(&mut hasher);
     kind.name.hash(&mut hasher);
-    file.name().hash(&mut hasher);
+    project_path.hash(&mut hasher);
 
     hasher.finish()
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Concurrent GitLab runners clone projects into separate directories, e.g. `{builds_dir}/$RUNNER_TOKEN_KEY/$CONCURRENT_ID/$NAMESPACE/$PROJECT_NAME`. Since the fingerprint uses the full path to the file, the fingerprints calculated by Ruff are different depending on which concurrent runner it executes on, so often an MR will appear to remove all existing issues and add them with new fingerprints.

I've adjusted the fingerprint function to use the project relative path, which fixes this. Unfortunately this will have a breaking change for any current users of this output - the fingerprints will change and appear in GitLab as all linting messages having been fixed and then created.

## Test Plan

<!-- How was it tested? -->
`cargo nextest run`

Running `ruff check --output-format gitlab` in a git repo, moving the repo and running again, verifying no diffs between the outputs
