### PR TITLE
[red-knot] fix incremental benchmark

### DIFF
--- a/crates/ruff_benchmark/benches/red_knot.rs
+++ b/crates/ruff_benchmark/benches/red_knot.rs
@@ -138,7 +138,7 @@ fn benchmark_incremental(criterion: &mut Criterion) {
                 case.fs
                     .write_file(
                         SystemPath::new("/src/foo.py"),
-                        format!("{BAR_CODE}\n# A comment\n"),
+                        format!("{FOO_CODE}\n# A comment\n"),
                     )
                     .unwrap();
 

--- a/crates/ruff_benchmark/benches/red_knot.rs
+++ b/crates/ruff_benchmark/benches/red_knot.rs
@@ -137,8 +137,8 @@ fn benchmark_incremental(criterion: &mut Criterion) {
 
                 case.fs
                     .write_file(
-                        SystemPath::new("/src/foo.py"),
-                        format!("{FOO_CODE}\n# A comment\n"),
+                        SystemPath::new("/src/bar.py"),
+                        format!("{BAR_CODE}\n# A comment\n"),
                     )
                     .unwrap();
 


### PR DESCRIPTION
Was it intentional that we rewrite `foo.py` with the `BAR_CODE` in the incremental benchmark?