### PR TITLE
Add scope and definitions for comprehensions

### DIFF
--- a/crates/red_knot_python_semantic/src/semantic_index.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index.rs
@@ -528,7 +528,7 @@ y = 2
         ));
     }
 
-    /// Test case to validate that the generator scope is correctly identifier and that the target
+    /// Test case to validate that the generator scope is correctly identified and that the target
     /// variable is defined only in the generator scope and not in the global scope.
     #[test]
     fn generator_scope() {
@@ -550,7 +550,7 @@ y = 2
             panic!("expected one child scope")
         };
 
-        assert_eq!(generator_scope.kind(), ScopeKind::Generator);
+        assert_eq!(generator_scope.kind(), ScopeKind::Comprehension);
         assert_eq!(
             generator_scope_id.to_scope_id(&db, file).name(&db),
             "<listcomp>"
@@ -596,7 +596,7 @@ y = 2
         let [definition] = use_def.use_definitions(element_use_id) else {
             panic!("expected one definition")
         };
-        let DefinitionKind::Generator(generator) = definition.node(&db) else {
+        let DefinitionKind::Comprehension(generator) = definition.node(&db) else {
             panic!("expected generator definition")
         };
         let ast::Comprehension { target, .. } = generator.node();
@@ -628,7 +628,7 @@ y = 2
             panic!("expected one child scope")
         };
 
-        assert_eq!(generator_scope.kind(), ScopeKind::Generator);
+        assert_eq!(generator_scope.kind(), ScopeKind::Comprehension);
         assert_eq!(
             generator_scope_id.to_scope_id(&db, file).name(&db),
             "<listcomp>"
@@ -644,7 +644,7 @@ y = 2
             panic!("expected one inner generator scope")
         };
 
-        assert_eq!(inner_generator_scope.kind(), ScopeKind::Generator);
+        assert_eq!(inner_generator_scope.kind(), ScopeKind::Comprehension);
         assert_eq!(
             inner_generator_scope_id.to_scope_id(&db, file).name(&db),
             "<setcomp>"
@@ -653,39 +653,6 @@ y = 2
         let inner_generator_symbol_table = index.symbol_table(inner_generator_scope_id);
 
         assert_eq!(names(&inner_generator_symbol_table), vec!["x"]);
-    }
-
-    /// Test that validates that the variables defined in assignment expressions within a generator
-    /// expressions are defined in the outer scope of the generator.
-    #[test]
-    fn assignment_expression_in_generator() {
-        let TestCase { db, file } = test_case(
-            "
-[a := 1 for x in iter1 if (b := 2)]
-",
-        );
-
-        let index = semantic_index(&db, file);
-        let global_table = index.symbol_table(FileScopeId::global());
-
-        assert_eq!(names(&global_table), vec!["iter1", "b", "a"]);
-
-        let [(generator_scope_id, generator_scope)] = index
-            .child_scopes(FileScopeId::global())
-            .collect::<Vec<_>>()[..]
-        else {
-            panic!("expected one child scope")
-        };
-
-        assert_eq!(generator_scope.kind(), ScopeKind::Generator);
-        assert_eq!(
-            generator_scope_id.to_scope_id(&db, file).name(&db),
-            "<listcomp>"
-        );
-
-        let generator_symbol_table = index.symbol_table(generator_scope_id);
-
-        assert_eq!(names(&generator_symbol_table), vec!["x"]);
     }
 
     #[test]

--- a/crates/red_knot_python_semantic/src/semantic_index/builder.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/builder.rs
@@ -258,8 +258,8 @@ impl<'db> SemanticIndexBuilder<'db> {
         nested_scope
     }
 
-    /// Visit a list of [`Comprehension`] nodes, assumed to be the comprehensions that compose a
-    /// generator expression, like a list or set comprehension.
+    /// Visit a list of [`Comprehension`] nodes, assumed to be the "generators" that compose a
+    /// comprehension (that is, the `for x in y` and `for y in z` parts of `x for x in y for y in z`.)
     ///
     /// [`Comprehension`]: ast::Comprehension
     fn visit_generators(&mut self, scope: NodeWithScopeRef, generators: &'db [ast::Comprehension]) {

--- a/crates/red_knot_python_semantic/src/semantic_index/definition.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/definition.rs
@@ -44,6 +44,7 @@ pub(crate) enum DefinitionNodeRef<'a> {
     NamedExpression(&'a ast::ExprNamed),
     Assignment(AssignmentDefinitionNodeRef<'a>),
     AnnotatedAssignment(&'a ast::StmtAnnAssign),
+    Generator(GeneratorDefinitionNodeRef<'a>),
 }
 
 impl<'a> From<&'a ast::StmtFunctionDef> for DefinitionNodeRef<'a> {
@@ -88,6 +89,12 @@ impl<'a> From<AssignmentDefinitionNodeRef<'a>> for DefinitionNodeRef<'a> {
     }
 }
 
+impl<'a> From<GeneratorDefinitionNodeRef<'a>> for DefinitionNodeRef<'a> {
+    fn from(node: GeneratorDefinitionNodeRef<'a>) -> Self {
+        Self::Generator(node)
+    }
+}
+
 #[derive(Copy, Clone, Debug)]
 pub(crate) struct ImportFromDefinitionNodeRef<'a> {
     pub(crate) node: &'a ast::StmtImportFrom,
@@ -98,6 +105,12 @@ pub(crate) struct ImportFromDefinitionNodeRef<'a> {
 pub(crate) struct AssignmentDefinitionNodeRef<'a> {
     pub(crate) assignment: &'a ast::StmtAssign,
     pub(crate) target: &'a ast::ExprName,
+}
+
+#[derive(Copy, Clone, Debug)]
+pub(crate) struct GeneratorDefinitionNodeRef<'a> {
+    pub(crate) node: &'a ast::Comprehension,
+    pub(crate) first: bool,
 }
 
 impl DefinitionNodeRef<'_> {
