### PR TITLE
[red-knot] Improve chained comparisons handling

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/narrow/conditionals_is.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/narrow/conditionals_is.md
@@ -29,8 +29,8 @@ reveal_type(y)  # revealed: A | None
 ## `is` in chained comparisons
 
 ```py
-x = True if flag else False
-y = True if flag else False
+x = True if x_flag else False
+y = True if y_flag else False
 
 reveal_type(x)  # revealed: bool
 reveal_type(y)  # revealed: bool

--- a/crates/red_knot_python_semantic/resources/mdtest/narrow/conditionals_is.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/narrow/conditionals_is.md
@@ -25,3 +25,17 @@ if y is x:
 
 reveal_type(y)  # revealed: A | None
 ```
+
+## `is` in chained comparisons
+
+```py
+x = True if flag else False
+y = True if flag else False
+
+reveal_type(x)  # revealed: bool
+reveal_type(y)  # revealed: bool
+
+if y is x is False: # Interpreted as `(y is x) and (x is False)`
+    reveal_type(x)  # revealed: Literal[False]
+    reveal_type(y)  # revealed: bool
+```

--- a/crates/red_knot_python_semantic/resources/mdtest/narrow/conditionals_is.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/narrow/conditionals_is.md
@@ -35,7 +35,7 @@ y = True if flag else False
 reveal_type(x)  # revealed: bool
 reveal_type(y)  # revealed: bool
 
-if y is x is False: # Interpreted as `(y is x) and (x is False)`
+if y is x is False:  # Interpreted as `(y is x) and (x is False)`
     reveal_type(x)  # revealed: Literal[False]
     reveal_type(y)  # revealed: bool
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/narrow/conditionals_is_not.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/narrow/conditionals_is_not.md
@@ -42,8 +42,8 @@ if x is not y:
 The type guard removes `False` from the union type of the tested value only.
 
 ```py
-x = True if flag else False
-y = True if flag else False
+x = True if x_flag else False
+y = True if y_flag else False
 
 reveal_type(x)  # revealed: bool
 reveal_type(y)  # revealed: bool

--- a/crates/red_knot_python_semantic/resources/mdtest/narrow/conditionals_is_not.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/narrow/conditionals_is_not.md
@@ -48,7 +48,7 @@ y = True if flag else False
 reveal_type(x)  # revealed: bool
 reveal_type(y)  # revealed: bool
 
-if y is not x is not False: # Interpreted as `(y is not x) and (x is not False)`
+if y is not x is not False:  # Interpreted as `(y is not x) and (x is not False)`
     reveal_type(x)  # revealed: Literal[True]
     reveal_type(y)  # revealed: bool
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/narrow/conditionals_is_not.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/narrow/conditionals_is_not.md
@@ -36,3 +36,19 @@ y = 345
 if x is not y:
     reveal_type(x)  # revealed: Literal[345]
 ```
+
+## `is not` in chained comparisons
+
+The type guard removes `False` from the union type of the tested value only.
+
+```py
+x = True if flag else False
+y = True if flag else False
+
+reveal_type(x)  # revealed: bool
+reveal_type(y)  # revealed: bool
+
+if y is not x is not False: # Interpreted as `(y is not x) and (x is not False)`
+    reveal_type(x)  # revealed: Literal[True]
+    reveal_type(y)  # revealed: bool
+```

--- a/crates/red_knot_python_semantic/src/types/narrow.rs
+++ b/crates/red_knot_python_semantic/src/types/narrow.rs
@@ -6,6 +6,7 @@ use crate::semantic_index::symbol::{ScopeId, ScopedSymbolId, SymbolTable};
 use crate::semantic_index::symbol_table;
 use crate::types::{infer_expression_types, IntersectionBuilder, Type};
 use crate::Db;
+use itertools::Itertools;
 use ruff_python_ast as ast;
 use rustc_hash::FxHashMap;
 use std::sync::Arc;
@@ -142,19 +143,21 @@ impl<'db> NarrowingConstraintsBuilder<'db> {
             ops,
             comparators,
         } = expr_compare;
-
-        if let ast::Expr::Name(ast::ExprName {
-            range: _,
-            id,
-            ctx: _,
-        }) = left.as_ref()
-        {
-            // SAFETY: we should always have a symbol for every Name node.
-            let symbol = self.symbols().symbol_id_by_name(id).unwrap();
-            let scope = self.scope();
-            let inference = infer_expression_types(self.db, expression);
-            for (op, comparator) in std::iter::zip(ops, comparators) {
-                let comp_ty = inference.expression_ty(comparator.scoped_ast_id(self.db, scope));
+        let scope = self.scope();
+        let comparator_tuples = std::iter::once(&**left)
+            .chain(comparators)
+            .tuple_windows::<(&ruff_python_ast::Expr, &ruff_python_ast::Expr)>();
+        let inference = infer_expression_types(self.db, expression);
+        for (op, (left, right)) in std::iter::zip(&**ops, comparator_tuples) {
+            if let ast::Expr::Name(ast::ExprName {
+                range: _,
+                id,
+                ctx: _,
+            }) = left
+            {
+                // SAFETY: we should always have a symbol for every Name node.
+                let symbol = self.symbols().symbol_id_by_name(id).unwrap();
+                let comp_ty = inference.expression_ty(right.scoped_ast_id(self.db, scope));
                 match op {
                     ast::CmpOp::IsNot => {
                         if comp_ty.is_singleton() {


### PR DESCRIPTION

<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

A small fix for comparisons of multiple comparators.
Instead of comparing each comparator to the leftmost item, we should compare it to the closest item on the left.

While implementing this, I noticed that we don’t yet narrow Yoda comparisons (e.g., `True is x`), so I didn’t change that behavior in this PR.

## Test Plan

Added some mdtests 🎉 
