### PR TITLE
Avoid short circuiting `B017` for multiple context managers

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_bugbear/B017.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_bugbear/B017.py
@@ -53,3 +53,6 @@ def test_pytest_raises():
 
     with pytest.raises(Exception, match="hello"):
         raise ValueError("This is also fine")
+
+    with contextlib.nullcontext(), pytest.raises(Exception):
+        raise ValueError("Multiple context managers")

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/assert_raises_exception.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/assert_raises_exception.rs
@@ -84,27 +84,27 @@ pub(crate) fn assert_raises_exception(checker: &mut Checker, items: &[WithItem])
             range: _,
         }) = &item.context_expr
         else {
-            return;
+            continue;
         };
 
         if item.optional_vars.is_some() {
-            return;
+            continue;
         }
 
         let [arg] = &*arguments.args else {
-            return;
+            continue;
         };
 
         let semantic = checker.semantic();
 
         let Some(builtin_symbol) = semantic.resolve_builtin_symbol(arg) else {
-            return;
+            continue;
         };
 
         let exception = match builtin_symbol {
             "Exception" => ExceptionKind::Exception,
             "BaseException" => ExceptionKind::BaseException,
-            _ => return,
+            _ => continue,
         };
 
         let assertion = if matches!(func.as_ref(), Expr::Attribute(ast::ExprAttribute { attr, .. }) if attr == "assertRaises")
@@ -117,7 +117,7 @@ pub(crate) fn assert_raises_exception(checker: &mut Checker, items: &[WithItem])
         {
             AssertionKind::PytestRaises
         } else {
-            return;
+            continue;
         };
 
         checker.diagnostics.push(Diagnostic::new(

--- a/crates/ruff_linter/src/rules/flake8_bugbear/snapshots/ruff_linter__rules__flake8_bugbear__tests__B017_B017.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/snapshots/ruff_linter__rules__flake8_bugbear__tests__B017_B017.py.snap
@@ -35,4 +35,11 @@ B017.py:48:10: B017 `pytest.raises(Exception)` should be considered evil
 49 |         raise ValueError("Hello")
    |
 
-
+B017.py:57:36: B017 `pytest.raises(Exception)` should be considered evil
+   |
+55 |         raise ValueError("This is also fine")
+56 | 
+57 |     with contextlib.nullcontext(), pytest.raises(Exception):
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^ B017
+58 |         raise ValueError("Multiple context managers")
+   |


### PR DESCRIPTION
## Summary

fixes: #13603
