### PR TITLE
Feat/unknown kinds

### DIFF
--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -886,7 +886,7 @@ impl<'db> IterationOutcome<'db> {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum UnknownTypeKind {
     /// Temporary variant that indicates that we *should*
     /// be able to infer a type here in due course, but currently can't

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -381,7 +381,7 @@ impl<'db> Type<'db> {
         match self {
             Type::Union(union) => union
                 .elements(db)
-                .into_iter()
+                .iter()
                 .fold(UnionBuilder::new(db), |builder, ty| {
                     builder.add(transform_fn(*ty))
                 })
@@ -893,7 +893,7 @@ impl<'db> IterationOutcome<'db> {
 
 // When it really matters to distinguish between different kinds of `Unknown` types
 // (see `PartialEq` implementation), we use the representation as `u8`
-#[derive(Debug, Clone, Copy, Eq, Hash)]
+#[derive(Debug, Clone, Copy, Eq)]
 #[repr(u8)]
 pub enum UnknownTypeKind {
     /// Temporary variant that indicates that we *should*
@@ -927,7 +927,7 @@ pub enum UnknownTypeKind {
     SecondOrder,
 
     /// Special kind for intersections that is equal to all other kinds. This allows to consider a
-    /// single Type::Unknown(_) in intersections. Should not be used in other contexts.
+    /// single `Type::Unknown(_)` in intersections. Should not be used in other contexts.
     AllKinds,
 }
 
@@ -938,6 +938,13 @@ impl PartialEq for UnknownTypeKind {
             (UnknownTypeKind::AllKinds, _) | (_, UnknownTypeKind::AllKinds) => true,
             _ => *self as u8 == *other as u8,
         }
+    }
+}
+
+impl std::hash::Hash for UnknownTypeKind {
+    // Deriving `Hash` with an explicit implementation of `PartialEq` is flagged by clippy
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        (*self as u8).hash(state);
     }
 }
 

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -919,6 +919,16 @@ pub enum UnknownTypeKind {
     SecondOrder,
 }
 
+impl UnknownTypeKind {
+    pub(crate) fn union(self, other: Self) -> Self {
+        if self == other {
+            self
+        } else {
+            UnknownTypeKind::SecondOrder
+        }
+    }
+}
+
 #[salsa::interned]
 pub struct FunctionType<'db> {
     /// name of the function at definition

--- a/crates/red_knot_python_semantic/src/types/builder.rs
+++ b/crates/red_knot_python_semantic/src/types/builder.rs
@@ -534,10 +534,7 @@ mod tests {
             .expect_intersection();
 
         assert_eq!(intersection.pos_vec(&db), &[t0]);
-        assert_eq!(
-            intersection.neg_vec(&db),
-            &[Type::Unknown(kind1.union(kind2))]
-        );
+        assert_eq!(intersection.neg_vec(&db), &[Type::Unknown(kind1)]);
     }
 
     #[test]

--- a/crates/red_knot_python_semantic/src/types/builder.rs
+++ b/crates/red_knot_python_semantic/src/types/builder.rs
@@ -79,15 +79,13 @@ impl<'db> UnionBuilder<'db> {
                     } else if element.is_subtype_of(self.db, ty) {
                         to_remove.push(index);
                     }
-                    match (element, ty) {
+
+                    if let (Type::Unknown(kind1), Type::Unknown(kind2)) = (element, ty) {
                         // Aggregate unknown types together as a single unknown type. Can only
                         // happen once because there can't be two unknown types in the same union.
-                        (Type::Unknown(kind1), Type::Unknown(kind2)) => {
-                            to_add = Type::Unknown(kind1.union(kind2));
-                            to_remove.push(index);
-                            break;
-                        }
-                        _ => {}
+                        to_add = Type::Unknown(kind1.union(kind2));
+                        to_remove.push(index);
+                        break;
                     }
                 }
 

--- a/crates/red_knot_python_semantic/src/types/display.rs
+++ b/crates/red_knot_python_semantic/src/types/display.rs
@@ -121,8 +121,6 @@ impl Display for DisplayUnionType<'_> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         let elements = self.ty.elements(self.db);
 
-        println!("elements: {:?}", elements);
-
         // Group literal types by kind.
         let mut grouped_literals = FxHashMap::default();
 

--- a/crates/red_knot_python_semantic/src/types/display.rs
+++ b/crates/red_knot_python_semantic/src/types/display.rs
@@ -64,7 +64,7 @@ impl Display for DisplayRepresentation<'_> {
         match self.ty {
             Type::Any => f.write_str("Any"),
             Type::Never => f.write_str("Never"),
-            Type::Unknown => f.write_str("Unknown"),
+            Type::Unknown(_) => f.write_str("Unknown"),
             Type::Unbound => f.write_str("Unbound"),
             Type::None => f.write_str("None"),
             Type::Module(file) => {

--- a/crates/red_knot_python_semantic/src/types/display.rs
+++ b/crates/red_knot_python_semantic/src/types/display.rs
@@ -64,6 +64,8 @@ impl Display for DisplayRepresentation<'_> {
         match self.ty {
             Type::Any => f.write_str("Any"),
             Type::Never => f.write_str("Never"),
+            // REVIEWERS: should we display 'RedKnotLimitation' differently?
+            // => intent: any test including 'red-knot-limitation' should be updated one day
             Type::Unknown(_) => f.write_str("Unknown"),
             Type::Unbound => f.write_str("Unbound"),
             Type::None => f.write_str("None"),
@@ -118,6 +120,8 @@ struct DisplayUnionType<'db> {
 impl Display for DisplayUnionType<'_> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         let elements = self.ty.elements(self.db);
+
+        println!("elements: {:?}", elements);
 
         // Group literal types by kind.
         let mut grouped_literals = FxHashMap::default();
@@ -338,7 +342,7 @@ mod tests {
         let mod_file = system_path_to_file(&db, "src/main.py").expect("Expected file to exist.");
 
         let union_elements = &[
-            Type::Unknown,
+            Type::Unknown(crate::types::UnknownTypeKind::TypeError),
             Type::IntLiteral(-1),
             global_symbol_ty(&db, mod_file, "A"),
             Type::StringLiteral(StringLiteralType::new(&db, Box::from("A"))),


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

### Previous Work

With https://github.com/astral-sh/ruff/pull/12986, @AlexWaygood tried to introduce a lower level of granularity into the `Unknown` type, similarly to what [mypy does for any](https://github.com/python/mypy/blob/fe15ee69b9225f808f8ed735671b73c31ae1bed8/mypy/types.py#L187-L215).

The main benefits (he targeted) were related to `unresolved-import` diagnostics.

### Current Approach

I rebased Alex's PR and continued his work following [some comments](https://github.com/astral-sh/ruff/pull/13395#issuecomment-2359136916) on a previous PR.

I would like to take his work as a basis to achieve a slightly different objective. This PR does not target enabling any specific user-facing feature. It's attempting to find a way for us to record more accurate information when we have it (e.g. detail the current `Unknown` into multiple kinds) without breaking other functionalities.

As a benefit, I hope this will allow us to
- Debug more comfortably complicated cases with all the information needed
  - Even when this additional information is not required to make the program work
- Gradually maintaining and introducing this additional information is easier early in the project than later
  - If some of this ends up being valuable for user-facing features
- Distinguish between expected behaviour & not implemented branches (`RedKnotLimitation`)
- Pave the way for the same pattern applied to `Any` (if mypy needs it, maybe we will too)

This PR is a draft and doesn't have all the answers, but I'll try to address the limiting factors that led Alex to close his previous work

### Previous Objections

#### Better alternative for `unresolved-imports`

One of the critical objections was that the previous PR's main goal could be achieved with an easier solution. See [this comment](https://github.com/astral-sh/ruff/pull/12986#issuecomment-2304626014).

I think this wouldn't apply here as I have a different core objective with this PR.

####  Behaviour for union

For unions, multiple `UnknownKindType` are aggregated together through the method
```rust
impl UnknownTypeKind {
    /// Method to aggregate multiple `UnknownTypeKind`s when they interact in any context
    pub(crate) fn union(self, other: Self) -> Self;
}
```
The specific of which implementation makes the most sense depends on how we use unions. There are many options. The most trivial would be to only return one kind (e.g. the first found). The most complicated would be to record a bitflag of all kinds encountered.

#### Behaviour for intersections

For intersections, I tried out an implementation with a special kind, `AllKinds`, which is equal to all other kinds. 

There can only be one kind of Unknown in a positive or negative intersection, making all unknown kinds valid (or invalid) for an intersection that contains any other unknown kind.

Another idea I had would be to make all `UnknownKind` indistinguishable by `Eq` & `Hash` so only code using `match` would make difference between the `UnknownTypeKind`, if they need to do so. I didn't implement this in the draft because I'm not sure it's a good idea. 

## Test Plan

- The core element is that all existing behaviour should not be impacted by this specialization of `Unknown`
- Added some tests for the behaviour of `Union` and `Intersection` that requires additional code

**P.S:** this is a draft, any feedback is welcome. I can try any implementation you'd like to see for the different problems stated above. If this PR's cost/value isn't worth it, no problem with closing!