### PR TITLE
[red-knot] Exclude drop time in benchmark

### DIFF
--- a/crates/ruff_benchmark/benches/red_knot.rs
+++ b/crates/ruff_benchmark/benches/red_knot.rs
@@ -100,7 +100,7 @@ fn benchmark_without_parse(criterion: &mut Criterion) {
     group.throughput(Throughput::Bytes(FOO_CODE.len() as u64));
 
     group.bench_function("red_knot_check_file[without_parse]", |b| {
-        b.iter_batched(
+        b.iter_batched_ref(
             || {
                 let case = setup_case();
                 // Pre-parse the module to only measure the semantic time.
@@ -111,7 +111,7 @@ fn benchmark_without_parse(criterion: &mut Criterion) {
             },
             |case| {
                 let Case { program, foo, .. } = case;
-                let result = program.check_file(foo).unwrap();
+                let result = program.check_file(*foo).unwrap();
 
                 assert_eq!(result.as_slice(), [] as [String; 0]);
             },
@@ -127,7 +127,7 @@ fn benchmark_incremental(criterion: &mut Criterion) {
     group.throughput(Throughput::Bytes(FOO_CODE.len() as u64));
 
     group.bench_function("red_knot_check_file[incremental]", |b| {
-        b.iter_batched(
+        b.iter_batched_ref(
             || {
                 let mut case = setup_case();
                 case.program.check_file(case.foo).unwrap();
@@ -144,7 +144,7 @@ fn benchmark_incremental(criterion: &mut Criterion) {
             },
             |case| {
                 let Case { program, foo, .. } = case;
-                let result = program.check_file(foo).unwrap();
+                let result = program.check_file(*foo).unwrap();
 
                 assert_eq!(result.as_slice(), [] as [String; 0]);
             },
@@ -160,11 +160,11 @@ fn benchmark_cold(criterion: &mut Criterion) {
     group.throughput(Throughput::Bytes(FOO_CODE.len() as u64));
 
     group.bench_function("red_knot_check_file[cold]", |b| {
-        b.iter_batched(
+        b.iter_batched_ref(
             setup_case,
             |case| {
                 let Case { program, foo, .. } = case;
-                let result = program.check_file(foo).unwrap();
+                let result = program.check_file(*foo).unwrap();
 
                 assert_eq!(result.as_slice(), [] as [String; 0]);
             },


### PR DESCRIPTION
## Summary

This PR changes the red knot benchmarks to exclude the `Program`'s `drop` time. 

The primary goal of the benchmarks is to measure the time it takes to check a single file. They do not measure a database's setup and teardown cost, which is also why the `Program` is passed into the benchmark function and not constructed inside of it. 

This doesn't mean that slow drop times aren't a concern—they are. But there are ways to mitigate them. For example, it's fine for the CLI to use `std::mem::forget` to leak memory before exiting because the OS will collect all memory anyway.


## Test Plan

See CI
