### PR TITLE
Avoid `E203` for f-string debug expression

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pycodestyle/E20.py
+++ b/crates/ruff_linter/resources/test/fixtures/pycodestyle/E20.py
@@ -185,3 +185,7 @@ f"{ham[lower +1 :, "columnname"]}"
 
 #: E203:1:13
 f"{ham[lower + 1  :, "columnname"]}"
+
+#: Okay: https://github.com/astral-sh/ruff/issues/12023
+f"{x = :.2f}"
+f"{(x) = :.2f}"

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/logical_lines/extraneous_whitespace.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/logical_lines/extraneous_whitespace.rs
@@ -273,6 +273,13 @@ pub(crate) fn extraneous_whitespace(line: &LogicalLine, context: &mut LogicalLin
                                     }
                                 }
                             } else {
+                                if fstrings > 0
+                                    && symbol == ':'
+                                    && matches!(prev_token, Some(TokenKind::Equal))
+                                {
+                                    // Avoid removing any whitespace for f-string debug expressions.
+                                    continue;
+                                }
                                 let mut diagnostic = Diagnostic::new(
                                     WhitespaceBeforePunctuation { symbol },
                                     TextRange::at(token.start() - offset, offset),

--- a/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E203_E20.py.snap
+++ b/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E203_E20.py.snap
@@ -331,6 +331,8 @@ E20.py:187:17: E203 [*] Whitespace before ':'
 186 | #: E203:1:13
 187 | f"{ham[lower + 1  :, "columnname"]}"
     |                 ^^ E203
+188 | 
+189 | #: Okay: https://github.com/astral-sh/ruff/issues/12023
     |
     = help: Remove whitespace before ':'
 
@@ -340,3 +342,6 @@ E20.py:187:17: E203 [*] Whitespace before ':'
 186 186 | #: E203:1:13
 187     |-f"{ham[lower + 1  :, "columnname"]}"
     187 |+f"{ham[lower + 1:, "columnname"]}"
+188 188 | 
+189 189 | #: Okay: https://github.com/astral-sh/ruff/issues/12023
+190 190 | f"{x = :.2f}"


### PR DESCRIPTION
## Summary

This PR fixes a bug where Ruff would raise `E203` for f-string debug expression. This isn't valid because whitespaces are important for debug expressions.

fixes: #12023

## Test Plan

Add test case and make sure there are no snapshot changes.