### PR TITLE
[red-knot] Use a distinct type for module search paths in the module resolver

### DIFF
--- a/crates/red_knot_module_resolver/src/db.rs
+++ b/crates/red_knot_module_resolver/src/db.rs
@@ -2,14 +2,14 @@ use ruff_db::Upcast;
 
 use crate::resolver::{
     editable_install_resolution_paths, file_to_module, internal::ModuleNameIngredient,
-    module_resolution_settings, resolve_module_query,
+    resolve_module_query, resolve_module_resolution_settings,
 };
 use crate::typeshed::parse_typeshed_versions;
 
 #[salsa::jar(db=Db)]
 pub struct Jar(
     ModuleNameIngredient<'_>,
-    module_resolution_settings,
+    resolve_module_resolution_settings,
     editable_install_resolution_paths,
     resolve_module_query,
     file_to_module,

--- a/crates/red_knot_module_resolver/src/lib.rs
+++ b/crates/red_knot_module_resolver/src/lib.rs
@@ -12,6 +12,7 @@ mod testing;
 pub use db::{Db, Jar};
 pub use module::{Module, ModuleKind};
 pub use module_name::ModuleName;
+pub use path::SearchPathValidationError;
 pub use resolver::resolve_module;
 pub use typeshed::{
     vendored_typeshed_stubs, TypeshedVersionsParseError, TypeshedVersionsParseErrorKind,

--- a/crates/red_knot_module_resolver/src/module.rs
+++ b/crates/red_knot_module_resolver/src/module.rs
@@ -5,7 +5,7 @@ use ruff_db::files::File;
 
 use crate::db::Db;
 use crate::module_name::ModuleName;
-use crate::path::{ModuleResolutionPathBuf, ModuleResolutionPathRef};
+use crate::path::ModuleSearchPath;
 
 /// Representation of a Python module.
 #[derive(Clone, PartialEq, Eq)]
@@ -17,7 +17,7 @@ impl Module {
     pub(crate) fn new(
         name: ModuleName,
         kind: ModuleKind,
-        search_path: Arc<ModuleResolutionPathBuf>,
+        search_path: ModuleSearchPath,
         file: File,
     ) -> Self {
         Self {
@@ -41,8 +41,8 @@ impl Module {
     }
 
     /// The search path from which the module was resolved.
-    pub(crate) fn search_path(&self) -> ModuleResolutionPathRef {
-        ModuleResolutionPathRef::from(&*self.inner.search_path)
+    pub(crate) fn search_path(&self) -> &ModuleSearchPath {
+        &self.inner.search_path
     }
 
     /// Determine whether this module is a single-file module or a package
@@ -77,7 +77,7 @@ impl salsa::DebugWithDb<dyn Db> for Module {
 struct ModuleInner {
     name: ModuleName,
     kind: ModuleKind,
-    search_path: Arc<ModuleResolutionPathBuf>,
+    search_path: ModuleSearchPath,
     file: File,
 }
 

--- a/crates/red_knot_module_resolver/src/testing.rs
+++ b/crates/red_knot_module_resolver/src/testing.rs
@@ -125,6 +125,8 @@ impl<T> TestCaseBuilder<T> {
         files: impl IntoIterator<Item = FileSpec>,
     ) -> SystemPathBuf {
         let root = location.as_ref().to_path_buf();
+        // Make sure to create the directory even if the list of files is empty:
+        db.memory_file_system().create_directory_all(&root).unwrap();
         db.write_files(
             files
                 .into_iter()


### PR DESCRIPTION
## Summary

This PR cleans up some of the settings validation and types in the module resolver. Namely:
- At various points in the crate, we use a type alias, a `ModuleResolutionPathBuf` or an `Arc<ModuleResolutionPathBuf>` to refer to a module search path. This PR goes some way to cleaning that up by introducing a newtype wrapper in `path.rs` for module-resolution paths that specifically represent _search paths_.
- Currently we validate that a `ModuleResolutionPathBuf` has either no extension, a `.pyi` extension or a `.py` extension. But for search paths specifically (which are the only module-resolution paths that are ever directly constructed), that's the wrong kind of validation for us to do: we should just validate that the path points to a directory.
- For custom typeshed directories, validate that a `<typeshed>/stdlib/` directory exists, that a `<typeshed>/stdlib/VERSIONS` file exists, and that the `VERSIONS` file parses.

This PR goes halfway to addressing @carljm's review comments in https://github.com/astral-sh/ruff/pull/12141#discussion_r1667010245. We now have a distinct type for representing search paths specifically outside of `path.rs`. However, internally, `path.rs` still doesn't make much distinction between search paths and other kinds of paths: it doesn't have to, because I implemented `Deref` for the new `ModuleSearchPath` struct; all methods available on `ModuleResolutionPathBuf` are implicitly available on `ModuleSearchPath`. This is somewhat lazy and unprincipled of me, and I've left a TODO comment to get rid of it. I spent much of yesterday trying to get to a more principled solution, but it ends up being a massive diff that rewrites much of `path.rs`, and I don't think it's a priority for now. I think this is a nice cleanup that clarifies the types and improves settings validation in the meantime, without being a massive rewrite that would be time-consuming to write and review.

## Test Plan

`cargo test -p red-knot_module_resolver`. I haven't added any new tests specifically as part of this PR, but I'm happy to if you'd find them useful, either as this PR or as a followup.
