### PR TITLE
[red-knot] add type narrowing

### DIFF
--- a/crates/red_knot/src/semantic.rs
+++ b/crates/red_knot/src/semantic.rs
@@ -837,7 +837,7 @@ mod tests {
         };
         let x_defs: Vec<_> = index
             .reachable_definitions(x_sym, x_use)
-            .map(|cd| cd.definition)
+            .map(|constrained_definition| constrained_definition.definition)
             .collect();
         assert_eq!(x_defs.len(), 1);
         let Definition::Assignment(node_key) = &x_defs[0] else {

--- a/crates/red_knot/src/semantic.rs
+++ b/crates/red_knot/src/semantic.rs
@@ -464,6 +464,7 @@ impl SourceOrderVisitor<'_> for SemanticIndexer {
             }
             ast::Stmt::Assign(node) => {
                 debug_assert!(self.current_definition.is_none());
+                self.visit_expr(&node.value);
                 self.current_definition =
                     Some(Definition::Assignment(TypedNodeKey::from_node(node)));
                 for expr in &node.targets {
@@ -471,7 +472,6 @@ impl SourceOrderVisitor<'_> for SemanticIndexer {
                 }
 
                 self.current_definition = None;
-                self.visit_expr(&node.value);
             }
             ast::Stmt::If(node) => {
                 // TODO detect statically known truthy or falsy test (via type inference, not naive

--- a/crates/red_knot/src/semantic.rs
+++ b/crates/red_knot/src/semantic.rs
@@ -2,6 +2,7 @@ use std::num::NonZeroU32;
 
 use ruff_python_ast as ast;
 use ruff_python_ast::visitor::source_order::SourceOrderVisitor;
+use ruff_python_ast::AstNode;
 
 use crate::ast_ids::{NodeKey, TypedNodeKey};
 use crate::cache::KeyValueCache;
@@ -13,8 +14,9 @@ use crate::parse::parse;
 use crate::Name;
 pub(crate) use definitions::Definition;
 use definitions::{ImportDefinition, ImportFromDefinition};
+pub(crate) use flow_graph::ConstrainedDefinition;
 use flow_graph::{FlowGraph, FlowGraphBuilder, FlowNodeId, ReachableDefinitionsIterator};
-use ruff_index::newtype_index;
+use ruff_index::{newtype_index, IndexVec};
 use rustc_hash::FxHashMap;
 use std::ops::{Deref, DerefMut};
 use std::sync::Arc;
@@ -78,6 +80,7 @@ impl SemanticIndex {
                 current_flow_node_id: FlowGraph::start(),
             }],
             expressions: FxHashMap::default(),
+            expressions_by_id: IndexVec::default(),
             current_definition: None,
         };
         indexer.visit_body(&module.body);
