### PR TITLE
[red-knot] more efficient UnionBuilder::add

### DIFF
--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -422,6 +422,8 @@ impl<'db> Type<'db> {
                 .elements(db)
                 .iter()
                 .any(|&elem_ty| ty.is_subtype_of(db, elem_ty)),
+            (_, Type::Instance(class)) if class.is_stdlib_symbol(db, "builtins", "object") => true,
+            (Type::Instance(class), _) if class.is_stdlib_symbol(db, "builtins", "object") => false,
             // TODO
             _ => false,
         }
@@ -1123,6 +1125,8 @@ mod tests {
         }
     }
 
+    #[test_case(Ty::BuiltinInstance("str"), Ty::BuiltinInstance("object"))]
+    #[test_case(Ty::BuiltinInstance("int"), Ty::BuiltinInstance("object"))]
     #[test_case(Ty::Unknown, Ty::IntLiteral(1))]
     #[test_case(Ty::Any, Ty::IntLiteral(1))]
     #[test_case(Ty::Never, Ty::IntLiteral(1))]
@@ -1140,6 +1144,7 @@ mod tests {
         assert!(from.into_type(&db).is_assignable_to(&db, to.into_type(&db)));
     }
 
+    #[test_case(Ty::BuiltinInstance("object"), Ty::BuiltinInstance("int"))]
     #[test_case(Ty::IntLiteral(1), Ty::BuiltinInstance("str"))]
     #[test_case(Ty::BuiltinInstance("int"), Ty::BuiltinInstance("str"))]
     #[test_case(Ty::BuiltinInstance("int"), Ty::IntLiteral(1))]
@@ -1148,6 +1153,8 @@ mod tests {
         assert!(!from.into_type(&db).is_assignable_to(&db, to.into_type(&db)));
     }
 
+    #[test_case(Ty::BuiltinInstance("str"), Ty::BuiltinInstance("object"))]
+    #[test_case(Ty::BuiltinInstance("int"), Ty::BuiltinInstance("object"))]
     #[test_case(Ty::Never, Ty::IntLiteral(1))]
     #[test_case(Ty::IntLiteral(1), Ty::BuiltinInstance("int"))]
     #[test_case(Ty::StringLiteral("foo"), Ty::BuiltinInstance("str"))]
@@ -1160,6 +1167,7 @@ mod tests {
         assert!(from.into_type(&db).is_subtype_of(&db, to.into_type(&db)));
     }
 
