### PR TITLE
Normalize implicit concatenated f-string quotes per part

### DIFF
--- a/crates/ruff_python_formatter/generate.py
+++ b/crates/ruff_python_formatter/generate.py
@@ -38,9 +38,10 @@ for node_line in node_lines:
     # implementation.
     if node in (
         "FString",
-        "StringLiteral",
         "FStringLiteralElement",
         "FStringExpressionElement",
+        "FStringFormatSpec",
+        "Identifier",
     ):
         continue
     nodes.append(node)

--- a/crates/ruff_python_formatter/generate.py
+++ b/crates/ruff_python_formatter/generate.py
@@ -33,8 +33,8 @@ node_lines = (
 nodes = []
 for node_line in node_lines:
     node = node_line.split("(")[1].split(")")[0].split("::")[-1].split("<")[0]
-    # `FString` and `StringLiteral` has a custom implementation while the formatting for
-    # `FStringLiteralElement` and `FStringExpressionElement` are handled by the `FString`
+    # `FString` has a custom implementation while the formatting for
+    # `FStringLiteralElement`, `FStringFormatSpec` and `FStringExpressionElement` are handled by the `FString`
     # implementation.
     if node in (
         "FString",

--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/fstring.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/fstring.py
@@ -313,4 +313,5 @@ hello {
 _ = (
     'This string should change its quotes to double quotes'
     f'This string uses double quotes in an expression {"woah"}'
+    f'This f-string does not use any quotes.'
 )

--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/fstring.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/fstring.py
@@ -307,3 +307,10 @@ hello {
           ]
       } --------
 """
+
+
+# Implicit concatenated f-string containing quotes
+_ = (
+    'This string should change its quotes to double quotes'
+    f'This string uses double quotes in an expression {"woah"}'
+)

--- a/crates/ruff_python_formatter/src/expression/expr_string_literal.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_string_literal.rs
@@ -4,37 +4,17 @@ use ruff_python_ast::{AnyNodeRef, ExprStringLiteral};
 use crate::expression::parentheses::{
     in_parentheses_only_group, NeedsParentheses, OptionalParentheses,
 };
-use crate::other::string_literal::{FormatStringLiteral, StringLiteralKind};
+use crate::other::string_literal::StringLiteralKind;
 use crate::prelude::*;
 use crate::string::{AnyString, FormatImplicitConcatenatedString};
 
 #[derive(Default)]
 pub struct FormatExprStringLiteral {
-    kind: ExprStringLiteralKind,
-}
-
-#[derive(Default, Copy, Clone, Debug)]
-pub enum ExprStringLiteralKind {
-    #[default]
-    String,
-    Docstring,
-}
-
-impl ExprStringLiteralKind {
-    const fn string_literal_kind(self) -> StringLiteralKind {
-        match self {
-            ExprStringLiteralKind::String => StringLiteralKind::String,
-            ExprStringLiteralKind::Docstring => StringLiteralKind::Docstring,
-        }
-    }
-
-    const fn is_docstring(self) -> bool {
-        matches!(self, ExprStringLiteralKind::Docstring)
-    }
+    kind: StringLiteralKind,
 }
 
 impl FormatRuleWithOptions<ExprStringLiteral, PyFormatContext<'_>> for FormatExprStringLiteral {
-    type Options = ExprStringLiteralKind;
+    type Options = StringLiteralKind;
 
     fn with_options(mut self, options: Self::Options) -> Self {
         self.kind = options;
@@ -47,9 +27,7 @@ impl FormatNodeRule<ExprStringLiteral> for FormatExprStringLiteral {
         let ExprStringLiteral { value, .. } = item;
 
         match value.as_slice() {
-            [string_literal] => {
-                FormatStringLiteral::new(string_literal, self.kind.string_literal_kind()).fmt(f)
-            }
+            [string_literal] => string_literal.format().with_options(self.kind).fmt(f),
             _ => {
                 // This is just a sanity check because [`DocstringStmt::try_from_statement`]
                 // ensures that the docstring is a *single* string literal.

--- a/crates/ruff_python_formatter/src/generated.rs
+++ b/crates/ruff_python_formatter/src/generated.rs
@@ -2935,6 +2935,42 @@ impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::TypeParamParamSpec {
     }
 }
 
+impl FormatRule<ast::StringLiteral, PyFormatContext<'_>>
+    for crate::other::string_literal::FormatStringLiteral
+{
+    #[inline]
+    fn fmt(&self, node: &ast::StringLiteral, f: &mut PyFormatter) -> FormatResult<()> {
+        FormatNodeRule::<ast::StringLiteral>::fmt(self, node, f)
+    }
+}
+impl<'ast> AsFormat<PyFormatContext<'ast>> for ast::StringLiteral {
+    type Format<'a> = FormatRefWithRule<
+        'a,
+        ast::StringLiteral,
+        crate::other::string_literal::FormatStringLiteral,
+        PyFormatContext<'ast>,
+    >;
+    fn format(&self) -> Self::Format<'_> {
+        FormatRefWithRule::new(
+            self,
+            crate::other::string_literal::FormatStringLiteral::default(),
+        )
+    }
+}
+impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::StringLiteral {
+    type Format = FormatOwnedWithRule<
+        ast::StringLiteral,
+        crate::other::string_literal::FormatStringLiteral,
+        PyFormatContext<'ast>,
+    >;
+    fn into_format(self) -> Self::Format {
+        FormatOwnedWithRule::new(
+            self,
+            crate::other::string_literal::FormatStringLiteral::default(),
+        )
+    }
+}
+
 impl FormatRule<ast::BytesLiteral, PyFormatContext<'_>>
     for crate::other::bytes_literal::FormatBytesLiteral
 {

--- a/crates/ruff_python_formatter/src/other/f_string_part.rs
+++ b/crates/ruff_python_formatter/src/other/f_string_part.rs
@@ -1,7 +1,6 @@
 use ruff_python_ast::FStringPart;
 
 use crate::other::f_string::FormatFString;
-use crate::other::string_literal::{FormatStringLiteral, StringLiteralKind};
 use crate::prelude::*;
 use crate::string::Quoting;
 
@@ -25,14 +24,7 @@ impl<'a> FormatFStringPart<'a> {
 impl Format<PyFormatContext<'_>> for FormatFStringPart<'_> {
     fn fmt(&self, f: &mut PyFormatter) -> FormatResult<()> {
         match self.part {
-            FStringPart::Literal(string_literal) => FormatStringLiteral::new(
-                string_literal,
-                // If an f-string part is a string literal, the f-string is always
-                // implicitly concatenated e.g., `"foo" f"bar {x}"`. A standalone
-                // string literal would be a string expression, not an f-string.
-                StringLiteralKind::InImplicitlyConcatenatedFString(self.quoting),
-            )
-            .fmt(f),
+            FStringPart::Literal(string_literal) => string_literal.format().fmt(f),
             FStringPart::FString(f_string) => FormatFString::new(f_string, self.quoting).fmt(f),
         }
     }

--- a/crates/ruff_python_formatter/src/other/f_string_part.rs
+++ b/crates/ruff_python_formatter/src/other/f_string_part.rs
@@ -1,6 +1,7 @@
 use ruff_python_ast::FStringPart;
 
 use crate::other::f_string::FormatFString;
+use crate::other::string_literal::StringLiteralKind;
 use crate::prelude::*;
 use crate::string::Quoting;
 
@@ -24,7 +25,13 @@ impl<'a> FormatFStringPart<'a> {
 impl Format<PyFormatContext<'_>> for FormatFStringPart<'_> {
     fn fmt(&self, f: &mut PyFormatter) -> FormatResult<()> {
         match self.part {
-            FStringPart::Literal(string_literal) => string_literal.format().fmt(f),
+            #[allow(deprecated)]
+            FStringPart::Literal(string_literal) => string_literal
+                .format()
+                .with_options(StringLiteralKind::InImplicitlyConcatenatedFString(
+                    self.quoting,
+                ))
+                .fmt(f),
             FStringPart::FString(f_string) => FormatFString::new(f_string, self.quoting).fmt(f),
         }
     }

--- a/crates/ruff_python_formatter/src/other/string_literal.rs
+++ b/crates/ruff_python_formatter/src/other/string_literal.rs
@@ -1,32 +1,32 @@
+use ruff_formatter::FormatRuleWithOptions;
 use ruff_python_ast::StringLiteral;
 
 use crate::prelude::*;
-use crate::string::{docstring, Quoting, StringNormalizer};
+use crate::string::{docstring, StringNormalizer};
 use crate::QuoteStyle;
 
-pub(crate) struct FormatStringLiteral<'a> {
-    value: &'a StringLiteral,
+#[derive(Default)]
+pub struct FormatStringLiteral {
     layout: StringLiteralKind,
 }
 
-impl<'a> FormatStringLiteral<'a> {
-    pub(crate) fn new(value: &'a StringLiteral, layout: StringLiteralKind) -> Self {
-        Self { value, layout }
+impl FormatRuleWithOptions<StringLiteral, PyFormatContext<'_>> for FormatStringLiteral {
+    type Options = StringLiteralKind;
+
+    fn with_options(mut self, layout: StringLiteralKind) -> Self {
+        self.layout = layout;
+        self
     }
 }
 
 /// The kind of a string literal.
 #[derive(Copy, Clone, Debug, Default)]
-pub(crate) enum StringLiteralKind {
+pub enum StringLiteralKind {
     /// A normal string literal e.g., `"foo"`.
     #[default]
     String,
     /// A string literal used as a docstring.
     Docstring,
-    /// A string literal that is implicitly concatenated with an f-string. This
-    /// makes the overall expression an f-string whose quoting detection comes
-    /// from the parent node (f-string expression).
-    InImplicitlyConcatenatedFString(Quoting),
 }
 
 impl StringLiteralKind {
@@ -34,18 +34,10 @@ impl StringLiteralKind {
     pub(crate) const fn is_docstring(self) -> bool {
         matches!(self, StringLiteralKind::Docstring)
     }
-
-    /// Returns the quoting to be used for this string literal.
-    fn quoting(self) -> Quoting {
-        match self {
-            StringLiteralKind::String | StringLiteralKind::Docstring => Quoting::CanChange,
-            StringLiteralKind::InImplicitlyConcatenatedFString(quoting) => quoting,
-        }
-    }
 }
 
-impl Format<PyFormatContext<'_>> for FormatStringLiteral<'_> {
-    fn fmt(&self, f: &mut PyFormatter) -> FormatResult<()> {
+impl FormatNodeRule<StringLiteral> for FormatStringLiteral {
+    fn fmt_fields(&self, item: &StringLiteral, f: &mut PyFormatter) -> FormatResult<()> {
         let quote_style = f.options().quote_style();
         let quote_style = if self.layout.is_docstring() && !quote_style.is_preserve() {
             // Per PEP 8 and PEP 257, always prefer double quotes for docstrings,
@@ -56,9 +48,8 @@ impl Format<PyFormatContext<'_>> for FormatStringLiteral<'_> {
         };
 
         let normalized = StringNormalizer::from_context(f.context())
-            .with_quoting(self.layout.quoting())
             .with_preferred_quote_style(quote_style)
-            .normalize(self.value.into());
+            .normalize(item.into());
 
         if self.layout.is_docstring() {
             docstring::format(&normalized, f)

--- a/crates/ruff_python_formatter/src/other/string_literal.rs
+++ b/crates/ruff_python_formatter/src/other/string_literal.rs
@@ -48,8 +48,11 @@ impl StringLiteralKind {
             StringLiteralKind::String | StringLiteralKind::Docstring => Quoting::CanChange,
             #[allow(deprecated)]
             StringLiteralKind::InImplicitlyConcatenatedFString(quoting) => {
+                // Allow string literals to pick the "optimal" quote character
+                // even if any other fstring in the implicit concatenation uses an expression
+                // containing a quote character.
                 // TODO: Remove StringLiteralKind::InImplicitlyConcatenatedFString when promoting
-                //   this style to stable
+                //   this style to stable and remove the layout from `AnyStringPart::String`.
                 if is_f_string_implicit_concatenated_string_literal_quotes_enabled(context) {
                     Quoting::CanChange
                 } else {

--- a/crates/ruff_python_formatter/src/preview.rs
+++ b/crates/ruff_python_formatter/src/preview.rs
@@ -19,6 +19,13 @@ pub(crate) fn is_f_string_formatting_enabled(context: &PyFormatContext) -> bool 
     context.is_preview()
 }
 
+/// See [#13539](https://github.com/astral-sh/ruff/pull/13539)
+pub(crate) fn is_f_string_implicit_concatenated_string_literal_quotes_enabled(
+    context: &PyFormatContext,
+) -> bool {
+    context.is_preview()
+}
+
 pub(crate) fn is_with_single_item_pre_39_enabled(context: &PyFormatContext) -> bool {
     context.is_preview()
 }

--- a/crates/ruff_python_formatter/src/statement/suite.rs
+++ b/crates/ruff_python_formatter/src/statement/suite.rs
@@ -11,7 +11,7 @@ use crate::comments::{
     leading_comments, trailing_comments, Comments, LeadingDanglingTrailingComments,
 };
 use crate::context::{NodeLevel, TopLevelStatementPosition, WithIndentLevel, WithNodeLevel};
-use crate::expression::expr_string_literal::ExprStringLiteralKind;
+use crate::other::string_literal::StringLiteralKind;
 use crate::prelude::*;
 use crate::statement::stmt_expr::FormatStmtExpr;
 use crate::verbatim::{
@@ -850,7 +850,7 @@ impl Format<PyFormatContext<'_>> for DocstringStmt<'_> {
                         .then_some(source_position(self.docstring.start())),
                     string_literal
                         .format()
-                        .with_options(ExprStringLiteralKind::Docstring),
+                        .with_options(StringLiteralKind::Docstring),
                     f.options()
                         .source_map_generation()
                         .is_enabled()

--- a/crates/ruff_python_formatter/src/string/any.rs
+++ b/crates/ruff_python_formatter/src/string/any.rs
@@ -11,6 +11,7 @@ use ruff_text_size::{Ranged, TextRange};
 
 use crate::expression::expr_f_string::f_string_quoting;
 use crate::other::f_string::FormatFString;
+use crate::other::string_literal::StringLiteralKind;
 use crate::prelude::*;
 use crate::string::Quoting;
 
@@ -148,15 +149,20 @@ impl<'a> Iterator for AnyStringPartsIter<'a> {
         let part = match self {
             Self::String(inner) => {
                 let part = inner.next()?;
-                AnyStringPart::String(part)
+                AnyStringPart::String {
+                    part,
+                    layout: StringLiteralKind::String,
+                }
             }
             Self::Bytes(inner) => AnyStringPart::Bytes(inner.next()?),
             Self::FString(inner, quoting) => {
                 let part = inner.next()?;
                 match part {
-                    ast::FStringPart::Literal(string_literal) => {
-                        AnyStringPart::String(string_literal)
-                    }
+                    ast::FStringPart::Literal(string_literal) => AnyStringPart::String {
+                        part: string_literal,
+                        #[allow(deprecated)]
+                        layout: StringLiteralKind::InImplicitlyConcatenatedFString(*quoting),
+                    },
                     ast::FStringPart::FString(f_string) => AnyStringPart::FString {
                         part: f_string,
                         quoting: *quoting,
@@ -177,7 +183,10 @@ impl FusedIterator for AnyStringPartsIter<'_> {}
 /// This is constructed from the [`AnyString::parts`] method on [`AnyString`].
 #[derive(Clone, Debug)]
 pub(super) enum AnyStringPart<'a> {
-    String(&'a ast::StringLiteral),
+    String {
+        part: &'a ast::StringLiteral,
+        layout: StringLiteralKind,
+    },
     Bytes(&'a ast::BytesLiteral),
     FString {
         part: &'a ast::FString,
@@ -188,7 +197,7 @@ pub(super) enum AnyStringPart<'a> {
 impl AnyStringPart<'_> {
     fn flags(&self) -> AnyStringFlags {
         match self {
-            Self::String(part) => part.flags.into(),
+            Self::String { part, .. } => part.flags.into(),
             Self::Bytes(bytes_literal) => bytes_literal.flags.into(),
             Self::FString { part, .. } => part.flags.into(),
         }
@@ -198,7 +207,7 @@ impl AnyStringPart<'_> {
 impl<'a> From<&AnyStringPart<'a>> for AnyNodeRef<'a> {
     fn from(value: &AnyStringPart<'a>) -> Self {
         match value {
-            AnyStringPart::String(part) => AnyNodeRef::StringLiteral(part),
+            AnyStringPart::String { part, .. } => AnyNodeRef::StringLiteral(part),
             AnyStringPart::Bytes(part) => AnyNodeRef::BytesLiteral(part),
             AnyStringPart::FString { part, .. } => AnyNodeRef::FString(part),
         }
@@ -208,7 +217,7 @@ impl<'a> From<&AnyStringPart<'a>> for AnyNodeRef<'a> {
 impl Ranged for AnyStringPart<'_> {
     fn range(&self) -> TextRange {
         match self {
-            Self::String(part) => part.range(),
+            Self::String { part, .. } => part.range(),
             Self::Bytes(part) => part.range(),
             Self::FString { part, .. } => part.range(),
         }
@@ -218,7 +227,7 @@ impl Ranged for AnyStringPart<'_> {
 impl Format<PyFormatContext<'_>> for AnyStringPart<'_> {
     fn fmt(&self, f: &mut PyFormatter) -> FormatResult<()> {
         match self {
-            AnyStringPart::String(part) => part.format().fmt(f),
+            AnyStringPart::String { part, layout } => part.format().with_options(*layout).fmt(f),
             AnyStringPart::Bytes(bytes_literal) => bytes_literal.format().fmt(f),
             AnyStringPart::FString { part, quoting } => FormatFString::new(part, *quoting).fmt(f),
         }

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__fstring.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__fstring.py.snap
@@ -319,6 +319,7 @@ hello {
 _ = (
     'This string should change its quotes to double quotes'
     f'This string uses double quotes in an expression {"woah"}'
+    f'This f-string does not use any quotes.'
 )
 ```
 
@@ -662,6 +663,7 @@ hello {
 _ = (
     "This string should change its quotes to double quotes"
     f'This string uses double quotes in an expression {"woah"}'
+    f"This f-string does not use any quotes."
 )
 ```
 
@@ -993,6 +995,7 @@ hello {
 _ = (
     'This string should change its quotes to double quotes'
     f'This string uses double quotes in an expression {"woah"}'
+    f'This f-string does not use any quotes.'
 )
 ```
 
@@ -1300,7 +1303,7 @@ _ = (
      # comment 27
      # comment 28
  } woah {x}"
-@@ -287,26 +299,26 @@
+@@ -287,27 +299,27 @@
          if indent2:
              foo = f"""hello world
  hello {
@@ -1342,5 +1345,7 @@ _ = (
 -    'This string should change its quotes to double quotes'
 +    "This string should change its quotes to double quotes"
      f'This string uses double quotes in an expression {"woah"}'
+-    f'This f-string does not use any quotes.'
++    f"This f-string does not use any quotes."
  )
 ```

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__fstring.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__fstring.py.snap
@@ -313,6 +313,13 @@ hello {
           ]
       } --------
 """
+
+
+# Implicit concatenated f-string containing quotes
+_ = (
+    'This string should change its quotes to double quotes'
+    f'This string uses double quotes in an expression {"woah"}'
+)
 ```
 
 ## Outputs
@@ -649,6 +656,13 @@ hello {
                 ]
             } --------
 """
+
+
+# Implicit concatenated f-string containing quotes
+_ = (
+    "This string should change its quotes to double quotes"
+    f'This string uses double quotes in an expression {"woah"}'
+)
 ```
 
 
@@ -973,6 +987,13 @@ hello {
           ]
       } --------
 """
+
+
+# Implicit concatenated f-string containing quotes
+_ = (
+    'This string should change its quotes to double quotes'
+    f'This string uses double quotes in an expression {"woah"}'
+)
 ```
 
 
@@ -1279,7 +1300,7 @@ hello {
      # comment 27
      # comment 28
  } woah {x}"
-@@ -287,19 +299,19 @@
+@@ -287,26 +299,26 @@
          if indent2:
              foo = f"""hello world
  hello {
@@ -1314,4 +1335,12 @@ hello {
 +                ]
 +            } --------
  """
+ 
+ 
+ # Implicit concatenated f-string containing quotes
+ _ = (
+-    'This string should change its quotes to double quotes'
++    "This string should change its quotes to double quotes"
+     f'This string uses double quotes in an expression {"woah"}'
+ )
 ```


### PR DESCRIPTION
This PR fixes a bug where ruff decided on whether the quotes for an implicit concatenated string can be changed for the entire expression instead of deciding on the part-level. 

**Input**
```python
_ = (
    'This string should change its quotes to double quotes'
    f'This string uses double quotes in an expression {"woah"}'
    f'This f-string does not use any quotes.'
)
```

**Stable**
```python
_ = (
    'This string should change its quotes to double quotes'
    f'This string uses double quotes in an expression {"woah"}'
    f'This f-string does not use any quotes.'
)
```


Notice how the formatter doesn't change any quotes only because one f-string has an expression containing double quotes. 

**Preview**
```python
_ = (
    "This string should change its quotes to double quotes"
    f'This string uses double quotes in an expression {"woah"}'
    f"This f-string does not use any quotes."
)
```

This matches black and how Ruff normalizes quotes for regular string literals (the decision is made per literal and for the entire implicit concatenated string expression)

