### PR TITLE
use owned ast and tokens in bench

### DIFF
--- a/crates/ruff_benchmark/benches/linter.rs
+++ b/crates/ruff_benchmark/benches/linter.rs
@@ -60,24 +60,25 @@ fn benchmark_linter(mut group: BenchmarkGroup, settings: &LinterSettings) {
                 // Parse the source.
                 let ast = parse_program_tokens(tokens.clone(), case.code(), false).unwrap();
 
-                b.iter(|| {
-                    let path = case.path();
-                    let result = lint_only(
-                        &path,
-                        None,
-                        settings,
-                        flags::Noqa::Enabled,
-                        &SourceKind::Python(case.code().to_string()),
-                        PySourceType::from(path.as_path()),
-                        ParseSource::Precomputed {
-                            tokens: &tokens,
-                            ast: &ast,
-                        },
-                    );
+                b.iter_batched(
+                    || (ast.clone(), tokens.clone()),
+                    |(ast, tokens)| {
+                        let path = case.path();
+                        let result = lint_only(
+                            &path,
+                            None,
+                            settings,
+                            flags::Noqa::Enabled,
+                            &SourceKind::Python(case.code().to_string()),
+                            PySourceType::from(path.as_path()),
+                            ParseSource::Precomputed { tokens, ast },
+                        );
 
-                    // Assert that file contains no parse errors
-                    assert_eq!(result.error, None);
-                });
+                        // Assert that file contains no parse errors
+                        assert_eq!(result.error, None);
+                    },
+                    criterion::BatchSize::SmallInput,
+                );
             },
         );
     }

--- a/crates/ruff_server/src/session/settings.rs
+++ b/crates/ruff_server/src/session/settings.rs
@@ -353,10 +353,12 @@ mod tests {
     use insta::assert_debug_snapshot;
     use serde::de::DeserializeOwned;
 
+    #[cfg(not(windows))]
     use ruff_linter::registry::Linter;
 
     use super::*;
 
+    #[cfg(not(windows))]
     const VS_CODE_INIT_OPTIONS_FIXTURE: &str =
         include_str!("../../resources/test/fixtures/settings/vs_code_initialization_options.json");
     const GLOBAL_ONLY_INIT_OPTIONS_FIXTURE: &str =
@@ -368,7 +370,8 @@ mod tests {
         serde_json::from_str(content).expect("test fixture JSON should deserialize")
     }
 
-    #[cfg_attr(not(windows), test)]
+    #[cfg(not(windows))]
+    #[test]
     fn test_vs_code_init_options_deserialize() {
         let options: InitializationOptions = deserialize_fixture(VS_CODE_INIT_OPTIONS_FIXTURE);
 
@@ -553,7 +556,8 @@ mod tests {
         "###);
     }
 
-    #[cfg_attr(not(windows), test)]
+    #[cfg(not(windows))]
+    #[test]
     fn test_vs_code_workspace_settings_resolve() {
         let options = deserialize_fixture(VS_CODE_INIT_OPTIONS_FIXTURE);
         let AllSettings {


### PR DESCRIPTION
## Summary

Use owned values for the linter benchmark as preparation for the parser refactor

The perf regressions come from the fact that the `tokens` and `ast` are now dropped inside the benchmark. I think this is good, because that is closer to what we see in production. 