### PR TITLE
Update help and documentation for `--output-format` to reflect `"full"` default

### DIFF
--- a/crates/ruff/src/args.rs
+++ b/crates/ruff/src/args.rs
@@ -182,8 +182,7 @@ pub struct CheckCommand {
     ignore_noqa: bool,
 
     /// Output serialization format for violations.
-    /// The default serialization format is "concise".
-    /// In preview mode, the default serialization format is "full".
+    /// The default serialization format is "full".
     #[arg(long, value_enum, env = "RUFF_OUTPUT_FORMAT")]
     pub output_format: Option<OutputFormat>,
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -594,10 +594,9 @@ Options:
           Ignore any `# noqa` comments
       --output-format <OUTPUT_FORMAT>
           Output serialization format for violations. The default serialization
-          format is "concise". In preview mode, the default serialization
-          format is "full" [env: RUFF_OUTPUT_FORMAT=] [possible values: text,
-          concise, full, json, json-lines, junit, grouped, github, gitlab,
-          pylint, rdjson, azure, sarif]
+          format is "full" [env: RUFF_OUTPUT_FORMAT=] [possible values: concise,
+          full, json, json-lines, junit, grouped, github, gitlab, pylint, rdjson,
+          azure, sarif]
   -o, --output-file <OUTPUT_FILE>
           Specify file to write the linter output to (default: stdout) [env:
           RUFF_OUTPUT_FILE=]

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -594,9 +594,9 @@ Options:
           Ignore any `# noqa` comments
       --output-format <OUTPUT_FORMAT>
           Output serialization format for violations. The default serialization
-          format is "full" [env: RUFF_OUTPUT_FORMAT=] [possible values: concise,
-          full, json, json-lines, junit, grouped, github, gitlab, pylint, rdjson,
-          azure, sarif]
+          format is "full" [env: RUFF_OUTPUT_FORMAT=] [possible values: text,
+          concise, full, json, json-lines, junit, grouped, github, gitlab,
+          pylint, rdjson, azure, sarif]
   -o, --output-file <OUTPUT_FILE>
           Specify file to write the linter output to (default: stdout) [env:
           RUFF_OUTPUT_FILE=]


### PR DESCRIPTION
fix #12247 

changed help to list "full" as the default for --output-format and removed "text" as an option (as this is no longer supported).

EDIT: I am trying to see why some of the checks below are failing, but don't know how to interpret the errors.