### PR TITLE
`ruff server`: Tracing system now respects log level and trace level, with options to log to a file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1943,7 +1943,6 @@ dependencies = [
  "toml",
  "tracing",
  "tracing-subscriber",
- "tracing-tree",
  "walkdir",
  "wild",
 ]
@@ -2344,6 +2343,7 @@ dependencies = [
  "serde_json",
  "shellexpand",
  "tracing",
+ "tracing-subscriber",
  "walkdir",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1942,7 +1942,6 @@ dependencies = [
  "tikv-jemallocator",
  "toml",
  "tracing",
- "tracing-subscriber",
  "walkdir",
  "wild",
 ]

--- a/crates/ruff/Cargo.toml
+++ b/crates/ruff/Cargo.toml
@@ -54,7 +54,6 @@ thiserror = { workspace = true }
 toml = { workspace = true }
 tracing = { workspace = true, features = ["log"] }
 tracing-subscriber = { workspace = true, features = ["registry"] }
-tracing-tree = { workspace = true }
 walkdir = { workspace = true }
 wild = { workspace = true }
 

--- a/crates/ruff/Cargo.toml
+++ b/crates/ruff/Cargo.toml
@@ -53,7 +53,6 @@ tempfile = { workspace = true }
 thiserror = { workspace = true }
 toml = { workspace = true }
 tracing = { workspace = true, features = ["log"] }
-tracing-subscriber = { workspace = true, features = ["registry"] }
 walkdir = { workspace = true }
 wild = { workspace = true }
 

--- a/crates/ruff/src/commands/server.rs
+++ b/crates/ruff/src/commands/server.rs
@@ -2,78 +2,15 @@ use std::num::NonZeroUsize;
 
 use crate::ExitStatus;
 use anyhow::Result;
-use ruff_linter::logging::LogLevel;
 use ruff_server::Server;
-use tracing::{level_filters::LevelFilter, metadata::Level, subscriber::Interest, Metadata};
-use tracing_subscriber::{
-    layer::{Context, Filter, SubscriberExt},
-    Layer, Registry,
-};
-use tracing_tree::time::Uptime;
 
-pub(crate) fn run_server(
-    preview: bool,
-    worker_threads: NonZeroUsize,
-    log_level: LogLevel,
-) -> Result<ExitStatus> {
+pub(crate) fn run_server(preview: bool, worker_threads: NonZeroUsize) -> Result<ExitStatus> {
     if !preview {
         tracing::error!("--preview needs to be provided as a command line argument while the server is still unstable.\nFor example: `ruff server --preview`");
         return Ok(ExitStatus::Error);
     }
-    let trace_level = if log_level == LogLevel::Verbose {
-        Level::TRACE
-    } else {
-        Level::DEBUG
-    };
-
-    let subscriber = Registry::default().with(
-        tracing_tree::HierarchicalLayer::default()
-            .with_indent_lines(true)
-            .with_indent_amount(2)
-            .with_bracketed_fields(true)
-            .with_targets(true)
-            .with_writer(|| Box::new(std::io::stderr()))
-            .with_timer(Uptime::default())
-            .with_filter(LoggingFilter { trace_level }),
-    );
-
-    tracing::subscriber::set_global_default(subscriber)?;
 
     let server = Server::new(worker_threads)?;
 
     server.run().map(|()| ExitStatus::Success)
-}
-
-struct LoggingFilter {
-    trace_level: Level,
-}
-
-impl LoggingFilter {
-    fn is_enabled(&self, meta: &Metadata<'_>) -> bool {
-        let filter = if meta.target().starts_with("ruff") {
-            self.trace_level
-        } else {
-            Level::INFO
-        };
-
-        meta.level() <= &filter
-    }
-}
-
-impl<S> Filter<S> for LoggingFilter {
-    fn enabled(&self, meta: &Metadata<'_>, _cx: &Context<'_, S>) -> bool {
-        self.is_enabled(meta)
-    }
-
-    fn callsite_enabled(&self, meta: &'static Metadata<'static>) -> Interest {
-        if self.is_enabled(meta) {
-            Interest::always()
-        } else {
-            Interest::never()
-        }
-    }
-
-    fn max_level_hint(&self) -> Option<LevelFilter> {
-        Some(LevelFilter::from_level(self.trace_level))
-    }
 }

--- a/crates/ruff/src/lib.rs
+++ b/crates/ruff/src/lib.rs
@@ -201,7 +201,7 @@ pub fn run(
         }
         Command::Check(args) => check(args, global_options),
         Command::Format(args) => format(args, global_options),
-        Command::Server(args) => server(args, global_options.log_level()),
+        Command::Server(args) => server(args),
     }
 }
 
