### PR TITLE
Error when using the `tab-size` option

### DIFF
--- a/crates/ruff/tests/format.rs
+++ b/crates/ruff/tests/format.rs
@@ -790,41 +790,6 @@ if condition:
     Ok(())
 }
 
-#[test]
-fn deprecated_options() -> Result<()> {
-    let tempdir = TempDir::new()?;
-    let ruff_toml = tempdir.path().join("ruff.toml");
-    fs::write(
-        &ruff_toml,
-        r"
-tab-size = 2
-",
-    )?;
-
-    insta::with_settings!({filters => vec![
-        (&*regex::escape(ruff_toml.to_str().unwrap()), "[RUFF-TOML-PATH]"),
-    ]}, {
-        assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
-            .args(["format", "--config"])
-            .arg(&ruff_toml)
-            .arg("-")
-            .pass_stdin(r"
-if True:
-    pass
-    "), @r###"
-        success: true
-        exit_code: 0
-        ----- stdout -----
-        if True:
-          pass
-
-        ----- stderr -----
-        warning: The `tab-size` option has been renamed to `indent-width` to emphasize that it configures the indentation used by the formatter as well as the tab width. Please update your configuration to use `indent-width = <value>` instead.
-        "###);
-    });
-    Ok(())
-}
-
 /// Since 0.1.0 the legacy format option is no longer supported
 #[test]
 fn legacy_format_option() -> Result<()> {

--- a/crates/ruff_workspace/src/configuration.rs
+++ b/crates/ruff_workspace/src/configuration.rs
@@ -421,13 +421,13 @@ impl Configuration {
         };
 
         #[allow(deprecated)]
-        let indent_width = {
-            if options.tab_size.is_some() {
-                warn_user_once!("The `tab-size` option has been renamed to `indent-width` to emphasize that it configures the indentation used by the formatter as well as the tab width. Please update your configuration to use `indent-width = <value>` instead.");
-            }
-
-            options.indent_width.or(options.tab_size)
-        };
+        if options.tab_size.is_some() {
+            let config_to_update = path.map_or_else(
+                || String::from("your `--config` CLI arguments"),
+                |path| format!("`{}`", fs::relativize_path(path)),
+            );
+            return Err(anyhow!("The `tab-size` option has been renamed to `indent-width` to emphasize that it configures the indentation used by the formatter as well as the tab width. Please update {config_to_update} to use `indent-width = <value>` instead."));
+        }
 
         let output_format = {
             options
@@ -508,7 +508,7 @@ impl Configuration {
             output_format,
             force_exclude: options.force_exclude,
             line_length: options.line_length,
-            indent_width,
+            indent_width: options.indent_width,
             namespace_packages: options
                 .namespace_packages
                 .map(|namespace_package| resolve_src(&namespace_package, project_root))

--- a/crates/ruff_workspace/src/options.rs
+++ b/crates/ruff_workspace/src/options.rs
@@ -397,24 +397,6 @@ pub struct Options {
     )]
     pub indent_width: Option<IndentWidth>,
 
-    /// The number of spaces a tab is equal to when enforcing long-line violations (like `E501`)
-    /// or formatting code with the formatter.
-    ///
-    /// This option changes the number of spaces inserted by the formatter when
-    /// using soft-tabs (`indent-style = space`).
-    #[option(
-        default = "4",
-        value_type = "int",
-        example = r#"
-            tab-size = 2
-        "#
-    )]
-    #[deprecated(
-        since = "0.1.2",
-        note = "The `tab-size` option has been renamed to `indent-width` to emphasize that it configures the indentation used by the formatter as well as the tab width. Please update your configuration to use `indent-width = <value>` instead."
-    )]
-    pub tab_size: Option<IndentWidth>,
-
     #[option_group]
     pub lint: Option<LintOptions>,
 

--- a/crates/ruff_workspace/src/options.rs
+++ b/crates/ruff_workspace/src/options.rs
@@ -397,6 +397,17 @@ pub struct Options {
     )]
     pub indent_width: Option<IndentWidth>,
 
