### PR TITLE
Fix codeblock dynamic line length calculation for indented examples

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/docstring_code_examples_dynamic_line_width.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/docstring_code_examples_dynamic_line_width.py
@@ -219,3 +219,72 @@ def doctest_extra_indent3():
     ...     df1, df2, df3, on="dt"
     ... )  # doctest: +IGNORE_RESULT
     """
+
+# See https://github.com/astral-sh/ruff/issues/13358
+def length_doctest():
+    """Get the length of the given list of numbers.
+
+    Args:
+        numbers: List of numbers.
+
+    Returns:
+        Integer length of the list of numbers.
+
+    Example:
+        >>> length([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20])
+        20
+    """
+
+
+def length_doctest_underindent():
+    """Get the length of the given list of numbers.
+
+        Args:
+            numbers: List of numbers.
+
+        Returns:
+            Integer length of the list of numbers.
+
+    Example:
+        >>> length([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20])
+        20
+    """
+
+
+# See https://github.com/astral-sh/ruff/issues/13358
+def length_markdown():
+    """Get the length of the given list of numbers.
+
+    Args:
+        numbers: List of numbers.
+
+    Returns:
+        Integer length of the list of numbers.
+
+    Example:
+
+        ```
+        length([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21])
+        ```
+    """
+
+
+# See https://github.com/astral-sh/ruff/issues/13358
+def length_rst():
+    """
+    Do cool stuff::
+
+        length([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21])
+    """
+    pass
+
+
+# See https://github.com/astral-sh/ruff/issues/13358
+def length_rst_in_section():
+    """
+    Examples:
+        Do cool stuff::
+
+            length([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20])
+    """
+    pass

--- a/crates/ruff_python_formatter/src/lib.rs
+++ b/crates/ruff_python_formatter/src/lib.rs
@@ -160,10 +160,7 @@ mod tests {
     use ruff_python_trivia::CommentRanges;
     use ruff_text_size::{TextRange, TextSize};
 
-    use crate::{
-        format_module_ast, format_module_source, format_range, DocstringCode, PreviewMode,
-        PyFormatOptions,
-    };
+    use crate::{format_module_ast, format_module_source, format_range, PyFormatOptions};
 
     /// Very basic test intentionally kept very similar to the CLI
     #[test]
@@ -191,16 +188,13 @@ if True:
     #[test]
     fn quick_test() {
         let source = r#"
-"""example.py file."""
-
-
-def length(numbers: list[int]) -> int:
-    """Get the length of the given list of numbers.
-    Example:
-      >>> length([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20])
-      20
-    """
-    return len(numbers)
+def main() -> None:
+    if True:
+        some_very_long_variable_name_abcdefghijk = Foo()
+        some_very_long_variable_name_abcdefghijk = some_very_long_variable_name_abcdefghijk[
+            some_very_long_variable_name_abcdefghijk.some_very_long_attribute_name
+            == "This is a very long string abcdefghijk"
+        ]
 
 "#;
         let source_type = PySourceType::Python;
@@ -209,9 +203,7 @@ def length(numbers: list[int]) -> int:
         let source_path = "code_inline.py";
         let parsed = parse(source, source_type.as_mode()).unwrap();
         let comment_ranges = CommentRanges::from(parsed.tokens());
-        let options = PyFormatOptions::from_extension(Path::new(source_path))
-            .with_preview(PreviewMode::Enabled)
-            .with_docstring_code(DocstringCode::Enabled);
+        let options = PyFormatOptions::from_extension(Path::new(source_path));
         let formatted = format_module_ast(&parsed, &comment_ranges, source, options).unwrap();
 
         // Uncomment the `dbg` to print the IR.

--- a/crates/ruff_python_formatter/src/lib.rs
+++ b/crates/ruff_python_formatter/src/lib.rs
@@ -160,7 +160,10 @@ mod tests {
     use ruff_python_trivia::CommentRanges;
     use ruff_text_size::{TextRange, TextSize};
 
-    use crate::{format_module_ast, format_module_source, format_range, PyFormatOptions};
+    use crate::{
+        format_module_ast, format_module_source, format_range, DocstringCode, PreviewMode,
+        PyFormatOptions,
+    };
 
     /// Very basic test intentionally kept very similar to the CLI
     #[test]
@@ -188,13 +191,16 @@ if True:
     #[test]
     fn quick_test() {
         let source = r#"
-def main() -> None:
-    if True:
-        some_very_long_variable_name_abcdefghijk = Foo()
-        some_very_long_variable_name_abcdefghijk = some_very_long_variable_name_abcdefghijk[
-            some_very_long_variable_name_abcdefghijk.some_very_long_attribute_name
-            == "This is a very long string abcdefghijk"
-        ]
+"""example.py file."""
+
+
+def length(numbers: list[int]) -> int:
+    """Get the length of the given list of numbers.
+    Example:
+      >>> length([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20])
+      20
+    """
+    return len(numbers)
 
 "#;
         let source_type = PySourceType::Python;
@@ -203,7 +209,9 @@ def main() -> None:
         let source_path = "code_inline.py";
         let parsed = parse(source, source_type.as_mode()).unwrap();
         let comment_ranges = CommentRanges::from(parsed.tokens());
-        let options = PyFormatOptions::from_extension(Path::new(source_path));
+        let options = PyFormatOptions::from_extension(Path::new(source_path))
+            .with_preview(PreviewMode::Enabled)
+            .with_docstring_code(DocstringCode::Enabled);
         let formatted = format_module_ast(&parsed, &comment_ranges, source, options).unwrap();
 
         // Uncomment the `dbg` to print the IR.

--- a/crates/ruff_python_formatter/src/preview.rs
+++ b/crates/ruff_python_formatter/src/preview.rs
@@ -44,3 +44,12 @@ pub(crate) fn is_empty_parameters_no_unnecessary_parentheses_around_return_value
 pub(crate) fn is_match_case_parentheses_enabled(context: &PyFormatContext) -> bool {
     context.is_preview()
 }
+
+/// This preview style fixes a bug with the docstring's `line-length` calculation when using the `dynamic` mode.
+/// The new style now respects the indent **inside** the docstring and reduces the `line-length` accordingly
+/// so that the docstring's code block fits into the global line-length setting.
+pub(crate) fn is_docstring_code_block_in_docstring_indent_enabled(
+    context: &PyFormatContext,
+) -> bool {
+    context.is_preview()
+}

--- a/crates/ruff_python_formatter/tests/snapshots/format@docstring_code_examples_dynamic_line_width.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@docstring_code_examples_dynamic_line_width.py.snap
@@ -225,6 +225,75 @@ def doctest_extra_indent3():
     ...     df1, df2, df3, on="dt"
     ... )  # doctest: +IGNORE_RESULT
     """
