### PR TITLE
Remove linter dependency from red_knot_server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1953,7 +1953,6 @@ dependencies = [
  "red_knot_python_semantic",
  "red_knot_workspace",
  "ruff_db",
- "ruff_linter",
  "ruff_notebook",
  "ruff_python_ast",
  "ruff_source_file",

--- a/crates/red_knot/src/logging.rs
+++ b/crates/red_knot/src/logging.rs
@@ -5,8 +5,8 @@ use colored::Colorize;
 use std::fmt;
 use std::fs::File;
 use std::io::BufWriter;
-use tracing::log::LevelFilter;
 use tracing::{Event, Subscriber};
+use tracing_subscriber::filter::LevelFilter;
 use tracing_subscriber::fmt::format::Writer;
 use tracing_subscriber::fmt::{FmtContext, FormatEvent, FormatFields};
 use tracing_subscriber::registry::LookupSpan;
@@ -60,10 +60,10 @@ pub(crate) enum VerbosityLevel {
 impl VerbosityLevel {
     const fn level_filter(self) -> LevelFilter {
         match self {
-            VerbosityLevel::Default => LevelFilter::Warn,
-            VerbosityLevel::Verbose => LevelFilter::Info,
-            VerbosityLevel::ExtraVerbose => LevelFilter::Debug,
-            VerbosityLevel::Trace => LevelFilter::Trace,
+            VerbosityLevel::Default => LevelFilter::WARN,
+            VerbosityLevel::Verbose => LevelFilter::INFO,
+            VerbosityLevel::ExtraVerbose => LevelFilter::DEBUG,
+            VerbosityLevel::Trace => LevelFilter::TRACE,
         }
     }
 
@@ -88,7 +88,7 @@ pub(crate) fn setup_tracing(level: VerbosityLevel) -> anyhow::Result<TracingGuar
         match level {
             VerbosityLevel::Default => {
                 // Show warning traces
-                EnvFilter::default().add_directive(tracing::level_filters::LevelFilter::WARN.into())
+                EnvFilter::default().add_directive(LevelFilter::WARN.into())
             }
             level => {
                 let level_filter = level.level_filter();

--- a/crates/red_knot_server/Cargo.toml
+++ b/crates/red_knot_server/Cargo.toml
@@ -14,7 +14,6 @@ license = { workspace = true }
 red_knot_python_semantic = { workspace = true }
 red_knot_workspace = { workspace = true }
 ruff_db = { workspace = true }
-ruff_linter = { workspace = true }
 ruff_notebook = { workspace = true }
 ruff_python_ast = { workspace = true }
 ruff_source_file = { workspace = true }

--- a/crates/red_knot_server/src/session/capabilities.rs
+++ b/crates/red_knot_server/src/session/capabilities.rs
@@ -1,5 +1,4 @@
 use lsp_types::ClientCapabilities;
-use ruff_linter::display_settings;
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 #[allow(clippy::struct_excessive_bools)]
@@ -64,22 +63,5 @@ impl ResolvedClientCapabilities {
             workspace_refresh,
             pull_diagnostics,
         }
-    }
-}
-
-impl std::fmt::Display for ResolvedClientCapabilities {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        display_settings! {
-            formatter = f,
-            namespace = "capabilities",
-            fields = [
-                self.code_action_deferred_edit_resolution,
-                self.apply_edit,
-                self.document_changes,
-                self.workspace_refresh,
-                self.pull_diagnostics,
-            ]
-        };
-        Ok(())
     }
 }

--- a/crates/red_knot_server/src/session/index.rs
+++ b/crates/red_knot_server/src/session/index.rs
@@ -278,18 +278,6 @@ impl DocumentQuery {
         }
     }
 
-    /// Generate a source kind used by the linter.
-    pub(crate) fn make_source_kind(&self) -> ruff_linter::source_kind::SourceKind {
-        match self {
-            Self::Text { document, .. } => {
-                ruff_linter::source_kind::SourceKind::Python(document.contents().to_string())
-            }
-            Self::Notebook { notebook, .. } => {
-                ruff_linter::source_kind::SourceKind::IpyNotebook(notebook.make_ruff_notebook())
-            }
-        }
-    }
-
     /// Attempts to access the underlying notebook document that this query is selecting.
     pub fn as_notebook(&self) -> Option<&NotebookDocument> {
         match self {


### PR DESCRIPTION
## Summary

This PR removes the `ruff_linter` dependency from `red_knot_server`. It should speed up the `red_knot` compilation time quiet a bit.

## Test Plan

`cargo build`
