### PR TITLE
[flake8-async] Fix false positives with multiple `async with` items (`ASYNC100`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_async/ASYNC100.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_async/ASYNC100.py
@@ -84,3 +84,8 @@ async def func():
 async def func():
     async with asyncio.timeout(delay=0.2), asyncio.TaskGroup(), asyncio.timeout(delay=0.2), asyncio.TaskGroup():
         ...
+
+
+async def func():
+    async with asyncio.timeout(delay=0.2), asyncio.timeout(delay=0.2):
+        ...

--- a/crates/ruff_linter/resources/test/fixtures/flake8_async/ASYNC100.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_async/ASYNC100.py
@@ -1,51 +1,63 @@
 import anyio
 import asyncio
 import trio
+from contextlib import nullcontext
 
 
 async def func():
-    async with trio.fail_after():
+    with trio.fail_after():
         ...
 
 
 async def func():
-    async with trio.fail_at():
+    with trio.fail_at():
         await ...
 
 
 async def func():
-    async with trio.move_on_after():
+    with trio.move_on_after():
         ...
 
 
 async def func():
-    async with trio.move_at():
+    with trio.move_at():
         await ...
 
 
 async def func():
-    async with trio.move_at():
+    with trio.move_at():
         async with trio.open_nursery():
             ...
 
 
 async def func():
-    async with anyio.move_on_after(delay=0.2):
+    with trio.move_at():
+        async for x in ...:
+            ...
+
+
+async def func():
+    with anyio.move_on_after(delay=0.2):
         ...
 
 
 async def func():
-    async with anyio.fail_after():
+    with anyio.fail_after():
         ...
 
 
 async def func():
-    async with anyio.CancelScope():
+    with anyio.CancelScope():
         ...
 
 
 async def func():
-    async with anyio.CancelScope():
+    with anyio.CancelScope(), nullcontext():
+        ...
+
+
+async def func():
+    with nullcontext(), anyio.CancelScope():
         ...
 
 
@@ -61,4 +73,14 @@ async def func():
 
 async def func():
     async with asyncio.timeout(delay=0.2), asyncio.TaskGroup():
+        ...
+
+
+async def func():
+    async with asyncio.timeout(delay=0.2), asyncio.TaskGroup(), asyncio.timeout(delay=0.2):
+        ...
+
+
+async def func():
+    async with asyncio.timeout(delay=0.2), asyncio.TaskGroup(), asyncio.timeout(delay=0.2), asyncio.TaskGroup():
         ...

--- a/crates/ruff_linter/src/rules/flake8_async/snapshots/ruff_linter__rules__flake8_async__tests__ASYNC100_ASYNC100.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_async/snapshots/ruff_linter__rules__flake8_async__tests__ASYNC100_ASYNC100.py.snap
@@ -1,20 +1,20 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_async/mod.rs
 ---
-ASYNC100.py:7:5: ASYNC100 A `with trio.fail_after(...):` context does not contain any `await` statements. This makes it pointless, as the timeout can only be triggered by a checkpoint.
+ASYNC100.py:8:5: ASYNC100 A `with trio.fail_after(...):` context does not contain any `await` statements. This makes it pointless, as the timeout can only be triggered by a checkpoint.
   |
-6 |   async def func():
-7 |       async with trio.fail_after():
+7 |   async def func():
+8 |       with trio.fail_after():
   |  _____^
-8 | |         ...
+9 | |         ...
   | |___________^ ASYNC100
   |
 
-ASYNC100.py:17:5: ASYNC100 A `with trio.move_on_after(...):` context does not contain any `await` statements. This makes it pointless, as the timeout can only be triggered by a checkpoint.
+ASYNC100.py:18:5: ASYNC100 A `with trio.move_on_after(...):` context does not contain any `await` statements. This makes it pointless, as the timeout can only be triggered by a checkpoint.
    |
-16 |   async def func():
-17 |       async with trio.move_on_after():
+17 |   async def func():
+18 |       with trio.move_on_after():
    |  _____^
-18 | |         ...
+19 | |         ...
    | |___________^ ASYNC100
    |

--- a/crates/ruff_linter/src/rules/flake8_async/snapshots/ruff_linter__rules__flake8_async__tests__preview__ASYNC100_ASYNC100.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_async/snapshots/ruff_linter__rules__flake8_async__tests__preview__ASYNC100_ASYNC100.py.snap
@@ -90,3 +90,12 @@ ASYNC100.py:80:5: ASYNC100 A `with asyncio.timeout(...):` context does not conta
 81 | |         ...
    | |___________^ ASYNC100
    |
+
+ASYNC100.py:90:5: ASYNC100 A `with asyncio.timeout(...):` context does not contain any `await` statements. This makes it pointless, as the timeout can only be triggered by a checkpoint.
+   |
+89 |   async def func():
+90 |       async with asyncio.timeout(delay=0.2), asyncio.timeout(delay=0.2):
+   |  _____^
+91 | |         ...
+   | |___________^ ASYNC100
+   |

--- a/crates/ruff_linter/src/rules/flake8_async/snapshots/ruff_linter__rules__flake8_async__tests__preview__ASYNC100_ASYNC100.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_async/snapshots/ruff_linter__rules__flake8_async__tests__preview__ASYNC100_ASYNC100.py.snap
@@ -1,74 +1,92 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_async/mod.rs
 ---
-ASYNC100.py:7:5: ASYNC100 A `with trio.fail_after(...):` context does not contain any `await` statements. This makes it pointless, as the timeout can only be triggered by a checkpoint.
+ASYNC100.py:8:5: ASYNC100 A `with trio.fail_after(...):` context does not contain any `await` statements. This makes it pointless, as the timeout can only be triggered by a checkpoint.
   |
-6 |   async def func():
-7 |       async with trio.fail_after():
+7 |   async def func():
+8 |       with trio.fail_after():
   |  _____^
-8 | |         ...
+9 | |         ...
   | |___________^ ASYNC100
   |
 
-ASYNC100.py:17:5: ASYNC100 A `with trio.move_on_after(...):` context does not contain any `await` statements. This makes it pointless, as the timeout can only be triggered by a checkpoint.
+ASYNC100.py:18:5: ASYNC100 A `with trio.move_on_after(...):` context does not contain any `await` statements. This makes it pointless, as the timeout can only be triggered by a checkpoint.
    |
-16 |   async def func():
-17 |       async with trio.move_on_after():
+17 |   async def func():
+18 |       with trio.move_on_after():
    |  _____^
-18 | |         ...
+19 | |         ...
    | |___________^ ASYNC100
    |
 
-ASYNC100.py:33:5: ASYNC100 A `with anyio.move_on_after(...):` context does not contain any `await` statements. This makes it pointless, as the timeout can only be triggered by a checkpoint.
+ASYNC100.py:40:5: ASYNC100 A `with anyio.move_on_after(...):` context does not contain any `await` statements. This makes it pointless, as the timeout can only be triggered by a checkpoint.
    |
-32 |   async def func():
-33 |       async with anyio.move_on_after(delay=0.2):
+39 |   async def func():
+40 |       with anyio.move_on_after(delay=0.2):
    |  _____^
-34 | |         ...
+41 | |         ...
    | |___________^ ASYNC100
    |
 
-ASYNC100.py:38:5: ASYNC100 A `with anyio.fail_after(...):` context does not contain any `await` statements. This makes it pointless, as the timeout can only be triggered by a checkpoint.
+ASYNC100.py:45:5: ASYNC100 A `with anyio.fail_after(...):` context does not contain any `await` statements. This makes it pointless, as the timeout can only be triggered by a checkpoint.
    |
-37 |   async def func():
-38 |       async with anyio.fail_after():
+44 |   async def func():
+45 |       with anyio.fail_after():
    |  _____^
-39 | |         ...
+46 | |         ...
    | |___________^ ASYNC100
    |
 
-ASYNC100.py:43:5: ASYNC100 A `with anyio.CancelScope(...):` context does not contain any `await` statements. This makes it pointless, as the timeout can only be triggered by a checkpoint.
+ASYNC100.py:50:5: ASYNC100 A `with anyio.CancelScope(...):` context does not contain any `await` statements. This makes it pointless, as the timeout can only be triggered by a checkpoint.
    |
-42 |   async def func():
-43 |       async with anyio.CancelScope():
+49 |   async def func():
+50 |       with anyio.CancelScope():
    |  _____^
-44 | |         ...
+51 | |         ...
    | |___________^ ASYNC100
    |
 
-ASYNC100.py:48:5: ASYNC100 A `with anyio.CancelScope(...):` context does not contain any `await` statements. This makes it pointless, as the timeout can only be triggered by a checkpoint.
+ASYNC100.py:55:5: ASYNC100 A `with anyio.CancelScope(...):` context does not contain any `await` statements. This makes it pointless, as the timeout can only be triggered by a checkpoint.
    |
-47 |   async def func():
-48 |       async with anyio.CancelScope():
+54 |   async def func():
+55 |       with anyio.CancelScope(), nullcontext():
    |  _____^
-49 | |         ...
+56 | |         ...
    | |___________^ ASYNC100
    |
 
-ASYNC100.py:53:5: ASYNC100 A `with asyncio.timeout(...):` context does not contain any `await` statements. This makes it pointless, as the timeout can only be triggered by a checkpoint.
+ASYNC100.py:60:5: ASYNC100 A `with anyio.CancelScope(...):` context does not contain any `await` statements. This makes it pointless, as the timeout can only be triggered by a checkpoint.
    |
-52 |   async def func():
-53 |       async with asyncio.timeout(delay=0.2):
+59 |   async def func():
+60 |       with nullcontext(), anyio.CancelScope():
    |  _____^
-54 | |         ...
+61 | |         ...
    | |___________^ ASYNC100
    |
 
-ASYNC100.py:58:5: ASYNC100 A `with asyncio.timeout_at(...):` context does not contain any `await` statements. This makes it pointless, as the timeout can only be triggered by a checkpoint.
+ASYNC100.py:65:5: ASYNC100 A `with asyncio.timeout(...):` context does not contain any `await` statements. This makes it pointless, as the timeout can only be triggered by a checkpoint.
    |
-57 |   async def func():
-58 |       async with asyncio.timeout_at(when=0.2):
+64 |   async def func():
+65 |       async with asyncio.timeout(delay=0.2):
    |  _____^
-59 | |         ...
+66 | |         ...
+   | |___________^ ASYNC100
+   |
+
+ASYNC100.py:70:5: ASYNC100 A `with asyncio.timeout_at(...):` context does not contain any `await` statements. This makes it pointless, as the timeout can only be triggered by a checkpoint.
+   |
+69 |   async def func():
+70 |       async with asyncio.timeout_at(when=0.2):
+   |  _____^
+71 | |         ...
+   | |___________^ ASYNC100
+   |
+
+ASYNC100.py:80:5: ASYNC100 A `with asyncio.timeout(...):` context does not contain any `await` statements. This makes it pointless, as the timeout can only be triggered by a checkpoint.
+   |
+79 |   async def func():
+80 |       async with asyncio.timeout(delay=0.2), asyncio.TaskGroup(), asyncio.timeout(delay=0.2):
+   |  _____^
+81 | |         ...
    | |___________^ ASYNC100
    |


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Please see https://github.com/astral-sh/ruff/pull/12605#discussion_r1699957443 for a description of the issue.

They way I fixed it is to get the *last* timeout item in the `with`, and if it's an `async with` and there are items after it, then don't trigger the lint.

## Test Plan

Updated the fixture with some more cases.