### PR TITLE
Added bytes type and some inference

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1926,6 +1926,7 @@ dependencies = [
  "ruff_db",
  "ruff_index",
  "ruff_python_ast",
+ "ruff_python_literal",
  "ruff_python_parser",
  "ruff_python_stdlib",
  "ruff_source_file",

--- a/crates/red_knot_python_semantic/Cargo.toml
+++ b/crates/red_knot_python_semantic/Cargo.toml
@@ -17,6 +17,7 @@ ruff_python_ast = { workspace = true }
 ruff_python_stdlib = { workspace = true }
 ruff_source_file = { workspace = true }
 ruff_text_size = { workspace = true }
+ruff_python_literal = { workspace = true }
 
 anyhow = { workspace = true }
 bitflags = { workspace = true }

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -380,7 +380,8 @@ pub struct IntersectionType<'db> {
 
 #[salsa::interned]
 pub struct BytesLiteralType<'db> {
-    value: Vec<u8>,
+    #[return_ref]
+    value: Box<[u8]>,
 }
 
 #[cfg(test)]

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -181,6 +181,8 @@ pub enum Type<'db> {
     IntLiteral(i64),
     /// A boolean literal, either `True` or `False`.
     BooleanLiteral(bool),
+    /// A bytes type, TODO bytes literals
+    Bytes,
     // TODO protocols, callable types, overloads, generics, type vars
 }
 
@@ -276,6 +278,10 @@ impl<'db> Type<'db> {
                 Type::Unknown
             }
             Type::BooleanLiteral(_) => Type::Unknown,
+            Type::Bytes => {
+                // TODO check if bytes have members
+                Type::Unknown
+            }
         }
     }
 

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -279,7 +279,7 @@ impl<'db> Type<'db> {
             }
             Type::BooleanLiteral(_) => Type::Unknown,
             Type::BytesLiteral(_) => {
-                // TODO check if bytes have members
+                // TODO defer to Type::Instance(<bytes from typeshed>).member
                 Type::Unknown
             }
         }

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -181,8 +181,6 @@ pub enum Type<'db> {
     IntLiteral(i64),
     /// A boolean literal, either `True` or `False`.
     BooleanLiteral(bool),
-    /// A bytes type, TODO bytes literals
-    Bytes,
     // TODO protocols, callable types, overloads, generics, type vars
 }
 
@@ -278,10 +276,6 @@ impl<'db> Type<'db> {
                 Type::Unknown
             }
             Type::BooleanLiteral(_) => Type::Unknown,
-            Type::Bytes => {
-                // TODO check if bytes have members
-                Type::Unknown
-            }
         }
     }
 

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -181,6 +181,8 @@ pub enum Type<'db> {
     IntLiteral(i64),
     /// A boolean literal, either `True` or `False`.
     BooleanLiteral(bool),
+    /// A bytes literal
+    BytesLiteral(BytesLiteralType<'db>),
     // TODO protocols, callable types, overloads, generics, type vars
 }
 
@@ -276,6 +278,10 @@ impl<'db> Type<'db> {
                 Type::Unknown
             }
             Type::BooleanLiteral(_) => Type::Unknown,
+            Type::BytesLiteral(_) => {
+                // TODO check if bytes have members
+                Type::Unknown
+            }
         }
     }
 
@@ -370,6 +376,11 @@ pub struct IntersectionType<'db> {
     /// narrowing along with intersections (e.g. `if not isinstance(...)`), so we represent them
     /// directly in intersections rather than as a separate type.
     negative: FxOrderSet<Type<'db>>,
+}
+
+#[salsa::interned]
+pub struct BytesLiteralType<'db> {
+    value: Vec<u8>,
 }
 
 #[cfg(test)]

--- a/crates/red_knot_python_semantic/src/types/display.rs
+++ b/crates/red_knot_python_semantic/src/types/display.rs
@@ -37,9 +37,7 @@ impl Display for DisplayType<'_> {
             Type::IntLiteral(n) => write!(f, "Literal[{n}]"),
             Type::BooleanLiteral(boolean) => {
                 write!(f, "Literal[{}]", if *boolean { "True" } else { "False" })
-            },
-            Type::Bytes => write!(f, "bytes"),
-
+            }
         }
     }
 }

