### PR TITLE
Improve consistency between linter rules in determining whether a function is property

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pydoclint/DOC201_google.py
+++ b/crates/ruff_linter/resources/test/fixtures/pydoclint/DOC201_google.py
@@ -71,3 +71,18 @@ def test():
         return 5
 
     print("I never return")
+
+
+from functools import cached_property
+
+class Baz:
+    # OK
+    @cached_property
+    def baz(self) -> str:
+        """
+        Do something
+
+        Args:
+            num (int): A number
+        """
+        return 'test'

--- a/crates/ruff_linter/resources/test/fixtures/pylint/property_with_parameters.py
+++ b/crates/ruff_linter/resources/test/fixtures/pylint/property_with_parameters.py
@@ -38,3 +38,12 @@ class VariadicParameters:
     @property
     def attribute_var_kwargs(self, **kwargs):  #[property-with-parameters]
         return {key: value * 2 for key, value in kwargs.items()}
+
+
+from functools import cached_property
+
+
+class Cached:
+    @cached_property
+    def cached_prop(self, value):  # [property-with-parameters]
+        ...

--- a/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLR0206_property_with_parameters.py.snap
+++ b/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLR0206_property_with_parameters.py.snap
@@ -42,3 +42,12 @@ property_with_parameters.py:39:9: PLR0206 Cannot have defined parameters for pro
    |         ^^^^^^^^^^^^^^^^^^^^ PLR0206
 40 |         return {key: value * 2 for key, value in kwargs.items()}
    |
+
+property_with_parameters.py:48:9: PLR0206 Cannot have defined parameters for properties
+   |
+46 | class Cached:
+47 |     @cached_property
+48 |     def cached_prop(self, value):  # [property-with-parameters]
+   |         ^^^^^^^^^^^ PLR0206
+49 |         ...
+   |

--- a/crates/ruff_python_semantic/src/definition.rs
+++ b/crates/ruff_python_semantic/src/definition.rs
@@ -6,13 +6,16 @@ use std::ops::Deref;
 use std::path::Path;
 
 use ruff_index::{newtype_index, IndexSlice, IndexVec};
-use ruff_python_ast::{self as ast, Stmt};
+use ruff_python_ast::name::QualifiedName;
+use ruff_python_ast::{self as ast, Stmt, StmtFunctionDef};
 use ruff_text_size::{Ranged, TextRange};
 
 use crate::analyze::visibility::{
-    class_visibility, function_visibility, method_visibility, module_visibility, Visibility,
+    class_visibility, function_visibility, is_property, method_visibility, module_visibility,
+    Visibility,
 };
 use crate::model::all::DunderAllName;
+use crate::SemanticModel;
 
 /// Id uniquely identifying a definition in a program.
 #[newtype_index]
@@ -146,6 +149,17 @@ impl<'a> Definition<'a> {
                 ..
             })
         )
+    }
+
+    pub fn is_property(
+        &self,
+        extra_properties: &[QualifiedName],
+        semantic: &SemanticModel,
+    ) -> bool {
+        self.as_function_def()
+            .is_some_and(|StmtFunctionDef { decorator_list, .. }| {
+                is_property(decorator_list, extra_properties, semantic)
+            })
     }
 
     /// Return the name of the definition.


### PR DESCRIPTION
## Summary

We have a function in `ruff_python_semantic` for detecting whether a function is a property or not. However, there are various linter rules where we've forgotten to use it. That means that our linter rules are internally inconsistent about whether they consider methods decorated with `@functools.cached_property` to be a property method, for example. This PR fixes that.

## Test Plan

`cargo test -p ruff_linter --lib`