### PR TITLE
Avoid running logical line rule logic if not enabled

### DIFF
--- a/crates/ruff_linter/src/rules/pycodestyle/rules/logical_lines/indentation.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/logical_lines/indentation.rs
@@ -250,7 +250,7 @@ impl Violation for OverIndented {
     }
 }
 
-/// E111, E114, E112, E113, E115, E116, E117
+/// E111, E112, E113, E114, E115, E116, E117
 pub(crate) fn indentation(
     logical_line: &LogicalLine,
     prev_logical_line: Option<&LogicalLine>,


### PR DESCRIPTION
## Summary

This PR updates the logical line rules entry-point function to only run the logic if any of the rules within that group is enabled.

Although this shouldn't really give any performance improvements, it's better not to do additional work if we can. This is also consistent with how other rules are run.

## Test Plan

`cargo insta test`
