### PR TITLE
[red-knot] Inline `Type::is_literal`

### DIFF
--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -220,19 +220,6 @@ impl<'db> Type<'db> {
         matches!(self, Type::Never)
     }
 
-    /// Returns `true` if this type should be displayed as a literal value.
-    pub const fn is_literal(&self) -> bool {
-        matches!(
-            self,
-            Type::IntLiteral(_)
-                | Type::BooleanLiteral(_)
-                | Type::StringLiteral(_)
-                | Type::BytesLiteral(_)
-                | Type::Class(_)
-                | Type::Function(_)
-        )
-    }
-
     pub const fn into_class_type(self) -> Option<ClassType<'db>> {
         match self {
             Type::Class(class_type) => Some(class_type),

--- a/crates/red_knot_python_semantic/src/types/display.rs
+++ b/crates/red_knot_python_semantic/src/types/display.rs
@@ -27,7 +27,15 @@ pub struct DisplayType<'db> {
 impl Display for DisplayType<'_> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         let representation = self.ty.representation(self.db);
-        if self.ty.is_literal() {
+        if matches!(
+            self.ty,
+            Type::IntLiteral(_)
+                | Type::BooleanLiteral(_)
+                | Type::StringLiteral(_)
+                | Type::BytesLiteral(_)
+                | Type::Class(_)
+                | Type::Function(_)
+        ) {
             write!(f, "Literal[{representation}]",)
         } else {
             representation.fmt(f)


### PR DESCRIPTION
The name of this method is somewhat confusing currently, as I would expect it to return `true` for `LiteralString`, but it doesn't (and `LiteralString` is displayed differently, so it wouldn't suit the method's current use case for it to include `LiteralString`). The method is only used in one location currently, so let's just inline it at that location.