### PR TITLE
Add scope assertion to `TypeInference.extend`

### DIFF
--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -817,8 +817,6 @@ impl<'db> TypeInferenceBuilder<'db> {
         } = parameter_with_default;
 
         self.infer_optional_expression(parameter.annotation.as_deref());
-
-        self.infer_definition(parameter_with_default);
     }
 
     fn infer_parameter(&mut self, parameter: &ast::Parameter) {
@@ -829,8 +827,6 @@ impl<'db> TypeInferenceBuilder<'db> {
         } = parameter;
 
         self.infer_optional_expression(annotation.as_deref());
-
-        self.infer_definition(parameter);
     }
 
     fn infer_parameter_with_default_definition(


### PR DESCRIPTION
## Summary

I thought this is an easy change, but many tests are now blowing up. I or someone else has to tacke a second look why and where
we're merging `TypeInference` results from different scopes. 

This PR adds a debug assertion that asserts that `TypeInference::extend` is only called on results that have the same scope. 
This is critical because `expressions` uses `ScopedExpressionId` that are local and merging expressions from different
scopes would lead to incorrect expression types.

We could consider storing `scope` only on `TypeInference` for debug builds. Doing so has the advantage that the `TypeInference` type is smaller of which we'll have many. However, a `ScopeId` is a `u32`... so it shouldn't matter that much and it avoids storing the `scope` both on `TypeInference` and `TypeInferenceBuilder`

## Test Plan

`cargo test`
