### PR TITLE
[`flake8-bugbear`] Tweak `B905` message to not suggest setting parameter `strict=` to `False`

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/zip_without_explicit_strict.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/zip_without_explicit_strict.rs
@@ -16,9 +16,9 @@ use crate::fix::edits::add_argument;
 /// resulting iterator will be silently truncated to the length of the shortest
 /// iterable. This can lead to subtle bugs.
 ///
-/// Use the `strict` parameter to raise a `ValueError` if the iterables are of
-/// non-uniform length. If the iterables are intentionally different lengths, the
-/// parameter should be explicitly set to `False`.
+/// Pass `strict=True` to raise a `ValueError` if the iterables are of
+/// non-uniform length. Alternatively, if the iterables are deliberately
+/// different lengths, pass `strict=False` to make the intention explicit.
 ///
 /// ## Example
 /// ```python

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/zip_without_explicit_strict.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/zip_without_explicit_strict.rs
@@ -47,7 +47,7 @@ impl AlwaysFixableViolation for ZipWithoutExplicitStrict {
     }
 
     fn fix_title(&self) -> String {
-        "Add explicit `strict=False`".to_string()
+        "Add explicit value for parameter `strict=`".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_bugbear/snapshots/ruff_linter__rules__flake8_bugbear__tests__B905.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/snapshots/ruff_linter__rules__flake8_bugbear__tests__B905.py.snap
@@ -9,7 +9,7 @@ B905.py:4:1: B905 [*] `zip()` without an explicit `strict=` parameter
 5 | zip(range(3))
 6 | zip("a", "b")
   |
-  = help: Add explicit `strict=False`
+  = help: Add explicit value for parameter `strict=`
 
 ℹ Safe fix
 1 1 | from itertools import count, cycle, repeat
@@ -30,7 +30,7 @@ B905.py:5:1: B905 [*] `zip()` without an explicit `strict=` parameter
 6 | zip("a", "b")
 7 | zip("a", "b", *zip("c"))
   |
-  = help: Add explicit `strict=False`
+  = help: Add explicit value for parameter `strict=`
 
 ℹ Safe fix
 2 2 | 
@@ -51,7 +51,7 @@ B905.py:6:1: B905 [*] `zip()` without an explicit `strict=` parameter
 7 | zip("a", "b", *zip("c"))
 8 | zip(zip("a"), strict=False)
   |
-  = help: Add explicit `strict=False`
+  = help: Add explicit value for parameter `strict=`
 
 ℹ Safe fix
 3 3 | # Errors
@@ -72,7 +72,7 @@ B905.py:7:1: B905 [*] `zip()` without an explicit `strict=` parameter
 8 | zip(zip("a"), strict=False)
 9 | zip(zip("a", strict=True))
   |
-  = help: Add explicit `strict=False`
+  = help: Add explicit value for parameter `strict=`
 
 ℹ Safe fix
 4 4 | zip()
@@ -93,7 +93,7 @@ B905.py:7:16: B905 [*] `zip()` without an explicit `strict=` parameter
 8 | zip(zip("a"), strict=False)
 9 | zip(zip("a", strict=True))
   |
-  = help: Add explicit `strict=False`
+  = help: Add explicit value for parameter `strict=`
 
 ℹ Safe fix
 4 4 | zip()
@@ -113,7 +113,7 @@ B905.py:8:5: B905 [*] `zip()` without an explicit `strict=` parameter
   |     ^^^^^^^^ B905
 9 | zip(zip("a", strict=True))
   |
-  = help: Add explicit `strict=False`
+  = help: Add explicit value for parameter `strict=`
 
 ℹ Safe fix
 5 5 | zip(range(3))
@@ -134,7 +134,7 @@ B905.py:9:1: B905 [*] `zip()` without an explicit `strict=` parameter
 10 | 
 11 | # OK
    |
-   = help: Add explicit `strict=False`
+   = help: Add explicit value for parameter `strict=`
 
 ℹ Safe fix
 6  6  | zip("a", "b")
@@ -153,7 +153,7 @@ B905.py:24:1: B905 [*] `zip()` without an explicit `strict=` parameter
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ B905
 25 | zip([1, 2, 3], repeat(1, times=4))
    |
-   = help: Add explicit `strict=False`
+   = help: Add explicit value for parameter `strict=`
 
 ℹ Safe fix
 21 21 | zip([1, 2, 3], repeat(1, times=None))
@@ -174,7 +174,7 @@ B905.py:25:1: B905 [*] `zip()` without an explicit `strict=` parameter
 26 | 
 27 | import builtins
    |
-   = help: Add explicit `strict=False`
+   = help: Add explicit value for parameter `strict=`
 
 ℹ Safe fix
 22 22 | 
@@ -193,7 +193,7 @@ B905.py:29:1: B905 [*] `zip()` without an explicit `strict=` parameter
 29 | builtins.zip([1, 2, 3])
    | ^^^^^^^^^^^^^^^^^^^^^^^ B905
    |
-   = help: Add explicit `strict=False`
+   = help: Add explicit value for parameter `strict=`
 
 ℹ Safe fix
 26 26 | 


### PR DESCRIPTION
## Summary

Tweaks the message of `B905` to not contradict the [B905 docs](https://docs.astral.sh/ruff/rules/zip-without-explicit-strict/#zip-without-explicit-strict-b905), leaves the autofix alone so as to avoid changing semantics or code behaviour. See also: https://github.com/astral-sh/ruff/issues/13581#issuecomment-2384800857 

## Test Plan

`cargo test`

## Issue link
Closes: https://github.com/astral-sh/ruff/issues/13581 
