### PR TITLE
Remove `red_knot_python_semantic::python_version::TargetVersion`

### DIFF
--- a/crates/red_knot/src/target_version.rs
+++ b/crates/red_knot/src/target_version.rs
@@ -13,22 +13,36 @@ pub enum TargetVersion {
     Py313,
 }
 
-impl std::fmt::Display for TargetVersion {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        red_knot_python_semantic::TargetVersion::from(*self).fmt(f)
+impl TargetVersion {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::Py37 => "py37",
+            Self::Py38 => "py38",
+            Self::Py39 => "py39",
+            Self::Py310 => "py310",
+            Self::Py311 => "py311",
+            Self::Py312 => "py312",
+            Self::Py313 => "py313",
+        }
     }
 }
 
-impl From<TargetVersion> for red_knot_python_semantic::TargetVersion {
+impl std::fmt::Display for TargetVersion {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl From<TargetVersion> for red_knot_python_semantic::PythonVersion {
     fn from(value: TargetVersion) -> Self {
         match value {
-            TargetVersion::Py37 => Self::Py37,
-            TargetVersion::Py38 => Self::Py38,
-            TargetVersion::Py39 => Self::Py39,
-            TargetVersion::Py310 => Self::Py310,
-            TargetVersion::Py311 => Self::Py311,
-            TargetVersion::Py312 => Self::Py312,
-            TargetVersion::Py313 => Self::Py313,
+            TargetVersion::Py37 => Self::PY37,
+            TargetVersion::Py38 => Self::PY38,
+            TargetVersion::Py39 => Self::PY39,
+            TargetVersion::Py310 => Self::PY310,
+            TargetVersion::Py311 => Self::PY311,
+            TargetVersion::Py312 => Self::PY312,
+            TargetVersion::Py313 => Self::PY313,
         }
     }
 }

--- a/crates/red_knot/tests/file_watching.rs
+++ b/crates/red_knot/tests/file_watching.rs
@@ -7,7 +7,7 @@ use anyhow::{anyhow, Context};
 use salsa::Setter;
 
 use red_knot_python_semantic::{
-    resolve_module, ModuleName, Program, ProgramSettings, SearchPathSettings, TargetVersion,
+    resolve_module, ModuleName, Program, ProgramSettings, PythonVersion, SearchPathSettings,
 };
 use red_knot_workspace::db::RootDatabase;
 use red_knot_workspace::watch;
@@ -234,7 +234,7 @@ where
     }
 
     let settings = ProgramSettings {
-        target_version: TargetVersion::default(),
+        target_version: PythonVersion::default(),
         search_paths,
     };
 

--- a/crates/red_knot_python_semantic/src/lib.rs
+++ b/crates/red_knot_python_semantic/src/lib.rs
@@ -6,7 +6,7 @@ pub use db::Db;
 pub use module_name::ModuleName;
 pub use module_resolver::{resolve_module, system_module_search_paths, vendored_typeshed_stubs};
 pub use program::{Program, ProgramSettings, SearchPathSettings};
-pub use python_version::{PythonVersion, TargetVersion, UnsupportedPythonVersion};
+pub use python_version::PythonVersion;
 pub use semantic_model::{HasTy, SemanticModel};
 
 pub mod ast_node_ref;

--- a/crates/red_knot_python_semantic/src/module_resolver/path.rs
+++ b/crates/red_knot_python_semantic/src/module_resolver/path.rs
@@ -626,7 +626,7 @@ mod tests {
 
     use super::*;
     use crate::module_resolver::testing::{FileSpec, MockedTypeshed, TestCase, TestCaseBuilder};
-    use crate::TargetVersion;
+    use crate::python_version::PythonVersion;
 
     impl ModulePath {
         #[must_use]
@@ -866,7 +866,7 @@ mod tests {
 
     fn typeshed_test_case(
         typeshed: MockedTypeshed,
-        target_version: TargetVersion,
+        target_version: PythonVersion,
     ) -> (TestDb, SearchPath) {
         let TestCase { db, stdlib, .. } = TestCaseBuilder::new()
             .with_custom_typeshed(typeshed)
@@ -878,11 +878,11 @@ mod tests {
     }
 
     fn py38_typeshed_test_case(typeshed: MockedTypeshed) -> (TestDb, SearchPath) {
-        typeshed_test_case(typeshed, TargetVersion::Py38)
+        typeshed_test_case(typeshed, PythonVersion::PY38)
     }
 
     fn py39_typeshed_test_case(typeshed: MockedTypeshed) -> (TestDb, SearchPath) {
-        typeshed_test_case(typeshed, TargetVersion::Py39)
+        typeshed_test_case(typeshed, PythonVersion::PY39)
     }
 
     #[test]
@@ -898,7 +898,7 @@ mod tests {
         };
 
         let (db, stdlib_path) = py38_typeshed_test_case(TYPESHED);
-        let resolver = ResolverState::new(&db, TargetVersion::Py38);
+        let resolver = ResolverState::new(&db, PythonVersion::PY38);
 
         let asyncio_regular_package = stdlib_path.join("asyncio");
         assert!(asyncio_regular_package.is_directory(&resolver));
@@ -926,7 +926,7 @@ mod tests {
         };
 
         let (db, stdlib_path) = py38_typeshed_test_case(TYPESHED);
-        let resolver = ResolverState::new(&db, TargetVersion::Py38);
+        let resolver = ResolverState::new(&db, PythonVersion::PY38);
 
         let xml_namespace_package = stdlib_path.join("xml");
         assert!(xml_namespace_package.is_directory(&resolver));
@@ -948,7 +948,7 @@ mod tests {
         };
 
         let (db, stdlib_path) = py38_typeshed_test_case(TYPESHED);
-        let resolver = ResolverState::new(&db, TargetVersion::Py38);
+        let resolver = ResolverState::new(&db, PythonVersion::PY38);
 
         let functools_module = stdlib_path.join("functools.pyi");
         assert!(functools_module.to_file(&resolver).is_some());
@@ -964,7 +964,7 @@ mod tests {
         };
 
         let (db, stdlib_path) = py38_typeshed_test_case(TYPESHED);
-        let resolver = ResolverState::new(&db, TargetVersion::Py38);
+        let resolver = ResolverState::new(&db, PythonVersion::PY38);
 
         let collections_regular_package = stdlib_path.join("collections");
         assert_eq!(collections_regular_package.to_file(&resolver), None);
@@ -980,7 +980,7 @@ mod tests {
         };
 
         let (db, stdlib_path) = py38_typeshed_test_case(TYPESHED);
-        let resolver = ResolverState::new(&db, TargetVersion::Py38);
+        let resolver = ResolverState::new(&db, PythonVersion::PY38);
 
         let importlib_namespace_package = stdlib_path.join("importlib");
         assert_eq!(importlib_namespace_package.to_file(&resolver), None);
@@ -1001,7 +1001,7 @@ mod tests {
         };
 
         let (db, stdlib_path) = py38_typeshed_test_case(TYPESHED);
-        let resolver = ResolverState::new(&db, TargetVersion::Py38);
+        let resolver = ResolverState::new(&db, PythonVersion::PY38);
 
         let non_existent = stdlib_path.join("doesnt_even_exist");
         assert_eq!(non_existent.to_file(&resolver), None);
@@ -1029,7 +1029,7 @@ mod tests {
         };
 
         let (db, stdlib_path) = py39_typeshed_test_case(TYPESHED);
-        let resolver = ResolverState::new(&db, TargetVersion::Py39);
+        let resolver = ResolverState::new(&db, PythonVersion::PY39);
 
         // Since we've set the target version to Py39,
         // `collections` should now exist as a directory, according to VERSIONS...
@@ -1058,7 +1058,7 @@ mod tests {
         };
 
         let (db, stdlib_path) = py39_typeshed_test_case(TYPESHED);
-        let resolver = ResolverState::new(&db, TargetVersion::Py39);
+        let resolver = ResolverState::new(&db, PythonVersion::PY39);
 
         // The `importlib` directory now also exists
         let importlib_namespace_package = stdlib_path.join("importlib");
@@ -1082,7 +1082,7 @@ mod tests {
         };
 
         let (db, stdlib_path) = py39_typeshed_test_case(TYPESHED);
-        let resolver = ResolverState::new(&db, TargetVersion::Py39);
+        let resolver = ResolverState::new(&db, PythonVersion::PY39);
 
         // The `xml` package no longer exists on py39:
         let xml_namespace_package = stdlib_path.join("xml");

--- a/crates/red_knot_python_semantic/src/module_resolver/state.rs
+++ b/crates/red_knot_python_semantic/src/module_resolver/state.rs
@@ -2,16 +2,16 @@ use ruff_db::vendored::VendoredFileSystem;
 
 use super::typeshed::LazyTypeshedVersions;
 use crate::db::Db;
-use crate::TargetVersion;
+use crate::python_version::PythonVersion;
 
 pub(crate) struct ResolverState<'db> {
     pub(crate) db: &'db dyn Db,
     pub(crate) typeshed_versions: LazyTypeshedVersions<'db>,
-    pub(crate) target_version: TargetVersion,
+    pub(crate) target_version: PythonVersion,
 }
 
 impl<'db> ResolverState<'db> {
-    pub(crate) fn new(db: &'db dyn Db, target_version: TargetVersion) -> Self {
+    pub(crate) fn new(db: &'db dyn Db, target_version: PythonVersion) -> Self {
         Self {
             db,
             typeshed_versions: LazyTypeshedVersions::new(),

--- a/crates/red_knot_python_semantic/src/module_resolver/testing.rs
+++ b/crates/red_knot_python_semantic/src/module_resolver/testing.rs
@@ -3,7 +3,7 @@ use ruff_db::vendored::VendoredPathBuf;
 
 use crate::db::tests::TestDb;
 use crate::program::{Program, SearchPathSettings};
-use crate::python_version::TargetVersion;
+use crate::python_version::PythonVersion;
 
 /// A test case for the module resolver.
 ///
@@ -17,7 +17,7 @@ pub(crate) struct TestCase<T> {
     // so this is a single directory instead of a `Vec` of directories,
     // like it is in `ruff_db::Program`.
     pub(crate) site_packages: SystemPathBuf,
-    pub(crate) target_version: TargetVersion,
+    pub(crate) target_version: PythonVersion,
 }
 
 /// A `(file_name, file_contents)` tuple
@@ -99,7 +99,7 @@ pub(crate) struct UnspecifiedTypeshed;
 /// to `()`.
 pub(crate) struct TestCaseBuilder<T> {
     typeshed_option: T,
-    target_version: TargetVersion,
+    target_version: PythonVersion,
     first_party_files: Vec<FileSpec>,
     site_packages_files: Vec<FileSpec>,
 }
@@ -118,7 +118,7 @@ impl<T> TestCaseBuilder<T> {
     }
 
     /// Specify the target Python version the module resolver should assume
-    pub(crate) fn with_target_version(mut self, target_version: TargetVersion) -> Self {
+    pub(crate) fn with_target_version(mut self, target_version: PythonVersion) -> Self {
         self.target_version = target_version;
         self
     }
@@ -145,7 +145,7 @@ impl TestCaseBuilder<UnspecifiedTypeshed> {
     pub(crate) fn new() -> TestCaseBuilder<UnspecifiedTypeshed> {
         Self {
             typeshed_option: UnspecifiedTypeshed,
-            target_version: TargetVersion::default(),
+            target_version: PythonVersion::default(),
             first_party_files: vec![],
             site_packages_files: vec![],
         }

--- a/crates/red_knot_python_semantic/src/program.rs
+++ b/crates/red_knot_python_semantic/src/program.rs
@@ -1,11 +1,11 @@
-use crate::python_version::TargetVersion;
+use crate::python_version::PythonVersion;
 use crate::Db;
 use ruff_db::system::SystemPathBuf;
 use salsa::Durability;
 
 #[salsa::input(singleton)]
 pub struct Program {
-    pub target_version: TargetVersion,
+    pub target_version: PythonVersion,
 
     #[return_ref]
     pub search_paths: SearchPathSettings,
@@ -21,7 +21,7 @@ impl Program {
 
 #[derive(Debug, Eq, PartialEq)]
 pub struct ProgramSettings {
-    pub target_version: TargetVersion,
+    pub target_version: PythonVersion,
     pub search_paths: SearchPathSettings,
 }
 

--- a/crates/red_knot_python_semantic/src/python_version.rs
+++ b/crates/red_knot_python_semantic/src/python_version.rs
@@ -1,58 +1,9 @@
 use std::fmt;
 
-/// Enumeration of all supported Python versions
+/// Representation of a Python version.
 ///
-/// TODO: unify with the `PythonVersion` enum in the linter/formatter crates?
-#[derive(Copy, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Default)]
-pub enum TargetVersion {
-    Py37,
-    #[default]
-    Py38,
-    Py39,
-    Py310,
-    Py311,
-    Py312,
-    Py313,
-}
-
-impl TargetVersion {
-    pub fn major_version(self) -> u8 {
-        PythonVersion::from(self).major
-    }
-
-    pub fn minor_version(self) -> u8 {
-        PythonVersion::from(self).minor
-    }
-
-    const fn as_display_str(self) -> &'static str {
-        match self {
-            Self::Py37 => "py37",
-            Self::Py38 => "py38",
-            Self::Py39 => "py39",
-            Self::Py310 => "py310",
-            Self::Py311 => "py311",
-            Self::Py312 => "py312",
-            Self::Py313 => "py313",
-        }
-    }
-}
-
-impl fmt::Display for TargetVersion {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(self.as_display_str())
-    }
-}
-
-impl fmt::Debug for TargetVersion {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Display::fmt(self, f)
-    }
-}
-
-/// Generic representation for a Python version.
-///
-/// Unlike [`TargetVersion`], this does not necessarily represent
-/// a Python version that we actually support.
+/// Unlike the `TargetVersion` enums in the CLI crates,
+/// this does not necessarily represent a Python version that we actually support.
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct PythonVersion {
     pub major: u8,
@@ -60,11 +11,34 @@ pub struct PythonVersion {
 }
 
 impl PythonVersion {
+    pub const PY37: PythonVersion = PythonVersion { major: 3, minor: 7 };
+    pub const PY38: PythonVersion = PythonVersion { major: 3, minor: 8 };
+    pub const PY39: PythonVersion = PythonVersion { major: 3, minor: 9 };
+    pub const PY310: PythonVersion = PythonVersion {
+        major: 3,
+        minor: 10,
+    };
+    pub const PY311: PythonVersion = PythonVersion {
+        major: 3,
+        minor: 11,
+    };
+    pub const PY312: PythonVersion = PythonVersion {
+        major: 3,
+        minor: 12,
+    };
+    pub const PY313: PythonVersion = PythonVersion {
+        major: 3,
+        minor: 13,
+    };
+
     pub fn free_threaded_build_available(self) -> bool {
-        self >= PythonVersion {
-            major: 3,
-            minor: 13,
-        }
+        self >= PythonVersion::PY313
+    }
+}
+
+impl Default for PythonVersion {
+    fn default() -> Self {
+        Self::PY38
     }
 }
 
@@ -84,62 +58,5 @@ impl fmt::Display for PythonVersion {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let PythonVersion { major, minor } = self;
         write!(f, "{major}.{minor}")
-    }
-}
-
-impl From<TargetVersion> for PythonVersion {
-    fn from(value: TargetVersion) -> Self {
-        match value {
-            TargetVersion::Py37 => PythonVersion { major: 3, minor: 7 },
-            TargetVersion::Py38 => PythonVersion { major: 3, minor: 8 },
-            TargetVersion::Py39 => PythonVersion { major: 3, minor: 9 },
-            TargetVersion::Py310 => PythonVersion {
-                major: 3,
-                minor: 10,
-            },
-            TargetVersion::Py311 => PythonVersion {
-                major: 3,
-                minor: 11,
-            },
-            TargetVersion::Py312 => PythonVersion {
-                major: 3,
-                minor: 12,
-            },
-            TargetVersion::Py313 => PythonVersion {
-                major: 3,
-                minor: 13,
-            },
-        }
-    }
-}
-
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
-pub struct UnsupportedPythonVersion(PythonVersion);
-
-impl fmt::Display for UnsupportedPythonVersion {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "Python version {} is unsupported", self.0)
-    }
-}
-
-impl std::error::Error for UnsupportedPythonVersion {}
-
-impl TryFrom<PythonVersion> for TargetVersion {
-    type Error = UnsupportedPythonVersion;
-
-    fn try_from(value: PythonVersion) -> Result<Self, Self::Error> {
-        let PythonVersion { major: 3, minor } = value else {
-            return Err(UnsupportedPythonVersion(value));
-        };
-        match minor {
-            7 => Ok(TargetVersion::Py37),
-            8 => Ok(TargetVersion::Py38),
-            9 => Ok(TargetVersion::Py39),
-            10 => Ok(TargetVersion::Py310),
-            11 => Ok(TargetVersion::Py311),
-            12 => Ok(TargetVersion::Py312),
-            13 => Ok(TargetVersion::Py313),
-            _ => Err(UnsupportedPythonVersion(value)),
-        }
     }
 }

--- a/crates/red_knot_python_semantic/src/semantic_model.rs
+++ b/crates/red_knot_python_semantic/src/semantic_model.rs
@@ -169,7 +169,7 @@ mod tests {
 
     use crate::db::tests::TestDb;
     use crate::program::{Program, SearchPathSettings};
-    use crate::python_version::TargetVersion;
+    use crate::python_version::PythonVersion;
     use crate::types::Type;
     use crate::{HasTy, SemanticModel};
 
@@ -177,7 +177,7 @@ mod tests {
         let db = TestDb::new();
         Program::new(
             &db,
-            TargetVersion::Py38,
+            PythonVersion::default(),
             SearchPathSettings {
                 extra_paths: vec![],
                 src_root: SystemPathBuf::from("/src"),

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -1503,7 +1503,7 @@ mod tests {
     use crate::builtins::builtins_scope;
     use crate::db::tests::TestDb;
     use crate::program::{Program, SearchPathSettings};
-    use crate::python_version::TargetVersion;
+    use crate::python_version::PythonVersion;
     use crate::semantic_index::definition::Definition;
     use crate::semantic_index::symbol::FileScopeId;
     use crate::semantic_index::{global_scope, semantic_index, symbol_table, use_def_map};
@@ -1515,7 +1515,7 @@ mod tests {
 
         Program::new(
             &db,
-            TargetVersion::Py38,
+            PythonVersion::default(),
             SearchPathSettings {
                 extra_paths: Vec::new(),
                 src_root: SystemPathBuf::from("/src"),
@@ -1532,7 +1532,7 @@ mod tests {
 
         Program::new(
             &db,
-            TargetVersion::Py38,
+            PythonVersion::default(),
             SearchPathSettings {
                 extra_paths: Vec::new(),
                 src_root: SystemPathBuf::from("/src"),

--- a/crates/red_knot_server/src/session.rs
+++ b/crates/red_knot_server/src/session.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use anyhow::anyhow;
 use lsp_types::{ClientCapabilities, Url};
 
-use red_knot_python_semantic::{ProgramSettings, SearchPathSettings, TargetVersion};
+use red_knot_python_semantic::{ProgramSettings, PythonVersion, SearchPathSettings};
 use red_knot_workspace::db::RootDatabase;
 use red_knot_workspace::workspace::WorkspaceMetadata;
 use ruff_db::files::{system_path_to_file, File};
@@ -70,7 +70,7 @@ impl Session {
             let metadata = WorkspaceMetadata::from_path(system_path, &system)?;
             // TODO(dhruvmanila): Get the values from the client settings
             let program_settings = ProgramSettings {
-                target_version: TargetVersion::default(),
+                target_version: PythonVersion::default(),
                 search_paths: SearchPathSettings {
                     extra_paths: vec![],
                     src_root: system_path.to_path_buf(),

--- a/crates/red_knot_wasm/src/lib.rs
+++ b/crates/red_knot_wasm/src/lib.rs
@@ -184,16 +184,16 @@ pub enum TargetVersion {
     Py313,
 }
 
-impl From<TargetVersion> for red_knot_python_semantic::TargetVersion {
+impl From<TargetVersion> for red_knot_python_semantic::PythonVersion {
     fn from(value: TargetVersion) -> Self {
         match value {
-            TargetVersion::Py37 => Self::Py37,
-            TargetVersion::Py38 => Self::Py38,
-            TargetVersion::Py39 => Self::Py39,
-            TargetVersion::Py310 => Self::Py310,
-            TargetVersion::Py311 => Self::Py311,
-            TargetVersion::Py312 => Self::Py312,
-            TargetVersion::Py313 => Self::Py313,
+            TargetVersion::Py37 => Self::PY37,
+            TargetVersion::Py38 => Self::PY38,
+            TargetVersion::Py39 => Self::PY39,
+            TargetVersion::Py310 => Self::PY310,
+            TargetVersion::Py311 => Self::PY311,
+            TargetVersion::Py312 => Self::PY312,
+            TargetVersion::Py313 => Self::PY313,
         }
     }
 }

--- a/crates/red_knot_workspace/src/lint.rs
+++ b/crates/red_knot_workspace/src/lint.rs
@@ -305,7 +305,7 @@ enum AnyImportRef<'a> {
 
 #[cfg(test)]
 mod tests {
-    use red_knot_python_semantic::{Program, SearchPathSettings, TargetVersion};
+    use red_knot_python_semantic::{Program, PythonVersion, SearchPathSettings};
     use ruff_db::files::system_path_to_file;
     use ruff_db::system::{DbWithTestSystem, SystemPathBuf};
 
@@ -322,7 +322,7 @@ mod tests {
 
         Program::new(
             &db,
-            TargetVersion::Py38,
+            PythonVersion::default(),
             SearchPathSettings {
                 extra_paths: Vec::new(),
                 src_root,

--- a/crates/red_knot_workspace/tests/check.rs
+++ b/crates/red_knot_workspace/tests/check.rs
@@ -1,4 +1,4 @@
-use red_knot_python_semantic::{ProgramSettings, SearchPathSettings, TargetVersion};
+use red_knot_python_semantic::{ProgramSettings, PythonVersion, SearchPathSettings};
 use red_knot_workspace::db::RootDatabase;
 use red_knot_workspace::lint::lint_semantic;
 use red_knot_workspace::workspace::WorkspaceMetadata;
@@ -17,7 +17,7 @@ fn setup_db(workspace_root: SystemPathBuf) -> anyhow::Result<RootDatabase> {
         site_packages: vec![],
     };
     let settings = ProgramSettings {
-        target_version: TargetVersion::default(),
+        target_version: PythonVersion::default(),
         search_paths,
     };
     let db = RootDatabase::new(workspace, settings, system);

--- a/crates/ruff_benchmark/benches/red_knot.rs
+++ b/crates/ruff_benchmark/benches/red_knot.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::disallowed_names)]
 
-use red_knot_python_semantic::{ProgramSettings, SearchPathSettings, TargetVersion};
+use red_knot_python_semantic::{ProgramSettings, PythonVersion, SearchPathSettings};
 use red_knot_workspace::db::RootDatabase;
 use red_knot_workspace::workspace::WorkspaceMetadata;
 use ruff_benchmark::criterion::{criterion_group, criterion_main, BatchSize, Criterion};
@@ -43,7 +43,7 @@ fn setup_case() -> Case {
     let src_root = SystemPath::new("/src");
     let metadata = WorkspaceMetadata::from_path(src_root, &system).unwrap();
     let settings = ProgramSettings {
-        target_version: TargetVersion::Py312,
+        target_version: PythonVersion::PY312,
         search_paths: SearchPathSettings {
             extra_paths: vec![],
             src_root: src_root.to_path_buf(),


### PR DESCRIPTION
## Summary

This PR is a followup to @MichaReiser's comment at https://github.com/astral-sh/ruff/pull/12782#discussion_r1711701881:

> I think it's now a bit confusing when to use `TargetVersion` vs `PythonVersion`? Shouldn't all (or at least most) our code be open for new Python versions? Or to phrase it differently, what's the benefit of limiting `TargetVersion` to a fixed set?

Instead of having two types in `ruff_python_semantic` -- one that represents an arbitrary Python version, and another that represents the fixed set of versions that we know we support -- this PR consolidates it so that we only use a single type (the more general one). The only case where we need a fixed enumeration of versions that we actually support (at least currently) is in a CLI argparsing context -- but the CLI crates already have their own enums.

This will have quite a few merge conflicts with https://github.com/astral-sh/ruff/pull/12786... I'm okay with waiting until @MichaReiser's stack of module-resolver validation PRs has landed before merging this. It's not urgent.

<!-- How was it tested? -->

`cargo test`