### PR TITLE
Keep track of deleted cell for reorder change request

### DIFF
--- a/crates/ruff_server/src/edit/text_document.rs
+++ b/crates/ruff_server/src/edit/text_document.rs
@@ -32,6 +32,10 @@ impl TextDocument {
         }
     }
 
+    pub fn into_contents(self) -> String {
+        self.contents
+    }
+
     pub fn contents(&self) -> &str {
         &self.contents
     }


### PR DESCRIPTION
## Summary

This PR fixes a bug where the server wouldn't retain the cell content in case of a reorder change request.

As mentioned in https://github.com/astral-sh/ruff/issues/12573#issuecomment-2257819298, this change request is modeled as (a) remove these cell URIs and (b) add these cell URIs. The cell content isn't provided. But, the way we've modeled the `NotebookCell` (it contains the underlying `TextDocument`), we need to keep track of the deleted cells to get the content.

This is not an ideal solution and a better long term solution would be to model it as per the spec but that is a big structural change and will affect multiple parts of the server. Modeling as per the spec would also avoid bugs like https://github.com/astral-sh/ruff/pull/11864. For context, that model would add complexity per https://github.com/astral-sh/ruff/pull/11206#discussion_r1600165481.

fixes: #12573

## Test Plan

This video shows the before and after the bug is fixed:

https://github.com/user-attachments/assets/2fcad4b5-f9af-4776-8640-4cd1fa16e325
