### PR TITLE
Use cursor offset for lexer checkpoint

### DIFF
--- a/crates/ruff_python_parser/src/parser/mod.rs
+++ b/crates/ruff_python_parser/src/parser/mod.rs
@@ -609,7 +609,7 @@ impl<'src> Parser<'src> {
     }
 
     /// Creates a checkpoint to which the parser can later return to using [`Self::rewind`].
-    fn checkpoint(&self) -> ParserCheckpoint<'src> {
+    fn checkpoint(&self) -> ParserCheckpoint {
         ParserCheckpoint {
             tokens: self.tokens.checkpoint(),
             errors_position: self.errors.len(),
@@ -620,7 +620,7 @@ impl<'src> Parser<'src> {
     }
 
     /// Restore the parser to the given checkpoint.
-    fn rewind(&mut self, checkpoint: ParserCheckpoint<'src>) {
+    fn rewind(&mut self, checkpoint: ParserCheckpoint) {
         let ParserCheckpoint {
             tokens,
             errors_position,
@@ -637,8 +637,8 @@ impl<'src> Parser<'src> {
     }
 }
 
-struct ParserCheckpoint<'src> {
-    tokens: TokenSourceCheckpoint<'src>,
+struct ParserCheckpoint {
+    tokens: TokenSourceCheckpoint,
     errors_position: usize,
     current_token_id: TokenId,
     prev_token_end: TextSize,

--- a/crates/ruff_python_parser/src/token_source.rs
+++ b/crates/ruff_python_parser/src/token_source.rs
@@ -126,7 +126,7 @@ impl<'src> TokenSource<'src> {
     }
 
     /// Creates a checkpoint to which the token source can later return to using [`Self::rewind`].
-    pub(crate) fn checkpoint(&self) -> TokenSourceCheckpoint<'src> {
+    pub(crate) fn checkpoint(&self) -> TokenSourceCheckpoint {
         TokenSourceCheckpoint {
             lexer_checkpoint: self.lexer.checkpoint(),
             tokens_position: self.tokens.len(),
@@ -135,7 +135,7 @@ impl<'src> TokenSource<'src> {
     }
 
     /// Restore the token source to the given checkpoint.
-    pub(crate) fn rewind(&mut self, checkpoint: TokenSourceCheckpoint<'src>) {
+    pub(crate) fn rewind(&mut self, checkpoint: TokenSourceCheckpoint) {
         let TokenSourceCheckpoint {
             lexer_checkpoint,
             tokens_position,
@@ -168,8 +168,8 @@ impl<'src> TokenSource<'src> {
     }
 }
 
-pub(crate) struct TokenSourceCheckpoint<'src> {
-    lexer_checkpoint: LexerCheckpoint<'src>,
+pub(crate) struct TokenSourceCheckpoint {
+    lexer_checkpoint: LexerCheckpoint,
     tokens_position: usize,
     comments_position: usize,
 }


### PR DESCRIPTION
## Summary

This PR updates the lexer checkpoint to store the cursor offset instead of cloning the cursor itself. This reduces the size of `LexerCheckpoint` from 136 to 112 bytes and also removes the need for lifetime.

## Test Plan

`cargo insta test`