### PR TITLE
[red-knot] Add more stress tests for module resolver invalidation

### DIFF
--- a/crates/red_knot_module_resolver/src/resolver.rs
+++ b/crates/red_knot_module_resolver/src/resolver.rs
@@ -1066,13 +1066,13 @@ mod tests {
         // it should resolve to site-packages:
         for path in [stdlib_functools_path, src_functools_path] {
             db.memory_file_system().remove_file(&path).unwrap();
-            File::touch_path(&mut db, &FilePath::System(path));
+            File::touch_path(&mut db, &path);
         }
         let stdlib_versions_path = stdlib.join("VERSIONS");
         db.memory_file_system()
             .write_file(&stdlib_versions_path, "")
             .unwrap();
-        File::touch_path(&mut db, &FilePath::System(stdlib_versions_path));
+        File::touch_path(&mut db, &stdlib_versions_path);
         let functools_module = resolve_module(&db, functools_module_name.clone()).unwrap();
         assert_eq!(functools_module.search_path(), site_packages);
         assert_eq!(

--- a/crates/red_knot_module_resolver/src/resolver.rs
+++ b/crates/red_knot_module_resolver/src/resolver.rs
@@ -1069,9 +1069,7 @@ mod tests {
             File::touch_path(&mut db, &path);
         }
         let stdlib_versions_path = stdlib.join("VERSIONS");
-        db.memory_file_system()
-            .write_file(&stdlib_versions_path, "")
-            .unwrap();
+        db.write_file(&stdlib_versions_path, "").unwrap();
         File::touch_path(&mut db, &stdlib_versions_path);
         let functools_module = resolve_module(&db, functools_module_name.clone()).unwrap();
         assert_eq!(functools_module.search_path(), site_packages);

--- a/crates/red_knot_module_resolver/src/resolver.rs
+++ b/crates/red_knot_module_resolver/src/resolver.rs
@@ -1064,16 +1064,15 @@ mod tests {
 
         // If we now delete both the stdlib and first-party files,
         // it should resolve to site-packages:
+        for path in [stdlib_functools_path, src_functools_path] {
+            db.memory_file_system().remove_file(&path).unwrap();
+            File::touch_path(&mut db, &FilePath::System(path));
+        }
+        let stdlib_versions_path = stdlib.join("VERSIONS");
         db.memory_file_system()
-            .remove_file(stdlib_functools_path)
+            .write_file(&stdlib_versions_path, "")
             .unwrap();
-        db.memory_file_system()
-            .write_file(stdlib.join("VERSIONS"), "")
-            .unwrap();
-        db.memory_file_system()
-            .remove_file(src_functools_path)
-            .unwrap();
-        dbg!(db.memory_file_system());
+        File::touch_path(&mut db, &FilePath::System(stdlib_versions_path));
         let functools_module = resolve_module(&db, functools_module_name.clone()).unwrap();
         assert_eq!(functools_module.search_path(), site_packages);
         assert_eq!(

--- a/crates/red_knot_python_semantic/src/db.rs
+++ b/crates/red_knot_python_semantic/src/db.rs
@@ -35,13 +35,8 @@ pub trait Db:
 
 #[cfg(test)]
 pub(crate) mod tests {
-    use std::fmt::Formatter;
-    use std::marker::PhantomData;
     use std::sync::Arc;
 
-    use salsa::id::AsId;
-    use salsa::ingredient::Ingredient;
-    use salsa::storage::HasIngredientsFor;
     use salsa::DebugWithDb;
 
     use red_knot_module_resolver::{vendored_typeshed_stubs, Db as ResolverDb, Jar as ResolverJar};
@@ -148,108 +143,6 @@ pub(crate) mod tests {
                 vendored: self.vendored.snapshot(),
                 events: self.events.clone(),
             })
-        }
-    }
-
-    pub(crate) fn assert_will_run_function_query<'db, C, Db, Jar>(
-        db: &'db Db,
-        to_function: impl FnOnce(&C) -> &salsa::function::FunctionIngredient<C>,
-        input: &C::Input<'db>,
-        events: &[salsa::Event],
-    ) where
-        C: salsa::function::Configuration<Jar = Jar>
-            + salsa::storage::IngredientsFor<Jar = Jar, Ingredients = C>,
-        Jar: HasIngredientsFor<C>,
-        Db: salsa::DbWithJar<Jar>,
-        C::Input<'db>: AsId,
-    {
-        will_run_function_query(db, to_function, input, events, true);
-    }
-
-    pub(crate) fn assert_will_not_run_function_query<'db, C, Db, Jar>(
-        db: &'db Db,
-        to_function: impl FnOnce(&C) -> &salsa::function::FunctionIngredient<C>,
-        input: &C::Input<'db>,
-        events: &[salsa::Event],
-    ) where
-        C: salsa::function::Configuration<Jar = Jar>
-            + salsa::storage::IngredientsFor<Jar = Jar, Ingredients = C>,
-        Jar: HasIngredientsFor<C>,
-        Db: salsa::DbWithJar<Jar>,
-        C::Input<'db>: AsId,
-    {
-        will_run_function_query(db, to_function, input, events, false);
-    }
-
-    fn will_run_function_query<'db, C, Db, Jar>(
-        db: &'db Db,
-        to_function: impl FnOnce(&C) -> &salsa::function::FunctionIngredient<C>,
-        input: &C::Input<'db>,
-        events: &[salsa::Event],
-        should_run: bool,
-    ) where
-        C: salsa::function::Configuration<Jar = Jar>
-            + salsa::storage::IngredientsFor<Jar = Jar, Ingredients = C>,
-        Jar: HasIngredientsFor<C>,
-        Db: salsa::DbWithJar<Jar>,
-        C::Input<'db>: AsId,
-    {
-        let (jar, _) =
-            <_ as salsa::storage::HasJar<<C as salsa::storage::IngredientsFor>::Jar>>::jar(db);
-        let ingredient = jar.ingredient();
-
-        let function_ingredient = to_function(ingredient);
-
-        let ingredient_index =
-            <salsa::function::FunctionIngredient<C> as Ingredient<Db>>::ingredient_index(
-                function_ingredient,
-            );
-
-        let did_run = events.iter().any(|event| {
-            if let salsa::EventKind::WillExecute { database_key } = event.kind {
-                database_key.ingredient_index() == ingredient_index
-                    && database_key.key_index() == input.as_id()
-            } else {
-                false
-            }
-        });
-
-        if should_run && !did_run {
-            panic!(
-                "Expected query {:?} to run but it didn't",
-                DebugIdx {
-                    db: PhantomData::<Db>,
-                    value_id: input.as_id(),
-                    ingredient: function_ingredient,
-                }
-            );
-        } else if !should_run && did_run {
-            panic!(
-                "Expected query {:?} not to run but it did",
-                DebugIdx {
-                    db: PhantomData::<Db>,
-                    value_id: input.as_id(),
-                    ingredient: function_ingredient,
-                }
-            );
-        }
-    }
-
-    struct DebugIdx<'a, I, Db>
-    where
-        I: Ingredient<Db>,
-    {
-        value_id: salsa::Id,
-        ingredient: &'a I,
-        db: PhantomData<Db>,
-    }
-
-    impl<'a, I, Db> std::fmt::Debug for DebugIdx<'a, I, Db>
-    where
-        I: Ingredient<Db>,
-    {
-        fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-            self.ingredient.fmt_index(Some(self.value_id), f)
         }
     }
 }

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -277,7 +277,7 @@ mod tests {
     use ruff_db::files::system_path_to_file;
     use ruff_db::parsed::parsed_module;
     use ruff_db::system::{DbWithTestSystem, SystemPathBuf};
-    use ruff_db::testing::{assert_will_not_run_function_query, assert_will_run_function_query};
+    use ruff_db::testing::{assert_function_query_was_not_run, assert_function_query_was_run};
 
     use crate::db::tests::TestDb;
     use crate::semantic_index::root_scope;
@@ -346,7 +346,7 @@ mod tests {
         let events = db.take_salsa_events();
 
         let a_root_scope = root_scope(&db, a);
-        assert_will_run_function_query::<infer_types, _, _>(
+        assert_function_query_was_run::<infer_types, _, _>(
             &db,
             |ty| &ty.function,
             &a_root_scope,
@@ -384,7 +384,7 @@ mod tests {
 
         let a_root_scope = root_scope(&db, a);
 
-        assert_will_not_run_function_query::<infer_types, _, _>(
+        assert_function_query_was_not_run::<infer_types, _, _>(
             &db,
             |ty| &ty.function,
             &a_root_scope,
@@ -421,7 +421,7 @@ mod tests {
         let events = db.take_salsa_events();
 
         let a_root_scope = root_scope(&db, a);
-        assert_will_not_run_function_query::<infer_types, _, _>(
+        assert_function_query_was_not_run::<infer_types, _, _>(
             &db,
             |ty| &ty.function,
             &a_root_scope,

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -277,10 +277,9 @@ mod tests {
     use ruff_db::files::system_path_to_file;
     use ruff_db::parsed::parsed_module;
     use ruff_db::system::{DbWithTestSystem, SystemPathBuf};
+    use ruff_db::testing::{assert_will_not_run_function_query, assert_will_run_function_query};
 
-    use crate::db::tests::{
-        assert_will_not_run_function_query, assert_will_run_function_query, TestDb,
-    };
+    use crate::db::tests::TestDb;
     use crate::semantic_index::root_scope;
     use crate::types::{infer_types, public_symbol_ty_by_name};
     use crate::{HasTy, SemanticModel};

--- a/crates/ruff_db/src/lib.rs
+++ b/crates/ruff_db/src/lib.rs
@@ -14,6 +14,7 @@ pub mod files;
 pub mod parsed;
 pub mod source;
 pub mod system;
+pub mod testing;
 pub mod vendored;
 
 pub(crate) type FxDashMap<K, V> = dashmap::DashMap<K, V, BuildHasherDefault<FxHasher>>;

--- a/crates/ruff_db/src/testing.rs
+++ b/crates/ruff_db/src/testing.rs
@@ -1,0 +1,114 @@
+//! Test helpers for working with Salsa databases
+
+use std::fmt;
+use std::marker::PhantomData;
+
+use salsa::id::AsId;
+use salsa::ingredient::Ingredient;
+use salsa::storage::HasIngredientsFor;
+
+/// Assert that calling `to_function` with `input` as an argument
+/// will result in a (re-)execution of the query specified by the generic parameter `C`
+pub fn assert_will_run_function_query<'db, C, Db, Jar>(
+    db: &'db Db,
+    to_function: impl FnOnce(&C) -> &salsa::function::FunctionIngredient<C>,
+    input: &C::Input<'db>,
+    events: &[salsa::Event],
+) where
+    C: salsa::function::Configuration<Jar = Jar>
+        + salsa::storage::IngredientsFor<Jar = Jar, Ingredients = C>,
+    Jar: HasIngredientsFor<C>,
+    Db: salsa::DbWithJar<Jar>,
+    C::Input<'db>: AsId,
+{
+    will_run_function_query(db, to_function, input, events, true);
+}
+
+/// Assert that calling `to_function` with `input` as an argument
+/// will *not* result in a (re-)execution of the query specified by the generic parameter `C`
+pub fn assert_will_not_run_function_query<'db, C, Db, Jar>(
+    db: &'db Db,
+    to_function: impl FnOnce(&C) -> &salsa::function::FunctionIngredient<C>,
+    input: &C::Input<'db>,
+    events: &[salsa::Event],
+) where
+    C: salsa::function::Configuration<Jar = Jar>
+        + salsa::storage::IngredientsFor<Jar = Jar, Ingredients = C>,
+    Jar: HasIngredientsFor<C>,
+    Db: salsa::DbWithJar<Jar>,
+    C::Input<'db>: AsId,
+{
+    will_run_function_query(db, to_function, input, events, false);
+}
+
+fn will_run_function_query<'db, C, Db, Jar>(
+    db: &'db Db,
+    to_function: impl FnOnce(&C) -> &salsa::function::FunctionIngredient<C>,
+    input: &C::Input<'db>,
+    events: &[salsa::Event],
+    should_run: bool,
+) where
+    C: salsa::function::Configuration<Jar = Jar>
+        + salsa::storage::IngredientsFor<Jar = Jar, Ingredients = C>,
+    Jar: HasIngredientsFor<C>,
+    Db: salsa::DbWithJar<Jar>,
+    C::Input<'db>: AsId,
+{
+    let (jar, _) =
+        <_ as salsa::storage::HasJar<<C as salsa::storage::IngredientsFor>::Jar>>::jar(db);
+    let ingredient = jar.ingredient();
+
+    let function_ingredient = to_function(ingredient);
+
+    let ingredient_index =
+        <salsa::function::FunctionIngredient<C> as Ingredient<Db>>::ingredient_index(
+            function_ingredient,
+        );
+
+    let did_run = events.iter().any(|event| {
+        if let salsa::EventKind::WillExecute { database_key } = event.kind {
+            database_key.ingredient_index() == ingredient_index
+                && database_key.key_index() == input.as_id()
+        } else {
+            false
+        }
+    });
+
+    if should_run && !did_run {
+        panic!(
+            "Expected query {:?} to run but it didn't",
+            DebugIdx {
+                db: PhantomData::<Db>,
+                value_id: input.as_id(),
+                ingredient: function_ingredient,
+            }
+        );
+    } else if !should_run && did_run {
+        panic!(
+            "Expected query {:?} not to run but it did",
+            DebugIdx {
+                db: PhantomData::<Db>,
+                value_id: input.as_id(),
+                ingredient: function_ingredient,
+            }
+        );
+    }
+}
+
+struct DebugIdx<'a, I, Db>
+where
+    I: Ingredient<Db>,
+{
+    value_id: salsa::Id,
+    ingredient: &'a I,
+    db: PhantomData<Db>,
+}
+
+impl<'a, I, Db> fmt::Debug for DebugIdx<'a, I, Db>
+where
+    I: Ingredient<Db>,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> std::fmt::Result {
+        self.ingredient.fmt_index(Some(self.value_id), f)
+    }
+}


### PR DESCRIPTION
## Summary

This PR adds a stress test to the module resolver to check that adding and removing files at various points in the module-resolution heirarchy invalidates the Salsa cache.

~~The test currently fails. Deleting the first-party and stdlib functools modules should invalidate the cache, meaning that functools now resolves to the functools module in site-packages. That's not the case, however: after deleting those two files, the module resolver appears to still be resolving the module to the deleted src/functools.py file.~~

~~I've tried to look into what might be causing this, but I haven't had any luck in figuring it out. Curious if @MichaReiser or @carljm have any ideas :/~~

## Test Plan

`cargo test -p red_knot_module_resolver`
