### PR TITLE
Fix latest version detection during Rooster invocations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,6 @@ force-exclude = '''
 [tool.rooster]
 major_labels = []  # Ruff never uses the major version number
 minor_labels = ["breaking"]   # Bump the minor version on breaking changes
-version_tag_prefix = "v"
 
 changelog_ignore_labels = ["internal", "ci", "red-knot"]
 


### PR DESCRIPTION
We no longer use the "v" prefix so Rooster detects the wrong version.