### PR TITLE
Fixed benchmarking section in Contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -530,6 +530,8 @@ You can run the benchmarks with
 cargo benchmark
 ```
 
+`cargo benchmark` is an alias for `cargo bench -p ruff_benchmark --bench linter --bench formatter --`
+
 #### Benchmark-driven Development
 
 Ruff uses [Criterion.rs](https://bheisler.github.io/criterion.rs/book/) for benchmarks. You can use
@@ -568,7 +570,7 @@ cargo install critcmp
 
 #### Tips
 
-- Use `cargo bench -p ruff_benchmark <filter>` to only run specific benchmarks. For example: `cargo benchmark lexer`
+- Use `cargo bench -p ruff_benchmark <filter>` to only run specific benchmarks. For example: `cargo bench -p ruff_benchmark lexer`
     to only run the lexer benchmarks.
 - Use `cargo bench -p ruff_benchmark -- --quiet` for a more cleaned up output (without statistical relevance)
 - Use `cargo bench -p ruff_benchmark -- --quick` to get faster results (more prone to noise)


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Noticed there was a wrong tip on the Contributing guide, `cargo benchmark lexer` wouldn't run any benches.
Probably a missed update on #9535 

It may make sense to remove the `cargo benchmark` command from the guide altogether, but up to the mantainers.

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

No tests

<!-- How was it tested? -->
