### PR TITLE
Downgrade benchmarks CI job to ubuntu 22

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -608,7 +608,7 @@ jobs:
           just test
 
   benchmarks:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: determine_changes
     if: ${{ github.repository == 'astral-sh/ruff' && (needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/main') }}
     timeout-minutes: 20


### PR DESCRIPTION
## Summary

GitHub is rolling out their ubuntu 24 runner image but Codspeed doesn't support ubuntu 24 yet. 

"Downgrade" the benchmarks runner to ubuntu 22.

I opened a [feature request](https://discord.com/channels/1065233827569598464/1295280911205666817/1295280911205666817) in codspeed's discord for ubuntu 24 support. 

## Test Plan

See GitHub checks
