### PR TITLE
[red-knot] Infer subscript expression types for bytes literals

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/literal/bytes.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/literal/bytes.md
@@ -1,0 +1,10 @@
+# Bytes literals
+
+## Simple
+
+```py
+reveal_type(b"red" b"knot")  # revealed: Literal[b"redknot"]
+reveal_type(b"hello")  # revealed: Literal[b"hello"]
+reveal_type(b"world" + b"!")  # revealed: Literal[b"world!"]
+reveal_type(b"\xff\x00")  # revealed: Literal[b"\xff\x00"]
+```

--- a/crates/red_knot_python_semantic/resources/mdtest/subscript/bytes.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/subscript/bytes.md
@@ -3,15 +3,6 @@
 ## Simple
 
 ```py
-reveal_type(b"red" b"knot")  # revealed: Literal[b"redknot"]
-reveal_type(b"hello")  # revealed: Literal[b"hello"]
-reveal_type(b"world" + b"!")  # revealed: Literal[b"world!"]
-reveal_type(b"\xff\x00")  # revealed: Literal[b"\xff\x00"]
-```
-
-## Indexing
-
-```py
 b = b"\x00abc\xff"
 
 reveal_type(b[0])  # revealed: Literal[b"\x00"]
@@ -27,4 +18,15 @@ reveal_type(x)  # revealed: Unknown
 
 y = b[-6]  # error: [index-out-of-bounds] "Index -6 is out of bounds for bytes literal `Literal[b"\x00abc\xff"]` with length 5"
 reveal_type(y)  # revealed: Unknown
+```
+
+## Function return
+
+```py
+def int_instance() -> int: ...
+
+
+a = b"abcde"[int_instance()]
+# TODO: Support overloads... Should be `bytes`
+reveal_type(a)  # revealed: @Todo
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/subscript/bytes.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/subscript/bytes.md
@@ -7,8 +7,11 @@ b = b"\x00abc\xff"
 
 reveal_type(b[0])  # revealed: Literal[b"\x00"]
 reveal_type(b[1])  # revealed: Literal[b"a"]
+reveal_type(b[4])  # revealed: Literal[b"\xff"]
+
 reveal_type(b[-1])  # revealed: Literal[b"\xff"]
 reveal_type(b[-2])  # revealed: Literal[b"c"]
+reveal_type(b[-5])  # revealed: Literal[b"\x00"]
 
 reveal_type(b[False])  # revealed: Literal[b"\x00"]
 reveal_type(b[True])  # revealed: Literal[b"a"]

--- a/crates/red_knot_python_semantic/resources/mdtest/subscript/bytes.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/subscript/bytes.md
@@ -8,3 +8,23 @@ reveal_type(b"hello")  # revealed: Literal[b"hello"]
 reveal_type(b"world" + b"!")  # revealed: Literal[b"world!"]
 reveal_type(b"\xff\x00")  # revealed: Literal[b"\xff\x00"]
 ```
+
+## Indexing
+
+```py
+b = b"\x00abc\xff"
+
+reveal_type(b[0])  # revealed: Literal[b"\x00"]
+reveal_type(b[1])  # revealed: Literal[b"a"]
+reveal_type(b[-1])  # revealed: Literal[b"\xff"]
+reveal_type(b[-2])  # revealed: Literal[b"c"]
+
+reveal_type(b[False])  # revealed: Literal[b"\x00"]
+reveal_type(b[True])  # revealed: Literal[b"a"]
+
+x = b[5]  # error: [index-out-of-bounds] "Index 5 is out of bounds for bytes literal `Literal[b"\x00abc\xff"]` with length 5"
+reveal_type(x)  # revealed: Unknown
+
+y = b[-6]  # error: [index-out-of-bounds] "Index -6 is out of bounds for bytes literal `Literal[b"\x00abc\xff"]` with length 5"
+reveal_type(y)  # revealed: Unknown
+```

--- a/crates/red_knot_python_semantic/resources/mdtest/subscript/string.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/subscript/string.md
@@ -10,6 +10,9 @@ reveal_type(s[1])  # revealed: Literal["b"]
 reveal_type(s[-1])  # revealed: Literal["e"]
 reveal_type(s[-2])  # revealed: Literal["d"]
 
