### PR TITLE
Pull all types in corpus tests

### DIFF
--- a/crates/red_knot_python_semantic/src/semantic_index/definition.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/definition.rs
@@ -248,6 +248,10 @@ impl AssignmentDefinitionKind {
     pub(crate) fn assignment(&self) -> &ast::StmtAssign {
         self.assignment.node()
     }
+
+    pub(crate) fn target(&self) -> &ast::ExprName {
+        self.target.node()
+    }
 }
 
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]

--- a/crates/red_knot_python_semantic/src/semantic_model.rs
+++ b/crates/red_knot_python_semantic/src/semantic_model.rs
@@ -147,29 +147,26 @@ impl HasTy for ast::Expr {
     }
 }
 
-impl HasTy for ast::StmtFunctionDef {
-    fn ty<'db>(&self, model: &SemanticModel<'db>) -> Type<'db> {
-        let index = semantic_index(model.db, model.file);
-        let definition = index.definition(self);
-        definition_ty(model.db, definition)
-    }
+macro_rules! impl_definition_has_ty {
+    ($ty: ty) => {
+        impl HasTy for $ty {
+            #[inline]
+            fn ty<'db>(&self, model: &SemanticModel<'db>) -> Type<'db> {
+                let index = semantic_index(model.db, model.file);
+                let definition = index.definition(self);
+                definition_ty(model.db, definition)
+            }
+        }
+    };
 }
 
