### PR TITLE
Fix incorect placement of trailing stub function comments

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/stub_functions_trailing_comments.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/stub_functions_trailing_comments.py
@@ -1,0 +1,25 @@
+# Regression tests for https://github.com/astral-sh/ruff/issues/11569
+
+
+# comment 1
+def foo(self) -> None: ...
+def bar(self) -> None: ...
+# comment 2
+
+# comment 3
+def baz(self) -> None:
+    return None
+# comment 4
+
+
+def foo(self) -> None: ...
+# comment 5
+
+def baz(self) -> None:
+    return None
+
+
+def foo(self) -> None:
+    ... # comment 5
+def baz(self) -> None:
+    return None

--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/stub_functions_trailing_comments.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/stub_functions_trailing_comments.py
@@ -23,3 +23,6 @@ def foo(self) -> None:
     ... # comment 5
 def baz(self) -> None:
     return None
+
+def foo(self) -> None: ...
+# comment 5

--- a/crates/ruff_python_formatter/src/statement/stmt_class_def.rs
+++ b/crates/ruff_python_formatter/src/statement/stmt_class_def.rs
@@ -55,7 +55,7 @@ impl FormatNodeRule<StmtClassDef> for FormatStmtClassDef {
         // newline between the comment and the node, but we _require_ two newlines. If there are
         // _no_ newlines between the comment and the node, we don't insert _any_ newlines; if there
         // are more than two, then `leading_comments` will preserve the correct number of newlines.
-        empty_lines_after_leading_comments(f, comments.leading(item)).fmt(f)?;
+        empty_lines_after_leading_comments(comments.leading(item)).fmt(f)?;
 
         write!(
             f,

--- a/crates/ruff_python_formatter/src/statement/stmt_class_def.rs
+++ b/crates/ruff_python_formatter/src/statement/stmt_class_def.rs
@@ -152,7 +152,7 @@ impl FormatNodeRule<StmtClassDef> for FormatStmtClassDef {
         //
         // # comment
         // ```
-        empty_lines_before_trailing_comments(f, comments.trailing(item), NodeKind::StmtClassDef)
+        empty_lines_before_trailing_comments(comments.trailing(item), NodeKind::StmtClassDef)
             .fmt(f)?;
 
         Ok(())

--- a/crates/ruff_python_formatter/src/statement/stmt_function_def.rs
+++ b/crates/ruff_python_formatter/src/statement/stmt_function_def.rs
@@ -86,7 +86,7 @@ impl FormatNodeRule<StmtFunctionDef> for FormatStmtFunctionDef {
         //
         // # comment
         // ```
-        empty_lines_before_trailing_comments(f, comments.trailing(item), NodeKind::StmtFunctionDef)
+        empty_lines_before_trailing_comments(comments.trailing(item), NodeKind::StmtFunctionDef)
             .fmt(f)
     }
 }

--- a/crates/ruff_python_formatter/src/statement/stmt_function_def.rs
+++ b/crates/ruff_python_formatter/src/statement/stmt_function_def.rs
@@ -52,7 +52,7 @@ impl FormatNodeRule<StmtFunctionDef> for FormatStmtFunctionDef {
         // newline between the comment and the node, but we _require_ two newlines. If there are
         // _no_ newlines between the comment and the node, we don't insert _any_ newlines; if there
         // are more than two, then `leading_comments` will preserve the correct number of newlines.
-        empty_lines_after_leading_comments(f, comments.leading(item)).fmt(f)?;
+        empty_lines_after_leading_comments(comments.leading(item)).fmt(f)?;
 
         write!(
             f,

--- a/crates/ruff_python_formatter/src/statement/suite.rs
+++ b/crates/ruff_python_formatter/src/statement/suite.rs
@@ -240,7 +240,8 @@ impl FormatRule<Suite, PyFormatContext<'_>> for FormatSuite {
                                     preceding_stub.end(),
                                     f.context().source(),
                                 ) < 2
-                            });
+                            })
+                        && !preceding_comments.has_trailing_own_line();
 
                     if !is_preceding_stub_function_without_empty_line {
                         match self.kind {

--- a/crates/ruff_python_formatter/tests/snapshots/format@statement__stub_functions_trailing_comments.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@statement__stub_functions_trailing_comments.py.snap
@@ -29,6 +29,9 @@ def foo(self) -> None:
     ... # comment 5
 def baz(self) -> None:
     return None
+
+def foo(self) -> None: ...
+# comment 5
 ```
 
 ## Output
@@ -65,4 +68,10 @@ def baz(self) -> None:
 def foo(self) -> None: ...  # comment 5
 def baz(self) -> None:
     return None
+
+
+def foo(self) -> None: ...
+
+
+# comment 5
 ```

--- a/crates/ruff_python_formatter/tests/snapshots/format@statement__stub_functions_trailing_comments.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@statement__stub_functions_trailing_comments.py.snap
@@ -1,0 +1,68 @@
+---
+source: crates/ruff_python_formatter/tests/fixtures.rs
+input_file: crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/stub_functions_trailing_comments.py
+---
+## Input
+```python
+# Regression tests for https://github.com/astral-sh/ruff/issues/11569
+
+
+# comment 1
+def foo(self) -> None: ...
+def bar(self) -> None: ...
+# comment 2
+
+# comment 3
+def baz(self) -> None:
+    return None
+# comment 4
+
+
+def foo(self) -> None: ...
+# comment 5
+
+def baz(self) -> None:
+    return None
+
+
+def foo(self) -> None:
+    ... # comment 5
+def baz(self) -> None:
+    return None
+```
+
+## Output
+```python
+# Regression tests for https://github.com/astral-sh/ruff/issues/11569
+
+
+# comment 1
+def foo(self) -> None: ...
+def bar(self) -> None: ...
+
+
+# comment 2
+
+
+# comment 3
+def baz(self) -> None:
+    return None
+
+
+# comment 4
+
+
+def foo(self) -> None: ...
+
+
+# comment 5
+
+
+def baz(self) -> None:
+    return None
+
+
+def foo(self) -> None: ...  # comment 5
+def baz(self) -> None:
+    return None
+```


### PR DESCRIPTION
## Summary

This fixes an issue in the formatter where it reorder comments or, worse, moved trailing stub function comments into the next's function body. 

The problem is that the formatter uses `line_suffix` for the trailing comments and the line suffixes are only flushed after the next newline. However, there's no such newline directly after the comment(s) because the formatter now allows newlines to be omitted between stub functions. 

The fix of this PR is to match Black's behavior to insert the empty lines if a collapsed stub has a trailing comment. I'm not very fond of the empty lines, because I think the comments should remain close to the stub body and not be separated by empty lines but it is consistent with how we format trailing function comments in other places and matches Black.

Closes https://github.com/astral-sh/ruff/issues/11569

## Test Plan

See added tests