### PR TITLE
[red-knot] simplify subtypes from unions

### DIFF
--- a/crates/red_knot_python_semantic/src/types/builder.rs
+++ b/crates/red_knot_python_semantic/src/types/builder.rs
@@ -52,11 +52,10 @@ impl<'db> UnionBuilder<'db> {
             }
             Type::Never => {}
             _ => {
-                let mut add = true;
                 let mut remove = vec![];
                 for element in &self.elements {
                     if ty.is_subtype_of(self.db, *element) {
-                        add = false;
+                        return self;
                     } else if element.is_subtype_of(self.db, ty) {
                         remove.push(*element);
                     }
@@ -64,9 +63,7 @@ impl<'db> UnionBuilder<'db> {
                 for element in remove {
                     self.elements.remove(&element);
                 }
-                if add {
-                    self.elements.insert(ty);
-                }
+                self.elements.insert(ty);
             }
         }
 

--- a/crates/red_knot_python_semantic/src/types/builder.rs
+++ b/crates/red_knot_python_semantic/src/types/builder.rs
@@ -46,11 +46,27 @@ impl<'db> UnionBuilder<'db> {
     pub(crate) fn add(mut self, ty: Type<'db>) -> Self {
         match ty {
             Type::Union(union) => {
-                self.elements.extend(union.elements(self.db));
+                for element in union.elements(self.db) {
+                    self = self.add(*element);
+                }
             }
             Type::Never => {}
             _ => {
-                self.elements.insert(ty);
+                let mut add = true;
+                let mut remove = vec![];
+                for element in &self.elements {
+                    if ty.is_subtype_of(self.db, *element) {
+                        add = false;
+                    } else if element.is_subtype_of(self.db, ty) {
+                        remove.push(*element);
+                    }
+                }
+                for element in remove {
+                    self.elements.remove(&element);
+                }
+                if add {
+                    self.elements.insert(ty);
+                }
             }
         }
 
@@ -367,6 +383,24 @@ mod tests {
 
         assert_eq!(union.elements_vec(&db), &[t0, t1, t2]);
     }
+
+    #[test]
+    fn build_union_simplify_subtype() {
+        let db = setup_db();
+        let t0 = builtins_symbol_ty(&db, "str").to_instance(&db);
+        let t1 = Type::LiteralString;
+        let t2 = Type::Unknown;
+        let u0 = UnionType::from_elements(&db, [t0, t1]);
+        let u1 = UnionType::from_elements(&db, [t1, t0]);
+        let u2 = UnionType::from_elements(&db, [t0, t1, t2]);
+
+        assert_eq!(u0, t0);
+        assert_eq!(u1, t0);
+        assert_eq!(u2.expect_union().elements_vec(&db), &[t0, t2]);
+    }
+
+    #[test]
+    fn build_union_no_simplify_any() {}
 
     impl<'db> IntersectionType<'db> {
         fn pos_vec(self, db: &'db TestDb) -> Vec<Type<'db>> {

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -5800,8 +5800,7 @@ mod tests {
         .unwrap();
         db.write_file("/src/c.pyi", "x: int").unwrap();
 
-        // TODO this should simplify to just 'int'
-        assert_public_ty(&db, "/src/a.py", "x", "int | Literal[1]");
+        assert_public_ty(&db, "/src/a.py", "x", "int");
     }
 
     // Incremental inference tests


### PR DESCRIPTION
Add `Type::is_subtype_of` method, and simplify subtypes out of unions.
