### PR TITLE
Create intermediary directories for `--output-file`

### DIFF
--- a/crates/ruff/src/lib.rs
+++ b/crates/ruff/src/lib.rs
@@ -237,6 +237,9 @@ pub fn check(args: CheckCommand, global_options: GlobalConfigArgs) -> Result<Exi
     let mut writer: Box<dyn Write> = match cli.output_file {
         Some(path) if !cli.watch => {
             colored::control::set_override(false);
+            if let Some(parent) = path.parent() {
+                std::fs::create_dir_all(parent)?;
+            }
             let file = File::create(path)?;
             Box::new(BufWriter::new(file))
         }


### PR DESCRIPTION
Closes https://github.com/astral-sh/ruff/issues/11549.