### PR TITLE
[red-knot] Move module-resolution logic to its own crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1978,7 +1978,7 @@ dependencies = [
  "notify",
  "parking_lot",
  "rayon",
- "red_knot_python_semantic",
+ "red_knot_module_resolver",
  "ruff_index",
  "ruff_notebook",
  "ruff_python_ast",
@@ -1996,6 +1996,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "red_knot_module_resolver"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "ruff_db",
+ "ruff_python_stdlib",
+ "salsa",
+ "smol_str",
+ "tempfile",
+ "tracing",
+]
+
+[[package]]
 name = "red_knot_python_semantic"
 version = "0.0.0"
 dependencies = [
@@ -2003,17 +2016,16 @@ dependencies = [
  "bitflags 2.5.0",
  "hashbrown 0.14.5",
  "indexmap",
+ "red_knot_module_resolver",
  "ruff_db",
  "ruff_index",
  "ruff_python_ast",
  "ruff_python_parser",
- "ruff_python_stdlib",
  "ruff_text_size",
  "rustc-hash",
  "salsa",
  "smallvec",
  "smol_str",
- "tempfile",
  "tracing",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ ruff_source_file = { path = "crates/ruff_source_file" }
 ruff_text_size = { path = "crates/ruff_text_size" }
 ruff_workspace = { path = "crates/ruff_workspace" }
 
-red_knot_python_semantic = { path = "crates/red_knot_python_semantic" }
+red_knot_module_resolver = { path = "crates/red_knot_module_resolver" }
 
 aho-corasick = { version = "1.1.3" }
 annotate-snippets = { version = "0.9.2", features = ["color"] }

--- a/crates/red_knot/Cargo.toml
+++ b/crates/red_knot/Cargo.toml
@@ -12,7 +12,7 @@ license.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-red_knot_python_semantic = { workspace = true }
+red_knot_module_resolver = { workspace = true }
 
 ruff_python_parser = { workspace = true }
 ruff_python_ast = { workspace = true }

--- a/crates/red_knot/src/module.rs
+++ b/crates/red_knot/src/module.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use dashmap::mapref::entry::Entry;
 use smol_str::SmolStr;
 
-use red_knot_python_semantic::module::ModuleKind;
+use red_knot_module_resolver::ModuleKind;
 
 use crate::db::{QueryResult, SemanticDb, SemanticJar};
 use crate::files::FileId;

--- a/crates/red_knot_module_resolver/Cargo.toml
+++ b/crates/red_knot_module_resolver/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "red_knot_python_semantic"
+name = "red_knot_module_resolver"
 version = "0.0.0"
 publish = false
 authors = { workspace = true }
@@ -11,25 +11,16 @@ repository = { workspace = true }
 license = { workspace = true }
 
 [dependencies]
-red_knot_module_resolver = { workspace = true }
 ruff_db = { workspace = true }
-ruff_index = { workspace = true }
-ruff_python_ast = { workspace = true }
-ruff_text_size = { workspace = true }
+ruff_python_stdlib = { workspace = true }
 
-bitflags = { workspace = true }
-indexmap = { workspace = true }
 salsa = { workspace = true }
-smallvec = { workspace = true }
 smol_str = { workspace = true }
 tracing = { workspace = true }
-rustc-hash = { workspace = true }
-hashbrown = { workspace = true }
 
 [dev-dependencies]
 anyhow = { workspace = true }
-ruff_python_parser = { workspace = true }
+tempfile = { workspace = true }
 
 [lints]
 workspace = true
-

--- a/crates/red_knot_module_resolver/src/db.rs
+++ b/crates/red_knot_module_resolver/src/db.rs
@@ -1,0 +1,156 @@
+use ruff_db::Upcast;
+
+use crate::resolver::{
+    file_to_module,
+    internal::{ModuleNameIngredient, ModuleResolverSearchPaths},
+    resolve_module_query,
+};
+
+#[salsa::jar(db=Db)]
+pub struct Jar(
+    ModuleNameIngredient<'_>,
+    ModuleResolverSearchPaths,
+    resolve_module_query,
+    file_to_module,
+);
+
+pub trait Db: salsa::DbWithJar<Jar> + ruff_db::Db + Upcast<dyn ruff_db::Db> {}
+
+pub(crate) mod tests {
+    use std::sync;
+
+    use salsa::DebugWithDb;
+
+    use ruff_db::file_system::{FileSystem, MemoryFileSystem, OsFileSystem};
+    use ruff_db::vfs::Vfs;
+
+    use super::*;
+
+    #[salsa::db(Jar, ruff_db::Jar)]
+    pub(crate) struct TestDb {
+        storage: salsa::Storage<Self>,
+        file_system: TestFileSystem,
+        events: sync::Arc<sync::Mutex<Vec<salsa::Event>>>,
+        vfs: Vfs,
+    }
+
+    impl TestDb {
+        #[allow(unused)]
+        pub(crate) fn new() -> Self {
+            Self {
+                storage: salsa::Storage::default(),
+                file_system: TestFileSystem::Memory(MemoryFileSystem::default()),
+                events: sync::Arc::default(),
+                vfs: Vfs::with_stubbed_vendored(),
+            }
+        }
+
+        /// Returns the memory file system.
+        ///
+        /// ## Panics
+        /// If this test db isn't using a memory file system.
+        #[allow(unused)]
+        pub(crate) fn memory_file_system(&self) -> &MemoryFileSystem {
+            if let TestFileSystem::Memory(fs) = &self.file_system {
+                fs
+            } else {
+                panic!("The test db is not using a memory file system");
+            }
+        }
+
+        /// Uses the real file system instead of the memory file system.
+        ///
+        /// This useful for testing advanced file system features like permissions, symlinks, etc.
+        ///
+        /// Note that any files written to the memory file system won't be copied over.
+        #[allow(unused)]
+        pub(crate) fn with_os_file_system(&mut self) {
+            self.file_system = TestFileSystem::Os(OsFileSystem);
+        }
+
+        #[allow(unused)]
+        pub(crate) fn vfs_mut(&mut self) -> &mut Vfs {
+            &mut self.vfs
+        }
+
+        /// Takes the salsa events.
+        ///
+        /// ## Panics
+        /// If there are any pending salsa snapshots.
+        #[allow(unused)]
+        pub(crate) fn take_salsa_events(&mut self) -> Vec<salsa::Event> {
+            let inner = sync::Arc::get_mut(&mut self.events).expect("no pending salsa snapshots");
+
+            let events = inner.get_mut().unwrap();
+            std::mem::take(&mut *events)
+        }
+
+        /// Clears the salsa events.
+        ///
+        /// ## Panics
+        /// If there are any pending salsa snapshots.
+        #[allow(unused)]
+        pub(crate) fn clear_salsa_events(&mut self) {
+            self.take_salsa_events();
+        }
+    }
+
+    impl Upcast<dyn ruff_db::Db> for TestDb {
+        fn upcast(&self) -> &(dyn ruff_db::Db + 'static) {
+            self
+        }
+    }
+
+    impl ruff_db::Db for TestDb {
+        fn file_system(&self) -> &dyn ruff_db::file_system::FileSystem {
+            self.file_system.inner()
+        }
+
+        fn vfs(&self) -> &ruff_db::vfs::Vfs {
+            &self.vfs
+        }
+    }
+
+    impl Db for TestDb {}
+
+    impl salsa::Database for TestDb {
+        fn salsa_event(&self, event: salsa::Event) {
+            tracing::trace!("event: {:?}", event.debug(self));
+            let mut events = self.events.lock().unwrap();
+            events.push(event);
+        }
+    }
+
+    impl salsa::ParallelDatabase for TestDb {
+        fn snapshot(&self) -> salsa::Snapshot<Self> {
+            salsa::Snapshot::new(Self {
+                storage: self.storage.snapshot(),
+                file_system: self.file_system.snapshot(),
+                events: self.events.clone(),
+                vfs: self.vfs.snapshot(),
+            })
+        }
+    }
+
+    enum TestFileSystem {
+        Memory(MemoryFileSystem),
+        #[allow(unused)]
+        Os(OsFileSystem),
+    }
+
+    impl TestFileSystem {
+        fn inner(&self) -> &dyn FileSystem {
+            match self {
+                Self::Memory(inner) => inner,
+                Self::Os(inner) => inner,
+            }
+        }
+
+        fn snapshot(&self) -> Self {
+            match self {
+                Self::Memory(inner) => Self::Memory(inner.snapshot()),
+                Self::Os(inner) => Self::Os(inner.snapshot()),
+            }
+        }
+    }
+}

--- a/crates/red_knot_module_resolver/src/lib.rs
+++ b/crates/red_knot_module_resolver/src/lib.rs
@@ -1,0 +1,7 @@
+mod db;
+mod module;
+mod resolver;
+
+pub use db::{Db, Jar};
+pub use module::{ModuleKind, ModuleName};
+pub use resolver::{resolve_module, set_module_resolution_settings, ModuleResolutionSettings};

--- a/crates/red_knot_module_resolver/src/module.rs
+++ b/crates/red_knot_module_resolver/src/module.rs
@@ -8,8 +8,6 @@ use ruff_python_stdlib::identifiers::is_identifier;
 
 use crate::Db;
 
-pub mod resolver;
-
 /// A module name, e.g. `foo.bar`.
 ///
 /// Always normalized to the absolute form (never a relative module name, i.e., never `.foo`).
@@ -46,7 +44,7 @@ impl ModuleName {
     /// ## Examples
     ///
     /// ```
-    /// use red_knot_python_semantic::module::ModuleName;
+    /// use red_knot_module_resolver::ModuleName;
     ///
     /// assert_eq!(ModuleName::new_static("foo.bar").as_deref(), Some("foo.bar"));
     /// assert_eq!(ModuleName::new_static(""), None);
@@ -78,7 +76,7 @@ impl ModuleName {
     /// # Examples
     ///
     /// ```
-    /// use red_knot_python_semantic::module::ModuleName;
+    /// use red_knot_module_resolver::ModuleName;
     ///
     /// assert_eq!(ModuleName::new_static("foo.bar.baz").unwrap().components().collect::<Vec<_>>(), vec!["foo", "bar", "baz"]);
     /// ```
@@ -91,7 +89,7 @@ impl ModuleName {
     /// # Examples
     ///
     /// ```
-    /// use red_knot_python_semantic::module::ModuleName;
+    /// use red_knot_module_resolver::ModuleName;
     ///
     /// assert_eq!(ModuleName::new_static("foo.bar").unwrap().parent(), Some(ModuleName::new_static("foo").unwrap()));
     /// assert_eq!(ModuleName::new_static("foo.bar.baz").unwrap().parent(), Some(ModuleName::new_static("foo.bar").unwrap()));
@@ -110,7 +108,7 @@ impl ModuleName {
     /// # Examples
     ///
     /// ```
-    /// use red_knot_python_semantic::module::ModuleName;
+    /// use red_knot_module_resolver::ModuleName;
     ///
     /// assert!(ModuleName::new_static("foo.bar").unwrap().starts_with(&ModuleName::new_static("foo").unwrap()));
     ///
@@ -135,7 +133,7 @@ impl ModuleName {
         &self.0
     }
 
-    fn from_relative_path(path: &FileSystemPath) -> Option<Self> {
+    pub(crate) fn from_relative_path(path: &FileSystemPath) -> Option<Self> {
         let path = if path.ends_with("__init__.py") || path.ends_with("__init__.pyi") {
             path.parent()?
         } else {
@@ -196,6 +194,22 @@ pub struct Module {
 }
 
 impl Module {
+    pub(crate) fn new(
+        name: ModuleName,
+        kind: ModuleKind,
+        search_path: ModuleSearchPath,
+        file: VfsFile,
+    ) -> Self {
+        Self {
+            inner: Arc::new(ModuleInner {
+                name,
+                kind,
+                search_path,
+                file,
+            }),
+        }
+    }
+
     /// The absolute name of the module (e.g. `foo.bar`)
     pub fn name(&self) -> &ModuleName {
         &self.inner.name

--- a/crates/red_knot_python_semantic/src/lib.rs
+++ b/crates/red_knot_python_semantic/src/lib.rs
@@ -1,6 +1,5 @@
 pub mod ast_node_ref;
 mod db;
-pub mod module;
 pub mod name;
 mod node_key;
 pub mod semantic_index;

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -513,9 +513,9 @@ mod tests {
     use crate::db::tests::{
         assert_will_not_run_function_query, assert_will_run_function_query, TestDb,
     };
-    use crate::module::resolver::{set_module_resolution_settings, ModuleResolutionSettings};
     use crate::semantic_index::root_scope;
     use crate::types::{expression_ty, infer_types, public_symbol_ty_by_name, TypingContext};
+    use red_knot_module_resolver::{set_module_resolution_settings, ModuleResolutionSettings};
 
     fn setup_db() -> TestDb {
         let mut db = TestDb::new();


### PR DESCRIPTION
## Summary

This PR moves module-resolution logic to its own crate. It attempts to make the minimal possible changes to do that, so that future PRs can build on top of it. As a result, there's a few things that this PR makes `pub` that probably shouldn't be `pub` in the long-term.

The PR... nearly compiles. I may need @MichaReiser's help for the remaining compile errors.