### PR TITLE
Make tests aware that py313 is the latest supported Python version

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP036_0.py
+++ b/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP036_0.py
@@ -179,13 +179,13 @@ if True:
     if sys.version_info > (3, 0): \
     expected_error = []
 
-if sys.version_info < (3,12):
+if sys.version_info < (3,13):
     print("py3")
 
-if sys.version_info <= (3,12):
+if sys.version_info <= (3,13):
     print("py3")
 
-if sys.version_info <= (3,12):
+if sys.version_info <= (3,13):
     print("py3")
 
 if sys.version_info == 10000000:
@@ -197,10 +197,10 @@ if sys.version_info < (3,10000000):
 if sys.version_info <= (3,10000000):
     print("py3")
 
-if sys.version_info > (3,12):
+if sys.version_info > (3,13):
     print("py3")
 
-if sys.version_info >= (3,12):
+if sys.version_info >= (3,13):
     print("py3")
 
 # Slices on `sys.version_info` should be treated equivalently.
@@ -210,10 +210,10 @@ if sys.version_info[:2] >= (3,0):
 if sys.version_info[:3] >= (3,0):
     print("py3")
 
-if sys.version_info[:2] > (3,13):
+if sys.version_info[:2] > (3,14):
     print("py3")
 
-if sys.version_info[:3] > (3,13):
+if sys.version_info[:3] > (3,14):
     print("py3")
 
 if sys.version_info > (3,0):

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP036_0.py.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP036_0.py.snap
@@ -663,13 +663,13 @@ UP036_0.py:179:8: UP036 [*] Version block is outdated for minimum Python version
 179     |-    if sys.version_info > (3, 0): \
 180 179 |     expected_error = []
 181 180 | 
-182 181 | if sys.version_info < (3,12):
+182 181 | if sys.version_info < (3,13):
 
 UP036_0.py:182:4: UP036 [*] Version block is outdated for minimum Python version
     |
 180 |     expected_error = []
 181 | 
-182 | if sys.version_info < (3,12):
+182 | if sys.version_info < (3,13):
     |    ^^^^^^^^^^^^^^^^^^^^^^^^^ UP036
 183 |     print("py3")
     |
@@ -679,10 +679,10 @@ UP036_0.py:182:4: UP036 [*] Version block is outdated for minimum Python version
 179 179 |     if sys.version_info > (3, 0): \
 180 180 |     expected_error = []
 181 181 | 
-182     |-if sys.version_info < (3,12):
+182     |-if sys.version_info < (3,13):
 183     |-    print("py3")
 184 182 | 
-185 183 | if sys.version_info <= (3,12):
+185 183 | if sys.version_info <= (3,13):
 186 184 |     print("py3")
 
 UP036_0.py:191:24: UP036 Version specifier is invalid
@@ -716,17 +716,17 @@ UP036_0.py:203:4: UP036 [*] Version block is outdated for minimum Python version
     |
 201 |     print("py3")
 202 | 
-203 | if sys.version_info >= (3,12):
+203 | if sys.version_info >= (3,13):
     |    ^^^^^^^^^^^^^^^^^^^^^^^^^^ UP036
 204 |     print("py3")
     |
     = help: Remove outdated version block
 
 ℹ Unsafe fix
-200 200 | if sys.version_info > (3,12):
+200 200 | if sys.version_info > (3,13):
 201 201 |     print("py3")
 202 202 | 
-203     |-if sys.version_info >= (3,12):
+203     |-if sys.version_info >= (3,13):
 204     |-    print("py3")
     203 |+print("py3")
 205 204 | 
@@ -771,7 +771,7 @@ UP036_0.py:210:4: UP036 [*] Version block is outdated for minimum Python version
 211     |-    print("py3")
     210 |+print("py3")
 212 211 | 
-213 212 | if sys.version_info[:2] > (3,13):
+213 212 | if sys.version_info[:2] > (3,14):
 214 213 |     print("py3")
 
 UP036_0.py:219:4: UP036 [*] Version block is outdated for minimum Python version
@@ -786,7 +786,7 @@ UP036_0.py:219:4: UP036 [*] Version block is outdated for minimum Python version
     = help: Remove outdated version block
 
 ℹ Unsafe fix
-216 216 | if sys.version_info[:3] > (3,13):
+216 216 | if sys.version_info[:3] > (3,14):
 217 217 |     print("py3")
 218 218 | 
 219     |-if sys.version_info > (3,0):
@@ -801,5 +801,3 @@ UP036_0.py:219:4: UP036 [*] Version block is outdated for minimum Python version
 226     |-    "this is\
     225 |+"this is\
 227 226 |     allowed too"
-
-

--- a/crates/ruff_linter/src/settings/types.rs
+++ b/crates/ruff_linter/src/settings/types.rs
@@ -50,6 +50,8 @@ pub enum PythonVersion {
     Py311,
     Py312,
     Py313,
+    // Remember to update the `latest()` function
+    // when adding new versions here!
 }
 
 impl From<PythonVersion> for Pep440Version {
@@ -61,8 +63,8 @@ impl From<PythonVersion> for Pep440Version {
 
 impl PythonVersion {
     /// Return the latest supported Python version.
-    pub fn latest() -> Self {
-        Self::iter().max().unwrap()
+    pub const fn latest() -> Self {
+        Self::Py313
     }
 
     pub const fn as_tuple(&self) -> (u8, u8) {

--- a/crates/ruff_linter/src/settings/types.rs
+++ b/crates/ruff_linter/src/settings/types.rs
@@ -61,8 +61,8 @@ impl From<PythonVersion> for Pep440Version {
 
 impl PythonVersion {
     /// Return the latest supported Python version.
-    pub const fn latest() -> Self {
-        Self::Py312
+    pub fn latest() -> Self {
+        Self::iter().max().unwrap()
     }
 
     pub const fn as_tuple(&self) -> (u8, u8) {


### PR DESCRIPTION
Working on a PR for #11413, I noticed that the linter tests still thought that py312 was the latest version. This affects which autofixes are displayed in the snapshots for several of the pyupgrade rules.