### PR TITLE
[red-knot] Fix bug where module resolution would not be invalidated if an entire package was deleted

### DIFF
--- a/crates/red_knot_module_resolver/src/path.rs
+++ b/crates/red_knot_module_resolver/src/path.rs
@@ -369,10 +369,9 @@ impl<'a> ModuleResolutionPathRefInner<'a> {
 
     #[must_use]
     fn is_regular_package(&self, search_path: Self, resolver: &ResolverState) -> bool {
-        fn is_non_stdlib_pkg(state: &ResolverState, path: &SystemPath) -> bool {
-            let file_system = state.system();
-            file_system.path_exists(&path.join("__init__.py"))
-                || file_system.path_exists(&path.join("__init__.pyi"))
+        fn is_non_stdlib_pkg(resolver: &ResolverState, path: &SystemPath) -> bool {
+            system_path_to_file(resolver.db.upcast(), path.join("__init__.py")).is_some()
+                || system_path_to_file(resolver.db.upcast(), path.join("__init__.py")).is_some()
         }
 
         match (self, search_path) {
@@ -387,8 +386,8 @@ impl<'a> ModuleResolutionPathRefInner<'a> {
                 match Self::query_stdlib_version( path, search_path, &stdlib_root, resolver) {
                     TypeshedVersionsQueryResult::DoesNotExist => false,
                     TypeshedVersionsQueryResult::Exists | TypeshedVersionsQueryResult::MaybeExists => match path {
-                        FilePathRef::System(path) => resolver.db.system().path_exists(&path.join("__init__.pyi")),
-                        FilePathRef::Vendored(path) => resolver.db.vendored().exists(path.join("__init__.pyi")),
+                        FilePathRef::System(path) => system_path_to_file(resolver.db.upcast(),path.join("__init__.pyi")).is_some(),
+                        FilePathRef::Vendored(path) => vendored_path_to_file(resolver.db.upcast(), path.join("__init__.pyi")).is_some(),
                     },
                 }
             }

--- a/crates/red_knot_module_resolver/src/resolver.rs
+++ b/crates/red_knot_module_resolver/src/resolver.rs
@@ -1603,23 +1603,4 @@ not_a_directory
             ModuleResolutionPathBuf::editable_installation_root(db.system(), "/src").unwrap()
         )));
     }
-
-    #[test]
-    fn resolution_query_invalidated_when_package_deleted() {
-        const SRC: &[FileSpec] = &[("foo/__init__.py", ""), ("foo/bar.py", "")];
-
-        let TestCase { mut db, src, .. } = TestCaseBuilder::new().with_src_files(SRC).build();
-        let memory_fs = db.memory_file_system();
-
-        let foo_bar_name = ModuleName::new_static("foo.bar").unwrap();
-
-        let foo_module = resolve_module(&db, foo_bar_name.clone()).unwrap();
-        assert_eq!(foo_module.file().path(&db), &src.join("foo/bar.py"));
-
-        memory_fs.remove_file(src.join("foo/__init__.py")).unwrap();
-        memory_fs.remove_file(src.join("foo/bar.py")).unwrap();
-        memory_fs.remove_directory(src.join("foo")).unwrap();
-        File::touch_path(&mut db, &src.join("foo/__init__.py"));
-        assert_eq!(resolve_module(&db, foo_bar_name), None);
-    }
 }


### PR DESCRIPTION
## Summary

This fixes a bug where module resolution would not be invalidated if an entire package was deleted

## Test Plan

I added a test that fails on `main`, and passes with this PR.
