### PR TITLE
Fix RUF027 false positives if `gettext` is imported using an alias

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/ruff/RUF027_1.py
+++ b/crates/ruff_linter/resources/test/fixtures/ruff/RUF027_1.py
@@ -38,3 +38,6 @@ def negative_cases():
     print(("{a}" "{c}").format(a=1, c=2))
     print("{a}".attribute.chaining.call(a=2))
     print("{a} {c}".format(a))
+
+    from gettext import gettext as fooooooo
+    fooooooo("This {should} also {be} understood as a {translation} string")


### PR DESCRIPTION
Noticed this while reviewing if it was ready to be stabilised