### PR TITLE
[Ecosystem checks] `trio` has changed its default branch name to `main`

### DIFF
--- a/python/ruff-ecosystem/ruff_ecosystem/defaults.py
+++ b/python/ruff-ecosystem/ruff_ecosystem/defaults.py
@@ -127,7 +127,7 @@ DEFAULT_TARGETS = [
         },
     ),
     Project(repo=Repository(owner="agronholm", name="anyio", ref="master")),
-    Project(repo=Repository(owner="python-trio", name="trio", ref="master")),
+    Project(repo=Repository(owner="python-trio", name="trio", ref="main")),
     Project(repo=Repository(owner="wntrblm", name="nox", ref="main")),
     Project(repo=Repository(owner="pytest-dev", name="pytest", ref="main")),
     Project(repo=Repository(owner="encode", name="httpx", ref="master")),


### PR DESCRIPTION
Fixes CI errors seen in https://github.com/astral-sh/ruff/pull/12224#issuecomment-2212594024

x-ref https://github.com/python-trio/trio/commit/17b3644f64b4bb10176e789dc23a8b57b1399f89
