### PR TITLE
[red-knot] Strip out non-pyi files from the typeshed zip file created at build time

### DIFF
--- a/crates/red_knot/Cargo.toml
+++ b/crates/red_knot/Cargo.toml
@@ -44,6 +44,7 @@ walkdir = { workspace = true }
 [dev-dependencies]
 insta = { workspace = true }
 tempfile = { workspace = true }
+walkdir = { workspace = true }
 
 [lints]
 workspace = true


### PR DESCRIPTION
## Summary

This tweaks the red-knot `build.rs` script to ensure that all non-`.pyi` files are stripped out from the zip created at build time, and asserts as much in our test suite. This means there's less room for error if typeshed changes its directory structure unexpectedly, which could theoretically cause us to accidentally start bundling parts of typeshed's test suite as part of the zip.

The only non-`.pyi` file we'll need from typeshed is the `stdlib/VERSIONS` file, and I think it's easier if we add that to the Ruff binary separately via `include_str!()`.

## Test Plan

Add some more assertions to `module.rs`.
