### PR TITLE
[red-knot] Inference for comparison of union types

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/comparison/unions.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/comparison/unions.md
@@ -62,3 +62,16 @@ reveal_type(small > large)   # revealed: Literal[False]
 reveal_type(small >= large)  # revealed: Literal[False] | bool
 reveal_type(small < large)   # revealed: Literal[True] | bool
 ```
+
+## Unsupported operations
+
+Make sure we emit a diagnostic if *any* of the possible comparisons is
+unsupported. For now, we fall back to `bool` for the result type instead of
+trying to infer something more precise from the other (supported) variants:
+
+```py
+x = [1, 2] if flag else 1
+
+result = 1 in x  # error: "Operator `in` is not supported"
+reveal_type(result)  # revealed: bool
+```

--- a/crates/red_knot_python_semantic/resources/mdtest/comparison/unions.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/comparison/unions.md
@@ -1,4 +1,4 @@
-### Comparison: Unions
+# Comparison: Unions
 
 ## Union on one side of the comparison
 

--- a/crates/red_knot_python_semantic/resources/mdtest/comparison/unions.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/comparison/unions.md
@@ -1,0 +1,64 @@
+### Comparison: Unions
+
+## Union on one side of the comparison
+
+Comparisons on union types need to consider all possible cases:
+
+```py
+one_or_two = 1 if flag else 2
+
+reveal_type(one_or_two <= 2)  # revealed: Literal[True]
+reveal_type(one_or_two <= 1)  # revealed: bool
+reveal_type(one_or_two <= 0)  # revealed: Literal[False]
+
+reveal_type(2 >= one_or_two)  # revealed: Literal[True]
+reveal_type(1 >= one_or_two)  # revealed: bool
+reveal_type(0 >= one_or_two)  # revealed: Literal[False]
+
+reveal_type(one_or_two < 1)  # revealed: Literal[False]
+reveal_type(one_or_two < 2)  # revealed: bool
+reveal_type(one_or_two < 3)  # revealed: Literal[True]
+
+reveal_type(one_or_two > 0)  # revealed: Literal[True]
+reveal_type(one_or_two > 1)  # revealed: bool
+reveal_type(one_or_two > 2)  # revealed: Literal[False]
+
+reveal_type(one_or_two == 3)  # revealed: Literal[False]
+reveal_type(one_or_two == 1)  # revealed: bool
+
+reveal_type(one_or_two != 3)  # revealed: Literal[True]
+reveal_type(one_or_two != 1)  # revealed: bool
+
+a_or_ab = "a" if flag else "ab"
+
+reveal_type(a_or_ab in "ab")  # revealed: Literal[True]
+reveal_type("a" in a_or_ab)  # revealed: Literal[True]
+
+reveal_type("c" not in a_or_ab)  # revealed: Literal[True]
+reveal_type("a" not in a_or_ab)  # revealed: Literal[False]
+
+reveal_type("b" in a_or_ab)  # revealed: bool
+reveal_type("b" not in a_or_ab)  # revealed: bool
+
+one_or_none = 1 if flag else None
+
+reveal_type(one_or_none is None)  # revealed: bool
+reveal_type(one_or_none is not None)  # revealed: bool
+```
+
+## Union on both sides of the comparison
+
+With unions on both sides, we need to consider the full cross product of
+options when building the resulting (union) type:
+
+```py
+small = 1 if flag_s else 2
+large = 2 if flag_l else 3
+
+reveal_type(small <= large)  # revealed: Literal[True]
+reveal_type(small > large)   # revealed: Literal[False]
+
+# TODO both of the following should be simplified to `bool`
+reveal_type(small >= large)  # revealed: Literal[False] | bool
+reveal_type(small < large)   # revealed: Literal[True] | bool
+```

--- a/crates/red_knot_python_semantic/resources/mdtest/comparison/unions.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/comparison/unions.md
@@ -56,11 +56,10 @@ small = 1 if flag_s else 2
 large = 2 if flag_l else 3
 
 reveal_type(small <= large)  # revealed: Literal[True]
-reveal_type(small > large)   # revealed: Literal[False]
+reveal_type(small >= large)  # revealed: bool
 
-# TODO both of the following should be simplified to `bool`
-reveal_type(small >= large)  # revealed: Literal[False] | bool
-reveal_type(small < large)   # revealed: Literal[True] | bool
+reveal_type(small < large)   # revealed: bool
+reveal_type(small > large)   # revealed: Literal[False]
 ```
 
 ## Unsupported operations

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -415,6 +415,11 @@ impl<'db> Type<'db> {
             (_, Type::Unknown | Type::Any | Type::Todo) => false,
             (Type::Never, _) => true,
             (_, Type::Never) => false,
+            (Type::BooleanLiteral(_), Type::Instance(class))
+                if class.is_known(db, KnownClass::Bool) =>
+            {
+                true
+            }
             (Type::IntLiteral(_), Type::Instance(class)) if class.is_known(db, KnownClass::Int) => {
                 true
             }

--- a/crates/red_knot_python_semantic/src/types/builder.rs
+++ b/crates/red_knot_python_semantic/src/types/builder.rs
@@ -374,6 +374,12 @@ mod tests {
 
         let union = UnionType::from_elements(&db, [t0, t1, t2, t3]).expect_union();
         assert_eq!(union.elements(&db), &[bool_instance_ty, t3]);
+
+        let result_ty = UnionType::from_elements(&db, [bool_instance_ty, t0]);
+        assert_eq!(result_ty, bool_instance_ty);
+
+        let result_ty = UnionType::from_elements(&db, [t0, bool_instance_ty]);
+        assert_eq!(result_ty, bool_instance_ty);
     }
 
     #[test]


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Add type inference for comparisons involving union types. For example:
```py
one_or_two = 1 if flag else 2

reveal_type(one_or_two <= 2)  # revealed: Literal[True]
reveal_type(one_or_two <= 1)  # revealed: bool
reveal_type(one_or_two <= 0)  # revealed: Literal[False]
```

closes #13779

## Test Plan

See `resources/mdtest/comparison/unions.md`
