### PR TITLE
[red-knot] Infer target types for unpacked tuple assignment

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/unpacking.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/unpacking.md
@@ -84,9 +84,9 @@ reveal_type(b)  # revealed: Literal[2]
 # TODO: Remove 'not-iterable' diagnostic
 [a, *b, c, d] = (1, 2)  # error: "Object of type `None` is not iterable"
 reveal_type(a)  # revealed: Literal[1]
-# TODO: Should be List[int] / List[Literal[2]] once support for assigning to starred expression is added
+# TODO: Should be List[Any] once support for assigning to starred expression is added
 reveal_type(b)  # revealed: @Todo
-reveal_type(c)  # revealed: Unknown
+reveal_type(c)  # revealed: Literal[2]
 reveal_type(d)  # revealed: Unknown
 ```
 
@@ -148,6 +148,44 @@ reveal_type(a)  # revealed: Unknown
 reveal_type(b)  # revealed: Unknown
 ```
 
+### Custom iterator unpacking
+
+```py
+class Iterator:
+    def __next__(self) -> int:
+        return 42
+
+
+class Iterable:
+    def __iter__(self) -> Iterator:
+        return Iterator()
+
+
+(a, b) = Iterable()
+reveal_type(a)  # revealed: int
+reveal_type(b)  # revealed: int
+```
+
+### Custom iterator unpacking nested
+
+```py
+class Iterator:
+    def __next__(self) -> int:
+        return 42
+
+
+class Iterable:
+    def __iter__(self) -> Iterator:
+        return Iterator()
+
+
+(a, (b, c), d) = (1, Iterable(), 2)
+reveal_type(a)  # revealed: Literal[1]
+reveal_type(b)  # revealed: int
+reveal_type(c)  # revealed: int
+reveal_type(d)  # revealed: Literal[2]
+```
+
 ## String
 
 ### Simple unpacking
@@ -186,7 +224,7 @@ reveal_type(b)  # revealed: LiteralString
 reveal_type(a)  # revealed: LiteralString
 # TODO: Should be List[LiteralString] once support for assigning to starred expression is added
 reveal_type(b)  # revealed: @Todo
-reveal_type(c)  # revealed: Unknown
+reveal_type(c)  # revealed: LiteralString
 reveal_type(d)  # revealed: Unknown
 ```
 

--- a/crates/red_knot_python_semantic/resources/mdtest/unpacking.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/unpacking.md
@@ -132,7 +132,7 @@ reveal_type(b)  # revealed: Unknown
 ### Simple unpacking
 
 ```py
-a, b = 'abc'
+a, b = 'ab'
 reveal_type(a)  # revealed: LiteralString
 reveal_type(b)  # revealed: LiteralString
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/unpacking.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/unpacking.md
@@ -61,6 +61,7 @@ reveal_type(c)  # revealed: Literal[4]
 ### Uneven unpacking (1)
 
 ```py
+# TODO: Add diagnostic (there aren't enough values to unpack)
 (a, b, c) = (1, 2)
 reveal_type(a)  # revealed: Literal[1]
 reveal_type(b)  # revealed: Literal[2]
@@ -70,6 +71,7 @@ reveal_type(c)  # revealed: Unknown
 ### Uneven unpacking (2)
 
 ```py
+# TODO: Add diagnostic (too many values to unpack)
 (a, b) = (1, 2, 3)
 reveal_type(a)  # revealed: Literal[1]
 reveal_type(b)  # revealed: Literal[2]
@@ -77,40 +79,59 @@ reveal_type(b)  # revealed: Literal[2]
 
 ### Starred expression (1)
 
-TODO: The error message here is because `infer_starred_expression` isn't complete
-
 ```py
+# TODO: Add diagnostic (need more values to unpack)
+# TODO: Remove 'not-iterable' diagnostic
 [a, *b, c, d] = (1, 2)  # error: "Object of type `None` is not iterable"
 reveal_type(a)  # revealed: Literal[1]
-# TODO: Should be List[int]
-reveal_type(b)  # revealed: Unknown
+# TODO: Should be List[int] / List[Literal[2]] once support for assigning to starred expression is added
+reveal_type(b)  # revealed: @Todo
 reveal_type(c)  # revealed: Unknown
 reveal_type(d)  # revealed: Unknown
 ```
 
 ### Starred expression (2)
 
