### PR TITLE
Consider irrefutable pattern similar to `if .. else` for `C901`

### DIFF
--- a/crates/ruff_linter/src/rules/mccabe/rules/function_is_too_complex.rs
+++ b/crates/ruff_linter/src/rules/mccabe/rules/function_is_too_complex.rs
@@ -1,5 +1,4 @@
-use ast::Pattern;
-use ruff_python_ast::{self as ast, ExceptHandler, Stmt};
+use ruff_python_ast::{self as ast, ExceptHandler, Pattern, Stmt};
 
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
@@ -104,8 +103,21 @@ fn get_complexity_number(stmts: &[Stmt]) -> usize {
                 if let Some(last_case) = cases.last() {
                     if let Pattern::MatchAs(match_as_pattern) = &last_case.pattern {
                         if match_as_pattern.pattern.is_none() {
-                            // the catch all `_` or named catch all case doesn't increase
-                            // the complexity similar to a plain `else` stmt.
+                            // The complexity of an irrefutable pattern is similar to an `else` block of an `if` statement.
+                            // This is either a wildcard pattern or a named catch-all pattern.
+                            // 
+                            // For example:
+                            // ```python
+                            // match subject:
+                            //     case 1: ...
+                            //     case _: ...
+                            //
+                            // match subject:
+                            //     case 1: ...
+                            //     case foo: ...
+                            // ```
+                            //
+                            // Irrefutable pattern: https://peps.python.org/pep-0634/#irrefutable-case-blocks
                             complexity -= 1;
                         }
                     }

--- a/crates/ruff_linter/src/rules/mccabe/rules/function_is_too_complex.rs
+++ b/crates/ruff_linter/src/rules/mccabe/rules/function_is_too_complex.rs
@@ -105,7 +105,7 @@ fn get_complexity_number(stmts: &[Stmt]) -> usize {
                         if match_as_pattern.pattern.is_none() {
                             // The complexity of an irrefutable pattern is similar to an `else` block of an `if` statement.
                             // This is either a wildcard pattern or a named catch-all pattern.
-                            // 
+                            //
                             // For example:
                             // ```python
                             // match subject:

--- a/crates/ruff_linter/src/rules/mccabe/rules/function_is_too_complex.rs
+++ b/crates/ruff_linter/src/rules/mccabe/rules/function_is_too_complex.rs
@@ -97,17 +97,18 @@ fn get_complexity_number(stmts: &[Stmt]) -> usize {
                 complexity += get_complexity_number(orelse);
             }
             Stmt::Match(ast::StmtMatch { cases, .. }) => {
-                let last_index = cases.len() - 1;
-                for (i, case) in cases.iter().enumerate() {
+                for case in cases {
                     complexity += 1;
-                    if let Pattern::MatchAs(match_as_pattern) = &case.pattern {
-                        if match_as_pattern.pattern.is_none() && i == last_index {
+                    complexity += get_complexity_number(&case.body);
+                }
+                if let Some(last_case) = cases.last() {
+                    if let Pattern::MatchAs(match_as_pattern) = &last_case.pattern {
+                        if match_as_pattern.pattern.is_none() {
                             // the catch all `_` or named catch all case doesn't increase
                             // the complexity similar to a plain `else` stmt.
                             complexity -= 1;
                         }
                     }
-                    complexity += get_complexity_number(&case.body);
                 }
             }
             Stmt::Try(ast::StmtTry {

--- a/crates/ruff_python_ast/src/nodes.rs
+++ b/crates/ruff_python_ast/src/nodes.rs
@@ -2998,6 +2998,21 @@ pub enum Pattern {
     MatchOr(PatternMatchOr),
 }
 
+impl Pattern {
+    /// Checks if the [`Pattern`] is an [irrefutable pattern].
+    ///
+    /// [irrefutable pattern]: https://peps.python.org/pep-0634/#irrefutable-case-blocks
+    pub fn is_irrefutable(&self) -> bool {
+        match self {
+            Pattern::MatchAs(PatternMatchAs { pattern: None, .. }) => true,
+            Pattern::MatchOr(PatternMatchOr { patterns, .. }) => {
+                patterns.iter().any(Pattern::is_irrefutable)
+            }
+            _ => false,
+        }
+    }
+}
+
 /// See also [MatchValue](https://docs.python.org/3/library/ast.html#ast.MatchValue)
 #[derive(Clone, Debug, PartialEq)]
 pub struct PatternMatchValue {


### PR DESCRIPTION
## Summary

Follow up to https://github.com/astral-sh/ruff/pull/11521

Removes the extra added complexity for catch all match cases. This matches the implementation of plain `else` statements. 

## Test Plan
Added new test cases.