### PR TITLE
Upgrade to Rust 1.79

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,7 @@ imperative = { version = "1.0.4" }
 indexmap = { version = "2.2.6" }
 indicatif = { version = "0.17.8" }
 indoc = { version = "2.0.4" }
-insta = { version = "1.35.1", feature = ["filters", "glob"] }
+insta = { version = "1.35.1" }
 insta-cmd = { version = "0.6.0" }
 is-macro = { version = "0.3.5" }
 is-wsl = { version = "0.4.0" }

--- a/crates/red_knot/src/module.rs
+++ b/crates/red_knot/src/module.rs
@@ -932,7 +932,7 @@ mod tests {
         // Luckily this crate will fail to build if this file isn't available at build time.
         const TYPESHED_ZIP_BYTES: &[u8] =
             include_bytes!(concat!(env!("OUT_DIR"), "/zipped_typeshed.zip"));
-        assert!(!TYPESHED_ZIP_BYTES.is_empty());
+
         let mut typeshed_zip_archive = ZipArchive::new(Cursor::new(TYPESHED_ZIP_BYTES))?;
 
         let path_to_functools = Path::new("stdlib").join("functools.pyi");

--- a/crates/ruff_linter/src/registry/rule_set.rs
+++ b/crates/ruff_linter/src/registry/rule_set.rs
@@ -1,7 +1,9 @@
-use crate::registry::Rule;
-use ruff_macros::CacheKey;
 use std::fmt::{Debug, Display, Formatter};
 use std::iter::FusedIterator;
+
+use ruff_macros::CacheKey;
+
+use crate::registry::Rule;
 
 const RULESET_SIZE: usize = 14;
 
@@ -367,7 +369,7 @@ impl Iterator for RuleSetIterator {
                 let rule_value = self.index * RuleSet::SLICE_BITS + bit;
                 // SAFETY: RuleSet guarantees that only valid rules are stored in the set.
                 #[allow(unsafe_code)]
-                return Some(unsafe { std::mem::transmute(rule_value) });
+                return Some(unsafe { std::mem::transmute::<u16, Rule>(rule_value) });
             }
 
             self.index += 1;
@@ -387,8 +389,9 @@ impl FusedIterator for RuleSetIterator {}
 
 #[cfg(test)]
 mod tests {
-    use crate::registry::{Rule, RuleSet};
     use strum::IntoEnumIterator;
+
+    use crate::registry::{Rule, RuleSet};
 
     /// Tests that the set can contain all rules
     #[test]

--- a/crates/ruff_python_formatter/src/other/parameters.rs
+++ b/crates/ruff_python_formatter/src/other/parameters.rs
@@ -1,5 +1,3 @@
-use std::usize;
-
 use ruff_formatter::{format_args, write, FormatRuleWithOptions};
 use ruff_python_ast::Parameters;
 use ruff_python_ast::{AnyNodeRef, AstNode};

--- a/crates/ruff_text_size/src/size.rs
+++ b/crates/ruff_text_size/src/size.rs
@@ -5,7 +5,6 @@ use {
         fmt, iter,
         num::TryFromIntError,
         ops::{Add, AddAssign, Sub, SubAssign},
-        u32,
     },
 };
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.78"
+channel = "1.79"


### PR DESCRIPTION
## Summary

Use [Rust 1.79](https://blog.rust-lang.org/2024/06/13/Rust-1.79.0.html) as local development version and in the release pipeline. 

1.79 has no breaking platform support change.

## Test Plan

`cargo build`
