### PR TITLE
Support ruff discovery in pip build environments

### DIFF
--- a/python/ruff/__main__.py
+++ b/python/ruff/__main__.py
@@ -33,12 +33,14 @@ def find_ruff_bin() -> str:
     if os.path.isfile(target_path):
         return target_path
 
-    # Might be a pip build environment
+    # Search for pip-specific build environments.
+    #
+    # See: https://github.com/pypa/pip/blob/102d8187a1f5a4cd5de7a549fd8a9af34e89a54f/src/pip/_internal/build_env.py#L87
     paths = os.environ.get("PATH", "").split(os.pathsep)
     if len(paths) >= 2:
-        # https://github.com/pypa/pip/blob/main/src/pip/_internal/build_env.py#L87
         first, second = os.path.split(paths[0]), os.path.split(paths[1])
-        # we need an overlay and normal folder within pip-build-env-{random} folders
+        # Search for both an `overlay` and `normal` folder within a `pip-build-env-{random}` folder. (The final segment
+        # of the path is the `bin` directory.)
         if (
             len(first) >= 3
             and len(second) >= 3
@@ -47,7 +49,8 @@ def find_ruff_bin() -> str:
             and second[-3].startswith("pip-build-env-")
             and second[-2] == "normal"
         ):
-            candidate = os.path.join(first, ruff_exe)  # the overlay contains ruff
+            # The overlay must contain the ruff binary.
+            candidate = os.path.join(first, ruff_exe)
             if os.path.isfile(candidate):
                 return candidate
 

--- a/python/ruff/__main__.py
+++ b/python/ruff/__main__.py
@@ -33,6 +33,24 @@ def find_ruff_bin() -> str:
     if os.path.isfile(target_path):
         return target_path
 
+    # Might be a pip build environment
+    paths = os.environ.get("PATH", "").split(os.pathsep)
+    if len(paths) >= 2:
+        # https://github.com/pypa/pip/blob/main/src/pip/_internal/build_env.py#L87
+        first, second = os.path.split(paths[0]), os.path.split(paths[1])
+        # we need an overlay and normal folder within pip-build-env-{random} folders
+        if (
+            len(first) >= 3
+            and len(second) >= 3
+            and first[-3].startswith("pip-build-env-")
+            and first[-2] == "overlay"
+            and second[-3].startswith("pip-build-env-")
+            and second[-2] == "normal"
+        ):
+            candidate = os.path.join(first, ruff_exe)  # the overlay contains ruff
+            if os.path.isfile(candidate):
+                return candidate
+
     raise FileNotFoundError(scripts_path)
 
 


### PR DESCRIPTION
Resolves https://github.com/astral-sh/ruff/issues/13321.

Contents of overlay:
```bash
/private/var/folders/v0/l8q3ghks2gs5ns2_p63tyqh40000gq/T/pip-build-env-e0ukpbvo/overlay/bin:
total 26M
-rwxr-xr-x 1 bgabor8 staff 26M Oct  1 08:22 ruff
drwxr-xr-x 3 bgabor8 staff  96 Oct  1 08:22 .
drwxr-xr-x 4 bgabor8 staff 128 Oct  1 08:22 ..
```

Python executable:
```bash
'/Users/bgabor8/git/github/ruff-find-bin-during-build/.venv/bin/python'
```
PATH is:
```bash
['/private/var/folders/v0/l8q3ghks2gs5ns2_p63tyqh40000gq/T/pip-build-env-e0ukpbvo/overlay/bin',
 '/private/var/folders/v0/l8q3ghks2gs5ns2_p63tyqh40000gq/T/pip-build-env-e0ukpbvo/normal/bin',
'/Library/Frameworks/Python.framework/Versions/3.11/bin',
'/Library/Frameworks/Python.framework/Versions/3.12/bin',
```
Not sure where to add tests, there does not seem to be any existing one. Can someone help me with that?