### PR TITLE
`ruff server`: Introduce the `ruff.printDebugInformation` command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1943,7 +1943,6 @@ dependencies = [
  "toml",
  "tracing",
  "tracing-subscriber",
- "tracing-tree",
  "walkdir",
  "wild",
 ]
@@ -2344,6 +2343,7 @@ dependencies = [
  "serde_json",
  "shellexpand",
  "tracing",
+ "tracing-subscriber",
  "walkdir",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1942,7 +1942,6 @@ dependencies = [
  "tikv-jemallocator",
  "toml",
  "tracing",
- "tracing-subscriber",
  "walkdir",
  "wild",
 ]

--- a/crates/ruff/Cargo.toml
+++ b/crates/ruff/Cargo.toml
@@ -54,7 +54,6 @@ thiserror = { workspace = true }
 toml = { workspace = true }
 tracing = { workspace = true, features = ["log"] }
 tracing-subscriber = { workspace = true, features = ["registry"] }
-tracing-tree = { workspace = true }
 walkdir = { workspace = true }
 wild = { workspace = true }
 

--- a/crates/ruff/Cargo.toml
+++ b/crates/ruff/Cargo.toml
@@ -53,7 +53,6 @@ tempfile = { workspace = true }
 thiserror = { workspace = true }
 toml = { workspace = true }
 tracing = { workspace = true, features = ["log"] }
-tracing-subscriber = { workspace = true, features = ["registry"] }
 walkdir = { workspace = true }
 wild = { workspace = true }
 

--- a/crates/ruff/src/commands/server.rs
+++ b/crates/ruff/src/commands/server.rs
@@ -2,78 +2,15 @@ use std::num::NonZeroUsize;
 
 use crate::ExitStatus;
 use anyhow::Result;
-use ruff_linter::logging::LogLevel;
 use ruff_server::Server;
-use tracing::{level_filters::LevelFilter, metadata::Level, subscriber::Interest, Metadata};
-use tracing_subscriber::{
-    layer::{Context, Filter, SubscriberExt},
-    Layer, Registry,
-};
-use tracing_tree::time::Uptime;
 
-pub(crate) fn run_server(
-    preview: bool,
-    worker_threads: NonZeroUsize,
-    log_level: LogLevel,
-) -> Result<ExitStatus> {
+pub(crate) fn run_server(preview: bool, worker_threads: NonZeroUsize) -> Result<ExitStatus> {
     if !preview {
         tracing::error!("--preview needs to be provided as a command line argument while the server is still unstable.\nFor example: `ruff server --preview`");
         return Ok(ExitStatus::Error);
     }
-    let trace_level = if log_level == LogLevel::Verbose {
-        Level::TRACE
-    } else {
-        Level::DEBUG
-    };
-
-    let subscriber = Registry::default().with(
-        tracing_tree::HierarchicalLayer::default()
-            .with_indent_lines(true)
-            .with_indent_amount(2)
-            .with_bracketed_fields(true)
-            .with_targets(true)
-            .with_writer(|| Box::new(std::io::stderr()))
-            .with_timer(Uptime::default())
-            .with_filter(LoggingFilter { trace_level }),
-    );
-
-    tracing::subscriber::set_global_default(subscriber)?;
 
     let server = Server::new(worker_threads)?;
 
     server.run().map(|()| ExitStatus::Success)
-}
-
-struct LoggingFilter {
-    trace_level: Level,
-}
-
-impl LoggingFilter {
-    fn is_enabled(&self, meta: &Metadata<'_>) -> bool {
-        let filter = if meta.target().starts_with("ruff") {
-            self.trace_level
-        } else {
-            Level::INFO
-        };
-
-        meta.level() <= &filter
-    }
-}
-
-impl<S> Filter<S> for LoggingFilter {
-    fn enabled(&self, meta: &Metadata<'_>, _cx: &Context<'_, S>) -> bool {
-        self.is_enabled(meta)
-    }
-
-    fn callsite_enabled(&self, meta: &'static Metadata<'static>) -> Interest {
-        if self.is_enabled(meta) {
-            Interest::always()
-        } else {
-            Interest::never()
-        }
-    }
-
-    fn max_level_hint(&self) -> Option<LevelFilter> {
-        Some(LevelFilter::from_level(self.trace_level))
-    }
 }

--- a/crates/ruff/src/lib.rs
+++ b/crates/ruff/src/lib.rs
@@ -201,7 +201,7 @@ pub fn run(
         }
         Command::Check(args) => check(args, global_options),
         Command::Format(args) => format(args, global_options),
-        Command::Server(args) => server(args, global_options.log_level()),
+        Command::Server(args) => server(args),
     }
 }
 
