### PR TITLE
docs: add `and formatter` to CLI startup message

### DIFF
--- a/crates/ruff/src/args.rs
+++ b/crates/ruff/src/args.rs
@@ -78,7 +78,7 @@ impl GlobalConfigArgs {
 #[command(
     author,
     name = "ruff",
-    about = "Ruff: An extremely fast Python linter.",
+    about = "Ruff: An extremely fast Python linter and formatter.",
     after_help = "For help with a specific command, see: `ruff help <command>`."
 )]
 #[command(version)]

--- a/crates/ruff/src/args.rs
+++ b/crates/ruff/src/args.rs
@@ -78,7 +78,7 @@ impl GlobalConfigArgs {
 #[command(
     author,
     name = "ruff",
-    about = "Ruff: An extremely fast Python linter and formatter.",
+    about = "Ruff: An extremely fast Python linter and code formatter.",
     after_help = "For help with a specific command, see: `ruff help <command>`."
 )]
 #[command(version)]

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -516,7 +516,7 @@ See `ruff help` for the full list of Ruff's top-level commands:
 <!-- Begin auto-generated command help. -->
 
 ```text
-Ruff: An extremely fast Python linter.
+Ruff: An extremely fast Python linter and code formatter.
 
 Usage: ruff [OPTIONS] <COMMAND>
 


### PR DESCRIPTION
## Summary

The PR adds a small `and code formatter` to the display message when you run `ruff` on your CLI, to match the repo description.

## Test Plan

No tests since it's just "docs". But I'd be glad to review/change/build it and see how it behaves when run locally.
