### PR TITLE
Preserve trailing inline comments on import-from statements

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/isort/trailing_comment.py
+++ b/crates/ruff_linter/resources/test/fixtures/isort/trailing_comment.py
@@ -1,0 +1,54 @@
+from mylib import (
+    MyClient,
+    MyMgmtClient,
+)  # some comment
+
+pass
+
+from mylib import (
+    MyClient,
+    MyMgmtClient,
+); from foo import (
+    bar
+)# some comment
+
+pass
+
+from foo import (
+    bar
+)
+from mylib import (
+    MyClient,
+    MyMgmtClient,
+    # some comment
+)
+
+pass
+
+from mylib import (
+    MyClient,
+    # some comment
+)
+
+pass
+
+from mylib import (
+    MyClient
+    # some comment
+)
+
+pass
+
+from mylib import (
+    # some comment
+    MyClient
+)
+
+pass
+
+# a
+from mylib import ( # b
+    # c
+    MyClient # d
+    # e
+) # f

--- a/crates/ruff_linter/src/rules/isort/format.rs
+++ b/crates/ruff_linter/src/rules/isort/format.rs
@@ -2,7 +2,7 @@ use ruff_python_codegen::Stylist;
 
 use crate::line_width::{LineLength, LineWidthBuilder};
 
-use super::types::{AliasData, CommentSet, ImportFromData, Importable};
+use super::types::{AliasData, ImportCommentSet, ImportFromCommentSet, ImportFromData, Importable};
 
 // Guess a capacity to use for string allocation.
 const CAPACITY: usize = 200;
