### PR TITLE
Use referencial equality in `traversal` helper methods

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/needless_bool.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/needless_bool.rs
@@ -144,7 +144,7 @@ pub(crate) fn needless_bool(checker: &mut Checker, stmt: &Stmt) {
                 .semantic()
                 .current_statement_parent()
                 .and_then(|parent| traversal::suite(stmt, parent))
-                .and_then(|suite| traversal::next_sibling(stmt, suite))
+                .and_then(|suite| suite.next_sibling())
             else {
                 return;
             };

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/reimplemented_builtin.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/reimplemented_builtin.rs
@@ -72,8 +72,7 @@ pub(crate) fn convert_for_loop_to_any_all(checker: &mut Checker, stmt: &Stmt) {
     // - `for` loop followed by `return True` or `return False`.
     let Some(terminal) = match_else_return(stmt).or_else(|| {
         let parent = checker.semantic().current_statement_parent()?;
-        let suite = traversal::suite(stmt, parent)?;
-        let sibling = traversal::next_sibling(stmt, suite)?;
+        let sibling = traversal::suite(stmt, parent)?.next_sibling()?;
         match_sibling_return(stmt, sibling)
     }) else {
         return;

--- a/crates/ruff_python_ast/src/traversal.rs
+++ b/crates/ruff_python_ast/src/traversal.rs
@@ -1,87 +1,81 @@
 //! Utilities for manually traversing a Python AST.
-use crate::{self as ast, AnyNodeRef, ExceptHandler, Stmt, Suite};
+use crate::{self as ast, AnyNodeRef, ExceptHandler, Stmt};
 
 /// Given a [`Stmt`] and its parent, return the [`Suite`] that contains the [`Stmt`].
-pub fn suite<'a>(stmt: &'a Stmt, parent: &'a Stmt) -> Option<&'a Suite> {
-    fn contains_same(suite: &[Stmt], stmt: &Stmt) -> bool {
-        suite
-            .iter()
-            .any(|sibling| AnyNodeRef::ptr_eq(sibling.into(), stmt.into()))
-    }
-
+pub fn suite<'a>(stmt: &'a Stmt, parent: &'a Stmt) -> Option<EnclosingSuite<'a>> {
     // TODO: refactor this to work without a parent, ie when `stmt` is at the top level
     match parent {
-        Stmt::FunctionDef(ast::StmtFunctionDef { body, .. }) => Some(body),
-        Stmt::ClassDef(ast::StmtClassDef { body, .. }) => Some(body),
-        Stmt::For(ast::StmtFor { body, orelse, .. }) => {
-            if contains_same(body, stmt) {
-                Some(body)
-            } else if contains_same(orelse, stmt) {
-                Some(orelse)
-            } else {
-                None
-            }
-        }
-        Stmt::While(ast::StmtWhile { body, orelse, .. }) => {
-            if contains_same(body, stmt) {
-                Some(body)
-            } else if contains_same(orelse, stmt) {
-                Some(orelse)
-            } else {
-                None
-            }
-        }
+        Stmt::FunctionDef(ast::StmtFunctionDef { body, .. }) => EnclosingSuite::new(body, stmt),
+        Stmt::ClassDef(ast::StmtClassDef { body, .. }) => EnclosingSuite::new(body, stmt),
+        Stmt::For(ast::StmtFor { body, orelse, .. }) => [body, orelse]
+            .iter()
+            .find_map(|suite| EnclosingSuite::new(suite, stmt)),
+        Stmt::While(ast::StmtWhile { body, orelse, .. }) => [body, orelse]
+            .iter()
+            .find_map(|suite| EnclosingSuite::new(suite, stmt)),
         Stmt::If(ast::StmtIf {
             body,
             elif_else_clauses,
             ..
-        }) => {
-            if contains_same(body, stmt) {
-                Some(body)
-            } else {
-                elif_else_clauses
-                    .iter()
-                    .map(|elif_else_clause| &elif_else_clause.body)
-                    .find(|body| contains_same(body, stmt))
-            }
-        }
-        Stmt::With(ast::StmtWith { body, .. }) => Some(body),
+        }) => [body]
+            .into_iter()
+            .chain(elif_else_clauses.iter().map(|clause| &clause.body))
+            .find_map(|suite| EnclosingSuite::new(suite, stmt)),
+        Stmt::With(ast::StmtWith { body, .. }) => EnclosingSuite::new(body, stmt),
         Stmt::Match(ast::StmtMatch { cases, .. }) => cases
             .iter()
             .map(|case| &case.body)
-            .find(|body| contains_same(body, stmt)),
+            .find_map(|body| EnclosingSuite::new(body, stmt)),
         Stmt::Try(ast::StmtTry {
             body,
             handlers,
             orelse,
             finalbody,
             ..
-        }) => {
-            if contains_same(body, stmt) {
-                Some(body)
-            } else if contains_same(orelse, stmt) {
-                Some(orelse)
-            } else if contains_same(finalbody, stmt) {
-                Some(finalbody)
-            } else {
+        }) => [body, orelse, finalbody]
+            .into_iter()
+            .chain(
                 handlers
                     .iter()
                     .filter_map(ExceptHandler::as_except_handler)
-                    .map(|handler| &handler.body)
-                    .find(|body| contains_same(body, stmt))
-            }
-        }
+                    .map(|handler| &handler.body),
+            )
+            .find_map(|suite| EnclosingSuite::new(suite, stmt)),
         _ => None,
     }
 }
 
