### PR TITLE
[red-knot] Fix tests in release builds

### DIFF
--- a/crates/red_knot/src/semantic.rs
+++ b/crates/red_knot/src/semantic.rs
@@ -271,17 +271,16 @@ impl SourceOrderVisitor<'_> for SemanticIndexer {
         let node_key = NodeKey::from_node(expr.into());
         let expression_id = self.expressions_by_id.push(node_key);
 
-        debug_assert_eq!(
-            expression_id,
-            self.flow_graph_builder
-                .record_expr(self.current_flow_node())
-        );
+        let flow_expression_id = self
+            .flow_graph_builder
+            .record_expr(self.current_flow_node());
+        debug_assert_eq!(expression_id, flow_expression_id);
 
-        debug_assert_eq!(
-            expression_id,
-            self.symbol_table_builder
-                .record_expression(self.cur_scope())
-        );
+        let symbol_expression_id = self
+            .symbol_table_builder
+            .record_expression(self.cur_scope());
+
+        debug_assert_eq!(expression_id, symbol_expression_id);
 
         self.expressions.insert(node_key, expression_id);
 


### PR DESCRIPTION
## Summary


This Test fixes the red-knot tests when run in release mode. 

The problem was that the semantic indexer code contained code with side effects inside of `debug_assert_eq` calls, that get stripped (entirely)
from release builds, removing the side effects. 

This PR moves the side-effects out from the `debug_assert_eq` calls.

Fixes https://github.com/astral-sh/ruff/issues/12018

## Test Plan

`cargo test -p red_knot --release`
