### PR TITLE
[red-knot] Use POSIX representations of paths when creating the typeshed zip file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1997,6 +1997,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "insta",
+ "path-slash",
  "ruff_db",
  "ruff_python_stdlib",
  "rustc-hash",

--- a/crates/red_knot_module_resolver/Cargo.toml
+++ b/crates/red_knot_module_resolver/Cargo.toml
@@ -21,12 +21,14 @@ tracing = { workspace = true }
 zip = { workspace = true }
 
 [build-dependencies]
+path-slash = { workspace = true }
 walkdir = { workspace = true }
 zip = { workspace = true }
 
 [dev-dependencies]
 anyhow = { workspace = true }
 insta = { workspace = true }
+path-slash = { workspace = true }
 tempfile = { workspace = true }
 
 [lints]

--- a/crates/red_knot_module_resolver/Cargo.toml
+++ b/crates/red_knot_module_resolver/Cargo.toml
@@ -28,7 +28,6 @@ zip = { workspace = true }
 [dev-dependencies]
 anyhow = { workspace = true }
 insta = { workspace = true }
-path-slash = { workspace = true }
 tempfile = { workspace = true }
 
 [lints]

--- a/crates/red_knot_module_resolver/src/typeshed.rs
+++ b/crates/red_knot_module_resolver/src/typeshed.rs
@@ -5,6 +5,8 @@ mod tests {
     use std::io::{self, Read};
     use std::path::Path;
 
+    use path_slash::PathExt;
+
     #[test]
     fn typeshed_zip_created_at_build_time() -> anyhow::Result<()> {
         // The file path here is hardcoded in this crate's `build.rs` script.
@@ -16,7 +18,7 @@ mod tests {
 
         let path_to_functools = Path::new("stdlib").join("functools.pyi");
         let mut functools_module_stub = typeshed_zip_archive
-            .by_name(path_to_functools.to_str().unwrap())
+            .by_name(&path_to_functools.to_slash().unwrap())
             .unwrap();
         assert!(functools_module_stub.is_file());
 

--- a/crates/red_knot_module_resolver/src/typeshed.rs
+++ b/crates/red_knot_module_resolver/src/typeshed.rs
@@ -3,9 +3,6 @@ pub(crate) mod versions;
 #[cfg(test)]
 mod tests {
     use std::io::{self, Read};
-    use std::path::Path;
-
-    use path_slash::PathExt;
 
     #[test]
     fn typeshed_zip_created_at_build_time() -> anyhow::Result<()> {
@@ -16,9 +13,8 @@ mod tests {
 
         let mut typeshed_zip_archive = zip::ZipArchive::new(io::Cursor::new(TYPESHED_ZIP_BYTES))?;
 
-        let path_to_functools = Path::new("stdlib").join("functools.pyi");
         let mut functools_module_stub = typeshed_zip_archive
-            .by_name(&path_to_functools.to_slash().unwrap())
+            .by_name("stdlib/functools.pyi")
             .unwrap();
         assert!(functools_module_stub.is_file());
 


### PR DESCRIPTION
## Summary

This PR fixes the bug that caused the tests added in https://github.com/astral-sh/ruff/pull/11970 to fail. In the higher-level `ruff_db::vendored::VendoredFileSystem` abstraction we use for querying whether files exist in the zip file, all paths are normalized to use POSIX path separators before they're looked up in the underlying zip archive. But when we're creating the zip archive in `build.rs`, we're currently just using the operating system's default path separator (`\\` on Windows!). If we normalize the path separator in the `ruff_db` abstractions, we need to also do so in `build.rs`.

## Test Plan

`cargo test -p red_knot_module_resolver` still passes for me on macOS; hopefully it will also pass on Windows in CI. I'm pretty confident this is the cause of the test failures we saw on https://github.com/astral-sh/ruff/pull/11970: in a PR to my fork here, I added some debug prints so we could figure out what was going on with Windows, and you can see that the zip file on Windows has paths such as `stdlib\\abc.pyi` instead of `stdlib/abc.pyi`: https://github.com/AlexWaygood/ruff/pull/10.