### PR TITLE
Enrich messages of SARIF results

### DIFF
--- a/crates/ruff_linter/src/message/sarif.rs
+++ b/crates/ruff_linter/src/message/sarif.rs
@@ -121,7 +121,7 @@ impl SarifResult {
         Ok(Self {
             rule: message.rule(),
             level: "error".to_string(),
-            message: message.name().to_string(),
+            message: message.body().to_string(),
             uri: url::Url::from_file_path(&path)
                 .map_err(|()| anyhow::anyhow!("Failed to convert path to URL: {}", path.display()))?
                 .to_string(),
@@ -215,6 +215,7 @@ mod tests {
             .unwrap();
         let results = sarif["runs"][0]["results"].as_array().unwrap();
         assert_eq!(results.len(), 3);
+        assert_eq!(results[0]["message"]["text"].as_str().unwrap(), "`os` imported but unused");
         assert!(rules.len() > 3);
     }
 }

--- a/crates/ruff_linter/src/message/sarif.rs
+++ b/crates/ruff_linter/src/message/sarif.rs
@@ -141,7 +141,7 @@ impl SarifResult {
         Ok(Self {
             rule: message.rule(),
             level: "error".to_string(),
-            message: message.name().to_string(),
+            message: message.body().to_string(),
             uri: path.display().to_string(),
             start_line: start_location.row,
             start_column: start_location.column,

--- a/crates/ruff_linter/src/message/sarif.rs
+++ b/crates/ruff_linter/src/message/sarif.rs
@@ -215,7 +215,10 @@ mod tests {
             .unwrap();
         let results = sarif["runs"][0]["results"].as_array().unwrap();
         assert_eq!(results.len(), 3);
-        assert_eq!(results[0]["message"]["text"].as_str().unwrap(), "`os` imported but unused");
+        assert_eq!(
+            results[0]["message"]["text"].as_str().unwrap(),
+            "`os` imported but unused"
+        );
         assert!(rules.len() > 3);
     }
 }


### PR DESCRIPTION
Closes #13179.

After this patch, we'll get more informative messages as below:

```json
{
  "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
  "runs": [
    {
      "results": [
        {
          "level": "error",
          "locations": [
            {
              "physicalLocation": {
                "artifactLocation": {...},
                "region": {
                  "endColumn": 10,
                  "endLine": 1,
                  "startColumn": 8,
                  "startLine": 1
                }
              }
            }
          ],
          "message": {
            "text": "`os` imported but unused"
          },
          "ruleId": "F401"
        },
        {
          "level": "error",
          "locations": [
            {
              "physicalLocation": {
                "artifactLocation": {...},
                "region": {
                  "endColumn": 34,
                  "endLine": 4,
                  "startColumn": 11,
                  "startLine": 4
                }
              }
            }
          ],
          "message": {
            "text": "`.format` call is missing argument(s) for placeholder(s): name"
          },
          "ruleId": "F524"
        }
      ],
      "tool": {...}
    }
  ],
  "version": "2.1.0"
}
```