### PR TITLE
Use backticks for code in red-knot messages

### DIFF
--- a/crates/red_knot/src/main.rs
+++ b/crates/red_knot/src/main.rs
@@ -160,7 +160,7 @@ fn run() -> anyhow::Result<ExitStatus> {
         SystemPathBuf::from_path_buf(cwd)
             .map_err(|path| {
                 anyhow!(
-                    "The current working directory '{}' contains non-unicode characters. Red Knot only supports unicode paths.",
+                    "The current working directory `{}` contains non-Unicode characters. Red Knot only supports Unicode paths.",
                     path.display()
                 )
             })?

--- a/crates/red_knot/src/main.rs
+++ b/crates/red_knot/src/main.rs
@@ -174,7 +174,7 @@ fn run() -> anyhow::Result<ExitStatus> {
                 Ok(SystemPath::absolute(cwd, &cli_base_path))
             } else {
                 Err(anyhow!(
-                    "Provided current-directory path '{cwd}' is not a directory."
+                    "Provided current-directory path `{cwd}` is not a directory"
                 ))
             }
         })

--- a/crates/red_knot/tests/file_watching.rs
+++ b/crates/red_knot/tests/file_watching.rs
@@ -42,14 +42,14 @@ impl TestCase {
 
     fn stop_watch(&mut self) -> Vec<watch::ChangeEvent> {
         self.try_stop_watch(Duration::from_secs(10))
-            .expect("Expected watch changes but observed none.")
+            .expect("Expected watch changes but observed none")
     }
 
     fn try_stop_watch(&mut self, timeout: Duration) -> Option<Vec<watch::ChangeEvent>> {
         let watcher = self
             .watcher
             .take()
-            .expect("Cannot call `stop_watch` more than once.");
+            .expect("Cannot call `stop_watch` more than once");
 
         let mut all_events = self
             .changes_receiver
@@ -72,7 +72,7 @@ impl TestCase {
     #[cfg(unix)]
     fn take_watch_changes(&self) -> Vec<watch::ChangeEvent> {
         self.try_take_watch_changes(Duration::from_secs(10))
-            .expect("Expected watch changes but observed none.")
+            .expect("Expected watch changes but observed none")
     }
 
     fn try_take_watch_changes(&self, timeout: Duration) -> Option<Vec<watch::ChangeEvent>> {
@@ -150,14 +150,14 @@ where
             let absolute_path = workspace_path.join(relative_path);
             if let Some(parent) = absolute_path.parent() {
                 std::fs::create_dir_all(parent).with_context(|| {
-                    format!("Failed to create parent directory for file '{relative_path}'.",)
+                    format!("Failed to create parent directory for file `{relative_path}`")
                 })?;
             }
 
             let mut file = std::fs::File::create(absolute_path.as_std_path())
-                .with_context(|| format!("Failed to open file '{relative_path}'"))?;
+                .with_context(|| format!("Failed to open file `{relative_path}`"))?;
             file.write_all(content.as_bytes())
-                .with_context(|| format!("Failed to write to file '{relative_path}'"))?;
+                .with_context(|| format!("Failed to write to file `{relative_path}`"))?;
             file.sync_data()?;
         }
 
@@ -209,7 +209,7 @@ where
     let workspace_path = root_path.join("workspace");
 
     std::fs::create_dir_all(workspace_path.as_std_path())
-        .with_context(|| format!("Failed to create workspace directory '{workspace_path}'",))?;
+        .with_context(|| format!("Failed to create workspace directory `{workspace_path}`"))?;
 
     setup_files
         .setup(&root_path, &workspace_path)
@@ -233,7 +233,7 @@ where
         }))
     {
         std::fs::create_dir_all(path.as_std_path())
-            .with_context(|| format!("Failed to create search path '{path}'"))?;
+            .with_context(|| format!("Failed to create search path `{path}`"))?;
     }
 
     let configuration = Configuration {
@@ -665,7 +665,7 @@ fn directory_deleted() -> anyhow::Result<()> {
 
     let bar = case.system_file(case.workspace_path("bar.py")).unwrap();
 
-    assert!(resolve_module(case.db().upcast(), ModuleName::new_static("sub.a").unwrap()).is_some(),);
+    assert!(resolve_module(case.db().upcast(), ModuleName::new_static("sub.a").unwrap()).is_some());
 
     let sub_path = case.workspace_path("sub");
 

--- a/crates/red_knot/tests/file_watching.rs
+++ b/crates/red_knot/tests/file_watching.rs
@@ -194,7 +194,7 @@ where
 
     let root_path = SystemPath::from_std_path(temp_dir.path()).ok_or_else(|| {
         anyhow!(
-            "Temp directory '{}' is not a valid UTF-8 path.",
+            "Temporary directory `{}` is not a valid UTF-8 path.",
             temp_dir.path().display()
         )
     })?;

--- a/crates/red_knot_python_semantic/src/module_resolver/resolver.rs
+++ b/crates/red_knot_python_semantic/src/module_resolver/resolver.rs
@@ -36,14 +36,14 @@ pub(crate) fn resolve_module_query<'db>(
     let _span = tracing::trace_span!("resolve_module", %name).entered();
 
     let Some((search_path, module_file, kind)) = resolve_name(db, name) else {
-        tracing::debug!("Module '{name}' not found in the search paths.");
+        tracing::debug!("Module `{name}` not found in search paths");
         return None;
     };
 
     let module = Module::new(name.clone(), kind, search_path, module_file);
 
     tracing::trace!(
-        "Resolved module '{name}' to '{path}'.",
+        "Resolved module `{name}` to `{path}`",
         path = module_file.path(db)
     );
 
@@ -324,7 +324,7 @@ pub(crate) fn dynamic_resolution_paths(db: &dyn Db) -> Vec<SearchPath> {
 
         let site_packages_root = files
             .root(db.upcast(), site_packages_dir)
-            .expect("Site-package root to have been created.");
+            .expect("Site-package root to have been created");
 
         // This query needs to be re-executed each time a `.pth` file
         // is added, modified or removed from the `site-packages` directory.

--- a/crates/red_knot_python_semantic/src/site_packages.rs
+++ b/crates/red_knot_python_semantic/src/site_packages.rs
@@ -192,7 +192,7 @@ impl VirtualEnvironment {
             } else {
                 tracing::warn!(
                     "Failed to resolve `sys.prefix` of the system Python installation \
-from the `home` value in the `pyvenv.cfg` file at '{}'. \
+from the `home` value in the `pyvenv.cfg` file at `{}`. \
 System site-packages will not be used for module resolution.",
                     venv_path.join("pyvenv.cfg")
                 );
@@ -426,7 +426,7 @@ impl Deref for SysPrefixPath {
 
 impl fmt::Display for SysPrefixPath {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "`sys.prefix` path '{}'", self.0)
+        write!(f, "`sys.prefix` path `{}`", self.0)
     }
 }
 
@@ -483,7 +483,7 @@ impl Deref for PythonHomePath {
 
 impl fmt::Display for PythonHomePath {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "`home` location '{}'", self.0)
+        write!(f, "`home` location `{}`", self.0)
     }
 }
 

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -169,7 +169,7 @@ fn bindings_ty<'db>(
 
     let first = all_types
         .next()
-        .expect("bindings_ty should never be called with zero definitions and no unbound_ty.");
+        .expect("bindings_ty should never be called with zero definitions and no unbound_ty");
 
     if let Some(second) = all_types.next() {
         UnionType::from_elements(db, [first, second].into_iter().chain(all_types))
@@ -204,7 +204,7 @@ fn declarations_ty<'db>(
     let mut all_types = undeclared_ty.into_iter().chain(decl_types);
 
     let first = all_types.next().expect(
-        "declarations_ty must not be called with zero declarations and no may-be-undeclared.",
+        "declarations_ty must not be called with zero declarations and no may-be-undeclared",
     );
 
     let mut conflicting: Vec<Type<'db>> = vec![];
@@ -917,7 +917,7 @@ impl<'db> CallOutcome<'db> {
                     node,
                     "call-non-callable",
                     format_args!(
-                        "Object of type `{}` is not callable.",
+                        "Object of type `{}` is not callable",
                         not_callable_ty.display(db)
                     ),
                 );
@@ -932,7 +932,7 @@ impl<'db> CallOutcome<'db> {
                     node,
                     "call-non-callable",
                     format_args!(
-                        "Object of type `{}` is not callable (due to union element `{}`).",
+                        "Object of type `{}` is not callable (due to union element `{}`)",
                         called_ty.display(db),
                         not_callable_ty.display(db),
                     ),
@@ -948,7 +948,7 @@ impl<'db> CallOutcome<'db> {
                     node,
                     "call-non-callable",
                     format_args!(
-                        "Object of type `{}` is not callable (due to union elements {}).",
+                        "Object of type `{}` is not callable (due to union elements {})",
                         called_ty.display(db),
                         not_callable_tys.display(db),
                     ),
@@ -974,7 +974,7 @@ impl<'db> CallOutcome<'db> {
                 builder.add_diagnostic(
                     node,
                     "revealed-type",
-                    format_args!("Revealed type is `{}`.", revealed_ty.display(db)),
+                    format_args!("Revealed type is `{}`", revealed_ty.display(db)),
                 );
                 Ok(*return_ty)
             }

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -917,7 +917,7 @@ impl<'db> CallOutcome<'db> {
                     node,
                     "call-non-callable",
                     format_args!(
-                        "Object of type '{}' is not callable.",
+                        "Object of type `{}` is not callable.",
                         not_callable_ty.display(db)
                     ),
                 );
@@ -932,7 +932,7 @@ impl<'db> CallOutcome<'db> {
                     node,
                     "call-non-callable",
                     format_args!(
-                        "Object of type '{}' is not callable (due to union element '{}').",
+                        "Object of type `{}` is not callable (due to union element `{}`).",
                         called_ty.display(db),
                         not_callable_ty.display(db),
                     ),
@@ -948,7 +948,7 @@ impl<'db> CallOutcome<'db> {
                     node,
                     "call-non-callable",
                     format_args!(
-                        "Object of type '{}' is not callable (due to union elements {}).",
+                        "Object of type `{}` is not callable (due to union elements {}).",
                         called_ty.display(db),
                         not_callable_tys.display(db),
                     ),
@@ -974,7 +974,7 @@ impl<'db> CallOutcome<'db> {
                 builder.add_diagnostic(
                     node,
                     "revealed-type",
-                    format_args!("Revealed type is '{}'.", revealed_ty.display(db)),
+                    format_args!("Revealed type is `{}`.", revealed_ty.display(db)),
                 );
                 Ok(*return_ty)
             }

--- a/crates/red_knot_python_semantic/src/types/display.rs
+++ b/crates/red_knot_python_semantic/src/types/display.rs
@@ -37,7 +37,7 @@ impl Display for DisplayType<'_> {
                 | Type::Class(_)
                 | Type::Function(_)
         ) {
-            write!(f, "Literal[{representation}]",)
+            write!(f, "Literal[{representation}]")
         } else {
             representation.fmt(f)
         }
@@ -335,7 +335,7 @@ mod tests {
             class B: ...
             ",
         )?;
-        let mod_file = system_path_to_file(&db, "src/main.py").expect("Expected file to exist.");
+        let mod_file = system_path_to_file(&db, "src/main.py").expect("file to exist");
 
         let union_elements = &[
             Type::Unknown,

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -480,12 +480,12 @@ impl<'db> TypeInferenceBuilder<'db> {
         match declared_ty {
             Type::Class(class) => {
                 self.add_diagnostic(node, "invalid-assignment", format_args!(
-                        "Implicit shadowing of class '{}'; annotate to make it explicit if this is intentional.",
+                        "Implicit shadowing of class `{}`; annotate to make it explicit if this is intentional.",
                         class.name(self.db)));
             }
             Type::Function(function) => {
                 self.add_diagnostic(node, "invalid-assignment", format_args!(
-                        "Implicit shadowing of function '{}'; annotate to make it explicit if this is intentional.",
+                        "Implicit shadowing of function `{}`; annotate to make it explicit if this is intentional.",
                         function.name(self.db)));
             }
             _ => {
@@ -493,7 +493,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                     node,
                     "invalid-assignment",
                     format_args!(
-                        "Object of type '{}' is not assignable to '{}'.",
+                        "Object of type `{}` is not assignable to `{}`.",
                         assigned_ty.display(self.db),
                         declared_ty.display(self.db),
                     ),
@@ -525,7 +525,7 @@ impl<'db> TypeInferenceBuilder<'db> {
             expr.into(),
             "division-by-zero",
             format_args!(
-                "Cannot {op} object of type '{}' {by_zero}",
+                "Cannot {op} object of type `{}` {by_zero}",
                 left.display(self.db)
             ),
         );
@@ -550,7 +550,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                     node,
                     "conflicting-declarations",
                     format_args!(
-                        "Conflicting declared types for '{symbol_name}': {}.",
+                        "Conflicting declared types for `{symbol_name}`: {}.",
                         conflicting.display(self.db)
                     ),
                 );
@@ -579,7 +579,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                 node,
                 "invalid-declaration",
                 format_args!(
-                    "Cannot declare type '{}' for inferred type '{}'.",
+                    "Cannot declare type `{}` for inferred type `{}`.",
                     ty.display(self.db),
                     inferred_ty.display(self.db)
                 ),
@@ -1280,7 +1280,7 @@ impl<'db> TypeInferenceBuilder<'db> {
             node,
             "not-iterable",
             format_args!(
-                "Object of type '{}' is not iterable.",
+                "Object of type `{}` is not iterable.",
                 not_iterable_ty.display(self.db)
             ),
         );
@@ -1298,7 +1298,7 @@ impl<'db> TypeInferenceBuilder<'db> {
             node,
             "index-out-of-bounds",
             format_args!(
-                "Index {index} is out of bounds for tuple of type '{}' with length {length}.",
+                "Index {index} is out of bounds for tuple of type `{}` with length {length}.",
                 tuple_ty.display(self.db)
             ),
         );
@@ -1316,7 +1316,7 @@ impl<'db> TypeInferenceBuilder<'db> {
             node,
             "index-out-of-bounds",
             format_args!(
-                "Index {index} is out of bounds for string '{}' with length {length}.",
+                "Index {index} is out of bounds for string `{}` with length {length}.",
                 string_ty.display(self.db)
             ),
         );
@@ -1333,7 +1333,7 @@ impl<'db> TypeInferenceBuilder<'db> {
             node,
             "non-subscriptable",
             format_args!(
-                "Cannot subscript object of type '{}' with no `{method}` method.",
+                "Cannot subscript object of type `{}` with no `{method}` method.",
                 non_subscriptable_ty.display(self.db)
             ),
         );
@@ -1516,7 +1516,7 @@ impl<'db> TypeInferenceBuilder<'db> {
 
         let module_name = if let Some(level) = NonZeroU32::new(*level) {
             tracing::trace!(
-                "Resolving imported object '{}' from module '{}' relative to file '{}'",
+                "Resolving imported object `{}` from module `{}` relative to file `{}`",
                 alias.name,
                 format_import_from_module(level.get(), module),
                 self.file.path(self.db),
@@ -1524,7 +1524,7 @@ impl<'db> TypeInferenceBuilder<'db> {
             self.relative_module_name(module, level)
         } else {
             tracing::trace!(
-                "Resolving imported object '{}' from module '{}'",
+                "Resolving imported object `{}` from module `{}`",
                 alias.name,
                 format_import_from_module(*level, module),
             );
@@ -1549,7 +1549,7 @@ impl<'db> TypeInferenceBuilder<'db> {
             }
             Err(ModuleNameResolutionError::TooManyDots) => {
                 tracing::debug!(
-                    "Relative module resolution '{}' failed: too many leading dots",
+                    "Relative module resolution `{}` failed: too many leading dots",
                     format_import_from_module(*level, module),
                 );
                 self.unresolved_module_diagnostic(import_from, *level, module);
@@ -1557,7 +1557,7 @@ impl<'db> TypeInferenceBuilder<'db> {
             }
             Err(ModuleNameResolutionError::UnknownCurrentModule) => {
                 tracing::debug!(
-                    "Relative module resolution '{}' failed; could not resolve file '{}' to a module",
+                    "Relative module resolution `{}` failed; could not resolve file `{}` to a module",
                     format_import_from_module(*level, module),
                     self.file.path(self.db)
                 );
@@ -2220,7 +2220,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                         name_node.into(),
                         "undefined-reveal",
                         format_args!(
-                            "'reveal_type' used without importing it; this is allowed for debugging convenience but will fail at runtime."),
+                            "`reveal_type` used without importing it; this is allowed for debugging convenience but will fail at runtime."),
                     );
                     builtin_ty = typing_extensions_symbol_ty(self.db, name);
                 }
@@ -2622,7 +2622,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                                 (&**value).into(),
                                 "call-non-callable",
                                 format_args!(
-                                    "Method `__getitem__` of type '{}' is not callable on object of type '{}'.",
+                                    "Method `__getitem__` of type `{}` is not callable on object of type `{}`.",
                                     err.called_ty().display(self.db),
                                     value_ty.display(self.db),
                                 ),
@@ -2644,7 +2644,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                                     (&**value).into(),
                                     "call-non-callable",
                                     format_args!(
-                                        "Method `__class_getitem__` of type '{}' is not callable on object of type '{}'.",
+                                        "Method `__class_getitem__` of type `{}` is not callable on object of type `{}`.",
                                         err.called_ty().display(self.db),
                                         value_ty.display(self.db),
                                     ),
@@ -3129,7 +3129,7 @@ mod tests {
             ",
         )?;
 
-        assert_file_diagnostics(&db, "/src/a.py", &["Revealed type is 'Literal[1]'."]);
+        assert_file_diagnostics(&db, "/src/a.py", &["Revealed type is `Literal[1]`."]);
 
         Ok(())
     }
@@ -3148,7 +3148,7 @@ mod tests {
             ",
         )?;
 
-        assert_file_diagnostics(&db, "/src/a.py", &["Revealed type is 'Literal[1]'."]);
+        assert_file_diagnostics(&db, "/src/a.py", &["Revealed type is `Literal[1]`."]);
 
         Ok(())
     }
@@ -3167,7 +3167,7 @@ mod tests {
             ",
         )?;
 
-        assert_file_diagnostics(&db, "/src/a.py", &["Revealed type is 'Literal[1]'."]);
+        assert_file_diagnostics(&db, "/src/a.py", &["Revealed type is `Literal[1]`."]);
 
         Ok(())
     }
@@ -3188,8 +3188,8 @@ mod tests {
             &db,
             "/src/a.py",
             &[
-                "'reveal_type' used without importing it; this is allowed for debugging convenience but will fail at runtime.",
-                "Revealed type is 'Literal[1]'.",
+                "`reveal_type` used without importing it; this is allowed for debugging convenience but will fail at runtime.",
+                "Revealed type is `Literal[1]`.",
             ],
         );
 
@@ -4144,7 +4144,7 @@ mod tests {
         assert_file_diagnostics(
             &db,
             "src/a.py",
-            &["Object of type 'Literal[1] | Literal[f]' is not callable (due to union element 'Literal[1]')."],
+            &["Object of type `Literal[1] | Literal[f]` is not callable (due to union element `Literal[1]`)."],
         );
         assert_public_ty(&db, "src/a.py", "x", "Unknown | int");
 
@@ -4173,7 +4173,7 @@ mod tests {
             &db,
             "src/a.py",
             &[
-                r#"Object of type 'Literal[1] | Literal["foo"] | Literal[f]' is not callable (due to union elements Literal[1], Literal["foo"])."#,
+                r#"Object of type `Literal[1] | Literal["foo"] | Literal[f]` is not callable (due to union elements Literal[1], Literal["foo"])."#,
             ],
         );
         assert_public_ty(&db, "src/a.py", "x", "Unknown | int");
@@ -4199,7 +4199,7 @@ mod tests {
         assert_file_diagnostics(
             &db,
             "src/a.py",
-            &[r#"Object of type 'Literal[1] | Literal["foo"]' is not callable."#],
+            &[r#"Object of type `Literal[1] | Literal["foo"]` is not callable."#],
         );
         assert_public_ty(&db, "src/a.py", "x", "Unknown");
 
@@ -4222,7 +4222,7 @@ mod tests {
         assert_file_diagnostics(
             &db,
             "/src/a.py",
-            &["Object of type 'Literal[123]' is not callable."],
+            &["Object of type `Literal[123]` is not callable."],
         );
     }
 
@@ -4297,11 +4297,11 @@ mod tests {
             &db,
             "src/a.py",
             &[
-                "Cannot divide object of type 'Literal[1]' by zero.",
-                "Cannot floor divide object of type 'Literal[2]' by zero.",
-                "Cannot reduce object of type 'Literal[3]' modulo zero.",
-                "Cannot divide object of type 'int' by zero.",
-                "Cannot divide object of type 'float' by zero.",
+                "Cannot divide object of type `Literal[1]` by zero.",
+                "Cannot floor divide object of type `Literal[2]` by zero.",
+                "Cannot reduce object of type `Literal[3]` modulo zero.",
+                "Cannot divide object of type `int` by zero.",
+                "Cannot divide object of type `float` by zero.",
             ],
         );
 
@@ -5658,7 +5658,7 @@ mod tests {
         assert_file_diagnostics(
             &db,
             "src/a.py",
-            &["Object of type 'NotIterable' is not iterable."],
+            &["Object of type `NotIterable` is not iterable."],
         );
         assert_public_ty(&db, "src/a.py", "x", "Unbound | Unknown");
 
@@ -5969,7 +5969,7 @@ mod tests {
         assert_file_diagnostics(
             &db,
             "src/a.py",
-            &["Object of type 'Unbound' is not iterable."],
+            &["Object of type `Unbound` is not iterable."],
         );
 
         Ok(())
@@ -5997,7 +5997,7 @@ mod tests {
 
         assert_scope_ty(&db, "src/a.py", &["foo", "<listcomp>"], "x", "int");
         assert_scope_ty(&db, "src/a.py", &["foo", "<listcomp>"], "z", "Unknown");
-        assert_file_diagnostics(&db, "src/a.py", &["Object of type 'int' is not iterable."]);
+        assert_file_diagnostics(&db, "src/a.py", &["Object of type `int` is not iterable."]);
 
         Ok(())
     }
@@ -6193,7 +6193,7 @@ mod tests {
         assert_file_diagnostics(
             &db,
             "/src/a.py",
-            &["Object of type 'Literal[123]' is not iterable."],
+            &["Object of type `Literal[123]` is not iterable."],
         );
     }
 
@@ -6219,7 +6219,7 @@ mod tests {
         assert_file_diagnostics(
             &db,
             "/src/a.py",
-            &["Object of type 'NotIterable' is not iterable."],
+            &["Object of type `NotIterable` is not iterable."],
         );
     }
 
@@ -6248,7 +6248,7 @@ mod tests {
         assert_file_diagnostics(
             &db,
             "/src/a.py",
-            &["Object of type 'NotIterable' is not iterable."],
+            &["Object of type `NotIterable` is not iterable."],
         );
     }
 
@@ -6278,7 +6278,7 @@ mod tests {
         assert_file_diagnostics(
             &db,
             "/src/a.py",
-            &["Object of type 'NotIterable' is not iterable."],
+            &["Object of type `NotIterable` is not iterable."],
         );
     }
 
@@ -6297,7 +6297,7 @@ mod tests {
         assert_file_diagnostics(
             &db,
             "/src/a.py",
-            &[r#"Object of type 'Literal["foo"]' is not assignable to 'int'."#],
+            &[r#"Object of type `Literal["foo"]` is not assignable to `int`."#],
         );
     }
 
@@ -6317,7 +6317,7 @@ mod tests {
         assert_file_diagnostics(
             &db,
             "/src/a.py",
-            &[r#"Object of type 'Literal["foo"]' is not assignable to 'int'."#],
+            &[r#"Object of type `Literal["foo"]` is not assignable to `int`."#],
         );
     }
 
@@ -6369,7 +6369,7 @@ mod tests {
         assert_file_diagnostics(
             &db,
             "/src/a.py",
-            &[r"Cannot declare type 'str' for inferred type 'Literal[1]'."],
+            &[r"Cannot declare type `str` for inferred type `Literal[1]`."],
         );
     }
 
@@ -6392,7 +6392,7 @@ mod tests {
         assert_file_diagnostics(
             &db,
             "/src/a.py",
-            &[r"Conflicting declared types for 'x': str, int."],
+            &[r"Conflicting declared types for `x`: str, int."],
         );
     }
 
@@ -6413,7 +6413,7 @@ mod tests {
         assert_file_diagnostics(
             &db,
             "/src/a.py",
-            &[r"Conflicting declared types for 'x': Unknown, int."],
+            &[r"Conflicting declared types for `x`: Unknown, int."],
         );
     }
 
@@ -6437,8 +6437,8 @@ mod tests {
             &db,
             "/src/a.py",
             &[
-                r"Conflicting declared types for 'x': str, int.",
-                r#"Object of type 'Literal[b"foo"]' is not assignable to 'str | int'."#,
+                r"Conflicting declared types for `x`: str, int.",
+                r#"Object of type `Literal[b"foo"]` is not assignable to `str | int`."#,
             ],
         );
     }
@@ -6460,7 +6460,7 @@ mod tests {
         assert_file_diagnostics(
             &db,
             "/src/a.py",
-            &[r"Conflicting declared types for 'x': Unknown, int."],
+            &[r"Conflicting declared types for `x`: Unknown, int."],
         );
     }
 
@@ -6499,7 +6499,7 @@ mod tests {
         assert_file_diagnostics(
             &db,
             "/src/a.py",
-            &["Implicit shadowing of function 'f'; annotate to make it explicit if this is intentional."],
+            &["Implicit shadowing of function `f`; annotate to make it explicit if this is intentional."],
         );
     }
 
@@ -6519,7 +6519,7 @@ mod tests {
         assert_file_diagnostics(
             &db,
             "/src/a.py",
-            &["Implicit shadowing of class 'C'; annotate to make it explicit if this is intentional."],
+            &["Implicit shadowing of class `C`; annotate to make it explicit if this is intentional."],
         );
     }
 
@@ -6574,7 +6574,7 @@ mod tests {
         assert_file_diagnostics(
             &db,
             "/src/a.py",
-            &[r#"Object of type 'Literal["foo"]' is not assignable to 'int'."#],
+            &[r#"Object of type `Literal["foo"]` is not assignable to `int`."#],
         );
     }
 
@@ -6755,7 +6755,7 @@ mod tests {
         assert_file_diagnostics(
             &db,
             "src/a.py",
-            &["Index 4 is out of bounds for tuple of type 'tuple[Literal[1], Literal[\"a\"], Literal[\"b\"]]' with length 3.", "Index -4 is out of bounds for tuple of type 'tuple[Literal[1], Literal[\"a\"], Literal[\"b\"]]' with length 3."],
+            &["Index 4 is out of bounds for tuple of type `tuple[Literal[1], Literal[\"a\"], Literal[\"b\"]]` with length 3.", "Index -4 is out of bounds for tuple of type `tuple[Literal[1], Literal[\"a\"], Literal[\"b\"]]` with length 3."],
         );
 
         Ok(())
@@ -6790,8 +6790,8 @@ mod tests {
             &db,
             "src/a.py",
             &[
-                "Index 8 is out of bounds for string 'Literal[\"abcde\"]' with length 5.",
-                "Index -8 is out of bounds for string 'Literal[\"abcde\"]' with length 5.",
+                "Index 8 is out of bounds for string `Literal[\"abcde\"]` with length 5.",
+                "Index -8 is out of bounds for string `Literal[\"abcde\"]` with length 5.",
             ],
         );
 
@@ -6816,7 +6816,7 @@ mod tests {
         assert_file_diagnostics(
             &db,
             "/src/a.py",
-            &["Cannot subscript object of type 'NotSubscriptable' with no `__getitem__` method."],
+            &["Cannot subscript object of type `NotSubscriptable` with no `__getitem__` method."],
         );
 
         Ok(())
@@ -6840,7 +6840,7 @@ mod tests {
         assert_file_diagnostics(
             &db,
             "/src/a.py",
-            &["Cannot subscript object of type 'Literal[NotSubscriptable]' with no `__class_getitem__` method."],
+            &["Cannot subscript object of type `Literal[NotSubscriptable]` with no `__class_getitem__` method."],
         );
 
         Ok(())
@@ -6864,7 +6864,7 @@ mod tests {
         assert_file_diagnostics(
             &db,
             "/src/a.py",
-            &["Method `__getitem__` of type 'None' is not callable on object of type 'NotSubscriptable'."],
+            &["Method `__getitem__` of type `None` is not callable on object of type `NotSubscriptable`."],
         );
 
         Ok(())
@@ -7039,7 +7039,7 @@ mod tests {
         assert_file_diagnostics(
             &db,
             "/src/a.py",
-            &["Method `__class_getitem__` of type 'Literal[__class_getitem__] | Unbound' is not callable on object of type 'Literal[Identity, Identity]'."],
+            &["Method `__class_getitem__` of type `Literal[__class_getitem__] | Unbound` is not callable on object of type `Literal[Identity, Identity]`."],
         );
 
         Ok(())
@@ -7071,7 +7071,7 @@ mod tests {
         assert_file_diagnostics(
             &db,
             "/src/a.py",
-            &["Cannot subscript object of type 'Literal[Identity] | Literal[1]' with no `__getitem__` method."],
+            &["Cannot subscript object of type `Literal[Identity] | Literal[1]` with no `__getitem__` method."],
         );
 
         Ok(())
@@ -7103,7 +7103,7 @@ mod tests {
         assert_public_ty(&db, "/src/a.py", "a", "float");
         assert_public_ty(&db, "/src/a.py", "b", "Unknown");
 
-        assert_file_diagnostics(&db, "src/a.py", &["Object of type 'Unit' is not callable."]);
+        assert_file_diagnostics(&db, "src/a.py", &["Object of type `Unit` is not callable."]);
 
         Ok(())
     }

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -480,12 +480,12 @@ impl<'db> TypeInferenceBuilder<'db> {
         match declared_ty {
             Type::Class(class) => {
                 self.add_diagnostic(node, "invalid-assignment", format_args!(
-                        "Implicit shadowing of class `{}`; annotate to make it explicit if this is intentional.",
+                        "Implicit shadowing of class `{}`; annotate to make it explicit if this is intentional",
                         class.name(self.db)));
             }
             Type::Function(function) => {
                 self.add_diagnostic(node, "invalid-assignment", format_args!(
-                        "Implicit shadowing of function `{}`; annotate to make it explicit if this is intentional.",
+                        "Implicit shadowing of function `{}`; annotate to make it explicit if this is intentional",
                         function.name(self.db)));
             }
             _ => {
@@ -493,7 +493,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                     node,
                     "invalid-assignment",
                     format_args!(
-                        "Object of type `{}` is not assignable to `{}`.",
+                        "Object of type `{}` is not assignable to `{}`",
                         assigned_ty.display(self.db),
                         declared_ty.display(self.db),
                     ),
@@ -515,9 +515,9 @@ impl<'db> TypeInferenceBuilder<'db> {
         };
 
         let (op, by_zero) = match expr.op {
-            ast::Operator::Div => ("divide", "by zero."),
-            ast::Operator::FloorDiv => ("floor divide", "by zero."),
-            ast::Operator::Mod => ("reduce", "modulo zero."),
+            ast::Operator::Div => ("divide", "by zero"),
+            ast::Operator::FloorDiv => ("floor divide", "by zero"),
+            ast::Operator::Mod => ("reduce", "modulo zero"),
             _ => return,
         };
 
@@ -550,7 +550,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                     node,
                     "conflicting-declarations",
                     format_args!(
-                        "Conflicting declared types for `{symbol_name}`: {}.",
+                        "Conflicting declared types for `{symbol_name}`: {}",
                         conflicting.display(self.db)
                     ),
                 );
@@ -579,7 +579,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                 node,
                 "invalid-declaration",
                 format_args!(
-                    "Cannot declare type `{}` for inferred type `{}`.",
+                    "Cannot declare type `{}` for inferred type `{}`",
                     ty.display(self.db),
                     inferred_ty.display(self.db)
                 ),
@@ -1280,7 +1280,7 @@ impl<'db> TypeInferenceBuilder<'db> {
             node,
             "not-iterable",
             format_args!(
-                "Object of type `{}` is not iterable.",
+                "Object of type `{}` is not iterable",
                 not_iterable_ty.display(self.db)
             ),
         );
@@ -1298,7 +1298,7 @@ impl<'db> TypeInferenceBuilder<'db> {
             node,
             "index-out-of-bounds",
             format_args!(
-                "Index {index} is out of bounds for tuple of type `{}` with length {length}.",
+                "Index {index} is out of bounds for tuple of type `{}` with length {length}",
                 tuple_ty.display(self.db)
             ),
         );
@@ -1316,7 +1316,7 @@ impl<'db> TypeInferenceBuilder<'db> {
             node,
             "index-out-of-bounds",
             format_args!(
-                "Index {index} is out of bounds for string `{}` with length {length}.",
+                "Index {index} is out of bounds for string `{}` with length {length}",
                 string_ty.display(self.db)
             ),
         );
@@ -1333,7 +1333,7 @@ impl<'db> TypeInferenceBuilder<'db> {
             node,
             "non-subscriptable",
             format_args!(
-                "Cannot subscript object of type `{}` with no `{method}` method.",
+                "Cannot subscript object of type `{}` with no `{method}` method",
                 non_subscriptable_ty.display(self.db)
             ),
         );
@@ -1455,7 +1455,7 @@ impl<'db> TypeInferenceBuilder<'db> {
             import_node.into(),
             "unresolved-import",
             format_args!(
-                "Cannot resolve import '{}{}'.",
+                "Cannot resolve import `{}{}`",
                 ".".repeat(level as usize),
                 module.unwrap_or_default()
             ),
@@ -1580,7 +1580,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                 AnyNodeRef::Alias(alias),
                 "unresolved-import",
                 format_args!(
-                    "Module '{}{}' has no member '{name}'",
+                    "Module `{}{}` has no member `{name}`",
                     ".".repeat(*level as usize),
                     module.unwrap_or_default()
                 ),
@@ -2220,7 +2220,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                         name_node.into(),
                         "undefined-reveal",
                         format_args!(
-                            "`reveal_type` used without importing it; this is allowed for debugging convenience but will fail at runtime."),
+                            "`reveal_type` used without importing it; this is allowed for debugging convenience but will fail at runtime"),
                     );
                     builtin_ty = typing_extensions_symbol_ty(self.db, name);
                 }
@@ -2622,7 +2622,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                                 (&**value).into(),
                                 "call-non-callable",
                                 format_args!(
-                                    "Method `__getitem__` of type `{}` is not callable on object of type `{}`.",
+                                    "Method `__getitem__` of type `{}` is not callable on object of type `{}`",
                                     err.called_ty().display(self.db),
                                     value_ty.display(self.db),
                                 ),
@@ -2644,7 +2644,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                                     (&**value).into(),
                                     "call-non-callable",
                                     format_args!(
-                                        "Method `__class_getitem__` of type `{}` is not callable on object of type `{}`.",
+                                        "Method `__class_getitem__` of type `{}` is not callable on object of type `{}`",
                                         err.called_ty().display(self.db),
                                         value_ty.display(self.db),
                                     ),
@@ -3065,7 +3065,7 @@ mod tests {
     }
 
     fn assert_public_ty(db: &TestDb, file_name: &str, symbol_name: &str, expected: &str) {
-        let file = system_path_to_file(db, file_name).expect("Expected file to exist.");
+        let file = system_path_to_file(db, file_name).expect("file to exist");
 
         let ty = global_symbol_ty(db, file, symbol_name);
         assert_eq!(
@@ -3082,7 +3082,7 @@ mod tests {
         symbol_name: &str,
         expected: &str,
     ) {
-        let file = system_path_to_file(db, file_name).expect("Expected file to exist.");
+        let file = system_path_to_file(db, file_name).expect("file to exist");
         let index = semantic_index(db, file);
         let mut file_scope_id = FileScopeId::global();
         let mut scope = file_scope_id.to_scope_id(db, file);
@@ -3129,7 +3129,7 @@ mod tests {
             ",
         )?;
 
-        assert_file_diagnostics(&db, "/src/a.py", &["Revealed type is `Literal[1]`."]);
+        assert_file_diagnostics(&db, "/src/a.py", &["Revealed type is `Literal[1]`"]);
 
         Ok(())
     }
@@ -3148,7 +3148,7 @@ mod tests {
             ",
         )?;
 
-        assert_file_diagnostics(&db, "/src/a.py", &["Revealed type is `Literal[1]`."]);
+        assert_file_diagnostics(&db, "/src/a.py", &["Revealed type is `Literal[1]`"]);
 
         Ok(())
     }
@@ -3167,7 +3167,7 @@ mod tests {
             ",
         )?;
 
-        assert_file_diagnostics(&db, "/src/a.py", &["Revealed type is `Literal[1]`."]);
+        assert_file_diagnostics(&db, "/src/a.py", &["Revealed type is `Literal[1]`"]);
 
         Ok(())
     }
@@ -3188,8 +3188,8 @@ mod tests {
             &db,
             "/src/a.py",
             &[
-                "`reveal_type` used without importing it; this is allowed for debugging convenience but will fail at runtime.",
-                "Revealed type is `Literal[1]`.",
+                "`reveal_type` used without importing it; this is allowed for debugging convenience but will fail at runtime",
+                "Revealed type is `Literal[1]`",
             ],
         );
 
@@ -3395,7 +3395,7 @@ mod tests {
             ",
         )?;
 
-        let mod_file = system_path_to_file(&db, "src/mod.py").expect("Expected file to exist.");
+        let mod_file = system_path_to_file(&db, "src/mod.py").expect("file to exist");
         let ty = global_symbol_ty(&db, mod_file, "Sub");
 
         let class = ty.expect_class();
@@ -4144,7 +4144,7 @@ mod tests {
         assert_file_diagnostics(
             &db,
             "src/a.py",
-            &["Object of type `Literal[1] | Literal[f]` is not callable (due to union element `Literal[1]`)."],
+            &["Object of type `Literal[1] | Literal[f]` is not callable (due to union element `Literal[1]`)"],
         );
         assert_public_ty(&db, "src/a.py", "x", "Unknown | int");
 
@@ -4173,7 +4173,7 @@ mod tests {
             &db,
             "src/a.py",
             &[
-                r#"Object of type `Literal[1] | Literal["foo"] | Literal[f]` is not callable (due to union elements Literal[1], Literal["foo"])."#,
+                r#"Object of type `Literal[1] | Literal["foo"] | Literal[f]` is not callable (due to union elements Literal[1], Literal["foo"])"#,
             ],
         );
         assert_public_ty(&db, "src/a.py", "x", "Unknown | int");
@@ -4199,7 +4199,7 @@ mod tests {
         assert_file_diagnostics(
             &db,
             "src/a.py",
-            &[r#"Object of type `Literal[1] | Literal["foo"]` is not callable."#],
+            &[r#"Object of type `Literal[1] | Literal["foo"]` is not callable"#],
         );
         assert_public_ty(&db, "src/a.py", "x", "Unknown");
 
@@ -4222,7 +4222,7 @@ mod tests {
         assert_file_diagnostics(
             &db,
             "/src/a.py",
-            &["Object of type `Literal[123]` is not callable."],
+            &["Object of type `Literal[123]` is not callable"],
         );
     }
 
@@ -4297,11 +4297,11 @@ mod tests {
             &db,
             "src/a.py",
             &[
-                "Cannot divide object of type `Literal[1]` by zero.",
-                "Cannot floor divide object of type `Literal[2]` by zero.",
-                "Cannot reduce object of type `Literal[3]` modulo zero.",
-                "Cannot divide object of type `int` by zero.",
-                "Cannot divide object of type `float` by zero.",
+                "Cannot divide object of type `Literal[1]` by zero",
+                "Cannot floor divide object of type `Literal[2]` by zero",
+                "Cannot reduce object of type `Literal[3]` modulo zero",
+                "Cannot divide object of type `int` by zero",
+                "Cannot divide object of type `float` by zero",
             ],
         );
 
@@ -4647,7 +4647,7 @@ mod tests {
             ",
         )?;
 
-        let a = system_path_to_file(&db, "src/a.py").expect("Expected file to exist.");
+        let a = system_path_to_file(&db, "src/a.py").expect("file to exist");
         let c_ty = global_symbol_ty(&db, a, "C");
         let c_class = c_ty.expect_class();
         let mut c_bases = c_class.bases(&db);
@@ -4677,7 +4677,7 @@ mod tests {
             ",
         )?;
 
-        let file = system_path_to_file(&db, "src/a.py").expect("Expected file to exist.");
+        let file = system_path_to_file(&db, "src/a.py").expect("file to exist");
         let index = semantic_index(&db, file);
         let function_scope = index
             .child_scopes(FileScopeId::global())
@@ -4708,7 +4708,7 @@ mod tests {
             ",
         )?;
 
-        let file = system_path_to_file(&db, "src/a.py").expect("Expected file to exist.");
+        let file = system_path_to_file(&db, "src/a.py").expect("file to exist");
         let index = semantic_index(&db, file);
         let function_scope = index
             .child_scopes(FileScopeId::global())
@@ -4739,7 +4739,7 @@ mod tests {
             ",
         )?;
 
-        let file = system_path_to_file(&db, "src/a.py").expect("Expected file to exist.");
+        let file = system_path_to_file(&db, "src/a.py").expect("file to exist");
         let index = semantic_index(&db, file);
         let function_scope = index
             .child_scopes(FileScopeId::global())
@@ -4773,7 +4773,7 @@ mod tests {
             ",
         )?;
 
-        let file = system_path_to_file(&db, "src/a.py").expect("Expected file to exist.");
+        let file = system_path_to_file(&db, "src/a.py").expect("file to exist");
         let index = semantic_index(&db, file);
         let class_scope = index
             .child_scopes(FileScopeId::global())
@@ -4874,7 +4874,7 @@ mod tests {
 
         assert_public_ty(&db, "/src/a.py", "x", "Literal[copyright]");
         // imported builtins module is the same file as the implicit builtins
-        let file = system_path_to_file(&db, "/src/a.py").expect("Expected file to exist.");
+        let file = system_path_to_file(&db, "/src/a.py").expect("file to exist");
         let builtins_ty = global_symbol_ty(&db, file, "builtins");
         let builtins_file = builtins_ty.expect_module();
         let implicit_builtins_file = builtins_module_scope(&db)
@@ -5388,7 +5388,7 @@ mod tests {
 
         db.write_file("src/foo.py", "import bar\n").unwrap();
 
-        assert_file_diagnostics(&db, "src/foo.py", &["Cannot resolve import 'bar'."]);
+        assert_file_diagnostics(&db, "src/foo.py", &["Cannot resolve import `bar`"]);
     }
 
     #[test]
@@ -5397,7 +5397,7 @@ mod tests {
 
         db.write_file("src/foo.py", "from bar import baz\n")
             .unwrap();
-        assert_file_diagnostics(&db, "/src/foo.py", &["Cannot resolve import 'bar'."]);
+        assert_file_diagnostics(&db, "/src/foo.py", &["Cannot resolve import `bar`"]);
     }
 
     #[test]
@@ -5407,7 +5407,7 @@ mod tests {
         db.write_files([("/src/a.py", ""), ("/src/b.py", "from a import thing")])
             .unwrap();
 
-        assert_file_diagnostics(&db, "/src/b.py", &["Module 'a' has no member 'thing'"]);
+        assert_file_diagnostics(&db, "/src/b.py", &["Module `a` has no member `thing`"]);
     }
 
     #[test]
@@ -5420,7 +5420,7 @@ mod tests {
         ])
         .unwrap();
 
-        assert_file_diagnostics(&db, "/src/a.py", &["Cannot resolve import 'foo'."]);
+        assert_file_diagnostics(&db, "/src/a.py", &["Cannot resolve import `foo`"]);
 
         // Importing the unresolved import into a second first-party file should not trigger
         // an additional "unresolved import" violation
@@ -5658,7 +5658,7 @@ mod tests {
         assert_file_diagnostics(
             &db,
             "src/a.py",
-            &["Object of type `NotIterable` is not iterable."],
+            &["Object of type `NotIterable` is not iterable"],
         );
         assert_public_ty(&db, "src/a.py", "x", "Unbound | Unknown");
 
@@ -5709,7 +5709,7 @@ mod tests {
         assert_file_diagnostics(
             &db,
             "src/a.py",
-            &["Cannot resolve import 'nonexistent_module'."],
+            &["Cannot resolve import `nonexistent_module`"],
         );
         assert_public_ty(&db, "src/a.py", "foo", "Unknown");
         assert_public_ty(&db, "src/a.py", "e", "Unknown");
@@ -5969,7 +5969,7 @@ mod tests {
         assert_file_diagnostics(
             &db,
             "src/a.py",
-            &["Object of type `Unbound` is not iterable."],
+            &["Object of type `Unbound` is not iterable"],
         );
 
         Ok(())
@@ -5997,7 +5997,7 @@ mod tests {
 
         assert_scope_ty(&db, "src/a.py", &["foo", "<listcomp>"], "x", "int");
         assert_scope_ty(&db, "src/a.py", &["foo", "<listcomp>"], "z", "Unknown");
-        assert_file_diagnostics(&db, "src/a.py", &["Object of type `int` is not iterable."]);
+        assert_file_diagnostics(&db, "src/a.py", &["Object of type `int` is not iterable"]);
 
         Ok(())
     }
@@ -6193,7 +6193,7 @@ mod tests {
         assert_file_diagnostics(
             &db,
             "/src/a.py",
-            &["Object of type `Literal[123]` is not iterable."],
+            &["Object of type `Literal[123]` is not iterable"],
         );
     }
 
@@ -6219,7 +6219,7 @@ mod tests {
         assert_file_diagnostics(
             &db,
             "/src/a.py",
-            &["Object of type `NotIterable` is not iterable."],
+            &["Object of type `NotIterable` is not iterable"],
         );
     }
 
@@ -6248,7 +6248,7 @@ mod tests {
         assert_file_diagnostics(
             &db,
             "/src/a.py",
-            &["Object of type `NotIterable` is not iterable."],
+            &["Object of type `NotIterable` is not iterable"],
         );
     }
 
@@ -6278,7 +6278,7 @@ mod tests {
         assert_file_diagnostics(
             &db,
             "/src/a.py",
-            &["Object of type `NotIterable` is not iterable."],
+            &["Object of type `NotIterable` is not iterable"],
         );
     }
 
@@ -6297,7 +6297,7 @@ mod tests {
         assert_file_diagnostics(
             &db,
             "/src/a.py",
-            &[r#"Object of type `Literal["foo"]` is not assignable to `int`."#],
+            &[r#"Object of type `Literal["foo"]` is not assignable to `int`"#],
         );
     }
 
@@ -6317,7 +6317,7 @@ mod tests {
         assert_file_diagnostics(
             &db,
             "/src/a.py",
-            &[r#"Object of type `Literal["foo"]` is not assignable to `int`."#],
+            &[r#"Object of type `Literal["foo"]` is not assignable to `int`"#],
         );
     }
 
@@ -6369,7 +6369,7 @@ mod tests {
         assert_file_diagnostics(
             &db,
             "/src/a.py",
-            &[r"Cannot declare type `str` for inferred type `Literal[1]`."],
+            &[r"Cannot declare type `str` for inferred type `Literal[1]`"],
         );
     }
 
@@ -6392,7 +6392,7 @@ mod tests {
         assert_file_diagnostics(
             &db,
             "/src/a.py",
-            &[r"Conflicting declared types for `x`: str, int."],
+            &[r"Conflicting declared types for `x`: str, int"],
         );
     }
 
@@ -6413,7 +6413,7 @@ mod tests {
         assert_file_diagnostics(
             &db,
             "/src/a.py",
-            &[r"Conflicting declared types for `x`: Unknown, int."],
+            &[r"Conflicting declared types for `x`: Unknown, int"],
         );
     }
 
@@ -6437,8 +6437,8 @@ mod tests {
             &db,
             "/src/a.py",
             &[
-                r"Conflicting declared types for `x`: str, int.",
-                r#"Object of type `Literal[b"foo"]` is not assignable to `str | int`."#,
+                r"Conflicting declared types for `x`: str, int",
+                r#"Object of type `Literal[b"foo"]` is not assignable to `str | int`"#,
             ],
         );
     }
@@ -6460,7 +6460,7 @@ mod tests {
         assert_file_diagnostics(
             &db,
             "/src/a.py",
-            &[r"Conflicting declared types for `x`: Unknown, int."],
+            &[r"Conflicting declared types for `x`: Unknown, int"],
         );
     }
 
@@ -6499,7 +6499,7 @@ mod tests {
         assert_file_diagnostics(
             &db,
             "/src/a.py",
-            &["Implicit shadowing of function `f`; annotate to make it explicit if this is intentional."],
+            &["Implicit shadowing of function `f`; annotate to make it explicit if this is intentional"],
         );
     }
 
@@ -6519,7 +6519,7 @@ mod tests {
         assert_file_diagnostics(
             &db,
             "/src/a.py",
-            &["Implicit shadowing of class `C`; annotate to make it explicit if this is intentional."],
+            &["Implicit shadowing of class `C`; annotate to make it explicit if this is intentional"],
         );
     }
 
@@ -6574,7 +6574,7 @@ mod tests {
         assert_file_diagnostics(
             &db,
             "/src/a.py",
-            &[r#"Object of type `Literal["foo"]` is not assignable to `int`."#],
+            &[r#"Object of type `Literal["foo"]` is not assignable to `int`"#],
         );
     }
 
@@ -6755,7 +6755,7 @@ mod tests {
         assert_file_diagnostics(
             &db,
             "src/a.py",
-            &["Index 4 is out of bounds for tuple of type `tuple[Literal[1], Literal[\"a\"], Literal[\"b\"]]` with length 3.", "Index -4 is out of bounds for tuple of type `tuple[Literal[1], Literal[\"a\"], Literal[\"b\"]]` with length 3."],
+            &["Index 4 is out of bounds for tuple of type `tuple[Literal[1], Literal[\"a\"], Literal[\"b\"]]` with length 3", "Index -4 is out of bounds for tuple of type `tuple[Literal[1], Literal[\"a\"], Literal[\"b\"]]` with length 3"],
         );
 
         Ok(())
@@ -6790,8 +6790,8 @@ mod tests {
             &db,
             "src/a.py",
             &[
-                "Index 8 is out of bounds for string `Literal[\"abcde\"]` with length 5.",
-                "Index -8 is out of bounds for string `Literal[\"abcde\"]` with length 5.",
+                "Index 8 is out of bounds for string `Literal[\"abcde\"]` with length 5",
+                "Index -8 is out of bounds for string `Literal[\"abcde\"]` with length 5",
             ],
         );
 
@@ -6816,7 +6816,7 @@ mod tests {
         assert_file_diagnostics(
             &db,
             "/src/a.py",
-            &["Cannot subscript object of type `NotSubscriptable` with no `__getitem__` method."],
+            &["Cannot subscript object of type `NotSubscriptable` with no `__getitem__` method"],
         );
 
         Ok(())
@@ -6840,7 +6840,7 @@ mod tests {
         assert_file_diagnostics(
             &db,
             "/src/a.py",
-            &["Cannot subscript object of type `Literal[NotSubscriptable]` with no `__class_getitem__` method."],
+            &["Cannot subscript object of type `Literal[NotSubscriptable]` with no `__class_getitem__` method"],
         );
 
         Ok(())
@@ -6864,7 +6864,7 @@ mod tests {
         assert_file_diagnostics(
             &db,
             "/src/a.py",
-            &["Method `__getitem__` of type `None` is not callable on object of type `NotSubscriptable`."],
+            &["Method `__getitem__` of type `None` is not callable on object of type `NotSubscriptable`"],
         );
 
         Ok(())
@@ -7039,7 +7039,7 @@ mod tests {
         assert_file_diagnostics(
             &db,
             "/src/a.py",
-            &["Method `__class_getitem__` of type `Literal[__class_getitem__] | Unbound` is not callable on object of type `Literal[Identity, Identity]`."],
+            &["Method `__class_getitem__` of type `Literal[__class_getitem__] | Unbound` is not callable on object of type `Literal[Identity, Identity]`"],
         );
 
         Ok(())
@@ -7071,7 +7071,7 @@ mod tests {
         assert_file_diagnostics(
             &db,
             "/src/a.py",
-            &["Cannot subscript object of type `Literal[Identity] | Literal[1]` with no `__getitem__` method."],
+            &["Cannot subscript object of type `Literal[Identity] | Literal[1]` with no `__getitem__` method"],
         );
 
         Ok(())
@@ -7103,7 +7103,7 @@ mod tests {
         assert_public_ty(&db, "/src/a.py", "a", "float");
         assert_public_ty(&db, "/src/a.py", "b", "Unknown");
 
-        assert_file_diagnostics(&db, "src/a.py", &["Object of type `Unit` is not callable."]);
+        assert_file_diagnostics(&db, "src/a.py", &["Object of type `Unit` is not callable"]);
 
         Ok(())
     }

--- a/crates/red_knot_server/src/server/api/requests/diagnostic.rs
+++ b/crates/red_knot_server/src/server/api/requests/diagnostic.rs
@@ -47,7 +47,7 @@ impl BackgroundDocumentRequestHandler for DocumentDiagnosticRequestHandler {
 fn compute_diagnostics(snapshot: &DocumentSnapshot, db: &RootDatabase) -> Vec<Diagnostic> {
     let Some(file) = snapshot.file(db) else {
         tracing::info!(
-            "No file found for snapshot for '{}'",
+            "No file found for snapshot for `{}`",
             snapshot.query().file_url()
         );
         return vec![];

--- a/crates/red_knot_wasm/tests/api.rs
+++ b/crates/red_knot_wasm/tests/api.rs
@@ -19,6 +19,6 @@ fn check() {
 
     assert_eq!(
         result,
-        vec!["/test.py:1:8: Cannot resolve import 'random22'."]
+        vec!["/test.py:1:8: Cannot resolve import `random22`"]
     );
 }

--- a/crates/red_knot_workspace/src/db/changes.rs
+++ b/crates/red_knot_workspace/src/db/changes.rs
@@ -157,7 +157,7 @@ impl RootDatabase {
                 base_configuration.cloned(),
             ) {
                 Ok(metadata) => {
-                    tracing::debug!("Reloading workspace after structural change.");
+                    tracing::debug!("Reloading workspace after structural change");
                     // TODO: Handle changes in the program settings.
                     workspace.reload(self, metadata);
                 }

--- a/crates/red_knot_workspace/src/lint.rs
+++ b/crates/red_knot_workspace/src/lint.rs
@@ -118,13 +118,13 @@ fn lint_maybe_undefined(context: &SemanticLintContext, name: &ast::ExprName) {
     if ty.is_unbound() {
         context.push_diagnostic(format_diagnostic(
             context,
-            &format!("Name '{}' used when not defined.", &name.id),
+            &format!("Name `{}` used when not defined.", &name.id),
             name.start(),
         ));
     } else if ty.may_be_unbound(semantic.db()) {
         context.push_diagnostic(format_diagnostic(
             context,
-            &format!("Name '{}' used when possibly not defined.", &name.id),
+            &format!("Name `{}` used when possibly not defined.", &name.id),
             name.start(),
         ));
     }
@@ -304,13 +304,13 @@ mod tests {
             *messages,
             if cfg!(windows) {
                 vec![
-                    "\\src\\a.py:3:4: Name 'flag' used when not defined.",
-                    "\\src\\a.py:5:1: Name 'y' used when possibly not defined.",
+                    "\\src\\a.py:3:4: Name `flag` used when not defined.",
+                    "\\src\\a.py:5:1: Name `y` used when possibly not defined.",
                 ]
             } else {
                 vec![
-                    "/src/a.py:3:4: Name 'flag' used when not defined.",
-                    "/src/a.py:5:1: Name 'y' used when possibly not defined.",
+                    "/src/a.py:3:4: Name `flag` used when not defined.",
+                    "/src/a.py:5:1: Name `y` used when possibly not defined.",
                 ]
             }
         );

--- a/crates/red_knot_workspace/src/lint.rs
+++ b/crates/red_knot_workspace/src/lint.rs
@@ -118,13 +118,13 @@ fn lint_maybe_undefined(context: &SemanticLintContext, name: &ast::ExprName) {
     if ty.is_unbound() {
         context.push_diagnostic(format_diagnostic(
             context,
-            &format!("Name `{}` used when not defined.", &name.id),
+            &format!("Name `{}` used when not defined", &name.id),
             name.start(),
         ));
     } else if ty.may_be_unbound(semantic.db()) {
         context.push_diagnostic(format_diagnostic(
             context,
-            &format!("Name `{}` used when possibly not defined.", &name.id),
+            &format!("Name `{}` used when possibly not defined", &name.id),
             name.start(),
         ));
     }
@@ -304,13 +304,13 @@ mod tests {
             *messages,
             if cfg!(windows) {
                 vec![
-                    "\\src\\a.py:3:4: Name `flag` used when not defined.",
-                    "\\src\\a.py:5:1: Name `y` used when possibly not defined.",
+                    "\\src\\a.py:3:4: Name `flag` used when not defined",
+                    "\\src\\a.py:5:1: Name `y` used when possibly not defined",
                 ]
             } else {
                 vec![
-                    "/src/a.py:3:4: Name `flag` used when not defined.",
-                    "/src/a.py:5:1: Name `y` used when possibly not defined.",
+                    "/src/a.py:3:4: Name `flag` used when not defined",
+                    "/src/a.py:5:1: Name `y` used when possibly not defined",
                 ]
             }
         );

--- a/crates/red_knot_workspace/src/watch/watcher.rs
+++ b/crates/red_knot_workspace/src/watch/watcher.rs
@@ -109,7 +109,7 @@ struct WatcherInner {
 impl Watcher {
     /// Sets up file watching for `path`.
     pub fn watch(&mut self, path: &SystemPath) -> notify::Result<()> {
-        tracing::debug!("Watching path: '{path}'.");
+        tracing::debug!("Watching path: `{path}`");
 
         self.inner_mut()
             .watcher
@@ -118,7 +118,7 @@ impl Watcher {
 
     /// Stops file watching for `path`.
     pub fn unwatch(&mut self, path: &SystemPath) -> notify::Result<()> {
-        tracing::debug!("Unwatching path: '{path}'.");
+        tracing::debug!("Unwatching path: `{path}`");
 
         self.inner_mut().watcher.unwatch(path.as_std_path())
     }
@@ -157,11 +157,11 @@ impl Watcher {
     }
 
     fn inner(&self) -> &WatcherInner {
-        self.inner.as_ref().expect("Watcher to be running.")
+        self.inner.as_ref().expect("Watcher to be running")
     }
 
     fn inner_mut(&mut self) -> &mut WatcherInner {
-        self.inner.as_mut().expect("Watcher to be running.")
+        self.inner.as_mut().expect("Watcher to be running")
     }
 }
 
@@ -179,7 +179,7 @@ struct Debouncer {
 
 impl Debouncer {
     fn add_result(&mut self, result: notify::Result<notify::Event>) {
-        tracing::trace!("Handling file watcher event: {result:?}.");
+        tracing::trace!("Handling file watcher event: {result:?}");
         match result {
             Ok(event) => self.add_event(event),
             Err(error) => self.add_error(error),
@@ -192,7 +192,7 @@ impl Debouncer {
         // are IO errors. All other errors should really only happen when adding or removing a watched folders.
         // It's not clear what an upstream handler should do in the case of an IOError (other than logging it).
         // That's what we do for now as well.
-        tracing::warn!("File watcher error: {error:?}.");
+        tracing::warn!("File watcher error: {error:?}");
     }
 
     fn add_event(&mut self, event: notify::Event) {
@@ -214,7 +214,7 @@ impl Debouncer {
             Ok(path) => path,
             Err(path) => {
                 tracing::debug!(
-                    "Ignore change to non-UTF8 path '{path}': {kind:?}",
+                    "Ignore change to non-UTF8 path `{path}`: {kind:?}",
                     path = path.display()
                 );
 
@@ -351,7 +351,7 @@ impl Debouncer {
             }
 
             EventKind::Any => {
-                tracing::debug!("Skipping any FS event for '{path}'.");
+                tracing::debug!("Skipping any FS event for `{path}`");
                 return;
             }
         };

--- a/crates/red_knot_workspace/src/watch/workspace_watcher.rs
+++ b/crates/red_knot_workspace/src/watch/workspace_watcher.rs
@@ -62,7 +62,7 @@ impl WorkspaceWatcher {
         // ```
         for path in self.watched_paths.drain(..) {
             if let Err(error) = self.watcher.unwatch(&path) {
-                info!("Failed to remove the file watcher for the path '{path}: {error}.");
+                info!("Failed to remove the file watcher for path `{path}`: {error}");
             }
         }
 
@@ -90,7 +90,7 @@ impl WorkspaceWatcher {
             // Ruff otherwise stills works as expected.
             if let Err(error) = self.watcher.watch(&path) {
                 // TODO: Log a user-facing warning.
-                tracing::warn!("Failed to setup watcher for path '{path}': {error}. You have to restart Ruff after making changes to files under this path or you might see stale results.");
+                tracing::warn!("Failed to setup watcher for path `{path}`: {error}. You have to restart Ruff after making changes to files under this path or you might see stale results.");
                 self.has_errored_paths = true;
             } else {
                 self.watched_paths.push(path);

--- a/crates/red_knot_workspace/src/workspace.rs
+++ b/crates/red_knot_workspace/src/workspace.rs
@@ -226,7 +226,7 @@ impl Workspace {
     ///
     /// This changes the behavior of `check` to only check the open files rather than all files in the workspace.
     pub fn open_file(self, db: &mut dyn Db, file: File) {
-        tracing::debug!("Opening file '{}'", file.path(db));
+        tracing::debug!("Opening file `{}`", file.path(db));
 
         let mut open_files = self.take_open_files(db);
         open_files.insert(file);
@@ -235,7 +235,7 @@ impl Workspace {
 
     /// Closes a file in the workspace.
     pub fn close_file(self, db: &mut dyn Db, file: File) -> bool {
-        tracing::debug!("Closing file '{}'", file.path(db));
+        tracing::debug!("Closing file `{}`", file.path(db));
 
         let mut open_files = self.take_open_files(db);
         let removed = open_files.remove(&file);
@@ -310,7 +310,7 @@ impl Package {
     #[tracing::instrument(level = "debug", skip(db))]
     pub fn remove_file(self, db: &mut dyn Db, file: File) {
         tracing::debug!(
-            "Removing file '{}' from package '{}'",
+            "Removing file `{}` from package `{}`",
             file.path(db),
             self.name(db)
         );
@@ -324,7 +324,7 @@ impl Package {
 
     pub fn add_file(self, db: &mut dyn Db, file: File) {
         tracing::debug!(
-            "Adding file '{}' to package '{}'",
+            "Adding file `{}` to package `{}`",
             file.path(db),
             self.name(db)
         );
@@ -346,7 +346,7 @@ impl Package {
                     tracing::debug_span!("index_package_files", package = %self.name(db)).entered();
 
                 let files = discover_package_files(db, self.root(db));
-                tracing::info!("Found {} files in package '{}'", files.len(), self.name(db));
+                tracing::info!("Found {} files in package `{}`", files.len(), self.name(db));
                 vacant.set(files)
             }
             Index::Indexed(indexed) => indexed,
@@ -372,7 +372,7 @@ impl Package {
     }
 
     pub fn reload_files(self, db: &mut dyn Db) {
-        tracing::debug!("Reloading files for package '{}'", self.name(db));
+        tracing::debug!("Reloading files for package `{}`", self.name(db));
 
         if !self.file_set(db).is_lazy() {
             // Force a re-index of the files in the next revision.

--- a/crates/ruff/src/cache.rs
+++ b/crates/ruff/src/cache.rs
@@ -111,7 +111,7 @@ impl Cache {
                 return Cache::empty(path, package_root);
             }
             Err(err) => {
-                warn_user!("Failed to open cache file '{}': {err}", path.display());
+                warn_user!("Failed to open cache file `{}`: {err}", path.display());
                 return Cache::empty(path, package_root);
             }
         };
@@ -119,7 +119,7 @@ impl Cache {
         let mut package: PackageCache = match bincode::deserialize_from(BufReader::new(file)) {
             Ok(package) => package,
             Err(err) => {
-                warn_user!("Failed parse cache file '{}': {err}", path.display());
+                warn_user!("Failed parse cache file `{}`: {err}", path.display());
                 return Cache::empty(path, package_root);
             }
         };
@@ -127,7 +127,7 @@ impl Cache {
         // Sanity check.
         if package.package_root != package_root {
             warn_user!(
-                "Different package root in cache: expected '{}', got '{}'",
+                "Different package root in cache: expected `{}`, got `{}`",
                 package_root.display(),
                 package.package_root.display(),
             );
@@ -185,7 +185,7 @@ impl Cache {
             // the user is running Ruff from multiple processes over the same directory).
             if cfg!(windows) && err.error.kind() == io::ErrorKind::PermissionDenied {
                 warn_user!(
-                    "Failed to write cache file '{}': {}",
+                    "Failed to write cache file `{}`: {}",
                     self.path.display(),
                     err.error
                 );
@@ -674,7 +674,7 @@ mod tests {
 
             assert!(
                 cache.package.files.contains_key(relative_path),
-                "missing file from cache: '{}'",
+                "missing file from cache: `{}`",
                 relative_path.display()
             );
         }

--- a/crates/ruff_benchmark/benches/red_knot.rs
+++ b/crates/ruff_benchmark/benches/red_knot.rs
@@ -24,8 +24,8 @@ const TOMLLIB_312_URL: &str = "https://raw.githubusercontent.com/python/cpython/
 
 // The failed import from 'collections.abc' is due to lack of support for 'import *'.
 static EXPECTED_DIAGNOSTICS: &[&str] = &[
-    "/src/tomllib/__init__.py:10:30: Name '__name__' used when not defined.",
-    "/src/tomllib/_parser.py:7:29: Module 'collections.abc' has no member 'Iterable'",
+    "/src/tomllib/__init__.py:10:30: Name `__name__` used when not defined",
+    "/src/tomllib/_parser.py:7:29: Module `collections.abc` has no member `Iterable`",
     "Line 69 is too long (89 characters)",
     "Use double quotes for strings",
     "Use double quotes for strings",

--- a/crates/ruff_db/src/files.rs
+++ b/crates/ruff_db/src/files.rs
@@ -132,7 +132,7 @@ impl Files {
                     Err(_) => return Err(FileError::NotFound),
                 };
 
-                tracing::trace!("Adding vendored file '{}'", path);
+                tracing::trace!("Adding vendored file `{}`", path);
                 let file = File::builder(FilePath::Vendored(path.to_path_buf()))
                     .permissions(Some(0o444))
                     .revision(metadata.revision())
@@ -406,17 +406,17 @@ impl File {
         };
 
         if file.status(db) != status {
-            tracing::debug!("Updating the status of '{}'", file.path(db),);
+            tracing::debug!("Updating the status of `{}`", file.path(db),);
             file.set_status(db).to(status);
         }
 
         if file.revision(db) != revision {
-            tracing::debug!("Updating the revision of '{}'", file.path(db));
+            tracing::debug!("Updating the revision of `{}`", file.path(db));
             file.set_revision(db).to(revision);
         }
 
         if file.permissions(db) != permission {
-            tracing::debug!("Updating the permissions of '{}'", file.path(db),);
+            tracing::debug!("Updating the permissions of `{}`", file.path(db),);
             file.set_permissions(db).to(permission);
         }
     }
@@ -450,7 +450,7 @@ impl VirtualFile {
     /// Increments the revision of the underlying [`File`].
     fn sync(&self, db: &mut dyn Db) {
         let file = self.0;
-        tracing::debug!("Updating the revision of '{}'", file.path(db));
+        tracing::debug!("Updating the revision of `{}`", file.path(db));
         let current_revision = file.revision(db);
         file.set_revision(db)
             .to(FileRevision::new(current_revision.as_u128() + 1));
@@ -458,7 +458,7 @@ impl VirtualFile {
 
     /// Closes the virtual file.
     pub fn close(&self, db: &mut dyn Db) {
-        tracing::debug!("Closing virtual file '{}'", self.0.path(db));
+        tracing::debug!("Closing virtual file `{}`", self.0.path(db));
         self.0.set_status(db).to(FileStatus::NotFound);
     }
 }

--- a/crates/ruff_db/src/files.rs
+++ b/crates/ruff_db/src/files.rs
@@ -406,7 +406,7 @@ impl File {
         };
 
         if file.status(db) != status {
-            tracing::debug!("Updating the status of `{}`", file.path(db),);
+            tracing::debug!("Updating the status of `{}`", file.path(db));
             file.set_status(db).to(status);
         }
 
@@ -416,7 +416,7 @@ impl File {
         }
 
         if file.permissions(db) != permission {
-            tracing::debug!("Updating the permissions of `{}`", file.path(db),);
+            tracing::debug!("Updating the permissions of `{}`", file.path(db));
             file.set_permissions(db).to(permission);
         }
     }

--- a/crates/ruff_formatter/src/format_element/document.rs
+++ b/crates/ruff_formatter/src/format_element/document.rs
@@ -878,9 +878,9 @@ mod tests {
                     [group(&format_args![
                         token("("),
                         soft_block_indent(&format_args![
-                            source_text_slice(TextRange::at(TextSize::new(0), TextSize::new(19)),),
+                            source_text_slice(TextRange::at(TextSize::new(0), TextSize::new(19))),
                             space(),
-                            source_text_slice(TextRange::at(TextSize::new(20), TextSize::new(28)),),
+                            source_text_slice(TextRange::at(TextSize::new(20), TextSize::new(28))),
                         ])
                     ])]
                 )

--- a/crates/ruff_formatter/src/printer/mod.rs
+++ b/crates/ruff_formatter/src/printer/mod.rs
@@ -1718,7 +1718,7 @@ mod tests {
                 token("b"),
                 soft_block_indent(&format_args!(
                     token("c"),
-                    soft_block_indent(&format_args!(token("d"), soft_line_break(), token("d"),)),
+                    soft_block_indent(&format_args!(token("d"), soft_line_break(), token("d"))),
                     token("c"),
                 )),
                 token("b"),

--- a/crates/ruff_linter/src/fix/mod.rs
+++ b/crates/ruff_linter/src/fix/mod.rs
@@ -226,8 +226,8 @@ print("hello world")
         assert_eq!(
             source_map.markers(),
             &[
-                SourceMarker::new(10.into(), 10.into(),),
-                SourceMarker::new(10.into(), 21.into(),),
+                SourceMarker::new(10.into(), 10.into()),
+                SourceMarker::new(10.into(), 21.into()),
             ]
         );
     }
@@ -263,8 +263,8 @@ class A(Bar):
         assert_eq!(
             source_map.markers(),
             &[
-                SourceMarker::new(8.into(), 8.into(),),
-                SourceMarker::new(14.into(), 11.into(),),
+                SourceMarker::new(8.into(), 8.into()),
+                SourceMarker::new(14.into(), 11.into()),
             ]
         );
     }
@@ -335,8 +335,8 @@ class A(object):
             &[
                 SourceMarker::new(8.into(), 8.into()),
                 SourceMarker::new(16.into(), 8.into()),
-                SourceMarker::new(22.into(), 14.into(),),
-                SourceMarker::new(30.into(), 14.into(),),
+                SourceMarker::new(22.into(), 14.into()),
+                SourceMarker::new(30.into(), 14.into()),
             ]
         );
     }
@@ -371,8 +371,8 @@ class A:
         assert_eq!(
             source_map.markers(),
             &[
-                SourceMarker::new(7.into(), 7.into(),),
-                SourceMarker::new(15.into(), 7.into(),),
+                SourceMarker::new(7.into(), 7.into()),
+                SourceMarker::new(15.into(), 7.into()),
             ]
         );
     }

--- a/crates/ruff_linter/src/rules/eradicate/detection.rs
+++ b/crates/ruff_linter/src/rules/eradicate/detection.rs
@@ -116,7 +116,7 @@ mod tests {
         assert!(!comment_contains_code(
             "# pylint: disable=redefined-outer-name",
             &[]
-        ),);
+        ));
         assert!(!comment_contains_code(
             "# Issue #999: This is not code",
             &[]
@@ -190,11 +190,11 @@ mod tests {
         assert!(comment_contains_code(
             "# user_content_type, _ = TimelineEvent.objects.using(db_alias).get_or_create(",
             &[]
-        ),);
+        ));
         assert!(comment_contains_code(
             "# (user_content_type, _) = TimelineEvent.objects.using(db_alias).get_or_create(",
             &[]
-        ),);
+        ));
         assert!(comment_contains_code(
             "# ( user_content_type , _ )= TimelineEvent.objects.using(db_alias).get_or_create(",
             &[]

--- a/crates/ruff_linter/src/rules/flake8_commas/rules/trailing_commas.rs
+++ b/crates/ruff_linter/src/rules/flake8_commas/rules/trailing_commas.rs
@@ -181,7 +181,7 @@ impl AlwaysFixableViolation for MissingTrailingComma {
 /// import json
 ///
 ///
-/// foo = (json.dumps({"bar": 1}),)
+/// foo = (json.dumps({"bar": 1}))
 /// ```
 #[violation]
 pub struct TrailingCommaOnBareTuple;


### PR DESCRIPTION
## Summary

...and remove periods from messages that don't span more than a single sentence.

This is more consistent with how we present user-facing messages in uv (which has a defined style guide).
