### PR TITLE
[red-knot] Watch search paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1898,6 +1898,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "bitflags 2.6.0",
+ "countme",
  "hashbrown",
  "ordermap",
  "red_knot_module_resolver",

--- a/crates/red_knot/src/watch.rs
+++ b/crates/red_knot/src/watch.rs
@@ -1,7 +1,9 @@
 use ruff_db::system::{SystemPath, SystemPathBuf};
 pub use watcher::{directory_watcher, EventHandler, Watcher};
+pub use workspace_watcher::WorkspaceWatcher;
 
 mod watcher;
+mod workspace_watcher;
 
 /// Classification of a file system change event.
 ///

--- a/crates/red_knot/src/watch/workspace_watcher.rs
+++ b/crates/red_knot/src/watch/workspace_watcher.rs
@@ -32,7 +32,7 @@ impl WorkspaceWatcher {
     }
 
     pub fn update(&mut self, db: &RootDatabase) {
-        let new_watch_paths = db.workspace().watch_paths(db);
+        let new_watch_paths = db.workspace().paths_to_watch(db);
 
         let mut added_folders = new_watch_paths.difference(&self.watched_paths).peekable();
         let mut removed_folders = self.watched_paths.difference(&new_watch_paths).peekable();

--- a/crates/red_knot/src/watch/workspace_watcher.rs
+++ b/crates/red_knot/src/watch/workspace_watcher.rs
@@ -1,0 +1,112 @@
+use crate::db::RootDatabase;
+use crate::watch::Watcher;
+use ruff_db::system::SystemPathBuf;
+use rustc_hash::FxHashSet;
+use std::fmt::{Formatter, Write};
+use tracing::info;
+
+/// Wrapper around a [`Watcher`] that watches the relevant paths of a workspace.
+pub struct WorkspaceWatcher {
+    watcher: Watcher,
+
+    /// The paths that need to be watched. This includes paths for which setting up file watching failed.
+    watched_paths: FxHashSet<SystemPathBuf>,
+
+    /// Paths that should be watched but setting up the watcher failed for some reason.
+    /// This should be rare.
+    errored_paths: Vec<SystemPathBuf>,
+}
+
+impl WorkspaceWatcher {
+    /// Create a new workspace watcher.
+    pub fn new(watcher: Watcher, db: &RootDatabase) -> Self {
+        let mut watcher = Self {
+            watcher,
+            watched_paths: FxHashSet::default(),
+            errored_paths: Vec::new(),
+        };
+
+        watcher.update(db);
+
+        watcher
+    }
+
+    pub fn update(&mut self, db: &RootDatabase) {
+        let new_watch_paths = db.workspace().watch_paths(db);
+
+        let mut added_folders = new_watch_paths.difference(&self.watched_paths).peekable();
+        let mut removed_folders = self.watched_paths.difference(&new_watch_paths).peekable();
+
+        if added_folders.peek().is_none() && removed_folders.peek().is_none() {
+            return;
+        }
+
+        for added_folder in added_folders {
+            // Log a warning. It's not worth aborting if registering a single folder fails because
+            // Ruff otherwise stills works as expected.
+            if let Err(error) = self.watcher.watch(added_folder) {
+                // TODO: Log a user-facing warning.
+                tracing::warn!("Failed to setup watcher for path '{added_folder}': {error}. You have to restart Ruff after making changes to files under this path or you might see stale results.");
+                self.errored_paths.push(added_folder.clone());
+            }
+        }
+
+        for removed_path in removed_folders {
+            if let Some(index) = self
+                .errored_paths
+                .iter()
+                .position(|path| path == removed_path)
+            {
+                self.errored_paths.swap_remove(index);
+                continue;
+            }
+
+            if let Err(error) = self.watcher.unwatch(removed_path) {
+                info!("Failed to remove the file watcher for the path '{removed_path}: {error}.");
+            }
+        }
+
+        info!(
+            "Set up file watchers for {}",
+            DisplayWatchedPaths {
+                paths: &new_watch_paths
+            }
+        );
+
+        self.watched_paths = new_watch_paths;
+    }
+
+    /// Returns `true` if setting up watching for any path failed.
+    pub fn has_errored_paths(&self) -> bool {
+        !self.errored_paths.is_empty()
+    }
+
+    pub fn flush(&self) {
+        self.watcher.flush();
+    }
+
+    pub fn stop(self) {
+        self.watcher.stop();
+    }
+}
+
+struct DisplayWatchedPaths<'a> {
+    paths: &'a FxHashSet<SystemPathBuf>,
+}
+
+impl std::fmt::Display for DisplayWatchedPaths<'_> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.write_char('[')?;
+
+        let mut iter = self.paths.iter();
+        if let Some(first) = iter.next() {
+            write!(f, "\"{first}\"")?;
+
+            for path in iter {
+                write!(f, ", \"{path}\"")?;
+            }
+        }
+
+        f.write_char(']')
+    }
+}

