### PR TITLE
[red-knot] resolve source/stubs over namespace packages

### DIFF
--- a/crates/red_knot_python_semantic/src/module_resolver/path.rs
+++ b/crates/red_knot_python_semantic/src/module_resolver/path.rs
@@ -59,6 +59,10 @@ impl ModulePath {
         self.relative_path.push(component);
     }
 
+    pub(crate) fn pop(&mut self) -> bool {
+        self.relative_path.pop()
+    }
+
     #[must_use]
     pub(super) fn is_directory(&self, resolver: &ResolverContext) -> bool {
         let ModulePath {

--- a/crates/red_knot_python_semantic/src/module_resolver/path.rs
+++ b/crates/red_knot_python_semantic/src/module_resolver/path.rs
@@ -72,15 +72,12 @@ impl ModulePath {
         };
 
         // Stubs have precedence over source files
-        if let Some(stub) = self.with_pyi_extension().to_file(&resolver) {
+        if let Some(stub) = self.with_pyi_extension().to_file(resolver) {
             Some((stub, kind))
-        } else if let Some(module) = self
-            .with_py_extension()
-            .and_then(|path| path.to_file(&resolver))
-        {
-            Some((module, kind))
         } else {
-            None
+            self.with_py_extension()
+                .and_then(|path| path.to_file(resolver))
+                .map(|module| (module, kind))
         }
     }
 

--- a/crates/red_knot_python_semantic/src/module_resolver/path.rs
+++ b/crates/red_knot_python_semantic/src/module_resolver/path.rs
@@ -9,7 +9,6 @@ use ruff_db::files::{system_path_to_file, vendored_path_to_file, File, FileError
 use ruff_db::system::{System, SystemPath, SystemPathBuf};
 use ruff_db::vendored::{VendoredPath, VendoredPathBuf};
 
-use super::module::ModuleKind;
 use super::typeshed::{typeshed_versions, TypeshedVersionsParseError, TypeshedVersionsQueryResult};
 use crate::db::Db;
 use crate::module_name::ModuleName;
@@ -61,24 +60,12 @@ impl ModulePath {
     }
 
     #[must_use]
-    pub(super) fn resolve_pure_module(
-        &self,
-        resolver: &ResolverContext,
-    ) -> Option<(File, ModuleKind)> {
-        let kind = if self.relative_path.ends_with("__init__") {
-            ModuleKind::Package
-        } else {
-            ModuleKind::Module
-        };
-
-        // Stubs have precedence over source files
-        if let Some(stub) = self.with_pyi_extension().to_file(resolver) {
-            Some((stub, kind))
-        } else {
-            self.with_py_extension()
+    pub(super) fn is_file_module(&self, resolver: &ResolverContext) -> bool {
+        self.with_pyi_extension().to_file(resolver).is_some()
+            || self
+                .with_py_extension()
                 .and_then(|path| path.to_file(resolver))
-                .map(|module| (module, kind))
-        }
+                .is_some()
     }
 
     #[must_use]

--- a/crates/red_knot_python_semantic/src/module_resolver/path.rs
+++ b/crates/red_knot_python_semantic/src/module_resolver/path.rs
@@ -60,15 +60,6 @@ impl ModulePath {
     }
 
     #[must_use]
-    pub(super) fn is_file_module(&self, resolver: &ResolverContext) -> bool {
-        self.with_pyi_extension().to_file(resolver).is_some()
-            || self
-                .with_py_extension()
-                .and_then(|path| path.to_file(resolver))
-                .is_some()
-    }
-
-    #[must_use]
     pub(super) fn is_directory(&self, resolver: &ResolverContext) -> bool {
         let ModulePath {
             search_path,

--- a/crates/red_knot_python_semantic/src/module_resolver/resolver.rs
+++ b/crates/red_knot_python_semantic/src/module_resolver/resolver.rs
@@ -602,6 +602,11 @@ fn resolve_name(db: &dyn Db, name: &ModuleName) -> Option<(SearchPath, File, Mod
     None
 }
 
+/// If `module` exists on disk with either a `.pyi` or `.py` extension,
+/// return the [`File`] corresponding to that path.
+///
+/// `.pyi` files take priority, as they always have priority when
+/// resolving modules.
 fn resolve_file_module(module: &ModulePath, resolver_state: &ResolverContext) -> Option<File> {
     // Stubs have precedence over source files
     module

--- a/crates/red_knot_python_semantic/src/module_resolver/resolver.rs
+++ b/crates/red_knot_python_semantic/src/module_resolver/resolver.rs
@@ -642,7 +642,7 @@ where
             in_namespace_package = false;
         } else if package_path.is_directory(resolver_state)
             // Pure modules hide namespace packages with the same name
-            && !package_path.is_file_module(resolver_state)
+            && resolve_file_module(&package_path, resolver_state).is_none()
         {
             // A directory without an `__init__.py` is a namespace package, continue with the next folder.
             in_namespace_package = true;

--- a/crates/red_knot_python_semantic/src/module_resolver/resolver.rs
+++ b/crates/red_knot_python_semantic/src/module_resolver/resolver.rs
@@ -569,19 +569,16 @@ fn resolve_name(db: &dyn Db, name: &ModuleName) -> Option<(SearchPath, File, Mod
 
                 package_path.push(module_name);
 
-                // Try to resolve a stub/module with the current name
-                let file_module = resolve_file_module(&package_path, &resolver_state);
-
-                // Then check if a regular package exists with the same name (it takes
-                // precedence)
+                // Check for a regular package first (highest priority)
                 package_path.push("__init__");
                 if let Some(regular_package) = resolve_file_module(&package_path, &resolver_state) {
                     return Some((search_path.clone(), regular_package, ModuleKind::Package));
                 }
 
-                // If we found a module (but no package), return it
-                if let Some(module) = file_module {
-                    return Some((search_path.clone(), module, ModuleKind::Module));
+                // Check for a file module next
+                package_path.pop();
+                if let Some(file_module) = resolve_file_module(&package_path, &resolver_state) {
+                    return Some((search_path.clone(), file_module, ModuleKind::Module));
                 }
 
                 // For regular packages, don't search the next search path. All files of that


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

This PR tries to fix #12278. That issue doesn't have the tag `help-wanted`, so I'm not sure if I can contribute a fix

## Summary



### Expected Behaviour

In python, a `module` can actually be 3 things:
- Regular file
- Package (directory with `__init__.py`)
- Namespace package (directory without `__init__.py`)

In the import logic, when resolving `foo.bar.baz`, we should have the following priority:
```
└─ foo
   └─ bar
      ├─ baz           <-- regular package over module
      │  └─ __init__.py
      └─ baz.py
```
**works**
```
└─ foo
   └─ bar
      ├─ baz.py        <-- module over namespace package
      └─ baz           <-- namespace package invisible (because of module)
         └─ ...
```
**doesn't work**

### Current Implementation

Currently, the code properly imports regular packages over modules, but when a namespace package is here, it makes a module with the same name invisible, which is the opposite of what we want.

We want to guarantee 3 things:
- Regular package has priority over module (covered in existing test)
- Module has priority over namespace package (new test)
- A namespace package is made invisible by a module of the same name (new test)

### Fixes

We have 2 core problems in our logic:
- We properly resolve a namespace package when a module of the same name exists
- When a package (root, regular, namespace) is located and we try to resolve the last component `foo`
  - If `foo` is a directory, we consider it's a regular package
    - If the `foo` directory was a namespace package, it fails and we don't test `foo` as a module
  - If `foo` is not a directory, we try to resolve it as a module

This is fixed by:
- Adding a check in package resolution to skip shadowed namespace packages
- Changing the way we resolve modules to not rely on `foo` being a directory
  - We directly check `foo/__init__`
  - If that doesn't work, we fallback to `foo`
  
## Test Plan

The issue #12278 introduces a unit test that should pass after the issue is fixed.
This test is included in the PR.