### PR TITLE
[red-knot] Format mdtest Python snippets more concisely

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,10 +46,10 @@ repos:
           )$
 
   - repo: https://github.com/adamchainz/blacken-docs
-    rev: 1.19.0
+    rev: 1.19.1
     hooks:
       - id: blacken-docs
-        args: ["--line-length", "130"]
+        args: ["--pyi", "--line-length", "130"]
         files: '^crates/.*/resources/mdtest/.*\.md'
         additional_dependencies:
           - black==24.10.0

--- a/crates/red_knot_python_semantic/resources/mdtest/assignment/unbound.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/assignment/unbound.md
@@ -15,12 +15,10 @@ Name lookups within a class scope fall back to globals, but lookups of class att
 ```py
 x = 1
 
-
 class C:
     y = x
     if flag:
         x = 2
-
 
 reveal_type(C.x)  # revealed: Literal[2]
 reveal_type(C.y)  # revealed: Literal[1]

--- a/crates/red_knot_python_semantic/resources/mdtest/attributes.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/attributes.md
@@ -4,15 +4,12 @@
 
 ```py
 if flag:
-
     class C:
         x = 1
 
 else:
-
     class C:
         x = 2
-
 
 reveal_type(C.x)  # revealed: Literal[1, 2]
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/binary/instances.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/binary/instances.md
@@ -53,9 +53,7 @@ class A:
     def __or__(self, other) -> A:
         return self
 
-
 class B: ...
-
 
 reveal_type(A() + B())  # revealed: A
 reveal_type(A() - B())  # revealed: A
@@ -117,9 +115,7 @@ class A:
     def __ror__(self, other) -> A:
         return self
 
-
 class B: ...
-
 
 reveal_type(B() + A())  # revealed: A
 reveal_type(B() - A())  # revealed: A
@@ -148,9 +144,7 @@ class A:
     def __rsub__(self, other) -> int:
         return 1
 
-
 class B: ...
-
 
 reveal_type(A() + B())  # revealed: int
 reveal_type(B() - A())  # revealed: int
@@ -167,14 +161,11 @@ class A:
     def __add__(self, other: B) -> int:
         return 42
 
-
 class B:
     def __radd__(self, other: A) -> str:
         return "foo"
 
-
 reveal_type(A() + B())  # revealed:  int
-
 
 # Edge case: C is a subtype of C, *but* if the two sides are of *equal* types,
 # the lhs *still* takes precedence
@@ -184,7 +175,6 @@ class C:
 
     def __radd__(self, other: C) -> str:
         return "foo"
-
 
 reveal_type(C() + C())  # revealed: int
 ```
@@ -203,21 +193,16 @@ class A:
     def __radd__(self, other) -> str:
         return "foo"
 
-
 class MyString(str): ...
-
 
 class B(A):
     def __radd__(self, other) -> MyString:
         return MyString()
 
-
 reveal_type(A() + B())  # revealed: MyString
-
 
 # N.B. Still a subtype of `A`, even though `A` does not appear directly in the class's `__bases__`
 class C(B): ...
-
 
 # TODO: we currently only understand direct subclasses as subtypes of the superclass.
 # We need to iterate through the full MRO rather than just the class's bases;
@@ -240,9 +225,7 @@ class A:
     def __radd__(self, other) -> int:
         return 42
 
-
 class B(A): ...
-
 
 reveal_type(A() + B())  # revealed: str
 ```
@@ -266,11 +249,9 @@ class A:
     def __sub__(self, other: A) -> A:
         return A()
 
-
 class B:
     def __rsub__(self, other: A) -> B:
         return B()
-
 
 # TODO: this should be `B` (the return annotation of `B.__rsub__`),
 # because `A.__sub__` is annotated as only accepting `A`,
@@ -287,10 +268,8 @@ class A:
     def __call__(self, other) -> int:
         return 42
 
-
 class B:
     __add__ = A()
