### PR TITLE
Use `TokenSource` to find new location for re-lexing

### DIFF
--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@f_string_unclosed_lbrace.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@f_string_unclosed_lbrace.py.snap
@@ -11,141 +11,105 @@ Module(
         body: [
             Expr(
                 StmtExpr {
-                    range: 0..4,
+                    range: 0..38,
                     value: FString(
                         ExprFString {
-                            range: 0..4,
-                            value: FStringValue {
-                                inner: Single(
-                                    FString(
-                                        FString {
-                                            range: 0..4,
-                                            elements: [
-                                                Expression(
-                                                    FStringExpressionElement {
-                                                        range: 2..3,
-                                                        expression: Name(
-                                                            ExprName {
-                                                                range: 3..3,
-                                                                id: "",
-                                                                ctx: Invalid,
-                                                            },
-                                                        ),
-                                                        debug_text: None,
-                                                        conversion: None,
-                                                        format_spec: None,
-                                                    },
-                                                ),
-                                            ],
-                                            flags: FStringFlags {
-                                                quote_style: Double,
-                                                prefix: Regular,
-                                                triple_quoted: false,
-                                            },
-                                        },
-                                    ),
-                                ),
-                            },
-                        },
-                    ),
-                },
-            ),
-            Expr(
-                StmtExpr {
-                    range: 5..14,
-                    value: FString(
-                        ExprFString {
-                            range: 5..14,
-                            value: FStringValue {
-                                inner: Single(
-                                    FString(
-                                        FString {
-                                            range: 5..14,
-                                            elements: [
-                                                Expression(
-                                                    FStringExpressionElement {
-                                                        range: 7..14,
-                                                        expression: Name(
-                                                            ExprName {
-                                                                range: 8..11,
-                                                                id: "foo",
-                                                                ctx: Load,
-                                                            },
-                                                        ),
-                                                        debug_text: None,
-                                                        conversion: None,
-                                                        format_spec: None,
-                                                    },
-                                                ),
-                                            ],
-                                            flags: FStringFlags {
-                                                quote_style: Double,
-                                                prefix: Regular,
-                                                triple_quoted: false,
-                                            },
-                                        },
-                                    ),
-                                ),
-                            },
-                        },
-                    ),
-                },
-            ),
-            Expr(
-                StmtExpr {
-                    range: 15..23,
-                    value: FString(
-                        ExprFString {
-                            range: 15..23,
-                            value: FStringValue {
-                                inner: Single(
-                                    FString(
-                                        FString {
-                                            range: 15..23,
-                                            elements: [
-                                                Expression(
-                                                    FStringExpressionElement {
-                                                        range: 17..22,
-                                                        expression: Name(
-                                                            ExprName {
-                                                                range: 18..21,
-                                                                id: "foo",
-                                                                ctx: Load,
-                                                            },
-                                                        ),
-                                                        debug_text: Some(
-                                                            DebugText {
-                                                                leading: "",
-                                                                trailing: "=",
-                                                            },
-                                                        ),
-                                                        conversion: None,
-                                                        format_spec: None,
-                                                    },
-                                                ),
-                                            ],
-                                            flags: FStringFlags {
-                                                quote_style: Double,
-                                                prefix: Regular,
-                                                triple_quoted: false,
-                                            },
-                                        },
-                                    ),
-                                ),
-                            },
-                        },
-                    ),
-                },
-            ),
-            Expr(
-                StmtExpr {
-                    range: 24..37,
-                    value: FString(
-                        ExprFString {
-                            range: 24..37,
+                            range: 0..38,
                             value: FStringValue {
                                 inner: Concatenated(
                                     [
+                                        FString(
+                                            FString {
+                                                range: 0..4,
+                                                elements: [
+                                                    Expression(
+                                                        FStringExpressionElement {
+                                                            range: 2..3,
+                                                            expression: Name(
+                                                                ExprName {
+                                                                    range: 3..3,
+                                                                    id: "",
+                                                                    ctx: Invalid,
+                                                                },
+                                                            ),
+                                                            debug_text: None,
+                                                            conversion: None,
+                                                            format_spec: None,
+                                                        },
+                                                    ),
+                                                ],
+                                                flags: FStringFlags {
+                                                    quote_style: Double,
+                                                    prefix: Regular,
+                                                    triple_quoted: false,
+                                                },
+                                            },
+                                        ),
+                                        FString(
+                                            FString {
+                                                range: 5..14,
+                                                elements: [
+                                                    Expression(
+                                                        FStringExpressionElement {
+                                                            range: 7..8,
+                                                            expression: Name(
+                                                                ExprName {
+                                                                    range: 8..8,
+                                                                    id: "",
+                                                                    ctx: Invalid,
+                                                                },
+                                                            ),
+                                                            debug_text: None,
+                                                            conversion: None,
+                                                            format_spec: None,
+                                                        },
+                                                    ),
+                                                    Literal(
+                                                        FStringLiteralElement {
+                                                            range: 8..13,
+                                                            value: "foo!r",
+                                                        },
+                                                    ),
+                                                ],
+                                                flags: FStringFlags {
+                                                    quote_style: Double,
+                                                    prefix: Regular,
+                                                    triple_quoted: false,
+                                                },
+                                            },
+                                        ),
+                                        FString(
+                                            FString {
+                                                range: 15..23,
+                                                elements: [
+                                                    Expression(
+                                                        FStringExpressionElement {
+                                                            range: 17..22,
+                                                            expression: Name(
+                                                                ExprName {
+                                                                    range: 18..21,
+                                                                    id: "foo",
+                                                                    ctx: Load,
+                                                                },
+                                                            ),
+                                                            debug_text: Some(
+                                                                DebugText {
+                                                                    leading: "",
+                                                                    trailing: "=",
+                                                                },
+                                                            ),
+                                                            conversion: None,
+                                                            format_spec: None,
+                                                        },
+                                                    ),
+                                                ],
+                                                flags: FStringFlags {
+                                                    quote_style: Double,
+                                                    prefix: Regular,
+                                                    triple_quoted: false,
+                                                },
+                                            },
+                                        ),
                                         FString(
                                             FString {
                                                 range: 24..28,
@@ -175,7 +139,7 @@ Module(
                                         ),
                                         FString(
                                             FString {
-                                                range: 29..37,
+                                                range: 29..38,
                                                 elements: [
                                                     Expression(
                                                         FStringExpressionElement {
@@ -223,24 +187,8 @@ Module(
 
   |
 1 | f"{"
-  |      Syntax Error: f-string: unterminated string
 2 | f"{foo!r"
-3 | f"{foo="
-  |
-
-
-  |
-1 | f"{"
-  |      Syntax Error: f-string: unterminated string
-2 | f"{foo!r"
-3 | f"{foo="
-  |
-
-
-  |
-1 | f"{"
-2 | f"{foo!r"
-  |        ^^ Syntax Error: missing closing quote in string literal
+  | ^^ Syntax Error: Expected FStringEnd, found FStringStart
 3 | f"{foo="
 4 | f"{"
   |
@@ -249,35 +197,7 @@ Module(
   |
 1 | f"{"
 2 | f"{foo!r"
-  |           Syntax Error: f-string: unterminated string
-3 | f"{foo="
-4 | f"{"
-  |
-
-
-  |
-1 | f"{"
-2 | f"{foo!r"
-  |           Syntax Error: f-string: unterminated string
-3 | f"{foo="
-4 | f"{"
-  |
-
-
-  |
-1 | f"{"
-2 | f"{foo!r"
-3 | f"{foo="
-  | ^^ Syntax Error: f-string: expecting '}'
-4 | f"{"
-5 | f"""{"""
-  |
-
-
-  |
-1 | f"{"
-2 | f"{foo!r"
-  |           Syntax Error: Expected FStringEnd, found Unknown
+  |    ^^^^^ Syntax Error: Expected an expression
 3 | f"{foo="
 4 | f"{"
   |
@@ -294,21 +214,10 @@ Module(
 
 
   |
-1 | f"{"
 2 | f"{foo!r"
 3 | f"{foo="
-  |          Syntax Error: f-string: unterminated string
 4 | f"{"
-5 | f"""{"""
-  |
-
-
-  |
-1 | f"{"
-2 | f"{foo!r"
-3 | f"{foo="
-  |          Syntax Error: f-string: unterminated string
-4 | f"{"
+  | ^^ Syntax Error: Expected FStringEnd, found FStringStart
 5 | f"""{"""
   |
 
@@ -317,7 +226,7 @@ Module(
 2 | f"{foo!r"
 3 | f"{foo="
 4 | f"{"
-  |    ^ Syntax Error: missing closing quote in string literal
+  |    ^ Syntax Error: Expected an expression
 5 | f"""{"""
   |
 
@@ -326,15 +235,19 @@ Module(
 3 | f"{foo="
 4 | f"{"
 5 | f"""{"""
-  | ^^^^ Syntax Error: Expected FStringEnd, found FStringStart
+  |______^
   |
 
 
   |
-3 | f"{foo="
 4 | f"{"
 5 | f"""{"""
-  |      ^^^ Syntax Error: Expected an expression
+  |
+
+
+  |
+4 | f"{"
+5 | f"""{"""
   |
 
 

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@f_string_unclosed_lbrace.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@f_string_unclosed_lbrace.py.snap
@@ -11,105 +11,141 @@ Module(
         body: [
             Expr(
                 StmtExpr {
-                    range: 0..38,
+                    range: 0..4,
                     value: FString(
                         ExprFString {
-                            range: 0..38,
+                            range: 0..4,
+                            value: FStringValue {
+                                inner: Single(
+                                    FString(
+                                        FString {
+                                            range: 0..4,
+                                            elements: [
+                                                Expression(
+                                                    FStringExpressionElement {
+                                                        range: 2..3,
+                                                        expression: Name(
+                                                            ExprName {
+                                                                range: 3..3,
+                                                                id: "",
+                                                                ctx: Invalid,
+                                                            },
+                                                        ),
+                                                        debug_text: None,
+                                                        conversion: None,
+                                                        format_spec: None,
+                                                    },
+                                                ),
+                                            ],
+                                            flags: FStringFlags {
+                                                quote_style: Double,
+                                                prefix: Regular,
+                                                triple_quoted: false,
+                                            },
+                                        },
+                                    ),
+                                ),
+                            },
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 5..14,
+                    value: FString(
+                        ExprFString {
+                            range: 5..14,
+                            value: FStringValue {
+                                inner: Single(
+                                    FString(
+                                        FString {
+                                            range: 5..14,
+                                            elements: [
+                                                Expression(
+                                                    FStringExpressionElement {
+                                                        range: 7..14,
+                                                        expression: Name(
+                                                            ExprName {
+                                                                range: 8..11,
+                                                                id: "foo",
+                                                                ctx: Load,
+                                                            },
+                                                        ),
+                                                        debug_text: None,
+                                                        conversion: None,
+                                                        format_spec: None,
+                                                    },
+                                                ),
+                                            ],
+                                            flags: FStringFlags {
+                                                quote_style: Double,
+                                                prefix: Regular,
+                                                triple_quoted: false,
+                                            },
+                                        },
+                                    ),
+                                ),
+                            },
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 15..23,
+                    value: FString(
+                        ExprFString {
+                            range: 15..23,
+                            value: FStringValue {
+                                inner: Single(
+                                    FString(
+                                        FString {
+                                            range: 15..23,
+                                            elements: [
+                                                Expression(
+                                                    FStringExpressionElement {
+                                                        range: 17..22,
+                                                        expression: Name(
+                                                            ExprName {
+                                                                range: 18..21,
+                                                                id: "foo",
+                                                                ctx: Load,
+                                                            },
+                                                        ),
+                                                        debug_text: Some(
+                                                            DebugText {
+                                                                leading: "",
+                                                                trailing: "=",
+                                                            },
+                                                        ),
+                                                        conversion: None,
+                                                        format_spec: None,
+                                                    },
+                                                ),
+                                            ],
+                                            flags: FStringFlags {
+                                                quote_style: Double,
+                                                prefix: Regular,
+                                                triple_quoted: false,
+                                            },
+                                        },
+                                    ),
+                                ),
+                            },
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 24..37,
+                    value: FString(
+                        ExprFString {
+                            range: 24..37,
                             value: FStringValue {
                                 inner: Concatenated(
                                     [
-                                        FString(
-                                            FString {
-                                                range: 0..4,
-                                                elements: [
-                                                    Expression(
-                                                        FStringExpressionElement {
-                                                            range: 2..3,
-                                                            expression: Name(
-                                                                ExprName {
-                                                                    range: 3..3,
-                                                                    id: "",
-                                                                    ctx: Invalid,
-                                                                },
-                                                            ),
-                                                            debug_text: None,
-                                                            conversion: None,
-                                                            format_spec: None,
-                                                        },
-                                                    ),
-                                                ],
-                                                flags: FStringFlags {
-                                                    quote_style: Double,
-                                                    prefix: Regular,
-                                                    triple_quoted: false,
-                                                },
-                                            },
-                                        ),
-                                        FString(
-                                            FString {
-                                                range: 5..14,
-                                                elements: [
-                                                    Expression(
-                                                        FStringExpressionElement {
-                                                            range: 7..8,
-                                                            expression: Name(
-                                                                ExprName {
-                                                                    range: 8..8,
-                                                                    id: "",
-                                                                    ctx: Invalid,
-                                                                },
-                                                            ),
-                                                            debug_text: None,
-                                                            conversion: None,
-                                                            format_spec: None,
-                                                        },
-                                                    ),
-                                                    Literal(
-                                                        FStringLiteralElement {
-                                                            range: 8..13,
-                                                            value: "foo!r",
-                                                        },
-                                                    ),
-                                                ],
-                                                flags: FStringFlags {
-                                                    quote_style: Double,
-                                                    prefix: Regular,
-                                                    triple_quoted: false,
-                                                },
-                                            },
-                                        ),
-                                        FString(
-                                            FString {
-                                                range: 15..23,
-                                                elements: [
-                                                    Expression(
-                                                        FStringExpressionElement {
-                                                            range: 17..22,
-                                                            expression: Name(
-                                                                ExprName {
-                                                                    range: 18..21,
-                                                                    id: "foo",
-                                                                    ctx: Load,
-                                                                },
-                                                            ),
-                                                            debug_text: Some(
-                                                                DebugText {
-                                                                    leading: "",
-                                                                    trailing: "=",
-                                                                },
-                                                            ),
-                                                            conversion: None,
-                                                            format_spec: None,
-                                                        },
-                                                    ),
-                                                ],
-                                                flags: FStringFlags {
-                                                    quote_style: Double,
-                                                    prefix: Regular,
-                                                    triple_quoted: false,
-                                                },
-                                            },
-                                        ),
                                         FString(
                                             FString {
                                                 range: 24..28,
@@ -139,7 +175,7 @@ Module(
                                         ),
                                         FString(
                                             FString {
-                                                range: 29..38,
+                                                range: 29..37,
                                                 elements: [
                                                     Expression(
                                                         FStringExpressionElement {
@@ -187,8 +223,24 @@ Module(
 
   |
 1 | f"{"
+  |      Syntax Error: f-string: unterminated string
 2 | f"{foo!r"
-  | ^^ Syntax Error: Expected FStringEnd, found FStringStart
+3 | f"{foo="
+  |
+
+
+  |
+1 | f"{"
+  |      Syntax Error: f-string: unterminated string
+2 | f"{foo!r"
+3 | f"{foo="
+  |
+
+
+  |
+1 | f"{"
+2 | f"{foo!r"
+  |        ^^ Syntax Error: missing closing quote in string literal
 3 | f"{foo="
 4 | f"{"
   |
@@ -197,7 +249,35 @@ Module(
   |
 1 | f"{"
 2 | f"{foo!r"
-  |    ^^^^^ Syntax Error: Expected an expression
+  |           Syntax Error: f-string: unterminated string
+3 | f"{foo="
+4 | f"{"
+  |
+
+
+  |
+1 | f"{"
+2 | f"{foo!r"
+  |           Syntax Error: f-string: unterminated string
+3 | f"{foo="
+4 | f"{"
+  |
+
+
+  |
+1 | f"{"
+2 | f"{foo!r"
+3 | f"{foo="
+  | ^^ Syntax Error: f-string: expecting '}'
+4 | f"{"
+5 | f"""{"""
+  |
+
+
+  |
+1 | f"{"
+2 | f"{foo!r"
+  |           Syntax Error: Expected FStringEnd, found Unknown
 3 | f"{foo="
 4 | f"{"
   |
@@ -214,19 +294,30 @@ Module(
 
 
   |
+1 | f"{"
+2 | f"{foo!r"
+3 | f"{foo="
+  |          Syntax Error: f-string: unterminated string
+4 | f"{"
+5 | f"""{"""
+  |
+
+
+  |
+1 | f"{"
+2 | f"{foo!r"
+3 | f"{foo="
+  |          Syntax Error: f-string: unterminated string
+4 | f"{"
+5 | f"""{"""
+  |
+
+
+  |
 2 | f"{foo!r"
 3 | f"{foo="
 4 | f"{"
-  | ^^ Syntax Error: Expected FStringEnd, found FStringStart
-5 | f"""{"""
-  |
-
-
-  |
-2 | f"{foo!r"
-3 | f"{foo="
-4 | f"{"
-  |    ^ Syntax Error: Expected an expression
+  |    ^ Syntax Error: missing closing quote in string literal
 5 | f"""{"""
   |
 
@@ -235,19 +326,15 @@ Module(
 3 | f"{foo="
 4 | f"{"
 5 | f"""{"""
-  |______^
+  | ^^^^ Syntax Error: Expected FStringEnd, found FStringStart
   |
 
 
   |
+3 | f"{foo="
 4 | f"{"
 5 | f"""{"""
-  |
-
-
-  |
-4 | f"{"
-5 | f"""{"""
+  |      ^^^ Syntax Error: Expected an expression
   |
 
 

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@implicitly_concatenated_unterminated_string.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@implicitly_concatenated_unterminated_string.py.snap
@@ -162,6 +162,15 @@ Module(
 
   |
 1 | 'hello' 'world
+  |               ^ Syntax Error: Expected a statement
+2 | 1 + 1
+3 | 'hello' f'world {x}
+4 | 2 + 2
+  |
+
+
+  |
+1 | 'hello' 'world
 2 | 1 + 1
 3 | 'hello' f'world {x}
   |                     Syntax Error: f-string: unterminated string

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@re_lexing__fstring_format_spec_1.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@re_lexing__fstring_format_spec_1.py.snap
@@ -335,8 +335,8 @@ Module(
   |
 5 | f'middle {'string':\
 6 |         'format spec'}
+  |                       ^ Syntax Error: Expected a statement
 7 | 
-  | ^ Syntax Error: Expected a statement
 8 | f'middle {'string':\\
 9 |         'format spec'}
   |

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@re_lexing__line_continuation_windows_eol.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@re_lexing__line_continuation_windows_eol.py.snap
@@ -82,8 +82,9 @@ Module(
 
   |
 1 |   call(a, b, # comment \
-2 | / 
-3 | | def bar():
+  |  _______________________^
+2 | | 
   | |_^ Syntax Error: Expected ')', found newline
+3 |   def bar():
 4 |       pass
   |


### PR DESCRIPTION
## Summary

This PR splits the re-lexing logic into two parts:
1. `TokenSource`: The token source will be responsible to find the position the lexer needs to be moved to
2. `Lexer`: The lexer will be responsible to reduce the nesting level and move itself to the new position if recovered from a parenthesized context

This split makes it easy to find the new lexer position without needing to implement the backwards lexing logic again which would need to handle cases involving:
* Different kinds of newlines
* Line continuation character(s)
* Comments
* Whitespaces

### F-strings

This change did reveal one thing about re-lexing f-strings. Consider the following example:
```py
f'{'
#  ^
f'foo'
```

Here, the quote as highlighted by the caret (`^`) is the start of a string inside an f-string expression. This is unterminated string which means the token emitted is actually `Unknown`. The parser tries to recover from it but there's no newline token in the vector so the new logic doesn't recover from it. The previous logic does recover because it's looking at the raw characters instead.

The parser would be at `FStringStart` (the one for the second line) when it calls into the re-lexing logic to recover from an unterminated f-string on the first line. So, moving backwards the first character encountered is a newline character but the first token encountered is an `Unknown` token.

This is improved with #12067 

fixes: #12046 
fixes: #12036

## Test Plan

Update the snapshot and validate the changes.
