### PR TITLE
[red-knot] use declared types in inference/checking

### DIFF
--- a/crates/red_knot_python_semantic/src/lib.rs
+++ b/crates/red_knot_python_semantic/src/lib.rs
@@ -23,4 +23,3 @@ mod stdlib;
 pub mod types;
 
 type FxOrderSet<V> = ordermap::set::OrderSet<V, BuildHasherDefault<FxHasher>>;
-type FxOrderMap<K, V> = ordermap::map::OrderMap<K, V, BuildHasherDefault<FxHasher>>;

--- a/crates/red_knot_python_semantic/src/semantic_index.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index.rs
@@ -27,9 +27,7 @@ pub mod expression;
 pub mod symbol;
 mod use_def;
 
-pub(crate) use self::use_def::{
-    BindingWithConstraints, BindingWithConstraintsIterator, DeclarationsIterator,
-};
+pub(crate) use self::use_def::{BindingWithConstraints, BindingWithConstraintsIterator};
 
 type SymbolMap = hashbrown::HashMap<ScopedSymbolId, (), ()>;
 

--- a/crates/red_knot_python_semantic/src/semantic_index.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index.rs
@@ -27,7 +27,9 @@ pub mod expression;
 pub mod symbol;
 mod use_def;
 
-pub(crate) use self::use_def::{BindingWithConstraints, BindingWithConstraintsIterator};
+pub(crate) use self::use_def::{
+    BindingWithConstraints, BindingWithConstraintsIterator, DeclarationsIterator,
+};
 
 type SymbolMap = hashbrown::HashMap<ScopedSymbolId, (), ()>;
 

--- a/crates/red_knot_python_semantic/src/semantic_index/definition.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/definition.rs
@@ -34,17 +34,14 @@ impl<'db> Definition<'db> {
         self.file_scope(db).to_scope_id(db, self.file(db))
     }
 
-    #[allow(unused)]
     pub(crate) fn category(self, db: &'db dyn Db) -> DefinitionCategory {
         self.kind(db).category()
     }
 
-    #[allow(unused)]
     pub(crate) fn is_declaration(self, db: &'db dyn Db) -> bool {
         self.kind(db).category().is_declaration()
     }
 
-    #[allow(unused)]
     pub(crate) fn is_binding(self, db: &'db dyn Db) -> bool {
         self.kind(db).category().is_binding()
     }

