### PR TITLE
`ruff server` searches for configuration in parent directories

### DIFF
--- a/crates/ruff_server/src/session/index/ruff_settings.rs
+++ b/crates/ruff_server/src/session/index/ruff_settings.rs
@@ -85,6 +85,10 @@ impl RuffSettingsIndex {
         // Add any settings from above the workspace root.
         for directory in root.ancestors() {
             if let Some(pyproject) = settings_toml(directory).ok().flatten() {
+                if index.contains_key(&pyproject) {
+                    continue;
+                }
+
                 let Ok(settings) = ruff_workspace::resolver::resolve_root_settings(
                     &pyproject,
                     Relativity::Parent,
@@ -111,6 +115,10 @@ impl RuffSettingsIndex {
             .map(DirEntry::into_path)
         {
             if let Some(pyproject) = settings_toml(&directory).ok().flatten() {
+                if index.contains_key(&pyproject) {
+                    continue;
+                }
+
                 let Ok(settings) = ruff_workspace::resolver::resolve_root_settings(
                     &pyproject,
                     Relativity::Parent,

--- a/crates/ruff_server/src/session/index/ruff_settings.rs
+++ b/crates/ruff_server/src/session/index/ruff_settings.rs
@@ -4,7 +4,7 @@ use ruff_linter::{
 };
 use ruff_workspace::{
     configuration::{Configuration, FormatConfiguration, LintConfiguration, RuleSelection},
-    pyproject::{find_user_settings_toml, settings_toml},
+    pyproject::{find_settings_toml, find_user_settings_toml},
     resolver::{ConfigurationTransformer, Relativity},
 };
 use std::{
@@ -88,7 +88,11 @@ impl RuffSettingsIndex {
             .filter(|entry| entry.file_type().is_dir())
             .map(DirEntry::into_path)
         {
-            if let Some(pyproject) = settings_toml(&directory).ok().flatten() {
+            if let Some(pyproject) = find_settings_toml(&directory).ok().flatten() {
+                if index.contains_key(&pyproject) {
+                    continue;
+                }
+
                 let Ok(settings) = ruff_workspace::resolver::resolve_root_settings(
                     &pyproject,
                     Relativity::Parent,


### PR DESCRIPTION
## Summary

Fixes #11506.

`RuffSettingsIndex::new` now searches for configuration files in parent directories.

## Test Plan

I confirmed that the original test case described in the issue worked as expected.