-
 
 reveal_type(B() + B())  # revealed: int
 ```
@@ -311,14 +290,11 @@ reveal_type(42 + 4.2)  # revealed: int
 # TODO should be complex, need to check arg type and fall back to `rhs.__radd__`
 reveal_type(3 + 3j)  # revealed: int
 
-
 def returns_int() -> int:
     return 42
 
-
 def returns_bool() -> bool:
     return True
-
 
 x = returns_bool()
 y = returns_int()
@@ -342,7 +318,6 @@ class A:
 
     def __radd__(self, other) -> A:
         return self
-
 
 reveal_type(A() + 1)  # revealed: A
 # TODO should be `A` since `int.__add__` doesn't support `A` instances
@@ -388,14 +363,11 @@ from does_not_exist import Foo  # error: [unresolved-import]
 
 reveal_type(Foo)  # revealed: Unknown
 
-
 class X:
     def __add__(self, other: object) -> int:
         return 42
 
-
 class Y(Foo): ...
-
 
 # TODO: Should be `int | Unknown`; see above discussion.
 reveal_type(X() + Y())  # revealed: int
@@ -411,11 +383,9 @@ The magic method must exist on the class, not just on the instance:
 def add_impl(self, other) -> int:
     return 1
 
-
 class A:
     def __init__(self):
         self.__add__ = add_impl
-
 
 # error: [unsupported-operator] "Operator `+` is unsupported between objects of type `A` and `A`"
 # revealed: Unknown
@@ -426,7 +396,6 @@ reveal_type(A() + A())
 
 ```py
 class A: ...
-
 
 # error: [unsupported-operator]
 # revealed: Unknown
@@ -441,13 +410,10 @@ A left-hand dunder method doesn't apply for the right-hand operand, or vice vers
 class A:
     def __add__(self, other) -> int: ...
 
-
 class B:
     def __radd__(self, other) -> int: ...
 
-
 class C: ...
-
 
 # error: [unsupported-operator]
 # revealed: Unknown
@@ -470,7 +436,6 @@ left-hand operand. For context, see
 class Foo:
     def __radd__(self, other: Foo) -> Foo:
         return self
-
 
 # error: [unsupported-operator]
 # revealed: Unknown

--- a/crates/red_knot_python_semantic/resources/mdtest/binary/integers.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/binary/integers.md
@@ -62,9 +62,7 @@ bool(1) / False
 # revealed: float
 reveal_type(1.0 / 0)
 
-
 class MyInt(int): ...
-
 
 # No error for a subclass of int
 # revealed: float

--- a/crates/red_knot_python_semantic/resources/mdtest/call/callable_instance.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/call/callable_instance.md
@@ -10,13 +10,10 @@ class Multiplier:
     def __call__(self, number: float) -> float:
         return number * self.factor
 
-
 a = Multiplier(2.0)(3.0)
 reveal_type(a)  # revealed: float
 
-
 class Unit: ...
-
 
 b = Unit()(3.0)  # error: "Object of type `Unit` is not callable"
 reveal_type(b)  # revealed: Unknown

--- a/crates/red_knot_python_semantic/resources/mdtest/call/constructor.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/call/constructor.md
@@ -3,6 +3,5 @@
 ```py
 class Foo: ...
 
-
 reveal_type(Foo())  # revealed: Foo
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/call/function.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/call/function.md
@@ -6,7 +6,6 @@
 def get_int() -> int:
     return 42
 
-
 reveal_type(get_int())  # revealed: int
 ```
 
@@ -15,7 +14,6 @@ reveal_type(get_int())  # revealed: int
 ```py
 async def get_int_async() -> int:
     return 42
-
 
 # TODO: we don't yet support `types.CoroutineType`, should be generic `Coroutine[Any, Any, int]`
 reveal_type(get_int_async())  # revealed: @Todo
@@ -26,19 +24,15 @@ reveal_type(get_int_async())  # revealed: @Todo
 ```py
 from typing import Callable
 
-
 def foo() -> int:
     return 42
-
 
 def decorator(func) -> Callable[[], int]:
     return foo
 
-
 @decorator
 def bar() -> str:
     return "bar"
