### PR TITLE
Short circuit `lex_identifier` if the name is longer or shorter than any known keyword

### DIFF
--- a/crates/ruff_python_parser/src/lexer.rs
+++ b/crates/ruff_python_parser/src/lexer.rs
@@ -648,6 +648,14 @@ impl<'src> Lexer<'src> {
             return TokenKind::Name;
         }
 
+        // Short circuit for names that are longer than any known keyword.
+        // It helps Rust to predict that the Name::new call in the keyword match's default branch
+        // is guaranteed to fit into a stack allocated (inline) Name.
+        if text.len() > 8 {
+            self.current_value = TokenValue::Name(Name::new(text));
+            return TokenKind::Name;
+        }
+
         match text {
             "False" => TokenKind::False,
             "None" => TokenKind::None,


### PR DESCRIPTION

## Summary

This PR address the regression introduced by https://github.com/astral-sh/ruff/pull/13808 when upgrading Ruff to Rust 1.82. 

I tried to debug the difference in compilerexplorer but it doesn't support Rust 1.82 yet.

## Test Plan

`cargo bench`
