### PR TITLE
isort: Don't infer namespace packages as first-party (only subpackages of namespace packages)

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_type_checking/rules/typing_only_runtime_import.rs
+++ b/crates/ruff_linter/src/rules/flake8_type_checking/rules/typing_only_runtime_import.rs
@@ -299,7 +299,7 @@ pub(crate) fn typing_only_runtime_import(
 
             // Categorize the import, using coarse-grained categorization.
             let import_type = match categorize(
-                &qualified_name.to_string(),
+                &import.module_name().join("."),
                 qualified_name.is_unresolved_import(),
                 &checker.settings.src,
                 checker.package(),


### PR DESCRIPTION
Fixes #12984 (will add docs/PR description/tests after I've seen the ecosystem report)