### PR TITLE
Do not put a space between `#` and `SBATCH` for comments

### DIFF
--- a/crates/ruff_python_formatter/src/comments/format.rs
+++ b/crates/ruff_python_formatter/src/comments/format.rs
@@ -482,6 +482,13 @@ fn normalize_comment<'a>(
         return Ok(Cow::Borrowed(trimmed));
     }
 
+    // Parameters for sbatch job scripts start with `#SBATCH`.
+    // Putting a space between `#` and `SBATCH` causes sbatch to no longer recognize the
+    // comment as a parameter directive.
+    if comment.line_position().is_own_line() && content.starts_with("SBATCH") {
+        return Ok(Cow::Borrowed(trimmed));
+    }
+
     // Otherwise, we need to normalize the comment by adding a space after the `#`.
     if content.starts_with('\u{A0}') {
         let trimmed = content.trim_start_matches('\u{A0}');


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary
The Slurm workload manager allows users to create job scripts and specify parameters to run the job with `#SBATCH [flag]`.
ruff currently reformats these to `# SBATCH [flag]`, which isn't recognized by Slurm because of the extra space.
This commit checks if comments start with `SBATCH`, and if so, does not add the space, similar to how shebangs are treated.
<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan
I didn't see any existing tests for adding that space, so I didn't add any of my own. I could go back and add tests though, if requested.
<!-- How was it tested? -->

## Additional Note
I understand if this doesn't get merged, since this change does technically constitute intentionally violating formatting guidelines.
However, this violation is in a situation where the user would very rarely want the current behavior.
