### PR TITLE
Implement a common trait for the string flags

### DIFF
--- a/crates/ruff_linter/src/directives.rs
+++ b/crates/ruff_linter/src/directives.rs
@@ -4,6 +4,7 @@ use std::iter::Peekable;
 use std::str::FromStr;
 
 use bitflags::bitflags;
+use ruff_python_ast::StringFlags;
 use ruff_python_parser::lexer::LexResult;
 use ruff_python_parser::Tok;
 use ruff_text_size::{Ranged, TextLen, TextRange, TextSize};

--- a/crates/ruff_linter/src/rules/flake8_quotes/helpers.rs
+++ b/crates/ruff_linter/src/rules/flake8_quotes/helpers.rs
@@ -1,9 +1,9 @@
-use ruff_python_ast::AnyStringFlags;
+use ruff_python_ast::AbstractStringFlags;
 use ruff_text_size::TextLen;
 
 /// Returns the raw contents of the string given the string's contents and flags.
 /// This is a string without the prefix and quotes.
-pub(super) fn raw_contents(contents: &str, flags: AnyStringFlags) -> &str {
+pub(super) fn raw_contents(contents: &str, flags: impl AbstractStringFlags) -> &str {
     &contents[flags.opener_len().to_usize()..(contents.text_len() - flags.closer_len()).to_usize()]
 }
 

--- a/crates/ruff_linter/src/rules/flake8_quotes/helpers.rs
+++ b/crates/ruff_linter/src/rules/flake8_quotes/helpers.rs
@@ -1,9 +1,9 @@
-use ruff_python_ast::AbstractStringFlags;
+use ruff_python_ast::{AnyStringFlags, StringFlags};
 use ruff_text_size::TextLen;
 
 /// Returns the raw contents of the string given the string's contents and flags.
 /// This is a string without the prefix and quotes.
-pub(super) fn raw_contents(contents: &str, flags: impl AbstractStringFlags) -> &str {
+pub(super) fn raw_contents(contents: &str, flags: AnyStringFlags) -> &str {
     &contents[flags.opener_len().to_usize()..(contents.text_len() - flags.closer_len()).to_usize()]
 }
 

--- a/crates/ruff_linter/src/rules/flake8_quotes/rules/avoidable_escaped_quote.rs
+++ b/crates/ruff_linter/src/rules/flake8_quotes/rules/avoidable_escaped_quote.rs
@@ -1,7 +1,7 @@
 use ruff_diagnostics::{AlwaysFixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::visitor::{walk_f_string, Visitor};
-use ruff_python_ast::{self as ast, AnyStringFlags, StringLike};
+use ruff_python_ast::{self as ast, AnyStringFlags, StringFlags, StringLike};
 use ruff_source_file::Locator;
 use ruff_text_size::{Ranged, TextRange, TextSize};
 

--- a/crates/ruff_linter/src/rules/flake8_quotes/rules/unnecessary_escaped_quote.rs
+++ b/crates/ruff_linter/src/rules/flake8_quotes/rules/unnecessary_escaped_quote.rs
@@ -1,6 +1,6 @@
 use ruff_diagnostics::{AlwaysFixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
-use ruff_python_ast::{self as ast, AbstractStringFlags, AnyStringFlags, StringLike};
+use ruff_python_ast::{self as ast, AnyStringFlags, StringFlags, StringLike};
 use ruff_source_file::Locator;
 use ruff_text_size::{Ranged, TextRange};
 

--- a/crates/ruff_linter/src/rules/flake8_quotes/rules/unnecessary_escaped_quote.rs
+++ b/crates/ruff_linter/src/rules/flake8_quotes/rules/unnecessary_escaped_quote.rs
@@ -1,6 +1,6 @@
 use ruff_diagnostics::{AlwaysFixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
-use ruff_python_ast::{self as ast, AnyStringFlags, StringLike};
+use ruff_python_ast::{self as ast, AbstractStringFlags, AnyStringFlags, StringLike};
 use ruff_source_file::Locator;
 use ruff_text_size::{Ranged, TextRange};
 

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/invalid_escape_sequence.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/invalid_escape_sequence.rs
@@ -2,7 +2,7 @@ use memchr::memchr_iter;
 
 use ruff_diagnostics::{AlwaysFixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
-use ruff_python_ast::{AnyStringFlags, FStringElement, StringFlags, StringLike, StringLikePart};
+use ruff_python_ast::{AnyStringFlags, FStringElement, StringLike, StringLikePart};
 use ruff_source_file::Locator;
 use ruff_text_size::{Ranged, TextLen, TextRange, TextSize};
 

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/invalid_escape_sequence.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/invalid_escape_sequence.rs
@@ -2,7 +2,7 @@ use memchr::memchr_iter;
 
 use ruff_diagnostics::{AlwaysFixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
-use ruff_python_ast::{AnyStringFlags, FStringElement, StringLike, StringLikePart};
+use ruff_python_ast::{AnyStringFlags, FStringElement, StringFlags, StringLike, StringLikePart};
 use ruff_source_file::Locator;
 use ruff_text_size::{Ranged, TextLen, TextRange, TextSize};
 

--- a/crates/ruff_linter/src/rules/pylint/rules/bad_string_format_character.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/bad_string_format_character.rs
@@ -2,7 +2,7 @@ use std::str::FromStr;
 
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
-use ruff_python_ast::{AbstractStringFlags, Expr, ExprStringLiteral, StringLiteral};
+use ruff_python_ast::{Expr, ExprStringLiteral, StringFlags, StringLiteral};
 use ruff_python_literal::{
     cformat::{CFormatErrorType, CFormatString},
     format::FormatPart,

--- a/crates/ruff_linter/src/rules/pylint/rules/bad_string_format_character.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/bad_string_format_character.rs
@@ -2,7 +2,7 @@ use std::str::FromStr;
 
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
-use ruff_python_ast::{AnyStringFlags, Expr, ExprStringLiteral};
+use ruff_python_ast::{AbstractStringFlags, Expr, ExprStringLiteral, StringLiteral};
 use ruff_python_literal::{
     cformat::{CFormatErrorType, CFormatString},
     format::FormatPart,
@@ -90,9 +90,13 @@ pub(crate) fn call(checker: &mut Checker, string: &str, range: TextRange) {
 /// PLE1300
 /// Ex) `"%z" % "1"`
 pub(crate) fn percent(checker: &mut Checker, expr: &Expr, format_string: &ExprStringLiteral) {
-    for string_literal in &format_string.value {
-        let string = checker.locator().slice(string_literal);
-        let flags = AnyStringFlags::from(string_literal.flags);
+    for StringLiteral {
+        value: _,
+        range,
+        flags,
+    } in &format_string.value
+    {
+        let string = checker.locator().slice(range);
         let string = &string
             [usize::from(flags.opener_len())..(string.len() - usize::from(flags.closer_len()))];
 

--- a/crates/ruff_linter/src/rules/pylint/rules/bad_string_format_type.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/bad_string_format_type.rs
@@ -1,6 +1,6 @@
 use std::str::FromStr;
 
-use ruff_python_ast::{self as ast, AbstractStringFlags, Expr, StringLiteral};
+use ruff_python_ast::{self as ast, Expr, StringFlags, StringLiteral};
 use ruff_python_literal::cformat::{CFormatPart, CFormatSpec, CFormatStrOrBytes, CFormatString};
 use ruff_text_size::Ranged;
 use rustc_hash::FxHashMap;

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/printf_string_formatting.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/printf_string_formatting.rs
@@ -3,8 +3,9 @@ use std::str::FromStr;
 
 use ruff_diagnostics::{Diagnostic, Edit, Fix, FixAvailability, Violation};
 use ruff_macros::{derive_message_formats, violation};
-use ruff_python_ast::whitespace::indentation;
-use ruff_python_ast::{self as ast, AnyStringFlags, Expr};
+use ruff_python_ast::{
+    self as ast, whitespace::indentation, AbstractStringFlags, AnyStringFlags, Expr,
+};
 use ruff_python_codegen::Stylist;
 use ruff_python_literal::cformat::{
     CConversionFlags, CFormatPart, CFormatPrecision, CFormatQuantity, CFormatString,

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/printf_string_formatting.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/printf_string_formatting.rs
@@ -3,9 +3,7 @@ use std::str::FromStr;
 
 use ruff_diagnostics::{Diagnostic, Edit, Fix, FixAvailability, Violation};
 use ruff_macros::{derive_message_formats, violation};
-use ruff_python_ast::{
-    self as ast, whitespace::indentation, AbstractStringFlags, AnyStringFlags, Expr,
-};
+use ruff_python_ast::{self as ast, whitespace::indentation, AnyStringFlags, Expr, StringFlags};
 use ruff_python_codegen::Stylist;
 use ruff_python_literal::cformat::{
     CConversionFlags, CFormatPart, CFormatPrecision, CFormatQuantity, CFormatString,

--- a/crates/ruff_python_ast/src/nodes.rs
+++ b/crates/ruff_python_ast/src/nodes.rs
@@ -1359,8 +1359,6 @@ pub trait StringFlags: Copy {
     /// does it begin and end with three consecutive quote characters?
     fn is_triple_quoted(self) -> bool;
 
-    fn is_raw_string(self) -> bool;
-
     fn prefix(self) -> AnyStringPrefix;
 
     /// A `str` representation of the quotes used to start and close.
@@ -1500,11 +1498,6 @@ impl StringFlags for FStringFlags {
         } else {
             Quote::Single
         }
-    }
-
-    fn is_raw_string(self) -> bool {
-        self.0
-            .intersects(FStringFlagsInner::R_PREFIX_LOWER.union(FStringFlagsInner::R_PREFIX_UPPER))
     }
 
     fn prefix(self) -> AnyStringPrefix {
@@ -1923,12 +1916,6 @@ impl StringFlags for StringLiteralFlags {
         self.0.contains(StringLiteralFlagsInner::TRIPLE_QUOTED)
     }
 
-    fn is_raw_string(self) -> bool {
-        self.0.intersects(
-            StringLiteralFlagsInner::R_PREFIX_LOWER.union(StringLiteralFlagsInner::R_PREFIX_UPPER),
-        )
-    }
-
     fn prefix(self) -> AnyStringPrefix {
         AnyStringPrefix::Regular(self.prefix())
     }
@@ -2276,12 +2263,6 @@ impl StringFlags for BytesLiteralFlags {
         }
     }
 
-    fn is_raw_string(self) -> bool {
-        self.0.intersects(
-            BytesLiteralFlagsInner::R_PREFIX_LOWER.union(BytesLiteralFlagsInner::R_PREFIX_UPPER),
-        )
-    }
-
     fn prefix(self) -> AnyStringPrefix {
         AnyStringPrefix::Bytes(self.prefix())
     }
@@ -2449,6 +2430,13 @@ impl AnyStringFlags {
         self.0.contains(AnyStringFlagsInner::U_PREFIX)
     }
 
+    /// Does the string have an `r` or `R` prefix?
+    pub const fn is_raw_string(self) -> bool {
+        self.0.intersects(
+            AnyStringFlagsInner::R_PREFIX_LOWER.union(AnyStringFlagsInner::R_PREFIX_UPPER),
+        )
+    }
+
     /// Does the string have an `f` or `F` prefix?
     pub const fn is_f_string(self) -> bool {
         self.0.contains(AnyStringFlagsInner::F_PREFIX)
@@ -2489,13 +2477,6 @@ impl StringFlags for AnyStringFlags {
     /// does it begin and end with three consecutive quote characters?
     fn is_triple_quoted(self) -> bool {
         self.0.contains(AnyStringFlagsInner::TRIPLE_QUOTED)
-    }
-
-    /// Does the string have an `r` or `R` prefix?
-    fn is_raw_string(self) -> bool {
-        self.0.intersects(
-            AnyStringFlagsInner::R_PREFIX_LOWER.union(AnyStringFlagsInner::R_PREFIX_UPPER),
-        )
     }
 
     fn prefix(self) -> AnyStringPrefix {

--- a/crates/ruff_python_ast/src/nodes.rs
+++ b/crates/ruff_python_ast/src/nodes.rs
@@ -15,9 +15,7 @@ use ruff_text_size::{Ranged, TextLen, TextRange, TextSize};
 use crate::{
     int,
     str::Quote,
-    str_prefix::{
-        AbstractStringPrefix, AnyStringPrefix, ByteStringPrefix, FStringPrefix, StringLiteralPrefix,
-    },
+    str_prefix::{AnyStringPrefix, ByteStringPrefix, FStringPrefix, StringLiteralPrefix},
     LiteralExpressionRef,
 };
 
@@ -1353,7 +1351,7 @@ impl Ranged for FStringPart {
     }
 }
 
-pub trait AbstractStringFlags: Copy {
+pub trait StringFlags: Copy {
     /// Does the string use single or double quotes in its opener and closer?
     fn quote_style(self) -> Quote;
 
@@ -1363,13 +1361,7 @@ pub trait AbstractStringFlags: Copy {
 
     fn is_raw_string(self) -> bool;
 
-    fn prefix(self) -> impl AbstractStringPrefix;
-
-    #[must_use]
-    fn with_quote_style(self, quotes: Quote) -> Self;
-
-    #[must_use]
-    fn with_triple_quotes(self) -> Self;
+    fn prefix(self) -> AnyStringPrefix;
 
     /// A `str` representation of the quotes used to start and close.
     /// This does not include any prefixes the string has in its opener.
@@ -1514,7 +1506,7 @@ impl FStringFlags {
     }
 }
 
-impl AbstractStringFlags for FStringFlags {
+impl StringFlags for FStringFlags {
     fn quote_style(self) -> Quote {
         self.quote_style()
     }
@@ -1527,16 +1519,8 @@ impl AbstractStringFlags for FStringFlags {
         self.is_raw_string()
     }
 
-    fn prefix(self) -> impl AbstractStringPrefix {
-        self.prefix()
-    }
-
-    fn with_quote_style(self, quotes: Quote) -> Self {
-        self.with_quote_style(quotes)
-    }
-
-    fn with_triple_quotes(self) -> Self {
-        self.with_triple_quotes()
+    fn prefix(self) -> AnyStringPrefix {
+        AnyStringPrefix::Format(self.prefix())
     }
 }
 
@@ -1956,7 +1940,7 @@ impl StringLiteralFlags {
     }
 }
 
-impl AbstractStringFlags for StringLiteralFlags {
+impl StringFlags for StringLiteralFlags {
     fn quote_style(self) -> Quote {
         self.quote_style()
     }
@@ -1969,16 +1953,8 @@ impl AbstractStringFlags for StringLiteralFlags {
         self.is_raw_string()
     }
 
-    fn prefix(self) -> impl AbstractStringPrefix {
-        self.prefix()
-    }
-
-    fn with_quote_style(self, quotes: Quote) -> Self {
-        self.with_quote_style(quotes)
-    }
-
-    fn with_triple_quotes(self) -> Self {
-        self.with_triple_quotes()
+    fn prefix(self) -> AnyStringPrefix {
+        AnyStringPrefix::Regular(self.prefix())
     }
 }
 
@@ -2329,7 +2305,7 @@ impl BytesLiteralFlags {
     }
 }
 
-impl AbstractStringFlags for BytesLiteralFlags {
+impl StringFlags for BytesLiteralFlags {
     fn quote_style(self) -> Quote {
         self.quote_style()
     }
@@ -2342,16 +2318,8 @@ impl AbstractStringFlags for BytesLiteralFlags {
         self.is_raw_string()
     }
 
-    fn prefix(self) -> impl AbstractStringPrefix {
-        self.prefix()
-    }
-
-    fn with_quote_style(self, quotes: Quote) -> Self {
-        self.with_quote_style(quotes)
-    }
-
-    fn with_triple_quotes(self) -> Self {
-        self.with_triple_quotes()
+    fn prefix(self) -> AnyStringPrefix {
+        AnyStringPrefix::Bytes(self.prefix())
     }
 }
 
@@ -2603,7 +2571,7 @@ impl AnyStringFlags {
     }
 }
 
-impl AbstractStringFlags for AnyStringFlags {
+impl StringFlags for AnyStringFlags {
     fn quote_style(self) -> Quote {
         self.quote_style()
     }
@@ -2616,16 +2584,8 @@ impl AbstractStringFlags for AnyStringFlags {
         self.is_raw_string()
     }
 
-    fn prefix(self) -> impl AbstractStringPrefix {
+    fn prefix(self) -> AnyStringPrefix {
         self.prefix()
-    }
-
-    fn with_quote_style(self, quotes: Quote) -> Self {
-        self.with_quote_style(quotes)
-    }
-
-    fn with_triple_quotes(self) -> Self {
-        self.with_triple_quotes()
     }
 }
 

--- a/crates/ruff_python_ast/src/str_prefix.rs
+++ b/crates/ruff_python_ast/src/str_prefix.rs
@@ -1,15 +1,10 @@
 use std::fmt;
 
-pub trait AbstractStringPrefix: Copy + fmt::Display {
-    fn as_str(self) -> &'static str;
-    fn is_raw(self) -> bool;
-}
-
 /// Enumerations of the valid prefixes a string literal can have.
 ///
 /// Bytestrings and f-strings are excluded from this enumeration,
 /// as they are represented by different AST nodes.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, is_macro::Is)]
 pub enum StringLiteralPrefix {
     /// Just a regular string with no prefixes
     Empty,
@@ -29,10 +24,6 @@ pub enum StringLiteralPrefix {
 }
 
 impl StringLiteralPrefix {
-    pub fn is_unicode(self) -> bool {
-        matches!(self, Self::Unicode)
-    }
-
     /// Return a `str` representation of the prefix
     pub const fn as_str(self) -> &'static str {
         match self {
@@ -41,20 +32,6 @@ impl StringLiteralPrefix {
             Self::Raw { uppercase: true } => "R",
             Self::Raw { uppercase: false } => "r",
         }
-    }
-
-    pub const fn is_raw(self) -> bool {
-        matches!(self, Self::Raw { .. })
-    }
-}
-
-impl AbstractStringPrefix for StringLiteralPrefix {
-    fn as_str(self) -> &'static str {
-        self.as_str()
-    }
-
-    fn is_raw(self) -> bool {
-        self.is_raw()
     }
 }
 
@@ -92,16 +69,6 @@ impl FStringPrefix {
     }
 }
 
-impl AbstractStringPrefix for FStringPrefix {
-    fn as_str(self) -> &'static str {
-        self.as_str()
-    }
-
-    fn is_raw(self) -> bool {
-        self.is_raw()
-    }
-}
-
 impl fmt::Display for FStringPrefix {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(self.as_str())
@@ -133,16 +100,6 @@ impl ByteStringPrefix {
     /// e.g. `rb"foo"` or `Rb"foo"`
     pub const fn is_raw(self) -> bool {
         matches!(self, Self::Raw { .. })
-    }
-}
-
-impl AbstractStringPrefix for ByteStringPrefix {
-    fn as_str(self) -> &'static str {
-        self.as_str()
-    }
-
-    fn is_raw(self) -> bool {
-        self.is_raw()
     }
 }
 
@@ -190,16 +147,6 @@ impl AnyStringPrefix {
             Self::Bytes(bytestring_prefix) => bytestring_prefix.is_raw(),
             Self::Format(fstring_prefix) => fstring_prefix.is_raw(),
         }
-    }
-}
-
-impl AbstractStringPrefix for AnyStringPrefix {
-    fn as_str(self) -> &'static str {
-        self.as_str()
-    }
-
-    fn is_raw(self) -> bool {
-        self.is_raw()
     }
 }
 

--- a/crates/ruff_python_ast/src/str_prefix.rs
+++ b/crates/ruff_python_ast/src/str_prefix.rs
@@ -1,10 +1,15 @@
 use std::fmt;
 
+pub trait AbstractStringPrefix: Copy + fmt::Display {
+    fn as_str(self) -> &'static str;
+    fn is_raw(self) -> bool;
+}
+
 /// Enumerations of the valid prefixes a string literal can have.
 ///
 /// Bytestrings and f-strings are excluded from this enumeration,
 /// as they are represented by different AST nodes.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, is_macro::Is)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum StringLiteralPrefix {
     /// Just a regular string with no prefixes
     Empty,
@@ -24,6 +29,10 @@ pub enum StringLiteralPrefix {
 }
 
 impl StringLiteralPrefix {
+    pub fn is_unicode(self) -> bool {
+        matches!(self, Self::Unicode)
+    }
+
     /// Return a `str` representation of the prefix
     pub const fn as_str(self) -> &'static str {
         match self {
@@ -32,6 +41,20 @@ impl StringLiteralPrefix {
             Self::Raw { uppercase: true } => "R",
             Self::Raw { uppercase: false } => "r",
         }
+    }
+
+    pub const fn is_raw(self) -> bool {
+        matches!(self, Self::Raw { .. })
+    }
+}
+
+impl AbstractStringPrefix for StringLiteralPrefix {
+    fn as_str(self) -> &'static str {
+        self.as_str()
+    }
+
+    fn is_raw(self) -> bool {
+        self.is_raw()
     }
 }
 
@@ -69,6 +92,16 @@ impl FStringPrefix {
     }
 }
 
+impl AbstractStringPrefix for FStringPrefix {
+    fn as_str(self) -> &'static str {
+        self.as_str()
+    }
+
+    fn is_raw(self) -> bool {
+        self.is_raw()
+    }
+}
+
 impl fmt::Display for FStringPrefix {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(self.as_str())
@@ -100,6 +133,16 @@ impl ByteStringPrefix {
     /// e.g. `rb"foo"` or `Rb"foo"`
     pub const fn is_raw(self) -> bool {
         matches!(self, Self::Raw { .. })
+    }
+}
+
+impl AbstractStringPrefix for ByteStringPrefix {
+    fn as_str(self) -> &'static str {
+        self.as_str()
+    }
+
+    fn is_raw(self) -> bool {
+        self.is_raw()
     }
 }
 
@@ -147,6 +190,16 @@ impl AnyStringPrefix {
             Self::Bytes(bytestring_prefix) => bytestring_prefix.is_raw(),
             Self::Format(fstring_prefix) => fstring_prefix.is_raw(),
         }
+    }
+}
+
+impl AbstractStringPrefix for AnyStringPrefix {
+    fn as_str(self) -> &'static str {
+        self.as_str()
+    }
+
+    fn is_raw(self) -> bool {
+        self.is_raw()
     }
 }
 

--- a/crates/ruff_python_codegen/src/stylist.rs
+++ b/crates/ruff_python_codegen/src/stylist.rs
@@ -4,7 +4,7 @@ use std::ops::Deref;
 
 use once_cell::unsync::OnceCell;
 
-use ruff_python_ast::str::Quote;
+use ruff_python_ast::{str::Quote, StringFlags};
 use ruff_python_parser::lexer::LexResult;
 use ruff_python_parser::Tok;
 use ruff_source_file::{find_newline, LineEnding, Locator};

--- a/crates/ruff_python_formatter/src/other/f_string.rs
+++ b/crates/ruff_python_formatter/src/other/f_string.rs
@@ -1,5 +1,5 @@
 use ruff_formatter::write;
-use ruff_python_ast::{AnyStringFlags, FString};
+use ruff_python_ast::{AnyStringFlags, FString, StringFlags};
 use ruff_source_file::Locator;
 
 use crate::prelude::*;

--- a/crates/ruff_python_formatter/src/other/f_string_element.rs
+++ b/crates/ruff_python_formatter/src/other/f_string_element.rs
@@ -3,6 +3,7 @@ use std::borrow::Cow;
 use ruff_formatter::{format_args, write, Buffer, RemoveSoftLinesBuffer};
 use ruff_python_ast::{
     ConversionFlag, Expr, FStringElement, FStringExpressionElement, FStringLiteralElement,
+    StringFlags,
 };
 use ruff_text_size::Ranged;
 

--- a/crates/ruff_python_formatter/src/string/any.rs
+++ b/crates/ruff_python_formatter/src/string/any.rs
@@ -4,7 +4,7 @@ use memchr::memchr2;
 
 use ruff_python_ast::{
     self as ast, AnyNodeRef, AnyStringFlags, Expr, ExprBytesLiteral, ExprFString,
-    ExprStringLiteral, ExpressionRef, StringLiteral,
+    ExprStringLiteral, ExpressionRef, StringFlags, StringLiteral,
 };
 use ruff_source_file::Locator;
 use ruff_text_size::{Ranged, TextRange};

--- a/crates/ruff_python_formatter/src/string/docstring.rs
+++ b/crates/ruff_python_formatter/src/string/docstring.rs
@@ -8,7 +8,7 @@ use std::{borrow::Cow, collections::VecDeque};
 use itertools::Itertools;
 
 use ruff_formatter::printer::SourceMapGeneration;
-use ruff_python_ast::str::Quote;
+use ruff_python_ast::{str::Quote, StringFlags};
 use ruff_python_parser::ParseError;
 use {once_cell::sync::Lazy, regex::Regex};
 use {

--- a/crates/ruff_python_formatter/src/string/mod.rs
+++ b/crates/ruff_python_formatter/src/string/mod.rs
@@ -5,7 +5,7 @@ use ruff_python_ast::str::Quote;
 use ruff_python_ast::{
     self as ast,
     str_prefix::{AnyStringPrefix, StringLiteralPrefix},
-    AbstractStringFlags, AnyStringFlags,
+    AnyStringFlags, StringFlags,
 };
 use ruff_text_size::{Ranged, TextRange};
 

--- a/crates/ruff_python_formatter/src/string/mod.rs
+++ b/crates/ruff_python_formatter/src/string/mod.rs
@@ -5,7 +5,7 @@ use ruff_python_ast::str::Quote;
 use ruff_python_ast::{
     self as ast,
     str_prefix::{AnyStringPrefix, StringLiteralPrefix},
-    AnyStringFlags,
+    AbstractStringFlags, AnyStringFlags,
 };
 use ruff_text_size::{Ranged, TextRange};
 

--- a/crates/ruff_python_formatter/src/string/normalize.rs
+++ b/crates/ruff_python_formatter/src/string/normalize.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 use std::iter::FusedIterator;
 
 use ruff_formatter::FormatContext;
-use ruff_python_ast::{str::Quote, AnyStringFlags};
+use ruff_python_ast::{str::Quote, AnyStringFlags, StringFlags};
 use ruff_source_file::Locator;
 use ruff_text_size::{Ranged, TextRange};
 

--- a/crates/ruff_python_index/src/multiline_ranges.rs
+++ b/crates/ruff_python_index/src/multiline_ranges.rs
@@ -1,3 +1,4 @@
+use ruff_python_ast::StringFlags;
 use ruff_python_parser::Tok;
 use ruff_text_size::TextRange;
 

--- a/crates/ruff_python_parser/src/lexer.rs
+++ b/crates/ruff_python_parser/src/lexer.rs
@@ -37,7 +37,7 @@ use unicode_normalization::UnicodeNormalization;
 use ruff_python_ast::{
     str::Quote,
     str_prefix::{AnyStringPrefix, FStringPrefix},
-    AnyStringFlags, Int, IpyEscapeKind,
+    AnyStringFlags, Int, IpyEscapeKind, StringFlags,
 };
 use ruff_text_size::{TextLen, TextRange, TextSize};
 

--- a/crates/ruff_python_parser/src/lexer/fstring.rs
+++ b/crates/ruff_python_parser/src/lexer/fstring.rs
@@ -1,4 +1,4 @@
-use ruff_python_ast::{AbstractStringFlags, AnyStringFlags};
+use ruff_python_ast::{AnyStringFlags, StringFlags};
 
 /// The context representing the current f-string that the lexer is in.
 #[derive(Debug)]

--- a/crates/ruff_python_parser/src/lexer/fstring.rs
+++ b/crates/ruff_python_parser/src/lexer/fstring.rs
@@ -1,4 +1,4 @@
-use ruff_python_ast::AnyStringFlags;
+use ruff_python_ast::{AbstractStringFlags, AnyStringFlags};
 
 /// The context representing the current f-string that the lexer is in.
 #[derive(Debug)]
@@ -42,7 +42,7 @@ impl FStringContext {
 
     /// Returns the triple quotes for the current f-string if it is a triple-quoted
     /// f-string, `None` otherwise.
-    pub(crate) const fn triple_quotes(&self) -> Option<&'static str> {
+    pub(crate) fn triple_quotes(&self) -> Option<&'static str> {
         if self.is_triple_quoted() {
             Some(self.flags.quote_str())
         } else {

--- a/crates/ruff_python_parser/src/lexer/fstring.rs
+++ b/crates/ruff_python_parser/src/lexer/fstring.rs
@@ -36,7 +36,7 @@ impl FStringContext {
     }
 
     /// Returns the quote character for the current f-string.
-    pub(crate) const fn quote_char(&self) -> char {
+    pub(crate) fn quote_char(&self) -> char {
         self.flags.quote_style().as_char()
     }
 
@@ -56,7 +56,7 @@ impl FStringContext {
     }
 
     /// Returns `true` if the current f-string is a triple-quoted f-string.
-    pub(crate) const fn is_triple_quoted(&self) -> bool {
+    pub(crate) fn is_triple_quoted(&self) -> bool {
         self.flags.is_triple_quoted()
     }
 

--- a/crates/ruff_python_parser/src/string.rs
+++ b/crates/ruff_python_parser/src/string.rs
@@ -2,7 +2,7 @@
 
 use bstr::ByteSlice;
 
-use ruff_python_ast::{self as ast, AbstractStringFlags, AnyStringFlags, Expr};
+use ruff_python_ast::{self as ast, AnyStringFlags, Expr, StringFlags};
 use ruff_text_size::{Ranged, TextRange, TextSize};
 
 use crate::lexer::{LexicalError, LexicalErrorType};

--- a/crates/ruff_python_parser/src/string.rs
+++ b/crates/ruff_python_parser/src/string.rs
@@ -2,7 +2,7 @@
 
 use bstr::ByteSlice;
 
-use ruff_python_ast::{self as ast, AnyStringFlags, Expr};
+use ruff_python_ast::{self as ast, AbstractStringFlags, AnyStringFlags, Expr};
 use ruff_text_size::{Ranged, TextRange, TextSize};
 
 use crate::lexer::{LexicalError, LexicalErrorType};

--- a/crates/ruff_python_parser/src/token.rs
+++ b/crates/ruff_python_parser/src/token.rs
@@ -7,9 +7,7 @@
 
 use std::fmt;
 
-use ruff_python_ast::{
-    AbstractStringFlags, AnyStringFlags, BoolOp, Int, IpyEscapeKind, Operator, UnaryOp,
-};
+use ruff_python_ast::{AnyStringFlags, BoolOp, Int, IpyEscapeKind, Operator, StringFlags, UnaryOp};
 
 /// The set of tokens the Python source code can be tokenized in.
 #[derive(Clone, Debug, PartialEq, is_macro::Is)]

--- a/crates/ruff_python_parser/src/token.rs
+++ b/crates/ruff_python_parser/src/token.rs
@@ -7,7 +7,9 @@
 
 use std::fmt;
 
-use ruff_python_ast::{AnyStringFlags, BoolOp, Int, IpyEscapeKind, Operator, UnaryOp};
+use ruff_python_ast::{
+    AbstractStringFlags, AnyStringFlags, BoolOp, Int, IpyEscapeKind, Operator, UnaryOp,
+};
 
 /// The set of tokens the Python source code can be tokenized in.
 #[derive(Clone, Debug, PartialEq, is_macro::Is)]


### PR DESCRIPTION
## Summary

This PR implements a common trait for the four "string flags" types in `crates/ruff_python_ast/src/nodes.rs`:
- `FStringFlags`
- `StringLiteralFlags`
- `ByteStringFlags`
- `AnyStringFlags`

This has the following advantages:
- It means that we enforce a consistent interface between the four types. Currently this is implicit; this PR makes it explicit, and ensures that they don't accidentally become inconsistent in the future.
- Various methods (`quote_str()`, `quote_len()`, `format_string_contents()`, etc.) that were previously only available on `AnyStringFlags` are now available on all four structs. This means that there is no need to convert the more precise types into the more general type, which was previously required if you wanted to access these methods. The PR updates two pylint rules so that they no longer make this conversion from more precise types to `AnyStringFlags`; instead, the trait is brought into scope so that the rules can access the methods directly without making any conversion.

It has the following disadvantages that I am aware of:
- The trait now needs to be explicitly brought into scope if you want to use any of the methods that come for free by virtue of implementing the trait. This might make these methods less discoverable for people implementing new linter rules
- It's more code for us to maintain, and there are currently relatively few uses of the methods that the trait provides default implementations for

This idea was suggested by @dhruvmanila in https://github.com/astral-sh/ruff/pull/11406#discussion_r1598494602

## Test Plan

`cargo test`. There should also be 0 ecosystem hits, as this is an internal refactor.
