### PR TITLE
Avoid allocating `OrderedSet` in `UnionBuilder::simplify`

### DIFF
--- a/crates/red_knot_python_semantic/src/types/builder.rs
+++ b/crates/red_knot_python_semantic/src/types/builder.rs
@@ -80,12 +80,14 @@ impl<'db> UnionBuilder<'db> {
             1 => self.elements[0],
             _ => {
                 self.simplify();
-                self.elements.shrink_to_fit();
 
                 match self.elements.len() {
                     0 => Type::Never,
                     1 => self.elements[0],
-                    _ => Type::Union(UnionType::new(self.db, self.elements)),
+                    _ => {
+                        self.elements.shrink_to_fit();
+                        Type::Union(UnionType::new(self.db, self.elements))
+                    }
                 }
             }
         }


### PR DESCRIPTION

## Summary

Calling `OrderedSet::is_superset` with a `[...].into()` allocates a new `OrderedSet`. The compiler may be able to
figure out that the set isn't strictly necessary, although I doubt that it is (requires reasoning across `is_superset` and `Into`). 

This PR removes the `is_superset` call with two simple `contains` calls. It also tries to preserve the type orders
(which may also help with performance because `remove` in an `OrderedSet` is `O(n)`.

## Test Plan

`cargo test`
