### PR TITLE
Format docs with ruff formatter

### DIFF
--- a/crates/ruff_linter/src/rules/pylint/rules/invalid_string_characters.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/invalid_string_characters.rs
@@ -57,7 +57,7 @@ impl AlwaysFixableViolation for InvalidCharacterBackspace {
 ///
 /// Use instead:
 /// ```python
-/// x = "\x1A"
+/// x = "\x1a"
 /// ```
 #[violation]
 pub struct InvalidCharacterSub;
@@ -90,7 +90,7 @@ impl AlwaysFixableViolation for InvalidCharacterSub {
 ///
 /// Use instead:
 /// ```python
-/// x = "\x1B"
+/// x = "\x1b"
 /// ```
 #[violation]
 pub struct InvalidCharacterEsc;
@@ -155,7 +155,7 @@ impl AlwaysFixableViolation for InvalidCharacterNul {
 ///
 /// Use instead:
 /// ```python
-/// x = "Dear Sir\u200B/\u200BMadam"  # zero width space
+/// x = "Dear Sir\u200b/\u200bMadam"  # zero width space
 /// ```
 #[violation]
 pub struct InvalidCharacterZeroWidthSpace;

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,4 @@
 PyYAML==6.0.2
-black==24.8.0
 mkdocs==1.6.0
 mkdocs-material==9.1.18
 mkdocs-redirects==1.2.1

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,5 @@
 PyYAML==6.0.2
+ruff==0.6.2
 mkdocs==1.6.0
 mkdocs-material==9.1.18
 mkdocs-redirects==1.2.1

--- a/scripts/check_docs_formatted.py
+++ b/scripts/check_docs_formatted.py
@@ -15,7 +15,6 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
-TARGET_VERSIONS = ["py37", "py38", "py39", "py310", "py311"]
 SNIPPED_RE = re.compile(
     r"(?P<before>^(?P<indent> *)```\s*python\n)"
     r"(?P<code>.*?)"

--- a/scripts/check_docs_formatted.py
+++ b/scripts/check_docs_formatted.py
@@ -11,8 +11,7 @@ from pathlib import Path
 from re import Match
 from typing import TYPE_CHECKING
 
-from black import FileMode
-from black import format_str as black_format_str
+from black import FileMode, format_str
 from black.mode import Mode, TargetVersion
 from black.parsing import InvalidInput
 
@@ -120,17 +119,17 @@ class CodeBlockError(Exception):
     """A code block parse error."""
 
 
-def format_str(
+def format_contents(
     src: str,
     black_mode: FileMode,
 ) -> tuple[str, Sequence[CodeBlockError]]:
-    """Format a single docs file string."""
+    """Format a single docs content."""
     errors: list[CodeBlockError] = []
 
     def _snipped_match(match: Match[str]) -> str:
         code = textwrap.dedent(match["code"])
         try:
-            code = black_format_str(code, mode=black_mode)
+            code = format_str(code, mode=black_mode)
         except InvalidInput as e:
             errors.append(CodeBlockError(e))
 
@@ -171,7 +170,7 @@ def format_file(
     # Remove everything after the last example
     contents = contents[: contents.rfind("```")] + "```"
 
-    new_contents, errors = format_str(contents, black_mode)
+    new_contents, errors = format_contents(contents, black_mode)
 
     if errors and not args.skip_errors and not error_known:
         for error in errors:

--- a/scripts/check_docs_formatted.py
+++ b/scripts/check_docs_formatted.py
@@ -111,8 +111,6 @@ KNOWN_PARSE_ERRORS = [
     "unexpected-indentation",
 ]
 
-ROOT_DIR = Path(__file__).resolve().parent.parent
-
 
 class CodeBlockError(Exception):
     """A code block parse error."""
@@ -127,8 +125,7 @@ def format_str(code: str) -> str:
     # Run ruff to format the tmp file
     try:
         completed_process = subprocess.run(
-            ["./target/debug/ruff", "format", "-"],
-            cwd=ROOT_DIR,
+            ["ruff", "format", "-"],
             check=True,
             capture_output=True,
             text=True,
@@ -279,11 +276,6 @@ def main(argv: Sequence[str] | None = None) -> int:
             print("\n".join([f"  - {x}" for x in duplicates]))
             print("Please remove them and re-run.")
             return 1
-
-    # Build ruff
-    print("Building ruff, this may take a some time...")
-    subprocess.run(["cargo", "build"], cwd=ROOT_DIR, check=True)
-    print("Ruff build complete.")
 
     violations = 0
     errors = 0

--- a/scripts/check_docs_formatted.py
+++ b/scripts/check_docs_formatted.py
@@ -264,6 +264,7 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     violations = 0
     errors = 0
+    print("Checking docs formatting...")
     for file in [*static_docs, *generated_docs]:
         rule_name = file.name.split(".")[0]
         if rule_name in KNOWN_FORMATTING_VIOLATIONS:
@@ -285,6 +286,8 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     if violations > 0 or errors > 0:
         return 1
+
+    print("All docs are formatted correctly.")
 
     return 0
 

--- a/scripts/check_docs_formatted.py
+++ b/scripts/check_docs_formatted.py
@@ -132,6 +132,8 @@ def format_contents(
             code = format_str(code, mode=black_mode)
         except InvalidInput as e:
             errors.append(CodeBlockError(e))
+        except NotImplementedError as e:
+            raise e
 
         code = textwrap.indent(code, match["indent"])
         return f'{match["before"]}{code}{match["after"]}'

--- a/scripts/check_docs_formatted.py
+++ b/scripts/check_docs_formatted.py
@@ -11,7 +11,8 @@ from pathlib import Path
 from re import Match
 from typing import TYPE_CHECKING
 
-import black
+from black import FileMode
+from black import format_str as black_format_str
 from black.mode import Mode, TargetVersion
 from black.parsing import InvalidInput
 
@@ -121,7 +122,7 @@ class CodeBlockError(Exception):
 
 def format_str(
     src: str,
-    black_mode: black.FileMode,
+    black_mode: FileMode,
 ) -> tuple[str, Sequence[CodeBlockError]]:
     """Format a single docs file string."""
     errors: list[CodeBlockError] = []
@@ -129,7 +130,7 @@ def format_str(
     def _snipped_match(match: Match[str]) -> str:
         code = textwrap.dedent(match["code"])
         try:
-            code = black.format_str(code, mode=black_mode)
+            code = black_format_str(code, mode=black_mode)
         except InvalidInput as e:
             errors.append(CodeBlockError(e))
 
@@ -142,7 +143,7 @@ def format_str(
 
 def format_file(
     file: Path,
-    black_mode: black.FileMode,
+    black_mode: FileMode,
     error_known: bool,
     args: argparse.Namespace,
 ) -> int:


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Now that Ruff provides a formatter, there is no need to rely on Black to check that the docs are formatted correctly in `check_docs_formatted.py`. This PR swaps out Black for the Ruff formatter and updates inconsistencies between the two. 

This PR will be a precursor to another PR ([branch](https://github.com/calumy/ruff/tree/format-pyi-in-docs)), updating the `check_docs_formatted.py` script to check for pyi files, fixing #11568.

## Test Plan

- CI to check that the docs are formatted correctly using the updated script.
