### PR TITLE
Disable jemalloc decay in benchmarks

### DIFF
--- a/crates/ruff_benchmark/Cargo.toml
+++ b/crates/ruff_benchmark/Cargo.toml
@@ -66,4 +66,4 @@ codspeed = ["codspeed-criterion-compat"]
 mimalloc = { workspace = true }
 
 [target.'cfg(all(not(target_os = "windows"), not(target_os = "openbsd"), any(target_arch = "x86_64", target_arch = "aarch64", target_arch = "powerpc64")))'.dev-dependencies]
-tikv-jemallocator = { workspace = true }
+tikv-jemallocator = { workspace = true, features = ["unprefixed_malloc_on_supported_platforms"] }

--- a/crates/ruff_benchmark/benches/linter.rs
+++ b/crates/ruff_benchmark/benches/linter.rs
@@ -28,6 +28,24 @@ static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 #[global_allocator]
 static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
+// Disable decay after 10s because it can show up as *random* slow allocations
+// in benchmarks. We don't need purging in benchmarks because it isn't important
+// to give unallocated pages back to the OS.
+// https://jemalloc.net/jemalloc.3.html#opt.dirty_decay_ms
+#[cfg(all(
+    not(target_os = "windows"),
+    not(target_os = "openbsd"),
+    any(
+        target_arch = "x86_64",
+        target_arch = "aarch64",
+        target_arch = "powerpc64"
+    )
+))]
+#[allow(non_upper_case_globals)]
+#[export_name = "malloc_conf"]
+#[allow(unsafe_code)]
+pub static malloc_conf: &[u8] = b"dirty_decay_ms:-1,muzzy_decay_ms:-1\0";
+
 fn create_test_cases() -> Result<Vec<TestCase>, TestFileDownloadError> {
     Ok(vec![
         TestCase::fast(TestFile::try_download("numpy/globals.py", "https://raw.githubusercontent.com/numpy/numpy/89d64415e349ca75a25250f22b874aa16e5c0973/numpy/_globals.py")?),


### PR DESCRIPTION
## Summary

Another try to make our linter benchmarks more stable. 

I honestly don't understand much of it. But jemalloc has a system to yield
unused pages back to the OS. However, it doesn't do so immediately, instead, jemalloc
waits 10s before running the decay function that then shows up in profiles. 

<img width="870" alt="Screenshot 2024-09-09 at 21 43 32" src="https://github.com/user-attachments/assets/c55a2d66-f4b7-4128-8b7b-0c3ce919906c">



I don't understand why the decay very predictably happens in the same allocation in `flake8_annotations` and
mainly when running the all-preview rules benchmarks. So maybe this is another fruitless attempt. 

We may want to port this to other benchmarks in the future, but I first want to see if it does help to make the benchmarks more predictable

## Test Plan

The codspeed benchmark show improvements due to removing some `decay` stack frames in head (that exist in base)
