### PR TITLE
Warn on invalid `# noqa` rule codes

### DIFF
--- a/crates/ruff_linter/src/checkers/noqa.rs
+++ b/crates/ruff_linter/src/checkers/noqa.rs
@@ -43,7 +43,8 @@ pub(crate) fn check_noqa(
     let exemption = FileExemption::from(&file_noqa_directives);
 
     // Extract all `noqa` directives.
-    let mut noqa_directives = NoqaDirectives::from_commented_ranges(comment_ranges, path, locator);
+    let mut noqa_directives =
+        NoqaDirectives::from_commented_ranges(comment_ranges, &settings.external, path, locator);
 
     // Indices of diagnostics that were ignored by a `noqa` directive.
     let mut ignored_diagnostics = vec![];

--- a/crates/ruff_linter/src/noqa.rs
+++ b/crates/ruff_linter/src/noqa.rs
@@ -183,7 +183,7 @@ impl<'a> Directive<'a> {
         // Extract, e.g., the `401` in `F401`.
         let suffix = line[prefix..]
             .chars()
-            .take_while(char::is_ascii_digit)
+            .take_while(char::is_ascii_alphanumeric)
             .count();
         if prefix > 0 && suffix > 0 {
             Some(&line[..prefix + suffix])
@@ -550,7 +550,7 @@ impl<'a> ParsedFileExemption<'a> {
         // Extract, e.g., the `401` in `F401`.
         let suffix = line[prefix..]
             .chars()
-            .take_while(char::is_ascii_digit)
+            .take_while(char::is_ascii_alphanumeric)
             .count();
         if prefix > 0 && suffix > 0 {
             Some(&line[..prefix + suffix])
@@ -897,7 +897,7 @@ pub(crate) struct NoqaDirectiveLine<'a> {
     pub(crate) directive: Directive<'a>,
     /// The codes that are ignored by the directive.
     pub(crate) matches: Vec<NoqaCode>,
-    // Whether the directive applies to range.end
+    /// Whether the directive applies to `range.end`.
     pub(crate) includes_end: bool,
 }
 
@@ -1190,6 +1190,18 @@ mod tests {
     #[test]
     fn noqa_invalid_codes() {
         let source = "# noqa: unused-import, F401, some other code";
+        assert_debug_snapshot!(Directive::try_extract(source, TextSize::default()));
+    }
+
+    #[test]
+    fn noqa_squashed_codes() {
+        let source = "# noqa: F401F841";
+        assert_debug_snapshot!(Directive::try_extract(source, TextSize::default()));
+    }
+
+    #[test]
+    fn noqa_empty_comma() {
+        let source = "# noqa: F401,,F841";
         assert_debug_snapshot!(Directive::try_extract(source, TextSize::default()));
     }
 

--- a/crates/ruff_linter/src/snapshots/ruff_linter__noqa__tests__noqa_empty_comma.snap
+++ b/crates/ruff_linter/src/snapshots/ruff_linter__noqa__tests__noqa_empty_comma.snap
@@ -1,0 +1,23 @@
+---
+source: crates/ruff_linter/src/noqa.rs
+expression: "Directive::try_extract(source, TextSize::default())"
+---
+Ok(
+    Some(
+        Codes(
+            Codes {
+                range: 0..18,
+                codes: [
+                    Code {
+                        code: "F401",
+                        range: 8..12,
+                    },
+                    Code {
+                        code: "F841",
+                        range: 14..18,
+                    },
+                ],
+            },
+        ),
+    ),
+)

--- a/crates/ruff_linter/src/snapshots/ruff_linter__noqa__tests__noqa_squashed_codes.snap
+++ b/crates/ruff_linter/src/snapshots/ruff_linter__noqa__tests__noqa_squashed_codes.snap
@@ -1,0 +1,19 @@
+---
+source: crates/ruff_linter/src/noqa.rs
+expression: "Directive::try_extract(source, TextSize::default())"
+---
+Ok(
+    Some(
+        Codes(
+            Codes {
+                range: 0..16,
+                codes: [
+                    Code {
+                        code: "F401F841",
+                        range: 8..16,
+                    },
+                ],
+            },
+        ),
+    ),
+)


### PR DESCRIPTION
## Summary

Today, we already warn if you do `# ruff: noqa: F401F841`... But not inline (e.g., `import os  # noqa: F401F841`).

This PR extends the warnings to the latter case.

It's not "breaking", but I'd suggest we ship it in a minor.

Fixes https://github.com/astral-sh/ruff/issues/15682
