### PR TITLE
Fix missing related settings header

### DIFF
--- a/crates/ruff_dev/src/generate_rules_table.rs
+++ b/crates/ruff_dev/src/generate_rules_table.rs
@@ -165,9 +165,9 @@ pub(crate) fn generate() -> String {
             table_out.push('\n');
         }
 
-        if Options::metadata().has(linter.name()) {
+        if Options::metadata().has(&format!("lint.{}", linter.name())) {
             table_out.push_str(&format!(
-                "For related settings, see [{}](settings.md#{}).",
+                "For related settings, see [{}](settings.md#lint{}).",
                 linter.name(),
                 linter.name(),
             ));


### PR DESCRIPTION
## Summary

Fixes https://github.com/astral-sh/ruff/issues/12012

This must have broken when I introduced the new top-level `lint` section. The issue was that
we probed for the `<linter>` config option instead of `lint.<linter>`. 

## Test Plan

![image](https://github.com/astral-sh/ruff/assets/1203881/143baeb3-1769-4aed-81dd-63e549012aae)

I verified that the link jumps to the right section
