### PR TITLE
[red-knot] Fix type inference for `except*` definitions

### DIFF
--- a/crates/red_knot_python_semantic/src/semantic_index/builder.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/builder.rs
@@ -696,6 +696,51 @@ where
                     self.flow_merge(after_subject);
                 }
             }
+            ast::Stmt::Try(ast::StmtTry {
+                body,
+                handlers,
+                orelse,
+                finalbody,
+                is_star,
+                range: _,
+            }) => {
+                self.visit_body(body);
+
+                for except_handler in handlers {
+                    let ast::ExceptHandler::ExceptHandler(except_handler) = except_handler;
+                    let ast::ExceptHandlerExceptHandler {
+                        name: symbol_name,
+                        type_: handled_exceptions,
+                        body: handler_body,
+                        range: _,
+                    } = except_handler;
+
+                    if let Some(handled_exceptions) = handled_exceptions {
+                        self.visit_expr(handled_exceptions);
+                    }
+
+                    // If `handled_exceptions` above was `None`, it's something like `except as e:`,
+                    // which is invalid syntax. However, it's still pretty obvious here that the user
+                    // *wanted* `e` to be bound, so we should still create a definition here nonetheless.
+                    if let Some(symbol_name) = symbol_name {
+                        let symbol = self
+                            .add_or_update_symbol(symbol_name.id.clone(), SymbolFlags::IS_DEFINED);
+
+                        self.add_definition(symbol, {
+                            if *is_star {
+                                DefinitionNodeRef::ExceptStarHandler(except_handler)
+                            } else {
+                                DefinitionNodeRef::ExceptHandler(except_handler)
+                            }
+                        });
+                    }
+
+                    self.visit_body(handler_body);
+                }
+
+                self.visit_body(orelse);
+                self.visit_body(finalbody);
+            }
             _ => {
                 walk_stmt(self, stmt);
             }
@@ -957,30 +1002,6 @@ where
         }
 
         self.current_match_case.as_mut().unwrap().index += 1;
-    }
-
-    fn visit_except_handler(&mut self, except_handler: &'ast ast::ExceptHandler) {
-        let ast::ExceptHandler::ExceptHandler(except_handler) = except_handler;
-        let ast::ExceptHandlerExceptHandler {
-            name: symbol_name,
-            type_: handled_exceptions,
-            body,
-            range: _,
-        } = except_handler;
-
-        if let Some(handled_exceptions) = handled_exceptions {
-            self.visit_expr(handled_exceptions);
-        }
-
-        // If `handled_exceptions` above was `None`, it's something like `except as e:`,
-        // which is invalid syntax. However, it's still pretty obvious here that the user
-        // *wanted* `e` to be bound, so we should still create a definition here nonetheless.
-        if let Some(symbol_name) = symbol_name {
-            let symbol = self.add_or_update_symbol(symbol_name.id.clone(), SymbolFlags::IS_DEFINED);
-            self.add_definition(symbol, except_handler);
-        }
-
-        self.visit_body(body);
     }
 }
 

--- a/crates/red_knot_python_semantic/src/semantic_index/builder.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/builder.rs
@@ -27,7 +27,9 @@ use crate::semantic_index::SemanticIndex;
 use crate::Db;
 
 use super::constraint::{Constraint, PatternConstraint};
-use super::definition::{MatchPatternDefinitionNodeRef, WithItemDefinitionNodeRef};
+use super::definition::{
+    ExceptHandlerDefinitionNodeRef, MatchPatternDefinitionNodeRef, WithItemDefinitionNodeRef,
+};
 
 pub(super) struct SemanticIndexBuilder<'db> {
     // Builder state
@@ -726,13 +728,13 @@ where
                         let symbol = self
                             .add_or_update_symbol(symbol_name.id.clone(), SymbolFlags::IS_DEFINED);
 
-                        self.add_definition(symbol, {
-                            if *is_star {
-                                DefinitionNodeRef::ExceptStarHandler(except_handler)
-                            } else {
-                                DefinitionNodeRef::ExceptHandler(except_handler)
-                            }
-                        });
+                        self.add_definition(
+                            symbol,
+                            DefinitionNodeRef::ExceptHandler(ExceptHandlerDefinitionNodeRef {
+                                handler: except_handler,
+                                is_star: *is_star,
+                            }),
+                        );
                     }
 
                     self.visit_body(handler_body);

--- a/crates/red_knot_python_semantic/src/semantic_index/definition.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/definition.rs
@@ -51,6 +51,7 @@ pub(crate) enum DefinitionNodeRef<'a> {
     WithItem(WithItemDefinitionNodeRef<'a>),
     MatchPattern(MatchPatternDefinitionNodeRef<'a>),
     ExceptHandler(&'a ast::ExceptHandlerExceptHandler),
+    ExceptStarHandler(&'a ast::ExceptHandlerExceptHandler),
 }
 
 impl<'a> From<&'a ast::StmtFunctionDef> for DefinitionNodeRef<'a> {
@@ -128,12 +129,6 @@ impl<'a> From<ast::AnyParameterRef<'a>> for DefinitionNodeRef<'a> {
 impl<'a> From<MatchPatternDefinitionNodeRef<'a>> for DefinitionNodeRef<'a> {
     fn from(node: MatchPatternDefinitionNodeRef<'a>) -> Self {
         Self::MatchPattern(node)
-    }
-}
-
-impl<'a> From<&'a ast::ExceptHandlerExceptHandler> for DefinitionNodeRef<'a> {
-    fn from(node: &'a ast::ExceptHandlerExceptHandler) -> Self {
-        Self::ExceptHandler(node)
     }
 }
 
@@ -261,6 +256,9 @@ impl DefinitionNodeRef<'_> {
             DefinitionNodeRef::ExceptHandler(handler) => {
                 DefinitionKind::ExceptHandler(AstNodeRef::new(parsed, handler))
             }
+            DefinitionNodeRef::ExceptStarHandler(handler) => {
+                DefinitionKind::ExceptStarHandler(AstNodeRef::new(parsed, handler))
+            }
         }
     }
 
@@ -294,6 +292,7 @@ impl DefinitionNodeRef<'_> {
                 identifier.into()
             }
             Self::ExceptHandler(handler) => handler.into(),
+            Self::ExceptStarHandler(handler) => handler.into(),
         }
     }
 }
@@ -315,6 +314,7 @@ pub enum DefinitionKind {
     WithItem(WithItemDefinitionKind),
     MatchPattern(MatchPatternDefinitionKind),
     ExceptHandler(AstNodeRef<ast::ExceptHandlerExceptHandler>),
+    ExceptStarHandler(AstNodeRef<ast::ExceptHandlerExceptHandler>),
 }
 
 #[derive(Clone, Debug)]


### PR DESCRIPTION
Once again, async Python requires different inference rules to sync Python!

A new `DefinitionNodeRef::ExceptStarHandler` variant is introduced, so that we can differentiate between except-handler definitions in `StmtTry { is_star: true }` nodes and those in `StmtTry { is_star: false }` nodes. The logic for adding these definitions is also moved in `builder.rs` so that we can know whether the `try` block is catching exceptions or exception groups. (We'll need to move the logic there anyway when adding control flow for these definitions.)

Lots of TODOs here, but I _think_ inferring `Instance(BaseExceptionGroup)` is better than just inferring `Unknown` for these definitions.

The PR is stacked on top of #13319