### PR TITLE
Avoid recomending operator.itemgetter with dependence on lambda arg

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/refurb/FURB118.py
+++ b/crates/ruff_linter/resources/test/fixtures/refurb/FURB118.py
@@ -60,6 +60,7 @@ op_itemgetter = lambda x, y: (x[0], y[0])
 op_itemgetter = lambda x: ()
 op_itemgetter = lambda x: (*x[0], x[1])
 op_itemgetter = lambda x: (x[0],)
+op_itemgetter = lambda x: x[x]
 
 
 def op_neg3(x, y):

--- a/crates/ruff_linter/src/rules/refurb/rules/reimplemented_operator.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/reimplemented_operator.rs
@@ -5,6 +5,7 @@ use anyhow::Result;
 
 use ruff_diagnostics::{Diagnostic, Edit, Fix, FixAvailability, Violation};
 use ruff_macros::{derive_message_formats, violation};
+use ruff_python_ast::helpers::any_over_expr;
 use ruff_python_ast::identifier::Identifier;
 use ruff_python_ast::{self as ast, Expr, ExprSlice, ExprSubscript, ExprTuple, Parameters, Stmt};
 use ruff_python_semantic::SemanticModel;
@@ -221,9 +222,17 @@ fn itemgetter_op(expr: &ExprSubscript, params: &Parameters, locator: &Locator) -
     let [arg] = params.args.as_slice() else {
         return None;
     };
+
+    // The argument to the lambda must match the subscripted value, as in: `lambda x: x[1]`.
     if !is_same_expression(arg, &expr.value) {
         return None;
     };
+
+    // The subscripted expression can't contain references to the argument, as in: `lambda x: x[x]`.
+    if any_over_expr(expr.slice.as_ref(), &|expr| is_same_expression(arg, expr)) {
+        return None;
+    }
+
     Some(Operator {
         name: "itemgetter",
         args: vec![subscript_slice_to_string(expr.slice.as_ref(), locator).to_string()],


### PR DESCRIPTION
## Summary

Closes https://github.com/astral-sh/ruff/issues/11573.
