### PR TITLE
[red-knot] Update source root path for benchmark

### DIFF
--- a/crates/ruff_benchmark/benches/red_knot.rs
+++ b/crates/ruff_benchmark/benches/red_knot.rs
@@ -40,7 +40,7 @@ fn setup_case() -> Case {
     ])
     .unwrap();
 
-    let src_root = SystemPath::new("/src");
+    let src_root = SystemPath::new("/src/tomllib");
     let metadata = WorkspaceMetadata::from_path(src_root, &system).unwrap();
     let settings = ProgramSettings {
         target_version: PythonVersion::PY312,


### PR DESCRIPTION
## Summary

I guess the existing path is correct but we currently don't have the ability to detect packages considering the below TODO:

https://github.com/astral-sh/ruff/blob/3eac2cae847770e28f87bef4e01faab71f95b201/crates/red_knot_workspace/src/workspace/metadata.rs#L33-L34

This means that the benchmark code considers `/src` as the package while `/src/tomllib` is the actual package. This means it's unable to resolve [relative imports](https://github.com/python/cpython/blob/e03073ff20107793a4ea28cdac0d6894774dd110/Lib/tomllib/_parser.py#L12-L20).

If this is correct, I can validate and update the expected diagnostics in the benchmark code.
