### PR TITLE
[red-knot] Add a `read_directory()` method to the `ruff_db::system::System` trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2102,6 +2102,7 @@ dependencies = [
  "ruff_text_size",
  "rustc-hash 2.0.0",
  "salsa",
+ "tempfile",
  "tracing",
  "zip",
 ]

--- a/crates/ruff_db/Cargo.toml
+++ b/crates/ruff_db/Cargo.toml
@@ -27,3 +27,4 @@ zip = { workspace = true }
 
 [dev-dependencies]
 insta = { workspace = true }
+tempfile = { workspace = true }

--- a/crates/ruff_db/src/system.rs
+++ b/crates/ruff_db/src/system.rs
@@ -54,6 +54,29 @@ pub trait System {
     /// Returns the current working directory
     fn current_directory(&self) -> &SystemPath;
 
+    /// Iterate over the contents of the directory at `path`.
+    ///
+    /// The returned iterator must have the following properties:
+    /// - It only iterates over the top level of the directory,
+    ///   i.e., it does not recurse into subdirectories.
+    /// - It skips the current and parent directories (`.` and `..`
+    ///   respectively).
+    /// - The iterator yields `std::io::Result<DirEntry>` instances.
+    ///   For each instance, an `Err` variant may signify that the path
+    ///   of the entry was not valid UTF8, in which case it should be an
+    ///   [`std::io::Error`] with the ErrorKind set to
+    ///   [`std::io::ErrorKind::InvalidData`] and the payload set to a
+    ///   [`camino::FromPathBufError`]. It may also indicate that
+    ///   "some sort of intermittent IO error occurred during iteration"
+    ///   (language taken from the [`std::fs::read_dir`] documentation).
+    ///
+    /// # Errors
+    /// Returns an error:
+    /// - if `path` does not exist in the system,
+    /// - if `path` does not point to a directory,
+    /// - if the process does not have sufficient permissions to
+    ///   view the contents of the directory at `path`
+    /// - May also return an error in some other situations as well.
     fn read_directory<'a>(
         &'a self,
         path: &SystemPath,

--- a/crates/ruff_db/src/system.rs
+++ b/crates/ruff_db/src/system.rs
@@ -57,7 +57,7 @@ pub trait System {
     fn read_directory<'a>(
         &'a self,
         path: &SystemPath,
-    ) -> Result<Box<dyn Iterator<Item = Result<DirEntry>> + 'a>>;
+    ) -> Result<Box<dyn Iterator<Item = Result<DirectoryEntry>> + 'a>>;
 
     fn as_any(&self) -> &dyn std::any::Any;
 }
@@ -105,12 +105,12 @@ impl FileType {
 }
 
 #[derive(Debug)]
