### PR TITLE
Revert "Use correct range to highlight line continuation error"

### DIFF
--- a/crates/ruff_python_parser/src/error.rs
+++ b/crates/ruff_python_parser/src/error.rs
@@ -404,7 +404,7 @@ impl std::fmt::Display for LexicalErrorType {
                 write!(f, "Got unexpected token {tok}")
             }
             LexicalErrorType::LineContinuationError => {
-                write!(f, "unexpected character after line continuation character")
+                write!(f, "Expected a newline after line continuation character")
             }
             LexicalErrorType::Eof => write!(f, "unexpected EOF while parsing"),
             LexicalErrorType::OtherError(msg) => write!(f, "{msg}"),

--- a/crates/ruff_python_parser/src/lexer.rs
+++ b/crates/ruff_python_parser/src/lexer.rs
@@ -247,7 +247,7 @@ impl<'src> Lexer<'src> {
                     } else if !self.cursor.eat_char('\n') {
                         return Some(self.push_error(LexicalError::new(
                             LexicalErrorType::LineContinuationError,
-                            TextRange::at(self.offset(), self.cursor.first().text_len()),
+                            TextRange::at(self.offset() - '\\'.text_len(), '\\'.text_len()),
                         )));
                     }
                     indentation = Indentation::root();
@@ -339,7 +339,7 @@ impl<'src> Lexer<'src> {
                     } else if !self.cursor.eat_char('\n') {
                         return Err(LexicalError::new(
                             LexicalErrorType::LineContinuationError,
-                            TextRange::at(self.offset(), self.cursor.first().text_len()),
+                            TextRange::at(self.offset() - '\\'.text_len(), '\\'.text_len()),
                         ));
                     }
                 }

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@re_lexing__line_continuation_1.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@re_lexing__line_continuation_1.py.snap
@@ -11,10 +11,10 @@ Module(
         body: [
             Expr(
                 StmtExpr {
-                    range: 0..14,
+                    range: 0..13,
                     value: Call(
                         ExprCall {
-                            range: 0..14,
+                            range: 0..13,
                             func: Name(
                                 ExprName {
                                     range: 0..4,
@@ -23,7 +23,7 @@ Module(
                                 },
                             ),
                             arguments: Arguments {
-                                range: 4..14,
+                                range: 4..13,
                                 args: [
                                     Name(
                                         ExprName {
@@ -82,7 +82,7 @@ Module(
 
   |
 1 | call(a, b, \\\
-  |             ^ Syntax Error: unexpected character after line continuation character
+  |            ^ Syntax Error: Expected a newline after line continuation character
 2 | 
 3 | def bar():
   |
@@ -90,7 +90,7 @@ Module(
 
   |
 1 | call(a, b, \\\
-  |              ^ Syntax Error: unexpected character after line continuation character
+  |             ^ Syntax Error: Expected a newline after line continuation character
 2 | 
 3 | def bar():
   |


### PR DESCRIPTION
This PR reverts https://github.com/astral-sh/ruff/pull/12016 with a small change where the error location points to the continuation character only. Earlier, it would also highlight the whitespace that came before it.

The motivation for this change is to avoid panic in https://github.com/astral-sh/ruff/pull/11950. For example:

```py
\)
```

Playground: https://play.ruff.rs/87711071-1b54-45a3-b45a-81a336a1ea61

The range of `Unknown` token and `Rpar` is the same. Once #11950 is enabled, the indexer would panic. It won't panic in the stable version because we stop at the first `Unknown` token.