### PR TITLE
[red-knot] Add control flow support for match statement

### DIFF
--- a/crates/red_knot_python_semantic/src/semantic_index.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index.rs
@@ -21,6 +21,7 @@ use crate::Db;
 
 pub mod ast_ids;
 mod builder;
+pub(crate) mod constraint;
 pub mod definition;
 pub mod expression;
 pub mod symbol;

--- a/crates/red_knot_python_semantic/src/semantic_index/builder.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/builder.rs
@@ -26,6 +26,7 @@ use crate::semantic_index::use_def::{FlowSnapshot, UseDefMapBuilder};
 use crate::semantic_index::SemanticIndex;
 use crate::Db;
 
+use super::constraint::{Constraint, PatternConstraint};
 use super::definition::{MatchPatternDefinitionNodeRef, WithItemDefinitionNodeRef};
 
 pub(super) struct SemanticIndexBuilder<'db> {
@@ -204,11 +205,37 @@ impl<'db> SemanticIndexBuilder<'db> {
         definition
     }
 
-    fn add_constraint(&mut self, constraint_node: &ast::Expr) -> Expression<'db> {
+    fn add_expression_constraint(&mut self, constraint_node: &ast::Expr) -> Expression<'db> {
         let expression = self.add_standalone_expression(constraint_node);
-        self.current_use_def_map_mut().record_constraint(expression);
+        self.current_use_def_map_mut()
+            .record_constraint(Constraint::Expression(expression));
 
         expression
+    }
+
+    fn add_pattern_constraint(
+        &mut self,
+        subject: &ast::Expr,
+        pattern: &ast::Pattern,
+    ) -> PatternConstraint<'db> {
+        #[allow(unsafe_code)]
+        let (subject, pattern) = unsafe {
+            (
+                AstNodeRef::new(self.module.clone(), subject),
+                AstNodeRef::new(self.module.clone(), pattern),
+            )
+        };
+        let pattern_constraint = PatternConstraint::new(
+            self.db,
+            self.file,
+            self.current_scope(),
+            subject,
+            pattern,
+            countme::Count::default(),
+        );
+        self.current_use_def_map_mut()
+            .record_constraint(Constraint::Pattern(pattern_constraint));
+        pattern_constraint
     }
 
     /// Record an expression that needs to be a Salsa ingredient, because we need to infer its type
