### PR TITLE
[red-knot] Do not panic if named expressions show up in assignment position

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/literal/collections/list.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/literal/collections/list.md
@@ -6,35 +6,3 @@
 x = []
 reveal_type(x)  # revealed: list
 ```
-
-## Indexing into lists
-
-A list can be indexed into with:
-
-- numbers
-- slices
-
-```py
-x = [1, 2, 3]
-reveal_type(x)  # revealed: list
-# TODO reveal int
-reveal_type(x[0])  # revealed: @Todo
-# TODO reveal list
-reveal_type(x[0:1])  # revealed: @Todo
-# TODO error
-reveal_type(x["a"])  # revealed: @Todo
-```
-
-## Assignments within list assignment
-
-In assignment, we might also have a named assignment.
-This should also get type checked.
-
-```py
-x = [1, 2, 3]
-x[0 if (y := 2) else 1] = 5
-# TODO error? (indeterminite index type)
-x["a" if (y := 2) else 1] = 6
-# TODO error (can't index via string)
-x["a" if (y := 2) else "b"] = 6
-```

--- a/crates/red_knot_python_semantic/resources/mdtest/literal/collections/list.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/literal/collections/list.md
@@ -6,3 +6,35 @@
 x = []
 reveal_type(x)  # revealed: list
 ```
+
+## Indexing into lists
+
+A list can be indexed into with:
+
+- numbers
+- slices
+
+```py
+x = [1, 2, 3]
+reveal_type(x)  # revealed: list
+# TODO reveal int
+reveal_type(x[0])  # revealed: @Todo
+# TODO reveal list
+reveal_type(x[0:1])  # revealed: @Todo
+# TODO error
+reveal_type(x["a"])  # revealed: @Todo
+```
+
+## Assignments within list assignment
+
+In assignment, we might also have a named assignment.
+This should also get type checked.
+
+```py
+x = [1, 2, 3]
+x[0 if (y := 2) else 1] = 5
+# TODO error? (indeterminite index type)
+x["a" if (y := 2) else 1] = 6
+# TODO error (can't index via string)
+x["a" if (y := 2) else "b"] = 6
+```

--- a/crates/red_knot_python_semantic/resources/mdtest/subscript/lists.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/subscript/lists.md
@@ -1,0 +1,33 @@
+# List subscripts
+
+## Indexing into lists
+
+A list can be indexed into with:
+
+- numbers
+- slices
+
+```py
+x = [1, 2, 3]
+reveal_type(x)  # revealed: list
+# TODO reveal int
+reveal_type(x[0])  # revealed: @Todo
+# TODO reveal list
+reveal_type(x[0:1])  # revealed: @Todo
+# TODO error
+reveal_type(x["a"])  # revealed: @Todo
+```
+
+## Assignments within list assignment
+
+In assignment, we might also have a named assignment.
+This should also get type checked.
+
+```py
+x = [1, 2, 3]
+x[0 if (y := 2) else 1] = 5
+# TODO error? (indeterminite index type)
+x["a" if (y := 2) else 1] = 6
+# TODO error (can't index via string)
+x["a" if (y := 2) else "b"] = 6
+```


### PR DESCRIPTION
Unfortunately the test I added here still fails (I believe due to scoping issues, still trying to wrap my head around how the scoping is supposed to work), but I believe my changes to the builder are correct: it is not incorrect for there to be `current_assignment`s to juggle, given the existence of named expressions.