### PR TITLE
red-knot: infer multiplication for strings and integers

### DIFF
--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -185,6 +185,10 @@ pub enum Type<'db> {
     StringLiteral(StringLiteralType<'db>),
     /// A bytes literal
     BytesLiteral(BytesLiteralType<'db>),
+    /// A literal string, like `StringLiteral`, but *without* the value.
+    ///
+    /// Useful for e.g. `1000000 * "hello"`.
+    LiteralString,
     // TODO protocols, callable types, overloads, generics, type vars
 }
 
@@ -280,7 +284,7 @@ impl<'db> Type<'db> {
                 Type::Unknown
             }
             Type::BooleanLiteral(_) => Type::Unknown,
-            Type::StringLiteral(_) => {
+            Type::StringLiteral(_) | Type::LiteralString => {
                 // TODO defer to Type::Instance(<str from typeshed>).member
                 Type::Unknown
             }

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -183,12 +183,11 @@ pub enum Type<'db> {
     BooleanLiteral(bool),
     /// A string literal
     StringLiteral(StringLiteralType<'db>),
+    /// A string known to originate only from literal values, but whose value is not known (unlike
+    /// `StringLiteral` above).
+    LiteralString,
     /// A bytes literal
     BytesLiteral(BytesLiteralType<'db>),
-    /// A literal string, like `StringLiteral`, but *without* the value.
-    ///
-    /// Useful for e.g. `1000000 * "hello"`.
-    LiteralString,
     // TODO protocols, callable types, overloads, generics, type vars
 }
 
@@ -284,8 +283,14 @@ impl<'db> Type<'db> {
                 Type::Unknown
             }
             Type::BooleanLiteral(_) => Type::Unknown,
-            Type::StringLiteral(_) | Type::LiteralString => {
-                // TODO defer to Type::Instance(<str from typeshed>).member
+            Type::StringLiteral(_) => {
+                // TODO defer to `typing.LiteralString`/`builtins.str` methods
+                // from typeshed's stubs
+                Type::Unknown
+            }
+            Type::LiteralString => {
+                // TODO defer to `typing.LiteralString`/`builtins.str` methods
+                // from typeshed's stubs
                 Type::Unknown
             }
             Type::BytesLiteral(_) => {
@@ -391,7 +396,7 @@ pub struct IntersectionType<'db> {
 #[salsa::interned]
 pub struct StringLiteralType<'db> {
     #[return_ref]
-    value: String,
+    value: Box<str>,
 }
 
 #[salsa::interned]

--- a/crates/red_knot_python_semantic/src/types/display.rs
+++ b/crates/red_knot_python_semantic/src/types/display.rs
@@ -46,6 +46,7 @@ impl Display for DisplayType<'_> {
                 r#"Literal["{}"]"#,
                 string.value(self.db).replace('"', r#"\""#)
             ),
+            Type::LiteralString => write!(f, "LiteralString"),
             Type::BytesLiteral(bytes) => {
                 let escape =
                     AsciiEscape::with_preferred_quote(bytes.value(self.db).as_ref(), Quote::Double);


### PR DESCRIPTION
## Summary

The resulting type when multiplying a string literal by an integer literal is one of two types:

- `StringLiteral`, in the case where it is a reasonably small resulting string (arbitrarily bounded here to 4096 bytes, roughly a page on many operating systems), including the fully expanded string.
- `LiteralString`, matching Pyright etc., for strings larger than that.

Additionally:

- Switch to using `Box<str>` instead of `String` for the internal value of `StringLiteral`, saving some non-trivial byte overhead (and keeping the total number of allocations the same).
- Be clearer and more accurate about which types we ought to defer to in `StringLiteral` and `LiteralString` member lookup.

## Test Plan

Added a test case covering multiplication times integers: positive,  negative, zero, and in and out of bounds.