### PR TITLE
[`flake8-async`] Fix references in documentation not displaying

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_async/rules/async_busy_wait.rs
+++ b/crates/ruff_linter/src/rules/flake8_async/rules/async_busy_wait.rs
@@ -34,9 +34,10 @@ use crate::settings::types::PreviewMode;
 ///     await DONE.wait()
 /// ```
 ///
-/// [`asyncio` events]: https://docs.python.org/3/library/asyncio-sync.html#asyncio.Event
-/// [`anyio` events]: https://trio.readthedocs.io/en/latest/reference-core.html#trio.Event
-/// [`trio` events]: https://anyio.readthedocs.io/en/latest/api.html#anyio.Event
+/// ## References
+/// - [`asyncio` events](https://docs.python.org/3/library/asyncio-sync.html#asyncio.Event)
+/// - [`anyio` events](https://trio.readthedocs.io/en/latest/reference-core.html#trio.Event)
+/// - [`trio` events](https://anyio.readthedocs.io/en/latest/api.html#anyio.Event)
 #[violation]
 pub struct AsyncBusyWait {
     module: AsyncModule,

--- a/crates/ruff_linter/src/rules/flake8_async/rules/async_function_with_timeout.rs
+++ b/crates/ruff_linter/src/rules/flake8_async/rules/async_function_with_timeout.rs
@@ -37,9 +37,10 @@ use crate::settings::types::PreviewMode;
 ///         await long_running_task()
 /// ```
 ///
-/// [`asyncio` timeouts]: https://docs.python.org/3/library/asyncio-task.html#timeouts
-/// [`anyio` timeouts]: https://anyio.readthedocs.io/en/stable/cancellation.html
-/// [`trio` timeouts]: https://trio.readthedocs.io/en/stable/reference-core.html#cancellation-and-timeouts
+/// ## References
+/// - [`asyncio` timeouts](https://docs.python.org/3/library/asyncio-task.html#timeouts)
+/// - [`anyio` timeouts](https://anyio.readthedocs.io/en/stable/cancellation.html)
+/// - [`trio` timeouts](https://trio.readthedocs.io/en/stable/reference-core.html#cancellation-and-timeouts)
 #[violation]
 pub struct AsyncFunctionWithTimeout {
     module: AsyncModule,

--- a/crates/ruff_linter/src/rules/flake8_async/rules/cancel_scope_no_checkpoint.rs
+++ b/crates/ruff_linter/src/rules/flake8_async/rules/cancel_scope_no_checkpoint.rs
@@ -32,9 +32,10 @@ use crate::settings::types::PreviewMode;
 ///         await awaitable()
 /// ```
 ///
-/// [`asyncio` timeouts]: https://docs.python.org/3/library/asyncio-task.html#timeouts
-/// [`anyio` timeouts]: https://anyio.readthedocs.io/en/stable/cancellation.html
-/// [`trio` timeouts]: https://trio.readthedocs.io/en/stable/reference-core.html#cancellation-and-timeouts
+/// ## References
+/// - [`asyncio` timeouts](https://docs.python.org/3/library/asyncio-task.html#timeouts)
+/// - [`anyio` timeouts](https://anyio.readthedocs.io/en/stable/cancellation.html)
+/// - [`trio` timeouts](https://trio.readthedocs.io/en/stable/reference-core.html#cancellation-and-timeouts)
 #[violation]
 pub struct CancelScopeNoCheckpoint {
     method_name: MethodName,


### PR DESCRIPTION
## Summary

Fix references in documentation of several `ASYNC` rules not displaying

## Test Plan

Validated documentation now displays correctly