### PR TITLE
refactor: Rename `FormatStringContinuation` to `FormatImplicitConcatenatedString`

### DIFF
--- a/crates/ruff_python_formatter/src/expression/binary_like.rs
+++ b/crates/ruff_python_formatter/src/expression/binary_like.rs
@@ -20,7 +20,7 @@ use crate::expression::parentheses::{
 };
 use crate::expression::OperatorPrecedence;
 use crate::prelude::*;
-use crate::string::{AnyString, FormatStringContinuation};
+use crate::string::{AnyString, FormatImplicitConcatenatedString};
 
 #[derive(Copy, Clone, Debug)]
 pub(super) enum BinaryLike<'a> {
@@ -394,10 +394,10 @@ impl Format<PyFormatContext<'_>> for BinaryLike<'_> {
                             [
                                 operand.leading_binary_comments().map(leading_comments),
                                 leading_comments(comments.leading(string_constant)),
-                                // Call `FormatStringContinuation` directly to avoid formatting
+                                // Call `FormatImplicitConcatenatedString` directly to avoid formatting
                                 // the implicitly concatenated string with the enclosing group
                                 // because the group is added by the binary like formatting.
-                                FormatStringContinuation::new(&string_constant),
+                                FormatImplicitConcatenatedString::new(string_constant),
                                 trailing_comments(comments.trailing(string_constant)),
                                 operand.trailing_binary_comments().map(trailing_comments),
                                 line_suffix_boundary(),
@@ -413,10 +413,10 @@ impl Format<PyFormatContext<'_>> for BinaryLike<'_> {
                             f,
                             [
                                 leading_comments(comments.leading(string_constant)),
-                                // Call `FormatStringContinuation` directly to avoid formatting
+                                // Call `FormatImplicitConcatenatedString` directly to avoid formatting
                                 // the implicitly concatenated string with the enclosing group
                                 // because the group is added by the binary like formatting.
-                                FormatStringContinuation::new(&string_constant),
+                                FormatImplicitConcatenatedString::new(string_constant),
                                 trailing_comments(comments.trailing(string_constant)),
                             ]
                         )?;

--- a/crates/ruff_python_formatter/src/expression/expr_bytes_literal.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_bytes_literal.rs
@@ -5,7 +5,7 @@ use crate::expression::parentheses::{
     in_parentheses_only_group, NeedsParentheses, OptionalParentheses,
 };
 use crate::prelude::*;
-use crate::string::{AnyString, FormatStringContinuation};
+use crate::string::{AnyString, FormatImplicitConcatenatedString};
 
 #[derive(Default)]
 pub struct FormatExprBytesLiteral;
@@ -16,8 +16,7 @@ impl FormatNodeRule<ExprBytesLiteral> for FormatExprBytesLiteral {
 
         match value.as_slice() {
             [bytes_literal] => bytes_literal.format().fmt(f),
-            _ => in_parentheses_only_group(&FormatStringContinuation::new(&AnyString::Bytes(item)))
-                .fmt(f),
+            _ => in_parentheses_only_group(&FormatImplicitConcatenatedString::new(item)).fmt(f),
         }
     }
 }

--- a/crates/ruff_python_formatter/src/expression/expr_f_string.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_f_string.rs
@@ -7,7 +7,7 @@ use crate::expression::parentheses::{
 };
 use crate::other::f_string_part::FormatFStringPart;
 use crate::prelude::*;
-use crate::string::{AnyString, FormatStringContinuation, Quoting};
+use crate::string::{AnyString, FormatImplicitConcatenatedString, Quoting};
 
 #[derive(Default)]
 pub struct FormatExprFString;
@@ -22,10 +22,7 @@ impl FormatNodeRule<ExprFString> for FormatExprFString {
                 f_string_quoting(item, &f.context().locator()),
             )
             .fmt(f),
-            _ => {
-                in_parentheses_only_group(&FormatStringContinuation::new(&AnyString::FString(item)))
-                    .fmt(f)
-            }
+            _ => in_parentheses_only_group(&FormatImplicitConcatenatedString::new(item)).fmt(f),
         }
     }
 }

--- a/crates/ruff_python_formatter/src/expression/expr_string_literal.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_string_literal.rs
@@ -6,7 +6,7 @@ use crate::expression::parentheses::{
 };
 use crate::other::string_literal::{FormatStringLiteral, StringLiteralKind};
 use crate::prelude::*;
-use crate::string::{AnyString, FormatStringContinuation};
+use crate::string::{AnyString, FormatImplicitConcatenatedString};
 
 #[derive(Default)]
 pub struct FormatExprStringLiteral {
@@ -55,7 +55,7 @@ impl FormatNodeRule<ExprStringLiteral> for FormatExprStringLiteral {
                 // ensures that the docstring is a *single* string literal.
                 assert!(!self.kind.is_docstring());
 
-                in_parentheses_only_group(&FormatStringContinuation::new(&AnyString::String(item)))
+                in_parentheses_only_group(&FormatImplicitConcatenatedString::new(item))
             }
             .fmt(f),
         }

--- a/crates/ruff_python_formatter/src/string/any.rs
+++ b/crates/ruff_python_formatter/src/string/any.rs
@@ -118,6 +118,24 @@ impl<'a> From<&AnyString<'a>> for ExpressionRef<'a> {
     }
 }
 
+impl<'a> From<&'a ExprBytesLiteral> for AnyString<'a> {
+    fn from(value: &'a ExprBytesLiteral) -> Self {
+        AnyString::Bytes(value)
+    }
+}
+
+impl<'a> From<&'a ExprStringLiteral> for AnyString<'a> {
+    fn from(value: &'a ExprStringLiteral) -> Self {
+        AnyString::String(value)
+    }
+}
+
+impl<'a> From<&'a ExprFString> for AnyString<'a> {
+    fn from(value: &'a ExprFString) -> Self {
+        AnyString::FString(value)
+    }
+}
+
 pub(super) enum AnyStringPartsIter<'a> {
     String(std::slice::Iter<'a, StringLiteral>),
     Bytes(std::slice::Iter<'a, ast::BytesLiteral>),


### PR DESCRIPTION
## Summary

What's in the title. I don't think a `StringContinuation` is a proper term in Python. There's line continuation. 
Anyway, I think implicit concatenated string easier to understand.

## Test Plan

`cargo test`
