### PR TITLE
Consider `--preview` flag for `server` subcommand

### DIFF
--- a/crates/ruff/src/args.rs
+++ b/crates/ruff/src/args.rs
@@ -494,9 +494,20 @@ pub struct FormatCommand {
 
 #[derive(Copy, Clone, Debug, clap::Parser)]
 pub struct ServerCommand {
-    /// Enable preview mode; required for regular operation
-    #[arg(long)]
-    pub(crate) preview: bool,
+    /// Enable preview mode. Use `--no-preview` to disable.
+    ///
+    /// This enables unstable server features and turns on the preview mode for the linter
+    /// and the formatter.
+    #[arg(long, overrides_with("no_preview"))]
+    preview: bool,
+    #[clap(long, overrides_with("preview"), hide = true)]
+    no_preview: bool,
+}
+
+impl ServerCommand {
+    pub(crate) fn resolve_preview(self) -> Option<bool> {
+        resolve_bool_arg(self.preview, self.no_preview)
+    }
 }
 
 #[derive(Debug, Clone, Copy, clap::ValueEnum)]

--- a/crates/ruff/src/commands/server.rs
+++ b/crates/ruff/src/commands/server.rs
@@ -4,13 +4,11 @@ use crate::ExitStatus;
 use anyhow::Result;
 use ruff_server::Server;
 
-pub(crate) fn run_server(preview: bool, worker_threads: NonZeroUsize) -> Result<ExitStatus> {
-    if !preview {
-        tracing::error!("--preview needs to be provided as a command line argument while the server is still unstable.\nFor example: `ruff server --preview`");
-        return Ok(ExitStatus::Error);
-    }
-
-    let server = Server::new(worker_threads)?;
+pub(crate) fn run_server(
+    worker_threads: NonZeroUsize,
+    preview: Option<bool>,
+) -> Result<ExitStatus> {
+    let server = Server::new(worker_threads, preview)?;
 
     server.run().map(|()| ExitStatus::Success)
 }

--- a/crates/ruff/src/lib.rs
+++ b/crates/ruff/src/lib.rs
@@ -200,15 +200,13 @@ fn format(args: FormatCommand, global_options: GlobalConfigArgs) -> Result<ExitS
 }
 
 fn server(args: ServerCommand) -> Result<ExitStatus> {
-    let ServerCommand { preview } = args;
-
     let four = NonZeroUsize::new(4).unwrap();
 
     // by default, we set the number of worker threads to `num_cpus`, with a maximum of 4.
     let worker_threads = std::thread::available_parallelism()
         .unwrap_or(four)
         .max(four);
-    commands::server::run_server(preview, worker_threads)
+    commands::server::run_server(worker_threads, args.resolve_preview())
 }
 
 pub fn check(args: CheckCommand, global_options: GlobalConfigArgs) -> Result<ExitStatus> {

--- a/crates/ruff_server/resources/test/fixtures/settings/empty_multiple_workspace.json
+++ b/crates/ruff_server/resources/test/fixtures/settings/empty_multiple_workspace.json
@@ -1,0 +1,16 @@
+{
+    "settings": [
+        {
+            "cwd": "/Users/test/projects/first",
+            "workspace": "file:///Users/test/projects/first"
+        },
+        {
+            "cwd": "/Users/test/projects/second",
+            "workspace": "file:///Users/test/projects/second"
+        }
+    ],
+    "globalSettings": {
+        "cwd": "/",
+        "workspace": "/"
+    }
+}

--- a/crates/ruff_server/resources/test/fixtures/settings/vs_code_initialization_options.json
+++ b/crates/ruff_server/resources/test/fixtures/settings/vs_code_initialization_options.json
@@ -1,7 +1,7 @@
 {
     "settings": [
         {
-            "experimentalServer": true,
+            "nativeServer": "on",
             "cwd": "/Users/test/projects/pandas",
             "workspace": "file:///Users/test/projects/pandas",
             "path": [],
@@ -21,9 +21,7 @@
             "lint": {
                 "enable": true,
                 "run": "onType",
-                "args": [
-                    "--preview"
-                ]
+                "args": []
             },
             "format": {
                 "args": []
@@ -31,10 +29,11 @@
             "enable": true,
             "organizeImports": true,
             "fixAll": true,
-            "showNotifications": "off"
+            "showNotifications": "off",
+            "showSyntaxErrors": true
         },
         {
-            "experimentalServer": true,
+            "nativeServer": "on",
             "cwd": "/Users/test/projects/scipy",
             "workspace": "file:///Users/test/projects/scipy",
             "path": [],
@@ -55,9 +54,7 @@
                 "enable": true,
                 "preview": false,
                 "run": "onType",
-                "args": [
-                    "--preview"
-                ]
+                "args": []
             },
             "format": {
                 "args": []
@@ -65,11 +62,12 @@
             "enable": true,
             "organizeImports": true,
             "fixAll": true,
-            "showNotifications": "off"
+            "showNotifications": "off",
+            "showSyntaxErrors": true
         }
     ],
     "globalSettings": {
-        "experimentalServer": true,
+        "nativeServer": "on",
         "cwd": "/",
         "workspace": "/",
         "path": [],
@@ -89,9 +87,7 @@
             "preview": true,
             "select": ["F", "I"],
             "run": "onType",
-            "args": [
-                "--preview"
-            ]
+            "args": []
         },
         "format": {
             "args": []
@@ -99,6 +95,7 @@
         "enable": true,
         "organizeImports": true,
         "fixAll": false,
-        "showNotifications": "off"
+        "showNotifications": "off",
+        "showSyntaxErrors": true
     }
 }


### PR DESCRIPTION
## Summary

This PR removes the requirement of `--preview` flag to run the `ruff server` and instead considers it to be an indicator to turn on preview mode for the linter and the formatter.

resolves: #12161 

## Test Plan

Add test cases to assert the `preview` value is updated accordingly.

In an editor context, I used the local `ruff` executable in Neovim with the `--preview` flag and verified that the preview-only violations are being highlighted.

Running with:
```lua
require('lspconfig').ruff.setup({
  cmd = {
    '/Users/dhruv/work/astral/ruff/target/debug/ruff',
    'server',
    '--preview',
  },
})
```
The screenshot shows that `E502` is highlighted with the below config in `pyproject.toml`:

<img width="877" alt="Screenshot 2024-07-17 at 16 43 09" src="https://github.com/user-attachments/assets/c7016ef3-55b1-4a14-bbd3-a07b1bcdd323">
