### PR TITLE
[red-knot] remove duplicate test from bad merge

### DIFF
--- a/crates/red_knot/src/semantic/types/infer.rs
+++ b/crates/red_knot/src/semantic/types/infer.rs
@@ -626,22 +626,4 @@ mod tests {
 
         assert_public_type(&case, "a", "x", "Literal[C1] | Literal[C2] | Literal[C3]")
     }
-
-    #[test]
-    fn ifexpr_nested() -> anyhow::Result<()> {
-        let case = create_test()?;
-
-        write_to_path(
-            &case,
-            "a.py",
-            "
-                class C1: pass
-                class C2: pass
-                class C3: pass
-                x = C1 if flag else C2 if flag2 else C3
-            ",
-        )?;
-
-        assert_public_type(&case, "a", "x", "(Literal[C1] | Literal[C2] | Literal[C3])")
-    }
 }


### PR DESCRIPTION
Somehow a merge of a PR that had all-green CI duplicated this test when it merged into main, breaking the build.
