### PR TITLE
Ignore unused arguments on stub functions

### DIFF
--- a/crates/ruff/tests/lint.rs
+++ b/crates/ruff/tests/lint.rs
@@ -1434,7 +1434,7 @@ def unused(x):
 
     insta::assert_snapshot!(test_code, @r###"
 
-    def unused(x):  # noqa: ANN001, ANN201, ARG001, D103
+    def unused(x):  # noqa: ANN001, ANN201, D103
         pass
     "###);
 

--- a/crates/ruff_linter/src/rules/flake8_unused_arguments/rules/unused_arguments.rs
+++ b/crates/ruff_linter/src/rules/flake8_unused_arguments/rules/unused_arguments.rs
@@ -344,6 +344,7 @@ pub(crate) fn unused_arguments(
             ) {
                 function_type::FunctionType::Function => {
                     if checker.enabled(Argumentable::Function.rule_code())
+                        && !function_type::is_stub(function_def, checker.semantic())
                         && !visibility::is_overload(decorator_list, checker.semantic())
                     {
                         function(

--- a/crates/ruff_linter/src/rules/flake8_unused_arguments/snapshots/ruff_linter__rules__flake8_unused_arguments__tests__ARG001_ARG.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_unused_arguments/snapshots/ruff_linter__rules__flake8_unused_arguments__tests__ARG001_ARG.py.snap
@@ -32,33 +32,3 @@ ARG.py:13:12: ARG001 Unused function argument: `x`
    |            ^ ARG001
 14 |     print("Hello, world!")
    |
-
-ARG.py:17:7: ARG001 Unused function argument: `self`
-   |
-17 | def f(self, x):
-   |       ^^^^ ARG001
-18 |     ...
-   |
-
-ARG.py:17:13: ARG001 Unused function argument: `x`
-   |
-17 | def f(self, x):
-   |             ^ ARG001
-18 |     ...
-   |
-
-ARG.py:21:7: ARG001 Unused function argument: `cls`
-   |
-21 | def f(cls, x):
-   |       ^^^ ARG001
-22 |     ...
-   |
-
-ARG.py:21:12: ARG001 Unused function argument: `x`
-   |
-21 | def f(cls, x):
-   |            ^ ARG001
-22 |     ...
-   |
-
-


### PR DESCRIPTION
## Summary

We already enforce this logic for the other `ARG` rules. I'm guessing this was an oversight.

Closes https://github.com/astral-sh/ruff/issues/12963.
