### PR TITLE
Fixup description of default values for `fixture-parentheses` and `mark-parentheses`

### DIFF
--- a/crates/ruff_workspace/src/options.rs
+++ b/crates/ruff_workspace/src/options.rs
@@ -1388,10 +1388,10 @@ impl Flake8ImportConventionsOptions {
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct Flake8PytestStyleOptions {
     /// Boolean flag specifying whether `@pytest.fixture()` without parameters
-    /// should have parentheses. If the option is set to `true` (the
-    /// default), `@pytest.fixture()` is valid and `@pytest.fixture` is
-    /// invalid. If set to `false`, `@pytest.fixture` is valid and
-    /// `@pytest.fixture()` is invalid.
+    /// should have parentheses. If the option is set to `false` (the default),
+    /// `@pytest.fixture` is valid and `@pytest.fixture()` is invalid. If set
+    /// to `true`, `@pytest.fixture()` is valid and `@pytest.fixture` is
+    /// invalid.
     #[option(
         default = "false",
         value_type = "bool",
@@ -1471,10 +1471,10 @@ pub struct Flake8PytestStyleOptions {
     pub raises_extend_require_match_for: Option<Vec<String>>,
 
     /// Boolean flag specifying whether `@pytest.mark.foo()` without parameters
-    /// should have parentheses. If the option is set to `true` (the
-    /// default), `@pytest.mark.foo()` is valid and `@pytest.mark.foo` is
-    /// invalid. If set to `false`, `@pytest.mark.foo` is valid and
-    /// `@pytest.mark.foo()` is invalid.
+    /// should have parentheses. If the option is set to `false` (the
+    /// default), `@pytest.mark.foo` is valid and `@pytest.mark.foo()` is
+    /// invalid. If set to `true`, `@pytest.mark.foo()` is valid and
+    /// `@pytest.mark.foo` is invalid.
     #[option(
         default = "false",
         value_type = "bool",

--- a/ruff.schema.json
+++ b/ruff.schema.json
@@ -1103,14 +1103,14 @@
       "type": "object",
       "properties": {
         "fixture-parentheses": {
-          "description": "Boolean flag specifying whether `@pytest.fixture()` without parameters should have parentheses. If the option is set to `true` (the default), `@pytest.fixture()` is valid and `@pytest.fixture` is invalid. If set to `false`, `@pytest.fixture` is valid and `@pytest.fixture()` is invalid.",
+          "description": "Boolean flag specifying whether `@pytest.fixture()` without parameters should have parentheses. If the option is set to `false` (the default), `@pytest.fixture` is valid and `@pytest.fixture()` is invalid. If set to `true`, `@pytest.fixture()` is valid and `@pytest.fixture` is invalid.",
           "type": [
             "boolean",
             "null"
           ]
         },
         "mark-parentheses": {
-          "description": "Boolean flag specifying whether `@pytest.mark.foo()` without parameters should have parentheses. If the option is set to `true` (the default), `@pytest.mark.foo()` is valid and `@pytest.mark.foo` is invalid. If set to `false`, `@pytest.mark.foo` is valid and `@pytest.mark.foo()` is invalid.",
+          "description": "Boolean flag specifying whether `@pytest.mark.foo()` without parameters should have parentheses. If the option is set to `false` (the default), `@pytest.mark.foo` is valid and `@pytest.mark.foo()` is invalid. If set to `true`, `@pytest.mark.foo()` is valid and `@pytest.mark.foo` is invalid.",
           "type": [
             "boolean",
             "null"


### PR DESCRIPTION
I noticed while creating a PR to update the schemastore entry for Ruff that there was still some language here that implied that these defaulted to true; but they default to false on ruff 0.6+. #12838 changed some but not all the language here.