### PR TITLE
[red-knot] type narrowing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1904,6 +1904,8 @@ dependencies = [
  "ruff_text_size",
  "rustc-hash 2.0.0",
  "salsa",
+ "smallvec",
+ "static_assertions",
  "tempfile",
  "tracing",
  "walkdir",

--- a/crates/red_knot_python_semantic/Cargo.toml
+++ b/crates/red_knot_python_semantic/Cargo.toml
@@ -29,6 +29,8 @@ salsa = { workspace = true }
 tracing = { workspace = true }
 rustc-hash = { workspace = true }
 hashbrown = { workspace = true }
+smallvec = { workspace = true }
+static_assertions = { workspace = true }
 
 [build-dependencies]
 path-slash = { workspace = true }

--- a/crates/red_knot_python_semantic/src/semantic_index.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index.rs
@@ -16,9 +16,8 @@ use crate::semantic_index::expression::Expression;
 use crate::semantic_index::symbol::{
     FileScopeId, NodeWithScopeKey, NodeWithScopeRef, Scope, ScopeId, ScopedSymbolId, SymbolTable,
 };
+use crate::semantic_index::use_def::UseDefMap;
 use crate::Db;
-
-pub(crate) use self::use_def::UseDefMap;
 
 pub mod ast_ids;
 mod builder;
@@ -26,6 +25,8 @@ pub mod definition;
 pub mod expression;
 pub mod symbol;
 mod use_def;
+
+pub(crate) use self::use_def::{DefinitionWithConstraints, DefinitionWithConstraintsIterator};
 
 type SymbolMap = hashbrown::HashMap<ScopedSymbolId, (), ()>;
 
@@ -310,11 +311,28 @@ mod tests {
     use ruff_text_size::{Ranged, TextRange};
 
     use crate::db::tests::TestDb;
-    use crate::semantic_index::ast_ids::HasScopedUseId;
-    use crate::semantic_index::definition::DefinitionKind;
-    use crate::semantic_index::symbol::{FileScopeId, Scope, ScopeKind, SymbolTable};
+    use crate::semantic_index::ast_ids::{HasScopedUseId, ScopedUseId};
+    use crate::semantic_index::definition::{Definition, DefinitionKind};
+    use crate::semantic_index::symbol::{
+        FileScopeId, Scope, ScopeKind, ScopedSymbolId, SymbolTable,
+    };
+    use crate::semantic_index::use_def::UseDefMap;
     use crate::semantic_index::{global_scope, semantic_index, symbol_table, use_def_map};
     use crate::Db;
+
+    impl UseDefMap<'_> {
+        fn first_public_definition(&self, symbol: ScopedSymbolId) -> Option<Definition<'_>> {
+            self.public_definitions(symbol)
+                .next()
+                .map(|constrained_definition| constrained_definition.definition)
+        }
+
+        fn first_use_definition(&self, use_id: ScopedUseId) -> Option<Definition<'_>> {
+            self.use_definitions(use_id)
+                .next()
+                .map(|constrained_definition| constrained_definition.definition)
+        }
+    }
 
     struct TestCase {
         db: TestDb,
@@ -374,9 +392,7 @@ mod tests {
         let foo = global_table.symbol_id_by_name("foo").unwrap();
 
         let use_def = use_def_map(&db, scope);
-        let [definition] = use_def.public_definitions(foo) else {
-            panic!("expected one definition");
-        };
+        let definition = use_def.first_public_definition(foo).unwrap();
         assert!(matches!(definition.node(&db), DefinitionKind::Import(_)));
     }
 
@@ -411,13 +427,13 @@ mod tests {
         );
 
         let use_def = use_def_map(&db, scope);
-        let [definition] = use_def.public_definitions(
-            global_table
-                .symbol_id_by_name("foo")
-                .expect("symbol to exist"),
-        ) else {
-            panic!("expected one definition");
-        };
+        let definition = use_def
+            .first_public_definition(
+                global_table
+                    .symbol_id_by_name("foo")
+                    .expect("symbol to exist"),
+            )
+            .unwrap();
         assert!(matches!(
             definition.node(&db),
             DefinitionKind::ImportFrom(_)
@@ -438,11 +454,9 @@ mod tests {
             "a symbol used but not defined in a scope should have only the used flag"
         );
         let use_def = use_def_map(&db, scope);
-        let [definition] =
-            use_def.public_definitions(global_table.symbol_id_by_name("x").expect("symbol exists"))
-        else {
-            panic!("expected one definition");
-        };
+        let definition = use_def
+            .first_public_definition(global_table.symbol_id_by_name("x").expect("symbol exists"))
+            .unwrap();
         assert!(matches!(
             definition.node(&db),
             DefinitionKind::Assignment(_)
@@ -477,11 +491,9 @@ y = 2
         assert_eq!(names(&class_table), vec!["x"]);
 
         let use_def = index.use_def_map(class_scope_id);
-        let [definition] =
-            use_def.public_definitions(class_table.symbol_id_by_name("x").expect("symbol exists"))
-        else {
-            panic!("expected one definition");
-        };
+        let definition = use_def
+            .first_public_definition(class_table.symbol_id_by_name("x").expect("symbol exists"))
+            .unwrap();
         assert!(matches!(
             definition.node(&db),
             DefinitionKind::Assignment(_)
@@ -515,13 +527,13 @@ y = 2
         assert_eq!(names(&function_table), vec!["x"]);
 
         let use_def = index.use_def_map(function_scope_id);
-        let [definition] = use_def.public_definitions(
-            function_table
-                .symbol_id_by_name("x")
-                .expect("symbol exists"),
-        ) else {
-            panic!("expected one definition");
-        };
+        let definition = use_def
+            .first_public_definition(
+                function_table
+                    .symbol_id_by_name("x")
+                    .expect("symbol exists"),
+            )
+            .unwrap();
         assert!(matches!(
             definition.node(&db),
             DefinitionKind::Assignment(_)
@@ -691,9 +703,7 @@ def f(a: str, /, b: str, c: int = 1, *args, d: int = 2, **kwargs):
         let element_use_id =
             element.scoped_use_id(&db, comprehension_scope_id.to_scope_id(&db, file));
 
-        let [definition] = use_def.use_definitions(element_use_id) else {
-            panic!("expected one definition")
-        };
+        let definition = use_def.first_use_definition(element_use_id).unwrap();
         let DefinitionKind::Comprehension(comprehension) = definition.node(&db) else {
             panic!("expected generator definition")
         };
@@ -790,13 +800,13 @@ def func():
         assert_eq!(names(&func2_table), vec!["y"]);
 
         let use_def = index.use_def_map(FileScopeId::global());
-        let [definition] = use_def.public_definitions(
-            global_table
-                .symbol_id_by_name("func")
-                .expect("symbol exists"),
-        ) else {
-            panic!("expected one definition");
-        };
+        let definition = use_def
+            .first_public_definition(
+                global_table
+                    .symbol_id_by_name("func")
+                    .expect("symbol exists"),
+            )
+            .unwrap();
         assert!(matches!(definition.node(&db), DefinitionKind::Function(_)));
     }
 
@@ -897,9 +907,7 @@ class C[T]:
         };
         let x_use_id = x_use_expr_name.scoped_use_id(&db, scope);
         let use_def = use_def_map(&db, scope);
-        let [definition] = use_def.use_definitions(x_use_id) else {
-            panic!("expected one definition");
-        };
+        let definition = use_def.first_use_definition(x_use_id).unwrap();
         let DefinitionKind::Assignment(assignment) = definition.node(&db) else {
             panic!("should be an assignment definition")
         };

--- a/crates/red_knot_python_semantic/src/semantic_index.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index.rs
@@ -569,26 +569,26 @@ def f(a: str, /, b: str, c: int = 1, *args, d: int = 2, **kwargs):
 
         let use_def = index.use_def_map(function_scope_id);
         for name in ["a", "b", "c", "d"] {
-            let [definition] = use_def.public_definitions(
-                function_table
-                    .symbol_id_by_name(name)
-                    .expect("symbol exists"),
-            ) else {
-                panic!("Expected parameter definition for {name}");
-            };
+            let definition = use_def
+                .first_public_definition(
+                    function_table
+                        .symbol_id_by_name(name)
+                        .expect("symbol exists"),
+                )
+                .unwrap();
             assert!(matches!(
                 definition.node(&db),
                 DefinitionKind::ParameterWithDefault(_)
             ));
         }
         for name in ["args", "kwargs"] {
-            let [definition] = use_def.public_definitions(
-                function_table
-                    .symbol_id_by_name(name)
-                    .expect("symbol exists"),
-            ) else {
-                panic!("Expected parameter definition for {name}");
-            };
+            let definition = use_def
+                .first_public_definition(
+                    function_table
+                        .symbol_id_by_name(name)
+                        .expect("symbol exists"),
+                )
+                .unwrap();
             assert!(matches!(definition.node(&db), DefinitionKind::Parameter(_)));
         }
     }
@@ -617,22 +617,22 @@ def f(a: str, /, b: str, c: int = 1, *args, d: int = 2, **kwargs):
 
         let use_def = index.use_def_map(lambda_scope_id);
         for name in ["a", "b", "c", "d"] {
-            let [definition] = use_def
-                .public_definitions(lambda_table.symbol_id_by_name(name).expect("symbol exists"))
-            else {
-                panic!("Expected parameter definition for {name}");
-            };
+            let definition = use_def
+                .first_public_definition(
+                    lambda_table.symbol_id_by_name(name).expect("symbol exists"),
+                )
+                .unwrap();
             assert!(matches!(
                 definition.node(&db),
                 DefinitionKind::ParameterWithDefault(_)
             ));
         }
         for name in ["args", "kwargs"] {
-            let [definition] = use_def
-                .public_definitions(lambda_table.symbol_id_by_name(name).expect("symbol exists"))
-            else {
-                panic!("Expected parameter definition for {name}");
-            };
+            let definition = use_def
+                .first_public_definition(
+                    lambda_table.symbol_id_by_name(name).expect("symbol exists"),
+                )
+                .unwrap();
             assert!(matches!(definition.node(&db), DefinitionKind::Parameter(_)));
         }
     }

--- a/crates/red_knot_python_semantic/src/semantic_index/builder.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/builder.rs
@@ -155,7 +155,7 @@ impl<'db> SemanticIndexBuilder<'db> {
         self.current_use_def_map_mut().restore(state);
     }
 
-    fn flow_merge(&mut self, state: &FlowSnapshot) {
+    fn flow_merge(&mut self, state: FlowSnapshot) {
         self.current_use_def_map_mut().merge(state);
     }
 
@@ -497,7 +497,7 @@ where
                     self.visit_elif_else_clause(clause);
                 }
                 for post_clause_state in post_clauses {
-                    self.flow_merge(&post_clause_state);
+                    self.flow_merge(post_clause_state);
                 }
                 let has_else = node
                     .elif_else_clauses
@@ -506,7 +506,7 @@ where
                 if !has_else {
                     // if there's no else clause, then it's possible we took none of the branches,
                     // and the pre_if state can reach here
-                    self.flow_merge(&pre_if);
+                    self.flow_merge(pre_if);
                 }
             }
             ast::Stmt::While(node) => {
@@ -524,13 +524,13 @@ where
 
                 // We may execute the `else` clause without ever executing the body, so merge in
                 // the pre-loop state before visiting `else`.
-                self.flow_merge(&pre_loop);
+                self.flow_merge(pre_loop);
                 self.visit_body(&node.orelse);
 
                 // Breaking out of a while loop bypasses the `else` clause, so merge in the break
                 // states after visiting `else`.
                 for break_state in break_states {
-                    self.flow_merge(&break_state);
+                    self.flow_merge(break_state);
                 }
             }
             ast::Stmt::Break(_) => {
@@ -640,7 +640,7 @@ where
                 let post_body = self.flow_snapshot();
                 self.flow_restore(pre_if);
                 self.visit_expr(orelse);
-                self.flow_merge(&post_body);
+                self.flow_merge(post_body);
             }
             ast::Expr::ListComp(
                 list_comprehension @ ast::ExprListComp {

--- a/crates/red_knot_python_semantic/src/semantic_index/expression.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/expression.rs
@@ -21,7 +21,7 @@ pub(crate) struct Expression<'db> {
     /// The expression node.
     #[no_eq]
     #[return_ref]
-    pub(crate) node: AstNodeRef<ast::Expr>,
+    pub(crate) node_ref: AstNodeRef<ast::Expr>,
 
     #[no_eq]
     count: countme::Count<Expression<'static>>,

--- a/crates/red_knot_python_semantic/src/semantic_index/use_def/bitset.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/use_def/bitset.rs
@@ -1,0 +1,228 @@
+/// Ordered set of `u32`.
+///
+/// Uses an inline bit-set for small values (up to 64 * B), falls back to heap allocated vector of
+/// blocks for larger values.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum BitSet<const B: usize> {
+    /// Bit-set (in 64-bit blocks) for the first 64 * B entries.
+    Inline([u64; B]),
+
+    /// Overflow beyond 64 * B.
+    Heap(Vec<u64>),
+}
+
+impl<const B: usize> Default for BitSet<B> {
+    fn default() -> Self {
+        // B * 64 must fit in a u32, or else we have unusable bits; this assertion makes the
+        // truncating casts to u32 below safe. This would be better as a const assertion, but
+        // that's not possible on stable with const generic params. (B should never really be
+        // anywhere close to this large.)
+        assert!(B * 64 < (u32::MAX as usize));
+        // This implementation requires usize >= 32 bits.
+        static_assertions::const_assert!(usize::BITS >= 32);
+        Self::Inline([0; B])
+    }
+}
+
+impl<const B: usize> BitSet<B> {
+    /// Create and return a new [`BitSet`] with a single `value` inserted.
+    pub(super) fn with(value: u32) -> Self {
+        let mut bitset = Self::default();
+        bitset.insert(value);
+        bitset
+    }
+
+    /// Convert from Inline to Heap representation.
+    fn overflow(&mut self, value: u32) {
+        let num_blocks_needed = (value / 64) + 1;
+        match self {
+            Self::Inline(blocks) => {
+                let mut vec = blocks.to_vec();
+                vec.resize(num_blocks_needed as usize, 0);
+                *self = Self::Heap(vec);
+            }
+            Self::Heap(vec) => {
+                vec.resize(num_blocks_needed as usize, 0);
+            }
+        }
+    }
+
+    fn get_blocks_mut(&mut self) -> &mut [u64] {
+        match self {
+            Self::Inline(blocks) => blocks.as_mut_slice(),
+            Self::Heap(blocks) => blocks.as_mut_slice(),
+        }
+    }
+
+    fn get_blocks(&self) -> &[u64] {
+        match self {
+            Self::Inline(blocks) => blocks.as_slice(),
+            Self::Heap(blocks) => blocks.as_slice(),
+        }
+    }
+
+    /// Insert a value into the [`BitSet`].
+    ///
+    /// Return true if the value was newly inserted, false if already present.
+    pub(super) fn insert(&mut self, value: u32) -> bool {
+        let value_usize = value as usize;
+        let (block, index) = (value_usize / 64, value_usize % 64);
+        if block >= self.get_blocks().len() {
+            self.overflow(value);
+        }
+        let blocks = self.get_blocks_mut();
+        let missing = blocks[block] & (1 << index) == 0;
+        blocks[block] |= 1 << index;
+        missing
+    }
+
+    /// Intersect in-place with another [`BitSet`].
+    pub(super) fn intersect(&mut self, other: &BitSet<B>) {
+        let my_blocks = self.get_blocks_mut();
+        let other_blocks = other.get_blocks();
+        let min_len = my_blocks.len().min(other_blocks.len());
+        for i in 0..min_len {
+            my_blocks[i] &= other_blocks[i];
+        }
+        for block in my_blocks.iter_mut().skip(min_len) {
+            *block = 0;
+        }
+    }
+
+    /// Return an iterator over the values (in ascending order) in this [`BitSet`].
+    pub(super) fn iter(&self) -> BitSetIterator<'_, B> {
+        let blocks = self.get_blocks();
+        BitSetIterator {
+            blocks,
+            current_block_index: 0,
+            current_block: blocks[0],
+        }
+    }
+}
+
+/// Iterator over values in a [`BitSet`].
+#[derive(Debug)]
+pub(super) struct BitSetIterator<'a, const B: usize> {
+    /// The blocks we are iterating over.
+    blocks: &'a [u64],
+
+    /// The index of the block we are currently iterating through.
+    current_block_index: usize,
+
+    /// The block we are currently iterating through (and zeroing as we go.)
+    current_block: u64,
+}
+
+impl<const B: usize> Iterator for BitSetIterator<'_, B> {
+    type Item = u32;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        while self.current_block == 0 {
+            if self.current_block_index + 1 >= self.blocks.len() {
+                return None;
+            }
+            self.current_block_index += 1;
+            self.current_block = self.blocks[self.current_block_index];
+        }
+        let lowest_bit_set = self.current_block.trailing_zeros();
+        // reset the lowest set bit, without a data dependency on `lowest_bit_set`
+        self.current_block &= self.current_block.wrapping_sub(1);
+        // SAFETY: `lowest_bit_set` cannot be more than 64, `current_block_index` cannot be more
+        // than `B - 1`, and we check above that `B * 64 < u32::MAX`. So both `64 *
+        // current_block_index` and the final value here must fit in u32.
+        #[allow(clippy::cast_possible_truncation)]
+        Some(lowest_bit_set + (64 * self.current_block_index) as u32)
+    }
+}
+
+impl<const B: usize> std::iter::FusedIterator for BitSetIterator<'_, B> {}
+
+#[cfg(test)]
+mod tests {
+    use super::BitSet;
+
+    fn assert_bitset<const B: usize>(bitset: &BitSet<B>, contents: &[u32]) {
+        assert_eq!(bitset.iter().collect::<Vec<_>>(), contents);
+    }
+
+    #[test]
+    fn iter() {
+        let mut b = BitSet::<1>::with(3);
+        b.insert(27);
+        b.insert(6);
+        assert!(matches!(b, BitSet::Inline(_)));
+        assert_bitset(&b, &[3, 6, 27]);
+    }
+
+    #[test]
+    fn iter_overflow() {
+        let mut b = BitSet::<1>::with(140);
+        b.insert(100);
+        b.insert(129);
+        assert!(matches!(b, BitSet::Heap(_)));
+        assert_bitset(&b, &[100, 129, 140]);
+    }
+
+    #[test]
+    fn intersect() {
+        let mut b1 = BitSet::<1>::with(4);
+        let mut b2 = BitSet::<1>::with(4);
+        b1.insert(23);
+        b2.insert(5);
+
+        b1.intersect(&b2);
+        assert_bitset(&b1, &[4]);
+    }
+
+    #[test]
+    fn intersect_mixed_1() {
+        let mut b1 = BitSet::<1>::with(4);
+        let mut b2 = BitSet::<1>::with(4);
+        b1.insert(89);
+        b2.insert(5);
+
+        b1.intersect(&b2);
+        assert_bitset(&b1, &[4]);
+    }
+
+    #[test]
+    fn intersect_mixed_2() {
+        let mut b1 = BitSet::<1>::with(4);
+        let mut b2 = BitSet::<1>::with(4);
+        b1.insert(23);
+        b2.insert(89);
+
+        b1.intersect(&b2);
+        assert_bitset(&b1, &[4]);
+    }
+
+    #[test]
+    fn intersect_heap() {
+        let mut b1 = BitSet::<1>::with(4);
+        let mut b2 = BitSet::<1>::with(4);
+        b1.insert(89);
+        b2.insert(90);
+
+        b1.intersect(&b2);
+        assert_bitset(&b1, &[4]);
+    }
+
+    #[test]
+    fn intersect_heap_2() {
+        let mut b1 = BitSet::<1>::with(89);
+        let mut b2 = BitSet::<1>::with(89);
+        b1.insert(91);
+        b2.insert(90);
+
+        b1.intersect(&b2);
+        assert_bitset(&b1, &[89]);
+    }
+
+    #[test]
+    fn multiple_blocks() {
+        let mut b = BitSet::<2>::with(120);
+        b.insert(45);
+        assert!(matches!(b, BitSet::Inline(_)));
+        assert_bitset(&b, &[45, 120]);
+    }
+}

--- a/crates/red_knot_python_semantic/src/semantic_index/use_def/symbol_state.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/use_def/symbol_state.rs
@@ -1,0 +1,369 @@
+//! Track visible definitions of a symbol, and applicable constraints per definition.
+//!
+//! These data structures operate entirely on scope-local newtype-indices for definitions and
+//! constraints, referring to their location in the `all_definitions` and `all_constraints`
+//! indexvecs in [`super::UseDefMapBuilder`].
+//!
+//! We need to track arbitrary associations between definitions and constraints, not just a single
+//! set of currently dominating constraints (where "dominating" means "control flow must have
+//! passed through it to reach this point"), because we can have dominating constraints that apply
+//! to some definitions but not others, as in this code:
+//!
+//! ```python
+//! x = 1 if flag else None
+//! if x is not None:
+//!     if flag2:
+//!         x = 2 if flag else None
+//!     x
+//! ```
+//!
+//! The `x is not None` constraint dominates the final use of `x`, but it applies only to the first
+//! definition of `x`, not the second, so `None` is a possible value for `x`.
+//!
+//! And we can't just track, for each definition, an index into a list of dominating constraints,
+//! either, because we can have definitions which are still visible, but subject to constraints
+//! that are no longer dominating, as in this code:
+//!
+//! ```python
+//! x = 0
+//! if flag1:
+//!     x = 1 if flag2 else None
+//!     assert x is not None
+//! x
+//! ```
+//!
+//! From the point of view of the final use of `x`, the `x is not None` constraint no longer
+//! dominates, but it does dominate the `x = 1 if flag2 else None` definition, so we have to keep
+//! track of that.
+//!
+//! The data structures used here ([`BitSet`] and [`smallvec::SmallVec`]) optimize for keeping all
+//! data inline (avoiding lots of scattered allocations) in small-to-medium cases, and falling back
+//! to heap allocation to be able to scale to arbitrary numbers of definitions and constraints when
+//! needed.
+use super::bitset::{BitSet, BitSetIterator};
+use ruff_index::newtype_index;
+use smallvec::SmallVec;
+
+/// A newtype-index for a definition in a particular scope.
+#[newtype_index]
+pub(super) struct ScopedDefinitionId;
+
+/// A newtype-index for a constraint expression in a particular scope.
+#[newtype_index]
+pub(super) struct ScopedConstraintId;
+
+/// Can reference this * 64 total definitions inline; more will fall back to the heap.
+const INLINE_DEFINITION_BLOCKS: usize = 3;
+
+/// A [`BitSet`] of [`ScopedDefinitionId`], representing visible definitions of a symbol in a scope.
+type Definitions = BitSet<INLINE_DEFINITION_BLOCKS>;
+type DefinitionsIterator<'a> = BitSetIterator<'a, INLINE_DEFINITION_BLOCKS>;
+
+/// Can reference this * 64 total constraints inline; more will fall back to the heap.
+const INLINE_CONSTRAINT_BLOCKS: usize = 2;
+
+/// Can keep inline this many visible definitions per symbol at a given time; more will go to heap.
+const INLINE_VISIBLE_DEFINITIONS_PER_SYMBOL: usize = 4;
+
+/// One [`BitSet`] of applicable [`ScopedConstraintId`] per visible definition.
+type Constraints =
+    SmallVec<[BitSet<INLINE_CONSTRAINT_BLOCKS>; INLINE_VISIBLE_DEFINITIONS_PER_SYMBOL]>;
+type ConstraintsIterator<'a> = std::slice::Iter<'a, BitSet<INLINE_CONSTRAINT_BLOCKS>>;
+
+/// Visible definitions and narrowing constraints for a single symbol at some point in control flow.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(super) struct SymbolState {
+    /// [`BitSet`]: which [`ScopedDefinitionId`] are visible for this symbol?
+    visible_definitions: Definitions,
+
+    /// For each definition, which [`ScopedConstraintId`] apply?
+    ///
+    /// This is a [`smallvec::SmallVec`] which should always have one [`BitSet`] of constraints per
+    /// definition in `visible_definitions`.
+    constraints: Constraints,
+
+    /// Could the symbol be unbound at this point?
+    may_be_unbound: bool,
+}
+
+/// A single [`ScopedDefinitionId`] with an iterator of its applicable [`ScopedConstraintId`].
+#[derive(Debug)]
+pub(super) struct DefinitionIdWithConstraints<'a> {
+    pub(super) definition: ScopedDefinitionId,
+    pub(super) constraint_ids: ConstraintIdIterator<'a>,
+}
+
+impl SymbolState {
+    /// Return a new [`SymbolState`] representing an unbound symbol.
+    pub(super) fn unbound() -> Self {
+        Self {
+            visible_definitions: Definitions::default(),
+            constraints: Constraints::default(),
+            may_be_unbound: true,
+        }
+    }
+
+    /// Return a new [`SymbolState`] representing a symbol with a single visible definition.
+    pub(super) fn with(definition_id: ScopedDefinitionId) -> Self {
+        let mut constraints = Constraints::with_capacity(1);
+        constraints.push(BitSet::default());
+        Self {
+            visible_definitions: Definitions::with(definition_id.into()),
+            constraints,
+            may_be_unbound: false,
+        }
+    }
+
+    /// Add Unbound as a possibility for this symbol.
+    pub(super) fn add_unbound(&mut self) {
+        self.may_be_unbound = true;
+    }
+
+    /// Add given constraint to all currently-visible definitions.
+    pub(super) fn add_constraint(&mut self, constraint_id: ScopedConstraintId) {
+        for bitset in &mut self.constraints {
+            bitset.insert(constraint_id.into());
+        }
+    }
+
+    /// Merge two [`SymbolState`] and return the result.
+    pub(super) fn merge(a: &SymbolState, b: &SymbolState) -> SymbolState {
+        let mut merged = Self {
+            visible_definitions: Definitions::default(),
+            constraints: Constraints::default(),
+            may_be_unbound: a.may_be_unbound || b.may_be_unbound,
+        };
+        let mut a_defs_iter = a.visible_definitions.iter();
+        let mut b_defs_iter = b.visible_definitions.iter();
+        let mut a_constraints_iter = a.constraints.iter();
+        let mut b_constraints_iter = b.constraints.iter();
+
+        let mut opt_a_def: Option<u32> = a_defs_iter.next();
+        let mut opt_b_def: Option<u32> = b_defs_iter.next();
+
+        // Iterate through the definitions from `a` and `b`, always processing the lower definition
+        // ID first, and pushing each definition onto the merged `SymbolState` with its
+        // constraints. If a definition is found in both `a` and `b`, push it with the intersection
+        // of the constraints from the two paths; a constraint that applies from only one possible
+        // path is irrelevant.
+
+        // Helper to push `def`, with constraints in `constraints_iter`, onto  merged`.
+        let push = |def, constraints_iter: &mut ConstraintsIterator, merged: &mut Self| {
+            merged.visible_definitions.insert(def);
+            // SAFETY: we only ever create SymbolState with either no definitions and no constraint
+            // bitsets (`::unbound`) or one definition and one constraint bitset (`::with`), and
+            // `::merge` always pushes one definition and one constraint bitset together (just
+            // below), so the number of definitions and the number of constraint bitsets can never
+            // get out of sync.
+            let constraints = constraints_iter
+                .next()
+                .expect("definitions and constraints length mismatch");
+            merged.constraints.push(constraints.clone());
+        };
+
+        loop {
+            match (opt_a_def, opt_b_def) {
+                (Some(a_def), Some(b_def)) => match a_def.cmp(&b_def) {
+                    std::cmp::Ordering::Less => {
+                        // Next definition ID is only in `a`, push it to `merged` and advance `a`.
+                        push(a_def, &mut a_constraints_iter, &mut merged);
+                        opt_a_def = a_defs_iter.next();
+                    }
+                    std::cmp::Ordering::Greater => {
+                        // Next definition ID is only in `b`, push it to `merged` and advance `b`.
+                        push(b_def, &mut b_constraints_iter, &mut merged);
+                        opt_b_def = b_defs_iter.next();
+                    }
+                    std::cmp::Ordering::Equal => {
+                        // Next definition is in both; push to `merged` and intersect constraints.
+                        push(a_def, &mut a_constraints_iter, &mut merged);
+                        // SAFETY: we only ever create SymbolState with either no definitions and
+                        // no constraint bitsets (`::unbound`) or one definition and one constraint
+                        // bitset (`::with`), and `::merge` always pushes one definition and one
+                        // constraint bitset together (just below), so the number of definitions
+                        // and the number of constraint bitsets can never get out of sync.
+                        let b_constraints = b_constraints_iter
+                            .next()
+                            .expect("definitions and constraints length mismatch");
+                        // If the same definition is visible through both paths, any constraint
+                        // that applies on only one path is irrelevant to the resulting type from
+                        // unioning the two paths, so we intersect the constraints.
+                        merged
+                            .constraints
+                            .last_mut()
+                            .unwrap()
+                            .intersect(b_constraints);
+                        opt_a_def = a_defs_iter.next();
+                        opt_b_def = b_defs_iter.next();
+                    }
+                },
+                (Some(a_def), None) => {
+                    // We've exhausted `b`, just push the def from `a` and move on to the next.
+                    push(a_def, &mut a_constraints_iter, &mut merged);
+                    opt_a_def = a_defs_iter.next();
+                }
+                (None, Some(b_def)) => {
+                    // We've exhausted `a`, just push the def from `b` and move on to the next.
+                    push(b_def, &mut b_constraints_iter, &mut merged);
+                    opt_b_def = b_defs_iter.next();
+                }
+                (None, None) => break,
+            }
+        }
+        merged
+    }
+
+    /// Get iterator over visible definitions with constraints.
+    pub(super) fn visible_definitions(&self) -> DefinitionIdWithConstraintsIterator {
+        DefinitionIdWithConstraintsIterator {
+            definitions: self.visible_definitions.iter(),
+            constraints: self.constraints.iter(),
+        }
+    }
+
+    /// Could the symbol be unbound?
+    pub(super) fn may_be_unbound(&self) -> bool {
+        self.may_be_unbound
+    }
+}
+
+/// The default state of a symbol (if we've seen no definitions of it) is unbound.
+impl Default for SymbolState {
+    fn default() -> Self {
+        SymbolState::unbound()
+    }
+}
+
+#[derive(Debug)]
+pub(super) struct DefinitionIdWithConstraintsIterator<'a> {
+    definitions: DefinitionsIterator<'a>,
+    constraints: ConstraintsIterator<'a>,
+}
+
+impl<'a> Iterator for DefinitionIdWithConstraintsIterator<'a> {
+    type Item = DefinitionIdWithConstraints<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match (self.definitions.next(), self.constraints.next()) {
+            (None, None) => None,
+            (Some(def), Some(constraints)) => Some(DefinitionIdWithConstraints {
+                definition: ScopedDefinitionId::from_u32(def),
+                constraint_ids: ConstraintIdIterator {
+                    wrapped: constraints.iter(),
+                },
+            }),
+            // SAFETY: see above.
+            _ => unreachable!("definitions and constraints length mismatch"),
+        }
+    }
+}
+
+impl std::iter::FusedIterator for DefinitionIdWithConstraintsIterator<'_> {}
+
+#[derive(Debug)]
+pub(super) struct ConstraintIdIterator<'a> {
+    wrapped: BitSetIterator<'a, INLINE_CONSTRAINT_BLOCKS>,
+}
+
+impl Iterator for ConstraintIdIterator<'_> {
+    type Item = ScopedConstraintId;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.wrapped.next().map(ScopedConstraintId::from_u32)
+    }
+}
+
+impl std::iter::FusedIterator for ConstraintIdIterator<'_> {}
+
+#[cfg(test)]
+mod tests {
+    use super::{ScopedConstraintId, ScopedDefinitionId, SymbolState};
+
+    impl SymbolState {
+        pub(crate) fn assert(&self, may_be_unbound: bool, expected: &[&str]) {
+            assert_eq!(self.may_be_unbound(), may_be_unbound);
+            let actual = self
+                .visible_definitions()
+                .map(|def_id_with_constraints| {
+                    format!(
+                        "{}<{}>",
+                        def_id_with_constraints.definition.as_u32(),
+                        def_id_with_constraints
+                            .constraint_ids
+                            .map(ScopedConstraintId::as_u32)
+                            .map(|idx| idx.to_string())
+                            .collect::<Vec<_>>()
+                            .join(", ")
+                    )
+                })
+                .collect::<Vec<_>>();
+            assert_eq!(actual, expected);
+        }
+    }
+
+    #[test]
+    fn unbound() {
+        let cd = SymbolState::unbound();
+
+        cd.assert(true, &[]);
+    }
+
+    #[test]
+    fn with() {
+        let cd = SymbolState::with(ScopedDefinitionId::from_u32(0));
+
+        cd.assert(false, &["0<>"]);
+    }
+
+    #[test]
+    fn add_unbound() {
+        let mut cd = SymbolState::with(ScopedDefinitionId::from_u32(0));
+        cd.add_unbound();
+
+        cd.assert(true, &["0<>"]);
+    }
+
+    #[test]
+    fn add_constraint() {
+        let mut cd = SymbolState::with(ScopedDefinitionId::from_u32(0));
+        cd.add_constraint(ScopedConstraintId::from_u32(0));
+
+        cd.assert(false, &["0<0>"]);
+    }
+
+    #[test]
+    fn merge() {
+        // merging the same definition with the same constraint keeps the constraint
+        let mut cd0a = SymbolState::with(ScopedDefinitionId::from_u32(0));
+        cd0a.add_constraint(ScopedConstraintId::from_u32(0));
+
+        let mut cd0b = SymbolState::with(ScopedDefinitionId::from_u32(0));
+        cd0b.add_constraint(ScopedConstraintId::from_u32(0));
+
+        let cd0 = SymbolState::merge(&cd0a, &cd0b);
+        cd0.assert(false, &["0<0>"]);
+
+        // merging the same definition with differing constraints drops all constraints
+        let mut cd1a = SymbolState::with(ScopedDefinitionId::from_u32(1));
+        cd1a.add_constraint(ScopedConstraintId::from_u32(1));
+
+        let mut cd1b = SymbolState::with(ScopedDefinitionId::from_u32(1));
+        cd1b.add_constraint(ScopedConstraintId::from_u32(2));
+
+        let cd1 = SymbolState::merge(&cd1a, &cd1b);
+        cd1.assert(false, &["1<>"]);
+
+        // merging a constrained definition with unbound keeps both
+        let mut cd2a = SymbolState::with(ScopedDefinitionId::from_u32(2));
+        cd2a.add_constraint(ScopedConstraintId::from_u32(3));
+
+        let cd2b = SymbolState::unbound();
+
+        let cd2 = SymbolState::merge(&cd2a, &cd2b);
+        cd2.assert(true, &["2<3>"]);
+
+        // merging different definitions keeps them each with their existing constraints
+        let cd = SymbolState::merge(&cd0, &cd2);
+        cd.assert(true, &["0<0>", "2<3>"]);
+    }
+}

