### PR TITLE
[red-knot] Use colors to improve readability of `mdtest` output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2134,6 +2134,7 @@ name = "red_knot_test"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "colored",
  "once_cell",
  "red_knot_python_semantic",
  "red_knot_vendored",

--- a/crates/red_knot_test/Cargo.toml
+++ b/crates/red_knot_test/Cargo.toml
@@ -20,6 +20,7 @@ ruff_source_file = { workspace = true }
 ruff_text_size = { workspace = true }
 
 anyhow = { workspace = true }
+colored = { workspace = true }
 once_cell = { workspace = true }
 regex = { workspace = true }
 rustc-hash = { workspace = true }

--- a/crates/red_knot_test/src/lib.rs
+++ b/crates/red_knot_test/src/lib.rs
@@ -35,7 +35,7 @@ pub fn run(path: &PathBuf, title: &str) {
             println!("\n{}\n", test.name().bold().underline());
 
             for (path, by_line) in failures {
-                println!("{}", format!("  {path}").bold());
+                println!("{}", path.as_str().bold());
                 for (line_number, failures) in by_line.iter() {
                     for failure in failures {
                         let line_info = format!("line {line_number}:").cyan();

--- a/crates/red_knot_test/src/lib.rs
+++ b/crates/red_knot_test/src/lib.rs
@@ -1,3 +1,4 @@
+use colored::Colorize;
 use parser as test_parser;
 use red_knot_python_semantic::types::check_types;
 use ruff_db::files::system_path_to_file;
@@ -31,10 +32,10 @@ pub fn run(path: &PathBuf, title: &str) {
     for test in suite.tests() {
         if let Err(failures) = run_test(&test) {
             any_failures = true;
-            println!("{}", test.name());
+            println!("\n{}\n", test.name().bold().underline());
 
             for (path, by_line) in failures {
-                println!("  {path}");
+                println!("{}", format!("  {path}").bold());
                 for (line, failures) in by_line.iter() {
                     for failure in failures {
                         println!("    line {line}: {failure}");
@@ -44,6 +45,8 @@ pub fn run(path: &PathBuf, title: &str) {
             }
         }
     }
+
+    println!("{}\n", "-".repeat(50));
 
     assert!(!any_failures, "Some tests failed.");
 }

--- a/crates/red_knot_test/src/lib.rs
+++ b/crates/red_knot_test/src/lib.rs
@@ -36,9 +36,10 @@ pub fn run(path: &PathBuf, title: &str) {
 
             for (path, by_line) in failures {
                 println!("{}", format!("  {path}").bold());
-                for (line, failures) in by_line.iter() {
+                for (line_number, failures) in by_line.iter() {
                     for failure in failures {
-                        println!("    line {line}: {failure}");
+                        let line_info = format!("line {line_number}:").cyan();
+                        println!("    {line_info} {failure}");
                     }
                 }
                 println!();

--- a/crates/red_knot_test/src/matcher.rs
+++ b/crates/red_knot_test/src/matcher.rs
@@ -364,6 +364,8 @@ mod tests {
     }
 
     fn get_result(source: &str, diagnostics: Vec<TestDiagnostic>) -> Result<(), FailuresByLine> {
+        colored::control::set_override(false);
+
         let mut db = crate::db::Db::setup(SystemPathBuf::from("/src"));
         db.write_file("/src/test.py", source).unwrap();
         let file = system_path_to_file(&db, "/src/test.py").unwrap();

--- a/crates/red_knot_test/src/matcher.rs
+++ b/crates/red_knot_test/src/matcher.rs
@@ -3,7 +3,7 @@
 use crate::assertion::{Assertion, ErrorAssertion, InlineFileAssertions};
 use crate::db::Db;
 use crate::diagnostic::SortedDiagnostics;
-use colored::{ColoredString, Colorize};
+use colored::Colorize;
 use red_knot_python_semantic::types::TypeCheckDiagnostic;
 use ruff_db::files::File;
 use ruff_db::source::{line_index, source_text, SourceText};
@@ -15,12 +15,12 @@ use std::sync::Arc;
 
 #[derive(Debug, Default)]
 pub(super) struct FailuresByLine {
-    failures: Vec<ColoredString>,
+    failures: Vec<String>,
     lines: Vec<LineFailures>,
 }
 
 impl FailuresByLine {
-    pub(super) fn iter(&self) -> impl Iterator<Item = (OneIndexed, &[ColoredString])> {
+    pub(super) fn iter(&self) -> impl Iterator<Item = (OneIndexed, &[String])> {
         self.lines.iter().map(|line_failures| {
             (
                 line_failures.line_number,
@@ -29,7 +29,7 @@ impl FailuresByLine {
         })
     }
 
-    fn push(&mut self, line_number: OneIndexed, messages: Vec<ColoredString>) {
+    fn push(&mut self, line_number: OneIndexed, messages: Vec<String>) {
         let start = self.failures.len();
         self.failures.extend(messages);
         self.lines.push(LineFailures {
@@ -143,35 +143,34 @@ impl Diagnostic for Arc<TypeCheckDiagnostic> {
 }
 
 trait Unmatched {
-    fn unmatched(&self) -> ColoredString;
+    fn unmatched(&self) -> String;
 }
 
-fn unmatched<'a, T: Unmatched + 'a>(unmatched: &'a [T]) -> Vec<ColoredString> {
+fn unmatched<'a, T: Unmatched + 'a>(unmatched: &'a [T]) -> Vec<String> {
     unmatched.iter().map(Unmatched::unmatched).collect()
 }
 
 trait UnmatchedWithColumn {
-    fn unmatched_with_column(&self, column: OneIndexed) -> ColoredString;
+    fn unmatched_with_column(&self, column: OneIndexed) -> String;
 }
 
 impl Unmatched for Assertion<'_> {
-    fn unmatched(&self) -> colored::ColoredString {
-        format!("unmatched assertion: {self}").color("red")
+    fn unmatched(&self) -> String {
+        format!("{} {self}", "unmatched assertion:".red())
     }
 }
 
 fn maybe_add_undefined_reveal_clarification<T: Diagnostic>(
     diagnostic: &T,
     original: std::fmt::Arguments,
-) -> ColoredString {
+) -> String {
     if diagnostic.rule() == "undefined-reveal" {
         format!(
-            "used built-in `reveal_type`: add a `# revealed` assertion on this line \
-            (original diagnostic: {original})"
+            "{} add a `# revealed` assertion on this line (original diagnostic: {original})",
+            "used built-in `reveal_type`:".yellow()
         )
-        .color("yellow")
     } else {
-        format!("unexpected error: {original}").color("red")
+        format!("{} {original}", "unexpected error:".red())
     }
 }
 
@@ -179,7 +178,7 @@ impl<T> Unmatched for T
 where
     T: Diagnostic,
 {
-    fn unmatched(&self) -> ColoredString {
+    fn unmatched(&self) -> String {
         maybe_add_undefined_reveal_clarification(
             self,
             format_args!(r#"[{}] "{}""#, self.rule(), self.message()),
@@ -191,7 +190,7 @@ impl<T> UnmatchedWithColumn for T
 where
     T: Diagnostic,
 {
-    fn unmatched_with_column(&self, column: OneIndexed) -> ColoredString {
+    fn unmatched_with_column(&self, column: OneIndexed) -> String {
         maybe_add_undefined_reveal_clarification(
             self,
             format_args!(r#"{column} [{}] "{}""#, self.rule(), self.message()),
@@ -219,7 +218,7 @@ impl Matcher {
         &self,
         diagnostics: &'a [T],
         assertions: &'a [Assertion<'b>],
-    ) -> Result<(), Vec<ColoredString>>
+    ) -> Result<(), Vec<String>>
     where
         'b: 'a,
     {
@@ -234,7 +233,10 @@ impl Matcher {
                     ..
                 })
             ) {
-                failures.push("invalid assertion: no rule or message text".color("red"));
+                failures.push(format!(
+                    "{} no rule or message text",
+                    "invalid assertion:".red()
+                ));
                 continue;
             }
             if !self.matches(assertion, &mut unmatched) {
@@ -321,7 +323,6 @@ impl Matcher {
 #[cfg(test)]
 mod tests {
     use super::FailuresByLine;
-    use colored::ColoredString;
     use ruff_db::files::system_path_to_file;
     use ruff_db::system::{DbWithTestSystem, SystemPathBuf};
     use ruff_python_trivia::textwrap::dedent;
@@ -386,7 +387,7 @@ mod tests {
             .collect();
         let failures: Vec<(OneIndexed, Vec<String>)> = failures
             .iter()
-            .map(|(idx, msgs)| (idx, msgs.iter().map(ColoredString::to_string).collect()))
+            .map(|(idx, msgs)| (idx, msgs.to_vec()))
             .collect();
 
         assert_eq!(failures, expected);


### PR DESCRIPTION
## Summary

Screenshot of previous output when tests failed:

![image](https://github.com/user-attachments/assets/33c6c126-f173-496f-97fd-db7a1591ada8)

---

With this PR:

![image](https://github.com/user-attachments/assets/7c079351-098c-41de-8a03-0f21c120eee0)

## Test Plan

I applied this diff to the branch for this PR, and ran `cargo test -p red_knot_python_semantic`, then took the above screenshots:

````diff
--- a/crates/red_knot_python_semantic/resources/mdtest/numbers.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/numbers.md
@@ -23,7 +23,7 @@ reveal_type(9223372036854775808)  # revealed: int
 There aren't literal float types, but we infer the general float type:
 
 ```py
-reveal_type(1.0)  # revealed: float
+reveal_type(1.0)  # revealed: str
 ```
 
 ## Complex
@@ -31,5 +31,5 @@ reveal_type(1.0)  # revealed: float
 Same for complex:
 
 ```py
-reveal_type(2j)  # revealed: complex
+reveal_type(2j)
 ```
````
