### PR TITLE
[red-knot] Add type inference for loop variables inside comprehension scopes

### DIFF
--- a/crates/red_knot_python_semantic/src/semantic_index/builder.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/builder.rs
@@ -689,6 +689,7 @@ where
                                     iterable: &node.iter,
                                     target: name_node,
                                     first,
+                                    is_async: node.is_async,
                                 },
                             );
                         }

--- a/crates/red_knot_python_semantic/src/semantic_index/definition.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/definition.rs
@@ -167,6 +167,7 @@ pub(crate) struct ComprehensionDefinitionNodeRef<'a> {
     pub(crate) iterable: &'a ast::Expr,
     pub(crate) target: &'a ast::ExprName,
     pub(crate) first: bool,
+    pub(crate) is_async: bool,
 }
 
 #[derive(Copy, Clone, Debug)]
@@ -227,10 +228,12 @@ impl DefinitionNodeRef<'_> {
                 iterable,
                 target,
                 first,
+                is_async,
             }) => DefinitionKind::Comprehension(ComprehensionDefinitionKind {
                 iterable: AstNodeRef::new(parsed.clone(), iterable),
                 target: AstNodeRef::new(parsed, target),
                 first,
+                is_async,
             }),
             DefinitionNodeRef::Parameter(parameter) => match parameter {
                 ast::AnyParameterRef::Variadic(parameter) => {
@@ -337,6 +340,7 @@ pub struct ComprehensionDefinitionKind {
     iterable: AstNodeRef<ast::Expr>,
     target: AstNodeRef<ast::ExprName>,
     first: bool,
+    is_async: bool,
 }
 
 impl ComprehensionDefinitionKind {
@@ -350,6 +354,10 @@ impl ComprehensionDefinitionKind {
 
     pub(crate) fn is_first(&self) -> bool {
         self.first
+    }
+
+    pub(crate) fn is_async(&self) -> bool {
+        self.is_async
     }
 }
 

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -1755,13 +1755,11 @@ impl<'db> TypeInferenceBuilder<'db> {
         let result = infer_expression_types(self.db, expression);
 
         // Two things are different if it's the first comprehension:
-        // (1) We must lookup the type of the expression in the outer scope
-        //     (symbols defined in this scope are not available for definitions
-        //     created by the first comprehension)
+        // (1) We must lookup the `ScopedExpressionId` of the iterable expression in the outer scope,
+        //     because that's the scope we visit it in in the semantic index builder
         // (2) We must *not* call `self.extend()` on the result of the type inference,
-        //     or we'll doubly infer the type of relevant symbols
-        //     (any symbols referenced from the first comprehension will have already been
-        //     inferred when analysing outer scopes)
+        //     because `ScopedExpressionId` are only meaningful within their own scope, so
+        //     we'd add types for random wrong expressions in the current scope
         let iterable_ty = if is_first {
             let lookup_scope = self
                 .index


### PR DESCRIPTION
## Summary

This adds type inference for loop variables inside comprehension scopes. The type-inference tests are passing, but it seems to currently trigger a panic in the corpus tests.

Async comprehensions will require different logic, so for now loop variables in these are inferred as `Unknown` still. In order to distinguish between async comprehension definitions and synchronous comprehensions definitions, a new `is_async` field is added to `ComprehensionDefinitionKind` and various other structs for tracking comprehension definitions.

## Test Plan

`cargo test -p red_knot_python_semantic` and `cargo test -p red_knot_workspace`
