### PR TITLE
Remove usage of `std::path::absolute` from snapshot test

### DIFF
--- a/crates/ruff_server/tests/notebook.rs
+++ b/crates/ruff_server/tests/notebook.rs
@@ -22,7 +22,7 @@ struct NotebookChange {
 #[test]
 fn super_resolution_overview() {
     let file_path =
-        std::path::absolute(PathBuf::from_str(SUPER_RESOLUTION_OVERVIEW_PATH).unwrap()).unwrap();
+        std::fs::canonicalize(PathBuf::from_str(SUPER_RESOLUTION_OVERVIEW_PATH).unwrap()).unwrap();
     let file_url = lsp_types::Url::from_file_path(&file_path).unwrap();
     let notebook = create_notebook(&file_path).unwrap();
 


### PR DESCRIPTION
## Summary

Using `std::path::absolute` in the Jupyter Notebook snapshot tests broke our MSRV checks: https://github.com/astral-sh/ruff/actions/runs/9608928482/job/26502534725?pr=11959.

This PR replaces the usage of `std::path::absolute` with `std::fs::canonicalize`, which should work identically in this case.