### PR TITLE
[red-knot] Type narrowing for `isinstance` checks

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/narrow/isinstance.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/narrow/isinstance.md
@@ -1,0 +1,63 @@
+# Narrowing for `isinstance` checks
+
+Narrowing for `isinstance(object, classinfo)` expressions.
+
+## `classinfo` is a single type
+
+```py
+x = 1 if flag else "a"
+
+if isinstance(x, int):
+    reveal_type(x)  # revealed: Literal[1]
+
+if isinstance(x, str):
+    reveal_type(x)  # revealed: Literal["a"]
+    if isinstance(x, int):
+        reveal_type(x)  # revealed: Never
+
+if isinstance(x, (int, object)):
+    reveal_type(x)  # revealed: Literal[1] | Literal["a"]
+```
+
+## `classinfo` is a tuple of types
+
+Note: `isinstance(x, (int, str))` should not be confused with
+`isinstance(x, tuple[(int, str)])`. The former is equivalent to
+`isinstance(x, int | str)`:
+
+```py
+x = 1 if flag else "a"
+
+if isinstance(x, (int, str)):
+    reveal_type(x)  # revealed: Literal[1] | Literal["a"]
+
+if isinstance(x, (int, bytes)):
+    reveal_type(x)  # revealed: Literal[1]
+
+if isinstance(x, (bytes, str)):
+    reveal_type(x)  # revealed: Literal["a"]
+
+# No narrowing should occur if a larger type is also
+# one of the possibilities:
+if isinstance(x, (int, object)):
+    reveal_type(x)  # revealed: Literal[1] | Literal["a"]
+
+y = 1 if flag1 else "a" if flag2 else b"b"
+if isinstance(y, (int, str)):
+    reveal_type(y)  # revealed: Literal[1] | Literal["a"]
+
+if isinstance(y, (int, bytes)):
+    reveal_type(y)  # revealed: Literal[1] | Literal[b"b"]
+
+if isinstance(y, (str, bytes)):
+    reveal_type(y)  # revealed: Literal["a"] | Literal[b"b"]
+```
+
+## `classinfo` is a nested tuple of types
+
+```py
+x = 1 if flag else "a"
+
+if isinstance(x, (bool, (bytes, int))):
+    reveal_type(x)  # revealed: Literal[1]
+```

--- a/crates/red_knot_python_semantic/resources/mdtest/narrow/isinstance.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/narrow/isinstance.md
@@ -93,3 +93,13 @@ x = 1 if flag else "a"
 if isinstance(x, int):
     reveal_type(x)  # revealed: Literal[1] | Literal["a"]
 ```
+
+## Do support narrowing if `isinstance` is aliased
+
+```py
+isinstance_alias = isinstance
+
+x = 1 if flag else "a"
+if isinstance_alias(x, int):
+    reveal_type(x)  # revealed: Literal[1]
+```

--- a/crates/red_knot_python_semantic/resources/mdtest/narrow/isinstance.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/narrow/isinstance.md
@@ -61,3 +61,23 @@ x = 1 if flag else "a"
 if isinstance(x, (bool, (bytes, int))):
     reveal_type(x)  # revealed: Literal[1]
 ```
+
+## Class types
+
+```py
+class A: ...
+
+
+class B: ...
+
+
+def get_object() -> object: ...
+
+
+x = get_object()
+
+if isinstance(x, A):
+    reveal_type(x)  # revealed: A
+    if isinstance(x, B):
+        reveal_type(x)  # revealed: A & B
+```

--- a/crates/red_knot_python_semantic/resources/mdtest/narrow/isinstance.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/narrow/isinstance.md
@@ -123,3 +123,11 @@ x = 1 if flag else "a"
 if imported_isinstance(x, int):
     reveal_type(x)  # revealed: Literal[1]
 ```
+
+## Do not narrow if there are keyword arguments
+
+```py
+x = 1 if flag else "a"
+if isinstance(x, int, foo="bar"):
+    reveal_type(x)  # revealed: Literal[1] | Literal["a"]
+```

--- a/crates/red_knot_python_semantic/resources/mdtest/narrow/isinstance.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/narrow/isinstance.md
@@ -86,6 +86,9 @@ if isinstance(x, A):
 
 ```py
 t = type("t", (), {})
