### PR TITLE
Remove default-run from 'red_knot' crate

### DIFF
--- a/crates/red_knot/Cargo.toml
+++ b/crates/red_knot/Cargo.toml
@@ -8,7 +8,6 @@ documentation.workspace = true
 repository.workspace = true
 authors.workspace = true
 license.workspace = true
-default-run = "red_knot"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
## Summary

This prevents `cargo run` to default to `ruff`.

## Test Plan

`cargo run` runs ruff 