+
+# See https://github.com/astral-sh/ruff/issues/13358
+def length_doctest():
+    """Get the length of the given list of numbers.
+
+    Args:
+        numbers: List of numbers.
+
+    Returns:
+        Integer length of the list of numbers.
+
+    Example:
+        >>> length([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20])
+        20
+    """
+
+
+def length_doctest_underindent():
+    """Get the length of the given list of numbers.
+
+        Args:
+            numbers: List of numbers.
+
+        Returns:
+            Integer length of the list of numbers.
+
+    Example:
+        >>> length([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20])
+        20
+    """
+
+
+# See https://github.com/astral-sh/ruff/issues/13358
+def length_markdown():
+    """Get the length of the given list of numbers.
+
+    Args:
+        numbers: List of numbers.
+
+    Returns:
+        Integer length of the list of numbers.
+
+    Example:
+
+        ```
+        length([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21])
+        ```
+    """
+
+
+# See https://github.com/astral-sh/ruff/issues/13358
+def length_rst():
+    """
+    Do cool stuff::
+
+        length([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21])
+    """
+    pass
+
+
+# See https://github.com/astral-sh/ruff/issues/13358
+def length_rst_in_section():
+    """
+    Examples:
+        Do cool stuff::
+
+            length([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20])
+    """
+    pass
 ```
 
 ## Outputs
@@ -533,6 +602,76 @@ def doctest_extra_indent3():
     ...     df1, df2, df3, on="dt"
     ... )  # doctest: +IGNORE_RESULT
     """
+
+
+# See https://github.com/astral-sh/ruff/issues/13358
+def length_doctest():
+    """Get the length of the given list of numbers.
+
+    Args:
+        numbers: List of numbers.
+
+    Returns:
+        Integer length of the list of numbers.
+
+    Example:
+        >>> length([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20])
+        20
+    """
+
+
+def length_doctest_underindent():
+    """Get the length of the given list of numbers.
+
+        Args:
+            numbers: List of numbers.
+
+        Returns:
+            Integer length of the list of numbers.
+
+    Example:
+        >>> length([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20])
+        20
+    """
+
+
+# See https://github.com/astral-sh/ruff/issues/13358
+def length_markdown():
+    """Get the length of the given list of numbers.
+
+    Args:
+        numbers: List of numbers.
+
+    Returns:
+        Integer length of the list of numbers.
+
+    Example:
+
+        ```
+        length([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21])
+        ```
+    """
+
+
+# See https://github.com/astral-sh/ruff/issues/13358
+def length_rst():
+    """
+    Do cool stuff::
+
+        length([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21])
+    """
+    pass
+
+
+# See https://github.com/astral-sh/ruff/issues/13358
+def length_rst_in_section():
+    """
+    Examples:
+        Do cool stuff::
+
+            length([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20])
+    """
+    pass
 ```
 
 
