### PR TITLE
[red-knot] infer basic (name-based) annotation expressions

### DIFF
--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -339,7 +339,7 @@ pub struct FunctionType<'db> {
     /// types of all decorators on this function
     decorators: Vec<Type<'db>>,
 
-    /// return type for this function
+    /// annotated return type for this function, if any
     returns: Option<Type<'db>>,
 }
 

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -338,6 +338,9 @@ pub struct FunctionType<'db> {
 
     /// types of all decorators on this function
     decorators: Vec<Type<'db>>,
+
+    /// return type for this function
+    returns: Option<Type<'db>>,
 }
 
 impl<'db> FunctionType<'db> {

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -100,6 +100,7 @@ pub(crate) fn definition_expression_ty<'db>(
     expression: &ast::Expr,
 ) -> Type<'db> {
     let expr_id = expression.scoped_ast_id(db, definition.scope(db));
+
     let inference = infer_definition_types(db, definition);
     if let Some(ty) = inference.try_expression_ty(expr_id) {
         ty

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -336,16 +336,28 @@ pub struct FunctionType<'db> {
     /// name of the function at definition
     pub name: ast::name::Name,
 
+    definition: Definition<'db>,
+
     /// types of all decorators on this function
     decorators: Vec<Type<'db>>,
-
-    /// annotated return type for this function, if any
-    returns: Option<Type<'db>>,
 }
 
 impl<'db> FunctionType<'db> {
     pub fn has_decorator(self, db: &dyn Db, decorator: Type<'_>) -> bool {
         self.decorators(db).contains(&decorator)
+    }
+
+    /// annotated return type for this function, if any
+    pub fn returns(&self, db: &'db dyn Db) -> Option<Type<'db>> {
+        let definition = self.definition(db);
+        let DefinitionKind::Function(function_stmt_node) = definition.node(db) else {
+            panic!("Function type definition must have `DefinitionKind::Function`")
+        };
+
+        function_stmt_node
+            .returns
+            .as_ref()
+            .map(|returns| definition_expression_ty(db, definition, returns.as_ref()))
     }
 }
 

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -100,7 +100,6 @@ pub(crate) fn definition_expression_ty<'db>(
     expression: &ast::Expr,
 ) -> Type<'db> {
     let expr_id = expression.scoped_ast_id(db, definition.scope(db));
