### PR TITLE
[Ruff 0.5] Stabilise `manual-dict-comprehension` (`PERF403`)

### DIFF
--- a/crates/ruff_linter/src/codes.rs
+++ b/crates/ruff_linter/src/codes.rs
@@ -998,7 +998,7 @@ pub fn code_to_rule(linter: Linter, code: &str) -> Option<(RuleGroup, Rule)> {
         (Perflint, "203") => (RuleGroup::Stable, rules::perflint::rules::TryExceptInLoop),
         (Perflint, "401") => (RuleGroup::Stable, rules::perflint::rules::ManualListComprehension),
         (Perflint, "402") => (RuleGroup::Stable, rules::perflint::rules::ManualListCopy),
-        (Perflint, "403") => (RuleGroup::Preview, rules::perflint::rules::ManualDictComprehension),
+        (Perflint, "403") => (RuleGroup::Stable, rules::perflint::rules::ManualDictComprehension),
 
         // flake8-fixme
         (Flake8Fixme, "001") => (RuleGroup::Stable, rules::flake8_fixme::rules::LineContainsFixme),

--- a/crates/ruff_workspace/src/configuration.rs
+++ b/crates/ruff_workspace/src/configuration.rs
@@ -1486,7 +1486,6 @@ mod tests {
     const PREVIEW_RULES: &[Rule] = &[
         Rule::IsinstanceTypeNone,
         Rule::IfExprMinMax,
-        Rule::ManualDictComprehension,
         Rule::ReimplementedStarmap,
         Rule::SliceCopy,
         Rule::TooManyPublicMethods,


### PR DESCRIPTION
## Summary

This rule's been in preview for a very long time (over 9 months, if I'm not mistaken). There are no open issues about it, the docs accurately describe what it does, and the implementation seems sound.

It's an opinionated rule that advocates a micro-optimisation -- but this is true for all the perflint rules, and is flagged in the docs. I don't think you'd enable the `PERF` category at all if you weren't interested in this kind of rule.
