### PR TITLE
Mention that `Cursor` is based on rustc's implementation.

### DIFF
--- a/crates/ruff_python_parser/src/lexer/cursor.rs
+++ b/crates/ruff_python_parser/src/lexer/cursor.rs
@@ -5,6 +5,8 @@ use ruff_text_size::{TextLen, TextSize};
 pub(crate) const EOF_CHAR: char = '\0';
 
 /// A cursor represents a pointer in the source code.
+///
+/// Based on [`rustc`'s `Cursor`](https://github.com/rust-lang/rust/blob/d1b7355d3d7b4ead564dbecb1d240fcc74fff21b/compiler/rustc_lexer/src/cursor.rs)
 #[derive(Clone, Debug)]
 pub(super) struct Cursor<'src> {
     /// An iterator over the [`char`]'s of the source code.

--- a/crates/ruff_python_trivia/src/cursor.rs
+++ b/crates/ruff_python_trivia/src/cursor.rs
@@ -5,6 +5,8 @@ use ruff_text_size::{TextLen, TextSize};
 pub const EOF_CHAR: char = '\0';
 
 /// A [`Cursor`] over a string.
+///
+/// Based on [`rustc`'s `Cursor`](https://github.com/rust-lang/rust/blob/d1b7355d3d7b4ead564dbecb1d240fcc74fff21b/compiler/rustc_lexer/src/cursor.rs)
 #[derive(Debug, Clone)]
 pub struct Cursor<'a> {
     chars: Chars<'a>,


### PR DESCRIPTION
## Summary

Fixes https://github.com/astral-sh/ruff/issues/12107



<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

None
