### PR TITLE
Add standalone installer instruction to docs

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -6,6 +6,13 @@ Ruff is available as [`ruff`](https://pypi.org/project/ruff/) on PyPI:
 pip install ruff
 ```
 
+Once installed, you can run Ruff from the command line:
+
+```shell
+ruff check   # Lint all files in the current directory.
+ruff format  # Format all files in the current directory.
+```
+
 Starting with version `0.5.0`, Ruff can be installed with our standalone installers:
 
 ```shell
@@ -18,13 +25,6 @@ powershell -c "irm https://astral.sh/ruff/install.ps1 | iex"
 # For a specific version.
 curl -LsSf https://astral.sh/ruff/0.5.0/install.sh | sh
 powershell -c "irm https://astral.sh/ruff/0.5.0/install.ps1 | iex"
-```
-
-Once installed, you can run Ruff from the command line:
-
-```shell
-ruff check   # Lint all files in the current directory.
-ruff format  # Format all files in the current directory.
 ```
 
 For **macOS Homebrew** and **Linuxbrew** users, Ruff is also available as [`ruff`](https://formulae.brew.sh/formula/ruff)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -6,6 +6,20 @@ Ruff is available as [`ruff`](https://pypi.org/project/ruff/) on PyPI:
 pip install ruff
 ```
 
+Starting with version `0.5.0`, Ruff can be installed with our standalone installers:
+
+```shell
+# On macOS and Linux.
+curl -LsSf https://astral.sh/ruff/install.sh | sh
+
+# On Windows.
+powershell -c "irm https://astral.sh/ruff/install.ps1 | iex"
+
+# For a specific version.
+curl -LsSf https://astral.sh/ruff/0.5.0/install.sh | sh
+powershell -c "irm https://astral.sh/ruff/0.5.0/install.ps1 | iex"
+```
+
 Once installed, you can run Ruff from the command line:
 
 ```shell


### PR DESCRIPTION
Adopted from `uv` README (https://github.com/astral-sh/uv#getting-started), this PR adds a section of using standalone installers in the installation section of Ruff docs.

### Preview

<img width="1391" alt="Screenshot 2024-06-28 at 09 26 39" src="https://github.com/astral-sh/ruff/assets/67177269/84a036e7-aee4-4b60-86ef-0d7aa992156a">
