### PR TITLE
[red-knot] Avoid panicking when hitting failures looking up AST information

### DIFF
--- a/crates/red_knot_python_semantic/src/semantic_index.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index.rs
@@ -198,8 +198,10 @@ impl<'db> SemanticIndex<'db> {
     pub(crate) fn definition(
         &self,
         definition_key: impl Into<DefinitionNodeKey>,
-    ) -> Definition<'db> {
-        self.definitions_by_node[&definition_key.into()]
+    ) -> Option<Definition<'db>> {
+        self.definitions_by_node
+            .get(&definition_key.into())
+            .copied()
     }
 
     /// Returns the [`Expression`] ingredient for an expression node.

--- a/crates/red_knot_python_semantic/src/semantic_index.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index.rs
@@ -736,8 +736,9 @@ def f(a: str, /, b: str, c: int = 1, *args, d: int = 2, **kwargs):
             .elt
             .as_name_expr()
             .unwrap();
-        let element_use_id =
-            element.scoped_use_id(&db, comprehension_scope_id.to_scope_id(&db, file));
+        let element_use_id = element
+            .scoped_use_id(&db, comprehension_scope_id.to_scope_id(&db, file))
+            .unwrap();
 
         let binding = use_def.first_binding_at_use(element_use_id).unwrap();
         let DefinitionKind::Comprehension(comprehension) = binding.kind(&db) else {
@@ -987,7 +988,7 @@ class C[T]:
         let ast::Expr::Name(x_use_expr_name) = x_use_expr.as_ref() else {
             panic!("expected a Name");
         };
-        let x_use_id = x_use_expr_name.scoped_use_id(&db, scope);
+        let x_use_id = x_use_expr_name.scoped_use_id(&db, scope).unwrap();
         let use_def = use_def_map(&db, scope);
         let binding = use_def.first_binding_at_use(x_use_id).unwrap();
         let DefinitionKind::Assignment(assignment) = binding.kind(&db) else {

--- a/crates/red_knot_python_semantic/src/semantic_index/builder.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/builder.rs
@@ -212,7 +212,9 @@ impl<'db> SemanticIndexBuilder<'db> {
         let existing_definition = self
             .definitions_by_node
             .insert(definition_node.key(), definition);
-        debug_assert_eq!(existing_definition, None);
+        if existing_definition.is_some() {
+            tracing::warn!("Existing definition was unexpectedly evicted");
+        }
 
         if category.is_binding() {
             self.mark_symbol_bound(symbol);

--- a/crates/red_knot_python_semantic/src/semantic_index/builder.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/builder.rs
@@ -9,6 +9,7 @@ use ruff_python_ast as ast;
 use ruff_python_ast::name::Name;
 use ruff_python_ast::visitor::{walk_expr, walk_pattern, walk_stmt, Visitor};
 use ruff_python_ast::AnyParameterRef;
+use ruff_python_ast::Expr;
 
 use crate::ast_node_ref::AstNodeRef;
 use crate::semantic_index::ast_ids::node_key::ExpressionNodeKey;

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -114,12 +114,18 @@ fn definition_expression_ty<'db>(
     definition: Definition<'db>,
     expression: &ast::Expr,
 ) -> Type<'db> {
-    let expr_id = expression.scoped_ast_id(db, definition.scope(db));
-    let inference = infer_definition_types(db, definition);
-    if let Some(ty) = inference.try_expression_ty(expr_id) {
-        ty
+    if let Some(expr_id) = expression.scoped_ast_id(db, definition.scope(db)) {
+        let inference = infer_definition_types(db, definition);
+        if let Some(ty) = inference.try_expression_ty(expr_id) {
+            ty
+        } else {
+            infer_deferred_types(db, definition)
+                .try_expression_ty(expr_id)
+                .unwrap_or(Type::Unknown)
+        }
     } else {
-        infer_deferred_types(db, definition).expression_ty(expr_id)
+        tracing::warn!("Can't find expression ID");
+        Type::Unknown
     }
 }
 


### PR DESCRIPTION
This is a set of changes that allow for `cargo --bin red_knot` to not panic (though report _many_ failures across the repo).

The main idea here is to avoid panicking if, instead, type inference can choose to have "less information". For example, if some entry is not found, we often can return `Unknown`. In a stable system this can lead to `Unknown` spreading in a nasty way, but here this could allow for easier post-mortem debugging (for example, querying the salsa DB ad-hoc to figure out _why_ certain expectations didn't hold).

I tried adding `tracing` logs in places that felt like indications of real failures upstream (in particular partial AST traversal). I'm not well versed in `tracing`, but in Python land I would probably group all of these into a specific logger so that they can be treated as "road to 1.0" stuff.

In this process I changed some ID lookup methods to return `Option`. I believe that the goal here is that this wouldn't be needed (as the inference DB should cover "everything"), but the changeset is so small that it feels worthwhile until AST failures are inbound.

Part of the failures I found were "invalid AST but still constructed by Ruff"-style errors.

An example is `x, y: int = 1, 2`. 

red_knot sees an annotated assignment, and so figures out the types of `1` and `2`, but then trying to assign `1` and `2` to the left side (as a tuple), but an awkward interaction between annotated assignments and tuple assignments (like `x, y = 1, 2`) leads to `x, y` getting defined by `1` and `2`. This hits the "shouldn't have more than one definition for an expression" problem.

Ultimately this is a syntax error to begin with, so then we probably shouldn't traverse this. But if we don't traverse it and "try our best" with the above, suddenly `x` and `y` don't have anything associated.

I think the "right thing" to do above is to try harder (for example, erase the signature in the type inference treatment). But I think this branch shows that the cost of trying to keep the system running instead doesn't have too high of a cost.

In any case, this branch is hopefully an indicator of what kinds of places in the code are triggering panics when running `red_knot` against the `ruff` repo (as artificial of an example that might be).

