### PR TITLE
Deprecate `UP027`

### DIFF
--- a/crates/ruff_linter/src/codes.rs
+++ b/crates/ruff_linter/src/codes.rs
@@ -510,7 +510,7 @@ pub fn code_to_rule(linter: Linter, code: &str) -> Option<(RuleGroup, Rule)> {
         (Pyupgrade, "024") => (RuleGroup::Stable, rules::pyupgrade::rules::OSErrorAlias),
         (Pyupgrade, "025") => (RuleGroup::Stable, rules::pyupgrade::rules::UnicodeKindPrefix),
         (Pyupgrade, "026") => (RuleGroup::Stable, rules::pyupgrade::rules::DeprecatedMockImport),
-        (Pyupgrade, "027") => (RuleGroup::Stable, rules::pyupgrade::rules::UnpackedListComprehension),
+        (Pyupgrade, "027") => (RuleGroup::Deprecated, rules::pyupgrade::rules::UnpackedListComprehension),
         (Pyupgrade, "028") => (RuleGroup::Stable, rules::pyupgrade::rules::YieldInForLoop),
         (Pyupgrade, "029") => (RuleGroup::Stable, rules::pyupgrade::rules::UnnecessaryBuiltinImport),
         (Pyupgrade, "030") => (RuleGroup::Stable, rules::pyupgrade::rules::FormatLiterals),

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/unpacked_list_comprehension.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/unpacked_list_comprehension.rs
@@ -7,13 +7,17 @@ use ruff_text_size::Ranged;
 
 use crate::checkers::ast::Checker;
 
+/// ## Deprecation
+/// There's no [evidence](https://github.com/astral-sh/ruff/issues/12754) that generators are
+/// meaningfully faster than list comprehensions when combined with unpacking.
+///
 /// ## What it does
 /// Checks for list comprehensions that are immediately unpacked.
 ///
 /// ## Why is this bad?
 /// There is no reason to use a list comprehension if the result is immediately
-/// unpacked. Instead, use a generator expression, which is more efficient as
-/// it avoids allocating an intermediary list.
+/// unpacked. unpacked. Instead, use a generator expression, which avoids allocating
+/// an intermediary list.
 ///
 /// ## Example
 /// ```python

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/unpacked_list_comprehension.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/unpacked_list_comprehension.rs
@@ -16,7 +16,7 @@ use crate::checkers::ast::Checker;
 ///
 /// ## Why is this bad?
 /// There is no reason to use a list comprehension if the result is immediately
-/// unpacked. unpacked. Instead, use a generator expression, which avoids allocating
+/// unpacked. Instead, use a generator expression, which avoids allocating
 /// an intermediary list.
 ///
 /// ## Example


### PR DESCRIPTION
## Summary
Closes https://github.com/astral-sh/ruff/issues/12754

## Test Plan

```shell
cargo run --bin ruff -- check --select UP027 ../ 
warning: Rule `UP027` is deprecated and will be removed in a future release.
warning: Detected debug build without --no-cache.
ruff failed
  Cause: Selection of deprecated rule `UP027` is not allowed when preview is enabled.
```
