### PR TITLE
[red-knot] document test framework

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,6 +28,7 @@ repos:
         additional_dependencies:
           - mdformat-mkdocs
           - mdformat-admon
+          - mdformat-footnote
         exclude: |
           (?x)^(
             docs/formatter/black\.md

--- a/crates/red_knot_python_semantic/resources/README.md
+++ b/crates/red_knot_python_semantic/resources/README.md
@@ -1,0 +1,4 @@
+Markdown files within the `mdtest/` subdirectory are tests of type inference and type checking;
+executed by the `tests/mdtest.rs` integration test.
+
+See `crates/red_knot_test/README.md` for documentation of this test format.

--- a/crates/red_knot_python_semantic/tests/mdtest.rs
+++ b/crates/red_knot_python_semantic/tests/mdtest.rs
@@ -1,6 +1,7 @@
 use red_knot_test::run;
 use std::path::PathBuf;
 
+/// See `crates/red_knot_test/README.md` for documentation on these tests.
 #[rstest::rstest]
 fn mdtest(#[files("resources/mdtest/**/*.md")] path: PathBuf) {
     let crate_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))

--- a/crates/red_knot_test/README.md
+++ b/crates/red_knot_test/README.md
@@ -148,7 +148,7 @@ x: int = "foo"  # error: [invalid-assignment]
 
 ```py
 from b import y
-x: int = y  3 error: [invalid-assignment]
+x: int = y  # error: [invalid-assignment]
 ```
 
 ```py path=b.py

--- a/crates/red_knot_test/README.md
+++ b/crates/red_knot_test/README.md
@@ -263,7 +263,7 @@ A fenced code block with no language will always be an error.
 ### Configuration
 
 We will add the ability to specify non-default red-knot configurations to use in tests, by including
-a TOML fenced code block:
+a TOML code block:
 
 ````markdown
 ```toml
@@ -357,9 +357,9 @@ The inline comment diagnostic assertions are useful for making quick, readable a
 diagnostics in a particular location. But sometimes we will want to assert on the full diagnostic
 output of checking an embedded Python file. Or sometimes (see “incremental tests” below) we will
 want to assert on diagnostics in a file, without impacting the contents of that file by changing a
-comment in it. In these cases, a Python fenced code block in a test could be followed by a fenced
-code block with language `output`; this would contain the full diagnostic output for the preceding
-test file:
+comment in it. In these cases, a Python code block in a test could be followed by a fenced code
+block with language `output`; this would contain the full diagnostic output for the preceding test
+file:
 
 ````markdown
 # full output

--- a/crates/red_knot_test/README.md
+++ b/crates/red_knot_test/README.md
@@ -39,7 +39,7 @@ after `# revealed:` must match exactly with the displayed form of the revealed t
 expression.
 
 The `reveal_type` function can be imported from the `typing` standard library module (or, for older
-Python versions, from the `typing_extensions` pseudo-standard-library module\[^extensions\]):
+Python versions, from the `typing_extensions` pseudo-standard-library module[^1]):
 
 ```py
 from typing import reveal_type
@@ -55,9 +55,6 @@ The `# revealed:` assertion must always match a revealed-type diagnostic, and wi
 undefined-reveal diagnostic, if present, so it's safe to use `reveal_type` in tests either with or
 without importing it. (Style preference is to not import it in tests, unless specifically testing
 something about the behavior of importing it.)
-
-\[^extensions\]: `typing-extensions` is a third-party module, but typeshed, and thus type checkers
-also, treat it as part of the standard library.
 
 #### error
 
@@ -445,3 +442,6 @@ in a later stage continue to exist with their previously-specified contents, and
 
 All stages should be run in order, incrementally, and then the final state should also be re-checked
 cold, to validate equivalence of cold and incremental check results.
+
+[^1]: `typing-extensions` is a third-party module, but typeshed, and thus type checkers
+    also, treat it as part of the standard library.

--- a/crates/red_knot_test/README.md
+++ b/crates/red_knot_test/README.md
@@ -27,7 +27,7 @@ fails.
 
 ## Assertions
 
-Two kinds of assertions are supported, `# revealed:` (shown above) and `# error:`.
+Two kinds of assertions are supported: `# revealed:` (shown above) and `# error:`.
 
 ### Assertion kinds
 
