### PR TITLE
[`flake8-bugbear`] Treat return as equivalent to break (`B909`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_bugbear/B909.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_bugbear/B909.py
@@ -173,3 +173,9 @@ for i, elem in enumerate(some_list):
 # should not error (dict)
 for i, elem in enumerate(some_list):
     some_list[elem] = 1
+
+# should not error
+def func():
+    for elem in some_list:
+        if some_list.pop() == 2:
+            return

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/loop_iterator_mutation.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/loop_iterator_mutation.rs
@@ -1,3 +1,6 @@
+use std::collections::HashMap;
+use std::fmt::Debug;
+
 use ruff_diagnostics::Diagnostic;
 use ruff_diagnostics::Violation;
 use ruff_macros::{derive_message_formats, violation};
@@ -6,11 +9,9 @@ use ruff_python_ast::name::UnqualifiedName;
 use ruff_python_ast::{
     visitor::{self, Visitor},
     Expr, ExprAttribute, ExprCall, ExprSubscript, ExprTuple, Stmt, StmtAssign, StmtAugAssign,
-    StmtBreak, StmtDelete, StmtFor, StmtIf,
+    StmtDelete, StmtFor, StmtIf,
 };
 use ruff_text_size::TextRange;
-use std::collections::HashMap;
-use std::fmt::Debug;
 
 use crate::checkers::ast::Checker;
 use crate::fix::snippet::SourceCodeSnippet;
@@ -285,7 +286,7 @@ impl<'a> Visitor<'a> for LoopMutationsVisitor<'a> {
             }
 
             // On break, clear the mutations for the current branch.
-            Stmt::Break(StmtBreak { range: _ }) => {
+            Stmt::Break(_) | Stmt::Return(_) => {
                 if let Some(mutations) = self.mutations.get_mut(&self.branch) {
                     mutations.clear();
                 }


### PR DESCRIPTION
Closes https://github.com/astral-sh/ruff/issues/12640.