### PR TITLE
Add newlines before comments in E305

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pycodestyle/E30.py
+++ b/crates/ruff_linter/resources/test/fixtures/pycodestyle/E30.py
@@ -962,3 +962,15 @@ def test_update():
 def test_clientmodel():
     pass
 # end
+
+
+# E305
+
+class A:
+    pass
+
+# ====== Cool constants ========
+BANANA = 100
+APPLE = 200
+
+# end

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/blank_lines.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/blank_lines.rs
@@ -902,8 +902,6 @@ impl<'a> BlankLinesChecker<'a> {
                 line.first_token_range,
             );
 
-            // Check if the preceding comment
-
             if let Some(blank_lines_range) = line.blank_lines.range() {
                 diagnostic.set_fix(Fix::safe_edit(Edit::range_replacement(
                     self.stylist
@@ -1029,10 +1027,10 @@ impl<'a> BlankLinesChecker<'a> {
                 )));
             } else {
                 diagnostic.set_fix(Fix::safe_edit(Edit::insertion(
-                    self.stylist
-                        .line_ending()
-                        .repeat(BLANK_LINES_TOP_LEVEL as usize),
-                    self.locator.line_start(line.first_token_range.start()),
+                    self.stylist.line_ending().repeat(
+                        (BLANK_LINES_TOP_LEVEL - line.preceding_blank_lines.count()) as usize,
+                    ),
+                    self.locator.line_start(state.last_non_comment_line_end),
                 )));
             }
 

--- a/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E305_E30.py.snap
+++ b/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E305_E30.py.snap
@@ -15,10 +15,9 @@ E30.py:798:1: E305 [*] Expected 2 blank lines after class or function definition
 796 796 | 
 797 797 |     # another comment
     798 |+
-    799 |+
-798 800 | fn()
-799 801 | # end
-800 802 | 
+798 799 | fn()
+799 800 | # end
+800 801 | 
 
 E30.py:809:1: E305 [*] Expected 2 blank lines after class or function definition, found (1)
     |
@@ -34,10 +33,9 @@ E30.py:809:1: E305 [*] Expected 2 blank lines after class or function definition
 807 807 | 
 808 808 |     # another comment
     809 |+
-    810 |+
-809 811 | a = 1
-810 812 | # end
-811 813 | 
+809 810 | a = 1
+810 811 | # end
+811 812 | 
 
 E30.py:821:1: E305 [*] Expected 2 blank lines after class or function definition, found (1)
     |
@@ -70,14 +68,13 @@ E30.py:833:1: E305 [*] Expected 2 blank lines after class or function definition
     = help: Add missing blank line(s)
 
 ℹ Safe fix
+829 829 | def a():
 830 830 |     print()
 831 831 | 
-832 832 | # Two spaces before comments, too.
-    833 |+
-    834 |+
-833 835 | if a():
-834 836 |     a()
-835 837 | # end
+    832 |+
+832 833 | # Two spaces before comments, too.
+833 834 | if a():
+834 835 |     a()
 
 E30.py:846:1: E305 [*] Expected 2 blank lines after class or function definition, found (1)
     |
@@ -98,3 +95,21 @@ E30.py:846:1: E305 [*] Expected 2 blank lines after class or function definition
 846 847 | if __name__ == '__main__':
 847 848 |     main()
 848 849 | # end
+
+E30.py:973:1: E305 [*] Expected 2 blank lines after class or function definition, found (1)
+    |
+972 | # ====== Cool constants ========
+973 | BANANA = 100
+    | ^^^^^^ E305
+974 | APPLE = 200
+    |
+    = help: Add missing blank line(s)
+
+ℹ Safe fix
+969 969 | class A:
+970 970 |     pass
+971 971 | 
+    972 |+
+972 973 | # ====== Cool constants ========
+973 974 | BANANA = 100
+974 975 | APPLE = 200

--- a/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__blank_lines_E305_notebook.snap
+++ b/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__blank_lines_E305_notebook.snap
@@ -16,7 +16,6 @@ E30.ipynb:55:1: E305 [*] Expected 2 blank lines after class or function definiti
 53 53 | 
 54 54 |     # another comment
    55 |+
-   56 |+
-55 57 | fn()
-56 58 | # end
-57 59 | # E306:3:5
+55 56 | fn()
+56 57 | # end
+57 58 | # E306:3:5


### PR DESCRIPTION
## Summary

There's still a problem here. Given:

```python
class Class():
    pass

    # comment

    # another comment
a = 1
```

We only add one newline before `a = 1` on the first pass, because `max_precedling_blank_lines` is 1... We then add the second newline on the second pass, so it ends up in the right state, but the logic is clearly wonky.

Closes https://github.com/astral-sh/ruff/issues/11508.
