### PR TITLE
Set Durability to 'HIGH' for most inputs and third-party libraries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2724,7 +2724,7 @@ checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
 [[package]]
 name = "salsa"
 version = "0.18.0"
-source = "git+https://github.com/salsa-rs/salsa.git?rev=cd339fc1c9a6ea0ffb1d09bd3bffb5633f776ef3#cd339fc1c9a6ea0ffb1d09bd3bffb5633f776ef3"
+source = "git+https://github.com/MichaReiser/salsa.git?rev=0cae5c52a3240172ef0be5c9d19e63448c53397c#0cae5c52a3240172ef0be5c9d19e63448c53397c"
 dependencies = [
  "arc-swap",
  "boomphf",
@@ -2744,12 +2744,12 @@ dependencies = [
 [[package]]
 name = "salsa-macro-rules"
 version = "0.1.0"
-source = "git+https://github.com/salsa-rs/salsa.git?rev=cd339fc1c9a6ea0ffb1d09bd3bffb5633f776ef3#cd339fc1c9a6ea0ffb1d09bd3bffb5633f776ef3"
+source = "git+https://github.com/MichaReiser/salsa.git?rev=0cae5c52a3240172ef0be5c9d19e63448c53397c#0cae5c52a3240172ef0be5c9d19e63448c53397c"
 
 [[package]]
 name = "salsa-macros"
 version = "0.18.0"
-source = "git+https://github.com/salsa-rs/salsa.git?rev=cd339fc1c9a6ea0ffb1d09bd3bffb5633f776ef3#cd339fc1c9a6ea0ffb1d09bd3bffb5633f776ef3"
+source = "git+https://github.com/MichaReiser/salsa.git?rev=0cae5c52a3240172ef0be5c9d19e63448c53397c#0cae5c52a3240172ef0be5c9d19e63448c53397c"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,7 +107,7 @@ rand = { version = "0.8.5" }
 rayon = { version = "1.10.0" }
 regex = { version = "1.10.2" }
 rustc-hash = { version = "2.0.0" }
-salsa = { git = "https://github.com/salsa-rs/salsa.git", rev = "cd339fc1c9a6ea0ffb1d09bd3bffb5633f776ef3" }
+salsa = { git = "https://github.com/MichaReiser/salsa.git", rev = "0cae5c52a3240172ef0be5c9d19e63448c53397c" }
 schemars = { version = "0.8.16" }
 seahash = { version = "4.1.0" }
 serde = { version = "1.0.197", features = ["derive"] }

--- a/crates/red_knot/src/db/changes.rs
+++ b/crates/red_knot/src/db/changes.rs
@@ -173,7 +173,7 @@ impl RootDatabase {
                 let package = workspace.package(self, &path);
                 let file = system_path_to_file(self, &path);
 
-                if let (Some(package), Some(file)) = (package, file) {
+                if let (Some(package), Ok(file)) = (package, file) {
                     package.add_file(self, file);
                 }
             }

--- a/crates/red_knot/src/workspace.rs
+++ b/crates/red_knot/src/workspace.rs
@@ -106,7 +106,7 @@ impl Workspace {
         }
 
         Workspace::builder(metadata.root, None, packages)
-            .durability(Durability::HIGH)
+            .durability(Durability::MEDIUM)
             .new(db)
     }
 
@@ -139,7 +139,7 @@ impl Workspace {
         }
 
         self.set_package_tree(db)
-            .with_durability(Durability::HIGH)
+            .with_durability(Durability::MEDIUM)
             .to(new_packages);
     }
 
@@ -310,7 +310,7 @@ impl Package {
 
     fn from_metadata(db: &dyn Db, metadata: PackageMetadata) -> Self {
         Self::builder(metadata.name, metadata.root, PackageFiles::default())
-            .durability(Durability::HIGH)
+            .durability(Durability::MEDIUM)
             .new(db)
     }
 
@@ -320,7 +320,7 @@ impl Package {
 
         if self.name(db) != metadata.name() {
             self.set_name(db)
-                .with_durability(Durability::HIGH)
+                .with_durability(Durability::MEDIUM)
                 .to(metadata.name);
         }
     }

--- a/crates/red_knot/src/workspace.rs
+++ b/crates/red_knot/src/workspace.rs
@@ -318,15 +318,19 @@ impl Package {
         let root = self.root(db);
         assert_eq!(root, metadata.root());
 
-        self.set_name(db)
-            .with_durability(Durability::HIGH)
-            .to(metadata.name);
+        if self.name(db) != metadata.name() {
+            self.set_name(db)
+                .with_durability(Durability::HIGH)
+                .to(metadata.name);
+        }
     }
 
     #[tracing::instrument(level = "debug", skip(db))]
     pub fn reload_files(self, db: &mut dyn Db) {
-        // Force a re-index of the files in the next revision.
-        self.set_file_set(db).to(PackageFiles::lazy());
+        if !self.file_set(db).is_lazy() {
+            // Force a re-index of the files in the next revision.
+            self.set_file_set(db).to(PackageFiles::lazy());
+        }
     }
 }
 
@@ -372,7 +376,7 @@ fn discover_package_files(db: &dyn Db, path: &SystemPath) -> FxHashSet<File> {
     for path in paths {
         // If this returns `None`, then the file was deleted between the `walk_directory` call and now.
         // We can ignore this.
-        if let Some(file) = system_path_to_file(db.upcast(), &path) {
+        if let Ok(file) = system_path_to_file(db.upcast(), &path) {
             files.insert(file);
         }
     }

--- a/crates/red_knot/src/workspace/files.rs
+++ b/crates/red_knot/src/workspace/files.rs
@@ -47,6 +47,10 @@ impl PackageFiles {
         }
     }
 
+    pub fn is_lazy(&self) -> bool {
+        matches!(*self.state.lock().unwrap(), State::Lazy)
+    }
+
     /// Returns a mutable view on the index that allows cheap in-place mutations.
     ///
     /// The changes are automatically written back to the database once the view is dropped.

--- a/crates/red_knot/tests/file_watching.rs
+++ b/crates/red_knot/tests/file_watching.rs
@@ -10,7 +10,7 @@ use red_knot::watch;
 use red_knot::watch::{directory_watcher, WorkspaceWatcher};
 use red_knot::workspace::WorkspaceMetadata;
 use red_knot_module_resolver::{resolve_module, ModuleName};
-use ruff_db::files::{system_path_to_file, File, SystemPathError};
+use ruff_db::files::{system_path_to_file, File, FileError};
 use ruff_db::program::{Program, ProgramSettings, SearchPathSettings, TargetVersion};
 use ruff_db::source::source_text;
 use ruff_db::system::{OsSystem, SystemPath, SystemPathBuf};
@@ -82,7 +82,7 @@ impl TestCase {
         collected
     }
 
-    fn system_file(&self, path: impl AsRef<SystemPath>) -> Result<File, SystemPathError> {
+    fn system_file(&self, path: impl AsRef<SystemPath>) -> Result<File, FileError> {
         system_path_to_file(self.db(), path.as_ref())
     }
 }
@@ -190,7 +190,7 @@ fn new_file() -> anyhow::Result<()> {
     let bar_file = case.system_file(&bar_path).unwrap();
     let foo_path = case.workspace_path("foo.py");
 
-    assert_eq!(case.system_file(&foo_path), Err(SystemPathError::NotFound));
+    assert_eq!(case.system_file(&foo_path), Err(FileError::NotFound));
     assert_eq!(&case.collect_package_files(&bar_path), &[bar_file]);
 
     std::fs::write(foo_path.as_std_path(), "print('Hello')")?;
@@ -213,7 +213,7 @@ fn new_ignored_file() -> anyhow::Result<()> {
     let bar_file = case.system_file(&bar_path).unwrap();
     let foo_path = case.workspace_path("foo.py");
 
-    assert_eq!(case.system_file(&foo_path), Err(SystemPathError::NotFound));
+    assert_eq!(case.system_file(&foo_path), Err(FileError::NotFound));
     assert_eq!(&case.collect_package_files(&bar_path), &[bar_file]);
 
     std::fs::write(foo_path.as_std_path(), "print('Hello')")?;

--- a/crates/red_knot/tests/file_watching.rs
+++ b/crates/red_knot/tests/file_watching.rs
@@ -10,7 +10,7 @@ use red_knot::watch;
 use red_knot::watch::{directory_watcher, WorkspaceWatcher};
 use red_knot::workspace::WorkspaceMetadata;
 use red_knot_module_resolver::{resolve_module, ModuleName};
-use ruff_db::files::{system_path_to_file, File};
+use ruff_db::files::{system_path_to_file, File, SystemPathError};
 use ruff_db::program::{Program, ProgramSettings, SearchPathSettings, TargetVersion};
 use ruff_db::source::source_text;
 use ruff_db::system::{OsSystem, SystemPath, SystemPathBuf};
@@ -82,7 +82,7 @@ impl TestCase {
         collected
     }
 
-    fn system_file(&self, path: impl AsRef<SystemPath>) -> Option<File> {
+    fn system_file(&self, path: impl AsRef<SystemPath>) -> Result<File, SystemPathError> {
         system_path_to_file(self.db(), path.as_ref())
     }
 }
@@ -190,7 +190,7 @@ fn new_file() -> anyhow::Result<()> {
     let bar_file = case.system_file(&bar_path).unwrap();
     let foo_path = case.workspace_path("foo.py");
 
-    assert_eq!(case.system_file(&foo_path), None);
+    assert_eq!(case.system_file(&foo_path), Err(SystemPathError::NotFound));
     assert_eq!(&case.collect_package_files(&bar_path), &[bar_file]);
 
     std::fs::write(foo_path.as_std_path(), "print('Hello')")?;
@@ -213,7 +213,7 @@ fn new_ignored_file() -> anyhow::Result<()> {
     let bar_file = case.system_file(&bar_path).unwrap();
     let foo_path = case.workspace_path("foo.py");
 
-    assert_eq!(case.system_file(&foo_path), None);
+    assert_eq!(case.system_file(&foo_path), Err(SystemPathError::NotFound));
     assert_eq!(&case.collect_package_files(&bar_path), &[bar_file]);
 
     std::fs::write(foo_path.as_std_path(), "print('Hello')")?;
@@ -222,7 +222,7 @@ fn new_ignored_file() -> anyhow::Result<()> {
 
     case.db_mut().apply_changes(changes);
 
-    assert!(case.system_file(&foo_path).is_some());
+    assert!(case.system_file(&foo_path).is_ok());
     assert_eq!(&case.collect_package_files(&bar_path), &[bar_file]);
 
     Ok(())
@@ -234,9 +234,7 @@ fn changed_file() -> anyhow::Result<()> {
     let mut case = setup([("foo.py", foo_source)])?;
     let foo_path = case.workspace_path("foo.py");
 
-    let foo = case
-        .system_file(&foo_path)
-        .ok_or_else(|| anyhow!("Foo not found"))?;
+    let foo = case.system_file(&foo_path)?;
     assert_eq!(source_text(case.db(), foo).as_str(), foo_source);
     assert_eq!(&case.collect_package_files(&foo_path), &[foo]);
 
@@ -260,9 +258,7 @@ fn changed_metadata() -> anyhow::Result<()> {
     let mut case = setup([("foo.py", "")])?;
     let foo_path = case.workspace_path("foo.py");
 
-    let foo = case
-        .system_file(&foo_path)
-        .ok_or_else(|| anyhow!("Foo not found"))?;
+    let foo = case.system_file(&foo_path)?;
     assert_eq!(
         foo.permissions(case.db()),
         Some(
@@ -302,9 +298,7 @@ fn deleted_file() -> anyhow::Result<()> {
     let mut case = setup([("foo.py", foo_source)])?;
     let foo_path = case.workspace_path("foo.py");
 
-    let foo = case
-        .system_file(&foo_path)
-        .ok_or_else(|| anyhow!("Foo not found"))?;
+    let foo = case.system_file(&foo_path)?;
 
     assert!(foo.exists(case.db()));
     assert_eq!(&case.collect_package_files(&foo_path), &[foo]);
@@ -333,9 +327,7 @@ fn move_file_to_trash() -> anyhow::Result<()> {
     let trash_path = case.root_path().join(".trash");
     std::fs::create_dir_all(trash_path.as_std_path())?;
 
-    let foo = case
-        .system_file(&foo_path)
-        .ok_or_else(|| anyhow!("Foo not found"))?;
+    let foo = case.system_file(&foo_path)?;
 
     assert!(foo.exists(case.db()));
     assert_eq!(&case.collect_package_files(&foo_path), &[foo]);
@@ -367,7 +359,7 @@ fn move_file_to_workspace() -> anyhow::Result<()> {
 
     let foo_in_workspace_path = case.workspace_path("foo.py");
 
-    assert!(case.system_file(&foo_path).is_some());
+    assert!(case.system_file(&foo_path).is_ok());
     assert_eq!(&case.collect_package_files(&bar_path), &[bar]);
     assert!(case
         .db()
@@ -381,9 +373,7 @@ fn move_file_to_workspace() -> anyhow::Result<()> {
 
     case.db_mut().apply_changes(changes);
 
-    let foo_in_workspace = case
-        .system_file(&foo_in_workspace_path)
-        .ok_or_else(|| anyhow!("Foo not found"))?;
+    let foo_in_workspace = case.system_file(&foo_in_workspace_path)?;
 
     assert!(foo_in_workspace.exists(case.db()));
     assert_eq!(
@@ -401,9 +391,7 @@ fn rename_file() -> anyhow::Result<()> {
     let foo_path = case.workspace_path("foo.py");
     let bar_path = case.workspace_path("bar.py");
 
-    let foo = case
-        .system_file(&foo_path)
-        .ok_or_else(|| anyhow!("Foo not found"))?;
+    let foo = case.system_file(&foo_path)?;
 
     assert_eq!(case.collect_package_files(&foo_path), [foo]);
 
@@ -415,9 +403,7 @@ fn rename_file() -> anyhow::Result<()> {
 
     assert!(!foo.exists(case.db()));
 
-    let bar = case
-        .system_file(&bar_path)
-        .ok_or_else(|| anyhow!("Bar not found"))?;
+    let bar = case.system_file(&bar_path)?;
 
     assert!(bar.exists(case.db()));
     assert_eq!(case.collect_package_files(&foo_path), [bar]);

--- a/crates/red_knot_module_resolver/src/resolver.rs
+++ b/crates/red_knot_module_resolver/src/resolver.rs
@@ -489,6 +489,7 @@ fn resolve_name(db: &dyn Db, name: &ModuleName) -> Option<(SearchPath, File, Mod
         if is_builtin_module && !search_path.is_standard_library() {
             continue;
         }
+
         let mut components = name.components();
         let module_name = components.next_back()?;
 
@@ -1282,6 +1283,7 @@ mod tests {
         db.memory_file_system()
             .remove_directory(foo_init_path.parent().unwrap())?;
         File::sync_path(&mut db, &foo_init_path);
+        File::sync_path(&mut db, foo_init_path.parent().unwrap());
 
         let foo_module = resolve_module(&db, foo_module_name).expect("Foo module to resolve");
         assert_eq!(&src.join("foo.py"), foo_module.file().path(&db));
@@ -1312,7 +1314,7 @@ mod tests {
         let functools_module = resolve_module(&db, functools_module_name.clone()).unwrap();
         assert_eq!(functools_module.search_path(), &stdlib);
         assert_eq!(
-            Some(functools_module.file()),
+            Ok(functools_module.file()),
             system_path_to_file(&db, &stdlib_functools_path)
         );
 
@@ -1332,7 +1334,7 @@ mod tests {
         );
         assert_eq!(functools_module.search_path(), &stdlib);
         assert_eq!(
-            Some(functools_module.file()),
+            Ok(functools_module.file()),
             system_path_to_file(&db, &stdlib_functools_path)
         );
     }
@@ -1358,7 +1360,7 @@ mod tests {
         let functools_module = resolve_module(&db, functools_module_name.clone()).unwrap();
         assert_eq!(functools_module.search_path(), &stdlib);
         assert_eq!(
-            Some(functools_module.file()),
+            Ok(functools_module.file()),
             system_path_to_file(&db, stdlib.join("functools.pyi"))
         );
 
@@ -1369,7 +1371,7 @@ mod tests {
         let functools_module = resolve_module(&db, functools_module_name.clone()).unwrap();
         assert_eq!(functools_module.search_path(), &src);
         assert_eq!(
-            Some(functools_module.file()),
+            Ok(functools_module.file()),
             system_path_to_file(&db, &src_functools_path)
         );
     }
@@ -1400,7 +1402,7 @@ mod tests {
         let functools_module = resolve_module(&db, functools_module_name.clone()).unwrap();
         assert_eq!(functools_module.search_path(), &src);
         assert_eq!(
-            Some(functools_module.file()),
+            Ok(functools_module.file()),
             system_path_to_file(&db, &src_functools_path)
         );
 
@@ -1413,7 +1415,7 @@ mod tests {
         let functools_module = resolve_module(&db, functools_module_name.clone()).unwrap();
         assert_eq!(functools_module.search_path(), &stdlib);
         assert_eq!(
-            Some(functools_module.file()),
+            Ok(functools_module.file()),
             system_path_to_file(&db, stdlib.join("functools.pyi"))
         );
     }

--- a/crates/red_knot_module_resolver/src/state.rs
+++ b/crates/red_knot_module_resolver/src/state.rs
@@ -1,5 +1,4 @@
 use ruff_db::program::TargetVersion;
-use ruff_db::system::System;
 use ruff_db::vendored::VendoredFileSystem;
 
 use crate::db::Db;
@@ -18,10 +17,6 @@ impl<'db> ResolverState<'db> {
             typeshed_versions: LazyTypeshedVersions::new(),
             target_version,
         }
-    }
-
-    pub(crate) fn system(&self) -> &dyn System {
-        self.db.system()
     }
 
     pub(crate) fn vendored(&self) -> &VendoredFileSystem {

--- a/crates/red_knot_module_resolver/src/typeshed/versions.rs
+++ b/crates/red_knot_module_resolver/src/typeshed/versions.rs
@@ -52,7 +52,7 @@ impl<'db> LazyTypeshedVersions<'db> {
             } else {
                 return &VENDORED_VERSIONS;
             };
-            let Some(versions_file) = system_path_to_file(db.upcast(), &versions_path) else {
+            let Ok(versions_file) = system_path_to_file(db.upcast(), &versions_path) else {
                 todo!(
                     "Still need to figure out how to handle VERSIONS files being deleted \
                     from custom typeshed directories! Expected a file to exist at {versions_path}"

--- a/crates/ruff_db/src/files.rs
+++ b/crates/ruff_db/src/files.rs
@@ -396,13 +396,21 @@ impl File {
 
         let durability = durability.unwrap_or_default();
 
-        file.set_status(db).with_durability(durability).to(status);
-        file.set_revision(db)
-            .with_durability(durability)
-            .to(revision);
-        file.set_permissions(db)
-            .with_durability(durability)
-            .to(permission);
+        if file.status(db) != status {
+            file.set_status(db).with_durability(durability).to(status);
+        }
+
+        if file.revision(db) != revision {
+            file.set_revision(db)
+                .with_durability(durability)
+                .to(revision);
+        }
+
+        if file.permissions(db) != permission {
+            file.set_permissions(db)
+                .with_durability(durability)
+                .to(permission);
+        }
     }
 
     /// Returns `true` if the file exists.

--- a/crates/ruff_db/src/files/file_root.rs
+++ b/crates/ruff_db/src/files/file_root.rs
@@ -1,6 +1,7 @@
 use std::fmt::Formatter;
 
 use path_slash::PathExt;
+use salsa::Durability;
 
 use crate::file_revision::FileRevision;
 use crate::system::{SystemPath, SystemPathBuf};
@@ -83,7 +84,9 @@ impl FileRoots {
         let mut route = normalized_path.replace('{', "{{").replace('}', "}}");
 
         // Insert a new source root
-        let root = FileRoot::new(db, path, kind, FileRevision::now());
+        let root = FileRoot::builder(path, kind, FileRevision::now())
+            .durability(Durability::HIGH)
+            .new(db);
 
         // Insert a path that matches the root itself
         self.by_path.insert(route.clone(), root).unwrap();

--- a/crates/ruff_db/src/files/path.rs
+++ b/crates/ruff_db/src/files/path.rs
@@ -95,7 +95,7 @@ impl FilePath {
     #[inline]
     pub fn to_file(&self, db: &dyn Db) -> Option<File> {
         match self {
-            FilePath::System(path) => system_path_to_file(db, path),
+            FilePath::System(path) => system_path_to_file(db, path).ok(),
             FilePath::Vendored(path) => vendored_path_to_file(db, path),
             FilePath::SystemVirtual(_) => None,
         }

--- a/crates/ruff_db/src/files/path.rs
+++ b/crates/ruff_db/src/files/path.rs
@@ -96,7 +96,7 @@ impl FilePath {
     pub fn to_file(&self, db: &dyn Db) -> Option<File> {
         match self {
             FilePath::System(path) => system_path_to_file(db, path).ok(),
-            FilePath::Vendored(path) => vendored_path_to_file(db, path),
+            FilePath::Vendored(path) => vendored_path_to_file(db, path).ok(),
             FilePath::SystemVirtual(_) => None,
         }
     }

--- a/crates/ruff_db/src/program.rs
+++ b/crates/ruff_db/src/program.rs
@@ -1,4 +1,5 @@
 use crate::{system::SystemPathBuf, Db};
+use salsa::Durability;
 
 #[salsa::input(singleton)]
 pub struct Program {
@@ -10,7 +11,9 @@ pub struct Program {
 
 impl Program {
     pub fn from_settings(db: &dyn Db, settings: ProgramSettings) -> Self {
-        Program::new(db, settings.target_version, settings.search_paths)
+        Program::builder(settings.target_version, settings.search_paths)
+            .durability(Durability::HIGH)
+            .new(db)
     }
 }
 

--- a/crates/ruff_db/src/system/memory_fs.rs
+++ b/crates/ruff_db/src/system/memory_fs.rs
@@ -207,7 +207,9 @@ impl MemoryFileSystem {
 
         let normalized = self.normalize_path(path.as_ref());
 
-        get_or_create_file(&mut by_path, &normalized)?.content = content.to_string();
+        let file = get_or_create_file(&mut by_path, &normalized)?;
+        file.content = content.to_string();
+        file.last_modified = FileTime::now();
 
         Ok(())
     }

--- a/crates/ruff_db/src/system/test.rs
+++ b/crates/ruff_db/src/system/test.rs
@@ -6,9 +6,6 @@ use crate::system::{
     DirectoryEntry, MemoryFileSystem, Metadata, Result, System, SystemPath, SystemVirtualPath,
 };
 use crate::Db;
-use std::any::Any;
-use std::panic::RefUnwindSafe;
-use std::sync::Arc;
 
 use super::walk_directory::WalkDirectoryBuilder;
 

--- a/crates/ruff_db/src/system/test.rs
+++ b/crates/ruff_db/src/system/test.rs
@@ -1,3 +1,7 @@
+use std::any::Any;
+use std::panic::RefUnwindSafe;
+use std::sync::Arc;
+
 use ruff_notebook::{Notebook, NotebookError};
 use ruff_python_trivia::textwrap;
 


### PR DESCRIPTION
## Summary

Salsa supports inputs with different durability levels. Inputs with lower durability are more likely to change. Using higher durability levels allows Salsa to short-circuit the query validation if a query only depends on inputs with high durability and no high durability input has changed. 

* `Files`: Files from third-party dependencies or the vendored file system have a high durability 
* `FileRoot`s have a high durability
* `Workspace`, `Package` have MEDIUM durability
* `Program` has a high durability

This PR only mitigates the cost for validating derived queries for unchanged inputs. The underlying problem that validating the *green* queries is "expensive" remains.

Fixes https://github.com/astral-sh/ruff/issues/12323

## `Files` changes

I noticed that we should only call salsa setters if the input value has changed. We otherwise unnecessarily invalidate all queries depending on that input. However, fixing this revealed that the module resolver relied on this incorrect behavior. 

This PR fixes the module resolver to not use `system().is_directory` which by-passes the salsa invalidation. I instead changed `system_path_to_file` from returning an `Option` to returning a `Result`. The `is_directory` check can then be written by asserting that `system_path_to_file` returns `Err(IsADirectory)`. 

## Testing

The Salsa API currently doesn't expose enough information to automatically verify whether a query validation is short-circuited or not. But I take the codspeed improvement and that all tests still pass as verification enough.