### PR TITLE
Add diagnostics panel and navigation features to playground

### DIFF
--- a/playground/.eslintrc
+++ b/playground/.eslintrc
@@ -14,7 +14,7 @@
   "rules": {
     // Disable some recommended rules that we don't want to enforce.
     "@typescript-eslint/no-explicit-any": "off",
-    "@typescript-eslint/no-empty-function": "off"
+    "eqeqeq": ["error","always", { "null":  "never"}]
   },
   "settings": {
     "react": {

--- a/playground/src/Editor/Diagnostics.tsx
+++ b/playground/src/Editor/Diagnostics.tsx
@@ -1,0 +1,92 @@
+import { Diagnostic } from "../pkg";
+import classNames from "classnames";
+import { Theme } from "./theme";
+import { useMemo } from "react";
+
+interface Props {
+  diagnostics: Diagnostic[];
+  theme: Theme;
+  onGoTo(line: number, column: number): void;
+}
+
+export default function Diagnostics({
+  diagnostics: unsorted,
+  theme,
+  onGoTo,
+}: Props) {
+  const diagnostics = useMemo(() => {
+    const sorted = [...unsorted];
+    sorted.sort((a, b) => {
+      if (a.location.row == b.location.row) {
+        return a.location.column - b.location.column;
+      }
+
+      return a.location.row - b.location.row;
+    });
+
+    return sorted;
+  }, [unsorted]);
+
+  return (
+    <div
+      className={classNames(
+        "flex flex-grow flex-col overflow-hidden",
+        theme === "dark" ? "text-white" : null,
+      )}
+    >
+      <div
+        className={classNames(
+          "border-b border-gray-200 px-2 py-1",
+          theme === "dark" ? "border-rock" : null,
+        )}
+      >
+        Diagnostics ({diagnostics.length})
+      </div>
+
+      <div className="flex flex-grow p-2 overflow-hidden">
+        <Items diagnostics={diagnostics} onGoTo={onGoTo} />
+      </div>
+    </div>
+  );
+}
+
+function Items({
+  diagnostics,
+  onGoTo,
+}: {
+  diagnostics: Array<Diagnostic>;
+  onGoTo(line: number, column: number): void;
+}) {
+  if (diagnostics.length === 0) {
+    return (
+      <div className={"flex flex-auto flex-col justify-center  items-center"}>
+        Everything is looking good!
+      </div>
+    );
+  }
+
+  return (
+    <ul className="space-y-0.5 flex-grow overflow-y-scroll">
+      {diagnostics.map((diagnostic) => {
+        return (
+          <li
+            key={`${diagnostic.location.row}:${diagnostic.location.column}-${diagnostic.code}`}
+          >
+            <button
+              onClick={() =>
+                onGoTo(diagnostic.location.row, diagnostic.location.column)
+              }
+              className="w-full text-start"
+            >
+              {diagnostic.message}{" "}
+              <span className="text-gray-500">
+                {diagnostic.code != null && `(${diagnostic.code})`} [Ln{" "}
+                {diagnostic.location.row}, Col {diagnostic.location.column}]
+              </span>
+            </button>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}

--- a/playground/src/Editor/Diagnostics.tsx
+++ b/playground/src/Editor/Diagnostics.tsx
@@ -17,7 +17,7 @@ export default function Diagnostics({
   const diagnostics = useMemo(() => {
     const sorted = [...unsorted];
     sorted.sort((a, b) => {
-      if (a.location.row == b.location.row) {
+      if (a.location.row === b.location.row) {
         return a.location.column - b.location.column;
       }
 

--- a/playground/src/Editor/Editor.tsx
+++ b/playground/src/Editor/Editor.tsx
@@ -1,9 +1,15 @@
-import { useDeferredValue, useMemo, useState } from "react";
+import {
+  useCallback,
+  useDeferredValue,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { Panel, PanelGroup } from "react-resizable-panels";
 import { Diagnostic, Workspace } from "../pkg";
 import { ErrorMessage } from "./ErrorMessage";
 import PrimarySideBar from "./PrimarySideBar";
-import { HorizontalResizeHandle } from "./ResizeHandle";
+import { HorizontalResizeHandle, VerticalResizeHandle } from "./ResizeHandle";
 import SecondaryPanel, {
   SecondaryPanelResult,
   SecondaryTool,
@@ -12,6 +18,9 @@ import SecondarySideBar from "./SecondarySideBar";
 import SettingsEditor from "./SettingsEditor";
 import SourceEditor from "./SourceEditor";
 import { Theme } from "./theme";
+import Diagnostics from "./Diagnostics";
+import { editor } from "monaco-editor";
+import IStandaloneCodeEditor = editor.IStandaloneCodeEditor;
 
 type Tab = "Source" | "Settings";
 
@@ -40,6 +49,7 @@ export default function Editor({
   onSourceChanged,
   onSettingsChanged,
 }: Props) {
+  const editorRef = useRef<IStandaloneCodeEditor | null>(null);
   const [tab, setTab] = useState<Tab>("Source");
   const [secondaryTool, setSecondaryTool] = useState<SecondaryTool | null>(
     () => {
@@ -74,6 +84,57 @@ export default function Editor({
 
     setSecondaryTool(tool);
   };
+
+  const handleGoTo = useCallback((line: number, column: number) => {
+    const editor = editorRef.current;
+
+    if (editor == null) {
+      return;
+    }
+
+    const position = { lineNumber: line, column };
+    editor.revealPosition(position);
+    editor.setPosition(position);
+  }, []);
+
+  const handleSourceEditorMount = useCallback(
+    (editor: IStandaloneCodeEditor) => {
+      editorRef.current = editor;
+    },
+    [],
+  );
+
+  const handleSelectByteRange = useCallback(
+    (startByteOffset: number, endByteOffset: number) => {
+      const model = editorRef.current?.getModel();
+
+      if (model == null || editorRef.current == null) {
+        return;
+      }
+
+      const startCharacterOffset = byteOffsetToCharOffset(
+        source.pythonSource,
+        startByteOffset,
+      );
+      const endCharacterOffset = byteOffsetToCharOffset(
+        source.pythonSource,
+        endByteOffset,
+      );
+
+      const start = model.getPositionAt(startCharacterOffset);
+      const end = model.getPositionAt(endCharacterOffset);
+
+      const range = {
+        startLineNumber: start.lineNumber,
+        startColumn: start.column,
+        endLineNumber: end.lineNumber,
+        endColumn: end.column,
+      };
+      editorRef.current?.revealRange(range);
+      editorRef.current?.setSelection(range);
+    },
+    [source.pythonSource],
+  );
 
   const deferredSource = useDeferredValue(source);
 
@@ -149,20 +210,43 @@ export default function Editor({
     <>
       <PanelGroup direction="horizontal" autoSaveId="main">
         <PrimarySideBar onSelectTool={(tool) => setTab(tool)} selected={tab} />
-        <Panel id="main" order={0} className="my-2" minSize={10}>
-          <SourceEditor
-            visible={tab === "Source"}
-            source={source.pythonSource}
-            theme={theme}
-            diagnostics={checkResult.diagnostics}
-            onChange={onSourceChanged}
-          />
-          <SettingsEditor
-            visible={tab === "Settings"}
-            source={source.settingsSource}
-            theme={theme}
-            onChange={onSettingsChanged}
-          />
+
+        <Panel id="main" order={0} minSize={10}>
+          <PanelGroup id="main" direction="vertical">
+            <Panel minSize={10} className="my-2" order={0}>
+              <SourceEditor
+                visible={tab === "Source"}
+                source={source.pythonSource}
+                theme={theme}
+                diagnostics={checkResult.diagnostics}
+                onChange={onSourceChanged}
+                onMount={handleSourceEditorMount}
+              />
+              <SettingsEditor
+                visible={tab === "Settings"}
+                source={source.settingsSource}
+                theme={theme}
+                onChange={onSettingsChanged}
+              />
+            </Panel>
+            {tab === "Source" && (
+              <>
+                <VerticalResizeHandle />
+                <Panel
+                  id="diagnostics"
+                  minSize={3}
+                  order={1}
+                  className="my-2 flex flex-grow"
+                >
+                  <Diagnostics
+                    diagnostics={checkResult.diagnostics}
+                    onGoTo={handleGoTo}
+                    theme={theme}
+                  />
+                </Panel>
+              </>
+            )}
+          </PanelGroup>
         </Panel>
         {secondaryTool != null && (
           <>
@@ -177,6 +261,7 @@ export default function Editor({
                 theme={theme}
                 tool={secondaryTool}
                 result={checkResult.secondary}
+                onSelectSourceByteRange={handleSelectByteRange}
               />
             </Panel>
           </>
@@ -209,4 +294,18 @@ function parseSecondaryTool(tool: string): SecondaryTool | null {
   }
 
   return null;
+}
+
+function byteOffsetToCharOffset(content: string, byteOffset: number): number {
+  // Create a Uint8Array from the UTF-8 string
+  const encoder = new TextEncoder();
+  const utf8Bytes = encoder.encode(content);
+
+  // Slice the byte array up to the byteOffset
+  const slicedBytes = utf8Bytes.slice(0, byteOffset);
+
+  // Decode the sliced bytes to get a substring
+  const decoder = new TextDecoder("utf-8");
+  const decodedString = decoder.decode(slicedBytes);
+  return decodedString.length;
 }

--- a/playground/src/Editor/PrimarySideBar.tsx
+++ b/playground/src/Editor/PrimarySideBar.tsx
@@ -18,7 +18,7 @@ export default function PrimarySideBar({
         title="Source"
         position={"left"}
         onClick={() => onSelectTool("Source")}
-        selected={selected == "Source"}
+        selected={selected === "Source"}
       >
         <FileIcon />
       </SideBarEntry>
@@ -27,7 +27,7 @@ export default function PrimarySideBar({
         title="Settings"
         position={"left"}
         onClick={() => onSelectTool("Settings")}
-        selected={selected == "Settings"}
+        selected={selected === "Settings"}
       >
         <SettingsIcon />
       </SideBarEntry>

--- a/playground/src/Editor/SettingsEditor.tsx
+++ b/playground/src/Editor/SettingsEditor.tsx
@@ -125,7 +125,7 @@ function stripToolRuff(settings: object) {
   const { tool, ...nonToolSettings } = settings as any;
 
   // Flatten out `tool.ruff.x` to just `x`
-  if (typeof tool == "object" && !Array.isArray(tool)) {
+  if (typeof tool === "object" && !Array.isArray(tool)) {
     if (tool.ruff != null) {
       return { ...nonToolSettings, ...tool.ruff };
     }

--- a/playground/src/Editor/SettingsEditor.tsx
+++ b/playground/src/Editor/SettingsEditor.tsx
@@ -70,7 +70,7 @@ export default function SettingsEditor({
         await navigator.clipboard.writeText(tomlSettings);
       },
     });
-    editor.onDidPaste((event) => {
+    const didPaste = editor.onDidPaste((event) => {
       const model = editor.getModel();
 
       if (model == null) {
@@ -97,6 +97,8 @@ export default function SettingsEditor({
         }
       }
     });
+
+    return () => didPaste.dispose();
   }, []);
 
   return (

--- a/playground/src/Editor/SourceEditor.tsx
+++ b/playground/src/Editor/SourceEditor.tsx
@@ -2,8 +2,6 @@
  * Editor for the Python source code.
  */
 
-// Array<{ offset: { start, end }, secondaryRange: Range }>
-
 import MonacoEditor, { Monaco, OnMount } from "@monaco-editor/react";
 import {
   editor,
@@ -107,7 +105,7 @@ export default function SourceEditor({
         fontSize: 14,
         roundedSelection: false,
         scrollBeyondLastLine: false,
-        contextmenu: false,
+        contextmenu: true,
       }}
       language={"python"}
       wrapperProps={visible ? {} : { style: { display: "none" } }}

--- a/playground/src/Editor/SourceEditor.tsx
+++ b/playground/src/Editor/SourceEditor.tsx
@@ -2,6 +2,8 @@
  * Editor for the Python source code.
  */
 
+// Array<{ offset: { start, end }, secondaryRange: Range }>
+
 import MonacoEditor, { Monaco, OnMount } from "@monaco-editor/react";
 import {
   editor,
@@ -15,6 +17,7 @@ import { useCallback, useEffect, useRef } from "react";
 import { Diagnostic } from "../pkg";
 import { Theme } from "./theme";
 import CodeActionProvider = languages.CodeActionProvider;
+import IStandaloneCodeEditor = editor.IStandaloneCodeEditor;
 
 type MonacoEditorState = {
   monaco: Monaco;
@@ -28,12 +31,14 @@ export default function SourceEditor({
   theme,
   diagnostics,
   onChange,
+  onMount,
 }: {
   visible: boolean;
   source: string;
   diagnostics: Diagnostic[];
   theme: Theme;
-  onChange: (pythonSource: string) => void;
+  onChange(pythonSource: string): void;
+  onMount(editor: IStandaloneCodeEditor): void;
 }) {
   const monacoRef = useRef<MonacoEditorState | null>(null);
 
@@ -70,7 +75,7 @@ export default function SourceEditor({
   );
 
   const handleMount: OnMount = useCallback(
-    (_editor, instance) => {
+    (editor, instance) => {
       const ruffActionsProvider = new RuffCodeActionProvider(diagnostics);
       const disposeCodeActionProvider =
         instance.languages.registerCodeActionProvider(
@@ -85,9 +90,11 @@ export default function SourceEditor({
         codeActionProvider: ruffActionsProvider,
         disposeCodeActionProvider,
       };
+
+      onMount(editor);
     },
 
-    [diagnostics],
+    [diagnostics, onMount],
   );
 
   return (


### PR DESCRIPTION
## Summary

This PR makes a few UX improvements:

1. Add a diagnostic panel. Syntax errors can sometimes be difficult to spot. A dedicated diagnostics panel makes reviewing all diagnostics in a file easier.
2. Add a `range` to `code` navigation. Clicking the range in the tokens or AST panel reveals the relevant source code.
3. Add a "reveal node" option that reveals the enclosing node or token

The range identification could be better. It uses a Regex to find the `x..y` ranges
without excluding occurrences in strings. I think that's fine. A range in a string
would be clickable, but it doesn't crash the playground. It either navigates to a bogus 
position or just does nothing.

## Test Plan


https://github.com/user-attachments/assets/4f16c0f9-02ed-4807-96f4-9afa07b113df

