### PR TITLE
[`pydoclint`] Permit yielding `None` in DOC402 and DOC403

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pydoclint/DOC201_numpy.py
+++ b/crates/ruff_linter/resources/test/fixtures/pydoclint/DOC201_numpy.py
@@ -187,3 +187,9 @@ def foo(s: str) -> str | None:
         A string.
     """
     return None
+
+
+# DOC201
+def bar() -> int | None:
+    """Bar-y method"""
+    return

--- a/crates/ruff_linter/resources/test/fixtures/pydoclint/DOC201_numpy.py
+++ b/crates/ruff_linter/resources/test/fixtures/pydoclint/DOC201_numpy.py
@@ -193,3 +193,44 @@ def foo(s: str) -> str | None:
 def bar() -> int | None:
     """Bar-y method"""
     return
+
+
+from collections.abc import Iterator, Generator
+
+
+# This is okay -- returning `None` is implied by `Iterator[str]`;
+# no need to document it
+def generator_function() -> Iterator[str]:
+    """Generate some strings"""
+    yield from "abc"
+    return
+
+
+# This is okay -- returning `None` is stated by `Generator[str, None, None]`;
+# no need to document it
+def generator_function_2() -> Generator[str, None, None]:
+    """Generate some strings"""
+    yield from "abc"
+    return
+
+
+# DOC201 -- returns None but `Generator[str, None, int | None]`
+# indicates it could sometimes return `int`
+def generator_function_3() -> Generator[str, None, int | None]:
+    """Generate some strings"""
+    yield from "abc"
+    return
+
+
+# DOC201 -- no type annotation and a non-None return
+# indicates it could sometimes return `int`
+def generator_function_4():
+    """Generate some strings"""
+    yield from "abc"
+    return 42
+
+
+# DOC201 -- no `yield` expressions, so not a generator function
+def not_a_generator() -> Iterator[int]:
+    """"No returns documented here, oh no"""
+    return (x for x in range(42))

--- a/crates/ruff_linter/resources/test/fixtures/pydoclint/DOC202_google.py
+++ b/crates/ruff_linter/resources/test/fixtures/pydoclint/DOC202_google.py
@@ -73,3 +73,15 @@ class A(metaclass=abc.abcmeta):
             dict: The values
         """
         return
+
+
+# DOC202 -- never explicitly returns anything, just short-circuits
+def foo(s: str, condition: bool):
+    """Fooey things.
+
+    Returns:
+        None
+    """
+    if not condition:
+        return
+    print(s)

--- a/crates/ruff_linter/resources/test/fixtures/pydoclint/DOC402_google.py
+++ b/crates/ruff_linter/resources/test/fixtures/pydoclint/DOC402_google.py
@@ -89,11 +89,19 @@ def f(num: int):
     yield 1
 
 
-from collections import abc
+import collections.abc
 
 
 # DOC402
-def foo() -> abc.Generator[int | None, None, None]:
+def foo() -> collections.abc.Generator[int | None, None, None]:
+    """
+    Do something
+    """
+    yield
+
+
+# DOC402
+def bar() -> collections.abc.Iterator[int | None]:
     """
     Do something
     """

--- a/crates/ruff_linter/resources/test/fixtures/pydoclint/DOC402_google.py
+++ b/crates/ruff_linter/resources/test/fixtures/pydoclint/DOC402_google.py
@@ -87,3 +87,14 @@ def f(num: int):
         num (int): A number
     """
     yield 1
+
+
+from collections import abc
+
+
+# DOC402
+def foo() -> abc.Generator[int | None, None, None]:
+    """
+    Do something
+    """
+    yield

