### PR TITLE
Use fallback settings when indexing the project

### DIFF
--- a/crates/ruff_server/src/session/index/ruff_settings.rs
+++ b/crates/ruff_server/src/session/index/ruff_settings.rs
@@ -172,7 +172,7 @@ impl RuffSettingsIndex {
 
                     if match_exclusion(&directory, file_name, &settings.file_resolver.exclude) {
                         tracing::debug!("Ignored path via `exclude`: {}", directory.display());
-                        return WalkState::Continue;
+                        return WalkState::Skip;
                     } else if match_exclusion(
                         &directory,
                         file_name,
@@ -182,7 +182,7 @@ impl RuffSettingsIndex {
                             "Ignored path via `extend-exclude`: {}",
                             directory.display()
                         );
-                        return WalkState::Continue;
+                        return WalkState::Skip;
                     }
                 }
 


### PR DESCRIPTION
## Summary

This PR updates the settings index building logic in the language server to consider the fallback settings for applying ignore filters in `WalkBuilder` and the exclusion via `exclude` / `extend-exclude`.

This flow matches the one in the `ruff` CLI where the root settings is built by (1) finding the workspace setting in the ancestor directory (2) finding the user configuration if that's missing and (3) fallback to using the default configuration.

Previously, the index building logic was being executed before (2) and (3). This PR reverses the logic so that the exclusion / `respect_gitignore` is being considered from the default settings if there's no workspace / user settings. This has the benefit that the server no longer enters the `.git` directory or any other excluded directory when a user opens a file in the home directory.

Related to #11366

## Test plan

Opened a test file from the home directory and confirmed with the debug trace (removed in #12360) that the server excludes the `.git` directory when indexing.