### PR TITLE
[`pep8-naming`] Don't flag `from` imports following conventional import names (`N817`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pep8_naming/N817.py
+++ b/crates/ruff_linter/resources/test/fixtures/pep8_naming/N817.py
@@ -4,3 +4,7 @@ from mod import CamelCase as CC
 
 # OK depending on configured import convention
 import xml.etree.ElementTree as ET
+from xml.etree import ElementTree as ET
+
+# Always an error
+from ..xml.eltree import ElementTree as ET

--- a/crates/ruff_linter/resources/test/fixtures/pep8_naming/N817.py
+++ b/crates/ruff_linter/resources/test/fixtures/pep8_naming/N817.py
@@ -6,5 +6,5 @@ from mod import CamelCase as CC
 import xml.etree.ElementTree as ET
 from xml.etree import ElementTree as ET
 
-# Always an error
+# Always an error (relative import)
 from ..xml.eltree import ElementTree as ET

--- a/crates/ruff_linter/src/rules/pep8_naming/snapshots/ruff_linter__rules__pep8_naming__tests__N817_N817.py.snap
+++ b/crates/ruff_linter/src/rules/pep8_naming/snapshots/ruff_linter__rules__pep8_naming__tests__N817_N817.py.snap
@@ -17,7 +17,7 @@ N817.py:2:17: N817 CamelCase `CamelCase` imported as acronym `CC`
 
 N817.py:10:26: N817 CamelCase `ElementTree` imported as acronym `ET`
    |
- 9 | # Always an error
+ 9 | # Always an error (relative import)
 10 | from ..xml.eltree import ElementTree as ET
    |                          ^^^^^^^^^^^^^^^^^ N817
    |

--- a/crates/ruff_linter/src/rules/pep8_naming/snapshots/ruff_linter__rules__pep8_naming__tests__N817_N817.py.snap
+++ b/crates/ruff_linter/src/rules/pep8_naming/snapshots/ruff_linter__rules__pep8_naming__tests__N817_N817.py.snap
@@ -15,4 +15,9 @@ N817.py:2:17: N817 CamelCase `CamelCase` imported as acronym `CC`
   |                 ^^^^^^^^^^^^^^^ N817
   |
 
-
+N817.py:10:26: N817 CamelCase `ElementTree` imported as acronym `ET`
+   |
+ 9 | # Always an error
+10 | from ..xml.eltree import ElementTree as ET
+   |                          ^^^^^^^^^^^^^^^^^ N817
+   |

--- a/crates/ruff_linter/src/rules/pep8_naming/snapshots/ruff_linter__rules__pep8_naming__tests__camelcase_imported_as_incorrect_convention.snap
+++ b/crates/ruff_linter/src/rules/pep8_naming/snapshots/ruff_linter__rules__pep8_naming__tests__camelcase_imported_as_incorrect_convention.snap
@@ -20,4 +20,22 @@ N817.py:6:8: N817 CamelCase `ElementTree` imported as acronym `ET`
 5 | # OK depending on configured import convention
 6 | import xml.etree.ElementTree as ET
   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^ N817
+7 | from xml.etree import ElementTree as ET
   |
+
+N817.py:7:23: N817 CamelCase `ElementTree` imported as acronym `ET`
+  |
+5 | # OK depending on configured import convention
+6 | import xml.etree.ElementTree as ET
+7 | from xml.etree import ElementTree as ET
+  |                       ^^^^^^^^^^^^^^^^^ N817
+8 | 
+9 | # Always an error
+  |
+
+N817.py:10:26: N817 CamelCase `ElementTree` imported as acronym `ET`
+   |
+ 9 | # Always an error
+10 | from ..xml.eltree import ElementTree as ET
+   |                          ^^^^^^^^^^^^^^^^^ N817
+   |

--- a/crates/ruff_linter/src/rules/pep8_naming/snapshots/ruff_linter__rules__pep8_naming__tests__camelcase_imported_as_incorrect_convention.snap
+++ b/crates/ruff_linter/src/rules/pep8_naming/snapshots/ruff_linter__rules__pep8_naming__tests__camelcase_imported_as_incorrect_convention.snap
@@ -30,12 +30,12 @@ N817.py:7:23: N817 CamelCase `ElementTree` imported as acronym `ET`
 7 | from xml.etree import ElementTree as ET
   |                       ^^^^^^^^^^^^^^^^^ N817
 8 | 
-9 | # Always an error
+9 | # Always an error (relative import)
   |
 
 N817.py:10:26: N817 CamelCase `ElementTree` imported as acronym `ET`
    |
- 9 | # Always an error
+ 9 | # Always an error (relative import)
 10 | from ..xml.eltree import ElementTree as ET
    |                          ^^^^^^^^^^^^^^^^^ N817
    |


### PR DESCRIPTION
## Summary

Fixes https://github.com/astral-sh/ruff/issues/12940

https://github.com/astral-sh/ruff/pull/12922 changes `N817` to not flag imports that follow an import convention. 
I missed to handle `from .. import` imports as part of this PR. This PR implements the same logic for `from .. import` imports.


## Test Plan

Added test
