### PR TITLE
Ignore non-file workspace URL

### DIFF
--- a/crates/ruff_server/src/message.rs
+++ b/crates/ruff_server/src/message.rs
@@ -37,10 +37,18 @@ pub(super) fn try_show_message(
     Ok(())
 }
 
-/// Sends an error to the client with a formatted message. The error is sent in a
-/// `window/showMessage` notification.
+/// Sends a request to display an error to the client with a formatted message. The error is sent
+/// in a `window/showMessage` notification.
 macro_rules! show_err_msg {
     ($msg:expr$(, $($arg:tt),*)?) => {
         crate::message::show_message(::core::format_args!($msg, $($($arg),*)?).to_string(), lsp_types::MessageType::ERROR)
+    };
+}
+
+/// Sends a request to display a warning to the client with a formatted message. The warning is
+/// sent in a `window/showMessage` notification.
+macro_rules! show_warn_msg {
+    ($msg:expr$(, $($arg:tt),*)?) => {
+        crate::message::show_message(::core::format_args!($msg, $($($arg),*)?).to_string(), lsp_types::MessageType::WARNING)
     };
 }

--- a/crates/ruff_server/src/session/index.rs
+++ b/crates/ruff_server/src/session/index.rs
@@ -201,7 +201,8 @@ impl Index {
         global_settings: &ClientSettings,
     ) -> crate::Result<()> {
         if workspace_url.scheme() != "file" {
-            tracing::info!("Ignoring non-file workspace URL: {workspace_url}");
+            tracing::warn!("Ignoring non-file workspace: {workspace_url}");
+            show_warn_msg!("Ruff does not support non-file workspaces; Ignoring {workspace_url}");
             return Ok(());
         }
         let workspace_path = workspace_url.to_file_path().map_err(|()| {


### PR DESCRIPTION
## Summary

This PR updates the server to ignore non-file workspace URL.

This is to avoid crashing the server if the URL scheme is not "file". We'd still raise an error if the URL to file path conversion fails.

Also, as per the docs of [`to_file_path`](https://docs.rs/url/2.5.2/url/struct.Url.html#method.to_file_path):

> Note: This does not actually check the URL’s scheme, and may give nonsensical results for other schemes. It is the user’s responsibility to check the URL’s scheme before calling this.

resolves: #12660

## Test Plan

I'm not sure how to test this locally but the change is small enough to validate on its own.