-impl HasTy for StmtClassDef {
-    fn ty<'db>(&self, model: &SemanticModel<'db>) -> Type<'db> {
-        let index = semantic_index(model.db, model.file);
-        let definition = index.definition(self);
-        definition_ty(model.db, definition)
-    }
-}
-
-impl HasTy for ast::Alias {
-    fn ty<'db>(&self, model: &SemanticModel<'db>) -> Type<'db> {
-        let index = semantic_index(model.db, model.file);
-        let definition = index.definition(self);
-        definition_ty(model.db, definition)
-    }
-}
+impl_definition_has_ty!(ast::StmtFunctionDef);
+impl_definition_has_ty!(StmtClassDef);
+impl_definition_has_ty!(ast::Alias);
+impl_definition_has_ty!(ast::StmtAnnAssign);
+impl_definition_has_ty!(ast::Comprehension);
+impl_definition_has_ty!(ast::Parameter);
+impl_definition_has_ty!(ast::ParameterWithDefault);
 
 #[cfg(test)]
 mod tests {

--- a/crates/red_knot_python_semantic/src/semantic_model.rs
+++ b/crates/red_knot_python_semantic/src/semantic_model.rs
@@ -163,24 +163,8 @@ macro_rules! impl_definition_has_ty {
 impl_definition_has_ty!(ast::StmtFunctionDef);
 impl_definition_has_ty!(ast::StmtClassDef);
 impl_definition_has_ty!(ast::Alias);
-impl_definition_has_ty!(ast::Comprehension);
 impl_definition_has_ty!(ast::Parameter);
 impl_definition_has_ty!(ast::ParameterWithDefault);
-
-impl HasTy for ast::StmtAnnAssign {
-    fn ty<'db>(&self, model: &SemanticModel<'db>) -> Type<'db> {
-        // FIXME: We don't consider assignments with non-name targets as definitions.
-        //   https://github.com/astral-sh/ruff/blob/e49d47a6fce4d42d4d9dc1da6ed9357a42bbc987/crates/red_knot_python_semantic/src/types/infer.rs#L728-L733
-        //   For now, call into the expression's type in this case.
-        if self.target.is_name_expr() {
-            let index = semantic_index(model.db, model.file);
-            let definition = index.definition(self);
-            definition_ty(model.db, definition)
-        } else {
-            self.target.ty(model)
-        }
-    }
-}
 
 #[cfg(test)]
 mod tests {

--- a/crates/red_knot_python_semantic/src/semantic_model.rs
+++ b/crates/red_knot_python_semantic/src/semantic_model.rs
@@ -163,10 +163,24 @@ macro_rules! impl_definition_has_ty {
 impl_definition_has_ty!(ast::StmtFunctionDef);
 impl_definition_has_ty!(StmtClassDef);
 impl_definition_has_ty!(ast::Alias);
-impl_definition_has_ty!(ast::StmtAnnAssign);
 impl_definition_has_ty!(ast::Comprehension);
 impl_definition_has_ty!(ast::Parameter);
 impl_definition_has_ty!(ast::ParameterWithDefault);
+
+impl HasTy for ast::StmtAnnAssign {
+    fn ty<'db>(&self, model: &SemanticModel<'db>) -> Type<'db> {
+        // FIXME: We don't consider assignments with non-name targets as definitions.
+        //   https://github.com/astral-sh/ruff/blob/e49d47a6fce4d42d4d9dc1da6ed9357a42bbc987/crates/red_knot_python_semantic/src/types/infer.rs#L728-L733
+        //   For now, call into the expression's type in this case.
+        if self.target.is_name_expr() {
+            let index = semantic_index(model.db, model.file);
+            let definition = index.definition(self);
+            definition_ty(model.db, definition)
+        } else {
+            self.target.ty(model)
+        }
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/crates/red_knot_python_semantic/src/semantic_model.rs
+++ b/crates/red_knot_python_semantic/src/semantic_model.rs
@@ -1,7 +1,7 @@
 use ruff_db::files::{File, FilePath};
 use ruff_db::source::line_index;
 use ruff_python_ast as ast;
-use ruff_python_ast::{Expr, ExpressionRef, StmtClassDef};
+use ruff_python_ast::{Expr, ExpressionRef};
 use ruff_source_file::LineIndex;
 
 use crate::module_name::ModuleName;
@@ -161,7 +161,7 @@ macro_rules! impl_definition_has_ty {
 }
 
 impl_definition_has_ty!(ast::StmtFunctionDef);
-impl_definition_has_ty!(StmtClassDef);
+impl_definition_has_ty!(ast::StmtClassDef);
 impl_definition_has_ty!(ast::Alias);
 impl_definition_has_ty!(ast::Comprehension);
 impl_definition_has_ty!(ast::Parameter);

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -757,8 +757,6 @@ impl<'db> TypeInferenceBuilder<'db> {
 
         let annotation_ty = self.infer_expression(annotation);
 
-        // FIXME: This seems incorrect? Shouldn't the target get the same type as the annotation?
-        //   E.g. calling `name.ty(model)` should return the same as `annotated.ty(model)`.?
         self.infer_expression(target);
 
         annotation_ty

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -294,7 +294,11 @@ impl<'db> TypeInferenceBuilder<'db> {
                 );
             }
             DefinitionKind::Assignment(assignment) => {
-                self.infer_assignment_definition(assignment.assignment(), definition);
+                self.infer_assignment_definition(
+                    assignment.target(),
+                    assignment.assignment(),
+                    definition,
+                );
             }
             DefinitionKind::AnnotatedAssignment(annotated_assignment) => {
                 self.infer_annotated_assignment_definition(annotated_assignment.node(), definition);
@@ -706,6 +710,7 @@ impl<'db> TypeInferenceBuilder<'db> {
 
     fn infer_assignment_definition(
         &mut self,
+        target: &ast::ExprName,
         assignment: &ast::StmtAssign,
         definition: Definition<'db>,
     ) {
@@ -715,6 +720,9 @@ impl<'db> TypeInferenceBuilder<'db> {
         let value_ty = self
             .types
             .expression_ty(assignment.value.scoped_ast_id(self.db, self.scope));
+        self.types
+            .expressions
+            .insert(target.scoped_ast_id(self.db, self.scope), value_ty);
         self.types.definitions.insert(definition, value_ty);
     }
 

--- a/crates/red_knot_workspace/tests/check.rs
+++ b/crates/red_knot_workspace/tests/check.rs
@@ -132,6 +132,12 @@ impl SourceOrderVisitor<'_> for PullTypesVisitor<'_> {
 
     fn visit_parameter_with_default(&mut self, parameter_with_default: &ParameterWithDefault) {
         let _ty = parameter_with_default.ty(&self.model);
-        source_order::walk_parameter_with_default(self, parameter_with_default);
+
+        // FIXME: We currently don't create a definition for the nested parameter in the semantic builder.
+        //   This seems correct to me because we otherwise end up with two definitions for the same symbol.
+        //   However, it breaks the contract that `parameter.ty` always returns a type (doesn't panic).
+        //   Not sure what the right fix is, but it's out of scope for changing the tests.
+        //   Example: `def foo(bar): ...` panics
+        // source_order::walk_parameter_with_default(self, parameter_with_default);
     }
 }

--- a/crates/red_knot_workspace/tests/check.rs
+++ b/crates/red_knot_workspace/tests/check.rs
@@ -1,9 +1,14 @@
-use red_knot_python_semantic::{ProgramSettings, PythonVersion, SearchPathSettings};
+use red_knot_python_semantic::{
+    HasTy, ProgramSettings, PythonVersion, SearchPathSettings, SemanticModel,
+};
 use red_knot_workspace::db::RootDatabase;
-use red_knot_workspace::lint::lint_semantic;
 use red_knot_workspace::workspace::WorkspaceMetadata;
-use ruff_db::files::system_path_to_file;
-use ruff_db::system::{OsSystem, SystemPathBuf};
+use ruff_db::files::{system_path_to_file, File};
+use ruff_db::parsed::parsed_module;
+use ruff_db::system::{OsSystem, SystemPath, SystemPathBuf};
+use ruff_python_ast::visitor::source_order;
+use ruff_python_ast::visitor::source_order::SourceOrderVisitor;
+use ruff_python_ast::{Alias, Comprehension, Expr, Parameter, ParameterWithDefault, Stmt};
 use std::fs;
 use std::path::PathBuf;
 
@@ -28,17 +33,105 @@ fn setup_db(workspace_root: SystemPathBuf) -> anyhow::Result<RootDatabase> {
 #[allow(clippy::print_stdout)]
 fn corpus_no_panic() -> anyhow::Result<()> {
     let corpus = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("resources/test/corpus");
-    let system_corpus =
-        SystemPathBuf::from_path_buf(corpus.clone()).expect("corpus path to be UTF8");
-    let db = setup_db(system_corpus.clone())?;
+    let system_corpus = SystemPath::from_std_path(&corpus).expect("corpus path to be UTF8");
+    let db = setup_db(system_corpus.to_path_buf())?;
 
     for path in fs::read_dir(&corpus).expect("corpus to be a directory") {
         let path = path.expect("path to not be an error").path();
         println!("checking {path:?}");
         let path = SystemPathBuf::from_path_buf(path.clone()).expect("path to be UTF-8");
-        // this test is only asserting that we can run the lint without a panic
+        // this test is only asserting that we can pull every expression and definition type without a panic
         let file = system_path_to_file(&db, path).expect("file to exist");
-        lint_semantic(&db, file);
+
+        pull_types(&db, file);
     }
     Ok(())
+}
+
+fn pull_types(db: &RootDatabase, file: File) {
+    let mut visitor = PullTypesVisitor::new(db, file);
+
+    let ast = parsed_module(db, file);
+
+    visitor.visit_body(&ast.suite());
+}
+
+struct PullTypesVisitor<'db> {
+    model: SemanticModel<'db>,
+}
+
+impl<'db> PullTypesVisitor<'db> {
+    fn new(db: &'db RootDatabase, file: File) -> Self {
+        Self {
+            model: SemanticModel::new(db, file),
+        }
+    }
+}
+
+impl SourceOrderVisitor<'_> for PullTypesVisitor<'_> {
+    fn visit_expr(&mut self, expr: &Expr) {
+        let _ty = expr.ty(&self.model);
+
+        source_order::walk_expr(self, expr);
+    }
+
+    fn visit_alias(&mut self, alias: &Alias) {
+        let _ty = alias.ty(&self.model);
+
+        source_order::walk_alias(self, alias);
+    }
+
+    fn visit_stmt(&mut self, stmt: &Stmt) {
+        match stmt {
+            Stmt::FunctionDef(function) => {
+                let _ty = function.ty(&self.model);
+            }
+            Stmt::ClassDef(class) => {
+                let _ty = class.ty(&self.model);
+            }
+            Stmt::AnnAssign(assign) => {
+                let _ty = assign.ty(&self.model);
+            }
+            Stmt::Return(_)
+            | Stmt::Delete(_)
+            | Stmt::Assign(_)
+            | Stmt::AugAssign(_)
+            | Stmt::TypeAlias(_)
+            | Stmt::For(_)
+            | Stmt::While(_)
+            | Stmt::If(_)
+            | Stmt::With(_)
+            | Stmt::Match(_)
+            | Stmt::Raise(_)
+            | Stmt::Try(_)
+            | Stmt::Assert(_)
+            | Stmt::Import(_)
+            | Stmt::ImportFrom(_)
+            | Stmt::Global(_)
+            | Stmt::Nonlocal(_)
+            | Stmt::Expr(_)
+            | Stmt::Pass(_)
+            | Stmt::Break(_)
+            | Stmt::Continue(_)
+            | Stmt::IpyEscapeCommand(_) => {}
+        }
+
+        source_order::walk_stmt(self, stmt);
+    }
+
+    fn visit_comprehension(&mut self, comprehension: &Comprehension) {
+        let _ty = comprehension.ty(&self.model);
+        source_order::walk_comprehension(self, comprehension);
+    }
+
+    fn visit_parameter(&mut self, parameter: &Parameter) {
+        let _ty = parameter.ty(&self.model);
+
+        source_order::walk_parameter(self, parameter);
+    }
+
+    fn visit_parameter_with_default(&mut self, parameter_with_default: &ParameterWithDefault) {
+        let _ty = parameter_with_default.ty(&self.model);
+        source_order::walk_parameter_with_default(self, parameter_with_default);
+    }
 }

--- a/crates/red_knot_workspace/tests/check.rs
+++ b/crates/red_knot_workspace/tests/check.rs
@@ -90,7 +90,12 @@ impl SourceOrderVisitor<'_> for PullTypesVisitor<'_> {
                 let _ty = class.ty(&self.model);
             }
             Stmt::AnnAssign(assign) => {
-                let _ty = assign.ty(&self.model);
+                let _assignment_ty = assign.ty(&self.model);
+
+                // FIXME: I think the following constraint should be true in all cases but it isn't.
+                // let target_ty = assign.target.ty(&self.model);
+                //
+                // assert_eq!(_assignment_ty, target_ty);
             }
             Stmt::Return(_)
             | Stmt::Delete(_)

--- a/crates/red_knot_workspace/tests/check.rs
+++ b/crates/red_knot_workspace/tests/check.rs
@@ -53,7 +53,7 @@ fn pull_types(db: &RootDatabase, file: File) {
 
     let ast = parsed_module(db, file);
 
-    visitor.visit_body(&ast.suite());
+    visitor.visit_body(ast.suite());
 }
 
 struct PullTypesVisitor<'db> {


### PR DESCRIPTION
## Summary

This PR changes our corpus test to pull all expression and definition types by calling `HasTy::ty`. 

This uncovered a few bugs. I addressed one as part of this PR, but a few are more involved. I added fixme's in the relevant places.

## Test Plan

<!-- How was it tested? -->
