### PR TITLE
[red-knot] Add a build.rs file to `red_knot_python_semantic`, and document pitfalls of using `rstest` in combination with `mdtest`

### DIFF
--- a/crates/red_knot_python_semantic/build.rs
+++ b/crates/red_knot_python_semantic/build.rs
@@ -1,0 +1,4 @@
+/// Rebuild the crate if a test file is added or removed from
+pub fn main() {
+    println!("cargo:rerun-if-changed=resources/mdtest/*.md");
+}

--- a/crates/red_knot_python_semantic/build.rs
+++ b/crates/red_knot_python_semantic/build.rs
@@ -1,4 +1,4 @@
 /// Rebuild the crate if a test file is added or removed from
 pub fn main() {
-    println!("cargo:rerun-if-changed=resources/mdtest/*.md");
+    println!("cargo:rerun-if-changed=resources/mdtest");
 }

--- a/crates/red_knot_test/README.md
+++ b/crates/red_knot_test/README.md
@@ -34,6 +34,19 @@ syntax, it's just how this README embeds an example mdtest Markdown document.)
 See actual example mdtest suites in
 [`crates/red_knot_python_semantic/resources/mdtest`](https://github.com/astral-sh/ruff/tree/main/crates/red_knot_python_semantic/resources/mdtest).
 
+> [!NOTE]
+> If you use `rstest` to generate a separate test for all Markdown files in a certain directory,
+> as with the example in `crates/red_knot_python_semantic/tests/mdtest.rs`,
+> you will likely want to also make sure that the crate the tests are in is rebuilt every time a
+> Markdown file is added or removed from the directory. See
+> [`crates/red_knot_python_semantic/build.rs`](https://github.com/astral-sh/ruff/tree/main/crates/red_knot_python_semantic/build.rs)
+> for an example of how to do this.
+>
+> This is because `rstest` generates its tests at build time rather than at runtime.
+> Without the `build.rs` file to force a rebuild when a Markdown file is added or removed,
+> a new Markdown test suite might not be run unless some other change in the crate caused a rebuild
+> following the addition of the new test file.
+
 ## Assertions
 
 Two kinds of assertions are supported: `# revealed:` (shown above) and `# error:`.

--- a/crates/red_knot_test/README.md
+++ b/crates/red_knot_test/README.md
@@ -34,8 +34,7 @@ syntax, it's just how this README embeds an example mdtest Markdown document.)
 See actual example mdtest suites in
 [`crates/red_knot_python_semantic/resources/mdtest`](https://github.com/astral-sh/ruff/tree/main/crates/red_knot_python_semantic/resources/mdtest).
 
-> [!NOTE]
-> If you use `rstest` to generate a separate test for all Markdown files in a certain directory,
+> ℹ️ Note: If you use `rstest` to generate a separate test for all Markdown files in a certain directory,
 > as with the example in `crates/red_knot_python_semantic/tests/mdtest.rs`,
 > you will likely want to also make sure that the crate the tests are in is rebuilt every time a
 > Markdown file is added or removed from the directory. See


### PR DESCRIPTION
## Summary

Fixes #13732. `rstest` generates tests at build time rather than at runtime, so it doesn't necessarily notice new Markdown tests being added to a `resources` directory unless you add some mechanism to force a rebuild of the crate. The [`rstest` docs](https://docs.rs/rstest/0.23.0/rstest/attr.rstest.html#files-path-as-input-arguments) recommend using a `build.rs` script for this purpose; I've done so here for the `red_knot_python_semantic` crate, and added some docs to the `red_knot_test` README so that we don't forget to do so when adding `mdtest`-based tests to other red-knot crates.

## Test Plan

I locally tested by adding a new Markdown test file to `crates/red_knot_python_semantic/resources/mdtest` with some deliberate errors. I then ran `cargo test -p red_knot_python_semantic` (without having made any other changes to the crate that would have triggered a rebuild). The `build.rs` file successfully forced a rebuild, and the test correctly failed.

~~Here's a screenshot of how the `NOTE` block I've added to the README is rendered on GitHub:~~

<details>
<summary>Screenshot</summary>

![image](https://github.com/user-attachments/assets/830cbf2b-7237-4be1-ab61-09c70d5b076c)

</details>

~~Unfortunately it doesn't seem to be universal Markdown syntax, e.g. VSCode doesn't render the `NOTE` block in the same way.~~

(Edit: I abandoned the fancy Markdown because our linters hated it.)