### PR TITLE
Update installation.md: Add x-cmd method to install ruff

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -48,6 +48,11 @@ on the `pkgx` registry:
 $ pkgx install ruff
 ```
 
+For **x-cmd** users, Ruff is also available as [ruff](https://www.x-cmd.com/pkg/ruff) on the `x-cmd` registry:
+```console
+$ x env use ruff
+```
+
 For **Arch Linux** users, Ruff is also available as [`ruff`](https://archlinux.org/packages/extra/x86_64/ruff/)
 on the official repositories:
 


### PR DESCRIPTION
## Summary

Add x-cmd method to install ruff

- Hi, we have implemented a lightweight [package manager using shell and awk](https://www.x-cmd.com/pkg/). It helps you download ruff release packages from the internet and extract them into a unified directory for management, without requiring root permissions.

- **I mean, can the installation method provided by x-cmd be added to the ruff installation.md?**[The installation method for the x command](https://www.x-cmd.com/start/) and [ruff demo](https://www.x-cmd.com/pkg/ruff)
  ```sh
  x env use ruff
  ```


## Test Plan

Nothing.