### PR TITLE
Replace `ruff-lsp` links in `README.md` with links to new documentation page

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ An extremely fast Python linter and code formatter, written in Rust.
 - 📏 Over [800 built-in rules](https://docs.astral.sh/ruff/rules/), with native re-implementations
     of popular Flake8 plugins, like flake8-bugbear
 - ⌨️ First-party [editor integrations](https://docs.astral.sh/ruff/integrations/) for
-    [VS Code](https://github.com/astral-sh/ruff-vscode) and [more](editors/setup.md)
+    [VS Code](https://github.com/astral-sh/ruff-vscode) and [more](https://docs.astral.sh/ruff/editors/setup)
 - 🌎 Monorepo-friendly, with [hierarchical and cascading configuration](https://docs.astral.sh/ruff/configuration/#pyprojecttoml-discovery)
 
 Ruff aims to be orders of magnitude faster than alternative tools while integrating more
@@ -179,7 +179,7 @@ Ruff can also be used as a [pre-commit](https://pre-commit.com/) hook via [`ruff
     - id: ruff-format
 ```
 
-Ruff can also be used as a [VS Code extension](https://github.com/astral-sh/ruff-vscode) or with [various other editors](editors/setup.md).
+Ruff can also be used as a [VS Code extension](https://github.com/astral-sh/ruff-vscode) or with [various other editors](https://docs.astral.sh/ruff/editors/setup).
 
 Ruff can also be used as a [GitHub Action](https://github.com/features/actions) via
 [`ruff-action`](https://github.com/chartboost/ruff-action):

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ An extremely fast Python linter and code formatter, written in Rust.
 - 📏 Over [800 built-in rules](https://docs.astral.sh/ruff/rules/), with native re-implementations
     of popular Flake8 plugins, like flake8-bugbear
 - ⌨️ First-party [editor integrations](https://docs.astral.sh/ruff/integrations/) for
-    [VS Code](https://github.com/astral-sh/ruff-vscode) and [more](docs/editors/index.md)
+    [VS Code](https://github.com/astral-sh/ruff-vscode) and [more](https://docs.astral.sh/ruff/editors/setup)
 - 🌎 Monorepo-friendly, with [hierarchical and cascading configuration](https://docs.astral.sh/ruff/configuration/#pyprojecttoml-discovery)
 
 Ruff aims to be orders of magnitude faster than alternative tools while integrating more
@@ -179,8 +179,7 @@ Ruff can also be used as a [pre-commit](https://pre-commit.com/) hook via [`ruff
     - id: ruff-format
 ```
 
-Ruff can also be used as a [VS Code extension](https://github.com/astral-sh/ruff-vscode) or
-alongside any other editor through the [Ruff LSP](docs/editors/index.md#language-server-protocol).
+Ruff can also be used as a [VS Code extension](https://github.com/astral-sh/ruff-vscode) or with [various other editors](https://docs.astral.sh/ruff/editors/setup).
 
 Ruff can also be used as a [GitHub Action](https://github.com/features/actions) via
 [`ruff-action`](https://github.com/chartboost/ruff-action):

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ An extremely fast Python linter and code formatter, written in Rust.
 - 📏 Over [800 built-in rules](https://docs.astral.sh/ruff/rules/), with native re-implementations
     of popular Flake8 plugins, like flake8-bugbear
 - ⌨️ First-party [editor integrations](https://docs.astral.sh/ruff/integrations/) for
-    [VS Code](https://github.com/astral-sh/ruff-vscode) and [more](https://docs.astral.sh/ruff/editors/)
+    [VS Code](https://github.com/astral-sh/ruff-vscode) and [more](docs/editors/index.md)
 - 🌎 Monorepo-friendly, with [hierarchical and cascading configuration](https://docs.astral.sh/ruff/configuration/#pyprojecttoml-discovery)
 
 Ruff aims to be orders of magnitude faster than alternative tools while integrating more
@@ -180,7 +180,7 @@ Ruff can also be used as a [pre-commit](https://pre-commit.com/) hook via [`ruff
 ```
 
 Ruff can also be used as a [VS Code extension](https://github.com/astral-sh/ruff-vscode) or
-alongside any other editor through the [Ruff LSP](https://docs.astral.sh/ruff/editors/#language-server-protocol).
+alongside any other editor through the [Ruff LSP](docs/editors/index.md#language-server-protocol).
 
 Ruff can also be used as a [GitHub Action](https://github.com/features/actions) via
 [`ruff-action`](https://github.com/chartboost/ruff-action):

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ An extremely fast Python linter and code formatter, written in Rust.
 - 📏 Over [800 built-in rules](https://docs.astral.sh/ruff/rules/), with native re-implementations
     of popular Flake8 plugins, like flake8-bugbear
 - ⌨️ First-party [editor integrations](https://docs.astral.sh/ruff/integrations/) for
-    [VS Code](https://github.com/astral-sh/ruff-vscode) and [more](https://docs.astral.sh/ruff/editors/setup)
+    [VS Code](https://github.com/astral-sh/ruff-vscode) and [more](editors/setup.md)
 - 🌎 Monorepo-friendly, with [hierarchical and cascading configuration](https://docs.astral.sh/ruff/configuration/#pyprojecttoml-discovery)
 
 Ruff aims to be orders of magnitude faster than alternative tools while integrating more
@@ -179,7 +179,7 @@ Ruff can also be used as a [pre-commit](https://pre-commit.com/) hook via [`ruff
     - id: ruff-format
 ```
 
-Ruff can also be used as a [VS Code extension](https://github.com/astral-sh/ruff-vscode) or with [various other editors](https://docs.astral.sh/ruff/editors/setup).
+Ruff can also be used as a [VS Code extension](https://github.com/astral-sh/ruff-vscode) or with [various other editors](editors/setup.md).
 
 Ruff can also be used as a [GitHub Action](https://github.com/features/actions) via
 [`ruff-action`](https://github.com/chartboost/ruff-action):

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ An extremely fast Python linter and code formatter, written in Rust.
 - 📏 Over [800 built-in rules](https://docs.astral.sh/ruff/rules/), with native re-implementations
     of popular Flake8 plugins, like flake8-bugbear
 - ⌨️ First-party [editor integrations](https://docs.astral.sh/ruff/integrations/) for
-    [VS Code](https://github.com/astral-sh/ruff-vscode) and [more](https://github.com/astral-sh/ruff-lsp)
+    [VS Code](https://github.com/astral-sh/ruff-vscode) and [more](https://docs.astral.sh/ruff/editors/)
 - 🌎 Monorepo-friendly, with [hierarchical and cascading configuration](https://docs.astral.sh/ruff/configuration/#pyprojecttoml-discovery)
 
 Ruff aims to be orders of magnitude faster than alternative tools while integrating more
@@ -180,7 +180,7 @@ Ruff can also be used as a [pre-commit](https://pre-commit.com/) hook via [`ruff
 ```
 
 Ruff can also be used as a [VS Code extension](https://github.com/astral-sh/ruff-vscode) or
-alongside any other editor through the [Ruff LSP](https://github.com/astral-sh/ruff-lsp).
+alongside any other editor through the [Ruff LSP](https://docs.astral.sh/ruff/editors/#language-server-protocol).
 
 Ruff can also be used as a [GitHub Action](https://github.com/features/actions) via
 [`ruff-action`](https://github.com/chartboost/ruff-action):

--- a/scripts/generate_mkdocs.py
+++ b/scripts/generate_mkdocs.py
@@ -62,6 +62,7 @@ LINK_REWRITES: dict[str, str] = {
         "configuration.md#pyprojecttoml-discovery"
     ),
     "https://docs.astral.sh/ruff/contributing/": "contributing.md",
+    "https://docs.astral.sh/ruff/editors/setup": "editors/setup.md",
     "https://docs.astral.sh/ruff/integrations/": "integrations.md",
     "https://docs.astral.sh/ruff/faq/#how-does-ruff-compare-to-flake8": (
         "faq.md#how-does-ruff-compare-to-flake8"


### PR DESCRIPTION
Since `ruff-lsp` has been (semi-)deprecated for sometime, it wouldn't make sense to mention it in the most prominent sections of the `README`. Instead, they should point to the new <i>[Editor Integrations](https://docs.astral.sh/ruff/editors/)</i> documentation page.