### PR TITLE
Enable preview mode for 'unstable' black tests

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/black/cases/context_managers_38.options.json
+++ b/crates/ruff_python_formatter/resources/test/fixtures/black/cases/context_managers_38.options.json
@@ -1,1 +1,0 @@
-{"target_version": "py38"}

--- a/crates/ruff_python_formatter/resources/test/fixtures/black/cases/context_managers_39.options.json
+++ b/crates/ruff_python_formatter/resources/test/fixtures/black/cases/context_managers_39.options.json
@@ -1,1 +1,0 @@
-{"target_version": "py39"}

--- a/crates/ruff_python_formatter/resources/test/fixtures/black/cases/context_managers_autodetect_39.options.json
+++ b/crates/ruff_python_formatter/resources/test/fixtures/black/cases/context_managers_autodetect_39.options.json
@@ -1,1 +1,0 @@
-{"target_version": "py39"}

--- a/crates/ruff_python_formatter/resources/test/fixtures/black/cases/pep_570.options.json
+++ b/crates/ruff_python_formatter/resources/test/fixtures/black/cases/pep_570.options.json
@@ -1,1 +1,0 @@
-{"target_version": "py38"}

--- a/crates/ruff_python_formatter/resources/test/fixtures/black/cases/pep_572.options.json
+++ b/crates/ruff_python_formatter/resources/test/fixtures/black/cases/pep_572.options.json
@@ -1,1 +1,0 @@
-{"target_version": "py38"}

--- a/crates/ruff_python_formatter/resources/test/fixtures/black/cases/pep_572_py39.options.json
+++ b/crates/ruff_python_formatter/resources/test/fixtures/black/cases/pep_572_py39.options.json
@@ -1,1 +1,0 @@
-{"target_version": "py39"}

--- a/crates/ruff_python_formatter/resources/test/fixtures/black/cases/pep_572_remove_parens.options.json
+++ b/crates/ruff_python_formatter/resources/test/fixtures/black/cases/pep_572_remove_parens.options.json
@@ -1,1 +1,0 @@
-{"target_version": "py38"}

--- a/crates/ruff_python_formatter/resources/test/fixtures/black/cases/preview_cantfit_string.options.json
+++ b/crates/ruff_python_formatter/resources/test/fixtures/black/cases/preview_cantfit_string.options.json
@@ -1,0 +1,1 @@
+{"preview": "enabled"}

--- a/crates/ruff_python_formatter/resources/test/fixtures/black/cases/preview_comments7.options.json
+++ b/crates/ruff_python_formatter/resources/test/fixtures/black/cases/preview_comments7.options.json
@@ -1,0 +1,1 @@
+{"preview": "enabled"}

--- a/crates/ruff_python_formatter/resources/test/fixtures/black/cases/preview_hug_parens_with_braces_and_square_brackets.options.json
+++ b/crates/ruff_python_formatter/resources/test/fixtures/black/cases/preview_hug_parens_with_braces_and_square_brackets.options.json
@@ -1,0 +1,1 @@
+{"preview": "enabled"}

--- a/crates/ruff_python_formatter/resources/test/fixtures/black/cases/preview_hug_parens_with_braces_and_square_brackets_no_ll1.options.json
+++ b/crates/ruff_python_formatter/resources/test/fixtures/black/cases/preview_hug_parens_with_braces_and_square_brackets_no_ll1.options.json
@@ -1,0 +1,1 @@
+{"preview": "enabled"}

--- a/crates/ruff_python_formatter/resources/test/fixtures/black/cases/preview_long_dict_values.options.json
+++ b/crates/ruff_python_formatter/resources/test/fixtures/black/cases/preview_long_dict_values.options.json
@@ -1,0 +1,1 @@
+{"preview": "enabled"}

--- a/crates/ruff_python_formatter/resources/test/fixtures/black/cases/preview_long_strings.options.json
+++ b/crates/ruff_python_formatter/resources/test/fixtures/black/cases/preview_long_strings.options.json
@@ -1,0 +1,1 @@
+{"preview": "enabled"}

--- a/crates/ruff_python_formatter/resources/test/fixtures/black/cases/preview_long_strings__east_asian_width.options.json
+++ b/crates/ruff_python_formatter/resources/test/fixtures/black/cases/preview_long_strings__east_asian_width.options.json
@@ -1,0 +1,1 @@
+{"preview": "enabled"}

--- a/crates/ruff_python_formatter/resources/test/fixtures/black/cases/preview_long_strings__edge_case.options.json
+++ b/crates/ruff_python_formatter/resources/test/fixtures/black/cases/preview_long_strings__edge_case.options.json
@@ -1,0 +1,1 @@
+{"preview": "enabled"}

--- a/crates/ruff_python_formatter/resources/test/fixtures/black/cases/preview_long_strings__regression.options.json
+++ b/crates/ruff_python_formatter/resources/test/fixtures/black/cases/preview_long_strings__regression.options.json
@@ -1,0 +1,1 @@
+{"preview": "enabled"}

--- a/crates/ruff_python_formatter/resources/test/fixtures/black/cases/preview_multiline_strings.options.json
+++ b/crates/ruff_python_formatter/resources/test/fixtures/black/cases/preview_multiline_strings.options.json
@@ -1,0 +1,1 @@
+{"preview": "enabled"}

--- a/crates/ruff_python_formatter/resources/test/fixtures/black/cases/preview_return_annotation_brackets_string.options.json
+++ b/crates/ruff_python_formatter/resources/test/fixtures/black/cases/preview_return_annotation_brackets_string.options.json
@@ -1,0 +1,1 @@
+{"preview": "enabled"}

--- a/crates/ruff_python_formatter/resources/test/fixtures/black/cases/python37.options.json
+++ b/crates/ruff_python_formatter/resources/test/fixtures/black/cases/python37.options.json
@@ -1,1 +1,0 @@
-{"target_version": "py37"}

--- a/crates/ruff_python_formatter/resources/test/fixtures/black/cases/python38.options.json
+++ b/crates/ruff_python_formatter/resources/test/fixtures/black/cases/python38.options.json
@@ -1,1 +1,0 @@
-{"target_version": "py38"}

--- a/crates/ruff_python_formatter/resources/test/fixtures/black/cases/python39.options.json
+++ b/crates/ruff_python_formatter/resources/test/fixtures/black/cases/python39.options.json
@@ -1,1 +1,0 @@
-{"target_version": "py39"}

--- a/crates/ruff_python_formatter/resources/test/fixtures/black/cases/remove_with_brackets.options.json
+++ b/crates/ruff_python_formatter/resources/test/fixtures/black/cases/remove_with_brackets.options.json
@@ -1,1 +1,0 @@
-{"target_version": "py39"}

--- a/crates/ruff_python_formatter/resources/test/fixtures/import_black_tests.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/import_black_tests.py
@@ -39,7 +39,7 @@ def import_fixture(fixture: Path, fixture_set: str):
         extension = "py"
 
         if flags:
-            if "--preview" in flags:
+            if "--preview" in flags or "--unstable" in flags:
                 options["preview"] = "enabled"
 
             if "--pyi" in flags:

