### PR TITLE
Fix module resolver symlink test on macOs

### DIFF
--- a/crates/red_knot_module_resolver/src/resolver.rs
+++ b/crates/red_knot_module_resolver/src/resolver.rs
@@ -639,6 +639,7 @@ impl PackageKind {
 
 #[cfg(test)]
 mod tests {
+    use anyhow::Context;
     use ruff_db::files::{system_path_to_file, File, FilePath};
     use ruff_db::system::DbWithTestSystem;
     use ruff_db::testing::{
@@ -1175,7 +1176,11 @@ mod tests {
         let mut db = TestDb::new();
 
         let temp_dir = tempfile::tempdir()?;
-        let root = SystemPath::from_std_path(temp_dir.path()).unwrap();
+        let root = temp_dir
+            .path()
+            .canonicalize()
+            .context("Failed to canonicalize temp dir")?;
+        let root = SystemPath::from_std_path(&root).unwrap();
         db.use_system(OsSystem::new(root));
 
         let src = root.join("src");


### PR DESCRIPTION
## Summary

Fixes https://github.com/astral-sh/ruff/issues/12656

`tempdir` on macOs uses a symlink and https://github.com/astral-sh/ruff/pull/12634 started to canonicalize search paths. 
That's why we need to update this test to use the canonicialized path of the temp directory. 

## Test Plan

`cargo test -p red_knot_module_resolver` passes on my mac
