### PR TITLE
Replace crates by dependi for VS Code Dev Container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -20,7 +20,7 @@
 			"extensions": [
 				"ms-python.python",
 				"rust-lang.rust-analyzer",
-				"serayuzgur.crates",
+				"fill-labs.dependi",
 				"tamasfe.even-better-toml",
 				"Swellaby.vscode-rust-test-adapter",
 				"charliermarsh.ruff"


### PR DESCRIPTION
## Summary
crates is now recommending migrating to dependi
![Screenshot from 2024-08-27 19-33-39](https://github.com/user-attachments/assets/c8f6480e-a07c-41a5-8bd0-d808c5a987a0)

## Test Plan
Opening dev-container installs correctly dependi
