### PR TITLE
[red-knot] small efficiency improvements and bugfixes to use-def map building

### DIFF
--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -1095,6 +1095,87 @@ mod tests {
     }
 
     #[test]
+    fn if_elif_else_single_symbol() -> anyhow::Result<()> {
+        let mut db = setup_db();
+
+        db.write_dedented(
+            "src/a.py",
+            "
+            if flag:
+                y = 1
+            elif flag2:
+                y = 2
+            else:
+                y = 3
+            ",
+        )?;
+
+        assert_public_ty(&db, "src/a.py", "y", "Literal[1, 2, 3]");
+        Ok(())
+    }
+
+    #[test]
+    fn if_elif_else_no_definition_in_else() -> anyhow::Result<()> {
+        let mut db = setup_db();
+
+        db.write_dedented(
+            "src/a.py",
+            "
+            y = 0
+            if flag:
+                y = 1
+            elif flag2:
+                y = 2
+            else:
+                pass
+            ",
+        )?;
+
+        assert_public_ty(&db, "src/a.py", "y", "Literal[0, 1, 2]");
+        Ok(())
+    }
+
+    #[test]
+    fn if_elif_else_no_definition_in_else_one_intervening_definition() -> anyhow::Result<()> {
+        let mut db = setup_db();
+
+        db.write_dedented(
+            "src/a.py",
+            "
+            y = 0
+            if flag:
+                y = 1
+                z = 3
+            elif flag2:
+                y = 2
+            else:
+                pass
+            ",
+        )?;
+
+        assert_public_ty(&db, "src/a.py", "y", "Literal[0, 1, 2]");
+        Ok(())
+    }
+
+    #[test]
+    fn nested_if() -> anyhow::Result<()> {
+        let mut db = setup_db();
+
+        db.write_dedented(
+            "src/a.py",
+            "
+            y = 0
+            if flag:
+                if flag2:
+                    y = 1
+            ",
+        )?;
+
+        assert_public_ty(&db, "src/a.py", "y", "Literal[0, 1]");
+        Ok(())
+    }
+
+    #[test]
     fn if_elif() -> anyhow::Result<()> {
         let mut db = setup_db();
 

--- a/crates/ruff_index/src/slice.rs
+++ b/crates/ruff_index/src/slice.rs
@@ -81,6 +81,13 @@ impl<I: Idx, T> IndexSlice<I, T> {
     }
 
     #[inline]
+    pub fn iter_mut_enumerated(
+        &mut self,
+    ) -> impl DoubleEndedIterator<Item = (I, &mut T)> + ExactSizeIterator + '_ {
+        self.raw.iter_mut().enumerate().map(|(n, t)| (I::new(n), t))
+    }
+
+    #[inline]
     pub fn last_index(&self) -> Option<I> {
         self.len().checked_sub(1).map(I::new)
     }


### PR DESCRIPTION
Adds inference tests sufficient to give full test coverage of the `UseDefMapBuilder::merge` method.

In the process I realized that we could implement visiting of if statements in `SemanticBuilder` with fewer `snapshot`, `restore`, and `merge` operations, so I restructured that visit a bit.

I also found one correctness bug in the `merge` method (it failed to extend the given snapshot with "unbound" for any missing symbols, meaning we would just lose the fact that the symbol could be unbound in the merged-in path), and two efficiency bugs (if one of the ranges to merge is empty, we can just use the other one, no need for copies, and if the ranges are overlapping -- which can occur with nested branches -- we can still just merge them with no copies), and fixed all three.