### PR TITLE
Remove "default" remark from `ruff check`

### DIFF
--- a/crates/ruff/src/args.rs
+++ b/crates/ruff/src/args.rs
@@ -92,7 +92,7 @@ pub struct Args {
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug, clap::Subcommand)]
 pub enum Command {
-    /// Run Ruff on the given files or directories (default).
+    /// Run Ruff on the given files or directories.
     Check(CheckCommand),
     /// Explain a rule (or all rules).
     #[command(group = clap::ArgGroup::new("selector").multiple(false).required(true))]

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -557,7 +557,7 @@ Or `ruff help check` for more on the linting command:
 <!-- Begin auto-generated check help. -->
 
 ```text
-Run Ruff on the given files or directories (default)
+Run Ruff on the given files or directories
 
 Usage: ruff check [OPTIONS] [FILES]...
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -515,7 +515,7 @@ Ruff: An extremely fast Python linter and code formatter.
 Usage: ruff [OPTIONS] <COMMAND>
 
 Commands:
-  check    Run Ruff on the given files or directories (default)
+  check    Run Ruff on the given files or directories
   rule     Explain a rule (or all rules)
   config   List or describe the available configuration options
   linter   List all supported upstream linters


### PR DESCRIPTION
## Summary

`ruff check` has not been the default in a long time. However, the help message and code comment still designate it as the default. The remark should have been removed in the deprecation PR #10169.

## Test Plan

Not tested.