@@ -69,15 +69,13 @@ match any diagnostic. The matching can be narrowed in three ways:
     `invalid-assignment`.
 - `# error: "Some text"` requires that the matched diagnostic's full message contain the text `Some text`.
 
-Any combination of two or all three of these can be used, but they must go in order: first column,
-if present; then rule code, if present, then contains-text, if present. For example, an assertion
-using all three would look like `# error: 8 [invalid-assignment] "Some text"`.
+Any combination of some or all of these can be used in a single assertion, but they must come in
+order: first column, if present; then rule code, if present; then contains-text, if present. For
+example, an assertion using all three would look like
+`# error: 8 [invalid-assignment] "Some text"`.
 
-Error assertions in tests intended to test type checker semantics should use primarily rule-code
+Error assertions in tests intended to test type checker semantics should primarily use rule-code
 assertions, with occasional contains-text assertions where needed to disambiguate.
-
-Some tests may exist in order to assert on the correct text-range or text of a diagnostic; these
-should use the appropriate assertions.
 
 ### Assertion locations
 
@@ -105,11 +103,11 @@ x: str = 1
 
 Intervening empty lines or non-assertion comments are not allowed; an assertion stack must be one
 assertion per line, immediately following each other, with the line immediately following the last
-assertion the line of source code emitting the matched diagnostics.
+assertion as the line of source code on which the matched diagnostics are emitted.
 
 ## Multi-file tests
 
-Some tests require multiple files, with imports from one file to another. Multiple fenced code
+Some tests require multiple files, with imports from one file into another. Multiple fenced code
 blocks represent multiple embedded files. Since files must have unique names, only zero or one files
 can use the default name of `/src/test.py`. Other files must explicitly specify their file name:
 
@@ -160,9 +158,9 @@ This test suite contains two tests, one named "Same-file invalid assignment" and
 "Cross-file invalid assignment". The first test involves only a single embedded file, and the second
 test involves two embedded files.
 
-The tests are run independently, in independent in-memory file-systems and with new red-knot salsa
-databases (so each is a from-scratch run of the type checker, with no data persisting from any
-previous test.)
+The tests are run independently, in independent in-memory file systems and with new red-knot [Salsa](https://github.com/salsa-rs/salsa)
+databases. This means that each is a from-scratch run of the type checker, with no data persisting from any
+previous test.
 
 Due to Rust test runner limitations, an entire test suite (Markdown file) is run as a single Rust
 test, so it's not possible to select individual tests within it to run.
@@ -198,14 +196,15 @@ reveal_type("foo")  # revealed: Literal["foo"]
 This test suite contains three tests, named "Literals - Numbers - Integer", "Literals - Numbers -
 Float", and "Literals - Strings".
 
-A header-demarcated section must either be a test or a grouping header, it cannot be both. That is,
+A header-demarcated section must either be a test or a grouping header; it cannot be both. That is,
 a header section can either contain embedded files (making it a test), or it can contain more
 deeply-nested headers (headers with more `#`), but it cannot contain both.
 
 ## Documentation of tests
 
 Arbitrary Markdown syntax (including of course normal prose paragraphs) is permitted (and ignored by
-the test framework) between fenced code blocks. This allows naturally documenting test intentions:
+the test framework) between fenced code blocks. This permits natural documentation of
+why a test exists, and what it intends to assert:
 
 ````markdown
 Assigning a string to a variable annotated as `int` is not permitted:
@@ -222,8 +221,8 @@ implemented:
 
 ### Multi-line diagnostic assertions
 
-We may want to be able to assert that a diagnostic spans multiple lines, and which columns it
-begins/ends on. The planned syntax for this uses `<<<` and `>>>` to mark the start and end lines for
+We may want to be able to assert that a diagnostic spans multiple lines, and to assert the columns it
+begins and/or ends on. The planned syntax for this will use `<<<` and `>>>` to mark the start and end lines for
 an assertion:
 
 ```py
@@ -252,10 +251,10 @@ partial
 
 We may want to also support testing Jupyter notebooks as embedded files using the `json` language.
 
-Of course red-knot is only run directly on `py` and `pyi` files, and assertion comments are only
+Of course, red-knot is only run directly on `py` and `pyi` files, and assertion comments are only
 possible in these files.
 
-(A fenced code block with no language should always be an error.)
+A fenced code block with no language will always be an error.
 
 ### Configuration
 
@@ -266,6 +265,7 @@ TOML fenced code block:
 ```toml
 [tool.knot]
 warn-on-any = true
