### PR TITLE
ci: persist a warm cache across jobs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -108,6 +108,8 @@ jobs:
           rustup component add clippy
           rustup target add wasm32-unknown-unknown
       - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: warm
       - name: "Clippy"
         run: cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
       - name: "Clippy (wasm)"
@@ -135,6 +137,8 @@ jobs:
           tool: cargo-insta
       - uses: Swatinem/rust-cache@v2
         with:
+          # NOTE: only this job updates the warm linux cache. No point in having
+          # it overwritten by other jobs.
           shared-key: warm
           save-if: ${{ github.ref_name == 'main' }}
       - name: "Run tests"
@@ -168,9 +172,6 @@ jobs:
         with:
           tool: cargo-nextest
       - uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: warm-windows
-          save-if: ${{ github.ref_name == 'main' }}
       - name: "Run tests"
         shell: bash
         env:
@@ -252,8 +253,7 @@ jobs:
           tool: cargo-insta
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: warm-msrv
-          save-if: ${{ github.ref_name == 'main' }}
+          shared-key: warm
       - name: "Run tests"
         shell: bash
         env:
@@ -272,6 +272,7 @@ jobs:
         run: rustup show
       - uses: Swatinem/rust-cache@v2
         with:
+          shared-key: warm
           workspaces: "fuzz -> target"
       - name: "Install cargo-binstall"
         uses: cargo-bins/cargo-binstall@main
@@ -325,6 +326,8 @@ jobs:
       - name: "Install Rust toolchain"
         run: rustup component add rustfmt
       - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: warm
       - run: ./scripts/add_rule.py --name DoTheThing --prefix PL --code C0999 --linter pylint
       - run: cargo check
       - run: cargo fmt --all --check
@@ -533,7 +536,6 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: warm
-          save-if: ${{ github.ref_name == 'main' }}
       - name: "Install Insiders dependencies"
         if: ${{ env.MKDOCS_INSIDERS_SSH_KEY_EXISTS == 'true' }}
         run: pip install -r docs/requirements-insiders.txt

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -134,6 +134,9 @@ jobs:
         with:
           tool: cargo-insta
       - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: warm
+          save-if: ${{ github.ref_name == 'main' }}
       - name: "Run tests"
         shell: bash
         env:
@@ -165,6 +168,9 @@ jobs:
         with:
           tool: cargo-nextest
       - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: warm-windows
+          save-if: ${{ github.ref_name == 'main' }}
       - name: "Run tests"
         shell: bash
         env:
@@ -191,6 +197,9 @@ jobs:
           cache-dependency-path: playground/package-lock.json
       - uses: jetli/wasm-pack-action@v0.4.0
       - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: warm-wasm
+          save-if: ${{ github.ref_name == 'main' }}
       - name: "Test ruff_wasm"
         run: |
           cd crates/ruff_wasm
@@ -242,6 +251,9 @@ jobs:
         with:
           tool: cargo-insta
       - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: warm-msrv
+          save-if: ${{ github.ref_name == 'main' }}
       - name: "Run tests"
         shell: bash
         env:
@@ -519,6 +531,9 @@ jobs:
       - name: "Install Rust toolchain"
         run: rustup show
       - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: warm
+          save-if: ${{ github.ref_name == 'main' }}
       - name: "Install Insiders dependencies"
         if: ${{ env.MKDOCS_INSIDERS_SSH_KEY_EXISTS == 'true' }}
         run: pip install -r docs/requirements-insiders.txt


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

I saw on Twitter that you guys want some help with faster CI.

This PR updates `Swatinem/rust-cache@v2` steps for testing jobs and other long-running tasks (except for release builds) to share cached build artifacts across jobs.

Each platform (linux/windows, didn't see tests for MacOS) gets its own warm cache. Caches are read by all branches, but only saved when CI runs on `main`.

## Test Plan

<!-- How was it tested? -->
This is what Oxc's CI does.