@@ -215,7 +215,7 @@ fn format(args: FormatCommand, global_options: GlobalConfigArgs) -> Result<ExitS
     }
 }
 
-fn server(args: ServerCommand, log_level: LogLevel) -> Result<ExitStatus> {
+fn server(args: ServerCommand) -> Result<ExitStatus> {
     let ServerCommand { preview } = args;
 
     let four = NonZeroUsize::new(4).unwrap();
@@ -224,7 +224,7 @@ fn server(args: ServerCommand, log_level: LogLevel) -> Result<ExitStatus> {
     let worker_threads = std::thread::available_parallelism()
         .unwrap_or(four)
         .max(four);
-    commands::server::run_server(preview, worker_threads, log_level)
+    commands::server::run_server(preview, worker_threads)
 }
 
 pub fn check(args: CheckCommand, global_options: GlobalConfigArgs) -> Result<ExitStatus> {

--- a/crates/ruff_server/Cargo.toml
+++ b/crates/ruff_server/Cargo.toml
@@ -38,6 +38,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 shellexpand = { workspace = true }
 tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
 walkdir = { workspace = true }
 
 [dev-dependencies]

--- a/crates/ruff_server/src/lib.rs
+++ b/crates/ruff_server/src/lib.rs
@@ -4,14 +4,16 @@ pub use edit::{PositionEncoding, TextDocument};
 use lsp_types::CodeActionKind;
 pub use server::Server;
 
+#[macro_use]
+mod message;
+
 mod edit;
 mod fix;
 mod format;
 mod lint;
-#[macro_use]
-mod message;
 mod server;
 mod session;
+mod trace;
 
 pub(crate) const SERVER_NAME: &str = "ruff";
 pub(crate) const DIAGNOSTIC_NAME: &str = "Ruff";

--- a/crates/ruff_server/src/message.rs
+++ b/crates/ruff_server/src/message.rs
@@ -32,7 +32,10 @@ pub(crate) fn init_messenger(client_sender: ClientSender) {
         }
 
         let backtrace = std::backtrace::Backtrace::force_capture();
-        tracing::error!("{panic_info}\n{backtrace}");
+        #[allow(clippy::print_stderr)]
+        {
+            eprintln!("{panic_info}\n{backtrace}");
+        }
     }));
 }
 

--- a/crates/ruff_server/src/server.rs
+++ b/crates/ruff_server/src/server.rs
@@ -64,9 +64,11 @@ impl Server {
             crate::version(),
         )?;
 
