### PR TITLE
Remove `allow-unused-imports` setting from the common lint options

### DIFF
--- a/crates/ruff_workspace/src/configuration.rs
+++ b/crates/ruff_workspace/src/configuration.rs
@@ -626,7 +626,6 @@ pub struct LintConfiguration {
     pub logger_objects: Option<Vec<String>>,
     pub task_tags: Option<Vec<String>>,
     pub typing_modules: Option<Vec<String>>,
-    pub allowed_unused_imports: Option<Vec<String>>,
 
     // Plugins
     pub flake8_annotations: Option<Flake8AnnotationsOptions>,
@@ -739,7 +738,7 @@ impl LintConfiguration {
             task_tags: options.common.task_tags,
             logger_objects: options.common.logger_objects,
             typing_modules: options.common.typing_modules,
-            allowed_unused_imports: options.common.allowed_unused_imports,
+
             // Plugins
             flake8_annotations: options.common.flake8_annotations,
             flake8_bandit: options.common.flake8_bandit,
@@ -1108,9 +1107,7 @@ impl LintConfiguration {
                 .or(config.explicit_preview_rules),
             task_tags: self.task_tags.or(config.task_tags),
             typing_modules: self.typing_modules.or(config.typing_modules),
-            allowed_unused_imports: self
-                .allowed_unused_imports
-                .or(config.allowed_unused_imports),
+
             // Plugins
             flake8_annotations: self.flake8_annotations.combine(config.flake8_annotations),
             flake8_bandit: self.flake8_bandit.combine(config.flake8_bandit),
@@ -1332,7 +1329,6 @@ fn warn_about_deprecated_top_level_lint_options(
         explicit_preview_rules,
         task_tags,
         typing_modules,
-        allowed_unused_imports,
         unfixable,
         flake8_annotations,
         flake8_bandit,
@@ -1430,9 +1426,6 @@ fn warn_about_deprecated_top_level_lint_options(
 
     if typing_modules.is_some() {
         used_options.push("typing-modules");
-    }
-    if allowed_unused_imports.is_some() {
-        used_options.push("allowed-unused-imports");
     }
 
     if unfixable.is_some() {

--- a/crates/ruff_workspace/src/options.rs
+++ b/crates/ruff_workspace/src/options.rs
@@ -796,16 +796,6 @@ pub struct LintCommonOptions {
     )]
     pub typing_modules: Option<Vec<String>>,
 
-    /// A list of modules which is allowed even though they are not used
-    /// in the code.
-    ///
-    /// This is useful when a module has a side effect when imported.
-    #[option(
-        default = r#"[]"#,
-        value_type = "list[str]",
-        example = r#"allowed-unused-imports = ["hvplot.pandas"]"#
-    )]
-    pub allowed_unused_imports: Option<Vec<String>>,
     /// A list of rule codes or prefixes to consider non-fixable.
     #[option(
         default = "[]",

--- a/ruff.schema.json
+++ b/ruff.schema.json
@@ -16,17 +16,6 @@
         "minLength": 1
       }
     },
-    "allowed-unused-imports": {
-      "description": "A list of modules which is allowed even though they are not used in the code.\n\nThis is useful when a module has a side effect when imported.",
-      "deprecated": true,
-      "type": [
-        "array",
-        "null"
-      ],
-      "items": {
-        "type": "string"
-      }
-    },
     "analyze": {
       "description": "Options to configure import map generation.",
       "anyOf": [
@@ -1896,16 +1885,6 @@
             "type": "string",
             "maxLength": 1,
             "minLength": 1
-          }
-        },
-        "allowed-unused-imports": {
-          "description": "A list of modules which is allowed even though they are not used in the code.\n\nThis is useful when a module has a side effect when imported.",
-          "type": [
-            "array",
-            "null"
-          ],
-          "items": {
-            "type": "string"
           }
         },
         "dummy-variable-rgx": {


### PR DESCRIPTION
## Summary

Fixes https://github.com/astral-sh/ruff/issues/13668

Luckily, the `lint.allow_unused_imports` setting isn't read anywhere.
However, this could still be considered a breaking change because Ruff might fail to read a previously valid configuration. 
I do think that it should be very unlikely, considering that the configuration was "useless" before.

The setting remains available under `lint.pyflakes`

https://github.com/astral-sh/ruff/blob/0035ca9fe7cb1c016ec2811f100a95796c0f455e/crates/ruff_workspace/src/options.rs#L2824-L2829

## Test Plan

`cargo test`
<!-- How was it tested? -->
