### PR TITLE
Handle singular case for incompatible rules warning

### DIFF
--- a/crates/ruff/src/commands/format.rs
+++ b/crates/ruff/src/commands/format.rs
@@ -810,8 +810,8 @@ pub(super) fn warn_incompatible_formatter_settings(resolver: &Resolver) {
             .map(|rule| format!("`{}`", rule.noqa_code()))
             .collect();
         rule_names.sort();
-        if rule_names.len() == 1 {
-            warn_user_once!("The following rule may cause conflicts when used with the formatter: {}. To avoid unexpected behavior, we recommend disabling this rule, either by removing it from the `select` or `extend-select` configuration, or adding it to the `ignore` configuration.", rule_names.join(", "));
+				if let [rule] == rule_names.as_slice() {
+            warn_user_once!("The following rule may cause conflicts when used with the formatter: {rule}. To avoid unexpected behavior, we recommend disabling this rule, either by removing it from the `select` or `extend-select` configuration, or adding it to the `ignore` configuration.");
         } else {
             warn_user_once!("The following rules may cause conflicts when used with the formatter: {}. To avoid unexpected behavior, we recommend disabling these rules, either by removing them from the `select` or `extend-select` configuration, or adding them to the `ignore` configuration.", rule_names.join(", "));
         }

--- a/crates/ruff/src/commands/format.rs
+++ b/crates/ruff/src/commands/format.rs
@@ -810,7 +810,11 @@ pub(super) fn warn_incompatible_formatter_settings(resolver: &Resolver) {
             .map(|rule| format!("`{}`", rule.noqa_code()))
             .collect();
         rule_names.sort();
-        warn_user_once!("The following rules may cause conflicts when used with the formatter: {}. To avoid unexpected behavior, we recommend disabling these rules, either by removing them from the `select` or `extend-select` configuration, or adding them to the `ignore` configuration.", rule_names.join(", "));
+        if rule_names.len() == 1 {
+            warn_user_once!("The following rule may cause conflicts when used with the formatter: {}. To avoid unexpected behavior, we recommend disabling this rule, either by removing it from the `select` or `extend-select` configuration, or adding it to the `ignore` configuration.", rule_names.join(", "));
+        } else {
+            warn_user_once!("The following rules may cause conflicts when used with the formatter: {}. To avoid unexpected behavior, we recommend disabling these rules, either by removing them from the `select` or `extend-select` configuration, or adding them to the `ignore` configuration.", rule_names.join(", "));
+        }
     }
 
     // Next, validate settings-specific incompatibilities.

--- a/crates/ruff/src/commands/format.rs
+++ b/crates/ruff/src/commands/format.rs
@@ -810,7 +810,7 @@ pub(super) fn warn_incompatible_formatter_settings(resolver: &Resolver) {
             .map(|rule| format!("`{}`", rule.noqa_code()))
             .collect();
         rule_names.sort();
-				if let [rule] == rule_names.as_slice() {
+				if let [rule] = rule_names.as_slice() {
             warn_user_once!("The following rule may cause conflicts when used with the formatter: {rule}. To avoid unexpected behavior, we recommend disabling this rule, either by removing it from the `select` or `extend-select` configuration, or adding it to the `ignore` configuration.");
         } else {
             warn_user_once!("The following rules may cause conflicts when used with the formatter: {}. To avoid unexpected behavior, we recommend disabling these rules, either by removing them from the `select` or `extend-select` configuration, or adding them to the `ignore` configuration.", rule_names.join(", "));

--- a/crates/ruff/src/commands/format.rs
+++ b/crates/ruff/src/commands/format.rs
@@ -810,7 +810,7 @@ pub(super) fn warn_incompatible_formatter_settings(resolver: &Resolver) {
             .map(|rule| format!("`{}`", rule.noqa_code()))
             .collect();
         rule_names.sort();
-		if let [rule] = rule_names.as_slice() {
+        if let [rule] = rule_names.as_slice() {
             warn_user_once!("The following rule may cause conflicts when used with the formatter: {rule}. To avoid unexpected behavior, we recommend disabling this rule, either by removing it from the `select` or `extend-select` configuration, or adding it to the `ignore` configuration.");
         } else {
             warn_user_once!("The following rules may cause conflicts when used with the formatter: {}. To avoid unexpected behavior, we recommend disabling these rules, either by removing them from the `select` or `extend-select` configuration, or adding them to the `ignore` configuration.", rule_names.join(", "));

--- a/crates/ruff/src/commands/format.rs
+++ b/crates/ruff/src/commands/format.rs
@@ -810,7 +810,7 @@ pub(super) fn warn_incompatible_formatter_settings(resolver: &Resolver) {
             .map(|rule| format!("`{}`", rule.noqa_code()))
             .collect();
         rule_names.sort();
-				if let [rule] = rule_names.as_slice() {
+		if let [rule] = rule_names.as_slice() {
             warn_user_once!("The following rule may cause conflicts when used with the formatter: {rule}. To avoid unexpected behavior, we recommend disabling this rule, either by removing it from the `select` or `extend-select` configuration, or adding it to the `ignore` configuration.");
         } else {
             warn_user_once!("The following rules may cause conflicts when used with the formatter: {}. To avoid unexpected behavior, we recommend disabling these rules, either by removing them from the `select` or `extend-select` configuration, or adding them to the `ignore` configuration.", rule_names.join(", "));

--- a/crates/ruff/tests/format.rs
+++ b/crates/ruff/tests/format.rs
@@ -785,7 +785,7 @@ if condition:
     	print('Should change quotes')
 
     ----- stderr -----
-    warning: The following rules may cause conflicts when used with the formatter: `COM812`. To avoid unexpected behavior, we recommend disabling these rules, either by removing them from the `select` or `extend-select` configuration, or adding them to the `ignore` configuration.
+    warning: The following rule may cause conflicts when used with the formatter: `COM812`. To avoid unexpected behavior, we recommend disabling this rule, either by removing it from the `select` or `extend-select` configuration, or adding it to the `ignore` configuration.
     "###);
     Ok(())
 }


### PR DESCRIPTION
When running Ruff format I got a slightly confusing message. The Ruff message was confusing, because it was in plural, even though only a single rule was giving me this error.

## Summary

- Updated the code to call `warn_user_once!` twice, handling both singular and plural cases separately.
- Ensures the warning message is grammatically correct when only one incompatible rule is present.

## Test Plan

It's a minor change, so the automatic tests should cover this.
