### PR TITLE
Add Vim and Kate setup guide for `ruff server`

### DIFF
--- a/crates/ruff_server/README.md
+++ b/crates/ruff_server/README.md
@@ -60,6 +60,14 @@ See the [Neovim setup guide](docs/setup/NEOVIM.md).
 
 See the [Helix setup guide](docs/setup//HELIX.md).
 
+#### Vim
+
+See the [Vim setup guide](docs/setup/VIM.md).
+
+#### Kate
+
+See the [Kate setup guide](docs/setup/KATE.md).
+
 ### Contributing
 
 If you're interested in contributing to `ruff server` - well, first of all, thank you! Second of all, you might find the

--- a/crates/ruff_server/docs/setup/KATE.md
+++ b/crates/ruff_server/docs/setup/KATE.md
@@ -1,8 +1,8 @@
 ## Kate Setup Guide for `ruff server`
 
 1. Activate the [LSP Client plugin](https://docs.kde.org/stable5/en/kate/kate/plugins.html#kate-application-plugins).
-2. Setup LSP Client [as desired](https://docs.kde.org/stable5/en/kate/kate/kate-application-plugin-lspclient.html).
-3. Finally, add this to Settings -> Configure Kate -> LSP Client -> User Server Settings:
+1. Setup LSP Client [as desired](https://docs.kde.org/stable5/en/kate/kate/kate-application-plugin-lspclient.html).
+1. Finally, add this to Settings -> Configure Kate -> LSP Client -> User Server Settings:
 
 ```json
 {

--- a/crates/ruff_server/docs/setup/KATE.md
+++ b/crates/ruff_server/docs/setup/KATE.md
@@ -2,7 +2,7 @@
 
 1. Activate the [LSP Client plugin](https://docs.kde.org/stable5/en/kate/kate/plugins.html#kate-application-plugins).
 1. Setup LSP Client [as desired](https://docs.kde.org/stable5/en/kate/kate/kate-application-plugin-lspclient.html).
-1. Finally, add this to Settings -> Configure Kate -> LSP Client -> User Server Settings:
+1. Finally, add this to `Settings` -> `Configure Kate` -> `LSP Client` -> `User Server Settings`:
 
 ```json
 {

--- a/crates/ruff_server/docs/setup/KATE.md
+++ b/crates/ruff_server/docs/setup/KATE.md
@@ -1,8 +1,8 @@
 ## Kate Setup Guide for `ruff server`
 
-1. [Activate the `LSP Client` plugin](https://docs.kde.org/stable5/en/kate/kate/plugins.html#kate-application-plugins).
-1. Setup `LSP Client` [as desired](https://docs.kde.org/stable5/en/kate/kate/kate-application-plugin-lspclient.html).
-1. Finally, add this to Settings -> Configure Kate -> LSP Client -> User Server Settings:
+1. Activate the [LSP Client plugin](https://docs.kde.org/stable5/en/kate/kate/plugins.html#kate-application-plugins).
+2. Setup LSP Client [as desired](https://docs.kde.org/stable5/en/kate/kate/kate-application-plugin-lspclient.html).
+3. Finally, add this to Settings -> Configure Kate -> LSP Client -> User Server Settings:
 
 ```json
 {
@@ -17,7 +17,7 @@
 }
 ```
 
-See [`LSP Client`'s documentation](https://docs.kde.org/stable5/en/kate/kate/kate-application-plugin-lspclient.html) for more details
+See [LSP Client documentation](https://docs.kde.org/stable5/en/kate/kate/kate-application-plugin-lspclient.html) for more details
 on how to configure the server from there.
 
 > \[!IMPORTANT\]

--- a/crates/ruff_server/docs/setup/KATE.md
+++ b/crates/ruff_server/docs/setup/KATE.md
@@ -1,0 +1,25 @@
+## Kate Setup Guide for `ruff server`
+
+1. [Activate the `LSP Client` plugin](https://docs.kde.org/stable5/en/kate/kate/plugins.html#kate-application-plugins).
+1. Setup `LSP Client` [as desired](https://docs.kde.org/stable5/en/kate/kate/kate-application-plugin-lspclient.html).
+1. Finally, add this to Settings -> Configure Kate -> LSP Client -> User Server Settings:
+
+```json
+{
+  "servers": {
+    "python": {
+      "command": ["ruff", "server", "--preview"],
+      "url": "https://github.com/astral-sh/ruff",
+      "highlightingModeRegex": "^Python$",
+      "settings": {}
+    }
+  }
+}
+```
+
+See [`LSP Client`'s documentation](https://docs.kde.org/stable5/en/kate/kate/kate-application-plugin-lspclient.html) for more details
+on how to configure the server from there.
+
+> \[!IMPORTANT\]
+>
+> Kate's LSP Client plugin does not support multiple servers for the same language.

--- a/crates/ruff_server/docs/setup/NEOVIM.md
+++ b/crates/ruff_server/docs/setup/NEOVIM.md
@@ -19,7 +19,8 @@ on how to configure the server from there.
 
 #### Tips
 
-If you're using Ruff alongside another LSP (like Pyright), you may want to defer to that LSP for certain capabilities, like `textDocument/hover`:
+If you're using Ruff alongside another LSP (like Pyright), you may want to defer to that LSP for certain capabilities,
+like `textDocument/hover`:
 
 ```lua
 local on_attach = function(client, bufnr)
@@ -34,7 +35,8 @@ require('lspconfig').ruff.setup {
 }
 ```
 
-If you'd like to use Ruff exclusively for linting, formatting, and import organization, you can disable those capabilities for Pyright:
+If you'd like to use Ruff exclusively for linting, formatting, and import organization, you can disable those
+capabilities for Pyright:
 
 ```lua
 require('lspconfig').pyright.setup {

--- a/crates/ruff_server/docs/setup/VIM.md
+++ b/crates/ruff_server/docs/setup/VIM.md
@@ -3,8 +3,8 @@
 ### Using `vim-lsp`
 
 1. Install [`vim-lsp`](https://github.com/prabirshrestha/vim-lsp).
-1. Setup `vim-lsp` [as desired](https://github.com/prabirshrestha/vim-lsp?tab=readme-ov-file#registering-servers).
-1. Finally, add this to your `.vimrc`:
+2. Setup `vim-lsp` [as desired](https://github.com/prabirshrestha/vim-lsp?tab=readme-ov-file#registering-servers).
+3. Finally, add this to your `.vimrc`:
 
 ```vim
 if executable('ruff')

--- a/crates/ruff_server/docs/setup/VIM.md
+++ b/crates/ruff_server/docs/setup/VIM.md
@@ -1,0 +1,42 @@
+## Vim Setup Guide for `ruff server`
+
+### Using `vim-lsp`
+
+1. Install [`vim-lsp`](https://github.com/prabirshrestha/vim-lsp).
+1. Setup `vim-lsp` [as desired](https://github.com/prabirshrestha/vim-lsp?tab=readme-ov-file#registering-servers).
+1. Finally, add this to your `.vimrc`:
+
+```vim
+if executable('ruff')
+    au User lsp_setup call lsp#register_server({
+        \ 'name': 'ruff',
+        \ 'cmd': {server_info->['ruff', 'server', '--preview']},
+        \ 'allowlist': ['python'],
+        \ 'workspace_config': {},
+        \ })
+endif
+```
+
+See [`vim-lsp`'s documentation](https://github.com/prabirshrestha/vim-lsp/blob/master/doc/vim-lsp.txt) for more details
+on how to configure the server from there.
+
+> \[!IMPORTANT\]
+>
+> If you have the older language server (`ruff-lsp`) configured in Vim, make sure to disable it to prevent any conflicts.
+
+#### Tips
+
+If you're using Ruff alongside another LSP (like Pyright), you may want to defer to that LSP for certain capabilities, like `textDocument/hover` by adding the following to the function `s:on_lsp_buffer_enabled()`:
+
+```vim
+function! s:on_lsp_buffer_enabled() abort
+    " add your keybindings here (see https://github.com/prabirshrestha/vim-lsp?tab=readme-ov-file#registering-servers)
+
+    let l:capabilities = lsp#get_server_capabilities('ruff')
+    if !empty(l:capabilities)
+      let l:capabilities.hoverProvider = v:false
+    endif
+endfunction
+```
+
+If you'd like to use Ruff exclusively for linting, formatting, and import organization, you can disable those capabilities for Pyright.

--- a/crates/ruff_server/docs/setup/VIM.md
+++ b/crates/ruff_server/docs/setup/VIM.md
@@ -3,8 +3,8 @@
 ### Using `vim-lsp`
 
 1. Install [`vim-lsp`](https://github.com/prabirshrestha/vim-lsp).
-2. Setup `vim-lsp` [as desired](https://github.com/prabirshrestha/vim-lsp?tab=readme-ov-file#registering-servers).
-3. Finally, add this to your `.vimrc`:
+1. Setup `vim-lsp` [as desired](https://github.com/prabirshrestha/vim-lsp?tab=readme-ov-file#registering-servers).
+1. Finally, add this to your `.vimrc`:
 
 ```vim
 if executable('ruff')

--- a/crates/ruff_server/docs/setup/VIM.md
+++ b/crates/ruff_server/docs/setup/VIM.md
@@ -38,5 +38,3 @@ function! s:on_lsp_buffer_enabled() abort
     endif
 endfunction
 ```
-
-If you'd like to use Ruff exclusively for linting, formatting, and import organization, you can disable those capabilities for Pyright.

--- a/crates/ruff_server/docs/setup/VIM.md
+++ b/crates/ruff_server/docs/setup/VIM.md
@@ -17,16 +17,17 @@ if executable('ruff')
 endif
 ```
 
-See [`vim-lsp`'s documentation](https://github.com/prabirshrestha/vim-lsp/blob/master/doc/vim-lsp.txt) for more details
-on how to configure the server from there.
+See the `vim-lsp` [documentation](https://github.com/prabirshrestha/vim-lsp/blob/master/doc/vim-lsp.txt) for more
+details on how to configure the language server.
 
 > \[!IMPORTANT\]
 >
-> If you have the older language server (`ruff-lsp`) configured in Vim, make sure to disable it to prevent any conflicts.
+> If Ruff's legacy language server (`ruff-lsp`) is configured in Vim, be sure to disable it to prevent any conflicts.
 
 #### Tips
 
-If you're using Ruff alongside another LSP (like Pyright), you may want to defer to that LSP for certain capabilities, like `textDocument/hover` by adding the following to the function `s:on_lsp_buffer_enabled()`:
+If you're using Ruff alongside another LSP (like Pyright), you may want to defer to that LSP for certain capabilities,
+like `textDocument/hover` by adding the following to the function `s:on_lsp_buffer_enabled()`:
 
 ```vim
 function! s:on_lsp_buffer_enabled() abort


### PR DESCRIPTION
## Summary

In the [roadmap for `ruff server`](https://github.com/astral-sh/ruff/discussions/10581) support for vim and kate is listed. Therefore I added setup guides for them based on the neovim guide. As I don't use pyright I wasn't able to translate the corresponding part from the neovim guide.

## Test Plan

Doesn't apply.
