### PR TITLE
[red-knot] Require that `FileSystem` objects implement `Debug`

### DIFF
--- a/crates/ruff_db/src/file_system.rs
+++ b/crates/ruff_db/src/file_system.rs
@@ -21,7 +21,7 @@ pub type Result<T> = std::io::Result<T>;
 /// * Accessing unsaved or even untitled files in the LSP use case
 /// * Testing with an in-memory file system
 /// * Running Ruff in a WASM environment without needing to stub out the full `std::fs` API.
-pub trait FileSystem {
+pub trait FileSystem: std::fmt::Debug {
     /// Reads the metadata of the file or directory at `path`.
     fn metadata(&self, path: &FileSystemPath) -> Result<Metadata>;
 

--- a/crates/ruff_db/src/file_system/os.rs
+++ b/crates/ruff_db/src/file_system/os.rs
@@ -2,7 +2,7 @@ use filetime::FileTime;
 
 use crate::file_system::{FileSystem, FileSystemPath, FileType, Metadata, Result};
 
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct OsFileSystem;
 
 impl OsFileSystem {


### PR DESCRIPTION
## Summary

This makes it easier to debug why things are going wrong if you have an object of type `&dyn FileSystem` and you want to add some debug prints to check if the objects you think are in the test filesystem are actually in the test filesystem.

## Test Plan

`cargo build`
