### PR TITLE
Fix: Recover boolean test flag after visiting subexpressions

### DIFF
--- a/crates/ruff_linter/src/checkers/ast/mod.rs
+++ b/crates/ruff_linter/src/checkers/ast/mod.rs
@@ -1461,6 +1461,11 @@ impl<'a> Visitor<'a> for Checker<'a> {
             _ => {}
         };
 
+        // Restore boolean test flag after examining subexpressions
+        if flags_snapshot.intersects(SemanticModelFlags::BOOLEAN_TEST) {
+            self.semantic.flags |= SemanticModelFlags::BOOLEAN_TEST;
+        }
+
         // Step 4: Analysis
         analyze::expression(expr, self);
         match expr {

--- a/crates/ruff_linter/src/checkers/ast/mod.rs
+++ b/crates/ruff_linter/src/checkers/ast/mod.rs
@@ -1461,13 +1461,7 @@ impl<'a> Visitor<'a> for Checker<'a> {
             _ => {}
         };
 
-        // Restore boolean test flag after examining subexpressions
-        if flags_snapshot.intersects(SemanticModelFlags::BOOLEAN_TEST) {
-            self.semantic.flags |= SemanticModelFlags::BOOLEAN_TEST;
-        }
-
         // Step 4: Analysis
-        analyze::expression(expr, self);
         match expr {
             Expr::StringLiteral(string_literal) => {
                 analyze::string_like(string_literal.into(), self);
@@ -1478,6 +1472,7 @@ impl<'a> Visitor<'a> for Checker<'a> {
         }
 
         self.semantic.flags = flags_snapshot;
+        analyze::expression(expr, self);
         self.semantic.pop_node();
     }
 


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To assist with the review, please ensure:
- The pull request includes a summary of the change (below).
- The title is descriptive of the change.
- Relevant issues are referenced where applicable.
-->

## Summary

<!-- What is the purpose of the change? What does it do, and why? -->

This PR corrects the logic for handling the boolean test flag during expression analysis.

Since the flag can be modified during subexpression traversal, it must be restored before analyzing the full expression.

Additionally, this change allows the `in_bool_test()` method in `crates/ruff_python_semantic/src/model.rs` to be used outside of boolean operations, such as in conditional tests within `Stmt::If`, `Stmt::While`, `Stmt::Assert`, and others.
