### PR TITLE
[red-knot] add BitSet::is_empty and BitSet::union

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1936,6 +1936,7 @@ dependencies = [
  "smallvec",
  "static_assertions",
  "tempfile",
+ "test-case",
  "thiserror",
  "tracing",
  "walkdir",

--- a/crates/red_knot_python_semantic/Cargo.toml
+++ b/crates/red_knot_python_semantic/Cargo.toml
@@ -33,6 +33,7 @@ rustc-hash = { workspace = true }
 hashbrown = { workspace = true }
 smallvec = { workspace = true }
 static_assertions = { workspace = true }
+test-case = { workspace = true }
 
 [build-dependencies]
 path-slash = { workspace = true }

--- a/crates/red_knot_python_semantic/src/semantic_index/use_def/bitset.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/use_def/bitset.rs
@@ -107,9 +107,8 @@ impl<const B: usize> BitSet<B> {
             max_len = other_len;
             self.resize_blocks(max_len);
         }
-        let other_blocks = other.blocks();
-        for (i, my_block) in self.blocks_mut().iter_mut().enumerate() {
-            *my_block |= other_blocks.get(i).unwrap_or(&0);
+        for (my_block, other_block) in self.blocks_mut().iter_mut().zip(other.blocks()) {
+            *my_block |= other_block;
         }
     }
 

--- a/crates/red_knot_python_semantic/src/semantic_index/use_def/bitset.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/use_def/bitset.rs
@@ -32,17 +32,26 @@ impl<const B: usize> BitSet<B> {
         bitset
     }
 
+    #[allow(unused)]
+    pub(super) fn is_empty(&self) -> bool {
+        self.blocks().iter().all(|&b| b == 0)
+    }
+
     /// Convert from Inline to Heap, if needed, and resize the Heap vector, if needed.
     fn resize(&mut self, value: u32) {
         let num_blocks_needed = (value / 64) + 1;
+        self.resize_blocks(num_blocks_needed as usize);
+    }
+
+    fn resize_blocks(&mut self, num_blocks_needed: usize) {
         match self {
             Self::Inline(blocks) => {
                 let mut vec = blocks.to_vec();
-                vec.resize(num_blocks_needed as usize, 0);
+                vec.resize(num_blocks_needed, 0);
                 *self = Self::Heap(vec);
             }
             Self::Heap(vec) => {
-                vec.resize(num_blocks_needed as usize, 0);
+                vec.resize(num_blocks_needed, 0);
             }
         }
     }
@@ -86,6 +95,21 @@ impl<const B: usize> BitSet<B> {
         }
         for block in my_blocks.iter_mut().skip(min_len) {
             *block = 0;
+        }
+    }
+
+    /// Union in-place with another [`BitSet`].
+    #[allow(unused)]
+    pub(super) fn union(&mut self, other: &BitSet<B>) {
+        let mut max_len = self.blocks().len();
+        let other_len = other.blocks().len();
+        if other_len > max_len {
+            max_len = other_len;
+            self.resize_blocks(max_len);
+        }
+        let other_blocks = other.blocks();
+        for (i, my_block) in self.blocks_mut().iter_mut().enumerate() {
+            *my_block |= other_blocks.get(i).unwrap_or(&0);
         }
     }
 
@@ -219,10 +243,70 @@ mod tests {
     }
 
     #[test]
+    fn union() {
+        let mut b1 = BitSet::<1>::with(2);
+        let b2 = BitSet::<1>::with(4);
+
+        b1.union(&b2);
+        assert_bitset(&b1, &[2, 4]);
+    }
+
+    #[test]
+    fn union_mixed_1() {
+        let mut b1 = BitSet::<1>::with(4);
+        let mut b2 = BitSet::<1>::with(4);
+        b1.insert(89);
+        b2.insert(5);
+
+        b1.union(&b2);
+        assert_bitset(&b1, &[4, 5, 89]);
+    }
+
+    #[test]
+    fn union_mixed_2() {
+        let mut b1 = BitSet::<1>::with(4);
+        let mut b2 = BitSet::<1>::with(4);
+        b1.insert(23);
+        b2.insert(89);
+
+        b1.union(&b2);
+        assert_bitset(&b1, &[4, 23, 89]);
+    }
+
+    #[test]
+    fn union_heap() {
+        let mut b1 = BitSet::<1>::with(4);
+        let mut b2 = BitSet::<1>::with(4);
+        b1.insert(89);
+        b2.insert(90);
+
+        b1.union(&b2);
+        assert_bitset(&b1, &[4, 89, 90]);
+    }
+
+    #[test]
+    fn union_heap_2() {
+        let mut b1 = BitSet::<1>::with(89);
+        let mut b2 = BitSet::<1>::with(89);
+        b1.insert(91);
+        b2.insert(90);
+
+        b1.union(&b2);
+        assert_bitset(&b1, &[89, 90, 91]);
+    }
+
+    #[test]
     fn multiple_blocks() {
         let mut b = BitSet::<2>::with(120);
         b.insert(45);
         assert!(matches!(b, BitSet::Inline(_)));
         assert_bitset(&b, &[45, 120]);
+    }
+
+    #[test]
+    fn empty() {
+        let b = BitSet::<1>::default();
+
+        assert!(b.is_empty());
     }
 }

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -2,6 +2,7 @@ use infer::TypeInferenceBuilder;
 use ruff_db::files::File;
 use ruff_python_ast as ast;
 
