### PR TITLE
`ruff server`: Closing an untitled, unsaved notebook document no longer throws an error

### DIFF
--- a/crates/ruff_server/src/server/api/notifications/did_close_notebook.rs
+++ b/crates/ruff_server/src/server/api/notifications/did_close_notebook.rs
@@ -1,8 +1,6 @@
-use crate::server::api::LSPResult;
 use crate::server::client::{Notifier, Requester};
 use crate::server::Result;
 use crate::session::Session;
-use lsp_server::ErrorCode;
 use lsp_types as types;
 use lsp_types::notification as notif;
 
@@ -14,20 +12,14 @@ impl super::NotificationHandler for DidCloseNotebook {
 
 impl super::SyncNotificationHandler for DidCloseNotebook {
     fn run(
-        session: &mut Session,
+        _session: &mut Session,
         _notifier: Notifier,
         _requester: &mut Requester,
-        types::DidCloseNotebookDocumentParams {
-            notebook_document: types::NotebookDocumentIdentifier { uri },
-            ..
-        }: types::DidCloseNotebookDocumentParams,
+        _params: types::DidCloseNotebookDocumentParams,
     ) -> Result<()> {
-        let key = session.key_from_url(uri);
-
-        session
-            .close_document(&key)
-            .with_failure_code(ErrorCode::InternalError)?;
-
+        // `textDocument/didClose` is called after didCloseNotebook,
+        // and the document is removed from the index at that point.
+        // For this specific notification, we don't need to do anything.
         Ok(())
     }
 }

--- a/crates/ruff_server/src/session/index.rs
+++ b/crates/ruff_server/src/session/index.rs
@@ -357,9 +357,11 @@ impl Index {
         };
         if let Some(notebook) = controller.as_notebook() {
             for url in notebook.urls() {
-                self.notebook_cells.remove(url).ok_or_else(|| {
-                    anyhow!("tried to de-register notebook cell with URL {url} that didn't exist")
-                })?;
+                if self.notebook_cells.remove(url).is_none() {
+                    tracing::debug!(
+                        "tried to de-register notebook cell with URL {url} that didn't exist"
+                    );
+                }
             }
         }
         Ok(())

--- a/crates/ruff_server/src/session/index.rs
+++ b/crates/ruff_server/src/session/index.rs
@@ -352,18 +352,9 @@ impl Index {
             anyhow::bail!("Tried to close unavailable document `{key}`");
         };
 
-        let Some(controller) = self.documents.remove(&url) else {
+        let Some(_) = self.documents.remove(&url) else {
             anyhow::bail!("tried to close document that didn't exist at {}", url)
         };
-        if let Some(notebook) = controller.as_notebook() {
-            for url in notebook.urls() {
-                if self.notebook_cells.remove(url).is_none() {
-                    tracing::debug!(
-                        "tried to de-register notebook cell with URL {url} that didn't exist"
-                    );
-                }
-            }
-        }
         Ok(())
     }
 


### PR DESCRIPTION
## Summary

Fixes #11651.
Fixes #11851.

We were double-closing a notebook document from the index, once in `textDocument/didClose` and then in the `notebookDocument/didClose` handler. The second time this happens, taking a snapshot fails.

I've rewritten how we handle snapshots for closing notebooks / notebook cells so that any failure is simply logged instead of propagating upwards. This implementation works consistently even if we don't receive `textDocument/didClose` notifications for each specific cell, since they get closed (and the diagnostics get cleared) in the notebook document removal process.

## Test Plan

1. Open an untitled, unsaved notebook with the `Create: New Jupyter Notebook` command from the VS Code command palette (`Ctrl/Cmd + Shift + P`)
2. Without saving the document, close it.
3. No error popup should appear.
4. Run the debug command (`Ruff: print debug information`) to confirm that there are no open documents
