### PR TITLE
Fix an argument name in B905 description

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/zip_without_explicit_strict.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/zip_without_explicit_strict.rs
@@ -32,7 +32,7 @@ use crate::fix::edits::add_argument;
 ///
 /// ## Fix safety
 /// This rule's fix is marked as unsafe for `zip` calls that contain
-/// `**kwargs`, as adding a `check` keyword argument to such a call may lead
+/// `**kwargs`, as adding a `strict` keyword argument to such a call may lead
 /// to a duplicate keyword argument error.
 ///
 /// ## References


### PR DESCRIPTION
The description of `zip-without-explicit-strict` erroneously mentions a non-existing `check` argument for `zip()`.