### PR TITLE
Respect per-file ignores for blanket and redirected noqa rules

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pygrep_hooks/PGH004_3.py
+++ b/crates/ruff_linter/resources/test/fixtures/pygrep_hooks/PGH004_3.py
@@ -1,0 +1,8 @@
+# noqa
+# ruff : noqa
+# ruff: noqa: F401
+# ruff: noqa: PGH004
+
+
+# flake8: noqa
+import math as m

--- a/crates/ruff_linter/src/rules/pygrep_hooks/mod.rs
+++ b/crates/ruff_linter/src/rules/pygrep_hooks/mod.rs
@@ -19,6 +19,7 @@ mod tests {
     #[test_case(Rule::BlanketNOQA, Path::new("PGH004_0.py"))]
     #[test_case(Rule::BlanketNOQA, Path::new("PGH004_1.py"))]
     #[test_case(Rule::BlanketNOQA, Path::new("PGH004_2.py"))]
+    #[test_case(Rule::BlanketNOQA, Path::new("PGH004_3.py"))]
     #[test_case(Rule::InvalidMockAccess, Path::new("PGH005_0.py"))]
     fn rules(rule_code: Rule, path: &Path) -> Result<()> {
         let snapshot = format!("{}_{}", rule_code.noqa_code(), path.to_string_lossy());

--- a/crates/ruff_linter/src/rules/pygrep_hooks/snapshots/ruff_linter__rules__pygrep_hooks__tests__PGH004_PGH004_3.py.snap
+++ b/crates/ruff_linter/src/rules/pygrep_hooks/snapshots/ruff_linter__rules__pygrep_hooks__tests__PGH004_PGH004_3.py.snap
@@ -1,0 +1,4 @@
+---
+source: crates/ruff_linter/src/rules/pygrep_hooks/mod.rs
+---
+


### PR DESCRIPTION
## Summary

Ensures that we respect per-file ignores and exemptions for these rules. Specifically, we allow:

```python
# ruff: noqa: PGH004
```

...to ignore `PGH004`.
