### PR TITLE
Distinguish between maybe and no side effects in contains_effects()

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/ruff/RUF019.py
+++ b/crates/ruff_linter/resources/test/fixtures/ruff/RUF019.py
@@ -22,3 +22,12 @@ v = "k" in d and d["k"]
 
 if f() in d and d[f()]:
     pass
+
+if c.a in dct and dct[c.a]:
+    pass
+
+if f"{c}" in dct and dct[f"{c}"]:
+    pass
+
+if f"{c.a}" in dct and dct[f"{c.a}"]:
+    pass

--- a/crates/ruff_linter/resources/test/fixtures/ruff/RUF019.py
+++ b/crates/ruff_linter/resources/test/fixtures/ruff/RUF019.py
@@ -23,6 +23,8 @@ v = "k" in d and d["k"]
 if f() in d and d[f()]:
     pass
 
+# RUF019, unsafe fixes
+
 if c.a in dct and dct[c.a]:
     pass
 

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/useless_expression.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/useless_expression.rs
@@ -97,7 +97,7 @@ pub(crate) fn useless_expression(checker: &mut Checker, value: &Expr) {
     }
 
     // Ignore statements that have side effects.
-    if contains_effect(value, |id| checker.semantic().has_builtin_binding(id)) {
+    if contains_effect(value, |id| checker.semantic().has_builtin_binding(id)).is_yes() {
         // Flag attributes as useless expressions, even if they're attached to calls or other
         // expressions.
         if value.is_attribute_expr() {

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_bool_op.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_bool_op.rs
@@ -387,7 +387,7 @@ pub(crate) fn duplicate_isinstance_call(checker: &mut Checker, expr: &Expr) {
                 },
                 expr.range(),
             );
-            if !contains_effect(target, |id| checker.semantic().has_builtin_binding(id)) {
+            if !contains_effect(target, |id| checker.semantic().has_builtin_binding(id)).is_yes() {
                 // Grab the types used in each duplicate `isinstance` call (e.g., `int` and `str`
                 // in `isinstance(obj, int) or isinstance(obj, str)`).
                 let types: Vec<&Expr> = indices
@@ -526,10 +526,9 @@ pub(crate) fn compare_with_tuple(checker: &mut Checker, expr: &Expr) {
         let (indices, comparators): (Vec<_>, Vec<_>) = matches.iter().copied().unzip();
 
         // Avoid rewriting (e.g.) `a == "foo" or a == f()`.
-        if comparators
-            .iter()
-            .any(|expr| contains_effect(expr, |id| checker.semantic().has_builtin_binding(id)))
-        {
+        if comparators.iter().any(|expr| {
+            contains_effect(expr, |id| checker.semantic().has_builtin_binding(id)).is_yes()
+        }) {
             continue;
         }
 
@@ -625,7 +624,7 @@ pub(crate) fn expr_and_not_expr(checker: &mut Checker, expr: &Expr) {
         return;
     }
 
-    if contains_effect(expr, |id| checker.semantic().has_builtin_binding(id)) {
+    if contains_effect(expr, |id| checker.semantic().has_builtin_binding(id)).is_yes() {
         return;
     }
 
@@ -682,7 +681,7 @@ pub(crate) fn expr_or_not_expr(checker: &mut Checker, expr: &Expr) {
         return;
     }
 
-    if contains_effect(expr, |id| checker.semantic().has_builtin_binding(id)) {
+    if contains_effect(expr, |id| checker.semantic().has_builtin_binding(id)).is_yes() {
         return;
     }
 
@@ -766,7 +765,7 @@ fn is_short_circuit(
         // Keep track of the location of the furthest-right, non-effectful expression.
         if value_truthiness.is_unknown()
             && (!checker.semantic().in_boolean_test()
-                || contains_effect(value, |id| checker.semantic().has_builtin_binding(id)))
+                || contains_effect(value, |id| checker.semantic().has_builtin_binding(id)).is_yes())
         {
             furthest = next_value;
             continue;

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/if_else_block_instead_of_dict_get.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/if_else_block_instead_of_dict_get.rs
@@ -163,7 +163,9 @@ pub(crate) fn if_else_block_instead_of_dict_get(checker: &mut Checker, stmt_if: 
     // Check that the default value is not "complex".
     if contains_effect(default_value, |id| {
         checker.semantic().has_builtin_binding(id)
-    }) {
+    })
+    .is_yes()
+    {
         return;
     }
 
@@ -268,7 +270,9 @@ pub(crate) fn if_exp_instead_of_dict_get(
     // Check that the default value is not "complex".
     if contains_effect(default_value, |id| {
         checker.semantic().has_builtin_binding(id)
-    }) {
+    })
+    .is_yes()
+    {
         return;
     }
 

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/if_else_block_instead_of_dict_lookup.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/if_else_block_instead_of_dict_lookup.rs
@@ -78,7 +78,7 @@ pub(crate) fn if_else_block_instead_of_dict_lookup(checker: &mut Checker, stmt_i
     };
 
     if value.as_ref().is_some_and(|value| {
-        contains_effect(value, |id| checker.semantic().has_builtin_binding(id))
+        contains_effect(value, |id| checker.semantic().has_builtin_binding(id)).is_yes()
     }) {
         return;
     }
@@ -111,7 +111,7 @@ pub(crate) fn if_else_block_instead_of_dict_lookup(checker: &mut Checker, stmt_i
                     return;
                 };
                 if value.as_ref().is_some_and(|value| {
-                    contains_effect(value, |id| checker.semantic().has_builtin_binding(id))
+                    contains_effect(value, |id| checker.semantic().has_builtin_binding(id)).is_yes()
                 }) {
                     return;
                 };
@@ -137,7 +137,7 @@ pub(crate) fn if_else_block_instead_of_dict_lookup(checker: &mut Checker, stmt_i
                 };
 
                 if value.as_ref().is_some_and(|value| {
-                    contains_effect(value, |id| checker.semantic().has_builtin_binding(id))
+                    contains_effect(value, |id| checker.semantic().has_builtin_binding(id)).is_yes()
                 }) {
                     return;
                 };

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/if_else_block_instead_of_if_exp.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/if_else_block_instead_of_if_exp.rs
@@ -179,7 +179,8 @@ pub(crate) fn if_else_block_instead_of_if_exp(checker: &mut Checker, stmt_if: &a
                 if ComparableExpr::from(test_node) == ComparableExpr::from(body_node)
                     && !contains_effect(test_node, |id| {
                         checker.semantic().has_builtin_binding(id)
-                    }) =>
+                    })
+                    .is_yes() =>
             {
                 let target_var = &body_target;
                 let binary = assignment_binary_or(target_var, body_value, else_value);
@@ -194,7 +195,8 @@ pub(crate) fn if_else_block_instead_of_if_exp(checker: &mut Checker, stmt_if: &a
                         && ComparableExpr::from(&op_expr.operand) == ComparableExpr::from(test_node)
                 })) && !contains_effect(test_node, |id| {
                     checker.semantic().has_builtin_binding(id)
-                }) =>
+                })
+                .is_yes() =>
             {
                 let target_var = &body_target;
                 let binary = assignment_binary_and(target_var, body_value, else_value);

--- a/crates/ruff_linter/src/rules/pyflakes/rules/unused_variable.rs
+++ b/crates/ruff_linter/src/rules/pyflakes/rules/unused_variable.rs
@@ -159,6 +159,7 @@ fn remove_unused_variable(binding: &Binding, checker: &Checker) -> Option<Fix> {
             if target.is_name_expr() {
                 return if targets.len() > 1
                     || contains_effect(value, |id| checker.semantic().has_builtin_binding(id))
+                        .is_yes()
                 {
                     // If the expression is complex (`x = foo()`), remove the assignment,
                     // but preserve the right-hand side.
@@ -201,7 +202,9 @@ fn remove_unused_variable(binding: &Binding, checker: &Checker) -> Option<Fix> {
     }) = statement
     {
         if target.is_name_expr() {
-            return if contains_effect(value, |id| checker.semantic().has_builtin_binding(id)) {
+            return if contains_effect(value, |id| checker.semantic().has_builtin_binding(id))
+                .is_yes()
+            {
                 // If the expression is complex (`x = foo()`), remove the assignment,
                 // but preserve the right-hand side.
                 let start = statement.start();

--- a/crates/ruff_linter/src/rules/pylint/rules/repeated_equality_comparison.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/repeated_equality_comparison.rs
@@ -211,7 +211,7 @@ fn to_allowed_value<'a>(
         return None;
     }
 
-    if contains_effect(value, |id| semantic.has_builtin_binding(id)) {
+    if contains_effect(value, |id| semantic.has_builtin_binding(id)).is_yes() {
         return None;
     }
 

--- a/crates/ruff_linter/src/rules/refurb/rules/check_and_remove_from_set.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/check_and_remove_from_set.rs
@@ -89,7 +89,7 @@ pub(crate) fn check_and_remove_from_set(checker: &mut Checker, if_stmt: &ast::St
         // `element` in the check should be the same as `element` in the body
         || !compare(&check_element.into(), &remove_element.into())
         // `element` shouldn't have a side effect, otherwise we might change the semantics of the program.
-        || contains_effect(check_element, |id| checker.semantic().has_builtin_binding(id))
+        || contains_effect(check_element, |id| checker.semantic().has_builtin_binding(id)).is_yes()
     {
         return;
     }

--- a/crates/ruff_linter/src/rules/refurb/rules/if_exp_instead_of_or_operator.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/if_exp_instead_of_or_operator.rs
@@ -79,7 +79,7 @@ pub(crate) fn if_exp_instead_of_or_operator(checker: &mut Checker, if_expr: &ast
             ),
             if_expr.range(),
         ),
-        if contains_effect(body, |id| checker.semantic().has_builtin_binding(id)) {
+        if contains_effect(body, |id| checker.semantic().has_builtin_binding(id)).is_yes() {
             Applicability::Unsafe
         } else {
             Applicability::Safe

--- a/crates/ruff_linter/src/rules/refurb/rules/print_empty_string.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/print_empty_string.rs
@@ -250,7 +250,9 @@ impl EmptyStringFix {
                         return true;
                     }
 
-                    if contains_effect(&keyword.value, |id| semantic.has_builtin_binding(id)) {
+                    if contains_effect(&keyword.value, |id| semantic.has_builtin_binding(id))
+                        .is_yes()
+                    {
                         applicability = Applicability::Unsafe;
                     }
 

--- a/crates/ruff_linter/src/rules/ruff/mod.rs
+++ b/crates/ruff_linter/src/rules/ruff/mod.rs
@@ -384,6 +384,7 @@ mod tests {
     }
 
     #[test_case(Rule::ZipInsteadOfPairwise, Path::new("RUF007.py"))]
+    #[test_case(Rule::UnnecessaryKeyCheck, Path::new("RUF019.py"))]
     fn preview_rules(rule_code: Rule, path: &Path) -> Result<()> {
         let snapshot = format!(
             "preview__{}_{}",

--- a/crates/ruff_linter/src/rules/ruff/rules/unnecessary_key_check.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/unnecessary_key_check.rs
@@ -131,7 +131,7 @@ pub(crate) fn unnecessary_key_check(checker: &mut Checker, expr: &Expr) {
         ),
         expr.range(),
     );
-    diagnostic.set_fix(if is_fix_safe {
+    diagnostic.set_fix(if is_fix_safe || checker.settings.preview.is_disabled() {
         Fix::safe_edit(edit)
     } else {
         Fix::unsafe_edit(edit)

--- a/crates/ruff_linter/src/rules/ruff/rules/unnecessary_key_check.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/unnecessary_key_check.rs
@@ -3,7 +3,7 @@ use ruff_python_ast::{self as ast, BoolOp, CmpOp, Expr};
 
 use ruff_diagnostics::{AlwaysFixableViolation, Applicability, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
-use ruff_python_ast::helpers::{maybe_contains_effect, Maybe};
+use ruff_python_ast::helpers::{contains_effect, Maybe};
 use ruff_python_ast::parenthesize::parenthesized_range;
 use ruff_text_size::Ranged;
 
@@ -97,10 +97,9 @@ pub(crate) fn unnecessary_key_check(checker: &mut Checker, expr: &Expr) {
     }
 
     let applicability =
-        match maybe_contains_effect(obj_left, |id| checker.semantic().has_builtin_binding(id))
-            .merge(maybe_contains_effect(key_left, |id| {
-                checker.semantic().has_builtin_binding(id)
-            })) {
+        match contains_effect(obj_left, |id| checker.semantic().has_builtin_binding(id)).merge(
+            contains_effect(key_left, |id| checker.semantic().has_builtin_binding(id)),
+        ) {
             Maybe::Yes => return,
             Maybe::Maybe => {
                 if checker.settings.preview.is_enabled() {

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF019_RUF019.py.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF019_RUF019.py.snap
@@ -120,3 +120,61 @@ RUF019.py:18:6: RUF019 [*] Unnecessary key check before dictionary access
 19 19 | 
 20 20 | # OK
 21 21 | v = "k" in d and d["k"]
+
+RUF019.py:26:4: RUF019 [*] Unnecessary key check before dictionary access
+   |
+24 |     pass
+25 | 
+26 | if c.a in dct and dct[c.a]:
+   |    ^^^^^^^^^^^^^^^^^^^^^^^ RUF019
+27 |     pass
+   |
+   = help: Replace with `dict.get`
+
+ℹ Unsafe fix
+23 23 | if f() in d and d[f()]:
+24 24 |     pass
+25 25 | 
+26    |-if c.a in dct and dct[c.a]:
+   26 |+if dct.get(c.a):
+27 27 |     pass
+28 28 | 
+29 29 | if f"{c}" in dct and dct[f"{c}"]:
+
+RUF019.py:29:4: RUF019 [*] Unnecessary key check before dictionary access
+   |
+27 |     pass
+28 | 
+29 | if f"{c}" in dct and dct[f"{c}"]:
+   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ RUF019
+30 |     pass
+   |
+   = help: Replace with `dict.get`
+
+ℹ Unsafe fix
+26 26 | if c.a in dct and dct[c.a]:
+27 27 |     pass
+28 28 | 
+29    |-if f"{c}" in dct and dct[f"{c}"]:
+   29 |+if dct.get(f"{c}"):
+30 30 |     pass
+31 31 | 
+32 32 | if f"{c.a}" in dct and dct[f"{c.a}"]:
+
+RUF019.py:32:4: RUF019 [*] Unnecessary key check before dictionary access
+   |
+30 |     pass
+31 | 
+32 | if f"{c.a}" in dct and dct[f"{c.a}"]:
+   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ RUF019
+33 |     pass
+   |
+   = help: Replace with `dict.get`
+
+ℹ Unsafe fix
+29 29 | if f"{c}" in dct and dct[f"{c}"]:
+30 30 |     pass
+31 31 | 
+32    |-if f"{c.a}" in dct and dct[f"{c.a}"]:
+   32 |+if dct.get(f"{c.a}"):
+33 33 |     pass

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF019_RUF019.py.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF019_RUF019.py.snap
@@ -121,60 +121,60 @@ RUF019.py:18:6: RUF019 [*] Unnecessary key check before dictionary access
 20 20 | # OK
 21 21 | v = "k" in d and d["k"]
 
-RUF019.py:26:4: RUF019 [*] Unnecessary key check before dictionary access
+RUF019.py:28:4: RUF019 [*] Unnecessary key check before dictionary access
    |
-24 |     pass
-25 | 
-26 | if c.a in dct and dct[c.a]:
+26 | # RUF019, unsafe fixes
+27 | 
+28 | if c.a in dct and dct[c.a]:
    |    ^^^^^^^^^^^^^^^^^^^^^^^ RUF019
-27 |     pass
+29 |     pass
    |
    = help: Replace with `dict.get`
 
 ℹ Safe fix
-23 23 | if f() in d and d[f()]:
-24 24 |     pass
 25 25 | 
-26    |-if c.a in dct and dct[c.a]:
-   26 |+if dct.get(c.a):
-27 27 |     pass
-28 28 | 
-29 29 | if f"{c}" in dct and dct[f"{c}"]:
+26 26 | # RUF019, unsafe fixes
+27 27 | 
+28    |-if c.a in dct and dct[c.a]:
+   28 |+if dct.get(c.a):
+29 29 |     pass
+30 30 | 
+31 31 | if f"{c}" in dct and dct[f"{c}"]:
 
-RUF019.py:29:4: RUF019 [*] Unnecessary key check before dictionary access
+RUF019.py:31:4: RUF019 [*] Unnecessary key check before dictionary access
    |
-27 |     pass
-28 | 
-29 | if f"{c}" in dct and dct[f"{c}"]:
+29 |     pass
+30 | 
+31 | if f"{c}" in dct and dct[f"{c}"]:
    |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ RUF019
-30 |     pass
+32 |     pass
    |
    = help: Replace with `dict.get`
 
 ℹ Safe fix
-26 26 | if c.a in dct and dct[c.a]:
-27 27 |     pass
-28 28 | 
-29    |-if f"{c}" in dct and dct[f"{c}"]:
-   29 |+if dct.get(f"{c}"):
-30 30 |     pass
-31 31 | 
-32 32 | if f"{c.a}" in dct and dct[f"{c.a}"]:
+28 28 | if c.a in dct and dct[c.a]:
+29 29 |     pass
+30 30 | 
+31    |-if f"{c}" in dct and dct[f"{c}"]:
+   31 |+if dct.get(f"{c}"):
+32 32 |     pass
+33 33 | 
+34 34 | if f"{c.a}" in dct and dct[f"{c.a}"]:
 
-RUF019.py:32:4: RUF019 [*] Unnecessary key check before dictionary access
+RUF019.py:34:4: RUF019 [*] Unnecessary key check before dictionary access
    |
-30 |     pass
-31 | 
-32 | if f"{c.a}" in dct and dct[f"{c.a}"]:
+32 |     pass
+33 | 
+34 | if f"{c.a}" in dct and dct[f"{c.a}"]:
    |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ RUF019
-33 |     pass
+35 |     pass
    |
    = help: Replace with `dict.get`
 
 ℹ Safe fix
-29 29 | if f"{c}" in dct and dct[f"{c}"]:
-30 30 |     pass
-31 31 | 
-32    |-if f"{c.a}" in dct and dct[f"{c.a}"]:
-   32 |+if dct.get(f"{c.a}"):
-33 33 |     pass
+31 31 | if f"{c}" in dct and dct[f"{c}"]:
+32 32 |     pass
+33 33 | 
+34    |-if f"{c.a}" in dct and dct[f"{c.a}"]:
+   34 |+if dct.get(f"{c.a}"):
+35 35 |     pass

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__preview__RUF019_RUF019.py.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__preview__RUF019_RUF019.py.snap
@@ -131,7 +131,7 @@ RUF019.py:26:4: RUF019 [*] Unnecessary key check before dictionary access
    |
    = help: Replace with `dict.get`
 
-ℹ Safe fix
+ℹ Unsafe fix
 23 23 | if f() in d and d[f()]:
 24 24 |     pass
 25 25 | 
@@ -151,7 +151,7 @@ RUF019.py:29:4: RUF019 [*] Unnecessary key check before dictionary access
    |
    = help: Replace with `dict.get`
 
-ℹ Safe fix
+ℹ Unsafe fix
 26 26 | if c.a in dct and dct[c.a]:
 27 27 |     pass
 28 28 | 
@@ -171,7 +171,7 @@ RUF019.py:32:4: RUF019 [*] Unnecessary key check before dictionary access
    |
    = help: Replace with `dict.get`
 
-ℹ Safe fix
+ℹ Unsafe fix
 29 29 | if f"{c}" in dct and dct[f"{c}"]:
 30 30 |     pass
 31 31 | 

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__preview__RUF019_RUF019.py.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__preview__RUF019_RUF019.py.snap
@@ -121,60 +121,60 @@ RUF019.py:18:6: RUF019 [*] Unnecessary key check before dictionary access
 20 20 | # OK
 21 21 | v = "k" in d and d["k"]
 
-RUF019.py:26:4: RUF019 [*] Unnecessary key check before dictionary access
+RUF019.py:28:4: RUF019 [*] Unnecessary key check before dictionary access
    |
-24 |     pass
-25 | 
-26 | if c.a in dct and dct[c.a]:
+26 | # RUF019, unsafe fixes
+27 | 
+28 | if c.a in dct and dct[c.a]:
    |    ^^^^^^^^^^^^^^^^^^^^^^^ RUF019
-27 |     pass
+29 |     pass
    |
    = help: Replace with `dict.get`
 
 ℹ Unsafe fix
-23 23 | if f() in d and d[f()]:
-24 24 |     pass
 25 25 | 
-26    |-if c.a in dct and dct[c.a]:
-   26 |+if dct.get(c.a):
-27 27 |     pass
-28 28 | 
-29 29 | if f"{c}" in dct and dct[f"{c}"]:
+26 26 | # RUF019, unsafe fixes
+27 27 | 
+28    |-if c.a in dct and dct[c.a]:
+   28 |+if dct.get(c.a):
+29 29 |     pass
+30 30 | 
+31 31 | if f"{c}" in dct and dct[f"{c}"]:
 
-RUF019.py:29:4: RUF019 [*] Unnecessary key check before dictionary access
+RUF019.py:31:4: RUF019 [*] Unnecessary key check before dictionary access
    |
-27 |     pass
-28 | 
-29 | if f"{c}" in dct and dct[f"{c}"]:
+29 |     pass
+30 | 
+31 | if f"{c}" in dct and dct[f"{c}"]:
    |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ RUF019
-30 |     pass
+32 |     pass
    |
    = help: Replace with `dict.get`
 
 ℹ Unsafe fix
-26 26 | if c.a in dct and dct[c.a]:
-27 27 |     pass
-28 28 | 
-29    |-if f"{c}" in dct and dct[f"{c}"]:
-   29 |+if dct.get(f"{c}"):
-30 30 |     pass
-31 31 | 
-32 32 | if f"{c.a}" in dct and dct[f"{c.a}"]:
+28 28 | if c.a in dct and dct[c.a]:
+29 29 |     pass
+30 30 | 
+31    |-if f"{c}" in dct and dct[f"{c}"]:
+   31 |+if dct.get(f"{c}"):
+32 32 |     pass
+33 33 | 
+34 34 | if f"{c.a}" in dct and dct[f"{c.a}"]:
 
-RUF019.py:32:4: RUF019 [*] Unnecessary key check before dictionary access
+RUF019.py:34:4: RUF019 [*] Unnecessary key check before dictionary access
    |
-30 |     pass
-31 | 
-32 | if f"{c.a}" in dct and dct[f"{c.a}"]:
+32 |     pass
+33 | 
+34 | if f"{c.a}" in dct and dct[f"{c.a}"]:
    |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ RUF019
-33 |     pass
+35 |     pass
    |
    = help: Replace with `dict.get`
 
 ℹ Unsafe fix
-29 29 | if f"{c}" in dct and dct[f"{c}"]:
-30 30 |     pass
-31 31 | 
-32    |-if f"{c.a}" in dct and dct[f"{c.a}"]:
-   32 |+if dct.get(f"{c.a}"):
-33 33 |     pass
+31 31 | if f"{c}" in dct and dct[f"{c}"]:
+32 32 |     pass
+33 33 | 
+34    |-if f"{c.a}" in dct and dct[f"{c.a}"]:
+   34 |+if dct.get(f"{c.a}"):
+35 35 |     pass

--- a/crates/ruff_linter/src/rules/tryceratops/rules/try_consider_else.rs
+++ b/crates/ruff_linter/src/rules/tryceratops/rules/try_consider_else.rs
@@ -67,7 +67,9 @@ pub(crate) fn try_consider_else(
         if let Some(stmt) = body.last() {
             if let Stmt::Return(ast::StmtReturn { value, range: _ }) = stmt {
                 if let Some(value) = value {
-                    if contains_effect(value, |id| checker.semantic().has_builtin_binding(id)) {
+                    if contains_effect(value, |id| checker.semantic().has_builtin_binding(id))
+                        .is_yes()
+                    {
                         return;
                     }
                 }

--- a/crates/ruff_python_ast/src/helpers.rs
+++ b/crates/ruff_python_ast/src/helpers.rs
@@ -39,18 +39,11 @@ where
     matches!(id, "list" | "tuple" | "set" | "dict" | "frozenset") && is_builtin(id)
 }
 
-/// Return `true` if the `Expr` contains an expression that appears to include a
-/// side-effect (like a function call).
+/// Return `Maybe::Yes`, `Maybe::Maybe`, or `Maybe::No` if the `Expr` contains an expression that appears to include a
+/// side-effect (like a function call) or not.
 ///
 /// Accepts a closure that determines whether a given name (e.g., `"list"`) is a Python builtin.
-pub fn contains_effect<F>(expr: &Expr, is_builtin: F) -> bool
-where
-    F: Fn(&str) -> bool,
-{
-    maybe_contains_effect(expr, is_builtin).is_yes()
-}
-
-pub fn maybe_contains_effect<F>(expr: &Expr, is_builtin: F) -> Maybe
+pub fn contains_effect<F>(expr: &Expr, is_builtin: F) -> Maybe
 where
     F: Fn(&str) -> bool,
 {
@@ -189,15 +182,6 @@ impl Maybe {
             (Maybe::Maybe, _) | (_, Maybe::Maybe) => Maybe::Maybe,
             (Maybe::No, Maybe::No) => Maybe::No,
         }
-    }
-}
-
-// Not ops implementation for Maybe
-impl std::ops::Not for Maybe {
-    type Output = bool;
-
-    fn not(self) -> Self::Output {
-        !self.is_yes()
     }
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->
This change introduce the `Maybe` to `contains_effects()` to be able to distinguish between possible and no side effects cases, and thus allowing a finer control of the behavior of the rule.

This was talked about in this comment issue as a way to address the issue.
- https://github.com/astral-sh/ruff/issues/12953#issuecomment-2295449654

The following list contains all rules using `contains_effects()`.
A description for each will be added to describe how the introduction of `Maybe` change the behavior of the rule in preview.

- [x] RUF019
  - The fix become unsafe when `contains_effects()` returns `Maybe::Maybe`
- [ ] B018
- [ ] SIM101
- [ ] SIM109
- [ ] SIM220
- [ ] SIM221
- [ ] SIM222
- [ ] SIM223
- [ ] SIM401
- [ ] SIM116
- [ ] SIM108
- [ ] F841
- [ ] PLR1714
- [ ] FURB132
- [ ] FURB110
- [ ] FURB105
- [ ] TRY300

## Test Plan

- [x] Add the problematic code from #12953 in RUF019 fixture
- [x] Add a preview snapshot of RUF019
- [x] Check there are no regression in the ecosystem for the stable version
<!-- How was it tested? -->