+use crate::module_resolver::file_to_module;
 use crate::semantic_index::ast_ids::HasScopedAstId;
 use crate::semantic_index::definition::{Definition, DefinitionKind};
 use crate::semantic_index::symbol::{ScopeId, ScopedSymbolId};
@@ -296,6 +297,42 @@ impl<'db> Type<'db> {
         }
     }
 
+    /// Return true if this type is assignable to type `other`.
+    #[allow(unused)]
+    pub(crate) fn is_assignable_to(self, db: &'db dyn Db, other: Type<'db>) -> bool {
+        if self.is_equivalent_to(db, other) {
+            return true;
+        }
+        match (self, other) {
+            (Type::Unknown | Type::Any | Type::Never, _) => true,
+            (_, Type::Unknown | Type::Any) => true,
+            (Type::IntLiteral(_), Type::Instance(class)) if class.is_builtin_named(db, "int") => {
+                true
+            }
+            (Type::StringLiteral(_), Type::LiteralString) => true,
+            (Type::StringLiteral(_) | Type::LiteralString, Type::Instance(class))
+                if class.is_builtin_named(db, "str") =>
+            {
+                true
+            }
+            (Type::BytesLiteral(_), Type::Instance(class))
+                if class.is_builtin_named(db, "bytes") =>
+            {
+                true
+            }
+            // TODO
+            _ => false,
+        }
+    }
+
+    /// Return true if this type is equivalent to type `other`.
+    #[allow(unused)]
+    pub(crate) fn is_equivalent_to(self, _db: &'db dyn Db, other: Type<'db>) -> bool {
+        // TODO equivalent but not identical structural types, differently-ordered unions and
+        // intersections, other cases?
+        self == other
+    }
+
     /// Resolve a member access of a type.
     ///
     /// For example, if `foo` is `Type::Instance(<Bar>)`,
