### PR TITLE
Omit `red-knot` PRs from the changelog

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,7 +87,7 @@ major_labels = []  # Ruff never uses the major version number
 minor_labels = ["breaking"]   # Bump the minor version on breaking changes
 version_tag_prefix = "v"
 
-changelog_ignore_labels = ["internal", "ci"]
+changelog_ignore_labels = ["internal", "ci", "red-knot"]
 
 changelog_sections.breaking = "Breaking changes"
 changelog_sections.preview = "Preview features"


### PR DESCRIPTION
## Summary

This just ensures that PRs labelled with `red-knot` are automatically filtered out from the auto-generated changelog (which we then manually finalize anyway).
