### PR TITLE
[pylint] removed dunder methods in Python 3 (PLW3201)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pylint/bad_dunder_method_name.py
+++ b/crates/ruff_linter/resources/test/fixtures/pylint/bad_dunder_method_name.py
@@ -94,7 +94,7 @@ class Apples:
     def __mro_entries__(self, bases):
         pass
 
-    # Deprecated in Python 3
+    # Removed with Python 3
     def __unicode__(self):
         pass
 

--- a/crates/ruff_linter/resources/test/fixtures/pylint/bad_dunder_method_name.py
+++ b/crates/ruff_linter/resources/test/fixtures/pylint/bad_dunder_method_name.py
@@ -94,6 +94,9 @@ class Apples:
     def __mro_entries__(self, bases):
         pass
 
+    # Deprecated in Python 3
+    def __unicode__(self):
+        pass
 
 def __foo_bar__():  # this is not checked by the [bad-dunder-name] rule
     ...

--- a/crates/ruff_linter/src/rules/pylint/helpers.rs
+++ b/crates/ruff_linter/src/rules/pylint/helpers.rs
@@ -168,10 +168,16 @@ impl<'a> Visitor<'_> for SequenceIndexVisitor<'a> {
     }
 }
 
-/// Returns `true` if a method is a known dunder method.
-pub(super) fn is_known_dunder_method(method: &str) -> bool {
-    matches!(
-        method,
+/// The kind of dunder method.
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+pub(super) enum DunderMethodKind {
+    Known,
+    Removed,
+}
+
+/// Returns the kind of dunder method.
+pub(super) fn dunder_method_kind(method: &str) -> Option<DunderMethodKind> {
+    match method {
         "__abs__"
             | "__add__"
             | "__aenter__"
@@ -304,14 +310,7 @@ pub(super) fn is_known_dunder_method(method: &str) -> bool {
             | "_missing_"
             | "_ignore_"
             | "_order_"
-            | "_generate_next_value_"
-    )
-}
-
-/// Returns `true` if the method is a known dunder method that is only allowed in Python 2.
-pub(super) fn is_deprecated_dunder_method_in_python3(method: &str) -> bool {
-    matches!(
-        method,
+            | "_generate_next_value_" => Some(DunderMethodKind::Known),
         "__unicode__"
             | "__div__"
             | "__rdiv__"
@@ -328,6 +327,12 @@ pub(super) fn is_deprecated_dunder_method_in_python3(method: &str) -> bool {
             | "__method__"
             | "__coerce__"
             | "__long__"
-            | "__rcmp__"
-    )
+            | "__rcmp__" => Some(DunderMethodKind::Removed),
+            _ => None,
+        }
+}
+
+/// Returns `true` if a method is a known dunder method.
+pub(super) fn is_known_dunder_method(method: &str) -> bool {
+    dunder_method_kind(method) == Some(DunderMethodKind::Known)
 }

--- a/crates/ruff_linter/src/rules/pylint/helpers.rs
+++ b/crates/ruff_linter/src/rules/pylint/helpers.rs
@@ -168,16 +168,10 @@ impl<'a> Visitor<'_> for SequenceIndexVisitor<'a> {
     }
 }
 
-/// The kind of dunder method.
-#[derive(Copy, Clone, PartialEq, Eq, Debug)]
-pub(super) enum DunderMethodKind {
-    Known,
-    Removed,
-}
-
-/// Returns the kind of dunder method.
-pub(super) fn dunder_method_kind(method: &str) -> Option<DunderMethodKind> {
-    match method {
+/// Returns `true` if a method is a known dunder method.
+pub(super) fn is_known_dunder_method(method: &str) -> bool {
+    matches!(
+        method,
         "__abs__"
             | "__add__"
             | "__aenter__"
@@ -310,29 +304,6 @@ pub(super) fn dunder_method_kind(method: &str) -> Option<DunderMethodKind> {
             | "_missing_"
             | "_ignore_"
             | "_order_"
-            | "_generate_next_value_" => Some(DunderMethodKind::Known),
-            | "__cmp__"
-            | "__coerce__"
-            | "__delslice__"
-            | "__div__"
-            | "__getslice__"
-            | "__hex__"
-            | "__idiv__"
-            | "__long__"
-            | "__members__"
-            | "__metaclass__"
-            | "__method__"
-            | "__nonzero__"
-            | "__oct__"
-            | "__rcmp__"
-            | "__rdiv__"
-            | "__setslice__"
-            | "__unicode__"=> Some(DunderMethodKind::Removed),
-            _ => None,
-        }
-}
-
-/// Returns `true` if a method is a known dunder method.
-pub(super) fn is_known_dunder_method(method: &str) -> bool {
-    dunder_method_kind(method) == Some(DunderMethodKind::Known)
+            | "_generate_next_value_"
+    )
 }

--- a/crates/ruff_linter/src/rules/pylint/helpers.rs
+++ b/crates/ruff_linter/src/rules/pylint/helpers.rs
@@ -311,23 +311,23 @@ pub(super) fn dunder_method_kind(method: &str) -> Option<DunderMethodKind> {
             | "_ignore_"
             | "_order_"
             | "_generate_next_value_" => Some(DunderMethodKind::Known),
-        "__unicode__"
-            | "__div__"
-            | "__rdiv__"
-            | "__idiv__"
-            | "__nonzero__"
-            | "__metaclass__"
             | "__cmp__"
-            | "__getslice__"
-            | "__setslice__"
-            | "__delslice__"
-            | "__oct__"
-            | "__hex__"
-            | "__members__"
-            | "__method__"
             | "__coerce__"
+            | "__delslice__"
+            | "__div__"
+            | "__getslice__"
+            | "__hex__"
+            | "__idiv__"
             | "__long__"
-            | "__rcmp__" => Some(DunderMethodKind::Removed),
+            | "__members__"
+            | "__metaclass__"
+            | "__method__"
+            | "__nonzero__"
+            | "__oct__"
+            | "__rcmp__"
+            | "__rdiv__"
+            | "__setslice__"
+            | "__unicode__"=> Some(DunderMethodKind::Removed),
             _ => None,
         }
 }

--- a/crates/ruff_linter/src/rules/pylint/helpers.rs
+++ b/crates/ruff_linter/src/rules/pylint/helpers.rs
@@ -326,11 +326,8 @@ pub(super) fn is_deprecated_dunder_method_in_python3(method: &str) -> bool {
             | "__hex__"
             | "__members__"
             | "__method__"
-            | "__corece__"
+            | "__coerce__"
             | "__long__"
             | "__rcmp__"
-            | "__iop__"
-            | "__rop__"
-            | "__op__"
     )
 }

--- a/crates/ruff_linter/src/rules/pylint/helpers.rs
+++ b/crates/ruff_linter/src/rules/pylint/helpers.rs
@@ -307,3 +307,30 @@ pub(super) fn is_known_dunder_method(method: &str) -> bool {
             | "_generate_next_value_"
     )
 }
