### PR TITLE
Avoid recommending context manager in `__enter__` implementations

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_simplify/SIM115.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_simplify/SIM115.py
@@ -46,3 +46,15 @@ with contextlib.ExitStack() as exit_stack:
 # OK (quick one-liner to clear file contents)
 open("filename", "w").close()
 pathlib.Path("filename").open("w").close()
+
+
+# OK (custom context manager)
+class MyFile:
+    def __init__(self, filename: str):
+        self.filename = filename
+
+    def __enter__(self):
+        self.file = open(self.filename)
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.file.close()


### PR DESCRIPTION
## Summary

Closes https://github.com/astral-sh/ruff/issues/11567.
