### PR TITLE
[red-knot] infer_symbol_public_type infers union of all definitions

### DIFF
--- a/crates/red_knot/src/types.rs
+++ b/crates/red_knot/src/types.rs
@@ -182,12 +182,12 @@ impl TypeStore {
             .add_class(name, scope_id, bases)
     }
 
-    fn add_union(&mut self, file_id: FileId, elems: &[Type]) -> UnionTypeId {
+    fn add_union(&self, file_id: FileId, elems: &[Type]) -> UnionTypeId {
         self.add_or_get_module(file_id).add_union(elems)
     }
 
     fn add_intersection(
-        &mut self,
+        &self,
         file_id: FileId,
         positive: &[Type],
         negative: &[Type],
@@ -777,7 +777,7 @@ mod tests {
 
     #[test]
     fn add_union() {
-        let mut store = TypeStore::default();
+        let store = TypeStore::default();
         let files = Files::default();
         let file_id = files.intern(Path::new("/foo"));
         let c1 = store.add_class(file_id, "C1", SymbolTable::root_scope_id(), Vec::new());
@@ -794,7 +794,7 @@ mod tests {
 
     #[test]
     fn add_intersection() {
-        let mut store = TypeStore::default();
+        let store = TypeStore::default();
         let files = Files::default();
         let file_id = files.intern(Path::new("/foo"));
         let c1 = store.add_class(file_id, "C1", SymbolTable::root_scope_id(), Vec::new());

--- a/crates/red_knot/src/types/infer.rs
+++ b/crates/red_knot/src/types/infer.rs
@@ -163,6 +163,7 @@ fn infer_expr_type(db: &dyn SemanticDb, file_id: FileId, expr: &ast::Expr) -> Qu
         ast::Expr::Name(name) => {
             // TODO look up in the correct scope, don't assume global
             if let Some(symbol_id) = symbols.root_symbol_id_by_name(&name.id) {
+                // TODO should use only reachable definitions, not public type
                 infer_symbol_public_type(db, GlobalSymbolId { file_id, symbol_id })
             } else {
                 Ok(Type::Unknown)

--- a/crates/red_knot/src/types/infer.rs
+++ b/crates/red_knot/src/types/infer.rs
@@ -25,6 +25,10 @@ pub fn infer_symbol_public_type(db: &dyn SemanticDb, symbol: GlobalSymbolId) -> 
         return Ok(ty);
     }
 
+    // The public type of a symbol is the union of all of its definitions. This is the most
+    // cautious/sound approach, though it can lead to a broader-than-desired type in a case like
+    // `x = 1; x = str(x)`, where the first definition of `x` can never be visible. TODO prune
+    // definitions that we can prove can't be visible.
     let tys = defs
         .iter()
         .map(|def| infer_definition_type(db, symbol, def.clone()))


### PR DESCRIPTION
## Summary

Rename `infer_symbol_type` to `infer_symbol_public_type`, and allow it to work on symbols with more than one definition. For now, use the most cautious/sound inference, which is the union of all definitions. We can prune this union more in future by eliminating definitions if we can show that they can't be visible (this requires both that the symbol is definitely later reassigned, and that there is no intervening call/import that might be able to see the over-written definition).

## Test Plan

Added a test showing inference of union from multiple definitions.