### PR TITLE
[red-knot] Add support for relative imports

### DIFF
--- a/crates/red_knot_python_semantic/src/module_name.rs
+++ b/crates/red_knot_python_semantic/src/module_name.rs
@@ -168,6 +168,25 @@ impl ModuleName {
         };
         Some(Self(name))
     }
+
+    /// Push a new "tail" to the module name.
+    ///
+    /// The tail may be a single component, e.g. `"foo"`
+    /// or a "dotted string" consisting of multiple components,
+    /// e.g. `"foo.bar.baz"`
+    ///
+    /// ## Errors
+    /// Returns an error if any component in `tail` was not a valid identifier,
+    /// maintaining the invariant enforced by the constructor.
+    pub fn push_tail(&mut self, tail: &str) -> Result<(), &'static str> {
+        if Self::is_valid_name(tail) {
+            self.0.push('.');
+            self.0.push_str(tail);
+            Ok(())
+        } else {
+            Err("Invalid component pushed: not an identifier")
+        }
+    }
 }
 
 impl Deref for ModuleName {

--- a/crates/red_knot_python_semantic/src/module_name.rs
+++ b/crates/red_knot_python_semantic/src/module_name.rs
@@ -169,23 +169,22 @@ impl ModuleName {
         Some(Self(name))
     }
 
-    /// Push a new "tail" to the module name.
+    /// Extend `self` with the components of `other`
     ///
-    /// The tail may be a single component, e.g. `"foo"`
-    /// or a "dotted string" consisting of multiple components,
-    /// e.g. `"foo.bar.baz"`
+    /// # Examples
     ///
-    /// ## Errors
-    /// Returns an error if any component in `tail` was not a valid identifier,
-    /// maintaining the invariant enforced by the constructor.
-    pub fn push_tail(&mut self, tail: &str) -> Result<(), &'static str> {
-        if Self::is_valid_name(tail) {
-            self.0.push('.');
-            self.0.push_str(tail);
-            Ok(())
-        } else {
-            Err("Invalid component pushed: not an identifier")
-        }
+    /// ```
+    /// use red_knot_python_semantic::ModuleName;
+    ///
+    /// let mut module_name = ModuleName::new_static("foo").unwrap();
+    /// module_name.extend(&ModuleName::new_static("bar").unwrap());
+    /// assert_eq!(&module_name, "foo.bar");
+    /// module_name.extend(&ModuleName::new_static("baz.eggs.ham").unwrap());
+    /// assert_eq!(&module_name, "foo.bar.baz.eggs.ham");
+    /// ```
+    pub fn extend(&mut self, other: &ModuleName) {
+        self.0.push('.');
+        self.0.push_str(other);
     }
 }
 

--- a/crates/red_knot_python_semantic/src/module_resolver/mod.rs
+++ b/crates/red_knot_python_semantic/src/module_resolver/mod.rs
@@ -2,7 +2,7 @@ use std::iter::FusedIterator;
 
 pub(crate) use module::Module;
 pub use resolver::resolve_module;
-pub(crate) use resolver::SearchPaths;
+pub(crate) use resolver::{file_to_module, SearchPaths};
 use ruff_db::system::SystemPath;
 pub use typeshed::vendored_typeshed_stubs;
 

--- a/crates/red_knot_python_semantic/src/module_resolver/module.rs
+++ b/crates/red_knot_python_semantic/src/module_resolver/module.rs
@@ -77,3 +77,9 @@ pub enum ModuleKind {
     /// A python package (`foo/__init__.py` or `foo/__init__.pyi`)
     Package,
 }
+
+impl ModuleKind {
+    pub const fn is_package(self) -> bool {
+        matches!(self, ModuleKind::Package)
+    }
+}

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -870,11 +870,11 @@ impl<'db> TypeInferenceBuilder<'db> {
     ///   - `from .foo import bar` => `level == 1`
     ///   - `from ...foo import bar` => `level == 3`
     /// - `tail` is the relative module name stripped of all leading dots:
-    ///   - `from .foo import bar` => `tail == `"foo"`
+    ///   - `from .foo import bar` => `tail == "foo"`
     ///   - `from ..foo.bar import baz` => `tail == "foo.bar"`
     fn relative_module_name(&self, tail: Option<&str>, level: NonZeroU32) -> Option<ModuleName> {
         let module = file_to_module(self.db, self.file)?;
-        let mut level = u32::from(level);
+        let mut level = level.get();
         if module.kind().is_package() {
             level -= 1;
         }
@@ -882,8 +882,8 @@ impl<'db> TypeInferenceBuilder<'db> {
         for _ in 0..level {
             module_name = module_name.parent()?;
         }
-        if let Some(tail) = tail {
-            module_name.push_tail(tail).ok()?;
+        if let Some(tail) = tail.and_then(ModuleName::new) {
+            module_name.extend(&tail);
         }
         Some(module_name)
     }

--- a/crates/ruff_benchmark/benches/red_knot.rs
+++ b/crates/ruff_benchmark/benches/red_knot.rs
@@ -89,7 +89,7 @@ fn benchmark_incremental(criterion: &mut Criterion) {
                 let Case { db, parser, .. } = case;
                 let result = db.check_file(*parser).unwrap();
 
-                assert_eq!(result.len(), 111);
+                assert_eq!(result.len(), 29);
             },
             BatchSize::SmallInput,
         );
@@ -104,7 +104,7 @@ fn benchmark_cold(criterion: &mut Criterion) {
                 let Case { db, parser, .. } = case;
                 let result = db.check_file(*parser).unwrap();
 
-                assert_eq!(result.len(), 111);
+                assert_eq!(result.len(), 29);
             },
             BatchSize::SmallInput,
         );


### PR DESCRIPTION
## Summary

This PR adds support for relative import statements, e.g. `from .foo import bar`, `from . import bar`, or `from ...foo import bar`.

## Test Plan

Several tests added to `infer.rs`.

Co-authored-by: Carl Meyer <carl@astral.sh>