### PR TITLE
Only include rules with diagnostics in SARIF metadata

### DIFF
--- a/crates/ruff_linter/src/message/sarif.rs
+++ b/crates/ruff_linter/src/message/sarif.rs
@@ -29,7 +29,7 @@ impl Emitter for SarifEmitter {
             .collect::<Result<Vec<_>>>()?;
 
         let mut rule_ids = HashSet::new();
-        for result in results.iter() {
+        for result in &results {
             if let Some(rule) = result.rule {
                 rule_ids.insert(rule.noqa_code().to_string());
             }


### PR DESCRIPTION
This PR can be considered as a follow-up of #13180.

## Motivation

The current Ruff's SARIF output contains all the 800+ rules, the vast majority of which have no relevance to the errors in results. IMO, this results in a large output and a lot of noise.

## Proposal

Per [the SARIF example](https://github.com/microsoft/sarif-tutorials/blob/main/docs/1-Introduction.md#a-simple-example), other linters such as ESLint only emits rules relevant to the errors in results. I think this could be an approach worth considering.

```json
{
  "version": "2.1.0",
  "$schema": "http://json.schemastore.org/sarif-2.1.0-rtm.4",
  "runs": [
    {
      "tool": {
        "driver": {
          "name": "ESLint",
          "informationUri": "https://eslint.org",
          "rules": [
            {
              "id": "no-unused-vars",
              "shortDescription": {
                "text": "disallow unused variables"
              },
              "helpUri": "https://eslint.org/docs/rules/no-unused-vars",
              "properties": {
                "category": "Variables"
              }
            }
          ]
        }
      },
      "artifacts": [
        {
          "location": {
            "uri": "file:///C:/dev/sarif/sarif-tutorials/samples/Introduction/simple-example.js"
          }
        }
      ],
      "results": [
        {
          "level": "error",
          "message": {
            "text": "'x' is assigned a value but never used."
          },
          "locations": [
            {
              "physicalLocation": {
                "artifactLocation": {
                  "uri": "file:///C:/dev/sarif/sarif-tutorials/samples/Introduction/simple-example.js",
                  "index": 0
                },
                "region": {
                  "startLine": 1,
                  "startColumn": 5
                }
              }
            }
          ],
          "ruleId": "no-unused-vars",
          "ruleIndex": 0
        }
      ]
    }
  ]
}
```