### PR TITLE
Refactor `ast_ids` traits to take `ScopeId` instead of `VfsFile` plus `FileScopeId`.

### DIFF
--- a/crates/red_knot_python_semantic/src/semantic_model.rs
+++ b/crates/red_knot_python_semantic/src/semantic_model.rs
@@ -45,9 +45,10 @@ impl HasTy for ast::ExpressionRef<'_> {
     fn ty<'db>(&self, model: &SemanticModel<'db>) -> Type<'db> {
         let index = semantic_index(model.db, model.file);
         let file_scope = index.expression_scope_id(*self);
-        let expression_id = self.scoped_ast_id(model.db, model.file, file_scope);
-
         let scope = file_scope.to_scope_id(model.db, model.file);
+
+        let expression_id = self.scoped_ast_id(model.db, scope);
+
         infer_types(model.db, scope).expression_ty(expression_id)
     }
 }
@@ -152,8 +153,7 @@ impl HasTy for ast::StmtFunctionDef {
         let scope = parent_scope_id.to_scope_id(model.db, model.file);
 
         let types = infer_types(model.db, scope);
-        let definition =
-            Definition::FunctionDef(self.scoped_ast_id(model.db, model.file, parent_scope_id));
+        let definition = Definition::FunctionDef(self.scoped_ast_id(model.db, scope));
 
         types.definition_ty(definition)
     }
@@ -175,8 +175,7 @@ impl HasTy for StmtClassDef {
         let scope = parent_scope_id.to_scope_id(model.db, model.file);
 
         let types = infer_types(model.db, scope);
-        let definition =
-            Definition::ClassDef(self.scoped_ast_id(model.db, model.file, parent_scope_id));
+        let definition = Definition::ClassDef(self.scoped_ast_id(model.db, scope));
 
         types.definition_ty(definition)
     }

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -191,7 +191,7 @@ impl<'db> TypeInferenceBuilder<'db> {
             decorator_list,
         } = function;
 
-        let function_id = function.scoped_ast_id(self.db, self.file_id, self.file_scope_id);
+        let function_id = function.scoped_ast_id(self.db, self.scope);
         let decorator_tys = decorator_list
             .iter()
             .map(|decorator| self.infer_decorator(decorator))
@@ -231,7 +231,7 @@ impl<'db> TypeInferenceBuilder<'db> {
             body: _,
         } = class;
 
-        let class_id = class.scoped_ast_id(self.db, self.file_id, self.file_scope_id);
+        let class_id = class.scoped_ast_id(self.db, self.scope);
 
         for decorator in decorator_list {
             self.infer_decorator(decorator);
@@ -303,7 +303,7 @@ impl<'db> TypeInferenceBuilder<'db> {
             self.infer_expression(target);
         }
 
-        let assign_id = assignment.scoped_ast_id(self.db, self.file_id, self.file_scope_id);
+        let assign_id = assignment.scoped_ast_id(self.db, self.scope);
 
         // TODO: Handle multiple targets.
         self.types
@@ -328,11 +328,7 @@ impl<'db> TypeInferenceBuilder<'db> {
         self.infer_expression(target);
 
         self.types.definition_tys.insert(
-            Definition::AnnotatedAssignment(assignment.scoped_ast_id(
-                self.db,
-                self.file_id,
-                self.file_scope_id,
-            )),
+            Definition::AnnotatedAssignment(assignment.scoped_ast_id(self.db, self.scope)),
             annotation_ty,
         );
     }
@@ -356,7 +352,7 @@ impl<'db> TypeInferenceBuilder<'db> {
     fn infer_import_statement(&mut self, import: &ast::StmtImport) {
         let ast::StmtImport { range: _, names } = import;
 
-        let import_id = import.scoped_ast_id(self.db, self.file_id, self.file_scope_id);
+        let import_id = import.scoped_ast_id(self.db, self.scope);
 
         for (i, alias) in names.iter().enumerate() {
             let ast::Alias {
@@ -389,7 +385,7 @@ impl<'db> TypeInferenceBuilder<'db> {
             level: _,
         } = import;
 
-        let import_id = import.scoped_ast_id(self.db, self.file_id, self.file_scope_id);
+        let import_id = import.scoped_ast_id(self.db, self.scope);
         let module_name = ModuleName::new(module.as_deref().expect("Support relative imports"));
 
         let module =
@@ -492,7 +488,7 @@ impl<'db> TypeInferenceBuilder<'db> {
         self.infer_expression(target);
 
         self.types.definition_tys.insert(
-            Definition::NamedExpr(named.scoped_ast_id(self.db, self.file_id, self.file_scope_id)),
+            Definition::NamedExpr(named.scoped_ast_id(self.db, self.scope)),
             value_ty,
         );
 


### PR DESCRIPTION
## Summary

This is a small refactor that changes the `ast_ids` traits to take a `ScopeId` argument instead of a `VfsFile` and `FileScopeId`. 

This is mainly to reduce the number of arguments, but it might even improve performance because most call-sites already have the `ScopeId` and previously it was necessary to lookup the `ScopeId`.

## Test Plan

`cargo test`