-/// Given a [`Stmt`] and its containing [`Suite`], return the next [`Stmt`] in the [`Suite`].
-pub fn next_sibling<'a>(stmt: &'a Stmt, suite: &'a Suite) -> Option<&'a Stmt> {
-    let mut iter = suite.iter();
-    while let Some(sibling) = iter.next() {
-        if AnyNodeRef::ptr_eq(sibling.into(), stmt.into()) {
-            return iter.next();
-        }
+pub struct EnclosingSuite<'a> {
+    suite: &'a [Stmt],
+    position: usize,
+}
+
+impl<'a> EnclosingSuite<'a> {
+    pub fn new(suite: &'a [Stmt], stmt: &'a Stmt) -> Option<Self> {
+        let position = suite
+            .iter()
+            .position(|sibling| AnyNodeRef::ptr_eq(sibling.into(), stmt.into()))?;
+
+        Some(EnclosingSuite { suite, position })
     }
-    None
+
+    pub fn next_sibling(&self) -> Option<&'a Stmt> {
+        self.suite.get(self.position + 1)
+    }
+
+    pub fn next_siblings(&self) -> &'a [Stmt] {
+        self.suite.get(self.position + 1..).unwrap_or_default()
+    }
+
+    pub fn previous_sibling(&self) -> Option<&'a Stmt> {
+        self.suite.get(self.position.checked_sub(1)?)
+    }
+}
+
+impl std::ops::Deref for EnclosingSuite<'_> {
+    type Target = [Stmt];
+
+    fn deref(&self) -> &Self::Target {
+        self.suite
+    }
 }

--- a/crates/ruff_python_ast/src/traversal.rs
+++ b/crates/ruff_python_ast/src/traversal.rs
@@ -1,7 +1,7 @@
 //! Utilities for manually traversing a Python AST.
 use crate::{self as ast, AnyNodeRef, ExceptHandler, Stmt};
 
-/// Given a [`Stmt`] and its parent, return the [`Suite`] that contains the [`Stmt`].
+/// Given a [`Stmt`] and its parent, return the [`ast::Suite`] that contains the [`Stmt`].
 pub fn suite<'a>(stmt: &'a Stmt, parent: &'a Stmt) -> Option<EnclosingSuite<'a>> {
     // TODO: refactor this to work without a parent, ie when `stmt` is at the top level
     match parent {


### PR DESCRIPTION
## Summary

`contains` and `==` do deep comparisons by default which can be fairly expensive depending on the nesting of a statement (arguably, maybe it's a bad idea to implement `PartialEq` on `Stmt`). 

This PR changes the `traversal` helpers to use pointer comparison instead so that they find the **same** and not an **equal** statement.

I also used this as a chance to make the `next_sibling` and `prev_siblings` (also needed for https://github.com/astral-sh/ruff/pull/13196) more efficient by avoiding an extra traversal to find the position in the suite. Instead, `suite` now returns an `EnclosingSuite` that also tracks the statement's position

## Test Plan

`cargo test`
