### PR TITLE
Do not offer an invalid fix for PLR1716 when the comparisons contain parenthesis

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pylint/boolean_chained_comparison.py
+++ b/crates/ruff_linter/resources/test/fixtures/pylint/boolean_chained_comparison.py
@@ -118,3 +118,11 @@ b = int(input())
 c = int(input())
 if a > b and b < c:
     pass
+
+
+# Unfixable due to parentheses.
+(a < b) and b < c
+a < b and (b < c)
+((a < b) and b < c)
+(a < b) and (b < c)
+(((a < b))) and (b < c)

--- a/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLR1716_boolean_chained_comparison.py.snap
+++ b/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLR1716_boolean_chained_comparison.py.snap
@@ -260,3 +260,54 @@ boolean_chained_comparison.py:73:24: PLR1716 [*] Contains chained boolean compar
 74 74 |     pass
 75 75 | 
 76 76 | # ------------
+
+boolean_chained_comparison.py:124:2: PLR1716 Contains chained boolean comparison that can be simplified
+    |
+123 | # Unfixable due to parentheses.
+124 | (a < b) and b < c
+    |  ^^^^^^^^^^^^^^^^ PLR1716
+125 | a < b and (b < c)
+126 | ((a < b) and b < c)
+    |
+    = help: Use a single compare expression
+
+boolean_chained_comparison.py:125:1: PLR1716 Contains chained boolean comparison that can be simplified
+    |
+123 | # Unfixable due to parentheses.
+124 | (a < b) and b < c
+125 | a < b and (b < c)
+    | ^^^^^^^^^^^^^^^^ PLR1716
+126 | ((a < b) and b < c)
+127 | (a < b) and (b < c)
+    |
+    = help: Use a single compare expression
+
+boolean_chained_comparison.py:126:3: PLR1716 Contains chained boolean comparison that can be simplified
+    |
+124 | (a < b) and b < c
+125 | a < b and (b < c)
+126 | ((a < b) and b < c)
+    |   ^^^^^^^^^^^^^^^^ PLR1716
+127 | (a < b) and (b < c)
+128 | (((a < b))) and (b < c)
+    |
+    = help: Use a single compare expression
+
+boolean_chained_comparison.py:127:2: PLR1716 Contains chained boolean comparison that can be simplified
+    |
+125 | a < b and (b < c)
+126 | ((a < b) and b < c)
+127 | (a < b) and (b < c)
+    |  ^^^^^^^^^^^^^^^^^ PLR1716
+128 | (((a < b))) and (b < c)
+    |
+    = help: Use a single compare expression
+
+boolean_chained_comparison.py:128:4: PLR1716 Contains chained boolean comparison that can be simplified
+    |
+126 | ((a < b) and b < c)
+127 | (a < b) and (b < c)
+128 | (((a < b))) and (b < c)
+    |    ^^^^^^^^^^^^^^^^^^^ PLR1716
+    |
+    = help: Use a single compare expression


### PR DESCRIPTION
Related to https://github.com/astral-sh/ruff/issues/13524

Doesn't offer a valid fix, opting to instead just not offer a fix at all. If someone points me to a good way to handle parenthesis here I'm down to try to fix the fix separately, but it looks quite hard.