### PR TITLE
Reduce extensive use of `snapshot.query`

### DIFF
--- a/crates/ruff_server/src/fix.rs
+++ b/crates/ruff_server/src/fix.rs
@@ -10,7 +10,6 @@ use ruff_linter::{
 use ruff_notebook::SourceValue;
 use ruff_source_file::LineIndex;
 use ruff_workspace::resolver::match_any_exclusion;
-use ruff_workspace::FileResolverSettings;
 
 use crate::{
     edit::{Replacement, ToRangeExt},
@@ -24,12 +23,13 @@ pub(crate) type Fixes = FxHashMap<lsp_types::Url, Vec<lsp_types::TextEdit>>;
 
 pub(crate) fn fix_all(
     query: &DocumentQuery,
-    file_resolver_settings: &FileResolverSettings,
     linter_settings: &LinterSettings,
     encoding: PositionEncoding,
 ) -> crate::Result<Fixes> {
     let document_path = query.file_path();
     let source_kind = query.make_source_kind();
+
+    let file_resolver_settings = query.settings().file_resolver();
 
     // If the document is excluded, return an empty list of fixes.
     if let Some(exclusion) = match_any_exclusion(

--- a/crates/ruff_server/src/lint.rs
+++ b/crates/ruff_server/src/lint.rs
@@ -7,7 +7,7 @@ use ruff_linter::{
     linter::{check_path, LinterResult, TokenSource},
     packaging::detect_package_root,
     registry::AsRule,
-    settings::{flags, LinterSettings},
+    settings::flags,
     source_kind::SourceKind,
 };
 use ruff_notebook::Notebook;
@@ -17,7 +17,6 @@ use ruff_python_parser::AsMode;
 use ruff_source_file::{LineIndex, Locator};
 use ruff_text_size::{Ranged, TextRange};
 use ruff_workspace::resolver::match_any_exclusion;
-use ruff_workspace::FileResolverSettings;
 use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
 
@@ -60,14 +59,11 @@ pub(crate) struct DiagnosticFix {
 /// A series of diagnostics across a single text document or an arbitrary number of notebook cells.
 pub(crate) type Diagnostics = FxHashMap<lsp_types::Url, Vec<lsp_types::Diagnostic>>;
 
-pub(crate) fn check(
-    query: &DocumentQuery,
-    file_resolver_settings: &FileResolverSettings,
-    linter_settings: &LinterSettings,
-    encoding: PositionEncoding,
-) -> Diagnostics {
+pub(crate) fn check(query: &DocumentQuery, encoding: PositionEncoding) -> Diagnostics {
     let document_path = query.file_path();
     let source_kind = query.make_source_kind();
+    let file_resolver_settings = query.settings().file_resolver();
+    let linter_settings = query.settings().linter();
 
     // If the document is excluded, return an empty list of diagnostics.
     if let Some(exclusion) = match_any_exclusion(

--- a/crates/ruff_server/src/server/api/diagnostics.rs
+++ b/crates/ruff_server/src/server/api/diagnostics.rs
@@ -8,12 +8,8 @@ use super::LSPResult;
 
 pub(super) fn generate_diagnostics(snapshot: &DocumentSnapshot) -> Diagnostics {
     if snapshot.client_settings().lint() {
-        crate::lint::check(
-            snapshot.query(),
-            snapshot.query().settings().file_resolver(),
-            snapshot.query().settings().linter(),
-            snapshot.encoding(),
-        )
+        let document = snapshot.query();
+        crate::lint::check(document, snapshot.encoding())
     } else {
         Diagnostics::default()
     }

--- a/crates/ruff_server/src/server/api/requests/code_action.rs
+++ b/crates/ruff_server/src/server/api/requests/code_action.rs
@@ -85,8 +85,10 @@ fn quick_fix(
         .map(|fix| {
             let mut tracker = WorkspaceEditTracker::new(snapshot.resolved_client_capabilities());
 
+            let document_url = snapshot.query().make_key().into_url();
+
             tracker.set_edits_for_document(
-                snapshot.query().make_key().into_url(),
+                document_url.clone(),
                 document.version(),
                 fix.edits.clone(),
             )?;
@@ -97,8 +99,7 @@ fn quick_fix(
                 edit: Some(tracker.into_workspace_edit()),
                 diagnostics: Some(vec![fix.fixed_diagnostic.clone()]),
                 data: Some(
-                    serde_json::to_value(snapshot.query().make_key().into_url())
-                        .expect("document url should serialize"),
+                    serde_json::to_value(document_url).expect("document url should serialize"),
                 ),
                 ..Default::default()
             }))
@@ -157,8 +158,6 @@ fn fix_all(snapshot: &DocumentSnapshot) -> crate::Result<CodeActionOrCommand> {
             Some(resolve_edit_for_fix_all(
                 document,
                 snapshot.resolved_client_capabilities(),
-                snapshot.query().settings().file_resolver(),
-                snapshot.query().settings().linter(),
                 snapshot.encoding(),
             )?),
             None,
@@ -194,8 +193,6 @@ fn notebook_fix_all(snapshot: &DocumentSnapshot) -> crate::Result<CodeActionOrCo
             Some(resolve_edit_for_fix_all(
                 document,
                 snapshot.resolved_client_capabilities(),
-                snapshot.query().settings().file_resolver(),
-                snapshot.query().settings().linter(),
                 snapshot.encoding(),
             )?),
             None,
@@ -231,8 +228,6 @@ fn organize_imports(snapshot: &DocumentSnapshot) -> crate::Result<CodeActionOrCo
             Some(resolve_edit_for_organize_imports(
                 document,
                 snapshot.resolved_client_capabilities(),
-                snapshot.query().settings().file_resolver(),
-                snapshot.query().settings().linter(),
                 snapshot.encoding(),
             )?),
             None,
@@ -268,8 +263,6 @@ fn notebook_organize_imports(snapshot: &DocumentSnapshot) -> crate::Result<CodeA
             Some(resolve_edit_for_organize_imports(
                 document,
                 snapshot.resolved_client_capabilities(),
-                snapshot.query().settings().file_resolver(),
-                snapshot.query().settings().linter(),
                 snapshot.encoding(),
             )?),
             None,

--- a/crates/ruff_server/src/server/api/requests/execute_command.rs
+++ b/crates/ruff_server/src/server/api/requests/execute_command.rs
@@ -64,8 +64,6 @@ impl super::SyncRequestHandler for ExecuteCommand {
                 Command::FixAll => {
                     let fixes = super::code_action_resolve::fix_all_edit(
                         snapshot.query(),
-                        snapshot.query().settings().file_resolver(),
-                        snapshot.query().settings().linter(),
                         snapshot.encoding(),
                     )
                     .with_failure_code(ErrorCode::InternalError)?;
@@ -82,8 +80,6 @@ impl super::SyncRequestHandler for ExecuteCommand {
                 Command::OrganizeImports => {
                     let fixes = super::code_action_resolve::organize_imports_edit(
                         snapshot.query(),
-                        snapshot.query().settings().file_resolver(),
-                        snapshot.query().settings().linter(),
                         snapshot.encoding(),
                     )
                     .with_failure_code(ErrorCode::InternalError)?;

--- a/crates/ruff_server/src/server/api/requests/format.rs
+++ b/crates/ruff_server/src/server/api/requests/format.rs
@@ -35,6 +35,7 @@ impl super::BackgroundDocumentRequestHandler for Format {
 /// Formats either a full text document or each individual cell in a single notebook document.
 pub(super) fn format_full_document(snapshot: &DocumentSnapshot) -> Result<Fixes> {
     let mut fixes = Fixes::default();
+    let query = snapshot.query();
 
     if let Some(notebook) = snapshot.query().as_notebook() {
         for (url, text_document) in notebook
@@ -43,10 +44,10 @@ pub(super) fn format_full_document(snapshot: &DocumentSnapshot) -> Result<Fixes>
         {
             if let Some(changes) = format_text_document(
                 text_document,
-                snapshot.query().source_type(),
-                snapshot.query().file_path(),
-                snapshot.query().settings().file_resolver(),
-                snapshot.query().settings().formatter(),
+                query.source_type(),
+                query.file_path(),
+                query.settings().file_resolver(),
+                query.settings().formatter(),
                 snapshot.encoding(),
                 true,
             )? {
@@ -55,11 +56,11 @@ pub(super) fn format_full_document(snapshot: &DocumentSnapshot) -> Result<Fixes>
         }
     } else {
         if let Some(changes) = format_text_document(
-            snapshot.query().as_single_document().unwrap(),
-            snapshot.query().source_type(),
-            snapshot.query().file_path(),
-            snapshot.query().settings().file_resolver(),
-            snapshot.query().settings().formatter(),
+            query.as_single_document().unwrap(),
+            query.source_type(),
+            query.file_path(),
+            query.settings().file_resolver(),
+            query.settings().formatter(),
             snapshot.encoding(),
             false,
         )? {
@@ -77,14 +78,15 @@ pub(super) fn format_document(snapshot: &DocumentSnapshot) -> Result<super::Form
         .query()
         .as_single_document()
         .expect("format should only be called on text documents or notebook cells");
+    let query = snapshot.query();
     format_text_document(
         text_document,
-        snapshot.query().source_type(),
-        snapshot.query().file_path(),
-        snapshot.query().settings().file_resolver(),
-        snapshot.query().settings().formatter(),
+        query.source_type(),
+        query.file_path(),
+        query.settings().file_resolver(),
+        query.settings().formatter(),
         snapshot.encoding(),
-        snapshot.query().as_notebook().is_some(),
+        query.as_notebook().is_some(),
     )
 }
 

--- a/crates/ruff_server/src/server/api/requests/format_range.rs
+++ b/crates/ruff_server/src/server/api/requests/format_range.rs
@@ -38,13 +38,14 @@ fn format_document_range(
         .query()
         .as_single_document()
         .expect("format should only be called on text documents or notebook cells");
+    let query = snapshot.query();
     format_text_document_range(
         text_document,
         range,
-        snapshot.query().source_type(),
-        snapshot.query().file_path(),
-        snapshot.query().settings().file_resolver(),
-        snapshot.query().settings().formatter(),
+        query.source_type(),
+        query.file_path(),
+        query.settings().file_resolver(),
+        query.settings().formatter(),
         snapshot.encoding(),
     )
 }


### PR DESCRIPTION
## Summary

Reduce the extensive use of `snapshot.query` and instead assign the result to a variable and reuse it. 

Also avoid passing unnecessary data to functins that can be retrieved from `query`.

## Test Plan

`cargo build`