@@ -555,6 +694,157 @@ def doctest_extra_indent3():
          """
  
  
+@@ -300,7 +302,28 @@
+         Integer length of the list of numbers.
+ 
+     Example:
+-        >>> length([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20])
++        >>> length([
++        ...     1,
++        ...     2,
++        ...     3,
++        ...     4,
++        ...     5,
++        ...     6,
++        ...     7,
++        ...     8,
++        ...     9,
++        ...     10,
++        ...     11,
++        ...     12,
++        ...     13,
++        ...     14,
++        ...     15,
++        ...     16,
++        ...     17,
++        ...     18,
++        ...     19,
++        ...     20,
++        ... ])
+         20
+     """
+ 
+@@ -315,7 +338,28 @@
+             Integer length of the list of numbers.
+ 
+     Example:
+-        >>> length([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20])
++        >>> length([
++        ...     1,
++        ...     2,
++        ...     3,
++        ...     4,
++        ...     5,
++        ...     6,
++        ...     7,
++        ...     8,
++        ...     9,
++        ...     10,
++        ...     11,
++        ...     12,
++        ...     13,
++        ...     14,
++        ...     15,
++        ...     16,
++        ...     17,
++        ...     18,
++        ...     19,
++        ...     20,
++        ... ])
+         20
+     """
+ 
+@@ -333,7 +377,29 @@
+     Example:
+ 
+         ```
+-        length([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21])
++        length([
++            1,
++            2,
++            3,
++            4,
++            5,
++            6,
++            7,
++            8,
++            9,
++            10,
++            11,
++            12,
++            13,
++            14,
++            15,
++            16,
++            17,
++            18,
++            19,
++            20,
++            21,
++        ])
+         ```
+     """
+ 
+@@ -343,7 +409,29 @@
+     """
+     Do cool stuff::
+ 
+-        length([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21])
++        length([
++            1,
++            2,
++            3,
++            4,
++            5,
++            6,
++            7,
++            8,
++            9,
++            10,
++            11,
++            12,
++            13,
++            14,
++            15,
++            16,
++            17,
++            18,
++            19,
++            20,
++            21,
++        ])
+     """
+     pass
+ 
+@@ -354,6 +442,27 @@
+     Examples:
+         Do cool stuff::
+ 
+-            length([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20])
++            length([
++                1,
++                2,
++                3,
++                4,
++                5,
++                6,
++                7,
++                8,
++                9,
++                10,
++                11,
++                12,
++                13,
++                14,
++                15,
++                16,
++                17,
++                18,
++                19,
++                20,
++            ])
+     """
+     pass
 ```
 
 
@@ -853,6 +1143,234 @@ def doctest_extra_indent3():
   --------
   >>> af1, af2, af3 = pl.align_frames(df1, df2, df3, on="dt")  # doctest: +IGNORE_RESULT
   """