+```
 
 ```py
 from typing import Any
@@ -275,32 +275,34 @@ def f(x: Any):  # error: [use-of-any]
 ```
 ````
 
-It should be possible to include a TOML fenced code block in a single test (as shown), or in a
-grouping section, in which case it applies to all nested tests within that grouping section. Configs
-at multiple level are allowed and merged, with the most-nested (closest to the test) taking
-precedence.
+It should be possible to include a TOML-fenced code block in a single test (as shown), or in a
+grouping section, in which case it applies to all nested tests within that grouping section.
+Configurations at multiple level are allowed and merged, with the most-nested (closest to the test)
+taking precedence.
 
 ### Configuring search paths and kinds
 
 The red-knot TOML config format hasn't been designed yet, and we may want to implement support in
 the test framework for configuring search paths before it is designed. If so, we can define some
 configuration options for now under the `[tool.knot.tests]` namespace. In the future, perhaps some
-of these can be replaced by real red-knot config options, maybe some of them will be kept long term
+of these can be replaced by real red-knot config options; some or all may also be kept long-term
 as test-specific options.
 
-We should be able to configure the default workspace root to something other than `/src/` using a
+Other future planned changes to configuration include:
+
+- We should be able to configure the default workspace root to something other than `/src/` using a
 `workspace-root` config option.
 
-We should be able to add a third-party root using the `third-party-root` config option.
+- We should be able to add a third-party root using the `third-party-root` config option.
 
-We may want to add additional config options for setting additional search path kinds.
+- We may want to add additional config options for setting additional search path kinds.
 
 Paths for `workspace-root` and `third-party-root` must be absolute.
 
 Relative embedded-file paths are relative to the workspace root, even if it is explicitly set to a
 non-default value using the `workspace-root` config.
 
-### Specifying custom typeshed
+### Specifying a custom typeshed
 
 Some tests will need to override the default typeshed with custom files. The `[tool.knot.tests]`
 config option `typeshed-root` should be usable for this:
@@ -323,6 +325,7 @@ file path is `test.py`:
 
 ```py
 reveal_type(I_AM_THE_ONLY_BUILTIN)  # revealed: Literal[1]
+```
 
 ````
 
@@ -342,7 +345,7 @@ diagnostics in a particular location. But sometimes we will want to assert on th
 output of a test. Or sometimes (see “incremental tests” below) we will want to assert on diagnostics
 in a file, without impacting the contents of that file by changing a comment in it. In these cases,
 a Python fenced code block in a test could be followed by a fenced code block with language
-`output`; this contains the full diagnostic output for the preceding test file:
+`output`; this would contain the full diagnostic output for the preceding test file:
 
 ````markdown
 # full output
@@ -352,7 +355,7 @@ x = 1
 reveal_type(x)
 ```
 
