### PR TITLE
`ruff_benchmark`: open all `tomllib` files in the red-knot benchmark

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2325,6 +2325,7 @@ dependencies = [
  "ruff_python_formatter",
  "ruff_python_parser",
  "ruff_python_trivia",
+ "rustc-hash 2.0.0",
  "serde",
  "serde_json",
  "tikv-jemallocator",

--- a/crates/ruff_benchmark/Cargo.toml
+++ b/crates/ruff_benchmark/Cargo.toml
@@ -41,6 +41,7 @@ codspeed-criterion-compat = { workspace = true, default-features = false, option
 criterion = { workspace = true, default-features = false }
 once_cell = { workspace = true }
 rayon = { workspace = true }
+rustc-hash = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 url = { workspace = true }

--- a/crates/ruff_benchmark/benches/red_knot.rs
+++ b/crates/ruff_benchmark/benches/red_knot.rs
@@ -10,13 +10,13 @@ use ruff_benchmark::criterion::{criterion_group, criterion_main, BatchSize, Crit
 use ruff_benchmark::TestFile;
 use ruff_db::files::{system_path_to_file, File};
 use ruff_db::source::source_text;
-use ruff_db::system::{MemoryFileSystem, SystemPath, TestSystem};
+use ruff_db::system::{MemoryFileSystem, SystemPath, SystemPathBuf, TestSystem};
 
 struct Case {
     db: RootDatabase,
     fs: MemoryFileSystem,
     re: File,
-    re_path: &'static SystemPath,
+    re_path: SystemPathBuf,
 }
 
 const TOMLLIB_312_URL: &str = "https://raw.githubusercontent.com/python/cpython/8e8a4baf652f6e1cee7acde9d78c4b6154539748/Lib/tomllib";
@@ -40,23 +40,21 @@ fn get_test_file(name: &str) -> TestFile {
     TestFile::try_download(&path, &url).unwrap()
 }
 
+fn tomllib_path(filename: &str) -> SystemPathBuf {
+    SystemPathBuf::from(format!("/src/tomllib/{filename}").as_str())
+}
+
 fn setup_case() -> Case {
     let system = TestSystem::default();
     let fs = system.memory_file_system().clone();
-    let parser_path = SystemPath::new("/src/tomllib/_parser.py");
-    let re_path = SystemPath::new("/src/tomllib/_re.py");
-    fs.write_files([
+
+    let tomllib_filenames = ["__init__.py", "_parser.py", "_re.py", "_types.py"];
+    fs.write_files(tomllib_filenames.iter().map(|filename| {
         (
-            SystemPath::new("/src/tomllib/__init__.py"),
-            get_test_file("__init__.py").code(),
-        ),
-        (parser_path, get_test_file("_parser.py").code()),
-        (re_path, get_test_file("_re.py").code()),
-        (
-            SystemPath::new("/src/tomllib/_types.py"),
-            get_test_file("_types.py").code(),
-        ),
-    ])
+            tomllib_path(filename),
+            get_test_file(filename).code().to_string(),
+        )
+    }))
     .unwrap();
 
     let src_root = SystemPath::new("/src");
@@ -71,11 +69,12 @@ fn setup_case() -> Case {
     .unwrap();
 
     let mut db = RootDatabase::new(metadata, system).unwrap();
-    let parser = system_path_to_file(&db, parser_path).unwrap();
+    let parser = system_path_to_file(&db, tomllib_path("_parser.py")).unwrap();
 
     db.workspace().open_file(&mut db, parser);
 
-    let re = system_path_to_file(&db, re_path).unwrap();
+    let re_path = tomllib_path("_re.py");
+    let re = system_path_to_file(&db, &re_path).unwrap();
 
     Case {
         db,
@@ -112,7 +111,7 @@ fn benchmark_incremental(criterion: &mut Criterion) {
 
                 case.fs
                     .write_file(
-                        case.re_path,
+                        &case.re_path,
                         format!("{}\n# A comment\n", source_text(&case.db, case.re).as_str()),
                     )
                     .unwrap();


### PR DESCRIPTION
## Summary

I noticed that the red-knot benchmark was reporting different diagnostics on `tomllib` than red-knot did if you just ran red-knot from the CLI on the `tomllib` copied-and-pasted into an empty directory locally. Specifically, the following diagnostic was not being reported by the red-knot benchmark, but _was_ being reported if you just ran red-knot locally:

```
/src/tomllib/__init__.py:10:30: Name '__name__' used when not defined.
```

After some investigation, I realised that the culprit was this line here:

https://github.com/astral-sh/ruff/blob/2a36b47f1395284d32ae2015e6c626f242922224/crates/ruff_benchmark/benches/red_knot.rs#L76

"Opening" the `tomllib/_parser.py` file means that red-knot will only check `_parser.py` and files that `_parser.py` depends on. `_parser.py` doesn't depend on `__init__.py`, so `__init__.py` isn't being checked at all by the red-knot benchmark currently. This PR therefore changes the benchmark so that all `tomllib` files are "opened", and thus all `tomllib` files are checked.

The first commit in this PR should have no impact on behaviour: it's just some refactoring I did so that I could see more clearly which files were being downloaded by the benchmark and copied into the `tomllib` directory used by the benchmark. 

## Test Plan

`cargo bench -p ruff_benchmark -- red_knot`