### PR TITLE
[Bug fix] Fix rule B909's panic when checking large loop blocks

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/loop_iterator_mutation.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/loop_iterator_mutation.rs
@@ -114,9 +114,9 @@ fn is_mutating_function(function_name: &str) -> bool {
 struct LoopMutationsVisitor<'a> {
     iter: &'a Expr,
     target: &'a Expr,
-    mutations: HashMap<u8, Vec<TextRange>>,
-    branches: Vec<u8>,
-    branch: u8,
+    mutations: HashMap<u32, Vec<TextRange>>,
+    branches: Vec<u32>,
+    branch: u32,
 }
 
 impl<'a> LoopMutationsVisitor<'a> {


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

This pr should close #11771 by changing `LoopMutationsVisitor::<field>branch` from `u8` to `u32`.

## Test Plan

<!-- How was it tested? -->
Tested using the example programme mentioned in the related issue.