-This is just an example, not a proposal that red-knot would every actually output diagnostics in
+This is just an example, not a proposal that red-knot would ever actually output diagnostics in
 precisely this format:
 
 ```output
@@ -361,9 +364,9 @@ test.py, line 1, col 1: revealed type is 'Literal[1]'
 ````
 
 We will want to build tooling to automatically capture and update these “full diagnostic output”
-blocks, when tests are run in an update-output mode (probably specified by env var.)
+blocks, when tests are run in an update-output mode (probably specified by an environment variable.)
 
-By default, an `output` block specifies diagnostic output for the file `<workspace-root>/test.py`.
+By default, an `output` block will specify diagnostic output for the file `<workspace-root>/test.py`.
 An `output` block can have a `path=` option, to explicitly specify the Python file for which it
 asserts diagnostic output, and a `stage=` option, to specify which stage of an incremental test it
 specifies diagnostic output at. (See “incremental tests” below.)
@@ -420,10 +423,10 @@ contents for `test.py` in stage 1, which we don't want to do in this test.)
 ````
 
 Any number of stages can be provided in an incremental test. If a stage re-specifies a filename that
-was specified in a previous stage (or the initial state), that file is modified. A new filename
-appearing for the first time in a new stage will create a new file. To delete a previously-created
+was specified in a previous stage (or the initial stage), that file is modified. A new filename
+appearing for the first time in a new stage will create a new file. To delete a previously created
 file, specify that file with the tag `delete` in its tag string (in this case, it is an error to
-provide non-empty contents.) Any previously-created files that are not re-specified in a later stage
+provide non-empty contents). Any previously-created files that are not re-specified in a later stage
 continue to exist with their previously-specified contents, and are not "touched".
 
 All stages should be run in order, incrementally, and then the final state should also be re-checked

--- a/crates/red_knot_test/README.md
+++ b/crates/red_knot_test/README.md
@@ -1,0 +1,430 @@
+# Writing type-checking / type-inference tests
+
+Any Markdown file can be a test suite.
+
+In order for it to be run as one, `red_knot_test::run` must be called with its path; see
+`crates/red_knot_python_semantic/tests/mdtest.rs` for an example that treats all Markdown files
+under a certain directory as test suites.
+
+A Markdown test suite can contain any number of tests. A test consists of one or more embedded
+"files", each defined by a triple-backticks fenced code block. The code block must have a tag string
+specifying its language; currently only `py` (Python files) and `pyi` (type stub files) are
+supported.
+
+The simplest possible test suite consists of just a single test, with a single file.
+
+````markdown
+```py
+reveal_type(1)  # revealed: Literal[1]
+```
+````
+
+When running this test, the mdtest framework will write a file with these contents to the default
+file path (`/src/test.py`) in its in-memory file system, run a type check on that file, and then
+match the resulting diagnostics with the assertions in the test. Assertions are in the form of
+Python comments. If all diagnostics and all assertions are matched, the test passes; otherwise, it
+fails.
+
+## Assertions
+
+Two kinds of assertions are supported, `# revealed:` (shown above) and `# error:`.
+
+### Assertion kinds
+
+#### revealed
+
+A `# revealed:` assertion should always be paired with a call to the `reveal_type` utility, which
+reveals (via a diagnostic) the inferred type of its argument (which can be any expression). The text
+after `# revealed:` must match exactly with the displayed form of the revealed type of that
+expression.
+
+The `reveal_type` function can be imported from the `typing` standard library module (or, for older
+Python versions, from the `typing_extensions` pseudo-standard-library module -- it is a third-party
+module, but typeshed, and thus type checkers also, treat it as part of the standard library):
+
+```py
+from typing import reveal_type
+
+reveal_type("foo")  # revealed: Literal["foo"]
+```
+
+For convenience, type checkers also pretend that `reveal_type` is a built-in, so that this import is
+not required. Using `reveal_type` without importing it issues a diagnostic warning that it was used
+without importing it, in addition to the diagnostic revealing the type of the expression.
+
+The `# revealed:` assertion must always match a revealed-type diagnostic, and will also match the
+undefined-reveal diagnostic, if present, so it's safe to use `reveal_type` in tests either with or
+without importing it. (Style preference is to usually not import it in tests, unless specifically
+testing something about the behavior of importing it.)
+
+#### error
+
+A comment beginning with `# error:` is an assertion that a type checker diagnostic will
+be emitted, with text span starting on that line. If the comment is simply `# error:`, this will
+match any diagnostic. The matching can be narrowed in three ways:
+
+- `# error: 8` requires that the matched diagnostic's text span begins on column 8 (one-indexed) of
+    this line.
+- `# error: [invalid-assignment]` requires that the matched diagnostic have the rule code
+    `invalid-assignment`.
+- `# error: "Some text"` requires that the matched diagnostic's full message contain the text `Some text`.
+
+Any combination of two or all three of these can be used, but they must go in order: first column,
+if present; then rule code, if present, then contains-text, if present. For example, an assertion
+using all three would look like `# error: 8 [invalid-assignment] "Some text"`.
+
+Error assertions in tests intended to test type checker semantics should use primarily rule-code
+assertions, with occasional contains-text assertions where needed to disambiguate.
+
+Some tests may exist in order to assert on the correct text-range or text of a diagnostic; these
+should use the appropriate assertions.
+
+### Assertion locations
+
+An assertion comment may be a line-trailing comment, in which case it applies to the line it is on:
+
+```py
+x: str = 1  # error: [invalid-assignment]
+```
+
+Or it may be a comment on its own line, in which case it applies to the next non-assertion-comment
+line:
+
+```py
+# error: [invalid-assignment]
+x: str = 1
+```
+
+Multiple assertions applying to the same line may be stacked:
+
+```py
+# error: [invalid-assignment]
+# revealed: Literal[1]
+x: str = 1
+```
+
+Intervening empty lines or non-assertion comments are not allowed; an assertion stack must be one
+assertion per line, immediately following each other, with the line immediately following the last
+assertion the line of source code emitting the matched diagnostics.
+
+## Multi-file tests
+
+Some tests require multiple files, with imports from one file to another. Multiple fenced code
+blocks represent multiple embedded files. Since files must have unique names, only zero or one files
+can use the default name of `/src/test.py`. Other files must explicitly specify their file name:
+
+````markdown
+```py
+from b import C
+reveal_type(C)  # Literal[C]
+```
+
+```py path=b.py
+class C: pass
+```
+````
+
+Relative file names are always relative to the "workspace root", which is also an import root.
+
+The default workspace root is `/src/`. Currently it is not possible to customize this in a test, but
+this is a feature we will want to add in the future.
+
+So the above test creates two files, `/src/test.py` and `/src/b.py`, and sets the workspace root to
+`/src/`, allowing `test.py` to import from `b.py` using the module name `b`.
+
+## Multi-test suites
+
+A single test suite (markdown file) can contain multiple tests, by demarcating them using Markdown
+header lines:
+
+````markdown
+# Same-file invalid assignment
+
+```py
+x: int = "foo"  # error: [invalid-assignment]
+```
+
+# Cross-file invalid assignment
+
+```py
+from b import y
+x: int = y  3 error: [invalid-assignment]
+```
+
+```py path=b.py
+y = "foo"
+```
+````
+
+This test suite contains two tests, one named "Same-file invalid assignment" and the other named
+"Cross-file invalid assignment". The first test involves only a single embedded file, and the second
+test involves two embedded files.
+
+The tests are run independently, in independent in-memory file-systems and with new red-knot salsa
+databases (so each is a from-scratch run of the type checker, with no data persisting from any
+previous test.)
+
+Due to Rust test runner limitations, an entire test suite (Markdown file) is run as a single Rust
+test, so it's not possible to select individual tests within it to run.
+
+## Structured test suites
+
+Markdown headers can also be used to group related tests within a suite:
+
+````markdown
+# Literals
+
+## Numbers
+
+### Integer
+
+```py
+reveal_type(1)  # revealed: Literal[1]
+```
+
+### Float
+
+```py
+reveal_type(1.0)  # revealed: float
+```
+
+## Strings
+
+```py
+reveal_type("foo")  # revealed: Literal["foo"]
+```
+````
+
+This test suite contains three tests, named "Literals - Numbers - Integer", "Literals - Numbers -
+Float", and "Literals - Strings".
+
+A header-demarcated section must either be a test or a grouping header, it cannot be both. That is,
+a header section can either contain embedded files (making it a test), or it can contain more
+deeply-nested headers (headers with more `#`), but it cannot contain both.
+
+## Documentation of tests
+
+Arbitrary Markdown syntax (including of course normal prose paragraphs) is permitted (and ignored by
+the test framework) between fenced code blocks. This allows naturally documenting test intentions:
+
+````markdown
+Assigning a string to a variable annotated as `int` is not permitted:
+
+```py
+x: int = "foo"  # error: [invalid-assignment]
+```
+````
+
+## Planned features
+
+There are some designed features that we intend for the test framework to have, but have not yet
+implemented:
+
+### Multi-line diagnostic assertions
+
+We may want to be able to assert that a diagnostic spans multiple lines, and which columns it
+begins/ends on. The planned syntax for this uses `<<<` and `>>>` to mark the start and end lines for
+an assertion:
+
+```py
+(3  # error: 2 [unsupported-operands] <<<
+  +
+ "foo")  # error: 6 >>>
+```
+
+The column assertion `6` on the ending line should be optional.
+
+In cases of overlapping such assertions, resolve ambiguity using more brackets: `<<<<` begins an
+assertion ended by `>>>>`, etc.
+
+### Non-Python files
+
+Some tests may need to specify non-Python embedded files: typeshed `stdlib/VERSIONS`, `pth` files,
+`py.typed` files, `pyvenv.cfg` files...
+
+We should allow specifying any of these using the `text` language in the code block tag string:
+
+````markdown
+```text path=/third-party/foo/py.typed
+partial
+```
+````
+
+We may want to also support testing Jupyter notebooks as embedded files using the `json` language.
+
+Of course red-knot is only run directly on `py` and `pyi` files, and assertion comments are only
+possible in these files.
+
+(A fenced code block with no language should always be an error.)
+
+### Configuration
+
+We should be able to specify non-default red-knot configurations to use in tests, by including a
+TOML fenced code block:
+
+````markdown
+```toml
+[tool.knot]
+warn-on-any = true
+
+```py
+from typing import Any
+
+def f(x: Any):  # error: [use-of-any]
+    pass
+```
+````
+
+It should be possible to include a TOML fenced code block in a single test (as shown), or in a
+grouping section, in which case it applies to all nested tests within that grouping section. Configs
+at multiple level are allowed and merged, with the most-nested (closest to the test) taking
+precedence.
+
+### Configuring search paths and kinds
+
+The red-knot TOML config format hasn't been designed yet, and we may want to implement support in
+the test framework for configuring search paths before it is designed. If so, we can define some
+configuration options for now under the `[tool.knot.tests]` namespace. In the future, perhaps some
+of these can be replaced by real red-knot config options, maybe some of them will be kept long term
+as test-specific options.
+
+We should be able to configure the default workspace root to something other than `/src/` using a
+`workspace-root` config option.
+
+We should be able to add a third-party root using the `third-party-root` config option.
+
+We may want to add additional config options for setting additional search path kinds.
+
+Paths for `workspace-root` and `third-party-root` must be absolute.
+
+Relative embedded-file paths are relative to the workspace root, even if it is explicitly set to a
+non-default value using the `workspace-root` config.
+
+### Specifying custom typeshed
+
+Some tests will need to override the default typeshed with custom files. The `[tool.knot.tests]`
+config option `typeshed-root` should be usable for this:
+
+````markdown
+```toml
+[tool.knot.tests]
+typeshed-root = "/typeshed"
+```
+
+This file is importable as part of our custom typeshed, because it is within `/typeshed`, which we
+configured above as our custom typeshed root:
+
+```py path=/typeshed/stdlib/builtins.pyi
+I_AM_THE_ONLY_BUILTIN = 1
+```
+
+This file is written to `/src/test.py`, because the default workspace root is `/src/ and the default
+file path is `test.py`:
+
+```py
+reveal_type(I_AM_THE_ONLY_BUILTIN)  # revealed: Literal[1]
+
+````
+
+A fenced code block with language `text` can be used to provide a `stdlib/VERSIONS` file in the
+custom typeshed root. If no such file is created explicitly, one should be created implicitly
+including entries enabling all specified `<typeshed-root>/stdlib` files for all supported Python
+versions.
+
+### I/O errors
+
+We could use an `error=` config option in the tag string to make a file cause an I/O error on read.
+
+### Asserting on full diagnostic output
+
+The inline comment diagnostic assertions are useful for making quick, readable assertions about
+diagnostics in a particular location. But sometimes we will want to assert on the full diagnostic
+output of a test. Or sometimes (see “incremental tests” below) we will want to assert on diagnostics
+in a file, without impacting the contents of that file by changing a comment in it. In these cases,
+a Python fenced code block in a test could be followed by a fenced code block with language
+`output`; this contains the full diagnostic output for the preceding test file:
+
+````markdown
+# full output
+
+```py
+x = 1
+reveal_type(x)
+```
+
+This is just an example, not a proposal that red-knot would every actually output diagnostics in
+precisely this format:
+
+```output
+test.py, line 1, col 1: revealed type is 'Literal[1]'
+```
+````
+
+We will want to build tooling to automatically capture and update these “full diagnostic output”
+blocks, when tests are run in an update-output mode (probably specified by env var.)
+
+By default, an `output` block specifies diagnostic output for the file `<workspace-root>/test.py`.
+An `output` block can have a `path=` option, to explicitly specify the Python file for which it
+asserts diagnostic output, and a `stage=` option, to specify which stage of an incremental test it
+specifies diagnostic output at. (See “incremental tests” below.)
+
+It is an error for an `output` block to exist, if there is no `py` or `python` block in the same
+test for the same file path.
+
+### Incremental tests
+
+Some tests should validate incremental checking, by initially creating some files, checking them,
+and then modifying/adding/deleting files and checking again.
+
+We should add the capability to create an incremental test by using the `stage=` option on some
+fenced code blocks in the test:
+
+````markdown
+# Incremental
+
+## modify a file
+
+Initial version of `test.py` and `b.py`:
+
+```py
+from b import x
+reveal_type(x)
+```
+
+```py path=b.py
+x = 1
+```
+
+Initial expected output for `test.py`:
+
+```output
+/src/test.py, line 1, col 1: revealed type is 'Literal[1]'
+```
+
+Now in our first incremental stage, modify the contents of `b.py`:
+
+```py path=b.py stage=1
+# b.py
+x = 2
+```
+
+And this is our updated expected output for `test.py` at stage 1:
+
+```output stage=1
+/src/test.py, line 1, col 1: revealed type is 'Literal[2]'
+```
+
+(One reason to use full-diagnostic-output blocks in this test is that updating
+inline-comment diagnostic assertions for `test.py` would require specifying new
+contents for `test.py` in stage 1, which we don't want to do in this test.)
+````
+
+Any number of stages can be provided in an incremental test. If a stage re-specifies a filename that
+was specified in a previous stage (or the initial state), that file is modified. A new filename
+appearing for the first time in a new stage will create a new file. To delete a previously-created
+file, specify that file with the tag `delete` in its tag string (in this case, it is an error to
+provide non-empty contents.) Any previously-created files that are not re-specified in a later stage
+continue to exist with their previously-specified contents, and are not "touched".
+
+All stages should be run in order, incrementally, and then the final state should also be re-checked
+cold, to validate equivalence of cold and incremental check results.

--- a/crates/red_knot_test/README.md
+++ b/crates/red_knot_test/README.md
@@ -98,7 +98,7 @@ Multiple assertions applying to the same line may be stacked:
 ```py
 # error: [invalid-assignment]
 # revealed: Literal[1]
