### PR TITLE
[red-knot] binary arithmetic on instances

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/binary/instances.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/binary/instances.md
@@ -14,21 +14,48 @@ We support inference for all Python's binary operators:
 
 ```py
 class A:
-    def __add__(self, other) -> A: return self
-    def __sub__(self, other) -> A: return self
-    def __mul__(self, other) -> A: return self
-    def __matmul__(self, other) -> A: return self
-    def __truediv__(self, other) -> A: return self
-    def __floordiv__(self, other) -> A: return self
-    def __mod__(self, other) -> A: return self
-    def __pow__(self, other) -> A: return self
-    def __lshift__(self, other) -> A: return self
-    def __rshift__(self, other) -> A: return self
-    def __and__(self, other) -> A: return self
-    def __xor__(self, other) -> A: return self
-    def __or__(self, other) -> A: return self
+    def __add__(self, other) -> A:
+        return self
 
-class B: pass
+    def __sub__(self, other) -> A:
+        return self
+
+    def __mul__(self, other) -> A:
+        return self
+
+    def __matmul__(self, other) -> A:
+        return self
+
+    def __truediv__(self, other) -> A:
+        return self
+
+    def __floordiv__(self, other) -> A:
+        return self
+
+    def __mod__(self, other) -> A:
+        return self
+
+    def __pow__(self, other) -> A:
+        return self
+
+    def __lshift__(self, other) -> A:
+        return self
+
+    def __rshift__(self, other) -> A:
+        return self
+
+    def __and__(self, other) -> A:
+        return self
+
+    def __xor__(self, other) -> A:
+        return self
+
+    def __or__(self, other) -> A:
+        return self
+
+
+class B: ...
+
 
 reveal_type(A() + B())  # revealed: A
 reveal_type(A() - B())  # revealed: A
@@ -51,21 +78,48 @@ We also support inference for reflected operations:
 
 ```py
 class A:
-    def __radd__(self, other) -> A: return self
-    def __rsub__(self, other) -> A: return self
-    def __rmul__(self, other) -> A: return self
-    def __rmatmul__(self, other) -> A: return self
-    def __rtruediv__(self, other) -> A: return self
-    def __rfloordiv__(self, other) -> A: return self
-    def __rmod__(self, other) -> A: return self
-    def __rpow__(self, other) -> A: return self
-    def __rlshift__(self, other) -> A: return self
-    def __rrshift__(self, other) -> A: return self
-    def __rand__(self, other) -> A: return self
-    def __rxor__(self, other) -> A: return self
-    def __ror__(self, other) -> A: return self
+    def __radd__(self, other) -> A:
+        return self
 
-class B: pass
+    def __rsub__(self, other) -> A:
+        return self
+
+    def __rmul__(self, other) -> A:
+        return self
+
+    def __rmatmul__(self, other) -> A:
+        return self
+
+    def __rtruediv__(self, other) -> A:
+        return self
+
+    def __rfloordiv__(self, other) -> A:
+        return self
+
+    def __rmod__(self, other) -> A:
+        return self
+
+    def __rpow__(self, other) -> A:
+        return self
+
+    def __rlshift__(self, other) -> A:
+        return self
+
+    def __rrshift__(self, other) -> A:
+        return self
+
+    def __rand__(self, other) -> A:
+        return self
+
+    def __rxor__(self, other) -> A:
+        return self
+
+    def __ror__(self, other) -> A:
+        return self
+
+
+class B: ...
+
 
 reveal_type(B() + A())  # revealed: A
 reveal_type(B() - A())  # revealed: A
@@ -88,11 +142,15 @@ The magic methods aren't required to return the type of `self`:
 
 ```py
 class A:
-    def __add__(self, other) -> int: return 1
-    def __rsub__(self, other) -> int: return 1
+    def __add__(self, other) -> int:
+        return 1
 
-class B:
-    pass
+    def __rsub__(self, other) -> int:
+        return 1
+
+
+class B: ...
+
 
 reveal_type(A() + B())  # revealed: int
 reveal_type(B() - A())  # revealed: int
@@ -106,18 +164,27 @@ side, `lhs.__add__` will take precedence:
 
 ```py
 class A:
-    def __add__(self, other: B) -> int: return 42
+    def __add__(self, other: B) -> int:
+        return 42
+
 
 class B:
