### PR TITLE
DOCS: navigate back to rule overview linter

### DIFF
--- a/crates/ruff_dev/src/generate_docs.rs
+++ b/crates/ruff_dev/src/generate_docs.rs
@@ -6,6 +6,7 @@ use std::fs;
 use std::path::PathBuf;
 
 use anyhow::Result;
+use itertools::Itertools;
 use regex::{Captures, Regex};
 use strum::IntoEnumIterator;
 
@@ -33,7 +34,26 @@ pub(crate) fn main(args: &Args) -> Result<()> {
 
             let (linter, _) = Linter::parse_code(&rule.noqa_code().to_string()).unwrap();
             if linter.url().is_some() {
-                output.push_str(&format!("Derived from the **{}** linter.", linter.name()));
+                let common_prefix: String = match linter.common_prefix() {
+                    "" => linter
+                        .upstream_categories()
+                        .unwrap()
+                        .iter()
+                        .map(|c| c.prefix)
+                        .join("-"),
+                    prefix => prefix.to_string(),
+                };
+                let anchor = format!(
+                    "{}-{}",
+                    linter.name().to_lowercase(),
+                    common_prefix.to_lowercase()
+                );
+
+                output.push_str(&format!(
+                    "Derived from the **[{}](../rules.md#{})** linter.",
+                    linter.name(),
+                    anchor
+                ));
                 output.push('\n');
                 output.push('\n');
             }


### PR DESCRIPTION
Implementation for one of the suggestions in https://github.com/astral-sh/ruff/issues/13367

## Summary

Link back to the rule table section for a linter from the rule-specific pages.

## Test Plan

Tested locally with `mkdocs serve`:

<img src="https://github.com/user-attachments/assets/555f58ae-c364-4502-8568-35d57aba1bc4">

(`pycodestyle` is now a clickable link) 