### PR TITLE
[red-knot] Consistently rename BoolLiteral => BooleanLiteral

### DIFF
--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -1756,7 +1756,7 @@ mod tests {
         None,
         Any,
         IntLiteral(i64),
-        BoolLiteral(bool),
+        BooleanLiteral(bool),
         StringLiteral(&'static str),
         LiteralString,
         BytesLiteral(&'static str),
@@ -1775,7 +1775,7 @@ mod tests {
                 Ty::Any => Type::Any,
                 Ty::IntLiteral(n) => Type::IntLiteral(n),
                 Ty::StringLiteral(s) => Type::StringLiteral(StringLiteralType::new(db, s)),
-                Ty::BoolLiteral(b) => Type::BooleanLiteral(b),
+                Ty::BooleanLiteral(b) => Type::BooleanLiteral(b),
                 Ty::LiteralString => Type::LiteralString,
                 Ty::BytesLiteral(s) => Type::BytesLiteral(BytesLiteralType::new(db, s.as_bytes())),
                 Ty::BuiltinInstance(s) => builtins_symbol_ty(db, s).to_instance(db),
@@ -1872,17 +1872,17 @@ mod tests {
     #[test_case(Ty::Never, Ty::Never)]
     #[test_case(Ty::Never, Ty::None)]
     #[test_case(Ty::Never, Ty::BuiltinInstance("int"))]
-    #[test_case(Ty::None, Ty::BoolLiteral(true))]
+    #[test_case(Ty::None, Ty::BooleanLiteral(true))]
     #[test_case(Ty::None, Ty::IntLiteral(1))]
     #[test_case(Ty::None, Ty::StringLiteral("test"))]
     #[test_case(Ty::None, Ty::BytesLiteral("test"))]
     #[test_case(Ty::None, Ty::LiteralString)]
     #[test_case(Ty::None, Ty::BuiltinInstance("int"))]
     #[test_case(Ty::None, Ty::Tuple(vec![Ty::None]))]
-    #[test_case(Ty::BoolLiteral(true), Ty::BoolLiteral(false))]
-    #[test_case(Ty::BoolLiteral(true), Ty::Tuple(vec![Ty::None]))]
-    #[test_case(Ty::BoolLiteral(true), Ty::IntLiteral(1))]
-    #[test_case(Ty::BoolLiteral(false), Ty::IntLiteral(0))]
+    #[test_case(Ty::BooleanLiteral(true), Ty::BooleanLiteral(false))]
+    #[test_case(Ty::BooleanLiteral(true), Ty::Tuple(vec![Ty::None]))]
+    #[test_case(Ty::BooleanLiteral(true), Ty::IntLiteral(1))]
+    #[test_case(Ty::BooleanLiteral(false), Ty::IntLiteral(0))]
     #[test_case(Ty::IntLiteral(1), Ty::IntLiteral(2))]
     #[test_case(Ty::IntLiteral(1), Ty::Tuple(vec![Ty::None]))]
     #[test_case(Ty::StringLiteral("a"), Ty::StringLiteral("b"))]
@@ -1911,10 +1911,10 @@ mod tests {
     #[test_case(Ty::None, Ty::BuiltinInstance("object"))]
     #[test_case(Ty::BuiltinInstance("int"), Ty::BuiltinInstance("int"))]
     #[test_case(Ty::BuiltinInstance("str"), Ty::LiteralString)]
-    #[test_case(Ty::BoolLiteral(true), Ty::BoolLiteral(true))]
-    #[test_case(Ty::BoolLiteral(false), Ty::BoolLiteral(false))]
-    #[test_case(Ty::BoolLiteral(true), Ty::BuiltinInstance("bool"))]
-    #[test_case(Ty::BoolLiteral(true), Ty::BuiltinInstance("int"))]
+    #[test_case(Ty::BooleanLiteral(true), Ty::BooleanLiteral(true))]
+    #[test_case(Ty::BooleanLiteral(false), Ty::BooleanLiteral(false))]
+    #[test_case(Ty::BooleanLiteral(true), Ty::BuiltinInstance("bool"))]
+    #[test_case(Ty::BooleanLiteral(true), Ty::BuiltinInstance("int"))]
     #[test_case(Ty::IntLiteral(1), Ty::IntLiteral(1))]
     #[test_case(Ty::StringLiteral("a"), Ty::StringLiteral("a"))]
     #[test_case(Ty::StringLiteral("a"), Ty::LiteralString)]
@@ -1957,8 +1957,8 @@ mod tests {
     }
 
     #[test_case(Ty::None)]
-    #[test_case(Ty::BoolLiteral(true))]
-    #[test_case(Ty::BoolLiteral(false))]
+    #[test_case(Ty::BooleanLiteral(true))]
+    #[test_case(Ty::BooleanLiteral(false))]
     fn is_singleton(from: Ty) {
         let db = setup_db();
 
@@ -1971,7 +1971,7 @@ mod tests {
     #[test_case(Ty::Union(vec![Ty::IntLiteral(1), Ty::IntLiteral(2)]))]
     #[test_case(Ty::Tuple(vec![]))]
     #[test_case(Ty::Tuple(vec![Ty::None]))]
-    #[test_case(Ty::Tuple(vec![Ty::None, Ty::BoolLiteral(true)]))]
+    #[test_case(Ty::Tuple(vec![Ty::None, Ty::BooleanLiteral(true)]))]
     fn is_not_singleton(from: Ty) {
         let db = setup_db();
 
@@ -2007,8 +2007,8 @@ mod tests {
     }
 
     #[test_case(Ty::IntLiteral(1), Ty::StringLiteral("1"))]
-    #[test_case(Ty::BoolLiteral(true), Ty::StringLiteral("True"))]
-    #[test_case(Ty::BoolLiteral(false), Ty::StringLiteral("False"))]
+    #[test_case(Ty::BooleanLiteral(true), Ty::StringLiteral("True"))]
+    #[test_case(Ty::BooleanLiteral(false), Ty::StringLiteral("False"))]
     #[test_case(Ty::StringLiteral("ab'cd"), Ty::StringLiteral("ab'cd"))] // no quotes
     #[test_case(Ty::LiteralString, Ty::LiteralString)]
     #[test_case(Ty::BuiltinInstance("int"), Ty::BuiltinInstance("str"))]
@@ -2019,8 +2019,8 @@ mod tests {
     }
 
     #[test_case(Ty::IntLiteral(1), Ty::StringLiteral("1"))]
-    #[test_case(Ty::BoolLiteral(true), Ty::StringLiteral("True"))]
-    #[test_case(Ty::BoolLiteral(false), Ty::StringLiteral("False"))]
+    #[test_case(Ty::BooleanLiteral(true), Ty::StringLiteral("True"))]
+    #[test_case(Ty::BooleanLiteral(false), Ty::StringLiteral("False"))]
     #[test_case(Ty::StringLiteral("ab'cd"), Ty::StringLiteral("'ab\\'cd'"))] // single quotes
     #[test_case(Ty::LiteralString, Ty::LiteralString)]
     #[test_case(Ty::BuiltinInstance("int"), Ty::BuiltinInstance("str"))]

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -1833,6 +1833,7 @@ mod tests {
     #[test_case(Ty::BuiltinInstance("int"), Ty::BuiltinInstance("object"))]
     #[test_case(Ty::Never, Ty::IntLiteral(1))]
     #[test_case(Ty::IntLiteral(1), Ty::BuiltinInstance("int"))]
+    #[test_case(Ty::BooleanLiteral(true), Ty::BuiltinInstance("bool"))]
     #[test_case(Ty::StringLiteral("foo"), Ty::BuiltinInstance("str"))]
     #[test_case(Ty::StringLiteral("foo"), Ty::LiteralString)]
     #[test_case(Ty::LiteralString, Ty::BuiltinInstance("str"))]

--- a/crates/red_knot_python_semantic/src/types/builder.rs
+++ b/crates/red_knot_python_semantic/src/types/builder.rs
@@ -852,7 +852,7 @@ mod tests {
         let db = setup_db();
 
         let t_bool = KnownClass::Bool.to_instance(&db);
-        let t_bool_literal = Type::BooleanLiteral(bool_value);
+        let t_boolean_literal = Type::BooleanLiteral(bool_value);
 
         // We add t_object in various orders (in first or second position) in
         // the tests below to ensure that the boolean simplification eliminates
@@ -862,26 +862,26 @@ mod tests {
         let ty = IntersectionBuilder::new(&db)
             .add_positive(t_object)
             .add_positive(t_bool)
-            .add_negative(t_bool_literal)
+            .add_negative(t_boolean_literal)
             .build();
         assert_eq!(ty, Type::BooleanLiteral(!bool_value));
 
         let ty = IntersectionBuilder::new(&db)
             .add_positive(t_bool)
             .add_positive(t_object)
-            .add_negative(t_bool_literal)
+            .add_negative(t_boolean_literal)
             .build();
         assert_eq!(ty, Type::BooleanLiteral(!bool_value));
 
         let ty = IntersectionBuilder::new(&db)
             .add_positive(t_object)
-            .add_negative(t_bool_literal)
+            .add_negative(t_boolean_literal)
             .add_positive(t_bool)
             .build();
         assert_eq!(ty, Type::BooleanLiteral(!bool_value));
 
         let ty = IntersectionBuilder::new(&db)
-            .add_negative(t_bool_literal)
+            .add_negative(t_boolean_literal)
             .add_positive(t_object)
             .add_positive(t_bool)
             .build();

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -3119,7 +3119,7 @@ impl<'db> TypeInferenceBuilder<'db> {
     /// Performs lexicographic comparison between two slices of types.
     ///
     /// For lexicographic comparison, elements from both slices are compared pairwise using
-    /// `infer_binary_type_comparison`. If a conclusive result cannot be determined as a `BoolLiteral`,
+    /// `infer_binary_type_comparison`. If a conclusive result cannot be determined as a `BooleanLiteral`,
     /// it returns `bool`. Returns `None` if the comparison is not supported.
     fn infer_lexicographic_type_comparison(
         &mut self,


### PR DESCRIPTION
## Summary

- Consistent naming: `BoolLiteral` => `BooleanLiteral` (it's mainly the `Ty::BoolLiteral` variant that was renamed)

  I tripped over this a few times now, so I thought I'll smooth it out.
- Add a new test case for `Literal[True] <: bool`, as suggested here: https://github.com/astral-sh/ruff/pull/13781#discussion_r1804922827
