### PR TITLE
Add note to include notebook files for native server

### DIFF
--- a/docs/editors/features.md
+++ b/docs/editors/features.md
@@ -94,6 +94,12 @@ alt="Hovering over a noqa code in VS Code"
 Similar to Ruff's CLI, the Ruff Language Server fully supports Jupyter Notebook files with all the
 capabilities available to Python files.
 
+!!! note
+    Unlike [`ruff-lsp`](https://github.com/astral-sh/ruff-lsp) and similar to the Ruff's CLI, the
+    native language server requires user to explicitly include the Jupyter Notebook files in the set
+    of files to lint and format. Refer to the [Jupyter Notebook discovery](https://docs.astral.sh/ruff/configuration/#jupyter-notebook-discovery)
+    section on how to do this.
+
 <img
 src="https://astral.sh/static/GIF/v0.4.5/ipynb_editing_vscode.gif"
 alt="Editing multiple Jupyter Notebook cells in VS Code"


### PR DESCRIPTION
## Summary

Similar to https://github.com/astral-sh/ruff-vscode/pull/547 but for the online docs.

Refer to https://github.com/astral-sh/ruff-vscode/issues/546

## Preview

<img width="1728" alt="Screenshot 2024-07-22 at 14 51 40" src="https://github.com/user-attachments/assets/39014278-c868-45b0-9058-42858a060fd8">