+
+# This isn't testing what we want it to test if we infer anything more precise here:
+reveal_type(t)  # revealed: type
 x = 1 if flag else "foo"
 
 if isinstance(x, t):

--- a/crates/red_knot_python_semantic/resources/mdtest/narrow/isinstance.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/narrow/isinstance.md
@@ -113,3 +113,13 @@ x = 1 if flag else "a"
 if isinstance_alias(x, int):
     reveal_type(x)  # revealed: Literal[1]
 ```
+
+## Do support narrowing if `isinstance` is imported
+
+```py
+from builtins import isinstance as imported_isinstance
+
+x = 1 if flag else "a"
+if imported_isinstance(x, int):
+    reveal_type(x)  # revealed: Literal[1]
+```

--- a/crates/red_knot_python_semantic/resources/mdtest/narrow/isinstance.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/narrow/isinstance.md
@@ -81,3 +81,15 @@ if isinstance(x, A):
     if isinstance(x, B):
         reveal_type(x)  # revealed: A & B
 ```
+
+## Do not use custom `isinstance` for narrowing
+
+```py
+def isinstance(x, t):
+    return True
+
+
+x = 1 if flag else "a"
+if isinstance(x, int):
+    reveal_type(x)  # revealed: Literal[1] | Literal["a"]
+```

--- a/crates/red_knot_python_semantic/resources/mdtest/narrow/isinstance.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/narrow/isinstance.md
@@ -127,6 +127,22 @@ if imported_isinstance(x, int):
     reveal_type(x)  # revealed: Literal[1]
 ```
 
+## Do not narrow if second argument is not a type
+
+```py
+x = 1 if flag else "a"
+
+# TODO: this should cause us to emit a diagnostic during
+# type checking
+if isinstance(x, "a"):
+    reveal_type(x)  # revealed: Literal[1] | Literal["a"]
+
+# TODO: this should cause us to emit a diagnostic during
+# type checking
+if isinstance(x, "int"):
+    reveal_type(x)  # revealed: Literal[1] | Literal["a"]
+```
+
 ## Do not narrow if there are keyword arguments
 
 ```py

--- a/crates/red_knot_python_semantic/resources/mdtest/narrow/isinstance.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/narrow/isinstance.md
@@ -128,6 +128,9 @@ if imported_isinstance(x, int):
 
 ```py
 x = 1 if flag else "a"
+
+# TODO: this should cause us to emit a diagnostic
+# (`isinstance` has no `foo` parameter)
 if isinstance(x, int, foo="bar"):
     reveal_type(x)  # revealed: Literal[1] | Literal["a"]
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/narrow/isinstance.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/narrow/isinstance.md
@@ -82,6 +82,16 @@ if isinstance(x, A):
         reveal_type(x)  # revealed: A & B
 ```
 
