### PR TITLE
[`pyupgrade`] Fix broken doc link and clarify that deprecated aliases were removed in Python 3.12 (`UP005`)

### DIFF
--- a/crates/ruff_linter/src/rules/pyupgrade/rules/deprecated_unittest_alias.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/deprecated_unittest_alias.rs
@@ -13,7 +13,7 @@ use crate::checkers::ast::Checker;
 ///
 /// ## Why is this bad?
 /// The `unittest` module has deprecated aliases for some of its methods.
-/// The aliases may be removed in future versions of Python. Instead,
+/// The deprecated aliases were removed in Python 3.12. Instead of aliases,
 /// use their non-deprecated counterparts.
 ///
 /// ## Example
@@ -37,7 +37,7 @@ use crate::checkers::ast::Checker;
 /// ```
 ///
 /// ## References
-/// - [Python documentation: Deprecated aliases](https://docs.python.org/3/library/unittest.html#deprecated-aliases)
+/// - [Python 3.11 documentation: Deprecated aliases](https://docs.python.org/3.11/library/unittest.html#deprecated-aliases)
 #[violation]
 pub struct DeprecatedUnittestAlias {
     alias: String,


### PR DESCRIPTION

## Summary

Deprecated `unittest` aliases [were removed in Python 3.12](https://docs.python.org/3.12/whatsnew/3.12.html#id3).
As they were removed, the deprecation notice was also removed from the official documentation, and now the link pointing to the latest Python 3 documentation is broken, so I replaced it with a link to Python 3.11 documentation,

## Test Plan

`cargo dev generate-docs`