### PR TITLE
[`pydoclint`] Deduplicate collected exceptions after traversing function bodies

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pydoclint/DOC501_google.py
+++ b/crates/ruff_linter/resources/test/fixtures/pydoclint/DOC501_google.py
@@ -232,3 +232,17 @@ def calculate_speed(distance: float, time: float) -> float:
     except Exception as e:
         print(f"Oh no, we encountered {e}")
         raise
+
+
+def foo():
+    """Foo.
+
+    Returns:
+        42: int.
+    """
+    if True:
+        raise TypeError  # DOC501
+    else:
+        raise TypeError  # no DOC501 here because we already emitted a diagnostic for the earlier `raise TypeError`
+    raise ValueError  # DOC501
+    return 42

--- a/crates/ruff_linter/resources/test/fixtures/pydoclint/DOC501_numpy.py
+++ b/crates/ruff_linter/resources/test/fixtures/pydoclint/DOC501_numpy.py
@@ -133,3 +133,19 @@ def calculate_speed(distance: float, time: float) -> float:
     except Exception as e:
         print(f"Oh no, we encountered {e}")
         raise
+
+
+def foo():
+    """Foo.
+
+    Returns
+    -------
+    int
+        42
+    """
+    if True:
+        raise TypeError  # DOC501
+    else:
+        raise TypeError  # no DOC501 here because we already emitted a diagnostic for the earlier `raise TypeError`
+    raise ValueError  # DOC501
+    return 42

--- a/crates/ruff_linter/src/rules/pydoclint/snapshots/ruff_linter__rules__pydoclint__tests__docstring-missing-exception_DOC501_google.py.snap
+++ b/crates/ruff_linter/src/rules/pydoclint/snapshots/ruff_linter__rules__pydoclint__tests__docstring-missing-exception_DOC501_google.py.snap
@@ -67,3 +67,24 @@ DOC501_google.py:213:9: DOC501 Raised exception `ZeroDivisionError` missing from
 215 |         print("Not a number? Shame on you!")
     |
     = help: Add `ZeroDivisionError` to the docstring
+
+DOC501_google.py:244:15: DOC501 Raised exception `TypeError` missing from docstring
+    |
+242 |     """
+243 |     if True:
+244 |         raise TypeError  # DOC501
+    |               ^^^^^^^^^ DOC501
+245 |     else:
+246 |         raise TypeError  # no DOC501 here because we already emitted a diagnostic for the earlier `raise TypeError`
+    |
+    = help: Add `TypeError` to the docstring
+
+DOC501_google.py:247:11: DOC501 Raised exception `ValueError` missing from docstring
+    |
+245 |     else:
+246 |         raise TypeError  # no DOC501 here because we already emitted a diagnostic for the earlier `raise TypeError`
+247 |     raise ValueError  # DOC501
+    |           ^^^^^^^^^^ DOC501
+248 |     return 42
+    |
+    = help: Add `ValueError` to the docstring

--- a/crates/ruff_linter/src/rules/pydoclint/snapshots/ruff_linter__rules__pydoclint__tests__docstring-missing-exception_DOC501_numpy.py.snap
+++ b/crates/ruff_linter/src/rules/pydoclint/snapshots/ruff_linter__rules__pydoclint__tests__docstring-missing-exception_DOC501_numpy.py.snap
@@ -38,3 +38,24 @@ DOC501_numpy.py:111:9: DOC501 Raised exception `TypeError` missing from docstrin
     |         ^^^^^ DOC501
     |
     = help: Add `TypeError` to the docstring
+
+DOC501_numpy.py:147:15: DOC501 Raised exception `TypeError` missing from docstring
+    |
+145 |     """
+146 |     if True:
+147 |         raise TypeError  # DOC501
+    |               ^^^^^^^^^ DOC501
+148 |     else:
+149 |         raise TypeError  # no DOC501 here because we already emitted a diagnostic for the earlier `raise TypeError`
+    |
+    = help: Add `TypeError` to the docstring
+
+DOC501_numpy.py:150:11: DOC501 Raised exception `ValueError` missing from docstring
+    |
+148 |     else:
+149 |         raise TypeError  # no DOC501 here because we already emitted a diagnostic for the earlier `raise TypeError`
+150 |     raise ValueError  # DOC501
+    |           ^^^^^^^^^^ DOC501
+151 |     return 42
+    |
+    = help: Add `ValueError` to the docstring


### PR DESCRIPTION
## Summary

I noticed when looking through the ecosystem report for #12639 that a function like this will be flagged twice for not stating in its docstring that it raises `TypeError`. We probably only need to emit one DOC501 violation for such a function:

```py
def foo():
    """Foo.

    Returns:
        42: int
    """
    raise TypeError
    raise TypeError
    return 42
```

## Test Plan

`cargo test -p ruff_linter`
