### PR TITLE
[red-knot] Add heterogeneous tuple type variant

### DIFF
--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -195,6 +195,8 @@ pub enum Type<'db> {
     LiteralString,
     /// A bytes literal
     BytesLiteral(BytesLiteralType<'db>),
+    /// A heterogeneous tuple type, with elements of the given types in source order.
+    Tuple(TupleType<'db>),
     // TODO protocols, callable types, overloads, generics, type vars
 }
 
@@ -362,6 +364,10 @@ impl<'db> Type<'db> {
                 // TODO defer to Type::Instance(<bytes from typeshed>).member
                 Type::Unknown
             }
+            Type::Tuple(_) => {
+                // TODO: defer to `typing.Tuple` / `builtins.tuple` methods from typeshed's stubs
+                Type::Unknown
+            }
         }
     }
 
@@ -473,6 +479,7 @@ impl<'db> Type<'db> {
             Type::Unknown => Type::Unknown,
             // TODO intersections
             Type::Intersection(_) => Type::Unknown,
+            Type::Tuple(_) => typeshed_symbol_ty(db, "tuple"),
         }
     }
 }
@@ -657,4 +664,10 @@ pub struct StringLiteralType<'db> {
 pub struct BytesLiteralType<'db> {
     #[return_ref]
     value: Box<[u8]>,
+}
+
+#[salsa::interned]
+pub struct TupleType<'db> {
+    #[return_ref]
+    elements: Vec<Type<'db>>,
 }

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -196,7 +196,7 @@ pub enum Type<'db> {
     /// A bytes literal
     BytesLiteral(BytesLiteralType<'db>),
     /// A heterogeneous tuple type, with elements of the given types in source order.
-    Tuple(TupleType<'db>),
+    TupleLiteral(TupleLiteralType<'db>),
     // TODO protocols, callable types, overloads, generics, type vars
 }
 
@@ -364,7 +364,7 @@ impl<'db> Type<'db> {
                 // TODO defer to Type::Instance(<bytes from typeshed>).member
                 Type::Unknown
             }
-            Type::Tuple(_) => {
+            Type::TupleLiteral(_) => {
                 // TODO: defer to `builtins.tuple` methods from typeshed's stubs
                 Type::Unknown
             }
@@ -479,7 +479,7 @@ impl<'db> Type<'db> {
             Type::Unknown => Type::Unknown,
             // TODO intersections
             Type::Intersection(_) => Type::Unknown,
-            Type::Tuple(_) => builtins_symbol_ty(db, "tuple"),
+            Type::TupleLiteral(_) => builtins_symbol_ty(db, "tuple"),
         }
     }
 }
@@ -667,7 +667,7 @@ pub struct BytesLiteralType<'db> {
 }
 
 #[salsa::interned]
-pub struct TupleType<'db> {
+pub struct TupleLiteralType<'db> {
     #[return_ref]
     elements: Vec<Type<'db>>,
 }

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -365,7 +365,7 @@ impl<'db> Type<'db> {
                 Type::Unknown
             }
             Type::Tuple(_) => {
-                // TODO: defer to `typing.Tuple` / `builtins.tuple` methods from typeshed's stubs
+                // TODO: defer to `builtins.tuple` methods from typeshed's stubs
                 Type::Unknown
             }
         }

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -196,7 +196,8 @@ pub enum Type<'db> {
     /// A bytes literal
     BytesLiteral(BytesLiteralType<'db>),
     /// A heterogeneous tuple type, with elements of the given types in source order.
-    TupleLiteral(TupleLiteralType<'db>),
+    // TODO: Support variable length homogeneous tuple type like `tuple[int, ...]`.
+    Tuple(TupleType<'db>),
     // TODO protocols, callable types, overloads, generics, type vars
 }
 
@@ -364,7 +365,7 @@ impl<'db> Type<'db> {
                 // TODO defer to Type::Instance(<bytes from typeshed>).member
                 Type::Unknown
             }
-            Type::TupleLiteral(_) => {
+            Type::Tuple(_) => {
                 // TODO: defer to `builtins.tuple` methods from typeshed's stubs
                 Type::Unknown
             }
@@ -479,7 +480,7 @@ impl<'db> Type<'db> {
             Type::Unknown => Type::Unknown,
             // TODO intersections
             Type::Intersection(_) => Type::Unknown,
-            Type::TupleLiteral(_) => builtins_symbol_ty(db, "tuple"),
+            Type::Tuple(_) => builtins_symbol_ty(db, "tuple"),
         }
     }
 }
@@ -667,7 +668,7 @@ pub struct BytesLiteralType<'db> {
 }
 
 #[salsa::interned]