+
+
+# See https://github.com/astral-sh/ruff/issues/13358
+def length_doctest():
+  """Get the length of the given list of numbers.
+
+  Args:
+      numbers: List of numbers.
+
+  Returns:
+      Integer length of the list of numbers.
+
+  Example:
+      >>> length([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20])
+      20
+  """
+
+
+def length_doctest_underindent():
+  """Get the length of the given list of numbers.
+
+      Args:
+          numbers: List of numbers.
+
+      Returns:
+          Integer length of the list of numbers.
+
+  Example:
+      >>> length([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20])
+      20
+  """
+
+
+# See https://github.com/astral-sh/ruff/issues/13358
+def length_markdown():
+  """Get the length of the given list of numbers.
+
+  Args:
+      numbers: List of numbers.
+
+  Returns:
+      Integer length of the list of numbers.
+
+  Example:
+
+      ```
+      length([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21])
+      ```
+  """
+
+
+# See https://github.com/astral-sh/ruff/issues/13358
+def length_rst():
+  """
+  Do cool stuff::
+
+      length([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21])
+  """
+  pass
+
+
+# See https://github.com/astral-sh/ruff/issues/13358
+def length_rst_in_section():
+  """
+  Examples:
+      Do cool stuff::
+
+          length([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20])
+  """
+  pass
+```
+
+
+#### Preview changes
+```diff
+--- Stable
++++ Preview
+@@ -290,7 +290,28 @@
+       Integer length of the list of numbers.
+ 
+   Example:
+-      >>> length([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20])
++      >>> length([
++      ...   1,
++      ...   2,
++      ...   3,
++      ...   4,
++      ...   5,
++      ...   6,
++      ...   7,
++      ...   8,
++      ...   9,
++      ...   10,
++      ...   11,
++      ...   12,
++      ...   13,
++      ...   14,
++      ...   15,
++      ...   16,
++      ...   17,
++      ...   18,
++      ...   19,
++      ...   20,
++      ... ])
+       20
+   """
+ 
+@@ -305,7 +326,28 @@
+           Integer length of the list of numbers.
+ 
+   Example:
+-      >>> length([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20])
++      >>> length([
++      ...   1,
++      ...   2,
++      ...   3,
++      ...   4,
++      ...   5,
++      ...   6,
++      ...   7,
++      ...   8,
++      ...   9,
++      ...   10,
++      ...   11,
++      ...   12,
++      ...   13,
++      ...   14,
++      ...   15,
++      ...   16,
++      ...   17,
++      ...   18,
++      ...   19,
++      ...   20,
++      ... ])
+       20
+   """
+ 
+@@ -323,7 +365,29 @@
+   Example:
+ 
+       ```
+-      length([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21])
++      length([
++        1,
++        2,
++        3,
++        4,
++        5,
++        6,
++        7,
++        8,
++        9,
++        10,
++        11,
++        12,
++        13,
++        14,
++        15,
++        16,
++        17,
++        18,
++        19,
++        20,
++        21,
++      ])
+       ```
+   """
+ 
+@@ -333,7 +397,29 @@
+   """
+   Do cool stuff::
+ 
+-      length([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21])
++      length([
++        1,
++        2,
++        3,
++        4,
++        5,
++        6,
++        7,
++        8,
++        9,
++        10,
++        11,
++        12,
++        13,
++        14,
++        15,
++        16,
++        17,
++        18,
++        19,
++        20,
++        21,
++      ])
+   """
+   pass
+ 
+@@ -344,6 +430,27 @@
+   Examples:
+       Do cool stuff::
+ 
+-          length([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20])
++          length([
++            1,
++            2,
++            3,
++            4,
++            5,
++            6,
++            7,
++            8,
++            9,
++            10,
++            11,
++            12,
++            13,
++            14,
++            15,
++            16,
++            17,
++            18,
++            19,
++            20,
++          ])
+   """
+   pass
 ```
 
 
@@ -1161,6 +1679,76 @@ def doctest_extra_indent3():
 	...     df1, df2, df3, on="dt"
 	... )  # doctest: +IGNORE_RESULT
 	"""
+
+
+# See https://github.com/astral-sh/ruff/issues/13358
+def length_doctest():
+	"""Get the length of the given list of numbers.
+
+	Args:
+	    numbers: List of numbers.
+
+	Returns:
+	    Integer length of the list of numbers.
+
+	Example:
+	    >>> length([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20])
+	    20
+	"""
+
+
+def length_doctest_underindent():
+	"""Get the length of the given list of numbers.
+
+	    Args:
+	        numbers: List of numbers.
+
+	    Returns:
+	        Integer length of the list of numbers.
+
+	Example:
+	    >>> length([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20])
+	    20
+	"""
+
+
+# See https://github.com/astral-sh/ruff/issues/13358
+def length_markdown():
+	"""Get the length of the given list of numbers.
+
+	Args:
+	    numbers: List of numbers.
+
+	Returns:
+	    Integer length of the list of numbers.
+
+	Example:
+
+	    ```
+	    length([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21])
+	    ```
+	"""
+
+
+# See https://github.com/astral-sh/ruff/issues/13358
+def length_rst():
+	"""
+	Do cool stuff::
+
+	    length([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21])
+	"""
+	pass
+
+
+# See https://github.com/astral-sh/ruff/issues/13358
+def length_rst_in_section():
+	"""
+	Examples:
+	    Do cool stuff::
+
+	        length([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20])
+	"""
+	pass
 ```
 
 
