### PR TITLE
Fix off-by one error in the `LineIndex::offset` calculation

### DIFF
--- a/crates/ruff/tests/format.rs
+++ b/crates/ruff/tests/format.rs
@@ -1945,11 +1945,10 @@ fn range_end_only() {
 def foo(arg1, arg2,):
     print("Should format this" )
 
-"#), @r###"
+"#), @r#"
     success: true
     exit_code: 0
     ----- stdout -----
-
     def foo(
         arg1,
         arg2,
@@ -1958,7 +1957,7 @@ def foo(arg1, arg2,):
 
 
     ----- stderr -----
-    "###);
+    "#);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

This fixes an error where Emacs showed obscure syntax errors.
The reason for the obscure syntax errors was that Ruff incorrectly
applied the change updates from emacs because of an off-by-one error 
in the UTF32 to UTF8 offset calculation. When you add a new type wrapper to make it clear that the offsets are one-based and you still get it wrong :shrug: 

We didn't notice this error before because VS code always uses UTF 16 and 
I think neovim uses UTF8. The same method is also used to detect the format range. 
But it was never significant there because range formatting always extends the range to the enclosing statement. 


Fixes https://github.com/emacs-lsp/lsp-mode/issues/4547
Fixes https://github.com/astral-sh/ruff-lsp/issues/495

and possibly https://github.com/astral-sh/ruff/issues/13392


## Test Plan

Added tests. I used emacs with a debug build that contains the fix and I no longer
observed any stale/obscure syntax errors
