### PR TITLE
[red-knot] Manually implement `Debug` for `VendoredFileSystem`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2202,6 +2202,7 @@ dependencies = [
  "countme",
  "dashmap",
  "filetime",
+ "insta",
  "once_cell",
  "ruff_python_ast",
  "ruff_python_parser",

--- a/crates/ruff_db/Cargo.toml
+++ b/crates/ruff_db/Cargo.toml
@@ -26,4 +26,5 @@ rustc-hash = { workspace = true }
 zip = { workspace = true }
 
 [dev-dependencies]
+insta = { workspace = true }
 once_cell = { workspace = true }


### PR DESCRIPTION
I temporarily added this in a PR to my fork so I could debug some test failures on Windows that were a result of paths not being normalized when the zip archive was being created at build time. It seems like it could be a useful method to have around generally, in case we need to debug similar issues in the future.