### PR TITLE
[flake8-bugbear] Allow singleton tuples with starred expressions in B013

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_bugbear/B013.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_bugbear/B013.py
@@ -12,3 +12,10 @@ except (*retriable_exceptions,):
     pass
 except(ValueError,):
     pass
+
+list_exceptions = [FileExistsError, FileNotFoundError]
+
+try:
+    pass
+except (*list_exceptions,):
+    pass

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/redundant_tuple_in_exception_handler.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/redundant_tuple_in_exception_handler.rs
@@ -1,6 +1,5 @@
 use ruff_diagnostics::{AlwaysFixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
-use ruff_python_ast::helpers::map_starred;
 use ruff_python_ast::{self as ast, ExceptHandler, Expr};
 use ruff_text_size::Ranged;
 

--- a/crates/ruff_linter/src/rules/flake8_bugbear/snapshots/ruff_linter__rules__flake8_bugbear__tests__B013_B013.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/snapshots/ruff_linter__rules__flake8_bugbear__tests__B013_B013.py.snap
@@ -22,27 +22,6 @@ B013.py:5:8: B013 [*] A length-one tuple literal is redundant in exception handl
 7 7 | except AttributeError:
 8 8 |     pass
 
-B013.py:11:8: B013 [*] A length-one tuple literal is redundant in exception handlers
-   |
- 9 | except (ImportError, TypeError):
-10 |     pass
-11 | except (*retriable_exceptions,):
-   |        ^^^^^^^^^^^^^^^^^^^^^^^^ B013
-12 |     pass
-13 | except(ValueError,):
-   |
-   = help: Replace with `except retriable_exceptions`
-
-ℹ Safe fix
-8  8  |     pass
-9  9  | except (ImportError, TypeError):
-10 10 |     pass
-11    |-except (*retriable_exceptions,):
-   11 |+except retriable_exceptions:
-12 12 |     pass
-13 13 | except(ValueError,):
-14 14 |     pass
-
 B013.py:13:7: B013 [*] A length-one tuple literal is redundant in exception handlers
    |
 11 | except (*retriable_exceptions,):
@@ -60,5 +39,5 @@ B013.py:13:7: B013 [*] A length-one tuple literal is redundant in exception hand
 13    |-except(ValueError,):
    13 |+except ValueError:
 14 14 |     pass
-
-
+15 15 | 
+16 16 | list_exceptions = [FileExistsError, FileNotFoundError]


### PR DESCRIPTION
## Summary

Closes #12450. Reverts previous attempt at handling starred expressions introduced in #7080 - replacing this approach by simply allowing such expressions.

## Test Plan

- [x] Added bug case to test fixture
- [x] Cargo test 
