### PR TITLE
refactor: remove unnecessary string hashes

### DIFF
--- a/crates/red_knot_python_semantic/src/semantic_index.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index.rs
@@ -1044,7 +1044,7 @@ class C[T]:
         }
 
         let TestCase { db, file } = test_case(
-            r#"
+            r"
 class Test:
     def foo():
         def bar():
@@ -1053,7 +1053,7 @@ class Test:
         pass
 
 def x():
-    pass"#,
+    pass",
         );
 
         let index = semantic_index(&db, file);

--- a/crates/ruff/tests/format.rs
+++ b/crates/ruff/tests/format.rs
@@ -326,18 +326,18 @@ fn docstring_options() -> Result<()> {
     let ruff_toml = tempdir.path().join("ruff.toml");
     fs::write(
         &ruff_toml,
-        r#"
+        r"
 [format]
 docstring-code-format = true
 docstring-code-line-length = 20
-"#,
+",
     )?;
 
     assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
         .args(["format", "--config"])
         .arg(&ruff_toml)
         .arg("-")
-        .pass_stdin(r#"
+        .pass_stdin(r"
 def f(x):
     '''
     Something about `f`. And an example:
@@ -357,7 +357,7 @@ def f(x):
     >>> foo, bar, quux = this_is_a_long_line(lion, hippo, lemur, bear)
     '''
     pass
-"#), @r###"
+"), @r###"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -509,9 +509,9 @@ fn syntax_error() -> Result<()> {
 
     fs::write(
         tempdir.path().join("main.py"),
-        r#"
+        r"
 from module import =
-"#,
+",
     )?;
 
     assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))

--- a/crates/ruff/tests/integration_test.rs
+++ b/crates/ruff/tests/integration_test.rs
@@ -158,15 +158,15 @@ fn check_default_files() -> Result<()> {
     let tempdir = TempDir::new()?;
     fs::write(
         tempdir.path().join("foo.py"),
-        r#"
+        r"
 import foo   # unused import
-"#,
+",
     )?;
     fs::write(
         tempdir.path().join("bar.py"),
-        r#"
+        r"
 import bar   # unused import
-"#,
+",
     )?;
 
     assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
@@ -906,10 +906,10 @@ fn full_output_preview_config() -> Result<()> {
     let pyproject_toml = tempdir.path().join("pyproject.toml");
     fs::write(
         &pyproject_toml,
-        r#"
+        r"
 [tool.ruff]
 preview = true
-"#,
+",
     )?;
     let mut cmd = RuffCheck::default().config(&pyproject_toml).build();
     assert_cmd_snapshot!(cmd.pass_stdin("l = 1"), @r###"

--- a/crates/ruff_linter/src/rules/ruff/rules/missing_fstring_syntax.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/missing_fstring_syntax.rs
@@ -61,7 +61,7 @@ pub struct MissingFStringSyntax;
 impl AlwaysFixableViolation for MissingFStringSyntax {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!(r#"Possible f-string without an `f` prefix"#)
+        format!(r"Possible f-string without an `f` prefix")
     }
 
     fn fix_title(&self) -> String {

--- a/crates/ruff_python_formatter/tests/normalizer.rs
+++ b/crates/ruff_python_formatter/tests/normalizer.rs
@@ -62,7 +62,7 @@ impl Transformer for Normalizer {
     fn visit_string_literal(&self, string_literal: &mut ast::StringLiteral) {
         static STRIP_DOC_TESTS: Lazy<Regex> = Lazy::new(|| {
             Regex::new(
-                r#"(?mx)
+                r"(?mx)
                     (
                         # strip doctest PS1 prompt lines
                         ^\s*>>>\s.*(\n|$)
@@ -71,7 +71,7 @@ impl Transformer for Normalizer {
                         # Also handles the case of an empty ... line.
                         ^\s*\.\.\.((\n|$)|\s.*(\n|$))
                     )+
-                "#,
+                ",
             )
             .unwrap()
         });
@@ -80,11 +80,11 @@ impl Transformer for Normalizer {
             // impossible) to detect a reStructuredText block with a simple
             // regex. So we just look for the start of a block and remove
             // everything after it. Talk about a hammer.
-            Regex::new(r#"::(?s:.*)"#).unwrap()
+            Regex::new(r"::(?s:.*)").unwrap()
         });
         static STRIP_MARKDOWN_BLOCKS: Lazy<Regex> = Lazy::new(|| {
             // This covers more than valid Markdown blocks, but that's OK.
-            Regex::new(r#"(```|~~~)\p{any}*(```|~~~|$)"#).unwrap()
+            Regex::new(r"(```|~~~)\p{any}*(```|~~~|$)").unwrap()
         });
 
         // Start by (1) stripping everything that looks like a code


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

This removes unnecessary `#`s in parts of the codebase to improve readability and maintainability.

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

`cargo test` passes locally.

<!-- How was it tested? -->