### PR TITLE
Basic concurrent checking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1989,6 +1989,7 @@ dependencies = [
  "anyhow",
  "crossbeam",
  "notify",
+ "rayon",
  "red_knot_python_semantic",
  "ruff_cache",
  "ruff_db",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2148,6 +2148,7 @@ dependencies = [
  "criterion",
  "mimalloc",
  "once_cell",
+ "rayon",
  "red_knot_python_semantic",
  "red_knot_workspace",
  "ruff_db",

--- a/crates/red_knot_wasm/tests/api.rs
+++ b/crates/red_knot_wasm/tests/api.rs
@@ -11,11 +11,11 @@ fn check() {
     };
     let mut workspace = Workspace::new("/", &settings).expect("Workspace to be created");
 
-    let test = workspace
+    workspace
         .open_file("test.py", "import random22\n")
         .expect("File to be opened");
 
-    let result = workspace.check_file(&test).expect("Check to succeed");
+    let result = workspace.check().expect("Check to succeed");
 
     assert_eq!(
         result,

--- a/crates/red_knot_workspace/Cargo.toml
+++ b/crates/red_knot_workspace/Cargo.toml
@@ -22,12 +22,13 @@ ruff_text_size = { workspace = true }
 anyhow = { workspace = true }
 crossbeam = { workspace = true }
 notify = { workspace = true }
+rayon = { workspace = true }
 rustc-hash = { workspace = true }
 salsa = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]
-ruff_db = { workspace = true, features = ["testing"]}
+ruff_db = { workspace = true, features = ["testing"] }
 
 [lints]
 workspace = true

--- a/crates/red_knot_workspace/src/db.rs
+++ b/crates/red_knot_workspace/src/db.rs
@@ -56,6 +56,8 @@ impl RootDatabase {
     }
 
     pub fn check_file(&self, file: File) -> Result<Vec<String>, Cancelled> {
+        let _span = tracing::debug_span!("check_file", file=%file.path(self)).entered();
+
         self.with_db(|db| check_file(db, file))
     }
 

--- a/crates/red_knot_workspace/src/workspace.rs
+++ b/crates/red_knot_workspace/src/workspace.rs
@@ -15,7 +15,8 @@ use ruff_db::{
 use ruff_python_ast::{name::Name, PySourceType};
 use ruff_text_size::Ranged;
 
-use crate::workspace::files::{Index, Indexed, PackageFiles};
+use crate::db::RootDatabase;
+use crate::workspace::files::{Index, Indexed, IndexedIter, PackageFiles};
 use crate::{
     db::Db,
     lint::{lint_semantic, lint_syntax},
@@ -190,23 +191,35 @@ impl Workspace {
     }
 
     /// Checks all open files in the workspace and its dependencies.
-    #[tracing::instrument(level = "debug", skip_all)]
-    pub fn check(self, db: &dyn Db) -> Vec<String> {
+    pub fn check(self, db: &RootDatabase) -> Vec<String> {
+        let workspace_span = tracing::debug_span!("check_workspace");
+        let _span = workspace_span.enter();
+
         tracing::debug!("Checking workspace");
+        let files = WorkspaceFiles::new(db, self);
+        let result = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let inner_result = Arc::clone(&result);
 
-        let mut result = Vec::new();
+        let db = db.snapshot();
+        let workspace_span = workspace_span.clone();
 
-        if let Some(open_files) = self.open_files(db) {
-            for file in open_files {
-                result.extend_from_slice(&check_file(db, *file));
+        rayon::scope(move |scope| {
+            for file in &files {
+                let result = inner_result.clone();
+                let db = db.snapshot();
+                let workspace_span = workspace_span.clone();
+
+                scope.spawn(move |_| {
+                    let check_file_span = tracing::debug_span!(parent: &workspace_span, "check_file", file=%file.path(&db));
+                    let _entered = check_file_span.entered();
+
+                    let file_diagnostics = check_file(&db, file);
+                    result.lock().unwrap().extend(file_diagnostics);
+                });
             }
-        } else {
-            for package in self.packages(db) {
-                result.extend(package.check(db));
-            }
-        }
+        });
 
-        result
+        Arc::into_inner(result).unwrap().into_inner().unwrap()
     }
 
     /// Opens a file in the workspace.
@@ -324,19 +337,6 @@ impl Package {
         index.insert(file);
     }
 
-    #[tracing::instrument(level = "debug", skip(db))]
-    pub(crate) fn check(self, db: &dyn Db) -> Vec<String> {
-        tracing::debug!("Checking package '{}'", self.root(db));
-
-        let mut result = Vec::new();
-        for file in &self.files(db) {
-            let diagnostics = check_file(db, file);
-            result.extend_from_slice(&diagnostics);
-        }
-
-        result
-    }
-
     /// Returns the files belonging to this package.
     pub fn files(self, db: &dyn Db) -> Indexed<'_> {
         let files = self.file_set(db);
@@ -384,9 +384,7 @@ impl Package {
 
 #[salsa::tracked]
 pub(super) fn check_file(db: &dyn Db, file: File) -> Vec<String> {
-    let path = file.path(db);
-    let _span = tracing::debug_span!("check_file", file=%path).entered();
-    tracing::debug!("Checking file '{path}'");
+    tracing::debug!("Checking file '{path}'", path = file.path(db));
 
     let mut diagnostics = Vec::new();
 
@@ -472,6 +470,73 @@ fn discover_package_files(db: &dyn Db, path: &SystemPath) -> FxHashSet<File> {
     }
 
     files
+}
+
+#[derive(Debug)]
+enum WorkspaceFiles<'a> {
+    OpenFiles(&'a FxHashSet<File>),
+    PackageFiles(Vec<Indexed<'a>>),
+}
+
+impl<'a> WorkspaceFiles<'a> {
+    fn new(db: &'a dyn Db, workspace: Workspace) -> Self {
+        if let Some(open_files) = workspace.open_files(db) {
+            WorkspaceFiles::OpenFiles(open_files)
+        } else {
+            WorkspaceFiles::PackageFiles(
+                workspace
+                    .packages(db)
+                    .map(|package| package.files(db))
+                    .collect(),
+            )
+        }
+    }
+}
+
+impl<'a> IntoIterator for &'a WorkspaceFiles<'a> {
+    type Item = File;
+    type IntoIter = WorkspaceFilesIter<'a>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        match self {
+            WorkspaceFiles::OpenFiles(files) => WorkspaceFilesIter::OpenFiles(files.iter()),
+            WorkspaceFiles::PackageFiles(package_files) => {
+                let mut package_files = package_files.iter();
+                WorkspaceFilesIter::PackageFiles {
+                    current: package_files.next().map(IntoIterator::into_iter),
+                    package_files,
+                }
+            }
+        }
+    }
+}
+
+enum WorkspaceFilesIter<'db> {
+    OpenFiles(std::collections::hash_set::Iter<'db, File>),
+    PackageFiles {
+        package_files: std::slice::Iter<'db, Indexed<'db>>,
+        current: Option<IndexedIter<'db>>,
+    },
+}
+
+impl Iterator for WorkspaceFilesIter<'_> {
+    type Item = File;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            WorkspaceFilesIter::OpenFiles(files) => files.next().copied(),
+            WorkspaceFilesIter::PackageFiles {
+                package_files,
+                current,
+            } => loop {
+                if let Some(file) = current.as_mut().and_then(Iterator::next) {
+                    return Some(file);
+                }
+
+                *current = Some(package_files.next()?.into_iter());
+            },
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/red_knot_workspace/src/workspace/files.rs
+++ b/crates/red_knot_workspace/src/workspace/files.rs
@@ -158,9 +158,11 @@ impl Deref for Indexed<'_> {
     }
 }
 
+pub(super) type IndexedIter<'a> = std::iter::Copied<std::collections::hash_set::Iter<'a, File>>;
+
 impl<'a> IntoIterator for &'a Indexed<'_> {
     type Item = File;
-    type IntoIter = std::iter::Copied<std::collections::hash_set::Iter<'a, File>>;
+    type IntoIter = IndexedIter<'a>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.files.iter().copied()

--- a/crates/ruff_benchmark/Cargo.toml
+++ b/crates/ruff_benchmark/Cargo.toml
@@ -37,13 +37,14 @@ name = "red_knot"
 harness = false
 
 [dependencies]
+codspeed-criterion-compat = { workspace = true, default-features = false, optional = true }
+criterion = { workspace = true, default-features = false }
 once_cell = { workspace = true }
+rayon = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 url = { workspace = true }
 ureq = { workspace = true }
-criterion = { workspace = true, default-features = false }
-codspeed-criterion-compat = { workspace = true, default-features = false, optional = true }
 
 [dev-dependencies]
 ruff_db = { workspace = true }


### PR DESCRIPTION
## Summary

This PR makes `workspace.check` to check the files concurrently. 

This PR doesn't explore more advanced scheduling. For example, we could try to not only schedule the workspace files 
but also the dependencies of those files. This would give us better performance where a project has few first-party modules but depends on many third-party modules. 

The main downside of concurrent checking is that the logs become harder to read, especially when using `-vvv` because the output of different threads is intertwined. I don't have a good solution for this yet other than using `RAYON_NUM_THREADS=1` to explicitly fall-back to a single thread. 

## Test Plan

Checking black goes down from 108ms to 34ms (12 cores)

### Main

```
black (cold)
Benchmark 1: knot
  Time (mean ± σ):     125.2 ms ±   3.8 ms    [User: 89.3 ms, System: 35.7 ms]
  Range (min … max):   117.7 ms … 133.3 ms    24 runs
 
  Warning: Ignoring non-zero exit code.
 
jinja (cold)
Benchmark 1: knot
  Time (mean ± σ):     139.1 ms ±   9.2 ms    [User: 100.1 ms, System: 38.8 ms]
  Range (min … max):   125.0 ms … 155.7 ms    22 runs
 
  Warning: Ignoring non-zero exit code.
 
isort (cold)
Benchmark 1: knot
  Time (mean ± σ):      85.2 ms ±   2.3 ms    [User: 60.1 ms, System: 25.0 ms]
  Range (min … max):    80.6 ms …  89.1 ms    32 runs
 
  Warning: Ignoring non-zero exit code.
```

### Concurrent

```
uv run benchmark  --min-runs=3 --knot
black (cold)
Benchmark 1: knot
  Time (mean ± σ):      36.1 ms ±   1.1 ms    [User: 125.6 ms, System: 71.7 ms]
  Range (min … max):    33.3 ms …  39.4 ms    77 runs
 
  Warning: Ignoring non-zero exit code.
 
jinja (cold)
Benchmark 1: knot
  Time (mean ± σ):      32.6 ms ±   1.5 ms    [User: 140.8 ms, System: 88.7 ms]
  Range (min … max):    29.5 ms …  36.4 ms    88 runs
 
  Warning: Ignoring non-zero exit code.
 
isort (cold)
Benchmark 1: knot
  Time (mean ± σ):      30.7 ms ±   1.2 ms    [User: 82.4 ms, System: 46.7 ms]
  Range (min … max):    28.4 ms …  34.4 ms    89 runs
 
  Warning: Ignoring non-zero exit code.
 ```