### PR TITLE
[red-knot] Resolve function annotations before adding function symbol

### DIFF
--- a/crates/red_knot_python_semantic/src/semantic_index.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index.rs
@@ -617,44 +617,6 @@ def f(a: str, /, b: str, c: int = 1, *args, d: int = 2, **kwargs):
     }
 
     #[test]
-    fn function_parameter_same_name_default() {
-        let TestCase { db, file } = test_case(
-            "
-def bool(x=bool):
-    return x
-",
-        );
-
-        let index = semantic_index(&db, file);
-        let global_table = symbol_table(&db, global_scope(&db, file));
-
-        assert_eq!(names(&global_table), vec!["bool"]);
-
-        let [(function_scope_id, _function_scope)] = index
-            .child_scopes(FileScopeId::global())
-            .collect::<Vec<_>>()[..]
-        else {
-            panic!("Expected a function scope")
-        };
-
-        let function_table = index.symbol_table(function_scope_id);
-        assert_eq!(names(&function_table), vec!["x"],);
-
-        let use_def = index.use_def_map(function_scope_id);
-        let definition = use_def
-            .first_public_definition(
-                function_table
-                    .symbol_id_by_name("x")
-                    .expect("symbol exists"),
-            )
-            .unwrap();
-        assert!(matches!(
-            definition.node(&db),
-            DefinitionKind::ParameterWithDefault(_)
-        ));
-    }
-
-    #[test]
     fn lambda_parameter_symbols() {
         let TestCase { db, file } = test_case("lambda a, b, c=1, *args, d=2, **kwargs: None");
 

--- a/crates/red_knot_python_semantic/src/semantic_index.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index.rs
@@ -617,6 +617,44 @@ def f(a: str, /, b: str, c: int = 1, *args, d: int = 2, **kwargs):
     }
 
     #[test]
+    fn function_parameter_same_name_default() {
+        let TestCase { db, file } = test_case(
+            "
+def bool(x=bool):
+    return x
+",
+        );
+
+        let index = semantic_index(&db, file);
+        let global_table = symbol_table(&db, global_scope(&db, file));
+
+        assert_eq!(names(&global_table), vec!["bool"]);
+
+        let [(function_scope_id, _function_scope)] = index
+            .child_scopes(FileScopeId::global())
+            .collect::<Vec<_>>()[..]
+        else {
+            panic!("Expected a function scope")
+        };
+
+        let function_table = index.symbol_table(function_scope_id);
+        assert_eq!(names(&function_table), vec!["x"],);
+
+        let use_def = index.use_def_map(function_scope_id);
+        let definition = use_def
+            .first_public_definition(
+                function_table
+                    .symbol_id_by_name("x")
+                    .expect("symbol exists"),
+            )
+            .unwrap();
+        assert!(matches!(
+            definition.node(&db),
+            DefinitionKind::ParameterWithDefault(_)
+        ));
+    }
+
+    #[test]
     fn lambda_parameter_symbols() {
         let TestCase { db, file } = test_case("lambda a, b, c=1, *args, d=2, **kwargs: None");
 

--- a/crates/red_knot_python_semantic/src/semantic_index.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index.rs
@@ -575,7 +575,7 @@ def f(a: str, /, b: str, c: int = 1, *args, d: int = 2, **kwargs):
         let index = semantic_index(&db, file);
         let global_table = symbol_table(&db, global_scope(&db, file));
 
-        assert_eq!(names(&global_table), vec!["f", "str", "int"]);
+        assert_eq!(names(&global_table), vec!["str", "int", "f"]);
 
         let [(function_scope_id, _function_scope)] = index
             .child_scopes(FileScopeId::global())

--- a/crates/red_knot_python_semantic/src/semantic_index/builder.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/builder.rs
@@ -412,11 +412,6 @@ where
                         builder.pop_scope()
                     },
                 );
