### PR TITLE
Do not bail code action resolution when a quick fix is requested

### DIFF
--- a/crates/ruff_server/src/server/api/requests/code_action_resolve.rs
+++ b/crates/ruff_server/src/server/api/requests/code_action_resolve.rs
@@ -69,10 +69,9 @@ impl super::BackgroundDocumentRequestHandler for CodeActionResolve {
                 .with_failure_code(ErrorCode::InternalError)?,
             ),
             SupportedCodeAction::QuickFix => {
-                return Err(anyhow::anyhow!(
-                    "Got a code action that should not need additional resolution: {action_kind:?}"
-                ))
-                .with_failure_code(ErrorCode::InvalidParams)
+                // The client may ask us to resolve a code action, as it has no way of knowing
+                // whether e.g. `command` field will be filled out by the resolution callback.
+                return Ok(action);
             }
         };
 


### PR DESCRIPTION
## Summary

When working on improving Ruff integration with Zed I noticed that it errors out when we try to resolve a code action of a `QUICKFIX` kind; apparently, per @dhruvmanila we shouldn't need to resolve it, as the edit is provided in the initial response for the code action. However, it's possible for the `resolve` call to fill out other fields (such as `command`). 
AFAICT Helix also tries to resolve the code actions unconditionally (as in, when either `edit` or `command` is absent); so does VSC. They can still apply the quickfixes though, as they do not error out on a failed call to resolve code actions - Zed does. Following suit on Zed's side does not cut it though, as we still get a log request from Ruff for that failure (which is surfaced in the UI).
There are also other language servers (such as [rust-analyzer](https://github.com/rust-lang/rust-analyzer/blob/c1c9e10f72ffd2e829d20ff1439ff49c2e121731/crates/rust-analyzer/src/handlers/request.rs#L1257)) that fill out both `command` and `edit` fields as a part of code action resolution.

This PR makes the resolve calls for quickfix actions return the input value.

## Test Plan

N/A
