### PR TITLE
intern names in the symbol table

### DIFF
--- a/crates/red_knot/src/lib.rs
+++ b/crates/red_knot/src/lib.rs
@@ -1,11 +1,14 @@
 use std::fmt::Formatter;
 use std::hash::BuildHasherDefault;
+use std::hash::{Hash, Hasher};
 use std::ops::Deref;
 use std::path::{Path, PathBuf};
 
+use hashbrown::hash_map::{HashMap, RawEntryMut};
 use rustc_hash::{FxHashSet, FxHasher};
 
 use crate::files::FileId;
+use ruff_index::{newtype_index, IndexVec};
 
 pub mod ast_ids;
 pub mod cache;
@@ -70,6 +73,16 @@ impl Workspace {
     }
 }
 
+// NOTE: Should we instead use existing ruff_python_semantic::model::NameId?
+#[newtype_index]
+pub struct NameId;
+
+impl<'a> NameId {
+    pub fn name(&self, names: &'a Names) -> &'a Name {
+        names.name(*self)
+    }
+}
+
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub struct Name(smol_str::SmolStr);
 
@@ -105,5 +118,64 @@ where
 impl std::fmt::Display for Name {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         f.write_str(self.as_str())
+    }
+}
+
+// NOTE: modeled after red_knot::files::FilesInner; not wrapped with Arc(s) for now, because it's
+// not clear that's necessary
+#[derive(Debug, Default)]
+pub struct Names {
+    by_name: HashMap<NameId, (), ()>,
+    by_id: IndexVec<NameId, Name>,
+}
+
+impl Names {
+    pub fn intern(&mut self, name: Name) -> NameId {
+        let hash = Names::hash_name(&name);
+        let entry = self
+            .by_name
+            .raw_entry_mut()
+            .from_hash(hash, |id| self.by_id[*id] == name);
+        match entry {
+            RawEntryMut::Occupied(kv) => *kv.key(),
+            RawEntryMut::Vacant(kv) => {
+                let name_id = self.by_id.push(name);
+                kv.insert_with_hasher(hash, name_id, (), |id| Names::hash_name(&self.by_id[*id]));
+                name_id
+            }
+        }
+    }
+
+    pub fn get(&self, name: &str) -> Option<NameId> {
+        let hash = Names::hash_name(name);
+        self.by_name
+            .raw_entry()
+            .from_hash(hash, |id| &*self.by_id[*id] == name)
+            .map(|(id, ())| *id)
+    }
+
+    pub fn name(&self, id: NameId) -> &Name {
+        &self.by_id[id]
+    }
+
+    fn hash_name(name: &str) -> u64 {
+        let mut hasher = FxHasher::default();
+        name.hash(&mut hasher);
+        hasher.finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn intern_names() {
+        let mut names = Names::default();
+        assert_ne!(names.intern(Name::new("a")), names.intern(Name::new("b")));
+        assert_eq!(names.intern(Name::new("a")), names.intern(Name::new("a")));
+        assert_eq!(names.intern(Name::new("b")), names.intern(Name::new("b")));
+        assert_eq!(names.by_name.len(), 2);
+        assert_eq!(names.by_id.len(), 2);
     }
 }


### PR DESCRIPTION
# intern all the names used in a module in its SymbolTable

## background

To implement kind-analysis for names, we must do a recursive traversal over the scopes in a module. This recursive traversal accumulates sets of names in a scope and its subscopes, and does some set operations on them. Therefore we either need to do set operations on sets of strings (possibly resulting in many allocations) or *intern all the names in the module* so that we may do set operations on sets of IDs. This PR implements the interning of names, in case we choose the italicized option.

## implementation

* Add a `NameId` type
* Replace `Name` field on `Symbol` with `NameId` field
* Add an string-interning data structure `Names` to the symbol table
* Add a method to `Symbol` and `NameId` with signature `fn(Self, Names) -> Name`
* Update existing tests

# note

* ~~Not ready for review b/c I have to rebase past conflicts~~
* Currently interning takes place in `SymbolTable::add_or_update_symbol` but it should be pushed upstream to the callers in a subsequent PR
* [ ] resolve most TODO/FIXME/NOTE before merging