### PR TITLE
`ruff server`: Support the usage of tildes and environment variables in `logFile`

### DIFF
--- a/crates/ruff_server/docs/setup/HELIX.md
+++ b/crates/ruff_server/docs/setup/HELIX.md
@@ -97,3 +97,5 @@ environment = { "RUFF_TRACE" = "messages" }
 logLevel = "debug"
 logFile = "~/.cache/helix/ruff.log"
 ```
+
+The `logFile` path supports tildes and environment variables.

--- a/crates/ruff_server/docs/setup/HELIX.md
+++ b/crates/ruff_server/docs/setup/HELIX.md
@@ -95,5 +95,5 @@ environment = { "RUFF_TRACE" = "messages" }
 
 [language-server.ruff.config.settings]
 logLevel = "debug"
-logFile = "/Users/developer/.cache/helix/ruff.log"
+logFile = "~/.cache/helix/ruff.log"
 ```

--- a/crates/ruff_server/docs/setup/NEOVIM.md
+++ b/crates/ruff_server/docs/setup/NEOVIM.md
@@ -90,3 +90,5 @@ require('lspconfig').ruff.setup {
   }
 }
 ```
+
+The `logFile` path supports tildes and environment variables.

--- a/crates/ruff_server/docs/setup/NEOVIM.md
+++ b/crates/ruff_server/docs/setup/NEOVIM.md
@@ -85,7 +85,7 @@ require('lspconfig').ruff.setup {
   init_options = {
     settings = {
       logLevel = "debug",
-      logFile = "your/log/file/path/log.txt"
+      logFile = "~/.config/nvim/logs/ruff_logs.txt"
     }
   }
 }

--- a/crates/ruff_server/docs/setup/NEOVIM.md
+++ b/crates/ruff_server/docs/setup/NEOVIM.md
@@ -85,7 +85,7 @@ require('lspconfig').ruff.setup {
   init_options = {
     settings = {
       logLevel = "debug",
-      logFile = "~/.config/nvim/logs/ruff_logs.txt"
+      logFile = "~/.local/state/nvim/ruff.log"
     }
   }
 }

--- a/crates/ruff_server/src/session/settings.rs
+++ b/crates/ruff_server/src/session/settings.rs
@@ -83,6 +83,7 @@ pub(crate) struct ClientSettings {
 #[serde(rename_all = "camelCase")]
 pub(crate) struct TracingSettings {
     pub(crate) log_level: Option<crate::trace::LogLevel>,
+    /// Path to the log file - tildes and environment variables are supported.
     pub(crate) log_file: Option<PathBuf>,
 }
 

--- a/crates/ruff_server/src/trace.rs
+++ b/crates/ruff_server/src/trace.rs
@@ -69,7 +69,16 @@ pub(crate) fn init_tracing(
             std::fs::OpenOptions::new()
                 .create(true)
                 .append(true)
-                .open(path)
+                .open(&path)
+                .map_err(|err| {
+                    #[allow(clippy::print_stderr)]
+                    {
+                        eprintln!(
+                            "Failed to open file at {} for logging: {err}",
+                            path.display()
+                        );
+                    }
+                })
                 .ok()
         });
 

--- a/crates/ruff_server/src/trace.rs
+++ b/crates/ruff_server/src/trace.rs
@@ -54,6 +54,8 @@ pub(crate) fn init_tracing(
 
     let log_file = log_file
         .map(|path| {
+            // this expands `logFile` so that tildes and environment variables
+            // are replaced with their values, if possible.
             if let Some(expanded) = shellexpand::full(&path.to_string_lossy())
                 .ok()
                 .and_then(|path| PathBuf::from_str(&path).ok())


### PR DESCRIPTION
## Summary

Fixes #11911.

`shellexpand` is now used on `logFile` to expand the file path, allowing the usage of `~` and environment variables.

## Test Plan

1. Set `logFile` in either Neovim or Helix to a file path that needs expansion, like `~/.config/helix/ruff_logs.txt`.
2. Ensure that `RUFF_TRACE` is set to `messages` or `verbose`
3. Open a Python file in Neovim/Helix
4. Confirm that a file at the path specified was created, with the expected logs.
