### PR TITLE
Only run executable rules when they are enabled

### DIFF
--- a/crates/ruff_linter/src/checkers/tokens.rs
+++ b/crates/ruff_linter/src/checkers/tokens.rs
@@ -154,7 +154,13 @@ pub(crate) fn check_tokens(
         Rule::ShebangNotFirstLine,
         Rule::ShebangMissingPython,
     ]) {
-        flake8_executable::rules::from_tokens(&mut diagnostics, path, locator, comment_ranges);
+        flake8_executable::rules::from_tokens(
+            &mut diagnostics,
+            path,
+            locator,
+            comment_ranges,
+            settings,
+        );
     }
 
     if settings.rules.any_enabled(&[

--- a/crates/ruff_linter/src/rules/flake8_executable/rules/mod.rs
+++ b/crates/ruff_linter/src/rules/flake8_executable/rules/mod.rs
@@ -1,5 +1,8 @@
 use std::path::Path;
 
+use crate::codes::Rule;
+use crate::comments::shebang::ShebangDirective;
+use crate::settings::LinterSettings;
 use ruff_diagnostics::Diagnostic;
 use ruff_python_trivia::CommentRanges;
 use ruff_source_file::Locator;
@@ -8,8 +11,6 @@ pub(crate) use shebang_missing_executable_file::*;
 pub(crate) use shebang_missing_python::*;
 pub(crate) use shebang_not_executable::*;
 pub(crate) use shebang_not_first_line::*;
-
-use crate::comments::shebang::ShebangDirective;
 
 mod shebang_leading_whitespace;
 mod shebang_missing_executable_file;
@@ -22,6 +23,7 @@ pub(crate) fn from_tokens(
     path: &Path,
     locator: &Locator,
     comment_ranges: &CommentRanges,
+    settings: &LinterSettings,
 ) {
     let mut has_any_shebang = false;
     for range in comment_ranges {
@@ -33,8 +35,10 @@ pub(crate) fn from_tokens(
                 diagnostics.push(diagnostic);
             }
 
-            if let Some(diagnostic) = shebang_not_executable(path, range) {
-                diagnostics.push(diagnostic);
+            if settings.rules.enabled(Rule::ShebangNotExecutable) {
+                if let Some(diagnostic) = shebang_not_executable(path, range) {
+                    diagnostics.push(diagnostic);
+                }
             }
 
             if let Some(diagnostic) = shebang_leading_whitespace(range, locator) {
@@ -48,8 +52,10 @@ pub(crate) fn from_tokens(
     }
 
     if !has_any_shebang {
-        if let Some(diagnostic) = shebang_missing_executable_file(path) {
-            diagnostics.push(diagnostic);
+        if settings.rules.enabled(Rule::ShebangMissingExecutableFile) {
+            if let Some(diagnostic) = shebang_missing_executable_file(path) {
+                diagnostics.push(diagnostic);
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

I noticed that the `flake8_executable::*ExecutableFile` rules run as part of the benchmark when I reviewed a [diff](https://codspeed.io/astral-sh/ruff/branches/alex/f821-error-msg) from another PR. 

That surprised me because IO rules should be disabled in codspeed because they are more flaky because they're syscalls. 

This PR disables the rules for good in benchmarks by adding the missing checks in `shebang_not_executable` to only call
the rules when they're enabled unlike before where we called the rules when any `flake8_executable` rule was enabled.  

## Test Plan

I added panis to the executable file rules and verified that running the benchmarks with the panics present doesn't panic.
