### PR TITLE
[red-knot] Implement C3 linearisation for calculating a class's Method Resolution Order

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/mro.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/mro.md
@@ -1,0 +1,37 @@
+# Mro tests
+
+## No bases
+
+```py
+class C:
+    pass
+
+reveal_type(C.__mro__)  # revealed: tuple[Literal[C], Literal[object]]
+```
+
+## The special case: `object` itself
+
+```py
+reveal_type(object.__mro__)  # revealed: tuple[Literal[object]]
+```
+
+## Explicit inheritance from `object`
+
+```py
+class C(object):
+    pass
+
+reveal_type(C.__mro__)  # revealed: tuple[Literal[C], Literal[object]]
+```
+
+## Explicit inheritance from non-`object` single base
+
+```py
+class A:
+    pass
+
+class B(A):
+    pass
+
+reveal_type(B.__mro__)  # revealed: tuple[Literal[B], Literal[A], Literal[object]]
+```

--- a/crates/red_knot_python_semantic/resources/mdtest/mro.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/mro.md
@@ -213,17 +213,58 @@ reveal_type(F.__mro__)  # revealed: tuple[Literal[F], Literal[E], Literal[B], Li
 def returns_bool() -> bool:
     return True
 
-if returns_bool():
-    x = float
-else:
-    x = int
+class A:
+    pass
 
-reveal_type(x)  # revealed: Literal[float, int]
+class B:
+    pass
+
+if returns_bool():
+    x = A
+else:
+    x = B
+
+reveal_type(x)  # revealed: Literal[A, B]
 
 class Foo(x):
     pass
 
-reveal_type(Foo.__mro__)  # revealed: tuple[Literal[Foo], Literal[float], Literal[object]] | tuple[Literal[Foo], Literal[int], Literal[object]]
+reveal_type(Foo.__mro__)  # revealed: tuple[Literal[Foo], Literal[A], Literal[object]] | tuple[Literal[Foo], Literal[B], Literal[object]]
 ```
 
+## `__bases__` includes multiple `Union`s
 
+```py
+def returns_bool() -> bool:
+    return True
+
+class A:
+    pass
+
+class B:
+    pass
+
+class C:
+    pass
+
+class D:
+    pass
+
+if returns_bool():
+    x = A
+else:
+    x = B
+
+if returns_bool():
+    y = C
+else:
+    y = D
+
+reveal_type(x)  # revealed: Literal[A, B]
+reveal_type(y)  # revealed: Literal[C, D]
+
+class Foo(x, y):
+    pass
+
+reveal_type(Foo.__mro__)  # revealed: tuple[Literal[Foo], Literal[A], Literal[D], Literal[object]] | tuple[Literal[Foo], Literal[B], Literal[D], Literal[object]] | tuple[Literal[Foo], Literal[A], Literal[C], Literal[object]] | tuple[Literal[Foo], Literal[B], Literal[C], Literal[object]]
+```

--- a/crates/red_knot_python_semantic/resources/mdtest/mro.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/mro.md
@@ -206,3 +206,24 @@ reveal_type(D.__mro__)  # revealed: tuple[Literal[D], Literal[A], Unknown, Liter
 reveal_type(E.__mro__)  # revealed: tuple[Literal[E], Literal[B], Literal[C], Literal[object]]
 reveal_type(F.__mro__)  # revealed: tuple[Literal[F], Literal[E], Literal[B], Literal[C], Literal[A], Unknown, Literal[object]]
 ```
+
+## `__bases__` includes a `Union`
+
+```py
+def returns_bool() -> bool:
+    return True
+
+if returns_bool():
+    x = float
+else:
+    x = int
+
+reveal_type(x)  # revealed: Literal[float, int]
+
+class Foo(x):
+    pass
+
+reveal_type(Foo.__mro__)  # revealed: tuple[Literal[Foo], Literal[float], Literal[object]] | tuple[Literal[Foo], Literal[int], Literal[object]]
+```
+
+

--- a/crates/red_knot_python_semantic/resources/mdtest/mro.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/mro.md
@@ -276,3 +276,52 @@ class Foo(x, y):
 
 reveal_type(Foo.__mro__)  # revealed: tuple[Literal[Foo], Literal[A], Literal[D], Literal[object]] | tuple[Literal[Foo], Literal[B], Literal[D], Literal[object]] | tuple[Literal[Foo], Literal[A], Literal[C], Literal[object]] | tuple[Literal[Foo], Literal[B], Literal[C], Literal[object]]
 ```
+
+## `__bases__` lists that cause errors at runtime
+
+If the class's `__bases__` cause an exception to be raised at runtime
+and therefore the class creation to fail, we infer the class's `__mro__`
+as being `[<class>, Unknown, object]`:
+
+```py
+class Foo(object, int):
+    pass
+
+reveal_type(Foo.__mro__)  # revealed: tuple[Literal[Foo], Unknown, Literal[object]]
+
+class Bar(Foo):
+    pass
+
+reveal_type(Bar.__mro__)  # revealed: tuple[Literal[Bar], Literal[Foo], Unknown, Literal[object]]
+
+# This is the `TypeError` at the bottom of "ex_2"
+# in the examples at <https://docs.python.org/3/howto/mro.html#the-end>
+
+class O:
+    pass
+
+class X(O):
+    pass
+
+class Y(O):
+    pass
+
+class A(X, Y):
+    pass
+
+class B(Y, X):
+    pass
+
+reveal_type(A.__mro__)  # revealed: tuple[Literal[A], Literal[X], Literal[Y], Literal[O], Literal[object]]
+reveal_type(B.__mro__)  # revealed: tuple[Literal[B], Literal[Y], Literal[X], Literal[O], Literal[object]]
+
+class Z(A, B):
+    pass
+
+reveal_type(Z.__mro__)  # revealed: tuple[Literal[Z], Unknown, Literal[object]]
+
+class AA(Z):
+    pass
+
+reveal_type(AA.__mro__)  # revealed: tuple[Literal[AA], Literal[Z], Unknown, Literal[object]]
+```

--- a/crates/red_knot_python_semantic/resources/mdtest/mro.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/mro.md
@@ -50,3 +50,130 @@ class C(A, B):
 
 reveal_type(C.__mro__)  # revealed: tuple[Literal[C], Literal[A], Literal[B], Literal[object]]
 ```
