### PR TITLE
Provide custom job permissions to `cargo-dist`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -276,6 +276,6 @@ publish-jobs = ["./publish-pypi", "./publish-wasm"]
 # Announcement jobs to run in CI
 post-announce-jobs = ["./notify-dependents", "./publish-docs", "./publish-playground"]
 # Custom permissions for GitHub Jobs
-github-custom-job-permissions = { "build-docker" = { packages = "write", contents = "read" } }
+github-custom-job-permissions = { "build-docker" = { packages = "write", contents = "read" }, "publish-wasm" = { contents = "read", id-token = "write", packages = "write" } }
 # Whether to install an updater program
 install-updater = false


### PR DESCRIPTION
We can't just directly update the `release.yml` file because that's auto-generated using `cargo-dist`. So, update the permissions in `Cargo.toml` and then use `cargo dist generate` to make sure there's no diff.