### PR TITLE
[red-knot] Infer `Unknown` for the loop var in `async for` loops

### DIFF
--- a/crates/red_knot_python_semantic/src/semantic_index/builder.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/builder.rs
@@ -672,6 +672,7 @@ where
                                 ForStmtDefinitionNodeRef {
                                     iterable: &node.iter,
                                     target: name_node,
+                                    is_async: node.is_async,
                                 },
                             );
                         }

--- a/crates/red_knot_python_semantic/src/semantic_index/definition.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/definition.rs
@@ -152,6 +152,7 @@ pub(crate) struct WithItemDefinitionNodeRef<'a> {
 pub(crate) struct ForStmtDefinitionNodeRef<'a> {
     pub(crate) iterable: &'a ast::Expr,
     pub(crate) target: &'a ast::ExprName,
+    pub(crate) is_async: bool,
 }
 
 #[derive(Copy, Clone, Debug)]
@@ -206,12 +207,15 @@ impl DefinitionNodeRef<'_> {
             DefinitionNodeRef::AugmentedAssignment(augmented_assignment) => {
                 DefinitionKind::AugmentedAssignment(AstNodeRef::new(parsed, augmented_assignment))
             }
-            DefinitionNodeRef::For(ForStmtDefinitionNodeRef { iterable, target }) => {
-                DefinitionKind::For(ForStmtDefinitionKind {
-                    iterable: AstNodeRef::new(parsed.clone(), iterable),
-                    target: AstNodeRef::new(parsed, target),
-                })
-            }
+            DefinitionNodeRef::For(ForStmtDefinitionNodeRef {
+                iterable,
+                target,
+                is_async,
+            }) => DefinitionKind::For(ForStmtDefinitionKind {
+                iterable: AstNodeRef::new(parsed.clone(), iterable),
+                target: AstNodeRef::new(parsed, target),
+                is_async,
+            }),
             DefinitionNodeRef::Comprehension(ComprehensionDefinitionNodeRef {
                 iterable,
                 target,
@@ -265,6 +269,7 @@ impl DefinitionNodeRef<'_> {
             Self::For(ForStmtDefinitionNodeRef {
                 iterable: _,
                 target,
+                is_async: _,
             }) => target.into(),
             Self::Comprehension(ComprehensionDefinitionNodeRef { target, .. }) => target.into(),
             Self::Parameter(node) => match node {
@@ -388,6 +393,7 @@ impl WithItemDefinitionKind {
 pub struct ForStmtDefinitionKind {
     iterable: AstNodeRef<ast::Expr>,
     target: AstNodeRef<ast::ExprName>,
+    is_async: bool,
 }
 
 impl ForStmtDefinitionKind {
@@ -397,6 +403,10 @@ impl ForStmtDefinitionKind {
 
     pub(crate) fn target(&self) -> &ast::ExprName {
         self.target.node()
+    }
+
+    pub(crate) fn is_async(&self) -> bool {
+        self.is_async
     }
 }
 


### PR DESCRIPTION
## Summary

`async for` loops use the asynchronous iteration protocol (involving `__aiter__` and `__anext__`) rather than the synchronous iteration protocol (involving `__iter__` and `__next__`). Understanding `__anext__` calls is beyond our capabilities until we can understanding async call expressions (which is probably blocked on generic coroutine types). For now, inferring `Unknown` for loop vars in `async for` loops is more accurate than erroneously using the synchronous iteration protocol for the types of these definitions.

## Test Plan

`cargo test -p red_knot_python_semantic --lib`
