### PR TITLE
[red knot] Use memmem::find instead of custom version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2083,6 +2083,7 @@ dependencies = [
  "hashbrown 0.15.0",
  "insta",
  "itertools 0.13.0",
+ "memchr",
  "ordermap",
  "red_knot_test",
  "red_knot_vendored",

--- a/crates/red_knot_python_semantic/Cargo.toml
+++ b/crates/red_knot_python_semantic/Cargo.toml
@@ -34,6 +34,7 @@ hashbrown = { workspace = true }
 smallvec = { workspace = true }
 static_assertions = { workspace = true }
 test-case = { workspace = true }
+memchr = { workspace = true }
 
 [dev-dependencies]
 ruff_db = { workspace = true, features = ["os", "testing"] }

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -2661,8 +2661,8 @@ impl<'db> TypeInferenceBuilder<'db> {
             }
 
             (Type::BytesLiteral(salsa_b1), Type::BytesLiteral(salsa_b2)) => {
-                let b1 = salsa_b1.value(self.db).as_ref();
-                let b2 = salsa_b2.value(self.db).as_ref();
+                let b1 = &**salsa_b1.value(self.db);
+                let b2 = &**salsa_b2.value(self.db);
                 match op {
                     ast::CmpOp::Eq => Some(Type::BooleanLiteral(b1 == b2)),
                     ast::CmpOp::NotEq => Some(Type::BooleanLiteral(b1 != b2)),

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -2661,16 +2661,6 @@ impl<'db> TypeInferenceBuilder<'db> {
             }
 
             (Type::BytesLiteral(salsa_b1), Type::BytesLiteral(salsa_b2)) => {
-                let contains_subsequence = |needle: &[u8], haystack: &[u8]| {
-                    if needle.is_empty() {
-                        true
-                    } else {
-                        haystack
-                            .windows(needle.len())
-                            .any(|window| window == needle)
-                    }
-                };
-
                 let b1 = salsa_b1.value(self.db).as_ref();
                 let b2 = salsa_b2.value(self.db).as_ref();
                 match op {
@@ -2680,8 +2670,12 @@ impl<'db> TypeInferenceBuilder<'db> {
                     ast::CmpOp::LtE => Some(Type::BooleanLiteral(b1 <= b2)),
                     ast::CmpOp::Gt => Some(Type::BooleanLiteral(b1 > b2)),
                     ast::CmpOp::GtE => Some(Type::BooleanLiteral(b1 >= b2)),
-                    ast::CmpOp::In => Some(Type::BooleanLiteral(contains_subsequence(b1, b2))),
-                    ast::CmpOp::NotIn => Some(Type::BooleanLiteral(!contains_subsequence(b1, b2))),
+                    ast::CmpOp::In => {
+                        Some(Type::BooleanLiteral(memchr::memmem::find(b2, b1).is_some()))
+                    }
+                    ast::CmpOp::NotIn => {
+                        Some(Type::BooleanLiteral(memchr::memmem::find(b2, b1).is_none()))
+                    }
                     ast::CmpOp::Is => {
                         if b1 == b2 {
                             Some(KnownClass::Bool.to_instance(self.db))


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

This is a follow-up on #13746:

- Use `memmem::find` instead of rolling our own inferior version.
- Avoid `x.as_ref()` calls using `&**x`

## Test Plan

—