### PR TITLE
Remove error messages for removed CLI aliases

### DIFF
--- a/crates/ruff/src/main.rs
+++ b/crates/ruff/src/main.rs
@@ -1,13 +1,11 @@
+use std::io::Write;
 use std::process::ExitCode;
 
-use clap::{Parser, Subcommand};
+use clap::Parser;
 use colored::Colorize;
-use log::error;
-use std::io::Write;
 
-use ruff::args::{Args, Command};
+use ruff::args::Args;
 use ruff::{run, ExitStatus};
-use ruff_linter::logging::{set_up_logging, LogLevel};
 
 #[cfg(target_os = "windows")]
 #[global_allocator]
@@ -40,47 +38,6 @@ pub fn main() -> ExitCode {
 
     let args = wild::args_os();
     let args = argfile::expand_args_from(args, argfile::parse_fromfile, argfile::PREFIX).unwrap();
-
-    // We can't use `warn_user` here because logging isn't set up at this point
-    // and we also don't know if the user runs ruff with quiet.
-    // Keep the message and pass it to `run` that is responsible for emitting the warning.
-    let deprecated_alias_error = match args.get(1).and_then(|arg| arg.to_str()) {
-        // Deprecated aliases that are handled by clap
-        Some("--explain") => {
-            Some("`ruff --explain <RULE>` has been removed. Use `ruff rule <RULE>` instead.")
-        }
-        Some("--clean") => {
-            Some("`ruff --clean` has been removed. Use `ruff clean` instead.")
-        }
-        Some("--generate-shell-completion") => {
-            Some("`ruff --generate-shell-completion <SHELL>` has been removed. Use `ruff generate-shell-completion <SHELL>` instead.")
-        }
-        // Deprecated `ruff` alias to `ruff check`
-        // Clap doesn't support default subcommands but we want to run `check` by
-        // default for convenience and backwards-compatibility, so we just
-        // preprocess the arguments accordingly before passing them to Clap.
-        Some(arg) if !Command::has_subcommand(arg)
-            && arg != "-h"
-            && arg != "--help"
-            && arg != "-V"
-            && arg != "--version"
-            && arg != "help" => {
-            {
-                Some("`ruff <path>` has been removed. Use `ruff check <path>` instead.")
-            }
-        },
-        _ => None
-    };
-
-    if let Some(error) = deprecated_alias_error {
-        #[allow(clippy::print_stderr)]
-        if set_up_logging(LogLevel::Default).is_ok() {
-            error!("{}", error);
-        } else {
-            eprintln!("{}", error.red().bold());
-        }
-        return ExitCode::FAILURE;
-    }
 
     let args = Args::parse_from(args);
 


### PR DESCRIPTION
## Summary

This PR removes the following CLI aliases: 

* `ruff <path>` to `ruff check <path>`
* `ruff --explain` to `ruff rule`
* `ruff --clean` to `ruff clean`
* `ruff --generate-shell-completion` to `ruff generate-shell-completion`

The aliases are deprecated since Ruff 0.3 and using them became a hard error in 0.5. 

Closes https://github.com/astral-sh/ruff/issues/10171


## Test Plan

I tested that using any of the aliases becomes a hard error. 

## Alternatives

We could keep the error messages around a little longer. It's not a lot of code but I would also expect that most users have migrated at this time (unless they skip 0.5)
