### PR TITLE
[`pydoclint`] Fix `DOC501` panic #12428

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pydoclint/DOC501.py
+++ b/crates/ruff_linter/resources/test/fixtures/pydoclint/DOC501.py
@@ -1,0 +1,8 @@
+# https://github.com/astral-sh/ruff/issues/12428
+def parse_bool(x, default=_parse_bool_sentinel):
+    """Parse a boolean value
+    bool or type(default)
+    Raises
+    `ValueError`
+   ê>>> all(parse_bool(x) for x in [True, "yes", "Yes", "true", "True", "on", "ON", "1", 1])
+    """

--- a/crates/ruff_linter/src/rules/pydoclint/mod.rs
+++ b/crates/ruff_linter/src/rules/pydoclint/mod.rs
@@ -15,6 +15,17 @@ mod tests {
     use crate::test::test_path;
     use crate::{assert_messages, settings};
 
+    #[test_case(Rule::DocstringMissingException, Path::new("DOC501.py"))]
+    fn rules(rule_code: Rule, path: &Path) -> Result<()> {
+        let snapshot = format!("{}_{}", rule_code.as_ref(), path.to_string_lossy());
+        let diagnostics = test_path(
+            Path::new("pydoclint").join(path).as_path(),
+            &settings::LinterSettings::for_rule(rule_code),
+        )?;
+        assert_messages!(snapshot, diagnostics);
+        Ok(())
+    }
+
     #[test_case(Rule::DocstringMissingException, Path::new("DOC501_google.py"))]
     #[test_case(Rule::DocstringExtraneousException, Path::new("DOC502_google.py"))]
     fn rules_google_style(rule_code: Rule, path: &Path) -> Result<()> {

--- a/crates/ruff_linter/src/rules/pydoclint/rules/check_docstring.rs
+++ b/crates/ruff_linter/src/rules/pydoclint/rules/check_docstring.rs
@@ -210,7 +210,7 @@ fn parse_entries_numpy(content: &str) -> Vec<QualifiedName> {
     for potential in split {
         if let Some(first_char) = potential.chars().nth(indentation) {
             if !first_char.is_whitespace() {
-                let entry = potential[indentation..].trim();
+                let entry = potential.trim();
                 entries.push(QualifiedName::user_defined(entry));
             }
         }

--- a/crates/ruff_linter/src/rules/pydoclint/rules/check_docstring.rs
+++ b/crates/ruff_linter/src/rules/pydoclint/rules/check_docstring.rs
@@ -208,10 +208,11 @@ fn parse_entries_numpy(content: &str) -> Vec<QualifiedName> {
     };
     let indentation = dashes.len() - dashes.trim_start().len();
     for potential in lines {
-        if let Some(first_char) = potential.chars().nth(indentation) {
-            if !first_char.is_whitespace() {
-                let entry = potential.trim();
-                entries.push(QualifiedName::user_defined(entry));
+        if let Some(entry) = potential.strip_prefix(&dashes[..indentation]) {
+            if let Some(first_char) = entry.chars().next() {
+                if !first_char.is_whitespace() {
+                    entries.push(QualifiedName::user_defined(entry.trim_end()));
+                }
             }
         }
     }

--- a/crates/ruff_linter/src/rules/pydoclint/rules/check_docstring.rs
+++ b/crates/ruff_linter/src/rules/pydoclint/rules/check_docstring.rs
@@ -206,9 +206,9 @@ fn parse_entries_numpy(content: &str) -> Vec<QualifiedName> {
     let Some(dashes) = lines.next() else {
         return entries;
     };
-    let indentation = dashes.len() - dashes.trim_start().len();
+    let indentation = &dashes[..dashes.len() - dashes.trim_start().len()];
     for potential in lines {
-        if let Some(entry) = potential.strip_prefix(&dashes[..indentation]) {
+        if let Some(entry) = potential.strip_prefix(indentation) {
             if let Some(first_char) = entry.chars().next() {
                 if !first_char.is_whitespace() {
                     entries.push(QualifiedName::user_defined(entry.trim_end()));

--- a/crates/ruff_linter/src/rules/pydoclint/rules/check_docstring.rs
+++ b/crates/ruff_linter/src/rules/pydoclint/rules/check_docstring.rs
@@ -180,7 +180,7 @@ fn parse_entries(content: &str, style: SectionStyle) -> Vec<QualifiedName> {
 /// ```
 fn parse_entries_google(content: &str) -> Vec<QualifiedName> {
     let mut entries: Vec<QualifiedName> = Vec::new();
-    for potential in content.split('\n') {
+    for potential in content.lines() {
         let Some(colon_idx) = potential.find(':') else {
             continue;
         };
@@ -202,12 +202,12 @@ fn parse_entries_google(content: &str) -> Vec<QualifiedName> {
 /// ```
 fn parse_entries_numpy(content: &str) -> Vec<QualifiedName> {
     let mut entries: Vec<QualifiedName> = Vec::new();
-    let mut split = content.split('\n');
-    let Some(dashes) = split.next() else {
+    let mut lines = content.lines();
+    let Some(dashes) = lines.next() else {
         return entries;
     };
     let indentation = dashes.len() - dashes.trim_start().len();
-    for potential in split {
+    for potential in lines {
         if let Some(first_char) = potential.chars().nth(indentation) {
             if !first_char.is_whitespace() {
                 let entry = potential.trim();

--- a/crates/ruff_linter/src/rules/pydoclint/snapshots/ruff_linter__rules__pydoclint__tests__docstring-missing-exception_DOC501.py.snap
+++ b/crates/ruff_linter/src/rules/pydoclint/snapshots/ruff_linter__rules__pydoclint__tests__docstring-missing-exception_DOC501.py.snap
@@ -1,0 +1,4 @@
+---
+source: crates/ruff_linter/src/rules/pydoclint/mod.rs
+---
+


### PR DESCRIPTION
## Summary

Fix panic reported in #12428. Where a string would sometimes get split within a character boundary. This bypasses the need to split the string.

This does not guarantee the correct formatting of the docstring, but neither did the previous implementation.

Resolves #12428 

## Test Plan

Test case added to fixture
