### PR TITLE
[red-knot] feat: Inference for `BytesLiteral` comparisons

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/comparison/byte_literals.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/comparison/byte_literals.md
@@ -1,5 +1,8 @@
 ### Comparison: Byte literals
 
+These tests assert that we infer precise `Literal` types for comparisons between objects
+inferred as having `Literal` bytes types:
+
 ```py
 reveal_type(b"abc" == b"abc")  # revealed: Literal[True]
 reveal_type(b"abc" == b"ab")   # revealed: Literal[False]

--- a/crates/red_knot_python_semantic/resources/mdtest/comparison/byte_literals.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/comparison/byte_literals.md
@@ -1,0 +1,40 @@
+### Comparison: Byte literals
+
+```py
+reveal_type(b"abc" == b"abc")  # revealed: Literal[True]
+reveal_type(b"abc" == b"ab")   # revealed: Literal[False]
+
+reveal_type(b"abc" != b"abc")  # revealed: Literal[False]
+reveal_type(b"abc" != b"ab")   # revealed: Literal[True]
+
+reveal_type(b"abc" < b"abd")   # revealed: Literal[True]
+reveal_type(b"abc" < b"abb")   # revealed: Literal[False]
+
+reveal_type(b"abc" <= b"abc")  # revealed: Literal[True]
+reveal_type(b"abc" <= b"abb")  # revealed: Literal[False]
+
+reveal_type(b"abc" > b"abd")   # revealed: Literal[False]
+reveal_type(b"abc" > b"abb")   # revealed: Literal[True]
+
+reveal_type(b"abc" >= b"abc")  # revealed: Literal[True]
+reveal_type(b"abc" >= b"abd")  # revealed: Literal[False]
+
+reveal_type(b"" in b"")                      # revealed: Literal[True]
+reveal_type(b"" in b"abc")                   # revealed: Literal[True]
+reveal_type(b"abc" in b"")                   # revealed: Literal[False]
+reveal_type(b"ab" in b"abc")                 # revealed: Literal[True]
+reveal_type(b"abc" in b"abc")                # revealed: Literal[True]
+reveal_type(b"d" in b"abc")                  # revealed: Literal[False]
+reveal_type(b"ac" in b"abc")                 # revealed: Literal[False]
+reveal_type(b"\x81\x82" in b"\x80\x81\x82")  # revealed: Literal[True]
+reveal_type(b"\x82\x83" in b"\x80\x81\x82")  # revealed: Literal[False]
+
+reveal_type(b"ab" not in b"abc")             # revealed: Literal[False]
+reveal_type(b"ac" not in b"abc")             # revealed: Literal[True]
+
+reveal_type(b"abc" is b"abc")      # revealed: bool
+reveal_type(b"abc" is b"ab")       # revealed: Literal[False]
+
+reveal_type(b"abc" is not b"abc")  # revealed: bool
+reveal_type(b"abc" is not b"ab")   # revealed: Literal[True]
+```


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Implements inference for `BytesLiteral` comparisons along the lines of https://github.com/astral-sh/ruff/pull/13634. A refactoring that unifies some code with what we do for `StringLiteral` (and possibly other cases, see also #13712) is planned for a later PR.

closes #13687

## Test Plan

Added tests using the new Markdown framework. I added the tests in `mdtest/comparison/byte_literals.md`, following the convention proposed in [this comment](https://github.com/astral-sh/ruff/pull/13712#discussion_r1797197213). This is somewhat in conflict with the proposed structure in #13719 which puts the `StringLiteral` tests under `mdtest/boolean.md`, so this will have to be sorted out after we agreed on a naming/grouping convention for these tests.