### PR TITLE
`ruff server`: Improve error message when a command is run on an unavailable document

### DIFF
--- a/crates/ruff_server/src/server/api/requests/execute_command.rs
+++ b/crates/ruff_server/src/server/api/requests/execute_command.rs
@@ -68,10 +68,10 @@ impl super::SyncRequestHandler for ExecuteCommand {
 
         let mut edit_tracker = WorkspaceEditTracker::new(session.resolved_client_capabilities());
         for Argument { uri, version } in arguments {
-            let snapshot = session
-                .take_snapshot(uri.clone())
-                .ok_or(anyhow::anyhow!("Document snapshot not available for {uri}",))
-                .with_failure_code(ErrorCode::InternalError)?;
+            let Some(snapshot) = session.take_snapshot(uri.clone()) else {
+                tracing::warn!("Document at {uri} could not be opened");
+                return Ok(None);
+            };
             match command {
                 Command::FixAll => {
                     let fixes = super::code_action_resolve::fix_all_edit(

--- a/crates/ruff_server/src/server/api/requests/execute_command.rs
+++ b/crates/ruff_server/src/server/api/requests/execute_command.rs
@@ -69,7 +69,8 @@ impl super::SyncRequestHandler for ExecuteCommand {
         let mut edit_tracker = WorkspaceEditTracker::new(session.resolved_client_capabilities());
         for Argument { uri, version } in arguments {
             let Some(snapshot) = session.take_snapshot(uri.clone()) else {
-                tracing::warn!("Document at {uri} could not be opened");
+                tracing::error!("Document at {uri} could not be opened");
+                show_err_msg!("Ruff does not recognize this file");
                 return Ok(None);
             };
             match command {


### PR DESCRIPTION
## Summary

Fixes #11744.

We now show a distinct popup message when we fail to get a document snapshot during command execution. This message more clearly communicates the issue to the user, instead of a generic "ruff encountered an error" message.

## Test Plan

Try running `Fix all auto-fixable problems` on an incompatible file (for example: `settings.json`). You should see the following popup message:
<img width="456" alt="Screenshot 2024-06-11 at 11 47 16 AM" src="https://github.com/astral-sh/ruff/assets/19577865/3a28e3d7-3896-4dd0-b117-f87300dd3b68">

