### PR TITLE
Fix prettier formatting in schema store update script

### DIFF
--- a/scripts/update_schemastore.py
+++ b/scripts/update_schemastore.py
@@ -79,7 +79,7 @@ def update_schemastore(
 
     # Run npm install
     src = schemastore_path.joinpath("src")
-    check_call(["npm", "install"], cwd=src)
+    check_call(["npm", "install"], cwd=schemastore_path)
 
     # Update the schema and format appropriately
     schema = json.loads(root.joinpath("ruff.schema.json").read_text())
@@ -89,7 +89,7 @@ def update_schemastore(
     )
     check_call(
         [
-            "node_modules/.bin/prettier",
+            "../node_modules/prettier/bin/prettier.cjs",
             "--plugin",
             "prettier-plugin-sort-json",
             "--write",
@@ -121,7 +121,7 @@ def update_schemastore(
         )
         # This should show the link to create a PR
         check_call(
-            ["git", "push", "--set-upstream", "origin", branch],
+            ["git", "push", "--set-upstream", "origin", branch, "--force"],
             cwd=schemastore_path,
         )
     else:


### PR DESCRIPTION
How was this working for anyone else? The `prettier` path did not exist on my machine. Also added `--force` to the push because otherwise you can't re-run the script for a given Ruff commit.