### PR TITLE
[`flake8-pytest-style`] Improve help message for `pytest-incorrect-mark-parentheses-style` (`PT023`)

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_pytest_style/rules/fixture.rs
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/rules/fixture.rs
@@ -606,7 +606,7 @@ impl AlwaysFixableViolation for PytestUnnecessaryAsyncioMarkOnFixture {
 }
 
 #[derive(Debug, PartialEq, Eq)]
-enum Parentheses {
+pub(crate) enum Parentheses {
     None,
     Empty,
 }

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/rules/fixture.rs
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/rules/fixture.rs
@@ -1,5 +1,3 @@
-use std::fmt;
-
 use ruff_diagnostics::{AlwaysFixableViolation, Violation};
 use ruff_diagnostics::{Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
@@ -20,6 +18,7 @@ use crate::registry::Rule;
 
 use super::helpers::{
     get_mark_decorators, is_pytest_fixture, is_pytest_yield_fixture, keyword_is_literal,
+    Parentheses,
 };
 
 /// ## What it does
@@ -602,21 +601,6 @@ impl AlwaysFixableViolation for PytestUnnecessaryAsyncioMarkOnFixture {
 
     fn fix_title(&self) -> String {
         "Remove `pytest.mark.asyncio`".to_string()
-    }
-}
-
-#[derive(Debug, PartialEq, Eq)]
-pub(crate) enum Parentheses {
-    None,
-    Empty,
-}
-
-impl fmt::Display for Parentheses {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            Parentheses::None => fmt.write_str(""),
-            Parentheses::Empty => fmt.write_str("()"),
-        }
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/rules/helpers.rs
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/rules/helpers.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use ruff_python_ast::helpers::map_callable;
 use ruff_python_ast::name::UnqualifiedName;
 use ruff_python_ast::{self as ast, Decorator, Expr, Keyword};
@@ -92,4 +94,19 @@ pub(super) fn split_names(names: &str) -> Vec<&str> {
             }
         })
         .collect::<Vec<&str>>()
+}
+
+#[derive(Debug, PartialEq, Eq, Copy, Clone)]
+pub(super) enum Parentheses {
+    None,
+    Empty,
+}
+
+impl fmt::Display for Parentheses {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Parentheses::None => fmt.write_str(""),
+            Parentheses::Empty => fmt.write_str("()"),
+        }
+    }
 }

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/rules/marks.rs
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/rules/marks.rs
@@ -6,9 +6,8 @@ use ruff_text_size::Ranged;
 
 use crate::checkers::ast::Checker;
 use crate::registry::Rule;
-use crate::rules::flake8_pytest_style::rules::fixture::Parentheses;
 
-use super::helpers::get_mark_decorators;
+use super::helpers::{get_mark_decorators, Parentheses};
 
 /// ## What it does
 /// Checks for argument-free `@pytest.mark.<marker>()` decorators with or
@@ -72,11 +71,7 @@ impl AlwaysFixableViolation for PytestIncorrectMarkParenthesesStyle {
     }
 
     fn fix_title(&self) -> String {
-        let PytestIncorrectMarkParenthesesStyle {
-            expected_parens: expected,
-            ..
-        } = self;
-        match expected {
+        match &self.expected_parens {
             Parentheses::None => "Remove parentheses".to_string(),
             Parentheses::Empty => "Add parentheses".to_string(),
         }

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/snapshots/ruff_linter__rules__flake8_pytest_style__tests__PT023_default.snap
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/snapshots/ruff_linter__rules__flake8_pytest_style__tests__PT023_default.snap
@@ -8,7 +8,7 @@ PT023.py:46:1: PT023 [*] Use `@pytest.mark.foo` over `@pytest.mark.foo()`
 47 | def test_something():
 48 |     pass
    |
-   = help: Add/remove parentheses
+   = help: Remove parentheses
 
 ℹ Safe fix
 43 43 | # With parentheses
@@ -27,7 +27,7 @@ PT023.py:51:1: PT023 [*] Use `@pytest.mark.foo` over `@pytest.mark.foo()`
 52 | class TestClass:
 53 |     def test_something():
    |
-   = help: Add/remove parentheses
+   = help: Remove parentheses
 
 ℹ Safe fix
 48 48 |     pass
@@ -47,7 +47,7 @@ PT023.py:58:5: PT023 [*] Use `@pytest.mark.foo` over `@pytest.mark.foo()`
 59 |     def test_something():
 60 |         pass
    |
-   = help: Add/remove parentheses
+   = help: Remove parentheses
 
 ℹ Safe fix
 55 55 | 
@@ -67,7 +67,7 @@ PT023.py:64:5: PT023 [*] Use `@pytest.mark.foo` over `@pytest.mark.foo()`
 65 |     class TestNestedClass:
 66 |         def test_something():
    |
-   = help: Add/remove parentheses
+   = help: Remove parentheses
 
 ℹ Safe fix
 61 61 | 
@@ -88,7 +88,7 @@ PT023.py:72:9: PT023 [*] Use `@pytest.mark.foo` over `@pytest.mark.foo()`
 73 |         def test_something():
 74 |             pass
    |
-   = help: Add/remove parentheses
+   = help: Remove parentheses
 
 ℹ Safe fix
 69 69 | 

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/snapshots/ruff_linter__rules__flake8_pytest_style__tests__PT023_parentheses.snap
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/snapshots/ruff_linter__rules__flake8_pytest_style__tests__PT023_parentheses.snap
@@ -8,7 +8,7 @@ PT023.py:12:1: PT023 [*] Use `@pytest.mark.foo()` over `@pytest.mark.foo`
 13 | def test_something():
 14 |     pass
    |
-   = help: Add/remove parentheses
+   = help: Add parentheses
 
 ℹ Safe fix
 9  9  | # Without parentheses
@@ -27,7 +27,7 @@ PT023.py:17:1: PT023 [*] Use `@pytest.mark.foo()` over `@pytest.mark.foo`
 18 | class TestClass:
 19 |     def test_something():
    |
-   = help: Add/remove parentheses
+   = help: Add parentheses
 
 ℹ Safe fix
 14 14 |     pass
@@ -47,7 +47,7 @@ PT023.py:24:5: PT023 [*] Use `@pytest.mark.foo()` over `@pytest.mark.foo`
 25 |     def test_something():
 26 |         pass
    |
-   = help: Add/remove parentheses
+   = help: Add parentheses
 
 ℹ Safe fix
 21 21 | 
@@ -67,7 +67,7 @@ PT023.py:30:5: PT023 [*] Use `@pytest.mark.foo()` over `@pytest.mark.foo`
 31 |     class TestNestedClass:
 32 |         def test_something():
    |
-   = help: Add/remove parentheses
+   = help: Add parentheses
 
 ℹ Safe fix
 27 27 | 
@@ -88,7 +88,7 @@ PT023.py:38:9: PT023 [*] Use `@pytest.mark.foo()` over `@pytest.mark.foo`
 39 |         def test_something():
 40 |             pass
    |
-   = help: Add/remove parentheses
+   = help: Add parentheses
 
 ℹ Safe fix
 35 35 | 


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

This PR updates the `PT023` error to align with `PT001`, explicitly stating whether the parentheses need to be added or removed. Fixes #13010.

## Test Plan

See updated snapshots