--- a/crates/red_knot_python_semantic/src/semantic_index/use_def.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/use_def.rs
@@ -308,7 +308,7 @@ impl<'db> UseDefMap<'db> {
         if let SymbolDefinitions::Declarations(declarations) =
             &self.definitions_by_definition[&binding]
         {
-            self.declarations_iterator(declarations, declarations.may_be_undeclared())
+            self.declarations_iterator(declarations)
         } else {
             unreachable!("Binding has non-Declarations in definitions_by_definition");
         }
@@ -319,7 +319,7 @@ impl<'db> UseDefMap<'db> {
         symbol: ScopedSymbolId,
     ) -> DeclarationsIterator<'_, 'db> {
         let declarations = self.public_symbols[symbol].declarations();
-        self.declarations_iterator(declarations, declarations.may_be_undeclared())
+        self.declarations_iterator(declarations)
     }
 
     pub(crate) fn has_public_declarations(&self, symbol: ScopedSymbolId) -> bool {
@@ -340,12 +340,11 @@ impl<'db> UseDefMap<'db> {
     fn declarations_iterator<'a>(
         &'a self,
         declarations: &'a SymbolDeclarations,
-        may_be_undeclared: bool,
     ) -> DeclarationsIterator<'a, 'db> {
         DeclarationsIterator {
             all_definitions: &self.all_definitions,
             inner: declarations.iter(),
-            may_be_undeclared,
+            may_be_undeclared: declarations.may_be_undeclared(),
         }
     }
 }

--- a/crates/red_knot_python_semantic/src/semantic_index/use_def.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/use_def.rs
@@ -289,7 +289,6 @@ impl<'db> UseDefMap<'db> {
         self.public_symbols[symbol].may_be_unbound()
     }
 
-    #[allow(unused)]
     pub(crate) fn bindings_at_declaration(
         &self,
         declaration: Definition<'db>,
@@ -302,7 +301,6 @@ impl<'db> UseDefMap<'db> {
         }
     }
 
-    #[allow(unused)]
     pub(crate) fn declarations_at_binding(
         &self,
         binding: Definition<'db>,
@@ -316,7 +314,6 @@ impl<'db> UseDefMap<'db> {
         }
     }
 
-    #[allow(unused)]
     pub(crate) fn public_declarations(
         &self,
         symbol: ScopedSymbolId,
@@ -324,7 +321,6 @@ impl<'db> UseDefMap<'db> {
         self.declarations_iterator(self.public_symbols[symbol].declarations())
     }
 
-    #[allow(unused)]
     pub(crate) fn has_public_declarations(&self, symbol: ScopedSymbolId) -> bool {
         !self.public_symbols[symbol].declarations().is_empty()
     }

--- a/crates/red_knot_python_semantic/src/semantic_index/use_def/bitset.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/use_def/bitset.rs
@@ -32,7 +32,6 @@ impl<const B: usize> BitSet<B> {
         bitset
     }
 
-    #[allow(unused)]
     pub(super) fn is_empty(&self) -> bool {
         self.blocks().iter().all(|&b| b == 0)
     }
@@ -99,7 +98,6 @@ impl<const B: usize> BitSet<B> {
     }
 
     /// Union in-place with another [`BitSet`].
-    #[allow(unused)]
     pub(super) fn union(&mut self, other: &BitSet<B>) {
         let mut max_len = self.blocks().len();
         let other_len = other.blocks().len();

--- a/crates/red_knot_python_semantic/src/semantic_index/use_def/symbol_state.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/use_def/symbol_state.rs
@@ -105,6 +105,11 @@ impl SymbolDeclarations {
         self.may_be_undeclared = false;
     }
 
+    /// Add undeclared as a possibility for this symbol.
+    fn set_may_be_undeclared(&mut self) {
+        self.may_be_undeclared = true;
+    }
+
     /// Return an iterator over live declarations for this symbol.
     pub(super) fn iter(&self) -> DeclarationIdIterator {
         DeclarationIdIterator {
@@ -209,6 +214,11 @@ impl SymbolState {
     /// Add given constraint to all live bindings.
     pub(super) fn record_constraint(&mut self, constraint_id: ScopedConstraintId) {
         self.bindings.record_constraint(constraint_id);
+    }
+
+    /// Add undeclared as a possibility for this symbol.
+    pub(super) fn set_may_be_undeclared(&mut self) {
+        self.declarations.set_may_be_undeclared();
     }
 
     /// Record a newly-encountered declaration of this symbol.
@@ -327,11 +337,6 @@ impl SymbolState {
     pub(super) fn may_be_unbound(&self) -> bool {
         self.bindings.may_be_unbound()
     }
-
-    /// Could the symbol be undeclared?
-    pub(super) fn may_be_undeclared(&self) -> bool {
-        self.declarations.may_be_undeclared()
-    }
 }
 
 /// The default state of a symbol, if we've seen no definitions of it, is undefined (that is,
@@ -433,7 +438,7 @@ mod tests {
         }
 
         pub(crate) fn assert_declarations(&self, may_be_undeclared: bool, expected: &[u32]) {
-            assert_eq!(self.may_be_undeclared(), may_be_undeclared);
+            assert_eq!(self.declarations.may_be_undeclared(), may_be_undeclared);
             let actual = self
                 .declarations()
                 .iter()
@@ -568,5 +573,14 @@ mod tests {
         sym.merge(sym2);
 
         sym.assert_declarations(true, &[1]);
+    }
+
+    #[test]
+    fn set_may_be_undeclared() {
+        let mut sym = SymbolState::undefined();
+        sym.record_declaration(ScopedDefinitionId::from_u32(0));
+        sym.set_may_be_undeclared();
+
+        sym.assert_declarations(true, &[0]);
     }
 }

--- a/crates/red_knot_python_semantic/src/semantic_index/use_def/symbol_state.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/use_def/symbol_state.rs
@@ -106,14 +106,12 @@ impl SymbolDeclarations {
     }
 
     /// Return an iterator over live declarations for this symbol.
-    #[allow(unused)]
     pub(super) fn iter(&self) -> DeclarationIdIterator {
         DeclarationIdIterator {
             inner: self.live_declarations.iter(),
         }
     }
 
-    #[allow(unused)]
     pub(super) fn is_empty(&self) -> bool {
         self.live_declarations.is_empty()
     }
@@ -393,7 +391,6 @@ impl Iterator for ConstraintIdIterator<'_> {
 
 impl std::iter::FusedIterator for ConstraintIdIterator<'_> {}
 
-#[allow(unused)]
 #[derive(Debug)]
 pub(super) struct DeclarationIdIterator<'a> {
     inner: DeclarationsIterator<'a>,

--- a/crates/red_knot_python_semantic/src/semantic_index/use_def/symbol_state.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/use_def/symbol_state.rs
@@ -415,44 +415,46 @@ impl std::iter::FusedIterator for DeclarationIdIterator<'_> {}
 mod tests {
     use super::{ScopedConstraintId, ScopedDefinitionId, SymbolState};
 
-    impl SymbolState {
-        pub(crate) fn assert_bindings(&self, may_be_unbound: bool, expected: &[&str]) {
-            assert_eq!(self.may_be_unbound(), may_be_unbound);
-            let actual = self
-                .bindings()
-                .iter()
-                .map(|def_id_with_constraints| {
-                    format!(
-                        "{}<{}>",
-                        def_id_with_constraints.definition.as_u32(),
-                        def_id_with_constraints
-                            .constraint_ids
-                            .map(ScopedConstraintId::as_u32)
-                            .map(|idx| idx.to_string())
-                            .collect::<Vec<_>>()
-                            .join(", ")
-                    )
-                })
-                .collect::<Vec<_>>();
-            assert_eq!(actual, expected);
-        }
+    fn assert_bindings(symbol: &SymbolState, may_be_unbound: bool, expected: &[&str]) {
+        assert_eq!(symbol.may_be_unbound(), may_be_unbound);
+        let actual = symbol
+            .bindings()
+            .iter()
+            .map(|def_id_with_constraints| {
+                format!(
+                    "{}<{}>",
+                    def_id_with_constraints.definition.as_u32(),
+                    def_id_with_constraints
+                        .constraint_ids
+                        .map(ScopedConstraintId::as_u32)
+                        .map(|idx| idx.to_string())
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                )
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(actual, expected);
+    }
 
-        pub(crate) fn assert_declarations(&self, may_be_undeclared: bool, expected: &[u32]) {
-            assert_eq!(self.declarations.may_be_undeclared(), may_be_undeclared);
-            let actual = self
-                .declarations()
-                .iter()
-                .map(ScopedDefinitionId::as_u32)
-                .collect::<Vec<_>>();
-            assert_eq!(actual, expected);
-        }
+    pub(crate) fn assert_declarations(
+        symbol: &SymbolState,
+        may_be_undeclared: bool,
+        expected: &[u32],
+    ) {
+        assert_eq!(symbol.declarations.may_be_undeclared(), may_be_undeclared);
+        let actual = symbol
+            .declarations()
+            .iter()
+            .map(ScopedDefinitionId::as_u32)
+            .collect::<Vec<_>>();
+        assert_eq!(actual, expected);
     }
 
     #[test]
     fn unbound() {
         let sym = SymbolState::undefined();
 
-        sym.assert_bindings(true, &[]);
+        assert_bindings(&sym, true, &[]);
     }
 
     #[test]
@@ -460,7 +462,7 @@ mod tests {
         let mut sym = SymbolState::undefined();
         sym.record_binding(ScopedDefinitionId::from_u32(0));
 
-        sym.assert_bindings(false, &["0<>"]);
+        assert_bindings(&sym, false, &["0<>"]);
     }
 
     #[test]
@@ -469,7 +471,7 @@ mod tests {
         sym.record_binding(ScopedDefinitionId::from_u32(0));
         sym.set_may_be_unbound();
 
-        sym.assert_bindings(true, &["0<>"]);
+        assert_bindings(&sym, true, &["0<>"]);
     }
 
     #[test]
@@ -478,7 +480,7 @@ mod tests {
         sym.record_binding(ScopedDefinitionId::from_u32(0));
         sym.record_constraint(ScopedConstraintId::from_u32(0));
 
-        sym.assert_bindings(false, &["0<0>"]);
+        assert_bindings(&sym, false, &["0<0>"]);
     }
 
     #[test]
@@ -494,7 +496,7 @@ mod tests {
 
         sym0a.merge(sym0b);
         let mut sym0 = sym0a;
-        sym0.assert_bindings(false, &["0<0>"]);
+        assert_bindings(&sym0, false, &["0<0>"]);
 
         // merging the same definition with differing constraints drops all constraints
         let mut sym1a = SymbolState::undefined();
@@ -507,7 +509,7 @@ mod tests {
 
         sym1a.merge(sym1b);
         let sym1 = sym1a;
-        sym1.assert_bindings(false, &["1<>"]);
+        assert_bindings(&sym1, false, &["1<>"]);
 
         // merging a constrained definition with unbound keeps both
         let mut sym2a = SymbolState::undefined();
@@ -518,19 +520,19 @@ mod tests {
 
         sym2a.merge(sym2b);
         let sym2 = sym2a;
-        sym2.assert_bindings(true, &["2<3>"]);
+        assert_bindings(&sym2, true, &["2<3>"]);
 
         // merging different definitions keeps them each with their existing constraints
         sym0.merge(sym2);
         let sym = sym0;
-        sym.assert_bindings(true, &["0<0>", "2<3>"]);
+        assert_bindings(&sym, true, &["0<0>", "2<3>"]);
     }
 
     #[test]
     fn no_declaration() {
         let sym = SymbolState::undefined();
 
-        sym.assert_declarations(true, &[]);
+        assert_declarations(&sym, true, &[]);
     }
 
     #[test]
@@ -538,7 +540,7 @@ mod tests {
         let mut sym = SymbolState::undefined();
         sym.record_declaration(ScopedDefinitionId::from_u32(1));
 
-        sym.assert_declarations(false, &[1]);
+        assert_declarations(&sym, false, &[1]);
     }
 
     #[test]
@@ -547,7 +549,7 @@ mod tests {
         sym.record_declaration(ScopedDefinitionId::from_u32(1));
         sym.record_declaration(ScopedDefinitionId::from_u32(2));
 
-        sym.assert_declarations(false, &[2]);
+        assert_declarations(&sym, false, &[2]);
     }
 
     #[test]
@@ -560,7 +562,7 @@ mod tests {
 
         sym.merge(sym2);
 
-        sym.assert_declarations(false, &[1, 2]);
+        assert_declarations(&sym, false, &[1, 2]);
     }
 
     #[test]
@@ -572,7 +574,7 @@ mod tests {
 
         sym.merge(sym2);
 
-        sym.assert_declarations(true, &[1]);
+        assert_declarations(&sym, true, &[1]);
     }
 
     #[test]
@@ -581,6 +583,6 @@ mod tests {
         sym.record_declaration(ScopedDefinitionId::from_u32(0));
         sym.set_may_be_undeclared();
 
-        sym.assert_declarations(true, &[0]);
+        assert_declarations(&sym, true, &[0]);
     }
 }

--- a/crates/red_knot_python_semantic/src/semantic_model.rs
+++ b/crates/red_knot_python_semantic/src/semantic_model.rs
@@ -8,7 +8,7 @@ use crate::module_name::ModuleName;
 use crate::module_resolver::{resolve_module, Module};
 use crate::semantic_index::ast_ids::HasScopedAstId;
 use crate::semantic_index::semantic_index;
-use crate::types::{definition_ty, global_symbol_ty, infer_scope_types, Type};
+use crate::types::{binding_ty, global_symbol_ty, infer_scope_types, Type};
 use crate::Db;
 
 pub struct SemanticModel<'db> {
@@ -147,24 +147,24 @@ impl HasTy for ast::Expr {
     }
 }
 
-macro_rules! impl_definition_has_ty {
+macro_rules! impl_binding_has_ty {
     ($ty: ty) => {
         impl HasTy for $ty {
             #[inline]
             fn ty<'db>(&self, model: &SemanticModel<'db>) -> Type<'db> {
                 let index = semantic_index(model.db, model.file);
-                let definition = index.definition(self);
-                definition_ty(model.db, definition)
+                let binding = index.definition(self);
+                binding_ty(model.db, binding)
             }
         }
     };
 }
 
-impl_definition_has_ty!(ast::StmtFunctionDef);
-impl_definition_has_ty!(ast::StmtClassDef);
-impl_definition_has_ty!(ast::Alias);
-impl_definition_has_ty!(ast::Parameter);
-impl_definition_has_ty!(ast::ParameterWithDefault);
+impl_binding_has_ty!(ast::StmtFunctionDef);
+impl_binding_has_ty!(ast::StmtClassDef);
+impl_binding_has_ty!(ast::Alias);
+impl_binding_has_ty!(ast::Parameter);
+impl_binding_has_ty!(ast::ParameterWithDefault);
 
 #[cfg(test)]
 mod tests {

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -41,11 +41,7 @@ pub fn check_types(db: &dyn Db, file: File) -> TypeCheckDiagnostics {
 }
 
 /// Infer the public type of a symbol (its type as seen from outside its scope).
-pub(crate) fn symbol_ty_by_id<'db>(
-    db: &'db dyn Db,
-    scope: ScopeId<'db>,
-    symbol: ScopedSymbolId,
-) -> Type<'db> {
+fn symbol_ty_by_id<'db>(db: &'db dyn Db, scope: ScopeId<'db>, symbol: ScopedSymbolId) -> Type<'db> {
     let _span = tracing::trace_span!("symbol_ty_by_id", ?symbol).entered();
 
     let use_def = use_def_map(db, scope);
@@ -67,7 +63,7 @@ pub(crate) fn symbol_ty_by_id<'db>(
 }
 
 /// Shorthand for `symbol_ty` that takes a symbol name instead of an ID.
-pub(crate) fn symbol_ty<'db>(db: &'db dyn Db, scope: ScopeId<'db>, name: &str) -> Type<'db> {
+fn symbol_ty<'db>(db: &'db dyn Db, scope: ScopeId<'db>, name: &str) -> Type<'db> {
     let table = symbol_table(db, scope);
     table
         .symbol_id_by_name(name)
@@ -87,7 +83,7 @@ pub(crate) fn binding_ty<'db>(db: &'db dyn Db, definition: Definition<'db>) -> T
 }
 
 /// Infer the type of a declaration.
-pub(crate) fn declaration_ty<'db>(db: &'db dyn Db, definition: Definition<'db>) -> Type<'db> {
+fn declaration_ty<'db>(db: &'db dyn Db, definition: Definition<'db>) -> Type<'db> {
     let inference = infer_definition_types(db, definition);
     inference.declaration_ty(definition)
 }
@@ -96,7 +92,7 @@ pub(crate) fn declaration_ty<'db>(db: &'db dyn Db, definition: Definition<'db>) 
 ///
 /// ## Panics
 /// If the given expression is not a sub-expression of the given [`Definition`].
-pub(crate) fn definition_expression_ty<'db>(
+fn definition_expression_ty<'db>(
     db: &'db dyn Db,
     definition: Definition<'db>,
     expression: &ast::Expr,
@@ -125,7 +121,7 @@ pub(crate) fn definition_expression_ty<'db>(
 /// Will panic if called with zero bindings and no `unbound_ty`. This is a logic error, as any
 /// symbol with zero visible bindings clearly may be unbound, and the caller should provide an
 /// `unbound_ty`.
-pub(crate) fn bindings_ty<'db>(
+fn bindings_ty<'db>(
     db: &'db dyn Db,
     bindings_with_constraints: BindingWithConstraintsIterator<'_, 'db>,
     unbound_ty: Option<Type<'db>>,
@@ -174,7 +170,7 @@ pub(crate) fn bindings_ty<'db>(
 ///
 /// # Panics
 /// Will panic if there are no declarations and no possibility of undeclared. This is a logic
-/// error, as any symbol with zero live declarations clearly may (must!) be undeclared.
+/// error, as any symbol with zero live declarations clearly must be undeclared.
 fn declarations_ty<'db>(
     db: &'db dyn Db,
     declarations: DeclarationsIterator<'_, 'db>,

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -16,6 +16,7 @@ use crate::{Db, FxOrderSet};
 
 pub(crate) use self::builder::{IntersectionBuilder, UnionBuilder};
 pub(crate) use self::diagnostic::TypeCheckDiagnostics;
+pub(crate) use self::display::TypeArrayDisplay;
 pub(crate) use self::infer::{
     infer_deferred_types, infer_definition_types, infer_expression_types, infer_scope_types,
 };
@@ -206,25 +207,10 @@ fn declarations_ty<'db>(
     DeclaredType {
         declared_ty,
         conflicting: if conflicting.is_empty() {
-            TypeList(conflicting.into())
+            None
         } else {
-            TypeList([first].into_iter().chain(conflicting).collect())
+            Some([first].into_iter().chain(conflicting).collect())
         },
-    }
-}
-
-#[derive(Debug)]
-struct DeclaredType<'db> {
-    declared_ty: Type<'db>,
-    conflicting: TypeList<'db>,
-}
-
-#[derive(Debug)]
-struct TypeList<'db>(Box<[Type<'db>]>);
-
-impl<'db> TypeList<'db> {
-    fn is_empty(&self) -> bool {
-        self.0.is_empty()
     }
 }
 
@@ -626,6 +612,12 @@ impl<'db> From<&Type<'db>> for Type<'db> {
     }
 }
 
+#[derive(Debug)]
+struct DeclaredType<'db> {
+    declared_ty: Type<'db>,
+    conflicting: Option<Box<[Type<'db>]>>,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum IterationOutcome<'db> {
     Iterable { element_ty: Type<'db> },
@@ -657,7 +649,7 @@ pub struct FunctionType<'db> {
     definition: Definition<'db>,
 
     /// types of all decorators on this function
-    decorators: Vec<Type<'db>>,
+    decorators: Box<[Type<'db>]>,
 }
 
 impl<'db> FunctionType<'db> {

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -164,14 +164,17 @@ fn bindings_ty<'db>(
     }
 }
 
+/// The result of looking up a declared type from declarations; see [`declarations_ty`].
 type DeclaredTypeResult<'db> = Result<Type<'db>, (Type<'db>, Box<[Type<'db>]>)>;
 
 /// Build a declared type from a [`DeclarationsIterator`].
 ///
-/// Will return a union if there is more than one declaration, or at least one plus the possibility
-/// of undeclared.
+/// If there is only one declaration, or all declarations declare the same type, returns
+/// `Ok(declared_type)`. If there are conflicting declarations, returns
+/// `Err((union_of_declared_types, conflicting_declared_types))`.
 ///
-/// If undeclared is a possibility, `Unknown` type will be part of the return type.
+/// If undeclared is a possibility, `Unknown` type will be part of the return type (and may
+/// conflict with other declarations.)
 ///
 /// # Panics
 /// Will panic if there are no declarations and no possibility of undeclared. This is a logic

--- a/crates/red_knot_python_semantic/src/types/display.rs
+++ b/crates/red_knot_python_semantic/src/types/display.rs
@@ -10,7 +10,7 @@ use crate::Db;
 use rustc_hash::FxHashMap;
 
 impl<'db> Type<'db> {
-    pub(crate) fn display(&self, db: &'db dyn Db) -> DisplayType {
+    pub fn display(&self, db: &'db dyn Db) -> DisplayType {
         DisplayType { ty: self, db }
     }
     fn representation(self, db: &'db dyn Db) -> DisplayRepresentation<'db> {
@@ -19,7 +19,7 @@ impl<'db> Type<'db> {
 }
 
 #[derive(Copy, Clone)]
-pub(crate) struct DisplayType<'db> {
+pub struct DisplayType<'db> {
     ty: &'db Type<'db>,
     db: &'db dyn Db,
 }
@@ -100,18 +100,18 @@ impl Display for DisplayRepresentation<'_> {
     }
 }
 
-impl<'a, 'db> UnionType<'db> {
-    fn display(&'a self, db: &'db dyn Db) -> DisplayUnionType<'a, 'db> {
+impl<'db> UnionType<'db> {
+    fn display(&'db self, db: &'db dyn Db) -> DisplayUnionType<'db> {
         DisplayUnionType { db, ty: self }
     }
 }
 
-struct DisplayUnionType<'a, 'db> {
-    ty: &'a UnionType<'db>,
+struct DisplayUnionType<'db> {
+    ty: &'db UnionType<'db>,
     db: &'db dyn Db,
 }
 
-impl Display for DisplayUnionType<'_, '_> {
+impl Display for DisplayUnionType<'_> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         let elements = self.ty.elements(self.db);
 
@@ -147,7 +147,7 @@ impl Display for DisplayUnionType<'_, '_> {
     }
 }
 
-impl fmt::Debug for DisplayUnionType<'_, '_> {
+impl fmt::Debug for DisplayUnionType<'_> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         Display::fmt(self, f)
     }
@@ -197,18 +197,18 @@ impl TryFrom<Type<'_>> for LiteralTypeKind {
     }
 }
 
-impl<'a, 'db> IntersectionType<'db> {
-    fn display(&'a self, db: &'db dyn Db) -> DisplayIntersectionType<'a, 'db> {
+impl<'db> IntersectionType<'db> {
+    fn display(&'db self, db: &'db dyn Db) -> DisplayIntersectionType<'db> {
         DisplayIntersectionType { db, ty: self }
     }
 }
 
-struct DisplayIntersectionType<'a, 'db> {
-    ty: &'a IntersectionType<'db>,
+struct DisplayIntersectionType<'db> {
+    ty: &'db IntersectionType<'db>,
     db: &'db dyn Db,
 }
 
-impl Display for DisplayIntersectionType<'_, '_> {
+impl Display for DisplayIntersectionType<'_> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         let tys = self
             .ty
@@ -233,7 +233,7 @@ impl Display for DisplayIntersectionType<'_, '_> {
     }
 }
 
-impl fmt::Debug for DisplayIntersectionType<'_, '_> {
+impl fmt::Debug for DisplayIntersectionType<'_> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         Display::fmt(self, f)
     }

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -502,13 +502,6 @@ impl<'db> TypeInferenceBuilder<'db> {
         }
     }
 
-    /*
-    if !declared_ty.is_equivalent_to(self.db, other_declared_ty) {
-        check_compat = false;
-        break;
-    }
-    */
-
     fn add_binding(&mut self, node: AnyNodeRef, binding: Definition<'db>, ty: Type<'db>) {
         debug_assert!(binding.is_binding(self.db));
         let use_def = self.index.use_def_map(binding.file_scope(self.db));

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -52,7 +52,7 @@ use crate::types::diagnostic::{TypeCheckDiagnostic, TypeCheckDiagnostics};
 use crate::types::{
     bindings_ty, builtins_symbol_ty, declarations_ty, global_symbol_ty, symbol_ty,
     BytesLiteralType, ClassType, DeclaredType, FunctionType, StringLiteralType, TupleType, Type,
-    UnionType,
+    TypeArrayDisplay, UnionType,
 };
 use crate::Db;
 
@@ -511,7 +511,7 @@ impl<'db> TypeInferenceBuilder<'db> {
             declared_ty,
             conflicting,
         } = declarations_ty(self.db, declarations);
-        if !conflicting.is_empty() {
+        if let Some(conflicting) = conflicting {
             // TODO point out the conflicting declarations in the diagnostic?
             let symbol_table = self.index.symbol_table(binding.file_scope(self.db));
             let symbol_name = symbol_table.symbol(binding.symbol(self.db)).name();
@@ -5393,7 +5393,7 @@ mod tests {
         assert_file_diagnostics(
             &db,
             "/src/a.py",
-            &[r"Conflicting declared types for 'x': 'str', 'int'."],
+            &[r"Conflicting declared types for 'x': str, int."],
         );
     }
 
@@ -5414,7 +5414,7 @@ mod tests {
         assert_file_diagnostics(
             &db,
             "/src/a.py",
-            &[r"Conflicting declared types for 'x': 'Unknown', 'int'."],
+            &[r"Conflicting declared types for 'x': Unknown, int."],
         );
     }
 
@@ -5438,7 +5438,7 @@ mod tests {
             &db,
             "/src/a.py",
             &[
-                r"Conflicting declared types for 'x': 'str', 'int'.",
+                r"Conflicting declared types for 'x': str, int.",
                 r#"Object of type 'Literal[b"foo"]' is not assignable to 'str | int'."#,
             ],
         );
@@ -5461,7 +5461,7 @@ mod tests {
         assert_file_diagnostics(
             &db,
             "/src/a.py",
-            &[r"Conflicting declared types for 'x': 'Unknown', 'int'."],
+            &[r"Conflicting declared types for 'x': Unknown, int."],
         );
     }
 

--- a/crates/ruff_benchmark/benches/red_knot.rs
+++ b/crates/ruff_benchmark/benches/red_knot.rs
@@ -23,7 +23,6 @@ const TOMLLIB_312_URL: &str = "https://raw.githubusercontent.com/python/cpython/
 
 // The failed import from 'collections.abc' is due to lack of support for 'import *'.
 static EXPECTED_DIAGNOSTICS: &[&str] = &[
-    "/src/tomllib/_parser.py:5:24: Module '__future__' has no member 'annotations'",
     "/src/tomllib/_parser.py:7:29: Module 'collections.abc' has no member 'Iterable'",
     "Line 69 is too long (89 characters)",
     "Use double quotes for strings",

--- a/crates/ruff_db/src/display.rs
+++ b/crates/ruff_db/src/display.rs
@@ -1,0 +1,52 @@
+use std::fmt::{self, Display, Formatter};
+
+pub trait FormatterJoinExtension<'b> {
+    fn join<'a>(&'a mut self, separator: &'static str) -> Join<'a, 'b>;
+}
+
+impl<'b> FormatterJoinExtension<'b> for Formatter<'b> {
+    fn join<'a>(&'a mut self, separator: &'static str) -> Join<'a, 'b> {
+        Join {
+            fmt: self,
+            separator,
+            result: fmt::Result::Ok(()),
+            seen_first: false,
+        }
+    }
+}
+
+pub struct Join<'a, 'b> {
+    fmt: &'a mut Formatter<'b>,
+    separator: &'static str,
+    result: fmt::Result,
+    seen_first: bool,
+}
+
+impl<'a, 'b> Join<'a, 'b> {
+    pub fn entry(&mut self, item: &dyn Display) -> &mut Self {
+        if self.seen_first {
+            self.result = self
+                .result
+                .and_then(|()| self.fmt.write_str(self.separator));
+        } else {
+            self.seen_first = true;
+        }
+        self.result = self.result.and_then(|()| item.fmt(self.fmt));
+        self
+    }
+
+    pub fn entries<I, F>(&mut self, items: I) -> &mut Self
+    where
+        I: IntoIterator<Item = F>,
+        F: Display,
+    {
+        for item in items {
+            self.entry(&item);
+        }
+        self
+    }
+
+    pub fn finish(&mut self) -> fmt::Result {
+        self.result
+    }
+}

--- a/crates/ruff_db/src/lib.rs
+++ b/crates/ruff_db/src/lib.rs
@@ -6,6 +6,7 @@ use crate::files::Files;
 use crate::system::System;
 use crate::vendored::VendoredFileSystem;
 
+pub mod display;
 pub mod file_revision;
 pub mod files;
 pub mod parsed;


### PR DESCRIPTION
Use declared types in inference and checking. This means several things:

* Imports prefer declarations over inference, when declarations are available.
* When we encounter a binding, we check that the bound value's inferred type is assignable to the live declarations of the bound symbol, if any.
* When we encounter a declaration, we check that the declared type is assignable from the inferred type of the symbol from previous bindings, if any.
* When we encounter a binding+declaration, we check that the inferred type of the bound value is assignable to the declared type.
