### PR TITLE
Remove `salsa::report_untracked_read` when finding the dynamic module resolution paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2173,6 +2173,8 @@ dependencies = [
  "filetime",
  "ignore",
  "insta",
+ "matchit",
+ "path-slash",
  "ruff_cache",
  "ruff_notebook",
  "ruff_python_ast",

--- a/crates/ruff_db/Cargo.toml
+++ b/crates/ruff_db/Cargo.toml
@@ -24,7 +24,9 @@ countme = { workspace = true }
 dashmap = { workspace = true }
 filetime = { workspace = true }
 ignore = { workspace = true, optional = true }
+matchit = { workspace = true }
 salsa = { workspace = true }
+path-slash = { workspace = true }
 tracing = { workspace = true }
 rustc-hash = { workspace = true }
 zip = { workspace = true }

--- a/crates/ruff_db/src/file_revision.rs
+++ b/crates/ruff_db/src/file_revision.rs
@@ -15,6 +15,10 @@ impl FileRevision {
         Self(value)
     }
 
+    pub fn now() -> Self {
+        Self::from(filetime::FileTime::now())
+    }
+
     pub const fn zero() -> Self {
         Self(0)
     }

--- a/crates/ruff_db/src/files/file_root.rs
+++ b/crates/ruff_db/src/files/file_root.rs
@@ -1,0 +1,125 @@
+use std::fmt::Formatter;
+
+use path_slash::PathExt;
+
+use crate::file_revision::FileRevision;
+use crate::system::{SystemPath, SystemPathBuf};
+use crate::Db;
+
+/// A root path for files tracked by the database.
+///
+/// We currently create roots for:
+/// * static module resolution paths
+/// * the workspace root
+///
+/// The main usage of file roots is to determine a file's durability. But it can also be used
+/// to make a salsa query dependent on whether a file in a root has changed without writing any
+/// manual invalidation logic.
+#[salsa::input]
+pub struct FileRoot {
+    /// The path of a root is guaranteed to never change.
+    #[return_ref]
+    path_buf: SystemPathBuf,
+
+    /// The kind of the root at the time of its creation.
+    kind_at_time_of_creation: FileRootKind,
+
+    /// A revision that changes when the contents of the source root change.
+    ///
+    /// The revision changes when a new file was added, removed, or changed inside this source root.
+    pub revision: FileRevision,
+}
+
+impl FileRoot {
+    pub fn path(self, db: &dyn Db) -> &SystemPath {
+        self.path_buf(db)
+    }
+
+    pub fn durability(self, db: &dyn Db) -> salsa::Durability {
+        match self.kind_at_time_of_creation(db) {
+            FileRootKind::Workspace => salsa::Durability::LOW,
+            FileRootKind::LibrarySearchPath => salsa::Durability::HIGH,
+        }
+    }
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum FileRootKind {
+    /// The root of a workspace.
+    Workspace,
+
+    /// A non-workspace module resolution search path.
+    LibrarySearchPath,
+}
+
+#[derive(Default)]
+pub(super) struct FileRoots {
+    by_path: matchit::Router<FileRoot>,
+    roots: Vec<FileRoot>,
+}
+
+impl FileRoots {
+    /// Tries to add a new root for `path` and returns the root.
+    ///
+    /// The root isn't added nor is the file root's kind updated if a root for `path` already exists.
+    pub(super) fn try_add(
+        &mut self,
+        db: &dyn Db,
+        path: SystemPathBuf,
+        kind: FileRootKind,
+    ) -> FileRoot {
+        // SAFETY: Guaranteed to succeed because `path` is a UTF-8 that only contains Unicode characters.
+        let normalized_path = path.as_std_path().to_slash().unwrap();
+
+        if let Ok(existing) = self.by_path.at(&normalized_path) {
+            // Only if it is an exact match
+            if existing.value.path(db) == &*path {
+                return *existing.value;
+            }
+        }
+
+        // normalize the path to use `/` separators and escape the '{' and '}' characters,
+        // which matchit uses for routing parameters
+        let mut route = normalized_path.replace('{', "{{").replace('}', "}}");
+
+        // Insert a new source root
+        let root = FileRoot::new(db, path, kind, FileRevision::now());
+
+        // Insert a path that matches the root itself
+        self.by_path.insert(route.clone(), root).unwrap();
+
+        // Insert a path that matches all subdirectories and files
+        route.push_str("/{*filepath}");
+
+        self.by_path.insert(route, root).unwrap();
+        self.roots.push(root);
+
+        root
+    }
+
+    /// Returns the closest root for `path` or `None` if no root contains `path`.
+    pub(super) fn at(&self, path: &SystemPath) -> Option<FileRoot> {
+        // SAFETY: Guaranteed to succeed because `path` is a UTF-8 that only contains Unicode characters.
+        let normalized_path = path.as_std_path().to_slash().unwrap();
+        dbg!(&normalized_path);
+        dbg!(&self.roots);
+        let entry = self.by_path.at(&normalized_path).ok()?;
+        Some(*entry.value)
+    }
+
+    pub(super) fn all(&self) -> impl Iterator<Item = FileRoot> + '_ {
+        self.roots.iter().copied()
+    }
+}
+
+impl std::fmt::Debug for FileRoots {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("FileRoots").field(&self.roots).finish()
+    }
+}
+
+impl PartialEq for FileRoots {
+    fn eq(&self, other: &Self) -> bool {
+        self.roots.eq(&other.roots)
+    }
+}

--- a/crates/ruff_db/src/testing.rs
+++ b/crates/ruff_db/src/testing.rs
@@ -76,9 +76,8 @@ where
 
     let event = events.iter().find(|event| {
         if let salsa::EventKind::WillExecute { database_key } = event.kind {
-            dbg!(db
-                .lookup_ingredient(database_key.ingredient_index())
-                .debug_name())
+            db.lookup_ingredient(database_key.ingredient_index())
+                .debug_name()
                 == query_name
                 && database_key.key_index() == input.as_id()
         } else {
@@ -190,7 +189,6 @@ fn const_query_was_not_run_fails_if_query_was_run() {
 
     assert_eq!(len(&db), 5);
     let events = db.take_salsa_events();
-    dbg!(&events);
 
     assert_const_function_query_was_not_run(&db, len, &events);
 }


### PR DESCRIPTION
## Summary

This PR introduces a new `FileRoot` input ingredient. A file root is a root directory in which we track files. 
The main use case for `FileRoot` is to use it to determine a file's durability. Files in the `Workspace` have a `LOW` durability
where files on any module search path are probably unlikely to change. 

`FileRoot` also comes with a revision tracks the time when a file was last changed, added, or removed in that directory. 
I use the revision in this PR to make the editable installation paths query dependent on the site-package content, so that
we no longer need the `db.report_untracked_read` call


## Test Plan

I updated the test that @AlexWaygood added that shows that the editable paths are correctly re-resolved
