### PR TITLE
[red-knot] add dev dependency on ruff_db os feature from red_knot_pyt…

### DIFF
--- a/crates/red_knot_python_semantic/Cargo.toml
+++ b/crates/red_knot_python_semantic/Cargo.toml
@@ -40,6 +40,7 @@ tempfile = { workspace = true }
 walkdir = { workspace = true }
 zip = { workspace = true }
 ruff_python_parser = { workspace = true }
+ruff_db = { workspace = true, features = ["os"]}
 
 [lints]
 workspace = true


### PR DESCRIPTION
Without this, `cargo test -p red_knot_python_semantic` breaks.
