### PR TITLE
Fix/#13070 defer annotations when future is active

### DIFF
--- a/crates/red_knot_python_semantic/src/semantic_index.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index.rs
@@ -115,6 +115,9 @@ pub(crate) struct SemanticIndex<'db> {
     /// Note: We should not depend on this map when analysing other files or
     /// changing a file invalidates all dependents.
     ast_ids: IndexVec<FileScopeId, AstIds>,
+
+    /// Flags about the global scope (code usage impacting inference)
+    has_future_annotations: bool,
 }
 
 impl<'db> SemanticIndex<'db> {
@@ -214,6 +217,12 @@ impl<'db> SemanticIndex<'db> {
     /// returns the scope in which that definition is defined in.
     pub(crate) fn node_scope(&self, node: NodeWithScopeRef) -> FileScopeId {
         self.scopes_by_node[&node.node_key()]
+    }
+
+    /// Checks if there is an import of `__future__.annotations` in the global scope, which affects
+    /// the logic for type inference.
+    pub(super) fn has_future_annotations(&self) -> bool {
+        self.has_future_annotations
     }
 }
 

--- a/crates/red_knot_python_semantic/src/semantic_index/builder.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/builder.rs
@@ -554,11 +554,8 @@ where
                     // imports here, we assume the user's intent was to apply the `__future__`
                     // import, so we still check using it (and will also emit a diagnostic about a
                     // miss-placed `__future__` import.)
-                    self.has_future_annotations |= alias.name.id.as_str() == "annotations"
-                        && node
-                            .module
-                            .as_ref()
-                            .is_some_and(|module| module.id().as_str() == "__future__");
+                    self.has_future_annotations |= alias.name.id == "annotations"
+                        && node.module.as_deref() == Some("__future__");
 
                     let symbol = self.add_symbol(symbol_name.clone());
 

--- a/crates/red_knot_python_semantic/src/semantic_index/builder.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/builder.rs
@@ -550,6 +550,10 @@ where
                     };
 
                     // Look for imports `from __future__ import annotations`, ignore `as ...`
+                    // We intentionally don't enforce the rules about location of `__future__`
+                    // imports here, we assume the user's intent was to apply the `__future__`
+                    // import, so we still check using it (and will also emit a diagnostic about a
+                    // miss-placed `__future__` import.)
                     self.has_future_annotations |= alias.name.id.as_str() == "annotations"
                         && node
                             .module

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -328,6 +328,10 @@ impl<'db> TypeInferenceBuilder<'db> {
         matches!(self.region, InferenceRegion::Deferred(_))
     }
 