-pub struct TupleLiteralType<'db> {
+pub struct TupleType<'db> {
     #[return_ref]
-    elements: Vec<Type<'db>>,
+    elements: Box<[Type<'db>]>,
 }

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -479,7 +479,7 @@ impl<'db> Type<'db> {
             Type::Unknown => Type::Unknown,
             // TODO intersections
             Type::Intersection(_) => Type::Unknown,
-            Type::Tuple(_) => typeshed_symbol_ty(db, "tuple"),
+            Type::Tuple(_) => builtins_symbol_ty(db, "tuple"),
         }
     }
 }

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -366,7 +366,7 @@ impl<'db> Type<'db> {
                 Type::Unknown
             }
             Type::Tuple(_) => {
-                // TODO: defer to `builtins.tuple` methods from typeshed's stubs
+                // TODO: implement tuple methods
                 Type::Unknown
             }
         }

--- a/crates/red_knot_python_semantic/src/types/display.rs
+++ b/crates/red_knot_python_semantic/src/types/display.rs
@@ -86,7 +86,7 @@ impl std::fmt::Display for DisplayRepresentation<'_> {
 
                 escape.bytes_repr().write(f)
             }
-            Type::Tuple(tuple) => {
+            Type::TupleLiteral(tuple) => {
                 f.write_str("tuple[")?;
                 let elements = tuple.elements(self.db);
                 if elements.is_empty() {

--- a/crates/red_knot_python_semantic/src/types/display.rs
+++ b/crates/red_knot_python_semantic/src/types/display.rs
@@ -86,6 +86,23 @@ impl std::fmt::Display for DisplayRepresentation<'_> {
 
                 escape.bytes_repr().write(f)
             }
+            Type::Tuple(tuple) => {
+                f.write_str("tuple[")?;
+                let elements = tuple.elements(self.db);
+                if elements.is_empty() {
+                    f.write_str("()")?;
+                } else {
+                    let mut first = true;
+                    for element in tuple.elements(self.db) {
+                        if !first {
+                            f.write_str(", ")?;
+                        }
+                        first = false;
+                        element.display(self.db).fmt(f)?;
+                    }
+                }
+                f.write_str("]")
+            }
         }
     }
 }