+    #[test_case(Ty::BuiltinInstance("object"), Ty::BuiltinInstance("int"))]
     #[test_case(Ty::Unknown, Ty::IntLiteral(1))]
     #[test_case(Ty::Any, Ty::IntLiteral(1))]
     #[test_case(Ty::IntLiteral(1), Ty::Unknown)]

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -994,7 +994,7 @@ impl<'db> ClassType<'db> {
 pub struct UnionType<'db> {
     /// The union type includes values in any of these types.
     #[return_ref]
-    elements: Vec<Type<'db>>,
+    elements: Box<[Type<'db>]>,
 }
 
 impl<'db> UnionType<'db> {

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -994,7 +994,7 @@ impl<'db> ClassType<'db> {
 pub struct UnionType<'db> {
     /// The union type includes values in any of these types.
     #[return_ref]
-    elements: FxOrderSet<Type<'db>>,
+    elements: Vec<Type<'db>>,
 }
 
 impl<'db> UnionType<'db> {
@@ -1023,7 +1023,7 @@ impl<'db> UnionType<'db> {
         db: &'db dyn Db,
         transform_fn: impl Fn(&Type<'db>) -> Type<'db>,
     ) -> Type<'db> {
-        Self::from_elements(db, self.elements(db).into_iter().map(transform_fn))
+        Self::from_elements(db, self.elements(db).iter().map(transform_fn))
     }
 }
 

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -996,10 +996,14 @@ impl<'db> ClassType<'db> {
 pub struct UnionType<'db> {
     /// The union type includes values in any of these types.
     #[return_ref]
-    elements: Box<[Type<'db>]>,
+    elements_boxed: Box<[Type<'db>]>,
 }
 
 impl<'db> UnionType<'db> {
+    fn elements(self, db: &'db dyn Db) -> &'db [Type<'db>] {
+        self.elements_boxed(db)
+    }
+
     /// Create a union from a list of elements
     /// (which may be eagerly simplified into a different variant of [`Type`] altogether).
     pub fn from_elements<T: Into<Type<'db>>>(

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -998,13 +998,6 @@ pub struct UnionType<'db> {
 }
 
 impl<'db> UnionType<'db> {
-    #[deprecated(
-        note = "This is O(n) and we shouldn't need it; TODO eliminate along with Type::Unbound."
-    )]
-    pub fn contains(&self, db: &'db dyn Db, ty: Type<'db>) -> bool {
-        self.elements(db).contains(&ty)
-    }
-
     /// Create a union from a list of elements
     /// (which may be eagerly simplified into a different variant of [`Type`] altogether).
     pub fn from_elements<T: Into<Type<'db>>>(

--- a/crates/red_knot_python_semantic/src/types/builder.rs
+++ b/crates/red_knot_python_semantic/src/types/builder.rs
@@ -27,6 +27,7 @@
 //!   * An intersection containing two non-overlapping types should simplify to [`Type::Never`].
 use crate::types::{builtins_symbol_ty, IntersectionType, Type, UnionType};
 use crate::{Db, FxOrderSet};
+use smallvec::SmallVec;
 
 pub(crate) struct UnionBuilder<'db> {
     elements: Vec<Type<'db>>,
@@ -59,7 +60,7 @@ impl<'db> UnionBuilder<'db> {
                     None
                 };
                 let mut to_add = ty;
-                let mut to_remove = vec![];
+                let mut to_remove = SmallVec::<[usize; 2]>::new();
                 for (index, element) in self.elements.iter().enumerate() {
                     if Some(*element) == bool_pair {
                         to_add = builtins_symbol_ty(self.db, "bool");

--- a/crates/red_knot_python_semantic/src/types/builder.rs
+++ b/crates/red_knot_python_semantic/src/types/builder.rs
@@ -59,6 +59,7 @@ impl<'db> UnionBuilder<'db> {
                 } else {
                     None
                 };
+
                 let mut to_add = ty;
                 let mut to_remove = SmallVec::<[usize; 2]>::new();
                 for (index, element) in self.elements.iter().enumerate() {
@@ -77,6 +78,7 @@ impl<'db> UnionBuilder<'db> {
                         to_remove.push(index);
                     }
                 }
+
                 match to_remove[..] {
                     [] => self.elements.push(to_add),
                     [index] => self.elements[index] = to_add,

--- a/crates/red_knot_python_semantic/src/types/builder.rs
+++ b/crates/red_knot_python_semantic/src/types/builder.rs
@@ -47,7 +47,7 @@ impl<'db> UnionBuilder<'db> {
             Type::Union(union) => {
                 let new_elements = union.elements(self.db);
                 self.elements.reserve(new_elements.len());
-                for element in &**new_elements {
+                for element in new_elements {
                     self = self.add(*element);
                 }
             }
@@ -328,7 +328,7 @@ mod tests {
         let t1 = Type::IntLiteral(1);
         let union = UnionType::from_elements(&db, [t0, t1]).expect_union();
 
-        assert_eq!(union.elements(&db).as_ref(), &[t0, t1]);
+        assert_eq!(union.elements(&db), &[t0, t1]);
     }
 
     #[test]
@@ -365,10 +365,10 @@ mod tests {
         let t3 = Type::IntLiteral(17);
 
         let union = UnionType::from_elements(&db, [t0, t1, t3]).expect_union();
-        assert_eq!(union.elements(&db).as_ref(), &[t0, t3]);
+        assert_eq!(union.elements(&db), &[t0, t3]);
 
         let union = UnionType::from_elements(&db, [t0, t1, t2, t3]).expect_union();
-        assert_eq!(union.elements(&db).as_ref(), &[bool_ty, t3]);
+        assert_eq!(union.elements(&db), &[bool_ty, t3]);
     }
 
     #[test]
@@ -380,7 +380,7 @@ mod tests {
         let u1 = UnionType::from_elements(&db, [t0, t1]);
         let union = UnionType::from_elements(&db, [u1, t2]).expect_union();
 
-        assert_eq!(union.elements(&db).as_ref(), &[t0, t1, t2]);
+        assert_eq!(union.elements(&db), &[t0, t1, t2]);
     }
 
     #[test]
@@ -403,8 +403,8 @@ mod tests {
         let u0 = UnionType::from_elements(&db, [t0, t1]);
         let u1 = UnionType::from_elements(&db, [t1, t0]);
 
-        assert_eq!(u0.expect_union().elements(&db).as_ref(), &[t0, t1]);
-        assert_eq!(u1.expect_union().elements(&db).as_ref(), &[t1, t0]);
+        assert_eq!(u0.expect_union().elements(&db), &[t0, t1]);
+        assert_eq!(u1.expect_union().elements(&db), &[t1, t0]);
     }
 
     #[test]
@@ -417,10 +417,7 @@ mod tests {
 
         let u0 = UnionType::from_elements(&db, [str_ty, unknown_ty, int_ty, object_ty]);
 
-        assert_eq!(
-            u0.expect_union().elements(&db).as_ref(),
-            &[unknown_ty, object_ty]
-        );
+        assert_eq!(u0.expect_union().elements(&db), &[unknown_ty, object_ty]);
     }
 
     impl<'db> IntersectionType<'db> {

--- a/crates/red_knot_python_semantic/src/types/builder.rs
+++ b/crates/red_knot_python_semantic/src/types/builder.rs
@@ -81,21 +81,20 @@ impl<'db> UnionBuilder<'db> {
                     [] => self.elements.push(to_add),
                     [index] => self.elements[index] = to_add,
                     _ => {
-                        let mut retain =
-                            Vec::with_capacity(self.elements.len() - to_remove.len() + 1);
-                        let mut remove_iter = to_remove.iter();
-                        let mut elements_iter = self.elements.iter().enumerate();
-                        'outer: for remove_index in remove_iter.by_ref() {
-                            for (index, element) in elements_iter.by_ref() {
-                                if index == *remove_index {
-                                    continue 'outer;
-                                }
-                                retain.push(*element);
-                            }
-                        }
-                        retain.extend(elements_iter.map(|(_, element)| element));
-                        retain.push(to_add);
-                        self.elements = retain;
+                        let mut current_index = 0;
+                        let mut to_remove = to_remove.into_iter();
+                        let mut next_to_remove_index = to_remove.next();
+                        self.elements.retain(|_| {
+                            let retain = if Some(current_index) == next_to_remove_index {
+                                next_to_remove_index = to_remove.next();
+                                false
+                            } else {
+                                true
+                            };
+                            current_index += 1;
+                            retain
+                        });
+                        self.elements.push(to_add);
                     }
                 }
             }

--- a/crates/red_knot_python_semantic/src/types/builder.rs
+++ b/crates/red_knot_python_semantic/src/types/builder.rs
@@ -47,7 +47,7 @@ impl<'db> UnionBuilder<'db> {
             Type::Union(union) => {
                 let new_elements = union.elements(self.db);
                 self.elements.reserve(new_elements.len());
-                for element in new_elements {
+                for element in &**new_elements {
                     self = self.add(*element);
                 }
             }

--- a/crates/red_knot_python_semantic/src/types/builder.rs
+++ b/crates/red_knot_python_semantic/src/types/builder.rs
@@ -297,7 +297,7 @@ mod tests {
     use crate::db::tests::TestDb;
     use crate::program::{Program, SearchPathSettings};
     use crate::python_version::PythonVersion;
-    use crate::types::{builtins_symbol_ty, StringLiteralType, UnionBuilder};
+    use crate::types::{builtins_symbol_ty, UnionBuilder};
     use crate::ProgramSettings;
     use ruff_db::system::{DbWithTestSystem, SystemPathBuf};
 
@@ -405,6 +405,22 @@ mod tests {
 
         assert_eq!(u0.expect_union().elements(&db).as_ref(), &[t0, t1]);
         assert_eq!(u1.expect_union().elements(&db).as_ref(), &[t1, t0]);
+    }
+
+    #[test]
+    fn build_union_subsume_multiple() {
+        let db = setup_db();
+        let str_ty = builtins_symbol_ty(&db, "str").to_instance(&db);
+        let int_ty = builtins_symbol_ty(&db, "int").to_instance(&db);
+        let object_ty = builtins_symbol_ty(&db, "object").to_instance(&db);
+        let unknown_ty = Type::Unknown;
+
+        let u0 = UnionType::from_elements(&db, [str_ty, unknown_ty, int_ty, object_ty]);
+
+        assert_eq!(
+            u0.expect_union().elements(&db).as_ref(),
+            &[unknown_ty, object_ty]
+        );
     }
 
     impl<'db> IntersectionType<'db> {

--- a/crates/red_knot_python_semantic/src/types/display.rs
+++ b/crates/red_knot_python_semantic/src/types/display.rs
@@ -122,7 +122,7 @@ impl Display for DisplayUnionType<'_> {
         // Group literal types by kind.
         let mut grouped_literals = FxHashMap::default();
 
-        for element in elements {
+        for element in &**elements {
             if let Ok(literal_kind) = LiteralTypeKind::try_from(*element) {
                 grouped_literals
                     .entry(literal_kind)
@@ -133,7 +133,7 @@ impl Display for DisplayUnionType<'_> {
 
         let mut join = f.join(" | ");
 
-        for element in elements {
+        for element in &**elements {
             if let Ok(literal_kind) = LiteralTypeKind::try_from(*element) {
                 let Some(mut literals) = grouped_literals.remove(&literal_kind) else {
                     continue;

--- a/crates/red_knot_python_semantic/src/types/display.rs
+++ b/crates/red_knot_python_semantic/src/types/display.rs
@@ -122,7 +122,7 @@ impl Display for DisplayUnionType<'_> {
         // Group literal types by kind.
         let mut grouped_literals = FxHashMap::default();
 
-        for element in &**elements {
+        for element in elements {
             if let Ok(literal_kind) = LiteralTypeKind::try_from(*element) {
                 grouped_literals
                     .entry(literal_kind)
@@ -133,7 +133,7 @@ impl Display for DisplayUnionType<'_> {
 
         let mut join = f.join(" | ");
 
-        for element in &**elements {
+        for element in elements {
             if let Ok(literal_kind) = LiteralTypeKind::try_from(*element) {
                 let Some(mut literals) = grouped_literals.remove(&literal_kind) else {
                     continue;

--- a/crates/red_knot_workspace/src/lint.rs
+++ b/crates/red_knot_workspace/src/lint.rs
@@ -114,23 +114,19 @@ fn lint_maybe_undefined(context: &SemanticLintContext, name: &ast::ExprName) {
         return;
     }
     let semantic = &context.semantic;
-    match name.ty(semantic) {
-        Type::Unbound => {
-            context.push_diagnostic(format_diagnostic(
-                context,
-                &format!("Name '{}' used when not defined.", &name.id),
-                name.start(),
-            ));
-        }
-        #[allow(deprecated)]
-        Type::Union(union) if union.contains(semantic.db(), Type::Unbound) => {
-            context.push_diagnostic(format_diagnostic(
-                context,
-                &format!("Name '{}' used when possibly not defined.", &name.id),
-                name.start(),
-            ));
-        }
-        _ => {}
+    let ty = name.ty(semantic);
+    if ty.is_unbound() {
+        context.push_diagnostic(format_diagnostic(
+            context,
+            &format!("Name '{}' used when not defined.", &name.id),
+            name.start(),
+        ));
+    } else if ty.may_be_unbound(semantic.db()) {
+        context.push_diagnostic(format_diagnostic(
+            context,
+            &format!("Name '{}' used when possibly not defined.", &name.id),
+            name.start(),
+        ));
     }
 }
 

--- a/crates/red_knot_workspace/src/lint.rs
+++ b/crates/red_knot_workspace/src/lint.rs
@@ -122,6 +122,7 @@ fn lint_maybe_undefined(context: &SemanticLintContext, name: &ast::ExprName) {
                 name.start(),
             ));
         }
+        #[allow(deprecated)]
         Type::Union(union) if union.contains(semantic.db(), Type::Unbound) => {
             context.push_diagnostic(format_diagnostic(
                 context,


### PR DESCRIPTION
Avoid quadratic time in subsumed elements when adding a super-type of existing union elements.

Reserve space in advance when adding multiple elements (from another union) to a union.

Make union elements a `Box<[Type]>` instead of an `FxOrderSet`; the set doesn't buy much since the rules of union uniqueness are defined in terms of supertype/subtype, not in terms of simple type identity.

Move sealed-boolean handling out of a separate `UnionBuilder::simplify` method and into `UnionBuilder::add`; now that `add` is iterating existing elements anyway, this is more efficient.

Remove `UnionType::contains`, since it's now `O(n)` and we shouldn't really need it, generally we care about subtype/supertype, not type identity. (Right now it's used for `Type::Unbound`, which shouldn't even be a type.)

Add support for `is_subtype_of` for the `object` type.

Addresses comments on https://github.com/astral-sh/ruff/pull/13401