### PR TITLE
Remove use of deprecated `E999` from the `fuzz-parser` script

### DIFF
--- a/scripts/fuzz-parser/fuzz.py
+++ b/scripts/fuzz-parser/fuzz.py
@@ -39,7 +39,7 @@ ExitCode = NewType("ExitCode", int)
 def contains_bug(code: str, *, ruff_executable: str) -> bool:
     """Return `True` if the code triggers a parser error."""
     completed_process = subprocess.run(
-        [ruff_executable, "check", "--select=E999", "--no-cache", "-"],
+        [ruff_executable, "check", "--config", "lint.select=[]", "--no-cache", "-"],
         capture_output=True,
         text=True,
         input=code,

--- a/scripts/fuzz-parser/requirements.txt
+++ b/scripts/fuzz-parser/requirements.txt
@@ -10,22 +10,27 @@ markdown-it-py==3.0.0
     # via rich
 mdurl==0.1.2
     # via markdown-it-py
-pygments==2.17.2
+pygments==2.18.0
     # via rich
 pysource-codegen==0.5.2
+    # via -r scripts/fuzz-parser/requirements.in
 pysource-minimize==0.6.3
+    # via -r scripts/fuzz-parser/requirements.in
 rich==13.7.1
     # via
     #   pysource-minimize
     #   rich-argparse
-rich-argparse==1.4.0
-ruff==0.4.2
+rich-argparse==1.5.2
+    # via -r scripts/fuzz-parser/requirements.in
+ruff==0.5.0
+    # via -r scripts/fuzz-parser/requirements.in
 six==1.16.0
     # via
     #   asttokens
     #   astunparse
 termcolor==2.4.0
-typing-extensions==4.11.0
+    # via -r scripts/fuzz-parser/requirements.in
+typing-extensions==4.12.2
     # via pysource-codegen
 wheel==0.43.0
     # via astunparse


### PR DESCRIPTION
## Summary

Using the `E999` code is now deprecated, so we shouldn't use it in the `fuzz-parser` script anymore. I _think_ the most idiomatic way of asking Ruff to "please detect syntax errors, but do not report any other checks" is now `--config='lint.select=[]'`.

I also bumped the requirement pins in the `requirements.txt` file, as they hadn't been updated in a while.

## Test Plan

In a virtual environment with the requirements installed, I ran `python scripts/fuzz-parser/fuzz.py $(shuf -i 0-100000 -n 1000)` to verify that the script still succeeded with these changes (it did). I then deliberately broke the parser with the below diff, and reran the command, to check that the fuzzer still reports when Ruff fails to parse valid syntax (it does):

```diff
diff --git a/crates/ruff_python_parser/src/lexer.rs b/crates/ruff_python_parser/src/lexer.rs
index d407ab357..2996b657a 100644
--- a/crates/ruff_python_parser/src/lexer.rs
+++ b/crates/ruff_python_parser/src/lexer.rs
@@ -364,18 +364,14 @@ impl<'src> Lexer<'src> {
             '\'' | '"' => self.lex_string(c),
             '=' => {
                 if self.cursor.eat_char('=') {
-                    TokenKind::EqEqual
+                    TokenKind::Unknown
                 } else {
                     self.state = State::AfterEqual;
-                    return TokenKind::Equal;
+                    return TokenKind::Unknown;
                 }
             }
             '+' => {
-                if self.cursor.eat_char('=') {
-                    TokenKind::PlusEqual
-                } else {
-                    TokenKind::Plus
-                }
+                TokenKind::Unknown
             }
             '*' => {
                 if self.cursor.eat_char('=') {
```