--- a/crates/ruff_python_formatter/tests/snapshots/black_compatibility@cases__context_managers_39.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/black_compatibility@cases__context_managers_39.py.snap
@@ -1,0 +1,340 @@
+---
+source: crates/ruff_python_formatter/tests/fixtures.rs
+input_file: crates/ruff_python_formatter/resources/test/fixtures/black/cases/context_managers_39.py
+---
+## Input
+
+```python
+with \
+     make_context_manager1() as cm1, \
+     make_context_manager2() as cm2, \
+     make_context_manager3() as cm3, \
+     make_context_manager4() as cm4 \
+:
+    pass
+
+
+# Leading comment
+with \
+     make_context_manager1() as cm1, \
+     make_context_manager2(), \
+     make_context_manager3() as cm3, \
+     make_context_manager4() \
+:
+    pass
+
+
+with \
+     new_new_new1() as cm1, \
+     new_new_new2() \
+:
+    pass
+
+
+with (
+     new_new_new1() as cm1,
+     new_new_new2()
+):
+    pass
+
+
+# Leading comment.
+with (
+     # First comment.
+     new_new_new1() as cm1,
+     # Second comment.
+     new_new_new2()
+     # Last comment.
+):
+    pass
+
+
+with \
+    this_is_a_very_long_call(looong_arg1=looong_value1, looong_arg2=looong_value2) as cm1, \
+    this_is_a_very_long_call(looong_arg1=looong_value1, looong_arg2=looong_value2, looong_arg3=looong_value3, looong_arg4=looong_value4) as cm2 \
+:
+    pass
+
+
+with mock.patch.object(
+    self.my_runner, "first_method", autospec=True
+) as mock_run_adb, mock.patch.object(
+    self.my_runner, "second_method", autospec=True, return_value="foo"
+):
+    pass
+
+
+with xxxxxxxx.some_kind_of_method(
+    some_argument=[
+        "first",
+        "second",
+        "third",
+    ]
+).another_method() as cmd:
+    pass
+
+
+async def func():
+    async with \
+        make_context_manager1() as cm1, \
+        make_context_manager2() as cm2, \
+        make_context_manager3() as cm3, \
+        make_context_manager4() as cm4 \
+    :
+        pass
+
+    async with some_function(
+        argument1, argument2, argument3="some_value"
+    ) as some_cm, some_other_function(
+        argument1, argument2, argument3="some_value"
+    ):
+        pass
+```
+
+## Black Differences
+
+```diff
+--- Black
++++ Ruff
+@@ -1,19 +1,9 @@
+-with (
+-    make_context_manager1() as cm1,
+-    make_context_manager2() as cm2,
+-    make_context_manager3() as cm3,
+-    make_context_manager4() as cm4,
+-):
++with make_context_manager1() as cm1, make_context_manager2() as cm2, make_context_manager3() as cm3, make_context_manager4() as cm4:
+     pass
+ 
+ 
+ # Leading comment
+-with (
+-    make_context_manager1() as cm1,
+-    make_context_manager2(),
+-    make_context_manager3() as cm3,
+-    make_context_manager4(),
+-):
++with make_context_manager1() as cm1, make_context_manager2(), make_context_manager3() as cm3, make_context_manager4():
+     pass
+ 
+ 
+@@ -36,25 +26,21 @@
+     pass
+ 
+ 
+-with (
+-    this_is_a_very_long_call(
+-        looong_arg1=looong_value1, looong_arg2=looong_value2
+-    ) as cm1,
+-    this_is_a_very_long_call(
+-        looong_arg1=looong_value1,
+-        looong_arg2=looong_value2,
+-        looong_arg3=looong_value3,
+-        looong_arg4=looong_value4,
+-    ) as cm2,
+-):
++with this_is_a_very_long_call(
++    looong_arg1=looong_value1, looong_arg2=looong_value2
++) as cm1, this_is_a_very_long_call(
++    looong_arg1=looong_value1,
++    looong_arg2=looong_value2,
++    looong_arg3=looong_value3,
++    looong_arg4=looong_value4,
++) as cm2:
+     pass
+ 
+ 
+-with (
+-    mock.patch.object(self.my_runner, "first_method", autospec=True) as mock_run_adb,
+-    mock.patch.object(
+-        self.my_runner, "second_method", autospec=True, return_value="foo"
+-    ),
++with mock.patch.object(
++    self.my_runner, "first_method", autospec=True
++) as mock_run_adb, mock.patch.object(
++    self.my_runner, "second_method", autospec=True, return_value="foo"
+ ):
+     pass
+ 
+@@ -70,16 +56,10 @@
+ 
+ 
+ async def func():
+-    async with (
+-        make_context_manager1() as cm1,
+-        make_context_manager2() as cm2,
+-        make_context_manager3() as cm3,
+-        make_context_manager4() as cm4,
+-    ):
++    async with make_context_manager1() as cm1, make_context_manager2() as cm2, make_context_manager3() as cm3, make_context_manager4() as cm4:
+         pass
+ 
+-    async with (
+-        some_function(argument1, argument2, argument3="some_value") as some_cm,
+-        some_other_function(argument1, argument2, argument3="some_value"),
+-    ):
++    async with some_function(
++        argument1, argument2, argument3="some_value"
++    ) as some_cm, some_other_function(argument1, argument2, argument3="some_value"):
+         pass
+```
+
+## Ruff Output
+
+```python
+with make_context_manager1() as cm1, make_context_manager2() as cm2, make_context_manager3() as cm3, make_context_manager4() as cm4:
+    pass
+
+
+# Leading comment
+with make_context_manager1() as cm1, make_context_manager2(), make_context_manager3() as cm3, make_context_manager4():
+    pass
+
+
+with new_new_new1() as cm1, new_new_new2():
+    pass
+
+
+with new_new_new1() as cm1, new_new_new2():
+    pass
+
+
+# Leading comment.
+with (
+    # First comment.
+    new_new_new1() as cm1,
+    # Second comment.
+    new_new_new2(),
+    # Last comment.
+):
+    pass
+
+
+with this_is_a_very_long_call(
+    looong_arg1=looong_value1, looong_arg2=looong_value2
+) as cm1, this_is_a_very_long_call(
+    looong_arg1=looong_value1,
+    looong_arg2=looong_value2,
+    looong_arg3=looong_value3,
+    looong_arg4=looong_value4,
+) as cm2:
+    pass
+
+
+with mock.patch.object(
+    self.my_runner, "first_method", autospec=True
+) as mock_run_adb, mock.patch.object(
+    self.my_runner, "second_method", autospec=True, return_value="foo"
+):
+    pass
+
+
+with xxxxxxxx.some_kind_of_method(
+    some_argument=[
+        "first",
+        "second",
+        "third",
+    ]
+).another_method() as cmd:
+    pass
+
+
+async def func():
+    async with make_context_manager1() as cm1, make_context_manager2() as cm2, make_context_manager3() as cm3, make_context_manager4() as cm4:
+        pass
+
+    async with some_function(
+        argument1, argument2, argument3="some_value"
+    ) as some_cm, some_other_function(argument1, argument2, argument3="some_value"):
+        pass
+```
+
+## Black Output
+
+```python
+with (
+    make_context_manager1() as cm1,
+    make_context_manager2() as cm2,
+    make_context_manager3() as cm3,
+    make_context_manager4() as cm4,
+):
+    pass
+
+
+# Leading comment
+with (
+    make_context_manager1() as cm1,
+    make_context_manager2(),
+    make_context_manager3() as cm3,
+    make_context_manager4(),
+):
+    pass
+
+
+with new_new_new1() as cm1, new_new_new2():
+    pass
+
+
+with new_new_new1() as cm1, new_new_new2():
+    pass
+
+
+# Leading comment.
+with (
+    # First comment.
+    new_new_new1() as cm1,
+    # Second comment.
+    new_new_new2(),
+    # Last comment.
+):
+    pass
+
+
+with (
+    this_is_a_very_long_call(
+        looong_arg1=looong_value1, looong_arg2=looong_value2
+    ) as cm1,
+    this_is_a_very_long_call(
+        looong_arg1=looong_value1,
+        looong_arg2=looong_value2,
+        looong_arg3=looong_value3,
+        looong_arg4=looong_value4,
+    ) as cm2,
+):
+    pass
+
+
+with (
+    mock.patch.object(self.my_runner, "first_method", autospec=True) as mock_run_adb,
+    mock.patch.object(
+        self.my_runner, "second_method", autospec=True, return_value="foo"
+    ),
+):
+    pass
+
+
+with xxxxxxxx.some_kind_of_method(
+    some_argument=[
+        "first",
+        "second",
+        "third",
+    ]
+).another_method() as cmd:
+    pass
+
+
+async def func():
+    async with (
+        make_context_manager1() as cm1,
+        make_context_manager2() as cm2,
+        make_context_manager3() as cm3,
+        make_context_manager4() as cm4,
+    ):
+        pass
+
+    async with (
+        some_function(argument1, argument2, argument3="some_value") as some_cm,
+        some_other_function(argument1, argument2, argument3="some_value"),
+    ):
+        pass
+```

