### PR TITLE
Fix incorrect placement of leading function comment with type params

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/class_definition.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/class_definition.py
@@ -224,3 +224,25 @@ class QuerySet(AltersData):
 
     as_manager.queryset_only = True
     as_manager = classmethod(as_manager)
+
+
+# Decorators
+@decorator
+# comment
+class Foo1: ...
+
+@decorator
+# comment
+class Foo2(Foo1): ...
+
+@decorator
+# comment
+class Foo3[T]: ...
+
+@decorator  # comment
+class Foo4: ...
+
+@decorator
+# comment
+@decorato2
+class Foo5: ...

--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/function.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/function.py
@@ -436,3 +436,25 @@ def function_with_variadic_generics(*args: *tuple[int],): ...
 
 # Generic arguments (PEP 695)
 def func[T](lotsoflongargs: T, lotsoflongargs2: T, lotsoflongargs3: T, lotsoflongargs4: T, lotsoflongargs5: T) -> T: ...
+
+
+# Decorators
+@decorator
+# comment
+def foo[S](x: S) -> S: ...
+
+@decorator
+# comment
+def foo(x: S) -> S: ...
+
+@decorator
+# comment
+def foo() -> S: ...
+
+@decorator
+# comment
+@decorator2
+def foo(x: S) -> S: ...
+
+@decorator # comment
+def foo(x: S) -> S: ...

--- a/crates/ruff_python_formatter/src/comments/placement.rs
+++ b/crates/ruff_python_formatter/src/comments/placement.rs
@@ -1076,7 +1076,7 @@ fn handle_leading_function_with_decorators_comment(comment: DecoratedComment) ->
 
     let is_following_parameters = comment
         .following_node()
-        .is_some_and(|node| node.is_parameters());
+        .is_some_and(|node| node.is_parameters() || node.is_type_params());
 
     if comment.line_position().is_own_line() && is_preceding_decorator && is_following_parameters {
         CommentPlacement::dangling(comment.enclosing_node(), comment)

--- a/crates/ruff_python_formatter/tests/snapshots/format@statement__class_definition.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@statement__class_definition.py.snap
@@ -230,6 +230,28 @@ class QuerySet(AltersData):
 
     as_manager.queryset_only = True
     as_manager = classmethod(as_manager)
+
+
+# Decorators
+@decorator
+# comment
+class Foo1: ...
+
+@decorator
+# comment
+class Foo2(Foo1): ...
+
+@decorator
+# comment
+class Foo3[T]: ...
+
+@decorator  # comment
+class Foo4: ...
+
+@decorator
+# comment
+@decorato2
+class Foo5: ...
 ```
 
 ## Output
@@ -489,7 +511,30 @@ class QuerySet(AltersData):
 
     as_manager.queryset_only = True
     as_manager = classmethod(as_manager)
+
+
+# Decorators
+@decorator
+# comment
+class Foo1: ...
+
+
+@decorator
+# comment
+class Foo2(Foo1): ...
+
+
+@decorator
+# comment
+class Foo3[T]: ...
+
+
+@decorator  # comment
+class Foo4: ...
+
+
+@decorator
+# comment
+@decorato2
+class Foo5: ...
 ```
-
-
-

--- a/crates/ruff_python_formatter/tests/snapshots/format@statement__function.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@statement__function.py.snap
@@ -442,6 +442,28 @@ def function_with_variadic_generics(*args: *tuple[int],): ...
 
 # Generic arguments (PEP 695)
 def func[T](lotsoflongargs: T, lotsoflongargs2: T, lotsoflongargs3: T, lotsoflongargs4: T, lotsoflongargs5: T) -> T: ...
+
+
+# Decorators
+@decorator
+# comment
+def foo[S](x: S) -> S: ...
+
+@decorator
+# comment
+def foo(x: S) -> S: ...
+
+@decorator
+# comment
+def foo() -> S: ...
+
+@decorator
+# comment
+@decorator2
+def foo(x: S) -> S: ...
+
+@decorator # comment
+def foo(x: S) -> S: ...
 ```
 
 ## Output
@@ -1041,6 +1063,32 @@ def func[T](
     lotsoflongargs4: T,
     lotsoflongargs5: T,
 ) -> T: ...
+
+
+# Decorators
+@decorator
+# comment
+def foo[S](x: S) -> S: ...
+
+
+@decorator
+# comment
+def foo(x: S) -> S: ...
+
+
+@decorator
+# comment
+def foo() -> S: ...
+
+
+@decorator
+# comment
+@decorator2
+def foo(x: S) -> S: ...
+
+
+@decorator  # comment
+def foo(x: S) -> S: ...
 ```
 
 


### PR DESCRIPTION
## Summary

Fixes https://github.com/astral-sh/ruff/issues/12430

```py
@decorator
# remark
def foo[S](x: S) -> S: ...
```

was formatted to 

```py
@decorator
def foo# remark
[S](x: S) -> S: ...
```

This PR marks the `# remark` as dangling comment and formats it between the decorator and the function header.

## Test Plan

Added tests. I also added test for classes.