@@ -1183,6 +1771,157 @@ def doctest_extra_indent3():
  		"""
  
  
+@@ -300,7 +302,28 @@
+ 	    Integer length of the list of numbers.
+ 
+ 	Example:
+-	    >>> length([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20])
++	    >>> length([
++	    ...     1,
++	    ...     2,
++	    ...     3,
++	    ...     4,
++	    ...     5,
++	    ...     6,
++	    ...     7,
++	    ...     8,
++	    ...     9,
++	    ...     10,
++	    ...     11,
++	    ...     12,
++	    ...     13,
++	    ...     14,
++	    ...     15,
++	    ...     16,
++	    ...     17,
++	    ...     18,
++	    ...     19,
++	    ...     20,
++	    ... ])
+ 	    20
+ 	"""
+ 
+@@ -315,7 +338,28 @@
+ 	        Integer length of the list of numbers.
+ 
+ 	Example:
+-	    >>> length([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20])
++	    >>> length([
++	    ...     1,
++	    ...     2,
++	    ...     3,
++	    ...     4,
++	    ...     5,
++	    ...     6,
++	    ...     7,
++	    ...     8,
++	    ...     9,
++	    ...     10,
++	    ...     11,
++	    ...     12,
++	    ...     13,
++	    ...     14,
++	    ...     15,
++	    ...     16,
++	    ...     17,
++	    ...     18,
++	    ...     19,
++	    ...     20,
++	    ... ])
+ 	    20
+ 	"""
+ 
+@@ -333,7 +377,29 @@
+ 	Example:
+ 
+ 	    ```
+-	    length([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21])
++	    length([
++	        1,
++	        2,
++	        3,
++	        4,
++	        5,
++	        6,
++	        7,
++	        8,
++	        9,
++	        10,
++	        11,
++	        12,
++	        13,
++	        14,
++	        15,
++	        16,
++	        17,
++	        18,
++	        19,
++	        20,
++	        21,
++	    ])
+ 	    ```
+ 	"""
+ 
+@@ -343,7 +409,29 @@
+ 	"""
+ 	Do cool stuff::
+ 
+-	    length([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21])
++	    length([
++	        1,
++	        2,
++	        3,
++	        4,
++	        5,
++	        6,
++	        7,
++	        8,
++	        9,
++	        10,
++	        11,
++	        12,
++	        13,
++	        14,
++	        15,
++	        16,
++	        17,
++	        18,
++	        19,
++	        20,
++	        21,
++	    ])
+ 	"""
+ 	pass
+ 
+@@ -354,6 +442,27 @@
+ 	Examples:
+ 	    Do cool stuff::
+ 
+-	        length([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20])
++	        length([
++	            1,
++	            2,
++	            3,
++	            4,
++	            5,
++	            6,
++	            7,
++	            8,
++	            9,
++	            10,
++	            11,
++	            12,
++	            13,
++	            14,
++	            15,
++	            16,
++	            17,
++	            18,
++	            19,
++	            20,
++	        ])
+ 	"""
+ 	pass
 ```
 
 
@@ -1921,6 +2660,170 @@ def doctest_extra_indent3():
 	...         df1, df2, df3, on="dt"
 	... )  # doctest: +IGNORE_RESULT
 	"""
