### PR TITLE
[`numpy`] Update `NPY201` to include exception deprecations

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/numpy/NPY201.py
+++ b/crates/ruff_linter/resources/test/fixtures/numpy/NPY201.py
@@ -114,3 +114,13 @@ def func():
     np.cumproduct([1, 2, 3])
 
     np.product([1, 2, 3])
+
+    np.trapz([1, 2, 3])
+
+    np.in1d([1, 2], [1, 3, 5])
+
+    np.AxisError
+
+    np.ComplexWarning
+
+    np.compare_chararrays

--- a/crates/ruff_linter/src/rules/numpy/rules/numpy_2_0_deprecation.rs
+++ b/crates/ruff_linter/src/rules/numpy/rules/numpy_2_0_deprecation.rs
@@ -574,6 +574,86 @@ pub(crate) fn numpy_2_0_deprecation(checker: &mut Checker, expr: &Expr) {
                     compatibility: Compatibility::BackwardsCompatible,
                 },
             }),
+            ["numpy", "AxisError"] => Some(Replacement {
+                existing: "AxisError",
+                details: Details::AutoImport {
+                    path: "numpy.exceptions",
+                    name: "AxisError",
+                    compatibility: Compatibility::BackwardsCompatible,
+                },
+            }),
+            ["numpy", "ComplexWarning"] => Some(Replacement {
+                existing: "ComplexWarning",
+                details: Details::AutoImport {
+                    path: "numpy.exceptions",
+                    name: "ComplexWarning",
+                    compatibility: Compatibility::BackwardsCompatible,
+                },
+            }),
+            ["numpy", "DTypePromotionError"] => Some(Replacement {
+                existing: "DTypePromotionError",
+                details: Details::AutoImport {
+                    path: "numpy.exceptions",
+                    name: "DTypePromotionError",
+                    compatibility: Compatibility::BackwardsCompatible,
+                },
+            }),
+            ["numpy", "ModuleDeprecationWarning"] => Some(Replacement {
+                existing: "ModuleDeprecationWarning",
+                details: Details::AutoImport {
+                    path: "numpy.exceptions",
+                    name: "ModuleDeprecationWarning",
+                    compatibility: Compatibility::BackwardsCompatible,
+                },
+            }),
+            ["numpy", "RankWarning"] => Some(Replacement {
+                existing: "RankWarning",
+                details: Details::AutoImport {
+                    path: "numpy.exceptions",
+                    name: "RankWarning",
+                    compatibility: Compatibility::Breaking,
+                },
+            }),
+            ["numpy", "TooHardError"] => Some(Replacement {
+                existing: "TooHardError",
+                details: Details::AutoImport {
+                    path: "numpy.exceptions",
+                    name: "TooHardError",
+                    compatibility: Compatibility::BackwardsCompatible,
+                },
+            }),
+            ["numpy", "VisibleDeprecationWarning"] => Some(Replacement {
+                existing: "VisibleDeprecationWarning",
+                details: Details::AutoImport {
+                    path: "numpy.exceptions",
+                    name: "VisibleDeprecationWarning",
+                    compatibility: Compatibility::BackwardsCompatible,
+                },
+            }),
+            ["numpy", "compare_chararrays"] => Some(Replacement {
+                existing: "compare_chararrays",
+                details: Details::AutoImport {
+                    path: "numpy.char",
+                    name: "compare_chararrays",
+                    compatibility: Compatibility::BackwardsCompatible,
+                },
+            }),
+            ["numpy", "chararray"] => Some(Replacement {
+                existing: "chararray",
+                details: Details::AutoImport {
+                    path: "numpy.char",
+                    name: "chararray",
+                    compatibility: Compatibility::BackwardsCompatible,
+                },
+            }),
+            ["numpy", "format_parser"] => Some(Replacement {
+                existing: "format_parser",
+                details: Details::AutoImport {
+                    path: "numpy.rec",
+                    name: "format_parser",
+                    compatibility: Compatibility::BackwardsCompatible,
+                },
+            }),
             _ => None,
         });
 

