### PR TITLE
[red-knot] Only store absolute paths in `Files`

### DIFF
--- a/crates/red_knot/src/main.rs
+++ b/crates/red_knot/src/main.rs
@@ -35,7 +35,9 @@ pub fn main() -> anyhow::Result<()> {
         return Err(anyhow::anyhow!("Invalid arguments"));
     }
 
-    let system = OsSystem;
+    let cwd = std::env::current_dir().unwrap();
+    let cwd = SystemPath::from_std_path(&cwd).unwrap();
+    let system = OsSystem::new(cwd);
     let entry_point = SystemPath::new(&arguments[1]);
 
     if !system.path_exists(entry_point) {

--- a/crates/red_knot_module_resolver/src/db.rs
+++ b/crates/red_knot_module_resolver/src/db.rs
@@ -189,9 +189,9 @@ pub(crate) mod tests {
 
         let db = TestDb::new();
 
-        let src = SystemPathBuf::from("src");
-        let site_packages = SystemPathBuf::from("site_packages");
-        let custom_typeshed = SystemPathBuf::from("typeshed");
+        let src = SystemPathBuf::from("/src");
+        let site_packages = SystemPathBuf::from("/site_packages");
+        let custom_typeshed = SystemPathBuf::from("/typeshed");
 
         let fs = db.memory_file_system();
 

--- a/crates/ruff_db/src/system.rs
+++ b/crates/ruff_db/src/system.rs
@@ -51,6 +51,9 @@ pub trait System {
             .map_or(false, |metadata| metadata.file_type.is_file())
     }
 
+    /// Returns the current working directory
+    fn current_directory(&self) -> &SystemPath;
+
     fn as_any(&self) -> &dyn std::any::Any;
 }
 

--- a/crates/ruff_db/src/system/test.rs
+++ b/crates/ruff_db/src/system/test.rs
@@ -34,8 +34,8 @@ impl TestSystem {
         }
     }
 
-    fn use_os_system(&mut self) {
-        self.inner = TestFileSystem::Os(OsSystem);
+    fn use_os_system(&mut self, os: OsSystem) {
+        self.inner = TestFileSystem::Os(os);
     }
 }
 
@@ -72,6 +72,13 @@ impl System for TestSystem {
         match &self.inner {
             TestFileSystem::Stub(fs) => fs.is_file(path),
             TestFileSystem::Os(fs) => fs.is_file(path),
+        }
+    }
+
+    fn current_directory(&self) -> &SystemPath {
+        match &self.inner {
+            TestFileSystem::Stub(fs) => fs.current_directory(),
+            TestFileSystem::Os(fs) => fs.current_directory(),
         }
     }
 
@@ -132,8 +139,8 @@ pub trait DbWithTestSystem: Db + Sized {
     /// This useful for testing advanced file system features like permissions, symlinks, etc.
     ///
     /// Note that any files written to the memory file system won't be copied over.
-    fn use_os_system(&mut self) {
-        self.test_system_mut().use_os_system();
+    fn use_os_system(&mut self, os: OsSystem) {
+        self.test_system_mut().use_os_system(os);
     }
 
     /// Returns the memory file system.


### PR DESCRIPTION
## Summary

This PR normalizes system paths in `Files` before looking them up (and storing) them. 

This prevents that we have multiple file ingredients that all point to the same underlying path.

Fixes https://github.com/astral-sh/ruff/issues/11907
Fixes https://github.com/astral-sh/ruff/issues/12209

## Test Plan

I verified that changes to files correctly propagate when running the Red Knot CLI with relative paths
