### PR TITLE
[red-knot] Add definition for with items

### DIFF
--- a/crates/red_knot_python_semantic/src/semantic_index.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index.rs
@@ -802,9 +802,9 @@ with item1 as x, item2 as y:
 
         let use_def = index.use_def_map(FileScopeId::global());
         for name in ["x", "y"] {
-            let [definition] = use_def
-                .public_definitions(global_table.symbol_id_by_name(name).expect("symbol exists"))
-            else {
+            let Some(definition) = use_def.first_public_definition(
+                global_table.symbol_id_by_name(name).expect("symbol exists"),
+            ) else {
                 panic!("Expected with item definition for {name}");
             };
             assert!(matches!(definition.node(&db), DefinitionKind::WithItem(_)));

--- a/crates/red_knot_python_semantic/src/semantic_index/builder.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/builder.rs
@@ -561,6 +561,17 @@ where
                     self.flow_merge(break_state);
                 }
             }
+            ast::Stmt::With(ast::StmtWith { items, body, .. }) => {
+                for item in items {
+                    self.visit_expr(&item.context_expr);
+                    if let Some(optional_vars) = item.optional_vars.as_deref() {
+                        self.current_assignment = Some(item.into());
+                        self.visit_expr(optional_vars);
+                        self.current_assignment = None;
+                    }
+                }
+                self.visit_body(body);
+            }
             ast::Stmt::Break(_) => {
                 self.loop_break_states.push(self.flow_snapshot());
             }
@@ -621,6 +632,9 @@ where
                                 symbol,
                                 ComprehensionDefinitionNodeRef { node, first },
                             );
+                        }
+                        Some(CurrentAssignment::WithItem(with_item)) => {
+                            self.add_definition(symbol, with_item);
                         }
                         None => {}
                     }
@@ -759,6 +773,7 @@ enum CurrentAssignment<'a> {
         node: &'a ast::Comprehension,
         first: bool,
     },
+    WithItem(&'a ast::WithItem),
 }
 
 impl<'a> From<&'a ast::StmtAssign> for CurrentAssignment<'a> {
@@ -782,5 +797,11 @@ impl<'a> From<&'a ast::StmtAugAssign> for CurrentAssignment<'a> {
 impl<'a> From<&'a ast::ExprNamed> for CurrentAssignment<'a> {
     fn from(value: &'a ast::ExprNamed) -> Self {
         Self::Named(value)
+    }
+}
+
+impl<'a> From<&'a ast::WithItem> for CurrentAssignment<'a> {
+    fn from(value: &'a ast::WithItem) -> Self {
+        Self::WithItem(value)
     }
 }

--- a/crates/red_knot_python_semantic/src/semantic_index/builder.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/builder.rs
@@ -26,6 +26,8 @@ use crate::semantic_index::use_def::{FlowSnapshot, UseDefMapBuilder};
 use crate::semantic_index::SemanticIndex;
 use crate::Db;
 
+use super::definition::WithItemDefinitionNodeRef;
+
 pub(super) struct SemanticIndexBuilder<'db> {
     // Builder state
     db: &'db dyn Db,
@@ -565,6 +567,7 @@ where
                 for item in items {
                     self.visit_expr(&item.context_expr);
                     if let Some(optional_vars) = item.optional_vars.as_deref() {
+                        self.add_standalone_expression(&item.context_expr);
                         self.current_assignment = Some(item.into());
                         self.visit_expr(optional_vars);
                         self.current_assignment = None;
@@ -634,7 +637,13 @@ where
                             );
                         }
                         Some(CurrentAssignment::WithItem(with_item)) => {
-                            self.add_definition(symbol, with_item);
+                            self.add_definition(
+                                symbol,
+                                WithItemDefinitionNodeRef {
+                                    node: with_item,
+                                    target: name_node,
+                                },
+                            );
                         }
                         None => {}
                     }

--- a/crates/red_knot_python_semantic/src/semantic_index/definition.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/definition.rs
@@ -47,6 +47,7 @@ pub(crate) enum DefinitionNodeRef<'a> {
     AugmentedAssignment(&'a ast::StmtAugAssign),
     Comprehension(ComprehensionDefinitionNodeRef<'a>),
     Parameter(ast::AnyParameterRef<'a>),
+    WithItem(&'a ast::WithItem),
 }
 
 impl<'a> From<&'a ast::StmtFunctionDef> for DefinitionNodeRef<'a> {
@@ -82,6 +83,12 @@ impl<'a> From<&'a ast::StmtAugAssign> for DefinitionNodeRef<'a> {
 impl<'a> From<&'a ast::Alias> for DefinitionNodeRef<'a> {
     fn from(node_ref: &'a ast::Alias) -> Self {
         Self::Import(node_ref)
+    }
+}
+
+impl<'a> From<&'a ast::WithItem> for DefinitionNodeRef<'a> {
+    fn from(node: &'a ast::WithItem) -> Self {
+        Self::WithItem(node)
     }
 }
 
@@ -175,6 +182,9 @@ impl DefinitionNodeRef<'_> {
                     DefinitionKind::ParameterWithDefault(AstNodeRef::new(parsed, parameter))
                 }
             },
+            DefinitionNodeRef::WithItem(item) => {
+                DefinitionKind::WithItem(AstNodeRef::new(parsed, item))
+            }
         }
     }
 
@@ -198,6 +208,7 @@ impl DefinitionNodeRef<'_> {
                 ast::AnyParameterRef::Variadic(parameter) => parameter.into(),
                 ast::AnyParameterRef::NonVariadic(parameter) => parameter.into(),
             },
+            Self::WithItem(node) => node.into(),
         }
     }
 }
@@ -215,6 +226,7 @@ pub enum DefinitionKind {
     Comprehension(ComprehensionDefinitionKind),
     Parameter(AstNodeRef<ast::Parameter>),
     ParameterWithDefault(AstNodeRef<ast::ParameterWithDefault>),
+    WithItem(AstNodeRef<ast::WithItem>),
 }
 
 #[derive(Clone, Debug)]
@@ -325,6 +337,12 @@ impl From<&ast::Parameter> for DefinitionNodeKey {
 
 impl From<&ast::ParameterWithDefault> for DefinitionNodeKey {
     fn from(node: &ast::ParameterWithDefault) -> Self {
+        Self(NodeKey::from_node(node))
+    }
+}
+
+impl From<&ast::WithItem> for DefinitionNodeKey {
+    fn from(node: &ast::WithItem) -> Self {
         Self(NodeKey::from_node(node))
     }
 }


### PR DESCRIPTION
## Summary

This PR adds symbols and definitions introduced by `with` statements.

The symbols and definitions are introduced for each with item. The type inference is updated to call the definition region type inference instead.

## Test Plan

Add test case to check for symbol table and definitions.