-    def __radd__(self, other: A) -> str: return "foo"
+    def __radd__(self, other: A) -> str:
+        return "foo"
+
 
 reveal_type(A() + B())  # revealed:  int
+
 
 # Edge case: C is a subtype of C, *but* if the two sides are of *equal* types,
 # the lhs *still* takes precedence
 class C:
-    def __add__(self, other: C) -> int: return 42
-    def __radd__(self, other: C) -> str: return "foo"
+    def __add__(self, other: C) -> int:
+        return 42
+
+    def __radd__(self, other: C) -> str:
+        return "foo"
+
 
 reveal_type(C() + C())  # revealed: int
 ```
@@ -130,18 +197,27 @@ right-hand operand takes precedence.
 
 ```py
 class A:
-    def __add__(self, other) -> str: return "foo"
-    def __radd__(self, other) -> str: return "foo"
+    def __add__(self, other) -> str:
+        return "foo"
+
+    def __radd__(self, other) -> str:
+        return "foo"
+
 
 class MyString(str): ...
 
+
 class B(A):
-    def __radd__(self, other) -> MyString: return MyString()
+    def __radd__(self, other) -> MyString:
+        return MyString()
+
 
 reveal_type(A() + B())  # revealed: MyString
 
+
 # N.B. Still a subtype of `A`, even though `A` does not appear directly in the class's `__bases__`
 class C(B): ...
+
 
 # TODO: we currently only understand direct subclasses as subtypes of the superclass.
 # We need to iterate through the full MRO rather than just the class's bases;
@@ -158,10 +234,15 @@ still takes precedence:
 
 ```py
 class A:
-    def __add__(self, other) -> str: return "foo"
-    def __radd__(self, other) -> int: return 42
+    def __add__(self, other) -> str:
+        return "foo"
 
-class B(A): pass
+    def __radd__(self, other) -> int:
+        return 42
+
+
+class B(A): ...
+
 
 reveal_type(A() + B())  # revealed: str
 ```
@@ -185,9 +266,11 @@ class A:
     def __sub__(self, other: A) -> A:
         return A()
 
+
 class B:
     def __rsub__(self, other: A) -> B:
         return B()
+
 
 # TODO: this should be `B` (the return annotation of `B.__rsub__`),
 # because `A.__sub__` is annotated as only accepting `A`,
@@ -204,8 +287,10 @@ class A:
     def __call__(self, other) -> int:
         return 42
 
+
 class B:
     __add__ = A()
+
 
 reveal_type(B() + B())  # revealed: int
 ```
@@ -226,11 +311,14 @@ reveal_type(42 + 4.2)  # revealed: int
 # TODO should be complex, need to check arg type and fall back to `rhs.__radd__`
 reveal_type(3 + 3j)  # revealed: int
 
+
 def returns_int() -> int:
     return 42
 
+
 def returns_bool() -> bool:
     return True
+
 
 x = returns_bool()
 y = returns_int()
@@ -249,8 +337,12 @@ instance handling for its instance super-type.
 
 ```py
 class A:
-    def __add__(self, other) -> A: return self
-    def __radd__(self, other) -> A: return self
+    def __add__(self, other) -> A:
+        return self
+
+    def __radd__(self, other) -> A:
+        return self
+
 
 reveal_type(A() + 1)  # revealed: A
 # TODO should be `A` since `int.__add__` doesn't support `A` instances
@@ -296,12 +388,14 @@ from does_not_exist import Foo  # error: [unresolved-import]
 
 reveal_type(Foo)  # revealed: Unknown
 
+
 class X:
     def __add__(self, other: object) -> int:
         return 42
 
-class Y(Foo):
-    pass
+
+class Y(Foo): ...
+
 
 # TODO: Should be `int | Unknown`; see above discussion.
 reveal_type(X() + Y())  # revealed: int
@@ -314,11 +408,14 @@ reveal_type(X() + Y())  # revealed: int
 The magic method must exist on the class, not just on the instance:
 
 ```py
-def add_impl(self, other) -> int: return 1
+def add_impl(self, other) -> int:
+    return 1
+
 
 class A:
     def __init__(self):
         self.__add__ = add_impl
+
 
 # error: [unsupported-operator] "Operator `+` is unsupported between objects of type `A` and `A`"
 # revealed: Unknown
@@ -328,7 +425,8 @@ reveal_type(A() + A())
 ### Missing dunder
 
 ```py
