### PR TITLE
docs: Minor formatting typo in F401 example.

### DIFF
--- a/crates/ruff/tests/snapshots/integration_test__rule_f401.snap
+++ b/crates/ruff/tests/snapshots/integration_test__rule_f401.snap
@@ -41,7 +41,7 @@ interface, as in:
 # __init__.py
 import some_module
 
-__all__ = [ "some_module"]
+__all__ = ["some_module"]
 ```
 
 ## Fix safety

--- a/crates/ruff_linter/src/rules/pyflakes/rules/unused_import.rs
+++ b/crates/ruff_linter/src/rules/pyflakes/rules/unused_import.rs
@@ -54,7 +54,7 @@ enum UnusedImportContext {
 /// # __init__.py
 /// import some_module
 ///
-/// __all__ = [ "some_module"]
+/// __all__ = ["some_module"]
 /// ```
 ///
 /// ## Fix safety


### PR DESCRIPTION
## Summary

Removed stray space in sample code snippet that is against ruff's own default formatting rules.

This documentation appears on https://docs.astral.sh/ruff/rules/unused-import/

## Test Plan

This is a trivially obvious change, verifiable with `ruff format --check`