-TODO: The error message here is because `infer_starred_expression` isn't complete
-
 ```py
-[a, *b, c] = (1, 2, 3)  # error: "Object of type `None` is not iterable"
+[a, *b, c] = (1, 2)  # error: "Object of type `None` is not iterable"
 reveal_type(a)  # revealed: Literal[1]
-# TODO: Should be List[int]
-reveal_type(b)  # revealed: Unknown
-reveal_type(c)  # revealed: Literal[3]
+# TODO: Should be List[Any] once support for assigning to starred expression is added
+reveal_type(b)  # revealed: @Todo
+reveal_type(c)  # revealed: Literal[2]
 ```
 
 ### Starred expression (3)
 
-TODO: The error message here is because `infer_starred_expression` isn't complete
+```py
+# TODO: Remove 'not-iterable' diagnostic
+[a, *b, c] = (1, 2, 3)  # error: "Object of type `None` is not iterable"
+reveal_type(a)  # revealed: Literal[1]
+# TODO: Should be List[int] once support for assigning to starred expression is added
+reveal_type(b)  # revealed: @Todo
+reveal_type(c)  # revealed: Literal[3]
+```
+
+### Starred expression (4)
 
 ```py
+# TODO: Remove 'not-iterable' diagnostic
 [a, *b, c, d] = (1, 2, 3, 4, 5, 6)  # error: "Object of type `None` is not iterable"
 reveal_type(a)  # revealed: Literal[1]
-# TODO: Should be List[int]
-reveal_type(b)  # revealed: Unknown
+# TODO: Should be List[int] once support for assigning to starred expression is added
+reveal_type(b)  # revealed: @Todo
 reveal_type(c)  # revealed: Literal[5]
 reveal_type(d)  # revealed: Literal[6]
+```
+
+### Starred expression (5)
+
+```py
+# TODO: Remove 'not-iterable' diagnostic
+[a, b, *c] = (1, 2, 3, 4)  # error: "Object of type `None` is not iterable"
+reveal_type(a)  # revealed: Literal[1]
+reveal_type(b)  # revealed: Literal[2]
+# TODO: Should be List[int] once support for assigning to starred expression is added
+reveal_type(c)  # revealed: @Todo
 ```
 
 ### Non-iterable unpacking
@@ -137,13 +158,78 @@ reveal_type(a)  # revealed: LiteralString
 reveal_type(b)  # revealed: LiteralString
 ```
 
-### Starred expression
-
-TODO: The error message here is because `infer_starred_expression` isn't complete
+### Uneven unpacking (1)
 
 ```py
-a, *b = 'abc'  # error: "Object of type `None` is not iterable"
+# TODO: Add diagnostic (there aren't enough values to unpack)
+a, b, c = 'ab'
 reveal_type(a)  # revealed: LiteralString
