### PR TITLE
`ruff server`: Introduce the `ruff.printDebugInformation` command

### DIFF
--- a/crates/ruff_server/src/session.rs
+++ b/crates/ruff_server/src/session.rs
@@ -145,12 +145,12 @@ impl Session {
         Ok(())
     }
 
-    pub(crate) fn count_documents(&self) -> usize {
-        self.index.count_documents()
+    pub(crate) fn num_documents(&self) -> usize {
+        self.index.num_documents()
     }
 
-    pub(crate) fn count_workspaces(&self) -> usize {
-        self.index.count_workspaces()
+    pub(crate) fn num_workspaces(&self) -> usize {
+        self.index.num_workspaces()
     }
 
     pub(crate) fn list_config_files(&self) -> Vec<&std::path::Path> {

--- a/crates/ruff_server/src/session.rs
+++ b/crates/ruff_server/src/session.rs
@@ -145,6 +145,18 @@ impl Session {
         Ok(())
     }
 
+    pub(crate) fn count_documents(&self) -> usize {
+        self.index.count_documents()
+    }
+
+    pub(crate) fn count_workspaces(&self) -> usize {
+        self.index.count_workspaces()
+    }
+
+    pub(crate) fn list_config_files(&self) -> Vec<&std::path::Path> {
+        self.index.list_config_files()
+    }
+
     pub(crate) fn resolved_client_capabilities(&self) -> &ResolvedClientCapabilities {
         &self.resolved_client_capabilities
     }

--- a/crates/ruff_server/src/session/capabilities.rs
+++ b/crates/ruff_server/src/session/capabilities.rs
@@ -1,4 +1,5 @@
 use lsp_types::ClientCapabilities;
+use ruff_linter::display_settings;
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 #[allow(clippy::struct_excessive_bools)]
@@ -63,5 +64,22 @@ impl ResolvedClientCapabilities {
             workspace_refresh,
             pull_diagnostics,
         }
+    }
+}
+
+impl std::fmt::Display for ResolvedClientCapabilities {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        display_settings! {
+            formatter = f,
+            namespace = "capabilities",
+            fields = [
+                self.code_action_deferred_edit_resolution,
+                self.apply_edit,
+                self.document_changes,
+                self.workspace_refresh,
+                self.pull_diagnostics,
+            ]
+        };
+        Ok(())
     }
 }

--- a/crates/ruff_server/src/session/index.rs
+++ b/crates/ruff_server/src/session/index.rs
@@ -187,11 +187,11 @@ impl Index {
         Self::register_workspace_settings(&mut self.settings, url, None, global_settings)
     }
 
-    pub(super) fn count_documents(&self) -> usize {
+    pub(super) fn num_documents(&self) -> usize {
         self.documents.len()
     }
 
-    pub(super) fn count_workspaces(&self) -> usize {
+    pub(super) fn num_workspaces(&self) -> usize {
         self.settings.len()
     }
 

--- a/crates/ruff_server/src/session/index.rs
+++ b/crates/ruff_server/src/session/index.rs
@@ -187,6 +187,21 @@ impl Index {
         Self::register_workspace_settings(&mut self.settings, url, None, global_settings)
     }
 
+    pub(super) fn count_documents(&self) -> usize {
+        self.documents.len()
+    }
+
+    pub(super) fn count_workspaces(&self) -> usize {
+        self.settings.len()
+    }
+
+    pub(super) fn list_config_files(&self) -> Vec<&Path> {
+        self.settings
+            .values()
+            .flat_map(|WorkspaceSettings { ruff_settings, .. }| ruff_settings.list_files())
+            .collect()
+    }
+
     fn register_workspace_settings(
         settings_index: &mut SettingsIndex,
         workspace_url: &Url,


### PR DESCRIPTION
## Summary

Closes #11715.

Introduces a new command, `ruff.printDebugInformation`. This will print useful information about the status of the server to `stderr`.

Right now, the information shown by this command includes:
* The path to the server executable
* The version of the executable
* The text encoding being used
* The number of open documents and workspaces
* A list of registered configuration files
* The capabilities of the client

## Test Plan

First, checkout and use [the corresponding `ruff-vscode` PR](https://github.com/astral-sh/ruff-vscode/pull/495).

Running the `Print debug information` command in VS Code should show something like the following in the Output channel:

<img width="991" alt="Screenshot 2024-06-11 at 11 41 46 AM" src="https://github.com/astral-sh/ruff/assets/19577865/ab93c009-bb7b-4291-b057-d44fdc6f9f86">


