### PR TITLE
[`pylint`] - Allow `__new__` methods to have `cls` as their first argument even if decorated with `@staticmethod` for `bad-staticmethod-argument` (`PLW0211`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pylint/bad_staticmethod_argument.py
+++ b/crates/ruff_linter/resources/test/fixtures/pylint/bad_staticmethod_argument.py
@@ -42,3 +42,9 @@ class Foo:
     @classmethod
     def graze(cls, x, y, z):
         pass
+
+
+class Foo:
+    @staticmethod
+    def __new__(cls, x, y, z):  # OK, see https://docs.python.org/3/reference/datamodel.html#basic-customization
+        pass

--- a/crates/ruff_linter/src/rules/pylint/rules/bad_staticmethod_argument.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/bad_staticmethod_argument.rs
@@ -91,13 +91,18 @@ pub(crate) fn bad_staticmethod_argument(
         return;
     };
 
-    if matches!(self_or_cls.name.as_str(), "self" | "cls") {
-        let diagnostic = Diagnostic::new(
-            BadStaticmethodArgument {
-                argument_name: self_or_cls.name.to_string(),
-            },
-            self_or_cls.range(),
-        );
-        diagnostics.push(diagnostic);
+    match (name.as_str(), self_or_cls.name.as_str()) {
+        ("__new__", "cls") => {
+            return;
+        }
+        (_, "self" | "cls") => {}
+        _ => return,
     }
+
+    diagnostics.push(Diagnostic::new(
+        BadStaticmethodArgument {
+            argument_name: self_or_cls.name.to_string(),
+        },
+        self_or_cls.range(),
+    ));
 }


### PR DESCRIPTION
## Summary

Fixes #12930

## Test Plan

`cargo test`