### PR TITLE
Add time, tzinfo, and timezone as immutable function calls

### DIFF
--- a/crates/ruff_python_stdlib/src/typing.rs
+++ b/crates/ruff_python_stdlib/src/typing.rs
@@ -299,8 +299,10 @@ pub fn is_mutable_return_type(qualified_name: &[&str]) -> bool {
 pub fn is_immutable_return_type(qualified_name: &[&str]) -> bool {
     matches!(
         qualified_name,
-        ["datetime", "date" | "datetime" | "timedelta"]
-            | ["decimal", "Decimal"]
+        [
+            "datetime",
+            "date" | "datetime" | "time" | "timedelta" | "timezone" | "tzinfo"
+        ] | ["decimal", "Decimal"]
             | ["fractions", "Fraction"]
             | ["operator", "attrgetter" | "itemgetter" | "methodcaller"]
             | ["pathlib", "Path"]


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Currently, `datetime.datetime`, `datetime.date`, and `datetime.timedelta` are correctly flagged as immutable calls, and RUF009 does not complain about their use in dataclasses. But the `datetime` module features three more classes that are also immutable: `time`, `tzinfo`, and `timezone`. See [here](https://docs.python.org/3/library/datetime.html#available-types) for details. These are missing, and that causes a false positive for e.g. the following example:

```python
from dataclasses import dataclass
from datetime import time


@dataclass
class Test:
    test: time = time()
```

## Test Plan

<!-- How was it tested? -->

Not sure, I'm not all that familiar with Rust or the Ruff internals. How do I add tests for this? 😄 