@@ -123,6 +126,7 @@ struct SemanticIndexer {
     /// the definition whose target(s) we are currently walking
     current_definition: Option<Definition>,
     expressions: FxHashMap<NodeKey, ExpressionId>,
+    expressions_by_id: IndexVec<ExpressionId, NodeKey>,
 }
 
 impl SemanticIndexer {
@@ -211,6 +215,23 @@ impl SemanticIndexer {
             .record_scope_for_node(node_key, scope_id);
     }
 
+    fn insert_constraint(&mut self, expr: &ast::Expr) {
+        let node_key = NodeKey::from_node(expr.into());
+        let expression_id = self.expressions[&node_key];
+        let constraint = self
+            .flow_graph_builder
+            .add_constraint(self.current_flow_node(), expression_id);
+        self.set_current_flow_node(constraint);
+    }
+
+    fn expression(&self, ast: &ast::ModModule, expression_id: ExpressionId) -> &ast::Expr {
+        let node_key = self.expressions_by_id[expression_id];
+        let node = node_key
+            .resolve(ast.as_any_node_ref())
+            .expect("node to resolve");
+        // TODO how to get an Expr out of a NodeKey?
+    }
+
     fn with_type_params(
         &mut self,
         name: &str,
@@ -240,9 +261,14 @@ impl SemanticIndexer {
 
 impl SourceOrderVisitor<'_> for SemanticIndexer {
     fn visit_expr(&mut self, expr: &ast::Expr) {
-        let expression_id = self
-            .flow_graph_builder
-            .record_expr(self.current_flow_node());
+        let node_key = NodeKey::from_node(expr.into());
+        let expression_id = self.expressions_by_id.push(node_key);
+
+        debug_assert_eq!(
+            expression_id,
+            self.flow_graph_builder
+                .record_expr(self.current_flow_node())
+        );
 
         debug_assert_eq!(
             expression_id,
@@ -250,8 +276,7 @@ impl SourceOrderVisitor<'_> for SemanticIndexer {
                 .record_expression(self.cur_scope())
         );
 
-        self.expressions
-            .insert(NodeKey::from_node(expr.into()), expression_id);
+        self.expressions.insert(node_key, expression_id);
 
         match expr {
             ast::Expr::Name(ast::ExprName { id, ctx, .. }) => {
@@ -290,6 +315,7 @@ impl SourceOrderVisitor<'_> for SemanticIndexer {
                 let if_branch = self.flow_graph_builder.add_branch(self.current_flow_node());
 
                 self.set_current_flow_node(if_branch);
+                self.insert_constraint(test);
                 self.visit_expr(body);
 
                 let post_body = self.current_flow_node();
@@ -453,6 +479,7 @@ impl SourceOrderVisitor<'_> for SemanticIndexer {
 
                 // visit the body of the `if` clause
                 self.set_current_flow_node(if_branch);
+                self.insert_constraint(&node.test);
                 self.visit_body(&node.body);
 
                 // Flow node for the last if/elif condition branch; represents the "no branch
@@ -471,13 +498,15 @@ impl SourceOrderVisitor<'_> for SemanticIndexer {
                 let mut last_branch_is_else = false;
 
                 for clause in &node.elif_else_clauses {
-                    if clause.test.is_some() {
+                    if let Some(test) = &clause.test {
+                        self.visit_expr(&test);
                         // This is an elif clause. Create a new branch node. Its predecessor is the
                         // previous branch node, because we can only take one branch in an entire
                         // if/elif/else chain, so if we take this branch, it can only be because we
                         // didn't take the previous one.
                         prior_branch = self.flow_graph_builder.add_branch(prior_branch);
                         self.set_current_flow_node(prior_branch);
+                        self.insert_constraint(test);
                     } else {
                         // This is an else clause. No need to create a branch node; there's no
                         // branch here, if we haven't taken any previous branch, we definitely go
@@ -799,7 +828,10 @@ mod tests {
         let ast::Stmt::Expr(ast::StmtExpr { value: x_use, .. }) = &ast.body[1] else {
             panic!("should be an expr")
         };
-        let x_defs: Vec<_> = index.reachable_definitions(x_sym, x_use).collect();
+        let x_defs: Vec<_> = index
+            .reachable_definitions(x_sym, x_use)
+            .map(|cd| cd.definition)
+            .collect();
         assert_eq!(x_defs.len(), 1);
         let Definition::Assignment(node_key) = &x_defs[0] else {
             panic!("def should be an assignment")

--- a/crates/red_knot/src/semantic.rs
+++ b/crates/red_knot/src/semantic.rs
@@ -224,12 +224,15 @@ impl SemanticIndexer {
         self.set_current_flow_node(constraint);
     }
 
-    fn expression(&self, ast: &ast::ModModule, expression_id: ExpressionId) -> &ast::Expr {
+    fn resolve_expression_id(
+        &self,
+        ast: &ast::ModModule,
+        expression_id: ExpressionId,
+    ) -> &ast::Expr {
         let node_key = self.expressions_by_id[expression_id];
         let node = node_key
             .resolve(ast.as_any_node_ref())
             .expect("node to resolve");
-        // TODO how to get an Expr out of a NodeKey?
     }
 
     fn with_type_params(

--- a/crates/red_knot/src/semantic/flow_graph.rs
+++ b/crates/red_knot/src/semantic/flow_graph.rs
@@ -12,9 +12,10 @@ pub(crate) enum FlowNode {
     Definition(DefinitionFlowNode),
     Branch(BranchFlowNode),
     Phi(PhiFlowNode),
+    Constraint(ConstraintFlowNode),
 }
 
-/// A Definition node represents a point in control flow where a symbol is defined
+/// A point in control flow where a symbol is defined
 #[derive(Debug)]
 pub(crate) struct DefinitionFlowNode {
     symbol_id: SymbolId,
@@ -22,17 +23,24 @@ pub(crate) struct DefinitionFlowNode {
     predecessor: FlowNodeId,
 }
 
-/// A Branch node represents a branch in control flow
+/// A branch in control flow
 #[derive(Debug)]
 pub(crate) struct BranchFlowNode {
     predecessor: FlowNodeId,
 }
 
-/// A Phi node represents a join point where control flow paths come together
+/// A join point where control flow paths come together
 #[derive(Debug)]
 pub(crate) struct PhiFlowNode {
     first_predecessor: FlowNodeId,
     second_predecessor: FlowNodeId,
+}
+
+/// A branch test which may apply constraints to a symbol's type
+#[derive(Debug)]
+pub(crate) struct ConstraintFlowNode {
+    predecessor: FlowNodeId,
+    test_expression: ExpressionId,
 }
 
 #[derive(Debug)]
@@ -98,6 +106,17 @@ impl FlowGraphBuilder {
         }))
     }
 
+    pub(crate) fn add_constraint(
+        &mut self,
+        predecessor: FlowNodeId,
+        test_expression: ExpressionId,
+    ) -> FlowNodeId {
+        self.add(FlowNode::Constraint(ConstraintFlowNode {
+            predecessor,
+            test_expression,
+        }))
+    }
+
     pub(super) fn record_expr(&mut self, node_id: FlowNodeId) -> ExpressionId {
         self.flow_graph.expression_map.push(node_id)
     }
@@ -109,11 +128,18 @@ impl FlowGraphBuilder {
     }
 }
 
+#[derive(Debug, Clone)]
+pub struct ConstrainedDefinition {
+    pub definition: Definition,
+    pub constraints: Vec<ExpressionId>,
+}
+
 #[derive(Debug)]
 pub struct ReachableDefinitionsIterator<'a> {
     flow_graph: &'a FlowGraph,
     symbol_id: SymbolId,
     pending: Vec<FlowNodeId>,
+    constraints: Vec<ExpressionId>,
 }
 
 impl<'a> ReachableDefinitionsIterator<'a> {
@@ -122,21 +148,34 @@ impl<'a> ReachableDefinitionsIterator<'a> {
             flow_graph,
             symbol_id,
             pending: vec![start_node_id],
+            constraints: vec![],
         }
     }
 }
 
 impl<'a> Iterator for ReachableDefinitionsIterator<'a> {
-    type Item = Definition;
+    type Item = ConstrainedDefinition;
 
     fn next(&mut self) -> Option<Self::Item> {
         loop {
             let flow_node_id = self.pending.pop()?;
             match &self.flow_graph.flow_nodes_by_id[flow_node_id] {
-                FlowNode::Start => return Some(Definition::Unbound),
+                FlowNode::Start => {
+                    // constraints on unbound are irrelevant
+                    self.constraints.clear();
+                    return Some(ConstrainedDefinition {
+                        definition: Definition::Unbound,
+                        constraints: vec![],
+                    });
+                }
                 FlowNode::Definition(def_node) => {
                     if def_node.symbol_id == self.symbol_id {
-                        return Some(def_node.definition.clone());
+                        let mut constrained_def = ConstrainedDefinition {
+                            definition: def_node.definition.clone(),
+                            constraints: vec![],
+                        };
+                        std::mem::swap(&mut constrained_def.constraints, &mut self.constraints);
+                        return Some(constrained_def);
                     }
                     self.pending.push(def_node.predecessor);
                 }
@@ -146,6 +185,10 @@ impl<'a> Iterator for ReachableDefinitionsIterator<'a> {
                 FlowNode::Phi(phi_node) => {
                     self.pending.push(phi_node.first_predecessor);
                     self.pending.push(phi_node.second_predecessor);
+                }
+                FlowNode::Constraint(constraint_node) => {
+                    self.pending.push(constraint_node.predecessor);
+                    self.constraints.push(constraint_node.test_expression);
                 }
             }
         }
@@ -191,6 +234,15 @@ impl std::fmt::Display for FlowGraph {
                         f,
                         r"  id{}-->id{}",
                         phi_node.first_predecessor.as_u32(),
+                        id.as_u32()
+                    )?;
+                }
+                FlowNode::Constraint(constraint_node) => {
+                    writeln!(f, r"((Constraint))")?;
+                    writeln!(
+                        f,
+                        r"  id{}-->id{}",
+                        constraint_node.predecessor.as_u32(),
                         id.as_u32()
                     )?;
                 }

--- a/crates/red_knot/src/semantic/flow_graph.rs
+++ b/crates/red_knot/src/semantic/flow_graph.rs
@@ -174,6 +174,9 @@ impl<'a> Iterator for ReachableDefinitionsIterator<'a> {
                             definition: def_node.definition.clone(),
                             constraints: vec![],
                         };
+                        // TODO this isn't correct, some constraints will still apply to the
+                        // next pending flow node; need to record constraints with each pending
+                        // node
                         std::mem::swap(&mut constrained_def.constraints, &mut self.constraints);
                         return Some(constrained_def);
                     }

--- a/crates/red_knot/src/semantic/types.rs
+++ b/crates/red_knot/src/semantic/types.rs
@@ -265,6 +265,7 @@ impl TypeStore {
                 _ => flattened.push(*ty),
             }
         }
+        // TODO don't add identical unions
         // TODO de-duplicate union elements
         match flattened[..] {
             [] => Type::Never,
@@ -306,6 +307,7 @@ impl TypeStore {
                 _ => neg_flattened.push(*ty),
             }
         }
+        // TODO don't add identical intersections
         // TODO deduplicate intersection elements
         // TODO maintain DNF form (union of intersections)
         match (&pos_flattened[..], &neg_flattened[..]) {

--- a/crates/red_knot/src/semantic/types.rs
+++ b/crates/red_knot/src/semantic/types.rs
@@ -256,7 +256,7 @@ impl TypeStore {
         self.add_or_get_module(file_id).add_union(elems)
     }
 
-    /// add union with normalization; may not return a UnionType
+    /// add union with normalization; may not return a `UnionType`
     fn add_union(&self, file_id: FileId, elems: &[Type]) -> Type {
         let mut flattened = Vec::with_capacity(elems.len());
         for ty in elems {
@@ -284,7 +284,7 @@ impl TypeStore {
             .add_intersection(positive, negative)
     }
 
-    /// add intersection with normalization; may not return an IntersectionType
+    /// add intersection with normalization; may not return an `IntersectionType`
     fn add_intersection(&self, file_id: FileId, positive: &[Type], negative: &[Type]) -> Type {
         let mut pos_flattened = Vec::with_capacity(positive.len());
         let mut neg_flattened = Vec::with_capacity(negative.len());

--- a/crates/red_knot/src/semantic/types/infer.rs
+++ b/crates/red_knot/src/semantic/types/infer.rs
@@ -756,11 +756,6 @@ mod tests {
 
         // TODO normalization of unions and intersections: this type is technically correct but
         // begging for normalization
-        assert_public_type(
-            &case,
-            "a",
-            "z",
-            "Literal[0] | Literal[1] | None & ~None | Literal[1] | None & ~None",
-        )
+        assert_public_type(&case, "a", "z", "Literal[0] | Literal[1] | None & ~None")
     }
 }

--- a/crates/red_knot/src/semantic/types/infer.rs
+++ b/crates/red_knot/src/semantic/types/infer.rs
@@ -101,14 +101,12 @@ pub fn infer_constrained_definition_type(
         definition,
         constraints,
     } = constrained_definition;
-    let definition_type = infer_definition_type(db, symbol, definition)?;
-    let constraint_types: Vec<Option<Type>> = constraints
-        .into_iter()
-        .map(|constraint| infer_constraint_type(db, symbol, constraint))
-        .collect::<QueryResult<Vec<_>>>()?;
-    let intersected_types: Vec<Type> = std::iter::once(definition_type)
-        .chain(constraint_types.into_iter().flatten())
-        .collect();
+    let mut intersected_types = vec![infer_definition_type(db, symbol, definition)?];
+    for constraint in constraints {
+        if let Some(constraint_type) = infer_constraint_type(db, symbol, constraint)? {
+            intersected_types.push(constraint_type);
+        }
+    }
     let jar: &SemanticJar = db.jar()?;
     Ok(jar
         .type_store
@@ -243,6 +241,7 @@ fn infer_constraint_type(
     constraint: ExpressionId,
 ) -> QueryResult<Option<Type>> {
     let index = semantic_index(db, symbol_id.file_id)?;
+    // TODO actually infer constraints
     Ok(None)
 }
 


### PR DESCRIPTION
## Summary

Add Constraint nodes to flow graph, and narrow types based on that (only `is None` and `is not None` narrowing supported for now, to prototype the structure.)

Also add simplification of zero- and one-element unions and intersections, and flattening of intersections.

There's a lot more normalization logic needed for unions and intersections (as is obvious from the inferred type in the added `narrow_none` test), but this will be non-trivial and I'd rather do it in a separate PR.

Here's a flowchart diagram for the code in the added `narrow_none` test:

![Screenshot 2024-06-07 at 2 58 00 PM](https://github.com/astral-sh/ruff/assets/61586/5152a400-739c-41ff-8bbf-3c19d16bd083)

The top branch is for the `if` expression in the initial assignment to `x`; that `Constraint` node would only affect the type of `flag`, which we don't care about in this test.

The second branch is for the `if` statement, with `Constraint` node affecting the type of `x`.

## Test Plan

Added tests.
