### PR TITLE
Provide contents read permission to wasm publish job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -225,6 +225,7 @@ jobs:
     secrets: inherit
     # publish jobs get escalated permissions
     permissions:
+      "contents": "read"
       "id-token": "write"
       "packages": "write"
 


### PR DESCRIPTION
The job has asked for the permission: https://github.com/astral-sh/ruff/blob/811f78d94dbf936b1b3fe74e788bf46b32677d8c/.github/workflows/publish-wasm.yml#L25