### PR TITLE
Publish docs and playground on `cargo-dist` release

### DIFF
--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -1,3 +1,7 @@
+# Publish the Ruff documentation.
+#
+# Assumed to run as a subworkflow of .github/workflows/release.yml; specifically, as a post-announce
+# job within `cargo-dist`.
 name: mkdocs
 
 on:
@@ -7,8 +11,11 @@ on:
         description: "The commit SHA, tag, or branch to publish. Uses the default branch if not specified."
         default: ""
         type: string
-  release:
-    types: [published]
+  workflow_call:
+    inputs:
+      plan:
+        required: true
+        type: string
 
 jobs:
   mkdocs:

--- a/.github/workflows/publish-playground.yaml
+++ b/.github/workflows/publish-playground.yaml
@@ -1,9 +1,16 @@
+# Publish the Ruff playground.
+#
+# Assumed to run as a subworkflow of .github/workflows/release.yml; specifically, as a post-announce
+# job within `cargo-dist`.
 name: "[Playground] Release"
 
 on:
   workflow_dispatch:
-  release:
-    types: [published]
+  workflow_call:
+    inputs:
+      plan:
+        required: true
+        type: string
 
 env:
   CARGO_INCREMENTAL: 0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -247,3 +247,21 @@ jobs:
     with:
       plan: ${{ needs.plan.outputs.val }}
     secrets: inherit
+
+  custom-publish-docs:
+    needs:
+      - plan
+      - announce
+    uses: ./.github/workflows/publish-docs.yml
+    with:
+      plan: ${{ needs.plan.outputs.val }}
+    secrets: inherit
+
+  custom-publish-playground:
+    needs:
+      - plan
+      - announce
+    uses: ./.github/workflows/publish-playground.yml
+    with:
+      plan: ${{ needs.plan.outputs.val }}
+    secrets: inherit

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -271,7 +271,7 @@ local-artifacts-jobs = ["./build-binaries", "./build-docker"]
 # Publish jobs to run in CI
 publish-jobs = ["./publish-pypi"]
 # Announcement jobs to run in CI
-post-announce-jobs = ["./notify-dependents"]
+post-announce-jobs = ["./notify-dependents", "./publish-docs", "./publish-playground"]
 # Skip checking whether the specified configuration files are up to date
 allow-dirty = ["ci"]
 # Whether to install an updater program


### PR DESCRIPTION
## Summary

These are now `post-announce-jobs`. So if they fail, the release itself will still succeed, which seems ok. (If we make them `publish-jobs`, then we might end up publishing to PyPI but failing the release itself if one of these fails.)

The intent is that these are still runnable via `workflow_dispatch` too.

Closes https://github.com/astral-sh/ruff/issues/12074.