### PR TITLE
Fix cache invalidation for nested pyproject.toml files

### DIFF
--- a/crates/ruff_workspace/src/resolver.rs
+++ b/crates/ruff_workspace/src/resolver.rs
@@ -156,9 +156,16 @@ impl<'a> Resolver<'a> {
             .insert(format!("{path}/{{*filepath}}"), self.settings.len() - 1)
         {
             Ok(()) => {}
-            Err(InsertError::Conflict { .. }) => {}
+            Err(InsertError::Conflict { .. }) => {
+                return;
+            }
             Err(_) => unreachable!("file paths are escaped before being inserted in the router"),
         }
+
+        // Insert a mapping that matches the directory itself (without a trailing slash).
+        // Inserting should always succeed because conflicts are resolved above and the above insertion guarantees
+        // that the path is correctly escaped.
+        self.router.insert(path, self.settings.len() - 1).unwrap();
     }
 
     /// Return the appropriate [`Settings`] for a given [`Path`].


### PR DESCRIPTION
## Summary

This PR fixes an issue with cache invalidation where changing a nested pyproject.toml didn't invalidate the cache for those files. 

The root cause of the issue was that the `Resolver` returned the wrong configuration when querying the settings by the directory because it only registers a route for `directory/{files}` but a query by directory misses the trailing `/`. 

Fixes #12721 
Fixes #12264

## Test Plan

Played throught the example in #12721
