### PR TITLE
[ruff] Skip tuples with slice expressions in `incorrectly-parenthesized-tuple-in-subscript (RUF031)`

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/ruff/RUF031.py
+++ b/crates/ruff_linter/resources/test/fixtures/ruff/RUF031.py
@@ -27,3 +27,5 @@ token_features[
 d[1,]
 d[(1,)]
 d[()] # empty tuples should be ignored
+d[:,] # slices in the subscript lead to syntax error if parens are added
+d[1,2,:]

--- a/crates/ruff_linter/resources/test/fixtures/ruff/RUF031_prefer_parens.py
+++ b/crates/ruff_linter/resources/test/fixtures/ruff/RUF031_prefer_parens.py
@@ -26,3 +26,6 @@ token_features[
 d[1,]
 d[(1,)]
 d[()] # empty tuples should be ignored
+
+d[:,] # slices in the subscript lead to syntax error if parens are added
+d[1,2,:]

--- a/crates/ruff_linter/src/rules/ruff/rules/incorrectly_parenthesized_tuple_in_subscript.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/incorrectly_parenthesized_tuple_in_subscript.rs
@@ -1,6 +1,6 @@
 use ruff_diagnostics::{AlwaysFixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
-use ruff_python_ast::ExprSubscript;
+use ruff_python_ast::{Expr, ExprSubscript};
 use ruff_text_size::Ranged;
 
 use crate::checkers::ast::Checker;
@@ -62,6 +62,9 @@ pub(crate) fn subscript_with_parenthesized_tuple(checker: &mut Checker, subscrip
         return;
     };
     if tuple_subscript.parenthesized == prefer_parentheses || tuple_subscript.elts.is_empty() {
+        return;
+    }
+    if prefer_parentheses & tuple_subscript.elts.iter().any(Expr::is_slice_expr) {
         return;
     }
     let locator = checker.locator();

--- a/crates/ruff_linter/src/rules/ruff/rules/incorrectly_parenthesized_tuple_in_subscript.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/incorrectly_parenthesized_tuple_in_subscript.rs
@@ -65,7 +65,7 @@ pub(crate) fn subscript_with_parenthesized_tuple(checker: &mut Checker, subscrip
         return;
     }
     // Adding parentheses in the presence of a slice leads to a syntax error.
-    if prefer_parentheses & tuple_subscript.elts.iter().any(Expr::is_slice_expr) {
+    if prefer_parentheses && tuple_subscript.elts.iter().any(Expr::is_slice_expr) {
         return;
     }
     let locator = checker.locator();

--- a/crates/ruff_linter/src/rules/ruff/rules/incorrectly_parenthesized_tuple_in_subscript.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/incorrectly_parenthesized_tuple_in_subscript.rs
@@ -64,6 +64,7 @@ pub(crate) fn subscript_with_parenthesized_tuple(checker: &mut Checker, subscrip
     if tuple_subscript.parenthesized == prefer_parentheses || tuple_subscript.elts.is_empty() {
         return;
     }
+    // Adding parentheses in the presence of a slice leads to a syntax error.
     if prefer_parentheses & tuple_subscript.elts.iter().any(Expr::is_slice_expr) {
         return;
     }

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF031_RUF031.py.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF031_RUF031.py.snap
@@ -156,6 +156,7 @@ RUF031.py:28:3: RUF031 [*] Avoid parentheses for tuples in subscripts.
 28 | d[(1,)]
    |   ^^^^ RUF031
 29 | d[()] # empty tuples should be ignored
+30 | d[:,] # slices in the subscript lead to syntax error if parens are added
    |
    = help: Remove the parentheses.
 
@@ -166,3 +167,5 @@ RUF031.py:28:3: RUF031 [*] Avoid parentheses for tuples in subscripts.
 28    |-d[(1,)]
    28 |+d[1,]
 29 29 | d[()] # empty tuples should be ignored
+30 30 | d[:,] # slices in the subscript lead to syntax error if parens are added
+31 31 | d[1,2,:]

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__prefer_parentheses_getitem_tuple.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__prefer_parentheses_getitem_tuple.snap
@@ -129,3 +129,5 @@ RUF031_prefer_parens.py:26:3: RUF031 [*] Use parentheses for tuples in subscript
 27 26 | d[(1,)]
    27 |+d[(1,)]
 28 28 | d[()] # empty tuples should be ignored
+29 29 | 
+30 30 | d[:,] # slices in the subscript lead to syntax error if parens are added


### PR DESCRIPTION
## Summary

Adding parentheses to a tuple in a subscript with elements that include slice expressions causes a syntax error.  For example, `d[(1,2,:)]` is a syntax error.

So, when `lint.ruff.parenthesize-tuple-in-subscript = true` and the tuple includes a slice expression, we skip this check and fix.

Closes #12766.
