### PR TITLE
Separate terminator token for f-string elements kind

### DIFF
--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@f_string_lambda_without_parentheses.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@f_string_lambda_without_parentheses.py.snap
@@ -11,15 +11,15 @@ Module(
         body: [
             Expr(
                 StmtExpr {
-                    range: 0..14,
+                    range: 0..16,
                     value: FString(
                         ExprFString {
-                            range: 0..14,
+                            range: 0..16,
                             value: FStringValue {
                                 inner: Single(
                                     FString(
                                         FString {
-                                            range: 0..14,
+                                            range: 0..16,
                                             elements: [
                                                 Expression(
                                                     FStringExpressionElement {
@@ -110,17 +110,5 @@ Module(
 
   |
 1 | f"{lambda x: x}"
-  |               ^ Syntax Error: Expected FStringEnd, found '}'
-  |
-
-
-  |
-1 | f"{lambda x: x}"
-  |                ^ Syntax Error: Expected a statement
-  |
-
-
-  |
-1 | f"{lambda x: x}"
-  |                 ^ Syntax Error: Expected a statement
+  |               ^ Syntax Error: Expected an f-string element or the end of the f-string
   |

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@f_string_unclosed_lbrace_in_format_spec.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@f_string_unclosed_lbrace_in_format_spec.py.snap
@@ -116,7 +116,7 @@ Module(
 
   |
 1 | f"hello {x:"
-  |            ^ Syntax Error: f-string: expecting '}'
+  |            ^ Syntax Error: Expected an f-string element or a '}'
 2 | f"hello {x:.3f"
   |
 
@@ -124,7 +124,7 @@ Module(
   |
 1 | f"hello {x:"
 2 | f"hello {x:.3f"
-  |               ^ Syntax Error: f-string: expecting '}'
+  |               ^ Syntax Error: Expected an f-string element or a '}'
   |
 
 

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@unterminated_fstring_newline_recovery.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@unterminated_fstring_newline_recovery.py.snap
@@ -335,7 +335,7 @@ Module(
 4 | 2 + 2
 5 | f"hello {x:
 6 | 3 + 3
-  | ^ Syntax Error: Expected an f-string element or the end of the f-string
+  | ^ Syntax Error: Expected an f-string element or a '}'
 7 | f"hello {x}
 8 | 4 + 4
   |


### PR DESCRIPTION
## Summary

This PR separates the terminator token for f-string elements depending on the context. A list of f-string element can occur either in a regular f-string or a format spec of an f-string. The terminator token is different depending on that context.

## Test Plan

`cargo insta test` and verify the updated snapshots.
