### PR TITLE
Red-knot: Track scopes per expression

### DIFF
--- a/crates/ruff_index/src/slice.rs
+++ b/crates/ruff_index/src/slice.rs
@@ -2,7 +2,7 @@ use crate::vec::IndexVec;
 use crate::Idx;
 use std::fmt::{Debug, Formatter};
 use std::marker::PhantomData;
-use std::ops::{Index, IndexMut};
+use std::ops::{Index, IndexMut, Range};
 
 /// A view into contiguous `T`s, indexed by `I` rather than by `usize`.
 #[derive(PartialEq, Eq, Hash)]
@@ -131,10 +131,26 @@ impl<I: Idx, T> Index<I> for IndexSlice<I, T> {
     }
 }
 
+impl<I: Idx, T> Index<Range<I>> for IndexSlice<I, T> {
+    type Output = [T];
+
+    #[inline]
+    fn index(&self, range: Range<I>) -> &[T] {
+        &self.raw[range.start.index()..range.end.index()]
+    }
+}
+
 impl<I: Idx, T> IndexMut<I> for IndexSlice<I, T> {
     #[inline]
     fn index_mut(&mut self, index: I) -> &mut T {
         &mut self.raw[index.index()]
+    }
+}
+
+impl<I: Idx, T> IndexMut<Range<I>> for IndexSlice<I, T> {
+    #[inline]
+    fn index_mut(&mut self, range: Range<I>) -> &mut [T] {
+        &mut self.raw[range.start.index()..range.end.index()]
     }
 }
 

--- a/crates/ruff_index/src/vec.rs
+++ b/crates/ruff_index/src/vec.rs
@@ -69,6 +69,11 @@ impl<I: Idx, T> IndexVec<I, T> {
     pub fn next_index(&self) -> I {
         I::new(self.raw.len())
     }
+
+    #[inline]
+    pub fn shrink_to_fit(&mut self) {
+        self.raw.shrink_to_fit();
+    }
 }
 
 impl<I, T> Debug for IndexVec<I, T>


### PR DESCRIPTION
## Summary

This PR extends the symbol table to track for every expression to which scope it belongs. 

To avoid having two `Expression -> X` hash maps, this PR indexes a single `Expr -> ExpressionId` hash map and uses an `IndexVec` for tracking the flow nodes and scopes. 

Open questions:

* It's unclear if we only want this functionality for expressions or all nodes
* Storing the scope for every expression seems a lot (it's small, but still). An alternative design is to instead build up an ancestor tree and iterate over the ancestor tree until we find the first `Function`, `Class`, `Comprehension`, `Lambda` and then resolve the scope using `scopes_by_node`. 

## Test Plan

Added test
