### PR TITLE
[red-knot] remove wrong __init__.py from file-watching tests

### DIFF
--- a/crates/red_knot/tests/file_watching.rs
+++ b/crates/red_knot/tests/file_watching.rs
@@ -655,7 +655,6 @@ fn search_path() -> anyhow::Result<()> {
     );
 
     std::fs::write(site_packages.join("a.py").as_std_path(), "class A: ...")?;
-    std::fs::write(site_packages.join("__init__.py").as_std_path(), "")?;
 
     let changes = case.stop_watch();
 
@@ -686,7 +685,6 @@ fn add_search_path() -> anyhow::Result<()> {
     });
 
     std::fs::write(site_packages.join("a.py").as_std_path(), "class A: ...")?;
-    std::fs::write(site_packages.join("__init__.py").as_std_path(), "")?;
 
     let changes = case.stop_watch();
 


### PR DESCRIPTION
`__init__.py` belongs inside a package directory, it doesn't belong at the root of site-packages. It doesn't necessarily do any harm there, either, but it's confusing, and confusing why this test would write it.
