### PR TITLE
[numpy] Update NPY201: add `np.NAN` to exception

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/numpy/NPY201.py
+++ b/crates/ruff_linter/resources/test/fixtures/numpy/NPY201.py
@@ -68,3 +68,5 @@ def func():
     np.longfloat(12+34j)
 
     np.lookfor
+
+    np.NAN

--- a/crates/ruff_linter/src/rules/numpy/rules/numpy_2_0_deprecation.rs
+++ b/crates/ruff_linter/src/rules/numpy/rules/numpy_2_0_deprecation.rs
@@ -380,16 +380,8 @@ pub(crate) fn numpy_2_0_deprecation(checker: &mut Checker, expr: &Expr) {
                     guideline: None,
                 },
             }),
-            ["numpy", "NaN"] => Some(Replacement {
-                existing: "NaN",
-                details: Details::AutoImport {
-                    path: "numpy",
-                    name: "nan",
-                    compatibility: Compatibility::BackwardsCompatible,
-                },
-            }),
-            ["numpy", "NAN"] => Some(Replacement {
-                existing: "NAN",
+            ["numpy", existing @ ("NaN" | "NAN")] => Some(Replacement {
+                existing,
                 details: Details::AutoImport {
                     path: "numpy",
                     name: "nan",

--- a/crates/ruff_linter/src/rules/numpy/rules/numpy_2_0_deprecation.rs
+++ b/crates/ruff_linter/src/rules/numpy/rules/numpy_2_0_deprecation.rs
@@ -388,6 +388,14 @@ pub(crate) fn numpy_2_0_deprecation(checker: &mut Checker, expr: &Expr) {
                     compatibility: Compatibility::BackwardsCompatible,
                 },
             }),
+            ["numpy", "NAN"] => Some(Replacement {
+                existing: "NAN",
+                details: Details::AutoImport {
+                    path: "numpy",
+                    name: "nan",
+                    compatibility: Compatibility::BackwardsCompatible,
+                },
+            }),
             ["numpy", "nbytes"] => Some(Replacement {
                 existing: "nbytes",
                 details: Details::Manual {

--- a/crates/ruff_linter/src/rules/numpy/snapshots/ruff_linter__rules__numpy__tests__numpy2-deprecation_NPY201.py.snap
+++ b/crates/ruff_linter/src/rules/numpy/snapshots/ruff_linter__rules__numpy__tests__numpy2-deprecation_NPY201.py.snap
@@ -552,6 +552,7 @@ NPY201.py:68:5: NPY201 [*] `np.longfloat` will be removed in NumPy 2.0. Use `num
    68 |+    np.longdouble(12+34j)
 69 69 | 
 70 70 |     np.lookfor
+71 71 | 
 
 NPY201.py:70:5: NPY201 `np.lookfor` will be removed in NumPy 2.0. Search NumPy’s documentation directly.
    |
@@ -559,4 +560,22 @@ NPY201.py:70:5: NPY201 `np.lookfor` will be removed in NumPy 2.0. Search NumPy�
 69 | 
 70 |     np.lookfor
    |     ^^^^^^^^^^ NPY201
+71 | 
+72 |     np.NAN
    |
+
+NPY201.py:72:5: NPY201 [*] `np.NAN` will be removed in NumPy 2.0. Use `numpy.nan` instead.
+   |
+70 |     np.lookfor
+71 | 
+72 |     np.NAN
+   |     ^^^^^^ NPY201
+   |
+   = help: Replace with `numpy.nan`
+
+ℹ Safe fix
+69 69 | 
+70 70 |     np.lookfor
+71 71 | 
+72    |-    np.NAN
+   72 |+    np.nan


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

np.NAN was also deprecated / removed, as reported in #12195.


Personally, i'd also wan't to have warnings for `from numpy import nan, NaN, NAN` (NAN and NaN shouldn't import as they've been removed) - but that's really out of my league - as there's no similar case at the moment (at least not in the NPY201 section).
Obviously, this would "also" apply to essentially all other cases of deprecations.

## Test Plan

Added testcase, manual test