### PR TITLE
[red-knot] Improve debuggability

### DIFF
--- a/crates/red_knot/src/program/mod.rs
+++ b/crates/red_knot/src/program/mod.rs
@@ -1,3 +1,4 @@
+use std::fmt;
 use std::panic::{AssertUnwindSafe, RefUnwindSafe};
 use std::sync::Arc;
 
@@ -96,6 +97,21 @@ impl Upcast<dyn SourceDb> for Program {
 impl Upcast<dyn ResolverDb> for Program {
     fn upcast(&self) -> &(dyn ResolverDb + 'static) {
         self
+    }
+}
+
+impl fmt::Debug for Program {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let Program {
+            storage: _,
+            files: _,
+            system,
+            workspace,
+        } = self;
+        f.debug_struct("TestDb")
+            .field("system", system)
+            .field("workspace", workspace)
+            .finish()
     }
 }
 

--- a/crates/red_knot_module_resolver/src/db.rs
+++ b/crates/red_knot_module_resolver/src/db.rs
@@ -20,6 +20,7 @@ pub trait Db: salsa::DbWithJar<Jar> + ruff_db::Db + Upcast<dyn ruff_db::Db> {}
 
 #[cfg(test)]
 pub(crate) mod tests {
+    use std::fmt;
     use std::sync;
 
     use salsa::DebugWithDb;
@@ -75,6 +76,24 @@ pub(crate) mod tests {
     impl Upcast<dyn ruff_db::Db> for TestDb {
         fn upcast(&self) -> &(dyn ruff_db::Db + 'static) {
             self
+        }
+    }
+
+    impl fmt::Debug for TestDb {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            let TestDb {
+                storage: _,
+                system,
+                vendored,
+                files: _,
+                events,
+            } = self;
+            let num_salsa_events = events.lock().unwrap().len();
+            f.debug_struct("TestDb")
+                .field("system", system)
+                .field("vendored", vendored)
+                .field("total_salsa_events", &num_salsa_events)
+                .finish()
         }
     }
 

--- a/crates/red_knot_module_resolver/src/state.rs
+++ b/crates/red_knot_module_resolver/src/state.rs
@@ -5,6 +5,7 @@ use crate::db::Db;
 use crate::supported_py_version::TargetVersion;
 use crate::typeshed::LazyTypeshedVersions;
 
+#[derive(Debug)]
 pub(crate) struct ResolverState<'db> {
     pub(crate) db: &'db dyn Db,
     pub(crate) typeshed_versions: LazyTypeshedVersions<'db>,

--- a/crates/red_knot_module_resolver/src/testing.rs
+++ b/crates/red_knot_module_resolver/src/testing.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use ruff_db::system::{DbWithTestSystem, SystemPath, SystemPathBuf};
 use ruff_db::vendored::VendoredPathBuf;
 
@@ -9,6 +11,7 @@ use crate::supported_py_version::TargetVersion;
 ///
 /// You generally shouldn't construct instances of this struct directly;
 /// instead, use the [`TestCaseBuilder`].
+#[derive(Debug)]
 pub(crate) struct TestCase<T> {
     pub(crate) db: TestDb,
     pub(crate) src: SystemPathBuf,
@@ -94,14 +97,15 @@ pub(crate) struct UnspecifiedTypeshed;
 /// If you have not called one of those options, the `stdlib` field
 /// on the [`TestCase`] instance created from `.build()` will be set
 /// to `()`.
-pub(crate) struct TestCaseBuilder<T> {
+#[derive(Debug)]
+pub(crate) struct TestCaseBuilder<T: fmt::Debug> {
     typeshed_option: T,
     target_version: TargetVersion,
     first_party_files: Vec<FileSpec>,
     site_packages_files: Vec<FileSpec>,
 }
 
-impl<T> TestCaseBuilder<T> {
+impl<T: fmt::Debug> TestCaseBuilder<T> {
     /// Specify files to be created in the `src` mock directory
     pub(crate) fn with_src_files(mut self, files: &[FileSpec]) -> Self {
         self.first_party_files.extend(files.iter().copied());

--- a/crates/red_knot_python_semantic/src/db.rs
+++ b/crates/red_knot_python_semantic/src/db.rs
@@ -35,6 +35,7 @@ pub trait Db:
 
 #[cfg(test)]
 pub(crate) mod tests {
+    use std::fmt;
     use std::sync::Arc;
 
     use salsa::DebugWithDb;
@@ -84,6 +85,24 @@ pub(crate) mod tests {
         /// If there are any pending salsa snapshots.
         pub(crate) fn clear_salsa_events(&mut self) {
             self.take_salsa_events();
+        }
+    }
+
+    impl fmt::Debug for TestDb {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            let TestDb {
+                storage: _,
+                files: _,
+                system,
+                vendored,
+                events,
+            } = self;
+            let num_events = events.lock().unwrap().len();
+            f.debug_struct("TestDb")
+                .field("system", system)
+                .field("total_salsa_events", &num_events)
+                .field("vendored", vendored)
+                .finish_non_exhaustive()
         }
     }
 


### PR DESCRIPTION
## Summary

This PR requires that all implementers of `ruff_db::db::Db` also implement `Debug`. The reason for doing this is it makes it much easier to debug variables that are typed as `&'db dyn Db`, and it means that we can simply `#[derive(Debug)]` on structs that have `db: &'db dyn Db` fields.

`Debug` needs to be manually implemented for all `TestDb` and `Program` classes, unfortunately, as `salsa::Storage` does not implement `Debug`, and all `TestDb` structs have a field of type `salsa::Storage`.