-class A: pass
+class A: ...
+
 
 # error: [unsupported-operator]
 # revealed: Unknown
@@ -343,10 +441,13 @@ A left-hand dunder method doesn't apply for the right-hand operand, or vice vers
 class A:
     def __add__(self, other) -> int: ...
 
+
 class B:
     def __radd__(self, other) -> int: ...
 
-class C: pass
+
+class C: ...
+
 
 # error: [unsupported-operator]
 # revealed: Unknown

--- a/crates/red_knot_python_semantic/resources/mdtest/binary/instances.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/binary/instances.md
@@ -302,7 +302,7 @@ class Y(Foo):
     pass
 
 # TODO: Should be `int | Unknown`; see above discussion.
-reveal_type(X() + Y())  # revealed: int
+reveal_type(X() + Y())  # revealed: Unknown
 ```
 
 ## Unsupported

--- a/crates/red_knot_python_semantic/resources/mdtest/binary/instances.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/binary/instances.md
@@ -302,7 +302,7 @@ class Y(Foo):
     pass
 
 # TODO: Should be `int | Unknown`; see above discussion.
-reveal_type(X() + Y())  # revealed: Unknown
+reveal_type(X() + Y())  # revealed: int
 ```
 
 ## Unsupported

--- a/crates/red_knot_python_semantic/resources/mdtest/binary/instances.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/binary/instances.md
@@ -265,7 +265,7 @@ class A:
     def __init__(self):
         self.__add__ = add_impl
 
-# error: [operator]
+# error: [unsupported-operator] "Operator `+` is unsupported between objects of type `A` and `A`"
 # revealed: Unknown
 reveal_type(A() + A())
 ```
@@ -275,7 +275,7 @@ reveal_type(A() + A())
 ```py
 class A: pass
 
-# error: [operator]
+# error: [unsupported-operator]
 # revealed: Unknown
 reveal_type(A() + A())
 ```
@@ -293,11 +293,11 @@ class B:
 
 class C: pass
 
-# error: [operator]
+# error: [unsupported-operator]
 # revealed: Unknown
 reveal_type(C() + A())
 
-# error: [operator]
+# error: [unsupported-operator]
 # revealed: Unknown
 reveal_type(B() + C())
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/binary/instances.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/binary/instances.md
@@ -142,7 +142,11 @@ reveal_type(A() + B())  # revealed: MyString
 # N.B. Still a subtype of `A`, even though `A` does not appear directly in the class's `__bases__`
 class C(B): ...
 
-reveal_type(A() + C())  # revealed: MyString
+# TODO: we currently only understand direct subclasses as subtypes of the superclass.
+# We need to iterate through the full MRO rather than just the class's bases;
+# if we do, we'll understand `C` as a subtype of `A`, and correctly understand this as being
+# `MyString` rather than `str`
+reveal_type(A() + C())  # revealed: str
 ```
 
 ## Reflected precedence 2