--- a/crates/red_knot_python_semantic/src/types/narrow.rs
+++ b/crates/red_knot_python_semantic/src/types/narrow.rs
@@ -1,0 +1,115 @@
+use crate::semantic_index::ast_ids::HasScopedAstId;
+use crate::semantic_index::definition::Definition;
+use crate::semantic_index::expression::Expression;
+use crate::semantic_index::symbol::{ScopeId, ScopedSymbolId, SymbolTable};
+use crate::semantic_index::symbol_table;
+use crate::types::{infer_expression_types, IntersectionBuilder, Type, TypeInference};
+use crate::Db;
+use ruff_python_ast as ast;
+use rustc_hash::FxHashMap;
+use std::sync::Arc;
+
+/// Return the type constraint that `test` (if true) would place on `definition`, if any.
+///
+/// For example, if we have this code:
+///
+/// ```python
+/// y = 1 if flag else None
+/// x = 1 if flag else None
+/// if x is not None:
+///     ...
+/// ```
+///
+/// The `test` expression `x is not None` places the constraint "not None" on the definition of
+/// `x`, so in that case we'd return `Some(Type::Intersection(negative=[Type::None]))`.
+///
+/// But if we called this with the same `test` expression, but the `definition` of `y`, no
+/// constraint is applied to that definition, so we'd just return `None`.
+pub(crate) fn narrowing_constraint<'db>(
+    db: &'db dyn Db,
+    test: Expression<'db>,
+    definition: Definition<'db>,
+) -> Option<Type<'db>> {
+    all_narrowing_constraints(db, test)
+        .get(&definition.symbol(db))
+        .copied()
+}
+
+#[salsa::tracked(return_ref)]
+fn all_narrowing_constraints<'db>(
+    db: &'db dyn Db,
+    test: Expression<'db>,
+) -> NarrowingConstraints<'db> {
+    NarrowingConstraintsBuilder::new(db, test).finish()
+}
+
+type NarrowingConstraints<'db> = FxHashMap<ScopedSymbolId, Type<'db>>;
+
+struct NarrowingConstraintsBuilder<'db> {
+    db: &'db dyn Db,
+    expression: Expression<'db>,
+    constraints: NarrowingConstraints<'db>,
+}
+
+impl<'db> NarrowingConstraintsBuilder<'db> {
+    fn new(db: &'db dyn Db, expression: Expression<'db>) -> Self {
+        Self {
+            db,
+            expression,
+            constraints: NarrowingConstraints::default(),
+        }
+    }
+
+    fn finish(mut self) -> NarrowingConstraints<'db> {
+        if let ast::Expr::Compare(expr_compare) = self.expression.node_ref(self.db).node() {
+            self.add_expr_compare(expr_compare);
+        }
+        // TODO other test expression kinds
+
+        self.constraints.shrink_to_fit();
+        self.constraints
+    }
+
+    fn symbols(&self) -> Arc<SymbolTable> {
+        symbol_table(self.db, self.scope())
+    }
+
+    fn scope(&self) -> ScopeId<'db> {
+        self.expression.scope(self.db)
+    }
+
+    fn inference(&self) -> &'db TypeInference<'db> {
+        infer_expression_types(self.db, self.expression)
+    }
+
+    fn add_expr_compare(&mut self, expr_compare: &ast::ExprCompare) {
+        let ast::ExprCompare {
+            range: _,
+            left,
+            ops,
+            comparators,
+        } = expr_compare;
+
+        if let ast::Expr::Name(ast::ExprName {
+            range: _,
+            id,
+            ctx: _,
+        }) = left.as_ref()
+        {
+            // SAFETY: we should always have a symbol for every Name node.
+            let symbol = self.symbols().symbol_id_by_name(id).unwrap();
+            let scope = self.scope();
+            let inference = self.inference();
+            for (op, comparator) in std::iter::zip(&**ops, &**comparators) {
+                let comp_ty = inference.expression_ty(comparator.scoped_ast_id(self.db, scope));
+                if matches!(op, ast::CmpOp::IsNot) {
+                    let ty = IntersectionBuilder::new(self.db)
+                        .add_negative(comp_ty)
+                        .build();
+                    self.constraints.insert(symbol, ty);
+                };
+                // TODO other comparison types
+            }
+        }
+    }
+}


### PR DESCRIPTION
Extend the `UseDefMap` to also track which constraints (provided by e.g. `if` tests) apply to each visible definition.

Uses a custom `BitSet` and `BitSetArray` to track which constraints apply to which definitions, while keeping data inline as much as possible.