### PR TITLE
[red-knot] Remove `Scope::name`

### DIFF
--- a/crates/red_knot_python_semantic/src/semantic_index/symbol.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/symbol.rs
@@ -214,7 +214,6 @@ impl FileScopeId {
 
 #[derive(Debug, Eq, PartialEq)]
 pub struct Scope {
-    pub(super) name: Name,
     pub(super) parent: Option<FileScopeId>,
     pub(super) definition: Option<Definition>,
     pub(super) defining_symbol: Option<FileSymbolId>,
@@ -223,10 +222,6 @@ pub struct Scope {
 }
 
 impl Scope {
-    pub fn name(&self) -> &Name {
-        &self.name
-    }
-
     pub fn definition(&self) -> Option<Definition> {
         self.definition
     }


### PR DESCRIPTION
## Summary

This PR removes `Scope::name` because it is currently unused outside tests and it requires cloning the names of every symbol and class which can get expensive. 

I can see how having a `name` might be useful for debugging. I'm open to have a *debug-only* `name` stored on `Scope` but we should then design it that way 
and also avoid writing tests around it. 

## Test Plan

`cargo test`
