### PR TITLE
[`flake8-todos`] Allow words starting with todo

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_todos/TD006.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_todos/TD006.py
@@ -1,5 +1,6 @@
 # TDO006 - accepted
 # TODO (evanrittenhouse): this is a valid TODO
+# Todoism is a word which starts with todo, but is not a todo
 # TDO006 - error
 # ToDo (evanrittenhouse): invalid capitalization
 # todo (evanrittenhouse): another invalid capitalization

--- a/crates/ruff_linter/src/directives.rs
+++ b/crates/ruff_linter/src/directives.rs
@@ -297,9 +297,11 @@ impl<'a> TodoDirective<'a> {
             let offset = subset.text_len() - trimmed.text_len();
             relative_offset += offset;
 
+            let first_word = trimmed.split(|c: char| !c.is_alphanumeric()).nth(0);
+
             // If we detect a TodoDirectiveKind variant substring in the comment, construct and
             // return the appropriate TodoDirective
-            if let Ok(directive_kind) = trimmed.parse::<TodoDirectiveKind>() {
+            if let Ok(directive_kind) = first_word?.parse::<TodoDirectiveKind>() {
                 let len = directive_kind.len();
 
                 return Some(Self {
@@ -334,40 +336,13 @@ impl FromStr for TodoDirectiveKind {
     type Err = ();
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        // The lengths of the respective variant strings: TODO, FIXME, HACK, XXX
-
-        for length in [3, 4, 5] {
-            let Some(substr) = s.get(..length) else {
-                break;
-            };
-
-            if s.len() > length {
-                if let Some(c) = s.chars().nth(length) {
-                    if c.is_alphanumeric() {
-                        // The word is longer, so ignore it
-                        continue;
-                    }
-                }
-            }
-
-            match substr.to_lowercase().as_str() {
-                "fixme" => {
-                    return Ok(TodoDirectiveKind::Fixme);
-                }
-                "hack" => {
-                    return Ok(TodoDirectiveKind::Hack);
-                }
-                "todo" => {
-                    return Ok(TodoDirectiveKind::Todo);
-                }
-                "xxx" => {
-                    return Ok(TodoDirectiveKind::Xxx);
-                }
-                _ => continue,
-            }
+        match s.to_lowercase().as_str() {
+            "fixme" => Ok(TodoDirectiveKind::Fixme),
+            "hack" => Ok(TodoDirectiveKind::Hack),
+            "todo" => Ok(TodoDirectiveKind::Todo),
+            "xxx" => Ok(TodoDirectiveKind::Xxx),
+            _ => Err(()),
         }
-
-        Err(())
     }
 }
 

--- a/crates/ruff_linter/src/directives.rs
+++ b/crates/ruff_linter/src/directives.rs
@@ -335,10 +335,20 @@ impl FromStr for TodoDirectiveKind {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         // The lengths of the respective variant strings: TODO, FIXME, HACK, XXX
+
         for length in [3, 4, 5] {
             let Some(substr) = s.get(..length) else {
                 break;
             };
+
+            if s.len() > length {
+                if let Some(c) = s.chars().nth(length) {
+                    if c.is_alphanumeric() {
+                        // The word is longer, so ignore it
+                        continue;
+                    }
+                }
+            }
 
             match substr.to_lowercase().as_str() {
                 "fixme" => {

--- a/crates/ruff_linter/src/directives.rs
+++ b/crates/ruff_linter/src/directives.rs
@@ -316,7 +316,7 @@ impl<'a> TodoDirective<'a> {
             // Shrink the subset to check for the next phrase starting with "#".
             if let Some(new_offset) = trimmed.find('#') {
                 relative_offset += TextSize::try_from(new_offset).unwrap();
-                subset = &subset[relative_offset.to_usize()..]
+                subset = &subset[relative_offset.to_usize()..];
             } else {
                 break;
             };

--- a/crates/ruff_linter/src/rules/flake8_todos/snapshots/ruff_linter__rules__flake8_todos__tests__invalid-todo-capitalization_TD006.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_todos/snapshots/ruff_linter__rules__flake8_todos__tests__invalid-todo-capitalization_TD006.py.snap
@@ -1,58 +1,56 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_todos/mod.rs
 ---
-TD006.py:4:3: TD006 [*] Invalid TODO capitalization: `ToDo` should be `TODO`
+TD006.py:5:3: TD006 [*] Invalid TODO capitalization: `ToDo` should be `TODO`
   |
-2 | # TODO (evanrittenhouse): this is a valid TODO
-3 | # TDO006 - error
-4 | # ToDo (evanrittenhouse): invalid capitalization
+3 | # Todoism is a word which starts with todo, but is not a todo
+4 | # TDO006 - error
+5 | # ToDo (evanrittenhouse): invalid capitalization
   |   ^^^^ TD006
-5 | # todo (evanrittenhouse): another invalid capitalization
-6 | # foo # todo: invalid capitalization
+6 | # todo (evanrittenhouse): another invalid capitalization
+7 | # foo # todo: invalid capitalization
   |
   = help: Replace `ToDo` with `TODO`
 
 ℹ Safe fix
-1 1 | # TDO006 - accepted
 2 2 | # TODO (evanrittenhouse): this is a valid TODO
-3 3 | # TDO006 - error
-4   |-# ToDo (evanrittenhouse): invalid capitalization
-  4 |+# TODO (evanrittenhouse): invalid capitalization
-5 5 | # todo (evanrittenhouse): another invalid capitalization
-6 6 | # foo # todo: invalid capitalization
+3 3 | # Todoism is a word which starts with todo, but is not a todo
+4 4 | # TDO006 - error
+5   |-# ToDo (evanrittenhouse): invalid capitalization
+  5 |+# TODO (evanrittenhouse): invalid capitalization
+6 6 | # todo (evanrittenhouse): another invalid capitalization
+7 7 | # foo # todo: invalid capitalization
 
-TD006.py:5:3: TD006 [*] Invalid TODO capitalization: `todo` should be `TODO`
+TD006.py:6:3: TD006 [*] Invalid TODO capitalization: `todo` should be `TODO`
   |
-3 | # TDO006 - error
-4 | # ToDo (evanrittenhouse): invalid capitalization
-5 | # todo (evanrittenhouse): another invalid capitalization
+4 | # TDO006 - error
+5 | # ToDo (evanrittenhouse): invalid capitalization
+6 | # todo (evanrittenhouse): another invalid capitalization
   |   ^^^^ TD006
-6 | # foo # todo: invalid capitalization
+7 | # foo # todo: invalid capitalization
   |
   = help: Replace `todo` with `TODO`
 
 ℹ Safe fix
-2 2 | # TODO (evanrittenhouse): this is a valid TODO
-3 3 | # TDO006 - error
-4 4 | # ToDo (evanrittenhouse): invalid capitalization
-5   |-# todo (evanrittenhouse): another invalid capitalization
-  5 |+# TODO (evanrittenhouse): another invalid capitalization
-6 6 | # foo # todo: invalid capitalization
+3 3 | # Todoism is a word which starts with todo, but is not a todo
+4 4 | # TDO006 - error
+5 5 | # ToDo (evanrittenhouse): invalid capitalization
+6   |-# todo (evanrittenhouse): another invalid capitalization
+  6 |+# TODO (evanrittenhouse): another invalid capitalization
+7 7 | # foo # todo: invalid capitalization
 
-TD006.py:6:9: TD006 [*] Invalid TODO capitalization: `todo` should be `TODO`
+TD006.py:7:9: TD006 [*] Invalid TODO capitalization: `todo` should be `TODO`
   |
-4 | # ToDo (evanrittenhouse): invalid capitalization
-5 | # todo (evanrittenhouse): another invalid capitalization
-6 | # foo # todo: invalid capitalization
+5 | # ToDo (evanrittenhouse): invalid capitalization
+6 | # todo (evanrittenhouse): another invalid capitalization
+7 | # foo # todo: invalid capitalization
   |         ^^^^ TD006
   |
   = help: Replace `todo` with `TODO`
 
 ℹ Safe fix
-3 3 | # TDO006 - error
-4 4 | # ToDo (evanrittenhouse): invalid capitalization
-5 5 | # todo (evanrittenhouse): another invalid capitalization
-6   |-# foo # todo: invalid capitalization
-  6 |+# foo # TODO: invalid capitalization
-
-
+4 4 | # TDO006 - error
+5 5 | # ToDo (evanrittenhouse): invalid capitalization
+6 6 | # todo (evanrittenhouse): another invalid capitalization
+7   |-# foo # todo: invalid capitalization
+  7 |+# foo # TODO: invalid capitalization


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Allow words which start with "todo" or other todo-directives
Fixes #13638

## Test Plan

Updated snapshots