--- a/crates/ruff_linter/resources/test/fixtures/pydoclint/DOC402_numpy.py
+++ b/crates/ruff_linter/resources/test/fixtures/pydoclint/DOC402_numpy.py
@@ -60,3 +60,73 @@ class Bar:
             A number
         """
         yield 'test'
+
+
+import typing
+
+
+# OK
+def foo() -> typing.Generator[None, None, None]:
+    """
+    Do something
+    """
+    yield None
+
+
+# OK
+def foo() -> typing.Generator[None, None, None]:
+    """
+    Do something
+    """
+    yield
+
+
+# DOC402
+def foo() -> typing.Generator[int | None, None, None]:
+    """
+    Do something
+    """
+    yield None
+    yield 1
+
+
+# DOC402
+def foo() -> typing.Generator[int, None, None]:
+    """
+    Do something
+    """
+    yield None
+
+
+# OK
+def foo():
+    """
+    Do something
+    """
+    yield None
+
+
+# OK
+def foo():
+    """
+    Do something
+    """
+    yield
+
+
+# DOC402
+def foo():
+    """
+    Do something
+    """
+    yield None
+    yield 1
+
+
+# DOC402
+def foo():
+    """
+    Do something
+    """
+    yield 1
+    yield

--- a/crates/ruff_linter/resources/test/fixtures/pydoclint/DOC402_numpy.py
+++ b/crates/ruff_linter/resources/test/fixtures/pydoclint/DOC402_numpy.py
@@ -130,3 +130,11 @@ def foo():
     """
     yield 1
     yield
+
+
+# DOC402
+def bar() -> typing.Iterator[int | None]:
+    """
+    Do something
+    """
+    yield

--- a/crates/ruff_linter/resources/test/fixtures/pydoclint/DOC403_google.py
+++ b/crates/ruff_linter/resources/test/fixtures/pydoclint/DOC403_google.py
@@ -48,3 +48,50 @@ class Bar:
             num (int): A number
         """
         print('test')
+
+
+import typing
+
+
+# OK
+def foo() -> typing.Generator[None, None, None]:
+    """
+    Do something
+
+    Yields:
+        When X.
+    """
+    yield
+
+
+# OK
+def foo() -> typing.Generator[None, None, None]:
+    """
+    Do something
+
+    Yields:
+        When X.
+    """
+    yield None
+
+
+# OK
+def foo():
+    """
+    Do something
+
+    Yields:
+        When X.
+    """
+    yield
+
+
+# OK
+def foo():
+    """
+    Do something
+
+    Yields:
+        When X.
+    """
+    yield None

--- a/crates/ruff_linter/resources/test/fixtures/pydoclint/DOC403_numpy.py
+++ b/crates/ruff_linter/resources/test/fixtures/pydoclint/DOC403_numpy.py
@@ -60,3 +60,54 @@ class Bar:
             A number
         """
         print('test')
+
+
+import typing
+
+
+# OK
+def foo() -> typing.Generator[None, None, None]:
+    """
+    Do something
+
+    Yields
+    ------
+        When X.
+    """
+    yield None
+
+
+# OK
+def foo() -> typing.Generator[None, None, None]:
+    """
+    Do something
+
+    Yields
+    ------
+        When X.
+    """
+    yield
+
+
+# OK
+def foo():
+    """
+    Do something
+
+    Yields
+    ------
+        When X.
+    """
+    yield None
+
+
+# OK
+def foo():
+    """
+    Do something
+
+    Yields
+    ------
+        When X.
+    """
+    yield

--- a/crates/ruff_linter/src/rules/pydoclint/rules/check_docstring.rs
+++ b/crates/ruff_linter/src/rules/pydoclint/rules/check_docstring.rs
@@ -647,6 +647,12 @@ impl<'a> Visitor<'a> for BodyVisitor<'a> {
                     is_none_return: value.is_none_literal_expr(),
                 });
             }
+            Stmt::Return(ast::StmtReturn { range, value: None }) => {
+                self.returns.push(ReturnEntry {
+                    range: *range,
+                    is_none_return: true,
+                });
+            }
             Stmt::FunctionDef(_) | Stmt::ClassDef(_) => return,
             _ => {}
         }

--- a/crates/ruff_linter/src/rules/pydoclint/rules/check_docstring.rs
+++ b/crates/ruff_linter/src/rules/pydoclint/rules/check_docstring.rs
@@ -736,8 +736,12 @@ fn generator_yield_annotation<'a>(expr: &'a Expr, checker: &'a Checker) -> Optio
             .segments(),
         [
             "typing" | "typing_extensions",
-            "Generator" | "AsyncGenerator"
-        ] | ["collections", "abc", "Generator" | "AsyncGenerator"]
+            "Generator" | "AsyncGenerator" | "Iterator" | "AsyncIterator"
+        ] | [
+            "collections",
+            "abc",
+            "Generator" | "AsyncGenerator" | "Iterator" | "AsyncIterator"
+        ]
     ) {
         return slice.elts.first();
     }

