### PR TITLE
[flake8-async] Do not lint yield in context manager `cancel-scope-no-checkpoint (ASYNC100)`

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_async/ASYNC100.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_async/ASYNC100.py
@@ -95,6 +95,13 @@ async def foo():
     with trio.fail_after(1):
         yield
 
+async def foo(): # even if only one branch contains a yield, we skip the lint
+    with trio.fail_after(1):
+        if something:
+            ...
+        else:
+            yield
+
 # https://github.com/astral-sh/ruff/issues/12873
 @asynccontextmanager
 async def good_code():

--- a/crates/ruff_linter/resources/test/fixtures/flake8_async/ASYNC100.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_async/ASYNC100.py
@@ -89,11 +89,13 @@ async def func():
 async def func():
     async with asyncio.timeout(delay=0.2), asyncio.timeout(delay=0.2):
         ...
-        
+
+
 # Don't trigger for blocks with a yield statement
 async def foo():
     with trio.fail_after(1):
         yield
+
 
 async def foo(): # even if only one branch contains a yield, we skip the lint
     with trio.fail_after(1):
@@ -101,6 +103,7 @@ async def foo(): # even if only one branch contains a yield, we skip the lint
             ...
         else:
             yield
+
 
 # https://github.com/astral-sh/ruff/issues/12873
 @asynccontextmanager

--- a/crates/ruff_linter/resources/test/fixtures/flake8_async/ASYNC100.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_async/ASYNC100.py
@@ -89,3 +89,16 @@ async def func():
 async def func():
     async with asyncio.timeout(delay=0.2), asyncio.timeout(delay=0.2):
         ...
+        
+# Don't trigger for blocks with a yield statement
+async def foo():
+    with trio.fail_after(1):
+        yield
+
+# https://github.com/astral-sh/ruff/issues/12873
+@asynccontextmanager
+async def good_code():
+    with anyio.fail_after(10):
+        # There's no await keyword here, but we presume that there
+        # will be in the caller we yield to, so this is safe.
+        yield

--- a/crates/ruff_linter/src/rules/flake8_async/rules/cancel_scope_no_checkpoint.rs
+++ b/crates/ruff_linter/src/rules/flake8_async/rules/cancel_scope_no_checkpoint.rs
@@ -85,8 +85,8 @@ pub(crate) fn cancel_scope_no_checkpoint(
 
     // Treat yields as checkpoints, since checkpoints can happen
     // in the caller yielded to.
-    // https://flake8-async.readthedocs.io/en/latest/rules.html#async100
-    // https://github.com/astral-sh/ruff/issues/12873
+    // See: https://flake8-async.readthedocs.io/en/latest/rules.html#async100
+    // See: https://github.com/astral-sh/ruff/issues/12873
     if any_over_body(&with_stmt.body, &Expr::is_yield_expr) {
         return;
     }

--- a/crates/ruff_linter/src/rules/flake8_async/rules/cancel_scope_no_checkpoint.rs
+++ b/crates/ruff_linter/src/rules/flake8_async/rules/cancel_scope_no_checkpoint.rs
@@ -1,8 +1,8 @@
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
-use ruff_python_ast::helpers::AwaitVisitor;
+use ruff_python_ast::helpers::{any_over_body, AwaitVisitor};
 use ruff_python_ast::visitor::Visitor;
-use ruff_python_ast::{StmtWith, WithItem};
+use ruff_python_ast::{Expr, StmtWith, WithItem};
 
 use crate::checkers::ast::Checker;
 use crate::rules::flake8_async::helpers::MethodName;
@@ -87,10 +87,7 @@ pub(crate) fn cancel_scope_no_checkpoint(
     // in the caller yielded to.
     // https://flake8-async.readthedocs.io/en/latest/rules.html#async100
     // https://github.com/astral-sh/ruff/issues/12873
-    if with_stmt.body.iter().any(|stmt| {
-        stmt.as_expr_stmt()
-            .is_some_and(|expr| expr.value.is_yield_expr())
-    }) {
+    if any_over_body(&with_stmt.body, &Expr::is_yield_expr) {
         return;
     }
 

--- a/crates/ruff_linter/src/rules/flake8_async/snapshots/ruff_linter__rules__flake8_async__tests__ASYNC100_ASYNC100.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_async/snapshots/ruff_linter__rules__flake8_async__tests__ASYNC100_ASYNC100.py.snap
@@ -98,4 +98,6 @@ ASYNC100.py:90:5: ASYNC100 A `with asyncio.timeout(...):` context does not conta
    |  _____^
 91 | |         ...
    | |___________^ ASYNC100
+92 |           
+93 |   # Don't trigger for blocks with a yield statement
    |

--- a/crates/ruff_linter/src/rules/flake8_async/snapshots/ruff_linter__rules__flake8_async__tests__ASYNC100_ASYNC100.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_async/snapshots/ruff_linter__rules__flake8_async__tests__ASYNC100_ASYNC100.py.snap
@@ -98,6 +98,4 @@ ASYNC100.py:90:5: ASYNC100 A `with asyncio.timeout(...):` context does not conta
    |  _____^
 91 | |         ...
    | |___________^ ASYNC100
-92 |           
-93 |   # Don't trigger for blocks with a yield statement
    |


### PR DESCRIPTION
For compatibility with upstream, treat `yield` as a checkpoint inside cancel scopes.

Closes #12873.
