### PR TITLE
Revert "Use the system allocator for codspeed benchmarks"

### DIFF
--- a/crates/ruff_benchmark/Cargo.toml
+++ b/crates/ruff_benchmark/Cargo.toml
@@ -64,5 +64,5 @@ codspeed = ["codspeed-criterion-compat"]
 [target.'cfg(target_os = "windows")'.dev-dependencies]
 mimalloc = { workspace = true }
 
-[target.'cfg(all(not(target_os = "windows"), not(codspeed), not(target_os = "openbsd"), any(target_arch = "x86_64", target_arch = "aarch64", target_arch = "powerpc64")))'.dev-dependencies]
+[target.'cfg(all(not(target_os = "windows"), not(target_os = "openbsd"), any(target_arch = "x86_64", target_arch = "aarch64", target_arch = "powerpc64")))'.dev-dependencies]
 tikv-jemallocator = { workspace = true }

--- a/crates/ruff_benchmark/benches/formatter.rs
+++ b/crates/ruff_benchmark/benches/formatter.rs
@@ -15,7 +15,6 @@ static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 #[cfg(all(
     not(target_os = "windows"),
     not(target_os = "openbsd"),
-    not(codspeed),
     any(
         target_arch = "x86_64",
         target_arch = "aarch64",

--- a/crates/ruff_benchmark/benches/lexer.rs
+++ b/crates/ruff_benchmark/benches/lexer.rs
@@ -11,7 +11,6 @@ static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 #[cfg(all(
     not(target_os = "windows"),
     not(target_os = "openbsd"),
-    not(codspeed),
     any(
         target_arch = "x86_64",
         target_arch = "aarch64",

--- a/crates/ruff_benchmark/benches/linter.rs
+++ b/crates/ruff_benchmark/benches/linter.rs
@@ -19,7 +19,6 @@ static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 #[cfg(all(
     not(target_os = "windows"),
     not(target_os = "openbsd"),
-    not(codspeed),
     any(
         target_arch = "x86_64",
         target_arch = "aarch64",

--- a/crates/ruff_benchmark/benches/parser.rs
+++ b/crates/ruff_benchmark/benches/parser.rs
@@ -13,7 +13,6 @@ static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 #[cfg(all(
     not(target_os = "windows"),
     not(target_os = "openbsd"),
-    not(codspeed),
     any(
         target_arch = "x86_64",
         target_arch = "aarch64",


### PR DESCRIPTION
Reverts astral-sh/ruff#13005

I don't see any improvements. I think it's even worse then before.