### PR TITLE
[red-knot] `Literal[True,False]` normalized to `builtins.bool`

### DIFF
--- a/crates/red_knot_python_semantic/src/types/builder.rs
+++ b/crates/red_knot_python_semantic/src/types/builder.rs
@@ -65,7 +65,12 @@ impl<'db> UnionBuilder<'db> {
             2 if self.elements.contains(&Type::BooleanLiteral(true))
                 && self.elements.contains(&Type::BooleanLiteral(false)) =>
             {
-                builtins_symbol_ty_by_name(self.db, "bool")
+                let ty = builtins_symbol_ty_by_name(self.db, "bool");
+                if ty.is_unbound() {
+                    Type::Union(UnionType::new(self.db, self.elements))
+                } else {
+                    ty
+                }
             }
             _ => Type::Union(UnionType::new(self.db, self.elements)),
         }

--- a/crates/red_knot_python_semantic/src/types/builder.rs
+++ b/crates/red_knot_python_semantic/src/types/builder.rs
@@ -68,11 +68,9 @@ impl<'db> UnionBuilder<'db> {
             .is_superset(&[Type::BooleanLiteral(true), Type::BooleanLiteral(false)].into())
         {
             let bool_ty = builtins_symbol_ty_by_name(self.db, "bool");
-            if !bool_ty.is_unbound() {
-                self.elements.remove(&Type::BooleanLiteral(true));
-                self.elements.remove(&Type::BooleanLiteral(false));
-                self.elements.insert(bool_ty);
-            }
+            self.elements.remove(&Type::BooleanLiteral(true));
+            self.elements.remove(&Type::BooleanLiteral(false));
+            self.elements.insert(bool_ty);
         }
     }
 

--- a/crates/red_knot_python_semantic/src/types/builder.rs
+++ b/crates/red_knot_python_semantic/src/types/builder.rs
@@ -331,16 +331,29 @@ mod tests {
 
     #[test]
     fn build_union_bool() {
-        let db = setup_db_with_python();
-        let ty_expect = builtins_symbol_ty_by_name(&db, "bool");
+        let db = setup_db();
+        let bool_ty = builtins_symbol_ty_by_name(&db, "bool");
+
         let t0 = Type::BooleanLiteral(true);
         let t1 = Type::BooleanLiteral(true);
         let t2 = Type::BooleanLiteral(false);
-        let ty_true = UnionBuilder::new(&db).add(t0).add(t1).build();
-        let ty = UnionBuilder::new(&db).add(t0).add(t1).add(t2).build();
+        let t3 = Type::IntLiteral(17);
 
-        assert_eq!(ty_true, Type::BooleanLiteral(true));
-        assert_eq!(ty, ty_expect);
+        let Type::Union(union) = UnionBuilder::new(&db).add(t0).add(t1).add(t3).build() else {
+            panic!("expected a union");
+        };
+        assert_eq!(union.elements_vec(&db), &[t0, t3]);
+        let Type::Union(union) = UnionBuilder::new(&db)
+            .add(t0)
+            .add(t1)
+            .add(t2)
+            .add(t3)
+            .build()
+        else {
+            panic!("expected a union");
+        };
+
+        assert_eq!(union.elements_vec(&db), &[t3, bool_ty]);
     }
 
     #[test]

--- a/crates/red_knot_python_semantic/src/types/builder.rs
+++ b/crates/red_knot_python_semantic/src/types/builder.rs
@@ -28,6 +28,8 @@
 use crate::types::{IntersectionType, Type, UnionType};
 use crate::{Db, FxOrderSet};
 
+use super::builtins_symbol_ty_by_name;
+
 pub(crate) struct UnionBuilder<'db> {
     elements: FxOrderSet<Type<'db>>,
     db: &'db dyn Db,
@@ -60,6 +62,11 @@ impl<'db> UnionBuilder<'db> {
         match self.elements.len() {
             0 => Type::Never,
             1 => self.elements[0],
+            2 if self.elements.contains(&Type::BooleanLiteral(true))
+                && self.elements.contains(&Type::BooleanLiteral(false)) =>
+            {
+                builtins_symbol_ty_by_name(self.db, "bool")
+            }
             _ => Type::Union(UnionType::new(self.db, self.elements)),
         }
     }

--- a/crates/red_knot_python_semantic/src/types/builder.rs
+++ b/crates/red_knot_python_semantic/src/types/builder.rs
@@ -265,17 +265,13 @@ mod tests {
     use crate::ProgramSettings;
     use ruff_db::system::{DbWithTestSystem, SystemPathBuf};
 
-    fn setup_db() -> TestDb {
-        TestDb::new()
-    }
-
     impl<'db> UnionType<'db> {
         fn elements_vec(self, db: &'db TestDb) -> Vec<Type<'db>> {
             self.elements(db).into_iter().collect()
         }
     }
 
-    fn setup_db_with_python() -> TestDb {
+    fn setup_db() -> TestDb {
         let db = TestDb::new();
 
         let src_root = SystemPathBuf::from("/src");


### PR DESCRIPTION
The `UnionBuilder` builds `builtins.bool` when handed `Literal[True]` and `Literal[False]`.

Caveat: If the builtins module is unfindable somehow, the builder falls back to the union type of these two literals.

First task from #12694
