### PR TITLE
Playground: Fix errors not shown on page load

### DIFF
--- a/playground/src/Editor/SourceEditor.tsx
+++ b/playground/src/Editor/SourceEditor.tsx
@@ -2,11 +2,25 @@
  * Editor for the Python source code.
  */
 
-import Editor, { BeforeMount, Monaco } from "@monaco-editor/react";
-import { MarkerSeverity, MarkerTag } from "monaco-editor";
+import Editor, { Monaco, OnMount } from "@monaco-editor/react";
+import {
+  editor,
+  IDisposable,
+  languages,
+  MarkerSeverity,
+  MarkerTag,
+  Range,
+} from "monaco-editor";
 import { useCallback, useEffect, useRef } from "react";
 import { Diagnostic } from "../pkg";
 import { Theme } from "./theme";
+import CodeActionProvider = languages.CodeActionProvider;
+
+type MonacoEditorState = {
+  monaco: Monaco;
+  codeActionProvider: RuffCodeActionProvider;
+  disposeCodeActionProvider: IDisposable;
+};
 
 export default function SourceEditor({
   visible,
@@ -21,80 +35,32 @@ export default function SourceEditor({
   theme: Theme;
   onChange: (pythonSource: string) => void;
 }) {
-  const monacoRef = useRef<Monaco | null>(null);
-  const monaco = monacoRef.current;
+  const monacoRef = useRef<MonacoEditorState | null>(null);
 
+  // Update the diagnostics in the editor.
   useEffect(() => {
-    const editor = monaco?.editor;
-    const model = editor?.getModels()[0];
-    if (!editor || !model) {
+    const editorState = monacoRef.current;
+
+    if (editorState == null) {
       return;
     }
 
-    editor.setModelMarkers(
-      model,
-      "owner",
-      diagnostics.map((diagnostic) => ({
-        startLineNumber: diagnostic.location.row,
-        startColumn: diagnostic.location.column,
-        endLineNumber: diagnostic.end_location.row,
-        endColumn: diagnostic.end_location.column,
-        message: diagnostic.code
-          ? `${diagnostic.code}: ${diagnostic.message}`
-          : diagnostic.message,
-        severity: MarkerSeverity.Error,
-        tags:
-          diagnostic.code === "F401" || diagnostic.code === "F841"
-            ? [MarkerTag.Unnecessary]
-            : [],
-      })),
-    );
+    editorState.codeActionProvider.diagnostics = diagnostics;
 
-    const codeActionProvider = monaco?.languages.registerCodeActionProvider(
-      "python",
-      {
-        provideCodeActions: function (model, position) {
-          const actions = diagnostics
-            .filter((check) => position.startLineNumber === check.location.row)
-            .filter(({ fix }) => fix)
-            .map((check) => ({
-              title: check.fix
-                ? check.fix.message
-                  ? `${check.code}: ${check.fix.message}`
-                  : `Fix ${check.code}`
-                : "Fix",
-              id: `fix-${check.code}`,
-              kind: "quickfix",
-              edit: check.fix
-                ? {
-                    edits: check.fix.edits.map((edit) => ({
-                      resource: model.uri,
-                      versionId: model.getVersionId(),
-                      textEdit: {
-                        range: {
-                          startLineNumber: edit.location.row,
-                          startColumn: edit.location.column,
-                          endLineNumber: edit.end_location.row,
-                          endColumn: edit.end_location.column,
-                        },
-                        text: edit.content || "",
-                      },
-                    })),
-                  }
-                : undefined,
-            }));
-          return {
-            actions,
-            dispose: () => {},
-          };
-        },
-      },
-    );
+    updateMarkers(editorState.monaco, diagnostics);
+  }, [diagnostics]);
+
+  // Dispose the code action provider on unmount.
+  useEffect(() => {
+    const disposeActionProvider = monacoRef.current?.disposeCodeActionProvider;
+    if (disposeActionProvider == null) {
+      return;
+    }
 
     return () => {
-      codeActionProvider?.dispose();
+      disposeActionProvider.dispose();
     };
-  }, [diagnostics, monaco]);
+  }, []);
 
   const handleChange = useCallback(
     (value: string | undefined) => {
@@ -103,14 +69,30 @@ export default function SourceEditor({
     [onChange],
   );
 
-  const handleMount: BeforeMount = useCallback(
-    (instance) => (monacoRef.current = instance),
-    [],
+  const handleMount: OnMount = useCallback(
+    (_editor, instance) => {
+      const ruffActionsProvider = new RuffCodeActionProvider(diagnostics);
+      const disposeCodeActionProvider =
+        instance.languages.registerCodeActionProvider(
+          "python",
+          ruffActionsProvider,
+        );
+
+      updateMarkers(instance, diagnostics);
+
+      monacoRef.current = {
+        monaco: instance,
+        codeActionProvider: ruffActionsProvider,
+        disposeCodeActionProvider,
+      };
+    },
+
+    [diagnostics],
   );
 
   return (
     <Editor
-      beforeMount={handleMount}
+      onMount={handleMount}
       options={{
         fixedOverflowWidgets: true,
         readOnly: false,
@@ -126,5 +108,78 @@ export default function SourceEditor({
       value={source}
       onChange={handleChange}
     />
+  );
+}
+
+class RuffCodeActionProvider implements CodeActionProvider {
+  constructor(public diagnostics: Array<Diagnostic>) {}
+
+  provideCodeActions(
+    model: editor.ITextModel,
+    range: Range,
+  ): languages.ProviderResult<languages.CodeActionList> {
+    const actions = this.diagnostics
+      .filter((check) => range.startLineNumber === check.location.row)
+      .filter(({ fix }) => fix)
+      .map((check) => ({
+        title: check.fix
+          ? check.fix.message
+            ? `${check.code}: ${check.fix.message}`
+            : `Fix ${check.code}`
+          : "Fix",
+        id: `fix-${check.code}`,
+        kind: "quickfix",
+
+        edit: check.fix
+          ? {
+              edits: check.fix.edits.map((edit) => ({
+                resource: model.uri,
+                versionId: model.getVersionId(),
+                textEdit: {
+                  range: {
+                    startLineNumber: edit.location.row,
+                    startColumn: edit.location.column,
+                    endLineNumber: edit.end_location.row,
+                    endColumn: edit.end_location.column,
+                  },
+                  text: edit.content || "",
+                },
+              })),
+            }
+          : undefined,
+      }));
+
+    return {
+      actions,
+      dispose: () => {},
+    };
+  }
+}
+
+function updateMarkers(monaco: Monaco, diagnostics: Array<Diagnostic>) {
+  const editor = monaco.editor;
+  const model = editor?.getModels()[0];
+
+  if (!model) {
+    return;
+  }
+
+  editor.setModelMarkers(
+    model,
+    "owner",
+    diagnostics.map((diagnostic) => ({
+      startLineNumber: diagnostic.location.row,
+      startColumn: diagnostic.location.column,
+      endLineNumber: diagnostic.end_location.row,
+      endColumn: diagnostic.end_location.column,
+      message: diagnostic.code
+        ? `${diagnostic.code}: ${diagnostic.message}`
+        : diagnostic.message,
+      severity: MarkerSeverity.Error,
+      tags:
+        diagnostic.code === "F401" || diagnostic.code === "F841"
+          ? [MarkerTag.Unnecessary]
+          : [],
+    })),
   );
 }


### PR DESCRIPTION
## Summary

This PR fixes a bug in the playground where errors for a restored snipped didn't show on page load. 

The core issue was that `editor` or `editor.getModels` was `None` when the diagnostics are updated, in which case the `useEffect` skips the diagnostics change. 

This PR fixes the issue by:

* Using `onMount` instead of `beforeMount` to only set the editor instance when the editor is fully loaded
* Setting the diagnostics as part of the `handleMount` callback because the mount event could be triggered after are updated

I used this as a chance to only register a single code action provider. 

Fixes https://github.com/astral-sh/ruff/issues/11918

## Test Plan

[Screencast from 2024-09-06 10-00-24.webm](https://github.com/user-attachments/assets/7d5b5bb5-ab93-4011-a7ab-34d7868d8233)
