### PR TITLE
[`pylint`] - fix incorrect starred expression replacement for `nested-min-max` (`PLW3301`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pylint/nested_min_max.py
+++ b/crates/ruff_linter/resources/test/fixtures/pylint/nested_min_max.py
@@ -43,7 +43,15 @@ max(1, max(*a))
 import builtins
 builtins.min(1, min(2, 3))
 
-max_word_len = max( # OK
+
+# PLW3301
+max_word_len = max(
+    max(len(word) for word in "blah blah blah".split(" ")),
+    len("Done!"),
+)
+
+# OK
+max_word_len = max(
     *(len(word) for word in "blah blah blah".split(" ")),
     len("Done!"),
 )

--- a/crates/ruff_linter/resources/test/fixtures/pylint/nested_min_max.py
+++ b/crates/ruff_linter/resources/test/fixtures/pylint/nested_min_max.py
@@ -42,3 +42,8 @@ max(1, max(*a))
 
 import builtins
 builtins.min(1, min(2, 3))
+
+max_word_len = max( # OK
+    *(len(word) for word in "blah blah blah".split(" ")),
+    len("Done!"),
+)

--- a/crates/ruff_linter/src/rules/pylint/rules/nested_min_max.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/nested_min_max.rs
@@ -101,18 +101,18 @@ fn collect_nested_args(min_max: MinMax, args: &[Expr], semantic: &SemanticModel)
                 range: _,
             }) = arg
             {
-                if let [arg] = &**args {
-                    if arg.as_starred_expr().is_none() {
-                        let new_arg = Expr::Starred(ast::ExprStarred {
-                            value: Box::new(arg.clone()),
-                            ctx: ast::ExprContext::Load,
-                            range: TextRange::default(),
-                        });
-                        new_args.push(new_arg);
-                        continue;
-                    }
-                }
                 if MinMax::try_from_call(func, keywords, semantic) == Some(min_max) {
+                    if let [arg] = &**args {
+                        if arg.as_starred_expr().is_none() {
+                            let new_arg = Expr::Starred(ast::ExprStarred {
+                                value: Box::new(arg.clone()),
+                                ctx: ast::ExprContext::Load,
+                                range: TextRange::default(),
+                            });
+                            new_args.push(new_arg);
+                            continue;
+                        }
+                    }
                     inner(min_max, args, semantic, new_args);
                     continue;
                 }

--- a/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLW3301_nested_min_max.py.snap
+++ b/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLW3301_nested_min_max.py.snap
@@ -303,8 +303,6 @@ nested_min_max.py:44:1: PLW3301 [*] Nested `min` calls can be flattened
 43 | import builtins
 44 | builtins.min(1, min(2, 3))
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^ PLW3301
-45 | 
-46 | max_word_len = max( # OK
    |
    = help: Flatten nested `min` calls
 
@@ -315,5 +313,32 @@ nested_min_max.py:44:1: PLW3301 [*] Nested `min` calls can be flattened
 44    |-builtins.min(1, min(2, 3))
    44 |+builtins.min(1, 2, 3)
 45 45 | 
-46 46 | max_word_len = max( # OK
-47 47 |     *(len(word) for word in "blah blah blah".split(" ")),
+46 46 | 
+47 47 | # PLW3301
+
+nested_min_max.py:48:16: PLW3301 [*] Nested `max` calls can be flattened
+   |
+47 |   # PLW3301
+48 |   max_word_len = max(
+   |  ________________^
+49 | |     max(len(word) for word in "blah blah blah".split(" ")),
+50 | |     len("Done!"),
+51 | | )
+   | |_^ PLW3301
+52 |   
+53 |   # OK
+   |
+   = help: Flatten nested `max` calls
+
+ℹ Unsafe fix
+45 45 | 
+46 46 | 
+47 47 | # PLW3301
+48    |-max_word_len = max(
+49    |-    max(len(word) for word in "blah blah blah".split(" ")),
+50    |-    len("Done!"),
+51    |-)
+   48 |+max_word_len = max(*(len(word) for word in "blah blah blah".split(" ")), len("Done!"))
+52 49 | 
+53 50 | # OK
+54 51 | max_word_len = max(

--- a/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLW3301_nested_min_max.py.snap
+++ b/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLW3301_nested_min_max.py.snap
@@ -303,6 +303,8 @@ nested_min_max.py:44:1: PLW3301 [*] Nested `min` calls can be flattened
 43 | import builtins
 44 | builtins.min(1, min(2, 3))
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^ PLW3301
+45 | 
+46 | max_word_len = max( # OK
    |
    = help: Flatten nested `min` calls
 
@@ -312,3 +314,6 @@ nested_min_max.py:44:1: PLW3301 [*] Nested `min` calls can be flattened
 43 43 | import builtins
 44    |-builtins.min(1, min(2, 3))
    44 |+builtins.min(1, 2, 3)
+45 45 | 
+46 46 | max_word_len = max( # OK
+47 47 |     *(len(word) for word in "blah blah blah".split(" ")),


### PR DESCRIPTION
## Summary

Moves the min/max detection up, and fixes #13088 

## Test Plan

`cargo test`