### PR TITLE
gitignore `.DS_STORE` files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -210,6 +210,9 @@ cython_debug/
 .*.sw?
 .sw?
 
+# Finder adds these files on MacOS
+.DS_STORE
+
 # Custom re-inclusions for the resolver test cases
 !crates/ruff_python_resolver/resources/test/airflow/venv/
 !crates/ruff_python_resolver/resources/test/airflow/venv/lib


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

It's really annoying to have a dirty working tree just because I opened a Ruff subdirectory in Finder

## Test Plan

I opened some subdirectories of Ruff with Finder and the `.DS_STORE` files that were added by Finder were no longer tracked by git.
