### PR TITLE
Avoid `E275` if keyword is followed by a semicolon

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pycodestyle/E27.py
+++ b/crates/ruff_linter/resources/test/fixtures/pycodestyle/E27.py
@@ -77,3 +77,6 @@ type	Number = int
 match(foo):
     case(1):
         pass
+
+# https://github.com/astral-sh/ruff/issues/12094
+pass;

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/logical_lines/missing_whitespace_after_keyword.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/logical_lines/missing_whitespace_after_keyword.rs
@@ -60,6 +60,7 @@ pub(crate) fn missing_whitespace_after_keyword(
                 || matches!(
                     tok1_kind,
                     TokenKind::Colon
+                        | TokenKind::Semi
                         | TokenKind::Newline
                         | TokenKind::NonLogicalNewline
                         // In the event of a syntax error, do not attempt to add a whitespace.

--- a/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E275_E27.py.snap
+++ b/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E275_E27.py.snap
@@ -124,6 +124,7 @@ E27.py:77:1: E275 [*] Missing whitespace after keyword
    77 |+match (foo):
 78 78 |     case(1):
 79 79 |         pass
+80 80 | 
 
 E27.py:78:5: E275 [*] Missing whitespace after keyword
    |
@@ -142,3 +143,5 @@ E27.py:78:5: E275 [*] Missing whitespace after keyword
 78    |-    case(1):
    78 |+    case (1):
 79 79 |         pass
+80 80 | 
+81 81 | # https://github.com/astral-sh/ruff/issues/12094


### PR DESCRIPTION
fixes: #12094 