### PR TITLE
Make mypy pass on black in `knot_benchmark`

### DIFF
--- a/scripts/knot_benchmark/src/benchmark/cases.py
+++ b/scripts/knot_benchmark/src/benchmark/cases.py
@@ -204,6 +204,8 @@ class Venv:
             "--python",
             self.python,
             "--quiet",
+            "--exclude-newer",
+            "2024-09-03T00:00:00Z",
             *dependencies,
         ]
 

--- a/scripts/knot_benchmark/src/benchmark/cases.py
+++ b/scripts/knot_benchmark/src/benchmark/cases.py
@@ -204,6 +204,9 @@ class Venv:
             "--python",
             self.python,
             "--quiet",
+            # We pass `--exclude-newer` to ensure that type-checking of one of
+            # our projects isn't unexpectedly broken by a change in the
+            # annotations of one of that project's dependencies
             "--exclude-newer",
             "2024-09-03T00:00:00Z",
             *dependencies,

--- a/scripts/knot_benchmark/src/benchmark/projects.py
+++ b/scripts/knot_benchmark/src/benchmark/projects.py
@@ -15,7 +15,11 @@ class Project(typing.NamedTuple):
     revision: str
 
     dependencies: list[str]
-    """List of type checking dependencies"""
+    """List of type checking dependencies.
+
+    Dependencies are pinned using a `--exclude-newer` flag when installing them
+    into the virtual environment; see the `Venv.install()` method for details.
+    """
 
     include: list[str] = []
     """The directories and files to check. If empty, checks the current directory"""

--- a/scripts/knot_benchmark/src/benchmark/projects.py
+++ b/scripts/knot_benchmark/src/benchmark/projects.py
@@ -96,7 +96,7 @@ ALL = [
     Project(
         name="black",
         repository="https://github.com/psf/black",
-        revision="c20423249e9d8dfb8581eebbfc67a13984ee45e9",
+        revision="ac28187bf4a4ac159651c73d3a50fe6d0f653eac",
         include=["src"],
         dependencies=[
             "aiohttp",


### PR DESCRIPTION
## Summary

This fixes one of the problems highlighted in #13229 in the `knot_benchmark` script. The issue was that recent versions of `aiohttp` led to typing errors in black. These were fixed in https://github.com/psf/black/commit/699b45aef7c05cbec25019ed3c990f97e8b3c944, but we pinned a commit of black prior to that in `knot_benchmark`; meanwhile, we were installing the latest version of `aiohttp`, because our dependencies for the projects being benchmarked were not pinned.

This PR bumps the pinned commit of black to a newer version, and adds a `--exclude-newer` flag (set to today's date) to the installation command so that we won't be impacted by issues like this in the future.

## Test Plan

```
~/dev/ruff/scripts/knot_benchmark (alex/black-bench)⚡ % uv run benchmark --project=black -vv --mypy --min-runs=1 --benchmark cold
2024-09-03 21:02:05 INFO Cloned black to /var/folders/gd/1czdxc454j15y8gns2krv8vc0000gn/T/tmp35jq5s6j.
black (cold)
2024-09-03 21:02:05 INFO Running ['hyperfine', '-i', '--show-output', '--warmup', '3', '--min-runs', '1', '--command-name', 'mypy', '--prepare', '', '/Users/alexw/dev/ruff/scripts/knot_benchmark/.venv/bin/mypy --python-executable /var/folders/gd/1czdxc454j15y8gns2krv8vc0000gn/T/tmp35jq5s6j/venv/bin/python src --no-incremental --cache-dir /dev/null']
Benchmark 1: mypy
Warning: unused section(s) in pyproject.toml: module = ['tests.data.*']
Success: no issues found in 40 source files
Warning: unused section(s) in pyproject.toml: module = ['tests.data.*']
Success: no issues found in 40 source files
Warning: unused section(s) in pyproject.toml: module = ['tests.data.*']
Success: no issues found in 40 source files
Warning: unused section(s) in pyproject.toml: module = ['tests.data.*']
Success: no issues found in 40 source files
Warning: unused section(s) in pyproject.toml: module = ['tests.data.*']
Success: no issues found in 40 source files
  Time (mean ± σ):      1.485 s ±  0.012 s    [User: 1.398 s, System: 0.084 s]
  Range (min … max):    1.476 s …  1.493 s    2 runs
```
