### PR TITLE
Avoid `no-self-use` for `attrs`-style validators

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pylint/no_self_use.py
+++ b/crates/ruff_linter/resources/test/fixtures/pylint/no_self_use.py
@@ -83,3 +83,23 @@ class B(A):
     def baz(self):
         if super().foo():
             ...
+
+
+# See: https://github.com/astral-sh/ruff/issues/12568
+from attrs import define, field
+
+
+@define
+class Foo:
+    x: int = field()
+    y: int
+
+    @x.validator
+    def validate_x(self, attribute, value):
+        if value <= 0:
+            raise ValueError("x must be a positive integer")
+
+    @y.validator
+    def validate_y(self, attribute, value):
+        if value <= 0:
+            raise ValueError("y must be a positive integer")

--- a/crates/ruff_linter/src/rules/pylint/rules/no_self_use.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/no_self_use.rs
@@ -87,6 +87,7 @@ pub(crate) fn no_self_use(
         || visibility::is_override(decorator_list, semantic)
         || visibility::is_overload(decorator_list, semantic)
         || visibility::is_property(decorator_list, extra_property_decorators, semantic)
+        || visibility::is_validator(decorator_list, semantic)
     {
         return;
     }

--- a/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLR6301_no_self_use.py.snap
+++ b/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLR6301_no_self_use.py.snap
@@ -27,4 +27,11 @@ no_self_use.py:13:9: PLR6301 Method `greeting_2` could be a function, class meth
 14 |         print("Hi!")
    |
 
-
+no_self_use.py:103:9: PLR6301 Method `validate_y` could be a function, class method, or static method
+    |
+102 |     @y.validator
+103 |     def validate_y(self, attribute, value):
+    |         ^^^^^^^^^^ PLR6301
+104 |         if value <= 0:
+105 |             raise ValueError("y must be a positive integer")
+    |


### PR DESCRIPTION
## Summary

Closes https://github.com/astral-sh/ruff/issues/12568.