+    /// The number of spaces a tab is equal to when enforcing long-line violations (like `E501`)
+    /// or formatting code with the formatter.
+    ///
+    /// This option changes the number of spaces inserted by the formatter when
+    /// using soft-tabs (`indent-style = space`).
+    #[deprecated(
+        since = "0.1.2",
+        note = "The `tab-size` option has been renamed to `indent-width` to emphasize that it configures the indentation used by the formatter as well as the tab width. Please update your configuration to use `indent-width = <value>` instead."
+    )]
+    pub tab_size: Option<IndentWidth>,
+
     #[option_group]
     pub lint: Option<LintOptions>,
 

--- a/ruff.schema.json
+++ b/ruff.schema.json
@@ -680,18 +680,6 @@
         "type": "string"
       }
     },
-    "tab-size": {
-      "description": "The number of spaces a tab is equal to when enforcing long-line violations (like `E501`) or formatting code with the formatter.\n\nThis option changes the number of spaces inserted by the formatter when using soft-tabs (`indent-style = space`).",
-      "deprecated": true,
-      "anyOf": [
-        {
-          "$ref": "#/definitions/IndentWidth"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
     "target-version": {
       "description": "The minimum Python version to target, e.g., when considering automatic code upgrades, like rewriting type annotations. Ruff will not propose changes using features that are not available in the given version.\n\nFor example, to represent supporting Python >=3.10 or ==3.10 specify `target-version = \"py310\"`.\n\nIf you're already using a `pyproject.toml` file, we recommend `project.requires-python` instead, as it's based on Python packaging standards, and will be respected by other tools. For example, Ruff treats the following as identical to `target-version = \"py38\"`:\n\n```toml [project] requires-python = \">=3.8\" ```\n\nIf both are specified, `target-version` takes precedence over `requires-python`.",
       "anyOf": [

--- a/ruff.schema.json
+++ b/ruff.schema.json
@@ -680,6 +680,18 @@
         "type": "string"
       }
     },
+    "tab-size": {
+      "description": "The number of spaces a tab is equal to when enforcing long-line violations (like `E501`) or formatting code with the formatter.\n\nThis option changes the number of spaces inserted by the formatter when using soft-tabs (`indent-style = space`).",
+      "deprecated": true,
+      "anyOf": [
+        {
+          "$ref": "#/definitions/IndentWidth"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "target-version": {
       "description": "The minimum Python version to target, e.g., when considering automatic code upgrades, like rewriting type annotations. Ruff will not propose changes using features that are not available in the given version.\n\nFor example, to represent supporting Python >=3.10 or ==3.10 specify `target-version = \"py310\"`.\n\nIf you're already using a `pyproject.toml` file, we recommend `project.requires-python` instead, as it's based on Python packaging standards, and will be respected by other tools. For example, Ruff treats the following as identical to `target-version = \"py38\"`:\n\n```toml [project] requires-python = \">=3.8\" ```\n\nIf both are specified, `target-version` takes precedence over `requires-python`.",
       "anyOf": [


### PR DESCRIPTION
## Summary

This PR makes the warning when using the `tab-size` option an error. The `tab-size` option was deprecated in Ruff 0.1.2 (released October 2023).

Part of https://github.com/astral-sh/ruff/issues/7650

## Test Plan

* Verified that the option isn't used by the LSP (I searched for tab-size and tab_size)
* Verified that the option isn't exposed via the CLI (other than using `--config`)
* Verified that using the previously accepted `tab-size` option fails

```shell
❯ ../ruff/target/debug/ruff check test.py --config tab-size=2
ruff failed
  Cause: The `tab-size` option has been renamed to `indent-width` to emphasize that it configures the indentation used by the formatter as well as the tab width. Please update your `--config` CLI arguments to use `indent-width = <value>` instead.

❯ ../ruff/target/debug/ruff check test.py 
ruff failed
  Cause: The `tab-size` option has been renamed to `indent-width` to emphasize that it configures the indentation used by the formatter as well as the tab width. Please update `pyproject.toml` to use `indent-width = <value>` instead.
```

* Verified that using `indent-width` works

```shell
❯ ../ruff/target/debug/ruff check test.py
warning: Detected debug build without --no-cache.
```