### PR TITLE
[`pydoclint`] Ignore `DOC201` when function name is "__new__"

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pydoclint/DOC201_google.py
+++ b/crates/ruff_linter/resources/test/fixtures/pydoclint/DOC201_google.py
@@ -207,3 +207,10 @@ def foo(s: str) -> str | None:
         s (str): A string.
     """
     return None
+
+
+class Spam:
+    # OK
+    def __new__(cls) -> 'Spam':
+        """New!!"""
+        return cls()

--- a/crates/ruff_linter/src/rules/pydoclint/rules/check_docstring.rs
+++ b/crates/ruff_linter/src/rules/pydoclint/rules/check_docstring.rs
@@ -741,6 +741,10 @@ fn returns_documented(
         || (matches!(convention, Some(Convention::Google)) && starts_with_returns(docstring))
 }
 
+fn should_document_returns(function_def: &ast::StmtFunctionDef) -> bool {
+    !matches!(function_def.name.as_str(), "__new__")
+}
+
 fn starts_with_yields(docstring: &Docstring) -> bool {
     if let Some(first_word) = docstring.body().as_str().split(' ').next() {
         return matches!(first_word, "Yield" | "Yields");
@@ -868,7 +872,9 @@ pub(crate) fn check_docstring(
 
     // DOC201
     if checker.enabled(Rule::DocstringMissingReturns) {
-        if !returns_documented(docstring, &docstring_sections, convention) {
+        if should_document_returns(function_def)
+            && !returns_documented(docstring, &docstring_sections, convention)
+        {
             let extra_property_decorators = checker.settings.pydocstyle.property_decorators();
             if !definition.is_property(extra_property_decorators, semantic) {
                 if let Some(body_return) = body_entries.returns.first() {


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Resolves #13079.

Do not enforce the documentation of `return` in a `__new__` function. Arguably this could apply to some other dunder methods.

## Test Plan

Added fixture.
