### PR TITLE
[`flake8-simplify`] - extend open-file-with-context-handler to work with dbm.sqlite3 (`SIM115`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_simplify/SIM115.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_simplify/SIM115.py
@@ -243,3 +243,16 @@ def aliased():
     from tarfile import TarFile as TF
     f = TF("foo").open()
     f.close()
+
+import dbm.sqlite3
+
+# OK
+with dbm.sqlite3.open("foo.db") as f:
+    print(f.keys())
+
+# OK
+dbm.sqlite3.open("foo.db").close()
+
+# SIM115
+f = dbm.sqlite3.open("foo.db")
+f.close()

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/open_file_with_context_handler.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/open_file_with_context_handler.rs
@@ -165,7 +165,7 @@ fn is_open_preview(semantic: &SemanticModel, call: &ast::ExprCall) -> bool {
                     | "tokenize"
                     | "wave",
                 "open"
-            ] | ["dbm", "gnu" | "ndbm" | "dumb", "open"]
+            ] | ["dbm", "gnu" | "ndbm" | "dumb" | "sqlite3", "open"]
                 | ["fileinput", "FileInput" | "input"]
                 | ["io", "open" | "open_code"]
                 | ["lzma", "LZMAFile" | "open"]

--- a/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__preview__SIM115_SIM115.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__preview__SIM115_SIM115.py.snap
@@ -324,3 +324,11 @@ SIM115.py:244:9: SIM115 Use a context manager for opening files
     |         ^^^^^^^^^^^^^^ SIM115
 245 |     f.close()
     |
+
+SIM115.py:257:5: SIM115 Use a context manager for opening files
+    |
+256 | # SIM115
+257 | f = dbm.sqlite3.open("foo.db")
+    |     ^^^^^^^^^^^^^^^^ SIM115
+258 | f.close()
+    |


### PR DESCRIPTION
## Summary

Adds upcoming `dbm.sqlite3` to rule that suggests using context managers to open things with.

See: https://docs.python.org/3.13/library/dbm.html#module-dbm.sqlite3

## Test Plan

`cargo test`