### PR TITLE
[red-knot] Move typeshed `VERSIONS` parser to the module resolver crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1973,7 +1973,6 @@ dependencies = [
  "dashmap",
  "hashbrown 0.14.5",
  "indexmap",
- "insta",
  "is-macro",
  "notify",
  "parking_lot",
@@ -1983,7 +1982,6 @@ dependencies = [
  "ruff_notebook",
  "ruff_python_ast",
  "ruff_python_parser",
- "ruff_python_stdlib",
  "ruff_text_size",
  "rustc-hash",
  "smol_str",
@@ -1998,8 +1996,10 @@ name = "red_knot_module_resolver"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "insta",
  "ruff_db",
  "ruff_python_stdlib",
+ "rustc-hash",
  "salsa",
  "smol_str",
  "tempfile",

--- a/crates/red_knot/Cargo.toml
+++ b/crates/red_knot/Cargo.toml
@@ -16,7 +16,6 @@ red_knot_module_resolver = { workspace = true }
 
 ruff_python_parser = { workspace = true }
 ruff_python_ast = { workspace = true }
-ruff_python_stdlib = { workspace = true }
 ruff_text_size = { workspace = true }
 ruff_index = { workspace = true }
 ruff_notebook = { workspace = true }
@@ -39,7 +38,6 @@ tracing-subscriber = { workspace = true }
 tracing-tree = { workspace = true }
 
 [dev-dependencies]
-insta = { workspace = true }
 tempfile = { workspace = true }
 
 [lints]

--- a/crates/red_knot/src/lib.rs
+++ b/crates/red_knot/src/lib.rs
@@ -19,7 +19,6 @@ mod parse;
 pub mod program;
 mod semantic;
 pub mod source;
-pub mod typeshed_versions;
 pub mod watch;
 
 pub(crate) type FxDashMap<K, V> = dashmap::DashMap<K, V, BuildHasherDefault<FxHasher>>;

--- a/crates/red_knot_module_resolver/Cargo.toml
+++ b/crates/red_knot_module_resolver/Cargo.toml
@@ -14,6 +14,7 @@ license = { workspace = true }
 ruff_db = { workspace = true }
 ruff_python_stdlib = { workspace = true }
 
+rustc-hash = { workspace = true }
 salsa = { workspace = true }
 smol_str = { workspace = true }
 tracing = { workspace = true }
@@ -25,6 +26,7 @@ zip = { workspace = true }
 
 [dev-dependencies]
 anyhow = { workspace = true }
+insta = { workspace = true }
 tempfile = { workspace = true }
 
 [lints]

--- a/crates/red_knot_module_resolver/src/lib.rs
+++ b/crates/red_knot_module_resolver/src/lib.rs
@@ -6,3 +6,4 @@ mod typeshed;
 pub use db::{Db, Jar};
 pub use module::{ModuleKind, ModuleName};
 pub use resolver::{resolve_module, set_module_resolution_settings, ModuleResolutionSettings};
+pub use typeshed::versions::TypeshedVersions;

--- a/crates/red_knot_module_resolver/src/typeshed.rs
+++ b/crates/red_knot_module_resolver/src/typeshed.rs
@@ -1,3 +1,5 @@
+pub(crate) mod versions;
+
 #[cfg(test)]
 mod tests {
     use std::io::{self, Read};

--- a/crates/red_knot_module_resolver/src/typeshed/versions.rs
+++ b/crates/red_knot_module_resolver/src/typeshed/versions.rs
@@ -320,30 +320,28 @@ mod tests {
     #[allow(unsafe_code)]
     const ONE: NonZeroU16 = unsafe { NonZeroU16::new_unchecked(1) };
 
-    // TODO(Alex): move VERSIONS parsing logic to red_knot_module_resolver, add this test back
-    //
-    // #[test]
-    // fn can_parse_vendored_versions_file() {
-    //     let versions_data = include_str!(concat!(
-    //         env!("CARGO_MANIFEST_DIR"),
-    //         "/vendor/typeshed/stdlib/VERSIONS"
-    //     ));
+    #[test]
+    fn can_parse_vendored_versions_file() {
+        let versions_data = include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/vendor/typeshed/stdlib/VERSIONS"
+        ));
 
-    //     let versions = TypeshedVersions::from_str(versions_data).unwrap();
-    //     assert!(versions.len() > 100);
-    //     assert!(versions.len() < 1000);
+        let versions = TypeshedVersions::from_str(versions_data).unwrap();
+        assert!(versions.len() > 100);
+        assert!(versions.len() < 1000);
 
-    //     assert!(versions.contains_module("asyncio"));
-    //     assert!(versions.module_exists_on_version("asyncio", SupportedPyVersion::Py310));
+        assert!(versions.contains_module("asyncio"));
+        assert!(versions.module_exists_on_version("asyncio", SupportedPyVersion::Py310));
 
-    //     assert!(versions.contains_module("asyncio.staggered"));
-    //     assert!(versions.module_exists_on_version("asyncio.staggered", SupportedPyVersion::Py38));
-    //     assert!(!versions.module_exists_on_version("asyncio.staggered", SupportedPyVersion::Py37));
+        assert!(versions.contains_module("asyncio.staggered"));
+        assert!(versions.module_exists_on_version("asyncio.staggered", SupportedPyVersion::Py38));
+        assert!(!versions.module_exists_on_version("asyncio.staggered", SupportedPyVersion::Py37));
 
-    //     assert!(versions.contains_module("audioop"));
-    //     assert!(versions.module_exists_on_version("audioop", SupportedPyVersion::Py312));
-    //     assert!(!versions.module_exists_on_version("audioop", SupportedPyVersion::Py313));
-    // }
+        assert!(versions.contains_module("audioop"));
+        assert!(versions.module_exists_on_version("audioop", SupportedPyVersion::Py312));
+        assert!(!versions.module_exists_on_version("audioop", SupportedPyVersion::Py313));
+    }
 
     #[test]
     fn can_parse_mock_versions_file() {


### PR DESCRIPTION
## Summary

This PR moves the `VERSIONS` parser from the `red_knot` crate to the `red_knot_module_resolver` crate, so that it can be used in the module resolver.