### PR TITLE
Update to macOS14 runner image

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -63,7 +63,7 @@ jobs:
 
   macos-x86_64:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-build') }}
-    runs-on: macos-13
+    runs-on: macos-14
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -63,7 +63,7 @@ jobs:
 
   macos-x86_64:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-build') }}
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Summary

Updates Github Actions macOS runner images to use macOS 13, since runners using 12 will be unavailable on/around December 3rd of this year.

Closes #13231 

For more info, see that issue, as well as https://github.com/actions/runner-images/issues/10721. There will be a 10-hour brownout on each Monday in November.

## Test Plan

I did not. 😎 (until after the checks passed)