### PR TITLE
Disable testing `ruff_benchmark` by default

### DIFF
--- a/crates/ruff_benchmark/Cargo.toml
+++ b/crates/ruff_benchmark/Cargo.toml
@@ -13,6 +13,7 @@ license = { workspace = true }
 
 [lib]
 bench = false
+test = false
 doctest = false
 
 [[bench]]


### PR DESCRIPTION
## Summary

Part of https://github.com/astral-sh/ruff/issues/12662

`ruff_benchmark` contains no tests. Remove it from the crates that are tested by default when running `cargo test`. It remains possible to run the (non-existing) tests with `cargo test -p ruff_benchmark).

## Test Plan

`cargo test`. Verified that `ruff_benchmark` doesn't show up in the list of built crates
