### PR TITLE
[`pylint`] - restrict `iteration-over-set` to only work on sets of literals (`PLC0208`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pylint/iteration_over_set.py
+++ b/crates/ruff_linter/resources/test/fixtures/pylint/iteration_over_set.py
@@ -56,3 +56,7 @@ for item in {1, 2, 3, 4, 5, 6, 2 // 1}:  # operations in set literals are fine
 
 for item in {1, 2, 3, 4, 5, 6, int("7")}:  # calls in set literals are fine
     print(f"I like {item}.")
+
+for item in {1, 2, 2}:  # duplicate literals will be ignored
+    # B033 catches this
+    print(f"I like {item}.")

--- a/crates/ruff_linter/resources/test/fixtures/pylint/iteration_over_set.py
+++ b/crates/ruff_linter/resources/test/fixtures/pylint/iteration_over_set.py
@@ -50,3 +50,9 @@ for number in {i for i in range(10)}:  # set comprehensions are fine
 
 for item in {*numbers_set, 4, 5, 6}:  # set unpacking is fine
     print(f"I like {item}.")
+
+for item in {1, 2, 3, 4, 5, 6, 2 // 1}:  # operations in set literals are fine
+    print(f"I like {item}.")
+
+for item in {1, 2, 3, 4, 5, 6, int("7")}:  # calls in set literals are fine
+    print(f"I like {item}.")

--- a/crates/ruff_linter/src/rules/pylint/rules/iteration_over_set.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/iteration_over_set.rs
@@ -7,7 +7,8 @@ use rustc_hash::{FxBuildHasher, FxHashSet};
 use crate::checkers::ast::Checker;
 
 /// ## What it does
-/// Checks for iterations over `set` literals.
+/// Checks for iteration over a `set` literal where each element in the set is
+/// itself a literal value.
 ///
 /// ## Why is this bad?
 /// Iterating over a `set` is less efficient than iterating over a sequence

--- a/crates/ruff_linter/src/rules/pylint/rules/iteration_over_set.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/iteration_over_set.rs
@@ -46,7 +46,10 @@ pub(crate) fn iteration_over_set(checker: &mut Checker, expr: &Expr) {
         return;
     };
 
-    if set.iter().any(Expr::is_starred_expr) {
+    // Only suggest a fix if all elements are literals.
+    // This is because we can't determine if the set is used to de-dupe
+    // the output values of a call, operation, etc.
+    if !set.iter().all(Expr::is_literal_expr) {
         return;
     }
 

--- a/crates/ruff_linter/src/rules/pylint/rules/iteration_over_set.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/iteration_over_set.rs
@@ -2,7 +2,7 @@ use ruff_diagnostics::{AlwaysFixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::{comparable::ComparableExpr, Expr};
 use ruff_text_size::Ranged;
-use rustc_hash::FxHashSet;
+use rustc_hash::{FxBuildHasher, FxHashSet};
 
 use crate::checkers::ast::Checker;
 
@@ -47,19 +47,16 @@ pub(crate) fn iteration_over_set(checker: &mut Checker, expr: &Expr) {
         return;
     };
 
-    let mut seen_values: FxHashSet<ComparableExpr> = FxHashSet::default();
+    if set.iter().any(|value| !value.is_literal_expr()) {
+        return;
+    }
 
+    let mut seen_values = FxHashSet::with_capacity_and_hasher(set.len(), FxBuildHasher);
     for value in set {
-        if value.is_literal_expr() {
-            let comparable_value = ComparableExpr::from(value);
-
-            if !seen_values.insert(comparable_value) {
-                // if the set contains a duplicate literal value, early exit.
-                // rule `B033` can catch that.
-                return;
-            }
-        } else {
-            // If the set contains a non-literal expression, early exit.
+        let comparable_value = ComparableExpr::from(value);
+        if !seen_values.insert(comparable_value) {
+            // if the set contains a duplicate literal value, early exit.
+            // rule `B033` can catch that.
             return;
         }
     }


### PR DESCRIPTION
## Summary

Restricts `iteration-over-set` to only work on sets of literals. There are valid use cases for iterating over a set, for de-duplication purposes.

Fixes #11694 

## Test Plan

`cargo test`
