### PR TITLE
[refurb] Count codepoints not bytes for `slice-to-remove-prefix-or-suffix (FURB188)`

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/refurb/FURB188.py
+++ b/crates/ruff_linter/resources/test/fixtures/refurb/FURB188.py
@@ -170,3 +170,15 @@ def ignore_step():
     if text.startswith("!"):
         text = text[1::2]
     print(text)
+
+def handle_unicode():
+    # should be skipped!
+    text = "řetězec"
+    if text.startswith("ř"): 
+        text = text[2:]
+
+    # should be linted
+    # with fix `text = text.removeprefix("ř")`
+    text = "řetězec"
+    if text.startswith("ř"): 
+        text = text[1:]

--- a/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__FURB188_FURB188.py.snap
+++ b/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__FURB188_FURB188.py.snap
@@ -250,4 +250,23 @@ FURB188.py:162:5: FURB188 [*] Prefer `removeprefix` over conditionally replacing
     162 |+    text = text.removeprefix("!")
 164 163 |     print(text)
 165 164 | 
-166 165 |
+166 165 | 
+
+FURB188.py:183:5: FURB188 [*] Prefer `removeprefix` over conditionally replacing with slice.
+    |
+181 |       # with fix `text = text.removeprefix("ř")`
+182 |       text = "řetězec"
+183 |       if text.startswith("ř"): 
+    |  _____^
+184 | |         text = text[1:]
+    | |_______________________^ FURB188
+    |
+    = help: Use removeprefix instead of assignment conditional upon startswith.
+
+ℹ Safe fix
+180 180 |     # should be linted
+181 181 |     # with fix `text = text.removeprefix("ř")`
+182 182 |     text = "řetězec"
+183     |-    if text.startswith("ř"): 
+184     |-        text = text[1:]
+    183 |+    text = text.removeprefix("ř")


### PR DESCRIPTION
This PR fixes the calculation of string length for the purposes of verifying when to suggest `removeprefix`/`removesuffix` (FURB188). Before, we used `text_len` which was counting bytes rather than codepoints (chars) and therefore disagreed with Python's `len` for non-ASCII text.

Closes #13620
