### PR TITLE
[red-knot] Treat empty intersection as 'object', fix intersection simplification

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/narrow/conditionals_nested.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/narrow/conditionals_nested.md
@@ -1,5 +1,7 @@
 # Narrowing for nested conditionals
 
+## Multiple negative contributions
+
 ```py
 def int_instance() -> int: ...
 
@@ -10,4 +12,15 @@ if x != 1:
     if x != 2:
         if x != 3:
             reveal_type(x)  # revealed: int & ~Literal[1] & ~Literal[2] & ~Literal[3]
+```
+
+## Multiple negative contributions with simplification
+
+```py
+x = 1 if flag1 else 2 if flag2 else 3
+
+if x != 1:
+    reveal_type(x)  # revealed: Literal[2, 3]
+    if x != 2:
+        reveal_type(x)  # revealed: Literal[3]
 ```

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -148,21 +148,12 @@ fn bindings_ty<'db>(
              binding,
              constraints,
          }| {
-            let mut constraint_tys =
+            let constraint_tys =
                 constraints.filter_map(|constraint| narrowing_constraint(db, constraint, binding));
-            let binding_ty = binding_ty(db, binding);
-            if let Some(first_constraint_ty) = constraint_tys.next() {
-                let mut builder = IntersectionBuilder::new(db);
-                builder = builder
-                    .add_positive(binding_ty)
-                    .add_positive(first_constraint_ty);
-                for constraint_ty in constraint_tys {
-                    builder = builder.add_positive(constraint_ty);
-                }
-                builder.build()
-            } else {
-                binding_ty
-            }
+
+            constraint_tys.fold(binding_ty(db, binding), |ty, constraint_ty| {
+                ty.intersect(db, constraint_ty)
+            })
         },
     );
     let mut all_types = unbound_ty.into_iter().chain(def_types);
@@ -1057,6 +1048,14 @@ impl<'db> Type<'db> {
             // TODO: handle more complex types
             _ => KnownClass::Str.to_instance(db),
         }
+    }
+
+    #[must_use]
+    pub fn intersect(&self, db: &'db dyn Db, other: Type<'db>) -> Type<'db> {
+        IntersectionBuilder::new(db)
+            .add_positive(*self)
+            .add_positive(other)
+            .build()
     }
 }
 
@@ -2110,5 +2109,35 @@ mod tests {
         let db = setup_db();
 
         assert_eq!(ty.into_type(&db).repr(&db), expected.into_type(&db));
+    }
+
+    #[test]
+    fn type_intersect() {
+        // Note: There are no tests for `Type::intersect`, as that functionality is covered
+        // by the tests for `IntersectionBuilder`. This particular test is a regression test
+        // for https://github.com/astral-sh/ruff/issues/13870.
+
+        let db = setup_db();
+
+        let t_1 = Type::IntLiteral(1);
+        let t_2 = Type::IntLiteral(2);
+        let t_3 = Type::IntLiteral(3);
+        let union = UnionType::from_elements(&db, [t_1, t_2, t_3]);
+
+        let t_object = Ty::BuiltinInstance("object").into_type(&db);
+        let constraint1 = IntersectionBuilder::new(&db)
+            .add_positive(t_object)
+            .add_negative(t_1)
+            .build();
+        let constraint2 = IntersectionBuilder::new(&db)
+            .add_positive(t_object)
+            .add_negative(t_2)
+            .build();
+
+        let ty = union
+            .intersect(&db, constraint1)
+            .intersect(&db, constraint2);
+
+        assert_eq!(ty, t_3);
     }
 }

--- a/crates/red_knot_python_semantic/src/types/narrow.rs
+++ b/crates/red_knot_python_semantic/src/types/narrow.rs
@@ -4,7 +4,7 @@ use crate::semantic_index::definition::Definition;
 use crate::semantic_index::expression::Expression;
 use crate::semantic_index::symbol::{ScopeId, ScopedSymbolId, SymbolTable};
 use crate::semantic_index::symbol_table;
-use crate::types::{infer_expression_types, IntersectionBuilder, Type};
+use crate::types::{infer_expression_types, IntersectionBuilder, KnownClass, Type};
 use crate::Db;
 use itertools::Itertools;
 use ruff_python_ast as ast;
@@ -168,6 +168,7 @@ impl<'db> NarrowingConstraintsBuilder<'db> {
                     ast::CmpOp::IsNot => {
                         if comp_ty.is_singleton() {
                             let ty = IntersectionBuilder::new(self.db)
+                                .add_positive(KnownClass::Object.to_instance(self.db))
                                 .add_negative(comp_ty)
                                 .build();
                             self.constraints.insert(symbol, ty);
@@ -181,6 +182,7 @@ impl<'db> NarrowingConstraintsBuilder<'db> {
                     ast::CmpOp::NotEq => {
                         if comp_ty.is_single_valued(self.db) {
                             let ty = IntersectionBuilder::new(self.db)
+                                .add_positive(KnownClass::Object.to_instance(self.db))
                                 .add_negative(comp_ty)
                                 .build();
                             self.constraints.insert(symbol, ty);

--- a/crates/red_knot_python_semantic/src/types/narrow.rs
+++ b/crates/red_knot_python_semantic/src/types/narrow.rs
@@ -4,7 +4,7 @@ use crate::semantic_index::definition::Definition;
 use crate::semantic_index::expression::Expression;
 use crate::semantic_index::symbol::{ScopeId, ScopedSymbolId, SymbolTable};
 use crate::semantic_index::symbol_table;
-use crate::types::{infer_expression_types, IntersectionBuilder, KnownClass, Type};
+use crate::types::{infer_expression_types, IntersectionBuilder, Type};
 use crate::Db;
 use itertools::Itertools;
 use ruff_python_ast as ast;
@@ -168,7 +168,6 @@ impl<'db> NarrowingConstraintsBuilder<'db> {
                     ast::CmpOp::IsNot => {
                         if comp_ty.is_singleton() {
                             let ty = IntersectionBuilder::new(self.db)
-                                .add_positive(KnownClass::Object.to_instance(self.db))
                                 .add_negative(comp_ty)
                                 .build();
                             self.constraints.insert(symbol, ty);
@@ -182,7 +181,6 @@ impl<'db> NarrowingConstraintsBuilder<'db> {
                     ast::CmpOp::NotEq => {
                         if comp_ty.is_single_valued(self.db) {
                             let ty = IntersectionBuilder::new(self.db)
-                                .add_positive(KnownClass::Object.to_instance(self.db))
                                 .add_negative(comp_ty)
                                 .build();
                             self.constraints.insert(symbol, ty);


### PR DESCRIPTION
## Summary

- Properly treat the empty intersection as being of type `object`.
- Consequently, change the simplification method to explicitly add `Never` to the positive side of the intersection when collapsing a type such as `int & str` to `Never`, as opposed to just clearing both the positive and the negative side.
- Minor code improvement in `bindings_ty`: use `peekable()` to check whether the iterator over constraints is empty, instead of handling first and subsequent elements separately.

fixes #13870

## Test Plan

- New unit tests for `IntersectionBuilder` to make sure the empty intersection represents `object`.
- Markdown-based regression test for the original issue in #13870