### PR TITLE
[red-knot] Add `Type::bool` and boolean expression inference

### DIFF
--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -548,7 +548,7 @@ impl<'db> Type<'db> {
                             if result.is_some_and(|result| truthiness != result) {
                                 return Truthiness::Ambiguous;
                             }
-                            result = truthiness.into();
+                            result = Some(truthiness);
                         }
                         Truthiness::Ambiguous => {
                             return Truthiness::Ambiguous;
@@ -561,12 +561,12 @@ impl<'db> Type<'db> {
                 // TODO
                 Truthiness::Ambiguous
             }
-            Type::IntLiteral(num) => (*num != 0).into(),
-            Type::BooleanLiteral(bool) => (*bool).into(),
-            Type::StringLiteral(str) => (!str.value(db).is_empty()).into(),
+            Type::IntLiteral(num) => Truthiness::from(*num != 0),
+            Type::BooleanLiteral(bool) => Truthiness::from(*bool),
+            Type::StringLiteral(str) => Truthiness::from(!str.value(db).is_empty()),
             Type::LiteralString => Truthiness::Ambiguous,
-            Type::BytesLiteral(bytes) => (!bytes.value(db).is_empty()).into(),
-            Type::Tuple(items) => (!items.elements(db).is_empty()).into(),
+            Type::BytesLiteral(bytes) => Truthiness::from(!bytes.value(db).is_empty()),
+            Type::Tuple(items) => Truthiness::from(!items.elements(db).is_empty()),
         }
     }
 

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -540,20 +540,18 @@ impl<'db> Type<'db> {
                 None
             }
             Type::Union(union) => {
-                let mut found_true = false;
-                let mut found_false = false;
+                let mut result: Option<bool> = None;
                 for value in union.elements(db) {
-                    match value.bool(db) {
-                        Some(true) => found_true = true,
-                        Some(false) => found_false = true,
-                        None => return None,
+                    if let Some(value) = value.bool(db) {
+                        if result.is_some_and(|result| value != result) {
+                            return None;
+                        }
+                        result = Some(value);
+                    } else {
+                        return None;
                     }
                 }
-                match (found_true, found_false) {
-                    (true, false) => Some(true),
-                    (false, true) => Some(false),
-                    _ => None,
-                }
+                result
             }
             Type::Intersection(_) => {
                 // TODO

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -525,10 +525,7 @@ impl<'db> Type<'db> {
     /// This is used to determine the value that would be returned when `__bool__` is called on an object
     pub fn bool(&self, db: &'db dyn Db) -> Option<bool> {
         match self {
-            Type::Any => None,
-            Type::Never => None,
-            Type::Unknown => None,
-            Type::Unbound => None,
+            Type::Any | Type::Never | Type::Unknown | Type::Unbound => None,
             Type::None => Some(false),
             Type::Function(_) | Type::RevealTypeFunction(_) => Some(true),
             Type::Module(_) => Some(true),

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -521,6 +521,39 @@ impl<'db> Type<'db> {
         }
     }
 
+    /// Resolves the boolean value of a type.
+    /// This is used to determine the value that would be returned by calling `bool()` on an object of this type.
+    pub fn boolean_value(&self, db: &'db dyn Db) -> Option<bool> {
+        match self {
+            Type::Any => None,
+            Type::Never => None,
+            Type::Unknown => None,
+            Type::Unbound => None,
+            Type::None => Some(false),
+            Type::Function(_) | Type::RevealTypeFunction(_) => Some(true),
+            Type::Module(_) => Some(true),
+            Type::Class(_) => Some(true),
+            Type::Instance(_) => {
+                // TODO
+                None
+            }
+            Type::Union(union) => {
+                // TODO
+                None
+            }
+            Type::Intersection(_) => {
+                // TODO
+                None
+            }
+            Type::IntLiteral(num) => Some(*num != 0),
+            Type::BooleanLiteral(bool) => Some(*bool),
+            Type::StringLiteral(str) => Some(!str.value(db).is_empty()),
+            Type::LiteralString => None,
+            Type::BytesLiteral(bytes) => Some(!bytes.value(db).is_empty()),
+            Type::Tuple(items) => Some(!items.elements(db).is_empty()),
+        }
+    }
+
     /// Return the type resulting from calling an object of this type.
     ///
     /// Returns `None` if `self` is not a callable type.

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -522,8 +522,8 @@ impl<'db> Type<'db> {
     }
 
     /// Resolves the boolean value of a type.
-    /// This is used to determine the value that would be returned by calling `bool()` on an object of this type.
-    pub fn boolean_value(&self, db: &'db dyn Db) -> Option<bool> {
+    /// This is used to determine the value that would be returned when `__bool__` is called on an object
+    pub fn bool(&self, db: &'db dyn Db) -> Option<bool> {
         match self {
             Type::Any => None,
             Type::Never => None,
@@ -538,7 +538,7 @@ impl<'db> Type<'db> {
                 let inner_values = union
                     .elements(db)
                     .iter()
-                    .map(|elem| elem.boolean_value(db))
+                    .map(|elem| elem.bool(db))
                     .collect::<FxOrderSet<_>>();
                 let mut found_true = false;
                 let mut found_false = false;
@@ -1267,7 +1267,7 @@ mod tests {
     #[test_case(Ty::Union(vec![Ty::IntLiteral(1), Ty::IntLiteral(2)]))]
     fn is_truthy(ty: Ty) {
         let db = setup_db();
-        assert_eq!(ty.into_type(&db).boolean_value(&db), Some(true));
+        assert_eq!(ty.into_type(&db).bool(&db), Some(true));
     }
 
     #[test_case(Ty::Tuple(vec![]))]
@@ -1276,7 +1276,7 @@ mod tests {
     #[test_case(Ty::Union(vec![Ty::IntLiteral(0), Ty::IntLiteral(0)]))]
     fn is_falsy(ty: Ty) {
         let db = setup_db();
-        assert_eq!(ty.into_type(&db).boolean_value(&db), Some(false));
+        assert_eq!(ty.into_type(&db).bool(&db), Some(false));
     }
 
     #[test_case(Ty::BuiltinInstance("str"))]
@@ -1285,6 +1285,6 @@ mod tests {
     #[test_case(Ty::Union(vec![Ty::BuiltinInstance("str"), Ty::IntLiteral(1)]))]
     fn boolean_value_is_unknown(ty: Ty) {
         let db = setup_db();
-        assert_eq!(ty.into_type(&db).boolean_value(&db), None);
+        assert_eq!(ty.into_type(&db).bool(&db), None);
     }
 }

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -6135,4 +6135,33 @@ mod tests {
         assert_public_ty(&db, "/src/a.py", "g", r#"Literal[""]"#);
         Ok(())
     }
+
+    #[test]
+    fn boolean_complex_expression() -> anyhow::Result<()> {
+        let mut db = setup_db();
+
+        db.write_dedented(
+            "/src/a.py",
+            r#"
+            def foo() -> str:
+                pass
+
+            a = "x" and "y" or "z"
+            b = "x" or "y" and "z"
+            c = "" and "y" or "z"
+            d = "" or "y" and "z"
+            e = "x" and "y" or ""
+            f = "x" or "y" and ""
+
+            "#,
+        )?;
+
+        assert_public_ty(&db, "/src/a.py", "a", r#"Literal["y"]"#);
+        assert_public_ty(&db, "/src/a.py", "b", r#"Literal["x"]"#);
+        assert_public_ty(&db, "/src/a.py", "c", r#"Literal["z"]"#);
+        assert_public_ty(&db, "/src/a.py", "d", r#"Literal["z"]"#);
+        assert_public_ty(&db, "/src/a.py", "e", r#"Literal["y"]"#);
+        assert_public_ty(&db, "/src/a.py", "f", r#"Literal["x"]"#);
+        Ok(())
+    }
 }

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -2327,7 +2327,7 @@ impl<'db> TypeInferenceBuilder<'db> {
             .map(|value| self.infer_expression(value))
             .collect();
         for (i, value_type) in inferred_types.iter().enumerate() {
-            let boolean_value = value_type.boolean_value(self.db);
+            let boolean_value = value_type.bool(self.db);
             if let Some(boolean_value) = boolean_value {
                 let is_last = i == values.len() - 1;
                 match (boolean_value, is_last, op) {

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -2322,14 +2322,17 @@ impl<'db> TypeInferenceBuilder<'db> {
             values,
         } = bool_op;
         let mut value_tys = Vec::new();
-        for (i, value) in values.iter().enumerate() {
-            let value_type = self.infer_expression(value);
+        let inferred_types: Vec<Type<'db>> = values
+            .iter()
+            .map(|value| self.infer_expression(value))
+            .collect();
+        for (i, value_type) in inferred_types.iter().enumerate() {
             let boolean_value = value_type.boolean_value(self.db);
             if let Some(boolean_value) = boolean_value {
                 let is_last = i == values.len() - 1;
                 match (boolean_value, is_last, op) {
                     (true, false, ast::BoolOp::And) => continue,
-                    (false, _, ast::BoolOp::And) => return value_type,
+                    (false, _, ast::BoolOp::And) => return *value_type,
                     (true, _, ast::BoolOp::Or) => {
                         value_tys.push(value_type);
                         break;

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -6086,9 +6086,9 @@ mod tests {
         assert_public_ty(&db, "/src/a.py", "b", r#"Literal["x"]"#);
         assert_public_ty(&db, "/src/a.py", "c", r#"Literal["y"]"#);
         assert_public_ty(&db, "/src/a.py", "d", r#"Literal["z"]"#);
-        assert_public_ty(&db, "/src/a.py", "e", r#"Literal[True]"#);
-        assert_public_ty(&db, "/src/a.py", "f", r#"Literal[False]"#);
-        assert_public_ty(&db, "/src/a.py", "g", r#"str | Literal[False]"#);
+        assert_public_ty(&db, "/src/a.py", "e", "Literal[True]");
+        assert_public_ty(&db, "/src/a.py", "f", "Literal[False]");
+        assert_public_ty(&db, "/src/a.py", "g", "str | Literal[False]");
 
         Ok(())
     }
@@ -6115,8 +6115,8 @@ mod tests {
 
         assert_public_ty(&db, "/src/a.py", "a", "Literal[False]");
         assert_public_ty(&db, "/src/a.py", "b", "Literal[False]");
-        assert_public_ty(&db, "/src/a.py", "c", r#"Literal[False]"#);
-        assert_public_ty(&db, "/src/a.py", "d", r#"str | Literal[True]"#);
+        assert_public_ty(&db, "/src/a.py", "c", "Literal[False]");
+        assert_public_ty(&db, "/src/a.py", "d", "str | Literal[True]");
         assert_public_ty(&db, "/src/a.py", "e", r#"Literal["z"]"#);
         assert_public_ty(&db, "/src/a.py", "f", r#"Literal[""]"#);
         assert_public_ty(&db, "/src/a.py", "g", r#"Literal[""]"#);

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -2331,8 +2331,8 @@ impl<'db> TypeInferenceBuilder<'db> {
             match (boolean_value, is_last, op) {
                 (Truthiness::Ambiguous, _, _) => value_tys.push(value_type),
                 (Truthiness::AlwaysTrue, false, ast::BoolOp::And) => continue,
-                (Truthiness::AlwaysFalse, _, ast::BoolOp::And) => return *value_type,
-                (Truthiness::AlwaysTrue, _, ast::BoolOp::Or) => {
+                (Truthiness::AlwaysTrue, _, ast::BoolOp::Or)
+                | (Truthiness::AlwaysFalse, _, ast::BoolOp::And) => {
                     value_tys.push(value_type);
                     break;
                 }
@@ -6079,6 +6079,7 @@ mod tests {
             e = False or True
             f = False or False
             g = foo() or False
+            h = foo() or True
             ",
         )?;
 
@@ -6089,6 +6090,7 @@ mod tests {
         assert_public_ty(&db, "/src/a.py", "e", "Literal[True]");
         assert_public_ty(&db, "/src/a.py", "f", "Literal[False]");
         assert_public_ty(&db, "/src/a.py", "g", "str | Literal[False]");
+        assert_public_ty(&db, "/src/a.py", "h", "str | Literal[True]");
 
         Ok(())
     }
@@ -6115,7 +6117,7 @@ mod tests {
 
         assert_public_ty(&db, "/src/a.py", "a", "Literal[False]");
         assert_public_ty(&db, "/src/a.py", "b", "Literal[False]");
-        assert_public_ty(&db, "/src/a.py", "c", "Literal[False]");
+        assert_public_ty(&db, "/src/a.py", "c", "str | Literal[False]");
         assert_public_ty(&db, "/src/a.py", "d", "str | Literal[True]");
         assert_public_ty(&db, "/src/a.py", "e", r#"Literal["z"]"#);
         assert_public_ty(&db, "/src/a.py", "f", r#"Literal[""]"#);


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Add boolean operator (`and` and `or`) support for several types. I'm pretty new to Rust so any feedback would be great. 

A new `Type::bool` function is created which may also help in https://github.com/astral-sh/ruff/pull/13432 as well.
Contributes to [#12701](https://github.com/astral-sh/ruff/issues/12701)

## Test Plan
Cargo tests
<!-- How was it tested? -->
