### PR TITLE
[red-knot] Use Windows specific path separator in tests

### DIFF
--- a/crates/red_knot_workspace/src/lint.rs
+++ b/crates/red_knot_workspace/src/lint.rs
@@ -411,10 +411,17 @@ mod tests {
 
         assert_eq!(
             *messages,
-            vec![
-                "/src/a.py:3:4: Name 'flag' used when not defined.",
-                "/src/a.py:5:1: Name 'y' used when possibly not defined."
-            ]
+            if cfg!(windows) {
+                vec![
+                    "\\src\\a.py:3:4: Name 'flag' used when not defined.",
+                    "\\src\\a.py:5:1: Name 'y' used when possibly not defined.",
+                ]
+            } else {
+                vec![
+                    "/src/a.py:3:4: Name 'flag' used when not defined.",
+                    "/src/a.py:5:1: Name 'y' used when possibly not defined.",
+                ]
+            }
         );
     }
 }


### PR DESCRIPTION
## Summary

fix-up for https://github.com/astral-sh/ruff/pull/12842 to use Windows specific path separator for test output.