### PR TITLE
Fix `normalize` arguments when `fstring_formatting` is disabled

### DIFF
--- a/crates/ruff_python_formatter/src/other/f_string.rs
+++ b/crates/ruff_python_formatter/src/other/f_string.rs
@@ -3,9 +3,7 @@ use ruff_python_ast::{AnyStringFlags, FString, StringFlags};
 use ruff_source_file::Locator;
 
 use crate::prelude::*;
-use crate::preview::{
-    is_f_string_formatting_enabled, is_f_string_implicit_concatenated_string_literal_quotes_enabled,
-};
+use crate::preview::is_f_string_formatting_enabled;
 use crate::string::{Quoting, StringNormalizer, StringQuotes};
 
 use super::f_string_element::FormatFStringElement;
@@ -33,12 +31,11 @@ impl Format<PyFormatContext<'_>> for FormatFString<'_> {
 
         // If the preview style is enabled, make the decision on what quotes to use locally for each
         // f-string instead of globally for the entire f-string expression.
-        let quoting =
-            if is_f_string_implicit_concatenated_string_literal_quotes_enabled(f.context()) {
-                Quoting::CanChange
-            } else {
-                self.quoting
-            };
+        let quoting = if is_f_string_formatting_enabled(f.context()) {
+            Quoting::CanChange
+        } else {
+            self.quoting
+        };
 
         let normalizer = StringNormalizer::from_context(f.context()).with_quoting(quoting);
 

--- a/crates/ruff_python_formatter/src/preview.rs
+++ b/crates/ruff_python_formatter/src/preview.rs
@@ -16,6 +16,8 @@ pub(crate) const fn is_hug_parens_with_braces_and_square_brackets_enabled(
 
 /// Returns `true` if the [`f-string formatting`](https://github.com/astral-sh/ruff/issues/7594) preview style is enabled.
 /// WARNING: This preview style depends on `is_f_string_implicit_concatenated_string_literal_quotes_enabled`.
+/// TODO: Remove `Quoting` when promoting this preview style and convert `FormatStringPart` etc. regular `FormatWithRule` implementations.
+/// TODO: Remove `format_f_string` from `normalize_string` when promoting this preview style.
 pub(crate) fn is_f_string_formatting_enabled(context: &PyFormatContext) -> bool {
     context.is_preview()
 }

--- a/crates/ruff_python_formatter/src/string/implicit.rs
+++ b/crates/ruff_python_formatter/src/string/implicit.rs
@@ -371,8 +371,9 @@ impl Format<PyFormatContext<'_>> for FormatLiteralContent {
             0,
             self.flags,
             self.flags.is_f_string() && !self.is_fstring,
-            true,
-            false,
+            // TODO: Remove the argument from `normalize_string` when promoting the `is_f_string_formatting_enabled` preview style.
+            self.flags.is_f_string() && !is_f_string_formatting_enabled(f.context()),
+            is_f_string_formatting_enabled(f.context()),
         );
 
         // Trim the start and end of the string if it's the first or last part of a docstring.

--- a/crates/ruff_python_formatter/src/string/normalize.rs
+++ b/crates/ruff_python_formatter/src/string/normalize.rs
@@ -626,7 +626,7 @@ pub(crate) fn normalize_string(
     let mut formatted_value_nesting = 0u32;
 
     while let Some((index, c)) = chars.next() {
-        if matches!(c, '{' | '}') && is_fstring {
+        if matches!(c, '{' | '}') {
             if escape_braces {
                 // Escape `{` and `}` when converting a regular string literal to an f-string literal.
                 output.push_str(&input[last_index..=index]);


### PR DESCRIPTION
## Summary

This fixes the invocation of `normalize_string` in the flat implicit concatenation formatting to respect whether
f-string formatting is enabled or not.

## Test Plan

I disabled f-string formatting by changing `is_f_string_formatting_enabled` to return `false`. 
All tests were passing except formatting `f"{'Hy "User"'}" f'{"Hy 'User'"}'`. It gets formatted as

```
f"{'Hy 'User''}{'Hy 'User''}"
```

which is not valid syntax.

I looked into fixing it but it's kind of hard because it requires detecting that this is not a valid pre 312 f-string and we should avoid flipping the quotes
for the second expression.... 


I suggest that we look into fixing this if we decide to only ship implicit concatenated string formatting but not f-string formatting (our current plan is to ship both).
There's a test that fails if we decide to only promote one style.

