### PR TITLE
Alternate quotes for strings inside f-strings in preview 

### DIFF
--- a/crates/ruff_dev/src/format_dev.rs
+++ b/crates/ruff_dev/src/format_dev.rs
@@ -251,8 +251,7 @@ pub(crate) fn main(args: &Args) -> anyhow::Result<ExitCode> {
         }
         info!(
             parent: None,
-            "Done: {} stability errors, {} files, similarity index {:.5}), files with differences: {} took {:.2}s, {} input files contained syntax errors ",
-            error_count,
+            "Done: {error_count} stability/syntax errors, {} files, similarity index {:.5}), files with differences: {} took {:.2}s, {} input files contained syntax errors ",
             result.file_count,
             result.statistics.similarity_index(),
             result.statistics.files_with_differences,
@@ -796,7 +795,7 @@ impl CheckFileError {
             | CheckFileError::PrintError(_)
             | CheckFileError::Panic { .. } => false,
             #[cfg(not(debug_assertions))]
-            CheckFileError::Slow(_) => false,
+            CheckFileError::Slow(_) => true,
         }
     }
 }

--- a/crates/ruff_python_ast/src/expression.rs
+++ b/crates/ruff_python_ast/src/expression.rs
@@ -524,6 +524,10 @@ impl StringLikePart<'_> {
             self.end() - kind.closer_len(),
         )
     }
+
+    pub const fn is_fstring(self) -> bool {
+        matches!(self, Self::FString(_))
+    }
 }
 
 impl<'a> From<&'a ast::StringLiteral> for StringLikePart<'a> {

--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/fstring.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/fstring.py
@@ -94,6 +94,8 @@ x = f"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa { # comment 8
                                              "bbbbbbbbbbbbbbbbbbbbbbbbbbbbb" } ccccccccccccccc"
 x = f"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa { # comment 9
                                              "bbbbbbbbbbbbbbbbbbbbbbbbbbbbb" = } ccccccccccccccc"
+x = f"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa { # comment 9
+                                             'bbbbbbbbbbbbbbbbbbbbbbbbbbbbb' = } ccccccccccccccc"
 
 # Multiple larger expressions which exceeds the line length limit. Here, we need to decide
 # whether to split at the first or second expression. This should work similarly to the
@@ -144,18 +146,37 @@ xxxxxxx = f"{
     {'aaaaaaaaaaaaaaaaaaaaaaaaa', 'bbbbbbbbbbbbbbbbbbbbbbbbbbb', 'cccccccccccccccccccccccccc'}
 }"
 
+#############################################################################################
 # Quotes
+#############################################################################################
 f"foo 'bar' {x}"
 f"foo \"bar\" {x}"
 f'foo "bar" {x}'
 f'foo \'bar\' {x}'
 f"foo {"bar"}"
-f"foo {'\'bar\''}"
+
+f"single quoted '{x}' double quoted \"{x}\"" # Same number of quotes => use preferred quote style
+f"single quote ' {x} double quoted \"{x}\""  # More double quotes => use single quotes
+f"single quoted '{x}' double quote \" {x}"  # More single quotes => use double quotes
+
+fr"single quotes ' {x}"  # Keep double because `'` can't be escaped
+fr'double quotes " {x}'  # Keep single because `"` can't be escaped
+fr'flip quotes {x}'  # Use preferred quotes, because raw string contains now quotes.
 
 # Here, the formatter will remove the escapes which is correct because they aren't allowed
 # pre 3.12. This means we can assume that the f-string is used in the context of 3.12.
+f"foo {'\'bar\''}"
 f"foo {'\"bar\"'}"
 
+# Quotes inside the expressions have no impact on the quote selection of the outer string.
+# Required so that the following two examples result in the same formatting.
+f'foo {10 + len("bar")}'
+f"foo {10 + len('bar')}"
+
+# Pre 312, preserve the outer quotes if the f-string contains quotes in the debug expression
+f'foo {10 + len("bar")=}'
+f'''foo {10 + len('''bar''')=}'''
+f'''foo {10 + len('bar')=}'''  # Fine to change the quotes because it uses triple quotes
 
 # Triple-quoted strings
 # It's ok to use the same quote char for the inner string if it's single-quoted.
@@ -163,6 +184,10 @@ f"""test {'inner'}"""
 f"""test {"inner"}"""
 # But if the inner string is also triple-quoted then we should preserve the existing quotes.
 f"""test {'''inner'''}"""
+
+# Not valid Pre 3.12
+f"""test {f'inner {'''inner inner'''}'}"""
+f"""test {f'''inner {"""inner inner"""}'''}"""
 
 # Magic trailing comma
 #
