### PR TITLE
Exit with an error if there are check failures

### DIFF
--- a/crates/red_knot/src/main.rs
+++ b/crates/red_knot/src/main.rs
@@ -197,21 +197,19 @@ fn run() -> anyhow::Result<ExitStatus> {
 
 #[derive(Copy, Clone)]
 pub enum ExitStatus {
-    /// Linting was successful and there were no linting errors.
-    Success,
-    /// Linting was successful but there were linting errors.
-    Failure,
-    /// Linting failed.
-    Error,
+    /// Checking was successful and there were no errors.
+    Success = 0,
+
+    /// Checking was successful but there were errors.
+    Failure = 1,
+
+    /// Checking failed.
+    Error = 2,
 }
 
 impl From<ExitStatus> for ExitCode {
     fn from(status: ExitStatus) -> Self {
-        match status {
-            ExitStatus::Success => ExitCode::from(0),
-            ExitStatus::Failure => ExitCode::from(1),
-            ExitStatus::Error => ExitCode::from(2),
-        }
+        ExitCode::from(status as u8)
     }
 }
 

--- a/crates/red_knot_server/src/lib.rs
+++ b/crates/red_knot_server/src/lib.rs
@@ -1,8 +1,11 @@
 #![allow(dead_code)]
 
+use anyhow::Context;
 pub use edit::{DocumentKey, NotebookDocument, PositionEncoding, TextDocument};
-pub use server::Server;
 pub use session::{ClientSettings, DocumentQuery, DocumentSnapshot, Session};
+use std::num::NonZeroUsize;
+
+use crate::server::Server;
 
 #[macro_use]
 mod message;
@@ -22,4 +25,19 @@ pub(crate) type Result<T> = anyhow::Result<T>;
 
 pub(crate) fn version() -> &'static str {
     env!("CARGO_PKG_VERSION")
+}
+
+pub fn run_server() -> anyhow::Result<()> {
+    let four = NonZeroUsize::new(4).unwrap();
+
+    // by default, we set the number of worker threads to `num_cpus`, with a maximum of 4.
+    let worker_threads = std::thread::available_parallelism()
+        .unwrap_or(four)
+        .max(four);
+
+    Server::new(worker_threads)
+        .context("Failed to start server")?
+        .run()?;
+
+    Ok(())
 }

--- a/crates/red_knot_server/src/server.rs
+++ b/crates/red_knot_server/src/server.rs
@@ -25,7 +25,7 @@ pub(crate) use connection::ClientSender;
 
 pub(crate) type Result<T> = std::result::Result<T, api::Error>;
 
-pub struct Server {
+pub(crate) struct Server {
     connection: Connection,
     client_capabilities: ClientCapabilities,
     worker_threads: NonZeroUsize,
@@ -33,7 +33,7 @@ pub struct Server {
 }
 
 impl Server {
-    pub fn new(worker_threads: NonZeroUsize) -> crate::Result<Self> {
+    pub(crate) fn new(worker_threads: NonZeroUsize) -> crate::Result<Self> {
         let connection = ConnectionInitializer::stdio();
 
         let (id, init_params) = connection.initialize_start()?;
@@ -113,7 +113,7 @@ impl Server {
         })
     }
 
-    pub fn run(self) -> crate::Result<()> {
+    pub(crate) fn run(self) -> crate::Result<()> {
         type PanicHook = Box<dyn Fn(&PanicInfo<'_>) + 'static + Sync + Send>;
         struct RestorePanicHook {
             hook: Option<PanicHook>,

--- a/crates/ruff/src/main.rs
+++ b/crates/ruff/src/main.rs
@@ -85,7 +85,6 @@ pub fn main() -> ExitCode {
     match run(args) {
         Ok(code) => code.into(),
         Err(err) => {
-            #[allow(clippy::print_stderr)]
             {
                 use std::io::Write;
 


### PR DESCRIPTION
## Summary

This PR copies the behavior from Ruff to exit with 1 if there are linting errors and 0 otherwise. 

## Test Plan

* I ran Red Knot on a directory with linting errors and verified that the exit code is 1.
* I ran Red Knot on a directory without linting errors and verified that the exit code is 0.
<!-- How was it tested? -->
