### PR TITLE
Avoid consuming trailing whitespace during re-lexing

### DIFF
--- a/crates/ruff_python_parser/resources/invalid/re_lex_logical_token.py
+++ b/crates/ruff_python_parser/resources/invalid/re_lex_logical_token.py
@@ -55,3 +55,9 @@ if call(f"hello {x
 if call(f"hello
     def bar():
         pass
+
+
+# There are trailing whitespace before the newline character but those whitespaces are
+# part of the comment token
+f"""hello {x # comment    
+y = 1

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@re_lex_logical_token.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@re_lex_logical_token.py.snap
@@ -7,7 +7,7 @@ input_file: crates/ruff_python_parser/resources/invalid/re_lex_logical_token.py
 ```
 Module(
     ModModule {
-        range: 0..979,
+        range: 0..1129,
         body: [
             If(
                 StmtIf {
@@ -670,6 +670,53 @@ Module(
                     ],
                 },
             ),
+            Expr(
+                StmtExpr {
+                    range: 1097..1109,
+                    value: FString(
+                        ExprFString {
+                            range: 1097..1109,
+                            value: FStringValue {
+                                inner: Single(
+                                    FString(
+                                        FString {
+                                            range: 1097..1109,
+                                            elements: [
+                                                Literal(
+                                                    FStringLiteralElement {
+                                                        range: 1101..1107,
+                                                        value: "hello ",
+                                                    },
+                                                ),
+                                                Expression(
+                                                    FStringExpressionElement {
+                                                        range: 1107..1109,
+                                                        expression: Name(
+                                                            ExprName {
+                                                                range: 1108..1109,
+                                                                id: "x",
+                                                                ctx: Load,
+                                                            },
+                                                        ),
+                                                        debug_text: None,
+                                                        conversion: None,
+                                                        format_spec: None,
+                                                    },
+                                                ),
+                                            ],
+                                            flags: FStringFlags {
+                                                quote_style: Double,
+                                                prefix: Regular,
+                                                triple_quoted: true,
+                                            },
+                                        },
+                                    ),
+                                ),
+                            },
+                        },
+                    ),
+                },
+            ),
         ],
     },
 )
@@ -831,8 +878,45 @@ Module(
 
 
    |
-55 | if call(f"hello
-56 |     def bar():
-57 |         pass
-   |              Syntax Error: Expected a statement
+60 | # There are trailing whitespace before the newline character but those whitespaces are
+61 | # part of the comment token
+62 | f"""hello {x # comment    
+   |  Syntax Error: Expected a statement
+63 | y = 1
+   |
+
+
+   |
+60 |   # There are trailing whitespace before the newline character but those whitespaces are
+61 |   # part of the comment token
+62 |   f"""hello {x # comment    
+   |  ___________________________^
+63 | | y = 1
+   | |_____^ Syntax Error: f-string: unterminated triple-quoted string
+   |
+
+
+   |
+61 | # part of the comment token
+62 | f"""hello {x # comment    
+63 | y = 1
+   | ^ Syntax Error: f-string: expecting '}'
+   |
+
+
+   |
+60 |   # There are trailing whitespace before the newline character but those whitespaces are
+61 |   # part of the comment token
+62 |   f"""hello {x # comment    
+   |  ___________________________^
+63 | | y = 1
+   | |_____^ Syntax Error: Expected FStringEnd, found Unknown
+   |
+
+
+   |
+61 | # part of the comment token
+62 | f"""hello {x # comment    
+63 | y = 1
+   |       Syntax Error: Expected a statement
    |


### PR DESCRIPTION
## Summary

This PR updates the re-lexing logic to avoid consuming the trailing whitespace and move the lexer explicitly to the last newline character encountered while moving backwards.

Consider the following code snippet as taken from the test case highlighted with whitespace (`.`) and newline (`\n`) characters:
```py
# There are trailing whitespace before the newline character but those whitespaces are
# part of the comment token
f"""hello {x # comment....\n
#                     ^
y = 1\n
```

The parser is at `y` when it's trying to recover from an unclosed `{`, so it calls into the re-lexing logic which tries to move the lexer back to the end of the previous line. But, as it consumed all whitespaces it moved the lexer to the location marked by `^` in the above code snippet. But, those whitespaces are part of the comment token. This means that the range for the two tokens were overlapping which introduced the panic.

Note that this is only a bug when there's a comment with a trailing whitespace otherwise it's fine to move the lexer to the whitespace character. This is because the lexer would just skip the whitespace otherwise. Nevertheless, this PR updates the logic to move it explicitly to the newline character in all cases.

fixes: #11929 

## Test Plan

Add test cases and update the snapshot. Make sure that it doesn't panic on the code snippet in the linked issue.
