### PR TITLE
[red-knot] use a simpler builtin in the benchmark

### DIFF
--- a/crates/ruff_benchmark/benches/red_knot.rs
+++ b/crates/ruff_benchmark/benches/red_knot.rs
@@ -17,17 +17,17 @@ import typing
 from bar import Bar
 
 class Foo(Bar):
-    def foo() -> str:
+    def foo() -> object:
         return "foo"
 
     @typing.override
-    def bar() -> str:
+    def bar() -> object:
         return "foo_bar"
 "#;
 
 static BAR_CODE: &str = r#"
 class Bar:
-    def bar() -> str:
+    def bar() -> object:
         return "bar"
 
     def random(arg: int) -> int:


### PR DESCRIPTION
In preparation for supporting resolving builtins, simplify the benchmark so it doesn't look up `str`, which is actually a complex builtin to deal with because it inherits `Sequence[str]`.
