### PR TITLE
[Minor typo] Fix article in "an fix"

### DIFF
--- a/crates/ruff_diagnostics/src/violation.rs
+++ b/crates/ruff_diagnostics/src/violation.rs
@@ -18,7 +18,7 @@ impl Display for FixAvailability {
 }
 
 pub trait Violation: Debug + PartialEq + Eq {
-    /// `None` in the case an fix is never available or otherwise Some
+    /// `None` in the case a fix is never available or otherwise Some
     /// [`FixAvailability`] describing the available fix.
     const FIX_AVAILABILITY: FixAvailability = FixAvailability::None;
 


### PR DESCRIPTION
Fixing a minor typo I came across: "an fix" -> "a fix".
