### PR TITLE
[red-knot] rename Definition::None to Definition::Unbound

### DIFF
--- a/crates/red_knot/src/semantic/flow_graph.rs
+++ b/crates/red_knot/src/semantic/flow_graph.rs
@@ -133,7 +133,7 @@ impl<'a> Iterator for ReachableDefinitionsIterator<'a> {
         loop {
             let flow_node_id = self.pending.pop()?;
             match &self.flow_graph.flow_nodes_by_id[flow_node_id] {
-                FlowNode::Start => return Some(Definition::None),
+                FlowNode::Start => return Some(Definition::Unbound),
                 FlowNode::Definition(def_node) => {
                     if def_node.symbol_id == self.symbol_id {
                         return Some(def_node.definition.clone());

--- a/crates/red_knot/src/semantic/symbol_table.rs
+++ b/crates/red_knot/src/semantic/symbol_table.rs
@@ -145,7 +145,8 @@ pub enum Definition {
     FunctionDef(TypedNodeKey<ast::StmtFunctionDef>),
     Assignment(TypedNodeKey<ast::StmtAssign>),
     AnnotatedAssignment(TypedNodeKey<ast::StmtAnnAssign>),
-    None,
+    /// represents the implicit initial definition of every name as "unbound"
+    Unbound,
     // TODO with statements, except handlers, function args...
 }
 

--- a/crates/red_knot/src/semantic/types/infer.rs
+++ b/crates/red_knot/src/semantic/types/infer.rs
@@ -58,7 +58,7 @@ where
         if tys.peek().is_some() {
             Ok(Type::Union(jar.type_store.add_union(
                 symbol.file_id,
-                &Iterator::chain([first].into_iter(), tys).collect::<QueryResult<Vec<_>>>()?,
+                &Iterator::chain(std::iter::once(first), tys).collect::<QueryResult<Vec<_>>>()?,
             )))
         } else {
             first
@@ -79,7 +79,7 @@ pub fn infer_definition_type(
     let file_id = symbol.file_id;
 
     match definition {
-        Definition::None => Ok(Type::Unbound),
+        Definition::Unbound => Ok(Type::Unbound),
         Definition::Import(ImportDefinition {
             module: module_name,
         }) => {


### PR DESCRIPTION
## Summary

After looking at this a bit, I think it does make sense to have `Unbound` as part of the `Definition` enum; if we are modeling `Unbound` as a type (which currently we are), then every symbol implicitly starts each scope with a "definition" as unbound, and the cleanest way to model that is as a real `Definition`. We should be able to handle a definition of "unbound" anywhere we handle definitions.

But the name `None` wasn't clear enough; changing the name to `Unbound` and adding a doc comment.

## Test Plan

Existing tests.
