### PR TITLE
Revert "Remove `--preview` as a required argument for `ruff server` (#12053)"

### DIFF
--- a/crates/ruff/src/commands/server.rs
+++ b/crates/ruff/src/commands/server.rs
@@ -4,7 +4,12 @@ use crate::ExitStatus;
 use anyhow::Result;
 use ruff_server::Server;
 
-pub(crate) fn run_server(_preview: bool, worker_threads: NonZeroUsize) -> Result<ExitStatus> {
+pub(crate) fn run_server(preview: bool, worker_threads: NonZeroUsize) -> Result<ExitStatus> {
+    if !preview {
+        tracing::error!("--preview needs to be provided as a command line argument while the server is still unstable.\nFor example: `ruff server --preview`");
+        return Ok(ExitStatus::Error);
+    }
+
     let server = Server::new(worker_threads)?;
 
     server.run().map(|()| ExitStatus::Success)


### PR DESCRIPTION
This reverts commit b28dc9ac14dd83175e65ed40c54ca65665c2dea5.

We're not ready to stabilize the server yet. There's some pending work for the VS Code extension and documentation improvements.

This change is to unblock Ruff release.
