### PR TITLE
Use `deflate` on PowerPC

### DIFF
--- a/crates/red_knot_python_semantic/Cargo.toml
+++ b/crates/red_knot_python_semantic/Cargo.toml
@@ -38,7 +38,12 @@ test-case = { workspace = true }
 [build-dependencies]
 path-slash = { workspace = true }
 walkdir = { workspace = true }
-zip = { workspace = true, features = ["zstd", "deflate"] }
+
+[target.'cfg(not(target_arch = "powerpc64"))'.build-dependencies]
+zip = { workspace = true, features = ["deflate", "zstd"] }
+
+[target.'cfg(target_arch = "powerpc64")'.build-dependencies]
+zip = { workspace = true, features = ["deflate"] }
 
 [dev-dependencies]
 ruff_db = { workspace = true, features = ["os", "testing"] }

--- a/crates/red_knot_python_semantic/build.rs
+++ b/crates/red_knot_python_semantic/build.rs
@@ -30,7 +30,8 @@ fn zip_dir(directory_path: &str, writer: File) -> ZipResult<File> {
     // We can't use `#[cfg(...)]` here because the target-arch in a build script is the
     // architecture of the system running the build script and not the architecture of the build-target.
     // That's why we use the `TARGET` environment variable here.
-    let method = if std::env::var("TARGET").unwrap().contains("wasm32") {
+    let target = std::env::var("TARGET").unwrap();
+    let method = if target.contains("wasm32") || target.contains("powerpc64") {
         CompressionMethod::Deflated
     } else {
         CompressionMethod::Zstd

--- a/crates/red_knot_python_semantic/build.rs
+++ b/crates/red_knot_python_semantic/build.rs
@@ -30,11 +30,17 @@ fn zip_dir(directory_path: &str, writer: File) -> ZipResult<File> {
     // We can't use `#[cfg(...)]` here because the target-arch in a build script is the
     // architecture of the system running the build script and not the architecture of the build-target.
     // That's why we use the `TARGET` environment variable here.
-    let target = std::env::var("TARGET").unwrap();
-    let method = if target.contains("wasm32") || target.contains("powerpc64") {
-        CompressionMethod::Deflated
-    } else {
-        CompressionMethod::Zstd
+    #[cfg(target_arch = "powerpc64")]
+    let method = CompressionMethod::Deflated;
+
+    #[cfg(not(target_arch = "powerpc64"))]
+    let method = {
+        let target = std::env::var("TARGET").unwrap();
+        if target.contains("wasm32") || target.contains("powerpc64") {
+            CompressionMethod::Deflated
+        } else {
+            CompressionMethod::Zstd
+        }
     };
 
     let options = FileOptions::default()

--- a/crates/ruff_db/Cargo.toml
+++ b/crates/ruff_db/Cargo.toml
@@ -34,12 +34,14 @@ tracing-subscriber = { workspace = true, optional = true }
 tracing-tree = { workspace = true, optional = true }
 rustc-hash = { workspace = true }
 
-[target.'cfg(not(target_arch="wasm32"))'.dependencies]
+[target.'cfg(not(any(target_arch = "wasm32", target_arch = "powerpc64")))'.dependencies]
 zip = { workspace = true, features = ["zstd"] }
 
-[target.'cfg(target_arch="wasm32")'.dependencies]
-web-time = { version = "1.1.0" }
+[target.'cfg(any(target_arch = "wasm32", target_arch = "powerpc64"))'.dependencies]
 zip = { workspace = true, features = ["deflate"] }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+web-time = { version = "1.1.0" }
 
 [dev-dependencies]
 insta = { workspace = true }


### PR DESCRIPTION
## Summary

I think this should work... But it's hard to test (see: https://github.com/conda-forge/ruff-feedstock/pull/219). AFAICT, those builds still happen on an X86 machine, so it should be okay that the build script _depends_ on zstd, as long as it doesn't have to pull it in.