### PR TITLE
Respect `lint.exclude` in ruff check `--add-noqa`

### DIFF
--- a/crates/ruff/src/commands/add_noqa.rs
+++ b/crates/ruff/src/commands/add_noqa.rs
@@ -10,7 +10,9 @@ use ruff_linter::linter::add_noqa_to_path;
 use ruff_linter::source_kind::SourceKind;
 use ruff_linter::warn_user_once;
 use ruff_python_ast::{PySourceType, SourceType};
-use ruff_workspace::resolver::{python_files_in_path, PyprojectConfig, ResolvedFile};
+use ruff_workspace::resolver::{
+    match_exclusion, python_files_in_path, PyprojectConfig, ResolvedFile,
+};
 
 use crate::args::ConfigArguments;
 
@@ -57,6 +59,15 @@ pub(crate) fn add_noqa(
                 .and_then(|parent| package_roots.get(parent))
                 .and_then(|package| *package);
             let settings = resolver.resolve(path);
+            if (settings.file_resolver.force_exclude || !resolved_file.is_root())
+                && match_exclusion(
+                    resolved_file.path(),
+                    resolved_file.file_name(),
+                    &settings.linter.exclude,
+                )
+            {
+                return None;
+            }
             let source_kind = match SourceKind::from_path(path, source_type) {
                 Ok(Some(source_kind)) => source_kind,
                 Ok(None) => return None,


### PR DESCRIPTION
## Summary

Closes https://github.com/astral-sh/ruff/issues/13423.