-# TODO: Should be List[str]
-reveal_type(b)  # revealed: Unknown
+reveal_type(b)  # revealed: LiteralString
+reveal_type(c)  # revealed: Unknown
+```
+
+### Uneven unpacking (2)
+
+```py
+# TODO: Add diagnostic (too many values to unpack)
+a, b = 'abc'
+reveal_type(a)  # revealed: LiteralString
+reveal_type(b)  # revealed: LiteralString
+```
+
+### Starred expression (1)
+
+```py
+# TODO: Add diagnostic (need more values to unpack)
+# TODO: Remove 'not-iterable' diagnostic
+(a, *b, c, d) = "ab"  # error: "Object of type `None` is not iterable"
+reveal_type(a)  # revealed: LiteralString
+# TODO: Should be List[LiteralString] once support for assigning to starred expression is added
+reveal_type(b)  # revealed: @Todo
+reveal_type(c)  # revealed: Unknown
+reveal_type(d)  # revealed: Unknown
+```
+
+### Starred expression (2)
+
+```py
+(a, *b, c) = "ab"  # error: "Object of type `None` is not iterable"
+reveal_type(a)  # revealed: LiteralString
+# TODO: Should be List[Any] once support for assigning to starred expression is added
+reveal_type(b)  # revealed: @Todo
+reveal_type(c)  # revealed: LiteralString
+```
+
+### Starred expression (3)
+
+```py
+# TODO: Remove 'not-iterable' diagnostic
+(a, *b, c) = "abc"  # error: "Object of type `None` is not iterable"
+reveal_type(a)  # revealed: LiteralString
+# TODO: Should be List[LiteralString] once support for assigning to starred expression is added
+reveal_type(b)  # revealed: @Todo
+reveal_type(c)  # revealed: LiteralString
+```
+
+### Starred expression (4)
+
+```py
+# TODO: Remove 'not-iterable' diagnostic
+(a, *b, c, d) = "abcdef"  # error: "Object of type `None` is not iterable"
+reveal_type(a)  # revealed: LiteralString
+# TODO: Should be List[LiteralString] once support for assigning to starred expression is added
+reveal_type(b)  # revealed: @Todo
+reveal_type(c)  # revealed: LiteralString
+reveal_type(d)  # revealed: LiteralString
+```
+
+### Starred expression (5)
+
+```py
+# TODO: Remove 'not-iterable' diagnostic
+(a, b, *c) = "abcd"  # error: "Object of type `None` is not iterable"
+reveal_type(a)  # revealed: LiteralString
+reveal_type(b)  # revealed: LiteralString
+# TODO: Should be List[int] once support for assigning to starred expression is added
+reveal_type(c)  # revealed: @Todo
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/unpacking.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/unpacking.md
@@ -113,6 +113,20 @@ reveal_type(c)  # revealed: Literal[5]
 reveal_type(d)  # revealed: Literal[6]
 ```
 
+### Non-iterable unpacking
+
+TODO: Remove duplicate diagnostics. This is happening because for a sequence-like
+assignment target, multiple definitions are created and the inference engine runs
+on each of them which results in duplicate diagnostics.
+
+```py
+# error: "Object of type `Literal[1]` is not iterable"
+# error: "Object of type `Literal[1]` is not iterable"
+a, b = 1
+reveal_type(a)  # revealed: Unknown
+reveal_type(b)  # revealed: Unknown
+```
+
 ## String
 
 ### Simple unpacking

--- a/crates/red_knot_python_semantic/resources/mdtest/unpacking.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/unpacking.md
@@ -84,7 +84,7 @@ reveal_type(b)  # revealed: Literal[2]
 # TODO: Remove 'not-iterable' diagnostic
 [a, *b, c, d] = (1, 2)  # error: "Object of type `None` is not iterable"
 reveal_type(a)  # revealed: Literal[1]
-# TODO: Should be List[Any] once support for assigning to starred expression is added
+# TODO: Should be list[Any] once support for assigning to starred expression is added
 reveal_type(b)  # revealed: @Todo
 reveal_type(c)  # revealed: Literal[2]
 reveal_type(d)  # revealed: Unknown
@@ -95,7 +95,7 @@ reveal_type(d)  # revealed: Unknown
 ```py
 [a, *b, c] = (1, 2)  # error: "Object of type `None` is not iterable"
 reveal_type(a)  # revealed: Literal[1]
-# TODO: Should be List[Any] once support for assigning to starred expression is added
+# TODO: Should be list[Any] once support for assigning to starred expression is added
 reveal_type(b)  # revealed: @Todo
 reveal_type(c)  # revealed: Literal[2]
 ```
@@ -106,7 +106,7 @@ reveal_type(c)  # revealed: Literal[2]
 # TODO: Remove 'not-iterable' diagnostic
 [a, *b, c] = (1, 2, 3)  # error: "Object of type `None` is not iterable"
 reveal_type(a)  # revealed: Literal[1]
-# TODO: Should be List[int] once support for assigning to starred expression is added
+# TODO: Should be list[int] once support for assigning to starred expression is added
 reveal_type(b)  # revealed: @Todo
 reveal_type(c)  # revealed: Literal[3]
 ```
@@ -117,7 +117,7 @@ reveal_type(c)  # revealed: Literal[3]
 # TODO: Remove 'not-iterable' diagnostic
 [a, *b, c, d] = (1, 2, 3, 4, 5, 6)  # error: "Object of type `None` is not iterable"
 reveal_type(a)  # revealed: Literal[1]
-# TODO: Should be List[int] once support for assigning to starred expression is added
+# TODO: Should be list[int] once support for assigning to starred expression is added
 reveal_type(b)  # revealed: @Todo
 reveal_type(c)  # revealed: Literal[5]
 reveal_type(d)  # revealed: Literal[6]
