### PR TITLE
[POC] `ruff server` Expand format action capability

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -6,5 +6,5 @@ benchmark = "bench -p ruff_benchmark --bench linter --bench formatter --"
 # that shared/dynamic library.
 #
 # See: https://github.com/astral-sh/ruff/issues/11503
-[target.'cfg(all(target_env="msvc", target_os = "windows"))']
+[target.'cfg(all(target_env = "msvc", target_os = "windows"))']
 rustflags = ["-C", "target-feature=+crt-static"]

--- a/crates/ruff_server/resources/test/fixtures/settings/global_only.json
+++ b/crates/ruff_server/resources/test/fixtures/settings/global_only.json
@@ -9,7 +9,9 @@
             "ignore": ["RUF001"],
             "run": "onSave"
         },
-        "fixAll": false,
+        "sourceAction": {
+            "fixAll": false
+        },
         "logLevel": "warn",
         "lineLength": 80,
         "exclude": ["third_party"]

--- a/crates/ruff_server/resources/test/fixtures/settings/vs_code_initialization_options.json
+++ b/crates/ruff_server/resources/test/fixtures/settings/vs_code_initialization_options.json
@@ -28,9 +28,11 @@
             "format": {
                 "args": []
             },
+            "sourceAction": {
+                "organizeImports": true,
+                "fixAll": true
+            },
             "enable": true,
-            "organizeImports": true,
-            "fixAll": true,
             "showNotifications": "off"
         },
         {
@@ -62,9 +64,11 @@
             "format": {
                 "args": []
             },
+            "sourceAction": {
+                "organizeImports": true,
+                "fixAll": true
+            },
             "enable": true,
-            "organizeImports": true,
-            "fixAll": true,
             "showNotifications": "off"
         }
     ],
@@ -87,7 +91,10 @@
         "lint": {
             "enable": true,
             "preview": true,
-            "select": ["F", "I"],
+            "select": [
+                "F",
+                "I"
+            ],
             "run": "onType",
             "args": [
                 "--preview"
@@ -96,9 +103,11 @@
         "format": {
             "args": []
         },
+        "sourceAction": {
+            "organizeImports": true,
+            "fixAll": false
+        },
         "enable": true,
-        "organizeImports": true,
-        "fixAll": false,
         "showNotifications": "off"
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary
implement https://github.com/astral-sh/ruff/issues/11756#issuecomment-2155720286 which is currently not ready for notebook documents:
```json
{
    "ruff.format.action": {
        "fix": true,
        "isort": true,
        "style": true,
    }
}
```

This PR also moves `ruff.fixAll` and `ruff.organizeImports` under `ruff.sourceAction` superset.


## Test Plan

Not tested yet

(self-note: also mention revealment issues on ruff-vscode/ruff-lsp)