+
+## Complex diamond inheritance (1)
+
+This is "ex_2" from https://docs.python.org/3/howto/mro.html#the-end
+
+```py
+class O:
+    pass
+
+class X(O):
+    pass
+
+class Y(O):
+    pass
+
+class A(X, Y):
+    pass
+
+class B(Y, X):
+    pass
+
+reveal_type(A.__mro__)  # revealed: tuple[Literal[A], Literal[X], Literal[Y], Literal[O], Literal[object]]
+reveal_type(B.__mro__)  # revealed: tuple[Literal[B], Literal[Y], Literal[X], Literal[O], Literal[object]]
+```
+
+## Complex diamond inheritance (2)
+
+This is "ex_5" from https://docs.python.org/3/howto/mro.html#the-end
+
+```py
+class O:
+    pass
+
+class F(O):
+    pass
+
+class E(O):
+    pass
+
+class D(O):
+    pass
+
+class C(D, F):
+    pass
+
+class B(D, E):
+    pass
+
+class A(B, C):
+    pass
+
+reveal_type(C.__mro__)  # revealed: tuple[Literal[C], Literal[D], Literal[F], Literal[O], Literal[object]]
+reveal_type(B.__mro__)  # revealed: tuple[Literal[B], Literal[D], Literal[E], Literal[O], Literal[object]]
+reveal_type(A.__mro__)  # revealed: tuple[Literal[A], Literal[B], Literal[C], Literal[D], Literal[E], Literal[F], Literal[O], Literal[object]]
+```
+
+## Complex diamond inheritance (3)
+
+This is "ex_6" from https://docs.python.org/3/howto/mro.html#the-end
+
+```py
+class O:
+    pass
+
+class F(O):
+    pass
+
+class E(O):
+    pass
+
+class D(O):
+    pass
+
+class C(D, F):
+    pass
+
+class B(E, D):
+    pass
+
+class A(B, C):
+    pass
+
+reveal_type(C.__mro__)  # revealed: tuple[Literal[C], Literal[D], Literal[F], Literal[O], Literal[object]]
+reveal_type(B.__mro__)  # revealed: tuple[Literal[B], Literal[E], Literal[D], Literal[O], Literal[object]]
+reveal_type(A.__mro__)  # revealed: tuple[Literal[A], Literal[B], Literal[E], Literal[C], Literal[D], Literal[F], Literal[O], Literal[object]]
+```
+
+## Complex diamond inheritance (4)
+
+This is "ex_9" from https://docs.python.org/3/howto/mro.html#the-end
+
+```py
+class O:
+    pass
+
+class A(O):
+    pass
+
+class B(O):
+    pass
+
+class C(O):
+    pass
+
+class D(O):
+    pass
+
+class E(O):
+    pass
+
+class K1(A, B, C):
+    pass
+
+class K2(D, B, E):
+    pass
+
+class K3(D, A):
+    pass
+
+class Z(K1, K2, K3):
+    pass
+
+reveal_type(K1.__mro__)  # revealed: tuple[Literal[K1], Literal[A], Literal[B], Literal[C], Literal[O], Literal[object]]
+reveal_type(K2.__mro__)  # revealed: tuple[Literal[K2], Literal[D], Literal[B], Literal[E], Literal[O], Literal[object]]
+reveal_type(K3.__mro__)  # revealed: tuple[Literal[K3], Literal[D], Literal[A], Literal[O], Literal[object]]
+reveal_type(Z.__mro__)  # revealed: tuple[Literal[Z], Literal[K1], Literal[K2], Literal[K3], Literal[D], Literal[A], Literal[B], Literal[C], Literal[E], Literal[O], Literal[object]]
+```

--- a/crates/red_knot_python_semantic/resources/mdtest/mro.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/mro.md
@@ -8,6 +8,11 @@ extremely important for *us* to know the precise possible values of
 a class's Method Resolution Order, or we won't be able to infer the
 correct type of attributes accessed from instances.
 
+For documentation on method resolution orders, see:
+
+- <https://docs.python.org/3/glossary.html#term-method-resolution-order>
+- <https://docs.python.org/3/howto/mro.html#python-2-3-mro>
+
 ## No bases
 
 ```py

--- a/crates/red_knot_python_semantic/resources/mdtest/mro.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/mro.md
@@ -325,3 +325,48 @@ class AA(Z):
 
 reveal_type(AA.__mro__)  # revealed: tuple[Literal[AA], Literal[Z], Unknown, Literal[object]]
 ```
+
+## `__bases__` lists that cause errors... now with `Union`s
+
+```py
+def returns_bool() -> bool:
+    return True
+
+class O:
+    pass
+
+class X(O):
+    pass
+
+class Y(O):
+    pass
+
+if bool():
+    foo = Y
+else:
+    foo = object
+
+class PossibleError(foo, X):
+    pass
+
+reveal_type(PossibleError.__mro__)  # revealed: tuple[Literal[PossibleError], Literal[Y], Literal[X], Literal[O], Literal[object]] | tuple[Literal[PossibleError], Unknown, Literal[object]]
+
+class A(X, Y):
+    pass
+
+reveal_type(A.__mro__)  # revealed: tuple[Literal[A], Literal[X], Literal[Y], Literal[O], Literal[object]]
+
+if returns_bool():
+    class B(X, Y):
+        pass
+else:
+    class B(Y, X):
+        pass
+
+reveal_type(B.__mro__)  # revealed: tuple[Literal[B], Literal[X], Literal[Y], Literal[O], Literal[object]] | tuple[Literal[B], Literal[Y], Literal[X], Literal[O], Literal[object]]
+
+class Z(A, B):
+    pass
+
+reveal_type(Z.__mro__)  # revealed: tuple[Literal[Z], Literal[A], Literal[B], Literal[X], Literal[Y], Literal[O], Literal[object]] | tuple[Literal[Z], Unknown, Literal[object]]
+```

--- a/crates/red_knot_python_semantic/resources/mdtest/mro.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/mro.md
@@ -177,3 +177,32 @@ reveal_type(K2.__mro__)  # revealed: tuple[Literal[K2], Literal[D], Literal[B], 
 reveal_type(K3.__mro__)  # revealed: tuple[Literal[K3], Literal[D], Literal[A], Literal[O], Literal[object]]
 reveal_type(Z.__mro__)  # revealed: tuple[Literal[Z], Literal[K1], Literal[K2], Literal[K3], Literal[D], Literal[A], Literal[B], Literal[C], Literal[E], Literal[O], Literal[object]]
 ```
+
+## Inheritance from `Unknown`
+
+```py
+from does_not_exist import DoesNotExist  # error: [unresolved-import]
+
+class A(DoesNotExist):
+    pass
+
+class B:
+    pass
+
+class C:
+    pass
+
+class D(A, B, C):
+    pass
+
+class E(B, C):
+    pass
+
+class F(E, A):
+    pass
+
+reveal_type(A.__mro__)  # revealed: tuple[Literal[A], Unknown, Literal[object]]
+reveal_type(D.__mro__)  # revealed: tuple[Literal[D], Literal[A], Unknown, Literal[B], Literal[C], Literal[object]]
+reveal_type(E.__mro__)  # revealed: tuple[Literal[E], Literal[B], Literal[C], Literal[object]]
+reveal_type(F.__mro__)  # revealed: tuple[Literal[F], Literal[E], Literal[B], Literal[C], Literal[A], Unknown, Literal[object]]
+```

--- a/crates/red_knot_python_semantic/resources/mdtest/mro.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/mro.md
@@ -53,7 +53,7 @@ reveal_type(C.__mro__)  # revealed: tuple[Literal[C], Literal[A], Literal[B], Li
 
 ## Complex diamond inheritance (1)
 
-This is "ex_2" from https://docs.python.org/3/howto/mro.html#the-end
+This is "ex_2" from <https://docs.python.org/3/howto/mro.html#the-end>
 
 ```py
 class O:
@@ -77,7 +77,7 @@ reveal_type(B.__mro__)  # revealed: tuple[Literal[B], Literal[Y], Literal[X], Li
 
 ## Complex diamond inheritance (2)
 
-This is "ex_5" from https://docs.python.org/3/howto/mro.html#the-end
+This is "ex_5" from <https://docs.python.org/3/howto/mro.html#the-end>
 
 ```py
 class O:
@@ -108,7 +108,7 @@ reveal_type(A.__mro__)  # revealed: tuple[Literal[A], Literal[B], Literal[C], Li
 
 ## Complex diamond inheritance (3)
 
-This is "ex_6" from https://docs.python.org/3/howto/mro.html#the-end
+This is "ex_6" from <https://docs.python.org/3/howto/mro.html#the-end>
 
 ```py
 class O:
@@ -139,7 +139,7 @@ reveal_type(A.__mro__)  # revealed: tuple[Literal[A], Literal[B], Literal[E], Li
 
 ## Complex diamond inheritance (4)
 
