### PR TITLE
Speed up mdtests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2978,7 +2978,7 @@ checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
 [[package]]
 name = "salsa"
 version = "0.18.0"
-source = "git+https://github.com/salsa-rs/salsa.git?rev=b14be5c0392f4c55eca60b92e457a35549372382#b14be5c0392f4c55eca60b92e457a35549372382"
+source = "git+https://github.com/salsa-rs/salsa.git?rev=254c749b02cde2fd29852a7463a33e800b771758#254c749b02cde2fd29852a7463a33e800b771758"
 dependencies = [
  "append-only-vec",
  "arc-swap",
@@ -2998,12 +2998,12 @@ dependencies = [
 [[package]]
 name = "salsa-macro-rules"
 version = "0.1.0"
-source = "git+https://github.com/salsa-rs/salsa.git?rev=b14be5c0392f4c55eca60b92e457a35549372382#b14be5c0392f4c55eca60b92e457a35549372382"
+source = "git+https://github.com/salsa-rs/salsa.git?rev=254c749b02cde2fd29852a7463a33e800b771758#254c749b02cde2fd29852a7463a33e800b771758"
 
 [[package]]
 name = "salsa-macros"
 version = "0.18.0"
-source = "git+https://github.com/salsa-rs/salsa.git?rev=b14be5c0392f4c55eca60b92e457a35549372382#b14be5c0392f4c55eca60b92e457a35549372382"
+source = "git+https://github.com/salsa-rs/salsa.git?rev=254c749b02cde2fd29852a7463a33e800b771758#254c749b02cde2fd29852a7463a33e800b771758"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,7 +116,7 @@ rand = { version = "0.8.5" }
 rayon = { version = "1.10.0" }
 regex = { version = "1.10.2" }
 rustc-hash = { version = "2.0.0" }
-salsa = { git = "https://github.com/salsa-rs/salsa.git", rev = "b14be5c0392f4c55eca60b92e457a35549372382" }
+salsa = { git = "https://github.com/salsa-rs/salsa.git", rev = "254c749b02cde2fd29852a7463a33e800b771758" }
 schemars = { version = "0.8.16" }
 seahash = { version = "4.1.0" }
 serde = { version = "1.0.197", features = ["derive"] }

--- a/crates/red_knot_test/src/db.rs
+++ b/crates/red_knot_test/src/db.rs
@@ -2,8 +2,7 @@ use red_knot_python_semantic::{
     Db as SemanticDb, Program, ProgramSettings, PythonVersion, SearchPathSettings,
 };
 use ruff_db::files::{File, Files};
-use ruff_db::system::{DbWithTestSystem, System, TestSystem};
-use ruff_db::system::{SystemPath, SystemPathBuf};
+use ruff_db::system::{DbWithTestSystem, System, SystemPath, SystemPathBuf, TestSystem};
 use ruff_db::vendored::VendoredFileSystem;
 use ruff_db::{Db as SourceDb, Upcast};
 

--- a/crates/red_knot_test/src/db.rs
+++ b/crates/red_knot_test/src/db.rs
@@ -2,13 +2,14 @@ use red_knot_python_semantic::{
     Db as SemanticDb, Program, ProgramSettings, PythonVersion, SearchPathSettings,
 };
 use ruff_db::files::{File, Files};
-use ruff_db::system::SystemPathBuf;
 use ruff_db::system::{DbWithTestSystem, System, TestSystem};
+use ruff_db::system::{SystemPath, SystemPathBuf};
 use ruff_db::vendored::VendoredFileSystem;
 use ruff_db::{Db as SourceDb, Upcast};
 
 #[salsa::db]
 pub(crate) struct Db {
+    workspace_root: SystemPathBuf,
     storage: salsa::Storage<Self>,
     files: Files,
     system: TestSystem,
@@ -18,6 +19,7 @@ pub(crate) struct Db {
 impl Db {
     pub(crate) fn setup(workspace_root: SystemPathBuf) -> Self {
         let db = Self {
+            workspace_root,
             storage: salsa::Storage::default(),
             system: TestSystem::default(),
             vendored: red_knot_vendored::file_system().clone(),
@@ -25,19 +27,23 @@ impl Db {
         };
 
         db.memory_file_system()
-            .create_directory_all(&workspace_root)
+            .create_directory_all(&db.workspace_root)
             .unwrap();
 
         Program::from_settings(
             &db,
             &ProgramSettings {
                 target_version: PythonVersion::default(),
-                search_paths: SearchPathSettings::new(workspace_root),
+                search_paths: SearchPathSettings::new(db.workspace_root.clone()),
             },
         )
         .expect("Invalid search path settings");
 
         db
+    }
+
+    pub(crate) fn workspace_root(&self) -> &SystemPath {
+        &self.workspace_root
     }
 }
 

--- a/crates/ruff_db/src/system/memory_fs.rs
+++ b/crates/ruff_db/src/system/memory_fs.rs
@@ -351,6 +351,17 @@ impl MemoryFileSystem {
 
         Ok(ReadDirectory::new(collected))
     }
+
+    /// Removes all files and directories except the current working directory.
+    pub fn remove_all(&self) {
+        self.inner.virtual_files.write().unwrap().clear();
+
+        self.inner
+            .by_path
+            .write()
+            .unwrap()
+            .retain(|key, _| key == self.inner.cwd.as_utf8_path());
+    }
 }
 
 impl Default for MemoryFileSystem {


### PR DESCRIPTION
## Summary

This PR speeds up th md tests by using a single salsa db per test suite. 
The main motivation for re-using the salsa DB is that we spend a decent amount of time re-parsing the typeshed stubs. The lower bound of any salsa test case is now around 120ms (on my machine). We should investigate if there's something we can improve to get this number down but this is beyond the scope of this PR.

The main downside of this approach is that it reduces test isolation. I do think that significant faster test execution is a fair tradeoff, especially considering that Salsa abstracts away the incremental vs "fresh" computation. 

However, it does mean that a salsa bug could lead to failing tests. In fact, I had to upgrade salsa to address a Salsa bug. 

Closes https://github.com/astral-sh/ruff/issues/13805


## Test Plan

On my machine, I get a 3x speedup.

This PR

```bash
    Starting 66 tests across 2 binaries (338 skipped)
        PASS [   0.154s] red_knot_python_semantic::mdtest mdtest::path_05_resources_mdtest_attributes_md
        PASS [   0.155s] red_knot_python_semantic::mdtest mdtest::path_02_resources_mdtest_assignment_multi_target_md
        PASS [   0.164s] red_knot_python_semantic::mdtest mdtest::path_01_resources_mdtest_assignment_annotations_md
        PASS [   0.165s] red_knot_python_semantic::mdtest mdtest::path_04_resources_mdtest_assignment_walrus_md
        PASS [   0.173s] red_knot_python_semantic::mdtest mdtest::path_06_resources_mdtest_binary_booleans_md
        PASS [   0.185s] red_knot_python_semantic::mdtest mdtest::path_08_resources_mdtest_binary_integers_md
        PASS [   0.188s] red_knot_python_semantic::mdtest mdtest::path_03_resources_mdtest_assignment_unbound_md
        PASS [   0.288s] red_knot_python_semantic::mdtest mdtest::path_07_resources_mdtest_binary_instances_md
        PASS [   0.137s] red_knot_python_semantic::mdtest mdtest::path_11_resources_mdtest_call_function_md
        PASS [   0.128s] red_knot_python_semantic::mdtest mdtest::path_13_resources_mdtest_comparison_byte_literals_md
        PASS [   0.138s] red_knot_python_semantic::mdtest mdtest::path_12_resources_mdtest_call_union_md
        PASS [   0.130s] red_knot_python_semantic::mdtest mdtest::path_15_resources_mdtest_comparison_non_boolean_returns_md
        PASS [   0.135s] red_knot_python_semantic::mdtest mdtest::path_14_resources_mdtest_comparison_integers_md
        PASS [   0.213s] red_knot_python_semantic::mdtest mdtest::path_10_resources_mdtest_call_constructor_md
        PASS [   0.216s] red_knot_python_semantic::mdtest mdtest::path_09_resources_mdtest_call_callable_instance_md
        PASS [   0.112s] red_knot_python_semantic::mdtest mdtest::path_20_resources_mdtest_conditional_if_expression_md
        PASS [   0.130s] red_knot_python_semantic::mdtest mdtest::path_18_resources_mdtest_comparison_unions_md
        PASS [   0.143s] red_knot_python_semantic::mdtest mdtest::path_19_resources_mdtest_comparison_unsupported_md
        PASS [   0.105s] red_knot_python_semantic::mdtest mdtest::path_22_resources_mdtest_conditional_match_md
        PASS [   0.178s] red_knot_python_semantic::mdtest mdtest::path_21_resources_mdtest_conditional_if_statement_md
        PASS [   0.145s] red_knot_python_semantic::mdtest mdtest::path_23_resources_mdtest_declaration_error_md
        PASS [   0.236s] red_knot_python_semantic::mdtest mdtest::path_16_resources_mdtest_comparison_strings_md
        PASS [   0.113s] red_knot_python_semantic::mdtest mdtest::path_26_resources_mdtest_exception_except_star_md
        PASS [   0.185s] red_knot_python_semantic::mdtest mdtest::path_24_resources_mdtest_exception_basic_md
        PASS [   0.100s] red_knot_python_semantic::mdtest mdtest::path_30_resources_mdtest_import_builtins_md
        PASS [   0.154s] red_knot_python_semantic::mdtest mdtest::path_27_resources_mdtest_expression_boolean_md
        PASS [   0.344s] red_knot_python_semantic::mdtest mdtest::path_17_resources_mdtest_comparison_tuples_md
        PASS [   0.134s] red_knot_python_semantic::mdtest mdtest::path_29_resources_mdtest_import_basic_md
        PASS [   0.151s] red_knot_python_semantic::mdtest mdtest::path_28_resources_mdtest_generics_md
        PASS [   0.265s] red_knot_python_semantic::mdtest mdtest::path_25_resources_mdtest_exception_control_flow_md
        PASS [   0.167s] red_knot_python_semantic::mdtest mdtest::path_31_resources_mdtest_import_conditional_md
        PASS [   0.093s] red_knot_python_semantic::mdtest mdtest::path_37_resources_mdtest_literal_collections_list_md
        PASS [   0.098s] red_knot_python_semantic::mdtest mdtest::path_36_resources_mdtest_literal_collections_dictionary_md
        PASS [   0.137s] red_knot_python_semantic::mdtest mdtest::path_32_resources_mdtest_import_errors_md
        PASS [   0.140s] red_knot_python_semantic::mdtest mdtest::path_35_resources_mdtest_literal_boolean_md
        PASS [   0.183s] red_knot_python_semantic::mdtest mdtest::path_34_resources_mdtest_import_stubs_md
        PASS [   0.126s] red_knot_python_semantic::mdtest mdtest::path_38_resources_mdtest_literal_collections_set_md
        PASS [   0.113s] red_knot_python_semantic::mdtest mdtest::path_39_resources_mdtest_literal_collections_tuple_md
        PASS [   0.231s] red_knot_python_semantic::mdtest mdtest::path_33_resources_mdtest_import_relative_md
        PASS [   0.106s] red_knot_python_semantic::mdtest mdtest::path_42_resources_mdtest_literal_float_md
        PASS [   0.116s] red_knot_python_semantic::mdtest mdtest::path_41_resources_mdtest_literal_f_string_md
        PASS [   0.210s] red_knot_python_semantic::mdtest mdtest::path_40_resources_mdtest_literal_complex_md
        PASS [   0.133s] red_knot_python_semantic::mdtest mdtest::path_45_resources_mdtest_loops_async_for_loops_md
        PASS [   0.154s] red_knot_python_semantic::mdtest mdtest::path_44_resources_mdtest_literal_string_md
        PASS [   0.140s] red_knot_python_semantic::mdtest mdtest::path_47_resources_mdtest_loops_iterators_md
        PASS [   0.139s] red_knot_python_semantic::mdtest mdtest::path_48_resources_mdtest_loops_while_loop_md
        PASS [   0.174s] red_knot_python_semantic::mdtest mdtest::path_46_resources_mdtest_loops_for_loop_md
        PASS [   0.232s] red_knot_python_semantic::mdtest mdtest::path_43_resources_mdtest_literal_integer_md
        PASS [   0.067s] red_knot_python_semantic::mdtest mdtest::path_55_resources_mdtest_shadowing_variable_declaration_md
        PASS [   0.229s] red_knot_python_semantic::mdtest mdtest::path_49_resources_mdtest_narrow_conditionals_is_md
        PASS [   0.150s] red_knot_python_semantic::mdtest mdtest::path_51_resources_mdtest_narrow_match_md
        PASS [   0.147s] red_knot_python_semantic::mdtest mdtest::path_52_resources_mdtest_scopes_builtin_md
        PASS [   0.128s] red_knot_python_semantic::mdtest mdtest::path_54_resources_mdtest_shadowing_function_md
        PASS [   0.173s] red_knot_python_semantic::mdtest mdtest::path_50_resources_mdtest_narrow_conditionals_is_not_md
        PASS [   0.163s] red_knot_python_semantic::mdtest mdtest::path_53_resources_mdtest_shadowing_class_md
        PASS [   0.156s] red_knot_python_semantic::mdtest mdtest::path_56_resources_mdtest_stubs_class_md
        PASS [   0.143s] red_knot_python_semantic::mdtest mdtest::path_57_resources_mdtest_subscript_bytes_md
        PASS [   0.138s] red_knot_python_semantic::mdtest mdtest::path_61_resources_mdtest_subscript_string_md
        PASS [   0.088s] red_knot_python_semantic::mdtest mdtest::path_64_resources_mdtest_unary_integers_md
        PASS [   0.155s] red_knot_python_semantic::mdtest mdtest::path_60_resources_mdtest_subscript_lists_md
        PASS [   0.185s] red_knot_python_semantic::mdtest mdtest::path_58_resources_mdtest_subscript_class_md
        PASS [   0.172s] red_knot_python_semantic::mdtest mdtest::path_59_resources_mdtest_subscript_instance_md
        PASS [   0.120s] red_knot_python_semantic::mdtest mdtest::path_63_resources_mdtest_unary_instance_md
        PASS [   0.153s] red_knot_python_semantic::mdtest mdtest::path_62_resources_mdtest_subscript_tuple_md
        PASS [   0.101s] red_knot_python_semantic::mdtest mdtest::path_65_resources_mdtest_unary_not_md
        PASS [   0.126s] red_knot_python_semantic::mdtest mdtest::path_66_resources_mdtest_unpacking_md
------------
     Summary [   1.389s] 66 tests run: 66 passed, 338 skipped
```

Main 

```bash
 cargo nextest run -p red_knot_python_semantic mdtest
    Finished `test` profile [unoptimized + debuginfo] target(s) in 3.91s
    Starting 66 tests across 2 binaries (338 skipped)
        PASS [   0.157s] red_knot_python_semantic::mdtest mdtest::path_06_resources_mdtest_binary_booleans_md
        PASS [   0.168s] red_knot_python_semantic::mdtest mdtest::path_02_resources_mdtest_assignment_multi_target_md
        PASS [   0.180s] red_knot_python_semantic::mdtest mdtest::path_05_resources_mdtest_attributes_md
        PASS [   0.114s] red_knot_python_semantic::mdtest mdtest::path_09_resources_mdtest_call_callable_instance_md
        PASS [   0.279s] red_knot_python_semantic::mdtest mdtest::path_03_resources_mdtest_assignment_unbound_md
        PASS [   0.120s] red_knot_python_semantic::mdtest mdtest::path_10_resources_mdtest_call_constructor_md
        PASS [   0.301s] red_knot_python_semantic::mdtest mdtest::path_04_resources_mdtest_assignment_walrus_md
        PASS [   0.360s] red_knot_python_semantic::mdtest mdtest::path_01_resources_mdtest_assignment_annotations_md
        PASS [   0.126s] red_knot_python_semantic::mdtest mdtest::path_13_resources_mdtest_comparison_byte_literals_md
        PASS [   0.139s] red_knot_python_semantic::mdtest mdtest::path_15_resources_mdtest_comparison_non_boolean_returns_md
        PASS [   0.269s] red_knot_python_semantic::mdtest mdtest::path_11_resources_mdtest_call_function_md
        PASS [   0.458s] red_knot_python_semantic::mdtest mdtest::path_08_resources_mdtest_binary_integers_md
        PASS [   0.145s] red_knot_python_semantic::mdtest mdtest::path_16_resources_mdtest_comparison_strings_md
        PASS [   0.276s] red_knot_python_semantic::mdtest mdtest::path_14_resources_mdtest_comparison_integers_md
        PASS [   0.118s] red_knot_python_semantic::mdtest mdtest::path_19_resources_mdtest_comparison_unsupported_md
        PASS [   0.340s] red_knot_python_semantic::mdtest mdtest::path_18_resources_mdtest_comparison_unions_md
        PASS [   0.556s] red_knot_python_semantic::mdtest mdtest::path_12_resources_mdtest_call_union_md
        PASS [   0.441s] red_knot_python_semantic::mdtest mdtest::path_20_resources_mdtest_conditional_if_expression_md
        PASS [   0.355s] red_knot_python_semantic::mdtest mdtest::path_22_resources_mdtest_conditional_match_md
        PASS [   0.368s] red_knot_python_semantic::mdtest mdtest::path_23_resources_mdtest_declaration_error_md
        PASS [   0.434s] red_knot_python_semantic::mdtest mdtest::path_24_resources_mdtest_exception_basic_md
        PASS [   0.348s] red_knot_python_semantic::mdtest mdtest::path_26_resources_mdtest_exception_except_star_md
        PASS [   0.876s] red_knot_python_semantic::mdtest mdtest::path_17_resources_mdtest_comparison_tuples_md
        PASS [   0.806s] red_knot_python_semantic::mdtest mdtest::path_21_resources_mdtest_conditional_if_statement_md
        PASS [   0.388s] red_knot_python_semantic::mdtest mdtest::path_28_resources_mdtest_generics_md
        PASS [   0.100s] red_knot_python_semantic::mdtest mdtest::path_30_resources_mdtest_import_builtins_md
        PASS [   0.237s] red_knot_python_semantic::mdtest mdtest::path_29_resources_mdtest_import_basic_md
        PASS [   0.230s] red_knot_python_semantic::mdtest mdtest::path_34_resources_mdtest_import_stubs_md
        PASS [   0.147s] red_knot_python_semantic::mdtest mdtest::path_35_resources_mdtest_literal_boolean_md
        PASS [   0.103s] red_knot_python_semantic::mdtest mdtest::path_36_resources_mdtest_literal_collections_dictionary_md
        PASS [   0.091s] red_knot_python_semantic::mdtest mdtest::path_37_resources_mdtest_literal_collections_list_md
        PASS [   0.436s] red_knot_python_semantic::mdtest mdtest::path_31_resources_mdtest_import_conditional_md
        PASS [   0.098s] red_knot_python_semantic::mdtest mdtest::path_38_resources_mdtest_literal_collections_set_md
        PASS [   0.085s] red_knot_python_semantic::mdtest mdtest::path_40_resources_mdtest_literal_complex_md
        PASS [   0.502s] red_knot_python_semantic::mdtest mdtest::path_32_resources_mdtest_import_errors_md
        PASS [   0.952s] red_knot_python_semantic::mdtest mdtest::path_27_resources_mdtest_expression_boolean_md
        PASS [   0.183s] red_knot_python_semantic::mdtest mdtest::path_39_resources_mdtest_literal_collections_tuple_md
        PASS [   0.104s] red_knot_python_semantic::mdtest mdtest::path_42_resources_mdtest_literal_float_md
        PASS [   1.115s] red_knot_python_semantic::mdtest mdtest::path_25_resources_mdtest_exception_control_flow_md
        PASS [   2.045s] red_knot_python_semantic::mdtest mdtest::path_07_resources_mdtest_binary_instances_md
        PASS [   0.120s] red_knot_python_semantic::mdtest mdtest::path_47_resources_mdtest_loops_iterators_md
        PASS [   0.196s] red_knot_python_semantic::mdtest mdtest::path_44_resources_mdtest_literal_string_md
        PASS [   0.209s] red_knot_python_semantic::mdtest mdtest::path_45_resources_mdtest_loops_async_for_loops_md
        PASS [   0.347s] red_knot_python_semantic::mdtest mdtest::path_41_resources_mdtest_literal_f_string_md
        PASS [   0.087s] red_knot_python_semantic::mdtest mdtest::path_51_resources_mdtest_narrow_match_md
        PASS [   0.189s] red_knot_python_semantic::mdtest mdtest::path_49_resources_mdtest_narrow_conditionals_is_md
        PASS [   0.210s] red_knot_python_semantic::mdtest mdtest::path_52_resources_mdtest_scopes_builtin_md
        PASS [   0.311s] red_knot_python_semantic::mdtest mdtest::path_48_resources_mdtest_loops_while_loop_md
        PASS [   0.305s] red_knot_python_semantic::mdtest mdtest::path_50_resources_mdtest_narrow_conditionals_is_not_md
        PASS [   0.223s] red_knot_python_semantic::mdtest mdtest::path_53_resources_mdtest_shadowing_class_md
        PASS [   0.087s] red_knot_python_semantic::mdtest mdtest::path_55_resources_mdtest_shadowing_variable_declaration_md
        PASS [   0.104s] red_knot_python_semantic::mdtest mdtest::path_56_resources_mdtest_stubs_class_md
        PASS [   0.127s] red_knot_python_semantic::mdtest mdtest::path_57_resources_mdtest_subscript_bytes_md
        PASS [   0.331s] red_knot_python_semantic::mdtest mdtest::path_54_resources_mdtest_shadowing_function_md
        PASS [   1.286s] red_knot_python_semantic::mdtest mdtest::path_33_resources_mdtest_import_relative_md
        PASS [   0.854s] red_knot_python_semantic::mdtest mdtest::path_43_resources_mdtest_literal_integer_md
        PASS [   0.126s] red_knot_python_semantic::mdtest mdtest::path_62_resources_mdtest_subscript_tuple_md
        PASS [   0.263s] red_knot_python_semantic::mdtest mdtest::path_60_resources_mdtest_subscript_lists_md
        PASS [   0.239s] red_knot_python_semantic::mdtest mdtest::path_61_resources_mdtest_subscript_string_md
        PASS [   0.155s] red_knot_python_semantic::mdtest mdtest::path_63_resources_mdtest_unary_instance_md
        PASS [   0.345s] red_knot_python_semantic::mdtest mdtest::path_59_resources_mdtest_subscript_instance_md
        PASS [   0.973s] red_knot_python_semantic::mdtest mdtest::path_46_resources_mdtest_loops_for_loop_md
        PASS [   0.248s] red_knot_python_semantic::mdtest mdtest::path_64_resources_mdtest_unary_integers_md
        PASS [   0.598s] red_knot_python_semantic::mdtest mdtest::path_58_resources_mdtest_subscript_class_md
        PASS [   0.590s] red_knot_python_semantic::mdtest mdtest::path_65_resources_mdtest_unary_not_md
        PASS [   1.626s] red_knot_python_semantic::mdtest mdtest::path_66_resources_mdtest_unpacking_md
------------
     Summary [   4.353s] 66 tests run: 66 passed, 338 skipped
```
