### PR TITLE
[red-knot] Rename `workspace_root` variables in the module resolver to `src_root`

### DIFF
--- a/crates/red_knot/src/main.rs
+++ b/crates/red_knot/src/main.rs
@@ -102,7 +102,7 @@ pub fn main() -> anyhow::Result<()> {
         target_version: target_version.into(),
         search_paths: SearchPathSettings {
             extra_paths,
-            workspace_root: workspace_metadata.root().to_path_buf(),
+            src_root: workspace_metadata.root().to_path_buf(),
             custom_typeshed: custom_typeshed_dir,
             site_packages: vec![],
         },

--- a/crates/red_knot/tests/file_watching.rs
+++ b/crates/red_knot/tests/file_watching.rs
@@ -179,7 +179,7 @@ where
 {
     setup_with_search_paths(setup_files, |_root, workspace_path| SearchPathSettings {
         extra_paths: vec![],
-        workspace_root: workspace_path.to_path_buf(),
+        src_root: workspace_path.to_path_buf(),
         custom_typeshed: None,
         site_packages: vec![],
     })
@@ -695,7 +695,7 @@ fn search_path() -> anyhow::Result<()> {
         setup_with_search_paths([("bar.py", "import sub.a")], |root_path, workspace_path| {
             SearchPathSettings {
                 extra_paths: vec![],
-                workspace_root: workspace_path.to_path_buf(),
+                src_root: workspace_path.to_path_buf(),
                 custom_typeshed: None,
                 site_packages: vec![root_path.join("site_packages")],
             }
@@ -755,7 +755,7 @@ fn remove_search_path() -> anyhow::Result<()> {
         setup_with_search_paths([("bar.py", "import sub.a")], |root_path, workspace_path| {
             SearchPathSettings {
                 extra_paths: vec![],
-                workspace_root: workspace_path.to_path_buf(),
+                src_root: workspace_path.to_path_buf(),
                 custom_typeshed: None,
                 site_packages: vec![root_path.join("site_packages")],
             }
@@ -1173,7 +1173,7 @@ mod unix {
             },
             |_root, workspace| SearchPathSettings {
                 extra_paths: vec![],
-                workspace_root: workspace.to_path_buf(),
+                src_root: workspace.to_path_buf(),
                 custom_typeshed: None,
                 site_packages: vec![workspace.join(".venv/lib/python3.12/site-packages")],
             },

--- a/crates/red_knot_module_resolver/src/resolver.rs
+++ b/crates/red_knot_module_resolver/src/resolver.rs
@@ -123,7 +123,7 @@ fn try_resolve_module_resolution_settings(
 
     let SearchPathSettings {
         extra_paths,
-        workspace_root,
+        src_root,
         custom_typeshed,
         site_packages,
     } = program.search_paths(db.upcast());
@@ -146,7 +146,7 @@ fn try_resolve_module_resolution_settings(
         static_search_paths.push(SearchPath::extra(system, path.clone())?);
     }
 
-    static_search_paths.push(SearchPath::first_party(system, workspace_root.clone())?);
+    static_search_paths.push(SearchPath::first_party(system, src_root.clone())?);
 
     static_search_paths.push(if let Some(custom_typeshed) = custom_typeshed.as_ref() {
         files.try_add_root(
@@ -459,7 +459,7 @@ fn resolve_name(db: &dyn Db, name: &ModuleName) -> Option<(SearchPath, File, Mod
     for search_path in resolver_settings.search_paths(db) {
         // When a builtin module is imported, standard module resolution is bypassed:
         // the module name always resolves to the stdlib module,
-        // even if there's a module of the same name in the workspace root
+        // even if there's a module of the same name in the first-party root
         // (which would normally result in the stdlib module being overridden).
         if is_builtin_module && !search_path.is_standard_library() {
             continue;
@@ -1160,7 +1160,7 @@ mod tests {
 
         let search_paths = SearchPathSettings {
             extra_paths: vec![],
-            workspace_root: src.clone(),
+            src_root: src.clone(),
             custom_typeshed: Some(custom_typeshed.clone()),
             site_packages: vec![site_packages],
         };
@@ -1664,7 +1664,7 @@ not_a_directory
             TargetVersion::default(),
             SearchPathSettings {
                 extra_paths: vec![],
-                workspace_root: SystemPathBuf::from("/src"),
+                src_root: SystemPathBuf::from("/src"),
                 custom_typeshed: None,
                 site_packages: vec![venv_site_packages, system_site_packages],
             },

--- a/crates/red_knot_module_resolver/src/testing.rs
+++ b/crates/red_knot_module_resolver/src/testing.rs
@@ -224,7 +224,7 @@ impl TestCaseBuilder<MockedTypeshed> {
             target_version,
             SearchPathSettings {
                 extra_paths: vec![],
-                workspace_root: src.clone(),
+                src_root: src.clone(),
                 custom_typeshed: Some(typeshed.clone()),
                 site_packages: vec![site_packages.clone()],
             },
@@ -277,7 +277,7 @@ impl TestCaseBuilder<VendoredTypeshed> {
             target_version,
             SearchPathSettings {
                 extra_paths: vec![],
-                workspace_root: src.clone(),
+                src_root: src.clone(),
                 custom_typeshed: None,
                 site_packages: vec![site_packages.clone()],
             },

--- a/crates/red_knot_python_semantic/src/semantic_model.rs
+++ b/crates/red_knot_python_semantic/src/semantic_model.rs
@@ -178,7 +178,7 @@ mod tests {
             TargetVersion::Py38,
             SearchPathSettings {
                 extra_paths: vec![],
-                workspace_root: SystemPathBuf::from("/src"),
+                src_root: SystemPathBuf::from("/src"),
                 site_packages: vec![],
                 custom_typeshed: None,
             },

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -1516,7 +1516,7 @@ mod tests {
             TargetVersion::Py38,
             SearchPathSettings {
                 extra_paths: Vec::new(),
-                workspace_root: SystemPathBuf::from("/src"),
+                src_root: SystemPathBuf::from("/src"),
                 site_packages: vec![],
                 custom_typeshed: None,
             },
@@ -1533,7 +1533,7 @@ mod tests {
             TargetVersion::Py38,
             SearchPathSettings {
                 extra_paths: Vec::new(),
-                workspace_root: SystemPathBuf::from("/src"),
+                src_root: SystemPathBuf::from("/src"),
                 site_packages: vec![],
                 custom_typeshed: Some(SystemPathBuf::from(typeshed)),
             },

--- a/crates/red_knot_workspace/src/lint.rs
+++ b/crates/red_knot_workspace/src/lint.rs
@@ -317,7 +317,7 @@ mod tests {
         setup_db_with_root(SystemPathBuf::from("/src"))
     }
 
-    fn setup_db_with_root(workspace_root: SystemPathBuf) -> TestDb {
+    fn setup_db_with_root(src_root: SystemPathBuf) -> TestDb {
         let db = TestDb::new();
 
         Program::new(
@@ -325,7 +325,7 @@ mod tests {
             TargetVersion::Py38,
             SearchPathSettings {
                 extra_paths: Vec::new(),
-                workspace_root,
+                src_root,
                 site_packages: vec![],
                 custom_typeshed: None,
             },

--- a/crates/red_knot_workspace/tests/check.rs
+++ b/crates/red_knot_workspace/tests/check.rs
@@ -12,7 +12,7 @@ fn setup_db(workspace_root: SystemPathBuf) -> anyhow::Result<RootDatabase> {
     let workspace = WorkspaceMetadata::from_path(&workspace_root, &system)?;
     let search_paths = SearchPathSettings {
         extra_paths: vec![],
-        workspace_root,
+        src_root: workspace_root,
         custom_typeshed: None,
         site_packages: vec![],
     };

--- a/crates/ruff_benchmark/benches/red_knot.rs
+++ b/crates/ruff_benchmark/benches/red_knot.rs
@@ -40,13 +40,13 @@ fn setup_case() -> Case {
     ])
     .unwrap();
 
-    let workspace_root = SystemPath::new("/src");
-    let metadata = WorkspaceMetadata::from_path(workspace_root, &system).unwrap();
+    let src_root = SystemPath::new("/src");
+    let metadata = WorkspaceMetadata::from_path(src_root, &system).unwrap();
     let settings = ProgramSettings {
         target_version: TargetVersion::Py312,
         search_paths: SearchPathSettings {
             extra_paths: vec![],
-            workspace_root: workspace_root.to_path_buf(),
+            src_root: src_root.to_path_buf(),
             site_packages: vec![],
             custom_typeshed: None,
         },

--- a/crates/ruff_db/src/program.rs
+++ b/crates/ruff_db/src/program.rs
@@ -85,7 +85,7 @@ pub struct SearchPathSettings {
     pub extra_paths: Vec<SystemPathBuf>,
 
     /// The root of the workspace, used for finding first-party modules.
-    pub workspace_root: SystemPathBuf,
+    pub src_root: SystemPathBuf,
 
     /// Optional path to a "custom typeshed" directory on disk for us to use for standard-library types.
     /// If this is not provided, we will fallback to our vendored typeshed stubs for the stdlib,


### PR DESCRIPTION
Fixes #12337