### PR TITLE
Update type annotation parsing API to return `Parsed`

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_annotations/rules/definition.rs
+++ b/crates/ruff_linter/src/rules/flake8_annotations/rules/definition.rs
@@ -518,7 +518,7 @@ fn check_dynamically_typed<F>(
             parse_type_annotation(string_expr, checker.locator().contents())
         {
             if type_hint_resolves_to_any(
-                &parsed_annotation,
+                parsed_annotation.expr(),
                 checker.semantic(),
                 checker.locator(),
                 checker.settings.target_version.minor(),

--- a/crates/ruff_linter/src/rules/ruff/rules/implicit_optional.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/implicit_optional.rs
@@ -183,7 +183,7 @@ pub(crate) fn implicit_optional(checker: &mut Checker, parameters: &Parameters) 
                 parse_type_annotation(string_expr, checker.locator().contents())
             {
                 let Some(expr) = type_hint_explicitly_allows_none(
-                    &parsed_annotation,
+                    parsed_annotation.expr(),
                     checker.semantic(),
                     checker.locator(),
                     checker.settings.target_version.minor(),

--- a/crates/ruff_linter/src/rules/ruff/typing.rs
+++ b/crates/ruff_linter/src/rules/ruff/typing.rs
@@ -112,10 +112,15 @@ impl<'a> TypingTarget<'a> {
                 ..
             }) => Some(TypingTarget::PEP604Union(left, right)),
             Expr::NoneLiteral(_) => Some(TypingTarget::None),
-            Expr::StringLiteral(string_expr) => {
-                parse_type_annotation(string_expr, locator.contents())
-                    .map_or(None, |(expr, _)| Some(TypingTarget::ForwardReference(expr)))
-            }
+            Expr::StringLiteral(string_expr) => parse_type_annotation(
+                string_expr,
+                locator.contents(),
+            )
+            .map_or(None, |(parsed_annotation, _)| {
+                Some(TypingTarget::ForwardReference(
+                    parsed_annotation.into_expr(),
+                ))
+            }),
             _ => semantic.resolve_qualified_name(expr).map_or(
                 // If we can't resolve the call path, it must be defined in the
                 // same file, so we assume it's `Any` as it could be a type alias.

--- a/crates/ruff_python_parser/src/lib.rs
+++ b/crates/ruff_python_parser/src/lib.rs
@@ -357,6 +357,11 @@ impl Parsed<ModExpression> {
         &self.syntax.body
     }
 
+    /// Returns a mutable reference to the expression contained in this parsed output.
+    pub fn expr_mut(&mut self) -> &mut Expr {
+        &mut self.syntax.body
+    }
+
     /// Consumes the [`Parsed`] output and returns the contained [`Expr`].
     pub fn into_expr(self) -> Expr {
         *self.syntax.body

--- a/crates/ruff_python_parser/src/typing.rs
+++ b/crates/ruff_python_parser/src/typing.rs
@@ -2,10 +2,10 @@
 
 use ruff_python_ast::relocate::relocate_expr;
 use ruff_python_ast::str::raw_contents;
-use ruff_python_ast::{Expr, ExprStringLiteral, StringFlags, StringLiteral};
+use ruff_python_ast::{ExprStringLiteral, ModExpression, StringFlags, StringLiteral};
 use ruff_text_size::Ranged;
 
-use crate::{parse_expression, parse_expression_range, ParseError};
+use crate::{parse_expression, parse_expression_range, ParseError, Parsed};
 
 #[derive(Copy, Clone, Debug)]
 pub enum AnnotationKind {
@@ -34,7 +34,7 @@ impl AnnotationKind {
 pub fn parse_type_annotation(
     string_expr: &ExprStringLiteral,
     source: &str,
-) -> Result<(Expr, AnnotationKind), ParseError> {
+) -> Result<(Parsed<ModExpression>, AnnotationKind), ParseError> {
     let expr_text = &source[string_expr.range()];
 
     if let [string_literal] = string_expr.value.as_slice() {
@@ -58,7 +58,7 @@ pub fn parse_type_annotation(
 fn parse_simple_type_annotation(
     string_literal: &StringLiteral,
     source: &str,
-) -> Result<(Expr, AnnotationKind), ParseError> {
+) -> Result<(Parsed<ModExpression>, AnnotationKind), ParseError> {
     Ok((
         parse_expression_range(
             source,
@@ -66,16 +66,15 @@ fn parse_simple_type_annotation(
                 .range()
                 .add_start(string_literal.flags.opener_len())
                 .sub_end(string_literal.flags.closer_len()),
-        )?
-        .into_expr(),
+        )?,
         AnnotationKind::Simple,
     ))
 }
 
 fn parse_complex_type_annotation(
     string_expr: &ExprStringLiteral,
-) -> Result<(Expr, AnnotationKind), ParseError> {
-    let mut parsed = parse_expression(string_expr.value.to_str())?.into_expr();
-    relocate_expr(&mut parsed, string_expr.range());
+) -> Result<(Parsed<ModExpression>, AnnotationKind), ParseError> {
+    let mut parsed = parse_expression(string_expr.value.to_str())?;
+    relocate_expr(parsed.expr_mut(), string_expr.range());
     Ok((parsed, AnnotationKind::Complex))
 }


### PR DESCRIPTION
## Summary

This PR updates the return type of `parse_type_annotation` from `Expr` to `Parsed<ModExpression>`. This is to allow accessing the tokens for the parsed sub-expression in the follow-up PR.

## Test Plan

`cargo insta test`
