### PR TITLE
Add API to emit type-checking diagnostics

### DIFF
--- a/crates/red_knot_python_semantic/src/db.rs
+++ b/crates/red_knot_python_semantic/src/db.rs
@@ -1,15 +1,18 @@
+use ruff_db::files::File;
 use ruff_db::{Db as SourceDb, Upcast};
 
 /// Database giving access to semantic information about a Python program.
 #[salsa::db]
-pub trait Db: SourceDb + Upcast<dyn SourceDb> {}
+pub trait Db: SourceDb + Upcast<dyn SourceDb> {
+    fn is_file_open(&self, file: File) -> bool;
+}
 
 #[cfg(test)]
 pub(crate) mod tests {
     use std::sync::Arc;
 
     use crate::module_resolver::vendored_typeshed_stubs;
-    use ruff_db::files::Files;
+    use ruff_db::files::{File, Files};
     use ruff_db::system::{DbWithTestSystem, System, TestSystem};
     use ruff_db::vendored::VendoredFileSystem;
     use ruff_db::{Db as SourceDb, Upcast};
@@ -91,7 +94,11 @@ pub(crate) mod tests {
     }
 
     #[salsa::db]
-    impl Db for TestDb {}
+    impl Db for TestDb {
+        fn is_file_open(&self, file: File) -> bool {
+            !file.path(self).is_vendored_path()
+        }
+    }
 
     #[salsa::db]
     impl salsa::Database for TestDb {

--- a/crates/red_knot_python_semantic/src/semantic_index.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index.rs
@@ -154,6 +154,10 @@ impl<'db> SemanticIndex<'db> {
         &self.scopes[id]
     }
 
+    pub(crate) fn scope_ids(&self) -> impl Iterator<Item = ScopeId> {
+        self.scope_ids_by_scope.iter().copied()
+    }
+
     /// Returns the id of the parent scope.
     pub(crate) fn parent_scope_id(&self, scope_id: FileScopeId) -> Option<FileScopeId> {
         let scope = self.scope(scope_id);

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -1,15 +1,15 @@
 use ruff_db::files::File;
 use ruff_python_ast::name::Name;
 
-use crate::{Db, FxOrderSet};
 use crate::builtins::builtins_scope;
-use crate::semantic_index::{
-    DefinitionWithConstraints, DefinitionWithConstraintsIterator, global_scope, semantic_index, symbol_table,
-    use_def_map,
-};
 use crate::semantic_index::definition::Definition;
-use crate::semantic_index::symbol::{ScopedSymbolId, ScopeId};
+use crate::semantic_index::symbol::{ScopeId, ScopedSymbolId};
+use crate::semantic_index::{
+    global_scope, semantic_index, symbol_table, use_def_map, DefinitionWithConstraints,
+    DefinitionWithConstraintsIterator,
+};
 use crate::types::narrow::narrowing_constraint;
+use crate::{Db, FxOrderSet};
 
 pub(crate) use self::builder::{IntersectionBuilder, UnionBuilder};
 pub(crate) use self::diagnostic::TypeCheckDiagnostics;
@@ -22,7 +22,6 @@ mod diagnostic;
 mod display;
 mod infer;
 mod narrow;
-
 
 pub fn check_types(db: &dyn Db, file: File) -> TypeCheckDiagnostics {
     let _span = tracing::trace_span!("check_types", file=?file.path(db)).entered();
@@ -349,4 +348,49 @@ pub struct IntersectionType<'db> {
     /// narrowing along with intersections (e.g. `if not isinstance(...)`), so we represent them
     /// directly in intersections rather than as a separate type.
     negative: FxOrderSet<Type<'db>>,
+}
+
+#[cfg(test)]
+mod tests {
+    use anyhow::Context;
+
+    use ruff_db::files::system_path_to_file;
+    use ruff_db::system::{DbWithTestSystem, SystemPathBuf};
+
+    use crate::db::tests::TestDb;
+    use crate::{Program, ProgramSettings, PythonVersion, SearchPathSettings};
+
+    #[test]
+    fn check_types() -> anyhow::Result<()> {
+        let mut db = TestDb::new();
+
+        db.write_file("src/foo.py", "import bar\n")
+            .context("Failed to write foo.py")?;
+
+        Program::from_settings(
+            &db,
+            ProgramSettings {
+                target_version: PythonVersion::default(),
+                search_paths: SearchPathSettings {
+                    extra_paths: Vec::new(),
+                    src_root: SystemPathBuf::from("/src"),
+                    site_packages: vec![],
+                    custom_typeshed: None,
+                },
+            },
+        )
+        .expect("Valid search path settings");
+
+        let foo = system_path_to_file(&db, "src/foo.py").context("Failed to resolve foo.py")?;
+
+        let diagnostics = super::check_types(&db, foo);
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(
+            diagnostics[0].message(),
+            "Import 'bar' could not be resolved."
+        );
+
+        Ok(())
+    }
 }

--- a/crates/red_knot_python_semantic/src/types/diagnostic.rs
+++ b/crates/red_knot_python_semantic/src/types/diagnostic.rs
@@ -1,0 +1,111 @@
+use ruff_db::files::File;
+use ruff_text_size::{Ranged, TextRange};
+use std::fmt::Formatter;
+use std::ops::Deref;
+use std::sync::Arc;
+
+#[derive(Debug, Eq, PartialEq)]
+pub struct TypeCheckDiagnostic {
+    // TODO: Don't use string keys for rules
+    pub(super) rule: String,
+    pub(super) message: String,
+    pub(super) range: TextRange,
+    pub(super) file: File,
+}
+
+impl TypeCheckDiagnostic {
+    pub fn rule(&self) -> &str {
+        &self.rule
+    }
+
+    pub fn message(&self) -> &str {
+        &self.message
+    }
+
+    pub fn file(&self) -> File {
+        self.file
+    }
+}
+
+impl Ranged for TypeCheckDiagnostic {
+    fn range(&self) -> TextRange {
+        self.range
+    }
+}
+
+/// A collection of type check diagnostics.
+///
+/// The diagnostics are wrapped in an `Arc` because they need to be cloned multiple times
+/// when going from `infer_expression` to `check_file`. We could consider
+/// making [`TypeCheckDiagnostic`] a Salsa struct to have them Arena-allocated (once the Tables refactor is done).
+/// Using Salsa struct does have the downside that it leaks the Salsa dependency into diagnostics and
+/// each Salsa-struct comes with an overhead.
+#[derive(Default, Eq, PartialEq)]
+pub struct TypeCheckDiagnostics {
+    inner: Vec<std::sync::Arc<TypeCheckDiagnostic>>,
+}
+
+impl TypeCheckDiagnostics {
+    pub fn new() -> Self {
+        Self { inner: Vec::new() }
+    }
+
+    pub(super) fn push(&mut self, diagnostic: TypeCheckDiagnostic) {
+        self.inner.push(Arc::new(diagnostic));
+    }
+
+    pub(crate) fn shrink_to_fit(&mut self) {
+        self.inner.shrink_to_fit();
+    }
+}
+
+impl Extend<TypeCheckDiagnostic> for TypeCheckDiagnostics {
+    fn extend<T: IntoIterator<Item = TypeCheckDiagnostic>>(&mut self, iter: T) {
+        self.inner.extend(iter.into_iter().map(std::sync::Arc::new));
+    }
+}
+
+impl Extend<std::sync::Arc<TypeCheckDiagnostic>> for TypeCheckDiagnostics {
+    fn extend<T: IntoIterator<Item = Arc<TypeCheckDiagnostic>>>(&mut self, iter: T) {
+        self.inner.extend(iter);
+    }
+}
+
+impl<'a> Extend<&'a std::sync::Arc<TypeCheckDiagnostic>> for TypeCheckDiagnostics {
+    fn extend<T: IntoIterator<Item = &'a Arc<TypeCheckDiagnostic>>>(&mut self, iter: T) {
+        self.inner
+            .extend(iter.into_iter().map(std::sync::Arc::clone));
+    }
+}
+
+impl std::fmt::Debug for TypeCheckDiagnostics {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        self.inner.fmt(f)
+    }
+}
+
+impl Deref for TypeCheckDiagnostics {
+    type Target = [std::sync::Arc<TypeCheckDiagnostic>];
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl IntoIterator for TypeCheckDiagnostics {
+    type Item = Arc<TypeCheckDiagnostic>;
+    type IntoIter = std::vec::IntoIter<std::sync::Arc<TypeCheckDiagnostic>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.inner.into_iter()
+    }
+}
+
+impl<'a> IntoIterator for &'a TypeCheckDiagnostics {
+    type Item = &'a Arc<TypeCheckDiagnostic>;
+    type IntoIter = std::slice::Iter<'a, std::sync::Arc<TypeCheckDiagnostic>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.inner.iter()
+    }
+}

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -1005,13 +1005,13 @@ impl<'db> TypeInferenceBuilder<'db> {
         };
 
         if let Some(module) = resolve_module(self.db, module_name.clone()) {
+            Type::Module(module.file())
+        } else {
             self.add_diagnostic(
                 node,
-                "reportMissingImport",
+                "report-missing-import",
                 format_args!("Import '{module_name}' could not be resolved."),
             );
-                builder.finish(format!("Import '{module_name}' could not be resolved."));
-            }
 
             Type::Unknown
         }
