### PR TITLE
Fix example in PLE1520 documentation

### DIFF
--- a/crates/ruff_linter/src/rules/pylint/rules/singledispatchmethod_function.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/singledispatchmethod_function.rs
@@ -30,7 +30,7 @@ use crate::importer::ImportRequest;
 /// Use instead:
 ///
 /// ```python
-/// from functools import singledispatchmethod
+/// from functools import singledispatch
 ///
 ///
 /// @singledispatch


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary
[PLE1520 singledispatchmethod-function](https://docs.astral.sh/ruff/rules/singledispatchmethod-function/) contained an error in *use_instead* section of the code example. 

The example imported `singledispatchmethod` while it uses `singledispatch`.

## Test Plan

All tests and pre-commit hooks were run as described in the [contributing/development](https://docs.astral.sh/ruff/contributing/#development) section of the docs.

To check the documentation:
1. Locally deploy the documentation as described in: https://docs.astral.sh/ruff/contributing/#mkdocs
1. Check whether the example is now correct.
