### PR TITLE
docs(*): fix a few typos, consistency issues and links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -280,7 +280,7 @@ These represent, respectively: the schema used to parse the `pyproject.toml` fil
 intermediate representation; and the final, internal representation used to power Ruff.
 
 To add a new configuration option, you'll likely want to modify these latter few files (along with
-`arg.rs`, if appropriate). If you want to pattern-match against an existing example, grep for
+`args.rs`, if appropriate). If you want to pattern-match against an existing example, grep for
 `dummy_variable_rgx`, which defines a regular expression to match against acceptable unused
 variables (e.g., `_`).
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -254,7 +254,7 @@ For a complete enumeration of the available configuration options, see [_Setting
 
 ## Config file discovery
 
-Similar to [ESLint](https://eslint.org/docs/latest/user-guide/configuring/configuration-files#cascading-and-hierarchy),
+Similar to [ESLint](https://eslint.org/docs/latest/use/configure/configuration-files#cascading-configuration-objects),
 Ruff supports hierarchical configuration, such that the "closest" config file in the
 directory hierarchy is used for every individual file, with all paths in the config file
 (e.g., `exclude` globs, `src` paths) being resolved relative to the directory containing that
@@ -275,7 +275,7 @@ There are a few exceptions to these rules:
 1. Any config-file-supported settings that are provided on the command-line (e.g., via
     `--select`) will override the settings in _every_ resolved configuration file.
 
-Unlike [ESLint](https://eslint.org/docs/latest/user-guide/configuring/configuration-files#cascading-and-hierarchy),
+Unlike [ESLint](https://eslint.org/docs/latest/use/configure/configuration-files#cascading-configuration-objects),
 Ruff does not merge settings across configuration files; instead, the "closest" configuration file
 is used, and any parent configuration files are ignored. In lieu of this implicit cascade, Ruff
 supports an [`extend`](settings.md#extend) field, which allows you to inherit the settings from another

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -64,7 +64,7 @@ natively, including:
 - [flake8-executable](https://pypi.org/project/flake8-executable/)
 - [flake8-gettext](https://pypi.org/project/flake8-gettext/)
 - [flake8-implicit-str-concat](https://pypi.org/project/flake8-implicit-str-concat/)
-- [flake8-import-conventions](https://github.com/joaopalmeiro/flake8-import-conventions)
+- [flake8-import-conventions](https://pypi.org/project/flake8-import-conventions/)
 - [flake8-logging](https://pypi.org/project/flake8-logging-format/)
 - [flake8-logging-format](https://pypi.org/project/flake8-logging-format/)
 - [flake8-no-pep420](https://pypi.org/project/flake8-no-pep420)
@@ -93,7 +93,7 @@ natively, including:
 - [pygrep-hooks](https://github.com/pre-commit/pygrep-hooks)
 - [pyupgrade](https://pypi.org/project/pyupgrade/)
 - [tryceratops](https://pypi.org/project/tryceratops/)
-- [yesqa](https://github.com/asottile/yesqa)
+- [yesqa](https://pypi.org/project/yesqa/)
 
 Note that, in some cases, Ruff uses different rule codes and prefixes than would be found in the
 originating Flake8 plugins. For example, Ruff uses `TID252` to represent the `I252` rule from
@@ -177,7 +177,7 @@ Today, Ruff can be used to replace Flake8 when used with any of the following pl
 - [flake8-executable](https://pypi.org/project/flake8-executable/)
 - [flake8-gettext](https://pypi.org/project/flake8-gettext/)
 - [flake8-implicit-str-concat](https://pypi.org/project/flake8-implicit-str-concat/)
-- [flake8-import-conventions](https://github.com/joaopalmeiro/flake8-import-conventions)
+- [flake8-import-conventions](https://pypi.org/project/flake8-import-conventions/)
 - [flake8-logging](https://pypi.org/project/flake8-logging/)
 - [flake8-logging-format](https://pypi.org/project/flake8-logging-format/)
 - [flake8-no-pep420](https://pypi.org/project/flake8-no-pep420)
@@ -204,7 +204,7 @@ Today, Ruff can be used to replace Flake8 when used with any of the following pl
 - [tryceratops](https://pypi.org/project/tryceratops/)
 
 Ruff can also replace [Black](https://pypi.org/project/black/), [isort](https://pypi.org/project/isort/),
-[yesqa](https://github.com/asottile/yesqa), [eradicate](https://pypi.org/project/eradicate/), and
+[yesqa](https://pypi.org/project/yesqa/), [eradicate](https://pypi.org/project/eradicate/), and
 most of the rules implemented in [pyupgrade](https://pypi.org/project/pyupgrade/).
 
 If you're looking to use Ruff, but rely on an unsupported Flake8 plugin, feel free to file an
@@ -271,7 +271,7 @@ Like isort, Ruff's import sorting is compatible with Black.
 
 ## How does Ruff determine which of my imports are first-party, third-party, etc.?
 
-Ruff accepts a `src` option that in your `pyproject.toml`, `ruff.toml`, or `.ruff.toml` file, which
+Ruff accepts a `src` option that in your `pyproject.toml`, `ruff.toml`, or `.ruff.toml` file,
 specifies the directories that Ruff should consider when determining whether an import is
 first-party.
 
@@ -602,7 +602,7 @@ convention = "google"
 ```toml
 line-length = 88
 
-[pydocstyle]
+[lint.pydocstyle]
 convention = "google"
 ```
 
@@ -619,9 +619,9 @@ and respects the `XDG_CONFIG_HOME` specification.
 On Windows, Ruff expects that file to be located at `~\AppData\Roaming\ruff\ruff.toml`.
 
 !!! note
-  Prior to `v0.5.0`, Ruff would read user-specific configuration from
-  `~/Library/Application Support/ruff/ruff.toml` on macOS. While Ruff will still respect
-  such configuration files, the use of `~/Library/ Application Support` is considered deprecated.
+    Prior to `v0.5.0`, Ruff would read user-specific configuration from
+    `~/Library/Application Support/ruff/ruff.toml` on macOS. While Ruff will still respect
+    such configuration files, the use of `~/Library/Application Support` is considered deprecated.
 
 For more, see the [`etcetera`](https://crates.io/crates/etcetera) crate.
 
@@ -630,7 +630,7 @@ For more, see the [`etcetera`](https://crates.io/crates/etcetera) crate.
 Ruff labels fixes as "safe" and "unsafe". By default, Ruff will fix all violations for which safe
 fixes are available, while unsafe fixes can be enabled via the [`unsafe-fixes`](settings.md#unsafe-fixes)
 setting, or passing the [`--unsafe-fixes`](settings.md#unsafe-fixes) flag to `ruff check`. For
-more, see [the fix documentation](configuration.md#fixes).
+more, see [the fix documentation](linter.md#fixes).
 
 Even still, given the dynamic nature of Python, it's difficult to have _complete_ certainty when
 making changes to code, even for seemingly trivial fixes. If a "safe" fix breaks your code, please

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -95,7 +95,7 @@ Upon successful installation, you should see Ruff's diagnostics surfaced directl
 
 ![Code Actions available in Neovim](https://user-images.githubusercontent.com/1309177/208278707-25fa37e4-079d-4597-ad35-b95dba066960.png)
 
-To use `ruff-lsp` with other editors, including Sublime Text and Helix, see the [`ruff-lsp` documentation](https://github.com/astral-sh/ruff-lsp#installation-and-usage).
+To use `ruff-lsp` with other editors, including Sublime Text and Helix, see the [`ruff-lsp` documentation](https://github.com/astral-sh/ruff-lsp#setup).
 
 ## Language Server Protocol (Unofficial)
 
@@ -350,7 +350,7 @@ jobs:
 Ruff can also be used as a GitHub Action via [`ruff-action`](https://github.com/chartboost/ruff-action).
 
 By default, `ruff-action` runs as a pass-fail test to ensure that a given repository doesn't contain
-any lint rule violations as per its [configuration](https://github.com/astral-sh/ruff/blob/main/docs/configuration.md).
+any lint rule violations as per its [configuration](configuration.md).
 However, under-the-hood, `ruff-action` installs and runs `ruff` directly, so it can be used to
 execute any supported `ruff` command (e.g., `ruff check --fix`).
 


### PR DESCRIPTION
## Summary

Fixes a few typos, consistency issues and dead links found across the documentation.