--- a/crates/red_knot_python_semantic/src/types/display.rs
+++ b/crates/red_knot_python_semantic/src/types/display.rs
@@ -93,7 +93,7 @@ impl std::fmt::Display for DisplayRepresentation<'_> {
                     f.write_str("()")?;
                 } else {
                     let mut first = true;
-                    for element in tuple.elements(self.db) {
+                    for element in &**elements {
                         if !first {
                             f.write_str(", ")?;
                         }

--- a/crates/red_knot_python_semantic/src/types/display.rs
+++ b/crates/red_knot_python_semantic/src/types/display.rs
@@ -86,7 +86,7 @@ impl std::fmt::Display for DisplayRepresentation<'_> {
 
                 escape.bytes_repr().write(f)
             }
-            Type::TupleLiteral(tuple) => {
+            Type::Tuple(tuple) => {
                 f.write_str("tuple[")?;
                 let elements = tuple.elements(self.db);
                 if elements.is_empty() {

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -1558,7 +1558,8 @@ impl<'db> TypeInferenceBuilder<'db> {
             .map(|elt| self.infer_expression(elt))
             .collect::<Vec<_>>();
 
-        // TODO generic
+        // TODO: Currently, we support only tuple literals like `(1, 2)` or `(x, y)` but we still
+        // need to support generic tuple types like `tuple[int, str]` and `tuple[int, ...]`.
         Type::TupleLiteral(TupleLiteralType::new(self.db, element_types))
     }
 

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -49,7 +49,7 @@ use crate::stdlib::builtins_module_scope;
 use crate::types::diagnostic::{TypeCheckDiagnostic, TypeCheckDiagnostics};
 use crate::types::{
     builtins_symbol_ty, definitions_ty, global_symbol_ty, symbol_ty, BytesLiteralType, ClassType,
-    FunctionType, StringLiteralType, TupleType, Type, UnionBuilder,
+    FunctionType, StringLiteralType, TupleLiteralType, Type, UnionBuilder,
 };
 use crate::Db;
 
@@ -1559,7 +1559,7 @@ impl<'db> TypeInferenceBuilder<'db> {
             .collect::<Vec<_>>();
 
         // TODO generic
-        Type::Tuple(TupleType::new(self.db, element_types))
+        Type::TupleLiteral(TupleLiteralType::new(self.db, element_types))
     }
 
     fn infer_list_expression(&mut self, list: &ast::ExprList) -> Type<'db> {

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -49,7 +49,7 @@ use crate::stdlib::builtins_module_scope;
 use crate::types::diagnostic::{TypeCheckDiagnostic, TypeCheckDiagnostics};
 use crate::types::{
     builtins_symbol_ty, definitions_ty, global_symbol_ty, symbol_ty, BytesLiteralType, ClassType,
-    FunctionType, StringLiteralType, Type, UnionBuilder,
+    FunctionType, StringLiteralType, TupleType, Type, UnionBuilder,
 };
 use crate::Db;
 
@@ -1553,12 +1553,13 @@ impl<'db> TypeInferenceBuilder<'db> {
             parenthesized: _,
         } = tuple;
 
-        for elt in elts {
-            self.infer_expression(elt);
-        }
+        let element_types = elts
+            .iter()
+            .map(|elt| self.infer_expression(elt))
+            .collect::<Vec<_>>();
 
         // TODO generic
-        builtins_symbol_ty(self.db, "tuple").to_instance()
+        Type::Tuple(TupleType::new(self.db, element_types))
     }
 
     fn infer_list_expression(&mut self, list: &ast::ExprList) -> Type<'db> {
@@ -4012,7 +4013,7 @@ mod tests {
     }
 
     #[test]
-    fn tuple_literal() -> anyhow::Result<()> {
+    fn empty_tuple_literal() -> anyhow::Result<()> {
         let mut db = setup_db();
 
         db.write_dedented(
@@ -4023,7 +4024,37 @@ mod tests {
         )?;
 
         // TODO should be a generic type
-        assert_public_ty(&db, "/src/a.py", "x", "tuple");
+        assert_public_ty(&db, "/src/a.py", "x", "tuple[()]");
+
+        Ok(())
+    }
+
+    #[test]
+    fn tuple_heterogeneous_literal() -> anyhow::Result<()> {
+        let mut db = setup_db();
+
+        db.write_dedented(
+            "/src/a.py",
+            "
+            x = (1, 'a')
+            y = (1, (2, 3))
+            z = (x, 2)
+            ",
+        )?;
+
+        assert_public_ty(&db, "/src/a.py", "x", r#"tuple[Literal[1], Literal["a"]]"#);
+        assert_public_ty(
+            &db,
+            "/src/a.py",
+            "y",
+            "tuple[Literal[1], tuple[Literal[2], Literal[3]]]",
+        );
+        assert_public_ty(
+            &db,
+            "/src/a.py",
+            "z",
+            r#"tuple[tuple[Literal[1], Literal["a"]], Literal[2]]"#,
+        );
 
         Ok(())
     }

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -49,7 +49,7 @@ use crate::stdlib::builtins_module_scope;
 use crate::types::diagnostic::{TypeCheckDiagnostic, TypeCheckDiagnostics};
 use crate::types::{
     builtins_symbol_ty, definitions_ty, global_symbol_ty, symbol_ty, BytesLiteralType, ClassType,
-    FunctionType, StringLiteralType, TupleLiteralType, Type, UnionBuilder,
+    FunctionType, StringLiteralType, TupleType, Type, UnionBuilder,
 };
 use crate::Db;
 
@@ -1558,9 +1558,7 @@ impl<'db> TypeInferenceBuilder<'db> {
             .map(|elt| self.infer_expression(elt))
             .collect::<Vec<_>>();
 
-        // TODO: Currently, we support only tuple literals like `(1, 2)` or `(x, y)` but we still
-        // need to support generic tuple types like `tuple[int, str]` and `tuple[int, ...]`.
-        Type::TupleLiteral(TupleLiteralType::new(self.db, element_types))
+        Type::Tuple(TupleType::new(self.db, element_types.into_boxed_slice()))
     }
 
     fn infer_list_expression(&mut self, list: &ast::ExprList) -> Type<'db> {
@@ -4024,7 +4022,6 @@ mod tests {
             ",
         )?;
 
-        // TODO should be a generic type
         assert_public_ty(&db, "/src/a.py", "x", "tuple[()]");
 
         Ok(())


### PR DESCRIPTION
## Summary

This PR adds a new `Type` variant called `TupleType` which is used for heterogeneous elements.

### Display notes

* For an empty tuple, I'm using `tuple[()]` as described in the docs: https://docs.python.org/3/library/typing.html#annotating-tuples
* For nested elements, it'll use the literal type instead of builtin type unlike Pyright which does `tuple[Literal[1], tuple[int, int]]` instead of `tuple[Literal[1], tuple[Literal[2], Literal[3]]]`. Also, mypy would give `tuple[builtins.int, builtins.int]` instead of `tuple[Literal[1], Literal[2]]`

## Test Plan

Update test case to account for the display change and add cases for multiple elements and nested tuple elements.
