### PR TITLE
Change `File::touch_path` to only take a `SystemPath`

### DIFF
--- a/crates/red_knot/src/program/mod.rs
+++ b/crates/red_knot/src/program/mod.rs
@@ -5,7 +5,7 @@ use salsa::{Cancelled, Database};
 
 use red_knot_module_resolver::{vendored_typeshed_stubs, Db as ResolverDb, Jar as ResolverJar};
 use red_knot_python_semantic::{Db as SemanticDb, Jar as SemanticJar};
-use ruff_db::files::{File, FilePath, Files};
+use ruff_db::files::{File, Files};
 use ruff_db::system::{System, SystemPathBuf};
 use ruff_db::vendored::VendoredFileSystem;
 use ruff_db::{Db as SourceDb, Jar as SourceJar, Upcast};
@@ -41,7 +41,7 @@ impl Program {
         I: IntoIterator<Item = FileWatcherChange>,
     {
         for change in changes {
-            File::touch_path(self, &FilePath::system(change.path));
+            File::touch_path(self, &change.path);
         }
     }
 

--- a/crates/red_knot_module_resolver/src/resolver.rs
+++ b/crates/red_knot_module_resolver/src/resolver.rs
@@ -991,7 +991,7 @@ mod tests {
         db.memory_file_system().remove_file(&foo_init_path)?;
         db.memory_file_system()
             .remove_directory(foo_init_path.parent().unwrap())?;
-        File::touch_path(&mut db, &FilePath::System(foo_init_path));
+        File::touch_path(&mut db, &foo_init_path);
 
         let foo_module = resolve_module(&db, foo_module_name).expect("Foo module to resolve");
         assert_eq!(&foo_path, foo_module.file().path(&db));

--- a/crates/ruff_db/src/system/test.rs
+++ b/crates/ruff_db/src/system/test.rs
@@ -1,4 +1,4 @@
-use crate::files::{File, FilePath};
+use crate::files::File;
 use crate::system::{MemoryFileSystem, Metadata, OsSystem, System, SystemPath};
 use crate::Db;
 use std::any::Any;
@@ -104,14 +104,14 @@ pub trait DbWithTestSystem: Db + Sized {
         path: impl AsRef<SystemPath>,
         content: impl ToString,
     ) -> crate::system::Result<()> {
-        let path = path.as_ref().to_path_buf();
+        let path = path.as_ref();
         let result = self
             .test_system()
             .memory_file_system()
-            .write_file(&path, content);
+            .write_file(path, content);
 
         if result.is_ok() {
-            File::touch_path(self, &FilePath::System(path));
+            File::touch_path(self, path);
         }
 
         result


### PR DESCRIPTION
## Summary

This PR changes the signature of `File::touch_path` to take a `SystemPath` instead of a `FilePath`, because `VendoredPath` can never change. 

## Test Plan

`cargo test`

<!-- How was it tested? -->
