### PR TITLE
Add the `testing` feature of `ruff_db` as a dev-dependency for `ruff_workspace`

### DIFF
--- a/crates/red_knot_workspace/Cargo.toml
+++ b/crates/red_knot_workspace/Cargo.toml
@@ -28,6 +28,7 @@ thiserror = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]
+ruff_db = { workspace = true, features = ["testing"]}
 
 [lints]
 workspace = true


### PR DESCRIPTION
Without this, `cargo test -p ruff_workspace` fails, as it relies on the `testing` feature without this being listed as an explicit requirement