### PR TITLE
[flake8-comprehensions] Do not lint `async for` comprehensions in `unnecessary-comprehension-in-call (C419)`

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_comprehensions/C419.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_comprehensions/C419.py
@@ -65,4 +65,4 @@ async def test() -> None:
     async def async_gen() -> AsyncGenerator[bool, None]:
         yield True
 
-    assert all([v async for v in async_gen()])  # Should not be linted
+    assert all([v async for v in async_gen()])  # OK

--- a/crates/ruff_linter/resources/test/fixtures/flake8_comprehensions/C419.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_comprehensions/C419.py
@@ -55,3 +55,14 @@ max({x.id for x in bar})
 
 # should not be linted...
 sum({x.id for x in bar})
+
+
+# https://github.com/astral-sh/ruff/issues/12891
+from collections.abc import AsyncGenerator
+
+
+async def test() -> None:
+    async def async_gen() -> AsyncGenerator[bool, None]:
+        yield True
+
+    assert all([v async for v in async_gen()])  # Should not be linted

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_comprehension_in_call.rs
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_comprehension_in_call.rs
@@ -112,7 +112,7 @@ pub(crate) fn unnecessary_comprehension_in_call(
     if contains_await(elt) {
         return;
     }
-    if generators.iter().any(|x| x.is_async) {
+    if generators.iter().any(|generator| generator.is_async) {
         return;
     }
     let Some(Ok(builtin_function)) = checker

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_comprehension_in_call.rs
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_comprehension_in_call.rs
@@ -100,12 +100,19 @@ pub(crate) fn unnecessary_comprehension_in_call(
     let Some(arg) = args.first() else {
         return;
     };
-    let (Expr::ListComp(ast::ExprListComp { elt, .. })
-    | Expr::SetComp(ast::ExprSetComp { elt, .. })) = arg
+    let (Expr::ListComp(ast::ExprListComp {
+        elt, generators, ..
+    })
+    | Expr::SetComp(ast::ExprSetComp {
+        elt, generators, ..
+    })) = arg
     else {
         return;
     };
     if contains_await(elt) {
+        return;
+    }
+    if generators.iter().any(|x| x.is_async) {
         return;
     }
     let Some(Ok(builtin_function)) = checker


### PR DESCRIPTION
List and set comprehensions using `async for` cannot be replaced with underlying generators; this PR modifies C419 to skip such comprehensions. 

Closes #12891.
