### PR TITLE
refactor: Return copied `TextRange` in `CommentRanges` iterator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1104,9 +1104,9 @@ dependencies = [
 
 [[package]]
 name = "insta"
-version = "1.39.0"
+version = "1.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "810ae6042d48e2c9e9215043563a58a80b877bc863228a74cf10c49d4620a6f5"
+checksum = "6593a41c7a73841868772495db7dc1e8ecab43bb5c0b6da2059246c4b506ab60"
 dependencies = [
  "console",
  "globset",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1104,9 +1104,9 @@ dependencies = [
 
 [[package]]
 name = "insta"
-version = "1.40.0"
+version = "1.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6593a41c7a73841868772495db7dc1e8ecab43bb5c0b6da2059246c4b506ab60"
+checksum = "810ae6042d48e2c9e9215043563a58a80b877bc863228a74cf10c49d4620a6f5"
 dependencies = [
  "console",
  "globset",

--- a/crates/ruff_linter/src/checkers/tokens.rs
+++ b/crates/ruff_linter/src/checkers/tokens.rs
@@ -63,7 +63,7 @@ pub(crate) fn check_tokens(
             ruff::rules::ambiguous_unicode_character_comment(
                 &mut diagnostics,
                 locator,
-                *range,
+                range,
                 settings,
             );
         }

--- a/crates/ruff_linter/src/noqa.rs
+++ b/crates/ruff_linter/src/noqa.rs
@@ -361,7 +361,7 @@ impl<'a> FileNoqaDirectives<'a> {
         let mut lines = vec![];
 
         for range in comment_ranges {
-            match ParsedFileExemption::try_extract(&contents[*range]) {
+            match ParsedFileExemption::try_extract(&contents[range]) {
                 Err(err) => {
                     #[allow(deprecated)]
                     let line = locator.compute_line_index(range.start());
@@ -403,7 +403,7 @@ impl<'a> FileNoqaDirectives<'a> {
                     };
 
                     lines.push(FileNoqaDirectiveLine {
-                        range: *range,
+                        range,
                         parsed_file_exemption: exemption,
                         matches,
                     });
@@ -922,7 +922,7 @@ impl<'a> NoqaDirectives<'a> {
         let mut directives = Vec::new();
 
         for range in comment_ranges {
-            match Directive::try_extract(locator.slice(*range), range.start()) {
+            match Directive::try_extract(locator.slice(range), range.start()) {
                 Err(err) => {
                     #[allow(deprecated)]
                     let line = locator.compute_line_index(range.start());

--- a/crates/ruff_linter/src/rules/eradicate/rules/commented_out_code.rs
+++ b/crates/ruff_linter/src/rules/eradicate/rules/commented_out_code.rs
@@ -55,7 +55,7 @@ pub(crate) fn commented_out_code(
 
     // Iterate over all comments in the document.
     for range in comment_ranges {
-        let line = locator.lines(*range);
+        let line = locator.lines(range);
 
         // Detect `/// script` tags.
         if in_script_tag {
@@ -75,9 +75,9 @@ pub(crate) fn commented_out_code(
 
         // Verify that the comment is on its own line, and that it contains code.
         if is_own_line_comment(line) && comment_contains_code(line, &settings.task_tags[..]) {
-            let mut diagnostic = Diagnostic::new(CommentedOutCode, *range);
+            let mut diagnostic = Diagnostic::new(CommentedOutCode, range);
             diagnostic.set_fix(Fix::display_only_edit(Edit::range_deletion(
-                locator.full_lines_range(*range),
+                locator.full_lines_range(range),
             )));
             diagnostics.push(diagnostic);
         }

--- a/crates/ruff_linter/src/rules/flake8_executable/rules/mod.rs
+++ b/crates/ruff_linter/src/rules/flake8_executable/rules/mod.rs
@@ -25,23 +25,23 @@ pub(crate) fn from_tokens(
 ) {
     let mut has_any_shebang = false;
     for range in comment_ranges {
-        let comment = locator.slice(*range);
+        let comment = locator.slice(range);
         if let Some(shebang) = ShebangDirective::try_extract(comment) {
             has_any_shebang = true;
 
-            if let Some(diagnostic) = shebang_missing_python(*range, &shebang) {
+            if let Some(diagnostic) = shebang_missing_python(range, &shebang) {
                 diagnostics.push(diagnostic);
             }
 
-            if let Some(diagnostic) = shebang_not_executable(path, *range) {
+            if let Some(diagnostic) = shebang_not_executable(path, range) {
                 diagnostics.push(diagnostic);
             }
 
-            if let Some(diagnostic) = shebang_leading_whitespace(*range, locator) {
+            if let Some(diagnostic) = shebang_leading_whitespace(range, locator) {
                 diagnostics.push(diagnostic);
             }
 
-            if let Some(diagnostic) = shebang_not_first_line(*range, locator) {
+            if let Some(diagnostic) = shebang_not_first_line(range, locator) {
                 diagnostics.push(diagnostic);
             }
         }

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/type_comment_in_stub.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/type_comment_in_stub.rs
@@ -41,10 +41,10 @@ pub(crate) fn type_comment_in_stub(
     comment_ranges: &CommentRanges,
 ) {
     for range in comment_ranges {
-        let comment = locator.slice(*range);
+        let comment = locator.slice(range);
 
         if TYPE_COMMENT_REGEX.is_match(comment) && !TYPE_IGNORE_REGEX.is_match(comment) {
-            diagnostics.push(Diagnostic::new(TypeCommentInStub, *range));
+            diagnostics.push(Diagnostic::new(TypeCommentInStub, range));
         }
     }
 }

--- a/crates/ruff_linter/src/rules/pygrep_hooks/rules/blanket_type_ignore.rs
+++ b/crates/ruff_linter/src/rules/pygrep_hooks/rules/blanket_type_ignore.rs
@@ -55,7 +55,7 @@ pub(crate) fn blanket_type_ignore(
     locator: &Locator,
 ) {
     for range in comment_ranges {
-        let line = locator.slice(*range);
+        let line = locator.slice(range);
 
         // Match, e.g., `# type: ignore` or `# type: ignore[attr-defined]`.
         // See: https://github.com/python/mypy/blob/b43e0d34247a6d1b3b9d9094d184bbfcb9808bb9/mypy/fastparse.py#L248

--- a/crates/ruff_linter/src/rules/pylint/rules/empty_comment.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/empty_comment.rs
@@ -56,7 +56,7 @@ pub(crate) fn empty_comments(
         }
 
         // If the line contains an empty comment, add a diagnostic.
-        if let Some(diagnostic) = empty_comment(*range, locator) {
+        if let Some(diagnostic) = empty_comment(range, locator) {
             diagnostics.push(diagnostic);
         }
     }

--- a/crates/ruff_linter/src/rules/ruff/rules/invalid_formatter_suppression_comment.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/invalid_formatter_suppression_comment.rs
@@ -75,7 +75,7 @@ pub(crate) fn ignored_formatter_suppression_comment(checker: &mut Checker, suite
         .into_iter()
         .filter_map(|range| {
             Some(SuppressionComment {
-                range: *range,
+                range,
                 kind: SuppressionKind::from_comment(locator.slice(range))?,
             })
         })

--- a/crates/ruff_python_trivia/src/comment_ranges.rs
+++ b/crates/ruff_python_trivia/src/comment_ranges.rs
@@ -215,10 +215,10 @@ impl Debug for CommentRanges {
 }
 
 impl<'a> IntoIterator for &'a CommentRanges {
-    type Item = &'a TextRange;
-    type IntoIter = std::slice::Iter<'a, TextRange>;
+    type Item = TextRange;
+    type IntoIter = std::iter::Copied<std::slice::Iter<'a, TextRange>>;
 
     fn into_iter(self) -> Self::IntoIter {
-        self.raw.iter()
+        self.raw.iter().copied()
     }
 }


### PR DESCRIPTION
## Summary

Refactors `CommentRanges::into_iter` to return an `Iterator` over `TextRange` instead of `&TextRange`. 
This reduces the need for `*range` and `TextRange` has the same size as `usize` on 64bit systems

## Test Plan

`cargo test`