--- a/crates/ruff_linter/src/rules/pydoclint/snapshots/ruff_linter__rules__pydoclint__tests__docstring-extraneous-returns_DOC202_google.py.snap
+++ b/crates/ruff_linter/src/rules/pydoclint/snapshots/ruff_linter__rules__pydoclint__tests__docstring-extraneous-returns_DOC202_google.py.snap
@@ -24,3 +24,16 @@ DOC202_google.py:36:1: DOC202 Docstring should not have a returns section becaus
 39 |           print('test')
    |
    = help: Remove the "Returns" section
+
+DOC202_google.py:82:1: DOC202 Docstring should not have a returns section because the function doesn't return anything
+   |
+80 |       """Fooey things.
+81 |   
+82 | /     Returns:
+83 | |         None
+84 | |     """
+   | |____^ DOC202
+85 |       if not condition:
+86 |           return
+   |
+   = help: Remove the "Returns" section

--- a/crates/ruff_linter/src/rules/pydoclint/snapshots/ruff_linter__rules__pydoclint__tests__docstring-missing-returns_DOC201_numpy.py.snap
+++ b/crates/ruff_linter/src/rules/pydoclint/snapshots/ruff_linter__rules__pydoclint__tests__docstring-missing-returns_DOC201_numpy.py.snap
@@ -67,3 +67,30 @@ DOC201_numpy.py:195:5: DOC201 `return` is not documented in docstring
     |     ^^^^^^ DOC201
     |
     = help: Add a "Returns" section to the docstring
+
+DOC201_numpy.py:222:5: DOC201 `return` is not documented in docstring
+    |
+220 |     """Generate some strings"""
+221 |     yield from "abc"
+222 |     return
+    |     ^^^^^^ DOC201
+    |
+    = help: Add a "Returns" section to the docstring
+
+DOC201_numpy.py:230:5: DOC201 `return` is not documented in docstring
+    |
+228 |     """Generate some strings"""
+229 |     yield from "abc"
+230 |     return 42
+    |     ^^^^^^^^^ DOC201
+    |
+    = help: Add a "Returns" section to the docstring
+
+DOC201_numpy.py:236:5: DOC201 `return` is not documented in docstring
+    |
+234 | def not_a_generator() -> Iterator[int]:
+235 |     """"No returns documented here, oh no"""
+236 |     return (x for x in range(42))
+    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ DOC201
+    |
+    = help: Add a "Returns" section to the docstring

--- a/crates/ruff_linter/src/rules/pydoclint/snapshots/ruff_linter__rules__pydoclint__tests__docstring-missing-returns_DOC201_numpy.py.snap
+++ b/crates/ruff_linter/src/rules/pydoclint/snapshots/ruff_linter__rules__pydoclint__tests__docstring-missing-returns_DOC201_numpy.py.snap
@@ -58,3 +58,12 @@ DOC201_numpy.py:189:5: DOC201 `return` is not documented in docstring
     |     ^^^^^^^^^^^ DOC201
     |
     = help: Add a "Returns" section to the docstring
+
+DOC201_numpy.py:195:5: DOC201 `return` is not documented in docstring
+    |
+193 | def bar() -> int | None:
+194 |     """Bar-y method"""
+195 |     return
+    |     ^^^^^^ DOC201
+    |
+    = help: Add a "Returns" section to the docstring

--- a/crates/ruff_linter/src/rules/pydoclint/snapshots/ruff_linter__rules__pydoclint__tests__docstring-missing-yields_DOC402_google.py.snap
+++ b/crates/ruff_linter/src/rules/pydoclint/snapshots/ruff_linter__rules__pydoclint__tests__docstring-missing-yields_DOC402_google.py.snap
@@ -38,3 +38,12 @@ DOC402_google.py:67:5: DOC402 `yield` is not documented in docstring
    |     ^^^^^^^^^^^^^^^^^^^^ DOC402
    |
    = help: Add a "Yields" section to the docstring
