### PR TITLE
Remove less used parser dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2249,8 +2249,6 @@ dependencies = [
  "bitflags 2.5.0",
  "bstr",
  "insta",
- "is-macro",
- "itertools 0.13.0",
  "memchr",
  "ruff_python_ast",
  "ruff_python_trivia",

--- a/crates/ruff_python_parser/Cargo.toml
+++ b/crates/ruff_python_parser/Cargo.toml
@@ -17,11 +17,8 @@ ruff_python_ast = { workspace = true }
 ruff_python_trivia = { workspace = true }
 ruff_text_size = { workspace = true }
 
-anyhow = { workspace = true }
 bitflags = { workspace = true }
 bstr = { workspace = true }
-is-macro = { workspace = true }
-itertools = { workspace = true }
 memchr = { workspace = true }
 rustc-hash = { workspace = true }
 static_assertions = { workspace = true }
@@ -33,6 +30,7 @@ unicode-normalization = { workspace = true }
 ruff_source_file = { workspace = true }
 
 annotate-snippets = { workspace = true }
+anyhow = { workspace = true }
 insta = { workspace = true, features = ["glob"] }
 walkdir = { workspace = true }
 

--- a/crates/ruff_python_parser/src/lexer.rs
+++ b/crates/ruff_python_parser/src/lexer.rs
@@ -6,16 +6,17 @@
 //!
 //! [Lexical analysis]: https://docs.python.org/3/reference/lexical_analysis.html
 
-use std::{char, cmp::Ordering, str::FromStr};
+use std::cmp::Ordering;
+use std::str::FromStr;
 
 use bitflags::bitflags;
+use unicode_ident::{is_xid_continue, is_xid_start};
+use unicode_normalization::UnicodeNormalization;
+
 use ruff_python_ast::str::Quote;
 use ruff_python_ast::str_prefix::{
     AnyStringPrefix, ByteStringPrefix, FStringPrefix, StringLiteralPrefix,
 };
-use unicode_ident::{is_xid_continue, is_xid_start};
-use unicode_normalization::UnicodeNormalization;
-
 use ruff_python_ast::{AnyStringFlags, Int, IpyEscapeKind, StringFlags};
 use ruff_text_size::{Ranged, TextLen, TextRange, TextSize};
 

--- a/crates/ruff_python_parser/src/lib.rs
+++ b/crates/ruff_python_parser/src/lib.rs
@@ -73,7 +73,6 @@ pub use crate::token::TokenKind;
 
 use crate::parser::Parser;
 
-use itertools::Itertools;
 use ruff_python_ast::{Expr, Mod, ModExpression, ModModule, PySourceType, Suite};
 use ruff_python_trivia::CommentRanges;
 use ruff_text_size::{Ranged, TextRange, TextSize};
@@ -388,9 +387,8 @@ impl Tokens {
         let end = *self.first_unknown_or_len.get_or_init(|| {
             self.raw
                 .iter()
-                .find_position(|token| token.kind() == TokenKind::Unknown)
-                .map(|(idx, _)| idx)
-                .unwrap_or_else(|| self.raw.len())
+                .position(|token| token.kind() == TokenKind::Unknown)
+                .unwrap_or(self.raw.len())
         });
         &self.raw[..end]
     }


### PR DESCRIPTION
## Summary

This PR removes the following dependencies from the `ruff_python_parser` crate:
* `anyhow` (moved to dev dependencies)
* `is-macro`
* `itertools`

The main motivation is that they aren't used much.

Additionally, it updates the return type of `parse_type_annotation` to use a more specific `ParseError` instead of the generic `anyhow::Error`.

## Test Plan

`cargo insta test`
