### PR TITLE
Add Open Wine Components to "Who's Using Ruff?"

### DIFF
--- a/README.md
+++ b/README.md
@@ -442,6 +442,7 @@ Ruff is used by a number of major open-source projects and companies, including:
 - [NumPyro](https://github.com/pyro-ppl/numpyro)
 - [ONNX](https://github.com/onnx/onnx)
 - [OpenBB](https://github.com/OpenBB-finance/OpenBBTerminal)
+- [Open Wine Components](https://github.com/Open-Wine-Components/umu-launcher)
 - [PDM](https://github.com/pdm-project/pdm)
 - [PaddlePaddle](https://github.com/PaddlePaddle/Paddle)
 - [Pandas](https://github.com/pandas-dev/pandas)


### PR DESCRIPTION
umu-launcher allows clients such as Lutris to properly run games on Linux using Valve's Proton outside of the Steam client, and the project uses ruff as its linter and formatter.
