### PR TITLE
[flake8_bugbear] message based on expression location [B015]

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_bugbear/B015.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_bugbear/B015.py
@@ -17,6 +17,11 @@ def test():
     1 in (1, 2)
 
 
+def test2():
+    1 in (1, 2)
+    return
+
+
 data = [x for x in [1, 2, 3] if x in (1, 2)]
 
 

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/useless_comparison.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/useless_comparison.rs
@@ -71,12 +71,13 @@ pub(crate) fn useless_comparison(checker: &mut Checker, expr: &Expr) {
 
         if let ScopeKind::Function(func_def) = semantic.current_scope().kind {
             if func_def.range.end() == expr.range().end() {
-                return checker.diagnostics.push(Diagnostic::new(
+                checker.diagnostics.push(Diagnostic::new(
                     UselessComparison {
                         at: ComparisonLocationAt::EndOfFunction,
                     },
                     expr.range(),
                 ));
+                return;
             }
         }
 
@@ -85,7 +86,7 @@ pub(crate) fn useless_comparison(checker: &mut Checker, expr: &Expr) {
                 at: ComparisonLocationAt::MiddleBody,
             },
             expr.range(),
-        ))
+        ));
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_bugbear/snapshots/ruff_linter__rules__flake8_bugbear__tests__B015_B015.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/snapshots/ruff_linter__rules__flake8_bugbear__tests__B015_B015.py.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_bugbear/mod.rs
+assertion_line: 74
 ---
 B015.py:3:1: B015 Pointless comparison. Did you mean to assign a value? Otherwise, prepend `assert` or remove it.
   |
@@ -19,7 +20,7 @@ B015.py:7:1: B015 Pointless comparison. Did you mean to assign a value? Otherwis
   | ^^^^^^^^^^^ B015
   |
 
-B015.py:17:5: B015 Pointless comparison. Did you mean to assign a value? Otherwise, prepend `assert` or remove it.
+B015.py:17:5: B015 Pointless comparison at end of function scope. Did you mean to return the expression result?
    |
 15 |     assert 1 in (1, 2)
 16 | 
@@ -27,11 +28,17 @@ B015.py:17:5: B015 Pointless comparison. Did you mean to assign a value? Otherwi
    |     ^^^^^^^^^^^ B015
    |
 
-B015.py:24:5: B015 Pointless comparison. Did you mean to assign a value? Otherwise, prepend `assert` or remove it.
+B015.py:21:5: B015 Pointless comparison. Did you mean to assign a value? Otherwise, prepend `assert` or remove it.
    |
-23 | class TestClass:
-24 |     1 == 1
+20 | def test2():
+21 |     1 in (1, 2)
+   |     ^^^^^^^^^^^ B015
+22 |     return
+   |
+
+B015.py:29:5: B015 Pointless comparison. Did you mean to assign a value? Otherwise, prepend `assert` or remove it.
+   |
+28 | class TestClass:
+29 |     1 == 1
    |     ^^^^^^ B015
    |
-
-


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary
for issue https://github.com/astral-sh/ruff/issues/12617, display different
message if useless comparison is at the end of function scope.

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

<!-- How was it tested? -->
```console
cargo run -p ruff -- check crates/ruff_linter/resources/test/fixtures/flake8_bugbear/B015.py --preview --no-cache --select B015
```

I also added another function to the test file, to see the message
if the comparison is not at the end of the scope 
