### PR TITLE
Consider 2-character EOL before line continuation

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,6 +8,7 @@ crates/ruff_linter/resources/test/fixtures/pycodestyle/W391_3.py text eol=crlf
 crates/ruff_python_formatter/resources/test/fixtures/ruff/docstring_code_examples_crlf.py text eol=crlf
 crates/ruff_python_formatter/tests/snapshots/format@docstring_code_examples_crlf.py.snap text eol=crlf
 
+crates/ruff_python_parser/resources/invalid/re_lexing/line_continuation_windows_eol.py text eol=crlf
 crates/ruff_python_parser/resources/invalid/re_lex_logical_token_windows_eol.py text eol=crlf
 crates/ruff_python_parser/resources/invalid/re_lex_logical_token_mac_eol.py text eol=cr
 

--- a/crates/ruff_python_parser/resources/invalid/re_lexing/line_continuation_windows_eol.py
+++ b/crates/ruff_python_parser/resources/invalid/re_lexing/line_continuation_windows_eol.py
@@ -1,0 +1,4 @@
+call(a, b, # comment \
+
+def bar():
+    pass

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@re_lexing__line_continuation_windows_eol.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@re_lexing__line_continuation_windows_eol.py.snap
@@ -1,0 +1,89 @@
+---
+source: crates/ruff_python_parser/tests/fixtures.rs
+input_file: crates/ruff_python_parser/resources/invalid/re_lexing/line_continuation_windows_eol.py
+---
+## AST
+
+```
+Module(
+    ModModule {
+        range: 0..46,
+        body: [
+            Expr(
+                StmtExpr {
+                    range: 0..10,
+                    value: Call(
+                        ExprCall {
+                            range: 0..10,
+                            func: Name(
+                                ExprName {
+                                    range: 0..4,
+                                    id: "call",
+                                    ctx: Load,
+                                },
+                            ),
+                            arguments: Arguments {
+                                range: 4..10,
+                                args: [
+                                    Name(
+                                        ExprName {
+                                            range: 5..6,
+                                            id: "a",
+                                            ctx: Load,
+                                        },
+                                    ),
+                                    Name(
+                                        ExprName {
+                                            range: 8..9,
+                                            id: "b",
+                                            ctx: Load,
+                                        },
+                                    ),
+                                ],
+                                keywords: [],
+                            },
+                        },
+                    ),
+                },
+            ),
+            FunctionDef(
+                StmtFunctionDef {
+                    range: 26..46,
+                    is_async: false,
+                    decorator_list: [],
+                    name: Identifier {
+                        id: "bar",
+                        range: 30..33,
+                    },
+                    type_params: None,
+                    parameters: Parameters {
+                        range: 33..35,
+                        posonlyargs: [],
+                        args: [],
+                        vararg: None,
+                        kwonlyargs: [],
+                        kwarg: None,
+                    },
+                    returns: None,
+                    body: [
+                        Pass(
+                            StmtPass {
+                                range: 42..46,
+                            },
+                        ),
+                    ],
+                },
+            ),
+        ],
+    },
+)
+```
+## Errors
+
+  |
+1 |   call(a, b, # comment \
+2 | / 
+3 | | def bar():
+  | |_^ Syntax Error: Expected ')', found newline
+4 |       pass
+  |


### PR DESCRIPTION
## Summary

This PR fixes a bug introduced in https://github.com/astral-sh/ruff/pull/12008 which didn't consider the two character newline after the line continuation character.

For example, consider the following code highlighted with whitespaces:
```py
call(foo # comment \\r\n
\r\n
def bar():\r\n
....pass\r\n
```
The lexer is at `def` when it's running the re-lexing logic and trying to move back to a newline character. It encounters `\n` and it's being escaped (incorrect) but `\r` is being escaped, so it moves the lexer to `\n` character. This creates an overlap in token ranges which causes the panic.

```
Name 0..4
Lpar 4..5
Name 5..8
Comment 9..20
NonLogicalNewline 20..22 <-- overlap between
Newline 21..22           <-- these two tokens
NonLogicalNewline 22..23
Def 23..26
...
```

fixes: #12028 

## Test Plan

Add a test case with line continuation and windows style newline character.
