### PR TITLE
[redknot] complete symbol table by populating Symbol::kind field

### DIFF
--- a/crates/red_knot/src/symbols.rs
+++ b/crates/red_knot/src/symbols.rs
@@ -120,10 +120,18 @@ impl Scope {
 
 #[derive(Debug)]
 pub(crate) enum Kind {
+    /// ...
+    /// TODO: correct?
     FreeVar,
+    /// Defined in current scope, used in at least one nested scope
     CellVar,
+    /// Defined in current scope, defined and `MARKED_NONLOCAL` in at least one nested scope
     CellVarAssigned,
+    /// `MARKED_GLOBAL` in current scope
+    /// TODO: correct?
     ExplicitGlobal,
+    /// Referenced but not defined in current scope
+    /// TODO: correct?
     ImplicitGlobal,
 }
 

--- a/crates/red_knot/src/symbols.rs
+++ b/crates/red_knot/src/symbols.rs
@@ -142,7 +142,7 @@ pub(crate) struct Symbol {
     name: Name,
     flags: SymbolFlags,
     scope_id: ScopeId,
-    // kind: Kind,
+    kind: Kind,
 }
 
 impl Symbol {
@@ -412,6 +412,7 @@ impl SymbolTable {
                     name,
                     flags,
                     scope_id,
+                    kind: Kind::FreeVar, // default kind until doing second pass
                 });
                 entry.insert_with_hasher(hash, id, (), |symid| {
                     SymbolTable::hash_name(&self.symbols_by_id[*symid].name)

--- a/crates/red_knot/src/symbols.rs
+++ b/crates/red_knot/src/symbols.rs
@@ -132,9 +132,7 @@ bitflags! {
     pub(crate) struct SymbolFlags: u8 {
         const IS_USED         = 1 << 0;
         const IS_DEFINED      = 1 << 1;
-        /// TODO: This flag is not yet set by anything
         const MARKED_GLOBAL   = 1 << 2;
-        /// TODO: This flag is not yet set by anything
         const MARKED_NONLOCAL = 1 << 3;
     }
 }
@@ -739,6 +737,18 @@ impl PreorderVisitor<'_> for SymbolTableBuilder {
                     Some(Definition::Assignment(TypedNodeKey::from_node(node)));
                 ast::visitor::preorder::walk_stmt(self, stmt);
                 self.current_definition = None;
+            }
+            ast::Stmt::Global(ast::StmtGlobal { names, .. }) => {
+                for name in names {
+                    self.add_or_update_symbol(&name.id, SymbolFlags::MARKED_GLOBAL);
+                }
+                ast::visitor::preorder::walk_stmt(self, stmt);
+            }
+            ast::Stmt::Nonlocal(ast::StmtNonlocal { names, .. }) => {
+                for name in names {
+                    self.add_or_update_symbol(&name.id, SymbolFlags::MARKED_NONLOCAL);
+                }
+                ast::visitor::preorder::walk_stmt(self, stmt);
             }
             _ => {
                 ast::visitor::preorder::walk_stmt(self, stmt);


### PR DESCRIPTION
followup to #11134 

* [x] Set `MARKED_NONLOCAL` and `MARKED_GLOBAL` flags during 1st pass (over AST)
* [ ] Add back the `Symbol::kind : Kind` field (or `Symbol::kind : Option<Kind>`?) with an appropriate default
* [ ] During 2nd pass (over symbol table hierarchy) set `Symbol::kind`
* [ ] Tests for each and tests to show precedence when conditions overlap