### PR TITLE
Fix Fuzz build

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -257,10 +257,13 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: "fuzz -> target"
-      - name: "Install cargo-fuzz"
-        uses: taiki-e/install-action@v2
+      - name: "Install cargo-binstall"
+        uses: cargo-bins/cargo-binstall@main
         with:
           tool: cargo-fuzz@0.11.2
+      - name: "Install cargo-fuzz"
+        # Download the latest version from quick install and not the github releases because github releases only has MUSL targets.
+        run: cargo binstall cargo-fuzz --force  --disable-strategies crate-meta-data --no-confirm
       - run: cargo fuzz build -s none
 
   fuzz-parser:


### PR DESCRIPTION
## Summary

Try to fix the Fuzz CI Job.

I'm not sure how and why it worked before because we always used the MUSL targets from the GitHub releases page. 

An alternative could be to add the Rust musl target, but I ran into issues locally where the MUSL target requires more dependencies.

## Test Plan

CI?
