### PR TITLE
Rendering enhancements for `config`'s Markdown output 

### DIFF
--- a/crates/ruff/tests/config.rs
+++ b/crates/ruff/tests/config.rs
@@ -20,8 +20,8 @@ fn lint_select() {
     `ignore`, respectively), more specific prefixes override less
     specific prefixes.
 
-    Default value: ["E4", "E7", "E9", "F"]  
-    Type: list[RuleSelector]  
+    Default value: `["E4", "E7", "E9", "F"]`  
+    Type: `list[RuleSelector]`  
     Example usage:
     ```toml
     # On top of the defaults (`E4`, E7`, `E9`, and `F`), enable flake8-bugbear (`B`) and flake8-quotes (`Q`).
@@ -43,8 +43,8 @@ fn lint_extendignore() {
     A list of rule codes or prefixes to ignore, in addition to those
     specified by `ignore`.
 
-    Default value: []  
-    Type: list[RuleSelector]  
+    Default value: `[]`  
+    Type: `list[RuleSelector]`  
     Deprecated: The `extend-ignore` option is now interchangeable with [`ignore`](#lint_ignore). Please update your configuration to use the [`ignore`](#lint_ignore) option instead.  
     Example usage:
     ```toml

--- a/crates/ruff_workspace/src/options_base.rs
+++ b/crates/ruff_workspace/src/options_base.rs
@@ -396,8 +396,8 @@ impl Display for OptionField {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         writeln!(f, "{}", self.doc)?;
         writeln!(f)?;
-        writeln!(f, "Default value: {}  ", self.default)?;
-        writeln!(f, "Type: {}  ", self.value_type)?;
+        writeln!(f, "Default value: `{}`  ", self.default)?;
+        writeln!(f, "Type: `{}`  ", self.value_type)?;
 
         if let Some(deprecated) = &self.deprecated {
             write!(f, "Deprecated")?;


### PR DESCRIPTION
Fixes #12960.

I updated the tests accordingly and also added a "deprecated" test case which uses `lint.extend-ignore`. There might be a better way to write those trailing spaces, however.