### PR TITLE
Expose internal types as public access

### DIFF
--- a/crates/ruff_python_parser/src/lib.rs
+++ b/crates/ruff_python_parser/src/lib.rs
@@ -67,7 +67,7 @@
 use std::iter::FusedIterator;
 use std::ops::Deref;
 
-pub use crate::error::{FStringErrorType, ParseError, ParseErrorType};
+pub use crate::error::{FStringErrorType, LexicalErrorType, ParseError, ParseErrorType};
 pub use crate::token::{Token, TokenKind};
 
 use crate::parser::Parser;


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Thanks for providing such a powerful project! 
I try to use `ruff_python_parser` as tokenizer for my toy python REPL project, https://github.com/zao111222333/pyapp.
Everything is so great besides some necessary types/APIs is internal rightnow. And I request expose them. Thanks again!

btw, here is a small example for the python REPL, `ruff_python_parser` is used to highlight & incomplete detect.
![](https://raw.githubusercontent.com/zao111222333/pyapp/refs/heads/main/demo.svg)

## Test Plan

I believe those changes will not change the functionality, so no test plan :)