### PR TITLE
[`flake8-comprehension`] Strip parentheses around generators in C400

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_comprehensions/C400.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_comprehensions/C400.py
@@ -11,6 +11,11 @@ x = list(
     x for x in range(3)
 )
 
+# Strip parentheses from inner generators.
+list((2 * x for x in range(3)))
+list(((2 * x for x in range(3))))
+list((((2 * x for x in range(3)))))
+
 # Not built-in list.
 def list(*args, **kwargs):
     return None

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/snapshots/ruff_linter__rules__flake8_comprehensions__tests__C400_C400.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/snapshots/ruff_linter__rules__flake8_comprehensions__tests__C400_C400.py.snap
@@ -73,7 +73,7 @@ C400.py:10:5: C400 [*] Unnecessary generator (rewrite using `list()`)
 12 | | )
    | |_^ C400
 13 |   
-14 |   # Not built-in list.
+14 |   # Strip parentheses from inner generators.
    |
    = help: Rewrite using `list()`
 
@@ -86,5 +86,66 @@ C400.py:10:5: C400 [*] Unnecessary generator (rewrite using `list()`)
 12    |-)
    10 |+x = list(range(3))
 13 11 | 
-14 12 | # Not built-in list.
-15 13 | def list(*args, **kwargs):
+14 12 | # Strip parentheses from inner generators.
+15 13 | list((2 * x for x in range(3)))
+
+C400.py:15:1: C400 [*] Unnecessary generator (rewrite as a `list` comprehension)
+   |
+14 | # Strip parentheses from inner generators.
+15 | list((2 * x for x in range(3)))
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ C400
+16 | list(((2 * x for x in range(3))))
+17 | list((((2 * x for x in range(3)))))
+   |
+   = help: Rewrite as a `list` comprehension
+
+ℹ Unsafe fix
+12 12 | )
+13 13 | 
+14 14 | # Strip parentheses from inner generators.
+15    |-list((2 * x for x in range(3)))
+   15 |+[2 * x for x in range(3)]
+16 16 | list(((2 * x for x in range(3))))
+17 17 | list((((2 * x for x in range(3)))))
+18 18 | 
+
+C400.py:16:1: C400 [*] Unnecessary generator (rewrite as a `list` comprehension)
+   |
+14 | # Strip parentheses from inner generators.
+15 | list((2 * x for x in range(3)))
+16 | list(((2 * x for x in range(3))))
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ C400
+17 | list((((2 * x for x in range(3)))))
+   |
+   = help: Rewrite as a `list` comprehension
+
+ℹ Unsafe fix
+13 13 | 
+14 14 | # Strip parentheses from inner generators.
+15 15 | list((2 * x for x in range(3)))
+16    |-list(((2 * x for x in range(3))))
+   16 |+[2 * x for x in range(3)]
+17 17 | list((((2 * x for x in range(3)))))
+18 18 | 
+19 19 | # Not built-in list.
+
+C400.py:17:1: C400 [*] Unnecessary generator (rewrite as a `list` comprehension)
+   |
+15 | list((2 * x for x in range(3)))
+16 | list(((2 * x for x in range(3))))
+17 | list((((2 * x for x in range(3)))))
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ C400
+18 | 
+19 | # Not built-in list.
+   |
+   = help: Rewrite as a `list` comprehension
+
+ℹ Unsafe fix
+14 14 | # Strip parentheses from inner generators.
+15 15 | list((2 * x for x in range(3)))
+16 16 | list(((2 * x for x in range(3))))
+17    |-list((((2 * x for x in range(3)))))
+   17 |+[2 * x for x in range(3)]
+18 18 | 
+19 19 | # Not built-in list.
+20 20 | def list(*args, **kwargs):


### PR DESCRIPTION
## Summary

Closes https://github.com/astral-sh/ruff/issues/11603.

