### PR TITLE
Match import name ignores against both name and alias

### DIFF
--- a/crates/ruff_linter/src/rules/pep8_naming/rules/camelcase_imported_as_acronym.rs
+++ b/crates/ruff_linter/src/rules/pep8_naming/rules/camelcase_imported_as_acronym.rs
@@ -62,7 +62,7 @@ pub(crate) fn camelcase_imported_as_acronym(
         && helpers::is_acronym(name, asname)
     {
         // Ignore any explicitly-allowed names.
-        if ignore_names.matches(name) {
+        if ignore_names.matches(name) || ignore_names.matches(asname) {
             return None;
         }
         let mut diagnostic = Diagnostic::new(

--- a/crates/ruff_linter/src/rules/pep8_naming/rules/camelcase_imported_as_constant.rs
+++ b/crates/ruff_linter/src/rules/pep8_naming/rules/camelcase_imported_as_constant.rs
@@ -59,7 +59,7 @@ pub(crate) fn camelcase_imported_as_constant(
         && !helpers::is_acronym(name, asname)
     {
         // Ignore any explicitly-allowed names.
-        if ignore_names.matches(asname) {
+        if ignore_names.matches(name) || ignore_names.matches(asname) {
             return None;
         }
         let mut diagnostic = Diagnostic::new(

--- a/crates/ruff_linter/src/rules/pep8_naming/rules/camelcase_imported_as_lowercase.rs
+++ b/crates/ruff_linter/src/rules/pep8_naming/rules/camelcase_imported_as_lowercase.rs
@@ -54,7 +54,7 @@ pub(crate) fn camelcase_imported_as_lowercase(
 ) -> Option<Diagnostic> {
     if helpers::is_camelcase(name) && ruff_python_stdlib::str::is_cased_lowercase(asname) {
         // Ignore any explicitly-allowed names.
-        if ignore_names.matches(asname) {
+        if ignore_names.matches(name) || ignore_names.matches(asname) {
             return None;
         }
         let mut diagnostic = Diagnostic::new(

--- a/crates/ruff_linter/src/rules/pep8_naming/rules/constant_imported_as_non_constant.rs
+++ b/crates/ruff_linter/src/rules/pep8_naming/rules/constant_imported_as_non_constant.rs
@@ -54,7 +54,7 @@ pub(crate) fn constant_imported_as_non_constant(
 ) -> Option<Diagnostic> {
     if str::is_cased_uppercase(name) && !str::is_cased_uppercase(asname) {
         // Ignore any explicitly-allowed names.
-        if ignore_names.matches(asname) {
+        if ignore_names.matches(name) || ignore_names.matches(asname) {
             return None;
         }
         let mut diagnostic = Diagnostic::new(

--- a/crates/ruff_linter/src/rules/pep8_naming/rules/lowercase_imported_as_non_lowercase.rs
+++ b/crates/ruff_linter/src/rules/pep8_naming/rules/lowercase_imported_as_non_lowercase.rs
@@ -54,7 +54,7 @@ pub(crate) fn lowercase_imported_as_non_lowercase(
     if !str::is_cased_uppercase(name) && str::is_cased_lowercase(name) && !str::is_lowercase(asname)
     {
         // Ignore any explicitly-allowed names.
-        if ignore_names.matches(asname) {
+        if ignore_names.matches(name) || ignore_names.matches(asname) {
             return None;
         }
         let mut diagnostic = Diagnostic::new(


### PR DESCRIPTION
## Summary

Right now, it's inconsistent... We sometimes match against the name, and sometimes against the alias (`asname`). I could see a case for always matching against the name, but matching against both seems fine too, since the rule is really about the combination of the two?

Closes https://github.com/astral-sh/ruff/issues/12031.