-        // TODO(jane): Support a log level setting
-        let log_level = crate::trace::LogLevel::Info;
-        let tracing_guard = crate::trace::init_tracing(connection.make_sender(), log_level);
+        if let Some(trace) = init_params.trace {
+            crate::trace::set_trace_value(trace);
+        }
+
+        let tracing_guard = crate::trace::init_tracing(connection.make_sender());
         crate::message::init_messenger(connection.make_sender());
 
         let AllSettings {

--- a/crates/ruff_server/src/server.rs
+++ b/crates/ruff_server/src/server.rs
@@ -68,7 +68,6 @@ impl Server {
         }
 
         crate::message::init_messenger(connection.make_sender());
-        crate::trace::init_tracing(connection.make_sender());
 
         let AllSettings {
             global_settings,
@@ -77,6 +76,13 @@ impl Server {
             init_params
                 .initialization_options
                 .unwrap_or_else(|| serde_json::Value::Object(serde_json::Map::default())),
+        );
+
+        crate::trace::init_tracing(
+            connection.make_sender(),
+            global_settings
+                .log_level()
+                .unwrap_or(crate::trace::LogLevel::Info),
         );
 
         let mut workspace_for_url = |url: lsp_types::Url| {

--- a/crates/ruff_server/src/server/api.rs
+++ b/crates/ruff_server/src/server/api.rs
@@ -93,6 +93,9 @@ pub(super) fn notification<'a>(notif: server::Notification) -> Task<'a> {
         notification::DidCloseNotebook::METHOD => {
             local_notification_task::<notification::DidCloseNotebook>(notif)
         }
+        notification::SetTrace::METHOD => {
+            local_notification_task::<notification::SetTrace>(notif)
+        }
         method => {
             tracing::warn!("Received notification {method} which does not have a handler.");
             return Task::nothing();

--- a/crates/ruff_server/src/server/api/notifications.rs
+++ b/crates/ruff_server/src/server/api/notifications.rs
@@ -8,6 +8,7 @@ mod did_close;
 mod did_close_notebook;
 mod did_open;
 mod did_open_notebook;
+mod set_trace;
 
 use super::traits::{NotificationHandler, SyncNotificationHandler};
 pub(super) use cancel::Cancel;
@@ -20,3 +21,4 @@ pub(super) use did_close::DidClose;
 pub(super) use did_close_notebook::DidCloseNotebook;
 pub(super) use did_open::DidOpen;
 pub(super) use did_open_notebook::DidOpenNotebook;
+pub(super) use set_trace::SetTrace;

--- a/crates/ruff_server/src/server/api/notifications/set_trace.rs
+++ b/crates/ruff_server/src/server/api/notifications/set_trace.rs
@@ -1,0 +1,23 @@
+use crate::server::client::{Notifier, Requester};
+use crate::server::Result;
+use crate::session::Session;
+use lsp_types as types;
+use lsp_types::notification as notif;
+
+pub(crate) struct SetTrace;
+
+impl super::NotificationHandler for SetTrace {
+    type NotificationType = notif::SetTrace;
+}
+
+impl super::SyncNotificationHandler for SetTrace {
+    fn run(
+        _session: &mut Session,
+        _notifier: Notifier,
+        _requester: &mut Requester,
+        params: types::SetTraceParams,
+    ) -> Result<()> {
+        crate::trace::set_trace_value(params.value);
+        Ok(())
+    }
+}

--- a/crates/ruff_server/src/session.rs
+++ b/crates/ruff_server/src/session.rs
@@ -145,6 +145,18 @@ impl Session {
         Ok(())
     }
 
+    pub(crate) fn count_documents(&self) -> usize {
+        self.index.count_documents()
+    }
+
+    pub(crate) fn count_workspaces(&self) -> usize {
+        self.index.count_workspaces()
+    }
+
+    pub(crate) fn list_config_files(&self) -> Vec<&std::path::Path> {
+        self.index.list_config_files()
+    }
+
     pub(crate) fn resolved_client_capabilities(&self) -> &ResolvedClientCapabilities {
         &self.resolved_client_capabilities
     }

--- a/crates/ruff_server/src/session/capabilities.rs
+++ b/crates/ruff_server/src/session/capabilities.rs
@@ -1,4 +1,5 @@
 use lsp_types::ClientCapabilities;
+use ruff_linter::display_settings;
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 #[allow(clippy::struct_excessive_bools)]
@@ -63,5 +64,22 @@ impl ResolvedClientCapabilities {
             workspace_refresh,
             pull_diagnostics,
         }
+    }
+}
+
+impl std::fmt::Display for ResolvedClientCapabilities {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        display_settings! {
+            formatter = f,
+            namespace = "capabilities",
+            fields = [
+                self.code_action_deferred_edit_resolution,
+                self.apply_edit,
+                self.document_changes,
+                self.workspace_refresh,
+                self.pull_diagnostics,
+            ]
+        };
+        Ok(())
     }
 }

--- a/crates/ruff_server/src/session/index.rs
+++ b/crates/ruff_server/src/session/index.rs
@@ -185,6 +185,21 @@ impl Index {
         Self::register_workspace_settings(&mut self.settings, url, None, global_settings)
     }
 
+    pub(super) fn count_documents(&self) -> usize {
+        self.documents.len()
+    }
+
+    pub(super) fn count_workspaces(&self) -> usize {
+        self.settings.len()
+    }
+
+    pub(super) fn list_config_files(&self) -> Vec<&Path> {
+        self.settings
+            .values()
+            .flat_map(|WorkspaceSettings { ruff_settings, .. }| ruff_settings.list_files())
+            .collect()
+    }
+
     fn register_workspace_settings(
         settings_index: &mut SettingsIndex,
         workspace_url: &Url,

--- a/crates/ruff_server/src/session/settings.rs
+++ b/crates/ruff_server/src/session/settings.rs
@@ -70,6 +70,7 @@ pub(crate) struct ClientSettings {
     exclude: Option<Vec<String>>,
     line_length: Option<LineLength>,
     configuration_preference: Option<ConfigurationPreference>,
+    pub(crate) log_level: Option<crate::trace::LogLevel>,
 }
 
 /// This is a direct representation of the workspace settings schema,
@@ -174,6 +175,15 @@ impl AllSettings {
                     .collect()
             }),
         }
+    }
+}
+
+impl ClientSettings {
+    /// Log level is taken directly from client settings, since we need it before
+    /// we resolve workspace settings. Additionally, this setting should only be set in global settings,
+    /// and any log level set in workspace settings will be ignored.
+    pub(crate) fn log_level(&self) -> Option<crate::trace::LogLevel> {
+        self.log_level
     }
 }
 
