### PR TITLE
[red-knot] Condense literals display by types

### DIFF
--- a/crates/red_knot_python_semantic/src/lib.rs
+++ b/crates/red_knot_python_semantic/src/lib.rs
@@ -23,3 +23,4 @@ pub(crate) mod site_packages;
 pub mod types;
 
 type FxOrderSet<V> = ordermap::set::OrderSet<V, BuildHasherDefault<FxHasher>>;
+type FxOrderMap<K, V> = ordermap::map::OrderMap<K, V, BuildHasherDefault<FxHasher>>;

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -224,6 +224,19 @@ impl<'db> Type<'db> {
         matches!(self, Type::Never)
     }
 
+    /// Returns `true` if this type should be displayed as a literal value.
+    pub const fn is_literal(&self) -> bool {
+        matches!(
+            self,
+            Type::IntLiteral(_)
+                | Type::BooleanLiteral(_)
+                | Type::StringLiteral(_)
+                | Type::BytesLiteral(_)
+                | Type::Class(_)
+                | Type::Function(_)
+        )
+    }
+
     pub fn may_be_unbound(&self, db: &'db dyn Db) -> bool {
         match self {
             Type::Unbound => true,

--- a/crates/red_knot_python_semantic/src/types/display.rs
+++ b/crates/red_knot_python_semantic/src/types/display.rs
@@ -80,32 +80,53 @@ impl Display for DisplayUnionType<'_> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         let union = self.ty;
 
-        let (int_literals, other_types): (Vec<Type>, Vec<Type>) = union
+        // Group literals by type: {int, string, bytes, boolean, function, class}
+        let mut all_literals: Vec<Vec<String>> =
+            vec![vec![], vec![], vec![], vec![], vec![], vec![]];
+        let mut other_types = vec![];
+
+        union
             .elements(self.db)
             .iter()
             .copied()
-            .partition(|ty| matches!(ty, Type::IntLiteral(_)));
+            .for_each(|ty| match ty {
+                // Write a String for each literal type appended in order of appearance
+                Type::IntLiteral(n) => all_literals[0].push(format!("{n}")),
+                Type::StringLiteral(s) => all_literals[1].push(format!("\"{}\"", s.value(self.db))),
+                Type::BytesLiteral(b) => {
+                    let escape =
+                        AsciiEscape::with_preferred_quote(b.value(self.db).as_ref(), Quote::Double);
+                    if let Some(string) = escape.bytes_repr().to_string() {
+                        all_literals[2].push(string);
+                    }
+                }
+                Type::BooleanLiteral(b) => all_literals[3].push(if b {
+                    "True".to_string()
+                } else {
+                    "False".to_string()
+                }),
+                Type::Class(c) => all_literals[4].push(c.name(self.db).to_string()),
+                Type::Function(f) => all_literals[5].push(f.name(self.db).to_string()),
+                _ => other_types.push(ty),
+            });
+
+        all_literals
+            .iter_mut()
+            .for_each(|group| group.sort_unstable());
 
         let mut first = true;
-        if !int_literals.is_empty() {
+        for literals_group in all_literals.iter().filter(|group| !group.is_empty()) {
+            if !first {
+                f.write_str(" | ")?;
+            };
+            first = false;
+
             f.write_str("Literal[")?;
-            let mut nums: Vec<_> = int_literals
-                .into_iter()
-                .filter_map(|ty| {
-                    if let Type::IntLiteral(n) = ty {
-                        Some(n)
-                    } else {
-                        None
-                    }
-                })
-                .collect();
-            nums.sort_unstable();
-            for num in nums {
-                if !first {
+            for (i, literal) in literals_group.iter().enumerate() {
+                if i > 0 {
                     f.write_str(", ")?;
                 }
-                write!(f, "{num}")?;
-                first = false;
+                write!(f, "{literal}")?;
             }
             f.write_str("]")?;
         }
@@ -165,5 +186,98 @@ impl Display for DisplayIntersectionType<'_> {
 impl std::fmt::Debug for DisplayIntersectionType<'_> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         std::fmt::Display::fmt(self, f)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::db::tests::TestDb;
+    use crate::types::{
+        global_symbol_ty_by_name, BytesLiteralType, StringLiteralType, Type, UnionBuilder,
+    };
+    use crate::{Program, ProgramSettings, PythonVersion, SearchPathSettings};
+    use ruff_db::files::system_path_to_file;
+    use ruff_db::system::{DbWithTestSystem, SystemPathBuf};
+
+    fn setup_db() -> TestDb {
+        let db = TestDb::new();
+
+        let src_root = SystemPathBuf::from("/src");
+        db.memory_file_system()
+            .create_directory_all(&src_root)
+            .unwrap();
+
+        Program::from_settings(
+            &db,
+            &ProgramSettings {
+                target_version: PythonVersion::default(),
+                search_paths: SearchPathSettings::new(src_root),
+            },
+        )
+        .expect("Valid search path settings");
+
+        db
+    }
+
+    #[test]
+    fn test_condense_literal_display_by_type() -> anyhow::Result<()> {
+        let mut db = setup_db();
+
+        db.write_dedented(
+            "src/main.py",
+            "
+            def foo(x: int) -> int:
+                return x + 1
+
+            def bar(s: str) -> str:
+                return s
+
+            class A: ...
+            class B: ...
+            ",
+        )?;
+        let mod_file = system_path_to_file(&db, "src/main.py").expect("Expected file to exist.");
+
+        let vec: Vec<Type<'_>> = vec![
+            // Bytes Literals
+            Type::BytesLiteral(BytesLiteralType::new(&db, Box::from([7]))),
+            Type::BytesLiteral(BytesLiteralType::new(&db, Box::from([0]))),
+            // Strings Literals
+            Type::StringLiteral(StringLiteralType::new(&db, Box::from("B"))),
+            Type::StringLiteral(StringLiteralType::new(&db, Box::from("A"))),
+            // Integers Literals
+            Type::IntLiteral(1),
+            Type::IntLiteral(-1),
+            Type::IntLiteral(0),
+            // Other non Literals
+            global_symbol_ty_by_name(&db, mod_file, "foo"),
+            global_symbol_ty_by_name(&db, mod_file, "bar"),
+            global_symbol_ty_by_name(&db, mod_file, "A"),
+            global_symbol_ty_by_name(&db, mod_file, "B"),
+            Type::None,
+            // Booleans Literals
+            Type::BooleanLiteral(false),
+            Type::BooleanLiteral(true),
+        ];
+        let builder = vec.iter().fold(UnionBuilder::new(&db), |builder, literal| {
+            builder.add(*literal)
+        });
+        let Type::Union(union) = builder.build() else {
+            panic!("expected a union");
+        };
+        let display = format!("{}", union.display(&db));
+        assert_eq!(
+            display,
+            concat!(
+                "Literal[-1, 0, 1] | ",
+                "Literal[\"A\", \"B\"] | ",
+                "Literal[b\"\\x00\", b\"\\x07\"] | ",
+                "Literal[False, True] | ",
+                "Literal[A, B] | ",
+                "Literal[bar, foo] | ",
+                "None"
+            )
+        );
+        Ok(())
     }
 }

--- a/crates/red_knot_python_semantic/src/types/display.rs
+++ b/crates/red_knot_python_semantic/src/types/display.rs
@@ -80,9 +80,8 @@ impl Display for DisplayUnionType<'_> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         let union = self.ty;
 
-        // Group literals by type: {int, string, bytes, boolean, function, class}
-        let mut all_literals: Vec<Vec<String>> =
-            vec![vec![], vec![], vec![], vec![], vec![], vec![]];
+        // Group literals by type: {int, string, bytes, function, class}
+        let mut all_literals: Vec<Vec<String>> = vec![vec![], vec![], vec![], vec![], vec![]];
         let mut other_types = vec![];
 
         union
@@ -100,13 +99,8 @@ impl Display for DisplayUnionType<'_> {
                         all_literals[2].push(string);
                     }
                 }
-                Type::BooleanLiteral(b) => all_literals[3].push(if b {
-                    "True".to_string()
-                } else {
-                    "False".to_string()
-                }),
-                Type::Class(c) => all_literals[4].push(c.name(self.db).to_string()),
-                Type::Function(f) => all_literals[5].push(f.name(self.db).to_string()),
+                Type::Class(c) => all_literals[3].push(c.name(self.db).to_string()),
+                Type::Function(f) => all_literals[4].push(f.name(self.db).to_string()),
                 _ => other_types.push(ty),
             });
 