@@ -523,7 +550,7 @@ where
             ast::Stmt::If(node) => {
                 self.visit_expr(&node.test);
                 let pre_if = self.flow_snapshot();
-                self.add_constraint(&node.test);
+                self.add_expression_constraint(&node.test);
                 self.visit_body(&node.body);
                 let mut post_clauses: Vec<FlowSnapshot> = vec![];
                 for clause in &node.elif_else_clauses {
@@ -615,8 +642,30 @@ where
             }) => {
                 self.add_standalone_expression(subject);
                 self.visit_expr(subject);
-                for case in cases {
+
+                let after_subject = self.flow_snapshot();
+                let Some((first, remaining)) = cases.split_first() else {
+                    // TODO: In case of error recovery, we should not panic here
+                    unreachable!("Match statement must have at least one case block");
+                };
+                self.add_pattern_constraint(subject, &first.pattern);
+                self.visit_match_case(first);
+
+                let mut post_case_snapshots = vec![];
+                for case in remaining {
+                    post_case_snapshots.push(self.flow_snapshot());
+                    self.flow_restore(after_subject.clone());
+                    self.add_pattern_constraint(subject, &case.pattern);
                     self.visit_match_case(case);
+                }
+                for post_clause_state in post_case_snapshots {
+                    self.flow_merge(post_clause_state);
+                }
+                if !cases
+                    .last()
+                    .is_some_and(|case| case.guard.is_none() && case.pattern.is_wildcard())
+                {
+                    self.flow_merge(after_subject);
                 }
             }
             _ => {

--- a/crates/red_knot_python_semantic/src/semantic_index/builder.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/builder.rs
@@ -645,8 +645,7 @@ where
 
                 let after_subject = self.flow_snapshot();
                 let Some((first, remaining)) = cases.split_first() else {
-                    // TODO: In case of error recovery, we should not panic here
-                    unreachable!("Match statement must have at least one case block");
+                    return;
                 };
                 self.add_pattern_constraint(subject, &first.pattern);
                 self.visit_match_case(first);

--- a/crates/red_knot_python_semantic/src/semantic_index/constraint.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/constraint.rs
@@ -1,0 +1,39 @@
+use ruff_db::files::File;
+use ruff_python_ast as ast;
+
+use crate::ast_node_ref::AstNodeRef;
+use crate::db::Db;
+use crate::semantic_index::expression::Expression;
+use crate::semantic_index::symbol::{FileScopeId, ScopeId};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum Constraint<'db> {
+    Expression(Expression<'db>),
+    Pattern(PatternConstraint<'db>),
+}
+
+#[salsa::tracked]
+pub(crate) struct PatternConstraint<'db> {
+    #[id]
+    pub(crate) file: File,
+
+    #[id]
+    pub(crate) file_scope: FileScopeId,
+
+    #[no_eq]
+    #[return_ref]
+    pub(crate) subject: AstNodeRef<ast::Expr>,
+
+    #[no_eq]
+    #[return_ref]
+    pub(crate) pattern: AstNodeRef<ast::Pattern>,
+
+    #[no_eq]
+    count: countme::Count<PatternConstraint<'static>>,
+}
+
+impl<'db> PatternConstraint<'db> {
+    pub(crate) fn scope(self, db: &'db dyn Db) -> ScopeId<'db> {
+        self.file_scope(db).to_scope_id(db, self.file(db))
+    }
+}

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -17,7 +17,6 @@ pub(crate) use self::builder::{IntersectionBuilder, UnionBuilder};
 pub(crate) use self::diagnostic::TypeCheckDiagnostics;
 pub(crate) use self::infer::{
     infer_deferred_types, infer_definition_types, infer_expression_types, infer_scope_types,
-    TypeInference,
 };
 
 mod builder;

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -121,8 +121,8 @@ pub(crate) fn definitions_ty<'db>(
              definition,
              constraints,
          }| {
-            let mut constraint_tys =
-                constraints.filter_map(|test| narrowing_constraint(db, test, definition));
+            let mut constraint_tys = constraints
+                .filter_map(|constraint| narrowing_constraint(db, constraint, definition));
             let definition_ty = definition_ty(db, definition);
             if let Some(first_constraint_ty) = constraint_tys.next() {
                 let mut builder = IntersectionBuilder::new(db);

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -3484,6 +3484,65 @@ mod tests {
     }
 
     #[test]
+    fn match_with_wildcard() {
+        let mut db = setup_db();
+
+        db.write_dedented(
+            "src/a.py",
+            "
+            match 0:
+                case 1:
+                    y = 2
+                case _:
+                    y = 3
+",
+        )
+        .unwrap();
+
+        assert_public_ty(&db, "src/a.py", "y", "Literal[2, 3]");
+    }
+
+    #[test]
+    fn match_without_wildcard() {
+        let mut db = setup_db();
+
+        db.write_dedented(
+            "src/a.py",
+            "
+            match 0:
+                case 1:
+                    y = 2
+                case 2:
+                    y = 3
+",
+        )
+        .unwrap();
+
+        assert_public_ty(&db, "src/a.py", "y", "Unbound | Literal[2, 3]");
+    }
+
+    #[test]
+    fn match_stmt() {
+        let mut db = setup_db();
+
+        db.write_dedented(
+            "src/a.py",
+            "
+            y = 1
+            y = 2
+            match 0:
+                case 1:
+                    y = 3
+                case 2:
+                    y = 4
+",
+        )
+        .unwrap();
+
+        assert_public_ty(&db, "src/a.py", "y", "Literal[2, 3, 4]");
+    }
+
+    #[test]
     fn import_cycle() -> anyhow::Result<()> {
         let mut db = setup_db();
 
@@ -3795,6 +3854,33 @@ mod tests {
         assert_public_ty(&db, "/src/a.py", "y", "Literal[0, 1]");
 
         Ok(())
+    }
+
+    #[test]
+    fn narrow_singleton_pattern() {
+        let mut db = setup_db();
+
+        db.write_dedented(
+            "/src/a.py",
+            "
+            x = None if flag else 1
+            y = 0
+            match x:
+                case None:
+                    y = x
+            ",
+        )
+        .unwrap();
+
+        // TODO: The correct inferred type should be `Literal[0] | None` but currently the
+        // simplification logic doesn't account for this. The final type with parenthesis:
+        // `Literal[0] | (None | Literal[1] & None)`
+        assert_public_ty(
+            &db,
+            "/src/a.py",
+            "y",
+            "Literal[0] | None | Literal[1] & None",
+        );
     }
 
     #[test]

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -3874,7 +3874,7 @@ mod tests {
 
         // TODO: The correct inferred type should be `Literal[0] | None` but currently the
         // simplification logic doesn't account for this. The final type with parenthesis:
-        // `Literal[0] | (None | Literal[1] & None)`
+        // `Literal[0] | None | (Literal[1] & None)`
         assert_public_ty(
             &db,
             "/src/a.py",

--- a/crates/red_knot_python_semantic/src/types/narrow.rs
+++ b/crates/red_knot_python_semantic/src/types/narrow.rs
@@ -32,9 +32,11 @@ pub(crate) fn narrowing_constraint<'db>(
     definition: Definition<'db>,
 ) -> Option<Type<'db>> {
     match constraint {
-        Constraint::Expression(expression) => all_narrowing_constraints(db, expression)
-            .get(&definition.symbol(db))
-            .copied(),
+        Constraint::Expression(expression) => {
+            all_narrowing_constraints_for_expression(db, expression)
+                .get(&definition.symbol(db))
+                .copied()
+        }
         Constraint::Pattern(pattern) => all_narrowing_constraints_for_pattern(db, pattern)
             .get(&definition.symbol(db))
             .copied(),
@@ -50,7 +52,7 @@ fn all_narrowing_constraints_for_pattern<'db>(
 }
 
 #[salsa::tracked(return_ref)]
-fn all_narrowing_constraints<'db>(
+fn all_narrowing_constraints_for_expression<'db>(
     db: &'db dyn Db,
     expression: Expression<'db>,
 ) -> NarrowingConstraints<'db> {
@@ -85,8 +87,8 @@ impl<'db> NarrowingConstraintsBuilder<'db> {
     }
 
     fn evaluate_expression_constraint(&mut self, expression: Expression<'db>) {
-        let inference = infer_expression_types(self.db, expression);
         if let ast::Expr::Compare(expr_compare) = expression.node_ref(self.db).node() {
+            let inference = infer_expression_types(self.db, expression);
             self.add_expr_compare(expr_compare, inference);
         }
         // TODO other test expression kinds

--- a/crates/red_knot_python_semantic/src/types/narrow.rs
+++ b/crates/red_knot_python_semantic/src/types/narrow.rs
@@ -4,7 +4,7 @@ use crate::semantic_index::definition::Definition;
 use crate::semantic_index::expression::Expression;
 use crate::semantic_index::symbol::{ScopeId, ScopedSymbolId, SymbolTable};
 use crate::semantic_index::symbol_table;
-use crate::types::{infer_expression_types, IntersectionBuilder, Type, TypeInference};
+use crate::types::{infer_expression_types, IntersectionBuilder, Type};
 use crate::Db;
 use ruff_python_ast as ast;
 use rustc_hash::FxHashMap;

--- a/crates/red_knot_python_semantic/src/types/narrow.rs
+++ b/crates/red_knot_python_semantic/src/types/narrow.rs
@@ -184,8 +184,7 @@ impl<'db> NarrowingConstraintsBuilder<'db> {
                 ast::Singleton::True => Type::BooleanLiteral(true),
                 ast::Singleton::False => Type::BooleanLiteral(false),
             };
-            let constraint = IntersectionBuilder::new(self.db).add_positive(ty).build();
-            self.constraints.insert(symbol, constraint);
+            self.constraints.insert(symbol, ty);
         }
     }
 }

--- a/crates/red_knot_python_semantic/src/types/narrow.rs
+++ b/crates/red_knot_python_semantic/src/types/narrow.rs
@@ -88,8 +88,7 @@ impl<'db> NarrowingConstraintsBuilder<'db> {
 
     fn evaluate_expression_constraint(&mut self, expression: Expression<'db>) {
         if let ast::Expr::Compare(expr_compare) = expression.node_ref(self.db).node() {
-            let inference = infer_expression_types(self.db, expression);
-            self.add_expr_compare(expr_compare, inference);
+            self.add_expr_compare(expr_compare, expression);
         }
         // TODO other test expression kinds
     }
@@ -136,11 +135,7 @@ impl<'db> NarrowingConstraintsBuilder<'db> {
         }
     }
 
-    fn add_expr_compare(
-        &mut self,
-        expr_compare: &ast::ExprCompare,
-        inference: &TypeInference<'db>,
-    ) {
+    fn add_expr_compare(&mut self, expr_compare: &ast::ExprCompare, expression: Expression<'db>) {
         let ast::ExprCompare {
             range: _,
             left,
@@ -157,6 +152,7 @@ impl<'db> NarrowingConstraintsBuilder<'db> {
             // SAFETY: we should always have a symbol for every Name node.
             let symbol = self.symbols().symbol_id_by_name(id).unwrap();
             let scope = self.scope();
+            let inference = infer_expression_types(self.db, expression);
             for (op, comparator) in std::iter::zip(&**ops, &**comparators) {
                 let comp_ty = inference.expression_ty(comparator.scoped_ast_id(self.db, scope));
                 if matches!(op, ast::CmpOp::IsNot) {

--- a/crates/ruff_python_ast/src/nodes.rs
+++ b/crates/ruff_python_ast/src/nodes.rs
@@ -3124,6 +3124,27 @@ impl Pattern {
             _ => false,
         }
     }
+
+    /// Checks if the [`Pattern`] is a [wildcard pattern].
+    ///
+    /// The following are wildcard patterns:
+    /// ```python
+    /// match subject:
+    ///     case _ as x: ...
+    ///     case _ | _: ...
+    ///     case _: ...
+    /// ```
+    ///
+    /// [wildcard pattern]: https://docs.python.org/3/reference/compound_stmts.html#wildcard-patterns
+    pub fn is_wildcard(&self) -> bool {
+        match self {
+            Pattern::MatchAs(PatternMatchAs { pattern, .. }) => pattern.is_none(),
+            Pattern::MatchOr(PatternMatchOr { patterns, .. }) => {
+                patterns.iter().all(Pattern::is_wildcard)
+            }
+            _ => false,
+        }
+    }
 }
 
 /// See also [MatchValue](https://docs.python.org/3/library/ast.html#ast.MatchValue)

--- a/crates/ruff_python_ast/src/nodes.rs
+++ b/crates/ruff_python_ast/src/nodes.rs
@@ -3138,7 +3138,9 @@ impl Pattern {
     /// [wildcard pattern]: https://docs.python.org/3/reference/compound_stmts.html#wildcard-patterns
     pub fn is_wildcard(&self) -> bool {
         match self {
-            Pattern::MatchAs(PatternMatchAs { pattern, .. }) => pattern.is_none(),
+            Pattern::MatchAs(PatternMatchAs { pattern, .. }) => {
+                pattern.as_deref().map_or(true, Pattern::is_wildcard)
+            }
             Pattern::MatchOr(PatternMatchOr { patterns, .. }) => {
                 patterns.iter().all(Pattern::is_wildcard)
             }

--- a/crates/ruff_python_ast_integration_tests/tests/match_pattern.rs
+++ b/crates/ruff_python_ast_integration_tests/tests/match_pattern.rs
@@ -1,0 +1,16 @@
+use ruff_python_parser::parse_module;
+
+#[test]
+fn pattern_is_wildcard() {
+    let source_code = r"
+match subject:
+    case _ as x: ...
+    case _ | _: ...
+    case _: ...
+";
+    let parsed = parse_module(source_code).unwrap();
+    let cases = &parsed.syntax().body[0].as_match_stmt().unwrap().cases;
+    for case in cases {
+        assert!(case.pattern.is_wildcard());
+    }
+}


### PR DESCRIPTION
## Summary

This PR adds support for control flow for match statement.

It also adds the necessary infrastructure required for narrowing constraints in case blocks and implements the logic for `PatternMatchSingleton` which is either `None` / `True` / `False`. Even after this the inferred type doesn't get simplified completely, there's a TODO for that in the test code.

## Test Plan

Add test cases for control flow for (a) when there's a wildcard pattern and (b) when there isn't. There's also a test case to verify the narrowing logic.