-
 
 # TODO: should reveal `int`, as the decorator replaces `bar` with `foo`
 reveal_type(bar())  # revealed: @Todo

--- a/crates/red_knot_python_semantic/resources/mdtest/call/union.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/call/union.md
@@ -13,7 +13,6 @@ else:
     def f() -> str:
         return "foo"
 
-
 reveal_type(f())  # revealed: int | str
 ```
 
@@ -26,7 +25,6 @@ if flag:
 
     def f() -> int:
         return 1
-
 
 reveal_type(f())  # revealed: Unknown | int
 ```
@@ -42,7 +40,6 @@ else:
 
     def f() -> int:
         return 1
-
 
 x = f()  # error: "Object of type `Literal[1] | Literal[f]` is not callable (due to union element `Literal[1]`)"
 reveal_type(x)  # revealed: Unknown | int
@@ -61,7 +58,6 @@ else:
 
     def f() -> int:
         return 1
-
 
 # error: "Object of type `Literal[1] | Literal["foo"] | Literal[f]` is not callable (due to union elements Literal[1], Literal["foo"])"
 # revealed: Unknown | int

--- a/crates/red_knot_python_semantic/resources/mdtest/comparison/integers.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/comparison/integers.md
@@ -21,7 +21,6 @@ reveal_type(1 <= "" and 0 < 1)  # revealed: @Todo | Literal[True]
 # TODO: implement lookup of `__eq__` on typeshed `int` stub.
 def int_instance() -> int: ...
 
-
 reveal_type(1 == int_instance())  # revealed: @Todo
 reveal_type(9 < int_instance())  # revealed: bool
 reveal_type(int_instance() < int_instance())  # revealed: bool

--- a/crates/red_knot_python_semantic/resources/mdtest/comparison/non_boolean_returns.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/comparison/non_boolean_returns.md
@@ -21,14 +21,14 @@ Walking through examples:
 ```py
 from __future__ import annotations
 
-
 class A:
     def __lt__(self, other) -> A: ...
+
 class B:
     def __lt__(self, other) -> B: ...
+
 class C:
     def __lt__(self, other) -> C: ...
-
 
 x = A() < B() < C()
 reveal_type(x)  # revealed: A | B

--- a/crates/red_knot_python_semantic/resources/mdtest/comparison/strings.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/comparison/strings.md
@@ -5,7 +5,6 @@
 ```py
 def str_instance() -> str: ...
 
-
 reveal_type("abc" == "abc")  # revealed: Literal[True]
 reveal_type("ab_cd" <= "ab_ce")  # revealed: Literal[True]
 reveal_type("abc" in "ab cd")  # revealed: Literal[False]

--- a/crates/red_knot_python_semantic/resources/mdtest/comparison/tuples.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/comparison/tuples.md
@@ -61,7 +61,6 @@ reveal_type(c >= d)  # revealed: Literal[True]
 def bool_instance() -> bool: ...
 def int_instance() -> int: ...
 
-
 a = (bool_instance(),)
 b = (int_instance(),)
 
@@ -144,7 +143,6 @@ class A:
     def __gt__(self, o) -> tuple: ...
     def __ge__(self, o) -> list: ...
 
-
 a = (A(), A())
 
 # TODO: All @Todo should be bool
@@ -162,7 +160,6 @@ reveal_type(a >= a)  # revealed: @Todo
 
 ```py
 def int_instance() -> int: ...
-
 
 a = (1, 2)
 b = ((3, 4), (1, 2))

--- a/crates/red_knot_python_semantic/resources/mdtest/exception/control_flow.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/exception/control_flow.md
@@ -40,7 +40,6 @@ to the `except` suite *after* that redefinition.
 def could_raise_returns_str() -> str:
     return "foo"
 
-
 x = 1
 
 try:
@@ -62,7 +61,6 @@ unify and `x` is not inferred as having a union type following the
 ```py path=branches_unify_to_non_union_type.py
 def could_raise_returns_str() -> str:
     return "foo"
