### PR TITLE
[Ruff 0.6] Stabilise `PLR6104`

### DIFF
--- a/crates/ruff_linter/src/codes.rs
+++ b/crates/ruff_linter/src/codes.rs
@@ -262,7 +262,7 @@ pub fn code_to_rule(linter: Linter, code: &str) -> Option<(RuleGroup, Rule)> {
         (Pylint, "R2004") => (RuleGroup::Stable, rules::pylint::rules::MagicValueComparison),
         (Pylint, "R2044") => (RuleGroup::Stable, rules::pylint::rules::EmptyComment),
         (Pylint, "R5501") => (RuleGroup::Stable, rules::pylint::rules::CollapsibleElseIf),
-        (Pylint, "R6104") => (RuleGroup::Preview, rules::pylint::rules::NonAugmentedAssignment),
+        (Pylint, "R6104") => (RuleGroup::Stable, rules::pylint::rules::NonAugmentedAssignment),
         (Pylint, "R6201") => (RuleGroup::Preview, rules::pylint::rules::LiteralMembership),
         (Pylint, "R6301") => (RuleGroup::Preview, rules::pylint::rules::NoSelfUse),
         (Pylint, "W0108") => (RuleGroup::Preview, rules::pylint::rules::UnnecessaryLambda),

--- a/crates/ruff_linter/src/rules/pylint/rules/non_augmented_assignment.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/non_augmented_assignment.rs
@@ -14,12 +14,12 @@ use crate::checkers::ast::Checker;
 /// statements.
 ///
 /// ## Why is this bad?
-/// If an assignment statement consists of a binary operation in which one
-/// operand is the same as the assignment target, it can be rewritten as an
-/// augmented assignment. For example, `x = x + 1` can be rewritten as
-/// `x += 1`.
+/// If the right-hand side of an assignment statement consists of a binary
+/// operation in which one operand is the same as the assignment target,
+/// it can be rewritten as an augmented assignment. For example, `x = x + 1
+/// can be rewritten as `x += 1`.
 ///
-/// When performing such an operation, augmented assignments are more concise
+/// When performing such an operation, an augmented assignment is more concise
 /// and idiomatic.
 ///
 /// ## Known problems
@@ -31,7 +31,7 @@ use crate::checkers::ast::Checker;
 /// For example, `x = "prefix-" + x` is not equivalent to `x += "prefix-"`,
 /// while `x = 1 + x` is equivalent to `x += 1`.
 ///
-/// If the type of the left-hand side cannot be inferred trivially, the rule
+/// If the type of the left-hand side cannot be trivially inferred, the rule
 /// will ignore the assignment.
 ///
 /// ## Example


### PR DESCRIPTION
Split out from #12857 so that it can be considered in isolation.

## Summary

This PR stabilises the `non-augmented-assignment` pylint rule (`PLR6104`). I think this rule makes sense and is reasonably uncontroversial. It's been in preview for >3 months and there haven't been any significant issues opened about it in several months.

However, it's a stylistic rule that's somewhat pedantic, and it has a lot of ecosystem hits.

## Test Plan

`cargo test`
