### PR TITLE
red-knot: Higher level, location independent AST

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -356,7 +356,7 @@ version = "4.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "528131438037fd55894f62d6e9f068b8f45ac57ffa77517819645d10aed04f64"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.66",
@@ -897,6 +897,12 @@ checksum = "e8094feaf31ff591f651a2664fb9cfd92bba7a60ce3197265e9482ebe753c8f7"
 dependencies = [
  "hashbrown 0.14.5",
 ]
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "heck"
@@ -2815,7 +2821,7 @@ version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7993a8e3a9e88a00351486baae9522c91b123a088f76469e5bd5cc17198ea87"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "rustversion",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1829,7 +1829,6 @@ dependencies = [
  "smol_str",
  "tempfile",
  "tracing",
- "tracing-log",
  "tracing-subscriber",
  "tracing-tree",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -463,6 +463,11 @@ name = "countme"
 version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7704b5fdd17b18ae31c4c1da5a2e0305a2bf17b5249300a9ee9ed7b72114c636"
+dependencies = [
+ "dashmap",
+ "once_cell",
+ "rustc-hash",
+]
 
 [[package]]
 name = "crc32fast"
@@ -1804,9 +1809,11 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bitflags 2.5.0",
+ "countme",
  "crossbeam",
  "ctrlc",
  "dashmap",
+ "filetime",
  "hashbrown 0.14.5",
  "indexmap",
  "notify",
@@ -1822,6 +1829,7 @@ dependencies = [
  "smol_str",
  "tempfile",
  "tracing",
+ "tracing-log",
  "tracing-subscriber",
  "tracing-tree",
 ]
@@ -2532,7 +2540,7 @@ checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
 [[package]]
 name = "salsa-2022"
 version = "0.1.0"
