### PR TITLE
#12044 hardcoded_sql_expressions bug

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/hardcoded_sql_expression.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/hardcoded_sql_expression.rs
@@ -11,7 +11,7 @@ use ruff_text_size::Ranged;
 use crate::checkers::ast::Checker;
 
 static SQL_REGEX: Lazy<Regex> = Lazy::new(|| {
-    Regex::new(r"(?i)\b(select\s+.+\s*from\s|delete\s+from\s|(insert|replace)\s.+\svalues\s|update\s.+\sset\s)")
+    Regex::new(r"(?i)\b(select\s.+\s+from\s|delete\s+from\s|(insert|replace)\s.+\svalues\s|update\s.+\sset\s)")
         .unwrap()
 });
 

--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/hardcoded_sql_expression.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/hardcoded_sql_expression.rs
@@ -11,7 +11,7 @@ use ruff_text_size::Ranged;
 use crate::checkers::ast::Checker;
 
 static SQL_REGEX: Lazy<Regex> = Lazy::new(|| {
-    Regex::new(r"(?i)\b(select\s.+\sfrom\s|delete\s+from\s|(insert|replace)\s.+\svalues\s|update\s.+\sset\s)")
+    Regex::new(r"(?i)\b(select\s+.+\s*from\s|delete\s+from\s|(insert|replace)\s.+\svalues\s|update\s.+\sset\s)")
         .unwrap()
 });
 

--- a/tests/test.py
+++ b/tests/test.py
@@ -1,0 +1,42 @@
+def sql():
+    foo = "foo"
+
+    f"""
+SELECT {foo}
+    FROM bar
+    """
+
+    f"""
+    SELECT
+        {foo}
+    FROM bar
+    """
+
+    f"""
+    SELECT {foo}
+    FROM
+        bar
+    """
+
+
+foo = "foo"
+
+f"SELECT * FROM {foo}.table"
+
+
+f"""SELECT * FROM 
+{foo}.table
+"""
+
+f"""SELECT *
+FROM {foo}.table
+"""
+
+f"""
+SELECT *
+FROM {foo}.table
+"""
+
+
+f"SELECT\
+ * FROM {foo}.table"


### PR DESCRIPTION
## Summary
This PR tried to fix #12044 raised for identifying all patterns which will be classified as prone to sql injections. 

## Test Plan
Created  `tests/test.py` will statements included in bug issue to check the implementation identifies all patterns. 


With the current change, only 2 scenarios are getting caught. Below is the log
```shell
cargo run -p ruff -- check --select S tests/test.py --no-cache
   Compiling ruff v0.6.2 (/Users/santhosh/Projects/personal/ruff/crates/ruff)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 4.87s
     Running `target/debug/ruff check --select S tests/test.py --no-cache`
tests/test.py:24:1: S608 Possible SQL injection vector through string-based query construction
   |
22 | foo = "foo"
23 |
24 | f"SELECT * FROM {foo}.table"
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ S608
   |

tests/test.py:27:1: S608 Possible SQL injection vector through string-based query construction
   |
27 | / f"""SELECT * FROM
28 | | {foo}.table
29 | | """
   | |___^ S608
30 |
31 |   f"""SELECT *
   |

Found 2 errors.
```

While when testing at online regex platforms, it is matching all the possible pattern in the test file. Below is the screenshot. 
![Screenshot 2024-08-26 at 2 32 56 PM](https://github.com/user-attachments/assets/2848e84f-c0a0-4a22-bd6e-1d4342dd839b)
