### PR TITLE
Update `Who's Using Ruff?` section to include `Godot`

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,6 +408,7 @@ Ruff is used by a number of major open-source projects and companies, including:
 - [Dagster](https://github.com/dagster-io/dagster)
 - Databricks ([MLflow](https://github.com/mlflow/mlflow))
 - [FastAPI](https://github.com/tiangolo/fastapi)
+- [Godot](https://github.com/godotengine/godot)
 - [Gradio](https://github.com/gradio-app/gradio)
 - [Great Expectations](https://github.com/great-expectations/great_expectations)
 - [HTTPX](https://github.com/encode/httpx)


### PR DESCRIPTION
## Summary

- Ever since https://github.com/godotengine/godot/pull/90457 was merged into the `master` branch, Godot has been using ruff for linting and formatting Python files. As such, this PR adds Godot to the "Who's Using Ruff?" section of the main `README.md` file.

## Test Plan

- N/A
