### PR TITLE
Warn about D203 formatter incompatibility

### DIFF
--- a/crates/ruff/src/commands/format.rs
+++ b/crates/ruff/src/commands/format.rs
@@ -794,6 +794,8 @@ pub(super) fn warn_incompatible_formatter_settings(resolver: &Resolver) {
             //     pass
             // ```
             Rule::MissingTrailingComma,
+            // The formatter always removes blank lines before the docstring.
+            Rule::OneBlankLineBeforeClass,
         ] {
             if setting.linter.rules.enabled(rule) {
                 incompatible_rules.insert(rule);


### PR DESCRIPTION
## Summary

Fixes https://github.com/astral-sh/ruff/issues/12220

## Test Plan

**Select all**

```
❯ cargo run --bin ruff -- format ../test/test2.py  --no-cache
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.12s
     Running `target/debug/ruff format ../test/test2.py --no-cache`
warning: `one-blank-line-before-class` (D203) and `no-blank-line-before-class` (D211) are incompatible. Ignoring `one-blank-line-before-class`.
warning: `multi-line-summary-first-line` (D212) and `multi-line-summary-second-line` (D213) are incompatible. Ignoring `multi-line-summary-second-line`.
1 file left unchanged
```

**With `D211` ignored (and D203 enabled)**

```
ruff on  main [$!] is 📦 v0.5.1 via 🐍 v3.12.4 via 🦀 v1.79.0 
❯ cargo run --bin ruff -- format ../test/test2.py  --no-cache
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.12s
     Running `target/debug/ruff format ../test/test2.py --no-cache`
warning: `multi-line-summary-first-line` (D212) and `multi-line-summary-second-line` (D213) are incompatible. Ignoring `multi-line-summary-second-line`.
warning: The following rules may cause conflicts when used with the formatter: `D203`. To avoid unexpected behavior, we recommend disabling these rules, either by removing them from the `select` or `extend-select` configuration, or adding them to the `ignore` configuration.
1 file left unchanged

```
