### PR TITLE
[red-knot] unswap naming of benchmark groups

### DIFF
--- a/crates/ruff_benchmark/benches/red_knot.rs
+++ b/crates/ruff_benchmark/benches/red_knot.rs
@@ -178,7 +178,7 @@ fn benchmark_cold(criterion: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(cold, benchmark_without_parse);
-criterion_group!(without_parse, benchmark_cold);
+criterion_group!(cold, benchmark_cold);
+criterion_group!(without_parse, benchmark_without_parse);
 criterion_group!(incremental, benchmark_incremental);
 criterion_main!(without_parse, cold, incremental);


### PR DESCRIPTION
Unless there's some logic in `criterion_group!` that I really don't understand, it looks like these benchmark group names were swapped, so the group labeled `without_parse` was actually the `cold` benchmark, and vice versa. Not sure this practically matters, since the benchmark function names were correct.