-
-                let symbol = self
-                    .add_or_update_symbol(function_def.name.id.clone(), SymbolFlags::IS_DEFINED);
-                self.add_definition(symbol, function_def);
-
                 // The default value of the parameters needs to be evaluated in the
                 // enclosing scope.
                 for default in function_def
@@ -426,6 +421,12 @@ where
                 {
                     self.visit_expr(default);
                 }
+                // The symbol for the function name itself has to be evaluated
+                // at the end to match the runtime evaluation of parameter defaults
+                // and return-type annotations.
+                let symbol = self
+                    .add_or_update_symbol(function_def.name.id.clone(), SymbolFlags::IS_DEFINED);
+                self.add_definition(symbol, function_def);
             }
             ast::Stmt::ClassDef(class) => {
                 for decorator in &class.decorator_list {

--- a/crates/red_knot_python_semantic/src/semantic_index/builder.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/builder.rs
@@ -392,20 +392,6 @@ where
                     self.visit_decorator(decorator);
                 }
 
-                let symbol = self
-                    .add_or_update_symbol(function_def.name.id.clone(), SymbolFlags::IS_DEFINED);
-                self.add_definition(symbol, function_def);
-
-                // The default value of the parameters needs to be evaluated in the
-                // enclosing scope.
-                for default in function_def
-                    .parameters
-                    .iter_non_variadic_params()
-                    .filter_map(|param| param.default.as_deref())
-                {
-                    self.visit_expr(default);
-                }
-
                 self.with_type_params(
                     NodeWithScopeRef::FunctionTypeParameters(function_def),
                     function_def.type_params.as_deref(),
@@ -426,6 +412,20 @@ where
                         builder.pop_scope()
                     },
                 );
+
+                let symbol = self
+                    .add_or_update_symbol(function_def.name.id.clone(), SymbolFlags::IS_DEFINED);
+                self.add_definition(symbol, function_def);
+
+                // The default value of the parameters needs to be evaluated in the
+                // enclosing scope.
+                for default in function_def
+                    .parameters
+                    .iter_non_variadic_params()
+                    .filter_map(|param| param.default.as_deref())
+                {
+                    self.visit_expr(default);
+                }
             }
             ast::Stmt::ClassDef(class) => {
                 for decorator in &class.decorator_list {

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -368,9 +368,9 @@ impl<'db> TypeInferenceBuilder<'db> {
         let Some(type_params) = function.type_params.as_deref() else {
             panic!("function type params scope without type params");
         };
+        self.infer_optional_expression(function.returns.as_deref());
         self.infer_type_parameters(type_params);
         self.infer_parameters(&function.parameters);
-        self.infer_optional_expression(function.returns.as_deref());
     }
 
     fn infer_function_body(&mut self, function: &ast::StmtFunctionDef) {

--- a/crates/red_knot_workspace/resources/test/corpus/25_func_annotations_same_name.py
+++ b/crates/red_knot_workspace/resources/test/corpus/25_func_annotations_same_name.py
@@ -1,0 +1,2 @@
+def bool(x) -> bool:
+    return True

--- a/crates/red_knot_workspace/resources/test/corpus/25_func_annotations_same_name.py
+++ b/crates/red_knot_workspace/resources/test/corpus/25_func_annotations_same_name.py
@@ -1,2 +1,11 @@
 def bool(x) -> bool:
     return True
+
+
+class MyClass: ...
+
+
+def MyClass() -> MyClass: ...
+
+
+def x(self) -> x: ...

--- a/crates/red_knot_workspace/resources/test/corpus/26_func_defaults_same_name.py
+++ b/crates/red_knot_workspace/resources/test/corpus/26_func_defaults_same_name.py
@@ -1,0 +1,2 @@
+def bool(x=bool):
+    return x


### PR DESCRIPTION
This PR has the `SemanticIndexBuilder` visit function definition annotations before adding the function symbol/name to the builder.

For example, the following snippet no longer causes a panic:

```python
def bool(x) -> bool:
    Return True
```

Note: This fix changes the ordering of the global symbol table.

Closes #13069