### PR TITLE
[`flake8-use-pathlib`] Fix typo in link to Path.stat (PTH116)

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_use_pathlib/violations.rs
+++ b/crates/ruff_linter/src/rules/flake8_use_pathlib/violations.rs
@@ -724,7 +724,7 @@ impl Violation for OsReadlink {
 /// ```
 ///
 /// ## References
-/// - [Python documentation: `Path.stat`](https://docs.python.org/3/library/pathlib.html#pathlib.Path.group)
+/// - [Python documentation: `Path.stat`](https://docs.python.org/3/library/pathlib.html#pathlib.Path.stat)
 /// - [Python documentation: `Path.group`](https://docs.python.org/3/library/pathlib.html#pathlib.Path.group)
 /// - [Python documentation: `Path.owner`](https://docs.python.org/3/library/pathlib.html#pathlib.Path.owner)
 /// - [Python documentation: `os.stat`](https://docs.python.org/3/library/os.html#os.stat)


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

There was a typo in the links of the docs of PTH116, where Path.stat used to link to Path.group.
Another rule, PTH202, does it correctly: 
https://github.com/astral-sh/ruff/blob/ec72e675d9325d404864c0848e969f59a89090a7/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/os_path_getsize.rs#L33

This PR only fixes a one word typo.

## Test Plan

<!-- How was it tested? -->
I did not test that the doc generation framework picked up these changes, I assume it will do it successfully.