### PR TITLE
[red knot] Fix narrowing for '… is not …' type guards, add '… is …' type guards

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/narrow/conditionals_is.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/narrow/conditionals_is.md
@@ -1,0 +1,26 @@
+# Narrowing for `is` conditionals
+
+## `is None`
+
+```py
+x = None if flag else 1
+
+if x is None:
+    # TODO the following should be simplified to 'None'
+    reveal_type(x)  # revealed: None | Literal[1] & None
+
+reveal_type(x)  # revealed: None | Literal[1]
+```
+
+## `is` for other types
+
+```py
+x = 345
+y = x if flag else None
+
+if y is x:
+    # TODO the following should be simplified to 'Literal[345]'
+    reveal_type(y)  # revealed: Literal[345] | None & Literal[345]
+
+reveal_type(y)  # revealed: Literal[345] | None
+```

--- a/crates/red_knot_python_semantic/resources/mdtest/narrow/conditionals_is.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/narrow/conditionals_is.md
@@ -15,12 +15,15 @@ reveal_type(x)  # revealed: None | Literal[1]
 ## `is` for other types
 
 ```py
-x = 345
+class A:
+    ...
+
+x = A()
 y = x if flag else None
 
 if y is x:
-    # TODO the following should be simplified to 'Literal[345]'
-    reveal_type(y)  # revealed: Literal[345] | None & Literal[345]
+    # TODO the following should be simplified to 'A'
+    reveal_type(y)  # revealed: A | None & A
 
-reveal_type(y)  # revealed: Literal[345] | None
+reveal_type(y)  # revealed: A | None
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/narrow/conditionals_is_not.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/narrow/conditionals_is_not.md
@@ -1,0 +1,37 @@
+# Narrowing for `is not` conditionals
+
+## `is not None`
+
+The type guard removes `None` from the union type:
+
+```py
+x = None if flag else 1
+
+if x is not None:
+    reveal_type(x)  # revealed: Literal[1]
+
+reveal_type(x)  # revealed: None | Literal[1]
+```
+
+## `is not` for other singleton types
+
+```py
+x = True if flag else False
+reveal_type(x)  # revealed: bool
+
+if x is not False:
+    # TODO the following should be `Literal[True]`
+    reveal_type(x)  # revealed: bool & ~Literal[False]
+```
+
+## `is not` for non-singleton types
+
+Non-singleton types should *not* narrow the type:
+
+```py
+x = [1]
+y = [1]
+
+if x is not y:
+    reveal_type(x)  # revealed: list
+```

--- a/crates/red_knot_python_semantic/resources/mdtest/narrow/conditionals_is_not.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/narrow/conditionals_is_not.md
@@ -35,5 +35,6 @@ x = [1]
 y = [1]
 
 if x is not y:
+    # TODO: should include type parameter: list[int]
     reveal_type(x)  # revealed: list
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/narrow/conditionals_is_not.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/narrow/conditionals_is_not.md
@@ -26,7 +26,9 @@ if x is not False:
 
 ## `is not` for non-singleton types
 
-Non-singleton types should *not* narrow the type:
+Non-singleton types should *not* narrow the type: two instances of a
+non-singleton class may occupy different addresses in memory even if
+they compare equal.
 
 ```py
 x = [1]