-x: str = 1
+x: str = reveal_type(1)
 ```
 
 Intervening empty lines or non-assertion comments are not allowed; an assertion stack must be one
@@ -293,20 +293,20 @@ variable.
 
 ### Configuring search paths and kinds
 
-The red-knot TOML config format hasn't been designed yet, and we may want to implement support in
-the test framework for configuring search paths before it is designed. If so, we can define some
-configuration options for now under the `[tool.knot.tests]` namespace. In the future, perhaps some
-of these can be replaced by real red-knot config options; some or all may also be kept long-term
-as test-specific options.
+The red-knot TOML configuration format hasn't been designed yet, and we may want to implement
+support in the test framework for configuring search paths before it is designed. If so, we can
+define some configuration options for now under the `[tool.knot.tests]` namespace. In the future,
+perhaps some of these can be replaced by real red-knot configuration options; some or all may also
+be kept long-term as test-specific options.
 
-Other future planned changes to configuration include:
+Some configuration options we will want to provide:
 
 - We should be able to configure the default workspace root to something other than `/src/` using a
-    `workspace-root` config option.
+    `workspace-root` configuration option.
 
-- We should be able to add a third-party root using the `third-party-root` config option.
+- We should be able to add a third-party root using the `third-party-root` configuration option.
 
-- We may want to add additional config options for setting additional search path kinds.
+- We may want to add additional configuration options for setting additional search path kinds.
 
 Paths for `workspace-root` and `third-party-root` must be absolute.
 
@@ -316,7 +316,7 @@ non-default value using the `workspace-root` config.
 ### Specifying a custom typeshed
 
 Some tests will need to override the default typeshed with custom files. The `[tool.knot.tests]`
-config option `typeshed-root` should be usable for this:
+configuration option `typeshed-root` should be usable for this:
 
 ````markdown
 ```toml