@@ -215,7 +215,7 @@ fn format(args: FormatCommand, global_options: GlobalConfigArgs) -> Result<ExitS
     }
 }
 
-fn server(args: ServerCommand, log_level: LogLevel) -> Result<ExitStatus> {
+fn server(args: ServerCommand) -> Result<ExitStatus> {
     let ServerCommand { preview } = args;
 
     let four = NonZeroUsize::new(4).unwrap();
@@ -224,7 +224,7 @@ fn server(args: ServerCommand, log_level: LogLevel) -> Result<ExitStatus> {
     let worker_threads = std::thread::available_parallelism()
         .unwrap_or(four)
         .max(four);
-    commands::server::run_server(preview, worker_threads, log_level)
+    commands::server::run_server(preview, worker_threads)
 }
 
 pub fn check(args: CheckCommand, global_options: GlobalConfigArgs) -> Result<ExitStatus> {

--- a/crates/ruff_server/Cargo.toml
+++ b/crates/ruff_server/Cargo.toml
@@ -38,6 +38,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 shellexpand = { workspace = true }
 tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
 walkdir = { workspace = true }
 
 [dev-dependencies]

--- a/crates/ruff_server/src/lib.rs
+++ b/crates/ruff_server/src/lib.rs
@@ -4,14 +4,16 @@ pub use edit::{PositionEncoding, TextDocument};
 use lsp_types::CodeActionKind;
 pub use server::Server;
 
+#[macro_use]
+mod message;
+
 mod edit;
 mod fix;
 mod format;
 mod lint;
-#[macro_use]
-mod message;
 mod server;
 mod session;
+mod trace;
 
 pub(crate) const SERVER_NAME: &str = "ruff";
 pub(crate) const DIAGNOSTIC_NAME: &str = "Ruff";

--- a/crates/ruff_server/src/message.rs
+++ b/crates/ruff_server/src/message.rs
@@ -32,7 +32,10 @@ pub(crate) fn init_messenger(client_sender: ClientSender) {
         }
 
         let backtrace = std::backtrace::Backtrace::force_capture();
-        tracing::error!("{panic_info}\n{backtrace}");
+        #[allow(clippy::print_stderr)]
+        {
+            eprintln!("{panic_info}\n{backtrace}");
+        }
     }));
 }
 

--- a/crates/ruff_server/src/message.rs
+++ b/crates/ruff_server/src/message.rs
@@ -32,8 +32,11 @@ pub(crate) fn init_messenger(client_sender: ClientSender) {
         }
 
         let backtrace = std::backtrace::Backtrace::force_capture();
+        tracing::error!("{panic_info}\n{backtrace}");
         #[allow(clippy::print_stderr)]
         {
+            // we also need to print to stderr directly in case tracing hasn't
+            // been initialized.
             eprintln!("{panic_info}\n{backtrace}");
         }
     }));

