### PR TITLE
Fix virtual environment details in `knot_benchmark`

### DIFF
--- a/scripts/knot_benchmark/src/benchmark/cases.py
+++ b/scripts/knot_benchmark/src/benchmark/cases.py
@@ -133,8 +133,8 @@ class Pyright(Tool):
     def cold_command(self, project: Project, venv: Venv) -> Command:
         command = [
             str(self.path),
-            "--venvpath",
             "--threads",
+            "--venvpath",
             str(
                 venv.path.parent
             ),  # This is not the path to the venv folder, but the folder that contains the venv...

--- a/scripts/knot_benchmark/src/benchmark/cases.py
+++ b/scripts/knot_benchmark/src/benchmark/cases.py
@@ -201,6 +201,8 @@ class Venv:
             "uv",
             "pip",
             "install",
+            "--python",
+            self.python,
             "--quiet",
             *dependencies,
         ]


### PR DESCRIPTION
Following https://github.com/astral-sh/ruff/pull/13227, pyright is looking for a virtual environment in a directory called '--threads', and no such directory exists. This PR fixes that, which slows pyright down again when checking black from 251.9ms to 1.751s on my machine