### PR TITLE
Use real file path when available in `ruff server`

### DIFF
--- a/crates/ruff_server/src/fix.rs
+++ b/crates/ruff_server/src/fix.rs
@@ -71,7 +71,7 @@ pub(crate) fn fix_all(
         result: LinterResult { error, .. },
         ..
     } = ruff_linter::linter::lint_fix(
-        query.virtual_file_path(),
+        &query.virtual_file_path(),
         package,
         flags::Noqa::Enabled,
         UnsafeFixes::Disabled,

--- a/crates/ruff_server/src/lint.rs
+++ b/crates/ruff_server/src/lint.rs
@@ -113,7 +113,7 @@ pub(crate) fn check(query: &DocumentQuery, encoding: PositionEncoding) -> Diagno
 
     // Generate checks.
     let LinterResult { data, .. } = check_path(
-        query.virtual_file_path(),
+        &query.virtual_file_path(),
         package,
         &locator,
         &stylist,
@@ -127,7 +127,7 @@ pub(crate) fn check(query: &DocumentQuery, encoding: PositionEncoding) -> Diagno
     );
 
     let noqa_edits = generate_noqa_edits(
-        query.virtual_file_path(),
+        &query.virtual_file_path(),
         data.as_slice(),
         &locator,
         parsed.comment_ranges(),

--- a/crates/ruff_server/src/session/index.rs
+++ b/crates/ruff_server/src/session/index.rs
@@ -1,8 +1,12 @@
+use std::borrow::Cow;
+use std::path::PathBuf;
+use std::{collections::BTreeMap, path::Path, sync::Arc};
+
 use anyhow::anyhow;
 use lsp_types::Url;
 use rustc_hash::FxHashMap;
-use std::path::PathBuf;
-use std::{collections::BTreeMap, path::Path, sync::Arc};
+
+pub(crate) use ruff_settings::RuffSettings;
 
 use crate::{
     edit::{DocumentKey, DocumentVersion, NotebookDocument},
@@ -12,8 +16,6 @@ use crate::{
 use super::{settings::ResolvedClientSettings, ClientSettings};
 
 mod ruff_settings;
-
-pub(crate) use ruff_settings::RuffSettings;
 
 type SettingsIndex = BTreeMap<PathBuf, WorkspaceSettings>;
 
@@ -544,8 +546,10 @@ impl DocumentQuery {
     /// Get the path for the document selected by this query, ignoring whether the file exists on disk.
     ///
     /// Returns the URL's path if this is an unsaved (untitled) document.
-    pub(crate) fn virtual_file_path(&self) -> &Path {
-        Path::new(self.file_url().path())
+    pub(crate) fn virtual_file_path(&self) -> Cow<Path> {
+        self.file_path()
+            .map(Cow::Owned)
+            .unwrap_or_else(|| Cow::Borrowed(Path::new(self.file_url().path())))
     }
 
     /// Attempt to access the single inner text document selected by the query.


### PR DESCRIPTION
## Summary

As-is, we're using the URL path for all files, leading us to use paths like:

```
/c%3A/Users/crmar/workspace/fastapi/tests/main.py
```

This doesn't match against per-file ignores and other patterns in Ruff configuration.

This PR modifies the LSP to use the real file path if available, and the virtual file path if not.

Closes https://github.com/astral-sh/ruff/issues/11751.

## Test Plan

Ran the LSP on Windows. In the FastAPI repo, added:

```toml
[tool.ruff.lint.per-file-ignores]
"tests/**/*.py" = ["F401"]
```

And verified that an unused import was ignored in `tests` after this change, but not before.
