### PR TITLE
Ignore invalid notebook in ecosystem checks

### DIFF
--- a/python/ruff-ecosystem/ruff_ecosystem/defaults.py
+++ b/python/ruff-ecosystem/ruff_ecosystem/defaults.py
@@ -125,6 +125,7 @@ DEFAULT_TARGETS = [
                 "examples/Chat_finetuning_data_prep.ipynb",
                 "examples/chatgpt/gpt_actions_library/gpt_action_google_drive.ipynb",
                 "examples/chatgpt/gpt_actions_library/gpt_action_redshift.ipynb",
+                "examples/chatgpt/gpt_actions_library/gpt_action_salesforce.ipynb",
             ],
         },
     ),


### PR DESCRIPTION
## Summary

The notebook is invalid because it contains a code cell whose content is in markdown:
https://github.com/openai/openai-cookbook/blob/457f4310700f93e7018b1822213ca99c613dbd1b/examples/chatgpt/gpt_actions_library/gpt_action_salesforce.ipynb#L106-L121

## Test plan

- [x] No ecosystem changes
