### PR TITLE
[red-knot] Eagerly validate search paths before constructing `Program`s

### DIFF
--- a/crates/red_knot/src/main.rs
+++ b/crates/red_knot/src/main.rs
@@ -15,7 +15,7 @@ use red_knot_workspace::db::RootDatabase;
 use red_knot_workspace::watch;
 use red_knot_workspace::watch::WorkspaceWatcher;
 use red_knot_workspace::workspace::WorkspaceMetadata;
-use ruff_db::program::{ProgramSettings, SearchPathSettings};
+use ruff_db::program::{RawProgramSettings, RawSearchPathSettings};
 use ruff_db::system::{OsSystem, System, SystemPathBuf};
 use target_version::TargetVersion;
 use verbosity::{Verbosity, VerbosityLevel};
@@ -145,9 +145,9 @@ pub fn main() -> anyhow::Result<()> {
     };
 
     // TODO: Respect the settings from the workspace metadata. when resolving the program settings.
-    let program_settings = ProgramSettings {
+    let program_settings = RawProgramSettings {
         target_version: target_version.into(),
-        search_paths: SearchPathSettings {
+        search_paths: RawSearchPathSettings {
             extra_paths,
             src_root: workspace_metadata.root().to_path_buf(),
             custom_typeshed: custom_typeshed_dir,
@@ -157,7 +157,7 @@ pub fn main() -> anyhow::Result<()> {
 
     // TODO: Use the `program_settings` to compute the key for the database's persistent
     //   cache and load the cache if it exists.
-    let mut db = RootDatabase::new(workspace_metadata, program_settings, system);
+    let mut db = RootDatabase::new(workspace_metadata, program_settings, system)?;
 
     let (main_loop, main_loop_cancellation_token) = MainLoop::new(verbosity);
 

--- a/crates/red_knot_module_resolver/src/settings_resolution.rs
+++ b/crates/red_knot_module_resolver/src/settings_resolution.rs
@@ -1,0 +1,105 @@
+use rustc_hash::{FxBuildHasher, FxHashSet};
+use salsa::Durability;
+
+use ruff_db::files::FileRootKind;
+use ruff_db::program::{Program, RawProgramSettings, RawSearchPathSettings, SearchPathSettings};
+
+use crate::db::Db;
+use crate::path::{SearchPath, SearchPathValidationError};
+
+/// Validate and normalize the raw settings given by the user
+/// into settings we can use for module resolution
+///
+/// This method also implements the typing spec's [module resolution order].
+///
+/// [module resolution order]: https://typing.readthedocs.io/en/latest/spec/distributing.html#import-resolution-ordering
+pub fn try_resolve_module_resolution_settings(
+    db: &dyn Db,
+    raw_settings: RawSearchPathSettings,
+) -> Result<SearchPathSettings, SearchPathValidationError> {
+    let RawSearchPathSettings {
+        extra_paths,
+        src_root,
+        custom_typeshed,
+        site_packages,
+    } = raw_settings;
+
+    let custom_typeshed = custom_typeshed.as_deref();
+
+    if !extra_paths.is_empty() {
+        tracing::info!("Extra search paths: {extra_paths:?}");
+    }
+
+    if let Some(custom_typeshed) = custom_typeshed {
+        tracing::info!("Custom typeshed directory: {custom_typeshed}");
+    }
+
+    if !site_packages.is_empty() {
+        tracing::info!("Site-packages directories: {site_packages:?}");
+    }
+
+    let system = db.system();
+    let files = db.files();
+
+    let mut static_search_paths = vec![];
+
+    for path in extra_paths {
+        files.try_add_root(db.upcast(), &path, FileRootKind::LibrarySearchPath);
+        static_search_paths.push(SearchPath::extra(system, path.clone())?);
+    }
+
+    static_search_paths.push(SearchPath::first_party(system, src_root.clone())?);
+
+    static_search_paths.push(if let Some(custom_typeshed) = custom_typeshed {
+        files.try_add_root(
+            db.upcast(),
+            custom_typeshed,
+            FileRootKind::LibrarySearchPath,
+        );
+        SearchPath::custom_stdlib(db, custom_typeshed.to_path_buf())?
+    } else {
+        SearchPath::vendored_stdlib()
+    });
+
+    // TODO vendor typeshed's third-party stubs as well as the stdlib and fallback to them as a final step
+
+    // Filter out module resolution paths that point to the same directory on disk (the same invariant maintained by [`sys.path` at runtime]).
+    // (Paths may, however, *overlap* -- e.g. you could have both `src/` and `src/foo`
+    // as module resolution paths simultaneously.)
+    //
+    // [`sys.path` at runtime]: https://docs.python.org/3/library/site.html#module-site
+    // This code doesn't use an `IndexSet` because the key is the system path and not the search root.
+    let mut seen_paths =
+        FxHashSet::with_capacity_and_hasher(static_search_paths.len(), FxBuildHasher);
+
+    static_search_paths.retain(|path| {
+        if let Some(path) = path.as_system_path() {
+            seen_paths.insert(path.to_path_buf())
+        } else {
+            true
+        }
+    });
+
+    Ok(SearchPathSettings {
+        static_search_paths: static_search_paths
+            .into_iter()
+            .map(ruff_db::program::SearchPath::from)
+            .collect(),
+        site_packages_paths: site_packages.clone(),
+    })
+}
+
+pub fn program_from_raw_settings(
+    db: &dyn Db,
+    settings: RawProgramSettings,
+) -> Result<Program, SearchPathValidationError> {
+    let RawProgramSettings {
+        target_version,
+        search_paths,
+    } = settings;
+    try_resolve_module_resolution_settings(db, search_paths).map(|search_path_settings| {
+        Program::builder(target_version, search_path_settings)
+            .durability(Durability::HIGH)
+            .new(db)
+    })
+}

--- a/crates/red_knot_module_resolver/src/testing.rs
+++ b/crates/red_knot_module_resolver/src/testing.rs
@@ -1,8 +1,9 @@
-use ruff_db::program::{Program, SearchPathSettings, TargetVersion};
+use ruff_db::program::{RawProgramSettings, RawSearchPathSettings, TargetVersion};
 use ruff_db::system::{DbWithTestSystem, SystemPath, SystemPathBuf};
 use ruff_db::vendored::VendoredPathBuf;
 
 use crate::db::tests::TestDb;
+use crate::program_from_raw_settings;
 
 /// A test case for the module resolver.
 ///
@@ -219,16 +220,19 @@ impl TestCaseBuilder<MockedTypeshed> {
         let src = Self::write_mock_directory(&mut db, "/src", first_party_files);
         let typeshed = Self::build_typeshed_mock(&mut db, &typeshed_option);
 
-        Program::new(
+        program_from_raw_settings(
             &db,
-            target_version,
-            SearchPathSettings {
-                extra_paths: vec![],
-                src_root: src.clone(),
-                custom_typeshed: Some(typeshed.clone()),
-                site_packages: vec![site_packages.clone()],
+            RawProgramSettings {
+                target_version,
+                search_paths: RawSearchPathSettings {
+                    extra_paths: vec![],
+                    src_root: src.clone(),
+                    custom_typeshed: Some(typeshed.clone()),
+                    site_packages: vec![site_packages.clone()],
+                },
             },
-        );
+        )
+        .unwrap();
 
         TestCase {
             db,
@@ -272,16 +276,19 @@ impl TestCaseBuilder<VendoredTypeshed> {
             Self::write_mock_directory(&mut db, "/site-packages", site_packages_files);
         let src = Self::write_mock_directory(&mut db, "/src", first_party_files);
 
-        Program::new(
+        program_from_raw_settings(
             &db,
-            target_version,
-            SearchPathSettings {
-                extra_paths: vec![],
-                src_root: src.clone(),
-                custom_typeshed: None,
-                site_packages: vec![site_packages.clone()],
+            RawProgramSettings {
+                target_version,
+                search_paths: RawSearchPathSettings {
+                    extra_paths: vec![],
+                    src_root: src.clone(),
+                    custom_typeshed: None,
+                    site_packages: vec![site_packages.clone()],
+                },
             },
-        );
+        )
+        .unwrap();
 
         TestCase {
             db,

--- a/crates/red_knot_python_semantic/src/semantic_model.rs
+++ b/crates/red_knot_python_semantic/src/semantic_model.rs
@@ -162,9 +162,10 @@ impl HasTy for ast::Alias {
 
 #[cfg(test)]
 mod tests {
+    use red_knot_module_resolver::program_from_raw_settings;
     use ruff_db::files::system_path_to_file;
     use ruff_db::parsed::parsed_module;
-    use ruff_db::program::{Program, SearchPathSettings, TargetVersion};
+    use ruff_db::program::{RawProgramSettings, RawSearchPathSettings, TargetVersion};
     use ruff_db::system::{DbWithTestSystem, SystemPathBuf};
 
     use crate::db::tests::TestDb;
@@ -173,16 +174,25 @@ mod tests {
 
     fn setup_db() -> TestDb {
         let db = TestDb::new();
-        Program::new(
+
+        let src_root = SystemPathBuf::from("/src");
+        db.memory_file_system()
+            .create_directory_all(&src_root)
+            .unwrap();
+
+        program_from_raw_settings(
             &db,
-            TargetVersion::Py38,
-            SearchPathSettings {
-                extra_paths: vec![],
-                src_root: SystemPathBuf::from("/src"),
-                site_packages: vec![],
-                custom_typeshed: None,
+            RawProgramSettings {
+                target_version: TargetVersion::default(),
+                search_paths: RawSearchPathSettings {
+                    extra_paths: vec![],
+                    src_root,
+                    site_packages: vec![],
+                    custom_typeshed: None,
+                },
             },
-        );
+        )
+        .unwrap();
 
         db
     }

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -1495,9 +1495,10 @@ impl<'db> TypeInferenceBuilder<'db> {
 
 #[cfg(test)]
 mod tests {
+    use red_knot_module_resolver::program_from_raw_settings;
     use ruff_db::files::{system_path_to_file, File};
     use ruff_db::parsed::parsed_module;
-    use ruff_db::program::{Program, SearchPathSettings, TargetVersion};
+    use ruff_db::program::{RawProgramSettings, RawSearchPathSettings, TargetVersion};
     use ruff_db::system::{DbWithTestSystem, SystemPathBuf};
     use ruff_db::testing::assert_function_query_was_not_run;
     use ruff_python_ast::name::Name;
@@ -1513,33 +1514,52 @@ mod tests {
     fn setup_db() -> TestDb {
         let db = TestDb::new();
 
-        Program::new(
+        let src_root = SystemPathBuf::from("/src");
+        db.memory_file_system()
+            .create_directory_all(&src_root)
+            .unwrap();
+
+        program_from_raw_settings(
             &db,
-            TargetVersion::Py38,
-            SearchPathSettings {
-                extra_paths: Vec::new(),
-                src_root: SystemPathBuf::from("/src"),
-                site_packages: vec![],
-                custom_typeshed: None,
+            RawProgramSettings {
+                target_version: TargetVersion::default(),
+                search_paths: RawSearchPathSettings {
+                    extra_paths: vec![],
+                    src_root,
+                    site_packages: vec![],
+                    custom_typeshed: None,
+                },
             },
-        );
+        )
+        .unwrap();
 
         db
     }
 
     fn setup_db_with_custom_typeshed(typeshed: &str) -> TestDb {
-        let db = TestDb::new();
+        let mut db = TestDb::new();
 
-        Program::new(
+        let src_root = SystemPathBuf::from("/src");
+        db.memory_file_system()
+            .create_directory_all(&src_root)
+            .unwrap();
+
+        let typeshed = SystemPathBuf::from(typeshed);
+        db.write_file(typeshed.join("stdlib/VERSIONS"), "").unwrap();
+
+        program_from_raw_settings(
             &db,
-            TargetVersion::Py38,
-            SearchPathSettings {
-                extra_paths: Vec::new(),
-                src_root: SystemPathBuf::from("/src"),
-                site_packages: vec![],
-                custom_typeshed: Some(SystemPathBuf::from(typeshed)),
+            RawProgramSettings {
+                target_version: TargetVersion::default(),
+                search_paths: RawSearchPathSettings {
+                    extra_paths: vec![],
+                    src_root,
+                    site_packages: vec![],
+                    custom_typeshed: Some(typeshed),
+                },
             },
-        );
+        )
+        .unwrap();
 
         db
     }

--- a/crates/red_knot_server/src/session.rs
+++ b/crates/red_knot_server/src/session.rs
@@ -11,7 +11,7 @@ use lsp_types::{ClientCapabilities, Url};
 use red_knot_workspace::db::RootDatabase;
 use red_knot_workspace::workspace::WorkspaceMetadata;
 use ruff_db::files::{system_path_to_file, File};
-use ruff_db::program::{ProgramSettings, SearchPathSettings, TargetVersion};
+use ruff_db::program::{RawProgramSettings, RawSearchPathSettings, TargetVersion};
 use ruff_db::system::SystemPath;
 
 use crate::edit::{DocumentKey, NotebookDocument};
@@ -69,16 +69,16 @@ impl Session {
 
             let metadata = WorkspaceMetadata::from_path(system_path, &system)?;
             // TODO(dhruvmanila): Get the values from the client settings
-            let program_settings = ProgramSettings {
+            let program_settings = RawProgramSettings {
                 target_version: TargetVersion::default(),
-                search_paths: SearchPathSettings {
+                search_paths: RawSearchPathSettings {
                     extra_paths: vec![],
                     src_root: system_path.to_path_buf(),
                     site_packages: vec![],
                     custom_typeshed: None,
                 },
             };
-            workspaces.insert(path, RootDatabase::new(metadata, program_settings, system));
+            workspaces.insert(path, RootDatabase::new(metadata, program_settings, system)?);
         }
 
         Ok(Self {

--- a/crates/red_knot_wasm/src/lib.rs
+++ b/crates/red_knot_wasm/src/lib.rs
@@ -6,7 +6,7 @@ use wasm_bindgen::prelude::*;
 use red_knot_workspace::db::RootDatabase;
 use red_knot_workspace::workspace::WorkspaceMetadata;
 use ruff_db::files::{system_path_to_file, File};
-use ruff_db::program::{ProgramSettings, SearchPathSettings};
+use ruff_db::program::{RawProgramSettings, RawSearchPathSettings};
 use ruff_db::system::walk_directory::WalkDirectoryBuilder;
 use ruff_db::system::{
     DirectoryEntry, MemoryFileSystem, Metadata, System, SystemPath, SystemPathBuf,
@@ -44,12 +44,12 @@ impl Workspace {
         let workspace =
             WorkspaceMetadata::from_path(SystemPath::new(root), &system).map_err(into_error)?;
 
-        let program_settings = ProgramSettings {
+        let program_settings = RawProgramSettings {
             target_version: settings.target_version.into(),
-            search_paths: SearchPathSettings::default(),
+            search_paths: RawSearchPathSettings::default(),
         };
 
-        let db = RootDatabase::new(workspace, program_settings, system.clone());
+        let db = RootDatabase::new(workspace, program_settings, system.clone()).unwrap();
 
         Ok(Self { db, system })
     }

--- a/crates/red_knot_workspace/src/lint.rs
+++ b/crates/red_knot_workspace/src/lint.rs
@@ -306,8 +306,9 @@ enum AnyImportRef<'a> {
 
 #[cfg(test)]
 mod tests {
+    use red_knot_module_resolver::program_from_raw_settings;
     use ruff_db::files::system_path_to_file;
-    use ruff_db::program::{Program, SearchPathSettings, TargetVersion};
+    use ruff_db::program::{RawProgramSettings, RawSearchPathSettings, TargetVersion};
     use ruff_db::system::{DbWithTestSystem, SystemPathBuf};
 
     use super::{lint_semantic, Diagnostics};
@@ -320,16 +321,23 @@ mod tests {
     fn setup_db_with_root(src_root: SystemPathBuf) -> TestDb {
         let db = TestDb::new();
 
-        Program::new(
+        db.memory_file_system()
+            .create_directory_all(&src_root)
+            .unwrap();
+
+        program_from_raw_settings(
             &db,
-            TargetVersion::Py38,
-            SearchPathSettings {
-                extra_paths: Vec::new(),
-                src_root,
-                site_packages: vec![],
-                custom_typeshed: None,
+            RawProgramSettings {
+                target_version: TargetVersion::default(),
+                search_paths: RawSearchPathSettings {
+                    extra_paths: vec![],
+                    src_root,
+                    site_packages: vec![],
+                    custom_typeshed: None,
+                },
             },
-        );
+        )
+        .unwrap();
 
         db
     }

--- a/crates/red_knot_workspace/tests/check.rs
+++ b/crates/red_knot_workspace/tests/check.rs
@@ -2,7 +2,7 @@ use red_knot_workspace::db::RootDatabase;
 use red_knot_workspace::lint::lint_semantic;
 use red_knot_workspace::workspace::WorkspaceMetadata;
 use ruff_db::files::system_path_to_file;
-use ruff_db::program::{ProgramSettings, SearchPathSettings, TargetVersion};
+use ruff_db::program::{RawProgramSettings, RawSearchPathSettings, TargetVersion};
 use ruff_db::system::{OsSystem, SystemPathBuf};
 use std::fs;
 use std::path::PathBuf;
@@ -10,17 +10,17 @@ use std::path::PathBuf;
 fn setup_db(workspace_root: SystemPathBuf) -> anyhow::Result<RootDatabase> {
     let system = OsSystem::new(&workspace_root);
     let workspace = WorkspaceMetadata::from_path(&workspace_root, &system)?;
-    let search_paths = SearchPathSettings {
+    let search_paths = RawSearchPathSettings {
         extra_paths: vec![],
         src_root: workspace_root,
         custom_typeshed: None,
         site_packages: vec![],
     };
-    let settings = ProgramSettings {
+    let settings = RawProgramSettings {
         target_version: TargetVersion::default(),
         search_paths,
     };
-    let db = RootDatabase::new(workspace, settings, system);
+    let db = RootDatabase::new(workspace, settings, system)?;
     Ok(db)
 }
 

--- a/crates/ruff_benchmark/benches/red_knot.rs
+++ b/crates/ruff_benchmark/benches/red_knot.rs
@@ -5,9 +5,9 @@ use red_knot_workspace::workspace::WorkspaceMetadata;
 use ruff_benchmark::criterion::{criterion_group, criterion_main, BatchSize, Criterion};
 use ruff_benchmark::TestFile;
 use ruff_db::files::{system_path_to_file, File};
-use ruff_db::program::{ProgramSettings, SearchPathSettings, TargetVersion};
+use ruff_db::program::{RawProgramSettings, RawSearchPathSettings, TargetVersion};
 use ruff_db::source::source_text;
-use ruff_db::system::{MemoryFileSystem, SystemPath, TestSystem};
+use ruff_db::system::{MemoryFileSystem, SystemPath, SystemPathBuf, TestSystem};
 
 struct Case {
     db: RootDatabase,
@@ -40,19 +40,19 @@ fn setup_case() -> Case {
     ])
     .unwrap();
 
-    let src_root = SystemPath::new("/src");
-    let metadata = WorkspaceMetadata::from_path(src_root, &system).unwrap();
-    let settings = ProgramSettings {
+    let src_root = SystemPathBuf::from("/src");
+    let metadata = WorkspaceMetadata::from_path(&src_root, &system).unwrap();
+    let settings = RawProgramSettings {
         target_version: TargetVersion::Py312,
-        search_paths: SearchPathSettings {
+        search_paths: RawSearchPathSettings {
             extra_paths: vec![],
-            src_root: src_root.to_path_buf(),
+            src_root,
             site_packages: vec![],
             custom_typeshed: None,
         },
     };
 
-    let mut db = RootDatabase::new(metadata, settings, system);
+    let mut db = RootDatabase::new(metadata, settings, system).unwrap();
     let parser = system_path_to_file(&db, parser_path).unwrap();
 
     db.workspace().open_file(&mut db, parser);

--- a/crates/ruff_db/src/program.rs
+++ b/crates/ruff_db/src/program.rs
@@ -92,6 +92,11 @@ pub struct SearchPathSettings {
     /// bundled as a zip file in the binary
     pub custom_typeshed: Option<SystemPathBuf>,
 
-    /// The path to the user's `site-packages` directory, where third-party packages from ``PyPI`` are installed.
+    /// The path to the user's `site-packages` directories,
+    /// where third-party packages from ``PyPI`` are installed.
+    ///
+    /// Usually there will either be 0 or 1 site-packages paths,
+    /// but some environments are able to access both a venv's `site-packages`
+    /// and the system installation's `site-packages`.
     pub site_packages: Vec<SystemPathBuf>,
 }


### PR DESCRIPTION
## Summary

This is a prototype for _a_ way by which we could move settings resolution for search paths out of the module resolver. It may not be the _best_ way; I'm not wedded to it necessarily!

Moving settings resolution for search paths out of the module resolver enables us to validate that these settings are correct before constructing `Program` instances, which is desirable because `Program` instances should ideally store validated, normalized settings on them rather than unvalidated, unnormalized settings.

The way this PR works is that in `crates/ruff_db/src/program.rs`, new `SearchPathInner` and `SearchPath` types are added. These are extremely minimal, but in terms of the data they hold they have 1:1 correspondence with the `SearchPathInner` and `SearchPath` types in `crates/red_knot_module_resolver/path.rs`. Having public types in `ruff_db` that can be cheaply and easily converted to and from the private types in `red_knot_module_resolver` means that the `Program` struct can use a `SearchPath` type in its fields (representing a validated, normalized search path) without depending on anything from the module-resolver crate.

The module resolver, meanwhile, exposes a new public function for creating a `Program` instance from the raw, unvalidated search-path settings. This function uses internals of the module resolver to attempt to construct validated `red_knot_module_resolver::SearchPath`s, and then cheaply converts those search paths to `ruff_db::SearchPath`s in order to construct a `Program` instance.

I initially experimented with simply moving the `SearchPathInner` and `SearchPath` types out of the module resolver crate entirely and into `ruff_db`. While this is doable, it is quite painful, because validating search paths requires knowledge of the internals of the module resolver. For example: one of the validation steps we need to perform is to check that the file at `stdlib/VERSIONS` parses as a valid `VERSIONS` file if the user has given us a custom typeshed directory. Attempting to parse `VERSIONS` requires knowledge of the structure of the `VERSIONS` file, which in turn requires knowledge of the `ModuleName` type, etc. etc.

## Guide to reviewing

I would recommend looking at the changes to `ruff_db` first, then the changes to `red_knot_module_resolver`, and everything else after that.

## Test Plan

`cargo test`
