### PR TITLE
Use rule name rather than message in `--statistics`

### DIFF
--- a/crates/ruff/tests/integration_test.rs
+++ b/crates/ruff/tests/integration_test.rs
@@ -861,6 +861,35 @@ fn show_statistics() {
 }
 
 #[test]
+fn show_statistics_json() {
+    let mut cmd = RuffCheck::default()
+        .args([
+            "--select",
+            "F401",
+            "--statistics",
+            "--output-format",
+            "json",
+        ])
+        .build();
+    assert_cmd_snapshot!(cmd
+        .pass_stdin("import sys\nimport os\n\nprint(os.getuid())\n"), @r###"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    [
+      {
+        "code": "F401",
+        "name": "unused-import",
+        "count": 1,
+        "fixable": true
+      }
+    ]
+
+    ----- stderr -----
+    "###);
+}
+
+#[test]
 fn nursery_prefix() {
     // Should only detect RUF90X, but not the unstable test rules
     let mut cmd = RuffCheck::default()

--- a/crates/ruff/tests/integration_test.rs
+++ b/crates/ruff/tests/integration_test.rs
@@ -854,7 +854,7 @@ fn show_statistics() {
     success: false
     exit_code: 1
     ----- stdout -----
-    1	F401	[*] `sys` imported but unused
+    1	F401	[*] unused-import
 
     ----- stderr -----
     "###);


### PR DESCRIPTION
## Summary

Since this changes the output schema of the JSON format for `--statistics`, let's include it in v0.5.0.

Closes https://github.com/astral-sh/ruff/issues/11097.