-
 
 x = 1
 
@@ -87,7 +85,6 @@ possibility when it comes to control-flow analysis.
 ```py
 def could_raise_returns_str() -> str:
     return "foo"
-
 
 x = 1
 
@@ -118,7 +115,6 @@ the three suites:
 ```py
 def could_raise_returns_str() -> str:
     return "foo"
-
 
 x = 1
 
@@ -153,7 +149,6 @@ the end of the `except` suite:
 def could_raise_returns_str() -> str:
     return "foo"
 
-
 x = 1
 
 try:
@@ -181,7 +176,6 @@ in their entireties:
 ```py
 def could_raise_returns_str() -> str:
     return "foo"
-
 
 x = 1
 
@@ -216,7 +210,6 @@ therefore `Literal[2]`:
 def could_raise_returns_str() -> str:
     return "foo"
 
-
 x = 1
 
 try:
@@ -243,7 +236,6 @@ suites, however; this is still a TODO item for us.)
 ```py path=no_redef_in_finally.py
 def could_raise_returns_str() -> str:
     return "foo"
-
 
 x = 1
 
@@ -277,14 +269,11 @@ following possibilities inside `finally` suites:
 def could_raise_returns_str() -> str:
     return "foo"
 
-
 def could_raise_returns_bytes() -> bytes:
     return b"foo"
 
-
 def could_raise_returns_bool() -> bool:
     return True
-
 
 x = 1
 
@@ -318,14 +307,11 @@ conclusion of the `finally` suite.)
 def could_raise_returns_str() -> str:
     return "foo"
 
-
 def could_raise_returns_bytes() -> bytes:
     return b"foo"
 
-
 def could_raise_returns_bool() -> bool:
     return True
-
 
 x = 1
 
@@ -352,22 +338,17 @@ An example with multiple `except` branches and a `finally` branch:
 def could_raise_returns_str() -> str:
     return "foo"
 
-
 def could_raise_returns_bytes() -> bytes:
     return b"foo"
-
 
 def could_raise_returns_bool() -> bool:
     return True
 
-
 def could_raise_returns_memoryview() -> memoryview:
     return memoryview(b"")
 
-
 def could_raise_returns_float() -> float:
     return 3.14
-
 
 x = 1
 
@@ -404,22 +385,17 @@ partway through the `else` suite due to an exception raised *there*.
 def could_raise_returns_str() -> str:
     return "foo"
 
-
 def could_raise_returns_bytes() -> bytes:
     return b"foo"
-
 
 def could_raise_returns_bool() -> bool:
     return True
 
-
 def could_raise_returns_memoryview() -> memoryview:
     return memoryview(b"")
 
-
 def could_raise_returns_float() -> float:
     return 3.14
-
 
 x = 1
 
@@ -452,30 +428,23 @@ The same again, this time with multiple `except` branches:
 def could_raise_returns_str() -> str:
     return "foo"
 
-
 def could_raise_returns_bytes() -> bytes:
     return b"foo"
-
 
 def could_raise_returns_bool() -> bool:
     return True
 
-
 def could_raise_returns_memoryview() -> memoryview:
     return memoryview(b"")
-
 
 def could_raise_returns_float() -> float:
     return 3.14
 
-
 def could_raise_returns_range() -> range:
     return range(42)
 
-
 def could_raise_returns_slice() -> slice:
     return slice(None)
-
 
 x = 1
 
@@ -524,52 +493,38 @@ prior to the suite running to completion.
 def could_raise_returns_str() -> str:
     return "foo"
 
-
 def could_raise_returns_bytes() -> bytes:
     return b"foo"
-
 
 def could_raise_returns_bool() -> bool:
     return True
 
-
 def could_raise_returns_memoryview() -> memoryview:
     return memoryview(b"")
-
 
 def could_raise_returns_float() -> float:
     return 3.14
 
-
 def could_raise_returns_range() -> range:
     return range(42)
-
 
 def could_raise_returns_slice() -> slice:
     return slice(None)
 
