### PR TITLE
Improve handling of metaclasses in various linter rules

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_bugbear/B019.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_bugbear/B019.py
@@ -118,3 +118,9 @@ class Foo(enum.Enum):
     @functools.cache
     def bar(self, arg: str) -> str:
         return f"{self} - {arg}"
+
+
+class Metaclass(type):
+    @functools.lru_cache
+    def lru_cached_instance_method_on_metaclass(cls, x: int):
+        ...

--- a/crates/ruff_linter/src/rules/flake8_bugbear/snapshots/ruff_linter__rules__flake8_bugbear__tests__B019_B019.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/snapshots/ruff_linter__rules__flake8_bugbear__tests__B019_B019.py.snap
@@ -80,4 +80,11 @@ B019.py:106:5: B019 Use of `functools.lru_cache` or `functools.cache` on methods
 108 |         ...
     |
 
-
+B019.py:124:5: B019 Use of `functools.lru_cache` or `functools.cache` on methods can lead to memory leaks
+    |
+123 | class Metaclass(type):
+124 |     @functools.lru_cache
+    |     ^^^^^^^^^^^^^^^^^^^^ B019
+125 |     def lru_cached_instance_method_on_metaclass(cls, x: int):
+126 |         ...
+    |

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/non_self_return_type.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/non_self_return_type.rs
@@ -135,7 +135,7 @@ pub(crate) fn non_self_return_type(
     };
 
     // PEP 673 forbids the use of `typing(_extensions).Self` in metaclasses.
-    if is_metaclass(class_def, semantic) {
+    if analyze::class::is_metaclass(class_def, semantic) {
         return;
     }
 
@@ -217,16 +217,6 @@ pub(crate) fn non_self_return_type(
         }
         _ => {}
     }
-}
-
-/// Returns `true` if the given class is a metaclass.
-fn is_metaclass(class_def: &ast::StmtClassDef, semantic: &SemanticModel) -> bool {
-    analyze::class::any_qualified_name(class_def, semantic, &|qualified_name| {
-        matches!(
-            qualified_name.segments(),
-            ["" | "builtins", "type"] | ["abc", "ABCMeta"] | ["enum", "EnumMeta" | "EnumType"]
-        )
-    })
 }
 
 /// Returns `true` if the method is an in-place binary operator.

--- a/crates/ruff_python_semantic/src/analyze/class.rs
+++ b/crates/ruff_python_semantic/src/analyze/class.rs
@@ -110,3 +110,13 @@ pub fn is_enumeration(class_def: &ast::StmtClassDef, semantic: &SemanticModel) -
         )
     })
 }
+
+/// Returns `true` if the given class is a metaclass.
+pub fn is_metaclass(class_def: &ast::StmtClassDef, semantic: &SemanticModel) -> bool {
+    any_qualified_name(class_def, semantic, &|qualified_name| {
+        matches!(
+            qualified_name.segments(),
+            ["" | "builtins", "type"] | ["abc", "ABCMeta"] | ["enum", "EnumMeta" | "EnumType"]
+        )
+    })
+}


### PR DESCRIPTION
## Summary

This PR does several interrelated things:
1. The first thing it does is move an `is_metaclass` function out of `crates/ruff_linter/src/rules/flake8_pyi/rules/non_self_return_type.rs` and into the `ruff_python_semantic` crate. It's a generally useful function, and we were doing similar analysis elsewhere (but we were doing it incorrectly). It's better to centralize it in one place.
2. The second thing it does is that it changes the `classify()` function in `ruff_python_semantic::analyze::function_type` so that it no longer reports that metaclass instance methods are classmethods. For our `pep8-naming` rules, it makes sense to treat metaclass instance methods like classmethods, since metaclass instance methods usually use `cls` for the name of the first parameter, like classmethods on non-metaclasses. However, the `classify()` function is used by many other linter rules, not just our `pep8-naming` rules. For those rules, it doesn't make sense for metaclass instance methods to be considered classmethods, since, well, they're not. An example is B019, which I've added a test for in this PR: I'm not sure it makes sense to treat instance methods on metaclasses any differently to instance methods on regular classes for that rule.
3. Since `ruff_python_semantic::analyze::function_type::classify()` no longer considers instance methods on metaclasses to be classmethods, I adjusted the `pep8-naming` rules so that they now do their own check to see whether an instance method is a method on a metaclass, in order to determine what the name of the first parameter should be.

FWIW, there were several buggy things in the check for metaclasses that `ruff_python_semantic::analyze::function_type::classify()` was doing:
- It was using `map_callable()` when it should have been using `map_subscript()`
- It was missing the `enum`-module metaclasses that the stdlib provides
- It was only looking at the direct bases on the class, instead of iterating up through the bases of all superclasses

## Test Plan

`cargo test -p ruff_linter`
