### PR TITLE
Detect basic wildcard imports in ruff analyze graph

### DIFF
--- a/crates/ruff_graph/src/collector.rs
+++ b/crates/ruff_graph/src/collector.rs
@@ -90,8 +90,10 @@ impl<'ast> SourceOrderVisitor<'ast> for Collector<'_> {
                         components.extend(module.split('.'));
                     }
 
-                    // Add the alias name.
-                    components.push(alias.name.as_str());
+                    // Add the alias name, unless it's a wildcard import.
+                    if alias.name.as_str() != "*" {
+                        components.push(alias.name.as_str());
+                    }
 
                     if let Some(module_name) = ModuleName::from_components(components) {
                         self.imports.push(CollectedImport::ImportFrom(module_name));


### PR DESCRIPTION
## Summary

I guess we can just ignore the `*` entirely for now? This will add the `__init__.py` for anything that's importing a package.
