### PR TITLE
Fix formatting for analyze `direction` values

### DIFF
--- a/crates/ruff_workspace/src/options.rs
+++ b/crates/ruff_workspace/src/options.rs
@@ -3355,8 +3355,8 @@ pub struct AnalyzeOptions {
     /// Whether to generate a map from file to files that it depends on (dependencies) or files that
     /// depend on it (dependents).
     #[option(
-        default = r#"\"dependencies\""#,
-        value_type = "\"dependents\" | \"dependencies\"",
+        default = r#""dependencies""#,
+        value_type = r#""dependents" | "dependencies""#,
         example = r#"
             direction = "dependencies"
         "#


### PR DESCRIPTION
## Summary

Noticed this in the docs:

![image](https://github.com/user-attachments/assets/14c6e95d-7aa7-444c-8666-4ce030c5290b)


## Test Plan

generated the docs with my changes

![image](https://github.com/user-attachments/assets/46e46fed-1348-4b4a-96ba-3346ca80d11a)
