### PR TITLE
[red-knot] clarify mdtest README

### DIFF
--- a/crates/red_knot_test/README.md
+++ b/crates/red_knot_test/README.md
@@ -25,6 +25,10 @@ match the resulting diagnostics with the assertions in the test. Assertions are 
 Python comments. If all diagnostics and all assertions are matched, the test passes; otherwise, it
 fails.
 
+(If you are reading this document in raw Markdown source rather than rendered Markdown, note that
+the quadruple-backtick-fenced "markdown" language code block above is NOT itself part of the mdtest
+syntax, it's just how this README embeds an example mdtest Markdown document.)
+
 ## Assertions
 
 Two kinds of assertions are supported: `# revealed:` (shown above) and `# error:`.
@@ -58,9 +62,8 @@ something about the behavior of importing it.)
 
 #### error
 
-A comment beginning with `# error:` is an assertion that a type checker diagnostic will
-be emitted, with text span starting on that line. If the comment is simply `# error:`, this will
-match any diagnostic. The matching can be narrowed in three ways:
+A comment beginning with `# error:` is an assertion that a type checker diagnostic will be emitted,
+with text span starting on that line. The matching can be narrowed in three ways:
 
 - `# error: [invalid-assignment]` requires that the matched diagnostic have the rule code
     `invalid-assignment`. (The square brackets are required.)
@@ -75,7 +78,8 @@ present; then contains-text, if present. For example, an assertion using all thr
 `# error: 8 [invalid-assignment] "Some text"`.
 
 Error assertions in tests intended to test type checker semantics should primarily use rule-code
-assertions, with occasional contains-text assertions where needed to disambiguate.
+assertions, with occasional contains-text assertions where needed to disambiguate or validate some
+details of the diagnostic message.
 
 ### Assertion locations
 

--- a/crates/red_knot_test/README.md
+++ b/crates/red_knot_test/README.md
@@ -29,7 +29,8 @@ fails.
 the quadruple-backtick-fenced "markdown" language code block above is NOT itself part of the mdtest
 syntax, it's just how this README embeds an example mdtest Markdown document.)
 
-See [a real example](https://github.com/astral-sh/ruff/blob/main/crates/red_knot_python_semantic/resources/mdtest/numbers.md) mdtest suite.
+See actual example mdtest suites in
+[`crates/red_knot_python_semantic/resources/mdtest`](https://github.com/astral-sh/ruff/tree/main/crates/red_knot_python_semantic/resources/mdtest).
 
 ## Assertions
 

--- a/crates/red_knot_test/README.md
+++ b/crates/red_knot_test/README.md
@@ -29,6 +29,8 @@ fails.
 the quadruple-backtick-fenced "markdown" language code block above is NOT itself part of the mdtest
 syntax, it's just how this README embeds an example mdtest Markdown document.)
 
+See [a real example](https://github.com/astral-sh/ruff/blob/main/crates/red_knot_python_semantic/resources/mdtest/numbers.md) mdtest suite.
+
 ## Assertions
 
 Two kinds of assertions are supported: `# revealed:` (shown above) and `# error:`.

--- a/crates/red_knot_test/README.md
+++ b/crates/red_knot_test/README.md
@@ -25,9 +25,11 @@ match the resulting diagnostics with the assertions in the test. Assertions are 
 Python comments. If all diagnostics and all assertions are matched, the test passes; otherwise, it
 fails.
 
+<!---
 (If you are reading this document in raw Markdown source rather than rendered Markdown, note that
 the quadruple-backtick-fenced "markdown" language code block above is NOT itself part of the mdtest
 syntax, it's just how this README embeds an example mdtest Markdown document.)
+--->
 
 See actual example mdtest suites in
 [`crates/red_knot_python_semantic/resources/mdtest`](https://github.com/astral-sh/ruff/tree/main/crates/red_knot_python_semantic/resources/mdtest).


### PR DESCRIPTION
Address a potential point of confusion that bit a contributor in https://github.com/astral-sh/ruff/pull/13719

Also remove a no-longer-accurate line about bare `error: ` assertions (which are no longer allowed) and clarify another point about which kinds of error assertions to use.
