### PR TITLE
Refactor method classification logic: `__new__` methods are now classified as `staticmethod`

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_unused_arguments/ARG.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_unused_arguments/ARG.py
@@ -189,6 +189,9 @@ def f(a, b):
 # Unused arguments on magic methods.
 ###
 class C:
+    def __new__(cls, x):
+        print("Hello, world!")
+
     def __init__(self, x) -> None:
         print("Hello, world!")
 
@@ -196,6 +199,12 @@ class C:
         return "Hello, world!"
 
     def __exit__(self, exc_type, exc_value, traceback) -> None:
+        print("Hello, world!")
+
+    def __init_subclass__(cls, x) -> None:
+        print("Hello, world!")
+
+    def __class_getitem__(cls, x):
         print("Hello, world!")
 
 

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/custom_type_var_return_type.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/custom_type_var_return_type.rs
@@ -189,9 +189,8 @@ impl<'a> ClassMethod<'a> {
     }
 }
 
-// Dunder new methods (`__new__`, also known as magic methods) are technically static methods,
-// with `cls` as their first argument. However, for the purpose of this check, we treat them
-// as class methods.
+// Dunder new methods (`__new__`) are technically static methods with `cls` as their first argument.
+// For simplicity of implementation, we treat them as class methods.
 use ClassMethod as DunderNewMethod;
 
 #[derive(Debug)]

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/custom_type_var_return_type.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/custom_type_var_return_type.rs
@@ -100,18 +100,25 @@ pub(crate) fn custom_type_var_return_type(
         &checker.settings.pep8_naming.classmethod_decorators,
         &checker.settings.pep8_naming.staticmethod_decorators,
     ) {
-        FunctionType::Function => return,
-        FunctionType::StaticMethod => return,
-        FunctionType::ClassMethod => Method::Class(ClassMethod {
-            cls_annotation: self_or_cls_annotation,
-            returns,
-            type_params,
-        }),
         FunctionType::Method => Method::Instance(InstanceMethod {
             self_annotation: self_or_cls_annotation,
             returns,
             type_params,
         }),
+        FunctionType::ClassMethod => Method::Class(ClassMethod {
+            cls_annotation: self_or_cls_annotation,
+            returns,
+            type_params,
+        }),
+        FunctionType::StaticMethod if matches!(name, "__new__") => {
+            Method::DunderNew(DunderNewMethod {
+                cls_annotation: self_or_cls_annotation,
+                returns,
+                type_params,
+            })
+        }
+        FunctionType::StaticMethod => return,
+        FunctionType::Function => return,
     };
 
     if method.uses_custom_var() {
@@ -126,6 +133,7 @@ pub(crate) fn custom_type_var_return_type(
 
 #[derive(Debug)]
 enum Method<'a> {
+    DunderNew(DunderNewMethod<'a>),
     Class(ClassMethod<'a>),
     Instance(InstanceMethod<'a>),
 }
@@ -133,6 +141,7 @@ enum Method<'a> {
 impl<'a> Method<'a> {
     fn uses_custom_var(&self) -> bool {
         match self {
+            Self::DunderNew(dunder_new_method) => dunder_new_method.uses_custom_var(),
             Self::Class(class_method) => class_method.uses_custom_var(),
             Self::Instance(instance_method) => instance_method.uses_custom_var(),
         }
@@ -179,6 +188,11 @@ impl<'a> ClassMethod<'a> {
         is_likely_private_typevar(&slice.id, self.type_params)
     }
 }
+
+// Dunder new methods (`__new__`, also known as magic methods) are technically static methods,
+// with `cls` as their first argument. However, for the purpose of this check, we treat them
+// as class methods.
+use ClassMethod as DunderNewMethod;
 
 #[derive(Debug)]
 struct InstanceMethod<'a> {

--- a/crates/ruff_linter/src/rules/flake8_unused_arguments/rules/unused_arguments.rs
+++ b/crates/ruff_linter/src/rules/flake8_unused_arguments/rules/unused_arguments.rs
@@ -422,6 +422,22 @@ pub(crate) fn unused_arguments(
                         && !visibility::is_override(decorator_list, checker.semantic())
                         && !visibility::is_overload(decorator_list, checker.semantic())
                     {
+                        if visibility::is_new(name) {
+                            method(
+                                Argumentable::StaticMethod,
+                                parameters,
+                                scope,
+                                checker.semantic(),
+                                &checker.settings.dummy_variable_rgx,
+                                checker
+                                    .settings
+                                    .flake8_unused_arguments
+                                    .ignore_variadic_names,
+                                diagnostics,
+                            );
+                            return;
+                        }
+
                         function(
                             Argumentable::StaticMethod,
                             parameters,

--- a/crates/ruff_linter/src/rules/flake8_unused_arguments/snapshots/ruff_linter__rules__flake8_unused_arguments__tests__ARG002_ARG.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_unused_arguments/snapshots/ruff_linter__rules__flake8_unused_arguments__tests__ARG002_ARG.py.snap
@@ -28,13 +28,11 @@ ARG.py:43:16: ARG002 Unused method argument: `x`
 44 |         print("Hello, world!")
    |
 
-ARG.py:192:24: ARG002 Unused method argument: `x`
+ARG.py:195:24: ARG002 Unused method argument: `x`
     |
-190 | ###
-191 | class C:
-192 |     def __init__(self, x) -> None:
-    |                        ^ ARG002
 193 |         print("Hello, world!")
+194 | 
+195 |     def __init__(self, x) -> None:
+    |                        ^ ARG002
+196 |         print("Hello, world!")
     |
-
-

--- a/crates/ruff_linter/src/rules/flake8_unused_arguments/snapshots/ruff_linter__rules__flake8_unused_arguments__tests__ARG004_ARG.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_unused_arguments/snapshots/ruff_linter__rules__flake8_unused_arguments__tests__ARG004_ARG.py.snap
@@ -25,4 +25,11 @@ ARG.py:55:11: ARG004 Unused static method argument: `x`
 56 |         print("Hello, world!")
    |
 
-
+ARG.py:192:22: ARG004 Unused static method argument: `x`
+    |
+190 | ###
+191 | class C:
+192 |     def __new__(cls, x):
+    |                      ^ ARG004
+193 |         print("Hello, world!")
+    |


### PR DESCRIPTION
## Summary

`__new__` methods are technically static methods, with `cls` as their first argument. However, Ruff currently classifies them as classmethod, which causes two issues:

- It conveys incorrect information, leading to confusion. For example, in cases like ARG003, `__new__` is explicitly treated as a classmethod.
- Future rules that should apply to staticmethod may not be applied correctly due to this misclassification.

Based on #13154, I have excluded the first argument `cls` of `__new__` from ARG004. (not concluded, it can be change)

Closes #13154