-
     let inference = infer_definition_types(db, definition);
     if let Some(ty) = inference.try_expression_ty(expr_id) {
         ty

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -1377,7 +1377,7 @@ impl<'db> TypeInferenceBuilder<'db> {
         //   stub of the forms other than a standalone name in scope.
         match expression {
             ast::Expr::Name(name) => {
-                assert!(
+                debug_assert!(
                     name.ctx.is_load(),
                     "name in a type expression is always 'load' but got: '{:?}'",
                     name.ctx

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -2121,8 +2121,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                     name.ctx
                 );
 
-                let instance = self.infer_name_expression(name).instance();
-                instance
+                self.infer_name_expression(name).instance()
             }
 
             ast::Expr::NoneLiteral(_literal) => Type::None,

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -1365,8 +1365,12 @@ impl<'db> TypeInferenceBuilder<'db> {
             _ => Type::Unknown, // TODO: this needs to error?
         };
 
+        let expr_id = expression.scoped_ast_id(self.db, self.scope);
+        self.types.expressions.insert(expr_id, ty);
+
         ty
     }
+
     fn infer_type_expression(&mut self, expression: &ast::Expr) -> Type<'db> {
         // https://typing.readthedocs.io/en/latest/spec/annotations.html#grammar-token-expression-grammar-type_expression
         // TODO: this does not include any of the special forms, and is only a

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -1321,7 +1321,7 @@ impl<'db> TypeInferenceBuilder<'db> {
         &mut self,
         expr: Option<&ast::Expr>,
     ) -> Option<Type<'db>> {
-        expr.map(|expr| self.annotation_expression(expr))
+        expr.map(|expr| self.infer_annotation_expression(expr))
     }
 
     fn infer_expression(&mut self, expression: &ast::Expr) -> Type<'db> {
@@ -2088,12 +2088,12 @@ impl<'db> TypeInferenceBuilder<'db> {
 
 /// Annotation expressions.
 impl<'db> TypeInferenceBuilder<'db> {
-    fn annotation_expression(&mut self, expression: &ast::Expr) -> Type<'db> {
+    fn infer_annotation_expression(&mut self, expression: &ast::Expr) -> Type<'db> {
         // https://typing.readthedocs.io/en/latest/spec/annotations.html#grammar-token-expression-grammar-annotation_expression
         let ty = match expression {
             // Forms which are possibly valid type expressions.
             type_expr @ (ast::Expr::NoneLiteral(..) | ast::Expr::Name(..)) => {
-                self.type_expression(type_expr)
+                self.infer_type_expression(type_expr)
             }
 
             // NOTE: This section is presently identical with the corresponding section in the type
@@ -2228,7 +2228,7 @@ impl<'db> TypeInferenceBuilder<'db> {
 
 /// Type expressions
 impl<'db> TypeInferenceBuilder<'db> {
-    fn type_expression(&mut self, expression: &ast::Expr) -> Type<'db> {
+    fn infer_type_expression(&mut self, expression: &ast::Expr) -> Type<'db> {
         // https://typing.readthedocs.io/en/latest/spec/annotations.html#grammar-token-expression-grammar-type_expression
         // TODO: this does not include any of the special forms, and is only a
         //   stub of the forms other than a standalone name in scope.

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -461,7 +461,12 @@ impl<'db> TypeInferenceBuilder<'db> {
         let Some(type_params) = function.type_params.as_deref() else {
             panic!("function type params scope without type params");
         };
-        self.infer_optional_expression(function.returns.as_deref());
+
+        // TODO: this should also be applied to type parameters and parameters.
+        if !self.is_stub() {
+            self.infer_optional_expression(function.returns.as_deref());
+        }
+
         self.infer_type_parameters(type_params);
         self.infer_parameters(&function.parameters);
     }
@@ -555,6 +560,7 @@ impl<'db> TypeInferenceBuilder<'db> {
         if type_params.is_none() {
             self.infer_parameters(parameters);
 
+            // TODO: this should also be applied to parameters.
             if !self.is_stub() {
                 self.infer_optional_annotation_expression(returns.as_deref());
             }

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -307,6 +307,7 @@ impl<'db> TypeInferenceBuilder<'db> {
     }
 
     /// Infers types in the given [`InferenceRegion`].
+    #[tracing::instrument(skip_all)]
     fn infer_region(&mut self) {
         match self.region {
             InferenceRegion::Scope(scope) => self.infer_region_scope(scope),
@@ -316,9 +317,8 @@ impl<'db> TypeInferenceBuilder<'db> {
         }
     }
 
+    #[tracing::instrument(skip_all)]
     fn infer_region_scope(&mut self, scope: ScopeId<'db>) {
-        let _span = tracing::trace_span!("infer_region_scope").entered();
-
         let node = scope.node(self.db);
         match node {
             NodeWithScopeKind::Module => {
@@ -363,6 +363,7 @@ impl<'db> TypeInferenceBuilder<'db> {
         }
     }
 
+    #[tracing::instrument(skip_all)]
     fn infer_region_definition(&mut self, definition: Definition<'db>) {
         match definition.node(self.db) {
             DefinitionKind::Function(function) => {
@@ -421,6 +422,7 @@ impl<'db> TypeInferenceBuilder<'db> {
         }
     }
 
+    #[tracing::instrument(skip_all)]
     fn infer_region_deferred(&mut self, definition: Definition<'db>) {
         match definition.node(self.db) {
             DefinitionKind::Function(function) => self.infer_function_deferred(function.node()),
@@ -432,10 +434,12 @@ impl<'db> TypeInferenceBuilder<'db> {
         }
     }
 
+    #[tracing::instrument(skip_all)]
     fn infer_region_expression(&mut self, expression: Expression<'db>) {
         self.infer_expression(expression.node_ref(self.db));
     }
 
+    #[tracing::instrument(skip_all)]
     fn infer_module(&mut self, module: &ast::ModModule) {
         self.infer_body(&module.body);
     }
@@ -517,16 +521,19 @@ impl<'db> TypeInferenceBuilder<'db> {
         }
     }
 
+    #[tracing::instrument(skip_all)]
     fn infer_definition(&mut self, node: impl Into<DefinitionNodeKey>) {
         let definition = self.index.definition(node);
         let result = infer_definition_types(self.db, definition);
         self.extend(result);
     }
 
+    #[tracing::instrument(skip_all)]
     fn infer_function_definition_statement(&mut self, function: &ast::StmtFunctionDef) {
         self.infer_definition(function);
     }
 
+    #[tracing::instrument(skip_all)]
     fn infer_function_definition(
         &mut self,
         function: &ast::StmtFunctionDef,
@@ -576,6 +583,7 @@ impl<'db> TypeInferenceBuilder<'db> {
         self.types.definitions.insert(definition, function_ty);
     }
 
+    #[tracing::instrument(skip_all)]
     fn infer_parameters(&mut self, parameters: &ast::Parameters) {
         let ast::Parameters {
             range: _,
@@ -597,6 +605,7 @@ impl<'db> TypeInferenceBuilder<'db> {
         }
     }
 
+    #[tracing::instrument(skip_all)]
     fn infer_parameter_with_default(&mut self, parameter_with_default: &ast::ParameterWithDefault) {
         let ast::ParameterWithDefault {
             range: _,
@@ -609,6 +618,7 @@ impl<'db> TypeInferenceBuilder<'db> {
         self.infer_definition(parameter_with_default);
     }
 
+    #[tracing::instrument(skip_all)]
     fn infer_parameter(&mut self, parameter: &ast::Parameter) {
         let ast::Parameter {
             range: _,
@@ -623,13 +633,18 @@ impl<'db> TypeInferenceBuilder<'db> {
 
     fn infer_parameter_with_default_definition(
         &mut self,
-        _parameter_with_default: &ast::ParameterWithDefault,
+        parameter_with_default: &ast::ParameterWithDefault,
         definition: Definition<'db>,
     ) {
+        tracing::trace!(
+            param = ?parameter_with_default,
+            "infer_parameter_with_default_definition",
+        );
         // TODO(dhruvmanila): Infer types from annotation or default expression
         self.types.definitions.insert(definition, Type::Unknown);
     }
 
+    #[tracing::instrument(skip_all)]
     fn infer_parameter_definition(
         &mut self,
         _parameter: &ast::Parameter,
@@ -640,10 +655,12 @@ impl<'db> TypeInferenceBuilder<'db> {
         self.types.definitions.insert(definition, Type::Unknown);
     }
 
+    #[tracing::instrument(skip_all)]
     fn infer_class_definition_statement(&mut self, class: &ast::StmtClassDef) {
         self.infer_definition(class);
     }
 
+    #[tracing::instrument(skip_all)]
     fn infer_class_definition(&mut self, class: &ast::StmtClassDef, definition: Definition<'db>) {
         let ast::StmtClassDef {
             range: _,

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -2234,14 +2234,20 @@ impl<'db> TypeInferenceBuilder<'db> {
                 Type::Unknown
             }
 
-            // Literals do not have meaningful values in the annotation expression context. However,
-            // we will we want to handle these differently when working with special forms, since
-            // `"hello"` is not valid in an annotation expression but `Literal["hello"]` is.
+            // TODO: parse the expression and check whether it is a string annotation.
+            // https://typing.readthedocs.io/en/latest/spec/annotations.html#string-annotations
             ast::Expr::StringLiteral(_literal) => Type::Unknown,
+
+            // TODO: an Ellipsis literal *on its own* does not have any meaning in annotation
+            // expressions, but is meaningful in the context of a number of special forms.
+            ast::Expr::EllipsisLiteral(_literal) => Type::Unknown,
+
+            // Other literals do not have meaningful values in the annotation expression context.
+            // However, we will we want to handle these differently when working with special forms,
+            // since (e.g.) `123` is not valid in an annotation expression but `Literal[123]` is.
             ast::Expr::BytesLiteral(_literal) => Type::Unknown,
             ast::Expr::NumberLiteral(_literal) => Type::Unknown,
             ast::Expr::BooleanLiteral(_literal) => Type::Unknown,
-            ast::Expr::EllipsisLiteral(_literal) => Type::Unknown,
 
             ast::Expr::IpyEscapeCommand(_) => todo!("Implement Ipy escape command support"),
         };
@@ -2281,14 +2287,20 @@ impl<'db> TypeInferenceBuilder<'db> {
 
             ast::Expr::NoneLiteral(_literal) => Type::None,
 
+            // TODO: parse the expression and check whether it is a string annotation.
+            // https://typing.readthedocs.io/en/latest/spec/annotations.html#string-annotations
+            ast::Expr::StringLiteral(_literal) => Type::Unknown,
+
+            // TODO: an Ellipsis literal *on its own* does not have any meaning in annotation
+            // expressions, but is meaningful in the context of a number of special forms.
+            ast::Expr::EllipsisLiteral(_literal) => Type::Unknown,
+
             // Other literals do not have meaningful values in the annotation expression context.
             // However, we will we want to handle these differently when working with special forms,
-            // since `"hello"` is not valid in an annotation expression but `Literal["hello"]` is.
-            ast::Expr::StringLiteral(_literal) => Type::Unknown,
+            // since (e.g.) `123` is not valid in an annotation expression but `Literal[123]` is.
             ast::Expr::BytesLiteral(_literal) => Type::Unknown,
             ast::Expr::NumberLiteral(_literal) => Type::Unknown,
             ast::Expr::BooleanLiteral(_literal) => Type::Unknown,
-            ast::Expr::EllipsisLiteral(_literal) => Type::Unknown,
 
             // NOTE: This section is presently identical with the corresponding section in the
             // annotation expressions implementation, but they may diverge from each other in the


### PR DESCRIPTION
## Summary

- Introduce methods for inferring annotation and type expressions.
- Correctly infer explicit return types from functions where they are simple names that can be resolved in scope.

Contributes to #12701 by way of helping unlock call expressions (this does not remotely finish that, as it stands, but it gets us moving that direction).

## Test Plan

Added a test for function return types which use the name form of an annotation expression, since this is aiming toward call expressions. When we extend this to working for other annotation and type expression positions, we should add explicit tests for those as well.
