### PR TITLE
Add RDJson support

### DIFF
--- a/crates/ruff/src/printer.rs
+++ b/crates/ruff/src/printer.rs
@@ -13,7 +13,7 @@ use ruff_linter::fs::relativize_path;
 use ruff_linter::logging::LogLevel;
 use ruff_linter::message::{
     AzureEmitter, Emitter, EmitterContext, GithubEmitter, GitlabEmitter, GroupedEmitter,
-    JsonEmitter, JsonLinesEmitter, JunitEmitter, PylintEmitter, RDJsonEmitter, SarifEmitter,
+    JsonEmitter, JsonLinesEmitter, JunitEmitter, PylintEmitter, RdjsonEmitter, SarifEmitter,
     TextEmitter,
 };
 use ruff_linter::notify_user;
@@ -243,8 +243,8 @@ impl Printer {
             SerializationFormat::Json => {
                 JsonEmitter.emit(writer, &diagnostics.messages, &context)?;
             }
-            SerializationFormat::RDJson => {
-                RDJsonEmitter.emit(writer, &diagnostics.messages, &context)?;
+            SerializationFormat::Rdjson => {
+                RdjsonEmitter.emit(writer, &diagnostics.messages, &context)?;
             }
             SerializationFormat::JsonLines => {
                 JsonLinesEmitter.emit(writer, &diagnostics.messages, &context)?;

--- a/crates/ruff/src/printer.rs
+++ b/crates/ruff/src/printer.rs
@@ -13,7 +13,8 @@ use ruff_linter::fs::relativize_path;
 use ruff_linter::logging::LogLevel;
 use ruff_linter::message::{
     AzureEmitter, Emitter, EmitterContext, GithubEmitter, GitlabEmitter, GroupedEmitter,
-    JsonEmitter, JsonLinesEmitter, JunitEmitter, PylintEmitter, SarifEmitter, TextEmitter,
+    JsonEmitter, JsonLinesEmitter, JunitEmitter, PylintEmitter, RDJsonEmitter, SarifEmitter,
+    TextEmitter,
 };
 use ruff_linter::notify_user;
 use ruff_linter::registry::{AsRule, Rule};
@@ -241,6 +242,9 @@ impl Printer {
         match self.format {
             SerializationFormat::Json => {
                 JsonEmitter.emit(writer, &diagnostics.messages, &context)?;
+            }
+            SerializationFormat::RDJson => {
+                RDJsonEmitter.emit(writer, &diagnostics.messages, &context)?;
             }
             SerializationFormat::JsonLines => {
                 JsonLinesEmitter.emit(writer, &diagnostics.messages, &context)?;

--- a/crates/ruff_linter/src/message/mod.rs
+++ b/crates/ruff_linter/src/message/mod.rs
@@ -13,7 +13,7 @@ pub use json::JsonEmitter;
 pub use json_lines::JsonLinesEmitter;
 pub use junit::JunitEmitter;
 pub use pylint::PylintEmitter;
-pub use rdjson::RDJsonEmitter;
+pub use rdjson::RdjsonEmitter;
 use ruff_diagnostics::{Diagnostic, DiagnosticKind, Fix};
 use ruff_notebook::NotebookIndex;
 use ruff_source_file::{SourceFile, SourceLocation};

--- a/crates/ruff_linter/src/message/mod.rs
+++ b/crates/ruff_linter/src/message/mod.rs
@@ -13,6 +13,7 @@ pub use json::JsonEmitter;
 pub use json_lines::JsonLinesEmitter;
 pub use junit::JunitEmitter;
 pub use pylint::PylintEmitter;
+pub use rdjson::RDJsonEmitter;
 use ruff_diagnostics::{Diagnostic, DiagnosticKind, Fix};
 use ruff_notebook::NotebookIndex;
 use ruff_source_file::{SourceFile, SourceLocation};
@@ -29,6 +30,7 @@ mod json;
 mod json_lines;
 mod junit;
 mod pylint;
+mod rdjson;
 mod sarif;
 mod text;
 

--- a/crates/ruff_linter/src/message/rdjson.rs
+++ b/crates/ruff_linter/src/message/rdjson.rs
@@ -67,7 +67,7 @@ pub(crate) fn message_to_rdjson_value(message: &Message) -> Value {
         "message": message.kind.body,
         "location": {
             "path": message.filename(),
-            "range": rdjson_range(start_location, end_location),
+            "range": rdjson_range(&start_location, &end_location),
         },
         "code": {
             "value": message.kind.rule().noqa_code().to_string(),
@@ -85,7 +85,7 @@ pub(crate) fn message_to_rdjson_value(message: &Message) -> Value {
         );
     };
 
-    return Value::Object(result);
+    Value::Object(result)
 }
 
 fn rdjson_suggestions(edits: &[Edit], source_code: &SourceCode) -> Value {
@@ -95,13 +95,13 @@ fn rdjson_suggestions(edits: &[Edit], source_code: &SourceCode) -> Value {
         let location = source_code.source_location(edit.start());
         let end_location = source_code.source_location(edit.end());
 
-        suggestions.push(json!({"range": rdjson_range(location, end_location), "text": edit.content().unwrap_or_default()}));
+        suggestions.push(json!({"range": rdjson_range(&location, &end_location), "text": edit.content().unwrap_or_default()}));
     }
 
-    return Value::Array(suggestions);
+    Value::Array(suggestions)
 }
 
-fn rdjson_range(start: SourceLocation, end: SourceLocation) -> Value {
+fn rdjson_range(start: &SourceLocation, end: &SourceLocation) -> Value {
     json!({
         "start": {
             "line": start.row,

--- a/crates/ruff_linter/src/message/rdjson.rs
+++ b/crates/ruff_linter/src/message/rdjson.rs
@@ -120,3 +120,19 @@ fn rdjson_range(start: SourceLocation, end: SourceLocation) -> Value {
         },
     })
 }
+
+#[cfg(test)]
+mod tests {
+    use insta::assert_snapshot;
+
+    use crate::message::tests::{capture_emitter_output, create_messages};
+    use crate::message::RDJsonEmitter;
+
+    #[test]
+    fn output() {
+        let mut emitter = RDJsonEmitter;
+        let content = capture_emitter_output(&mut emitter, &create_messages());
+
+        assert_snapshot!(content);
+    }
+}

--- a/crates/ruff_linter/src/message/rdjson.rs
+++ b/crates/ruff_linter/src/message/rdjson.rs
@@ -12,9 +12,9 @@ use crate::message::{Emitter, EmitterContext, Message, SourceLocation};
 use crate::registry::AsRule;
 
 #[derive(Default)]
-pub struct RDJsonEmitter;
+pub struct RdjsonEmitter;
 
-impl Emitter for RDJsonEmitter {
+impl Emitter for RdjsonEmitter {
     fn emit(
         &mut self,
         writer: &mut dyn Write,
@@ -119,11 +119,11 @@ mod tests {
     use insta::assert_snapshot;
 
     use crate::message::tests::{capture_emitter_output, create_messages};
-    use crate::message::RDJsonEmitter;
+    use crate::message::RdjsonEmitter;
 
     #[test]
     fn output() {
-        let mut emitter = RDJsonEmitter;
+        let mut emitter = RdjsonEmitter;
         let content = capture_emitter_output(&mut emitter, &create_messages());
 
         assert_snapshot!(content);

--- a/crates/ruff_linter/src/message/rdjson.rs
+++ b/crates/ruff_linter/src/message/rdjson.rs
@@ -60,15 +60,10 @@ impl Serialize for ExpandedMessages<'_> {
 pub(crate) fn message_to_rdjson_value(message: &Message) -> Value {
     let source_code = message.file.to_source_code();
 
-    let fix = message.fix.as_ref().map(|fix| ExpandedEdits {
-        edits: fix.edits(),
-        source_code: &source_code,
-    });
-
     let start_location = source_code.source_location(message.start());
     let end_location = source_code.source_location(message.end());
 
-    json!({
+    let mut result = json!({
         "message": message.kind.body,
         "location": {
             "path": message.filename(),
@@ -78,34 +73,32 @@ pub(crate) fn message_to_rdjson_value(message: &Message) -> Value {
             "value": message.kind.rule().noqa_code().to_string(),
             "url": message.kind.rule().url(),
         },
-        "suggestions": fix,
     })
+    .as_object()
+    .unwrap()
+    .clone();
+
+    if let Some(fix) = message.fix.as_ref() {
+        result.insert(
+            "suggestions".into(),
+            rdjson_suggestions(fix.edits(), &source_code),
+        );
+    };
+
+    return Value::Object(result);
 }
 
-struct ExpandedEdits<'a> {
-    edits: &'a [Edit],
-    source_code: &'a SourceCode<'a, 'a>,
-}
+fn rdjson_suggestions(edits: &[Edit], source_code: &SourceCode) -> Value {
+    let mut suggestions: Vec<Value> = vec![];
 
-impl Serialize for ExpandedEdits<'_> {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        let mut s = serializer.serialize_seq(Some(self.edits.len()))?;
+    for edit in edits {
+        let location = source_code.source_location(edit.start());
+        let end_location = source_code.source_location(edit.end());
 
-        for edit in self.edits {
-            let location = self.source_code.source_location(edit.start());
-            let end_location = self.source_code.source_location(edit.end());
-
-            s.serialize_element(&json!({
-                "range": rdjson_range(location, end_location),
-                "text": edit.content().unwrap_or_default(),
-            }))?;
-        }
-
-        s.end()
+        suggestions.push(json!({"range": rdjson_range(location, end_location), "text": edit.content().unwrap_or_default()}));
     }
+
+    return Value::Array(suggestions);
 }
 
 fn rdjson_range(start: SourceLocation, end: SourceLocation) -> Value {

--- a/crates/ruff_linter/src/message/rdjson.rs
+++ b/crates/ruff_linter/src/message/rdjson.rs
@@ -1,0 +1,88 @@
+use std::io::Write;
+
+use serde::ser::SerializeSeq;
+use serde::{Serialize, Serializer};
+use serde_json::{json, Value};
+
+use ruff_text_size::Ranged;
+
+use crate::message::{Emitter, EmitterContext, Message, SourceLocation};
+use crate::registry::AsRule;
+
+#[derive(Default)]
+pub struct RDJsonEmitter;
+
+impl Emitter for RDJsonEmitter {
+    fn emit(
+        &mut self,
+        writer: &mut dyn Write,
+        messages: &[Message],
+        _context: &EmitterContext,
+    ) -> anyhow::Result<()> {
+        serde_json::to_writer_pretty(
+            writer,
+            &json!({
+                "source": {
+                    "name": "ruff",
+                    "url": "https://docs.astral.sh/ruff",
+                },
+                "severity": "warning",
+                "diagnostics": &ExpandedMessages{ messages }
+            }),
+        )?;
+
+        Ok(())
+    }
+}
+
+struct ExpandedMessages<'a> {
+    messages: &'a [Message],
+}
+
+impl Serialize for ExpandedMessages<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut s = serializer.serialize_seq(Some(self.messages.len()))?;
+
+        for message in self.messages {
+            let value = message_to_rdjson_value(message);
+            s.serialize_element(&value)?;
+        }
+
+        s.end()
+    }
+}
+
+pub(crate) fn message_to_rdjson_value(message: &Message) -> Value {
+    let source_code = message.file.to_source_code();
+
+    let start_location = source_code.source_location(message.start());
+    let end_location = source_code.source_location(message.end());
+
+    json!({
+        "message": message.kind.body,
+        "location": {
+            "path": message.filename(),
+            "range": rdjson_range(start_location, end_location),
+        },
+        "code": {
+            "value": message.kind.rule().noqa_code().to_string(),
+            "url": message.kind.rule().url(),
+        },
+    })
+}
+
+fn rdjson_range(start: SourceLocation, end: SourceLocation) -> Value {
+    json!({
+        "start": {
+            "line": start.row,
+            "column": start.column,
+        },
+        "end": {
+            "line": start.row,
+            "column": end.column,
+        },
+    })
+}

--- a/crates/ruff_linter/src/message/snapshots/ruff_linter__message__rdjson__tests__output.snap
+++ b/crates/ruff_linter/src/message/snapshots/ruff_linter__message__rdjson__tests__output.snap
@@ -92,8 +92,7 @@ expression: content
           }
         }
       },
-      "message": "Undefined name `a`",
-      "suggestions": null
+      "message": "Undefined name `a`"
     }
   ],
   "severity": "warning",

--- a/crates/ruff_linter/src/message/snapshots/ruff_linter__message__rdjson__tests__output.snap
+++ b/crates/ruff_linter/src/message/snapshots/ruff_linter__message__rdjson__tests__output.snap
@@ -1,0 +1,104 @@
+---
+source: crates/ruff_linter/src/message/rdjson.rs
+expression: content
+---
+{
+  "diagnostics": [
+    {
+      "code": {
+        "url": "https://docs.astral.sh/ruff/rules/unused-import",
+        "value": "F401"
+      },
+      "location": {
+        "path": "fib.py",
+        "range": {
+          "end": {
+            "column": 10,
+            "line": 1
+          },
+          "start": {
+            "column": 8,
+            "line": 1
+          }
+        }
+      },
+      "message": "`os` imported but unused",
+      "suggestions": [
+        {
+          "range": {
+            "end": {
+              "column": 1,
+              "line": 2
+            },
+            "start": {
+              "column": 1,
+              "line": 1
+            }
+          },
+          "text": ""
+        }
+      ]
+    },
+    {
+      "code": {
+        "url": "https://docs.astral.sh/ruff/rules/unused-variable",
+        "value": "F841"
+      },
+      "location": {
+        "path": "fib.py",
+        "range": {
+          "end": {
+            "column": 6,
+            "line": 6
+          },
+          "start": {
+            "column": 5,
+            "line": 6
+          }
+        }
+      },
+      "message": "Local variable `x` is assigned to but never used",
+      "suggestions": [
+        {
+          "range": {
+            "end": {
+              "column": 10,
+              "line": 6
+            },
+            "start": {
+              "column": 5,
+              "line": 6
+            }
+          },
+          "text": ""
+        }
+      ]
+    },
+    {
+      "code": {
+        "url": "https://docs.astral.sh/ruff/rules/undefined-name",
+        "value": "F821"
+      },
+      "location": {
+        "path": "undef.py",
+        "range": {
+          "end": {
+            "column": 5,
+            "line": 1
+          },
+          "start": {
+            "column": 4,
+            "line": 1
+          }
+        }
+      },
+      "message": "Undefined name `a`",
+      "suggestions": null
+    }
+  ],
+  "severity": "warning",
+  "source": {
+    "name": "ruff",
+    "url": "https://docs.astral.sh/ruff"
+  }
+}

--- a/crates/ruff_linter/src/settings/types.rs
+++ b/crates/ruff_linter/src/settings/types.rs
@@ -513,6 +513,7 @@ pub enum SerializationFormat {
     Github,
     Gitlab,
     Pylint,
+    RDJson,
     Azure,
     Sarif,
 }
@@ -530,6 +531,7 @@ impl Display for SerializationFormat {
             Self::Github => write!(f, "github"),
             Self::Gitlab => write!(f, "gitlab"),
             Self::Pylint => write!(f, "pylint"),
+            Self::RDJson => write!(f, "rdjson"),
             Self::Azure => write!(f, "azure"),
             Self::Sarif => write!(f, "sarif"),
         }

--- a/crates/ruff_linter/src/settings/types.rs
+++ b/crates/ruff_linter/src/settings/types.rs
@@ -513,7 +513,7 @@ pub enum SerializationFormat {
     Github,
     Gitlab,
     Pylint,
-    RDJson,
+    Rdjson,
     Azure,
     Sarif,
 }
@@ -531,7 +531,7 @@ impl Display for SerializationFormat {
             Self::Github => write!(f, "github"),
             Self::Gitlab => write!(f, "gitlab"),
             Self::Pylint => write!(f, "pylint"),
-            Self::RDJson => write!(f, "rdjson"),
+            Self::Rdjson => write!(f, "rdjson"),
             Self::Azure => write!(f, "azure"),
             Self::Sarif => write!(f, "sarif"),
         }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -599,7 +599,7 @@ Options:
           format is "concise". In preview mode, the default serialization
           format is "full" [env: RUFF_OUTPUT_FORMAT=] [possible values: text,
           concise, full, json, json-lines, junit, grouped, github, gitlab,
-          pylint, azure, sarif]
+          pylint, rd-json, azure, sarif]
   -o, --output-file <OUTPUT_FILE>
           Specify file to write the linter output to (default: stdout) [env:
           RUFF_OUTPUT_FILE=]

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -599,7 +599,7 @@ Options:
           format is "concise". In preview mode, the default serialization
           format is "full" [env: RUFF_OUTPUT_FORMAT=] [possible values: text,
           concise, full, json, json-lines, junit, grouped, github, gitlab,
-          pylint, rd-json, azure, sarif]
+          pylint, rdjson, azure, sarif]
   -o, --output-file <OUTPUT_FILE>
           Specify file to write the linter output to (default: stdout) [env:
           RUFF_OUTPUT_FILE=]

--- a/ruff.schema.json
+++ b/ruff.schema.json
@@ -3947,6 +3947,7 @@
         "github",
         "gitlab",
         "pylint",
+        "r-d-json",
         "azure",
         "sarif"
       ]

--- a/ruff.schema.json
+++ b/ruff.schema.json
@@ -3947,7 +3947,7 @@
         "github",
         "gitlab",
         "pylint",
-        "r-d-json",
+        "rdjson",
         "azure",
         "sarif"
       ]


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Implement support for RDJson output for `ruff check`, as requested in #8655.

## Test Plan

Tested using a snapshot test. Same approach as for e.g. the JSON output formatter.

## Additional info

I tried to keep the implementation close to the JSON implementation.

I had to deviate a bit to make the `suggestions` key work: If there are no suggestions, then setting `suggestions` to `null` is invalid according to the JSONSchema. Therefore, I opted for a slightly more complex implementation, that skips the `suggestions` key entirely if there are no fixes available for the given diagnostic. Maybe it would have been easier to set `"suggestions": []`, but I ended up doing it this way.

I didn't consider notebooks, as I _think_ that RDJson doesn't work with notebooks. This should be confirmed, and if so, there should be some form of warning or error emitted when trying to output diagnostics for a notebook.

I also didn't consider `ruff format`, as this comment: https://github.com/astral-sh/ruff/issues/8655#issuecomment-1811446160 suggests that that wouldn't be compatible.

I'm new to Rust, any feedback is appreciated. :slightly_smiling_face: I implemented this in order to have a productive rainy saturday afternoon, I'm not knowledgeable about RDJson beyond the sources linked in the issue.
