### PR TITLE
Fix stale syntax errors in playground

### DIFF
--- a/playground/src/Editor/Diagnostics.tsx
+++ b/playground/src/Editor/Diagnostics.tsx
@@ -67,10 +67,10 @@ function Items({
 
   return (
     <ul className="space-y-0.5 flex-grow overflow-y-scroll">
-      {diagnostics.map((diagnostic) => {
+      {diagnostics.map((diagnostic, index) => {
         return (
           <li
-            key={`${diagnostic.location.row}:${diagnostic.location.column}-${diagnostic.code}`}
+            key={`${diagnostic.location.row}:${diagnostic.location.column}-${diagnostic.code ?? index}`}
           >
             <button
               onClick={() =>


### PR DESCRIPTION
## Summary

Fixes https://github.com/astral-sh/ruff/issues/13877

The problem was that syntax errors have no code. This resulted in two diagnostic-lines to have the same key which isn't allowed in React.

## Test Plan

Tested locally that syntax errors disappear from the diagnostics panel when they are fixed.