-
 def could_raise_returns_complex() -> complex:
     return 3j
-
 
 def could_raise_returns_bytearray() -> bytearray:
     return bytearray()
 
-
 class Foo: ...
-
-
 class Bar: ...
-
 
 def could_raise_returns_Foo() -> Foo:
     return Foo()
 
-
 def could_raise_returns_Bar() -> Bar:
     return Bar()
-
 
 x = 1
 
@@ -632,22 +587,17 @@ variable by that name in the outer scope:
 def could_raise_returns_str() -> str:
     return "foo"
 
-
 def could_raise_returns_bytes() -> bytes:
     return b"foo"
-
 
 def could_raise_returns_range() -> range:
     return range(42)
 
-
 def could_raise_returns_bytearray() -> bytearray:
     return bytearray()
 
-
 def could_raise_returns_float() -> float:
     return 3.14
-
 
 x = 1
 
@@ -670,7 +620,6 @@ try:
             # TODO: should be `str | bytes | bytearray | float`
             reveal_type(x)  # revealed: bytes | float
         reveal_type(x)  # revealed: bytes | float
-
     x = foo
     reveal_type(x)  # revealed: Literal[foo]
 except:

--- a/crates/red_knot_python_semantic/resources/mdtest/expression/boolean.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/expression/boolean.md
@@ -6,7 +6,6 @@
 def foo() -> str:
     pass
 
-
 reveal_type(True or False)  # revealed: Literal[True]
 reveal_type("x" or "y" or "z")  # revealed: Literal["x"]
 reveal_type("" or "y" or "z")  # revealed: Literal["y"]
@@ -23,7 +22,6 @@ reveal_type(foo() or True)  # revealed: str | Literal[True]
 def foo() -> str:
     pass
 
-
 reveal_type(True and False)  # revealed: Literal[False]
 reveal_type(False and True)  # revealed: Literal[False]
 reveal_type(foo() and False)  # revealed: str | Literal[False]
@@ -39,7 +37,6 @@ reveal_type("" and "y")  # revealed: Literal[""]
 def returns_bool() -> bool:
     return True
 
-
 if returns_bool():
     x = True
 else:
@@ -53,7 +50,6 @@ reveal_type(x)  # revealed: bool
 ```py
 def foo() -> str:
     pass
-
 
 reveal_type("x" and "y" or "z")  # revealed: Literal["y"]
 reveal_type("x" or "y" and "z")  # revealed: Literal["x"]
@@ -69,7 +65,6 @@ reveal_type("x" or "y" and "")  # revealed: Literal["x"]
 
 ```py path=a.py
 redefined_builtin_bool = bool
-
 
 def my_bool(x) -> bool:
     return True
@@ -90,9 +85,7 @@ reveal_type(bool((0,)))  # revealed: Literal[True]
 reveal_type(bool("NON EMPTY"))  # revealed: Literal[True]
 reveal_type(bool(True))  # revealed: Literal[True]
 
-
 def foo(): ...
-
 
 reveal_type(bool(foo))  # revealed: Literal[True]
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/generics.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/generics.md
@@ -12,7 +12,6 @@ class MyBox[T]:
     def __init__(self, data: T):
         self.data = data
 
-
 # TODO not error (should be subscriptable)
 box: MyBox[int] = MyBox(5)  # error: [non-subscriptable]
 # TODO error differently (str and int don't unify)
@@ -32,10 +31,8 @@ class MyBox[T]:
     def __init__(self, data: T):
         self.data = data
 
-
 # TODO not error on the subscripting
 class MySecureBox[T](MyBox[T]): ...  # error: [non-subscriptable]
-
 
 secure_box: MySecureBox[int] = MySecureBox(5)
 reveal_type(secure_box)  # revealed: MySecureBox
