### PR TITLE
[red-knot] Fix typos in the module resolver

### DIFF
--- a/crates/red_knot_module_resolver/src/path.rs
+++ b/crates/red_knot_module_resolver/src/path.rs
@@ -324,8 +324,8 @@ impl fmt::Display for SearchPathValidationError {
             Self::NoStdlibSubdirectory(path) => {
                 write!(f, "The directory at {path} has no `stdlib/` subdirectory")
             }
-            Self::NoVersionsFile(path) => write!(f, "Expected a file at {path}/stldib/VERSIONS"),
-            Self::VersionsIsADirectory(path) => write!(f, "{path}/stldib/VERSIONS is a directory."),
+            Self::NoVersionsFile(path) => write!(f, "Expected a file at {path}/stdlib/VERSIONS"),
+            Self::VersionsIsADirectory(path) => write!(f, "{path}/stdlib/VERSIONS is a directory."),
             Self::VersionsParseError(underlying_error) => underlying_error.fmt(f),
         }
     }


### PR DESCRIPTION
One added in https://github.com/astral-sh/ruff/commit/e52be0951aad5483a0e453dded78627fc74e7e2a, the other in https://github.com/astral-sh/ruff/commit/a2286c8e47ec1ac84467f7db10e773589faff9f9