--- a/crates/ruff_server/src/server.rs
+++ b/crates/ruff_server/src/server.rs
@@ -81,9 +81,10 @@ impl Server {
         crate::trace::init_tracing(
             connection.make_sender(),
             global_settings
-                .log_level()
+                .tracing
+                .log_level
                 .unwrap_or(crate::trace::LogLevel::Info),
-            global_settings.log_file(),
+            global_settings.tracing.log_file.as_deref(),
         );
 
         let mut workspace_for_url = |url: lsp_types::Url| {

--- a/crates/ruff_server/src/server.rs
+++ b/crates/ruff_server/src/server.rs
@@ -64,9 +64,11 @@ impl Server {
             crate::version(),
         )?;
 
-        // TODO(jane): Support a log level setting
-        let log_level = crate::trace::LogLevel::Info;
-        let tracing_guard = crate::trace::init_tracing(connection.make_sender(), log_level);
+        if let Some(trace) = init_params.trace {
+            crate::trace::set_trace_value(trace);
+        }
+
+        let tracing_guard = crate::trace::init_tracing(connection.make_sender());
         crate::message::init_messenger(connection.make_sender());
 
         let AllSettings {

--- a/crates/ruff_server/src/server.rs
+++ b/crates/ruff_server/src/server.rs
@@ -83,6 +83,7 @@ impl Server {
             global_settings
                 .log_level()
                 .unwrap_or(crate::trace::LogLevel::Info),
+            global_settings.log_file(),
         );
 
         let mut workspace_for_url = |url: lsp_types::Url| {

--- a/crates/ruff_server/src/server.rs
+++ b/crates/ruff_server/src/server.rs
@@ -68,7 +68,6 @@ impl Server {
         }
 
         crate::message::init_messenger(connection.make_sender());
-        crate::trace::init_tracing(connection.make_sender());
 
         let AllSettings {
             global_settings,
@@ -77,6 +76,13 @@ impl Server {
             init_params
                 .initialization_options
                 .unwrap_or_else(|| serde_json::Value::Object(serde_json::Map::default())),
+        );
+
+        crate::trace::init_tracing(
+            connection.make_sender(),
+            global_settings
+                .log_level()
+                .unwrap_or(crate::trace::LogLevel::Info),
         );
 
         let mut workspace_for_url = |url: lsp_types::Url| {

--- a/crates/ruff_server/src/server/api.rs
+++ b/crates/ruff_server/src/server/api.rs
@@ -93,6 +93,9 @@ pub(super) fn notification<'a>(notif: server::Notification) -> Task<'a> {
         notification::DidCloseNotebook::METHOD => {
             local_notification_task::<notification::DidCloseNotebook>(notif)
         }
+        notification::SetTrace::METHOD => {
+            local_notification_task::<notification::SetTrace>(notif)
+        }
         method => {
             tracing::warn!("Received notification {method} which does not have a handler.");
             return Task::nothing();

--- a/crates/ruff_server/src/server/api/notifications.rs
+++ b/crates/ruff_server/src/server/api/notifications.rs
@@ -8,6 +8,7 @@ mod did_close;
 mod did_close_notebook;
 mod did_open;
 mod did_open_notebook;
+mod set_trace;
 
 use super::traits::{NotificationHandler, SyncNotificationHandler};
 pub(super) use cancel::Cancel;
@@ -20,3 +21,4 @@ pub(super) use did_close::DidClose;
 pub(super) use did_close_notebook::DidCloseNotebook;
 pub(super) use did_open::DidOpen;
 pub(super) use did_open_notebook::DidOpenNotebook;
+pub(super) use set_trace::SetTrace;

--- a/crates/ruff_server/src/server/api/notifications/set_trace.rs
+++ b/crates/ruff_server/src/server/api/notifications/set_trace.rs
@@ -1,0 +1,23 @@
+use crate::server::client::{Notifier, Requester};
+use crate::server::Result;
+use crate::session::Session;
+use lsp_types as types;
+use lsp_types::notification as notif;
+
+pub(crate) struct SetTrace;
+
+impl super::NotificationHandler for SetTrace {
+    type NotificationType = notif::SetTrace;
+}
+
+impl super::SyncNotificationHandler for SetTrace {
+    fn run(
+        _session: &mut Session,
+        _notifier: Notifier,
+        _requester: &mut Requester,
+        params: types::SetTraceParams,
+    ) -> Result<()> {
+        crate::trace::set_trace_value(params.value);
+        Ok(())
+    }
+}

--- a/crates/ruff_server/src/server/schedule/thread/pool.rs
+++ b/crates/ruff_server/src/server/schedule/thread/pool.rs
@@ -56,10 +56,10 @@ impl Pool {
         let extant_tasks = Arc::new(AtomicUsize::new(0));
 
         let mut handles = Vec::with_capacity(threads);
-        for _ in 0..threads {
+        for i in 0..threads {
             let handle = Builder::new(INITIAL_PRIORITY)
                 .stack_size(STACK_SIZE)
-                .name("Worker".into())
+                .name(format!("ruff:worker:{i}"))
                 .spawn({
                     let extant_tasks = Arc::clone(&extant_tasks);
                     let job_receiver: Receiver<Job> = job_receiver.clone();

--- a/crates/ruff_server/src/session/settings.rs
+++ b/crates/ruff_server/src/session/settings.rs
@@ -438,8 +438,10 @@ mod tests {
                 exclude: None,
                 line_length: None,
                 configuration_preference: None,
-                log_level: None,
-                log_file: None,
+                tracing: TracingSettings {
+                    log_level: None,
+                    log_file: None,
+                },
             },
             workspace_settings: [
                 WorkspaceSettings {
@@ -488,8 +490,10 @@ mod tests {
                         exclude: None,
                         line_length: None,
                         configuration_preference: None,
-                        log_level: None,
-                        log_file: None,
+                        tracing: TracingSettings {
+                            log_level: None,
+                            log_file: None,
+                        },
                     },
                     workspace: Url {
                         scheme: "file",
@@ -551,8 +555,10 @@ mod tests {
                         exclude: None,
                         line_length: None,
                         configuration_preference: None,
-                        log_level: None,
-                        log_file: None,
+                        tracing: TracingSettings {
+                            log_level: None,
+                            log_file: None,
+                        },
                     },
                     workspace: Url {
                         scheme: "file",
@@ -693,10 +699,12 @@ mod tests {
                     ),
                 ),
                 configuration_preference: None,
-                log_level: Some(
-                    Warn,
-                ),
-                log_file: None,
+                tracing: TracingSettings {
+                    log_level: Some(
+                        Warn,
+                    ),
+                    log_file: None,
+                },
             },
         }
         "###);

--- a/crates/ruff_server/src/session/settings.rs
+++ b/crates/ruff_server/src/session/settings.rs
@@ -70,6 +70,7 @@ pub(crate) struct ClientSettings {
     exclude: Option<Vec<String>>,
     line_length: Option<LineLength>,
     configuration_preference: Option<ConfigurationPreference>,
+    pub(crate) log_level: Option<crate::trace::LogLevel>,
 }
 
 /// This is a direct representation of the workspace settings schema,
@@ -174,6 +175,15 @@ impl AllSettings {
                     .collect()
             }),
         }
+    }
+}
+
+impl ClientSettings {
+    /// Log level is taken directly from client settings, since we need it before
+    /// we resolve workspace settings. Additionally, this setting should only be set in global settings,
+    /// and any log level set in workspace settings will be ignored.
+    pub(crate) fn log_level(&self) -> Option<crate::trace::LogLevel> {
+        self.log_level
     }
 }
 
@@ -424,6 +434,7 @@ mod tests {
                 exclude: None,
                 line_length: None,
                 configuration_preference: None,
+                log_level: None,
             },
             workspace_settings: [
                 WorkspaceSettings {
@@ -472,6 +483,7 @@ mod tests {
                         exclude: None,
                         line_length: None,
                         configuration_preference: None,
+                        log_level: None,
                     },
                     workspace: Url {
                         scheme: "file",
@@ -533,6 +545,7 @@ mod tests {
                         exclude: None,
                         line_length: None,
                         configuration_preference: None,
+                        log_level: None,
                     },
                     workspace: Url {
                         scheme: "file",
@@ -588,7 +601,7 @@ mod tests {
                     exclude: None,
                     line_length: None,
                     configuration_preference: ConfigurationPreference::default(),
-                }
+                },
             }
         );
         let path =
@@ -619,7 +632,7 @@ mod tests {
                     exclude: None,
                     line_length: None,
                     configuration_preference: ConfigurationPreference::EditorFirst,
-                }
+                },
             }
         );
     }
@@ -673,6 +686,9 @@ mod tests {
                     ),
                 ),
                 configuration_preference: None,
+                log_level: Some(
+                    Warn,
+                ),
             },
         }
         "###);
@@ -703,7 +719,7 @@ mod tests {
                     exclude: Some(vec!["third_party".into()]),
                     line_length: Some(LineLength::try_from(80).unwrap()),
                     configuration_preference: ConfigurationPreference::EditorFirst,
-                }
+                },
             }
         );
     }