@@ -52,10 +49,8 @@ This should hold true even with generics at play.
 ```py path=a.pyi
 class Seq[T]: ...
 
-
 # TODO not error on the subscripting
 class S[T](Seq[S]): ...  # error: [non-subscriptable]
-
 
 reveal_type(S)  # revealed: Literal[S]
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/loops/for_loop.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/loops/for_loop.md
@@ -7,11 +7,9 @@ class IntIterator:
     def __next__(self) -> int:
         return 42
 
-
 class IntIterable:
     def __iter__(self) -> IntIterator:
         return IntIterator()
-
 
 for x in IntIterable():
     pass
@@ -26,11 +24,9 @@ class IntIterator:
     def __next__(self) -> int:
         return 42
 
-
 class IntIterable:
     def __iter__(self) -> IntIterator:
         return IntIterator()
-
 
 x = "foo"
 
@@ -47,11 +43,9 @@ class IntIterator:
     def __next__(self) -> int:
         return 42
 
-
 class IntIterable:
     def __iter__(self) -> IntIterator:
         return IntIterator()
-
 
 for x in IntIterable():
     pass
@@ -68,11 +62,9 @@ class IntIterator:
     def __next__(self) -> int:
         return 42
 
-
 class IntIterable:
     def __iter__(self) -> IntIterator:
         return IntIterator()
-
 
 for x in IntIterable():
     if x > 5:
@@ -89,7 +81,6 @@ reveal_type(x)  # revealed: int | Literal["foo"]
 class OldStyleIterable:
     def __getitem__(self, key: int) -> int:
         return 42
-
 
 for x in OldStyleIterable():
     pass
@@ -115,7 +106,6 @@ class NotIterable:
     else:
         __iter__ = None
 
-
 for x in NotIterable():  # error: "Object of type `NotIterable` is not iterable"
     pass
 
@@ -136,9 +126,7 @@ for x in nonsense:  # error: "Object of type `Literal[123]` is not iterable"
 class NotIterable:
     def __getitem__(self, key: int) -> int:
         return 42
-
     __iter__ = None
-
 
 for x in NotIterable():  # error: "Object of type `NotIterable` is not iterable"
     pass

--- a/crates/red_knot_python_semantic/resources/mdtest/loops/iterators.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/loops/iterators.md
@@ -5,15 +5,12 @@
 ```py
 class NotIterable: ...
 
-
 class Iterator:
     def __next__(self) -> int:
         return 42
 
-
 class Iterable:
     def __iter__(self) -> Iterator: ...
-
 
 def generator_function():
     yield from Iterable()

--- a/crates/red_knot_python_semantic/resources/mdtest/narrow/conditionals_is.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/narrow/conditionals_is.md
@@ -16,7 +16,6 @@ reveal_type(x)  # revealed: None | Literal[1]
 ```py
 class A: ...
 
-
 x = A()
 y = x if flag else None
 

--- a/crates/red_knot_python_semantic/resources/mdtest/narrow/conditionals_nested.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/narrow/conditionals_nested.md
@@ -5,7 +5,6 @@
 ```py
 def int_instance() -> int: ...
 
-
 x = int_instance()
 
 if x != 1:

--- a/crates/red_knot_python_semantic/resources/mdtest/narrow/conditionals_not_eq.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/narrow/conditionals_not_eq.md
@@ -31,10 +31,7 @@ if x != 1:
 
 ```py
 class A: ...
-
-
 class B: ...
-
 
 C = A if flag else B
 
@@ -48,7 +45,6 @@ Only single-valued types should narrow the type:
 
 ```py
 def int_instance() -> int: ...
-
 
 x = int_instance() if flag else None
 y = int_instance()

--- a/crates/red_knot_python_semantic/resources/mdtest/narrow/isinstance.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/narrow/isinstance.md
@@ -66,13 +66,9 @@ if isinstance(x, (bool, (bytes, int))):
 
 ```py
 class A: ...
-
-
 class B: ...
 
-
 def get_object() -> object: ...
-
 
 x = get_object()
 
@@ -100,7 +96,6 @@ if isinstance(x, t):
 ```py
 def isinstance(x, t):
     return True
-
 
 x = 1 if flag else "a"
 if isinstance(x, int):

