### PR TITLE
Use `space` separator before parenthesiszed expressions in comprehensions with leading comments.

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/list_comp.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/list_comp.py
@@ -105,3 +105,66 @@ aaaaaaaaaaaaaaaaaaaaa = [
 # Parenthesized targets and iterators.
 [x for (x) in y]
 [x for x in (y)]
+
+
+# Leading expression comments:
+y = [
+    a
+    for (
+        # comment
+        a
+    ) in (
+        # comment
+        x
+    )
+    if (
+        # asdasd
+        "askldaklsdnmklasmdlkasmdlkasmdlkasmdasd"
+        != "as,mdnaskldmlkasdmlaksdmlkasdlkasdm"
+        and "zxcm,.nzxclm,zxnckmnzxckmnzxczxc" != "zxcasdasdlmnasdlknaslkdnmlaskdm"
+    )
+    if (
+        # comment
+        x
+    )
+]
+
+# Tuple target:
+y = [
+    a
+    for
+        # comment
+        a, b
+     in x
+    if  True
+]
+
+
+y = [
+    a
+    for (
+        # comment
+        a, b
+    )
+    in x
+    if  True
+]
+
+
+y = [
+    a
+    for
+        # comment
+        a
+    in
+        # comment
+        x
+    if
+        # asdasd
+        "askldaklsdnmklasmdlkasmdlkasmdlkasmdasd"
+        != "as,mdnaskldmlkasdmlaksdmlkasdlkasdm"
+        and "zxcm,.nzxclm,zxnckmnzxckmnzxczxc" != "zxcasdasdlmnasdlknaslkdnmlaskdm"
+    if
+        # comment
+        x
+]

--- a/crates/ruff_python_formatter/src/preview.rs
+++ b/crates/ruff_python_formatter/src/preview.rs
@@ -22,3 +22,10 @@ pub(crate) fn is_f_string_formatting_enabled(context: &PyFormatContext) -> bool 
 pub(crate) fn is_with_single_item_pre_39_enabled(context: &PyFormatContext) -> bool {
     context.is_preview()
 }
+
+/// See [#12282](https://github.com/astral-sh/ruff/pull/12282).
+pub(crate) fn is_comprehension_leading_expression_comments_same_line_enabled(
+    context: &PyFormatContext,
+) -> bool {
+    context.is_preview()
+}

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__list_comp.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__list_comp.py.snap
@@ -111,6 +111,69 @@ aaaaaaaaaaaaaaaaaaaaa = [
 # Parenthesized targets and iterators.
 [x for (x) in y]
 [x for x in (y)]
+
+
+# Leading expression comments:
+y = [
+    a
+    for (
+        # comment
+        a
+    ) in (
+        # comment
+        x
+    )
+    if (
+        # asdasd
+        "askldaklsdnmklasmdlkasmdlkasmdlkasmdasd"
+        != "as,mdnaskldmlkasdmlaksdmlkasdlkasdm"
+        and "zxcm,.nzxclm,zxnckmnzxckmnzxczxc" != "zxcasdasdlmnasdlknaslkdnmlaskdm"
+    )
+    if (
+        # comment
+        x
+    )
+]
+
+# Tuple target:
+y = [
+    a
+    for
+        # comment
+        a, b
+     in x
+    if  True
+]
+
+
+y = [
+    a
+    for (
+        # comment
+        a, b
+    )
+    in x
+    if  True
+]
+
+
+y = [
+    a
+    for
+        # comment
+        a
+    in
+        # comment
+        x
+    if
+        # asdasd
+        "askldaklsdnmklasmdlkasmdlkasmdlkasmdasd"
+        != "as,mdnaskldmlkasdmlaksdmlkasdlkasdm"
+        and "zxcm,.nzxclm,zxnckmnzxckmnzxczxc" != "zxcasdasdlmnasdlknaslkdnmlaskdm"
+    if
+        # comment
+        x
+]
 ```
 
 ## Output
@@ -254,7 +317,104 @@ aaaaaaaaaaaaaaaaaaaaa = [
 # Parenthesized targets and iterators.
 [x for (x) in y]
 [x for x in (y)]
+
+
+# Leading expression comments:
+y = [
+    a
+    for
+    (
+        # comment
+        a
+    ) in
+    (
+        # comment
+        x
+    )
+    if
+    (
+        # asdasd
+        "askldaklsdnmklasmdlkasmdlkasmdlkasmdasd"
+        != "as,mdnaskldmlkasdmlaksdmlkasdlkasdm"
+        and "zxcm,.nzxclm,zxnckmnzxckmnzxczxc" != "zxcasdasdlmnasdlknaslkdnmlaskdm"
+    )
+    if
+    (
+        # comment
+        x
+    )
+]
+
+# Tuple target:
+y = [
+    a
+    for
+    # comment
+    a, b in x
+    if True
+]
+
+
+y = [
+    a
+    for (
+        # comment
+        a,
+        b,
+    ) in x
+    if True
+]
+
+
+y = [
+    a
+    for
+    # comment
+    a in
+    # comment
+    x
+    if
+    # asdasd
+    "askldaklsdnmklasmdlkasmdlkasmdlkasmdasd" != "as,mdnaskldmlkasdmlaksdmlkasdlkasdm"
+    and "zxcm,.nzxclm,zxnckmnzxckmnzxczxc" != "zxcasdasdlmnasdlknaslkdnmlaskdm"
+    if
+    # comment
+    x
+]
 ```
 
 
-
+## Preview changes
+```diff
+--- Stable
++++ Preview
+@@ -142,24 +142,20 @@
+ # Leading expression comments:
+ y = [
+     a
+-    for
+-    (
++    for (
+         # comment
+         a
+-    ) in
+-    (
++    ) in (
+         # comment
+         x
+     )
+-    if
+-    (
++    if (
+         # asdasd
+         "askldaklsdnmklasmdlkasmdlkasmdlkasmdasd"
+         != "as,mdnaskldmlkasdmlaksdmlkasdlkasdm"
+         and "zxcm,.nzxclm,zxnckmnzxckmnzxczxc" != "zxcasdasdlmnasdlknaslkdnmlaskdm"
+     )
+-    if
+-    (
++    if (
+         # comment
+         x
+     )
+```


### PR DESCRIPTION
## Summary

Keeps the parentheses on the same line as the preceding keyword if the following expression has leading comments. 


Fixes https://github.com/astral-sh/ruff/issues/12280

```python
y = [
    a
    for (
        # comment
        a
    ) in (
        # comment
        x
    )
    if (
        # asdasd
        "askldaklsdnmklasmdlkasmdlkasmdlkasmdasd"
        != "as,mdnaskldmlkasdmlaksdmlkasdlkasdm"
        and "zxcm,.nzxclm,zxnckmnzxckmnzxczxc" != "zxcasdasdlmnasdlknaslkdnmlaskdm"
    )
    if (
        # comment
        x
    )
]


```


<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

I added three new integration tests. 

The changes are gated behind preview because this isn't a fix addressing a stability issue or because the formatted produced invalid sytnax.