### PR TITLE
add conventional xml.etree.ElementTree import alias

### DIFF
--- a/crates/ruff/tests/snapshots/show_settings__display_default_settings.snap
+++ b/crates/ruff/tests/snapshots/show_settings__display_default_settings.snap
@@ -259,6 +259,7 @@ linter.flake8_import_conventions.aliases = {
 	seaborn = sns,
 	tensorflow = tf,
 	tkinter = tk,
+	xml.etree.ElementTree = ET,
 }
 linter.flake8_import_conventions.banned_aliases = {}
 linter.flake8_import_conventions.banned_from = []

--- a/crates/ruff_linter/src/rules/flake8_import_conventions/settings.rs
+++ b/crates/ruff_linter/src/rules/flake8_import_conventions/settings.rs
@@ -24,6 +24,7 @@ const CONVENTIONAL_ALIASES: &[(&str, &str)] = &[
     ("plotly.express", "px"),
     ("polars", "pl"),
     ("pyarrow", "pa"),
+    ("xml.etree.ElementTree", "ET"),
 ];
 
 #[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize, CacheKey)]

--- a/crates/ruff_workspace/src/options.rs
+++ b/crates/ruff_workspace/src/options.rs
@@ -1291,7 +1291,7 @@ pub struct Flake8ImportConventionsOptions {
     /// The conventional aliases for imports. These aliases can be extended by
     /// the [`extend-aliases`](#lint_flake8-import-conventions_extend-aliases) option.
     #[option(
-        default = r#"{"altair": "alt", "matplotlib": "mpl", "matplotlib.pyplot": "plt", "numpy": "np", "pandas": "pd", "seaborn": "sns", "tensorflow": "tf", "tkinter":  "tk", "holoviews": "hv", "panel": "pn", "plotly.express": "px", "polars": "pl", "pyarrow": "pa"}"#,
+        default = r#"{"altair": "alt", "matplotlib": "mpl", "matplotlib.pyplot": "plt", "numpy": "np", "pandas": "pd", "seaborn": "sns", "tensorflow": "tf", "tkinter":  "tk", "holoviews": "hv", "panel": "pn", "plotly.express": "px", "polars": "pl", "pyarrow": "pa", "xml.etree.ElementTree": "ET"}"#,
         value_type = "dict[str, str]",
         scope = "aliases",
         example = r#"


### PR DESCRIPTION
## Summary

Adding a conventional alias for [ElementTree](https://docs.python.org/3/library/xml.etree.elementtree.html). I looked for other conventional aliases in standard library in order to generalize the point, but found none.
There is still an issue with this. It conflicts with `N817 CamelCase 'ElementTree' imported as acronym 'ET'`. I have to ignore locally:
`import xml.etree.ElementTree as ET # noqa: N817`
too bad

## Test Plan

only test as a `lint.flake8-import-conventions.extend-aliases` configuration option