@@ -347,7 +347,8 @@ versions.
 
 ### I/O errors
 
-We could use an `error=` config option in the tag string to make a file cause an I/O error on read.
+We could use an `error=` configuration option in the tag string to make an embedded file cause an
+I/O error on read.
 
 ### Asserting on full diagnostic output
 

--- a/crates/red_knot_test/README.md
+++ b/crates/red_knot_test/README.md
@@ -39,7 +39,7 @@ after `# revealed:` must match exactly with the displayed form of the revealed t
 expression.
 
 The `reveal_type` function can be imported from the `typing` standard library module (or, for older
-Python versions, from the `typing_extensions` pseudo-standard-library module[^1]):
+Python versions, from the `typing_extensions` pseudo-standard-library module[^extensions]):
 
 ```py
 from typing import reveal_type
@@ -443,5 +443,5 @@ in a later stage continue to exist with their previously-specified contents, and
 All stages should be run in order, incrementally, and then the final state should also be re-checked
 cold, to validate equivalence of cold and incremental check results.
 
-[^1]: `typing-extensions` is a third-party module, but typeshed, and thus type checkers
+[^extensions]: `typing-extensions` is a third-party module, but typeshed, and thus type checkers
     also, treat it as part of the standard library.

--- a/crates/red_knot_test/README.md
+++ b/crates/red_knot_test/README.md
@@ -64,14 +64,15 @@ match any diagnostic. The matching can be narrowed in three ways:
 
 - `# error: [invalid-assignment]` requires that the matched diagnostic have the rule code
     `invalid-assignment`. (The square brackets are required.)