--- a/crates/ruff_python_formatter/tests/snapshots/black_compatibility@cases__context_managers_autodetect_39.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/black_compatibility@cases__context_managers_autodetect_39.py.snap
@@ -1,0 +1,79 @@
+---
+source: crates/ruff_python_formatter/tests/fixtures.rs
+input_file: crates/ruff_python_formatter/resources/test/fixtures/black/cases/context_managers_autodetect_39.py
+---
+## Input
+
+```python
+# This file uses parenthesized context managers introduced in Python 3.9.
+
+
+with \
+     make_context_manager1() as cm1, \
+     make_context_manager2() as cm2, \
+     make_context_manager3() as cm3, \
+     make_context_manager4() as cm4 \
+:
+    pass
+
+
+with (
+     new_new_new1() as cm1,
+     new_new_new2()
+):
+    pass
+```
+
+## Black Differences
+
+```diff
+--- Black
++++ Ruff
+@@ -1,12 +1,7 @@
+ # This file uses parenthesized context managers introduced in Python 3.9.
+ 
+ 
+-with (
+-    make_context_manager1() as cm1,
+-    make_context_manager2() as cm2,
+-    make_context_manager3() as cm3,
+-    make_context_manager4() as cm4,
+-):
++with make_context_manager1() as cm1, make_context_manager2() as cm2, make_context_manager3() as cm3, make_context_manager4() as cm4:
+     pass
+ 
+ 
+```
+
+## Ruff Output
+
+```python
+# This file uses parenthesized context managers introduced in Python 3.9.
+
+
+with make_context_manager1() as cm1, make_context_manager2() as cm2, make_context_manager3() as cm3, make_context_manager4() as cm4:
+    pass
+
+
+with new_new_new1() as cm1, new_new_new2():
+    pass
+```
+
+## Black Output
+
+```python
+# This file uses parenthesized context managers introduced in Python 3.9.
+
+
+with (
+    make_context_manager1() as cm1,
+    make_context_manager2() as cm2,
+    make_context_manager3() as cm3,
+    make_context_manager4() as cm4,
+):
+    pass
+
+
+with new_new_new1() as cm1, new_new_new2():
+    pass
+```

