### PR TITLE
Remove deprecated `extend-ignore` and `extend-unfixable` options

### DIFF
--- a/crates/ruff/src/args.rs
+++ b/crates/ruff/src/args.rs
@@ -238,16 +238,6 @@ pub struct CheckCommand {
         hide_possible_values = true
     )]
     pub extend_select: Option<Vec<RuleSelector>>,
-    /// Like --ignore. (Deprecated: You can just use --ignore instead.)
-    #[arg(
-        long,
-        value_delimiter = ',',
-        value_name = "RULE_CODE",
-        value_parser = RuleSelectorParser,
-        help_heading = "Rule selection",
-        hide = true
-    )]
-    pub extend_ignore: Option<Vec<RuleSelector>>,
     /// List of mappings from file pattern to code to exclude.
     #[arg(long, value_delimiter = ',', help_heading = "Rule selection")]
     pub per_file_ignores: Option<Vec<PatternPrefixPair>>,
@@ -300,16 +290,7 @@ pub struct CheckCommand {
         hide_possible_values = true
     )]
     pub extend_fixable: Option<Vec<RuleSelector>>,
-    /// Like --unfixable. (Deprecated: You can just use --unfixable instead.)
-    #[arg(
-        long,
-        value_delimiter = ',',
-        value_name = "RULE_CODE",
-        value_parser = RuleSelectorParser,
-        help_heading = "Rule selection",
-        hide = true
-    )]
-    pub extend_unfixable: Option<Vec<RuleSelector>>,
+
     /// Respect file exclusions via `.gitignore` and other standard ignore files.
     /// Use `--no-respect-gitignore` to disable.
     #[arg(