--- a/crates/red_knot_python_semantic/src/types/display.rs
+++ b/crates/red_knot_python_semantic/src/types/display.rs
@@ -2,6 +2,9 @@
 
 use std::fmt::{Display, Formatter};
 
+use ruff_python_ast::str::Quote;
+use ruff_python_literal::escape::AsciiEscape;
+
 use crate::types::{IntersectionType, Type, UnionType};
 use crate::Db;
 
@@ -37,6 +40,15 @@ impl Display for DisplayType<'_> {
             Type::IntLiteral(n) => write!(f, "Literal[{n}]"),
             Type::BooleanLiteral(boolean) => {
                 write!(f, "Literal[{}]", if *boolean { "True" } else { "False" })
+            }
+            Type::BytesLiteral(bytes) => {
+                // TODO: cant I just borrow this value?
+                let value = bytes.value(self.db);
+                let escape = AsciiEscape::with_preferred_quote(value.as_ref(), Quote::Double);
+
+                f.write_str("Literal[")?;
+                escape.bytes_repr().write(f)?;
+                f.write_str("]")
             }
         }
     }

--- a/crates/red_knot_python_semantic/src/types/display.rs
+++ b/crates/red_knot_python_semantic/src/types/display.rs
@@ -42,9 +42,8 @@ impl Display for DisplayType<'_> {
                 write!(f, "Literal[{}]", if *boolean { "True" } else { "False" })
             }
             Type::BytesLiteral(bytes) => {
-                // TODO: cant I just borrow this value?
-                let value = bytes.value(self.db);
-                let escape = AsciiEscape::with_preferred_quote(value.as_ref(), Quote::Double);
+                let escape =
+                    AsciiEscape::with_preferred_quote(bytes.value(self.db).as_ref(), Quote::Double);
 
                 f.write_str("Literal[")?;
                 escape.bytes_repr().write(f)?;

--- a/crates/red_knot_python_semantic/src/types/display.rs
+++ b/crates/red_knot_python_semantic/src/types/display.rs
@@ -37,7 +37,9 @@ impl Display for DisplayType<'_> {
             Type::IntLiteral(n) => write!(f, "Literal[{n}]"),
             Type::BooleanLiteral(boolean) => {
                 write!(f, "Literal[{}]", if *boolean { "True" } else { "False" })
-            }
+            },
+            Type::Bytes => write!(f, "bytes"),
+
         }
     }
 }

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -1687,6 +1687,7 @@ impl<'db> TypeInferenceBuilder<'db> {
         let left_ty = self.infer_expression(left);
         let right_ty = self.infer_expression(right);
 
+        // TODO flatten the matches by matching on (left_ty, right_ty, op)
         match left_ty {
             Type::Any => Type::Any,
             Type::Unknown => Type::Unknown,

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -1729,15 +1729,12 @@ impl<'db> TypeInferenceBuilder<'db> {
                 match right_ty {
                     Type::BytesLiteral(rhs) => {
                         match op {
-                            ast::Operator::Add => {
-                                Type::BytesLiteral(BytesLiteralType::new(
-                                    self.db,
-                                    // TODO the value accessors are cloning?
-                                    [lhs.value(self.db).as_ref(), rhs.value(self.db).as_ref()]
-                                        .concat()
-                                        .into_boxed_slice(),
-                                ))
-                            }
+                            ast::Operator::Add => Type::BytesLiteral(BytesLiteralType::new(
+                                self.db,
+                                [lhs.value(self.db).as_ref(), rhs.value(self.db).as_ref()]
+                                    .concat()
+                                    .into_boxed_slice(),
+                            )),
                             _ => Type::Unknown, // TODO
                         }
                     }

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -1207,7 +1207,7 @@ impl<'db> TypeInferenceBuilder<'db> {
 
     #[allow(clippy::unused_self)]
     fn infer_bytes_literal_expression(&mut self, _literal: &ast::ExprBytesLiteral) -> Type<'db> {
-        Type::Bytes
+        builtins_symbol_ty_by_name(self.db, "bytes").instance()
     }
 
     fn infer_fstring_expression(&mut self, fstring: &ast::ExprFString) -> Type<'db> {
@@ -1719,20 +1719,6 @@ impl<'db> TypeInferenceBuilder<'db> {
                         }
                     }
                     _ => Type::Unknown, // TODO
-                }
-            }
-            Type::Bytes => {
-                match right_ty {
-                    Type::Bytes => {
-                        match op {
-                            ast::Operator::Add => {
-                                Type::Bytes
-                            }
-                            _ => Type::Unknown, // TODO
-                        }
-                    }
-                    _ => Type::Unknown, // TODO
-
                 }
             }
             _ => Type::Unknown, // TODO
@@ -2252,10 +2238,9 @@ mod tests {
     fn bytes_type() -> anyhow::Result<()> {
         let mut db = setup_db();
 
-        db.write_file("src/a.py", "x = b'hello'\ny = b'world' + b'!'")?;
+        db.write_file("src/a.py", "x = b'hello'")?;
 
         assert_public_ty(&db, "src/a.py", "x", "bytes");
-        assert_public_ty(&db, "src/a.py", "y", "bytes");
 
         Ok(())
     }

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -1207,8 +1207,7 @@ impl<'db> TypeInferenceBuilder<'db> {
 
     #[allow(clippy::unused_self)]
     fn infer_bytes_literal_expression(&mut self, _literal: &ast::ExprBytesLiteral) -> Type<'db> {
-        // TODO
-        Type::Unknown
+        Type::Bytes
     }
 
     fn infer_fstring_expression(&mut self, fstring: &ast::ExprFString) -> Type<'db> {
@@ -1722,6 +1721,20 @@ impl<'db> TypeInferenceBuilder<'db> {
                     _ => Type::Unknown, // TODO
                 }
             }
+            Type::Bytes => {
+                match right_ty {
+                    Type::Bytes => {
+                        match op {
+                            ast::Operator::Add => {
+                                Type::Bytes
+                            }
+                            _ => Type::Unknown, // TODO
+                        }
+                    }
+                    _ => Type::Unknown, // TODO
+
+                }
+            }
             _ => Type::Unknown, // TODO
         }
     }