--- a/crates/ruff_python_formatter/tests/snapshots/black_compatibility@cases__preview_hug_parens_with_braces_and_square_brackets.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/black_compatibility@cases__preview_hug_parens_with_braces_and_square_brackets.py.snap
@@ -177,94 +177,7 @@ for foo in ["a", "b"]:
 ```diff
 --- Black
 +++ Ruff
-@@ -1,43 +1,55 @@
- def foo_brackets(request):
--    return JsonResponse({
--        "var_1": foo,
--        "var_2": bar,
--    })
-+    return JsonResponse(
-+        {
-+            "var_1": foo,
-+            "var_2": bar,
-+        }
-+    )
- 
- 
- def foo_square_brackets(request):
--    return JsonResponse([
--        "var_1",
--        "var_2",
--    ])
-+    return JsonResponse(
-+        [
-+            "var_1",
-+            "var_2",
-+        ]
-+    )
- 
- 
--func({
--    "a": 37,
--    "b": 42,
--    "c": 927,
--    "aaaaaaaaaaaaaaaaaaaaaaaaa": 11111111111111111111111111111111111111111,
--})
-+func(
-+    {
-+        "a": 37,
-+        "b": 42,
-+        "c": 927,
-+        "aaaaaaaaaaaaaaaaaaaaaaaaa": 11111111111111111111111111111111111111111,
-+    }
-+)
- 
--func([
--    "random_string_number_one",
--    "random_string_number_two",
--    "random_string_number_three",
--    "random_string_number_four",
--])
-+func(
-+    [
-+        "random_string_number_one",
-+        "random_string_number_two",
-+        "random_string_number_three",
-+        "random_string_number_four",
-+    ]
-+)
- 
--func({
--    # expand me
--    "a": 37,
--    "b": 42,
--    "c": 927,
--})
-+func(
-+    {
-+        # expand me
-+        "a": 37,
-+        "b": 42,
-+        "c": 927,
-+    }
-+)
- 
--func([
--    "a",
--    "b",
--    "c",
--])
-+func(
-+    [
-+        "a",
-+        "b",
-+        "c",
-+    ]
-+)
- 
- func(
-     [
-@@ -47,17 +59,21 @@
+@@ -47,17 +47,21 @@
      ],
  )
  
@@ -296,67 +209,9 @@ for foo in ["a", "b"]:
  
  func(
      # preserve me
-@@ -68,38 +84,48 @@
-     ]
- )
- 
--func([  # preserve me but hug brackets
--    "c",
--    "d",
--    "e",
--])
-+func(
-+    [  # preserve me but hug brackets
-+        "c",
-+        "d",
-+        "e",
-+    ]
-+)
- 
--func([
--    # preserve me but hug brackets
--    "c",
--    "d",
--    "e",
--])
-+func(
-+    [
-+        # preserve me but hug brackets
-+        "c",
-+        "d",
-+        "e",
-+    ]
-+)
- 
--func([
--    "c",
--    # preserve me but hug brackets
--    "d",
--    "e",
--])
-+func(
-+    [
-+        "c",
-+        # preserve me but hug brackets
-+        "d",
-+        "e",
-+    ]
-+)
- 
--func([
--    "c",
--    "d",
--    "e",
--    # preserve me but hug brackets
--])
-+func(
-+    [
-+        "c",
-+        "d",
-+        "e",
-+        # preserve me but hug brackets
-+    ]
-+)
+@@ -95,11 +99,13 @@
+     # preserve me but hug brackets
+ ])
  
 -func([
 -    "c",
@@ -373,28 +228,21 @@ for foo in ["a", "b"]:
  
  func(
      [
-@@ -114,13 +140,15 @@
- func(
-     [x for x in "long line long line long line long line long line long line long line"]
+@@ -111,10 +117,10 @@
  )
--func([
--    x
--    for x in [
-+func(
-+    [
-         x
--        for x in "long line long line long line long line long line long line long line"
-+        for x in [
-+            x
-+            for x in "long line long line long line long line long line long line long line"
-+        ]
-     ]
--])
-+)
  
- foooooooooooooooooooo(
-     [{c: n + 1 for c in range(256)} for n in range(100)] + [{}], {size}
-@@ -131,10 +159,12 @@
+ func([x for x in "short line"])
+-func(
+-    [x for x in "long line long line long line long line long line long line long line"]
+-)
+ func([
++    x for x in "long line long line long line long line long line long line long line"
++])
++func([
+     x
+     for x in [
+         x
+@@ -131,10 +137,12 @@
  )
  
  nested_mapping = {
@@ -411,135 +259,64 @@ for foo in ["a", "b"]:
  }
  explicit_exploding = [
      [
-@@ -144,24 +174,34 @@
-         ],
-     ],
- ]
--single_item_do_not_explode = Context({
--    "version": get_docs_version(),
--})
-+single_item_do_not_explode = Context(
-+    {
-+        "version": get_docs_version(),
-+    }
-+)
- 
--foo(*[
--    str(i) for i in range(100000000000000000000000000000000000000000000000000000000000)
--])
-+foo(
-+    *[
-+        str(i)
-+        for i in range(100000000000000000000000000000000000000000000000000000000000)
-+    ]
-+)
- 
--foo(**{
--    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa": 1,
--    "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb": 2,
--    "ccccccccccccccccccccccccccccccccc": 3,
--    **other,
--})
-+foo(
-+    **{
-+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa": 1,
-+        "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb": 2,
-+        "ccccccccccccccccccccccccccccccccc": 3,
-+        **other,
-+    }
-+)
- 
--foo(**{
--    x: y for x, y in enumerate(["long long long long line", "long long long long line"])
--})
-+foo(
-+    **{
-+        x: y
-+        for x, y in enumerate(["long long long long line", "long long long long line"])
-+    }
-+)
+@@ -164,9 +172,9 @@
+ })
  
  # Edge case when deciding whether to hug the brackets without inner content.
- very_very_very_long_variable = very_very_very_long_module.VeryVeryVeryVeryLongClassName(
-@@ -169,11 +209,13 @@
- )
+-very_very_very_long_variable = very_very_very_long_module.VeryVeryVeryVeryLongClassName(
+-    [[]]
+-)
++very_very_very_long_variable = very_very_very_long_module.VeryVeryVeryVeryLongClassName([
++    []
++])
  
  for foo in ["a", "b"]:
--    output.extend([
--        individual
--        for
--        # Foobar
--        container in xs_by_y[foo]
--        # Foobar
--        for individual in container["nested"]
--    ])
-+    output.extend(
-+        [
-+            individual
-+            for
-+            # Foobar
-+            container in xs_by_y[foo]
-+            # Foobar
-+            for individual in container["nested"]
-+        ]
-+    )
+     output.extend([
 ```
 
 ## Ruff Output
 
 ```python
 def foo_brackets(request):
-    return JsonResponse(
-        {
-            "var_1": foo,
-            "var_2": bar,
-        }
-    )
+    return JsonResponse({
+        "var_1": foo,
+        "var_2": bar,
+    })
 
 
 def foo_square_brackets(request):
-    return JsonResponse(
-        [
-            "var_1",
-            "var_2",
-        ]
-    )
+    return JsonResponse([
+        "var_1",
+        "var_2",
+    ])
 
 
-func(
-    {
-        "a": 37,
-        "b": 42,
-        "c": 927,
-        "aaaaaaaaaaaaaaaaaaaaaaaaa": 11111111111111111111111111111111111111111,
-    }
-)
+func({
+    "a": 37,
+    "b": 42,
+    "c": 927,
+    "aaaaaaaaaaaaaaaaaaaaaaaaa": 11111111111111111111111111111111111111111,
+})
 
-func(
-    [
-        "random_string_number_one",
-        "random_string_number_two",
-        "random_string_number_three",
-        "random_string_number_four",
-    ]
-)
+func([
+    "random_string_number_one",
+    "random_string_number_two",
+    "random_string_number_three",
+    "random_string_number_four",
+])
 
-func(
-    {
-        # expand me
-        "a": 37,
-        "b": 42,
-        "c": 927,
-    }
-)
+func({
+    # expand me
+    "a": 37,
+    "b": 42,
+    "c": 927,
+})
 
-func(
-    [
-        "a",
-        "b",
-        "c",
-    ]
-)
+func([
+    "a",
+    "b",
+    "c",
+])
 
 func(
     [
@@ -574,40 +351,32 @@ func(
     ]
 )
 
-func(
-    [  # preserve me but hug brackets
-        "c",
-        "d",
-        "e",
-    ]
-)
+func([  # preserve me but hug brackets
+    "c",
+    "d",
+    "e",
+])
 
-func(
-    [
-        # preserve me but hug brackets
-        "c",
-        "d",
-        "e",
-    ]
-)
+func([
+    # preserve me but hug brackets
+    "c",
+    "d",
+    "e",
+])
 
-func(
-    [
-        "c",
-        # preserve me but hug brackets
-        "d",
-        "e",
-    ]
-)
+func([
+    "c",
+    # preserve me but hug brackets
+    "d",
+    "e",
+])
 
-func(
-    [
-        "c",
-        "d",
-        "e",
-        # preserve me but hug brackets
-    ]
-)
+func([
+    "c",
+    "d",
+    "e",
+    # preserve me but hug brackets
+])
 
 func(
     [
@@ -627,18 +396,16 @@ func(
 )
 
 func([x for x in "short line"])
-func(
-    [x for x in "long line long line long line long line long line long line long line"]
-)
-func(
-    [
+func([
+    x for x in "long line long line long line long line long line long line long line"
+])
+func([
+    x
+    for x in [
         x
-        for x in [
-            x
-            for x in "long line long line long line long line long line long line long line"
-        ]
+        for x in "long line long line long line long line long line long line long line"
     ]
-)
+])
 
 foooooooooooooooooooo(
     [{c: n + 1 for c in range(256)} for n in range(100)] + [{}], {size}
@@ -664,51 +431,39 @@ explicit_exploding = [
         ],
     ],
 ]
-single_item_do_not_explode = Context(
-    {
-        "version": get_docs_version(),
-    }
-)
+single_item_do_not_explode = Context({
+    "version": get_docs_version(),
+})
 
-foo(
-    *[
-        str(i)
-        for i in range(100000000000000000000000000000000000000000000000000000000000)
-    ]
-)
+foo(*[
+    str(i) for i in range(100000000000000000000000000000000000000000000000000000000000)
+])
 
-foo(
-    **{
-        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa": 1,
-        "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb": 2,
-        "ccccccccccccccccccccccccccccccccc": 3,
-        **other,
-    }
-)
+foo(**{
+    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa": 1,
+    "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb": 2,
+    "ccccccccccccccccccccccccccccccccc": 3,
+    **other,
+})
 
-foo(
-    **{
-        x: y
-        for x, y in enumerate(["long long long long line", "long long long long line"])
-    }
-)
+foo(**{
+    x: y for x, y in enumerate(["long long long long line", "long long long long line"])
+})
 
 # Edge case when deciding whether to hug the brackets without inner content.
-very_very_very_long_variable = very_very_very_long_module.VeryVeryVeryVeryLongClassName(
-    [[]]
-)
+very_very_very_long_variable = very_very_very_long_module.VeryVeryVeryVeryLongClassName([
+    []
+])
 
 for foo in ["a", "b"]:
-    output.extend(
-        [
-            individual
-            for
-            # Foobar
-            container in xs_by_y[foo]
-            # Foobar
-            for individual in container["nested"]
-        ]
-    )
+    output.extend([
+        individual
+        for
+        # Foobar
+        container in xs_by_y[foo]
+        # Foobar
+        for individual in container["nested"]
+    ])
 ```
 
 ## Black Output

