### PR TITLE
[`fastapi`] Implement `fast-api-unused-path-parameter` (`FAST003`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/fastapi/FAST003.py
+++ b/crates/ruff_linter/resources/test/fixtures/fastapi/FAST003.py
@@ -4,28 +4,50 @@ app = FastAPI()
 
 
 # Errors
-
 @app.get("/things/{thing_id}")
 async def read_thing(query: str):
     return {"query": query}
+
 
 @app.get("/books/isbn-{isbn}")
 async def read_thing():
     ...
 
 
+@app.get("/things/{thing_id:path}")
+async def read_thing(query: str):
+    return {"query": query}
+
+
+@app.get("/things/{thing_id : path}")
+async def read_thing(query: str):
+    return {"query": query}
+
+
 
 # OK
-
-
 @app.get("/things/{thing_id}")
 async def read_thing(thing_id: int, query: str):
     return {"thing_id": thing_id, "query": query}
+
 
 @app.get("/books/isbn-{isbn}")
 async def read_thing(isbn: str):
     return {"isbn": isbn}
 
+
+@app.get("/things/{thing_id:path}")
+async def read_thing(thing_id: str, query: str):
+    return {"thing_id": thing_id, "query": query}
+
+
+@app.get("/things/{thing_id : path}")
+async def read_thing(thing_id: str, query: str):
+    return {"thing_id": thing_id, "query": query}
+
+
+
+# Ignored
 @app.get("/things/{thing-id}")
 async def read_thing(query: str):
     return {"query": query}

--- a/crates/ruff_linter/resources/test/fixtures/fastapi/FAST003.py
+++ b/crates/ruff_linter/resources/test/fixtures/fastapi/FAST003.py
@@ -91,6 +91,11 @@ async def read_thing(*, author: str, title: str):
     return {"author": author, "title": title}
 
 
+@app.get("/books/{author}/{title:path}")
+async def read_thing(*, author: str, title: str):
+    return {"author": author, "title": title}
+
+
 
 # Ignored
 @app.get("/things/{thing-id}")

--- a/crates/ruff_linter/resources/test/fixtures/fastapi/FAST003.py
+++ b/crates/ruff_linter/resources/test/fixtures/fastapi/FAST003.py
@@ -26,3 +26,6 @@ async def read_thing(thing_id: int, query: str):
 async def read_thing(isbn: str):
     return {"isbn": isbn}
 
+@app.get("/things/{thing-id}")
+async def read_thing(query: str):
+    return {"query": query}

--- a/crates/ruff_linter/resources/test/fixtures/fastapi/FAST003.py
+++ b/crates/ruff_linter/resources/test/fixtures/fastapi/FAST003.py
@@ -1,0 +1,28 @@
+from fastapi import FastAPI
+
+app = FastAPI()
+
+
+# Errors
+
+@app.get("/things/{thing_id}")
+async def read_thing(query: str):
+    return {"query": query}
+
+@app.get("/books/isbn-{isbn}")
+async def read_thing():
+    ...
+
+
+
+# OK
+
+
+@app.get("/things/{thing_id}")
+async def read_thing(thing_id: int, query: str):
+    return {"thing_id": thing_id, "query": query}
+
+@app.get("/books/isbn-{isbn}")
+async def read_thing(isbn: str):
+    return {"isbn": isbn}
+

--- a/crates/ruff_linter/resources/test/fixtures/fastapi/FAST003.py
+++ b/crates/ruff_linter/resources/test/fixtures/fastapi/FAST003.py
@@ -34,6 +34,31 @@ async def read_thing():
     ...
 
 
+@app.get("/books/{author}/{title}")
+async def read_thing(author: str, title: str, /):
+    return {"author": author, "title": title}
+
+
+@app.get("/books/{author}/{title}/{page}")
+async def read_thing(
+    author: str,
+    query: str,
+): ...
+
+
+@app.get("/books/{author}/{title}")
+async def read_thing():
+    ...
+
+
+@app.get("/books/{author}/{title}")
+async def read_thing(*, author: str):
+    ...
+
+@app.get("/books/{author}/{title}")
+async def read_thing(hello, /, *, author: str):
+    ...
+
 
 # OK
 @app.get("/things/{thing_id}")
@@ -58,6 +83,11 @@ async def read_thing(thing_id: str, query: str):
 
 @app.get("/books/{author}/{title}")
 async def read_thing(author: str, title: str):
+    return {"author": author, "title": title}
+
+
+@app.get("/books/{author}/{title}")
+async def read_thing(*, author: str, title: str):
     return {"author": author, "title": title}
 
 

--- a/crates/ruff_linter/resources/test/fixtures/fastapi/FAST003.py
+++ b/crates/ruff_linter/resources/test/fixtures/fastapi/FAST003.py
@@ -29,7 +29,7 @@ async def read_thing(author: str):
     return {"author": author}
 
 
-@app.get("/books/{author}/{title}")
+@app.get("/books/{author_name}/{title}")
 async def read_thing():
     ...
 
@@ -99,5 +99,15 @@ async def read_thing(*, author: str, title: str):
 
 # Ignored
 @app.get("/things/{thing-id}")
+async def read_thing(query: str):
+    return {"query": query}
+
+
+@app.get("/things/{thing_id!r}")
+async def read_thing(query: str):
+    return {"query": query}
+
+
+@app.get("/things/{thing_id=}")
 async def read_thing(query: str):
     return {"query": query}

--- a/crates/ruff_linter/resources/test/fixtures/fastapi/FAST003.py
+++ b/crates/ruff_linter/resources/test/fixtures/fastapi/FAST003.py
@@ -24,6 +24,16 @@ async def read_thing(query: str):
     return {"query": query}
 
 
+@app.get("/books/{author}/{title}")
+async def read_thing(author: str):
+    return {"author": author}
+
+
+@app.get("/books/{author}/{title}")
+async def read_thing():
+    ...
+
+
 
 # OK
 @app.get("/things/{thing_id}")
@@ -44,6 +54,11 @@ async def read_thing(thing_id: str, query: str):
 @app.get("/things/{thing_id : path}")
 async def read_thing(thing_id: str, query: str):
     return {"thing_id": thing_id, "query": query}
+
+
+@app.get("/books/{author}/{title}")
+async def read_thing(author: str, title: str):
+    return {"author": author, "title": title}
 
 
 

--- a/crates/ruff_linter/resources/test/fixtures/fastapi/FAST003.py
+++ b/crates/ruff_linter/resources/test/fixtures/fastapi/FAST003.py
@@ -55,9 +55,31 @@ async def read_thing():
 async def read_thing(*, author: str):
     ...
 
+
 @app.get("/books/{author}/{title}")
 async def read_thing(hello, /, *, author: str):
     ...
+
+
+@app.get("/things/{thing_id}")
+async def read_thing(
+        query: str,
+):
+    return {"query": query}
+
+
+@app.get("/things/{thing_id}")
+async def read_thing(
+        query: str = "default",
+):
+    return {"query": query}
+
+
+@app.get("/things/{thing_id}")
+async def read_thing(
+        *, query: str = "default",
+):
+    return {"query": query}
 
 
 # OK
@@ -94,7 +116,6 @@ async def read_thing(*, author: str, title: str):
 @app.get("/books/{author}/{title:path}")
 async def read_thing(*, author: str, title: str):
     return {"author": author, "title": title}
-
 
 
 # Ignored

--- a/crates/ruff_linter/src/checkers/ast/analyze/statement.rs
+++ b/crates/ruff_linter/src/checkers/ast/analyze/statement.rs
@@ -94,6 +94,9 @@ pub(crate) fn statement(stmt: &Stmt, checker: &mut Checker) {
             if checker.enabled(Rule::FastApiNonAnnotatedDependency) {
                 fastapi::rules::fastapi_non_annotated_dependency(checker, function_def);
             }
+            if checker.enabled(Rule::FastApiUnusedPathParameter) {
+                fastapi::rules::fastapi_unused_path_parameter(checker, function_def);
+            }
             if checker.enabled(Rule::AmbiguousFunctionName) {
                 if let Some(diagnostic) = pycodestyle::rules::ambiguous_function_name(name) {
                     checker.diagnostics.push(diagnostic);

--- a/crates/ruff_linter/src/codes.rs
+++ b/crates/ruff_linter/src/codes.rs
@@ -919,6 +919,7 @@ pub fn code_to_rule(linter: Linter, code: &str) -> Option<(RuleGroup, Rule)> {
         // fastapi
         (FastApi, "001") => (RuleGroup::Preview, rules::fastapi::rules::FastApiRedundantResponseModel),
         (FastApi, "002") => (RuleGroup::Preview, rules::fastapi::rules::FastApiNonAnnotatedDependency),
+        (FastApi, "003") => (RuleGroup::Preview, rules::fastapi::rules::FastApiUnusedPathParameter),
 
         // pydoclint
         (Pydoclint, "201") => (RuleGroup::Preview, rules::pydoclint::rules::DocstringMissingReturns),

--- a/crates/ruff_linter/src/rules/fastapi/mod.rs
+++ b/crates/ruff_linter/src/rules/fastapi/mod.rs
@@ -15,6 +15,7 @@ mod tests {
 
     #[test_case(Rule::FastApiRedundantResponseModel, Path::new("FAST001.py"))]
     #[test_case(Rule::FastApiNonAnnotatedDependency, Path::new("FAST002.py"))]
+    #[test_case(Rule::FastApiUnusedPathParameter, Path::new("FAST003.py"))]
     fn rules(rule_code: Rule, path: &Path) -> Result<()> {
         let snapshot = format!("{}_{}", rule_code.as_ref(), path.to_string_lossy());
         let diagnostics = test_path(

--- a/crates/ruff_linter/src/rules/fastapi/rules/fastapi_unused_path_parameter.rs
+++ b/crates/ruff_linter/src/rules/fastapi/rules/fastapi_unused_path_parameter.rs
@@ -1,5 +1,3 @@
-use std::vec;
-
 use ruff_diagnostics::{Applicability, Fix};
 use ruff_diagnostics::{Diagnostic, FixAvailability, Violation};
 use ruff_macros::{derive_message_formats, violation};

--- a/crates/ruff_linter/src/rules/fastapi/rules/fastapi_unused_path_parameter.rs
+++ b/crates/ruff_linter/src/rules/fastapi/rules/fastapi_unused_path_parameter.rs
@@ -65,12 +65,13 @@ impl Violation for FastApiUnusedPathParameter {
 }
 
 fn extract_path_params_from_route(input: &str) -> Vec<String> {
-    // Define a regular expression to match text inside curly braces
+    // We ignore text after a colon, since those are path convertors
+    // See also: https://fastapi.tiangolo.com/tutorial/path-params/?h=path#path-convertor
     let re = Regex::new(r"\{([^:}]+)").unwrap();
 
     // Collect all matches and return them as a vector of strings
     re.captures_iter(input)
-        .filter_map(|cap| cap.get(1).map(|m| m.as_str().to_string()))
+        .filter_map(|cap| cap.get(1).map(|m| m.as_str().trim().to_string()))
         .collect()
 }
 

--- a/crates/ruff_linter/src/rules/fastapi/rules/fastapi_unused_path_parameter.rs
+++ b/crates/ruff_linter/src/rules/fastapi/rules/fastapi_unused_path_parameter.rs
@@ -137,6 +137,11 @@ pub(crate) fn fastapi_unused_path_parameter(
         .iter()
         .filter_map(|expr| expr.as_f_string())
         .flat_map(|inner_fstring| inner_fstring.elements.expressions())
+        // We ignore any expressions that have a conversion (like !r or !s), as FastAPI will
+        // normalize them in an undocumented way.
+        .filter(|inner_expr| inner_expr.conversion.is_none())
+        // We also ignore any expressions that have debug text, for the same reason.
+        .filter(|inner_expr| inner_expr.debug_text.is_none())
         .filter_map(|inner_expr| {
             inner_expr
                 .expression

--- a/crates/ruff_linter/src/rules/fastapi/rules/fastapi_unused_path_parameter.rs
+++ b/crates/ruff_linter/src/rules/fastapi/rules/fastapi_unused_path_parameter.rs
@@ -33,6 +33,7 @@ use ruff_python_stdlib::identifiers::is_identifier;
 ///
 /// app = FastAPI()
 ///
+///
 /// @app.get("/things/{thing_id}")
 /// async def read_thing(query: str):
 ///     ...
@@ -44,6 +45,7 @@ use ruff_python_stdlib::identifiers::is_identifier;
 /// from fastapi import FastAPI
 ///
 /// app = FastAPI()
+///
 ///
 /// @app.get("/things/{thing_id}")
 /// async def read_thing(thing_id: int, query: str):

--- a/crates/ruff_linter/src/rules/fastapi/rules/fastapi_unused_path_parameter.rs
+++ b/crates/ruff_linter/src/rules/fastapi/rules/fastapi_unused_path_parameter.rs
@@ -1,0 +1,129 @@
+use ruff_diagnostics::{Diagnostic, Violation};
+use ruff_macros::{derive_message_formats, violation};
+use ruff_python_ast as ast;
+use ruff_python_semantic::Modules;
+use ruff_text_size::Ranged;
+
+use crate::checkers::ast::Checker;
+use crate::rules::fastapi::rules::is_fastapi_route;
+use crate::rules::fastapi::rules::is_fastapi_route_decorator;
+use regex::Regex;
+
+/// ## What it does
+/// Identifies FastAPI routes that declare path parameters in the route path but not in the function signature.
+///
+/// ## Why is this bad?
+/// Path parameters are used to extract values from the URL path.
+/// If a path parameter is declared in the route path but not in the function signature, it will not be accessible in the function body, which is likely a mistake.
+///
+/// ## Example
+///
+/// ```python
+/// from fastapi import FastAPI
+///
+/// app = FastAPI()
+///
+/// @app.get("/things/{thing_id}")
+/// async def read_thing(query: str):
+///     ...
+/// ```
+///
+/// Use instead:
+///
+/// ```python
+/// from fastapi import FastAPI
+///
+/// app = FastAPI()
+///
+/// @app.get("/things/{thing_id}")
+/// async def read_thing(thing_id: int, query: str):
+///     ...
+/// ```
+
+#[violation]
+pub struct FastApiUnusedPathParameter {
+    arg_name: String,
+    function_name: String,
+}
+
+impl Violation for FastApiUnusedPathParameter {
+    #[derive_message_formats]
+    fn message(&self) -> String {
+        let Self {
+            arg_name,
+            function_name,
+        } = self;
+        format!(
+            "Path parameter `{arg_name}` in route path but not in function signature `{function_name}`"
+        )
+    }
+}
+
+fn extract_path_params_from_route(input: &str) -> Vec<String> {
+    // Define a regular expression to match text inside curly braces
+    let re = Regex::new(r"\{([^:}]+)").unwrap();
+
+    // Collect all matches and return them as a vector of strings
+    re.captures_iter(input)
+        .filter_map(|cap| cap.get(1).map(|m| m.as_str().to_string()))
+        .collect()
+}
+
+pub(crate) fn fastapi_unused_path_parameter(
+    checker: &mut Checker,
+    function_def: &ast::StmtFunctionDef,
+) {
+    if !checker.semantic().seen_module(Modules::FASTAPI) {
+        return;
+    }
+    if !is_fastapi_route(function_def, checker.semantic()) {
+        return;
+    }
+
+    // Get the route path from the decorator
+    let route_decorator = function_def
+        .decorator_list
+        .iter()
+        .find_map(|decorator| is_fastapi_route_decorator(decorator, checker.semantic()));
+
+    let Some(route_decorator) = route_decorator else {
+        return;
+    };
+
+    let path_arg = route_decorator.arguments.args.first();
+    let Some(path_arg) = path_arg else {
+        return;
+    };
+    // Lets path_arg go out of scope so we can reuse checker later
+    let diagnostic_range = path_arg.range();
+    // We can't really handle anything other than string literals
+    let path = match path_arg.as_string_literal_expr() {
+        Some(path_arg) => path_arg.value.to_string(),
+        None => return,
+    };
+
+    let path_params = extract_path_params_from_route(&path);
+
+    // Now we extract the arguments from the function signature
+    let args = function_def
+        .parameters
+        .args
+        .iter()
+        .chain(function_def.parameters.kwonlyargs.iter())
+        .map(|arg| arg.parameter.name.to_string())
+        .collect::<Vec<_>>();
+
+    // Check if any of the path parameters are not in the function signature
+    for path_param in path_params {
+        if !args.contains(&path_param) {
+            let diagnostic = Diagnostic::new(
+                FastApiUnusedPathParameter {
+                    arg_name: path_param.clone(),
+                    function_name: function_def.name.to_string(),
+                },
+                diagnostic_range,
+            );
+            checker.diagnostics.push(diagnostic);
+        }
+    }
+}

--- a/crates/ruff_linter/src/rules/fastapi/rules/fastapi_unused_path_parameter.rs
+++ b/crates/ruff_linter/src/rules/fastapi/rules/fastapi_unused_path_parameter.rs
@@ -80,10 +80,10 @@ impl Violation for FastApiUnusedPathParameter {
 
     fn fix_title(&self) -> Option<String> {
         let Self { arg_name, .. } = self;
-        if !self.arg_name_already_used {
-            Some(format!("Add `{arg_name}` to function signature"))
-        } else {
+        if self.arg_name_already_used {
             None
+        } else {
+            Some(format!("Add `{arg_name}` to function signature"))
         }
     }
 }
@@ -173,6 +173,7 @@ pub(crate) fn fastapi_unused_path_parameter(
                     .contains(&path_param),
             };
             let fixable = violation.fix_title().is_some();
+            #[allow(clippy::cast_possible_truncation)]
             let mut diagnostic = Diagnostic::new(
                 violation,
                 diagnostic_range

--- a/crates/ruff_linter/src/rules/fastapi/rules/fastapi_unused_path_parameter.rs
+++ b/crates/ruff_linter/src/rules/fastapi/rules/fastapi_unused_path_parameter.rs
@@ -147,8 +147,7 @@ pub(crate) fn fastapi_unused_path_parameter(
                 .expression
                 .as_name_expr()
                 .map(|name_expr| (name_expr.id().to_string(), inner_expr.range()))
-        })
-        .collect::<Vec<_>>();
+        });
 
     // Now we extract the arguments from the function signature
     let named_args = function_def

--- a/crates/ruff_linter/src/rules/fastapi/rules/fastapi_unused_path_parameter.rs
+++ b/crates/ruff_linter/src/rules/fastapi/rules/fastapi_unused_path_parameter.rs
@@ -1,7 +1,7 @@
 use std::ops::Range;
 
 use ruff_diagnostics::{Applicability, Fix};
-use ruff_diagnostics::{Diagnostic, Violation};
+use ruff_diagnostics::{Diagnostic, FixAvailability, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast as ast;
 use ruff_python_semantic::Modules;
@@ -58,6 +58,8 @@ pub struct FastApiUnusedPathParameter {
 }
 
 impl Violation for FastApiUnusedPathParameter {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Sometimes;
+
     #[derive_message_formats]
     fn message(&self) -> String {
         let Self {

--- a/crates/ruff_linter/src/rules/fastapi/rules/fastapi_unused_path_parameter.rs
+++ b/crates/ruff_linter/src/rules/fastapi/rules/fastapi_unused_path_parameter.rs
@@ -32,8 +32,7 @@ use ruff_python_stdlib::identifiers::is_identifier;
 ///
 ///
 /// @app.get("/things/{thing_id}")
-/// async def read_thing(query: str):
-///     ...
+/// async def read_thing(query: str): ...
 /// ```
 ///
 /// Use instead:
@@ -45,8 +44,7 @@ use ruff_python_stdlib::identifiers::is_identifier;
 ///
 ///
 /// @app.get("/things/{thing_id}")
-/// async def read_thing(thing_id: int, query: str):
-///     ...
+/// async def read_thing(thing_id: int, query: str): ...
 /// ```
 
 #[violation]

--- a/crates/ruff_linter/src/rules/fastapi/rules/mod.rs
+++ b/crates/ruff_linter/src/rules/fastapi/rules/mod.rs
@@ -1,8 +1,10 @@
 pub(crate) use fastapi_non_annotated_dependency::*;
 pub(crate) use fastapi_redundant_response_model::*;
+pub(crate) use fastapi_unused_path_parameter::*;
 
 mod fastapi_non_annotated_dependency;
 mod fastapi_redundant_response_model;
+mod fastapi_unused_path_parameter;
 
 use ruff_python_ast::{Decorator, ExprCall, StmtFunctionDef};
 use ruff_python_semantic::analyze::typing::resolve_assignment;

--- a/crates/ruff_linter/src/rules/fastapi/snapshots/ruff_linter__rules__fastapi__tests__fast-api-unused-path-parameter_FAST003.py.snap
+++ b/crates/ruff_linter/src/rules/fastapi/snapshots/ruff_linter__rules__fastapi__tests__fast-api-unused-path-parameter_FAST003.py.snap
@@ -97,29 +97,29 @@ FAST003.py:27:27: FAST003 [*] Path parameter `title` in route path but not in fu
 30 30 | 
 31 31 | 
 
-FAST003.py:32:18: FAST003 [*] Path parameter `author` in route path but not in function `read_thing`.
+FAST003.py:32:18: FAST003 [*] Path parameter `author_name` in route path but not in function `read_thing`.
    |
-32 | @app.get("/books/{author}/{title}")
-   |                  ^^^^^^^^ FAST003
+32 | @app.get("/books/{author_name}/{title}")
+   |                  ^^^^^^^^^^^^^ FAST003
 33 | async def read_thing():
 34 |     ...
    |
-   = help: Add `author` to function signature
+   = help: Add `author_name` to function signature
 
 ℹ Safe fix
 30 30 | 
 31 31 | 
-32 32 | @app.get("/books/{author}/{title}")
+32 32 | @app.get("/books/{author_name}/{title}")
 33    |-async def read_thing():
-   33 |+async def read_thing(author):
+   33 |+async def read_thing(author_name):
 34 34 |     ...
 35 35 | 
 36 36 | 
 
-FAST003.py:32:27: FAST003 [*] Path parameter `title` in route path but not in function `read_thing`.
+FAST003.py:32:32: FAST003 [*] Path parameter `title` in route path but not in function `read_thing`.
    |
-32 | @app.get("/books/{author}/{title}")
-   |                           ^^^^^^^ FAST003
+32 | @app.get("/books/{author_name}/{title}")
+   |                                ^^^^^^^ FAST003
 33 | async def read_thing():
 34 |     ...
    |
@@ -128,7 +128,7 @@ FAST003.py:32:27: FAST003 [*] Path parameter `title` in route path but not in fu
 ℹ Safe fix
 30 30 | 
 31 31 | 
-32 32 | @app.get("/books/{author}/{title}")
+32 32 | @app.get("/books/{author_name}/{title}")
 33    |-async def read_thing():
    33 |+async def read_thing(title):
 34 34 |     ...

--- a/crates/ruff_linter/src/rules/fastapi/snapshots/ruff_linter__rules__fastapi__tests__fast-api-unused-path-parameter_FAST003.py.snap
+++ b/crates/ruff_linter/src/rules/fastapi/snapshots/ruff_linter__rules__fastapi__tests__fast-api-unused-path-parameter_FAST003.py.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff_linter/src/rules/fastapi/mod.rs
 ---
-FAST003.py:7:19: FAST003 [*] Path parameter `thing_id` in route path but not in function `read_thing`.
+FAST003.py:7:19: FAST003 [*] Parameter `thing_id` appears in route path, but not in `read_thing` signature
   |
 6 | # Errors
 7 | @app.get("/things/{thing_id}")
@@ -11,7 +11,7 @@ FAST003.py:7:19: FAST003 [*] Path parameter `thing_id` in route path but not in 
   |
   = help: Add `thing_id` to function signature
 
-ℹ Safe fix
+ℹ Unsafe fix
 5 5 | 
 6 6 | # Errors
 7 7 | @app.get("/things/{thing_id}")
@@ -21,7 +21,7 @@ FAST003.py:7:19: FAST003 [*] Path parameter `thing_id` in route path but not in 
 10 10 | 
 11 11 | 
 
-FAST003.py:12:23: FAST003 [*] Path parameter `isbn` in route path but not in function `read_thing`.
+FAST003.py:12:23: FAST003 [*] Parameter `isbn` appears in route path, but not in `read_thing` signature
    |
 12 | @app.get("/books/isbn-{isbn}")
    |                       ^^^^^^ FAST003
@@ -30,7 +30,7 @@ FAST003.py:12:23: FAST003 [*] Path parameter `isbn` in route path but not in fun
    |
    = help: Add `isbn` to function signature
 
-ℹ Safe fix
+ℹ Unsafe fix
 10 10 | 
 11 11 | 
 12 12 | @app.get("/books/isbn-{isbn}")
@@ -40,7 +40,7 @@ FAST003.py:12:23: FAST003 [*] Path parameter `isbn` in route path but not in fun
 15 15 | 
 16 16 | 
 
-FAST003.py:17:19: FAST003 [*] Path parameter `thing_id` in route path but not in function `read_thing`.
+FAST003.py:17:19: FAST003 [*] Parameter `thing_id` appears in route path, but not in `read_thing` signature
    |
 17 | @app.get("/things/{thing_id:path}")
    |                   ^^^^^^^^^^^^^^^ FAST003
@@ -49,7 +49,7 @@ FAST003.py:17:19: FAST003 [*] Path parameter `thing_id` in route path but not in
    |
    = help: Add `thing_id` to function signature
 
-ℹ Safe fix
+ℹ Unsafe fix
 15 15 | 
 16 16 | 
 17 17 | @app.get("/things/{thing_id:path}")
@@ -59,7 +59,7 @@ FAST003.py:17:19: FAST003 [*] Path parameter `thing_id` in route path but not in
 20 20 | 
 21 21 | 
 
-FAST003.py:22:19: FAST003 [*] Path parameter `thing_id` in route path but not in function `read_thing`.
+FAST003.py:22:19: FAST003 [*] Parameter `thing_id` appears in route path, but not in `read_thing` signature
    |
 22 | @app.get("/things/{thing_id : path}")
    |                   ^^^^^^^^^^^^^^^^^ FAST003
@@ -68,7 +68,7 @@ FAST003.py:22:19: FAST003 [*] Path parameter `thing_id` in route path but not in
    |
    = help: Add `thing_id` to function signature
 
-ℹ Safe fix
+ℹ Unsafe fix
 20 20 | 
 21 21 | 
 22 22 | @app.get("/things/{thing_id : path}")
@@ -78,7 +78,7 @@ FAST003.py:22:19: FAST003 [*] Path parameter `thing_id` in route path but not in
 25 25 | 
 26 26 | 
 
-FAST003.py:27:27: FAST003 [*] Path parameter `title` in route path but not in function `read_thing`.
+FAST003.py:27:27: FAST003 [*] Parameter `title` appears in route path, but not in `read_thing` signature
    |
 27 | @app.get("/books/{author}/{title}")
    |                           ^^^^^^^ FAST003
@@ -87,7 +87,7 @@ FAST003.py:27:27: FAST003 [*] Path parameter `title` in route path but not in fu
    |
    = help: Add `title` to function signature
 
-ℹ Safe fix
+ℹ Unsafe fix
 25 25 | 
 26 26 | 
 27 27 | @app.get("/books/{author}/{title}")
@@ -97,7 +97,7 @@ FAST003.py:27:27: FAST003 [*] Path parameter `title` in route path but not in fu
 30 30 | 
 31 31 | 
 
-FAST003.py:32:18: FAST003 [*] Path parameter `author_name` in route path but not in function `read_thing`.
+FAST003.py:32:18: FAST003 [*] Parameter `author_name` appears in route path, but not in `read_thing` signature
    |
 32 | @app.get("/books/{author_name}/{title}")
    |                  ^^^^^^^^^^^^^ FAST003
@@ -106,7 +106,7 @@ FAST003.py:32:18: FAST003 [*] Path parameter `author_name` in route path but not
    |
    = help: Add `author_name` to function signature
 
-ℹ Safe fix
+ℹ Unsafe fix
 30 30 | 
 31 31 | 
 32 32 | @app.get("/books/{author_name}/{title}")
@@ -116,7 +116,7 @@ FAST003.py:32:18: FAST003 [*] Path parameter `author_name` in route path but not
 35 35 | 
 36 36 | 
 
-FAST003.py:32:32: FAST003 [*] Path parameter `title` in route path but not in function `read_thing`.
+FAST003.py:32:32: FAST003 [*] Parameter `title` appears in route path, but not in `read_thing` signature
    |
 32 | @app.get("/books/{author_name}/{title}")
    |                                ^^^^^^^ FAST003
@@ -125,7 +125,7 @@ FAST003.py:32:32: FAST003 [*] Path parameter `title` in route path but not in fu
    |
    = help: Add `title` to function signature
 
-ℹ Safe fix
+ℹ Unsafe fix
 30 30 | 
 31 31 | 
 32 32 | @app.get("/books/{author_name}/{title}")
@@ -135,7 +135,7 @@ FAST003.py:32:32: FAST003 [*] Path parameter `title` in route path but not in fu
 35 35 | 
 36 36 | 
 
-FAST003.py:37:18: FAST003 Path parameter `author` in route path, but appears as a positional-only argument in function `read_thing`. Consider making it a regular argument.
+FAST003.py:37:18: FAST003 Parameter `author` appears in route path, but only as a positional-only argument in `read_thing` signature
    |
 37 | @app.get("/books/{author}/{title}")
    |                  ^^^^^^^^ FAST003
@@ -143,7 +143,7 @@ FAST003.py:37:18: FAST003 Path parameter `author` in route path, but appears as 
 39 |     return {"author": author, "title": title}
    |
 
-FAST003.py:37:27: FAST003 Path parameter `title` in route path, but appears as a positional-only argument in function `read_thing`. Consider making it a regular argument.
+FAST003.py:37:27: FAST003 Parameter `title` appears in route path, but only as a positional-only argument in `read_thing` signature
    |
 37 | @app.get("/books/{author}/{title}")
    |                           ^^^^^^^ FAST003
@@ -151,7 +151,7 @@ FAST003.py:37:27: FAST003 Path parameter `title` in route path, but appears as a
 39 |     return {"author": author, "title": title}
    |
 
-FAST003.py:42:27: FAST003 [*] Path parameter `title` in route path but not in function `read_thing`.
+FAST003.py:42:27: FAST003 [*] Parameter `title` appears in route path, but not in `read_thing` signature
    |
 42 | @app.get("/books/{author}/{title}/{page}")
    |                           ^^^^^^^ FAST003
@@ -160,7 +160,7 @@ FAST003.py:42:27: FAST003 [*] Path parameter `title` in route path but not in fu
    |
    = help: Add `title` to function signature
 
-ℹ Safe fix
+ℹ Unsafe fix
 42 42 | @app.get("/books/{author}/{title}/{page}")
 43 43 | async def read_thing(
 44 44 |     author: str,
@@ -170,7 +170,7 @@ FAST003.py:42:27: FAST003 [*] Path parameter `title` in route path but not in fu
 47 47 | 
 48 48 | 
 
-FAST003.py:42:35: FAST003 [*] Path parameter `page` in route path but not in function `read_thing`.
+FAST003.py:42:35: FAST003 [*] Parameter `page` appears in route path, but not in `read_thing` signature
    |
 42 | @app.get("/books/{author}/{title}/{page}")
    |                                   ^^^^^^ FAST003
@@ -179,7 +179,7 @@ FAST003.py:42:35: FAST003 [*] Path parameter `page` in route path but not in fun
    |
    = help: Add `page` to function signature
 
-ℹ Safe fix
+ℹ Unsafe fix
 42 42 | @app.get("/books/{author}/{title}/{page}")
 43 43 | async def read_thing(
 44 44 |     author: str,
@@ -189,7 +189,7 @@ FAST003.py:42:35: FAST003 [*] Path parameter `page` in route path but not in fun
 47 47 | 
 48 48 | 
 
-FAST003.py:49:18: FAST003 [*] Path parameter `author` in route path but not in function `read_thing`.
+FAST003.py:49:18: FAST003 [*] Parameter `author` appears in route path, but not in `read_thing` signature
    |
 49 | @app.get("/books/{author}/{title}")
    |                  ^^^^^^^^ FAST003
@@ -198,7 +198,7 @@ FAST003.py:49:18: FAST003 [*] Path parameter `author` in route path but not in f
    |
    = help: Add `author` to function signature
 
-ℹ Safe fix
+ℹ Unsafe fix
 47 47 | 
 48 48 | 
 49 49 | @app.get("/books/{author}/{title}")
@@ -208,7 +208,7 @@ FAST003.py:49:18: FAST003 [*] Path parameter `author` in route path but not in f
 52 52 | 
 53 53 | 
 
-FAST003.py:49:27: FAST003 [*] Path parameter `title` in route path but not in function `read_thing`.
+FAST003.py:49:27: FAST003 [*] Parameter `title` appears in route path, but not in `read_thing` signature
    |
 49 | @app.get("/books/{author}/{title}")
    |                           ^^^^^^^ FAST003
@@ -217,7 +217,7 @@ FAST003.py:49:27: FAST003 [*] Path parameter `title` in route path but not in fu
    |
    = help: Add `title` to function signature
 
-ℹ Safe fix
+ℹ Unsafe fix
 47 47 | 
 48 48 | 
 49 49 | @app.get("/books/{author}/{title}")
@@ -227,7 +227,7 @@ FAST003.py:49:27: FAST003 [*] Path parameter `title` in route path but not in fu
 52 52 | 
 53 53 | 
 
-FAST003.py:54:27: FAST003 [*] Path parameter `title` in route path but not in function `read_thing`.
+FAST003.py:54:27: FAST003 [*] Parameter `title` appears in route path, but not in `read_thing` signature
    |
 54 | @app.get("/books/{author}/{title}")
    |                           ^^^^^^^ FAST003
@@ -236,7 +236,7 @@ FAST003.py:54:27: FAST003 [*] Path parameter `title` in route path but not in fu
    |
    = help: Add `title` to function signature
 
-ℹ Safe fix
+ℹ Unsafe fix
 52 52 | 
 53 53 | 
 54 54 | @app.get("/books/{author}/{title}")
@@ -244,25 +244,80 @@ FAST003.py:54:27: FAST003 [*] Path parameter `title` in route path but not in fu
    55 |+async def read_thing(title, *, author: str):
 56 56 |     ...
 57 57 | 
-58 58 | @app.get("/books/{author}/{title}")
+58 58 | 
 
-FAST003.py:58:27: FAST003 [*] Path parameter `title` in route path but not in function `read_thing`.
+FAST003.py:59:27: FAST003 [*] Parameter `title` appears in route path, but not in `read_thing` signature
    |
-56 |     ...
-57 | 
-58 | @app.get("/books/{author}/{title}")
+59 | @app.get("/books/{author}/{title}")
    |                           ^^^^^^^ FAST003
-59 | async def read_thing(hello, /, *, author: str):
-60 |     ...
+60 | async def read_thing(hello, /, *, author: str):
+61 |     ...
    |
    = help: Add `title` to function signature
 
-ℹ Safe fix
-56 56 |     ...
+ℹ Unsafe fix
 57 57 | 
-58 58 | @app.get("/books/{author}/{title}")
-59    |-async def read_thing(hello, /, *, author: str):
-   59 |+async def read_thing(hello, /, title, *, author: str):
-60 60 |     ...
-61 61 | 
-62 62 |
+58 58 | 
+59 59 | @app.get("/books/{author}/{title}")
+60    |-async def read_thing(hello, /, *, author: str):
+   60 |+async def read_thing(hello, /, title, *, author: str):
+61 61 |     ...
+62 62 | 
+63 63 | 
+
+FAST003.py:64:19: FAST003 [*] Parameter `thing_id` appears in route path, but not in `read_thing` signature
+   |
+64 | @app.get("/things/{thing_id}")
+   |                   ^^^^^^^^^^ FAST003
+65 | async def read_thing(
+66 |         query: str,
+   |
+   = help: Add `thing_id` to function signature
+
+ℹ Unsafe fix
+63 63 | 
+64 64 | @app.get("/things/{thing_id}")
+65 65 | async def read_thing(
+66    |-        query: str,
+   66 |+        query: str, thing_id,
+67 67 | ):
+68 68 |     return {"query": query}
+69 69 | 
+
+FAST003.py:71:19: FAST003 [*] Parameter `thing_id` appears in route path, but not in `read_thing` signature
+   |
+71 | @app.get("/things/{thing_id}")
+   |                   ^^^^^^^^^^ FAST003
+72 | async def read_thing(
+73 |         query: str = "default",
+   |
+   = help: Add `thing_id` to function signature
+
+ℹ Unsafe fix
+70 70 | 
+71 71 | @app.get("/things/{thing_id}")
+72 72 | async def read_thing(
+73    |-        query: str = "default",
+   73 |+        thing_id, query: str = "default",
+74 74 | ):
+75 75 |     return {"query": query}
+76 76 | 
+
+FAST003.py:78:19: FAST003 [*] Parameter `thing_id` appears in route path, but not in `read_thing` signature
+   |
+78 | @app.get("/things/{thing_id}")
+   |                   ^^^^^^^^^^ FAST003
+79 | async def read_thing(
+80 |         *, query: str = "default",
+   |
+   = help: Add `thing_id` to function signature
+
+ℹ Unsafe fix
+77 77 | 
+78 78 | @app.get("/things/{thing_id}")
+79 79 | async def read_thing(
+80    |-        *, query: str = "default",
+   80 |+        thing_id, *, query: str = "default",
+81 81 | ):
+82 82 |     return {"query": query}
+83 83 |

--- a/crates/ruff_linter/src/rules/fastapi/snapshots/ruff_linter__rules__fastapi__tests__fast-api-unused-path-parameter_FAST003.py.snap
+++ b/crates/ruff_linter/src/rules/fastapi/snapshots/ruff_linter__rules__fastapi__tests__fast-api-unused-path-parameter_FAST003.py.snap
@@ -1,0 +1,268 @@
+---
+source: crates/ruff_linter/src/rules/fastapi/mod.rs
+---
+FAST003.py:7:19: FAST003 [*] Path parameter `thing_id` in route path but not in function `read_thing`.
+  |
+6 | # Errors
+7 | @app.get("/things/{thing_id}")
+  |                   ^^^^^^^^^^ FAST003
+8 | async def read_thing(query: str):
+9 |     return {"query": query}
+  |
+  = help: Add `thing_id` to function signature
+
+ℹ Safe fix
+5 5 | 
+6 6 | # Errors
+7 7 | @app.get("/things/{thing_id}")
+8   |-async def read_thing(query: str):
+  8 |+async def read_thing(query: str, thing_id):
+9 9 |     return {"query": query}
+10 10 | 
+11 11 | 
+
+FAST003.py:12:23: FAST003 [*] Path parameter `isbn` in route path but not in function `read_thing`.
+   |
+12 | @app.get("/books/isbn-{isbn}")
+   |                       ^^^^^^ FAST003
+13 | async def read_thing():
+14 |     ...
+   |
+   = help: Add `isbn` to function signature
+
+ℹ Safe fix
+10 10 | 
+11 11 | 
+12 12 | @app.get("/books/isbn-{isbn}")
+13    |-async def read_thing():
+   13 |+async def read_thing(isbn):
+14 14 |     ...
+15 15 | 
+16 16 | 
+
+FAST003.py:17:19: FAST003 [*] Path parameter `thing_id` in route path but not in function `read_thing`.
+   |
+17 | @app.get("/things/{thing_id:path}")
+   |                   ^^^^^^^^^^^^^^^ FAST003
+18 | async def read_thing(query: str):
+19 |     return {"query": query}
+   |
+   = help: Add `thing_id` to function signature
+
+ℹ Safe fix
+15 15 | 
+16 16 | 
+17 17 | @app.get("/things/{thing_id:path}")
+18    |-async def read_thing(query: str):
+   18 |+async def read_thing(query: str, thing_id):
+19 19 |     return {"query": query}
+20 20 | 
+21 21 | 
+
+FAST003.py:22:19: FAST003 [*] Path parameter `thing_id` in route path but not in function `read_thing`.
+   |
+22 | @app.get("/things/{thing_id : path}")
+   |                   ^^^^^^^^^^^^^^^^^ FAST003
+23 | async def read_thing(query: str):
+24 |     return {"query": query}
+   |
+   = help: Add `thing_id` to function signature
+
+ℹ Safe fix
+20 20 | 
+21 21 | 
+22 22 | @app.get("/things/{thing_id : path}")
+23    |-async def read_thing(query: str):
+   23 |+async def read_thing(query: str, thing_id):
+24 24 |     return {"query": query}
+25 25 | 
+26 26 | 
+
+FAST003.py:27:27: FAST003 [*] Path parameter `title` in route path but not in function `read_thing`.
+   |
+27 | @app.get("/books/{author}/{title}")
+   |                           ^^^^^^^ FAST003
+28 | async def read_thing(author: str):
+29 |     return {"author": author}
+   |
+   = help: Add `title` to function signature
+
+ℹ Safe fix
+25 25 | 
+26 26 | 
+27 27 | @app.get("/books/{author}/{title}")
+28    |-async def read_thing(author: str):
+   28 |+async def read_thing(author: str, title):
+29 29 |     return {"author": author}
+30 30 | 
+31 31 | 
+
+FAST003.py:32:18: FAST003 [*] Path parameter `author` in route path but not in function `read_thing`.
+   |
+32 | @app.get("/books/{author}/{title}")
+   |                  ^^^^^^^^ FAST003
+33 | async def read_thing():
+34 |     ...
+   |
+   = help: Add `author` to function signature
+
+ℹ Safe fix
+30 30 | 
+31 31 | 
+32 32 | @app.get("/books/{author}/{title}")
+33    |-async def read_thing():
+   33 |+async def read_thing(author):
+34 34 |     ...
+35 35 | 
+36 36 | 
+
+FAST003.py:32:27: FAST003 [*] Path parameter `title` in route path but not in function `read_thing`.
+   |
+32 | @app.get("/books/{author}/{title}")
+   |                           ^^^^^^^ FAST003
+33 | async def read_thing():
+34 |     ...
+   |
+   = help: Add `title` to function signature
+
+ℹ Safe fix
+30 30 | 
+31 31 | 
+32 32 | @app.get("/books/{author}/{title}")
+33    |-async def read_thing():
+   33 |+async def read_thing(title):
+34 34 |     ...
+35 35 | 
+36 36 | 
+
+FAST003.py:37:18: FAST003 Path parameter `author` in route path, but appears as a positional-only argument in function `read_thing`. Consider making it a regular argument.
+   |
+37 | @app.get("/books/{author}/{title}")
+   |                  ^^^^^^^^ FAST003
+38 | async def read_thing(author: str, title: str, /):
+39 |     return {"author": author, "title": title}
+   |
+
+FAST003.py:37:27: FAST003 Path parameter `title` in route path, but appears as a positional-only argument in function `read_thing`. Consider making it a regular argument.
+   |
+37 | @app.get("/books/{author}/{title}")
+   |                           ^^^^^^^ FAST003
+38 | async def read_thing(author: str, title: str, /):
+39 |     return {"author": author, "title": title}
+   |
+
+FAST003.py:42:27: FAST003 [*] Path parameter `title` in route path but not in function `read_thing`.
+   |
+42 | @app.get("/books/{author}/{title}/{page}")
+   |                           ^^^^^^^ FAST003
+43 | async def read_thing(
+44 |     author: str,
+   |
+   = help: Add `title` to function signature
+
+ℹ Safe fix
+42 42 | @app.get("/books/{author}/{title}/{page}")
+43 43 | async def read_thing(
+44 44 |     author: str,
+45    |-    query: str,
+   45 |+    query: str, title,
+46 46 | ): ...
+47 47 | 
+48 48 | 
+
+FAST003.py:42:35: FAST003 [*] Path parameter `page` in route path but not in function `read_thing`.
+   |
+42 | @app.get("/books/{author}/{title}/{page}")
+   |                                   ^^^^^^ FAST003
+43 | async def read_thing(
+44 |     author: str,
+   |
+   = help: Add `page` to function signature
+
+ℹ Safe fix
+42 42 | @app.get("/books/{author}/{title}/{page}")
+43 43 | async def read_thing(
+44 44 |     author: str,
+45    |-    query: str,
+   45 |+    query: str, page,
+46 46 | ): ...
+47 47 | 
+48 48 | 
+
+FAST003.py:49:18: FAST003 [*] Path parameter `author` in route path but not in function `read_thing`.
+   |
+49 | @app.get("/books/{author}/{title}")
+   |                  ^^^^^^^^ FAST003
+50 | async def read_thing():
+51 |     ...
+   |
+   = help: Add `author` to function signature
+
+ℹ Safe fix
+47 47 | 
+48 48 | 
+49 49 | @app.get("/books/{author}/{title}")
+50    |-async def read_thing():
+   50 |+async def read_thing(author):
+51 51 |     ...
+52 52 | 
+53 53 | 
+
+FAST003.py:49:27: FAST003 [*] Path parameter `title` in route path but not in function `read_thing`.
+   |
+49 | @app.get("/books/{author}/{title}")
+   |                           ^^^^^^^ FAST003
+50 | async def read_thing():
+51 |     ...
+   |
+   = help: Add `title` to function signature
+
+ℹ Safe fix
+47 47 | 
+48 48 | 
+49 49 | @app.get("/books/{author}/{title}")
+50    |-async def read_thing():
+   50 |+async def read_thing(title):
+51 51 |     ...
+52 52 | 
+53 53 | 
+
+FAST003.py:54:27: FAST003 [*] Path parameter `title` in route path but not in function `read_thing`.
+   |
+54 | @app.get("/books/{author}/{title}")
+   |                           ^^^^^^^ FAST003
+55 | async def read_thing(*, author: str):
+56 |     ...
+   |
+   = help: Add `title` to function signature
+
+ℹ Safe fix
+52 52 | 
+53 53 | 
+54 54 | @app.get("/books/{author}/{title}")
+55    |-async def read_thing(*, author: str):
+   55 |+async def read_thing(title, *, author: str):
+56 56 |     ...
+57 57 | 
+58 58 | @app.get("/books/{author}/{title}")
+
+FAST003.py:58:27: FAST003 [*] Path parameter `title` in route path but not in function `read_thing`.
+   |
+56 |     ...
+57 | 
+58 | @app.get("/books/{author}/{title}")
+   |                           ^^^^^^^ FAST003
+59 | async def read_thing(hello, /, *, author: str):
+60 |     ...
+   |
+   = help: Add `title` to function signature
+
+ℹ Safe fix
+56 56 |     ...
+57 57 | 
+58 58 | @app.get("/books/{author}/{title}")
+59    |-async def read_thing(hello, /, *, author: str):
+   59 |+async def read_thing(hello, /, title, *, author: str):
+60 60 |     ...
+61 61 | 
+62 62 |

--- a/ruff.schema.json
+++ b/ruff.schema.json
@@ -3091,6 +3091,7 @@
         "FAST00",
         "FAST001",
         "FAST002",
+        "FAST003",
         "FBT",
         "FBT0",
         "FBT00",


### PR DESCRIPTION
This adds the `fast-api-unused-path-parameter` lint rule, as described in #12632.

I'm still pretty new to rust, so the code can probably be improved, feel free to tell me if there's any changes i should make.  

Also, i needed to add the `add_parameter` edit function, not sure if it was in the scope of the PR or if i should've made another one.