### PR TITLE
[`pylint`] Fix flag name in `too-many-public-methods` (`PLR0904`)

### DIFF
--- a/crates/ruff_linter/src/rules/pylint/rules/too_many_public_methods.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/too_many_public_methods.rs
@@ -19,7 +19,7 @@ use crate::checkers::ast::Checker;
 /// Instead, consider refactoring the class into separate classes.
 ///
 /// ## Example
-/// Assuming that `pylint.max-public-settings` is set to 5:
+/// Assuming that `lint.pylint.max-public-methods` is set to 5:
 /// ```python
 /// class Linter:
 ///     def __init__(self):


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->
Corrects the name of the flag in the docs for the `too-many-public-methods` rule (`PLR0904`).


## Test Plan

<!-- How was it tested? -->
Not tested locally.
