### PR TITLE
[red-knot] [minor] Improve helper methods for builtin types

### DIFF
--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -385,8 +385,12 @@ impl<'db> Type<'db> {
         }
     }
 
-    pub fn builtin_str(db: &'db dyn Db) -> Self {
-        builtins_symbol_ty(db, "str")
+    pub fn builtin_str_instance(db: &'db dyn Db) -> Self {
+        builtins_symbol_ty(db, "str").to_instance(db)
+    }
+
+    pub fn builtin_int_instance(db: &'db dyn Db) -> Self {
+        builtins_symbol_ty(db, "int").to_instance(db)
     }
 
     pub fn is_stdlib_symbol(&self, db: &'db dyn Db, module_name: &str, name: &str) -> bool {
@@ -765,7 +769,7 @@ impl<'db> Type<'db> {
             Type::IntLiteral(_) | Type::BooleanLiteral(_) => self.repr(db),
             Type::StringLiteral(_) | Type::LiteralString => *self,
             // TODO: handle more complex types
-            _ => Type::builtin_str(db).to_instance(db),
+            _ => Type::builtin_str_instance(db),
         }
     }
 
@@ -788,7 +792,7 @@ impl<'db> Type<'db> {
             })),
             Type::LiteralString => Type::LiteralString,
             // TODO: handle more complex types
-            _ => Type::builtin_str(db).to_instance(db),
+            _ => Type::builtin_str_instance(db),
         }
     }
 }

--- a/crates/red_knot_python_semantic/src/types/builder.rs
+++ b/crates/red_knot_python_semantic/src/types/builder.rs
@@ -389,7 +389,7 @@ mod tests {
     #[test]
     fn build_union_simplify_subtype() {
         let db = setup_db();
-        let t0 = builtins_symbol_ty(&db, "str").to_instance(&db);
+        let t0 = Type::builtin_str_instance(&db);
         let t1 = Type::LiteralString;
         let u0 = UnionType::from_elements(&db, [t0, t1]);
         let u1 = UnionType::from_elements(&db, [t1, t0]);
@@ -401,7 +401,7 @@ mod tests {
     #[test]
     fn build_union_no_simplify_unknown() {
         let db = setup_db();
-        let t0 = builtins_symbol_ty(&db, "str").to_instance(&db);
+        let t0 = Type::builtin_str_instance(&db);
         let t1 = Type::Unknown;
         let u0 = UnionType::from_elements(&db, [t0, t1]);
         let u1 = UnionType::from_elements(&db, [t1, t0]);
@@ -413,8 +413,8 @@ mod tests {
     #[test]
     fn build_union_subsume_multiple() {
         let db = setup_db();
-        let str_ty = builtins_symbol_ty(&db, "str").to_instance(&db);
-        let int_ty = builtins_symbol_ty(&db, "int").to_instance(&db);
+        let str_ty = Type::builtin_str_instance(&db);
+        let int_ty = Type::builtin_int_instance(&db);
         let object_ty = builtins_symbol_ty(&db, "object").to_instance(&db);
         let unknown_ty = Type::Unknown;
 

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -1688,7 +1688,7 @@ impl<'db> TypeInferenceBuilder<'db> {
             ast::Number::Int(n) => n
                 .as_i64()
                 .map(Type::IntLiteral)
-                .unwrap_or_else(|| builtins_symbol_ty(self.db, "int").to_instance(self.db)),
+                .unwrap_or_else(|| Type::builtin_int_instance(self.db)),
             ast::Number::Float(_) => builtins_symbol_ty(self.db, "float").to_instance(self.db),
             ast::Number::Complex { .. } => {
                 builtins_symbol_ty(self.db, "complex").to_instance(self.db)
@@ -2327,17 +2327,17 @@ impl<'db> TypeInferenceBuilder<'db> {
             (Type::IntLiteral(n), Type::IntLiteral(m), ast::Operator::Add) => n
                 .checked_add(m)
                 .map(Type::IntLiteral)
-                .unwrap_or_else(|| builtins_symbol_ty(self.db, "int").to_instance(self.db)),
+                .unwrap_or_else(|| Type::builtin_int_instance(self.db)),
 
             (Type::IntLiteral(n), Type::IntLiteral(m), ast::Operator::Sub) => n
                 .checked_sub(m)
                 .map(Type::IntLiteral)
-                .unwrap_or_else(|| builtins_symbol_ty(self.db, "int").to_instance(self.db)),
+                .unwrap_or_else(|| Type::builtin_int_instance(self.db)),
 
             (Type::IntLiteral(n), Type::IntLiteral(m), ast::Operator::Mult) => n
                 .checked_mul(m)
                 .map(Type::IntLiteral)
-                .unwrap_or_else(|| builtins_symbol_ty(self.db, "int").to_instance(self.db)),
+                .unwrap_or_else(|| Type::builtin_int_instance(self.db)),
 
             (Type::IntLiteral(_), Type::IntLiteral(_), ast::Operator::Div) => {
                 builtins_symbol_ty(self.db, "float").to_instance(self.db)
@@ -2346,12 +2346,12 @@ impl<'db> TypeInferenceBuilder<'db> {
             (Type::IntLiteral(n), Type::IntLiteral(m), ast::Operator::FloorDiv) => n
                 .checked_div(m)
                 .map(Type::IntLiteral)
-                .unwrap_or_else(|| builtins_symbol_ty(self.db, "int").to_instance(self.db)),
+                .unwrap_or_else(|| Type::builtin_int_instance(self.db)),
 
             (Type::IntLiteral(n), Type::IntLiteral(m), ast::Operator::Mod) => n
                 .checked_rem(m)
                 .map(Type::IntLiteral)
-                .unwrap_or_else(|| builtins_symbol_ty(self.db, "int").to_instance(self.db)),
+                .unwrap_or_else(|| Type::builtin_int_instance(self.db)),
 
             (Type::BytesLiteral(lhs), Type::BytesLiteral(rhs), ast::Operator::Add) => {
                 Type::BytesLiteral(BytesLiteralType::new(
@@ -2911,7 +2911,7 @@ impl StringPartsCollector {
 
     fn ty(self, db: &dyn Db) -> Type {
         if self.expression {
-            Type::builtin_str(db).to_instance(db)
+            Type::builtin_str_instance(db)
         } else if let Some(concatenated) = self.concatenated {
             Type::StringLiteral(StringLiteralType::new(db, concatenated.into_boxed_str()))
         } else {


### PR DESCRIPTION
## Summary

https://github.com/astral-sh/ruff/commit/16394880822f017ac3c5856f6c29cfa95f779c97 added a `Type::builtin_str()` helper method. We call `builtin_symbol_ty(&db, "int")` at least as often, so I think it probably makes sense to have a helper method for that as well. In the vast majority of cases, we're also immediately calling `.to_instance()` on the returned type, so I think it makes sense to have `builtin_str_instance()` and `builtin_int_instance()` helpers rather than `builtin_str()` and `builtin_int` helpers.

## Test Plan

`cargo test -p red_knot_python_semantic`
