### PR TITLE
Remove layout values from `AnyStringPart`

### DIFF
--- a/crates/ruff_python_formatter/src/other/bytes_literal.rs
+++ b/crates/ruff_python_formatter/src/other/bytes_literal.rs
@@ -9,7 +9,6 @@ pub struct FormatBytesLiteral;
 impl FormatNodeRule<BytesLiteral> for FormatBytesLiteral {
     fn fmt_fields(&self, item: &BytesLiteral, f: &mut PyFormatter) -> FormatResult<()> {
         StringNormalizer::from_context(f.context())
-            .with_preferred_quote_style(f.options().quote_style())
             .normalize(item.into())
             .fmt(f)
     }

--- a/crates/ruff_python_formatter/src/other/f_string.rs
+++ b/crates/ruff_python_formatter/src/other/f_string.rs
@@ -40,9 +40,7 @@ impl Format<PyFormatContext<'_>> for FormatFString<'_> {
                 self.quoting
             };
 
-        let normalizer = StringNormalizer::from_context(f.context())
-            .with_quoting(quoting)
-            .with_preferred_quote_style(f.options().quote_style());
+        let normalizer = StringNormalizer::from_context(f.context()).with_quoting(quoting);
 
         // If f-string formatting is disabled (not in preview), then we will
         // fall back to the previous behavior of normalizing the f-string.

--- a/crates/ruff_python_formatter/src/string/any.rs
+++ b/crates/ruff_python_formatter/src/string/any.rs
@@ -10,9 +10,6 @@ use ruff_source_file::Locator;
 use ruff_text_size::{Ranged, TextRange};
 
 use crate::expression::expr_f_string::f_string_quoting;
-use crate::other::f_string::FormatFString;
-use crate::other::string_literal::StringLiteralKind;
-use crate::prelude::*;
 use crate::string::Quoting;
 
 /// Represents any kind of string expression. This could be either a string,
@@ -46,6 +43,10 @@ impl<'a> AnyString<'a> {
         }
     }
 
