### PR TITLE
Use `starts_with('/')` instead of `is_absolute` to avoid platform specific API

### DIFF
--- a/crates/ruff_db/src/file_system/memory.rs
+++ b/crates/ruff_db/src/file_system/memory.rs
@@ -35,7 +35,7 @@ impl MemoryFileSystem {
         let cwd = Utf8PathBuf::from(cwd.as_ref().as_str());
 
         assert!(
-            cwd.is_absolute(),
+            cwd.starts_with("/"),
             "The current working directory must be an absolute path."
         );
 


### PR DESCRIPTION
## Summary

This PR fixes the build on windows.

## Test Plan

See CI
