### PR TITLE
Remove unused dependencies, sync existing versions

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -20,15 +20,13 @@ cargo-fuzz = true
 ruff_linter = { path = "../crates/ruff_linter" }
 ruff_python_ast = { path = "../crates/ruff_python_ast" }
 ruff_python_codegen = { path = "../crates/ruff_python_codegen" }
-ruff_python_index = { path = "../crates/ruff_python_index" }
 ruff_python_parser = { path = "../crates/ruff_python_parser" }
 ruff_source_file = { path = "../crates/ruff_source_file" }
 ruff_python_formatter = { path = "../crates/ruff_python_formatter"}
 ruff_text_size = { path = "../crates/ruff_text_size" }
 
-arbitrary = { version = "1.3.0", features = ["derive"] }
 libfuzzer-sys = { git = "https://github.com/rust-fuzz/libfuzzer", default-features = false }
-similar = { version = "2.2.1" }
+similar = { version = "2.5.0" }
 
 # Prevent this from interfering with workspaces
 [workspace]


### PR DESCRIPTION
## Summary

This PR removes unused dependencies from `fuzz` crate and syncs the `similar` crate to the workspace version. This will help in resolve https://github.com/astral-sh/ruff/pull/12442.

## Test Plan

Build the fuzz crate:

For Mac (it requires the nightly build):
```
cargo +nightly fuzz build
```