@@ -588,6 +625,16 @@ pub struct ClassType<'db> {
 }
 
 impl<'db> ClassType<'db> {
+    /// Return true if this class is the builtin type with given name.
+    #[allow(unused)]
+    pub(crate) fn is_builtin_named(self, db: &'db dyn Db, name: &str) -> bool {
+        name == self.name(db).as_str()
+            && file_to_module(db, self.body_scope(db).file(db))
+                // Builtin module names are special-cased in the resolver, so there can't be a
+                // module named builtins other than the actual builtins.
+                .is_some_and(|module| module.name().as_str() == "builtins")
+    }
+
     /// Return an iterator over the types of this class's bases.
     ///
     /// # Panics:
@@ -701,4 +748,105 @@ pub struct BytesLiteralType<'db> {
 pub struct TupleType<'db> {
     #[return_ref]
     elements: Box<[Type<'db>]>,
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::needless_pass_by_value)]
+
+    use super::{builtins_symbol_ty, BytesLiteralType, StringLiteralType, Type, UnionType};
+    use crate::db::tests::TestDb;
+    use crate::program::{Program, SearchPathSettings};
+    use crate::python_version::PythonVersion;
+    use crate::ProgramSettings;
+    use ruff_db::system::{DbWithTestSystem, SystemPathBuf};
+    use test_case::test_case;
+
+    fn setup_db() -> TestDb {
+        let db = TestDb::new();
+
+        let src_root = SystemPathBuf::from("/src");
+        db.memory_file_system()
+            .create_directory_all(&src_root)
+            .unwrap();
+
+        Program::from_settings(
+            &db,
+            &ProgramSettings {
+                target_version: PythonVersion::default(),
+                search_paths: SearchPathSettings::new(src_root),
+            },
+        )
+        .expect("Valid search path settings");
+
+        db
+    }
+
+    /// A test representation of a type that can be transformed unambiguously into a real Type,
+    /// given a db.
+    #[derive(Debug)]
+    enum Ty {
+        Never,
+        Unknown,
+        Any,
+        IntLiteral(i64),
+        StringLiteral(&'static str),
+        LiteralString,
+        BytesLiteral(&'static str),
+        BuiltinInstance(&'static str),
+        Union(Box<[Ty]>),
+    }
+
+    impl Ty {
+        fn to_type<'db>(&self, db: &'db TestDb) -> Type<'db> {
+            match self {
+                Ty::Never => Type::Never,
+                Ty::Unknown => Type::Unknown,
+                Ty::Any => Type::Any,
+                Ty::IntLiteral(n) => Type::IntLiteral(*n),
+                Ty::StringLiteral(s) => {
+                    Type::StringLiteral(StringLiteralType::new(db, (*s).into()))
+                }
+                Ty::LiteralString => Type::LiteralString,
+                Ty::BytesLiteral(s) => {
+                    Type::BytesLiteral(BytesLiteralType::new(db, s.as_bytes().into()))
+                }
+                Ty::BuiltinInstance(s) => builtins_symbol_ty(db, s).to_instance(db),
+                Ty::Union(tys) => UnionType::from_elements(db, tys.iter().map(|ty| ty.to_type(db))),
+            }
+        }
+    }
+
+    #[test_case(Ty::Unknown, Ty::IntLiteral(1))]
+    #[test_case(Ty::Any, Ty::IntLiteral(1))]
+    #[test_case(Ty::Never, Ty::IntLiteral(1))]
+    #[test_case(Ty::IntLiteral(1), Ty::Unknown)]
+    #[test_case(Ty::IntLiteral(1), Ty::Any)]
+    #[test_case(Ty::IntLiteral(1), Ty::BuiltinInstance("int"))]
+    #[test_case(Ty::StringLiteral("foo"), Ty::BuiltinInstance("str"))]
+    #[test_case(Ty::StringLiteral("foo"), Ty::LiteralString)]
+    #[test_case(Ty::LiteralString, Ty::BuiltinInstance("str"))]
+    #[test_case(Ty::BytesLiteral("foo"), Ty::BuiltinInstance("bytes"))]
+    fn is_assignable_to(from: Ty, to: Ty) {
+        let db = setup_db();
+        assert!(from.to_type(&db).is_assignable_to(&db, to.to_type(&db)));
+    }
+
+    #[test_case(Ty::IntLiteral(1), Ty::BuiltinInstance("str"))]
+    #[test_case(Ty::BuiltinInstance("int"), Ty::BuiltinInstance("str"))]
+    #[test_case(Ty::BuiltinInstance("int"), Ty::IntLiteral(1))]
+    fn is_not_assignable_to(from: Ty, to: Ty) {
+        let db = setup_db();
+        assert!(!from.to_type(&db).is_assignable_to(&db, to.to_type(&db)));
+    }
+
+    #[test_case(
+        Ty::Union(Box::new([Ty::IntLiteral(1), Ty::IntLiteral(2)])),
+        Ty::Union(Box::new([Ty::IntLiteral(1), Ty::IntLiteral(2)]))
+    )]
+    fn is_equivalent_to(from: Ty, to: Ty) {
+        let db = setup_db();
+
+        assert!(from.to_type(&db).is_equivalent_to(&db, to.to_type(&db)));
+    }
 }

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -297,10 +297,9 @@ impl<'db> Type<'db> {
         }
     }
 
-    /// Return true if this type is assignable to type `target`.
+    /// Return true if this type is [assignable to] type `target`.
     ///
-    /// Definition of assignability in the typing spec:
-    /// <https://typing.readthedocs.io/en/latest/spec/concepts.html#the-assignable-to-or-consistent-subtyping-relation>
+    /// [assignable to]: https://typing.readthedocs.io/en/latest/spec/concepts.html#the-assignable-to-or-consistent-subtyping-relation
     #[allow(unused)]
     pub(crate) fn is_assignable_to(self, db: &'db dyn Db, target: Type<'db>) -> bool {
         if self.is_equivalent_to(db, target) {


### PR DESCRIPTION
Add `::is_empty` and `::union` methods to the `BitSet` implementation.

Allowing unused for now, until these methods become used later with the declared-types implementation.
