### PR TITLE
Update lexer to only emit the `TokenKind`

### DIFF
--- a/crates/ruff_python_parser/src/lexer.rs
+++ b/crates/ruff_python_parser/src/lexer.rs
@@ -807,6 +807,7 @@ impl<'src> Lexer<'src> {
     /// Lex the next token.
     pub(crate) fn next_token(&mut self) -> TokenKind {
         self.cursor.start_token();
+        self.current_value = TokenValue::None;
         self.current_kind = self.lex_token();
         self.current_range = self.token_range();
         self.current_kind


### PR DESCRIPTION
## Summary

This PR updates the lexer to only emit `TokenKind` instead of the `Token` struct.

The token source will construct the `Token` struct right before adding it to the token vector.
