### PR TITLE
[red-knot] Encapsulate module resolution logic in `module.rs`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1778,6 +1778,7 @@ dependencies = [
  "dashmap",
  "hashbrown 0.14.5",
  "indexmap",
+ "is-macro",
  "notify",
  "parking_lot",
  "rayon",

--- a/crates/red_knot/Cargo.toml
+++ b/crates/red_knot/Cargo.toml
@@ -25,6 +25,7 @@ ctrlc = { version = "3.4.4" }
 dashmap = { workspace = true }
 hashbrown = { workspace = true }
 indexmap = { workspace = true }
+is-macro = { workspace = true }
 notify = { workspace = true }
 parking_lot = { workspace = true }
 rayon = { workspace = true }

--- a/crates/red_knot/src/main.rs
+++ b/crates/red_knot/src/main.rs
@@ -12,7 +12,7 @@ use tracing_subscriber::{Layer, Registry};
 use tracing_tree::time::Uptime;
 
 use red_knot::db::{HasJar, ParallelDatabase, QueryError, SourceDb, SourceJar};
-use red_knot::module::{set_module_search_paths, ModuleSearchPath, ModuleSearchPathKind};
+use red_knot::module::{set_module_search_paths, ResolvedSearchPathOrder};
 use red_knot::program::check::ExecutionMode;
 use red_knot::program::{FileWatcherChange, Program};
 use red_knot::watch::FileWatcher;
@@ -44,12 +44,12 @@ fn main() -> anyhow::Result<()> {
     let workspace_folder = entry_point.parent().unwrap();
     let workspace = Workspace::new(workspace_folder.to_path_buf());
 
-    let workspace_search_path = ModuleSearchPath::new(
-        workspace.root().to_path_buf(),
-        ModuleSearchPathKind::FirstParty,
-    );
+    let workspace_search_path = workspace.root().to_path_buf();
+    let resolved_search_paths =
+        ResolvedSearchPathOrder::new(vec![], workspace_search_path, None, None);
+
     let mut program = Program::new(workspace);
-    set_module_search_paths(&mut program, vec![workspace_search_path]);
+    set_module_search_paths(&mut program, resolved_search_paths);
 
     let entry_id = program.file_id(entry_point);
     program.workspace_mut().open_file(entry_id);

--- a/crates/red_knot/src/main.rs
+++ b/crates/red_knot/src/main.rs
@@ -12,7 +12,7 @@ use tracing_subscriber::{Layer, Registry};
 use tracing_tree::time::Uptime;
 
 use red_knot::db::{HasJar, ParallelDatabase, QueryError, SourceDb, SourceJar};
-use red_knot::module::{set_module_search_paths, ResolvedSearchPathOrder};
+use red_knot::module::{set_module_search_paths, OrderedSearchPaths};
 use red_knot::program::check::ExecutionMode;
 use red_knot::program::{FileWatcherChange, Program};
 use red_knot::watch::FileWatcher;
@@ -45,8 +45,7 @@ fn main() -> anyhow::Result<()> {
     let workspace = Workspace::new(workspace_folder.to_path_buf());
 
     let workspace_search_path = workspace.root().to_path_buf();
-    let resolved_search_paths =
-        ResolvedSearchPathOrder::new(vec![], workspace_search_path, None, None);
+    let resolved_search_paths = OrderedSearchPaths::new(vec![], workspace_search_path, None, None);
 
     let mut program = Program::new(workspace);
     set_module_search_paths(&mut program, resolved_search_paths);

--- a/crates/red_knot/src/module.rs
+++ b/crates/red_knot/src/module.rs
@@ -418,7 +418,11 @@ impl Deref for ResolvedSearchPathOrder {
 ///   or pyright's stubPath configuration setting.
 /// - `workspace_root` is the root of the workspace,
 ///   used for finding first-party modules
-/// - `custom_typeshed`
+/// - `site-packages` is the path to the user's `site-packages` directory,
+///   where third-party packages from ``PyPI`` are installed
+/// - `custom_typeshed` is a path to standard-library typeshed stubs.
+///   Currently this has to be a directory that exists on disk.
+///   (TODO: fall back to vendored stubs if no custom directory is provided.)
 impl ResolvedSearchPathOrder {
     pub fn new(
         extra_paths: Vec<PathBuf>,

--- a/crates/red_knot/src/semantic/types/infer.rs
+++ b/crates/red_knot/src/semantic/types/infer.rs
@@ -234,10 +234,12 @@ fn infer_expr_type(db: &dyn SemanticDb, file_id: FileId, expr: &ast::Expr) -> Qu
 #[cfg(test)]
 mod tests {
 
+    use std::path::PathBuf;
+
     use crate::db::tests::TestDb;
     use crate::db::{HasJar, SemanticJar};
     use crate::module::{
-        resolve_module, set_module_search_paths, ModuleName, ModuleSearchPath, ModuleSearchPathKind,
+        resolve_module, set_module_search_paths, ModuleName, ResolvedSearchPathOrder,
     };
     use crate::semantic::{infer_symbol_public_type, resolve_global_symbol, Type};
     use crate::Name;
@@ -249,7 +251,7 @@ mod tests {
         temp_dir: tempfile::TempDir,
         db: TestDb,
 
-        src: ModuleSearchPath,
+        src: PathBuf,
     }
 
     fn create_test() -> std::io::Result<TestCase> {
@@ -257,18 +259,18 @@ mod tests {
 
         let src = temp_dir.path().join("src");
         std::fs::create_dir(&src)?;
-        let src = ModuleSearchPath::new(src.canonicalize()?, ModuleSearchPathKind::FirstParty);
+        let src = src.canonicalize()?;
 
-        let roots = vec![src.clone()];
+        let resolved_search_path = ResolvedSearchPathOrder::new(vec![], src.clone(), None, None);
 
         let mut db = TestDb::default();
-        set_module_search_paths(&mut db, roots);
+        set_module_search_paths(&mut db, resolved_search_path);
 
         Ok(TestCase { temp_dir, db, src })
     }
 
     fn write_to_path(case: &TestCase, relative_path: &str, contents: &str) -> anyhow::Result<()> {
-        let path = case.src.path().join(relative_path);
+        let path = case.src.join(relative_path);
         std::fs::write(path, contents)?;
         Ok(())
     }
@@ -414,9 +416,7 @@ mod tests {
     #[test]
     fn resolve_visible_def() -> anyhow::Result<()> {
         let case = create_test()?;
-
         write_to_path(&case, "a.py", "y = 1; y = 2; x = y")?;
-
         assert_public_type(&case, "a", "x", "Literal[2]")
     }
 

--- a/crates/red_knot/src/semantic/types/infer.rs
+++ b/crates/red_knot/src/semantic/types/infer.rs
@@ -238,9 +238,7 @@ mod tests {
 
     use crate::db::tests::TestDb;
     use crate::db::{HasJar, SemanticJar};
-    use crate::module::{
-        resolve_module, set_module_search_paths, ModuleName, ResolvedSearchPathOrder,
-    };
+    use crate::module::{resolve_module, set_module_search_paths, ModuleName, OrderedSearchPaths};
     use crate::semantic::{infer_symbol_public_type, resolve_global_symbol, Type};
     use crate::Name;
 
@@ -261,7 +259,7 @@ mod tests {
         std::fs::create_dir(&src)?;
         let src = src.canonicalize()?;
 
-        let resolved_search_path = ResolvedSearchPathOrder::new(vec![], src.clone(), None, None);
+        let resolved_search_path = OrderedSearchPaths::new(vec![], src.clone(), None, None);
 
         let mut db = TestDb::default();
         set_module_search_paths(&mut db, resolved_search_path);


### PR DESCRIPTION
This PR encapsulates all module-resolution logic in `module.rs`. Currently a `Vec` of search paths is passed into the routines in `module.rs`, but this opens the door to the search paths being passed in an incorrect order. The order of search paths should be maintained as an invariant via a common routine to avoid the possiblity of error.

`ResolvedSearchPathOrder::new()` implements the module resolution order given at https://typing.readthedocs.io/en/latest/spec/distributing.html#import-resolution-ordering, with some small differences (applying the changes proposed in https://discuss.python.org/t/pep-561-s-module-resolution-order-seems-incorrect/55048).

Work towards https://github.com/astral-sh/ruff/issues/11653