### PR TITLE
[red-knot] Add more tests asserting that the VendoredFileSystem and the `VERSIONS` parser work with the vendored typeshed stubs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1997,7 +1997,6 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "insta",
- "once_cell",
  "ruff_db",
  "ruff_python_stdlib",
  "rustc-hash",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1997,6 +1997,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "insta",
+ "path-slash",
  "ruff_db",
  "ruff_python_stdlib",
  "rustc-hash",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1997,6 +1997,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "insta",
+ "once_cell",
  "ruff_db",
  "ruff_python_stdlib",
  "rustc-hash",

--- a/crates/red_knot_module_resolver/Cargo.toml
+++ b/crates/red_knot_module_resolver/Cargo.toml
@@ -27,7 +27,6 @@ zip = { workspace = true }
 [dev-dependencies]
 anyhow = { workspace = true }
 insta = { workspace = true }
-once_cell = { workspace = true }
 tempfile = { workspace = true }
 walkdir = { workspace = true }
 

--- a/crates/red_knot_module_resolver/Cargo.toml
+++ b/crates/red_knot_module_resolver/Cargo.toml
@@ -27,7 +27,9 @@ zip = { workspace = true }
 [dev-dependencies]
 anyhow = { workspace = true }
 insta = { workspace = true }
+once_cell = { workspace = true }
 tempfile = { workspace = true }
+walkdir = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/red_knot_module_resolver/Cargo.toml
+++ b/crates/red_knot_module_resolver/Cargo.toml
@@ -27,6 +27,7 @@ zip = { workspace = true }
 [dev-dependencies]
 anyhow = { workspace = true }
 insta = { workspace = true }
+path-slash = { workspace = true }
 tempfile = { workspace = true }
 walkdir = { workspace = true }
 

