### PR TITLE
[red-knot] refactor Definitions out of symbol table

### DIFF
--- a/crates/red_knot/src/semantic.rs
+++ b/crates/red_knot/src/semantic.rs
@@ -11,18 +11,18 @@ use crate::module::Module;
 use crate::module::ModuleName;
 use crate::parse::parse;
 use crate::Name;
+pub(crate) use definitions::Definition;
+use definitions::{ImportDefinition, ImportFromDefinition};
 use flow_graph::{FlowGraph, FlowGraphBuilder, FlowNodeId, ReachableDefinitionsIterator};
 use ruff_index::newtype_index;
 use rustc_hash::FxHashMap;
 use std::ops::{Deref, DerefMut};
 use std::sync::Arc;
-pub(crate) use symbol_table::{Definition, Dependency, SymbolId};
-use symbol_table::{
-    ImportDefinition, ImportFromDefinition, ScopeId, ScopeKind, SymbolFlags, SymbolTable,
-    SymbolTableBuilder,
-};
+pub(crate) use symbol_table::{Dependency, SymbolId};
+use symbol_table::{ScopeId, ScopeKind, SymbolFlags, SymbolTable, SymbolTableBuilder};
 pub(crate) use types::{infer_definition_type, infer_symbol_public_type, Type, TypeStore};
 
+mod definitions;
 mod flow_graph;
 mod symbol_table;
 mod types;

--- a/crates/red_knot/src/semantic/definitions.rs
+++ b/crates/red_knot/src/semantic/definitions.rs
@@ -1,0 +1,51 @@
+use crate::ast_ids::TypedNodeKey;
+use crate::semantic::ModuleName;
+use crate::Name;
+use ruff_python_ast as ast;
+
+// TODO storing TypedNodeKey for definitions means we have to search to find them again in the AST;
+// this is at best O(log n). If looking up definitions is a bottleneck we should look for
+// alternatives here.
+// TODO intern Definitions in SymbolTable and reference using IDs?
+#[derive(Clone, Debug)]
+pub enum Definition {
+    // For the import cases, we don't need reference to any arbitrary AST subtrees (annotations,
+    // RHS), and referencing just the import statement node is imprecise (a single import statement
+    // can assign many symbols, we'd have to re-search for the one we care about), so we just copy
+    // the small amount of information we need from the AST.
+    Import(ImportDefinition),
+    ImportFrom(ImportFromDefinition),
+    ClassDef(TypedNodeKey<ast::StmtClassDef>),
+    FunctionDef(TypedNodeKey<ast::StmtFunctionDef>),
+    Assignment(TypedNodeKey<ast::StmtAssign>),
+    AnnotatedAssignment(TypedNodeKey<ast::StmtAnnAssign>),
+    /// represents the implicit initial definition of every name as "unbound"
+    Unbound,
+    // TODO with statements, except handlers, function args...
+}
+
+#[derive(Clone, Debug)]
+pub struct ImportDefinition {
+    pub module: ModuleName,
+}
+
+#[derive(Clone, Debug)]
+pub struct ImportFromDefinition {
+    pub module: Option<ModuleName>,
+    pub name: Name,
+    pub level: u32,
+}
+
+impl ImportFromDefinition {
+    pub fn module(&self) -> Option<&ModuleName> {
+        self.module.as_ref()
+    }
+
+    pub fn name(&self) -> &Name {
+        &self.name
+    }
+
+    pub fn level(&self) -> u32 {
+        self.level
+    }
+}

--- a/crates/red_knot/src/semantic/flow_graph.rs
+++ b/crates/red_knot/src/semantic/flow_graph.rs
@@ -1,5 +1,5 @@
-use super::symbol_table::{Definition, SymbolId};
-use crate::semantic::ExpressionId;
+use super::symbol_table::SymbolId;
+use crate::semantic::{Definition, ExpressionId};
 use ruff_index::{newtype_index, IndexVec};
 use std::iter::FusedIterator;
 

--- a/crates/red_knot/src/semantic/symbol_table.rs
+++ b/crates/red_knot/src/semantic/symbol_table.rs
@@ -9,11 +9,10 @@ use hashbrown::hash_map::{Keys, RawEntryMut};
 use rustc_hash::{FxHashMap, FxHasher};
 
 use ruff_index::{newtype_index, IndexVec};
-use ruff_python_ast as ast;
 
-use crate::ast_ids::{NodeKey, TypedNodeKey};
+use crate::ast_ids::NodeKey;
 use crate::module::ModuleName;
-use crate::semantic::ExpressionId;
+use crate::semantic::{Definition, ExpressionId};
 use crate::Name;
 
 type Map<K, V> = hashbrown::HashMap<K, V, ()>;
@@ -127,53 +126,6 @@ impl Symbol {
     // TODO: implement Symbol.kind 2-pass analysis to categorize as: free-var, cell-var,
     // explicit-global, implicit-global and implement Symbol.kind by modifying the preorder
     // traversal code
-}
-
-// TODO storing TypedNodeKey for definitions means we have to search to find them again in the AST;
-// this is at best O(log n). If looking up definitions is a bottleneck we should look for
-// alternatives here.
-// TODO intern Definitions in SymbolTable and reference using IDs?
-#[derive(Clone, Debug)]
-pub enum Definition {
-    // For the import cases, we don't need reference to any arbitrary AST subtrees (annotations,
-    // RHS), and referencing just the import statement node is imprecise (a single import statement
-    // can assign many symbols, we'd have to re-search for the one we care about), so we just copy
-    // the small amount of information we need from the AST.
-    Import(ImportDefinition),
-    ImportFrom(ImportFromDefinition),
-    ClassDef(TypedNodeKey<ast::StmtClassDef>),
-    FunctionDef(TypedNodeKey<ast::StmtFunctionDef>),
-    Assignment(TypedNodeKey<ast::StmtAssign>),
-    AnnotatedAssignment(TypedNodeKey<ast::StmtAnnAssign>),
-    /// represents the implicit initial definition of every name as "unbound"
-    Unbound,
-    // TODO with statements, except handlers, function args...
-}
-
-#[derive(Clone, Debug)]
-pub struct ImportDefinition {
-    pub module: ModuleName,
-}
-
-#[derive(Clone, Debug)]
-pub struct ImportFromDefinition {
-    pub module: Option<ModuleName>,
-    pub name: Name,
-    pub level: u32,
-}
-
-impl ImportFromDefinition {
-    pub fn module(&self) -> Option<&ModuleName> {
-        self.module.as_ref()
-    }
-
-    pub fn name(&self) -> &Name {
-        &self.name
-    }
-
-    pub fn level(&self) -> u32 {
-        self.level
-    }
 }
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
## Summary

Definitions are used in symbol table and in flow graph, and aren't inherently owned by one or the other; move them into their own submodule.

## Test Plan

Existing tests.