-This is "ex_9" from https://docs.python.org/3/howto/mro.html#the-end
+This is "ex_9" from <https://docs.python.org/3/howto/mro.html#the-end>
 
 ```py
 class O:

--- a/crates/red_knot_python_semantic/resources/mdtest/mro.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/mro.md
@@ -1,4 +1,12 @@
-# Mro tests
+# Method Resolution Order tests
+
+Tests that assert that we can infer the correct type for a class's
+`__mro__` attribute.
+
+This attribute is rarely accessed directly at runtime. However, it's
+extremely important for *us* to know the precise possible values of
+a class's Method Resolution Order, or we won't be able to infer the
+correct type of attributes accessed from instances.
 
 ## No bases
 

--- a/crates/red_knot_python_semantic/resources/mdtest/mro.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/mro.md
@@ -284,7 +284,7 @@ and therefore the class creation to fail, we infer the class's `__mro__`
 as being `[<class>, Unknown, object]`:
 
 ```py
-class Foo(object, int):
+class Foo(object, int):  # error: [inconsistent-mro] "Cannot create a consistent method resolution order (MRO) for class `Foo` with possible bases list `[<class 'object'>, <class 'int'>]`"
     pass
 
 reveal_type(Foo.__mro__)  # revealed: tuple[Literal[Foo], Unknown, Literal[object]]
@@ -315,7 +315,7 @@ class B(Y, X):
 reveal_type(A.__mro__)  # revealed: tuple[Literal[A], Literal[X], Literal[Y], Literal[O], Literal[object]]
 reveal_type(B.__mro__)  # revealed: tuple[Literal[B], Literal[Y], Literal[X], Literal[O], Literal[object]]
 
-class Z(A, B):
+class Z(A, B):  # error: [inconsistent-mro] "Cannot create a consistent method resolution order (MRO) for class `Z` with possible bases list `[<class 'A'>, <class 'B'>]`"
     pass
 
 reveal_type(Z.__mro__)  # revealed: tuple[Literal[Z], Unknown, Literal[object]]
@@ -346,7 +346,7 @@ if bool():
 else:
     foo = object
 
-class PossibleError(foo, X):
+class PossibleError(foo, X):  # error: [inconsistent-mro] "Cannot create a consistent method resolution order (MRO) for class `PossibleError` with possible bases list `[<class 'object'>, <class 'X'>]`"
     pass
 
 reveal_type(PossibleError.__mro__)  # revealed: tuple[Literal[PossibleError], Literal[Y], Literal[X], Literal[O], Literal[object]] | tuple[Literal[PossibleError], Unknown, Literal[object]]
@@ -365,7 +365,7 @@ else:
 
 reveal_type(B.__mro__)  # revealed: tuple[Literal[B], Literal[X], Literal[Y], Literal[O], Literal[object]] | tuple[Literal[B], Literal[Y], Literal[X], Literal[O], Literal[object]]
 
-class Z(A, B):
+class Z(A, B):  # error: [inconsistent-mro] "Cannot create a consistent method resolution order (MRO) for class `Z` with possible bases list `[<class 'A'>, <class 'B'>]`"
     pass
 
 reveal_type(Z.__mro__)  # revealed: tuple[Literal[Z], Literal[A], Literal[B], Literal[X], Literal[Y], Literal[O], Literal[object]] | tuple[Literal[Z], Unknown, Literal[object]]

