### PR TITLE
Improve detection of whether a symbol refers to a builtin exception

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pylint/useless_exception_statement.py
+++ b/crates/ruff_linter/resources/test/fixtures/pylint/useless_exception_statement.py
@@ -119,3 +119,10 @@ def func():
 def func():
     with suppress(AttributeError):
         raise AttributeError("This is an exception")  # OK
+
+
+import builtins
+
+builtins.TypeError("still an exception even though it's an Attribute")
+
+PythonFinalizationError("Added in Python 3.13")

--- a/crates/ruff_linter/src/checkers/ast/mod.rs
+++ b/crates/ruff_linter/src/checkers/ast/mod.rs
@@ -57,7 +57,7 @@ use ruff_python_semantic::{
     ModuleKind, ModuleSource, NodeId, ScopeId, ScopeKind, SemanticModel, SemanticModelFlags,
     StarImport, SubmoduleImport,
 };
-use ruff_python_stdlib::builtins::{python_builtins, IPYTHON_BUILTINS, MAGIC_GLOBALS};
+use ruff_python_stdlib::builtins::{python_builtins, MAGIC_GLOBALS};
 use ruff_python_trivia::CommentRanges;
 use ruff_source_file::{Locator, OneIndexed, SourceRow};
 use ruff_text_size::{Ranged, TextRange, TextSize};
@@ -1951,16 +1951,13 @@ impl<'a> Checker<'a> {
     }
 
     fn bind_builtins(&mut self) {
-        for builtin in python_builtins(self.settings.target_version.minor())
+        let standard_builtins = python_builtins(
+            self.settings.target_version.minor(),
+            self.source_type.is_ipynb(),
+        );
+        for builtin in standard_builtins
             .iter()
             .chain(MAGIC_GLOBALS.iter())
-            .chain(
-                self.source_type
-                    .is_ipynb()
-                    .then_some(IPYTHON_BUILTINS)
-                    .into_iter()
-                    .flatten(),
-            )
             .copied()
             .chain(self.settings.builtins.iter().map(String::as_str))
         {

--- a/crates/ruff_linter/src/rules/flake8_builtins/helpers.rs
+++ b/crates/ruff_linter/src/rules/flake8_builtins/helpers.rs
@@ -1,6 +1,6 @@
 use crate::settings::types::PythonVersion;
 use ruff_python_ast::PySourceType;
-use ruff_python_stdlib::builtins::{is_ipython_builtin, is_python_builtin};
+use ruff_python_stdlib::builtins::is_python_builtin;
 
 pub(super) fn shadows_builtin(
     name: &str,
@@ -8,9 +8,7 @@ pub(super) fn shadows_builtin(
     ignorelist: &[String],
     python_version: PythonVersion,
 ) -> bool {
-    if is_python_builtin(name, python_version.minor())
-        || source_type.is_ipynb() && is_ipython_builtin(name)
-    {
+    if is_python_builtin(name, python_version.minor(), source_type.is_ipynb()) {
         ignorelist.iter().all(|ignore| ignore != name)
     } else {
         false

--- a/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLW0133_useless_exception_statement.py.snap
+++ b/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLW0133_useless_exception_statement.py.snap
@@ -213,3 +213,39 @@ useless_exception_statement.py:71:5: PLW0133 [*] Missing `raise` statement on ex
 72 72 | 
 73 73 | 
 74 74 | # Non-violation test cases: PLW0133
+
+useless_exception_statement.py:126:1: PLW0133 [*] Missing `raise` statement on exception
+    |
+124 | import builtins
+125 | 
+126 | builtins.TypeError("still an exception even though it's an Attribute")
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PLW0133
+127 | 
+128 | PythonFinalizationError("Added in Python 3.13")
+    |
+    = help: Add `raise` keyword
+
+ℹ Unsafe fix
+123 123 | 
+124 124 | import builtins
+125 125 | 
+126     |-builtins.TypeError("still an exception even though it's an Attribute")
+    126 |+raise builtins.TypeError("still an exception even though it's an Attribute")
+127 127 | 
+128 128 | PythonFinalizationError("Added in Python 3.13")
+
+useless_exception_statement.py:128:1: PLW0133 [*] Missing `raise` statement on exception
+    |
+126 | builtins.TypeError("still an exception even though it's an Attribute")
+127 | 
+128 | PythonFinalizationError("Added in Python 3.13")
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PLW0133
+    |
+    = help: Add `raise` keyword
+
+ℹ Unsafe fix
+125 125 | 
+126 126 | builtins.TypeError("still an exception even though it's an Attribute")
+127 127 | 
+128     |-PythonFinalizationError("Added in Python 3.13")
+    128 |+raise PythonFinalizationError("Added in Python 3.13")

--- a/crates/ruff_python_stdlib/src/builtins.rs
+++ b/crates/ruff_python_stdlib/src/builtins.rs
@@ -26,7 +26,7 @@ pub const MAGIC_GLOBALS: &[&str] = &[
 /// Return the list of builtins for the given Python minor version.
 ///
 /// Intended to be kept in sync with [`is_python_builtin`].
-pub fn python_builtins(minor_version: u8, include_ipython_builtins: bool) -> Vec<&'static str> {
+pub fn python_builtins(minor_version: u8, is_notebook: bool) -> Vec<&'static str> {
     let mut builtins = vec![
         "ArithmeticError",
         "AssertionError",
@@ -194,7 +194,7 @@ pub fn python_builtins(minor_version: u8, include_ipython_builtins: bool) -> Vec
         builtins.push("PythonFinalizationError");
     }
 
-    if include_ipython_builtins {
+    if is_notebook {
         builtins.extend(IPYTHON_BUILTINS);
     }
 
@@ -204,8 +204,8 @@ pub fn python_builtins(minor_version: u8, include_ipython_builtins: bool) -> Vec
 /// Returns `true` if the given name is that of a Python builtin.
 ///
 /// Intended to be kept in sync with [`python_builtins`].
-pub fn is_python_builtin(name: &str, minor_version: u8, include_ipython_builtins: bool) -> bool {
-    if include_ipython_builtins && is_ipython_builtin(name) {
+pub fn is_python_builtin(name: &str, minor_version: u8, is_notebook: bool) -> bool {
+    if is_notebook && is_ipython_builtin(name) {
         return true;
     }
     matches!(


### PR DESCRIPTION
## Summary

This PR makes several minor improvements to functions in the `ruff_python_stdlib::builtins` module. It is a followup to https://github.com/astral-sh/ruff/pull/13172. The following changes are made:
- `is_ipython_builtin` becomes private, and `is_python_builtin` calls `is_ipython_builtin`. We don't have a use case for distinguishing between IPython builtins and regular builtins, and the way we currently have the checks split into two functions seems error-prone, as you could easily forget to call `is_ipython_builtin`, which would lead to incorrect results when checking a notebook
- The `is_exception` function was missing several builtin exceptions added in newer Python versions.
- I made the `is_exception` function take account of the Python version an exception was added in, similar to the change https://github.com/astral-sh/ruff/pull/13172 made to `is_python_builtin`.

## Test Plan

I added some new fixtures to the sole lint rule that uses `is_exception()`. Other than the changes to that function, the changes here aren't particularly user-facing.