### PR TITLE
[ruff] Ignore empty tuples for `incorrectly-parenthesized-tuple-in-subscript (RUF031)`

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/ruff/RUF031.py
+++ b/crates/ruff_linter/resources/test/fixtures/ruff/RUF031.py
@@ -26,3 +26,4 @@ token_features[
 
 d[1,]
 d[(1,)]
+d[()] # empty tuples should be ignored

--- a/crates/ruff_linter/resources/test/fixtures/ruff/RUF031_prefer_parens.py
+++ b/crates/ruff_linter/resources/test/fixtures/ruff/RUF031_prefer_parens.py
@@ -25,3 +25,4 @@ token_features[
 ] = self._extract_raw_features_from_token
 d[1,]
 d[(1,)]
+d[()] # empty tuples should be ignored

--- a/crates/ruff_linter/src/rules/ruff/rules/incorrectly_parenthesized_tuple_in_subscript.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/incorrectly_parenthesized_tuple_in_subscript.rs
@@ -6,7 +6,7 @@ use ruff_text_size::Ranged;
 use crate::checkers::ast::Checker;
 
 /// ## What it does
-/// Checks for consistent style regarding whether tuples in subscripts
+/// Checks for consistent style regarding whether nonempty tuples in subscripts
 /// are parenthesized.
 ///
 /// The exact nature of this violation depends on the setting
@@ -20,14 +20,14 @@ use crate::checkers::ast::Checker;
 /// ## Example
 ///
 /// ```python
-/// directions = {(0, 1): "North", (-1, 0): "East", (0, -1): "South", (1, 0): "West"}
+/// directions = {(0, 1): "North", (1, 0): "East", (0, -1): "South", (-1, 0): "West"}
 /// directions[(0, 1)]
 /// ```
 ///
 /// Use instead (with default setting):
 ///
 /// ```python
-/// directions = {(0, 1): "North", (-1, 0): "East", (0, -1): "South", (1, 0): "West"}
+/// directions = {(0, 1): "North", (1, 0): "East", (0, -1): "South", (-1, 0): "West"}
 /// directions[0, 1]
 /// ```
 

--- a/crates/ruff_linter/src/rules/ruff/rules/incorrectly_parenthesized_tuple_in_subscript.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/incorrectly_parenthesized_tuple_in_subscript.rs
@@ -61,7 +61,7 @@ pub(crate) fn subscript_with_parenthesized_tuple(checker: &mut Checker, subscrip
     let Some(tuple_subscript) = subscript.slice.as_tuple_expr() else {
         return;
     };
-    if tuple_subscript.parenthesized == prefer_parentheses {
+    if tuple_subscript.parenthesized == prefer_parentheses || tuple_subscript.elts.is_empty() {
         return;
     }
     let locator = checker.locator();

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF031_RUF031.py.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF031_RUF031.py.snap
@@ -155,6 +155,7 @@ RUF031.py:28:3: RUF031 [*] Avoid parentheses for tuples in subscripts.
 27 | d[1,]
 28 | d[(1,)]
    |   ^^^^ RUF031
+29 | d[()] # empty tuples should be ignored
    |
    = help: Remove the parentheses.
 
@@ -164,3 +165,4 @@ RUF031.py:28:3: RUF031 [*] Avoid parentheses for tuples in subscripts.
 27 27 | d[1,]
 28    |-d[(1,)]
    28 |+d[1,]
+29 29 | d[()] # empty tuples should be ignored

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__prefer_parentheses_getitem_tuple.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__prefer_parentheses_getitem_tuple.snap
@@ -117,6 +117,7 @@ RUF031_prefer_parens.py:26:3: RUF031 [*] Use parentheses for tuples in subscript
 26 | d[1,]
    |   ^^ RUF031
 27 | d[(1,)]
+28 | d[()] # empty tuples should be ignored
    |
    = help: Parenthesize the tuple.
 
@@ -127,3 +128,4 @@ RUF031_prefer_parens.py:26:3: RUF031 [*] Use parentheses for tuples in subscript
 26    |-d[1,]
 27 26 | d[(1,)]
    27 |+d[(1,)]
+28 28 | d[()] # empty tuples should be ignored


### PR DESCRIPTION
## Summary

It is a syntax error to replace `d[()]` with `d[]`, so we skip empty tuples when checking for violations of RUF031.

Closes #12739.
