### PR TITLE
[DOCS] Add CrowdCent's `numerblox` to Ruff users.

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,6 +417,7 @@ Ruff is used by a number of major open-source projects and companies, including:
 - [Babel](https://github.com/python-babel/babel)
 - Benchling ([Refac](https://github.com/benchling/refac))
 - [Bokeh](https://github.com/bokeh/bokeh)
+- CrowdCent ([NumerBlox](https://github.com/crowdcent/numerblox))
 - [Cryptography (PyCA)](https://github.com/pyca/cryptography)
 - CERN ([Indico](https://getindico.io/))
 - [DVC](https://github.com/iterative/dvc)

--- a/README.md
+++ b/README.md
@@ -417,7 +417,7 @@ Ruff is used by a number of major open-source projects and companies, including:
 - [Babel](https://github.com/python-babel/babel)
 - Benchling ([Refac](https://github.com/benchling/refac))
 - [Bokeh](https://github.com/bokeh/bokeh)
-- CrowdCent ([NumerBlox](https://github.com/crowdcent/numerblox))
+- CrowdCent ([NumerBlox](https://github.com/crowdcent/numerblox)) <!-- typos: ignore -->
 - [Cryptography (PyCA)](https://github.com/pyca/cryptography)
 - CERN ([Indico](https://getindico.io/))
 - [DVC](https://github.com/iterative/dvc)

--- a/_typos.toml
+++ b/_typos.toml
@@ -12,7 +12,7 @@ pn = "pn"  # `import panel as pd` is a thing
 poit = "poit"
 BA = "BA" # acronym for "Bad Allowed", used in testing.
 jod = "jod" # e.g., `jod-thread`
-NumerBlox = "NumerBlox" # Library name in "Who's Using Ruff?"
+Numer = "Numer" # Library name 'NumerBlox' in "Who's Using Ruff?"
 
 [default]
 extend-ignore-re = [

--- a/_typos.toml
+++ b/_typos.toml
@@ -12,6 +12,7 @@ pn = "pn"  # `import panel as pd` is a thing
 poit = "poit"
 BA = "BA" # acronym for "Bad Allowed", used in testing.
 jod = "jod" # e.g., `jod-thread`
+NumerBlox = "NumerBlox" # Library name in "Who's Using Ruff?"
 
 [default]
 extend-ignore-re = [

--- a/_typos.toml
+++ b/_typos.toml
@@ -12,7 +12,6 @@ pn = "pn"  # `import panel as pd` is a thing
 poit = "poit"
 BA = "BA" # acronym for "Bad Allowed", used in testing.
 jod = "jod" # e.g., `jod-thread`
-NumerBlox = "NumerBlox"
 
 [default]
 extend-ignore-re = [

--- a/_typos.toml
+++ b/_typos.toml
@@ -12,6 +12,7 @@ pn = "pn"  # `import panel as pd` is a thing
 poit = "poit"
 BA = "BA" # acronym for "Bad Allowed", used in testing.
 jod = "jod" # e.g., `jod-thread`
+NumerBlox = "NumerBlox"
 
 [default]
 extend-ignore-re = [


### PR DESCRIPTION
Hi, our open source project [NumerBlox](https://github.com/crowdcent/numerblox) migrated to `uv` and `ruff`. Would appreciate the project being included in the list of Ruff users.

## Summary

Add [NumerBlox](https://github.com/crowdcent/numerblox) to Ruff users in README.md. 