### PR TITLE
Add server config to filter out syntax error diagnostics

### DIFF
--- a/crates/ruff_server/src/server/api/diagnostics.rs
+++ b/crates/ruff_server/src/server/api/diagnostics.rs
@@ -9,7 +9,11 @@ use super::LSPResult;
 pub(super) fn generate_diagnostics(snapshot: &DocumentSnapshot) -> DiagnosticsMap {
     if snapshot.client_settings().lint() {
         let document = snapshot.query();
-        crate::lint::check(document, snapshot.encoding())
+        crate::lint::check(
+            document,
+            snapshot.encoding(),
+            snapshot.client_settings().show_syntax_errors(),
+        )
     } else {
         DiagnosticsMap::default()
     }

--- a/crates/ruff_server/src/session/settings.rs
+++ b/crates/ruff_server/src/session/settings.rs
@@ -456,6 +456,7 @@ mod tests {
                 exclude: None,
                 line_length: None,
                 configuration_preference: None,
+                show_syntax_errors: None,
                 tracing: TracingSettings {
                     log_level: None,
                     log_file: None,
@@ -508,6 +509,7 @@ mod tests {
                         exclude: None,
                         line_length: None,
                         configuration_preference: None,
+                        show_syntax_errors: None,
                         tracing: TracingSettings {
                             log_level: None,
                             log_file: None,
@@ -573,6 +575,7 @@ mod tests {
                         exclude: None,
                         line_length: None,
                         configuration_preference: None,
+                        show_syntax_errors: None,
                         tracing: TracingSettings {
                             log_level: None,
                             log_file: None,
@@ -719,6 +722,7 @@ mod tests {
                     ),
                 ),
                 configuration_preference: None,
+                show_syntax_errors: None,
                 tracing: TracingSettings {
                     log_level: Some(
                         Warn,

--- a/crates/ruff_server/src/session/settings.rs
+++ b/crates/ruff_server/src/session/settings.rs
@@ -21,6 +21,7 @@ pub(crate) struct ResolvedClientSettings {
     lint_enable: bool,
     disable_rule_comment_enable: bool,
     fix_violation_enable: bool,
+    show_syntax_errors: bool,
     editor_settings: ResolvedEditorSettings,
 }
 
@@ -70,6 +71,13 @@ pub struct ClientSettings {
     exclude: Option<Vec<String>>,
     line_length: Option<LineLength>,
     configuration_preference: Option<ConfigurationPreference>,
+
+    /// If `true` or [`None`], show syntax errors as diagnostics.
+    ///
+    /// This is useful when using Ruff with other language servers, allowing the user to refer
+    /// to syntax errors from only one source.
+    show_syntax_errors: Option<bool>,
+
     // These settings are only needed for tracing, and are only read from the global configuration.
     // These will not be in the resolved settings.
     #[serde(flatten)]
@@ -244,6 +252,11 @@ impl ResolvedClientSettings {
                 },
                 true,
             ),
+            show_syntax_errors: Self::resolve_or(
+                all_settings,
+                |settings| settings.show_syntax_errors,
+                true,
+            ),
             editor_settings: ResolvedEditorSettings {
                 configuration: Self::resolve_optional(all_settings, |settings| {
                     settings
@@ -343,6 +356,10 @@ impl ResolvedClientSettings {
 
     pub(crate) fn fix_violation(&self) -> bool {
         self.fix_violation_enable
+    }
+
+    pub(crate) fn show_syntax_errors(&self) -> bool {
+        self.show_syntax_errors
     }
 
     pub(crate) fn editor_settings(&self) -> &ResolvedEditorSettings {
@@ -602,6 +619,7 @@ mod tests {
                 lint_enable: true,
                 disable_rule_comment_enable: false,
                 fix_violation_enable: false,
+                show_syntax_errors: true,
                 editor_settings: ResolvedEditorSettings {
                     configuration: None,
                     lint_preview: Some(true),
@@ -633,6 +651,7 @@ mod tests {
                 lint_enable: true,
                 disable_rule_comment_enable: true,
                 fix_violation_enable: false,
+                show_syntax_errors: true,
                 editor_settings: ResolvedEditorSettings {
                     configuration: None,
                     lint_preview: Some(false),
@@ -726,6 +745,7 @@ mod tests {
                 lint_enable: true,
                 disable_rule_comment_enable: false,
                 fix_violation_enable: true,
+                show_syntax_errors: true,
                 editor_settings: ResolvedEditorSettings {
                     configuration: None,
                     lint_preview: None,


### PR DESCRIPTION
## Summary

Follow-up from #11901 

This PR adds a new server setting to show / hide syntax errors.

## Test Plan

### VS Code

Using https://github.com/astral-sh/ruff-vscode/pull/504 with the following config:

```json
{
  "ruff.nativeServer": true,
  "ruff.path": ["/Users/dhruv/work/astral/ruff/target/debug/ruff"],
  "ruff.showSyntaxErrors": true
}
```

First, set `ruff.showSyntaxErrors` to `true`:
<img width="1177" alt="Screenshot 2024-06-27 at 08 34 58" src="https://github.com/astral-sh/ruff/assets/67177269/5d77547a-a908-4a00-8714-7c00784e8679">

And then set it to `false`:
<img width="1185" alt="Screenshot 2024-06-27 at 08 35 19" src="https://github.com/astral-sh/ruff/assets/67177269/9720f089-f10c-420b-a2c1-2bbb2245be35">

### Neovim

Using the following Ruff server config:

```lua
require('lspconfig').ruff.setup {
  init_options = {
    settings = {
      showSyntaxErrors = false,
    },
  },
}
```

First, set `showSyntaxErrors` to `true`:
<img width="1279" alt="Screenshot 2024-06-27 at 08 28 03" src="https://github.com/astral-sh/ruff/assets/67177269/e694e231-91ba-47f8-8e8a-ad2e82b85a45">

And then set it to `false`:
<img width="1284" alt="Screenshot 2024-06-27 at 08 28 20" src="https://github.com/astral-sh/ruff/assets/67177269/25b86a57-02b1-44f7-9f65-cf5fdde93b0c">
