### PR TITLE
Remove duplication around `is_trivia` functions

### DIFF
--- a/crates/ruff_linter/src/rules/pycodestyle/helpers.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/helpers.rs
@@ -1,4 +1,18 @@
+use ruff_python_parser::TokenKind;
+
 /// Returns `true` if the name should be considered "ambiguous".
 pub(super) fn is_ambiguous_name(name: &str) -> bool {
     name == "l" || name == "I" || name == "O"
+}
+
+/// Returns `true` if the given `token` is a non-logical token.
+///
+/// Unlike [`TokenKind::is_trivia`], this function also considers the indent, dedent and newline
+/// tokens.
+pub(super) const fn is_non_logical_token(token: TokenKind) -> bool {
+    token.is_trivia()
+        || matches!(
+            token,
+            TokenKind::Newline | TokenKind::Indent | TokenKind::Dedent
+        )
 }

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/blank_lines.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/blank_lines.rs
@@ -15,13 +15,14 @@ use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::PySourceType;
 use ruff_python_codegen::Stylist;
 use ruff_python_parser::TokenKind;
+use ruff_python_trivia::PythonWhitespace;
 use ruff_source_file::{Locator, UniversalNewlines};
 use ruff_text_size::TextRange;
 use ruff_text_size::TextSize;
 
 use crate::checkers::logical_lines::expand_indent;
 use crate::line_width::IndentWidth;
-use ruff_python_trivia::PythonWhitespace;
+use crate::rules::pycodestyle::helpers::is_non_logical_token;
 
 /// Number of blank lines around top level classes and functions.
 const BLANK_LINES_TOP_LEVEL: u32 = 2;
@@ -489,13 +490,13 @@ impl<'a> Iterator for LinePreprocessor<'a> {
                     (logical_line_kind, range)
                 };
 
-            if !kind.is_trivia() {
+            if !is_non_logical_token(kind) {
                 line_is_comment_only = false;
             }
 
             // A docstring line is composed only of the docstring (TokenKind::String) and trivia tokens.
             // (If a comment follows a docstring, we still count the line as a docstring)
-            if kind != TokenKind::String && !kind.is_trivia() {
+            if kind != TokenKind::String && !is_non_logical_token(kind) {
                 is_docstring = false;
             }
 
@@ -545,7 +546,7 @@ impl<'a> Iterator for LinePreprocessor<'a> {
                 _ => {}
             }
 
-            if !kind.is_trivia() {
+            if !is_non_logical_token(kind) {
                 last_token = kind;
             }
         }

--- a/crates/ruff_linter/src/rules/pyflakes/rules/invalid_literal_comparisons.rs
+++ b/crates/ruff_linter/src/rules/pyflakes/rules/invalid_literal_comparisons.rs
@@ -146,7 +146,7 @@ fn locate_cmp_ops(expr: &Expr, tokens: &Tokens) -> Vec<LocatedCmpOp> {
     let mut tok_iter = tokens
         .in_range(expr.range())
         .iter()
-        .filter(|token| !token.is_trivia())
+        .filter(|token| !token.kind().is_trivia())
         .peekable();
 
     let mut ops: Vec<LocatedCmpOp> = vec![];

--- a/crates/ruff_python_parser/src/lexer.rs
+++ b/crates/ruff_python_parser/src/lexer.rs
@@ -1626,12 +1626,6 @@ impl Token {
         (self.kind, self.range)
     }
 
-    /// Returns `true` if this is a trivia token.
-    #[inline]
-    pub const fn is_trivia(self) -> bool {
-        matches!(self.kind, TokenKind::Comment | TokenKind::NonLogicalNewline)
-    }
-
     /// Returns `true` if this is any kind of string token.
     const fn is_any_string(self) -> bool {
         matches!(

--- a/crates/ruff_python_parser/src/token.rs
+++ b/crates/ruff_python_parser/src/token.rs
@@ -192,13 +192,15 @@ pub enum TokenKind {
 }
 
 impl TokenKind {
+    /// Returns `true` if this is an end of file token.
     #[inline]
     pub const fn is_eof(self) -> bool {
         matches!(self, TokenKind::EndOfFile)
     }
 
+    /// Returns `true` if this is either a newline or non-logical newline token.
     #[inline]
-    pub const fn is_newline(self) -> bool {
+    pub const fn is_any_newline(self) -> bool {
         matches!(self, TokenKind::Newline | TokenKind::NonLogicalNewline)
     }
 
@@ -294,21 +296,16 @@ impl TokenKind {
         )
     }
 
+    /// Returns `true` if this is a singleton token i.e., `True`, `False`, or `None`.
     #[inline]
     pub const fn is_singleton(self) -> bool {
         matches!(self, TokenKind::False | TokenKind::True | TokenKind::None)
     }
 
+    /// Returns `true` if this is a trivia token i.e., a comment or a non-logical newline.
     #[inline]
     pub const fn is_trivia(&self) -> bool {
-        matches!(
-            self,
-            TokenKind::Newline
-                | TokenKind::Indent
-                | TokenKind::Dedent
-                | TokenKind::NonLogicalNewline
-                | TokenKind::Comment
-        )
+        matches!(self, TokenKind::Comment | TokenKind::NonLogicalNewline)
     }
 
     #[inline]

--- a/crates/ruff_python_parser/src/token_source.rs
+++ b/crates/ruff_python_parser/src/token_source.rs
@@ -114,7 +114,7 @@ impl<'src> TokenSource<'src> {
     fn do_bump(&mut self) {
         loop {
             let kind = self.lexer.next_token();
-            if is_trivia(kind) {
+            if kind.is_trivia() {
                 self.tokens
                     .push(Token::new(kind, self.current_range(), self.current_flags()));
                 continue;
@@ -127,7 +127,7 @@ impl<'src> TokenSource<'src> {
     fn next_non_trivia_token(&mut self) -> TokenKind {
         loop {
             let kind = self.lexer.next_token();
-            if is_trivia(kind) {
+            if kind.is_trivia() {
                 continue;
             }
             break kind;
@@ -186,8 +186,4 @@ pub(crate) struct TokenSourceCheckpoint {
 fn allocate_tokens_vec(contents: &str) -> Vec<Token> {
     let lower_bound = contents.len().saturating_mul(15) / 100;
     Vec::with_capacity(lower_bound)
-}
-
-fn is_trivia(token: TokenKind) -> bool {
-    matches!(token, TokenKind::Comment | TokenKind::NonLogicalNewline)
 }


### PR DESCRIPTION
## Summary

This PR removes the duplication around `is_trivia` functions.

There are two of them in the codebase:
1. In `pycodestyle`, it's for newline, indent, dedent, non-logical newline and comment
2. In the parser, it's for non-logical newline and comment

The `TokenKind::is_trivia` method used (1) but that's not correct in that context. So, this PR introduces a new `is_non_logical_token` helper method for the `pycodestyle` crate and updates the `TokenKind::is_trivia` implementation with (2).

This also means we can remove `Token::is_trivia` method and the standalone `token_source::is_trivia` function and use the one on `TokenKind`.

## Test Plan

`cargo insta test`