### PR TITLE
[red-knot] Once again, add more tests asserting that the `VendoredFileSystem` and the `VERSIONS` parser work with the vendored typeshed stubs

### DIFF
--- a/crates/red_knot_module_resolver/Cargo.toml
+++ b/crates/red_knot_module_resolver/Cargo.toml
@@ -28,7 +28,6 @@ zip = { workspace = true }
 [dev-dependencies]
 anyhow = { workspace = true }
 insta = { workspace = true }
-path-slash = { workspace = true }
 tempfile = { workspace = true }
 walkdir = { workspace = true }
 

--- a/crates/red_knot_module_resolver/Cargo.toml
+++ b/crates/red_knot_module_resolver/Cargo.toml
@@ -28,7 +28,9 @@ zip = { workspace = true }
 [dev-dependencies]
 anyhow = { workspace = true }
 insta = { workspace = true }
+path-slash = { workspace = true }
 tempfile = { workspace = true }
+walkdir = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/red_knot_module_resolver/src/typeshed.rs
+++ b/crates/red_knot_module_resolver/src/typeshed.rs
@@ -3,6 +3,7 @@ pub(crate) mod versions;
 #[cfg(test)]
 mod tests {
     use std::io::{self, Read};
+    use std::path::Path;
 
     use path_slash::PathExt;
 
@@ -58,13 +59,25 @@ mod tests {
 
             assert!(
                 vendored_typeshed_stubs.exists(vendored_path),
-                "Expected {vendored_path:?} to exist in the `VendoredFileSystem`!"
+                "Expected {vendored_path:?} to exist in the `VendoredFileSystem`!
+
+                Vendored file system:
+
+                {vendored_typeshed_stubs:#?}
+                "
             );
 
             let vendored_path_kind = vendored_typeshed_stubs
                 .metadata(vendored_path)
                 .unwrap_or_else(|| {
-                    panic!("Expected metadata for {vendored_path:?} to be retrievable from the `VendoredFileSystem!")
+                    panic!(
+                        "Expected metadata for {vendored_path:?} to be retrievable from the `VendoredFileSystem!
+
+                        Vendored file system:
+
+                        {vendored_typeshed_stubs:#?}
+                        "
+                    )
                 })
                 .kind();
 

--- a/crates/red_knot_module_resolver/src/typeshed.rs
+++ b/crates/red_knot_module_resolver/src/typeshed.rs
@@ -4,14 +4,20 @@ pub(crate) mod versions;
 mod tests {
     use std::io::{self, Read};
 
-    #[test]
-    fn typeshed_zip_created_at_build_time() -> anyhow::Result<()> {
-        // The file path here is hardcoded in this crate's `build.rs` script.
-        // Luckily this crate will fail to build if this file isn't available at build time.
-        const TYPESHED_ZIP_BYTES: &[u8] =
-            include_bytes!(concat!(env!("OUT_DIR"), "/zipped_typeshed.zip"));
+    use path_slash::PathExt;
 
-        let mut typeshed_zip_archive = zip::ZipArchive::new(io::Cursor::new(TYPESHED_ZIP_BYTES))?;
+    use ruff_db::vendored::VendoredFileSystem;
+    use ruff_db::vfs::VendoredPath;
+
+    // The file path here is hardcoded in this crate's `build.rs` script.
+    // Luckily this crate will fail to build if this file isn't available at build time.
+    const TYPESHED_ZIP_BYTES: &[u8] =
+        include_bytes!(concat!(env!("OUT_DIR"), "/zipped_typeshed.zip"));
+
+    #[test]
+    fn typeshed_zip_created_at_build_time() {
+        let mut typeshed_zip_archive =
+            zip::ZipArchive::new(io::Cursor::new(TYPESHED_ZIP_BYTES)).unwrap();
 
         let mut functools_module_stub = typeshed_zip_archive
             .by_name("stdlib/functools.pyi")
@@ -19,9 +25,59 @@ mod tests {
         assert!(functools_module_stub.is_file());
 
         let mut functools_module_stub_source = String::new();
-        functools_module_stub.read_to_string(&mut functools_module_stub_source)?;
+        functools_module_stub
+            .read_to_string(&mut functools_module_stub_source)
+            .unwrap();
 
         assert!(functools_module_stub_source.contains("def update_wrapper("));
-        Ok(())
+    }
+
+    #[test]
+    fn typeshed_vfs_consistent_with_vendored_stubs() {
+        let vendored_typeshed_dir = Path::new("vendor/typeshed").canonicalize().unwrap();
+        let vendored_typeshed_stubs = VendoredFileSystem::new(TYPESHED_ZIP_BYTES).unwrap();
+
+        let mut empty_iterator = true;
+        for entry in walkdir::WalkDir::new(&vendored_typeshed_dir).min_depth(1) {
+            empty_iterator = false;
+            let entry = entry.unwrap();
+            let absolute_path = entry.path();
+            let file_type = entry.file_type();
+
+            let relative_path = absolute_path
+                .strip_prefix(&vendored_typeshed_dir)
+                .unwrap_or_else(|_| {
+                    panic!("Expected {absolute_path:?} to be a child of {vendored_typeshed_dir:?}")
+                });
+
+            let posix_style_path = relative_path
+                .to_slash()
+                .unwrap_or_else(|| panic!("Expected {relative_path:?} to be a valid UTF-8 path"));
+
+            let vendored_path = VendoredPath::new(&*posix_style_path);
+
+            assert!(
+                vendored_typeshed_stubs.exists(vendored_path),
+                "Expected {vendored_path:?} to exist in the `VendoredFileSystem`!"
+            );
+
+            let vendored_path_kind = vendored_typeshed_stubs
+                .metadata(vendored_path)
+                .unwrap_or_else(|| {
+                    panic!("Expected metadata for {vendored_path:?} to be retrievable from the `VendoredFileSystem!")
+                })
+                .kind();
+
+            assert_eq!(
+                vendored_path_kind.is_directory(),
+                file_type.is_dir(),
+                "{vendored_path:?} had type {vendored_path_kind:?}, inconsistent with fs path {relative_path:?}: {file_type:?}"
+            );
+        }
+
+        assert!(
+            !empty_iterator,
+            "Expected there to be at least one file or directory in the vendored typeshed stubs!"
+        );
     }
 }

--- a/crates/red_knot_module_resolver/src/typeshed.rs
+++ b/crates/red_knot_module_resolver/src/typeshed.rs
@@ -5,8 +5,6 @@ mod tests {
     use std::io::{self, Read};
     use std::path::Path;
 
-    use path_slash::PathExt;
-
     use ruff_db::vendored::VendoredFileSystem;
     use ruff_db::vfs::VendoredPath;
 
@@ -52,10 +50,11 @@ mod tests {
                 });
 
             let posix_style_path = relative_path
-                .to_slash()
+                .as_os_str()
+                .to_str()
                 .unwrap_or_else(|| panic!("Expected {relative_path:?} to be a valid UTF-8 path"));
 
-            let vendored_path = VendoredPath::new(&*posix_style_path);
+            let vendored_path = VendoredPath::new(posix_style_path);
 
             assert!(
                 vendored_typeshed_stubs.exists(vendored_path),


### PR DESCRIPTION
This reapplies https://github.com/astral-sh/ruff/pull/11970, which was previously reverted in https://github.com/astral-sh/ruff/pull/11975 as the tests failed on Windows. The tests should now pass on Windows thanks to https://github.com/astral-sh/ruff/pull/11982; but if they do fail again, it should be easier to debug them now, thanks to https://github.com/astral-sh/ruff/pull/11983.