--- a/crates/red_knot_python_semantic/resources/mdtest/mro.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/mro.md
@@ -35,3 +35,18 @@ class B(A):
 
 reveal_type(B.__mro__)  # revealed: tuple[Literal[B], Literal[A], Literal[object]]
 ```
+
+## Linearization of multiple bases
+
+```py
+class A:
+    pass
+
+class B:
+    pass
+
+class C(A, B):
+    pass
+
+reveal_type(C.__mro__)  # revealed: tuple[Literal[C], Literal[A], Literal[B], Literal[object]]
+```

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -1378,10 +1378,12 @@ impl<'db> ClassType<'db> {
 
     fn mro(self, db: &'db dyn Db) -> Box<[ClassBase<'db>]> {
         if self.bases(db).len() == 0 {
-            return Box::new([
-                ClassBase::Class(self),
-                ClassBase::Class(KnownClass::Object.to_class(db).expect_class()),
-            ]);
+            let object = KnownClass::Object.to_class(db).expect_class();
+            return if self == object {
+                Box::new([ClassBase::Class(self)])
+            } else {
+                Box::new([ClassBase::Class(self), ClassBase::Class(object)])
+            };
         }
         todo!()
     }

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -1431,7 +1431,7 @@ impl<'db> ClassType<'db> {
         if name == "__mro__" {
             let mro_possibilities = self.mro_possibilities(db);
             let mut union_builder = UnionBuilder::new(db);
-            for mro in mro_possibilities.iter(db) {
+            for mro in mro_possibilities.iter(db, mro::ClassBase::Class(self)) {
                 let elements = mro.iter().map(Type::from).collect();
                 union_builder = union_builder.add(Type::Tuple(TupleType::new(db, elements)));
             }
@@ -1455,7 +1455,7 @@ impl<'db> ClassType<'db> {
     pub fn inherited_class_member(self, db: &'db dyn Db, name: &str) -> Type<'db> {
         let mro_possibilities = self.mro_possibilities(db);
         let mut union_builder = UnionBuilder::new(db);
-        'outer: for mro in mro_possibilities.iter(db) {
+        'outer: for mro in mro_possibilities.iter(db, mro::ClassBase::Class(self)) {
             for base in &*mro {
                 let member = base.own_class_member(db, name);
                 if !member.is_unbound() {

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -1457,6 +1457,7 @@ impl<'db> ClassType<'db> {
                         .iter()
                         .map(|base| base.mro_possibilities(db))
                         .collect_vec();
+
                     let cartesian_product = possible_mros_per_base
                         .iter()
                         .map(|mro_set| mro_set.iter())

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -1381,6 +1381,13 @@ impl<'db> ClassType<'db> {
             })
     }
 
+    pub(crate) fn node(&self, db: &'db dyn Db) -> &ast::StmtClassDef {
+        let DefinitionKind::Class(class_stmt_node) = self.definition(db).kind(db) else {
+            panic!("Class type definition must have DefinitionKind::Class");
+        };
+        class_stmt_node
+    }
+
     /// Return an array of the types of this class's bases.
     ///
     /// The returned array should exactly match the result of `t.__bases__`
@@ -1394,11 +1401,7 @@ impl<'db> ClassType<'db> {
     /// # Panics:
     /// If `definition` is not a `DefinitionKind::Class`.
     pub fn bases(&self, db: &'db dyn Db) -> Box<[Type<'db>]> {
-        let definition = self.definition(db);
-        let DefinitionKind::Class(class_stmt_node) = definition.kind(db) else {
-            panic!("Class type definition must have DefinitionKind::Class");
-        };
-        let base_nodes = class_stmt_node.bases();
+        let base_nodes = self.node(db).bases();
         let object = KnownClass::Object.to_class(db);
 
         if Type::Class(*self) == object {
@@ -1416,7 +1419,7 @@ impl<'db> ClassType<'db> {
         } else {
             base_nodes
                 .iter()
-                .map(move |base_expr| definition_expression_ty(db, definition, base_expr))
+                .map(move |base_expr| definition_expression_ty(db, self.definition(db), base_expr))
                 .collect()
         }
     }

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -1365,7 +1365,7 @@ impl<'db> ClassType<'db> {
     ///
     /// # Panics:
     /// If `definition` is not a `DefinitionKind::Class`.
-    pub fn bases(&self, db: &'db dyn Db) -> impl Iterator<Item = Type<'db>> {
+    pub fn bases(&self, db: &'db dyn Db) -> impl ExactSizeIterator<Item = Type<'db>> {
         let definition = self.definition(db);
         let DefinitionKind::Class(class_stmt_node) = definition.kind(db) else {
             panic!("Class type definition must have DefinitionKind::Class");
@@ -1376,7 +1376,13 @@ impl<'db> ClassType<'db> {
             .map(move |base_expr| definition_expression_ty(db, definition, base_expr))
     }
 
-    fn mro(&self, db: &'db dyn Db) -> Box<[ClassBase<'db>]> {
+    fn mro(self, db: &'db dyn Db) -> Box<[ClassBase<'db>]> {
+        if self.bases(db).len() == 0 {
+            return Box::new([
+                ClassBase::Class(self),
+                ClassBase::Class(KnownClass::Object.to_class(db).expect_class()),
+            ]);
+        }
         todo!()
     }
 

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -1470,8 +1470,8 @@ impl<'db> ClassType<'db> {
     }
 
     pub fn inherited_class_member(self, db: &'db dyn Db, name: &str) -> Type<'db> {
-        for base in self.bases(db) {
-            let member = base.member(db, name);
+        for base in &self.mro(db).unwrap() {
+            let member = base.own_class_member(db, name);
             if !member.is_unbound() {
                 return member;
             }
@@ -1497,6 +1497,15 @@ impl<'db> ClassBase<'db> {
                 self,
                 ClassBase::Class(KnownClass::Object.to_class(db).expect_class()),
             ])),
+        }
+    }
+
+    fn own_class_member(self, db: &'db dyn Db, member: &str) -> Type<'db> {
+        match self {
+            Self::Any => Type::Any,
+            Self::Todo => Type::Todo,
+            Self::Unknown => Type::Unknown,
+            Self::Class(class) => class.own_class_member(db, member),
         }
     }
 

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -1,7 +1,6 @@
 use infer::TypeInferenceBuilder;
 use ruff_db::files::File;
 use ruff_python_ast as ast;
-use std::fmt::Debug;
 
 use crate::module_resolver::file_to_module;
 use crate::semantic_index::ast_ids::HasScopedAstId;

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -13,7 +13,7 @@ use crate::semantic_index::{
 use crate::stdlib::{
     builtins_symbol_ty, types_symbol_ty, typeshed_symbol_ty, typing_extensions_symbol_ty,
 };
-use crate::types::mro::MroPossibilities;
+use crate::types::mro::ClassMroSet;
 use crate::types::narrow::narrowing_constraint;
 use crate::{Db, FxOrderSet, Module};
 
@@ -1360,8 +1360,8 @@ impl<'db> ClassType<'db> {
     ///
     /// [method resolution order]: https://docs.python.org/3/glossary.html#term-method-resolution-order
     #[salsa::tracked(return_ref)]
-    fn mro_possibilities(self, db: &'db dyn Db) -> MroPossibilities<'db> {
-        MroPossibilities::of_class(db, self)
+    fn mro_possibilities(self, db: &'db dyn Db) -> ClassMroSet<'db> {
+        ClassMroSet::of_class(db, self)
     }
 }
 
@@ -1456,7 +1456,7 @@ impl<'db> ClassType<'db> {
         let mro_possibilities = self.mro_possibilities(db);
         let mut union_builder = UnionBuilder::new(db);
         'outer: for mro in mro_possibilities.iter(db, mro::ClassBase::Class(self)) {
-            for base in &*mro {
+            for base in &**mro {
                 let member = base.own_class_member(db, name);
                 if !member.is_unbound() {
                     union_builder = union_builder.add(member);

--- a/crates/red_knot_python_semantic/src/types/builder.rs
+++ b/crates/red_knot_python_semantic/src/types/builder.rs
@@ -45,6 +45,7 @@ impl<'db> UnionBuilder<'db> {
     }
 
     /// Adds a type to this union.
+    #[must_use]
     pub(crate) fn add(mut self, ty: Type<'db>) -> Self {
         match ty {
             Type::Union(union) => {

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -3639,6 +3639,7 @@ mod tests {
 
         let base_names: Vec<_> = class
             .bases(&db)
+            .iter()
             .map(|base_ty| format!("{}", base_ty.display(&db)))
             .collect();
 
@@ -5054,12 +5055,12 @@ mod tests {
         let a = system_path_to_file(&db, "src/a.py").expect("file to exist");
         let c_ty = global_symbol_ty(&db, a, "C");
         let c_class = c_ty.expect_class();
-        let mut c_bases = c_class.bases(&db);
-        let b_ty = c_bases.next().unwrap();
+        let c_bases = c_class.bases(&db);
+        let b_ty = c_bases[0];
         let b_class = b_ty.expect_class();
         assert_eq!(b_class.name(&db), "B");
-        let mut b_bases = b_class.bases(&db);
-        let a_ty = b_bases.next().unwrap();
+        let b_bases = b_class.bases(&db);
+        let a_ty = b_bases[0];
         let a_class = a_ty.expect_class();
         assert_eq!(a_class.name(&db), "A");
 
@@ -5313,15 +5314,8 @@ mod tests {
         db.write_file("/src/a.pyi", "class C(object): pass")?;
         let file = system_path_to_file(&db, "/src/a.pyi").unwrap();
         let ty = global_symbol_ty(&db, file, "C");
-
-        let base = ty
-            .expect_class()
-            .bases(&db)
-            .next()
-            .expect("there should be at least one base");
-
+        let base = ty.expect_class().bases(&db)[0];
         assert_eq!(base.display(&db).to_string(), "Literal[object]");
-
         Ok(())
     }
 

--- a/crates/red_knot_python_semantic/src/types/mro.rs
+++ b/crates/red_knot_python_semantic/src/types/mro.rs
@@ -1,18 +1,204 @@
 use super::{ClassType, KnownClass, Type};
 use crate::Db;
+use itertools::Itertools;
 use rustc_hash::FxHashSet;
 use std::borrow::Cow;
 use std::collections::VecDeque;
 
-pub(super) fn fork_bases<'db>(
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum MroPossibilities<'db> {
+    /// It can be statically determined that there is only exactly 1
+    /// possible `__mro__` for this class; here it is:
+    Known(Mro<'db>),
+
+    /// There are multiple possible `__mro__`s for this class:
+    Ambiguous(FxHashSet<Option<Mro<'db>>>),
+}
+
+impl<'db> MroPossibilities<'db> {
+    pub(super) fn of_class(db: &'db dyn Db, class: ClassType<'db>) -> Self {
+        let bases = class.bases(db);
+
+        // Start with some fast paths for some common occurences:
+        if !bases.iter().any(Type::is_union) {
+            if let Some(short_circuit) = mro_of_class_fast_path(db, class, &bases) {
+                return short_circuit;
+            }
+        }
+
+        mro_of_class_slow_path(db, class, &bases)
+    }
+
+    fn known(mro: impl Into<Mro<'db>>) -> Self {
+        Self::Known(mro.into())
+    }
+
+    pub(super) fn iter<'s>(&'s self) -> MroPossibilityIterator<'s, 'db> {
+        match self {
+            Self::Known(single_mro) => MroPossibilityIterator::Single(std::iter::once(single_mro)),
+            Self::Ambiguous(multiple_mros) => {
+                MroPossibilityIterator::Multiple(multiple_mros.iter())
+            }
+        }
+    }
+}
+
+impl<'s, 'db> IntoIterator for &'s MroPossibilities<'db> {
+    type IntoIter = MroPossibilityIterator<'s, 'db>;
+    type Item = Option<&'s Mro<'db>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+/// Fast path that is only valid if we know that none of the bases is a union type
+fn mro_of_class_fast_path<'db>(
     db: &'db dyn Db,
+    class: ClassType<'db>,
     bases: &[Type<'db>],
-) -> FxHashSet<Box<[ClassBase<'db>]>> {
+) -> Option<MroPossibilities<'db>> {
+    match bases {
+        // 0 bases means that it must be `object` itself.
+        //
+        // The case for `object` itself isn't really that common,
+        // but we may as well handle it here, since it's known and easy:
+        [] => {
+            debug_assert_eq!(
+                Type::Class(class),
+                KnownClass::Object.to_class(db),
+                "Only `object` should have 0 bases in Python"
+            );
+            Some(MroPossibilities::known([class]))
+        }
+
+        // The class has a single base.
+        //
+        // That could be an explicit base (`class A(B): pass`),
+        // or an implicit base (which is always `object`: `class A: pass`).
+        [single_base] => {
+            let object = KnownClass::Object.to_class(db);
+            let mro = if single_base == &object {
+                MroPossibilities::known([class, object.expect_class()])
+            } else {
+                let mut possibilities = FxHashSet::default();
+                for possibility in &*ClassBase::from(single_base).mro_possibilities(db) {
+                    let Some(possibility) = possibility else {
+                        possibilities.insert(None);
+                        continue;
+                    };
+                    possibilities.insert(Some(
+                        std::iter::once(ClassBase::Class(class))
+                            .chain(possibility.iter().copied())
+                            .collect(),
+                    ));
+                }
+                MroPossibilities::Ambiguous(possibilities)
+            };
+            Some(mro)
+        }
+
+        // The class has multiple bases.
+        //
+        // At this point, whatever we do isn't really going to be "fast",
+        // so we may as well fallback to the slow path below.
+        // Even though we know that none of our direct bases is a union type,
+        // that doesn't mean that none of our indirect bases is a union type...
+        _ => None,
+    }
+}
+
+/// Slow path: this is only taken if the class has multiple bases
+/// (of which any might be a union type),
+/// or it has a single base, and the base is a union type.
+fn mro_of_class_slow_path<'db>(
+    db: &'db dyn Db,
+    class: ClassType<'db>,
+    bases: &[Type<'db>],
+) -> MroPossibilities<'db> {
+    let bases_possibilities = fork_bases(db, bases);
+    debug_assert_ne!(bases_possibilities.len(), 0);
+    let mut mro_possibilities = FxHashSet::default();
+
+    for bases_possibility in &bases_possibilities {
+        match bases_possibility {
+            [] => panic!("Only `object` should ever have 0 bases, which should have been handled in a fast path"),
+
+            // fast path for a common case: only inherits from a single base
+            [single_base] => {
+                let object = ClassBase::Class(KnownClass::Object.to_class(db).expect_class());
+                if *single_base == object {
+                    mro_possibilities.insert(Some(Mro::from([ClassBase::Class(class), object])));
+                } else {
+                    for possibility in &*single_base.mro_possibilities(db) {
+                        let Some(possibility) = possibility else {
+                            mro_possibilities.insert(None);
+                            continue;
+                        };
+                        mro_possibilities.insert(Some(
+                            std::iter::once(ClassBase::Class(class))
+                                .chain(possibility.iter().copied())
+                                .collect(),
+                        ));
+                    }
+                }
+            }
+
+            // slow path of the slow path: fall back to full C3 linearisation algorithm
+            // as described in https://docs.python.org/3/howto/mro.html#python-2-3-mro
+            //
+            // For a Python-3 translation of the algorithm described in that document,
+            // see https://gist.github.com/AlexWaygood/674db1fce6856a90f251f63e73853639
+            _ => {
+                let bases = VecDeque::from_iter(bases_possibility);
+
+                let possible_mros_per_base: Vec<_> = bases
+                    .iter()
+                    .map(|base| base.mro_possibilities(db))
+                    .collect();
+
+                let mro_cartesian_product = possible_mros_per_base
+                    .iter()
+                    .map(|mro_set| mro_set.iter())
+                    .multi_cartesian_product();
+
+                // Each `possible_mros_of_bases` is a concrete possibility of the list of mros of all of the bases:
+                // where the bases are `[B1, B2, B..N]`, `possible_mros_of_bases` represents one possibility of
+                // `[mro_of_B1, mro_of_B2, mro_of_B..N]`
+                for possible_mros_of_bases in mro_cartesian_product {
+                    let Some(possible_mros_of_bases) = possible_mros_of_bases
+                        .into_iter()
+                        .map(|maybe_mro| maybe_mro.map(|mro|mro.iter().copied().collect()))
+                        .collect::<Option<Vec<_>>>()
+                    else {
+                        mro_possibilities.insert(None);
+                        continue;
+                    };
+                    let linearized = c3_merge(
+                        std::iter::once(VecDeque::from([ClassBase::Class(class)]))
+                            .chain(possible_mros_of_bases)
+                            .chain(std::iter::once(bases.iter().copied().copied().collect()))
+                            .collect(),
+                    );
+                    mro_possibilities.insert(linearized);
+                }
+            }
+        }
+    }
+
+    debug_assert_ne!(mro_possibilities.len(), 0);
+    MroPossibilities::Ambiguous(mro_possibilities)
+}
+
+fn fork_bases<'db>(db: &'db dyn Db, bases: &[Type<'db>]) -> BasesPossibilities<'db> {
+    if !bases.iter().any(Type::is_union) {
+        return BasesPossibilities::Single(bases.iter().map(ClassBase::from).collect());
+    }
     let mut possibilities = FxHashSet::from_iter([Box::default()]);
     for base in bases {
         possibilities = add_next_base(db, &possibilities, *base);
     }
-    possibilities
+    BasesPossibilities::Multiple(possibilities)
 }
 
 fn add_next_base<'db>(
@@ -47,37 +233,49 @@ fn add_next_base<'db>(
     new_possibilities
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(super) enum MroPossibilities<'db> {
-    /// It can be statically determined that there is only exactly 1
-    /// possible `__mro__` for this class; here it is:
-    Known(Mro<'db>),
-
-    /// There are multiple possible `__mro__`s for this class:
-    Ambiguous(FxHashSet<Option<Mro<'db>>>),
+enum BasesPossibilities<'db> {
+    Single(Box<[ClassBase<'db>]>),
+    Multiple(FxHashSet<Box<[ClassBase<'db>]>>),
 }
 
-impl<'db> MroPossibilities<'db> {
-    pub(super) fn known(mro: impl Into<Mro<'db>>) -> Self {
-        Self::Known(mro.into())
+impl<'db> BasesPossibilities<'db> {
+    fn len(&self) -> usize {
+        match self {
+            Self::Single(_) => 1,
+            Self::Multiple(possibilities) => possibilities.len(),
+        }
     }
 
-    pub(super) fn iter<'s>(&'s self) -> MroPossibilityIterator<'s, 'db> {
+    fn iter<'s>(&'s self) -> BasesPossibilityIterator<'s, 'db> {
         match self {
-            Self::Known(single_mro) => MroPossibilityIterator::Single(std::iter::once(single_mro)),
-            Self::Ambiguous(multiple_mros) => {
-                MroPossibilityIterator::Multiple(multiple_mros.iter())
-            }
+            Self::Single(bases) => BasesPossibilityIterator::Single(std::iter::once(&**bases)),
+            Self::Multiple(bases) => BasesPossibilityIterator::Multiple(bases.iter()),
         }
     }
 }
 
-impl<'s, 'db> IntoIterator for &'s MroPossibilities<'db> {
-    type IntoIter = MroPossibilityIterator<'s, 'db>;
-    type Item = Option<&'s Mro<'db>>;
+impl<'a, 'db> IntoIterator for &'a BasesPossibilities<'db> {
+    type IntoIter = BasesPossibilityIterator<'a, 'db>;
+    type Item = &'a [ClassBase<'db>];
 
     fn into_iter(self) -> Self::IntoIter {
         self.iter()
+    }
+}
+
+enum BasesPossibilityIterator<'a, 'db> {
+    Single(std::iter::Once<&'a [ClassBase<'db>]>),
+    Multiple(std::collections::hash_set::Iter<'a, Box<[ClassBase<'db>]>>),
+}
+
+impl<'a, 'db> Iterator for BasesPossibilityIterator<'a, 'db> {
+    type Item = &'a [ClassBase<'db>];
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            Self::Single(iter) => iter.next(),
+            Self::Multiple(iter) => iter.next().map(Box::as_ref),
+        }
     }
 }
 
@@ -107,7 +305,7 @@ pub(super) enum ClassBase<'db> {
 }
 
 impl<'db> ClassBase<'db> {
-    pub(super) fn mro_possibilities(self, db: &'db dyn Db) -> Cow<MroPossibilities<'db>> {
+    fn mro_possibilities(self, db: &'db dyn Db) -> Cow<MroPossibilities<'db>> {
         match self {
             ClassBase::Class(class) => Cow::Borrowed(class.mro_possibilities(db)),
             ClassBase::Any | ClassBase::Todo | ClassBase::Unknown => {
@@ -254,7 +452,7 @@ impl<'db> IntoIterator for Mro<'db> {
 ///
 /// [C3-merge algorithm]: https://docs.python.org/3/howto/mro.html#python-2-3-mro
 /// [method resolution order]: https://docs.python.org/3/glossary.html#term-method-resolution-order
-pub(super) fn c3_merge(mut seqs: Vec<VecDeque<ClassBase>>) -> Option<Mro> {
+fn c3_merge(mut seqs: Vec<VecDeque<ClassBase>>) -> Option<Mro> {
     let mut mro = Mro::default();
 
     loop {

--- a/crates/red_knot_python_semantic/src/types/mro.rs
+++ b/crates/red_knot_python_semantic/src/types/mro.rs
@@ -26,7 +26,7 @@ impl<'db> MroPossibilities<'db> {
     pub(super) fn of_class(db: &'db dyn Db, class: ClassType<'db>) -> Self {
         let bases = class.bases(db);
 
-        // Start with some fast paths for some common occurences:
+        // Start with some fast paths for some common occurrences:
         if !bases.iter().any(Type::is_union) {
             if let Some(short_circuit) = mro_of_class_fast_path(db, class, &bases) {
                 return short_circuit;
@@ -247,7 +247,7 @@ fn add_next_base<'db>(
 /// The possible value of `__bases__` for a given class.
 ///
 /// Whereas [`ClassType::bases`] returns a list of types in which any type
-/// might be a [`Type::Union`], this enum tranforms the list of types so that we
+/// might be a [`Type::Union`], this enum transforms the list of types so that we
 /// have a union of possible `__bases__` lists rather than a single list
 /// that could contain a union.
 enum BasesPossibilities<'db> {

--- a/crates/red_knot_python_semantic/src/types/mro.rs
+++ b/crates/red_knot_python_semantic/src/types/mro.rs
@@ -421,12 +421,12 @@ impl<'db> ClassBase<'db> {
         }
     }
 
-    pub(super) fn display(self, db: &'db dyn Db) -> String {
+    pub(super) fn display(self, db: &'db dyn Db) -> Cow<'static, str> {
         match self {
-            Self::Any => "ClassBase(Any)".to_string(),
-            Self::Todo => "ClassBase(Todo)".to_string(),
-            Self::Unknown => "ClassBase(Unknown)".to_string(),
-            Self::Class(class) => format!("ClassBase(<class '{}'>)", class.name(db)),
+            Self::Any => Cow::Borrowed("Any"),
+            Self::Todo => Cow::Borrowed("Todo"),
+            Self::Unknown => Cow::Borrowed("Unknown"),
+            Self::Class(class) => Cow::Owned(format!("<class '{}'>", class.name(db))),
         }
     }
 
@@ -514,10 +514,6 @@ impl<'db> Mro<'db> {
 
     pub(super) fn iter(&self) -> std::collections::vec_deque::Iter<'_, ClassBase<'db>> {
         self.0.iter()
-    }
-
-    pub(super) fn display(&self, db: &'db dyn Db) -> Vec<String> {
-        self.0.iter().map(|base| base.display(db)).collect()
     }
 
     fn push(&mut self, element: ClassBase<'db>) {

--- a/crates/red_knot_python_semantic/src/types/mro.rs
+++ b/crates/red_knot_python_semantic/src/types/mro.rs
@@ -243,7 +243,7 @@ fn mro_of_class_slow_path<'db>(
                     let linearized = c3_merge(
                         std::iter::once(VecDeque::from([ClassBase::Class(class)]))
                             .chain(possible_mros_of_bases)
-                            .chain(std::iter::once(bases.iter().copied().copied().collect()))
+                            .chain(std::iter::once(bases.iter().map(|base|**base).collect()))
                             .collect(),
                     );
                     match linearized {
@@ -504,7 +504,7 @@ impl<'db> From<&ClassBase<'db>> for Type<'db> {
 ///
 /// See [`ClassType::mro_possibilities`] for more details.
 #[derive(PartialEq, Eq, Default, Hash, Clone, Debug)]
-pub(super) struct Mro<'db>(VecDeque<ClassBase<'db>>);
+pub(super) struct Mro<'db>(Vec<ClassBase<'db>>);
 
 impl<'db> Mro<'db> {
     fn from_error(db: &'db dyn Db, class: ClassType<'db>) -> Self {
@@ -515,18 +515,18 @@ impl<'db> Mro<'db> {
         ])
     }
 
-    pub(super) fn iter(&self) -> std::collections::vec_deque::Iter<'_, ClassBase<'db>> {
+    pub(super) fn iter(&self) -> std::slice::Iter<'_, ClassBase<'db>> {
         self.0.iter()
     }
 
     fn push(&mut self, element: ClassBase<'db>) {
-        self.0.push_back(element);
+        self.0.push(element);
     }
 }
 
 impl<'db, const N: usize> From<[ClassBase<'db>; N]> for Mro<'db> {
     fn from(value: [ClassBase<'db>; N]) -> Self {
-        Self(VecDeque::from(value))
+        Self(Vec::from(value))
     }
 }
 
@@ -543,7 +543,7 @@ impl<'db> FromIterator<ClassBase<'db>> for Mro<'db> {
 }
 
 impl<'a, 'db> IntoIterator for &'a Mro<'db> {
-    type IntoIter = std::collections::vec_deque::Iter<'a, ClassBase<'db>>;
+    type IntoIter = std::slice::Iter<'a, ClassBase<'db>>;
     type Item = &'a ClassBase<'db>;
 
     fn into_iter(self) -> Self::IntoIter {

--- a/crates/red_knot_python_semantic/src/types/mro.rs
+++ b/crates/red_knot_python_semantic/src/types/mro.rs
@@ -1,0 +1,282 @@
+use super::{ClassType, KnownClass, Type};
+use crate::Db;
+use rustc_hash::FxHashSet;
+use std::borrow::Cow;
+use std::collections::VecDeque;
+
+pub(super) fn fork_bases<'db>(
+    db: &'db dyn Db,
+    bases: &[Type<'db>],
+) -> FxHashSet<Box<[ClassBase<'db>]>> {
+    let mut possibilities = FxHashSet::from_iter([Box::default()]);
+    for base in bases {
+        possibilities = add_next_base(db, &possibilities, *base);
+    }
+    possibilities
+}
+
+fn add_next_base<'db>(
+    db: &'db dyn Db,
+    bases_possibilities: &FxHashSet<Box<[ClassBase<'db>]>>,
+    next_base: Type<'db>,
+) -> FxHashSet<Box<[ClassBase<'db>]>> {
+    let mut new_possibilities = FxHashSet::default();
+    let mut add_non_union_base = |fork: &[ClassBase<'db>], base: Type<'db>| {
+        new_possibilities.insert(
+            fork.iter()
+                .copied()
+                .chain(std::iter::once(ClassBase::from(base)))
+                .collect(),
+        );
+    };
+    match next_base {
+        Type::Union(union) => {
+            for element in union.elements(db) {
+                for existing_possibility in bases_possibilities {
+                    add_non_union_base(existing_possibility, *element);
+                }
+            }
+        }
+        _ => {
+            for possibility in bases_possibilities {
+                add_non_union_base(possibility, next_base);
+            }
+        }
+    }
+    debug_assert_ne!(new_possibilities.len(), 0);
+    new_possibilities
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum MroPossibilities<'db> {
+    /// It can be statically determined that there is only exactly 1
+    /// possible `__mro__` for this class; here it is:
+    Known(Mro<'db>),
+
+    /// There are multiple possible `__mro__`s for this class:
+    Ambiguous(FxHashSet<Option<Mro<'db>>>),
+}
+
+impl<'db> MroPossibilities<'db> {
+    pub(super) fn iter<'s>(&'s self) -> MroPossibilityIterator<'s, 'db> {
+        match self {
+            Self::Known(single_mro) => MroPossibilityIterator::Single(std::iter::once(single_mro)),
+            Self::Ambiguous(multiple_mros) => {
+                MroPossibilityIterator::Multiple(multiple_mros.iter())
+            }
+        }
+    }
+}
+
+impl<'s, 'db> IntoIterator for &'s MroPossibilities<'db> {
+    type IntoIter = MroPossibilityIterator<'s, 'db>;
+    type Item = Option<&'s Mro<'db>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+#[derive(Clone)]
+pub(super) enum MroPossibilityIterator<'a, 'db> {
+    Single(std::iter::Once<&'a Mro<'db>>),
+    Multiple(std::collections::hash_set::Iter<'a, Option<Mro<'db>>>),
+}
+
+impl<'a, 'db> Iterator for MroPossibilityIterator<'a, 'db> {
+    type Item = Option<&'a Mro<'db>>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            Self::Single(iter) => iter.next().map(Some),
+            Self::Multiple(iter) => iter.next().map(Option::as_ref),
+        }
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+pub(super) enum ClassBase<'db> {
+    Class(ClassType<'db>),
+    Any,
+    Todo,
+    Unknown,
+}
+
+impl<'db> ClassBase<'db> {
+    pub(super) fn mro_possibilities(self, db: &'db dyn Db) -> Cow<MroPossibilities<'db>> {
+        match self {
+            ClassBase::Class(class) => Cow::Borrowed(class.mro_possibilities(db)),
+            ClassBase::Any | ClassBase::Todo | ClassBase::Unknown => {
+                let object = ClassBase::Class(KnownClass::Object.to_class(db).expect_class());
+                Cow::Owned(MroPossibilities::Known(Mro::from([self, object])))
+            }
+        }
+    }
+
+    pub(super) fn own_class_member(self, db: &'db dyn Db, member: &str) -> Type<'db> {
+        match self {
+            Self::Any => Type::Any,
+            Self::Todo => Type::Todo,
+            Self::Unknown => Type::Unknown,
+            Self::Class(class) => class.own_class_member(db, member),
+        }
+    }
+
+    pub(super) fn display(self, db: &'db dyn Db) -> String {
+        match self {
+            Self::Any => "ClassBase(Any)".to_string(),
+            Self::Todo => "ClassBase(Todo)".to_string(),
+            Self::Unknown => "ClassBase(Unknown)".to_string(),
+            Self::Class(class) => format!("ClassBase(<class '{}'>)", class.name(db)),
+        }
+    }
+}
+
+impl<'db> From<Type<'db>> for ClassBase<'db> {
+    fn from(value: Type<'db>) -> Self {
+        match value {
+            Type::Any => ClassBase::Any,
+            Type::Todo => ClassBase::Todo,
+            Type::Unknown => ClassBase::Unknown,
+            Type::Class(class) => ClassBase::Class(class),
+            // TODO support `__mro_entries__`?? --Alex
+            Type::Instance(_) => ClassBase::Todo,
+            // These are all errors:
+            Type::Unbound
+            | Type::BooleanLiteral(_)
+            | Type::BytesLiteral(_)
+            | Type::Function(_)
+            | Type::IntLiteral(_)
+            | Type::LiteralString
+            | Type::Module(_)
+            | Type::Never
+            | Type::None
+            | Type::StringLiteral(_)
+            | Type::Tuple(_) => ClassBase::Unknown,
+            // It *might* be possible to support these,
+            // but it would make our logic much more complicated and less performant
+            // (we'd have to consider multiple possible mros for any given class definition).
+            // Neither mypy nor pyright supports these, so for now at least it seems reasonable
+            // to treat these as an error.
+            Type::Intersection(_) | Type::Union(_) => ClassBase::Unknown,
+        }
+    }
+}
+
+impl<'db> From<&Type<'db>> for ClassBase<'db> {
+    fn from(value: &Type<'db>) -> Self {
+        Self::from(*value)
+    }
+}
+
+impl<'db> From<ClassBase<'db>> for Type<'db> {
+    fn from(value: ClassBase<'db>) -> Self {
+        match value {
+            ClassBase::Class(class) => Type::Class(class),
+            ClassBase::Any => Type::Any,
+            ClassBase::Todo => Type::Todo,
+            ClassBase::Unknown => Type::Unknown,
+        }
+    }
+}
+
+impl<'db> From<&ClassBase<'db>> for Type<'db> {
+    fn from(value: &ClassBase<'db>) -> Self {
+        Self::from(*value)
+    }
+}
+
+#[derive(PartialEq, Eq, Default, Hash, Clone, Debug)]
+pub(super) struct Mro<'db>(VecDeque<ClassBase<'db>>);
+
+impl<'db> Mro<'db> {
+    pub(super) fn iter(&self) -> std::collections::vec_deque::Iter<'_, ClassBase<'db>> {
+        self.0.iter()
+    }
+
+    pub(super) fn display(&self, db: &'db dyn Db) -> Vec<String> {
+        self.0.iter().map(|base| base.display(db)).collect()
+    }
+
+    fn push(&mut self, element: ClassBase<'db>) {
+        self.0.push_back(element);
+    }
+}
+
+impl<'db, const N: usize> From<[ClassBase<'db>; N]> for Mro<'db> {
+    fn from(value: [ClassBase<'db>; N]) -> Self {
+        Self(VecDeque::from(value))
+    }
+}
+
+impl<'db> FromIterator<ClassBase<'db>> for Mro<'db> {
+    fn from_iter<T: IntoIterator<Item = ClassBase<'db>>>(iter: T) -> Self {
+        Self(iter.into_iter().collect())
+    }
+}
+
+impl<'db> From<Mro<'db>> for VecDeque<ClassBase<'db>> {
+    fn from(value: Mro<'db>) -> Self {
+        value.0
+    }
+}
+
+impl<'a, 'db> IntoIterator for &'a Mro<'db> {
+    type IntoIter = std::collections::vec_deque::Iter<'a, ClassBase<'db>>;
+    type Item = &'a ClassBase<'db>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+impl<'db> IntoIterator for Mro<'db> {
+    type IntoIter = std::collections::vec_deque::IntoIter<ClassBase<'db>>;
+    type Item = ClassBase<'db>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
+/// Implementation of the [C3-merge algorithm] for calculating a Python class's
+/// [method resolution order].
+///
+/// [C3-merge algorithm]: https://docs.python.org/3/howto/mro.html#python-2-3-mro
+/// [method resolution order]: https://docs.python.org/3/glossary.html#term-method-resolution-order
+pub(super) fn c3_merge(mut seqs: Vec<VecDeque<ClassBase>>) -> Option<Mro> {
+    let mut mro = Mro::default();
+
+    loop {
+        seqs.retain(|seq| !seq.is_empty());
+
+        if seqs.is_empty() {
+            return Some(mro);
+        }
+
+        let mut candidate: Option<ClassBase> = None;
+
+        for seq in &seqs {
+            let maybe_candidate = seq[0];
+
+            let is_valid_candidate = !seqs
+                .iter()
+                .any(|seq| seq.iter().skip(1).any(|base| base == &maybe_candidate));
+
+            if is_valid_candidate {
+                candidate = Some(maybe_candidate);
+                break;
+            }
+        }
+
+        let candidate = candidate?;
+
+        mro.push(candidate);
+
+        for seq in &mut seqs {
+            if seq[0] == candidate {
+                seq.pop_front();
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

A Python class's ["Method Resolution Order"](https://docs.python.org/3/glossary.html#term-method-resolution-order) ("MRO") is the order in which superclasses of that class are traversed by the Python runtime when searching for an attribute (which includes methods) on that class. Accurately inferring a class's MRO is essential for a type checker if it is going to be able to accurately lookup the types of attributes and methods accessed on that class (or instances of that class).

For simple classes, the MRO (which is accessible at runtime via the `__mro__` attribute on a class) is simple:

```pycon
>>> object.__mro__
(<class 'object'>,)
>>> class Foo: pass
... 
>>> Foo.__mro__  # classes without explicit bases implicitly inherit from `object`
(<class '__main__.Foo'>, <class 'object'>)
>>> class Bar(Foo): pass
... 
>>> Bar.__mro__
(<class '__main__.Bar'>, <class '__main__.Foo'>, <class 'object'>)
```

For more complex classes that use multiple inheritance, things can get a bit more complicated, however:

```pycon
>>> class Foo: pass
... 
>>> class Bar(Foo): pass
... 
>>> class Baz(Foo): pass
... 
>>> class Spam(Bar, Baz): pass
... 
>>> Spam.__mro__  # no class ever appears more than once in an `__mro__`
(<class '__main__.Spam'>, <class '__main__.Bar'>, <class '__main__.Baz'>, <class '__main__.Foo'>, <class 'object'>)
```

And for some classes, Python realises that it cannot determine which order the superclasses should be positioned in order to create the MRO at class creation time:

```pycon
>>> class Foo(object, int): pass
... 
Traceback (most recent call last):
  File "<python-input-12>", line 1, in <module>
    class Foo(object, int): pass
