### PR TITLE
[red-knot] Emit a diagnostic if the value of a starred expression or a `yield from` expression is not iterable

### DIFF
--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -1816,7 +1816,10 @@ impl<'db> TypeInferenceBuilder<'db> {
             ctx: _,
         } = starred;
 
-        self.infer_expression(value);
+        let iterable_ty = self.infer_expression(value);
+        iterable_ty.iterate(self.db, || {
+            self.not_iterable_diagnostic(value.as_ref().into(), iterable_ty);
+        });
 
         // TODO
         Type::Unknown
@@ -1834,9 +1837,12 @@ impl<'db> TypeInferenceBuilder<'db> {
     fn infer_yield_from_expression(&mut self, yield_from: &ast::ExprYieldFrom) -> Type<'db> {
         let ast::ExprYieldFrom { range: _, value } = yield_from;
 
-        self.infer_expression(value);
+        let iterable_ty = self.infer_expression(value);
+        iterable_ty.iterate(self.db, || {
+            self.not_iterable_diagnostic(value.as_ref().into(), iterable_ty);
+        });
 
-        // TODO get type from awaitable
+        // TODO get type from `SendType` of generator/awaitable
         Type::Unknown
     }
 


### PR DESCRIPTION
## Summary

This PR builds on #13195. It ensures that we emit the `not-iterable` diagnostic on expressions such as the following:

```py
class NotIterable: pass

def foo():
    [*NotIterable()]
    yield from NotIterable()
```

The `Type::iterate()` method is refactored slightly so that it's easier for callers of the method to all emit the same diagnostic: it now accepts a `diagnostic_fn` callback that emits a diagnostic if the type is not found to be an iterable type.

I deliberately haven't tackled comprehensions in this PR, for two reasons:
1. There's some more complications there
2. I think @dhruvmanila has been working a lot on comprehensions/there are several TODOs in the code that are assigned to him!

## Test Plan

`cargo test`
