### PR TITLE
[`pycodestyle`] Fix whitespace-related false positives and false negatives inside type-parameter lists

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pycodestyle/E23.py
+++ b/crates/ruff_linter/resources/test/fixtures/pycodestyle/E23.py
@@ -114,13 +114,17 @@ def pep_696_bad[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= by
     pass
 
 class PEP696Bad[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes]:
-    pass
+    def pep_696_bad_method[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes](
+        self,
+        x:A = "foo"[::-1],
+        y:B = [[["foo", "bar"]]],
+        z:object = "fooo",
+    ):
+        pass
 
 class PEP696BadWithEmptyBases[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes]():
-    pass
-
-class PEP696BadWithNonEmptyBases[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes](object, something_dynamic[x::-1]):
-    pass
+    class IndentedPEP696BadWithNonEmptyBases[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes](object, something_dynamic[x::-1]):
+        pass
 
 # Should be no E231 errors on any of these:
 def pep_696_good[A: object="foo"[::-1], B: object =[[["foo", "bar"]]], C: object= bytes](

--- a/crates/ruff_linter/resources/test/fixtures/pycodestyle/E23.py
+++ b/crates/ruff_linter/resources/test/fixtures/pycodestyle/E23.py
@@ -104,3 +104,37 @@ x = [
         ]
     }
 ]
+
+# Should be E231 errors on all of these type parameters and function parameters, but not on their (strange) defaults
+def pep_696_bad[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes](
+    x:A = "foo"[::-1],
+    y:B = [[["foo", "bar"]]],
+    z:object = "fooo",
+):
+    pass
+
+class PEP696Bad[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes]:
+    pass
+
+class PEP696BadWithEmptyBases[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes]():
+    pass
+
+class PEP696BadWithNonEmptyBases[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes](object, something_dynamic[x::-1]):
+    pass
+
+# Should be no E231 errors on any of these:
+def pep_696_good[A: object="foo"[::-1], B: object =[[["foo", "bar"]]], C: object= bytes](
+    x: A = "foo"[::-1],
+    y: B = [[["foo", "bar"]]],
+    z: object = "fooo",
+):
+    pass
+
+class PEP696Good[A: object="foo"[::-1], B: object =[[["foo", "bar"]]], C: object= bytes]:
+    pass
+
+class PEP696GoodWithEmptyBases[A: object="foo"[::-1], B: object =[[["foo", "bar"]]], C: object= bytes]():
+    pass
+
+class PEP696GoodWithNonEmptyBases[A: object="foo"[::-1], B: object =[[["foo", "bar"]]], C: object= bytes](object, something_dynamic[x::-1]):
+    pass

--- a/crates/ruff_linter/resources/test/fixtures/pycodestyle/E25.py
+++ b/crates/ruff_linter/resources/test/fixtures/pycodestyle/E25.py
@@ -73,4 +73,5 @@ def pep_696_good[A = int, B: object = str, C:object = memoryview]():
     pass
 
 class PEP696Good[A = int, B: object = str, C:object = memoryview]:
-    pass
+    def pep_696_good_method[A = int, B: object = str, C:object = memoryview](self):
+        pass

--- a/crates/ruff_linter/resources/test/fixtures/pycodestyle/E25.py
+++ b/crates/ruff_linter/resources/test/fixtures/pycodestyle/E25.py
@@ -59,3 +59,18 @@ f"normal {f"{a=}"} normal"
 print(f"{foo = }")
 # ...but then it creates false negatives for now
 print(f"{foo(a = 1)}")
+
+# There should be at least one E251 diagnostic for each type parameter here:
+def pep_696_bad[A=int, B =str, C= bool, D:object=int, E: object=str, F: object =bool, G: object= bytes]():
+    pass
+
+class PEP696Bad[A=int, B =str, C= bool, D:object=int, E: object=str, F: object =bool, G: object= bytes]:
+    pass
+
+# The last of these should cause us to emit E231,
+# but E231 isn't tested by this fixture:
+def pep_696_good[A = int, B: object = str, C:object = memoryview]():
+    pass
+
+class PEP696Good[A = int, B: object = str, C:object = memoryview]:
+    pass

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/logical_lines/missing_whitespace.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/logical_lines/missing_whitespace.rs
@@ -6,7 +6,7 @@ use ruff_text_size::Ranged;
 
 use crate::checkers::logical_lines::LogicalLinesContext;
 
-use super::{LogicalLine, TypeParamsState};
+use super::{DefinitionState, LogicalLine};
 
 /// ## What it does
 /// Checks for missing whitespace after `,`, `;`, and `:`.
