### PR TITLE
Skip checking a file if it failed to read

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2166,6 +2166,7 @@ dependencies = [
  "rustc-hash 2.0.0",
  "salsa",
  "tempfile",
+ "thiserror",
  "tracing",
  "tracing-subscriber",
  "tracing-tree",

--- a/crates/red_knot_workspace/src/workspace.rs
+++ b/crates/red_knot_workspace/src/workspace.rs
@@ -1,9 +1,10 @@
-use salsa::{Durability, Setter as _};
 use std::{collections::BTreeMap, sync::Arc};
 
 use rustc_hash::{FxBuildHasher, FxHashSet};
+use salsa::{Durability, Setter as _};
 
 pub use metadata::{PackageMetadata, WorkspaceMetadata};
+use ruff_db::source::{source_text, SourceDiagnostic};
 use ruff_db::{
     files::{system_path_to_file, File},
     system::{walk_directory::WalkState, SystemPath, SystemPathBuf},
@@ -345,12 +346,28 @@ impl Package {
     }
 }
 
+#[salsa::tracked]
 pub(super) fn check_file(db: &dyn Db, file: File) -> Diagnostics {
     let path = file.path(db);
     let _span = tracing::debug_span!("check_file", file=%path).entered();
     tracing::debug!("Checking file {path}");
 
     let mut diagnostics = Vec::new();
+
+    // The use of an accumulator seems unnecessarily complicated here.
+    let source_diagnostics = source_text::accumulated::<SourceDiagnostic>(db.upcast(), file);
+
+    // Abort checking if there are IO errors.
+    if !source_diagnostics.is_empty() {
+        diagnostics.extend(
+            source_diagnostics
+                .iter()
+                .map(std::string::ToString::to_string),
+        );
+
+        return Diagnostics::from(diagnostics);
+    }
+
     diagnostics.extend_from_slice(lint_syntax(db, file));
     diagnostics.extend_from_slice(lint_semantic(db, file));
     Diagnostics::from(diagnostics)
@@ -397,4 +414,49 @@ fn discover_package_files(db: &dyn Db, path: &SystemPath) -> FxHashSet<File> {
     }
 
     files
+}
+
+#[cfg(test)]
+mod tests {
+    use ruff_db::files::system_path_to_file;
+    use ruff_db::source::source_text;
+    use ruff_db::system::{DbWithTestSystem, SystemPath};
+    use ruff_db::testing::assert_function_query_was_not_run;
+
+    use crate::db::tests::TestDb;
+    use crate::lint::{lint_syntax, Diagnostics};
+    use crate::workspace::check_file;
+
+    #[test]
+    fn check_file_skips_linting_when_file_cant_be_read() -> ruff_db::system::Result<()> {
+        let mut db = TestDb::new();
+        let path = SystemPath::new("test.py");
+
+        db.write_file(path, "x = 10")?;
+        let file = system_path_to_file(&db, path).unwrap();
+
+        // Now the file gets deleted before we had a chance to read its source text.
+        db.memory_file_system().remove_file(path)?;
+        file.sync(&mut db);
+
+        assert_eq!(source_text(&db, file).as_str(), "");
+        assert_eq!(
+            check_file(&db, file),
+            Diagnostics::List(vec![
+                "Failed to read file: No such file or directory".to_string()
+            ])
+        );
+
+        let events = db.take_salsa_events();
+        assert_function_query_was_not_run(&db, lint_syntax, file, &events);
+
+        // The user now creates a new file with an empty text. The source text
+        // content returned by `source_text` remains unchanged, but the diagnostics should get updated.
+        db.write_file(path, "").unwrap();
+
+        assert_eq!(source_text(&db, file).as_str(), "");
+        assert_eq!(check_file(&db, file), Diagnostics::Empty);
+
+        Ok(())
+    }
 }

--- a/crates/red_knot_workspace/src/workspace.rs
+++ b/crates/red_knot_workspace/src/workspace.rs
@@ -354,17 +354,16 @@ pub(super) fn check_file(db: &dyn Db, file: File) -> Diagnostics {
 
     let mut diagnostics = Vec::new();
 
-    // The use of an accumulator seems unnecessarily complicated here.
     let source_diagnostics = source_text::accumulated::<SourceDiagnostic>(db.upcast(), file);
+    // TODO(micha): Consider using a single accumulator for all diagnostics
+    diagnostics.extend(
+        source_diagnostics
+            .iter()
+            .map(std::string::ToString::to_string),
+    );
 
     // Abort checking if there are IO errors.
-    if !source_diagnostics.is_empty() {
-        diagnostics.extend(
-            source_diagnostics
-                .iter()
-                .map(std::string::ToString::to_string),
-        );
-
+    if source_text(db.upcast(), file).has_read_error() {
         return Diagnostics::from(diagnostics);
     }
 

--- a/crates/ruff_db/Cargo.toml
+++ b/crates/ruff_db/Cargo.toml
@@ -27,6 +27,7 @@ ignore = { workspace = true, optional = true }
 matchit = { workspace = true }
 salsa = { workspace = true }
 path-slash = { workspace = true }
+thiserror = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, optional = true }
 tracing-tree = { workspace = true, optional = true }


### PR DESCRIPTION
## Summary

Up to know, there was the risk of a race condition between when we discovered the files of a package and when we called `check_file` 
because a file could have been deleted in the meantime before the file watch notification came in. This PR changes `check_file` to raise an error (diagnostic) if that happens. 

I explored a few different designs and ultimately ended with using an accumulator. It's not the nicest API. 

**`try_source_text` function with specify**

My first approach was to introduce a `try_source_text` that returns a `Result<SourceText, SourceTextError>` and uses `specify` (Salsa) to cache the read source text
when the file could be read successfully. Unfortunately, this doesn't work because `specify` requires that the query arguments are tracked Salsa structs, but `File` is an input. 

**`try_source_text` query**
My second approach was to change `source_text` to `try_source_text` that returns a `Result<SourceText, SourceTextError` (now a salsa query) and
to introduce a new `source_text` function (not a salsa query) that invokes the fallback logic. 

This could technically work but there are a few caveats:

* Every (uncached) `source_text` call would create an empty fallback notebook. This should not be too bad because we only do this when we have a very specific race.
* `std::io::Error` doesn't implement `Eq`. That means `source_text` can no longer use Salsa's backdating optimization (because the `Result` no longer implements `Eq`)

**Accumulator**

I do this in this PR: I use a salsa accumulator to emit a diagnostic in source text and explicitly consume the diagnostic in `check_file`. 

I would have preferred if the test for reading the file was more explicit (e.g., by using a `Result`), but I also think the way it is now is fine. 
However, we'll have to add these checks everywhere where we perform file-centric operations (`check`, `fix`, `format`).

We don't need the check for other operations like providing auto-completion because the fallback of an empty document is sufficient in that case. 
The fallback primarily exists to avoid creating additional diagnostics because the text is empty. 


## Should we just change `source_text` to always return a `Result`. 

Besides the points mentioned above: Changing `source_text` to return a `Result` would require making all queries that transitively read a file's source text (which is almost all queries)
to return a `Result`. That would be very painful without having a clear upside. In most cases, assuming the file is empty is actually a pretty good default (e.g., it results in an *import not found** error when trying to import a symbol from that file. This is not 100% accurate but good enough considering that this is a race condition. 


<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

See the added integration test
