### PR TITLE
[red-knot] Infer type of class constructor call expression

### DIFF
--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -328,7 +328,8 @@ impl<'db> Type<'db> {
         match self {
             Type::Function(function_type) => function_type.returns(db).or(Some(Type::Unknown)),
 
-            Type::Class(_class_ty) => Some(self.instance()),
+            // TODO annotated return type on `__new__` or metaclass `__call__`
+            Type::Class(class) => Some(Type::Instance(*class)),
 
             // TODO: handle classes which implement the Callable protocol
             Type::Instance(_instance_ty) => Some(Type::Unknown),

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -328,8 +328,7 @@ impl<'db> Type<'db> {
         match self {
             Type::Function(function_type) => function_type.returns(db).or(Some(Type::Unknown)),
 
-            // TODO: handle class constructors
-            Type::Class(_class_ty) => Some(Type::Unknown),
+            Type::Class(_class_ty) => Some(self.instance()),
 
             // TODO: handle classes which implement the Callable protocol
             Type::Instance(_instance_ty) => Some(Type::Unknown),

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -2835,6 +2835,24 @@ mod tests {
     }
 
     #[test]
+    fn class_constructor_call_expression() -> anyhow::Result<()> {
+        let mut db = setup_db();
+
+        db.write_dedented(
+            "src/a.py",
+            "
+            class Foo: ...
+
+            x = Foo()
+            ",
+        )?;
+
+        assert_public_ty(&db, "src/a.py", "x", "Foo");
+
+        Ok(())
+    }
+
+    #[test]
     fn resolve_union() -> anyhow::Result<()> {
         let mut db = setup_db();
 


### PR DESCRIPTION
This tiny PR implements the following type inference: the type of `Foo(...)` will be `Foo`.
