### PR TITLE
[red-knot] fix lookups of possibly-shadowed builtins

### DIFF
--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -145,8 +145,27 @@ impl<'db> Type<'db> {
         matches!(self, Type::Unbound)
     }
 
-    pub const fn is_unknown(&self) -> bool {
-        matches!(self, Type::Unknown)
+    pub fn may_be_unbound(&self, db: &'db dyn Db) -> bool {
+        match self {
+            Type::Unbound => true,
+            Type::Union(union) => union.contains(db, Type::Unbound),
+            _ => false,
+        }
+    }
+
+    #[must_use]
+    pub fn replace_unbound_with(&self, db: &'db dyn Db, replacement: Type<'db>) -> Type<'db> {
+        match self {
+            Type::Unbound => replacement,
+            Type::Union(union) => union
+                .elements(db)
+                .into_iter()
+                .fold(UnionBuilder::new(db), |builder, ty| {
+                    builder.add(ty.replace_unbound_with(db, replacement))
+                })
+                .build(),
+            ty => *ty,
+        }
     }
 
     #[must_use]

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -145,10 +145,16 @@ impl<'db> Type<'db> {
         matches!(self, Type::Unbound)
     }
 
+    pub const fn is_never(&self) -> bool {
+        matches!(self, Type::Never)
+    }
+
     pub fn may_be_unbound(&self, db: &'db dyn Db) -> bool {
         match self {
             Type::Unbound => true,
             Type::Union(union) => union.contains(db, Type::Unbound),
+            // Unbound can't appear in an intersection, because an intersection with Unbound
+            // simplifies to just Unbound.
             _ => false,
         }
     }

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -1360,10 +1360,13 @@ impl<'db> TypeInferenceBuilder<'db> {
                             global_symbol_ty_by_name(self.db, self.file, id)
                         };
                         // fallback to builtins
-                        if matches!(unbound_ty, Type::Unbound)
+                        if unbound_ty.may_be_unbound(self.db)
                             && Some(self.scope) != builtins_scope(self.db)
                         {
-                            unbound_ty = builtins_symbol_ty_by_name(self.db, id);
+                            unbound_ty = unbound_ty.replace_unbound_with(
+                                self.db,
+                                builtins_symbol_ty_by_name(self.db, id),
+                            );
                         }
                         Some(unbound_ty)
                     } else {
@@ -2159,6 +2162,38 @@ mod tests {
 
         assert_eq!(x_ty.display(&db).to_string(), "Unbound");
         assert_eq!(y_ty.display(&db).to_string(), "Literal[1]");
+
+        Ok(())
+    }
+
+    #[test]
+    fn conditionally_global_or_builtin() -> anyhow::Result<()> {
+        let mut db = setup_db();
+
+        db.write_dedented(
+            "/src/a.py",
+            "
+            if flag:
+                copyright = 1
+            def f():
+                y = copyright
+            ",
+        )?;
+
+        let file = system_path_to_file(&db, "src/a.py").expect("Expected file to exist.");
+        let index = semantic_index(&db, file);
+        let function_scope = index
+            .child_scopes(FileScopeId::global())
+            .next()
+            .unwrap()
+            .0
+            .to_scope_id(&db, file);
+        let y_ty = symbol_ty_by_name(&db, function_scope, "y");
+
+        assert_eq!(
+            y_ty.display(&db).to_string(),
+            "Literal[1] | Literal[copyright]"
+        );
 
         Ok(())
     }

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -1354,7 +1354,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                     let symbol = symbols.symbol_by_name(id).unwrap();
                     if !symbol.is_defined() || !self.scope.is_function_like(self.db) {
                         // implicit global
-                        let mut unbound_ty = if file_scope_id == FileScopeId::global() {
+                        let unbound_ty = if file_scope_id == FileScopeId::global() {
                             Type::Unbound
                         } else {
                             global_symbol_ty_by_name(self.db, self.file, id)
@@ -1363,12 +1363,13 @@ impl<'db> TypeInferenceBuilder<'db> {
                         if unbound_ty.may_be_unbound(self.db)
                             && Some(self.scope) != builtins_scope(self.db)
                         {
-                            unbound_ty = unbound_ty.replace_unbound_with(
+                            Some(unbound_ty.replace_unbound_with(
                                 self.db,
                                 builtins_symbol_ty_by_name(self.db, id),
-                            );
+                            ))
+                        } else {
+                            Some(unbound_ty)
                         }
-                        Some(unbound_ty)
                     } else {
                         Some(Type::Unbound)
                     }


### PR DESCRIPTION
If a builtin is conditionally shadowed by a global, we didn't correctly fall back to builtins for the not-defined-in-globals path (see added test for an example.)