### PR TITLE
docs(integrations): fix link to `python-lsp-server`

### DIFF
--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -100,7 +100,7 @@ To use `ruff-lsp` with other editors, including Sublime Text and Helix, see the 
 ## Language Server Protocol (Unofficial)
 
 Ruff is also available as the [`python-lsp-ruff`](https://github.com/python-lsp/python-lsp-ruff)
-plugin for [`python-lsp-server`](https://github.com/python-lsp/python-lsp-ruff), both of which are
+plugin for [`python-lsp-server`](https://github.com/python-lsp/python-lsp-server), both of which are
 installable from PyPI:
 
 ```shell


### PR DESCRIPTION
## Summary

In the section "Language Server Protocol (Unofficial)" in the integration docs there is a link to `python-lsp-server` that currently links to the `python-lsp-ruff` repo. This PR updates the link to the `python-lsp-server` repo.

## Test Plan

By clicking the link in the doc :-)