--- a/crates/red_knot/src/workspace.rs
+++ b/crates/red_knot/src/workspace.rs
@@ -245,7 +245,7 @@ impl Workspace {
     /// Returns the paths that should be watched.
     ///
     /// The paths that require watching might change with every revision.
-    pub fn watch_paths(self, db: &dyn Db) -> FxHashSet<SystemPathBuf> {
+    pub fn paths_to_watch(self, db: &dyn Db) -> FxHashSet<SystemPathBuf> {
         ruff_db::system::deduplicate_nested_paths(
             std::iter::once(self.root(db)).chain(system_module_search_paths(db.upcast())),
         )

--- a/crates/red_knot_module_resolver/src/lib.rs
+++ b/crates/red_knot_module_resolver/src/lib.rs
@@ -1,3 +1,16 @@
+use std::iter::FusedIterator;
+
+pub use db::{Db, Jar};
+pub use module::{Module, ModuleKind};
+pub use module_name::ModuleName;
+pub use resolver::resolve_module;
+use ruff_db::system::SystemPath;
+pub use typeshed::{
+    vendored_typeshed_stubs, TypeshedVersionsParseError, TypeshedVersionsParseErrorKind,
+};
+
+use crate::resolver::{module_resolution_settings, SearchPathIterator};
+
 mod db;
 mod module;
 mod module_name;
@@ -9,10 +22,29 @@ mod typeshed;
 #[cfg(test)]
 mod testing;
 
-pub use db::{Db, Jar};
-pub use module::{Module, ModuleKind};
-pub use module_name::ModuleName;
-pub use resolver::resolve_module;
-pub use typeshed::{
-    vendored_typeshed_stubs, TypeshedVersionsParseError, TypeshedVersionsParseErrorKind,
-};
+/// Returns an iterator over all search paths pointing to a system path
+pub fn system_module_search_paths(db: &dyn Db) -> SystemModuleSearchPathsIter {
+    SystemModuleSearchPathsIter {
+        inner: module_resolution_settings(db).search_paths(db),
+    }
+}
+
+pub struct SystemModuleSearchPathsIter<'db> {
+    inner: SearchPathIterator<'db>,
+}
+
+impl<'db> Iterator for SystemModuleSearchPathsIter<'db> {
+    type Item = &'db SystemPath;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            let next = self.inner.next()?;
+
+            if let Some(system_path) = next.as_system_path() {
+                return Some(system_path);
+            }
+        }
+    }
+}
+
+impl FusedIterator for SystemModuleSearchPathsIter<'_> {}

--- a/crates/red_knot_module_resolver/src/resolver.rs
+++ b/crates/red_knot_module_resolver/src/resolver.rs
@@ -258,7 +258,7 @@ pub(crate) fn editable_install_resolution_paths(db: &dyn Db) -> Vec<ModuleSearch
 /// are only calculated lazily.
 ///
 /// [`sys.path` at runtime]: https://docs.python.org/3/library/site.html#module-site
-struct SearchPathIterator<'db> {
+pub(crate) struct SearchPathIterator<'db> {
     db: &'db dyn Db,
     static_paths: std::slice::Iter<'db, ModuleSearchPath>,
     dynamic_paths: Option<std::slice::Iter<'db, ModuleSearchPath>>,
@@ -399,7 +399,7 @@ impl ModuleResolutionSettings {
         self.target_version
     }
 
