### PR TITLE
RUF027: Ignore template strings passed to logging calls and `builtins._()` calls

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/ruff/RUF027_1.py
+++ b/crates/ruff_linter/resources/test/fixtures/ruff/RUF027_1.py
@@ -45,3 +45,17 @@ def negative_cases():
 
     import django.utils.translations
     y = django.utils.translations.gettext("This {should} be understood as a translation string too!")
+
+    # Calling `gettext.install()` literall monkey-patches `builtins._ = ...`,
+    # so even the fully qualified access of `builtins._()` should be considered
+    # a possible `gettext` call.
+    import builtins
+    another = 42
+    z = builtins._("{another} translation string")
+
+    # Usually logging strings use `%`-style string interpolation,
+    # but `logging` can be configured to use `{}` the same as f-strings,
+    # so these should also be ignored.
+    # See https://docs.python.org/3/howto/logging-cookbook.html#formatting-styles
+    import logging
+    logging.info("yet {another} non-f-string")

--- a/crates/ruff_linter/src/checkers/ast/analyze/expression.rs
+++ b/crates/ruff_linter/src/checkers/ast/analyze/expression.rs
@@ -1077,12 +1077,7 @@ pub(crate) fn expression(expr: &Expr, checker: &mut Checker) {
             }
             if checker.enabled(Rule::MissingFStringSyntax) {
                 for string_literal in value.literals() {
-                    ruff::rules::missing_fstring_syntax(
-                        &mut checker.diagnostics,
-                        string_literal,
-                        checker.locator,
-                        &checker.semantic,
-                    );
+                    ruff::rules::missing_fstring_syntax(checker, string_literal);
                 }
             }
         }
@@ -1378,12 +1373,7 @@ pub(crate) fn expression(expr: &Expr, checker: &mut Checker) {
             }
             if checker.enabled(Rule::MissingFStringSyntax) {
                 for string_literal in value.as_slice() {
-                    ruff::rules::missing_fstring_syntax(
-                        &mut checker.diagnostics,
-                        string_literal,
-                        checker.locator,
-                        &checker.semantic,
-                    );
+                    ruff::rules::missing_fstring_syntax(checker, string_literal);
                 }
             }
         }

--- a/crates/ruff_linter/src/rules/ruff/rules/missing_fstring_syntax.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/missing_fstring_syntax.rs
@@ -1,13 +1,17 @@
-use memchr::memchr2_iter;
 use ruff_diagnostics::{AlwaysFixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::{self as ast};
 use ruff_python_literal::format::FormatSpec;
 use ruff_python_parser::parse_expression;
+use ruff_python_semantic::analyze::logging;
 use ruff_python_semantic::SemanticModel;
 use ruff_source_file::Locator;
 use ruff_text_size::{Ranged, TextRange};
+
+use memchr::memchr2_iter;
 use rustc_hash::FxHashSet;
+
+use crate::checkers::ast::Checker;
 
 /// ## What it does
 /// Checks for strings that contain f-string syntax but are not f-strings.
@@ -55,12 +59,9 @@ impl AlwaysFixableViolation for MissingFStringSyntax {
 }
 
 /// RUF027
-pub(crate) fn missing_fstring_syntax(
-    diagnostics: &mut Vec<Diagnostic>,
-    literal: &ast::StringLiteral,
-    locator: &Locator,
-    semantic: &SemanticModel,
-) {
+pub(crate) fn missing_fstring_syntax(checker: &mut Checker, literal: &ast::StringLiteral) {
+    let semantic = checker.semantic();
+
     // we want to avoid statement expressions that are just a string literal.
     // there's no reason to have standalone f-strings and this lets us avoid docstrings too
     if let ast::Stmt::Expr(ast::StmtExpr { value, .. }) = semantic.current_statement() {
@@ -71,18 +72,25 @@ pub(crate) fn missing_fstring_syntax(
     }
 
     // We also want to avoid expressions that are intended to be translated.
-    if semantic
-        .current_expressions()
-        .any(|expr| is_gettext(expr, semantic))
-    {
+    if semantic.current_expressions().any(|expr| {
+        is_gettext(expr, semantic)
+            || is_logger_call(expr, semantic, &checker.settings.logger_objects)
+    }) {
         return;
     }
 
-    if should_be_fstring(literal, locator, semantic) {
+    if should_be_fstring(literal, checker.locator(), semantic) {
         let diagnostic = Diagnostic::new(MissingFStringSyntax, literal.range())
             .with_fix(fix_fstring_syntax(literal.range()));
-        diagnostics.push(diagnostic);
+        checker.diagnostics.push(diagnostic);
     }
+}
+
+fn is_logger_call(expr: &ast::Expr, semantic: &SemanticModel, logger_objects: &[String]) -> bool {
+    let ast::Expr::Call(ast::ExprCall { func, .. }) = expr else {
+        return false;
+    };
+    logging::is_logger_candidate(func, semantic, logger_objects)
 }
 
 /// Returns `true` if an expression appears to be a `gettext` call.
@@ -119,7 +127,7 @@ fn is_gettext(expr: &ast::Expr, semantic: &SemanticModel) -> bool {
         .is_some_and(|qualified_name| {
             matches!(
                 qualified_name.segments(),
-                ["gettext", "gettext" | "ngettext"]
+                ["gettext", "gettext" | "ngettext"] | ["builtins", "_"]
             )
         })
 }


### PR DESCRIPTION
## Summary

#12869 initially proposed stabilising RUF027, but the ecosystem report showed that there were too many false positives. Some of those false positives stem from the fact that we currently emit errors on calls like this:

```py
import logging

foo = 42
logging.error("{foo}")
```

But you're not meant to pass f-strings to logging calls, as the `logging` module lazily evaluates template strings like this to improve performance. The default style of string interpolation used by the `logging` module is `%`-style interpolation, but this can be configured to use `{}`-style instead: https://docs.python.org/3/howto/logging-cookbook.html#formatting-styles. As such, this PR adjusts the rule's logic to ignore any strings that are inside logging calls.

I'm also making another small tweak to the logic used to detect `gettext` calls. Specifically, we weren't recognising a fully qualified call to `builtins._()` as a `gettext` call. But running `gettext.install()` literally monkeypatches the `builtins` module, so even this fully qualified access should be recognised by us as a `gettext` call.

## Test Plan

I added some new fixtures that Ruff will emit errors on currently, but doesn't with this PR branch.