+## No narrowing for instances of `builtins.type`
+
+```py
+t = type("t", (), {})
+x = 1 if flag else "foo"
+
+if isinstance(x, t):
+    reveal_type(x)  # revealed: Literal[1] | Literal["foo"]
+```
+
 ## Do not use custom `isinstance` for narrowing
 
 ```py

--- a/crates/red_knot_python_semantic/src/semantic_index/definition.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/definition.rs
@@ -47,7 +47,13 @@ impl<'db> Definition<'db> {
         self.kind(db).category().is_binding()
     }
 
-    /// Return true if this is a symbol was defined in the `typing` or `typing_extensions` modules
+    pub(crate) fn is_builtin_definition(self, db: &'db dyn Db) -> bool {
+        file_to_module(db, self.file(db)).is_some_and(|module| {
+            module.search_path().is_standard_library() && matches!(&**module.name(), "builtins")
+        })
+    }
+
+    /// Return true if this symbol was defined in the `typing` or `typing_extensions` modules
     pub(crate) fn is_typing_definition(self, db: &'db dyn Db) -> bool {
         file_to_module(db, self.file(db)).is_some_and(|module| {
             module.search_path().is_standard_library()

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -874,6 +874,9 @@ impl<'db> Type<'db> {
                     function_type.return_type(db),
                     *arg_types.first().unwrap_or(&Type::Unknown),
                 ),
+                Some(KnownFunction::IsInstance) => {
+                    CallOutcome::callable(KnownClass::Bool.to_instance(db))
+                }
             },
 
             // TODO annotated return type on `__new__` or metaclass `__call__`
@@ -1603,6 +1606,8 @@ impl<'db> FunctionType<'db> {
 pub enum KnownFunction {
     /// `builtins.reveal_type`, `typing.reveal_type` or `typing_extensions.reveal_type`
     RevealType,
+    /// `builtins.isinstance`
+    IsInstance,
 }
 
 #[salsa::interned]

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -779,6 +779,9 @@ impl<'db> TypeInferenceBuilder<'db> {
             "reveal_type" if definition.is_typing_definition(self.db) => {
                 Some(KnownFunction::RevealType)
             }
+            "isinstance" if definition.is_builtin_definition(self.db) => {
+                Some(KnownFunction::IsInstance)
+            }
             _ => None,
         };
         let function_ty = Type::FunctionLiteral(FunctionType::new(

--- a/crates/red_knot_python_semantic/src/types/narrow.rs
+++ b/crates/red_knot_python_semantic/src/types/narrow.rs
@@ -228,7 +228,9 @@ impl<'db> NarrowingConstraintsBuilder<'db> {
             .expression_ty(expr_call.func.scoped_ast_id(self.db, scope))
             .into_function_literal_type()
         {
-            if func_type.known(self.db) == Some(KnownFunction::IsInstance) {
+            if func_type.known(self.db) == Some(KnownFunction::IsInstance)
+                && expr_call.arguments.keywords.is_empty()
+            {
                 if let [ast::Expr::Name(ast::ExprName { id, .. }), rhs] = &*expr_call.arguments.args
                 {
                     let symbol = self.symbols().symbol_id_by_name(id).unwrap();

--- a/crates/red_knot_python_semantic/src/types/narrow.rs
+++ b/crates/red_knot_python_semantic/src/types/narrow.rs
@@ -228,7 +228,7 @@ impl<'db> NarrowingConstraintsBuilder<'db> {
             .expression_ty(expr_call.func.scoped_ast_id(self.db, scope))
             .into_function_literal_type()
         {
-            if func_type.known(self.db) == Some(KnownFunction::IsInstance)
+            if func_type.is_known(self.db, KnownFunction::IsInstance)
                 && expr_call.arguments.keywords.is_empty()
             {
                 if let [ast::Expr::Name(ast::ExprName { id, .. }), rhs] = &*expr_call.arguments.args


### PR DESCRIPTION
## Summary

Add type narrowing for [`isinstance(object, classinfo)`](https://docs.python.org/3/library/functions.html#isinstance) checks:
```py
x = 1 if flag else "a"

if isinstance(x, int):
    reveal_type(x)  # revealed: Literal[1]
```

To do:
- [x] Should we emit a diagnostic if we detect that arguments to the `isinstance` call are incorrect? Or would that happen anyway in type inference, because we would check `isinstance` calls against [this typeshed signature](https://github.com/python/typeshed/blob/ca65e087f1f9dfc28e89192b60ce7cfc2e92c674/stdlib/builtins.pyi#L1468):
    ```pyi
    def isinstance(obj: object, class_or_tuple: _ClassInfo, /) -> bool: ...
    ```
    => would happen in type inference/checking.
- [x] ~~Add support for [PEP 604](https://peps.python.org/pep-0604/) union types on the right-hand side. Supporting `str | int` is different from supporting `(str, int)`: For the latter, we can simply use the inferred type (`tuple[type[str], type[int]]`) and generate a constraint from it. However, if we attempt to do the same for the former, we would get `builtin.UnionType` (or `@Todo`, currently). So we probably need to walk the AST and extract the necessary information from there, similar to how we would generate a type annotation from the AST of `str | int`.~~ => deferred for now

closes #13893

## Test Plan

New Markdown-based tests in `narrow/isinstance.md`.