@@ -249,15 +243,15 @@ mod tests {
             Type::IntLiteral(1),
             Type::IntLiteral(-1),
             Type::IntLiteral(0),
-            // Other non Literals
+            // Functions
             global_symbol_ty_by_name(&db, mod_file, "foo"),
             global_symbol_ty_by_name(&db, mod_file, "bar"),
+            // Classes
             global_symbol_ty_by_name(&db, mod_file, "A"),
             global_symbol_ty_by_name(&db, mod_file, "B"),
-            Type::None,
-            // Booleans Literals
-            Type::BooleanLiteral(false),
+            // Other non-grouped types
             Type::BooleanLiteral(true),
+            Type::None,
         ];
         let builder = vec.iter().fold(UnionBuilder::new(&db), |builder, literal| {
             builder.add(*literal)
@@ -272,9 +266,9 @@ mod tests {
                 "Literal[-1, 0, 1] | ",
                 "Literal[\"A\", \"B\"] | ",
                 "Literal[b\"\\x00\", b\"\\x07\"] | ",
-                "Literal[False, True] | ",
                 "Literal[A, B] | ",
                 "Literal[bar, foo] | ",
+                "Literal[True] | ",
                 "None"
             )
         );

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -3596,7 +3596,7 @@ mod tests {
         assert_public_ty(&db, "/src/a.py", "x", "Literal[2, 3]");
         // if just-body were possible without the break, then 0 would be possible for y
         // 1 and 2 both being possible for y shows that we can hit else with or without body
-        assert_public_ty(&db, "/src/a.py", "y", "Literal[4, 1, 2]");
+        assert_public_ty(&db, "/src/a.py", "y", "Literal[1, 2, 4]");
 
         Ok(())
     }

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -2814,7 +2814,7 @@ mod tests {
 
         // TODO: update this once `infer_ellipsis_literal_expression` correctly
         // infers `types.EllipsisType`.
-        assert_public_ty(&db, "src/a.py", "x", "Literal[EllipsisType] | Unknown");
+        assert_public_ty(&db, "src/a.py", "x", "Unknown | Literal[EllipsisType]");
 
         Ok(())
     }
@@ -3093,7 +3093,7 @@ mod tests {
             ",
         )?;
 
-        assert_public_ty(&db, "src/a.py", "x", "Literal[3] | Unbound");
+        assert_public_ty(&db, "src/a.py", "x", "Unbound | Literal[3]");
         Ok(())
     }
 
