### PR TITLE
Remove jemalloc crate when building on AIX

### DIFF
--- a/crates/ruff/Cargo.toml
+++ b/crates/ruff/Cargo.toml
@@ -79,7 +79,7 @@ ignored = ["chrono"]
 [target.'cfg(target_os = "windows")'.dependencies]
 mimalloc = { workspace = true }
 
-[target.'cfg(all(not(target_os = "windows"), not(target_os = "openbsd"), any(target_arch = "x86_64", target_arch = "aarch64", target_arch = "powerpc64")))'.dependencies]
+[target.'cfg(all(not(target_os = "windows"), not(target_os = "openbsd"), not(target_os = "aix"), any(target_arch = "x86_64", target_arch = "aarch64", target_arch = "powerpc64")))'.dependencies]
 tikv-jemallocator = { workspace = true }
 
 [lints]

--- a/crates/ruff/src/main.rs
+++ b/crates/ruff/src/main.rs
@@ -16,6 +16,7 @@ static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 #[cfg(all(
     not(target_os = "windows"),
     not(target_os = "openbsd"),
+    not(target_os = "aix"),
     any(
         target_arch = "x86_64",
         target_arch = "aarch64",


### PR DESCRIPTION
## Summary
Building ruff on AIX breaks on `tiki-jemalloc-sys` due to OS header incompatibility

## Test Plan
`cargo test`

