### PR TITLE
Enable multithreading for pyright

### DIFF
--- a/scripts/knot_benchmark/src/benchmark/cases.py
+++ b/scripts/knot_benchmark/src/benchmark/cases.py
@@ -134,6 +134,7 @@ class Pyright(Tool):
         command = [
             str(self.path),
             "--venvpath",
+            "--threads",
             str(
                 venv.path.parent
             ),  # This is not the path to the venv folder, but the folder that contains the venv...


### PR DESCRIPTION
## Summary

Enable multithreading for pyright for a fairer comparison.

```
uv run benchmark  --min-runs=3 --project=black
black (cold)
Benchmark 1: knot
  Time (mean ± σ):      34.4 ms ±   1.7 ms    [User: 126.6 ms, System: 74.6 ms]
  Range (min … max):    31.8 ms …  39.2 ms    75 runs
 
  Warning: Ignoring non-zero exit code.
 
Benchmark 2: Pyright
  Time (mean ± σ):     245.0 ms ±   4.3 ms    [User: 156.2 ms, System: 32.6 ms]
  Range (min … max):   238.0 ms … 252.4 ms    12 runs
 
  Warning: Ignoring non-zero exit code.
 
Benchmark 3: mypy
  Time (mean ± σ):      3.270 s ±  0.042 s    [User: 3.128 s, System: 0.135 s]
  Range (min … max):    3.222 s …  3.302 s    3 runs
 
  Warning: Ignoring non-zero exit code.
 
Summary
  knot ran
    7.11 ± 0.37 times faster than Pyright
   94.97 ± 4.76 times faster than mypy
black (warm)
Benchmark 1: mypy
  Time (mean ± σ):     478.5 ms ±  18.8 ms    [User: 416.1 ms, System: 61.1 ms]
  Range (min … max):   459.0 ms … 507.8 ms    6 runs
 
  Warning: Ignoring non-zero exit code.
```

It improves pyright's performance from ~3s to 245ms

