### PR TITLE
docs(options): fix some typos and improve consistency

### DIFF
--- a/crates/ruff_workspace/src/options.rs
+++ b/crates/ruff_workspace/src/options.rs
@@ -75,7 +75,7 @@ pub struct Options {
     pub extend: Option<String>,
 
     /// The style in which violation messages should be formatted: `"full"`
-    /// (shows source),`"concise"` (default), `"grouped"` (group messages by file), `"json"`
+    /// (shows source), `"concise"` (default), `"grouped"` (group messages by file), `"json"`
     /// (machine-readable), `"junit"` (machine-readable XML), `"github"` (GitHub
     /// Actions annotations), `"gitlab"` (GitLab CI code quality report),
     /// `"pylint"` (Pylint text format) or `"azure"` (Azure Pipeline logging commands).
@@ -421,7 +421,7 @@ pub struct Options {
     pub format: Option<FormatOptions>,
 }
 
-/// Configures how ruff checks your code.
+/// Configures how Ruff checks your code.
 ///
 /// Options specified in the `lint` section take precedence over the deprecated top-level settings.
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
@@ -1313,7 +1313,7 @@ pub struct Flake8ImportConventionsOptions {
         value_type = "dict[str, str]",
         scope = "extend-aliases",
         example = r#"
-            # Declare a custom alias for the `matplotlib` module.
+            # Declare a custom alias for the `dask` module.
             "dask.dataframe" = "dd"
         "#
     )]
