### PR TITLE
[red-knot] feat: Introduce `Truthy` and `Falsy` to allow more precise typing

### DIFF
--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -406,7 +406,7 @@ impl<'db> Type<'db> {
         IntersectionBuilder::build_truthy(db, *self)
     }
 
-    /// Return the `Falsy` subset of this type (intersection with Truthy).
+    /// Return the `Falsy` subset of this type (intersection with Falsy).
     #[must_use]
     pub fn falsy(&self, db: &'db dyn Db) -> Type<'db> {
         self.falsy_set(db)

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -245,6 +245,13 @@ pub enum Type<'db> {
     Unbound,
     /// The None object -- TODO remove this in favor of Instance(types.NoneType)
     None,
+    /// Type for narrowing a type to the subset of that type that is truthy (bool(x) == True).
+    /// Mainly used in intersections: `X & Truthy`. Example: for `list` it's all lists of `len > 0`
+    Truthy,
+    /// Type for narrowing a type to the subset of that type that is falsy (bool(x) == False).
+    /// Mainly used in intersections: `X & Falsy`. Example: for `int` it's the singleton
+    /// `IntLiteral[0]`.
+    Falsy,
     /// Temporary type for symbols that can't be inferred yet because of missing implementations.
     /// Behaves equivalently to `Any`.
     ///

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -641,9 +641,9 @@ impl<'db> Type<'db> {
             Type::Intersection(intersection) => {
                 // The truthiness of the intersection is the intersection of the truthiness of its
                 // elements:
-                // - `Ambiguous` ∩ `Truthy` = `Truthy`
-                // - `Ambiguous` ∩ `Falsy` = `Falsy`
-                // - `Truthy` ∩ `Falsy` = `Never`  -- this should be impossible to build
+                // - `Ambiguous` & `Truthy` == `Truthy`
+                // - `Ambiguous` & `Falsy` == `Falsy`
+                // - `Truthy` & `Falsy` == `Never`  -- this should be impossible to build
                 intersection
                     // Negative elements (what this intersection should not be) do not have an
                     // influence on the truthiness of the intersection.

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -614,10 +614,6 @@ impl<'db> Type<'db> {
                 // More info in https://docs.python.org/3/library/stdtypes.html#truth-value-testing
                 Truthiness::Ambiguous
             }
-            // Temporary special case for `None` until we handle generic instances
-            Type::Instance(class) if class.is_known(db, KnownClass::NoneType) => {
-                Truthiness::AlwaysFalse
-            }
             // Temporary special case for `FunctionType` until we handle generic instances
             Type::Instance(class) if class.is_known(db, KnownClass::FunctionType) => {
                 Truthiness::AlwaysTrue

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -448,7 +448,6 @@ impl<'db> Type<'db> {
     #[must_use]
     pub fn truthy_set(&self, db: &'db dyn Db) -> Option<Type<'db>> {
         match self {
-            Type::None => Some(Type::Never),
             Type::Instance(class) => match class.known(db) {
                 Some(KnownClass::Bool) => Some(Type::BooleanLiteral(true)),
                 _ => match self.bool(db) {
@@ -459,7 +458,11 @@ impl<'db> Type<'db> {
                     Truthiness::Ambiguous => None,
                 },
             },
-            _ => None,
+            _ => match self.bool(db) {
+                Truthiness::AlwaysFalse => Some(*self),
+                Truthiness::AlwaysTrue => Some(Type::Never),
+                Truthiness::Ambiguous => None,
+            },
         }
     }
 

--- a/crates/red_knot_python_semantic/src/types/builder.rs
+++ b/crates/red_knot_python_semantic/src/types/builder.rs
@@ -692,4 +692,31 @@ mod tests {
             .build();
         assert_eq!(truthy_and_falsy, KnownClass::Int.to_instance(&db));
     }
+
+    #[test]
+    fn build_intersection_truthy_and_falsy_is_always_positive() {
+        let db = setup_db();
+
+        // `X & !Truthy` -> `X & Falsy`
+        let truthy_int_positive = IntersectionBuilder::new(&db)
+            .add_positive(KnownClass::Int.to_instance(&db))
+            .add_positive(Type::Truthy)
+            .build();
+        let falsy_int_negative = IntersectionBuilder::new(&db)
+            .add_positive(KnownClass::Int.to_instance(&db))
+            .add_negative(Type::Falsy)
+            .build();
+        assert_eq!(truthy_int_positive, falsy_int_negative);
+
+        // `X & !Falsy` -> `X & Truthy`
+        let falsy_int_positive = IntersectionBuilder::new(&db)
+            .add_positive(KnownClass::Int.to_instance(&db))
+            .add_positive(Type::Falsy)
+            .build();
+        let truthy_int_negative = IntersectionBuilder::new(&db)
+            .add_positive(KnownClass::Int.to_instance(&db))
+            .add_negative(Type::Truthy)
+            .build();
+        assert_eq!(falsy_int_positive, truthy_int_negative);
+    }
 }

--- a/crates/red_knot_python_semantic/src/types/builder.rs
+++ b/crates/red_knot_python_semantic/src/types/builder.rs
@@ -772,7 +772,7 @@ mod tests {
         let falsy_int = IntersectionBuilder::build_falsy(&db, KnownClass::Int.to_instance(&db));
         assert_eq!(falsy_int, Type::IntLiteral(0));
 
-        let empty_str = Type::StringLiteral(StringLiteralType::new(&db, "".into()));
+        let empty_str = Type::StringLiteral(StringLiteralType::empty(&db));
         let falsy_str = IntersectionBuilder::build_falsy(&db, KnownClass::Str.to_instance(&db));
         assert_eq!(falsy_str, empty_str);
 
@@ -782,11 +782,11 @@ mod tests {
         let falsy_bool = IntersectionBuilder::build_falsy(&db, KnownClass::Bool.to_instance(&db));
         assert_eq!(falsy_bool, Type::BooleanLiteral(false));
 
-        let empty_tuple = Type::Tuple(TupleType::new(&db, vec![].into()));
+        let empty_tuple = Type::Tuple(TupleType::empty(&db));
         let falsy_tuple = IntersectionBuilder::build_falsy(&db, KnownClass::Tuple.to_instance(&db));
         assert_eq!(falsy_tuple, empty_tuple);
 
-        let empty_bytes = Type::BytesLiteral(BytesLiteralType::new(&db, vec![].into()));
+        let empty_bytes = Type::BytesLiteral(BytesLiteralType::empty(&db));
         let falsy_bytes = IntersectionBuilder::build_falsy(&db, KnownClass::Bytes.to_instance(&db));
         assert_eq!(falsy_bytes, empty_bytes);
 
@@ -833,13 +833,13 @@ mod tests {
         // `X` -> `AlwaysFalse` => `X & Truthy` = `Never`
         // TODO: add a test case for `NoneType` when supported
 
-        let empty_string = Type::StringLiteral(StringLiteralType::new(&db, "".into()));
+        let empty_string = Type::StringLiteral(StringLiteralType::empty(&db));
         assert_eq!(
             IntersectionBuilder::build_truthy(&db, empty_string),
             Type::Never
         );
 
-        let empty_bytes = Type::BytesLiteral(BytesLiteralType::new(&db, vec![].into()));
+        let empty_bytes = Type::BytesLiteral(BytesLiteralType::empty(&db));
         assert_eq!(
             IntersectionBuilder::build_truthy(
                 &db,
@@ -849,7 +849,7 @@ mod tests {
         );
 
         // `X` -> `AlwaysFalse` => `X & Falsy` = `X`
-        let empty_tuple = Type::Tuple(TupleType::new(&db, vec![].into()));
+        let empty_tuple = Type::Tuple(TupleType::empty(&db));
         assert_eq!(
             IntersectionBuilder::build_falsy(&db, empty_tuple),
             empty_tuple
@@ -948,7 +948,7 @@ mod tests {
         );
 
         let str_instance = KnownClass::Str.to_instance(&db);
-        let empty_str = Type::StringLiteral(StringLiteralType::new(&db, "".into()));
+        let empty_str = Type::StringLiteral(StringLiteralType::empty(&db));
         assert_eq!(
             UnionBuilder::new(&db)
                 .add(empty_str)

--- a/crates/red_knot_python_semantic/src/types/display.rs
+++ b/crates/red_knot_python_semantic/src/types/display.rs
@@ -100,6 +100,8 @@ impl Display for DisplayRepresentation<'_> {
                 }
                 f.write_str("]")
             }
+            Type::Truthy => f.write_str("Truthy"),
+            Type::Falsy => f.write_str("Falsy"),
         }
     }
 }


### PR DESCRIPTION
## Summary

This is a PR trying to address #13632.

Reminder of the problem: when evaluating boolean operations, we could improve precision of types
```python
reveal_type(str_instance() and 8)  # Current: `str | Literal[8]` -- Expected `Literal["", 8]`
``` 
The idea is that in some contexts, we can narrow a type to the subset of instances that are `truthy` (`boo(instance) == True`) or the subset of instances that are `falsy`(`boo(instance) == False`).

As @carljm suggested, a very generic way to express this would be to implement two new types, `Truthy` and `Falsy`, and express "the subset of `A` instances that evaluate to `True`" as `A & Truthy` (and conversely for `False` and `Falsy`).

### Interface

On a high level, this should be fairly straightforward to use when required

- Introduce two new types `Truthy` and `Falsy`
- Convenience method to create `A & Truthy` (and falsy): `IntersectionBuilder::build_truthy(a_ty)`

### Interesting Cases

Here's a list of interesting cases that might be unlocked by this more precise type knowledge. Some of them are more or less complicated to handle and maybe shouldn't be supported.

#### Behaviour of Falsy and Truthy outside of intersections

While they only make sense in intersections and probably should only exist in that context, we do need to implement the behaviour of `Falsy` and `Truthy` outside of intersections, as they're a `Type` variant.
Suggestions are welcome if I didn't handle that part properly, I don't have specific opinions or feedback on this part of the implementation.

#### Consistency of intersections

As it's been raised in [this comment](https://github.com/astral-sh/ruff/issues/13632#issuecomment-2395193418) by @AlexWaygood, the existence of `Truthy` and `Falsy` coupled with having both `positive` (must be) and negative (must not be) elements in intersection leads to a question:
- Do we need both `truthy` and `falsy`
- `X & Falsy` = `X & ~Truthy`

Currently, as this PR explores a first attempt with `Truthy` and `Falsy`, we need to make sure that only one of the above two representations is used.

#### Defined falsy and truthy subsets

Some types have a known subset of instances that are `falsy`:
- `bool → False`
- `int → 0`
- `str → ""`
- `bytes → b''`
- `tuple → (,)`
- `list → []`, `dict → {}`, `set → set()` - we can't really represent that at the moment

Conversely for truthy (most types in Python are truthy, so this is rarely defined)
- `bool -> True`

This could be used in a few ways (that I can think of)
- Simplify `int & Falsy` to `Literal[0]` (we most probably want that)
- Simplify `int & Truthy | Literal[0]` to `int`
  ```python
  # Case 1
  reveal_type(int_instance() or 0)  # Should be `int != 0 | 0` → `int`
  ```
  - Note: that's a more advanced case of `X & Truthy | X & Falsy` → `X` (which we should support)
- Unify `int & ~0` (where `~0` is `Literal[0]` in the negatives) to `int & Truthy`
  - This is not really a "simplification" as both say the same thing, but we need consistency
- `x1 | x2` where `x1` is `X & Truthy` and `x2` is `X & Falsy`
  - This is what we're doing with `BooleanLiteral(true)`, `BooleanLiteral(false)` and `bool`
  - Not coded as I can't think of any other type that has both a known set of ` truthy` and `falsy` values
  
So far, all subsets I can think of have been singletons (no `UnionType`). This means that my code might maybe either be too simple (can't handle non-singleton) or too complicated (tries to handle non singleton) at times.

I guess that if we want to include this knowledge in the feature, knowing if non-singleton cases should be supported (or if they even exist) would help.
  
#### Simplifying `X & Falsy` / `X & Truthy`

I think that's a fairly straightforward feature. Some types (e.g. `FunctionType`) have a constant `Truthiness` (for `FunctionType.bool() → Truthiness::AlwaysTrue`), so associating them with `Truthy` or `Falsy` can be simplified.
- `X & Truthy` → `X` if `x.bool() == Truthiness::AlwaysTrue`
- `X & Falsy` → `Never` if `x.bool() == Truthiness::AlwaysTrue`
- ... (same for `AlwaysFalse`)

Overall, we should probably guarantee at build time that you can't have both `AlwaysTrue` and `AlwaysFalse` elements in an intersection, because elements of this intersection would need to have both properties, and that's not possible.

## Test Plan

- Added unit tests in the `builder.rs` for intersection/union cases
  - Overall, all features written about above should have one or more dedicated tests
- Added some "integration tests" in `infer.rs` through boolean chained operations (currently the only way to create `X & Truthy` or `X & Falsy` intersections)
- Edited existing tests with a more precise type inference
- Solved a random test's `// TODO`
  - `Literal[0] | None | Literal[1] & None` became `Literal[0] | None` with this PR which was the expected behaviour
  - Note that this should have been solved by other features eventually

We could eventually add some additional integration tests that would be "easier to read" by adding support for the following snippet
```python
a = A()
reveal_type(a)  # type: `A`
if A():
   reveal_type(a)  # type: `A & Truthy`
```

## Concerns & Feedback on the current implementation

I think this feature is very exciting. It would allow us to represent types with more precision, which is always nice.

I do have some concerns with my implementation as it is now
- Taken individually, most cases are easy to follow
- But it feels like I "hardcorded" many corner cases in the code
  - Especially the `InnerIntersectionBuilder::simplify` method
- I think that I can't really picture the kind of intersections we'll work with in practice, so I might either not test enough or test things that can't happen
- Performance might not be optimal in some areas

As always feedback is welcome, don't hesitate to question the entire direction I took to achieve this, I'll be happy to refine this with whatever we can learn from this first iteration.
