### PR TITLE
Windows: Statically linked C runtime

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -10,8 +10,3 @@ benchmark = "bench -p ruff_benchmark --bench linter --bench formatter --"
 rustflags = ["-C", "target-feature=+crt-static"]
 [target.i686-pc-windows-msvc]
 rustflags = ["-C", "target-feature=+crt-static"]
-[target.x86_64-unknown-linux-musl]
-rustflags = [
-  "-C", "target-feature=+crt-static",
-  "-C", "link-self-contained=yes",
-]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,17 @@
 [alias]
 dev = "run --package ruff_dev --bin ruff_dev"
 benchmark = "bench -p ruff_benchmark --bench linter --bench formatter --"
+
+# statically link the C runtime so the executable does not depend on
+# that shared/dynamic library.
+#
+# See: https://github.com/astral-sh/ruff/issues/11503
+[target.x86_64-pc-windows-msvc]
+rustflags = ["-C", "target-feature=+crt-static"]
+[target.i686-pc-windows-msvc]
+rustflags = ["-C", "target-feature=+crt-static"]
+[target.x86_64-unknown-linux-musl]
+rustflags = [
+  "-C", "target-feature=+crt-static",
+  "-C", "link-self-contained=yes",
+]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -6,7 +6,5 @@ benchmark = "bench -p ruff_benchmark --bench linter --bench formatter --"
 # that shared/dynamic library.
 #
 # See: https://github.com/astral-sh/ruff/issues/11503
-[target.x86_64-pc-windows-msvc]
-rustflags = ["-C", "target-feature=+crt-static"]
-[target.i686-pc-windows-msvc]
+[target.'cfg(all(target_env="msvc", target_os = "windows"))']
 rustflags = ["-C", "target-feature=+crt-static"]


### PR DESCRIPTION
## Summary
Here is a comparison between [0.4.6 released binaries](https://github.com/astral-sh/ruff/actions/runs/9274921378) (dynamic-crt) and [current PR binaries](https://github.com/T-256/ruff/actions/runs/9283204908) (static-crt):

| TARGET | dynamic size | static size | increased size |
| - | - | - | - |
| aarch64-pc-windows-msvc | 7.32 MB | 7.36 MB | 0.04 MB |
| i686-pc-windows-msvc | 7.14 MB | 7.2 MB | 0.06 MB |
| x86_64-pc-windows-msvc | 7.85 MB | 7.91 MB | 0.06 MB |

Uncompressed binaries:
| TARGET | dynamic size | static size | increased size |
| - | - | - | - |
| aarch64-pc-windows-msvc | 19.5 MB | 19.6 MB | 0.1 MB |
| i686-pc-windows-msvc | 18.5 MB | 18.6 MB | 0.1 MB |
| x86_64-pc-windows-msvc | 23 MB | 23.1 MB | 0.1 MB |


Closes #11503