### PR TITLE
[red-knot] rename {Class,Module,Function} => {Class,Module,Function}Literal

### DIFF
--- a/crates/red_knot_python_semantic/src/semantic_model.rs
+++ b/crates/red_knot_python_semantic/src/semantic_model.rs
@@ -175,7 +175,6 @@ mod tests {
     use crate::db::tests::TestDb;
     use crate::program::{Program, SearchPathSettings};
     use crate::python_version::PythonVersion;
-    use crate::types::Type;
     use crate::{HasTy, ProgramSettings, SemanticModel};
 
     fn setup_db<'a>(files: impl IntoIterator<Item = (&'a str, &'a str)>) -> anyhow::Result<TestDb> {
@@ -205,7 +204,7 @@ mod tests {
         let model = SemanticModel::new(&db, foo);
         let ty = function.ty(&model);
 
-        assert!(matches!(ty, Type::FunctionLiteral(_)));
+        assert!(ty.is_function_literal());
 
         Ok(())
     }
@@ -222,7 +221,7 @@ mod tests {
         let model = SemanticModel::new(&db, foo);
         let ty = class.ty(&model);
 
-        assert!(matches!(ty, Type::ClassLiteral(_)));
+        assert!(ty.is_class_literal());
 
         Ok(())
     }
@@ -243,7 +242,7 @@ mod tests {
         let model = SemanticModel::new(&db, bar);
         let ty = alias.ty(&model);
 
-        assert!(matches!(ty, Type::ClassLiteral(_)));
+        assert!(ty.is_class_literal());
 
         Ok(())
     }

--- a/crates/red_knot_python_semantic/src/semantic_model.rs
+++ b/crates/red_knot_python_semantic/src/semantic_model.rs
@@ -205,7 +205,7 @@ mod tests {
         let model = SemanticModel::new(&db, foo);
         let ty = function.ty(&model);
 
-        assert!(matches!(ty, Type::Function(_)));
+        assert!(matches!(ty, Type::FunctionLiteral(_)));
 
         Ok(())
     }
@@ -222,7 +222,7 @@ mod tests {
         let model = SemanticModel::new(&db, foo);
         let ty = class.ty(&model);
 
-        assert!(matches!(ty, Type::Class(_)));
+        assert!(matches!(ty, Type::ClassLiteral(_)));
 
         Ok(())
     }
@@ -243,7 +243,7 @@ mod tests {
         let model = SemanticModel::new(&db, bar);
         let ty = alias.ty(&model);
 
-        assert!(matches!(ty, Type::Class(_)));
+        assert!(matches!(ty, Type::ClassLiteral(_)));
 
         Ok(())
     }

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -292,27 +292,27 @@ impl<'db> Type<'db> {
         matches!(self, Type::Never)
     }
 
-    pub const fn into_class_type(self) -> Option<ClassType<'db>> {
+    pub const fn into_class_literal_type(self) -> Option<ClassType<'db>> {
         match self {
             Type::ClassLiteral(class_type) => Some(class_type),
             _ => None,
         }
     }
 
-    pub fn expect_class(self) -> ClassType<'db> {
-        self.into_class_type()
+    pub fn expect_class_literal(self) -> ClassType<'db> {
+        self.into_class_literal_type()
             .expect("Expected a Type::ClassLiteral variant")
     }
 
-    pub const fn into_module_type(self) -> Option<File> {
+    pub const fn into_module_literal_type(self) -> Option<File> {
         match self {
             Type::ModuleLiteral(file) => Some(file),
             _ => None,
         }
     }
 
-    pub fn expect_module(self) -> File {
-        self.into_module_type()
+    pub fn expect_module_literal(self) -> File {
+        self.into_module_literal_type()
             .expect("Expected a Type::ModuleLiteral variant")
     }
 
@@ -340,15 +340,15 @@ impl<'db> Type<'db> {
             .expect("Expected a Type::Intersection variant")
     }
 
-    pub const fn into_function_type(self) -> Option<FunctionType<'db>> {
+    pub const fn into_function_literal_type(self) -> Option<FunctionType<'db>> {
         match self {
             Type::FunctionLiteral(function_type) => Some(function_type),
             _ => None,
         }
     }
 
-    pub fn expect_function(self) -> FunctionType<'db> {
-        self.into_function_type()
+    pub fn expect_function_literal(self) -> FunctionType<'db> {
+        self.into_function_literal_type()
             .expect("Expected a Type::FunctionLiteral variant")
     }
 
@@ -394,9 +394,9 @@ impl<'db> Type<'db> {
     }
 
     /// Return true if the type is a class or a union of classes.
