### PR TITLE
Introduce `HasTy` trait and `SemanticModel` facade

### DIFF
--- a/crates/red_knot_module_resolver/src/lib.rs
+++ b/crates/red_knot_module_resolver/src/lib.rs
@@ -4,6 +4,6 @@ mod resolver;
 mod typeshed;
 
 pub use db::{Db, Jar};
-pub use module::{ModuleKind, ModuleName};
+pub use module::{Module, ModuleKind, ModuleName};
 pub use resolver::{resolve_module, set_module_resolution_settings, ModuleResolutionSettings};
 pub use typeshed::versions::TypeshedVersions;

--- a/crates/red_knot_module_resolver/src/resolver.rs
+++ b/crates/red_knot_module_resolver/src/resolver.rs
@@ -1,4 +1,3 @@
-use salsa::DebugWithDb;
 use std::ops::Deref;
 
 use ruff_db::file_system::{FileSystem, FileSystemPath, FileSystemPathBuf};
@@ -42,7 +41,7 @@ pub(crate) fn resolve_module_query<'db>(
     db: &'db dyn Db,
     module_name: internal::ModuleNameIngredient<'db>,
 ) -> Option<Module> {
-    let _ = tracing::trace_span!("resolve_module", module_name = ?module_name.debug(db)).enter();
+    let _span = tracing::trace_span!("resolve_module", ?module_name).entered();
 
     let name = module_name.name(db);
 
@@ -76,7 +75,7 @@ pub fn path_to_module(db: &dyn Db, path: &VfsPath) -> Option<Module> {
 #[salsa::tracked]
 #[allow(unused)]
 pub(crate) fn file_to_module(db: &dyn Db, file: VfsFile) -> Option<Module> {
-    let _ = tracing::trace_span!("file_to_module", file = ?file.debug(db.upcast())).enter();
+    let _span = tracing::trace_span!("file_to_module", ?file).entered();
 
     let path = file.path(db.upcast());
 

--- a/crates/red_knot_python_semantic/src/lib.rs
+++ b/crates/red_knot_python_semantic/src/lib.rs
@@ -1,11 +1,15 @@
+use std::hash::BuildHasherDefault;
+
+use rustc_hash::FxHasher;
+
+pub use db::{Db, Jar};
+pub use semantic_model::{HasTy, SemanticModel};
+
 pub mod ast_node_ref;
 mod db;
 mod node_key;
 pub mod semantic_index;
+mod semantic_model;
 pub mod types;
 
 type FxIndexSet<V> = indexmap::set::IndexSet<V, BuildHasherDefault<FxHasher>>;
-
-pub use db::{Db, Jar};
-use rustc_hash::FxHasher;
-use std::hash::BuildHasherDefault;

--- a/crates/red_knot_python_semantic/src/semantic_index/builder.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/builder.rs
@@ -9,15 +9,12 @@ use ruff_python_ast::name::Name;
 use ruff_python_ast::visitor::{walk_expr, walk_stmt, Visitor};
 
 use crate::node_key::NodeKey;
-use crate::semantic_index::ast_ids::{
-    AstId, AstIdsBuilder, ScopeAssignmentId, ScopeClassId, ScopeFunctionId, ScopeImportFromId,
-    ScopeImportId, ScopeNamedExprId,
-};
+use crate::semantic_index::ast_ids::{AstId, AstIdsBuilder, ScopedClassId, ScopedFunctionId};
 use crate::semantic_index::definition::{Definition, ImportDefinition, ImportFromDefinition};
 use crate::semantic_index::symbol::{
-    FileScopeId, FileSymbolId, Scope, ScopedSymbolId, SymbolFlags, SymbolTableBuilder,
+    FileScopeId, FileSymbolId, Scope, ScopeKind, ScopedSymbolId, SymbolFlags, SymbolTableBuilder,
 };
-use crate::semantic_index::{NodeWithScopeId, SemanticIndex};
+use crate::semantic_index::{NodeWithScopeId, NodeWithScopeKey, SemanticIndex};
 
 pub(super) struct SemanticIndexBuilder<'a> {
     // Builder state
@@ -32,6 +29,7 @@ pub(super) struct SemanticIndexBuilder<'a> {
     ast_ids: IndexVec<FileScopeId, AstIdsBuilder>,
     expression_scopes: FxHashMap<NodeKey, FileScopeId>,
     scope_nodes: IndexVec<FileScopeId, NodeWithScopeId>,
+    node_scopes: FxHashMap<NodeWithScopeKey, FileScopeId>,
 }
 
 impl<'a> SemanticIndexBuilder<'a> {
@@ -45,12 +43,16 @@ impl<'a> SemanticIndexBuilder<'a> {
             symbol_tables: IndexVec::new(),
             ast_ids: IndexVec::new(),
             expression_scopes: FxHashMap::default(),
+            node_scopes: FxHashMap::default(),
             scope_nodes: IndexVec::new(),
         };
 
         builder.push_scope_with_parent(
-            NodeWithScopeId::Module,
-            &Name::new_static("<module>"),
+            NodeWithScope::new(
+                parsed.syntax(),
+                NodeWithScopeId::Module,
+                Name::new_static("<module>"),
+            ),
             None,
             None,
             None,
@@ -68,42 +70,44 @@ impl<'a> SemanticIndexBuilder<'a> {
 
     fn push_scope(
         &mut self,
-        node: NodeWithScopeId,
-        name: &Name,
+        node: NodeWithScope,
         defining_symbol: Option<FileSymbolId>,
         definition: Option<Definition>,
     ) {
         let parent = self.current_scope();
-        self.push_scope_with_parent(node, name, defining_symbol, definition, Some(parent));
+        self.push_scope_with_parent(node, defining_symbol, definition, Some(parent));
     }
 
     fn push_scope_with_parent(
         &mut self,
-        node: NodeWithScopeId,
-        name: &Name,
+        node: NodeWithScope,
         defining_symbol: Option<FileSymbolId>,
         definition: Option<Definition>,
         parent: Option<FileScopeId>,
     ) {
         let children_start = self.scopes.next_index() + 1;
+        let node_key = node.key();
+        let node_id = node.id();
+        let scope_kind = node.scope_kind();
 
         let scope = Scope {
-            name: name.clone(),
+            name: node.name,
             parent,
             defining_symbol,
             definition,
-            kind: node.scope_kind(),
+            kind: scope_kind,
             descendents: children_start..children_start,
         };
 
         let scope_id = self.scopes.push(scope);
         self.symbol_tables.push(SymbolTableBuilder::new());
         let ast_id_scope = self.ast_ids.push(AstIdsBuilder::new());
-        let scope_node_id = self.scope_nodes.push(node);
+        let scope_node_id = self.scope_nodes.push(node_id);
 
         debug_assert_eq!(ast_id_scope, scope_id);
         debug_assert_eq!(scope_id, scope_node_id);
         self.scope_stack.push(scope_id);
+        self.node_scopes.insert(node_key, scope_id);
     }
 
     fn pop_scope(&mut self) -> FileScopeId {
@@ -124,10 +128,18 @@ impl<'a> SemanticIndexBuilder<'a> {
         &mut self.ast_ids[scope_id]
     }
 
-    fn add_or_update_symbol(&mut self, name: Name, flags: SymbolFlags) -> ScopedSymbolId {
-        let symbol_table = self.current_symbol_table();
+    fn add_or_update_symbol(&mut self, name: Name, flags: SymbolFlags) -> FileSymbolId {
+        for scope in self.scope_stack.iter().rev().skip(1) {
+            let builder = &self.symbol_tables[*scope];
 
-        symbol_table.add_or_update_symbol(name, flags, None)
+            if let Some(symbol) = builder.symbol_by_name(&name) {
+                return FileSymbolId::new(*scope, symbol);
+            }
+        }
+
+        let scope = self.current_scope();
+        let symbol_table = self.current_symbol_table();
+        FileSymbolId::new(scope, symbol_table.add_or_update_symbol(name, flags, None))
     }
 
     fn add_or_update_symbol_with_definition(
@@ -142,7 +154,7 @@ impl<'a> SemanticIndexBuilder<'a> {
 
     fn with_type_params(
         &mut self,
-        name: &Name,
+        name: Name,
         with_params: &WithTypeParams,
         defining_symbol: FileSymbolId,
         nested: impl FnOnce(&mut Self) -> FileScopeId,
@@ -150,14 +162,13 @@ impl<'a> SemanticIndexBuilder<'a> {
         let type_params = with_params.type_parameters();
 
         if let Some(type_params) = type_params {
-            let type_node = match with_params {
+            let type_params_id = match with_params {
                 WithTypeParams::ClassDef { id, .. } => NodeWithScopeId::ClassTypeParams(*id),
                 WithTypeParams::FunctionDef { id, .. } => NodeWithScopeId::FunctionTypeParams(*id),
             };
 
             self.push_scope(
-                type_node,
-                name,
+                NodeWithScope::new(type_params, type_params_id, name),
                 Some(defining_symbol),
                 Some(with_params.definition()),
             );
@@ -211,9 +222,10 @@ impl<'a> SemanticIndexBuilder<'a> {
         SemanticIndex {
             symbol_tables,
             scopes: self.scopes,
-            scope_nodes: self.scope_nodes,
+            nodes_by_scope: self.scope_nodes,
+            scopes_by_node: self.node_scopes,
             ast_ids,
-            expression_scopes: self.expression_scopes,
+            scopes_by_expression: self.expression_scopes,
         }
     }
 }
@@ -233,7 +245,7 @@ impl Visitor<'_> for SemanticIndexBuilder<'_> {
                     self.visit_decorator(decorator);
                 }
                 let name = &function_def.name.id;
-                let function_id = ScopeFunctionId(statement_id);
+                let function_id = ScopedFunctionId(statement_id);
                 let definition = Definition::FunctionDef(function_id);
                 let scope = self.current_scope();
                 let symbol = FileSymbolId::new(
@@ -242,7 +254,7 @@ impl Visitor<'_> for SemanticIndexBuilder<'_> {
                 );
 
                 self.with_type_params(
-                    name,
+                    name.clone(),
                     &WithTypeParams::FunctionDef {
                         node: function_def,
                         id: AstId::new(scope, function_id),
@@ -255,8 +267,11 @@ impl Visitor<'_> for SemanticIndexBuilder<'_> {
                         }
 
                         builder.push_scope(
-                            NodeWithScopeId::Function(AstId::new(scope, function_id)),
-                            name,
+                            NodeWithScope::new(
+                                function_def,
+                                NodeWithScopeId::Function(AstId::new(scope, function_id)),
+                                name.clone(),
+                            ),
                             Some(symbol),
                             Some(definition),
                         );
@@ -271,15 +286,15 @@ impl Visitor<'_> for SemanticIndexBuilder<'_> {
                 }
 
                 let name = &class.name.id;
-                let class_id = ScopeClassId(statement_id);
-                let definition = Definition::from(class_id);
+                let class_id = ScopedClassId(statement_id);
+                let definition = Definition::ClassDef(class_id);
                 let scope = self.current_scope();
                 let id = FileSymbolId::new(
                     self.current_scope(),
                     self.add_or_update_symbol_with_definition(name.clone(), definition),
                 );
                 self.with_type_params(
-                    name,
+                    name.clone(),
                     &WithTypeParams::ClassDef {
                         node: class,
                         id: AstId::new(scope, class_id),
@@ -291,8 +306,11 @@ impl Visitor<'_> for SemanticIndexBuilder<'_> {
                         }
 
                         builder.push_scope(
-                            NodeWithScopeId::Class(AstId::new(scope, class_id)),
-                            name,
+                            NodeWithScope::new(
+                                class,
+                                NodeWithScopeId::Class(AstId::new(scope, class_id)),
+                                name.clone(),
+                            ),
                             Some(id),
                             Some(definition),
                         );
@@ -311,7 +329,7 @@ impl Visitor<'_> for SemanticIndexBuilder<'_> {
                     };
 
                     let def = Definition::Import(ImportDefinition {
-                        import_id: ScopeImportId(statement_id),
+                        import_id: statement_id,
                         alias: u32::try_from(i).unwrap(),
                     });
                     self.add_or_update_symbol_with_definition(symbol_name, def);
@@ -330,7 +348,7 @@ impl Visitor<'_> for SemanticIndexBuilder<'_> {
                         &alias.name.id
                     };
                     let def = Definition::ImportFrom(ImportFromDefinition {
-                        import_id: ScopeImportFromId(statement_id),
+                        import_id: statement_id,
                         name: u32::try_from(i).unwrap(),
                     });
                     self.add_or_update_symbol_with_definition(symbol_name.clone(), def);
@@ -339,8 +357,7 @@ impl Visitor<'_> for SemanticIndexBuilder<'_> {
             ast::Stmt::Assign(node) => {
                 debug_assert!(self.current_definition.is_none());
                 self.visit_expr(&node.value);
-                self.current_definition =
-                    Some(Definition::Assignment(ScopeAssignmentId(statement_id)));
+                self.current_definition = Some(Definition::Assignment(statement_id));
                 for target in &node.targets {
                     self.visit_expr(target);
                 }
@@ -385,8 +402,7 @@ impl Visitor<'_> for SemanticIndexBuilder<'_> {
             }
             ast::Expr::Named(node) => {
                 debug_assert!(self.current_definition.is_none());
-                self.current_definition =
-                    Some(Definition::NamedExpr(ScopeNamedExprId(expression_id)));
+                self.current_definition = Some(Definition::NamedExpr(expression_id));
                 // TODO walrus in comprehensions is implicitly nonlocal
                 self.visit_expr(&node.target);
                 self.current_definition = None;
@@ -428,11 +444,11 @@ impl Visitor<'_> for SemanticIndexBuilder<'_> {
 enum WithTypeParams<'a> {
     ClassDef {
         node: &'a ast::StmtClassDef,
-        id: AstId<ScopeClassId>,
+        id: AstId<ScopedClassId>,
     },
     FunctionDef {
         node: &'a ast::StmtFunctionDef,
-        id: AstId<ScopeFunctionId>,
+        id: AstId<ScopedFunctionId>,
     },
 }
 
@@ -448,6 +464,41 @@ impl<'a> WithTypeParams<'a> {
         match self {
             WithTypeParams::ClassDef { id, .. } => Definition::ClassDef(id.in_scope_id()),
             WithTypeParams::FunctionDef { id, .. } => Definition::FunctionDef(id.in_scope_id()),
+        }
+    }
+}
+
+struct NodeWithScope {
+    id: NodeWithScopeId,
+    key: NodeWithScopeKey,
+    name: Name,
+}
+
+impl NodeWithScope {
+    fn new(node: impl Into<NodeWithScopeKey>, id: NodeWithScopeId, name: Name) -> Self {
+        Self {
+            id,
+            key: node.into(),
+            name,
+        }
+    }
+
+    fn id(&self) -> NodeWithScopeId {
+        self.id
+    }
+
+    fn key(&self) -> NodeWithScopeKey {
+        self.key
+    }
+
+    fn scope_kind(&self) -> ScopeKind {
+        match self.id {
+            NodeWithScopeId::Module => ScopeKind::Module,
+            NodeWithScopeId::Class(_) => ScopeKind::Class,
+            NodeWithScopeId::Function(_) => ScopeKind::Function,
+            NodeWithScopeId::ClassTypeParams(_) | NodeWithScopeId::FunctionTypeParams(_) => {
+                ScopeKind::Annotation
+            }
         }
     }
 }

--- a/crates/red_knot_python_semantic/src/semantic_index/definition.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/definition.rs
@@ -1,17 +1,16 @@
 use crate::semantic_index::ast_ids::{
-    ScopeAnnotatedAssignmentId, ScopeAssignmentId, ScopeClassId, ScopeFunctionId,
-    ScopeImportFromId, ScopeImportId, ScopeNamedExprId,
+    ScopedClassId, ScopedExpressionId, ScopedFunctionId, ScopedStatementId,
 };
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum Definition {
     Import(ImportDefinition),
     ImportFrom(ImportFromDefinition),
-    ClassDef(ScopeClassId),
-    FunctionDef(ScopeFunctionId),
-    Assignment(ScopeAssignmentId),
-    AnnotatedAssignment(ScopeAnnotatedAssignmentId),
-    NamedExpr(ScopeNamedExprId),
+    ClassDef(ScopedClassId),
+    FunctionDef(ScopedFunctionId),
+    Assignment(ScopedStatementId),
+    AnnotatedAssignment(ScopedStatementId),
+    NamedExpr(ScopedExpressionId),
     /// represents the implicit initial definition of every name as "unbound"
     Unbound,
     // TODO with statements, except handlers, function args...
@@ -29,39 +28,21 @@ impl From<ImportFromDefinition> for Definition {
     }
 }
 
-impl From<ScopeClassId> for Definition {
-    fn from(value: ScopeClassId) -> Self {
+impl From<ScopedClassId> for Definition {
+    fn from(value: ScopedClassId) -> Self {
         Self::ClassDef(value)
     }
 }
 
-impl From<ScopeFunctionId> for Definition {
-    fn from(value: ScopeFunctionId) -> Self {
+impl From<ScopedFunctionId> for Definition {
+    fn from(value: ScopedFunctionId) -> Self {
         Self::FunctionDef(value)
-    }
-}
-
-impl From<ScopeAssignmentId> for Definition {
-    fn from(value: ScopeAssignmentId) -> Self {
-        Self::Assignment(value)
-    }
-}
-
-impl From<ScopeAnnotatedAssignmentId> for Definition {
-    fn from(value: ScopeAnnotatedAssignmentId) -> Self {
-        Self::AnnotatedAssignment(value)
-    }
-}
-
-impl From<ScopeNamedExprId> for Definition {
-    fn from(value: ScopeNamedExprId) -> Self {
-        Self::NamedExpr(value)
     }
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub struct ImportDefinition {
-    pub(crate) import_id: ScopeImportId,
+    pub(crate) import_id: ScopedStatementId,
 
     /// Index into [`ruff_python_ast::StmtImport::names`].
     pub(crate) alias: u32,
@@ -69,7 +50,7 @@ pub struct ImportDefinition {
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub struct ImportFromDefinition {
-    pub(crate) import_id: ScopeImportFromId,
+    pub(crate) import_id: ScopedStatementId,
 
     /// Index into [`ruff_python_ast::StmtImportFrom::names`].
     pub(crate) name: u32,

--- a/crates/red_knot_python_semantic/src/semantic_index/symbol.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/symbol.rs
@@ -4,7 +4,6 @@ use std::ops::Range;
 use bitflags::bitflags;
 use hashbrown::hash_map::RawEntryMut;
 use rustc_hash::FxHasher;
-use salsa::DebugWithDb;
 use smallvec::SmallVec;
 
 use crate::semantic_index::definition::Definition;
@@ -128,7 +127,7 @@ impl ScopedSymbolId {
 /// Returns a mapping from [`FileScopeId`] to globally unique [`ScopeId`].
 #[salsa::tracked(return_ref)]
 pub(crate) fn scopes_map(db: &dyn Db, file: VfsFile) -> ScopesMap<'_> {
-    let _ = tracing::trace_span!("scopes_map", file = ?file.debug(db.upcast())).enter();
+    let _span = tracing::trace_span!("scopes_map", ?file).entered();
 
     let index = semantic_index(db, file);
 
@@ -160,7 +159,7 @@ impl<'db> ScopesMap<'db> {
 
 #[salsa::tracked(return_ref)]
 pub(crate) fn public_symbols_map(db: &dyn Db, file: VfsFile) -> PublicSymbolsMap<'_> {
-    let _ = tracing::trace_span!("public_symbols_map", file = ?file.debug(db.upcast())).enter();
+    let _span = tracing::trace_span!("public_symbols_map", ?file).entered();
 
     let module_scope = root_scope(db, file);
     let symbols = symbol_table(db, module_scope);
@@ -369,6 +368,10 @@ impl SymbolTableBuilder {
                 id
             }
         }
+    }
+
+    pub(super) fn symbol_by_name(&self, name: &str) -> Option<ScopedSymbolId> {
+        self.table.symbol_id_by_name(name)
     }
 
     pub(super) fn finish(mut self) -> SymbolTable {

--- a/crates/red_knot_python_semantic/src/semantic_model.rs
+++ b/crates/red_knot_python_semantic/src/semantic_model.rs
@@ -1,0 +1,183 @@
+use red_knot_module_resolver::{resolve_module, Module, ModuleName};
+use ruff_db::vfs::VfsFile;
+use ruff_python_ast as ast;
+use ruff_python_ast::{Expr, ExpressionRef, StmtClassDef};
+
+use crate::semantic_index::ast_ids::HasScopedAstId;
+use crate::semantic_index::definition::Definition;
+use crate::semantic_index::symbol::{PublicSymbolId, ScopeKind};
+use crate::semantic_index::{public_symbol, semantic_index, NodeWithScopeKey};
+use crate::types::{infer_types, public_symbol_ty, Type, TypingContext};
+use crate::Db;
+
+pub struct SemanticModel<'db> {
+    db: &'db dyn Db,
+    file: VfsFile,
+}
+
+impl<'db> SemanticModel<'db> {
+    pub fn new(db: &'db dyn Db, file: VfsFile) -> Self {
+        Self { db, file }
+    }
+
+    pub fn resolve_module(&self, module_name: ModuleName) -> Option<Module> {
+        resolve_module(self.db.upcast(), module_name)
+    }
+
+    pub fn public_symbol(&self, module: &Module, symbol_name: &str) -> Option<PublicSymbolId<'db>> {
+        public_symbol(self.db, module.file(), symbol_name)
+    }
+
+    pub fn public_symbol_ty(&self, symbol: PublicSymbolId<'db>) -> Type<'db> {
+        public_symbol_ty(self.db, symbol)
+    }
+
+    pub fn typing_context(&self) -> TypingContext<'db, '_> {
+        TypingContext::global(self.db)
+    }
+}
+
+pub trait HasTy {
+    fn ty<'db>(&self, model: &SemanticModel<'db>) -> Type<'db>;
+}
+
+impl HasTy for ast::ExpressionRef<'_> {
+    fn ty<'db>(&self, model: &SemanticModel<'db>) -> Type<'db> {
+        let index = semantic_index(model.db, model.file);
+        let file_scope = index.expression_scope_id(*self);
+        let expression_id = self.scoped_ast_id(model.db, model.file, file_scope);
+
+        let scope = file_scope.to_scope_id(model.db, model.file);
+        infer_types(model.db, scope).expression_ty(expression_id)
+    }
+}
+
+macro_rules! impl_expression_has_ty {
+    ($ty: ty) => {
+        impl HasTy for $ty {
+            #[inline]
+            fn ty<'db>(&self, model: &SemanticModel<'db>) -> Type<'db> {
+                let expression_ref = ExpressionRef::from(self);
+                expression_ref.ty(model)
+            }
+        }
+    };
+}
+
+impl_expression_has_ty!(ast::ExprBoolOp);
+impl_expression_has_ty!(ast::ExprNamed);
+impl_expression_has_ty!(ast::ExprBinOp);
+impl_expression_has_ty!(ast::ExprUnaryOp);
+impl_expression_has_ty!(ast::ExprLambda);
+impl_expression_has_ty!(ast::ExprIf);
+impl_expression_has_ty!(ast::ExprDict);
+impl_expression_has_ty!(ast::ExprSet);
+impl_expression_has_ty!(ast::ExprListComp);
+impl_expression_has_ty!(ast::ExprSetComp);
+impl_expression_has_ty!(ast::ExprDictComp);
+impl_expression_has_ty!(ast::ExprGenerator);
+impl_expression_has_ty!(ast::ExprAwait);
+impl_expression_has_ty!(ast::ExprYield);
+impl_expression_has_ty!(ast::ExprYieldFrom);
+impl_expression_has_ty!(ast::ExprCompare);
+impl_expression_has_ty!(ast::ExprCall);
+impl_expression_has_ty!(ast::ExprFString);
+impl_expression_has_ty!(ast::ExprStringLiteral);
+impl_expression_has_ty!(ast::ExprBytesLiteral);
+impl_expression_has_ty!(ast::ExprNumberLiteral);
+impl_expression_has_ty!(ast::ExprBooleanLiteral);
+impl_expression_has_ty!(ast::ExprNoneLiteral);
+impl_expression_has_ty!(ast::ExprEllipsisLiteral);
+impl_expression_has_ty!(ast::ExprAttribute);
+impl_expression_has_ty!(ast::ExprSubscript);
+impl_expression_has_ty!(ast::ExprStarred);
+impl_expression_has_ty!(ast::ExprName);
+impl_expression_has_ty!(ast::ExprList);
+impl_expression_has_ty!(ast::ExprTuple);
+impl_expression_has_ty!(ast::ExprSlice);
+impl_expression_has_ty!(ast::ExprIpyEscapeCommand);
+
+impl HasTy for ast::Expr {
+    fn ty<'db>(&self, model: &SemanticModel<'db>) -> Type<'db> {
+        match self {
+            Expr::BoolOp(inner) => inner.ty(model),
+            Expr::Named(inner) => inner.ty(model),
+            Expr::BinOp(inner) => inner.ty(model),
+            Expr::UnaryOp(inner) => inner.ty(model),
+            Expr::Lambda(inner) => inner.ty(model),
+            Expr::If(inner) => inner.ty(model),
+            Expr::Dict(inner) => inner.ty(model),
+            Expr::Set(inner) => inner.ty(model),
+            Expr::ListComp(inner) => inner.ty(model),
+            Expr::SetComp(inner) => inner.ty(model),
+            Expr::DictComp(inner) => inner.ty(model),
+            Expr::Generator(inner) => inner.ty(model),
+            Expr::Await(inner) => inner.ty(model),
+            Expr::Yield(inner) => inner.ty(model),
+            Expr::YieldFrom(inner) => inner.ty(model),
+            Expr::Compare(inner) => inner.ty(model),
+            Expr::Call(inner) => inner.ty(model),
+            Expr::FString(inner) => inner.ty(model),
+            Expr::StringLiteral(inner) => inner.ty(model),
+            Expr::BytesLiteral(inner) => inner.ty(model),
+            Expr::NumberLiteral(inner) => inner.ty(model),
+            Expr::BooleanLiteral(inner) => inner.ty(model),
+            Expr::NoneLiteral(inner) => inner.ty(model),
+            Expr::EllipsisLiteral(inner) => inner.ty(model),
+            Expr::Attribute(inner) => inner.ty(model),
+            Expr::Subscript(inner) => inner.ty(model),
+            Expr::Starred(inner) => inner.ty(model),
+            Expr::Name(inner) => inner.ty(model),
+            Expr::List(inner) => inner.ty(model),
+            Expr::Tuple(inner) => inner.ty(model),
+            Expr::Slice(inner) => inner.ty(model),
+            Expr::IpyEscapeCommand(inner) => inner.ty(model),
+        }
+    }
+}
+
+impl HasTy for ast::StmtFunctionDef {
+    fn ty<'db>(&self, model: &SemanticModel<'db>) -> Type<'db> {
+        let index = semantic_index(model.db, model.file);
+        let definition_scope = index.definition_scope(NodeWithScopeKey::from(self));
+
+        // SAFETY: A function always has either an enclosing module, function or class scope.
+        let mut parent_scope_id = index.parent_scope_id(definition_scope).unwrap();
+        let parent_scope = index.scope(parent_scope_id);
+
+        if parent_scope.kind() == ScopeKind::Annotation {
+            parent_scope_id = index.parent_scope_id(parent_scope_id).unwrap();
+        }
+
+        let scope = parent_scope_id.to_scope_id(model.db, model.file);
+
+        let types = infer_types(model.db, scope);
+        let definition =
+            Definition::FunctionDef(self.scoped_ast_id(model.db, model.file, parent_scope_id));
+
+        types.definition_ty(definition)
+    }
+}
+
+impl HasTy for StmtClassDef {
+    fn ty<'db>(&self, model: &SemanticModel<'db>) -> Type<'db> {
+        let index = semantic_index(model.db, model.file);
+        let definition_scope = index.definition_scope(NodeWithScopeKey::from(self));
+
+        // SAFETY: A class always has either an enclosing module, function or class scope.
+        let mut parent_scope_id = index.parent_scope_id(definition_scope).unwrap();
+        let parent_scope = index.scope(parent_scope_id);
+
+        if parent_scope.kind() == ScopeKind::Annotation {
+            parent_scope_id = index.parent_scope_id(parent_scope_id).unwrap();
+        }
+
+        let scope = parent_scope_id.to_scope_id(model.db, model.file);
+
+        let types = infer_types(model.db, scope);
+        let definition =
+            Definition::ClassDef(self.scoped_ast_id(model.db, model.file, parent_scope_id));
+
+        types.definition_ty(definition)
+    }
+}

--- a/crates/ruff_db/src/parsed.rs
+++ b/crates/ruff_db/src/parsed.rs
@@ -1,4 +1,3 @@
-use salsa::DebugWithDb;
 use std::fmt::Formatter;
 use std::ops::Deref;
 use std::sync::Arc;
@@ -23,7 +22,7 @@ use crate::Db;
 /// for determining if a query result is unchanged.
 #[salsa::tracked(return_ref, no_eq)]
 pub fn parsed_module(db: &dyn Db, file: VfsFile) -> ParsedModule {
-    let _ = tracing::trace_span!("parse_module", file = ?file.debug(db)).enter();
+    let _span = tracing::trace_span!("parse_module", file = ?file).entered();
 
     let source = source_text(db, file);
     let path = file.path(db);

--- a/crates/ruff_db/src/source.rs
+++ b/crates/ruff_db/src/source.rs
@@ -10,7 +10,7 @@ use crate::Db;
 /// Reads the content of file.
 #[salsa::tracked]
 pub fn source_text(db: &dyn Db, file: VfsFile) -> SourceText {
-    let _ = tracing::trace_span!("source_text", file = ?file.debug(db)).enter();
+    let _span = tracing::trace_span!("source_text", ?file).entered();
 
     let content = file.read(db);
 
@@ -22,7 +22,7 @@ pub fn source_text(db: &dyn Db, file: VfsFile) -> SourceText {
 /// Computes the [`LineIndex`] for `file`.
 #[salsa::tracked]
 pub fn line_index(db: &dyn Db, file: VfsFile) -> LineIndex {
-    let _ = tracing::trace_span!("line_index", file = ?file.debug(db)).enter();
+    let _span = tracing::trace_span!("line_index", file = ?file.debug(db)).entered();
 
     let source = source_text(db, file);
 


### PR DESCRIPTION
## Summary

This PR introduces a new `HasTy` trait that AST nodes implement that support looking up their type. 

It also introduces a `SemanticModel` facade that acts as the public interface of the semantic analysis. 

I think the API could be better. It's a bit awkward that you need to construct a `typing_context` and pass that to type operations. I think we need to spend some more time on fully designing the API that we want to provide to lint rules.

## Other changes

I changed the symbol table builder to not introduce new symbols for reads, if a parent scope defines a symbol with that name. There's probably a better and more correct way of implementing this but I needed a fix or using `typing.override` as a decorator would always resolve to `Unbound`. 

## Follow-up work

* Implement `HasTy` for `Alias` 
* Merge `HasTy` with a `SemanticNode` trait that also gives access to the node's symbol (only `Some` for `ExprName` and `Alias`), or a node's scope. I decided not to implement this as part of this PR because it wasn't exactly clear to me what `scope` would return. Is it the enclosing scope or the scope that the node defines? 

## Test plan

I updated the `lint_bad_override` rule to use the new API. It's not optimized for performance. For example, we look up the `typing.override` type for every class definition. 

```rust
fn lint_bad_override(context: &SemanticLintContext, class: &ast::StmtClassDef) {
    let semantic = &context.semantic;
    let typing_context = semantic.typing_context();

    // TODO we should have a special marker on the real typing module (from typeshed) so if you
    //   have your own "typing" module in your project, we don't consider it THE typing module (and
    //   same for other stdlib modules that our lint rules care about)
    let Some(typing) = semantic.resolve_module(ModuleName::new("typing").unwrap()) else {
        return;
    };

    let Some(typing_override) = semantic.public_symbol(typing, "override") else {
        return;
    };

    let override_ty = semantic.public_symbol_ty(typing_override);

    let class_ty = class.ty(semantic);

    for function in class
        .body
        .iter()
        .filter_map(|stmt| stmt.as_function_def_stmt())
    {
        let Type::Function(ty) = function.ty(semantic) else {
            return;
        };

        if ty.has_decorator(&typing_context, override_ty) {
            let method_name = ty.name(&typing_context);
            if class_ty
                .inherited_class_member(&typing_context, method_name)
                .is_none()
            {
                // TODO should have a qualname() method to support nested classes
                context.push_diagnostic(
                    format!(
                        "Method {}.{} is decorated with `typing.override` but does not override any base class method",
                        class_ty.name(&typing_context),
                        method_name,
                    ));
            }
        }
    }
}
```

