### PR TITLE
Update `trapz` and `in1d` deprecation for NPY201

### DIFF
--- a/crates/ruff_linter/src/rules/numpy/rules/numpy_2_0_deprecation.rs
+++ b/crates/ruff_linter/src/rules/numpy/rules/numpy_2_0_deprecation.rs
@@ -306,6 +306,14 @@ pub(crate) fn numpy_2_0_deprecation(checker: &mut Checker, expr: &Expr) {
                     guideline: Some("Use the `np.errstate` context manager instead."),
                 },
             }),
+            ["numpy", "in1d"] => Some(Replacement {
+                existing: "in1d",
+                details: Details::AutoImport {
+                    path: "numpy",
+                    name: "isin",
+                    compatibility: Compatibility::BackwardsCompatible,
+                },
+            }),
             ["numpy", "INF"] => Some(Replacement {
                 existing: "INF",
                 details: Details::AutoImport {
@@ -534,6 +542,14 @@ pub(crate) fn numpy_2_0_deprecation(checker: &mut Checker, expr: &Expr) {
                     path: "numpy.lib",
                     name: "tracemalloc_domain",
                     compatibility: Compatibility::BackwardsCompatible,
+                },
+            }),
+            ["numpy", "trapz"] => Some(Replacement {
+                existing: "trapz",
+                details: Details::AutoImport {
+                    path: "numpy",
+                    name: "trapezoid",
+                    compatibility: Compatibility::Breaking,
                 },
             }),
             ["numpy", "unicode_"] => Some(Replacement {


### PR DESCRIPTION
## Summary

Adds missing deprecation of `trapz` and `in1d` for NPY201 as listed in the [migration guide](https://numpy.org/devdocs/numpy_2_0_migration_guide.html#changes-to-namespaces). The change from `trapz` to `trapezoid` is not backwards compatible.
