### PR TITLE
Use `indentation` consistently

### DIFF
--- a/crates/ruff_formatter/src/builders.rs
+++ b/crates/ruff_formatter/src/builders.rs
@@ -727,11 +727,11 @@ impl<Context> std::fmt::Debug for Indent<'_, Context> {
     }
 }
 
-/// It reduces the indention for the given content depending on the closest [indent] or [align] parent element.
+/// It reduces the indentation for the given content depending on the closest [indent] or [align] parent element.
 /// - [align] Undoes the spaces added by [align]
-/// - [indent] Reduces the indention level by one
+/// - [indent] Reduces the indentation level by one
 ///
-/// This is a No-op if the indention level is zero.
+/// This is a No-op if the indentation level is zero.
 ///
 /// # Examples
 ///
@@ -863,7 +863,7 @@ where
 ///
 /// # Examples
 ///
-/// ## Tab indention
+/// ## Tab indentation
 ///
 /// ```
 /// use std::num::NonZeroU8;
@@ -904,11 +904,11 @@ where
 ///
 /// - the printer indents the function's `}` by two spaces because it is inside of an `align`.
 /// - the block `console.log` gets indented by two tabs.
-///   This is because `align` increases the indention level by one (same as `indent`)
+///   This is because `align` increases the indentation level by one (same as `indent`)
 ///   if you nest an `indent` inside an `align`.
-///   Meaning that, `align > ... > indent` results in the same indention as `indent > ... > indent`.
+///   Meaning that, `align > ... > indent` results in the same indentation as `indent > ... > indent`.
 ///
-/// ## Spaces indention
+/// ## Spaces indentation
 ///
 /// ```
 /// use std::num::NonZeroU8;
@@ -952,11 +952,11 @@ where
 /// # }
 /// ```
 ///
-/// The printing of `align` differs if using spaces as indention sequence *and* it contains an `indent`.
-/// You can see the difference when comparing the indention of the `console.log(...)` expression to the previous example:
+/// The printing of `align` differs if using spaces as indentation sequence *and* it contains an `indent`.
+/// You can see the difference when comparing the indentation of the `console.log(...)` expression to the previous example:
 ///
-/// - tab indention: Printer indents the expression with two tabs because the `align` increases the indention level.
-/// - space indention: Printer indents the expression by 4 spaces (one indention level) **and** 2 spaces for the align.
+/// - tab indentation: Printer indents the expression with two tabs because the `align` increases the indentation level.
+/// - space indentation: Printer indents the expression by 4 spaces (one indentation level) **and** 2 spaces for the align.
 pub fn align<Content, Context>(count: u8, content: &Content) -> Align<Context>
 where
     Content: Format<Context>,
@@ -992,12 +992,12 @@ impl<Context> std::fmt::Debug for Align<'_, Context> {
     }
 }
 
-/// Inserts a hard line break before and after the content and increases the indention level for the content by one.
+/// Inserts a hard line break before and after the content and increases the indentation level for the content by one.
 ///
 /// Block indents indent a block of code, such as in a function body, and therefore insert a line
 /// break before and after the content.
 ///
-/// Doesn't create an indention if the passed in content is [`FormatElement.is_empty`].
+/// Doesn't create an indentation if the passed in content is [`FormatElement.is_empty`].
 ///
 /// # Examples
 ///
@@ -1035,7 +1035,7 @@ pub fn block_indent<Context>(content: &impl Format<Context>) -> BlockIndent<Cont
 }
 
 /// Indents the content by inserting a line break before and after the content and increasing
-/// the indention level for the content by one if the enclosing group doesn't fit on a single line.
+/// the indentation level for the content by one if the enclosing group doesn't fit on a single line.
 /// Doesn't change the formatting if the enclosing group fits on a single line.
 ///
 /// # Examples
@@ -2057,7 +2057,7 @@ impl<Context> std::fmt::Debug for IfGroupBreaks<'_, Context> {
 /// If you want to indent some content if the enclosing group breaks, use [`indent`].
 ///
 /// Use [`if_group_breaks`] or [`if_group_fits_on_line`] if the fitting and breaking content differs more than just the
-/// indention level.
+/// indentation level.
 ///
 /// # Examples
 ///