+
+/// Returns `true` if the method is a known dunder method that is only allowed in Python 2.
+pub(super) fn is_deprecated_dunder_method_in_python3(method: &str) -> bool {
+    matches!(
+        method,
+        "__unicode__"
+            | "__div__"
+            | "__rdiv__"
+            | "__idiv__"
+            | "__nonzero__"
+            | "__metaclass__"
+            | "__cmp__"
+            | "__getslice__"
+            | "__setslice__"
+            | "__delslice__"
+            | "__oct__"
+            | "__hex__"
+            | "__members__"
+            | "__method__"
+            | "__corece__"
+            | "__long__"
+            | "__rcmp__"
+            | "__iop__"
+            | "__rop__"
+            | "__op__"
+    )
+}

--- a/crates/ruff_linter/src/rules/pylint/rules/bad_dunder_method_name.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/bad_dunder_method_name.rs
@@ -14,7 +14,7 @@ enum Kind {
 }
 
 /// ## What it does
-/// Checks for misspelled, unknown, and no longer supported dunder names in method definitions.
+/// Checks for misspelled, unknown and no longer supported dunder names in method definitions.
 ///
 /// ## Why is this bad?
 /// Misspelled or no longer supported dunder name methods may cause your code to not function

--- a/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLW3201_bad_dunder_method_name.py.snap
+++ b/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLW3201_bad_dunder_method_name.py.snap
@@ -60,7 +60,7 @@ bad_dunder_method_name.py:23:9: PLW3201 Bad or misspelled dunder method name `__
 
 bad_dunder_method_name.py:98:9: PLW3201 Python 2 or older only dunder method name `__unicode__`
    |
-97 |     # Deprecated in Python 3
+97 |     # Removed with Python 3
 98 |     def __unicode__(self):
    |         ^^^^^^^^^^^ PLW3201
 99 |         pass

--- a/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLW3201_bad_dunder_method_name.py.snap
+++ b/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLW3201_bad_dunder_method_name.py.snap
@@ -58,7 +58,7 @@ bad_dunder_method_name.py:23:9: PLW3201 Bad or misspelled dunder method name `__
 25 |         pass
    |
 