TypeError: Cannot create a consistent method resolution order (MRO) for bases object, int
>>> class A: pass
... 
>>> class B: pass
... 
>>> class C(A, B): pass
... 
>>> class D(B, A): pass
... 
>>> class E(C, D): pass
... 
Traceback (most recent call last):
  File "<python-input-17>", line 1, in <module>
    class E(C, D): pass
TypeError: Cannot create a consistent method resolution order (MRO) for bases A, B
```

The algorithm Python uses at runtime to determine what a class's MRO should be is known as the C3 linearisation algorithm. An in-depth description of the motivations and details of the algorithm can be found in [this article](https://docs.python.org/3/howto/mro.html#python-2-3-mro) in the Python docs. The article is quite old, however, and the algorithm given at the bottom of the page is written in Python 2. As part of working on this PR, I translated the algorithm first into Python 3 (see [this gist](https://gist.github.com/AlexWaygood/674db1fce6856a90f251f63e73853639)), and then into Rust (the `c3_merge` function in `mro.rs` in this PR). In order for us to correctly infer a class's MRO, we need our own implementation of the C3 linearisation algorithm.

The C3 linearisation algorithm isn't _too_ complicated by itself. However, there are additional complexities for a type checker when it comes to calculating a class's MRO. The C3 linearisation algorithm calculates an MRO from a list of bases given to it: but what if one of the bases of a class is inferred as a `Union` type by red-knot? In this situation, there will be multiple possible lists of bases, and therefore potentially multiple possible MROs, for that single class. For this reason, mypy and pyright both reject classes that have an object in their bases list which is inferred as a `Union` type, as it adds a fair amount of complexity to the semantic model. However, this PR nonetheless attempts to support such cases, for several reasons:
- As long as all elements in the union are valid class bases, it's perfectly type-safe. We should, in general, try not to emit false positives on valid code.
- It's nice to support more things than mypy and pyright do; we should attempt to provide added value over these existing type checkers that goes beyond simply being faster
- Doing multi-version checking will probably be difficult without this feature due to the way that typeshed branches on `sys.version_info` conditions, which means that we will likely often infer a union for an object used as a class base.

As well as having to adapt the C3 linearisation algorithm to account for the possibility that a class might have a `Union` in its bases, I also had to make some changes to account for the fact that a class might have a dynamic type in its bases: in our current model, we have three dynamic types, which are `Unknown`, `Any` and `Todo`. This PR takes the simple approach of deciding that the MRO of `Any` is `[Any, object]`, the MRO of `Unknown` is `[Unknown, object]`, and the MRO of `Todo` is `[Todo, object]`; other than that, they are not treated particularly specially by the C3 linearisation algorithm. Other than simplicity, this has a few advantages:
- It matches the runtime:
  ```pycon
  >>> from typing import Any
  >>> Any.__mro__
  (typing.Any, <class 'object'>)
  ```
- It means that they behave just like any other class base in Python: an invariant upheld by all other class bases in Python is that they all inherit from `object`.

Dynamic types will have to be treated specially when it comes to attribute and method access from these types; however, that is for a separate PR.

## Implementation strategy

The implementation is encapsulated in a new `red_knot_python_semantic` submodule, `types/mro.rs`. `ClassType::mro_possibilities` returns a HashSet of possible MROs that the class could have given its bases, and this calls out to functions in the `mro.rs` submodule. If there are no union types in the bases list (or in any of the bases of those bases), then there will be exactly one possible MRO for the class; but if there are any union types in the class's bases or the bases of those bases (etc.), then the class could have one of several possible MROs. At each stage, the implementation tries to avoid forking if possible. I've attempted to optimise the implementation based on the assumption that most classes will not have union types in their bases (or the bases of their bases, etc.); there are various fast paths that are predicated on this.

It's necessary for us to emit a diagnostic if we can determine that a particular list of bases will (or could) cause a `TypeError` to be raised at runtime due to an unresolvable MRO. However, we can't do this while creating the `ClassType` and storing it in `self.types.declarations` in `infer.rs`, as we need to know the bases of the class in order to determine its MRO, and some of the bases may be deferred. This PR therefore iterates over all classes in a certain scope after all types (including deferred types) have been inferred, as part of `TypeInferenceBuilder::infer_region_scope`. For types that will (or could) raise an exception due to an invalid MRO, we infer the MRO as being `[<class in question>, Unknown, object]` as well as emitting the diagnostic.

## For discussion

There's a performance regression of around 4% on the codspeed incremental benchmark. I've tried to get it down a bit, and it has gone down a bit, but I'm out of ideas for how to reduce it further. Open to suggestions :-)

## Test Plan

Beautiful Markdown tests added using @carljm's new test framework. Several tests taken from https://docs.python.org/3/howto/mro.html#python-2-3-mro.