### PR TITLE
Avoid `E275` if keyword followed by comma

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pycodestyle/E27.py
+++ b/crates/ruff_linter/resources/test/fixtures/pycodestyle/E27.py
@@ -80,3 +80,5 @@ match(foo):
 
 # https://github.com/astral-sh/ruff/issues/12094
 pass;
+
+yield, x

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/logical_lines/missing_whitespace_after_keyword.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/logical_lines/missing_whitespace_after_keyword.rs
@@ -56,7 +56,8 @@ pub(crate) fn missing_whitespace_after_keyword(
             && !(tok0_kind.is_singleton()
                 || matches!(tok0_kind, TokenKind::Async | TokenKind::Await)
                 || tok0_kind == TokenKind::Except && tok1_kind == TokenKind::Star
-                || tok0_kind == TokenKind::Yield && tok1_kind == TokenKind::Rpar
+                || tok0_kind == TokenKind::Yield
+                    && matches!(tok1_kind, TokenKind::Rpar | TokenKind::Comma)
                 || matches!(
                     tok1_kind,
                     TokenKind::Colon


### PR DESCRIPTION
## Summary

Use the following to reproduce this:
```console
$ cargo run -- check --select=E275,E203 --preview --no-cache ~/playground/ruff/src/play.py --fix
debug error: Failed to converge after 100 iterations in `/Users/dhruv/playground/ruff/src/play.py` with rule codes E275:---
yield,x

---
/Users/dhruv/playground/ruff/src/play.py:1:1: E275 Missing whitespace after keyword
  |
1 | yield,x
  | ^^^^^ E275
  |
  = help: Added missing whitespace after keyword

Found 101 errors (100 fixed, 1 remaining).
[*] 1 fixable with the `--fix` option.
```

## Test Plan

Add a test case and run `cargo insta test`.