### PR TITLE
Use ZIP file size metadata to allocate string

### DIFF
--- a/crates/ruff_db/src/vendored.rs
+++ b/crates/ruff_db/src/vendored.rs
@@ -97,7 +97,12 @@ impl VendoredFileSystem {
         fn read_to_string(fs: &VendoredFileSystem, path: &VendoredPath) -> Result<String> {
             let mut archive = fs.lock_archive();
             let mut zip_file = archive.lookup_path(&NormalizedVendoredPath::from(path))?;
-            let mut buffer = String::new();
+
+            let mut buffer = String::with_capacity(
+                usize::try_from(zip_file.size())
+                    .unwrap_or(usize::MAX)
+                    .min(10_000_000),
+            );
             zip_file.read_to_string(&mut buffer)?;
             Ok(buffer)
         }

--- a/crates/ruff_db/src/vendored.rs
+++ b/crates/ruff_db/src/vendored.rs
@@ -98,6 +98,10 @@ impl VendoredFileSystem {
             let mut archive = fs.lock_archive();
             let mut zip_file = archive.lookup_path(&NormalizedVendoredPath::from(path))?;
 
+            // Pre-allocate the buffer with the size specified in the ZIP file metadata
+            // because `read_to_string` passes `None` as the size hint.
+            // But let's not trust the zip file metadata (even though it's vendored)
+            // and limit it to a reasonable size.
             let mut buffer = String::with_capacity(
                 usize::try_from(zip_file.size())
                     .unwrap_or(usize::MAX)


### PR DESCRIPTION
## Summary

We spend about 1.4% in `VendoredFileSystem::read_to_string`. Let's pre-allocate the string with the right size by using the zip file metadata
as a heuristic (don't trust it!)

## Test Plan

`cargo test`

I verified that total spend in `VendoredFileSystem::read_to_string` goes down to 1.1% and it no longer shows up as a large contributor to `malloc`