+reveal_type(s[False])  # revealed: Literal["a"]
+reveal_type(s[True])  # revealed: Literal["b"]
+
 a = s[8]  # error: [index-out-of-bounds] "Index 8 is out of bounds for string `Literal["abcde"]` with length 5"
 reveal_type(a)  # revealed: Unknown
 

--- a/crates/red_knot_python_semantic/resources/mdtest/subscript/string.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/subscript/string.md
@@ -23,11 +23,10 @@ reveal_type(b)  # revealed: Unknown
 ## Function return
 
 ```py
-def add(x: int, y: int) -> int:
-    return x + y
+def int_instance() -> int: ...
 
 
-a = "abcde"[add(0, 1)]
+a = "abcde"[int_instance()]
 # TODO: Support overloads... Should be `str`
 reveal_type(a)  # revealed: @Todo
 ```

--- a/crates/red_knot_python_semantic/src/lib.rs
+++ b/crates/red_knot_python_semantic/src/lib.rs
@@ -21,5 +21,6 @@ mod semantic_model;
 pub(crate) mod site_packages;
 mod stdlib;
 pub mod types;
+mod util;
 
 type FxOrderSet<V> = ordermap::set::OrderSet<V, BuildHasherDefault<FxHasher>>;

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -55,6 +55,7 @@ use crate::types::{
     typing_extensions_symbol_ty, BytesLiteralType, ClassType, FunctionType, KnownFunction,
     StringLiteralType, Truthiness, TupleType, Type, TypeArrayDisplay, UnionType,
 };
+use crate::util::subscript::{iterator_at_index, slice_at_index};
 use crate::Db;
 
 use super::{KnownClass, UnionBuilder};
@@ -3173,36 +3174,6 @@ impl<'db> TypeInferenceBuilder<'db> {
         value_ty: Type<'db>,
         slice_ty: Type<'db>,
     ) -> Type<'db> {
