### PR TITLE
Update broken links in the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,14 +29,14 @@ An extremely fast Python linter and code formatter, written in Rust.
 - 🐍 Installable via `pip`
 - 🛠️ `pyproject.toml` support
 - 🤝 Python 3.13 compatibility
-- ⚖️ Drop-in parity with [Flake8](https://docs.astral.sh/ruff/faq/#how-does-ruff-compare-to-flake8), isort, and Black
+- ⚖️ Drop-in parity with [Flake8](https://docs.astral.sh/ruff/faq/#how-does-ruffs-linter-compare-to-flake8), isort, and [Black](https://docs.astral.sh/ruff/faq/#how-does-ruffs-formatter-compare-to-black)
 - 📦 Built-in caching, to avoid re-analyzing unchanged files
 - 🔧 Fix support, for automatic error correction (e.g., automatically remove unused imports)
 - 📏 Over [800 built-in rules](https://docs.astral.sh/ruff/rules/), with native re-implementations
     of popular Flake8 plugins, like flake8-bugbear
 - ⌨️ First-party [editor integrations](https://docs.astral.sh/ruff/integrations/) for
     [VS Code](https://github.com/astral-sh/ruff-vscode) and [more](https://docs.astral.sh/ruff/editors/setup)
-- 🌎 Monorepo-friendly, with [hierarchical and cascading configuration](https://docs.astral.sh/ruff/configuration/#pyprojecttoml-discovery)
+- 🌎 Monorepo-friendly, with [hierarchical and cascading configuration](https://docs.astral.sh/ruff/configuration/#config-file-discovery)
 
 Ruff aims to be orders of magnitude faster than alternative tools while integrating more
 functionality behind a single, common interface.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -381,7 +381,7 @@ You can also change the default selection using the [`include`](settings.md#incl
 Ruff has built-in support for [Jupyter Notebooks](https://jupyter.org/).
 
 !!! info
-    Notebooks are linted and formatted by default when using [preview mode](preview).
+    Notebooks are linted and formatted by default when using [preview mode](preview.md).
     You can opt-out of notebook linting and formatting by adding `*.ipynb` to [`extend-exclude`](settings.md#extend-exclude).
 
 To opt in to linting and formatting Jupyter Notebook (`.ipynb`) files, add the `*.ipynb` pattern to

--- a/docs/linter.md
+++ b/docs/linter.md
@@ -235,9 +235,8 @@ You may use prefixes to select rules as well, e.g., `F` can be used to promote f
 
 ### Disabling fixes
 
-To limit the set of rules that Ruff should fix, use the [`lint.fixable`](settings.md#lint_fixable) and
-[`lint.unfixable`](settings.md#lint_unfixable) settings, along with their [`lint.extend-fixable`](settings.md#lint_extend-fixable)
-and [`lint.extend-unfixable`](settings.md#lint_extend-unfixable) variants.
+To limit the set of rules that Ruff should fix, use the [`lint.fixable`](settings.md#lint_fixable)
+or [`lint.extend-fixable`](settings.md#lint_extend-fixable), and [`lint.unfixable`](settings.md#lint_unfixable) settings.
 
 For example, the following configuration would enable fixes for all rules except
 [`unused-imports`](rules/unused-import.md) (`F401`):

--- a/scripts/generate_mkdocs.py
+++ b/scripts/generate_mkdocs.py
@@ -58,14 +58,17 @@ SECTIONS: list[Section] = [
 LINK_REWRITES: dict[str, str] = {
     "https://docs.astral.sh/ruff/": "index.md",
     "https://docs.astral.sh/ruff/configuration/": "configuration.md",
-    "https://docs.astral.sh/ruff/configuration/#pyprojecttoml-discovery": (
-        "configuration.md#pyprojecttoml-discovery"
+    "https://docs.astral.sh/ruff/configuration/#config-file-discovery": (
+        "configuration.md#config-file-discovery"
     ),
     "https://docs.astral.sh/ruff/contributing/": "contributing.md",
     "https://docs.astral.sh/ruff/editors/setup": "editors/setup.md",
     "https://docs.astral.sh/ruff/integrations/": "integrations.md",
-    "https://docs.astral.sh/ruff/faq/#how-does-ruff-compare-to-flake8": (
-        "faq.md#how-does-ruff-compare-to-flake8"
+    "https://docs.astral.sh/ruff/faq/#how-does-ruffs-linter-compare-to-flake8": (
+        "faq.md#how-does-ruffs-linter-compare-to-flake8"
+    ),
+    "https://docs.astral.sh/ruff/faq/#how-does-ruffs-formatter-compare-to-black": (
+        "faq.md#how-does-ruffs-formatter-compare-to-black"
     ),
     "https://docs.astral.sh/ruff/installation/": "installation.md",
     "https://docs.astral.sh/ruff/rules/": "rules.md",


### PR DESCRIPTION
## Summary

Running `mkdocs server -f mkdocs.insiders.yml` gave warnings about these broken links.

## Test plan

I built the docs locally and verified that the updated links work properly.