### PR TITLE
Use `$/logTrace` for server trace logs in Zed and VS Code

### DIFF
--- a/crates/ruff_server/src/server.rs
+++ b/crates/ruff_server/src/server.rs
@@ -90,6 +90,7 @@ impl Server {
                 .log_level
                 .unwrap_or(crate::trace::LogLevel::Info),
             global_settings.tracing.log_file.as_deref(),
+            &init_params.client_info,
         );
 
         let mut workspace_for_url = |url: lsp_types::Url| {

--- a/crates/ruff_server/src/server.rs
+++ b/crates/ruff_server/src/server.rs
@@ -84,13 +84,13 @@ impl Server {
         } = all_settings;
 
         crate::trace::init_tracing(
-            &connection.make_sender(),
+            connection.make_sender(),
             global_settings
                 .tracing
                 .log_level
                 .unwrap_or(crate::trace::LogLevel::Info),
             global_settings.tracing.log_file.as_deref(),
-            &init_params.client_info,
+            init_params.client_info.as_ref(),
         );
 
         let mut workspace_for_url = |url: lsp_types::Url| {

--- a/crates/ruff_server/src/server.rs
+++ b/crates/ruff_server/src/server.rs
@@ -84,7 +84,7 @@ impl Server {
         } = all_settings;
 
         crate::trace::init_tracing(
-            connection.make_sender(),
+            &connection.make_sender(),
             global_settings
                 .tracing
                 .log_level

--- a/crates/ruff_server/src/trace.rs
+++ b/crates/ruff_server/src/trace.rs
@@ -82,7 +82,7 @@ impl<'a> MakeWriter<'a> for TraceLogWriter {
 }
 
 pub(crate) fn init_tracing(
-    sender: ClientSender,
+    sender: &ClientSender,
     log_level: LogLevel,
     log_file: Option<&std::path::Path>,
     client: &Option<ClientInfo>,

--- a/crates/ruff_server/src/trace.rs
+++ b/crates/ruff_server/src/trace.rs
@@ -82,13 +82,13 @@ impl<'a> MakeWriter<'a> for TraceLogWriter {
 }
 
 pub(crate) fn init_tracing(
-    sender: &ClientSender,
+    sender: ClientSender,
     log_level: LogLevel,
     log_file: Option<&std::path::Path>,
-    client: &Option<ClientInfo>,
+    client: Option<&ClientInfo>,
 ) {
     LOGGING_SENDER
-        .set(sender.clone())
+        .set(sender)
         .expect("logging sender should only be initialized once");
 
     let log_file = log_file
@@ -124,10 +124,9 @@ pub(crate) fn init_tracing(
     let logger = match log_file {
         Some(file) => BoxMakeWriter::new(Arc::new(file)),
         None => {
-            if client
-                .as_ref()
-                .is_some_and(|client| client.name.starts_with("Zed ") || client.name == "Zed")
-            {
+            if client.is_some_and(|client| {
+                client.name.starts_with("Zed") || client.name.starts_with("Visual Studio Code")
+            }) {
                 BoxMakeWriter::new(TraceLogWriter)
             } else {
                 BoxMakeWriter::new(std::io::stderr)

--- a/crates/ruff_server/src/trace.rs
+++ b/crates/ruff_server/src/trace.rs
@@ -14,16 +14,22 @@
 //!
 //! Tracing will write to `stderr` by default, which should appear in the logs for most LSP clients.
 //! A `logFile` path can also be specified in the settings, and output will be directed there instead.
-use lsp_types::TraceValue;
+use core::{fmt, str};
+use lsp_server::{Message, Notification};
+use lsp_types::{
+    notification::{LogTrace, Notification as _},
+    TraceValue,
+};
 use serde::Deserialize;
 use std::{
+    io::{Error as IoError, ErrorKind, Write},
     path::PathBuf,
     str::FromStr,
     sync::{Arc, Mutex, OnceLock},
 };
 use tracing::level_filters::LevelFilter;
 use tracing_subscriber::{
-    fmt::{time::Uptime, writer::BoxMakeWriter},
+    fmt::{time::Uptime, writer::BoxMakeWriter, MakeWriter},
     layer::SubscriberExt,
     Layer,
 };
@@ -43,13 +49,45 @@ pub(crate) fn set_trace_value(trace_value: TraceValue) {
     *global_trace_value = trace_value;
 }
 
+// A tracing writer that uses LSPs logTrace method.
+struct TraceLogWriter;
+
+impl Write for TraceLogWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        let message = str::from_utf8(buf).map_err(|e| IoError::new(ErrorKind::InvalidData, e))?;
+        LOGGING_SENDER
+            .get()
+            .expect("logging sender should be initialized at this point")
+            .send(Message::Notification(Notification {
+                method: LogTrace::METHOD.to_owned(),
+                params: serde_json::json!({
+                    "message": message
+                }),
+            }))
+            .map_err(|e| IoError::new(ErrorKind::Other, e))?;
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+impl<'a> MakeWriter<'a> for TraceLogWriter {
+    type Writer = Self;
+
+    fn make_writer(&'a self) -> Self::Writer {
+        Self
+    }
+}
+
 pub(crate) fn init_tracing(
     sender: ClientSender,
     log_level: LogLevel,
     log_file: Option<&std::path::Path>,
 ) {
     LOGGING_SENDER
-        .set(sender)
+        .set(sender.clone())
         .expect("logging sender should only be initialized once");
 
     let log_file = log_file
@@ -82,15 +120,16 @@ pub(crate) fn init_tracing(
                 .ok()
         });
 
+    let logger = match log_file {
+        Some(file) => BoxMakeWriter::new(Arc::new(file)),
+        None => BoxMakeWriter::new(TraceLogWriter),
+    };
     let subscriber = tracing_subscriber::Registry::default().with(
         tracing_subscriber::fmt::layer()
             .with_timer(Uptime::default())
             .with_thread_names(true)
             .with_ansi(false)
-            .with_writer(match log_file {
-                Some(file) => BoxMakeWriter::new(Arc::new(file)),
-                None => BoxMakeWriter::new(std::io::stderr),
-            })
+            .with_writer(logger)
             .with_filter(TraceLevelFilter)
             .with_filter(LogLevelFilter { filter: log_level }),
     );


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

This pull request adds support for logging via `$/logTrace` RPC messages. It also enables that code path for when a client is Zed editor (as there's no way for us to generically tell whether a client prefers `$/logTrace` over stderr.

Related to: #12523
/cc @dhruvmanila 

## Test Plan

I've built Ruff from this branch and tested it manually with Zed.
