### PR TITLE
Correct `Some value is incorrect`

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_errmsg/rules/string_in_exception.rs
+++ b/crates/ruff_linter/src/rules/flake8_errmsg/rules/string_in_exception.rs
@@ -30,7 +30,7 @@ use crate::registry::Rule;
 /// ```console
 /// Traceback (most recent call last):
 ///   File "tmp.py", line 2, in <module>
-///     raise RuntimeError("Some value is incorrect")
+///     raise RuntimeError("'Some value' is incorrect")
 /// RuntimeError: 'Some value' is incorrect
 /// ```
 ///


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->


## Summary

Add missing single-quotes to documentation for [EM101](https://docs.astral.sh/ruff/rules/raw-string-in-exception/). The quotes around `'Some value'` were missing only in the traceback.

## Test Plan

None
