### PR TITLE
Remove all `useEffect` usages

### DIFF
--- a/playground/.gitignore
+++ b/playground/.gitignore
@@ -128,3 +128,6 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+
+# Wrangler
+api/.wrangler

--- a/playground/README.md
+++ b/playground/README.md
@@ -12,7 +12,7 @@ Finally, install TypeScript dependencies with `npm install`, and run the develop
 
 To run the datastore, which is based on [Workers KV](https://developers.cloudflare.com/workers/runtime-apis/kv/),
 install the [Wrangler CLI](https://developers.cloudflare.com/workers/wrangler/install-and-update/),
-then run `npx wrangler dev --local` from the `./playground/db` directory. Note that the datastore is
+then run `npx wrangler dev --local` from the `./playground/api` directory. Note that the datastore is
 only required to generate shareable URLs for code snippets. The development datastore does not
 require Cloudflare authentication or login, but in turn only persists data locally.
 

--- a/playground/src/Editor/Chrome.tsx
+++ b/playground/src/Editor/Chrome.tsx
@@ -1,0 +1,123 @@
+import { useCallback, useMemo, useRef, useState } from "react";
+import Header from "./Header";
+import { persist, persistLocal, restore, stringify } from "./settings";
+import { useTheme } from "./theme";
+import { default as Editor, Source } from "./Editor";
+import initRuff, { Workspace } from "../pkg/ruff_wasm";
+import { loader } from "@monaco-editor/react";
+import { setupMonaco } from "./setupMonaco";
+import { DEFAULT_PYTHON_SOURCE } from "../constants";
+
+export default function Chrome() {
+  const initPromise = useRef<null | Promise<void>>(null);
+  const [pythonSource, setPythonSource] = useState<null | string>(null);
+  const [settings, setSettings] = useState<null | string>(null);
+  const [revision, setRevision] = useState(0);
+  const [ruffVersion, setRuffVersion] = useState<string | null>(null);
+
+  const [theme, setTheme] = useTheme();
+
+  const handleShare = useCallback(() => {
+    if (settings == null || pythonSource == null) {
+      return;
+    }
+
+    persist(settings, pythonSource).catch((error) =>
+      console.error(`Failed to share playground: ${error}`),
+    );
+  }, [pythonSource, settings]);
+
+  if (initPromise.current == null) {
+    initPromise.current = startPlayground()
+      .then(({ sourceCode, settings, ruffVersion }) => {
+        setPythonSource(sourceCode);
+        setSettings(settings);
+        setRuffVersion(ruffVersion);
+        setRevision(1);
+      })
+      .catch((error) => {
+        console.error("Failed to initialize playground.", error);
+      });
+  }
+
+  const handleSourceChanged = useCallback(
+    (source: string) => {
+      setPythonSource(source);
+      setRevision((revision) => revision + 1);
+
+      if (settings != null) {
+        persistLocal({ pythonSource: source, settingsSource: settings });
+      }
+    },
+    [settings],
+  );
+
+  const handleSettingsChanged = useCallback(
+    (settings: string) => {
+      setSettings(settings);
+      setRevision((revision) => revision + 1);
+
+      if (pythonSource != null) {
+        persistLocal({ pythonSource: pythonSource, settingsSource: settings });
+      }
+    },
+    [pythonSource],
+  );
+
+  const source: Source | null = useMemo(() => {
+    if (pythonSource == null || settings == null) {
+      return null;
+    }
+
+    return { pythonSource, settingsSource: settings };
+  }, [settings, pythonSource]);
+
+  return (
+    <main className="flex flex-col h-full bg-ayu-background dark:bg-ayu-background-dark">
+      <Header
+        edit={revision}
+        theme={theme}
+        version={ruffVersion}
+        onChangeTheme={setTheme}
+        onShare={handleShare}
+      />
+
+      <div className="flex flex-grow">
+        {source != null && (
+          <Editor
+            theme={theme}
+            source={source}
+            onSettingsChanged={handleSettingsChanged}
+            onSourceChanged={handleSourceChanged}
+          />
+        )}
+      </div>
+    </main>
+  );
+}
+
+// Run once during startup. Initializes monaco, loads the wasm file, and restores the previous editor state.
+async function startPlayground(): Promise<{
+  sourceCode: string;
+  settings: string;
+  ruffVersion: string;
+}> {
+  await initRuff();
+  const monaco = await loader.init();
+
+  console.log(monaco);
+
+  setupMonaco(monaco);
+
+  const response = await restore();
+  const [settingsSource, pythonSource] = response ?? [
+    stringify(Workspace.defaultSettings()),
+    DEFAULT_PYTHON_SOURCE,
+  ];
+
+  return {
+    sourceCode: pythonSource,
+    settings: settingsSource,
+    ruffVersion: Workspace.version(),
+  };
+}

--- a/playground/src/Editor/Editor.tsx
+++ b/playground/src/Editor/Editor.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useDeferredValue, useEffect, useState } from "react";
+import { useCallback, useDeferredValue, useMemo, useState } from "react";
 import { Panel, PanelGroup } from "react-resizable-panels";
 import { Diagnostic, Workspace } from "../pkg/ruff_wasm";
 import { ErrorMessage } from "./ErrorMessage";
@@ -40,12 +40,6 @@ export default function Editor({
   initialSettings,
   ruffVersion,
 }: Props) {
-  const [checkResult, setCheckResult] = useState<CheckResult>({
-    diagnostics: [],
-    error: null,
-    secondary: null,
-  });
-
   const [source, setSource] = useState<Source>({
     revision: 0,
     pythonSource: initialSource,
@@ -65,6 +59,7 @@ export default function Editor({
       }
     },
   );
+
   const [theme, setTheme] = useTheme();
 
   // Ideally this would be retrieved right from the URL... but routing without a proper
@@ -90,7 +85,7 @@ export default function Editor({
 
   const deferredSource = useDeferredValue(source);
 
-  useEffect(() => {
+  const checkResult: CheckResult = useMemo(() => {
     const { pythonSource, settingsSource } = deferredSource;
 
     try {
@@ -144,17 +139,17 @@ export default function Editor({
         };
       }
 
-      setCheckResult({
+      return {
         diagnostics,
         error: null,
         secondary,
-      });
+      };
     } catch (e) {
-      setCheckResult({
+      return {
         diagnostics: [],
         error: (e as Error).message,
         secondary: null,
-      });
+      };
     }
   }, [deferredSource, secondaryTool]);
 

--- a/playground/src/Editor/SourceEditor.tsx
+++ b/playground/src/Editor/SourceEditor.tsx
@@ -5,7 +5,7 @@
 import Editor, { BeforeMount, Monaco } from "@monaco-editor/react";
 import { MarkerSeverity, MarkerTag } from "monaco-editor";
 import { useCallback, useEffect, useRef } from "react";
-import { Diagnostic } from "../pkg";
+import { Diagnostic } from "../pkg/ruff_wasm";
 import { Theme } from "./theme";
 
 export default function SourceEditor({

--- a/playground/src/Editor/theme.ts
+++ b/playground/src/Editor/theme.ts
@@ -1,12 +1,14 @@
 /**
  * Light and dark mode theming.
  */
-import { useEffect, useState } from "react";
+import { useState } from "react";
 
 export type Theme = "dark" | "light";
 
 export function useTheme(): [Theme, (theme: Theme) => void] {
-  const [localTheme, setLocalTheme] = useState<Theme>("light");
+  const [localTheme, setLocalTheme] = useState<Theme>(() =>
+    detectInitialTheme(),
+  );
 
   const setTheme = (mode: Theme) => {
     if (mode === "dark") {
@@ -18,18 +20,18 @@ export function useTheme(): [Theme, (theme: Theme) => void] {
     setLocalTheme(mode);
   };
 
-  useEffect(() => {
-    const initialTheme = localStorage.getItem("theme");
-    if (initialTheme === "dark") {
-      setTheme("dark");
-    } else if (initialTheme === "light") {
-      setTheme("light");
-    } else if (window.matchMedia("(prefers-color-scheme: dark)").matches) {
-      setTheme("dark");
-    } else {
-      setTheme("light");
-    }
-  }, []);
-
   return [localTheme, setTheme];
+}
+
+function detectInitialTheme(): Theme {
+  const initialTheme = localStorage.getItem("theme");
+  if (initialTheme === "dark") {
+    return "dark";
+  } else if (initialTheme === "light") {
+    return "light";
+  } else if (window.matchMedia("(prefers-color-scheme: dark)").matches) {
+    return "dark";
+  } else {
+    return "light";
+  }
 }

--- a/playground/src/main.tsx
+++ b/playground/src/main.tsx
@@ -1,46 +1,10 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
-import Editor from "./Editor";
 import "./index.css";
-import { loader } from "@monaco-editor/react";
-import { setupMonaco } from "./Editor/setupMonaco";
-import { restore, stringify } from "./Editor/settings";
-import { DEFAULT_PYTHON_SOURCE } from "./constants";
-import init, { Workspace } from "./ruff";
+import Chrome from "./Editor/Chrome";
 
-startPlayground()
-  .then(({ sourceCode, settings, ruffVersion }) => {
-    ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
-      <React.StrictMode>
-        <Editor
-          initialSettings={settings}
-          initialSource={sourceCode}
-          ruffVersion={ruffVersion}
-        />
-      </React.StrictMode>,
-    );
-  })
-  .catch((error) => console.error("Failed to start playground", error));
-
-// Run once during startup. Initializes monaco, loads the wasm file, and restores the previous editor state.
-async function startPlayground(): Promise<{
-  sourceCode: string;
-  settings: string;
-  ruffVersion: string;
-}> {
-  const initialized = init();
-  loader.init().then(setupMonaco);
-  await initialized;
-
-  const response = await restore();
-  const [settingsSource, pythonSource] = response ?? [
-    stringify(Workspace.defaultSettings()),
-    DEFAULT_PYTHON_SOURCE,
-  ];
-
-  return {
-    sourceCode: pythonSource,
-    settings: settingsSource,
-    ruffVersion: Workspace.version(),
-  };
-}
+ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
+  <React.StrictMode>
+    <Chrome />
+  </React.StrictMode>,
+);

--- a/playground/src/main.tsx
+++ b/playground/src/main.tsx
@@ -4,11 +4,41 @@ import Editor from "./Editor";
 import "./index.css";
 import { loader } from "@monaco-editor/react";
 import { setupMonaco } from "./Editor/setupMonaco";
+import { restore, stringify } from "./Editor/settings";
+import { DEFAULT_PYTHON_SOURCE } from "./constants";
+import init, { Workspace } from "./pkg";
 
-loader.init().then(setupMonaco);
+const { sourceCode, settings, ruffVersion } = await startPlayground();
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>
-    <Editor />
+    <Editor
+      initialSettings={settings}
+      initialSource={sourceCode}
+      ruffVersion={ruffVersion}
+    />
   </React.StrictMode>,
 );
+
+// Run once during startup. Initializes monaco, loads the wasm file, and restores the previous editor state.
+async function startPlayground(): Promise<{
+  sourceCode: string;
+  settings: string;
+  ruffVersion: string;
+}> {
+  const initialized = init();
+  loader.init().then(setupMonaco);
+  await initialized;
+
+  const response = await restore();
+  const [settingsSource, pythonSource] = response ?? [
+    stringify(Workspace.defaultSettings()),
+    DEFAULT_PYTHON_SOURCE,
+  ];
+
+  return {
+    sourceCode: pythonSource,
+    settings: settingsSource,
+    ruffVersion: Workspace.version(),
+  };
+}

--- a/playground/src/main.tsx
+++ b/playground/src/main.tsx
@@ -6,19 +6,21 @@ import { loader } from "@monaco-editor/react";
 import { setupMonaco } from "./Editor/setupMonaco";
 import { restore, stringify } from "./Editor/settings";
 import { DEFAULT_PYTHON_SOURCE } from "./constants";
-import init, { Workspace } from "./pkg";
+import init, { Workspace } from "./ruff";
 
-const { sourceCode, settings, ruffVersion } = await startPlayground();
-
-ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
-  <React.StrictMode>
-    <Editor
-      initialSettings={settings}
-      initialSource={sourceCode}
-      ruffVersion={ruffVersion}
-    />
-  </React.StrictMode>,
-);
+startPlayground()
+  .then(({ sourceCode, settings, ruffVersion }) => {
+    ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
+      <React.StrictMode>
+        <Editor
+          initialSettings={settings}
+          initialSource={sourceCode}
+          ruffVersion={ruffVersion}
+        />
+      </React.StrictMode>,
+    );
+  })
+  .catch((error) => console.error("Failed to start playground", error));
 
 // Run once during startup. Initializes monaco, loads the wasm file, and restores the previous editor state.
 async function startPlayground(): Promise<{


### PR DESCRIPTION
## Summary

The primary usage of effects is to interact with an external system. We don't have this. That's why this PR replaces all
`useEffect` usages with better suited hooks or removes them alltogether. See https://react.dev/learn/you-might-not-need-an-effect

## Test Plan

* Made changes
* Reload the editor
* Verified that changes are persisted
* Changed the theme to dark mode and reloaded the editor. Theme was persisted

I wasn't able to test sharing. The wrangler server goes up to 100% CPU usage whenever I hit share with or without my changes... 
