### PR TITLE
[red-knot] Infer `Todo`, not `Unknown`, for PEP-604 unions in annotations

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/assignment/annotations.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/assignment/annotations.md
@@ -22,3 +22,13 @@ x: int = "foo"  # error: [invalid-assignment] "Object of type `Literal["foo"]` i
 x: int
 x = "foo"  # error: [invalid-assignment] "Object of type `Literal["foo"]` is not assignable to `int`"
 ```
+
+## PEP-604 annotations not yet supported
+
+```py
+def f() -> str | None:
+    return None
+
+# TODO: should be `str | None` (but Todo is better than `Unknown`)
+reveal_type(f())  # revealed: @Todo
+```

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -220,6 +220,9 @@ fn declarations_ty<'db>(
     } else {
         first
     };
+    // Make sure not to emit spurious errors relating to `Type::Todo`,
+    // since we only infer this type due to a limitation in our current model
+    conflicting.retain(|ty| !ty.is_todo());
     if conflicting.is_empty() {
         Ok(declared_ty)
     } else {
@@ -290,6 +293,10 @@ impl<'db> Type<'db> {
 
     pub const fn is_never(&self) -> bool {
         matches!(self, Type::Never)
+    }
+
+    pub const fn is_todo(&self) -> bool {
+        matches!(self, Type::Todo)
     }
 
     pub const fn into_class_literal_type(self) -> Option<ClassType<'db>> {

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -3474,7 +3474,12 @@ impl<'db> TypeInferenceBuilder<'db> {
             // TODO PEP-604 unions
             ast::Expr::BinOp(binary) => {
                 self.infer_binary_expression(binary);
-                Type::Todo
+                match binary.op {
+                    // PEP-604 unions are okay
+                    ast::Operator::BitOr => Type::Todo,
+                    // anything else is an invalid annotation:
+                    _ => Type::Unknown,
+                }
             }
 
             // Forms which are invalid in the context of annotation expressions: we infer their

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -3471,6 +3471,12 @@ impl<'db> TypeInferenceBuilder<'db> {
                 Type::Todo
             }
 
+            // TODO PEP-604 unions
+            ast::Expr::BinOp(binary) => {
+                self.infer_binary_expression(binary);
+                Type::Todo
+            }
+
             // Forms which are invalid in the context of annotation expressions: we infer their
             // nested expressions as normal expressions, but the type of the top-level expression is
             // always `Type::Unknown` in these cases.
@@ -3480,10 +3486,6 @@ impl<'db> TypeInferenceBuilder<'db> {
             }
             ast::Expr::Named(named) => {
                 self.infer_named_expression(named);
-                Type::Unknown
-            }
-            ast::Expr::BinOp(binary) => {
-                self.infer_binary_expression(binary);
                 Type::Unknown
             }
             ast::Expr::UnaryOp(unary) => {


### PR DESCRIPTION
## Summary

We don't support PEP-604 annotations yet, but we _should_, so this should be `Type::Todo`, not `Type::Unknown`.

Making this change on its own results in several new spurious errors in the `tomllib` benchmark:

```
    "/src/tomllib/_parser.py:108:17: Conflicting declared types for `second_char`: Unknown, @Todo",
    "/src/tomllib/_parser.py:267:9: Conflicting declared types for `char`: Unknown, @Todo",
    "/src/tomllib/_parser.py:364:9: Conflicting declared types for `char`: Unknown, @Todo",
    "/src/tomllib/_parser.py:381:13: Conflicting declared types for `char`: Unknown, @Todo",
    "/src/tomllib/_parser.py:395:9: Conflicting declared types for `char`: Unknown, @Todo",
    "/src/tomllib/_parser.py:590:9: Conflicting declared types for `char`: Unknown, @Todo",
```

But it doesn't seem correct to me to emit these errors (since `Todo` is only ever inferred in situations where we acknowledge our inference is currently lacking), so I've added some logic to filter out `Todo` from the `conflicting` vector in `red_knot_python_semantic::types::declarations_ty`.

This unblocks #13904: without this change, that PR leads to many false-positive or counter-intuitive errors, since the attributes on `types.ModuleType` use PEP-604 unions in their type annotations.

## Test Plan

- `cargo test -p red_knot_python_semantic`
- `cargo bench -p ruff_benchmark -- red_knot`