@@ -681,10 +662,8 @@ impl CheckCommand {
             exclude: self.exclude,
             extend_exclude: self.extend_exclude,
             extend_fixable: self.extend_fixable,
-            extend_ignore: self.extend_ignore,
             extend_per_file_ignores: self.extend_per_file_ignores,
             extend_select: self.extend_select,
-            extend_unfixable: self.extend_unfixable,
             fixable: self.fixable,
             ignore: self.ignore,
             line_length: self.line_length,
@@ -1200,9 +1179,7 @@ struct ExplicitConfigOverrides {
     exclude: Option<Vec<FilePattern>>,
     extend_exclude: Option<Vec<FilePattern>>,
     extend_fixable: Option<Vec<RuleSelector>>,
-    extend_ignore: Option<Vec<RuleSelector>>,
     extend_select: Option<Vec<RuleSelector>>,
-    extend_unfixable: Option<Vec<RuleSelector>>,
     fixable: Option<Vec<RuleSelector>>,
     ignore: Option<Vec<RuleSelector>>,
     line_length: Option<LineLength>,
@@ -1255,22 +1232,10 @@ impl ConfigurationTransformer for ExplicitConfigOverrides {
         }
         config.lint.rule_selections.push(RuleSelection {
             select: self.select.clone(),
-            ignore: self
-                .ignore
-                .iter()
-                .cloned()
-                .chain(self.extend_ignore.iter().cloned())
-                .flatten()
-                .collect(),
+            ignore: self.ignore.iter().flatten().cloned().collect(),
             extend_select: self.extend_select.clone().unwrap_or_default(),
             fixable: self.fixable.clone(),
-            unfixable: self
-                .unfixable
-                .iter()
-                .cloned()
-                .chain(self.extend_unfixable.iter().cloned())
-                .flatten()
-                .collect(),
+            unfixable: self.unfixable.iter().flatten().cloned().collect(),
             extend_fixable: self.extend_fixable.clone().unwrap_or_default(),
         });
         if let Some(output_format) = &self.output_format {

--- a/crates/ruff_linter/resources/test/project/examples/docs/ruff.toml
+++ b/crates/ruff_linter/resources/test/project/examples/docs/ruff.toml
@@ -1,6 +1,8 @@
 extend = "../../pyproject.toml"
 src = ["."]
+
+[lint]
 # Enable I001, and re-enable F841, to test extension priority.
 extend-select = ["I001", "F841"]
-extend-ignore = ["F401"]
+ignore = ["F401"]
 extend-exclude = ["./docs/concepts/file.py"]

--- a/crates/ruff_linter/resources/test/project/pyproject.toml
+++ b/crates/ruff_linter/resources/test/project/pyproject.toml
@@ -4,4 +4,4 @@ exclude = ["examples/excluded"]
 
 [tool.ruff.lint]
 extend-select = ["I001"]
-extend-ignore = ["F841"]
+ignore = ["F841"]

--- a/crates/ruff_workspace/src/configuration.rs
+++ b/crates/ruff_workspace/src/configuration.rs
@@ -643,23 +643,6 @@ pub struct LintConfiguration {
 impl LintConfiguration {
     fn from_options(options: LintOptions, project_root: &Path) -> Result<Self> {
         #[allow(deprecated)]
-        let ignore = options
-            .common
-            .ignore
-            .into_iter()
-            .flatten()
-            .chain(options.common.extend_ignore.into_iter().flatten())
-            .collect();
-        #[allow(deprecated)]
-        let unfixable = options
-            .common
-            .unfixable
-            .into_iter()
-            .flatten()
-            .chain(options.common.extend_unfixable.into_iter().flatten())
-            .collect();
-
-        #[allow(deprecated)]
         let ignore_init_module_imports = {
             if options.common.ignore_init_module_imports.is_some() {
                 warn_user_once!("The `ignore-init-module-imports` option is deprecated and will be removed in a future release. Ruff's handling of imports in `__init__.py` files has been improved (in preview) and unused imports will always be flagged.");
@@ -681,10 +664,10 @@ impl LintConfiguration {
 
             rule_selections: vec![RuleSelection {
                 select: options.common.select,
-                ignore,
+                ignore: options.common.ignore.into_iter().flatten().collect(),
                 extend_select: options.common.extend_select.unwrap_or_default(),
                 fixable: options.common.fixable,
-                unfixable,
+                unfixable: options.common.unfixable.into_iter().flatten().collect(),
                 extend_fixable: options.common.extend_fixable.unwrap_or_default(),
             }],
             extend_safe_fixes: options.common.extend_safe_fixes.unwrap_or_default(),
@@ -1285,22 +1268,12 @@ fn warn_about_deprecated_top_level_lint_options(
         used_options.push("dummy-variable-rgx");
     }
 
-    #[allow(deprecated)]
-    if top_level_options.extend_ignore.is_some() {
-        used_options.push("extend-ignore");
-    }
-
     if top_level_options.extend_select.is_some() {
         used_options.push("extend-select");
     }
 
     if top_level_options.extend_fixable.is_some() {
         used_options.push("extend-fixable");
-    }
-
-    #[allow(deprecated)]
-    if top_level_options.extend_unfixable.is_some() {
-        used_options.push("extend-unfixable");
     }
 
     if top_level_options.external.is_some() {

--- a/crates/ruff_workspace/src/options.rs
+++ b/crates/ruff_workspace/src/options.rs
@@ -574,21 +574,6 @@ pub struct LintCommonOptions {
     )]
     pub dummy_variable_rgx: Option<String>,
 
-    /// A list of rule codes or prefixes to ignore, in addition to those
-    /// specified by `ignore`.
-    #[option(
-        default = "[]",
-        value_type = "list[RuleSelector]",
-        example = r#"
-            # Skip unused variable rules (`F841`).
-            extend-ignore = ["F841"]
-        "#
-    )]
-    #[deprecated(
-        note = "The `extend-ignore` option is now interchangeable with `ignore`. Please update your configuration to use the `ignore` option instead."
-    )]
-    pub extend_ignore: Option<Vec<RuleSelector>>,
-
     /// A list of rule codes or prefixes to enable, in addition to those
     /// specified by `select`.
     #[option(
@@ -612,13 +597,6 @@ pub struct LintCommonOptions {
         "#
     )]
     pub extend_fixable: Option<Vec<RuleSelector>>,
-
-    /// A list of rule codes or prefixes to consider non-auto-fixable, in addition to those
-    /// specified by `unfixable`.
-    #[deprecated(
-        note = "The `extend-unfixable` option is now interchangeable with `unfixable`. Please update your configuration to use the `unfixable` option instead."
-    )]
-    pub extend_unfixable: Option<Vec<RuleSelector>>,
 
     /// A list of rule codes or prefixes that are unsupported by Ruff, but should be
     /// preserved when (e.g.) validating `# noqa` directives. Useful for

--- a/docs/linter.md
+++ b/docs/linter.md
@@ -237,7 +237,7 @@ You may use prefixes to select rules as well, e.g., `F` can be used to promote f
 
 To limit the set of rules that Ruff should fix, use the [`lint.fixable`](settings.md#lint_fixable) and
 [`lint.unfixable`](settings.md#lint_unfixable) settings, along with their [`lint.extend-fixable`](settings.md#lint_extend-fixable)
-and [`lint.extend-unfixable`](settings.md#lint_extend-unfixable) variants.
+and [`lint.unfixable`](settings.md#lint_unfixable) variants.
 
 For example, the following configuration would enable fixes for all rules except
 [`unused-imports`](rules/unused-import.md) (`F401`):

--- a/ruff.schema.json
+++ b/ruff.schema.json
@@ -87,17 +87,6 @@
         "$ref": "#/definitions/RuleSelector"
       }
     },
-    "extend-ignore": {
-      "description": "A list of rule codes or prefixes to ignore, in addition to those specified by `ignore`.",
-      "deprecated": true,
-      "type": [
-        "array",
-        "null"
-      ],
-      "items": {
-        "$ref": "#/definitions/RuleSelector"
-      }
-    },
     "extend-include": {
       "description": "A list of file patterns to include when linting, in addition to those specified by `include`.\n\nInclusion are based on globs, and should be single-path patterns, like `*.pyw`, to include any file with the `.pyw` extension.\n\nFor more information on the glob syntax, refer to the [`globset` documentation](https://docs.rs/globset/latest/globset/#syntax).",
       "type": [
@@ -135,17 +124,6 @@
     },
     "extend-select": {
       "description": "A list of rule codes or prefixes to enable, in addition to those specified by `select`.",
-      "deprecated": true,
-      "type": [
-        "array",
-        "null"
-      ],
-      "items": {
-        "$ref": "#/definitions/RuleSelector"
-      }
-    },
-    "extend-unfixable": {
-      "description": "A list of rule codes or prefixes to consider non-auto-fixable, in addition to those specified by `unfixable`.",
       "deprecated": true,
       "type": [
         "array",
@@ -1835,17 +1813,6 @@
             "$ref": "#/definitions/RuleSelector"
           }
         },
-        "extend-ignore": {
-          "description": "A list of rule codes or prefixes to ignore, in addition to those specified by `ignore`.",
-          "deprecated": true,
-          "type": [
-            "array",
-            "null"
-          ],
-          "items": {
-            "$ref": "#/definitions/RuleSelector"
-          }
-        },
         "extend-per-file-ignores": {
           "description": "A list of mappings from file pattern to rule codes or prefixes to exclude, in addition to any rules excluded by `per-file-ignores`.",
           "type": [
@@ -1871,17 +1838,6 @@
         },
         "extend-select": {
           "description": "A list of rule codes or prefixes to enable, in addition to those specified by `select`.",
-          "type": [
-            "array",
-            "null"
-          ],
-          "items": {
-            "$ref": "#/definitions/RuleSelector"
-          }
-        },
-        "extend-unfixable": {
-          "description": "A list of rule codes or prefixes to consider non-auto-fixable, in addition to those specified by `unfixable`.",
-          "deprecated": true,
           "type": [
             "array",
             "null"


### PR DESCRIPTION
## Summary

This PR removes the deprecated `lint.extend-ignore` and `lint.extend-unfixable` options.  The options were deprecated in https://github.com/astral-sh/ruff/pull/2312 (0.0.238)


Part of https://github.com/astral-sh/ruff/issues/7650

## Test Plan

Running ruff with a configuration containing `extend-ignore` or `extend-unfixable` now fails

```
❯ ../ruff/target/debug/ruff check test.py --no-cache
ruff failed
  Cause: Failed to parse /home/micha/astral/test/pyproject.toml
  Cause: TOML parse error at line 38, column 1
   |
38 | [tool.ruff.lint]
   | ^^^^^^^^^^^^^^^^
unknown field `extend-ignore`
```

Changing the option to `ignore` "ignores" the rule as expected.