### PR TITLE
[red-knot] Refactor `path.rs` in the module resolver

### DIFF
--- a/crates/red_knot_module_resolver/src/lib.rs
+++ b/crates/red_knot_module_resolver/src/lib.rs
@@ -40,7 +40,7 @@ impl<'db> Iterator for SystemModuleSearchPathsIter<'db> {
         loop {
             let next = self.inner.next()?;
 
-            if let Some(system_path) = next.as_system_path() {
+            if let Some(system_path) = next.as_system_path_buf() {
                 return Some(system_path);
             }
         }

--- a/crates/red_knot_module_resolver/src/module.rs
+++ b/crates/red_knot_module_resolver/src/module.rs
@@ -5,7 +5,7 @@ use ruff_db::files::File;
 
 use crate::db::Db;
 use crate::module_name::ModuleName;
-use crate::path::ModuleSearchPath;
+use crate::path::SearchPath;
 
 /// Representation of a Python module.
 #[derive(Clone, PartialEq, Eq)]
@@ -17,7 +17,7 @@ impl Module {
     pub(crate) fn new(
         name: ModuleName,
         kind: ModuleKind,
-        search_path: ModuleSearchPath,
+        search_path: SearchPath,
         file: File,
     ) -> Self {
         Self {
@@ -41,7 +41,7 @@ impl Module {
     }
 
     /// The search path from which the module was resolved.
-    pub(crate) fn search_path(&self) -> &ModuleSearchPath {
+    pub(crate) fn search_path(&self) -> &SearchPath {
         &self.inner.search_path
     }
 
@@ -77,7 +77,7 @@ impl salsa::DebugWithDb<dyn Db> for Module {
 struct ModuleInner {
     name: ModuleName,
     kind: ModuleKind,
-    search_path: ModuleSearchPath,
+    search_path: SearchPath,
     file: File,
 }
 

--- a/crates/red_knot_module_resolver/src/path.rs
+++ b/crates/red_knot_module_resolver/src/path.rs
@@ -890,24 +890,24 @@ impl ModuleSearchPath {
     #[must_use]
     pub(crate) fn as_system_path(&self) -> Option<&SystemPathBuf> {
         match &self.0 {
-            ModuleSearchPathInner::Extra(path) => Some(&*path.0),
-            ModuleSearchPathInner::FirstParty(path) => Some(&*path.0),
-            ModuleSearchPathInner::StandardLibraryCustom(path) => Some(&*path.0),
+            ModuleSearchPathInner::Extra(path)
+            | ModuleSearchPathInner::FirstParty(path)
+            | ModuleSearchPathInner::StandardLibraryCustom(path)
+            | ModuleSearchPathInner::SitePackages(path)
+            | ModuleSearchPathInner::Editable(path) => Some(&*path.0),
             ModuleSearchPathInner::StandardLibraryVendored(_) => None,
-            ModuleSearchPathInner::SitePackages(path) => Some(&*path.0),
-            ModuleSearchPathInner::Editable(path) => Some(&*path.0),
         }
     }
 
     #[must_use]
     pub(crate) fn as_vendored_path(&self) -> Option<&VendoredPathBuf> {
         match &self.0 {
-            ModuleSearchPathInner::Extra(_) => None,
-            ModuleSearchPathInner::FirstParty(_) => None,
-            ModuleSearchPathInner::StandardLibraryCustom(_) => None,
             ModuleSearchPathInner::StandardLibraryVendored(path) => Some(&*path.0),
-            ModuleSearchPathInner::SitePackages(_) => None,
-            ModuleSearchPathInner::Editable(_) => None,
+            ModuleSearchPathInner::Extra(_)
+            | ModuleSearchPathInner::FirstParty(_)
+            | ModuleSearchPathInner::StandardLibraryCustom(_)
+            | ModuleSearchPathInner::SitePackages(_)
+            | ModuleSearchPathInner::Editable(_) => None,
         }
     }
 }

--- a/crates/red_knot_module_resolver/src/resolver.rs
+++ b/crates/red_knot_module_resolver/src/resolver.rs
@@ -127,20 +127,20 @@ fn try_resolve_module_resolution_settings(
 
     let mut static_search_paths = vec![];
 
-    for path in extra_paths {
+    for path in extra_paths.iter().cloned() {
         static_search_paths.push(SearchPath::extra(system, path)?);
     }
 
-    static_search_paths.push(SearchPath::first_party(system, workspace_root)?);
+    static_search_paths.push(SearchPath::first_party(system, workspace_root.clone())?);
 
     static_search_paths.push(if let Some(custom_typeshed) = custom_typeshed.as_ref() {
-        SearchPath::custom_stdlib(db, custom_typeshed)?
+        SearchPath::custom_stdlib(db, custom_typeshed.clone())?
     } else {
         SearchPath::vendored_stdlib()
     });
 
     if let Some(site_packages) = site_packages {
-        static_search_paths.push(SearchPath::site_packages(system, site_packages)?);
+        static_search_paths.push(SearchPath::site_packages(system, site_packages.clone())?);
     }
 
     // TODO vendor typeshed's third-party stubs as well as the stdlib and fallback to them as a final step
@@ -1651,7 +1651,10 @@ not_a_directory
         let search_paths: Vec<&SearchPath> =
             module_resolution_settings(&db).search_paths(&db).collect();
 
-        assert!(search_paths.contains(&&SearchPath::first_party(db.system(), "/src").unwrap()));
-        assert!(!search_paths.contains(&&SearchPath::editable(db.system(), "/src").unwrap()));
+        assert!(search_paths.contains(
+            &&SearchPath::first_party(db.system(), SystemPathBuf::from("/src")).unwrap()
+        ));
+        assert!(!search_paths
+            .contains(&&SearchPath::editable(db.system(), SystemPathBuf::from("/src")).unwrap()));
     }
 }

--- a/crates/red_knot_module_resolver/src/resolver.rs
+++ b/crates/red_knot_module_resolver/src/resolver.rs
@@ -583,7 +583,7 @@ where
 
 #[derive(Debug)]
 struct ResolvedPackage {
-    path: ModulePath<'static>,
+    path: ModulePath,
     kind: PackageKind,
 }
 

--- a/crates/ruff_db/src/system/path.rs
+++ b/crates/ruff_db/src/system/path.rs
@@ -402,6 +402,14 @@ impl SystemPath {
     }
 }
 
+impl ToOwned for SystemPath {
+    type Owned = SystemPathBuf;
+
+    fn to_owned(&self) -> Self::Owned {
+        self.to_path_buf()
+    }
+}
+
 /// An owned, mutable path on [`System`](`super::System`) (akin to [`String`]).
 ///
 /// The path is guaranteed to be valid UTF-8.
@@ -467,6 +475,12 @@ impl SystemPathBuf {
     #[inline]
     pub fn as_path(&self) -> &SystemPath {
         SystemPath::new(&self.0)
+    }
+}
+
+impl std::borrow::Borrow<SystemPath> for SystemPathBuf {
+    fn borrow(&self) -> &SystemPath {
+        self
     }
 }
 

--- a/crates/ruff_db/src/system/path.rs
+++ b/crates/ruff_db/src/system/path.rs
@@ -3,6 +3,7 @@
 //    but there's no compile time guarantee that a [`OsSystem`] never gets an untitled file path.
 
 use camino::{Utf8Path, Utf8PathBuf};
+use std::borrow::Borrow;
 use std::fmt::Formatter;
 use std::ops::Deref;
 use std::path::{Path, StripPrefixError};
@@ -402,6 +403,14 @@ impl SystemPath {
     }
 }
 
+impl ToOwned for SystemPath {
+    type Owned = SystemPathBuf;
+
+    fn to_owned(&self) -> Self::Owned {
+        self.to_path_buf()
+    }
+}
+
 /// An owned, mutable path on [`System`](`super::System`) (akin to [`String`]).
 ///
 /// The path is guaranteed to be valid UTF-8.
@@ -467,6 +476,12 @@ impl SystemPathBuf {
     #[inline]
     pub fn as_path(&self) -> &SystemPath {
         SystemPath::new(&self.0)
+    }
+}
+
+impl Borrow<SystemPath> for SystemPathBuf {
+    fn borrow(&self) -> &SystemPath {
+        self.as_path()
     }
 }
 

--- a/crates/ruff_db/src/system/path.rs
+++ b/crates/ruff_db/src/system/path.rs
@@ -496,6 +496,20 @@ impl AsRef<SystemPath> for SystemPath {
     }
 }
 
+impl AsRef<SystemPath> for Utf8Path {
+    #[inline]
+    fn as_ref(&self) -> &SystemPath {
+        SystemPath::new(self)
+    }
+}
+
+impl AsRef<SystemPath> for Utf8PathBuf {
+    #[inline]
+    fn as_ref(&self) -> &SystemPath {
+        SystemPath::new(self.as_path())
+    }
+}
+
 impl AsRef<SystemPath> for str {
     #[inline]
     fn as_ref(&self) -> &SystemPath {

--- a/crates/ruff_db/src/system/path.rs
+++ b/crates/ruff_db/src/system/path.rs
@@ -402,14 +402,6 @@ impl SystemPath {
     }
 }
 
-impl ToOwned for SystemPath {
-    type Owned = SystemPathBuf;
-
-    fn to_owned(&self) -> Self::Owned {
-        self.to_path_buf()
-    }
-}
-
 /// An owned, mutable path on [`System`](`super::System`) (akin to [`String`]).
 ///
 /// The path is guaranteed to be valid UTF-8.
@@ -475,12 +467,6 @@ impl SystemPathBuf {
     #[inline]
     pub fn as_path(&self) -> &SystemPath {
         SystemPath::new(&self.0)
-    }
-}
-
-impl std::borrow::Borrow<SystemPath> for SystemPathBuf {
-    fn borrow(&self) -> &SystemPath {
-        self
     }
 }
 

--- a/crates/ruff_db/src/vendored/path.rs
+++ b/crates/ruff_db/src/vendored/path.rs
@@ -69,6 +69,14 @@ impl VendoredPath {
     }
 }
 
+impl ToOwned for VendoredPath {
+    type Owned = VendoredPathBuf;
+
+    fn to_owned(&self) -> Self::Owned {
+        self.to_path_buf()
+    }
+}
+
 #[repr(transparent)]
 #[derive(Debug, Eq, PartialEq, Clone, Hash)]
 pub struct VendoredPathBuf(Utf8PathBuf);
@@ -90,6 +98,12 @@ impl VendoredPathBuf {
 
     pub fn push(&mut self, component: impl AsRef<VendoredPath>) {
         self.0.push(component.as_ref())
+    }
+}
+
+impl std::borrow::Borrow<VendoredPath> for VendoredPathBuf {
+    fn borrow(&self) -> &VendoredPath {
+        self
     }
 }
 

--- a/crates/ruff_db/src/vendored/path.rs
+++ b/crates/ruff_db/src/vendored/path.rs
@@ -1,3 +1,4 @@
+use std::borrow::Borrow;
 use std::ops::Deref;
 use std::path;
 
@@ -73,6 +74,14 @@ impl VendoredPath {
     }
 }
 
+impl ToOwned for VendoredPath {
+    type Owned = VendoredPathBuf;
+
+    fn to_owned(&self) -> VendoredPathBuf {
+        self.to_path_buf()
+    }
+}
+
 #[repr(transparent)]
 #[derive(Debug, Eq, PartialEq, Clone, Hash)]
 pub struct VendoredPathBuf(Utf8PathBuf);
@@ -88,12 +97,19 @@ impl VendoredPathBuf {
         Self(Utf8PathBuf::new())
     }
 
+    #[inline]
     pub fn as_path(&self) -> &VendoredPath {
         VendoredPath::new(&self.0)
     }
 
     pub fn push(&mut self, component: impl AsRef<VendoredPath>) {
         self.0.push(component.as_ref())
+    }
+}
+
+impl Borrow<VendoredPath> for VendoredPathBuf {
+    fn borrow(&self) -> &VendoredPath {
+        self.as_path()
     }
 }
 

--- a/crates/ruff_db/src/vendored/path.rs
+++ b/crates/ruff_db/src/vendored/path.rs
@@ -23,6 +23,10 @@ impl VendoredPath {
         self.0.as_str()
     }
 
+    pub fn as_utf8_path(&self) -> &camino::Utf8Path {
+        &self.0
+    }
+
     pub fn as_std_path(&self) -> &path::Path {
         self.0.as_std_path()
     }
@@ -103,6 +107,20 @@ impl AsRef<VendoredPath> for VendoredPath {
     #[inline]
     fn as_ref(&self) -> &VendoredPath {
         self
+    }
+}
+
+impl AsRef<VendoredPath> for Utf8Path {
+    #[inline]
+    fn as_ref(&self) -> &VendoredPath {
+        VendoredPath::new(self)
+    }
+}
+
+impl AsRef<VendoredPath> for Utf8PathBuf {
+    #[inline]
+    fn as_ref(&self) -> &VendoredPath {
+        VendoredPath::new(self.as_path())
     }
 }
 

--- a/crates/ruff_db/src/vendored/path.rs
+++ b/crates/ruff_db/src/vendored/path.rs
@@ -69,14 +69,6 @@ impl VendoredPath {
     }
 }
 
-impl ToOwned for VendoredPath {
-    type Owned = VendoredPathBuf;
-
-    fn to_owned(&self) -> Self::Owned {
-        self.to_path_buf()
-    }
-}
-
 #[repr(transparent)]
 #[derive(Debug, Eq, PartialEq, Clone, Hash)]
 pub struct VendoredPathBuf(Utf8PathBuf);
@@ -98,12 +90,6 @@ impl VendoredPathBuf {
 
     pub fn push(&mut self, component: impl AsRef<VendoredPath>) {
         self.0.push(component.as_ref())
-    }
-}
-
-impl std::borrow::Borrow<VendoredPath> for VendoredPathBuf {
-    fn borrow(&self) -> &VendoredPath {
-        self
     }
 }
 


### PR DESCRIPTION
## Summary

This PR more-or-less completely rewrites the `path.rs` submodule in the redknot module resolver, addressing @carljm's comments in https://github.com/astral-sh/ruff/pull/12141#discussion_r1667010245 and https://github.com/astral-sh/ruff/pull/12141#discussion_r1667031874. The external API exposed to other submodules in the module resolver is almost entirely unchanged, however.

Some of the major changes made include:
- There's no longer two enums, one representing owned module paths and one representing borrowed module paths. Instead, there's a single `ModulePath` type.
- The `ModuleSearchPath` type in `path.rs` (renamed to `SearchPath`) no longer dereferences to `ModulePath`. Instead, it's a fully distinct type that only implements the methods that make sense on a search path.
- Custom stdlib paths and vendored stdlib paths are now represented as two different variants. A custom stdlib path is in many ways more similar to a site-packages path than it is to a vendored stdlib path. Treating them as two separate variants cleans up the code a bunch, and allows us to remove any usage of the `FilePath` enum from `path.rs`.
- `ModulePath`s now always remember the search path from which they were derived, and are always represented internally as a `{search_path, relative_path}` struct.

## Test Plan

`cargo test -p red_knot_module_resolver`