@@ -130,7 +130,7 @@ reveal_type(d)  # revealed: Literal[6]
 [a, b, *c] = (1, 2, 3, 4)  # error: "Object of type `None` is not iterable"
 reveal_type(a)  # revealed: Literal[1]
 reveal_type(b)  # revealed: Literal[2]
-# TODO: Should be List[int] once support for assigning to starred expression is added
+# TODO: Should be list[int] once support for assigning to starred expression is added
 reveal_type(c)  # revealed: @Todo
 ```
 
@@ -222,7 +222,7 @@ reveal_type(b)  # revealed: LiteralString
 # TODO: Remove 'not-iterable' diagnostic
 (a, *b, c, d) = "ab"  # error: "Object of type `None` is not iterable"
 reveal_type(a)  # revealed: LiteralString
-# TODO: Should be List[LiteralString] once support for assigning to starred expression is added
+# TODO: Should be list[LiteralString] once support for assigning to starred expression is added
 reveal_type(b)  # revealed: @Todo
 reveal_type(c)  # revealed: LiteralString
 reveal_type(d)  # revealed: Unknown
@@ -233,7 +233,7 @@ reveal_type(d)  # revealed: Unknown
 ```py
 (a, *b, c) = "ab"  # error: "Object of type `None` is not iterable"
 reveal_type(a)  # revealed: LiteralString
-# TODO: Should be List[Any] once support for assigning to starred expression is added
+# TODO: Should be list[Any] once support for assigning to starred expression is added
 reveal_type(b)  # revealed: @Todo
 reveal_type(c)  # revealed: LiteralString
 ```
@@ -244,7 +244,7 @@ reveal_type(c)  # revealed: LiteralString
 # TODO: Remove 'not-iterable' diagnostic
 (a, *b, c) = "abc"  # error: "Object of type `None` is not iterable"
 reveal_type(a)  # revealed: LiteralString
-# TODO: Should be List[LiteralString] once support for assigning to starred expression is added
+# TODO: Should be list[LiteralString] once support for assigning to starred expression is added
 reveal_type(b)  # revealed: @Todo
 reveal_type(c)  # revealed: LiteralString
 ```
@@ -255,7 +255,7 @@ reveal_type(c)  # revealed: LiteralString
 # TODO: Remove 'not-iterable' diagnostic
 (a, *b, c, d) = "abcdef"  # error: "Object of type `None` is not iterable"
 reveal_type(a)  # revealed: LiteralString
-# TODO: Should be List[LiteralString] once support for assigning to starred expression is added
+# TODO: Should be list[LiteralString] once support for assigning to starred expression is added
 reveal_type(b)  # revealed: @Todo
 reveal_type(c)  # revealed: LiteralString
 reveal_type(d)  # revealed: LiteralString
@@ -268,6 +268,6 @@ reveal_type(d)  # revealed: LiteralString
 (a, b, *c) = "abcd"  # error: "Object of type `None` is not iterable"
 reveal_type(a)  # revealed: LiteralString
 reveal_type(b)  # revealed: LiteralString