+
+
+# See https://github.com/astral-sh/ruff/issues/13358
+def length_doctest():
+	"""Get the length of the given list of numbers.
+
+	Args:
+	    numbers: List of numbers.
+
+	Returns:
+	    Integer length of the list of numbers.
+
+	Example:
+	    >>> length(
+	    ...         [
+	    ...                 1,
+	    ...                 2,
+	    ...                 3,
+	    ...                 4,
+	    ...                 5,
+	    ...                 6,
+	    ...                 7,
+	    ...                 8,
+	    ...                 9,
+	    ...                 10,
+	    ...                 11,
+	    ...                 12,
+	    ...                 13,
+	    ...                 14,
+	    ...                 15,
+	    ...                 16,
+	    ...                 17,
+	    ...                 18,
+	    ...                 19,
+	    ...                 20,
+	    ...         ]
+	    ... )
+	    20
+	"""
+
+
+def length_doctest_underindent():
+	"""Get the length of the given list of numbers.
+
+	    Args:
+	        numbers: List of numbers.
+
+	    Returns:
+	        Integer length of the list of numbers.
+
+	Example:
+	    >>> length(
+	    ...         [
+	    ...                 1,
+	    ...                 2,
+	    ...                 3,
+	    ...                 4,
+	    ...                 5,
+	    ...                 6,
+	    ...                 7,
+	    ...                 8,
+	    ...                 9,
+	    ...                 10,
+	    ...                 11,
+	    ...                 12,
+	    ...                 13,
+	    ...                 14,
+	    ...                 15,
+	    ...                 16,
+	    ...                 17,
+	    ...                 18,
+	    ...                 19,
+	    ...                 20,
+	    ...         ]
+	    ... )
+	    20
+	"""
+
+
+# See https://github.com/astral-sh/ruff/issues/13358
+def length_markdown():
+	"""Get the length of the given list of numbers.
+
+	Args:
+	    numbers: List of numbers.
+
+	Returns:
+	    Integer length of the list of numbers.
+
+	Example:
+
+	    ```
+	    length(
+	            [
+	                    1,
+	                    2,
+	                    3,
+	                    4,
+	                    5,
+	                    6,
+	                    7,
+	                    8,
+	                    9,
+	                    10,
+	                    11,
+	                    12,
+	                    13,
+	                    14,
+	                    15,
+	                    16,
+	                    17,
+	                    18,
+	                    19,
+	                    20,
+	                    21,
+	            ]
+	    )
+	    ```
+	"""
+
+
+# See https://github.com/astral-sh/ruff/issues/13358
+def length_rst():
+	"""
+	Do cool stuff::
+
+	    length(
+	            [
+	                    1,
+	                    2,
+	                    3,
+	                    4,
+	                    5,
+	                    6,
+	                    7,
+	                    8,
+	                    9,
+	                    10,
+	                    11,
+	                    12,
+	                    13,
+	                    14,
+	                    15,
+	                    16,
+	                    17,
+	                    18,
+	                    19,
+	                    20,
+	                    21,
+	            ]
+	    )
+	"""
+	pass
+
+
+# See https://github.com/astral-sh/ruff/issues/13358
+def length_rst_in_section():
+	"""
+	Examples:
+	    Do cool stuff::
+
+	        length([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20])
+	"""
+	pass
 ```
 
 
@@ -1943,7 +2846,249 @@ def doctest_extra_indent3():
  		"""
  
  
+@@ -730,30 +732,28 @@
+ 	    Integer length of the list of numbers.
+ 
+ 	Example:
+-	    >>> length(
+-	    ...         [
+-	    ...                 1,
+-	    ...                 2,
+-	    ...                 3,
+-	    ...                 4,
+-	    ...                 5,
+-	    ...                 6,
+-	    ...                 7,
+-	    ...                 8,
+-	    ...                 9,
+-	    ...                 10,
+-	    ...                 11,
+-	    ...                 12,
+-	    ...                 13,
+-	    ...                 14,
+-	    ...                 15,
+-	    ...                 16,
+-	    ...                 17,
+-	    ...                 18,
+-	    ...                 19,
+-	    ...                 20,
+-	    ...         ]
+-	    ... )
++	    >>> length([
++	    ...         1,
++	    ...         2,
++	    ...         3,
++	    ...         4,
++	    ...         5,
++	    ...         6,
++	    ...         7,
++	    ...         8,
++	    ...         9,
++	    ...         10,
++	    ...         11,
++	    ...         12,
++	    ...         13,
++	    ...         14,
++	    ...         15,
++	    ...         16,
++	    ...         17,
++	    ...         18,
++	    ...         19,
++	    ...         20,
++	    ... ])
+ 	    20
+ 	"""
+ 
+@@ -768,30 +768,28 @@
+ 	        Integer length of the list of numbers.
+ 
+ 	Example:
+-	    >>> length(
+-	    ...         [
+-	    ...                 1,
+-	    ...                 2,
+-	    ...                 3,
+-	    ...                 4,
+-	    ...                 5,
+-	    ...                 6,
+-	    ...                 7,
+-	    ...                 8,
+-	    ...                 9,
+-	    ...                 10,
+-	    ...                 11,
+-	    ...                 12,
+-	    ...                 13,
+-	    ...                 14,
+-	    ...                 15,
+-	    ...                 16,
+-	    ...                 17,
+-	    ...                 18,
+-	    ...                 19,
+-	    ...                 20,
+-	    ...         ]
+-	    ... )
++	    >>> length([
++	    ...         1,
++	    ...         2,
++	    ...         3,
++	    ...         4,
++	    ...         5,
++	    ...         6,
++	    ...         7,
++	    ...         8,
++	    ...         9,
++	    ...         10,
++	    ...         11,
++	    ...         12,
++	    ...         13,
++	    ...         14,
++	    ...         15,
++	    ...         16,
++	    ...         17,
++	    ...         18,
++	    ...         19,
++	    ...         20,
++	    ... ])
+ 	    20
+ 	"""
+ 
+@@ -809,31 +807,29 @@
+ 	Example:
+ 
+ 	    ```
+-	    length(
+-	            [
+-	                    1,
+-	                    2,
+-	                    3,
+-	                    4,
+-	                    5,
+-	                    6,
+-	                    7,
+-	                    8,
+-	                    9,
+-	                    10,
+-	                    11,
+-	                    12,
+-	                    13,
+-	                    14,
+-	                    15,
+-	                    16,
+-	                    17,
+-	                    18,
+-	                    19,
+-	                    20,
+-	                    21,
+-	            ]
+-	    )
++	    length([
++	            1,
++	            2,
++	            3,
++	            4,
++	            5,
++	            6,
++	            7,
++	            8,
++	            9,
++	            10,
++	            11,
++	            12,
++	            13,
++	            14,
++	            15,
++	            16,
++	            17,
++	            18,
++	            19,
++	            20,
++	            21,
++	    ])
+ 	    ```
+ 	"""
+ 
+@@ -843,31 +839,29 @@
+ 	"""
+ 	Do cool stuff::
+ 
+-	    length(
+-	            [
+-	                    1,
+-	                    2,
+-	                    3,
+-	                    4,
+-	                    5,
+-	                    6,
+-	                    7,
+-	                    8,
+-	                    9,
+-	                    10,
+-	                    11,
+-	                    12,
+-	                    13,
+-	                    14,
+-	                    15,
+-	                    16,
+-	                    17,
+-	                    18,
+-	                    19,
+-	                    20,
+-	                    21,
+-	            ]
+-	    )
++	    length([
++	            1,
++	            2,
++	            3,
++	            4,
++	            5,
++	            6,
++	            7,
++	            8,
++	            9,
++	            10,
++	            11,
++	            12,
++	            13,
++	            14,
++	            15,
++	            16,
++	            17,
++	            18,
++	            19,
++	            20,
++	            21,
++	    ])
+ 	"""
+ 	pass
+ 
+@@ -878,6 +872,27 @@
+ 	Examples:
+ 	    Do cool stuff::
+ 
+-	        length([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20])
++	        length([
++	                1,
++	                2,
++	                3,
++	                4,
++	                5,
++	                6,
++	                7,
++	                8,
++	                9,
++	                10,
++	                11,
++	                12,
++	                13,
++	                14,
++	                15,
++	                16,
++	                17,
++	                18,
++	                19,
++	                20,
++	        ])
+ 	"""
+ 	pass
 ```
-
-
-


### PR DESCRIPTION
## Summary

This PR fixes the `line-length` calculation for the mode `dynamic` for docstring code blocks. 

```python
def length(numbers: list[int]) -> int:
    """Get the length of the given list of numbers.

    Example:
        >>> length([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20])
        20
    """
    return len(numbers)
```

The current implementation only accounted for the docstring's indent and the space taken by the `>>> ` but it didn't account for the indent *inside* the docstring (for spaces relative to `Example`). This PR changes the line length calculation to consider the relative indent.

Fixes https://github.com/astral-sh/ruff/issues/13358


## Test Plan

I added a few new tests that and they demonstrate that the lines remain collapsed but expand in preview mode (with the fix).

I reviewed all ecosystem changes and they look correct. Many of those docstrings also have `E501` suppressions that won't be needed with the fix.