### PR TITLE
Avoid syntax error notification for source code actions

### DIFF
--- a/crates/ruff_server/src/fix.rs
+++ b/crates/ruff_server/src/fix.rs
@@ -69,8 +69,7 @@ pub(crate) fn fix_all(
     let FixerResult {
         transformed,
         result: LinterResult {
-            has_syntax_error: has_error,
-            ..
+            has_syntax_error, ..
         },
         ..
     } = ruff_linter::linter::lint_fix(
@@ -83,9 +82,9 @@ pub(crate) fn fix_all(
         source_type,
     )?;
 
-    if has_error {
-        // abort early if a parsing error occurred
-        return Err(anyhow::anyhow!("A parsing error occurred during `fix_all`"));
+    if has_syntax_error {
+        // If there's a syntax error, then there won't be any fixes to apply.
+        return Ok(Fixes::default());
     }
 
     // fast path: if `transformed` is still borrowed, no changes were made and we can return early


### PR DESCRIPTION
## Summary

This PR avoids the error notification if a user selects the source code actions and there's a syntax error in the source.

Before https://github.com/astral-sh/ruff/pull/12134, the change would've been different. But that PR disables generating fixes if there's a syntax error. This means that we can return an empty map instead as there won't be any fixes in the diagnostics returned by the `lint_fix` function.

For reference, following are the screenshot as on `main` with the error:

**VS Code:**

<img width="1715" alt="Screenshot 2024-07-02 at 16 39 59" src="https://github.com/astral-sh/ruff/assets/67177269/62f3e99b-0b0c-4608-84a2-26aeabcc6933">

**Neovim:**

<img width="1717" alt="Screenshot 2024-07-02 at 16 38 50" src="https://github.com/astral-sh/ruff/assets/67177269/5d637c36-d7f8-4a3b-8011-9a89708919a8">

fixes: #11931

## Test Plan

Considering the following code snippet where there are two diagnostics (syntax error and useless semicolon `E703`):
```py
x;

y =
```

### VS Code

https://github.com/astral-sh/ruff/assets/67177269/943537fc-ed8d-448d-8a36-1e34536c4f3e

### Neovim

https://github.com/astral-sh/ruff/assets/67177269/4e6f3372-6e5b-4380-8919-6221066efd5b

