### PR TITLE
[`pydoclint`] Consider `DOC201` satisfied if docstring begins with "Returns"

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pydoclint/DOC201_google.py
+++ b/crates/ruff_linter/resources/test/fixtures/pydoclint/DOC201_google.py
@@ -92,3 +92,9 @@ class Baz:
 def f():
     """Returns 1."""
     return 1
+
+
+# OK
+def f():
+    """Return 1."""
+    return 1

--- a/crates/ruff_linter/resources/test/fixtures/pydoclint/DOC201_google.py
+++ b/crates/ruff_linter/resources/test/fixtures/pydoclint/DOC201_google.py
@@ -98,3 +98,14 @@ def f():
 def f():
     """Return 1."""
     return 1
+
+
+# OK
+def f(num: int):
+    """
+    Returns 1.
+
+    Args:
+        num (int): A number
+    """
+    return 1

--- a/crates/ruff_linter/resources/test/fixtures/pydoclint/DOC201_google.py
+++ b/crates/ruff_linter/resources/test/fixtures/pydoclint/DOC201_google.py
@@ -102,8 +102,7 @@ def f():
 
 # OK
 def f(num: int):
-    """
-    Returns 1.
+    """Returns 1.
 
     Args:
         num (int): A number

--- a/crates/ruff_linter/resources/test/fixtures/pydoclint/DOC201_google.py
+++ b/crates/ruff_linter/resources/test/fixtures/pydoclint/DOC201_google.py
@@ -86,3 +86,9 @@ class Baz:
             num (int): A number
         """
         return 'test'
+
+
+# OK
+def f():
+    """Returns 1."""
+    return 1

--- a/crates/ruff_linter/resources/test/fixtures/pydoclint/DOC402_google.py
+++ b/crates/ruff_linter/resources/test/fixtures/pydoclint/DOC402_google.py
@@ -77,3 +77,14 @@ def f():
 def f():
     """Yield 1."""
     yield 1
+
+
+# OK
+def f(num: int):
+    """
+    Yields 1.
+
+    Args:
+        num (int): A number
+    """
+    yield 1

--- a/crates/ruff_linter/resources/test/fixtures/pydoclint/DOC402_google.py
+++ b/crates/ruff_linter/resources/test/fixtures/pydoclint/DOC402_google.py
@@ -66,3 +66,14 @@ def test():
     """Do something."""
     yield from range(10)
 
+
+# OK
+def f():
+    """Yields 1."""
+    yield 1
+
+
+# OK
+def f():
+    """Yield 1."""
+    yield 1

--- a/crates/ruff_linter/resources/test/fixtures/pydoclint/DOC402_google.py
+++ b/crates/ruff_linter/resources/test/fixtures/pydoclint/DOC402_google.py
@@ -81,8 +81,7 @@ def f():
 
 # OK
 def f(num: int):
-    """
-    Yields 1.
+    """Yields 1.
 
     Args:
         num (int): A number

--- a/crates/ruff_linter/src/checkers/ast/analyze/definitions.rs
+++ b/crates/ruff_linter/src/checkers/ast/analyze/definitions.rs
@@ -328,6 +328,7 @@ pub(crate) fn definitions(checker: &mut Checker) {
                     pydoclint::rules::check_docstring(
                         checker,
                         definition,
+                        &docstring,
                         &section_contexts,
                         checker.settings.pydocstyle.convention(),
                     );

--- a/crates/ruff_linter/src/rules/pydoclint/rules/check_docstring.rs
+++ b/crates/ruff_linter/src/rules/pydoclint/rules/check_docstring.rs
@@ -651,7 +651,7 @@ fn is_exception_or_base_exception(qualified_name: &QualifiedName) -> bool {
 }
 
 fn starts_with_returns(docstring: &Docstring) -> bool {
-    if let Some(first_word) = docstring.body().as_str().split(" ").next() {
+    if let Some(first_word) = docstring.body().as_str().split(' ').next() {
         return first_word == "Returns";
     }
     false


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Resolves #12636

Consider docstrings which begin with the word "Returns" as having satisfactorily documented they're returns. For example
```python
def f():
    """Returns 1."""
    return 1
```
is valid.

## Test Plan

Added example to test fixture.
