### PR TITLE
Fix leftover references to `red_knot_python_semantic/vendor/`

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -1,6 +1,6 @@
 [files]
 # https://github.com/crate-ci/typos/issues/868
-extend-exclude = ["crates/red_knot_python_semantic/vendor/**/*", "**/resources/**/*", "**/snapshots/**/*"]
+extend-exclude = ["crates/ruff_vendored/vendor/**/*", "**/resources/**/*", "**/snapshots/**/*"]
 
 [default.extend-words]
 "arange" = "arange"  # e.g. `numpy.arange`

--- a/crates/red_knot_python_semantic/README.md
+++ b/crates/red_knot_python_semantic/README.md
@@ -4,6 +4,6 @@ Semantic analysis for the red-knot project.
 
 ## Vendored types for the stdlib
 
-This crate vendors [typeshed](https://github.com/python/typeshed)'s stubs for the standard library. The vendored stubs can be found in `crates/red_knot_python_semantic/vendor/typeshed`. The file `crates/red_knot_python_semantic/vendor/typeshed/source_commit.txt` tells you the typeshed commit that our vendored stdlib stubs currently correspond to.
+This crate vendors [typeshed](https://github.com/python/typeshed)'s stubs for the standard library. The vendored stubs can be found in `crates/ruff_vendored/vendor/typeshed`. The file `crates/ruff_vendored/vendor/typeshed/source_commit.txt` tells you the typeshed commit that our vendored stdlib stubs currently correspond to.
 
 The typeshed stubs are updated every two weeks via an automated PR using the `sync_typeshed.yaml` workflow in the `.github/workflows` directory. This workflow can also be triggered at any time via [workflow dispatch](https://docs.github.com/en/actions/using-workflows/manually-running-a-workflow#running-a-workflow).

--- a/crates/ruff/tests/snapshots/show_settings__display_default_settings.snap
+++ b/crates/ruff/tests/snapshots/show_settings__display_default_settings.snap
@@ -50,7 +50,7 @@ file_resolver.exclude = [
 	"venv",
 ]
 file_resolver.extend_exclude = [
-	"crates/red_knot_python_semantic/vendor/",
+	"crates/ruff_vendored/vendor/",
 	"crates/ruff/resources/",
 	"crates/ruff_linter/resources/",
 	"crates/ruff_python_formatter/resources/",

--- a/crates/ruff_vendored/README.md
+++ b/crates/ruff_vendored/README.md
@@ -1,8 +1,4 @@
-# Red Knot
-
-Semantic analysis for the red-knot project.
-
-## Vendored types for the stdlib
+# Vendored types for the stdlib
 
 This crate vendors [typeshed](https://github.com/python/typeshed)'s stubs for the standard library. The vendored stubs can be found in `crates/ruff_vendored/vendor/typeshed`. The file `crates/ruff_vendored/vendor/typeshed/source_commit.txt` tells you the typeshed commit that our vendored stdlib stubs currently correspond to.
 

--- a/crates/ruff_vendored/build.rs
+++ b/crates/ruff_vendored/build.rs
@@ -3,7 +3,7 @@
 //!
 //! This script should be automatically run at build time
 //! whenever the script itself changes, or whenever any files
-//! in `crates/red_knot_python_semantic/vendor/typeshed` change.
+//! in `crates/ruff_vendored/vendor/typeshed` change.
 
 use std::fs::File;
 use std::path::Path;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ include = [
 
 [tool.ruff]
 extend-exclude = [
-  "crates/red_knot_python_semantic/vendor/",
+  "crates/ruff_vendored/vendor/",
   "crates/ruff/resources/",
   "crates/ruff_linter/resources/",
   "crates/ruff_python_formatter/resources/",
@@ -75,7 +75,7 @@ ignore = [
 [tool.black]
 force-exclude = '''
 /(
-  | crates/red_knot_python_semantic/vendor
+  | crates/ruff_vendored/vendor
   | crates/ruff_linter/resources
   | crates/ruff_python_formatter/resources
   | crates/ruff_python_parser/resources


### PR DESCRIPTION
## Summary

Updates a red-knot's README to point to the new vendored typeshed location
