### PR TITLE
Flaky file watching tests, add debug assertions

### DIFF
--- a/crates/red_knot/src/watch/watcher.rs
+++ b/crates/red_knot/src/watch/watcher.rs
@@ -240,7 +240,7 @@ impl Debouncer {
                 }
 
                 ModifyKind::Data(_) => ChangeEvent::Changed {
-                    kind: ChangedKind::FileMetadata,
+                    kind: ChangedKind::FileContent,
                     path,
                 },
 

--- a/crates/red_knot/tests/file_watching.rs
+++ b/crates/red_knot/tests/file_watching.rs
@@ -265,6 +265,8 @@ fn changed_file() -> anyhow::Result<()> {
 
     let changes = case.stop_watch();
 
+    assert!(!changes.is_empty());
+
     case.db_mut().apply_changes(changes);
 
     assert_eq!(source_text(case.db(), foo).as_str(), "print('Version 2')");


### PR DESCRIPTION
## Summary

It's unclear to me why the file watching test is flaky. Let's add a debug assertion that `changes` isn't empty. 

## Test Plan


