### PR TITLE
Isolate non-breaking whitespace indentation test case

### DIFF
--- a/crates/ruff_python_codegen/src/stylist.rs
+++ b/crates/ruff_python_codegen/src/stylist.rs
@@ -214,6 +214,20 @@ x = (
         let stylist = Stylist::from_tokens(parsed.tokens(), &locator);
         assert_eq!(stylist.indentation(), &Indentation("  ".to_string()));
 
+        // formfeed indent, see `detect_indention` comment.
+        let contents = r"
+class FormFeedIndent:
+   def __init__(self, a=[]):
+        print(a)
+";
+        let locator = Locator::new(contents);
+        let parsed = parse_module(contents).unwrap();
+        let stylist = Stylist::from_tokens(parsed.tokens(), &locator);
+        assert_eq!(stylist.indentation(), &Indentation(" ".to_string()));
+    }
+
+    #[test]
+    fn indent_non_breaking_whitespace() {
         let contents = r"
 x = (
  1,
@@ -227,17 +241,6 @@ x = (
             Stylist::from_tokens(parsed.tokens(), &locator).indentation(),
             &Indentation(" ".to_string())
         );
-
-        // formfeed indent, see `detect_indention` comment.
-        let contents = r"
-class FormFeedIndent:
-   def __init__(self, a=[]):
-        print(a)
-";
-        let locator = Locator::new(contents);
-        let parsed = parse_module(contents).unwrap();
-        let stylist = Stylist::from_tokens(parsed.tokens(), &locator);
-        assert_eq!(stylist.indentation(), &Indentation(" ".to_string()));
     }
 
     #[test]


### PR DESCRIPTION
As discussed in Discord, this moves the test case for non-breaking whitespace into its own method.