### PR TITLE
[`ruff`] - allow private variables for `RUF006`

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/ruff/RUF006.py
+++ b/crates/ruff_linter/resources/test/fixtures/ruff/RUF006.py
@@ -185,3 +185,8 @@ def f():
     global task
     loop = asyncio.get_event_loop()
     task = loop.create_task(main()) # Error
+
+# OK
+def f():
+    loop = asyncio.get_event_loop()
+    _task = loop.create_task(main())

--- a/crates/ruff_linter/src/rules/ruff/rules/asyncio_dangling_task.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/asyncio_dangling_task.rs
@@ -127,6 +127,7 @@ pub(crate) fn asyncio_dangling_binding(
         if binding.is_used()
             || binding.is_global()
             || binding.is_nonlocal()
+            || binding.is_private_declaration()
             || !binding.kind.is_assignment()
         {
             continue;
@@ -145,6 +146,7 @@ pub(crate) fn asyncio_dangling_binding(
             if binding.is_used()
                 || binding.is_global()
                 || binding.is_nonlocal()
+                || binding.is_private_declaration()
                 || !binding.kind.is_assignment()
             {
                 continue;


### PR DESCRIPTION
## Summary

Changes RUF006 to allow private vars.

I believe this is a reasonable addition, private declarations surely satisfy the underlying needs.

## Test Plan

`cargo test`