### PR TITLE
Consider the content of the new cells during notebook sync

### DIFF
--- a/crates/ruff_server/src/session/index.rs
+++ b/crates/ruff_server/src/session/index.rs
@@ -145,14 +145,16 @@ impl Index {
         encoding: PositionEncoding,
     ) -> crate::Result<()> {
         // update notebook cell index
-        if let Some(lsp_types::NotebookDocumentCellChangeStructure { did_open, .. }) =
-            cells.as_ref().and_then(|cells| cells.structure.as_ref())
+        if let Some(lsp_types::NotebookDocumentCellChangeStructure {
+            did_open: Some(did_open),
+            ..
+        }) = cells.as_ref().and_then(|cells| cells.structure.as_ref())
         {
             let Some(path) = self.url_for_key(key).cloned() else {
                 anyhow::bail!("Tried to open unavailable document `{key}`");
             };
 
-            for opened_cell in did_open.iter().flatten() {
+            for opened_cell in did_open {
                 self.notebook_cells
                     .insert(opened_cell.uri.clone(), path.clone());
             }


### PR DESCRIPTION
## Summary

This PR fixes the bug where the server was not considering the `cells.structure.didOpen` field to sync up the new content of the newly added cells.

The parameters corresponding to this request provides two fields to get the newly added cells:
1. `cells.structure.array.cells`: This is a list of `NotebookCell` which doesn't contain any cell content. The only useful information from this array is the cell kind and the cell document URI which we use to initialize the new cell in the index.
2. `cells.structure.didOpen`: This is a list of `TextDocumentItem` which corresponds to the newly added cells. This actually contains the text content and the version.

This wasn't a problem before because we initialize the cell with an empty string and this isn't a problem when someone just creates an empty cell. But, when someone copy-pastes a cell, the cell needs to be initialized with the content.

fixes: #12201 

## Test Plan

First, let's see the panic in action:

1. Press <kbd>Esc</kbd> to allow using the keyboard to perform cell actions (move around, copy, paste, etc.)
2. Copy the second cell with <kbd>c</kbd> key
3. Delete the second cell with <kbd>dd</kbd> key
4. Paste the copied cell with <kbd>p</kbd> key

You can see that the content isn't synced up because the `unused-import` for `sys` is still being highlighted but it's being used in the second cell. And, the hover isn't working either. Then, as I start editing the second cell, it panics.

https://github.com/astral-sh/ruff/assets/67177269/fc58364c-c8fc-4c11-a917-71b6dd90c1ef

Now, here's the preview of the fixed version:

https://github.com/astral-sh/ruff/assets/67177269/207872dd-dca6-49ee-8b6e-80435c7ef22e