-        fn iterator_at_index<T>(
-            mut iter: impl DoubleEndedIterator<Item = T>,
-            index: i64,
-        ) -> Option<T> {
-            if index < 0 {
-                let nth_rev = index
-                    .checked_neg()
-                    .and_then(|int| usize::try_from(int).ok())?
-                    .checked_sub(1)?;
-
-                iter.rev().nth(nth_rev)
-            } else {
-                let nth = usize::try_from(index).ok()?;
-                iter.nth(nth)
-            }
-        }
-
-        fn slice_at_index<T>(slice: &[T], index: i64) -> Option<&T> {
-            let positive_index = if index < 0 {
-                slice.len().checked_sub(
-                    index
-                        .checked_neg()
-                        .and_then(|int| usize::try_from(int).ok())?,
-                )
-            } else {
-                usize::try_from(index).ok()
-            };
-            slice.get(positive_index?)
-        }
-
         match (value_ty, slice_ty) {
             // Ex) Given `("a", "b", "c", "d")[1]`, return `"b"`
             (Type::Tuple(tuple_ty), Type::IntLiteral(int)) => {

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -1466,8 +1466,9 @@ impl<'db> TypeInferenceBuilder<'db> {
     }
 
     /// Emit a diagnostic declaring that an index is out of bounds for a tuple.
-    pub(super) fn tuple_index_out_of_bounds_diagnostic(
+    pub(super) fn index_out_of_bounds_diagnostic(
         &mut self,
+        kind: &'static str,
         node: AnyNodeRef,
         tuple_ty: Type<'db>,
         length: usize,
@@ -1477,26 +1478,8 @@ impl<'db> TypeInferenceBuilder<'db> {
             node,
             "index-out-of-bounds",
             format_args!(
-                "Index {index} is out of bounds for tuple of type `{}` with length {length}",
+                "Index {index} is out of bounds for {kind} `{}` with length {length}",
                 tuple_ty.display(self.db)
-            ),
-        );
-    }
-
-    /// Emit a diagnostic declaring that an index is out of bounds for a string.
-    pub(super) fn string_index_out_of_bounds_diagnostic(
-        &mut self,
-        node: AnyNodeRef,
-        string_ty: Type<'db>,
-        length: usize,
-        index: i64,
-    ) {
-        self.add_diagnostic(
-            node,
-            "index-out-of-bounds",
-            format_args!(
-                "Index {index} is out of bounds for string `{}` with length {length}",
-                string_ty.display(self.db)
             ),
         );
     }
@@ -3198,7 +3181,8 @@ impl<'db> TypeInferenceBuilder<'db> {
                     .ok()
                     .and_then(|index| elements.get(index).copied())
                     .unwrap_or_else(|| {
-                        self.tuple_index_out_of_bounds_diagnostic(
+                        self.index_out_of_bounds_diagnostic(
+                            "tuple",
                             value_node.into(),
                             value_ty,
                             elements.len(),
@@ -3215,7 +3199,8 @@ impl<'db> TypeInferenceBuilder<'db> {
                     .and_then(|index| elements.len().checked_sub(index))
                     .and_then(|index| elements.get(index).copied())
                     .unwrap_or_else(|| {
-                        self.tuple_index_out_of_bounds_diagnostic(
+                        self.index_out_of_bounds_diagnostic(
+                            "tuple",
                             value_node.into(),
                             value_ty,
                             elements.len(),
@@ -3243,7 +3228,8 @@ impl<'db> TypeInferenceBuilder<'db> {
                         ))
                     })
                     .unwrap_or_else(|| {
-                        self.string_index_out_of_bounds_diagnostic(
+                        self.index_out_of_bounds_diagnostic(
+                            "string",
                             value_node.into(),
                             value_ty,
                             literal_value.chars().count(),
@@ -3266,7 +3252,8 @@ impl<'db> TypeInferenceBuilder<'db> {
                         ))
                     })
                     .unwrap_or_else(|| {
-                        self.string_index_out_of_bounds_diagnostic(
+                        self.index_out_of_bounds_diagnostic(
+                            "string",
                             value_node.into(),
                             value_ty,
                             literal_value.chars().count(),

--- a/crates/red_knot_python_semantic/src/util/mod.rs
+++ b/crates/red_knot_python_semantic/src/util/mod.rs
@@ -1,0 +1,1 @@
+pub(crate) mod subscript;

--- a/crates/red_knot_python_semantic/src/util/subscript.rs
+++ b/crates/red_knot_python_semantic/src/util/subscript.rs
@@ -1,0 +1,29 @@
+pub(crate) fn iterator_at_index<T>(
+    mut iter: impl DoubleEndedIterator<Item = T>,
+    index: i64,
+) -> Option<T> {
+    if index < 0 {
+        let nth_rev = index
+            .checked_neg()
+            .and_then(|int| usize::try_from(int).ok())?
+            .checked_sub(1)?;
+
+        iter.rev().nth(nth_rev)
+    } else {
+        let nth = usize::try_from(index).ok()?;
+        iter.nth(nth)
+    }
+}
+
+pub(crate) fn slice_at_index<T>(slice: &[T], index: i64) -> Option<&T> {
+    let positive_index = if index < 0 {
+        slice.len().checked_sub(
+            index
+                .checked_neg()
+                .and_then(|int| usize::try_from(int).ok())?,
+        )
+    } else {
+        usize::try_from(index).ok()
+    };
+    slice.get(positive_index?)
+}

--- a/crates/red_knot_python_semantic/src/util/subscript.rs
+++ b/crates/red_knot_python_semantic/src/util/subscript.rs
@@ -68,7 +68,12 @@ mod tests {
 
         assert_eq!(iter.clone().python_subscript(-1), Some(u64::MAX));
         assert_eq!(iter.clone().python_subscript(-2), Some(u64::MAX - 1));
-        // i64::MIN is not representable as a positive number, so the
+
+        // i64::MIN is not representable as a positive number, so it is not
+        // a valid index:
+        assert_eq!(iter.clone().python_subscript(i64::MIN), None);
+
+        // but i64::MIN +1 is:
         assert_eq!(
             iter.clone().python_subscript(i64::MIN + 1),
             Some(2u64.pow(63) + 1)

--- a/crates/red_knot_python_semantic/src/util/subscript.rs
+++ b/crates/red_knot_python_semantic/src/util/subscript.rs
@@ -1,122 +1,77 @@
-pub(crate) fn iterator_at_index<T>(
-    mut iter: impl DoubleEndedIterator<Item = T>,
-    index: i64,
-) -> Option<T> {
-    if index < 0 {
-        let nth_rev = index
-            .checked_neg()
-            .and_then(|int| usize::try_from(int).ok())?
-            .checked_sub(1)?;
+pub(crate) trait PythonSubscript {
+    type Item;
 
-        iter.rev().nth(nth_rev)
-    } else {
-        let nth = usize::try_from(index).ok()?;
-        iter.nth(nth)
-    }
+    fn python_subscript(&mut self, index: i64) -> Option<Self::Item>;
 }
 
-pub(crate) fn slice_at_index<T>(slice: &[T], index: i64) -> Option<&T> {
-    let positive_index = if index < 0 {
-        slice.len().checked_sub(
-            index
-                .checked_neg()
-                .and_then(|int| usize::try_from(int).ok())?,
-        )
-    } else {
-        usize::try_from(index).ok()
-    };
-    slice.get(positive_index?)
+impl<I, T: DoubleEndedIterator<Item = I>> PythonSubscript for T {
+    type Item = I;
+
+    fn python_subscript(&mut self, index: i64) -> Option<I> {
+        if index >= 0 {
+            self.nth(usize::try_from(index).ok()?)
+        } else {
+            let nth_rev = usize::try_from(index.checked_neg()?).ok()?.checked_sub(1)?;
+            self.rev().nth(nth_rev)
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{iterator_at_index, slice_at_index};
+    use super::PythonSubscript;
 
     #[test]
-    fn iterator_at_index_basic() {
+    fn python_subscript_basic() {
         let iter = 'a'..='e';
 
-        assert_eq!(iterator_at_index(iter.clone(), 0), Some('a'));
-        assert_eq!(iterator_at_index(iter.clone(), 1), Some('b'));
-        assert_eq!(iterator_at_index(iter.clone(), 4), Some('e'));
-        assert_eq!(iterator_at_index(iter.clone(), 5), None);
+        assert_eq!(iter.clone().python_subscript(0), Some('a'));
+        assert_eq!(iter.clone().python_subscript(1), Some('b'));
+        assert_eq!(iter.clone().python_subscript(4), Some('e'));
+        assert_eq!(iter.clone().python_subscript(5), None);
 
-        assert_eq!(iterator_at_index(iter.clone(), -1), Some('e'));
-        assert_eq!(iterator_at_index(iter.clone(), -2), Some('d'));
-        assert_eq!(iterator_at_index(iter.clone(), -5), Some('a'));
-        assert_eq!(iterator_at_index(iter.clone(), -6), None);
+        assert_eq!(iter.clone().python_subscript(-1), Some('e'));
+        assert_eq!(iter.clone().python_subscript(-2), Some('d'));
+        assert_eq!(iter.clone().python_subscript(-5), Some('a'));
+        assert_eq!(iter.clone().python_subscript(-6), None);
     }
 
     #[test]
-    fn iterator_at_index_empty() {
+    fn python_subscript_empty() {
         let iter = 'a'..'a';
 
-        assert_eq!(iterator_at_index(iter.clone(), 0), None);
-        assert_eq!(iterator_at_index(iter.clone(), 1), None);
-        assert_eq!(iterator_at_index(iter.clone(), -1), None);
+        assert_eq!(iter.clone().python_subscript(0), None);
+        assert_eq!(iter.clone().python_subscript(1), None);
+        assert_eq!(iter.clone().python_subscript(-1), None);
     }
 
     #[test]
-    fn iterator_at_index_single_element() {
-        let iter = std::iter::once('a');
+    fn python_subscript_single_element() {
+        let iter = 'a'..='a';
 
-        assert_eq!(iterator_at_index(iter.clone(), 0), Some('a'));
-        assert_eq!(iterator_at_index(iter.clone(), 1), None);
-        assert_eq!(iterator_at_index(iter.clone(), -1), Some('a'));
-        assert_eq!(iterator_at_index(iter.clone(), -2), None);
+        assert_eq!(iter.clone().python_subscript(0), Some('a'));
+        assert_eq!(iter.clone().python_subscript(1), None);
+        assert_eq!(iter.clone().python_subscript(-1), Some('a'));
+        assert_eq!(iter.clone().python_subscript(-2), None);
     }
 
     #[test]
-    fn iterator_at_index_uses_full_index_range() {
+    fn python_subscript_uses_full_index_range() {
         let iter = 0..=u64::MAX;
 
-        assert_eq!(iterator_at_index(iter.clone(), 0), Some(0));
-        assert_eq!(iterator_at_index(iter.clone(), 1), Some(1));
+        assert_eq!(iter.clone().python_subscript(0), Some(0));
+        assert_eq!(iter.clone().python_subscript(1), Some(1));
         assert_eq!(
-            iterator_at_index(iter.clone(), i64::MAX),
+            iter.clone().python_subscript(i64::MAX),
             Some(i64::MAX as u64)
         );
 
-        assert_eq!(iterator_at_index(iter.clone(), -1), Some(u64::MAX));
-        assert_eq!(iterator_at_index(iter.clone(), -2), Some(u64::MAX - 1));
+        assert_eq!(iter.clone().python_subscript(-1), Some(u64::MAX));
+        assert_eq!(iter.clone().python_subscript(-2), Some(u64::MAX - 1));
         // i64::MIN is not representable as a positive number, so the
         assert_eq!(
-            iterator_at_index(iter.clone(), i64::MIN + 1),
+            iter.clone().python_subscript(i64::MIN + 1),
             Some(2u64.pow(63) + 1)
         );
-    }
-
-    #[test]
-    fn slice_at_index_basic() {
-        let slice = &['a', 'b', 'c', 'd', 'e'];
-
-        assert_eq!(slice_at_index(slice, 0), Some(&'a'));
-        assert_eq!(slice_at_index(slice, 1), Some(&'b'));
-        assert_eq!(slice_at_index(slice, 4), Some(&'e'));
-        assert_eq!(slice_at_index(slice, 5), None);
-
-        assert_eq!(slice_at_index(slice, -1), Some(&'e'));
-        assert_eq!(slice_at_index(slice, -2), Some(&'d'));
-        assert_eq!(slice_at_index(slice, -5), Some(&'a'));
-        assert_eq!(slice_at_index(slice, -6), None);
-    }
-
-    #[test]
-    fn slice_at_index_empty() {
-        let slice: &[char] = &[];
-
-        assert_eq!(slice_at_index(slice, 0), None);
-        assert_eq!(slice_at_index(slice, 1), None);
-        assert_eq!(slice_at_index(slice, -1), None);
-    }
-
-    #[test]
-    fn slice_at_index_single_element() {
-        let slice = &['a'];
-
-        assert_eq!(slice_at_index(slice, 0), Some(&'a'));
-        assert_eq!(slice_at_index(slice, 1), None);
-        assert_eq!(slice_at_index(slice, -1), Some(&'a'));
-        assert_eq!(slice_at_index(slice, -2), None);
     }
 }

--- a/crates/red_knot_python_semantic/src/util/subscript.rs
+++ b/crates/red_knot_python_semantic/src/util/subscript.rs
@@ -27,3 +27,96 @@ pub(crate) fn slice_at_index<T>(slice: &[T], index: i64) -> Option<&T> {
     };
     slice.get(positive_index?)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{iterator_at_index, slice_at_index};
+
+    #[test]
+    fn iterator_at_index_basic() {
+        let iter = 'a'..='e';
+
+        assert_eq!(iterator_at_index(iter.clone(), 0), Some('a'));
+        assert_eq!(iterator_at_index(iter.clone(), 1), Some('b'));
+        assert_eq!(iterator_at_index(iter.clone(), 4), Some('e'));
+        assert_eq!(iterator_at_index(iter.clone(), 5), None);
+
+        assert_eq!(iterator_at_index(iter.clone(), -1), Some('e'));
+        assert_eq!(iterator_at_index(iter.clone(), -2), Some('d'));
+        assert_eq!(iterator_at_index(iter.clone(), -5), Some('a'));
+        assert_eq!(iterator_at_index(iter.clone(), -6), None);
+    }
+
+    #[test]
+    fn iterator_at_index_empty() {
+        let iter = 'a'..'a';
+
+        assert_eq!(iterator_at_index(iter.clone(), 0), None);
+        assert_eq!(iterator_at_index(iter.clone(), 1), None);
+        assert_eq!(iterator_at_index(iter.clone(), -1), None);
+    }
+
+    #[test]
+    fn iterator_at_index_single_element() {
+        let iter = std::iter::once('a');
+
+        assert_eq!(iterator_at_index(iter.clone(), 0), Some('a'));
+        assert_eq!(iterator_at_index(iter.clone(), 1), None);
+        assert_eq!(iterator_at_index(iter.clone(), -1), Some('a'));
+        assert_eq!(iterator_at_index(iter.clone(), -2), None);
+    }
+
+    #[test]
+    fn iterator_at_index_uses_full_index_range() {
+        let iter = 0..=u64::MAX;
+
+        assert_eq!(iterator_at_index(iter.clone(), 0), Some(0));
+        assert_eq!(iterator_at_index(iter.clone(), 1), Some(1));
+        assert_eq!(
+            iterator_at_index(iter.clone(), i64::MAX),
+            Some(i64::MAX as u64)
+        );
+
+        assert_eq!(iterator_at_index(iter.clone(), -1), Some(u64::MAX));
+        assert_eq!(iterator_at_index(iter.clone(), -2), Some(u64::MAX - 1));
+        // i64::MIN is not representable as a positive number, so the
+        assert_eq!(
+            iterator_at_index(iter.clone(), i64::MIN + 1),
+            Some(2u64.pow(63) + 1)
+        );
+    }
+
+    #[test]
+    fn slice_at_index_basic() {
+        let slice = &['a', 'b', 'c', 'd', 'e'];
+
+        assert_eq!(slice_at_index(slice, 0), Some(&'a'));
+        assert_eq!(slice_at_index(slice, 1), Some(&'b'));
+        assert_eq!(slice_at_index(slice, 4), Some(&'e'));
+        assert_eq!(slice_at_index(slice, 5), None);
+
+        assert_eq!(slice_at_index(slice, -1), Some(&'e'));
+        assert_eq!(slice_at_index(slice, -2), Some(&'d'));
+        assert_eq!(slice_at_index(slice, -5), Some(&'a'));
+        assert_eq!(slice_at_index(slice, -6), None);
+    }
+
+    #[test]
+    fn slice_at_index_empty() {
+        let slice: &[char] = &[];
+
+        assert_eq!(slice_at_index(slice, 0), None);
+        assert_eq!(slice_at_index(slice, 1), None);
+        assert_eq!(slice_at_index(slice, -1), None);
+    }
+
+    #[test]
+    fn slice_at_index_single_element() {
+        let slice = &['a'];
+
+        assert_eq!(slice_at_index(slice, 0), Some(&'a'));
+        assert_eq!(slice_at_index(slice, 1), None);
+        assert_eq!(slice_at_index(slice, -1), Some(&'a'));
+        assert_eq!(slice_at_index(slice, -2), None);
+    }
+}


### PR DESCRIPTION
## Summary

Infer subscript expression types for bytes literals:
```py
b = b"\x00abc\xff"

reveal_type(b[0])  # revealed: Literal[b"\x00"]
reveal_type(b[1])  # revealed: Literal[b"a"]
reveal_type(b[-1])  # revealed: Literal[b"\xff"]
reveal_type(b[-2])  # revealed: Literal[b"c"]

reveal_type(b[False])  # revealed: Literal[b"\x00"]
reveal_type(b[True])  # revealed: Literal[b"a"]
```


part of #13689 (https://github.com/astral-sh/ruff/issues/13689#issuecomment-2404285064)

## Test Plan

- New Markdown-based tests (see `mdtest/subscript/bytes.md`)
- Added missing test for `string_literal[bool_literal]`