### PR TITLE
[red-knot] Remove use of `str` from benchmarks

### DIFF
--- a/crates/ruff_benchmark/benches/red_knot.rs
+++ b/crates/ruff_benchmark/benches/red_knot.rs
@@ -17,17 +17,17 @@ import typing
 from bar import Bar
 
 class Foo(Bar):
-    def foo() -> str:
+    def foo() -> object:
         return "foo"
 
     @typing.override
-    def bar() -> str:
+    def bar() -> object:
         return "foo_bar"
 "#;
 
 static BAR_CODE: &str = r#"
 class Bar:
-    def bar() -> str:
+    def bar() -> object:
         return "bar"
 
     def random(arg: int) -> int:


### PR DESCRIPTION
#12390 adds support for resolving types to classes in typeshed's `builtins.pyi` stub file. This causes redknot to crash when attempting to execute this benchmark, as the `str` definition in typeshed is too complex for us to handle right now. `object` is a simpler type definition which we can resolve symbols to without crashing.
