### PR TITLE
[red-knot] AnnAssign with no RHS is not a Definition

### DIFF
--- a/crates/ruff_benchmark/benches/red_knot.rs
+++ b/crates/ruff_benchmark/benches/red_knot.rs
@@ -23,6 +23,7 @@ const TOMLLIB_312_URL: &str = "https://raw.githubusercontent.com/python/cpython/
 
 // The failed import from 'collections.abc' is due to lack of support for 'import *'.
 static EXPECTED_DIAGNOSTICS: &[&str] = &[
+    "/src/tomllib/_parser.py:5:24: Module '__future__' has no member 'annotations'",
     "/src/tomllib/_parser.py:7:29: Module 'collections.abc' has no member 'Iterable'",
     "Line 69 is too long (89 characters)",
     "Use double quotes for strings",


### PR DESCRIPTION
My plan for handling declared types is to introduce a `Declaration` in addition to `Definition`. A `Declaration` is an annotation of a name with a type; a `Definition` is an actual runtime assignment of a value to a name. A few things (an annotated function parameter, an annotated-assignment with an RHS) are both a `Definition` and a `Declaration`.

This more cleanly separates type inference (only cares about `Definition`) from declared types (only impacted by a `Declaration`), and I think it will work out better than trying to squeeze everything into `Definition`. One of the tests in this PR (`annotation_only_assignment_transparent_to_local_inference`) demonstrates one reason why. The statement `x: int` should have no effect on local inference of the type of `x`; whatever the locally inferred type of `x` was before `x: int` should still be the inferred type after `x: int`. This is actually quite hard to do if `x: int` is considered a `Definition`, because a core assumption of the use-def map is that a `Definition` replaces the previous value. To achieve this would require some hackery to effectively treat `x: int` sort of as if it were `x: int = x`, but it's not really even equivalent to that, so this approach gets quite ugly.

As a first step in this plan, this PR stops treating AnnAssign with no RHS as a `Definition`, which fixes behavior in a couple added tests.

This actually makes things temporarily worse for the ellipsis-type test, since it is defined in typeshed only using annotated assignments with no RHS. This will be fixed properly by the upcoming addition of declarations, which should also treat a declared type as sufficient to import a name, at least from a stub.