### PR TITLE
[red-knot] Rename some methods on `VendoredFileSystem` for consistency

### DIFF
--- a/crates/red_knot_module_resolver/src/path.rs
+++ b/crates/red_knot_module_resolver/src/path.rs
@@ -329,7 +329,7 @@ impl<'a> ModuleResolutionPathRefInner<'a> {
                     TypeshedVersionsQueryResult::DoesNotExist => false,
                     TypeshedVersionsQueryResult::Exists | TypeshedVersionsQueryResult::MaybeExists => match path {
                         FilePathRef::System(path) => resolver.db.system().path_exists(&path.join("__init__.pyi")),
-                        FilePathRef::Vendored(path) => resolver.db.vendored().exists(path.join("__init__.pyi")),
+                        FilePathRef::Vendored(path) => resolver.db.vendored().path_exists(path.join("__init__.pyi")),
                     },
                 }
             }

--- a/crates/red_knot_module_resolver/src/typeshed/vendored.rs
+++ b/crates/red_knot_module_resolver/src/typeshed/vendored.rs
@@ -61,7 +61,7 @@ mod tests {
                 .unwrap_or_else(|_| panic!("Expected {relative_path:?} to be valid UTF-8"));
 
             assert!(
-                vendored_typeshed_stubs.exists(vendored_path),
+                vendored_typeshed_stubs.path_exists(vendored_path),
                 "Expected {vendored_path:?} to exist in the `VendoredFileSystem`!
 
                 Vendored file system:
@@ -71,7 +71,7 @@ mod tests {
             );
 
             let vendored_path_kind = vendored_typeshed_stubs
-                .metadata(vendored_path)
+                .path_metadata(vendored_path)
                 .unwrap_or_else(|_| {
                     panic!(
                         "Expected metadata for {vendored_path:?} to be retrievable from the `VendoredFileSystem!

--- a/crates/ruff_db/src/files.rs
+++ b/crates/ruff_db/src/files.rs
@@ -111,7 +111,7 @@ impl Files {
         {
             Entry::Occupied(entry) => *entry.get(),
             Entry::Vacant(entry) => {
-                let metadata = db.vendored().metadata(path).ok()?;
+                let metadata = db.vendored().path_metadata(path).ok()?;
 
                 let file = File::new(
                     db,

--- a/crates/ruff_db/src/vendored.rs
+++ b/crates/ruff_db/src/vendored.rs
@@ -45,7 +45,7 @@ impl VendoredFileSystem {
         }
     }
 
-    pub fn exists(&self, path: impl AsRef<VendoredPath>) -> bool {
+    pub fn path_exists(&self, path: impl AsRef<VendoredPath>) -> bool {
         fn exists(fs: &VendoredFileSystem, path: &VendoredPath) -> bool {
             let normalized = NormalizedVendoredPath::from(path);
             let mut archive = fs.lock_archive();
@@ -63,7 +63,7 @@ impl VendoredFileSystem {
         exists(self, path.as_ref())
     }
 
-    pub fn metadata(&self, path: impl AsRef<VendoredPath>) -> Result<Metadata> {
+    pub fn path_metadata(&self, path: impl AsRef<VendoredPath>) -> Result<Metadata> {
         fn metadata(fs: &VendoredFileSystem, path: &VendoredPath) -> Result<Metadata> {
             let normalized = NormalizedVendoredPath::from(path);
             let mut archive = fs.lock_archive();
@@ -83,12 +83,12 @@ impl VendoredFileSystem {
     }
 
     pub fn is_directory(&self, path: impl AsRef<VendoredPath>) -> bool {
-        self.metadata(path)
+        self.path_metadata(path)
             .is_ok_and(|metadata| metadata.kind().is_directory())
     }
 
     pub fn is_file(&self, path: impl AsRef<VendoredPath>) -> bool {
-        self.metadata(path)
+        self.path_metadata(path)
             .is_ok_and(|metadata| metadata.kind().is_file())
     }
 
@@ -471,9 +471,9 @@ pub(crate) mod tests {
 
         let path = VendoredPath::new(dirname);
 
-        assert!(mock_typeshed.exists(path));
+        assert!(mock_typeshed.path_exists(path));
         assert!(mock_typeshed.read_to_string(path).is_err());
-        let metadata = mock_typeshed.metadata(path).unwrap();
+        let metadata = mock_typeshed.path_metadata(path).unwrap();
         assert!(metadata.kind().is_directory());
     }
 
@@ -510,8 +510,8 @@ pub(crate) mod tests {
     fn test_nonexistent_path(path: &str) {
         let mock_typeshed = mock_typeshed();
         let path = VendoredPath::new(path);
-        assert!(!mock_typeshed.exists(path));
-        assert!(mock_typeshed.metadata(path).is_err());
+        assert!(!mock_typeshed.path_exists(path));
+        assert!(mock_typeshed.path_metadata(path).is_err());
         assert!(mock_typeshed
             .read_to_string(path)
             .is_err_and(|err| err.to_string().contains("file not found")));
@@ -538,8 +538,8 @@ pub(crate) mod tests {
     }
 
     fn test_file(mock_typeshed: &VendoredFileSystem, path: &VendoredPath) {
-        assert!(mock_typeshed.exists(path));
-        let metadata = mock_typeshed.metadata(path).unwrap();
+        assert!(mock_typeshed.path_exists(path));
+        let metadata = mock_typeshed.path_metadata(path).unwrap();
         assert!(metadata.kind().is_file());
     }
 


### PR DESCRIPTION
## Summary

Following https://github.com/astral-sh/ruff/commit/ac04380f360b1fca84435fbbf3154f61e551a871, we have a situation where the `ruff_db::system::System` trait has methods such as `path_exists()` and `path_metadata`, but the `VendoredFileSystem` struct simply calls its equivalent methods `exists()` and `metadata`. This leads to some funny-looking code here, where the two branches are doing equivalent operations with different types, but the methods being called have two different names:

https://github.com/astral-sh/ruff/blob/6fa4e32ad318afbec4c6997c69731bb4c256ef82/crates/red_knot_module_resolver/src/path.rs#L330-L333

This PR renames the methods on `VendoredFileSystem` to be consistent with the new names for the methods on the `System` trait.