--- a/crates/ruff_server/src/session/settings.rs
+++ b/crates/ruff_server/src/session/settings.rs
@@ -445,6 +445,7 @@ mod tests {
                 line_length: None,
                 configuration_preference: None,
                 log_level: None,
+                log_file: None,
             },
             workspace_settings: [
                 WorkspaceSettings {
@@ -494,6 +495,7 @@ mod tests {
                         line_length: None,
                         configuration_preference: None,
                         log_level: None,
+                        log_file: None,
                     },
                     workspace: Url {
                         scheme: "file",
@@ -556,6 +558,7 @@ mod tests {
                         line_length: None,
                         configuration_preference: None,
                         log_level: None,
+                        log_file: None,
                     },
                     workspace: Url {
                         scheme: "file",
@@ -699,6 +702,7 @@ mod tests {
                 log_level: Some(
                     Warn,
                 ),
+                log_file: None,
             },
         }
         "###);

--- a/crates/ruff_server/src/session/settings.rs
+++ b/crates/ruff_server/src/session/settings.rs
@@ -72,8 +72,18 @@ pub(crate) struct ClientSettings {
     configuration_preference: Option<ConfigurationPreference>,
     // These settings are only needed for tracing, and are only read from the global configuration.
     // These will not be in the resolved settings.
-    log_level: Option<crate::trace::LogLevel>,
-    log_file: Option<PathBuf>,
+    #[serde(flatten)]
+    pub(crate) tracing: TracingSettings,
+}
+
+/// Settings needed to initialize tracing. These will only be
+/// read from the global configuration.
+#[derive(Debug, Deserialize, Default)]
+#[cfg_attr(test, derive(PartialEq, Eq))]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct TracingSettings {
+    pub(crate) log_level: Option<crate::trace::LogLevel>,
+    pub(crate) log_file: Option<PathBuf>,
 }
 
 /// This is a direct representation of the workspace settings schema,
@@ -178,22 +188,6 @@ impl AllSettings {
                     .collect()
             }),
         }
