### PR TITLE
[`ruff`] - extend comment deletions for unused-noqa (`RUF100`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/ruff/RUF100_5.py
+++ b/crates/ruff_linter/resources/test/fixtures/ruff/RUF100_5.py
@@ -9,3 +9,13 @@ dictionary = {
 
 
 #import os  # noqa: E501
+
+def f():
+    data = 1
+    # line below should autofix to `return data  # fmt: skip`
+    return data  # noqa: RET504 # fmt: skip
+
+def f():
+    data = 1
+    # line below should autofix to `return data`
+    return data  # noqa: RET504 - intentional incorrect noqa, will be removed

--- a/crates/ruff_linter/src/checkers/noqa.rs
+++ b/crates/ruff_linter/src/checkers/noqa.rs
@@ -8,7 +8,7 @@ use rustc_hash::FxHashSet;
 use ruff_diagnostics::{Diagnostic, Edit, Fix};
 use ruff_python_trivia::CommentRanges;
 use ruff_source_file::Locator;
-use ruff_text_size::{Ranged, TextRange};
+use ruff_text_size::Ranged;
 
 use crate::fix::edits::delete_comment;
 use crate::noqa::{
@@ -119,10 +119,8 @@ pub(crate) fn check_noqa(
                 Directive::All(directive) => {
                     if line.matches.is_empty() {
                         let edit = delete_comment(directive.range(), locator);
-                        let mut diagnostic = Diagnostic::new(
-                            UnusedNOQA { codes: None },
-                            TextRange::new(directive.start(), edit.end()),
-                        );
+                        let mut diagnostic =
+                            Diagnostic::new(UnusedNOQA { codes: None }, directive.range());
                         diagnostic.set_fix(Fix::safe_edit(edit));
 
                         diagnostics.push(diagnostic);
@@ -203,7 +201,7 @@ pub(crate) fn check_noqa(
                                         .collect(),
                                 }),
                             },
-                            TextRange::new(directive.start(), edit.end()),
+                            directive.range(),
                         );
                         diagnostic.set_fix(Fix::safe_edit(edit));
                         diagnostics.push(diagnostic);

--- a/crates/ruff_linter/src/fix/edits.rs
+++ b/crates/ruff_linter/src/fix/edits.rs
@@ -99,11 +99,8 @@ pub(crate) fn delete_comment(range: TextRange, locator: &Locator) -> Edit {
     }
     // Ex) `x = 1  # noqa here`
     else {
-        // Replace `# noqa here` with `# here`.
-        Edit::range_replacement(
-            "# ".to_string(),
-            TextRange::new(range.start(), range.end() + trailing_space_len),
-        )
+        // Remove `# noqa here` and whitespace
+        Edit::deletion(range.start() - leading_space_len, line_range.end())
     }
 }
 

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__ruf100_3.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__ruf100_3.snap
@@ -3,10 +3,11 @@ source: crates/ruff_linter/src/rules/ruff/mod.rs
 ---
 RUF100_3.py:1:1: RUF100 [*] Unused blanket `noqa` directive
   |
-1 | # noqa
-  | ^^^^^^ RUF100
-2 | # noqa # comment
-3 | print()  # noqa
+1 | / # noqa
+2 | | # noqa # comment
+  | |_^ RUF100
+3 |   print()  # noqa
+4 |   print()  # noqa # comment
   |
   = help: Remove unused `noqa` directive
 
@@ -20,7 +21,7 @@ RUF100_3.py:2:1: RUF100 [*] Unused blanket `noqa` directive
   |
 1 | # noqa
 2 | # noqa # comment
-  | ^^^^^^ RUF100
+  | ^^^^^^^ RUF100
 3 | print()  # noqa
 4 | print()  # noqa # comment
   |
@@ -59,7 +60,7 @@ RUF100_3.py:4:10: RUF100 [*] Unused blanket `noqa` directive
 2 | # noqa # comment
 3 | print()  # noqa
 4 | print()  # noqa # comment
-  |          ^^^^^^ RUF100
+  |          ^^^^^^^ RUF100
 5 | print()  # noqa  # comment
 6 | print()  # noqa comment
   |
@@ -80,7 +81,7 @@ RUF100_3.py:5:10: RUF100 [*] Unused blanket `noqa` directive
 3 | print()  # noqa
 4 | print()  # noqa # comment
 5 | print()  # noqa  # comment
-  |          ^^^^^^ RUF100
+  |          ^^^^^^^^ RUF100
 6 | print()  # noqa comment
 7 | print()  # noqa  comment
   |
@@ -101,7 +102,7 @@ RUF100_3.py:6:10: RUF100 [*] Unused blanket `noqa` directive
 4 | print()  # noqa # comment
 5 | print()  # noqa  # comment
 6 | print()  # noqa comment
-  |          ^^^^^^ RUF100
+  |          ^^^^^^^^^^^^^^ RUF100
 7 | print()  # noqa  comment
 8 | print(a)  # noqa
   |
@@ -112,7 +113,7 @@ RUF100_3.py:6:10: RUF100 [*] Unused blanket `noqa` directive
 4 4 | print()  # noqa # comment
 5 5 | print()  # noqa  # comment
 6   |-print()  # noqa comment
-  6 |+print()  # comment
+  6 |+print()
 7 7 | print()  # noqa  comment
 8 8 | print(a)  # noqa
 9 9 | print(a)  # noqa # comment
@@ -122,7 +123,7 @@ RUF100_3.py:7:10: RUF100 [*] Unused blanket `noqa` directive
 5 | print()  # noqa  # comment
 6 | print()  # noqa comment
 7 | print()  # noqa  comment
-  |          ^^^^^^ RUF100
+  |          ^^^^^^^^^^^^^^^ RUF100
 8 | print(a)  # noqa
 9 | print(a)  # noqa # comment
   |
@@ -133,19 +134,20 @@ RUF100_3.py:7:10: RUF100 [*] Unused blanket `noqa` directive
 5 5 | print()  # noqa  # comment
 6 6 | print()  # noqa comment
 7   |-print()  # noqa  comment
-  7 |+print()  # comment
+  7 |+print()
 8 8 | print(a)  # noqa
 9 9 | print(a)  # noqa # comment
 10 10 | print(a)  # noqa  # comment
 
 RUF100_3.py:14:1: RUF100 [*] Unused `noqa` directive (unused: `E501`, `F821`)
    |
-12 | print(a)  # noqa  comment
-13 | 
-14 | # noqa: E501, F821
-   | ^^^^^^^^^^^^^^^^^^ RUF100
-15 | # noqa: E501, F821 # comment
-16 | print()  # noqa: E501, F821
+12 |   print(a)  # noqa  comment
+13 |   
+14 | / # noqa: E501, F821
+15 | | # noqa: E501, F821 # comment
+   | |_^ RUF100
+16 |   print()  # noqa: E501, F821
+17 |   print()  # noqa: E501, F821 # comment
    |
    = help: Remove unused `noqa` directive
 
@@ -162,7 +164,7 @@ RUF100_3.py:15:1: RUF100 [*] Unused `noqa` directive (unused: `E501`, `F821`)
    |
 14 | # noqa: E501, F821
 15 | # noqa: E501, F821 # comment
-   | ^^^^^^^^^^^^^^^^^^ RUF100
+   | ^^^^^^^^^^^^^^^^^^^ RUF100
 16 | print()  # noqa: E501, F821
 17 | print()  # noqa: E501, F821 # comment
    |
@@ -204,7 +206,7 @@ RUF100_3.py:17:10: RUF100 [*] Unused `noqa` directive (unused: `E501`, `F821`)
 15 | # noqa: E501, F821 # comment
 16 | print()  # noqa: E501, F821
 17 | print()  # noqa: E501, F821 # comment
-   |          ^^^^^^^^^^^^^^^^^^ RUF100
+   |          ^^^^^^^^^^^^^^^^^^^ RUF100
 18 | print()  # noqa: E501, F821  # comment
 19 | print()  # noqa: E501, F821 comment
    |
@@ -225,7 +227,7 @@ RUF100_3.py:18:10: RUF100 [*] Unused `noqa` directive (unused: `E501`, `F821`)
 16 | print()  # noqa: E501, F821
 17 | print()  # noqa: E501, F821 # comment
 18 | print()  # noqa: E501, F821  # comment
-   |          ^^^^^^^^^^^^^^^^^^ RUF100
+   |          ^^^^^^^^^^^^^^^^^^^^ RUF100
 19 | print()  # noqa: E501, F821 comment
 20 | print()  # noqa: E501, F821  comment
    |
@@ -246,7 +248,7 @@ RUF100_3.py:19:10: RUF100 [*] Unused `noqa` directive (unused: `E501`, `F821`)
 17 | print()  # noqa: E501, F821 # comment
 18 | print()  # noqa: E501, F821  # comment
 19 | print()  # noqa: E501, F821 comment
-   |          ^^^^^^^^^^^^^^^^^^ RUF100
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^ RUF100
 20 | print()  # noqa: E501, F821  comment
 21 | print(a)  # noqa: E501, F821
    |
@@ -257,7 +259,7 @@ RUF100_3.py:19:10: RUF100 [*] Unused `noqa` directive (unused: `E501`, `F821`)
 17 17 | print()  # noqa: E501, F821 # comment
 18 18 | print()  # noqa: E501, F821  # comment
 19    |-print()  # noqa: E501, F821 comment
-   19 |+print()  # comment
+   19 |+print()
 20 20 | print()  # noqa: E501, F821  comment
 21 21 | print(a)  # noqa: E501, F821
 22 22 | print(a)  # noqa: E501, F821 # comment
@@ -267,7 +269,7 @@ RUF100_3.py:20:10: RUF100 [*] Unused `noqa` directive (unused: `E501`, `F821`)
 18 | print()  # noqa: E501, F821  # comment
 19 | print()  # noqa: E501, F821 comment
 20 | print()  # noqa: E501, F821  comment
-   |          ^^^^^^^^^^^^^^^^^^ RUF100
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^ RUF100
 21 | print(a)  # noqa: E501, F821
 22 | print(a)  # noqa: E501, F821 # comment
    |
@@ -278,7 +280,7 @@ RUF100_3.py:20:10: RUF100 [*] Unused `noqa` directive (unused: `E501`, `F821`)
 18 18 | print()  # noqa: E501, F821  # comment
 19 19 | print()  # noqa: E501, F821 comment
 20    |-print()  # noqa: E501, F821  comment
-   20 |+print()  # comment
+   20 |+print()
 21 21 | print(a)  # noqa: E501, F821
 22 22 | print(a)  # noqa: E501, F821 # comment
 23 23 | print(a)  # noqa: E501, F821  # comment
@@ -428,5 +430,3 @@ RUF100_3.py:28:39: RUF100 [*] Unused `noqa` directive (unused: `E501`)
 27 27 | print(a)  # comment with unicode µ    # noqa: E501
 28    |-print(a)  # comment with unicode µ    # noqa: E501, F821
    28 |+print(a)  # comment with unicode µ    # noqa: F821
-
-

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__ruf100_3.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__ruf100_3.snap
@@ -3,11 +3,10 @@ source: crates/ruff_linter/src/rules/ruff/mod.rs
 ---
 RUF100_3.py:1:1: RUF100 [*] Unused blanket `noqa` directive
   |
-1 | / # noqa
-2 | | # noqa # comment
-  | |_^ RUF100
-3 |   print()  # noqa
-4 |   print()  # noqa # comment
+1 | # noqa
+  | ^^^^^^ RUF100
+2 | # noqa # comment
+3 | print()  # noqa
   |
   = help: Remove unused `noqa` directive
 
@@ -21,7 +20,7 @@ RUF100_3.py:2:1: RUF100 [*] Unused blanket `noqa` directive
   |
 1 | # noqa
 2 | # noqa # comment
-  | ^^^^^^^ RUF100
+  | ^^^^^^ RUF100
 3 | print()  # noqa
 4 | print()  # noqa # comment
   |
@@ -60,7 +59,7 @@ RUF100_3.py:4:10: RUF100 [*] Unused blanket `noqa` directive
 2 | # noqa # comment
 3 | print()  # noqa
 4 | print()  # noqa # comment
-  |          ^^^^^^^ RUF100
+  |          ^^^^^^ RUF100
 5 | print()  # noqa  # comment
 6 | print()  # noqa comment
   |
@@ -81,7 +80,7 @@ RUF100_3.py:5:10: RUF100 [*] Unused blanket `noqa` directive
 3 | print()  # noqa
 4 | print()  # noqa # comment
 5 | print()  # noqa  # comment
-  |          ^^^^^^^^ RUF100
+  |          ^^^^^^ RUF100
 6 | print()  # noqa comment
 7 | print()  # noqa  comment
   |
@@ -102,7 +101,7 @@ RUF100_3.py:6:10: RUF100 [*] Unused blanket `noqa` directive
 4 | print()  # noqa # comment
 5 | print()  # noqa  # comment
 6 | print()  # noqa comment
-  |          ^^^^^^^^^^^^^^ RUF100
+  |          ^^^^^^ RUF100
 7 | print()  # noqa  comment
 8 | print(a)  # noqa
   |
@@ -123,7 +122,7 @@ RUF100_3.py:7:10: RUF100 [*] Unused blanket `noqa` directive
 5 | print()  # noqa  # comment
 6 | print()  # noqa comment
 7 | print()  # noqa  comment
-  |          ^^^^^^^^^^^^^^^ RUF100
+  |          ^^^^^^ RUF100
 8 | print(a)  # noqa
 9 | print(a)  # noqa # comment
   |
@@ -141,13 +140,12 @@ RUF100_3.py:7:10: RUF100 [*] Unused blanket `noqa` directive
 
 RUF100_3.py:14:1: RUF100 [*] Unused `noqa` directive (unused: `E501`, `F821`)
    |
-12 |   print(a)  # noqa  comment
-13 |   
-14 | / # noqa: E501, F821
-15 | | # noqa: E501, F821 # comment
-   | |_^ RUF100
-16 |   print()  # noqa: E501, F821
-17 |   print()  # noqa: E501, F821 # comment
+12 | print(a)  # noqa  comment
+13 | 
+14 | # noqa: E501, F821
+   | ^^^^^^^^^^^^^^^^^^ RUF100
+15 | # noqa: E501, F821 # comment
+16 | print()  # noqa: E501, F821
    |
    = help: Remove unused `noqa` directive
 
@@ -164,7 +162,7 @@ RUF100_3.py:15:1: RUF100 [*] Unused `noqa` directive (unused: `E501`, `F821`)
    |
 14 | # noqa: E501, F821
 15 | # noqa: E501, F821 # comment
-   | ^^^^^^^^^^^^^^^^^^^ RUF100
+   | ^^^^^^^^^^^^^^^^^^ RUF100
 16 | print()  # noqa: E501, F821
 17 | print()  # noqa: E501, F821 # comment
    |
@@ -206,7 +204,7 @@ RUF100_3.py:17:10: RUF100 [*] Unused `noqa` directive (unused: `E501`, `F821`)
 15 | # noqa: E501, F821 # comment
 16 | print()  # noqa: E501, F821
 17 | print()  # noqa: E501, F821 # comment
-   |          ^^^^^^^^^^^^^^^^^^^ RUF100
+   |          ^^^^^^^^^^^^^^^^^^ RUF100
 18 | print()  # noqa: E501, F821  # comment
 19 | print()  # noqa: E501, F821 comment
    |
@@ -227,7 +225,7 @@ RUF100_3.py:18:10: RUF100 [*] Unused `noqa` directive (unused: `E501`, `F821`)
 16 | print()  # noqa: E501, F821
 17 | print()  # noqa: E501, F821 # comment
 18 | print()  # noqa: E501, F821  # comment
-   |          ^^^^^^^^^^^^^^^^^^^^ RUF100
+   |          ^^^^^^^^^^^^^^^^^^ RUF100
 19 | print()  # noqa: E501, F821 comment
 20 | print()  # noqa: E501, F821  comment
    |
@@ -248,7 +246,7 @@ RUF100_3.py:19:10: RUF100 [*] Unused `noqa` directive (unused: `E501`, `F821`)
 17 | print()  # noqa: E501, F821 # comment
 18 | print()  # noqa: E501, F821  # comment
 19 | print()  # noqa: E501, F821 comment
-   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^ RUF100
+   |          ^^^^^^^^^^^^^^^^^^ RUF100
 20 | print()  # noqa: E501, F821  comment
 21 | print(a)  # noqa: E501, F821
    |
@@ -269,7 +267,7 @@ RUF100_3.py:20:10: RUF100 [*] Unused `noqa` directive (unused: `E501`, `F821`)
 18 | print()  # noqa: E501, F821  # comment
 19 | print()  # noqa: E501, F821 comment
 20 | print()  # noqa: E501, F821  comment
-   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^ RUF100
+   |          ^^^^^^^^^^^^^^^^^^ RUF100
 21 | print(a)  # noqa: E501, F821
 22 | print(a)  # noqa: E501, F821 # comment
    |

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__ruf100_5.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__ruf100_5.snap
@@ -62,7 +62,7 @@ RUF100_5.py:16:18: RUF100 [*] Unused `noqa` directive (non-enabled: `RET504`)
 14 |     data = 1
 15 |     # line below should autofix to `return data  # fmt: skip`
 16 |     return data  # noqa: RET504 # fmt: skip
-   |                  ^^^^^^^^^^^^^^^ RUF100
+   |                  ^^^^^^^^^^^^^^ RUF100
 17 | 
 18 | def f():
    |
@@ -83,7 +83,7 @@ RUF100_5.py:21:18: RUF100 [*] Unused `noqa` directive (non-enabled: `RET504`)
 19 |     data = 1
 20 |     # line below should autofix to `return data`
 21 |     return data  # noqa: RET504 - intentional incorrect noqa, will be removed
-   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ RUF100
+   |                  ^^^^^^^^^^^^^^ RUF100
    |
    = help: Remove unused `noqa` directive
 

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__ruf100_5.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__ruf100_5.snap
@@ -24,6 +24,8 @@ RUF100_5.py:11:1: ERA001 Found commented-out code
    |
 11 | #import os  # noqa: E501
    | ^^^^^^^^^^^^^^^^^^^^^^^^ ERA001
+12 | 
+13 | def f():
    |
    = help: Remove commented-out code
 
@@ -32,11 +34,16 @@ RUF100_5.py:11:1: ERA001 Found commented-out code
 9  9  | 
 10 10 | 
 11    |-#import os  # noqa: E501
+12 11 | 
+13 12 | def f():
+14 13 |     data = 1
 
 RUF100_5.py:11:13: RUF100 [*] Unused `noqa` directive (unused: `E501`)
    |
 11 | #import os  # noqa: E501
    |             ^^^^^^^^^^^^ RUF100
+12 | 
+13 | def f():
    |
    = help: Remove unused `noqa` directive
 
@@ -46,5 +53,43 @@ RUF100_5.py:11:13: RUF100 [*] Unused `noqa` directive (unused: `E501`)
 10 10 | 
 11    |-#import os  # noqa: E501
    11 |+#import os
+12 12 | 
+13 13 | def f():
+14 14 |     data = 1
 
+RUF100_5.py:16:18: RUF100 [*] Unused `noqa` directive (non-enabled: `RET504`)
+   |
+14 |     data = 1
+15 |     # line below should autofix to `return data  # fmt: skip`
+16 |     return data  # noqa: RET504 # fmt: skip
+   |                  ^^^^^^^^^^^^^^^ RUF100
+17 | 
+18 | def f():
+   |
+   = help: Remove unused `noqa` directive
 
+ℹ Safe fix
+13 13 | def f():
+14 14 |     data = 1
+15 15 |     # line below should autofix to `return data  # fmt: skip`
+16    |-    return data  # noqa: RET504 # fmt: skip
+   16 |+    return data  # fmt: skip
+17 17 | 
+18 18 | def f():
+19 19 |     data = 1
+
+RUF100_5.py:21:18: RUF100 [*] Unused `noqa` directive (non-enabled: `RET504`)
+   |
+19 |     data = 1
+20 |     # line below should autofix to `return data`
+21 |     return data  # noqa: RET504 - intentional incorrect noqa, will be removed
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ RUF100
+   |
+   = help: Remove unused `noqa` directive
+
+ℹ Safe fix
+18 18 | def f():
+19 19 |     data = 1
+20 20 |     # line below should autofix to `return data`
+21    |-    return data  # noqa: RET504 - intentional incorrect noqa, will be removed
+   21 |+    return data


### PR DESCRIPTION
## Summary

Extends deletions for RUF100, deleting trailing text from noqa directives, while preserving upcoming comments on the same line if any.

In cases where it deletes a comment up to another comment on the same line, the whitespace between them is now shown to be in the autofix in the diagnostic as well. Leading whitespace before the removed comment is not, though.

Fixes #12251 

## Test Plan

`cargo test`