-- `# error: "Some text"` requires that the matched diagnostic's full message contain the text `Some text`. (The double quotes are required in the assertion comment; they are not part of the matched
-    text.)
+- `# error: "Some text"` requires that the diagnostic's full message contain the text `Some text`.
+    (The double quotes are required in the assertion comment; they are not part of the matched text.)
 - `# error: 8 [rule-code]` or `# error: 8 "Some text"` additionally requires that the matched
     diagnostic's text span begins on column 8 (one-indexed) of this line.
 
 Assertions must contain either a rule code or a contains-text, or both, and may optionally also
-include a column. They must come in order: first column, if present; then rule code, if present;
-then contains-text, if present. For example, an assertion using all three would look like `# error: 8 [invalid-assignment] "Some text"`.
+include a column number. They must come in order: first column, if present; then rule code, if
+present; then contains-text, if present. For example, an assertion using all three would look like
+`# error: 8 [invalid-assignment] "Some text"`.
 
 Error assertions in tests intended to test type checker semantics should primarily use rule-code
 assertions, with occasional contains-text assertions where needed to disambiguate.
@@ -158,9 +159,9 @@ This test suite contains two tests, one named "Same-file invalid assignment" and
 "Cross-file invalid assignment". The first test involves only a single embedded file, and the second
 test involves two embedded files.
 
