### PR TITLE
Remove `--preview` as a required argument for `ruff server`

### DIFF
--- a/crates/ruff/src/commands/server.rs
+++ b/crates/ruff/src/commands/server.rs
@@ -4,12 +4,7 @@ use crate::ExitStatus;
 use anyhow::Result;
 use ruff_server::Server;
 
-pub(crate) fn run_server(preview: bool, worker_threads: NonZeroUsize) -> Result<ExitStatus> {
-    if !preview {
-        tracing::error!("--preview needs to be provided as a command line argument while the server is still unstable.\nFor example: `ruff server --preview`");
-        return Ok(ExitStatus::Error);
-    }
-
+pub(crate) fn run_server(_preview: bool, worker_threads: NonZeroUsize) -> Result<ExitStatus> {
     let server = Server::new(worker_threads)?;
 
     server.run().map(|()| ExitStatus::Success)


### PR DESCRIPTION
## Summary

`ruff server` has reached a point of stabilization, and `--preview` is no longer required as a flag.

`--preview` is still supported as a flag, since future features may be need to gated behind it initially.

## Test Plan

A simple way to test this is to run `ruff server` from the command line. No error about a missing `--preview` argument should be reported.
