### PR TITLE
[red-knot] Support files outside of any workspace

### DIFF
--- a/crates/red_knot_server/src/server.rs
+++ b/crates/red_knot_server/src/server.rs
@@ -99,6 +99,11 @@ impl Server {
                 anyhow::anyhow!("Failed to get the current working directory while creating a default workspace.")
             })?;
 
+        if workspaces.len() > 1 {
+            // TODO(dhruvmanila): Support multi-root workspaces
+            anyhow::bail!("Multi-root workspaces are not supported yet");
+        }
+
         Ok(Self {
             connection,
             worker_threads,

--- a/crates/red_knot_server/src/server/api/notifications/did_close.rs
+++ b/crates/red_knot_server/src/server/api/notifications/did_close.rs
@@ -2,8 +2,6 @@ use lsp_server::ErrorCode;
 use lsp_types::notification::DidCloseTextDocument;
 use lsp_types::DidCloseTextDocumentParams;
 
-use ruff_db::files::File;
-
 use crate::server::api::diagnostics::clear_diagnostics;
 use crate::server::api::traits::{NotificationHandler, SyncNotificationHandler};
 use crate::server::api::LSPResult;
@@ -25,7 +23,7 @@ impl SyncNotificationHandler for DidCloseTextDocumentHandler {
         _requester: &mut Requester,
         params: DidCloseTextDocumentParams,
     ) -> Result<()> {
-        let Ok(path) = url_to_system_path(&params.text_document.uri) else {
+        let Ok(_path) = url_to_system_path(&params.text_document.uri) else {
             return Ok(());
         };
 
@@ -33,10 +31,6 @@ impl SyncNotificationHandler for DidCloseTextDocumentHandler {
         session
             .close_document(&key)
             .with_failure_code(ErrorCode::InternalError)?;
-
-        if let Some(db) = session.workspace_db_for_path_mut(path.as_std_path()) {
-            File::sync_path(db, &path);
-        }
 
         clear_diagnostics(key.url(), &notifier)?;
 

--- a/crates/red_knot_server/src/server/api/notifications/did_close_notebook.rs
+++ b/crates/red_knot_server/src/server/api/notifications/did_close_notebook.rs
@@ -1,8 +1,6 @@
 use lsp_types::notification::DidCloseNotebookDocument;
 use lsp_types::DidCloseNotebookDocumentParams;
 
-use ruff_db::files::File;
-
 use crate::server::api::traits::{NotificationHandler, SyncNotificationHandler};
 use crate::server::api::LSPResult;
 use crate::server::client::{Notifier, Requester};
@@ -23,7 +21,7 @@ impl SyncNotificationHandler for DidCloseNotebookHandler {
         _requester: &mut Requester,
         params: DidCloseNotebookDocumentParams,
     ) -> Result<()> {
-        let Ok(path) = url_to_system_path(&params.notebook_document.uri) else {
+        let Ok(_path) = url_to_system_path(&params.notebook_document.uri) else {
             return Ok(());
         };
 
@@ -31,10 +29,6 @@ impl SyncNotificationHandler for DidCloseNotebookHandler {
         session
             .close_document(&key)
             .with_failure_code(lsp_server::ErrorCode::InternalError)?;
-
-        if let Some(db) = session.workspace_db_for_path_mut(path.as_std_path()) {
-            File::sync_path(db, &path);
-        }
 
         Ok(())
     }

--- a/crates/red_knot_server/src/server/api/notifications/did_open.rs
+++ b/crates/red_knot_server/src/server/api/notifications/did_open.rs
@@ -34,7 +34,7 @@ impl SyncNotificationHandler for DidOpenTextDocumentHandler {
             Some(db) => db,
             None => session.default_workspace_db_mut(),
         };
-        db.apply_changes(vec![ChangeEvent::file_created(path)], None);
+        db.apply_changes(vec![ChangeEvent::Opened(path)], None);
 
         // TODO(dhruvmanila): Publish diagnostics if the client doesn't support pull diagnostics
 

--- a/crates/red_knot_server/src/server/api/notifications/did_open_notebook.rs
+++ b/crates/red_knot_server/src/server/api/notifications/did_open_notebook.rs
@@ -2,7 +2,7 @@ use lsp_server::ErrorCode;
 use lsp_types::notification::DidOpenNotebookDocument;
 use lsp_types::DidOpenNotebookDocumentParams;
 
-use ruff_db::files::system_path_to_file;
+use red_knot_workspace::watch::ChangeEvent;
 
 use crate::edit::NotebookDocument;
 use crate::server::api::traits::{NotificationHandler, SyncNotificationHandler};
@@ -38,11 +38,11 @@ impl SyncNotificationHandler for DidOpenNotebookHandler {
         .with_failure_code(ErrorCode::InternalError)?;
         session.open_notebook_document(params.notebook_document.uri.clone(), notebook);
 
-        if let Some(db) = session.workspace_db_for_path_mut(path.as_std_path()) {
-            // TODO(dhruvmanila): Store the `file` in `DocumentController`
-            let file = system_path_to_file(db, &path).unwrap();
-            file.sync(db);
-        }
+        let db = match session.workspace_db_for_path_mut(path.as_std_path()) {
+            Some(db) => db,
+            None => session.default_workspace_db_mut(),
+        };
+        db.apply_changes(vec![ChangeEvent::file_created(path)], None);
 
         // TODO(dhruvmanila): Publish diagnostics if the client doesn't support pull diagnostics
 

--- a/crates/red_knot_server/src/server/api/notifications/did_open_notebook.rs
+++ b/crates/red_knot_server/src/server/api/notifications/did_open_notebook.rs
@@ -42,7 +42,7 @@ impl SyncNotificationHandler for DidOpenNotebookHandler {
             Some(db) => db,
             None => session.default_workspace_db_mut(),
         };
-        db.apply_changes(vec![ChangeEvent::file_created(path)], None);
+        db.apply_changes(vec![ChangeEvent::Opened(path)], None);
 
         // TODO(dhruvmanila): Publish diagnostics if the client doesn't support pull diagnostics
 

--- a/crates/red_knot_server/src/server/api/traits.rs
+++ b/crates/red_knot_server/src/server/api/traits.rs
@@ -34,7 +34,7 @@ pub(super) trait BackgroundDocumentRequestHandler: RequestHandler {
 
     fn run_with_snapshot(
         snapshot: DocumentSnapshot,
-        db: Option<RootDatabase>,
+        db: RootDatabase,
         notifier: Notifier,
         params: <<Self as RequestHandler>::RequestType as Request>::Params,
     ) -> super::Result<<<Self as RequestHandler>::RequestType as Request>::Result>;

--- a/crates/red_knot_server/src/session.rs
+++ b/crates/red_knot_server/src/session.rs
@@ -82,6 +82,10 @@ impl Session {
         })
     }
 
+    // TODO(dhruvmanila): Ideally, we should have a single method for `workspace_db_for_path_mut`
+    // and `default_workspace_db_mut` but the borrow checker doesn't allow that.
+    // https://github.com/astral-sh/ruff/pull/13041#discussion_r1726725437
+
     /// Returns a reference to the workspace [`RootDatabase`] corresponding to the given path, if
     /// any.
     pub(crate) fn workspace_db_for_path(&self, path: impl AsRef<Path>) -> Option<&RootDatabase> {

--- a/crates/red_knot_server/src/session.rs
+++ b/crates/red_knot_server/src/session.rs
@@ -82,6 +82,8 @@ impl Session {
         })
     }
 
+    /// Returns a reference to the workspace [`RootDatabase`] corresponding to the given path, if
+    /// any.
     pub(crate) fn workspace_db_for_path(&self, path: impl AsRef<Path>) -> Option<&RootDatabase> {
         self.workspaces
             .range(..=path.as_ref().to_path_buf())
@@ -89,6 +91,8 @@ impl Session {
             .map(|(_, db)| db)
     }
 
+    /// Returns a mutable reference to the workspace [`RootDatabase`] corresponding to the given
+    /// path, if any.
     pub(crate) fn workspace_db_for_path_mut(
         &mut self,
         path: impl AsRef<Path>,
@@ -97,6 +101,19 @@ impl Session {
             .range_mut(..=path.as_ref().to_path_buf())
             .next_back()
             .map(|(_, db)| db)
+    }
+
+    /// Returns a reference to the default workspace [`RootDatabase`]. The default workspace is the
+    /// minimum root path in the workspace map.
+    pub(crate) fn default_workspace_db(&self) -> &RootDatabase {
+        // SAFETY: Currently, red knot only support a single workspace.
+        self.workspaces.values().next().unwrap()
+    }
+
+    /// Returns a mutable reference to the default workspace [`RootDatabase`].
+    pub(crate) fn default_workspace_db_mut(&mut self) -> &mut RootDatabase {
+        // SAFETY: Currently, red knot only support a single workspace.
+        self.workspaces.values_mut().next().unwrap()
     }
 
     pub fn key_from_url(&self, url: Url) -> DocumentKey {

--- a/crates/red_knot_workspace/src/db/changes.rs
+++ b/crates/red_knot_workspace/src/db/changes.rs
@@ -72,7 +72,8 @@ impl RootDatabase {
             }
 
             match change {
-                watch::ChangeEvent::Changed { path, kind: _ } => sync_path(self, &path),
+                watch::ChangeEvent::Changed { path, kind: _ }
+                | watch::ChangeEvent::Opened(path) => sync_path(self, &path),
 
                 watch::ChangeEvent::Created { kind, path } => {
                     match kind {

--- a/crates/red_knot_workspace/src/watch.rs
+++ b/crates/red_knot_workspace/src/watch.rs
@@ -46,6 +46,16 @@ pub enum ChangeEvent {
 }
 
 impl ChangeEvent {
+    /// Creates a new [`Created`] event for a file at the given path.
+    ///
+    /// [`Created`]: ChangeEvent::Created
+    pub fn file_created(path: SystemPathBuf) -> ChangeEvent {
+        ChangeEvent::Created {
+            path,
+            kind: CreatedKind::File,
+        }
+    }
+
     pub fn file_name(&self) -> Option<&str> {
         self.path().and_then(|path| path.file_name())
     }

--- a/crates/red_knot_workspace/src/watch.rs
+++ b/crates/red_knot_workspace/src/watch.rs
@@ -20,6 +20,9 @@ mod workspace_watcher;
 /// event instead of emitting an event for each file or subdirectory in that path.
 #[derive(Debug, PartialEq, Eq)]
 pub enum ChangeEvent {
+    /// The file corresponding to the given path was opened in an editor.
+    Opened(SystemPathBuf),
+
     /// A new path was created
     Created {
         path: SystemPathBuf,
@@ -46,23 +49,14 @@ pub enum ChangeEvent {
 }
 
 impl ChangeEvent {
-    /// Creates a new [`Created`] event for a file at the given path.
-    ///
-    /// [`Created`]: ChangeEvent::Created
-    pub fn file_created(path: SystemPathBuf) -> ChangeEvent {
-        ChangeEvent::Created {
-            path,
-            kind: CreatedKind::File,
-        }
-    }
-
     pub fn file_name(&self) -> Option<&str> {
         self.path().and_then(|path| path.file_name())
     }
 
     pub fn path(&self) -> Option<&SystemPath> {
         match self {
-            ChangeEvent::Created { path, .. }
+            ChangeEvent::Opened(path)
+            | ChangeEvent::Created { path, .. }
             | ChangeEvent::Changed { path, .. }
             | ChangeEvent::Deleted { path, .. } => Some(path),
             ChangeEvent::Rescan => None,


### PR DESCRIPTION
## Summary

This PR adds basic support for files outside of any workspace in the red knot server.

This also limits the red knot server to only work in a single workspace. The server will not start if there are multiple workspaces.

## Test Plan

https://github.com/user-attachments/assets/de601387-0ad5-433c-9d2c-7b6ae5137654


