### PR TITLE
[red-knot] Fix async function edge case for inference of call expressions

### DIFF
--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -381,10 +381,14 @@ impl<'db> FunctionType<'db> {
             panic!("Function type definition must have `DefinitionKind::Function`")
         };
 
-        function_stmt_node
-            .returns
-            .as_ref()
-            .map(|returns| definition_expression_ty(db, definition, returns.as_ref()))
+        function_stmt_node.returns.as_ref().map(|returns| {
+            if function_stmt_node.is_async {
+                // TODO: generic `types.CoroutineType`!
+                Type::Unknown
+            } else {
+                definition_expression_ty(db, definition, returns.as_ref())
+            }
+        })
     }
 }
 

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -2835,6 +2835,26 @@ mod tests {
     }
 
     #[test]
+    fn basic_async_call_expression() -> anyhow::Result<()> {
+        let mut db = setup_db();
+
+        db.write_dedented(
+            "src/a.py",
+            "
+            async def get_int_async() -> int:
+                return 42
+
+            x = get_int_async()
+            ",
+        )?;
+
+        // TODO: Generic `types.CoroutineType`!
+        assert_public_ty(&db, "src/a.py", "x", "Unknown");
+
+        Ok(())
+    }
+
+    #[test]
     fn class_constructor_call_expression() -> anyhow::Result<()> {
         let mut db = setup_db();
 


### PR DESCRIPTION
If we see an async function annotated as returning `int`, we'll need to infer objects returned from calls to that function as being of type `types.CoroutineType[Any, Any, int]` rather than simply `int`. This is a small oversight from #13164