### PR TITLE
docs: add stricter validation options

### DIFF
--- a/mkdocs.template.yml
+++ b/mkdocs.template.yml
@@ -71,3 +71,8 @@ not_in_nav: |
 extra:
   analytics:
     provider: fathom
+validation:
+  omitted_files: warn
+  absolute_links: warn
+  unrecognized_links: warn
+  anchors: warn


### PR DESCRIPTION
## Summary

Applying the same change as done in https://github.com/astral-sh/uv/pull/6096. Note that in `uv` repository, this [broke the docs build](https://github.com/astral-sh/uv/pull/6096#issuecomment-2290151150) because `anchors` is `mdkocs` 1.6+ only, and insiders used 1.5.0 while public dependencies used 1.6.0, but in this repository, both use 1.6.0 ([public](https://github.com/astral-sh/ruff/blob/049cda2ff37bcae59f7dae9af6a453075c76e635/docs/requirements.txt#L3), [insiders](https://github.com/astral-sh/ruff/blob/049cda2ff37bcae59f7dae9af6a453075c76e635/docs/requirements-insiders.txt#L3)), so this should not be an issue to have in the template.

Contrarily to `uv` repository, no violations were reported here, but this could prevent adding some in the future.

## Test Plan

Local run of the documentation + `mkdocs build --strict`.