### PR TITLE
fix issues in discovering ruff in pip build environments

### DIFF
--- a/python/ruff/__main__.py
+++ b/python/ruff/__main__.py
@@ -57,20 +57,21 @@ def find_ruff_bin() -> str:
     #
     # See: https://github.com/pypa/pip/blob/102d8187a1f5a4cd5de7a549fd8a9af34e89a54f/src/pip/_internal/build_env.py#L87
     paths = os.environ.get("PATH", "").split(os.pathsep)
-    maybe_overlay = get_last_three_path_parts(paths[0])
-    maybe_normal = get_last_three_path_parts(paths[1])
-    if (
-        len(maybe_normal) >= 3
-        and maybe_normal[-1].startswith("pip-build-env-")
-        and maybe_normal[-2] == "normal"
-        and len(maybe_overlay) >= 3
-        and maybe_overlay[-1].startswith("pip-build-env-")
-        and maybe_overlay[-2] == "overlay"
-    ):
-        # The overlay must contain the ruff binary.
-        candidate = os.path.join(paths[0], ruff_exe)
-        if os.path.isfile(candidate):
-            return candidate
+    if len(paths) >= 2:
+        maybe_overlay = get_last_three_path_parts(paths[0])
+        maybe_normal = get_last_three_path_parts(paths[1])
+        if (
+            len(maybe_normal) >= 3
+            and maybe_normal[-1].startswith("pip-build-env-")
+            and maybe_normal[-2] == "normal"
+            and len(maybe_overlay) >= 3
+            and maybe_overlay[-1].startswith("pip-build-env-")
+            and maybe_overlay[-2] == "overlay"
+        ):
+            # The overlay must contain the ruff binary.
+            candidate = os.path.join(paths[0], ruff_exe)
+            if os.path.isfile(candidate):
+                return candidate
 
     raise FileNotFoundError(scripts_path)
 

--- a/python/ruff/__main__.py
+++ b/python/ruff/__main__.py
@@ -3,23 +3,6 @@ import sys
 import sysconfig
 
 
-def get_last_three_path_parts(path: str) -> list[str]:
-    """Return a list of up to the last three parts of a path."""
-    parts, idx = [], 0
-
-    while idx < 3:
-        new_path, base = os.path.split(path)
-        if base or new_path != path:
-            parts.append(base)
-            path = new_path
-            idx += 1
-        else:
-            parts.append(path)
-            break
-
-    return parts
-
-
 def find_ruff_bin() -> str:
     """Return the ruff binary path."""
 
@@ -58,6 +41,22 @@ def find_ruff_bin() -> str:
     # See: https://github.com/pypa/pip/blob/102d8187a1f5a4cd5de7a549fd8a9af34e89a54f/src/pip/_internal/build_env.py#L87
     paths = os.environ.get("PATH", "").split(os.pathsep)
     if len(paths) >= 2:
+
+        def get_last_three_path_parts(path: str) -> list[str]:
+            """Return a list of up to the last three parts of a path."""
+            parts = []
+
+            while len(parts) < 3:
+                head, tail = os.path.split(path)
+                if tail or head != path:
+                    parts.append(tail)
+                    path = head
+                else:
+                    parts.append(path)
+                    break
+
+            return parts
+
         maybe_overlay = get_last_three_path_parts(paths[0])
         maybe_normal = get_last_three_path_parts(paths[1])
         if (

--- a/python/ruff/__main__.py
+++ b/python/ruff/__main__.py
@@ -3,6 +3,23 @@ import sys
 import sysconfig
 
 
+def get_last_three_path_parts(path: str) -> list[str]:
+    """Return a list of up to the last three parts of a path."""
+    parts, idx = [], 0
+
+    while idx < 3:
+        new_path, base = os.path.split(path)
+        if base or new_path != path:
+            parts.append(base)
+            path = new_path
+            idx += 1
+        else:
+            parts.append(path)
+            break
+
+    return parts
+
+
 def find_ruff_bin() -> str:
     """Return the ruff binary path."""
 
@@ -35,24 +52,25 @@ def find_ruff_bin() -> str:
 
     # Search for pip-specific build environments.
     #
+    # Expect to find ruff in <prefix>/pip-build-env-<rand>/overlay/bin/ruff
+    # Expect to find a "normal" folder at <prefix>/pip-build-env-<rand>/normal
+    #
     # See: https://github.com/pypa/pip/blob/102d8187a1f5a4cd5de7a549fd8a9af34e89a54f/src/pip/_internal/build_env.py#L87
     paths = os.environ.get("PATH", "").split(os.pathsep)
-    if len(paths) >= 2:
-        first, second = os.path.split(paths[0]), os.path.split(paths[1])
-        # Search for both an `overlay` and `normal` folder within a `pip-build-env-{random}` folder. (The final segment
-        # of the path is the `bin` directory.)
-        if (
-            len(first) >= 3
-            and len(second) >= 3
-            and first[-3].startswith("pip-build-env-")
-            and first[-2] == "overlay"
-            and second[-3].startswith("pip-build-env-")
-            and second[-2] == "normal"
-        ):
-            # The overlay must contain the ruff binary.
-            candidate = os.path.join(first, ruff_exe)
-            if os.path.isfile(candidate):
-                return candidate
+    maybe_overlay = get_last_three_path_parts(paths[0])
+    maybe_normal = get_last_three_path_parts(paths[1])
+    if (
+        len(maybe_normal) >= 3
+        and maybe_normal[-1].startswith("pip-build-env-")
+        and maybe_normal[-2] == "normal"
+        and len(maybe_overlay) >= 3
+        and maybe_overlay[-1].startswith("pip-build-env-")
+        and maybe_overlay[-2] == "overlay"
+    ):
+        # The overlay must contain the ruff binary.
+        candidate = os.path.join(paths[0], ruff_exe)
+        if os.path.isfile(candidate):
+            return candidate
 
     raise FileNotFoundError(scripts_path)
 


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->
Changes in this PR https://github.com/astral-sh/ruff/pull/13591 did not allow correct discovery in pip build environments.

```python
# both of these variables are tuple[str, str] (length is 2)
first, second = os.path.split(paths[0]), os.path.split(paths[1])

# so these length checks are guaranteed to fail even for build environment folders
if (
    len(first) >= 3
    and len(second) >= 3 
    ...
)
```

~~Here we instead use `pathlib`, and we check all `pip-build-env-` paths for the folder that is expected to contain the `ruff` executable.~~

Here we update the logic to more properly split out the path components that we use for `pip-build-env-` inspection.

## Test Plan

I've checked this manually against a workflow that was failing, I'm not sure what to do for real tests. The same issues apply as with the previous PR.
