### PR TITLE
Include docs requirements for Renovate upgrades

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -8,13 +8,16 @@
   semanticCommits: "disabled",
   separateMajorMinor: false,
   prHourlyLimit: 10,
-  enabledManagers: ["github-actions", "pre-commit", "cargo", "pep621", "npm"],
+  enabledManagers: ["github-actions", "pre-commit", "cargo", "pep621", "pip_requirements", "npm"],
   cargo: {
     // See https://docs.renovatebot.com/configuration-options/#rangestrategy
     rangeStrategy: "update-lockfile",
   },
   pep621: {
     fileMatch: ["^(python|scripts)/.*pyproject\\.toml$"],
+  },
+  pip_requirements: {
+    fileMatch: ["^docs/requirements.*\\.txt$"],
   },
   npm: {
     fileMatch: ["^playground/.*package\\.json$"],
@@ -46,6 +49,14 @@
       // See: https://github.com/astral-sh/uv/issues/3642
       matchPackagePatterns: ["zip"],
       matchManagers: ["cargo"],
+      enabled: false,
+    },
+    {
+      // `mkdocs-material` requires a manual update to keep the version in sync
+      // with `mkdocs-material-insider`.
+      // See: https://squidfunk.github.io/mkdocs-material/insiders/upgrade/
+      matchManagers: ["pip_requirements"],
+      matchPackagePatterns: ["mkdocs-material"],
       enabled: false,
     },
     {


### PR DESCRIPTION
## Summary

This PR updates the Renovate config to account for the `requirements*.txt` files in `docs/` directory.

The `mkdocs-material` upgrade is ignored because we use commit SHA for the insider version and it should match the corresponding public version as per the docs: https://squidfunk.github.io/mkdocs-material/insiders/upgrade/ (`9.x.x-insiders-4.x.x`).

## Test Plan

```console
❯ renovate-config-validator
(node:83193) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
 INFO: Validating .github/renovate.json5
 INFO: Config validated successfully
```
