### PR TITLE
[red-knot]: Implement `HasTy` for `Alias`

### DIFF
--- a/crates/red_knot_module_resolver/src/lib.rs
+++ b/crates/red_knot_module_resolver/src/lib.rs
@@ -3,5 +3,5 @@ mod module;
 mod resolver;
 
 pub use db::{Db, Jar};
-pub use module::{ModuleKind, ModuleName};
+pub use module::{Module, ModuleKind, ModuleName};
 pub use resolver::{resolve_module, set_module_resolution_settings, ModuleResolutionSettings};

--- a/crates/red_knot_module_resolver/src/resolver.rs
+++ b/crates/red_knot_module_resolver/src/resolver.rs
@@ -1,4 +1,3 @@
-use salsa::DebugWithDb;
 use std::ops::Deref;
 
 use ruff_db::file_system::{FileSystem, FileSystemPath, FileSystemPathBuf};
@@ -42,7 +41,7 @@ pub(crate) fn resolve_module_query<'db>(
     db: &'db dyn Db,
     module_name: internal::ModuleNameIngredient<'db>,
 ) -> Option<Module> {
-    let _ = tracing::trace_span!("resolve_module", module_name = ?module_name.debug(db)).enter();
+    let _span = tracing::trace_span!("resolve_module", ?module_name).entered();
 
     let name = module_name.name(db);
 
@@ -76,7 +75,7 @@ pub fn path_to_module(db: &dyn Db, path: &VfsPath) -> Option<Module> {
 #[salsa::tracked]
 #[allow(unused)]
 pub(crate) fn file_to_module(db: &dyn Db, file: VfsFile) -> Option<Module> {
-    let _ = tracing::trace_span!("file_to_module", file = ?file.debug(db.upcast())).enter();
+    let _span = tracing::trace_span!("file_to_module", ?file).entered();
 
     let path = file.path(db.upcast());
 

--- a/crates/red_knot_python_semantic/src/lib.rs
+++ b/crates/red_knot_python_semantic/src/lib.rs
@@ -1,12 +1,16 @@
+use std::hash::BuildHasherDefault;
+
+use rustc_hash::FxHasher;
+
+pub use db::{Db, Jar};
+pub use semantic_model::{HasTy, SemanticModel};
+
 pub mod ast_node_ref;
 mod db;
 pub mod name;
 mod node_key;
 pub mod semantic_index;
+mod semantic_model;
 pub mod types;
 
 type FxIndexSet<V> = indexmap::set::IndexSet<V, BuildHasherDefault<FxHasher>>;
-
-pub use db::{Db, Jar};
-use rustc_hash::FxHasher;
-use std::hash::BuildHasherDefault;

--- a/crates/red_knot_python_semantic/src/semantic_index/ast_ids.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/ast_ids.rs
@@ -4,10 +4,11 @@ use ruff_db::parsed::ParsedModule;
 use ruff_db::vfs::VfsFile;
 use ruff_index::{newtype_index, IndexVec};
 use ruff_python_ast as ast;
-use ruff_python_ast::{AnyNodeRef, ExpressionRef};
+use ruff_python_ast::{Alias, ExpressionRef, StmtClassDef, StmtFunctionDef};
 
 use crate::ast_node_ref::AstNodeRef;
 use crate::node_key::NodeKey;
+use crate::semantic_index::definition::DefinitionNodeKey;
 use crate::semantic_index::semantic_index;
 use crate::semantic_index::symbol::{FileScopeId, ScopeId};
 use crate::Db;
@@ -32,26 +33,19 @@ pub(crate) struct AstIds {
     expressions: IndexVec<ScopedExpressionId, AstNodeRef<ast::Expr>>,
 
     /// Maps expressions to their expression id. Uses `NodeKey` because it avoids cloning [`Parsed`].
-    expressions_map: FxHashMap<NodeKey, ScopedExpressionId>,
+    expressions_map: FxHashMap<ExpressionNodeKey, ScopedExpressionId>,
 
-    statements: IndexVec<ScopedStatementId, AstNodeRef<ast::Stmt>>,
+    definitions: IndexVec<ScopedDefinitionNodeId, DefinitionNodeRef>,
 
-    statements_map: FxHashMap<NodeKey, ScopedStatementId>,
+    definitions_map: FxHashMap<DefinitionNodeKey, ScopedDefinitionNodeId>,
 }
 
 impl AstIds {
-    fn statement_id<'a, N>(&self, node: N) -> ScopedStatementId
-    where
-        N: Into<AnyNodeRef<'a>>,
-    {
-        self.statements_map[&NodeKey::from_node(node.into())]
-    }
-
     fn expression_id<'a, N>(&self, node: N) -> ScopedExpressionId
     where
         N: Into<ExpressionRef<'a>>,
     {
-        self.expressions_map[&NodeKey::from_node(node.into())]
+        self.expressions_map[&ExpressionNodeKey::from(node.into())]
     }
 }
 
@@ -60,7 +54,7 @@ impl std::fmt::Debug for AstIds {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("AstIds")
             .field("expressions", &self.expressions)
-            .field("statements", &self.statements)
+            .field("statements", &self.definitions)
             .finish()
     }
 }
@@ -228,12 +222,12 @@ impl ScopedAstIdNode for ast::Expr {
 
 /// Uniquely identifies an [`ast::Stmt`] in a [`FileScopeId`].
 #[newtype_index]
-pub struct ScopedStatementId;
+pub struct ScopedDefinitionNodeId;
 
-macro_rules! impl_has_scoped_statement_id {
+macro_rules! impl_has_scoped_definition_id {
     ($ty: ty) => {
         impl HasScopedAstId for $ty {
-            type Id = ScopedStatementId;
+            type Id = ScopedDefinitionNodeId;
 
             fn scoped_ast_id(
                 &self,
@@ -243,25 +237,14 @@ macro_rules! impl_has_scoped_statement_id {
             ) -> Self::Id {
                 let scope = file_scope.to_scope_id(db, file);
                 let ast_ids = ast_ids(db, scope);
-                ast_ids.statement_id(self)
+                ast_ids.definitions_map[&self.into()]
             }
         }
     };
 }
 
-impl_has_scoped_statement_id!(ast::Stmt);
-
-impl ScopedAstIdNode for ast::Stmt {
-    fn lookup_in_scope(db: &dyn Db, file: VfsFile, file_scope: FileScopeId, id: Self::Id) -> &Self {
-        let scope = file_scope.to_scope_id(db, file);
-        let ast_ids = ast_ids(db, scope);
-
-        ast_ids.statements[id].node()
-    }
-}
-
 #[derive(Debug, Eq, PartialEq, Copy, Clone, Hash)]
-pub struct ScopedFunctionId(pub(super) ScopedStatementId);
+pub struct ScopedFunctionId(ScopedDefinitionNodeId);
 
 impl HasScopedAstId for ast::StmtFunctionDef {
     type Id = ScopedFunctionId;
@@ -269,20 +252,25 @@ impl HasScopedAstId for ast::StmtFunctionDef {
     fn scoped_ast_id(&self, db: &dyn Db, file: VfsFile, file_scope: FileScopeId) -> Self::Id {
         let scope = file_scope.to_scope_id(db, file);
         let ast_ids = ast_ids(db, scope);
-        ScopedFunctionId(ast_ids.statement_id(self))
+        ScopedFunctionId(ast_ids.definitions_map[&self.into()])
     }
 }
 
 impl ScopedAstIdNode for ast::StmtFunctionDef {
-    fn lookup_in_scope(db: &dyn Db, file: VfsFile, scope: FileScopeId, id: Self::Id) -> &Self {
-        ast::Stmt::lookup_in_scope(db, file, scope, id.0)
-            .as_function_def_stmt()
-            .unwrap()
+    fn lookup_in_scope(db: &dyn Db, file: VfsFile, file_scope: FileScopeId, id: Self::Id) -> &Self {
+        let scope = file_scope.to_scope_id(db, file);
+        let ast_ids = ast_ids(db, scope);
+
+        if let DefinitionNodeRef::Function(function) = &ast_ids.definitions[id.0] {
+            function.node()
+        } else {
+            panic!("Expected function definition")
+        }
     }
 }
 
 #[derive(Debug, Eq, PartialEq, Copy, Clone, Hash)]
-pub struct ScopedClassId(pub(super) ScopedStatementId);
+pub struct ScopedClassId(ScopedDefinitionNodeId);
 
 impl HasScopedAstId for ast::StmtClassDef {
     type Id = ScopedClassId;
@@ -290,37 +278,41 @@ impl HasScopedAstId for ast::StmtClassDef {
     fn scoped_ast_id(&self, db: &dyn Db, file: VfsFile, file_scope: FileScopeId) -> Self::Id {
         let scope = file_scope.to_scope_id(db, file);
         let ast_ids = ast_ids(db, scope);
-        ScopedClassId(ast_ids.statement_id(self))
+        ScopedClassId(ast_ids.definitions_map[&self.into()])
     }
 }
 
 impl ScopedAstIdNode for ast::StmtClassDef {
-    fn lookup_in_scope(db: &dyn Db, file: VfsFile, scope: FileScopeId, id: Self::Id) -> &Self {
-        let statement = ast::Stmt::lookup_in_scope(db, file, scope, id.0);
-        statement.as_class_def_stmt().unwrap()
+    fn lookup_in_scope(db: &dyn Db, file: VfsFile, file_scope: FileScopeId, id: Self::Id) -> &Self {
+        let scope = file_scope.to_scope_id(db, file);
+        let ast_ids = ast_ids(db, scope);
+
+        if let DefinitionNodeRef::Class(class) = &ast_ids.definitions[id.0] {
+            class.node()
+        } else {
+            panic!("Expected class definition")
+        }
     }
 }
 
-impl_has_scoped_statement_id!(ast::StmtAssign);
-impl_has_scoped_statement_id!(ast::StmtAnnAssign);
-impl_has_scoped_statement_id!(ast::StmtImport);
-impl_has_scoped_statement_id!(ast::StmtImportFrom);
+impl_has_scoped_definition_id!(ast::Alias);
 
 #[derive(Debug)]
 pub(super) struct AstIdsBuilder {
     expressions: IndexVec<ScopedExpressionId, AstNodeRef<ast::Expr>>,
-    expressions_map: FxHashMap<NodeKey, ScopedExpressionId>,
-    statements: IndexVec<ScopedStatementId, AstNodeRef<ast::Stmt>>,
-    statements_map: FxHashMap<NodeKey, ScopedStatementId>,
+    expressions_map: FxHashMap<ExpressionNodeKey, ScopedExpressionId>,
+    definitions: IndexVec<ScopedDefinitionNodeId, DefinitionNodeRef>,
+    definitions_map: FxHashMap<DefinitionNodeKey, ScopedDefinitionNodeId>,
 }
 
+#[allow(unsafe_code)]
 impl AstIdsBuilder {
     pub(super) fn new() -> Self {
         Self {
             expressions: IndexVec::default(),
             expressions_map: FxHashMap::default(),
-            statements: IndexVec::default(),
-            statements_map: FxHashMap::default(),
+            definitions: IndexVec::default(),
+            definitions_map: FxHashMap::default(),
         }
     }
 
@@ -329,18 +321,59 @@ impl AstIdsBuilder {
     /// ## Safety
     /// The function is marked as unsafe because it calls [`AstNodeRef::new`] which requires
     /// that `stmt` is a child of `parsed`.
-    #[allow(unsafe_code)]
-    pub(super) unsafe fn record_statement(
+    pub(super) unsafe fn record_function_definition(
         &mut self,
-        stmt: &ast::Stmt,
+        function_definition: &ast::StmtFunctionDef,
         parsed: &ParsedModule,
-    ) -> ScopedStatementId {
-        let statement_id = self.statements.push(AstNodeRef::new(parsed.clone(), stmt));
+    ) -> ScopedFunctionId {
+        let function_id = self
+            .definitions
+            .push(AstNodeRef::new(parsed.clone(), function_definition).into());
 
-        self.statements_map
-            .insert(NodeKey::from_node(stmt), statement_id);
+        self.definitions_map
+            .insert(DefinitionNodeKey::from(function_definition), function_id);
 
-        statement_id
+        ScopedFunctionId(function_id)
+    }
+
+    /// Adds `stmt` to the AST ids map and returns its id.
+    ///
+    /// ## Safety
+    /// The function is marked as unsafe because it calls [`AstNodeRef::new`] which requires
+    /// that `stmt` is a child of `parsed`.
+    pub(super) unsafe fn record_class_definition(
+        &mut self,
+        class_definition: &ast::StmtClassDef,
+        parsed: &ParsedModule,
+    ) -> ScopedClassId {
+        let function_id = self
+            .definitions
+            .push(AstNodeRef::new(parsed.clone(), class_definition).into());
+
+        self.definitions_map
+            .insert(DefinitionNodeKey::from(class_definition), function_id);
+
+        ScopedClassId(function_id)
+    }
+
+    /// Adds `stmt` to the AST ids map and returns its id.
+    ///
+    /// ## Safety
+    /// The function is marked as unsafe because it calls [`AstNodeRef::new`] which requires
+    /// that `stmt` is a child of `parsed`.
+    pub(super) unsafe fn record_alias(
+        &mut self,
+        alias: &ast::Alias,
+        parsed: &ParsedModule,
+    ) -> ScopedDefinitionNodeId {
+        let alias_id = self
+            .definitions
+            .push(AstNodeRef::new(parsed.clone(), alias).into());
+
+        self.definitions_map
+            .insert(DefinitionNodeKey::from(alias), alias_id);
+
+        alias_id
     }
 
     /// Adds `expr` to the AST ids map and returns its id.
@@ -356,8 +389,7 @@ impl AstIdsBuilder {
     ) -> ScopedExpressionId {
         let expression_id = self.expressions.push(AstNodeRef::new(parsed.clone(), expr));
 
-        self.expressions_map
-            .insert(NodeKey::from_node(expr), expression_id);
+        self.expressions_map.insert(expr.into(), expression_id);
 
         expression_id
     }
@@ -365,14 +397,54 @@ impl AstIdsBuilder {
     pub(super) fn finish(mut self) -> AstIds {
         self.expressions.shrink_to_fit();
         self.expressions_map.shrink_to_fit();
-        self.statements.shrink_to_fit();
-        self.statements_map.shrink_to_fit();
+        self.definitions.shrink_to_fit();
+        self.definitions_map.shrink_to_fit();
 
         AstIds {
             expressions: self.expressions,
             expressions_map: self.expressions_map,
-            statements: self.statements,
-            statements_map: self.statements_map,
+            definitions: self.definitions,
+            definitions_map: self.definitions_map,
         }
+    }
+}
+
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
+struct ExpressionNodeKey(NodeKey);
+
+impl From<ExpressionRef<'_>> for ExpressionNodeKey {
+    fn from(value: ExpressionRef<'_>) -> Self {
+        Self(NodeKey::from_node(value))
+    }
+}
+
+impl From<&ast::Expr> for ExpressionNodeKey {
+    fn from(value: &ast::Expr) -> Self {
+        Self(NodeKey::from_node(value))
+    }
+}
+
+#[derive(Debug)]
+enum DefinitionNodeRef {
+    Alias(()),
+    Function(AstNodeRef<ast::StmtFunctionDef>),
+    Class(AstNodeRef<ast::StmtClassDef>),
+}
+
+impl From<AstNodeRef<ast::StmtFunctionDef>> for DefinitionNodeRef {
+    fn from(value: AstNodeRef<StmtFunctionDef>) -> Self {
+        Self::Function(value)
+    }
+}
+
+impl From<AstNodeRef<ast::StmtClassDef>> for DefinitionNodeRef {
+    fn from(value: AstNodeRef<StmtClassDef>) -> Self {
+        Self::Class(value)
+    }
+}
+
+impl From<AstNodeRef<ast::Alias>> for DefinitionNodeRef {
+    fn from(_value: AstNodeRef<Alias>) -> Self {
+        Self::Alias(())
     }
 }

--- a/crates/red_knot_python_semantic/src/semantic_index/builder.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/builder.rs
@@ -9,15 +9,12 @@ use ruff_python_ast::visitor::{walk_expr, walk_stmt, Visitor};
 
 use crate::name::Name;
 use crate::node_key::NodeKey;
-use crate::semantic_index::ast_ids::{
-    AstId, AstIdsBuilder, ScopeAssignmentId, ScopeClassId, ScopeFunctionId, ScopeImportFromId,
-    ScopeImportId, ScopeNamedExprId,
-};
+use crate::semantic_index::ast_ids::{AstId, AstIdsBuilder, ScopedClassId, ScopedFunctionId};
 use crate::semantic_index::definition::{Definition, ImportDefinition, ImportFromDefinition};
 use crate::semantic_index::symbol::{
-    FileScopeId, FileSymbolId, Scope, ScopedSymbolId, SymbolFlags, SymbolTableBuilder,
+    FileScopeId, FileSymbolId, Scope, ScopeKind, ScopedSymbolId, SymbolFlags, SymbolTableBuilder,
 };
-use crate::semantic_index::{NodeWithScopeId, SemanticIndex};
+use crate::semantic_index::{NodeWithScopeId, NodeWithScopeKey, SemanticIndex};
 
 pub(super) struct SemanticIndexBuilder<'a> {
     // Builder state
@@ -32,6 +29,7 @@ pub(super) struct SemanticIndexBuilder<'a> {
     ast_ids: IndexVec<FileScopeId, AstIdsBuilder>,
     expression_scopes: FxHashMap<NodeKey, FileScopeId>,
     scope_nodes: IndexVec<FileScopeId, NodeWithScopeId>,
+    node_scopes: FxHashMap<NodeWithScopeKey, FileScopeId>,
 }
 
 impl<'a> SemanticIndexBuilder<'a> {
@@ -45,12 +43,16 @@ impl<'a> SemanticIndexBuilder<'a> {
             symbol_tables: IndexVec::new(),
             ast_ids: IndexVec::new(),
             expression_scopes: FxHashMap::default(),
+            node_scopes: FxHashMap::default(),
             scope_nodes: IndexVec::new(),
         };
 
         builder.push_scope_with_parent(
-            NodeWithScopeId::Module,
-            &Name::new_static("<module>"),
+            NodeWithScope::new(
+                parsed.syntax(),
+                NodeWithScopeId::Module,
+                Name::new_static("<module>"),
+            ),
             None,
             None,
             None,
@@ -68,42 +70,44 @@ impl<'a> SemanticIndexBuilder<'a> {
 
     fn push_scope(
         &mut self,
-        node: NodeWithScopeId,
-        name: &Name,
+        node: NodeWithScope,
         defining_symbol: Option<FileSymbolId>,
         definition: Option<Definition>,
     ) {
         let parent = self.current_scope();
-        self.push_scope_with_parent(node, name, defining_symbol, definition, Some(parent));
+        self.push_scope_with_parent(node, defining_symbol, definition, Some(parent));
     }
 
     fn push_scope_with_parent(
         &mut self,
-        node: NodeWithScopeId,
-        name: &Name,
+        node: NodeWithScope,
         defining_symbol: Option<FileSymbolId>,
         definition: Option<Definition>,
         parent: Option<FileScopeId>,
     ) {
         let children_start = self.scopes.next_index() + 1;
+        let node_key = node.key();
+        let node_id = node.id();
+        let scope_kind = node.scope_kind();
 
         let scope = Scope {
-            name: name.clone(),
+            name: node.name,
             parent,
             defining_symbol,
             definition,
-            kind: node.scope_kind(),
+            kind: scope_kind,
             descendents: children_start..children_start,
         };
 
         let scope_id = self.scopes.push(scope);
         self.symbol_tables.push(SymbolTableBuilder::new());
         let ast_id_scope = self.ast_ids.push(AstIdsBuilder::new());
-        let scope_node_id = self.scope_nodes.push(node);
+        let scope_node_id = self.scope_nodes.push(node_id);
 
         debug_assert_eq!(ast_id_scope, scope_id);
         debug_assert_eq!(scope_id, scope_node_id);
         self.scope_stack.push(scope_id);
+        self.node_scopes.insert(node_key, scope_id);
     }
 
     fn pop_scope(&mut self) -> FileScopeId {
@@ -124,10 +128,18 @@ impl<'a> SemanticIndexBuilder<'a> {
         &mut self.ast_ids[scope_id]
     }
 
-    fn add_or_update_symbol(&mut self, name: Name, flags: SymbolFlags) -> ScopedSymbolId {
-        let symbol_table = self.current_symbol_table();
+    fn add_or_update_symbol(&mut self, name: Name, flags: SymbolFlags) -> FileSymbolId {
+        for scope in self.scope_stack.iter().rev().skip(1) {
+            let builder = &self.symbol_tables[*scope];
 
-        symbol_table.add_or_update_symbol(name, flags, None)
+            if let Some(symbol) = builder.symbol_by_name(&name) {
+                return FileSymbolId::new(*scope, symbol);
+            }
+        }
+
+        let scope = self.current_scope();
+        let symbol_table = self.current_symbol_table();
+        FileSymbolId::new(scope, symbol_table.add_or_update_symbol(name, flags, None))
     }
 
     fn add_or_update_symbol_with_definition(
@@ -143,7 +155,7 @@ impl<'a> SemanticIndexBuilder<'a> {
 
     fn with_type_params(
         &mut self,
-        name: &Name,
+        name: Name,
         with_params: &WithTypeParams,
         defining_symbol: FileSymbolId,
         nested: impl FnOnce(&mut Self) -> FileScopeId,
@@ -151,14 +163,13 @@ impl<'a> SemanticIndexBuilder<'a> {
         let type_params = with_params.type_parameters();
 
         if let Some(type_params) = type_params {
-            let type_node = match with_params {
+            let type_params_id = match with_params {
                 WithTypeParams::ClassDef { id, .. } => NodeWithScopeId::ClassTypeParams(*id),
                 WithTypeParams::FunctionDef { id, .. } => NodeWithScopeId::FunctionTypeParams(*id),
             };
 
             self.push_scope(
-                type_node,
-                name,
+                NodeWithScope::new(type_params, type_params_id, name),
                 Some(defining_symbol),
                 Some(with_params.definition()),
             );
@@ -212,9 +223,10 @@ impl<'a> SemanticIndexBuilder<'a> {
         SemanticIndex {
             symbol_tables,
             scopes: self.scopes,
-            scope_nodes: self.scope_nodes,
+            nodes_by_scope: self.scope_nodes,
+            scopes_by_node: self.node_scopes,
             ast_ids,
-            expression_scopes: self.expression_scopes,
+            scopes_by_expression: self.expression_scopes,
         }
     }
 }
@@ -234,7 +246,7 @@ impl Visitor<'_> for SemanticIndexBuilder<'_> {
                     self.visit_decorator(decorator);
                 }
                 let name = Name::new(&function_def.name.id);
-                let function_id = ScopeFunctionId(statement_id);
+                let function_id = ScopedFunctionId(statement_id);
                 let definition = Definition::FunctionDef(function_id);
                 let scope = self.current_scope();
                 let symbol = FileSymbolId::new(
@@ -243,7 +255,7 @@ impl Visitor<'_> for SemanticIndexBuilder<'_> {
                 );
 
                 self.with_type_params(
-                    &name,
+                    name.clone(),
                     &WithTypeParams::FunctionDef {
                         node: function_def,
                         id: AstId::new(scope, function_id),
@@ -256,8 +268,11 @@ impl Visitor<'_> for SemanticIndexBuilder<'_> {
                         }
 
                         builder.push_scope(
-                            NodeWithScopeId::Function(AstId::new(scope, function_id)),
-                            &name,
+                            NodeWithScope::new(
+                                function_def,
+                                NodeWithScopeId::Function(AstId::new(scope, function_id)),
+                                name,
+                            ),
                             Some(symbol),
                             Some(definition),
                         );
@@ -272,15 +287,15 @@ impl Visitor<'_> for SemanticIndexBuilder<'_> {
                 }
 
                 let name = Name::new(&class.name.id);
-                let class_id = ScopeClassId(statement_id);
-                let definition = Definition::from(class_id);
+                let class_id = ScopedClassId(statement_id);
+                let definition = Definition::ClassDef(class_id);
                 let scope = self.current_scope();
                 let id = FileSymbolId::new(
                     self.current_scope(),
                     self.add_or_update_symbol_with_definition(name.clone(), definition),
                 );
                 self.with_type_params(
-                    &name,
+                    name.clone(),
                     &WithTypeParams::ClassDef {
                         node: class,
                         id: AstId::new(scope, class_id),
@@ -292,8 +307,11 @@ impl Visitor<'_> for SemanticIndexBuilder<'_> {
                         }
 
                         builder.push_scope(
-                            NodeWithScopeId::Class(AstId::new(scope, class_id)),
-                            &name,
+                            NodeWithScope::new(
+                                class,
+                                NodeWithScopeId::Class(AstId::new(scope, class_id)),
+                                name,
+                            ),
                             Some(id),
                             Some(definition),
                         );
@@ -312,7 +330,7 @@ impl Visitor<'_> for SemanticIndexBuilder<'_> {
                     };
 
                     let def = Definition::Import(ImportDefinition {
-                        import_id: ScopeImportId(statement_id),
+                        import_id: statement_id,
                         alias: u32::try_from(i).unwrap(),
                     });
                     self.add_or_update_symbol_with_definition(Name::new(symbol_name), def);
@@ -331,7 +349,7 @@ impl Visitor<'_> for SemanticIndexBuilder<'_> {
                         alias.name.id.as_str()
                     };
                     let def = Definition::ImportFrom(ImportFromDefinition {
-                        import_id: ScopeImportFromId(statement_id),
+                        import_id: statement_id,
                         name: u32::try_from(i).unwrap(),
                     });
                     self.add_or_update_symbol_with_definition(Name::new(symbol_name), def);
@@ -340,8 +358,7 @@ impl Visitor<'_> for SemanticIndexBuilder<'_> {
             ast::Stmt::Assign(node) => {
                 debug_assert!(self.current_definition.is_none());
                 self.visit_expr(&node.value);
-                self.current_definition =
-                    Some(Definition::Assignment(ScopeAssignmentId(statement_id)));
+                self.current_definition = Some(Definition::Assignment(statement_id));
                 for target in &node.targets {
                     self.visit_expr(target);
                 }
@@ -386,8 +403,7 @@ impl Visitor<'_> for SemanticIndexBuilder<'_> {
             }
             ast::Expr::Named(node) => {
                 debug_assert!(self.current_definition.is_none());
-                self.current_definition =
-                    Some(Definition::NamedExpr(ScopeNamedExprId(expression_id)));
+                self.current_definition = Some(Definition::NamedExpr(expression_id));
                 // TODO walrus in comprehensions is implicitly nonlocal
                 self.visit_expr(&node.target);
                 self.current_definition = None;
@@ -429,11 +445,11 @@ impl Visitor<'_> for SemanticIndexBuilder<'_> {
 enum WithTypeParams<'a> {
     ClassDef {
         node: &'a ast::StmtClassDef,
-        id: AstId<ScopeClassId>,
+        id: AstId<ScopedClassId>,
     },
     FunctionDef {
         node: &'a ast::StmtFunctionDef,
-        id: AstId<ScopeFunctionId>,
+        id: AstId<ScopedFunctionId>,
     },
 }
 
@@ -449,6 +465,41 @@ impl<'a> WithTypeParams<'a> {
         match self {
             WithTypeParams::ClassDef { id, .. } => Definition::ClassDef(id.in_scope_id()),
             WithTypeParams::FunctionDef { id, .. } => Definition::FunctionDef(id.in_scope_id()),
+        }
+    }
+}
+
+struct NodeWithScope {
+    id: NodeWithScopeId,
+    key: NodeWithScopeKey,
+    name: Name,
+}
+
+impl NodeWithScope {
+    fn new(node: impl Into<NodeWithScopeKey>, id: NodeWithScopeId, name: Name) -> Self {
+        Self {
+            id,
+            key: node.into(),
+            name,
+        }
+    }
+
+    fn id(&self) -> NodeWithScopeId {
+        self.id
+    }
+
+    fn key(&self) -> NodeWithScopeKey {
+        self.key
+    }
+
+    fn scope_kind(&self) -> ScopeKind {
+        match self.id {
+            NodeWithScopeId::Module => ScopeKind::Module,
+            NodeWithScopeId::Class(_) => ScopeKind::Class,
+            NodeWithScopeId::Function(_) => ScopeKind::Function,
+            NodeWithScopeId::ClassTypeParams(_) | NodeWithScopeId::FunctionTypeParams(_) => {
+                ScopeKind::Annotation
+            }
         }
     }
 }

--- a/crates/red_knot_python_semantic/src/semantic_index/definition.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/definition.rs
@@ -1,17 +1,16 @@
 use crate::semantic_index::ast_ids::{
-    ScopeAnnotatedAssignmentId, ScopeAssignmentId, ScopeClassId, ScopeFunctionId,
-    ScopeImportFromId, ScopeImportId, ScopeNamedExprId,
+    ScopedClassId, ScopedExpressionId, ScopedFunctionId, ScopedStatementId,
 };
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum Definition {
     Import(ImportDefinition),
     ImportFrom(ImportFromDefinition),
-    ClassDef(ScopeClassId),
-    FunctionDef(ScopeFunctionId),
-    Assignment(ScopeAssignmentId),
-    AnnotatedAssignment(ScopeAnnotatedAssignmentId),
-    NamedExpr(ScopeNamedExprId),
+    ClassDef(ScopedClassId),
+    FunctionDef(ScopedFunctionId),
+    Assignment(ScopedStatementId),
+    AnnotatedAssignment(ScopedStatementId),
+    NamedExpr(ScopedExpressionId),
     /// represents the implicit initial definition of every name as "unbound"
     Unbound,
     // TODO with statements, except handlers, function args...
@@ -29,39 +28,21 @@ impl From<ImportFromDefinition> for Definition {
     }
 }
 
-impl From<ScopeClassId> for Definition {
-    fn from(value: ScopeClassId) -> Self {
+impl From<ScopedClassId> for Definition {
+    fn from(value: ScopedClassId) -> Self {
         Self::ClassDef(value)
     }
 }
 
-impl From<ScopeFunctionId> for Definition {
-    fn from(value: ScopeFunctionId) -> Self {
+impl From<ScopedFunctionId> for Definition {
+    fn from(value: ScopedFunctionId) -> Self {
         Self::FunctionDef(value)
-    }
-}
-
-impl From<ScopeAssignmentId> for Definition {
-    fn from(value: ScopeAssignmentId) -> Self {
-        Self::Assignment(value)
-    }
-}
-
-impl From<ScopeAnnotatedAssignmentId> for Definition {
-    fn from(value: ScopeAnnotatedAssignmentId) -> Self {
-        Self::AnnotatedAssignment(value)
-    }
-}
-
-impl From<ScopeNamedExprId> for Definition {
-    fn from(value: ScopeNamedExprId) -> Self {
-        Self::NamedExpr(value)
     }
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub struct ImportDefinition {
-    pub(crate) import_id: ScopeImportId,
+    pub(crate) import_id: ScopedStatementId,
 
     /// Index into [`ruff_python_ast::StmtImport::names`].
     pub(crate) alias: u32,
@@ -69,7 +50,7 @@ pub struct ImportDefinition {
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub struct ImportFromDefinition {
-    pub(crate) import_id: ScopeImportFromId,
+    pub(crate) import_id: ScopedStatementId,
 
     /// Index into [`ruff_python_ast::StmtImportFrom::names`].
     pub(crate) name: u32,

--- a/crates/red_knot_python_semantic/src/semantic_index/definition.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/definition.rs
@@ -1,31 +1,19 @@
+use crate::node_key::NodeKey;
 use crate::semantic_index::ast_ids::{
-    ScopedClassId, ScopedExpressionId, ScopedFunctionId, ScopedStatementId,
+    ScopedClassId, ScopedDefinitionNodeId, ScopedExpressionId, ScopedFunctionId,
 };
+use ruff_python_ast as ast;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum Definition {
-    Import(ImportDefinition),
-    ImportFrom(ImportFromDefinition),
+    ImportAlias(ScopedDefinitionNodeId),
     ClassDef(ScopedClassId),
     FunctionDef(ScopedFunctionId),
-    Assignment(ScopedStatementId),
-    AnnotatedAssignment(ScopedStatementId),
+    Target(ScopedExpressionId),
     NamedExpr(ScopedExpressionId),
     /// represents the implicit initial definition of every name as "unbound"
     Unbound,
     // TODO with statements, except handlers, function args...
-}
-
-impl From<ImportDefinition> for Definition {
-    fn from(value: ImportDefinition) -> Self {
-        Self::Import(value)
-    }
-}
-
-impl From<ImportFromDefinition> for Definition {
-    fn from(value: ImportFromDefinition) -> Self {
-        Self::ImportFrom(value)
-    }
 }
 
 impl From<ScopedClassId> for Definition {
@@ -40,18 +28,23 @@ impl From<ScopedFunctionId> for Definition {
     }
 }
 
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
-pub struct ImportDefinition {
-    pub(crate) import_id: ScopedStatementId,
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
+pub(crate) struct DefinitionNodeKey(NodeKey);
 
-    /// Index into [`ruff_python_ast::StmtImport::names`].
-    pub(crate) alias: u32,
+impl From<&ast::StmtFunctionDef> for DefinitionNodeKey {
+    fn from(value: &ast::StmtFunctionDef) -> Self {
+        Self(NodeKey::from_node(value))
+    }
 }
 
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
-pub struct ImportFromDefinition {
-    pub(crate) import_id: ScopedStatementId,
+impl From<&ast::StmtClassDef> for DefinitionNodeKey {
+    fn from(value: &ast::StmtClassDef) -> Self {
+        Self(NodeKey::from_node(value))
+    }
+}
 
-    /// Index into [`ruff_python_ast::StmtImportFrom::names`].
-    pub(crate) name: u32,
+impl From<&ast::Alias> for DefinitionNodeKey {
+    fn from(value: &ast::Alias) -> Self {
+        Self(NodeKey::from_node(value))
+    }
 }

--- a/crates/red_knot_python_semantic/src/semantic_model.rs
+++ b/crates/red_knot_python_semantic/src/semantic_model.rs
@@ -1,0 +1,183 @@
+use red_knot_module_resolver::{resolve_module, Module, ModuleName};
+use ruff_db::vfs::VfsFile;
+use ruff_python_ast as ast;
+use ruff_python_ast::{Expr, ExpressionRef, StmtClassDef};
+
+use crate::semantic_index::ast_ids::HasScopedAstId;
+use crate::semantic_index::definition::Definition;
+use crate::semantic_index::symbol::{PublicSymbolId, ScopeKind};
+use crate::semantic_index::{public_symbol, semantic_index, NodeWithScopeKey};
+use crate::types::{infer_types, public_symbol_ty, Type, TypingContext};
+use crate::Db;
+
+pub struct SemanticModel<'db> {
+    db: &'db dyn Db,
+    file: VfsFile,
+}
+
+impl<'db> SemanticModel<'db> {
+    pub fn new(db: &'db dyn Db, file: VfsFile) -> Self {
+        Self { db, file }
+    }
+
+    pub fn resolve_module(&self, module_name: ModuleName) -> Option<Module> {
+        resolve_module(self.db.upcast(), module_name)
+    }
+
+    pub fn public_symbol(&self, module: &Module, symbol_name: &str) -> Option<PublicSymbolId<'db>> {
+        public_symbol(self.db, module.file(), symbol_name)
+    }
+
+    pub fn public_symbol_ty(&self, symbol: PublicSymbolId<'db>) -> Type<'db> {
+        public_symbol_ty(self.db, symbol)
+    }
+
+    pub fn typing_context(&self) -> TypingContext<'db, '_> {
+        TypingContext::global(self.db)
+    }
+}
+
+pub trait HasTy {
+    fn ty<'db>(&self, model: &SemanticModel<'db>) -> Type<'db>;
+}
+
+impl HasTy for ast::ExpressionRef<'_> {
+    fn ty<'db>(&self, model: &SemanticModel<'db>) -> Type<'db> {
+        let index = semantic_index(model.db, model.file);
+        let file_scope = index.expression_scope_id(*self);
+        let expression_id = self.scoped_ast_id(model.db, model.file, file_scope);
+
+        let scope = file_scope.to_scope_id(model.db, model.file);
+        infer_types(model.db, scope).expression_ty(expression_id)
+    }
+}
+
+macro_rules! impl_expression_has_ty {
+    ($ty: ty) => {
+        impl HasTy for $ty {
+            #[inline]
+            fn ty<'db>(&self, model: &SemanticModel<'db>) -> Type<'db> {
+                let expression_ref = ExpressionRef::from(self);
+                expression_ref.ty(model)
+            }
+        }
+    };
+}
+
+impl_expression_has_ty!(ast::ExprBoolOp);
+impl_expression_has_ty!(ast::ExprNamed);
+impl_expression_has_ty!(ast::ExprBinOp);
+impl_expression_has_ty!(ast::ExprUnaryOp);
+impl_expression_has_ty!(ast::ExprLambda);
+impl_expression_has_ty!(ast::ExprIf);
+impl_expression_has_ty!(ast::ExprDict);
+impl_expression_has_ty!(ast::ExprSet);
+impl_expression_has_ty!(ast::ExprListComp);
+impl_expression_has_ty!(ast::ExprSetComp);
+impl_expression_has_ty!(ast::ExprDictComp);
+impl_expression_has_ty!(ast::ExprGenerator);
+impl_expression_has_ty!(ast::ExprAwait);
+impl_expression_has_ty!(ast::ExprYield);
+impl_expression_has_ty!(ast::ExprYieldFrom);
+impl_expression_has_ty!(ast::ExprCompare);
+impl_expression_has_ty!(ast::ExprCall);
+impl_expression_has_ty!(ast::ExprFString);
+impl_expression_has_ty!(ast::ExprStringLiteral);
+impl_expression_has_ty!(ast::ExprBytesLiteral);
+impl_expression_has_ty!(ast::ExprNumberLiteral);
+impl_expression_has_ty!(ast::ExprBooleanLiteral);
+impl_expression_has_ty!(ast::ExprNoneLiteral);
+impl_expression_has_ty!(ast::ExprEllipsisLiteral);
+impl_expression_has_ty!(ast::ExprAttribute);
+impl_expression_has_ty!(ast::ExprSubscript);
+impl_expression_has_ty!(ast::ExprStarred);
+impl_expression_has_ty!(ast::ExprName);
+impl_expression_has_ty!(ast::ExprList);
+impl_expression_has_ty!(ast::ExprTuple);
+impl_expression_has_ty!(ast::ExprSlice);
+impl_expression_has_ty!(ast::ExprIpyEscapeCommand);
+
+impl HasTy for ast::Expr {
+    fn ty<'db>(&self, model: &SemanticModel<'db>) -> Type<'db> {
+        match self {
+            Expr::BoolOp(inner) => inner.ty(model),
+            Expr::Named(inner) => inner.ty(model),
+            Expr::BinOp(inner) => inner.ty(model),
+            Expr::UnaryOp(inner) => inner.ty(model),
+            Expr::Lambda(inner) => inner.ty(model),
+            Expr::If(inner) => inner.ty(model),
+            Expr::Dict(inner) => inner.ty(model),
+            Expr::Set(inner) => inner.ty(model),
+            Expr::ListComp(inner) => inner.ty(model),
+            Expr::SetComp(inner) => inner.ty(model),
+            Expr::DictComp(inner) => inner.ty(model),
+            Expr::Generator(inner) => inner.ty(model),
+            Expr::Await(inner) => inner.ty(model),
+            Expr::Yield(inner) => inner.ty(model),
+            Expr::YieldFrom(inner) => inner.ty(model),
+            Expr::Compare(inner) => inner.ty(model),
+            Expr::Call(inner) => inner.ty(model),
+            Expr::FString(inner) => inner.ty(model),
+            Expr::StringLiteral(inner) => inner.ty(model),
+            Expr::BytesLiteral(inner) => inner.ty(model),
+            Expr::NumberLiteral(inner) => inner.ty(model),
+            Expr::BooleanLiteral(inner) => inner.ty(model),
+            Expr::NoneLiteral(inner) => inner.ty(model),
+            Expr::EllipsisLiteral(inner) => inner.ty(model),
+            Expr::Attribute(inner) => inner.ty(model),
+            Expr::Subscript(inner) => inner.ty(model),
+            Expr::Starred(inner) => inner.ty(model),
+            Expr::Name(inner) => inner.ty(model),
+            Expr::List(inner) => inner.ty(model),
+            Expr::Tuple(inner) => inner.ty(model),
+            Expr::Slice(inner) => inner.ty(model),
+            Expr::IpyEscapeCommand(inner) => inner.ty(model),
+        }
+    }
+}
+
+impl HasTy for ast::StmtFunctionDef {
+    fn ty<'db>(&self, model: &SemanticModel<'db>) -> Type<'db> {
+        let index = semantic_index(model.db, model.file);
+        let definition_scope = index.definition_scope(NodeWithScopeKey::from(self));
+
+        // SAFETY: A function always has either an enclosing module, function or class scope.
+        let mut parent_scope_id = index.parent_scope_id(definition_scope).unwrap();
+        let parent_scope = index.scope(parent_scope_id);
+
+        if parent_scope.kind() == ScopeKind::Annotation {
+            parent_scope_id = index.parent_scope_id(parent_scope_id).unwrap();
+        }
+
+        let scope = parent_scope_id.to_scope_id(model.db, model.file);
+
+        let types = infer_types(model.db, scope);
+        let definition =
+            Definition::FunctionDef(self.scoped_ast_id(model.db, model.file, parent_scope_id));
+
+        types.definition_ty(definition)
+    }
+}
+
+impl HasTy for StmtClassDef {
+    fn ty<'db>(&self, model: &SemanticModel<'db>) -> Type<'db> {
+        let index = semantic_index(model.db, model.file);
+        let definition_scope = index.definition_scope(NodeWithScopeKey::from(self));
+
+        // SAFETY: A class always has either an enclosing module, function or class scope.
+        let mut parent_scope_id = index.parent_scope_id(definition_scope).unwrap();
+        let parent_scope = index.scope(parent_scope_id);
+
+        if parent_scope.kind() == ScopeKind::Annotation {
+            parent_scope_id = index.parent_scope_id(parent_scope_id).unwrap();
+        }
+
+        let scope = parent_scope_id.to_scope_id(model.db, model.file);
+
+        let types = infer_types(model.db, scope);
+        let definition =
+            Definition::ClassDef(self.scoped_ast_id(model.db, model.file, parent_scope_id));
+
+        types.definition_ty(definition)
+    }
+}

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -144,7 +144,7 @@ impl<'db> Type<'db> {
             Type::Any => Some(Type::Any),
             Type::Never => todo!("attribute lookup on Never type"),
             Type::Unknown => Some(Type::Unknown),
-            Type::Unbound => todo!("attribute lookup on Unbound type"),
+            Type::Unbound => None,
             Type::None => todo!("attribute lookup on None type"),
             Type::Function(_) => todo!("attribute lookup on Function type"),
             Type::Module(module) => module.member(context, name),

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -1,12 +1,10 @@
-use salsa::DebugWithDb;
-
 use ruff_db::parsed::parsed_module;
 use ruff_db::vfs::VfsFile;
 use ruff_index::newtype_index;
 use ruff_python_ast as ast;
 
 use crate::name::Name;
-use crate::semantic_index::ast_ids::{AstIdNode, ScopeAstIdNode};
+use crate::semantic_index::ast_ids::AstIdNode;
 use crate::semantic_index::symbol::{FileScopeId, PublicSymbolId, ScopeId};
 use crate::semantic_index::{
     public_symbol, root_scope, semantic_index, symbol_table, NodeWithScopeId,
@@ -17,28 +15,6 @@ use crate::FxIndexSet;
 
 mod display;
 mod infer;
-
-/// Infers the type of `expr`.
-///
-/// Calling this function from a salsa query adds a dependency on [`semantic_index`]
-/// which changes with every AST change. That's why you should only call
-/// this function for the current file that's being analyzed and not for
-/// a dependency (or the query reruns whenever a dependency change).
-///
-/// Prefer [`public_symbol_ty`] when resolving the type of symbol from another file.
-#[tracing::instrument(level = "debug", skip(db))]
-pub(crate) fn expression_ty<'db>(
-    db: &'db dyn Db,
-    file: VfsFile,
-    expression: &ast::Expr,
-) -> Type<'db> {
-    let index = semantic_index(db, file);
-    let file_scope = index.expression_scope_id(expression);
-    let expression_id = expression.scope_ast_id(db, file, file_scope);
-    let scope = file_scope.to_scope_id(db, file);
-
-    infer_types(db, scope).expression_ty(expression_id)
-}
 
 /// Infers the type of a public symbol.
 ///
@@ -66,7 +42,7 @@ pub(crate) fn expression_ty<'db>(
 /// This being a query ensures that the invalidation short-circuits if the type of this symbol didn't change.
 #[salsa::tracked]
 pub(crate) fn public_symbol_ty<'db>(db: &'db dyn Db, symbol: PublicSymbolId<'db>) -> Type<'db> {
-    let _ = tracing::trace_span!("public_symbol_ty", symbol = ?symbol.debug(db)).enter();
+    let _span = tracing::trace_span!("public_symbol_ty", ?symbol).entered();
 
     let file = symbol.file(db);
     let scope = root_scope(db, file);
@@ -88,7 +64,7 @@ pub fn public_symbol_ty_by_name<'db>(
 /// Infers all types for `scope`.
 #[salsa::tracked(return_ref)]
 pub(crate) fn infer_types<'db>(db: &'db dyn Db, scope: ScopeId<'db>) -> TypeInference<'db> {
-    let _ = tracing::trace_span!("infer_types", scope = ?scope.debug(db)).enter();
+    let _span = tracing::trace_span!("infer_types", ?scope).entered();
 
     let file = scope.file(db);
     // Using the index here is fine because the code below depends on the AST anyway.
@@ -271,6 +247,18 @@ impl<'a> FunctionType<'a> {
     }
 }
 
+impl<'db> TypeId<'db, ScopedFunctionTypeId> {
+    pub fn name<'a>(self, context: &'a TypingContext<'db, 'a>) -> &'a Name {
+        let function_ty = self.lookup(context);
+        &function_ty.name
+    }
+
+    pub fn has_decorator(self, context: &TypingContext, decorator: Type<'db>) -> bool {
+        let function_ty = self.lookup(context);
+        function_ty.decorators.contains(&decorator)
+    }
+}
+
 #[newtype_index]
 pub struct ScopedClassTypeId;
 
@@ -283,14 +271,42 @@ impl ScopedTypeId for ScopedClassTypeId {
 }
 
 impl<'db> TypeId<'db, ScopedClassTypeId> {
+    pub fn name<'a>(self, context: &'a TypingContext<'db, 'a>) -> &'a Name {
+        let class_ty = self.lookup(context);
+        &class_ty.name
+    }
+
     /// Returns the class member of this class named `name`.
     ///
     /// The member resolves to a member of the class itself or any of its bases.
-    fn class_member(self, context: &TypingContext<'db, '_>, name: &Name) -> Option<Type<'db>> {
+    pub fn class_member(self, context: &TypingContext<'db, '_>, name: &Name) -> Option<Type<'db>> {
         if let Some(member) = self.own_class_member(context, name) {
             return Some(member);
         }
 
+        self.inherited_class_member(context, name)
+    }
+
+    /// Returns the inferred type of the class member named `name`.
+    pub fn own_class_member(
+        self,
+        context: &TypingContext<'db, '_>,
+        name: &Name,
+    ) -> Option<Type<'db>> {
+        let class = self.lookup(context);
+
+        let symbols = symbol_table(context.db, class.body_scope);
+        let symbol = symbols.symbol_id_by_name(name)?;
+        let types = context.types(class.body_scope);
+
+        Some(types.symbol_ty(symbol))
+    }
+
+    pub fn inherited_class_member(
+        self,
+        context: &TypingContext<'db, '_>,
+        name: &Name,
+    ) -> Option<Type<'db>> {
         let class = self.lookup(context);
         for base in &class.bases {
             if let Some(member) = base.member(context, name) {
@@ -299,17 +315,6 @@ impl<'db> TypeId<'db, ScopedClassTypeId> {
         }
 
         None
-    }
-
-    /// Returns the inferred type of the class member named `name`.
-    fn own_class_member(self, context: &TypingContext<'db, '_>, name: &Name) -> Option<Type<'db>> {
-        let class = self.lookup(context);
-
-        let symbols = symbol_table(context.db, class.body_scope);
-        let symbol = symbols.symbol_id_by_name(name)?;
-        let types = context.types(class.body_scope);
-
-        Some(types.symbol_ty(symbol))
     }
 }
 
@@ -506,6 +511,7 @@ impl<'db, 'inference> TypingContext<'db, 'inference> {
 
 #[cfg(test)]
 mod tests {
+    use red_knot_module_resolver::{set_module_resolution_settings, ModuleResolutionSettings};
     use ruff_db::file_system::FileSystemPathBuf;
     use ruff_db::parsed::parsed_module;
     use ruff_db::vfs::system_path_to_file;
@@ -514,8 +520,8 @@ mod tests {
         assert_will_not_run_function_query, assert_will_run_function_query, TestDb,
     };
     use crate::semantic_index::root_scope;
-    use crate::types::{expression_ty, infer_types, public_symbol_ty_by_name, TypingContext};
-    use red_knot_module_resolver::{set_module_resolution_settings, ModuleResolutionSettings};
+    use crate::types::{infer_types, public_symbol_ty_by_name, TypingContext};
+    use crate::{HasTy, SemanticModel};
 
     fn setup_db() -> TestDb {
         let mut db = TestDb::new();
@@ -542,8 +548,9 @@ mod tests {
         let parsed = parsed_module(&db, a);
 
         let statement = parsed.suite().first().unwrap().as_assign_stmt().unwrap();
+        let model = SemanticModel::new(&db, a);
 
-        let literal_ty = expression_ty(&db, a, &statement.value);
+        let literal_ty = statement.value.ty(&model);
 
         assert_eq!(
             format!("{}", literal_ty.display(&TypingContext::global(&db))),

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -10,14 +10,14 @@ use ruff_python_ast as ast;
 use ruff_python_ast::{ExprContext, TypeParams};
 
 use crate::name::Name;
-use crate::semantic_index::ast_ids::{ScopeAstIdNode, ScopeExpressionId};
+use crate::semantic_index::ast_ids::{HasScopedAstId, ScopedExpressionId};
 use crate::semantic_index::definition::{Definition, ImportDefinition, ImportFromDefinition};
 use crate::semantic_index::symbol::{FileScopeId, ScopeId, ScopeKind, ScopedSymbolId, SymbolTable};
 use crate::semantic_index::{symbol_table, ChildrenIter, SemanticIndex};
 use crate::types::{
-    ClassType, FunctionType, IntersectionType, ModuleType, ScopedClassTypeId, ScopedFunctionTypeId,
-    ScopedIntersectionTypeId, ScopedUnionTypeId, Type, TypeId, TypingContext, UnionType,
-    UnionTypeBuilder,
+    infer_types, ClassType, FunctionType, IntersectionType, ModuleType, ScopedClassTypeId,
+    ScopedFunctionTypeId, ScopedIntersectionTypeId, ScopedUnionTypeId, Type, TypeId, TypingContext,
+    UnionType, UnionTypeBuilder,
 };
 use crate::Db;
 
@@ -37,15 +37,18 @@ pub(crate) struct TypeInference<'db> {
     intersection_types: IndexVec<ScopedIntersectionTypeId, IntersectionType<'db>>,
 
     /// The types of every expression in this scope.
-    expression_tys: IndexVec<ScopeExpressionId, Type<'db>>,
+    expression_tys: IndexVec<ScopedExpressionId, Type<'db>>,
 
     /// The public types of every symbol in this scope.
     symbol_tys: IndexVec<ScopedSymbolId, Type<'db>>,
+
+    /// The type of a definition.
+    definition_tys: FxHashMap<Definition, Type<'db>>,
 }
 
 impl<'db> TypeInference<'db> {
     #[allow(unused)]
-    pub(super) fn expression_ty(&self, expression: ScopeExpressionId) -> Type<'db> {
+    pub(crate) fn expression_ty(&self, expression: ScopedExpressionId) -> Type<'db> {
         self.expression_tys[expression]
     }
 
@@ -73,6 +76,10 @@ impl<'db> TypeInference<'db> {
         &self.intersection_types[id]
     }
 
+    pub(crate) fn definition_ty(&self, definition: Definition) -> Type<'db> {
+        self.definition_tys[&definition]
+    }
+
     fn shrink_to_fit(&mut self) {
         self.class_types.shrink_to_fit();
         self.function_types.shrink_to_fit();
@@ -81,6 +88,7 @@ impl<'db> TypeInference<'db> {
 
         self.expression_tys.shrink_to_fit();
         self.symbol_tys.shrink_to_fit();
+        self.definition_tys.shrink_to_fit();
     }
 }
 
@@ -97,7 +105,6 @@ pub(super) struct TypeInferenceBuilder<'a> {
 
     /// The type inference results
     types: TypeInference<'a>,
-    definition_tys: FxHashMap<Definition, Type<'a>>,
     children_scopes: ChildrenIter<'a>,
 }
 
@@ -118,7 +125,6 @@ impl<'db> TypeInferenceBuilder<'db> {
 
             db,
             types: TypeInference::default(),
-            definition_tys: FxHashMap::default(),
             children_scopes,
         }
     }
@@ -186,7 +192,7 @@ impl<'db> TypeInferenceBuilder<'db> {
             decorator_list,
         } = function;
 
-        let function_id = function.scope_ast_id(self.db, self.file_id, self.file_scope_id);
+        let function_id = function.scoped_ast_id(self.db, self.file_id, self.file_scope_id);
         let decorator_tys = decorator_list
             .iter()
             .map(|decorator| self.infer_decorator(decorator))
@@ -211,7 +217,8 @@ impl<'db> TypeInferenceBuilder<'db> {
             ScopeKind::Function | ScopeKind::Annotation
         ));
 
-        self.definition_tys
+        self.types
+            .definition_tys
             .insert(Definition::FunctionDef(function_id), function_ty);
     }
 
@@ -225,7 +232,7 @@ impl<'db> TypeInferenceBuilder<'db> {
             body: _,
         } = class;
 
-        let class_id = class.scope_ast_id(self.db, self.file_id, self.file_scope_id);
+        let class_id = class.scoped_ast_id(self.db, self.file_id, self.file_scope_id);
 
         for decorator in decorator_list {
             self.infer_decorator(decorator);
@@ -253,7 +260,8 @@ impl<'db> TypeInferenceBuilder<'db> {
             body_scope: class_body_scope_id.to_scope_id(self.db, self.file_id),
         });
 
-        self.definition_tys
+        self.types
+            .definition_tys
             .insert(Definition::ClassDef(class_id), class_ty);
     }
 
@@ -296,10 +304,11 @@ impl<'db> TypeInferenceBuilder<'db> {
             self.infer_expression(target);
         }
 
-        let assign_id = assignment.scope_ast_id(self.db, self.file_id, self.file_scope_id);
+        let assign_id = assignment.scoped_ast_id(self.db, self.file_id, self.file_scope_id);
 
         // TODO: Handle multiple targets.
-        self.definition_tys
+        self.types
+            .definition_tys
             .insert(Definition::Assignment(assign_id), value_ty);
     }
 
@@ -319,8 +328,8 @@ impl<'db> TypeInferenceBuilder<'db> {
         let annotation_ty = self.infer_expression(annotation);
         self.infer_expression(target);
 
-        self.definition_tys.insert(
-            Definition::AnnotatedAssignment(assignment.scope_ast_id(
+        self.types.definition_tys.insert(
+            Definition::AnnotatedAssignment(assignment.scoped_ast_id(
                 self.db,
                 self.file_id,
                 self.file_scope_id,
@@ -348,7 +357,7 @@ impl<'db> TypeInferenceBuilder<'db> {
     fn infer_import_statement(&mut self, import: &ast::StmtImport) {
         let ast::StmtImport { range: _, names } = import;
 
-        let import_id = import.scope_ast_id(self.db, self.file_id, self.file_scope_id);
+        let import_id = import.scoped_ast_id(self.db, self.file_id, self.file_scope_id);
 
         for (i, alias) in names.iter().enumerate() {
             let ast::Alias {
@@ -363,7 +372,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                 .map(|module| self.typing_context().module_ty(module.file()))
                 .unwrap_or(Type::Unknown);
 
-            self.definition_tys.insert(
+            self.types.definition_tys.insert(
                 Definition::Import(ImportDefinition {
                     import_id,
                     alias: u32::try_from(i).unwrap(),
@@ -381,7 +390,7 @@ impl<'db> TypeInferenceBuilder<'db> {
             level: _,
         } = import;
 
-        let import_id = import.scope_ast_id(self.db, self.file_id, self.file_scope_id);
+        let import_id = import.scoped_ast_id(self.db, self.file_id, self.file_scope_id);
         let module_name = ModuleName::new(module.as_deref().expect("Support relative imports"));
 
         let module =
@@ -401,7 +410,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                 .member(&self.typing_context(), &Name::new(&name.id))
                 .unwrap_or(Type::Unknown);
 
-            self.definition_tys.insert(
+            self.types.definition_tys.insert(
                 Definition::ImportFrom(ImportFromDefinition {
                     import_id,
                     name: u32::try_from(i).unwrap(),
@@ -483,8 +492,8 @@ impl<'db> TypeInferenceBuilder<'db> {
         let value_ty = self.infer_expression(value);
         self.infer_expression(target);
 
-        self.definition_tys.insert(
-            Definition::NamedExpr(named.scope_ast_id(self.db, self.file_id, self.file_scope_id)),
+        self.types.definition_tys.insert(
+            Definition::NamedExpr(named.scoped_ast_id(self.db, self.file_id, self.file_scope_id)),
             value_ty,
         );
 
@@ -531,11 +540,12 @@ impl<'db> TypeInferenceBuilder<'db> {
                         // TODO: Skip over class scopes unless the they are a immediately-nested type param scope.
                         // TODO: Support built-ins
 
-                        let symbol_table =
-                            symbol_table(self.db, ancestor_id.to_scope_id(self.db, self.file_id));
+                        let ancestor_scope = ancestor_id.to_scope_id(self.db, self.file_id);
+                        let symbol_table = symbol_table(self.db, ancestor_scope);
 
-                        if let Some(_symbol_id) = symbol_table.symbol_id_by_name(id) {
-                            todo!("Return type for symbol from outer scope");
+                        if let Some(symbol_id) = symbol_table.symbol_id_by_name(id) {
+                            let types = infer_types(self.db, ancestor_scope);
+                            return types.symbol_ty(symbol_id);
                         }
                     }
                     Type::Unknown
@@ -667,7 +677,7 @@ impl<'db> TypeInferenceBuilder<'db> {
         let mut definitions = symbol
             .definitions()
             .iter()
-            .filter_map(|definition| self.definition_tys.get(definition).copied());
+            .filter_map(|definition| self.types.definition_tys.get(definition).copied());
 
         let Some(first) = definitions.next() else {
             return Type::Unbound;

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -11,7 +11,7 @@ use ruff_python_ast::{ExprContext, TypeParams};
 
 use crate::name::Name;
 use crate::semantic_index::ast_ids::{HasScopedAstId, ScopedExpressionId};
-use crate::semantic_index::definition::{Definition, ImportDefinition, ImportFromDefinition};
+use crate::semantic_index::definition::Definition;
 use crate::semantic_index::symbol::{FileScopeId, ScopeId, ScopeKind, ScopedSymbolId, SymbolTable};
 use crate::semantic_index::{symbol_table, ChildrenIter, SemanticIndex};
 use crate::types::{
@@ -301,15 +301,14 @@ impl<'db> TypeInferenceBuilder<'db> {
         let value_ty = self.infer_expression(value);
 
         for target in targets {
+            let target_id = target.scoped_ast_id(self.db, self.file_id, self.file_scope_id);
+
             self.infer_expression(target);
+
+            self.types
+                .definition_tys
+                .insert(Definition::Target(target_id), value_ty);
         }
-
-        let assign_id = assignment.scoped_ast_id(self.db, self.file_id, self.file_scope_id);
-
-        // TODO: Handle multiple targets.
-        self.types
-            .definition_tys
-            .insert(Definition::Assignment(assign_id), value_ty);
     }
 
     fn infer_annotated_assignment_statement(&mut self, assignment: &ast::StmtAnnAssign) {
@@ -328,14 +327,11 @@ impl<'db> TypeInferenceBuilder<'db> {
         let annotation_ty = self.infer_expression(annotation);
         self.infer_expression(target);
 
-        self.types.definition_tys.insert(
-            Definition::AnnotatedAssignment(assignment.scoped_ast_id(
-                self.db,
-                self.file_id,
-                self.file_scope_id,
-            )),
-            annotation_ty,
-        );
+        let target_id = target.scoped_ast_id(self.db, self.file_id, self.file_scope_id);
+
+        self.types
+            .definition_tys
+            .insert(Definition::Target(target_id), annotation_ty);
     }
 
     fn infer_for_statement(&mut self, for_statement: &ast::StmtFor) {
@@ -357,9 +353,7 @@ impl<'db> TypeInferenceBuilder<'db> {
     fn infer_import_statement(&mut self, import: &ast::StmtImport) {
         let ast::StmtImport { range: _, names } = import;
 
-        let import_id = import.scoped_ast_id(self.db, self.file_id, self.file_scope_id);
-
-        for (i, alias) in names.iter().enumerate() {
+        for alias in names {
             let ast::Alias {
                 range: _,
                 name,
@@ -372,13 +366,11 @@ impl<'db> TypeInferenceBuilder<'db> {
                 .map(|module| self.typing_context().module_ty(module.file()))
                 .unwrap_or(Type::Unknown);
 
-            self.types.definition_tys.insert(
-                Definition::Import(ImportDefinition {
-                    import_id,
-                    alias: u32::try_from(i).unwrap(),
-                }),
-                module_ty,
-            );
+            let definition_id = alias.scoped_ast_id(self.db, self.file_id, self.file_scope_id);
+
+            self.types
+                .definition_tys
+                .insert(Definition::ImportAlias(definition_id), module_ty);
         }
     }
 
@@ -390,7 +382,6 @@ impl<'db> TypeInferenceBuilder<'db> {
             level: _,
         } = import;
 
-        let import_id = import.scoped_ast_id(self.db, self.file_id, self.file_scope_id);
         let module_name = ModuleName::new(module.as_deref().expect("Support relative imports"));
 
         let module =
@@ -399,7 +390,7 @@ impl<'db> TypeInferenceBuilder<'db> {
             .map(|module| self.typing_context().module_ty(module.file()))
             .unwrap_or(Type::Unknown);
 
-        for (i, alias) in names.iter().enumerate() {
+        for alias in names {
             let ast::Alias {
                 range: _,
                 name,
@@ -410,13 +401,11 @@ impl<'db> TypeInferenceBuilder<'db> {
                 .member(&self.typing_context(), &Name::new(&name.id))
                 .unwrap_or(Type::Unknown);
 
-            self.types.definition_tys.insert(
-                Definition::ImportFrom(ImportFromDefinition {
-                    import_id,
-                    name: u32::try_from(i).unwrap(),
-                }),
-                ty,
-            );
+            let definition_id = alias.scoped_ast_id(self.db, self.file_id, self.file_scope_id);
+
+            self.types
+                .definition_tys
+                .insert(Definition::ImportAlias(definition_id), ty);
         }
     }
 

--- a/crates/ruff_db/src/parsed.rs
+++ b/crates/ruff_db/src/parsed.rs
@@ -1,4 +1,3 @@
-use salsa::DebugWithDb;
 use std::fmt::Formatter;
 use std::ops::Deref;
 use std::sync::Arc;
@@ -23,7 +22,7 @@ use crate::Db;
 /// for determining if a query result is unchanged.
 #[salsa::tracked(return_ref, no_eq)]
 pub fn parsed_module(db: &dyn Db, file: VfsFile) -> ParsedModule {
-    let _ = tracing::trace_span!("parse_module", file = ?file.debug(db)).enter();
+    let _span = tracing::trace_span!("parse_module", file = ?file).entered();
 
     let source = source_text(db, file);
     let path = file.path(db);

--- a/crates/ruff_db/src/source.rs
+++ b/crates/ruff_db/src/source.rs
@@ -10,7 +10,7 @@ use crate::Db;
 /// Reads the content of file.
 #[salsa::tracked]
 pub fn source_text(db: &dyn Db, file: VfsFile) -> SourceText {
-    let _ = tracing::trace_span!("source_text", file = ?file.debug(db)).enter();
+    let _span = tracing::trace_span!("source_text", ?file).entered();
 
     let content = file.read(db);
 
@@ -22,7 +22,7 @@ pub fn source_text(db: &dyn Db, file: VfsFile) -> SourceText {
 /// Computes the [`LineIndex`] for `file`.
 #[salsa::tracked]
 pub fn line_index(db: &dyn Db, file: VfsFile) -> LineIndex {
-    let _ = tracing::trace_span!("line_index", file = ?file.debug(db)).enter();
+    let _span = tracing::trace_span!("line_index", file = ?file.debug(db)).entered();
 
     let source = source_text(db, file);
 


### PR DESCRIPTION
## Summary

This PR implements `HasTy` for `Alias` as a preparation to implement the bad-imports lint rules. 

The bad-imports lint rule tests if an import resolves to `Unbound`. This requires querying querying the type of a specific import-item. 
The way this is done in this PR is to change `AstIds` to not track `Statement`s but instead have a `Definition`s map, so that we also get IDs for import definitions (and allocate fewer IDs in total). 

## Test Plan

Implemented the `bad-overrides` lint rule on top of the  new API