-bad_dunder_method_name.py:98:9: PLW3201 Deprecated dunder method name in Python 3 `__unicode__`
+bad_dunder_method_name.py:98:9: PLW3201 Python 2 or older only dunder method name `__unicode__`
    |
 97 |     # Deprecated in Python 3
 98 |     def __unicode__(self):

--- a/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLW3201_bad_dunder_method_name.py.snap
+++ b/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLW3201_bad_dunder_method_name.py.snap
@@ -58,4 +58,10 @@ bad_dunder_method_name.py:23:9: PLW3201 Bad or misspelled dunder method name `__
 25 |         pass
    |
 
-
+bad_dunder_method_name.py:98:9: PLW3201 Deprecated dunder method name in Python 3 `__unicode__`
+   |
+97 |     # Deprecated in Python 3
+98 |     def __unicode__(self):
+   |         ^^^^^^^^^^^ PLW3201
+99 |         pass
+   |

--- a/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLW3201_bad_dunder_method_name.py.snap
+++ b/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLW3201_bad_dunder_method_name.py.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff_linter/src/rules/pylint/mod.rs
 ---
-bad_dunder_method_name.py:5:9: PLW3201 Bad or misspelled dunder method name `_init_`
+bad_dunder_method_name.py:5:9: PLW3201 Dunder method `_init_` has no special meaning in Python 3
   |
 4 | class Apples:
 5 |     def _init_(self):  # [bad-dunder-name]
@@ -9,7 +9,7 @@ bad_dunder_method_name.py:5:9: PLW3201 Bad or misspelled dunder method name `_in
 6 |         pass
   |
 
-bad_dunder_method_name.py:8:9: PLW3201 Bad or misspelled dunder method name `__hello__`
+bad_dunder_method_name.py:8:9: PLW3201 Dunder method `__hello__` has no special meaning in Python 3
   |
 6 |         pass
 7 | 
@@ -18,7 +18,7 @@ bad_dunder_method_name.py:8:9: PLW3201 Bad or misspelled dunder method name `__h
 9 |         print("hello")
   |
 
-bad_dunder_method_name.py:11:9: PLW3201 Bad or misspelled dunder method name `__init_`
+bad_dunder_method_name.py:11:9: PLW3201 Dunder method `__init_` has no special meaning in Python 3
    |
  9 |         print("hello")
 10 | 
@@ -28,7 +28,7 @@ bad_dunder_method_name.py:11:9: PLW3201 Bad or misspelled dunder method name `__
 13 |         pass
    |
 
-bad_dunder_method_name.py:15:9: PLW3201 Bad or misspelled dunder method name `_init_`
+bad_dunder_method_name.py:15:9: PLW3201 Dunder method `_init_` has no special meaning in Python 3
    |
 13 |         pass
 14 | 
@@ -38,7 +38,7 @@ bad_dunder_method_name.py:15:9: PLW3201 Bad or misspelled dunder method name `_i
 17 |         pass
    |
 
-bad_dunder_method_name.py:19:9: PLW3201 Bad or misspelled dunder method name `___neg__`
+bad_dunder_method_name.py:19:9: PLW3201 Dunder method `___neg__` has no special meaning in Python 3
    |
 17 |         pass
 18 | 
@@ -48,7 +48,7 @@ bad_dunder_method_name.py:19:9: PLW3201 Bad or misspelled dunder method name `__
 21 |         pass
    |
 
-bad_dunder_method_name.py:23:9: PLW3201 Bad or misspelled dunder method name `__inv__`
+bad_dunder_method_name.py:23:9: PLW3201 Dunder method `__inv__` has no special meaning in Python 3
    |
 21 |         pass
 22 | 
@@ -58,7 +58,7 @@ bad_dunder_method_name.py:23:9: PLW3201 Bad or misspelled dunder method name `__
 25 |         pass
    |
 
-bad_dunder_method_name.py:98:9: PLW3201 Python 2 or older only dunder method name `__unicode__`
+bad_dunder_method_name.py:98:9: PLW3201 Dunder method `__unicode__` has no special meaning in Python 3
    |
 97 |     # Removed with Python 3
 98 |     def __unicode__(self):


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary
Add message for deprecated dunder methods not supported in Python 3

This PR addresses issue #12883 by adding custom messages in `PLW3201` for dunder methods that were deprecated in Python 2 and are no longer valid in Python 3. The message is displayed for the dunder methods listed in #12607 and additional  methods that are no longer part of Python 3 documentation:
- `__iop__`
- `__rop__`
- `__op__`
<!-- What's the purpose of the change? What does it do, and why? -->

fixes #12883

## Test Plan

<!-- How was it tested? -->
New snapshot added and `cargo test` 