@@ -1731,12 +1731,12 @@ impl<'db> TypeInferenceBuilder<'db> {
                 }
             }
         }
-    /// Adds a new diagnostic.
+    }
 
+    /// Adds a new diagnostic.
+    ///
     /// The diagnostic does not get added if the rule isn't enabled for this file.
     fn add_diagnostic(&mut self, node: AnyNodeRef, rule: &str, message: std::fmt::Arguments) {
-        rule: &str,
-    ) -> Option<TypeCheckDiagnosticBuilder> {
         if !self.db.is_file_open(self.file) {
             return;
         }

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -29,7 +29,8 @@ use salsa::plumbing::AsId;
 use ruff_db::files::File;
 use ruff_db::parsed::parsed_module;
 use ruff_python_ast as ast;
-use ruff_python_ast::{Expr, ExprContext};
+use ruff_python_ast::{AnyNodeRef, ExprContext};
+use ruff_text_size::Ranged;
 
 use crate::builtins::builtins_scope;
 use crate::module_name::ModuleName;
@@ -40,6 +41,7 @@ use crate::semantic_index::expression::Expression;
 use crate::semantic_index::semantic_index;
 use crate::semantic_index::symbol::{FileScopeId, NodeWithScopeKind, NodeWithScopeRef, ScopeId};
 use crate::semantic_index::SemanticIndex;
+use crate::types::diagnostic::{TypeCheckDiagnostic, TypeCheckDiagnostics};
 use crate::types::{
     builtins_symbol_ty_by_name, definitions_ty, global_symbol_ty_by_name, ClassType, FunctionType,
     Name, Type, UnionBuilder,
@@ -123,13 +125,16 @@ pub(crate) enum InferenceRegion<'db> {
 }
 
 /// The inferred types for a single region.
-#[derive(Debug, Eq, PartialEq, Default, Clone)]
+#[derive(Debug, Eq, PartialEq, Default)]
 pub(crate) struct TypeInference<'db> {
     /// The types of every expression in this region.
     expressions: FxHashMap<ScopedExpressionId, Type<'db>>,
 
     /// The types of every definition in this region.
     definitions: FxHashMap<Definition<'db>, Type<'db>>,
+
+    /// The diagnostics for this region.
+    diagnostics: TypeCheckDiagnostics,
 }
 
 impl<'db> TypeInference<'db> {
@@ -142,9 +147,14 @@ impl<'db> TypeInference<'db> {
         self.definitions[&definition]
     }
 
+    pub(crate) fn diagnostics(&self) -> &[std::sync::Arc<TypeCheckDiagnostic>] {
+        &self.diagnostics
+    }
+
     fn shrink_to_fit(&mut self) {
         self.expressions.shrink_to_fit();
         self.definitions.shrink_to_fit();
+        self.diagnostics.shrink_to_fit();
     }
 }
 
