### PR TITLE
Make `ruff_notebook` a workspace dependency in `ruff_server`

### DIFF
--- a/crates/ruff_server/Cargo.toml
+++ b/crates/ruff_server/Cargo.toml
@@ -16,12 +16,12 @@ license = { workspace = true }
 ruff_diagnostics = { workspace = true }
 ruff_formatter = { workspace = true }
 ruff_linter = { workspace = true }
+ruff_notebook = { workspace = true }
 ruff_python_ast = { workspace = true }
 ruff_python_codegen = { workspace = true }
 ruff_python_formatter = { workspace = true }
 ruff_python_index = { workspace = true }
 ruff_python_parser = { workspace = true }
-ruff_notebook = { path = "../ruff_notebook" }
 ruff_source_file = { workspace = true }
 ruff_text_size = { workspace = true }
 ruff_workspace = { workspace = true }


### PR DESCRIPTION
## Summary
The `ruff_notebook` dependency was added in https://github.dev/astral-sh/ruff/pull/11206

I suspect it's a merge conflict. So lets update the dependency to use the format that Charlie prefers ;)

## Test Plan

`cargo build`
