### PR TITLE
[red-knot] feat: implement integer comparison

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2083,6 +2083,7 @@ dependencies = [
  "countme",
  "hashbrown",
  "insta",
+ "itertools 0.13.0",
  "ordermap",
  "red_knot_vendored",
  "ruff_db",

--- a/crates/red_knot_python_semantic/Cargo.toml
+++ b/crates/red_knot_python_semantic/Cargo.toml
@@ -24,6 +24,7 @@ bitflags = { workspace = true }
 camino = { workspace = true }
 compact_str = { workspace = true }
 countme = { workspace = true }
+itertools = { workspace = true}
 ordermap = { workspace = true }
 salsa = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -2446,10 +2446,10 @@ impl<'db> TypeInferenceBuilder<'db> {
     /// Computes the output of a chain of (one) boolean operation, consuming as input an iterator
     /// of types. The iterator is consumed even if the boolean evaluation can be short-circuited,
     /// in order to ensure the invariant that all expressions are evaluated when inferring types.
-    fn infer_chained_boolean_types<T: Into<Type<'db>>>(
+    fn infer_chained_boolean_types(
         db: &'db dyn Db,
         op: ast::BoolOp,
-        values: impl IntoIterator<Item = T>,
+        values: impl IntoIterator<Item = Type<'db>>,
         n_values: usize,
     ) -> Type<'db> {
         let mut done = false;
@@ -2460,17 +2460,16 @@ impl<'db> TypeInferenceBuilder<'db> {
                     Type::Never
                 } else {
                     let is_last = i == n_values - 1;
-                    let value_ty: Type<'db> = ty.into();
-                    match (value_ty.bool(db), is_last, op) {
-                        (Truthiness::Ambiguous, _, _) => value_ty,
+                    match (ty.bool(db), is_last, op) {
+                        (Truthiness::Ambiguous, _, _) => ty,
                         (Truthiness::AlwaysTrue, false, ast::BoolOp::And) => Type::Never,
                         (Truthiness::AlwaysFalse, false, ast::BoolOp::Or) => Type::Never,
                         (Truthiness::AlwaysFalse, _, ast::BoolOp::And)
                         | (Truthiness::AlwaysTrue, _, ast::BoolOp::Or) => {
                             done = true;
-                            value_ty
+                            ty
                         }
-                        (_, true, _) => value_ty,
+                        (_, true, _) => ty,
                     }
                 }
             }),

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -2487,9 +2487,8 @@ impl<'db> TypeInferenceBuilder<'db> {
         } = compare;
 
         self.infer_expression(left);
-        for expr in comparators {
-            self.infer_expression(expr);
-        }
+        for right in comparators.as_ref() {
+            self.infer_expression(right);
 
         // https://docs.python.org/3/reference/expressions.html#comparisons
         // > Formally, if `a, b, c, …, y, z` are expressions and `op1, op2, …, opN` are comparison

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -2516,7 +2516,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                                 AnyNodeRef::ExprCompare(compare),
                                 "operator-unsupported",
                                 format_args!(
-                                    "Operator \"{}\" is not supported for types {} and {}",
+                                    "Operator `{}` is not supported for types `{}` and `{}`",
                                     op,
                                     left_ty.display(self.db),
                                     right_ty.display(self.db)
@@ -4118,9 +4118,9 @@ mod tests {
             &db,
             "src/a.py",
             &[
-                "Operator \"in\" is not supported for types Literal[1] and Literal[7]",
-                "Operator \"not in\" is not supported for types Literal[0] and Literal[10]",
-                "Operator \"<\" is not supported for types object and Literal[5]",
+                "Operator `in` is not supported for types `Literal[1]` and `Literal[7]`",
+                "Operator `not in` is not supported for types `Literal[0]` and `Literal[10]`",
+                "Operator `<` is not supported for types `object` and `Literal[5]`",
             ],
         );
         assert_public_ty(&db, "src/a.py", "a", "bool");

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -2574,16 +2574,12 @@ impl<'db> TypeInferenceBuilder<'db> {
                 // Undefined for (int, int)
                 ast::CmpOp::In | ast::CmpOp::NotIn => None,
             },
-            (Type::IntLiteral(_), Type::Instance(_)) => self.infer_binary_type_comparison(
-                builtins_symbol_ty(self.db, "int").to_instance(self.db),
-                op,
-                right,
-            ),
-            (Type::Instance(_), Type::IntLiteral(_)) => self.infer_binary_type_comparison(
-                left,
-                op,
-                builtins_symbol_ty(self.db, "int").to_instance(self.db),
-            ),
+            (Type::IntLiteral(_), Type::Instance(_)) => {
+                self.infer_binary_type_comparison(Type::builtin_int_instance(self.db), op, right)
+            }
+            (Type::Instance(_), Type::IntLiteral(_)) => {
+                self.infer_binary_type_comparison(left, op, Type::builtin_int_instance(self.db))
+            }
             // Booleans are coded as integers (False = 0, True = 1)
             (Type::IntLiteral(n), Type::BooleanLiteral(b)) => self.infer_binary_type_comparison(
                 Type::IntLiteral(n),

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -2534,7 +2534,7 @@ impl<'db> TypeInferenceBuilder<'db> {
         )
     }
 
-    /// Infers the type of a binary comparison (e.g. '<left> == <right>'). See
+    /// Infers the type of a binary comparison (e.g. 'left == right'). See
     /// `infer_compare_expression` for the higher level logic dealing with multi-comparison
     /// expressions.
     ///
@@ -3146,7 +3146,7 @@ fn perform_rich_comparison<'db>(
     //
     // TODO: the reflected dunder actually has priority if the r.h.s. is a strict subclass of the
     // l.h.s.
-    // TODO: __neq__ in object will call __eq__ if __neq__ is not defined
+    // TODO: `object.__ne__` will call `__eq__` if `__ne__` is not defined
 
     let dunder = left.class_member(db, dunder_name);
     if !dunder.is_unbound() {

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -2551,9 +2551,10 @@ impl<'db> TypeInferenceBuilder<'db> {
         op: ast::CmpOp,
         right: Type<'db>,
     ) -> Option<Type<'db>> {
-        // Note: identity (is, is not) is unreliable in Python and not part of the language specs.
-        // - `[ast::CompOp::Is]`: return `false` if different, `bool` if the same
-        // - `[ast::CompOp::IsNot]`: return `true` if different, `bool` if the same
+        // Note: identity (is, is not) for equal builtin types is unreliable and not part of the
+        // language spec.
+        // - `[ast::CompOp::Is]`: return `false` if unequal, `bool` if equal
+        // - `[ast::CompOp::IsNot]`: return `true` if unequal, `bool` if equal
         match (left, right) {
             (Type::IntLiteral(n), Type::IntLiteral(m)) => match op {
                 ast::CmpOp::Eq => Some(Type::BooleanLiteral(n == m)),

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -2489,6 +2489,7 @@ impl<'db> TypeInferenceBuilder<'db> {
         self.infer_expression(left);
         for right in comparators.as_ref() {
             self.infer_expression(right);
+        }
 
         // https://docs.python.org/3/reference/expressions.html#comparisons
         // > Formally, if `a, b, c, …, y, z` are expressions and `op1, op2, …, opN` are comparison


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Implements the comparison operator for `[Type::IntLiteral]` and `[Type::BoolLiteral]` (as an artifact of special handling of `True` and `False` in python).
Sets the framework to implement more comparison for types known at static time (e.g. `BoolLiteral`, `StringLiteral`), allowing us to only implement cases of the triplet `<left> Type`, `<right> Type`, `CmpOp`.
Contributes to #12701 (without checking off an item yet).

## Implementation Details

I couldn't avoid allocating a `Vec<Type>` for the first evaluation of initial expressions before iterating over pairs of expression types (`.windows(2)`). Currently, I couldn't use `.windows` on iterators. This seems to be possible using some crates or an experimental API. If anyone has an idea on how to achieve this without allocation, I'd love to hear it.

## Test Plan

- Added a test for the comparison of literals that should include most cases of note.
- Added a test for the comparison of int instances

Please note that the cases do not cover 100% of the branches as there are many and the current testing strategy with variables make this fairly confusing once we have too many in one test.

I'll probably open a separate PR with a candidate util function for cases like this (checking the public type of many separate statements).