--- a/crates/red_knot_python_semantic/resources/mdtest/binary/instances.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/binary/instances.md
@@ -1,0 +1,264 @@
+# Binary operations on instances
+
+Binary operations in Python are implemented by means of magic double-underscore methods.
+
+For references, see:
+
+- <https://snarky.ca/unravelling-binary-arithmetic-operations-in-python/>
+- <https://docs.python.org/3/reference/datamodel.html#emulating-numeric-types>
+
+## Operations
+
+We support inference for all Python's binary operators:
+`+`, `-`, `*`, `@`, `/`, `//`, `%`, `**`, `<<`, `>>`, `&`, `^`, and `|`.
+
+```py
+class A:
+    def __add__(self, other) -> A: return self
+    def __sub__(self, other) -> A: return self
+    def __mul__(self, other) -> A: return self
+    def __matmul__(self, other) -> A: return self
+    def __truediv__(self, other) -> A: return self
+    def __floordiv__(self, other) -> A: return self
+    def __mod__(self, other) -> A: return self
+    def __pow__(self, other) -> A: return self
+    def __lshift__(self, other) -> A: return self
+    def __rshift__(self, other) -> A: return self
+    def __and__(self, other) -> A: return self
+    def __xor__(self, other) -> A: return self
+    def __or__(self, other) -> A: return self
+
+class B: pass
+
+reveal_type(A() + B())  # revealed: A
+reveal_type(A() - B())  # revealed: A
+reveal_type(A() * B())  # revealed: A
+reveal_type(A() @ B())  # revealed: A
+reveal_type(A() / B())  # revealed: A
+reveal_type(A() // B())  # revealed: A
+reveal_type(A() % B())  # revealed: A
+reveal_type(A() ** B())  # revealed: A
+reveal_type(A() << B())  # revealed: A
+reveal_type(A() >> B())  # revealed: A
+reveal_type(A() & B())  # revealed: A
+reveal_type(A() ^ B())  # revealed: A
+reveal_type(A() | B())  # revealed: A
+```
+
+## Reflected
+
+We also support inference for reflected operations:
+
+```py
+class A:
+    def __radd__(self, other) -> A: return self
+    def __rsub__(self, other) -> A: return self
+    def __rmul__(self, other) -> A: return self
+    def __rmatmul__(self, other) -> A: return self
+    def __rtruediv__(self, other) -> A: return self
+    def __rfloordiv__(self, other) -> A: return self
+    def __rmod__(self, other) -> A: return self
+    def __rpow__(self, other) -> A: return self
+    def __rlshift__(self, other) -> A: return self
+    def __rrshift__(self, other) -> A: return self
+    def __rand__(self, other) -> A: return self
+    def __rxor__(self, other) -> A: return self
+    def __ror__(self, other) -> A: return self
+
+class B: pass
+    
+
+reveal_type(B() + A())  # revealed: A
+reveal_type(B() - A())  # revealed: A
+reveal_type(B() * A())  # revealed: A
+reveal_type(B() @ A())  # revealed: A
+reveal_type(B() / A())  # revealed: A
+reveal_type(B() // A())  # revealed: A
+reveal_type(B() % A())  # revealed: A
+reveal_type(B() ** A())  # revealed: A
+reveal_type(B() << A())  # revealed: A
+reveal_type(B() >> A())  # revealed: A
+reveal_type(B() & A())  # revealed: A
+reveal_type(B() ^ A())  # revealed: A
+reveal_type(B() | A())  # revealed: A
+```
+
+## Return different type
+
+The magic methods aren't required to return the type of `self`:
+
+```py
+class A:
+    def __add__(self, other) -> int: return 1
+    def __rsub__(self, other) -> int: return 1
+
+reveal_type(A() + "foo")  # revealed: int
+reveal_type("foo" - A())  # revealed: int
+```
+
+## Reflected precedence
+
+If the right-hand operand is a subtype of the left-hand operand and has a
+different implementation of the reflected method, the reflected method on the
+right-hand operand takes precedence.
+
+```py
+class A:
+    def __add__(self, other) -> str: return "foo"
+
+class B(A):
+    def __radd__(self, other) -> int: return 42
+
+reveal_type(A() + B())  # revealed: int
+```
+
+## Reflected precedence 2
+
+If the right-hand operand is a subtype of the left-hand operand, but does not
+override the reflected method, the left-hand operand's non-reflected method
+still takes precedence:
+
+```py
+class A:
+    def __add__(self, other) -> str: return "foo"
+    def __radd__(self, other) -> int: return 42
+
+class B(A): pass
+
+reveal_type(A() + B())  # revealed: str
+```
+
+## Only reflected supported
+
+For example, at runtime, `(1).__add__(1.2)` is `NotImplemented`, but
+`(1.2).__radd__(1) == 2.2`, meaning that `1 + 1.2` succeeds at runtime
+(producing `2.2`).
+
+```py
+class A:
+    def __sub__(self, other: A) -> A:
+        return A()
+
+class B:
+    def __rsub__(self, other: A) -> B:
+        return B()
+
+A() - B()
+```
+
+## Callable instances as dunders
+
+Believe it or not, this is supported at runtime:
+
+```py
+class A:
+    def __call__(self, other) -> int:
+        return 42
+
+class B:
+    __add__ = A()
+
+reveal_type(B() + B())  # revealed: int
+```
+
+## Integration test: numbers from typeshed
+
+```py
+# TODO should be complex, need to check arg type and fall back
+reveal_type(3.14 + 3j)  # revealed: float
+reveal_type(3j + 3.14)  # revealed: complex
+# TODO should be float, need to check arg type and fall back
+reveal_type(42 + 4.2)  # revealed: int
+reveal_type(4.2 + 42)  # revealed: float
+reveal_type(3j + 3)  # revealed: complex
+# TODO should be complex, need to check arg type and fall back
+reveal_type(3 + 3j)  # revealed: int
+
+def returns_int() -> int:
+    return 42
+
+def returns_bool() -> bool:
+    return True
+
+x = returns_bool
+
+reveal_type(returns_bool() + returns_int())  # revealed: int
+# TODO should be float, need to check arg type and fall back
+reveal_type(returns_int() + 4.12)  # revealed: int
+reveal_type(4.2 + returns_bool())  # revealed: float
+```
+
+## With literal types
+
+When we have a literal type for one operand, we're able to fall back to the
+instance handling for its instance super-type.
+
+```py
+class A:
+    def __add__(self, other) -> A: return self
+    def __radd__(self, other) -> A: return self
+
+reveal_type(A() + 1)  # revealed: A
+reveal_type(1 + A())  # revealed: int
+reveal_type(A() + "foo")  # revealed: A
+# TODO should be A since `str.__add__` doesn't support A instances
+reveal_type("foo" + A())  # revealed: @Todo
+reveal_type(A() + b"foo")  # revealed: A
+reveal_type(b"foo" + A())  # revealed: bytes
+reveal_type(A() + ())  # revealed: A
+# TODO this should be A, since tuple's `__add__` doesn't support A instances
+reveal_type(() + A())  # revealed: @Todo
+```
+
+## Unsupported
+
+### Dunder on instance
+
+The magic method must be on the class, not just on the instance:
+
+```py
+def add_impl(self, other) -> int: return 1
+
+class A:
+    def __init__(self):
+        self.__add__ = add_impl
+
+a = A()
+
+# error: [operator]
+# revealed: Unknown
+reveal_type(a + 1)
+```
+
+### Missing dunder
+
+```py
+class A: pass
+
+# error: [operator]
+# revealed: Unknown
+reveal_type(A() + A())
+```
+
+### Wrong position
+
+A left-hand dunder method doesn't apply for the right-hand operand, or vice versa:
+
+```py
+class A:
+    def __add__(self, other) -> int: ...
+
+class B:
+    def __radd__(self, other) -> int: ...
+
+# error: [operator]
+# revealed: Unknown
+reveal_type(1 + A())
+# error: [operator]
+# revealed: Unknown
+reveal_type(B() + 1)
+```
+
+### Wrong type
+
+TODO: check signature and error if `other` is the wrong type

