### PR TITLE
[red-knot] Add support for untitled files

### DIFF
--- a/crates/red_knot_module_resolver/src/path.rs
+++ b/crates/red_knot_module_resolver/src/path.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 
 use camino::{Utf8Path, Utf8PathBuf};
 
-use ruff_db::files::{system_path_to_file, vendored_path_to_file, File, FilePath};
+use ruff_db::files::{system_path_to_file, vendored_path_to_file, File};
 use ruff_db::system::{System, SystemPath, SystemPathBuf};
 use ruff_db::vendored::{VendoredPath, VendoredPathBuf};
 
@@ -474,18 +474,21 @@ impl SearchPath {
         matches!(&*self.0, SearchPathInner::SitePackages(_))
     }
 
-    #[must_use]
-    pub(crate) fn relativize_path(&self, path: &FilePath) -> Option<ModulePath> {
-        let extension = path.extension();
-
+    fn is_valid_extension(&self, extension: &str) -> bool {
         if self.is_standard_library() {
-            if extension.is_some_and(|extension| extension != "pyi") {
-                return None;
-            }
+            extension == "pyi"
         } else {
-            if extension.is_some_and(|extension| !matches!(extension, "pyi" | "py")) {
-                return None;
-            }
+            matches!(extension, "pyi" | "py")
+        }
+    }
+
+    #[must_use]
+    pub(crate) fn relativize_system_path(&self, path: &SystemPath) -> Option<ModulePath> {
+        if path
+            .extension()
+            .is_some_and(|extension| !self.is_valid_extension(extension))
+        {
+            return None;
         }
 
         match &*self.0 {
@@ -493,16 +496,36 @@ impl SearchPath {
             | SearchPathInner::FirstParty(search_path)
             | SearchPathInner::StandardLibraryCustom(search_path)
             | SearchPathInner::SitePackages(search_path)
-            | SearchPathInner::Editable(search_path) => path
-                .as_system_path()
-                .and_then(|absolute_path| absolute_path.strip_prefix(search_path).ok())
-                .map(|relative_path| ModulePath {
-                    search_path: self.clone(),
-                    relative_path: relative_path.as_utf8_path().to_path_buf(),
-                }),
+            | SearchPathInner::Editable(search_path) => {
+                path.strip_prefix(search_path)
+                    .ok()
+                    .map(|relative_path| ModulePath {
+                        search_path: self.clone(),
+                        relative_path: relative_path.as_utf8_path().to_path_buf(),
+                    })
+            }
+            SearchPathInner::StandardLibraryVendored(_) => None,
+        }
+    }
+
+    #[must_use]
+    pub(crate) fn relativize_vendored_path(&self, path: &VendoredPath) -> Option<ModulePath> {
+        if path
+            .extension()
+            .is_some_and(|extension| !self.is_valid_extension(extension))
+        {
+            return None;
+        }
+
+        match &*self.0 {
+            SearchPathInner::Extra(_)
+            | SearchPathInner::FirstParty(_)
+            | SearchPathInner::StandardLibraryCustom(_)
+            | SearchPathInner::SitePackages(_)
+            | SearchPathInner::Editable(_) => None,
             SearchPathInner::StandardLibraryVendored(search_path) => path
-                .as_vendored_path()
-                .and_then(|absolute_path| absolute_path.strip_prefix(search_path).ok())
+                .strip_prefix(search_path)
+                .ok()
                 .map(|relative_path| ModulePath {
                     search_path: self.clone(),
                     relative_path: relative_path.as_utf8_path().to_path_buf(),
@@ -793,14 +816,14 @@ mod tests {
         let root = SearchPath::custom_stdlib(&db, stdlib.parent().unwrap().to_path_buf()).unwrap();
 
         // Must have a `.pyi` extension or no extension:
-        let bad_absolute_path = FilePath::system("foo/stdlib/x.py");
-        assert_eq!(root.relativize_path(&bad_absolute_path), None);
-        let second_bad_absolute_path = FilePath::system("foo/stdlib/x.rs");
-        assert_eq!(root.relativize_path(&second_bad_absolute_path), None);
+        let bad_absolute_path = SystemPath::new("foo/stdlib/x.py");
+        assert_eq!(root.relativize_system_path(bad_absolute_path), None);
+        let second_bad_absolute_path = SystemPath::new("foo/stdlib/x.rs");
+        assert_eq!(root.relativize_system_path(second_bad_absolute_path), None);
 
         // Must be a path that is a child of `root`:
-        let third_bad_absolute_path = FilePath::system("bar/stdlib/x.pyi");
-        assert_eq!(root.relativize_path(&third_bad_absolute_path), None);
+        let third_bad_absolute_path = SystemPath::new("bar/stdlib/x.pyi");
+        assert_eq!(root.relativize_system_path(third_bad_absolute_path), None);
     }
 
     #[test]
@@ -809,19 +832,21 @@ mod tests {
 
         let root = SearchPath::extra(db.system(), src.clone()).unwrap();
         // Must have a `.py` extension, a `.pyi` extension, or no extension:
-        let bad_absolute_path = FilePath::System(src.join("x.rs"));
-        assert_eq!(root.relativize_path(&bad_absolute_path), None);
+        let bad_absolute_path = src.join("x.rs");
+        assert_eq!(root.relativize_system_path(&bad_absolute_path), None);
         // Must be a path that is a child of `root`:
-        let second_bad_absolute_path = FilePath::system("bar/src/x.pyi");
-        assert_eq!(root.relativize_path(&second_bad_absolute_path), None);
+        let second_bad_absolute_path = SystemPath::new("bar/src/x.pyi");
+        assert_eq!(root.relativize_system_path(second_bad_absolute_path), None);
     }
 
     #[test]
     fn relativize_path() {
         let TestCase { db, src, .. } = TestCaseBuilder::new().build();
         let src_search_path = SearchPath::first_party(db.system(), src.clone()).unwrap();
-        let eggs_package = FilePath::System(src.join("eggs/__init__.pyi"));
-        let module_path = src_search_path.relativize_path(&eggs_package).unwrap();
+        let eggs_package = src.join("eggs/__init__.pyi");
+        let module_path = src_search_path
+            .relativize_system_path(&eggs_package)
+            .unwrap();
         assert_eq!(
             &module_path.relative_path,
             Utf8Path::new("eggs/__init__.pyi")

--- a/crates/ruff_db/src/files.rs
+++ b/crates/ruff_db/src/files.rs
@@ -5,7 +5,7 @@ use dashmap::mapref::entry::Entry;
 
 use crate::file_revision::FileRevision;
 use crate::files::private::FileStatus;
-use crate::system::{SystemPath, SystemPathBuf};
+use crate::system::{Metadata, SystemPath, SystemPathBuf, SystemVirtualPath, SystemVirtualPathBuf};
 use crate::vendored::{VendoredPath, VendoredPathBuf};
 use crate::{Db, FxDashMap};
 pub use path::FilePath;
@@ -27,6 +27,12 @@ pub fn system_path_to_file(db: &dyn Db, path: impl AsRef<SystemPath>) -> Option<
     file.exists(db).then_some(file)
 }
 
+/// Interns a virtual file system path and returns a salsa [`File`] ingredient.
+#[inline]
+pub fn system_virtual_path_to_file(db: &dyn Db, path: impl AsRef<SystemVirtualPath>) -> File {
+    db.files().system_virtual(db, path.as_ref())
+}
+
 /// Interns a vendored file path. Returns `Some` if the vendored file for `path` exists and `None` otherwise.
 #[inline]
 pub fn vendored_path_to_file(db: &dyn Db, path: impl AsRef<VendoredPath>) -> Option<File> {
@@ -46,6 +52,9 @@ struct FilesInner {
     /// The map also stores entries for files that don't exist on the file system. This is necessary
     /// so that queries that depend on the existence of a file are re-executed when the file is created.
     system_by_path: FxDashMap<SystemPathBuf, File>,
+
+    /// Lookup table that maps [`SystemVirtualPathBuf`]s to salsa interned [`File`] instances.
+    system_virtual_by_path: FxDashMap<SystemVirtualPathBuf, File>,
 
     /// Lookup table that maps vendored files to the salsa [`File`] ingredients.
     vendored_by_path: FxDashMap<VendoredPathBuf, File>,
@@ -97,6 +106,37 @@ impl Files {
             .system_by_path
             .get(&absolute)
             .map(|entry| *entry.value())
+    }
+
+    #[tracing::instrument(level = "trace", skip(self, db), ret)]
+    fn system_virtual(&self, db: &dyn Db, path: &SystemVirtualPath) -> File {
+        *self
+            .inner
+            .system_virtual_by_path
+            .entry(path.to_path_buf())
+            .or_insert_with(|| {
+                let path_buf = path.to_path_buf();
+                let metadata = db.system().virtual_path_metadata(&path_buf);
+
+                match metadata {
+                    Ok(metadata) => File::new(
+                        db,
+                        FilePath::SystemVirtual(path_buf),
+                        metadata.permissions(),
+                        metadata.revision(),
+                        FileStatus::Exists,
+                        Count::default(),
+                    ),
+                    _ => File::new(
+                        db,
+                        FilePath::SystemVirtual(path_buf),
+                        None,
+                        FileRevision::zero(),
+                        FileStatus::Deleted,
+                        Count::default(),
+                    ),
+                }
+            })
     }
 
     /// Looks up a vendored file by its path. Returns `Some` if a vendored file for the given path
@@ -227,6 +267,9 @@ impl File {
                 db.system().read_to_string(system)
             }
             FilePath::Vendored(vendored) => db.vendored().read_to_string(vendored),
+            FilePath::SystemVirtual(system_virtual) => {
+                db.system().read_virtual_path_to_string(system_virtual)
+            }
         }
     }
 
@@ -248,6 +291,9 @@ impl File {
                 std::io::ErrorKind::InvalidInput,
                 "Reading a notebook from the vendored file system is not supported.",
             ))),
+            FilePath::SystemVirtual(system_virtual) => {
+                db.system().read_virtual_path_to_notebook(system_virtual)
+            }
         }
     }
 
@@ -255,7 +301,7 @@ impl File {
     #[tracing::instrument(level = "debug", skip(db))]
     pub fn sync_path(db: &mut dyn Db, path: &SystemPath) {
         let absolute = SystemPath::absolute(path, db.system().current_directory());
-        Self::sync_impl(db, &absolute, None);
+        Self::sync_system_path(db, &absolute, None);
     }
 
     /// Syncs the [`File`]'s state with the state of the file on the system.
@@ -265,22 +311,32 @@ impl File {
 
         match path {
             FilePath::System(system) => {
-                Self::sync_impl(db, &system, Some(self));
+                Self::sync_system_path(db, &system, Some(self));
             }
             FilePath::Vendored(_) => {
                 // Readonly, can never be out of date.
             }
+            FilePath::SystemVirtual(system_virtual) => {
+                Self::sync_system_virtual_path(db, &system_virtual, self);
+            }
         }
     }
 
-    /// Private method providing the implementation for [`Self::sync_path`] and [`Self::sync_path`].
-    fn sync_impl(db: &mut dyn Db, path: &SystemPath, file: Option<File>) {
+    fn sync_system_path(db: &mut dyn Db, path: &SystemPath, file: Option<File>) {
         let Some(file) = file.or_else(|| db.files().try_system(db, path)) else {
             return;
         };
-
         let metadata = db.system().path_metadata(path);
+        Self::sync_impl(db, metadata, file);
+    }
 
+    fn sync_system_virtual_path(db: &mut dyn Db, path: &SystemVirtualPath, file: File) {
+        let metadata = db.system().virtual_path_metadata(path);
+        Self::sync_impl(db, metadata, file);
+    }
+
+    /// Private method providing the implementation for [`Self::sync_path`] and [`Self::sync`].
+    fn sync_impl(db: &mut dyn Db, metadata: crate::system::Result<Metadata>, file: File) {
         let (status, revision, permission) = match metadata {
             Ok(metadata) if metadata.file_type().is_file() => (
                 FileStatus::Exists,

--- a/crates/ruff_db/src/files/path.rs
+++ b/crates/ruff_db/src/files/path.rs
@@ -3,8 +3,6 @@ use crate::system::{SystemPath, SystemPathBuf, SystemVirtualPath, SystemVirtualP
 use crate::vendored::{VendoredPath, VendoredPathBuf};
 use crate::Db;
 
-use super::system_virtual_path_to_file;
-
 /// Path to a file.
 ///
 /// The path abstracts that files in Ruff can come from different sources:
@@ -92,14 +90,14 @@ impl FilePath {
     ///
     /// Returns `Some` if a file for `path` exists and is accessible by the user. Returns `None` otherwise.
     ///
-    /// See [`system_path_to_file`], [`vendored_path_to_file`], or [`system_virtual_path_to_file`]
-    /// if you always have either a file system path, vendored path, or virtual path respectively.
+    /// See [`system_path_to_file`] or [`vendored_path_to_file`] if you always have either a file
+    /// system or vendored path.
     #[inline]
     pub fn to_file(&self, db: &dyn Db) -> Option<File> {
         match self {
             FilePath::System(path) => system_path_to_file(db, path),
             FilePath::Vendored(path) => vendored_path_to_file(db, path),
-            FilePath::SystemVirtual(path) => Some(system_virtual_path_to_file(db, path)),
+            FilePath::SystemVirtual(_) => None,
         }
     }
 

--- a/crates/ruff_db/src/files/path.rs
+++ b/crates/ruff_db/src/files/path.rs
@@ -1,18 +1,23 @@
 use crate::files::{system_path_to_file, vendored_path_to_file, File};
-use crate::system::{SystemPath, SystemPathBuf};
+use crate::system::{SystemPath, SystemPathBuf, SystemVirtualPath, SystemVirtualPathBuf};
 use crate::vendored::{VendoredPath, VendoredPathBuf};
 use crate::Db;
+
+use super::system_virtual_path_to_file;
 
 /// Path to a file.
 ///
 /// The path abstracts that files in Ruff can come from different sources:
 ///
 /// * a file stored on the [host system](crate::system::System).
+/// * a virtual file stored on the [host system](crate::system::System).
 /// * a vendored file stored in the [vendored file system](crate::vendored::VendoredFileSystem).
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub enum FilePath {
     /// Path to a file on the [host system](crate::system::System).
     System(SystemPathBuf),
+    /// Path to a virtual file on the [host system](crate::system::System).
+    SystemVirtual(SystemVirtualPathBuf),
     /// Path to a file vendored as part of Ruff. Stored in the [vendored file system](crate::vendored::VendoredFileSystem).
     Vendored(VendoredPathBuf),
 }
@@ -30,7 +35,7 @@ impl FilePath {
     pub fn into_system_path_buf(self) -> Option<SystemPathBuf> {
         match self {
             FilePath::System(path) => Some(path),
-            FilePath::Vendored(_) => None,
+            FilePath::Vendored(_) | FilePath::SystemVirtual(_) => None,
         }
     }
 
@@ -39,7 +44,7 @@ impl FilePath {
     pub fn as_system_path(&self) -> Option<&SystemPath> {
         match self {
             FilePath::System(path) => Some(path.as_path()),
-            FilePath::Vendored(_) => None,
+            FilePath::Vendored(_) | FilePath::SystemVirtual(_) => None,
         }
     }
 
@@ -48,6 +53,14 @@ impl FilePath {
     #[inline]
     pub const fn is_system_path(&self) -> bool {
         matches!(self, FilePath::System(_))
+    }
+
+    /// Returns `true` if the path is a file system path that is virtual i.e., it doesn't exists on
+    /// disk.
+    #[must_use]
+    #[inline]
+    pub const fn is_system_virtual_path(&self) -> bool {
+        matches!(self, FilePath::SystemVirtual(_))
     }
 
     /// Returns `true` if the path is a vendored path.
@@ -62,7 +75,7 @@ impl FilePath {
     pub fn as_vendored_path(&self) -> Option<&VendoredPath> {
         match self {
             FilePath::Vendored(path) => Some(path.as_path()),
-            FilePath::System(_) => None,
+            FilePath::System(_) | FilePath::SystemVirtual(_) => None,
         }
     }
 
@@ -71,6 +84,7 @@ impl FilePath {
         match self {
             FilePath::System(path) => path.as_str(),
             FilePath::Vendored(path) => path.as_str(),
+            FilePath::SystemVirtual(path) => path.as_str(),
         }
     }
 
@@ -78,12 +92,14 @@ impl FilePath {
     ///
     /// Returns `Some` if a file for `path` exists and is accessible by the user. Returns `None` otherwise.
     ///
-    /// See [`system_path_to_file`] and [`vendored_path_to_file`] if you always have either a file system or vendored path.
+    /// See [`system_path_to_file`], [`vendored_path_to_file`], or [`system_virtual_path_to_file`]
+    /// if you always have either a file system path, vendored path, or virtual path respectively.
     #[inline]
     pub fn to_file(&self, db: &dyn Db) -> Option<File> {
         match self {
             FilePath::System(path) => system_path_to_file(db, path),
             FilePath::Vendored(path) => vendored_path_to_file(db, path),
+            FilePath::SystemVirtual(path) => Some(system_virtual_path_to_file(db, path)),
         }
     }
 
@@ -92,6 +108,7 @@ impl FilePath {
         match self {
             FilePath::System(path) => path.extension(),
             FilePath::Vendored(path) => path.extension(),
+            FilePath::SystemVirtual(_) => None,
         }
     }
 }
@@ -123,6 +140,18 @@ impl From<VendoredPathBuf> for FilePath {
 impl From<&VendoredPath> for FilePath {
     fn from(value: &VendoredPath) -> Self {
         Self::Vendored(value.to_path_buf())
+    }
+}
+
+impl From<&SystemVirtualPath> for FilePath {
+    fn from(value: &SystemVirtualPath) -> Self {
+        FilePath::SystemVirtual(value.to_path_buf())
+    }
+}
+
+impl From<SystemVirtualPathBuf> for FilePath {
+    fn from(value: SystemVirtualPathBuf) -> Self {
+        FilePath::SystemVirtual(value)
     }
 }
 

--- a/crates/ruff_db/src/parsed.rs
+++ b/crates/ruff_db/src/parsed.rs
@@ -32,6 +32,8 @@ pub fn parsed_module(db: &dyn Db, file: File) -> ParsedModule {
             .extension()
             .map_or(PySourceType::Python, PySourceType::from_extension),
         FilePath::Vendored(_) => PySourceType::Stub,
+        // TODO(dhruvmanila): Virtual paths can be Jupyter Notebooks as well
+        FilePath::SystemVirtual(_) => PySourceType::Python,
     };
 
     ParsedModule::new(parse_unchecked_source(&source, ty))

--- a/crates/ruff_db/src/parsed.rs
+++ b/crates/ruff_db/src/parsed.rs
@@ -32,8 +32,9 @@ pub fn parsed_module(db: &dyn Db, file: File) -> ParsedModule {
             .extension()
             .map_or(PySourceType::Python, PySourceType::from_extension),
         FilePath::Vendored(_) => PySourceType::Stub,
-        // TODO(dhruvmanila): Virtual paths can be Jupyter Notebooks as well
-        FilePath::SystemVirtual(_) => PySourceType::Python,
+        FilePath::SystemVirtual(path) => path
+            .extension()
+            .map_or(PySourceType::Python, PySourceType::from_extension),
     };
 
     ParsedModule::new(parse_unchecked_source(&source, ty))
@@ -76,9 +77,10 @@ impl std::fmt::Debug for ParsedModule {
 mod tests {
     use crate::files::{system_path_to_file, vendored_path_to_file};
     use crate::parsed::parsed_module;
-    use crate::system::{DbWithTestSystem, SystemPath};
+    use crate::system::{DbWithTestSystem, SystemPath, SystemVirtualPath};
     use crate::tests::TestDb;
     use crate::vendored::{tests::VendoredFileSystemBuilder, VendoredPath};
+    use crate::Db;
 
     #[test]
     fn python_file() -> crate::system::Result<()> {
@@ -104,6 +106,38 @@ mod tests {
         db.write_file(path, "%timeit a = b".to_string())?;
 
         let file = system_path_to_file(&db, path).unwrap();
+
+        let parsed = parsed_module(&db, file);
+
+        assert!(parsed.is_valid());
+
+        Ok(())
+    }
+
+    #[test]
+    fn virtual_python_file() -> crate::system::Result<()> {
+        let mut db = TestDb::new();
+        let path = SystemVirtualPath::new("untitled:Untitled-1");
+
+        db.write_virtual_file(path, "x = 10");
+
+        let file = db.files().add_virtual_file(&db, path).unwrap();
+
+        let parsed = parsed_module(&db, file);
+
+        assert!(parsed.is_valid());
+
+        Ok(())
+    }
+
+    #[test]
+    fn virtual_ipynb_file() -> crate::system::Result<()> {
+        let mut db = TestDb::new();
+        let path = SystemVirtualPath::new("untitled:Untitled-1.ipynb");
+
+        db.write_virtual_file(path, "%timeit a = b");
+
+        let file = db.files().add_virtual_file(&db, path).unwrap();
 
         let parsed = parsed_module(&db, file);
 

--- a/crates/ruff_db/src/system.rs
+++ b/crates/ruff_db/src/system.rs
@@ -11,6 +11,7 @@ use crate::file_revision::FileRevision;
 
 pub use self::path::{
     deduplicate_nested_paths, DeduplicatedNestedPathsIter, SystemPath, SystemPathBuf,
+    SystemVirtualPath, SystemVirtualPathBuf,
 };
 
 mod memory_fs;
@@ -49,6 +50,18 @@ pub trait System: Debug {
     /// allowing to skip the notebook deserialization. Systems that don't use a structured
     /// representation fall-back to deserializing the notebook from a string.
     fn read_to_notebook(&self, path: &SystemPath) -> std::result::Result<Notebook, NotebookError>;
+
+    /// Reads the metadata of the virtual file at `path`.
+    fn virtual_path_metadata(&self, path: &SystemVirtualPath) -> Result<Metadata>;
+
+    /// Reads the content of the virtual file at `path` into a [`String`].
+    fn read_virtual_path_to_string(&self, path: &SystemVirtualPath) -> Result<String>;
+
+    /// Reads the content of the virtual file at `path` as a [`Notebook`].
+    fn read_virtual_path_to_notebook(
+        &self,
+        path: &SystemVirtualPath,
+    ) -> std::result::Result<Notebook, NotebookError>;
 
     /// Returns `true` if `path` exists.
     fn path_exists(&self, path: &SystemPath) -> bool {

--- a/crates/ruff_db/src/system/memory_fs.rs
+++ b/crates/ruff_db/src/system/memory_fs.rs
@@ -5,8 +5,11 @@ use std::sync::{Arc, RwLock, RwLockWriteGuard};
 use camino::{Utf8Path, Utf8PathBuf};
 use filetime::FileTime;
 
+use ruff_notebook::{Notebook, NotebookError};
+
 use crate::system::{
     walk_directory, DirectoryEntry, FileType, Metadata, Result, SystemPath, SystemPathBuf,
+    SystemVirtualPath,
 };
 
 use super::walk_directory::{
@@ -132,6 +135,21 @@ impl MemoryFileSystem {
     ) -> std::result::Result<ruff_notebook::Notebook, ruff_notebook::NotebookError> {
         let content = self.read_to_string(path)?;
         ruff_notebook::Notebook::from_source_code(&content)
+    }
+
+    pub(crate) fn virtual_path_metadata(&self, _path: &SystemVirtualPath) -> Result<Metadata> {
+        Err(not_found())
+    }
+
+    pub(crate) fn read_virtual_path_to_string(&self, _path: &SystemVirtualPath) -> Result<String> {
+        Err(not_found())
+    }
+
+    pub(crate) fn read_virtual_path_to_notebook(
+        &self,
+        _path: &SystemVirtualPath,
+    ) -> std::result::Result<Notebook, NotebookError> {
+        Err(NotebookError::from(not_found()))
     }
 
     pub fn exists(&self, path: &SystemPath) -> bool {

--- a/crates/ruff_db/src/system/os.rs
+++ b/crates/ruff_db/src/system/os.rs
@@ -7,6 +7,7 @@ use ruff_notebook::{Notebook, NotebookError};
 
 use crate::system::{
     DirectoryEntry, FileType, Metadata, Result, System, SystemPath, SystemPathBuf,
+    SystemVirtualPath,
 };
 
 use super::walk_directory::{
@@ -74,6 +75,21 @@ impl System for OsSystem {
 
     fn read_to_notebook(&self, path: &SystemPath) -> std::result::Result<Notebook, NotebookError> {
         Notebook::from_path(path.as_std_path())
+    }
+
+    fn virtual_path_metadata(&self, _path: &SystemVirtualPath) -> Result<Metadata> {
+        Err(not_found())
+    }
+
+    fn read_virtual_path_to_string(&self, _path: &SystemVirtualPath) -> Result<String> {
+        Err(not_found())
+    }
+
+    fn read_virtual_path_to_notebook(
+        &self,
+        _path: &SystemVirtualPath,
+    ) -> std::result::Result<Notebook, NotebookError> {
+        Err(NotebookError::from(not_found()))
     }
 
     fn path_exists(&self, path: &SystemPath) -> bool {
@@ -273,6 +289,10 @@ impl From<WalkState> for ignore::WalkState {
             WalkState::Quit => ignore::WalkState::Quit,
         }
     }
+}
+
+fn not_found() -> std::io::Error {
+    std::io::Error::new(std::io::ErrorKind::NotFound, "No such file or directory")
 }
 
 #[cfg(test)]

--- a/crates/ruff_db/src/system/path.rs
+++ b/crates/ruff_db/src/system/path.rs
@@ -609,6 +609,23 @@ impl SystemVirtualPath {
         SystemVirtualPathBuf(self.0.to_string())
     }
 
+    /// Extracts the file extension, if possible.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ruff_db::system::SystemVirtualPath;
+    ///
+    /// assert_eq!(None, SystemVirtualPath::new("untitled:Untitled-1").extension());
+    /// assert_eq!("ipynb", SystemVirtualPath::new("untitled:Untitled-1.ipynb").extension().unwrap());
+    /// assert_eq!("ipynb", SystemVirtualPath::new("vscode-notebook-cell:Untitled-1.ipynb").extension().unwrap());
+    /// ```
+    ///
+    /// See [`Path::extension`] for more details.
+    pub fn extension(&self) -> Option<&str> {
+        Path::new(&self.0).extension().and_then(|ext| ext.to_str())
+    }
+
     /// Returns the path as a string slice.
     #[inline]
     pub fn as_str(&self) -> &str {

--- a/crates/ruff_db/src/system/path.rs
+++ b/crates/ruff_db/src/system/path.rs
@@ -593,6 +593,120 @@ impl ruff_cache::CacheKey for SystemPathBuf {
     }
 }
 
+/// A slice of a virtual path on [`System`](super::System) (akin to [`str`]).
+#[repr(transparent)]
+pub struct SystemVirtualPath(str);
+
+impl SystemVirtualPath {
+    pub fn new(path: &str) -> &SystemVirtualPath {
+        // SAFETY: SystemVirtualPath is marked as #[repr(transparent)] so the conversion from a
+        // *const str to a *const SystemVirtualPath is valid.
+        unsafe { &*(path as *const str as *const SystemVirtualPath) }
+    }
+
+    /// Converts the path to an owned [`SystemVirtualPathBuf`].
+    pub fn to_path_buf(&self) -> SystemVirtualPathBuf {
+        SystemVirtualPathBuf(self.0.to_string())
+    }
+
+    /// Returns the path as a string slice.
+    #[inline]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+/// An owned, virtual path on [`System`](`super::System`) (akin to [`String`]).
+#[derive(Eq, PartialEq, Clone, Hash, PartialOrd, Ord)]
+pub struct SystemVirtualPathBuf(String);
+
+impl SystemVirtualPathBuf {
+    #[inline]
+    pub fn as_path(&self) -> &SystemVirtualPath {
+        SystemVirtualPath::new(&self.0)
+    }
+}
+
+impl From<String> for SystemVirtualPathBuf {
+    fn from(value: String) -> Self {
+        SystemVirtualPathBuf(value)
+    }
+}
+
+impl AsRef<SystemVirtualPath> for SystemVirtualPathBuf {
+    #[inline]
+    fn as_ref(&self) -> &SystemVirtualPath {
+        self.as_path()
+    }
+}
+
+impl AsRef<SystemVirtualPath> for SystemVirtualPath {
+    #[inline]
+    fn as_ref(&self) -> &SystemVirtualPath {
+        self
+    }
+}
+
+impl AsRef<SystemVirtualPath> for str {
+    #[inline]
+    fn as_ref(&self) -> &SystemVirtualPath {
+        SystemVirtualPath::new(self)
+    }
+}
+
+impl AsRef<SystemVirtualPath> for String {
+    #[inline]
+    fn as_ref(&self) -> &SystemVirtualPath {
+        SystemVirtualPath::new(self)
+    }
+}
+
+impl Deref for SystemVirtualPathBuf {
+    type Target = SystemVirtualPath;
+
+    fn deref(&self) -> &Self::Target {
+        self.as_path()
+    }
+}
+
+impl std::fmt::Debug for SystemVirtualPath {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl std::fmt::Display for SystemVirtualPath {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl std::fmt::Debug for SystemVirtualPathBuf {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl std::fmt::Display for SystemVirtualPathBuf {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+#[cfg(feature = "cache")]
+impl ruff_cache::CacheKey for SystemVirtualPath {
+    fn cache_key(&self, hasher: &mut ruff_cache::CacheKeyHasher) {
+        self.as_str().cache_key(hasher);
+    }
+}
+
+#[cfg(feature = "cache")]
+impl ruff_cache::CacheKey for SystemVirtualPathBuf {
+    fn cache_key(&self, hasher: &mut ruff_cache::CacheKeyHasher) {
+        self.as_path().cache_key(hasher);
+    }
+}
+
 /// Deduplicates identical paths and removes nested paths.
 ///
 /// # Examples

--- a/crates/ruff_db/src/system/test.rs
+++ b/crates/ruff_db/src/system/test.rs
@@ -177,6 +177,14 @@ pub trait DbWithTestSystem: Db + Sized {
         result
     }
 
+    /// Writes the content of the given virtual file.
+    fn write_virtual_file(&mut self, path: impl AsRef<SystemVirtualPath>, content: impl ToString) {
+        let path = path.as_ref();
+        self.test_system()
+            .memory_file_system()
+            .write_virtual_file(path, content);
+    }
+
     /// Writes auto-dedented text to a file.
     fn write_dedented(&mut self, path: &str, content: &str) -> crate::system::Result<()> {
         self.write_file(path, textwrap::dedent(content))?;

--- a/crates/ruff_db/src/system/test.rs
+++ b/crates/ruff_db/src/system/test.rs
@@ -2,7 +2,9 @@ use ruff_notebook::{Notebook, NotebookError};
 use ruff_python_trivia::textwrap;
 
 use crate::files::File;
-use crate::system::{DirectoryEntry, MemoryFileSystem, Metadata, Result, System, SystemPath};
+use crate::system::{
+    DirectoryEntry, MemoryFileSystem, Metadata, Result, System, SystemPath, SystemVirtualPath,
+};
 use crate::Db;
 use std::any::Any;
 use std::panic::RefUnwindSafe;
@@ -68,6 +70,30 @@ impl System for TestSystem {
         match &self.inner {
             TestSystemInner::Stub(fs) => fs.read_to_notebook(path),
             TestSystemInner::System(system) => system.read_to_notebook(path),
+        }
+    }
+
+    fn virtual_path_metadata(&self, path: &SystemVirtualPath) -> Result<Metadata> {
+        match &self.inner {
+            TestSystemInner::Stub(fs) => fs.virtual_path_metadata(path),
+            TestSystemInner::System(system) => system.virtual_path_metadata(path),
+        }
+    }
+
+    fn read_virtual_path_to_string(&self, path: &SystemVirtualPath) -> Result<String> {
+        match &self.inner {
+            TestSystemInner::Stub(fs) => fs.read_virtual_path_to_string(path),
+            TestSystemInner::System(system) => system.read_virtual_path_to_string(path),
+        }
+    }
+
+    fn read_virtual_path_to_notebook(
+        &self,
+        path: &SystemVirtualPath,
+    ) -> std::result::Result<Notebook, NotebookError> {
+        match &self.inner {
+            TestSystemInner::Stub(fs) => fs.read_virtual_path_to_notebook(path),
+            TestSystemInner::System(system) => system.read_virtual_path_to_notebook(path),
         }
     }
 


### PR DESCRIPTION
## Summary

This PR adds support for untitled files in the Red Knot project.

Refer to the [design discussion](https://github.com/astral-sh/ruff/discussions/12336) for more details.

### Changes
* The `parsed_module` always assumes that the `SystemVirtual` path is of `PySourceType::Python`.
* For the module resolver, as suggested, I went ahead by adding a new `SystemOrVendoredPath` enum and renamed `FilePathRef` to `SystemOrVendoredPathRef` (happy to consider better names here).
* The `file_to_module` query would return if it's a `FilePath::SystemVirtual` variant because a virtual file doesn't belong to any module.
* The sync implementation for the system virtual path is basically the same as that of system path except that it uses the `virtual_path_metadata`. The reason for this is that the system (language server) would provide the metadata on whether it still exists or not and if it exists, the corresponding metadata.

For point (1), VS Code would use `Untitled-1` for Python files and `Untitled-1.ipynb` for Jupyter Notebooks. We could use this distinction to determine whether the source type is `Python` or `Ipynb`.

## Test Plan

Added test cases in #12526 
