### PR TITLE
Update documentation to mention `etcetera` crate instead of `dirs` for user configuration discovery

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -263,15 +263,15 @@ config file.
 There are a few exceptions to these rules:
 
 1. In locating the "closest" `pyproject.toml` file for a given path, Ruff ignores any
-    `pyproject.toml` files that lack a `[tool.ruff]` section.
+    `pyproject.toml` files that lack a `[tool.ruff]` section. ddd
 1. If a configuration file is passed directly via `--config`, those settings are used for _all_
     analyzed files, and any relative paths in that configuration file (like `exclude` globs or
     `src` paths) are resolved relative to the _current_ working directory.
 1. If no config file is found in the filesystem hierarchy, Ruff will fall back to using
     a default configuration. If a user-specific configuration file exists
     at `${config_dir}/ruff/pyproject.toml`, that file will be used instead of the default
-    configuration, with `${config_dir}` being determined via the [`dirs`](https://docs.rs/dirs/4.0.0/dirs/fn.config_dir.html)
-    crate, and all relative paths being again resolved relative to the _current working directory_.
+    configuration, with `${config_dir}` being determined via [`etcetera`'s native strategy](https://docs.rs/etcetera/latest/etcetera/#native-strategy),
+    and all relative paths being again resolved relative to the _current working directory_.
 1. Any config-file-supported settings that are provided on the command-line (e.g., via
     `--select`) will override the settings in _every_ resolved configuration file.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -263,7 +263,7 @@ config file.
 There are a few exceptions to these rules:
 
 1. In locating the "closest" `pyproject.toml` file for a given path, Ruff ignores any
-    `pyproject.toml` files that lack a `[tool.ruff]` section. ddd
+    `pyproject.toml` files that lack a `[tool.ruff]` section.
 1. If a configuration file is passed directly via `--config`, those settings are used for _all_
     analyzed files, and any relative paths in that configuration file (like `exclude` globs or
     `src` paths) are resolved relative to the _current_ working directory.


### PR DESCRIPTION
## Summary

We now use the `etcetera` crate to discover the configuration directory. This PR updates the documentation to reflect this change.


