### PR TITLE
F401 sort bindings before adding to __all__

### DIFF
--- a/crates/ruff_linter/src/rules/pyflakes/rules/unused_import.rs
+++ b/crates/ruff_linter/src/rules/pyflakes/rules/unused_import.rs
@@ -330,7 +330,7 @@ pub(crate) fn unused_import(checker: &Checker, scope: &Scope, diagnostics: &mut 
                     fix_by_reexporting(
                         checker,
                         import_statement,
-                        &to_reexport.iter().map(|(b, _)| b).collect::<Vec<_>>(),
+                        &mut to_reexport.iter().map(|(b, _)| b).collect::<Vec<_>>(),
                         &dunder_all_exprs,
                     )
                     .ok(),
@@ -450,7 +450,7 @@ fn fix_by_removing_imports<'a>(
 fn fix_by_reexporting(
     checker: &Checker,
     node_id: NodeId,
-    imports: &[&ImportBinding],
+    imports: &mut [&ImportBinding],
     dunder_all_exprs: &[&ast::Expr],
 ) -> Result<Fix> {
     let statement = checker.semantic().statement(node_id);
@@ -458,6 +458,7 @@ fn fix_by_reexporting(
         bail!("Expected import bindings");
     }
 
+    imports.sort_by_key(|b| b.name);
     let edits = match dunder_all_exprs {
         [] => fix::edits::make_redundant_alias(
             imports.iter().map(|b| b.import.member_name()),

--- a/crates/ruff_linter/src/rules/pyflakes/rules/unused_import.rs
+++ b/crates/ruff_linter/src/rules/pyflakes/rules/unused_import.rs
@@ -330,7 +330,7 @@ pub(crate) fn unused_import(checker: &Checker, scope: &Scope, diagnostics: &mut 
                     fix_by_reexporting(
                         checker,
                         import_statement,
-                        &mut to_reexport.iter().map(|(b, _)| b).collect::<Vec<_>>(),
+                        to_reexport.iter().map(|(b, _)| b).collect::<Vec<_>>(),
                         &dunder_all_exprs,
                     )
                     .ok(),
@@ -450,7 +450,7 @@ fn fix_by_removing_imports<'a>(
 fn fix_by_reexporting(
     checker: &Checker,
     node_id: NodeId,
-    imports: &mut [&ImportBinding],
+    mut imports: Vec<&ImportBinding>,
     dunder_all_exprs: &[&ast::Expr],
 ) -> Result<Fix> {
     let statement = checker.semantic().statement(node_id);
@@ -459,6 +459,7 @@ fn fix_by_reexporting(
     }
 
     imports.sort_by_key(|b| b.name);
+
     let edits = match dunder_all_exprs {
         [] => fix::edits::make_redundant_alias(
             imports.iter().map(|b| b.import.member_name()),


### PR DESCRIPTION
Sort the binding IDs before passing them to the add-to-`__all__` function to address #11619.