### PR TITLE
Make server panic hook more error resilient

### DIFF
--- a/crates/ruff/src/main.rs
+++ b/crates/ruff/src/main.rs
@@ -87,14 +87,19 @@ pub fn main() -> ExitCode {
         Err(err) => {
             #[allow(clippy::print_stderr)]
             {
+                use std::io::Write;
+
+                // Use `writeln` instead of `eprintln` to avoid panicking when the stderr pipe is broken.
+                let mut stderr = std::io::stderr().lock();
+
                 // This communicates that this isn't a linter error but ruff itself hard-errored for
                 // some reason (e.g. failed to resolve the configuration)
-                eprintln!("{}", "ruff failed".red().bold());
+                writeln!(stderr, "{}", "ruff failed".red().bold()).ok();
                 // Currently we generally only see one error, but e.g. with io errors when resolving
                 // the configuration it is help to chain errors ("resolving configuration failed" ->
                 // "failed to read file: subdir/pyproject.toml")
                 for cause in err.chain() {
-                    eprintln!("  {} {cause}", "Cause:".bold());
+                    writeln!(stderr, "  {} {cause}", "Cause:".bold()).ok();
                 }
             }
             ExitStatus::Error.into()

--- a/crates/ruff_server/src/message.rs
+++ b/crates/ruff_server/src/message.rs
@@ -1,6 +1,6 @@
-use std::sync::OnceLock;
-
+use anyhow::Context;
 use lsp_types::notification::Notification;
+use std::sync::OnceLock;
 
 use crate::server::ClientSender;
 
@@ -10,55 +10,31 @@ pub(crate) fn init_messenger(client_sender: ClientSender) {
     MESSENGER
         .set(client_sender)
         .expect("messenger should only be initialized once");
-
-    // unregister any previously registered panic hook
-    let _ = std::panic::take_hook();
-
-    // When we panic, try to notify the client.
-    std::panic::set_hook(Box::new(move |panic_info| {
-        use std::io::Write;
-
-        if let Some(messenger) = MESSENGER.get() {
-            let _ = messenger.send(lsp_server::Message::Notification(
-                lsp_server::Notification {
-                    method: lsp_types::notification::ShowMessage::METHOD.into(),
-                    params: serde_json::to_value(lsp_types::ShowMessageParams {
-                        typ: lsp_types::MessageType::ERROR,
-                        message: String::from(
-                            "The Ruff language server exited with a panic. See the logs for more details."
-                        ),
-                    })
-                    .unwrap_or_default(),
-                },
-            ));
-        }
-
-        let backtrace = std::backtrace::Backtrace::force_capture();
-        tracing::error!("{panic_info}\n{backtrace}");
-
-        // we also need to print to stderr directly in case tracing hasn't
-        // been initialized.
-        // But use `writeln` instead of `eprintln` to avoid panicking when the stderr pipe is broken.
-        let mut stderr = std::io::stderr().lock();
-        writeln!(stderr, "{panic_info}\n{backtrace}").ok();
-    }));
 }
 
 pub(crate) fn show_message(message: String, message_type: lsp_types::MessageType) {
+    try_show_message(message, message_type).unwrap();
+}
+
+pub(super) fn try_show_message(
+    message: String,
+    message_type: lsp_types::MessageType,
+) -> crate::Result<()> {
     MESSENGER
         .get()
-        .expect("messenger should be initialized")
+        .ok_or_else(|| anyhow::anyhow!("messenger not initialized"))?
         .send(lsp_server::Message::Notification(
             lsp_server::Notification {
                 method: lsp_types::notification::ShowMessage::METHOD.into(),
                 params: serde_json::to_value(lsp_types::ShowMessageParams {
                     typ: message_type,
                     message,
-                })
-                .unwrap(),
+                })?,
             },
         ))
-        .expect("message should send");
+        .context("Failed to send message")?;
+
+    Ok(())
 }
 
 /// Sends an error to the client with a formatted message. The error is sent in a

