### PR TITLE
Use correct range to highlight line continuation error

### DIFF
--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@re_lexing__line_continuation_1.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@re_lexing__line_continuation_1.py.snap
@@ -11,10 +11,10 @@ Module(
         body: [
             Expr(
                 StmtExpr {
-                    range: 0..13,
+                    range: 0..14,
                     value: Call(
                         ExprCall {
-                            range: 0..13,
+                            range: 0..14,
                             func: Name(
                                 ExprName {
                                     range: 0..4,
@@ -23,7 +23,7 @@ Module(
                                 },
                             ),
                             arguments: Arguments {
-                                range: 4..13,
+                                range: 4..14,
                                 args: [
                                     Name(
                                         ExprName {
@@ -82,7 +82,7 @@ Module(
 
   |
 1 | call(a, b, \\\
-  |           ^^ Syntax Error: unexpected character after line continuation character
+  |             ^ Syntax Error: unexpected character after line continuation character
 2 | 
 3 | def bar():
   |
@@ -90,7 +90,7 @@ Module(
 
   |
 1 | call(a, b, \\\
-  |             ^ Syntax Error: unexpected character after line continuation character
+  |              ^ Syntax Error: unexpected character after line continuation character
 2 | 
 3 | def bar():
   |


### PR DESCRIPTION
## Summary

This PR fixes the range highlighted for the line continuation error.

Previously, it would highlight an incorrect range:
```
1 | call(a, b, \\\
  |           ^^ Syntax Error: unexpected character after line continuation character
2 | 
3 | def bar():
  |
```

And now:
```
  |
1 | call(a, b, \\\
  |             ^ Syntax Error: unexpected character after line continuation character
2 | 
3 | def bar():
  |
```

This is implemented by avoiding to update the token range for the `Unknown` token which is emitted when there's a lexical error. Instead, the `push_error` helper method will be responsible to update the range to the error location.

This actually becomes a requirement which can be seen in follow-up PRs.

## Test Plan

Update and validate the snapshot.
