### PR TITLE
[`flake8-2020`] fix minor typo in `YTT301` documentation

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_2020/rules/subscript.rs
+++ b/crates/ruff_linter/src/rules/flake8_2020/rules/subscript.rs
@@ -93,7 +93,7 @@ impl Violation for SysVersion2 {
 /// ## Why is this bad?
 /// If the current major or minor version consists of multiple digits,
 /// `sys.version[0]` will select the first digit of the major version number
-/// only (e.g., `"3.10"` would evaluate to `"1"`). This is likely unintended,
+/// only (e.g., `"10.2"` would evaluate to `"1"`). This is likely unintended,
 /// and can lead to subtle bugs if the version string is used to test against a
 /// major version number.
 ///


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->
Current doc says `sys.version[0]` will select the first digit of a major version number (correct) then as an example says 

> e.g., `"3.10"` would evaluate to `"1"`

(would actually evaluate to `"3"`). Changed the example version to a two-digit number to make the problem more clear.

## Test Plan

<!-- How was it tested? -->
ran the following:
- `cargo run -p ruff -- check crates/ruff_linter/resources/test/fixtures/flake8_2020/YTT301.py --no-cache`
- `cargo insta review`
- `cargo test`
which all passed.