@@ -424,6 +434,7 @@ mod tests {
                 exclude: None,
                 line_length: None,
                 configuration_preference: None,
+                log_level: None,
             },
             workspace_settings: [
                 WorkspaceSettings {
@@ -472,6 +483,7 @@ mod tests {
                         exclude: None,
                         line_length: None,
                         configuration_preference: None,
+                        log_level: None,
                     },
                     workspace: Url {
                         scheme: "file",
@@ -533,6 +545,7 @@ mod tests {
                         exclude: None,
                         line_length: None,
                         configuration_preference: None,
+                        log_level: None,
                     },
                     workspace: Url {
                         scheme: "file",
@@ -588,7 +601,7 @@ mod tests {
                     exclude: None,
                     line_length: None,
                     configuration_preference: ConfigurationPreference::default(),
-                }
+                },
             }
         );
         let path =
@@ -619,7 +632,7 @@ mod tests {
                     exclude: None,
                     line_length: None,
                     configuration_preference: ConfigurationPreference::EditorFirst,
-                }
+                },
             }
         );
     }
@@ -673,6 +686,9 @@ mod tests {
                     ),
                 ),
                 configuration_preference: None,
+                log_level: Some(
+                    Warn,
+                ),
             },
         }
         "###);
@@ -703,7 +719,7 @@ mod tests {
                     exclude: Some(vec!["third_party".into()]),
                     line_length: Some(LineLength::try_from(80).unwrap()),
                     configuration_preference: ConfigurationPreference::EditorFirst,
-                }
+                },
             }
         );
     }

