### PR TITLE
Fix `mkdocs` CI job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -518,6 +518,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
       - name: "Add SSH key"
         if: ${{ env.MKDOCS_INSIDERS_SSH_KEY_EXISTS == 'true' }}
         uses: webfactory/ssh-agent@v0.9.0
@@ -525,13 +527,15 @@ jobs:
           ssh-private-key: ${{ secrets.MKDOCS_INSIDERS_SSH_KEY }}
       - name: "Install Rust toolchain"
         run: rustup show
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
       - uses: Swatinem/rust-cache@v2
       - name: "Install Insiders dependencies"
         if: ${{ env.MKDOCS_INSIDERS_SSH_KEY_EXISTS == 'true' }}
-        run: pip install -r docs/requirements-insiders.txt
+        run: uv pip install -r docs/requirements-insiders.txt --system
       - name: "Install dependencies"
         if: ${{ env.MKDOCS_INSIDERS_SSH_KEY_EXISTS != 'true' }}
-        run: pip install -r docs/requirements.txt
+        run: uv pip install -r docs/requirements.txt --system
       - name: "Update README File"
         run: python scripts/transform_readme.py --target mkdocs
       - name: "Generate docs"


### PR DESCRIPTION
## Summary

This PR specifies sets an explicit python version for `setup-python` because it otherwise skips installing any python version and running pip then fails because it doesn't allow installing into an externally managed python installation. 

I used this as a chance to migrate the workflow to `uv pip`

## Test Plan

See CI