### PR TITLE
Avoid recommending `__slots__` for classes that inherit from more than `namedtuple`

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_slots/SLOT002.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_slots/SLOT002.py
@@ -1,4 +1,5 @@
 from collections import namedtuple
+from enum import Enum
 from typing import NamedTuple
 
 
@@ -19,4 +20,16 @@ class Good(namedtuple("foo", ["str", "int"])):  # OK
 
 
 class Good(NamedTuple):  # Ok
+    pass
+
+
+class Good(namedtuple("foo", ["str", "int"]), Enum):
+    pass
+
+
+class UnusualButStillBad(namedtuple("foo", ["str", "int"]), NamedTuple("foo", [("x", int, "y", int)])):
+    pass
+
+
+class UnusualButStillBad(namedtuple("foo", ["str", "int"]), object):
     pass

--- a/crates/ruff_linter/src/rules/flake8_slots/snapshots/ruff_linter__rules__flake8_slots__tests__SLOT002_SLOT002.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_slots/snapshots/ruff_linter__rules__flake8_slots__tests__SLOT002_SLOT002.py.snap
@@ -1,16 +1,30 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_slots/mod.rs
 ---
-SLOT002.py:5:7: SLOT002 Subclasses of `collections.namedtuple()` should define `__slots__`
+SLOT002.py:6:7: SLOT002 Subclasses of `collections.namedtuple()` should define `__slots__`
   |
-5 | class Bad(namedtuple("foo", ["str", "int"])):  # SLOT002
+6 | class Bad(namedtuple("foo", ["str", "int"])):  # SLOT002
   |       ^^^ SLOT002
-6 |     pass
+7 |     pass
   |
 
-SLOT002.py:9:7: SLOT002 Subclasses of call-based `typing.NamedTuple()` should define `__slots__`
+SLOT002.py:10:7: SLOT002 Subclasses of call-based `typing.NamedTuple()` should define `__slots__`
    |
- 9 | class UnusualButStillBad(NamedTuple("foo", [("x", int, "y", int)])):  # SLOT002
+10 | class UnusualButStillBad(NamedTuple("foo", [("x", int, "y", int)])):  # SLOT002
    |       ^^^^^^^^^^^^^^^^^^ SLOT002
-10 |     pass
+11 |     pass
+   |
+
+SLOT002.py:30:7: SLOT002 Subclasses of `collections.namedtuple()` should define `__slots__`
+   |
+30 | class UnusualButStillBad(namedtuple("foo", ["str", "int"]), NamedTuple("foo", [("x", int, "y", int)])):
+   |       ^^^^^^^^^^^^^^^^^^ SLOT002
+31 |     pass
+   |
+
+SLOT002.py:34:7: SLOT002 Subclasses of `collections.namedtuple()` should define `__slots__`
+   |
+34 | class UnusualButStillBad(namedtuple("foo", ["str", "int"]), object):
+   |       ^^^^^^^^^^^^^^^^^^ SLOT002
+35 |     pass
    |


### PR DESCRIPTION
## Summary

Closes https://github.com/astral-sh/ruff/issues/11887.