+
+DOC402_google.py:100:5: DOC402 `yield` is not documented in docstring
+    |
+ 98 |     Do something
+ 99 |     """
+100 |     yield
+    |     ^^^^^ DOC402
+    |
+    = help: Add a "Yields" section to the docstring

--- a/crates/ruff_linter/src/rules/pydoclint/snapshots/ruff_linter__rules__pydoclint__tests__docstring-missing-yields_DOC402_google.py.snap
+++ b/crates/ruff_linter/src/rules/pydoclint/snapshots/ruff_linter__rules__pydoclint__tests__docstring-missing-yields_DOC402_google.py.snap
@@ -47,3 +47,12 @@ DOC402_google.py:100:5: DOC402 `yield` is not documented in docstring
     |     ^^^^^ DOC402
     |
     = help: Add a "Yields" section to the docstring
+
+DOC402_google.py:108:5: DOC402 `yield` is not documented in docstring
+    |
+106 |     Do something
+107 |     """
+108 |     yield
+    |     ^^^^^ DOC402
+    |
+    = help: Add a "Yields" section to the docstring

--- a/crates/ruff_linter/src/rules/pydoclint/snapshots/ruff_linter__rules__pydoclint__tests__docstring-missing-yields_DOC402_numpy.py.snap
+++ b/crates/ruff_linter/src/rules/pydoclint/snapshots/ruff_linter__rules__pydoclint__tests__docstring-missing-yields_DOC402_numpy.py.snap
@@ -18,3 +18,42 @@ DOC402_numpy.py:62:9: DOC402 `yield` is not documented in docstring
    |         ^^^^^^^^^^^^ DOC402
    |
    = help: Add a "Yields" section to the docstring
+
+DOC402_numpy.py:89:5: DOC402 `yield` is not documented in docstring
+   |
+87 |     Do something
+88 |     """
+89 |     yield None
+   |     ^^^^^^^^^^ DOC402
+90 |     yield 1
+   |
+   = help: Add a "Yields" section to the docstring
+
+DOC402_numpy.py:98:5: DOC402 `yield` is not documented in docstring
+   |
+96 |     Do something
+97 |     """
+98 |     yield None
+   |     ^^^^^^^^^^ DOC402
+   |
+   = help: Add a "Yields" section to the docstring
+
+DOC402_numpy.py:122:5: DOC402 `yield` is not documented in docstring
+    |
+120 |     Do something
+121 |     """
+122 |     yield None
+    |     ^^^^^^^^^^ DOC402
+123 |     yield 1
+    |
+    = help: Add a "Yields" section to the docstring
+
+DOC402_numpy.py:131:5: DOC402 `yield` is not documented in docstring
+    |
+129 |     Do something
+130 |     """
+131 |     yield 1
+    |     ^^^^^^^ DOC402
+132 |     yield
+    |
+    = help: Add a "Yields" section to the docstring

--- a/crates/ruff_linter/src/rules/pydoclint/snapshots/ruff_linter__rules__pydoclint__tests__docstring-missing-yields_DOC402_numpy.py.snap
+++ b/crates/ruff_linter/src/rules/pydoclint/snapshots/ruff_linter__rules__pydoclint__tests__docstring-missing-yields_DOC402_numpy.py.snap
@@ -57,3 +57,12 @@ DOC402_numpy.py:131:5: DOC402 `yield` is not documented in docstring
 132 |     yield
     |
     = help: Add a "Yields" section to the docstring
+
+DOC402_numpy.py:140:5: DOC402 `yield` is not documented in docstring
+    |
+138 |     Do something
+139 |     """
+140 |     yield
+    |     ^^^^^ DOC402
+    |
+    = help: Add a "Yields" section to the docstring


### PR DESCRIPTION
## Summary

Currently, [docstring-extraneous-yields (DOC403)](https://docs.astral.sh/ruff/rules/docstring-extraneous-yields/) reports a diagnostic if there is a yields section in a docstring for a function that yields `None` implicitly; for example,

```python
from collections import abc

def gen() -> abc.Generator[None, None, None]:
    """A very helpful docstring.

    Yields:
        When foo.
    """
    ...  # some code
    yield
    ...  # some more code
```

This is problematic, as sometimes you want to document this yielding behaviour.

This patch permits such docstrings by now counting implicit `yield None` statements as yields. It then updates [docstring-missing-yields (DOC402)](https://docs.astral.sh/ruff/rules/docstring-missing-yields/) to allow users to forego a yield section if the function is resolved to yield `None` only (by checking the return annotation, or by checking the yield statements if the return type is not annotated).

This is similar to #13064

Closes #13001

## Test Plan

`cargo nextest run`
