### PR TITLE
Avoid panic when analyze graph hits broken pipe

### DIFF
--- a/crates/ruff/src/commands/analyze_graph.rs
+++ b/crates/ruff/src/commands/analyze_graph.rs
@@ -10,6 +10,7 @@ use ruff_linter::{warn_user, warn_user_once};
 use ruff_python_ast::{PySourceType, SourceType};
 use ruff_workspace::resolver::{match_exclusion, python_files_in_path, ResolvedFile};
 use rustc_hash::FxHashMap;
+use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
@@ -174,7 +175,11 @@ pub(crate) fn analyze_graph(
     };
 
     // Print to JSON.
-    println!("{}", serde_json::to_string_pretty(&import_map)?);
+    writeln!(
+        std::io::stdout(),
+        "{}",
+        serde_json::to_string_pretty(&import_map)?
+    )?;
 
     std::mem::forget(db);
 


### PR DESCRIPTION
## Summary

I think we should also make the change that @BurntSushi recommended in the linked issue, but this gets rid of the panic.

See: https://github.com/astral-sh/ruff/issues/13483

See: https://github.com/astral-sh/ruff/issues/13442

## Test Plan

```
warning: `ruff analyze graph` is experimental and may change without warning
{
  "/Users/crmarsh/workspace/django/django/__init__.py": [
    "/Users/crmarsh/workspace/django/django/apps/__init__.py",
    "/Users/crmarsh/workspace/django/django/conf/__init__.py",
    "/Users/crmarsh/workspace/django/django/urls/__init__.py",
    "/Users/crmarsh/workspace/django/django/utils/log.py",
    "/Users/crmarsh/workspace/django/django/utils/version.py"
  ],
  "/Users/crmarsh/workspace/django/django/__main__.py": [
    "/Users/crmarsh/workspace/django/django/core/management/__init__.py"
ruff failed
  Cause: Broken pipe (os error 32)
```
