### PR TITLE
Revert "Remove criterion/codspeed compat layer (#12524)"

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -616,7 +616,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: "Build benchmarks"
-        run: cargo codspeed build -p ruff_benchmark
+        run: cargo codspeed build --features codspeed -p ruff_benchmark
 
       - name: "Run benchmarks"
         uses: CodSpeedHQ/action@v3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2149,6 +2149,7 @@ name = "ruff_benchmark"
 version = "0.0.0"
 dependencies = [
  "codspeed-criterion-compat",
+ "criterion",
  "mimalloc",
  "once_cell",
  "red_knot_workspace",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ console_error_panic_hook = { version = "0.1.7" }
 console_log = { version = "1.0.0" }
 countme = { version = "3.0.1" }
 compact_str = "0.8.0"
+criterion = { version = "0.5.1", default-features = false }
 crossbeam = { version = "0.8.4" }
 dashmap = { version = "6.0.1" }
 drop_bomb = { version = "0.1.5" }
@@ -156,7 +157,7 @@ zip = { version = "0.6.6", default-features = false, features = ["zstd"] }
 [workspace.lints.rust]
 unsafe_code = "warn"
 unreachable_pub = "warn"
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(fuzzing)'] }
+unexpected_cfgs = { level = "warn", check-cfg = ["cfg(fuzzing)", "cfg(codspeed)"] }
 
 [workspace.lints.clippy]
 pedantic = { level = "warn", priority = -2 }

--- a/crates/ruff_benchmark/Cargo.toml
+++ b/crates/ruff_benchmark/Cargo.toml
@@ -42,7 +42,8 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 url = { workspace = true }
 ureq = { workspace = true }
-codspeed-criterion-compat = { workspace = true, default-features = false }
+criterion = { workspace = true, default-features = false }
+codspeed-criterion-compat = { workspace = true, default-features = false, optional = true }
 
 [dev-dependencies]
 ruff_db = { workspace = true }
@@ -55,6 +56,9 @@ red_knot_workspace = { workspace = true }
 
 [lints]
 workspace = true
+
+[features]
+codspeed = ["codspeed-criterion-compat"]
 
 [target.'cfg(target_os = "windows")'.dev-dependencies]
 mimalloc = { workspace = true }

--- a/crates/ruff_benchmark/benches/formatter.rs
+++ b/crates/ruff_benchmark/benches/formatter.rs
@@ -1,9 +1,8 @@
 use std::path::Path;
 
-use codspeed_criterion_compat::{
+use ruff_benchmark::criterion::{
     criterion_group, criterion_main, BenchmarkId, Criterion, Throughput,
 };
-
 use ruff_benchmark::{TestCase, TestFile, TestFileDownloadError};
 use ruff_python_formatter::{format_module_ast, PreviewMode, PyFormatOptions};
 use ruff_python_parser::{parse, Mode};

--- a/crates/ruff_benchmark/benches/lexer.rs
+++ b/crates/ruff_benchmark/benches/lexer.rs
@@ -1,7 +1,6 @@
-use codspeed_criterion_compat::{
+use ruff_benchmark::criterion::{
     criterion_group, criterion_main, measurement::WallTime, BenchmarkId, Criterion, Throughput,
 };
-
 use ruff_benchmark::{TestCase, TestFile, TestFileDownloadError};
 use ruff_python_parser::{lexer, Mode, TokenKind};
 

--- a/crates/ruff_benchmark/benches/linter.rs
+++ b/crates/ruff_benchmark/benches/linter.rs
@@ -1,8 +1,6 @@
-use codspeed_criterion_compat::{
-    self as criterion, criterion_group, criterion_main, BenchmarkGroup, BenchmarkId, Criterion,
-    Throughput,
+use ruff_benchmark::criterion::{
+    criterion_group, criterion_main, BenchmarkGroup, BenchmarkId, Criterion, Throughput,
 };
-use criterion::measurement;
 use ruff_benchmark::{TestCase, TestFile, TestFileDownloadError};
 use ruff_linter::linter::{lint_only, ParseSource};
 use ruff_linter::rule_selector::PreviewOptions;
@@ -46,7 +44,7 @@ fn create_test_cases() -> Result<Vec<TestCase>, TestFileDownloadError> {
     ])
 }
 
-fn benchmark_linter(mut group: BenchmarkGroup<measurement::WallTime>, settings: &LinterSettings) {
+fn benchmark_linter(mut group: BenchmarkGroup, settings: &LinterSettings) {
     let test_cases = create_test_cases().unwrap();
 
     for case in test_cases {

--- a/crates/ruff_benchmark/benches/parser.rs
+++ b/crates/ruff_benchmark/benches/parser.rs
@@ -1,7 +1,6 @@
-use codspeed_criterion_compat::{
+use ruff_benchmark::criterion::{
     criterion_group, criterion_main, measurement::WallTime, BenchmarkId, Criterion, Throughput,
 };
-
 use ruff_benchmark::{TestCase, TestFile, TestFileDownloadError};
 use ruff_python_ast::statement_visitor::{walk_stmt, StatementVisitor};
 use ruff_python_ast::Stmt;

--- a/crates/ruff_benchmark/benches/red_knot.rs
+++ b/crates/ruff_benchmark/benches/red_knot.rs
@@ -1,9 +1,8 @@
 #![allow(clippy::disallowed_names)]
 
-use codspeed_criterion_compat::{criterion_group, criterion_main, BatchSize, Criterion};
-
 use red_knot_workspace::db::RootDatabase;
 use red_knot_workspace::workspace::WorkspaceMetadata;
+use ruff_benchmark::criterion::{criterion_group, criterion_main, BatchSize, Criterion};
 use ruff_benchmark::TestFile;
 use ruff_db::files::{system_path_to_file, File};
 use ruff_db::program::{ProgramSettings, SearchPathSettings, TargetVersion};

--- a/crates/ruff_benchmark/src/criterion.rs
+++ b/crates/ruff_benchmark/src/criterion.rs
@@ -1,0 +1,13 @@
+//! This module re-exports the criterion API but picks the right backend depending on whether
+//! the benchmarks are built to run locally or with codspeed.
+//! The compat layer is required because codspeed doesn't support all platforms.
+//! See [#12662](https://github.com/astral-sh/ruff/issues/12662)
+
+#[cfg(not(codspeed))]
+pub use criterion::*;
+
+#[cfg(not(codspeed))]
+pub type BenchmarkGroup<'a> = criterion::BenchmarkGroup<'a, measurement::WallTime>;
+
+#[cfg(codspeed)]
+pub use codspeed_criterion_compat::*;

--- a/crates/ruff_benchmark/src/lib.rs
+++ b/crates/ruff_benchmark/src/lib.rs
@@ -1,3 +1,5 @@
+pub mod criterion;
+
 use std::fmt::{Display, Formatter};
 use std::path::PathBuf;
 use std::process::Command;


### PR DESCRIPTION
## Summary

Revert https://github.com/astral-sh/ruff/pull/12524 because codspeed fails to build on less common platforms. 

Fixes https://github.com/astral-sh/ruff/issues/12662