--- a/crates/red_knot_python_semantic/resources/mdtest/binary/instances.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/binary/instances.md
@@ -111,7 +111,14 @@ class A:
 class B:
     def __radd__(self, other: A) -> str: return "foo"
 
+# C is a subtype of C, but if the two sides are of equal types,
+# the lhs *still* takes precedence
+class C:
+    def __add__(self, other: C) -> int: return 42
+    def __radd__(self, other: C) -> str: return "foo"
+
 reveal_type(A() + B())  # revealed:  int
+reveal_type(C() + C())  # revealed: int
 ```
 
 ## Reflected precedence for subtypes (in some cases)
@@ -125,12 +132,17 @@ class A:
     def __add__(self, other) -> str: return "foo"
     def __radd__(self, other) -> str: return "foo"
 
-class MyString(str): pass
+class MyString(str): ...
 
 class B(A):
     def __radd__(self, other) -> MyString: return MyString()
 
 reveal_type(A() + B())  # revealed: MyString
+
+# N.B. Still a subtype of `A`, even though `A` does not appear directly in the class's `__bases__`
+class C(B): ...
+
+reveal_type(A() + C())  # revealed: MyString
 ```
 
 ## Reflected precedence 2

--- a/crates/red_knot_python_semantic/resources/mdtest/binary/integers.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/binary/integers.md
@@ -42,6 +42,6 @@ e = 1.0 / 0
 reveal_type(a)  # revealed: float
 reveal_type(b)  # revealed: int
 reveal_type(c)  # revealed: int
