### PR TITLE
[`flake8-pyi`] - fix dropped exprs in `PYI030` autofix

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI030.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI030.py
@@ -87,3 +87,7 @@ field24: typing.Union[Literal[1], typing.Union[Literal[2], typing.Union[Literal[
 
 # Should use the first literal subscript attribute when fixing
 field25: typing.Union[typing_extensions.Literal[1], typing.Union[Literal[2], typing.Union[Literal[3], Literal[4]]], str]  # Error
+
+from typing import IO, Literal
+
+InlineOption = Literal["a"] | Literal["b"] | IO[str]

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/unnecessary_literal_union.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/unnecessary_literal_union.rs
@@ -80,6 +80,8 @@ pub(crate) fn unnecessary_literal_union<'a>(checker: &mut Checker, expr: &'a Exp
                 } else {
                     literal_exprs.push(slice);
                 }
+            } else {
+                other_exprs.push(expr);
             }
         } else {
             other_exprs.push(expr);

--- a/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI030_PYI030.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI030_PYI030.py.snap
@@ -517,6 +517,8 @@ PYI030.py:89:10: PYI030 [*] Multiple literal members in a union. Use a single li
 88 | # Should use the first literal subscript attribute when fixing
 89 | field25: typing.Union[typing_extensions.Literal[1], typing.Union[Literal[2], typing.Union[Literal[3], Literal[4]]], str]  # Error
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI030
+90 | 
+91 | from typing import IO, Literal
    |
    = help: Replace with a single `Literal`
 
@@ -526,5 +528,22 @@ PYI030.py:89:10: PYI030 [*] Multiple literal members in a union. Use a single li
 88 88 | # Should use the first literal subscript attribute when fixing
 89    |-field25: typing.Union[typing_extensions.Literal[1], typing.Union[Literal[2], typing.Union[Literal[3], Literal[4]]], str]  # Error
    89 |+field25: typing.Union[typing_extensions.Literal[1, 2, 3, 4], str]  # Error
+90 90 | 
+91 91 | from typing import IO, Literal
+92 92 | 
 
+PYI030.py:93:16: PYI030 [*] Multiple literal members in a union. Use a single literal, e.g. `Literal["a", "b"]`
+   |
+91 | from typing import IO, Literal
+92 | 
+93 | InlineOption = Literal["a"] | Literal["b"] | IO[str]
+   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI030
+   |
+   = help: Replace with a single `Literal`
 
+ℹ Safe fix
+90 90 | 
+91 91 | from typing import IO, Literal
+92 92 | 
+93    |-InlineOption = Literal["a"] | Literal["b"] | IO[str]
+   93 |+InlineOption = Literal["a", "b"] | IO[str]


### PR DESCRIPTION
## Summary

Adds fix for dropped exprs from PYI030 autofix

Fixes #13685

## Test Plan

`cargo test`