--- a/crates/ruff_python_formatter/tests/snapshots/black_compatibility@cases__preview_hug_parens_with_braces_and_square_brackets_no_ll1.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/black_compatibility@cases__preview_hug_parens_with_braces_and_square_brackets_no_ll1.py.snap
@@ -35,30 +35,10 @@ nested_array = [[["long line", "long long line", "long long long line", "long lo
 ```diff
 --- Black
 +++ Ruff
-@@ -1,47 +1,65 @@
- # split out from preview_hug_parens_with_brackes_and_square_brackets, as it produces
- # different code on the second pass with line-length 1 in many cases.
- # Seems to be about whether the last string in a sequence gets wrapped in parens or not.
--foo(*[
--    "long long long long long line",
--    "long long long long long line",
--    "long long long long long line",
--])
-+foo(
-+    *[
-+        "long long long long long line",
-+        "long long long long long line",
-+        "long long long long long line",
-+    ]
-+)
- func({"short line"})
--func({
--    "long line",
--    "long long line",
--    "long long long line",
--    "long long long long line",
--    "long long long long long line",
--})
+@@ -14,13 +14,15 @@
+     "long long long long line",
+     "long long long long long line",
+ })
 -func({{
 -    "long line",
 -    "long long line",
@@ -66,20 +46,22 @@ nested_array = [[["long line", "long long line", "long long long line", "long lo
 -    "long long long long line",
 -    "long long long long long line",
 -}})
--func((
--    "long line",
--    "long long line",
--    "long long long line",
--    "long long long long line",
--    "long long long long long line",
--))
--func(((
--    "long line",
--    "long long line",
--    "long long long line",
--    "long long long long line",
--    "long long long long long line",
--)))
++func({
++    {
++        "long line",
++        "long long line",
++        "long long long line",
++        "long long long long line",
++        "long long long long long line",
++    }
++})
+ func((
+     "long line",
+     "long long line",
+@@ -35,31 +37,63 @@
+     "long long long long line",
+     "long long long long long line",
+ )))
 -func([[
 -    "long line",
 -    "long long line",
@@ -87,61 +69,82 @@ nested_array = [[["long line", "long long line", "long long long line", "long lo
 -    "long long long long line",
 -    "long long long long long line",
 -]])
-+func(
-+    {
-+        "long line",
-+        "long long line",
-+        "long long long line",
-+        "long long long long line",
-+        "long long long long long line",
-+    }
-+)
-+func(
-+    {
-+        {
-+            "long line",
-+            "long long line",
-+            "long long long line",
-+            "long long long long line",
-+            "long long long long long line",
-+        }
-+    }
-+)
-+func(
-+    (
-+        "long line",
-+        "long long line",
-+        "long long long line",
-+        "long long long long line",
-+        "long long long long long line",
-+    )
-+)
-+func(
-+    (
-+        (
-+            "long line",
-+            "long long line",
-+            "long long long line",
-+            "long long long long line",
-+            "long long long long long line",
-+        )
-+    )
-+)
-+func(
++func([
 +    [
-+        [
-+            "long line",
-+            "long long line",
-+            "long long long line",
-+            "long long long long line",
-+            "long long long long long line",
-+        ]
++        "long line",
++        "long long line",
++        "long long long line",
++        "long long long long line",
++        "long long long long long line",
 +    ]
-+)
++])
  
  
  # Do not hug if the argument fits on a single line.
-@@ -70,10 +88,14 @@
+-func(
+-    {"fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit line"}
+-)
+-func(
+-    ("fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit line")
+-)
+-func(
+-    ["fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit line"]
+-)
+-func(
+-    **{"fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit---"}
+-)
+-func(
+-    *("fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit----")
+-)
++func({
++    "fit line",
++    "fit line",
++    "fit line",
++    "fit line",
++    "fit line",
++    "fit line",
++    "fit line",
++})
++func((
++    "fit line",
++    "fit line",
++    "fit line",
++    "fit line",
++    "fit line",
++    "fit line",
++    "fit line",
++))
++func([
++    "fit line",
++    "fit line",
++    "fit line",
++    "fit line",
++    "fit line",
++    "fit line",
++    "fit line",
++])
++func(**{
++    "fit line",
++    "fit line",
++    "fit line",
++    "fit line",
++    "fit line",
++    "fit line",
++    "fit---",
++})
++func(*(
++    "fit line",
++    "fit line",
++    "fit line",
++    "fit line",
++    "fit line",
++    "fit line",
++    "fit----",
++))
+ array = [
+     {"fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit line"}
+ ]
+@@ -70,10 +104,14 @@
      ["fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit line"]
  ]
  
@@ -171,15 +174,20 @@ nested_array = [[["long line", "long long line", "long long long line", "long lo
 # split out from preview_hug_parens_with_brackes_and_square_brackets, as it produces
 # different code on the second pass with line-length 1 in many cases.
 # Seems to be about whether the last string in a sequence gets wrapped in parens or not.
-foo(
-    *[
-        "long long long long long line",
-        "long long long long long line",
-        "long long long long long line",
-    ]
-)
+foo(*[
+    "long long long long long line",
+    "long long long long long line",
+    "long long long long long line",
+])
 func({"short line"})
-func(
+func({
+    "long line",
+    "long long line",
+    "long long long line",
+    "long long long long line",
+    "long long long long long line",
+})
+func({
     {
         "long line",
         "long long line",
@@ -187,67 +195,78 @@ func(
         "long long long long line",
         "long long long long long line",
     }
-)
-func(
-    {
-        {
-            "long line",
-            "long long line",
-            "long long long line",
-            "long long long long line",
-            "long long long long long line",
-        }
-    }
-)
-func(
-    (
-        "long line",
-        "long long line",
-        "long long long line",
-        "long long long long line",
-        "long long long long long line",
-    )
-)
-func(
-    (
-        (
-            "long line",
-            "long long line",
-            "long long long line",
-            "long long long long line",
-            "long long long long long line",
-        )
-    )
-)
-func(
+})
+func((
+    "long line",
+    "long long line",
+    "long long long line",
+    "long long long long line",
+    "long long long long long line",
+))
+func(((
+    "long line",
+    "long long line",
+    "long long long line",
+    "long long long long line",
+    "long long long long long line",
+)))
+func([
     [
-        [
-            "long line",
-            "long long line",
-            "long long long line",
-            "long long long long line",
-            "long long long long long line",
-        ]
+        "long line",
+        "long long line",
+        "long long long line",
+        "long long long long line",
+        "long long long long long line",
     ]
-)
+])
 
 
 # Do not hug if the argument fits on a single line.
-func(
-    {"fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit line"}
-)
-func(
-    ("fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit line")
-)
-func(
-    ["fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit line"]
-)
-func(
-    **{"fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit---"}
-)
-func(
-    *("fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit----")
-)
+func({
+    "fit line",
+    "fit line",
+    "fit line",
+    "fit line",
+    "fit line",
+    "fit line",
+    "fit line",
+})
+func((
+    "fit line",
+    "fit line",
+    "fit line",
+    "fit line",
+    "fit line",
+    "fit line",
+    "fit line",
+))
+func([
+    "fit line",
+    "fit line",
+    "fit line",
+    "fit line",
+    "fit line",
+    "fit line",
+    "fit line",
+])
+func(**{
+    "fit line",
+    "fit line",
+    "fit line",
+    "fit line",
+    "fit line",
+    "fit line",
+    "fit---",
+})
+func(*(
+    "fit line",
+    "fit line",
+    "fit line",
+    "fit line",
+    "fit line",
+    "fit line",
+    "fit----",
+))
 array = [
     {"fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit line"}
 ]

--- a/crates/ruff_python_formatter/tests/snapshots/black_compatibility@cases__preview_long_dict_values.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/black_compatibility@cases__preview_long_dict_values.py.snap
@@ -114,37 +114,19 @@ class Random:
  }
  
  {
-@@ -52,16 +46,18 @@
- class Random:
-     def func():
-         random_service.status.active_states.inactive = (
--            make_new_top_level_state_from_dict({
--                "topLevelBase": {
--                    "secondaryBase": {
--                        "timestamp": 1234,
--                        "latitude": 1,
--                        "longitude": 2,
+@@ -58,9 +52,9 @@
+                         "timestamp": 1234,
+                         "latitude": 1,
+                         "longitude": 2,
 -                        "actionTimestamp": (
 -                            Timestamp(seconds=1530584000, nanos=0).ToJsonString()
 -                        ),
--                    }
--                },
--            })
-+            make_new_top_level_state_from_dict(
-+                {
-+                    "topLevelBase": {
-+                        "secondaryBase": {
-+                            "timestamp": 1234,
-+                            "latitude": 1,
-+                            "longitude": 2,
-+                            "actionTimestamp": Timestamp(
-+                                seconds=1530584000, nanos=0
-+                            ).ToJsonString(),
-+                        }
-+                    },
-+                }
-+            )
-         )
++                        "actionTimestamp": Timestamp(
++                            seconds=1530584000, nanos=0
++                        ).ToJsonString(),
+                     }
+                 },
+             })
 ```
 
 ## Ruff Output
@@ -198,20 +180,18 @@ my_dict = {
 class Random:
     def func():
         random_service.status.active_states.inactive = (
-            make_new_top_level_state_from_dict(
-                {
-                    "topLevelBase": {
-                        "secondaryBase": {
-                            "timestamp": 1234,
-                            "latitude": 1,
-                            "longitude": 2,
-                            "actionTimestamp": Timestamp(
-                                seconds=1530584000, nanos=0
-                            ).ToJsonString(),
-                        }
-                    },
-                }
-            )
+            make_new_top_level_state_from_dict({
+                "topLevelBase": {
+                    "secondaryBase": {
+                        "timestamp": 1234,
+                        "latitude": 1,
+                        "longitude": 2,
+                        "actionTimestamp": Timestamp(
+                            seconds=1530584000, nanos=0
+                        ).ToJsonString(),
+                    }
+                },
+            })
         )
 ```
 

--- a/crates/ruff_python_formatter/tests/snapshots/black_compatibility@cases__preview_long_strings.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/black_compatibility@cases__preview_long_strings.py.snap
@@ -902,7 +902,7 @@ log.info(f"""Skipping: {'a' == 'b'} {desc['ms_name']} {money=} {dte=} {pos_share
  )
  
  dict_with_lambda_values = {
-@@ -524,61 +383,54 @@
+@@ -524,65 +383,58 @@
  
  # Complex string concatenations with a method call in the middle.
  code = (
@@ -941,7 +941,7 @@ log.info(f"""Skipping: {'a' == 'b'} {desc['ms_name']} {money=} {dte=} {pos_share
  log.info(
 -    "Skipping:"
 -    f" {desc['db_id']} {foo('bar',x=123)} {'foo' != 'bar'} {(x := 'abc=')} {pos_share=} {desc['status']} {desc['exposure_max']}"
-+    f'Skipping: {desc["db_id"]} {foo("bar",x=123)} {"foo" != "bar"} {(x := "abc=")} {pos_share=} {desc["status"]} {desc["exposure_max"]}'
++    f'Skipping: {desc["db_id"]} {foo("bar", x=123)} {"foo" != "bar"} {(x := "abc=")} {pos_share=} {desc["status"]} {desc["exposure_max"]}'
  )
  
  log.info(
@@ -981,6 +981,18 @@ log.info(f"""Skipping: {'a' == 'b'} {desc['ms_name']} {money=} {dte=} {pos_share
  )
  
  log.info(
+-    f"""Skipping: {"a" == 'b'} {desc["ms_name"]} {money=} {dte=} {pos_share=} {desc["status"]} {desc["exposure_max"]}"""
++    f"""Skipping: {"a" == "b"} {desc["ms_name"]} {money=} {dte=} {pos_share=} {desc["status"]} {desc["exposure_max"]}"""
+ )
+ 
+ log.info(
+@@ -590,5 +442,5 @@
+ )
+ 
+ log.info(
+-    f"""Skipping: {'a' == 'b'} {desc['ms_name']} {money=} {dte=} {pos_share=} {desc['status']} {desc['exposure_max']}"""
++    f"""Skipping: {"a" == "b"} {desc["ms_name"]} {money=} {dte=} {pos_share=} {desc["status"]} {desc["exposure_max"]}"""
+ )
 ```
 
 ## Ruff Output
@@ -1394,7 +1406,7 @@ log.info(
 )
 
 log.info(
-    f'Skipping: {desc["db_id"]} {foo("bar",x=123)} {"foo" != "bar"} {(x := "abc=")} {pos_share=} {desc["status"]} {desc["exposure_max"]}'
+    f'Skipping: {desc["db_id"]} {foo("bar", x=123)} {"foo" != "bar"} {(x := "abc=")} {pos_share=} {desc["status"]} {desc["exposure_max"]}'
 )
 
 log.info(
@@ -1422,7 +1434,7 @@ log.info(
 )
 
 log.info(
-    f"""Skipping: {"a" == 'b'} {desc["ms_name"]} {money=} {dte=} {pos_share=} {desc["status"]} {desc["exposure_max"]}"""
+    f"""Skipping: {"a" == "b"} {desc["ms_name"]} {money=} {dte=} {pos_share=} {desc["status"]} {desc["exposure_max"]}"""
 )
 
 log.info(
@@ -1430,7 +1442,7 @@ log.info(
 )
 
 log.info(
-    f"""Skipping: {'a' == 'b'} {desc['ms_name']} {money=} {dte=} {pos_share=} {desc['status']} {desc['exposure_max']}"""
+    f"""Skipping: {"a" == "b"} {desc["ms_name"]} {money=} {dte=} {pos_share=} {desc["status"]} {desc["exposure_max"]}"""
 )
 ```
 

--- a/crates/ruff_python_formatter/tests/snapshots/black_compatibility@cases__preview_long_strings__regression.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/black_compatibility@cases__preview_long_strings__regression.py.snap
@@ -573,7 +573,7 @@ s = f'Lorem Ipsum is simply dummy text of the printing and typesetting industry:
 ```diff
 --- Black
 +++ Ruff
-@@ -25,41 +25,42 @@
+@@ -25,20 +25,17 @@
      "Jaguar",
  )
  
@@ -599,27 +599,7 @@ s = f'Lorem Ipsum is simply dummy text of the printing and typesetting industry:
          )
  
  
- class A:
-     def foo():
--        XXXXXXXXXXXX.append((
--            "xxx_xxxxxxxxxx(xxxxx={}, xxxx={}, xxxxx, xxxx_xxxx_xxxxxxxxxx={})".format(
--                xxxxx, xxxx, xxxx_xxxx_xxxxxxxxxx
--            ),
--            my_var,
--            my_other_var,
--        ))
-+        XXXXXXXXXXXX.append(
-+            (
-+                "xxx_xxxxxxxxxx(xxxxx={}, xxxx={}, xxxxx, xxxx_xxxx_xxxxxxxxxx={})".format(
-+                    xxxxx, xxxx, xxxx_xxxx_xxxxxxxxxx
-+                ),
-+                my_var,
-+                my_other_var,
-+            )
-+        )
- 
- 
- class A:
+@@ -57,9 +54,11 @@
      class B:
          def foo():
              bar(
@@ -634,7 +614,7 @@ s = f'Lorem Ipsum is simply dummy text of the printing and typesetting industry:
                  ),
                  varX,
                  varY,
-@@ -70,9 +71,10 @@
+@@ -70,9 +69,10 @@
  def foo(xxxx):
      for xxx_xxxx, _xxx_xxx, _xxx_xxxxx, xxx_xxxx in xxxx:
          for xxx in xxx_xxxx:
@@ -648,7 +628,7 @@ s = f'Lorem Ipsum is simply dummy text of the printing and typesetting industry:
              )
  
  
-@@ -80,10 +82,11 @@
+@@ -80,10 +80,11 @@
      def disappearing_comment():
          return (
              (  # xx -x xxxxxxx xx xxx xxxxxxx.
@@ -662,7 +642,7 @@ s = f'Lorem Ipsum is simply dummy text of the printing and typesetting industry:
                          "--xxxxxxx --xxxxxx=x --xxxxxx-xxxxx=xxxxxx"
                          " --xxxxxx-xxxx=xxxxxxxxxxx.xxx"
                      )
-@@ -113,18 +116,25 @@
+@@ -113,18 +114,25 @@
  
  
  func_call_where_string_arg_has_method_call_and_bad_parens(
@@ -694,7 +674,7 @@ s = f'Lorem Ipsum is simply dummy text of the printing and typesetting industry:
  )
  
  
-@@ -132,52 +142,60 @@
+@@ -132,52 +140,60 @@
      def append(self):
          if True:
              xxxx.xxxxxxx.xxxxx(
@@ -788,7 +768,7 @@ s = f'Lorem Ipsum is simply dummy text of the printing and typesetting industry:
  }
  
  
-@@ -185,10 +203,10 @@
+@@ -185,10 +201,10 @@
      def foo(self):
          if True:
              xxxxx_xxxxxxxxxxxx(
@@ -803,7 +783,7 @@ s = f'Lorem Ipsum is simply dummy text of the printing and typesetting industry:
              )
  
  
-@@ -232,39 +250,24 @@
+@@ -232,39 +248,24 @@
  
  some_dictionary = {
      "xxxxx006": [
@@ -852,7 +832,7 @@ s = f'Lorem Ipsum is simply dummy text of the printing and typesetting industry:
  
  some_commented_string = (  # This comment stays at the top.
      "This string is long but not so long that it needs hahahah toooooo be so greatttt"
-@@ -279,36 +282,25 @@
+@@ -279,37 +280,26 @@
  )
  
  lpar_and_rpar_have_comments = func_call(  # LPAR Comment
@@ -872,13 +852,13 @@ s = f'Lorem Ipsum is simply dummy text of the printing and typesetting industry:
 -    f" {'' if ID is None else ID} | perl -nE 'print if /^{field}:/'"
 -)
 +cmd_fstring = f"sudo -E deluge-console info --detailed --sort-reverse=time_added {'' if ID is None else ID} | perl -nE 'print if /^{field}:/'"
++
++cmd_fstring = f"sudo -E deluge-console info --detailed --sort-reverse=time_added {'{{}}' if ID is None else ID} | perl -nE 'print if /^{field}:/'"
  
 -cmd_fstring = (
 -    "sudo -E deluge-console info --detailed --sort-reverse=time_added"
 -    f" {'{{}}' if ID is None else ID} | perl -nE 'print if /^{field}:/'"
 -)
-+cmd_fstring = f"sudo -E deluge-console info --detailed --sort-reverse=time_added {'{{}}' if ID is None else ID} | perl -nE 'print if /^{field}:/'"
-+
 +cmd_fstring = f"sudo -E deluge-console info --detailed --sort-reverse=time_added {{'' if ID is None else ID}} | perl -nE 'print if /^{field}:/'"
  
 -cmd_fstring = (
@@ -892,12 +872,13 @@ s = f'Lorem Ipsum is simply dummy text of the printing and typesetting industry:
 -    f" certainly, absolutely {does}."
 +    f"We have to remember to escape {braces}." " Like {these}." f" But not {this}."
  )
--
--fstring = f"We have to remember to escape {braces}. Like {{these}}. But not {this}."
  
+-fstring = f"We have to remember to escape {braces}. Like {{these}}. But not {this}."
+-
  
  class A:
-@@ -364,10 +356,7 @@
+     class B:
+@@ -364,10 +354,7 @@
          def foo():
              if not hasattr(module, name):
                  raise ValueError(
@@ -909,7 +890,7 @@ s = f'Lorem Ipsum is simply dummy text of the printing and typesetting industry:
                      % (name, module_name, get_docs_version())
                  )
  
-@@ -382,35 +371,33 @@
+@@ -382,23 +369,19 @@
  
  class Step(StepBase):
      def who(self):
@@ -931,29 +912,16 @@ s = f'Lorem Ipsum is simply dummy text of the printing and typesetting industry:
          )
  
  
--xxxxxxx_xxxxxx_xxxxxxx = xxx([
--    xxxxxxxxxxxx(
--        xxxxxx_xxxxxxx=(
+ xxxxxxx_xxxxxx_xxxxxxx = xxx([
+     xxxxxxxxxxxx(
+         xxxxxx_xxxxxxx=(
 -            '((x.aaaaaaaaa = "xxxxxx.xxxxxxxxxxxxxxxxxxxxx") || (x.xxxxxxxxx ='
 -            ' "xxxxxxxxxxxx")) && '
--            # xxxxx xxxxxxxxxxxx xxxx xxx (xxxxxxxxxxxxxxxx) xx x xxxxxxxxx xx xxxxxx.
--            "(x.bbbbbbbbbbbb.xxx != "
--            '"xxx:xxx:xxx::cccccccccccc:xxxxxxx-xxxx/xxxxxxxxxxx/xxxxxxxxxxxxxxxxx") && '
-+xxxxxxx_xxxxxx_xxxxxxx = xxx(
-+    [
-+        xxxxxxxxxxxx(
-+            xxxxxx_xxxxxxx=(
-+                '((x.aaaaaaaaa = "xxxxxx.xxxxxxxxxxxxxxxxxxxxx") || (x.xxxxxxxxx = "xxxxxxxxxxxx")) && '
-+                # xxxxx xxxxxxxxxxxx xxxx xxx (xxxxxxxxxxxxxxxx) xx x xxxxxxxxx xx xxxxxx.
-+                "(x.bbbbbbbbbbbb.xxx != "
-+                '"xxx:xxx:xxx::cccccccccccc:xxxxxxx-xxxx/xxxxxxxxxxx/xxxxxxxxxxxxxxxxx") && '
-+            )
-         )
--    )
--])
-+    ]
-+)
- 
++            '((x.aaaaaaaaa = "xxxxxx.xxxxxxxxxxxxxxxxxxxxx") || (x.xxxxxxxxx = "xxxxxxxxxxxx")) && '
+             # xxxxx xxxxxxxxxxxx xxxx xxx (xxxxxxxxxxxxxxxx) xx x xxxxxxxxx xx xxxxxx.
+             "(x.bbbbbbbbbbbb.xxx != "
+             '"xxx:xxx:xxx::cccccccccccc:xxxxxxx-xxxx/xxxxxxxxxxx/xxxxxxxxxxxxxxxxx") && '
+@@ -409,8 +392,8 @@
  if __name__ == "__main__":
      for i in range(4, 8):
          cmd = (
@@ -964,7 +932,7 @@ s = f'Lorem Ipsum is simply dummy text of the printing and typesetting industry:
          )
  
  
-@@ -432,9 +419,7 @@
+@@ -432,9 +415,7 @@
          assert xxxxxxx_xxxx in [
              x.xxxxx.xxxxxx.xxxxx.xxxxxx,
              x.xxxxx.xxxxxx.xxxxx.xxxx,
@@ -975,7 +943,7 @@ s = f'Lorem Ipsum is simply dummy text of the printing and typesetting industry:
  
  
  value.__dict__[key] = (
-@@ -449,8 +434,7 @@
+@@ -449,8 +430,7 @@
  
  RE_TWO_BACKSLASHES = {
      "asdf_hjkl_jkl": re.compile(
@@ -985,23 +953,23 @@ s = f'Lorem Ipsum is simply dummy text of the printing and typesetting industry:
      ),
  }
  
-@@ -462,13 +446,9 @@
+@@ -462,13 +442,9 @@
  
  # We do NOT split on f-string expressions.
  print(
 -    "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam."
 -    f" {[f'{i}' for i in range(10)]}"
--)
++    f"Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam. {[f'{i}' for i in range(10)]}"
+ )
 -x = (
 -    "This is a long string which contains an f-expr that should not split"
 -    f" {{{[i for i in range(5)]}}}."
-+    f"Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam. {[f'{i}' for i in range(10)]}"
- )
+-)
 +x = f"This is a long string which contains an f-expr that should not split {{{[i for i in range(5)]}}}."
  
  # The parens should NOT be removed in this case.
  (
-@@ -478,8 +458,8 @@
+@@ -478,8 +454,8 @@
  
  # The parens should NOT be removed in this case.
  (
@@ -1012,7 +980,13 @@ s = f'Lorem Ipsum is simply dummy text of the printing and typesetting industry:
  )
  
  # The parens should NOT be removed in this case.
-@@ -518,88 +498,78 @@
+@@ -513,93 +489,83 @@
+ 
+ 
+ temp_msg = (
+-    f"{f'{humanize_number(pos)}.': <{pound_len+2}} "
++    f"{f'{humanize_number(pos)}.': <{pound_len + 2}} "
+     f"{balance: <{bal_len + 5}} "
      f"<<{author.display_name}>>\n"
  )
  
@@ -1136,7 +1110,13 @@ s = f'Lorem Ipsum is simply dummy text of the printing and typesetting industry:
      "6. Click on Create Credential at the top."
      '7. At the top click the link for "API key".'
      "8. No application restrictions are needed. Click Create at the bottom."
-@@ -613,55 +583,40 @@
+@@ -608,60 +574,45 @@
+ 
+ # It shouldn't matter if the string prefixes are capitalized.
+ temp_msg = (
+-    f"{F'{humanize_number(pos)}.': <{pound_len+2}} "
++    f"{f'{humanize_number(pos)}.': <{pound_len + 2}} "
+     f"{balance: <{bal_len + 5}} "
      f"<<{author.display_name}>>\n"
  )
  
@@ -1209,7 +1189,7 @@ s = f'Lorem Ipsum is simply dummy text of the printing and typesetting industry:
  )
  
  # Regression test for https://github.com/psf/black/issues/3455.
-@@ -672,9 +627,11 @@
+@@ -672,9 +623,11 @@
  }
  
  # Regression test for https://github.com/psf/black/issues/3506.
@@ -1273,15 +1253,13 @@ class A:
 
 class A:
     def foo():
-        XXXXXXXXXXXX.append(
-            (
-                "xxx_xxxxxxxxxx(xxxxx={}, xxxx={}, xxxxx, xxxx_xxxx_xxxxxxxxxx={})".format(
-                    xxxxx, xxxx, xxxx_xxxx_xxxxxxxxxx
-                ),
-                my_var,
-                my_other_var,
-            )
-        )
+        XXXXXXXXXXXX.append((
+            "xxx_xxxxxxxxxx(xxxxx={}, xxxx={}, xxxxx, xxxx_xxxx_xxxxxxxxxx={})".format(
+                xxxxx, xxxx, xxxx_xxxx_xxxxxxxxxx
+            ),
+            my_var,
+            my_other_var,
+        ))
 
 
 class A:
@@ -1612,18 +1590,16 @@ class Step(StepBase):
         )
 
 
-xxxxxxx_xxxxxx_xxxxxxx = xxx(
-    [
-        xxxxxxxxxxxx(
-            xxxxxx_xxxxxxx=(
-                '((x.aaaaaaaaa = "xxxxxx.xxxxxxxxxxxxxxxxxxxxx") || (x.xxxxxxxxx = "xxxxxxxxxxxx")) && '
-                # xxxxx xxxxxxxxxxxx xxxx xxx (xxxxxxxxxxxxxxxx) xx x xxxxxxxxx xx xxxxxx.
-                "(x.bbbbbbbbbbbb.xxx != "
-                '"xxx:xxx:xxx::cccccccccccc:xxxxxxx-xxxx/xxxxxxxxxxx/xxxxxxxxxxxxxxxxx") && '
-            )
+xxxxxxx_xxxxxx_xxxxxxx = xxx([
+    xxxxxxxxxxxx(
+        xxxxxx_xxxxxxx=(
+            '((x.aaaaaaaaa = "xxxxxx.xxxxxxxxxxxxxxxxxxxxx") || (x.xxxxxxxxx = "xxxxxxxxxxxx")) && '
+            # xxxxx xxxxxxxxxxxx xxxx xxx (xxxxxxxxxxxxxxxx) xx x xxxxxxxxx xx xxxxxx.
+            "(x.bbbbbbbbbbbb.xxx != "
+            '"xxx:xxx:xxx::cccccccccccc:xxxxxxx-xxxx/xxxxxxxxxxx/xxxxxxxxxxxxxxxxx") && '
         )
-    ]
-)
+    )
+])
 
 if __name__ == "__main__":
     for i in range(4, 8):
@@ -1725,7 +1701,7 @@ class X:
 
 
 temp_msg = (
-    f"{f'{humanize_number(pos)}.': <{pound_len+2}} "
+    f"{f'{humanize_number(pos)}.': <{pound_len + 2}} "
     f"{balance: <{bal_len + 5}} "
     f"<<{author.display_name}>>\n"
 )
@@ -1810,7 +1786,7 @@ message = (
 
 # It shouldn't matter if the string prefixes are capitalized.
 temp_msg = (
-    f"{F'{humanize_number(pos)}.': <{pound_len+2}} "
+    f"{f'{humanize_number(pos)}.': <{pound_len + 2}} "
     f"{balance: <{bal_len + 5}} "
     f"<<{author.display_name}>>\n"
 )


### PR DESCRIPTION
## Summary

This PR updates the Black test corpus and enables preview mode for all tests that require `unstable` in black (similar to preview but these styles have known bugs)

## Test Plan

`cargo test`
