### PR TITLE
Update PEP reference in future_rewritable_type_annotation.rs

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_future_annotations/rules/future_rewritable_type_annotation.rs
+++ b/crates/ruff_linter/src/rules/flake8_future_annotations/rules/future_rewritable_type_annotation.rs
@@ -12,7 +12,7 @@ use crate::checkers::ast::Checker;
 /// PEP 563.
 ///
 /// ## Why is this bad?
-/// PEP 563 enabled the use of a number of convenient type annotations, such as
+/// PEP 585 enabled the use of a number of convenient type annotations, such as
 /// `list[str]` instead of `List[str]`. However, these annotations are only
 /// available on Python 3.9 and higher, _unless_ the `from __future__ import annotations`
 /// import is present.


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Documentation mentions:

> PEP 563 enabled the use of a number of convenient type annotations, such as `list[str]` instead of `List[str]`

but it meant [PEP 585](https://peps.python.org/pep-0585/) instead.

[PEP 563](https://peps.python.org/pep-0563/) is the one defining `from __future__ import annotations`.

## Test Plan

No automated test required, just verify that https://peps.python.org/pep-0585/ is the correct reference.