@@ -42,13 +42,13 @@ impl AlwaysFixableViolation for MissingWhitespace {
 /// E231
 pub(crate) fn missing_whitespace(line: &LogicalLine, context: &mut LogicalLinesContext) {
     let mut fstrings = 0u32;
-    let mut type_params_state = TypeParamsState::new();
+    let mut definition_state = DefinitionState::from_tokens(line.tokens());
     let mut brackets = Vec::new();
     let mut iter = line.tokens().iter().peekable();
 
     while let Some(token) = iter.next() {
         let kind = token.kind();
-        type_params_state.visit_token_kind(kind);
+        definition_state.visit_token_kind(kind);
         match kind {
             TokenKind::FStringStart => fstrings += 1,
             TokenKind::FStringEnd => fstrings = fstrings.saturating_sub(1),
@@ -88,7 +88,7 @@ pub(crate) fn missing_whitespace(line: &LogicalLine, context: &mut LogicalLinesC
                         match (kind, next_token.kind()) {
                             (TokenKind::Colon, _)
                                 if matches!(brackets.last(), Some(TokenKind::Lsqb))
-                                    && !(type_params_state.in_type_params()
+                                    && !(definition_state.in_type_params()
                                         && brackets.len() == 1) =>
                             {
                                 continue; // Slice syntax, no space required

--- a/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E231_E23.py.snap
+++ b/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E231_E23.py.snap
@@ -476,3 +476,306 @@ E23.py:102:24: E231 [*] Missing whitespace after ','
 103 103 |             },
 104 104 |         ]
 105 105 |     }
+
+E23.py:109:18: E231 [*] Missing whitespace after ':'
+    |
+108 | # Should be E231 errors on all of these type parameters and function parameters, but not on their (strange) defaults
+109 | def pep_696_bad[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes](
+    |                  ^ E231
+110 |     x:A = "foo"[::-1],
+111 |     y:B = [[["foo", "bar"]]],
+    |
+    = help: Add missing whitespace
+
+ℹ Safe fix
+106 106 | ]
+107 107 | 
+108 108 | # Should be E231 errors on all of these type parameters and function parameters, but not on their (strange) defaults
+109     |-def pep_696_bad[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes](
+    109 |+def pep_696_bad[A: object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes](
+110 110 |     x:A = "foo"[::-1],
+111 111 |     y:B = [[["foo", "bar"]]],
+112 112 |     z:object = "fooo",
+
+E23.py:109:40: E231 [*] Missing whitespace after ':'
+    |
+108 | # Should be E231 errors on all of these type parameters and function parameters, but not on their (strange) defaults
+109 | def pep_696_bad[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes](
+    |                                        ^ E231
+110 |     x:A = "foo"[::-1],
+111 |     y:B = [[["foo", "bar"]]],
+    |
+    = help: Add missing whitespace
+
+ℹ Safe fix
+106 106 | ]
+107 107 | 
+108 108 | # Should be E231 errors on all of these type parameters and function parameters, but not on their (strange) defaults
+109     |-def pep_696_bad[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes](
+    109 |+def pep_696_bad[A:object="foo"[::-1], B: object =[[["foo", "bar"]]], C:object= bytes](
+110 110 |     x:A = "foo"[::-1],
+111 111 |     y:B = [[["foo", "bar"]]],
+112 112 |     z:object = "fooo",
+
+E23.py:109:70: E231 [*] Missing whitespace after ':'
+    |
+108 | # Should be E231 errors on all of these type parameters and function parameters, but not on their (strange) defaults
+109 | def pep_696_bad[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes](
+    |                                                                      ^ E231
+110 |     x:A = "foo"[::-1],
+111 |     y:B = [[["foo", "bar"]]],
+    |
+    = help: Add missing whitespace
+
+ℹ Safe fix
+106 106 | ]
+107 107 | 
+108 108 | # Should be E231 errors on all of these type parameters and function parameters, but not on their (strange) defaults
+109     |-def pep_696_bad[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes](
+    109 |+def pep_696_bad[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C: object= bytes](
+110 110 |     x:A = "foo"[::-1],
+111 111 |     y:B = [[["foo", "bar"]]],
+112 112 |     z:object = "fooo",
+
+E23.py:110:6: E231 [*] Missing whitespace after ':'
+    |
+108 | # Should be E231 errors on all of these type parameters and function parameters, but not on their (strange) defaults
+109 | def pep_696_bad[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes](
+110 |     x:A = "foo"[::-1],
+    |      ^ E231
+111 |     y:B = [[["foo", "bar"]]],
+112 |     z:object = "fooo",
+    |
+    = help: Add missing whitespace
+
+ℹ Safe fix
+107 107 | 
+108 108 | # Should be E231 errors on all of these type parameters and function parameters, but not on their (strange) defaults
+109 109 | def pep_696_bad[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes](
+110     |-    x:A = "foo"[::-1],
+    110 |+    x: A = "foo"[::-1],
+111 111 |     y:B = [[["foo", "bar"]]],
+112 112 |     z:object = "fooo",
+113 113 | ):
+
+E23.py:111:6: E231 [*] Missing whitespace after ':'
+    |
+109 | def pep_696_bad[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes](
+110 |     x:A = "foo"[::-1],
+111 |     y:B = [[["foo", "bar"]]],
+    |      ^ E231
+112 |     z:object = "fooo",
+113 | ):
+    |
+    = help: Add missing whitespace
+
+ℹ Safe fix
+108 108 | # Should be E231 errors on all of these type parameters and function parameters, but not on their (strange) defaults
+109 109 | def pep_696_bad[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes](
+110 110 |     x:A = "foo"[::-1],
+111     |-    y:B = [[["foo", "bar"]]],
+    111 |+    y: B = [[["foo", "bar"]]],
+112 112 |     z:object = "fooo",
+113 113 | ):
+114 114 |     pass
+
+E23.py:112:6: E231 [*] Missing whitespace after ':'
+    |
+110 |     x:A = "foo"[::-1],
+111 |     y:B = [[["foo", "bar"]]],
+112 |     z:object = "fooo",
+    |      ^ E231
+113 | ):
+114 |     pass
+    |
+    = help: Add missing whitespace
+
+ℹ Safe fix
+109 109 | def pep_696_bad[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes](
+110 110 |     x:A = "foo"[::-1],
+111 111 |     y:B = [[["foo", "bar"]]],
+112     |-    z:object = "fooo",
+    112 |+    z: object = "fooo",
+113 113 | ):
+114 114 |     pass
+115 115 | 
+
+E23.py:116:18: E231 [*] Missing whitespace after ':'
+    |
+114 |     pass
+115 | 
+116 | class PEP696Bad[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes]:
+    |                  ^ E231
+117 |     pass
+    |
+    = help: Add missing whitespace
+
+ℹ Safe fix
+113 113 | ):
+114 114 |     pass
+115 115 | 
+116     |-class PEP696Bad[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes]:
+    116 |+class PEP696Bad[A: object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes]:
+117 117 |     pass
+118 118 | 
+119 119 | class PEP696BadWithEmptyBases[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes]():
+
+E23.py:116:40: E231 [*] Missing whitespace after ':'
+    |
+114 |     pass
+115 | 
+116 | class PEP696Bad[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes]:
+    |                                        ^ E231
+117 |     pass
+    |
+    = help: Add missing whitespace
+
+ℹ Safe fix
+113 113 | ):
+114 114 |     pass
+115 115 | 
+116     |-class PEP696Bad[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes]:
+    116 |+class PEP696Bad[A:object="foo"[::-1], B: object =[[["foo", "bar"]]], C:object= bytes]:
+117 117 |     pass
+118 118 | 
+119 119 | class PEP696BadWithEmptyBases[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes]():
+
+E23.py:116:70: E231 [*] Missing whitespace after ':'
+    |
+114 |     pass
+115 | 
+116 | class PEP696Bad[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes]:
+    |                                                                      ^ E231
+117 |     pass
+    |
+    = help: Add missing whitespace
+
+ℹ Safe fix
+113 113 | ):
+114 114 |     pass
+115 115 | 
+116     |-class PEP696Bad[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes]:
+    116 |+class PEP696Bad[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C: object= bytes]:
+117 117 |     pass
+118 118 | 
+119 119 | class PEP696BadWithEmptyBases[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes]():
+
+E23.py:119:32: E231 [*] Missing whitespace after ':'
+    |
+117 |     pass
+118 | 
+119 | class PEP696BadWithEmptyBases[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes]():
+    |                                ^ E231
+120 |     pass
+    |
+    = help: Add missing whitespace
+
+ℹ Safe fix
+116 116 | class PEP696Bad[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes]:
+117 117 |     pass
+118 118 | 
+119     |-class PEP696BadWithEmptyBases[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes]():
+    119 |+class PEP696BadWithEmptyBases[A: object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes]():
+120 120 |     pass
+121 121 | 
+122 122 | class PEP696BadWithNonEmptyBases[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes](object, something_dynamic[x::-1]):
+
+E23.py:119:54: E231 [*] Missing whitespace after ':'
+    |
+117 |     pass
+118 | 
+119 | class PEP696BadWithEmptyBases[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes]():
+    |                                                      ^ E231
+120 |     pass
+    |
+    = help: Add missing whitespace
+
+ℹ Safe fix
+116 116 | class PEP696Bad[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes]:
+117 117 |     pass
+118 118 | 
+119     |-class PEP696BadWithEmptyBases[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes]():
+    119 |+class PEP696BadWithEmptyBases[A:object="foo"[::-1], B: object =[[["foo", "bar"]]], C:object= bytes]():
+120 120 |     pass
+121 121 | 
+122 122 | class PEP696BadWithNonEmptyBases[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes](object, something_dynamic[x::-1]):
+
+E23.py:119:84: E231 [*] Missing whitespace after ':'
+    |
+117 |     pass
+118 | 
+119 | class PEP696BadWithEmptyBases[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes]():
+    |                                                                                    ^ E231
+120 |     pass
+    |
+    = help: Add missing whitespace
+
+ℹ Safe fix
+116 116 | class PEP696Bad[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes]:
+117 117 |     pass
+118 118 | 
+119     |-class PEP696BadWithEmptyBases[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes]():
+    119 |+class PEP696BadWithEmptyBases[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C: object= bytes]():
+120 120 |     pass
+121 121 | 
+122 122 | class PEP696BadWithNonEmptyBases[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes](object, something_dynamic[x::-1]):
+
+E23.py:122:35: E231 [*] Missing whitespace after ':'
+    |
+120 |     pass
+121 | 
+122 | class PEP696BadWithNonEmptyBases[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes](object, something_dynamic[x::-1]):
+    |                                   ^ E231
+123 |     pass
+    |
+    = help: Add missing whitespace
+
+ℹ Safe fix
+119 119 | class PEP696BadWithEmptyBases[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes]():
+120 120 |     pass
+121 121 | 
+122     |-class PEP696BadWithNonEmptyBases[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes](object, something_dynamic[x::-1]):
+    122 |+class PEP696BadWithNonEmptyBases[A: object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes](object, something_dynamic[x::-1]):
+123 123 |     pass
+124 124 | 
+125 125 | # Should be no E231 errors on any of these:
+
+E23.py:122:57: E231 [*] Missing whitespace after ':'
+    |
+120 |     pass
+121 | 
+122 | class PEP696BadWithNonEmptyBases[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes](object, something_dynamic[x::-1]):
+    |                                                         ^ E231
+123 |     pass
+    |
+    = help: Add missing whitespace
+
+ℹ Safe fix
+119 119 | class PEP696BadWithEmptyBases[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes]():
+120 120 |     pass
+121 121 | 
+122     |-class PEP696BadWithNonEmptyBases[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes](object, something_dynamic[x::-1]):
+    122 |+class PEP696BadWithNonEmptyBases[A:object="foo"[::-1], B: object =[[["foo", "bar"]]], C:object= bytes](object, something_dynamic[x::-1]):
+123 123 |     pass
+124 124 | 
+125 125 | # Should be no E231 errors on any of these:
+
+E23.py:122:87: E231 [*] Missing whitespace after ':'
+    |
+120 |     pass
+121 | 
+122 | class PEP696BadWithNonEmptyBases[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes](object, something_dynamic[x::-1]):
+    |                                                                                       ^ E231
+123 |     pass
+    |
+    = help: Add missing whitespace
+
+ℹ Safe fix
+119 119 | class PEP696BadWithEmptyBases[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes]():
+120 120 |     pass
+121 121 | 
+122     |-class PEP696BadWithNonEmptyBases[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes](object, something_dynamic[x::-1]):
+    122 |+class PEP696BadWithNonEmptyBases[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C: object= bytes](object, something_dynamic[x::-1]):
+123 123 |     pass
+124 124 | 
+125 125 | # Should be no E231 errors on any of these:

--- a/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E231_E23.py.snap
+++ b/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E231_E23.py.snap
@@ -606,7 +606,8 @@ E23.py:116:18: E231 [*] Missing whitespace after ':'
 115 | 
 116 | class PEP696Bad[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes]:
     |                  ^ E231
-117 |     pass
+117 |     def pep_696_bad_method[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes](
+118 |         self,
     |
     = help: Add missing whitespace
 
@@ -616,9 +617,9 @@ E23.py:116:18: E231 [*] Missing whitespace after ':'
 115 115 | 
 116     |-class PEP696Bad[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes]:
     116 |+class PEP696Bad[A: object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes]:
-117 117 |     pass
-118 118 | 
-119 119 | class PEP696BadWithEmptyBases[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes]():
+117 117 |     def pep_696_bad_method[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes](
+118 118 |         self,
+119 119 |         x:A = "foo"[::-1],
 
 E23.py:116:40: E231 [*] Missing whitespace after ':'
     |
@@ -626,7 +627,8 @@ E23.py:116:40: E231 [*] Missing whitespace after ':'
 115 | 
 116 | class PEP696Bad[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes]:
     |                                        ^ E231
-117 |     pass
+117 |     def pep_696_bad_method[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes](
+118 |         self,
     |
     = help: Add missing whitespace
 
@@ -636,9 +638,9 @@ E23.py:116:40: E231 [*] Missing whitespace after ':'
 115 115 | 
 116     |-class PEP696Bad[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes]:
     116 |+class PEP696Bad[A:object="foo"[::-1], B: object =[[["foo", "bar"]]], C:object= bytes]:
-117 117 |     pass
-118 118 | 
-119 119 | class PEP696BadWithEmptyBases[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes]():
+117 117 |     def pep_696_bad_method[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes](
+118 118 |         self,
+119 119 |         x:A = "foo"[::-1],
 
 E23.py:116:70: E231 [*] Missing whitespace after ':'
     |
@@ -646,7 +648,8 @@ E23.py:116:70: E231 [*] Missing whitespace after ':'
 115 | 
 116 | class PEP696Bad[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes]:
     |                                                                      ^ E231
-117 |     pass
+117 |     def pep_696_bad_method[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes](
+118 |         self,
     |
     = help: Add missing whitespace
 
@@ -656,126 +659,249 @@ E23.py:116:70: E231 [*] Missing whitespace after ':'
 115 115 | 
 116     |-class PEP696Bad[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes]:
     116 |+class PEP696Bad[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C: object= bytes]:
-117 117 |     pass
-118 118 | 
-119 119 | class PEP696BadWithEmptyBases[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes]():
+117 117 |     def pep_696_bad_method[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes](
+118 118 |         self,
+119 119 |         x:A = "foo"[::-1],
 
-E23.py:119:32: E231 [*] Missing whitespace after ':'
+E23.py:117:29: E231 [*] Missing whitespace after ':'
     |
-117 |     pass
-118 | 
-119 | class PEP696BadWithEmptyBases[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes]():
+116 | class PEP696Bad[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes]:
+117 |     def pep_696_bad_method[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes](
+    |                             ^ E231
+118 |         self,
+119 |         x:A = "foo"[::-1],
+    |
+    = help: Add missing whitespace
+
+ℹ Safe fix
+114 114 |     pass
+115 115 | 
+116 116 | class PEP696Bad[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes]:
+117     |-    def pep_696_bad_method[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes](
+    117 |+    def pep_696_bad_method[A: object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes](
+118 118 |         self,
+119 119 |         x:A = "foo"[::-1],
+120 120 |         y:B = [[["foo", "bar"]]],
+
+E23.py:117:51: E231 [*] Missing whitespace after ':'
+    |
+116 | class PEP696Bad[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes]:
+117 |     def pep_696_bad_method[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes](
+    |                                                   ^ E231
+118 |         self,
+119 |         x:A = "foo"[::-1],
+    |
+    = help: Add missing whitespace
+
+ℹ Safe fix
+114 114 |     pass
+115 115 | 
+116 116 | class PEP696Bad[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes]:
+117     |-    def pep_696_bad_method[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes](
+    117 |+    def pep_696_bad_method[A:object="foo"[::-1], B: object =[[["foo", "bar"]]], C:object= bytes](
+118 118 |         self,
+119 119 |         x:A = "foo"[::-1],
+120 120 |         y:B = [[["foo", "bar"]]],
+
+E23.py:117:81: E231 [*] Missing whitespace after ':'
+    |
+116 | class PEP696Bad[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes]:
+117 |     def pep_696_bad_method[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes](
+    |                                                                                 ^ E231
+118 |         self,
+119 |         x:A = "foo"[::-1],
+    |
+    = help: Add missing whitespace
+
+ℹ Safe fix
+114 114 |     pass
+115 115 | 
+116 116 | class PEP696Bad[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes]:
+117     |-    def pep_696_bad_method[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes](
+    117 |+    def pep_696_bad_method[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C: object= bytes](
+118 118 |         self,
+119 119 |         x:A = "foo"[::-1],
+120 120 |         y:B = [[["foo", "bar"]]],
+
+E23.py:119:10: E231 [*] Missing whitespace after ':'
+    |
+117 |     def pep_696_bad_method[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes](
+118 |         self,
+119 |         x:A = "foo"[::-1],
+    |          ^ E231
+120 |         y:B = [[["foo", "bar"]]],
+121 |         z:object = "fooo",
+    |
+    = help: Add missing whitespace
+
+ℹ Safe fix
+116 116 | class PEP696Bad[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes]:
+117 117 |     def pep_696_bad_method[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes](
+118 118 |         self,
+119     |-        x:A = "foo"[::-1],
+    119 |+        x: A = "foo"[::-1],
+120 120 |         y:B = [[["foo", "bar"]]],
+121 121 |         z:object = "fooo",
+122 122 |     ):
+
+E23.py:120:10: E231 [*] Missing whitespace after ':'
+    |
+118 |         self,
+119 |         x:A = "foo"[::-1],
+120 |         y:B = [[["foo", "bar"]]],
+    |          ^ E231
+121 |         z:object = "fooo",
+122 |     ):
+    |
+    = help: Add missing whitespace
+
+ℹ Safe fix
+117 117 |     def pep_696_bad_method[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes](
+118 118 |         self,
+119 119 |         x:A = "foo"[::-1],
+120     |-        y:B = [[["foo", "bar"]]],
+    120 |+        y: B = [[["foo", "bar"]]],
+121 121 |         z:object = "fooo",
+122 122 |     ):
+123 123 |         pass
+
+E23.py:121:10: E231 [*] Missing whitespace after ':'
+    |
+119 |         x:A = "foo"[::-1],
+120 |         y:B = [[["foo", "bar"]]],
+121 |         z:object = "fooo",
+    |          ^ E231
+122 |     ):
+123 |         pass
+    |
+    = help: Add missing whitespace
+
+ℹ Safe fix
+118 118 |         self,
+119 119 |         x:A = "foo"[::-1],
+120 120 |         y:B = [[["foo", "bar"]]],
+121     |-        z:object = "fooo",
+    121 |+        z: object = "fooo",
+122 122 |     ):
+123 123 |         pass
+124 124 | 
+
+E23.py:125:32: E231 [*] Missing whitespace after ':'
+    |
+123 |         pass
+124 | 
+125 | class PEP696BadWithEmptyBases[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes]():
     |                                ^ E231
-120 |     pass
+126 |     class IndentedPEP696BadWithNonEmptyBases[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes](object, something_dynamic[x::-1]):
+127 |         pass
     |
     = help: Add missing whitespace
 
 ℹ Safe fix
-116 116 | class PEP696Bad[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes]:
-117 117 |     pass
-118 118 | 
-119     |-class PEP696BadWithEmptyBases[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes]():
-    119 |+class PEP696BadWithEmptyBases[A: object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes]():
-120 120 |     pass
-121 121 | 
-122 122 | class PEP696BadWithNonEmptyBases[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes](object, something_dynamic[x::-1]):
+122 122 |     ):
+123 123 |         pass
+124 124 | 
+125     |-class PEP696BadWithEmptyBases[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes]():
+    125 |+class PEP696BadWithEmptyBases[A: object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes]():
+126 126 |     class IndentedPEP696BadWithNonEmptyBases[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes](object, something_dynamic[x::-1]):
+127 127 |         pass
+128 128 | 
 
-E23.py:119:54: E231 [*] Missing whitespace after ':'
+E23.py:125:54: E231 [*] Missing whitespace after ':'
     |
-117 |     pass
-118 | 
-119 | class PEP696BadWithEmptyBases[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes]():
+123 |         pass
+124 | 
+125 | class PEP696BadWithEmptyBases[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes]():
     |                                                      ^ E231
-120 |     pass
+126 |     class IndentedPEP696BadWithNonEmptyBases[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes](object, something_dynamic[x::-1]):
+127 |         pass
     |
     = help: Add missing whitespace
 
 ℹ Safe fix
-116 116 | class PEP696Bad[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes]:
-117 117 |     pass
-118 118 | 
-119     |-class PEP696BadWithEmptyBases[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes]():
-    119 |+class PEP696BadWithEmptyBases[A:object="foo"[::-1], B: object =[[["foo", "bar"]]], C:object= bytes]():
-120 120 |     pass
-121 121 | 
-122 122 | class PEP696BadWithNonEmptyBases[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes](object, something_dynamic[x::-1]):
+122 122 |     ):
+123 123 |         pass
+124 124 | 
+125     |-class PEP696BadWithEmptyBases[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes]():
+    125 |+class PEP696BadWithEmptyBases[A:object="foo"[::-1], B: object =[[["foo", "bar"]]], C:object= bytes]():
+126 126 |     class IndentedPEP696BadWithNonEmptyBases[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes](object, something_dynamic[x::-1]):
+127 127 |         pass
+128 128 | 
 
-E23.py:119:84: E231 [*] Missing whitespace after ':'
+E23.py:125:84: E231 [*] Missing whitespace after ':'
     |
-117 |     pass
-118 | 
-119 | class PEP696BadWithEmptyBases[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes]():
+123 |         pass
+124 | 
+125 | class PEP696BadWithEmptyBases[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes]():
     |                                                                                    ^ E231
-120 |     pass
+126 |     class IndentedPEP696BadWithNonEmptyBases[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes](object, something_dynamic[x::-1]):
+127 |         pass
     |
     = help: Add missing whitespace
 
 ℹ Safe fix
-116 116 | class PEP696Bad[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes]:
-117 117 |     pass
-118 118 | 
-119     |-class PEP696BadWithEmptyBases[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes]():
-    119 |+class PEP696BadWithEmptyBases[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C: object= bytes]():
-120 120 |     pass
-121 121 | 
-122 122 | class PEP696BadWithNonEmptyBases[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes](object, something_dynamic[x::-1]):
-
-E23.py:122:35: E231 [*] Missing whitespace after ':'
-    |
-120 |     pass
-121 | 
-122 | class PEP696BadWithNonEmptyBases[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes](object, something_dynamic[x::-1]):
-    |                                   ^ E231
-123 |     pass
-    |
-    = help: Add missing whitespace
-
-ℹ Safe fix
-119 119 | class PEP696BadWithEmptyBases[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes]():
-120 120 |     pass
-121 121 | 
-122     |-class PEP696BadWithNonEmptyBases[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes](object, something_dynamic[x::-1]):
-    122 |+class PEP696BadWithNonEmptyBases[A: object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes](object, something_dynamic[x::-1]):
-123 123 |     pass
+122 122 |     ):
+123 123 |         pass
 124 124 | 
-125 125 | # Should be no E231 errors on any of these:
+125     |-class PEP696BadWithEmptyBases[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes]():
+    125 |+class PEP696BadWithEmptyBases[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C: object= bytes]():
+126 126 |     class IndentedPEP696BadWithNonEmptyBases[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes](object, something_dynamic[x::-1]):
+127 127 |         pass
+128 128 | 
 
-E23.py:122:57: E231 [*] Missing whitespace after ':'
+E23.py:126:47: E231 [*] Missing whitespace after ':'
     |
-120 |     pass
-121 | 
-122 | class PEP696BadWithNonEmptyBases[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes](object, something_dynamic[x::-1]):
-    |                                                         ^ E231
-123 |     pass
-    |
-    = help: Add missing whitespace
-
-ℹ Safe fix
-119 119 | class PEP696BadWithEmptyBases[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes]():
-120 120 |     pass
-121 121 | 
-122     |-class PEP696BadWithNonEmptyBases[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes](object, something_dynamic[x::-1]):
-    122 |+class PEP696BadWithNonEmptyBases[A:object="foo"[::-1], B: object =[[["foo", "bar"]]], C:object= bytes](object, something_dynamic[x::-1]):
-123 123 |     pass
-124 124 | 
-125 125 | # Should be no E231 errors on any of these:
-
-E23.py:122:87: E231 [*] Missing whitespace after ':'
-    |
-120 |     pass
-121 | 
-122 | class PEP696BadWithNonEmptyBases[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes](object, something_dynamic[x::-1]):
-    |                                                                                       ^ E231
-123 |     pass
+125 | class PEP696BadWithEmptyBases[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes]():
+126 |     class IndentedPEP696BadWithNonEmptyBases[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes](object, something_dynamic[x::-1]):
+    |                                               ^ E231
+127 |         pass
     |
     = help: Add missing whitespace
 
 ℹ Safe fix
-119 119 | class PEP696BadWithEmptyBases[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes]():
-120 120 |     pass
-121 121 | 
-122     |-class PEP696BadWithNonEmptyBases[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes](object, something_dynamic[x::-1]):
-    122 |+class PEP696BadWithNonEmptyBases[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C: object= bytes](object, something_dynamic[x::-1]):
-123 123 |     pass
+123 123 |         pass
 124 124 | 
-125 125 | # Should be no E231 errors on any of these:
+125 125 | class PEP696BadWithEmptyBases[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes]():
+126     |-    class IndentedPEP696BadWithNonEmptyBases[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes](object, something_dynamic[x::-1]):
+    126 |+    class IndentedPEP696BadWithNonEmptyBases[A: object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes](object, something_dynamic[x::-1]):
+127 127 |         pass
+128 128 | 
+129 129 | # Should be no E231 errors on any of these:
+
+E23.py:126:69: E231 [*] Missing whitespace after ':'
+    |
+125 | class PEP696BadWithEmptyBases[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes]():
+126 |     class IndentedPEP696BadWithNonEmptyBases[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes](object, something_dynamic[x::-1]):
+    |                                                                     ^ E231
+127 |         pass
+    |
+    = help: Add missing whitespace
+
+ℹ Safe fix
+123 123 |         pass
+124 124 | 
+125 125 | class PEP696BadWithEmptyBases[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes]():
+126     |-    class IndentedPEP696BadWithNonEmptyBases[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes](object, something_dynamic[x::-1]):
+    126 |+    class IndentedPEP696BadWithNonEmptyBases[A:object="foo"[::-1], B: object =[[["foo", "bar"]]], C:object= bytes](object, something_dynamic[x::-1]):
+127 127 |         pass
+128 128 | 
+129 129 | # Should be no E231 errors on any of these:
+
+E23.py:126:99: E231 [*] Missing whitespace after ':'
+    |
+125 | class PEP696BadWithEmptyBases[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes]():
+126 |     class IndentedPEP696BadWithNonEmptyBases[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes](object, something_dynamic[x::-1]):
+    |                                                                                                   ^ E231
+127 |         pass
+    |
+    = help: Add missing whitespace
+
+ℹ Safe fix
+123 123 |         pass
+124 124 | 
+125 125 | class PEP696BadWithEmptyBases[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes]():
+126     |-    class IndentedPEP696BadWithNonEmptyBases[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C:object= bytes](object, something_dynamic[x::-1]):
+    126 |+    class IndentedPEP696BadWithNonEmptyBases[A:object="foo"[::-1], B:object =[[["foo", "bar"]]], C: object= bytes](object, something_dynamic[x::-1]):
+127 127 |         pass
+128 128 | 
+129 129 | # Should be no E231 errors on any of these:

--- a/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E252_E25.py.snap
+++ b/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E252_E25.py.snap
@@ -85,4 +85,392 @@ E25.py:46:36: E252 [*] Missing whitespace around parameter equals
 48 48 | #: Okay
 49 49 | def add(a: int = _default(name='f')):
 
+E25.py:64:18: E252 [*] Missing whitespace around parameter equals
+   |
+63 | # There should be at least one E251 diagnostic for each type parameter here:
+64 | def pep_696_bad[A=int, B =str, C= bool, D:object=int, E: object=str, F: object =bool, G: object= bytes]():
+   |                  ^ E252
+65 |     pass
+   |
+   = help: Add missing whitespace
 
+ℹ Safe fix
+61 61 | print(f"{foo(a = 1)}")
+62 62 | 
+63 63 | # There should be at least one E251 diagnostic for each type parameter here:
+64    |-def pep_696_bad[A=int, B =str, C= bool, D:object=int, E: object=str, F: object =bool, G: object= bytes]():
+   64 |+def pep_696_bad[A =int, B =str, C= bool, D:object=int, E: object=str, F: object =bool, G: object= bytes]():
+65 65 |     pass
+66 66 | 
+67 67 | class PEP696Bad[A=int, B =str, C= bool, D:object=int, E: object=str, F: object =bool, G: object= bytes]:
+
+E25.py:64:18: E252 [*] Missing whitespace around parameter equals
+   |
+63 | # There should be at least one E251 diagnostic for each type parameter here:
+64 | def pep_696_bad[A=int, B =str, C= bool, D:object=int, E: object=str, F: object =bool, G: object= bytes]():
+   |                  ^ E252
+65 |     pass
+   |
+   = help: Add missing whitespace
+
+ℹ Safe fix
+61 61 | print(f"{foo(a = 1)}")
+62 62 | 
+63 63 | # There should be at least one E251 diagnostic for each type parameter here:
+64    |-def pep_696_bad[A=int, B =str, C= bool, D:object=int, E: object=str, F: object =bool, G: object= bytes]():
+   64 |+def pep_696_bad[A= int, B =str, C= bool, D:object=int, E: object=str, F: object =bool, G: object= bytes]():
+65 65 |     pass
+66 66 | 
+67 67 | class PEP696Bad[A=int, B =str, C= bool, D:object=int, E: object=str, F: object =bool, G: object= bytes]:
+
+E25.py:64:26: E252 [*] Missing whitespace around parameter equals
+   |
+63 | # There should be at least one E251 diagnostic for each type parameter here:
+64 | def pep_696_bad[A=int, B =str, C= bool, D:object=int, E: object=str, F: object =bool, G: object= bytes]():
+   |                          ^ E252
+65 |     pass
+   |
+   = help: Add missing whitespace
+
+ℹ Safe fix
+61 61 | print(f"{foo(a = 1)}")
+62 62 | 
+63 63 | # There should be at least one E251 diagnostic for each type parameter here:
+64    |-def pep_696_bad[A=int, B =str, C= bool, D:object=int, E: object=str, F: object =bool, G: object= bytes]():
+   64 |+def pep_696_bad[A=int, B = str, C= bool, D:object=int, E: object=str, F: object =bool, G: object= bytes]():
+65 65 |     pass
+66 66 | 
+67 67 | class PEP696Bad[A=int, B =str, C= bool, D:object=int, E: object=str, F: object =bool, G: object= bytes]:
+
+E25.py:64:33: E252 [*] Missing whitespace around parameter equals
+   |
+63 | # There should be at least one E251 diagnostic for each type parameter here:
+64 | def pep_696_bad[A=int, B =str, C= bool, D:object=int, E: object=str, F: object =bool, G: object= bytes]():
+   |                                 ^ E252
+65 |     pass
+   |
+   = help: Add missing whitespace
+
+ℹ Safe fix
+61 61 | print(f"{foo(a = 1)}")
+62 62 | 
+63 63 | # There should be at least one E251 diagnostic for each type parameter here:
+64    |-def pep_696_bad[A=int, B =str, C= bool, D:object=int, E: object=str, F: object =bool, G: object= bytes]():
+   64 |+def pep_696_bad[A=int, B =str, C = bool, D:object=int, E: object=str, F: object =bool, G: object= bytes]():
+65 65 |     pass
+66 66 | 
+67 67 | class PEP696Bad[A=int, B =str, C= bool, D:object=int, E: object=str, F: object =bool, G: object= bytes]:
+
+E25.py:64:49: E252 [*] Missing whitespace around parameter equals
+   |
+63 | # There should be at least one E251 diagnostic for each type parameter here:
+64 | def pep_696_bad[A=int, B =str, C= bool, D:object=int, E: object=str, F: object =bool, G: object= bytes]():
+   |                                                 ^ E252
+65 |     pass
+   |
+   = help: Add missing whitespace
+
+ℹ Safe fix
+61 61 | print(f"{foo(a = 1)}")
+62 62 | 
+63 63 | # There should be at least one E251 diagnostic for each type parameter here:
+64    |-def pep_696_bad[A=int, B =str, C= bool, D:object=int, E: object=str, F: object =bool, G: object= bytes]():
+   64 |+def pep_696_bad[A=int, B =str, C= bool, D:object =int, E: object=str, F: object =bool, G: object= bytes]():
+65 65 |     pass
+66 66 | 
+67 67 | class PEP696Bad[A=int, B =str, C= bool, D:object=int, E: object=str, F: object =bool, G: object= bytes]:
+
+E25.py:64:49: E252 [*] Missing whitespace around parameter equals
+   |
+63 | # There should be at least one E251 diagnostic for each type parameter here:
+64 | def pep_696_bad[A=int, B =str, C= bool, D:object=int, E: object=str, F: object =bool, G: object= bytes]():
+   |                                                 ^ E252
+65 |     pass
+   |
+   = help: Add missing whitespace
+
+ℹ Safe fix
+61 61 | print(f"{foo(a = 1)}")
+62 62 | 
+63 63 | # There should be at least one E251 diagnostic for each type parameter here:
+64    |-def pep_696_bad[A=int, B =str, C= bool, D:object=int, E: object=str, F: object =bool, G: object= bytes]():
+   64 |+def pep_696_bad[A=int, B =str, C= bool, D:object= int, E: object=str, F: object =bool, G: object= bytes]():
+65 65 |     pass
+66 66 | 
+67 67 | class PEP696Bad[A=int, B =str, C= bool, D:object=int, E: object=str, F: object =bool, G: object= bytes]:
+
+E25.py:64:64: E252 [*] Missing whitespace around parameter equals
+   |
+63 | # There should be at least one E251 diagnostic for each type parameter here:
+64 | def pep_696_bad[A=int, B =str, C= bool, D:object=int, E: object=str, F: object =bool, G: object= bytes]():
+   |                                                                ^ E252
+65 |     pass
+   |
+   = help: Add missing whitespace
+
+ℹ Safe fix
+61 61 | print(f"{foo(a = 1)}")
+62 62 | 
+63 63 | # There should be at least one E251 diagnostic for each type parameter here:
+64    |-def pep_696_bad[A=int, B =str, C= bool, D:object=int, E: object=str, F: object =bool, G: object= bytes]():
+   64 |+def pep_696_bad[A=int, B =str, C= bool, D:object=int, E: object =str, F: object =bool, G: object= bytes]():
+65 65 |     pass
+66 66 | 
+67 67 | class PEP696Bad[A=int, B =str, C= bool, D:object=int, E: object=str, F: object =bool, G: object= bytes]:
+
+E25.py:64:64: E252 [*] Missing whitespace around parameter equals
+   |
+63 | # There should be at least one E251 diagnostic for each type parameter here:
+64 | def pep_696_bad[A=int, B =str, C= bool, D:object=int, E: object=str, F: object =bool, G: object= bytes]():
+   |                                                                ^ E252
+65 |     pass
+   |
+   = help: Add missing whitespace
+
+ℹ Safe fix
+61 61 | print(f"{foo(a = 1)}")
+62 62 | 
+63 63 | # There should be at least one E251 diagnostic for each type parameter here:
+64    |-def pep_696_bad[A=int, B =str, C= bool, D:object=int, E: object=str, F: object =bool, G: object= bytes]():
+   64 |+def pep_696_bad[A=int, B =str, C= bool, D:object=int, E: object= str, F: object =bool, G: object= bytes]():
+65 65 |     pass
+66 66 | 
+67 67 | class PEP696Bad[A=int, B =str, C= bool, D:object=int, E: object=str, F: object =bool, G: object= bytes]:
+
+E25.py:64:80: E252 [*] Missing whitespace around parameter equals
+   |
+63 | # There should be at least one E251 diagnostic for each type parameter here:
+64 | def pep_696_bad[A=int, B =str, C= bool, D:object=int, E: object=str, F: object =bool, G: object= bytes]():
+   |                                                                                ^ E252
+65 |     pass
+   |
+   = help: Add missing whitespace
+
+ℹ Safe fix
+61 61 | print(f"{foo(a = 1)}")
+62 62 | 
+63 63 | # There should be at least one E251 diagnostic for each type parameter here:
+64    |-def pep_696_bad[A=int, B =str, C= bool, D:object=int, E: object=str, F: object =bool, G: object= bytes]():
+   64 |+def pep_696_bad[A=int, B =str, C= bool, D:object=int, E: object=str, F: object = bool, G: object= bytes]():
+65 65 |     pass
+66 66 | 
+67 67 | class PEP696Bad[A=int, B =str, C= bool, D:object=int, E: object=str, F: object =bool, G: object= bytes]:
+
+E25.py:64:96: E252 [*] Missing whitespace around parameter equals
+   |
+63 | # There should be at least one E251 diagnostic for each type parameter here:
+64 | def pep_696_bad[A=int, B =str, C= bool, D:object=int, E: object=str, F: object =bool, G: object= bytes]():
+   |                                                                                                ^ E252
+65 |     pass
+   |
+   = help: Add missing whitespace
+
+ℹ Safe fix
+61 61 | print(f"{foo(a = 1)}")
+62 62 | 
+63 63 | # There should be at least one E251 diagnostic for each type parameter here:
+64    |-def pep_696_bad[A=int, B =str, C= bool, D:object=int, E: object=str, F: object =bool, G: object= bytes]():
+   64 |+def pep_696_bad[A=int, B =str, C= bool, D:object=int, E: object=str, F: object =bool, G: object = bytes]():
+65 65 |     pass
+66 66 | 
+67 67 | class PEP696Bad[A=int, B =str, C= bool, D:object=int, E: object=str, F: object =bool, G: object= bytes]:
+
+E25.py:67:18: E252 [*] Missing whitespace around parameter equals
+   |
+65 |     pass
+66 | 
+67 | class PEP696Bad[A=int, B =str, C= bool, D:object=int, E: object=str, F: object =bool, G: object= bytes]:
+   |                  ^ E252
+68 |     pass
+   |
+   = help: Add missing whitespace
+
+ℹ Safe fix
+64 64 | def pep_696_bad[A=int, B =str, C= bool, D:object=int, E: object=str, F: object =bool, G: object= bytes]():
+65 65 |     pass
+66 66 | 
+67    |-class PEP696Bad[A=int, B =str, C= bool, D:object=int, E: object=str, F: object =bool, G: object= bytes]:
+   67 |+class PEP696Bad[A =int, B =str, C= bool, D:object=int, E: object=str, F: object =bool, G: object= bytes]:
+68 68 |     pass
+69 69 | 
+70 70 | # The last of these should cause us to emit E231,
+
+E25.py:67:18: E252 [*] Missing whitespace around parameter equals
+   |
+65 |     pass
+66 | 
+67 | class PEP696Bad[A=int, B =str, C= bool, D:object=int, E: object=str, F: object =bool, G: object= bytes]:
+   |                  ^ E252
+68 |     pass
+   |
+   = help: Add missing whitespace
+
+ℹ Safe fix
+64 64 | def pep_696_bad[A=int, B =str, C= bool, D:object=int, E: object=str, F: object =bool, G: object= bytes]():
+65 65 |     pass
+66 66 | 
+67    |-class PEP696Bad[A=int, B =str, C= bool, D:object=int, E: object=str, F: object =bool, G: object= bytes]:
+   67 |+class PEP696Bad[A= int, B =str, C= bool, D:object=int, E: object=str, F: object =bool, G: object= bytes]:
+68 68 |     pass
+69 69 | 
+70 70 | # The last of these should cause us to emit E231,
+
+E25.py:67:26: E252 [*] Missing whitespace around parameter equals
+   |
+65 |     pass
+66 | 
+67 | class PEP696Bad[A=int, B =str, C= bool, D:object=int, E: object=str, F: object =bool, G: object= bytes]:
+   |                          ^ E252
+68 |     pass
+   |
+   = help: Add missing whitespace
+
+ℹ Safe fix
+64 64 | def pep_696_bad[A=int, B =str, C= bool, D:object=int, E: object=str, F: object =bool, G: object= bytes]():
+65 65 |     pass
+66 66 | 
+67    |-class PEP696Bad[A=int, B =str, C= bool, D:object=int, E: object=str, F: object =bool, G: object= bytes]:
+   67 |+class PEP696Bad[A=int, B = str, C= bool, D:object=int, E: object=str, F: object =bool, G: object= bytes]:
+68 68 |     pass
+69 69 | 
+70 70 | # The last of these should cause us to emit E231,
+
+E25.py:67:33: E252 [*] Missing whitespace around parameter equals
+   |
+65 |     pass
+66 | 
+67 | class PEP696Bad[A=int, B =str, C= bool, D:object=int, E: object=str, F: object =bool, G: object= bytes]:
+   |                                 ^ E252
+68 |     pass
+   |
+   = help: Add missing whitespace
+
+ℹ Safe fix
+64 64 | def pep_696_bad[A=int, B =str, C= bool, D:object=int, E: object=str, F: object =bool, G: object= bytes]():
+65 65 |     pass
+66 66 | 
+67    |-class PEP696Bad[A=int, B =str, C= bool, D:object=int, E: object=str, F: object =bool, G: object= bytes]:
+   67 |+class PEP696Bad[A=int, B =str, C = bool, D:object=int, E: object=str, F: object =bool, G: object= bytes]:
+68 68 |     pass
+69 69 | 
+70 70 | # The last of these should cause us to emit E231,
+
+E25.py:67:49: E252 [*] Missing whitespace around parameter equals
+   |
+65 |     pass
+66 | 
+67 | class PEP696Bad[A=int, B =str, C= bool, D:object=int, E: object=str, F: object =bool, G: object= bytes]:
+   |                                                 ^ E252
+68 |     pass
+   |
+   = help: Add missing whitespace
+
+ℹ Safe fix
+64 64 | def pep_696_bad[A=int, B =str, C= bool, D:object=int, E: object=str, F: object =bool, G: object= bytes]():
+65 65 |     pass
+66 66 | 
+67    |-class PEP696Bad[A=int, B =str, C= bool, D:object=int, E: object=str, F: object =bool, G: object= bytes]:
+   67 |+class PEP696Bad[A=int, B =str, C= bool, D:object =int, E: object=str, F: object =bool, G: object= bytes]:
+68 68 |     pass
+69 69 | 
+70 70 | # The last of these should cause us to emit E231,
+
+E25.py:67:49: E252 [*] Missing whitespace around parameter equals
+   |
+65 |     pass
+66 | 
+67 | class PEP696Bad[A=int, B =str, C= bool, D:object=int, E: object=str, F: object =bool, G: object= bytes]:
+   |                                                 ^ E252
+68 |     pass
+   |
+   = help: Add missing whitespace
+
+ℹ Safe fix
+64 64 | def pep_696_bad[A=int, B =str, C= bool, D:object=int, E: object=str, F: object =bool, G: object= bytes]():
+65 65 |     pass
+66 66 | 
+67    |-class PEP696Bad[A=int, B =str, C= bool, D:object=int, E: object=str, F: object =bool, G: object= bytes]:
+   67 |+class PEP696Bad[A=int, B =str, C= bool, D:object= int, E: object=str, F: object =bool, G: object= bytes]:
+68 68 |     pass
+69 69 | 
+70 70 | # The last of these should cause us to emit E231,
+
+E25.py:67:64: E252 [*] Missing whitespace around parameter equals
+   |
+65 |     pass
+66 | 
+67 | class PEP696Bad[A=int, B =str, C= bool, D:object=int, E: object=str, F: object =bool, G: object= bytes]:
+   |                                                                ^ E252
+68 |     pass
+   |
+   = help: Add missing whitespace
+
+ℹ Safe fix
+64 64 | def pep_696_bad[A=int, B =str, C= bool, D:object=int, E: object=str, F: object =bool, G: object= bytes]():
+65 65 |     pass
+66 66 | 
+67    |-class PEP696Bad[A=int, B =str, C= bool, D:object=int, E: object=str, F: object =bool, G: object= bytes]:
+   67 |+class PEP696Bad[A=int, B =str, C= bool, D:object=int, E: object =str, F: object =bool, G: object= bytes]:
+68 68 |     pass
+69 69 | 
+70 70 | # The last of these should cause us to emit E231,
+
+E25.py:67:64: E252 [*] Missing whitespace around parameter equals
+   |
+65 |     pass
+66 | 
+67 | class PEP696Bad[A=int, B =str, C= bool, D:object=int, E: object=str, F: object =bool, G: object= bytes]:
+   |                                                                ^ E252
+68 |     pass
+   |
+   = help: Add missing whitespace
+
+ℹ Safe fix
+64 64 | def pep_696_bad[A=int, B =str, C= bool, D:object=int, E: object=str, F: object =bool, G: object= bytes]():
+65 65 |     pass
+66 66 | 
+67    |-class PEP696Bad[A=int, B =str, C= bool, D:object=int, E: object=str, F: object =bool, G: object= bytes]:
+   67 |+class PEP696Bad[A=int, B =str, C= bool, D:object=int, E: object= str, F: object =bool, G: object= bytes]:
+68 68 |     pass
+69 69 | 
+70 70 | # The last of these should cause us to emit E231,
+
+E25.py:67:80: E252 [*] Missing whitespace around parameter equals
+   |
+65 |     pass
+66 | 
+67 | class PEP696Bad[A=int, B =str, C= bool, D:object=int, E: object=str, F: object =bool, G: object= bytes]:
+   |                                                                                ^ E252
+68 |     pass
+   |
+   = help: Add missing whitespace
+
+ℹ Safe fix
+64 64 | def pep_696_bad[A=int, B =str, C= bool, D:object=int, E: object=str, F: object =bool, G: object= bytes]():
+65 65 |     pass
+66 66 | 
+67    |-class PEP696Bad[A=int, B =str, C= bool, D:object=int, E: object=str, F: object =bool, G: object= bytes]:
+   67 |+class PEP696Bad[A=int, B =str, C= bool, D:object=int, E: object=str, F: object = bool, G: object= bytes]:
+68 68 |     pass
+69 69 | 
+70 70 | # The last of these should cause us to emit E231,
+
+E25.py:67:96: E252 [*] Missing whitespace around parameter equals
+   |
+65 |     pass
+66 | 
+67 | class PEP696Bad[A=int, B =str, C= bool, D:object=int, E: object=str, F: object =bool, G: object= bytes]:
+   |                                                                                                ^ E252
+68 |     pass
+   |
+   = help: Add missing whitespace
+
+ℹ Safe fix
+64 64 | def pep_696_bad[A=int, B =str, C= bool, D:object=int, E: object=str, F: object =bool, G: object= bytes]():
+65 65 |     pass
+66 66 | 
+67    |-class PEP696Bad[A=int, B =str, C= bool, D:object=int, E: object=str, F: object =bool, G: object= bytes]:
+   67 |+class PEP696Bad[A=int, B =str, C= bool, D:object=int, E: object=str, F: object =bool, G: object = bytes]:
+68 68 |     pass
+69 69 | 
+70 70 | # The last of these should cause us to emit E231,


### PR DESCRIPTION
## Summary

Fixes #13699.

We had false positives and false negatives regarding whitespace in type-parameter lists, that led to conflicts between the linter and the formatter. Specifically, we emitted a false positive here:

```py
def foo[T = int](): ...  # E251: Unexpected spaces around keyword / parameter equals
```

and a false negative here:

```py
def foo[T:int](): ...  # should be an E231 error here (no space in between `T:` and `int`), but there isn't
```

This PR adds a `TypeParamsState` enum, to keep track of whether we're currently visiting the `LogicalLineToken`s in a type parameters list or not. The common solution is then used to fix the bugs in both rules.

Type parameter lists are new syntax that is only available in Python 3.13+, which is why this is only coming up now.

## Test Plan

Fixtures have been added with examples of both class and function definitions that have type parameters