-# TODO: Should be List[int] once support for assigning to starred expression is added
+# TODO: Should be list[int] once support for assigning to starred expression is added
 reveal_type(c)  # revealed: @Todo
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/unpacking.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/unpacking.md
@@ -1,0 +1,135 @@
+# Unpacking
+
+## Tuple
+
+### Simple tuple
+
+```py
+(a, b, c) = (1, 2, 3)
+reveal_type(a)  # revealed: Literal[1]
+reveal_type(b)  # revealed: Literal[2]
+reveal_type(c)  # revealed: Literal[3]
+```
+
+### Simple list
+
+```py
+[a, b, c] = (1, 2, 3)
+reveal_type(a)  # revealed: Literal[1]
+reveal_type(b)  # revealed: Literal[2]
+reveal_type(c)  # revealed: Literal[3]
+```
+
+### Simple mixed
+
+```py
+[a, (b, c), d] = (1, (2, 3), 4)
+reveal_type(a)  # revealed: Literal[1]
+reveal_type(b)  # revealed: Literal[2]
+reveal_type(c)  # revealed: Literal[3]
+reveal_type(d)  # revealed: Literal[4]
+```
+
+### Multiple assignment
+
+```py
+a, b = c = 1, 2
+reveal_type(a)  # revealed: Literal[1]
+reveal_type(b)  # revealed: Literal[2]
+reveal_type(c)  # revealed: tuple[Literal[1], Literal[2]]
+```
+
+### Nested tuple with unpacking
+
+```py
+(a, (b, c), d) = (1, (2, 3), 4)
+reveal_type(a)  # revealed: Literal[1]
+reveal_type(b)  # revealed: Literal[2]
+reveal_type(c)  # revealed: Literal[3]
+reveal_type(d)  # revealed: Literal[4]
+```
+
+### Nested tuple without unpacking
+
+```py
+(a, b, c) = (1, (2, 3), 4)
+reveal_type(a)  # revealed: Literal[1]
+reveal_type(b)  # revealed: tuple[Literal[2], Literal[3]]
+reveal_type(c)  # revealed: Literal[4]
+```
+
+### Uneven unpacking (1)
+
+```py
+(a, b, c) = (1, 2)
+reveal_type(a)  # revealed: Literal[1]
+reveal_type(b)  # revealed: Literal[2]
+reveal_type(c)  # revealed: Unknown
+```
+
+### Uneven unpacking (2)
+
+```py
+(a, b) = (1, 2, 3)
+reveal_type(a)  # revealed: Literal[1]
+reveal_type(b)  # revealed: Literal[2]
+```
+
+### Starred expression (1)
+
+TODO: The error message here is because `infer_starred_expression` isn't complete
+
+```py
+[a, *b, c, d] = (1, 2)  # error: "Object of type `None` is not iterable"
+reveal_type(a)  # revealed: Literal[1]
+# TODO: Should be List[int]
+reveal_type(b)  # revealed: Unknown
+reveal_type(c)  # revealed: Unknown
+reveal_type(d)  # revealed: Unknown
+```
+
+### Starred expression (2)
+
+TODO: The error message here is because `infer_starred_expression` isn't complete
+
+```py
+[a, *b, c] = (1, 2, 3)  # error: "Object of type `None` is not iterable"
+reveal_type(a)  # revealed: Literal[1]
+# TODO: Should be List[int]
+reveal_type(b)  # revealed: Unknown
+reveal_type(c)  # revealed: Literal[3]
+```
+
+### Starred expression (3)
+
+TODO: The error message here is because `infer_starred_expression` isn't complete
+
+```py
+[a, *b, c, d] = (1, 2, 3, 4, 5, 6)  # error: "Object of type `None` is not iterable"
+reveal_type(a)  # revealed: Literal[1]
+# TODO: Should be List[int]
+reveal_type(b)  # revealed: Unknown
+reveal_type(c)  # revealed: Literal[5]
+reveal_type(d)  # revealed: Literal[6]
+```
+
+## String
+
+### Simple unpacking
+
+```py
+a, b = 'abc'
+reveal_type(a)  # revealed: LiteralString
+reveal_type(b)  # revealed: LiteralString
+```
+
+### Starred expression
+
+TODO: The error message here is because `infer_starred_expression` isn't complete
+
+```py
+a, *b = 'abc'  # error: "Object of type `None` is not iterable"
+reveal_type(a)  # revealed: LiteralString
+# TODO: Should be List[str]
+reveal_type(b)  # revealed: Unknown
+```

--- a/crates/red_knot_python_semantic/src/semantic_index.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index.rs
@@ -994,7 +994,7 @@ class C[T]:
         let ast::Expr::NumberLiteral(ast::ExprNumberLiteral {
             value: ast::Number::Int(num),
             ..
-        }) = &*assignment.assignment().value
+        }) = assignment.value()
         else {
             panic!("should be a number literal")
         };

--- a/crates/red_knot_python_semantic/src/semantic_index/builder.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/builder.rs
@@ -566,7 +566,7 @@ where
                 debug_assert!(self.current_assignment.is_none());
                 self.visit_expr(&node.value);
                 self.add_standalone_expression(&node.value);
