### PR TITLE
Add necessary permissions for cargo-dist Docker build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,6 +100,9 @@ jobs:
     with:
       plan: ${{ needs.plan.outputs.val }}
     secrets: inherit
+    permissions:
+      packages: write
+      contents: read
 
   # Build and package all the platform-agnostic(ish) things
   build-global-artifacts:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -273,6 +273,6 @@ publish-jobs = ["./publish-pypi"]
 # Announcement jobs to run in CI
 post-announce-jobs = ["./notify-dependents"]
 # Skip checking whether the specified configuration files are up to date
-#allow-dirty = ["ci"]
+allow-dirty = ["ci"]
 # Whether to install an updater program
 install-updater = false


### PR DESCRIPTION
## Summary

We have to do the same thing in uv: https://github.com/astral-sh/uv/blob/bf46792839e6d3dbb09d31aa497b9945b8f5151b/.github/workflows/release.yml#L103.

I think I undid this change locally while testing, it was definitely in the branch at one point!
