### PR TITLE
Use `CompactString` for `ModuleName`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1881,7 +1881,6 @@ dependencies = [
  "ruff_python_parser",
  "ruff_text_size",
  "rustc-hash 2.0.0",
- "smol_str",
  "tempfile",
  "tracing",
  "tracing-subscriber",
@@ -1893,13 +1892,13 @@ name = "red_knot_module_resolver"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "compact_str",
  "insta",
  "path-slash",
  "ruff_db",
  "ruff_python_stdlib",
  "rustc-hash 2.0.0",
  "salsa",
- "smol_str",
  "tempfile",
  "tracing",
  "walkdir",
@@ -2859,15 +2858,6 @@ name = "smallvec"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
-
-[[package]]
-name = "smol_str"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd538fb6910ac1099850255cf94a94df6551fbdd602454387d0adb2d1ca6dead"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "spin"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,7 +120,6 @@ serde_with = { version = "3.6.0", default-features = false, features = [
 shellexpand = { version = "3.0.0" }
 similar = { version = "2.4.0", features = ["inline"] }
 smallvec = { version = "1.13.2" }
-smol_str = { version = "0.2.2" }
 static_assertions = "1.1.0"
 strum = { version = "0.26.0", features = ["strum_macros"] }
 strum_macros = { version = "0.26.0" }

--- a/crates/red_knot/Cargo.toml
+++ b/crates/red_knot/Cargo.toml
@@ -32,7 +32,6 @@ notify = { workspace = true }
 parking_lot = { workspace = true }
 rayon = { workspace = true }
 rustc-hash = { workspace = true }
-smol_str = { version = "0.2.1" }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 tracing-tree = { workspace = true }

--- a/crates/red_knot/src/program/check.rs
+++ b/crates/red_knot/src/program/check.rs
@@ -51,7 +51,7 @@ impl Program {
                     // TODO We may want to have a different check functions for non-first-party
                     //   files because we only need to index them and not check them.
                     //   Supporting non-first-party code also requires supporting typing stubs.
-                    if let Some(dependency) = resolve_module(self, dependency_name)? {
+                    if let Some(dependency) = resolve_module(self, &dependency_name)? {
                         if dependency.path(self)?.root().kind().is_first_party() {
                             context.schedule_dependency(dependency.path(self)?.file());
                         }

--- a/crates/red_knot/src/semantic.rs
+++ b/crates/red_knot/src/semantic.rs
@@ -9,12 +9,12 @@ use crate::cache::KeyValueCache;
 use crate::db::{QueryResult, SemanticDb, SemanticJar};
 use crate::files::FileId;
 use crate::module::Module;
-use crate::module::ModuleName;
 use crate::parse::parse;
 pub(crate) use definitions::Definition;
 use definitions::{ImportDefinition, ImportFromDefinition};
 pub(crate) use flow_graph::ConstrainedDefinition;
 use flow_graph::{FlowGraph, FlowGraphBuilder, FlowNodeId, ReachableDefinitionsIterator};
+use red_knot_module_resolver::ModuleName;
 use ruff_index::{newtype_index, IndexVec};
 use rustc_hash::FxHashMap;
 use std::ops::{Deref, DerefMut};
@@ -410,7 +410,7 @@ impl SourceOrderVisitor<'_> for SemanticIndexer {
                         alias.name.id.split('.').next().unwrap()
                     };
 
-                    let module = ModuleName::new(&alias.name.id);
+                    let module = ModuleName::new(&alias.name.id).unwrap();
 
                     let def = Definition::Import(ImportDefinition {
                         module: module.clone(),
@@ -426,7 +426,7 @@ impl SourceOrderVisitor<'_> for SemanticIndexer {
                 level,
                 ..
             }) => {
-                let module = module.as_ref().map(|m| ModuleName::new(&m.id));
+                let module = module.as_ref().and_then(|m| ModuleName::new(&m.id));
 
                 for alias in names {
                     let symbol_name = if let Some(asname) = &alias.asname {

--- a/crates/red_knot/src/semantic/definitions.rs
+++ b/crates/red_knot/src/semantic/definitions.rs
@@ -1,5 +1,5 @@
 use crate::ast_ids::TypedNodeKey;
-use crate::semantic::ModuleName;
+use red_knot_module_resolver::ModuleName;
 use ruff_python_ast as ast;
 use ruff_python_ast::name::Name;
 

--- a/crates/red_knot/src/semantic/symbol_table.rs
+++ b/crates/red_knot/src/semantic/symbol_table.rs
@@ -6,13 +6,13 @@ use std::num::NonZeroU32;
 
 use bitflags::bitflags;
 use hashbrown::hash_map::{Keys, RawEntryMut};
+use red_knot_module_resolver::ModuleName;
 use rustc_hash::{FxHashMap, FxHasher};
 
 use ruff_index::{newtype_index, IndexVec};
 use ruff_python_ast::name::Name;
 
 use crate::ast_ids::NodeKey;
-use crate::module::ModuleName;
 use crate::semantic::{Definition, ExpressionId};
 
 type Map<K, V> = hashbrown::HashMap<K, V, ()>;

--- a/crates/red_knot/src/semantic/types.rs
+++ b/crates/red_knot/src/semantic/types.rs
@@ -2,7 +2,7 @@
 use crate::ast_ids::NodeKey;
 use crate::db::{QueryResult, SemanticDb, SemanticJar};
 use crate::files::FileId;
-use crate::module::{Module, ModuleName};
+use crate::module::Module;
 use crate::semantic::{
     resolve_global_symbol, semantic_index, GlobalSymbolId, ScopeId, ScopeKind, SymbolId,
 };
@@ -14,6 +14,7 @@ use rustc_hash::FxHashMap;
 pub(crate) mod infer;
 
 pub(crate) use infer::{infer_definition_type, infer_symbol_public_type};
+use red_knot_module_resolver::ModuleName;
 use ruff_python_ast::name::Name;
 
 /// unique ID for a type

--- a/crates/red_knot_module_resolver/Cargo.toml
+++ b/crates/red_knot_module_resolver/Cargo.toml
@@ -14,9 +14,9 @@ license = { workspace = true }
 ruff_db = { workspace = true }
 ruff_python_stdlib = { workspace = true }
 
+compact_str = { workspace = true }
 rustc-hash = { workspace = true }
 salsa = { workspace = true }
-smol_str = { workspace = true }
 tracing = { workspace = true }
 zip = { workspace = true }
 


### PR DESCRIPTION
## Summary

This PR refactors `ModuleName` to use `CompactString` instead of `smol_str` to reduce the number of small-string crates to one. 
`CompactString` showed significantely better performance in the parser and lexer benchmarks than `smol_str`.

One notable difference between the two crates is that `smol_str::clone` is `O(1)` whereas `CompactString` is more like a regular `String` with `O(n)` cloning. 
We'll see if the `O(n)` cloning becomes a problem in `red_knot` once we have proper benchmarks. For now, I'm going to assume it is okay. 

I refactored `red_knot` to use the `red_knot_module_resovler::ModuleName`. That code will be deleted soon anyway. 

## Test Plan

`cargo test`
