### PR TITLE
[red-knot] Fallback to attributes on types.ModuleType if a symbol can't be found in locals or globals

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/scopes/moduletype_attrs.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/scopes/moduletype_attrs.md
@@ -9,12 +9,10 @@ before deciding that the name is unbound.
 
 ```py
 reveal_type(__name__)  # revealed: str
-
-# TODO: infer types from PEP-604 union annotations
-reveal_type(__file__)  # revealed: @Todo
-reveal_type(__loader__)  # revealed: @Todo
-reveal_type(__package__)  # revealed: @Todo
-reveal_type(__spec__)  # revealed: @Todo
+reveal_type(__file__)  # revealed: str | None
+reveal_type(__loader__)  # revealed: LoaderProtocol | None
+reveal_type(__package__)  # revealed: str | None
+reveal_type(__spec__)  # revealed: ModuleSpec | None
 
 # TODO: generics
 reveal_type(__path__)  # revealed: @Todo
@@ -61,11 +59,15 @@ import typing
 reveal_type(typing.__name__)  # revealed: str
 reveal_type(typing.__init__)  # revealed: Literal[__init__]
 
-# This one comes from `builtins.object`, not `types.ModuleType`:
-# TODO: we don't currently understand `types.ModuleType` as inheriting from `object`
+# These come from `builtins.object`, not `types.ModuleType`:
+# TODO: we don't currently understand `types.ModuleType` as inheriting from `object`;
+# these should not reveal `Unbound`:
 reveal_type(typing.__eq__)  # revealed: Unbound
+reveal_type(typing.__class__)  # revealed: Unbound
+reveal_type(typing.__module__)  # revealed: Unbound
 
-# TODO: needs support for attribute access on instances
+# TODO: needs support for attribute access on instances, properties and generics;
+# should be `dict[str, Any]`
 reveal_type(typing.__dict__)  # revealed: @Todo
 ```
 
@@ -88,13 +90,18 @@ global namespace:
 
 ```py path=foo.py
 __dict__ = "foo"
+
+reveal_type(__dict__)  # revealed: Literal["foo"]
 ```
 
 ```py path=bar.py
 import foo
+from foo import __dict__ as foo_dict
 
-# TODO: needs support for attribute access on instances
+# TODO: needs support for attribute access on instances, properties, and generics;
+# should be `dict[str, Any]` for both of these:
 reveal_type(foo.__dict__)  # revealed: @Todo
+reveal_type(foo_dict)  # revealed: @Todo
 ```
 
 ## Conditionally global or `ModuleType` attribute

--- a/crates/red_knot_python_semantic/resources/mdtest/scopes/moduletype_attrs.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/scopes/moduletype_attrs.md
@@ -20,7 +20,9 @@ reveal_type(__spec__)  # revealed: @Todo
 reveal_type(__path__)  # revealed: @Todo
 
 # TODO: this should probably be added to typeshed; not sure why it isn't?
-reveal_type(__doc__)  # revealed: Unbound
+# error: [unresolved-reference]
+# revealed: Unbound
+reveal_type(__doc__)
 
 class X:
     reveal_type(__name__)  # revealed: str
@@ -33,9 +35,28 @@ However, three attributes on `types.ModuleType` are not present as implicit
 module globals; these are excluded:
 
 ```py path=unbound_dunders.py
-reveal_type(__getattr__)  # revealed: Unbound
-reveal_type(__dict__)  # revealed: Unbound
-reveal_type(__init__)  # revealed: Unbound
+# error: [unresolved-reference]
+# revealed: Unbound
+reveal_type(__getattr__)
+
+# error: [unresolved-reference]
+# revealed: Unbound
+reveal_type(__dict__)
+
+# error: [unresolved-reference]
+# revealed: Unbound
+reveal_type(__init__)
+```
+
+## Accessed as attributes
+
+`ModuleType` attributes can also be accessed as attributes
+on module-literal inhabitants:
+
+```py
+import typing
+
+reveal_type(typing.__name__)  # revealed: str
 ```
 
 ## Conditionally global or `ModuleType` attribute