--- a/crates/red_knot_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/narrow/match.md
@@ -1,0 +1,17 @@
+# Narrowing for `match` statements
+
+## Single `match` pattern
+
+```py
+x = None if flag else 1
+reveal_type(x)  # revealed: None | Literal[1]
+
+y = 0
+
+match x:
+    case None:
+        y = x
+
+# TODO intersection simplification: should be just Literal[0] | None
+reveal_type(y)  # revealed: Literal[0] | None | Literal[1] & None
+```

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -496,11 +496,9 @@ impl<'db> Type<'db> {
                 tuple.elements(db).is_empty()
             }
             Type::Union(..) => {
-                // There are some rare edge cases where a union type might be a singleton type.
-                // For example, a union with just one element (which itself is a singleton). Or
-                // a union with an empty type (e.g. Never | None). Here, we assume that such
-                // types would have been simplified to a different representation earlier and
-                // simply return false.
+                // A single-element union, where the sole element was a singleton, would itself
+                // be a singleton type. However, unions with length < 2 should never appear in
+                // our model due to [`UnionBuilder::build`].
                 false
             }
             Type::Intersection(..) => {

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -472,6 +472,7 @@ impl<'db> Type<'db> {
             Type::Any
             | Type::Never
             | Type::Unknown
+            | Type::Todo
             | Type::Unbound
             | Type::Module(..)
             | Type::Instance(..)
@@ -508,7 +509,6 @@ impl<'db> Type<'db> {
                 //
                 false
             }
-            Type::Todo => todo!(),
         }
     }
 

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -486,10 +486,7 @@ impl<'db> Type<'db> {
                 false
             }
             Type::None | Type::BooleanLiteral(_) | Type::Function(..) | Type::Class(..) => true,
