### PR TITLE
Avoid displaying syntax error as log message

### DIFF
--- a/crates/ruff/tests/integration_test.rs
+++ b/crates/ruff/tests/integration_test.rs
@@ -807,7 +807,6 @@ fn stdin_parse_error() {
     Found 1 error.
 
     ----- stderr -----
-    error: Failed to parse at 1:16: Expected one or more symbol names after import
     "###);
 }
 
@@ -836,7 +835,6 @@ fn stdin_multiple_parse_error() {
     Found 2 errors.
 
     ----- stderr -----
-    error: Failed to parse at 1:16: Expected one or more symbol names after import
     "###);
 }
 
@@ -858,7 +856,6 @@ fn parse_error_not_included() {
     Found 1 error.
 
     ----- stderr -----
-    error: Failed to parse at 1:6: Expected an expression
     "###);
 }
 

--- a/crates/ruff_linter/src/linter.rs
+++ b/crates/ruff_linter/src/linter.rs
@@ -5,7 +5,6 @@ use std::path::Path;
 use anyhow::{anyhow, Result};
 use colored::Colorize;
 use itertools::Itertools;
-use log::error;
 use rustc_hash::FxHashMap;
 
 use ruff_diagnostics::Diagnostic;
@@ -26,7 +25,6 @@ use crate::checkers::tokens::check_tokens;
 use crate::directives::Directives;
 use crate::doc_lines::{doc_lines_from_ast, doc_lines_from_tokens};
 use crate::fix::{fix_file, FixResult};
-use crate::logging::DisplayParseError;
 use crate::message::Message;
 use crate::noqa::add_noqa;
 use crate::registry::{AsRule, Rule, RuleSet};
@@ -354,8 +352,7 @@ pub fn add_noqa_to_path(
 
     // Generate diagnostics, ignoring any existing `noqa` directives.
     let LinterResult {
-        data: diagnostics,
-        error,
+        data: diagnostics, ..
     } = check_path(
         path,
         package,
@@ -369,19 +366,6 @@ pub fn add_noqa_to_path(
         source_type,
         &parsed,
     );
-
-    // Log any parse errors.
-    if let Some(error) = error {
-        error!(
-            "{}",
-            DisplayParseError::from_source_code(
-                error,
-                Some(path.to_path_buf()),
-                &locator.to_source_code(),
-                source_kind,
-            )
-        );
-    }
 
     // Add any missing `# noqa` pragmas.
     // TODO(dhruvmanila): Add support for Jupyter Notebooks


### PR DESCRIPTION
## Summary

Follow-up to #11901 

This PR avoids displaying the syntax errors as log message now that the `E999` diagnostic cannot be disabled.

For context on why this was added, refer to https://github.com/astral-sh/ruff/pull/2505. Basically, we would allow ignoring the syntax error diagnostic because certain syntax feature weren't supported back then like `match` statement. And, if a user ignored `E999`, Ruff would give no feedback if the source code contained any syntax error. So, this log message was a way to indicate to the user even if `E999` was disabled.

The current state of the parser is such that (a) it matches with the latest grammar and (b) it's easy to add support for any new syntax.

**Note:** This PR doesn't remove the `DisplayParseError` struct because it's still being used by the formatter.

## Test Plan

Update existing snapshots from the integration tests.
