### PR TITLE
[red-knot] Use track_caller for expect_ methods

### DIFF
--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -299,6 +299,7 @@ impl<'db> Type<'db> {
         }
     }
 
+    #[track_caller]
     pub fn expect_class_literal(self) -> ClassType<'db> {
         self.into_class_literal_type()
             .expect("Expected a Type::ClassLiteral variant")
@@ -315,6 +316,7 @@ impl<'db> Type<'db> {
         }
     }
 
+    #[track_caller]
     pub fn expect_module_literal(self) -> File {
         self.into_module_literal_type()
             .expect("Expected a Type::ModuleLiteral variant")
@@ -327,6 +329,7 @@ impl<'db> Type<'db> {
         }
     }
 
+    #[track_caller]
     pub fn expect_union(self) -> UnionType<'db> {
         self.into_union_type()
             .expect("Expected a Type::Union variant")
@@ -343,6 +346,7 @@ impl<'db> Type<'db> {
         }
     }
 
+    #[track_caller]
     pub fn expect_intersection(self) -> IntersectionType<'db> {
         self.into_intersection_type()
             .expect("Expected a Type::Intersection variant")
@@ -355,6 +359,7 @@ impl<'db> Type<'db> {
         }
     }
 
+    #[track_caller]
     pub fn expect_function_literal(self) -> FunctionType<'db> {
         self.into_function_literal_type()
             .expect("Expected a Type::FunctionLiteral variant")
@@ -371,6 +376,7 @@ impl<'db> Type<'db> {
         }
     }
 
+    #[track_caller]
     pub fn expect_int_literal(self) -> i64 {
         self.into_int_literal_type()
             .expect("Expected a Type::IntLiteral variant")

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -205,6 +205,7 @@ impl<'db> TypeInference<'db> {
         }
     }
 
+    #[track_caller]
     pub(crate) fn expression_ty(&self, expression: ScopedExpressionId) -> Type<'db> {
         self.expressions[&expression]
     }
@@ -213,10 +214,12 @@ impl<'db> TypeInference<'db> {
         self.expressions.get(&expression).copied()
     }
 
+    #[track_caller]
     pub(crate) fn binding_ty(&self, definition: Definition<'db>) -> Type<'db> {
         self.bindings[&definition]
     }
 
+    #[track_caller]
     pub(crate) fn declaration_ty(&self, definition: Definition<'db>) -> Type<'db> {
         self.declarations[&definition]
     }


### PR DESCRIPTION
## Summary

A minor quality-of-life improvement: add [`#[track_caller]`](https://doc.rust-lang.org/reference/attributes/codegen.html#the-track_caller-attribute) attribute to `Type::expect_xyz()` methods such that the panic-location is reported one level higher up in the stack trace.

before: reports location inside the `Type::expect_class_literal()` method. Not very useful.
```
thread 'types::infer::tests::deferred_annotation_builtin' panicked at crates/red_knot_python_semantic/src/types.rs:304:14:
Expected a Type::ClassLiteral variant
```

after: reports location at the `Type::expect_class_literal()` call site, where the error was made.
```
thread 'types::infer::tests::deferred_annotation_builtin' panicked at crates/red_knot_python_semantic/src/types/infer.rs:4302:14:
Expected a Type::ClassLiteral variant
```

## Test Plan

Called `expect_class_literal()` on something that's not a `Type::ClassLiteral` and saw that the error was reported at the call site.