### PR TITLE
Don't skip over imports and other nodes containing nested statements in import collector

### DIFF
--- a/crates/ruff/tests/.analyze_graph.rs.pending-snap
+++ b/crates/ruff/tests/.analyze_graph.rs.pending-snap
@@ -1,0 +1,6 @@
+{"run_id":"1727350954-469459432","line":315,"new":{"module_name":"analyze_graph","snapshot_name":"nested_imports","metadata":{"source":"crates/ruff/tests/analyze_graph.rs","assertion_line":315,"info":{"program":"ruff","args":["analyze","graph","--preview"]}},"snapshot":"success: true\nexit_code: 0\n----- stdout -----\n{\n  \"ruff/__init__.py\": [],\n  \"ruff/a.py\": [],\n  \"ruff/b.py\": [\n    \"ruff/c.py\"\n  ],\n  \"ruff/c.py\": [],\n  \"ruff/d.py\": []\n}\n\n----- stderr -----\n"},"old":{"module_name":"analyze_graph","metadata":{},"snapshot":"success: true\nexit_code: 0\n----- stdout -----\n{\n  \"ruff/__init__.py\": [],\n  \"ruff/a.py\": [\n    \"ruff/b.py\"\n  ],\n  \"ruff/b.py\": [\n    \"ruff/c.py\",\n    \"ruff/d.py\"\n  ],\n  \"ruff/c.py\": [],\n  \"ruff/d.py\": []\n}\n\n----- stderr -----"}}
+{"run_id":"1727351009-933385109","line":255,"new":null,"old":null}
+{"run_id":"1727351009-933385109","line":153,"new":null,"old":null}
+{"run_id":"1727351009-933385109","line":69,"new":null,"old":null}
+{"run_id":"1727351009-933385109","line":314,"new":null,"old":null}
+{"run_id":"1727351009-933385109","line":202,"new":null,"old":null}

--- a/crates/ruff/tests/.analyze_graph.rs.pending-snap
+++ b/crates/ruff/tests/.analyze_graph.rs.pending-snap
@@ -1,6 +1,0 @@
-{"run_id":"1727350954-469459432","line":315,"new":{"module_name":"analyze_graph","snapshot_name":"nested_imports","metadata":{"source":"crates/ruff/tests/analyze_graph.rs","assertion_line":315,"info":{"program":"ruff","args":["analyze","graph","--preview"]}},"snapshot":"success: true\nexit_code: 0\n----- stdout -----\n{\n  \"ruff/__init__.py\": [],\n  \"ruff/a.py\": [],\n  \"ruff/b.py\": [\n    \"ruff/c.py\"\n  ],\n  \"ruff/c.py\": [],\n  \"ruff/d.py\": []\n}\n\n----- stderr -----\n"},"old":{"module_name":"analyze_graph","metadata":{},"snapshot":"success: true\nexit_code: 0\n----- stdout -----\n{\n  \"ruff/__init__.py\": [],\n  \"ruff/a.py\": [\n    \"ruff/b.py\"\n  ],\n  \"ruff/b.py\": [\n    \"ruff/c.py\",\n    \"ruff/d.py\"\n  ],\n  \"ruff/c.py\": [],\n  \"ruff/d.py\": []\n}\n\n----- stderr -----"}}
-{"run_id":"1727351009-933385109","line":255,"new":null,"old":null}
-{"run_id":"1727351009-933385109","line":153,"new":null,"old":null}
-{"run_id":"1727351009-933385109","line":69,"new":null,"old":null}
-{"run_id":"1727351009-933385109","line":314,"new":null,"old":null}
-{"run_id":"1727351009-933385109","line":202,"new":null,"old":null}