@@ -10,7 +10,7 @@ const CAPACITY: usize = 200;
 /// Add a plain import statement to the [`RopeBuilder`].
 pub(crate) fn format_import(
     alias: &AliasData,
-    comments: &CommentSet,
+    comments: &ImportCommentSet,
     is_first: bool,
     stylist: &Stylist,
 ) -> String {
@@ -43,8 +43,8 @@ pub(crate) fn format_import(
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn format_import_from(
     import_from: &ImportFromData,
-    comments: &CommentSet,
-    aliases: &[(AliasData, CommentSet)],
+    comments: &ImportFromCommentSet,
+    aliases: &[(AliasData, ImportFromCommentSet)],
     line_length: LineLength,
     indentation_width: LineWidthBuilder,
     stylist: &Stylist,
@@ -68,12 +68,19 @@ pub(crate) fn format_import_from(
         return single_line;
     }
 
-    // We can only inline if none of the aliases have atop or inline comments.
+    // We can only inline if none of the aliases have comments.
     if !trailing_comma
         && (aliases.len() == 1
-            || aliases
-                .iter()
-                .all(|(_, CommentSet { atop, inline })| atop.is_empty() && inline.is_empty()))
+            || aliases.iter().all(
+                |(
+                    _,
+                    ImportFromCommentSet {
+                        atop,
+                        inline,
+                        trailing,
+                    },
+                )| atop.is_empty() && inline.is_empty() && trailing.is_empty(),
+            ))
         && (!force_wrap_aliases
             || aliases.len() == 1
             || aliases.iter().all(|(alias, _)| alias.asname.is_none()))
@@ -99,8 +106,8 @@ pub(crate) fn format_import_from(
 /// This method assumes that the output source code is syntactically valid.
 fn format_single_line(
     import_from: &ImportFromData,
-    comments: &CommentSet,
-    aliases: &[(AliasData, CommentSet)],
+    comments: &ImportFromCommentSet,
+    aliases: &[(AliasData, ImportFromCommentSet)],
     is_first: bool,
     stylist: &Stylist,
     indentation_width: LineWidthBuilder,
@@ -122,7 +129,7 @@ fn format_single_line(
     output.push_str(" import ");
     line_width = line_width.add_width(5).add_str(&module_name).add_width(8);
 
-    for (index, (AliasData { name, asname }, comments)) in aliases.iter().enumerate() {
+    for (index, (AliasData { name, asname }, _)) in aliases.iter().enumerate() {
         if let Some(asname) = asname {
             output.push_str(name);
             output.push_str(" as ");
@@ -136,6 +143,22 @@ fn format_single_line(
             output.push_str(", ");
             line_width = line_width.add_width(2);
         }
+    }
+
+    for comment in &comments.inline {
+        output.push(' ');
+        output.push(' ');
+        output.push_str(comment);
+        line_width = line_width.add_width(2).add_str(comment);
+    }
+
+    for (_, comments) in aliases {
+        for comment in &comments.atop {
+            output.push(' ');
+            output.push(' ');
+            output.push_str(comment);
+            line_width = line_width.add_width(2).add_str(comment);
+        }
 
         for comment in &comments.inline {
             output.push(' ');
@@ -143,9 +166,16 @@ fn format_single_line(
             output.push_str(comment);
             line_width = line_width.add_width(2).add_str(comment);
         }
+
+        for comment in &comments.trailing {
+            output.push(' ');
+            output.push(' ');
+            output.push_str(comment);
+            line_width = line_width.add_width(2).add_str(comment);
+        }
     }
 
-    for comment in &comments.inline {
+    for comment in &comments.trailing {
         output.push(' ');
         output.push(' ');
         output.push_str(comment);
@@ -160,8 +190,8 @@ fn format_single_line(
 /// Format an import-from statement in multi-line format.
 fn format_multi_line(
     import_from: &ImportFromData,
-    comments: &CommentSet,
-    aliases: &[(AliasData, CommentSet)],
+    comments: &ImportFromCommentSet,
+    aliases: &[(AliasData, ImportFromCommentSet)],
     is_first: bool,
     stylist: &Stylist,
 ) -> String {
@@ -208,9 +238,20 @@ fn format_multi_line(
             output.push_str(comment);
         }
         output.push_str(&stylist.line_ending());
+
+        for comment in &comments.trailing {
+            output.push_str(stylist.indentation());
+            output.push_str(comment);
+            output.push_str(&stylist.line_ending());
+        }
     }
 
     output.push(')');
+
+    for comment in &comments.trailing {
+        output.push_str("  ");
+        output.push_str(comment);
+    }
     output.push_str(&stylist.line_ending());
 
     output

--- a/crates/ruff_linter/src/rules/isort/mod.rs
+++ b/crates/ruff_linter/src/rules/isort/mod.rs
@@ -41,6 +41,7 @@ pub(crate) struct AnnotatedAliasData<'a> {
     pub(crate) asname: Option<&'a str>,
     pub(crate) atop: Vec<Comment<'a>>,
     pub(crate) inline: Vec<Comment<'a>>,
+    pub(crate) trailing: Vec<Comment<'a>>,
 }
 
 #[derive(Debug)]
@@ -56,6 +57,7 @@ pub(crate) enum AnnotatedImport<'a> {
         level: u32,
         atop: Vec<Comment<'a>>,
         inline: Vec<Comment<'a>>,
+        trailing: Vec<Comment<'a>>,
         trailing_comma: TrailingComma,
     },
 }
@@ -342,6 +344,7 @@ mod tests {
     #[test_case(Path::new("sort_similar_imports.py"))]
     #[test_case(Path::new("split.py"))]
     #[test_case(Path::new("star_before_others.py"))]
+    #[test_case(Path::new("trailing_comment.py"))]
     #[test_case(Path::new("trailing_suffix.py"))]
     #[test_case(Path::new("two_space.py"))]
     #[test_case(Path::new("type_comments.py"))]

--- a/crates/ruff_linter/src/rules/isort/normalize.rs
+++ b/crates/ruff_linter/src/rules/isort/normalize.rs
@@ -48,6 +48,7 @@ pub(crate) fn normalize_imports<'a>(
                 level,
                 atop,
                 inline,
+                trailing,
                 trailing_comma,
             } => {
                 // Whether to track each member of the import as a separate entry.
@@ -80,9 +81,12 @@ pub(crate) fn normalize_imports<'a>(
                             }
                         }
 
-                        // Replicate the inline comments onto every member.
+                        // Replicate the inline (and after) comments onto every member.
                         for comment in &inline {
                             import_from.comments.inline.push(comment.value.clone());
+                        }
+                        for comment in &trailing {
+                            import_from.comments.trailing.push(comment.value.clone());
                         }
                     }
                 } else {
@@ -113,9 +117,11 @@ pub(crate) fn normalize_imports<'a>(
                         for comment in atop {
                             import_from.comments.atop.push(comment.value);
                         }
-
                         for comment in inline {
                             import_from.comments.inline.push(comment.value);
+                        }
+                        for comment in trailing {
+                            import_from.comments.trailing.push(comment.value);
                         }
                     }
                 }
@@ -160,6 +166,9 @@ pub(crate) fn normalize_imports<'a>(
                     }
                     for comment in alias.inline {
                         comment_set.inline.push(comment.value);
+                    }
+                    for comment in alias.trailing {
+                        comment_set.trailing.push(comment.value);
                     }
 
                     // Propagate trailing commas.

--- a/crates/ruff_linter/src/rules/isort/order.rs
+++ b/crates/ruff_linter/src/rules/isort/order.rs
@@ -5,7 +5,7 @@ use itertools::Itertools;
 use super::settings::Settings;
 use super::sorting::{MemberKey, ModuleKey};
 use super::types::EitherImport::{self, Import, ImportFrom};
-use super::types::{AliasData, CommentSet, ImportBlock, ImportFromStatement};
+use super::types::{AliasData, ImportBlock, ImportFromCommentSet, ImportFromStatement};
 
 pub(crate) fn order_imports<'a>(
     block: ImportBlock<'a>,
@@ -49,7 +49,7 @@ pub(crate) fn order_imports<'a>(
                             .sorted_by_cached_key(|(alias, _)| {
                                 MemberKey::from_member(alias.name, alias.asname, settings)
                             })
-                            .collect::<Vec<(AliasData, CommentSet)>>(),
+                            .collect::<Vec<(AliasData, ImportFromCommentSet)>>(),
                     )
                 },
             );

