### PR TITLE
Fix NumPy 2.0 rule for `np.alltrue` and `np.sometrue`

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/numpy/NPY201_2.py
+++ b/crates/ruff_linter/resources/test/fixtures/numpy/NPY201_2.py
@@ -41,7 +41,7 @@ def func():
 
     np.alltrue([True, True])
 
-    np.anytrue([True, False])
+    np.sometrue([True, False])
 
     np.cumproduct([1, 2, 3])
 

--- a/crates/ruff_linter/src/rules/numpy/rules/numpy_2_0_deprecation.rs
+++ b/crates/ruff_linter/src/rules/numpy/rules/numpy_2_0_deprecation.rs
@@ -186,8 +186,10 @@ pub(crate) fn numpy_2_0_deprecation(checker: &mut Checker, expr: &Expr) {
             }),
             ["numpy", "alltrue"] => Some(Replacement {
                 existing: "alltrue",
-                details: Details::AutoPurePython {
-                    python_expr: "all",
+                details: Details::AutoImport {
+                    path: "numpy",
+                    name: "all",
+                    compatibility: Compatibility::BackwardsCompatible,
                 },
             }),
             ["numpy", "asfarray"] => Some(Replacement {
@@ -524,8 +526,10 @@ pub(crate) fn numpy_2_0_deprecation(checker: &mut Checker, expr: &Expr) {
             }),
             ["numpy", "sometrue"] => Some(Replacement {
                 existing: "sometrue",
-                details: Details::AutoPurePython {
-                    python_expr: "any",
+                details: Details::AutoImport {
+                    path: "numpy",
+                    name: "any",
+                    compatibility: Compatibility::BackwardsCompatible,
                 },
             }),
             ["numpy", "source"] => Some(Replacement {

--- a/crates/ruff_linter/src/rules/numpy/snapshots/ruff_linter__rules__numpy__tests__numpy2-deprecation_NPY201_2.py.snap
+++ b/crates/ruff_linter/src/rules/numpy/snapshots/ruff_linter__rules__numpy__tests__numpy2-deprecation_NPY201_2.py.snap
@@ -313,7 +313,7 @@ NPY201_2.py:42:5: NPY201 [*] `np.alltrue` will be removed in NumPy 2.0. Use `num
 42 |     np.alltrue([True, True])
    |     ^^^^^^^^^^ NPY201
 43 | 
-44 |     np.anytrue([True, False])
+44 |     np.sometrue([True, False])
    |
    = help: Replace with `numpy.all`
 
@@ -324,12 +324,33 @@ NPY201_2.py:42:5: NPY201 [*] `np.alltrue` will be removed in NumPy 2.0. Use `num
 42    |-    np.alltrue([True, True])
    42 |+    np.all([True, True])
 43 43 | 
-44 44 |     np.anytrue([True, False])
+44 44 |     np.sometrue([True, False])
 45 45 | 
+
+NPY201_2.py:42:5: NPY201 [*] `np.sometrue` will be removed in NumPy 2.0. Use `numpy.any` instead.
+   |
+42 |     np.alltrue([True, True])
+43 | 
+44 |     np.sometrue([True, False])
+   |     ^^^^^^^^^^^ NPY201
+45 | 
+46 |     np.cumproduct([1, 2, 3])
+   |
+   = help: Replace with `numpy.any`
+
+ℹ Safe fix
+41 41 | 
+42 42 |     np.alltrue([True, True])
+43 43 | 
+44    |-    np.sometrue([True, False])
+   44 |+    np.any([True, False])
+45 45 | 
+46 46 |     np.cumproduct([1, 2, 3])
+47 47 | 
 
 NPY201_2.py:46:5: NPY201 [*] `np.cumproduct` will be removed in NumPy 2.0. Use `numpy.cumprod` instead.
    |
-44 |     np.anytrue([True, False])
+44 |     np.sometrue([True, False])
 45 | 
 46 |     np.cumproduct([1, 2, 3])
    |     ^^^^^^^^^^^^^ NPY201
@@ -340,7 +361,7 @@ NPY201_2.py:46:5: NPY201 [*] `np.cumproduct` will be removed in NumPy 2.0. Use `
 
 ℹ Safe fix
 43 43 | 
-44 44 |     np.anytrue([True, False])
+44 44 |     np.sometrue([True, False])
 45 45 | 
 46    |-    np.cumproduct([1, 2, 3])
    46 |+    np.cumprod([1, 2, 3])

--- a/crates/ruff_linter/src/rules/numpy/snapshots/ruff_linter__rules__numpy__tests__numpy2-deprecation_NPY201_2.py.snap
+++ b/crates/ruff_linter/src/rules/numpy/snapshots/ruff_linter__rules__numpy__tests__numpy2-deprecation_NPY201_2.py.snap
@@ -327,7 +327,7 @@ NPY201_2.py:42:5: NPY201 [*] `np.alltrue` will be removed in NumPy 2.0. Use `num
 44 44 |     np.sometrue([True, False])
 45 45 | 
 
-NPY201_2.py:42:5: NPY201 [*] `np.sometrue` will be removed in NumPy 2.0. Use `numpy.any` instead.
+NPY201_2.py:44:5: NPY201 [*] `np.sometrue` will be removed in NumPy 2.0. Use `numpy.any` instead.
    |
 42 |     np.alltrue([True, True])
 43 | 

--- a/crates/ruff_linter/src/rules/numpy/snapshots/ruff_linter__rules__numpy__tests__numpy2-deprecation_NPY201_2.py.snap
+++ b/crates/ruff_linter/src/rules/numpy/snapshots/ruff_linter__rules__numpy__tests__numpy2-deprecation_NPY201_2.py.snap
@@ -306,7 +306,7 @@ NPY201_2.py:40:5: NPY201 [*] `np.row_stack` will be removed in NumPy 2.0. Use `n
 42 42 |     np.alltrue([True, True])
 43 43 | 
 
-NPY201_2.py:42:5: NPY201 [*] `np.alltrue` will be removed in NumPy 2.0. Use `all` instead.
+NPY201_2.py:42:5: NPY201 [*] `np.alltrue` will be removed in NumPy 2.0. Use `numpy.all` instead.
    |
 40 |     np.row_stack(([1,2], [3,4]))
 41 | 
@@ -315,14 +315,14 @@ NPY201_2.py:42:5: NPY201 [*] `np.alltrue` will be removed in NumPy 2.0. Use `all
 43 | 
 44 |     np.anytrue([True, False])
    |
-   = help: Replace with `all`
+   = help: Replace with `numpy.all`
 
 ℹ Safe fix
 39 39 | 
 40 40 |     np.row_stack(([1,2], [3,4]))
 41 41 | 
 42    |-    np.alltrue([True, True])
-   42 |+    all([True, True])
+   42 |+    np.all([True, True])
 43 43 | 
 44 44 |     np.anytrue([True, False])
 45 45 | 


### PR DESCRIPTION
Fixes: https://github.com/astral-sh/ruff/issues/12416

Also to be fixed in NumPy: https://github.com/numpy/numpy/pull/27015