### PR TITLE
[red-knot] Lazy package file discovery

### DIFF
--- a/crates/red_knot/src/db.rs
+++ b/crates/red_knot/src/db.rs
@@ -12,7 +12,7 @@ use ruff_db::vendored::VendoredFileSystem;
 use ruff_db::{Db as SourceDb, Jar as SourceJar, Upcast};
 
 use crate::lint::{lint_semantic, lint_syntax, unwind_if_cancelled, Diagnostics};
-use crate::workspace::{check_file, Package, Workspace, WorkspaceMetadata};
+use crate::workspace::{check_file, Package, Package_files, Workspace, WorkspaceMetadata};
 
 mod changes;
 
@@ -22,6 +22,7 @@ pub trait Db: DbWithJar<Jar> + SemanticDb + Upcast<dyn SemanticDb> {}
 pub struct Jar(
     Workspace,
     Package,
+    Package_files,
     lint_syntax,
     lint_semantic,
     unwind_if_cancelled,

--- a/crates/red_knot/src/workspace.rs
+++ b/crates/red_knot/src/workspace.rs
@@ -12,7 +12,7 @@ use ruff_db::{
 };
 use ruff_python_ast::{name::Name, PySourceType};
 
-use crate::workspace::files::{Files, IndexedFiles, PackageFiles};
+use crate::workspace::files::{Index, IndexedFiles, PackageFiles};
 use crate::{
     db::Db,
     lint::{lint_semantic, lint_syntax, Diagnostics},
@@ -255,7 +255,7 @@ impl Package {
 
     #[tracing::instrument(level = "debug", skip(db))]
     pub fn remove_file(self, db: &mut dyn Db, file: File) {
-        let Some(mut index) = PackageFiles::index_mut(db, self) else {
+        let Some(mut index) = PackageFiles::indexed_mut(db, self) else {
             return;
         };
 
@@ -264,7 +264,7 @@ impl Package {
 
     #[tracing::instrument(level = "debug", skip(db))]
     pub fn add_file(self, db: &mut dyn Db, file: File) {
-        let Some(mut index) = PackageFiles::index_mut(db, self) else {
+        let Some(mut index) = PackageFiles::indexed_mut(db, self) else {
             return;
         };
 
@@ -288,11 +288,11 @@ impl Package {
         let files = self.file_set(db);
 
         let indexed = match files.get() {
-            Files::Lazy(vacant) => {
+            Index::Lazy(vacant) => {
                 let files = discover_package_files(db, self.root(db));
                 vacant.set(files)
             }
-            Files::Indexed(indexed) => indexed,
+            Index::Indexed(indexed) => indexed,
         };
 
         indexed

--- a/crates/red_knot/src/workspace.rs
+++ b/crates/red_knot/src/workspace.rs
@@ -1,5 +1,5 @@
 // TODO: Fix clippy warnings created by salsa macros
-#![allow(clippy::used_underscore_binding)]
+#![allow(clippy::used_underscore_binding, unreachable_pub)]
 
 use std::{collections::BTreeMap, sync::Arc};
 
@@ -12,11 +12,13 @@ use ruff_db::{
 };
 use ruff_python_ast::{name::Name, PySourceType};
 
+use crate::workspace::files::{Files, IndexedFiles, PackageFiles};
 use crate::{
     db::Db,
     lint::{lint_semantic, lint_syntax, Diagnostics},
 };
 
+mod files;
 mod metadata;
 
 /// The project workspace as a Salsa ingredient.
@@ -93,7 +95,7 @@ pub struct Package {
 
     /// The files that are part of this package.
     #[return_ref]
-    file_set: Arc<FxHashSet<File>>,
+    file_set: PackageFiles,
     // TODO: Add the loaded settings.
 }
 
@@ -240,6 +242,7 @@ impl Workspace {
     }
 }
 
+#[salsa::tracked]
 impl Package {
     pub fn root(self, db: &dyn Db) -> &SystemPath {
         self.root_buf(db)
@@ -247,73 +250,69 @@ impl Package {
 
     /// Returns `true` if `file` is a first-party file part of this package.
     pub fn contains_file(self, db: &dyn Db, file: File) -> bool {
-        self.files(db).contains(&file)
-    }
-
-    pub fn files(self, db: &dyn Db) -> &FxHashSet<File> {
-        self.file_set(db)
+        self.files(db).read().contains(&file)
     }
 
     #[tracing::instrument(level = "debug", skip(db))]
-    pub fn remove_file(self, db: &mut dyn Db, file: File) -> bool {
-        let mut files_arc = self.file_set(db).clone();
+    pub fn remove_file(self, db: &mut dyn Db, file: File) {
+        let Some(mut index) = PackageFiles::index_mut(db, self) else {
+            return;
+        };
 
-        // Set a dummy value. Salsa will cancel any pending queries and remove its own reference to `files`
-        // so that the reference counter to `files` now drops to 1.
-        self.set_file_set(db).to(Arc::new(FxHashSet::default()));
-
-        let files = Arc::get_mut(&mut files_arc).unwrap();
-        let removed = files.remove(&file);
-        self.set_file_set(db).to(files_arc);
-
-        removed
+        index.remove(file);
     }
 
     #[tracing::instrument(level = "debug", skip(db))]
-    pub fn add_file(self, db: &mut dyn Db, file: File) -> bool {
-        let mut files_arc = self.file_set(db).clone();
+    pub fn add_file(self, db: &mut dyn Db, file: File) {
+        let Some(mut index) = PackageFiles::index_mut(db, self) else {
+            return;
+        };
 
-        // Set a dummy value. Salsa will cancel any pending queries and remove its own reference to `files`
-        // so that the reference counter to `files` now drops to 1.
-        self.set_file_set(db).to(Arc::new(FxHashSet::default()));
-
-        let files = Arc::get_mut(&mut files_arc).unwrap();
-        let added = files.insert(file);
-        self.set_file_set(db).to(files_arc);
-
-        added
+        index.insert(file);
     }
 
     #[tracing::instrument(level = "debug", skip(db))]
     pub(crate) fn check(self, db: &dyn Db) -> Vec<String> {
         let mut result = Vec::new();
-        for file in self.files(db) {
-            let diagnostics = check_file(db, *file);
+        for file in &self.files(db).read() {
+            let diagnostics = check_file(db, file);
             result.extend_from_slice(&diagnostics);
         }
 
         result
     }
 
-    fn from_metadata(db: &dyn Db, metadata: PackageMetadata) -> Self {
-        let files = discover_package_files(db, metadata.root());
+    /// Returns the files belonging to this package.
+    #[salsa::tracked]
+    pub fn files(self, db: &dyn Db) -> IndexedFiles {
+        let files = self.file_set(db);
 
-        Self::new(db, metadata.name, metadata.root, Arc::new(files))
+        let indexed = match files.get() {
+            Files::Lazy(vacant) => {
+                let files = discover_package_files(db, self.root(db));
+                vacant.set(files)
+            }
+            Files::Indexed(indexed) => indexed,
+        };
+
+        indexed
+    }
+
+    fn from_metadata(db: &dyn Db, metadata: PackageMetadata) -> Self {
+        Self::new(db, metadata.name, metadata.root, PackageFiles::default())
     }
 
     fn update(self, db: &mut dyn Db, metadata: PackageMetadata) {
         let root = self.root(db);
         assert_eq!(root, metadata.root());
 
-        self.reload_files(db);
         self.set_name(db).to(metadata.name);
     }
 
     #[tracing::instrument(level = "debug", skip(db))]
     pub fn reload_files(self, db: &mut dyn Db) {
-        let files = discover_package_files(db, self.root(db));
-
-        self.set_file_set(db).to(Arc::new(files));
+        // Force a re-index of the files in the next revision.
+        self.set_file_set(db).to(PackageFiles::lazy());
     }
 }
 

--- a/crates/red_knot/src/workspace/files.rs
+++ b/crates/red_knot/src/workspace/files.rs
@@ -110,7 +110,7 @@ impl<'a> LazyFiles<'a> {
 /// The type is cheap clonable and allows for in-place mutation of the files. The in-place mutation requires
 /// extra care because the type is used as the result of Salsa queries and Salsa relies on a type's equality
 /// to determine if the output has changed. This is accomplished by using a `revision` that gets incremented
-/// whenever the files are changed. The revision ensures that salas's comparison of the
+/// whenever the files are changed. The revision ensures that salsa's comparison of the
 /// previous [`IndexedFiles`] with the next [`IndexedFiles`] returns false even though they both
 /// point to the same underlying hash set.
 ///

--- a/crates/red_knot/src/workspace/files.rs
+++ b/crates/red_knot/src/workspace/files.rs
@@ -1,0 +1,242 @@
+use std::iter::FusedIterator;
+use std::ops::Deref;
+use std::sync::Arc;
+
+use rustc_hash::FxHashSet;
+
+use crate::db::Db;
+use crate::workspace::Package;
+use ruff_db::files::File;
+
+/// The indexed files of a package.
+///
+/// The indexing happens lazily, but the files are then cached for subsequent reads.
+///
+/// ## Implementation
+/// The implementation uses internal mutability to transition between the lazy and indexed state
+/// without triggering a new salsa revision. The internal mutability **must not** be used for any
+/// other state transition that requires invalidating dependent salsa queries (e.g. adding or removing
+/// files from the index **must** go through the salsa setter to let salsa know about the input change).
+#[derive(Debug)]
+pub struct PackageFiles {
+    state: std::sync::Mutex<State>,
+}
+
+impl PackageFiles {
+    pub fn lazy() -> Self {
+        Self {
+            state: std::sync::Mutex::new(State::Lazy),
+        }
+    }
+
+    fn indexed(indexed_files: IndexedFiles) -> Self {
+        Self {
+            state: std::sync::Mutex::new(State::Indexed(indexed_files)),
+        }
+    }
+
+    pub fn get(&self) -> Files {
+        let state = self.state.lock().unwrap();
+
+        match &*state {
+            State::Lazy => Files::Lazy(LazyFiles { files: state }),
+            State::Indexed(files) => Files::Indexed(files.clone()),
+        }
+    }
+
+    /// Returns a mutable view on the index that allows cheap in-place mutations.
+    ///
+    /// The changes are automatically written back to the database once the view is dropped.
+    pub fn index_mut(db: &mut dyn Db, package: Package) -> Option<IndexedFilesMut> {
+        // Calling `runtime_mut` cancels all pending salsa queries. This ensures that there are no pending
+        // reads to the file set.
+        let _ = db.runtime_mut();
+
+        let files = package.file_set(db);
+        let state = files.state.lock().unwrap();
+
+        match &*state {
+            State::Lazy => None,
+            State::Indexed(indexed) => {
+                let indexed = indexed.clone();
+                drop(state);
+
+                Some(IndexedFilesMut {
+                    db,
+                    package,
+                    new_revision: indexed.revision,
+                    indexed,
+                })
+            }
+        }
+    }
+}
+
+impl Default for PackageFiles {
+    fn default() -> Self {
+        Self::lazy()
+    }
+}
+
+#[derive(Debug)]
+enum State {
+    /// The files of a package haven't been indexed yet.
+    Lazy,
+
+    /// The files are indexed. Stores the known files of a package.
+    Indexed(IndexedFiles),
+}
+
+pub enum Files<'a> {
+    Lazy(LazyFiles<'a>),
+    Indexed(IndexedFiles),
+}
+
+pub struct LazyFiles<'a> {
+    files: std::sync::MutexGuard<'a, State>,
+}
+
+impl<'a> LazyFiles<'a> {
+    /// Sets the files of a package to `files`.
+    pub fn set(mut self, files: FxHashSet<File>) -> IndexedFiles {
+        let files = IndexedFiles::new(files);
+        *self.files = State::Indexed(files.clone());
+        files
+    }
+}
+
+/// The indexed files of a package.
+///
+/// The type is cheap clonable and allows for in-place mutation of the files. The in-place mutation requires
+/// extra care because the type is used as the result of Salsa queries and Salsa relies on a type's equality
+/// to determine if the output has changed. This is accomplished by using a `revision` that gets incremented
+/// whenever the files are changed. The revision ensures that salas's comparison of the
+/// previous [`IndexedFiles`] with the next [`IndexedFiles`] returns false even though they both
+/// point to the same underlying hash set.
+///
+/// Two [`IndexedFiles`] are only equal if they have the same revision and point to the **same** (identity) hash set.
+#[derive(Debug, Clone)]
+pub struct IndexedFiles {
+    revision: u64,
+    files: Arc<std::sync::Mutex<FxHashSet<File>>>,
+}
+
+impl IndexedFiles {
+    fn new(files: FxHashSet<File>) -> Self {
+        Self {
+            files: Arc::new(std::sync::Mutex::new(files)),
+            revision: 0,
+        }
+    }
+
+    /// Locks the file index for reading.
+    pub fn read(&self) -> IndexedFilesGuard {
+        IndexedFilesGuard {
+            guard: self.files.lock().unwrap(),
+        }
+    }
+}
+
+impl PartialEq for IndexedFiles {
+    fn eq(&self, other: &Self) -> bool {
+        self.revision == other.revision && Arc::ptr_eq(&self.files, &other.files)
+    }
+}
+
+impl Eq for IndexedFiles {}
+
+pub struct IndexedFilesGuard<'a> {
+    guard: std::sync::MutexGuard<'a, FxHashSet<File>>,
+}
+
+impl Deref for IndexedFilesGuard<'_> {
+    type Target = FxHashSet<File>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.guard
+    }
+}
+
+impl<'a> IntoIterator for &'a IndexedFilesGuard<'a> {
+    type Item = File;
+    type IntoIter = IndexedFilesIter<'a>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        IndexedFilesIter {
+            inner: self.guard.iter(),
+        }
+    }
+}
+
+pub struct IndexedFilesIter<'a> {
+    inner: std::collections::hash_set::Iter<'a, File>,
+}
+
+impl<'a> Iterator for IndexedFilesIter<'a> {
+    type Item = File;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner.next().copied()
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.inner.size_hint()
+    }
+}
+
+impl FusedIterator for IndexedFilesIter<'_> {}
+
+impl ExactSizeIterator for IndexedFilesIter<'_> {}
+
+/// A Mutable view of a package's indexed files.
+///
+/// Allows in-place mutation of the files without deep cloning the hash set.
+/// The changes are written back when the mutable view is dropped or by calling [`Self::set`] manually.
+pub struct IndexedFilesMut<'db> {
+    db: &'db mut dyn Db,
+    package: Package,
+    indexed: IndexedFiles,
+    new_revision: u64,
+}
+
+impl IndexedFilesMut<'_> {
+    pub fn insert(&mut self, file: File) -> bool {
+        if self.indexed.files.lock().unwrap().insert(file) {
+            self.new_revision += 1;
+            true
+        } else {
+            false
+        }
+    }
+
+    pub fn remove(&mut self, file: File) -> bool {
+        if self.indexed.files.lock().unwrap().remove(&file) {
+            self.new_revision += 1;
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Writes the changes back to the database.
+    pub fn set(mut self) {
+        self.set_impl();
+    }
+
+    fn set_impl(&mut self) {
+        if self.indexed.revision != self.new_revision {
+            self.package
+                .set_file_set(self.db)
+                .to(PackageFiles::indexed(IndexedFiles {
+                    revision: self.new_revision,
+                    files: self.indexed.files.clone(),
+                }));
+        }
+    }
+}
+
+impl Drop for IndexedFilesMut<'_> {
+    fn drop(&mut self) {
+        self.set_impl();
+    }
+}

--- a/crates/red_knot/src/workspace/files.rs
+++ b/crates/red_knot/src/workspace/files.rs
@@ -14,9 +14,10 @@ use ruff_db::files::File;
 ///
 /// ## Implementation
 /// The implementation uses internal mutability to transition between the lazy and indexed state
-/// without triggering a new salsa revision. The internal mutability **must not** be used for any
-/// other state transition that requires invalidating dependent salsa queries (e.g. adding or removing
-/// files from the index **must** go through the salsa setter to let salsa know about the input change).
+/// without triggering a new salsa revision. This is safe because the initial indexing happens on first access,
+/// so no query can be depending on the contents of the indexed files before that. All subsequent mutations to
+/// the indexed files must go through `IndexedFilesMut`, which uses the Salsa setter `package.set_file_set` to
+/// ensure that Salsa always knows when the set of indexed files have changed.
 #[derive(Debug)]
 pub struct PackageFiles {
     state: std::sync::Mutex<State>,

--- a/crates/ruff_db/src/lib.rs
+++ b/crates/ruff_db/src/lib.rs
@@ -19,7 +19,8 @@ pub mod system;
 pub mod testing;
 pub mod vendored;
 
-pub(crate) type FxDashMap<K, V> = dashmap::DashMap<K, V, BuildHasherDefault<FxHasher>>;
+pub type FxDashMap<K, V> = dashmap::DashMap<K, V, BuildHasherDefault<FxHasher>>;
+pub type FxDashSet<K> = dashmap::DashSet<K, BuildHasherDefault<FxHasher>>;
 
 #[salsa::jar(db=Db)]
 pub struct Jar(File, Program, source_text, line_index, parsed_module);


### PR DESCRIPTION
## Summary
This PR changes the package file discovery from being done eagerly when loading the workspace to lazily when the files are first needed (e.g. because `workspace.check` is called). 

Implementing lazy discovery is a bit tricky because we don't want to throw away all discovered files when a new file watch event comes in. Instead, 
we want to update the workspace files in-place and tell Salsa that the files have changed. 

This PR uses an approach that uses internal mutability to achieve this while guaranteeing that the package files from one salsa revision don't compare equal to the same files in the next salsa revision (unless they are 100% equal).

## Test Plan

Updated integration tests.