--- a/crates/ruff/tests/analyze_graph.rs
+++ b/crates/ruff/tests/analyze_graph.rs
@@ -121,6 +121,100 @@ fn dependents() -> Result<()> {
         def f(): pass
     "#})?;
 
+    insta::with_settings!({
+        filters => INSTA_FILTERS.to_vec(),
+    }, {
+        assert_cmd_snapshot!(command().arg("--direction").arg("dependents").current_dir(&root), @r###"
+            success: true
+            exit_code: 0
+            ----- stdout -----
+            {
+              "ruff/__init__.py": [],
+              "ruff/a.py": [],
+              "ruff/b.py": [
+                "ruff/a.py"
+              ],
+              "ruff/c.py": [
+                "ruff/b.py"
+              ],
+              "ruff/d.py": [
+                "ruff/c.py"
+              ],
+              "ruff/e.py": [
+                "ruff/d.py"
+              ]
+            }
+
+            ----- stderr -----
+            "###);
+    });
+
+    Ok(())
+}
+
+#[test]
+fn string_detection() -> Result<()> {
+    let tempdir = TempDir::new()?;
+
+    let root = ChildPath::new(tempdir.path());
+
+    root.child("ruff").child("__init__.py").write_str("")?;
+    root.child("ruff")
+        .child("a.py")
+        .write_str(indoc::indoc! {r#"
+        import ruff.b
+    "#})?;
+    root.child("ruff")
+        .child("b.py")
+        .write_str(indoc::indoc! {r#"
+        import importlib
+
+        importlib.import_module("ruff.c")
+    "#})?;
+    root.child("ruff").child("c.py").write_str("")?;
+
+    insta::with_settings!({
+        filters => INSTA_FILTERS.to_vec(),
+    }, {
+        assert_cmd_snapshot!(command().current_dir(&root), @r###"
+            success: true
+            exit_code: 0
+            ----- stdout -----
+            {
+              "ruff/__init__.py": [],
+              "ruff/a.py": [
+                "ruff/b.py"
+              ],
+              "ruff/b.py": [],
+              "ruff/c.py": []
+            }
+
+            ----- stderr -----
+            "###);
+    });
+
+    insta::with_settings!({
+        filters => INSTA_FILTERS.to_vec(),
+    }, {
+        assert_cmd_snapshot!(command().arg("--detect-string-imports").current_dir(&root), @r###"
+            success: true
+            exit_code: 0
+            ----- stdout -----
+            {
+              "ruff/__init__.py": [],
+              "ruff/a.py": [
+                "ruff/b.py"
+              ],
+              "ruff/b.py": [
+                "ruff/c.py"
+              ],
+              "ruff/c.py": []
+            }
+
+            ----- stderr -----
+            "###);
+    });
+
     Ok(())
 }
 

--- a/crates/ruff/tests/analyze_graph.rs
+++ b/crates/ruff/tests/analyze_graph.rs
@@ -25,7 +25,11 @@ const INSTA_FILTERS: &[(&str, &str)] = &[
     (r"\\", "/"),
 ];
 
-fn setup_sample_project(root: &ChildPath) -> Result<()> {
+#[test]
+fn dependencies() -> Result<()> {
+    let tempdir = TempDir::new()?;
+    let root = ChildPath::new(tempdir.path());
+
     root.child("ruff").child("__init__.py").write_str("")?;
     root.child("ruff")
         .child("a.py")
@@ -52,16 +56,6 @@ fn setup_sample_project(root: &ChildPath) -> Result<()> {
         .write_str(indoc::indoc! {r#"
         def f(): pass
     "#})?;
-
-    Ok(())
-}
-
-#[test]
-fn dependencies() -> Result<()> {
-    let tempdir = TempDir::new()?;
-    let root = ChildPath::new(tempdir.path());
-
-    setup_sample_project(&root)?;
 
     insta::with_settings!({
         filters => INSTA_FILTERS.to_vec(),

--- a/crates/ruff_graph/src/collector.rs
+++ b/crates/ruff_graph/src/collector.rs
@@ -46,6 +46,12 @@ impl<'ast> SourceOrderVisitor<'ast> for Collector<'_> {
                     | AnyNodeRef::StmtWith(_)
                     | AnyNodeRef::StmtIf(_)
                     | AnyNodeRef::StmtTry(_)
+                    | AnyNodeRef::StmtMatch(_)
+                    | AnyNodeRef::MatchCase(_)
+                    | AnyNodeRef::StmtImport(_)
+                    | AnyNodeRef::StmtImportFrom(_)
+                    | AnyNodeRef::ElifElseClause(_)
+                    | AnyNodeRef::ExceptHandlerExceptHandler(_)
             )
         {
             TraversalSignal::Traverse

--- a/crates/ruff_graph/src/collector.rs
+++ b/crates/ruff_graph/src/collector.rs
@@ -1,8 +1,8 @@
 use red_knot_python_semantic::ModuleName;
 use ruff_python_ast::visitor::source_order::{
-    walk_expr, walk_module, walk_stmt, SourceOrderVisitor, TraversalSignal,
+    walk_expr, walk_module, walk_stmt, SourceOrderVisitor,
 };
-use ruff_python_ast::{self as ast, AnyNodeRef, Expr, Mod, Stmt};
+use ruff_python_ast::{self as ast, Expr, Mod, Stmt};
 
 /// Collect all imports for a given Python file.
 #[derive(Default, Debug)]
@@ -32,34 +32,6 @@ impl<'a> Collector<'a> {
 }
 
 impl<'ast> SourceOrderVisitor<'ast> for Collector<'_> {
-    fn enter_node(&mut self, node: AnyNodeRef<'ast>) -> TraversalSignal {
-        // If string detection is enabled, we have to visit everything. Otherwise, we should only
-        // visit compounds statements, which can contain import statements.
-        if self.string_imports
-            || matches!(
-                node,
-                AnyNodeRef::ModModule(_)
-                    | AnyNodeRef::StmtFunctionDef(_)
-                    | AnyNodeRef::StmtClassDef(_)
-                    | AnyNodeRef::StmtWhile(_)
-                    | AnyNodeRef::StmtFor(_)
-                    | AnyNodeRef::StmtWith(_)
-                    | AnyNodeRef::StmtIf(_)
-                    | AnyNodeRef::StmtTry(_)
-                    | AnyNodeRef::StmtMatch(_)
-                    | AnyNodeRef::MatchCase(_)
-                    | AnyNodeRef::StmtImport(_)
-                    | AnyNodeRef::StmtImportFrom(_)
-                    | AnyNodeRef::ElifElseClause(_)
-                    | AnyNodeRef::ExceptHandlerExceptHandler(_)
-            )
-        {
-            TraversalSignal::Traverse
-        } else {
-            TraversalSignal::Skip
-        }
-    }
-
     fn visit_stmt(&mut self, stmt: &'ast Stmt) {
         match stmt {
             Stmt::ImportFrom(ast::StmtImportFrom {
@@ -113,8 +85,37 @@ impl<'ast> SourceOrderVisitor<'ast> for Collector<'_> {
                     }
                 }
             }
-            _ => {
+            Stmt::FunctionDef(_)
+            | Stmt::ClassDef(_)
+            | Stmt::While(_)
+            | Stmt::If(_)
+            | Stmt::With(_)
+            | Stmt::Match(_)
+            | Stmt::Try(_)
+            | Stmt::For(_) => {
+                // Always traverse into compound statements.
                 walk_stmt(self, stmt);
+            }
+
+            Stmt::Return(_)
+            | Stmt::Delete(_)
+            | Stmt::Assign(_)
+            | Stmt::AugAssign(_)
+            | Stmt::AnnAssign(_)
+            | Stmt::TypeAlias(_)
+            | Stmt::Raise(_)
+            | Stmt::Assert(_)
+            | Stmt::Global(_)
+            | Stmt::Nonlocal(_)
+            | Stmt::Expr(_)
+            | Stmt::Pass(_)
+            | Stmt::Break(_)
+            | Stmt::Continue(_)
+            | Stmt::IpyEscapeCommand(_) => {
+                // Only traverse simple statements when string imports is enabled.
+                if self.string_imports {
+                    walk_stmt(self, stmt);
+                }
             }
         }
     }

--- a/crates/ruff_graph/src/lib.rs
+++ b/crates/ruff_graph/src/lib.rs
@@ -92,7 +92,7 @@ impl ModuleImports {
 }
 
 #[derive(Debug, Default)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ImportMap(BTreeMap<SystemPathBuf, ModuleImports>);
 
 impl ImportMap {

--- a/crates/ruff_graph/src/lib.rs
+++ b/crates/ruff_graph/src/lib.rs
@@ -1,13 +1,15 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use anyhow::Result;
+
+use ruff_db::system::{SystemPath, SystemPathBuf};
+use ruff_python_ast::helpers::to_module_path;
+use ruff_python_parser::{parse, Mode};
+
 use crate::collector::Collector;
 pub use crate::db::ModuleDb;
 use crate::resolver::Resolver;
 pub use crate::settings::{AnalyzeSettings, Direction};
-use anyhow::Result;
-use ruff_db::system::{SystemPath, SystemPathBuf};
-use ruff_python_ast::helpers::to_module_path;
-use ruff_python_parser::{parse, Mode};
-use serde::{Deserialize, Serialize};
-use std::collections::{BTreeMap, BTreeSet};
 
 mod collector;
 mod db;
@@ -15,7 +17,7 @@ mod resolver;
 mod settings;
 
 #[derive(Debug, Default)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ModuleImports(BTreeSet<SystemPathBuf>);
 
 impl ModuleImports {


### PR DESCRIPTION
## Summary

This is a follow up for https://github.com/astral-sh/ruff/pull/13441/

`enter_node` is called for every node and it's important that it returns `true` for any node between `ModModule` and an import statement, including the import statement itself. 

Getting this right in `enter_node` seems hard and it's easy to forget adding a new "include" when a new compound statement gets added. 

This PR moves the traversal logic into the `visist_stmt` by requiring explicit match arms for each statement. I think this is easier to understand
and less error prone.


Also... `enter_node` doesn't get call when a visitor overrides `visit_stmt`. That's an oversight from my side when designing the visitor. 