### PR TITLE
[red-knot] support for typing.reveal_type

### DIFF
--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -745,7 +745,7 @@ impl<'db> CallOutcome<'db> {
             } => {
                 let mut not_callable = vec![];
                 let mut union_builder = UnionBuilder::new(db);
-                for outcome in outcomes {
+                for outcome in &**outcomes {
                     union_builder =
                         union_builder.add(if let Self::NotCallable { not_callable_ty } = outcome {
                             not_callable.push(*not_callable_ty);

--- a/crates/red_knot_python_semantic/src/types/display.rs
+++ b/crates/red_knot_python_semantic/src/types/display.rs
@@ -36,6 +36,7 @@ impl Display for DisplayType<'_> {
                 | Type::BytesLiteral(_)
                 | Type::Class(_)
                 | Type::Function(_)
+                | Type::RevealTypeFunction(_)
         ) {
             write!(f, "Literal[{representation}]",)
         } else {
@@ -72,7 +73,9 @@ impl Display for DisplayRepresentation<'_> {
             // TODO functions and classes should display using a fully qualified name
             Type::Class(class) => f.write_str(class.name(self.db)),
             Type::Instance(class) => f.write_str(class.name(self.db)),
-            Type::Function(function) => f.write_str(function.name(self.db)),
+            Type::Function(function) | Type::RevealTypeFunction(function) => {
+                f.write_str(function.name(self.db))
+            }
             Type::Union(union) => union.display(self.db).fmt(f),
             Type::Intersection(intersection) => intersection.display(self.db).fmt(f),
             Type::IntLiteral(n) => n.fmt(f),
@@ -191,7 +194,7 @@ impl TryFrom<Type<'_>> for LiteralTypeKind {
     fn try_from(value: Type<'_>) -> Result<Self, Self::Error> {
         match value {
             Type::Class(_) => Ok(Self::Class),
-            Type::Function(_) => Ok(Self::Function),
+            Type::Function(_) | Type::RevealTypeFunction(_) => Ok(Self::Function),
             Type::IntLiteral(_) => Ok(Self::IntLiteral),
             Type::StringLiteral(_) => Ok(Self::StringLiteral),
             Type::BytesLiteral(_) => Ok(Self::BytesLiteral),

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -2409,13 +2409,6 @@ impl<'db> TypeInferenceBuilder<'db> {
         rule: &str,
         message: std::fmt::Arguments,
     ) {
-        self.add_diagnostic_string(node, rule, message.to_string());
-    }
-
-    /// Adds a new diagnostic with a string message.
-    ///
-    /// The diagnostic does not get added if the rule isn't enabled for this file.
-    pub(super) fn add_diagnostic_string(&mut self, node: AnyNodeRef, rule: &str, message: String) {
         if !self.db.is_file_open(self.file) {
             return;
         }
@@ -2429,7 +2422,7 @@ impl<'db> TypeInferenceBuilder<'db> {
         self.types.diagnostics.push(TypeCheckDiagnostic {
             file: self.file,
             rule: rule.to_string(),
-            message,
+            message: message.to_string(),
             range: node.range(),
         });
     }

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -704,12 +704,12 @@ impl<'db> TypeInferenceBuilder<'db> {
             }
         }
 
-        let function_ty = Type::Function(FunctionType::new(
-            self.db,
-            name.id.clone(),
-            definition,
-            decorator_tys,
-        ));
+        let function_type = FunctionType::new(self.db, name.id.clone(), definition, decorator_tys);
+        let function_ty = if function_type.is_stdlib_symbol(self.db, "typing", "reveal_type") {
+            Type::RevealTypeFunction(function_type)
+        } else {
+            Type::Function(function_type)
+        };
 
         self.add_declaration_with_binding(function.into(), definition, function_ty, function_ty);
     }

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -2747,6 +2747,25 @@ mod tests {
     }
 
     #[test]
+    fn reveal_type() -> anyhow::Result<()> {
+        let mut db = setup_db();
+
+        db.write_dedented(
+            "/src/a.py",
+            "
+            from typing import reveal_type
+
+            x = 1
+            reveal_type(x)
+            ",
+        )?;
+
+        assert_file_diagnostics(&db, "/src/a.py", &["Revealed type of 'x' is 'Literal[1]'."]);
+
+        Ok(())
+    }
+
+    #[test]
     fn follow_import_to_class() -> anyhow::Result<()> {
         let mut db = setup_db();
 


### PR DESCRIPTION
Add support for the `typing.reveal_type` function, emitting a diagnostic revealing the type of its single argument. This is a necessary piece for the planned testing framework.

This puts the cart slightly in front of the horse, in that we don't yet have proper support for validating call signatures / argument types. But it's easy to do just enough to make `reveal_type` work.

This PR includes support for calling union types (this is necessary because we don't yet support `sys.version_info` checks, so `typing.reveal_type` itself is a union type), plus some nice consolidated error messages for calls to unions where some elements are not callable. This is mostly to demonstrate the flexibility in diagnostics that we get from the `CallOutcome` enum.