### PR TITLE
Update salsa

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -195,18 +195,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
-name = "boomphf"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "617e2d952880a00583ddb9237ac3965732e8df6a92a8e7bcc054100ec467ec3b"
-dependencies = [
- "crossbeam-utils",
- "log",
- "rayon",
- "wyhash",
-]
-
-[[package]]
 name = "bstr"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2716,15 +2704,15 @@ checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
 [[package]]
 name = "salsa"
 version = "0.18.0"
-source = "git+https://github.com/MichaReiser/salsa.git?rev=b8635811b826a137ca0b8f9e1ab7d13b050d25a3#b8635811b826a137ca0b8f9e1ab7d13b050d25a3"
+source = "git+https://github.com/MichaReiser/salsa.git?tag=red-knot-0.0.1#ece083e15b79f155f9e4368ec1318cec9a08d88b"
 dependencies = [
  "append-only-vec",
  "arc-swap",
- "boomphf",
  "crossbeam",
  "dashmap 6.0.1",
  "hashlink",
  "indexmap",
+ "lazy_static",
  "parking_lot",
  "rustc-hash 2.0.0",
  "salsa-macro-rules",
@@ -2736,12 +2724,12 @@ dependencies = [
 [[package]]
 name = "salsa-macro-rules"
 version = "0.1.0"
-source = "git+https://github.com/MichaReiser/salsa.git?rev=b8635811b826a137ca0b8f9e1ab7d13b050d25a3#b8635811b826a137ca0b8f9e1ab7d13b050d25a3"
+source = "git+https://github.com/MichaReiser/salsa.git?tag=red-knot-0.0.1#ece083e15b79f155f9e4368ec1318cec9a08d88b"
 
 [[package]]
 name = "salsa-macros"
 version = "0.18.0"
-source = "git+https://github.com/MichaReiser/salsa.git?rev=b8635811b826a137ca0b8f9e1ab7d13b050d25a3#b8635811b826a137ca0b8f9e1ab7d13b050d25a3"
+source = "git+https://github.com/MichaReiser/salsa.git?tag=red-knot-0.0.1#ece083e15b79f155f9e4368ec1318cec9a08d88b"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -3851,15 +3839,6 @@ name = "winsafe"
 version = "0.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
-
-[[package]]
-name = "wyhash"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf6e163c25e3fac820b4b453185ea2dea3b6a3e0a721d4d23d75bd33734c295"
-dependencies = [
- "rand_core",
-]
 
 [[package]]
 name = "yansi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1935,7 +1935,6 @@ dependencies = [
  "ruff_source_file",
  "ruff_text_size",
  "rustc-hash 2.0.0",
- "salsa",
  "serde",
  "serde_json",
  "shellexpand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,7 +109,7 @@ rand = { version = "0.8.5" }
 rayon = { version = "1.10.0" }
 regex = { version = "1.10.2" }
 rustc-hash = { version = "2.0.0" }
-salsa = { git = "https://github.com/MichaReiser/salsa.git", rev = "b8635811b826a137ca0b8f9e1ab7d13b050d25a3" }
+salsa = { git = "https://github.com/MichaReiser/salsa.git", tag = "red-knot-0.0.1" }
 schemars = { version = "0.8.16" }
 seahash = { version = "4.1.0" }
 serde = { version = "1.0.197", features = ["derive"] }

--- a/crates/red_knot_module_resolver/src/db.rs
+++ b/crates/red_knot_module_resolver/src/db.rs
@@ -74,10 +74,6 @@ pub(crate) mod tests {
             &self.system
         }
 
-        fn system_mut(&mut self) -> &mut dyn ruff_db::system::System {
-            &mut self.system
-        }
-
         fn files(&self) -> &Files {
             &self.files
         }

--- a/crates/red_knot_module_resolver/src/db.rs
+++ b/crates/red_knot_module_resolver/src/db.rs
@@ -98,12 +98,11 @@ pub(crate) mod tests {
 
     #[salsa::db]
     impl salsa::Database for TestDb {
-        fn salsa_event(&self, event: salsa::Event) {
-            self.attach(|_| {
-                tracing::trace!("event: {event:?}");
-                let mut events = self.events.lock().unwrap();
-                events.push(event);
-            });
+        fn salsa_event(&self, event: &dyn Fn() -> salsa::Event) {
+            let event = event();
+            tracing::trace!("event: {event:?}");
+            let mut events = self.events.lock().unwrap();
+            events.push(event);
         }
     }
 }

--- a/crates/red_knot_python_semantic/src/db.rs
+++ b/crates/red_knot_python_semantic/src/db.rs
@@ -112,12 +112,11 @@ pub(crate) mod tests {
 
     #[salsa::db]
     impl salsa::Database for TestDb {
-        fn salsa_event(&self, event: salsa::Event) {
-            self.attach(|_| {
-                tracing::trace!("event: {event:?}");
-                let mut events = self.events.lock().unwrap();
-                events.push(event);
-            });
+        fn salsa_event(&self, event: &dyn Fn() -> salsa::Event) {
+            let event = event();
+            tracing::trace!("event: {event:?}");
+            let mut events = self.events.lock().unwrap();
+            events.push(event);
         }
     }
 }

--- a/crates/red_knot_python_semantic/src/db.rs
+++ b/crates/red_knot_python_semantic/src/db.rs
@@ -77,10 +77,6 @@ pub(crate) mod tests {
             &self.system
         }
 
-        fn system_mut(&mut self) -> &mut dyn System {
-            &mut self.system
-        }
-
         fn files(&self) -> &Files {
             &self.files
         }

--- a/crates/red_knot_server/Cargo.toml
+++ b/crates/red_knot_server/Cargo.toml
@@ -25,7 +25,6 @@ jod-thread = { workspace = true }
 lsp-server = { workspace = true }
 lsp-types = { workspace = true }
 rustc-hash = { workspace = true }
-salsa = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 shellexpand = { workspace = true }

--- a/crates/red_knot_server/src/server/api.rs
+++ b/crates/red_knot_server/src/server/api.rs
@@ -7,6 +7,7 @@ mod requests;
 mod traits;
 
 use notifications as notification;
+use red_knot_workspace::db::RootDatabase;
 use requests as request;
 
 use self::traits::{NotificationHandler, RequestHandler};
@@ -84,7 +85,9 @@ fn background_request_task<'a, R: traits::BackgroundDocumentRequestHandler>(
         let Ok(path) = url_to_system_path(&url) else {
             return Box::new(|_, _| {});
         };
-        let db = session.workspace_db_for_path(path.as_std_path()).cloned();
+        let db = session
+            .workspace_db_for_path(path.as_std_path())
+            .map(RootDatabase::snapshot);
 
         let Some(snapshot) = session.take_snapshot(url) else {
             return Box::new(|_, _| {});

--- a/crates/red_knot_server/src/server/api/notifications/did_close.rs
+++ b/crates/red_knot_server/src/server/api/notifications/did_close.rs
@@ -35,7 +35,7 @@ impl SyncNotificationHandler for DidCloseTextDocumentHandler {
             .with_failure_code(ErrorCode::InternalError)?;
 
         if let Some(db) = session.workspace_db_for_path_mut(path.as_std_path()) {
-            File::sync_path(db.get_mut(), &path);
+            File::sync_path(db, &path);
         }
 
         clear_diagnostics(key.url(), &notifier)?;

--- a/crates/red_knot_server/src/server/api/notifications/did_close_notebook.rs
+++ b/crates/red_knot_server/src/server/api/notifications/did_close_notebook.rs
@@ -33,7 +33,7 @@ impl SyncNotificationHandler for DidCloseNotebookHandler {
             .with_failure_code(lsp_server::ErrorCode::InternalError)?;
 
         if let Some(db) = session.workspace_db_for_path_mut(path.as_std_path()) {
-            File::sync_path(db.get_mut(), &path);
+            File::sync_path(db, &path);
         }
 
         Ok(())

--- a/crates/red_knot_server/src/server/api/notifications/did_open.rs
+++ b/crates/red_knot_server/src/server/api/notifications/did_open.rs
@@ -32,8 +32,8 @@ impl SyncNotificationHandler for DidOpenTextDocumentHandler {
 
         if let Some(db) = session.workspace_db_for_path_mut(path.as_std_path()) {
             // TODO(dhruvmanila): Store the `file` in `DocumentController`
-            let file = system_path_to_file(&**db, &path).unwrap();
-            file.sync(db.get_mut());
+            let file = system_path_to_file(db, &path).unwrap();
+            file.sync(db);
         }
 
         // TODO(dhruvmanila): Publish diagnostics if the client doesn't support pull diagnostics

--- a/crates/red_knot_server/src/server/api/notifications/did_open_notebook.rs
+++ b/crates/red_knot_server/src/server/api/notifications/did_open_notebook.rs
@@ -40,8 +40,8 @@ impl SyncNotificationHandler for DidOpenNotebookHandler {
 
         if let Some(db) = session.workspace_db_for_path_mut(path.as_std_path()) {
             // TODO(dhruvmanila): Store the `file` in `DocumentController`
-            let file = system_path_to_file(&**db, &path).unwrap();
-            file.sync(db.get_mut());
+            let file = system_path_to_file(db, &path).unwrap();
+            file.sync(db);
         }
 
         // TODO(dhruvmanila): Publish diagnostics if the client doesn't support pull diagnostics

--- a/crates/red_knot_server/src/server/api/requests/diagnostic.rs
+++ b/crates/red_knot_server/src/server/api/requests/diagnostic.rs
@@ -25,7 +25,7 @@ impl BackgroundDocumentRequestHandler for DocumentDiagnosticRequestHandler {
 
     fn run_with_snapshot(
         snapshot: DocumentSnapshot,
-        db: Option<salsa::Handle<RootDatabase>>,
+        db: Option<RootDatabase>,
         _notifier: Notifier,
         _params: DocumentDiagnosticParams,
     ) -> Result<DocumentDiagnosticReportResult> {

--- a/crates/red_knot_server/src/server/api/traits.rs
+++ b/crates/red_knot_server/src/server/api/traits.rs
@@ -34,7 +34,7 @@ pub(super) trait BackgroundDocumentRequestHandler: RequestHandler {
 
     fn run_with_snapshot(
         snapshot: DocumentSnapshot,
-        db: Option<salsa::Handle<RootDatabase>>,
+        db: Option<RootDatabase>,
         notifier: Notifier,
         params: <<Self as RequestHandler>::RequestType as Request>::Params,
     ) -> super::Result<<<Self as RequestHandler>::RequestType as Request>::Result>;

--- a/crates/red_knot_workspace/src/workspace/files.rs
+++ b/crates/red_knot_workspace/src/workspace/files.rs
@@ -57,7 +57,7 @@ impl PackageFiles {
     pub fn indexed_mut(db: &mut dyn Db, package: Package) -> Option<IndexedFilesMut> {
         // Calling `runtime_mut` cancels all pending salsa queries. This ensures that there are no pending
         // reads to the file set.
-        let _ = db.runtime_mut();
+        let _ = db.as_dyn_database_mut().zalsa_mut();
 
         let files = package.file_set(db);
 

--- a/crates/red_knot_workspace/src/workspace/files.rs
+++ b/crates/red_knot_workspace/src/workspace/files.rs
@@ -55,8 +55,9 @@ impl PackageFiles {
     ///
     /// The changes are automatically written back to the database once the view is dropped.
     pub fn indexed_mut(db: &mut dyn Db, package: Package) -> Option<IndexedFilesMut> {
-        // Calling `runtime_mut` cancels all pending salsa queries. This ensures that there are no pending
+        // Calling `zalsa_mut` cancels all pending salsa queries. This ensures that there are no pending
         // reads to the file set.
+        // TODO: Use a non-internal API instead https://salsa.zulipchat.com/#narrow/stream/333573-salsa-3.2E0/topic/Expose.20an.20API.20to.20cancel.20other.20queries
         let _ = db.as_dyn_database_mut().zalsa_mut();
 
         let files = package.file_set(db);

--- a/crates/ruff_db/src/files.rs
+++ b/crates/ruff_db/src/files.rs
@@ -252,6 +252,13 @@ impl Files {
                 .to(FileRevision::now());
         }
     }
+
+    #[must_use]
+    pub fn snapshot(&self) -> Self {
+        Self {
+            inner: Arc::clone(&self.inner),
+        }
+    }
 }
 
 impl std::fmt::Debug for Files {
@@ -264,6 +271,8 @@ impl std::fmt::Debug for Files {
         map.finish()
     }
 }
+
+impl std::panic::RefUnwindSafe for Files {}
 
 /// A file that's either stored on the host system's file system or in the vendored file system.
 #[salsa::input]

--- a/crates/ruff_db/src/lib.rs
+++ b/crates/ruff_db/src/lib.rs
@@ -23,7 +23,6 @@ pub type FxDashSet<K> = dashmap::DashSet<K, BuildHasherDefault<FxHasher>>;
 pub trait Db: salsa::Database {
     fn vendored(&self) -> &VendoredFileSystem;
     fn system(&self) -> &dyn System;
-    fn system_mut(&mut self) -> &mut dyn System;
     fn files(&self) -> &Files;
 }
 
@@ -102,10 +101,6 @@ mod tests {
 
         fn system(&self) -> &dyn System {
             &self.system
-        }
-
-        fn system_mut(&mut self) -> &mut dyn System {
-            &mut self.system
         }
 
         fn files(&self) -> &Files {

--- a/crates/ruff_db/src/lib.rs
+++ b/crates/ruff_db/src/lib.rs
@@ -125,12 +125,11 @@ mod tests {
 
     #[salsa::db]
     impl salsa::Database for TestDb {
-        fn salsa_event(&self, event: salsa::Event) {
-            salsa::Database::attach(self, |_| {
-                tracing::trace!("event: {:?}", event);
-                let mut events = self.events.lock().unwrap();
-                events.push(event);
-            });
+        fn salsa_event(&self, event: &dyn Fn() -> salsa::Event) {
+            let event = event();
+            tracing::trace!("event: {:?}", event);
+            let mut events = self.events.lock().unwrap();
+            events.push(event);
         }
     }
 }

--- a/crates/ruff_db/src/testing.rs
+++ b/crates/ruff_db/src/testing.rs
@@ -76,9 +76,7 @@ where
 
     let event = events.iter().find(|event| {
         if let salsa::EventKind::WillExecute { database_key } = event.kind {
-            db.lookup_ingredient(database_key.ingredient_index())
-                .debug_name()
-                == query_name
+            db.ingredient_debug_name(database_key.ingredient_index()) == query_name
                 && database_key.key_index() == input.as_id()
         } else {
             false


### PR DESCRIPTION
## Summary

Pull in the latest salsa changes. The most notable changes are:

* The `Handle<Database>` was removed again. This requires re-adding `snapshot` methods to `RootDatabase` and using an `Arc` for System. @dhruvmanila this requires [some trickery](https://salsa.zulipchat.com/#narrow/stream/333573-salsa-3.2E0/topic/Expose.20an.20API.20to.20cancel.20other.20queries) to implement `system_mut`. I can with that in case my PR lands first
* Fewer thread local storage usage (let's see if this shows in the benchmarks
* The builder API is now part of the official salsa

## Test Plan

`cargo test`