--- a/crates/ruff_formatter/src/format_element/tag.rs
+++ b/crates/ruff_formatter/src/format_element/tag.rs
@@ -20,7 +20,7 @@ pub enum Tag {
     StartAlign(Align),
     EndAlign,
 
-    /// Reduces the indention of the specified content either by one level or to the root, depending on the mode.
+    /// Reduces the indentation of the specified content either by one level or to the root, depending on the mode.
     /// Reverse operation of `Indent` and can be used to *undo* an `Align` for nested content.
     StartDedent(DedentMode),
     EndDedent,

--- a/crates/ruff_formatter/src/printer/call_stack.rs
+++ b/crates/ruff_formatter/src/printer/call_stack.rs
@@ -1,7 +1,7 @@
 use crate::format_element::tag::TagKind;
 use crate::format_element::PrintMode;
 use crate::printer::stack::{Stack, StackedStack};
-use crate::printer::{Indention, MeasureMode};
+use crate::printer::{Indentation, MeasureMode};
 use crate::{IndentStyle, InvalidDocumentError, PrintError, PrintResult};
 use std::fmt::Debug;
 use std::num::NonZeroU8;
@@ -26,13 +26,13 @@ pub(super) struct StackFrame {
 /// data structures. Such structures should be stored on the [`PrinterState`] instead.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub(super) struct PrintElementArgs {
-    indent: Indention,
+    indent: Indentation,
     mode: PrintMode,
     measure_mode: MeasureMode,
 }
 
 impl PrintElementArgs {
-    pub(crate) fn new(indent: Indention) -> Self {
+    pub(crate) fn new(indent: Indentation) -> Self {
         Self {
             indent,
             ..Self::default()
@@ -47,7 +47,7 @@ impl PrintElementArgs {
         self.measure_mode
     }
 
-    pub(super) fn indention(self) -> Indention {
+    pub(super) fn indentation(self) -> Indentation {
         self.indent
     }
 
@@ -62,7 +62,7 @@ impl PrintElementArgs {
     }
 
     pub(crate) fn reset_indent(mut self) -> Self {
-        self.indent = Indention::default();
+        self.indent = Indentation::default();
         self
     }
 
@@ -85,7 +85,7 @@ impl PrintElementArgs {
 impl Default for PrintElementArgs {
     fn default() -> Self {
         Self {
-            indent: Indention::Level(0),
+            indent: Indentation::Level(0),
             mode: PrintMode::Expanded,
             measure_mode: MeasureMode::FirstLine,
         }

--- a/crates/ruff_python_codegen/src/stylist.rs
+++ b/crates/ruff_python_codegen/src/stylist.rs
@@ -36,7 +36,7 @@ impl<'a> Stylist<'a> {
     }
 
     pub fn from_tokens(tokens: &Tokens, locator: &'a Locator<'a>) -> Self {
-        let indentation = detect_indention(tokens, locator);
+        let indentation = detect_indentation(tokens, locator);
 
         Self {
             locator,
@@ -60,7 +60,7 @@ fn detect_quote(tokens: &[Token]) -> Quote {
     Quote::default()
 }
 
-fn detect_indention(tokens: &[Token], locator: &Locator) -> Indentation {
+fn detect_indentation(tokens: &[Token], locator: &Locator) -> Indentation {
     let indent_range = tokens.iter().find_map(|token| {
         if matches!(token.kind(), TokenKind::Indent) {
             Some(token.range())
@@ -204,7 +204,7 @@ x = (
         let stylist = Stylist::from_tokens(parsed.tokens(), &locator);
         assert_eq!(stylist.indentation(), &Indentation("  ".to_string()));
 
-        // formfeed indent, see `detect_indention` comment.
+        // formfeed indent, see `detect_indentation` comment.
         let contents = r"
 class FormFeedIndent:
    def __init__(self, a=[]):


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

This was [discussed](https://discord.com/channels/1039017663004942429/1070132471699607623/1258392448569184417) previously on Discord, and then found out _indention_ was used in multiple places in the code. _indentation_ was used more than _indention_, so figured it would be easier to replace the existing _indention_ usage to _indentation_.

## Test Plan

<!-- How was it tested? -->
