### PR TITLE
Bump version to 0.6

### DIFF
--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -1,5 +1,43 @@
 # Breaking Changes
 
+## 0.6.0
+
+- The pytest rules `PT001` and `PT023` now default to omitting the decorator parentheses when there are no arguments ([#12838](https://github.com/astral-sh/ruff/pull/12838)).
+
+- Detect imports in `src` layouts by default for `isort` rules ([#12848](https://github.com/astral-sh/ruff/pull/12848))
+
+- Lint and format Jupyter Notebook by default ([#12878](https://github.com/astral-sh/ruff/pull/12878)).
+
+    You can disable specific rules for notebooks using [`per-file-ignores`](https://docs.astral.sh/ruff/settings/#lint_per-file-ignores):
+
+    ```toml
+    [tool.ruff.lint.per-file-ignores]
+    "*.ipynb" = ["E501"] # disable line-too-long in notebooks
+    ```
+
+    If you'd prefer to either only lint or only format Jupyter Notebook files, you can use the
+    section-specific `exclude` option to do so. For example, the following would only lint Jupyter
+    Notebook files and not format them:
+
+    ```toml
+    [tool.ruff.format]
+    exclude = ["*.ipynb"]
+    ```
+
+    And, conversely, the following would only format Jupyter Notebook files and not lint them:
+
+    ```toml
+    [tool.ruff.lint]
+    exclude = ["*.ipynb"]
+    ```
+
+    You can completely disable Jupyter Notebook support by updating the [`extend-exclude`](https://docs.astral.sh/ruff/settings/#extend-exclude) setting:
+
+    ```toml
+    [tool.ruff]
+    extend-exclude = ["*.ipynb"]
+    ```
+
 ## 0.5.0
 
 - Follow the XDG specification to discover user-level configurations on macOS (same as on other Unix platforms)

--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -2,9 +2,9 @@
 
 ## 0.6.0
 
-- The pytest rules `PT001` and `PT023` now default to omitting the decorator parentheses when there are no arguments ([#12838](https://github.com/astral-sh/ruff/pull/12838)).
-
 - Detect imports in `src` layouts by default for `isort` rules ([#12848](https://github.com/astral-sh/ruff/pull/12848))
+
+- The pytest rules `PT001` and `PT023` now default to omitting the decorator parentheses when there are no arguments ([#12838](https://github.com/astral-sh/ruff/pull/12838)).
 
 - Lint and format Jupyter Notebook by default ([#12878](https://github.com/astral-sh/ruff/pull/12878)).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,43 +4,120 @@
 
 ### Breaking changes
 
-- Ruff 0.6 ([#12834](https://github.com/astral-sh/ruff/pull/12834))
+See also, the "Remapped rules" section which may result in disabled rules.
+
+- The pytest rules `PT001` and `PT023` now default to omitting the decorator parentheses when there are no arguments ([#12838](https://github.com/astral-sh/ruff/pull/12838)).
+
+- Detect imports in `src` layouts by default ([#12848](https://github.com/astral-sh/ruff/pull/12848))
+
+- Enable Jupyter Notebook formatting and linting by default ([#12878](https://github.com/astral-sh/ruff/pull/12878)).
+
+    You can disable specific rules for notebooks using [`per-file-ignores`](https://docs.astral.sh/ruff/settings/#lint_per-file-ignores):
+
+    ```toml
+    [tool.ruff.lint.per-file-ignores]
+    "*.ipynb" = ["E501"] # disable line-too-long in notebooks
+    ```
+
+    If you'd prefer to either only lint or only format Jupyter Notebook files, you can use the
+    section-specific `exclude` option to do so. For example, the following would only lint Jupyter
+    Notebook files and not format them:
+
+    ```toml
+    [tool.ruff.format]
+    exclude = ["*.ipynb"]
+    ```
+
+    And, conversely, the following would only format Jupyter Notebook files and not lint them:
+
+    ```toml
+    [tool.ruff.lint]
+    exclude = ["*.ipynb"]
+    ```
+
+    You can completely disable Jupyter Notebook support by updating the [`extend-exclude`](https://docs.astral.sh/ruff/rules/superfluous-else-continue/) setting:
+
+    ```toml
+    [tool.ruff]
+    extend-exclude = ["*.ipynb"]
+    ```
+
+### Deprecations
+
+The following rules are now deprecated:
+
+- [`pytest-missing-fixture-name-underscore`](https://docs.astral.sh/ruff/rules/pytest-missing-fixture-name-underscore/) (`PT004`)
+- [`pytest-incorrect-fixture-name-underscore`](https://docs.astral.sh/ruff/rules/pytest-incorrect-fixture-name-underscore/) (`PT005`)
+- [`unpacked-list-comprehension`](https://docs.astral.sh/ruff/rules/unpacked-list-comprehension/) (`UP027`)
+
+### Remapped rules
+
+The following rules have been remapped to new rule codes:
+
+- [`unnecessary-dict-comprehension-for-iterable`](https://docs.astral.sh/ruff/rules/unnecessary-dict-comprehension-for-iterable/): `RUF025` to `C420`
+
+### Stabilization
+
+The following rules have been stabilized and are no longer in preview:
+
+- [`singledispatch-method`](https://docs.astral.sh/ruff/rules/singledispatch-method/) (`PLE1519`)
+- [`singledispatchmethod-function`](https://docs.astral.sh/ruff/rules/singledispatchmethod-function/) (`PLE1520`)
+- [`bad-staticmethod-argument`](https://docs.astral.sh/ruff/rules/bad-staticmethod-argument/) (`PLW0211`)
+- [`if-stmt-min-max`](https://docs.astral.sh/ruff/rules/if-stmt-min-max/) (`PLR1730`)
+- [`invalid-bytes-return-type`](https://docs.astral.sh/ruff/rules/invalid-bytes-return-type/) (`PLE0308`)
+- [`invalid-hash-return-type`](https://docs.astral.sh/ruff/rules/invalid-hash-return-type/) (`PLE0309`)
+- [`invalid-index-return-type`](https://docs.astral.sh/ruff/rules/invalid-index-return-type/) (`PLE0305`)
+- [`invalid-length-return-type`](https://docs.astral.sh/ruff/rules/invalid-length-return-type/) (`E303`)
+- [`self-or-cls-assignment`](https://docs.astral.sh/ruff/rules/self-or-cls-assignment/) (`PLW0642`)
+- [`byte-string-usage`](https://docs.astral.sh/ruff/rules/byte-string-usage/) (`PYI057`)
+- [`duplicate-literal-member`](https://docs.astral.sh/ruff/rules/duplicate-literal-member/) (`PYI062`)
+- [`redirected-noqa`](https://docs.astral.sh/ruff/rules/redirected-noqa/) (`RUF101`)
+
+The following behaviors have been stabilized:
+
+- [`cancel-scope-no-checkpoint`](https://docs.astral.sh/ruff/rules/cancel-scope-no-checkpoint/) (`ASYNC100`): Support `asyncio` and `anyio` context mangers.
+- [`async-function-with-timeout`](https://docs.astral.sh/ruff/rules/async-function-with-timeout/) (`ASYNC109`): Support `asyncio` and `anyio` context mangers.
+- [`async-busy-wait`](https://docs.astral.sh/ruff/rules/async-busy-wait/) (`ASYNC110`): Support `asyncio` and `anyio` context mangers.
+- [`async-zero-sleep`](https://docs.astral.sh/ruff/rules/async-zero-sleep/) (`ASYNC115`): Support `anyio` context mangers.
+- [`long-sleep-not-forever`](https://docs.astral.sh/ruff/rules/long-sleep-not-forever/) (`ASYNC116`): : Support `anyio` context mangers.
+
+The following fixes have been stabilized:
+
+- [`superfluous-else-return`](https://docs.astral.sh/ruff/rules/superfluous-else-return/) (`RET505`)
+- [`superfluous-else-raise`](https://docs.astral.sh/ruff/rules/superfluous-else-raise/) (`RET506`)
+- [`superfluous-else-continue`](https://docs.astral.sh/ruff/rules/superfluous-else-continue/) (`RET507`)
+- [`superfluous-else-break`](https://docs.astral.sh/ruff/rules/superfluous-else-break/) (`RET508`)
 
 ### Preview features
 
-- RUF027: Ignore template strings passed to logging calls and `builtins._()` calls ([#12889](https://github.com/astral-sh/ruff/pull/12889))
-- [`pyupgrade`] Show violations without auto-fix for `UP031` ([#11229](https://github.com/astral-sh/ruff/pull/11229))
-- [flake8-return] Only add return None at end of function (RET503) ([#11074](https://github.com/astral-sh/ruff/pull/11074))
-- [flake8-simplify] Further simplify to binary in preview for `if-else-block-instead-of-if-exp (SIM108)` ([#12796](https://github.com/astral-sh/ruff/pull/12796))
-- [ruff] Do not remove parens for tuples with starred expressions in Python <=3.10 `RUF031` ([#12784](https://github.com/astral-sh/ruff/pull/12784))
-- `RUF031`: Ignore unparenthesized tuples in subscripts when the subscript is obviously a type annotation or type alias ([#12762](https://github.com/astral-sh/ruff/pull/12762))
+- \[`flake8-simplify`\] Further simplify to binary in preview for (`SIM108`) ([#12796](https://github.com/astral-sh/ruff/pull/12796))
+- \[`pyupgrade`\] Show violations without auto-fix (`UP031`) ([#11229](https://github.com/astral-sh/ruff/pull/11229))
+
+### Rule changes
+
+- \[`flake8-import-conventions`\] Add `xml.etree.ElementTree` to default conventions ([#12455](https://github.com/astral-sh/ruff/pull/12455))
+- \[`flake8-pytest-style`\] Add a space after comma in CSV output (`PT006`) ([#12853](https://github.com/astral-sh/ruff/pull/12853))
 
 ### Server
 
-- Collect errors while building up the settings index ([#12781](https://github.com/astral-sh/ruff/pull/12781))
+- Show a message for incorrect settings ([#12781](https://github.com/astral-sh/ruff/pull/12781))
 
 ### Bug fixes
 
-- Avoid treating `dataclasses.KW_ONLY` as typing-only ([#12863](https://github.com/astral-sh/ruff/pull/12863))
-- Don't enforce returns and yields in abstract methods ([#12771](https://github.com/astral-sh/ruff/pull/12771))
+- \[`flake8-return`\] Only add return `None` at end of a function (`RET503`) ([#11074](https://github.com/astral-sh/ruff/pull/11074))
+- \[`flake8-type-checking`\] Avoid treating `dataclasses.KW_ONLY` as typing-only (`TCH003`) ([#12863](https://github.com/astral-sh/ruff/pull/12863))
+- \[`pep8-naming`\] Treat `type(Protocol)` et al as metaclass base (`N805`) ([#12770](https://github.com/astral-sh/ruff/pull/12770))
+- \[`pydoclint`\] Don't enforce returns and yields in abstract methods (`DOC201`, `DOC202`) ([#12771](https://github.com/astral-sh/ruff/pull/12771))
+- \[`ruff`\] Skip tuples with slice expressions in (`RUF031`) ([#12768](https://github.com/astral-sh/ruff/pull/12768))
+- \[`ruff`\] Ignore unparenthesized tuples in subscripts when the subscript is a type annotation or type alias (`RUF031`) ([#12762](https://github.com/astral-sh/ruff/pull/12762))
+- \[`ruff`\] Ignore template strings passed to logging and `builtins._()` calls (`RUF027`) ([#12889](https://github.com/astral-sh/ruff/pull/12889))
+- \[`ruff`\] Do not remove parens for tuples with starred expressions in Python \<=3.10 (`RUF031`) ([#12784](https://github.com/astral-sh/ruff/pull/12784))
 - Evaluate default parameter value in enclosing scope ([#12852](https://github.com/astral-sh/ruff/pull/12852))
-- Treat `type(Protocol)` et al as metaclass base ([#12770](https://github.com/astral-sh/ruff/pull/12770))
-- [ruff] Skip tuples with slice expressions in `incorrectly-parenthesized-tuple-in-subscript (RUF031)` ([#12768](https://github.com/astral-sh/ruff/pull/12768))
-
-### Documentation
-
-- Add known problems warning to `type-comparison` rule ([#12769](https://github.com/astral-sh/ruff/pull/12769))
-- Document that BLE001 supports both BaseException and Exception ([#12788](https://github.com/astral-sh/ruff/pull/12788))
-- Improve docs for `missing-fstring-syntax` (`RUF027`) ([#12886](https://github.com/astral-sh/ruff/pull/12886))
-- Improve docs for `non-augmented-assignment` (`PLR6104`) ([#12887](https://github.com/astral-sh/ruff/pull/12887))
-- Improvements to documentation ([#12712](https://github.com/astral-sh/ruff/pull/12712))
-- [Minor typo] Fix article in "an fix" ([#12797](https://github.com/astral-sh/ruff/pull/12797))
 
 ### Other changes
 
-- Consider VS Code cell metadata to determine valid code cells ([#12864](https://github.com/astral-sh/ruff/pull/12864))
-- Fallback to kernelspec to check if it's a Python notebook ([#12875](https://github.com/astral-sh/ruff/pull/12875))
-- [`flake8-pytest-style`] Add a space after comma in CSV output (`PT006`) ([#12853](https://github.com/astral-sh/ruff/pull/12853))
+- Respect VS Code cell metadata when detecting the language of Jupyter Notebook cells ([#12864](https://github.com/astral-sh/ruff/pull/12864))
+- Respect `kernelspec` cell metadata when detecting the language of Jupyter Notebook cells ([#12875](https://github.com/astral-sh/ruff/pull/12875))
 
 ## 0.5.7
 
@@ -2215,9 +2292,9 @@ Read Ruff's new [versioning policy](https://docs.astral.sh/ruff/versioning/).
 - Unsafe fixes are no longer displayed or applied without opt-in ([#7769](https://github.com/astral-sh/ruff/pull/7769))
 - Drop formatting specific rules from the default set ([#7900](https://github.com/astral-sh/ruff/pull/7900))
 - The deprecated `format` setting has been removed ([#7984](https://github.com/astral-sh/ruff/pull/7984))
-  - The `format` setting cannot be used to configure the output format, use `output-format` instead
-  - The `RUFF_FORMAT` environment variable is ignored, use `RUFF_OUTPUT_FORMAT` instead
-  - The `--format` option has been removed from `ruff check`, use `--output-format` instead
+    - The `format` setting cannot be used to configure the output format, use `output-format` instead
+    - The `RUFF_FORMAT` environment variable is ignored, use `RUFF_OUTPUT_FORMAT` instead
+    - The `--format` option has been removed from `ruff check`, use `--output-format` instead
 
 ### Rule changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,47 @@
 # Changelog
 
+## 0.6.0
+
+### Breaking changes
+
+- Ruff 0.6 ([#12834](https://github.com/astral-sh/ruff/pull/12834))
+
+### Preview features
+
+- RUF027: Ignore template strings passed to logging calls and `builtins._()` calls ([#12889](https://github.com/astral-sh/ruff/pull/12889))
+- [`pyupgrade`] Show violations without auto-fix for `UP031` ([#11229](https://github.com/astral-sh/ruff/pull/11229))
+- [flake8-return] Only add return None at end of function (RET503) ([#11074](https://github.com/astral-sh/ruff/pull/11074))
+- [flake8-simplify] Further simplify to binary in preview for `if-else-block-instead-of-if-exp (SIM108)` ([#12796](https://github.com/astral-sh/ruff/pull/12796))
+- [ruff] Do not remove parens for tuples with starred expressions in Python <=3.10 `RUF031` ([#12784](https://github.com/astral-sh/ruff/pull/12784))
+- `RUF031`: Ignore unparenthesized tuples in subscripts when the subscript is obviously a type annotation or type alias ([#12762](https://github.com/astral-sh/ruff/pull/12762))
+
+### Server
+
+- Collect errors while building up the settings index ([#12781](https://github.com/astral-sh/ruff/pull/12781))
+
+### Bug fixes
+
+- Avoid treating `dataclasses.KW_ONLY` as typing-only ([#12863](https://github.com/astral-sh/ruff/pull/12863))
+- Don't enforce returns and yields in abstract methods ([#12771](https://github.com/astral-sh/ruff/pull/12771))
+- Evaluate default parameter value in enclosing scope ([#12852](https://github.com/astral-sh/ruff/pull/12852))
+- Treat `type(Protocol)` et al as metaclass base ([#12770](https://github.com/astral-sh/ruff/pull/12770))
+- [ruff] Skip tuples with slice expressions in `incorrectly-parenthesized-tuple-in-subscript (RUF031)` ([#12768](https://github.com/astral-sh/ruff/pull/12768))
+
+### Documentation
+
+- Add known problems warning to `type-comparison` rule ([#12769](https://github.com/astral-sh/ruff/pull/12769))
+- Document that BLE001 supports both BaseException and Exception ([#12788](https://github.com/astral-sh/ruff/pull/12788))
+- Improve docs for `missing-fstring-syntax` (`RUF027`) ([#12886](https://github.com/astral-sh/ruff/pull/12886))
+- Improve docs for `non-augmented-assignment` (`PLR6104`) ([#12887](https://github.com/astral-sh/ruff/pull/12887))
+- Improvements to documentation ([#12712](https://github.com/astral-sh/ruff/pull/12712))
+- [Minor typo] Fix article in "an fix" ([#12797](https://github.com/astral-sh/ruff/pull/12797))
+
+### Other changes
+
+- Consider VS Code cell metadata to determine valid code cells ([#12864](https://github.com/astral-sh/ruff/pull/12864))
+- Fallback to kernelspec to check if it's a Python notebook ([#12875](https://github.com/astral-sh/ruff/pull/12875))
+- [`flake8-pytest-style`] Add a space after comma in CSV output (`PT006`) ([#12853](https://github.com/astral-sh/ruff/pull/12853))
+
 ## 0.5.7
 
 ### Preview features
@@ -2173,9 +2215,9 @@ Read Ruff's new [versioning policy](https://docs.astral.sh/ruff/versioning/).
 - Unsafe fixes are no longer displayed or applied without opt-in ([#7769](https://github.com/astral-sh/ruff/pull/7769))
 - Drop formatting specific rules from the default set ([#7900](https://github.com/astral-sh/ruff/pull/7900))
 - The deprecated `format` setting has been removed ([#7984](https://github.com/astral-sh/ruff/pull/7984))
-    - The `format` setting cannot be used to configure the output format, use `output-format` instead
-    - The `RUFF_FORMAT` environment variable is ignored, use `RUFF_OUTPUT_FORMAT` instead
-    - The `--format` option has been removed from `ruff check`, use `--output-format` instead
+  - The `format` setting cannot be used to configure the output format, use `output-format` instead
+  - The `RUFF_FORMAT` environment variable is ignored, use `RUFF_OUTPUT_FORMAT` instead
+  - The `--format` option has been removed from `ruff check`, use `--output-format` instead
 
 ### Rule changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,45 +2,15 @@
 
 ## 0.6.0
 
+Check out the [blog post](https://astral.sh/blog/ruff-v0.6.0) for a migration guide and overview of the changes!
+
 ### Breaking changes
 
 See also, the "Remapped rules" section which may result in disabled rules.
 
+- Lint and format Jupyter Notebook by default ([#12878](https://github.com/astral-sh/ruff/pull/12878)).
+- Detect imports in `src` layouts by default for `isort` rules ([#12848](https://github.com/astral-sh/ruff/pull/12848))
 - The pytest rules `PT001` and `PT023` now default to omitting the decorator parentheses when there are no arguments ([#12838](https://github.com/astral-sh/ruff/pull/12838)).
-
-- Detect imports in `src` layouts by default ([#12848](https://github.com/astral-sh/ruff/pull/12848))
-
-- Enable Jupyter Notebook formatting and linting by default ([#12878](https://github.com/astral-sh/ruff/pull/12878)).
-
-    You can disable specific rules for notebooks using [`per-file-ignores`](https://docs.astral.sh/ruff/settings/#lint_per-file-ignores):
-
-    ```toml
-    [tool.ruff.lint.per-file-ignores]
-    "*.ipynb" = ["E501"] # disable line-too-long in notebooks
-    ```
-
-    If you'd prefer to either only lint or only format Jupyter Notebook files, you can use the
-    section-specific `exclude` option to do so. For example, the following would only lint Jupyter
-    Notebook files and not format them:
-
-    ```toml
-    [tool.ruff.format]
-    exclude = ["*.ipynb"]
-    ```
-
-    And, conversely, the following would only format Jupyter Notebook files and not lint them:
-
-    ```toml
-    [tool.ruff.lint]
-    exclude = ["*.ipynb"]
-    ```
-
-    You can completely disable Jupyter Notebook support by updating the [`extend-exclude`](https://docs.astral.sh/ruff/rules/superfluous-else-continue/) setting:
-
-    ```toml
-    [tool.ruff]
-    extend-exclude = ["*.ipynb"]
-    ```
 
 ### Deprecations
 
@@ -79,7 +49,7 @@ The following behaviors have been stabilized:
 - [`async-function-with-timeout`](https://docs.astral.sh/ruff/rules/async-function-with-timeout/) (`ASYNC109`): Support `asyncio` and `anyio` context mangers.
 - [`async-busy-wait`](https://docs.astral.sh/ruff/rules/async-busy-wait/) (`ASYNC110`): Support `asyncio` and `anyio` context mangers.
 - [`async-zero-sleep`](https://docs.astral.sh/ruff/rules/async-zero-sleep/) (`ASYNC115`): Support `anyio` context mangers.
-- [`long-sleep-not-forever`](https://docs.astral.sh/ruff/rules/long-sleep-not-forever/) (`ASYNC116`): : Support `anyio` context mangers.
+- [`long-sleep-not-forever`](https://docs.astral.sh/ruff/rules/long-sleep-not-forever/) (`ASYNC116`): Support `anyio` context mangers.
 
 The following fixes have been stabilized:
 
@@ -114,12 +84,12 @@ The following fixes have been stabilized:
 - \[`ruff`\] Ignore unparenthesized tuples in subscripts when the subscript is a type annotation or type alias (`RUF031`) ([#12762](https://github.com/astral-sh/ruff/pull/12762))
 - \[`ruff`\] Ignore template strings passed to logging and `builtins._()` calls (`RUF027`) ([#12889](https://github.com/astral-sh/ruff/pull/12889))
 - \[`ruff`\] Do not remove parens for tuples with starred expressions in Python \<=3.10 (`RUF031`) ([#12784](https://github.com/astral-sh/ruff/pull/12784))
-- Evaluate default parameter value in enclosing scope ([#12852](https://github.com/astral-sh/ruff/pull/12852))
+- Evaluate default parameter values for a function in that function's enclosing scope ([#12852](https://github.com/astral-sh/ruff/pull/12852))
 
 ### Other changes
 
 - Respect VS Code cell metadata when detecting the language of Jupyter Notebook cells ([#12864](https://github.com/astral-sh/ruff/pull/12864))
-- Respect `kernelspec` cell metadata when detecting the language of Jupyter Notebook cells ([#12875](https://github.com/astral-sh/ruff/pull/12875))
+- Respect `kernelspec` notebook metadata when detecting the preferred language for a Jupyter Notebook ([#12875](https://github.com/astral-sh/ruff/pull/12875))
 
 ## 0.5.7
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,8 @@ The following fixes have been stabilized:
 
 ### Bug fixes
 
+- \[`flake8-async`\] Do not lint yield in context manager (`ASYNC100`) ([#12896](https://github.com/astral-sh/ruff/pull/12896))
+- \[`flake8-comprehensions`\] Do not lint `async for` comprehensions (`C419`) ([#12895](https://github.com/astral-sh/ruff/pull/12895))
 - \[`flake8-return`\] Only add return `None` at end of a function (`RET503`) ([#11074](https://github.com/astral-sh/ruff/pull/11074))
 - \[`flake8-type-checking`\] Avoid treating `dataclasses.KW_ONLY` as typing-only (`TCH003`) ([#12863](https://github.com/astral-sh/ruff/pull/12863))
 - \[`pep8-naming`\] Treat `type(Protocol)` et al as metaclass base (`N805`) ([#12770](https://github.com/astral-sh/ruff/pull/12770))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2060,7 +2060,7 @@ dependencies = [
 
 [[package]]
 name = "ruff"
-version = "0.5.7"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "argfile",
@@ -2252,7 +2252,7 @@ dependencies = [
 
 [[package]]
 name = "ruff_linter"
-version = "0.5.7"
+version = "0.6.0"
 dependencies = [
  "aho-corasick",
  "annotate-snippets 0.9.2",
@@ -2572,7 +2572,7 @@ dependencies = [
 
 [[package]]
 name = "ruff_wasm"
-version = "0.5.7"
+version = "0.6.0"
 dependencies = [
  "console_error_panic_hook",
  "console_log",

--- a/README.md
+++ b/README.md
@@ -136,8 +136,8 @@ curl -LsSf https://astral.sh/ruff/install.sh | sh
 powershell -c "irm https://astral.sh/ruff/install.ps1 | iex"
 
 # For a specific version.
-curl -LsSf https://astral.sh/ruff/0.5.7/install.sh | sh
-powershell -c "irm https://astral.sh/ruff/0.5.7/install.ps1 | iex"
+curl -LsSf https://astral.sh/ruff/0.6.0/install.sh | sh
+powershell -c "irm https://astral.sh/ruff/0.6.0/install.ps1 | iex"
 ```
 
 You can also install Ruff via [Homebrew](https://formulae.brew.sh/formula/ruff), [Conda](https://anaconda.org/conda-forge/ruff),
@@ -170,7 +170,7 @@ Ruff can also be used as a [pre-commit](https://pre-commit.com/) hook via [`ruff
 ```yaml
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.
-  rev: v0.5.7
+  rev: v0.6.0
   hooks:
     # Run the linter.
     - id: ruff

--- a/crates/ruff/Cargo.toml
+++ b/crates/ruff/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ruff"
-version = "0.5.7"
+version = "0.6.0"
 publish = true
 authors = { workspace = true }
 edition = { workspace = true }

--- a/crates/ruff_linter/Cargo.toml
+++ b/crates/ruff_linter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ruff_linter"
-version = "0.5.7"
+version = "0.6.0"
 publish = false
 authors = { workspace = true }
 edition = { workspace = true }

--- a/crates/ruff_wasm/Cargo.toml
+++ b/crates/ruff_wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ruff_wasm"
-version = "0.5.7"
+version = "0.6.0"
 publish = false
 authors = { workspace = true }
 edition = { workspace = true }

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -78,7 +78,7 @@ Ruff can be used as a [pre-commit](https://pre-commit.com) hook via [`ruff-pre-c
 ```yaml
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.
-  rev: v0.5.7
+  rev: v0.6.0
   hooks:
     # Run the linter.
     - id: ruff
@@ -91,7 +91,7 @@ To enable lint fixes, add the `--fix` argument to the lint hook:
 ```yaml
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.
-  rev: v0.5.7
+  rev: v0.6.0
   hooks:
     # Run the linter.
     - id: ruff
@@ -105,7 +105,7 @@ To run the hooks over Jupyter Notebooks too, add `jupyter` to the list of allowe
 ```yaml
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.
-  rev: v0.5.7
+  rev: v0.6.0
   hooks:
     # Run the linter.
     - id: ruff

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "ruff"
-version = "0.5.7"
+version = "0.6.0"
 description = "An extremely fast Python linter and code formatter, written in Rust."
 authors = [{ name = "Astral Software Inc.", email = "hey@astral.sh" }]
 readme = "README.md"

--- a/scripts/benchmarks/pyproject.toml
+++ b/scripts/benchmarks/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "scripts"
-version = "0.5.7"
+version = "0.6.0"
 description = ""
 authors = ["Charles Marsh <charlie.r.marsh@gmail.com>"]
 


### PR DESCRIPTION
## Summary

This PR now does the *actual* release of Ruff 0.6


* [x] Write Changelog
* [x] Copy breaking changes into `BREAKING_CHANGES.md`
* [ ] Run the release workflow
* [ ] Update the schemastore
* [ ] Bump ruff version in ruff-vscode, release extension

