### PR TITLE
Fix build of `ruff_benchmark` on NixOS

### DIFF
--- a/crates/ruff_benchmark/Cargo.toml
+++ b/crates/ruff_benchmark/Cargo.toml
@@ -66,4 +66,4 @@ codspeed = ["codspeed-criterion-compat"]
 mimalloc = { workspace = true }
 
 [target.'cfg(all(not(target_os = "windows"), not(target_os = "openbsd"), any(target_arch = "x86_64", target_arch = "aarch64", target_arch = "powerpc64")))'.dev-dependencies]
-tikv-jemallocator = { workspace = true, features = ["unprefixed_malloc_on_supported_platforms"] }
+tikv-jemallocator = { workspace = true }

--- a/crates/ruff_benchmark/benches/linter.rs
+++ b/crates/ruff_benchmark/benches/linter.rs
@@ -42,9 +42,9 @@ static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
     )
 ))]
 #[allow(non_upper_case_globals)]
-#[export_name = "malloc_conf"]
+#[export_name = "_rjem_malloc_conf"]
 #[allow(unsafe_code)]
-pub static malloc_conf: &[u8] = b"dirty_decay_ms:-1,muzzy_decay_ms:-1\0";
+pub static _rjem_malloc_conf: &[u8] = b"dirty_decay_ms:-1,muzzy_decay_ms:-1\0";
 
 fn create_test_cases() -> Result<Vec<TestCase>, TestFileDownloadError> {
     Ok(vec![


### PR DESCRIPTION
## Summary


See https://github.com/astral-sh/ruff/pull/13299#issuecomment-2351185007

This PR fixes the `ruff_benchmark` build on NixOS by not relying on the `unprefixed_malloc_on_supported_platforms` feature and instead export the conf as `_rjem_malloc_conf`


