### PR TITLE
[red-knot] Use the right scope when considering class bases

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/generics.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/generics.md
@@ -1,0 +1,41 @@
+# PEP 695 Generics
+
+## Class Declarations
+
+Basic PEP 695 generics
+
+```py
+class MyBox[T]:
+  data: T
+  box_model_number = 695
+  def __init__(self, data: T):
+    self.data = data
+
+# TODO not error (should be subscriptable)
+box: MyBox[int] = MyBox(5)  # error: [non-subscriptable]
+# TODO error differently (str and int don't unify)
+wrong_innards: MyBox[int] = MyBox("five")  # error: [non-subscriptable]
+# TODO reveal int
+reveal_type(box.data)  # revealed: @Todo
+
+reveal_type(MyBox.box_model_number)  # revealed: Literal[695]
+```
+
+## Subclassing
+
+```py
+class MyBox[T]:
+  data: T
+  
+  def __init__(self, data: T):
+    self.data = data
+
+# TODO not error on the subscripting
+class MySecureBox[T](MyBox[T]):  # error: [non-subscriptable]
+  pass
+
+secure_box: MySecureBox[int] = MySecureBox(5)
+reveal_type(secure_box)  # revealed: MySecureBox
+# TODO reveal int
+reveal_type(secure_box.data)  # revealed: @Todo
+```

