### PR TITLE
[red-knot] Add notebook support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2088,6 +2088,7 @@ dependencies = [
  "filetime",
  "ignore",
  "insta",
+ "ruff_notebook",
  "ruff_python_ast",
  "ruff_python_parser",
  "ruff_source_file",

--- a/crates/red_knot_module_resolver/src/typeshed/versions.rs
+++ b/crates/red_knot_module_resolver/src/typeshed/versions.rs
@@ -10,7 +10,6 @@ use ruff_db::system::SystemPath;
 use rustc_hash::FxHashMap;
 
 use ruff_db::files::{system_path_to_file, File};
-use ruff_db::source::source_text;
 
 use crate::db::Db;
 use crate::module_name::ModuleName;
@@ -74,7 +73,10 @@ pub(crate) fn parse_typeshed_versions(
     db: &dyn Db,
     versions_file: File,
 ) -> Result<TypeshedVersions, TypeshedVersionsParseError> {
-    let file_content = source_text(db.upcast(), versions_file);
+    // TODO: Handle IO errors
+    let file_content = versions_file
+        .read_to_string(db.upcast())
+        .unwrap_or_default();
     file_content.parse()
 }
 

--- a/crates/ruff_db/Cargo.toml
+++ b/crates/ruff_db/Cargo.toml
@@ -11,6 +11,7 @@ repository = { workspace = true }
 license = { workspace = true }
 
 [dependencies]
+ruff_notebook = { workspace = true }
 ruff_python_ast = { workspace = true }
 ruff_python_parser = { workspace = true }
 ruff_source_file = { workspace = true }

--- a/crates/ruff_db/src/source.rs
+++ b/crates/ruff_db/src/source.rs
@@ -1,47 +1,83 @@
-use countme::Count;
-use ruff_source_file::LineIndex;
-use salsa::DebugWithDb;
 use std::ops::Deref;
 use std::sync::Arc;
+
+use countme::Count;
+use salsa::DebugWithDb;
+
+use ruff_notebook::Notebook;
+use ruff_python_ast::PySourceType;
+use ruff_source_file::LineIndex;
 
 use crate::files::File;
 use crate::Db;
 
-/// Reads the content of file.
+/// Reads the source text of a python text file (must be valid UTF8) or notebook.
 #[salsa::tracked]
 pub fn source_text(db: &dyn Db, file: File) -> SourceText {
     let _span = tracing::trace_span!("source_text", ?file).entered();
 
-    let content = file.read_to_string(db);
+    if let Some(path) = file.path(db).as_system_path() {
+        if path.extension().is_some_and(|extension| {
+            PySourceType::try_from_extension(extension) == Some(PySourceType::Ipynb)
+        }) {
+            // TODO(micha): Proper error handling and emit a diagnostic. Tackle it together with `source_text`.
+            let notebook = db.system().read_to_notebook(path).unwrap_or_else(|error| {
+                tracing::error!("Failed to load notebook: {error}");
+                Notebook::empty()
+            });
+
+            return SourceText {
+                inner: Arc::new(SourceTextInner {
+                    kind: SourceTextKind::Notebook(notebook),
+                    count: Count::new(),
+                }),
+            };
+        }
+    };
+
+    let content = file.read_to_string(db).unwrap_or_else(|error| {
+        tracing::error!("Failed to load file: {error}");
+        String::default()
+    });
 
     SourceText {
-        inner: Arc::from(content),
-        count: Count::new(),
+        inner: Arc::new(SourceTextInner {
+            kind: SourceTextKind::Text(content),
+            count: Count::new(),
+        }),
     }
 }
 
-/// Computes the [`LineIndex`] for `file`.
-#[salsa::tracked]
-pub fn line_index(db: &dyn Db, file: File) -> LineIndex {
-    let _span = tracing::trace_span!("line_index", file = ?file.debug(db)).entered();
-
-    let source = source_text(db, file);
-
-    LineIndex::from_source_text(&source)
-}
-
-/// The source text of a [`File`].
+/// The source text of a file containing python code.
+///
+/// The file containing the source text can either be a text file or a notebook.
 ///
 /// Cheap cloneable in `O(1)`.
 #[derive(Clone, Eq, PartialEq)]
 pub struct SourceText {
-    inner: Arc<str>,
-    count: Count<Self>,
+    inner: Arc<SourceTextInner>,
 }
 
 impl SourceText {
+    /// Returns the python code as a `str`.
     pub fn as_str(&self) -> &str {
-        &self.inner
+        match &self.inner.kind {
+            SourceTextKind::Text(source) => source,
+            SourceTextKind::Notebook(notebook) => notebook.source_code(),
+        }
+    }
+
+    /// Returns the underlying notebook if this is a notebook file.
+    pub fn as_notebook(&self) -> Option<&Notebook> {
+        match &self.inner.kind {
+            SourceTextKind::Notebook(notebook) => Some(notebook),
+            SourceTextKind::Text(_) => None,
+        }
+    }
+
+    /// Returns `true` if this is a notebook source file.
+    pub fn is_notebook(&self) -> bool {
+        matches!(&self.inner.kind, SourceTextKind::Notebook(_))
     }
 }
 
@@ -55,20 +91,54 @@ impl Deref for SourceText {
 
 impl std::fmt::Debug for SourceText {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_tuple("SourceText").field(&self.inner).finish()
+        let mut dbg = f.debug_tuple("SourceText");
+
+        match &self.inner.kind {
+            SourceTextKind::Text(text) => {
+                dbg.field(text);
+            }
+            SourceTextKind::Notebook(notebook) => {
+                dbg.field(notebook);
+            }
+        }
+
+        dbg.finish()
     }
+}
+
+#[derive(Eq, PartialEq)]
+struct SourceTextInner {
+    count: Count<SourceText>,
+    kind: SourceTextKind,
+}
+
+#[derive(Eq, PartialEq)]
+enum SourceTextKind {
+    Text(String),
+    Notebook(Notebook),
+}
+
+/// Computes the [`LineIndex`] for `file`.
+#[salsa::tracked]
+pub fn line_index(db: &dyn Db, file: File) -> LineIndex {
+    let _span = tracing::trace_span!("line_index", file = ?file.debug(db)).entered();
+
+    let source = source_text(db, file);
+
+    LineIndex::from_source_text(&source)
 }
 
 #[cfg(test)]
 mod tests {
     use salsa::EventKind;
 
+    use ruff_source_file::OneIndexed;
+    use ruff_text_size::TextSize;
+
     use crate::files::system_path_to_file;
     use crate::source::{line_index, source_text};
     use crate::system::{DbWithTestSystem, SystemPath};
     use crate::tests::TestDb;
-    use ruff_source_file::OneIndexed;
-    use ruff_text_size::TextSize;
 
     #[test]
     fn re_runs_query_when_file_revision_changes() -> crate::system::Result<()> {
@@ -79,11 +149,11 @@ mod tests {
 
         let file = system_path_to_file(&db, path).unwrap();
 
-        assert_eq!(&*source_text(&db, file), "x = 10");
+        assert_eq!(source_text(&db, file).as_str(), "x = 10");
 
         db.write_file(path, "x = 20".to_string()).unwrap();
 
-        assert_eq!(&*source_text(&db, file), "x = 20");
+        assert_eq!(source_text(&db, file).as_str(), "x = 20");
 
         Ok(())
     }
@@ -97,13 +167,13 @@ mod tests {
 
         let file = system_path_to_file(&db, path).unwrap();
 
-        assert_eq!(&*source_text(&db, file), "x = 10");
+        assert_eq!(source_text(&db, file).as_str(), "x = 10");
 
         // Change the file permission only
         file.set_permissions(&mut db).to(Some(0o777));
 
         db.clear_salsa_events();
-        assert_eq!(&*source_text(&db, file), "x = 10");
+        assert_eq!(source_text(&db, file).as_str(), "x = 10");
 
         let events = db.take_salsa_events();
 
@@ -123,13 +193,53 @@ mod tests {
 
         let file = system_path_to_file(&db, path).unwrap();
         let index = line_index(&db, file);
-        let text = source_text(&db, file);
+        let source = source_text(&db, file);
 
         assert_eq!(index.line_count(), 2);
         assert_eq!(
-            index.line_start(OneIndexed::from_zero_indexed(0), &text),
+            index.line_start(OneIndexed::from_zero_indexed(0), source.as_str()),
             TextSize::new(0)
         );
+
+        Ok(())
+    }
+
+    #[test]
+    fn notebook() -> crate::system::Result<()> {
+        let mut db = TestDb::new();
+
+        let path = SystemPath::new("test.ipynb");
+        db.write_file(
+            path,
+            r#"
+{
+    "cells": [{"cell_type": "code", "source": ["x = 10"], "metadata": {}, "outputs": []}],
+    "metadata": {
+        "kernelspec": {
+            "display_name": "Python (ruff)",
+            "language": "python",
+            "name": "ruff"
+        },
+        "language_info": {
+            "file_extension": ".py",
+            "mimetype": "text/x-python",
+            "name": "python",
+            "nbconvert_exporter": "python",
+            "pygments_lexer": "ipython3",
+            "version": "3.11.3"
+        }
+     },
+     "nbformat": 4,
+     "nbformat_minor": 4
+}"#,
+        )?;
+
+        let file = system_path_to_file(&db, path).unwrap();
+        let source = source_text(&db, file);
+
+        assert!(source.is_notebook());
+        assert_eq!(source.as_str(), "x = 10\n");
+        assert!(source.as_notebook().is_some());
 
         Ok(())
     }

--- a/crates/ruff_db/src/system.rs
+++ b/crates/ruff_db/src/system.rs
@@ -3,6 +3,7 @@ use std::fmt::Debug;
 pub use memory_fs::MemoryFileSystem;
 #[cfg(feature = "os")]
 pub use os::OsSystem;
+use ruff_notebook::{Notebook, NotebookError};
 pub use test::{DbWithTestSystem, TestSystem};
 use walk_directory::WalkDirectoryBuilder;
 
@@ -39,6 +40,13 @@ pub trait System: Debug {
 
     /// Reads the content of the file at `path` into a [`String`].
     fn read_to_string(&self, path: &SystemPath) -> Result<String>;
+
+    /// Reads the content of the file at `path` as a Notebook.
+    ///
+    /// This method optimizes for the case where the system holds a structured representation of a [`Notebook`],
+    /// allowing to skip the notebook deserialization. Systems that don't use a structured
+    /// representation fall-back to deserializing the notebook from a string.
+    fn read_to_notebook(&self, path: &SystemPath) -> std::result::Result<Notebook, NotebookError>;
 
     /// Returns `true` if `path` exists.
     fn path_exists(&self, path: &SystemPath) -> bool {

--- a/crates/ruff_db/src/system/memory_fs.rs
+++ b/crates/ruff_db/src/system/memory_fs.rs
@@ -126,6 +126,14 @@ impl MemoryFileSystem {
         read_to_string(self, path.as_ref())
     }
 
+    pub(crate) fn read_to_notebook(
+        &self,
+        path: impl AsRef<SystemPath>,
+    ) -> std::result::Result<ruff_notebook::Notebook, ruff_notebook::NotebookError> {
+        let content = self.read_to_string(path)?;
+        ruff_notebook::Notebook::from_source_code(&content)
+    }
+
     pub fn exists(&self, path: &SystemPath) -> bool {
         let by_path = self.inner.by_path.read().unwrap();
         let normalized = self.normalize_path(path);

--- a/crates/ruff_db/src/system/os.rs
+++ b/crates/ruff_db/src/system/os.rs
@@ -1,9 +1,13 @@
+use std::sync::Arc;
+use std::{any::Any, path::PathBuf};
+
+use filetime::FileTime;
+
+use ruff_notebook::{Notebook, NotebookError};
+
 use crate::system::{
     DirectoryEntry, FileType, Metadata, Result, System, SystemPath, SystemPathBuf,
 };
-use filetime::FileTime;
-use std::sync::Arc;
-use std::{any::Any, path::PathBuf};
 
 use super::walk_directory::{
     self, DirectoryWalker, WalkDirectoryBuilder, WalkDirectoryConfiguration,
@@ -63,6 +67,10 @@ impl System for OsSystem {
 
     fn read_to_string(&self, path: &SystemPath) -> Result<String> {
         std::fs::read_to_string(path.as_std_path())
+    }
+
+    fn read_to_notebook(&self, path: &SystemPath) -> std::result::Result<Notebook, NotebookError> {
+        Notebook::from_path(path.as_std_path())
     }
 
     fn path_exists(&self, path: &SystemPath) -> bool {
@@ -266,10 +274,12 @@ impl From<WalkState> for ignore::WalkState {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use tempfile::TempDir;
+
     use crate::system::walk_directory::tests::DirectoryEntryToString;
     use crate::system::DirectoryEntry;
-    use tempfile::TempDir;
+
+    use super::*;
 
     #[test]
     fn read_directory() {

--- a/crates/ruff_db/src/system/test.rs
+++ b/crates/ruff_db/src/system/test.rs
@@ -1,3 +1,5 @@
+use ruff_notebook::{Notebook, NotebookError};
+
 use crate::files::File;
 use crate::system::{DirectoryEntry, MemoryFileSystem, Metadata, Result, System, SystemPath};
 use crate::Db;
@@ -50,14 +52,21 @@ impl System for TestSystem {
     fn path_metadata(&self, path: &SystemPath) -> crate::system::Result<Metadata> {
         match &self.inner {
             TestSystemInner::Stub(fs) => fs.metadata(path),
-            TestSystemInner::System(fs) => fs.path_metadata(path),
+            TestSystemInner::System(system) => system.path_metadata(path),
         }
     }
 
     fn read_to_string(&self, path: &SystemPath) -> crate::system::Result<String> {
         match &self.inner {
             TestSystemInner::Stub(fs) => fs.read_to_string(path),
-            TestSystemInner::System(fs) => fs.read_to_string(path),
+            TestSystemInner::System(system) => system.read_to_string(path),
+        }
+    }
+
+    fn read_to_notebook(&self, path: &SystemPath) -> std::result::Result<Notebook, NotebookError> {
+        match &self.inner {
+            TestSystemInner::Stub(fs) => fs.read_to_notebook(path),
+            TestSystemInner::System(system) => system.read_to_notebook(path),
         }
     }
 

--- a/crates/ruff_notebook/src/schema.rs
+++ b/crates/ruff_notebook/src/schema.rs
@@ -161,7 +161,7 @@ pub struct CodeCell {
 
 /// Notebook root-level metadata.
 #[skip_serializing_none]
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Default)]
 pub struct RawNotebookMetadata {
     /// The author(s) of the notebook document
     pub authors: Option<Value>,

--- a/crates/ruff_python_ast/src/lib.rs
+++ b/crates/ruff_python_ast/src/lib.rs
@@ -86,12 +86,19 @@ impl PySourceType {
     ///
     /// Falls back to `Python` if the extension is not recognized.
     pub fn from_extension(extension: &str) -> Self {
-        match extension {
+        Self::try_from_extension(extension).unwrap_or_default()
+    }
+
+    /// Infers the source type from the file extension.
+    pub fn try_from_extension(extension: &str) -> Option<Self> {
+        let ty = match extension {
             "py" => Self::Python,
             "pyi" => Self::Stub,
             "ipynb" => Self::Ipynb,
-            _ => Self::Python,
-        }
+            _ => return None,
+        };
+
+        Some(ty)
     }
 }
 


### PR DESCRIPTION
## Summary

This PR adds notebook support to red knot. 

The way notebooks are handled in Ruff is that it parses the notebook and concatenates the content of all cells to a single string. The concatenated string is then passed to the linter or formatter. Reported diagnostics are mapped back to their origin cells by using a source map. 

This PR doesn't implement any of the fancy re-mapping logic but adds support for reading notebooks into a structured representation. This requires two additions:

* A new `System::read_to_notebook` method that reads a system path to a `Notebook`. The motivation for this method is that the LSP uses a structured notebook representation (slightly different from the representation used by `ruff_notebook`) that's cheaper to convert to a `ruff_notebook::Notebook` then reparsing the notebook from source.
* I renamed `SourceCode` to `SourceFile` and changed it to use an internal enum that is either `Text` or `Notebook` to account for the fact that a file can either be a text or notebook.


## Open questions

I'm not too happy with the name `SourceFile`. I'm open for better suggestions but I also don't want to block the PR on finding the perfect name (the query is used very sparsely and a rename is quickly done)


## Cell and embedded file support

I intentionally excluded support for cell-based queries or a design for supporting embedded files (e.g. a doctest block in a python file). I think we could support both and a way of doing it could be to:

* Make `SourceFile` a salsa tracked struct
* Add additional `Cell` and `Embedded` variants that either store another salsa tracked struct, or at least store the origin file id and an index to identify the cell or embed in the file. 

Methods that can operate on any source-file would be changed to accept a `SourceFile` instead of a `File` argument. However, it's unclear if we want this:

* The only use case for a cell-level granular query today is to format a single cell. Formatting a single cell is so fast that it doesn't justifies creating a query for it. 
* It's unclear if we have many queries that can operate on any file content or if this is more a one-off, in which case `Cell` and `Embed` could be salsa tracked structs and we define `format_cell` and `parse_cell` etc. queries rather than having one generic `parse` query.
* An alternative is to introduce a new salsa tracked on top of `SourceFile` with the variants `File`, `Embed`, and `Cell`. 

## Test Plan

I added a notebook file to my test folder and verified that Red Knot runs the lint rules on its content.