### PR TITLE
`ruff server`: Add tracing setup guide to Neovim documentation

### DIFF
--- a/crates/ruff_server/docs/setup/NEOVIM.md
+++ b/crates/ruff_server/docs/setup/NEOVIM.md
@@ -57,6 +57,7 @@ require('lspconfig').pyright.setup {
 
 By default, Ruff will not show any logs. To enable logging in Neovim, you'll need to set the `RUFF_TRACE` environment variable
 to either `messages` or `verbose`:
+
 ```lua
 require('lspconfig').ruff.setup {
   cmd_env = { RUFF_TRACE = "messages" }
@@ -64,6 +65,7 @@ require('lspconfig').ruff.setup {
 ```
 
 You can set the log level in `settings`:
+
 ```lua
 require('lspconfig').ruff.setup {
   cmd_env = { RUFF_TRACE = "messages" },
@@ -73,7 +75,8 @@ require('lspconfig').ruff.setup {
 }
 ```
 
-It's also possible to divert Ruff's logs to a seperate file with the `logFile` setting:
+It's also possible to divert Ruff's logs to a separate file with the `logFile` setting:
+
 ```lua
 require('lspconfig').ruff.setup {
   cmd_env = { RUFF_TRACE = "messages" },

--- a/crates/ruff_server/docs/setup/NEOVIM.md
+++ b/crates/ruff_server/docs/setup/NEOVIM.md
@@ -69,8 +69,10 @@ You can set the log level in `settings`:
 ```lua
 require('lspconfig').ruff.setup {
   cmd_env = { RUFF_TRACE = "messages" },
-  settings = {
-    logLevel = "debug",
+  init_options = {
+    settings = {
+      logLevel = "debug",
+    }
   }
 }
 ```
@@ -80,9 +82,11 @@ It's also possible to divert Ruff's logs to a separate file with the `logFile` s
 ```lua
 require('lspconfig').ruff.setup {
   cmd_env = { RUFF_TRACE = "messages" },
-  settings = {
-    logLevel = "debug",
-    logFile = "your/log/file/path/log.txt"
+  init_options = {
+    settings = {
+      logLevel = "debug",
+      logFile = "your/log/file/path/log.txt"
+    }
   }
 }
 ```

--- a/crates/ruff_server/docs/setup/NEOVIM.md
+++ b/crates/ruff_server/docs/setup/NEOVIM.md
@@ -54,3 +54,32 @@ require('lspconfig').pyright.setup {
   },
 }
 ```
+
+By default, Ruff will not show any logs. To enable logging in Neovim, you'll need to set the `RUFF_TRACE` environment variable
+to either `messages` or `verbose`:
+```lua
+require('lspconfig').ruff.setup {
+  cmd_env = { RUFF_TRACE = "messages" }
+}
+```
+
+You can set the log level in `settings`:
+```lua
+require('lspconfig').ruff.setup {
+  cmd_env = { RUFF_TRACE = "messages" },
+  settings = {
+    logLevel = "debug",
+  }
+}
+```
+
+It's also possible to divert Ruff's logs to a seperate file with the `logFile` setting:
+```lua
+require('lspconfig').ruff.setup {
+  cmd_env = { RUFF_TRACE = "messages" },
+  settings = {
+    logLevel = "debug",
+    logFile = "your/log/file/path/log.txt"
+  }
+}
+```


### PR DESCRIPTION
A follow-up to [this suggestion](https://github.com/astral-sh/ruff/pull/11747#discussion_r1634297757) on the tracing PR.