### PR TITLE
Add missing traceback line in `f-string-in-exception` docstring.

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_errmsg/rules/string_in_exception.rs
+++ b/crates/ruff_linter/src/rules/flake8_errmsg/rules/string_in_exception.rs
@@ -97,6 +97,7 @@ impl Violation for RawStringInException {
 ///
 /// Which will produce a traceback like:
 /// ```console
+/// Traceback (most recent call last):
 ///   File "tmp.py", line 3, in <module>
 ///     raise RuntimeError(msg)
 /// RuntimeError: 'Some value' is incorrect


### PR DESCRIPTION
## Summary

Add missing traceback line in `f-string-in-exception` docstring.

Solves https://github.com/astral-sh/ruff/issues/12504.