### PR TITLE
Improve normalization of `VendoredPath`s

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2210,6 +2210,7 @@ dependencies = [
  "ruff_text_size",
  "rustc-hash",
  "salsa",
+ "thiserror",
  "tracing",
  "zip",
 ]

--- a/crates/red_knot_module_resolver/src/typeshed.rs
+++ b/crates/red_knot_module_resolver/src/typeshed.rs
@@ -64,9 +64,10 @@ mod tests {
 
             let vendored_path_kind = vendored_typeshed_stubs
                 .metadata(vendored_path)
-                .unwrap_or_else(|| {
+                .unwrap_or_else(|err| {
                     panic!(
                         "Expected metadata for {vendored_path:?} to be retrievable from the `VendoredFileSystem!
+                        Error encountered: {err}
 
                         Vendored file system:
 

--- a/crates/ruff_db/Cargo.toml
+++ b/crates/ruff_db/Cargo.toml
@@ -23,6 +23,7 @@ filetime = { workspace = true }
 salsa = { workspace = true }
 tracing = { workspace = true }
 rustc-hash = { workspace = true }
+thiserror = { workspace = true }
 zip = { workspace = true }
 
 [dev-dependencies]


### PR DESCRIPTION
## Summary

This is a competing PR to #11989. Instead of making `VendoredPath` normalization eager, it makes the lazy normalization that we currently do more principled:
- the normalization function checks for `..` path components that attempt to "escape" from the zip archive altogether (e.g. `VendoredPath("..")` should be rejected)
- the normalization function returns a `Result` instead of panicking if the `VendoredPath` is invalid.

## Test Plan

`cargo test -p ruff_db`
