### PR TITLE
[red-knot] Track root cause of why a type is inferred as `Unknown`

### DIFF
--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -151,7 +151,7 @@ pub(crate) fn definitions_ty<'db>(
 }
 
 /// Unique ID for a type.
-#[derive(Copy, Clone, Debug, PartialOrd, Ord, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub enum Type<'db> {
     /// the dynamic type: a statically-unknown set of values
     Any,
@@ -292,7 +292,7 @@ impl<'db> Type<'db> {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum UnknownTypeKind {
     /// Temporary variant that indicates that we *should*
     /// be able to infer a type here in due course, but currently can't

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -325,6 +325,16 @@ pub enum UnknownTypeKind {
     SecondOrder,
 }
 
+impl UnknownTypeKind {
+    pub(crate) fn union(self, other: Self) -> Self {
+        if self == other {
+            self
+        } else {
+            UnknownTypeKind::SecondOrder
+        }
+    }
+}
+
 #[salsa::interned]
 pub struct FunctionType<'db> {
     /// name of the function at definition

--- a/crates/red_knot_python_semantic/src/types/display.rs
+++ b/crates/red_knot_python_semantic/src/types/display.rs
@@ -22,7 +22,7 @@ impl Display for DisplayType<'_> {
         match self.ty {
             Type::Any => f.write_str("Any"),
             Type::Never => f.write_str("Never"),
-            Type::Unknown => f.write_str("Unknown"),
+            Type::Unknown(_) => f.write_str("Unknown"),
             Type::Unbound => f.write_str("Unbound"),
             Type::None => f.write_str("None"),
             Type::Module(file) => {

--- a/crates/ruff_benchmark/benches/red_knot.rs
+++ b/crates/ruff_benchmark/benches/red_knot.rs
@@ -19,18 +19,9 @@ struct Case {
 
 const TOMLLIB_312_URL: &str = "https://raw.githubusercontent.com/python/cpython/8e8a4baf652f6e1cee7acde9d78c4b6154539748/Lib/tomllib";
 
-// This first "unresolved import" is because we don't understand `*` imports yet.
-// The following "unresolved import" violations are because we can't distinguish currently from
-// "Symbol exists in the module but its type is unknown" and
-// "Symbol does not exist in the module"
+// The "unresolved import" is because we don't understand `*` imports yet.
 static EXPECTED_DIAGNOSTICS: &[&str] = &[
     "/src/tomllib/_parser.py:7:29: Could not resolve import of 'Iterable' from 'collections.abc'",
-    "/src/tomllib/_parser.py:10:20: Could not resolve import of 'Any' from 'typing'",
-    "/src/tomllib/_parser.py:13:5: Could not resolve import of 'RE_DATETIME' from '._re'",
-    "/src/tomllib/_parser.py:14:5: Could not resolve import of 'RE_LOCALTIME' from '._re'",
-    "/src/tomllib/_parser.py:15:5: Could not resolve import of 'RE_NUMBER' from '._re'",
-    "/src/tomllib/_parser.py:20:21: Could not resolve import of 'Key' from '._types'",
-    "/src/tomllib/_parser.py:20:26: Could not resolve import of 'ParseFloat' from '._types'",
     "Line 69 is too long (89 characters)",
     "Use double quotes for strings",
     "Use double quotes for strings",


### PR DESCRIPTION
## Summary

This PR adds detailed information to our type inference so we can track exactly why a symbol has been inferred as `Unknown`. This allows us to restore the `unresolved-import` red-knot lint to the level of accuracy it had prior to https://github.com/astral-sh/ruff/commit/a9847af6e89c593dcb49023b5e88ba7f4a84a61a, because we can now distinguish between `Unknown` types that were caused by unresolved imports and other kinds of `Unknown` types. The approach is similar to [the one mypy uses](https://github.com/python/mypy/blob/fe15ee69b9225f808f8ed735671b73c31ae1bed8/mypy/types.py#L187-L215).

## Test Plan

There are two ways in which this PR is tested:
1. The assertion in the benchmark is changed: six spurious "Unresolved import" diagnostics go away, meaning the number of diagnostics drops from 34 to 28. The only remaining "unresolved import" diagnostic is emitted on [this line](https://github.com/python/cpython/blob/e077b201f49a6007ddad7c1b6e3069a037b6d952/Lib/tomllib/_parser.py#L7), which is because we don't understand `*` imports yet, and `Iterable` is defined in the typeshed stub for `collections.abc` [here](https://github.com/python/typeshed/blob/937270df0c25dc56a02f7199f1943fdb7d47aa9d/stdlib/collections/abc.pyi#L1).
2. A test is unskipped in `red_knot_workspace/src/lint.rs` asserting that a project structure (where the `foo` module does not exist) like this only triggers an "unresolved import" diagnostic in `a.py`, and not in `b.py`:
   - `/src/a.py`: `import foo as foo`
   - `/src/b.py`: `from a import foo`