--- a/crates/red_knot_python_semantic/resources/mdtest/scopes/moduletype_attrs.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/scopes/moduletype_attrs.md
@@ -1,0 +1,75 @@
+# Implicit globals from `types.ModuleType`
+
+## Implicit `ModuleType` globals
+
+All modules are instances of `types.ModuleType`.
+If a name can't be found in any local or global scope, we look it up
+as an attribute on `types.ModuleType` in typeshed
+before deciding that the name is unbound.
+
+```py
+reveal_type(__name__)  # revealed: str
+
+# TODO: infer types from PEP-604 union annotations
+reveal_type(__file__)  # revealed: @Todo
+reveal_type(__loader__)  # revealed: @Todo
+reveal_type(__package__)  # revealed: @Todo
+reveal_type(__spec__)  # revealed: @Todo
+
+# TODO: generics
+reveal_type(__path__)  # revealed: @Todo
+
+# TODO: this should probably be added to typeshed; not sure why it isn't?
+reveal_type(__doc__)  # revealed: Unbound
+
+class X:
+    reveal_type(__name__)  # revealed: str
+
+def foo():
+    reveal_type(__name__)  # revealed: str
+```
+
+However, three attributes on `types.ModuleType` are not present as implicit
+module globals; these are excluded:
+
+```py path=unbound_dunders.py
+reveal_type(__getattr__)  # revealed: Unbound
+reveal_type(__dict__)  # revealed: Unbound
+reveal_type(__init__)  # revealed: Unbound
+```
+
+## Conditionally global or `ModuleType` attribute
+
+Attributes overridden in the module namespace take priority.
+If a builtin name is conditionally defined as a global, however,
+a name lookup should union the `ModuleType` type with the conditionally defined type:
+
+```py
+__file__ = 42
+
+def returns_bool() -> bool:
+    return True
+
+if returns_bool():
+    __name__ = 1
+
+reveal_type(__file__)  # revealed: Literal[42]
+reveal_type(__name__)  # revealed: str | Literal[1]
+```
+
+## Conditionally global or `ModuleType` attribute, with annotation
+
+The same is true if the name is annotated:
+
+```py
+__file__: int = 42
+
+def returns_bool() -> bool:
+    return True
+
+if returns_bool():
+    __name__: int = 1
+
+reveal_type(__file__)  # revealed: Literal[42]
+reveal_type(__name__)  # revealed: str | Literal[1]
+```

--- a/crates/red_knot_python_semantic/src/semantic_index/builder.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/builder.rs
@@ -195,6 +195,10 @@ impl<'db> SemanticIndexBuilder<'db> {
         self.current_symbol_table().mark_symbol_bound(id);
     }
 
+    fn mark_symbol_declared(&mut self, id: ScopedSymbolId) {
+        self.current_symbol_table().mark_symbol_declared(id);
+    }
+
     fn mark_symbol_used(&mut self, id: ScopedSymbolId) {
         self.current_symbol_table().mark_symbol_used(id);
     }
