### PR TITLE
Docs: Respect SELinux with podman for docker mount

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -70,6 +70,7 @@ sudo zypper install python3-ruff
 
 On **Docker**, it is published as `ghcr.io/astral-sh/ruff`, tagged for each release and `latest` for
 the latest release.
+If you use Podman and SELinux, mount the current directory by using `.:/io:Z`.
 
 ```shell
 docker run -v .:/io --rm ghcr.io/astral-sh/ruff check


### PR DESCRIPTION
Tested on Fedora 40 with Podman 5.1.1 and ruff "0.5.0" and "latest". source: https://unix.stackexchange.com/q/651198


## Error without fix

````
$ podman run --rm -it -v .:/io ghcr.io/astral-sh/ruff:latest check
error: Failed to initialize cache at /io/.ruff_cache: Permission denied (os error 13)
warning: Encountered error: Permission denied (os error 13)
All checks passed!

$ podman run --rm -it -v .:/io ghcr.io/astral-sh/ruff:latest format
error: Failed to initialize cache at /io/.ruff_cache: Permission denied (os error 13)
error: Encountered error: Permission denied (os error 13)
````

## Summary

Running ruff by using a docker container requires `:Z` when mounting the current directory on Fedora with SELinux and Podman.

## Test Plan

````
$ podman run --rm -it -v .:/io:Z ghcr.io/astral-sh/ruff:latest check
$ podman run --rm -it -v .:/io:Z ghcr.io/astral-sh/ruff:0.5.0 check
````