### PR TITLE
`ruff server`: Add tracing setup guide to Helix documentation 

### DIFF
--- a/crates/ruff_server/docs/setup/HELIX.md
+++ b/crates/ruff_server/docs/setup/HELIX.md
@@ -62,6 +62,7 @@ preview = true
 
 By default, Ruff does not log anything to Helix. To enable logging, set the `RUFF_TRACE` environment variable
 to either `messages` or `verbose`. This will set the trace level for this server.
+
 ```toml
 [language-server.ruff]
 command = "ruff"
@@ -73,7 +74,8 @@ environment = { "RUFF_TRACE" = "messages" }
 > `RUFF_TRACE=verbose` does not enable Helix's verbose mode by itself. You'll need to run Helix with `-v` for verbose logging.
 
 To change the log level for Ruff (which is `info` by default), use the `logLevel` setting:
-```toml
+
+````toml
 ```toml
 [language-server.ruff]
 command = "ruff"
@@ -82,4 +84,4 @@ environment = { "RUFF_TRACE" = "messages" }
 
 [language-server.ruff.config.settings]
 logLevel = "debug"
-```
+````

--- a/crates/ruff_server/docs/setup/HELIX.md
+++ b/crates/ruff_server/docs/setup/HELIX.md
@@ -61,7 +61,7 @@ preview = true
 ```
 
 By default, Ruff does not log anything to Helix. To enable logging, set the `RUFF_TRACE` environment variable
-to either `messages` or `verbose`. This will set the trace level for this server.
+to either `messages` or `verbose`.
 
 ```toml
 [language-server.ruff]

--- a/crates/ruff_server/docs/setup/HELIX.md
+++ b/crates/ruff_server/docs/setup/HELIX.md
@@ -75,7 +75,6 @@ environment = { "RUFF_TRACE" = "messages" }
 
 To change the log level for Ruff (which is `info` by default), use the `logLevel` setting:
 
-````toml
 ```toml
 [language-server.ruff]
 command = "ruff"
@@ -84,4 +83,17 @@ environment = { "RUFF_TRACE" = "messages" }
 
 [language-server.ruff.config.settings]
 logLevel = "debug"
-````
+```
+
+You can also divert Ruff's logs to a separate file with the `logFile` setting:
+
+```toml
+[language-server.ruff]
+command = "ruff"
+args = ["server", "--preview"]
+environment = { "RUFF_TRACE" = "messages" }
+
+[language-server.ruff.config.settings]
+logLevel = "debug"
+logFile = "your/log/file/path/log.txt"
+```

--- a/crates/ruff_server/docs/setup/HELIX.md
+++ b/crates/ruff_server/docs/setup/HELIX.md
@@ -95,5 +95,5 @@ environment = { "RUFF_TRACE" = "messages" }
 
 [language-server.ruff.config.settings]
 logLevel = "debug"
-logFile = "your/log/file/path/log.txt"
+logFile = "/Users/developer/.cache/helix/ruff.log"
 ```

--- a/crates/ruff_server/docs/setup/HELIX.md
+++ b/crates/ruff_server/docs/setup/HELIX.md
@@ -52,10 +52,34 @@ You can pass settings into `ruff server` using `[language-server.ruff.config.set
 
 ```toml
 [language-server.ruff.config.settings]
-line-length = 80
+lineLength = 80
 [language-server.ruff.config.settings.lint]
 select = ["E4", "E7"]
 preview = false
 [language-server.ruff.config.settings.format]
 preview = true
+```
+
+By default, Ruff does not log anything to Helix. To enable logging, set the `RUFF_TRACE` environment variable
+to either `messages` or `verbose`. This will set the trace level for this server.
+```toml
+[language-server.ruff]
+command = "ruff"
+args = ["server", "--preview"]
+environment = { "RUFF_TRACE" = "messages" }
+```
+
+> \[!NOTE\]
+> `RUFF_TRACE=verbose` does not enable Helix's verbose mode by itself. You'll need to run Helix with `-v` for verbose logging.
+
+To change the log level for Ruff (which is `info` by default), use the `logLevel` setting:
+```toml
+```toml
+[language-server.ruff]
+command = "ruff"
+args = ["server", "--preview"]
+environment = { "RUFF_TRACE" = "messages" }
+
+[language-server.ruff.config.settings]
+logLevel = "debug"
 ```


### PR DESCRIPTION
A follow-up to [this suggestion](https://github.com/astral-sh/ruff/pull/11747#discussion_r1634297757) on the tracing PR.