### PR TITLE
[red-knot] Add symbols defined by `match` statements

### DIFF
--- a/crates/red_knot_python_semantic/src/semantic_index.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index.rs
@@ -1017,4 +1017,28 @@ def x():
             vec!["bar", "foo", "Test", "<module>"]
         );
     }
+
+    #[test]
+    fn match_stmt_symbols() {
+        let TestCase { db, file } = test_case(
+            "
+match subject:
+    case a: ...
+    case [b, c, *d]: ...
+    case e as f: ...
+    case {'x': g, **h}: ...
+    case Foo(i, z=j): ...
+    case k | l: ...
+    case _: ...
+",
+        );
+
+        let global_table = symbol_table(&db, global_scope(&db, file));
+
+        assert!(global_table.symbol_by_name("Foo").unwrap().is_used());
+        assert_eq!(
+            names(&global_table),
+            vec!["subject", "a", "b", "c", "d", "f", "e", "h", "g", "Foo", "i", "j", "k", "l"]
+        );
+    }
 }

--- a/crates/red_knot_python_semantic/src/semantic_index/builder.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/builder.rs
@@ -7,7 +7,7 @@ use ruff_db::parsed::ParsedModule;
 use ruff_index::IndexVec;
 use ruff_python_ast as ast;
 use ruff_python_ast::name::Name;
-use ruff_python_ast::visitor::{walk_expr, walk_parameter, walk_stmt, Visitor};
+use ruff_python_ast::visitor::{walk_expr, walk_pattern, walk_stmt, Visitor};
 use ruff_python_ast::AnyParameterRef;
 
 use crate::ast_node_ref::AstNodeRef;

--- a/crates/red_knot_python_semantic/src/semantic_index/builder.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/builder.rs
@@ -7,7 +7,7 @@ use ruff_db::parsed::ParsedModule;
 use ruff_index::IndexVec;
 use ruff_python_ast as ast;
 use ruff_python_ast::name::Name;
-use ruff_python_ast::visitor::{walk_expr, walk_stmt, Visitor};
+use ruff_python_ast::visitor::{walk_expr, walk_parameter, walk_stmt, Visitor};
 use ruff_python_ast::AnyParameterRef;
 
 use crate::ast_node_ref::AstNodeRef;
@@ -746,6 +746,25 @@ where
         for parameter in parameters.iter().map(ast::AnyParameterRef::as_parameter) {
             self.visit_parameter(parameter);
         }
+    }
+
+    fn visit_pattern(&mut self, pattern: &'ast ast::Pattern) {
+        if let ast::Pattern::MatchAs(ast::PatternMatchAs {
+            name: Some(name), ..
+        })
+        | ast::Pattern::MatchStar(ast::PatternMatchStar {
+            name: Some(name),
+            range: _,
+        })
+        | ast::Pattern::MatchMapping(ast::PatternMatchMapping {
+            rest: Some(name), ..
+        }) = pattern
+        {
+            // TODO(dhruvmanila): Add definition
+            self.add_or_update_symbol(name.id.clone(), SymbolFlags::IS_DEFINED);
+        }
+
+        walk_pattern(self, pattern);
     }
 }
 


### PR DESCRIPTION
## Summary

This PR adds symbols introduced by `match` statements.

There are three patterns that introduces new symbols:
* `as` pattern
* Sequence pattern
* Mapping pattern

The recursive nature of the visitor makes sure that all symbols are added.

## Test Plan

Add test case for all types of patterns that introduces a symbol.