### PR TITLE
[`flake8-self`] Ignore sunder accesses in `flake8-self` rule

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_self/SLF001.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_self/SLF001.py
@@ -77,3 +77,8 @@ print(foo._asdict())
 import os
 
 os._exit()
+
+
+from enum import Enum
+
+Enum._missing_(1)  # OK

--- a/crates/ruff_linter/src/rules/flake8_self/rules/private_member_access.rs
+++ b/crates/ruff_linter/src/rules/flake8_self/rules/private_member_access.rs
@@ -20,6 +20,9 @@ use crate::checkers::ast::Checker;
 /// versions, that it will have the same type, or that it will have the same
 /// behavior. Instead, use the class's public interface.
 ///
+/// This rule ignores accesses on dunder methods (e.g., `__init__`) and sunder
+/// methods (e.g., `_missing_`).
+///
 /// ## Example
 /// ```python
 /// class Class:
@@ -70,128 +73,143 @@ pub(crate) fn private_member_access(checker: &mut Checker, expr: &Expr) {
         return;
     }
 
-    if (attr.starts_with("__") && !attr.ends_with("__"))
-        || (attr.starts_with('_') && !attr.starts_with("__"))
+    // Ignore non-private accesses.
+    if !attr.starts_with('_') {
+        return;
+    }
+
+    // Ignore dunder accesses.
+    let is_dunder = attr.starts_with("__") && attr.ends_with("__");
+    if is_dunder {
+        return;
+    }
+
+    // Ignore sunder accesses.
+    let is_sunder = attr.starts_with('_')
+        && attr.ends_with('_')
+        && !attr.starts_with("__")
+        && !attr.ends_with("__");
+    if is_sunder {
+        return;
+    }
+
+    if checker
+        .settings
+        .flake8_self
+        .ignore_names
+        .contains(attr.as_ref())
     {
+        return;
+    }
+
+    // Ignore accesses on instances within special methods (e.g., `__eq__`).
+    if let ScopeKind::Function(ast::StmtFunctionDef { name, .. }) =
+        checker.semantic().current_scope().kind
+    {
+        if matches!(
+            name.as_str(),
+            "__lt__"
+                | "__le__"
+                | "__eq__"
+                | "__ne__"
+                | "__gt__"
+                | "__ge__"
+                | "__add__"
+                | "__sub__"
+                | "__mul__"
+                | "__matmul__"
+                | "__truediv__"
+                | "__floordiv__"
+                | "__mod__"
+                | "__divmod__"
+                | "__pow__"
+                | "__lshift__"
+                | "__rshift__"
+                | "__and__"
+                | "__xor__"
+                | "__or__"
+                | "__radd__"
+                | "__rsub__"
+                | "__rmul__"
+                | "__rmatmul__"
+                | "__rtruediv__"
+                | "__rfloordiv__"
+                | "__rmod__"
+                | "__rdivmod__"
+                | "__rpow__"
+                | "__rlshift__"
+                | "__rrshift__"
+                | "__rand__"
+                | "__rxor__"
+                | "__ror__"
+                | "__iadd__"
+                | "__isub__"
+                | "__imul__"
+                | "__imatmul__"
+                | "__itruediv__"
+                | "__ifloordiv__"
+                | "__imod__"
+                | "__ipow__"
+                | "__ilshift__"
+                | "__irshift__"
+                | "__iand__"
+                | "__ixor__"
+                | "__ior__"
+        ) {
+            return;
+        }
+    }
+
+    // Allow some documented private methods, like `os._exit()`.
+    if let Some(qualified_name) = checker.semantic().resolve_qualified_name(expr) {
+        if matches!(qualified_name.segments(), ["os", "_exit"]) {
+            return;
+        }
+    }
+
+    if let Expr::Call(ast::ExprCall { func, .. }) = value.as_ref() {
+        // Ignore `super()` calls.
+        if let Some(name) = UnqualifiedName::from_expr(func) {
+            if matches!(name.segments(), ["super"]) {
+                return;
+            }
+        }
+    }
+
+    if let Some(name) = UnqualifiedName::from_expr(value) {
+        // Ignore `self` and `cls` accesses.
+        if matches!(name.segments(), ["self" | "cls" | "mcs"]) {
+            return;
+        }
+    }
+
+    if let Expr::Name(name) = value.as_ref() {
+        // Ignore accesses on class members from _within_ the class.
         if checker
-            .settings
-            .flake8_self
-            .ignore_names
-            .contains(attr.as_ref())
+            .semantic()
+            .resolve_name(name)
+            .and_then(|id| {
+                if let BindingKind::ClassDefinition(scope) = checker.semantic().binding(id).kind {
+                    Some(scope)
+                } else {
+                    None
+                }
+            })
+            .is_some_and(|scope| {
+                checker
+                    .semantic()
+                    .current_scope_ids()
+                    .any(|parent| scope == parent)
+            })
         {
             return;
         }
-
-        // Ignore accesses on instances within special methods (e.g., `__eq__`).
-        if let ScopeKind::Function(ast::StmtFunctionDef { name, .. }) =
-            checker.semantic().current_scope().kind
-        {
-            if matches!(
-                name.as_str(),
-                "__lt__"
-                    | "__le__"
-                    | "__eq__"
-                    | "__ne__"
-                    | "__gt__"
-                    | "__ge__"
-                    | "__add__"
-                    | "__sub__"
-                    | "__mul__"
-                    | "__matmul__"
-                    | "__truediv__"
-                    | "__floordiv__"
-                    | "__mod__"
-                    | "__divmod__"
-                    | "__pow__"
-                    | "__lshift__"
-                    | "__rshift__"
-                    | "__and__"
-                    | "__xor__"
-                    | "__or__"
-                    | "__radd__"
-                    | "__rsub__"
-                    | "__rmul__"
-                    | "__rmatmul__"
-                    | "__rtruediv__"
-                    | "__rfloordiv__"
-                    | "__rmod__"
-                    | "__rdivmod__"
-                    | "__rpow__"
-                    | "__rlshift__"
-                    | "__rrshift__"
-                    | "__rand__"
-                    | "__rxor__"
-                    | "__ror__"
-                    | "__iadd__"
-                    | "__isub__"
-                    | "__imul__"
-                    | "__imatmul__"
-                    | "__itruediv__"
-                    | "__ifloordiv__"
-                    | "__imod__"
-                    | "__ipow__"
-                    | "__ilshift__"
-                    | "__irshift__"
-                    | "__iand__"
-                    | "__ixor__"
-                    | "__ior__"
-            ) {
-                return;
-            }
-        }
-
-        // Allow some documented private methods, like `os._exit()`.
-        if let Some(qualified_name) = checker.semantic().resolve_qualified_name(expr) {
-            if matches!(qualified_name.segments(), ["os", "_exit"]) {
-                return;
-            }
-        }
-
-        if let Expr::Call(ast::ExprCall { func, .. }) = value.as_ref() {
-            // Ignore `super()` calls.
-            if let Some(name) = UnqualifiedName::from_expr(func) {
-                if matches!(name.segments(), ["super"]) {
-                    return;
-                }
-            }
-        }
-
-        if let Some(name) = UnqualifiedName::from_expr(value) {
-            // Ignore `self` and `cls` accesses.
-            if matches!(name.segments(), ["self" | "cls" | "mcs"]) {
-                return;
-            }
-        }
-
-        if let Expr::Name(name) = value.as_ref() {
-            // Ignore accesses on class members from _within_ the class.
-            if checker
-                .semantic()
-                .resolve_name(name)
-                .and_then(|id| {
-                    if let BindingKind::ClassDefinition(scope) = checker.semantic().binding(id).kind
-                    {
-                        Some(scope)
-                    } else {
-                        None
-                    }
-                })
-                .is_some_and(|scope| {
-                    checker
-                        .semantic()
-                        .current_scope_ids()
-                        .any(|parent| scope == parent)
-                })
-            {
-                return;
-            }
-        }
-
-        checker.diagnostics.push(Diagnostic::new(
-            PrivateMemberAccess {
-                access: attr.to_string(),
-            },
-            expr.range(),
-        ));
     }
+
+    checker.diagnostics.push(Diagnostic::new(
+        PrivateMemberAccess {
+            access: attr.to_string(),
+        },
+        expr.range(),
+    ));
 }


### PR DESCRIPTION
## Summary

We already ignore dunders, so ignoring sunders (as in https://docs.python.org/3/library/enum.html#supported-sunder-names) makes sense to me.