### PR TITLE
Add anchor tags to README headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ For more, see the [documentation](https://docs.astral.sh/ruff/).
 1. [Who's Using Ruff?](#whos-using-ruff)
 1. [License](#license)
 
-## Getting Started
+## Getting Started<a id="getting-started"></a>
 
 For more, see the [documentation](https://docs.astral.sh/ruff/).
 
@@ -195,7 +195,7 @@ jobs:
       - uses: chartboost/ruff-action@v1
 ```
 
-### Configuration
+### Configuration<a id="configuration"></a>
 
 Ruff can be configured through a `pyproject.toml`, `ruff.toml`, or `.ruff.toml` file (see:
 [_Configuration_](https://docs.astral.sh/ruff/configuration/), or [_Settings_](https://docs.astral.sh/ruff/settings/)
@@ -291,7 +291,7 @@ features that may change prior to stabilization.
 See `ruff help` for more on Ruff's top-level commands, or `ruff help check` and `ruff help format`
 for more on the linting and formatting commands, respectively.
 
-## Rules
+## Rules<a id="rules"></a>
 
 <!-- Begin section: Rules -->
 
@@ -367,21 +367,21 @@ quality tools, including:
 
 For a complete enumeration of the supported rules, see [_Rules_](https://docs.astral.sh/ruff/rules/).
 
-## Contributing
+## Contributing<a id="contributing"></a>
 
 Contributions are welcome and highly appreciated. To get started, check out the
 [**contributing guidelines**](https://docs.astral.sh/ruff/contributing/).
 
 You can also join us on [**Discord**](https://discord.com/invite/astral-sh).
 
-## Support
+## Support<a id="support"></a>
 
 Having trouble? Check out the existing issues on [**GitHub**](https://github.com/astral-sh/ruff/issues),
 or feel free to [**open a new one**](https://github.com/astral-sh/ruff/issues/new).
 
 You can also ask for help on [**Discord**](https://discord.com/invite/astral-sh).
 
-## Acknowledgements
+## Acknowledgements<a id="acknowledgements"></a>
 
 Ruff's linter draws on both the APIs and implementation details of many other
 tools in the Python ecosystem, especially [Flake8](https://github.com/PyCQA/flake8), [Pyflakes](https://github.com/PyCQA/pyflakes),
@@ -405,7 +405,7 @@ Ruff is the beneficiary of a large number of [contributors](https://github.com/a
 
 Ruff is released under the MIT license.
 
-## Who's Using Ruff?
+## Who's Using Ruff?<a id="whos-using-ruff"></a>
 
 Ruff is used by a number of major open-source projects and companies, including:
 
@@ -524,7 +524,7 @@ If you're using Ruff, consider adding the Ruff badge to your project's `README.m
 <a href="https://github.com/astral-sh/ruff"><img src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json" alt="Ruff" style="max-width:100%;"></a>
 ```
 
-## License
+## License<a id="license"></a>
 
 This repository is licensed under the [MIT License](https://github.com/astral-sh/ruff/blob/main/LICENSE)
 


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

This pull request adds anchor tags to the elements referenced in the table of contents section of the readme used on [PyPI](https://pypi.org/project/ruff/) as an attempt to fix #7257. This update follows [this suggestion](https://github.com/pypa/readme_renderer/issues/169#issuecomment-808577486) to add anchor tags (with no spaces) after the title that is to be linked to.

## Test Plan

<!-- How was it tested? -->
- This has been tested on GitHub to check that the additional tags do not interfere with how the read me is rendered; see: https://github.com/calumy/ruff/blob/add-links-to-pypi-docs/README.md
- MK docs were generated using the `generate_mkdocs.py` script; however  as the added tags are beyond the comment `<!-- End section: Overview -->`, they are excluded so will not change how the docs are rendered.
- I was unable to verify how PyPI renders this change, any suggestions would be appreciated and I can follow up on this. Hopefully, the four thumbs up/heart on [this comment](https://github.com/pypa/readme_renderer/issues/169#issuecomment-808577486) and [this suggestion](https://github.com/pypa/readme_renderer/issues/169#issuecomment-1765616890)  all suggest that this approach should work.