--- a/crates/ruff_linter/src/rules/isort/snapshots/ruff_linter__rules__isort__tests__as_imports_comments.py.snap
+++ b/crates/ruff_linter/src/rules/isort/snapshots/ruff_linter__rules__isort__tests__as_imports_comments.py.snap
@@ -36,10 +36,8 @@ as_imports_comments.py:1:1: I001 [*] Import block is un-sorted or un-formatted
 12    |-
 13    |-from bop import (  # Comment on `bop`
 14    |-    Member  # Comment on `Member`
-   4  |+from baz import Member as Alias  # Comment on `Alias`  # Comment on `baz`
-   5  |+from bop import Member  # Comment on `Member`  # Comment on `bop`
+   4  |+from baz import Member as Alias  # Comment on `baz`  # Comment on `Alias`
+   5  |+from bop import Member  # Comment on `bop`  # Comment on `Member`
    6  |+from foo import (  # Comment on `foo`
    7  |+    Member as Alias,  # Comment on `Alias`
 15 8  | )
-
-

--- a/crates/ruff_linter/src/rules/isort/snapshots/ruff_linter__rules__isort__tests__trailing_comment.py.snap
+++ b/crates/ruff_linter/src/rules/isort/snapshots/ruff_linter__rules__isort__tests__trailing_comment.py.snap
@@ -1,0 +1,148 @@
+---
+source: crates/ruff_linter/src/rules/isort/mod.rs
+---
+trailing_comment.py:8:1: I001 [*] Import block is un-sorted or un-formatted
+   |
+ 6 |   pass
+ 7 |   
+ 8 | / from mylib import (
+ 9 | |     MyClient,
+10 | |     MyMgmtClient,
+11 | | ); from foo import (
+12 | |     bar
+13 | | )# some comment
+14 | | 
+15 | | pass
+   | |_^ I001
+16 |   
+17 |   from foo import (
+   |
+   = help: Organize imports
+
+ℹ Safe fix
+5  5  | 
+6  6  | pass
+7  7  | 
+   8  |+from foo import bar  # some comment
+8  9  | from mylib import (
+9  10 |     MyClient,
+10 11 |     MyMgmtClient,
+11    |-); from foo import (
+12    |-    bar
+13    |-)# some comment
+   12 |+)
+14 13 | 
+15 14 | pass
+16 15 | 
+
+trailing_comment.py:17:1: I001 [*] Import block is un-sorted or un-formatted
+   |
+15 |   pass
+16 |   
+17 | / from foo import (
+18 | |     bar
+19 | | )
+20 | | from mylib import (
+21 | |     MyClient,
+22 | |     MyMgmtClient,
+23 | |     # some comment
+24 | | )
+25 | | 
+26 | | pass
+   | |_^ I001
+27 |   
+28 |   from mylib import (
+   |
+   = help: Organize imports
+
+ℹ Safe fix
+14 14 | 
+15 15 | pass
+16 16 | 
+17    |-from foo import (
+18    |-    bar
+19    |-)
+   17 |+from foo import bar
+20 18 | from mylib import (
+21 19 |     MyClient,
+22 20 |     MyMgmtClient,
+
+trailing_comment.py:35:1: I001 [*] Import block is un-sorted or un-formatted
+   |
+33 |   pass
+34 |   
+35 | / from mylib import (
+36 | |     MyClient
+37 | |     # some comment
+38 | | )
+39 | | 
+40 | | pass
+   | |_^ I001
+41 |   
+42 |   from mylib import (
+   |
+   = help: Organize imports
+
+ℹ Safe fix
+32 32 | 
+33 33 | pass
+34 34 | 
+35    |-from mylib import (
+36    |-    MyClient
+37    |-    # some comment
+38    |-)
+   35 |+from mylib import MyClient  # some comment
+39 36 | 
+40 37 | pass
+41 38 | 
+
+trailing_comment.py:42:1: I001 [*] Import block is un-sorted or un-formatted
+   |
+40 |   pass
+41 |   
+42 | / from mylib import (
+43 | |     # some comment
+44 | |     MyClient
+45 | | )
+46 | | 
+47 | | pass
+   | |_^ I001
+48 |   
+49 |   # a
+   |
+   = help: Organize imports
+
+ℹ Safe fix
+39 39 | 
+40 40 | pass
+41 41 | 
+42    |-from mylib import (
+43    |-    # some comment
+44    |-    MyClient
+45    |-)
+   42 |+from mylib import MyClient  # some comment
+46 43 | 
+47 44 | pass
+48 45 | 
+
+trailing_comment.py:50:1: I001 [*] Import block is un-sorted or un-formatted
+   |
+49 |   # a
+50 | / from mylib import ( # b
+51 | |     # c
+52 | |     MyClient # d
+53 | |     # e
+54 | | ) # f
+   |
+   = help: Organize imports
+
+ℹ Safe fix
+47 47 | pass
+48 48 | 
+49 49 | # a
+50    |-from mylib import ( # b
+51    |-    # c
+52    |-    MyClient # d
+53    |-    # e
+54    |-) # f
+   50 |+from mylib import MyClient  # b  # c  # d  # e  # f

--- a/crates/ruff_linter/src/rules/isort/types.rs
+++ b/crates/ruff_linter/src/rules/isort/types.rs
@@ -24,9 +24,16 @@ pub(crate) struct AliasData<'a> {
 }
 
 #[derive(Debug, Default, Clone)]
-pub(crate) struct CommentSet<'a> {
+pub(crate) struct ImportCommentSet<'a> {
     pub(crate) atop: Vec<Cow<'a, str>>,
     pub(crate) inline: Vec<Cow<'a, str>>,
+}
+
+#[derive(Debug, Default, Clone)]
+pub(crate) struct ImportFromCommentSet<'a> {
+    pub(crate) atop: Vec<Cow<'a, str>>,
+    pub(crate) inline: Vec<Cow<'a, str>>,
+    pub(crate) trailing: Vec<Cow<'a, str>>,
 }
 
 pub(crate) trait Importable<'a> {
@@ -65,8 +72,8 @@ impl<'a> Importable<'a> for ImportFromData<'a> {
 
 #[derive(Debug, Default)]
 pub(crate) struct ImportFromStatement<'a> {
-    pub(crate) comments: CommentSet<'a>,
-    pub(crate) aliases: FxHashMap<AliasData<'a>, CommentSet<'a>>,
+    pub(crate) comments: ImportFromCommentSet<'a>,
+    pub(crate) aliases: FxHashMap<AliasData<'a>, ImportFromCommentSet<'a>>,
     pub(crate) trailing_comma: TrailingComma,
 }
 
