### PR TITLE
[red-knot] Reload notebook on file change

### DIFF
--- a/crates/red_knot/src/lint.rs
+++ b/crates/red_knot/src/lint.rs
@@ -103,7 +103,7 @@ fn lint_unresolved_imports(context: &SemanticLintContext, import: AnyImportRef) 
             for alias in &import.names {
                 let ty = alias.ty(&context.semantic);
 
-                if ty.is_unknown() {
+                if ty.is_unbound() {
                     context.push_diagnostic(format!("Unresolved import '{}'", &alias.name));
                 }
             }
@@ -112,7 +112,7 @@ fn lint_unresolved_imports(context: &SemanticLintContext, import: AnyImportRef) 
             for alias in &import.names {
                 let ty = alias.ty(&context.semantic);
 
-                if ty.is_unknown() {
+                if ty.is_unbound() {
                     context.push_diagnostic(format!("Unresolved import '{}'", &alias.name));
                 }
             }

--- a/crates/ruff_db/src/source.rs
+++ b/crates/ruff_db/src/source.rs
@@ -21,7 +21,7 @@ pub fn source_text(db: &dyn Db, file: File) -> SourceText {
             PySourceType::try_from_extension(extension) == Some(PySourceType::Ipynb)
         }) {
             // TODO(micha): Proper error handling and emit a diagnostic. Tackle it together with `source_text`.
-            let notebook = db.system().read_to_notebook(path).unwrap_or_else(|error| {
+            let notebook = file.read_to_notebook(db).unwrap_or_else(|error| {
                 tracing::error!("Failed to load notebook: {error}");
                 Notebook::empty()
             });


### PR DESCRIPTION
## Summary

During a VC with Alex I noticed that I forgot to add a dependency on the `File`'s revision when reading notebooks. 
The implication of this is that a notebook file never gets reloaded. 

This PR adds a new `File::read_to_notebook` method similar to `File::read_to_string` that correctly adds the `revision` dependency.

## Test Plan

I verified that adding an unknown import to a notebook after starting Red Knot triggers a re-run and that it emits a diagnostic for the import
