### PR TITLE
[red-knot] rename module_global to global

### DIFF
--- a/crates/red_knot/src/lint.rs
+++ b/crates/red_knot/src/lint.rs
@@ -130,7 +130,7 @@ fn lint_bad_override(context: &SemanticLintContext, class: &ast::StmtClassDef) {
         return;
     };
 
-    let override_ty = semantic.module_global_symbol_ty(&typing, "override");
+    let override_ty = semantic.global_symbol_ty(&typing, "override");
 
     let Type::Class(class_ty) = class.ty(semantic) else {
         return;

--- a/crates/red_knot_python_semantic/src/db.rs
+++ b/crates/red_knot_python_semantic/src/db.rs
@@ -6,7 +6,7 @@ use ruff_db::{Db as SourceDb, Upcast};
 use crate::semantic_index::definition::Definition;
 use crate::semantic_index::expression::Expression;
 use crate::semantic_index::symbol::ScopeId;
-use crate::semantic_index::{module_global_scope, semantic_index, symbol_table, use_def_map};
+use crate::semantic_index::{global_scope, semantic_index, symbol_table, use_def_map};
 use crate::types::{
     infer_definition_types, infer_expression_types, infer_scope_types, ClassType, FunctionType,
     IntersectionType, UnionType,
@@ -23,7 +23,7 @@ pub struct Jar(
     IntersectionType<'_>,
     symbol_table,
     use_def_map,
-    module_global_scope,
+    global_scope,
     semantic_index,
     infer_definition_types,
     infer_expression_types,

--- a/crates/red_knot_python_semantic/src/semantic_index/symbol.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/symbol.rs
@@ -133,7 +133,7 @@ pub struct FileScopeId;
 
 impl FileScopeId {
     /// Returns the scope id of the module-global scope.
-    pub fn module_global() -> Self {
+    pub fn global() -> Self {
         FileScopeId::from_u32(0)
     }
 

--- a/crates/red_knot_python_semantic/src/semantic_model.rs
+++ b/crates/red_knot_python_semantic/src/semantic_model.rs
@@ -5,7 +5,7 @@ use ruff_python_ast::{Expr, ExpressionRef, StmtClassDef};
 
 use crate::semantic_index::ast_ids::HasScopedAstId;
 use crate::semantic_index::semantic_index;
-use crate::types::{definition_ty, infer_scope_types, module_global_symbol_ty_by_name, Type};
+use crate::types::{definition_ty, global_symbol_ty_by_name, infer_scope_types, Type};
 use crate::Db;
 
 pub struct SemanticModel<'db> {
@@ -28,8 +28,8 @@ impl<'db> SemanticModel<'db> {
         resolve_module(self.db.upcast(), module_name)
     }
 
-    pub fn module_global_symbol_ty(&self, module: &Module, symbol_name: &str) -> Type<'db> {
-        module_global_symbol_ty_by_name(self.db, module.file(), symbol_name)
+    pub fn global_symbol_ty(&self, module: &Module, symbol_name: &str) -> Type<'db> {
+        global_symbol_ty_by_name(self.db, module.file(), symbol_name)
     }
 }
 

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -3,7 +3,7 @@ use ruff_python_ast::name::Name;
 
 use crate::semantic_index::definition::Definition;
 use crate::semantic_index::symbol::{ScopeId, ScopedSymbolId};
-use crate::semantic_index::{module_global_scope, symbol_table, use_def_map};
+use crate::semantic_index::{global_scope, symbol_table, use_def_map};
 use crate::{Db, FxOrderSet};
 
 mod display;
@@ -43,12 +43,8 @@ pub(crate) fn symbol_ty_by_name<'db>(
 }
 
 /// Shorthand for `symbol_ty` that looks up a module-global symbol in a file.
-pub(crate) fn module_global_symbol_ty_by_name<'db>(
-    db: &'db dyn Db,
-    file: File,
-    name: &str,
-) -> Type<'db> {
-    symbol_ty_by_name(db, module_global_scope(db, file), name)
+pub(crate) fn global_symbol_ty_by_name<'db>(db: &'db dyn Db, file: File, name: &str) -> Type<'db> {
+    symbol_ty_by_name(db, global_scope(db, file), name)
 }
 
 /// Infer the type of a [`Definition`].
@@ -145,7 +141,7 @@ impl<'db> Type<'db> {
             Type::Unbound => Type::Unbound,
             Type::None => todo!("attribute lookup on None type"),
             Type::Function(_) => todo!("attribute lookup on Function type"),
-            Type::Module(file) => module_global_symbol_ty_by_name(db, *file, name),
+            Type::Module(file) => global_symbol_ty_by_name(db, *file, name),
             Type::Class(class) => class.class_member(db, name),
             Type::Instance(_) => {
                 // TODO MRO? get_own_instance_member, get_instance_member


### PR DESCRIPTION
Per comments in https://github.com/astral-sh/ruff/pull/12269, "module global" is kind of long, and arguably redundant.

I tried just using "module" but there were too many cases where I felt this was ambiguous. I like the way "global" works out better, though it does require an understanding that in Python "global" generally means "module global" not "globally global" (though in a sense module globals are also globally global since modules are singletons).