### PR TITLE
Explicitly add schemars to ruff_python_ast Cargo.toml

### DIFF
--- a/crates/ruff_linter/Cargo.toml
+++ b/crates/ruff_linter/Cargo.toml
@@ -17,7 +17,7 @@ ruff_cache = { workspace = true }
 ruff_diagnostics = { workspace = true, features = ["serde"] }
 ruff_notebook = { workspace = true }
 ruff_macros = { workspace = true }
-ruff_python_ast = { workspace = true, features = ["serde"] }
+ruff_python_ast = { workspace = true, features = ["serde", "cache"] }
 ruff_python_codegen = { workspace = true }
 ruff_python_index = { workspace = true }
 ruff_python_literal = { workspace = true }
@@ -79,7 +79,7 @@ colored = { workspace = true, features = ["no-color"] }
 
 [features]
 default = []
-schemars = ["dep:schemars"]
+schemars = ["dep:schemars", "ruff_python_ast/schemars"]
 # Enables rules for internal integration tests
 test-rules = []
 

--- a/crates/ruff_python_ast/Cargo.toml
+++ b/crates/ruff_python_ast/Cargo.toml
@@ -31,7 +31,8 @@ compact_str = { workspace = true }
 
 [features]
 schemars = ["dep:schemars"]
-serde = ["dep:serde", "ruff_text_size/serde", "dep:ruff_cache", "compact_str/serde", "dep:ruff_macros", "dep:schemars"]
+cache = ["dep:ruff_cache", "dep:ruff_macros"]
+serde = ["dep:serde", "ruff_text_size/serde", "dep:ruff_cache", "compact_str/serde"]
 
 [lints]
 workspace = true

--- a/crates/ruff_python_ast/Cargo.toml
+++ b/crates/ruff_python_ast/Cargo.toml
@@ -30,6 +30,7 @@ serde = { workspace = true, optional = true }
 compact_str = { workspace = true }
 
 [features]
+schemars = ["dep:schemars"]
 serde = ["dep:serde", "ruff_text_size/serde", "dep:ruff_cache", "compact_str/serde", "dep:ruff_macros", "dep:schemars"]
 
 [lints]

--- a/crates/ruff_python_ast/src/name.rs
+++ b/crates/ruff_python_ast/src/name.rs
@@ -6,10 +6,8 @@ use std::ops::Deref;
 use crate::{nodes, Expr};
 
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde::Serialize, serde::Deserialize, ruff_macros::CacheKey)
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "cache", derive(ruff_macros::CacheKey))]
 pub struct Name(compact_str::CompactString);
 
 impl Name {
@@ -179,7 +177,7 @@ impl PartialEq<Name> for &String {
     }
 }
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "schemars")]
 impl schemars::JsonSchema for Name {
     fn is_referenceable() -> bool {
         String::is_referenceable()


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Context: [Updating ruff from 0.5.0 to 0.5.1 on nixpkgs](https://github.com/NixOS/nixpkgs/pull/324823).

We noticed that since https://github.com/astral-sh/ruff/commit/5109b50bb3847738eeb209352cf26bda392adf62, `ruff` was not building successfully in our pipeline:
```
thread 'main' panicked at cargo-auditable/src/collect_audit_data.rs:77:9:
error: Package `ruff_python_ast v0.0.0 (/build/source/crates/ruff_python_ast)` does not have feature `schemars`. It has an optional dependency with that name, but that dependency us>

note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
error: could not compile `ruff_python_formatter` (bin "ruff_python_formatter")
```

This patch by @eljamm seems to fix it on our end.

## Test Plan

We were able to build `ruff` 0.5.1 with this patch and its test suite is passing.
