### PR TITLE
Fix formatter instability for lines only consisting of zero-width characters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2215,7 +2215,6 @@ dependencies = [
  "static_assertions",
  "thiserror",
  "tracing",
- "unicode-width",
 ]
 
 [[package]]

--- a/crates/ruff_python_formatter/Cargo.toml
+++ b/crates/ruff_python_formatter/Cargo.toml
@@ -37,7 +37,6 @@ smallvec = { workspace = true }
 static_assertions = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
-unicode-width = { workspace = true }
 
 [dev-dependencies]
 ruff_formatter = { workspace = true }

--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/docstring_non_visible_characters.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/docstring_non_visible_characters.py
@@ -1,0 +1,6 @@
+# Regresssion test for https://github.com/astral-sh/ruff/issues/11724
+
+'''
+
+
+'''

--- a/crates/ruff_python_formatter/src/verbatim.rs
+++ b/crates/ruff_python_formatter/src/verbatim.rs
@@ -2,8 +2,6 @@ use std::borrow::Cow;
 use std::iter::FusedIterator;
 use std::slice::Iter;
 
-use unicode_width::UnicodeWidthStr;
-
 use ruff_formatter::{write, FormatError};
 use ruff_python_ast::AnyNodeRef;
 use ruff_python_ast::Stmt;
@@ -760,17 +758,7 @@ impl Format<PyFormatContext<'_>> for FormatVerbatimStatementRange {
 
                 // Write the line separator that terminates the line, except if it is the last line (that isn't separated by a hard line break).
                 if logical_line.has_trailing_newline {
-                    // Insert an empty line if the text is non-empty but all characters have a width of zero.
-                    // This is necessary to work around the fact that the Printer omits hard line breaks if the line width is 0.
-                    // The alternative is to "fix" the printer and explicitly track the width and whether the line is empty.
-                    // There's currently no use case for zero-width content outside of the verbatim context (and, form feeds are a Python specific speciality).
-                    // It, therefore, feels wrong to add additional complexity to the very hot `Printer::print_char` function,
-                    // to work around this special case. Therefore, work around the Printer behavior here, in the cold verbatim-formatting.
-                    if f.context().source()[trimmed_line_range].width() == 0 {
-                        empty_line().fmt(f)?;
-                    } else {
-                        hard_line_break().fmt(f)?;
-                    }
+                    hard_line_break().fmt(f)?;
                 }
             }
 

--- a/crates/ruff_python_formatter/tests/snapshots/format@docstring_non_visible_characters.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@docstring_non_visible_characters.py.snap
@@ -1,0 +1,23 @@
+---
+source: crates/ruff_python_formatter/tests/fixtures.rs
+input_file: crates/ruff_python_formatter/resources/test/fixtures/ruff/docstring_non_visible_characters.py
+---
+## Input
+```python
+# Regresssion test for https://github.com/astral-sh/ruff/issues/11724
+
+'''
+
+
+'''
+```
+
+## Output
+```python
+# Regresssion test for https://github.com/astral-sh/ruff/issues/11724
+
+"""
+
+
+"""
+```


### PR DESCRIPTION
## Summary

Fixes https://github.com/astral-sh/ruff/issues/11724#issuecomment-2148183543

Code from the linked issue that produces instable formatting:

```python

'''


'''
```

This turned out to be something entirely different than I expected. 
I initially thought that it was an issue with the docstring rendering, which uses `trim` instead of `PythonWhitespace::trim`. 
But I learned the better when I compared the generated IR for the above snippet and the same snippet but with `\u{15}` (the non visible character in the snippet above) with `a`. 
Both snippets generate the same IR! That means this is a bug in the `Printer` and not in the Python formatter. 

It turns out that the fix is relatively simple. 

The `Printer` omits `hard_line_break` IR elements or only renders a single `\n` for a `empty_line` IR elements when the 
current line is all empty. The problem is that the `Printer` uses the line width to determine if the line is empty. 
However, using the line width here isn't correct because a line can be non-empty but has a zero width if it only consists of zero-width characters, which is exactly what we have in the reported instability. 

I considered removing this behavior but we rely heavily on it in `suite.rs` and I'm not going to touch this to fix this bug! 
So what I did instead is to change the `Printer` to keep track of the start of the current line and test if the current formatted line is empty. 

I don't suspect that this changes performance much because it only adds a single write after a newline character. Testing whether the line gets a bit more expensive
because it now needs to dereference into the buffer, but I think in total, this is just noise.

And I was wrong lol. THis has a huge perf impact. Let's see if I can do better


## Backwards compatibility

It's hard to be a 100% sure, but I'm confident that it doesn't have widespread impact because zero-width characters are rare, even more so zero-width lines only consisting of zero-width characters. 

The only zero-width character that Python allows outside strings and comments is the form-feed character. Ruff does not preserve line-feed characters except in suppressed ranges. The existing implementation used a work-around to avoid this very specific printer behavior. This PR allows to remove the work around and the tests keep passing.


For strings, we write the entire string content as a single text, preserving line breaks as is.

For comments: That's the issue discovered here. Existing code would already have the trailing line stripped and reformatting the same code wouldn't insert the trailing line after the zero-width characters line. 

So we should be good 

## Test Plan

Added test. All existing tests keep passing. 


## Thanks

Thanks to @jasikpark for finding the instability and helping me to reproduce the issue. 