-    }
-}
-
-impl ClientSettings {
-    /// `logLevel` is taken directly from client settings, since we need it before
-    /// we resolve workspace settings. Additionally, this setting should only be set in global settings,
-    /// and any log level set in workspace settings will be ignored.
-    pub(crate) fn log_level(&self) -> Option<crate::trace::LogLevel> {
-        self.log_level
-    }
-
-    /// `logFile` is taken directly from client settings, since we need it before
-    /// we resolve workspace settings. Additionally, this setting should only be set in global settings,
-    /// and any log level set in workspace settings will be ignored.
-    pub(crate) fn log_file(&self) -> Option<&std::path::Path> {
-        self.log_file.as_deref()
     }
 }
 

--- a/crates/ruff_server/src/session/settings.rs
+++ b/crates/ruff_server/src/session/settings.rs
@@ -70,7 +70,10 @@ pub(crate) struct ClientSettings {
     exclude: Option<Vec<String>>,
     line_length: Option<LineLength>,
     configuration_preference: Option<ConfigurationPreference>,
-    pub(crate) log_level: Option<crate::trace::LogLevel>,
+    // These settings are only needed for tracing, and are only read from the global configuration.
+    // These will not be in the resolved settings.
+    log_level: Option<crate::trace::LogLevel>,
+    log_file: Option<PathBuf>,
 }
 
 /// This is a direct representation of the workspace settings schema,
@@ -179,11 +182,18 @@ impl AllSettings {
 }
 
 impl ClientSettings {
-    /// Log level is taken directly from client settings, since we need it before
+    /// `logLevel` is taken directly from client settings, since we need it before
     /// we resolve workspace settings. Additionally, this setting should only be set in global settings,
     /// and any log level set in workspace settings will be ignored.
     pub(crate) fn log_level(&self) -> Option<crate::trace::LogLevel> {
         self.log_level
+    }
+
+    /// `logFile` is taken directly from client settings, since we need it before
+    /// we resolve workspace settings. Additionally, this setting should only be set in global settings,
+    /// and any log level set in workspace settings will be ignored.
+    pub(crate) fn log_file(&self) -> Option<&std::path::Path> {
+        self.log_file.as_deref()
     }
 }
 

--- a/crates/ruff_server/src/trace.rs
+++ b/crates/ruff_server/src/trace.rs
@@ -8,7 +8,7 @@ use crate::server::ClientSender;
 
 static LOGGING_SENDER: OnceLock<ClientSender> = OnceLock::new();
 
