### PR TITLE
Mark `sys.version_info[0] < 3` and similar comparisons as outdated

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP036_0.py
+++ b/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP036_0.py
@@ -225,3 +225,33 @@ if sys.version_info > (3,0):
 
     "this is\
     allowed too"
+
+if sys.version_info[0] == 3:
+    print("py3")
+
+if sys.version_info[0] <= 3:
+    print("py3")
+
+if sys.version_info[0] < 3:
+    print("py3")
+
+if sys.version_info[0] >= 3:
+    print("py3")
+
+if sys.version_info[0] > 3:
+    print("py3")
+
+if sys.version_info[0] == 2:
+    print("py3")
+
+if sys.version_info[0] <= 2:
+    print("py3")
+
+if sys.version_info[0] < 2:
+    print("py3")
+
+if sys.version_info[0] >= 2:
+    print("py3")
+
+if sys.version_info[0] > 2:
+    print("py3")

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP036_0.py.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP036_0.py.snap
@@ -801,3 +801,207 @@ UP036_0.py:219:4: UP036 [*] Version block is outdated for minimum Python version
 226     |-    "this is\
     225 |+"this is\
 227 226 |     allowed too"
+228 227 | 
+229 228 | if sys.version_info[0] == 3:
+
+UP036_0.py:229:4: UP036 [*] Version block is outdated for minimum Python version
+    |
+227 |     allowed too"
+228 | 
+229 | if sys.version_info[0] == 3:
+    |    ^^^^^^^^^^^^^^^^^^^^^^^^ UP036
+230 |     print("py3")
+    |
+    = help: Remove outdated version block
+
+ℹ Unsafe fix
+226 226 |     "this is\
+227 227 |     allowed too"
+228 228 | 
+229     |-if sys.version_info[0] == 3:
+230     |-    print("py3")
+    229 |+print("py3")
+231 230 | 
+232 231 | if sys.version_info[0] <= 3:
+233 232 |     print("py3")
+
+UP036_0.py:232:4: UP036 [*] Version block is outdated for minimum Python version
+    |
+230 |     print("py3")
+231 | 
+232 | if sys.version_info[0] <= 3:
+    |    ^^^^^^^^^^^^^^^^^^^^^^^^ UP036
+233 |     print("py3")
+    |
+    = help: Remove outdated version block
+
+ℹ Unsafe fix
+229 229 | if sys.version_info[0] == 3:
+230 230 |     print("py3")
+231 231 | 
+232     |-if sys.version_info[0] <= 3:
+233     |-    print("py3")
+    232 |+print("py3")
+234 233 | 
+235 234 | if sys.version_info[0] < 3:
+236 235 |     print("py3")
+
+UP036_0.py:235:4: UP036 [*] Version block is outdated for minimum Python version
+    |
+233 |     print("py3")
+234 | 
+235 | if sys.version_info[0] < 3:
+    |    ^^^^^^^^^^^^^^^^^^^^^^^ UP036
+236 |     print("py3")
+    |
+    = help: Remove outdated version block
+
+ℹ Unsafe fix
+232 232 | if sys.version_info[0] <= 3:
+233 233 |     print("py3")
+234 234 | 
+235     |-if sys.version_info[0] < 3:
+236     |-    print("py3")
+237 235 | 
+238 236 | if sys.version_info[0] >= 3:
+239 237 |     print("py3")
+
+UP036_0.py:238:4: UP036 [*] Version block is outdated for minimum Python version
+    |
+236 |     print("py3")
+237 | 
+238 | if sys.version_info[0] >= 3:
+    |    ^^^^^^^^^^^^^^^^^^^^^^^^ UP036
+239 |     print("py3")
+    |
+    = help: Remove outdated version block
+
+ℹ Unsafe fix
+235 235 | if sys.version_info[0] < 3:
+236 236 |     print("py3")
+237 237 | 
+238     |-if sys.version_info[0] >= 3:
+239     |-    print("py3")
+    238 |+print("py3")
+240 239 | 
+241 240 | if sys.version_info[0] > 3:
+242 241 |     print("py3")
+
+UP036_0.py:241:4: UP036 [*] Version block is outdated for minimum Python version
+    |
+239 |     print("py3")
+240 | 
+241 | if sys.version_info[0] > 3:
+    |    ^^^^^^^^^^^^^^^^^^^^^^^ UP036
+242 |     print("py3")
+    |
+    = help: Remove outdated version block
+
+ℹ Unsafe fix
+238 238 | if sys.version_info[0] >= 3:
+239 239 |     print("py3")
+240 240 | 
+241     |-if sys.version_info[0] > 3:
+242     |-    print("py3")
+243 241 | 
+244 242 | if sys.version_info[0] == 2:
+245 243 |     print("py3")
+
+UP036_0.py:244:4: UP036 [*] Version block is outdated for minimum Python version
+    |
+242 |     print("py3")
+243 | 
+244 | if sys.version_info[0] == 2:
+    |    ^^^^^^^^^^^^^^^^^^^^^^^^ UP036
+245 |     print("py3")
+    |
+    = help: Remove outdated version block
+
+ℹ Unsafe fix
+241 241 | if sys.version_info[0] > 3:
+242 242 |     print("py3")
+243 243 | 
+244     |-if sys.version_info[0] == 2:
+245     |-    print("py3")
+246 244 | 
+247 245 | if sys.version_info[0] <= 2:
+248 246 |     print("py3")
+
+UP036_0.py:247:4: UP036 [*] Version block is outdated for minimum Python version
+    |
+245 |     print("py3")
+246 | 
+247 | if sys.version_info[0] <= 2:
+    |    ^^^^^^^^^^^^^^^^^^^^^^^^ UP036
+248 |     print("py3")
+    |
+    = help: Remove outdated version block
+
+ℹ Unsafe fix
+244 244 | if sys.version_info[0] == 2:
+245 245 |     print("py3")
+246 246 | 
+247     |-if sys.version_info[0] <= 2:
+248     |-    print("py3")
+249 247 | 
+250 248 | if sys.version_info[0] < 2:
+251 249 |     print("py3")
+
+UP036_0.py:250:4: UP036 [*] Version block is outdated for minimum Python version
+    |
+248 |     print("py3")
+249 | 
+250 | if sys.version_info[0] < 2:
+    |    ^^^^^^^^^^^^^^^^^^^^^^^ UP036
+251 |     print("py3")
+    |
+    = help: Remove outdated version block
+
+ℹ Unsafe fix
+247 247 | if sys.version_info[0] <= 2:
+248 248 |     print("py3")
+249 249 | 
+250     |-if sys.version_info[0] < 2:
+251     |-    print("py3")
+252 250 | 
+253 251 | if sys.version_info[0] >= 2:
+254 252 |     print("py3")
+
+UP036_0.py:253:4: UP036 [*] Version block is outdated for minimum Python version
+    |
+251 |     print("py3")
+252 | 
+253 | if sys.version_info[0] >= 2:
+    |    ^^^^^^^^^^^^^^^^^^^^^^^^ UP036
+254 |     print("py3")
+    |
+    = help: Remove outdated version block
+
+ℹ Unsafe fix
+250 250 | if sys.version_info[0] < 2:
+251 251 |     print("py3")
+252 252 | 
+253     |-if sys.version_info[0] >= 2:
+254     |-    print("py3")
+    253 |+print("py3")
+255 254 | 
+256 255 | if sys.version_info[0] > 2:
+257 256 |     print("py3")
+
+UP036_0.py:256:4: UP036 [*] Version block is outdated for minimum Python version
+    |
+254 |     print("py3")
+255 | 
+256 | if sys.version_info[0] > 2:
+    |    ^^^^^^^^^^^^^^^^^^^^^^^ UP036
+257 |     print("py3")
+    |
+    = help: Remove outdated version block
+
+ℹ Unsafe fix
+253 253 | if sys.version_info[0] >= 2:
+254 254 |     print("py3")
+255 255 | 
+256     |-if sys.version_info[0] > 2:
+257     |-    print("py3")
+    256 |+print("py3")


### PR DESCRIPTION
## Summary

Closes https://github.com/astral-sh/ruff/issues/12993.
