### PR TITLE
[red-knot] Infer generator expressions

### DIFF
--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -188,6 +188,8 @@ pub enum Type<'db> {
     LiteralString,
     /// A bytes literal
     BytesLiteral(BytesLiteralType<'db>),
+    /// A generator
+    Generator(GeneratorType<'db>),
     // TODO protocols, callable types, overloads, generics, type vars
 }
 
@@ -297,6 +299,7 @@ impl<'db> Type<'db> {
                 // TODO defer to Type::Instance(<bytes from typeshed>).member
                 Type::Unknown
             }
+            Type::Generator(_) => Type::Unknown,
         }
     }
 
@@ -403,6 +406,13 @@ pub struct StringLiteralType<'db> {
 pub struct BytesLiteralType<'db> {
     #[return_ref]
     value: Box<[u8]>,
+}
+
+#[salsa::interned]
+pub struct GeneratorType<'db> {
+    yield_type: Type<'db>,
+    send_type: Type<'db>,
+    return_type: Type<'db>,
 }
 
 #[cfg(test)]

--- a/crates/red_knot_python_semantic/src/types/display.rs
+++ b/crates/red_knot_python_semantic/src/types/display.rs
@@ -55,6 +55,22 @@ impl Display for DisplayType<'_> {
                 escape.bytes_repr().write(f)?;
                 f.write_str("]")
             }
+            Type::Generator(generator) => write!(
+                f,
+                "Generator[{}, {}, {}]",
+                DisplayType {
+                    ty: &generator.yield_type(self.db),
+                    db: self.db
+                },
+                DisplayType {
+                    ty: &generator.send_type(self.db),
+                    db: self.db
+                },
+                DisplayType {
+                    ty: &generator.return_type(self.db),
+                    db: self.db
+                }
+            ),
         }
     }
 }

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -1418,7 +1418,6 @@ impl<'db> TypeInferenceBuilder<'db> {
 
         let yield_type = self.infer_first_comprehension_iter(generators);
 
-        // TODO generator type
         Type::Generator(GeneratorType::new(
             self.db,
             yield_type,


### PR DESCRIPTION
Adds a `Generator` type and infers the type of a generator expression as `Generator[T, None, None]` where `T` is the inferred type of the first comprehension.

Related to #12701.
