### PR TITLE
Make `ruff_db` a required crate for `ruff_python_semantic`

### DIFF
--- a/crates/ruff_python_semantic/Cargo.toml
+++ b/crates/ruff_python_semantic/Cargo.toml
@@ -14,7 +14,7 @@ license = { workspace = true }
 doctest = false
 
 [dependencies]
-ruff_db = { workspace = true, optional = true }
+ruff_db = { workspace = true }
 ruff_index = { workspace = true }
 ruff_python_ast = { workspace = true }
 ruff_python_stdlib = { workspace = true }
@@ -34,4 +34,4 @@ ruff_python_parser = { workspace = true }
 workspace = true
 
 [features]
-red_knot = ["dep:ruff_db", "dep:salsa", "dep:tracing"]
+red_knot = ["dep:salsa", "dep:tracing"]


### PR DESCRIPTION
## Summary

This PR makes the `ruff_db` a required crate for `ruff_python_semantic`.

Refer https://github.com/astral-sh/ruff/actions/runs/9516626143/job/26233307158?pr=11872

## Test Plan

1. `maturin sdist --out dist`
2. `tar -xf dist/ruff-0.4.8.tar.gz --directory=dist/ruff-0.4.8`
3. `pip install dist/ruff-0.4.8.tar.gz` works
