### PR TITLE
[red-knot] feat: add `StringLiteral` and `LiteralString` comparison

### DIFF
--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -2614,18 +2614,10 @@ impl<'db> TypeInferenceBuilder<'db> {
                 ),
 
             (Type::StringLiteral(salsa_s1), Type::StringLiteral(salsa_s2)) => {
-                // For anything non-ASCII, don't even try to infer precise literal types.
-                // It would be complicated, it's an unimportant edge case,
-                // and Rust and Python probably do subtly different things
-                // in their string methods for non-ASCII characters.
+                // Note: this relies on rust's `PartialOrd` implementation for `String` matching
+                // the behavior of Python's string comparison. Which is not exactly guaranteed.
                 let s1 = salsa_s1.value(self.db);
-                if !s1.is_ascii() {
-                    return Some(builtins_symbol_ty(self.db, "bool").to_instance(self.db));
-                }
                 let s2 = salsa_s2.value(self.db);
-                if !s2.is_ascii() {
-                    return Some(builtins_symbol_ty(self.db, "bool").to_instance(self.db));
-                }
                 match op {
                     ast::CmpOp::Eq => Some(Type::BooleanLiteral(s1 == s2)),
                     ast::CmpOp::NotEq => Some(Type::BooleanLiteral(s1 != s2)),

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -2640,17 +2640,17 @@ impl<'db> TypeInferenceBuilder<'db> {
                 }
             }
             (Type::StringLiteral(_), _) => {
-                self.infer_binary_type_comparison(Type::builtin_str_instance(self.db), op, right)
+                self.infer_binary_type_comparison(KnownClass::Str.to_instance(self.db), op, right)
             }
             (_, Type::StringLiteral(_)) => {
-                self.infer_binary_type_comparison(left, op, Type::builtin_str_instance(self.db))
+                self.infer_binary_type_comparison(left, op, KnownClass::Str.to_instance(self.db))
             }
 
             (Type::LiteralString, _) => {
-                self.infer_binary_type_comparison(Type::builtin_str_instance(self.db), op, right)
+                self.infer_binary_type_comparison(KnownClass::Str.to_instance(self.db), op, right)
             }
             (_, Type::LiteralString) => {
-                self.infer_binary_type_comparison(left, op, Type::builtin_str_instance(self.db))
+                self.infer_binary_type_comparison(left, op, KnownClass::Str.to_instance(self.db))
             }
 
             // Lookup the rich comparison `__dunder__` methods on instances

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -2614,9 +2614,6 @@ impl<'db> TypeInferenceBuilder<'db> {
                 ),
 
             (Type::StringLiteral(salsa_s1), Type::StringLiteral(salsa_s2)) => {
-                // TODO: this relies on rust's `PartialOrd` implementation for `String` matching
-                // the behavior of Python's string comparison. Which is not exactly guaranteed,
-                // especially for non ascii characters.
                 let s1 = salsa_s1.value(self.db);
                 let s2 = salsa_s2.value(self.db);
                 match op {

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -4181,7 +4181,6 @@ mod tests {
             h = "A" is not "B"
             i = str_instance() < "..."
             j = "ab" < "ab_cd"
-            k = "£12" >= "£10"  # Sadly, not in red-knot, because £ is not ASCII
             "#,
         )?;
 
@@ -4197,8 +4196,6 @@ mod tests {
         // Very cornercase test ensuring we're not comparing the interned salsa symbols, which
         // compare by order of declaration
         assert_public_ty(&db, "src/a.py", "j", "Literal[True]");
-        // Case for non-ASCII characters (not supported as a likely source of edge cases)
-        assert_public_ty(&db, "src/a.py", "k", "bool");
 
         Ok(())
     }

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -2614,8 +2614,9 @@ impl<'db> TypeInferenceBuilder<'db> {
                 ),
 
             (Type::StringLiteral(salsa_s1), Type::StringLiteral(salsa_s2)) => {
-                // Note: this relies on rust's `PartialOrd` implementation for `String` matching
-                // the behavior of Python's string comparison. Which is not exactly guaranteed.
+                // TODO: this relies on rust's `PartialOrd` implementation for `String` matching
+                // the behavior of Python's string comparison. Which is not exactly guaranteed,
+                // especially for non ascii characters.
                 let s1 = salsa_s1.value(self.db);
                 let s2 = salsa_s2.value(self.db);
                 match op {

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -2535,9 +2535,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                                 ast::CmpOp::In
                                 | ast::CmpOp::NotIn
                                 | ast::CmpOp::Is
-                                | ast::CmpOp::IsNot => {
-                                    builtins_symbol_ty(self.db, "bool").to_instance(self.db)
-                                }
+                                | ast::CmpOp::IsNot => KnownClass::Bool.to_instance(self.db),
                                 // Other operators can return arbitrary types
                                 _ => Type::Unknown,
                             }
@@ -2573,14 +2571,14 @@ impl<'db> TypeInferenceBuilder<'db> {
                 ast::CmpOp::GtE => Some(Type::BooleanLiteral(n >= m)),
                 ast::CmpOp::Is => {
                     if n == m {
-                        Some(builtins_symbol_ty(self.db, "bool").to_instance(self.db))
+                        Some(KnownClass::Bool.to_instance(self.db))
                     } else {
                         Some(Type::BooleanLiteral(false))
                     }
                 }
                 ast::CmpOp::IsNot => {
                     if n == m {
-                        Some(builtins_symbol_ty(self.db, "bool").to_instance(self.db))
+                        Some(KnownClass::Bool.to_instance(self.db))
                     } else {
                         Some(Type::BooleanLiteral(true))
                     }
@@ -2627,14 +2625,14 @@ impl<'db> TypeInferenceBuilder<'db> {
                     ast::CmpOp::NotIn => Some(Type::BooleanLiteral(!s2.contains(s1.as_ref()))),
                     ast::CmpOp::Is => {
                         if s1 == s2 {
-                            Some(builtins_symbol_ty(self.db, "bool").to_instance(self.db))
+                            Some(KnownClass::Bool.to_instance(self.db))
                         } else {
                             Some(Type::BooleanLiteral(false))
                         }
                     }
                     ast::CmpOp::IsNot => {
                         if s1 == s2 {
-                            Some(builtins_symbol_ty(self.db, "bool").to_instance(self.db))
+                            Some(KnownClass::Bool.to_instance(self.db))
                         } else {
                             Some(Type::BooleanLiteral(true))
                         }

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -4181,6 +4181,7 @@ mod tests {
             h = "A" is not "B"
             i = str_instance() < "..."
             j = "ab" < "ab_cd"
+            k = "£12" >= "£10"  # Sadly, not in red-knot, because £ is not ASCII
             "#,
         )?;
 
@@ -4196,6 +4197,8 @@ mod tests {
         // Very cornercase test ensuring we're not comparing the interned salsa symbols, which
         // compare by order of declaration
         assert_public_ty(&db, "src/a.py", "j", "Literal[True]");
+        // Case for non-ASCII characters (not supported as a likely source of edge cases)
+        assert_public_ty(&db, "src/a.py", "k", "bool");
 
         Ok(())
     }

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -2614,10 +2614,18 @@ impl<'db> TypeInferenceBuilder<'db> {
                 ),
 
             (Type::StringLiteral(salsa_s1), Type::StringLiteral(salsa_s2)) => {
-                // Note: this relies on rust's `PartialOrd` implementation for `String` matching
-                // the behavior of Python's string comparison. Which is not exactly guaranteed.
+                // For anything non-ASCII, don't even try to infer precise literal types.
+                // It would be complicated, it's an unimportant edge case,
+                // and Rust and Python probably do subtly different things
+                // in their string methods for non-ASCII characters.
                 let s1 = salsa_s1.value(self.db);
+                if !s1.is_ascii() {
+                    return Some(builtins_symbol_ty(self.db, "bool").to_instance(self.db));
+                }
                 let s2 = salsa_s2.value(self.db);
+                if !s2.is_ascii() {
+                    return Some(builtins_symbol_ty(self.db, "bool").to_instance(self.db));
+                }
                 match op {
                     ast::CmpOp::Eq => Some(Type::BooleanLiteral(s1 == s2)),
                     ast::CmpOp::NotEq => Some(Type::BooleanLiteral(s1 != s2)),


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Implements string lietral comparisons and fallbacks to `str` instance for `LiteralString`.
Completes an item in #13618

## Test Plan

- Adds a dedicated test with non exhaustive cases
