### PR TITLE
[`flake8-pytest-style`] Add a space after comma in CSV output (`PT006`)

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_pytest_style/rules/parametrize.rs
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/rules/parametrize.rs
@@ -292,7 +292,7 @@ fn elts_to_csv(elts: &[Expr], generator: Generator) -> Option<String> {
             .fold(String::new(), |mut acc, elt| {
                 if let Expr::StringLiteral(ast::ExprStringLiteral { value, .. }) = elt {
                     if !acc.is_empty() {
-                        acc.push(',');
+                        acc.push_str(", ");
                     }
                     acc.push_str(value.to_str());
                 }

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/snapshots/ruff_linter__rules__flake8_pytest_style__tests__PT006_csv.snap
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/snapshots/ruff_linter__rules__flake8_pytest_style__tests__PT006_csv.snap
@@ -15,7 +15,7 @@ PT006.py:24:26: PT006 [*] Wrong type passed to first argument of `@pytest.mark.p
 22 22 | 
 23 23 | 
 24    |-@pytest.mark.parametrize(("param1", "param2"), [(1, 2), (3, 4)])
-   24 |+@pytest.mark.parametrize("param1,param2", [(1, 2), (3, 4)])
+   24 |+@pytest.mark.parametrize("param1, param2", [(1, 2), (3, 4)])
 25 25 | def test_tuple(param1, param2):
 26 26 |     ...
 27 27 | 
@@ -53,7 +53,7 @@ PT006.py:34:26: PT006 [*] Wrong type passed to first argument of `@pytest.mark.p
 32 32 | 
 33 33 | 
 34    |-@pytest.mark.parametrize(["param1", "param2"], [(1, 2), (3, 4)])
-   34 |+@pytest.mark.parametrize("param1,param2", [(1, 2), (3, 4)])
+   34 |+@pytest.mark.parametrize("param1, param2", [(1, 2), (3, 4)])
 35 35 | def test_list(param1, param2):
 36 36 |     ...
 37 37 | 


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

See #12703. This only addresses the first bullet point, adding a space after the comma in the suggested fix from list/tuple to string.

## Test Plan

Updated the snapshots and compared.
