### PR TITLE
Allow downloading ecosystem results from forks

### DIFF
--- a/.github/workflows/pr-comment.yaml
+++ b/.github/workflows/pr-comment.yaml
@@ -2,8 +2,8 @@ name: Ecosystem check comment
 
 on:
   workflow_run:
-    workflows: [ CI ]
-    types: [ completed ]
+    workflows: [CI]
+    types: [completed]
   workflow_dispatch:
     inputs:
       workflow_run_id:

--- a/.github/workflows/pr-comment.yaml
+++ b/.github/workflows/pr-comment.yaml
@@ -2,8 +2,8 @@ name: Ecosystem check comment
 
 on:
   workflow_run:
-    workflows: [CI]
-    types: [completed]
+    workflows: [ CI ]
+    types: [ completed ]
   workflow_dispatch:
     inputs:
       workflow_run_id:
@@ -23,6 +23,7 @@ jobs:
           name: pr-number
           run_id: ${{ github.event.workflow_run.id ||  github.event.inputs.workflow_run_id }}
           if_no_artifact_found: ignore
+          allow_forks: true
 
       - name: Parse pull request number
         id: pr-number
@@ -43,6 +44,7 @@ jobs:
           path: pr/ecosystem
           workflow_conclusion: completed
           if_no_artifact_found: ignore
+          allow_forks: true
 
       - name: Generate comment content
         id: generate-comment


### PR DESCRIPTION
## Summary

The default for `allow_forks` changed from `true` to `false` with the release of v4 on the 3rd of June.

Fixes https://github.com/astral-sh/ruff/issues/12543

## Test Plan

* [Run](https://github.com/astral-sh/ruff/actions/runs/10124925760/job/27999836193)
* [Comment](https://github.com/astral-sh/ruff/pull/12538#issuecomment-2254193716)
