### PR TITLE
[red-knot] Handle StringLiteral truncation

### DIFF
--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -2055,12 +2055,9 @@ impl<'db> TypeInferenceBuilder<'db> {
 
             (
                 Type::StringLiteral(_) | Type::LiteralString,
-                Type::LiteralString,
+                Type::StringLiteral(_) | Type::LiteralString,
                 ast::Operator::Add,
-            )
-            | (Type::LiteralString, Type::StringLiteral(_), ast::Operator::Add) => {
-                Type::LiteralString
-            }
+            ) => Type::LiteralString,
 
             (Type::StringLiteral(s), Type::IntLiteral(n), ast::Operator::Mult)
             | (Type::IntLiteral(n), Type::StringLiteral(s), ast::Operator::Mult) => {

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -2898,6 +2898,25 @@ mod tests {
     }
 
     #[test]
+    fn truncated_string_literals_become_literal_string() -> anyhow::Result<()> {
+        let mut db = setup_db();
+        let content = format!(
+            r#"
+        w = "{y}"
+        x = "a" + "{z}"
+        "#,
+            y = "a".repeat(TypeInferenceBuilder::MAX_STRING_LITERAL_SIZE + 1),
+            z = "a".repeat(TypeInferenceBuilder::MAX_STRING_LITERAL_SIZE),
+        );
+        db.write_dedented("src/a.py", &content)?;
+
+        assert_public_ty(&db, "src/a.py", "w", "LiteralString");
+        assert_public_ty(&db, "src/a.py", "x", "LiteralString");
+
+        Ok(())
+    }
+
+    #[test]
     fn bytes_type() -> anyhow::Result<()> {
         let mut db = setup_db();
 

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -2935,6 +2935,28 @@ mod tests {
     }
 
     #[test]
+    fn adding_string_literals_and_literal_string() -> anyhow::Result<()> {
+        let mut db = setup_db();
+        let content = format!(
+            r#"
+        v = "{y}"
+        w = "{y}" + "a"
+        x = "a" + "{y}"
+        z = "{y}" + "{y}"
+        "#,
+            y = "a".repeat(TypeInferenceBuilder::MAX_STRING_LITERAL_SIZE + 1),
+        );
+        db.write_dedented("src/a.py", &content)?;
+
+        assert_public_ty(&db, "src/a.py", "v", "LiteralString");
+        assert_public_ty(&db, "src/a.py", "w", "LiteralString");
+        assert_public_ty(&db, "src/a.py", "x", "LiteralString");
+        assert_public_ty(&db, "src/a.py", "z", "LiteralString");
+
+        Ok(())
+    }
+
+    #[test]
     fn bytes_type() -> anyhow::Result<()> {
         let mut db = setup_db();
 

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -2053,6 +2053,15 @@ impl<'db> TypeInferenceBuilder<'db> {
                 }
             }
 
+            (
+                Type::StringLiteral(_) | Type::LiteralString,
+                Type::LiteralString,
+                ast::Operator::Add,
+            )
+            | (Type::LiteralString, Type::StringLiteral(_), ast::Operator::Add) => {
+                Type::LiteralString
+            }
+
             (Type::StringLiteral(s), Type::IntLiteral(n), ast::Operator::Mult)
             | (Type::IntLiteral(n), Type::StringLiteral(s), ast::Operator::Mult) => {
                 if n < 1 {
@@ -2066,6 +2075,15 @@ impl<'db> TypeInferenceBuilder<'db> {
                     } else {
                         Type::LiteralString
                     }
+                } else {
+                    Type::LiteralString
+                }
+            }
+
+            (Type::LiteralString, Type::IntLiteral(n), ast::Operator::Mult)
+            | (Type::IntLiteral(n), Type::LiteralString, ast::Operator::Mult) => {
+                if n < 1 {
+                    Type::StringLiteral(StringLiteralType::new(self.db, Box::default()))
                 } else {
                     Type::LiteralString
                 }

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -2920,6 +2920,8 @@ mod tests {
         v = "{y}"
         w = 10*"{y}"
         x = "{y}"*10
+        z = 0*"{y}"
+        u = (-100)*"{y}"
         "#,
             y = "a".repeat(TypeInferenceBuilder::MAX_STRING_LITERAL_SIZE + 1),
         );
@@ -2928,7 +2930,8 @@ mod tests {
         assert_public_ty(&db, "src/a.py", "v", "LiteralString");
         assert_public_ty(&db, "src/a.py", "w", "LiteralString");
         assert_public_ty(&db, "src/a.py", "x", "LiteralString");
-
+        assert_public_ty(&db, "src/a.py", "z", r#"Literal[""]"#);
+        assert_public_ty(&db, "src/a.py", "u", r#"Literal[""]"#);
         Ok(())
     }
 

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -2913,6 +2913,26 @@ mod tests {
     }
 
     #[test]
+    fn multiplied_literal_string() -> anyhow::Result<()> {
+        let mut db = setup_db();
+        let content = format!(
+            r#"
+        v = "{y}"
+        w = 10*"{y}"
+        x = "{y}"*10
+        "#,
+            y = "a".repeat(TypeInferenceBuilder::MAX_STRING_LITERAL_SIZE + 1),
+        );
+        db.write_dedented("src/a.py", &content)?;
+
+        assert_public_ty(&db, "src/a.py", "v", "LiteralString");
+        assert_public_ty(&db, "src/a.py", "w", "LiteralString");
+        assert_public_ty(&db, "src/a.py", "x", "LiteralString");
+
+        Ok(())
+    }
+
+    #[test]
     fn truncated_string_literals_become_literal_string() -> anyhow::Result<()> {
         let mut db = setup_db();
         let content = format!(


### PR DESCRIPTION
When a type of the form `Literal["..."]` would be constructed with too large of a string, this PR converts it to `LiteralString` instead.

We also extend inference for binary operations to include the case where one of the operands is `LiteralString`.

Closes #13224
