### PR TITLE
Set 1.75 as minimal Rust version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2021"
-rust-version = "1.74"
+rust-version = "1.75"
 homepage = "https://docs.astral.sh/ruff"
 documentation = "https://docs.astral.sh/ruff"
 repository = "https://github.com/astral-sh/ruff"


### PR DESCRIPTION
## Summary

Salsa requires https://github.com/rust-lang/rust/issues/91611 which stabalized with [1.75](https://blog.rust-lang.org/2023/12/28/Rust-1.75.0.html)

1.75 doesn't change the supported platforms. So I think this upgrade is fine in a minor.

## Test Plan

`cargo build`