@@ -3119,8 +3119,8 @@ mod tests {
         )?;
 
         assert_public_ty(&db, "src/a.py", "x", "Literal[3, 4, 5]");
-        assert_public_ty(&db, "src/a.py", "r", "Literal[2] | Unbound");
-        assert_public_ty(&db, "src/a.py", "s", "Literal[5] | Unbound");
+        assert_public_ty(&db, "src/a.py", "r", "Unbound | Literal[2]");
+        assert_public_ty(&db, "src/a.py", "s", "Unbound | Literal[5]");
         Ok(())
     }
 
@@ -3389,7 +3389,7 @@ mod tests {
         let y_ty = symbol_ty_by_name(&db, class_scope, "y");
         let x_ty = symbol_ty_by_name(&db, class_scope, "x");
 
-        assert_eq!(x_ty.display(&db).to_string(), "Literal[2] | Unbound");
+        assert_eq!(x_ty.display(&db).to_string(), "Unbound | Literal[2]");
         assert_eq!(y_ty.display(&db).to_string(), "Literal[1]");
 
         Ok(())
@@ -3522,7 +3522,7 @@ mod tests {
             ",
         )?;
 
-        assert_public_ty(&db, "/src/a.py", "x", "Literal[1] | None");
+        assert_public_ty(&db, "/src/a.py", "x", "None | Literal[1]");
         assert_public_ty(&db, "/src/a.py", "y", "Literal[0, 1]");
 
         Ok(())

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -2814,7 +2814,7 @@ mod tests {
 
         // TODO: update this once `infer_ellipsis_literal_expression` correctly
         // infers `types.EllipsisType`.
-        assert_public_ty(&db, "src/a.py", "x", "Unknown | Literal[EllipsisType]");
+        assert_public_ty(&db, "src/a.py", "x", "Literal[EllipsisType] | Unknown");
 
         Ok(())
     }

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -3356,7 +3356,7 @@ mod tests {
 
         assert_eq!(
             y_ty.display(&db).to_string(),
-            "Literal[1] | Literal[copyright]"
+            "Literal[copyright] | Literal[1]"
         );
 
         Ok(())
@@ -3596,7 +3596,7 @@ mod tests {
         assert_public_ty(&db, "/src/a.py", "x", "Literal[2, 3]");
         // if just-body were possible without the break, then 0 would be possible for y
         // 1 and 2 both being possible for y shows that we can hit else with or without body
-        assert_public_ty(&db, "/src/a.py", "y", "Literal[1, 2, 4]");
+        assert_public_ty(&db, "/src/a.py", "y", "Literal[4, 1, 2]");
 
         Ok(())
     }


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Fixes #11785 by condensing string literals by type.

Currently supports (in this order of display):
- Integer Literals: `Literal[0] | Literal[1]` → `Literal[0, 1]`
- String Literals: `Literal["a"] | Literal["b"]` → `Literal["a", "b"]`
- Bytes Literals: `Literal[b"\x00"] | Literal[b"\x07"]` → `Literal[b"\x00", b"\x07"]`
- Booleans Literals: `Literal[False] | Literal[True]` → `Literal[False, True]`
- Classes: `Literal[A] | Literal[B]` → `Literal[A, B]`
- Functions: `Literal[bar] | Literal[foo]` → `Literal[bar, foo]`

Behaviour for all other types is unchanged.

## Notes

This affects one existing test because this gives priority to condensed unions (e.g. classes) over non condensed types, which happened in 1 test case.

## Test Plan

Adds a unit test in `crates/red_knot_python_semantic/src/types/display.rs`