### PR TITLE
Allow `ipytest` cell magic

### DIFF
--- a/crates/ruff_notebook/src/cell.rs
+++ b/crates/ruff_notebook/src/cell.rs
@@ -238,9 +238,19 @@ impl Cell {
             //
             // This is to avoid false positives when these variables are referenced
             // elsewhere in the notebook.
+            //
+            // Refer https://github.com/astral-sh/ruff/issues/13718 for `ipytest`.
             !matches!(
                 command,
-                "capture" | "debug" | "prun" | "pypy" | "python" | "python3" | "time" | "timeit"
+                "capture"
+                    | "debug"
+                    | "ipytest"
+                    | "prun"
+                    | "pypy"
+                    | "python"
+                    | "python3"
+                    | "time"
+                    | "timeit"
             )
         })
     }


### PR DESCRIPTION
## Summary

fixes: #13718 

## Test Plan

Using the notebook as mentioned in https://github.com/astral-sh/ruff/issues/13718#issuecomment-2410631674, this PR does not give the "F821 Undefined name `test_sorted`" diagnostic.