@@ -312,6 +337,6 @@ hello {
 # Implicit concatenated f-string containing quotes
 _ = (
     'This string should change its quotes to double quotes'
-    f'This string uses double quotes in an expression {"woah"}'
+    f'This string uses double quotes in an expression {"it's a quote"}'
     f'This f-string does not use any quotes.'
 )

--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/fstring.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/fstring.py
@@ -185,6 +185,12 @@ f"""test {"inner"}"""
 # But if the inner string is also triple-quoted then we should preserve the existing quotes.
 f"""test {'''inner'''}"""
 
+# It's not okay to change the quote style if the inner string is triple quoted and contains a quote.
+f'{"""other " """}'
+f'{"""other " """ + "more"}'
+f'{b"""other " """}'
+f'{f"""other " """}'
+
 # Not valid Pre 3.12
 f"""test {f'inner {'''inner inner'''}'}"""
 f"""test {f'''inner {"""inner inner"""}'''}"""

--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/fstring_py312.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/fstring_py312.py
@@ -4,3 +4,6 @@
 
 # Quotes reuse
 f"{'a'}"
+
+# 312+, it's okay to change the outer quotes even when there's a debug expression using the same quotes
+f'foo {10 + len("bar")=}'

--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/fstring_py312.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/fstring_py312.py
@@ -7,3 +7,11 @@ f"{'a'}"
 
 # 312+, it's okay to change the outer quotes even when there's a debug expression using the same quotes
 f'foo {10 + len("bar")=}'
+f'''foo {10 + len("""bar""")=}'''
+
+# 312+, it's okay to change the quotes here without creating an invalid f-string
+f'{"""other " """}'
+f'{"""other " """ + "more"}'
+f'{b"""other " """}'
+f'{f"""other " """}'
+

--- a/crates/ruff_python_formatter/src/other/f_string_element.rs
+++ b/crates/ruff_python_formatter/src/other/f_string_element.rs
@@ -2,8 +2,8 @@ use std::borrow::Cow;
 
 use ruff_formatter::{format_args, write, Buffer, RemoveSoftLinesBuffer};
 use ruff_python_ast::{
-    ConversionFlag, Expr, FStringElement, FStringExpressionElement, FStringLiteralElement,
-    StringFlags,
+    AnyStringFlags, ConversionFlag, Expr, FStringElement, FStringExpressionElement,
+    FStringLiteralElement, StringFlags,
 };
 use ruff_text_size::Ranged;
 
@@ -33,7 +33,7 @@ impl Format<PyFormatContext<'_>> for FormatFStringElement<'_> {
     fn fmt(&self, f: &mut PyFormatter) -> FormatResult<()> {
         match self.element {
             FStringElement::Literal(string_literal) => {
-                FormatFStringLiteralElement::new(string_literal, self.context).fmt(f)
+                FormatFStringLiteralElement::new(string_literal, self.context.flags()).fmt(f)
             }
             FStringElement::Expression(expression) => {
                 FormatFStringExpressionElement::new(expression, self.context).fmt(f)
@@ -45,19 +45,23 @@ impl Format<PyFormatContext<'_>> for FormatFStringElement<'_> {
 /// Formats an f-string literal element.
 pub(crate) struct FormatFStringLiteralElement<'a> {
     element: &'a FStringLiteralElement,
-    context: FStringContext,
+    /// Flags of the enclosing F-string part
+    fstring_flags: AnyStringFlags,
 }
 
 impl<'a> FormatFStringLiteralElement<'a> {
-    pub(crate) fn new(element: &'a FStringLiteralElement, context: FStringContext) -> Self {
-        Self { element, context }
+    pub(crate) fn new(element: &'a FStringLiteralElement, fstring_flags: AnyStringFlags) -> Self {
+        Self {
+            element,
+            fstring_flags,
+        }
     }
 }
 
 impl Format<PyFormatContext<'_>> for FormatFStringLiteralElement<'_> {
     fn fmt(&self, f: &mut PyFormatter) -> FormatResult<()> {
         let literal_content = f.context().locator().slice(self.element.range());
-        let normalized = normalize_string(literal_content, 0, self.context.flags(), true);
+        let normalized = normalize_string(literal_content, 0, self.fstring_flags, true);
         match &normalized {
             Cow::Borrowed(_) => source_text_slice(self.element.range()).fmt(f),
             Cow::Owned(normalized) => text(normalized).fmt(f),

--- a/crates/ruff_python_formatter/src/preview.rs
+++ b/crates/ruff_python_formatter/src/preview.rs
@@ -15,11 +15,13 @@ pub(crate) const fn is_hug_parens_with_braces_and_square_brackets_enabled(
 }
 
 /// Returns `true` if the [`f-string formatting`](https://github.com/astral-sh/ruff/issues/7594) preview style is enabled.
+/// WARNING: This preview style depends on `is_f_string_implicit_concatenated_string_literal_quotes_enabled`.
 pub(crate) fn is_f_string_formatting_enabled(context: &PyFormatContext) -> bool {
     context.is_preview()
 }
 
 /// See [#13539](https://github.com/astral-sh/ruff/pull/13539)
+/// Remove `Quoting` when stabalizing this preview style.
 pub(crate) fn is_f_string_implicit_concatenated_string_literal_quotes_enabled(
     context: &PyFormatContext,
 ) -> bool {

--- a/crates/ruff_python_formatter/src/string/normalize.rs
+++ b/crates/ruff_python_formatter/src/string/normalize.rs
@@ -3,7 +3,7 @@ use std::cmp::Ordering;
 use std::iter::FusedIterator;
 
 use ruff_formatter::FormatContext;
-use ruff_python_ast::{str::Quote, AnyStringFlags, StringFlags, StringLikePart};
+use ruff_python_ast::{str::Quote, AnyStringFlags, FStringElement, StringFlags, StringLikePart};
 use ruff_text_size::{Ranged, TextRange};
 
 use crate::context::FStringState;
@@ -37,53 +37,34 @@ impl<'a, 'src> StringNormalizer<'a, 'src> {
         self
     }
 
-    fn quoting(&self, string: StringLikePart) -> Quoting {
-        match (self.quoting, self.context.f_string_state()) {
-            (Quoting::Preserve, _) => Quoting::Preserve,
-
-            // If we're inside an f-string, we need to make sure to preserve the
-            // existing quotes unless we're inside a triple-quoted f-string and
-            // the inner string itself isn't triple-quoted. For example:
-            //
-            // ```python
-            // f"""outer {"inner"}"""  # Valid
-            // f"""outer {"""inner"""}"""  # Invalid
-            // ```
-            //
-            // Or, if the target version supports PEP 701.
-            //
-            // The reason to preserve the quotes is based on the assumption that
-            // the original f-string is valid in terms of quoting, and we don't
-            // want to change that to make it invalid.
-            (Quoting::CanChange, FStringState::InsideExpressionElement(context)) => {
-                if (context.f_string().flags().is_triple_quoted()
-                    && !string.flags().is_triple_quoted())
-                    || self.context.options().target_version().supports_pep_701()
-                {
-                    Quoting::CanChange
-                } else {
-                    Quoting::Preserve
-                }
-            }
-
-            (Quoting::CanChange, _) => Quoting::CanChange,
-        }
-    }
-
     /// Determines the preferred quote style for `string`.
     /// The formatter should use the preferred quote style unless
     /// it can't because the string contains the preferred quotes OR
     /// it leads to more escaping.
     pub(super) fn preferred_quote_style(&self, string: StringLikePart) -> QuoteStyle {
-        match self.quoting(string) {
+        match self.quoting {
             Quoting::Preserve => QuoteStyle::Preserve,
             Quoting::CanChange => {
                 let preferred_quote_style = self
                     .preferred_quote_style
                     .unwrap_or(self.context.options().quote_style());
 
+                if preferred_quote_style.is_preserve() {
+                    return QuoteStyle::Preserve;
+                }
+
+                // For f-strings prefer alternating the quotes unless The outer string is triple quoted and the inner isn't.
+                if let FStringState::InsideExpressionElement(parent_context) =
+                    self.context.f_string_state()
+                {
+                    let parent_flags = parent_context.f_string().flags();
+
+                    if !parent_flags.is_triple_quoted() || string.flags().is_triple_quoted() {
+                        return QuoteStyle::from(parent_flags.quote_style().opposite());
+                    }
+                }
+
                 // Per PEP 8, always prefer double quotes for triple-quoted strings.
-                // Except when using quote-style-preserve.
                 if string.flags().is_triple_quoted() {
                     // ... unless we're formatting a code snippet inside a docstring,
                     // then we specifically want to invert our quote style to avoid
@@ -132,8 +113,6 @@ impl<'a, 'src> StringNormalizer<'a, 'src> {
                     // if it doesn't have perfect alignment with PEP8.
                     if let Some(quote) = self.context.docstring() {
                         QuoteStyle::from(quote.opposite())
-                    } else if preferred_quote_style.is_preserve() {
-                        QuoteStyle::Preserve
                     } else {
                         QuoteStyle::Double
                     }
@@ -146,6 +125,49 @@ impl<'a, 'src> StringNormalizer<'a, 'src> {
 
     /// Computes the strings preferred quotes.
     pub(crate) fn choose_quotes(&self, string: StringLikePart) -> QuoteSelection {
+        // Preserve the f-string quotes if the target version isn't newer or equal than Python 3.12
+        // and an f-string expression contains a debug text with a quote character
+        // because the formatter will emit the debug expression **exctly** the same as in the source text.
+        if is_f_string_formatting_enabled(self.context)
+            && !self.context.options().target_version().supports_pep_701()
+        {
+            if let StringLikePart::FString(fstring) = string {
+                if fstring
+                    .elements
+                    .iter()
+                    .filter_map(FStringElement::as_expression)
+                    .any(|expression| {
+                        if expression.debug_text.is_some() {
+                            let content = self.context.locator().slice(expression.range());
+                            match string.flags().quote_style() {
+                                Quote::Single => {
+                                    if string.flags().is_triple_quoted() {
+                                        content.contains(r#"""""#)
+                                    } else {
+                                        content.contains('"')
+                                    }
+                                }
+                                Quote::Double => {
+                                    if string.flags().is_triple_quoted() {
+                                        content.contains("'''")
+                                    } else {
+                                        content.contains('\'')
+                                    }
+                                }
+                            }
+                        } else {
+                            false
+                        }
+                    })
+                {
+                    return QuoteSelection {
+                        flags: string.flags(),
+                        first_quote_or_normalized_char_offset: None,
+                    };
+                }
+            }
+        }
+
         let raw_content = self.context.locator().slice(string.content_range());
         let first_quote_or_normalized_char_offset = raw_content
             .bytes()
@@ -163,12 +185,18 @@ impl<'a, 'src> StringNormalizer<'a, 'src> {
             // The preferred quote style is single or double quotes, and the string contains a quote or
             // another character that may require escaping
             (Ok(preferred_quote), Some(first_quote_or_normalized_char_offset)) => {
-                let quote = QuoteMetadata::from_str(
-                    &raw_content[first_quote_or_normalized_char_offset..],
-                    string.flags(),
-                    preferred_quote,
-                )
-                .choose(preferred_quote);
+                let metadata = if string.is_fstring() {
+                    QuoteMetadata::from_part(string, self.context, preferred_quote)
+                } else {
+                    QuoteMetadata::from_str(
+                        &raw_content[first_quote_or_normalized_char_offset..],
+                        string.flags(),
+                        preferred_quote,
+                    )
+                };
+
+                let quote = metadata.choose(preferred_quote);
+
                 string_flags.with_quote_style(quote)
             }
 
@@ -235,6 +263,62 @@ pub(crate) struct QuoteMetadata {
 /// Tracks information about the used quotes in a string which is used
 /// to choose the quotes for a part.
 impl QuoteMetadata {
+    pub(crate) fn from_part(
+        part: StringLikePart,
+        context: &PyFormatContext,
+        preferred_quote: Quote,
+    ) -> Self {
+        match part {
+            StringLikePart::String(_) | StringLikePart::Bytes(_) => {
+                let text = context.locator().slice(part.content_range());
+
+                Self::from_str(text, part.flags(), preferred_quote)
+            }
+            StringLikePart::FString(fstring) => {
+                if is_f_string_formatting_enabled(context) {
+                    // For f-strings, only consider the quotes inside string-literals but ignore
+                    // quotes inside expressions. This allows both the outer and the nested literals
+                    // to make the optimal local-choice to reduce the total number of quotes necessary.
+                    // This doesn't require any pre 312 special handling because an expression
+                    // can never contain the outer quote character, not even escaped:
+                    // ```python
+                    // f"{'escaping a quote like this \" is a syntax error pre 312'}"
+                    // ```
+                    let mut literals = fstring
+                        .elements
+                        .iter()
+                        .filter_map(FStringElement::as_literal);
+
+                    let Some(first) = literals.next() else {
+                        return QuoteMetadata::from_str("", part.flags(), preferred_quote);
+                    };
+
+                    let mut metadata = QuoteMetadata::from_str(
+                        context.locator().slice(first.range()),
+                        fstring.flags.into(),
+                        preferred_quote,
+                    );
+
+                    for literal in literals {
+                        metadata = metadata
+                            .merge(&QuoteMetadata::from_str(
+                                context.locator().slice(literal.range()),
+                                fstring.flags.into(),
+                                preferred_quote,
+                            ))
+                            .expect("Merge to succeed because all parts have the same flags");
+                    }
+
+                    metadata
+                } else {
+                    let text = context.locator().slice(part.content_range());
+
+                    Self::from_str(text, part.flags(), preferred_quote)
+                }
+            }
+        }
+    }
+
     pub(crate) fn from_str(text: &str, flags: AnyStringFlags, preferred_quote: Quote) -> Self {
         let kind = if flags.is_raw_string() {
             QuoteMetadataKind::raw(text, preferred_quote, flags.is_triple_quoted())
@@ -275,6 +359,61 @@ impl QuoteMetadata {
                 Ordering::Greater => Quote::Double,
             },
         }
+    }
+
+    /// Merges the quotes metadata of different literals.
+    ///
+    /// ## Raw and triple quoted strings
+    /// Merging raw and triple quoted strings is only correct if all literals are from the same part.
+    /// E.g. it's okay to merge triple and raw strings from a single `FString` part's literals
+    /// but it isn't safe to merge raw and triple quoted strings from different parts of an implicit
+    /// concatenated string. Where safe means, it may lead to incorrect results.
+    pub(super) fn merge(self, other: &QuoteMetadata) -> Option<QuoteMetadata> {
+        let kind = match (self.kind, other.kind) {
+            (
+                QuoteMetadataKind::Regular {
+                    single_quotes: self_single,
+                    double_quotes: self_double,
+                },
+                QuoteMetadataKind::Regular {
+                    single_quotes: other_single,
+                    double_quotes: other_double,
+                },
+            ) => QuoteMetadataKind::Regular {
+                single_quotes: self_single + other_single,
+                double_quotes: self_double + other_double,
+            },
+
+            // Can't merge quotes from raw strings (even when both strings are raw)
+            (
+                QuoteMetadataKind::Raw {
+                    contains_preferred: self_contains_preferred,
+                },
+                QuoteMetadataKind::Raw {
+                    contains_preferred: other_contains_preferred,
+                },
+            ) => QuoteMetadataKind::Raw {
+                contains_preferred: self_contains_preferred || other_contains_preferred,
+            },
+
+            (
+                QuoteMetadataKind::Triple {
+                    contains_preferred: self_contains_preferred,
+                },
+                QuoteMetadataKind::Triple {
+                    contains_preferred: other_contains_preferred,
+                },
+            ) => QuoteMetadataKind::Triple {
+                contains_preferred: self_contains_preferred || other_contains_preferred,
+            },
+
+            (_, _) => return None,
+        };
+
+        Some(Self {
+            kind,
+            source_style: self.source_style,
+        })
     }
 }
 

--- a/crates/ruff_python_formatter/tests/snapshots/black_compatibility@cases__preview_long_strings.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/black_compatibility@cases__preview_long_strings.py.snap
@@ -941,7 +941,7 @@ log.info(f"""Skipping: {'a' == 'b'} {desc['ms_name']} {money=} {dte=} {pos_share
  log.info(
 -    "Skipping:"
 -    f" {desc['db_id']} {foo('bar',x=123)} {'foo' != 'bar'} {(x := 'abc=')} {pos_share=} {desc['status']} {desc['exposure_max']}"
-+    f'Skipping: {desc["db_id"]} {foo("bar", x=123)} {"foo" != "bar"} {(x := "abc=")} {pos_share=} {desc["status"]} {desc["exposure_max"]}'
++    f"Skipping: {desc['db_id']} {foo('bar', x=123)} {'foo' != 'bar'} {(x := 'abc=')} {pos_share=} {desc['status']} {desc['exposure_max']}"
  )
  
  log.info(
@@ -965,7 +965,7 @@ log.info(f"""Skipping: {'a' == 'b'} {desc['ms_name']} {money=} {dte=} {pos_share
  log.info(
 -    "Skipping:"
 -    f" {'a' == 'b' == 'c' == 'd'} {desc['ms_name']} {money=} {dte=} {pos_share=} {desc['status']} {desc['exposure_max']}"
-+    f'Skipping: {"a" == "b" == "c" == "d"} {desc["ms_name"]} {money=} {dte=} {pos_share=} {desc["status"]} {desc["exposure_max"]}'
++    f"Skipping: {'a' == 'b' == 'c' == 'd'} {desc['ms_name']} {money=} {dte=} {pos_share=} {desc['status']} {desc['exposure_max']}"
  )
  
  log.info(
@@ -1406,7 +1406,7 @@ log.info(
 )
 
 log.info(
-    f'Skipping: {desc["db_id"]} {foo("bar", x=123)} {"foo" != "bar"} {(x := "abc=")} {pos_share=} {desc["status"]} {desc["exposure_max"]}'
+    f"Skipping: {desc['db_id']} {foo('bar', x=123)} {'foo' != 'bar'} {(x := 'abc=')} {pos_share=} {desc['status']} {desc['exposure_max']}"
 )
 
 log.info(
@@ -1422,7 +1422,7 @@ log.info(
 )
 
 log.info(
-    f'Skipping: {"a" == "b" == "c" == "d"} {desc["ms_name"]} {money=} {dte=} {pos_share=} {desc["status"]} {desc["exposure_max"]}'
+    f"Skipping: {'a' == 'b' == 'c' == 'd'} {desc['ms_name']} {money=} {dte=} {pos_share=} {desc['status']} {desc['exposure_max']}"
 )
 
 log.info(

--- a/crates/ruff_python_formatter/tests/snapshots/black_compatibility@cases__preview_long_strings__regression.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/black_compatibility@cases__preview_long_strings__regression.py.snap
@@ -1201,10 +1201,10 @@ s = f'Lorem Ipsum is simply dummy text of the printing and typesetting industry:
 +    "With single quote: ' "
 +    f" {my_dict['foo']}"
 +    ' With double quote: " '
-+    f' {my_dict["bar"]}'
++    f" {my_dict['bar']}"
  )
 +
-+s = f'Lorem Ipsum is simply dummy text of the printing and typesetting industry:\'{my_dict["foo"]}\''
++s = f"Lorem Ipsum is simply dummy text of the printing and typesetting industry:'{my_dict['foo']}'"
 ```
 
 ## Ruff Output
@@ -1839,10 +1839,10 @@ s = (
     "With single quote: ' "
     f" {my_dict['foo']}"
     ' With double quote: " '
-    f' {my_dict["bar"]}'
+    f" {my_dict['bar']}"
 )
 
-s = f'Lorem Ipsum is simply dummy text of the printing and typesetting industry:\'{my_dict["foo"]}\''
+s = f"Lorem Ipsum is simply dummy text of the printing and typesetting industry:'{my_dict['foo']}'"
 ```
 
 ## Black Output

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__fstring.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__fstring.py.snap
@@ -191,6 +191,12 @@ f"""test {"inner"}"""
 # But if the inner string is also triple-quoted then we should preserve the existing quotes.
 f"""test {'''inner'''}"""
 
+# It's not okay to change the quote style if the inner string is triple quoted and contains a quote.
+f'{"""other " """}'
+f'{"""other " """ + "more"}'
+f'{b"""other " """}'
+f'{f"""other " """}'
+
 # Not valid Pre 3.12
 f"""test {f'inner {'''inner inner'''}'}"""
 f"""test {f'''inner {"""inner inner"""}'''}"""
@@ -562,6 +568,12 @@ f"""test {"inner"}"""
 # But if the inner string is also triple-quoted then we should preserve the existing quotes.
 f"""test {'''inner'''}"""
 
+# It's not okay to change the quote style if the inner string is triple quoted and contains a quote.
+f'{"""other " """}'
+f'{"""other " """ + "more"}'
+f'{b"""other " """}'
+f'{f"""other " """}'
+
 # Not valid Pre 3.12
 f"""test {f"inner {'''inner inner'''}"}"""
 f"""test {f'''inner {"""inner inner"""}'''}"""
@@ -919,6 +931,12 @@ f"""test {"inner"}"""
 # But if the inner string is also triple-quoted then we should preserve the existing quotes.
 f"""test {'''inner'''}"""
 
+# It's not okay to change the quote style if the inner string is triple quoted and contains a quote.
+f'{"""other " """}'
+f'{"""other " """ + "more"}'
+f'{b"""other " """}'
+f'{f"""other " """}'
+
 # Not valid Pre 3.12
 f"""test {f'inner {'''inner inner'''}'}"""
 f"""test {f'''inner {"""inner inner"""}'''}"""
@@ -1217,7 +1235,7 @@ _ = (
  
  f"single quoted '{x}' double quoted \"{x}\""  # Same number of quotes => use preferred quote style
  f'single quote \' {x} double quoted "{x}"'  # More double quotes => use single quotes
-@@ -163,28 +175,28 @@
+@@ -163,23 +175,23 @@
  
  # Here, the formatter will remove the escapes which is correct because they aren't allowed
  # pre 3.12. This means we can assume that the f-string is used in the context of 3.12.
@@ -1246,13 +1264,16 @@ _ = (
  # But if the inner string is also triple-quoted then we should preserve the existing quotes.
  f"""test {'''inner'''}"""
  
+@@ -190,7 +202,7 @@
+ f'{f"""other " """}'
+ 
  # Not valid Pre 3.12
 -f"""test {f'inner {'''inner inner'''}'}"""
 +f"""test {f"inner {'''inner inner'''}"}"""
  f"""test {f'''inner {"""inner inner"""}'''}"""
  
  # Magic trailing comma
-@@ -196,63 +208,66 @@
+@@ -202,63 +214,66 @@
  f"aaaaaaa {['aaaaaaaaaaaaaaa', 'bbbbbbbbbbbbb', 'ccccccccccccccccc', 'ddddddddddddddd', 'eeeeeeeeeeeeee']} aaaaaaa"
  
  # And, if the trailing comma is already present, we still need to remove it.
@@ -1347,7 +1368,7 @@ _ = (
       # comment} cccccccccc"""
  
  # Conversion flags
-@@ -260,24 +275,21 @@
+@@ -266,24 +281,21 @@
  # This is not a valid Python code because of the additional whitespace between the `!`
  # and conversion type. But, our parser isn't strict about this. This should probably be
  # removed once we have a strict parser.
@@ -1379,7 +1400,7 @@ _ = (
  
  x = f"""
  {              # comment 22
-@@ -286,19 +298,19 @@
+@@ -292,19 +304,19 @@
  
  # Here, the debug expression is in a nested f-string so we should start preserving
  # whitespaces from that point onwards. This means we should format the outer f-string.
@@ -1407,7 +1428,7 @@ _ = (
      # comment 27
      # comment 28
  } woah {x}"
-@@ -312,27 +324,27 @@
+@@ -318,27 +330,27 @@
          if indent2:
              foo = f"""hello world
  hello {

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__fstring.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__fstring.py.snap
@@ -100,6 +100,8 @@ x = f"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa { # comment 8
                                              "bbbbbbbbbbbbbbbbbbbbbbbbbbbbb" } ccccccccccccccc"
 x = f"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa { # comment 9
                                              "bbbbbbbbbbbbbbbbbbbbbbbbbbbbb" = } ccccccccccccccc"
+x = f"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa { # comment 9
+                                             'bbbbbbbbbbbbbbbbbbbbbbbbbbbbb' = } ccccccccccccccc"
 
 # Multiple larger expressions which exceeds the line length limit. Here, we need to decide
 # whether to split at the first or second expression. This should work similarly to the
@@ -150,18 +152,37 @@ xxxxxxx = f"{
     {'aaaaaaaaaaaaaaaaaaaaaaaaa', 'bbbbbbbbbbbbbbbbbbbbbbbbbbb', 'cccccccccccccccccccccccccc'}
 }"
 
+#############################################################################################
 # Quotes
+#############################################################################################
 f"foo 'bar' {x}"
 f"foo \"bar\" {x}"
 f'foo "bar" {x}'
 f'foo \'bar\' {x}'
 f"foo {"bar"}"
-f"foo {'\'bar\''}"
+
+f"single quoted '{x}' double quoted \"{x}\"" # Same number of quotes => use preferred quote style
+f"single quote ' {x} double quoted \"{x}\""  # More double quotes => use single quotes
+f"single quoted '{x}' double quote \" {x}"  # More single quotes => use double quotes
+
+fr"single quotes ' {x}"  # Keep double because `'` can't be escaped
+fr'double quotes " {x}'  # Keep single because `"` can't be escaped
+fr'flip quotes {x}'  # Use preferred quotes, because raw string contains now quotes.
 
 # Here, the formatter will remove the escapes which is correct because they aren't allowed
 # pre 3.12. This means we can assume that the f-string is used in the context of 3.12.
+f"foo {'\'bar\''}"
 f"foo {'\"bar\"'}"
 
+# Quotes inside the expressions have no impact on the quote selection of the outer string.
+# Required so that the following two examples result in the same formatting.
+f'foo {10 + len("bar")}'
+f"foo {10 + len('bar')}"
+
+# Pre 312, preserve the outer quotes if the f-string contains quotes in the debug expression
+f'foo {10 + len("bar")=}'
+f'''foo {10 + len('''bar''')=}'''
+f'''foo {10 + len('bar')=}'''  # Fine to change the quotes because it uses triple quotes
 
 # Triple-quoted strings
 # It's ok to use the same quote char for the inner string if it's single-quoted.
@@ -169,6 +190,10 @@ f"""test {'inner'}"""
 f"""test {"inner"}"""
 # But if the inner string is also triple-quoted then we should preserve the existing quotes.
 f"""test {'''inner'''}"""
+
+# Not valid Pre 3.12
+f"""test {f'inner {'''inner inner'''}'}"""
+f"""test {f'''inner {"""inner inner"""}'''}"""
 
 # Magic trailing comma
 #
@@ -318,7 +343,7 @@ hello {
 # Implicit concatenated f-string containing quotes
 _ = (
     'This string should change its quotes to double quotes'
-    f'This string uses double quotes in an expression {"woah"}'
+    f'This string uses double quotes in an expression {"it's a quote"}'
     f'This f-string does not use any quotes.'
 )
 ```
@@ -429,13 +454,15 @@ aaaaaaaaaaa = (
 
 # This should never add the optional parentheses because even after adding them, the
 # f-string exceeds the line length limit.
-x = f"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa {"bbbbbbbbbbbbbbbbbbbbbbbbbbbbb"} ccccccccccccccc"
+x = f"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa {'bbbbbbbbbbbbbbbbbbbbbbbbbbbbb'} ccccccccccccccc"
 x = f"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa { "bbbbbbbbbbbbbbbbbbbbbbbbbbbbb" = } ccccccccccccccc"
 x = f"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa {  # comment 8
-    "bbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    'bbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
 } ccccccccccccccc"
 x = f"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa { # comment 9
                                              "bbbbbbbbbbbbbbbbbbbbbbbbbbbbb" = } ccccccccccccccc"
+x = f"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa { # comment 9
+                                             'bbbbbbbbbbbbbbbbbbbbbbbbbbbbb' = } ccccccccccccccc"
 
 # Multiple larger expressions which exceeds the line length limit. Here, we need to decide
 # whether to split at the first or second expression. This should work similarly to the
@@ -496,18 +523,37 @@ xxxxxxx = f"{
     }
 }"
 
+#############################################################################################
 # Quotes
+#############################################################################################
 f"foo 'bar' {x}"
 f'foo "bar" {x}'
 f'foo "bar" {x}'
 f"foo 'bar' {x}"
-f"foo {"bar"}"
-f"foo {'\'bar\''}"
+f"foo {'bar'}"
+
+f"single quoted '{x}' double quoted \"{x}\""  # Same number of quotes => use preferred quote style
+f'single quote \' {x} double quoted "{x}"'  # More double quotes => use single quotes
+f"single quoted '{x}' double quote \" {x}"  # More single quotes => use double quotes
+
+rf"single quotes ' {x}"  # Keep double because `'` can't be escaped
+rf'double quotes " {x}'  # Keep single because `"` can't be escaped
+rf"flip quotes {x}"  # Use preferred quotes, because raw string contains now quotes.
 
 # Here, the formatter will remove the escapes which is correct because they aren't allowed
 # pre 3.12. This means we can assume that the f-string is used in the context of 3.12.
+f"foo {"'bar'"}"
 f"foo {'"bar"'}"
 
+# Quotes inside the expressions have no impact on the quote selection of the outer string.
+# Required so that the following two examples result in the same formatting.
+f"foo {10 + len('bar')}"
+f"foo {10 + len('bar')}"
+
+# Pre 312, preserve the outer quotes if the f-string contains quotes in the debug expression
+f'foo {10 + len("bar")=}'
+f"""foo {10 + len('''bar''')=}"""
+f"""foo {10 + len('bar')=}"""  # Fine to change the quotes because it uses triple quotes
 
 # Triple-quoted strings
 # It's ok to use the same quote char for the inner string if it's single-quoted.
@@ -515,6 +561,10 @@ f"""test {"inner"}"""
 f"""test {"inner"}"""
 # But if the inner string is also triple-quoted then we should preserve the existing quotes.
 f"""test {'''inner'''}"""
+
+# Not valid Pre 3.12
+f"""test {f"inner {'''inner inner'''}"}"""
+f"""test {f'''inner {"""inner inner"""}'''}"""
 
 # Magic trailing comma
 #
@@ -662,7 +712,7 @@ hello {
 # Implicit concatenated f-string containing quotes
 _ = (
     "This string should change its quotes to double quotes"
-    f'This string uses double quotes in an expression {"woah"}'
+    f"This string uses double quotes in an expression {"it's a quote"}"
     f"This f-string does not use any quotes."
 )
 ```
@@ -778,6 +828,8 @@ x = f"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa { # comment 8
                                              "bbbbbbbbbbbbbbbbbbbbbbbbbbbbb" } ccccccccccccccc"
 x = f"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa { # comment 9
                                              "bbbbbbbbbbbbbbbbbbbbbbbbbbbbb" = } ccccccccccccccc"
+x = f"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa { # comment 9
+                                             'bbbbbbbbbbbbbbbbbbbbbbbbbbbbb' = } ccccccccccccccc"
 
 # Multiple larger expressions which exceeds the line length limit. Here, we need to decide
 # whether to split at the first or second expression. This should work similarly to the
@@ -828,18 +880,37 @@ xxxxxxx = f"{
     {'aaaaaaaaaaaaaaaaaaaaaaaaa', 'bbbbbbbbbbbbbbbbbbbbbbbbbbb', 'cccccccccccccccccccccccccc'}
 }"
 
+#############################################################################################
 # Quotes
+#############################################################################################
 f"foo 'bar' {x}"
 f'foo "bar" {x}'
 f'foo "bar" {x}'
 f"foo 'bar' {x}"
 f"foo {"bar"}"
-f"foo {'\'bar\''}"
+
+f"single quoted '{x}' double quoted \"{x}\""  # Same number of quotes => use preferred quote style
+f'single quote \' {x} double quoted "{x}"'  # More double quotes => use single quotes
+f"single quoted '{x}' double quote \" {x}"  # More single quotes => use double quotes
+
+rf"single quotes ' {x}"  # Keep double because `'` can't be escaped
+rf'double quotes " {x}'  # Keep single because `"` can't be escaped
+rf"flip quotes {x}"  # Use preferred quotes, because raw string contains now quotes.
 
 # Here, the formatter will remove the escapes which is correct because they aren't allowed
 # pre 3.12. This means we can assume that the f-string is used in the context of 3.12.
+f"foo {'\'bar\''}"
 f"foo {'\"bar\"'}"
 
+# Quotes inside the expressions have no impact on the quote selection of the outer string.
+# Required so that the following two examples result in the same formatting.
+f'foo {10 + len("bar")}'
+f"foo {10 + len('bar')}"
+
+# Pre 312, preserve the outer quotes if the f-string contains quotes in the debug expression
+f'foo {10 + len("bar")=}'
+f'''foo {10 + len('''bar''')=}'''
+f"""foo {10 + len('bar')=}"""  # Fine to change the quotes because it uses triple quotes
 
 # Triple-quoted strings
 # It's ok to use the same quote char for the inner string if it's single-quoted.
@@ -847,6 +918,10 @@ f"""test {'inner'}"""
 f"""test {"inner"}"""
 # But if the inner string is also triple-quoted then we should preserve the existing quotes.
 f"""test {'''inner'''}"""
+
+# Not valid Pre 3.12
+f"""test {f'inner {'''inner inner'''}'}"""
+f"""test {f'''inner {"""inner inner"""}'''}"""
 
 # Magic trailing comma
 #
@@ -994,7 +1069,7 @@ hello {
 # Implicit concatenated f-string containing quotes
 _ = (
     'This string should change its quotes to double quotes'
-    f'This string uses double quotes in an expression {"woah"}'
+    f'This string uses double quotes in an expression {"it's a quote"}'
     f'This f-string does not use any quotes.'
 )
 ```
@@ -1022,7 +1097,7 @@ _ = (
      "    f()\n"
      # XXX: The following line changes depending on whether the tests
      # are run through the interactive interpreter or with -m
-@@ -67,64 +67,72 @@
+@@ -67,29 +67,31 @@
  x = f"{a}"
  x = f"{
      a = }"
@@ -1052,16 +1127,17 @@ _ = (
  # This should never add the optional parentheses because even after adding them, the
  # f-string exceeds the line length limit.
 -x = f"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa { "bbbbbbbbbbbbbbbbbbbbbbbbbbbbb" } ccccccccccccccc"
-+x = f"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa {"bbbbbbbbbbbbbbbbbbbbbbbbbbbbb"} ccccccccccccccc"
++x = f"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa {'bbbbbbbbbbbbbbbbbbbbbbbbbbbbb'} ccccccccccccccc"
  x = f"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa { "bbbbbbbbbbbbbbbbbbbbbbbbbbbbb" = } ccccccccccccccc"
 -x = f"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa { # comment 8
 -                                             "bbbbbbbbbbbbbbbbbbbbbbbbbbbbb" } ccccccccccccccc"
 +x = f"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa {  # comment 8
-+    "bbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
++    'bbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
 +} ccccccccccccccc"
  x = f"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa { # comment 9
                                               "bbbbbbbbbbbbbbbbbbbbbbbbbbbbb" = } ccccccccccccccc"
- 
+ x = f"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa { # comment 9
+@@ -98,35 +100,41 @@
  # Multiple larger expressions which exceeds the line length limit. Here, we need to decide
  # whether to split at the first or second expression. This should work similarly to the
  # assignment statement formatting where we split from right to left in preview mode.
@@ -1119,7 +1195,7 @@ _ = (
  x = f"{    # comment 13
      {'x': 1, 'y': 2} = }"
  # But, if there's a format specifier or a conversion flag then we don't need to add
-@@ -139,7 +147,11 @@
+@@ -141,7 +149,11 @@
  }"
  # And, split the expression itself because it exceeds the line length.
  xxxxxxx = f"{
@@ -1131,14 +1207,36 @@ _ = (
 +    }
  }"
  
- # Quotes
-@@ -152,13 +164,13 @@
+ #############################################################################################
+@@ -151,7 +163,7 @@
+ f'foo "bar" {x}'
+ f'foo "bar" {x}'
+ f"foo 'bar' {x}"
+-f"foo {"bar"}"
++f"foo {'bar'}"
+ 
+ f"single quoted '{x}' double quoted \"{x}\""  # Same number of quotes => use preferred quote style
+ f'single quote \' {x} double quoted "{x}"'  # More double quotes => use single quotes
+@@ -163,28 +175,28 @@
  
  # Here, the formatter will remove the escapes which is correct because they aren't allowed
  # pre 3.12. This means we can assume that the f-string is used in the context of 3.12.
+-f"foo {'\'bar\''}"
 -f"foo {'\"bar\"'}"
++f"foo {"'bar'"}"
 +f"foo {'"bar"'}"
  
+ # Quotes inside the expressions have no impact on the quote selection of the outer string.
+ # Required so that the following two examples result in the same formatting.
+-f'foo {10 + len("bar")}'
+ f"foo {10 + len('bar')}"
++f"foo {10 + len('bar')}"
+ 
+ # Pre 312, preserve the outer quotes if the f-string contains quotes in the debug expression
+ f'foo {10 + len("bar")=}'
+-f'''foo {10 + len('''bar''')=}'''
++f"""foo {10 + len('''bar''')=}"""
+ f"""foo {10 + len('bar')=}"""  # Fine to change the quotes because it uses triple quotes
  
  # Triple-quoted strings
  # It's ok to use the same quote char for the inner string if it's single-quoted.
@@ -1148,7 +1246,13 @@ _ = (
  # But if the inner string is also triple-quoted then we should preserve the existing quotes.
  f"""test {'''inner'''}"""
  
-@@ -171,63 +183,66 @@
+ # Not valid Pre 3.12
+-f"""test {f'inner {'''inner inner'''}'}"""
++f"""test {f"inner {'''inner inner'''}"}"""
+ f"""test {f'''inner {"""inner inner"""}'''}"""
+ 
+ # Magic trailing comma
+@@ -196,63 +208,66 @@
  f"aaaaaaa {['aaaaaaaaaaaaaaa', 'bbbbbbbbbbbbb', 'ccccccccccccccccc', 'ddddddddddddddd', 'eeeeeeeeeeeeee']} aaaaaaa"
  
  # And, if the trailing comma is already present, we still need to remove it.
@@ -1243,7 +1347,7 @@ _ = (
       # comment} cccccccccc"""
  
  # Conversion flags
-@@ -235,24 +250,21 @@
+@@ -260,24 +275,21 @@
  # This is not a valid Python code because of the additional whitespace between the `!`
  # and conversion type. But, our parser isn't strict about this. This should probably be
  # removed once we have a strict parser.
@@ -1275,7 +1379,7 @@ _ = (
  
  x = f"""
  {              # comment 22
-@@ -261,19 +273,19 @@
+@@ -286,19 +298,19 @@
  
  # Here, the debug expression is in a nested f-string so we should start preserving
  # whitespaces from that point onwards. This means we should format the outer f-string.
@@ -1303,7 +1407,7 @@ _ = (
      # comment 27
      # comment 28
  } woah {x}"
-@@ -287,27 +299,27 @@
+@@ -312,27 +324,27 @@
          if indent2:
              foo = f"""hello world
  hello {
@@ -1343,9 +1447,10 @@ _ = (
  # Implicit concatenated f-string containing quotes
  _ = (
 -    'This string should change its quotes to double quotes'
-+    "This string should change its quotes to double quotes"
-     f'This string uses double quotes in an expression {"woah"}'
+-    f'This string uses double quotes in an expression {"it's a quote"}'
 -    f'This f-string does not use any quotes.'
++    "This string should change its quotes to double quotes"
++    f"This string uses double quotes in an expression {"it's a quote"}"
 +    f"This f-string does not use any quotes."
  )
 ```

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__fstring_py312.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__fstring_py312.py.snap
@@ -13,6 +13,14 @@ f"{'a'}"
 
 # 312+, it's okay to change the outer quotes even when there's a debug expression using the same quotes
 f'foo {10 + len("bar")=}'
+f'''foo {10 + len("""bar""")=}'''
+
+# 312+, it's okay to change the quotes here without creating an invalid f-string
+f'{"""other " """}'
+f'{"""other " """ + "more"}'
+f'{b"""other " """}'
+f'{f"""other " """}'
+
 ```
 
 ## Outputs
@@ -41,6 +49,13 @@ f"{'a'}"
 
 # 312+, it's okay to change the outer quotes even when there's a debug expression using the same quotes
 f'foo {10 + len("bar")=}'
+f'''foo {10 + len("""bar""")=}'''
+
+# 312+, it's okay to change the quotes here without creating an invalid f-string
+f'{"""other " """}'
+f'{"""other " """ + "more"}'
+f'{b"""other " """}'
+f'{f"""other " """}'
 ```
 
 
@@ -48,10 +63,22 @@ f'foo {10 + len("bar")=}'
 ```diff
 --- Stable
 +++ Preview
-@@ -6,4 +6,4 @@
+@@ -6,11 +6,11 @@
  f"{'a'}"
  
  # 312+, it's okay to change the outer quotes even when there's a debug expression using the same quotes
 -f'foo {10 + len("bar")=}'
+-f'''foo {10 + len("""bar""")=}'''
 +f"foo {10 + len("bar")=}"
++f"""foo {10 + len("""bar""")=}"""
+ 
+ # 312+, it's okay to change the quotes here without creating an invalid f-string
+-f'{"""other " """}'
+-f'{"""other " """ + "more"}'
+-f'{b"""other " """}'
+-f'{f"""other " """}'
++f"{'''other " '''}"
++f"{'''other " ''' + 'more'}"
++f"{b'''other " '''}"
++f"{f'''other " '''}"
 ```

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__fstring_py312.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__fstring_py312.py.snap
@@ -10,6 +10,9 @@ input_file: crates/ruff_python_formatter/resources/test/fixtures/ruff/expression
 
 # Quotes reuse
 f"{'a'}"
+
+# 312+, it's okay to change the outer quotes even when there's a debug expression using the same quotes
+f'foo {10 + len("bar")=}'
 ```
 
 ## Outputs
@@ -35,6 +38,9 @@ source_type                = Python
 
 # Quotes reuse
 f"{'a'}"
+
+# 312+, it's okay to change the outer quotes even when there's a debug expression using the same quotes
+f'foo {10 + len("bar")=}'
 ```
 
 
@@ -42,10 +48,10 @@ f"{'a'}"
 ```diff
 --- Stable
 +++ Preview
-@@ -3,4 +3,4 @@
- # version isn't set.
+@@ -6,4 +6,4 @@
+ f"{'a'}"
  
- # Quotes reuse
--f"{'a'}"
-+f"{"a"}"
+ # 312+, it's okay to change the outer quotes even when there's a debug expression using the same quotes
+-f'foo {10 + len("bar")=}'
++f"foo {10 + len("bar")=}"
 ```


### PR DESCRIPTION
## Summary

This PR changes how quotes are selected for f-strings and nested string literals when preview mode is on.

For the outer f-string: The logic is the same as for any other strings, except that we only count the quotes inside literal parts. This is different from before where `choose_quotes` analyzed the entire f-string, including expressions. 

The rules for inner f-strings are:

* If the outer f-string is a triple quoted string: Prefer the configured quote style 
* If the outer f-string is single quoted: Prefer the opposite quote style (alternate the quote styles).

```python
f"{'inner'}"

# Before
f"{"inner"}"
```

The only exception to the above rule is when targeting <Py312 and the f-string contains a debug-expression that itself contains quotes:

```python
f'{a + "b"=}' # Can't change the quotes here
```

In this case, changing the quotes is unsafe because the debug expression will retain its existing quotes. That's why the implementation must preserve the outer quotes as is. Changing the outer quotes is fine when targeting Py312+.

```python
f"{a + "b"=}"
```

The advantage of limiting the pre-312 behavior to only debug expressions is that an upgrade of the target version to 312 should result in a very small diff considering that debug expressions containing quotes should be rare.


Fixes https://github.com/astral-sh/ruff/issues/13237
Fixes https://github.com/astral-sh/ruff/issues/11056

## Considerations

This new style no longer optimizes for the fewest "foreign" quotes in total. E.g. it changes

```python
return f'#{data["node"]["number"]} {component_str}{data["node"]["title"]}'
```

to 

```python
return f"#{data['node']['number']} {component_str}{data['node']['title']}"
```

where the total preferred quotes count is 2, but it uses 8 single quotes.

## Test Plan

* Added tests
* Reviewed the snapshot changes
* Reviewed the ecosystem changes

## Review

The most useful for review is if you can think of more cursed f-string examples where the above approach might produce invalid f-strings or weird looking quote selections.
