### PR TITLE
red-knot: Add a method to resolve a file for an arbitrary `VfsPath`

### DIFF
--- a/crates/ruff_db/src/parsed.rs
+++ b/crates/ruff_db/src/parsed.rs
@@ -70,7 +70,7 @@ mod tests {
     use crate::parsed::parsed_module;
     use crate::tests::TestDb;
     use crate::vfs::VendoredPath;
-    use crate::vfs::{file_system_path_to_file, vendored_path_to_file};
+    use crate::vfs::{system_path_to_file, vendored_path_to_file};
 
     #[test]
     fn python_file() -> crate::file_system::Result<()> {
@@ -80,7 +80,7 @@ mod tests {
         db.file_system_mut()
             .write_file(path, "x = 10".to_string())?;
 
-        let file = file_system_path_to_file(&db, path).unwrap();
+        let file = system_path_to_file(&db, path).unwrap();
 
         let parsed = parsed_module(&db, file);
 
@@ -97,7 +97,7 @@ mod tests {
         db.file_system_mut()
             .write_file(path, "%timeit a = b".to_string())?;
 
-        let file = file_system_path_to_file(&db, path).unwrap();
+        let file = system_path_to_file(&db, path).unwrap();
 
         let parsed = parsed_module(&db, file);
 

--- a/crates/ruff_db/src/parsed.rs
+++ b/crates/ruff_db/src/parsed.rs
@@ -70,17 +70,17 @@ mod tests {
     use crate::parsed::parsed_module;
     use crate::tests::TestDb;
     use crate::vfs::VendoredPath;
-    use crate::Db;
+    use crate::vfs::{file_system_path_to_file, vendored_path_to_file};
 
     #[test]
     fn python_file() -> crate::file_system::Result<()> {
         let mut db = TestDb::new();
-        let path = FileSystemPath::new("test.py");
+        let path = "test.py";
 
         db.file_system_mut()
             .write_file(path, "x = 10".to_string())?;
 
-        let file = db.file(path);
+        let file = file_system_path_to_file(&db, path);
 
         let parsed = parsed_module(&db, file);
 
@@ -97,7 +97,7 @@ mod tests {
         db.file_system_mut()
             .write_file(path, "%timeit a = b".to_string())?;
 
-        let file = db.file(path);
+        let file = file_system_path_to_file(&db, path);
 
         let parsed = parsed_module(&db, file);
 
@@ -122,7 +122,7 @@ else:
     from posixpath import __all__ as __all__"#,
         )]);
 
-        let file = db.vendored_file(VendoredPath::new("path.pyi")).unwrap();
+        let file = vendored_path_to_file(&db, VendoredPath::new("path.pyi")).unwrap();
 
         let parsed = parsed_module(&db, file);
 

--- a/crates/ruff_db/src/parsed.rs
+++ b/crates/ruff_db/src/parsed.rs
@@ -80,7 +80,7 @@ mod tests {
         db.file_system_mut()
             .write_file(path, "x = 10".to_string())?;
 
-        let file = file_system_path_to_file(&db, path);
+        let file = file_system_path_to_file(&db, path).unwrap();
 
         let parsed = parsed_module(&db, file);
 
@@ -97,7 +97,7 @@ mod tests {
         db.file_system_mut()
             .write_file(path, "%timeit a = b".to_string())?;
 
-        let file = file_system_path_to_file(&db, path);
+        let file = file_system_path_to_file(&db, path).unwrap();
 
         let parsed = parsed_module(&db, file);
 

--- a/crates/ruff_db/src/source.rs
+++ b/crates/ruff_db/src/source.rs
@@ -63,7 +63,7 @@ mod tests {
     use crate::file_system::FileSystemPath;
     use crate::source::{line_index, source_text};
     use crate::tests::TestDb;
-    use crate::Db;
+    use crate::vfs::file_system_path_to_file;
 
     #[test]
     fn re_runs_query_when_file_revision_changes() -> crate::file_system::Result<()> {
@@ -73,7 +73,7 @@ mod tests {
         db.file_system_mut()
             .write_file(path, "x = 10".to_string())?;
 
-        let file = db.file(path);
+        let file = file_system_path_to_file(&db, path);
 
         assert_eq!(&*source_text(&db, file), "x = 10");
 
@@ -95,7 +95,7 @@ mod tests {
         db.file_system_mut()
             .write_file(path, "x = 10".to_string())?;
 
-        let file = db.file(path);
+        let file = file_system_path_to_file(&db, path);
 
         assert_eq!(&*source_text(&db, file), "x = 10");
 
@@ -122,7 +122,7 @@ mod tests {
         db.file_system_mut()
             .write_file(path, "x = 10\ny = 20".to_string())?;
 
-        let file = db.file(path);
+        let file = file_system_path_to_file(&db, path);
         let index = line_index(&db, file);
         let text = source_text(&db, file);
 

--- a/crates/ruff_db/src/source.rs
+++ b/crates/ruff_db/src/source.rs
@@ -63,7 +63,7 @@ mod tests {
     use crate::file_system::FileSystemPath;
     use crate::source::{line_index, source_text};
     use crate::tests::TestDb;
-    use crate::vfs::file_system_path_to_file;
+    use crate::vfs::system_path_to_file;
 
     #[test]
     fn re_runs_query_when_file_revision_changes() -> crate::file_system::Result<()> {
@@ -73,7 +73,7 @@ mod tests {
         db.file_system_mut()
             .write_file(path, "x = 10".to_string())?;
 
-        let file = file_system_path_to_file(&db, path).unwrap();
+        let file = system_path_to_file(&db, path).unwrap();
 
         assert_eq!(&*source_text(&db, file), "x = 10");
 
@@ -95,7 +95,7 @@ mod tests {
         db.file_system_mut()
             .write_file(path, "x = 10".to_string())?;
 
-        let file = file_system_path_to_file(&db, path).unwrap();
+        let file = system_path_to_file(&db, path).unwrap();
 
         assert_eq!(&*source_text(&db, file), "x = 10");
 
@@ -122,7 +122,7 @@ mod tests {
         db.file_system_mut()
             .write_file(path, "x = 10\ny = 20".to_string())?;
 
-        let file = file_system_path_to_file(&db, path).unwrap();
+        let file = system_path_to_file(&db, path).unwrap();
         let index = line_index(&db, file);
         let text = source_text(&db, file);
 

--- a/crates/ruff_db/src/source.rs
+++ b/crates/ruff_db/src/source.rs
@@ -73,7 +73,7 @@ mod tests {
         db.file_system_mut()
             .write_file(path, "x = 10".to_string())?;
 
-        let file = file_system_path_to_file(&db, path);
+        let file = file_system_path_to_file(&db, path).unwrap();
 
         assert_eq!(&*source_text(&db, file), "x = 10");
 
@@ -95,7 +95,7 @@ mod tests {
         db.file_system_mut()
             .write_file(path, "x = 10".to_string())?;
 
-        let file = file_system_path_to_file(&db, path);
+        let file = file_system_path_to_file(&db, path).unwrap();
 
         assert_eq!(&*source_text(&db, file), "x = 10");
 
@@ -122,7 +122,7 @@ mod tests {
         db.file_system_mut()
             .write_file(path, "x = 10\ny = 20".to_string())?;
 
-        let file = file_system_path_to_file(&db, path);
+        let file = file_system_path_to_file(&db, path).unwrap();
         let index = line_index(&db, file);
         let text = source_text(&db, file);
 

--- a/crates/ruff_db/src/vfs.rs
+++ b/crates/ruff_db/src/vfs.rs
@@ -20,7 +20,7 @@ pub fn system_path_to_file(db: &dyn Db, path: impl AsRef<FileSystemPath>) -> Opt
 
     // It's important that `vfs.file_system` creates a `VfsFile` even for files that don't exist or don't
     // exist anymore so that Salsa can track that the caller of this function depends on the existence of
-    // that file. This function filters out file that don't exist, but Salsa will know that it must
+    // that file. This function filters out files that don't exist, but Salsa will know that it must
     // re-run the calling query whenever the `file`'s status changes (because of the `.status` call here).
     match file.status(db) {
         FileStatus::Exists => Some(file),

--- a/crates/ruff_db/src/vfs.rs
+++ b/crates/ruff_db/src/vfs.rs
@@ -10,6 +10,39 @@ use crate::{Db, FxDashMap};
 
 mod path;
 
+/// Interns a file system path and returns a salsa `File` ingredient.
+///
+/// The operation is guaranteed to always succeed, even if the path doesn't exist, isn't accessible, or if the path points to a directory.
+/// In these cases, a file with status [`FileStatus::Deleted`](vfs::FileStatus::Deleted) is returned.
+#[inline]
+pub fn file_system_path_to_file(db: &dyn Db, path: impl AsRef<FileSystemPath>) -> VfsFile {
+    db.vfs().file_system(db, path.as_ref())
+}
+
+/// Interns a vendored file path. Returns `None` if no such vendored file exists and `Some` otherwise.
+#[inline]
+pub fn vendored_path_to_file(db: &dyn Db, path: impl AsRef<VendoredPath>) -> Option<VfsFile> {
+    db.vfs().vendored(db, path.as_ref())
+}
+
+/// Interns a virtual file system path and returns a salsa `File` ingredient.
+///
+/// * For a [`VfsPath::FileSystem`] path, the function always returns `Some` even if the path doesn't exist,
+///     isn't accessible, or if the path points to a directory.
+///     In these cases, the [`VfsFile::status`] is set to [`FileStatus::Deleted`] to signify that the file isn't accessible.
+///
+/// * For a [`VfsPath::Vendored`] path, the function returns `Some` if a vendored file for the given
+///     path exists and `None` otherwise.
+///
+/// See [`file_system_path_to_file`] and [`vendored_path_to_file`] if you always have either a file system or vendored path.
+#[inline]
+pub fn vfs_path_to_file(db: &dyn Db, path: &VfsPath) -> Option<VfsFile> {
+    match path {
+        VfsPath::FileSystem(path) => Some(file_system_path_to_file(db, path)),
+        VfsPath::Vendored(path) => vendored_path_to_file(db, path),
+    }
+}
+
 /// Virtual file system that supports files from different sources.
 ///
 /// The [`Vfs`] supports accessing files from:
@@ -64,7 +97,7 @@ impl Vfs {
     ///
     /// The operation always succeeds even if the path doesn't exist on disk, isn't accessible or if the path points to a directory.
     /// In these cases, a file with status [`FileStatus::Deleted`] is returned.
-    pub fn file(&self, db: &dyn Db, path: &FileSystemPath) -> VfsFile {
+    fn file_system(&self, db: &dyn Db, path: &FileSystemPath) -> VfsFile {
         *self
             .inner
             .files_by_path
@@ -95,7 +128,7 @@ impl Vfs {
 
     /// Looks up a vendored file by its path. Returns `Some` if a vendored file for the given path
     /// exists and `None` otherwise.
-    pub fn vendored(&self, db: &dyn Db, path: &VendoredPath) -> Option<VfsFile> {
+    fn vendored(&self, db: &dyn Db, path: &VendoredPath) -> Option<VfsFile> {
         let file = match self
             .inner
             .files_by_path
@@ -260,10 +293,9 @@ impl VendoredVfs {
 
 #[cfg(test)]
 mod tests {
-    use crate::file_system::{FileRevision, FileSystemPath};
+    use crate::file_system::FileRevision;
     use crate::tests::TestDb;
-    use crate::vfs::{FileStatus, VendoredPath};
-    use crate::Db;
+    use crate::vfs::{file_system_path_to_file, vendored_path_to_file, FileStatus};
 
     #[test]
     fn file_system_existing_file() -> crate::file_system::Result<()> {
@@ -272,7 +304,7 @@ mod tests {
         db.file_system_mut()
             .write_files([("test.py", "print('Hello world')")])?;
 
-        let test = db.file(FileSystemPath::new("test.py"));
+        let test = file_system_path_to_file(&db, "test.py");
 
         assert_eq!(test.status(&db), FileStatus::Exists);
         assert_eq!(test.permissions(&db), Some(0o755));
@@ -286,7 +318,7 @@ mod tests {
     fn file_system_non_existing_file() {
         let db = TestDb::new();
 
-        let test = db.file(FileSystemPath::new("test.py"));
+        let test = file_system_path_to_file(&db, "test.py");
 
         assert_eq!(test.status(&db), FileStatus::Deleted);
         assert_eq!(test.permissions(&db), None);
@@ -301,9 +333,7 @@ mod tests {
         db.vfs_mut()
             .stub_vendored([("test.py", "def foo() -> str")]);
 
-        let test = db
-            .vendored_file(VendoredPath::new("test.py"))
-            .expect("Vendored file to exist.");
+        let test = vendored_path_to_file(&db, "test.py").expect("Vendored file to exist.");
 
         assert_eq!(test.status(&db), FileStatus::Exists);
         assert_eq!(test.permissions(&db), Some(0o444));
@@ -315,6 +345,6 @@ mod tests {
     fn stubbed_vendored_file_non_existing() {
         let db = TestDb::new();
 
-        assert_eq!(db.vendored_file(VendoredPath::new("test.py")), None);
+        assert_eq!(vendored_path_to_file(&db, "test.py"), None);
     }
 }


### PR DESCRIPTION
## Summary

When I started working on porting the module resolver, I realized that the `path_to_module` function operates on an arbitrary `VfsPath` and it must be able to resolve it to a `VfsFile`. 

The problem I ran into is that the existing salsa db doesn't provide an API to resolve the file for an arbitrary path. This PR addresses this by replacing `db.file` and `db.vendored` with `vendored_path_to_file`, `file_system_path_to_file`, `vfs_path_to_file` functions.

The advantage of free-standing functions over trait functions is that these can take an `impl AsRef<.Path>` as argument which makes them more ergonomic. I kept the path specific operations because they're slightly more ergonomic (they don't require creating a `VfsPath` first).

## Test Plan

`cargo test`