-            Type::Tuple(tuple) => {
-                !tuple.elements(db).is_empty()
-                    && tuple.elements(db).iter().all(|ty| ty.is_singleton(db))
-            }
+            Type::Tuple(tuple) => tuple.elements(db).iter().all(|ty| ty.is_singleton(db)),
             Type::Union(..) => {
                 // There are some rare edge cases where a union type might be a singleton type.
                 // For example, a union with just one element (which itself is a singleton). Or
@@ -1672,6 +1669,7 @@ mod tests {
     #[test_case(Ty::None)]
     #[test_case(Ty::BoolLiteral(true))]
     #[test_case(Ty::BoolLiteral(false))]
+    #[test_case(Ty::Tuple(vec![]))]
     #[test_case(Ty::Tuple(vec![Ty::None]))]
     #[test_case(Ty::Tuple(vec![Ty::None, Ty::BoolLiteral(true)]))]
     fn is_singleton(from: Ty) {
@@ -1684,7 +1682,6 @@ mod tests {
     #[test_case(Ty::IntLiteral(345))]
     #[test_case(Ty::BuiltinInstance("str"))]
     #[test_case(Ty::Union(vec![Ty::IntLiteral(1), Ty::IntLiteral(2)]))]
-    #[test_case(Ty::Tuple(vec![]))]
     fn is_not_singleton(from: Ty) {
         let db = setup_db();
 

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -474,7 +474,6 @@ impl<'db> Type<'db> {
             | Type::Unknown
             | Type::Todo
             | Type::Unbound
-            | Type::Module(..)
             | Type::Instance(..) // TODO some instance types can be singleton types (EllipsisType, NotImplementedType)
             | Type::IntLiteral(..)
             | Type::StringLiteral(..)
@@ -485,7 +484,7 @@ impl<'db> Type<'db> {
                 // are both of type Literal[345], for example.
                 false
             }
-            Type::None | Type::BooleanLiteral(_) | Type::Function(..) | Type::Class(..) => true,
+            Type::None | Type::BooleanLiteral(_) | Type::Function(..) | Type::Class(..) | Type::Module(..) => true,
             Type::Tuple(tuple) => {
                 // We deliberately deviate from the language specification [1] here and claim
                 // that the empty tuple type is a singleton type. The reasoning is that `()`

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -475,7 +475,7 @@ impl<'db> Type<'db> {
             | Type::Todo
             | Type::Unbound
             | Type::Module(..)
-            | Type::Instance(..)
+            | Type::Instance(..) // TODO some instance types can be singleton types (EllipsisType, NotImplementedType)
             | Type::IntLiteral(..)
             | Type::StringLiteral(..)
             | Type::BytesLiteral(..)

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -5422,53 +5422,6 @@ mod tests {
     }
 
     #[test]
-    fn narrow_not_none() -> anyhow::Result<()> {
-        let mut db = setup_db();
-
-        db.write_dedented(
-            "/src/a.py",
-            "
-            x = None if flag else 1
-            y = 0
-            if x is not None:
-                y = x
-            ",
-        )?;
-
-        assert_public_ty(&db, "/src/a.py", "x", "None | Literal[1]");
-        assert_public_ty(&db, "/src/a.py", "y", "Literal[0, 1]");
-
-        Ok(())
-    }
-
-    #[test]
-    fn narrow_singleton_pattern() {
-        let mut db = setup_db();
-
-        db.write_dedented(
-            "/src/a.py",
-            "
-            x = None if flag else 1
-            y = 0
-            match x:
-                case None:
-                    y = x
-            ",
-        )
-        .unwrap();
-
-        // TODO: The correct inferred type should be `Literal[0] | None` but currently the
-        // simplification logic doesn't account for this. The final type with parenthesis:
-        // `Literal[0] | None | (Literal[1] & None)`
-        assert_public_ty(
-            &db,
-            "/src/a.py",
-            "y",
-            "Literal[0] | None | Literal[1] & None",
-        );
-    }
-
-    #[test]
     fn while_loop() -> anyhow::Result<()> {
         let mut db = setup_db();
 

--- a/crates/red_knot_python_semantic/src/types/narrow.rs
+++ b/crates/red_knot_python_semantic/src/types/narrow.rs
@@ -156,11 +156,15 @@ impl<'db> NarrowingConstraintsBuilder<'db> {
             for (op, comparator) in std::iter::zip(&**ops, &**comparators) {
                 let comp_ty = inference.expression_ty(comparator.scoped_ast_id(self.db, scope));
                 match op {
-                    ast::CmpOp::IsNot if comp_ty.is_singleton(self.db) => {
-                        let ty = IntersectionBuilder::new(self.db)
-                            .add_negative(comp_ty)
-                            .build();
-                        self.constraints.insert(symbol, ty);
+                    ast::CmpOp::IsNot => {
+                        if comp_ty.is_singleton(self.db) {
+                            let ty = IntersectionBuilder::new(self.db)
+                                .add_negative(comp_ty)
+                                .build();
+                            self.constraints.insert(symbol, ty);
+                        } else {
+                            // Non-singletons cannot be safely narrowed using `is not`
+                        }
                     }
                     ast::CmpOp::Is => {
                         self.constraints.insert(symbol, comp_ty);

--- a/crates/red_knot_python_semantic/src/types/narrow.rs
+++ b/crates/red_knot_python_semantic/src/types/narrow.rs
@@ -155,13 +155,20 @@ impl<'db> NarrowingConstraintsBuilder<'db> {
             let inference = infer_expression_types(self.db, expression);
             for (op, comparator) in std::iter::zip(&**ops, &**comparators) {
                 let comp_ty = inference.expression_ty(comparator.scoped_ast_id(self.db, scope));
-                if matches!(op, ast::CmpOp::IsNot) {
-                    let ty = IntersectionBuilder::new(self.db)
-                        .add_negative(comp_ty)
-                        .build();
-                    self.constraints.insert(symbol, ty);
-                };
-                // TODO other comparison types
+                match op {
+                    ast::CmpOp::IsNot if comp_ty.is_singleton(self.db) => {
+                        let ty = IntersectionBuilder::new(self.db)
+                            .add_negative(comp_ty)
+                            .build();
+                        self.constraints.insert(symbol, ty);
+                    }
+                    ast::CmpOp::Is => {
+                        self.constraints.insert(symbol, comp_ty);
+                    }
+                    _ => {
+                        // TODO other comparison types
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

- Fix a bug with `… is not …` type guards.
 
  Previously, in an example like
  ```py
  x = [1]
  y = [1]
  
  if x is not y:
      reveal_type(x)
  ```
  we would infer a type of `list[int] & ~list[int] == Never` for `x` inside the conditional (instead of `list[int]`), since we built a (negative) intersection with the type of the right hand side (`y`). However, as this example shows, this assumption can only be made for singleton types (types with a single inhabitant) such as `None`.
- Add support for `… is …` type guards.

closes #13715

## Test Plan

Moved existing `narrow_…` tests to Markdown-based tests and added new ones (including a regression test for the bug described above). Note that will create some conflicts with https://github.com/astral-sh/ruff/pull/13719. I tried to establish the correct organizational structure as proposed in [this comment](https://github.com/astral-sh/ruff/pull/13719#discussion_r1800188105)