### PR TITLE
Remove `result_like` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1630,17 +1630,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
 
 [[package]]
-name = "pmutil"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52a40bc70c2c58040d2d8b167ba9a5ff59fc9dab7ad44771cfde3dcfde7a09c6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "portable-atomic"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1860,27 +1849,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
 
 [[package]]
-name = "result-like"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abf7172fef6a7d056b5c26bf6c826570267562d51697f4982ff3ba4aec68a9df"
-dependencies = [
- "result-like-derive",
-]
-
-[[package]]
-name = "result-like-derive"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8d6574c02e894d66370cfc681e5d68fedbc9a548fb55b30a96b3f0ae22d0fe5"
-dependencies = [
- "pmutil",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "ring"
 version = "0.17.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2086,7 +2054,6 @@ dependencies = [
  "pyproject-toml",
  "quick-junit",
  "regex",
- "result-like",
  "ruff_cache",
  "ruff_diagnostics",
  "ruff_macros",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,7 +99,6 @@ quote = { version = "1.0.23" }
 rand = { version = "0.8.5" }
 rayon = { version = "1.10.0" }
 regex = { version = "1.10.2" }
-result-like = { version = "0.5.0" }
 rustc-hash = { version = "1.1.0" }
 schemars = { version = "0.8.16" }
 seahash = { version = "4.1.0" }

--- a/crates/ruff/src/commands/check.rs
+++ b/crates/ruff/src/commands/check.rs
@@ -59,7 +59,7 @@ pub(crate) fn check(
     );
 
     // Load the caches.
-    let caches = if bool::from(cache) {
+    let caches = if cache.is_enabled() {
         Some(PackageCacheMap::init(&package_roots, &resolver))
     } else {
         None

--- a/crates/ruff/src/diagnostics.rs
+++ b/crates/ruff/src/diagnostics.rs
@@ -186,7 +186,7 @@ pub(crate) fn lint_path(
 ) -> Result<Diagnostics> {
     // Check the cache.
     let caching = match cache {
-        Some(cache) if noqa.into() => {
+        Some(cache) if noqa.is_enabled() => {
             let relative_path = cache
                 .relative_path(path)
                 .expect("wrong package cache for file");

--- a/crates/ruff_linter/Cargo.toml
+++ b/crates/ruff_linter/Cargo.toml
@@ -56,7 +56,6 @@ pep440_rs = { workspace = true, features = ["serde"] }
 pyproject-toml = { workspace = true }
 quick-junit = { workspace = true }
 regex = { workspace = true }
-result-like = { workspace = true }
 rustc-hash = { workspace = true }
 schemars = { workspace = true, optional = true }
 serde = { workspace = true }

--- a/crates/ruff_linter/src/checkers/ast/mod.rs
+++ b/crates/ruff_linter/src/checkers/ast/mod.rs
@@ -281,7 +281,7 @@ impl<'a> Checker<'a> {
         // members from the fix that will eventually be excluded by a `noqa`.
         // Unfortunately, we _do_ want to register a `Diagnostic` for each
         // eventually-ignored import, so that our `noqa` counts are accurate.
-        if !self.noqa.to_bool() {
+        if !self.noqa.is_enabled() {
             return false;
         }
         noqa::rule_is_ignored(code, offset, self.noqa_line_for, self.locator)

--- a/crates/ruff_linter/src/linter.rs
+++ b/crates/ruff_linter/src/linter.rs
@@ -299,7 +299,7 @@ pub fn check_path(
     }
 
     // Enforce `noqa` directives.
-    if (noqa.into() && !diagnostics.is_empty())
+    if (noqa.is_enabled() && !diagnostics.is_empty())
         || settings
             .rules
             .iter_enabled()
@@ -315,7 +315,7 @@ pub fn check_path(
             &per_file_ignores,
             settings,
         );
-        if noqa.into() {
+        if noqa.is_enabled() {
             for index in ignored.iter().rev() {
                 diagnostics.swap_remove(*index);
             }

--- a/crates/ruff_linter/src/settings/flags.rs
+++ b/crates/ruff_linter/src/settings/flags.rs
@@ -5,14 +5,46 @@ pub enum FixMode {
     Diff,
 }
 
-#[derive(Debug, Copy, Clone, Hash, result_like::BoolLike)]
+#[derive(Debug, Copy, Clone, Hash)]
 pub enum Noqa {
     Enabled,
     Disabled,
 }
 
-#[derive(Debug, Copy, Clone, Hash, result_like::BoolLike)]
+impl Noqa {
+    pub const fn is_enabled(self) -> bool {
+        matches!(self, Noqa::Enabled)
+    }
+}
+
+impl From<bool> for Noqa {
+    fn from(value: bool) -> Self {
+        if value {
+            Noqa::Enabled
+        } else {
+            Noqa::Disabled
+        }
+    }
+}
+
+#[derive(Debug, Copy, Clone, Hash)]
 pub enum Cache {
     Enabled,
     Disabled,
+}
+
+impl Cache {
+    pub const fn is_enabled(self) -> bool {
+        matches!(self, Cache::Enabled)
+    }
+}
+
+impl From<bool> for Cache {
+    fn from(value: bool) -> Self {
+        if value {
+            Cache::Enabled
+        } else {
+            Cache::Disabled
+        }
+    }
 }


### PR DESCRIPTION
## Summary

This PR removes the `result-like` dependency and instead implement the required functionality. The motivation being that `noqa.is_enabled()` is easier to read than `noqa.into()`.

For context, I was just trying to understand the syntax error workflow and I saw these flags which were being converted via `into`. I always find `into` confusing because you never know what's it being converted into unless you know the type. Later realized that it's just a boolean flag. After removing the usages from these two flags, it turns out that the dependency is only being used in one rule so I thought to remove that as well.

## Test Plan

`cargo insta test`
