### PR TITLE
Upgrade to Rust 1.81

### DIFF
--- a/crates/ruff_linter/src/rules/pydocstyle/rules/triple_quotes.rs
+++ b/crates/ruff_linter/src/rules/pydocstyle/rules/triple_quotes.rs
@@ -67,9 +67,7 @@ impl Violation for TripleSingleQuotes {
 pub(crate) fn triple_quotes(checker: &mut Checker, docstring: &Docstring) {
     let leading_quote = docstring.leading_quote();
 
-    let prefixes = leading_quote
-        .trim_end_matches(|c| c == '\'' || c == '"')
-        .to_owned();
+    let prefixes = leading_quote.trim_end_matches(['\'', '"']).to_owned();
 
     let expected_quote = if docstring.body().contains("\"\"\"") {
         if docstring.body().contains("\'\'\'") {

--- a/crates/ruff_python_parser/src/string.rs
+++ b/crates/ruff_python_parser/src/string.rs
@@ -97,9 +97,8 @@ impl StringParser {
 
     #[inline]
     fn next_char(&mut self) -> Option<char> {
-        self.source[self.cursor..].chars().next().map(|c| {
+        self.source[self.cursor..].chars().next().inspect(|c| {
             self.cursor += c.len_utf8();
-            c
         })
     }
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.80"
+channel = "1.81"


### PR DESCRIPTION
## Summary

Upgrades to Rust [1.81](https://blog.rust-lang.org/2024/09/05/Rust-1.81.0.html).

I'm a bit worried about the change that an incorrect `Ord` implementation now panics when sorting instead of resulting in a messed-up sorting.  We discovered at least one such bug thanks to fuzzing. 

## Test Plan

`cargo test`
