### PR TITLE
Red Knot - Infer the return value of bool() 

### DIFF
--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -583,7 +583,20 @@ impl<'db> Type<'db> {
             ),
 
             // TODO annotated return type on `__new__` or metaclass `__call__`
-            Type::Class(class) => CallOutcome::callable(Type::Instance(class)),
+            Type::Class(class) => {
+                // If the class is the builtin-bool class (for example `bool(1)`), we try to return
+                // the specific truthiness value of the input arg, `Literal[True]` for the example above.
+                let is_bool = class.is_stdlib_symbol(db, "builtins", "bool");
+                CallOutcome::callable(if is_bool {
+                    arg_types
+                        .first()
+                        .unwrap_or(&Type::Unknown)
+                        .bool(db)
+                        .into_type(db)
+                } else {
+                    Type::Instance(class)
+                })
+            }
 
             // TODO: handle classes which implement the `__call__` protocol
             Type::Instance(_instance_ty) => CallOutcome::callable(Type::Unknown),

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -2027,20 +2027,9 @@ impl<'db> TypeInferenceBuilder<'db> {
         // TODO: proper typed call signature, representing keyword args etc
         let arg_types = self.infer_arguments(arguments);
         let function_type = self.infer_expression(func);
-
-        // If the function is a bool (for example `x = bool(1)`), we can do some special handling
-        // and return more specific types.
-        return if function_type == builtins_symbol_ty(self.db, "bool") {
-            self.infer_bool_call_expression(arg_types.as_slice())
-        } else {
-            function_type
-                .call(self.db, arg_types.as_slice())
-                .unwrap_with_diagnostic(self.db, func.as_ref().into(), self)
-        };
-    }
-
-    fn infer_bool_call_expression(&self, arg_types: &[Type]) -> Type<'db> {
-        arg_types[0].bool(self.db).into_type(self.db)
+        function_type
+            .call(self.db, arg_types.as_slice())
+            .unwrap_with_diagnostic(self.db, func.as_ref().into(), self)
     }
 
     fn infer_starred_expression(&mut self, starred: &ast::ExprStarred) -> Type<'db> {

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -2031,7 +2031,7 @@ impl<'db> TypeInferenceBuilder<'db> {
         // If the function is a bool (for example `x = bool(1)`), we can do some special handling
         // and return more specific types.
         return if function_type == builtins_symbol_ty(self.db, "bool") {
-            self.infer_bool_call_expression(&arg_types)
+            self.infer_bool_call_expression(arg_types.as_slice())
         } else {
             function_type
                 .call(self.db, arg_types.as_slice())


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary
Following #13449, this PR adds custom handling for the bool contractor, so when the input type has statically known truthiness value, it will be used as the return value of the bool function.
For example, in the following snippet x will now be resolved to `Literal[True]` instead of `bool`.
```python
x = bool(1)
```
 
<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan
Some cargo tests were added. 
<!-- How was it tested? -->
