### PR TITLE
Use string expression for parsing type annotation

### DIFF
--- a/crates/ruff_linter/src/checkers/ast/deferred.rs
+++ b/crates/ruff_linter/src/checkers/ast/deferred.rs
@@ -1,13 +1,12 @@
-use ruff_python_ast::Expr;
+use ruff_python_ast::{Expr, ExprStringLiteral};
 use ruff_python_semantic::{ScopeId, Snapshot};
-use ruff_text_size::TextRange;
 
 /// A collection of AST nodes that are deferred for later visitation. Used to, e.g., store
 /// functions, whose bodies shouldn't be visited until all module-level definitions have been
 /// visited.
 #[derive(Debug, Default)]
 pub(crate) struct Visit<'a> {
-    pub(crate) string_type_definitions: Vec<(TextRange, &'a str, Snapshot)>,
+    pub(crate) string_type_definitions: Vec<(&'a ExprStringLiteral, Snapshot)>,
     pub(crate) future_type_definitions: Vec<(&'a Expr, Snapshot)>,
     pub(crate) type_param_definitions: Vec<(&'a Expr, Snapshot)>,
     pub(crate) functions: Vec<Snapshot>,

--- a/crates/ruff_linter/src/rules/flake8_annotations/rules/definition.rs
+++ b/crates/ruff_linter/src/rules/flake8_annotations/rules/definition.rs
@@ -512,10 +512,10 @@ fn check_dynamically_typed<F>(
 ) where
     F: FnOnce() -> String,
 {
-    if let Expr::StringLiteral(ast::ExprStringLiteral { range, value }) = annotation {
+    if let Expr::StringLiteral(string_expr) = annotation {
         // Quoted annotations
         if let Ok((parsed_annotation, _)) =
-            parse_type_annotation(value.to_str(), *range, checker.locator().contents())
+            parse_type_annotation(string_expr, checker.locator().contents())
         {
             if type_hint_resolves_to_any(
                 &parsed_annotation,

--- a/crates/ruff_linter/src/rules/ruff/rules/implicit_optional.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/implicit_optional.rs
@@ -177,13 +177,13 @@ pub(crate) fn implicit_optional(checker: &mut Checker, parameters: &Parameters) 
             continue;
         };
 
-        if let Expr::StringLiteral(ast::ExprStringLiteral { range, value }) = annotation.as_ref() {
+        if let Expr::StringLiteral(string_expr) = annotation.as_ref() {
             // Quoted annotation.
-            if let Ok((annotation, kind)) =
-                parse_type_annotation(value.to_str(), *range, checker.locator().contents())
+            if let Ok((parsed_annotation, kind)) =
+                parse_type_annotation(string_expr, checker.locator().contents())
             {
                 let Some(expr) = type_hint_explicitly_allows_none(
-                    &annotation,
+                    &parsed_annotation,
                     checker.semantic(),
                     checker.locator(),
                     checker.settings.target_version.minor(),

--- a/crates/ruff_linter/src/rules/ruff/typing.rs
+++ b/crates/ruff_linter/src/rules/ruff/typing.rs
@@ -112,8 +112,8 @@ impl<'a> TypingTarget<'a> {
                 ..
             }) => Some(TypingTarget::PEP604Union(left, right)),
             Expr::NoneLiteral(_) => Some(TypingTarget::None),
-            Expr::StringLiteral(ast::ExprStringLiteral { value, range }) => {
-                parse_type_annotation(value.to_str(), *range, locator.contents())
+            Expr::StringLiteral(string_expr) => {
+                parse_type_annotation(string_expr, locator.contents())
                     .map_or(None, |(expr, _)| Some(TypingTarget::ForwardReference(expr)))
             }
             _ => semantic.resolve_qualified_name(expr).map_or(


### PR DESCRIPTION
## Summary

This PR updates the logic for parsing type annotation to accept a `ExprStringLiteral` node instead of the string value and the range.

The main motivation of this change is to simplify the implementation of `parse_type_annotation` function with:
* Use the `opener_len` and `closer_len` from the string flags to get the raw contents range instead of extracting it via
	* `str::leading_quote(expression).unwrap().text_len()`
	* `str::trailing_quote(expression).unwrap().text_len()`
* Avoid comparing the string content if we already know that it's implicitly concatenated

## Test Plan

`cargo insta test`