-                for target in &node.targets {
+                for (target_index, target) in node.targets.iter().enumerate() {
                     let kind = match target {
                         ast::Expr::List(_) | ast::Expr::Tuple(_) => Some(AssignmentKind::Sequence),
                         ast::Expr::Name(_) => Some(AssignmentKind::Name),
@@ -574,8 +574,8 @@ where
                     };
                     if let Some(kind) = kind {
                         self.current_assignment = Some(CurrentAssignment::Assign {
-                            target,
-                            value: &node.value,
+                            assignment: node,
+                            target_index,
                             kind,
                         });
                     }
@@ -827,16 +827,16 @@ where
                 if is_definition {
                     match self.current_assignment {
                         Some(CurrentAssignment::Assign {
-                            target,
-                            value,
+                            assignment,
+                            target_index,
                             kind,
                         }) => {
                             self.add_definition(
                                 symbol,
                                 AssignmentDefinitionNodeRef {
-                                    target,
-                                    value,
-                                    variable: name_node,
+                                    assignment,
+                                    target_index,
+                                    name: name_node,
                                     kind,
                                 },
                             );
@@ -1063,8 +1063,8 @@ where
 #[derive(Copy, Clone, Debug)]
 enum CurrentAssignment<'a> {
     Assign {
-        target: &'a ast::Expr,
-        value: &'a ast::Expr,
+        assignment: &'a ast::StmtAssign,
+        target_index: usize,
         kind: AssignmentKind,
     },
     AnnAssign(&'a ast::StmtAnnAssign),

--- a/crates/red_knot_python_semantic/src/semantic_index/builder.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/builder.rs
@@ -580,8 +580,8 @@ where
                         });
                     }
                     self.visit_expr(target);
+                    self.current_assignment = None;
                 }
-                self.current_assignment = None;
             }
             ast::Stmt::AnnAssign(node) => {
                 debug_assert!(self.current_assignment.is_none());

--- a/crates/red_knot_python_semantic/src/semantic_index/builder.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/builder.rs
@@ -568,15 +568,17 @@ where
                 self.add_standalone_expression(&node.value);
                 for target in &node.targets {
                     let kind = match target {
-                        ast::Expr::List(_) | ast::Expr::Tuple(_) => AssignmentKind::Sequence,
-                        // TODO: Should we continue for an error recovery case like `1 = 2`?
-                        _ => AssignmentKind::Other,
+                        ast::Expr::List(_) | ast::Expr::Tuple(_) => Some(AssignmentKind::Sequence),
+                        ast::Expr::Name(_) => Some(AssignmentKind::Name),
+                        _ => None,
                     };
-                    self.current_assignment = Some(CurrentAssignment::Assign {
-                        target,
-                        value: &node.value,
-                        kind,
-                    });
+                    if let Some(kind) = kind {
+                        self.current_assignment = Some(CurrentAssignment::Assign {
+                            target,
+                            value: &node.value,
+                            kind,
+                        });
+                    }
                     self.visit_expr(target);
                 }
                 self.current_assignment = None;

--- a/crates/red_knot_python_semantic/src/semantic_index/builder.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/builder.rs
@@ -569,12 +569,8 @@ where
                 for target in &node.targets {
                     let kind = match target {
                         ast::Expr::List(_) | ast::Expr::Tuple(_) => AssignmentKind::Sequence,
-                        ast::Expr::Name(_)
-                        | ast::Expr::Starred(_)
-                        | ast::Expr::Attribute(_)
-                        | ast::Expr::Subscript(_) => AssignmentKind::Other,
-                        // TODO: is this a good default for an error recovery case like `1 = 2`?
-                        _ => continue,
+                        // TODO: Should we continue for an error recovery case like `1 = 2`?
+                        _ => AssignmentKind::Other,
                     };
                     self.current_assignment = Some(CurrentAssignment::Assign {
                         target,

--- a/crates/red_knot_python_semantic/src/semantic_index/definition.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/definition.rs
@@ -160,9 +160,9 @@ pub(crate) struct ImportFromDefinitionNodeRef<'a> {
 
 #[derive(Copy, Clone, Debug)]
 pub(crate) struct AssignmentDefinitionNodeRef<'a> {
-    pub(crate) target: &'a ast::Expr,
-    pub(crate) value: &'a ast::Expr,
-    pub(crate) variable: &'a ast::ExprName,
+    pub(crate) assignment: &'a ast::StmtAssign,
+    pub(crate) target_index: usize,
+    pub(crate) name: &'a ast::ExprName,
     pub(crate) kind: AssignmentKind,
 }
 
@@ -227,14 +227,14 @@ impl DefinitionNodeRef<'_> {
                 DefinitionKind::NamedExpression(AstNodeRef::new(parsed, named))
             }
             DefinitionNodeRef::Assignment(AssignmentDefinitionNodeRef {
-                value,
-                target,
-                variable,
+                assignment,
+                target_index,
+                name,
                 kind,
             }) => DefinitionKind::Assignment(AssignmentDefinitionKind {
-                value: AstNodeRef::new(parsed.clone(), value),
-                target: AstNodeRef::new(parsed.clone(), target),
-                variable: AstNodeRef::new(parsed, variable),
+                assignment: AstNodeRef::new(parsed.clone(), assignment),
+                target_index,
+                name: AstNodeRef::new(parsed, name),
                 kind,
             }),
             DefinitionNodeRef::AnnotatedAssignment(assign) => {
@@ -306,11 +306,11 @@ impl DefinitionNodeRef<'_> {
             Self::Class(node) => node.into(),
             Self::NamedExpression(node) => node.into(),
             Self::Assignment(AssignmentDefinitionNodeRef {
-                value: _,
-                target: _,
-                variable,
+                assignment: _,
+                target_index: _,
+                name,
                 kind: _,
-            }) => variable.into(),
+            }) => name.into(),
             Self::AnnotatedAssignment(node) => node.into(),
             Self::AugmentedAssignment(node) => node.into(),
             Self::For(ForStmtDefinitionNodeRef {
@@ -493,23 +493,23 @@ impl ImportFromDefinitionKind {
 
 #[derive(Clone, Debug)]
 pub struct AssignmentDefinitionKind {
-    target: AstNodeRef<ast::Expr>,
-    value: AstNodeRef<ast::Expr>,
-    variable: AstNodeRef<ast::ExprName>,
+    assignment: AstNodeRef<ast::StmtAssign>,
+    target_index: usize,
+    name: AstNodeRef<ast::ExprName>,
     kind: AssignmentKind,
 }
 
 impl AssignmentDefinitionKind {
     pub(crate) fn value(&self) -> &ast::Expr {
-        self.value.node()
+        &self.assignment.node().value
     }
 
     pub(crate) fn target(&self) -> &ast::Expr {
-        self.target.node()
+        &self.assignment.node().targets[self.target_index]
     }
 
-    pub(crate) fn variable(&self) -> &ast::ExprName {
-        self.variable.node()
+    pub(crate) fn name(&self) -> &ast::ExprName {
+        self.name.node()
     }
 
     pub(crate) fn kind(&self) -> AssignmentKind {

--- a/crates/red_knot_python_semantic/src/semantic_index/definition.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/definition.rs
@@ -521,7 +521,7 @@ impl AssignmentDefinitionKind {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum AssignmentKind {
     Sequence,
-    Other,
+    Name,
 }
 
 #[derive(Clone, Debug)]

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -292,13 +292,6 @@ impl<'db> Type<'db> {
         matches!(self, Type::Never)
     }
 
-    pub const fn as_tuple_type(&self) -> Option<&TupleType<'db>> {
-        match self {
-            Type::Tuple(tuple_type) => Some(tuple_type),
-            _ => None,
-        }
-    }
-
     pub const fn into_class_type(self) -> Option<ClassType<'db>> {
         match self {
             Type::Class(class_type) => Some(class_type),

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -1539,6 +1539,10 @@ impl<'db> TupleType<'db> {
     pub fn get(&self, db: &'db dyn Db, index: usize) -> Option<Type<'db>> {
         self.elements(db).get(index).copied()
     }
+
+    pub fn len(&self, db: &'db dyn Db) -> usize {
+        self.elements(db).len()
+    }
 }
 
 #[cfg(test)]

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -292,6 +292,13 @@ impl<'db> Type<'db> {
         matches!(self, Type::Never)
     }
 
+    pub const fn as_tuple_type(&self) -> Option<&TupleType<'db>> {
+        match self {
+            Type::Tuple(tuple_type) => Some(tuple_type),
+            _ => None,
+        }
+    }
+
     pub const fn into_class_type(self) -> Option<ClassType<'db>> {
         match self {
             Type::Class(class_type) => Some(class_type),
@@ -1510,6 +1517,12 @@ pub struct StringLiteralType<'db> {
     value: Box<str>,
 }
 
+impl<'db> StringLiteralType<'db> {
+    pub fn len(&self, db: &'db dyn Db) -> usize {
+        self.value(db).len()
+    }
+}
+
 #[salsa::interned]
 pub struct BytesLiteralType<'db> {
     #[return_ref]
@@ -1520,6 +1533,12 @@ pub struct BytesLiteralType<'db> {
 pub struct TupleType<'db> {
     #[return_ref]
     elements: Box<[Type<'db>]>,
+}
+
+impl<'db> TupleType<'db> {
+    pub fn get(&self, db: &'db dyn Db, index: usize) -> Option<Type<'db>> {
+        self.elements(db).get(index).copied()
+    }
 }
 
 #[cfg(test)]

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -1277,7 +1277,10 @@ impl<'db> TypeInferenceBuilder<'db> {
                     }
                     Type::StringLiteral(string_literal_ty) => {
                         // Deconstruct the string literal to delegate the inference back to the
-                        // tuple type for correct handling of starred expressions.
+                        // tuple type for correct handling of starred expressions. We could go
+                        // further and deconstruct to an array of `StringLiteral` with each
+                        // individual character, instead of just an array of `LiteralString`, but
+                        // there would be a cost and it's not clear that it's worth it.
                         let value_ty = Type::Tuple(TupleType::new(
                             builder.db,
                             vec![Type::LiteralString; string_literal_ty.len(builder.db)]

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -1150,13 +1150,18 @@ impl<'db> TypeInferenceBuilder<'db> {
         let ast::StmtAssign {
             range: _,
             targets,
-            value: _,
+            value,
         } = assignment;
 
         for target in targets {
             if let ast::Expr::Name(name) = target {
                 self.infer_definition(name);
             } else {
+                // TODO infer definitions in unpacking assignment. When we do, this duplication of
+                // the "get `Expression`, call `infer_expression_types` on it, `self.extend`" dance
+                // will be removed; it'll all happen in `infer_assignment_definition` instead.
+                let expression = self.index.expression(value.as_ref());
+                self.extend(infer_expression_types(self.db, expression));
                 self.infer_expression(target);
             }
         }

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -1271,8 +1271,13 @@ impl<'db> TypeInferenceBuilder<'db> {
                             Cow::Borrowed(tuple_ty.elements(builder.db).as_ref())
                         };
 
-                        for (element, element_ty) in elts.iter().zip(element_types.iter()) {
-                            if let Some(ty) = inner(builder, element, *element_ty, variable) {
+                        for (index, element) in elts.iter().enumerate() {
+                            if let Some(ty) = inner(
+                                builder,
+                                element,
+                                element_types.get(index).copied().unwrap_or(Type::Unknown),
+                                variable,
+                            ) {
                                 return Some(ty);
                             }
                         }

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -1191,9 +1191,9 @@ impl<'db> TypeInferenceBuilder<'db> {
 
         let value_ty = self.expression_ty(value);
 
-        let target_ty = match (value_ty, kind) {
-            (_, AssignmentKind::Sequence) => self.infer_sequence_unpacking(target, value_ty, name),
-            _ => value_ty,
+        let target_ty = match kind {
+            AssignmentKind::Sequence => self.infer_sequence_unpacking(target, value_ty, name),
+            AssignmentKind::Name => value_ty,
         };
 
         self.add_binding(name.into(), definition, target_ty);


### PR DESCRIPTION
## Summary

This PR adds support for unpacking tuple expression in an assignment statement where the target expression can be a tuple or a list (the allowed sequence targets).

The implementation introduces a new `infer_assignment_target` which can then be used for other targets like the ones in for loops as well. This delegates it to the `infer_definition`. The final implementation uses a recursive function that visits the target expression in source order and compares the variable node that corresponds to the definition. At the same time, it keeps track of where it is on the assignment value type.

The logic also accounts for the number of elements on both sides such that it matches even if there's a gap in between. For example, if there's a starred expression like `(a, *b, c) = (1, 2, 3)`, then the type of `a` will be `Literal[1]` and the type of `b` will be `Literal[2]`.

There are a couple of follow-ups that can be done:
* Use this logic for other target positions like `for` loop
* Add diagnostics for mis-match length between LHS and RHS

## Test Plan

Add various test cases using the new markdown test framework.
Validate that existing test cases pass.
