### PR TITLE
[red knot] Minor follow-up tasks regarding singleton types

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/narrow/conditionals_is_not.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/narrow/conditionals_is_not.md
@@ -31,10 +31,9 @@ non-singleton class may occupy different addresses in memory even if
 they compare equal.
 
 ```py
-x = [1]
-y = [1]
+x = 345
+y = 345
 
 if x is not y:
-    # TODO: should include type parameter: list[int]
-    reveal_type(x)  # revealed: list
+    reveal_type(x)  # revealed: Literal[345]
 ```

--- a/crates/red_knot_python_semantic/src/types/narrow.rs
+++ b/crates/red_knot_python_semantic/src/types/narrow.rs
@@ -157,7 +157,7 @@ impl<'db> NarrowingConstraintsBuilder<'db> {
                 let comp_ty = inference.expression_ty(comparator.scoped_ast_id(self.db, scope));
                 match op {
                     ast::CmpOp::IsNot => {
-                        if comp_ty.is_singleton(self.db) {
+                        if comp_ty.is_singleton() {
                             let ty = IntersectionBuilder::new(self.db)
                                 .add_negative(comp_ty)
                                 .build();


### PR DESCRIPTION
## Summary

- Do not treat empty tuples as singletons after discussion [1]
- Improve comment regarding intersection types
- Resolve unnecessary TODO in Markdown test

[1] https://discuss.python.org/t/should-we-specify-in-the-language-reference-that-the-empty-tuple-is-a-singleton/67957

## Test Plan

—