### PR TITLE
[flake8-comprehensions] Account for list and set comprehensions in `unnecessary-literal-within-tuple-call` (`C409`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_comprehensions/C409.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_comprehensions/C409.py
@@ -24,3 +24,21 @@ tuple((
 t6 = tuple([1])
 t7 = tuple((1,))
 t8 = tuple([1,])
+
+tuple([x for x in range(5)])
+tuple({x for x in range(10)})
+tuple(x for x in range(5))
+tuple([
+    x for x in [1,2,3]
+])
+tuple( # comment
+    [x for x in [1,2,3]]
+)
+tuple([ # comment
+    x for x in range(10)
+])
+tuple(
+    {
+        x for x in [1,2,3]
+    }
+)

--- a/crates/ruff_linter/src/checkers/ast/analyze/expression.rs
+++ b/crates/ruff_linter/src/checkers/ast/analyze/expression.rs
@@ -704,7 +704,9 @@ pub(crate) fn expression(expr: &Expr, checker: &mut Checker) {
                 );
             }
             if checker.enabled(Rule::UnnecessaryLiteralWithinTupleCall) {
-                flake8_comprehensions::rules::unnecessary_literal_within_tuple_call(checker, call);
+                flake8_comprehensions::rules::unnecessary_literal_within_tuple_call(
+                    checker, expr, call,
+                );
             }
             if checker.enabled(Rule::UnnecessaryLiteralWithinListCall) {
                 flake8_comprehensions::rules::unnecessary_literal_within_list_call(checker, call);

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/mod.rs
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/mod.rs
@@ -45,6 +45,7 @@ mod tests {
         Ok(())
     }
 
+    #[test_case(Rule::UnnecessaryLiteralWithinTupleCall, Path::new("C409.py"))]
     #[test_case(Rule::UnnecessaryComprehensionInCall, Path::new("C419_1.py"))]
     fn preview_rules(rule_code: Rule, path: &Path) -> Result<()> {
         let snapshot = format!(

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_literal_within_tuple_call.rs
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_literal_within_tuple_call.rs
@@ -12,7 +12,7 @@ use super::helpers;
 
 /// ## What it does
 /// Checks for `tuple` calls that take unnecessary list or tuple literals as
-/// arguments.
+/// arguments. This includes literals in the form of list or set comprehensions.
 ///
 /// ## Why is this bad?
 /// It's unnecessary to use a list or tuple literal within a `tuple()` call,
@@ -26,17 +26,22 @@ use super::helpers;
 /// ```python
 /// tuple([1, 2])
 /// tuple((1, 2))
+/// tuple([x for x in range(10)])
 /// ```
 ///
 /// Use instead:
 /// ```python
 /// (1, 2)
 /// (1, 2)
+/// tuple(x for x in range(10))
 /// ```
 ///
 /// ## Fix safety
 /// This rule's fix is marked as unsafe, as it may occasionally drop comments
 /// when rewriting the call. In most cases, though, comments will be preserved.
+/// Moreover, in the case where a comprehension is replaced by a generator,
+/// code behavior may be changed if the iteration has side-effects.
+///
 #[violation]
 pub struct UnnecessaryLiteralWithinTupleCall {
     literal: String,

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/snapshots/ruff_linter__rules__flake8_comprehensions__tests__C409_C409.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/snapshots/ruff_linter__rules__flake8_comprehensions__tests__C409_C409.py.snap
@@ -8,7 +8,7 @@ C409.py:1:6: C409 [*] Unnecessary `list` literal passed to `tuple()` (rewrite as
 2 | t2 = tuple([1, 2])
 3 | t3 = tuple((1, 2))
   |
-  = help: Rewrite as a `tuple` literal
+  = help: Rewrite as a `tuple` literal.
 
 ℹ Unsafe fix
 1   |-t1 = tuple([])
@@ -25,7 +25,7 @@ C409.py:2:6: C409 [*] Unnecessary `list` literal passed to `tuple()` (rewrite as
 3 | t3 = tuple((1, 2))
 4 | t4 = tuple([
   |
-  = help: Rewrite as a `tuple` literal
+  = help: Rewrite as a `tuple` literal.
 
 ℹ Unsafe fix
 1 1 | t1 = tuple([])
@@ -44,7 +44,7 @@ C409.py:3:6: C409 [*] Unnecessary `tuple` literal passed to `tuple()` (remove th
 4 | t4 = tuple([
 5 |     1,
   |
-  = help: Remove outer `tuple` call
+  = help: Remove the outer call to `tuple()`.
 
 ℹ Unsafe fix
 1 1 | t1 = tuple([])
@@ -68,7 +68,7 @@ C409.py:4:6: C409 [*] Unnecessary `list` literal passed to `tuple()` (rewrite as
 8 |   t5 = tuple(
 9 |       (1, 2)
   |
-  = help: Rewrite as a `tuple` literal
+  = help: Rewrite as a `tuple` literal.
 
 ℹ Unsafe fix
 1 1 | t1 = tuple([])
@@ -96,7 +96,7 @@ C409.py:8:6: C409 [*] Unnecessary `tuple` literal passed to `tuple()` (remove th
 11 |   
 12 |   tuple(  # comment
    |
-   = help: Remove outer `tuple` call
+   = help: Remove the outer call to `tuple()`.
 
 ℹ Unsafe fix
 5  5  |     1,
@@ -121,7 +121,7 @@ C409.py:12:1: C409 [*] Unnecessary `list` literal passed to `tuple()` (rewrite a
 15 |   
 16 |   tuple([  # comment
    |
-   = help: Rewrite as a `tuple` literal
+   = help: Rewrite as a `tuple` literal.
 
 ℹ Unsafe fix
 9  9  |     (1, 2)
@@ -146,7 +146,7 @@ C409.py:16:1: C409 [*] Unnecessary `list` literal passed to `tuple()` (rewrite a
 19 |   
 20 |   tuple((
    |
-   = help: Rewrite as a `tuple` literal
+   = help: Rewrite as a `tuple` literal.
 
 ℹ Unsafe fix
 13 13 |     [1, 2]
@@ -172,7 +172,7 @@ C409.py:20:1: C409 [*] Unnecessary `tuple` literal passed to `tuple()` (remove t
 23 |   
 24 |   t6 = tuple([1])
    |
-   = help: Remove outer `tuple` call
+   = help: Remove the outer call to `tuple()`.
 
 ℹ Unsafe fix
 17 17 |     1, 2
@@ -196,7 +196,7 @@ C409.py:24:6: C409 [*] Unnecessary `list` literal passed to `tuple()` (rewrite a
 25 | t7 = tuple((1,))
 26 | t8 = tuple([1,])
    |
-   = help: Rewrite as a `tuple` literal
+   = help: Rewrite as a `tuple` literal.
 
 ℹ Unsafe fix
 21 21 |     1,
@@ -215,7 +215,7 @@ C409.py:25:6: C409 [*] Unnecessary `tuple` literal passed to `tuple()` (remove t
    |      ^^^^^^^^^^^ C409
 26 | t8 = tuple([1,])
    |
-   = help: Remove outer `tuple` call
+   = help: Remove the outer call to `tuple()`.
 
 ℹ Unsafe fix
 22 22 | ))
@@ -236,7 +236,7 @@ C409.py:26:6: C409 [*] Unnecessary `list` literal passed to `tuple()` (rewrite a
 27 | 
 28 | tuple([x for x in range(5)])
    |
-   = help: Rewrite as a `tuple` literal
+   = help: Rewrite as a `tuple` literal.
 
 ℹ Unsafe fix
 23 23 | 
@@ -248,7 +248,7 @@ C409.py:26:6: C409 [*] Unnecessary `list` literal passed to `tuple()` (rewrite a
 28 28 | tuple([x for x in range(5)])
 29 29 | tuple({x for x in range(10)})
 
-C409.py:28:1: C409 [*] Unnecessary `list comprehension` literal passed to `tuple()` (remove the outer call to `tuple()`)
+C409.py:28:1: C409 [*] Unnecessary list comprehension passed to `tuple()` (rewrite with generator)
    |
 26 | t8 = tuple([1,])
 27 | 
@@ -257,7 +257,7 @@ C409.py:28:1: C409 [*] Unnecessary `list comprehension` literal passed to `tuple
 29 | tuple({x for x in range(10)})
 30 | tuple(x for x in range(5))
    |
-   = help: Remove outer `tuple` call
+   = help: Rewrite with generator
 
 ℹ Unsafe fix
 25 25 | t7 = tuple((1,))
@@ -269,27 +269,7 @@ C409.py:28:1: C409 [*] Unnecessary `list comprehension` literal passed to `tuple
 30 30 | tuple(x for x in range(5))
 31 31 | tuple([
 
-C409.py:29:1: C409 [*] Unnecessary `set comprehension` literal passed to `tuple()` (remove the outer call to `tuple()`)
-   |
-28 | tuple([x for x in range(5)])
-29 | tuple({x for x in range(10)})
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ C409
-30 | tuple(x for x in range(5))
-31 | tuple([
-   |
-   = help: Remove outer `tuple` call
-
-ℹ Unsafe fix
-26 26 | t8 = tuple([1,])
-27 27 | 
-28 28 | tuple([x for x in range(5)])
-29    |-tuple({x for x in range(10)})
-   29 |+tuple(x for x in range(10))
-30 30 | tuple(x for x in range(5))
-31 31 | tuple([
-32 32 |     x for x in [1,2,3]
-
-C409.py:31:1: C409 [*] Unnecessary `list comprehension` literal passed to `tuple()` (remove the outer call to `tuple()`)
+C409.py:31:1: C409 [*] Unnecessary list comprehension passed to `tuple()` (rewrite with generator)
    |
 29 |   tuple({x for x in range(10)})
 30 |   tuple(x for x in range(5))
@@ -300,7 +280,7 @@ C409.py:31:1: C409 [*] Unnecessary `list comprehension` literal passed to `tuple
 34 |   tuple( # comment
 35 |       [x for x in [1,2,3]]
    |
-   = help: Remove outer `tuple` call
+   = help: Rewrite with generator
 
 ℹ Unsafe fix
 28 28 | tuple([x for x in range(5)])
@@ -314,7 +294,7 @@ C409.py:31:1: C409 [*] Unnecessary `list comprehension` literal passed to `tuple
 35 33 |     [x for x in [1,2,3]]
 36 34 | )
 
-C409.py:34:1: C409 [*] Unnecessary `list comprehension` literal passed to `tuple()` (remove the outer call to `tuple()`)
+C409.py:34:1: C409 [*] Unnecessary list comprehension passed to `tuple()` (rewrite with generator)
    |
 32 |       x for x in [1,2,3]
 33 |   ])
@@ -325,7 +305,7 @@ C409.py:34:1: C409 [*] Unnecessary `list comprehension` literal passed to `tuple
 37 |   tuple([ # comment
 38 |       x for x in range(10)
    |
-   = help: Remove outer `tuple` call
+   = help: Rewrite with generator
 
 ℹ Unsafe fix
 32 32 |     x for x in [1,2,3]
@@ -337,7 +317,7 @@ C409.py:34:1: C409 [*] Unnecessary `list comprehension` literal passed to `tuple
 37 37 | tuple([ # comment
 38 38 |     x for x in range(10)
 
-C409.py:37:1: C409 [*] Unnecessary `list comprehension` literal passed to `tuple()` (remove the outer call to `tuple()`)
+C409.py:37:1: C409 [*] Unnecessary list comprehension passed to `tuple()` (rewrite with generator)
    |
 35 |       [x for x in [1,2,3]]
 36 |   )
@@ -348,7 +328,7 @@ C409.py:37:1: C409 [*] Unnecessary `list comprehension` literal passed to `tuple
 40 |   tuple(
 41 |       {
    |
-   = help: Remove outer `tuple` call
+   = help: Rewrite with generator
 
 ℹ Unsafe fix
 34 34 | tuple( # comment
@@ -364,26 +344,3 @@ C409.py:37:1: C409 [*] Unnecessary `list comprehension` literal passed to `tuple
 41 41 |     {
 42 42 |         x for x in [1,2,3]
 43 43 |     }
-
-C409.py:40:1: C409 [*] Unnecessary `set comprehension` literal passed to `tuple()` (remove the outer call to `tuple()`)
-   |
-38 |       x for x in range(10)
-39 |   ])
-40 | / tuple(
-41 | |     {
-42 | |         x for x in [1,2,3]
-43 | |     }
-44 | | )
-   | |_^ C409
-   |
-   = help: Remove outer `tuple` call
-
-ℹ Unsafe fix
-38 38 |     x for x in range(10)
-39 39 | ])
-40 40 | tuple(
-41    |-    {
-42    |-        x for x in [1,2,3]
-43    |-    }
-   41 |+    x for x in [1,2,3]
-44 42 | )

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/snapshots/ruff_linter__rules__flake8_comprehensions__tests__C409_C409.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/snapshots/ruff_linter__rules__flake8_comprehensions__tests__C409_C409.py.snap
@@ -206,6 +206,7 @@ C409.py:24:6: C409 [*] Unnecessary `list` literal passed to `tuple()` (rewrite a
    24 |+t6 = (1,)
 25 25 | t7 = tuple((1,))
 26 26 | t8 = tuple([1,])
+27 27 | 
 
 C409.py:25:6: C409 [*] Unnecessary `tuple` literal passed to `tuple()` (remove the outer call to `tuple()`)
    |
@@ -223,6 +224,8 @@ C409.py:25:6: C409 [*] Unnecessary `tuple` literal passed to `tuple()` (remove t
 25    |-t7 = tuple((1,))
    25 |+t7 = (1,)
 26 26 | t8 = tuple([1,])
+27 27 | 
+28 28 | tuple([x for x in range(5)])
 
 C409.py:26:6: C409 [*] Unnecessary `list` literal passed to `tuple()` (rewrite as a `tuple` literal)
    |
@@ -230,6 +233,8 @@ C409.py:26:6: C409 [*] Unnecessary `list` literal passed to `tuple()` (rewrite a
 25 | t7 = tuple((1,))
 26 | t8 = tuple([1,])
    |      ^^^^^^^^^^^ C409
+27 | 
+28 | tuple([x for x in range(5)])
    |
    = help: Rewrite as a `tuple` literal
 
@@ -239,3 +244,146 @@ C409.py:26:6: C409 [*] Unnecessary `list` literal passed to `tuple()` (rewrite a
 25 25 | t7 = tuple((1,))
 26    |-t8 = tuple([1,])
    26 |+t8 = (1,)
+27 27 | 
+28 28 | tuple([x for x in range(5)])
+29 29 | tuple({x for x in range(10)})
+
+C409.py:28:1: C409 [*] Unnecessary `list comprehension` literal passed to `tuple()` (remove the outer call to `tuple()`)
+   |
+26 | t8 = tuple([1,])
+27 | 
+28 | tuple([x for x in range(5)])
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ C409
+29 | tuple({x for x in range(10)})
+30 | tuple(x for x in range(5))
+   |
+   = help: Remove outer `tuple` call
+
+ℹ Unsafe fix
+25 25 | t7 = tuple((1,))
+26 26 | t8 = tuple([1,])
+27 27 | 
+28    |-tuple([x for x in range(5)])
+   28 |+tuple(x for x in range(5))
+29 29 | tuple({x for x in range(10)})
+30 30 | tuple(x for x in range(5))
+31 31 | tuple([
+
+C409.py:29:1: C409 [*] Unnecessary `set comprehension` literal passed to `tuple()` (remove the outer call to `tuple()`)
+   |
+28 | tuple([x for x in range(5)])
+29 | tuple({x for x in range(10)})
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ C409
+30 | tuple(x for x in range(5))
+31 | tuple([
+   |
+   = help: Remove outer `tuple` call
+
+ℹ Unsafe fix
+26 26 | t8 = tuple([1,])
+27 27 | 
+28 28 | tuple([x for x in range(5)])
+29    |-tuple({x for x in range(10)})
+   29 |+tuple(x for x in range(10))
+30 30 | tuple(x for x in range(5))
+31 31 | tuple([
+32 32 |     x for x in [1,2,3]
+
+C409.py:31:1: C409 [*] Unnecessary `list comprehension` literal passed to `tuple()` (remove the outer call to `tuple()`)
+   |
+29 |   tuple({x for x in range(10)})
+30 |   tuple(x for x in range(5))
+31 | / tuple([
+32 | |     x for x in [1,2,3]
+33 | | ])
+   | |__^ C409
+34 |   tuple( # comment
+35 |       [x for x in [1,2,3]]
+   |
+   = help: Remove outer `tuple` call
+
+ℹ Unsafe fix
+28 28 | tuple([x for x in range(5)])
+29 29 | tuple({x for x in range(10)})
+30 30 | tuple(x for x in range(5))
+31    |-tuple([
+32    |-    x for x in [1,2,3]
+33    |-])
+   31 |+tuple(x for x in [1,2,3])
+34 32 | tuple( # comment
+35 33 |     [x for x in [1,2,3]]
+36 34 | )
+
+C409.py:34:1: C409 [*] Unnecessary `list comprehension` literal passed to `tuple()` (remove the outer call to `tuple()`)
+   |
+32 |       x for x in [1,2,3]
+33 |   ])
+34 | / tuple( # comment
+35 | |     [x for x in [1,2,3]]
+36 | | )
+   | |_^ C409
+37 |   tuple([ # comment
+38 |       x for x in range(10)
+   |
+   = help: Remove outer `tuple` call
+
+ℹ Unsafe fix
+32 32 |     x for x in [1,2,3]
+33 33 | ])
+34 34 | tuple( # comment
+35    |-    [x for x in [1,2,3]]
+   35 |+    x for x in [1,2,3]
+36 36 | )
+37 37 | tuple([ # comment
+38 38 |     x for x in range(10)
+
+C409.py:37:1: C409 [*] Unnecessary `list comprehension` literal passed to `tuple()` (remove the outer call to `tuple()`)
+   |
+35 |       [x for x in [1,2,3]]
+36 |   )
+37 | / tuple([ # comment
+38 | |     x for x in range(10)
+39 | | ])
+   | |__^ C409
+40 |   tuple(
+41 |       {
+   |
+   = help: Remove outer `tuple` call
+
+ℹ Unsafe fix
+34 34 | tuple( # comment
+35 35 |     [x for x in [1,2,3]]
+36 36 | )
+37    |-tuple([ # comment
+38    |-    x for x in range(10)
+39    |-])
+40 37 | tuple(
+   38 |+# comment
+   39 |+x for x in range(10))
+   40 |+tuple(
+41 41 |     {
+42 42 |         x for x in [1,2,3]
+43 43 |     }
+
+C409.py:40:1: C409 [*] Unnecessary `set comprehension` literal passed to `tuple()` (remove the outer call to `tuple()`)
+   |
+38 |       x for x in range(10)
+39 |   ])
+40 | / tuple(
+41 | |     {
+42 | |         x for x in [1,2,3]
+43 | |     }
+44 | | )
+   | |_^ C409
+   |
+   = help: Remove outer `tuple` call
+
+ℹ Unsafe fix
+38 38 |     x for x in range(10)
+39 39 | ])
+40 40 | tuple(
+41    |-    {
+42    |-        x for x in [1,2,3]
+43    |-    }
+   41 |+    x for x in [1,2,3]
+44 42 | )

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/snapshots/ruff_linter__rules__flake8_comprehensions__tests__preview__C409_C409.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/snapshots/ruff_linter__rules__flake8_comprehensions__tests__preview__C409_C409.py.snap
@@ -247,3 +247,100 @@ C409.py:26:6: C409 [*] Unnecessary `list` literal passed to `tuple()` (rewrite a
 27 27 | 
 28 28 | tuple([x for x in range(5)])
 29 29 | tuple({x for x in range(10)})
+
+C409.py:28:1: C409 [*] Unnecessary list comprehension passed to `tuple()` (rewrite as a generator)
+   |
+26 | t8 = tuple([1,])
+27 | 
+28 | tuple([x for x in range(5)])
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ C409
+29 | tuple({x for x in range(10)})
+30 | tuple(x for x in range(5))
+   |
+   = help: Rewrite as a generator
+
+ℹ Unsafe fix
+25 25 | t7 = tuple((1,))
+26 26 | t8 = tuple([1,])
+27 27 | 
+28    |-tuple([x for x in range(5)])
+   28 |+tuple(x for x in range(5))
+29 29 | tuple({x for x in range(10)})
+30 30 | tuple(x for x in range(5))
+31 31 | tuple([
+
+C409.py:31:1: C409 [*] Unnecessary list comprehension passed to `tuple()` (rewrite as a generator)
+   |
+29 |   tuple({x for x in range(10)})
+30 |   tuple(x for x in range(5))
+31 | / tuple([
+32 | |     x for x in [1,2,3]
+33 | | ])
+   | |__^ C409
+34 |   tuple( # comment
+35 |       [x for x in [1,2,3]]
+   |
+   = help: Rewrite as a generator
+
+ℹ Unsafe fix
+28 28 | tuple([x for x in range(5)])
+29 29 | tuple({x for x in range(10)})
+30 30 | tuple(x for x in range(5))
+31    |-tuple([
+32    |-    x for x in [1,2,3]
+33    |-])
+   31 |+tuple(x for x in [1,2,3])
+34 32 | tuple( # comment
+35 33 |     [x for x in [1,2,3]]
+36 34 | )
+
+C409.py:34:1: C409 [*] Unnecessary list comprehension passed to `tuple()` (rewrite as a generator)
+   |
+32 |       x for x in [1,2,3]
+33 |   ])
+34 | / tuple( # comment
+35 | |     [x for x in [1,2,3]]
+36 | | )
+   | |_^ C409
+37 |   tuple([ # comment
+38 |       x for x in range(10)
+   |
+   = help: Rewrite as a generator
+
+ℹ Unsafe fix
+32 32 |     x for x in [1,2,3]
+33 33 | ])
+34 34 | tuple( # comment
+35    |-    [x for x in [1,2,3]]
+   35 |+    x for x in [1,2,3]
+36 36 | )
+37 37 | tuple([ # comment
+38 38 |     x for x in range(10)
+
+C409.py:37:1: C409 [*] Unnecessary list comprehension passed to `tuple()` (rewrite as a generator)
+   |
+35 |       [x for x in [1,2,3]]
+36 |   )
+37 | / tuple([ # comment
+38 | |     x for x in range(10)
+39 | | ])
+   | |__^ C409
+40 |   tuple(
+41 |       {
+   |
+   = help: Rewrite as a generator
+
+ℹ Unsafe fix
+34 34 | tuple( # comment
+35 35 |     [x for x in [1,2,3]]
+36 36 | )
+37    |-tuple([ # comment
+38    |-    x for x in range(10)
+39    |-])
+40 37 | tuple(
+   38 |+# comment
+   39 |+x for x in range(10))
+   40 |+tuple(
+41 41 |     {
+42 42 |         x for x in [1,2,3]
+43 43 |     }


### PR DESCRIPTION
## Summary

Make it a violation of `C409` to call `tuple` with a list or set comprehension, and
implement the (unsafe) fix of calling the `tuple` with the underlying generator instead.

Closes #12648.

## Test Plan

Test fixture updated, cargo test, docs checked for updated description.