+    fn has_future_annotations(&self) -> bool {
+        self.index.has_future_annotations()
+    }
+
     /// Infers types in the given [`InferenceRegion`].
     fn infer_region(&mut self) {
         match self.region {
@@ -697,7 +701,7 @@ impl<'db> TypeInferenceBuilder<'db> {
             self.infer_parameters(parameters);
 
             // TODO: this should also be applied to parameter annotations.
-            if self.is_stub() {
+            if self.is_stub() || self.has_future_annotations() {
                 self.types.has_deferred = true;
             } else {
                 self.infer_optional_annotation_expression(returns.as_deref());
@@ -825,9 +829,9 @@ impl<'db> TypeInferenceBuilder<'db> {
             self.infer_expression(&keyword.value);
         }
 
-        // inference of bases deferred in stubs
+        // Inference of bases deferred in stubs
         // TODO also defer stringified generic type parameters
-        if self.is_stub() {
+        if self.is_stub() || self.has_future_annotations() {
             self.types.has_deferred = true;
         } else {
             for base in class.bases() {
@@ -837,13 +841,12 @@ impl<'db> TypeInferenceBuilder<'db> {
     }
 
     fn infer_function_deferred(&mut self, function: &ast::StmtFunctionDef) {
-        if self.is_stub() {
-            self.infer_optional_annotation_expression(function.returns.as_deref());
-        }
+        self.infer_optional_annotation_expression(function.returns.as_deref());
+        if self.is_stub() || self.has_future_annotations() {}
     }
 
     fn infer_class_deferred(&mut self, class: &ast::StmtClassDef) {
-        if self.is_stub() {
+        if self.is_stub() || self.has_future_annotations() {
             for base in class.bases() {
                 self.infer_expression(base);
             }
@@ -4005,6 +4008,63 @@ mod tests {
             .expect("there should be at least one base");
 
         assert_eq!(base.display(&db).to_string(), "Literal[object]");
+
+        Ok(())
+    }
+
+    #[test]
+    fn deferred_annotation_in_stubs_always_resolve() -> anyhow::Result<()> {
+        let mut db = setup_db();
+
+        // Stub files should always resolve deferred annotations
+        db.write_dedented(
+            "/src/stub.pyi",
+            "
+            def get_foo() -> Foo: ...
+            class Foo: ...
+            foo = get_foo()
+            ",
+        )?;
+        assert_public_ty(&db, "/src/stub.pyi", "foo", "Foo");
+
+        Ok(())
+    }
+
+    #[test]
+    fn deferred_annotations_regular_source_fails() -> anyhow::Result<()> {
+        let mut db = setup_db();
+
+        // In (regular) source files, deferred annotations are *not* resolved
+        // Also tests imports from `__future__` that are not annotations
+        db.write_dedented(
+            "/src/source.py",
+            "
+            from __future__ import with_statement as annotations
+            def get_foo() -> Foo: ...
+            class Foo: ...
+            foo = get_foo()
+            ",
+        )?;
+        assert_public_ty(&db, "/src/source.py", "foo", "Unknown");
+
+        Ok(())
+    }
+
+    #[test]
+    fn deferred_annotation_in_sources_with_future_resolves() -> anyhow::Result<()> {
+        let mut db = setup_db();
+
+        // In source files with `__future__.annotations`, deferred annotations are resolved
+        db.write_dedented(
+            "/src/source_with_future.py",
+            "
+            from __future__ import annotations
+            def get_foo() -> Foo: ...
+            class Foo: ...
+            foo = get_foo()
+            ",
+        )?;
+        assert_public_ty(&db, "/src/source_with_future.py", "foo", "Foo");
 
         Ok(())
     }

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -321,7 +321,7 @@ impl<'db> TypeInferenceBuilder<'db> {
     /// Are we currently inferring types in file with deferred types?
     /// This is true for stub files and files with `__future__.annotations`
     fn are_all_types_deferred(&self) -> bool {
-        self.file.is_stub(self.db.upcast()) || self.index.has_future_annotations()
+        self.index.has_future_annotations() || self.file.is_stub(self.db.upcast())
     }
 
     /// Are we currently inferring deferred types?


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

This PR tries to provide support for deferred resolution of type-hints in files with `from __future__ import annotations`. Fixes #13070.

### Implementation

Currently, the method `is_stub` is already used in multiple places to resolve deferred annotations. As all current usage of `is_stubs` are dedicated to deferred type inference, I decided in this implementation to refactor `is_stubs` && `has_future_annotations` together in `are_all_types_deferred`.
We can also keep them separate and always test them together.

The main difficulty is how to know if that flag is active. I tried an implementation that checks this when building the semantic index. I do not know if it's the best choice (as `SemanticIndex` doesn't have any attribute similar to this), but the building of the semantic index already parses every statement in the file, which was ideal to find this flag.

Happy to get any feedback on a better spot for this if you can think of one.

## Test Plan

There is currently one test addressing deferred annotations resolution, focused on builtins. I don't quite understand why builtins require deferred annotations, so I focused on test cases I encounter when coding in python.

In my experience, the two most common occurrences requiring deferred annotations (in regular code) are:
- Referencing a symbol before it's defined
- Referencing a class inside one of its own methods

Some testing led me to find that we don't currently support [type resolution for methods](https://github.com/astral-sh/ruff/blob/4eb849aed3a6df9ce0f45dd7a2fdb525e31e61e3/crates/red_knot_python_semantic/src/types.rs#L439), so I only tested the case of referencing a symbol before its definition.

I added 3 separate test case, all with the same base code:
```python
def get_foo() -> Foo: ...
class Foo: ...
foo = get_foo()  # Resolved if and only if deferred annotations are active
```
- Inside a source file (`*.py`, `foo` must not resolve (`Unknown`)
- Inside a stub file (`*.pyi`), `foo` must resolve to `Foo`
- Inside a source file **with __future__.annotations**, `foo` must resolve to `Foo`
