### PR TITLE
[red-knot] Allow calling `bool()` with no arguments

### DIFF
--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -592,11 +592,11 @@ impl<'db> Type<'db> {
                 // the specific truthiness value of the input arg, `Literal[True]` for the example above.
                 let is_bool = class.is_stdlib_symbol(db, "builtins", "bool");
                 CallOutcome::callable(if is_bool {
-                    arg_types
-                        .first()
-                        .unwrap_or(&Type::Unknown)
-                        .bool(db)
-                        .into_type(db)
+                    if let Some(arg) = arg_types.first() {
+                        arg.bool(db).into_type(db)
+                    } else {
+                        Type::BooleanLiteral(false)
+                    }
                 } else {
                     Type::Instance(class)
                 })

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -6494,6 +6494,7 @@ mod tests {
             c = bool(None)
             d = bool("")
             e = bool(False)
+            f = bool()
             "#,
         )?;
         assert_public_ty(&db, "/src/a.py", "a", "Literal[False]");
@@ -6501,6 +6502,7 @@ mod tests {
         assert_public_ty(&db, "/src/a.py", "c", "Literal[False]");
         assert_public_ty(&db, "/src/a.py", "d", "Literal[False]");
         assert_public_ty(&db, "/src/a.py", "e", "Literal[False]");
+        assert_public_ty(&db, "/src/a.py", "f", "Literal[False]");
         Ok(())
     }
 


### PR DESCRIPTION
Fixes a small oversight in #13538