### PR TITLE
Remove `E999` to find diagnostic severity

### DIFF
--- a/crates/ruff_server/src/lint.rs
+++ b/crates/ruff_server/src/lint.rs
@@ -364,8 +364,7 @@ fn severity(code: &str) -> lsp_types::DiagnosticSeverity {
     match code {
         // F821: undefined name <name>
         // E902: IOError
-        // E999: SyntaxError
-        "F821" | "E902" | "E999" => lsp_types::DiagnosticSeverity::ERROR,
+        "F821" | "E902" => lsp_types::DiagnosticSeverity::ERROR,
         _ => lsp_types::DiagnosticSeverity::WARNING,
     }
 }


### PR DESCRIPTION
## Summary

This PR removes the need to check for `E999` code to find the diagnostic severity in the server.

**Note:** This is just removing a redundant check because all `ParseErrors` are converted to `Diagnostic` with default `Error` severity by https://github.com/astral-sh/ruff/blob/63c92586a10bfa9b75db9cb87a9ac08618a2ed95/crates/ruff_server/src/lint.rs#L309-L346

## Test Plan

Verify that syntax errors are still shown with error severity as it did before:

<img width="1313" alt="Screenshot 2024-06-28 at 09 30 20" src="https://github.com/astral-sh/ruff/assets/67177269/75e389a7-01ea-461c-86a2-0dfc244e515d">
