### PR TITLE
Remove `ecosystem_ci` flag from Ruff CLI

### DIFF
--- a/crates/ruff/src/args.rs
+++ b/crates/ruff/src/args.rs
@@ -400,9 +400,6 @@ pub struct CheckCommand {
         conflicts_with = "watch",
     )]
     pub show_settings: bool,
-    /// Dev-only argument to show fixes
-    #[arg(long, hide = true)]
-    pub ecosystem_ci: bool,
 }
 
 #[derive(Clone, Debug, clap::Parser)]
@@ -662,7 +659,6 @@ impl CheckCommand {
         let check_arguments = CheckArguments {
             add_noqa: self.add_noqa,
             diff: self.diff,
-            ecosystem_ci: self.ecosystem_ci,
             exit_non_zero_on_fix: self.exit_non_zero_on_fix,
             exit_zero: self.exit_zero,
             files: self.files,
@@ -946,7 +942,6 @@ fn resolve_output_format(
 pub struct CheckArguments {
     pub add_noqa: bool,
     pub diff: bool,
-    pub ecosystem_ci: bool,
     pub exit_non_zero_on_fix: bool,
     pub exit_zero: bool,
     pub files: Vec<PathBuf>,

--- a/crates/ruff/src/lib.rs
+++ b/crates/ruff/src/lib.rs
@@ -287,13 +287,6 @@ pub fn check(args: CheckCommand, global_options: GlobalConfigArgs) -> Result<Exi
     if show_fixes {
         printer_flags |= PrinterFlags::SHOW_FIX_SUMMARY;
     }
-    if cli.ecosystem_ci {
-        warn_user!(
-            "The formatting of fixes emitted by this option is a work-in-progress, subject to \
-            change at any time, and intended only for internal use."
-        );
-        printer_flags |= PrinterFlags::SHOW_FIX_DIFF;
-    }
 
     #[cfg(debug_assertions)]
     if cache {

--- a/python/ruff-ecosystem/ruff_ecosystem/projects.py
+++ b/python/ruff-ecosystem/ruff_ecosystem/projects.py
@@ -221,7 +221,7 @@ class CheckOptions(CommandOptions):
         if self.exclude:
             args.extend(["--exclude", self.exclude])
         if self.show_fixes:
-            args.extend(["--show-fixes", "--ecosystem-ci"])
+            args.extend(["--show-fixes"])
         return args
 
 

--- a/scripts/check_ecosystem.py
+++ b/scripts/check_ecosystem.py
@@ -191,7 +191,7 @@ async def check(
     if exclude:
         ruff_args.extend(["--exclude", exclude])
     if show_fixes:
-        ruff_args.extend(["--show-fixes", "--ecosystem-ci"])
+        ruff_args.extend(["--show-fixes"])
 
     start = time.time()
     proc = await create_subprocess_exec(


### PR DESCRIPTION
## Summary

@zanieb noticed while we were discussing #12595 that this flag is now unnecessary, so remove it and the flags which reference it.

## Test Plan

Question for maintainers: is there a test to add *or* remove here? (I’ve opened this as a draft PR with that in view!)
