### PR TITLE
[red-knot] Add tracing to Salsa queries

### DIFF
--- a/crates/red_knot_python_semantic/src/semantic_index/symbol.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/symbol.rs
@@ -8,6 +8,7 @@ use std::ops::Range;
 use bitflags::bitflags;
 use hashbrown::hash_map::RawEntryMut;
 use rustc_hash::FxHasher;
+use salsa::DebugWithDb;
 use smallvec::SmallVec;
 
 use ruff_db::vfs::VfsFile;
@@ -132,6 +133,8 @@ impl ScopedSymbolId {
 /// Returns a mapping from [`FileScopeId`] to globally unique [`ScopeId`].
 #[salsa::tracked(return_ref)]
 pub(crate) fn scopes_map(db: &dyn Db, file: VfsFile) -> ScopesMap {
+    let _ = tracing::trace_span!("scopes_map", file = ?file.debug(db.upcast())).enter();
+
     let index = semantic_index(db, file);
 
     let scopes: IndexVec<_, _> = index
@@ -162,6 +165,8 @@ impl ScopesMap {
 
 #[salsa::tracked(return_ref)]
 pub(crate) fn public_symbols_map(db: &dyn Db, file: VfsFile) -> PublicSymbolsMap {
+    let _ = tracing::trace_span!("public_symbols_map", file = ?file.debug(db.upcast())).enter();
+
     let module_scope = root_scope(db, file);
     let symbols = symbol_table(db, module_scope);
 

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -62,7 +62,7 @@ pub(crate) fn expression_ty(db: &dyn Db, file: VfsFile, expression: &ast::Expr) 
 /// This being a query ensures that the invalidation short-circuits if the type of this symbol didn't change.
 #[salsa::tracked]
 pub(crate) fn public_symbol_ty(db: &dyn Db, symbol: PublicSymbolId) -> Type {
-    let _ = tracing::debug_span!("public_symbol_ty", symbol = ?symbol.debug(db)).enter();
+    let _ = tracing::trace_span!("public_symbol_ty", symbol = ?symbol.debug(db)).enter();
 
     let file = symbol.file(db);
     let scope = root_scope(db, file);
@@ -80,6 +80,8 @@ pub fn public_symbol_ty_by_name(db: &dyn Db, file: VfsFile, name: &str) -> Optio
 /// Infers all types for `scope`.
 #[salsa::tracked(return_ref)]
 pub(crate) fn infer_types(db: &dyn Db, scope: ScopeId) -> TypeInference {
+    let _ = tracing::trace_span!("infer_types", scope = ?scope.debug(db)).enter();
+
     let file = scope.file(db);
     // Using the index here is fine because the code below depends on the AST anyway.
     // The isolation of the query is by the return inferred types.

--- a/crates/ruff_db/src/parsed.rs
+++ b/crates/ruff_db/src/parsed.rs
@@ -1,3 +1,4 @@
+use salsa::DebugWithDb;
 use std::fmt::Formatter;
 use std::ops::Deref;
 use std::sync::Arc;
@@ -22,6 +23,8 @@ use crate::Db;
 /// for determining if a query result is unchanged.
 #[salsa::tracked(return_ref, no_eq)]
 pub fn parsed_module(db: &dyn Db, file: VfsFile) -> ParsedModule {
+    let _ = tracing::trace_span!("parse_module", file = ?file.debug(db)).enter();
+
     let source = source_text(db, file);
     let path = file.path(db);
 

--- a/crates/ruff_db/src/source.rs
+++ b/crates/ruff_db/src/source.rs
@@ -1,3 +1,4 @@
+use salsa::DebugWithDb;
 use std::ops::Deref;
 use std::sync::Arc;
 
@@ -9,6 +10,8 @@ use crate::Db;
 /// Reads the content of file.
 #[salsa::tracked]
 pub fn source_text(db: &dyn Db, file: VfsFile) -> SourceText {
+    let _ = tracing::trace_span!("source_text", file = ?file.debug(db)).enter();
+
     let content = file.read(db);
 
     SourceText {
@@ -19,6 +22,8 @@ pub fn source_text(db: &dyn Db, file: VfsFile) -> SourceText {
 /// Computes the [`LineIndex`] for `file`.
 #[salsa::tracked]
 pub fn line_index(db: &dyn Db, file: VfsFile) -> LineIndex {
+    let _ = tracing::trace_span!("line_index", file = ?file.debug(db)).enter();
+
     let source = source_text(db, file);
 
     LineIndex::from_source_text(&source)


### PR DESCRIPTION
## Summary

This PR adds tracing instrumentation to Salsa queries. 

I intentionally didn't use the `#[tracing::instrument]` attribute because, depending on the ordering, the attribute is applied to the query implementation only or the query implementation and the `get` function that retrieves the cached value or calls the query implementation.
Using `debug_span!` avoids the ambiguity and has the added benefit that we can call the `DebugWithDb` implementation instead of just `debug` on the arguments. 

