### PR TITLE
[red-knot] support deferred evaluation of type expressions

### DIFF
--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -1,8 +1,9 @@
 use ruff_db::files::File;
-use ruff_python_ast::name::Name;
+use ruff_python_ast as ast;
 
 use crate::builtins::builtins_scope;
-use crate::semantic_index::definition::Definition;
+use crate::semantic_index::ast_ids::HasScopedAstId;
+use crate::semantic_index::definition::{Definition, DefinitionKind};
 use crate::semantic_index::symbol::{ScopeId, ScopedSymbolId};
 use crate::semantic_index::{
     global_scope, semantic_index, symbol_table, use_def_map, DefinitionWithConstraints,
@@ -243,7 +244,7 @@ impl<'db> Type<'db> {
     /// us to explicitly consider whether to handle an error or propagate
     /// it up the call stack.
     #[must_use]
-    pub fn member(&self, db: &'db dyn Db, name: &Name) -> Type<'db> {
+    pub fn member(&self, db: &'db dyn Db, name: &ast::name::Name) -> Type<'db> {
         match self {
             Type::Any => Type::Any,
             Type::Never => {
@@ -314,7 +315,7 @@ impl<'db> Type<'db> {
 #[salsa::interned]
 pub struct FunctionType<'db> {
     /// name of the function at definition
-    pub name: Name,
+    pub name: ast::name::Name,
 
     /// types of all decorators on this function
     decorators: Vec<Type<'db>>,
@@ -329,19 +330,35 @@ impl<'db> FunctionType<'db> {
 #[salsa::interned]
 pub struct ClassType<'db> {
     /// Name of the class at definition
-    pub name: Name,
+    pub name: ast::name::Name,
 
-    /// Types of all class bases
-    bases: Vec<Type<'db>>,
+    definition: Definition<'db>,
 
     body_scope: ScopeId<'db>,
 }
 
 impl<'db> ClassType<'db> {
+    /// Return an iterator over the types of this class's bases.
+    ///
+    /// # Panics:
+    /// If `definition` is not a `DefinitionKind::Class`.
+    pub fn bases(&self, db: &'db dyn Db) -> impl Iterator<Item = Type<'db>> {
+        let DefinitionKind::Class(class_stmt_node) = self.definition(db).node(db) else {
+            panic!("Class type definition must have DefinitionKind::Class");
+        };
+        // TODO if there are type params, the bases should be inferred inside that scope (only)
+        let scope = self.definition(db).scope(db);
+        let inference = infer_scope_types(db, scope);
+        class_stmt_node
+            .bases()
+            .iter()
+            .map(move |base_expr| inference.expression_ty(base_expr.scoped_ast_id(db, scope)))
+    }
+
     /// Returns the class member of this class named `name`.
     ///
     /// The member resolves to a member of the class itself or any of its bases.
-    pub fn class_member(self, db: &'db dyn Db, name: &Name) -> Type<'db> {
+    pub fn class_member(self, db: &'db dyn Db, name: &ast::name::Name) -> Type<'db> {
         let member = self.own_class_member(db, name);
         if !member.is_unbound() {
             return member;
@@ -351,12 +368,12 @@ impl<'db> ClassType<'db> {
     }
 
     /// Returns the inferred type of the class member named `name`.
-    pub fn own_class_member(self, db: &'db dyn Db, name: &Name) -> Type<'db> {
+    pub fn own_class_member(self, db: &'db dyn Db, name: &ast::name::Name) -> Type<'db> {
         let scope = self.body_scope(db);
         symbol_ty_by_name(db, scope, name)
     }
 
-    pub fn inherited_class_member(self, db: &'db dyn Db, name: &Name) -> Type<'db> {
+    pub fn inherited_class_member(self, db: &'db dyn Db, name: &ast::name::Name) -> Type<'db> {
         for base in self.bases(db) {
             let member = base.member(db, name);
             if !member.is_unbound() {

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -1758,8 +1758,9 @@ impl<'db> TypeInferenceBuilder<'db> {
         // if we're inferring types of deferred expressions, always treat them as public symbols
         if self.is_deferred() {
             let symbols = self.index.symbol_table(file_scope_id);
-            // SAFETY: the symbol table always creates a symbol for every Name node.
-            let symbol = symbols.symbol_id_by_name(id).unwrap();
+            let symbol = symbols
+                .symbol_id_by_name(id)
+                .expect("Expected the symbol table to create a symbol for every Name node");
             return symbol_ty(self.db, self.scope, symbol);
         }
 

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -3053,6 +3053,16 @@ mod tests {
         Ok(())
     }
 
+    /// Test that a class's bases can be self-referential; this looks silly but
+    /// a slightly more complex version of tit actually occurs in typeshed: `class str(Sequence[str]): ...`
+    #[test]
+    fn cyclical_class_pyi_definition() -> anyhow::Result<()> {
+        let mut db = setup_db();
+        db.write_file("/src/a.pyi", "class C(C): ...")?;
+        assert_public_ty(&db, "/src/a.pyi", "C", "Literal[C]");
+        Ok(())
+    }
+
     #[test]
     fn narrow_not_none() -> anyhow::Result<()> {
         let mut db = setup_db();

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -3146,13 +3146,21 @@ mod tests {
         Ok(())
     }
 
-    /// Test that a class's bases can be self-referential; this looks silly but a slightly more
-    /// complex version of it actually occurs in typeshed: `class str(Sequence[str]): ...`
+    /// A class's bases can be self-referential; this looks silly but a slightly more complex
+    /// version of it actually occurs in typeshed: `class str(Sequence[str]): ...`
     #[test]
     fn cyclical_class_pyi_definition() -> anyhow::Result<()> {
         let mut db = setup_db();
         db.write_file("/src/a.pyi", "class C(C): ...")?;
         assert_public_ty(&db, "/src/a.pyi", "C", "Literal[C]");
+        Ok(())
+    }
+
+    #[test]
+    fn str_builtin() -> anyhow::Result<()> {
+        let mut db = setup_db();
+        db.write_file("/src/a.py", "x = str")?;
+        assert_public_ty(&db, "/src/a.py", "x", "Literal[str]");
         Ok(())
     }
 

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -645,6 +645,10 @@ impl<'db> TypeInferenceBuilder<'db> {
 
         self.types.definitions.insert(definition, class_ty);
 
+        for keyword in class.keywords() {
+            self.infer_expression(&keyword.value);
+        }
+
         // inference of bases deferred in stubs
         if !self.is_stub() {
             for base in class.bases() {

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -177,6 +177,10 @@ impl<'db> TypeInference<'db> {
         self.expressions[&expression]
     }
 
+    pub(crate) fn try_expression_ty(&self, expression: ScopedExpressionId) -> Option<Type<'db>> {
+        self.expressions.get(&expression).copied()
+    }
+
     pub(crate) fn definition_ty(&self, definition: Definition<'db>) -> Type<'db> {
         self.definitions[&definition]
     }
@@ -658,6 +662,7 @@ impl<'db> TypeInferenceBuilder<'db> {
         }
 
         // inference of bases deferred in stubs
+        // TODO also defer stringified generic type parameters
         if !self.is_stub() {
             for base in class.bases() {
                 self.infer_expression(base);

--- a/crates/ruff_db/src/files.rs
+++ b/crates/ruff_db/src/files.rs
@@ -424,6 +424,13 @@ impl File {
     pub fn exists(self, db: &dyn Db) -> bool {
         self.status(db) == FileStatus::Exists
     }
+
+    /// Returns `true` if the file should be analyzed as a type stub.
+    pub fn is_stub(self, db: &dyn Db) -> bool {
+        self.path(db)
+            .extension()
+            .is_some_and(|extension| extension == "pyi")
+    }
 }
 
 /// A virtual file that doesn't exist on the file system.

--- a/crates/ruff_db/src/files.rs
+++ b/crates/ruff_db/src/files.rs
@@ -8,6 +8,7 @@ use salsa::{Durability, Setter};
 pub use file_root::{FileRoot, FileRootKind};
 pub use path::FilePath;
 use ruff_notebook::{Notebook, NotebookError};
+use ruff_python_ast::PySourceType;
 
 use crate::file_revision::FileRevision;
 use crate::files::file_root::FileRoots;
@@ -429,7 +430,7 @@ impl File {
     pub fn is_stub(self, db: &dyn Db) -> bool {
         self.path(db)
             .extension()
-            .is_some_and(|extension| extension == "pyi")
+            .is_some_and(|extension| PySourceType::from_extension(extension).is_stub())
     }
 }
 


### PR DESCRIPTION
Prototype deferred evaluation of type expressions by deferring evaluation of class bases in a stub file. This allows self-referential class definitions, as occur with the definition of `str` in typeshed (which inherits `Sequence[str]`).
