### PR TITLE
Add Eglot setup guide for Emacs editor

### DIFF
--- a/docs/editors/setup.md
+++ b/docs/editors/setup.md
@@ -333,6 +333,17 @@ IntelliJ Marketplace (maintained by [@koxudaxi](https://github.com/koxudaxi)).
 
 ## Emacs
 
+Ruff can be used via Eglot as language server with [`eglot`](https://github.com/joaotavora/eglot), which is in Emacs's core.
+You can enable it with automatic formatting on save as in code below.
+
+```elisp
+(add-hook 'python-mode-hook 'eglot-ensure)
+(with-eval-after-load 'eglot
+  (add-to-list 'eglot-server-programs
+               '(python-mode . ("ruff" "server")))
+  (add-hook 'after-save-hook 'eglot-format))
+```
+
 Ruff is available as [`flymake-ruff`](https://melpa.org/#/flymake-ruff) on MELPA:
 
 ```elisp

--- a/docs/editors/setup.md
+++ b/docs/editors/setup.md
@@ -333,8 +333,8 @@ IntelliJ Marketplace (maintained by [@koxudaxi](https://github.com/koxudaxi)).
 
 ## Emacs
 
-Ruff can be used via Eglot as language server with [`Eglot`](https://github.com/joaotavora/eglot), which is in Emacs's core.
-You can enable it with automatic formatting on save as in code below.
+Ruff can be utilized as a language server via [`Eglot`](https://github.com/joaotavora/eglot), which is in Emacs's core.
+To enable Ruff with automatic formatting on save, use the following configuration:
 
 ```elisp
 (add-hook 'python-mode-hook 'eglot-ensure)

--- a/docs/editors/setup.md
+++ b/docs/editors/setup.md
@@ -333,7 +333,7 @@ IntelliJ Marketplace (maintained by [@koxudaxi](https://github.com/koxudaxi)).
 
 ## Emacs
 
-Ruff can be used via Eglot as language server with [`eglot`](https://github.com/joaotavora/eglot), which is in Emacs's core.
+Ruff can be used via Eglot as language server with [`Eglot`](https://github.com/joaotavora/eglot), which is in Emacs's core.
 You can enable it with automatic formatting on save as in code below.
 
 ```elisp


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->
The purpose of this change is to explain how to use ruff as a language server in Eglot with automatic formatting because I've struggle to use it with Eglot. I've search it online and found that there are some people also struggle too. (See [this reddit post](https://www.reddit.com/r/emacs/comments/118mo6w/eglot_automatic_formatting/) and https://github.com/astral-sh/ruff-lsp/issues/19#issuecomment-1435138828)


## Test Plan

<!-- How was it tested? -->
I've use this setting myself. And I will continue maintain this part as long as I use it.
