### PR TITLE
Add `hyperfine` installation instructions; update `hyperfine` code samples

### DIFF
--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -3,7 +3,6 @@
 rustup default < rust-toolchain
 rustup component add clippy rustfmt
 cargo install cargo-insta
-cargo install hyperfine
 cargo fetch
 
 pip install maturin pre-commit

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -3,6 +3,7 @@
 rustup default < rust-toolchain
 rustup component add clippy rustfmt
 cargo install cargo-insta
+cargo install hyperfine
 cargo fetch
 
 pip install maturin pre-commit

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -407,8 +407,8 @@ To benchmark the release build:
 
 ```shell
 cargo build --release && hyperfine --warmup 10 \
-  "./target/release/ruff ./crates/ruff_linter/resources/test/cpython/ --no-cache -e" \
-  "./target/release/ruff ./crates/ruff_linter/resources/test/cpython/ -e"
+  "./target/release/ruff check ./crates/ruff_linter/resources/test/cpython/ --no-cache -e" \
+  "./target/release/ruff check ./crates/ruff_linter/resources/test/cpython/ -e"
 
 Benchmark 1: ./target/release/ruff ./crates/ruff_linter/resources/test/cpython/ --no-cache
   Time (mean ± σ):     293.8 ms ±   3.2 ms    [User: 2384.6 ms, System: 90.3 ms]
@@ -427,7 +427,7 @@ To benchmark against the ecosystem's existing tools:
 
 ```shell
 hyperfine --ignore-failure --warmup 5 \
-  "./target/release/ruff ./crates/ruff_linter/resources/test/cpython/ --no-cache" \
+  "./target/release/ruff check ./crates/ruff_linter/resources/test/cpython/ --no-cache" \
   "pyflakes crates/ruff_linter/resources/test/cpython" \
   "autoflake --recursive --expand-star-imports --remove-all-unused-imports --remove-unused-variables --remove-duplicate-keys resources/test/cpython" \
   "pycodestyle crates/ruff_linter/resources/test/cpython" \
@@ -473,7 +473,7 @@ To benchmark a subset of rules, e.g. `LineTooLong` and `DocLineTooLong`:
 
 ```shell
 cargo build --release && hyperfine --warmup 10 \
-  "./target/release/ruff ./crates/ruff_linter/resources/test/cpython/ --no-cache -e --select W505,E501"
+  "./target/release/ruff check ./crates/ruff_linter/resources/test/cpython/ --no-cache -e --select W505,E501"
 ```
 
 You can run `poetry install` from `./scripts/benchmarks` to create a working environment for the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -397,6 +397,12 @@ which makes it a good target for benchmarking.
 git clone --branch 3.10 https://github.com/python/cpython.git crates/ruff_linter/resources/test/cpython
 ```
 
+Install `hyperfine`:
+
+```shell
+cargo install hyperfine
+```
+
 To benchmark the release build:
 
 ```shell


### PR DESCRIPTION
## Summary

When following the step-by-step instructions to run the benchmarks in `CONTRIBUTING.md`, I encountered two errors: 

**Error 1:**
`bash: hyperfine: command not found`
    
**Solution**: I updated the instructions to include the step of installing the benchmark tool. 

**Error 2:**
```shell
$ ./target/release/ruff ./crates/ruff_linter/resources/test/cpython/ 
error: `ruff <path>` has been removed. Use `ruff check <path>` instead.
```
**Solution**: I added `check`.

## Test Plan

I tested it by running the benchmark-related commands in a new workspace within GitHub Codespaces.