+    pub(crate) const fn is_fstring(self) -> bool {
+        matches!(self, Self::FString(_))
+    }
+
     /// Returns the quoting to be used for this string.
     pub(super) fn quoting(self, locator: &Locator<'_>) -> Quoting {
         match self {
@@ -54,23 +55,21 @@ impl<'a> AnyString<'a> {
         }
     }
 
-    /// Returns a vector of all the [`AnyStringPart`] of this string.
-    pub(super) fn parts(self, quoting: Quoting) -> AnyStringPartsIter<'a> {
+    /// Returns an iterator over the [`AnyStringPart`]s of this string.
+    pub(super) fn parts(self) -> AnyStringPartsIter<'a> {
         match self {
             Self::String(ExprStringLiteral { value, .. }) => {
                 AnyStringPartsIter::String(value.iter())
             }
             Self::Bytes(ExprBytesLiteral { value, .. }) => AnyStringPartsIter::Bytes(value.iter()),
-            Self::FString(ExprFString { value, .. }) => {
-                AnyStringPartsIter::FString(value.iter(), quoting)
-            }
+            Self::FString(ExprFString { value, .. }) => AnyStringPartsIter::FString(value.iter()),
         }
     }
 
     pub(crate) fn is_multiline(self, source: &str) -> bool {
         match self {
             AnyString::String(_) | AnyString::Bytes(_) => {
-                self.parts(Quoting::default())
+                self.parts()
                     .next()
                     .is_some_and(|part| part.flags().is_triple_quoted())
                     && memchr2(b'\n', b'\r', source[self.range()].as_bytes()).is_some()
@@ -139,7 +138,7 @@ impl<'a> From<&'a ExprFString> for AnyString<'a> {
 pub(super) enum AnyStringPartsIter<'a> {
     String(std::slice::Iter<'a, StringLiteral>),
     Bytes(std::slice::Iter<'a, ast::BytesLiteral>),
-    FString(std::slice::Iter<'a, ast::FStringPart>, Quoting),
+    FString(std::slice::Iter<'a, ast::FStringPart>),
 }
 
 impl<'a> Iterator for AnyStringPartsIter<'a> {
@@ -147,28 +146,12 @@ impl<'a> Iterator for AnyStringPartsIter<'a> {
 
     fn next(&mut self) -> Option<Self::Item> {
         let part = match self {
-            Self::String(inner) => {
-                let part = inner.next()?;
-                AnyStringPart::String {
-                    part,
-                    layout: StringLiteralKind::String,
-                }
-            }
+            Self::String(inner) => AnyStringPart::String(inner.next()?),
             Self::Bytes(inner) => AnyStringPart::Bytes(inner.next()?),
-            Self::FString(inner, quoting) => {
-                let part = inner.next()?;
-                match part {
-                    ast::FStringPart::Literal(string_literal) => AnyStringPart::String {
-                        part: string_literal,
-                        #[allow(deprecated)]
-                        layout: StringLiteralKind::InImplicitlyConcatenatedFString(*quoting),
-                    },
-                    ast::FStringPart::FString(f_string) => AnyStringPart::FString {
-                        part: f_string,
-                        quoting: *quoting,
-                    },
-                }
-            }
+            Self::FString(inner) => match inner.next()? {
+                ast::FStringPart::Literal(string_literal) => AnyStringPart::String(string_literal),
+                ast::FStringPart::FString(f_string) => AnyStringPart::FString(f_string),
+            },
         };
 
         Some(part)
@@ -183,23 +166,17 @@ impl FusedIterator for AnyStringPartsIter<'_> {}
 /// This is constructed from the [`AnyString::parts`] method on [`AnyString`].
 #[derive(Clone, Debug)]
 pub(super) enum AnyStringPart<'a> {
-    String {
-        part: &'a ast::StringLiteral,
-        layout: StringLiteralKind,
-    },
+    String(&'a ast::StringLiteral),
     Bytes(&'a ast::BytesLiteral),
-    FString {
-        part: &'a ast::FString,
-        quoting: Quoting,
-    },
+    FString(&'a ast::FString),
 }
 
 impl AnyStringPart<'_> {
     fn flags(&self) -> AnyStringFlags {
         match self {
-            Self::String { part, .. } => part.flags.into(),
+            Self::String(part) => part.flags.into(),
             Self::Bytes(bytes_literal) => bytes_literal.flags.into(),
-            Self::FString { part, .. } => part.flags.into(),
+            Self::FString(part) => part.flags.into(),
         }
     }
 }
@@ -207,9 +184,9 @@ impl AnyStringPart<'_> {
 impl<'a> From<&AnyStringPart<'a>> for AnyNodeRef<'a> {
     fn from(value: &AnyStringPart<'a>) -> Self {
         match value {
-            AnyStringPart::String { part, .. } => AnyNodeRef::StringLiteral(part),
+            AnyStringPart::String(part) => AnyNodeRef::StringLiteral(part),
             AnyStringPart::Bytes(part) => AnyNodeRef::BytesLiteral(part),
-            AnyStringPart::FString { part, .. } => AnyNodeRef::FString(part),
+            AnyStringPart::FString(part) => AnyNodeRef::FString(part),
         }
     }
 }
@@ -217,19 +194,9 @@ impl<'a> From<&AnyStringPart<'a>> for AnyNodeRef<'a> {
 impl Ranged for AnyStringPart<'_> {
     fn range(&self) -> TextRange {
         match self {
-            Self::String { part, .. } => part.range(),
+            Self::String(part) => part.range(),
             Self::Bytes(part) => part.range(),
-            Self::FString { part, .. } => part.range(),
-        }
-    }
-}
-
-impl Format<PyFormatContext<'_>> for AnyStringPart<'_> {
-    fn fmt(&self, f: &mut PyFormatter) -> FormatResult<()> {
-        match self {
-            AnyStringPart::String { part, layout } => part.format().with_options(*layout).fmt(f),
-            AnyStringPart::Bytes(bytes_literal) => bytes_literal.format().fmt(f),
-            AnyStringPart::FString { part, quoting } => FormatFString::new(part, *quoting).fmt(f),
+            Self::FString(part) => part.range(),
         }
     }
 }

--- a/crates/ruff_python_formatter/src/string/normalize.rs
+++ b/crates/ruff_python_formatter/src/string/normalize.rs
@@ -22,7 +22,7 @@ impl<'a, 'src> StringNormalizer<'a, 'src> {
     pub(crate) fn from_context(context: &'a PyFormatContext<'src>) -> Self {
         Self {
             quoting: Quoting::default(),
-            preferred_quote_style: QuoteStyle::default(),
+            preferred_quote_style: context.options().quote_style(),
             context,
         }
     }


### PR DESCRIPTION
## Summary

This is a small refactor to simplify `AnyStringPart`. I always found it difficult to reason about how the `quoting` flows through the formatting
and this was part due to it being routed to `parts`, `AnyStringPart` and finally its `Format` implementation. 

This PR makes `AnyStringPart` a simple enum over the different parts as it used to be and moves the logic for 
formatting a part into the `FormatImplicitConcatenatedString`, the only place where it is used. 

## Test Plan

`cargo test`
