### PR TITLE
Fix configuration inheritance for configurations specified in the LSP settings

### DIFF
--- a/crates/ruff_workspace/src/pyproject.rs
+++ b/crates/ruff_workspace/src/pyproject.rs
@@ -140,7 +140,7 @@ pub fn find_user_settings_toml() -> Option<PathBuf> {
 }
 
 /// Load `Options` from a `pyproject.toml` or `ruff.toml` file.
-pub fn load_options<P: AsRef<Path>>(path: P) -> Result<Options> {
+pub(super) fn load_options<P: AsRef<Path>>(path: P) -> Result<Options> {
     if path.as_ref().ends_with("pyproject.toml") {
         let pyproject = parse_pyproject_toml(&path)?;
         let mut ruff = pyproject

--- a/crates/ruff_workspace/src/resolver.rs
+++ b/crates/ruff_workspace/src/resolver.rs
@@ -263,7 +263,7 @@ pub trait ConfigurationTransformer {
 // configuration file extends another in the same path, we'll re-parse the same
 // file at least twice (possibly more than twice, since we'll also parse it when
 // resolving the "default" configuration).
-fn resolve_configuration(
+pub fn resolve_configuration(
     pyproject: &Path,
     relativity: Relativity,
     transformer: &dyn ConfigurationTransformer,


### PR DESCRIPTION
## Summary
This PR addresses a bug where the ruff LSP didn't follow a configuration's `extend` when the configuration is specified in the LSP settings.

Fixes https://github.com/astral-sh/ruff/issues/13261

## Test Plan

I created a workspace layout as described in https://github.com/astral-sh/ruff/issues/13261 and verified that the diagnostic isn't shown on main but is shown with this patch. 
