### PR TITLE
[red-knot] add support for typing_extensions.reveal_type

### DIFF
--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -859,7 +859,7 @@ impl<'db> FunctionType<'db> {
         name == self.name(db)
             && file_to_module(db, self.definition(db).file(db)).is_some_and(|module| {
                 module.search_path().is_standard_library()
-                    && (module.name() == "typing" || module.name() == "typing_extensions")
+                    && matches!(module.name(), "typing" | "typing_extensions")
             })
     }
 

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -859,7 +859,7 @@ impl<'db> FunctionType<'db> {
         name == self.name(db)
             && file_to_module(db, self.definition(db).file(db)).is_some_and(|module| {
                 module.search_path().is_standard_library()
-                    && matches!(module.name(), "typing" | "typing_extensions")
+                    && matches!(&**module.name(), "typing" | "typing_extensions")
             })
     }
 

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -854,6 +854,15 @@ impl<'db> FunctionType<'db> {
             })
     }
 
+    /// Return true if this is a symbol with given name from `typing` or `typing_extensions`.
+    pub(crate) fn is_typing_symbol(self, db: &'db dyn Db, name: &str) -> bool {
+        name == self.name(db)
+            && file_to_module(db, self.definition(db).file(db)).is_some_and(|module| {
+                module.search_path().is_standard_library()
+                    && (module.name() == "typing" || module.name() == "typing_extensions")
+            })
+    }
+
     pub fn has_decorator(self, db: &dyn Db, decorator: Type<'_>) -> bool {
         self.decorators(db).contains(&decorator)
     }

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -705,9 +705,7 @@ impl<'db> TypeInferenceBuilder<'db> {
         }
 
         let function_type = FunctionType::new(self.db, name.id.clone(), definition, decorator_tys);
-        let function_ty = if function_type.is_stdlib_symbol(self.db, "typing", "reveal_type")
-            || function_type.is_stdlib_symbol(self.db, "typing_extensions", "reveal_type")
-        {
+        let function_ty = if function_type.is_typing_symbol(self.db, "reveal_type") {
             Type::RevealTypeFunction(function_type)
         } else {
             Type::Function(function_type)

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -705,7 +705,9 @@ impl<'db> TypeInferenceBuilder<'db> {
         }
 
         let function_type = FunctionType::new(self.db, name.id.clone(), definition, decorator_tys);
-        let function_ty = if function_type.is_stdlib_symbol(self.db, "typing", "reveal_type") {
+        let function_ty = if function_type.is_stdlib_symbol(self.db, "typing", "reveal_type")
+            || function_type.is_stdlib_symbol(self.db, "typing_extensions", "reveal_type")
+        {
             Type::RevealTypeFunction(function_type)
         } else {
             Type::Function(function_type)
@@ -2753,6 +2755,44 @@ mod tests {
 
             x = 1
             reveal_type(x)
+            ",
+        )?;
+
+        assert_file_diagnostics(&db, "/src/a.py", &["Revealed type is 'Literal[1]'."]);
+
+        Ok(())
+    }
+
+    #[test]
+    fn reveal_type_aliased() -> anyhow::Result<()> {
+        let mut db = setup_db();
+
+        db.write_dedented(
+            "/src/a.py",
+            "
+            from typing import reveal_type as rt
+
+            x = 1
+            rt(x)
+            ",
+        )?;
+
+        assert_file_diagnostics(&db, "/src/a.py", &["Revealed type is 'Literal[1]'."]);
+
+        Ok(())
+    }
+
+    #[test]
+    fn reveal_type_typing_extensions() -> anyhow::Result<()> {
+        let mut db = setup_db();
+
+        db.write_dedented(
+            "/src/a.py",
+            "
+            import typing_extensions
+
+            x = 1
+            typing_extensions.reveal_type(x)
             ",
         )?;
 


### PR DESCRIPTION
Before `typing.reveal_type` existed, there was `typing_extensions.reveal_type`. We should support both.

Also adds a test to verify that we can handle aliasing of `reveal_type` to a different name.

Adds a bit of code to ensure that if we have a union of different `reveal_type` functions (e.g. a union containing both `typing_extensions.reveal_type` and `typing.reveal_type`) we still emit the reveal-type diagnostic only once. This is probably unlikely in practice, but it doesn't hurt to handle it smoothly. (It comes up now because we don't support `version_info` checks yet, so `typing_extensions.reveal_type` is actually that union.)
