### PR TITLE
[red-knot] qualify function/class name with module/file

### DIFF
--- a/crates/red_knot_module_resolver/src/lib.rs
+++ b/crates/red_knot_module_resolver/src/lib.rs
@@ -3,7 +3,7 @@ use std::iter::FusedIterator;
 pub use db::{Db, Jar};
 pub use module::{Module, ModuleKind};
 pub use module_name::ModuleName;
-pub use resolver::resolve_module;
+pub use resolver::{file_to_module, resolve_module};
 use ruff_db::system::SystemPath;
 pub use typeshed::{
     vendored_typeshed_stubs, TypeshedVersionsParseError, TypeshedVersionsParseErrorKind,

--- a/crates/red_knot_module_resolver/src/resolver.rs
+++ b/crates/red_knot_module_resolver/src/resolver.rs
@@ -60,8 +60,9 @@ pub(crate) fn path_to_module(db: &dyn Db, path: &FilePath) -> Option<Module> {
 /// Resolves the module for the file with the given id.
 ///
 /// Returns `None` if the file is not a module locatable via any of the known search paths.
+#[allow(unreachable_pub)]
 #[salsa::tracked]
-pub(crate) fn file_to_module(db: &dyn Db, file: File) -> Option<Module> {
+pub fn file_to_module(db: &dyn Db, file: File) -> Option<Module> {
     let _span = tracing::trace_span!("file_to_module", ?file).entered();
 
     let path = file.path(db.upcast());

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -1,3 +1,4 @@
+use red_knot_module_resolver::{file_to_module, Module};
 use ruff_db::files::File;
 use ruff_python_ast::name::Name;
 
@@ -181,11 +182,18 @@ pub struct FunctionType<'db> {
     /// name of the function at definition
     pub name: Name,
 
+    /// file in which the function is defined
+    pub file: File,
+
     /// types of all decorators on this function
     decorators: Vec<Type<'db>>,
 }
 
 impl<'db> FunctionType<'db> {
+    pub fn module(self, db: &dyn Db) -> Option<Module> {
+        file_to_module(db.upcast(), self.file(db))
+    }
+
     pub fn has_decorator(self, db: &dyn Db, decorator: Type<'_>) -> bool {
         self.decorators(db).contains(&decorator)
     }
@@ -196,6 +204,9 @@ pub struct ClassType<'db> {
     /// Name of the class at definition
     pub name: Name,
 
+    /// file in which the class is defined
+    pub file: File,
+
     /// Types of all class bases
     bases: Vec<Type<'db>>,
 
@@ -203,6 +214,10 @@ pub struct ClassType<'db> {
 }
 
 impl<'db> ClassType<'db> {
+    pub fn module(self, db: &dyn Db) -> Option<Module> {
+        file_to_module(db.upcast(), self.file(db))
+    }
+
     /// Returns the class member of this class named `name`.
     ///
     /// The member resolves to a member of the class itself or any of its bases.

--- a/crates/red_knot_python_semantic/src/types/display.rs
+++ b/crates/red_knot_python_semantic/src/types/display.rs
@@ -28,10 +28,31 @@ impl Display for DisplayType<'_> {
             Type::Module(file) => {
                 write!(f, "<module '{:?}'>", file.path(self.db.upcast()))
             }
-            // TODO functions and classes should display using a fully qualified name
-            Type::Class(class) => write!(f, "Literal[{}]", class.name(self.db)),
+            Type::Class(class) => {
+                if let Some(module) = class.module(self.db) {
+                    write!(f, "Literal[{}.{}]", module.name(), class.name(self.db))
+                } else {
+                    write!(
+                        f,
+                        "Literal[<{}>.{}]",
+                        class.file(self.db).path(self.db.upcast()).as_ref(),
+                        class.name(self.db)
+                    )
+                }
+            }
             Type::Instance(class) => f.write_str(&class.name(self.db)),
-            Type::Function(function) => write!(f, "Literal[{}]", function.name(self.db)),
+            Type::Function(function) => {
+                if let Some(module) = function.module(self.db) {
+                    write!(f, "Literal[{}.{}]", module.name(), function.name(self.db))
+                } else {
+                    write!(
+                        f,
+                        "Literal[<{}>.{}]",
+                        function.file(self.db).path(self.db.upcast()).as_ref(),
+                        function.name(self.db)
+                    )
+                }
+            }
             Type::Union(union) => union.display(self.db).fmt(f),
             Type::Intersection(intersection) => intersection.display(self.db).fmt(f),
             Type::IntLiteral(n) => write!(f, "Literal[{n}]"),


### PR DESCRIPTION
When we display a class or function type, include the module name, not just the class/function name.

If the file in which it's defined is not an importable module (e.g. a script outside the import search paths), use the path to the file in brackets instead of a module name.