### PR TITLE
Modernize build scripts

### DIFF
--- a/crates/red_knot_python_semantic/build.rs
+++ b/crates/red_knot_python_semantic/build.rs
@@ -1,4 +1,4 @@
 /// Rebuild the crate if a test file is added or removed from
 pub fn main() {
-    println!("cargo:rerun-if-changed=resources/mdtest");
+    println!("cargo::rerun-if-changed=resources/mdtest");
 }

--- a/crates/red_knot_vendored/build.rs
+++ b/crates/red_knot_vendored/build.rs
@@ -69,7 +69,7 @@ fn zip_dir(directory_path: &str, writer: File) -> ZipResult<File> {
 }
 
 fn main() {
-    println!("cargo:rerun-if-changed={TYPESHED_SOURCE_DIR}");
+    println!("cargo::rerun-if-changed={TYPESHED_SOURCE_DIR}");
     assert!(
         Path::new(TYPESHED_SOURCE_DIR).is_dir(),
         "Where is typeshed?"

--- a/crates/ruff/build.rs
+++ b/crates/ruff/build.rs
@@ -11,7 +11,7 @@ fn main() {
 
     #[allow(clippy::disallowed_methods)]
     let target = std::env::var("TARGET").unwrap();
-    println!("cargo:rustc-env=RUST_HOST_TARGET={target}");
+    println!("cargo::rustc-env=RUST_HOST_TARGET={target}");
 }
 
 fn commit_info(workspace_root: &Path) {
@@ -23,7 +23,7 @@ fn commit_info(workspace_root: &Path) {
 
     let git_head_path = git_dir.join("HEAD");
     println!(
-        "cargo:rerun-if-changed={}",
+        "cargo::rerun-if-changed={}",
         git_head_path.as_path().display()
     );
 
@@ -39,7 +39,7 @@ fn commit_info(workspace_root: &Path) {
         if let Some(git_ref) = git_ref_parts.next() {
             let git_ref_path = git_dir.join(git_ref);
             println!(
-                "cargo:rerun-if-changed={}",
+                "cargo::rerun-if-changed={}",
                 git_ref_path.as_path().display()
             );
         }
@@ -59,21 +59,21 @@ fn commit_info(workspace_root: &Path) {
     let stdout = String::from_utf8(output.stdout).unwrap();
     let mut parts = stdout.split_whitespace();
     let mut next = || parts.next().unwrap();
-    println!("cargo:rustc-env=RUFF_COMMIT_HASH={}", next());
-    println!("cargo:rustc-env=RUFF_COMMIT_SHORT_HASH={}", next());
-    println!("cargo:rustc-env=RUFF_COMMIT_DATE={}", next());
+    println!("cargo::rustc-env=RUFF_COMMIT_HASH={}", next());
+    println!("cargo::rustc-env=RUFF_COMMIT_SHORT_HASH={}", next());
+    println!("cargo::rustc-env=RUFF_COMMIT_DATE={}", next());
 
     // Describe can fail for some commits
     // https://git-scm.com/docs/pretty-formats#Documentation/pretty-formats.txt-emdescribeoptionsem
     if let Some(describe) = parts.next() {
         let mut describe_parts = describe.split('-');
         println!(
-            "cargo:rustc-env=RUFF_LAST_TAG={}",
+            "cargo::rustc-env=RUFF_LAST_TAG={}",
             describe_parts.next().unwrap()
         );
         // If this is the tagged commit, this component will be missing
         println!(
-            "cargo:rustc-env=RUFF_LAST_TAG_DISTANCE={}",
+            "cargo::rustc-env=RUFF_LAST_TAG_DISTANCE={}",
             describe_parts.next().unwrap_or("0")
         );
     }


### PR DESCRIPTION
## Summary

Use the modern `cargo::KEY=VALUE` syntax (as described in the [docs](https://doc.rust-lang.org/cargo/reference/build-scripts.html#outputs-of-the-build-script)) that was stabilised in MSRV 1.77, rather than the deprecated `cargo:KEY=VALUE` syntax.

## Test Plan

`cargo test`
