### PR TITLE
[red-knot] Report line numbers in mdtest relative to the markdown file, not the test snippet

### DIFF
--- a/crates/red_knot_test/src/lib.rs
+++ b/crates/red_knot_test/src/lib.rs
@@ -52,7 +52,7 @@ pub fn run(path: &Path, title: &str) {
         }
     }
 
-    println!("{}\n", "-".repeat(50));
+    println!("\n{}\n", "-".repeat(50));
 
     assert!(!any_failures, "Some tests failed.");
 }

--- a/crates/red_knot_test/src/lib.rs
+++ b/crates/red_knot_test/src/lib.rs
@@ -45,7 +45,6 @@ pub fn run(path: &Path, title: &str) {
                 for (line_number, failures) in by_line.iter() {
                     for failure in failures {
                         let line_info = format!("{title}:{line_number}").cyan();
-
                         println!("    {line_info} {failure}");
                     }
                 }

--- a/crates/red_knot_test/src/lib.rs
+++ b/crates/red_knot_test/src/lib.rs
@@ -38,7 +38,7 @@ pub fn run(path: &Path, title: &str) {
 
         if let Err(failures) = run_test(&mut db, &test) {
             any_failures = true;
-            println!("\n{}", test.name().bold().underline());
+            println!("\n{}\n", test.name().bold().underline());
 
             for by_line in failures {
                 for (line_number, failures) in by_line.iter() {

--- a/crates/red_knot_test/src/lib.rs
+++ b/crates/red_knot_test/src/lib.rs
@@ -61,10 +61,10 @@ pub fn run(path: &Path, title: &str) {
     assert!(!any_failures, "Some tests failed.");
 }
 
-fn run_test(db: &mut db::Db, spec: &parser::MarkdownTest) -> Result<(), Failures> {
+fn run_test(db: &mut db::Db, test: &parser::MarkdownTest) -> Result<(), Failures> {
     let workspace_root = db.workspace_root().to_path_buf();
 
-    let test_files: Vec<_> = spec
+    let test_files: Vec<_> = test
         .files()
         .map(|embedded| {
             assert!(
@@ -91,7 +91,7 @@ fn run_test(db: &mut db::Db, spec: &parser::MarkdownTest) -> Result<(), Failures
             assert!(
                 parsed.errors().is_empty(),
                 "Python syntax errors in {}, {}: {:?}",
-                spec.name(),
+                test.name(),
                 test_file.file.path(db),
                 parsed.errors()
             );

--- a/crates/red_knot_test/src/lib.rs
+++ b/crates/red_knot_test/src/lib.rs
@@ -49,7 +49,6 @@ pub fn run(path: &Path, title: &str) {
                         println!("    {line_info} {failure}");
                     }
                 }
-                println!();
             }
         }
     }

--- a/crates/red_knot_test/src/matcher.rs
+++ b/crates/red_knot_test/src/matcher.rs
@@ -41,6 +41,20 @@ impl FailuresByLine {
     fn is_empty(&self) -> bool {
         self.lines.is_empty()
     }
+
+    pub(crate) fn offset_errors(self, offset: OneIndexed) -> Self {
+        Self {
+            failures: self.failures,
+            lines: self
+                .lines
+                .into_iter()
+                .map(|line_failures| LineFailures {
+                    line_number: line_failures.line_number.saturating_add(offset.get()),
+                    range: line_failures.range,
+                })
+                .collect(),
+        }
+    }
 }
 
 #[derive(Debug)]

--- a/crates/red_knot_test/src/matcher.rs
+++ b/crates/red_knot_test/src/matcher.rs
@@ -49,14 +49,10 @@ impl FailuresByLine {
                 .lines
                 .into_iter()
                 .map(|line_failures| LineFailures {
-                    line_number: OneIndexed::try_from(
-                        line_failures
-                            .line_number
-                            .get()
-                            .checked_add(offset.get())
-                            .unwrap(),
-                    )
-                    .unwrap(),
+                    line_number: line_failures
+                        .line_number
+                        .checked_add(offset)
+                        .expect("The number of lines in a test file should fit into a `usize`"),
                     range: line_failures.range,
                 })
                 .collect(),

--- a/crates/red_knot_test/src/matcher.rs
+++ b/crates/red_knot_test/src/matcher.rs
@@ -49,7 +49,14 @@ impl FailuresByLine {
                 .lines
                 .into_iter()
                 .map(|line_failures| LineFailures {
-                    line_number: line_failures.line_number.saturating_add(offset.get()),
+                    line_number: OneIndexed::try_from(
+                        line_failures
+                            .line_number
+                            .get()
+                            .checked_add(offset.get())
+                            .unwrap(),
+                    )
+                    .unwrap(),
                     range: line_failures.range,
                 })
                 .collect(),

--- a/crates/red_knot_test/src/matcher.rs
+++ b/crates/red_knot_test/src/matcher.rs
@@ -41,23 +41,6 @@ impl FailuresByLine {
     fn is_empty(&self) -> bool {
         self.lines.is_empty()
     }
-
-    pub(crate) fn offset_errors(self, offset: OneIndexed) -> Self {
-        Self {
-            failures: self.failures,
-            lines: self
-                .lines
-                .into_iter()
-                .map(|line_failures| LineFailures {
-                    line_number: line_failures
-                        .line_number
-                        .checked_add(offset)
-                        .expect("The number of lines in a test file should fit into a `usize`"),
-                    range: line_failures.range,
-                })
-                .collect(),
-        }
-    }
 }
 
 #[derive(Debug)]

--- a/crates/red_knot_test/src/parser.rs
+++ b/crates/red_knot_test/src/parser.rs
@@ -137,7 +137,7 @@ pub(crate) struct EmbeddedFile<'s> {
     pub(crate) lang: &'s str,
     pub(crate) code: &'s str,
 
-    /// The offset of the backticks in the markdown file
+    /// The offset of the backticks beginning the code block within the markdown file
     pub(crate) md_offset: TextSize,
 }
 

--- a/crates/red_knot_test/src/parser.rs
+++ b/crates/red_knot_test/src/parser.rs
@@ -135,7 +135,7 @@ pub(crate) struct EmbeddedFile<'s> {
     pub(crate) lang: &'s str,
     pub(crate) code: &'s str,
 
-    /// The line number of the ``` in the markdown file
+    /// The line number of the backticks in the markdown file
     pub(crate) starting_line_number: OneIndexed,
 }
 
@@ -217,7 +217,7 @@ impl<'s> Parser<'s> {
             files: IndexVec::default(),
             unparsed: source,
             md_offset: TextSize::new(0),
-            line_index: LineIndex::from_source_text(&source),
+            line_index: LineIndex::from_source_text(source),
             stack: SectionStack::new(root_section_id),
             current_section_files: None,
         }

--- a/crates/red_knot_test/src/parser.rs
+++ b/crates/red_knot_test/src/parser.rs
@@ -41,13 +41,13 @@ impl<'s> MarkdownTestSuite<'s> {
 /// headers in the file), containing one or more embedded Python files as fenced code blocks, and
 /// containing no nested header subsections.
 #[derive(Debug)]
-pub(crate) struct MarkdownSpec<'m, 's> {
+pub(crate) struct MarkdownTest<'m, 's> {
     suite: &'m MarkdownTestSuite<'s>,
     section: &'m Section<'s>,
     files: &'m [EmbeddedFile<'s>],
 }
 
-impl<'m, 's> MarkdownSpec<'m, 's> {
+impl<'m, 's> MarkdownTest<'m, 's> {
     pub(crate) fn name(&self) -> String {
         let mut name = String::new();
         let mut parent_id = self.section.parent_id;
@@ -71,7 +71,7 @@ impl<'m, 's> MarkdownSpec<'m, 's> {
     }
 }
 
-/// Iterator yielding all [`MarkdownSpec`]s in a [`MarkdownTestSuite`].
+/// Iterator yielding all [`MarkdownTest`]s in a [`MarkdownTestSuite`].
 #[derive(Debug)]
 pub(crate) struct MarkdownTestIterator<'m, 's> {
     suite: &'m MarkdownTestSuite<'s>,
@@ -79,7 +79,7 @@ pub(crate) struct MarkdownTestIterator<'m, 's> {
 }
 
 impl<'m, 's> Iterator for MarkdownTestIterator<'m, 's> {
-    type Item = MarkdownSpec<'m, 's>;
+    type Item = MarkdownTest<'m, 's>;
 
     fn next(&mut self) -> Option<Self::Item> {
         let mut current_file_index = self.current_file_index;
@@ -92,7 +92,7 @@ impl<'m, 's> Iterator for MarkdownTestIterator<'m, 's> {
         let files = &self.suite.files[EmbeddedFileId::from_usize(self.current_file_index)
             ..EmbeddedFileId::from_usize(current_file_index)];
         self.current_file_index = current_file_index;
-        Some(MarkdownSpec {
+        Some(MarkdownTest {
             suite: self.suite,
             section: &self.suite.sections[section_id],
             files,
@@ -110,7 +110,7 @@ struct SectionId;
 /// same number or fewer `#` characters).
 ///
 /// A header section may either contain one or more embedded Python files (making it a
-/// [`MarkdownSpec`]), or it may contain nested sections (headers with more `#` characters), but
+/// [`MarkdownTest`]), or it may contain nested sections (headers with more `#` characters), but
 /// not both.
 #[derive(Debug)]
 struct Section<'s> {
@@ -127,7 +127,7 @@ struct EmbeddedFileId;
 /// Currently must be a Python file (`py` language) or type stub (`pyi`). In the future we plan
 /// support other kinds of files as well (TOML configuration, typeshed VERSIONS, `pth` files...).
 ///
-/// A Python embedded file makes its containing [`Section`] into a [`MarkdownSpec`], and will be
+/// A Python embedded file makes its containing [`Section`] into a [`MarkdownTest`], and will be
 /// type-checked and searched for inline-comment assertions to match against the diagnostics from
 /// type checking.
 #[derive(Debug)]

--- a/crates/red_knot_test/src/parser.rs
+++ b/crates/red_knot_test/src/parser.rs
@@ -41,13 +41,13 @@ impl<'s> MarkdownTestSuite<'s> {
 /// headers in the file), containing one or more embedded Python files as fenced code blocks, and
 /// containing no nested header subsections.
 #[derive(Debug)]
-pub(crate) struct MarkdownTest<'m, 's> {
+pub(crate) struct MarkdownSpec<'m, 's> {
     suite: &'m MarkdownTestSuite<'s>,
     section: &'m Section<'s>,
     files: &'m [EmbeddedFile<'s>],
 }
 
-impl<'m, 's> MarkdownTest<'m, 's> {
+impl<'m, 's> MarkdownSpec<'m, 's> {
     pub(crate) fn name(&self) -> String {
         let mut name = String::new();
         let mut parent_id = self.section.parent_id;
@@ -71,7 +71,7 @@ impl<'m, 's> MarkdownTest<'m, 's> {
     }
 }
 
-/// Iterator yielding all [`MarkdownTest`]s in a [`MarkdownTestSuite`].
+/// Iterator yielding all [`MarkdownSpec`]s in a [`MarkdownTestSuite`].
 #[derive(Debug)]
 pub(crate) struct MarkdownTestIterator<'m, 's> {
     suite: &'m MarkdownTestSuite<'s>,
@@ -79,7 +79,7 @@ pub(crate) struct MarkdownTestIterator<'m, 's> {
 }
 
 impl<'m, 's> Iterator for MarkdownTestIterator<'m, 's> {
-    type Item = MarkdownTest<'m, 's>;
+    type Item = MarkdownSpec<'m, 's>;
 
     fn next(&mut self) -> Option<Self::Item> {
         let mut current_file_index = self.current_file_index;
@@ -92,7 +92,7 @@ impl<'m, 's> Iterator for MarkdownTestIterator<'m, 's> {
         let files = &self.suite.files[EmbeddedFileId::from_usize(self.current_file_index)
             ..EmbeddedFileId::from_usize(current_file_index)];
         self.current_file_index = current_file_index;
-        Some(MarkdownTest {
+        Some(MarkdownSpec {
             suite: self.suite,
             section: &self.suite.sections[section_id],
             files,
@@ -110,7 +110,7 @@ struct SectionId;
 /// same number or fewer `#` characters).
 ///
 /// A header section may either contain one or more embedded Python files (making it a
-/// [`MarkdownTest`]), or it may contain nested sections (headers with more `#` characters), but
+/// [`MarkdownSpec`]), or it may contain nested sections (headers with more `#` characters), but
 /// not both.
 #[derive(Debug)]
 struct Section<'s> {
@@ -127,7 +127,7 @@ struct EmbeddedFileId;
 /// Currently must be a Python file (`py` language) or type stub (`pyi`). In the future we plan
 /// support other kinds of files as well (TOML configuration, typeshed VERSIONS, `pth` files...).
 ///
-/// A Python embedded file makes its containing [`Section`] into a [`MarkdownTest`], and will be
+/// A Python embedded file makes its containing [`Section`] into a [`MarkdownSpec`], and will be
 /// type-checked and searched for inline-comment assertions to match against the diagnostics from
 /// type checking.
 #[derive(Debug)]

--- a/crates/ruff_python_trivia/src/cursor.rs
+++ b/crates/ruff_python_trivia/src/cursor.rs
@@ -26,6 +26,16 @@ impl<'a> Cursor<'a> {
         self.chars.clone()
     }
 
+    /// Returns the remaining input as byte slice.
+    pub fn as_bytes(&self) -> &'a [u8] {
+        self.as_str().as_bytes()
+    }
+
+    /// Returns the remaining input as string slice.
+    pub fn as_str(&self) -> &'a str {
+        self.chars.as_str()
+    }
+
     /// Peeks the next character from the input stream without consuming it.
     /// Returns [`EOF_CHAR`] if the file is at the end of the file.
     pub fn first(&self) -> char {
@@ -109,5 +119,14 @@ impl<'a> Cursor<'a> {
         while predicate(self.last()) && !self.is_eof() {
             self.bump_back();
         }
+    }
+
+    /// Skips the next `count` bytes.
+    ///
+    /// ## Panics
+    ///  - If `count` is larger than the remaining bytes in the input stream.
+    ///  - If `count` indexes into a multi-byte character.
+    pub fn skip_bytes(&mut self, count: usize) {
+        self.chars = self.chars.as_str()[count..].chars();
     }
 }

--- a/crates/ruff_source_file/src/line_index.rs
+++ b/crates/ruff_source_file/src/line_index.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 use std::fmt::{Debug, Formatter};
-use std::num::{NonZeroUsize, ParseIntError};
+use std::num::{IntErrorKind, NonZeroUsize, ParseIntError, TryFromIntError};
 use std::ops::Deref;
 use std::str::FromStr;
 use std::sync::Arc;
@@ -415,6 +415,22 @@ impl FromStr for OneIndexed {
     type Err = ParseIntError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         Ok(OneIndexed(NonZeroUsize::from_str(s)?))
+    }
+}
+
+impl TryFrom<usize> for OneIndexed {
+    type Error = TryFromIntError;
+
+    fn try_from(value: usize) -> Result<Self, Self::Error> {
+        Ok(OneIndexed(NonZeroUsize::try_from(value)?))
+    }
+}
+
+impl TryInto<usize> for OneIndexed {
+    type Error = IntErrorKind;
+
+    fn try_into(self) -> Result<usize, Self::Error> {
+        Ok(self.0.get())
     }
 }
 

--- a/crates/ruff_source_file/src/line_index.rs
+++ b/crates/ruff_source_file/src/line_index.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 use std::fmt::{Debug, Formatter};
-use std::num::{IntErrorKind, NonZeroUsize, ParseIntError, TryFromIntError};
+use std::num::{NonZeroUsize, ParseIntError};
 use std::ops::Deref;
 use std::str::FromStr;
 use std::sync::Arc;
@@ -394,6 +394,18 @@ impl OneIndexed {
             None => Self::MIN,
         }
     }
+
+    /// Checked addition. Returns `None` if overflow occurred.
+    #[must_use]
+    pub fn checked_add(self, rhs: Self) -> Option<Self> {
+        self.0.checked_add(rhs.0.get()).map(Self)
+    }
+
+    /// Checked subtraction. Returns `None` if overflow occurred.
+    #[must_use]
+    pub fn checked_sub(self, rhs: Self) -> Option<Self> {
+        self.0.get().checked_sub(rhs.get()).and_then(Self::new)
+    }
 }
 
 impl fmt::Display for OneIndexed {
@@ -415,22 +427,6 @@ impl FromStr for OneIndexed {
     type Err = ParseIntError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         Ok(OneIndexed(NonZeroUsize::from_str(s)?))
-    }
-}
-
-impl TryFrom<usize> for OneIndexed {
-    type Error = TryFromIntError;
-
-    fn try_from(value: usize) -> Result<Self, Self::Error> {
-        Ok(OneIndexed(NonZeroUsize::try_from(value)?))
-    }
-}
-
-impl TryInto<usize> for OneIndexed {
-    type Error = IntErrorKind;
-
-    fn try_into(self) -> Result<usize, Self::Error> {
-        Ok(self.0.get())
     }
 }
 


### PR DESCRIPTION
Summary: Adds absolute line numbers to mdtest (fixes #13798)

Test Plan: 

https://github.com/user-attachments/assets/63f84e34-da00-4146-a22b-e17322d5d687
