### PR TITLE
Add a method to `Checker` for cached parsing of stringified type annotations

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_annotations/rules/definition.rs
+++ b/crates/ruff_linter/src/rules/flake8_annotations/rules/definition.rs
@@ -4,7 +4,6 @@ use ruff_python_ast::helpers::ReturnStatementVisitor;
 use ruff_python_ast::identifier::Identifier;
 use ruff_python_ast::visitor::Visitor;
 use ruff_python_ast::{self as ast, Expr, ParameterWithDefault, Stmt};
-use ruff_python_parser::typing::parse_type_annotation;
 use ruff_python_semantic::analyze::visibility;
 use ruff_python_semantic::Definition;
 use ruff_python_stdlib::typing::simple_magic_return_type;
@@ -514,13 +513,10 @@ fn check_dynamically_typed<F>(
 {
     if let Expr::StringLiteral(string_expr) = annotation {
         // Quoted annotations
-        if let Ok(parsed_annotation) =
-            parse_type_annotation(string_expr, checker.locator().contents())
-        {
+        if let Ok(parsed_annotation) = checker.parse_type_annotation(string_expr) {
             if type_hint_resolves_to_any(
                 parsed_annotation.expression(),
-                checker.semantic(),
-                checker.locator(),
+                checker,
                 checker.settings.target_version.minor(),
             ) {
                 diagnostics.push(Diagnostic::new(
@@ -530,12 +526,7 @@ fn check_dynamically_typed<F>(
             }
         }
     } else {
-        if type_hint_resolves_to_any(
-            annotation,
-            checker.semantic(),
-            checker.locator(),
-            checker.settings.target_version.minor(),
-        ) {
+        if type_hint_resolves_to_any(annotation, checker, checker.settings.target_version.minor()) {
             diagnostics.push(Diagnostic::new(
                 AnyType { name: func() },
                 annotation.range(),

--- a/crates/ruff_linter/src/rules/flake8_annotations/rules/definition.rs
+++ b/crates/ruff_linter/src/rules/flake8_annotations/rules/definition.rs
@@ -514,11 +514,11 @@ fn check_dynamically_typed<F>(
 {
     if let Expr::StringLiteral(string_expr) = annotation {
         // Quoted annotations
-        if let Ok((parsed_annotation, _)) =
+        if let Ok(parsed_annotation) =
             parse_type_annotation(string_expr, checker.locator().contents())
         {
             if type_hint_resolves_to_any(
-                parsed_annotation.expr(),
+                parsed_annotation.expression(),
                 checker.semantic(),
                 checker.locator(),
                 checker.settings.target_version.minor(),

--- a/crates/ruff_linter/src/rules/flake8_annotations/rules/definition.rs
+++ b/crates/ruff_linter/src/rules/flake8_annotations/rules/definition.rs
@@ -513,7 +513,7 @@ fn check_dynamically_typed<F>(
 {
     if let Expr::StringLiteral(string_expr) = annotation {
         // Quoted annotations
-        if let Ok(parsed_annotation) = checker.parse_type_annotation(string_expr) {
+        if let Some(parsed_annotation) = checker.parse_type_annotation(string_expr) {
             if type_hint_resolves_to_any(
                 parsed_annotation.expression(),
                 checker,

--- a/crates/ruff_linter/src/rules/ruff/rules/implicit_optional.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/implicit_optional.rs
@@ -179,7 +179,7 @@ pub(crate) fn implicit_optional(checker: &mut Checker, parameters: &Parameters) 
 
         if let Expr::StringLiteral(string_expr) = annotation.as_ref() {
             // Quoted annotation.
-            if let Ok(parsed_annotation) = checker.parse_type_annotation(string_expr) {
+            if let Some(parsed_annotation) = checker.parse_type_annotation(string_expr) {
                 let Some(expr) = type_hint_explicitly_allows_none(
                     parsed_annotation.expression(),
                     checker,

--- a/crates/ruff_linter/src/rules/ruff/rules/implicit_optional.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/implicit_optional.rs
@@ -7,7 +7,6 @@ use ruff_macros::{derive_message_formats, violation};
 
 use ruff_python_ast::name::Name;
 use ruff_python_ast::{self as ast, Expr, Operator, ParameterWithDefault, Parameters};
-use ruff_python_parser::typing::parse_type_annotation;
 use ruff_text_size::{Ranged, TextRange};
 
 use crate::checkers::ast::Checker;
@@ -180,13 +179,10 @@ pub(crate) fn implicit_optional(checker: &mut Checker, parameters: &Parameters) 
 
         if let Expr::StringLiteral(string_expr) = annotation.as_ref() {
             // Quoted annotation.
-            if let Ok(parsed_annotation) =
-                parse_type_annotation(string_expr, checker.locator().contents())
-            {
+            if let Ok(parsed_annotation) = checker.parse_type_annotation(string_expr) {
                 let Some(expr) = type_hint_explicitly_allows_none(
                     parsed_annotation.expression(),
-                    checker.semantic(),
-                    checker.locator(),
+                    checker,
                     checker.settings.target_version.minor(),
                 ) else {
                     continue;
@@ -204,8 +200,7 @@ pub(crate) fn implicit_optional(checker: &mut Checker, parameters: &Parameters) 
             // Unquoted annotation.
             let Some(expr) = type_hint_explicitly_allows_none(
                 annotation,
-                checker.semantic(),
-                checker.locator(),
+                checker,
                 checker.settings.target_version.minor(),
             ) else {
                 continue;

--- a/crates/ruff_linter/src/rules/ruff/rules/implicit_optional.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/implicit_optional.rs
@@ -180,11 +180,11 @@ pub(crate) fn implicit_optional(checker: &mut Checker, parameters: &Parameters) 
 
         if let Expr::StringLiteral(string_expr) = annotation.as_ref() {
             // Quoted annotation.
-            if let Ok((parsed_annotation, kind)) =
+            if let Ok(parsed_annotation) =
                 parse_type_annotation(string_expr, checker.locator().contents())
             {
                 let Some(expr) = type_hint_explicitly_allows_none(
-                    parsed_annotation.expr(),
+                    parsed_annotation.expression(),
                     checker.semantic(),
                     checker.locator(),
                     checker.settings.target_version.minor(),
@@ -195,7 +195,7 @@ pub(crate) fn implicit_optional(checker: &mut Checker, parameters: &Parameters) 
 
                 let mut diagnostic =
                     Diagnostic::new(ImplicitOptional { conversion_type }, expr.range());
-                if kind.is_simple() {
+                if parsed_annotation.kind().is_simple() {
                     diagnostic.try_set_fix(|| generate_fix(checker, conversion_type, expr));
                 }
                 checker.diagnostics.push(diagnostic);

--- a/crates/ruff_linter/src/rules/ruff/typing.rs
+++ b/crates/ruff_linter/src/rules/ruff/typing.rs
@@ -110,10 +110,8 @@ impl<'a> TypingTarget<'a> {
             Expr::StringLiteral(string_expr) => checker
                 .parse_type_annotation(string_expr)
                 .as_ref()
-                .map_or(None, |parsed_annotation| {
-                    Some(TypingTarget::ForwardReference(
-                        parsed_annotation.expression(),
-                    ))
+                .map(|parsed_annotation| {
+                    TypingTarget::ForwardReference(parsed_annotation.expression())
                 }),
             _ => semantic.resolve_qualified_name(expr).map_or(
                 // If we can't resolve the call path, it must be defined in the

--- a/crates/ruff_linter/src/rules/ruff/typing.rs
+++ b/crates/ruff_linter/src/rules/ruff/typing.rs
@@ -116,9 +116,9 @@ impl<'a> TypingTarget<'a> {
                 string_expr,
                 locator.contents(),
             )
-            .map_or(None, |(parsed_annotation, _)| {
+            .map_or(None, |parsed_annotation| {
                 Some(TypingTarget::ForwardReference(
-                    parsed_annotation.into_expr(),
+                    parsed_annotation.into_expression(),
                 ))
             }),
             _ => semantic.resolve_qualified_name(expr).map_or(

--- a/crates/ruff_linter/src/rules/ruff/typing.rs
+++ b/crates/ruff_linter/src/rules/ruff/typing.rs
@@ -2,10 +2,9 @@ use itertools::Either::{Left, Right};
 use ruff_python_ast::name::QualifiedName;
 use ruff_python_ast::{self as ast, Expr, Operator};
 
-use ruff_python_parser::typing::parse_type_annotation;
-use ruff_python_semantic::SemanticModel;
 use ruff_python_stdlib::sys::is_known_standard_library;
-use ruff_source_file::Locator;
+
+use crate::checkers::ast::Checker;
 
 /// Returns `true` if the given qualified name is a known type.
 ///
@@ -40,7 +39,7 @@ enum TypingTarget<'a> {
     Object,
 
     /// Forward reference to a type e.g., `"List[str]"`.
-    ForwardReference(Expr),
+    ForwardReference(&'a Expr),
 
     /// A `typing.Union` type e.g., `Union[int, str]`.
     Union(&'a Expr),
@@ -71,12 +70,8 @@ enum TypingTarget<'a> {
 }
 
 impl<'a> TypingTarget<'a> {
-    fn try_from_expr(
-        expr: &'a Expr,
-        semantic: &SemanticModel,
-        locator: &Locator,
-        minor_version: u8,
-    ) -> Option<Self> {
+    fn try_from_expr(expr: &'a Expr, checker: &'a Checker, minor_version: u8) -> Option<Self> {
+        let semantic = checker.semantic();
         match expr {
             Expr::Subscript(ast::ExprSubscript { value, slice, .. }) => {
                 semantic.resolve_qualified_name(value).map_or(
@@ -112,15 +107,14 @@ impl<'a> TypingTarget<'a> {
                 ..
             }) => Some(TypingTarget::PEP604Union(left, right)),
             Expr::NoneLiteral(_) => Some(TypingTarget::None),
-            Expr::StringLiteral(string_expr) => parse_type_annotation(
-                string_expr,
-                locator.contents(),
-            )
-            .map_or(None, |parsed_annotation| {
-                Some(TypingTarget::ForwardReference(
-                    parsed_annotation.into_expression(),
-                ))
-            }),
+            Expr::StringLiteral(string_expr) => checker
+                .parse_type_annotation(string_expr)
+                .as_ref()
+                .map_or(None, |parsed_annotation| {
+                    Some(TypingTarget::ForwardReference(
+                        parsed_annotation.expression(),
+                    ))
+                }),
             _ => semantic.resolve_qualified_name(expr).map_or(
                 // If we can't resolve the call path, it must be defined in the
                 // same file, so we assume it's `Any` as it could be a type alias.
@@ -149,12 +143,7 @@ impl<'a> TypingTarget<'a> {
     }
 
     /// Check if the [`TypingTarget`] explicitly allows `None`.
-    fn contains_none(
-        &self,
-        semantic: &SemanticModel,
-        locator: &Locator,
-        minor_version: u8,
-    ) -> bool {
+    fn contains_none(&self, checker: &Checker, minor_version: u8) -> bool {
         match self {
             TypingTarget::None
             | TypingTarget::Optional(_)
@@ -166,43 +155,43 @@ impl<'a> TypingTarget<'a> {
             TypingTarget::Literal(slice) => resolve_slice_value(slice).any(|element| {
                 // Literal can only contain `None`, a literal value, other `Literal`
                 // or an enum value.
-                match TypingTarget::try_from_expr(element, semantic, locator, minor_version) {
+                match TypingTarget::try_from_expr(element, checker, minor_version) {
                     None | Some(TypingTarget::None) => true,
                     Some(new_target @ TypingTarget::Literal(_)) => {
-                        new_target.contains_none(semantic, locator, minor_version)
+                        new_target.contains_none(checker, minor_version)
                     }
                     _ => false,
                 }
             }),
             TypingTarget::Union(slice) => resolve_slice_value(slice).any(|element| {
-                TypingTarget::try_from_expr(element, semantic, locator, minor_version)
+                TypingTarget::try_from_expr(element, checker, minor_version)
                     .map_or(true, |new_target| {
-                        new_target.contains_none(semantic, locator, minor_version)
+                        new_target.contains_none(checker, minor_version)
                     })
             }),
             TypingTarget::PEP604Union(left, right) => [left, right].iter().any(|element| {
-                TypingTarget::try_from_expr(element, semantic, locator, minor_version)
+                TypingTarget::try_from_expr(element, checker, minor_version)
                     .map_or(true, |new_target| {
-                        new_target.contains_none(semantic, locator, minor_version)
+                        new_target.contains_none(checker, minor_version)
                     })
             }),
             TypingTarget::Annotated(expr) => {
-                TypingTarget::try_from_expr(expr, semantic, locator, minor_version)
+                TypingTarget::try_from_expr(expr, checker, minor_version)
                     .map_or(true, |new_target| {
-                        new_target.contains_none(semantic, locator, minor_version)
+                        new_target.contains_none(checker, minor_version)
                     })
             }
             TypingTarget::ForwardReference(expr) => {
-                TypingTarget::try_from_expr(expr, semantic, locator, minor_version)
+                TypingTarget::try_from_expr(expr, checker, minor_version)
                     .map_or(true, |new_target| {
-                        new_target.contains_none(semantic, locator, minor_version)
+                        new_target.contains_none(checker, minor_version)
                     })
             }
         }
     }
 
     /// Check if the [`TypingTarget`] explicitly allows `Any`.
-    fn contains_any(&self, semantic: &SemanticModel, locator: &Locator, minor_version: u8) -> bool {
+    fn contains_any(&self, checker: &Checker, minor_version: u8) -> bool {
         match self {
             TypingTarget::Any => true,
             // `Literal` cannot contain `Any` as it's a dynamic value.
@@ -213,27 +202,27 @@ impl<'a> TypingTarget<'a> {
             | TypingTarget::Known
             | TypingTarget::Unknown => false,
             TypingTarget::Union(slice) => resolve_slice_value(slice).any(|element| {
-                TypingTarget::try_from_expr(element, semantic, locator, minor_version)
+                TypingTarget::try_from_expr(element, checker, minor_version)
                     .map_or(true, |new_target| {
-                        new_target.contains_any(semantic, locator, minor_version)
+                        new_target.contains_any(checker, minor_version)
                     })
             }),
             TypingTarget::PEP604Union(left, right) => [left, right].iter().any(|element| {
-                TypingTarget::try_from_expr(element, semantic, locator, minor_version)
+                TypingTarget::try_from_expr(element, checker, minor_version)
                     .map_or(true, |new_target| {
-                        new_target.contains_any(semantic, locator, minor_version)
+                        new_target.contains_any(checker, minor_version)
                     })
             }),
             TypingTarget::Annotated(expr) | TypingTarget::Optional(expr) => {
-                TypingTarget::try_from_expr(expr, semantic, locator, minor_version)
+                TypingTarget::try_from_expr(expr, checker, minor_version)
                     .map_or(true, |new_target| {
-                        new_target.contains_any(semantic, locator, minor_version)
+                        new_target.contains_any(checker, minor_version)
                     })
             }
             TypingTarget::ForwardReference(expr) => {
-                TypingTarget::try_from_expr(expr, semantic, locator, minor_version)
+                TypingTarget::try_from_expr(expr, checker, minor_version)
                     .map_or(true, |new_target| {
-                        new_target.contains_any(semantic, locator, minor_version)
+                        new_target.contains_any(checker, minor_version)
                     })
             }
         }
@@ -249,11 +238,10 @@ impl<'a> TypingTarget<'a> {
 /// This function assumes that the annotation is a valid typing annotation expression.
 pub(crate) fn type_hint_explicitly_allows_none<'a>(
     annotation: &'a Expr,
-    semantic: &SemanticModel,
-    locator: &Locator,
+    checker: &'a Checker,
     minor_version: u8,
 ) -> Option<&'a Expr> {
-    match TypingTarget::try_from_expr(annotation, semantic, locator, minor_version) {
+    match TypingTarget::try_from_expr(annotation, checker, minor_version) {
         None |
             // Short circuit on top level `None`, `Any` or `Optional`
             Some(TypingTarget::None | TypingTarget::Optional(_) | TypingTarget::Any) => None,
@@ -262,10 +250,10 @@ pub(crate) fn type_hint_explicitly_allows_none<'a>(
         // is found nested inside another type, then the outer type should
         // be returned.
         Some(TypingTarget::Annotated(expr)) => {
-            type_hint_explicitly_allows_none(expr, semantic, locator, minor_version)
+            type_hint_explicitly_allows_none(expr, checker, minor_version)
         }
         Some(target) => {
-            if target.contains_none(semantic, locator, minor_version) {
+            if target.contains_none(checker, minor_version) {
                 None
             } else {
                 Some(annotation)
@@ -279,20 +267,19 @@ pub(crate) fn type_hint_explicitly_allows_none<'a>(
 /// This function assumes that the annotation is a valid typing annotation expression.
 pub(crate) fn type_hint_resolves_to_any(
     annotation: &Expr,
-    semantic: &SemanticModel,
-    locator: &Locator,
+    checker: &Checker,
     minor_version: u8,
 ) -> bool {
-    match TypingTarget::try_from_expr(annotation, semantic, locator, minor_version) {
+    match TypingTarget::try_from_expr(annotation, checker, minor_version) {
         None |
             // Short circuit on top level `Any`
             Some(TypingTarget::Any) => true,
         // Top-level `Annotated` node should check if the inner type resolves
         // to `Any`.
         Some(TypingTarget::Annotated(expr)) => {
-            type_hint_resolves_to_any(expr, semantic, locator, minor_version)
+            type_hint_resolves_to_any(expr, checker, minor_version)
         }
-        Some(target) => target.contains_any(semantic, locator, minor_version),
+        Some(target) => target.contains_any(checker, minor_version),
     }
 }
 

--- a/crates/ruff_python_parser/src/typing.rs
+++ b/crates/ruff_python_parser/src/typing.rs
@@ -24,10 +24,6 @@ impl ParsedAnnotation {
         self.parsed.expr()
     }
 
-    pub fn into_expression(self) -> Expr {
-        self.parsed.into_expr()
-    }
-
     pub fn kind(&self) -> AnnotationKind {
         self.kind
     }

--- a/crates/ruff_python_parser/src/typing.rs
+++ b/crates/ruff_python_parser/src/typing.rs
@@ -7,7 +7,7 @@ use ruff_text_size::Ranged;
 
 use crate::{parse_expression, parse_expression_range, ParseError, Parsed};
 
-pub type AnnotationParseResult = Result<ParsedAnnotation, ParseError>;
+type AnnotationParseResult = Result<ParsedAnnotation, ParseError>;
 
 #[derive(Debug)]
 pub struct ParsedAnnotation {

--- a/crates/ruff_python_parser/src/typing.rs
+++ b/crates/ruff_python_parser/src/typing.rs
@@ -2,10 +2,36 @@
 
 use ruff_python_ast::relocate::relocate_expr;
 use ruff_python_ast::str::raw_contents;
-use ruff_python_ast::{ExprStringLiteral, ModExpression, StringFlags, StringLiteral};
+use ruff_python_ast::{Expr, ExprStringLiteral, ModExpression, StringFlags, StringLiteral};
 use ruff_text_size::Ranged;
 
 use crate::{parse_expression, parse_expression_range, ParseError, Parsed};
+
+pub type AnnotationParseResult = Result<ParsedAnnotation, ParseError>;
+
+#[derive(Debug)]
+pub struct ParsedAnnotation {
+    parsed: Parsed<ModExpression>,
+    kind: AnnotationKind,
+}
+
+impl ParsedAnnotation {
+    pub fn parsed(&self) -> &Parsed<ModExpression> {
+        &self.parsed
+    }
+
+    pub fn expression(&self) -> &Expr {
+        self.parsed.expr()
+    }
+
+    pub fn into_expression(self) -> Expr {
+        self.parsed.into_expr()
+    }
+
+    pub fn kind(&self) -> AnnotationKind {
+        self.kind
+    }
+}
 
 #[derive(Copy, Clone, Debug)]
 pub enum AnnotationKind {
@@ -34,7 +60,7 @@ impl AnnotationKind {
 pub fn parse_type_annotation(
     string_expr: &ExprStringLiteral,
     source: &str,
-) -> Result<(Parsed<ModExpression>, AnnotationKind), ParseError> {
+) -> AnnotationParseResult {
     let expr_text = &source[string_expr.range()];
 
     if let [string_literal] = string_expr.value.as_slice() {
@@ -58,23 +84,22 @@ pub fn parse_type_annotation(
 fn parse_simple_type_annotation(
     string_literal: &StringLiteral,
     source: &str,
-) -> Result<(Parsed<ModExpression>, AnnotationKind), ParseError> {
-    Ok((
-        parse_expression_range(
-            source,
-            string_literal
-                .range()
-                .add_start(string_literal.flags.opener_len())
-                .sub_end(string_literal.flags.closer_len()),
-        )?,
-        AnnotationKind::Simple,
-    ))
+) -> AnnotationParseResult {
+    let range_excluding_quotes = string_literal
+        .range()
+        .add_start(string_literal.flags.opener_len())
+        .sub_end(string_literal.flags.closer_len());
+    Ok(ParsedAnnotation {
+        parsed: parse_expression_range(source, range_excluding_quotes)?,
+        kind: AnnotationKind::Simple,
+    })
 }
 
-fn parse_complex_type_annotation(
-    string_expr: &ExprStringLiteral,
-) -> Result<(Parsed<ModExpression>, AnnotationKind), ParseError> {
+fn parse_complex_type_annotation(string_expr: &ExprStringLiteral) -> AnnotationParseResult {
     let mut parsed = parse_expression(string_expr.value.to_str())?;
     relocate_expr(parsed.expr_mut(), string_expr.range());
-    Ok((parsed, AnnotationKind::Complex))
+    Ok(ParsedAnnotation {
+        parsed,
+        kind: AnnotationKind::Complex,
+    })
 }


### PR DESCRIPTION
## Summary

This PR adds a method to `ruff_linter::checkers::ast::Checker` for cached parsing of stringified type annotations. It was decided in review of #12951 that this would be desirable, since `ruff_python_parser::typing::parse_type_annotation` can be quite expensive. However, since we already have a number of linter rules that call `ruff_python_parser::typing::parse_type_annotation`, it seemed to me like this would make sense as a standalone PR. (Adding caching was also more complicated than I expected, so separating this into its own PR should make life easier for reviewers.) If this is accepted, I'll rebase #12951 on top of it.

The PR should be easiest to review commit-by-commit. Each commit on its own passes the entire test suite. The first two commits do some refactoring to lay the groundwork for adding the new method. The third commit adds the new method and makes use of it in `crates/ruff_linter/src/checkers/ast/mod.rs`; the final commit makes use of the new method in various linter rules that currently use `ruff_python_parser::typing::parse_type_annotation`.

## Test Plan

`cargo test`
