### PR TITLE
[red-knot] Fix call expression inference edge case for decorated functions

### DIFF
--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -2806,10 +2806,7 @@ mod tests {
             panic!("example is not a function");
         };
 
-        let returns = function
-            .returns(&db)
-            .expect("There is a return type on the function");
-
+        let returns = function.return_type(&db);
         assert_eq!(returns.display(&db).to_string(), "int");
 
         Ok(())
@@ -2849,6 +2846,35 @@ mod tests {
         )?;
 
         // TODO: Generic `types.CoroutineType`!
+        assert_public_ty(&db, "src/a.py", "x", "Unknown");
+
+        Ok(())
+    }
+
+    #[test]
+    fn basic_decorated_call_expression() -> anyhow::Result<()> {
+        let mut db = setup_db();
+
+        db.write_dedented(
+            "src/a.py",
+            "
+            from typing import Callable
+
+            def foo() -> int:
+                return 42
+
+            def decorator(func) -> Callable[[], int]:
+                return foo
+
+            @decorator
+            def bar() -> str:
+                return 'bar'
+
+            x = bar()
+            ",
+        )?;
+
+        // TODO: should be `int`!
         assert_public_ty(&db, "src/a.py", "x", "Unknown");
 
         Ok(())


### PR DESCRIPTION
## Summary

If a function is decorated, we can't rely on the function's return annotation to give us accurate information about the type the function returns. The classic example of this is `contextlib.contextmanager`: although it is annotated correctly, the following function doesn't return an `Iterator` of `str`s, it returns an instance of `contextlib._GeneratorContextManager`:

```py
from collections.abc import Iterator
from contextlib import contextmanager

@contextmanager
def foo() -> Iterator[str]:
    yield "foo"
```

To understand decorators properly we'll need to understand `typing.Callable`, which we don't yet. For now, `Unknown` is a better type to infer if a function has any decorators.

I changed the `FunctionType::returns` method to return a `Type<'db>` as part of this PR (rather than an `Option<Type<'db>>`, as the distinction between an annotated function and an unannotated function becomes much muddier when you consider decorators: if the function is decorated, it's the type of _decorator_ that becomes important as to whether we can infer the return type just from looking at the signatures, rather than the type of the function being passed into the decorator.

## Test Plan

`cargo test -p red_knot_python_semantic`