@@ -131,6 +144,12 @@ impl DefinitionNodeRef<'_> {
             DefinitionNodeRef::AnnotatedAssignment(assign) => {
                 DefinitionKind::AnnotatedAssignment(AstNodeRef::new(parsed, assign))
             }
+            DefinitionNodeRef::Generator(GeneratorDefinitionNodeRef { node, first }) => {
+                DefinitionKind::Generator(GeneratorDefinitionKind {
+                    node: AstNodeRef::new(parsed, node),
+                    first,
+                })
+            }
         }
     }
 
@@ -148,6 +167,7 @@ impl DefinitionNodeRef<'_> {
                 target,
             }) => target.into(),
             Self::AnnotatedAssignment(node) => node.into(),
+            Self::Generator(GeneratorDefinitionNodeRef { node, first: _ }) => node.into(),
         }
     }
 }
@@ -161,6 +181,23 @@ pub enum DefinitionKind {
     NamedExpression(AstNodeRef<ast::ExprNamed>),
     Assignment(AssignmentDefinitionKind),
     AnnotatedAssignment(AstNodeRef<ast::StmtAnnAssign>),
+    Generator(GeneratorDefinitionKind),
+}
+
+#[derive(Clone, Debug)]
+pub struct GeneratorDefinitionKind {
+    node: AstNodeRef<ast::Comprehension>,
+    first: bool,
+}
+
+impl GeneratorDefinitionKind {
+    pub(crate) fn node(&self) -> &ast::Comprehension {
+        self.node.node()
+    }
+
+    pub(crate) fn is_first(&self) -> bool {
+        self.first
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -227,6 +264,12 @@ impl From<&ast::ExprNamed> for DefinitionNodeKey {
 
 impl From<&ast::StmtAnnAssign> for DefinitionNodeKey {
     fn from(node: &ast::StmtAnnAssign) -> Self {
+        Self(NodeKey::from_node(node))
+    }
+}
+
+impl From<&ast::Comprehension> for DefinitionNodeKey {
+    fn from(node: &ast::Comprehension) -> Self {
         Self(NodeKey::from_node(node))
     }
 }

--- a/crates/red_knot_python_semantic/src/semantic_index/definition.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/definition.rs
@@ -44,7 +44,7 @@ pub(crate) enum DefinitionNodeRef<'a> {
     NamedExpression(&'a ast::ExprNamed),
     Assignment(AssignmentDefinitionNodeRef<'a>),
     AnnotatedAssignment(&'a ast::StmtAnnAssign),
-    Generator(GeneratorDefinitionNodeRef<'a>),
+    Comprehension(ComprehensionDefinitionNodeRef<'a>),
 }
 
 impl<'a> From<&'a ast::StmtFunctionDef> for DefinitionNodeRef<'a> {
@@ -89,9 +89,9 @@ impl<'a> From<AssignmentDefinitionNodeRef<'a>> for DefinitionNodeRef<'a> {
     }
 }
 
-impl<'a> From<GeneratorDefinitionNodeRef<'a>> for DefinitionNodeRef<'a> {
-    fn from(node: GeneratorDefinitionNodeRef<'a>) -> Self {
-        Self::Generator(node)
+impl<'a> From<ComprehensionDefinitionNodeRef<'a>> for DefinitionNodeRef<'a> {
+    fn from(node: ComprehensionDefinitionNodeRef<'a>) -> Self {
+        Self::Comprehension(node)
     }
 }
 
@@ -108,7 +108,7 @@ pub(crate) struct AssignmentDefinitionNodeRef<'a> {
 }
 
 #[derive(Copy, Clone, Debug)]
-pub(crate) struct GeneratorDefinitionNodeRef<'a> {
+pub(crate) struct ComprehensionDefinitionNodeRef<'a> {
     pub(crate) node: &'a ast::Comprehension,
     pub(crate) first: bool,
 }
@@ -144,8 +144,8 @@ impl DefinitionNodeRef<'_> {
             DefinitionNodeRef::AnnotatedAssignment(assign) => {
                 DefinitionKind::AnnotatedAssignment(AstNodeRef::new(parsed, assign))
             }
-            DefinitionNodeRef::Generator(GeneratorDefinitionNodeRef { node, first }) => {
-                DefinitionKind::Generator(GeneratorDefinitionKind {
+            DefinitionNodeRef::Comprehension(ComprehensionDefinitionNodeRef { node, first }) => {
+                DefinitionKind::Comprehension(ComprehensionDefinitionKind {
                     node: AstNodeRef::new(parsed, node),
                     first,
                 })
@@ -167,7 +167,7 @@ impl DefinitionNodeRef<'_> {
                 target,
             }) => target.into(),
             Self::AnnotatedAssignment(node) => node.into(),
-            Self::Generator(GeneratorDefinitionNodeRef { node, first: _ }) => node.into(),
+            Self::Comprehension(ComprehensionDefinitionNodeRef { node, first: _ }) => node.into(),
         }
     }
 }
@@ -181,16 +181,16 @@ pub enum DefinitionKind {
     NamedExpression(AstNodeRef<ast::ExprNamed>),
     Assignment(AssignmentDefinitionKind),
     AnnotatedAssignment(AstNodeRef<ast::StmtAnnAssign>),
-    Generator(GeneratorDefinitionKind),
+    Comprehension(ComprehensionDefinitionKind),
 }
 
 #[derive(Clone, Debug)]
-pub struct GeneratorDefinitionKind {
+pub struct ComprehensionDefinitionKind {
     node: AstNodeRef<ast::Comprehension>,
     first: bool,
 }
 
-impl GeneratorDefinitionKind {
+impl ComprehensionDefinitionKind {
     pub(crate) fn node(&self) -> &ast::Comprehension {
         self.node.node()
     }

--- a/crates/red_knot_python_semantic/src/semantic_index/symbol.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/symbol.rs
@@ -127,6 +127,10 @@ impl<'db> ScopeId<'db> {
             NodeWithScopeKind::Function(function)
             | NodeWithScopeKind::FunctionTypeParameters(function) => function.name.as_str(),
             NodeWithScopeKind::Lambda(_) => "<lambda>",
+            NodeWithScopeKind::ListComprehension(_) => "<listcomp>",
+            NodeWithScopeKind::SetComprehension(_) => "<setcomp>",
+            NodeWithScopeKind::DictComprehension(_) => "<dictcomp>",
+            NodeWithScopeKind::Generator(_) => "<generator>",
         }
     }
 }
@@ -170,6 +174,13 @@ pub enum ScopeKind {
     Annotation,
     Class,
     Function,
+    Generator,
+}
+
+impl ScopeKind {
+    pub const fn is_generator(self) -> bool {
+        matches!(self, ScopeKind::Generator)
+    }
 }
 
 /// Symbol table for a specific [`Scope`].
@@ -300,6 +311,10 @@ pub(crate) enum NodeWithScopeRef<'a> {
     Lambda(&'a ast::ExprLambda),
     FunctionTypeParameters(&'a ast::StmtFunctionDef),
     ClassTypeParameters(&'a ast::StmtClassDef),
+    ListComprehension(&'a ast::ExprListComp),
+    SetComprehension(&'a ast::ExprSetComp),
+    DictComprehension(&'a ast::ExprDictComp),
+    Generator(&'a ast::ExprGenerator),
 }
 
 impl NodeWithScopeRef<'_> {
@@ -326,6 +341,18 @@ impl NodeWithScopeRef<'_> {
             NodeWithScopeRef::ClassTypeParameters(class) => {
                 NodeWithScopeKind::ClassTypeParameters(AstNodeRef::new(module, class))
             }
+            NodeWithScopeRef::ListComprehension(comprehension) => {
+                NodeWithScopeKind::ListComprehension(AstNodeRef::new(module, comprehension))
+            }
+            NodeWithScopeRef::SetComprehension(comprehension) => {
+                NodeWithScopeKind::SetComprehension(AstNodeRef::new(module, comprehension))
+            }
+            NodeWithScopeRef::DictComprehension(comprehension) => {
+                NodeWithScopeKind::DictComprehension(AstNodeRef::new(module, comprehension))
+            }
+            NodeWithScopeRef::Generator(generator) => {
+                NodeWithScopeKind::Generator(AstNodeRef::new(module, generator))
+            }
         }
     }
 
@@ -337,6 +364,10 @@ impl NodeWithScopeRef<'_> {
             NodeWithScopeRef::Lambda(_) => ScopeKind::Function,
             NodeWithScopeRef::FunctionTypeParameters(_)
             | NodeWithScopeRef::ClassTypeParameters(_) => ScopeKind::Annotation,
+            NodeWithScopeRef::ListComprehension(_)
+            | NodeWithScopeRef::SetComprehension(_)
+            | NodeWithScopeRef::DictComprehension(_)
+            | NodeWithScopeRef::Generator(_) => ScopeKind::Generator,
         }
     }
 
@@ -356,6 +387,18 @@ impl NodeWithScopeRef<'_> {
             NodeWithScopeRef::ClassTypeParameters(class) => {
                 NodeWithScopeKey::ClassTypeParameters(NodeKey::from_node(class))
             }
+            NodeWithScopeRef::ListComprehension(comprehension) => {
+                NodeWithScopeKey::ListComprehension(NodeKey::from_node(comprehension))
+            }
+            NodeWithScopeRef::SetComprehension(comprehension) => {
+                NodeWithScopeKey::SetComprehension(NodeKey::from_node(comprehension))
+            }
+            NodeWithScopeRef::DictComprehension(comprehension) => {
+                NodeWithScopeKey::DictComprehension(NodeKey::from_node(comprehension))
+            }
+            NodeWithScopeRef::Generator(generator) => {
+                NodeWithScopeKey::Generator(NodeKey::from_node(generator))
+            }
         }
     }
 }
@@ -369,6 +412,10 @@ pub enum NodeWithScopeKind {
     Function(AstNodeRef<ast::StmtFunctionDef>),
     FunctionTypeParameters(AstNodeRef<ast::StmtFunctionDef>),
     Lambda(AstNodeRef<ast::ExprLambda>),
+    ListComprehension(AstNodeRef<ast::ExprListComp>),
+    SetComprehension(AstNodeRef<ast::ExprSetComp>),
+    DictComprehension(AstNodeRef<ast::ExprDictComp>),
+    Generator(AstNodeRef<ast::ExprGenerator>),
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
@@ -379,4 +426,8 @@ pub(crate) enum NodeWithScopeKey {
     Function(NodeKey),
     FunctionTypeParameters(NodeKey),
     Lambda(NodeKey),
+    ListComprehension(NodeKey),
+    SetComprehension(NodeKey),
+    DictComprehension(NodeKey),
+    Generator(NodeKey),
 }

--- a/crates/red_knot_python_semantic/src/semantic_index/symbol.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/symbol.rs
@@ -114,6 +114,10 @@ impl<'db> ScopeId<'db> {
             NodeWithScopeKind::ClassTypeParameters(_)
                 | NodeWithScopeKind::FunctionTypeParameters(_)
                 | NodeWithScopeKind::Function(_)
+                | NodeWithScopeKind::ListComprehension(_)
+                | NodeWithScopeKind::SetComprehension(_)
+                | NodeWithScopeKind::DictComprehension(_)
+                | NodeWithScopeKind::GeneratorExpression(_)
         )
     }
 
@@ -130,7 +134,7 @@ impl<'db> ScopeId<'db> {
             NodeWithScopeKind::ListComprehension(_) => "<listcomp>",
             NodeWithScopeKind::SetComprehension(_) => "<setcomp>",
             NodeWithScopeKind::DictComprehension(_) => "<dictcomp>",
-            NodeWithScopeKind::Generator(_) => "<generator>",
+            NodeWithScopeKind::GeneratorExpression(_) => "<generator>",
         }
     }
 }
