### PR TITLE
Remove several incorrect uses of `map_callable()`

### DIFF
--- a/crates/ruff_python_semantic/src/analyze/visibility.rs
+++ b/crates/ruff_python_semantic/src/analyze/visibility.rs
@@ -28,23 +28,23 @@ pub fn is_classmethod(decorator_list: &[Decorator], semantic: &SemanticModel) ->
 
 /// Returns `true` if a function definition is an `@overload`.
 pub fn is_overload(decorator_list: &[Decorator], semantic: &SemanticModel) -> bool {
-    decorator_list.iter().any(|decorator| {
-        semantic.match_typing_expr(map_callable(&decorator.expression), "overload")
-    })
+    decorator_list
+        .iter()
+        .any(|decorator| semantic.match_typing_expr(&decorator.expression, "overload"))
 }
 
 /// Returns `true` if a function definition is an `@override` (PEP 698).
 pub fn is_override(decorator_list: &[Decorator], semantic: &SemanticModel) -> bool {
-    decorator_list.iter().any(|decorator| {
-        semantic.match_typing_expr(map_callable(&decorator.expression), "override")
-    })
+    decorator_list
+        .iter()
+        .any(|decorator| semantic.match_typing_expr(&decorator.expression, "override"))
 }
 
 /// Returns `true` if a function definition is an abstract method based on its decorators.
 pub fn is_abstract(decorator_list: &[Decorator], semantic: &SemanticModel) -> bool {
     decorator_list.iter().any(|decorator| {
         semantic
-            .resolve_qualified_name(map_callable(&decorator.expression))
+            .resolve_qualified_name(&decorator.expression)
             .is_some_and(|qualified_name| {
                 matches!(
                     qualified_name.segments(),
@@ -86,7 +86,7 @@ pub fn is_property(
 pub fn is_final(decorator_list: &[Decorator], semantic: &SemanticModel) -> bool {
     decorator_list
         .iter()
-        .any(|decorator| semantic.match_typing_expr(map_callable(&decorator.expression), "final"))
+        .any(|decorator| semantic.match_typing_expr(&decorator.expression, "final"))
 }
 
 /// Returns `true` if a function is a "magic method".


### PR DESCRIPTION
None of these decorators can ever be called as e.g. `@decorator()`; they all have to always be called without parens, e.g. `@decorator`. As such, these `map_callable()` calls are unnecessary and slightly confusing.