### PR TITLE
[`ruff`] Ignore `fstring-missing-syntax` (`RUF027`) for `fastAPI` paths

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/ruff/RUF027_1.py
+++ b/crates/ruff_linter/resources/test/fixtures/ruff/RUF027_1.py
@@ -59,3 +59,12 @@ def negative_cases():
     # See https://docs.python.org/3/howto/logging-cookbook.html#formatting-styles
     import logging
     logging.info("yet {another} non-f-string")
+
+    # See https://fastapi.tiangolo.com/tutorial/path-params/
+    from fastapi import FastAPI
+    app = FastAPI()
+    item_id = 42
+
+    @app.get("/items/{item_id}")
+    async def read_item(item_id):
+        return {"item_id": item_id}

--- a/crates/ruff_linter/src/rules/fastapi/rules/mod.rs
+++ b/crates/ruff_linter/src/rules/fastapi/rules/mod.rs
@@ -6,12 +6,15 @@ mod fastapi_non_annotated_dependency;
 mod fastapi_redundant_response_model;
 mod fastapi_unused_path_parameter;
 
-use ruff_python_ast::{Decorator, ExprCall, StmtFunctionDef};
+use ruff_python_ast as ast;
 use ruff_python_semantic::analyze::typing::resolve_assignment;
 use ruff_python_semantic::SemanticModel;
 
 /// Returns `true` if the function is a FastAPI route.
-pub(crate) fn is_fastapi_route(function_def: &StmtFunctionDef, semantic: &SemanticModel) -> bool {
+pub(crate) fn is_fastapi_route(
+    function_def: &ast::StmtFunctionDef,
+    semantic: &SemanticModel,
+) -> bool {
     return function_def
         .decorator_list
         .iter()
@@ -20,27 +23,29 @@ pub(crate) fn is_fastapi_route(function_def: &StmtFunctionDef, semantic: &Semant
 
 /// Returns `true` if the decorator is indicative of a FastAPI route.
 pub(crate) fn is_fastapi_route_decorator<'a>(
-    decorator: &'a Decorator,
+    decorator: &'a ast::Decorator,
     semantic: &'a SemanticModel,
-) -> Option<&'a ExprCall> {
+) -> Option<&'a ast::ExprCall> {
     let call = decorator.expression.as_call_expr()?;
-    let decorator_method = call.func.as_attribute_expr()?;
-    let method_name = &decorator_method.attr;
+    is_fastapi_route_call(call, semantic).then_some(call)
+}
+
+pub(crate) fn is_fastapi_route_call(call_expr: &ast::ExprCall, semantic: &SemanticModel) -> bool {
+    let ast::Expr::Attribute(ast::ExprAttribute { attr, value, .. }) = &*call_expr.func else {
+        return false;
+    };
 
     if !matches!(
-        method_name.as_str(),
+        attr.as_str(),
         "get" | "post" | "put" | "delete" | "patch" | "options" | "head" | "trace"
     ) {
-        return None;
+        return false;
     }
 
-    let qualified_name = resolve_assignment(&decorator_method.value, semantic)?;
-    if matches!(
-        qualified_name.segments(),
-        ["fastapi", "FastAPI" | "APIRouter"]
-    ) {
-        Some(call)
-    } else {
-        None
-    }
+    resolve_assignment(value, semantic).is_some_and(|qualified_name| {
+        matches!(
+            qualified_name.segments(),
+            ["fastapi", "FastAPI" | "APIRouter"]
+        )
+    })
 }


### PR DESCRIPTION
## Summary

As suggested by @MichaReiser in https://github.com/astral-sh/ruff/pull/12886#pullrequestreview-2237679793, this adds an exemption to `RUF027` for `fastAPI` paths, which require template strings rather than eagerly evaluated f-strings.

## Test Plan

I added a fixture that causes Ruff to emit a false-positive error on `main` but no longer does with this PR.
