### PR TITLE
Correct parenthesized long nested-expressions example to match Ruff's output

### DIFF
--- a/docs/formatter/black.md
+++ b/docs/formatter/black.md
@@ -91,37 +91,41 @@ Black 24 and newer parenthesizes long conditional expressions and type annotatio
     ),
 ]
 
+
 def foo(
-  i: int,
-  x: (
-    Loooooooooooooooooooooooong
-    | Looooooooooooooooong
-    | Looooooooooooooooooooong
-    | Looooooong
-  ),
-  *,
-  s: str,
+    i: int,
+    x: (
+        Loooooooooooooooooooooooong
+        | Looooooooooooooooong
+        | Looooooooooooooooooooong
+        | Looooooong
+    ),
+    *,
+    s: str,
 ) -> None:
-  pass
+    pass
 
 # Ruff
 [
-  "____________________________",
-  "foo",
-  "bar",
-  "baz" if some_really_looooooooong_variable else "some other looooooooooooooong value"
+    "____________________________",
+    "foo",
+    "bar",
+    "baz"
+    if some_really_looooooooong_variable
+    else "some other looooooooooooooong value",
 ]
 
+
 def foo(
-  i: int,
-  x: Loooooooooooooooooooooooong
-     | Looooooooooooooooong
-     | Looooooooooooooooooooong
-     | Looooooong,
-  *,
-  s: str,
+    i: int,
+    x: Loooooooooooooooooooooooong
+    | Looooooooooooooooong
+    | Looooooooooooooooooooong
+    | Looooooong,
+    *,
+    s: str,
 ) -> None:
-  pass
+    pass
 ```
 
 We agree that Ruff's formatting (that matches Black's 23) is hard to read and needs improvement. But we aren't convinced that parenthesizing long nested expressions is the best solution, especially when considering expression formatting holistically. That's why we want to defer the decision until we've explored alternative nested expression formatting styles. See [psf/Black#4123](https://github.com/psf/black/issues/4123) for an in-depth explanation of our concerns and an outline of possible alternatives.


### PR DESCRIPTION
## Summary

The output shown for long nested-expressions didn't match Ruff's output. I must have used the output that I **want** rather than what Ruff does today. 

I copied the input into Black and Ruff and pasted the output into the readme

Fixes https://github.com/astral-sh/ruff/issues/12138
