### PR TITLE
Remove `pylint::helpers::CmpOpExt`

### DIFF
--- a/crates/ruff_linter/src/rules/pylint/helpers.rs
+++ b/crates/ruff_linter/src/rules/pylint/helpers.rs
@@ -1,8 +1,6 @@
-use std::fmt;
-
 use ruff_python_ast as ast;
 use ruff_python_ast::visitor::Visitor;
-use ruff_python_ast::{visitor, Arguments, CmpOp, Expr, Stmt};
+use ruff_python_ast::{visitor, Arguments, Expr, Stmt};
 use ruff_python_semantic::analyze::function_type;
 use ruff_python_semantic::{ScopeKind, SemanticModel};
 use ruff_text_size::TextRange;
@@ -55,34 +53,6 @@ pub(super) fn in_dunder_method(
         return false;
     }
     true
-}
-
-/// A wrapper around [`CmpOp`] that implements `Display`.
-#[derive(Debug)]
-pub(super) struct CmpOpExt(CmpOp);
-
-impl From<&CmpOp> for CmpOpExt {
-    fn from(cmp_op: &CmpOp) -> Self {
-        CmpOpExt(*cmp_op)
-    }
-}
-
-impl fmt::Display for CmpOpExt {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let representation = match self.0 {
-            CmpOp::Eq => "==",
-            CmpOp::NotEq => "!=",
-            CmpOp::Lt => "<",
-            CmpOp::LtE => "<=",
-            CmpOp::Gt => ">",
-            CmpOp::GtE => ">=",
-            CmpOp::Is => "is",
-            CmpOp::IsNot => "is not",
-            CmpOp::In => "in",
-            CmpOp::NotIn => "not in",
-        };
-        write!(f, "{representation}")
-    }
 }
 
 /// Visitor to track reads from an iterable in a loop.

--- a/crates/ruff_linter/src/rules/pylint/rules/comparison_of_constant.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/comparison_of_constant.rs
@@ -6,7 +6,6 @@ use ruff_macros::{derive_message_formats, violation};
 use ruff_text_size::Ranged;
 
 use crate::checkers::ast::Checker;
-use crate::rules::pylint::helpers::CmpOpExt;
 
 /// ## What it does
 /// Checks for comparisons between constants.
@@ -45,8 +44,7 @@ impl Violation for ComparisonOfConstant {
         } = self;
 
         format!(
-            "Two constants compared in a comparison, consider replacing `{left_constant} {} {right_constant}`",
-            CmpOpExt::from(op)
+            "Two constants compared in a comparison, consider replacing `{left_constant} {op} {right_constant}`",
         )
     }
 }

--- a/crates/ruff_linter/src/rules/pylint/rules/comparison_with_itself.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/comparison_with_itself.rs
@@ -7,7 +7,6 @@ use ruff_python_ast::{CmpOp, Expr};
 use ruff_text_size::Ranged;
 
 use crate::checkers::ast::Checker;
-use crate::rules::pylint::helpers::CmpOpExt;
 
 /// ## What it does
 /// Checks for operations that compare a name to itself.
@@ -66,7 +65,7 @@ pub(crate) fn comparison_with_itself(
                 let actual = format!(
                     "{} {} {}",
                     checker.locator().slice(left),
-                    CmpOpExt::from(op),
+                    op,
                     checker.locator().slice(right)
                 );
                 checker.diagnostics.push(Diagnostic::new(
@@ -114,7 +113,7 @@ pub(crate) fn comparison_with_itself(
                     let actual = format!(
                         "{} {} {}",
                         checker.locator().slice(left),
-                        CmpOpExt::from(op),
+                        op,
                         checker.locator().slice(right)
                     );
                     checker.diagnostics.push(Diagnostic::new(


### PR DESCRIPTION
`ruff_python_ast::nodes::CmpOp` implements `Display` these days, so there's no longer any need for this wrapper