-    fn search_paths<'db>(&'db self, db: &'db dyn Db) -> SearchPathIterator<'db> {
+    pub(crate) fn search_paths<'db>(&'db self, db: &'db dyn Db) -> SearchPathIterator<'db> {
         SearchPathIterator {
             db,
             static_paths: self.static_search_paths.iter(),

--- a/crates/red_knot_python_semantic/Cargo.toml
+++ b/crates/red_knot_python_semantic/Cargo.toml
@@ -18,6 +18,7 @@ ruff_python_ast = { workspace = true }
 ruff_text_size = { workspace = true }
 
 bitflags = { workspace = true }
+countme = { workspace = true }
 ordermap = { workspace = true }
 salsa = { workspace = true }
 tracing = { workspace = true }

--- a/crates/red_knot_python_semantic/src/semantic_index/builder.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/builder.rs
@@ -103,9 +103,13 @@ impl<'db> SemanticIndexBuilder<'db> {
 
         #[allow(unsafe_code)]
         // SAFETY: `node` is guaranteed to be a child of `self.module`
-        let scope_id = ScopeId::new(self.db, self.file, file_scope_id, unsafe {
-            node.to_kind(self.module.clone())
-        });
+        let scope_id = ScopeId::new(
+            self.db,
+            self.file,
+            file_scope_id,
+            unsafe { node.to_kind(self.module.clone()) },
+            countme::Count::default(),
+        );
 
         self.scope_ids_by_scope.push(scope_id);
         self.scopes_by_node.insert(node.node_key(), file_scope_id);
@@ -180,6 +184,7 @@ impl<'db> SemanticIndexBuilder<'db> {
             unsafe {
                 definition_node.into_owned(self.module.clone())
             },
+            countme::Count::default(),
         );
 
         self.definitions_by_node
@@ -201,6 +206,7 @@ impl<'db> SemanticIndexBuilder<'db> {
             unsafe {
                 AstNodeRef::new(self.module.clone(), expression_node)
             },
+            countme::Count::default(),
         );
         self.expressions_by_node
             .insert(expression_node.into(), expression);

--- a/crates/red_knot_python_semantic/src/semantic_index/definition.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/definition.rs
@@ -24,6 +24,9 @@ pub struct Definition<'db> {
     #[no_eq]
     #[return_ref]
     pub(crate) node: DefinitionKind,
+
+    #[no_eq]
+    count: countme::Count<Definition<'static>>,
 }
 
 impl<'db> Definition<'db> {

--- a/crates/red_knot_python_semantic/src/semantic_index/expression.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/expression.rs
@@ -22,6 +22,9 @@ pub(crate) struct Expression<'db> {
     #[no_eq]
     #[return_ref]
     pub(crate) node: AstNodeRef<ast::Expr>,
+
+    #[no_eq]
+    count: countme::Count<Expression<'static>>,
 }
 
 impl<'db> Expression<'db> {

--- a/crates/red_knot_python_semantic/src/semantic_index/symbol.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/symbol.rs
@@ -100,6 +100,9 @@ pub struct ScopeId<'db> {
     #[no_eq]
     #[return_ref]
     pub node: NodeWithScopeKind,
+
+    #[no_eq]
+    count: countme::Count<ScopeId<'static>>,
 }
 
 impl<'db> ScopeId<'db> {

--- a/crates/ruff_db/src/program.rs
+++ b/crates/ruff_db/src/program.rs
@@ -65,7 +65,7 @@ impl std::fmt::Debug for TargetVersion {
 }
 
 /// Configures the search paths for module resolution.
-#[derive(Eq, PartialEq, Debug)]
+#[derive(Eq, PartialEq, Debug, Clone)]
 pub struct SearchPathSettings {
     /// List of user-provided paths that should take first priority in the module resolution.
     /// Examples in other type checkers are mypy's MYPYPATH environment variable,

--- a/crates/ruff_db/src/system.rs
+++ b/crates/ruff_db/src/system.rs
@@ -9,7 +9,9 @@ use walk_directory::WalkDirectoryBuilder;
 
 use crate::file_revision::FileRevision;
 
-pub use self::path::{SystemPath, SystemPathBuf};
+pub use self::path::{
+    deduplicate_nested_paths, DeduplicatedNestedPathsIter, SystemPath, SystemPathBuf,
+};
 
 mod memory_fs;
 #[cfg(feature = "os")]

--- a/crates/ruff_db/src/system/path.rs
+++ b/crates/ruff_db/src/system/path.rs
@@ -591,7 +591,9 @@ impl<'a> DeduplicatedNestedPathsIter<'a> {
         I: IntoIterator<Item = &'a SystemPath>,
     {
         let mut paths = paths.into_iter().collect::<Vec<_>>();
+        // Sort the path to ensure that e.g. `/a/b/c`, comes right after `/a/b`.
         paths.sort_unstable();
+
         let mut iter = paths.into_iter();
 
         Self {


### PR DESCRIPTION
## Summary

This PR extends the CLI to watch not only the workspace root but also all search paths. The watcher automatically registers new search paths or stops watching search paths when the program's `SearchPathSettings` change.

## Test Plan

Added integration tests.