--- a/crates/ruff_linter/src/rules/numpy/snapshots/ruff_linter__rules__numpy__tests__numpy2-deprecation_NPY201.py.snap
+++ b/crates/ruff_linter/src/rules/numpy/snapshots/ruff_linter__rules__numpy__tests__numpy2-deprecation_NPY201.py.snap
@@ -909,6 +909,7 @@ NPY201.py:114:5: NPY201 [*] `np.cumproduct` will be removed in NumPy 2.0. Use `n
     114 |+    np.cumprod([1, 2, 3])
 115 115 | 
 116 116 |     np.product([1, 2, 3])
+117 117 | 
 
 NPY201.py:116:5: NPY201 [*] `np.product` will be removed in NumPy 2.0. Use `numpy.prod` instead.
     |
@@ -916,6 +917,8 @@ NPY201.py:116:5: NPY201 [*] `np.product` will be removed in NumPy 2.0. Use `nump
 115 | 
 116 |     np.product([1, 2, 3])
     |     ^^^^^^^^^^ NPY201
+117 | 
+118 |     np.trapz([1, 2, 3])
     |
     = help: Replace with `numpy.prod`
 
@@ -925,5 +928,94 @@ NPY201.py:116:5: NPY201 [*] `np.product` will be removed in NumPy 2.0. Use `nump
 115 115 | 
 116     |-    np.product([1, 2, 3])
     116 |+    np.prod([1, 2, 3])
+117 117 | 
+118 118 |     np.trapz([1, 2, 3])
+119 119 | 
 
+NPY201.py:118:5: NPY201 [*] `np.trapz` will be removed in NumPy 2.0. Use `numpy.trapezoid` on NumPy 2.0, or ignore this warning on earlier versions.
+    |
+116 |     np.product([1, 2, 3])
+117 | 
+118 |     np.trapz([1, 2, 3])
+    |     ^^^^^^^^ NPY201
+119 | 
+120 |     np.in1d([1, 2], [1, 3, 5])
+    |
+    = help: Replace with `numpy.trapezoid` (requires NumPy 2.0 or greater)
 
+ℹ Unsafe fix
+115 115 | 
+116 116 |     np.product([1, 2, 3])
+117 117 | 
+118     |-    np.trapz([1, 2, 3])
+    118 |+    np.trapezoid([1, 2, 3])
+119 119 | 
+120 120 |     np.in1d([1, 2], [1, 3, 5])
+121 121 | 
+
+NPY201.py:120:5: NPY201 [*] `np.in1d` will be removed in NumPy 2.0. Use `numpy.isin` instead.
+    |
+118 |     np.trapz([1, 2, 3])
+119 | 
+120 |     np.in1d([1, 2], [1, 3, 5])
+    |     ^^^^^^^ NPY201
+121 | 
+122 |     np.AxisError
+    |
+    = help: Replace with `numpy.isin`
+
+ℹ Safe fix
+117 117 | 
+118 118 |     np.trapz([1, 2, 3])
+119 119 | 
+120     |-    np.in1d([1, 2], [1, 3, 5])
+    120 |+    np.isin([1, 2], [1, 3, 5])
+121 121 | 
+122 122 |     np.AxisError
+123 123 | 
+
+NPY201.py:122:5: NPY201 [*] `np.AxisError` will be removed in NumPy 2.0. Use `numpy.exceptions.AxisError` instead.
+    |
+120 |     np.in1d([1, 2], [1, 3, 5])
+121 | 
+122 |     np.AxisError
+    |     ^^^^^^^^^^^^ NPY201
+123 | 
+124 |     np.ComplexWarning
+    |
+    = help: Replace with `numpy.exceptions.AxisError`
+
+ℹ Safe fix
+    1   |+from numpy.exceptions import AxisError
+1   2   | def func():
+2   3   |     import numpy as np
+3   4   | 
+--------------------------------------------------------------------------------
+119 120 | 
+120 121 |     np.in1d([1, 2], [1, 3, 5])
+121 122 | 
+122     |-    np.AxisError
+    123 |+    AxisError
+123 124 | 
+124 125 |     np.ComplexWarning
+
+NPY201.py:124:5: NPY201 [*] `np.ComplexWarning` will be removed in NumPy 2.0. Use `numpy.exceptions.ComplexWarning` instead.
+    |
+122 |     np.AxisError
+123 | 
+124 |     np.ComplexWarning
+    |     ^^^^^^^^^^^^^^^^^ NPY201
+    |
+    = help: Replace with `numpy.exceptions.ComplexWarning`
+
+ℹ Safe fix
+    1   |+from numpy.exceptions import ComplexWarning
+1   2   | def func():
+2   3   |     import numpy as np
+3   4   | 
+--------------------------------------------------------------------------------
+121 122 | 
+122 123 |     np.AxisError
+123 124 | 
+124     |-    np.ComplexWarning
+    125 |+    ComplexWarning

--- a/crates/ruff_linter/src/rules/numpy/snapshots/ruff_linter__rules__numpy__tests__numpy2-deprecation_NPY201.py.snap
+++ b/crates/ruff_linter/src/rules/numpy/snapshots/ruff_linter__rules__numpy__tests__numpy2-deprecation_NPY201.py.snap
@@ -998,6 +998,7 @@ NPY201.py:122:5: NPY201 [*] `np.AxisError` will be removed in NumPy 2.0. Use `nu
     123 |+    AxisError
 123 124 | 
 124 125 |     np.ComplexWarning