-    pub fn is_class(&self, db: &'db dyn Db) -> bool {
+    pub fn is_class_literal(&self, db: &'db dyn Db) -> bool {
         match self {
-            Type::Union(union) => union.elements(db).iter().all(|ty| ty.is_class(db)),
+            Type::Union(union) => union.elements(db).iter().all(|ty| ty.is_class_literal(db)),
             Type::ClassLiteral(_) => true,
             // / TODO include type[X], once we add that type
             _ => false,

--- a/crates/red_knot_python_semantic/src/types/builder.rs
+++ b/crates/red_knot_python_semantic/src/types/builder.rs
@@ -231,7 +231,7 @@ impl<'db> InnerIntersectionBuilder<'db> {
                     if let Some(&Type::BooleanLiteral(value)) = self
                         .negative
                         .iter()
-                        .find(|element| matches!(element, Type::BooleanLiteral(..)))
+                        .find(|element| element.is_boolean_literal())
                     {
                         *self = Self::new();
                         self.positive.insert(Type::BooleanLiteral(!value));

--- a/crates/red_knot_python_semantic/src/types/display.rs
+++ b/crates/red_knot_python_semantic/src/types/display.rs
@@ -34,8 +34,8 @@ impl Display for DisplayType<'_> {
                 | Type::BooleanLiteral(_)
                 | Type::StringLiteral(_)
                 | Type::BytesLiteral(_)
-                | Type::Class(_)
-                | Type::Function(_)
+                | Type::ClassLiteral(_)
+                | Type::FunctionLiteral(_)
         ) {
             write!(f, "Literal[{representation}]")
         } else {
@@ -69,13 +69,13 @@ impl Display for DisplayRepresentation<'_> {
             // `[Type::Todo]`'s display should be explicit that is not a valid display of
             // any other type
             Type::Todo => f.write_str("@Todo"),
-            Type::Module(file) => {
+            Type::ModuleLiteral(file) => {
                 write!(f, "<module '{:?}'>", file.path(self.db))
             }
             // TODO functions and classes should display using a fully qualified name
-            Type::Class(class) => f.write_str(class.name(self.db)),
+            Type::ClassLiteral(class) => f.write_str(class.name(self.db)),
             Type::Instance(class) => f.write_str(class.name(self.db)),
-            Type::Function(function) => f.write_str(function.name(self.db)),
+            Type::FunctionLiteral(function) => f.write_str(function.name(self.db)),
             Type::Union(union) => union.display(self.db).fmt(f),
             Type::Intersection(intersection) => intersection.display(self.db).fmt(f),
             Type::IntLiteral(n) => n.fmt(f),
@@ -138,7 +138,7 @@ impl Display for DisplayUnionType<'_> {
                 let Some(mut literals) = grouped_literals.remove(&literal_kind) else {
                     continue;
                 };
-                if literal_kind == LiteralTypeKind::IntLiteral {
+                if literal_kind == LiteralTypeKind::Int {
                     literals.sort_unstable_by_key(|ty| ty.expect_int_literal());
                 }
                 join.entry(&DisplayLiteralGroup {
@@ -183,9 +183,9 @@ impl Display for DisplayLiteralGroup<'_> {
 enum LiteralTypeKind {
     Class,
     Function,
-    IntLiteral,
-    StringLiteral,
-    BytesLiteral,
+    Int,
+    String,
+    Bytes,
 }
 
 impl TryFrom<Type<'_>> for LiteralTypeKind {
@@ -193,11 +193,11 @@ impl TryFrom<Type<'_>> for LiteralTypeKind {
 
     fn try_from(value: Type<'_>) -> Result<Self, Self::Error> {
         match value {
-            Type::Class(_) => Ok(Self::Class),
-            Type::Function(_) => Ok(Self::Function),
-            Type::IntLiteral(_) => Ok(Self::IntLiteral),
-            Type::StringLiteral(_) => Ok(Self::StringLiteral),
-            Type::BytesLiteral(_) => Ok(Self::BytesLiteral),
+            Type::ClassLiteral(_) => Ok(Self::Class),
+            Type::FunctionLiteral(_) => Ok(Self::Function),
+            Type::IntLiteral(_) => Ok(Self::Int),
+            Type::StringLiteral(_) => Ok(Self::String),
+            Type::BytesLiteral(_) => Ok(Self::Bytes),
             _ => Err(()),
         }
     }

--- a/crates/red_knot_python_semantic/src/types/display.rs
+++ b/crates/red_knot_python_semantic/src/types/display.rs
@@ -179,6 +179,12 @@ impl Display for DisplayLiteralGroup<'_> {
     }
 }
 
+/// Enumeration of literal types that are displayed in a "condensed way" inside `Literal` slices.
+///
+/// For example, `Literal[1] | Literal[2]` is displayed as `"Literal[1, 2]"`.
+/// Not all `Literal` types are displayed using `Literal` slices
+/// (e.g. it would be inappropriate to display `LiteralString`
+/// as `Literal[LiteralString]`).
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 enum CondensedDisplayTypeKind {
     Class,

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -510,12 +510,12 @@ impl<'db> TypeInferenceBuilder<'db> {
         assigned_ty: Type<'db>,
     ) {
         match declared_ty {
-            Type::Class(class) => {
+            Type::ClassLiteral(class) => {
                 self.add_diagnostic(node, "invalid-assignment", format_args!(
                         "Implicit shadowing of class `{}`; annotate to make it explicit if this is intentional",
                         class.name(self.db)));
             }
-            Type::Function(function) => {
+            Type::FunctionLiteral(function) => {
                 self.add_diagnostic(node, "invalid-assignment", format_args!(
                         "Implicit shadowing of function `{}`; annotate to make it explicit if this is intentional",
                         function.name(self.db)));
@@ -778,7 +778,7 @@ impl<'db> TypeInferenceBuilder<'db> {
             }
             _ => None,
         };
-        let function_ty = Type::Function(FunctionType::new(
+        let function_ty = Type::FunctionLiteral(FunctionType::new(
             self.db,
             name.id.clone(),
             function_kind,
@@ -887,7 +887,7 @@ impl<'db> TypeInferenceBuilder<'db> {
             .as_ref()
             .and_then(|module| KnownClass::maybe_from_module(module, name.as_str()));
 
-        let class_ty = Type::Class(ClassType::new(
+        let class_ty = Type::ClassLiteral(ClassType::new(
             self.db,
             name.id.clone(),
             definition,
@@ -1056,7 +1056,7 @@ impl<'db> TypeInferenceBuilder<'db> {
             // anything else is invalid and should lead to a diagnostic being reported --Alex
             match node_ty {
                 Type::Any | Type::Unknown => node_ty,
-                Type::Class(class_ty) => Type::Instance(class_ty),
+                Type::ClassLiteral(class_ty) => Type::Instance(class_ty),
                 Type::Tuple(tuple) => UnionType::from_elements(
                     self.db,
                     tuple
@@ -1773,7 +1773,7 @@ impl<'db> TypeInferenceBuilder<'db> {
     }
 
     fn module_ty_from_name(&self, module_name: &ModuleName) -> Option<Type<'db>> {
-        resolve_module(self.db, module_name).map(|module| Type::Module(module.file()))
+        resolve_module(self.db, module_name).map(|module| Type::ModuleLiteral(module.file()))
     }
 
     fn infer_decorator(&mut self, decorator: &ast::Decorator) -> Type<'db> {
@@ -3331,7 +3331,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                             });
                     }
 
-                    if matches!(value_ty, Type::Class(class) if class.is_known(self.db, KnownClass::Type))
+                    if matches!(value_ty, Type::ClassLiteral(class) if class.is_known(self.db, KnownClass::Type))
                     {
                         return KnownClass::GenericAlias.to_instance(self.db);
                     }

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -1311,7 +1311,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                         }
                     }
                     _ => {
-                        let value_ty = if matches!(value_ty, Type::LiteralString) {
+                        let value_ty = if value_ty.is_literal_string() {
                             Type::LiteralString
                         } else {
                             value_ty

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -3311,7 +3311,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                 // even if the target version is Python 3.8 or lower,
                 // despite the fact that there will be no corresponding `__class_getitem__`
                 // method in these `sys.version_info` branches.
-                if value_ty.is_class_literal(self.db) {
+                if value_ty.is_subtype_of(self.db, KnownClass::Type.to_instance(self.db)) {
                     let dunder_class_getitem_method = value_ty.member(self.db, "__class_getitem__");
                     if !dunder_class_getitem_method.is_unbound() {
                         return dunder_class_getitem_method

--- a/crates/red_knot_workspace/src/lint.rs
+++ b/crates/red_knot_workspace/src/lint.rs
@@ -142,7 +142,7 @@ fn lint_bad_override(context: &SemanticLintContext, class: &ast::StmtClassDef) {
 
     let override_ty = semantic.global_symbol_ty(&typing, "override");
 
-    let Type::Class(class_ty) = class.ty(semantic) else {
+    let Type::ClassLiteral(class_ty) = class.ty(semantic) else {
         return;
     };
 
@@ -151,7 +151,7 @@ fn lint_bad_override(context: &SemanticLintContext, class: &ast::StmtClassDef) {
         .iter()
         .filter_map(|stmt| stmt.as_function_def_stmt())
     {
-        let Type::Function(ty) = function.ty(semantic) else {
+        let Type::FunctionLiteral(ty) = function.ty(semantic) else {
             return;
         };
 


### PR DESCRIPTION
## Summary

* Rename `Type::Class` => `Type::ClassLiteral`
* Rename `Type::Function` => `Type::FunctionLiteral`
* Do not rename `Type::Module`
* Remove `*Literal` suffixes in `display::LiteralTypeKind` variants, as per clippy suggestion
* Get rid of `Type::is_class()` in favor of `is_subtype_of(…, 'type')`; modifiy `is_subtype_of` to support this.
* Add new `Type::is_xyz()` methods and use them instead of matching on `Type` variants.

closes #13863 

## Test Plan

New `is_subtype_of_class_literals` unit test.