### PR TITLE
Add `allow-unused-imports` setting for `unused-import` rule (`F401`)

### DIFF
--- a/crates/ruff/tests/snapshots/show_settings__display_default_settings.snap
+++ b/crates/ruff/tests/snapshots/show_settings__display_default_settings.snap
@@ -220,7 +220,7 @@ linter.task_tags = [
 	XXX,
 ]
 linter.typing_modules = []
-linter.allowed_imports = []
+linter.allowed_unused_imports = []
 
 # Linter Plugins
 linter.flake8_annotations.mypy_init_return = false

--- a/crates/ruff/tests/snapshots/show_settings__display_default_settings.snap
+++ b/crates/ruff/tests/snapshots/show_settings__display_default_settings.snap
@@ -220,7 +220,6 @@ linter.task_tags = [
 	XXX,
 ]
 linter.typing_modules = []
-linter.allowed_unused_imports = []
 
 # Linter Plugins
 linter.flake8_annotations.mypy_init_return = false
@@ -360,6 +359,7 @@ linter.pycodestyle.max_line_length = 88
 linter.pycodestyle.max_doc_length = none
 linter.pycodestyle.ignore_overlong_task_comments = false
 linter.pyflakes.extend_generics = []
+linter.pyflakes.allowed_unused_imports = []
 linter.pylint.allow_magic_value_types = [
 	str,
 	bytes,

--- a/crates/ruff/tests/snapshots/show_settings__display_default_settings.snap
+++ b/crates/ruff/tests/snapshots/show_settings__display_default_settings.snap
@@ -220,6 +220,7 @@ linter.task_tags = [
 	XXX,
 ]
 linter.typing_modules = []
+linter.allowed_imports = []
 
 # Linter Plugins
 linter.flake8_annotations.mypy_init_return = false

--- a/crates/ruff_linter/resources/test/fixtures/pyflakes/F401_31.py
+++ b/crates/ruff_linter/resources/test/fixtures/pyflakes/F401_31.py
@@ -2,4 +2,11 @@
 Test: allowed-unused-imports
 """
 
+# OK
 import hvplot.pandas
+import hvplot.pandas.plots
+from hvplot.pandas import scatter_matrix
+from hvplot.pandas.plots import scatter_matrix
+
+# Errors
+from hvplot.pandas_alias import scatter_matrix

--- a/crates/ruff_linter/resources/test/fixtures/pyflakes/F401_31.py
+++ b/crates/ruff_linter/resources/test/fixtures/pyflakes/F401_31.py
@@ -1,0 +1,5 @@
+"""
+Test: allowed-unused-imports
+"""
+
+import hvplot.pandas

--- a/crates/ruff_linter/src/rules/pyflakes/mod.rs
+++ b/crates/ruff_linter/src/rules/pyflakes/mod.rs
@@ -327,6 +327,18 @@ mod tests {
         assert_messages!(snapshot, diagnostics);
         Ok(())
     }
+    #[test_case(Rule::UnusedImport, Path::new("F401_31.py"))]
+    fn f401_allowed_unused_imports_option(rule_code: Rule, path: &Path) -> Result<()> {
+        let diagnostics = test_path(
+            Path::new("pyflakes").join(path).as_path(),
+            &LinterSettings {
+                allowed_unused_imports: vec!["hvplot.pandas".to_string()],
+                ..LinterSettings::for_rule(rule_code)
+            },
+        )?;
+        assert_messages!(diagnostics);
+        Ok(())
+    }
 
     #[test]
     fn f841_dummy_variable_rgx() -> Result<()> {

--- a/crates/ruff_linter/src/rules/pyflakes/mod.rs
+++ b/crates/ruff_linter/src/rules/pyflakes/mod.rs
@@ -332,7 +332,10 @@ mod tests {
         let diagnostics = test_path(
             Path::new("pyflakes").join(path).as_path(),
             &LinterSettings {
-                allowed_unused_imports: vec!["hvplot.pandas".to_string()],
+                pyflakes: pyflakes::settings::Settings {
+                    ignore_unused_imports: vec!["hvplot.pandas".to_string()],
+                    ..pyflakes::settings::Settings::default()
+                },
                 ..LinterSettings::for_rule(rule_code)
             },
         )?;
@@ -439,7 +442,7 @@ mod tests {
             Path::new("pyflakes/project/foo/bar.py"),
             &LinterSettings {
                 typing_modules: vec!["foo.typical".to_string()],
-                ..LinterSettings::for_rules(vec![Rule::UndefinedName])
+                ..LinterSettings::for_rule(Rule::UndefinedName)
             },
         )?;
         assert_messages!(diagnostics);
@@ -452,7 +455,7 @@ mod tests {
             Path::new("pyflakes/project/foo/bop/baz.py"),
             &LinterSettings {
                 typing_modules: vec!["foo.typical".to_string()],
-                ..LinterSettings::for_rules(vec![Rule::UndefinedName])
+                ..LinterSettings::for_rule(Rule::UndefinedName)
             },
         )?;
         assert_messages!(diagnostics);
@@ -467,8 +470,9 @@ mod tests {
             &LinterSettings {
                 pyflakes: pyflakes::settings::Settings {
                     extend_generics: vec!["django.db.models.ForeignKey".to_string()],
+                    ..pyflakes::settings::Settings::default()
                 },
-                ..LinterSettings::for_rules(vec![Rule::UnusedImport])
+                ..LinterSettings::for_rule(Rule::UnusedImport)
             },
         )?;
         assert_messages!(snapshot, diagnostics);

--- a/crates/ruff_linter/src/rules/pyflakes/mod.rs
+++ b/crates/ruff_linter/src/rules/pyflakes/mod.rs
@@ -333,7 +333,7 @@ mod tests {
             Path::new("pyflakes").join(path).as_path(),
             &LinterSettings {
                 pyflakes: pyflakes::settings::Settings {
-                    ignore_unused_imports: vec!["hvplot.pandas".to_string()],
+                    allowed_unused_imports: vec!["hvplot.pandas".to_string()],
                     ..pyflakes::settings::Settings::default()
                 },
                 ..LinterSettings::for_rule(rule_code)

--- a/crates/ruff_linter/src/rules/pyflakes/rules/unused_import.rs
+++ b/crates/ruff_linter/src/rules/pyflakes/rules/unused_import.rs
@@ -307,6 +307,14 @@ pub(crate) fn unused_import(checker: &Checker, scope: &Scope, diagnostics: &mut 
         {
             continue;
         }
+        if checker
+            .settings
+            .allowed_imports
+            .iter()
+            .any(|allowed_import| name.starts_with(allowed_import))
+        {
+            continue;
+        }
 
         let import = ImportBinding {
             name,

--- a/crates/ruff_linter/src/rules/pyflakes/rules/unused_import.rs
+++ b/crates/ruff_linter/src/rules/pyflakes/rules/unused_import.rs
@@ -6,6 +6,7 @@ use std::collections::BTreeMap;
 
 use ruff_diagnostics::{Applicability, Diagnostic, Fix, FixAvailability, Violation};
 use ruff_macros::{derive_message_formats, violation};
+use ruff_python_ast::name::QualifiedName;
 use ruff_python_ast::{self as ast, Stmt};
 use ruff_python_semantic::{
     AnyImport, BindingKind, Exceptions, Imported, NodeId, Scope, SemanticModel, SubmoduleImport,
@@ -307,11 +308,17 @@ pub(crate) fn unused_import(checker: &Checker, scope: &Scope, diagnostics: &mut 
         {
             continue;
         }
+
+        // If an import was marked as allowed, avoid treating it as unused.
         if checker
             .settings
-            .allowed_unused_imports
+            .pyflakes
+            .ignore_unused_imports
             .iter()
-            .any(|allowed_unused_import| name.starts_with(allowed_unused_import))
+            .any(|allowed_unused_import| {
+                let allowed_unused_import = QualifiedName::from_dotted_name(allowed_unused_import);
+                import.qualified_name().starts_with(&allowed_unused_import)
+            })
         {
             continue;
         }

--- a/crates/ruff_linter/src/rules/pyflakes/rules/unused_import.rs
+++ b/crates/ruff_linter/src/rules/pyflakes/rules/unused_import.rs
@@ -313,7 +313,7 @@ pub(crate) fn unused_import(checker: &Checker, scope: &Scope, diagnostics: &mut 
         if checker
             .settings
             .pyflakes
-            .ignore_unused_imports
+            .allowed_unused_imports
             .iter()
             .any(|allowed_unused_import| {
                 let allowed_unused_import = QualifiedName::from_dotted_name(allowed_unused_import);

--- a/crates/ruff_linter/src/rules/pyflakes/rules/unused_import.rs
+++ b/crates/ruff_linter/src/rules/pyflakes/rules/unused_import.rs
@@ -309,9 +309,9 @@ pub(crate) fn unused_import(checker: &Checker, scope: &Scope, diagnostics: &mut 
         }
         if checker
             .settings
-            .allowed_imports
+            .allowed_unused_imports
             .iter()
-            .any(|allowed_import| name.starts_with(allowed_import))
+            .any(|allowed_unused_import| name.starts_with(allowed_unused_import))
         {
             continue;
         }

--- a/crates/ruff_linter/src/rules/pyflakes/settings.rs
+++ b/crates/ruff_linter/src/rules/pyflakes/settings.rs
@@ -7,6 +7,7 @@ use std::fmt;
 #[derive(Debug, Clone, Default, CacheKey)]
 pub struct Settings {
     pub extend_generics: Vec<String>,
+    pub ignore_unused_imports: Vec<String>,
 }
 
 impl fmt::Display for Settings {
@@ -15,7 +16,8 @@ impl fmt::Display for Settings {
             formatter = f,
             namespace = "linter.pyflakes",
             fields = [
-                self.extend_generics | debug
+                self.extend_generics | debug,
+                self.ignore_unused_imports | debug
             ]
         }
         Ok(())

--- a/crates/ruff_linter/src/rules/pyflakes/settings.rs
+++ b/crates/ruff_linter/src/rules/pyflakes/settings.rs
@@ -7,7 +7,7 @@ use std::fmt;
 #[derive(Debug, Clone, Default, CacheKey)]
 pub struct Settings {
     pub extend_generics: Vec<String>,
-    pub ignore_unused_imports: Vec<String>,
+    pub allowed_unused_imports: Vec<String>,
 }
 
 impl fmt::Display for Settings {
@@ -17,7 +17,7 @@ impl fmt::Display for Settings {
             namespace = "linter.pyflakes",
             fields = [
                 self.extend_generics | debug,
-                self.ignore_unused_imports | debug
+                self.allowed_unused_imports | debug
             ]
         }
         Ok(())

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__f401_allowed_unused_imports_option.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__f401_allowed_unused_imports_option.snap
@@ -1,0 +1,4 @@
+---
+source: crates/ruff_linter/src/rules/pyflakes/mod.rs
+---
+

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__f401_allowed_unused_imports_option.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__f401_allowed_unused_imports_option.snap
@@ -1,4 +1,16 @@
 ---
 source: crates/ruff_linter/src/rules/pyflakes/mod.rs
 ---
+F401_31.py:12:33: F401 [*] `hvplot.pandas_alias.scatter_matrix` imported but unused
+   |
+11 | # Errors
+12 | from hvplot.pandas_alias import scatter_matrix
+   |                                 ^^^^^^^^^^^^^^ F401
+   |
+   = help: Remove unused import: `hvplot.pandas_alias.scatter_matrix`
 
+ℹ Safe fix
+9  9  | from hvplot.pandas.plots import scatter_matrix
+10 10 | 
+11 11 | # Errors
+12    |-from hvplot.pandas_alias import scatter_matrix

--- a/crates/ruff_linter/src/settings/mod.rs
+++ b/crates/ruff_linter/src/settings/mod.rs
@@ -238,6 +238,7 @@ pub struct LinterSettings {
     pub line_length: LineLength,
     pub task_tags: Vec<String>,
     pub typing_modules: Vec<String>,
+    pub allowed_imports: Vec<String>,
 
     // Plugins
     pub flake8_annotations: flake8_annotations::settings::Settings,
@@ -299,6 +300,7 @@ impl Display for LinterSettings {
                 self.line_length,
                 self.task_tags | array,
                 self.typing_modules | array,
+                self.allowed_imports | array,
             ]
         }
         writeln!(f, "\n# Linter Plugins")?;
@@ -405,6 +407,7 @@ impl LinterSettings {
 
             task_tags: TASK_TAGS.iter().map(ToString::to_string).collect(),
             typing_modules: vec![],
+            allowed_imports: vec![],
             flake8_annotations: flake8_annotations::settings::Settings::default(),
             flake8_bandit: flake8_bandit::settings::Settings::default(),
             flake8_boolean_trap: flake8_boolean_trap::settings::Settings::default(),

--- a/crates/ruff_linter/src/settings/mod.rs
+++ b/crates/ruff_linter/src/settings/mod.rs
@@ -238,7 +238,7 @@ pub struct LinterSettings {
     pub line_length: LineLength,
     pub task_tags: Vec<String>,
     pub typing_modules: Vec<String>,
-    pub allowed_imports: Vec<String>,
+    pub allowed_unused_imports: Vec<String>,
 
     // Plugins
     pub flake8_annotations: flake8_annotations::settings::Settings,
@@ -300,7 +300,7 @@ impl Display for LinterSettings {
                 self.line_length,
                 self.task_tags | array,
                 self.typing_modules | array,
-                self.allowed_imports | array,
+                self.allowed_unused_imports | array,
             ]
         }
         writeln!(f, "\n# Linter Plugins")?;
@@ -407,7 +407,7 @@ impl LinterSettings {
 
             task_tags: TASK_TAGS.iter().map(ToString::to_string).collect(),
             typing_modules: vec![],
-            allowed_imports: vec![],
+            allowed_unused_imports: vec![],
             flake8_annotations: flake8_annotations::settings::Settings::default(),
             flake8_bandit: flake8_bandit::settings::Settings::default(),
             flake8_boolean_trap: flake8_boolean_trap::settings::Settings::default(),

--- a/crates/ruff_linter/src/settings/mod.rs
+++ b/crates/ruff_linter/src/settings/mod.rs
@@ -238,7 +238,6 @@ pub struct LinterSettings {
     pub line_length: LineLength,
     pub task_tags: Vec<String>,
     pub typing_modules: Vec<String>,
-    pub allowed_unused_imports: Vec<String>,
 
     // Plugins
     pub flake8_annotations: flake8_annotations::settings::Settings,
@@ -300,7 +299,6 @@ impl Display for LinterSettings {
                 self.line_length,
                 self.task_tags | array,
                 self.typing_modules | array,
-                self.allowed_unused_imports | array,
             ]
         }
         writeln!(f, "\n# Linter Plugins")?;
@@ -407,7 +405,6 @@ impl LinterSettings {
 
             task_tags: TASK_TAGS.iter().map(ToString::to_string).collect(),
             typing_modules: vec![],
-            allowed_unused_imports: vec![],
             flake8_annotations: flake8_annotations::settings::Settings::default(),
             flake8_bandit: flake8_bandit::settings::Settings::default(),
             flake8_boolean_trap: flake8_boolean_trap::settings::Settings::default(),

--- a/crates/ruff_workspace/src/configuration.rs
+++ b/crates/ruff_workspace/src/configuration.rs
@@ -303,7 +303,6 @@ impl Configuration {
                     .unwrap_or_else(|| TASK_TAGS.iter().map(ToString::to_string).collect()),
                 logger_objects: lint.logger_objects.unwrap_or_default(),
                 typing_modules: lint.typing_modules.unwrap_or_default(),
-                allowed_unused_imports: lint.allowed_unused_imports.unwrap_or_default(),
                 // Plugins
                 flake8_annotations: lint
                     .flake8_annotations

--- a/crates/ruff_workspace/src/configuration.rs
+++ b/crates/ruff_workspace/src/configuration.rs
@@ -303,7 +303,7 @@ impl Configuration {
                     .unwrap_or_else(|| TASK_TAGS.iter().map(ToString::to_string).collect()),
                 logger_objects: lint.logger_objects.unwrap_or_default(),
                 typing_modules: lint.typing_modules.unwrap_or_default(),
-                allowed_imports: lint.allowed_imports.unwrap_or_default(),
+                allowed_unused_imports: lint.allowed_unused_imports.unwrap_or_default(),
                 // Plugins
                 flake8_annotations: lint
                     .flake8_annotations
@@ -627,7 +627,7 @@ pub struct LintConfiguration {
     pub logger_objects: Option<Vec<String>>,
     pub task_tags: Option<Vec<String>>,
     pub typing_modules: Option<Vec<String>>,
-    pub allowed_imports: Option<Vec<String>>,
+    pub allowed_unused_imports: Option<Vec<String>>,
 
     // Plugins
     pub flake8_annotations: Option<Flake8AnnotationsOptions>,
@@ -740,7 +740,7 @@ impl LintConfiguration {
             task_tags: options.common.task_tags,
             logger_objects: options.common.logger_objects,
             typing_modules: options.common.typing_modules,
-            allowed_imports: options.common.allowed_imports,
+            allowed_unused_imports: options.common.allowed_unused_imports,
             // Plugins
             flake8_annotations: options.common.flake8_annotations,
             flake8_bandit: options.common.flake8_bandit,
@@ -1109,7 +1109,9 @@ impl LintConfiguration {
                 .or(config.explicit_preview_rules),
             task_tags: self.task_tags.or(config.task_tags),
             typing_modules: self.typing_modules.or(config.typing_modules),
-            allowed_imports: self.allowed_imports.or(config.allowed_imports),
+            allowed_unused_imports: self
+                .allowed_unused_imports
+                .or(config.allowed_unused_imports),
             // Plugins
             flake8_annotations: self.flake8_annotations.combine(config.flake8_annotations),
             flake8_bandit: self.flake8_bandit.combine(config.flake8_bandit),
@@ -1331,7 +1333,7 @@ fn warn_about_deprecated_top_level_lint_options(
         explicit_preview_rules,
         task_tags,
         typing_modules,
-        allowed_imports,
+        allowed_unused_imports,
         unfixable,
         flake8_annotations,
         flake8_bandit,
@@ -1430,8 +1432,8 @@ fn warn_about_deprecated_top_level_lint_options(
     if typing_modules.is_some() {
         used_options.push("typing-modules");
     }
-    if allowed_imports.is_some() {
-        used_options.push("allowed-imports");
+    if allowed_unused_imports.is_some() {
+        used_options.push("allowed-unused-imports");
     }
 
     if unfixable.is_some() {

--- a/crates/ruff_workspace/src/configuration.rs
+++ b/crates/ruff_workspace/src/configuration.rs
@@ -303,6 +303,7 @@ impl Configuration {
                     .unwrap_or_else(|| TASK_TAGS.iter().map(ToString::to_string).collect()),
                 logger_objects: lint.logger_objects.unwrap_or_default(),
                 typing_modules: lint.typing_modules.unwrap_or_default(),
+                allowed_imports: lint.allowed_imports.unwrap_or_default(),
                 // Plugins
                 flake8_annotations: lint
                     .flake8_annotations
@@ -626,6 +627,7 @@ pub struct LintConfiguration {
     pub logger_objects: Option<Vec<String>>,
     pub task_tags: Option<Vec<String>>,
     pub typing_modules: Option<Vec<String>>,
+    pub allowed_imports: Option<Vec<String>>,
 
     // Plugins
     pub flake8_annotations: Option<Flake8AnnotationsOptions>,
@@ -738,6 +740,7 @@ impl LintConfiguration {
             task_tags: options.common.task_tags,
             logger_objects: options.common.logger_objects,
             typing_modules: options.common.typing_modules,
+            allowed_imports: options.common.allowed_imports,
             // Plugins
             flake8_annotations: options.common.flake8_annotations,
             flake8_bandit: options.common.flake8_bandit,
@@ -1106,6 +1109,7 @@ impl LintConfiguration {
                 .or(config.explicit_preview_rules),
             task_tags: self.task_tags.or(config.task_tags),
             typing_modules: self.typing_modules.or(config.typing_modules),
+            allowed_imports: self.allowed_imports.or(config.allowed_imports),
             // Plugins
             flake8_annotations: self.flake8_annotations.combine(config.flake8_annotations),
             flake8_bandit: self.flake8_bandit.combine(config.flake8_bandit),
@@ -1327,6 +1331,7 @@ fn warn_about_deprecated_top_level_lint_options(
         explicit_preview_rules,
         task_tags,
         typing_modules,
+        allowed_imports,
         unfixable,
         flake8_annotations,
         flake8_bandit,
@@ -1424,6 +1429,9 @@ fn warn_about_deprecated_top_level_lint_options(
 
     if typing_modules.is_some() {
         used_options.push("typing-modules");
+    }
+    if allowed_imports.is_some() {
+        used_options.push("allowed-imports");
     }
 
     if unfixable.is_some() {

--- a/crates/ruff_workspace/src/options.rs
+++ b/crates/ruff_workspace/src/options.rs
@@ -796,8 +796,10 @@ pub struct LintCommonOptions {
     )]
     pub typing_modules: Option<Vec<String>>,
 
-    /// A list of modules which is allowed even thought it is not used
+    /// A list of modules which is allowed even thought they are not used
     /// in the code.
+    ///
+    /// This is useful when a module has a side effect when imported.
     #[option(
         default = r#"[]"#,
         value_type = "list[str]",

--- a/crates/ruff_workspace/src/options.rs
+++ b/crates/ruff_workspace/src/options.rs
@@ -2822,12 +2822,28 @@ pub struct PyflakesOptions {
         example = "extend-generics = [\"django.db.models.ForeignKey\"]"
     )]
     pub extend_generics: Option<Vec<String>>,
+
+    /// A list of modules to ignore when considering unused imports.
+    ///
+    /// Used to prevent violations for specific modules that are known to have side effects on
+    /// import (e.g., `hvplot.pandas`).
+    ///
+    /// Modules in this list are expected to be fully-qualified names (e.g., `hvplot.pandas`). Any
+    /// submodule of a given module will also be ignored (e.g., given `hvplot`, `hvplot.pandas`
+    /// will also be ignored).
+    #[option(
+        default = r#"[]"#,
+        value_type = "list[str]",
+        example = r#"allowed-unused-imports = ["hvplot.pandas"]"#
+    )]
+    pub ignore_unused_imports: Option<Vec<String>>,
 }
 
 impl PyflakesOptions {
     pub fn into_settings(self) -> pyflakes::settings::Settings {
         pyflakes::settings::Settings {
             extend_generics: self.extend_generics.unwrap_or_default(),
+            ignore_unused_imports: self.ignore_unused_imports.unwrap_or_default(),
         }
     }
 }

--- a/crates/ruff_workspace/src/options.rs
+++ b/crates/ruff_workspace/src/options.rs
@@ -801,9 +801,9 @@ pub struct LintCommonOptions {
     #[option(
         default = r#"[]"#,
         value_type = "list[str]",
-        example = r#"allowed-imports = ["hvplot.pandas"]"#
+        example = r#"allowed-unused-imports = ["hvplot.pandas"]"#
     )]
-    pub allowed_imports: Option<Vec<String>>,
+    pub allowed_unused_imports: Option<Vec<String>>,
     /// A list of rule codes or prefixes to consider non-fixable.
     #[option(
         default = "[]",

--- a/crates/ruff_workspace/src/options.rs
+++ b/crates/ruff_workspace/src/options.rs
@@ -796,6 +796,14 @@ pub struct LintCommonOptions {
     )]
     pub typing_modules: Option<Vec<String>>,
 
+    /// A list of modules which is allowed even thought it is not used
+    /// in the code.
+    #[option(
+        default = r#"[]"#,
+        value_type = "list[str]",
+        example = r#"allowed-imports = ["hvplot.pandas"]"#
+    )]
+    pub allowed_imports: Option<Vec<String>>,
     /// A list of rule codes or prefixes to consider non-fixable.
     #[option(
         default = "[]",

--- a/crates/ruff_workspace/src/options.rs
+++ b/crates/ruff_workspace/src/options.rs
@@ -2836,14 +2836,14 @@ pub struct PyflakesOptions {
         value_type = "list[str]",
         example = r#"allowed-unused-imports = ["hvplot.pandas"]"#
     )]
-    pub ignore_unused_imports: Option<Vec<String>>,
+    pub allowed_unused_imports: Option<Vec<String>>,
 }
 
 impl PyflakesOptions {
     pub fn into_settings(self) -> pyflakes::settings::Settings {
         pyflakes::settings::Settings {
             extend_generics: self.extend_generics.unwrap_or_default(),
-            ignore_unused_imports: self.ignore_unused_imports.unwrap_or_default(),
+            allowed_unused_imports: self.allowed_unused_imports.unwrap_or_default(),
         }
     }
 }

--- a/ruff.schema.json
+++ b/ruff.schema.json
@@ -2606,8 +2606,8 @@
     "PyflakesOptions": {
       "type": "object",
       "properties": {
-        "extend-generics": {
-          "description": "Additional functions or classes to consider generic, such that any subscripts should be treated as type annotation (e.g., `ForeignKey` in `django.db.models.ForeignKey[\"User\"]`.\n\nExpects to receive a list of fully-qualified names (e.g., `django.db.models.ForeignKey`, rather than `ForeignKey`).",
+        "allowed-unused-imports": {
+          "description": "A list of modules to ignore when considering unused imports.\n\nUsed to prevent violations for specific modules that are known to have side effects on import (e.g., `hvplot.pandas`).\n\nModules in this list are expected to be fully-qualified names (e.g., `hvplot.pandas`). Any submodule of a given module will also be ignored (e.g., given `hvplot`, `hvplot.pandas` will also be ignored).",
           "type": [
             "array",
             "null"
@@ -2616,8 +2616,8 @@
             "type": "string"
           }
         },
-        "ignore-unused-imports": {
-          "description": "A list of modules to ignore when considering unused imports.\n\nUsed to prevent violations for specific modules that are known to have side effects on import (e.g., `hvplot.pandas`).\n\nModules in this list are expected to be fully-qualified names (e.g., `hvplot.pandas`). Any submodule of a given module will also be ignored (e.g., given `hvplot`, `hvplot.pandas` will also be ignored).",
+        "extend-generics": {
+          "description": "Additional functions or classes to consider generic, such that any subscripts should be treated as type annotation (e.g., `ForeignKey` in `django.db.models.ForeignKey[\"User\"]`.\n\nExpects to receive a list of fully-qualified names (e.g., `django.db.models.ForeignKey`, rather than `ForeignKey`).",
           "type": [
             "array",
             "null"

--- a/ruff.schema.json
+++ b/ruff.schema.json
@@ -2615,6 +2615,16 @@
           "items": {
             "type": "string"
           }
+        },
+        "ignore-unused-imports": {
+          "description": "A list of modules to ignore when considering unused imports.\n\nUsed to prevent violations for specific modules that are known to have side effects on import (e.g., `hvplot.pandas`).\n\nModules in this list are expected to be fully-qualified names (e.g., `hvplot.pandas`). Any submodule of a given module will also be ignored (e.g., given `hvplot`, `hvplot.pandas` will also be ignored).",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
         }
       },
       "additionalProperties": false

--- a/ruff.schema.json
+++ b/ruff.schema.json
@@ -16,6 +16,17 @@
         "minLength": 1
       }
     },
+    "allowed-imports": {
+      "description": "A list of modules which is allowed even thought it is not used in the code.",
+      "deprecated": true,
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "type": "string"
+      }
+    },
     "analyze": {
       "description": "Options to configure import map generation.",
       "anyOf": [
@@ -1885,6 +1896,16 @@
             "type": "string",
             "maxLength": 1,
             "minLength": 1
+          }
+        },
+        "allowed-imports": {
+          "description": "A list of modules which is allowed even thought it is not used in the code.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
           }
         },
         "dummy-variable-rgx": {

--- a/ruff.schema.json
+++ b/ruff.schema.json
@@ -17,7 +17,7 @@
       }
     },
     "allowed-unused-imports": {
-      "description": "A list of modules which is allowed even thought it is not used in the code.",
+      "description": "A list of modules which is allowed even thought they are not used in the code.\n\nThis is useful when a module has a side effect when imported.",
       "deprecated": true,
       "type": [
         "array",
@@ -1899,7 +1899,7 @@
           }
         },
         "allowed-unused-imports": {
-          "description": "A list of modules which is allowed even thought it is not used in the code.",
+          "description": "A list of modules which is allowed even thought they are not used in the code.\n\nThis is useful when a module has a side effect when imported.",
           "type": [
             "array",
             "null"

--- a/ruff.schema.json
+++ b/ruff.schema.json
@@ -16,7 +16,7 @@
         "minLength": 1
       }
     },
-    "allowed-imports": {
+    "allowed-unused-imports": {
       "description": "A list of modules which is allowed even thought it is not used in the code.",
       "deprecated": true,
       "type": [
@@ -1898,7 +1898,7 @@
             "minLength": 1
           }
         },
-        "allowed-imports": {
+        "allowed-unused-imports": {
           "description": "A list of modules which is allowed even thought it is not used in the code.",
           "type": [
             "array",


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary
Resolves https://github.com/astral-sh/ruff/issues/9962 by allowing a configuration setting `allowed-unused-imports`

TODO:
- [x] Figure out the correct name and place for the setting; currently, I have added it top level.
- [x] The comparison is pretty naive. I tried using `glob::Pattern` but couldn't get it to work in the configuration.
- [x] Add tests
- [x] Update documentations

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

<!-- How was it tested? -->
`cargo test`