### PR TITLE
Disable the `typeset` plugin

### DIFF
--- a/mkdocs.template.yml
+++ b/mkdocs.template.yml
@@ -62,7 +62,6 @@ markdown_extensions:
       alternate_style: true
 plugins:
   - search
-  - typeset
 extra_css:
   - stylesheets/extra.css
 extra_javascript:


### PR DESCRIPTION
## Summary

There seems to be a bad interaction between enabling anchorlinks and the `typeset` plugin. I think the former is more important than the latter... so disabling the latter for now.

## Test Plan

Before:

![Screenshot 2024-09-25 at 7 53 21 PM](https://github.com/user-attachments/assets/bf7c70bb-19ab-4ece-9709-4c297f8ba67b)

After:

![Screenshot 2024-09-25 at 7 53 12 PM](https://github.com/user-attachments/assets/e767a575-1664-4288-aecb-82e8b1b1a7bd)


