### PR TITLE
[`isort`] Improve rule documentation with a link to the option (`I002`)

### DIFF
--- a/crates/ruff_linter/src/rules/isort/rules/add_required_imports.rs
+++ b/crates/ruff_linter/src/rules/isort/rules/add_required_imports.rs
@@ -35,6 +35,9 @@ use crate::settings::LinterSettings;
 ///
 /// import typing
 /// ```
+///
+/// ## Options
+/// - `lint.isort.required-imports`
 #[violation]
 pub struct MissingRequiredImport(pub String);
 


### PR DESCRIPTION
## Summary

https://docs.astral.sh/ruff/rules/missing-required-import/ is missing a link to https://docs.astral.sh/ruff/settings/#lint_isort_required-imports that controls this rule's behavior.

## Test Plan

`cargo dev generate-docs`
`grep 'lint.isort.required-imports' docs/rules/missing-required-import.md`