@@ -174,12 +178,12 @@ pub enum ScopeKind {
     Annotation,
     Class,
     Function,
-    Generator,
+    Comprehension,
 }
 
 impl ScopeKind {
-    pub const fn is_generator(self) -> bool {
-        matches!(self, ScopeKind::Generator)
+    pub const fn is_comprehension(self) -> bool {
+        matches!(self, ScopeKind::Comprehension)
     }
 }
 
@@ -314,7 +318,7 @@ pub(crate) enum NodeWithScopeRef<'a> {
     ListComprehension(&'a ast::ExprListComp),
     SetComprehension(&'a ast::ExprSetComp),
     DictComprehension(&'a ast::ExprDictComp),
-    Generator(&'a ast::ExprGenerator),
+    GeneratorExpression(&'a ast::ExprGenerator),
 }
 
 impl NodeWithScopeRef<'_> {
@@ -350,8 +354,8 @@ impl NodeWithScopeRef<'_> {
             NodeWithScopeRef::DictComprehension(comprehension) => {
                 NodeWithScopeKind::DictComprehension(AstNodeRef::new(module, comprehension))
             }
-            NodeWithScopeRef::Generator(generator) => {
-                NodeWithScopeKind::Generator(AstNodeRef::new(module, generator))
+            NodeWithScopeRef::GeneratorExpression(generator) => {
+                NodeWithScopeKind::GeneratorExpression(AstNodeRef::new(module, generator))
             }
         }
     }
@@ -367,7 +371,7 @@ impl NodeWithScopeRef<'_> {
             NodeWithScopeRef::ListComprehension(_)
             | NodeWithScopeRef::SetComprehension(_)
             | NodeWithScopeRef::DictComprehension(_)
-            | NodeWithScopeRef::Generator(_) => ScopeKind::Generator,
+            | NodeWithScopeRef::GeneratorExpression(_) => ScopeKind::Comprehension,
         }
     }
 
@@ -396,8 +400,8 @@ impl NodeWithScopeRef<'_> {
             NodeWithScopeRef::DictComprehension(comprehension) => {
                 NodeWithScopeKey::DictComprehension(NodeKey::from_node(comprehension))
             }
-            NodeWithScopeRef::Generator(generator) => {
-                NodeWithScopeKey::Generator(NodeKey::from_node(generator))
+            NodeWithScopeRef::GeneratorExpression(generator) => {
+                NodeWithScopeKey::GeneratorExpression(NodeKey::from_node(generator))
             }
         }
     }
@@ -415,7 +419,7 @@ pub enum NodeWithScopeKind {
     ListComprehension(AstNodeRef<ast::ExprListComp>),
     SetComprehension(AstNodeRef<ast::ExprSetComp>),
     DictComprehension(AstNodeRef<ast::ExprDictComp>),
-    Generator(AstNodeRef<ast::ExprGenerator>),
+    GeneratorExpression(AstNodeRef<ast::ExprGenerator>),
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
@@ -429,5 +433,5 @@ pub(crate) enum NodeWithScopeKey {
     ListComprehension(NodeKey),
     SetComprehension(NodeKey),
     DictComprehension(NodeKey),
-    Generator(NodeKey),
+    GeneratorExpression(NodeKey),
 }

--- a/crates/ruff_benchmark/benches/red_knot.rs
+++ b/crates/ruff_benchmark/benches/red_knot.rs
@@ -89,7 +89,7 @@ fn benchmark_incremental(criterion: &mut Criterion) {
                 let Case { db, parser, .. } = case;
                 let result = db.check_file(*parser).unwrap();
 
-                assert_eq!(result.len(), 403);
+                assert_eq!(result.len(), 402);
             },
             BatchSize::SmallInput,
         );
@@ -104,7 +104,7 @@ fn benchmark_cold(criterion: &mut Criterion) {
                 let Case { db, parser, .. } = case;
                 let result = db.check_file(*parser).unwrap();
 
-                assert_eq!(result.len(), 403);
+                assert_eq!(result.len(), 402);
             },
             BatchSize::SmallInput,
         );


