### PR TITLE
Set `fail_fast: false` in `.pre-commit-config.yaml`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-fail_fast: true
+fail_fast: false
 
 exclude: |
   (?x)^(


### PR DESCRIPTION
## Summary

`fail_fast: true` means that pre-commit stops as soon as a single hook reports a failure. @MichaReiser finds this annoying and so do I: it means that you often have to run `pre-commit run -a` several times in the Ruff repo in order to fix linter complaints in Markdown files.

The default is `fail_fast: false`, but it looks like we overrode the default in https://github.com/astral-sh/ruff/pull/3017.

The docs for the `fail_fast` setting are here: https://pre-commit.com/#top_level-fail_fast

## Test Plan

`pre-commit run -a`
