### PR TITLE
Limit `requirements.txt` files updated by renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -14,12 +14,24 @@
     rangeStrategy: "update-lockfile",
   },
   pep621: {
+    // The default for this package manager is to only search for `pyproject.toml` files
+    // found at the repository root: https://docs.renovatebot.com/modules/manager/pep621/#file-matching
     fileMatch: ["^(python|scripts)/.*pyproject\\.toml$"],
   },
   pip_requirements: {
-    fileMatch: ["^docs/requirements.*\\.txt$"],
+    // The default for this package manager is to run on all requirements.txt files:
+    // https://docs.renovatebot.com/modules/manager/pip_requirements/#file-matching
+    // `fileMatch` doesn't work for excluding files; to exclude `requirements.txt` files
+    // outside the `doc/` directory, we instead have to use `ignorePaths` with a "negative glob pattern".
+    // See:
+    // - https://docs.renovatebot.com/modules/manager/#ignoring-files-that-match-the-default-filematch
+    // - https://docs.renovatebot.com/configuration-options/#ignorepaths
+    // - https://docs.renovatebot.com/string-pattern-matching/#negative-matching
+    ignorePaths: ["!docs/**"]
   },
   npm: {
+    // The default for this package manager is to only search for `package.json` files
+    // found at the repository root: https://docs.renovatebot.com/modules/manager/npm/#file-matching
     fileMatch: ["^playground/.*package\\.json$"],
   },
   "pre-commit": {

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -22,12 +22,14 @@
     // The default for this package manager is to run on all requirements.txt files:
     // https://docs.renovatebot.com/modules/manager/pip_requirements/#file-matching
     // `fileMatch` doesn't work for excluding files; to exclude `requirements.txt` files
-    // outside the `doc/` directory, we instead have to use `ignorePaths` with a "negative glob pattern".
+    // outside the `doc/` directory, we instead have to use `ignorePaths`. Unlike `fileMatch`,
+    // which takes a regex string, `ignorePaths` takes a glob string, so we have to use
+    // a "negative glob pattern".
     // See:
     // - https://docs.renovatebot.com/modules/manager/#ignoring-files-that-match-the-default-filematch
     // - https://docs.renovatebot.com/configuration-options/#ignorepaths
     // - https://docs.renovatebot.com/string-pattern-matching/#negative-matching
-    ignorePaths: ["!docs/**"]
+    ignorePaths: ["!docs/requirements*.txt"]
   },
   npm: {
     // The default for this package manager is to only search for `package.json` files


### PR DESCRIPTION
## Summary

Following https://github.com/astral-sh/ruff/commit/50ff5c754421474b353f94edfdc1fed7a8c3b82b, renovate is now filing PRs to update all `requirements.txt` files in Ruff:
- https://github.com/astral-sh/ruff/pull/12829
- https://github.com/astral-sh/ruff/pull/12823

The `requirements.txt` file being updated in ^both of those PRs isn't really appropriate for renovate to update, as it's generated by a `uv pip compile` command, and renovate hasn't implemented support for uv yet.

It turns out that the reason that renovate is doing this is because the `fileMatch` settings is _additive_ -- when you specify a regex under a `fileMatch` key, renovate uses that pattern _in addition_ to its default. (Specifying the pattern doesn't _override_ renovate's default.) To actually exclude files from being updated by renovate, we have to use `ignorePaths`. We haven't come across this before now, because the other package managers we have enabled in our renovate configs all have somewhat conservative defaults that will only update files found at the repository root. Renovate's `pip_requirements` package manager, however, will search for `requirements.txt` files anywhere and everywhere.

## Test Plan

```
~/dev/ruff (renovate-config-fix) % npx --yes --package renovate -- renovate-config-validator --strict    
(node:31231) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
 INFO: Validating .github/renovate.json5
 INFO: Config validated successfully
```
