### PR TITLE
[red-knot] Rename some methods in the module resolver

### DIFF
--- a/crates/red_knot_module_resolver/src/lib.rs
+++ b/crates/red_knot_module_resolver/src/lib.rs
@@ -40,7 +40,7 @@ impl<'db> Iterator for SystemModuleSearchPathsIter<'db> {
         loop {
             let next = self.inner.next()?;
 
-            if let Some(system_path) = next.as_system_path_buf() {
+            if let Some(system_path) = next.as_system_path() {
                 return Some(system_path);
             }
         }

--- a/crates/red_knot_module_resolver/src/path.rs
+++ b/crates/red_knot_module_resolver/src/path.rs
@@ -224,7 +224,7 @@ impl PartialEq<SystemPathBuf> for ModulePath {
             relative_path,
         } = self;
         search_path
-            .as_system_path_buf()
+            .as_system_path()
             .and_then(|search_path| other.strip_prefix(search_path).ok())
             .is_some_and(|other_relative_path| other_relative_path.as_utf8_path() == relative_path)
     }
@@ -243,7 +243,7 @@ impl PartialEq<VendoredPathBuf> for ModulePath {
             relative_path,
         } = self;
         search_path
-            .as_vendored_path_buf()
+            .as_vendored_path()
             .and_then(|search_path| other.strip_prefix(search_path).ok())
             .is_some_and(|other_relative_path| other_relative_path.as_utf8_path() == relative_path)
     }
@@ -511,7 +511,7 @@ impl SearchPath {
     }
 
     #[must_use]
-    pub(crate) fn as_system_path_buf(&self) -> Option<&SystemPath> {
+    pub(crate) fn as_system_path(&self) -> Option<&SystemPath> {
         match &*self.0 {
             SearchPathInner::Extra(path)
             | SearchPathInner::FirstParty(path)
@@ -523,7 +523,7 @@ impl SearchPath {
     }
 
     #[must_use]
-    pub(crate) fn as_vendored_path_buf(&self) -> Option<&VendoredPath> {
+    pub(crate) fn as_vendored_path(&self) -> Option<&VendoredPath> {
         match &*self.0 {
             SearchPathInner::StandardLibraryVendored(path) => Some(path),
             SearchPathInner::Extra(_)
@@ -537,7 +537,7 @@ impl SearchPath {
 
 impl PartialEq<SystemPath> for SearchPath {
     fn eq(&self, other: &SystemPath) -> bool {
-        self.as_system_path_buf().is_some_and(|path| path == other)
+        self.as_system_path().is_some_and(|path| path == other)
     }
 }
 
@@ -561,8 +561,7 @@ impl PartialEq<SearchPath> for SystemPathBuf {
 
 impl PartialEq<VendoredPath> for SearchPath {
     fn eq(&self, other: &VendoredPath) -> bool {
-        self.as_vendored_path_buf()
-            .is_some_and(|path| path == other)
+        self.as_vendored_path().is_some_and(|path| path == other)
     }
 }
 

--- a/crates/red_knot_module_resolver/src/resolver.rs
+++ b/crates/red_knot_module_resolver/src/resolver.rs
@@ -158,7 +158,7 @@ fn try_resolve_module_resolution_settings(
         FxHashSet::with_capacity_and_hasher(static_search_paths.len(), FxBuildHasher);
 
     static_search_paths.retain(|path| {
-        if let Some(path) = path.as_system_path_buf() {
+        if let Some(path) = path.as_system_path() {
             seen_paths.insert(path.to_path_buf())
         } else {
             true
@@ -204,7 +204,7 @@ pub(crate) fn editable_install_resolution_paths(db: &dyn Db) -> Vec<SearchPath> 
 
     if let Some(site_packages) = site_packages {
         let site_packages = site_packages
-            .as_system_path_buf()
+            .as_system_path()
             .expect("Expected site-packages never to be a VendoredPath!");
 
         // As well as modules installed directly into `site-packages`,
@@ -225,7 +225,7 @@ pub(crate) fn editable_install_resolution_paths(db: &dyn Db) -> Vec<SearchPath> 
 
         let mut existing_paths: FxHashSet<_> = static_search_paths
             .iter()
-            .filter_map(|path| path.as_system_path_buf())
+            .filter_map(|path| path.as_system_path())
             .map(Cow::Borrowed)
             .collect();
 
@@ -234,7 +234,7 @@ pub(crate) fn editable_install_resolution_paths(db: &dyn Db) -> Vec<SearchPath> 
         for pth_file in &all_pth_files {
             for installation in pth_file.editable_installations() {
                 if existing_paths.insert(Cow::Owned(
-                    installation.as_system_path_buf().unwrap().to_path_buf(),
+                    installation.as_system_path().unwrap().to_path_buf(),
                 )) {
                     dynamic_paths.push(installation);
                 }


### PR DESCRIPTION
I changed the return types of these methods just before merging #12494 (addressing Micha's review), but forgot to change the names of the methods, so they're now badly named