-source = "git+https://github.com/salsa-rs/salsa.git?rev=f5aec4abefb4c5e67cba6d8ea91c216bc2838f10#f5aec4abefb4c5e67cba6d8ea91c216bc2838f10"
+source = "git+https://github.com/salsa-rs/salsa.git?rev=05b4e3ebdcdc47730cdd359e7e97fb2470527279#05b4e3ebdcdc47730cdd359e7e97fb2470527279"
 dependencies = [
  "arc-swap",
  "crossbeam",
@@ -2550,7 +2558,7 @@ dependencies = [
 [[package]]
 name = "salsa-2022-macros"
 version = "0.1.0"
-source = "git+https://github.com/salsa-rs/salsa.git?rev=f5aec4abefb4c5e67cba6d8ea91c216bc2838f10#f5aec4abefb4c5e67cba6d8ea91c216bc2838f10"
+source = "git+https://github.com/salsa-rs/salsa.git?rev=05b4e3ebdcdc47730cdd359e7e97fb2470527279#05b4e3ebdcdc47730cdd359e7e97fb2470527279"
 dependencies = [
  "eyre",
  "heck 0.4.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,6 +134,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
 
 [[package]]
+name = "arc-swap"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
+
+[[package]]
 name = "argfile"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -353,7 +359,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -594,7 +600,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.10.0",
- "syn",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -605,7 +611,7 @@ checksum = "a668eda54683121533a393014d8692171709ff57a7d61f187b6e782719f8933f"
 dependencies = [
  "darling_core",
  "quote",
- "syn",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -729,6 +735,16 @@ checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "eyre"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd915d99f24784cdc19fd37ef22b97e3ff0ae756c7e492e9fbfe897d61e2aec"
+dependencies = [
+ "indenter",
+ "once_cell",
 ]
 
 [[package]]
@@ -869,6 +885,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashlink"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8094feaf31ff591f651a2664fb9cfd92bba7a60ce3197265e9482ebe753c8f7"
+dependencies = [
+ "hashbrown 0.14.5",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -969,6 +994,12 @@ dependencies = [
  "phf",
  "rust-stemmers",
 ]
+
+[[package]]
+name = "indenter"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
 name = "indexmap"
@@ -1075,7 +1106,7 @@ dependencies = [
  "Inflector",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -1192,7 +1223,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2ae40017ac09cd2c6a53504cb3c871c7f2b41466eac5bc66ba63f39073b467b"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -1637,7 +1668,7 @@ checksum = "52a40bc70c2c58040d2d8b167ba9a5ff59fc9dab7ad44771cfde3dcfde7a09c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -1787,6 +1818,7 @@ dependencies = [
  "ruff_python_parser",
  "ruff_text_size",
  "rustc-hash",
+ "salsa-2022",
  "smol_str",
  "tempfile",
  "tracing",
@@ -1876,7 +1908,7 @@ dependencies = [
  "pmutil",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -2125,7 +2157,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "ruff_python_trivia",
- "syn",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -2498,6 +2530,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
 
 [[package]]
+name = "salsa-2022"
+version = "0.1.0"
+source = "git+https://github.com/salsa-rs/salsa.git?rev=f5aec4abefb4c5e67cba6d8ea91c216bc2838f10#f5aec4abefb4c5e67cba6d8ea91c216bc2838f10"
+dependencies = [
+ "arc-swap",
+ "crossbeam",
+ "crossbeam-utils",
+ "dashmap",
+ "hashlink",
+ "indexmap",
+ "log",
+ "parking_lot",
+ "rustc-hash",
+ "salsa-2022-macros",
+ "smallvec",
+]
+
+[[package]]
+name = "salsa-2022-macros"
+version = "0.1.0"
+source = "git+https://github.com/salsa-rs/salsa.git?rev=f5aec4abefb4c5e67cba6d8ea91c216bc2838f10#f5aec4abefb4c5e67cba6d8ea91c216bc2838f10"
+dependencies = [
+ "eyre",
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2527,7 +2589,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -2576,7 +2638,7 @@ checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -2587,7 +2649,7 @@ checksum = "330f01ce65a3a5fe59a60c82f3c9a024b573b8a6e875bd233fe5f934e71d54e3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -2609,7 +2671,7 @@ checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -2650,7 +2712,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -2750,7 +2812,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -2758,6 +2820,17 @@ name = "subtle"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "syn"
@@ -2823,7 +2896,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -2834,7 +2907,7 @@ checksum = "5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.66",
  "test-case-core",
 ]
 
@@ -2855,7 +2928,7 @@ checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -2967,7 +3040,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -3197,7 +3270,7 @@ checksum = "9881bea7cbe687e36c9ab3b778c36cd0487402e270304e8b1296d5085303c1a2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -3282,7 +3355,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.66",
  "wasm-bindgen-shared",
 ]
 
@@ -3316,7 +3389,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.66",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3349,7 +3422,7 @@ checksum = "b7f89739351a2e03cb94beb799d47fb2cac01759b40ec441f7de39b00cbf7ef0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -3618,7 +3691,7 @@ checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.66",
 ]
 
 [[package]]

--- a/crates/red_knot/Cargo.toml
+++ b/crates/red_knot/Cargo.toml
@@ -34,7 +34,6 @@ rustc-hash = { workspace = true }
 salsa = { git = "https://github.com/salsa-rs/salsa.git", package = "salsa-2022", rev = "05b4e3ebdcdc47730cdd359e7e97fb2470527279" }
 smol_str = { version = "0.2.1" }
 tracing = { workspace = true }
-tracing-log = { version = "0.2.0" }
 tracing-subscriber = { workspace = true }
 tracing-tree = { workspace = true }
 

--- a/crates/red_knot/Cargo.toml
+++ b/crates/red_knot/Cargo.toml
@@ -29,6 +29,7 @@ notify = { workspace = true }
 parking_lot = { workspace = true }
 rayon = { workspace = true }
 rustc-hash = { workspace = true }
+salsa = { git = "https://github.com/salsa-rs/salsa.git", package = "salsa-2022", rev = "f5aec4abefb4c5e67cba6d8ea91c216bc2838f10" }
 smol_str = { version = "0.2.1" }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/crates/red_knot/Cargo.toml
+++ b/crates/red_knot/Cargo.toml
@@ -20,23 +20,27 @@ ruff_notebook = { workspace = true }
 
 anyhow = { workspace = true }
 bitflags = { workspace = true }
+countme = { workspace = true, features = ["enable"] }
 crossbeam = { workspace = true }
 ctrlc = { version = "3.4.4" }
 dashmap = { workspace = true }
+filetime = { workspace = true }
 hashbrown = { workspace = true }
 indexmap = { workspace = true }
 notify = { workspace = true }
 parking_lot = { workspace = true }
 rayon = { workspace = true }
 rustc-hash = { workspace = true }
-salsa = { git = "https://github.com/salsa-rs/salsa.git", package = "salsa-2022", rev = "f5aec4abefb4c5e67cba6d8ea91c216bc2838f10" }
+salsa = { git = "https://github.com/salsa-rs/salsa.git", package = "salsa-2022", rev = "05b4e3ebdcdc47730cdd359e7e97fb2470527279" }
 smol_str = { version = "0.2.1" }
 tracing = { workspace = true }
+tracing-log = { version = "0.2.0" }
 tracing-subscriber = { workspace = true }
 tracing-tree = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }
+
 
 [lints]
 workspace = true

--- a/crates/red_knot/src/ast_ids.rs
+++ b/crates/red_knot/src/ast_ids.rs
@@ -266,7 +266,7 @@ enum DeferredNode<'a> {
     ClassDefinition(&'a StmtClassDef),
 }
 
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+#[derive(Copy, Clone, Debug, Hash)]
 pub struct TypedNodeKey<N: AstNode> {
     /// The type erased node key.
     inner: NodeKey,
@@ -303,6 +303,14 @@ impl<N: AstNode> TypedNodeKey<N> {
         &self.inner
     }
 }
+
+impl<N: AstNode> PartialEq<Self> for TypedNodeKey<N> {
+    fn eq(&self, other: &Self) -> bool {
+        self.inner == other.inner
+    }
+}
+
+impl<N: AstNode> Eq for TypedNodeKey<N> {}
 
 struct FindNodeKeyVisitor<'a> {
     key: NodeKey,

--- a/crates/red_knot/src/lib.rs
+++ b/crates/red_knot/src/lib.rs
@@ -17,6 +17,7 @@ pub mod lint;
 pub mod module;
 mod parse;
 pub mod program;
+mod salsa_db;
 pub mod source;
 mod symbols;
 mod types;

--- a/crates/red_knot/src/module.rs
+++ b/crates/red_knot/src/module.rs
@@ -115,7 +115,8 @@ impl ModuleName {
         Self(smol_str::SmolStr::new(name))
     }
 
-    fn from_relative_path(path: &Path) -> Option<Self> {
+    // TODO(Micha): Make private again when the Salsa db module resolution logic lives next to this module again.
+    pub(crate) fn from_relative_path(path: &Path) -> Option<Self> {
         let path = if path.ends_with("__init__.py") || path.ends_with("__init__.pyi") {
             path.parent()?
         } else {

--- a/crates/red_knot/src/module.rs
+++ b/crates/red_knot/src/module.rs
@@ -660,13 +660,13 @@ where
 }
 
 #[derive(Debug)]
-struct ResolvedPackage {
-    path: PathBuf,
-    kind: PackageKind,
+pub struct ResolvedPackage {
+    pub path: PathBuf,
+    pub kind: PackageKind,
 }
 
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]
-enum PackageKind {
+pub enum PackageKind {
     /// A root package or module. E.g. `foo` in `foo.bar.baz` or just `foo`.
     Root,
 
@@ -682,7 +682,7 @@ enum PackageKind {
 }
 
 impl PackageKind {
-    const fn is_regular_package(self) -> bool {
+    pub const fn is_regular_package(self) -> bool {
         matches!(self, PackageKind::Regular)
     }
 }

--- a/crates/red_knot/src/salsa_db.rs
+++ b/crates/red_knot/src/salsa_db.rs
@@ -1,46 +1,211 @@
 #![allow(unreachable_pub)]
+#![allow(unused)]
 
+use std::fmt::Formatter;
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use parking_lot::lock_api::RwLockUpgradableReadGuard;
-use parking_lot::RwLock;
+use countme::Count;
+use dashmap::mapref::entry::Entry;
+use filetime::FileTime;
 use rustc_hash::FxHashMap;
-use salsa::Event;
-use tracing::warn;
+use salsa::database::AsSalsaDatabase;
+use salsa::{DebugWithDb, Event};
+use tracing::{debug, debug_span, warn, Level};
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::{Layer, Registry};
+use tracing_tree::time::Uptime;
 
 use ruff_python_ast::visitor::preorder::{PreorderVisitor, TraversalSignal};
-use ruff_python_ast::visitor::{preorder, Visitor};
+use ruff_python_ast::visitor::{preorder, walk_stmt, Visitor};
 use ruff_python_ast::{AnyNodeRef, Expr, Mod, ModModule, Stmt, StmtExpr};
 use ruff_python_parser::Mode;
 use ruff_text_size::{Ranged, TextRange};
 
 use crate::ast_ids::AstIds;
 use crate::files::{FileId, Files};
-use crate::module::ModuleName;
+use crate::module::{ModuleKind, ModuleSearchPath};
+use crate::salsa_db::source::{File, SourceText};
+use crate::FxDashMap;
 
-// TODO salsa recommends to have one jar per crate and call it `Jar`. We're not doing this here
-// because I don't want that many crates just yet.
-#[salsa::input(jar=SourceJar)]
-pub struct SourceText {
-    file: FileId,
+use self::source::{Db as SourceDb, Jar as SourceJar};
 
-    #[return_ref]
-    text: String,
-}
+pub mod source {
+    use std::path::PathBuf;
+    use std::sync::Arc;
 
-#[salsa::tracked(jar=SourceJar)]
-pub struct Parsed {
-    // TODO should this be an arc to avoid some lifetime awkwardness for call-sites.
-    #[return_ref]
-    pub ast: ModModule,
+    use countme::Count;
+    use dashmap::mapref::entry::Entry;
+    use filetime::FileTime;
 
-    #[return_ref]
-    pub imports: Vec<String>,
+    use ruff_python_ast::{Mod, ModModule, Stmt, StmtExpr};
+    use ruff_python_parser::Mode;
+    use ruff_text_size::{Ranged, TextRange};
 
-    // TODO use an accumulator for this?
-    #[return_ref]
-    pub errors: Vec<ruff_python_parser::ParseError>,
+    use crate::FxDashMap;
+
+    #[salsa::input(jar=Jar)]
+    pub struct File {
+        #[return_ref]
+        pub path: PathBuf,
+
+        pub permissions: u32,
+        pub last_modified_time: FileTime,
+        _count: Count<File>,
+    }
+
+    impl File {
+        #[tracing::instrument(level = "debug", skip(db))]
+        pub fn touch(&self, db: &mut dyn Db) {
+            let path = self.path(db);
+            let metadata = path.metadata().unwrap();
+            let last_modified = filetime::FileTime::from_last_modification_time(&metadata);
+
+            self.set_last_modified_time(db).to(last_modified);
+        }
+    }
+
+    #[salsa::tracked(jar=Jar)]
+    impl File {
+        #[salsa::tracked]
+        pub fn source(self, db: &dyn Db) -> SourceText {
+            let _ = self.last_modified_time(db); // Read the last modified date to trigger a re-run when the file changes.
+            let text = std::fs::read_to_string(self.path(db)).unwrap_or_default();
+
+            SourceText {
+                text: Arc::new(text),
+                count: Count::default(),
+            }
+        }
+    }
+
+    #[derive(Debug, Clone, Default)]
+    pub struct Files {
+        inner: Arc<FilesInner>,
+    }
+
+    impl Files {
+        pub(super) fn resolve(&self, db: &dyn Db, path: PathBuf) -> File {
+            match self.inner.by_path.entry(path.clone()) {
+                Entry::Occupied(entry) => {
+                    let file = entry.get();
+                    *file
+                }
+                Entry::Vacant(entry) => {
+                    let metadata = path.metadata();
+                    let (last_modified, permissions) = if let Ok(metadata) = metadata {
+                        let last_modified =
+                            filetime::FileTime::from_last_modification_time(&metadata);
+                        #[cfg(unix)]
+                        let permissions = if cfg!(unix) {
+                            use std::os::unix::fs::PermissionsExt;
+                            metadata.permissions().mode()
+                        } else {
+                            0
+                        };
+
+                        (last_modified, permissions)
+                    } else {
+                        (FileTime::zero(), 0)
+                    };
+
+                    // TODO: How to set the durability?
+
+                    let file = File::new(db, path, permissions, last_modified, Count::default());
+                    entry.insert(file);
+
+                    file
+                }
+            }
+        }
+    }
+
+    #[derive(Debug, Default)]
+    struct FilesInner {
+        by_path: FxDashMap<PathBuf, File>,
+    }
+
+    // TODO salsa recommends to have one jar per crate and call it `Jar`. We're not doing this here
+    // because I don't want that many crates just yet.
+    #[derive(Debug, Clone, Eq, PartialEq)]
+    pub struct SourceText {
+        pub text: Arc<String>,
+        count: Count<SourceText>,
+    }
+
+    impl SourceText {
+        pub fn text(&self) -> &str {
+            self.text.as_str()
+        }
+    }
+
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct Parsed {
+        inner: Arc<ParsedInner>,
+    }
+
+    impl Parsed {
+        pub fn ast(&self) -> &ModModule {
+            &self.inner.ast
+        }
+
+        pub fn errors(&self) -> &[ruff_python_parser::ParseError] {
+            &self.inner.errors
+        }
+    }
+
+    #[derive(Debug, PartialEq)]
+    struct ParsedInner {
+        // TODO should this be an arc to avoid some lifetime awkwardness for call-sites.
+        pub ast: ModModule,
+
+        // TODO use an accumulator for this?
+        pub errors: Vec<ruff_python_parser::ParseError>,
+    }
+
+    #[tracing::instrument(level = "debug", skip(db))]
+    #[salsa::tracked(jar=Jar, no_eq)]
+    pub fn parse(db: &dyn Db, file: File) -> Parsed {
+        let source = file.source(db);
+        let text = source.text();
+
+        let result = ruff_python_parser::parse(text, Mode::Module);
+
+        let (module, errors) = match result {
+            Ok(Mod::Module(module)) => (module, vec![]),
+            Ok(Mod::Expression(expression)) => (
+                ModModule {
+                    range: expression.range(),
+                    body: vec![Stmt::Expr(StmtExpr {
+                        range: expression.range(),
+                        value: expression.body,
+                    })],
+                },
+                vec![],
+            ),
+            Err(errors) => (
+                ModModule {
+                    range: TextRange::default(),
+                    body: Vec::new(),
+                },
+                vec![errors],
+            ),
+        };
+
+        Parsed {
+            inner: Arc::new(ParsedInner {
+                ast: module,
+                errors,
+            }),
+        }
+    }
+
+    #[salsa::jar(db=Db)]
+    pub struct Jar(File, File_source, parse);
+
+    pub trait Db: salsa::DbWithJar<Jar> {
+        fn file(&self, path: PathBuf) -> File;
+    }
 }
 
 #[salsa::tracked(jar=SemanticJar)]
@@ -55,28 +220,90 @@ pub struct PhysicalLinesCheck {
     pub diagnostics: Vec<String>,
 }
 
-#[salsa::jar(db=SourceDb)]
-pub struct SourceJar(SourceText, Parsed, parse);
+#[salsa::input(jar=SemanticJar, singleton)]
+pub struct ModuleSearchPaths {
+    #[return_ref]
+    paths: Vec<ModuleSearchPath>,
+}
+
+#[salsa::interned(jar=SemanticJar)]
+pub struct ModuleName {
+    name: smol_str::SmolStr,
+}
+
+impl ModuleName {
+    pub fn components(&self, db: &dyn SemanticDb) -> Vec<String> {
+        let name = self.name(db);
+        name.split(".").map(String::from).collect()
+    }
+}
+
+// TODO should this be tracked or not?
+// I think yes, so that we can reference to it using ids.
+#[salsa::tracked(jar=SemanticJar)]
+pub struct Module {
+    name: ModuleName,
+    file: File,
+}
+
+#[salsa::tracked(jar=SemanticJar)]
+pub struct Symbol {
+    #[id]
+    #[returned_ref]
+    pub name: smol_str::SmolStr,
+
+    count: Count<Symbol>,
+}
+
+#[derive(Eq, PartialEq, Default)]
+pub struct SymbolTable {
+    symbols: FxHashMap<smol_str::SmolStr, Symbol>,
+}
+
+impl SymbolTable {
+    fn insert(&mut self, name: smol_str::SmolStr, symbol: Symbol) {
+        self.symbols.insert(name, symbol);
+    }
+}
+
+impl std::fmt::Debug for SymbolTable {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        self.symbols.fmt(f)
+    }
+}
+
+impl<Db> DebugWithDb<Db> for SymbolTable
+where
+    Db: AsSalsaDatabase + SemanticDb,
+{
+    fn fmt(&self, f: &mut Formatter<'_>, db: &Db) -> std::fmt::Result {
+        let mut map = f.debug_map();
+
+        for (name, symbol) in &self.symbols {
+            map.entry(name, &symbol.debug(db));
+        }
+        map.finish()
+    }
+}
 
 #[salsa::jar(db=SemanticDb)]
 pub struct SemanticJar(
     SyntaxCheck,
     PhysicalLinesCheck,
+    ModuleSearchPaths,
+    Symbol,
     Module,
+    ModuleName,
     dependencies,
+    symbol_table,
     check_syntax,
     check_physical_lines,
     ast_ids,
+    resolve_module,
 );
 
-pub trait SourceDb: salsa::DbWithJar<SourceJar> {
-    fn source_text(&self, file_id: FileId) -> std::io::Result<SourceText>;
-
-    fn files(&self) -> &Files;
-}
-
-pub trait SemanticDb: SourceDb + salsa::DbWithJar<SemanticJar> {
-    fn upcast(&self) -> &dyn SourceDb;
+pub trait SemanticDb: source::Db + salsa::DbWithJar<SemanticJar> {
+    fn upcast(&self) -> &dyn source::Db;
 }
 
 pub trait Db: SemanticDb {
@@ -87,42 +314,22 @@ pub trait Db: SemanticDb {
 pub struct Database {
     storage: salsa::Storage<Self>,
 
-    // can define additional fields
-    // TODO how to reuse file ids across runs? Do we want this to be part of salsa or shout the id
-    //   mapping happen out side because we don't want to read them from disk every time?
-    sources: Arc<RwLock<FxHashMap<FileId, SourceText>>>,
-    files: Files,
+    files: source::Files,
 }
 
 impl Database {
-    pub fn new(files: Files) -> Self {
+    pub fn new() -> Self {
         Self {
-            sources: Arc::new(RwLock::new(FxHashMap::default())),
-            files,
+            files: source::Files::default(),
             storage: Default::default(),
         }
     }
 }
 
 impl SourceDb for Database {
-    fn source_text(&self, file_id: FileId) -> std::io::Result<SourceText> {
-        let lock = self.sources.upgradable_read();
-        if let Some(source) = lock.get(&file_id) {
-            return Ok(*source);
-        }
-
-        let mut upgraded = RwLockUpgradableReadGuard::upgrade(lock);
-
-        let path = self.files.path(file_id);
-        let file = SourceText::new(self, file_id, std::fs::read_to_string(path)?);
-
-        upgraded.insert(file_id, file);
-
-        Ok(file)
-    }
-
-    fn files(&self) -> &Files {
-        &self.files
+    #[tracing::instrument(level = "debug", skip(self))]
+    fn file(&self, path: PathBuf) -> File {
+        self.files.resolve(self, path)
     }
 }
 
@@ -140,7 +347,7 @@ impl Db for Database {
 
 impl salsa::Database for Database {
     fn salsa_event(&self, event: Event) {
-        tracing::debug!("{:#?}", event);
+        let _ = debug_span!("event", "{:?}", event.debug(self));
     }
 }
 
@@ -149,128 +356,238 @@ impl salsa::ParallelDatabase for Database {
         salsa::Snapshot::new(Database {
             storage: self.storage.snapshot(),
 
-            sources: self.sources.clone(),
             // This is ok, because files is an arc
-            files: self.files.snapshot(),
+            files: self.files.clone(),
         })
     }
 }
 
-#[salsa::tracked(jar=SourceJar)]
-pub fn parse(db: &dyn SourceDb, source: SourceText) -> Parsed {
-    let text = source.text(db);
-
-    let result = ruff_python_parser::parse(text, Mode::Module);
-
-    let (module, errors) = match result {
-        Ok(Mod::Module(module)) => (module, vec![]),
-        Ok(Mod::Expression(expression)) => (
-            ModModule {
-                range: expression.range(),
-                body: vec![Stmt::Expr(StmtExpr {
-                    range: expression.range(),
-                    value: expression.body,
-                })],
-            },
-            vec![],
-        ),
-        Err(errors) => (
-            ModModule {
-                range: TextRange::default(),
-                body: Vec::new(),
-            },
-            vec![errors],
-        ),
-    };
-
-    // Okay, there's actually no input mapping for tracked structs, ugh.
-    Parsed::new(db, module, Vec::new(), errors)
-}
-
+#[tracing::instrument(level = "debug", skip(db))]
 #[salsa::tracked(jar=SemanticJar)]
-pub fn dependencies(db: &dyn SemanticDb, source_text: SourceText) -> Arc<Vec<Dependency>> {
-    let parsed = parse(db.upcast(), source_text);
+pub fn dependencies(db: &dyn SemanticDb, file: File) -> Arc<Vec<Module>> {
+    struct DependenciesVisitor<'a> {
+        db: &'a dyn SemanticDb,
+        module_path: PathBuf,
+        dependencies: Vec<Module>,
+    }
+
+    // TODO support package imports
+    impl PreorderVisitor<'_> for DependenciesVisitor<'_> {
+        fn enter_node(&mut self, node: AnyNodeRef) -> TraversalSignal {
+            // Don't traverse into expressions
+            if node.is_expression() {
+                return TraversalSignal::Skip;
+            }
+
+            TraversalSignal::Traverse
+        }
+
+        fn visit_stmt(&mut self, stmt: &Stmt) {
+            match stmt {
+                Stmt::Import(import) => {
+                    for alias in &import.names {
+                        if let Some(module) = resolve_module_by_name(self.db, &alias.name) {
+                            self.dependencies.push(module);
+                        }
+                    }
+                }
+
+                Stmt::ImportFrom(from) => {
+                    if let Some(module) = &from.module {
+                        assert_eq!(from.level, 0, "Relative imports not supported");
+
+                        if let Some(module) = resolve_module_by_name(self.db, module) {
+                            self.dependencies.push(module);
+                        }
+                    } else {
+                        warn!("Relative imports are not supported");
+                    }
+                }
+                _ => {}
+            }
+            preorder::walk_stmt(self, stmt);
+        }
+    }
+
+    let parsed = source::parse(db.upcast(), file);
 
     let mut visitor = DependenciesVisitor {
-        module_path: db
-            .files()
-            .path(source_text.file(db.upcast()))
+        db,
+        module_path: file
+            .path(db.upcast())
             .parent()
             .map_or_else(PathBuf::new, std::borrow::ToOwned::to_owned),
         dependencies: Vec::new(),
     };
 
     // TODO change the visitor so that `visit_mod` accepts a `ModRef` node that we can construct from module.
-    visitor.visit_body(&parsed.ast(db.upcast()).body);
+    visitor.visit_body(&parsed.ast().body);
 
     Arc::new(visitor.dependencies)
 
     // TODO we should extract the names of dependencies during parsing to avoid an extra traversal here.
 }
 
-struct DependenciesVisitor {
-    module_path: PathBuf,
-    dependencies: Vec<Dependency>,
-}
-
-impl DependenciesVisitor {
-    fn push_dependency(&mut self, path: PathBuf) {
-        // TODO handle error case by pushing a diagnostic?
-        let joined = self.module_path.join(path);
-        if let Ok(normalized) = joined.canonicalize() {
-            self.dependencies.push(Dependency { path: normalized });
-        } else {
-            warn!("Could not canonicalize path: {:?}", joined);
-        }
-    }
-}
-
-// TODO support package imports
-impl PreorderVisitor<'_> for DependenciesVisitor {
-    fn enter_node(&mut self, node: AnyNodeRef) -> TraversalSignal {
-        // Don't traverse into expressions
-        if node.is_expression() {
-            return TraversalSignal::Skip;
-        }
-
-        TraversalSignal::Traverse
-    }
-
-    fn visit_stmt(&mut self, stmt: &Stmt) {
-        match stmt {
-            Stmt::Import(import) => {
-                for alias in &import.names {
-                    let path: PathBuf = alias.name.split('.').collect();
-
-                    self.push_dependency(path.with_extension("py"));
-                }
-            }
-
-            Stmt::ImportFrom(from) => {
-                if let Some(module) = &from.module {
-                    let path: PathBuf = module.split('.').collect();
-                    self.push_dependency(path.with_extension("py"));
-                } else {
-                    let path: PathBuf = (0..from.level).map(|_| "..").collect();
-                    self.push_dependency(path.with_extension("py"));
-                }
-            }
-            _ => {}
-        }
-        preorder::walk_stmt(self, stmt);
-    }
-}
-
-#[derive(Eq, PartialEq, Hash, Clone, Debug)]
-pub struct Dependency {
-    // A relative path from the current module to the dependency
-    pub path: PathBuf,
-}
-
-// TODO it's unclear to me if the function should accept a parsed or a source text?
-//   Is it best practice to inline as many db calls or should we ask the caller to do the db calls?
+#[tracing::instrument(level = "debug", skip(db))]
 #[salsa::tracked(jar=SemanticJar)]
-pub fn check_syntax(db: &dyn SemanticDb, parsed: Parsed) -> SyntaxCheck {
+fn symbol_table(db: &dyn SemanticDb, file_id: File) -> Arc<SymbolTable> {
+    struct SymbolTableVisitor<'db> {
+        symbols: SymbolTable,
+        db: &'db dyn SemanticDb,
+    }
+
+    impl PreorderVisitor<'_> for SymbolTableVisitor<'_> {
+        fn visit_stmt(&mut self, stmt: &'_ Stmt) {
+            match stmt {
+                Stmt::Assign(assign) => {
+                    for target in &assign.targets {
+                        if let Expr::Name(name) = &target {
+                            let name = smol_str::SmolStr::new(&name.id);
+                            self.symbols
+                                .insert(name.clone(), Symbol::new(self.db, name, Count::default()));
+                        }
+                    }
+                }
+                _ => {}
+            }
+
+            preorder::walk_stmt(self, stmt);
+        }
+    }
+
+    let parsed = source::parse(db.upcast(), file_id);
+    let mut visitor = SymbolTableVisitor {
+        db,
+        symbols: SymbolTable::default(),
+    };
+
+    visitor.visit_body(&parsed.ast().body);
+
+    Arc::new(visitor.symbols)
+}
+
+fn resolve_module_by_name(db: &dyn SemanticDb, name: &str) -> Option<Module> {
+    let module_name = ModuleName::new(db, name.into());
+
+    resolve_module(db, module_name)
+}
+
+#[tracing::instrument(level = "debug", skip(db))]
+#[salsa::tracked(jar=SemanticJar)]
+fn resolve_module(db: &dyn SemanticDb, name: ModuleName) -> Option<Module> {
+    let search_paths = ModuleSearchPaths::get(db);
+
+    for search_path in search_paths.paths(db) {
+        let mut components = name.components(db).into_iter();
+        let module_name = components.next_back()?;
+
+        match resolve_package(db, search_path, components) {
+            Ok(resolved_package) => {
+                let mut package_path = resolved_package.path;
+
+                package_path.push(module_name);
+
+                // Must be a `__init__.pyi` or `__init__.py` or it isn't a package.
+                let kind = if package_path.is_dir() {
+                    package_path.push("__init__");
+                    ModuleKind::Package
+                } else {
+                    ModuleKind::Module
+                };
+
+                // TODO Implement full https://peps.python.org/pep-0561/#type-checker-module-resolution-order resolution
+                let stub = package_path.with_extension("pyi");
+                let stub_file = db.file(stub.clone());
+
+                if stub.is_file() {
+                    return Some(Module::new(db, name, stub_file));
+                }
+
+                let module = package_path.with_extension("py");
+                let module_file = db.file(module.clone());
+
+                if module.is_file() {
+                    return Some(Module::new(db, name, module_file));
+                }
+
+                // For regular packages, don't search the next search path. All files of that
+                // package must be in the same location
+                if resolved_package.kind.is_regular_package() {
+                    return None;
+                }
+            }
+            Err(parent_kind) => {
+                if parent_kind.is_regular_package() {
+                    // For regular packages, don't search the next search path.
+                    return None;
+                }
+            }
+        }
+    }
+    None
+}
+
+fn resolve_package<'a, I>(
+    db: &dyn SemanticDb,
+    module_search_path: &ModuleSearchPath,
+    components: I,
+) -> Result<crate::module::ResolvedPackage, crate::module::PackageKind>
+where
+    I: Iterator<Item = String>,
+{
+    let mut package_path = module_search_path.path().to_path_buf();
+
+    // `true` if inside a folder that is a namespace package (has no `__init__.py`).
+    // Namespace packages are special because they can be spread across multiple search paths.
+    // https://peps.python.org/pep-0420/
+    let mut in_namespace_package = false;
+
+    // `true` if resolving a sub-package. For example, `true` when resolving `bar` of `foo.bar`.
+    let mut in_sub_package = false;
+
+    // For `foo.bar.baz`, test that `foo` and `baz` both contain a `__init__.py`.
+    for folder in components {
+        package_path.push(folder);
+
+        let has_init_py = package_path.join("__init__.py").is_file()
+            || package_path.join("__init__.pyi").is_file();
+
+        if has_init_py {
+            in_namespace_package = false;
+        } else if package_path.is_dir() {
+            // A directory without an `__init__.py` is a namespace package, continue with the next folder.
+            in_namespace_package = true;
+        } else if in_namespace_package {
+            // Package not found but it is part of a namespace package.
+            return Err(crate::module::PackageKind::Namespace);
+        } else if in_sub_package {
+            // A regular sub package wasn't found.
+            return Err(crate::module::PackageKind::Regular);
+        } else {
+            // We couldn't find `foo` for `foo.bar.baz`, search the next search path.
+            return Err(crate::module::PackageKind::Root);
+        }
+
+        in_sub_package = true;
+    }
+
+    let kind = if in_namespace_package {
+        crate::module::PackageKind::Namespace
+    } else if in_sub_package {
+        crate::module::PackageKind::Regular
+    } else {
+        crate::module::PackageKind::Root
+    };
+
+    Ok(crate::module::ResolvedPackage {
+        kind,
+        path: package_path,
+    })
+}
+
+#[tracing::instrument(level = "debug", skip(db))]
+#[salsa::tracked(jar=SemanticJar)]
+pub fn check_syntax(db: &dyn SemanticDb, file: File) -> SyntaxCheck {
     // TODO I haven't looked into how many rules are pure syntax checks.
     //   It may be necessary to at least give access to a simplified semantic model.
     struct SyntaxChecker {
@@ -287,17 +604,22 @@ pub fn check_syntax(db: &dyn SemanticDb, parsed: Parsed) -> SyntaxCheck {
         }
     }
 
+    let parsed = source::parse(db.upcast(), file);
+
     let mut visitor = SyntaxChecker {
         diagnostics: Vec::new(),
     };
-    visitor.visit_body(&parsed.ast(db.upcast()).body);
+
+    visitor.visit_body(&parsed.ast().body);
 
     SyntaxCheck::new(db, visitor.diagnostics)
 }
 
+#[tracing::instrument(level = "debug", skip(db))]
 #[salsa::tracked(jar=SemanticJar)]
-pub fn check_physical_lines(db: &dyn SemanticDb, source_text: SourceText) -> PhysicalLinesCheck {
-    let text = source_text.text(db.upcast());
+pub fn check_physical_lines(db: &dyn SemanticDb, file: File) -> PhysicalLinesCheck {
+    let source = file.source(db.upcast());
+    let text = source.text();
 
     let mut diagnostics = Vec::new();
     let mut line_number = 0u32;
@@ -311,16 +633,116 @@ pub fn check_physical_lines(db: &dyn SemanticDb, source_text: SourceText) -> Phy
     PhysicalLinesCheck::new(db, diagnostics)
 }
 
+#[tracing::instrument(level = "debug", skip(db))]
 #[salsa::tracked(jar=SemanticJar)]
-pub fn ast_ids(db: &dyn SemanticDb, source: SourceText) -> Arc<AstIds> {
-    let parsed = parse(db.upcast(), source);
-    let ast = parsed.ast(db.upcast());
+pub fn ast_ids(db: &dyn SemanticDb, file: File) -> Arc<AstIds> {
+    let parsed = source::parse(db.upcast(), file);
 
-    Arc::new(AstIds::from_module(ast))
+    Arc::new(AstIds::from_module(parsed.ast()))
 }
 
-#[salsa::interned(jar=SemanticJar)]
-struct Module {
-    name: ModuleName,
-    path: PathBuf,
+#[cfg(test)]
+mod tests {
+    use salsa::storage::HasJar;
+    use salsa::DebugWithDb;
+    use tracing::{debug, Level};
+    use tracing_subscriber::fmt::time;
+    use tracing_subscriber::fmt::writer::MakeWriterExt;
+    use tracing_subscriber::prelude::__tracing_subscriber_SubscriberExt;
+    use tracing_subscriber::Registry;
+    use tracing_tree::time::Uptime;
+
+    use crate::module::ModuleSearchPathKind;
+    use crate::salsa_db::source::Db;
+
+    use super::{
+        dependencies, source, symbol_table, Database, ModuleSearchPath, ModuleSearchPaths, Symbol,
+    };
+
+    #[test]
+    fn inputs() {
+        countme::enable(true);
+        setup_tracing();
+        // log::set_max_level(LevelFilter::Trace);
+        // log::set_logger()
+
+        let tempdir = tempfile::tempdir().unwrap();
+        let main = tempdir.path().join("main.py");
+        let foo = tempdir.path().join("foo.py");
+
+        std::fs::write(&main, "import foo;\nx = 1").unwrap();
+        std::fs::write(&foo, "x = 10").unwrap();
+
+        let mut db = Database::new();
+        ModuleSearchPaths::new(
+            &mut db,
+            vec![ModuleSearchPath::new(
+                tempdir.path().to_owned(),
+                ModuleSearchPathKind::FirstParty,
+            )],
+        );
+
+        let main_file = db.file(main.clone());
+
+        dependencies(&db, main_file);
+        debug!("{:#?}", &symbol_table(&db, main_file).debug(&db));
+
+        std::fs::write(&main, "print('Hello, Micha!')").unwrap();
+
+        main_file.touch(&mut db);
+
+        // let (source_jar, _): (&mut SourceJar, _) = db.jar_mut();
+        // source_jar.0.reset()
+
+        assert_eq!("print('Hello, Micha!')", main_file.source(&db).text());
+
+        debug!("{:#?}", &symbol_table(&db, main_file).debug(&db));
+
+        // The file never gets collected.
+        main_file.touch(&mut db);
+
+        // TODO: Is there a way to remove a file?
+
+        // There's only one source alive. I guess that makes sense because we never read the content of `foo.py`.
+
+        eprintln!("{}", countme::get_all());
+    }
+
+    fn setup_tracing() {
+        // tracing_log::LogTracer::init().unwrap();
+
+        // let subscriber = Registry::default().with(
+        //     tracing_tree::HierarchicalLayer::default()
+        //         .with_indent_lines(true)
+        //         .with_indent_amount(2)
+        //         .with_bracketed_fields(true)
+        //         .with_thread_ids(true)
+        //         .with_targets(true)
+        //         // .with_writer(|| Box::new(std::io::stderr()))
+        //         .with_timer(Uptime::default()),
+        // );
+        //
+        let subscriber = tracing_subscriber::fmt()
+            // Use a more compact, abbreviated log format
+            .compact()
+            .with_span_events(
+                tracing_subscriber::fmt::format::FmtSpan::ENTER
+                    | tracing_subscriber::fmt::format::FmtSpan::CLOSE,
+            )
+            // Display source code file paths
+            .with_file(false)
+            // Display source code line numbers
+            .with_line_number(true)
+            // Display the thread ID an event was recorded on
+            .with_thread_ids(false)
+            .with_timer(time())
+            // Don't display the event's target (module path)
+            .with_target(true)
+            .with_max_level(Level::TRACE)
+            .with_writer(std::io::stderr)
+            // Build the subscriber
+            .finish();
+
+        tracing::subscriber::set_global_default(subscriber).unwrap();
+    }
 }

--- a/crates/red_knot/src/salsa_db.rs
+++ b/crates/red_knot/src/salsa_db.rs
@@ -1,327 +1,33 @@
 #![allow(unreachable_pub)]
-#![allow(unused)]
+#![allow(clippy::used_underscore_binding)]
 
-use std::fmt::Formatter;
 use std::path::PathBuf;
-use std::sync::Arc;
 
-use countme::Count;
-use dashmap::mapref::entry::Entry;
-use filetime::FileTime;
-use rustc_hash::FxHashMap;
-use salsa::database::AsSalsaDatabase;
-use salsa::{DebugWithDb, Event};
-use tracing::{debug, debug_span, warn, Level};
-use tracing_subscriber::layer::SubscriberExt;
-use tracing_subscriber::{Layer, Registry};
-use tracing_tree::time::Uptime;
+use salsa::{DebugWithDb, Event, Storage};
+use tracing::{debug_span, warn};
 
-use ruff_python_ast::visitor::preorder::{PreorderVisitor, TraversalSignal};
-use ruff_python_ast::visitor::{preorder, walk_stmt, Visitor};
-use ruff_python_ast::{AnyNodeRef, Expr, Mod, ModModule, Stmt, StmtExpr};
-use ruff_python_parser::Mode;
-use ruff_text_size::{Ranged, TextRange};
+use crate::db::Upcast;
+use crate::salsa_db::source::File;
 
-use crate::ast_ids::AstIds;
-use crate::files::{FileId, Files};
-use crate::module::{ModuleKind, ModuleSearchPath};
-use crate::salsa_db::source::{File, SourceText};
-use crate::FxDashMap;
+use self::source::Db as SourceDb;
 
-use self::source::{Db as SourceDb, Jar as SourceJar};
+pub mod lint;
+pub mod semantic;
+pub mod source;
 
-pub mod source {
-    use std::path::PathBuf;
-    use std::sync::Arc;
-
-    use countme::Count;
-    use dashmap::mapref::entry::Entry;
-    use filetime::FileTime;
-
-    use ruff_python_ast::{Mod, ModModule, Stmt, StmtExpr};
-    use ruff_python_parser::Mode;
-    use ruff_text_size::{Ranged, TextRange};
-
-    use crate::FxDashMap;
-
-    #[salsa::input(jar=Jar)]
-    pub struct File {
-        #[return_ref]
-        pub path: PathBuf,
-
-        pub permissions: u32,
-        pub last_modified_time: FileTime,
-        _count: Count<File>,
-    }
-
-    impl File {
-        #[tracing::instrument(level = "debug", skip(db))]
-        pub fn touch(&self, db: &mut dyn Db) {
-            let path = self.path(db);
-            let metadata = path.metadata().unwrap();
-            let last_modified = filetime::FileTime::from_last_modification_time(&metadata);
-
-            self.set_last_modified_time(db).to(last_modified);
-        }
-    }
-
-    #[salsa::tracked(jar=Jar)]
-    impl File {
-        #[salsa::tracked]
-        pub fn source(self, db: &dyn Db) -> SourceText {
-            let _ = self.last_modified_time(db); // Read the last modified date to trigger a re-run when the file changes.
-            let text = std::fs::read_to_string(self.path(db)).unwrap_or_default();
-
-            SourceText {
-                text: Arc::new(text),
-                count: Count::default(),
-            }
-        }
-    }
-
-    #[derive(Debug, Clone, Default)]
-    pub struct Files {
-        inner: Arc<FilesInner>,
-    }
-
-    impl Files {
-        pub(super) fn resolve(&self, db: &dyn Db, path: PathBuf) -> File {
-            match self.inner.by_path.entry(path.clone()) {
-                Entry::Occupied(entry) => {
-                    let file = entry.get();
-                    *file
-                }
-                Entry::Vacant(entry) => {
-                    let metadata = path.metadata();
-                    let (last_modified, permissions) = if let Ok(metadata) = metadata {
-                        let last_modified =
-                            filetime::FileTime::from_last_modification_time(&metadata);
-                        #[cfg(unix)]
-                        let permissions = if cfg!(unix) {
-                            use std::os::unix::fs::PermissionsExt;
-                            metadata.permissions().mode()
-                        } else {
-                            0
-                        };
-
-                        (last_modified, permissions)
-                    } else {
-                        (FileTime::zero(), 0)
-                    };
-
-                    // TODO: How to set the durability?
-
-                    let file = File::new(db, path, permissions, last_modified, Count::default());
-                    entry.insert(file);
-
-                    file
-                }
-            }
-        }
-    }
-
-    #[derive(Debug, Default)]
-    struct FilesInner {
-        by_path: FxDashMap<PathBuf, File>,
-    }
-
-    // TODO salsa recommends to have one jar per crate and call it `Jar`. We're not doing this here
-    // because I don't want that many crates just yet.
-    #[derive(Debug, Clone, Eq, PartialEq)]
-    pub struct SourceText {
-        pub text: Arc<String>,
-        count: Count<SourceText>,
-    }
-
-    impl SourceText {
-        pub fn text(&self) -> &str {
-            self.text.as_str()
-        }
-    }
-
-    #[derive(Debug, Clone, PartialEq)]
-    pub struct Parsed {
-        inner: Arc<ParsedInner>,
-    }
-
-    impl Parsed {
-        pub fn ast(&self) -> &ModModule {
-            &self.inner.ast
-        }
-
-        pub fn errors(&self) -> &[ruff_python_parser::ParseError] {
-            &self.inner.errors
-        }
-    }
-
-    #[derive(Debug, PartialEq)]
-    struct ParsedInner {
-        // TODO should this be an arc to avoid some lifetime awkwardness for call-sites.
-        pub ast: ModModule,
-
-        // TODO use an accumulator for this?
-        pub errors: Vec<ruff_python_parser::ParseError>,
-    }
-
-    #[tracing::instrument(level = "debug", skip(db))]
-    #[salsa::tracked(jar=Jar, no_eq)]
-    pub fn parse(db: &dyn Db, file: File) -> Parsed {
-        let source = file.source(db);
-        let text = source.text();
-
-        let result = ruff_python_parser::parse(text, Mode::Module);
-
-        let (module, errors) = match result {
-            Ok(Mod::Module(module)) => (module, vec![]),
-            Ok(Mod::Expression(expression)) => (
-                ModModule {
-                    range: expression.range(),
-                    body: vec![Stmt::Expr(StmtExpr {
-                        range: expression.range(),
-                        value: expression.body,
-                    })],
-                },
-                vec![],
-            ),
-            Err(errors) => (
-                ModModule {
-                    range: TextRange::default(),
-                    body: Vec::new(),
-                },
-                vec![errors],
-            ),
-        };
-
-        Parsed {
-            inner: Arc::new(ParsedInner {
-                ast: module,
-                errors,
-            }),
-        }
-    }
-
-    #[salsa::jar(db=Db)]
-    pub struct Jar(File, File_source, parse);
-
-    pub trait Db: salsa::DbWithJar<Jar> {
-        fn file(&self, path: PathBuf) -> File;
-    }
-}
-
-#[salsa::tracked(jar=SemanticJar)]
-pub struct SyntaxCheck {
-    #[returned_ref]
-    pub diagnostics: Vec<String>,
-}
-
-#[salsa::tracked(jar=SemanticJar)]
-pub struct PhysicalLinesCheck {
-    #[returned_ref]
-    pub diagnostics: Vec<String>,
-}
-
-#[salsa::input(jar=SemanticJar, singleton)]
-pub struct ModuleSearchPaths {
-    #[return_ref]
-    paths: Vec<ModuleSearchPath>,
-}
-
-#[salsa::interned(jar=SemanticJar)]
-pub struct ModuleName {
-    name: smol_str::SmolStr,
-}
-
-impl ModuleName {
-    pub fn components(&self, db: &dyn SemanticDb) -> Vec<String> {
-        let name = self.name(db);
-        name.split(".").map(String::from).collect()
-    }
-}
-
-// TODO should this be tracked or not?
-// I think yes, so that we can reference to it using ids.
-#[salsa::tracked(jar=SemanticJar)]
-pub struct Module {
-    name: ModuleName,
-    file: File,
-}
-
-#[salsa::tracked(jar=SemanticJar)]
-pub struct Symbol {
-    #[id]
-    #[returned_ref]
-    pub name: smol_str::SmolStr,
-
-    count: Count<Symbol>,
-}
-
-#[derive(Eq, PartialEq, Default)]
-pub struct SymbolTable {
-    symbols: FxHashMap<smol_str::SmolStr, Symbol>,
-}
-
-impl SymbolTable {
-    fn insert(&mut self, name: smol_str::SmolStr, symbol: Symbol) {
-        self.symbols.insert(name, symbol);
-    }
-}
-
-impl std::fmt::Debug for SymbolTable {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        self.symbols.fmt(f)
-    }
-}
-
-impl<Db> DebugWithDb<Db> for SymbolTable
-where
-    Db: AsSalsaDatabase + SemanticDb,
-{
-    fn fmt(&self, f: &mut Formatter<'_>, db: &Db) -> std::fmt::Result {
-        let mut map = f.debug_map();
-
-        for (name, symbol) in &self.symbols {
-            map.entry(name, &symbol.debug(db));
-        }
-        map.finish()
-    }
-}
-
-#[salsa::jar(db=SemanticDb)]
-pub struct SemanticJar(
-    SyntaxCheck,
-    PhysicalLinesCheck,
-    ModuleSearchPaths,
-    Symbol,
-    Module,
-    ModuleName,
-    dependencies,
-    symbol_table,
-    check_syntax,
-    check_physical_lines,
-    ast_ids,
-    resolve_module,
-);
-
-pub trait SemanticDb: source::Db + salsa::DbWithJar<SemanticJar> {
-    fn upcast(&self) -> &dyn source::Db;
-}
-
-pub trait Db: SemanticDb {
-    fn upcast(&self) -> &dyn SemanticDb;
-}
-
-#[salsa::db(self::SourceJar, self::SemanticJar)]
+#[salsa::db(source::Jar, lint::Jar, semantic::Jar)]
 pub struct Database {
-    storage: salsa::Storage<Self>,
+    storage: Storage<Self>,
 
     files: source::Files,
 }
 
 impl Database {
+    #[allow(unused)]
     pub fn new() -> Self {
         Self {
             files: source::Files::default(),
-            storage: Default::default(),
+            storage: Storage::default(),
         }
     }
 }
@@ -333,17 +39,21 @@ impl SourceDb for Database {
     }
 }
 
-impl SemanticDb for Database {
-    fn upcast(&self) -> &dyn SourceDb {
+impl semantic::Db for Database {}
+
+impl Upcast<dyn source::Db> for Database {
+    fn upcast(&self) -> &(dyn source::Db + 'static) {
         self
     }
 }
 
-impl Db for Database {
-    fn upcast(&self) -> &dyn SemanticDb {
+impl Upcast<dyn semantic::Db> for Database {
+    fn upcast(&self) -> &(dyn semantic::Db + 'static) {
         self
     }
 }
+
+impl lint::Db for Database {}
 
 impl salsa::Database for Database {
     fn salsa_event(&self, event: Event) {
@@ -362,319 +72,87 @@ impl salsa::ParallelDatabase for Database {
     }
 }
 
-#[tracing::instrument(level = "debug", skip(db))]
-#[salsa::tracked(jar=SemanticJar)]
-pub fn dependencies(db: &dyn SemanticDb, file: File) -> Arc<Vec<Module>> {
-    struct DependenciesVisitor<'a> {
-        db: &'a dyn SemanticDb,
-        module_path: PathBuf,
-        dependencies: Vec<Module>,
-    }
-
-    // TODO support package imports
-    impl PreorderVisitor<'_> for DependenciesVisitor<'_> {
-        fn enter_node(&mut self, node: AnyNodeRef) -> TraversalSignal {
-            // Don't traverse into expressions
-            if node.is_expression() {
-                return TraversalSignal::Skip;
-            }
-
-            TraversalSignal::Traverse
-        }
-
-        fn visit_stmt(&mut self, stmt: &Stmt) {
-            match stmt {
-                Stmt::Import(import) => {
-                    for alias in &import.names {
-                        if let Some(module) = resolve_module_by_name(self.db, &alias.name) {
-                            self.dependencies.push(module);
-                        }
-                    }
-                }
-
-                Stmt::ImportFrom(from) => {
-                    if let Some(module) = &from.module {
-                        assert_eq!(from.level, 0, "Relative imports not supported");
-
-                        if let Some(module) = resolve_module_by_name(self.db, module) {
-                            self.dependencies.push(module);
-                        }
-                    } else {
-                        warn!("Relative imports are not supported");
-                    }
-                }
-                _ => {}
-            }
-            preorder::walk_stmt(self, stmt);
-        }
-    }
-
-    let parsed = source::parse(db.upcast(), file);
-
-    let mut visitor = DependenciesVisitor {
-        db,
-        module_path: file
-            .path(db.upcast())
-            .parent()
-            .map_or_else(PathBuf::new, std::borrow::ToOwned::to_owned),
-        dependencies: Vec::new(),
-    };
-
-    // TODO change the visitor so that `visit_mod` accepts a `ModRef` node that we can construct from module.
-    visitor.visit_body(&parsed.ast().body);
-
-    Arc::new(visitor.dependencies)
-
-    // TODO we should extract the names of dependencies during parsing to avoid an extra traversal here.
-}
-
-#[tracing::instrument(level = "debug", skip(db))]
-#[salsa::tracked(jar=SemanticJar)]
-fn symbol_table(db: &dyn SemanticDb, file_id: File) -> Arc<SymbolTable> {
-    struct SymbolTableVisitor<'db> {
-        symbols: SymbolTable,
-        db: &'db dyn SemanticDb,
-    }
-
-    impl PreorderVisitor<'_> for SymbolTableVisitor<'_> {
-        fn visit_stmt(&mut self, stmt: &'_ Stmt) {
-            match stmt {
-                Stmt::Assign(assign) => {
-                    for target in &assign.targets {
-                        if let Expr::Name(name) = &target {
-                            let name = smol_str::SmolStr::new(&name.id);
-                            self.symbols
-                                .insert(name.clone(), Symbol::new(self.db, name, Count::default()));
-                        }
-                    }
-                }
-                _ => {}
-            }
-
-            preorder::walk_stmt(self, stmt);
-        }
-    }
-
-    let parsed = source::parse(db.upcast(), file_id);
-    let mut visitor = SymbolTableVisitor {
-        db,
-        symbols: SymbolTable::default(),
-    };
-
-    visitor.visit_body(&parsed.ast().body);
-
-    Arc::new(visitor.symbols)
-}
-
-fn resolve_module_by_name(db: &dyn SemanticDb, name: &str) -> Option<Module> {
-    let module_name = ModuleName::new(db, name.into());
-
-    resolve_module(db, module_name)
-}
-
-#[tracing::instrument(level = "debug", skip(db))]
-#[salsa::tracked(jar=SemanticJar)]
-fn resolve_module(db: &dyn SemanticDb, name: ModuleName) -> Option<Module> {
-    let search_paths = ModuleSearchPaths::get(db);
-
-    for search_path in search_paths.paths(db) {
-        let mut components = name.components(db).into_iter();
-        let module_name = components.next_back()?;
-
-        match resolve_package(db, search_path, components) {
-            Ok(resolved_package) => {
-                let mut package_path = resolved_package.path;
-
-                package_path.push(module_name);
-
-                // Must be a `__init__.pyi` or `__init__.py` or it isn't a package.
-                let kind = if package_path.is_dir() {
-                    package_path.push("__init__");
-                    ModuleKind::Package
-                } else {
-                    ModuleKind::Module
-                };
-
-                // TODO Implement full https://peps.python.org/pep-0561/#type-checker-module-resolution-order resolution
-                let stub = package_path.with_extension("pyi");
-                let stub_file = db.file(stub.clone());
-
-                if stub.is_file() {
-                    return Some(Module::new(db, name, stub_file));
-                }
-
-                let module = package_path.with_extension("py");
-                let module_file = db.file(module.clone());
-
-                if module.is_file() {
-                    return Some(Module::new(db, name, module_file));
-                }
-
-                // For regular packages, don't search the next search path. All files of that
-                // package must be in the same location
-                if resolved_package.kind.is_regular_package() {
-                    return None;
-                }
-            }
-            Err(parent_kind) => {
-                if parent_kind.is_regular_package() {
-                    // For regular packages, don't search the next search path.
-                    return None;
-                }
-            }
-        }
-    }
-    None
-}
-
-fn resolve_package<'a, I>(
-    db: &dyn SemanticDb,
-    module_search_path: &ModuleSearchPath,
-    components: I,
-) -> Result<crate::module::ResolvedPackage, crate::module::PackageKind>
-where
-    I: Iterator<Item = String>,
-{
-    let mut package_path = module_search_path.path().to_path_buf();
-
-    // `true` if inside a folder that is a namespace package (has no `__init__.py`).
-    // Namespace packages are special because they can be spread across multiple search paths.
-    // https://peps.python.org/pep-0420/
-    let mut in_namespace_package = false;
-
-    // `true` if resolving a sub-package. For example, `true` when resolving `bar` of `foo.bar`.
-    let mut in_sub_package = false;
-
-    // For `foo.bar.baz`, test that `foo` and `baz` both contain a `__init__.py`.
-    for folder in components {
-        package_path.push(folder);
-
-        let has_init_py = package_path.join("__init__.py").is_file()
-            || package_path.join("__init__.pyi").is_file();
-
-        if has_init_py {
-            in_namespace_package = false;
-        } else if package_path.is_dir() {
-            // A directory without an `__init__.py` is a namespace package, continue with the next folder.
-            in_namespace_package = true;
-        } else if in_namespace_package {
-            // Package not found but it is part of a namespace package.
-            return Err(crate::module::PackageKind::Namespace);
-        } else if in_sub_package {
-            // A regular sub package wasn't found.
-            return Err(crate::module::PackageKind::Regular);
-        } else {
-            // We couldn't find `foo` for `foo.bar.baz`, search the next search path.
-            return Err(crate::module::PackageKind::Root);
-        }
-
-        in_sub_package = true;
-    }
-
-    let kind = if in_namespace_package {
-        crate::module::PackageKind::Namespace
-    } else if in_sub_package {
-        crate::module::PackageKind::Regular
-    } else {
-        crate::module::PackageKind::Root
-    };
-
-    Ok(crate::module::ResolvedPackage {
-        kind,
-        path: package_path,
-    })
-}
-
-#[tracing::instrument(level = "debug", skip(db))]
-#[salsa::tracked(jar=SemanticJar)]
-pub fn check_syntax(db: &dyn SemanticDb, file: File) -> SyntaxCheck {
-    // TODO I haven't looked into how many rules are pure syntax checks.
-    //   It may be necessary to at least give access to a simplified semantic model.
-    struct SyntaxChecker {
-        diagnostics: Vec<String>,
-    }
-
-    impl Visitor<'_> for SyntaxChecker {
-        fn visit_expr(&mut self, expr: &'_ Expr) {
-            if let Expr::Name(name) = expr {
-                if &name.id == "a" {
-                    self.diagnostics.push("Use of name a".to_string());
-                }
-            }
-        }
-    }
-
-    let parsed = source::parse(db.upcast(), file);
-
-    let mut visitor = SyntaxChecker {
-        diagnostics: Vec::new(),
-    };
-
-    visitor.visit_body(&parsed.ast().body);
-
-    SyntaxCheck::new(db, visitor.diagnostics)
-}
-
-#[tracing::instrument(level = "debug", skip(db))]
-#[salsa::tracked(jar=SemanticJar)]
-pub fn check_physical_lines(db: &dyn SemanticDb, file: File) -> PhysicalLinesCheck {
-    let source = file.source(db.upcast());
-    let text = source.text();
-
-    let mut diagnostics = Vec::new();
-    let mut line_number = 0u32;
-    for line in text.lines() {
-        if line.chars().count() > 88 {
-            diagnostics.push(format!("Line {} too long", line_number + 1));
-        }
-        line_number += 1;
-    }
-
-    PhysicalLinesCheck::new(db, diagnostics)
-}
-
-#[tracing::instrument(level = "debug", skip(db))]
-#[salsa::tracked(jar=SemanticJar)]
-pub fn ast_ids(db: &dyn SemanticDb, file: File) -> Arc<AstIds> {
-    let parsed = source::parse(db.upcast(), file);
-
-    Arc::new(AstIds::from_module(parsed.ast()))
-}
-
 #[cfg(test)]
 mod tests {
-    use salsa::storage::HasJar;
-    use salsa::DebugWithDb;
+    use salsa::{DebugWithDb, Event, Storage};
+    use std::path::PathBuf;
     use tracing::{debug, Level};
     use tracing_subscriber::fmt::time;
-    use tracing_subscriber::fmt::writer::MakeWriterExt;
-    use tracing_subscriber::prelude::__tracing_subscriber_SubscriberExt;
-    use tracing_subscriber::Registry;
-    use tracing_tree::time::Uptime;
 
-    use crate::module::ModuleSearchPathKind;
-    use crate::salsa_db::source::Db;
+    use crate::db::Upcast;
+    use crate::salsa_db::semantic::{dependencies, symbol_table};
+    use crate::salsa_db::source::{Db, File};
 
-    use super::{
-        dependencies, source, symbol_table, Database, ModuleSearchPath, ModuleSearchPaths, Symbol,
+    use super::lint;
+    use super::semantic;
+    use super::semantic::module::{
+        set_module_search_paths, ModuleSearchPath, ModuleSearchPathKind,
     };
+    use super::source;
+    use super::Database;
 
+    #[salsa::db(source::Jar, lint::Jar, semantic::Jar)]
+    pub struct TestDb {
+        storage: salsa::Storage<Self>,
+
+        files: source::Files,
+        events: std::sync::Mutex<Vec<salsa::Event>>,
+    }
+
+    impl TestDb {
+        pub fn new() -> Self {
+            Self {
+                files: source::Files::default(),
+                storage: Storage::default(),
+                events: std::sync::Mutex::new(Vec::new()),
+            }
+        }
+    }
+
+    impl source::Db for TestDb {
+        #[tracing::instrument(level = "debug", skip(self))]
+        fn file(&self, path: PathBuf) -> File {
+            self.files.resolve(self, path)
+        }
+    }
+
+    impl semantic::Db for TestDb {}
+
+    impl Upcast<dyn source::Db> for TestDb {
+        fn upcast(&self) -> &(dyn source::Db + 'static) {
+            self
+        }
+    }
+
+    impl Upcast<dyn semantic::Db> for TestDb {
+        fn upcast(&self) -> &(dyn semantic::Db + 'static) {
+            self
+        }
+    }
+
+    impl lint::Db for TestDb {}
+
+    impl salsa::Database for TestDb {
+        fn salsa_event(&self, event: Event) {
+            self.events.lock().unwrap().push(event);
+        }
+    }
+
+    #[allow(clippy::print_stderr)]
     #[test]
     fn inputs() {
         countme::enable(true);
         setup_tracing();
-        // log::set_max_level(LevelFilter::Trace);
-        // log::set_logger()
 
         let tempdir = tempfile::tempdir().unwrap();
         let main = tempdir.path().join("main.py");
         let foo = tempdir.path().join("foo.py");
 
         std::fs::write(&main, "import foo;\nx = 1").unwrap();
-        std::fs::write(&foo, "x = 10").unwrap();
+        std::fs::write(foo, "x = 10").unwrap();
 
         let mut db = Database::new();
-        ModuleSearchPaths::new(
+        set_module_search_paths(
             &mut db,
             vec![ModuleSearchPath::new(
                 tempdir.path().to_owned(),
@@ -709,19 +187,6 @@ mod tests {
     }
 
     fn setup_tracing() {
-        // tracing_log::LogTracer::init().unwrap();
-
-        // let subscriber = Registry::default().with(
-        //     tracing_tree::HierarchicalLayer::default()
-        //         .with_indent_lines(true)
-        //         .with_indent_amount(2)
-        //         .with_bracketed_fields(true)
-        //         .with_thread_ids(true)
-        //         .with_targets(true)
-        //         // .with_writer(|| Box::new(std::io::stderr()))
-        //         .with_timer(Uptime::default()),
-        // );
-        //
         let subscriber = tracing_subscriber::fmt()
             // Use a more compact, abbreviated log format
             .compact()

--- a/crates/red_knot/src/salsa_db.rs
+++ b/crates/red_knot/src/salsa_db.rs
@@ -1,0 +1,326 @@
+#![allow(unreachable_pub)]
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use parking_lot::lock_api::RwLockUpgradableReadGuard;
+use parking_lot::RwLock;
+use rustc_hash::FxHashMap;
+use salsa::Event;
+use tracing::warn;
+
+use ruff_python_ast::visitor::preorder::{PreorderVisitor, TraversalSignal};
+use ruff_python_ast::visitor::{preorder, Visitor};
+use ruff_python_ast::{AnyNodeRef, Expr, Mod, ModModule, Stmt, StmtExpr};
+use ruff_python_parser::Mode;
+use ruff_text_size::{Ranged, TextRange};
+
+use crate::ast_ids::AstIds;
+use crate::files::{FileId, Files};
+use crate::module::ModuleName;
+
+// TODO salsa recommends to have one jar per crate and call it `Jar`. We're not doing this here
+// because I don't want that many crates just yet.
+#[salsa::input(jar=SourceJar)]
+pub struct SourceText {
+    file: FileId,
+
+    #[return_ref]
+    text: String,
+}
+
+#[salsa::tracked(jar=SourceJar)]
+pub struct Parsed {
+    // TODO should this be an arc to avoid some lifetime awkwardness for call-sites.
+    #[return_ref]
+    pub ast: ModModule,
+
+    #[return_ref]
+    pub imports: Vec<String>,
+
+    // TODO use an accumulator for this?
+    #[return_ref]
+    pub errors: Vec<ruff_python_parser::ParseError>,
+}
+
+#[salsa::tracked(jar=SemanticJar)]
+pub struct SyntaxCheck {
+    #[returned_ref]
+    pub diagnostics: Vec<String>,
+}
+
+#[salsa::tracked(jar=SemanticJar)]
+pub struct PhysicalLinesCheck {
+    #[returned_ref]
+    pub diagnostics: Vec<String>,
+}
+
+#[salsa::jar(db=SourceDb)]
+pub struct SourceJar(SourceText, Parsed, parse);
+
+#[salsa::jar(db=SemanticDb)]
+pub struct SemanticJar(
+    SyntaxCheck,
+    PhysicalLinesCheck,
+    Module,
+    dependencies,
+    check_syntax,
+    check_physical_lines,
+    ast_ids,
+);
+
+pub trait SourceDb: salsa::DbWithJar<SourceJar> {
+    fn source_text(&self, file_id: FileId) -> std::io::Result<SourceText>;
+
+    fn files(&self) -> &Files;
+}
+
+pub trait SemanticDb: SourceDb + salsa::DbWithJar<SemanticJar> {
+    fn upcast(&self) -> &dyn SourceDb;
+}
+
+pub trait Db: SemanticDb {
+    fn upcast(&self) -> &dyn SemanticDb;
+}
+
+#[salsa::db(self::SourceJar, self::SemanticJar)]
+pub struct Database {
+    storage: salsa::Storage<Self>,
+
+    // can define additional fields
+    // TODO how to reuse file ids across runs? Do we want this to be part of salsa or shout the id
+    //   mapping happen out side because we don't want to read them from disk every time?
+    sources: Arc<RwLock<FxHashMap<FileId, SourceText>>>,
+    files: Files,
+}
+
+impl Database {
+    pub fn new(files: Files) -> Self {
+        Self {
+            sources: Arc::new(RwLock::new(FxHashMap::default())),
+            files,
+            storage: Default::default(),
+        }
+    }
+}
+
+impl SourceDb for Database {
+    fn source_text(&self, file_id: FileId) -> std::io::Result<SourceText> {
+        let lock = self.sources.upgradable_read();
+        if let Some(source) = lock.get(&file_id) {
+            return Ok(*source);
+        }
+
+        let mut upgraded = RwLockUpgradableReadGuard::upgrade(lock);
+
+        let path = self.files.path(file_id);
+        let file = SourceText::new(self, file_id, std::fs::read_to_string(path)?);
+
+        upgraded.insert(file_id, file);
+
+        Ok(file)
+    }
+
+    fn files(&self) -> &Files {
+        &self.files
+    }
+}
+
+impl SemanticDb for Database {
+    fn upcast(&self) -> &dyn SourceDb {
+        self
+    }
+}
+
+impl Db for Database {
+    fn upcast(&self) -> &dyn SemanticDb {
+        self
+    }
+}
+
+impl salsa::Database for Database {
+    fn salsa_event(&self, event: Event) {
+        tracing::debug!("{:#?}", event);
+    }
+}
+
+impl salsa::ParallelDatabase for Database {
+    fn snapshot(&self) -> salsa::Snapshot<Self> {
+        salsa::Snapshot::new(Database {
+            storage: self.storage.snapshot(),
+
+            sources: self.sources.clone(),
+            // This is ok, because files is an arc
+            files: self.files.snapshot(),
+        })
+    }
+}
+
+#[salsa::tracked(jar=SourceJar)]
+pub fn parse(db: &dyn SourceDb, source: SourceText) -> Parsed {
+    let text = source.text(db);
+
+    let result = ruff_python_parser::parse(text, Mode::Module);
+
+    let (module, errors) = match result {
+        Ok(Mod::Module(module)) => (module, vec![]),
+        Ok(Mod::Expression(expression)) => (
+            ModModule {
+                range: expression.range(),
+                body: vec![Stmt::Expr(StmtExpr {
+                    range: expression.range(),
+                    value: expression.body,
+                })],
+            },
+            vec![],
+        ),
+        Err(errors) => (
+            ModModule {
+                range: TextRange::default(),
+                body: Vec::new(),
+            },
+            vec![errors],
+        ),
+    };
+
+    // Okay, there's actually no input mapping for tracked structs, ugh.
+    Parsed::new(db, module, Vec::new(), errors)
+}
+
+#[salsa::tracked(jar=SemanticJar)]
+pub fn dependencies(db: &dyn SemanticDb, source_text: SourceText) -> Arc<Vec<Dependency>> {
+    let parsed = parse(db.upcast(), source_text);
+
+    let mut visitor = DependenciesVisitor {
+        module_path: db
+            .files()
+            .path(source_text.file(db.upcast()))
+            .parent()
+            .map_or_else(PathBuf::new, std::borrow::ToOwned::to_owned),
+        dependencies: Vec::new(),
+    };
+
+    // TODO change the visitor so that `visit_mod` accepts a `ModRef` node that we can construct from module.
+    visitor.visit_body(&parsed.ast(db.upcast()).body);
+
+    Arc::new(visitor.dependencies)
+
+    // TODO we should extract the names of dependencies during parsing to avoid an extra traversal here.
+}
+
+struct DependenciesVisitor {
+    module_path: PathBuf,
+    dependencies: Vec<Dependency>,
+}
+
+impl DependenciesVisitor {
+    fn push_dependency(&mut self, path: PathBuf) {
+        // TODO handle error case by pushing a diagnostic?
+        let joined = self.module_path.join(path);
+        if let Ok(normalized) = joined.canonicalize() {
+            self.dependencies.push(Dependency { path: normalized });
+        } else {
+            warn!("Could not canonicalize path: {:?}", joined);
+        }
+    }
+}
+
+// TODO support package imports
+impl PreorderVisitor<'_> for DependenciesVisitor {
+    fn enter_node(&mut self, node: AnyNodeRef) -> TraversalSignal {
+        // Don't traverse into expressions
+        if node.is_expression() {
+            return TraversalSignal::Skip;
+        }
+
+        TraversalSignal::Traverse
+    }
+
+    fn visit_stmt(&mut self, stmt: &Stmt) {
+        match stmt {
+            Stmt::Import(import) => {
+                for alias in &import.names {
+                    let path: PathBuf = alias.name.split('.').collect();
+
+                    self.push_dependency(path.with_extension("py"));
+                }
+            }
+
+            Stmt::ImportFrom(from) => {
+                if let Some(module) = &from.module {
+                    let path: PathBuf = module.split('.').collect();
+                    self.push_dependency(path.with_extension("py"));
+                } else {
+                    let path: PathBuf = (0..from.level).map(|_| "..").collect();
+                    self.push_dependency(path.with_extension("py"));
+                }
+            }
+            _ => {}
+        }
+        preorder::walk_stmt(self, stmt);
+    }
+}
+
+#[derive(Eq, PartialEq, Hash, Clone, Debug)]
+pub struct Dependency {
+    // A relative path from the current module to the dependency
+    pub path: PathBuf,
+}
+
+// TODO it's unclear to me if the function should accept a parsed or a source text?
+//   Is it best practice to inline as many db calls or should we ask the caller to do the db calls?
+#[salsa::tracked(jar=SemanticJar)]
+pub fn check_syntax(db: &dyn SemanticDb, parsed: Parsed) -> SyntaxCheck {
+    // TODO I haven't looked into how many rules are pure syntax checks.
+    //   It may be necessary to at least give access to a simplified semantic model.
+    struct SyntaxChecker {
+        diagnostics: Vec<String>,
+    }
+
+    impl Visitor<'_> for SyntaxChecker {
+        fn visit_expr(&mut self, expr: &'_ Expr) {
+            if let Expr::Name(name) = expr {
+                if &name.id == "a" {
+                    self.diagnostics.push("Use of name a".to_string());
+                }
+            }
+        }
+    }
+
+    let mut visitor = SyntaxChecker {
+        diagnostics: Vec::new(),
+    };
+    visitor.visit_body(&parsed.ast(db.upcast()).body);
+
+    SyntaxCheck::new(db, visitor.diagnostics)
+}
+
+#[salsa::tracked(jar=SemanticJar)]
+pub fn check_physical_lines(db: &dyn SemanticDb, source_text: SourceText) -> PhysicalLinesCheck {
+    let text = source_text.text(db.upcast());
+
+    let mut diagnostics = Vec::new();
+    let mut line_number = 0u32;
+    for line in text.lines() {
+        if line.chars().count() > 88 {
+            diagnostics.push(format!("Line {} too long", line_number + 1));
+        }
+        line_number += 1;
+    }
+
+    PhysicalLinesCheck::new(db, diagnostics)
+}
+
+#[salsa::tracked(jar=SemanticJar)]
+pub fn ast_ids(db: &dyn SemanticDb, source: SourceText) -> Arc<AstIds> {
+    let parsed = parse(db.upcast(), source);
+    let ast = parsed.ast(db.upcast());
+
+    Arc::new(AstIds::from_module(ast))
+}
+
+#[salsa::interned(jar=SemanticJar)]
+struct Module {
+    name: ModuleName,
+    path: PathBuf,
+}

--- a/crates/red_knot/src/salsa_db.rs
+++ b/crates/red_knot/src/salsa_db.rs
@@ -11,11 +11,12 @@ use crate::salsa_db::source::File;
 
 use self::source::Db as SourceDb;
 
+mod hir;
 pub mod lint;
 pub mod semantic;
 pub mod source;
 
-#[salsa::db(source::Jar, lint::Jar, semantic::Jar)]
+#[salsa::db(source::Jar, lint::Jar, hir::Jar, semantic::Jar)]
 pub struct Database {
     storage: Storage<Self>,
 
@@ -39,10 +40,18 @@ impl SourceDb for Database {
     }
 }
 
+impl hir::Db for Database {}
+
 impl semantic::Db for Database {}
 
 impl Upcast<dyn source::Db> for Database {
     fn upcast(&self) -> &(dyn source::Db + 'static) {
+        self
+    }
+}
+
+impl Upcast<dyn hir::Db> for Database {
+    fn upcast(&self) -> &(dyn hir::Db + 'static) {
         self
     }
 }
@@ -83,15 +92,15 @@ mod tests {
     use crate::salsa_db::semantic::{dependencies, symbol_table};
     use crate::salsa_db::source::{Db, File};
 
-    use super::lint;
     use super::semantic;
     use super::semantic::module::{
         set_module_search_paths, ModuleSearchPath, ModuleSearchPathKind,
     };
     use super::source;
     use super::Database;
+    use super::{hir, lint};
 
-    #[salsa::db(source::Jar, lint::Jar, semantic::Jar)]
+    #[salsa::db(source::Jar, lint::Jar, hir::Jar, semantic::Jar)]
     pub struct TestDb {
         storage: salsa::Storage<Self>,
 
@@ -116,10 +125,18 @@ mod tests {
         }
     }
 
+    impl hir::Db for TestDb {}
+
     impl semantic::Db for TestDb {}
 
     impl Upcast<dyn source::Db> for TestDb {
         fn upcast(&self) -> &(dyn source::Db + 'static) {
+            self
+        }
+    }
+
+    impl Upcast<dyn hir::Db> for TestDb {
+        fn upcast(&self) -> &(dyn hir::Db + 'static) {
             self
         }
     }

--- a/crates/red_knot/src/salsa_db/hir.rs
+++ b/crates/red_knot/src/salsa_db/hir.rs
@@ -1,7 +1,552 @@
+use std::fmt::Formatter;
+use std::ops::{Deref, Range};
+use std::sync::Arc;
+
+use rustc_hash::FxHashMap;
+
+use ruff_index::{newtype_index, IndexSlice, IndexVec};
+use ruff_python_ast::{BoolOp, Expr, ModModule, Operator, Stmt, StmtClassDef, StmtFunctionDef};
+use ruff_python_parser::Parsed;
+
 use crate::db::Upcast;
 use crate::salsa_db::source;
+use crate::Name;
+
+use super::source::File;
+
+#[salsa::tracked(jar=Jar)]
+pub struct Function {
+    pub file: File,
+
+    pub parent: WithBody,
+
+    #[return_ref]
+    pub name: Name,
+}
+
+#[salsa::tracked(jar=Jar)]
+pub struct Class {
+    pub file: File,
+
+    pub parent: WithBody,
+
+    #[return_ref]
+    pub name: Name,
+}
+
+#[salsa::tracked(jar=Jar)]
+pub struct Body {
+    #[return_ref]
+    pub ast: BodyAst,
+
+    #[return_ref]
+    pub source_map: BodySourceMap,
+}
+
+pub trait HastNode {
+    type AstNode;
+
+    fn ast_node(&self, db: &dyn Db) -> AstNodeRef<Self::AstNode>;
+}
+
+impl HastNode for Function {
+    type AstNode = ruff_python_ast::StmtFunctionDef;
+
+    fn ast_node(&self, db: &dyn Db) -> AstNodeRef<Self::AstNode> {
+        let parent = self.parent(db);
+        let parent_body = parent.body(db);
+
+        let parent_source_map = parent_body.source_map(db);
+        parent_source_map[*self].clone()
+    }
+}
+
+impl HastNode for Class {
+    type AstNode = ruff_python_ast::StmtClassDef;
+
+    fn ast_node(&self, db: &dyn Db) -> AstNodeRef<Self::AstNode> {
+        let parent = self.parent(db);
+        let parent_body = parent.body(db);
+
+        let parent_source_map = parent_body.source_map(db);
+        parent_source_map[*self].clone()
+    }
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct BodyAst {
+    statements: IndexVec<StatementId, Statement>,
+    expressions: IndexVec<ExpressionId, Expression>,
+}
+
+impl BodyAst {
+    pub fn statements(&self) -> &IndexSlice<StatementId, Statement> {
+        &self.statements
+    }
+
+    fn shrink_to_fit(&mut self) {
+        self.statements.shrink_to_fit();
+        self.expressions.shrink_to_fit();
+    }
+}
+
+impl std::ops::Index<ExpressionId> for BodyAst {
+    type Output = Expression;
+
+    #[inline]
+    fn index(&self, index: ExpressionId) -> &Self::Output {
+        &self.expressions[index]
+    }
+}
+
+impl std::ops::Index<Range<ExpressionId>> for BodyAst {
+    type Output = [Expression];
+
+    #[inline]
+    fn index(&self, index: Range<ExpressionId>) -> &Self::Output {
+        &self.expressions[index]
+    }
+}
+
+impl std::ops::Index<StatementId> for BodyAst {
+    type Output = Statement;
+
+    #[inline]
+    fn index(&self, index: StatementId) -> &Self::Output {
+        &self.statements[index]
+    }
+}
+
+#[derive(Default, Debug, PartialEq, Eq)]
+pub struct BodySourceMap {
+    // TODO: use typed node key or similar here
+    statements_map: IndexVec<StatementId, AstNodeRef<Stmt>>,
+    expressions_map: IndexVec<ExpressionId, AstNodeRef<Expr>>,
+
+    functions_map: FxHashMap<Function, AstNodeRef<StmtFunctionDef>>,
+    class_map: FxHashMap<Class, AstNodeRef<StmtClassDef>>,
+}
+
+impl BodySourceMap {
+    fn shrink_to_fit(&mut self) {
+        self.statements_map.shrink_to_fit();
+        self.expressions_map.shrink_to_fit();
+        self.functions_map.shrink_to_fit();
+        self.class_map.shrink_to_fit();
+    }
+}
+
+impl std::ops::Index<ExpressionId> for BodySourceMap {
+    type Output = AstNodeRef<Expr>;
+
+    #[inline]
+    fn index(&self, index: ExpressionId) -> &Self::Output {
+        &self.expressions_map[index]
+    }
+}
+
+impl std::ops::Index<StatementId> for BodySourceMap {
+    type Output = AstNodeRef<Stmt>;
+
+    #[inline]
+    fn index(&self, index: StatementId) -> &Self::Output {
+        &self.statements_map[index]
+    }
+}
+
+impl std::ops::Index<Function> for BodySourceMap {
+    type Output = AstNodeRef<StmtFunctionDef>;
+
+    #[inline]
+    fn index(&self, index: Function) -> &Self::Output {
+        &self.functions_map[&index]
+    }
+}
+
+impl std::ops::Index<Class> for BodySourceMap {
+    type Output = AstNodeRef<StmtClassDef>;
+
+    #[inline]
+    fn index(&self, index: Class) -> &Self::Output {
+        &self.class_map[&index]
+    }
+}
+
+#[newtype_index]
+pub struct StatementId;
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum Statement {
+    If {
+        test: ExpressionId,
+        body: Range<StatementId>,
+        // FIXME elif_else_clause
+    },
+    Raise {
+        exception: Option<ExpressionId>,
+        cause: Option<ExpressionId>,
+    },
+    Assert {
+        test: ExpressionId,
+        msg: Option<ExpressionId>,
+    },
+    Pass,
+    Break,
+    Continue,
+    While {
+        test: ExpressionId,
+        body: Range<StatementId>,
+        or_else: Range<StatementId>,
+    },
+    For {
+        is_async: bool,
+        target: ExpressionId,
+        iterator: ExpressionId,
+        body: Range<StatementId>,
+        or_else: Range<StatementId>,
+    },
+    Assignment {
+        targets: Range<ExpressionId>,
+        value: ExpressionId,
+    },
+    AnnotatedAssignment {
+        target: ExpressionId,
+        annotation: ExpressionId,
+        value: Option<ExpressionId>,
+        simple: bool,
+    },
+    AugmentedAssignment {
+        target: ExpressionId,
+        op: Operator,
+        value: ExpressionId,
+    },
+    Delete {
+        targets: Range<ExpressionId>,
+    },
+    Return {
+        value: Option<ExpressionId>,
+    },
+    Function(Function),
+    Class(Class),
+    Expression(ExpressionId),
+}
+
+#[newtype_index]
+pub struct ExpressionId;
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum Expression {
+    BoolOp {
+        op: BoolOp,
+        values: Range<ExpressionId>,
+    },
+
+    Call {
+        func: ExpressionId,
+    },
+
+    Name(Name),
+    NoneLiteral,
+    BooleanLiteral(bool),
+}
+
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+pub enum WithBody {
+    Function(Function),
+    Class(Class),
+    Module(File),
+}
+
+impl WithBody {
+    pub fn body(self, db: &dyn Db) -> Body {
+        match self {
+            WithBody::Function(function) => function_body(db, function),
+            WithBody::Module(module) => module_body(db, module),
+            WithBody::Class(_) => todo!(),
+        }
+    }
+
+    pub fn file(self, db: &dyn Db) -> File {
+        match self {
+            WithBody::Module(file) => file,
+            WithBody::Function(function) => function.file(db),
+            WithBody::Class(class) => class.file(db),
+        }
+    }
+}
+
+// I wonder if we should build the entire HIR in a single pass
+// That would also simplify looking up the `FunctionLoc`
+//
+#[salsa::tracked(jar=Jar)]
+pub fn module_body(db: &dyn Db, file: File) -> Body {
+    BodyBuilder::lower_module(db, file)
+}
+
+#[salsa::tracked(jar=Jar)]
+pub fn function_body(db: &dyn Db, function: Function) -> Body {
+    BodyBuilder::lower_function_body(db, function)
+}
+
+// TODO rust analyzer defines something like AssocItemLoc
+// which stores the ItemTreeId with the ItemId. In our case
+// it would be BodyId + FunctionId.
+// Main challenge, we don't know the body id just yet.
 
 #[salsa::jar(db=Db)]
-pub struct Jar();
+pub struct Jar(Function, Class, Body, function_body, module_body);
 
 pub trait Db: source::Db + salsa::DbWithJar<Jar> + Upcast<dyn source::Db> {}
+
+#[derive(Clone)]
+pub struct AstNodeRef<T> {
+    /// Holds on to the root to ensure that the parsed AST isn't dropped.
+    /// That guarantees us that, for as long as the parsed AST isn't dropped, the pointer
+    /// to the node must remain valid too.
+    _root: Arc<Parsed<ModModule>>,
+    node: std::ptr::NonNull<T>,
+}
+#[allow(unsafe_code)]
+impl<T> AstNodeRef<T> {
+    /// ## Safety
+    /// The caller must ensure that `node` is part of the `parsed` syntax tree.
+    pub unsafe fn new(node: &T, parsed: Arc<Parsed<ModModule>>) -> Self {
+        Self {
+            _root: parsed,
+            node: std::ptr::NonNull::from(node),
+        }
+    }
+
+    pub fn node(&self) -> &T {
+        // SAFETY: Holding a reference to the root ensures that the child
+        // node can't be dropped.
+
+        unsafe { self.node.as_ref() }
+    }
+}
+
+impl<T> Deref for AstNodeRef<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        self.node()
+    }
+}
+
+impl<T> PartialEq for AstNodeRef<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.node == other.node
+    }
+}
+
+impl<T> Eq for AstNodeRef<T> {}
+
+impl<T: std::fmt::Debug> std::fmt::Debug for AstNodeRef<T> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("AstNodeRef").field(self.node()).finish()
+    }
+}
+
+#[allow(unsafe_code)]
+unsafe impl<T: Send + Sync> Send for AstNodeRef<T> {}
+#[allow(unsafe_code)]
+unsafe impl<T: Send + Sync> Sync for AstNodeRef<T> {}
+
+pub struct BodyBuilder<'db> {
+    db: &'db dyn Db,
+    ast: BodyAst,
+    parent: WithBody,
+    file: File,
+    parsed: Arc<Parsed<ModModule>>,
+    source_map: BodySourceMap,
+}
+
+impl<'db> BodyBuilder<'db> {
+    fn lower_function_body(db: &'db dyn Db, function: Function) -> Body {
+        let file = function.file(db);
+        let parsed = source::parse(db.upcast(), file);
+        let function_node = function.ast_node(db);
+
+        let mut builder = Self {
+            db,
+            file,
+            parent: WithBody::Function(function),
+            parsed,
+            ast: BodyAst::default(),
+            source_map: BodySourceMap::default(),
+        };
+
+        builder.lower_suite(&function_node.body);
+
+        builder.finish()
+    }
+
+    fn lower_module(db: &'db dyn Db, file: File) -> Body {
+        let parsed = source::parse(db.upcast(), file);
+        let module = parsed.syntax();
+
+        let mut builder = Self {
+            db,
+            file,
+            parent: WithBody::Module(file),
+            parsed: parsed.clone(),
+            ast: BodyAst::default(),
+            source_map: BodySourceMap::default(),
+        };
+
+        builder.lower_suite(&module.body);
+
+        builder.finish()
+    }
+
+    fn lower_statement(&mut self, stmt: &Stmt) -> StatementId {
+        let statement = match stmt {
+            Stmt::If(if_stmt) => Statement::If {
+                test: self.lower_expression(&if_stmt.test),
+                body: self.lower_suite(&if_stmt.body),
+            },
+            Stmt::While(while_stmt) => Statement::While {
+                test: self.lower_expression(&while_stmt.test),
+                body: self.lower_suite(&while_stmt.body),
+                or_else: self.lower_suite(&while_stmt.orelse),
+            },
+            Stmt::For(for_stmt) => Statement::For {
+                is_async: for_stmt.is_async,
+                target: self.lower_expression(&for_stmt.target),
+                iterator: self.lower_expression(&for_stmt.iter),
+                body: self.lower_suite(&for_stmt.body),
+                or_else: self.lower_suite(&for_stmt.orelse),
+            },
+            Stmt::Assign(assign) => Statement::Assignment {
+                targets: self.lower_expressions(&assign.targets),
+                value: self.lower_expression(&assign.value),
+            },
+            Stmt::AnnAssign(assign) => Statement::AnnotatedAssignment {
+                target: self.lower_expression(&assign.target),
+                annotation: self.lower_expression(&assign.annotation),
+                value: assign
+                    .value
+                    .as_ref()
+                    .map(|expr| self.lower_expression(expr)),
+                simple: assign.simple,
+            },
+            Stmt::AugAssign(assign) => Statement::AugmentedAssignment {
+                target: self.lower_expression(&assign.target),
+                op: assign.op,
+                value: self.lower_expression(&assign.value),
+            },
+            Stmt::Delete(delete) => Statement::Delete {
+                targets: self.lower_expressions(&delete.targets),
+            },
+            Stmt::Return(return_stmt) => Statement::Return {
+                value: return_stmt
+                    .value
+                    .as_ref()
+                    .map(|expr| self.lower_expression(expr)),
+            },
+            Stmt::Raise(raise) => Statement::Raise {
+                exception: raise.exc.as_ref().map(|expr| self.lower_expression(expr)),
+                cause: raise.cause.as_ref().map(|expr| self.lower_expression(expr)),
+            },
+            Stmt::FunctionDef(function_def) => {
+                let function = Function::new(
+                    self.db,
+                    self.file,
+                    self.parent,
+                    Name::new(&function_def.name),
+                );
+                #[allow(unsafe_code)]
+                self.source_map.functions_map.insert(function, unsafe {
+                    AstNodeRef::new(function_def, self.parsed.clone())
+                });
+
+                Statement::Function(function)
+            }
+
+            Stmt::ClassDef(class_def) => {
+                let class = Class::new(self.db, self.file, self.parent, Name::new(&class_def.name));
+                #[allow(unsafe_code)]
+                self.source_map.class_map.insert(class, unsafe {
+                    AstNodeRef::new(class_def, self.parsed.clone())
+                });
+
+                Statement::Class(class)
+            }
+            Stmt::Pass(_) => Statement::Pass,
+            Stmt::Break(_) => Statement::Break,
+            Stmt::Continue(_) => Statement::Continue,
+
+            _ => todo!(),
+        };
+
+        let statement_id = self.ast.statements.push(statement);
+        #[allow(unsafe_code)]
+        let source_map_id = self
+            .source_map
+            .statements_map
+            .push(unsafe { AstNodeRef::new(stmt, self.parsed.clone()) });
+
+        debug_assert_eq!(statement_id, source_map_id);
+
+        statement_id
+    }
+
+    fn lower_suite(&mut self, stmts: &[Stmt]) -> Range<StatementId> {
+        let start = self.ast.statements.next_index();
+
+        for statement in stmts {
+            self.lower_statement(statement);
+        }
+
+        Range {
+            start,
+            end: self.ast.statements.next_index(),
+        }
+    }
+
+    fn lower_expression(&mut self, expr: &Expr) -> ExpressionId {
+        let expression = match expr {
+            Expr::BoolOp(bool_op) => Expression::BoolOp {
+                op: bool_op.op,
+                values: self.lower_expressions(&bool_op.values),
+            },
+            Expr::Call(call) => Expression::Call {
+                func: self.lower_expression(&call.func),
+            },
+            Expr::NoneLiteral(_) => Expression::NoneLiteral,
+            Expr::BooleanLiteral(bool) => Expression::BooleanLiteral(bool.value),
+            Expr::Name(name) => Expression::Name(Name::new(&name.id)),
+            _ => todo!(),
+        };
+
+        let expression_id = self.ast.expressions.push(expression);
+        #[allow(unsafe_code)]
+        let source_map_id = self
+            .source_map
+            .expressions_map
+            .push(unsafe { AstNodeRef::new(expr, self.parsed.clone()) });
+        debug_assert_eq!(expression_id, source_map_id);
+
+        expression_id
+    }
+
+    fn lower_expressions(&mut self, exprs: &[Expr]) -> Range<ExpressionId> {
+        let start = self.ast.expressions.next_index();
+
+        for expr in exprs {
+            self.lower_expression(expr);
+        }
+
+        Range {
+            start,
+            end: self.ast.expressions.next_index(),
+        }
+    }
+
+    fn finish(mut self) -> Body {
+        self.ast.shrink_to_fit();
+        self.source_map.shrink_to_fit();
+
+        Body::new(self.db, self.ast, self.source_map)
+    }
+}

--- a/crates/red_knot/src/salsa_db/hir.rs
+++ b/crates/red_knot/src/salsa_db/hir.rs
@@ -1,0 +1,7 @@
+use crate::db::Upcast;
+use crate::salsa_db::source;
+
+#[salsa::jar(db=Db)]
+pub struct Jar();
+
+pub trait Db: source::Db + salsa::DbWithJar<Jar> + Upcast<dyn source::Db> {}

--- a/crates/red_knot/src/salsa_db/lint.rs
+++ b/crates/red_knot/src/salsa_db/lint.rs
@@ -1,0 +1,74 @@
+use crate::db::Upcast;
+use crate::salsa_db::source::File;
+use crate::salsa_db::{semantic, source};
+use ruff_python_ast::visitor::Visitor;
+use ruff_python_ast::Expr;
+use tracing::warn;
+
+#[salsa::tracked(jar=Jar)]
+pub struct SyntaxCheck {
+    #[returned_ref]
+    pub diagnostics: Vec<String>,
+}
+
+#[salsa::tracked(jar=Jar)]
+pub struct PhysicalLinesCheck {
+    #[returned_ref]
+    pub diagnostics: Vec<String>,
+}
+
+#[tracing::instrument(level = "debug", skip(db))]
+#[salsa::tracked(jar=Jar)]
+pub fn check_syntax(db: &dyn Db, file: File) -> SyntaxCheck {
+    // TODO I haven't looked into how many rules are pure syntax checks.
+    //   It may be necessary to at least give access to a simplified semantic model.
+    struct SyntaxChecker {
+        diagnostics: Vec<String>,
+    }
+
+    impl Visitor<'_> for SyntaxChecker {
+        fn visit_expr(&mut self, expr: &'_ Expr) {
+            if let Expr::Name(name) = expr {
+                if &name.id == "a" {
+                    self.diagnostics.push("Use of name a".to_string());
+                }
+            }
+        }
+    }
+
+    let parsed = source::parse(db.upcast(), file);
+
+    let mut visitor = SyntaxChecker {
+        diagnostics: Vec::new(),
+    };
+
+    visitor.visit_body(&parsed.ast().body);
+
+    SyntaxCheck::new(db, visitor.diagnostics)
+}
+
+#[tracing::instrument(level = "debug", skip(db))]
+#[salsa::tracked(jar=Jar)]
+pub fn check_physical_lines(db: &dyn Db, file: File) -> PhysicalLinesCheck {
+    let source = file.source(db.upcast());
+    let text = source.text();
+
+    let mut diagnostics = Vec::new();
+    for (line_number, line) in text.lines().enumerate() {
+        if line.chars().count() > 88 {
+            diagnostics.push(format!("Line {} too long", line_number + 1));
+        }
+    }
+
+    PhysicalLinesCheck::new(db, diagnostics)
+}
+
+#[salsa::jar(db=Db)]
+pub struct Jar(
+    PhysicalLinesCheck,
+    SyntaxCheck,
+    check_physical_lines,
+    check_syntax,
+);
+
+pub trait Db: semantic::Db + salsa::DbWithJar<Jar> + Upcast<dyn semantic::Db> {}

--- a/crates/red_knot/src/salsa_db/lint.rs
+++ b/crates/red_knot/src/salsa_db/lint.rs
@@ -77,7 +77,7 @@ pub fn check_syntax(db: &dyn Db, file: File) -> SyntaxCheck {
         diagnostics: Vec::new(),
     };
 
-    visitor.visit_body(&parsed.ast().body);
+    visitor.visit_body(&parsed.syntax().body);
 
     SyntaxCheck::new(visitor.diagnostics)
 }

--- a/crates/red_knot/src/salsa_db/semantic.rs
+++ b/crates/red_knot/src/salsa_db/semantic.rs
@@ -18,8 +18,8 @@ use crate::module::ModuleName;
 use crate::salsa_db::semantic::module::{
     file_to_module, Module, ModuleSearchPaths, ResolvedModule,
 };
-use crate::salsa_db::source;
 use crate::salsa_db::source::File;
+use crate::salsa_db::{hir, source};
 use crate::symbols::Dependency;
 
 pub use self::module::resolve_module;
@@ -198,4 +198,4 @@ pub struct Jar(
     file_to_module,
 );
 
-pub trait Db: source::Db + salsa::DbWithJar<Jar> + Upcast<dyn source::Db> {}
+pub trait Db: hir::Db + salsa::DbWithJar<Jar> + Upcast<dyn hir::Db> {}

--- a/crates/red_knot/src/salsa_db/semantic.rs
+++ b/crates/red_knot/src/salsa_db/semantic.rs
@@ -98,7 +98,7 @@ pub fn dependencies(db: &dyn Db, file: File) -> Arc<[ModuleName]> {
                     if let Some(level) = NonZeroU32::new(from.level) {
                         // FIXME how to handle dependencies if the current file isn't a module?
                         //  e.g. what if the current file is a jupyter notebook. We should still be able to resolve files somehow.
-                        if let Some(resolved_module) = self.resolved_module {
+                        if let Some(resolved_module) = &self.resolved_module {
                             if let Some(dependency) = resolved_module.resolve_dependency(
                                 self.db,
                                 &Dependency::Relative {
@@ -191,7 +191,6 @@ pub struct Jar(
     ModuleSearchPaths,
     Symbol,
     Module,
-    ResolvedModule,
     dependencies,
     symbol_table,
     ast_ids,

--- a/crates/red_knot/src/salsa_db/semantic.rs
+++ b/crates/red_knot/src/salsa_db/semantic.rs
@@ -132,7 +132,7 @@ pub fn dependencies(db: &dyn Db, file: File) -> Arc<[ModuleName]> {
     };
 
     // TODO change the visitor so that `visit_mod` accepts a `ModRef` node that we can construct from module.
-    visitor.visit_body(&parsed.ast().body);
+    visitor.visit_body(&parsed.syntax().body);
 
     Arc::from(visitor.dependencies)
 
@@ -173,7 +173,7 @@ pub fn symbol_table(db: &dyn Db, file_id: File) -> Arc<SymbolTable> {
         symbols: SymbolTable::default(),
     };
 
-    visitor.visit_body(&parsed.ast().body);
+    visitor.visit_body(&parsed.syntax().body);
 
     Arc::new(visitor.symbols)
 }
@@ -183,7 +183,7 @@ pub fn symbol_table(db: &dyn Db, file_id: File) -> Arc<SymbolTable> {
 pub fn ast_ids(db: &dyn Db, file: File) -> Arc<AstIds> {
     let parsed = source::parse(db.upcast(), file);
 
-    Arc::new(AstIds::from_module(parsed.ast()))
+    Arc::new(AstIds::from_module(parsed.syntax()))
 }
 
 #[salsa::jar(db=Db)]

--- a/crates/red_knot/src/salsa_db/semantic.rs
+++ b/crates/red_knot/src/salsa_db/semantic.rs
@@ -1,0 +1,202 @@
+use std::fmt::Formatter;
+use std::num::NonZeroU32;
+use std::sync::Arc;
+
+use countme::Count;
+use rustc_hash::FxHashMap;
+use salsa::database::AsSalsaDatabase;
+use salsa::DebugWithDb;
+use tracing::warn;
+
+use ruff_python_ast::visitor::preorder;
+use ruff_python_ast::visitor::preorder::{PreorderVisitor, TraversalSignal};
+use ruff_python_ast::{AnyNodeRef, Expr, Stmt};
+
+use crate::ast_ids::AstIds;
+use crate::db::Upcast;
+use crate::module::ModuleName;
+use crate::salsa_db::semantic::module::{
+    file_to_module, Module, ModuleSearchPaths, ResolvedModule,
+};
+use crate::salsa_db::source;
+use crate::salsa_db::source::File;
+use crate::symbols::Dependency;
+
+pub use self::module::resolve_module;
+
+pub mod module;
+
+#[salsa::tracked(jar=Jar)]
+pub struct Symbol {
+    #[id]
+    #[returned_ref]
+    pub name: smol_str::SmolStr,
+
+    count: Count<Symbol>,
+}
+
+#[derive(Eq, PartialEq, Default)]
+pub struct SymbolTable {
+    symbols: FxHashMap<smol_str::SmolStr, Symbol>,
+}
+
+impl SymbolTable {
+    fn insert(&mut self, name: smol_str::SmolStr, symbol: Symbol) {
+        self.symbols.insert(name, symbol);
+    }
+}
+
+impl std::fmt::Debug for SymbolTable {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        self.symbols.fmt(f)
+    }
+}
+
+impl<Db> DebugWithDb<Db> for SymbolTable
+where
+    Db: AsSalsaDatabase + self::Db,
+{
+    fn fmt(&self, f: &mut Formatter<'_>, db: &Db) -> std::fmt::Result {
+        let mut map = f.debug_map();
+
+        for (name, symbol) in &self.symbols {
+            map.entry(name, &symbol.debug(db));
+        }
+        map.finish()
+    }
+}
+
+#[tracing::instrument(level = "debug", skip(db))]
+#[salsa::tracked(jar=Jar)]
+pub fn dependencies(db: &dyn Db, file: File) -> Arc<[ModuleName]> {
+    struct DependenciesVisitor<'a> {
+        db: &'a dyn Db,
+        resolved_module: Option<ResolvedModule>,
+        dependencies: Vec<ModuleName>,
+    }
+
+    // TODO support package imports
+    impl PreorderVisitor<'_> for DependenciesVisitor<'_> {
+        fn enter_node(&mut self, node: AnyNodeRef) -> TraversalSignal {
+            // Don't traverse into expressions
+            if node.is_expression() {
+                return TraversalSignal::Skip;
+            }
+
+            TraversalSignal::Traverse
+        }
+
+        fn visit_stmt(&mut self, stmt: &Stmt) {
+            match stmt {
+                Stmt::Import(import) => {
+                    for alias in &import.names {
+                        self.dependencies.push(ModuleName::new(&alias.name));
+                    }
+                }
+
+                Stmt::ImportFrom(from) => {
+                    if let Some(level) = NonZeroU32::new(from.level) {
+                        // FIXME how to handle dependencies if the current file isn't a module?
+                        //  e.g. what if the current file is a jupyter notebook. We should still be able to resolve files somehow.
+                        if let Some(resolved_module) = self.resolved_module {
+                            if let Some(dependency) = resolved_module.resolve_dependency(
+                                self.db,
+                                &Dependency::Relative {
+                                    module: from
+                                        .module
+                                        .as_ref()
+                                        .map(|module| ModuleName::new(module)),
+                                    level,
+                                },
+                            ) {
+                                self.dependencies.push(dependency);
+                            };
+                        }
+                    } else {
+                        let module = from.module.as_ref().unwrap();
+                        self.dependencies.push(ModuleName::new(module));
+                    }
+                }
+                _ => {}
+            }
+            preorder::walk_stmt(self, stmt);
+        }
+    }
+
+    let parsed = source::parse(db.upcast(), file);
+
+    let mut visitor = DependenciesVisitor {
+        db,
+        resolved_module: file_to_module(db, file),
+        dependencies: Vec::new(),
+    };
+
+    // TODO change the visitor so that `visit_mod` accepts a `ModRef` node that we can construct from module.
+    visitor.visit_body(&parsed.ast().body);
+
+    Arc::from(visitor.dependencies)
+
+    // TODO we should extract the names of dependencies during parsing to avoid an extra traversal here.
+}
+
+#[tracing::instrument(level = "debug", skip(db))]
+#[salsa::tracked(jar=Jar)]
+pub fn symbol_table(db: &dyn Db, file_id: File) -> Arc<SymbolTable> {
+    struct SymbolTableVisitor<'db> {
+        symbols: SymbolTable,
+        db: &'db dyn Db,
+    }
+
+    impl PreorderVisitor<'_> for SymbolTableVisitor<'_> {
+        fn visit_stmt(&mut self, stmt: &'_ Stmt) {
+            #[allow(clippy::single_match)]
+            match stmt {
+                Stmt::Assign(assign) => {
+                    for target in &assign.targets {
+                        if let Expr::Name(name) = &target {
+                            let name = smol_str::SmolStr::new(&name.id);
+                            self.symbols
+                                .insert(name.clone(), Symbol::new(self.db, name, Count::default()));
+                        }
+                    }
+                }
+                _ => {}
+            }
+
+            preorder::walk_stmt(self, stmt);
+        }
+    }
+
+    let parsed = source::parse(db.upcast(), file_id);
+    let mut visitor = SymbolTableVisitor {
+        db,
+        symbols: SymbolTable::default(),
+    };
+
+    visitor.visit_body(&parsed.ast().body);
+
+    Arc::new(visitor.symbols)
+}
+
+#[tracing::instrument(level = "debug", skip(db))]
+#[salsa::tracked(jar=Jar)]
+pub fn ast_ids(db: &dyn Db, file: File) -> Arc<AstIds> {
+    let parsed = source::parse(db.upcast(), file);
+
+    Arc::new(AstIds::from_module(parsed.ast()))
+}
+
+#[salsa::jar(db=Db)]
+pub struct Jar(
+    ModuleSearchPaths,
+    Symbol,
+    Module,
+    ResolvedModule,
+    dependencies,
+    symbol_table,
+    ast_ids,
+    resolve_module,
+    file_to_module,
+);
+
+pub trait Db: source::Db + salsa::DbWithJar<Jar> + Upcast<dyn source::Db> {}

--- a/crates/red_knot/src/salsa_db/semantic/module.rs
+++ b/crates/red_knot/src/salsa_db/semantic/module.rs
@@ -1,0 +1,874 @@
+use std::fmt::Formatter;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use crate::module::ModuleName;
+use crate::salsa_db::source::File;
+use crate::symbols::Dependency;
+
+use super::Db;
+use super::Jar;
+
+/// ID uniquely identifying a module.
+#[salsa::interned(jar=Jar)]
+pub struct Module {
+    #[return_ref]
+    name: ModuleName,
+}
+
+#[salsa::tracked(jar=Jar)]
+pub struct ResolvedModule {
+    #[id]
+    #[return_ref]
+    name: ModuleName,
+    kind: ModuleKind,
+    search_path: ModuleSearchPath,
+    file: File,
+}
+
+impl ResolvedModule {
+    pub fn resolve_dependency(self, db: &dyn Db, dependency: &Dependency) -> Option<ModuleName> {
+        let (level, module) = match dependency {
+            // FIXME use clone here
+            Dependency::Module(module) => return Some(ModuleName::new(module)),
+            Dependency::Relative { level, module } => (*level, module.as_deref()),
+        };
+
+        let mut components = self.name(db).components().peekable();
+
+        let start = match self.kind(db) {
+            // `.` resolves to the enclosing package
+            ModuleKind::Module => 0,
+            // `.` resolves to the current package
+            ModuleKind::Package => 1,
+        };
+
+        // Skip over the relative parts.
+        for _ in start..level.get() {
+            components.next_back()?;
+        }
+
+        let mut name = String::new();
+
+        for part in components.chain(module) {
+            if !name.is_empty() {
+                name.push('.');
+            }
+
+            name.push_str(part);
+        }
+
+        if name.is_empty() {
+            None
+        } else {
+            Some(ModuleName::new(&name))
+        }
+    }
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+pub enum ModuleKind {
+    Module,
+
+    /// A python package (a `__init__.py` or `__init__.pyi` file)
+    Package,
+}
+
+/// A search path in which to search modules.
+/// Corresponds to a path in [`sys.path`](https://docs.python.org/3/library/sys_path_init.html) at runtime.
+///
+/// Cloning a search path is cheap because it's an `Arc`.
+#[derive(Clone, PartialEq, Eq)]
+pub struct ModuleSearchPath {
+    inner: Arc<ModuleSearchPathInner>,
+}
+
+impl ModuleSearchPath {
+    #[allow(unused)]
+    pub fn new(path: PathBuf, kind: ModuleSearchPathKind) -> Self {
+        Self {
+            inner: Arc::new(ModuleSearchPathInner { path, kind }),
+        }
+    }
+
+    #[allow(unused)]
+    pub fn kind(&self) -> ModuleSearchPathKind {
+        self.inner.kind
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.inner.path
+    }
+}
+
+impl std::fmt::Debug for ModuleSearchPath {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        self.inner.fmt(f)
+    }
+}
+
+#[derive(Debug, Eq, PartialEq)]
+struct ModuleSearchPathInner {
+    path: PathBuf,
+    kind: ModuleSearchPathKind,
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+#[allow(unused)]
+pub enum ModuleSearchPathKind {
+    // Project dependency
+    FirstParty,
+
+    // e.g. site packages
+    ThirdParty,
+
+    // e.g. built-in modules, typeshed
+    #[allow(unused)]
+    StandardLibrary,
+}
+
+impl ModuleSearchPathKind {
+    #[allow(unused)]
+    pub const fn is_first_party(self) -> bool {
+        matches!(self, Self::FirstParty)
+    }
+}
+/// ID uniquely identifying a module.
+#[salsa::input(jar=Jar, singleton)]
+pub struct ModuleSearchPaths {
+    #[return_ref]
+    pub paths: Vec<ModuleSearchPath>,
+}
+
+pub fn module_search_paths(db: &dyn Db) -> &[ModuleSearchPath] {
+    ModuleSearchPaths::get(db).paths(db).as_slice()
+}
+
+/// Changes the module search paths to `search_paths`.
+#[allow(unused)]
+pub fn set_module_search_paths(db: &mut dyn Db, search_paths: Vec<ModuleSearchPath>) {
+    if let Some(existing) = ModuleSearchPaths::try_get(db) {
+        existing.set_paths(db).to(search_paths);
+    } else {
+        ModuleSearchPaths::new(db, search_paths);
+    }
+}
+
+#[allow(unused)]
+pub fn resolve_module_name(db: &dyn Db, name: ModuleName) -> Option<ResolvedModule> {
+    resolve_module(db, Module::new(db, name))
+}
+
+/// Resolves a module name to a module id
+#[tracing::instrument(level = "debug", skip(db))]
+#[salsa::tracked(jar=Jar)]
+pub fn resolve_module(db: &dyn Db, module: Module) -> Option<ResolvedModule> {
+    let name = module.name(db);
+
+    let (root_path, resolved_file, kind) = resolve_module_path(db, name)?;
+
+    let normalized = resolved_file
+        .path(db.upcast())
+        .canonicalize()
+        .map(|path| db.file(path))
+        .unwrap_or_else(|_| resolved_file);
+
+    Some(ResolvedModule::new(
+        db,
+        name.clone(),
+        kind,
+        root_path,
+        normalized,
+    ))
+}
+
+/// Resolves the module id for the given path.
+///
+/// Returns `None` if the path is not a module in `sys.path`.
+#[tracing::instrument(level = "debug", skip(db))]
+pub fn path_to_module(db: &dyn Db, path: &Path) -> Option<ResolvedModule> {
+    let file = db.file(path.to_path_buf());
+    file_to_module(db, file)
+}
+
+/// Resolves the module id for the file with the given id.
+#[tracing::instrument(level = "debug", skip(db))]
+#[salsa::tracked(jar=Jar)]
+pub fn file_to_module(db: &dyn Db, file: File) -> Option<ResolvedModule> {
+    let path = file.path(db.upcast());
+    debug_assert!(path.is_absolute());
+
+    let (root_path, relative_path) = module_search_paths(db).iter().find_map(|root| {
+        let relative_path = path.strip_prefix(root.path()).ok()?;
+        Some((root.clone(), relative_path))
+    })?;
+
+    let module_name = ModuleName::from_relative_path(relative_path)?;
+
+    // Resolve the module name to see if Python would resolve the name to the same path.
+    // If it doesn't, then that means that multiple modules have the same in different
+    // root paths, but that the module corresponding to the past path is in a lower priority path,
+    // in which case we ignore it.
+    let module = resolve_module(db, Module::new(db, module_name))?;
+
+    if module.search_path(db) == root_path {
+        let normalized = path
+            .canonicalize()
+            .map(|path| db.file(path))
+            .unwrap_or(file);
+
+        if normalized != module.file(db) {
+            // This path is for a module with the same name but with a different precedence. For example:
+            // ```
+            // src/foo.py
+            // src/foo/__init__.py
+            // ```
+            // The module name of `src/foo.py` is `foo`, but the module loaded by Python is `src/foo/__init__.py`.
+            // That means we need to ignore `src/foo.py` even though it resolves to the same module name.
+            return None;
+        }
+
+        Some(module)
+    } else {
+        // This path is for a module with the same name but in a module search path with a lower priority.
+        // Ignore it.
+        None
+    }
+}
+
+fn resolve_module_path(
+    db: &dyn Db,
+    name: &ModuleName,
+) -> Option<(ModuleSearchPath, File, ModuleKind)> {
+    let search_paths = module_search_paths(db);
+
+    for search_path in search_paths {
+        let mut components = name.components();
+        let module_name = components.next_back()?;
+
+        match resolve_package(db, search_path, components) {
+            Ok(resolved_package) => {
+                let mut package_path = resolved_package.path;
+
+                package_path.push(module_name);
+
+                // Must be a `__init__.pyi` or `__init__.py` or it isn't a package.
+                let kind = if package_path.is_dir() {
+                    package_path.push("__init__");
+                    ModuleKind::Package
+                } else {
+                    ModuleKind::Module
+                };
+
+                // TODO Implement full https://peps.python.org/pep-0561/#type-checker-module-resolution-order resolution
+                let stub = db.file(package_path.with_extension("pyi"));
+
+                if stub.exists(db.upcast()) {
+                    return Some((search_path.clone(), stub, kind));
+                }
+
+                let module = db.file(package_path.with_extension("py"));
+
+                if module.exists(db.upcast()) {
+                    return Some((search_path.clone(), module, kind));
+                }
+
+                // For regular packages, don't search the next search path. All files of that
+                // package must be in the same location
+                if resolved_package.kind.is_regular_package() {
+                    return None;
+                }
+            }
+            Err(parent_kind) => {
+                if parent_kind.is_regular_package() {
+                    // For regular packages, don't search the next search path.
+                    return None;
+                }
+            }
+        }
+    }
+
+    None
+}
+
+fn resolve_package<'a, I>(
+    db: &dyn Db,
+    module_search_path: &ModuleSearchPath,
+    components: I,
+) -> Result<ResolvedPackage, PackageKind>
+where
+    I: Iterator<Item = &'a str>,
+{
+    let mut package_path = module_search_path.path().to_path_buf();
+
+    // `true` if inside a folder that is a namespace package (has no `__init__.py`).
+    // Namespace packages are special because they can be spread across multiple search paths.
+    // https://peps.python.org/pep-0420/
+    let mut in_namespace_package = false;
+
+    // `true` if resolving a sub-package. For example, `true` when resolving `bar` of `foo.bar`.
+    let mut in_sub_package = false;
+
+    // For `foo.bar.baz`, test that `foo` and `baz` both contain a `__init__.py`.
+    for folder in components {
+        package_path.push(folder);
+
+        let has_init_py = db
+            .file(package_path.join("__init__.py"))
+            .exists(db.upcast())
+            || db
+                .file(package_path.join("__init__.pyi"))
+                .exists(db.upcast());
+
+        if has_init_py {
+            in_namespace_package = false;
+        } else if package_path.is_dir() {
+            // A directory without an `__init__.py` is a namespace package, continue with the next folder.
+            in_namespace_package = true;
+        } else if in_namespace_package {
+            // Package not found but it is part of a namespace package.
+            return Err(PackageKind::Namespace);
+        } else if in_sub_package {
+            // A regular sub package wasn't found.
+            return Err(PackageKind::Regular);
+        } else {
+            // We couldn't find `foo` for `foo.bar.baz`, search the next search path.
+            return Err(PackageKind::Root);
+        }
+
+        in_sub_package = true;
+    }
+
+    let kind = if in_namespace_package {
+        PackageKind::Namespace
+    } else if in_sub_package {
+        PackageKind::Regular
+    } else {
+        PackageKind::Root
+    };
+
+    Ok(ResolvedPackage {
+        kind,
+        path: package_path,
+    })
+}
+
+#[derive(Debug)]
+pub struct ResolvedPackage {
+    pub path: PathBuf,
+    pub kind: PackageKind,
+}
+
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+pub enum PackageKind {
+    /// A root package or module. E.g. `foo` in `foo.bar.baz` or just `foo`.
+    Root,
+
+    /// A regular sub-package where the parent contains an `__init__.py`. For example `bar` in `foo.bar` when the `foo` directory contains an `__init__.py`.
+    Regular,
+
+    /// A sub-package in a namespace package. A namespace package is a package without an `__init__.py`.
+    ///
+    /// For example, `bar` in `foo.bar` if the `foo` directory contains no `__init__.py`.
+    Namespace,
+}
+
+impl PackageKind {
+    pub const fn is_regular_package(self) -> bool {
+        matches!(self, PackageKind::Regular)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::salsa_db::source::Db;
+    use salsa::DebugWithDb;
+    use std::num::NonZeroU32;
+
+    use crate::salsa_db::tests::TestDb;
+    use crate::symbols::Dependency;
+
+    use super::{
+        path_to_module, resolve_module_name, set_module_search_paths, ModuleKind, ModuleName,
+        ModuleSearchPath, ModuleSearchPathKind,
+    };
+
+    struct TestCase {
+        temp_dir: tempfile::TempDir,
+        db: TestDb,
+
+        src: ModuleSearchPath,
+        site_packages: ModuleSearchPath,
+    }
+
+    fn create_resolver() -> std::io::Result<TestCase> {
+        let temp_dir = tempfile::tempdir()?;
+
+        let src = temp_dir.path().join("src");
+        let site_packages = temp_dir.path().join("site_packages");
+
+        std::fs::create_dir(&src)?;
+        std::fs::create_dir(&site_packages)?;
+
+        let src = ModuleSearchPath::new(src.canonicalize()?, ModuleSearchPathKind::FirstParty);
+        let site_packages = ModuleSearchPath::new(
+            site_packages.canonicalize()?,
+            ModuleSearchPathKind::ThirdParty,
+        );
+
+        let roots = vec![src.clone(), site_packages.clone()];
+
+        let mut db = TestDb::new();
+        set_module_search_paths(&mut db, roots);
+
+        Ok(TestCase {
+            temp_dir,
+            db,
+            src,
+            site_packages,
+        })
+    }
+
+    #[test]
+    fn first_party_module() -> anyhow::Result<()> {
+        let TestCase {
+            db,
+            src,
+            temp_dir: _temp_dir,
+            ..
+        } = create_resolver()?;
+
+        let foo_path = src.path().join("foo.py");
+        std::fs::write(&foo_path, "print('Hello, world!')")?;
+
+        let foo_module = resolve_module_name(&db, ModuleName::new("foo")).unwrap();
+
+        assert_eq!(
+            Some(foo_module),
+            resolve_module_name(&db, ModuleName::new("foo"))
+        );
+
+        assert_eq!(&ModuleName::new("foo"), foo_module.name(&db));
+        assert_eq!(src, foo_module.search_path(&db));
+        assert_eq!(ModuleKind::Module, foo_module.kind(&db));
+        assert_eq!(&foo_path, foo_module.file(&db).path(&db));
+
+        assert_eq!(Some(foo_module), path_to_module(&db, &foo_path));
+
+        Ok(())
+    }
+
+    #[test]
+    fn resolve_package() -> anyhow::Result<()> {
+        let TestCase {
+            src,
+            db,
+            temp_dir: _temp_dir,
+            ..
+        } = create_resolver()?;
+
+        let foo_dir = src.path().join("foo");
+        let foo_path = foo_dir.join("__init__.py");
+        std::fs::create_dir(&foo_dir)?;
+        std::fs::write(&foo_path, "print('Hello, world!')")?;
+
+        let foo_module = resolve_module_name(&db, ModuleName::new("foo")).unwrap();
+
+        assert_eq!(&ModuleName::new("foo"), foo_module.name(&db));
+        assert_eq!(src, foo_module.search_path(&db));
+        assert_eq!(&foo_path, foo_module.file(&db).path(&db));
+
+        assert_eq!(Some(foo_module), path_to_module(&db, &foo_path));
+
+        // Resolving by directory doesn't resolve to the init file.
+        assert_eq!(None, path_to_module(&db, &foo_dir));
+
+        Ok(())
+    }
+
+    #[test]
+    fn package_priority_over_module() -> anyhow::Result<()> {
+        let TestCase {
+            db,
+            temp_dir: _temp_dir,
+            src,
+            ..
+        } = create_resolver()?;
+
+        let foo_dir = src.path().join("foo");
+        let foo_init = foo_dir.join("__init__.py");
+        std::fs::create_dir(&foo_dir)?;
+        std::fs::write(&foo_init, "print('Hello, world!')")?;
+
+        let foo_py = src.path().join("foo.py");
+        std::fs::write(&foo_py, "print('Hello, world!')")?;
+
+        let foo_module = resolve_module_name(&db, ModuleName::new("foo")).unwrap();
+
+        assert_eq!(src, foo_module.search_path(&db));
+        assert_eq!(&foo_init, foo_module.file(&db).path(&db));
+        assert_eq!(ModuleKind::Package, foo_module.kind(&db));
+
+        assert_eq!(Some(foo_module), path_to_module(&db, &foo_init));
+        assert_eq!(None, path_to_module(&db, &foo_py));
+
+        Ok(())
+    }
+
+    #[test]
+    fn typing_stub_over_module() -> anyhow::Result<()> {
+        let TestCase {
+            db,
+            src,
+            temp_dir: _temp_dir,
+            ..
+        } = create_resolver()?;
+
+        let foo_stub = src.path().join("foo.pyi");
+        let foo_py = src.path().join("foo.py");
+        std::fs::write(&foo_stub, "x: int")?;
+        std::fs::write(&foo_py, "print('Hello, world!')")?;
+
+        let foo = resolve_module_name(&db, ModuleName::new("foo")).unwrap();
+
+        assert_eq!(src, foo.search_path(&db));
+        assert_eq!(&foo_stub, foo.file(&db).path(&db));
+
+        assert_eq!(Some(foo), path_to_module(&db, &foo_stub));
+        assert_eq!(None, path_to_module(&db, &foo_py));
+
+        Ok(())
+    }
+
+    #[test]
+    fn sub_packages() -> anyhow::Result<()> {
+        let TestCase {
+            db,
+            src,
+            temp_dir: _temp_dir,
+            ..
+        } = create_resolver()?;
+
+        let foo = src.path().join("foo");
+        let bar = foo.join("bar");
+        let baz = bar.join("baz.py");
+
+        std::fs::create_dir_all(&bar)?;
+        std::fs::write(foo.join("__init__.py"), "")?;
+        std::fs::write(bar.join("__init__.py"), "")?;
+        std::fs::write(&baz, "print('Hello, world!')")?;
+
+        let baz_module = resolve_module_name(&db, ModuleName::new("foo.bar.baz")).unwrap();
+
+        assert_eq!(src, baz_module.search_path(&db));
+        assert_eq!(&baz, baz_module.file(&db).path(&db));
+
+        assert_eq!(Some(baz_module), path_to_module(&db, &baz));
+
+        Ok(())
+    }
+
+    #[test]
+    fn namespace_package() -> anyhow::Result<()> {
+        let TestCase {
+            db,
+            temp_dir: _,
+            src,
+            site_packages,
+        } = create_resolver()?;
+
+        // From [PEP420](https://peps.python.org/pep-0420/#nested-namespace-packages).
+        // But uses `src` for `project1` and `site_packages2` for `project2`.
+        // ```
+        // src
+        //   parent
+        //     child
+        //       one.py
+        // site_packages
+        //   parent
+        //     child
+        //       two.py
+        // ```
+
+        let parent1 = src.path().join("parent");
+        let child1 = parent1.join("child");
+        let one = child1.join("one.py");
+
+        std::fs::create_dir_all(child1)?;
+        std::fs::write(&one, "print('Hello, world!')")?;
+
+        let parent2 = site_packages.path().join("parent");
+        let child2 = parent2.join("child");
+        let two = child2.join("two.py");
+
+        std::fs::create_dir_all(&child2)?;
+        std::fs::write(&two, "print('Hello, world!')")?;
+
+        let one_module = resolve_module_name(&db, ModuleName::new("parent.child.one")).unwrap();
+
+        assert_eq!(Some(one_module), path_to_module(&db, &one));
+
+        let two_module = resolve_module_name(&db, ModuleName::new("parent.child.two")).unwrap();
+        assert_eq!(Some(two_module), path_to_module(&db, &two));
+
+        Ok(())
+    }
+
+    #[test]
+    fn regular_package_in_namespace_package() -> anyhow::Result<()> {
+        let TestCase {
+            db,
+            temp_dir: _,
+            src,
+            site_packages,
+        } = create_resolver()?;
+
+        // Adopted test case from the [PEP420 examples](https://peps.python.org/pep-0420/#nested-namespace-packages).
+        // The `src/parent/child` package is a regular package. Therefore, `site_packages/parent/child/two.py` should not be resolved.
+        // ```
+        // src
+        //   parent
+        //     child
+        //       one.py
+        // site_packages
+        //   parent
+        //     child
+        //       two.py
+        // ```
+
+        let parent1 = src.path().join("parent");
+        let child1 = parent1.join("child");
+        let one = child1.join("one.py");
+
+        std::fs::create_dir_all(&child1)?;
+        std::fs::write(child1.join("__init__.py"), "print('Hello, world!')")?;
+        std::fs::write(&one, "print('Hello, world!')")?;
+
+        let parent2 = site_packages.path().join("parent");
+        let child2 = parent2.join("child");
+        let two = child2.join("two.py");
+
+        std::fs::create_dir_all(&child2)?;
+        std::fs::write(two, "print('Hello, world!')")?;
+
+        let one_module = resolve_module_name(&db, ModuleName::new("parent.child.one")).unwrap();
+
+        assert_eq!(Some(one_module), path_to_module(&db, &one));
+
+        assert_eq!(
+            None,
+            resolve_module_name(&db, ModuleName::new("parent.child.two"))
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn module_search_path_priority() -> anyhow::Result<()> {
+        let TestCase {
+            db,
+            src,
+            site_packages,
+            temp_dir: _temp_dir,
+        } = create_resolver()?;
+
+        let foo_src = src.path().join("foo.py");
+        let foo_site_packages = site_packages.path().join("foo.py");
+
+        std::fs::write(&foo_src, "")?;
+        std::fs::write(&foo_site_packages, "")?;
+
+        let foo_module = resolve_module_name(&db, ModuleName::new("foo")).unwrap();
+
+        assert_eq!(src, foo_module.search_path(&db));
+        assert_eq!(&foo_src, foo_module.file(&db).path(&db));
+
+        assert_eq!(Some(foo_module), path_to_module(&db, &foo_src));
+        assert_eq!(None, path_to_module(&db, &foo_site_packages));
+
+        Ok(())
+    }
+
+    #[test]
+    #[cfg(target_family = "unix")]
+    fn symlink() -> anyhow::Result<()> {
+        let TestCase {
+            db,
+            src,
+            temp_dir: _temp_dir,
+            ..
+        } = create_resolver()?;
+
+        let foo = src.path().join("foo.py");
+        let bar = src.path().join("bar.py");
+
+        std::fs::write(&foo, "")?;
+        std::os::unix::fs::symlink(&foo, &bar)?;
+
+        let foo_module = resolve_module_name(&db, ModuleName::new("foo")).unwrap();
+        let bar_module = resolve_module_name(&db, ModuleName::new("bar")).unwrap();
+
+        assert_ne!(foo_module, bar_module);
+
+        assert_eq!(src, foo_module.search_path(&db));
+        assert_eq!(&foo, foo_module.file(&db).path(&db));
+
+        // Bar has a different name but it should point to the same file.
+
+        assert_eq!(src, bar_module.search_path(&db));
+        assert_eq!(foo_module.file(&db), bar_module.file(&db));
+        assert_eq!(&foo, bar_module.file(&db).path(&db));
+
+        assert_eq!(Some(foo_module), path_to_module(&db, &foo));
+        assert_eq!(Some(bar_module), path_to_module(&db, &bar));
+
+        Ok(())
+    }
+
+    #[test]
+    fn resolve_dependency() -> anyhow::Result<()> {
+        let TestCase {
+            src,
+            db,
+            temp_dir: _temp_dir,
+            ..
+        } = create_resolver()?;
+
+        let foo_dir = src.path().join("foo");
+        let foo_path = foo_dir.join("__init__.py");
+        let bar_path = foo_dir.join("bar.py");
+
+        std::fs::create_dir(&foo_dir)?;
+        std::fs::write(foo_path, "from .bar import test")?;
+        std::fs::write(bar_path, "test = 'Hello world'")?;
+
+        let foo_module = resolve_module_name(&db, ModuleName::new("foo")).unwrap();
+        let bar_module = resolve_module_name(&db, ModuleName::new("foo.bar")).unwrap();
+
+        // `from . import bar` in `foo/__init__.py` resolves to `foo`
+        assert_eq!(
+            Some(ModuleName::new("foo")),
+            foo_module.resolve_dependency(
+                &db,
+                &Dependency::Relative {
+                    level: NonZeroU32::new(1).unwrap(),
+                    module: None,
+                }
+            )
+        );
+
+        // `from baz import bar` in `foo/__init__.py` should resolve to `baz.py`
+        assert_eq!(
+            Some(ModuleName::new("baz")),
+            foo_module.resolve_dependency(
+                &db,
+                &Dependency::Module(crate::module::ModuleName::new("baz"))
+            )
+        );
+
+        // from .bar import test in `foo/__init__.py` should resolve to `foo/bar.py`
+        assert_eq!(
+            Some(ModuleName::new("foo.bar")),
+            foo_module.resolve_dependency(
+                &db,
+                &Dependency::Relative {
+                    level: NonZeroU32::new(1).unwrap(),
+                    module: Some(crate::module::ModuleName::new("bar"))
+                }
+            )
+        );
+
+        // from .. import test in `foo/__init__.py` resolves to `` which is not a module
+        assert_eq!(
+            None,
+            foo_module.resolve_dependency(
+                &db,
+                &Dependency::Relative {
+                    level: NonZeroU32::new(2).unwrap(),
+                    module: None
+                }
+            )
+        );
+
+        // `from . import test` in `foo/bar.py` resolves to `foo`
+        assert_eq!(
+            Some(ModuleName::new("foo")),
+            bar_module.resolve_dependency(
+                &db,
+                &Dependency::Relative {
+                    level: NonZeroU32::new(1).unwrap(),
+                    module: None
+                }
+            )
+        );
+
+        // `from baz import test` in `foo/bar.py` resolves to `baz`
+        assert_eq!(
+            Some(ModuleName::new("baz")),
+            bar_module.resolve_dependency(
+                &db,
+                &Dependency::Module(crate::module::ModuleName::new("baz"))
+            )
+        );
+
+        // `from .baz import test` in `foo/bar.py` resolves to `foo.baz`.
+        assert_eq!(
+            Some(ModuleName::new("foo.baz")),
+            bar_module.resolve_dependency(
+                &db,
+                &Dependency::Relative {
+                    level: NonZeroU32::new(1).unwrap(),
+                    module: Some(crate::module::ModuleName::new("baz"))
+                }
+            )
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn cache_invalidation() -> anyhow::Result<()> {
+        let TestCase {
+            mut db,
+            temp_dir: _,
+            src,
+            site_packages,
+        } = create_resolver()?;
+
+        let parent1 = src.path().join("parent");
+        let one = parent1.join("one.py");
+
+        std::fs::create_dir_all(&parent1)?;
+        std::fs::write(&one, "print('Hello, world!')")?;
+
+        let parent2 = site_packages.path().join("parent");
+        let two = parent2.join("two.py");
+
+        std::fs::create_dir_all(&parent2)?;
+        std::fs::write(&two, "print('Hello, world!')")?;
+
+        let one_module = resolve_module_name(&db, ModuleName::new("parent.one")).unwrap();
+
+        assert_eq!(Some(one_module), path_to_module(&db, &one));
+
+        let two_module = resolve_module_name(&db, ModuleName::new("parent.two")).unwrap();
+        assert_eq!(Some(two_module), path_to_module(&db, &two));
+
+        // Add an `__init__.py` to the `site_packages/parent` folder, which makes it a non-namespace package and
+        // should invalidate `two_module`.
+
+        let parent1_init = parent1.join("__init__.py");
+        std::fs::write(&parent1_init, "")?;
+
+        let init_file = db.file(parent1_init);
+        init_file.touch(&mut db);
+        init_file.debug(&db);
+
+        assert_eq!(
+            None,
+            resolve_module_name(&db, ModuleName::new("parent.two"))
+        );
+        assert_eq!(None, path_to_module(&db, &two));
+
+        Ok(())
+    }
+}

--- a/crates/red_knot/src/salsa_db/source.rs
+++ b/crates/red_knot/src/salsa_db/source.rs
@@ -1,0 +1,253 @@
+use std::fmt::Formatter;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use countme::Count;
+use dashmap::mapref::entry::Entry;
+use filetime::FileTime;
+
+use ruff_python_ast::{Mod, ModModule, Stmt, StmtExpr};
+use ruff_python_parser::Mode;
+use ruff_text_size::{Ranged, TextRange};
+
+use crate::FxDashMap;
+
+/// A file can be considered unchanged for as long as it has the same revision.
+///
+/// The value of the revision itself has no meaning other than to encode the version of the file.
+/// Therefore, it's not possible to identify which revision is newer by comparing the values.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum FileRevision {
+    LastModified(FileTime),
+    #[allow(unused)]
+    ContentHash(u128),
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+pub enum FileStatus {
+    Exists,
+    /// The file was deleted, didn't exist to begin with or the path isn't a file.
+    Deleted,
+}
+
+#[salsa::input(jar=Jar)]
+pub struct File {
+    #[return_ref]
+    pub path: PathBuf,
+
+    pub permissions: u32,
+
+    pub revision: FileRevision,
+
+    pub status: FileStatus,
+
+    #[allow(unused)]
+    count: Count<File>,
+}
+
+impl File {
+    /// Updates the metadata of the file.
+    #[tracing::instrument(level = "debug", skip(db))]
+    pub fn touch(self, db: &mut dyn Db) {
+        let path = self.path(db);
+
+        if let Ok(metadata) = path.metadata() {
+            let last_modified = FileTime::from_last_modification_time(&metadata);
+            #[cfg(unix)]
+            let permissions = if cfg!(unix) {
+                use std::os::unix::fs::PermissionsExt;
+                metadata.permissions().mode()
+            } else {
+                0
+            };
+
+            self.set_revision(db)
+                .to(FileRevision::LastModified(last_modified));
+            self.set_permissions(db).to(permissions);
+            self.set_status(db).to(FileStatus::Exists);
+        } else {
+            self.delete(db);
+        }
+    }
+
+    pub fn delete(self, db: &mut dyn Db) {
+        self.set_status(db).to(FileStatus::Deleted);
+        self.set_permissions(db).to(0);
+        self.set_revision(db)
+            .to(FileRevision::LastModified(FileTime::zero()));
+    }
+
+    pub fn exists(self, db: &dyn Db) -> bool {
+        self.status(db) == FileStatus::Exists
+    }
+}
+
+#[salsa::tracked(jar=Jar)]
+impl File {
+    #[salsa::tracked]
+    pub fn source(self, db: &dyn Db) -> SourceText {
+        // Read the revision to force a re-run of this query when the file gets updated.
+        let _ = self.revision(db);
+        let text = std::fs::read_to_string(self.path(db)).unwrap_or_default();
+
+        SourceText {
+            text: Arc::from(text),
+            count: Count::default(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct Files {
+    inner: Arc<FilesInner>,
+}
+
+impl Files {
+    pub(super) fn resolve(&self, db: &dyn Db, path: PathBuf) -> File {
+        match self.inner.by_path.entry(path.clone()) {
+            Entry::Occupied(entry) => {
+                let file = entry.get();
+                *file
+            }
+            Entry::Vacant(entry) => {
+                let metadata = path.metadata();
+
+                let file = if let Ok(metadata) = metadata {
+                    let (last_modified, permissions, file_status) = if metadata.is_file() {
+                        let last_modified = FileTime::from_last_modification_time(&metadata);
+                        #[cfg(unix)]
+                        let permissions = if cfg!(unix) {
+                            use std::os::unix::fs::PermissionsExt;
+                            metadata.permissions().mode()
+                        } else {
+                            0
+                        };
+
+                        (last_modified, permissions, FileStatus::Exists)
+                    } else {
+                        (FileTime::zero(), 0, FileStatus::Deleted)
+                    };
+
+                    File::new(
+                        db,
+                        path,
+                        permissions,
+                        FileRevision::LastModified(last_modified),
+                        file_status,
+                        Count::default(),
+                    )
+                } else {
+                    File::new(
+                        db,
+                        path,
+                        0,
+                        FileRevision::LastModified(FileTime::zero()),
+                        FileStatus::Deleted,
+                        Count::default(),
+                    )
+                };
+
+                // TODO: Set a higher durability for std files.
+
+                entry.insert(file);
+
+                file
+            }
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+struct FilesInner {
+    by_path: FxDashMap<PathBuf, File>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct SourceText {
+    pub text: Arc<str>,
+    count: Count<SourceText>,
+}
+
+impl SourceText {
+    pub fn text(&self) -> &str {
+        &self.text
+    }
+}
+
+#[derive(Clone, PartialEq)]
+pub struct Parsed {
+    inner: Arc<ParsedInner>,
+}
+
+impl Parsed {
+    pub fn ast(&self) -> &ModModule {
+        &self.inner.ast
+    }
+
+    #[allow(unused)]
+    pub fn errors(&self) -> &[ruff_python_parser::ParseError] {
+        &self.inner.errors
+    }
+}
+
+impl std::fmt::Debug for Parsed {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Parsed")
+            .field("ast", &self.inner.ast)
+            .field("errors", &self.inner.errors)
+            .finish()
+    }
+}
+
+#[derive(Debug, PartialEq)]
+struct ParsedInner {
+    // TODO should this be an arc to avoid some lifetime awkwardness for call-sites.
+    pub ast: ModModule,
+
+    // TODO use an accumulator for this?
+    pub errors: Vec<ruff_python_parser::ParseError>,
+}
+
+#[tracing::instrument(level = "debug", skip(db))]
+#[salsa::tracked(jar=Jar, no_eq)]
+pub fn parse(db: &dyn Db, file: File) -> Parsed {
+    let source = file.source(db);
+    let text = source.text();
+
+    let result = ruff_python_parser::parse(text, Mode::Module);
+
+    let (module, errors) = match result {
+        Ok(Mod::Module(module)) => (module, vec![]),
+        Ok(Mod::Expression(expression)) => (
+            ModModule {
+                range: expression.range(),
+                body: vec![Stmt::Expr(StmtExpr {
+                    range: expression.range(),
+                    value: expression.body,
+                })],
+            },
+            vec![],
+        ),
+        Err(errors) => (
+            ModModule {
+                range: TextRange::default(),
+                body: Vec::new(),
+            },
+            vec![errors],
+        ),
+    };
+
+    Parsed {
+        inner: Arc::new(ParsedInner {
+            ast: module,
+            errors,
+        }),
+    }
+}
+
+#[salsa::jar(db=Db)]
+pub struct Jar(File, File_source, parse);
+
+pub trait Db: salsa::DbWithJar<Jar> {
+    fn file(&self, path: PathBuf) -> File;
+}

--- a/crates/ruff_index/src/slice.rs
+++ b/crates/ruff_index/src/slice.rs
@@ -2,7 +2,7 @@ use crate::vec::IndexVec;
 use crate::Idx;
 use std::fmt::{Debug, Formatter};
 use std::marker::PhantomData;
-use std::ops::{Index, IndexMut};
+use std::ops::{Index, IndexMut, Range};
 
 /// A view into contiguous `T`s, indexed by `I` rather than by `usize`.
 #[derive(PartialEq, Eq, Hash)]
@@ -128,6 +128,15 @@ impl<I: Idx, T> Index<I> for IndexSlice<I, T> {
     #[inline]
     fn index(&self, index: I) -> &T {
         &self.raw[index.index()]
+    }
+}
+
+impl<I: Idx, T> Index<Range<I>> for IndexSlice<I, T> {
+    type Output = [T];
+
+    #[inline]
+    fn index(&self, index: Range<I>) -> &[T] {
+        &self.raw[index.start.index()..index.end.index()]
     }
 }
 

--- a/crates/ruff_index/src/vec.rs
+++ b/crates/ruff_index/src/vec.rs
@@ -69,6 +69,11 @@ impl<I: Idx, T> IndexVec<I, T> {
     pub fn next_index(&self) -> I {
         I::new(self.raw.len())
     }
+
+    #[inline]
+    pub fn shrink_to_fit(&mut self) {
+        self.raw.shrink_to_fit()
+    }
 }
 
 impl<I, T> Debug for IndexVec<I, T>


### PR DESCRIPTION
## Summary

This PR is mainly to explore a location independent, higher level AST for red knot. 

The motivation for a location independent higher level AST is to have sub-level invalidation granularity. 
What I mean by that is that e.g. whitespace only changes should not invalidate any type inference results
but they do because the AST stores location informations that change when adding or removing characters from a document. 

A higher level AST (HAST) also allow to avoid infering the types when making local changes in a function. 

Let's say we have 

```python
def add(x, y):
	x + y

def multiply(x, y):
	x * y

```

It shouldn't be necessary to do type inference for `add` when making changes to `multiply` because `add`'s body doesn't change nor does it depend on `multiply` in anyway (it doesn't call the function). 

An HAST enables function level garnulariy, but it doesn't come for free:

* It requires building an additional AST that is very familiar to the AST created by the parser with the exception that it doesn't include TextRange's and that we build it per "function" rather than building the entire AST for the entire module
* It requires rebuilding a lot of the infrastructure like visitors 
* We end up with two AST representations and need a way to map between the representations 
* The HAST, at least what I built so far, is awkward to use
* While the HAST optimizes the time it takes to reanalyze when making local changes, the cost for reanalyzing in the worst case remains unchanged (or is now higher because of the extra intermediate representations). For example, adding a new symbol to the module scope requires type-checking the entire file because each sub scope depends on the root scope. 
  That means, while the HIR helps to improve the average response time in the LSP, it doesn't help improving the time of all requests. This is not a reason why we should not do it. But maybe it's more beneficial to reduce the cost of running the entire analysis so that an HIR isn't needed.  



## Test Plan

<!-- How was it tested? -->
