### PR TITLE
Add Dify to Ruff users

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,6 +424,7 @@ Ruff is used by a number of major open-source projects and companies, including:
 - [Dagger](https://github.com/dagger/dagger)
 - [Dagster](https://github.com/dagster-io/dagster)
 - Databricks ([MLflow](https://github.com/mlflow/mlflow))
+- [Dify](https://github.com/langgenius/dify)
 - [FastAPI](https://github.com/tiangolo/fastapi)
 - [Godot](https://github.com/godotengine/godot)
 - [Gradio](https://github.com/gradio-app/gradio)


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->
- Add the popular LLM Ops project Dify to the user list in Readme, as Dify introduced Ruff for lining since Feb 2024 in https://github.com/langgenius/dify/pull/2366

## Test Plan

<!-- How was it tested? -->
