### PR TITLE
Use the system allocator for codspeed benchmarks

### DIFF
--- a/crates/ruff_benchmark/Cargo.toml
+++ b/crates/ruff_benchmark/Cargo.toml
@@ -64,5 +64,5 @@ codspeed = ["codspeed-criterion-compat"]
 [target.'cfg(target_os = "windows")'.dev-dependencies]
 mimalloc = { workspace = true }
 
-[target.'cfg(all(not(target_os = "windows"), not(target_os = "openbsd"), any(target_arch = "x86_64", target_arch = "aarch64", target_arch = "powerpc64")))'.dev-dependencies]
+[target.'cfg(all(not(target_os = "windows"), not(codspeed), not(target_os = "openbsd"), any(target_arch = "x86_64", target_arch = "aarch64", target_arch = "powerpc64")))'.dev-dependencies]
 tikv-jemallocator = { workspace = true }

--- a/crates/ruff_benchmark/benches/formatter.rs
+++ b/crates/ruff_benchmark/benches/formatter.rs
@@ -15,6 +15,7 @@ static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 #[cfg(all(
     not(target_os = "windows"),
     not(target_os = "openbsd"),
+    not(codspeed),
     any(
         target_arch = "x86_64",
         target_arch = "aarch64",

--- a/crates/ruff_benchmark/benches/lexer.rs
+++ b/crates/ruff_benchmark/benches/lexer.rs
@@ -11,6 +11,7 @@ static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 #[cfg(all(
     not(target_os = "windows"),
     not(target_os = "openbsd"),
+    not(codspeed),
     any(
         target_arch = "x86_64",
         target_arch = "aarch64",

--- a/crates/ruff_benchmark/benches/linter.rs
+++ b/crates/ruff_benchmark/benches/linter.rs
@@ -19,6 +19,7 @@ static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 #[cfg(all(
     not(target_os = "windows"),
     not(target_os = "openbsd"),
+    not(codspeed),
     any(
         target_arch = "x86_64",
         target_arch = "aarch64",

--- a/crates/ruff_benchmark/benches/parser.rs
+++ b/crates/ruff_benchmark/benches/parser.rs
@@ -13,6 +13,7 @@ static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 #[cfg(all(
     not(target_os = "windows"),
     not(target_os = "openbsd"),
+    not(codspeed),
     any(
         target_arch = "x86_64",
         target_arch = "aarch64",


### PR DESCRIPTION
## Summary

Our benchmarks have been very flaky recently. The one thing that I noticed is that it is mainly due to changes where jemalloc performs reallocations (or moves entire arenas). This *randomness* is intentional by jemalloc but is kind of hurtful in "reliable" benchmarks. 

I haven't found a way to disable the randomness. This PR suggests disabling jemalloc for benchmarks running in codspeed. This has the downside that the codspeed benchmarks are further away from what we run in production. I do think that this is the less worse outcome than us loosing trust in our benchmarks (I'm currently ignoring them because they're just noise). 

[Codspeed support thread](https://discord.com/channels/1065233827569598464/1211340667809169530/1220074050106167357)

## Test plan

We'll have to test on main to see if the benchmark results are more stable.