--- a/crates/red_knot_module_resolver/src/typeshed.rs
+++ b/crates/red_knot_module_resolver/src/typeshed.rs
@@ -3,27 +3,15 @@ pub(crate) mod versions;
 #[cfg(test)]
 mod tests {
     use std::io::{self, Read};
-    use std::path::{Path, PathBuf};
-    use std::str::FromStr;
-
-    use once_cell::sync::Lazy;
+    use std::path::Path;
 
     use ruff_db::vendored::VendoredFileSystem;
     use ruff_db::vfs::VendoredPath;
-
-    use crate::module::ModuleName;
-
-    use super::versions::*;
-
-    const TYPESHED_STDLIB_DIR: &str = "stdlib";
 
     // The file path here is hardcoded in this crate's `build.rs` script.
     // Luckily this crate will fail to build if this file isn't available at build time.
     const TYPESHED_ZIP_BYTES: &[u8] =
         include_bytes!(concat!(env!("OUT_DIR"), "/zipped_typeshed.zip"));
-
-    static VENDORED_TYPESHED_DIR: Lazy<PathBuf> =
-        Lazy::new(|| Path::new("vendor/typeshed").canonicalize().unwrap());
 
     #[test]
     fn typeshed_zip_created_at_build_time() {
@@ -46,62 +34,49 @@ mod tests {
 
     #[test]
     fn typeshed_vfs_consistent_with_vendored_stubs() {
+        let vendored_typeshed_dir = Path::new("vendor/typeshed").canonicalize().unwrap();
         let vendored_typeshed_stubs = VendoredFileSystem::new(TYPESHED_ZIP_BYTES).unwrap();
 
         let mut empty_iterator = true;
-        for entry in walkdir::WalkDir::new(&*VENDORED_TYPESHED_DIR).min_depth(1) {
+        for entry in walkdir::WalkDir::new(&vendored_typeshed_dir).min_depth(1) {
             empty_iterator = false;
             let entry = entry.unwrap();
             let absolute_path = entry.path();
             let file_type = entry.file_type();
 
-            let relative_path = absolute_path.strip_prefix(&*VENDORED_TYPESHED_DIR).unwrap();
-            let vendored_path = VendoredPath::new(relative_path.to_str().unwrap());
+            let relative_path = absolute_path
+                .strip_prefix(&vendored_typeshed_dir)
+                .unwrap_or_else(|_| {
+                    panic!("Expected {absolute_path:?} to be a child of {vendored_typeshed_dir:?}")
+                });
 
-            assert!(vendored_typeshed_stubs.exists(vendored_path));
+            let vendored_path =
+                VendoredPath::new(relative_path.to_str().unwrap_or_else(|| {
+                    panic!("Expected {relative_path:?} to be a valid UTF-8 path")
+                }));
+
+            assert!(
+                vendored_typeshed_stubs.exists(vendored_path),
+                "Expected {vendored_path:?} to exist in the `VendoredFileSystem`!"
+            );
 
             let vendored_path_kind = vendored_typeshed_stubs
                 .metadata(vendored_path)
-                .unwrap()
+                .unwrap_or_else(|| {
+                    panic!("Expected metadata for {vendored_path:?} to be retrievable from the `VendoredFileSystem!")
+                })
                 .kind();
-            assert_eq!(vendored_path_kind.is_directory(), file_type.is_dir());
-        }
-        assert!(!empty_iterator);
-    }
 
-    #[test]
-    fn typeshed_versions_consistent_with_vendored_stubs() {
-        const VERSIONS_DATA: &str = include_str!("../vendor/typeshed/stdlib/VERSIONS");
-        let vendored_typeshed_versions = TypeshedVersions::from_str(VERSIONS_DATA).unwrap();
-
-        let mut empty_iterator = true;
-        for entry in std::fs::read_dir(VENDORED_TYPESHED_DIR.join(TYPESHED_STDLIB_DIR)).unwrap() {
-            empty_iterator = false;
-            let entry = entry.unwrap();
-            let absolute_path = entry.path();
-            let relative_path = absolute_path
-                .strip_prefix(&*VENDORED_TYPESHED_DIR)
-                .and_then(|path| path.strip_prefix(TYPESHED_STDLIB_DIR))
-                .unwrap();
-            if relative_path == Path::new("VERSIONS") {
-                continue;
-            }
-            let mut top_level_module = relative_path
-                .components()
-                .next()
-                .unwrap()
-                .as_os_str()
-                .to_str()
-                .unwrap();
-            if let Some(extension) = absolute_path.extension() {
-                top_level_module = top_level_module
-                    .strip_suffix(extension.to_str().unwrap())
-                    .and_then(|string| string.strip_suffix('.'))
-                    .unwrap();
-            }
-            let top_level_module = ModuleName::new(top_level_module).unwrap();
-            assert!(vendored_typeshed_versions.contains_module(&top_level_module));
+            assert_eq!(
+                vendored_path_kind.is_directory(),
+                file_type.is_dir(),
+                "{vendored_path:?} had type {vendored_path_kind:?}, inconsistent with fs path {relative_path:?}: {file_type:?}"
+            );
         }
-        assert!(!empty_iterator);
+
+        assert!(
+            !empty_iterator,
+            "Expected there to be at least one file or directory in the vendored typeshed stubs!"
+        );
     }
 }

--- a/crates/red_knot_module_resolver/src/typeshed.rs
+++ b/crates/red_knot_module_resolver/src/typeshed.rs
@@ -3,16 +3,32 @@ pub(crate) mod versions;
 #[cfg(test)]
 mod tests {
     use std::io::{self, Read};
-    use std::path::Path;
+    use std::path::{Path, PathBuf};
+    use std::str::FromStr;
+
+    use once_cell::sync::Lazy;
+
+    use ruff_db::vendored::VendoredFileSystem;
+    use ruff_db::vfs::VendoredPath;
+
+    use crate::module::ModuleName;
+
+    use super::versions::*;
+
+    const TYPESHED_STDLIB_DIR: &str = "stdlib";
+
+    // The file path here is hardcoded in this crate's `build.rs` script.
+    // Luckily this crate will fail to build if this file isn't available at build time.
+    const TYPESHED_ZIP_BYTES: &[u8] =
+        include_bytes!(concat!(env!("OUT_DIR"), "/zipped_typeshed.zip"));
+
+    static VENDORED_TYPESHED_DIR: Lazy<PathBuf> =
+        Lazy::new(|| Path::new("vendor/typeshed").canonicalize().unwrap());
 
     #[test]
-    fn typeshed_zip_created_at_build_time() -> anyhow::Result<()> {
-        // The file path here is hardcoded in this crate's `build.rs` script.
-        // Luckily this crate will fail to build if this file isn't available at build time.
-        const TYPESHED_ZIP_BYTES: &[u8] =
-            include_bytes!(concat!(env!("OUT_DIR"), "/zipped_typeshed.zip"));
-
-        let mut typeshed_zip_archive = zip::ZipArchive::new(io::Cursor::new(TYPESHED_ZIP_BYTES))?;
+    fn typeshed_zip_created_at_build_time() {
+        let mut typeshed_zip_archive =
+            zip::ZipArchive::new(io::Cursor::new(TYPESHED_ZIP_BYTES)).unwrap();
 
         let path_to_functools = Path::new("stdlib").join("functools.pyi");
         let mut functools_module_stub = typeshed_zip_archive
@@ -21,9 +37,71 @@ mod tests {
         assert!(functools_module_stub.is_file());
 
         let mut functools_module_stub_source = String::new();
-        functools_module_stub.read_to_string(&mut functools_module_stub_source)?;
+        functools_module_stub
+            .read_to_string(&mut functools_module_stub_source)
+            .unwrap();
 
         assert!(functools_module_stub_source.contains("def update_wrapper("));
-        Ok(())
+    }
+
+    #[test]
+    fn typeshed_vfs_consistent_with_vendored_stubs() {
+        let vendored_typeshed_stubs = VendoredFileSystem::new(TYPESHED_ZIP_BYTES).unwrap();
+
+        let mut empty_iterator = true;
+        for entry in walkdir::WalkDir::new(&*VENDORED_TYPESHED_DIR).min_depth(1) {
+            empty_iterator = false;
+            let entry = entry.unwrap();
+            let absolute_path = entry.path();
+            let file_type = entry.file_type();
+
+            let relative_path = absolute_path.strip_prefix(&*VENDORED_TYPESHED_DIR).unwrap();
+            let vendored_path = VendoredPath::new(relative_path.to_str().unwrap());
+
+            assert!(vendored_typeshed_stubs.exists(vendored_path));
+
+            let vendored_path_kind = vendored_typeshed_stubs
+                .metadata(vendored_path)
+                .unwrap()
+                .kind();
+            assert_eq!(vendored_path_kind.is_directory(), file_type.is_dir());
+        }
+        assert!(!empty_iterator);
+    }
+
+    #[test]
+    fn typeshed_versions_consistent_with_vendored_stubs() {
+        const VERSIONS_DATA: &str = include_str!("../vendor/typeshed/stdlib/VERSIONS");
+        let vendored_typeshed_versions = TypeshedVersions::from_str(VERSIONS_DATA).unwrap();
+
+        let mut empty_iterator = true;
+        for entry in std::fs::read_dir(VENDORED_TYPESHED_DIR.join(TYPESHED_STDLIB_DIR)).unwrap() {
+            empty_iterator = false;
+            let entry = entry.unwrap();
+            let absolute_path = entry.path();
+            let relative_path = absolute_path
+                .strip_prefix(&*VENDORED_TYPESHED_DIR)
+                .and_then(|path| path.strip_prefix(TYPESHED_STDLIB_DIR))
+                .unwrap();
+            if relative_path == Path::new("VERSIONS") {
+                continue;
+            }
+            let mut top_level_module = relative_path
+                .components()
+                .next()
+                .unwrap()
+                .as_os_str()
+                .to_str()
+                .unwrap();
+            if let Some(extension) = absolute_path.extension() {
+                top_level_module = top_level_module
+                    .strip_suffix(extension.to_str().unwrap())
+                    .and_then(|string| string.strip_suffix('.'))
+                    .unwrap();
+            }
+            let top_level_module = ModuleName::new(top_level_module).unwrap();
+            assert!(vendored_typeshed_versions.contains_module(&top_level_module));
+        }
+        assert!(!empty_iterator);
     }
 }

--- a/crates/red_knot_module_resolver/src/typeshed.rs
+++ b/crates/red_knot_module_resolver/src/typeshed.rs
@@ -5,6 +5,8 @@ mod tests {
     use std::io::{self, Read};
     use std::path::Path;
 
+    use path_slash::PathExt;
+
     use ruff_db::vendored::VendoredFileSystem;
     use ruff_db::vfs::VendoredPath;
 
@@ -50,10 +52,11 @@ mod tests {
                     panic!("Expected {absolute_path:?} to be a child of {vendored_typeshed_dir:?}")
                 });
 
-            let vendored_path =
-                VendoredPath::new(relative_path.to_str().unwrap_or_else(|| {
-                    panic!("Expected {relative_path:?} to be a valid UTF-8 path")
-                }));
+            let posix_style_path = relative_path
+                .to_slash()
+                .unwrap_or_else(|| panic!("Expected {relative_path:?} to be a valid UTF-8 path"));
+
+            let vendored_path = VendoredPath::new(&*posix_style_path);
 
             assert!(
                 vendored_typeshed_stubs.exists(vendored_path),

--- a/crates/red_knot_module_resolver/src/typeshed/versions.rs
+++ b/crates/red_knot_module_resolver/src/typeshed/versions.rs
@@ -357,11 +357,8 @@ mod tests {
         let mut empty_iterator = true;
 
         let stdlib_stubs_path = vendored_typeshed_dir.join(TYPESHED_STDLIB_DIR);
-        let stdlib_iterator = std::fs::read_dir(&stdlib_stubs_path).unwrap_or_else(|_| {
-            panic!("Expected {stdlib_stubs_path:?} to be a readable directory!")
-        });
 
-        for entry in stdlib_iterator {
+        for entry in std::fs::read_dir(&stdlib_stubs_path).unwrap() {
             empty_iterator = false;
             let entry = entry.unwrap();
             let absolute_path = entry.path();

--- a/crates/red_knot_module_resolver/src/typeshed/versions.rs
+++ b/crates/red_knot_module_resolver/src/typeshed/versions.rs
@@ -308,10 +308,13 @@ impl From<SupportedPyVersion> for PyVersion {
 #[cfg(test)]
 mod tests {
     use std::num::{IntErrorKind, NonZeroU16};
+    use std::path::Path;
 
     use super::*;
 
     use insta::assert_snapshot;
+
+    const TYPESHED_STDLIB_DIR: &str = "stdlib";
 
     #[allow(unsafe_code)]
     const ONE: NonZeroU16 = unsafe { NonZeroU16::new_unchecked(1) };
@@ -343,6 +346,63 @@ mod tests {
         assert!(versions.contains_module(&audioop));
         assert!(versions.module_exists_on_version(audioop.clone(), SupportedPyVersion::Py312));
         assert!(!versions.module_exists_on_version(audioop, SupportedPyVersion::Py313));
+    }
+
+    #[test]
+    fn typeshed_versions_consistent_with_vendored_stubs() {
+        const VERSIONS_DATA: &str = include_str!("../../vendor/typeshed/stdlib/VERSIONS");
+        let vendored_typeshed_dir = Path::new("vendor/typeshed").canonicalize().unwrap();
+        let vendored_typeshed_versions = TypeshedVersions::from_str(VERSIONS_DATA).unwrap();
+
+        let mut empty_iterator = true;
+
+        let stdlib_stubs_path = vendored_typeshed_dir.join(TYPESHED_STDLIB_DIR);
+        let stdlib_iterator = std::fs::read_dir(&stdlib_stubs_path).unwrap_or_else(|_| {
+            panic!("Expected {stdlib_stubs_path:?} to be a readable directory!")
+        });
+
+        for entry in stdlib_iterator {
+            empty_iterator = false;
+            let entry = entry.unwrap();
+            let absolute_path = entry.path();
+
+            let relative_path = absolute_path
+                .strip_prefix(&stdlib_stubs_path)
+                .unwrap_or_else(|_| panic!("Expected path to be a child of {stdlib_stubs_path:?} but found {absolute_path:?}"));
+
+            let relative_path_str = relative_path.as_os_str().to_str().unwrap_or_else(|| {
+                panic!("Expected all typeshed paths to be valid UTF-8; got {relative_path:?}")
+            });
+            if relative_path_str == "VERSIONS" {
+                continue;
+            }
+
+            let top_level_module = if let Some(extension) = relative_path.extension() {
+                // It was a file; strip off the file extension to get the module name:
+                let extension = extension
+                    .to_str()
+                    .unwrap_or_else(||panic!("Expected all file extensions to be UTF-8; was not true for {relative_path:?}"));
+
+                relative_path_str
+                    .strip_suffix(extension)
+                    .and_then(|string| string.strip_suffix('.')).unwrap_or_else(|| {
+                        panic!("Expected path {relative_path_str:?} to end with computed extension {extension:?}")
+                })
+            } else {
+                // It was a directory; no need to do anything to get the module name
+                relative_path_str
+            };
+
+            let top_level_module = ModuleName::new(top_level_module)
+                .unwrap_or_else(|| panic!("{top_level_module:?} was not a valid module name!"));
+
+            assert!(vendored_typeshed_versions.contains_module(&top_level_module));
+        }
+
+        assert!(
+            !empty_iterator,
+            "Expected there to be at least one file or directory in the vendored typeshed stubs"
+        );
     }
 
     #[test]


### PR DESCRIPTION
- Assert that all modules found in the `vendor/typeshed` directory can be retrieved from the zipfile using the `VendoredFileSystem` struct.
- Assert that all top-level modules found in `vendor/typeshed` are included in `VERSIONS`