### PR DESCRIPTION
## Summary

This PR adds scope and definition for comprehension nodes. This includes the following nodes:
* List comprehension
* Dictionary comprehension
* Set comprehension 
* Generator expression

### Scope

Each expression here adds it's own scope with one caveat - the `iter` expression of the first generator is part of the parent scope. For example, in the following code snippet the `iter1` variable is evaluated in the outer scope.

```py
[x for x in iter1]
```

> The iterable expression in the leftmost for clause is evaluated directly in the enclosing scope and then passed as an argument to the implicitly nested scope. 
>
> Reference: https://docs.python.org/3/reference/expressions.html#displays-for-lists-sets-and-dictionaries

There's another special case for assignment expressions:

> There is one special case: an assignment expression occurring in a list, set or dict comprehension or in a generator expression (below collectively referred to as “comprehensions”) binds the target in the containing scope, honoring a nonlocal or global declaration for the target in that scope, if one exists.
>
> Reference: https://peps.python.org/pep-0572/#scope-of-the-target

For example, in the following code snippet, the variables `a` and `b` are available after the comprehension while `x` isn't:
```py
[a := 1 for x in range(2) if (b := 2)]
```

### Definition

Each comprehension node adds a single definition, the "target" variable (`[_ for target in iter]`). This has been accounted for and a new variant has been added to `DefinitionKind`.

### Type Inference

Currently, type inference is limited to a single scope. It doesn't _enter_ in another scope to infer the types of the remaining expressions of a node. To accommodate this, the type inference for a **scope** requires new methods which _doesn't_ infer the type of the `iter` expression of the leftmost outer generator (that's defined in the enclosing scope).

The type inference for the scope region is split into two parts:
* `infer_generator_expression` (similarly for comprehensions) infers the type of the `iter` expression of the leftmost outer generator
* `infer_generator_expression_scope` (similarly for comprehension) infers the type of the remaining expressions except for the one mentioned in the previous point

The type inference for the **definition** also needs to account for this special case of leftmost generator. This is done by defining a `first` boolean parameter which indicates whether this comprehension definition occurs first in the enclosing expression.

## Test Plan

New test cases were added to validate multiple scenarios. Refer to the documentation for each test case which explains what is being tested.