--- a/crates/red_knot_python_semantic/resources/mdtest/scopes/builtin.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/scopes/builtin.md
@@ -9,10 +9,8 @@ with the conditionally-defined type:
 def returns_bool() -> bool:
     return True
 
-
 if returns_bool():
     copyright = 1
-
 
 def f():
     reveal_type(copyright)  # revealed: Literal[copyright] | Literal[1]
@@ -26,10 +24,8 @@ Same is true if the name is annotated:
 def returns_bool() -> bool:
     return True
 
-
 if returns_bool():
     copyright: int = 1
-
 
 def f():
     reveal_type(copyright)  # revealed: Literal[copyright] | int

--- a/crates/red_knot_python_semantic/resources/mdtest/shadowing/class.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/shadowing/class.md
@@ -5,7 +5,6 @@
 ```py
 class C: ...
 
-
 C = 1  # error: "Implicit shadowing of class `C`; annotate to make it explicit if this is intentional"
 ```
 
@@ -15,7 +14,6 @@ No diagnostic is raised in the case of explicit shadowing:
 
 ```py
 class C: ...
-
 
 C: int = 1
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/shadowing/function.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/shadowing/function.md
@@ -14,7 +14,6 @@ def f(x: str):
 ```py path=a.py
 def f(): ...
 
-
 f = 1  # error: "Implicit shadowing of function `f`; annotate to make it explicit if this is intentional"
 ```
 
@@ -22,7 +21,6 @@ f = 1  # error: "Implicit shadowing of function `f`; annotate to make it explici
 
 ```py path=a.py
 def f(): ...
-
 
 f: int = 1
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/stubs/class.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/stubs/class.md
@@ -7,6 +7,5 @@ In type stubs, classes can reference themselves in their base class definitions.
 ```py path=a.pyi
 class C(C): ...
 
-
 reveal_type(C)  # revealed: Literal[C]
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/subscript/bytes.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/subscript/bytes.md
@@ -28,7 +28,6 @@ reveal_type(y)  # revealed: Unknown
 ```py
 def int_instance() -> int: ...
 
-
 a = b"abcde"[int_instance()]
 # TODO: Support overloads... Should be `bytes`
 reveal_type(a)  # revealed: @Todo

--- a/crates/red_knot_python_semantic/resources/mdtest/subscript/class.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/subscript/class.md
@@ -5,7 +5,6 @@
 ```py
 class NotSubscriptable: ...
 
-
 a = NotSubscriptable[0]  # error: "Cannot subscript object of type `Literal[NotSubscriptable]` with no `__class_getitem__` method"
 ```
 
@@ -16,7 +15,6 @@ class Identity:
     def __class_getitem__(cls, item: int) -> str:
         return item
 
-
 reveal_type(Identity[0])  # revealed: str
 ```
 
@@ -25,18 +23,15 @@ reveal_type(Identity[0])  # revealed: str
 ```py
 flag = True
 
-
 class UnionClassGetItem:
     if flag:
 
         def __class_getitem__(cls, item: int) -> str:
             return item
-
     else:
 
         def __class_getitem__(cls, item: int) -> int:
             return item
-
 
 reveal_type(UnionClassGetItem[0])  # revealed: str | int
 ```
@@ -46,16 +41,13 @@ reveal_type(UnionClassGetItem[0])  # revealed: str | int
 ```py
 flag = True
 
-
 class A:
     def __class_getitem__(cls, item: int) -> str:
         return item
 
-
 class B:
     def __class_getitem__(cls, item: int) -> int:
         return item
-
 
 x = A if flag else B
 
@@ -69,15 +61,12 @@ reveal_type(x[0])  # revealed: str | int
 flag = True
 
 if flag:
-
     class Spam:
         def __class_getitem__(self, x: int) -> str:
             return "foo"
 
 else:
-
     class Spam: ...
-
 
 # error: [call-non-callable] "Method `__class_getitem__` of type `Literal[__class_getitem__] | Unbound` is not callable on object of type `Literal[Spam, Spam]`"
 # revealed: str | Unknown
