### PR TITLE
red-knot: Use `parse_unchecked` to get all parse errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1789,7 +1789,6 @@ dependencies = [
  "rustc-hash",
  "smol_str",
  "tempfile",
- "textwrap",
  "tracing",
  "tracing-subscriber",
  "tracing-tree",
@@ -2691,12 +2690,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
-name = "smawk"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
-
-[[package]]
 name = "smol_str"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2843,17 +2836,6 @@ dependencies = [
  "quote",
  "syn",
  "test-case-core",
-]
-
-[[package]]
-name = "textwrap"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9"
-dependencies = [
- "smawk",
- "unicode-linebreak",
- "unicode-width",
 ]
 
 [[package]]
@@ -3110,12 +3092,6 @@ name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
-
-[[package]]
-name = "unicode-linebreak"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
 
 [[package]]
 name = "unicode-normalization"

--- a/crates/red_knot/Cargo.toml
+++ b/crates/red_knot/Cargo.toml
@@ -35,7 +35,6 @@ tracing-subscriber = { workspace = true }
 tracing-tree = { workspace = true }
 
 [dev-dependencies]
-textwrap = { version = "0.16.1" }
 tempfile = { workspace = true }
 
 [lints]

--- a/crates/red_knot/src/lint.rs
+++ b/crates/red_knot/src/lint.rs
@@ -87,7 +87,7 @@ pub(crate) fn lint_semantic(db: &dyn LintDb, file_id: FileId) -> QueryResult<Dia
         let context = SemanticLintContext {
             file_id: *file_id,
             source,
-            parsed: &*parsed,
+            parsed: &parsed,
             symbols,
             db,
             diagnostics: RefCell::new(Vec::new()),

--- a/crates/red_knot/src/lint.rs
+++ b/crates/red_knot/src/lint.rs
@@ -5,12 +5,13 @@ use std::time::Duration;
 
 use ruff_python_ast::visitor::Visitor;
 use ruff_python_ast::{ModModule, StringLiteral};
+use ruff_python_parser::Parsed;
 
 use crate::cache::KeyValueCache;
 use crate::db::{LintDb, LintJar, QueryResult};
 use crate::files::FileId;
 use crate::module::ModuleName;
-use crate::parse::{parse, Parsed};
+use crate::parse::parse;
 use crate::source::{source_text, Source};
 use crate::symbols::{
     resolve_global_symbol, symbol_table, Definition, GlobalSymbolId, SymbolId, SymbolTable,
@@ -40,7 +41,7 @@ pub(crate) fn lint_syntax(db: &dyn LintDb, file_id: FileId) -> QueryResult<Diagn
         let parsed = parse(db.upcast(), *file_id)?;
 
         if parsed.errors().is_empty() {
-            let ast = parsed.ast();
+            let ast = parsed.syntax();
 
             let mut visitor = SyntaxLintVisitor {
                 diagnostics,
@@ -86,7 +87,7 @@ pub(crate) fn lint_semantic(db: &dyn LintDb, file_id: FileId) -> QueryResult<Dia
         let context = SemanticLintContext {
             file_id: *file_id,
             source,
-            parsed,
+            parsed: &*parsed,
             symbols,
             db,
             diagnostics: RefCell::new(Vec::new()),
@@ -194,7 +195,7 @@ fn lint_bad_overrides(context: &SemanticLintContext) -> QueryResult<()> {
 pub struct SemanticLintContext<'a> {
     file_id: FileId,
     source: Source,
-    parsed: Parsed,
+    parsed: &'a Parsed<ModModule>,
     symbols: Arc<SymbolTable>,
     db: &'a dyn LintDb,
     diagnostics: RefCell<Vec<String>>,
@@ -209,8 +210,8 @@ impl<'a> SemanticLintContext<'a> {
         self.file_id
     }
 
-    pub fn ast(&self) -> &ModModule {
-        self.parsed.ast()
+    pub fn ast(&self) -> &'a ModModule {
+        self.parsed.syntax()
     }
 
     pub fn symbols(&self) -> &SymbolTable {

--- a/crates/red_knot/src/parse.rs
+++ b/crates/red_knot/src/parse.rs
@@ -1,87 +1,34 @@
 use std::ops::{Deref, DerefMut};
 use std::sync::Arc;
 
-use ruff_python_ast as ast;
-use ruff_python_parser::{Mode, ParseError};
-use ruff_text_size::{Ranged, TextRange};
+use ruff_python_ast::ModModule;
+use ruff_python_parser::{Mode, Parsed};
 
 use crate::cache::KeyValueCache;
 use crate::db::{QueryResult, SourceDb};
 use crate::files::FileId;
 use crate::source::source_text;
 
-#[derive(Debug, Clone, PartialEq)]
-pub struct Parsed {
-    inner: Arc<ParsedInner>,
-}
-
-#[derive(Debug, PartialEq)]
-struct ParsedInner {
-    ast: ast::ModModule,
-    errors: Vec<ParseError>,
-}
-
-impl Parsed {
-    fn new(ast: ast::ModModule, errors: Vec<ParseError>) -> Self {
-        Self {
-            inner: Arc::new(ParsedInner { ast, errors }),
-        }
-    }
-
-    pub(crate) fn from_text(text: &str) -> Self {
-        let result = ruff_python_parser::parse(text, Mode::Module);
-
-        let (module, errors) = match result {
-            Ok(parsed) => match parsed.into_syntax() {
-                ast::Mod::Module(module) => (module, vec![]),
-                ast::Mod::Expression(expression) => (
-                    ast::ModModule {
-                        range: expression.range(),
-                        body: vec![ast::Stmt::Expr(ast::StmtExpr {
-                            range: expression.range(),
-                            value: expression.body,
-                        })],
-                    },
-                    vec![],
-                ),
-            },
-            Err(errors) => (
-                ast::ModModule {
-                    range: TextRange::default(),
-                    body: Vec::new(),
-                },
-                vec![errors],
-            ),
-        };
-
-        Parsed::new(module, errors)
-    }
-
-    pub fn ast(&self) -> &ast::ModModule {
-        &self.inner.ast
-    }
-
-    pub fn errors(&self) -> &[ParseError] {
-        &self.inner.errors
-    }
-}
-
 #[tracing::instrument(level = "debug", skip(db))]
-pub(crate) fn parse(db: &dyn SourceDb, file_id: FileId) -> QueryResult<Parsed> {
+pub(crate) fn parse(db: &dyn SourceDb, file_id: FileId) -> QueryResult<Arc<Parsed<ModModule>>> {
     let jar = db.jar()?;
 
     jar.parsed.get(&file_id, |file_id| {
         let source = source_text(db, *file_id)?;
 
-        Ok(Parsed::from_text(source.text()))
+        Ok(Arc::new(
+            ruff_python_parser::parse_unchecked(source.text(), Mode::Module)
+                .try_into_module()
+                .unwrap(),
+        ))
     })
 }
 
 #[derive(Debug, Default)]
-pub struct ParsedStorage(KeyValueCache<FileId, Parsed>);
+pub struct ParsedStorage(KeyValueCache<FileId, Arc<Parsed<ModModule>>>);
 
 impl Deref for ParsedStorage {
-    type Target = KeyValueCache<FileId, Parsed>;
+    type Target = KeyValueCache<FileId, Arc<Parsed<ModModule>>>;
 
     fn deref(&self) -> &Self::Target {
         &self.0

--- a/crates/red_knot/src/parse.rs
+++ b/crates/red_knot/src/parse.rs
@@ -2,7 +2,7 @@ use std::ops::{Deref, DerefMut};
 use std::sync::Arc;
 
 use ruff_python_ast::ModModule;
-use ruff_python_parser::{Mode, Parsed};
+use ruff_python_parser::Parsed;
 
 use crate::cache::KeyValueCache;
 use crate::db::{QueryResult, SourceDb};
@@ -16,11 +16,10 @@ pub(crate) fn parse(db: &dyn SourceDb, file_id: FileId) -> QueryResult<Arc<Parse
     jar.parsed.get(&file_id, |file_id| {
         let source = source_text(db, *file_id)?;
 
-        Ok(Arc::new(
-            ruff_python_parser::parse_unchecked(source.text(), Mode::Module)
-                .try_into_module()
-                .unwrap(),
-        ))
+        Ok(Arc::new(ruff_python_parser::parse_unchecked_source(
+            source.text(),
+            source.kind().into(),
+        )))
     })
 }
 

--- a/crates/red_knot/src/source.rs
+++ b/crates/red_knot/src/source.rs
@@ -53,6 +53,16 @@ pub enum SourceKind {
     IpyNotebook(Arc<Notebook>),
 }
 
+impl<'a> From<&'a SourceKind> for PySourceType {
+    fn from(value: &'a SourceKind) -> Self {
+        match value {
+            SourceKind::Python(_) => PySourceType::Python,
+            SourceKind::Stub(_) => PySourceType::Stub,
+            SourceKind::IpyNotebook(_) => PySourceType::Ipynb,
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub struct Source {
     kind: SourceKind,

--- a/crates/red_knot/src/types/infer.rs
+++ b/crates/red_knot/src/types/infer.rs
@@ -213,7 +213,6 @@ fn infer_expr_type(db: &dyn SemanticDb, file_id: FileId, expr: &ast::Expr) -> Qu
 
 #[cfg(test)]
 mod tests {
-    use textwrap::dedent;
 
     use crate::db::tests::TestDb;
     use crate::db::{HasJar, SemanticJar};
@@ -251,7 +250,7 @@ mod tests {
 
     fn write_to_path(case: &TestCase, relpath: &str, contents: &str) -> anyhow::Result<()> {
         let path = case.src.path().join(relpath);
-        std::fs::write(path, dedent(contents))?;
+        std::fs::write(path, contents)?;
         Ok(())
     }
 

--- a/crates/red_knot/src/types/infer.rs
+++ b/crates/red_knot/src/types/infer.rs
@@ -107,7 +107,7 @@ pub fn infer_definition_type(
                 Ok(ty)
             } else {
                 let parsed = parse(db.upcast(), file_id)?;
-                let ast = parsed.ast();
+                let ast = parsed.syntax();
                 let table = symbol_table(db, file_id)?;
                 let node = node_key.resolve_unwrap(ast.as_any_node_ref());
 
@@ -127,7 +127,7 @@ pub fn infer_definition_type(
                 Ok(ty)
             } else {
                 let parsed = parse(db.upcast(), file_id)?;
-                let ast = parsed.ast();
+                let ast = parsed.syntax();
                 let table = symbol_table(db, file_id)?;
                 let node = node_key
                     .resolve(ast.as_any_node_ref())
@@ -154,14 +154,14 @@ pub fn infer_definition_type(
         }
         Definition::Assignment(node_key) => {
             let parsed = parse(db.upcast(), file_id)?;
-            let ast = parsed.ast();
+            let ast = parsed.syntax();
             let node = node_key.resolve_unwrap(ast.as_any_node_ref());
             // TODO handle unpacking assignment correctly (here and for AnnotatedAssignment case, below)
             infer_expr_type(db, file_id, &node.value)
         }
         Definition::AnnotatedAssignment(node_key) => {
             let parsed = parse(db.upcast(), file_id)?;
-            let ast = parsed.ast();
+            let ast = parsed.syntax();
             let node = node_key.resolve_unwrap(ast.as_any_node_ref());
             // TODO actually look at the annotation
             let Some(value) = &node.value else {

--- a/crates/ruff_python_parser/src/lib.rs
+++ b/crates/ruff_python_parser/src/lib.rs
@@ -64,7 +64,6 @@
 //! [parsing]: https://en.wikipedia.org/wiki/Parsing
 //! [lexer]: crate::lexer
 
-use std::cell::OnceCell;
 use std::ops::Deref;
 
 pub use crate::error::{FStringErrorType, ParseError, ParseErrorType};
@@ -308,7 +307,7 @@ impl Parsed<Mod> {
     /// returns [`None`].
     ///
     /// [`Some(Parsed<ModModule>)`]: Some
-    fn try_into_module(self) -> Option<Parsed<ModModule>> {
+    pub fn try_into_module(self) -> Option<Parsed<ModModule>> {
         match self.syntax {
             Mod::Module(module) => Some(Parsed {
                 syntax: module,
@@ -327,7 +326,7 @@ impl Parsed<Mod> {
     /// Otherwise, it returns [`None`].
     ///
     /// [`Some(Parsed<ModExpression>)`]: Some
-    fn try_into_expression(self) -> Option<Parsed<ModExpression>> {
+    pub fn try_into_expression(self) -> Option<Parsed<ModExpression>> {
         match self.syntax {
             Mod::Module(_) => None,
             Mod::Expression(expression) => Some(Parsed {
@@ -370,14 +369,14 @@ pub struct Tokens {
     raw: Vec<Token>,
 
     /// Index of the first [`TokenKind::Unknown`] token or the length of the token vector.
-    first_unknown_or_len: OnceCell<usize>,
+    first_unknown_or_len: std::sync::OnceLock<usize>,
 }
 
 impl Tokens {
     pub(crate) fn new(tokens: Vec<Token>) -> Tokens {
         Tokens {
             raw: tokens,
-            first_unknown_or_len: OnceCell::new(),
+            first_unknown_or_len: std::sync::OnceLock::new(),
         }
     }
 


### PR DESCRIPTION
## Summary

The parser now supports to return all parse errors instead of just the first. Let's use that and also reuse the ast's `Parsed` module instead of defining our own.

## Test Plan

`cargo test`
