### PR TITLE
Avoid consuming newline for unterminated string

### DIFF
--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@implicitly_concatenated_unterminated_string.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@implicitly_concatenated_unterminated_string.py.snap
@@ -162,6 +162,15 @@ Module(
 
   |
 1 | 'hello' 'world
+  |               ^ Syntax Error: Expected a statement
+2 | 1 + 1
+3 | 'hello' f'world {x}
+4 | 2 + 2
+  |
+
+
+  |
+1 | 'hello' 'world
 2 | 1 + 1
 3 | 'hello' f'world {x}
   |                     Syntax Error: f-string: unterminated string

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@re_lexing__fstring_format_spec_1.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@re_lexing__fstring_format_spec_1.py.snap
@@ -335,8 +335,8 @@ Module(
   |
 5 | f'middle {'string':\
 6 |         'format spec'}
+  |                       ^ Syntax Error: Expected a statement
 7 | 
-  | ^ Syntax Error: Expected a statement
 8 | f'middle {'string':\\
 9 |         'format spec'}
   |


### PR DESCRIPTION
## Summary

This PR fixes the lexer logic to **not** consume the newline character for an unterminated string literal.

Currently, the lexer would consume it to be part of the string itself but that would be bad for recovery because then the lexer wouldn't emit the newline token ever. This PR fixes that to avoid consuming the newline character in that case.

This was discovered during https://github.com/astral-sh/ruff/pull/12060.

## Test Plan

Update the snapshots and validate them.