### PR TITLE
Fix TODO directive out of bounds acccess

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_fixme/T00.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_fixme/T00.py
@@ -6,3 +6,8 @@
 # hack: hack
 # FIXME: fixme
 # fixme: fixme
+
+# test # TODO: todo
+
+
+# #d#

--- a/crates/ruff_linter/src/directives.rs
+++ b/crates/ruff_linter/src/directives.rs
@@ -316,7 +316,7 @@ impl<'a> TodoDirective<'a> {
             // Shrink the subset to check for the next phrase starting with "#".
             if let Some(new_offset) = trimmed.find('#') {
                 relative_offset += TextSize::try_from(new_offset).unwrap();
-                subset = &subset[relative_offset.to_usize()..];
+                subset = &comment[relative_offset.to_usize()..];
             } else {
                 break;
             };

--- a/crates/ruff_linter/src/rules/flake8_fixme/snapshots/ruff_linter__rules__flake8_fixme__tests__line-contains-fixme_T00.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_fixme/snapshots/ruff_linter__rules__flake8_fixme__tests__line-contains-fixme_T00.py.snap
@@ -11,11 +11,11 @@ T00.py:7:3: FIX001 Line contains FIXME, consider resolving the issue
   |
 
 T00.py:8:3: FIX001 Line contains FIXME, consider resolving the issue
-  |
-6 | # hack: hack
-7 | # FIXME: fixme
-8 | # fixme: fixme
-  |   ^^^^^ FIX001
-  |
-
-
+   |
+ 6 | # hack: hack
+ 7 | # FIXME: fixme
+ 8 | # fixme: fixme
+   |   ^^^^^ FIX001
+ 9 | 
+10 | # test # TODO: todo
+   |

--- a/crates/ruff_linter/src/rules/flake8_fixme/snapshots/ruff_linter__rules__flake8_fixme__tests__line-contains-todo_T00.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_fixme/snapshots/ruff_linter__rules__flake8_fixme__tests__line-contains-todo_T00.py.snap
@@ -18,4 +18,10 @@ T00.py:2:3: FIX002 Line contains TODO, consider resolving the issue
 4 | # xxx: xxx
   |
 
-
+T00.py:10:10: FIX002 Line contains TODO, consider resolving the issue
+   |
+ 8 | # fixme: fixme
+ 9 | 
+10 | # test # TODO: todo
+   |          ^^^^ FIX002
+   |


### PR DESCRIPTION
## Summary

Fixes an out of bound access that I introduced https://github.com/astral-sh/ruff/pull/13640 where the old code was incorrect too, because it didn't handle joined comments correctly.

This PR fixes the out of bound access and adds a test for joined comments (`# test # TODO: fixme`).

Fixes https://github.com/astral-sh/ruff/issues/13755

## Test Plan

See added tests
