### PR TITLE
Update OpenAI excluded notebooks from ecosystem checks

### DIFF
--- a/python/ruff-ecosystem/ruff_ecosystem/defaults.py
+++ b/python/ruff-ecosystem/ruff_ecosystem/defaults.py
@@ -119,15 +119,12 @@ DEFAULT_TARGETS = [
         check_options=CheckOptions(select=JUPYTER_NOTEBOOK_SELECT),
         config_overrides={
             "include": ["*.ipynb"],
-            # TODO(dhruvmanila): Re-enable after fixing the notebook.
+            # These notebooks contain syntax errors because certain plain text / markdown
+            # cells are marked as code cells.
             "exclude": [
-                "examples/gpt_actions_library/.gpt_action_getting_started.ipynb",
-                "examples/gpt_actions_library/gpt_action_bigquery.ipynb",
-                "examples/chatgpt/gpt_actions_library/gpt_action_canvaslms.ipynb",
-                "examples/chatgpt/gpt_actions_library/.gpt_action_getting_started.ipynb",
-                "examples/chatgpt/gpt_actions_library/gpt_action_outlook.ipynb",
-                "examples/chatgpt/gpt_actions_library/gpt_action_salesforce.ipynb",
-                "examples/chatgpt/gpt_actions_library/gpt_action_bigquery.ipynb",
+                "examples/Chat_finetuning_data_prep.ipynb",
+                "examples/chatgpt/gpt_actions_library/gpt_action_google_drive.ipynb",
+                "examples/chatgpt/gpt_actions_library/gpt_action_redshift.ipynb",
             ],
         },
     ),


### PR DESCRIPTION
## Summary

Follow-up to #12864, we don't need to exclude these notebooks anymore.

## Test plan

- [x] Make sure that ecosystem checks are green.