@@ -235,6 +245,7 @@ impl<'db> TypeInferenceBuilder<'db> {
     fn extend(&mut self, inference: &TypeInference<'db>) {
         self.types.definitions.extend(inference.definitions.iter());
         self.types.expressions.extend(inference.expressions.iter());
+        self.types.diagnostics.extend(&inference.diagnostics);
     }
 
     /// Infers types in the given [`InferenceRegion`].
@@ -1059,7 +1070,7 @@ impl<'db> TypeInferenceBuilder<'db> {
             ast::Expr::Yield(yield_expression) => self.infer_yield_expression(yield_expression),
             ast::Expr::YieldFrom(yield_from) => self.infer_yield_from_expression(yield_from),
             ast::Expr::Await(await_expression) => self.infer_await_expression(await_expression),
-            Expr::IpyEscapeCommand(_) => todo!("Implement Ipy escape command support"),
+            ast::Expr::IpyEscapeCommand(_) => todo!("Implement Ipy escape command support"),
         };
 
         let expr_id = expression.scoped_ast_id(self.db, self.scope);
@@ -1090,8 +1101,10 @@ impl<'db> TypeInferenceBuilder<'db> {
         Type::BooleanLiteral(*value)
     }
 
-    #[allow(clippy::unused_self)]
-    fn infer_string_literal_expression(&mut self, _literal: &ast::ExprStringLiteral) -> Type<'db> {
+    fn infer_string_literal_expression(&mut self, literal: &ast::ExprStringLiteral) -> Type<'db> {
+        if let Some(builder) = self.push_diagnostic(literal.into(), "unimplemented") {
+            builder.finish("Unimplemented node StringLiteralExpression")
+        }
         // TODO Literal["..."] or str
         Type::Unknown
     }