@@ -225,6 +229,9 @@ impl<'db> SemanticIndexBuilder<'db> {
 
         if category.is_binding() {
             self.mark_symbol_bound(symbol);
+        }
+        if category.is_declaration() {
+            self.mark_symbol_declared(symbol);
         }
 
         let use_def = self.current_use_def_map_mut();
@@ -359,6 +366,7 @@ impl<'db> SemanticIndexBuilder<'db> {
                 // note that the "bound" on the typevar is a totally different thing than whether
                 // or not a name is "bound" by a typevar declaration; the latter is always true.
                 self.mark_symbol_bound(symbol);
+                self.mark_symbol_declared(symbol);
                 if let Some(bounds) = bound {
                     self.visit_expr(bounds);
                 }

--- a/crates/red_knot_python_semantic/src/semantic_index/symbol.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/symbol.rs
@@ -47,17 +47,22 @@ impl Symbol {
     pub fn is_bound(&self) -> bool {
         self.flags.contains(SymbolFlags::IS_BOUND)
     }
+
+    pub fn is_declared(&self) -> bool {
+        self.flags.contains(SymbolFlags::IS_DECLARED)
+    }
 }
 
 bitflags! {
     #[derive(Copy, Clone, Debug, Eq, PartialEq)]
     struct SymbolFlags: u8 {
         const IS_USED         = 1 << 0;
-        const IS_BOUND      = 1 << 1;
+        const IS_BOUND        = 1 << 1;
+        const IS_DECLARED     = 1 << 2;
         /// TODO: This flag is not yet set by anything
-        const MARKED_GLOBAL   = 1 << 2;
+        const MARKED_GLOBAL   = 1 << 3;
         /// TODO: This flag is not yet set by anything
-        const MARKED_NONLOCAL = 1 << 3;
+        const MARKED_NONLOCAL = 1 << 4;
     }
 }
 
@@ -296,6 +301,10 @@ impl SymbolTableBuilder {
 
     pub(super) fn mark_symbol_bound(&mut self, id: ScopedSymbolId) {
         self.table.symbols[id].insert_flags(SymbolFlags::IS_BOUND);
+    }
+
+    pub(super) fn mark_symbol_declared(&mut self, id: ScopedSymbolId) {
+        self.table.symbols[id].insert_flags(SymbolFlags::IS_DECLARED);
     }
 
     pub(super) fn mark_symbol_used(&mut self, id: ScopedSymbolId) {

--- a/crates/red_knot_python_semantic/src/semantic_index/symbol.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/symbol.rs
@@ -48,12 +48,17 @@ impl Symbol {
         self.flags.contains(SymbolFlags::IS_BOUND)
     }
 
+    /// Is the symbol declared in its containing scope?
     pub fn is_declared(&self) -> bool {
         self.flags.contains(SymbolFlags::IS_DECLARED)
     }
 }
 
 bitflags! {
+    /// Flags that can be queried to obtain information about a symbol in a given scope.
+    ///
+    /// See the doc-comment at the top of [`super::use_def`] for explanations of what it
+    /// means for a symbol to be *bound* as opposed to *declared*.
     #[derive(Copy, Clone, Debug, Eq, PartialEq)]
     struct SymbolFlags: u8 {
         const IS_USED         = 1 << 0;

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -95,7 +95,11 @@ pub(crate) fn global_symbol_ty<'db>(db: &'db dyn Db, file: File, name: &str) -> 
     // Not defined explicitly in the global scope?
     // All modules are instances of `types.ModuleType`;
     // look it up there (with a few very special exceptions)
-    if explicit_ty.may_be_unbound(db) && !matches!(name, "__dict__" | "__init__" | "__getattr__") {
+    if matches!(
+        name,
+        "__name__" | "__file__" | "__loader__" | "__package__" | "__path__" | "__spec__"
+    ) && explicit_ty.may_be_unbound(db)
+    {
         // TODO: this should be `KnownClass::ModuleType.to_instance()`,
         // but we don't yet support looking up attributes on instances
         let module_type = KnownClass::ModuleType.to_class(db);

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -2370,20 +2370,6 @@ impl<'db> TypeInferenceBuilder<'db> {
                 global_symbol_ty(self.db, self.file, name)
             };
 
-            // Still possibly unbound? All modules are instances of `types.ModuleType`;
-            // look it up there (with a few very special exceptions)
-            if ty.may_be_unbound(self.db)
-                && !matches!(&**name, "__dict__" | "__init__" | "__getattr__")
-            {
-                // TODO: this should be `KnownClass::ModuleType.to_instance()`,
-                // but we don't yet support looking up attributes on instances
-                let module_type = KnownClass::ModuleType.to_class(self.db);
-                let module_type_member_ty = module_type.member(self.db, name);
-                if !module_type_member_ty.is_unbound() {
-                    return ty.replace_unbound_with(self.db, module_type_member_ty);
-                }
-            }
-
             // Fallback to builtins (without infinite recursion if we're already in builtins.)
             if ty.may_be_unbound(self.db) && Some(self.scope()) != builtins_module_scope(self.db) {
                 let mut builtin_ty = builtins_symbol_ty(self.db, name);

--- a/crates/ruff_benchmark/benches/red_knot.rs
+++ b/crates/ruff_benchmark/benches/red_knot.rs
@@ -23,8 +23,6 @@ struct Case {
 const TOMLLIB_312_URL: &str = "https://raw.githubusercontent.com/python/cpython/8e8a4baf652f6e1cee7acde9d78c4b6154539748/Lib/tomllib";
 
 static EXPECTED_DIAGNOSTICS: &[&str] = &[
-    // We don't support `ModuleType`-attributes as globals yet:
-    "/src/tomllib/__init__.py:10:30: Name `__name__` used when not defined",
     // We don't support `*` imports yet:
     "/src/tomllib/_parser.py:7:29: Module `collections.abc` has no member `Iterable`",
     // We don't support terminal statements in control flow yet:


### PR DESCRIPTION
## Summary

All modules in Python are instances of `types.ModuleType`. [Various attributes on `types.ModuleType` in typeshed](https://github.com/python/typeshed/blob/783171b9f7412823ed1a531e9c84feee755f8303/stdlib/types.pyi#L331-L344) represent "implicit globals" that are part of the namespace of every module in Python, even if not explicitly defined. As such, before declaring that a symbol is unbound (and in fact, before looking the symbol up in the `builtins` scope) we should look the symbol up as an attribute on `types.ModuleType`. The only attributes on `types.ModuleType` that are _not_ present as implicit globals are `__dict__`, `__getattr__` and `__init__`.

## Test Plan

Markdown test added as `crates/red_knot_python_semantic/resources/mdtest/scopes/moduletype_attrs.md`. We also get to remove a false-positive error from the `tomllib` benchmark 🎉