### PR TITLE
Use default settings if initialization options is empty or not provided

### DIFF
--- a/crates/ruff_server/resources/test/fixtures/settings/global_only.json
+++ b/crates/ruff_server/resources/test/fixtures/settings/global_only.json
@@ -1,15 +1,17 @@
 {
-    "codeAction": {
-        "disableRuleComment": {
-            "enable": false
-        }
-    },
-    "lint": {
-        "ignore": ["RUF001"],
-        "run": "onSave"
-    },
-    "fixAll": false,
-    "logLevel": "warn",
-    "lineLength": 80,
-    "exclude": ["third_party"]
+    "settings": {
+        "codeAction": {
+            "disableRuleComment": {
+                "enable": false
+            }
+        },
+        "lint": {
+            "ignore": ["RUF001"],
+            "run": "onSave"
+        },
+        "fixAll": false,
+        "logLevel": "warn",
+        "lineLength": 80,
+        "exclude": ["third_party"]
+    }
 }

--- a/crates/ruff_server/src/session/settings.rs
+++ b/crates/ruff_server/src/session/settings.rs
@@ -130,6 +130,7 @@ enum InitializationOptions {
         workspace_settings: Vec<WorkspaceSettings>,
     },
     GlobalOnly {
+        #[serde(default)]
         settings: ClientSettings,
     },
 }

--- a/crates/ruff_server/src/session/settings.rs
+++ b/crates/ruff_server/src/session/settings.rs
@@ -130,7 +130,6 @@ enum InitializationOptions {
         workspace_settings: Vec<WorkspaceSettings>,
     },
     GlobalOnly {
-        #[serde(flatten)]
         settings: ClientSettings,
     },
 }


### PR DESCRIPTION
## Summary

This PR fixes the bug to avoid flattening the global-only settings for the new server.

This was added in https://github.com/astral-sh/ruff/pull/11497, possibly to correctly de-serialize an empty value (`{}`). But, this lead to a bug where the configuration under the `settings` key was not being read for global-only variant.

By using #[serde(default)], we ensure that the settings field in the `GlobalOnly` variant is optional and that an empty JSON object `{}` is correctly deserialized into `GlobalOnly` with a default `ClientSettings` instance.

fixes: #11507 

## Test Plan

Update the snapshot and existing test case. Also, verify the following settings in Neovim:

1. Nothing

```lua
ruff = {
  cmd = {
    '/Users/dhruv/work/astral/ruff/target/debug/ruff',
    'server',
    '--preview',
  },
}
```

2. Empty dictionary

```lua
ruff = {
  cmd = {
    '/Users/dhruv/work/astral/ruff/target/debug/ruff',
    'server',
    '--preview',
  },
  init_options = vim.empty_dict(),
}
```

3. Empty `settings`

```lua
ruff = {
  cmd = {
    '/Users/dhruv/work/astral/ruff/target/debug/ruff',
    'server',
    '--preview',
  },
  init_options = {
    settings = vim.empty_dict(),
  },
}
```

4. With some configuration:

```lua
ruff = {
  cmd = {
    '/Users/dhruv/work/astral/ruff/target/debug/ruff',
    'server',
    '--preview',
  },
  init_options = {
    settings = {
      configuration = '/tmp/ruff-repro/pyproject.toml',
    },
  },
}
```

