### PR TITLE
Fix NFKC normalization bug when removing unused imports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2319,6 +2319,7 @@ dependencies = [
  "thiserror",
  "toml",
  "typed-arena",
+ "unicode-normalization",
  "unicode-width",
  "unicode_names2",
  "url",

--- a/crates/ruff_linter/Cargo.toml
+++ b/crates/ruff_linter/Cargo.toml
@@ -69,6 +69,7 @@ toml = { workspace = true }
 typed-arena = { workspace = true }
 unicode-width = { workspace = true }
 unicode_names2 = { workspace = true }
+unicode-normalization = { workspace = true }
 url = { workspace = true }
 
 [dev-dependencies]

--- a/crates/ruff_linter/resources/test/fixtures/pyflakes/F401_30.py
+++ b/crates/ruff_linter/resources/test/fixtures/pyflakes/F401_30.py
@@ -1,0 +1,6 @@
+"""
+Test: ensure we're able to correctly remove unused imports
+even if they have characters in them that undergo NFKC normalization
+"""
+
+from .main import MaµToMan

--- a/crates/ruff_linter/src/fix/codemods.rs
+++ b/crates/ruff_linter/src/fix/codemods.rs
@@ -170,6 +170,7 @@ pub(crate) fn retain_imports(
     Ok(tree.codegen_stylist(stylist))
 }
 
+/// Create an NFKC-normalized qualified name from a libCST node.
 fn qualified_name_from_name_or_attribute(module: &NameOrAttribute) -> String {
     fn collect_segments<'a>(expr: &'a Expression, parts: &mut SmallVec<[&'a str; 8]>) {
         match expr {
@@ -187,6 +188,14 @@ fn qualified_name_from_name_or_attribute(module: &NameOrAttribute) -> String {
         }
     }
 
+    /// Attempt to create an [`UnqualifiedName`] from a libCST expression.
+    ///
+    /// Strictly speaking, the `UnqualifiedName` returned by this function may be invalid,
+    /// since it hasn't been NFKC-normalized. In order for an `UnqualifiedName` to be
+    /// comparable to one constructed from a `ruff_python_ast` node, it has to undergo
+    /// NFKC normalization. As a local function, however, this is fine;
+    /// the outer function always performs NFKC normalization before returning the
+    /// qualified name to the caller.
     fn unqualified_name_from_expression<'a>(
         expr: &'a Expression<'a>,
     ) -> Option<UnqualifiedName<'a>> {

--- a/crates/ruff_linter/src/fix/codemods.rs
+++ b/crates/ruff_linter/src/fix/codemods.rs
@@ -170,33 +170,35 @@ pub(crate) fn retain_imports(
     Ok(tree.codegen_stylist(stylist))
 }
 
-fn collect_segments<'a>(expr: &'a Expression, parts: &mut SmallVec<[&'a str; 8]>) {
-    match expr {
-        Expression::Call(expr) => {
-            collect_segments(&expr.func, parts);
-        }
-        Expression::Attribute(expr) => {
-            collect_segments(&expr.value, parts);
-            parts.push(expr.attr.value);
-        }
-        Expression::Name(expr) => {
-            parts.push(expr.value);
-        }
-        _ => {}
-    }
-}
-
-fn unqualified_name_from_expression<'a>(expr: &'a Expression<'a>) -> Option<UnqualifiedName<'a>> {
-    let mut segments = smallvec![];
-    collect_segments(expr, &mut segments);
-    if segments.is_empty() {
-        None
-    } else {
-        Some(segments.into_iter().collect())
-    }
-}
-
 fn qualified_name_from_name_or_attribute(module: &NameOrAttribute) -> String {
+    fn collect_segments<'a>(expr: &'a Expression, parts: &mut SmallVec<[&'a str; 8]>) {
+        match expr {
+            Expression::Call(expr) => {
+                collect_segments(&expr.func, parts);
+            }
+            Expression::Attribute(expr) => {
+                collect_segments(&expr.value, parts);
+                parts.push(expr.attr.value);
+            }
+            Expression::Name(expr) => {
+                parts.push(expr.value);
+            }
+            _ => {}
+        }
+    }
+
+    fn unqualified_name_from_expression<'a>(
+        expr: &'a Expression<'a>,
+    ) -> Option<UnqualifiedName<'a>> {
+        let mut segments = smallvec![];
+        collect_segments(expr, &mut segments);
+        if segments.is_empty() {
+            None
+        } else {
+            Some(segments.into_iter().collect())
+        }
+    }
+
     let unnormalized = match module {
         NameOrAttribute::N(name) => Cow::Borrowed(name.value),
         NameOrAttribute::A(attr) => {
@@ -208,5 +210,6 @@ fn qualified_name_from_name_or_attribute(module: &NameOrAttribute) -> String {
             )
         }
     };
+
     unnormalized.nfkc().collect()
 }

--- a/crates/ruff_linter/src/rules/pyflakes/mod.rs
+++ b/crates/ruff_linter/src/rules/pyflakes/mod.rs
@@ -258,6 +258,7 @@ mod tests {
     #[test_case(Rule::UnusedImport, Path::new("F401_27__all_mistyped/__init__.py"))]
     #[test_case(Rule::UnusedImport, Path::new("F401_28__all_multiple/__init__.py"))]
     #[test_case(Rule::UnusedImport, Path::new("F401_29__all_conditional/__init__.py"))]
+    #[test_case(Rule::UnusedImport, Path::new("F401_30.py"))]
     fn f401_deprecated_option(rule_code: Rule, path: &Path) -> Result<()> {
         let snapshot = format!(
             "{}_deprecated_option_{}",

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F401_deprecated_option_F401_30.py.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F401_deprecated_option_F401_30.py.snap
@@ -1,0 +1,17 @@
+---
+source: crates/ruff_linter/src/rules/pyflakes/mod.rs
+---
+F401_30.py:6:19: F401 [*] `.main.MaμToMan` imported but unused
+  |
+4 | """
+5 | 
+6 | from .main import MaµToMan
+  |                   ^^^^^^^^ F401
+  |
+  = help: Remove unused import: `.main.MaμToMan`
+
+ℹ Safe fix
+3 3 | even if they have characters in them that undergo NFKC normalization
+4 4 | """
+5 5 | 
+6   |-from .main import MaµToMan


### PR DESCRIPTION
Fixes #12570.

## Summary

Our lexer eagerly applies NFKC normalization to NKFC-confusable unicode characters; this is done to match Python's semantics at runtime, where the interpreter views these characters as the same. When removing unused imports, however, we use `libCST`, which doesn't apply the same normalization (it would be incorrect for `libCST` to do so, since it's a CST rather than an AST). This can lead to a `QualifiedName` constructed from a `libCST` node not comparing equal to a `QualifiedName` constructed from a `ruff_python_ast` node that represents the same sapn of source code as the `libCST` node. The difference here between the two parsers is the root cause of #12570.

This PR therefore takes care to apply NFKC normalization when constructing `QualifiedName`s from `libCST` nodes, so that these `QualifiedName`s are always comparable to `QualifiedName`s constructed from `ruff_python_ast` nodes.

## Test plan

`cargo test`