### PR TITLE
[red-knot] [WIP] SSA-style use-def map (unoptimized)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1904,6 +1904,7 @@ dependencies = [
  "ruff_text_size",
  "rustc-hash 2.0.0",
  "salsa",
+ "smallvec",
  "tempfile",
  "tracing",
  "walkdir",

--- a/crates/red_knot_python_semantic/Cargo.toml
+++ b/crates/red_knot_python_semantic/Cargo.toml
@@ -26,6 +26,7 @@ countme = { workspace = true }
 once_cell = { workspace = true }
 ordermap = { workspace = true }
 salsa = { workspace = true }
+smallvec = { workspace = true }
 tracing = { workspace = true }
 rustc-hash = { workspace = true }
 hashbrown = { workspace = true }

--- a/crates/red_knot_python_semantic/src/semantic_index/symbol.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/symbol.rs
@@ -272,7 +272,7 @@ impl SymbolTableBuilder {
         &mut self,
         name: Name,
         flags: SymbolFlags,
-    ) -> (ScopedSymbolId, bool) {
+    ) -> ScopedSymbolId {
         let hash = SymbolTable::hash_name(&name);
         let entry = self
             .table
@@ -285,7 +285,7 @@ impl SymbolTableBuilder {
                 let symbol = &mut self.table.symbols[*entry.key()];
                 symbol.insert_flags(flags);
 
-                (*entry.key(), false)
+                *entry.key()
             }
             RawEntryMut::Vacant(entry) => {
                 let mut symbol = Symbol::new(name);
@@ -295,7 +295,7 @@ impl SymbolTableBuilder {
                 entry.insert_with_hasher(hash, id, (), |id| {
                     SymbolTable::hash_name(self.table.symbols[*id].name().as_str())
                 });
-                (id, true)
+                id
             }
         }
     }

--- a/crates/red_knot_python_semantic/src/semantic_model.rs
+++ b/crates/red_knot_python_semantic/src/semantic_model.rs
@@ -151,7 +151,7 @@ impl HasTy for ast::StmtFunctionDef {
     fn ty<'db>(&self, model: &SemanticModel<'db>) -> Type<'db> {
         let index = semantic_index(model.db, model.file);
         let definition = index.definition(self);
-        definition_ty(model.db, definition)
+        definition_ty(model.db, Some(definition))
     }
 }
 
@@ -159,7 +159,7 @@ impl HasTy for StmtClassDef {
     fn ty<'db>(&self, model: &SemanticModel<'db>) -> Type<'db> {
         let index = semantic_index(model.db, model.file);
         let definition = index.definition(self);
-        definition_ty(model.db, definition)
+        definition_ty(model.db, Some(definition))
     }
 }
 
@@ -167,7 +167,7 @@ impl HasTy for ast::Alias {
     fn ty<'db>(&self, model: &SemanticModel<'db>) -> Type<'db> {
         let index = semantic_index(model.db, model.file);
         let definition = index.definition(self);
-        definition_ty(model.db, definition)
+        definition_ty(model.db, Some(definition))
     }
 }
 


### PR DESCRIPTION
This uses the algorithm in https://c9x.me/compile/bib/braun13cc.pdf to do our use-def map in an SSA style, where there's always only one visible definition for a symbol, and we use Phi definitions at control-flow merge points to merge the visible definitions from each path.

In a sense this is a synthesis between the first version (where we built a CFG and traversed it lazily in type inference) and the current code. This still associates uses with definitions directly in semantic indexing rather than lazily traversing in type inference, but it does the use-def association using memoized lazy traversal of a CFG. 

Significant advantages I see of this approach:
- In scopes where we don’t need inferred public types for all symbols, it can save tracking metadata for symbols after the point where they are no longer used. 
- The Phi definitions allow us to cache union and intersection building and simplification (which will get more expensive as we add more to the type system and do proper subtype based simplification); in the current system this work is redone for every use of a symbol with multiple definitions/constraints. 
- It doesn’t require tracking an MxN matrix of definitions bs constraints for all symbols in building the use def map. 

It's a significant regression right now, but it's also missing some needed optimizations to avoid creating lots of unnecessary trivial Phi nodes.