+125 126 | 
 
 NPY201.py:124:5: NPY201 [*] `np.ComplexWarning` will be removed in NumPy 2.0. Use `numpy.exceptions.ComplexWarning` instead.
     |
@@ -1005,6 +1006,8 @@ NPY201.py:124:5: NPY201 [*] `np.ComplexWarning` will be removed in NumPy 2.0. Us
 123 | 
 124 |     np.ComplexWarning
     |     ^^^^^^^^^^^^^^^^^ NPY201
+125 | 
+126 |     np.compare_chararrays
     |
     = help: Replace with `numpy.exceptions.ComplexWarning`
 
@@ -1019,3 +1022,26 @@ NPY201.py:124:5: NPY201 [*] `np.ComplexWarning` will be removed in NumPy 2.0. Us
 123 124 | 
 124     |-    np.ComplexWarning
     125 |+    ComplexWarning
+125 126 | 
+126 127 |     np.compare_chararrays
+
+NPY201.py:126:5: NPY201 [*] `np.compare_chararrays` will be removed in NumPy 2.0. Use `numpy.char.compare_chararrays` instead.
+    |
+124 |     np.ComplexWarning
+125 | 
+126 |     np.compare_chararrays
+    |     ^^^^^^^^^^^^^^^^^^^^^ NPY201
+    |
+    = help: Replace with `numpy.char.compare_chararrays`
+
+ℹ Safe fix
+    1   |+from numpy.char import compare_chararrays
+1   2   | def func():
+2   3   |     import numpy as np
+3   4   | 
+--------------------------------------------------------------------------------
+123 124 | 
+124 125 |     np.ComplexWarning
+125 126 | 
+126     |-    np.compare_chararrays
+    127 |+    compare_chararrays

--- a/crates/ruff_linter/src/test.rs
+++ b/crates/ruff_linter/src/test.rs
@@ -90,7 +90,7 @@ pub fn test_snippet(contents: &str, settings: &LinterSettings) -> Vec<Message> {
 }
 
 thread_local! {
-    static MAX_ITERATIONS: std::cell::Cell<usize> = const { std::cell::Cell::new(10) };
+    static MAX_ITERATIONS: std::cell::Cell<usize> = const { std::cell::Cell::new(12) };
 }
 
 pub fn set_max_iterations(max: usize) {


### PR DESCRIPTION
Hi!

This PR updates `NPY201` rule to address https://github.com/astral-sh/ruff/issues/12034 and partially https://github.com/numpy/numpy/issues/26800. 