### PR TITLE
Clarify special control flow parameters for `PLR0917`: `too-many-positional`

### DIFF
--- a/crates/ruff_linter/src/rules/pylint/rules/too_many_positional.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/too_many_positional.rs
@@ -18,8 +18,8 @@ use crate::checkers::ast::Checker;
 /// readers than providing arguments by name.
 ///
 /// Consider refactoring functions with many arguments into smaller functions
-/// with fewer arguments, using objects to group related arguments, or
-/// migrating to keyword-only arguments.
+/// with fewer arguments, using objects to group related arguments, or migrating to
+/// [keyword-only arguments](https://docs.python.org/3/tutorial/controlflow.html#special-parameters).
 ///
 /// ## Example
 /// ```python


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Adds a hyperlink to the Python 3 tutorial on special control flow parameters to the docs of the `too-many-positional` rule.

Fixes #11868.

## Test Plan

<!-- How was it tested? -->

Docs were built locally as described [here](https://docs.astral.sh/ruff/contributing/#mkdocs).