### PR TITLE
[red-knot] Add a convenience method for constructing a union from a list of elements

### DIFF
--- a/crates/red_knot_python_semantic/src/types/builder.rs
+++ b/crates/red_knot_python_semantic/src/types/builder.rs
@@ -276,7 +276,7 @@ mod tests {
     use crate::db::tests::TestDb;
     use crate::program::{Program, SearchPathSettings};
     use crate::python_version::PythonVersion;
-    use crate::types::builtins_symbol_ty;
+    use crate::types::{builtins_symbol_ty, UnionBuilder};
     use crate::ProgramSettings;
     use ruff_db::system::{DbWithTestSystem, SystemPathBuf};
 
@@ -327,7 +327,7 @@ mod tests {
     #[test]
     fn build_union_empty() {
         let db = setup_db();
-        let ty = UnionType::from_elements(&db, []);
+        let ty = UnionBuilder::new(&db).build();
         assert_eq!(ty, Type::Never);
     }
 

--- a/crates/red_knot_python_semantic/src/types/builder.rs
+++ b/crates/red_knot_python_semantic/src/types/builder.rs
@@ -169,11 +169,12 @@ impl<'db> IntersectionBuilder<'db> {
         if self.intersections.len() == 1 {
             self.intersections.pop().unwrap().build(self.db)
         } else {
-            let mut builder = UnionBuilder::new(self.db);
-            for inner in self.intersections {
-                builder = builder.add(inner.build(self.db));
-            }
-            builder.build()
+            UnionType::from_elements(
+                self.db,
+                self.intersections
+                    .into_iter()
+                    .map(|inner| inner.build(self.db)),
+            )
         }
     }
 }
@@ -271,7 +272,7 @@ impl<'db> InnerIntersectionBuilder<'db> {
 
 #[cfg(test)]
 mod tests {
-    use super::{IntersectionBuilder, IntersectionType, Type, UnionBuilder, UnionType};
+    use super::{IntersectionBuilder, IntersectionType, Type, UnionType};
     use crate::db::tests::TestDb;
     use crate::program::{Program, SearchPathSettings};
     use crate::python_version::PythonVersion;
@@ -310,11 +311,7 @@ mod tests {
         let db = setup_db();
         let t0 = Type::IntLiteral(0);
         let t1 = Type::IntLiteral(1);
-        let union = UnionBuilder::new(&db)
-            .add(t0)
-            .add(t1)
-            .build()
-            .expect_union();
+        let union = UnionType::from_elements(&db, [t0, t1]).expect_union();
 
         assert_eq!(union.elements_vec(&db), &[t0, t1]);
     }
@@ -323,16 +320,14 @@ mod tests {
     fn build_union_single() {
         let db = setup_db();
         let t0 = Type::IntLiteral(0);
-        let ty = UnionBuilder::new(&db).add(t0).build();
-
+        let ty = UnionType::from_elements(&db, [t0]);
         assert_eq!(ty, t0);
     }
 
     #[test]
     fn build_union_empty() {
         let db = setup_db();
-        let ty = UnionBuilder::new(&db).build();
-
+        let ty = UnionType::from_elements(&db, []);
         assert_eq!(ty, Type::Never);
     }
 
@@ -340,8 +335,7 @@ mod tests {
     fn build_union_never() {
         let db = setup_db();
         let t0 = Type::IntLiteral(0);
-        let ty = UnionBuilder::new(&db).add(t0).add(Type::Never).build();
-
+        let ty = UnionType::from_elements(&db, [t0, Type::Never]);
         assert_eq!(ty, t0);
     }
 
@@ -355,21 +349,10 @@ mod tests {
         let t2 = Type::BooleanLiteral(false);
         let t3 = Type::IntLiteral(17);
 
-        let union = UnionBuilder::new(&db)
-            .add(t0)
-            .add(t1)
-            .add(t3)
-            .build()
-            .expect_union();
+        let union = UnionType::from_elements(&db, [t0, t1, t3]).expect_union();
         assert_eq!(union.elements_vec(&db), &[t0, t3]);
-        let union = UnionBuilder::new(&db)
-            .add(t0)
-            .add(t1)
-            .add(t2)
-            .add(t3)
-            .build()
-            .expect_union();
 
+        let union = UnionType::from_elements(&db, [t0, t1, t2, t3]).expect_union();
         assert_eq!(union.elements_vec(&db), &[bool_ty, t3]);
     }
 
@@ -379,12 +362,8 @@ mod tests {
         let t0 = Type::IntLiteral(0);
         let t1 = Type::IntLiteral(1);
         let t2 = Type::IntLiteral(2);
-        let u1 = UnionBuilder::new(&db).add(t0).add(t1).build();
-        let union = UnionBuilder::new(&db)
-            .add(u1)
-            .add(t2)
-            .build()
-            .expect_union();
+        let u1 = UnionType::from_elements(&db, [t0, t1]);
+        let union = UnionType::from_elements(&db, [u1, t2]).expect_union();
 
         assert_eq!(union.elements_vec(&db), &[t0, t1, t2]);
     }
@@ -460,7 +439,7 @@ mod tests {
         let t0 = Type::IntLiteral(0);
         let t1 = Type::IntLiteral(1);
         let ta = Type::Any;
-        let u0 = UnionBuilder::new(&db).add(t0).add(t1).build();
+        let u0 = UnionType::from_elements(&db, [t0, t1]);
 
         let union = IntersectionBuilder::new(&db)
             .add_positive(ta)

--- a/crates/red_knot_python_semantic/src/types/display.rs
+++ b/crates/red_knot_python_semantic/src/types/display.rs
@@ -253,7 +253,7 @@ mod tests {
     use ruff_db::system::{DbWithTestSystem, SystemPathBuf};
 
     use crate::db::tests::TestDb;
-    use crate::types::{global_symbol_ty, BytesLiteralType, StringLiteralType, Type, UnionBuilder};
+    use crate::types::{global_symbol_ty, BytesLiteralType, StringLiteralType, Type, UnionType};
     use crate::{Program, ProgramSettings, PythonVersion, SearchPathSettings};
 
     fn setup_db() -> TestDb {
@@ -295,7 +295,7 @@ mod tests {
         )?;
         let mod_file = system_path_to_file(&db, "src/main.py").expect("Expected file to exist.");
 
-        let vec: Vec<Type<'_>> = vec![
+        let union_elements = &[
             Type::Unknown,
             Type::IntLiteral(-1),
             global_symbol_ty(&db, mod_file, "A"),
@@ -311,10 +311,7 @@ mod tests {
             Type::BooleanLiteral(true),
             Type::None,
         ];
-        let builder = vec.iter().fold(UnionBuilder::new(&db), |builder, literal| {
-            builder.add(*literal)
-        });
-        let union = builder.build().expect_union();
+        let union = UnionType::from_elements(&db, union_elements.iter().copied()).expect_union();
         let display = format!("{}", union.display(&db));
         assert_eq!(
             display,

--- a/crates/red_knot_python_semantic/src/types/display.rs
+++ b/crates/red_knot_python_semantic/src/types/display.rs
@@ -311,7 +311,7 @@ mod tests {
             Type::BooleanLiteral(true),
             Type::None,
         ];
-        let union = UnionType::from_elements(&db, union_elements.iter().copied()).expect_union();
+        let union = UnionType::from_elements(&db, union_elements).expect_union();
         let display = format!("{}", union.display(&db));
         assert_eq!(
             display,

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -49,7 +49,7 @@ use crate::stdlib::builtins_module_scope;
 use crate::types::diagnostic::{TypeCheckDiagnostic, TypeCheckDiagnostics};
 use crate::types::{
     builtins_symbol_ty, definitions_ty, global_symbol_ty, symbol_ty, BytesLiteralType, ClassType,
-    FunctionType, StringLiteralType, TupleType, Type, UnionBuilder,
+    FunctionType, StringLiteralType, TupleType, Type, UnionType,
 };
 use crate::Db;
 
@@ -1827,10 +1827,7 @@ impl<'db> TypeInferenceBuilder<'db> {
         let body_ty = self.infer_expression(body);
         let orelse_ty = self.infer_expression(orelse);
 
-        UnionBuilder::new(self.db)
-            .add(body_ty)
-            .add(orelse_ty)
-            .build()
+        UnionType::from_elements(self.db, [body_ty, orelse_ty])
     }
 
     fn infer_lambda_body(&mut self, lambda_expression: &ast::ExprLambda) {


### PR DESCRIPTION
## Summary

This pattern is coming up a lot, and it will keep coming up! This PR adds a `UnionType::from_elements` method that is somewhat more ergonomic than having to manually call `UnionBuilder::new(&db).add(elem0).add(elem1).build()` every time we want to create a new union.

(PR is stacked on top of #13314)

## Test Plan

`cargo test`
