### PR TITLE
Remove allcation in `parse_identifier`

### DIFF
--- a/crates/ruff_python_parser/src/parser/expression.rs
+++ b/crates/ruff_python_parser/src/parser/expression.rs
@@ -478,7 +478,7 @@ impl<'src> Parser<'src> {
                 unreachable!();
             };
             return ast::Identifier {
-                id: name.to_string(),
+                id: name.into_string(),
                 range,
             };
         }


### PR DESCRIPTION
## Summary

I think this PR removes an allocation from `parse_identifier`. 

`parse_identifier` converts the `Box<str>` from the `TokenValue::Name` to a `String` by calling `.to_string`. 
`to_string` is a small wrapper around `format!("{name}")` which allocates a new string without reusing the `Box<str>` allocation, unless the compiler can see through the operation. 

This PR uses `Box<str>::into_string` which, to my knowledge, reuses the underlying allocation. 

## Test Plan

`cargo test`