-The tests are run independently, in independent in-memory file systems and with new red-knot [Salsa](https://github.com/salsa-rs/salsa)
-databases. This means that each is a from-scratch run of the type checker, with no data persisting from any
-previous test.
+The tests are run independently, in independent in-memory file systems and with new red-knot
+[Salsa](https://github.com/salsa-rs/salsa) databases. This means that each is a from-scratch run of
+the type checker, with no data persisting from any previous test.
 
 Due to `cargo test` limitations, an entire test suite (Markdown file) is run as a single Rust test,
 so it's not possible to select individual tests within it to run.
@@ -276,10 +277,10 @@ def f(x: Any):  # error: [use-of-any]
 ```
 ````
 
-It should be possible to include a TOML-fenced code block in a single test (as shown), or in a
-grouping section, in which case it applies to all nested tests within that grouping section.
-Configurations at multiple level are allowed and merged, with the most-nested (closest to the test)
-taking precedence.
+It should be possible to include a TOML code block in a single test (as shown), or in a grouping
+section, in which case it applies to all nested tests within that grouping section. Configurations
+at multiple level are allowed and merged, with the most-nested (closest to the test) taking
+precedence.
 
 ### Running just a single test from a suite
 


### PR DESCRIPTION
This adds documentation for the new test framework.

I also added documentation for the planned design of features we haven't built yet (clearly marked as such), so that this doc can become the sole source of truth for the test framework design (we don't need to refer back to the original internal design document.)

Also fixes a few issues in the test framework implementation that were discovered in writing up the docs.