@@ -1389,10 +1389,10 @@ pub struct Flake8PytestStyleOptions {
     /// The following values are supported:
     ///
     /// - `csv` — a comma-separated list, e.g.
-    ///   `@pytest.mark.parametrize('name1,name2', ...)`
+    ///   `@pytest.mark.parametrize("name1,name2", ...)`
     /// - `tuple` (default) — e.g.
-    ///   `@pytest.mark.parametrize(('name1', 'name2'), ...)`
-    /// - `list` — e.g. `@pytest.mark.parametrize(['name1', 'name2'], ...)`
+    ///   `@pytest.mark.parametrize(("name1", "name2"), ...)`
+    /// - `list` — e.g. `@pytest.mark.parametrize(["name1", "name2"], ...)`
     #[option(
         default = "tuple",
         value_type = r#""csv" | "tuple" | "list""#,
@@ -1403,8 +1403,8 @@ pub struct Flake8PytestStyleOptions {
     /// Expected type for the list of values rows in `@pytest.mark.parametrize`.
     /// The following values are supported:
     ///
-    /// - `tuple` — e.g. `@pytest.mark.parametrize('name', (1, 2, 3))`
-    /// - `list` (default) — e.g. `@pytest.mark.parametrize('name', [1, 2, 3])`
+    /// - `tuple` — e.g. `@pytest.mark.parametrize("name", (1, 2, 3))`
+    /// - `list` (default) — e.g. `@pytest.mark.parametrize("name", [1, 2, 3])`
     #[option(
         default = "list",
         value_type = r#""tuple" | "list""#,
@@ -1416,9 +1416,9 @@ pub struct Flake8PytestStyleOptions {
     /// case of multiple parameters. The following values are supported:
     ///
     /// - `tuple` (default) — e.g.
-    ///   `@pytest.mark.parametrize(('name1', 'name2'), [(1, 2), (3, 4)])`
+    ///   `@pytest.mark.parametrize(("name1", "name2"), [(1, 2), (3, 4)])`
     /// - `list` — e.g.
-    ///   `@pytest.mark.parametrize(('name1', 'name2'), [[1, 2], [3, 4]])`
+    ///   `@pytest.mark.parametrize(("name1", "name2"), [[1, 2], [3, 4]])`
     #[option(
         default = "tuple",
         value_type = r#""tuple" | "list""#,
@@ -1459,7 +1459,7 @@ pub struct Flake8PytestStyleOptions {
     /// Boolean flag specifying whether `@pytest.mark.foo()` without parameters
     /// should have parentheses. If the option is set to `true` (the
     /// default), `@pytest.mark.foo()` is valid and `@pytest.mark.foo` is
-    /// invalid. If set to `false`, `@pytest.fixture` is valid and
+    /// invalid. If set to `false`, `@pytest.mark.foo` is valid and
     /// `@pytest.mark.foo()` is invalid.
     ///
     /// If [preview](https://docs.astral.sh/ruff/preview/) is enabled, defaults to
@@ -1684,7 +1684,7 @@ impl Flake8TidyImportsOptions {
 #[serde(deny_unknown_fields, rename_all = "kebab-case")]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct Flake8TypeCheckingOptions {
-    /// Enforce TC001, TC002, and TC003 rules even when valid runtime imports
+    /// Enforce `TC001`, `TC002`, and `TC003` rules even when valid runtime imports
     /// are present for the same module.
     ///
     /// See flake8-type-checking's [strict](https://github.com/snok/flake8-type-checking#strict) option.
@@ -2138,7 +2138,7 @@ pub struct IsortOptions {
         default = r#"third-party"#,
         value_type = "str",
         example = r#"
-            default-section = "third-party"
+            default-section = "first-party"
         "#
     )]
     pub default_section: Option<ImportSection>,
@@ -2156,8 +2156,8 @@ pub struct IsortOptions {
     ///
     /// Setting `no-sections = true` will instead group all imports into a single section:
     /// ```python
-    /// import os
     /// import numpy
+    /// import os
     /// import pandas
     /// import sys
     /// ```
@@ -2508,7 +2508,7 @@ impl McCabeOptions {
 pub struct Pep8NamingOptions {
     /// A list of names (or patterns) to ignore when considering `pep8-naming` violations.
     ///
-    /// Supports glob patterns. For example, to ignore all names starting with
+    /// Supports glob patterns. For example, to ignore all names starting with `test_`
     /// or ending with `_test`, you could use `ignore-names = ["test_*", "*_test"]`.
     /// For more information on the glob syntax, refer to the [`globset` documentation](https://docs.rs/globset/latest/globset/#syntax).
     #[option(
@@ -2523,7 +2523,7 @@ pub struct Pep8NamingOptions {
     /// Additional names (or patterns) to ignore when considering `pep8-naming` violations,
     /// in addition to those included in `ignore-names`
     ///
-    /// Supports glob patterns. For example, to ignore all names starting with
+    /// Supports glob patterns. For example, to ignore all names starting with `test_`
     /// or ending with `_test`, you could use `ignore-names = ["test_*", "*_test"]`.
     /// For more information on the glob syntax, refer to the [`globset` documentation](https://docs.rs/globset/latest/globset/#syntax).
     #[option(
@@ -2605,10 +2605,12 @@ pub struct PycodestyleOptions {
     /// `pycodestyle.line-length` to a value larger than [`line-length`](#line-length).
     ///
     /// ```toml
-    /// line-length = 88 # The formatter wraps lines at a length of 88
+    /// # The formatter wraps lines at a length of 88.
+    /// line-length = 88
     ///
     /// [pycodestyle]
-    /// max-line-length = 100 # E501 reports lines that exceed the length of 100.
+    /// # E501 reports lines that exceed the length of 100.
+    /// max-line-length = 100
     /// ```
     ///
     /// The length is determined by the number of characters per line, except for lines containing East Asian characters or emojis.
@@ -2626,7 +2628,7 @@ pub struct PycodestyleOptions {
 
     /// The maximum line length to allow for [`doc-line-too-long`](https://docs.astral.sh/ruff/rules/doc-line-too-long/) violations within
     /// documentation (`W505`), including standalone comments. By default,
-    /// this is set to null which disables reporting violations.
+    /// this is set to `null` which disables reporting violations.
     ///
     /// The length is determined by the number of characters per line, except for lines containing Asian characters or emojis.
     /// For these lines, the [unicode width](https://unicode.org/reports/tr11/) of each character is added up to determine the length.
@@ -2670,7 +2672,7 @@ impl PycodestyleOptions {
 #[serde(deny_unknown_fields, rename_all = "kebab-case")]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct PydocstyleOptions {
-    /// Whether to use Google-style or NumPy-style conventions or the [PEP 257](https://peps.python.org/pep-0257/)
+    /// Whether to use Google-style, NumPy-style conventions, or the [PEP 257](https://peps.python.org/pep-0257/)
     /// defaults when analyzing docstring sections.
     ///
     /// Enabling a convention will disable all rules that are not included in
@@ -2788,7 +2790,7 @@ impl PyflakesOptions {
 #[serde(deny_unknown_fields, rename_all = "kebab-case")]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct PylintOptions {
-    /// Constant types to ignore when used as "magic values" (see: `PLR2004`).
+    /// Constant types to ignore when used as "magic values" (see `PLR2004`).
     #[option(
         default = r#"["str", "bytes"]"#,
         value_type = r#"list["str" | "bytes" | "complex" | "float" | "int"]"#,
@@ -2799,7 +2801,7 @@ pub struct PylintOptions {
     pub allow_magic_value_types: Option<Vec<ConstantType>>,
 
     /// Dunder methods name to allow, in addition to the default set from the
-    /// Python standard library (see: `PLW3201`).
+    /// Python standard library (see `PLW3201`).
     #[option(
         default = r#"[]"#,
         value_type = r#"list[str]"#,
@@ -2809,23 +2811,22 @@ pub struct PylintOptions {
     )]
     pub allow_dunder_method_names: Option<FxHashSet<String>>,
 
-    /// Maximum number of branches allowed for a function or method body (see:
-    /// `PLR0912`).
-    #[option(default = r"12", value_type = "int", example = r"max-branches = 12")]
+    /// Maximum number of branches allowed for a function or method body (see `PLR0912`).
+    #[option(default = r"12", value_type = "int", example = r"max-branches = 15")]
     pub max_branches: Option<usize>,
 
     /// Maximum number of return statements allowed for a function or method
     /// body (see `PLR0911`)
-    #[option(default = r"6", value_type = "int", example = r"max-returns = 6")]
+    #[option(default = r"6", value_type = "int", example = r"max-returns = 10")]
     pub max_returns: Option<usize>,
 
     /// Maximum number of arguments allowed for a function or method definition
-    /// (see: `PLR0913`).
-    #[option(default = r"5", value_type = "int", example = r"max-args = 5")]
+    /// (see `PLR0913`).
+    #[option(default = r"5", value_type = "int", example = r"max-args = 10")]
     pub max_args: Option<usize>,
 
     /// Maximum number of positional arguments allowed for a function or method definition
-    /// (see: `PLR0917`).
+    /// (see `PLR0917`).
     ///
     /// If not specified, defaults to the value of `max-args`.
     #[option(
@@ -2835,32 +2836,34 @@ pub struct PylintOptions {
     )]
     pub max_positional_args: Option<usize>,
 
-    /// Maximum number of local variables allowed for a function or method body (see:
-    /// `PLR0914`).
-    #[option(default = r"15", value_type = "int", example = r"max-locals = 15")]
+    /// Maximum number of local variables allowed for a function or method body (see `PLR0914`).
+    #[option(default = r"15", value_type = "int", example = r"max-locals = 20")]
     pub max_locals: Option<usize>,
 
-    /// Maximum number of statements allowed for a function or method body (see:
-    /// `PLR0915`).
-    #[option(default = r"50", value_type = "int", example = r"max-statements = 50")]
+    /// Maximum number of statements allowed for a function or method body (see `PLR0915`).
+    #[option(default = r"50", value_type = "int", example = r"max-statements = 75")]
     pub max_statements: Option<usize>,
 
-    /// Maximum number of public methods allowed for a class (see: `PLR0904`).
+    /// Maximum number of public methods allowed for a class (see `PLR0904`).
     #[option(
         default = r"20",
         value_type = "int",
-        example = r"max-public-methods = 20"
+        example = r"max-public-methods = 30"
     )]
     pub max_public_methods: Option<usize>,
 
     /// Maximum number of Boolean expressions allowed within a single `if` statement
-    /// (see: `PLR0916`).
-    #[option(default = r"5", value_type = "int", example = r"max-bool-expr = 5")]
+    /// (see `PLR0916`).
+    #[option(default = r"5", value_type = "int", example = r"max-bool-expr = 10")]
     pub max_bool_expr: Option<usize>,
 
     /// Maximum number of nested blocks allowed within a function or method body
-    /// (see: `PLR1702`).
-    #[option(default = r"5", value_type = "int", example = r"max-nested-blocks = 5")]
+    /// (see `PLR1702`).
+    #[option(
+        default = r"5",
+        value_type = "int",
+        example = r"max-nested-blocks = 10"
+    )]
     pub max_nested_blocks: Option<usize>,
 }
 
@@ -2912,7 +2915,7 @@ pub struct PyUpgradeOptions {
     /// version.
     ///
     /// For example, while the following is valid Python 3.8 code due to the
-    /// presence of `from __future__ import annotations`, the use of `str| int`
+    /// presence of `from __future__ import annotations`, the use of `str | int`
     /// prior to Python 3.10 will cause Pydantic to raise a `TypeError` at
     /// runtime:
     ///
@@ -2922,7 +2925,7 @@ pub struct PyUpgradeOptions {
     /// import pydantic
     ///
     /// class Foo(pydantic.BaseModel):
-    ///    bar: str | int
+    ///     bar: str | int
     /// ```
     ///
     ///
@@ -2945,7 +2948,7 @@ impl PyUpgradeOptions {
     }
 }
 
-/// Configures the way ruff formats your code.
+/// Configures the way Ruff formats your code.
 #[derive(
     Clone, Debug, PartialEq, Eq, Default, Deserialize, Serialize, OptionsMetadata, CombineOptions,
 )]
@@ -2994,7 +2997,7 @@ pub struct FormatOptions {
     ///     print("Hello") #  Spaces indent the `print` statement.
     /// ```
     ///
-    /// `indent-style = "tab""`:
+    /// `indent-style = "tab"`:
     ///
     /// ```python
     /// def f():
@@ -3032,7 +3035,7 @@ pub struct FormatOptions {
     /// ```
     ///
     /// Ruff will change the quotes of the string assigned to `a` to single quotes when using `quote-style = "single"`.
-    /// However, ruff uses double quotes for he string assigned to `b` because using single quotes would require escaping the `'`,
+    /// However, Ruff uses double quotes for the string assigned to `b` because using single quotes would require escaping the `'`,
     /// which leads to the less readable code: `'It\'s monday morning'`.
     ///
     /// In addition, Ruff supports the quote style `preserve` for projects that already use
@@ -3055,7 +3058,7 @@ pub struct FormatOptions {
     /// collapsing the arguments to a single line doesn't exceed the line length if `skip-magic-trailing-comma = false`:
     ///
     /// ```python
-    ///  # The arguments remain on separate lines because of the trailing comma after `b`
+    /// # The arguments remain on separate lines because of the trailing comma after `b`
     /// def test(
     ///     a,
     ///     b,

--- a/crates/ruff_workspace/src/options.rs
+++ b/crates/ruff_workspace/src/options.rs
@@ -105,7 +105,7 @@ pub struct Options {
     )]
     pub unsafe_fixes: Option<bool>,
 
-    /// Like `fix`, but disables reporting on leftover violation. Implies `fix`.
+    /// Like [`fix`](#fix), but disables reporting on leftover violation. Implies [`fix`](#fix).
     #[option(default = "false", value_type = "bool", example = "fix-only = true")]
     pub fix_only: Option<bool>,
 
@@ -128,7 +128,7 @@ pub struct Options {
     /// Useful for unifying results across many environments, e.g., with a
     /// `pyproject.toml` file.
     ///
-    /// Accepts a PEP 440 specifier, like `==0.3.1` or `>=0.3.1`.
+    /// Accepts a [PEP 440](https://peps.python.org/pep-0440/) specifier, like `==0.3.1` or `>=0.3.1`.
     #[option(
         default = "null",
         value_type = "str",
@@ -177,7 +177,7 @@ pub struct Options {
     pub exclude: Option<Vec<String>>,
 
     /// A list of file patterns to omit from formatting and linting, in addition to those
-    /// specified by `exclude`.
+    /// specified by [`exclude`](#exclude).
     ///
     /// Exclusions are based on globs, and can be either:
     ///
@@ -201,7 +201,7 @@ pub struct Options {
     pub extend_exclude: Option<Vec<String>>,
 
     /// A list of file patterns to include when linting, in addition to those
-    /// specified by `include`.
+    /// specified by [`include`](#include).
     ///
     /// Inclusion are based on globs, and should be single-path patterns, like
     /// `*.pyw`, to include any file with the `.pyw` extension.
@@ -217,8 +217,8 @@ pub struct Options {
     )]
     pub extend_include: Option<Vec<String>>,
 
-    /// Whether to enforce `exclude` and `extend-exclude` patterns, even for
-    /// paths that are passed to Ruff explicitly. Typically, Ruff will lint
+    /// Whether to enforce [`exclude`](#exclude) and [`extend-exclude`](#extend-exclude) patterns,
+    /// even for paths that are passed to Ruff explicitly. Typically, Ruff will lint
     /// any paths passed in directly, even if they would typically be
     /// excluded. Setting `force-exclude = true` will cause Ruff to
     /// respect these exclusions unequivocally.
@@ -564,12 +564,12 @@ pub struct LintCommonOptions {
         "#
     )]
     #[deprecated(
-        note = "The `extend-ignore` option is now interchangeable with `ignore`. Please update your configuration to use the `ignore` option instead."
+        note = "The `extend-ignore` option is now interchangeable with [`ignore`](#lint_ignore). Please update your configuration to use the [`ignore`](#lint_ignore) option instead."
     )]
     pub extend_ignore: Option<Vec<RuleSelector>>,
 
     /// A list of rule codes or prefixes to enable, in addition to those
-    /// specified by `select`.
+    /// specified by [`select`](#lint_select).
     #[option(
         default = "[]",
         value_type = "list[RuleSelector]",
@@ -581,7 +581,7 @@ pub struct LintCommonOptions {
     pub extend_select: Option<Vec<RuleSelector>>,
 
     /// A list of rule codes or prefixes to consider fixable, in addition to those
-    /// specified by `fixable`.
+    /// specified by [`fixable`](#lint_fixable).
     #[option(
         default = r#"[]"#,
         value_type = "list[RuleSelector]",
@@ -593,9 +593,9 @@ pub struct LintCommonOptions {
     pub extend_fixable: Option<Vec<RuleSelector>>,
 
     /// A list of rule codes or prefixes to consider non-auto-fixable, in addition to those
-    /// specified by `unfixable`.
+    /// specified by [`unfixable`](#lint_unfixable).
     #[deprecated(
-        note = "The `extend-unfixable` option is now interchangeable with `unfixable`. Please update your configuration to use the `unfixable` option instead."
+        note = "The `extend-unfixable` option is now interchangeable with [`unfixable`](#lint_unfixable). Please update your configuration to use the `unfixable` option instead."
     )]
     pub extend_unfixable: Option<Vec<RuleSelector>>,
 
@@ -746,7 +746,7 @@ pub struct LintCommonOptions {
     ///
     /// Comments starting with these tags will be ignored by commented-out code
     /// detection (`ERA`), and skipped by line-length rules (`E501`) if
-    /// `ignore-overlong-task-comments` is set to `true`.
+    /// [`ignore-overlong-task-comments`](#lint_pycodestyle_ignore-overlong-task-comments) is set to `true`.
     #[option(
         default = r#"["TODO", "FIXME", "XXX"]"#,
         value_type = "list[str]",
@@ -904,7 +904,7 @@ pub struct LintCommonOptions {
     pub per_file_ignores: Option<FxHashMap<String, Vec<RuleSelector>>>,
 
     /// A list of mappings from file pattern to rule codes or prefixes to
-    /// exclude, in addition to any rules excluded by `per-file-ignores`.
+    /// exclude, in addition to any rules excluded by [`per-file-ignores`](#lint_per-file-ignores).
     #[option(
         default = "{}",
         value_type = "dict[str, list[RuleSelector]]",
@@ -1002,7 +1002,7 @@ pub struct Flake8BanditOptions {
     pub hardcoded_tmp_directory: Option<Vec<String>>,
 
     /// A list of directories to consider temporary, in addition to those
-    /// specified by `hardcoded-tmp-directory`.
+    /// specified by [`hardcoded-tmp-directory`](#lint_flake8-bandit_hardcoded-tmp-directory).
     #[option(
         default = "[]",
         value_type = "list[str]",
@@ -1227,7 +1227,7 @@ pub struct Flake8GetTextOptions {
     pub function_names: Option<Vec<Name>>,
 
     /// Additional function names to consider as internationalization calls, in addition to those
-    /// included in `function-names`.
+    /// included in [`function-names`](#lint_flake8-gettext_function-names).
     #[option(
         default = r#"[]"#,
         value_type = "list[str]",
@@ -1289,7 +1289,7 @@ impl Flake8ImplicitStrConcatOptions {
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct Flake8ImportConventionsOptions {
     /// The conventional aliases for imports. These aliases can be extended by
-    /// the `extend-aliases` option.
+    /// the [`extend-aliases`](#lint_flake8-import-conventions_extend-aliases) option.
     #[option(
         default = r#"{"altair": "alt", "matplotlib": "mpl", "matplotlib.pyplot": "plt", "numpy": "np", "pandas": "pd", "seaborn": "sns", "tensorflow": "tf", "tkinter":  "tk", "holoviews": "hv", "panel": "pn", "plotly.express": "px", "polars": "pl", "pyarrow": "pa"}"#,
         value_type = "dict[str, str]",
@@ -1307,7 +1307,7 @@ pub struct Flake8ImportConventionsOptions {
     pub aliases: Option<FxHashMap<String, String>>,
 
     /// A mapping from module to conventional import alias. These aliases will
-    /// be added to the `aliases` mapping.
+    /// be added to the [`aliases`](#lint_flake8-import-conventions_aliases) mapping.
     #[option(
         default = r#"{}"#,
         value_type = "dict[str, str]",
@@ -1518,7 +1518,7 @@ pub struct Flake8QuotesOptions {
     /// Quote style to prefer for inline strings (either "single" or
     /// "double").
     ///
-    /// When using the formatter, ensure that `format.quote-style` is set to
+    /// When using the formatter, ensure that [`format.quote-style`](#format_quote-style) is set to
     /// the same preferred quote style.
     #[option(
         default = r#""double""#,
@@ -1598,7 +1598,7 @@ pub struct Flake8SelfOptions {
     pub ignore_names: Option<Vec<Name>>,
 
     /// Additional names to ignore when considering `flake8-self` violations,
-    /// in addition to those included in `ignore-names`.
+    /// in addition to those included in [`ignore-names`](#lint_flake8-self_ignore-names).
     #[option(
         default = r#"[]"#,
         value_type = "list[str]",
@@ -1849,11 +1849,11 @@ pub struct IsortOptions {
     /// ```
     ///
     /// Note that this setting is only effective when combined with
-    /// `combine-as-imports = true`. When `combine-as-imports` isn't
+    /// `combine-as-imports = true`. When [`combine-as-imports`](#lint_isort_combine-as-imports) isn't
     /// enabled, every aliased `import from` will be given its own line, in
     /// which case, wrapping is not necessary.
     ///
-    /// When using the formatter, ensure that `format.skip-magic-trailing-comma` is set to `false` (default)
+    /// When using the formatter, ensure that [`format.skip-magic-trailing-comma`](#format_skip-magic-trailing-comma) is set to `false` (default)
     /// when enabling `force-wrap-aliases` to avoid that the formatter collapses members if they all fit on a single line.
     #[option(
         default = r#"false"#,
@@ -1899,7 +1899,7 @@ pub struct IsortOptions {
     ///
     /// See isort's [`split-on-trailing-comma`](https://pycqa.github.io/isort/docs/configuration/options.html#split-on-trailing-comma) option.
     ///
-    /// When using the formatter, ensure that `format.skip-magic-trailing-comma` is set to `false` (default) when enabling `split-on-trailing-comma`
+    /// When using the formatter, ensure that [`format.skip-magic-trailing-comma`](#format_skip-magic-trailing-comma) is set to `false` (default) when enabling `split-on-trailing-comma`
     /// to avoid that the formatter removes the trailing commas.
     #[option(
         default = r#"true"#,
@@ -2014,7 +2014,7 @@ pub struct IsortOptions {
     /// versa.
     ///
     /// The default ("furthest-to-closest") is equivalent to isort's
-    /// `reverse-relative` default (`reverse-relative = false`); setting
+    /// [`reverse-relative`](https://pycqa.github.io/isort/docs/configuration/options.html#reverse-relative) default (`reverse-relative = false`); setting
     /// this to "closest-to-furthest" is equivalent to isort's
     /// `reverse-relative = true`.
     #[option(
@@ -2037,7 +2037,7 @@ pub struct IsortOptions {
     pub required_imports: Option<Vec<String>>,
 
     /// An override list of tokens to always recognize as a Class for
-    /// `order-by-type` regardless of casing.
+    /// [`order-by-type`](#lint_isort_order-by-type) regardless of casing.
     #[option(
         default = r#"[]"#,
         value_type = "list[str]",
@@ -2048,7 +2048,7 @@ pub struct IsortOptions {
     pub classes: Option<Vec<String>>,
 
     /// An override list of tokens to always recognize as a CONSTANT
-    /// for `order-by-type` regardless of casing.
+    /// for [`order-by-type`](#lint_isort_order-by-type) regardless of casing.
     #[option(
         default = r#"[]"#,
         value_type = "list[str]",
@@ -2059,7 +2059,7 @@ pub struct IsortOptions {
     pub constants: Option<Vec<String>>,
 
     /// An override list of tokens to always recognize as a var
-    /// for `order-by-type` regardless of casing.
+    /// for [`order-by-type`](#lint_isort_order-by-type) regardless of casing.
     #[option(
         default = r#"[]"#,
         value_type = "list[str]",
@@ -2133,7 +2133,7 @@ pub struct IsortOptions {
     )]
     pub section_order: Option<Vec<ImportSection>>,
 
-    /// Define a default section for any imports that don't fit into the specified `section-order`.
+    /// Define a default section for any imports that don't fit into the specified [`section-order`](#lint_isort_section-order).
     #[option(
         default = r#"third-party"#,
         value_type = "str",
@@ -2235,7 +2235,7 @@ pub struct IsortOptions {
     )]
     pub length_sort: Option<bool>,
 
-    /// Sort straight imports by their string length. Similar to `length-sort`,
+    /// Sort straight imports by their string length. Similar to [`length-sort`](#lint_isort_length-sort),
     /// but applies only to straight imports and doesn't affect `from` imports.
     #[option(
         default = r#"false"#,
@@ -2264,7 +2264,7 @@ pub struct IsortOptions {
     /// langchain = ["langchain-*"]
     /// ```
     ///
-    /// Custom sections should typically be inserted into the `section-order` list to ensure that
+    /// Custom sections should typically be inserted into the [`section-order`](#lint_isort_section-order) list to ensure that
     /// they're displayed as a standalone group and in the intended order, as in:
     /// ```toml
     /// section-order = [
@@ -2277,8 +2277,8 @@ pub struct IsortOptions {
     /// ]
     /// ```
     ///
-    /// If a custom section is omitted from `section-order`, imports in that section will be
-    /// assigned to the `default-section` (which defaults to `third-party`).
+    /// If a custom section is omitted from [`section-order`](#lint_isort_section-order), imports in that section will be
+    /// assigned to the [`default-section`](#lint_isort_default-section) (which defaults to `third-party`).
     #[option(
         default = "{}",
         value_type = "dict[str, list[str]]",
@@ -2521,7 +2521,7 @@ pub struct Pep8NamingOptions {
     pub ignore_names: Option<Vec<String>>,
 
     /// Additional names (or patterns) to ignore when considering `pep8-naming` violations,
-    /// in addition to those included in `ignore-names`
+    /// in addition to those included in [`ignore-names`](#lint_pep8-naming_ignore-names).
     ///
     /// Supports glob patterns. For example, to ignore all names starting with `test_`
     /// or ending with `_test`, you could use `ignore-names = ["test_*", "*_test"]`.
@@ -2644,7 +2644,7 @@ pub struct PycodestyleOptions {
     pub max_doc_length: Option<LineLength>,
 
     /// Whether line-length violations (`E501`) should be triggered for
-    /// comments starting with `task-tags` (by default: \["TODO", "FIXME",
+    /// comments starting with [`task-tags`](#lint_task-tags) (by default: \["TODO", "FIXME",
     /// and "XXX"\]).
     #[option(
         default = "false",
@@ -2899,7 +2899,7 @@ impl PylintOptions {
 #[serde(deny_unknown_fields, rename_all = "kebab-case")]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct PyUpgradeOptions {
-    /// Whether to avoid PEP 585 (`List[int]` -> `list[int]`) and PEP 604
+    /// Whether to avoid [PEP 585](https://peps.python.org/pep-0585/) (`List[int]` -> `list[int]`) and [PEP 604](https://peps.python.org/pep-0604/)
     /// (`Union[str, int]` -> `str | int`) rewrites even if a file imports
     /// `from __future__ import annotations`.
     ///
@@ -3197,8 +3197,8 @@ pub struct FormatOptions {
     /// in the reformatted code example that exceed the globally configured
     /// line length limit.
     ///
-    /// For example, when this is set to `20` and `docstring-code-format` is
-    /// enabled, then this code:
+    /// For example, when this is set to `20` and [`docstring-code-format`](#docstring-code-format)
+    /// is enabled, then this code:
     ///
     /// ```python
     /// def f(x):

--- a/ruff.schema.json
+++ b/ruff.schema.json
@@ -531,7 +531,7 @@
       }
     },
     "output-format": {
-      "description": "The style in which violation messages should be formatted: `\"full\"` (shows source),`\"concise\"` (default), `\"grouped\"` (group messages by file), `\"json\"` (machine-readable), `\"junit\"` (machine-readable XML), `\"github\"` (GitHub Actions annotations), `\"gitlab\"` (GitLab CI code quality report), `\"pylint\"` (Pylint text format) or `\"azure\"` (Azure Pipeline logging commands).",
+      "description": "The style in which violation messages should be formatted: `\"full\"` (shows source), `\"concise\"` (default), `\"grouped\"` (group messages by file), `\"json\"` (machine-readable), `\"junit\"` (machine-readable XML), `\"github\"` (GitHub Actions annotations), `\"gitlab\"` (GitLab CI code quality report), `\"pylint\"` (Pylint text format) or `\"azure\"` (Azure Pipeline logging commands).",
       "anyOf": [
         {
           "$ref": "#/definitions/OutputFormat"
@@ -1100,14 +1100,14 @@
           ]
         },
         "mark-parentheses": {
-          "description": "Boolean flag specifying whether `@pytest.mark.foo()` without parameters should have parentheses. If the option is set to `true` (the default), `@pytest.mark.foo()` is valid and `@pytest.mark.foo` is invalid. If set to `false`, `@pytest.fixture` is valid and `@pytest.mark.foo()` is invalid.\n\nIf [preview](https://docs.astral.sh/ruff/preview/) is enabled, defaults to `false`.",
+          "description": "Boolean flag specifying whether `@pytest.mark.foo()` without parameters should have parentheses. If the option is set to `true` (the default), `@pytest.mark.foo()` is valid and `@pytest.mark.foo` is invalid. If set to `false`, `@pytest.mark.foo` is valid and `@pytest.mark.foo()` is invalid.\n\nIf [preview](https://docs.astral.sh/ruff/preview/) is enabled, defaults to `false`.",
           "type": [
             "boolean",
             "null"
           ]
         },
         "parametrize-names-type": {
-          "description": "Expected type for multiple argument names in `@pytest.mark.parametrize`. The following values are supported:\n\n- `csv` — a comma-separated list, e.g. `@pytest.mark.parametrize('name1,name2', ...)` - `tuple` (default) — e.g. `@pytest.mark.parametrize(('name1', 'name2'), ...)` - `list` — e.g. `@pytest.mark.parametrize(['name1', 'name2'], ...)`",
+          "description": "Expected type for multiple argument names in `@pytest.mark.parametrize`. The following values are supported:\n\n- `csv` — a comma-separated list, e.g. `@pytest.mark.parametrize(\"name1,name2\", ...)` - `tuple` (default) — e.g. `@pytest.mark.parametrize((\"name1\", \"name2\"), ...)` - `list` — e.g. `@pytest.mark.parametrize([\"name1\", \"name2\"], ...)`",
           "anyOf": [
             {
               "$ref": "#/definitions/ParametrizeNameType"
@@ -1118,7 +1118,7 @@
           ]
         },
         "parametrize-values-row-type": {
-          "description": "Expected type for each row of values in `@pytest.mark.parametrize` in case of multiple parameters. The following values are supported:\n\n- `tuple` (default) — e.g. `@pytest.mark.parametrize(('name1', 'name2'), [(1, 2), (3, 4)])` - `list` — e.g. `@pytest.mark.parametrize(('name1', 'name2'), [[1, 2], [3, 4]])`",
+          "description": "Expected type for each row of values in `@pytest.mark.parametrize` in case of multiple parameters. The following values are supported:\n\n- `tuple` (default) — e.g. `@pytest.mark.parametrize((\"name1\", \"name2\"), [(1, 2), (3, 4)])` - `list` — e.g. `@pytest.mark.parametrize((\"name1\", \"name2\"), [[1, 2], [3, 4]])`",
           "anyOf": [
             {
               "$ref": "#/definitions/ParametrizeValuesRowType"
@@ -1129,7 +1129,7 @@
           ]
         },
         "parametrize-values-type": {
-          "description": "Expected type for the list of values rows in `@pytest.mark.parametrize`. The following values are supported:\n\n- `tuple` — e.g. `@pytest.mark.parametrize('name', (1, 2, 3))` - `list` (default) — e.g. `@pytest.mark.parametrize('name', [1, 2, 3])`",
+          "description": "Expected type for the list of values rows in `@pytest.mark.parametrize`. The following values are supported:\n\n- `tuple` — e.g. `@pytest.mark.parametrize(\"name\", (1, 2, 3))` - `list` (default) — e.g. `@pytest.mark.parametrize(\"name\", [1, 2, 3])`",
           "anyOf": [
             {
               "$ref": "#/definitions/ParametrizeValuesType"
@@ -1312,7 +1312,7 @@
           }
         },
         "strict": {
-          "description": "Enforce TC001, TC002, and TC003 rules even when valid runtime imports are present for the same module.\n\nSee flake8-type-checking's [strict](https://github.com/snok/flake8-type-checking#strict) option.",
+          "description": "Enforce `TC001`, `TC002`, and `TC003` rules even when valid runtime imports are present for the same module.\n\nSee flake8-type-checking's [strict](https://github.com/snok/flake8-type-checking#strict) option.",
           "type": [
             "boolean",
             "null"
@@ -1335,7 +1335,7 @@
       "additionalProperties": false
     },
     "FormatOptions": {
-      "description": "Configures the way ruff formats your code.",
+      "description": "Configures the way Ruff formats your code.",
       "type": "object",
       "properties": {
         "docstring-code-format": {
@@ -1367,7 +1367,7 @@
           }
         },
         "indent-style": {
-          "description": "Whether to use spaces or tabs for indentation.\n\n`indent-style = \"space\"` (default):\n\n```python def f(): print(\"Hello\") #  Spaces indent the `print` statement. ```\n\n`indent-style = \"tab\"\"`:\n\n```python def f(): print(\"Hello\") #  A tab `\\t` indents the `print` statement. ```\n\nPEP 8 recommends using spaces for [indentation](https://peps.python.org/pep-0008/#indentation). We care about accessibility; if you do not need tabs for accessibility, we do not recommend you use them.\n\nSee [`indent-width`](#indent-width) to configure the number of spaces per indentation and the tab width.",
+          "description": "Whether to use spaces or tabs for indentation.\n\n`indent-style = \"space\"` (default):\n\n```python def f(): print(\"Hello\") #  Spaces indent the `print` statement. ```\n\n`indent-style = \"tab\"`:\n\n```python def f(): print(\"Hello\") #  A tab `\\t` indents the `print` statement. ```\n\nPEP 8 recommends using spaces for [indentation](https://peps.python.org/pep-0008/#indentation). We care about accessibility; if you do not need tabs for accessibility, we do not recommend you use them.\n\nSee [`indent-width`](#indent-width) to configure the number of spaces per indentation and the tab width.",
           "anyOf": [
             {
               "$ref": "#/definitions/IndentStyle"
@@ -1396,7 +1396,7 @@
           ]
         },
         "quote-style": {
-          "description": "Configures the preferred quote character for strings. The recommended options are\n\n* `double` (default): Use double quotes `\"` * `single`: Use single quotes `'`\n\nIn compliance with [PEP 8](https://peps.python.org/pep-0008/) and [PEP 257](https://peps.python.org/pep-0257/), Ruff prefers double quotes for triple quoted strings and docstrings even when using `quote-style = \"single\"`.\n\nRuff deviates from using the configured quotes if doing so prevents the need for escaping quote characters inside the string:\n\n```python a = \"a string without any quotes\" b = \"It's monday morning\" ```\n\nRuff will change the quotes of the string assigned to `a` to single quotes when using `quote-style = \"single\"`. However, ruff uses double quotes for he string assigned to `b` because using single quotes would require escaping the `'`, which leads to the less readable code: `'It\\'s monday morning'`.\n\nIn addition, Ruff supports the quote style `preserve` for projects that already use a mixture of single and double quotes and can't migrate to the `double` or `single` style. The quote style `preserve` leaves the quotes of all strings unchanged.",
+          "description": "Configures the preferred quote character for strings. The recommended options are\n\n* `double` (default): Use double quotes `\"` * `single`: Use single quotes `'`\n\nIn compliance with [PEP 8](https://peps.python.org/pep-0008/) and [PEP 257](https://peps.python.org/pep-0257/), Ruff prefers double quotes for triple quoted strings and docstrings even when using `quote-style = \"single\"`.\n\nRuff deviates from using the configured quotes if doing so prevents the need for escaping quote characters inside the string:\n\n```python a = \"a string without any quotes\" b = \"It's monday morning\" ```\n\nRuff will change the quotes of the string assigned to `a` to single quotes when using `quote-style = \"single\"`. However, Ruff uses double quotes for the string assigned to `b` because using single quotes would require escaping the `'`, which leads to the less readable code: `'It\\'s monday morning'`.\n\nIn addition, Ruff supports the quote style `preserve` for projects that already use a mixture of single and double quotes and can't migrate to the `double` or `single` style. The quote style `preserve` leaves the quotes of all strings unchanged.",
           "anyOf": [
             {
               "$ref": "#/definitions/QuoteStyle"
@@ -1645,7 +1645,7 @@
           }
         },
         "no-sections": {
-          "description": "Put all imports into the same section bucket.\n\nFor example, rather than separating standard library and third-party imports, as in: ```python import os import sys\n\nimport numpy import pandas ```\n\nSetting `no-sections = true` will instead group all imports into a single section: ```python import os import numpy import pandas import sys ```",
+          "description": "Put all imports into the same section bucket.\n\nFor example, rather than separating standard library and third-party imports, as in: ```python import os import sys\n\nimport numpy import pandas ```\n\nSetting `no-sections = true` will instead group all imports into a single section: ```python import numpy import os import pandas import sys ```",
           "type": [
             "boolean",
             "null"
@@ -1778,7 +1778,7 @@
       "minimum": 1.0
     },
     "LintOptions": {
-      "description": "Configures how ruff checks your code.\n\nOptions specified in the `lint` section take precedence over the deprecated top-level settings.",
+      "description": "Configures how Ruff checks your code.\n\nOptions specified in the `lint` section take precedence over the deprecated top-level settings.",
       "type": "object",
       "properties": {
         "allowed-confusables": {
@@ -2357,7 +2357,7 @@
           }
         },
         "extend-ignore-names": {
-          "description": "Additional names (or patterns) to ignore when considering `pep8-naming` violations, in addition to those included in `ignore-names`\n\nSupports glob patterns. For example, to ignore all names starting with or ending with `_test`, you could use `ignore-names = [\"test_*\", \"*_test\"]`. For more information on the glob syntax, refer to the [`globset` documentation](https://docs.rs/globset/latest/globset/#syntax).",
+          "description": "Additional names (or patterns) to ignore when considering `pep8-naming` violations, in addition to those included in `ignore-names`\n\nSupports glob patterns. For example, to ignore all names starting with `test_` or ending with `_test`, you could use `ignore-names = [\"test_*\", \"*_test\"]`. For more information on the glob syntax, refer to the [`globset` documentation](https://docs.rs/globset/latest/globset/#syntax).",
           "type": [
             "array",
             "null"
@@ -2367,7 +2367,7 @@
           }
         },
         "ignore-names": {
-          "description": "A list of names (or patterns) to ignore when considering `pep8-naming` violations.\n\nSupports glob patterns. For example, to ignore all names starting with or ending with `_test`, you could use `ignore-names = [\"test_*\", \"*_test\"]`. For more information on the glob syntax, refer to the [`globset` documentation](https://docs.rs/globset/latest/globset/#syntax).",
+          "description": "A list of names (or patterns) to ignore when considering `pep8-naming` violations.\n\nSupports glob patterns. For example, to ignore all names starting with `test_` or ending with `_test`, you could use `ignore-names = [\"test_*\", \"*_test\"]`. For more information on the glob syntax, refer to the [`globset` documentation](https://docs.rs/globset/latest/globset/#syntax).",
           "type": [
             "array",
             "null"
@@ -2393,7 +2393,7 @@
       "type": "object",
       "properties": {
         "keep-runtime-typing": {
-          "description": "Whether to avoid PEP 585 (`List[int]` -> `list[int]`) and PEP 604 (`Union[str, int]` -> `str | int`) rewrites even if a file imports `from __future__ import annotations`.\n\nThis setting is only applicable when the target Python version is below 3.9 and 3.10 respectively, and is most commonly used when working with libraries like Pydantic and FastAPI, which rely on the ability to parse type annotations at runtime. The use of `from __future__ import annotations` causes Python to treat the type annotations as strings, which typically allows for the use of language features that appear in later Python versions but are not yet supported by the current version (e.g., `str | int`). However, libraries that rely on runtime type annotations will break if the annotations are incompatible with the current Python version.\n\nFor example, while the following is valid Python 3.8 code due to the presence of `from __future__ import annotations`, the use of `str| int` prior to Python 3.10 will cause Pydantic to raise a `TypeError` at runtime:\n\n```python from __future__ import annotations\n\nimport pydantic\n\nclass Foo(pydantic.BaseModel): bar: str | int ```",
+          "description": "Whether to avoid PEP 585 (`List[int]` -> `list[int]`) and PEP 604 (`Union[str, int]` -> `str | int`) rewrites even if a file imports `from __future__ import annotations`.\n\nThis setting is only applicable when the target Python version is below 3.9 and 3.10 respectively, and is most commonly used when working with libraries like Pydantic and FastAPI, which rely on the ability to parse type annotations at runtime. The use of `from __future__ import annotations` causes Python to treat the type annotations as strings, which typically allows for the use of language features that appear in later Python versions but are not yet supported by the current version (e.g., `str | int`). However, libraries that rely on runtime type annotations will break if the annotations are incompatible with the current Python version.\n\nFor example, while the following is valid Python 3.8 code due to the presence of `from __future__ import annotations`, the use of `str | int` prior to Python 3.10 will cause Pydantic to raise a `TypeError` at runtime:\n\n```python from __future__ import annotations\n\nimport pydantic\n\nclass Foo(pydantic.BaseModel): bar: str | int ```",
           "type": [
             "boolean",
             "null"
@@ -2413,7 +2413,7 @@
           ]
         },
         "max-doc-length": {
-          "description": "The maximum line length to allow for [`doc-line-too-long`](https://docs.astral.sh/ruff/rules/doc-line-too-long/) violations within documentation (`W505`), including standalone comments. By default, this is set to null which disables reporting violations.\n\nThe length is determined by the number of characters per line, except for lines containing Asian characters or emojis. For these lines, the [unicode width](https://unicode.org/reports/tr11/) of each character is added up to determine the length.\n\nSee the [`doc-line-too-long`](https://docs.astral.sh/ruff/rules/doc-line-too-long/) rule for more information.",
+          "description": "The maximum line length to allow for [`doc-line-too-long`](https://docs.astral.sh/ruff/rules/doc-line-too-long/) violations within documentation (`W505`), including standalone comments. By default, this is set to `null` which disables reporting violations.\n\nThe length is determined by the number of characters per line, except for lines containing Asian characters or emojis. For these lines, the [unicode width](https://unicode.org/reports/tr11/) of each character is added up to determine the length.\n\nSee the [`doc-line-too-long`](https://docs.astral.sh/ruff/rules/doc-line-too-long/) rule for more information.",
           "anyOf": [
             {
               "$ref": "#/definitions/LineLength"
@@ -2424,7 +2424,7 @@
           ]
         },
         "max-line-length": {
-          "description": "The maximum line length to allow for [`line-too-long`](https://docs.astral.sh/ruff/rules/line-too-long/) violations. By default, this is set to the value of the [`line-length`](#line-length) option.\n\nUse this option when you want to detect extra-long lines that the formatter can't automatically split by setting `pycodestyle.line-length` to a value larger than [`line-length`](#line-length).\n\n```toml line-length = 88 # The formatter wraps lines at a length of 88\n\n[pycodestyle] max-line-length = 100 # E501 reports lines that exceed the length of 100. ```\n\nThe length is determined by the number of characters per line, except for lines containing East Asian characters or emojis. For these lines, the [unicode width](https://unicode.org/reports/tr11/) of each character is added up to determine the length.\n\nSee the [`line-too-long`](https://docs.astral.sh/ruff/rules/line-too-long/) rule for more information.",
+          "description": "The maximum line length to allow for [`line-too-long`](https://docs.astral.sh/ruff/rules/line-too-long/) violations. By default, this is set to the value of the [`line-length`](#line-length) option.\n\nUse this option when you want to detect extra-long lines that the formatter can't automatically split by setting `pycodestyle.line-length` to a value larger than [`line-length`](#line-length).\n\n```toml # The formatter wraps lines at a length of 88. line-length = 88\n\n[pycodestyle] # E501 reports lines that exceed the length of 100. max-line-length = 100 ```\n\nThe length is determined by the number of characters per line, except for lines containing East Asian characters or emojis. For these lines, the [unicode width](https://unicode.org/reports/tr11/) of each character is added up to determine the length.\n\nSee the [`line-too-long`](https://docs.astral.sh/ruff/rules/line-too-long/) rule for more information.",
           "anyOf": [
             {
               "$ref": "#/definitions/LineLength"
@@ -2441,7 +2441,7 @@
       "type": "object",
       "properties": {
         "convention": {
-          "description": "Whether to use Google-style or NumPy-style conventions or the [PEP 257](https://peps.python.org/pep-0257/) defaults when analyzing docstring sections.\n\nEnabling a convention will disable all rules that are not included in the specified convention. As such, the intended workflow is to enable a convention and then selectively enable or disable any additional rules on top of it.\n\nFor example, to use Google-style conventions but avoid requiring documentation for every function parameter:\n\n```toml [tool.ruff.lint] # Enable all `pydocstyle` rules, limiting to those that adhere to the # Google convention via `convention = \"google\"`, below. select = [\"D\"]\n\n# On top of the Google convention, disable `D417`, which requires # documentation for every function parameter. ignore = [\"D417\"]\n\n[tool.ruff.lint.pydocstyle] convention = \"google\" ```\n\nTo enable an additional rule that's excluded from the convention, select the desired rule via its fully qualified rule code (e.g., `D400` instead of `D4` or `D40`):\n\n```toml [tool.ruff.lint] # Enable D400 on top of the Google convention. extend-select = [\"D400\"]\n\n[tool.ruff.lint.pydocstyle] convention = \"google\" ```",
+          "description": "Whether to use Google-style, NumPy-style conventions, or the [PEP 257](https://peps.python.org/pep-0257/) defaults when analyzing docstring sections.\n\nEnabling a convention will disable all rules that are not included in the specified convention. As such, the intended workflow is to enable a convention and then selectively enable or disable any additional rules on top of it.\n\nFor example, to use Google-style conventions but avoid requiring documentation for every function parameter:\n\n```toml [tool.ruff.lint] # Enable all `pydocstyle` rules, limiting to those that adhere to the # Google convention via `convention = \"google\"`, below. select = [\"D\"]\n\n# On top of the Google convention, disable `D417`, which requires # documentation for every function parameter. ignore = [\"D417\"]\n\n[tool.ruff.lint.pydocstyle] convention = \"google\" ```\n\nTo enable an additional rule that's excluded from the convention, select the desired rule via its fully qualified rule code (e.g., `D400` instead of `D4` or `D40`):\n\n```toml [tool.ruff.lint] # Enable D400 on top of the Google convention. extend-select = [\"D400\"]\n\n[tool.ruff.lint.pydocstyle] convention = \"google\" ```",
           "anyOf": [
             {
               "$ref": "#/definitions/Convention"
@@ -2494,7 +2494,7 @@
       "type": "object",
       "properties": {
         "allow-dunder-method-names": {
-          "description": "Dunder methods name to allow, in addition to the default set from the Python standard library (see: `PLW3201`).",
+          "description": "Dunder methods name to allow, in addition to the default set from the Python standard library (see `PLW3201`).",
           "type": [
             "array",
             "null"
@@ -2505,7 +2505,7 @@
           "uniqueItems": true
         },
         "allow-magic-value-types": {
-          "description": "Constant types to ignore when used as \"magic values\" (see: `PLR2004`).",
+          "description": "Constant types to ignore when used as \"magic values\" (see `PLR2004`).",
           "type": [
             "array",
             "null"
@@ -2515,7 +2515,7 @@
           }
         },
         "max-args": {
-          "description": "Maximum number of arguments allowed for a function or method definition (see: `PLR0913`).",
+          "description": "Maximum number of arguments allowed for a function or method definition (see `PLR0913`).",
           "type": [
             "integer",
             "null"
@@ -2524,7 +2524,7 @@
           "minimum": 0.0
         },
         "max-bool-expr": {
-          "description": "Maximum number of Boolean expressions allowed within a single `if` statement (see: `PLR0916`).",
+          "description": "Maximum number of Boolean expressions allowed within a single `if` statement (see `PLR0916`).",
           "type": [
             "integer",
             "null"
@@ -2533,7 +2533,7 @@
           "minimum": 0.0
         },
         "max-branches": {
-          "description": "Maximum number of branches allowed for a function or method body (see: `PLR0912`).",
+          "description": "Maximum number of branches allowed for a function or method body (see `PLR0912`).",
           "type": [
             "integer",
             "null"
@@ -2542,7 +2542,7 @@
           "minimum": 0.0
         },
         "max-locals": {
-          "description": "Maximum number of local variables allowed for a function or method body (see: `PLR0914`).",
+          "description": "Maximum number of local variables allowed for a function or method body (see `PLR0914`).",
           "type": [
             "integer",
             "null"
@@ -2551,7 +2551,7 @@
           "minimum": 0.0
         },
         "max-nested-blocks": {
-          "description": "Maximum number of nested blocks allowed within a function or method body (see: `PLR1702`).",
+          "description": "Maximum number of nested blocks allowed within a function or method body (see `PLR1702`).",
           "type": [
             "integer",
             "null"
@@ -2560,7 +2560,7 @@
           "minimum": 0.0
         },
         "max-positional-args": {
-          "description": "Maximum number of positional arguments allowed for a function or method definition (see: `PLR0917`).\n\nIf not specified, defaults to the value of `max-args`.",
+          "description": "Maximum number of positional arguments allowed for a function or method definition (see `PLR0917`).\n\nIf not specified, defaults to the value of `max-args`.",
           "type": [
             "integer",
             "null"
@@ -2569,7 +2569,7 @@
           "minimum": 0.0
         },
         "max-public-methods": {
-          "description": "Maximum number of public methods allowed for a class (see: `PLR0904`).",
+          "description": "Maximum number of public methods allowed for a class (see `PLR0904`).",
           "type": [
             "integer",
             "null"
@@ -2587,7 +2587,7 @@
           "minimum": 0.0
         },
         "max-statements": {
-          "description": "Maximum number of statements allowed for a function or method body (see: `PLR0915`).",
+          "description": "Maximum number of statements allowed for a function or method body (see `PLR0915`).",
           "type": [
             "integer",
             "null"

--- a/ruff.schema.json
+++ b/ruff.schema.json
@@ -67,7 +67,7 @@
       ]
     },
     "extend-exclude": {
-      "description": "A list of file patterns to omit from formatting and linting, in addition to those specified by `exclude`.\n\nExclusions are based on globs, and can be either:\n\n- Single-path patterns, like `.mypy_cache` (to exclude any directory named `.mypy_cache` in the tree), `foo.py` (to exclude any file named `foo.py`), or `foo_*.py` (to exclude any file matching `foo_*.py` ). - Relative patterns, like `directory/foo.py` (to exclude that specific file) or `directory/*.py` (to exclude any Python files in `directory`). Note that these paths are relative to the project root (e.g., the directory containing your `pyproject.toml`).\n\nFor more information on the glob syntax, refer to the [`globset` documentation](https://docs.rs/globset/latest/globset/#syntax).",
+      "description": "A list of file patterns to omit from formatting and linting, in addition to those specified by [`exclude`](#exclude).\n\nExclusions are based on globs, and can be either:\n\n- Single-path patterns, like `.mypy_cache` (to exclude any directory named `.mypy_cache` in the tree), `foo.py` (to exclude any file named `foo.py`), or `foo_*.py` (to exclude any file matching `foo_*.py` ). - Relative patterns, like `directory/foo.py` (to exclude that specific file) or `directory/*.py` (to exclude any Python files in `directory`). Note that these paths are relative to the project root (e.g., the directory containing your `pyproject.toml`).\n\nFor more information on the glob syntax, refer to the [`globset` documentation](https://docs.rs/globset/latest/globset/#syntax).",
       "type": [
         "array",
         "null"
@@ -77,7 +77,7 @@
       }
     },
     "extend-fixable": {
-      "description": "A list of rule codes or prefixes to consider fixable, in addition to those specified by `fixable`.",
+      "description": "A list of rule codes or prefixes to consider fixable, in addition to those specified by [`fixable`](#lint_fixable).",
       "deprecated": true,
       "type": [
         "array",
@@ -99,7 +99,7 @@
       }
     },
     "extend-include": {
-      "description": "A list of file patterns to include when linting, in addition to those specified by `include`.\n\nInclusion are based on globs, and should be single-path patterns, like `*.pyw`, to include any file with the `.pyw` extension.\n\nFor more information on the glob syntax, refer to the [`globset` documentation](https://docs.rs/globset/latest/globset/#syntax).",
+      "description": "A list of file patterns to include when linting, in addition to those specified by [`include`](#include).\n\nInclusion are based on globs, and should be single-path patterns, like `*.pyw`, to include any file with the `.pyw` extension.\n\nFor more information on the glob syntax, refer to the [`globset` documentation](https://docs.rs/globset/latest/globset/#syntax).",
       "type": [
         "array",
         "null"
@@ -109,7 +109,7 @@
       }
     },
     "extend-per-file-ignores": {
-      "description": "A list of mappings from file pattern to rule codes or prefixes to exclude, in addition to any rules excluded by `per-file-ignores`.",
+      "description": "A list of mappings from file pattern to rule codes or prefixes to exclude, in addition to any rules excluded by [`per-file-ignores`](#lint_per-file-ignores).",
       "deprecated": true,
       "type": [
         "object",
@@ -134,7 +134,7 @@
       }
     },
     "extend-select": {
-      "description": "A list of rule codes or prefixes to enable, in addition to those specified by `select`.",
+      "description": "A list of rule codes or prefixes to enable, in addition to those specified by [`select`](#lint_select).",
       "deprecated": true,
       "type": [
         "array",
@@ -145,7 +145,7 @@
       }
     },
     "extend-unfixable": {
-      "description": "A list of rule codes or prefixes to consider non-auto-fixable, in addition to those specified by `unfixable`.",
+      "description": "A list of rule codes or prefixes to consider non-auto-fixable, in addition to those specified by [`unfixable`](#lint_unfixable).",
       "deprecated": true,
       "type": [
         "array",
@@ -185,7 +185,7 @@
       ]
     },
     "fix-only": {
-      "description": "Like `fix`, but disables reporting on leftover violation. Implies `fix`.",
+      "description": "Like [`fix`](#fix), but disables reporting on leftover violation. Implies [`fix`](#fix).",
       "type": [
         "boolean",
         "null"
@@ -407,7 +407,7 @@
       ]
     },
     "force-exclude": {
-      "description": "Whether to enforce `exclude` and `extend-exclude` patterns, even for paths that are passed to Ruff explicitly. Typically, Ruff will lint any paths passed in directly, even if they would typically be excluded. Setting `force-exclude = true` will cause Ruff to respect these exclusions unequivocally.\n\nThis is useful for [`pre-commit`](https://pre-commit.com/), which explicitly passes all changed files to the [`ruff-pre-commit`](https://github.com/astral-sh/ruff-pre-commit) plugin, regardless of whether they're marked as excluded by Ruff's own settings.",
+      "description": "Whether to enforce [`exclude`](#exclude) and [`extend-exclude`](#extend-exclude) patterns, even for paths that are passed to Ruff explicitly. Typically, Ruff will lint any paths passed in directly, even if they would typically be excluded. Setting `force-exclude = true` will cause Ruff to respect these exclusions unequivocally.\n\nThis is useful for [`pre-commit`](https://pre-commit.com/), which explicitly passes all changed files to the [`ruff-pre-commit`](https://github.com/astral-sh/ruff-pre-commit) plugin, regardless of whether they're marked as excluded by Ruff's own settings.",
       "type": [
         "boolean",
         "null"
@@ -635,7 +635,7 @@
       ]
     },
     "required-version": {
-      "description": "Enforce a requirement on the version of Ruff, to enforce at runtime. If the version of Ruff does not meet the requirement, Ruff will exit with an error.\n\nUseful for unifying results across many environments, e.g., with a `pyproject.toml` file.\n\nAccepts a PEP 440 specifier, like `==0.3.1` or `>=0.3.1`.",
+      "description": "Enforce a requirement on the version of Ruff, to enforce at runtime. If the version of Ruff does not meet the requirement, Ruff will exit with an error.\n\nUseful for unifying results across many environments, e.g., with a `pyproject.toml` file.\n\nAccepts a [PEP 440](https://peps.python.org/pep-0440/) specifier, like `==0.3.1` or `>=0.3.1`.",
       "anyOf": [
         {
           "$ref": "#/definitions/RequiredVersion"
@@ -704,7 +704,7 @@
       ]
     },
     "task-tags": {
-      "description": "A list of task tags to recognize (e.g., \"TODO\", \"FIXME\", \"XXX\").\n\nComments starting with these tags will be ignored by commented-out code detection (`ERA`), and skipped by line-length rules (`E501`) if `ignore-overlong-task-comments` is set to `true`.",
+      "description": "A list of task tags to recognize (e.g., \"TODO\", \"FIXME\", \"XXX\").\n\nComments starting with these tags will be ignored by commented-out code detection (`ERA`), and skipped by line-length rules (`E501`) if [`ignore-overlong-task-comments`](#lint_pycodestyle_ignore-overlong-task-comments) is set to `true`.",
       "deprecated": true,
       "type": [
         "array",
@@ -886,7 +886,7 @@
           }
         },
         "hardcoded-tmp-directory-extend": {
-          "description": "A list of directories to consider temporary, in addition to those specified by `hardcoded-tmp-directory`.",
+          "description": "A list of directories to consider temporary, in addition to those specified by [`hardcoded-tmp-directory`](#lint_flake8-bandit_hardcoded-tmp-directory).",
           "type": [
             "array",
             "null"
@@ -1007,7 +1007,7 @@
       "type": "object",
       "properties": {
         "extend-function-names": {
-          "description": "Additional function names to consider as internationalization calls, in addition to those included in `function-names`.",
+          "description": "Additional function names to consider as internationalization calls, in addition to those included in [`function-names`](#lint_flake8-gettext_function-names).",
           "type": [
             "array",
             "null"
@@ -1046,7 +1046,7 @@
       "type": "object",
       "properties": {
         "aliases": {
-          "description": "The conventional aliases for imports. These aliases can be extended by the `extend-aliases` option.",
+          "description": "The conventional aliases for imports. These aliases can be extended by the [`extend-aliases`](#lint_flake8-import-conventions_extend-aliases) option.",
           "type": [
             "object",
             "null"
@@ -1077,7 +1077,7 @@
           "uniqueItems": true
         },
         "extend-aliases": {
-          "description": "A mapping from module to conventional import alias. These aliases will be added to the `aliases` mapping.",
+          "description": "A mapping from module to conventional import alias. These aliases will be added to the [`aliases`](#lint_flake8-import-conventions_aliases) mapping.",
           "type": [
             "object",
             "null"
@@ -1184,7 +1184,7 @@
           ]
         },
         "inline-quotes": {
-          "description": "Quote style to prefer for inline strings (either \"single\" or \"double\").\n\nWhen using the formatter, ensure that `format.quote-style` is set to the same preferred quote style.",
+          "description": "Quote style to prefer for inline strings (either \"single\" or \"double\").\n\nWhen using the formatter, ensure that [`format.quote-style`](#format_quote-style) is set to the same preferred quote style.",
           "anyOf": [
             {
               "$ref": "#/definitions/Quote"
@@ -1212,7 +1212,7 @@
       "type": "object",
       "properties": {
         "extend-ignore-names": {
-          "description": "Additional names to ignore when considering `flake8-self` violations, in addition to those included in `ignore-names`.",
+          "description": "Additional names to ignore when considering `flake8-self` violations, in addition to those included in [`ignore-names`](#lint_flake8-self_ignore-names).",
           "type": [
             "array",
             "null"
@@ -1346,7 +1346,7 @@
           ]
         },
         "docstring-code-line-length": {
-          "description": "Set the line length used when formatting code snippets in docstrings.\n\nThis only has an effect when the `docstring-code-format` setting is enabled.\n\nThe default value for this setting is `\"dynamic\"`, which has the effect of ensuring that any reformatted code examples in docstrings adhere to the global line length configuration that is used for the surrounding Python code. The point of this setting is that it takes the indentation of the docstring into account when reformatting code examples.\n\nAlternatively, this can be set to a fixed integer, which will result in the same line length limit being applied to all reformatted code examples in docstrings. When set to a fixed integer, the indent of the docstring is not taken into account. That is, this may result in lines in the reformatted code example that exceed the globally configured line length limit.\n\nFor example, when this is set to `20` and `docstring-code-format` is enabled, then this code:\n\n```python def f(x): ''' Something about `f`. And an example:\n\n.. code-block:: python\n\nfoo, bar, quux = this_is_a_long_line(lion, hippo, lemur, bear) ''' pass ```\n\n... will be reformatted (assuming the rest of the options are set to their defaults) as:\n\n```python def f(x): \"\"\" Something about `f`. And an example:\n\n.. code-block:: python\n\n( foo, bar, quux, ) = this_is_a_long_line( lion, hippo, lemur, bear, ) \"\"\" pass ```",
+          "description": "Set the line length used when formatting code snippets in docstrings.\n\nThis only has an effect when the `docstring-code-format` setting is enabled.\n\nThe default value for this setting is `\"dynamic\"`, which has the effect of ensuring that any reformatted code examples in docstrings adhere to the global line length configuration that is used for the surrounding Python code. The point of this setting is that it takes the indentation of the docstring into account when reformatting code examples.\n\nAlternatively, this can be set to a fixed integer, which will result in the same line length limit being applied to all reformatted code examples in docstrings. When set to a fixed integer, the indent of the docstring is not taken into account. That is, this may result in lines in the reformatted code example that exceed the globally configured line length limit.\n\nFor example, when this is set to `20` and [`docstring-code-format`](#docstring-code-format) is enabled, then this code:\n\n```python def f(x): ''' Something about `f`. And an example:\n\n.. code-block:: python\n\nfoo, bar, quux = this_is_a_long_line(lion, hippo, lemur, bear) ''' pass ```\n\n... will be reformatted (assuming the rest of the options are set to their defaults) as:\n\n```python def f(x): \"\"\" Something about `f`. And an example:\n\n.. code-block:: python\n\n( foo, bar, quux, ) = this_is_a_long_line( lion, hippo, lemur, bear, ) \"\"\" pass ```",
           "anyOf": [
             {
               "$ref": "#/definitions/DocstringCodeLineWidth"
@@ -1471,7 +1471,7 @@
           ]
         },
         "classes": {
-          "description": "An override list of tokens to always recognize as a Class for `order-by-type` regardless of casing.",
+          "description": "An override list of tokens to always recognize as a Class for [`order-by-type`](#lint_isort_order-by-type) regardless of casing.",
           "type": [
             "array",
             "null"
@@ -1488,7 +1488,7 @@
           ]
         },
         "constants": {
-          "description": "An override list of tokens to always recognize as a CONSTANT for `order-by-type` regardless of casing.",
+          "description": "An override list of tokens to always recognize as a CONSTANT for [`order-by-type`](#lint_isort_order-by-type) regardless of casing.",
           "type": [
             "array",
             "null"
@@ -1498,7 +1498,7 @@
           }
         },
         "default-section": {
-          "description": "Define a default section for any imports that don't fit into the specified `section-order`.",
+          "description": "Define a default section for any imports that don't fit into the specified [`section-order`](#lint_isort_section-order).",
           "anyOf": [
             {
               "$ref": "#/definitions/ImportSection"
@@ -1550,7 +1550,7 @@
           }
         },
         "force-wrap-aliases": {
-          "description": "Force `import from` statements with multiple members and at least one alias (e.g., `import A as B`) to wrap such that every line contains exactly one member. For example, this formatting would be retained, rather than condensing to a single line:\n\n```python from .utils import ( test_directory as test_directory, test_id as test_id ) ```\n\nNote that this setting is only effective when combined with `combine-as-imports = true`. When `combine-as-imports` isn't enabled, every aliased `import from` will be given its own line, in which case, wrapping is not necessary.\n\nWhen using the formatter, ensure that `format.skip-magic-trailing-comma` is set to `false` (default) when enabling `force-wrap-aliases` to avoid that the formatter collapses members if they all fit on a single line.",
+          "description": "Force `import from` statements with multiple members and at least one alias (e.g., `import A as B`) to wrap such that every line contains exactly one member. For example, this formatting would be retained, rather than condensing to a single line:\n\n```python from .utils import ( test_directory as test_directory, test_id as test_id ) ```\n\nNote that this setting is only effective when combined with `combine-as-imports = true`. When [`combine-as-imports`](#lint_isort_combine-as-imports) isn't enabled, every aliased `import from` will be given its own line, in which case, wrapping is not necessary.\n\nWhen using the formatter, ensure that [`format.skip-magic-trailing-comma`](#format_skip-magic-trailing-comma) is set to `false` (default) when enabling `force-wrap-aliases` to avoid that the formatter collapses members if they all fit on a single line.",
           "type": [
             "boolean",
             "null"
@@ -1611,7 +1611,7 @@
           ]
         },
         "length-sort-straight": {
-          "description": "Sort straight imports by their string length. Similar to `length-sort`, but applies only to straight imports and doesn't affect `from` imports.",
+          "description": "Sort straight imports by their string length. Similar to [`length-sort`](#lint_isort_length-sort), but applies only to straight imports and doesn't affect `from` imports.",
           "type": [
             "boolean",
             "null"
@@ -1659,7 +1659,7 @@
           ]
         },
         "relative-imports-order": {
-          "description": "Whether to place \"closer\" imports (fewer `.` characters, most local) before \"further\" imports (more `.` characters, least local), or vice versa.\n\nThe default (\"furthest-to-closest\") is equivalent to isort's `reverse-relative` default (`reverse-relative = false`); setting this to \"closest-to-furthest\" is equivalent to isort's `reverse-relative = true`.",
+          "description": "Whether to place \"closer\" imports (fewer `.` characters, most local) before \"further\" imports (more `.` characters, least local), or vice versa.\n\nThe default (\"furthest-to-closest\") is equivalent to isort's [`reverse-relative`](https://pycqa.github.io/isort/docs/configuration/options.html#reverse-relative) default (`reverse-relative = false`); setting this to \"closest-to-furthest\" is equivalent to isort's `reverse-relative = true`.",
           "anyOf": [
             {
               "$ref": "#/definitions/RelativeImportsOrder"
@@ -1690,7 +1690,7 @@
           }
         },
         "sections": {
-          "description": "A list of mappings from section names to modules.\n\nBy default, imports are categorized according to their type (e.g., `future`, `third-party`, and so on). This setting allows you to group modules into custom sections, to augment or override the built-in sections.\n\nFor example, to group all testing utilities, you could create a `testing` section: ```toml testing = [\"pytest\", \"hypothesis\"] ```\n\nThe values in the list are treated as glob patterns. For example, to match all packages in the LangChain ecosystem (`langchain-core`, `langchain-openai`, etc.): ```toml langchain = [\"langchain-*\"] ```\n\nCustom sections should typically be inserted into the `section-order` list to ensure that they're displayed as a standalone group and in the intended order, as in: ```toml section-order = [ \"future\", \"standard-library\", \"third-party\", \"first-party\", \"local-folder\", \"testing\" ] ```\n\nIf a custom section is omitted from `section-order`, imports in that section will be assigned to the `default-section` (which defaults to `third-party`).",
+          "description": "A list of mappings from section names to modules.\n\nBy default, imports are categorized according to their type (e.g., `future`, `third-party`, and so on). This setting allows you to group modules into custom sections, to augment or override the built-in sections.\n\nFor example, to group all testing utilities, you could create a `testing` section: ```toml testing = [\"pytest\", \"hypothesis\"] ```\n\nThe values in the list are treated as glob patterns. For example, to match all packages in the LangChain ecosystem (`langchain-core`, `langchain-openai`, etc.): ```toml langchain = [\"langchain-*\"] ```\n\nCustom sections should typically be inserted into the [`section-order`](#lint_isort_section-order) list to ensure that they're displayed as a standalone group and in the intended order, as in: ```toml section-order = [ \"future\", \"standard-library\", \"third-party\", \"first-party\", \"local-folder\", \"testing\" ] ```\n\nIf a custom section is omitted from [`section-order`](#lint_isort_section-order), imports in that section will be assigned to the [`default-section`](#lint_isort_default-section) (which defaults to `third-party`).",
           "type": [
             "object",
             "null"
@@ -1713,14 +1713,14 @@
           }
         },
         "split-on-trailing-comma": {
-          "description": "If a comma is placed after the last member in a multi-line import, then the imports will never be folded into one line.\n\nSee isort's [`split-on-trailing-comma`](https://pycqa.github.io/isort/docs/configuration/options.html#split-on-trailing-comma) option.\n\nWhen using the formatter, ensure that `format.skip-magic-trailing-comma` is set to `false` (default) when enabling `split-on-trailing-comma` to avoid that the formatter removes the trailing commas.",
+          "description": "If a comma is placed after the last member in a multi-line import, then the imports will never be folded into one line.\n\nSee isort's [`split-on-trailing-comma`](https://pycqa.github.io/isort/docs/configuration/options.html#split-on-trailing-comma) option.\n\nWhen using the formatter, ensure that [`format.skip-magic-trailing-comma`](#format_skip-magic-trailing-comma) is set to `false` (default) when enabling `split-on-trailing-comma` to avoid that the formatter removes the trailing commas.",
           "type": [
             "boolean",
             "null"
           ]
         },
         "variables": {
-          "description": "An override list of tokens to always recognize as a var for `order-by-type` regardless of casing.",
+          "description": "An override list of tokens to always recognize as a var for [`order-by-type`](#lint_isort_order-by-type) regardless of casing.",
           "type": [
             "array",
             "null"
@@ -1818,7 +1818,7 @@
           ]
         },
         "extend-fixable": {
-          "description": "A list of rule codes or prefixes to consider fixable, in addition to those specified by `fixable`.",
+          "description": "A list of rule codes or prefixes to consider fixable, in addition to those specified by [`fixable`](#lint_fixable).",
           "type": [
             "array",
             "null"
@@ -1839,7 +1839,7 @@
           }
         },
         "extend-per-file-ignores": {
-          "description": "A list of mappings from file pattern to rule codes or prefixes to exclude, in addition to any rules excluded by `per-file-ignores`.",
+          "description": "A list of mappings from file pattern to rule codes or prefixes to exclude, in addition to any rules excluded by [`per-file-ignores`](#lint_per-file-ignores).",
           "type": [
             "object",
             "null"
@@ -1862,7 +1862,7 @@
           }
         },
         "extend-select": {
-          "description": "A list of rule codes or prefixes to enable, in addition to those specified by `select`.",
+          "description": "A list of rule codes or prefixes to enable, in addition to those specified by [`select`](#lint_select).",
           "type": [
             "array",
             "null"
@@ -1872,7 +1872,7 @@
           }
         },
         "extend-unfixable": {
-          "description": "A list of rule codes or prefixes to consider non-auto-fixable, in addition to those specified by `unfixable`.",
+          "description": "A list of rule codes or prefixes to consider non-auto-fixable, in addition to those specified by [`unfixable`](#lint_unfixable).",
           "deprecated": true,
           "type": [
             "array",
@@ -2246,7 +2246,7 @@
           }
         },
         "task-tags": {
-          "description": "A list of task tags to recognize (e.g., \"TODO\", \"FIXME\", \"XXX\").\n\nComments starting with these tags will be ignored by commented-out code detection (`ERA`), and skipped by line-length rules (`E501`) if `ignore-overlong-task-comments` is set to `true`.",
+          "description": "A list of task tags to recognize (e.g., \"TODO\", \"FIXME\", \"XXX\").\n\nComments starting with these tags will be ignored by commented-out code detection (`ERA`), and skipped by line-length rules (`E501`) if [`ignore-overlong-task-comments`](#lint_pycodestyle_ignore-overlong-task-comments) is set to `true`.",
           "type": [
             "array",
             "null"
@@ -2357,7 +2357,7 @@
           }
         },
         "extend-ignore-names": {
-          "description": "Additional names (or patterns) to ignore when considering `pep8-naming` violations, in addition to those included in `ignore-names`\n\nSupports glob patterns. For example, to ignore all names starting with `test_` or ending with `_test`, you could use `ignore-names = [\"test_*\", \"*_test\"]`. For more information on the glob syntax, refer to the [`globset` documentation](https://docs.rs/globset/latest/globset/#syntax).",
+          "description": "Additional names (or patterns) to ignore when considering `pep8-naming` violations, in addition to those included in [`ignore-names`](#lint_pep8-naming_ignore-names).\n\nSupports glob patterns. For example, to ignore all names starting with `test_` or ending with `_test`, you could use `ignore-names = [\"test_*\", \"*_test\"]`. For more information on the glob syntax, refer to the [`globset` documentation](https://docs.rs/globset/latest/globset/#syntax).",
           "type": [
             "array",
             "null"
@@ -2393,7 +2393,7 @@
       "type": "object",
       "properties": {
         "keep-runtime-typing": {
-          "description": "Whether to avoid PEP 585 (`List[int]` -> `list[int]`) and PEP 604 (`Union[str, int]` -> `str | int`) rewrites even if a file imports `from __future__ import annotations`.\n\nThis setting is only applicable when the target Python version is below 3.9 and 3.10 respectively, and is most commonly used when working with libraries like Pydantic and FastAPI, which rely on the ability to parse type annotations at runtime. The use of `from __future__ import annotations` causes Python to treat the type annotations as strings, which typically allows for the use of language features that appear in later Python versions but are not yet supported by the current version (e.g., `str | int`). However, libraries that rely on runtime type annotations will break if the annotations are incompatible with the current Python version.\n\nFor example, while the following is valid Python 3.8 code due to the presence of `from __future__ import annotations`, the use of `str | int` prior to Python 3.10 will cause Pydantic to raise a `TypeError` at runtime:\n\n```python from __future__ import annotations\n\nimport pydantic\n\nclass Foo(pydantic.BaseModel): bar: str | int ```",
+          "description": "Whether to avoid [PEP 585](https://peps.python.org/pep-0585/) (`List[int]` -> `list[int]`) and [PEP 604](https://peps.python.org/pep-0604/) (`Union[str, int]` -> `str | int`) rewrites even if a file imports `from __future__ import annotations`.\n\nThis setting is only applicable when the target Python version is below 3.9 and 3.10 respectively, and is most commonly used when working with libraries like Pydantic and FastAPI, which rely on the ability to parse type annotations at runtime. The use of `from __future__ import annotations` causes Python to treat the type annotations as strings, which typically allows for the use of language features that appear in later Python versions but are not yet supported by the current version (e.g., `str | int`). However, libraries that rely on runtime type annotations will break if the annotations are incompatible with the current Python version.\n\nFor example, while the following is valid Python 3.8 code due to the presence of `from __future__ import annotations`, the use of `str | int` prior to Python 3.10 will cause Pydantic to raise a `TypeError` at runtime:\n\n```python from __future__ import annotations\n\nimport pydantic\n\nclass Foo(pydantic.BaseModel): bar: str | int ```",
           "type": [
             "boolean",
             "null"
@@ -2406,7 +2406,7 @@
       "type": "object",
       "properties": {
         "ignore-overlong-task-comments": {
-          "description": "Whether line-length violations (`E501`) should be triggered for comments starting with `task-tags` (by default: \\[\"TODO\", \"FIXME\", and \"XXX\"\\]).",
+          "description": "Whether line-length violations (`E501`) should be triggered for comments starting with [`task-tags`](#lint_task-tags) (by default: \\[\"TODO\", \"FIXME\", and \"XXX\"\\]).",
           "type": [
             "boolean",
             "null"


### PR DESCRIPTION
## Summary

Fixes a few typos and consistency issues in the "Settings" documentation:
- use "Ruff" consistently in the few places where "ruff" is used
- use double quotes in the few places where single quotes are used
- add backticks around rule codes where they are currently missing
- update a few example values where they are the same as the defaults, for consistency

2nd commit might be controversial, as there are many options mentioned where we don't currently link to the documentation sections, so maybe it's done on purpose, as this will also appear in the JSON schema where it's not desirable? If that's the case, I can easily drop it.

## Test Plan

Local testing.