### PR TITLE
Disable E741 in stub files

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pycodestyle/E741.pyi
+++ b/crates/ruff_linter/resources/test/fixtures/pycodestyle/E741.pyi
@@ -1,0 +1,75 @@
+from contextlib import contextmanager
+
+l = 0
+I = 0
+O = 0
+l: int = 0
+
+a, l = 0, 1
+[a, l] = 0, 1
+a, *l = 0, 1, 2
+a = l = 0
+
+o = 0
+i = 0
+
+for l in range(3):
+    pass
+
+
+for a, l in zip(range(3), range(3)):
+    pass
+
+
+def f1():
+    global l
+    l = 0
+
+
+def f2():
+    l = 0
+
+    def f3():
+        nonlocal l
+        l = 1
+
+    f3()
+    return l
+
+
+def f4(l, /, I):
+    return l, I, O
+
+
+def f5(l=0, *, I=1):
+    return l, I
+
+
+def f6(*l, **I):
+    return l, I
+
+
+@contextmanager
+def ctx1():
+    yield 0
+
+
+with ctx1() as l:
+    pass
+
+
+@contextmanager
+def ctx2():
+    yield 0, 1
+
+
+with ctx2() as (a, l):
+    pass
+
+try:
+    pass
+except ValueError as l:
+    pass
+
+if (l := 5) > 0:
+    pass

--- a/crates/ruff_linter/src/checkers/ast/analyze/except_handler.rs
+++ b/crates/ruff_linter/src/checkers/ast/analyze/except_handler.rs
@@ -1,4 +1,4 @@
-use ruff_python_ast::{self as ast, ExceptHandler};
+use ruff_python_ast::{self as ast, ExceptHandler, PySourceType};
 use ruff_text_size::Ranged;
 
 use crate::checkers::ast::Checker;
@@ -69,7 +69,9 @@ pub(crate) fn except_handler(except_handler: &ExceptHandler, checker: &mut Check
                 pylint::rules::binary_op_exception(checker, except_handler);
             }
             if let Some(name) = name {
-                if checker.enabled(Rule::AmbiguousVariableName) {
+                if checker.source_type != PySourceType::Stub
+                    && checker.enabled(Rule::AmbiguousVariableName)
+                {
                     if let Some(diagnostic) =
                         pycodestyle::rules::ambiguous_variable_name(name.as_str(), name.range())
                     {

--- a/crates/ruff_linter/src/checkers/ast/analyze/expression.rs
+++ b/crates/ruff_linter/src/checkers/ast/analyze/expression.rs
@@ -1,4 +1,4 @@
-use ruff_python_ast::{self as ast, Arguments, Expr, ExprContext, Operator};
+use ruff_python_ast::{self as ast, Arguments, Expr, ExprContext, Operator, PySourceType};
 use ruff_python_literal::cformat::{CFormatError, CFormatErrorType};
 
 use ruff_diagnostics::Diagnostic;
@@ -258,7 +258,9 @@ pub(crate) fn expression(expr: &Expr, checker: &mut Checker) {
                             );
                         }
                     }
-                    if checker.enabled(Rule::AmbiguousVariableName) {
+                    if checker.source_type != PySourceType::Stub
+                        && checker.enabled(Rule::AmbiguousVariableName)
+                    {
                         if let Some(diagnostic) =
                             pycodestyle::rules::ambiguous_variable_name(id, expr.range())
                         {

--- a/crates/ruff_linter/src/checkers/ast/analyze/parameter.rs
+++ b/crates/ruff_linter/src/checkers/ast/analyze/parameter.rs
@@ -1,4 +1,5 @@
 use ruff_python_ast::Parameter;
+use ruff_python_ast::PySourceType;
 use ruff_text_size::Ranged;
 
 use crate::checkers::ast::Checker;
@@ -7,7 +8,7 @@ use crate::rules::{flake8_builtins, pep8_naming, pycodestyle};
 
 /// Run lint rules over a [`Parameter`] syntax node.
 pub(crate) fn parameter(parameter: &Parameter, checker: &mut Checker) {
-    if checker.enabled(Rule::AmbiguousVariableName) {
+    if checker.source_type != PySourceType::Stub && checker.enabled(Rule::AmbiguousVariableName) {
         if let Some(diagnostic) =
             pycodestyle::rules::ambiguous_variable_name(&parameter.name, parameter.name.range())
         {

--- a/crates/ruff_linter/src/checkers/ast/analyze/statement.rs
+++ b/crates/ruff_linter/src/checkers/ast/analyze/statement.rs
@@ -1,7 +1,7 @@
 use ruff_diagnostics::Diagnostic;
 use ruff_python_ast::helpers;
 use ruff_python_ast::types::Node;
-use ruff_python_ast::{self as ast, Expr, Stmt};
+use ruff_python_ast::{self as ast, Expr, PySourceType, Stmt};
 use ruff_python_semantic::ScopeKind;
 use ruff_text_size::Ranged;
 
@@ -23,14 +23,18 @@ pub(crate) fn statement(stmt: &Stmt, checker: &mut Checker) {
             if checker.enabled(Rule::GlobalAtModuleLevel) {
                 pylint::rules::global_at_module_level(checker, stmt);
             }
-            if checker.enabled(Rule::AmbiguousVariableName) {
+            if checker.source_type != PySourceType::Stub
+                && checker.enabled(Rule::AmbiguousVariableName)
+            {
                 checker.diagnostics.extend(names.iter().filter_map(|name| {
                     pycodestyle::rules::ambiguous_variable_name(name, name.range())
                 }));
             }
         }
         Stmt::Nonlocal(nonlocal @ ast::StmtNonlocal { names, range: _ }) => {
-            if checker.enabled(Rule::AmbiguousVariableName) {
+            if checker.source_type != PySourceType::Stub
+                && checker.enabled(Rule::AmbiguousVariableName)
+            {
                 checker.diagnostics.extend(names.iter().filter_map(|name| {
                     pycodestyle::rules::ambiguous_variable_name(name, name.range())
                 }));

--- a/crates/ruff_linter/src/rules/pycodestyle/mod.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/mod.rs
@@ -26,6 +26,7 @@ mod tests {
     #[test_case(Rule::AmbiguousClassName, Path::new("E742.py"))]
     #[test_case(Rule::AmbiguousFunctionName, Path::new("E743.py"))]
     #[test_case(Rule::AmbiguousVariableName, Path::new("E741.py"))]
+    #[test_case(Rule::AmbiguousVariableName, Path::new("E741.pyi"))]
     #[test_case(Rule::LambdaAssignment, Path::new("E731.py"))]
     #[test_case(Rule::BareExcept, Path::new("E722.py"))]
     #[test_case(Rule::BlankLineWithWhitespace, Path::new("W29.py"))]

--- a/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E741_E741.pyi.snap
+++ b/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E741_E741.pyi.snap
@@ -1,0 +1,4 @@
+---
+source: crates/ruff_linter/src/rules/pycodestyle/mod.rs
+---
+


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

As noted in #10569, E741 should not be active in `.pyi` files as the file author does not control the variable name. Instead, this is deferred to the author of the package for which the stub file is substituting for.

My rust skills are being stretched here. I assume there is a more elegant way of implementing the check `checker.source_type != PySourceType::Stub` in the `ambiguous_variable_name` function so that it is only implemented in one place (similar to `non_unique_enums`); however, I can't get the borrow checker to agree to this.

## Test Plan

Added a new test case were `E741.py` was duplicated and renamed to `E741.pyi` and a snapshot to confirm that no errors were raised for this new case as E741 should be disabled in `.pyi` files. 