--- a/crates/ruff_server/src/trace.rs
+++ b/crates/ruff_server/src/trace.rs
@@ -8,7 +8,7 @@ use crate::server::ClientSender;
 
 static LOGGING_SENDER: OnceLock<ClientSender> = OnceLock::new();
 
-static TRACE_VALUE: Mutex<lsp_types::TraceValue> = Mutex::new(lsp_types::TraceValue::Messages);
+static TRACE_VALUE: Mutex<lsp_types::TraceValue> = Mutex::new(lsp_types::TraceValue::Off);
 
 pub(crate) fn set_trace_value(trace_value: TraceValue) {
     let mut global_trace_value = TRACE_VALUE

--- a/crates/ruff_server/src/trace.rs
+++ b/crates/ruff_server/src/trace.rs
@@ -10,11 +10,6 @@ static LOGGING_SENDER: OnceLock<ClientSender> = OnceLock::new();
 
 static TRACE_VALUE: Mutex<lsp_types::TraceValue> = Mutex::new(lsp_types::TraceValue::Off);
 
-pub(crate) fn stderr_subscriber() -> impl tracing::Subscriber {
-    tracing_subscriber::registry()
-        .with(tracing_subscriber::fmt::layer().with_writer(|| Box::new(std::io::stderr())))
-}
-
 pub(crate) fn set_trace_value(trace_value: TraceValue) {
     let mut global_trace_value = TRACE_VALUE
         .lock()

--- a/crates/ruff_server/src/trace.rs
+++ b/crates/ruff_server/src/trace.rs
@@ -17,16 +17,13 @@ pub(crate) fn set_trace_value(trace_value: TraceValue) {
     *global_trace_value = trace_value;
 }
 
-pub(crate) fn init_tracing(sender: ClientSender) {
+pub(crate) fn init_tracing(sender: ClientSender, log_level: LogLevel) {
     LOGGING_SENDER
         .set(sender)
         .expect("logging sender should only be initialized once");
 
-    // TODO(jane): Provide a way to set the log level
-    let subscriber =
-        tracing_subscriber::Registry::default().with(LogLayer.with_filter(LogFilter {
-            filter: LogLevel::Info,
-        }));
+    let subscriber = tracing_subscriber::Registry::default()
+        .with(LogLayer.with_filter(LogFilter { filter: log_level }));
 
     tracing::subscriber::set_global_default(subscriber)
         .expect("should be able to set global default subscriber");

--- a/crates/ruff_server/src/trace.rs
+++ b/crates/ruff_server/src/trace.rs
@@ -10,6 +10,11 @@ static LOGGING_SENDER: OnceLock<ClientSender> = OnceLock::new();
 
 static TRACE_VALUE: Mutex<lsp_types::TraceValue> = Mutex::new(lsp_types::TraceValue::Off);
 
+pub(crate) fn stderr_subscriber() -> impl tracing::Subscriber {
+    tracing_subscriber::registry()
+        .with(tracing_subscriber::fmt::layer().with_writer(|| Box::new(std::io::stderr())))
+}
+
 pub(crate) fn set_trace_value(trace_value: TraceValue) {
     let mut global_trace_value = TRACE_VALUE
         .lock()

--- a/crates/ruff_server/src/trace.rs
+++ b/crates/ruff_server/src/trace.rs
@@ -1,0 +1,127 @@
+use lsp_types::notification::Notification;
+use serde::Deserialize;
+use std::sync::OnceLock;
+use tracing::{level_filters::LevelFilter, Event};
+use tracing_subscriber::layer::SubscriberExt;
+
+use crate::server::ClientSender;
+
+static LOGGING_SENDER: OnceLock<ClientSender> = OnceLock::new();
+
+pub(crate) fn init_tracing(
+    sender: ClientSender,
+    filter: LogLevel,
+) -> tracing::subscriber::DefaultGuard {
+    LOGGING_SENDER
+        .set(sender)
+        .expect("logging sender should only be initialized once");
+
+    let subscriber = tracing_subscriber::Registry::default().with(LogLayer { filter });
+
+    tracing::subscriber::set_default(subscriber)
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Default, PartialEq, Eq, PartialOrd, Ord)]
+#[serde(rename_all = "lowercase")]
+pub(crate) enum LogLevel {
+    #[default]
+    Error,
+    Warn,
+    Info,
+    Debug,
+}
+
+impl LogLevel {
+    fn from_trace_level(level: tracing::Level) -> Self {
+        match level {
+            tracing::Level::ERROR => Self::Error,
+            tracing::Level::WARN => Self::Warn,
+            tracing::Level::INFO => Self::Info,
+            _ => Self::Debug,
+        }
+    }
+
+    fn message_type(self) -> lsp_types::MessageType {
+        match self {
+            Self::Error => lsp_types::MessageType::ERROR,
+            Self::Warn => lsp_types::MessageType::WARNING,
+            Self::Info => lsp_types::MessageType::INFO,
+            // TODO(jane): LSP `0.3.18` will introduce `MessageType::DEBUG`,
+            // and we should consider using that.
+            Self::Debug => lsp_types::MessageType::LOG,
+        }
+    }
+
+    fn trace_level(self) -> tracing::Level {
+        match self {
+            Self::Error => tracing::Level::ERROR,
+            Self::Warn => tracing::Level::WARN,
+            Self::Info => tracing::Level::INFO,
+            Self::Debug => tracing::Level::DEBUG,
+        }
+    }
+}
+
+struct LogLayer {
+    filter: LogLevel,
+}
+
+impl tracing_subscriber::Layer<tracing_subscriber::Registry> for LogLayer {
+    fn register_callsite(
+        &self,
+        metadata: &'static tracing::Metadata<'static>,
+    ) -> tracing::subscriber::Interest {
+        if metadata.is_event()
+            && metadata
+                .fields()
+                .iter()
+                .any(|field| field.name() == "message")
+        {
+            tracing::subscriber::Interest::always()
+        } else {
+            tracing::subscriber::Interest::never()
+        }
+    }
+
+    fn max_level_hint(&self) -> Option<tracing::level_filters::LevelFilter> {
+        Some(LevelFilter::from_level(self.filter.trace_level()))
+    }
+
+    fn on_event(
+        &self,
+        event: &Event<'_>,
+        _ctx: tracing_subscriber::layer::Context<'_, tracing_subscriber::Registry>,
+    ) {
+        let mut message_visitor =
+            LogMessageVisitor(LogLevel::from_trace_level(*event.metadata().level()));
+        event.record(&mut message_visitor);
+    }
+}
+
+#[derive(Default)]
+struct LogMessageVisitor(LogLevel);
+
+impl tracing::field::Visit for LogMessageVisitor {
+    fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+        if field.name() == "message" {
+            log(format!("{value:?}"), self.0);
+        }
+    }
+}
+
+#[inline]
+fn log(message: String, level: LogLevel) {
+    let _ = LOGGING_SENDER
+        .get()
+        .expect("logging channel should be initialized")
+        .send(lsp_server::Message::Notification(
+            lsp_server::Notification {
+                method: lsp_types::notification::LogMessage::METHOD.into(),
+                params: serde_json::to_value(lsp_types::LogMessageParams {
+                    typ: level.message_type(),
+                    message,
+                })
+                .expect("log notification should serialize"),
+            },
+        ));
+}


### PR DESCRIPTION
## Summary

Closes #11715.

## Test Plan

(TODO: I need to open the corresponding VS Code PR before this is testable)

In VS Code, running the `Print debug information` command should show something like the following in the Output channel:
<img width="632" alt="Screenshot 2024-06-10 at 12 21 07 PM" src="https://github.com/astral-sh/ruff/assets/19577865/85871162-f31e-4671-aeac-1c4e1e1503ad">

