### PR TITLE
pydocstyle: Add ignore setting to linter docs

### DIFF
--- a/crates/ruff_linter/src/rules/pydocstyle/rules/not_missing.rs
+++ b/crates/ruff_linter/src/rules/pydocstyle/rules/not_missing.rs
@@ -218,6 +218,9 @@ impl Violation for UndocumentedPublicClass {
 ///             raise ValueError("Tried to greet an unhappy cat.")
 /// ```
 ///
+/// ## Options
+/// - `lint.pydocstyle.ignore-decorators`
+///
 /// ## References
 /// - [PEP 257 – Docstring Conventions](https://peps.python.org/pep-0257/)
 /// - [PEP 287 – reStructuredText Docstring Format](https://peps.python.org/pep-0287/)
@@ -304,6 +307,9 @@ impl Violation for UndocumentedPublicMethod {
 ///     except ZeroDivisionError as exc:
 ///         raise FasterThanLightError from exc
 /// ```
+///
+/// ## Options
+/// - `lint.pydocstyle.ignore-decorators`
 ///
 /// ## References
 /// - [PEP 257 – Docstring Conventions](https://peps.python.org/pep-0257/)
@@ -401,6 +407,9 @@ impl Violation for UndocumentedPublicPackage {
 /// cat = Cat("Dusty")
 /// print(cat)  # "Cat: Dusty"
 /// ```
+///
+/// ## Options
+/// - `lint.pydocstyle.ignore-decorators`
 ///
 /// ## References
 /// - [PEP 257 – Docstring Conventions](https://peps.python.org/pep-0257/)
@@ -501,6 +510,9 @@ impl Violation for UndocumentedPublicNestedClass {
 ///         self.name: str = name
 ///         self.population: int = population
 /// ```
+///
+/// ## Options
+/// - `lint.pydocstyle.ignore-decorators`
 ///
 /// ## References
 /// - [PEP 257 – Docstring Conventions](https://peps.python.org/pep-0257/)


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Adds config item `lint.pydocstyle.ignore-decorators` to the documentation for relevant pydocstyle linters

## Test Plan

<!-- How was it tested? -->

Manually checked `mkdocs` that it was serving well-formatted docs pages with the linter.


Fixes #12942 