### PR TITLE
[red-knot] Handle multiple comprehension targets

### DIFF
--- a/crates/red_knot_python_semantic/src/semantic_index/builder.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/builder.rs
@@ -282,6 +282,7 @@ impl<'db> SemanticIndexBuilder<'db> {
 
         // The `iter` of the first generator is evaluated in the outer scope, while all subsequent
         // nodes are evaluated in the inner scope.
+        self.add_standalone_expression(&generator.iter);
         self.visit_expr(&generator.iter);
         self.push_scope(scope);
 
@@ -297,6 +298,7 @@ impl<'db> SemanticIndexBuilder<'db> {
         }
 
         for generator in generators_iter {
+            self.add_standalone_expression(&generator.iter);
             self.visit_expr(&generator.iter);
 
             self.current_assignment = Some(CurrentAssignment::Comprehension {
@@ -675,7 +677,11 @@ where
                         Some(CurrentAssignment::Comprehension { node, first }) => {
                             self.add_definition(
                                 symbol,
-                                ComprehensionDefinitionNodeRef { node, first },
+                                ComprehensionDefinitionNodeRef {
+                                    iterable: &node.iter,
+                                    target: name_node,
+                                    first,
+                                },
                             );
                         }
                         Some(CurrentAssignment::WithItem(with_item)) => {

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -1615,7 +1615,7 @@ impl<'db> TypeInferenceBuilder<'db> {
         } = generator;
 
         self.infer_expression(elt);
-        self.infer_comprehensions_scope(generators);
+        self.infer_comprehensions(generators);
     }
 
     fn infer_list_comprehension_expression_scope(&mut self, listcomp: &ast::ExprListComp) {
@@ -1626,7 +1626,7 @@ impl<'db> TypeInferenceBuilder<'db> {
         } = listcomp;
 
         self.infer_expression(elt);
-        self.infer_comprehensions_scope(generators);
+        self.infer_comprehensions(generators);
     }
 
     fn infer_dict_comprehension_expression_scope(&mut self, dictcomp: &ast::ExprDictComp) {
@@ -1639,7 +1639,7 @@ impl<'db> TypeInferenceBuilder<'db> {
 
         self.infer_expression(key);
         self.infer_expression(value);
-        self.infer_comprehensions_scope(generators);
+        self.infer_comprehensions(generators);
     }
 
     fn infer_set_comprehension_expression_scope(&mut self, setcomp: &ast::ExprSetComp) {
@@ -1650,21 +1650,21 @@ impl<'db> TypeInferenceBuilder<'db> {
         } = setcomp;
 
         self.infer_expression(elt);
-        self.infer_comprehensions_scope(generators);
+        self.infer_comprehensions(generators);
     }
 
-    fn infer_comprehensions_scope(&mut self, comprehensions: &[ast::Comprehension]) {
-        let mut generators_iter = comprehensions.iter();
-        let Some(first_generator) = generators_iter.next() else {
+    fn infer_comprehensions(&mut self, comprehensions: &[ast::Comprehension]) {
+        let mut comprehensions_iter = comprehensions.iter();
+        let Some(first_comprehension) = comprehensions_iter.next() else {
             unreachable!("Comprehension must contain at least one generator");
         };
-        self.infer_comprehension_scope(first_generator, true);
-        for generator in generators_iter {
-            self.infer_comprehension_scope(generator, false);
+        self.infer_comprehension(first_comprehension, true);
+        for comprehension in comprehensions_iter {
+            self.infer_comprehension(comprehension, false);
         }
     }
 
-    fn infer_comprehension_scope(&mut self, comprehension: &ast::Comprehension, is_first: bool) {
+    fn infer_comprehension(&mut self, comprehension: &ast::Comprehension, is_first: bool) {
         let ast::Comprehension {
             range: _,
             target,

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -402,7 +402,8 @@ impl<'db> TypeInferenceBuilder<'db> {
             }
             DefinitionKind::Comprehension(comprehension) => {
                 self.infer_comprehension_definition(
-                    comprehension.node(),
+                    comprehension.iterable(),
+                    comprehension.target(),
                     comprehension.is_first(),
                     definition,
                 );
@@ -1544,11 +1545,11 @@ impl<'db> TypeInferenceBuilder<'db> {
 
     /// Infer the type of the `iter` expression of the first comprehension.
     fn infer_first_comprehension_iter(&mut self, comprehensions: &[ast::Comprehension]) {
-        let mut generators_iter = comprehensions.iter();
-        let Some(first_generator) = generators_iter.next() else {
+        let mut comprehensions_iter = comprehensions.iter();
+        let Some(first_comprehension) = comprehensions_iter.next() else {
             unreachable!("Comprehension must contain at least one generator");
         };
-        self.infer_expression(&first_generator.iter);
+        self.infer_expression(&first_comprehension.iter);
     }
 
     fn infer_generator_expression(&mut self, generator: &ast::ExprGenerator) -> Type<'db> {
@@ -1614,9 +1615,7 @@ impl<'db> TypeInferenceBuilder<'db> {
         } = generator;
 
         self.infer_expression(elt);
-        for comprehension in generators {
-            self.infer_comprehension(comprehension);
-        }
+        self.infer_comprehensions_scope(generators);
     }
 
     fn infer_list_comprehension_expression_scope(&mut self, listcomp: &ast::ExprListComp) {
@@ -1627,9 +1626,7 @@ impl<'db> TypeInferenceBuilder<'db> {
         } = listcomp;
 
         self.infer_expression(elt);
-        for comprehension in generators {
-            self.infer_comprehension(comprehension);
-        }
+        self.infer_comprehensions_scope(generators);
     }
 
     fn infer_dict_comprehension_expression_scope(&mut self, dictcomp: &ast::ExprDictComp) {
@@ -1642,9 +1639,7 @@ impl<'db> TypeInferenceBuilder<'db> {
 
         self.infer_expression(key);
         self.infer_expression(value);
-        for comprehension in generators {
-            self.infer_comprehension(comprehension);
-        }
+        self.infer_comprehensions_scope(generators);
     }
 
     fn infer_set_comprehension_expression_scope(&mut self, setcomp: &ast::ExprSetComp) {
@@ -1655,37 +1650,68 @@ impl<'db> TypeInferenceBuilder<'db> {
         } = setcomp;
 
         self.infer_expression(elt);
-        for comprehension in generators {
-            self.infer_comprehension(comprehension);
+        self.infer_comprehensions_scope(generators);
+    }
+
+    fn infer_comprehensions_scope(&mut self, comprehensions: &[ast::Comprehension]) {
+        let mut generators_iter = comprehensions.iter();
+        let Some(first_generator) = generators_iter.next() else {
+            unreachable!("Comprehension must contain at least one generator");
+        };
+        self.infer_comprehension_scope(first_generator, true);
+        for generator in generators_iter {
+            self.infer_comprehension_scope(generator, false);
         }
     }
 
-    fn infer_comprehension(&mut self, comprehension: &ast::Comprehension) {
-        self.infer_definition(comprehension);
-        for expr in &comprehension.ifs {
-            self.infer_expression(expr);
-        }
-    }
-
-    fn infer_comprehension_definition(
-        &mut self,
-        comprehension: &ast::Comprehension,
-        is_first: bool,
-        definition: Definition<'db>,
-    ) {
+    fn infer_comprehension_scope(&mut self, comprehension: &ast::Comprehension, is_first: bool) {
         let ast::Comprehension {
             range: _,
             target,
             iter,
-            ifs: _,
+            ifs,
             is_async: _,
         } = comprehension;
 
         if !is_first {
             self.infer_expression(iter);
         }
-        // TODO(dhruvmanila): The target type should be inferred based on the iter type instead.
-        let target_ty = self.infer_expression(target);
+        // TODO more complex assignment targets
+        if let ast::Expr::Name(name) = target {
+            self.infer_definition(name);
+        } else {
+            self.infer_expression(target);
+        }
+        for expr in ifs {
+            self.infer_expression(expr);
+        }
+    }
+
+    fn infer_comprehension_definition(
+        &mut self,
+        iterable: &ast::Expr,
+        target: &ast::ExprName,
+        is_first: bool,
+        definition: Definition<'db>,
+    ) {
+        if !is_first {
+            let expression = self.index.expression(iterable);
+            let result = infer_expression_types(self.db, expression);
+            self.extend(result);
+            let _iterable_ty = self
+                .types
+                .expression_ty(iterable.scoped_ast_id(self.db, self.scope));
+        }
+        // TODO(dhruvmanila): The iter type for the first comprehension is coming from the
+        // enclosing scope.
+
+        // TODO(dhruvmanila): The target type should be inferred based on the iter type instead,
+        // similar to how it's done in `infer_for_statement_definition`.
+        let target_ty = Type::Unknown;
+
+        self.types
+            .expressions
+            .insert(target.scoped_ast_id(self.db, self.scope), target_ty);
         self.types.definitions.insert(definition, target_ty);
     }
 


### PR DESCRIPTION
## Summary

Part of #13085, this PR updates the comprehension definition to handle multiple targets.

## Test Plan

Update existing semantic index test case for comprehension with multiple targets. Running corpus tests shouldn't panic.