@@ -1704,6 +1717,31 @@ impl<'db> TypeInferenceBuilder<'db> {
                 }
             }
         }
+    }
+
+    // TODO return a builder?
+    #[allow(dead_code)]
+    fn push_diagnostic(
+        &mut self,
+        node: AnyNodeRef,
+        rule: &str,
+    ) -> Option<TypeCheckDiagnosticBuilder> {
+        if !self.db.is_file_open(self.file) {
+            return;
+        }
+
+        // TODO: Don't emit the diagnostic if:
+        // * The enclosing node contains any syntax errors
+        // * The rule is disabled for this file. We probably want to introduce a new query that
+        //   returns a rule selector for a given file that respects the package's settings,
+        //   any global pragma comments in the file, and any per-file-ignores.
+
+        self.types.diagnostics.push(TypeCheckDiagnostic {
+            file: self.file,
+            rule: rule.to_string(),
+            message: message.to_string(),
+            range: node.range(),
+        });
     }
 
     pub(super) fn finish(mut self) -> TypeInference<'db> {

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -1009,7 +1009,7 @@ impl<'db> TypeInferenceBuilder<'db> {
         } else {
             self.add_diagnostic(
                 node,
-                "report-missing-import",
+                "unresolved-import",
                 format_args!("Import '{module_name}' could not be resolved."),
             );
 

--- a/crates/red_knot_wasm/src/lib.rs
+++ b/crates/red_knot_wasm/src/lib.rs
@@ -109,7 +109,7 @@ impl Workspace {
     pub fn check_file(&self, file_id: &FileHandle) -> Result<Vec<String>, Error> {
         let result = self.db.check_file(file_id.file).map_err(into_error)?;
 
-        Ok(result.to_vec())
+        Ok(result.clone())
     }
 
     /// Checks all open files

--- a/crates/red_knot_wasm/tests/api.rs
+++ b/crates/red_knot_wasm/tests/api.rs
@@ -17,5 +17,8 @@ fn check() {
 
     let result = workspace.check_file(&test).expect("Check to succeed");
 
-    assert_eq!(result, vec!["/test.py:1:8: Unresolved import 'random22'"]);
+    assert_eq!(
+        result,
+        vec!["/test.py:1:8: Import 'random22' could not be resolved.",]
+    );
 }

--- a/crates/red_knot_workspace/src/db.rs
+++ b/crates/red_knot_workspace/src/db.rs
@@ -11,7 +11,6 @@ use ruff_db::{Db as SourceDb, Upcast};
 use salsa::plumbing::ZalsaDatabase;
 use salsa::{Cancelled, Event};
 
-use crate::lint::Diagnostics;
 use crate::workspace::{check_file, Workspace, WorkspaceMetadata};
 
 mod changes;
@@ -61,7 +60,7 @@ impl RootDatabase {
         self.with_db(|db| db.workspace().check(db))
     }
 
-    pub fn check_file(&self, file: File) -> Result<Diagnostics, Cancelled> {
+    pub fn check_file(&self, file: File) -> Result<Vec<String>, Cancelled> {
         self.with_db(|db| check_file(db, file))
     }
 

--- a/crates/red_knot_workspace/src/db.rs
+++ b/crates/red_knot_workspace/src/db.rs
@@ -114,7 +114,15 @@ impl Upcast<dyn SourceDb> for RootDatabase {
 }
 
 #[salsa::db]
-impl SemanticDb for RootDatabase {}
+impl SemanticDb for RootDatabase {
+    fn is_file_open(&self, file: File) -> bool {
+        let Some(workspace) = &self.workspace else {
+            return false;
+        };
+
+        workspace.is_file_open(self, file)
+    }
+}
 
 #[salsa::db]
 impl SourceDb for RootDatabase {
@@ -241,7 +249,12 @@ pub(crate) mod tests {
     }
 
     #[salsa::db]
-    impl red_knot_python_semantic::Db for TestDb {}
+    impl red_knot_python_semantic::Db for TestDb {
+        fn is_file_open(&self, file: ruff_db::files::File) -> bool {
+            !file.path(self).is_vendored_path()
+        }
+    }
+
     #[salsa::db]
     impl Db for TestDb {}
 

--- a/crates/red_knot_workspace/src/lint.rs
+++ b/crates/red_knot_workspace/src/lint.rs
@@ -1,5 +1,4 @@
 use std::cell::RefCell;
-use std::ops::Deref;
 use std::time::Duration;
 
 use tracing::debug_span;
@@ -22,7 +21,7 @@ use crate::db::Db;
 pub(crate) fn unwind_if_cancelled(db: &dyn Db) {}
 
 #[salsa::tracked(return_ref)]
-pub(crate) fn lint_syntax(db: &dyn Db, file_id: File) -> Diagnostics {
+pub(crate) fn lint_syntax(db: &dyn Db, file_id: File) -> Vec<String> {
     #[allow(clippy::print_stdout)]
     if std::env::var("RED_KNOT_SLOW_LINT").is_ok() {
         for i in 0..10 {
@@ -64,7 +63,7 @@ pub(crate) fn lint_syntax(db: &dyn Db, file_id: File) -> Diagnostics {
         }));
     }
 
-    Diagnostics::from(diagnostics)
+    diagnostics
 }
 
 fn lint_lines(source: &str, diagnostics: &mut Vec<String>) {
@@ -86,7 +85,7 @@ fn lint_lines(source: &str, diagnostics: &mut Vec<String>) {
 
 #[allow(unreachable_pub)]
 #[salsa::tracked(return_ref)]
-pub fn lint_semantic(db: &dyn Db, file_id: File) -> Diagnostics {
+pub fn lint_semantic(db: &dyn Db, file_id: File) -> Vec<String> {
     let _span = debug_span!("lint_semantic", file=%file_id.path(db)).entered();
 
     let source = source_text(db.upcast(), file_id);
@@ -94,7 +93,7 @@ pub fn lint_semantic(db: &dyn Db, file_id: File) -> Diagnostics {
     let semantic = SemanticModel::new(db.upcast(), file_id);
 
     if !parsed.is_valid() {
-        return Diagnostics::Empty;
+        return vec![];
     }
 
     let context = SemanticLintContext {
@@ -106,7 +105,7 @@ pub fn lint_semantic(db: &dyn Db, file_id: File) -> Diagnostics {
 
     SemanticVisitor { context: &context }.visit_body(parsed.suite());
 
-    Diagnostics::from(context.diagnostics.take())
+    context.diagnostics.take()
 }
 
 fn format_diagnostic(context: &SemanticLintContext, message: &str, start: TextSize) -> String {
@@ -308,53 +307,6 @@ impl Visitor<'_> for SemanticVisitor<'_> {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum Diagnostics {
-    Empty,
-    List(Vec<String>),
-}
-
-impl Diagnostics {
-    pub fn as_slice(&self) -> &[String] {
-        match self {
-            Diagnostics::Empty => &[],
-            Diagnostics::List(list) => list.as_slice(),
-        }
-    }
-}
-
-impl Deref for Diagnostics {
-    type Target = [String];
-    fn deref(&self) -> &Self::Target {
-        self.as_slice()
-    }
-}
-
-impl From<Vec<String>> for Diagnostics {
-    fn from(value: Vec<String>) -> Self {
-        if value.is_empty() {
-            Diagnostics::Empty
-        } else {
-            Diagnostics::List(value)
-        }
-    }
-}
-
-#[derive(Copy, Clone, Debug)]
-enum AnyImportRef<'a> {
-    Import(&'a ast::StmtImport),
-    ImportFrom(&'a ast::StmtImportFrom),
-}
-
-impl Ranged for AnyImportRef<'_> {
-    fn range(&self) -> ruff_text_size::TextRange {
-        match self {
-            AnyImportRef::Import(import) => import.range(),
-            AnyImportRef::ImportFrom(import) => import.range(),
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use red_knot_python_semantic::{Program, ProgramSettings, PythonVersion, SearchPathSettings};
@@ -363,7 +315,7 @@ mod tests {
 
     use crate::db::tests::TestDb;
 
-    use super::{lint_semantic, Diagnostics};
+    use super::lint_semantic;
 
     fn setup_db() -> TestDb {
         setup_db_with_root(SystemPathBuf::from("/src"))
@@ -409,9 +361,9 @@ mod tests {
         .unwrap();
 
         let file = system_path_to_file(&db, "/src/a.py").expect("file to exist");
-        let Diagnostics::List(messages) = lint_semantic(&db, file) else {
-            panic!("expected some diagnostics");
-        };
+        let messages = lint_semantic(&db, file);
+
+        assert_ne!(messages, &[] as &[String], "expected some diagnostics");
 
         assert_eq!(
             *messages,

--- a/crates/red_knot_workspace/src/lint.rs
+++ b/crates/red_knot_workspace/src/lint.rs
@@ -244,11 +244,8 @@ struct SemanticVisitor<'a> {
 
 impl Visitor<'_> for SemanticVisitor<'_> {
     fn visit_stmt(&mut self, stmt: &ast::Stmt) {
-        match stmt {
-            ast::Stmt::ClassDef(class) => {
-                lint_bad_override(self.context, class);
-            }
-            _ => {}
+        if let ast::Stmt::ClassDef(class) = stmt {
+            lint_bad_override(self.context, class);
         }
 
         walk_stmt(self, stmt);

--- a/crates/red_knot_workspace/src/lint.rs
+++ b/crates/red_knot_workspace/src/lint.rs
@@ -115,7 +115,7 @@ fn format_diagnostic(context: &SemanticLintContext, message: &str, start: TextSi
         .source_location(start, context.source_text());
     format!(
         "{}:{}:{}: {}",
-        context.semantic.file_path().as_str(),
+        context.semantic.file_path(),
         source_location.row,
         source_location.column,
         message,

--- a/crates/red_knot_workspace/src/lint.rs
+++ b/crates/red_knot_workspace/src/lint.rs
@@ -122,41 +122,6 @@ fn format_diagnostic(context: &SemanticLintContext, message: &str, start: TextSi
     )
 }
 
-fn lint_unresolved_imports(context: &SemanticLintContext, import: AnyImportRef) {
-    // TODO: this treats any symbol with `Type::Unknown` as an unresolved import,
-    // which isn't really correct: if it exists but has `Type::Unknown` in the
-    // module we're importing it from, we shouldn't really emit a diagnostic here,
-    // but currently do.
-    match import {
-        AnyImportRef::Import(import) => {
-            for alias in &import.names {
-                let ty = alias.ty(&context.semantic);
-
-                if ty.is_unknown() {
-                    context.push_diagnostic(format_diagnostic(
-                        context,
-                        &format!("Unresolved import '{}'", &alias.name),
-                        alias.start(),
-                    ));
-                }
-            }
-        }
-        AnyImportRef::ImportFrom(import) => {
-            for alias in &import.names {
-                let ty = alias.ty(&context.semantic);
-
-                if ty.is_unknown() {
-                    context.push_diagnostic(format_diagnostic(
-                        context,
-                        &format!("Unresolved import '{}'", &alias.name),
-                        alias.start(),
-                    ));
-                }
-            }
-        }
-    }
-}
-
 fn lint_maybe_undefined(context: &SemanticLintContext, name: &ast::ExprName) {
     if !matches!(name.ctx, ast::ExprContext::Load) {
         return;
@@ -282,12 +247,6 @@ impl Visitor<'_> for SemanticVisitor<'_> {
         match stmt {
             ast::Stmt::ClassDef(class) => {
                 lint_bad_override(self.context, class);
-            }
-            ast::Stmt::Import(import) => {
-                lint_unresolved_imports(self.context, AnyImportRef::Import(import));
-            }
-            ast::Stmt::ImportFrom(import) => {
-                lint_unresolved_imports(self.context, AnyImportRef::ImportFrom(import));
             }
             _ => {}
         }

--- a/crates/red_knot_workspace/src/workspace.rs
+++ b/crates/red_knot_workspace/src/workspace.rs
@@ -13,6 +13,7 @@ use ruff_db::{
 use ruff_python_ast::{name::Name, PySourceType};
 use ruff_text_size::Ranged;
 
+use crate::workspace::files::{Index, Indexed, PackageFiles};
 use crate::{
     db::Db,
     lint::{lint_semantic, lint_syntax},

--- a/crates/red_knot_workspace/src/workspace.rs
+++ b/crates/red_knot_workspace/src/workspace.rs
@@ -258,22 +258,13 @@ impl Workspace {
     /// * It has a [`SystemPath`] and belongs to a package's `src` files
     /// * It has a [`SystemVirtualPath`](ruff_db::system::SystemVirtualPath)
     pub fn is_file_open(self, db: &dyn Db, file: File) -> bool {
-        tracing::trace!("Testing if {} is open.", file.path(db));
         if let Some(open_files) = self.open_files(db) {
             open_files.contains(&file)
         } else if let Some(system_path) = file.path(db).as_system_path() {
-            self.package(db, system_path).map_or(false, |package| {
-                tracing::trace!(
-                    "Checking if {} is in package {}",
-                    file.path(db),
-                    package.name(db)
-                );
-                package.contains_file(db, file)
-            })
-        } else if file.path(db).is_system_virtual_path() {
-            true
+            self.package(db, system_path)
+                .map_or(false, |package| package.contains_file(db, file))
         } else {
-            false
+            file.path(db).is_system_virtual_path()
         }
     }
 }

--- a/crates/ruff_benchmark/benches/red_knot.rs
+++ b/crates/ruff_benchmark/benches/red_knot.rs
@@ -104,7 +104,7 @@ fn benchmark_cold(criterion: &mut Criterion) {
                 let Case { db, parser, .. } = case;
                 let result = db.check_file(*parser).unwrap();
 
-                assert_eq!(result.len(), 34);
+                assert_eq!(result.len(), EXPECTED_DIAGNOSTICS);
             },
             BatchSize::SmallInput,
         );

--- a/crates/ruff_benchmark/benches/red_knot.rs
+++ b/crates/ruff_benchmark/benches/red_knot.rs
@@ -18,6 +18,7 @@ struct Case {
 }
 
 const TOMLLIB_312_URL: &str = "https://raw.githubusercontent.com/python/cpython/8e8a4baf652f6e1cee7acde9d78c4b6154539748/Lib/tomllib";
+const EXPECTED_DIAGNOSTICS: usize = 27;
 
 fn get_test_file(name: &str) -> TestFile {
     let path = format!("tomllib/{name}");
@@ -89,7 +90,7 @@ fn benchmark_incremental(criterion: &mut Criterion) {
                 let Case { db, parser, .. } = case;
                 let result = db.check_file(*parser).unwrap();
 
-                assert_eq!(result.len(), 34);
+                assert_eq!(result.len(), EXPECTED_DIAGNOSTICS);
             },
             BatchSize::SmallInput,
         );

--- a/crates/ruff_source_file/src/lib.rs
+++ b/crates/ruff_source_file/src/lib.rs
@@ -254,6 +254,12 @@ impl Debug for SourceLocation {
     }
 }
 
+impl std::fmt::Display for SourceLocation {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{row}:{column}", row = self.row, column = self.column)
+    }
+}
+
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub enum SourceRow {
     /// A row within a cell in a Jupyter Notebook.


### PR DESCRIPTION
## Summary

This PR introduces a new API to `TypeInferenceBuilder` to emit type-checking diagnostics. 

The API is intentionally kept simple. The PR doesn't aim to resolve on how we represent rules/violations in Red Knot. 

## Design considerations

This PR wraps diagnostics in an `Arc` to make them cheap-cloneable. It's desired to have cheap-cloneable diagnostics
because we have to copy them between `infer_expression` -> `infer_definition` -> `infer_scope`... 

An alternative design that I think is worth exploring once the Salsa tables refactor lands is to introduce a 
`TypeCheckDiagnosticIngredient` that has a single field, the diagnostic. The advantage of this approach would be that
we get "Arena" allocation for the diagnostics. The downside is that diagnostic must be verified everytime the revision changes which
isn't entirely free. 

## Rule Selector

Long term, I think we want to have a `rule_selector(file) -> RuleSelector` query that resolves the enabled rules per file. 
As said before, this PR doesn't try to resolve how and which rules are enabled per file. That's why I omitted this part for now but the idea is that 
`push_diagnostic` would call the `rule_selector` instead of just calling `is_file_open`. 

## Example diagnostic
I implemented an example diagnostic that flags unresolved imports.

## Why do we need `is_file_open` 

The check for `is_file_open` is mainly an optimization to avoid generating a lot of diagnostics that will never be shown. 


## Test Plan

I added a small unit test. I also verified that running the CLI shows the diagnostic.