--- a/crates/red_knot_python_semantic/resources/mdtest/generics.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/generics.md
@@ -39,3 +39,19 @@ reveal_type(secure_box)  # revealed: MySecureBox
 # TODO reveal int
 reveal_type(secure_box.data)  # revealed: @Todo
 ```
+
+## Cyclical class definition
+
+In type stubs, classes can reference themselves in their base class definitions. For example, in `typeshed`, we have `class str(Sequence[str]): ...`.
+
+This should hold true even with generics at play.
+
+```py path=a.pyi
+class Seq[T]:
+  pass
+
+# TODO not error on the subscripting
+class S[T](Seq[S]):  # error: [non-subscriptable]
+  pass
+reveal_type(S)  # revealed: Literal[S]
+```

--- a/crates/red_knot_python_semantic/src/semantic_index/ast_ids.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/ast_ids.rs
@@ -35,12 +35,9 @@ pub(crate) struct AstIds {
 impl AstIds {
     fn expression_id(&self, key: impl Into<ExpressionNodeKey>) -> ScopedExpressionId {
         let key = &key.into();
-        match self.expressions_map.get(key) {
-            Some(result) => *result,
-            None => {
-                panic!("Could not find expression ID for {key:?}");
-            }
-        }
+        *self.expressions_map.get(key).unwrap_or_else(|| {
+            panic!("Could not find expression ID for {key:?}");
+        })
     }
 
     fn use_id(&self, key: impl Into<ExpressionNodeKey>) -> ScopedUseId {

--- a/crates/red_knot_python_semantic/src/semantic_index/ast_ids.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/ast_ids.rs
@@ -34,7 +34,13 @@ pub(crate) struct AstIds {
 
 impl AstIds {
     fn expression_id(&self, key: impl Into<ExpressionNodeKey>) -> ScopedExpressionId {
-        self.expressions_map[&key.into()]
+        let key = &key.into();
+        match self.expressions_map.get(key) {
+            Some(result) => *result,
+            None => {
+                panic!("Could not find expression ID for {key:?}");
+            }
+        }
     }
 
     fn use_id(&self, key: impl Into<ExpressionNodeKey>) -> ScopedUseId {

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -1416,7 +1416,6 @@ impl<'db> ClassType<'db> {
         let DefinitionKind::Class(class_stmt_node) = definition.kind(db) else {
             panic!("Class type definition must have DefinitionKind::Class");
         };
-        let model: SemanticModel<'db> = SemanticModel::new(db, definition.file(db));
         class_stmt_node
             .bases()
             .iter()
@@ -1424,6 +1423,7 @@ impl<'db> ClassType<'db> {
                 if class_stmt_node.type_params.is_some() {
                     // when we have a specialized scope, we'll look up the inference
                     // within that scope
+                    let model: SemanticModel<'db> = SemanticModel::new(db, definition.file(db));
                     base_expr.ty(&model)
                 } else {
                     // Otherwise, we can do the lookup based on the definition scope

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -1426,7 +1426,7 @@ impl<'db> ClassType<'db> {
             .bases_specialized_scope(db)
             .map(|bases_scope| (bases_scope, infer_scope_types(db, bases_scope)));
 
-        let mapper = move |base_expr: &ast::Expr| {
+        class_stmt_node.bases().iter().map(move |base_expr: &ast::Expr| {
             if let Some((bases_scope, inferences)) = bases_scope_info {
                 // when we have a specialized scope, we'll look up the inference
                 // within that scope
@@ -1435,8 +1435,7 @@ impl<'db> ClassType<'db> {
                 // Otherwise, we can do the lookup based on the definition scope
                 definition_expression_ty(db, definition, base_expr)
             }
-        };
-        class_stmt_node.bases().iter().map(mapper)
+        })
     }
 
     /// Returns the class member of this class named `name`.

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -1422,11 +1422,9 @@ impl<'db> ClassType<'db> {
         };
 
         // if there's a type params scope
-        let bases_scope_info: Option<(ScopeId<'db>, &TypeInference<'db>)> =
-            match self.bases_specialized_scope(db) {
-                None => None,
-                Some(bases_scope) => Some((bases_scope, infer_scope_types(db, bases_scope))),
-            };
+        let bases_scope_info: Option<(ScopeId<'db>, &TypeInference<'db>)> = self
+            .bases_specialized_scope(db)
+            .map(|bases_scope| (bases_scope, infer_scope_types(db, bases_scope)));
 
         let mapper = move |base_expr: &ast::Expr| {
             if let Some((bases_scope, inferences)) = bases_scope_info {

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -872,19 +872,11 @@ impl<'db> TypeInferenceBuilder<'db> {
             .as_ref()
             .and_then(|module| KnownClass::maybe_from_module(module, name.as_str()));
 
-        // when type_params.is_some(), there's a specialized scope for the bases + keywords
-        let bases_specialized_scope = type_params.as_ref().map(|_| {
-            self.index
-                .node_scope(NodeWithScopeRef::ClassTypeParameters(class))
-                .to_scope_id(self.db, self.file)
-        });
-
         let class_ty = Type::Class(ClassType::new(
             self.db,
             name.id.clone(),
             definition,
             body_scope,
-            bases_specialized_scope,
             maybe_known_class,
         ));
 

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -871,11 +871,20 @@ impl<'db> TypeInferenceBuilder<'db> {
         let maybe_known_class = file_to_module(self.db, body_scope.file(self.db))
             .as_ref()
             .and_then(|module| KnownClass::maybe_from_module(module, name.as_str()));
+
+        // when type_params.is_some(), there's a specialized scope for the bases + keywords
+        let bases_specialized_scope = type_params.as_ref().map(|_| {
+            self.index
+                .node_scope(NodeWithScopeRef::ClassTypeParameters(class))
+                .to_scope_id(self.db, self.file)
+        });
+
         let class_ty = Type::Class(ClassType::new(
             self.db,
             name.id.clone(),
             definition,
             body_scope,
+            bases_specialized_scope,
             maybe_known_class,
         ));
 


### PR DESCRIPTION
Summary
---------

PEP 695 Generics introduce a scope inside a class statement's arguments and keywords.

```
class C[T](A[T]):  # the T in A[T] is not from the global scope but from a type-param-specfic scope
   ...
```

When doing inference on the class bases, we currently have been doing base class expression lookups in the global scope. Not an issue without generics (since a scope is only created when generics are present).

This change instead makes sure to stop the global scope inference from going into expressions within this sub-scope. Since there is a separate scope, `check_file` and friends will trigger inference on these expressions still.

Another change as a part of this is making sure that `ClassType` looks up its bases in the right scope. I do not believe the way I do the lookup in this change is the most precise way, and would appreciate comments on that fragment.

Test Plan
----------
`cargo test --package red_knot_python_semantic generics` will run the markdown test that previously would panic due to scope lookup issues