### PR TITLE
`ruff server` correctly treats `.pyi` files as stub files

### DIFF
--- a/crates/ruff_server/src/session/index.rs
+++ b/crates/ruff_server/src/session/index.rs
@@ -465,7 +465,7 @@ impl DocumentQuery {
     /// Get the source type of the document associated with this query.
     pub(crate) fn source_type(&self) -> ruff_python_ast::PySourceType {
         match self {
-            Self::Text { .. } => ruff_python_ast::PySourceType::Python,
+            Self::Text { .. } => ruff_python_ast::PySourceType::from(self.file_path()),
             Self::Notebook { .. } => ruff_python_ast::PySourceType::Ipynb,
         }
     }


### PR DESCRIPTION
## Summary

Fixes #11534.

`DocumentQuery::source_type` now returns `PySourceType::Stub` when the document is a `.pyi` file.

## Test Plan

I confirmed that stub-specific rule violations appeared with a build from this PR (they were not visible from a `main` build).

<img width="1066" alt="Screenshot 2024-05-24 at 2 15 38 PM" src="https://github.com/astral-sh/ruff/assets/19577865/cd519b7e-21e4-41c8-bc30-43eb6d4d438e">
