### PR TITLE
[red-knot] Cleanup module-resolution logic in `module.rs`

### DIFF
--- a/crates/red_knot/src/main.rs
+++ b/crates/red_knot/src/main.rs
@@ -12,7 +12,7 @@ use tracing_subscriber::{Layer, Registry};
 use tracing_tree::time::Uptime;
 
 use red_knot::db::{HasJar, ParallelDatabase, QueryError, SourceDb, SourceJar};
-use red_knot::module::{set_module_search_paths, OrderedSearchPaths};
+use red_knot::module::{set_module_search_paths, ModuleResolutionInputs};
 use red_knot::program::check::ExecutionMode;
 use red_knot::program::{FileWatcherChange, Program};
 use red_knot::watch::FileWatcher;
@@ -45,10 +45,16 @@ fn main() -> anyhow::Result<()> {
     let workspace = Workspace::new(workspace_folder.to_path_buf());
 
     let workspace_search_path = workspace.root().to_path_buf();
-    let resolved_search_paths = OrderedSearchPaths::new(vec![], workspace_search_path, None, None);
+
+    let search_paths = ModuleResolutionInputs {
+        extra_paths: vec![],
+        workspace_root: workspace_search_path,
+        site_packages: None,
+        custom_typeshed: None,
+    };
 
     let mut program = Program::new(workspace);
-    set_module_search_paths(&mut program, resolved_search_paths);
+    set_module_search_paths(&mut program, search_paths);
 
     let entry_id = program.file_id(entry_point);
     program.workspace_mut().open_file(entry_id);

--- a/crates/red_knot/src/semantic/types/infer.rs
+++ b/crates/red_knot/src/semantic/types/infer.rs
@@ -247,7 +247,9 @@ mod tests {
 
     use crate::db::tests::TestDb;
     use crate::db::{HasJar, SemanticJar};
-    use crate::module::{resolve_module, set_module_search_paths, ModuleName, OrderedSearchPaths};
+    use crate::module::{
+        resolve_module, set_module_search_paths, ModuleName, ModuleResolutionInputs,
+    };
     use crate::semantic::{infer_symbol_public_type, resolve_global_symbol, Type};
     use crate::Name;
 
@@ -268,10 +270,15 @@ mod tests {
         std::fs::create_dir(&src)?;
         let src = src.canonicalize()?;
 
-        let resolved_search_path = OrderedSearchPaths::new(vec![], src.clone(), None, None);
+        let search_paths = ModuleResolutionInputs {
+            extra_paths: vec![],
+            workspace_root: src.clone(),
+            site_packages: None,
+            custom_typeshed: None,
+        };
 
         let mut db = TestDb::default();
-        set_module_search_paths(&mut db, resolved_search_path);
+        set_module_search_paths(&mut db, search_paths);
 
         Ok(TestCase { temp_dir, db, src })
     }


### PR DESCRIPTION
Various fixes addressing @carljm's post-merge review of #11767

- Use a config struct to pass in the various search paths, to improve readability
- Resolve the standard-library subdirectory in typeshed eagerly, instead of every time we're trying to use that search path
- Various fixups to comments and docs