-reveal_type(d)  # revealed: @Todo
-reveal_type(e)  # revealed: @Todo
+reveal_type(d)  # revealed: float
+reveal_type(e)  # revealed: float
 ```

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -440,6 +440,9 @@ impl<'db> Type<'db> {
                 .any(|&elem_ty| ty.is_subtype_of(db, elem_ty)),
             (_, Type::Instance(class)) if class.is_known(db, KnownClass::Object) => true,
             (Type::Instance(class), _) if class.is_known(db, KnownClass::Object) => false,
+            (Type::Instance(self_class), Type::Instance(target_class)) => self_class
+                .bases(db) // TODO: this should iterate through the MRO, not through the bases
+                .any(|base| base == Type::Class(target_class)),
             // TODO
             _ => false,
         }

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -1446,7 +1446,9 @@ impl<'db> ClassType<'db> {
         (other == self)
             || self.bases(db).any(|base| match base {
                 Type::Class(base_class) => base_class == other,
-                Type::Any | Type::Unknown => true,
+                // `is_subclass_of` is checking the subtype relation, in which gradual types do not
+                // participate, so we should not return `True` if we find `Any/Unknown` in the
+                // bases.
                 _ => false,
             })
     }

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -2660,9 +2660,7 @@ impl<'db> TypeInferenceBuilder<'db> {
             ),
 
             (Type::Instance(left_class), Type::Instance(right_class), op) => {
-                if left_class != right_class
-                    && right_class.is_subclass_of(self.db, Type::Class(left_class))
-                {
+                if left_class != right_class && right_class.is_subclass_of(self.db, left_class) {
                     let reflected_dunder = op.reflected_dunder();
                     let rhs_reflected = right_class.class_member(self.db, reflected_dunder);
                     if !rhs_reflected.is_unbound()

--- a/crates/ruff_python_ast/src/nodes.rs
+++ b/crates/ruff_python_ast/src/nodes.rs
@@ -2971,6 +2971,42 @@ impl Operator {
             Operator::FloorDiv => "//",
         }
     }
+
+    pub const fn dunder(self) -> &'static str {
+        match self {
+            Operator::Add => "__add__",
+            Operator::Sub => "__sub__",
+            Operator::Mult => "__mul__",
+            Operator::MatMult => "__matmul__",
+            Operator::Div => "__truediv__",
+            Operator::Mod => "__mod__",
+            Operator::Pow => "__pow__",
+            Operator::LShift => "__lshift__",
+            Operator::RShift => "__rshift__",
+            Operator::BitOr => "__or__",
+            Operator::BitXor => "__xor__",
+            Operator::BitAnd => "__and__",
+            Operator::FloorDiv => "__floordiv__",
+        }
+    }
+
+    pub const fn reflected_dunder(self) -> &'static str {
+        match self {
+            Operator::Add => "__radd__",
+            Operator::Sub => "__rsub__",
+            Operator::Mult => "__rmul__",
+            Operator::MatMult => "__rmatmul__",
+            Operator::Div => "__rtruediv__",
+            Operator::Mod => "__rmod__",
+            Operator::Pow => "__rpow__",
+            Operator::LShift => "__rlshift__",
+            Operator::RShift => "__rrshift__",
+            Operator::BitOr => "__ror__",
+            Operator::BitXor => "__rxor__",
+            Operator::BitAnd => "__rand__",
+            Operator::FloorDiv => "__rfloordiv__",
+        }
+    }
 }
 
 impl fmt::Display for Operator {


### PR DESCRIPTION
This implements the (subtle!) algorithm that Python uses for binary arithmetic operations between two instances. The full algorithm is described well in [this blog post](https://snarky.ca/unravelling-binary-arithmetic-operations-in-python/) by Brett Cannon; the official Python docs for this are [here](https://docs.python.org/3/reference/datamodel.html#emulating-numeric-types).

There are still many TODOs in the code and tests. The main remaining tasks in this area are:
- There are many type errors we do not currently catch, and some types that we do not yet infer correctly, because we would need to validate the types of arguments passed to functions.
- We do not yet have any capability to traverse a class's MRO to understand if one class is a subclass of the other

Closes #13590