@@ -90,7 +79,6 @@ reveal_type(Spam[42])
 flag = True
 
 if flag:
-
     class Eggs:
         def __class_getitem__(self, x: int) -> str:
             return "foo"

--- a/crates/red_knot_python_semantic/resources/mdtest/subscript/instance.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/subscript/instance.md
@@ -5,7 +5,6 @@
 ```py
 class NotSubscriptable: ...
 
-
 a = NotSubscriptable()[0]  # error: "Cannot subscript object of type `NotSubscriptable` with no `__getitem__` method"
 ```
 
@@ -14,7 +13,6 @@ a = NotSubscriptable()[0]  # error: "Cannot subscript object of type `NotSubscri
 ```py
 class NotSubscriptable:
     __getitem__ = None
-
 
 a = NotSubscriptable()[0]  # error: "Method `__getitem__` of type `None` is not callable on object of type `NotSubscriptable`"
 ```
@@ -26,7 +24,6 @@ class Identity:
     def __getitem__(self, index: int) -> int:
         return index
 
-
 reveal_type(Identity()[0])  # revealed: int
 ```
 
@@ -35,18 +32,15 @@ reveal_type(Identity()[0])  # revealed: int
 ```py
 flag = True
 
-
 class Identity:
     if flag:
 
         def __getitem__(self, index: int) -> int:
             return index
-
     else:
 
         def __getitem__(self, index: int) -> str:
             return str(index)
-
 
 reveal_type(Identity()[0])  # revealed: int | str
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/subscript/string.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/subscript/string.md
@@ -25,7 +25,6 @@ reveal_type(b)  # revealed: Unknown
 ```py
 def int_instance() -> int: ...
 
-
 a = "abcde"[int_instance()]
 # TODO: Support overloads... Should be `str`
 reveal_type(a)  # revealed: @Todo

--- a/crates/red_knot_python_semantic/resources/mdtest/unary/instance.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/unary/instance.md
@@ -14,16 +14,13 @@ class Number:
     def __invert__(self) -> Literal[True]:
         return True
 
-
 a = Number()
 
 reveal_type(+a)  # revealed: int
 reveal_type(-a)  # revealed: int
 reveal_type(~a)  # revealed: @Todo
 
-
 class NoDunder: ...
-
 
 b = NoDunder()
 +b  # error: [unsupported-operator] "Unary operator `+` is unsupported for type `NoDunder`"

--- a/crates/red_knot_python_semantic/resources/mdtest/unary/not.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/unary/not.md
@@ -12,10 +12,8 @@ reveal_type(not not None)  # revealed: Literal[False]
 ```py
 from typing import reveal_type
 
-
 def f():
     return 1
-
 
 reveal_type(not f)  # revealed: Literal[False]
 # TODO Unknown should not be part of the type of typing.reveal_type
@@ -27,7 +25,6 @@ reveal_type(not f)  # revealed: Literal[False]
 ```py
 import b
 import warnings
-
 
 reveal_type(not b)  # revealed: Literal[False]
 reveal_type(not warnings)  # revealed: Literal[False]

--- a/crates/red_knot_python_semantic/resources/mdtest/unpacking.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/unpacking.md
@@ -155,11 +155,9 @@ class Iterator:
     def __next__(self) -> int:
         return 42
 
-
 class Iterable:
     def __iter__(self) -> Iterator:
         return Iterator()
-
 
 (a, b) = Iterable()
 reveal_type(a)  # revealed: int
@@ -173,11 +171,9 @@ class Iterator:
     def __next__(self) -> int:
         return 42
 
-
 class Iterable:
     def __iter__(self) -> Iterator:
         return Iterator()
-
 
 (a, (b, c), d) = (1, Iterable(), 2)
 reveal_type(a)  # revealed: Literal[1]


### PR DESCRIPTION
## Summary

The latest release of `blacken-docs` adds a `--pyi` flag, which allows us to format the Python snippets as if they are stubs (i.e., more concisely).

## Test Plan

`pre-commit run -a`
