### PR TITLE
Avoid depth counting when detecting indentation

### DIFF
--- a/crates/ruff_python_codegen/src/stylist.rs
+++ b/crates/ruff_python_codegen/src/stylist.rs
@@ -97,26 +97,16 @@ fn detect_indention(tokens: &[Token], locator: &Locator) -> Indentation {
         //   cos,
         // )
         // ```
-        let mut depth = 0usize;
         for token in tokens {
-            match token.kind() {
-                TokenKind::Lpar | TokenKind::Lbrace | TokenKind::Lsqb => {
-                    depth = depth.saturating_add(1);
-                }
-                TokenKind::Rpar | TokenKind::Rbrace | TokenKind::Rsqb => {
-                    depth = depth.saturating_sub(1);
-                }
-                TokenKind::NonLogicalNewline => {
-                    let line = locator.line(token.end());
-                    let indent_index = line.find(|c: char| !c.is_whitespace());
-                    if let Some(indent_index) = indent_index {
-                        if indent_index > 0 {
-                            let whitespace = &line[..indent_index];
-                            return Indentation(whitespace.to_string());
-                        }
+            if token.kind() == TokenKind::NonLogicalNewline {
+                let line = locator.line(token.end());
+                let indent_index = line.find(|c: char| !c.is_whitespace());
+                if let Some(indent_index) = indent_index {
+                    if indent_index > 0 {
+                        let whitespace = &line[..indent_index];
+                        return Indentation(whitespace.to_string());
                     }
                 }
-                _ => {}
             }
         }
 


### PR DESCRIPTION
## Summary

This PR avoids the `depth` counter when detecting indentation from non-logical lines because it seems to never be used. It might have been a leftover when the logic was added originally in #11608.

## Test Plan

`cargo insta test`
