### PR TITLE
Log warnings when skipping editable installations

### DIFF
--- a/crates/red_knot_python_semantic/src/module_resolver/resolver.rs
+++ b/crates/red_knot_python_semantic/src/module_resolver/resolver.rs
@@ -300,9 +300,7 @@ pub(crate) fn dynamic_resolution_paths(db: &dyn Db) -> Vec<SearchPath> {
         let mut all_pth_files: Vec<PthFile> = pth_file_iterator.collect();
         all_pth_files.sort_unstable_by(|a, b| a.path.cmp(&b.path));
 
-        let installations = all_pth_files
-            .iter()
-            .flat_map(PthFile::editable_installations);
+        let installations = all_pth_files.iter().flat_map(PthFile::items);
 
         for installation in installations {
             if existing_paths.insert(Cow::Owned(installation.clone())) {
@@ -312,7 +310,7 @@ pub(crate) fn dynamic_resolution_paths(db: &dyn Db) -> Vec<SearchPath> {
                     }
 
                     Err(error) => {
-                        tracing::warn!("Skipping editable installation: {error}");
+                        tracing::debug!("Skipping editable installation: {error}");
                     }
                 }
             }
@@ -367,7 +365,7 @@ struct PthFile<'db> {
 impl<'db> PthFile<'db> {
     /// Yield paths in this `.pth` file that appear to represent editable installations,
     /// and should therefore be added as module-resolution search paths.
-    fn editable_installations(&'db self) -> impl Iterator<Item = SystemPathBuf> + 'db {
+    fn items(&'db self) -> impl Iterator<Item = SystemPathBuf> + 'db {
         let PthFile {
             path: _,
             contents,


### PR DESCRIPTION
## Summary

This PR adds warning messages when skipping editable installations instead of skipping them silently.

## Test Plan

Not sure how to test this best without spending too much time on it. 
