### PR TITLE
[`pydoclint`] Teach rules to understand reraised exceptions as being explicitly raised

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pydoclint/DOC501_google.py
+++ b/crates/ruff_linter/resources/test/fixtures/pydoclint/DOC501_google.py
@@ -190,3 +190,45 @@ def foo(bar: int):
         something.SomeError: Wow.
     """
     raise something.SomeError
+
+
+# DOC501
+def calculate_speed(distance: float, time: float) -> float:
+    """Calculate speed as distance divided by time.
+
+    Args:
+        distance: Distance traveled.
+        time: Time spent traveling.
+
+    Returns:
+        Speed as distance divided by time.
+
+    Raises:
+        TypeError: if you didn't pass a number for both parameters
+    """
+    try:
+        return distance / time
+    except ZeroDivisionError:
+        print("Oh no, why would you divide something by zero?")
+        raise
+    except TypeError:
+        print("Not a number? Shame on you!")
+        raise
+
+
+# This is fine
+def calculate_speed(distance: float, time: float) -> float:
+    """Calculate speed as distance divided by time.
+
+    Args:
+        distance: Distance traveled.
+        time: Time spent traveling.
+
+    Returns:
+        Speed as distance divided by time.
+    """
+    try:
+        return distance / time
+    except Exception as e:
+        print(f"Oh no, we encountered {e}")
+        raise

--- a/crates/ruff_linter/resources/test/fixtures/pydoclint/DOC501_numpy.py
+++ b/crates/ruff_linter/resources/test/fixtures/pydoclint/DOC501_numpy.py
@@ -76,3 +76,60 @@ def calculate_speed(distance: float, time: float) -> float:
         raise FasterThanLightError from exc
     except:
         raise ValueError
+
+
+# DOC501
+def calculate_speed(distance: float, time: float) -> float:
+    """Calculate speed as distance divided by time.
+
+    ACalculate speed as distance divided by time.
+
+    Parameters
+    ----------
+    distance : float
+        Distance traveled.
+    time : float
+        Time spent traveling.
+
+    Returns
+    -------
+    float
+        Speed as distance divided by time.
+
+    Raises
+    ------
+    ZeroDivisionError
+        If attempting to divide by zero.
+    """
+    try:
+        return distance / time
+    except ZeroDivisionError:
+        print("Oh no, why would you divide something by zero?")
+        raise
+    except TypeError:
+        print("Not a number? Shame on you!")
+        raise
+
+
+# This is fine
+def calculate_speed(distance: float, time: float) -> float:
+    """
+    Calculate speed as distance divided by time.
+
+    Parameters
+    ----------
+    distance : float
+        Distance traveled.
+    time : float
+        Time spent traveling.
+
+    Returns
+    -------
+    float
+        Speed as distance divided by time.
+    """
+    try:
+        return distance / time
+    except Exception as e:
+        print(f"Oh no, we encountered {e}")
+        raise

--- a/crates/ruff_linter/resources/test/fixtures/pydoclint/DOC502_google.py
+++ b/crates/ruff_linter/resources/test/fixtures/pydoclint/DOC502_google.py
@@ -56,3 +56,28 @@ def calculate_speed(distance: float, time: float) -> float:
         return distance / time
     except ZeroDivisionError as exc:
         raise FasterThanLightError from exc
+
+
+# This is fine
+def calculate_speed(distance: float, time: float) -> float:
+    """Calculate speed as distance divided by time.
+
+    Args:
+        distance: Distance traveled.
+        time: Time spent traveling.
+
+    Returns:
+        Speed as distance divided by time.
+
+    Raises:
+        ZeroDivisionError: If you pass `0` for the time
+        TypeError: if you didn't pass a number for both parameters
+    """
+    try:
+        return distance / time
+    except ZeroDivisionError:
+        print("Oh no, why would you divide something by zero?")
+        raise
+    except TypeError:
+        print("Not a number? Shame on you!")
+        raise

--- a/crates/ruff_linter/resources/test/fixtures/pydoclint/DOC502_numpy.py
+++ b/crates/ruff_linter/resources/test/fixtures/pydoclint/DOC502_numpy.py
@@ -82,3 +82,38 @@ def calculate_speed(distance: float, time: float) -> float:
         return distance / time
     except ZeroDivisionError as exc:
         raise FasterThanLightError from exc
+
+
+# This is fine
+def calculate_speed(distance: float, time: float) -> float:
+    """Calculate speed as distance divided by time.
+
+    ACalculate speed as distance divided by time.
+
+    Parameters
+    ----------
+    distance : float
+        Distance traveled.
+    time : float
+        Time spent traveling.
+
+    Returns
+    -------
+    float
+        Speed as distance divided by time.
+
+    Raises
+    ------
+    TypeError
+        If one or both of the parameters is not a number.
+    ZeroDivisionError
+        If attempting to divide by zero.
+    """
+    try:
+        return distance / time
+    except ZeroDivisionError:
+        print("Oh no, why would you divide something by zero?")
+        raise
+    except TypeError:
+        print("Not a number? Shame on you!")
+        raise

--- a/crates/ruff_linter/src/rules/pydoclint/snapshots/ruff_linter__rules__pydoclint__tests__docstring-missing-exception_DOC501_google.py.snap
+++ b/crates/ruff_linter/src/rules/pydoclint/snapshots/ruff_linter__rules__pydoclint__tests__docstring-missing-exception_DOC501_google.py.snap
@@ -56,3 +56,14 @@ DOC501_google.py:139:11: DOC501 Raised exception `SomeError` missing from docstr
     |           ^^^^^^^^^^^^^^^^^^^ DOC501
     |
     = help: Add `SomeError` to the docstring
+
+DOC501_google.py:213:9: DOC501 Raised exception `ZeroDivisionError` missing from docstring
+    |
+211 |     except ZeroDivisionError:
+212 |         print("Oh no, why would you divide something by zero?")
+213 |         raise
+    |         ^^^^^ DOC501
+214 |     except TypeError:
+215 |         print("Not a number? Shame on you!")
+    |
+    = help: Add `ZeroDivisionError` to the docstring

--- a/crates/ruff_linter/src/rules/pydoclint/snapshots/ruff_linter__rules__pydoclint__tests__docstring-missing-exception_DOC501_numpy.py.snap
+++ b/crates/ruff_linter/src/rules/pydoclint/snapshots/ruff_linter__rules__pydoclint__tests__docstring-missing-exception_DOC501_numpy.py.snap
@@ -29,3 +29,12 @@ DOC501_numpy.py:78:15: DOC501 Raised exception `ValueError` missing from docstri
    |               ^^^^^^^^^^ DOC501
    |
    = help: Add `ValueError` to the docstring
+
+DOC501_numpy.py:111:9: DOC501 Raised exception `TypeError` missing from docstring
+    |
+109 |     except TypeError:
+110 |         print("Not a number? Shame on you!")
+111 |         raise
+    |         ^^^^^ DOC501
+    |
+    = help: Add `TypeError` to the docstring


### PR DESCRIPTION
## Summary

Fixes #12630.

DOC501 and DOC502 now understand functions with constructs like this to be explicitly raising `TypeError` (which should be documented in a function's docstring):

```py
try:
    foo():
except TypeError:
    ...
    raise
```

I made an exception for `Exception` and `BaseException`, however. Constructs like this are reasonably common, and I don't think anybody would say that it's worth putting in the docstring that it raises "some kind of generic exception":

```py
try:
    foo()
except BaseException:
    do_some_logging()
    raise
```

## Test Plan

`cargo test -p ruff_linter --lib`
