### PR TITLE
[red-knot] Allow `type[]` to be subscripted

### DIFF
--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -837,6 +837,7 @@ pub enum KnownClass {
     Set,
     Dict,
     // Types
+    GenericAlias,
     ModuleType,
     FunctionType,
     // Typeshed
@@ -857,6 +858,7 @@ impl<'db> KnownClass {
             Self::Dict => "dict",
             Self::List => "list",
             Self::Type => "type",
+            Self::GenericAlias => "GenericAlias",
             Self::ModuleType => "ModuleType",
             Self::FunctionType => "FunctionType",
             Self::NoneType => "NoneType",
@@ -880,7 +882,9 @@ impl<'db> KnownClass {
             | Self::Tuple
             | Self::Set
             | Self::Dict => builtins_symbol_ty(db, self.as_str()),
-            Self::ModuleType | Self::FunctionType => types_symbol_ty(db, self.as_str()),
+            Self::GenericAlias | Self::ModuleType | Self::FunctionType => {
+                types_symbol_ty(db, self.as_str())
+            }
             Self::NoneType => typeshed_symbol_ty(db, self.as_str()),
         }
     }
@@ -910,6 +914,7 @@ impl<'db> KnownClass {
             "set" => Some(Self::Set),
             "dict" => Some(Self::Dict),
             "list" => Some(Self::List),
+            "GenericAlias" => Some(Self::GenericAlias),
             "NoneType" => Some(Self::NoneType),
             "ModuleType" => Some(Self::ModuleType),
             "FunctionType" => Some(Self::FunctionType),
@@ -934,7 +939,7 @@ impl<'db> KnownClass {
             | Self::Tuple
             | Self::Set
             | Self::Dict => module.name() == "builtins",
-            Self::ModuleType | Self::FunctionType => module.name() == "types",
+            Self::GenericAlias | Self::ModuleType | Self::FunctionType => module.name() == "types",
             Self::NoneType => matches!(module.name().as_str(), "_typeshed" | "types"),
         }
     }


### PR DESCRIPTION
Fixed a TODO by adding another TODO. It's the red-knot way!

## Summary

`builtins.type` can be subscripted at runtime on Python 3.9+, even though it has no `__class_getitem__` method and its metaclass (which is... itself) has no `__getitem__` method. The special case is [hardcoded directly into `PyObject_GetItem` in CPython](https://github.com/python/cpython/blob/744caa8ef42ab67c6aa20cd691e078721e72e22a/Objects/abstract.c#L181-L184). We just have to replicate the special case in our semantic model.

This will fail at runtime on Python <3.9. However, there's a bunch of outstanding questions (detailed in the TODO comment I added) regarding how we deal with subscriptions of other generic types on lower Python versions. Since we want to avoid too many false positives for now, I haven't tried to address this; I've just made `type` subscriptable on all Python versions.

## Test Plan

`cargo test -p red_knot_python_semantic --lib`
