### PR TITLE
Ignore more OpenAI notebooks with syntax errors in the ecosystem check

### DIFF
--- a/python/ruff-ecosystem/ruff_ecosystem/defaults.py
+++ b/python/ruff-ecosystem/ruff_ecosystem/defaults.py
@@ -123,6 +123,8 @@ DEFAULT_TARGETS = [
             "exclude": [
                 "examples/gpt_actions_library/.gpt_action_getting_started.ipynb",
                 "examples/gpt_actions_library/gpt_action_bigquery.ipynb",
+                "examples/chatgpt/gpt_actions_library/.gpt_action_getting_started.ipynb",
+                "examples/chatgpt/gpt_actions_library/gpt_action_bigquery.ipynb",
             ],
         },
     ),


### PR DESCRIPTION
## Summary

Ignore more OpenAI notebooks that make the ecosystem checks fail.

## Test Plan

CI