-pub struct DirEntry {
+pub struct DirectoryEntry {
     path: SystemPathBuf,
     file_type: Result<FileType>,
 }
 
-impl DirEntry {
+impl DirectoryEntry {
     pub fn new(path: SystemPathBuf, file_type: Result<FileType>) -> Self {
         Self { path, file_type }
     }
@@ -124,7 +124,7 @@ impl DirEntry {
     }
 }
 
-impl PartialEq for DirEntry {
+impl PartialEq for DirectoryEntry {
     fn eq(&self, other: &Self) -> bool {
         self.path == other.path
     }

--- a/crates/ruff_db/src/system.rs
+++ b/crates/ruff_db/src/system.rs
@@ -83,7 +83,7 @@ impl Metadata {
     }
 }
 
-#[derive(Copy, Clone, Eq, PartialEq, Debug, Hash, PartialOrd, Ord)]
+#[derive(Copy, Clone, Eq, PartialEq, Debug, Hash)]
 pub enum FileType {
     File,
     Directory,
@@ -104,14 +104,14 @@ impl FileType {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug)]
 pub struct DirEntry {
     path: SystemPathBuf,
-    file_type: FileType,
+    file_type: Result<FileType>,
 }
 
 impl DirEntry {
-    pub fn new(path: SystemPathBuf, file_type: FileType) -> Self {
+    pub fn new(path: SystemPathBuf, file_type: Result<FileType>) -> Self {
         Self { path, file_type }
     }
 
@@ -119,7 +119,13 @@ impl DirEntry {
         &self.path
     }
 
-    pub fn file_type(&self) -> FileType {
-        self.file_type
+    pub fn file_type(&self) -> &Result<FileType> {
+        &self.file_type
+    }
+}
+
+impl PartialEq for DirEntry {
+    fn eq(&self, other: &Self) -> bool {
+        self.path == other.path
     }
 }

--- a/crates/ruff_db/src/system.rs
+++ b/crates/ruff_db/src/system.rs
@@ -54,6 +54,11 @@ pub trait System {
     /// Returns the current working directory
     fn current_directory(&self) -> &SystemPath;
 
+    fn read_dir<'a>(
+        &'a self,
+        path: &SystemPath,
+    ) -> Result<Box<dyn Iterator<Item = Result<DirEntry>> + 'a>>;
+
     fn as_any(&self) -> &dyn std::any::Any;
 }
 
@@ -78,7 +83,7 @@ impl Metadata {
     }
 }
 
-#[derive(Copy, Clone, Eq, PartialEq, Debug, Hash)]
+#[derive(Copy, Clone, Eq, PartialEq, Debug, Hash, PartialOrd, Ord)]
 pub enum FileType {
     File,
     Directory,
@@ -96,5 +101,25 @@ impl FileType {
 
     pub const fn is_symlink(self) -> bool {
         matches!(self, FileType::Symlink)
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct DirEntry {
+    path: SystemPathBuf,
+    file_type: FileType,
+}
+
+impl DirEntry {
+    pub fn new(path: SystemPathBuf, file_type: FileType) -> Self {
+        Self { path, file_type }
+    }
+
+    pub fn path(&self) -> &SystemPath {
+        &self.path
+    }
+
+    pub fn file_type(&self) -> FileType {
+        self.file_type
     }
 }

--- a/crates/ruff_db/src/system.rs
+++ b/crates/ruff_db/src/system.rs
@@ -54,7 +54,7 @@ pub trait System {
     /// Returns the current working directory
     fn current_directory(&self) -> &SystemPath;
 
-    fn read_dir<'a>(
+    fn read_directory<'a>(
         &'a self,
         path: &SystemPath,
     ) -> Result<Box<dyn Iterator<Item = Result<DirEntry>> + 'a>>;

--- a/crates/ruff_db/src/system/memory_fs.rs
+++ b/crates/ruff_db/src/system/memory_fs.rs
@@ -238,7 +238,7 @@ impl MemoryFileSystem {
         normalized.into_utf8_path_buf()
     }
 
-    pub(crate) fn read_directory(
+    pub fn read_directory(
         &self,
         path: impl AsRef<SystemPath>,
     ) -> Result<impl Iterator<Item = Result<DirectoryEntry>> + '_> {

--- a/crates/ruff_db/src/system/memory_fs.rs
+++ b/crates/ruff_db/src/system/memory_fs.rs
@@ -316,7 +316,7 @@ impl<'a> Iterator for DirectoryIterator<'a> {
             } else {
                 FileType::File
             };
-            break Some(Ok(DirEntry::new(path, file_type)));
+            break Some(Ok(DirEntry::new(path, Ok(file_type))));
         }
     }
 }
@@ -675,9 +675,9 @@ mod tests {
             .map(Result::unwrap)
             .collect();
         let expected_contents = vec![
-            DirEntry::new(SystemPathBuf::from("/a/bar.py"), FileType::File),
-            DirEntry::new(SystemPathBuf::from("/a/baz.pyi"), FileType::File),
-            DirEntry::new(SystemPathBuf::from("/a/foo"), FileType::Directory),
+            DirEntry::new(SystemPathBuf::from("/a/bar.py"), Ok(FileType::File)),
+            DirEntry::new(SystemPathBuf::from("/a/baz.pyi"), Ok(FileType::File)),
+            DirEntry::new(SystemPathBuf::from("/a/foo"), Ok(FileType::Directory)),
         ];
         assert_eq!(contents, expected_contents)
     }

--- a/crates/ruff_db/src/system/memory_fs.rs
+++ b/crates/ruff_db/src/system/memory_fs.rs
@@ -239,7 +239,7 @@ impl MemoryFileSystem {
         normalized.into_utf8_path_buf()
     }
 
-    pub(crate) fn read_dir(&self, path: impl AsRef<SystemPath>) -> Result<DirectoryIterator> {
+    pub(crate) fn read_directory(&self, path: impl AsRef<SystemPath>) -> Result<DirectoryIterator> {
         let by_path = self.inner.by_path.read().unwrap();
         let normalized = self.normalize_path(path.as_ref());
         let entry = by_path.get(&normalized).ok_or_else(not_found)?;
@@ -667,9 +667,13 @@ mod tests {
     }
 
     #[test]
-    fn read_dir() {
+    fn read_directory() {
         let fs = with_files(["b.ts", "a/bar.py", "d.rs", "a/foo/bar.py", "a/baz.pyi"]);
-        let contents: Vec<DirEntry> = fs.read_dir("a").unwrap().map(Result::unwrap).collect();
+        let contents: Vec<DirEntry> = fs
+            .read_directory("a")
+            .unwrap()
+            .map(Result::unwrap)
+            .collect();
         let expected_contents = vec![
             DirEntry::new(SystemPathBuf::from("/a/bar.py"), FileType::File),
             DirEntry::new(SystemPathBuf::from("/a/baz.pyi"), FileType::File),
@@ -679,16 +683,16 @@ mod tests {
     }
 
     #[test]
-    fn read_dir_nonexistent() {
+    fn read_directory_nonexistent() {
         let fs = MemoryFileSystem::new();
-        let error = fs.read_dir("doesnt_exist").unwrap_err();
+        let error = fs.read_directory("doesnt_exist").unwrap_err();
         assert_eq!(error.kind(), std::io::ErrorKind::NotFound);
     }
 
     #[test]
-    fn read_dir_on_file() {
+    fn read_directory_on_file() {
         let fs = with_files(["a.py"]);
-        let error = fs.read_dir("a.py").unwrap_err();
+        let error = fs.read_directory("a.py").unwrap_err();
         assert_eq!(error.kind(), std::io::ErrorKind::Other);
         assert!(error.to_string().contains("Not a directory"));
     }

--- a/crates/ruff_db/src/system/os.rs
+++ b/crates/ruff_db/src/system/os.rs
@@ -158,10 +158,15 @@ mod tests {
         let Err(error) = result else {
             panic!("Expected the read_dir() call to fail!");
         };
-        dbg!(error.to_string());
+
         // We can't assert the error kind here because it's apparently an unstable feature!
         // https://github.com/rust-lang/rust/issues/86442
         // assert_eq!(error.kind(), std::io::ErrorKind::NotADirectory);
-        assert!(error.to_string().contains("Not a directory"));
+
+        // We can't even assert the error message on all platforms, as it's different on Windows,
+        // where the message is "The directory name is invalid" rather than "Not a directory".
+        if cfg!(unix) {
+            assert!(error.to_string().contains("Not a directory"));
+        }
     }
 }

--- a/crates/ruff_db/src/system/os.rs
+++ b/crates/ruff_db/src/system/os.rs
@@ -69,7 +69,10 @@ impl System for OsSystem {
         self
     }
 
-    fn read_dir(&self, path: &SystemPath) -> Result<Box<dyn Iterator<Item = Result<DirEntry>>>> {
+    fn read_directory(
+        &self,
+        path: &SystemPath,
+    ) -> Result<Box<dyn Iterator<Item = Result<DirEntry>>>> {
         Ok(Box::new(
             path.as_camino_path()
                 .read_dir_utf8()?
@@ -108,7 +111,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn read_dir() {
+    fn read_directory() {
         let tempdir = TempDir::new().unwrap();
         let tempdir_path = tempdir.path();
         std::fs::create_dir_all(tempdir_path.join("a/foo")).unwrap();
@@ -121,7 +124,7 @@ mod tests {
         let fs = OsSystem::new(tempdir_path);
 
         let mut sorted_contents: Vec<DirEntry> = fs
-            .read_dir(&tempdir_path.join("a"))
+            .read_directory(&tempdir_path.join("a"))
             .unwrap()
             .map(Result::unwrap)
             .collect();
@@ -136,21 +139,21 @@ mod tests {
     }
 
     #[test]
-    fn read_dir_nonexistent() {
+    fn read_directory_nonexistent() {
         let fs = OsSystem::new("");
-        let result = fs.read_dir(SystemPath::new("doesnt_exist"));
+        let result = fs.read_directory(SystemPath::new("doesnt_exist"));
         assert!(result.is_err_and(|error| error.kind() == std::io::ErrorKind::NotFound));
     }
 
     #[test]
-    fn read_dir_on_file() {
+    fn read_directory_on_file() {
         let tempdir = TempDir::new().unwrap();
         let tempdir_path = tempdir.path();
         std::fs::File::create(tempdir_path.join("a.py")).unwrap();
 
         let tempdir_path = SystemPath::from_std_path(tempdir_path).unwrap();
         let fs = OsSystem::new(tempdir_path);
-        let result = fs.read_dir(&tempdir_path.join("a.py"));
+        let result = fs.read_directory(&tempdir_path.join("a.py"));
         let Err(error) = result else {
             panic!("Expected the read_dir() call to fail!");
         };

--- a/crates/ruff_db/src/system/os.rs
+++ b/crates/ruff_db/src/system/os.rs
@@ -76,7 +76,7 @@ impl System for OsSystem {
         path: &SystemPath,
     ) -> Result<Box<dyn Iterator<Item = Result<DirectoryEntry>>>> {
         Ok(Box::new(
-            path.as_camino_path()
+            path.as_utf8_path()
                 .read_dir_utf8()?
                 .map(|res| res.map(DirectoryEntry::from)),
         ))

--- a/crates/ruff_db/src/system/os.rs
+++ b/crates/ruff_db/src/system/os.rs
@@ -1,4 +1,6 @@
-use crate::system::{DirEntry, FileType, Metadata, Result, System, SystemPath, SystemPathBuf};
+use crate::system::{
+    DirectoryEntry, FileType, Metadata, Result, System, SystemPath, SystemPathBuf,
+};
 use filetime::FileTime;
 use std::any::Any;
 use std::sync::Arc;
@@ -72,11 +74,11 @@ impl System for OsSystem {
     fn read_directory(
         &self,
         path: &SystemPath,
-    ) -> Result<Box<dyn Iterator<Item = Result<DirEntry>>>> {
+    ) -> Result<Box<dyn Iterator<Item = Result<DirectoryEntry>>>> {
         Ok(Box::new(
             path.as_camino_path()
                 .read_dir_utf8()?
-                .map(|res| res.map(DirEntry::from)),
+                .map(|res| res.map(DirectoryEntry::from)),
         ))
     }
 }
@@ -93,7 +95,7 @@ impl From<std::fs::FileType> for FileType {
     }
 }
 
-impl From<camino::Utf8DirEntry> for DirEntry {
+impl From<camino::Utf8DirEntry> for DirectoryEntry {
     fn from(value: camino::Utf8DirEntry) -> Self {
         let file_type = value.file_type().map(FileType::from);
         Self {
@@ -122,7 +124,7 @@ mod tests {
         let tempdir_path = SystemPath::from_std_path(tempdir_path).unwrap();
         let fs = OsSystem::new(tempdir_path);
 
-        let mut sorted_contents: Vec<DirEntry> = fs
+        let mut sorted_contents: Vec<DirectoryEntry> = fs
             .read_directory(&tempdir_path.join("a"))
             .unwrap()
             .map(Result::unwrap)
@@ -130,9 +132,9 @@ mod tests {
         sorted_contents.sort_by(|a, b| a.path.cmp(&b.path));
 
         let expected_contents = vec![
-            DirEntry::new(tempdir_path.join("a/bar.py"), Ok(FileType::File)),
-            DirEntry::new(tempdir_path.join("a/baz.pyi"), Ok(FileType::File)),
-            DirEntry::new(tempdir_path.join("a/foo"), Ok(FileType::Directory)),
+            DirectoryEntry::new(tempdir_path.join("a/bar.py"), Ok(FileType::File)),
+            DirectoryEntry::new(tempdir_path.join("a/baz.pyi"), Ok(FileType::File)),
+            DirectoryEntry::new(tempdir_path.join("a/foo"), Ok(FileType::Directory)),
         ];
         assert_eq!(sorted_contents, expected_contents)
     }

--- a/crates/ruff_db/src/system/os.rs
+++ b/crates/ruff_db/src/system/os.rs
@@ -158,6 +158,7 @@ mod tests {
         let Err(error) = result else {
             panic!("Expected the read_dir() call to fail!");
         };
+        dbg!(error.to_string());
         // We can't assert the error kind here because it's apparently an unstable feature!
         // https://github.com/rust-lang/rust/issues/86442
         // assert_eq!(error.kind(), std::io::ErrorKind::NotADirectory);

--- a/crates/ruff_db/src/system/path.rs
+++ b/crates/ruff_db/src/system/path.rs
@@ -303,6 +303,12 @@ impl SystemPath {
         self.0.as_std_path()
     }
 
+    /// Returns the [`Utf8Path`] for the file.
+    #[inline]
+    pub fn as_camino_path(&self) -> &Utf8Path {
+        &self.0
+    }
+
     pub fn from_std_path(path: &Path) -> Option<&SystemPath> {
         Some(SystemPath::new(Utf8Path::from_path(path)?))
     }

--- a/crates/ruff_db/src/system/path.rs
+++ b/crates/ruff_db/src/system/path.rs
@@ -305,7 +305,7 @@ impl SystemPath {
 
     /// Returns the [`Utf8Path`] for the file.
     #[inline]
-    pub fn as_camino_path(&self) -> &Utf8Path {
+    pub fn as_utf8_path(&self) -> &Utf8Path {
         &self.0
     }
 

--- a/crates/ruff_db/src/system/test.rs
+++ b/crates/ruff_db/src/system/test.rs
@@ -86,13 +86,13 @@ impl System for TestSystem {
         self
     }
 
-    fn read_dir<'a>(
+    fn read_directory<'a>(
         &'a self,
         path: &SystemPath,
     ) -> Result<Box<dyn Iterator<Item = Result<DirEntry>> + 'a>> {
         match &self.inner {
-            TestFileSystem::Os(fs) => fs.read_dir(path),
-            TestFileSystem::Stub(fs) => Ok(Box::new(fs.read_dir(path)?)),
+            TestFileSystem::Os(fs) => fs.read_directory(path),
+            TestFileSystem::Stub(fs) => Ok(Box::new(fs.read_directory(path)?)),
         }
     }
 }

--- a/crates/ruff_db/src/system/test.rs
+++ b/crates/ruff_db/src/system/test.rs
@@ -1,5 +1,5 @@
 use crate::files::File;
-use crate::system::{MemoryFileSystem, Metadata, OsSystem, System, SystemPath};
+use crate::system::{DirEntry, MemoryFileSystem, Metadata, OsSystem, Result, System, SystemPath};
 use crate::Db;
 use std::any::Any;
 
@@ -84,6 +84,16 @@ impl System for TestSystem {
 
     fn as_any(&self) -> &dyn Any {
         self
+    }
+
+    fn read_dir<'a>(
+        &'a self,
+        path: &SystemPath,
+    ) -> Result<Box<dyn Iterator<Item = Result<DirEntry>> + 'a>> {
+        match &self.inner {
+            TestFileSystem::Os(fs) => fs.read_dir(path),
+            TestFileSystem::Stub(fs) => Ok(Box::new(fs.read_dir(path)?)),
+        }
     }
 }
 

--- a/crates/ruff_db/src/system/test.rs
+++ b/crates/ruff_db/src/system/test.rs
@@ -1,5 +1,7 @@
 use crate::files::File;
-use crate::system::{DirEntry, MemoryFileSystem, Metadata, OsSystem, Result, System, SystemPath};
+use crate::system::{
+    DirectoryEntry, MemoryFileSystem, Metadata, OsSystem, Result, System, SystemPath,
+};
 use crate::Db;
 use std::any::Any;
 
@@ -89,7 +91,7 @@ impl System for TestSystem {
     fn read_directory<'a>(
         &'a self,
         path: &SystemPath,
-    ) -> Result<Box<dyn Iterator<Item = Result<DirEntry>> + 'a>> {
+    ) -> Result<Box<dyn Iterator<Item = Result<DirectoryEntry>> + 'a>> {
         match &self.inner {
             TestFileSystem::Os(fs) => fs.read_directory(path),
             TestFileSystem::Stub(fs) => Ok(Box::new(fs.read_directory(path)?)),


### PR DESCRIPTION
## Summary

Editable installations in Python are (usually[^1]) implemented via static `.pth` files that are inserted into `site-packages` by the build backend. If the sole contents of a `.pth` file in the `site-packages` directory are an absolute path to a directory on disk, Python will consider that path to be an additional module-resolution search path that will be appended to `sys.path` on startup.

To support editable installations in the red-knot module resolver, we'll need to similarly search through the top level of `site-packages` searching for `.pth` files. In order to achieve this, this PR adds a `read_dir()` method to the `ruff_db::system::System` trait.

A rough indication of the functionality we'll need for editable support can be seen in the following function, which is part of the port @charliermarsh did of pyright's module resolver:

https://github.com/astral-sh/ruff/blob/d0298dc26d471666acc01dacdb603e3e95aca06f/crates/ruff_python_resolver/src/search.rs#L97-L134

## Test Plan

`cargo test -p ruff_db`

[^1]: Newer versions of setuptools use a more dynamic approach for editable installations, where the `.pth` file contains Python code which, when executed, dynamically computes the path which should be appended to `sys.path`. Setuptools is alone in using this approach for editable installations, and no other type checkers support editable installations produced via this method. Setuptools also provides a way of switching to the old approach for editable installations, where the `.pth` file simply contains a static path. As such, I do not intend to attempt to support editable installations created using this approach.