### PR TITLE
Fix typo in configuration docs

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -189,7 +189,7 @@ As an example, the following would configure Ruff to:
     # 3. Avoid trying to fix flake8-bugbear (`B`) violations.
     unfixable = ["B"]
 
-    # 4. Ignore `E402` (import violations) in all `__init__.py` files, and in select subdirectories.
+    # 4. Ignore `E402` (import violations) in all `__init__.py` files, and in selected subdirectories.
     [tool.ruff.lint.per-file-ignores]
     "__init__.py" = ["E402"]
     "**/{tests,docs,tools}/*" = ["E402"]
@@ -212,7 +212,7 @@ As an example, the following would configure Ruff to:
     # 3. Avoid trying to fix flake8-bugbear (`B`) violations.
     unfixable = ["B"]
 
-    # 4. Ignore `E402` (import violations) in all `__init__.py` files, and in select subdirectories.
+    # 4. Ignore `E402` (import violations) in all `__init__.py` files, and in selected subdirectories.
     [lint.per-file-ignores]
     "__init__.py" = ["E402"]
     "**/{tests,docs,tools}/*" = ["E402"]


### PR DESCRIPTION

<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary
Fix a typo in the configuration docs.

Context: I noticed this typo when reading the docs.

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan
No test plan since it only changes a markdown file.
That said, I did double-check with ChatGPT that this was indeed the correct grammar in English.

<!-- How was it tested? -->