@@ -2231,6 +2244,18 @@ mod tests {
 
         assert_public_ty(&db, "src/a.py", "x", "Literal[True]");
         assert_public_ty(&db, "src/a.py", "y", "Literal[False]");
+
+        Ok(())
+    }
+
+    #[test]
+    fn bytes_type() -> anyhow::Result<()> {
+        let mut db = setup_db();
+
+        db.write_file("src/a.py", "x = b'hello'\ny = b'world' + b'!'")?;
+
+        assert_public_ty(&db, "src/a.py", "x", "bytes");
+        assert_public_ty(&db, "src/a.py", "y", "bytes");
 
         Ok(())
     }

--- a/crates/ruff_python_ast/src/nodes.rs
+++ b/crates/ruff_python_ast/src/nodes.rs
@@ -2152,7 +2152,7 @@ impl BytesLiteralValue {
     }
 
     /// Returns an iterator over the bytes of the concatenated bytes.
-    fn bytes(&self) -> impl Iterator<Item = u8> + '_ {
+    pub fn bytes(&self) -> impl Iterator<Item = u8> + '_ {
         self.iter().flat_map(|part| part.as_slice().iter().copied())
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

This PR adds the `bytes` type to red-knot:
- Added the `bytes` type
- Added support for bytes literals
- Support for the `+` operator

Improves on #12701 

Big TODO on supporting and normalizing r-prefixed bytestrings (`rb"hello\n"`)

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

Added a test for a bytes literals, concatenation, and corner values

<!-- How was it tested? -->
