### PR TITLE
Set durabilities for low-durability fields on high-durability inputs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2739,7 +2739,7 @@ checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
 [[package]]
 name = "salsa"
 version = "0.18.0"
-source = "git+https://github.com/MichaReiser/salsa.git?rev=0cae5c52a3240172ef0be5c9d19e63448c53397c#0cae5c52a3240172ef0be5c9d19e63448c53397c"
+source = "git+https://github.com/MichaReiser/salsa.git?rev=d1b770f0e1c994d6e921bf39bd54e7c08485e614#d1b770f0e1c994d6e921bf39bd54e7c08485e614"
 dependencies = [
  "arc-swap",
  "boomphf",
@@ -2759,12 +2759,12 @@ dependencies = [
 [[package]]
 name = "salsa-macro-rules"
 version = "0.1.0"
-source = "git+https://github.com/MichaReiser/salsa.git?rev=0cae5c52a3240172ef0be5c9d19e63448c53397c#0cae5c52a3240172ef0be5c9d19e63448c53397c"
+source = "git+https://github.com/MichaReiser/salsa.git?rev=d1b770f0e1c994d6e921bf39bd54e7c08485e614#d1b770f0e1c994d6e921bf39bd54e7c08485e614"
 
 [[package]]
 name = "salsa-macros"
 version = "0.18.0"
-source = "git+https://github.com/MichaReiser/salsa.git?rev=0cae5c52a3240172ef0be5c9d19e63448c53397c#0cae5c52a3240172ef0be5c9d19e63448c53397c"
+source = "git+https://github.com/MichaReiser/salsa.git?rev=d1b770f0e1c994d6e921bf39bd54e7c08485e614#d1b770f0e1c994d6e921bf39bd54e7c08485e614"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2739,7 +2739,7 @@ checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
 [[package]]
 name = "salsa"
 version = "0.18.0"
-source = "git+https://github.com/MichaReiser/salsa.git?rev=d1b770f0e1c994d6e921bf39bd54e7c08485e614#d1b770f0e1c994d6e921bf39bd54e7c08485e614"
+source = "git+https://github.com/MichaReiser/salsa.git?rev=635e23943c095077c4a423488ac829b4ae0bfa77#635e23943c095077c4a423488ac829b4ae0bfa77"
 dependencies = [
  "arc-swap",
  "boomphf",
@@ -2759,12 +2759,12 @@ dependencies = [
 [[package]]
 name = "salsa-macro-rules"
 version = "0.1.0"
-source = "git+https://github.com/MichaReiser/salsa.git?rev=d1b770f0e1c994d6e921bf39bd54e7c08485e614#d1b770f0e1c994d6e921bf39bd54e7c08485e614"
+source = "git+https://github.com/MichaReiser/salsa.git?rev=635e23943c095077c4a423488ac829b4ae0bfa77#635e23943c095077c4a423488ac829b4ae0bfa77"
 
 [[package]]
 name = "salsa-macros"
 version = "0.18.0"
-source = "git+https://github.com/MichaReiser/salsa.git?rev=d1b770f0e1c994d6e921bf39bd54e7c08485e614#d1b770f0e1c994d6e921bf39bd54e7c08485e614"
+source = "git+https://github.com/MichaReiser/salsa.git?rev=635e23943c095077c4a423488ac829b4ae0bfa77#635e23943c095077c4a423488ac829b4ae0bfa77"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,7 +107,7 @@ rand = { version = "0.8.5" }
 rayon = { version = "1.10.0" }
 regex = { version = "1.10.2" }
 rustc-hash = { version = "2.0.0" }
-salsa = { git = "https://github.com/MichaReiser/salsa.git", rev = "0cae5c52a3240172ef0be5c9d19e63448c53397c" }
+salsa = { git = "https://github.com/MichaReiser/salsa.git", rev = "d1b770f0e1c994d6e921bf39bd54e7c08485e614" }
 schemars = { version = "0.8.16" }
 seahash = { version = "4.1.0" }
 serde = { version = "1.0.197", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,7 +107,7 @@ rand = { version = "0.8.5" }
 rayon = { version = "1.10.0" }
 regex = { version = "1.10.2" }
 rustc-hash = { version = "2.0.0" }
-salsa = { git = "https://github.com/MichaReiser/salsa.git", rev = "d1b770f0e1c994d6e921bf39bd54e7c08485e614" }
+salsa = { git = "https://github.com/MichaReiser/salsa.git", rev = "635e23943c095077c4a423488ac829b4ae0bfa77" }
 schemars = { version = "0.8.16" }
 seahash = { version = "4.1.0" }
 serde = { version = "1.0.197", features = ["derive"] }

--- a/crates/red_knot_workspace/src/workspace.rs
+++ b/crates/red_knot_workspace/src/workspace.rs
@@ -73,6 +73,7 @@ pub struct Workspace {
     /// Setting the open files to a non-`None` value changes `check` to only check the
     /// open files rather than all files in the workspace.
     #[return_ref]
+    #[default]
     open_file_set: Option<Arc<FxHashSet<File>>>,
 
     /// The (first-party) packages in this workspace.
@@ -92,6 +93,7 @@ pub struct Package {
 
     /// The files that are part of this package.
     #[return_ref]
+    #[default]
     file_set: PackageFiles,
     // TODO: Add the loaded settings.
 }
@@ -105,8 +107,9 @@ impl Workspace {
             packages.insert(package.root.clone(), Package::from_metadata(db, package));
         }
 
-        Workspace::builder(metadata.root, None, packages)
+        Workspace::builder(metadata.root, packages)
             .durability(Durability::MEDIUM)
+            .open_file_set_durability(Durability::LOW)
             .new(db)
     }
 
@@ -309,8 +312,9 @@ impl Package {
     }
 
     fn from_metadata(db: &dyn Db, metadata: PackageMetadata) -> Self {
-        Self::builder(metadata.name, metadata.root, PackageFiles::default())
+        Self::builder(metadata.name, metadata.root)
             .durability(Durability::MEDIUM)
+            .file_set_durability(Durability::LOW)
             .new(db)
     }
 

--- a/crates/red_knot_workspace/src/workspace.rs
+++ b/crates/red_knot_workspace/src/workspace.rs
@@ -74,7 +74,7 @@ pub struct Workspace {
     /// open files rather than all files in the workspace.
     #[return_ref]
     #[default]
-    open_file_set: Option<Arc<FxHashSet<File>>>,
+    open_fileset: Option<Arc<FxHashSet<File>>>,
 
     /// The (first-party) packages in this workspace.
     #[return_ref]
@@ -109,7 +109,7 @@ impl Workspace {
 
         Workspace::builder(metadata.root, packages)
             .durability(Durability::MEDIUM)
-            .open_file_set_durability(Durability::LOW)
+            .open_fileset_durability(Durability::LOW)
             .new(db)
     }
 
@@ -217,7 +217,7 @@ impl Workspace {
 
     /// Returns the open files in the workspace or `None` if the entire workspace should be checked.
     pub fn open_files(self, db: &dyn Db) -> Option<&FxHashSet<File>> {
-        self.open_file_set(db).as_deref()
+        self.open_fileset(db).as_deref()
     }
 
     /// Sets the open files in the workspace.
@@ -225,7 +225,7 @@ impl Workspace {
     /// This changes the behavior of `check` to only check the open files rather than all files in the workspace.
     #[tracing::instrument(level = "debug", skip(self, db))]
     pub fn set_open_files(self, db: &mut dyn Db, open_files: FxHashSet<File>) {
-        self.set_open_file_set(db).to(Some(Arc::new(open_files)));
+        self.set_open_fileset(db).to(Some(Arc::new(open_files)));
     }
 
     /// This takes the open files from the workspace and returns them.
@@ -234,7 +234,7 @@ impl Workspace {
     pub fn take_open_files(self, db: &mut dyn Db) -> FxHashSet<File> {
         // Salsa will cancel any pending queries and remove its own reference to `open_files`
         // so that the reference counter to `open_files` now drops to 1.
-        let open_files = self.set_open_file_set(db).to(None);
+        let open_files = self.set_open_fileset(db).to(None);
 
         if let Some(open_files) = open_files {
             Arc::try_unwrap(open_files).unwrap()

--- a/crates/ruff_db/src/file_revision.rs
+++ b/crates/ruff_db/src/file_revision.rs
@@ -7,7 +7,7 @@
 /// * The last modification time of the file.
 /// * The hash of the file's content.
 /// * The revision as it comes from an external system, for example the LSP.
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Default)]
 pub struct FileRevision(u128);
 
 impl FileRevision {

--- a/crates/ruff_db/src/files/file_root.rs
+++ b/crates/ruff_db/src/files/file_root.rs
@@ -37,10 +37,7 @@ impl FileRoot {
     }
 
     pub fn durability(self, db: &dyn Db) -> salsa::Durability {
-        match self.kind_at_time_of_creation(db) {
-            FileRootKind::Workspace => salsa::Durability::LOW,
-            FileRootKind::LibrarySearchPath => salsa::Durability::HIGH,
-        }
+        self.kind_at_time_of_creation(db).durability()
     }
 }
 
@@ -51,6 +48,15 @@ pub enum FileRootKind {
 
     /// A non-workspace module resolution search path.
     LibrarySearchPath,
+}
+
+impl FileRootKind {
+    const fn durability(self) -> Durability {
+        match self {
+            FileRootKind::Workspace => Durability::LOW,
+            FileRootKind::LibrarySearchPath => Durability::HIGH,
+        }
+    }
 }
 
 #[derive(Default)]
@@ -86,6 +92,7 @@ impl FileRoots {
         // Insert a new source root
         let root = FileRoot::builder(path, kind, FileRevision::now())
             .durability(Durability::HIGH)
+            .revision_durability(kind.durability())
             .new(db);
 
         // Insert a path that matches the root itself


### PR DESCRIPTION
## Summary

This PR sets the durability of low-durability fields on structs with a high durability. 
This prevents that changing those files requires a deep verification for all revisions. 

## Test Plan

`cargo test`