--- a/crates/ruff_server/src/server.rs
+++ b/crates/ruff_server/src/server.rs
@@ -1,10 +1,10 @@
 //! Scheduling, I/O, and API endpoints.
 
-use std::num::NonZeroUsize;
-use std::str::FromStr;
-
 use lsp_server as lsp;
 use lsp_types as types;
+use std::num::NonZeroUsize;
+use std::panic::PanicInfo;
+use std::str::FromStr;
 use types::ClientCapabilities;
 use types::CodeActionKind;
 use types::CodeActionOptions;
@@ -36,6 +36,7 @@ mod client;
 mod connection;
 mod schedule;
 
+use crate::message::try_show_message;
 pub(crate) use connection::ClientSender;
 
 pub(crate) type Result<T> = std::result::Result<T, api::Error>;
@@ -133,6 +134,46 @@ impl Server {
     }
 
     pub fn run(self) -> crate::Result<()> {
+        type PanicHook = Box<dyn Fn(&PanicInfo<'_>) + 'static + Sync + Send>;
+        struct RestorePanicHook {
+            hook: Option<PanicHook>,
+        }
+
+        impl Drop for RestorePanicHook {
+            fn drop(&mut self) {
+                if let Some(hook) = self.hook.take() {
+                    std::panic::set_hook(hook);
+                }
+            }
+        }
+
+        // unregister any previously registered panic hook
+        // The hook will be restored when this function exits.
+        let _ = RestorePanicHook {
+            hook: Some(std::panic::take_hook()),
+        };
+
+        // When we panic, try to notify the client.
+        std::panic::set_hook(Box::new(move |panic_info| {
+            use std::io::Write;
+
+            let backtrace = std::backtrace::Backtrace::force_capture();
+            tracing::error!("{panic_info}\n{backtrace}");
+
+            // we also need to print to stderr directly for when using `$logTrace` because
+            // the message won't be sent to the client.
+            // But don't use `eprintln` because `eprintln` itself may panic if the pipe is broken.
+            let mut stderr = std::io::stderr().lock();
+            writeln!(stderr, "{panic_info}\n{backtrace}").ok();
+
+            try_show_message(
+                "The Ruff language server exited with a panic. See the logs for more details."
+                    .to_string(),
+                lsp_types::MessageType::ERROR,
+            )
+            .ok();
+        }));
+
         event_loop_thread(move || {
             Self::event_loop(
                 &self.connection,


### PR DESCRIPTION
## Summary

`eprintln` can panic when the stderr pipe is broken which is very unfortunate if it happens in the server's panic hook.

This PR uses `writeln` with `.ok()` as a more forgiving way to write the error message. 

This should fix https://github.com/astral-sh/ruff/issues/12545 although it is still unclear to me how to get into the broken pipe case. 

## Test Plan

I added a panic in the diagnostics request:

* NeoVim shows an error that the ruff server panicked
* The log contains the panic
  ```
	  0.008529319s ERROR ruff:worker:0 ruff_server::message: panicked at crates/ruff_server/src/server/api/requests/diagnostic.rs:23:9:
	no diagnostics for you
	   0: ruff_server::message::init_messenger::{{closure}}
	   1: std::panicking::rust_panic_with_hook
	   2: std::panicking::begin_panic_handler::{{closure}}
	   3: std::sys_common::backtrace::__rust_end_short_backtrace
	   4: rust_begin_unwind
	   5: core::panicking::panic_fmt
	   6: <ruff_server::server::api::requests::diagnostic::DocumentDiagnostic as ruff_server::server::api::traits::BackgroundDocumentRequestHandler>::run_with_snapshot
	   7: core::ops::function::FnOnce::call_once{{vtable.shim}}
	   8: core::ops::function::FnOnce::call_once{{vtable.shim}}
	   9: std::sys_common::backtrace::__rust_begin_short_backtrace
	  10: core::ops::function::FnOnce::call_once{{vtable.shim}}
	  11: std::sys::pal::unix::thread::Thread::new::thread_start
	  12: <unknown>
	  13: <unknown>
  ```
