### PR TITLE
Use enum values instead of struct with single field

### DIFF
--- a/crates/ruff_python_parser/src/lexer.rs
+++ b/crates/ruff_python_parser/src/lexer.rs
@@ -1660,23 +1660,14 @@ pub(crate) enum TokenValue {
     #[default]
     None,
     /// Token value for a name, commonly known as an identifier.
-    Name {
-        /// The name value.
-        ///
-        /// Unicode names are NFKC-normalized by the lexer,
-        /// matching [the behaviour of Python's lexer](https://docs.python.org/3/reference/lexical_analysis.html#identifiers)
-        name: Box<str>,
-    },
+    ///
+    /// Unicode names are NFKC-normalized by the lexer,
+    /// matching [the behaviour of Python's lexer](https://docs.python.org/3/reference/lexical_analysis.html#identifiers)
+    Name(Box<str>),
     /// Token value for an integer.
-    Int {
-        /// The integer value.
-        value: Int,
-    },
+    Int(Int),
     /// Token value for a floating point number.
-    Float {
-        /// The float value.
-        value: f64,
-    },
+    Float(f64),
     /// Token value for a complex number.
     Complex {
         /// The real part of the complex number.
@@ -1685,16 +1676,10 @@ pub(crate) enum TokenValue {
         imag: f64,
     },
     /// Token value for a string.
-    String {
-        /// The string value.
-        value: Box<str>,
-    },
+    String(Box<str>),
     /// Token value that includes the portion of text inside the f-string that's not
     /// part of the expression part and isn't an opening or closing brace.
-    FStringMiddle {
-        /// The string value.
-        value: Box<str>,
-    },
+    FStringMiddle(Box<str>),
     /// Token value for IPython escape commands. These are recognized by the lexer
     /// only when the mode is [`Mode::Ipython`].
     IpyEscapeCommand {
@@ -1948,7 +1933,7 @@ mod tests {
         let output = lex(source, mode);
 
         if !output.errors.is_empty() {
-            let mut message = "Unexpected lexical errors for a valid program:\n".to_string();
+            let mut message = "Unexpected lexical errors for a valid source:\n".to_string();
             for error in &output.errors {
                 writeln!(&mut message, "{error:?}").unwrap();
             }

--- a/crates/ruff_python_parser/src/parser/expression.rs
+++ b/crates/ruff_python_parser/src/parser/expression.rs
@@ -475,7 +475,7 @@ impl<'src> Parser<'src> {
         let range = self.current_token_range();
 
         if self.at(TokenKind::Name) {
-            let TokenValue::Name { name } = self.bump_value(TokenKind::Name) else {
+            let TokenValue::Name(name) = self.bump_value(TokenKind::Name) else {
                 unreachable!();
             };
             return ast::Identifier {
@@ -524,7 +524,7 @@ impl<'src> Parser<'src> {
 
         let lhs = match self.current_token_kind() {
             TokenKind::Float => {
-                let TokenValue::Float { value } = self.bump_value(TokenKind::Float) else {
+                let TokenValue::Float(value) = self.bump_value(TokenKind::Float) else {
                     unreachable!()
                 };
 
@@ -543,7 +543,7 @@ impl<'src> Parser<'src> {
                 })
             }
             TokenKind::Int => {
-                let TokenValue::Int { value } = self.bump_value(TokenKind::Int) else {
+                let TokenValue::Int(value) = self.bump_value(TokenKind::Int) else {
                     unreachable!()
                 };
                 Expr::NumberLiteral(ast::ExprNumberLiteral {
@@ -1257,7 +1257,7 @@ impl<'src> Parser<'src> {
         let range = self.current_token_range();
         let flags = self.tokens.current_flags().as_any_string_flags();
 
-        let TokenValue::String { value } = self.bump_value(TokenKind::String) else {
+        let TokenValue::String(value) = self.bump_value(TokenKind::String) else {
             unreachable!()
         };
 
@@ -1332,7 +1332,7 @@ impl<'src> Parser<'src> {
                 }
                 TokenKind::FStringMiddle => {
                     let range = parser.current_token_range();
-                    let TokenValue::FStringMiddle { value } =
+                    let TokenValue::FStringMiddle(value) =
                         parser.bump_value(TokenKind::FStringMiddle)
                     else {
                         unreachable!()
@@ -1427,7 +1427,7 @@ impl<'src> Parser<'src> {
         let conversion = if self.eat(TokenKind::Exclamation) {
             let conversion_flag_range = self.current_token_range();
             if self.at(TokenKind::Name) {
-                let TokenValue::Name { name } = self.bump_value(TokenKind::Name) else {
+                let TokenValue::Name(name) = self.bump_value(TokenKind::Name) else {
                     unreachable!();
                 };
                 match &*name {

--- a/crates/ruff_python_parser/src/parser/pattern.rs
+++ b/crates/ruff_python_parser/src/parser/pattern.rs
@@ -412,7 +412,7 @@ impl<'src> Parser<'src> {
                 })
             }
             TokenKind::Int => {
-                let TokenValue::Int { value } = self.bump_value(TokenKind::Int) else {
+                let TokenValue::Int(value) = self.bump_value(TokenKind::Int) else {
                     unreachable!()
                 };
                 let range = self.node_range(start);
@@ -426,7 +426,7 @@ impl<'src> Parser<'src> {
                 })
             }
             TokenKind::Float => {
-                let TokenValue::Float { value } = self.bump_value(TokenKind::Float) else {
+                let TokenValue::Float(value) = self.bump_value(TokenKind::Float) else {
                     unreachable!()
                 };
                 let range = self.node_range(start);

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__assignment.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__assignment.snap
@@ -6,9 +6,9 @@ expression: lex_source(source)
 ```
 [
     (
-        Name {
-            name: "a_variable",
-        },
+        Name(
+            "a_variable",
+        ),
         0..10,
     ),
     (
@@ -16,9 +16,9 @@ expression: lex_source(source)
         11..12,
     ),
     (
-        Int {
-            value: 99,
-        },
+        Int(
+            99,
+        ),
         13..15,
     ),
     (
@@ -26,9 +26,9 @@ expression: lex_source(source)
         16..17,
     ),
     (
-        Int {
-            value: 2,
-        },
+        Int(
+            2,
+        ),
         18..19,
     ),
     (
@@ -36,9 +36,9 @@ expression: lex_source(source)
         19..20,
     ),
     (
-        Int {
-            value: 0,
-        },
+        Int(
+            0,
+        ),
         20..21,
     ),
     (

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__comment_until_mac_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__comment_until_mac_eol.snap
@@ -6,9 +6,9 @@ expression: comment_until_eol(MAC_EOL)
 ```
 [
     (
-        Int {
-            value: 123,
-        },
+        Int(
+            123,
+        ),
         0..3,
     ),
     (
@@ -20,9 +20,9 @@ expression: comment_until_eol(MAC_EOL)
         10..11,
     ),
     (
-        Int {
-            value: 456,
-        },
+        Int(
+            456,
+        ),
         11..14,
     ),
     (

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__comment_until_unix_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__comment_until_unix_eol.snap
@@ -6,9 +6,9 @@ expression: comment_until_eol(UNIX_EOL)
 ```
 [
     (
-        Int {
-            value: 123,
-        },
+        Int(
+            123,
+        ),
         0..3,
     ),
     (
@@ -20,9 +20,9 @@ expression: comment_until_eol(UNIX_EOL)
         10..11,
     ),
     (
-        Int {
-            value: 456,
-        },
+        Int(
+            456,
+        ),
         11..14,
     ),
     (

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__comment_until_windows_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__comment_until_windows_eol.snap
@@ -6,9 +6,9 @@ expression: comment_until_eol(WINDOWS_EOL)
 ```
 [
     (
-        Int {
-            value: 123,
-        },
+        Int(
+            123,
+        ),
         0..3,
     ),
     (
@@ -20,9 +20,9 @@ expression: comment_until_eol(WINDOWS_EOL)
         10..12,
     ),
     (
-        Int {
-            value: 456,
-        },
+        Int(
+            456,
+        ),
         12..15,
     ),
     (

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__double_dedent_with_mac_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__double_dedent_with_mac_eol.snap
@@ -10,9 +10,9 @@ expression: double_dedent_with_eol(MAC_EOL)
         0..3,
     ),
     (
-        Name {
-            name: "foo",
-        },
+        Name(
+            "foo",
+        ),
         4..7,
     ),
     (
@@ -40,9 +40,9 @@ expression: double_dedent_with_eol(MAC_EOL)
         12..14,
     ),
     (
-        Name {
-            name: "x",
-        },
+        Name(
+            "x",
+        ),
         15..16,
     ),
     (
@@ -66,9 +66,9 @@ expression: double_dedent_with_eol(MAC_EOL)
         21..27,
     ),
     (
-        Int {
-            value: 99,
-        },
+        Int(
+            99,
+        ),
         28..30,
     ),
     (

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__double_dedent_with_tabs_mac_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__double_dedent_with_tabs_mac_eol.snap
@@ -10,9 +10,9 @@ expression: double_dedent_with_tabs_eol(MAC_EOL)
         0..3,
     ),
     (
-        Name {
-            name: "foo",
-        },
+        Name(
+            "foo",
+        ),
         4..7,
     ),
     (
@@ -40,9 +40,9 @@ expression: double_dedent_with_tabs_eol(MAC_EOL)
         12..14,
     ),
     (
-        Name {
-            name: "x",
-        },
+        Name(
+            "x",
+        ),
         15..16,
     ),
     (
@@ -66,9 +66,9 @@ expression: double_dedent_with_tabs_eol(MAC_EOL)
         22..28,
     ),
     (
-        Int {
-            value: 99,
-        },
+        Int(
+            99,
+        ),
         29..31,
     ),
     (

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__double_dedent_with_tabs_unix_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__double_dedent_with_tabs_unix_eol.snap
@@ -10,9 +10,9 @@ expression: double_dedent_with_tabs_eol(UNIX_EOL)
         0..3,
     ),
     (
-        Name {
-            name: "foo",
-        },
+        Name(
+            "foo",
+        ),
         4..7,
     ),
     (
@@ -40,9 +40,9 @@ expression: double_dedent_with_tabs_eol(UNIX_EOL)
         12..14,
     ),
     (
-        Name {
-            name: "x",
-        },
+        Name(
+            "x",
+        ),
         15..16,
     ),
     (
@@ -66,9 +66,9 @@ expression: double_dedent_with_tabs_eol(UNIX_EOL)
         22..28,
     ),
     (
-        Int {
-            value: 99,
-        },
+        Int(
+            99,
+        ),
         29..31,
     ),
     (

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__double_dedent_with_tabs_windows_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__double_dedent_with_tabs_windows_eol.snap
@@ -10,9 +10,9 @@ expression: double_dedent_with_tabs_eol(WINDOWS_EOL)
         0..3,
     ),
     (
-        Name {
-            name: "foo",
-        },
+        Name(
+            "foo",
+        ),
         4..7,
     ),
     (
@@ -40,9 +40,9 @@ expression: double_dedent_with_tabs_eol(WINDOWS_EOL)
         13..15,
     ),
     (
-        Name {
-            name: "x",
-        },
+        Name(
+            "x",
+        ),
         16..17,
     ),
     (
@@ -66,9 +66,9 @@ expression: double_dedent_with_tabs_eol(WINDOWS_EOL)
         25..31,
     ),
     (
-        Int {
-            value: 99,
-        },
+        Int(
+            99,
+        ),
         32..34,
     ),
     (

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__double_dedent_with_unix_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__double_dedent_with_unix_eol.snap
@@ -10,9 +10,9 @@ expression: double_dedent_with_eol(UNIX_EOL)
         0..3,
     ),
     (
-        Name {
-            name: "foo",
-        },
+        Name(
+            "foo",
+        ),
         4..7,
     ),
     (
@@ -40,9 +40,9 @@ expression: double_dedent_with_eol(UNIX_EOL)
         12..14,
     ),
     (
-        Name {
-            name: "x",
-        },
+        Name(
+            "x",
+        ),
         15..16,
     ),
     (
@@ -66,9 +66,9 @@ expression: double_dedent_with_eol(UNIX_EOL)
         21..27,
     ),
     (
-        Int {
-            value: 99,
-        },
+        Int(
+            99,
+        ),
         28..30,
     ),
     (

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__double_dedent_with_windows_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__double_dedent_with_windows_eol.snap
@@ -10,9 +10,9 @@ expression: double_dedent_with_eol(WINDOWS_EOL)
         0..3,
     ),
     (
-        Name {
-            name: "foo",
-        },
+        Name(
+            "foo",
+        ),
         4..7,
     ),
     (
@@ -40,9 +40,9 @@ expression: double_dedent_with_eol(WINDOWS_EOL)
         13..15,
     ),
     (
-        Name {
-            name: "x",
-        },
+        Name(
+            "x",
+        ),
         16..17,
     ),
     (
@@ -66,9 +66,9 @@ expression: double_dedent_with_eol(WINDOWS_EOL)
         24..30,
     ),
     (
-        Int {
-            value: 99,
-        },
+        Int(
+            99,
+        ),
         31..33,
     ),
     (

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__empty_fstrings.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__empty_fstrings.snap
@@ -20,9 +20,9 @@ expression: lex_source(source)
         ),
     ),
     (
-        String {
-            value: "",
-        },
+        String(
+            "",
+        ),
         4..6,
         TokenFlags(
             DOUBLE_QUOTES,
@@ -57,9 +57,9 @@ expression: lex_source(source)
         ),
     ),
     (
-        String {
-            value: "",
-        },
+        String(
+            "",
+        ),
         15..17,
     ),
     (

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__escape_unicode_name.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__escape_unicode_name.snap
@@ -6,9 +6,9 @@ expression: lex_source(source)
 ```
 [
     (
-        String {
-            value: "\\N{EN SPACE}",
-        },
+        String(
+            "\\N{EN SPACE}",
+        ),
         0..14,
         TokenFlags(
             DOUBLE_QUOTES,

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring.snap
@@ -13,9 +13,9 @@ expression: lex_source(source)
         ),
     ),
     (
-        FStringMiddle {
-            value: "normal ",
-        },
+        FStringMiddle(
+            "normal ",
+        ),
         2..9,
         TokenFlags(
             DOUBLE_QUOTES | F_STRING,
@@ -26,9 +26,9 @@ expression: lex_source(source)
         9..10,
     ),
     (
-        Name {
-            name: "foo",
-        },
+        Name(
+            "foo",
+        ),
         10..13,
     ),
     (
@@ -36,9 +36,9 @@ expression: lex_source(source)
         13..14,
     ),
     (
-        FStringMiddle {
-            value: " {another} ",
-        },
+        FStringMiddle(
+            " {another} ",
+        ),
         14..27,
         TokenFlags(
             DOUBLE_QUOTES | F_STRING,
@@ -49,9 +49,9 @@ expression: lex_source(source)
         27..28,
     ),
     (
-        Name {
-            name: "bar",
-        },
+        Name(
+            "bar",
+        ),
         28..31,
     ),
     (
@@ -59,9 +59,9 @@ expression: lex_source(source)
         31..32,
     ),
     (
-        FStringMiddle {
-            value: " {",
-        },
+        FStringMiddle(
+            " {",
+        ),
         32..35,
         TokenFlags(
             DOUBLE_QUOTES | F_STRING,
@@ -72,9 +72,9 @@ expression: lex_source(source)
         35..36,
     ),
     (
-        Name {
-            name: "three",
-        },
+        Name(
+            "three",
+        ),
         36..41,
     ),
     (
@@ -82,9 +82,9 @@ expression: lex_source(source)
         41..42,
     ),
     (
-        FStringMiddle {
-            value: "}",
-        },
+        FStringMiddle(
+            "}",
+        ),
         42..44,
         TokenFlags(
             DOUBLE_QUOTES | F_STRING,

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_comments.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_comments.snap
@@ -13,9 +13,9 @@ expression: lex_source(source)
         ),
     ),
     (
-        FStringMiddle {
-            value: "\n# not a comment ",
-        },
+        FStringMiddle(
+            "\n# not a comment ",
+        ),
         4..21,
         TokenFlags(
             DOUBLE_QUOTES | TRIPLE_QUOTED_STRING | F_STRING,
@@ -34,9 +34,9 @@ expression: lex_source(source)
         34..35,
     ),
     (
-        Name {
-            name: "x",
-        },
+        Name(
+            "x",
+        ),
         39..40,
     ),
     (
@@ -48,9 +48,9 @@ expression: lex_source(source)
         41..42,
     ),
     (
-        FStringMiddle {
-            value: " # not a comment\n",
-        },
+        FStringMiddle(
+            " # not a comment\n",
+        ),
         42..59,
         TokenFlags(
             DOUBLE_QUOTES | TRIPLE_QUOTED_STRING | F_STRING,

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_conversion.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_conversion.snap
@@ -17,9 +17,9 @@ expression: lex_source(source)
         2..3,
     ),
     (
-        Name {
-            name: "x",
-        },
+        Name(
+            "x",
+        ),
         3..4,
     ),
     (
@@ -27,9 +27,9 @@ expression: lex_source(source)
         4..5,
     ),
     (
-        Name {
-            name: "s",
-        },
+        Name(
+            "s",
+        ),
         5..6,
     ),
     (
@@ -37,9 +37,9 @@ expression: lex_source(source)
         6..7,
     ),
     (
-        FStringMiddle {
-            value: " ",
-        },
+        FStringMiddle(
+            " ",
+        ),
         7..8,
         TokenFlags(
             DOUBLE_QUOTES | F_STRING,
@@ -50,9 +50,9 @@ expression: lex_source(source)
         8..9,
     ),
     (
-        Name {
-            name: "x",
-        },
+        Name(
+            "x",
+        ),
         9..10,
     ),
     (
@@ -64,9 +64,9 @@ expression: lex_source(source)
         11..12,
     ),
     (
-        Name {
-            name: "r",
-        },
+        Name(
+            "r",
+        ),
         12..13,
     ),
     (
@@ -74,9 +74,9 @@ expression: lex_source(source)
         13..14,
     ),
     (
-        FStringMiddle {
-            value: " ",
-        },
+        FStringMiddle(
+            " ",
+        ),
         14..15,
         TokenFlags(
             DOUBLE_QUOTES | F_STRING,
@@ -87,9 +87,9 @@ expression: lex_source(source)
         15..16,
     ),
     (
-        Name {
-            name: "x",
-        },
+        Name(
+            "x",
+        ),
         16..17,
     ),
     (
@@ -97,9 +97,9 @@ expression: lex_source(source)
         17..18,
     ),
     (
-        FStringMiddle {
-            value: ".3f!r",
-        },
+        FStringMiddle(
+            ".3f!r",
+        ),
         18..23,
         TokenFlags(
             DOUBLE_QUOTES | F_STRING,
@@ -110,9 +110,9 @@ expression: lex_source(source)
         23..24,
     ),
     (
-        FStringMiddle {
-            value: " {x!r}",
-        },
+        FStringMiddle(
+            " {x!r}",
+        ),
         24..32,
         TokenFlags(
             DOUBLE_QUOTES | F_STRING,

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_escape.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_escape.snap
@@ -13,9 +13,9 @@ expression: lex_source(source)
         ),
     ),
     (
-        FStringMiddle {
-            value: "\\",
-        },
+        FStringMiddle(
+            "\\",
+        ),
         2..3,
         TokenFlags(
             DOUBLE_QUOTES | F_STRING,
@@ -26,9 +26,9 @@ expression: lex_source(source)
         3..4,
     ),
     (
-        Name {
-            name: "x",
-        },
+        Name(
+            "x",
+        ),
         4..5,
     ),
     (
@@ -36,9 +36,9 @@ expression: lex_source(source)
         5..6,
     ),
     (
-        FStringMiddle {
-            value: "\\\"\\",
-        },
+        FStringMiddle(
+            "\\\"\\",
+        ),
         6..9,
         TokenFlags(
             DOUBLE_QUOTES | F_STRING,
@@ -49,9 +49,9 @@ expression: lex_source(source)
         9..10,
     ),
     (
-        Name {
-            name: "x",
-        },
+        Name(
+            "x",
+        ),
         10..11,
     ),
     (
@@ -63,9 +63,9 @@ expression: lex_source(source)
         12..13,
     ),
     (
-        FStringMiddle {
-            value: " \\\"\\\"\\\n end",
-        },
+        FStringMiddle(
+            " \\\"\\\"\\\n end",
+        ),
         13..24,
         TokenFlags(
             DOUBLE_QUOTES | F_STRING,

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_escape_braces.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_escape_braces.snap
@@ -13,9 +13,9 @@ expression: lex_source(source)
         ),
     ),
     (
-        FStringMiddle {
-            value: "\\",
-        },
+        FStringMiddle(
+            "\\",
+        ),
         2..3,
         TokenFlags(
             F_STRING,
@@ -26,9 +26,9 @@ expression: lex_source(source)
         3..4,
     ),
     (
-        Name {
-            name: "foo",
-        },
+        Name(
+            "foo",
+        ),
         4..7,
     ),
     (
@@ -50,9 +50,9 @@ expression: lex_source(source)
         ),
     ),
     (
-        FStringMiddle {
-            value: "\\\\",
-        },
+        FStringMiddle(
+            "\\\\",
+        ),
         12..14,
         TokenFlags(
             F_STRING,
@@ -63,9 +63,9 @@ expression: lex_source(source)
         14..15,
     ),
     (
-        Name {
-            name: "foo",
-        },
+        Name(
+            "foo",
+        ),
         15..18,
     ),
     (
@@ -87,9 +87,9 @@ expression: lex_source(source)
         ),
     ),
     (
-        FStringMiddle {
-            value: "\\{foo}",
-        },
+        FStringMiddle(
+            "\\{foo}",
+        ),
         23..31,
         TokenFlags(
             F_STRING,
@@ -110,9 +110,9 @@ expression: lex_source(source)
         ),
     ),
     (
-        FStringMiddle {
-            value: "\\\\{foo}",
-        },
+        FStringMiddle(
+            "\\\\{foo}",
+        ),
         35..44,
         TokenFlags(
             F_STRING,

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_escape_raw.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_escape_raw.snap
@@ -13,9 +13,9 @@ expression: lex_source(source)
         ),
     ),
     (
-        FStringMiddle {
-            value: "\\",
-        },
+        FStringMiddle(
+            "\\",
+        ),
         3..4,
         TokenFlags(
             DOUBLE_QUOTES | F_STRING | RAW_STRING_LOWERCASE,
@@ -26,9 +26,9 @@ expression: lex_source(source)
         4..5,
     ),
     (
-        Name {
-            name: "x",
-        },
+        Name(
+            "x",
+        ),
         5..6,
     ),
     (
@@ -36,9 +36,9 @@ expression: lex_source(source)
         6..7,
     ),
     (
-        FStringMiddle {
-            value: "\\\"\\",
-        },
+        FStringMiddle(
+            "\\\"\\",
+        ),
         7..10,
         TokenFlags(
             DOUBLE_QUOTES | F_STRING | RAW_STRING_LOWERCASE,
@@ -49,9 +49,9 @@ expression: lex_source(source)
         10..11,
     ),
     (
-        Name {
-            name: "x",
-        },
+        Name(
+            "x",
+        ),
         11..12,
     ),
     (
@@ -63,9 +63,9 @@ expression: lex_source(source)
         13..14,
     ),
     (
-        FStringMiddle {
-            value: " \\\"\\\"\\\n end",
-        },
+        FStringMiddle(
+            " \\\"\\\"\\\n end",
+        ),
         14..25,
         TokenFlags(
             DOUBLE_QUOTES | F_STRING | RAW_STRING_LOWERCASE,

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_expression_multiline.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_expression_multiline.snap
@@ -13,9 +13,9 @@ expression: lex_source(source)
         ),
     ),
     (
-        FStringMiddle {
-            value: "first ",
-        },
+        FStringMiddle(
+            "first ",
+        ),
         2..8,
         TokenFlags(
             DOUBLE_QUOTES | F_STRING,
@@ -30,9 +30,9 @@ expression: lex_source(source)
         9..10,
     ),
     (
-        Name {
-            name: "x",
-        },
+        Name(
+            "x",
+        ),
         14..15,
     ),
     (
@@ -48,9 +48,9 @@ expression: lex_source(source)
         25..26,
     ),
     (
-        Name {
-            name: "y",
-        },
+        Name(
+            "y",
+        ),
         38..39,
     ),
     (
@@ -62,9 +62,9 @@ expression: lex_source(source)
         40..41,
     ),
     (
-        FStringMiddle {
-            value: " second",
-        },
+        FStringMiddle(
+            " second",
+        ),
         41..48,
         TokenFlags(
             DOUBLE_QUOTES | F_STRING,

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_multiline.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_multiline.snap
@@ -13,9 +13,9 @@ expression: lex_source(source)
         ),
     ),
     (
-        FStringMiddle {
-            value: "\nhello\n    world\n",
-        },
+        FStringMiddle(
+            "\nhello\n    world\n",
+        ),
         4..21,
         TokenFlags(
             DOUBLE_QUOTES | TRIPLE_QUOTED_STRING | F_STRING,
@@ -36,9 +36,9 @@ expression: lex_source(source)
         ),
     ),
     (
-        FStringMiddle {
-            value: "\n    world\nhello\n",
-        },
+        FStringMiddle(
+            "\n    world\nhello\n",
+        ),
         29..46,
         TokenFlags(
             TRIPLE_QUOTED_STRING | F_STRING,
@@ -59,9 +59,9 @@ expression: lex_source(source)
         ),
     ),
     (
-        FStringMiddle {
-            value: "some ",
-        },
+        FStringMiddle(
+            "some ",
+        ),
         52..57,
         TokenFlags(
             DOUBLE_QUOTES | F_STRING,
@@ -79,9 +79,9 @@ expression: lex_source(source)
         ),
     ),
     (
-        FStringMiddle {
-            value: "multiline\nallowed ",
-        },
+        FStringMiddle(
+            "multiline\nallowed ",
+        ),
         62..80,
         TokenFlags(
             DOUBLE_QUOTES | TRIPLE_QUOTED_STRING | F_STRING,
@@ -92,9 +92,9 @@ expression: lex_source(source)
         80..81,
     ),
     (
-        Name {
-            name: "x",
-        },
+        Name(
+            "x",
+        ),
         81..82,
     ),
     (
@@ -113,9 +113,9 @@ expression: lex_source(source)
         86..87,
     ),
     (
-        FStringMiddle {
-            value: " string",
-        },
+        FStringMiddle(
+            " string",
+        ),
         87..94,
         TokenFlags(
             DOUBLE_QUOTES | F_STRING,

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_named_unicode.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_named_unicode.snap
@@ -13,9 +13,9 @@ expression: lex_source(source)
         ),
     ),
     (
-        FStringMiddle {
-            value: "\\N{BULLET} normal \\Nope \\N",
-        },
+        FStringMiddle(
+            "\\N{BULLET} normal \\Nope \\N",
+        ),
         2..28,
         TokenFlags(
             DOUBLE_QUOTES | F_STRING,

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_named_unicode_raw.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_named_unicode_raw.snap
@@ -13,9 +13,9 @@ expression: lex_source(source)
         ),
     ),
     (
-        FStringMiddle {
-            value: "\\N",
-        },
+        FStringMiddle(
+            "\\N",
+        ),
         3..5,
         TokenFlags(
             DOUBLE_QUOTES | F_STRING | RAW_STRING_LOWERCASE,
@@ -26,9 +26,9 @@ expression: lex_source(source)
         5..6,
     ),
     (
-        Name {
-            name: "BULLET",
-        },
+        Name(
+            "BULLET",
+        ),
         6..12,
     ),
     (
@@ -36,9 +36,9 @@ expression: lex_source(source)
         12..13,
     ),
     (
-        FStringMiddle {
-            value: " normal",
-        },
+        FStringMiddle(
+            " normal",
+        ),
         13..20,
         TokenFlags(
             DOUBLE_QUOTES | F_STRING | RAW_STRING_LOWERCASE,

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_nested.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_nested.snap
@@ -13,9 +13,9 @@ expression: lex_source(source)
         ),
     ),
     (
-        FStringMiddle {
-            value: "foo ",
-        },
+        FStringMiddle(
+            "foo ",
+        ),
         2..6,
         TokenFlags(
             DOUBLE_QUOTES | F_STRING,
@@ -33,9 +33,9 @@ expression: lex_source(source)
         ),
     ),
     (
-        FStringMiddle {
-            value: "bar ",
-        },
+        FStringMiddle(
+            "bar ",
+        ),
         9..13,
         TokenFlags(
             DOUBLE_QUOTES | F_STRING,
@@ -46,9 +46,9 @@ expression: lex_source(source)
         13..14,
     ),
     (
-        Name {
-            name: "x",
-        },
+        Name(
+            "x",
+        ),
         14..15,
     ),
     (
@@ -67,9 +67,9 @@ expression: lex_source(source)
         20..21,
     ),
     (
-        Name {
-            name: "wow",
-        },
+        Name(
+            "wow",
+        ),
         21..24,
     ),
     (
@@ -99,9 +99,9 @@ expression: lex_source(source)
         28..29,
     ),
     (
-        FStringMiddle {
-            value: " baz",
-        },
+        FStringMiddle(
+            " baz",
+        ),
         29..33,
         TokenFlags(
             DOUBLE_QUOTES | F_STRING,
@@ -122,9 +122,9 @@ expression: lex_source(source)
         ),
     ),
     (
-        FStringMiddle {
-            value: "foo ",
-        },
+        FStringMiddle(
+            "foo ",
+        ),
         37..41,
         TokenFlags(
             F_STRING,
@@ -142,9 +142,9 @@ expression: lex_source(source)
         ),
     ),
     (
-        FStringMiddle {
-            value: "bar",
-        },
+        FStringMiddle(
+            "bar",
+        ),
         44..47,
         TokenFlags(
             F_STRING,
@@ -162,9 +162,9 @@ expression: lex_source(source)
         48..49,
     ),
     (
-        FStringMiddle {
-            value: " some ",
-        },
+        FStringMiddle(
+            " some ",
+        ),
         49..55,
         TokenFlags(
             F_STRING,
@@ -182,9 +182,9 @@ expression: lex_source(source)
         ),
     ),
     (
-        FStringMiddle {
-            value: "another",
-        },
+        FStringMiddle(
+            "another",
+        ),
         58..65,
         TokenFlags(
             DOUBLE_QUOTES | F_STRING,

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_parentheses.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_parentheses.snap
@@ -35,9 +35,9 @@ expression: lex_source(source)
         ),
     ),
     (
-        FStringMiddle {
-            value: "{}",
-        },
+        FStringMiddle(
+            "{}",
+        ),
         8..12,
         TokenFlags(
             DOUBLE_QUOTES | F_STRING,
@@ -58,9 +58,9 @@ expression: lex_source(source)
         ),
     ),
     (
-        FStringMiddle {
-            value: " ",
-        },
+        FStringMiddle(
+            " ",
+        ),
         16..17,
         TokenFlags(
             DOUBLE_QUOTES | F_STRING,
@@ -89,9 +89,9 @@ expression: lex_source(source)
         ),
     ),
     (
-        FStringMiddle {
-            value: "{",
-        },
+        FStringMiddle(
+            "{",
+        ),
         23..25,
         TokenFlags(
             DOUBLE_QUOTES | F_STRING,
@@ -106,9 +106,9 @@ expression: lex_source(source)
         26..27,
     ),
     (
-        FStringMiddle {
-            value: "}",
-        },
+        FStringMiddle(
+            "}",
+        ),
         27..29,
         TokenFlags(
             DOUBLE_QUOTES | F_STRING,
@@ -129,9 +129,9 @@ expression: lex_source(source)
         ),
     ),
     (
-        FStringMiddle {
-            value: "{{}}",
-        },
+        FStringMiddle(
+            "{{}}",
+        ),
         33..41,
         TokenFlags(
             DOUBLE_QUOTES | F_STRING,
@@ -152,9 +152,9 @@ expression: lex_source(source)
         ),
     ),
     (
-        FStringMiddle {
-            value: " ",
-        },
+        FStringMiddle(
+            " ",
+        ),
         45..46,
         TokenFlags(
             DOUBLE_QUOTES | F_STRING,
@@ -169,9 +169,9 @@ expression: lex_source(source)
         47..48,
     ),
     (
-        FStringMiddle {
-            value: " {} {",
-        },
+        FStringMiddle(
+            " {} {",
+        ),
         48..56,
         TokenFlags(
             DOUBLE_QUOTES | F_STRING,
@@ -186,9 +186,9 @@ expression: lex_source(source)
         57..58,
     ),
     (
-        FStringMiddle {
-            value: "} {{}}  ",
-        },
+        FStringMiddle(
+            "} {{}}  ",
+        ),
         58..71,
         TokenFlags(
             DOUBLE_QUOTES | F_STRING,

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_single_quote_escape_mac_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_single_quote_escape_mac_eol.snap
@@ -13,9 +13,9 @@ expression: fstring_single_quote_escape_eol(MAC_EOL)
         ),
     ),
     (
-        FStringMiddle {
-            value: "text \\\r more text",
-        },
+        FStringMiddle(
+            "text \\\r more text",
+        ),
         2..19,
         TokenFlags(
             F_STRING,

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_single_quote_escape_unix_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_single_quote_escape_unix_eol.snap
@@ -13,9 +13,9 @@ expression: fstring_single_quote_escape_eol(UNIX_EOL)
         ),
     ),
     (
-        FStringMiddle {
-            value: "text \\\n more text",
-        },
+        FStringMiddle(
+            "text \\\n more text",
+        ),
         2..19,
         TokenFlags(
             F_STRING,

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_single_quote_escape_windows_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_single_quote_escape_windows_eol.snap
@@ -13,9 +13,9 @@ expression: fstring_single_quote_escape_eol(WINDOWS_EOL)
         ),
     ),
     (
-        FStringMiddle {
-            value: "text \\\r\n more text",
-        },
+        FStringMiddle(
+            "text \\\r\n more text",
+        ),
         2..20,
         TokenFlags(
             F_STRING,

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_with_format_spec.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_with_format_spec.snap
@@ -17,9 +17,9 @@ expression: lex_source(source)
         2..3,
     ),
     (
-        Name {
-            name: "foo",
-        },
+        Name(
+            "foo",
+        ),
         3..6,
     ),
     (
@@ -31,9 +31,9 @@ expression: lex_source(source)
         7..8,
     ),
     (
-        FStringMiddle {
-            value: " ",
-        },
+        FStringMiddle(
+            " ",
+        ),
         8..9,
         TokenFlags(
             DOUBLE_QUOTES | F_STRING,
@@ -44,9 +44,9 @@ expression: lex_source(source)
         9..10,
     ),
     (
-        Name {
-            name: "x",
-        },
+        Name(
+            "x",
+        ),
         10..11,
     ),
     (
@@ -58,9 +58,9 @@ expression: lex_source(source)
         12..13,
     ),
     (
-        Name {
-            name: "s",
-        },
+        Name(
+            "s",
+        ),
         13..14,
     ),
     (
@@ -68,9 +68,9 @@ expression: lex_source(source)
         14..15,
     ),
     (
-        FStringMiddle {
-            value: ".3f",
-        },
+        FStringMiddle(
+            ".3f",
+        ),
         15..18,
         TokenFlags(
             DOUBLE_QUOTES | F_STRING,
@@ -81,9 +81,9 @@ expression: lex_source(source)
         18..19,
     ),
     (
-        FStringMiddle {
-            value: " ",
-        },
+        FStringMiddle(
+            " ",
+        ),
         19..20,
         TokenFlags(
             DOUBLE_QUOTES | F_STRING,
@@ -94,9 +94,9 @@ expression: lex_source(source)
         20..21,
     ),
     (
-        Name {
-            name: "x",
-        },
+        Name(
+            "x",
+        ),
         21..22,
     ),
     (
@@ -104,9 +104,9 @@ expression: lex_source(source)
         22..23,
     ),
     (
-        FStringMiddle {
-            value: ".",
-        },
+        FStringMiddle(
+            ".",
+        ),
         23..24,
         TokenFlags(
             DOUBLE_QUOTES | F_STRING,
@@ -117,9 +117,9 @@ expression: lex_source(source)
         24..25,
     ),
     (
-        Name {
-            name: "y",
-        },
+        Name(
+            "y",
+        ),
         25..26,
     ),
     (
@@ -127,9 +127,9 @@ expression: lex_source(source)
         26..27,
     ),
     (
-        FStringMiddle {
-            value: "f",
-        },
+        FStringMiddle(
+            "f",
+        ),
         27..28,
         TokenFlags(
             DOUBLE_QUOTES | F_STRING,
@@ -140,9 +140,9 @@ expression: lex_source(source)
         28..29,
     ),
     (
-        FStringMiddle {
-            value: " ",
-        },
+        FStringMiddle(
+            " ",
+        ),
         29..30,
         TokenFlags(
             DOUBLE_QUOTES | F_STRING,
@@ -153,9 +153,9 @@ expression: lex_source(source)
         30..31,
     ),
     (
-        String {
-            value: "",
-        },
+        String(
+            "",
+        ),
         31..33,
     ),
     (
@@ -163,9 +163,9 @@ expression: lex_source(source)
         33..34,
     ),
     (
-        FStringMiddle {
-            value: "*^",
-        },
+        FStringMiddle(
+            "*^",
+        ),
         34..36,
         TokenFlags(
             DOUBLE_QUOTES | F_STRING,
@@ -176,9 +176,9 @@ expression: lex_source(source)
         36..37,
     ),
     (
-        Int {
-            value: 1,
-        },
+        Int(
+            1,
+        ),
         37..38,
     ),
     (
@@ -190,9 +190,9 @@ expression: lex_source(source)
         39..40,
     ),
     (
-        Int {
-            value: 1,
-        },
+        Int(
+            1,
+        ),
         40..41,
     ),
     (
@@ -208,9 +208,9 @@ expression: lex_source(source)
         43..44,
     ),
     (
-        FStringMiddle {
-            value: " ",
-        },
+        FStringMiddle(
+            " ",
+        ),
         44..45,
         TokenFlags(
             DOUBLE_QUOTES | F_STRING,
@@ -221,9 +221,9 @@ expression: lex_source(source)
         45..46,
     ),
     (
-        Name {
-            name: "x",
-        },
+        Name(
+            "x",
+        ),
         46..47,
     ),
     (
@@ -239,9 +239,9 @@ expression: lex_source(source)
         49..50,
     ),
     (
-        Int {
-            value: 1,
-        },
+        Int(
+            1,
+        ),
         50..51,
     ),
     (
@@ -253,9 +253,9 @@ expression: lex_source(source)
         52..53,
     ),
     (
-        Name {
-            name: "pop",
-        },
+        Name(
+            "pop",
+        ),
         53..56,
     ),
     (

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_with_ipy_escape_command.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_with_ipy_escape_command.snap
@@ -13,9 +13,9 @@ expression: lex_source(source)
         ),
     ),
     (
-        FStringMiddle {
-            value: "foo ",
-        },
+        FStringMiddle(
+            "foo ",
+        ),
         2..6,
         TokenFlags(
             DOUBLE_QUOTES | F_STRING,
@@ -30,9 +30,9 @@ expression: lex_source(source)
         7..8,
     ),
     (
-        Name {
-            name: "pwd",
-        },
+        Name(
+            "pwd",
+        ),
         8..11,
     ),
     (
@@ -40,9 +40,9 @@ expression: lex_source(source)
         11..12,
     ),
     (
-        FStringMiddle {
-            value: " bar",
-        },
+        FStringMiddle(
+            " bar",
+        ),
         12..16,
         TokenFlags(
             DOUBLE_QUOTES | F_STRING,

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_with_lambda_expression.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_with_lambda_expression.snap
@@ -21,9 +21,9 @@ expression: lex_source(source)
         3..9,
     ),
     (
-        Name {
-            name: "x",
-        },
+        Name(
+            "x",
+        ),
         10..11,
     ),
     (
@@ -35,9 +35,9 @@ expression: lex_source(source)
         12..13,
     ),
     (
-        Name {
-            name: "x",
-        },
+        Name(
+            "x",
+        ),
         13..14,
     ),
     (
@@ -79,9 +79,9 @@ expression: lex_source(source)
         22..28,
     ),
     (
-        Name {
-            name: "x",
-        },
+        Name(
+            "x",
+        ),
         29..30,
     ),
     (
@@ -93,9 +93,9 @@ expression: lex_source(source)
         31..32,
     ),
     (
-        Name {
-            name: "x",
-        },
+        Name(
+            "x",
+        ),
         32..33,
     ),
     (

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_with_multiline_format_spec.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_with_multiline_format_spec.snap
@@ -13,9 +13,9 @@ expression: lex_source(source)
         ),
     ),
     (
-        FStringMiddle {
-            value: "__",
-        },
+        FStringMiddle(
+            "__",
+        ),
         4..6,
         TokenFlags(
             TRIPLE_QUOTED_STRING | F_STRING,
@@ -30,9 +30,9 @@ expression: lex_source(source)
         7..8,
     ),
     (
-        Name {
-            name: "x",
-        },
+        Name(
+            "x",
+        ),
         12..13,
     ),
     (
@@ -40,9 +40,9 @@ expression: lex_source(source)
         13..14,
     ),
     (
-        FStringMiddle {
-            value: "d\n",
-        },
+        FStringMiddle(
+            "d\n",
+        ),
         14..16,
         TokenFlags(
             TRIPLE_QUOTED_STRING | F_STRING,
@@ -53,9 +53,9 @@ expression: lex_source(source)
         16..17,
     ),
     (
-        FStringMiddle {
-            value: "__",
-        },
+        FStringMiddle(
+            "__",
+        ),
         17..19,
         TokenFlags(
             TRIPLE_QUOTED_STRING | F_STRING,
@@ -80,9 +80,9 @@ expression: lex_source(source)
         ),
     ),
     (
-        FStringMiddle {
-            value: "__",
-        },
+        FStringMiddle(
+            "__",
+        ),
         27..29,
         TokenFlags(
             TRIPLE_QUOTED_STRING | F_STRING,
@@ -97,9 +97,9 @@ expression: lex_source(source)
         30..31,
     ),
     (
-        Name {
-            name: "x",
-        },
+        Name(
+            "x",
+        ),
         35..36,
     ),
     (
@@ -107,9 +107,9 @@ expression: lex_source(source)
         36..37,
     ),
     (
-        FStringMiddle {
-            value: "a\n        b\n          c\n",
-        },
+        FStringMiddle(
+            "a\n        b\n          c\n",
+        ),
         37..61,
         TokenFlags(
             TRIPLE_QUOTED_STRING | F_STRING,
@@ -120,9 +120,9 @@ expression: lex_source(source)
         61..62,
     ),
     (
-        FStringMiddle {
-            value: "__",
-        },
+        FStringMiddle(
+            "__",
+        ),
         62..64,
         TokenFlags(
             TRIPLE_QUOTED_STRING | F_STRING,
@@ -147,9 +147,9 @@ expression: lex_source(source)
         ),
     ),
     (
-        FStringMiddle {
-            value: "__",
-        },
+        FStringMiddle(
+            "__",
+        ),
         70..72,
         TokenFlags(
             F_STRING,
@@ -164,9 +164,9 @@ expression: lex_source(source)
         73..74,
     ),
     (
-        Name {
-            name: "x",
-        },
+        Name(
+            "x",
+        ),
         78..79,
     ),
     (
@@ -174,9 +174,9 @@ expression: lex_source(source)
         79..80,
     ),
     (
-        FStringMiddle {
-            value: "d",
-        },
+        FStringMiddle(
+            "d",
+        ),
         80..81,
         TokenFlags(
             F_STRING,
@@ -191,9 +191,9 @@ expression: lex_source(source)
         82..83,
     ),
     (
-        FStringMiddle {
-            value: "__",
-        },
+        FStringMiddle(
+            "__",
+        ),
         83..85,
         TokenFlags(
             F_STRING,
@@ -218,9 +218,9 @@ expression: lex_source(source)
         ),
     ),
     (
-        FStringMiddle {
-            value: "__",
-        },
+        FStringMiddle(
+            "__",
+        ),
         89..91,
         TokenFlags(
             F_STRING,
@@ -235,9 +235,9 @@ expression: lex_source(source)
         92..93,
     ),
     (
-        Name {
-            name: "x",
-        },
+        Name(
+            "x",
+        ),
         97..98,
     ),
     (
@@ -245,9 +245,9 @@ expression: lex_source(source)
         98..99,
     ),
     (
-        FStringMiddle {
-            value: "a",
-        },
+        FStringMiddle(
+            "a",
+        ),
         99..100,
         TokenFlags(
             F_STRING,
@@ -258,9 +258,9 @@ expression: lex_source(source)
         100..101,
     ),
     (
-        Name {
-            name: "b",
-        },
+        Name(
+            "b",
+        ),
         109..110,
     ),
     (
@@ -272,9 +272,9 @@ expression: lex_source(source)
         111..112,
     ),
     (
-        FStringMiddle {
-            value: "__",
-        },
+        FStringMiddle(
+            "__",
+        ),
         112..114,
         TokenFlags(
             F_STRING,

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_with_named_expression.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_with_named_expression.snap
@@ -17,9 +17,9 @@ expression: lex_source(source)
         2..3,
     ),
     (
-        Name {
-            name: "x",
-        },
+        Name(
+            "x",
+        ),
         3..4,
     ),
     (
@@ -27,9 +27,9 @@ expression: lex_source(source)
         4..5,
     ),
     (
-        FStringMiddle {
-            value: "=10",
-        },
+        FStringMiddle(
+            "=10",
+        ),
         5..8,
         TokenFlags(
             DOUBLE_QUOTES | F_STRING,
@@ -40,9 +40,9 @@ expression: lex_source(source)
         8..9,
     ),
     (
-        FStringMiddle {
-            value: " ",
-        },
+        FStringMiddle(
+            " ",
+        ),
         9..10,
         TokenFlags(
             DOUBLE_QUOTES | F_STRING,
@@ -57,9 +57,9 @@ expression: lex_source(source)
         11..12,
     ),
     (
-        Name {
-            name: "x",
-        },
+        Name(
+            "x",
+        ),
         12..13,
     ),
     (
@@ -67,9 +67,9 @@ expression: lex_source(source)
         13..15,
     ),
     (
-        Int {
-            value: 10,
-        },
+        Int(
+            10,
+        ),
         15..17,
     ),
     (
@@ -81,9 +81,9 @@ expression: lex_source(source)
         18..19,
     ),
     (
-        FStringMiddle {
-            value: " ",
-        },
+        FStringMiddle(
+            " ",
+        ),
         19..20,
         TokenFlags(
             DOUBLE_QUOTES | F_STRING,
@@ -94,9 +94,9 @@ expression: lex_source(source)
         20..21,
     ),
     (
-        Name {
-            name: "x",
-        },
+        Name(
+            "x",
+        ),
         21..22,
     ),
     (
@@ -108,9 +108,9 @@ expression: lex_source(source)
         23..24,
     ),
     (
-        Name {
-            name: "y",
-        },
+        Name(
+            "y",
+        ),
         24..25,
     ),
     (
@@ -118,9 +118,9 @@ expression: lex_source(source)
         25..27,
     ),
     (
-        Int {
-            value: 10,
-        },
+        Int(
+            10,
+        ),
         27..29,
     ),
     (
@@ -132,9 +132,9 @@ expression: lex_source(source)
         30..31,
     ),
     (
-        FStringMiddle {
-            value: " ",
-        },
+        FStringMiddle(
+            " ",
+        ),
         31..32,
         TokenFlags(
             DOUBLE_QUOTES | F_STRING,
@@ -149,9 +149,9 @@ expression: lex_source(source)
         33..34,
     ),
     (
-        Name {
-            name: "x",
-        },
+        Name(
+            "x",
+        ),
         34..35,
     ),
     (
@@ -159,9 +159,9 @@ expression: lex_source(source)
         35..37,
     ),
     (
-        Int {
-            value: 10,
-        },
+        Int(
+            10,
+        ),
         37..39,
     ),
     (

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_with_nul_char.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_with_nul_char.snap
@@ -13,9 +13,9 @@ expression: lex_source(source)
         ),
     ),
     (
-        FStringMiddle {
-            value: "\\0",
-        },
+        FStringMiddle(
+            "\\0",
+        ),
         2..4,
         TokenFlags(
             F_STRING,

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__indentation_with_mac_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__indentation_with_mac_eol.snap
@@ -10,9 +10,9 @@ expression: indentation_with_eol(MAC_EOL)
         0..3,
     ),
     (
-        Name {
-            name: "foo",
-        },
+        Name(
+            "foo",
+        ),
         4..7,
     ),
     (
@@ -40,9 +40,9 @@ expression: indentation_with_eol(MAC_EOL)
         15..21,
     ),
     (
-        Int {
-            value: 99,
-        },
+        Int(
+            99,
+        ),
         22..24,
     ),
     (

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__indentation_with_unix_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__indentation_with_unix_eol.snap
@@ -10,9 +10,9 @@ expression: indentation_with_eol(UNIX_EOL)
         0..3,
     ),
     (
-        Name {
-            name: "foo",
-        },
+        Name(
+            "foo",
+        ),
         4..7,
     ),
     (
@@ -40,9 +40,9 @@ expression: indentation_with_eol(UNIX_EOL)
         15..21,
     ),
     (
-        Int {
-            value: 99,
-        },
+        Int(
+            99,
+        ),
         22..24,
     ),
     (

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__indentation_with_windows_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__indentation_with_windows_eol.snap
@@ -10,9 +10,9 @@ expression: indentation_with_eol(WINDOWS_EOL)
         0..3,
     ),
     (
-        Name {
-            name: "foo",
-        },
+        Name(
+            "foo",
+        ),
         4..7,
     ),
     (
@@ -40,9 +40,9 @@ expression: indentation_with_eol(WINDOWS_EOL)
         16..22,
     ),
     (
-        Int {
-            value: 99,
-        },
+        Int(
+            99,
+        ),
         23..25,
     ),
     (

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__ipython_escape_command_assignment.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__ipython_escape_command_assignment.snap
@@ -6,9 +6,9 @@ expression: lex_jupyter_source(source)
 ```
 [
     (
-        Name {
-            name: "pwd",
-        },
+        Name(
+            "pwd",
+        ),
         0..3,
     ),
     (
@@ -27,9 +27,9 @@ expression: lex_jupyter_source(source)
         10..11,
     ),
     (
-        Name {
-            name: "foo",
-        },
+        Name(
+            "foo",
+        ),
         11..14,
     ),
     (
@@ -48,9 +48,9 @@ expression: lex_jupyter_source(source)
         30..31,
     ),
     (
-        Name {
-            name: "bar",
-        },
+        Name(
+            "bar",
+        ),
         31..34,
     ),
     (
@@ -69,9 +69,9 @@ expression: lex_jupyter_source(source)
         50..51,
     ),
     (
-        Name {
-            name: "baz",
-        },
+        Name(
+            "baz",
+        ),
         51..54,
     ),
     (

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__line_comment_empty.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__line_comment_empty.snap
@@ -6,9 +6,9 @@ expression: lex_source(&source)
 ```
 [
     (
-        Int {
-            value: 99232,
-        },
+        Int(
+            99232,
+        ),
         0..5,
     ),
     (

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__line_comment_long.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__line_comment_long.snap
@@ -6,9 +6,9 @@ expression: lex_source(&source)
 ```
 [
     (
-        Int {
-            value: 99232,
-        },
+        Int(
+            99232,
+        ),
         0..5,
     ),
     (

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__line_comment_single_whitespace.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__line_comment_single_whitespace.snap
@@ -6,9 +6,9 @@ expression: lex_source(&source)
 ```
 [
     (
-        Int {
-            value: 99232,
-        },
+        Int(
+            99232,
+        ),
         0..5,
     ),
     (

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__line_comment_whitespace.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__line_comment_whitespace.snap
@@ -6,9 +6,9 @@ expression: lex_source(&source)
 ```
 [
     (
-        Int {
-            value: 99232,
-        },
+        Int(
+            99232,
+        ),
         0..5,
     ),
     (

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__match_softkeyword_in_notebook.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__match_softkeyword_in_notebook.snap
@@ -10,9 +10,9 @@ expression: lex_jupyter_source(source)
         0..5,
     ),
     (
-        Name {
-            name: "foo",
-        },
+        Name(
+            "foo",
+        ),
         6..9,
     ),
     (
@@ -32,9 +32,9 @@ expression: lex_jupyter_source(source)
         15..19,
     ),
     (
-        Name {
-            name: "bar",
-        },
+        Name(
+            "bar",
+        ),
         20..23,
     ),
     (

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__newline_in_brackets_mac_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__newline_in_brackets_mac_eol.snap
@@ -6,9 +6,9 @@ expression: newline_in_brackets_eol(MAC_EOL)
 ```
 [
     (
-        Name {
-            name: "x",
-        },
+        Name(
+            "x",
+        ),
         0..1,
     ),
     (
@@ -28,9 +28,9 @@ expression: newline_in_brackets_eol(MAC_EOL)
         6..7,
     ),
     (
-        Int {
-            value: 1,
-        },
+        Int(
+            1,
+        ),
         11..12,
     ),
     (
@@ -38,9 +38,9 @@ expression: newline_in_brackets_eol(MAC_EOL)
         12..13,
     ),
     (
-        Int {
-            value: 2,
-        },
+        Int(
+            2,
+        ),
         13..14,
     ),
     (
@@ -56,9 +56,9 @@ expression: newline_in_brackets_eol(MAC_EOL)
         16..17,
     ),
     (
-        Int {
-            value: 3,
-        },
+        Int(
+            3,
+        ),
         17..18,
     ),
     (
@@ -70,9 +70,9 @@ expression: newline_in_brackets_eol(MAC_EOL)
         19..20,
     ),
     (
-        Int {
-            value: 4,
-        },
+        Int(
+            4,
+        ),
         20..21,
     ),
     (
@@ -100,9 +100,9 @@ expression: newline_in_brackets_eol(MAC_EOL)
         27..28,
     ),
     (
-        Int {
-            value: 5,
-        },
+        Int(
+            5,
+        ),
         28..29,
     ),
     (
@@ -114,9 +114,9 @@ expression: newline_in_brackets_eol(MAC_EOL)
         30..31,
     ),
     (
-        Int {
-            value: 6,
-        },
+        Int(
+            6,
+        ),
         31..32,
     ),
     (
@@ -124,9 +124,9 @@ expression: newline_in_brackets_eol(MAC_EOL)
         32..33,
     ),
     (
-        Int {
-            value: 7,
-        },
+        Int(
+            7,
+        ),
         35..36,
     ),
     (

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__newline_in_brackets_unix_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__newline_in_brackets_unix_eol.snap
@@ -6,9 +6,9 @@ expression: newline_in_brackets_eol(UNIX_EOL)
 ```
 [
     (
-        Name {
-            name: "x",
-        },
+        Name(
+            "x",
+        ),
         0..1,
     ),
     (
@@ -28,9 +28,9 @@ expression: newline_in_brackets_eol(UNIX_EOL)
         6..7,
     ),
     (
-        Int {
-            value: 1,
-        },
+        Int(
+            1,
+        ),
         11..12,
     ),
     (
@@ -38,9 +38,9 @@ expression: newline_in_brackets_eol(UNIX_EOL)
         12..13,
     ),
     (
-        Int {
-            value: 2,
-        },
+        Int(
+            2,
+        ),
         13..14,
     ),
     (
@@ -56,9 +56,9 @@ expression: newline_in_brackets_eol(UNIX_EOL)
         16..17,
     ),
     (
-        Int {
-            value: 3,
-        },
+        Int(
+            3,
+        ),
         17..18,
     ),
     (
@@ -70,9 +70,9 @@ expression: newline_in_brackets_eol(UNIX_EOL)
         19..20,
     ),
     (
-        Int {
-            value: 4,
-        },
+        Int(
+            4,
+        ),
         20..21,
     ),
     (
@@ -100,9 +100,9 @@ expression: newline_in_brackets_eol(UNIX_EOL)
         27..28,
     ),
     (
-        Int {
-            value: 5,
-        },
+        Int(
+            5,
+        ),
         28..29,
     ),
     (
@@ -114,9 +114,9 @@ expression: newline_in_brackets_eol(UNIX_EOL)
         30..31,
     ),
     (
-        Int {
-            value: 6,
-        },
+        Int(
+            6,
+        ),
         31..32,
     ),
     (
@@ -124,9 +124,9 @@ expression: newline_in_brackets_eol(UNIX_EOL)
         32..33,
     ),
     (
-        Int {
-            value: 7,
-        },
+        Int(
+            7,
+        ),
         35..36,
     ),
     (

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__newline_in_brackets_windows_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__newline_in_brackets_windows_eol.snap
@@ -6,9 +6,9 @@ expression: newline_in_brackets_eol(WINDOWS_EOL)
 ```
 [
     (
-        Name {
-            name: "x",
-        },
+        Name(
+            "x",
+        ),
         0..1,
     ),
     (
@@ -28,9 +28,9 @@ expression: newline_in_brackets_eol(WINDOWS_EOL)
         7..9,
     ),
     (
-        Int {
-            value: 1,
-        },
+        Int(
+            1,
+        ),
         13..14,
     ),
     (
@@ -38,9 +38,9 @@ expression: newline_in_brackets_eol(WINDOWS_EOL)
         14..15,
     ),
     (
-        Int {
-            value: 2,
-        },
+        Int(
+            2,
+        ),
         15..16,
     ),
     (
@@ -56,9 +56,9 @@ expression: newline_in_brackets_eol(WINDOWS_EOL)
         19..20,
     ),
     (
-        Int {
-            value: 3,
-        },
+        Int(
+            3,
+        ),
         20..21,
     ),
     (
@@ -70,9 +70,9 @@ expression: newline_in_brackets_eol(WINDOWS_EOL)
         22..24,
     ),
     (
-        Int {
-            value: 4,
-        },
+        Int(
+            4,
+        ),
         24..25,
     ),
     (
@@ -100,9 +100,9 @@ expression: newline_in_brackets_eol(WINDOWS_EOL)
         32..34,
     ),
     (
-        Int {
-            value: 5,
-        },
+        Int(
+            5,
+        ),
         34..35,
     ),
     (
@@ -114,9 +114,9 @@ expression: newline_in_brackets_eol(WINDOWS_EOL)
         36..38,
     ),
     (
-        Int {
-            value: 6,
-        },
+        Int(
+            6,
+        ),
         38..39,
     ),
     (
@@ -124,9 +124,9 @@ expression: newline_in_brackets_eol(WINDOWS_EOL)
         39..40,
     ),
     (
-        Int {
-            value: 7,
-        },
+        Int(
+            7,
+        ),
         43..44,
     ),
     (

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__non_logical_newline_in_string_continuation.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__non_logical_newline_in_string_continuation.snap
@@ -14,9 +14,9 @@ expression: lex_source(source)
         1..2,
     ),
     (
-        String {
-            value: "a",
-        },
+        String(
+            "a",
+        ),
         6..9,
     ),
     (
@@ -24,9 +24,9 @@ expression: lex_source(source)
         9..10,
     ),
     (
-        String {
-            value: "b",
-        },
+        String(
+            "b",
+        ),
         14..17,
     ),
     (
@@ -38,15 +38,15 @@ expression: lex_source(source)
         18..19,
     ),
     (
-        String {
-            value: "c",
-        },
+        String(
+            "c",
+        ),
         23..26,
     ),
     (
-        String {
-            value: "d",
-        },
+        String(
+            "d",
+        ),
         33..36,
     ),
     (

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__numbers.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__numbers.snap
@@ -6,57 +6,57 @@ expression: lex_source(source)
 ```
 [
     (
-        Int {
-            value: 47,
-        },
+        Int(
+            47,
+        ),
         0..4,
     ),
     (
-        Int {
-            value: 10,
-        },
+        Int(
+            10,
+        ),
         5..9,
     ),
     (
-        Int {
-            value: 13,
-        },
+        Int(
+            13,
+        ),
         10..16,
     ),
     (
-        Int {
-            value: 0,
-        },
+        Int(
+            0,
+        ),
         17..18,
     ),
     (
-        Int {
-            value: 123,
-        },
+        Int(
+            123,
+        ),
         19..22,
     ),
     (
-        Int {
-            value: 1234567890,
-        },
+        Int(
+            1234567890,
+        ),
         23..36,
     ),
     (
-        Float {
-            value: 0.2,
-        },
+        Float(
+            0.2,
+        ),
         37..40,
     ),
     (
-        Float {
-            value: 100.0,
-        },
+        Float(
+            100.0,
+        ),
         41..45,
     ),
     (
-        Float {
-            value: 2100.0,
-        },
+        Float(
+            2100.0,
+        ),
         46..51,
     ),
     (
@@ -74,21 +74,21 @@ expression: lex_source(source)
         55..59,
     ),
     (
-        Int {
-            value: 0,
-        },
+        Int(
+            0,
+        ),
         60..63,
     ),
     (
-        Int {
-            value: 11051210869376104954,
-        },
+        Int(
+            11051210869376104954,
+        ),
         64..82,
     ),
     (
-        Int {
-            value: 0x995DC9BBDF1939FA995DC9BBDF1939FA,
-        },
+        Int(
+            0x995DC9BBDF1939FA995DC9BBDF1939FA,
+        ),
         83..117,
     ),
     (

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__string.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__string.snap
@@ -6,66 +6,66 @@ expression: lex_source(source)
 ```
 [
     (
-        String {
-            value: "double",
-        },
+        String(
+            "double",
+        ),
         0..8,
         TokenFlags(
             DOUBLE_QUOTES,
         ),
     ),
     (
-        String {
-            value: "single",
-        },
+        String(
+            "single",
+        ),
         9..17,
     ),
     (
-        String {
-            value: "can\\'t",
-        },
+        String(
+            "can\\'t",
+        ),
         18..26,
     ),
     (
-        String {
-            value: "\\\\\\\"",
-        },
+        String(
+            "\\\\\\\"",
+        ),
         27..33,
         TokenFlags(
             DOUBLE_QUOTES,
         ),
     ),
     (
-        String {
-            value: "\\t\\r\\n",
-        },
+        String(
+            "\\t\\r\\n",
+        ),
         34..42,
     ),
     (
-        String {
-            value: "\\g",
-        },
+        String(
+            "\\g",
+        ),
         43..47,
     ),
     (
-        String {
-            value: "raw\\'",
-        },
+        String(
+            "raw\\'",
+        ),
         48..56,
         TokenFlags(
             RAW_STRING_LOWERCASE,
         ),
     ),
     (
-        String {
-            value: "\\420",
-        },
+        String(
+            "\\420",
+        ),
         57..63,
     ),
     (
-        String {
-            value: "\\200\\0a",
-        },
+        String(
+            "\\200\\0a",
+        ),
         64..73,
     ),
     (

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__string_continuation_with_mac_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__string_continuation_with_mac_eol.snap
@@ -6,9 +6,9 @@ expression: string_continuation_with_eol(MAC_EOL)
 ```
 [
     (
-        String {
-            value: "abc\\\rdef",
-        },
+        String(
+            "abc\\\rdef",
+        ),
         0..10,
         TokenFlags(
             DOUBLE_QUOTES,

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__string_continuation_with_unix_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__string_continuation_with_unix_eol.snap
@@ -6,9 +6,9 @@ expression: string_continuation_with_eol(UNIX_EOL)
 ```
 [
     (
-        String {
-            value: "abc\\\ndef",
-        },
+        String(
+            "abc\\\ndef",
+        ),
         0..10,
         TokenFlags(
             DOUBLE_QUOTES,

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__string_continuation_with_windows_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__string_continuation_with_windows_eol.snap
@@ -6,9 +6,9 @@ expression: string_continuation_with_eol(WINDOWS_EOL)
 ```
 [
     (
-        String {
-            value: "abc\\\r\ndef",
-        },
+        String(
+            "abc\\\r\ndef",
+        ),
         0..11,
         TokenFlags(
             DOUBLE_QUOTES,

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__triple_quoted_mac_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__triple_quoted_mac_eol.snap
@@ -6,9 +6,9 @@ expression: triple_quoted_eol(MAC_EOL)
 ```
 [
     (
-        String {
-            value: "\r test string\r ",
-        },
+        String(
+            "\r test string\r ",
+        ),
         0..21,
         TokenFlags(
             DOUBLE_QUOTES | TRIPLE_QUOTED_STRING,

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__triple_quoted_unix_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__triple_quoted_unix_eol.snap
@@ -6,9 +6,9 @@ expression: triple_quoted_eol(UNIX_EOL)
 ```
 [
     (
-        String {
-            value: "\n test string\n ",
-        },
+        String(
+            "\n test string\n ",
+        ),
         0..21,
         TokenFlags(
             DOUBLE_QUOTES | TRIPLE_QUOTED_STRING,

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__triple_quoted_windows_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__triple_quoted_windows_eol.snap
@@ -6,9 +6,9 @@ expression: triple_quoted_eol(WINDOWS_EOL)
 ```
 [
     (
-        String {
-            value: "\r\n test string\r\n ",
-        },
+        String(
+            "\r\n test string\r\n ",
+        ),
         0..23,
         TokenFlags(
             DOUBLE_QUOTES | TRIPLE_QUOTED_STRING,


### PR DESCRIPTION
## Summary

This PR is a follow-up to #11475 to use enum values where there's struct with a single field. The main motivation to use struct was to keep the snapshot update to a minimum which allows me to validate it. Now that the validation is done, we can revert it back.

## Test Plan

Update the snapshots.
