### PR TITLE
Avoid close cells on `notebookDocument/didClose`

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -6,5 +6,5 @@ benchmark = "bench -p ruff_benchmark --bench linter --bench formatter --"
 # that shared/dynamic library.
 #
 # See: https://github.com/astral-sh/ruff/issues/11503
-[target.'cfg(all(target_env="msvc", target_os = "windows"))']
+[target.'cfg(all(target_env = "msvc", target_os = "windows"))']
 rustflags = ["-C", "target-feature=+crt-static"]

--- a/crates/ruff_server/src/edit/notebook.rs
+++ b/crates/ruff_server/src/edit/notebook.rs
@@ -169,7 +169,7 @@ impl NotebookDocument {
     }
 
     /// Returns a list of cell URIs in the order they appear in the array.
-    pub(crate) fn urls(&self) -> impl Iterator<Item = &lsp_types::Url> {
+    pub(crate) fn cell_urls(&self) -> impl Iterator<Item = &lsp_types::Url> {
         self.cells.iter().map(|cell| &cell.url)
     }
 

--- a/crates/ruff_server/src/fix.rs
+++ b/crates/ruff_server/src/fix.rs
@@ -111,7 +111,7 @@ pub(crate) fn fix_all(
             .iter()
             .map(cell_source)
             .zip(modified_notebook.cells().iter().map(cell_source))
-            .zip(notebook.urls())
+            .zip(notebook.cell_urls())
         {
             let source_index = LineIndex::from_source_text(&source);
             let modified_index = LineIndex::from_source_text(&modified);

--- a/crates/ruff_server/src/lint.rs
+++ b/crates/ruff_server/src/lint.rs
@@ -141,7 +141,7 @@ pub(crate) fn check(query: &DocumentQuery, encoding: PositionEncoding) -> Diagno
     // Populates all relevant URLs with an empty diagnostic list.
     // This ensures that documents without diagnostics still get updated.
     if let Some(notebook) = query.as_notebook() {
-        for url in notebook.urls() {
+        for url in notebook.cell_urls() {
             diagnostics.entry(url.clone()).or_default();
         }
     } else {

--- a/crates/ruff_server/src/server/api/requests/format.rs
+++ b/crates/ruff_server/src/server/api/requests/format.rs
@@ -36,7 +36,7 @@ pub(super) fn format_full_document(snapshot: &DocumentSnapshot) -> Result<Fixes>
     match snapshot.query() {
         DocumentQuery::Notebook { notebook, .. } => {
             for (url, text_document) in notebook
-                .urls()
+                .cell_urls()
                 .map(|url| (url.clone(), notebook.cell_document_by_uri(url).unwrap()))
             {
                 if let Some(changes) =


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary
Fixes https://github.com/astral-sh/ruff/issues/11651
Fixes https://github.com/astral-sh/ruff/issues/11851

As a follow-up of https://github.com/astral-sh/ruff/pull/11864 
<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

<!-- How was it tested? -->
Close (Ctrl+F4) documents with type of notebook/interactive-window/untitled-notebook and check no popup error message shows. 