@@ -74,7 +81,7 @@ pub(crate) struct ImportFromStatement<'a> {
 pub(crate) struct ImportBlock<'a> {
     // Set of (name, asname), used to track regular imports.
     // Ex) `import module`
-    pub(crate) import: FxHashMap<AliasData<'a>, CommentSet<'a>>,
+    pub(crate) import: FxHashMap<AliasData<'a>, ImportCommentSet<'a>>,
     // Map from (module, level) to `AliasData`, used to track 'from' imports.
     // Ex) `from module import member`
     pub(crate) import_from: FxHashMap<ImportFromData<'a>, ImportFromStatement<'a>>,
@@ -87,15 +94,13 @@ pub(crate) struct ImportBlock<'a> {
     pub(crate) import_from_star: FxHashMap<ImportFromData<'a>, ImportFromStatement<'a>>,
 }
 
-type AliasDataWithComments<'a> = (AliasData<'a>, CommentSet<'a>);
-
-type Import<'a> = AliasDataWithComments<'a>;
+type Import<'a> = (AliasData<'a>, ImportCommentSet<'a>);
 
 type ImportFrom<'a> = (
     ImportFromData<'a>,
-    CommentSet<'a>,
+    ImportFromCommentSet<'a>,
     TrailingComma,
-    Vec<AliasDataWithComments<'a>>,
+    Vec<(AliasData<'a>, ImportFromCommentSet<'a>)>,
 );
 
 #[derive(Debug)]


### PR DESCRIPTION
## Summary

Right now, in the isort comment model, there's nowhere for trailing comments on the _statement_ to go, as in:

```python
from mylib import (
    MyClient,
    MyMgmtClient,
)  # some comment
```

If the comment is on the _alias_, we do preserve it, because we attach it to the alias, as in:

```python
from mylib import (
    MyClient,
    MyMgmtClient,  # some comment
)
```

Similarly, if the comment is trailing on an import statement (non-`from`), we again attach it to the alias, because it can't be parenthesized, as in:

```python
import foo  # some comment
```

This PR adds logic to track and preserve those trailing comments.

We also no longer drop several other comments, like:

```python
from mylib import (
    # some comment
    MyClient
)
```

Closes https://github.com/astral-sh/ruff/issues/12487.