-static TRACE_VALUE: Mutex<lsp_types::TraceValue> = Mutex::new(lsp_types::TraceValue::Messages);
+static TRACE_VALUE: Mutex<lsp_types::TraceValue> = Mutex::new(lsp_types::TraceValue::Off);
 
 pub(crate) fn set_trace_value(trace_value: TraceValue) {
     let mut global_trace_value = TRACE_VALUE

--- a/crates/ruff_server/src/trace.rs
+++ b/crates/ruff_server/src/trace.rs
@@ -1,17 +1,17 @@
 //! The tracing system for `ruff server`.
-//! 
+//!
 //! Traces are controlled by the `logLevel` setting, along with the
 //! trace level set through the LSP. On VS Code, the trace level can
 //! also be set with `ruff.trace.server`. A trace level of `messages` or
 //! `verbose` will enable tracing - otherwise, no traces will be shown.
-//! 
+//!
 //! `logLevel` can be used to configure the level of tracing that is shown.
 //! By default, `logLevel` is set to `"info"`.
-//! 
+//!
 //! The server also supports the `RUFF_TRACE` environment variable, which will
 //! override the trace value provided by the LSP client. Use this if there's no good way
 //! to set the trace value through your editor's configuration.
-//! 
+//!
 //! Tracing will write to `stderr` by default, which should appear in the logs for most LSP clients.
 //! A `logFile` path can also be specified in the settings, and output will be directed there instead.
 use lsp_types::TraceValue;

--- a/crates/ruff_server/src/trace.rs
+++ b/crates/ruff_server/src/trace.rs
@@ -10,11 +10,6 @@ static LOGGING_SENDER: OnceLock<ClientSender> = OnceLock::new();
 
 static TRACE_VALUE: Mutex<lsp_types::TraceValue> = Mutex::new(lsp_types::TraceValue::Off);
 
-pub(crate) fn stderr_subscriber() -> impl tracing::Subscriber {
-    tracing_subscriber::registry()
-        .with(tracing_subscriber::fmt::layer().with_writer(|| Box::new(std::io::stderr())))
-}
-
 pub(crate) fn set_trace_value(trace_value: TraceValue) {
     let mut global_trace_value = TRACE_VALUE
         .lock()

--- a/crates/ruff_server/src/trace.rs
+++ b/crates/ruff_server/src/trace.rs
@@ -6,6 +6,8 @@ use tracing_subscriber::{fmt::time::Uptime, layer::SubscriberExt, Layer};
 
 use crate::server::ClientSender;
 
+const TRACE_ENV_KEY: &str = "RUFF_TRACE";
+
 static LOGGING_SENDER: OnceLock<ClientSender> = OnceLock::new();
 
 static TRACE_VALUE: Mutex<lsp_types::TraceValue> = Mutex::new(lsp_types::TraceValue::Off);
@@ -97,7 +99,7 @@ impl<S> tracing_subscriber::layer::Filter<S> for TraceLevelFilter {
 
 #[inline]
 fn trace_value() -> lsp_types::TraceValue {
-    std::env::var("RUFF_TRACE")
+    std::env::var(TRACE_ENV_KEY)
         .ok()
         .and_then(|trace| serde_json::from_value(serde_json::Value::String(trace)).ok())
         .unwrap_or_else(|| {

--- a/crates/ruff_server/src/trace.rs
+++ b/crates/ruff_server/src/trace.rs
@@ -1,6 +1,9 @@
 use lsp_types::TraceValue;
 use serde::Deserialize;
-use std::sync::{Mutex, OnceLock};
+use std::{
+    path::PathBuf,
+    sync::{Mutex, OnceLock},
+};
 use tracing::level_filters::LevelFilter;
 use tracing_subscriber::{fmt::time::Uptime, layer::SubscriberExt, Layer};
 
@@ -19,7 +22,11 @@ pub(crate) fn set_trace_value(trace_value: TraceValue) {
     *global_trace_value = trace_value;
 }
 
-pub(crate) fn init_tracing(sender: ClientSender, log_level: LogLevel) {
+pub(crate) fn init_tracing(
+    sender: ClientSender,
+    log_level: LogLevel,
+    log_file: Option<&std::path::Path>,
+) {
     LOGGING_SENDER
         .set(sender)
         .expect("logging sender should only be initialized once");
@@ -29,7 +36,7 @@ pub(crate) fn init_tracing(sender: ClientSender, log_level: LogLevel) {
             .with_timer(Uptime::default())
             .with_thread_names(true)
             .with_ansi(false)
-            .with_writer(|| Box::new(std::io::stderr()))
+            .with_writer(TracingWriter::new(log_file))
             .with_filter(TraceLevelFilter)
             .with_filter(LogLevelFilter { filter: log_level }),
     );
@@ -94,6 +101,32 @@ impl<S> tracing_subscriber::layer::Filter<S> for TraceLevelFilter {
         _: &tracing_subscriber::layer::Context<'_, S>,
     ) -> bool {
         trace_value() != lsp_types::TraceValue::Off
+    }
+}
+
+struct TracingWriter(Option<PathBuf>);
+
+impl TracingWriter {
+    fn new(file: Option<&std::path::Path>) -> TracingWriter {
+        Self(file.map(std::path::Path::to_path_buf))
+    }
+}
+
+impl tracing_subscriber::fmt::MakeWriter<'_> for TracingWriter {
+    type Writer = Box<dyn std::io::Write>;
+
+    fn make_writer(&self) -> Self::Writer {
+        if let Some(file) = self.0.as_ref().and_then(|path| {
+            std::fs::OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(path)
+                .ok()
+        }) {
+            Box::new(file)
+        } else {
+            Box::new(std::io::stderr())
+        }
     }
 }
 

--- a/crates/ruff_server/src/trace.rs
+++ b/crates/ruff_server/src/trace.rs
@@ -17,16 +17,13 @@ pub(crate) fn set_trace_value(trace_value: TraceValue) {
     *global_trace_value = trace_value;
 }
 
-pub(crate) fn init_tracing(sender: ClientSender) {
+pub(crate) fn init_tracing(sender: ClientSender, log_level: LogLevel) {
     LOGGING_SENDER
         .set(sender)
         .expect("logging sender should only be initialized once");
 
-    // TODO(jane): Provide a way to set the log level
-    let subscriber =
-        tracing_subscriber::Registry::default().with(LogLayer.with_filter(LogFilter {
-            filter: LogLevel::Info,
-        }));
+    let subscriber = tracing_subscriber::Registry::default()
+        .with(LogLayer.with_filter(LogFilter { filter: log_level }));
 
     tracing::subscriber::set_global_default(subscriber)
         .expect("should be able to set global default subscriber");

--- a/crates/ruff_server/src/trace.rs
+++ b/crates/ruff_server/src/trace.rs
@@ -10,6 +10,11 @@ static LOGGING_SENDER: OnceLock<ClientSender> = OnceLock::new();
 
 static TRACE_VALUE: Mutex<lsp_types::TraceValue> = Mutex::new(lsp_types::TraceValue::Off);
 
+pub(crate) fn stderr_subscriber() -> impl tracing::Subscriber {
+    tracing_subscriber::registry()
+        .with(tracing_subscriber::fmt::layer().with_writer(|| Box::new(std::io::stderr())))
+}
+
 pub(crate) fn set_trace_value(trace_value: TraceValue) {
     let mut global_trace_value = TRACE_VALUE
         .lock()

--- a/crates/ruff_server/src/trace.rs
+++ b/crates/ruff_server/src/trace.rs
@@ -84,10 +84,12 @@ impl LogLevel {
     }
 }
 
+/// Filters out traces which have a log level lower than the `logLevel` set by the client.
 struct LogLevelFilter {
     filter: LogLevel,
 }
 
+/// Filters out traces if the trace value set by the client is `off`.
 struct TraceLevelFilter;
 
 impl<S> tracing_subscriber::layer::Filter<S> for LogLevelFilter {

--- a/crates/ruff_server/src/trace.rs
+++ b/crates/ruff_server/src/trace.rs
@@ -1,0 +1,127 @@
+use lsp_types::notification::Notification;
+use serde::Deserialize;
+use std::sync::OnceLock;
+use tracing::{level_filters::LevelFilter, Event};
+use tracing_subscriber::layer::SubscriberExt;
+
+use crate::server::ClientSender;
+
+static LOGGING_SENDER: OnceLock<ClientSender> = OnceLock::new();
+
+pub(crate) fn init_tracing(
+    sender: ClientSender,
+    filter: LogLevel,
+) -> tracing::subscriber::DefaultGuard {
+    LOGGING_SENDER
+        .set(sender)
+        .expect("logging sender should only be initialized once");
+
+    let subscriber = tracing_subscriber::Registry::default().with(LogLayer { filter });
+
+    tracing::subscriber::set_default(subscriber)
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Default, PartialEq, Eq, PartialOrd, Ord)]
+#[serde(rename_all = "lowercase")]
+pub(crate) enum LogLevel {
+    #[default]
+    Error,
+    Warn,
+    Info,
+    Debug,
+}
+
+impl LogLevel {
+    fn from_trace_level(level: tracing::Level) -> Self {
+        match level {
+            tracing::Level::ERROR => Self::Error,
+            tracing::Level::WARN => Self::Warn,
+            tracing::Level::INFO => Self::Info,
+            _ => Self::Debug,
+        }
+    }
+
+    fn message_type(self) -> lsp_types::MessageType {
+        match self {
+            Self::Error => lsp_types::MessageType::ERROR,
+            Self::Warn => lsp_types::MessageType::WARNING,
+            Self::Info => lsp_types::MessageType::INFO,
+            // TODO(jane): LSP `0.3.18` will introduce `MessageType::DEBUG`,
+            // and we should consider using that.
+            Self::Debug => lsp_types::MessageType::LOG,
+        }
+    }
+
+    fn trace_level(self) -> tracing::Level {
+        match self {
+            Self::Error => tracing::Level::ERROR,
+            Self::Warn => tracing::Level::WARN,
+            Self::Info => tracing::Level::INFO,
+            Self::Debug => tracing::Level::DEBUG,
+        }
+    }
+}
+
+struct LogLayer {
+    filter: LogLevel,
+}
+
+impl tracing_subscriber::Layer<tracing_subscriber::Registry> for LogLayer {
+    fn register_callsite(
+        &self,
+        metadata: &'static tracing::Metadata<'static>,
+    ) -> tracing::subscriber::Interest {
+        if metadata.is_event()
+            && metadata
+                .fields()
+                .iter()
+                .any(|field| field.name() == "message")
+        {
+            tracing::subscriber::Interest::always()
+        } else {
+            tracing::subscriber::Interest::never()
+        }
+    }
+
+    fn max_level_hint(&self) -> Option<tracing::level_filters::LevelFilter> {
+        Some(LevelFilter::from_level(self.filter.trace_level()))
+    }
+
+    fn on_event(
+        &self,
+        event: &Event<'_>,
+        _ctx: tracing_subscriber::layer::Context<'_, tracing_subscriber::Registry>,
+    ) {
+        let mut message_visitor =
+            LogMessageVisitor(LogLevel::from_trace_level(*event.metadata().level()));
+        event.record(&mut message_visitor);
+    }
+}
+
+#[derive(Default)]
+struct LogMessageVisitor(LogLevel);
+
+impl tracing::field::Visit for LogMessageVisitor {
+    fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+        if field.name() == "message" {
+            log(format!("{value:?}"), self.0);
+        }
+    }
+}
+
+#[inline]
+fn log(message: String, level: LogLevel) {
+    let _ = LOGGING_SENDER
+        .get()
+        .expect("logging channel should be initialized")
+        .send(lsp_server::Message::Notification(
+            lsp_server::Notification {
+                method: lsp_types::notification::LogMessage::METHOD.into(),
+                params: serde_json::to_value(lsp_types::LogMessageParams {
+                    typ: level.message_type(),
+                    message,
+                })
+                .expect("log notification should serialize"),
+            },
+        ));
+}

--- a/crates/ruff_server/src/trace.rs
+++ b/crates/ruff_server/src/trace.rs
@@ -1,3 +1,19 @@
+//! The tracing system for `ruff server`.
+//! 
+//! Traces are controlled by the `logLevel` setting, along with the
+//! trace level set through the LSP. On VS Code, the trace level can
+//! also be set with `ruff.trace.server`. A trace level of `messages` or
+//! `verbose` will enable tracing - otherwise, no traces will be shown.
+//! 
+//! `logLevel` can be used to configure the level of tracing that is shown.
+//! By default, `logLevel` is set to `"info"`.
+//! 
+//! The server also supports the `RUFF_TRACE` environment variable, which will
+//! override the trace value provided by the LSP client. Use this if there's no good way
+//! to set the trace value through your editor's configuration.
+//! 
+//! Tracing will write to `stderr` by default, which should appear in the logs for most LSP clients.
+//! A `logFile` path can also be specified in the settings, and output will be directed there instead.
 use lsp_types::TraceValue;
 use serde::Deserialize;
 use std::{


### PR DESCRIPTION
## Summary

Fixes #10968.
Fixes #11545.

The server's tracing system has been rewritten from the ground up. The server now has trace level and log level settings which restrict the tracing events and spans that get logged. 

* A `logLevel` setting has been added, which lets a user set the log level. By default, it is set to `"info"`.
* A `logFile` setting has also been added, which lets the user supply an optional file to send tracing output (it does not have to exist as a file yet). By default, if this is unset, tracing output will be sent to `stderr`.
* A `$/setTrace` handler has also been added, and we also set the trace level from the initialization options. For editors without direct support for tracing, the environment variable `RUFF_TRACE` can override the trace level.
* Small changes have been made to how we display tracing output. We no longer use `tracing-tree`, and instead use `tracing_subscriber::fmt::Layer` to format output. Thread names are now included in traces, and I've made some adjustment to thread worker names to be more useful.

## Test Plan

In VS Code, with `ruff.trace.server` set to its default value, no logs from Ruff should appear.

After changing `ruff.trace.server` to either `messages` or `verbose`, you should see log messages at `info` level or higher appear in Ruff's output:
<img width="1005" alt="Screenshot 2024-06-10 at 10 35 04 AM" src="https://github.com/astral-sh/ruff/assets/19577865/6050d107-9815-4bd2-96d0-e86f096a57f5">

In Helix, by default, no logs from Ruff should appear.

To set the trace level in Helix, you'll need to modify your language configuration as follows:
```toml
[language-server.ruff]
command = "/Users/jane/astral/ruff/target/debug/ruff"
args = ["server", "--preview"]
environment = { "RUFF_TRACE" = "messages" }
```

After doing this, logs of `info` level or higher should be visible in Helix:
<img width="1216" alt="Screenshot 2024-06-10 at 10 39 26 AM" src="https://github.com/astral-sh/ruff/assets/19577865/8ff88692-d3f7-4fd1-941e-86fb338fcdcc">

You can use `:log-open` to quickly open the Helix log file.

In Neovim, by default, no logs from Ruff should appear.

To set the trace level in Neovim, you'll need to modify your configuration as follows:
```lua
require('lspconfig').ruff.setup {
  cmd = {"/path/to/debug/executable", "server", "--preview"},
  cmd_env = { RUFF_TRACE = "messages" }
}
```

You should see logs appear in `:LspLog` that look like the following:
<img width="1490" alt="Screenshot 2024-06-11 at 11 24 01 AM" src="https://github.com/astral-sh/ruff/assets/19577865/576cd5fa-03cf-477a-b879-b29a9a1200ff">

You can adjust `logLevel` and `logFile` in `settings`:
```lua
require('lspconfig').ruff.setup {
  cmd = {"/path/to/debug/executable", "server", "--preview"},
  cmd_env = { RUFF_TRACE = "messages" },
  settings = {
    logLevel = "debug",
    logFile = "your/log/file/path/log.txt"
  }
}
```

The `logLevel` and `logFile` can also be set in Helix like so:
```toml
[language-server.ruff.config.settings]
logLevel = "debug"
logFile = "your/log/file/path/log.txt"
```

Even if this log file does not exist, it should now be created and written to after running the server:

<img width="1148" alt="Screenshot 2024-06-10 at 10 43 44 AM" src="https://github.com/astral-sh/ruff/assets/19577865/ab533cf7-d5ac-4178-97f1-e56da17450dd">
