### PR TITLE
[red-knot] Slice expression types & subscript expressions with slices

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/subscript/bytes.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/subscript/bytes.md
@@ -1,6 +1,6 @@
-# Bytes subscript
+# Bytes subscripts
 
-## Simple
+## Indexing
 
 ```py
 b = b"\x00abc\xff"
@@ -21,6 +21,18 @@ reveal_type(x)  # revealed: Unknown
 
 y = b[-6]  # error: [index-out-of-bounds] "Index -6 is out of bounds for bytes literal `Literal[b"\x00abc\xff"]` with length 5"
 reveal_type(y)  # revealed: Unknown
+```
+
+## Slices
+
+```py
+b = b"\x00abc\xff"
+
+reveal_type(b[0:2])  # revealed: Literal[b"\x00a"]
+reveal_type(b[-3:])  # revealed: Literal[b"bc\xff"]
+
+a = b[::0]  # error: [slice-step-zero]
+reveal_type(a)  # revealed: Unknown
 ```
 
 ## Function return

--- a/crates/red_knot_python_semantic/resources/mdtest/subscript/bytes.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/subscript/bytes.md
@@ -31,8 +31,10 @@ b = b"\x00abc\xff"
 reveal_type(b[0:2])  # revealed: Literal[b"\x00a"]
 reveal_type(b[-3:])  # revealed: Literal[b"bc\xff"]
 
-a = b[::0]  # error: [slice-step-zero]
-reveal_type(a)  # revealed: Unknown
+b[0:4:0]  # error: [zero-stepsize-in-slice]
+b[:4:0]  # error: [zero-stepsize-in-slice]
+b[0::0]  # error: [zero-stepsize-in-slice]
+b[::0]  # error: [zero-stepsize-in-slice]
 ```
 
 ## Function return

--- a/crates/red_knot_python_semantic/resources/mdtest/subscript/bytes.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/subscript/bytes.md
@@ -21,6 +21,13 @@ reveal_type(x)  # revealed: Unknown
 
 y = b[-6]  # error: [index-out-of-bounds] "Index -6 is out of bounds for bytes literal `Literal[b"\x00abc\xff"]` with length 5"
 reveal_type(y)  # revealed: Unknown
+
+def int_instance() -> int:
+    return 42
+
+a = b"abcde"[int_instance()]
+# TODO: Support overloads... Should be `bytes`
+reveal_type(a)  # revealed: @Todo
 ```
 
 ## Slices
@@ -35,15 +42,16 @@ b[0:4:0]  # error: [zero-stepsize-in-slice]
 b[:4:0]  # error: [zero-stepsize-in-slice]
 b[0::0]  # error: [zero-stepsize-in-slice]
 b[::0]  # error: [zero-stepsize-in-slice]
-```
 
-## Function return
+def int_instance() -> int: ...
 
-```py
-def int_instance() -> int:
-    return 42
-
-a = b"abcde"[int_instance()]
+byte_slice1 = b[int_instance() : int_instance()]
 # TODO: Support overloads... Should be `bytes`
-reveal_type(a)  # revealed: @Todo
+reveal_type(byte_slice1)  # revealed: @Todo
+
+def bytes_instance() -> bytes: ...
+
+byte_slice2 = bytes_instance()[0:5]
+# TODO: Support overloads... Should be `bytes`
+reveal_type(byte_slice2)  # revealed: @Todo
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/subscript/stepsize_zero.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/subscript/stepsize_zero.md
@@ -1,0 +1,14 @@
+# Stepsize zero in slices
+
+We raise a `zero-stepsize-in-slice` diagnostic when trying to slice a literal
+string, bytes, or tuple with a step size of zero (see tests in `string.md`,
+`bytes.md` and `tuple.md`). But we don't want to raise this diagnostic when
+slicing a custom type:
+
+```py
+class MySequence:
+    def __getitem__(self, s: slice) -> int:
+        return 0
+
+MySequence()[0:1:0]  # No error
+```

--- a/crates/red_knot_python_semantic/resources/mdtest/subscript/string.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/subscript/string.md
@@ -41,6 +41,9 @@ reveal_type(s[:1])  # revealed: Literal["a"]
 reveal_type(s[:5])  # revealed: Literal["abcde"]
 
 reveal_type(s[:])  # revealed: Literal["abcde"]
+
+a = s[0:5:0]  # error: [slice-step-zero]
+reveal_type(a)  # revealed: Unknown
 ```
 
 ## Function return

--- a/crates/red_knot_python_semantic/resources/mdtest/subscript/string.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/subscript/string.md
@@ -18,6 +18,12 @@ reveal_type(a)  # revealed: Unknown
 
 b = s[-8]  # error: [index-out-of-bounds] "Index -8 is out of bounds for string `Literal["abcde"]` with length 5"
 reveal_type(b)  # revealed: Unknown
+
+def int_instance() -> int: ...
+
+a = "abcde"[int_instance()]
+# TODO: Support overloads... Should be `str`
+reveal_type(a)  # revealed: @Todo
 ```
 
 ## Slices
@@ -67,15 +73,16 @@ s[0:4:0]  # error: [zero-stepsize-in-slice]
 s[:4:0]  # error: [zero-stepsize-in-slice]
 s[0::0]  # error: [zero-stepsize-in-slice]
 s[::0]  # error: [zero-stepsize-in-slice]
-```
 
-## Function return
+def int_instance() -> int: ...
 
-```py
-def int_instance() -> int:
-    return 42
+substring1 = s[int_instance() : int_instance()]
+# TODO: Support overloads... Should be `LiteralString`
+reveal_type(substring1)  # revealed: @Todo
 
-a = "abcde"[int_instance()]
+def str_instance() -> str: ...
+
+substring2 = str_instance()[0:5]
 # TODO: Support overloads... Should be `str`
-reveal_type(a)  # revealed: @Todo
+reveal_type(substring2)  # revealed: @Todo
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/subscript/string.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/subscript/string.md
@@ -42,6 +42,12 @@ reveal_type(s[:5])  # revealed: Literal["abcde"]
 
 reveal_type(s[:])  # revealed: Literal["abcde"]
 
+reveal_type(s[::-1])  # revealed: Literal["edcba"]
+reveal_type(s[-2:-5:-1])  # revealed: Literal["dcb"]
+reveal_type(s[::2])  # revealed: Literal["ace"]
+reveal_type(s[::-2])  # revealed: Literal["eca"]
+reveal_type(s[-1::-3])  # revealed: Literal["eb"]
+
 a = s[0:5:0]  # error: [slice-step-zero]
 reveal_type(a)  # revealed: Unknown
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/subscript/string.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/subscript/string.md
@@ -63,8 +63,10 @@ reveal_type(s[start:stop:step])  # revealed: Literal["bd"]
 reveal_type(s[False:True])  # revealed: Literal["a"]
 reveal_type(s[True:3])  # revealed: Literal["bc"]
 
-a = s[0:5:0]  # error: [slice-step-zero]
-reveal_type(a)  # revealed: Unknown
+s[0:4:0]  # error: [zero-stepsize-in-slice]
+s[:4:0]  # error: [zero-stepsize-in-slice]
+s[0::0]  # error: [zero-stepsize-in-slice]
+s[::0]  # error: [zero-stepsize-in-slice]
 ```
 
 ## Function return

--- a/crates/red_knot_python_semantic/resources/mdtest/subscript/string.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/subscript/string.md
@@ -29,24 +29,39 @@ reveal_type(s[0:0])  # revealed: Literal[""]
 reveal_type(s[0:1])  # revealed: Literal["a"]
 reveal_type(s[0:2])  # revealed: Literal["ab"]
 reveal_type(s[0:5])  # revealed: Literal["abcde"]
+reveal_type(s[0:6])  # revealed: Literal["abcde"]
+reveal_type(s[1:3])  # revealed: Literal["bc"]
 
 reveal_type(s[-3:5])  # revealed: Literal["cde"]
+reveal_type(s[-4:-2])  # revealed: Literal["bc"]
+reveal_type(s[-10:10])  # revealed: Literal["abcde"]
 
 reveal_type(s[0:])  # revealed: Literal["abcde"]
-reveal_type(s[1:])  # revealed: Literal["bcde"]
+reveal_type(s[2:])  # revealed: Literal["cde"]
 reveal_type(s[5:])  # revealed: Literal[""]
-
+reveal_type(s[:2])  # revealed: Literal["ab"]
 reveal_type(s[:0])  # revealed: Literal[""]
-reveal_type(s[:1])  # revealed: Literal["a"]
-reveal_type(s[:5])  # revealed: Literal["abcde"]
-
+reveal_type(s[:2])  # revealed: Literal["ab"]
+reveal_type(s[:10])  # revealed: Literal["abcde"]
 reveal_type(s[:])  # revealed: Literal["abcde"]
 
 reveal_type(s[::-1])  # revealed: Literal["edcba"]
-reveal_type(s[-2:-5:-1])  # revealed: Literal["dcb"]
 reveal_type(s[::2])  # revealed: Literal["ace"]
+reveal_type(s[-2:-5:-1])  # revealed: Literal["dcb"]
 reveal_type(s[::-2])  # revealed: Literal["eca"]
 reveal_type(s[-1::-3])  # revealed: Literal["eb"]
+
+reveal_type(s[None:2:None])  # revealed: Literal["ab"]
+reveal_type(s[1:None:1])  # revealed: Literal["bcde"]
+reveal_type(s[None:None:None])  # revealed: Literal["abcde"]
+
+start = 1
+stop = None
+step = 2
+reveal_type(s[start:stop:step])  # revealed: Literal["bd"]
+
+reveal_type(s[False:True])  # revealed: Literal["a"]
+reveal_type(s[True:3])  # revealed: Literal["bc"]
 
 a = s[0:5:0]  # error: [slice-step-zero]
 reveal_type(a)  # revealed: Unknown

--- a/crates/red_knot_python_semantic/resources/mdtest/subscript/string.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/subscript/string.md
@@ -1,6 +1,6 @@
-# Subscript on strings
+# String subscripts
 
-## Simple
+## Indexing
 
 ```py
 s = "abcde"

--- a/crates/red_knot_python_semantic/resources/mdtest/subscript/string.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/subscript/string.md
@@ -20,6 +20,29 @@ b = s[-8]  # error: [index-out-of-bounds] "Index -8 is out of bounds for string 
 reveal_type(b)  # revealed: Unknown
 ```
 
+## Slices
+
+```py
+s = "abcde"
+
+reveal_type(s[0:0])  # revealed: Literal[""]
+reveal_type(s[0:1])  # revealed: Literal["a"]
+reveal_type(s[0:2])  # revealed: Literal["ab"]
+reveal_type(s[0:5])  # revealed: Literal["abcde"]
+
+reveal_type(s[-3:5])  # revealed: Literal["cde"]
+
+reveal_type(s[0:])  # revealed: Literal["abcde"]
+reveal_type(s[1:])  # revealed: Literal["bcde"]
+reveal_type(s[5:])  # revealed: Literal[""]
+
+reveal_type(s[:0])  # revealed: Literal[""]
+reveal_type(s[:1])  # revealed: Literal["a"]
+reveal_type(s[:5])  # revealed: Literal["abcde"]
+
+reveal_type(s[:])  # revealed: Literal["abcde"]
+```
+
 ## Function return
 
 ```py

--- a/crates/red_knot_python_semantic/resources/mdtest/subscript/tuple.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/subscript/tuple.md
@@ -1,6 +1,6 @@
 # Tuple subscripts
 
-## Basic
+## Indexing
 
 ```py
 t = (1, "a", "b")
@@ -9,6 +9,9 @@ reveal_type(t[0])  # revealed: Literal[1]
 reveal_type(t[1])  # revealed: Literal["a"]
 reveal_type(t[-1])  # revealed: Literal["b"]
 reveal_type(t[-2])  # revealed: Literal["a"]
+
+reveal_type(t[False])  # revealed: Literal[1]
+reveal_type(t[True])  # revealed: Literal["a"]
 
 a = t[4]  # error: [index-out-of-bounds]
 reveal_type(a)  # revealed: Unknown

--- a/crates/red_knot_python_semantic/resources/mdtest/subscript/tuple.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/subscript/tuple.md
@@ -62,6 +62,8 @@ reveal_type(t[start:stop:step])  # revealed: tuple[Literal["a"], Literal[b"b"]]
 reveal_type(t[False:True])  # revealed: tuple[Literal[1]]
 reveal_type(t[True:3])  # revealed: tuple[Literal["a"], None]
 
-a = t[0:4:0]  # error: [slice-step-zero]
-reveal_type(a)  # revealed: Unknown
+t[0:4:0]  # error: [zero-stepsize-in-slice]
+t[:4:0]  # error: [zero-stepsize-in-slice]
+t[0::0]  # error: [zero-stepsize-in-slice]
+t[::0]  # error: [zero-stepsize-in-slice]
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/subscript/tuple.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/subscript/tuple.md
@@ -16,3 +16,13 @@ reveal_type(a)  # revealed: Unknown
 b = t[-4]  # error: [index-out-of-bounds]
 reveal_type(b)  # revealed: Unknown
 ```
+
+## Slices
+
+```py
+t = (1, "a", None, b"b")
+
+reveal_type(t[0:2])  # revealed: tuple[Literal[1], Literal["a"]]
+reveal_type(t[1:3])  # revealed: tuple[Literal["a"], None]
+reveal_type(t[-2:4])  # revealed: tuple[None, Literal[b"b"]]
+```

--- a/crates/red_knot_python_semantic/resources/mdtest/subscript/tuple.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/subscript/tuple.md
@@ -66,4 +66,10 @@ t[0:4:0]  # error: [zero-stepsize-in-slice]
 t[:4:0]  # error: [zero-stepsize-in-slice]
 t[0::0]  # error: [zero-stepsize-in-slice]
 t[::0]  # error: [zero-stepsize-in-slice]
+
+def int_instance() -> int: ...
+
+tuple_slice = t[int_instance() : int_instance()]
+# TODO: Support overloads... Should be `tuple[Literal[1, 'a', b"b"] | None, ...]`
+reveal_type(tuple_slice)  # revealed: @Todo
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/subscript/tuple.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/subscript/tuple.md
@@ -25,4 +25,27 @@ t = (1, "a", None, b"b")
 reveal_type(t[0:2])  # revealed: tuple[Literal[1], Literal["a"]]
 reveal_type(t[1:3])  # revealed: tuple[Literal["a"], None]
 reveal_type(t[-2:4])  # revealed: tuple[None, Literal[b"b"]]
+reveal_type(t[2:])  # revealed: tuple[None, Literal[b"b"]]
+reveal_type(t[:2])  # revealed: tuple[Literal[1], Literal["a"]]
+reveal_type(t[:])  # revealed: tuple[Literal[1], Literal["a"], None, Literal[b"b"]]
+reveal_type(t[:10])  # revealed: tuple[Literal[1], Literal["a"], None, Literal[b"b"]]
+reveal_type(t[-10:])  # revealed: tuple[Literal[1], Literal["a"], None, Literal[b"b"]]
+
+reveal_type(t[::2])  # revealed: tuple[Literal[1], None]
+reveal_type(t[::-2])  # revealed: tuple[Literal[b"b"], Literal["a"]]
+
+reveal_type(t[None:2:None])  # revealed: tuple[Literal[1], Literal["a"]]
+reveal_type(t[1:None:1])  # revealed: tuple[Literal["a"], None, Literal[b"b"]]
+reveal_type(t[None:None:None])  # revealed: tuple[Literal[1], Literal["a"], None, Literal[b"b"]]
+
+start = 1
+stop = None
+step = 2
+reveal_type(t[start:stop:step])  # revealed: tuple[Literal["a"], Literal[b"b"]]
+
+reveal_type(t[False:True])  # revealed: tuple[Literal[1]]
+reveal_type(t[True:3])  # revealed: tuple[Literal["a"], None]
+
+a = t[0:4:0]  # error: [slice-step-zero]
+reveal_type(a)  # revealed: Unknown
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/subscript/tuple.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/subscript/tuple.md
@@ -25,17 +25,30 @@ reveal_type(b)  # revealed: Unknown
 ```py
 t = (1, "a", None, b"b")
 
+reveal_type(t[0:0])  # revealed: tuple[()]
+reveal_type(t[0:1])  # revealed: tuple[Literal[1]]
 reveal_type(t[0:2])  # revealed: tuple[Literal[1], Literal["a"]]
+reveal_type(t[0:4])  # revealed: tuple[Literal[1], Literal["a"], None, Literal[b"b"]]
+reveal_type(t[0:5])  # revealed: tuple[Literal[1], Literal["a"], None, Literal[b"b"]]
 reveal_type(t[1:3])  # revealed: tuple[Literal["a"], None]
-reveal_type(t[-2:4])  # revealed: tuple[None, Literal[b"b"]]
-reveal_type(t[2:])  # revealed: tuple[None, Literal[b"b"]]
-reveal_type(t[:2])  # revealed: tuple[Literal[1], Literal["a"]]
-reveal_type(t[:])  # revealed: tuple[Literal[1], Literal["a"], None, Literal[b"b"]]
-reveal_type(t[:10])  # revealed: tuple[Literal[1], Literal["a"], None, Literal[b"b"]]
-reveal_type(t[-10:])  # revealed: tuple[Literal[1], Literal["a"], None, Literal[b"b"]]
 
+reveal_type(t[-2:4])  # revealed: tuple[None, Literal[b"b"]]
+reveal_type(t[-3:-1])  # revealed: tuple[Literal["a"], None]
+reveal_type(t[-10:10])  # revealed: tuple[Literal[1], Literal["a"], None, Literal[b"b"]]
+
+reveal_type(t[0:])  # revealed: tuple[Literal[1], Literal["a"], None, Literal[b"b"]]
+reveal_type(t[2:])  # revealed: tuple[None, Literal[b"b"]]
+reveal_type(t[4:])  # revealed: tuple[()]
+reveal_type(t[:0])  # revealed: tuple[()]
+reveal_type(t[:2])  # revealed: tuple[Literal[1], Literal["a"]]
+reveal_type(t[:10])  # revealed: tuple[Literal[1], Literal["a"], None, Literal[b"b"]]
+reveal_type(t[:])  # revealed: tuple[Literal[1], Literal["a"], None, Literal[b"b"]]
+
+reveal_type(t[::-1])  # revealed: tuple[Literal[b"b"], None, Literal["a"], Literal[1]]
 reveal_type(t[::2])  # revealed: tuple[Literal[1], None]
+reveal_type(t[-2:-5:-1])  # revealed: tuple[None, Literal["a"], Literal[1]]
 reveal_type(t[::-2])  # revealed: tuple[Literal[b"b"], Literal["a"]]
+reveal_type(t[-1::-3])  # revealed: tuple[Literal[b"b"], Literal[1]]
 
 reveal_type(t[None:2:None])  # revealed: tuple[Literal[1], Literal["a"]]
 reveal_type(t[1:None:1])  # revealed: tuple[Literal["a"], None, Literal[b"b"]]

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -1,3 +1,5 @@
+use std::num::NonZero;
+
 use infer::TypeInferenceBuilder;
 use ruff_db::files::File;
 use ruff_python_ast as ast;
@@ -1826,7 +1828,7 @@ pub struct BytesLiteralType<'db> {
 pub struct SliceLiteralType<'db> {
     start: Option<i32>,
     stop: Option<i32>,
-    step: Option<i32>,
+    step: Option<NonZero<i32>>,
 }
 
 #[salsa::interned]

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -283,6 +283,8 @@ pub enum Type<'db> {
     LiteralString,
     /// A bytes literal
     BytesLiteral(BytesLiteralType<'db>),
+    /// A slice sliteral, e.g. `1:5`, `10:0:-1` or `:`
+    SliceLiteral(SliceLiteralType<'db>),
     /// A heterogeneous tuple type, with elements of the given types in source order.
     // TODO: Support variable length homogeneous tuple type like `tuple[int, ...]`.
     Tuple(TupleType<'db>),
@@ -553,6 +555,7 @@ impl<'db> Type<'db> {
                 | Type::IntLiteral(..)
                 | Type::StringLiteral(..)
                 | Type::BytesLiteral(..)
+                | Type::SliceLiteral(..)
                 | Type::FunctionLiteral(..)
                 | Type::ModuleLiteral(..)
                 | Type::ClassLiteral(..)),
@@ -561,6 +564,7 @@ impl<'db> Type<'db> {
                 | Type::IntLiteral(..)
                 | Type::StringLiteral(..)
                 | Type::BytesLiteral(..)
+                | Type::SliceLiteral(..)
                 | Type::FunctionLiteral(..)
                 | Type::ModuleLiteral(..)
                 | Type::ClassLiteral(..)),
@@ -611,6 +615,13 @@ impl<'db> Type<'db> {
                 Some(KnownClass::Bytes | KnownClass::Object)
             ),
             (Type::BytesLiteral(..), _) | (_, Type::BytesLiteral(..)) => true,
+
+            (Type::SliceLiteral(..), Type::Instance(class_type))
+            | (Type::Instance(class_type), Type::SliceLiteral(..)) => !matches!(
+                class_type.known(db),
+                Some(KnownClass::Slice | KnownClass::Object)
+            ),
+            (Type::SliceLiteral(..), _) | (_, Type::SliceLiteral(..)) => true,
 
             (
                 Type::FunctionLiteral(..) | Type::ModuleLiteral(..) | Type::ClassLiteral(..),
@@ -673,6 +684,7 @@ impl<'db> Type<'db> {
             | Type::IntLiteral(..)
             | Type::StringLiteral(..)
             | Type::BytesLiteral(..)
+            | Type::SliceLiteral(..)
             | Type::LiteralString => {
                 // Note: The literal types included in this pattern are not true singletons.
                 // There can be multiple Python objects (at different memory locations) that
@@ -717,7 +729,8 @@ impl<'db> Type<'db> {
             | Type::IntLiteral(..)
             | Type::BooleanLiteral(..)
             | Type::StringLiteral(..)
-            | Type::BytesLiteral(..) => true,
+            | Type::BytesLiteral(..)
+            | Type::SliceLiteral(..) => true,
 
             Type::Tuple(tuple) => tuple
                 .elements(db)
@@ -738,6 +751,7 @@ impl<'db> Type<'db> {
                     | KnownClass::Tuple
                     | KnownClass::Set
                     | KnownClass::Dict
+                    | KnownClass::Slice
                     | KnownClass::GenericAlias
                     | KnownClass::ModuleType
                     | KnownClass::FunctionType,
@@ -818,6 +832,10 @@ impl<'db> Type<'db> {
                 // TODO defer to Type::Instance(<bytes from typeshed>).member
                 Type::Todo
             }
+            Type::SliceLiteral(_) => {
+                // TODO defer to `builtins.slice` methods
+                Type::Todo
+            }
             Type::Tuple(_) => {
                 // TODO: implement tuple methods
                 Type::Todo
@@ -872,6 +890,7 @@ impl<'db> Type<'db> {
             Type::StringLiteral(str) => Truthiness::from(!str.value(db).is_empty()),
             Type::LiteralString => Truthiness::Ambiguous,
             Type::BytesLiteral(bytes) => Truthiness::from(!bytes.value(db).is_empty()),
+            Type::SliceLiteral(_) => Truthiness::AlwaysTrue,
             Type::Tuple(items) => Truthiness::from(!items.elements(db).is_empty()),
         }
     }
@@ -1028,6 +1047,7 @@ impl<'db> Type<'db> {
             | Type::ModuleLiteral(_)
             | Type::IntLiteral(_)
             | Type::StringLiteral(_)
+            | Type::SliceLiteral(_)
             | Type::Tuple(_)
             | Type::LiteralString
             | Type::None => Type::Unknown,
@@ -1045,6 +1065,7 @@ impl<'db> Type<'db> {
             Type::Union(union) => union.map(db, |ty| ty.to_meta_type(db)),
             Type::BooleanLiteral(_) => KnownClass::Bool.to_class(db),
             Type::BytesLiteral(_) => KnownClass::Bytes.to_class(db),
+            Type::SliceLiteral(_) => KnownClass::Slice.to_class(db),
             Type::IntLiteral(_) => KnownClass::Int.to_class(db),
             Type::FunctionLiteral(_) => KnownClass::FunctionType.to_class(db),
             Type::ModuleLiteral(_) => KnownClass::ModuleType.to_class(db),
@@ -1128,6 +1149,7 @@ pub enum KnownClass {
     Tuple,
     Set,
     Dict,
+    Slice,
     // Types
     GenericAlias,
     ModuleType,
@@ -1150,6 +1172,7 @@ impl<'db> KnownClass {
             Self::Dict => "dict",
             Self::List => "list",
             Self::Type => "type",
+            Self::Slice => "slice",
             Self::GenericAlias => "GenericAlias",
             Self::ModuleType => "ModuleType",
             Self::FunctionType => "FunctionType",
@@ -1173,7 +1196,8 @@ impl<'db> KnownClass {
             | Self::List
             | Self::Tuple
             | Self::Set
-            | Self::Dict => builtins_symbol_ty(db, self.as_str()),
+            | Self::Dict
+            | Self::Slice => builtins_symbol_ty(db, self.as_str()),
             Self::GenericAlias | Self::ModuleType | Self::FunctionType => {
                 types_symbol_ty(db, self.as_str())
             }
@@ -1206,6 +1230,7 @@ impl<'db> KnownClass {
             "set" => Some(Self::Set),
             "dict" => Some(Self::Dict),
             "list" => Some(Self::List),
+            "slice" => Some(Self::Slice),
             "GenericAlias" => Some(Self::GenericAlias),
             "NoneType" => Some(Self::NoneType),
             "ModuleType" => Some(Self::ModuleType),
@@ -1230,7 +1255,8 @@ impl<'db> KnownClass {
             | Self::List
             | Self::Tuple
             | Self::Set
-            | Self::Dict => module.name() == "builtins",
+            | Self::Dict
+            | Self::Slice => module.name() == "builtins",
             Self::GenericAlias | Self::ModuleType | Self::FunctionType => module.name() == "types",
             Self::NoneType => matches!(module.name().as_str(), "_typeshed" | "types"),
         }
@@ -1794,6 +1820,13 @@ impl<'db> StringLiteralType<'db> {
 pub struct BytesLiteralType<'db> {
     #[return_ref]
     value: Box<[u8]>,
+}
+
+#[salsa::interned]
+pub struct SliceLiteralType<'db> {
+    start: Option<i64>,
+    stop: Option<i64>,
+    step: Option<i64>,
 }
 
 #[salsa::interned]

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -283,7 +283,7 @@ pub enum Type<'db> {
     LiteralString,
     /// A bytes literal
     BytesLiteral(BytesLiteralType<'db>),
-    /// A slice sliteral, e.g. `1:5`, `10:0:-1` or `:`
+    /// A slice literal, e.g. `1:5`, `10:0:-1` or `:`
     SliceLiteral(SliceLiteralType<'db>),
     /// A heterogeneous tuple type, with elements of the given types in source order.
     // TODO: Support variable length homogeneous tuple type like `tuple[int, ...]`.

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -1824,9 +1824,9 @@ pub struct BytesLiteralType<'db> {
 
 #[salsa::interned]
 pub struct SliceLiteralType<'db> {
-    start: Option<i64>,
-    stop: Option<i64>,
-    step: Option<i64>,
+    start: Option<i32>,
+    stop: Option<i32>,
+    step: Option<i32>,
 }
 
 #[salsa::interned]

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -1,5 +1,3 @@
-use std::num::NonZeroI32;
-
 use infer::TypeInferenceBuilder;
 use ruff_db::files::File;
 use ruff_python_ast as ast;
@@ -1828,7 +1826,7 @@ pub struct BytesLiteralType<'db> {
 pub struct SliceLiteralType<'db> {
     start: Option<i32>,
     stop: Option<i32>,
-    step: Option<NonZeroI32>,
+    step: Option<i32>,
 }
 
 #[salsa::interned]

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -1,4 +1,4 @@
-use std::num::NonZero;
+use std::num::NonZeroI32;
 
 use infer::TypeInferenceBuilder;
 use ruff_db::files::File;
@@ -1828,7 +1828,7 @@ pub struct BytesLiteralType<'db> {
 pub struct SliceLiteralType<'db> {
     start: Option<i32>,
     stop: Option<i32>,
-    step: Option<NonZero<i32>>,
+    step: Option<NonZeroI32>,
 }
 
 #[salsa::interned]

--- a/crates/red_knot_python_semantic/src/types/display.rs
+++ b/crates/red_knot_python_semantic/src/types/display.rs
@@ -319,8 +319,6 @@ impl<'db> Display for DisplayTypeArray<'_, 'db> {
 
 #[cfg(test)]
 mod tests {
-    use std::num::NonZeroI32;
-
     use ruff_db::files::system_path_to_file;
     use ruff_db::system::{DbWithTestSystem, SystemPathBuf};
 
@@ -432,25 +430,15 @@ mod tests {
             "slice[Literal[1], Literal[5]]"
         );
         assert_eq!(
-            Type::SliceLiteral(SliceLiteralType::new(
-                &db,
-                Some(1),
-                Some(5),
-                Some(NonZeroI32::new(2).unwrap())
-            ))
-            .display(&db)
-            .to_string(),
+            Type::SliceLiteral(SliceLiteralType::new(&db, Some(1), Some(5), Some(2)))
+                .display(&db)
+                .to_string(),
             "slice[Literal[1], Literal[5], Literal[2]]"
         );
         assert_eq!(
-            Type::SliceLiteral(SliceLiteralType::new(
-                &db,
-                None,
-                None,
-                Some(NonZeroI32::new(2).unwrap())
-            ))
-            .display(&db)
-            .to_string(),
+            Type::SliceLiteral(SliceLiteralType::new(&db, None, None, Some(2)))
+                .display(&db)
+                .to_string(),
             "slice[None, None, Literal[2]]"
         );
     }

--- a/crates/red_knot_python_semantic/src/types/display.rs
+++ b/crates/red_knot_python_semantic/src/types/display.rs
@@ -90,6 +90,15 @@ impl Display for DisplayRepresentation<'_> {
 
                 escape.bytes_repr().write(f)
             }
+            Type::SliceLiteral(slice) => {
+                write!(
+                    f,
+                    "slice[{start:?}, {stop:?}, {step:?}]", // TODO
+                    start = slice.start(self.db),
+                    stop = slice.stop(self.db),
+                    step = slice.step(self.db),
+                )
+            }
             Type::Tuple(tuple) => {
                 f.write_str("tuple[")?;
                 let elements = tuple.elements(self.db);

--- a/crates/red_knot_python_semantic/src/types/display.rs
+++ b/crates/red_knot_python_semantic/src/types/display.rs
@@ -93,10 +93,19 @@ impl Display for DisplayRepresentation<'_> {
             Type::SliceLiteral(slice) => {
                 write!(
                     f,
-                    "slice[{start:?}, {stop:?}, {step:?}]", // TODO
-                    start = slice.start(self.db),
-                    stop = slice.stop(self.db),
-                    step = slice.step(self.db),
+                    "slice[{start}, {stop}, {step}]",
+                    start = slice
+                        .start(self.db)
+                        .map(|s| s.to_string())
+                        .unwrap_or_else(String::new),
+                    stop = slice
+                        .stop(self.db)
+                        .map(|s| s.to_string())
+                        .unwrap_or_else(String::new),
+                    step = slice
+                        .step(self.db)
+                        .map(|s| s.to_string())
+                        .unwrap_or_else(String::new)
                 )
             }
             Type::Tuple(tuple) => {

--- a/crates/red_knot_python_semantic/src/types/display.rs
+++ b/crates/red_knot_python_semantic/src/types/display.rs
@@ -96,15 +96,15 @@ impl Display for DisplayRepresentation<'_> {
                     "slice[{start}, {stop}{step}]",
                     start = slice
                         .start(self.db)
-                        .map(|s| format!("Literal[{}], ", s))
+                        .map(|s| format!("Literal[{}]", s))
                         .unwrap_or("None".into()),
                     stop = slice
                         .stop(self.db)
-                        .map(|s| format!("Literal[{}], ", s))
+                        .map(|s| format!("Literal[{}]", s))
                         .unwrap_or("None".into()),
                     step = slice
                         .step(self.db)
-                        .map(|s| format!(", {}", s))
+                        .map(|s| format!(", Literal[{}]", s))
                         .unwrap_or_default()
                 )
             }

--- a/crates/red_knot_python_semantic/src/types/display.rs
+++ b/crates/red_knot_python_semantic/src/types/display.rs
@@ -319,6 +319,8 @@ impl<'db> Display for DisplayTypeArray<'_, 'db> {
 
 #[cfg(test)]
 mod tests {
+    use std::num::NonZero;
+
     use ruff_db::files::system_path_to_file;
     use ruff_db::system::{DbWithTestSystem, SystemPathBuf};
 
@@ -430,15 +432,25 @@ mod tests {
             "slice[Literal[1], Literal[5]]"
         );
         assert_eq!(
-            Type::SliceLiteral(SliceLiteralType::new(&db, Some(1), Some(5), Some(2)))
-                .display(&db)
-                .to_string(),
+            Type::SliceLiteral(SliceLiteralType::new(
+                &db,
+                Some(1),
+                Some(5),
+                Some(NonZero::new(2).unwrap())
+            ))
+            .display(&db)
+            .to_string(),
             "slice[Literal[1], Literal[5], Literal[2]]"
         );
         assert_eq!(
-            Type::SliceLiteral(SliceLiteralType::new(&db, None, None, Some(2)))
-                .display(&db)
-                .to_string(),
+            Type::SliceLiteral(SliceLiteralType::new(
+                &db,
+                None,
+                None,
+                Some(NonZero::new(2).unwrap())
+            ))
+            .display(&db)
+            .to_string(),
             "slice[None, None, Literal[2]]"
         );
     }

--- a/crates/red_knot_python_semantic/src/types/display.rs
+++ b/crates/red_knot_python_semantic/src/types/display.rs
@@ -319,7 +319,7 @@ impl<'db> Display for DisplayTypeArray<'_, 'db> {
 
 #[cfg(test)]
 mod tests {
-    use std::num::NonZero;
+    use std::num::NonZeroI32;
 
     use ruff_db::files::system_path_to_file;
     use ruff_db::system::{DbWithTestSystem, SystemPathBuf};
@@ -436,7 +436,7 @@ mod tests {
                 &db,
                 Some(1),
                 Some(5),
-                Some(NonZero::new(2).unwrap())
+                Some(NonZeroI32::new(2).unwrap())
             ))
             .display(&db)
             .to_string(),
@@ -447,7 +447,7 @@ mod tests {
                 &db,
                 None,
                 None,
-                Some(NonZero::new(2).unwrap())
+                Some(NonZeroI32::new(2).unwrap())
             ))
             .display(&db)
             .to_string(),

--- a/crates/red_knot_python_semantic/src/types/display.rs
+++ b/crates/red_knot_python_semantic/src/types/display.rs
@@ -91,22 +91,26 @@ impl Display for DisplayRepresentation<'_> {
                 escape.bytes_repr().write(f)
             }
             Type::SliceLiteral(slice) => {
-                write!(
-                    f,
-                    "slice[{start}, {stop}{step}]",
-                    start = slice
-                        .start(self.db)
-                        .map(|s| format!("Literal[{s}]"))
-                        .unwrap_or("None".into()),
-                    stop = slice
-                        .stop(self.db)
-                        .map(|s| format!("Literal[{s}]"))
-                        .unwrap_or("None".into()),
-                    step = slice
-                        .step(self.db)
-                        .map(|s| format!(", Literal[{s}]"))
-                        .unwrap_or_default()
-                )
+                f.write_str("slice[")?;
+                if let Some(start) = slice.start(self.db) {
+                    write!(f, "Literal[{start}]")?;
+                } else {
+                    f.write_str("None")?;
+                }
+
+                f.write_str(", ")?;
+
+                if let Some(stop) = slice.stop(self.db) {
+                    write!(f, "Literal[{stop}]")?;
+                } else {
+                    f.write_str("None")?;
+                }
+
+                if let Some(step) = slice.step(self.db) {
+                    write!(f, ", Literal[{step}]")?;
+                }
+
+                f.write_str("]")
             }
             Type::Tuple(tuple) => {
                 f.write_str("tuple[")?;

--- a/crates/red_knot_python_semantic/src/types/display.rs
+++ b/crates/red_knot_python_semantic/src/types/display.rs
@@ -96,15 +96,15 @@ impl Display for DisplayRepresentation<'_> {
                     "slice[{start}, {stop}{step}]",
                     start = slice
                         .start(self.db)
-                        .map(|s| format!("Literal[{}]", s))
+                        .map(|s| format!("Literal[{s}]"))
                         .unwrap_or("None".into()),
                     stop = slice
                         .stop(self.db)
-                        .map(|s| format!("Literal[{}]", s))
+                        .map(|s| format!("Literal[{s}]"))
                         .unwrap_or("None".into()),
                     step = slice
                         .step(self.db)
-                        .map(|s| format!(", Literal[{}]", s))
+                        .map(|s| format!(", Literal[{s}]"))
                         .unwrap_or_default()
                 )
             }

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -3270,12 +3270,12 @@ impl<'db> TypeInferenceBuilder<'db> {
                 let start = slice_ty.start(self.db);
                 let stop = slice_ty.stop(self.db);
                 let step = slice_ty.step(self.db);
+
                 let chars: Vec<_> = literal_value.chars().collect();
                 if let Ok(new_chars) = chars.into_iter().py_slice(start, stop, step) {
-                    let new_literal = new_chars.collect::<String>();
                     Type::StringLiteral(StringLiteralType::new(
                         self.db,
-                        new_literal.into_boxed_str(),
+                        new_chars.collect::<String>().into_boxed_str(),
                     ))
                 } else {
                     self.slice_step_size_zero_diagnostic(value_node.into());

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -28,7 +28,7 @@
 //! definitions once the rest of the types in the scope have been inferred.
 use itertools::Itertools;
 use std::borrow::Cow;
-use std::num::{NonZero, NonZeroU32};
+use std::num::{NonZeroI32, NonZeroU32};
 
 use ruff_db::files::File;
 use ruff_db::parsed::parsed_module;
@@ -3420,7 +3420,7 @@ impl<'db> TypeInferenceBuilder<'db> {
             type_to_slice_argument(ty_step),
         ) {
             (SliceArg::Arg(lower), SliceArg::Arg(upper), SliceArg::Arg(step)) => {
-                match step.map(NonZero::new) {
+                match step.map(NonZeroI32::new) {
                     Some(Some(step)) => {
                         Type::SliceLiteral(SliceLiteralType::new(self.db, lower, upper, Some(step)))
                     }

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -3223,7 +3223,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                 let step = slice_ty.step(self.db);
 
                 let new_elements: Vec<_> = elements
-                    .iter()
+                    .as_ref()
                     .py_slice(start, stop, step)
                     .copied()
                     .collect();
@@ -3261,12 +3261,9 @@ impl<'db> TypeInferenceBuilder<'db> {
                 let stop = slice_ty.stop(self.db);
                 let step = slice_ty.step(self.db);
 
-                let mut chars = literal_value.chars().collect::<Vec<_>>().into_iter();
-                let new_chars = chars.py_slice(start, stop, step);
-                Type::StringLiteral(StringLiteralType::new(
-                    self.db,
-                    new_chars.collect::<String>().into_boxed_str(),
-                ))
+                let chars: Vec<_> = literal_value.chars().collect();
+                let literal: String = chars.as_slice().py_slice(start, stop, step).collect();
+                Type::StringLiteral(StringLiteralType::new(self.db, literal.into_boxed_str()))
             }
             // Ex) Given `b"value"[1]`, return `b"a"`
             (Type::BytesLiteral(literal_ty), Type::IntLiteral(int))
@@ -3298,7 +3295,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                 let step = slice_ty.step(self.db);
 
                 let new_bytes: Vec<u8> = literal_value
-                    .iter()
+                    .as_ref()
                     .py_slice(start, stop, step)
                     .copied()
                     .collect();

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -3210,7 +3210,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                 let elements = tuple_ty.elements(self.db);
                 elements
                     .iter()
-                    .py_index(i32::try_from(int).unwrap())
+                    .py_index(i32::try_from(int).expect("checked in branch arm"))
                     .copied()
                     .unwrap_or_else(|_| {
                         self.index_out_of_bounds_diagnostic(
@@ -3246,7 +3246,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                 let literal_value = literal_ty.value(self.db);
                 literal_value
                     .chars()
-                    .py_index(i32::try_from(int).unwrap())
+                    .py_index(i32::try_from(int).expect("checked in branch arm"))
                     .map(|ch| {
                         Type::StringLiteral(StringLiteralType::new(
                             self.db,
@@ -3290,7 +3290,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                 let literal_value = literal_ty.value(self.db);
                 literal_value
                     .iter()
-                    .py_index(i32::try_from(int).unwrap())
+                    .py_index(i32::try_from(int).expect("checked in branch arm"))
                     .map(|byte| {
                         Type::BytesLiteral(BytesLiteralType::new(self.db, [*byte].as_slice()))
                     })
@@ -3423,7 +3423,7 @@ impl<'db> TypeInferenceBuilder<'db> {
 
         let type_to_slice_argument = |ty: Option<Type<'db>>| match ty {
             Some(Type::IntLiteral(n)) if i32::try_from(n).is_ok() => {
-                SliceArg::Arg(Some(i32::try_from(n).unwrap()))
+                SliceArg::Arg(Some(i32::try_from(n).expect("checked in branch arm")))
             }
             Some(Type::BooleanLiteral(b)) => SliceArg::Arg(Some(i32::from(b))),
             Some(Type::None) => SliceArg::Arg(None),

--- a/crates/red_knot_python_semantic/src/util/subscript.rs
+++ b/crates/red_knot_python_semantic/src/util/subscript.rs
@@ -19,7 +19,7 @@ fn from_nonnegative_i32(index: i32) -> usize {
     debug_assert!(index >= 0);
 
     // SAFETY: `index` is non-negative, and `usize` is at least 32 bits.
-    index as usize
+    usize::try_from(index).unwrap()
 }
 
 fn from_negative_i32(index: i32) -> usize {

--- a/crates/red_knot_python_semantic/src/util/subscript.rs
+++ b/crates/red_knot_python_semantic/src/util/subscript.rs
@@ -65,7 +65,7 @@ where
     fn py_index(&mut self, index: i32) -> Result<I, OutOfBoundsError> {
         match Nth::from_index(index) {
             Nth::FromStart(nth) => self.nth(nth).ok_or(OutOfBoundsError),
-            Nth::FromEnd(nth_rev) => self.rev().nth(nth_rev).ok_or(OutOfBoundsError),
+            Nth::FromEnd(nth_rev) => self.nth_back(nth_rev).ok_or(OutOfBoundsError),
         }
     }
 }

--- a/crates/red_knot_python_semantic/src/util/subscript.rs
+++ b/crates/red_knot_python_semantic/src/util/subscript.rs
@@ -2,7 +2,7 @@
 //! operations (`PySlice`) on iterators, following the semantics of equivalent
 //! operations in Python.
 
-use std::{cmp::Ordering, num::NonZero};
+use std::{cmp::Ordering, num::NonZeroI32};
 
 use itertools::Either;
 
@@ -79,7 +79,7 @@ pub(crate) trait PySlice {
         &self,
         start: Option<i32>,
         stop: Option<i32>,
-        step: Option<NonZero<i32>>,
+        step: Option<NonZeroI32>,
     ) -> Either<impl Iterator<Item = &Self::Item>, impl Iterator<Item = &Self::Item>>;
 }
 
@@ -90,9 +90,9 @@ impl<T> PySlice for &[T] {
         &self,
         start: Option<i32>,
         stop: Option<i32>,
-        step_int: Option<NonZero<i32>>,
+        step_int: Option<NonZeroI32>,
     ) -> Either<impl Iterator<Item = &Self::Item>, impl Iterator<Item = &Self::Item>> {
-        let step_int = step_int.unwrap_or(NonZero::new(1).unwrap());
+        let step_int = step_int.unwrap_or(NonZeroI32::new(1).unwrap());
 
         let len = self.len();
         if len == 0 {
@@ -146,7 +146,7 @@ impl<T> PySlice for &[T] {
 #[cfg(test)]
 #[allow(clippy::redundant_clone)]
 mod tests {
-    use std::num::NonZero;
+    use std::num::NonZeroI32;
 
     use crate::util::subscript::OutOfBoundsError;
 
@@ -214,7 +214,7 @@ mod tests {
         assert_equal(
             input
                 .as_slice()
-                .py_slice(start, stop, step.map(|s| NonZero::new(s).unwrap())),
+                .py_slice(start, stop, step.map(|s| NonZeroI32::new(s).unwrap())),
             expected.iter(),
         );
     }

--- a/crates/red_knot_python_semantic/src/util/subscript.rs
+++ b/crates/red_knot_python_semantic/src/util/subscript.rs
@@ -1,3 +1,7 @@
+//! This module provides utility functions for indexing (`PyIndex`) and slicing
+//! operations (`PySlice`) on iterators, following the semantics of equivalent
+//! operations in Python.
+
 use std::cmp::Ordering;
 
 #[derive(Debug, Clone, Copy, PartialEq)]

--- a/crates/red_knot_python_semantic/src/util/subscript.rs
+++ b/crates/red_knot_python_semantic/src/util/subscript.rs
@@ -114,28 +114,26 @@ where
         let to_nonnegative_index = |index| Nth::from_index(index).to_nonnegative_index(len);
 
         if step_int > 0 {
+            let step = from_nonnegative_i32(step_int);
             let start = start.map(to_nonnegative_index).unwrap_or(0).clamp(0, len);
             let stop = stop.map(to_nonnegative_index).unwrap_or(len).clamp(0, len);
 
-            let step = from_nonnegative_i32(step_int);
-            let (skip, take_n, step) = match start.cmp(&stop) {
+            let (skip, take, step) = match start.cmp(&stop) {
                 Ordering::Less => (start, stop - start, step),
                 Ordering::Equal | Ordering::Greater => (start, 0, step),
             };
 
-            Ok(Box::new(self.skip(skip).take(take_n).step_by(step)))
+            Ok(Box::new(self.skip(skip).take(take).step_by(step)))
         } else {
+            let step = from_negative_i32(step_int);
             let start = start
                 .map(to_nonnegative_index)
                 .unwrap_or(len)
                 .clamp(0, len - 1);
-            let stop = stop
-                .map(to_nonnegative_index)
-                .map(|index| index.clamp(0, len - 1));
 
-            let step = from_negative_i32(step_int);
+            let (skip, take, step) = if let Some(stop) = stop {
+                let stop = to_nonnegative_index(stop).clamp(0, len - 1);
 
-            let (skip, take_n, step) = if let Some(stop) = stop {
                 match start.cmp(&stop) {
                     Ordering::Greater => ((len - 1) - start, start - stop, step),
                     Ordering::Less | Ordering::Equal => (len - start, 0, step),
@@ -144,7 +142,7 @@ where
                 ((len - 1) - start, len, step)
             };
 
-            Ok(Box::new(self.rev().skip(skip).take(take_n).step_by(step)))
+            Ok(Box::new(self.rev().skip(skip).take(take).step_by(step)))
         }
     }
 }

--- a/crates/red_knot_python_semantic/src/util/subscript.rs
+++ b/crates/red_knot_python_semantic/src/util/subscript.rs
@@ -219,19 +219,6 @@ mod tests {
         );
     }
 
-    #[track_caller]
-    fn assert_slice_returns_none<const N: usize>(
-        input: &[char; N],
-        start: Option<i32>,
-        stop: Option<i32>,
-        step: Option<i32>,
-    ) {
-        assert!(matches!(
-            input.iter().py_slice(start, stop, step),
-            Err(StepSizeZeroError)
-        ));
-    }
-
     #[test]
     fn py_slice_empty_input() {
         let input = [];
@@ -399,8 +386,18 @@ mod tests {
         let input = ['a', 'b', 'c', 'd', 'e', 'f', 'g'];
 
         // Step size zero is invalid:
-        assert_slice_returns_none(&input, Some(0), Some(5), Some(0));
-        assert_slice_returns_none(&input, Some(0), Some(0), Some(0));
+        assert!(matches!(
+            input.iter().py_slice(None, None, Some(0)),
+            Err(StepSizeZeroError)
+        ));
+        assert!(matches!(
+            input.iter().py_slice(Some(0), Some(5), Some(0)),
+            Err(StepSizeZeroError)
+        ));
+        assert!(matches!(
+            input.iter().py_slice(Some(0), Some(0), Some(0)),
+            Err(StepSizeZeroError)
+        ));
 
         assert_eq_slice(&input, Some(0), Some(8), Some(2), &['a', 'c', 'e', 'g']);
         assert_eq_slice(&input, Some(0), Some(7), Some(2), &['a', 'c', 'e', 'g']);
@@ -415,6 +412,8 @@ mod tests {
 
         assert_eq_slice(&input, Some(0), Some(7), Some(3), &['a', 'd', 'g']);
         assert_eq_slice(&input, Some(0), Some(6), Some(3), &['a', 'd']);
+
+        assert_eq_slice(&input, Some(0), None, Some(10), &['a']);
     }
 
     #[test]
@@ -440,5 +439,10 @@ mod tests {
         assert_eq_slice(&input, Some(5), Some(3), Some(-2), &['f']);
         assert_eq_slice(&input, Some(5), Some(4), Some(-2), &['f']);
         assert_eq_slice(&input, Some(5), Some(5), Some(-2), &[]);
+
+        assert_eq_slice(&input, Some(6), None, Some(-3), &['g', 'd', 'a']);
+        assert_eq_slice(&input, Some(6), Some(0), Some(-3), &['g', 'd']);
+
+        assert_eq_slice(&input, Some(7), None, Some(-10), &['g']);
     }
 }

--- a/crates/red_knot_python_semantic/src/util/subscript.rs
+++ b/crates/red_knot_python_semantic/src/util/subscript.rs
@@ -15,11 +15,6 @@ pub(crate) trait PyIndex {
     fn py_index(&mut self, index: i32) -> Result<Self::Item, OutOfBoundsError>;
 }
 
-enum Nth {
-    FromStart(usize),
-    FromEnd(usize),
-}
-
 fn from_nonnegative_i32(index: i32) -> usize {
     static_assertions::const_assert!(usize::BITS >= 32);
     debug_assert!(index >= 0);
@@ -37,6 +32,11 @@ fn from_negative_i32(index: i32) -> usize {
         // it as a usize, since usize is at least 32 bits.
         from_nonnegative_i32(i32::MAX) + 1
     })
+}
+
+enum Nth {
+    FromStart(usize),
+    FromEnd(usize),
 }
 
 impl Nth {

--- a/crates/red_knot_python_semantic/src/util/subscript.rs
+++ b/crates/red_knot_python_semantic/src/util/subscript.rs
@@ -131,15 +131,19 @@ where
                 .unwrap_or(len)
                 .clamp(0, len - 1);
 
-            let (skip, take, step) = if let Some(stop) = stop {
-                let stop = to_nonnegative_index(stop).clamp(0, len - 1);
-
-                match start.cmp(&stop) {
-                    Ordering::Greater => ((len - 1) - start, start - stop, step),
-                    Ordering::Less | Ordering::Equal => (len - start, 0, step),
+            let (skip, take, step) = match stop {
+                Some(stop) if i32::try_from(len).map(|len| stop < -len).unwrap_or(false) => {
+                    ((len - 1) - start, len, step)
                 }
-            } else {
-                ((len - 1) - start, len, step)
+                None => ((len - 1) - start, len, step),
+                Some(stop) => {
+                    let stop = to_nonnegative_index(stop).clamp(0, len - 1);
+
+                    match start.cmp(&stop) {
+                        Ordering::Greater => ((len - 1) - start, start - stop, step),
+                        Ordering::Less | Ordering::Equal => (len - start, 0, step),
+                    }
+                }
             };
 
             Ok(Box::new(self.rev().skip(skip).take(take).step_by(step)))
@@ -444,5 +448,10 @@ mod tests {
         assert_eq_slice(&input, Some(6), Some(0), Some(-3), &['g', 'd']);
 
         assert_eq_slice(&input, Some(7), None, Some(-10), &['g']);
+
+        assert_eq_slice(&input, Some(-6), Some(-9), Some(-1), &['b', 'a']);
+        assert_eq_slice(&input, Some(-6), Some(-8), Some(-1), &['b', 'a']);
+        assert_eq_slice(&input, Some(-6), Some(-7), Some(-1), &['b']);
+        assert_eq_slice(&input, Some(-6), Some(-6), Some(-1), &[]);
     }
 }

--- a/crates/red_knot_python_semantic/src/util/subscript.rs
+++ b/crates/red_knot_python_semantic/src/util/subscript.rs
@@ -95,15 +95,15 @@ where
     where
         I: 'a,
     {
+        let step_int = step_int.unwrap_or(1);
+        if step_int == 0 {
+            return Err(StepSizeZeroError);
+        }
+
         let len = self.len();
 
         if len == 0 {
             return Ok(Box::new(std::iter::empty()));
-        }
-
-        let step_int = step_int.unwrap_or(1);
-        if step_int == 0 {
-            return Err(StepSizeZeroError);
         }
 
         if step_int > 0 {

--- a/crates/red_knot_python_semantic/src/util/subscript.rs
+++ b/crates/red_knot_python_semantic/src/util/subscript.rs
@@ -115,10 +115,9 @@ impl<T> PySlice for &[T] {
 
         let len = self.len();
         if len == 0 {
-            #[allow(
-                clippy::iter_skip_zero,
-                reason = "The iterator needs to have the same type as the step>0 case below."
-            )]
+            // The iterator needs to have the same type as the step>0 case below,
+            // so we need to use `.skip(0)`.
+            #[allow(clippy::iter_skip_zero)]
             return Either::Left(self.iter().skip(0).take(0).step_by(1));
         }
 

--- a/crates/red_knot_python_semantic/src/util/subscript.rs
+++ b/crates/red_knot_python_semantic/src/util/subscript.rs
@@ -75,27 +75,31 @@ where
 pub(crate) trait PySlice {
     type Item;
 
-    fn py_slice<'a>(
-        &'a self,
+    fn py_slice(
+        &self,
         start: Option<i32>,
         stop: Option<i32>,
         step: Option<NonZero<i32>>,
-    ) -> Either<impl Iterator<Item = &'a Self::Item>, impl Iterator<Item = &'a Self::Item>>;
+    ) -> Either<impl Iterator<Item = &Self::Item>, impl Iterator<Item = &Self::Item>>;
 }
 
 impl<T> PySlice for &[T] {
     type Item = T;
 
-    fn py_slice<'a>(
-        &'a self,
+    fn py_slice(
+        &self,
         start: Option<i32>,
         stop: Option<i32>,
         step_int: Option<NonZero<i32>>,
-    ) -> Either<impl Iterator<Item = &'a Self::Item>, impl Iterator<Item = &'a Self::Item>> {
+    ) -> Either<impl Iterator<Item = &Self::Item>, impl Iterator<Item = &Self::Item>> {
         let step_int = step_int.unwrap_or(NonZero::new(1).unwrap());
 
         let len = self.len();
         if len == 0 {
+            #[allow(
+                clippy::iter_skip_zero,
+                reason = "The iterator needs to have the same type as the step>0 case below."
+            )]
             return Either::Left(self.iter().skip(0).take(0).step_by(1));
         }
 

--- a/crates/red_knot_python_semantic/src/util/subscript.rs
+++ b/crates/red_knot_python_semantic/src/util/subscript.rs
@@ -1,18 +1,165 @@
-pub(crate) trait PythonSubscript {
+use std::cmp::Ordering;
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(crate) struct OutOfBoundsError;
+
+pub(crate) trait PyIndex {
     type Item;
 
-    fn python_subscript(&mut self, index: i64) -> Option<Self::Item>;
+    fn py_index(&mut self, index: i64) -> Result<Self::Item, OutOfBoundsError>;
 }
 
-impl<I, T: DoubleEndedIterator<Item = I>> PythonSubscript for T {
+enum Nth {
+    FromStart(usize),
+    FromEnd(usize),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+struct ExceedsUsizeBoundsError;
+
+fn from_nonnegative_i64(index: i64) -> Result<usize, ExceedsUsizeBoundsError> {
+    usize::try_from(index).map_err(|_| ExceedsUsizeBoundsError)
+}
+
+fn from_negative_i64(index: i64) -> Result<usize, ExceedsUsizeBoundsError> {
+    Ok(index
+        .checked_neg()
+        .map(from_nonnegative_i64)
+        .transpose()?
+        .unwrap_or({
+            // The 'checked_neg' above only fails for i64::MIN. We can not
+            // represent -i64::MIN as a i64, but we can represent it as a
+            // usize (on 64bit platforms):
+            from_nonnegative_i64(i64::MAX)? + 1
+        }))
+}
+
+impl Nth {
+    fn from_index(index: i64) -> Result<Self, ExceedsUsizeBoundsError> {
+        if index >= 0 {
+            Ok(Nth::FromStart(from_nonnegative_i64(index)?))
+        } else {
+            Ok(Nth::FromEnd(from_negative_i64(index)? - 1))
+        }
+    }
+
+    fn to_nonnegative_index(&self, len: usize) -> usize {
+        match self {
+            Nth::FromStart(nth) => *nth,
+            Nth::FromEnd(nth_rev) => len - (*nth_rev).min(len - 1) - 1,
+        }
+    }
+}
+
+impl<I, T> PyIndex for T
+where
+    T: DoubleEndedIterator<Item = I>,
+{
     type Item = I;
 
-    fn python_subscript(&mut self, index: i64) -> Option<I> {
-        if index >= 0 {
-            self.nth(usize::try_from(index).ok()?)
+    fn py_index(&mut self, index: i64) -> Result<I, OutOfBoundsError> {
+        match Nth::from_index(index).map_err(|ExceedsUsizeBoundsError| OutOfBoundsError)? // TODO: this is an assumption that might be unjustified
+        {
+            Nth::FromStart(nth) => self.nth(nth).ok_or(OutOfBoundsError),
+            Nth::FromEnd(nth_rev) => self.rev().nth(nth_rev).ok_or(OutOfBoundsError),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(crate) struct StepSizeZeroError;
+
+pub(crate) trait PySlice {
+    type Item;
+
+    fn py_slice<'a>(
+        &'a mut self,
+        start: Option<i64>,
+        stop: Option<i64>,
+        step: Option<i64>,
+    ) -> Result<Box<dyn Iterator<Item = Self::Item> + 'a>, StepSizeZeroError>
+    where
+        Self::Item: 'a;
+}
+
+impl<I, T> PySlice for T
+where
+    T: DoubleEndedIterator<Item = I> + ExactSizeIterator<Item = I> + Iterator<Item = I>,
+{
+    type Item = I;
+
+    fn py_slice<'a>(
+        &'a mut self,
+        start: Option<i64>,
+        stop: Option<i64>,
+        step_int: Option<i64>,
+    ) -> Result<Box<dyn Iterator<Item = I> + 'a>, StepSizeZeroError>
+    where
+        I: 'a,
+    {
+        let len = self.len();
+
+        if len == 0 {
+            return Ok(Box::new(std::iter::empty()));
+        }
+
+        let step_int = step_int.unwrap_or(1);
+        if step_int == 0 {
+            return Err(StepSizeZeroError);
+        }
+
+        if step_int > 0 {
+            let start = start
+                .map(Nth::from_index)
+                .transpose()
+                .unwrap() // TODO
+                .map(|start| start.to_nonnegative_index(len))
+                .unwrap_or(0)
+                .clamp(0, len);
+            let stop = stop
+                .map(Nth::from_index)
+                .transpose()
+                .unwrap() // TODO
+                .map(|stop| stop.to_nonnegative_index(len))
+                .unwrap_or(len)
+                .clamp(0, len);
+
+            let step = from_nonnegative_i64(step_int).unwrap(); // TODO
+            let (skip, take_n, step) = match start.cmp(&stop) {
+                Ordering::Equal => (start, 0, step),
+                Ordering::Less => (start, stop - start, step),
+                Ordering::Greater => (stop + 1, 0, step),
+            };
+
+            Ok(Box::new(self.skip(skip).take(take_n).step_by(step)))
         } else {
-            let nth_rev = usize::try_from(index.checked_neg()?).ok()?.checked_sub(1)?;
-            self.rev().nth(nth_rev)
+            let start = start
+                .map(Nth::from_index)
+                .transpose()
+                .unwrap() // TODO
+                .map(|start| start.to_nonnegative_index(len))
+                .unwrap_or(len)
+                .clamp(0, len - 1);
+            let stop = stop
+                .map(Nth::from_index)
+                .transpose()
+                .unwrap() // TODO
+                .map(|stop| stop.to_nonnegative_index(len))
+                .map(|index| index.clamp(0, len - 1));
+
+            let step = from_negative_i64(step_int).unwrap(); // TODO
+
+            let (skip, take_n, step) = if let Some(stop) = stop {
+                match start.cmp(&stop) {
+                    Ordering::Equal => (start, 0, step),
+                    Ordering::Less => (len - start, 0, step),
+                    Ordering::Greater => ((len - 1) - start, start - stop, step),
+                }
+            } else {
+                ((len - 1) - start, len, step)
+            };
+
+            Ok(Box::new(self.rev().skip(skip).take(take_n).step_by(step)))
         }
     }
 }
@@ -20,64 +167,310 @@ impl<I, T: DoubleEndedIterator<Item = I>> PythonSubscript for T {
 #[cfg(test)]
 #[allow(clippy::redundant_clone)]
 mod tests {
-    use super::PythonSubscript;
+    use crate::util::subscript::{OutOfBoundsError, StepSizeZeroError};
+
+    use super::{PyIndex, PySlice};
+    use itertools::assert_equal;
 
     #[test]
-    fn python_subscript_basic() {
-        let iter = 'a'..='e';
+    fn py_index_empty() {
+        let iter = std::iter::empty::<char>();
 
-        assert_eq!(iter.clone().python_subscript(0), Some('a'));
-        assert_eq!(iter.clone().python_subscript(1), Some('b'));
-        assert_eq!(iter.clone().python_subscript(4), Some('e'));
-        assert_eq!(iter.clone().python_subscript(5), None);
-
-        assert_eq!(iter.clone().python_subscript(-1), Some('e'));
-        assert_eq!(iter.clone().python_subscript(-2), Some('d'));
-        assert_eq!(iter.clone().python_subscript(-5), Some('a'));
-        assert_eq!(iter.clone().python_subscript(-6), None);
+        assert_eq!(iter.clone().py_index(0), Err(OutOfBoundsError));
+        assert_eq!(iter.clone().py_index(1), Err(OutOfBoundsError));
+        assert_eq!(iter.clone().py_index(-1), Err(OutOfBoundsError));
+        assert_eq!(iter.clone().py_index(i64::MIN), Err(OutOfBoundsError));
+        assert_eq!(iter.clone().py_index(i64::MAX), Err(OutOfBoundsError));
     }
 
     #[test]
-    fn python_subscript_empty() {
-        let iter = 'a'..'a';
+    fn py_index_single_element() {
+        let iter = ['a'].into_iter();
 
-        assert_eq!(iter.clone().python_subscript(0), None);
-        assert_eq!(iter.clone().python_subscript(1), None);
-        assert_eq!(iter.clone().python_subscript(-1), None);
+        assert_eq!(iter.clone().py_index(0), Ok('a'));
+        assert_eq!(iter.clone().py_index(1), Err(OutOfBoundsError));
+        assert_eq!(iter.clone().py_index(-1), Ok('a'));
+        assert_eq!(iter.clone().py_index(-2), Err(OutOfBoundsError));
     }
 
     #[test]
-    fn python_subscript_single_element() {
-        let iter = 'a'..='a';
+    fn py_index_more_elements() {
+        let iter = ['a', 'b', 'c', 'd', 'e'].into_iter();
 
-        assert_eq!(iter.clone().python_subscript(0), Some('a'));
-        assert_eq!(iter.clone().python_subscript(1), None);
-        assert_eq!(iter.clone().python_subscript(-1), Some('a'));
-        assert_eq!(iter.clone().python_subscript(-2), None);
+        assert_eq!(iter.clone().py_index(0), Ok('a'));
+        assert_eq!(iter.clone().py_index(1), Ok('b'));
+        assert_eq!(iter.clone().py_index(4), Ok('e'));
+        assert_eq!(iter.clone().py_index(5), Err(OutOfBoundsError));
+
+        assert_eq!(iter.clone().py_index(-1), Ok('e'));
+        assert_eq!(iter.clone().py_index(-2), Ok('d'));
+        assert_eq!(iter.clone().py_index(-5), Ok('a'));
+        assert_eq!(iter.clone().py_index(-6), Err(OutOfBoundsError));
     }
 
     #[test]
-    fn python_subscript_uses_full_index_range() {
+    fn py_index_uses_full_index_range() {
         let iter = 0..=u64::MAX;
 
-        assert_eq!(iter.clone().python_subscript(0), Some(0));
-        assert_eq!(iter.clone().python_subscript(1), Some(1));
+        // u64::MAX - |i64::MIN| + 1 = 2^64 - 1 - 2^63 + 1 = 2^63
+        assert_eq!(iter.clone().py_index(i64::MIN), Ok(2u64.pow(63)));
+        assert_eq!(iter.clone().py_index(-2), Ok(u64::MAX - 2 + 1));
+        assert_eq!(iter.clone().py_index(-1), Ok(u64::MAX - 1 + 1));
+
+        assert_eq!(iter.clone().py_index(0), Ok(0));
+        assert_eq!(iter.clone().py_index(1), Ok(1));
+        assert_eq!(iter.clone().py_index(i64::MAX), Ok(i64::MAX as u64));
+    }
+
+    #[cfg(target_pointer_width = "32")]
+    #[test]
+    fn py_index_uses_full_index_range_32bit() {
+        let iter = 0..=u64::MAX;
+
         assert_eq!(
-            iter.clone().python_subscript(i64::MAX),
-            Some(i64::MAX as u64)
+            iter.clone().py_index(i64::MAX),
+            Err(OutOfBoundsError::ExceedsUsizeBounds)
         );
-
-        assert_eq!(iter.clone().python_subscript(-1), Some(u64::MAX));
-        assert_eq!(iter.clone().python_subscript(-2), Some(u64::MAX - 1));
-
-        // i64::MIN is not representable as a positive number, so it is not
-        // a valid index:
-        assert_eq!(iter.clone().python_subscript(i64::MIN), None);
-
-        // but i64::MIN +1 is:
         assert_eq!(
-            iter.clone().python_subscript(i64::MIN + 1),
-            Some(2u64.pow(63) + 1)
+            iter.clone().py_index(i64::MIN),
+            Err(OutOfBoundsError::ExceedsUsizeBounds)
         );
+    }
+
+    #[track_caller]
+    fn assert_eq_slice<const N: usize, const M: usize>(
+        input: &[char; N],
+        start: Option<i64>,
+        stop: Option<i64>,
+        step: Option<i64>,
+        expected: &[char; M],
+    ) {
+        assert_equal(
+            input.iter().py_slice(start, stop, step).unwrap(),
+            expected.iter(),
+        );
+    }
+
+    #[track_caller]
+    fn assert_slice_returns_none<const N: usize>(
+        input: &[char; N],
+        start: Option<i64>,
+        stop: Option<i64>,
+        step: Option<i64>,
+    ) {
+        assert!(matches!(
+            input.iter().py_slice(start, stop, step),
+            Err(StepSizeZeroError)
+        ));
+    }
+
+    #[test]
+    fn py_slice_empty_input() {
+        let input = [];
+
+        assert_eq_slice(&input, None, None, None, &[]);
+        assert_eq_slice(&input, Some(0), None, None, &[]);
+        assert_eq_slice(&input, None, Some(0), None, &[]);
+        assert_eq_slice(&input, Some(0), Some(0), None, &[]);
+        assert_eq_slice(&input, Some(-5), Some(-5), None, &[]);
+        assert_eq_slice(&input, None, None, Some(-1), &[]);
+        assert_eq_slice(&input, None, None, Some(2), &[]);
+    }
+
+    #[test]
+    fn py_slice_single_element_input() {
+        let input = ['a'];
+
+        assert_eq_slice(&input, None, None, None, &['a']);
+
+        assert_eq_slice(&input, Some(0), None, None, &['a']);
+        assert_eq_slice(&input, None, Some(0), None, &[]);
+        assert_eq_slice(&input, Some(0), Some(0), None, &[]);
+        assert_eq_slice(&input, Some(0), Some(1), None, &['a']);
+        assert_eq_slice(&input, Some(0), Some(2), None, &['a']);
+
+        assert_eq_slice(&input, Some(-1), None, None, &['a']);
+        assert_eq_slice(&input, Some(-1), Some(-1), None, &[]);
+        assert_eq_slice(&input, Some(-1), Some(0), None, &[]);
+        assert_eq_slice(&input, Some(-1), Some(1), None, &['a']);
+        assert_eq_slice(&input, Some(-1), Some(2), None, &['a']);
+        assert_eq_slice(&input, None, Some(-1), None, &[]);
+
+        assert_eq_slice(&input, Some(-2), None, None, &['a']);
+        assert_eq_slice(&input, Some(-2), Some(-1), None, &[]);
+        assert_eq_slice(&input, Some(-2), Some(0), None, &[]);
+        assert_eq_slice(&input, Some(-2), Some(1), None, &['a']);
+        assert_eq_slice(&input, Some(-2), Some(2), None, &['a']);
+    }
+
+    #[test]
+    fn py_slice_nonnegative_indices() {
+        let input = ['a', 'b', 'c', 'd', 'e'];
+
+        assert_eq_slice(&input, None, Some(0), None, &[]);
+        assert_eq_slice(&input, None, Some(1), None, &['a']);
+        assert_eq_slice(&input, None, Some(4), None, &['a', 'b', 'c', 'd']);
+        assert_eq_slice(&input, None, Some(5), None, &['a', 'b', 'c', 'd', 'e']);
+        assert_eq_slice(&input, None, Some(6), None, &['a', 'b', 'c', 'd', 'e']);
+        assert_eq_slice(&input, None, None, None, &['a', 'b', 'c', 'd', 'e']);
+
+        assert_eq_slice(&input, Some(0), Some(0), None, &[]);
+        assert_eq_slice(&input, Some(0), Some(1), None, &['a']);
+        assert_eq_slice(&input, Some(0), Some(4), None, &['a', 'b', 'c', 'd']);
+        assert_eq_slice(&input, Some(0), Some(5), None, &['a', 'b', 'c', 'd', 'e']);
+        assert_eq_slice(&input, Some(0), Some(6), None, &['a', 'b', 'c', 'd', 'e']);
+        assert_eq_slice(&input, Some(0), None, None, &['a', 'b', 'c', 'd', 'e']);
+
+        assert_eq_slice(&input, Some(1), Some(0), None, &[]);
+        assert_eq_slice(&input, Some(1), Some(1), None, &[]);
+        assert_eq_slice(&input, Some(1), Some(2), None, &['b']);
+        assert_eq_slice(&input, Some(1), Some(4), None, &['b', 'c', 'd']);
+        assert_eq_slice(&input, Some(1), Some(5), None, &['b', 'c', 'd', 'e']);
+        assert_eq_slice(&input, Some(1), Some(6), None, &['b', 'c', 'd', 'e']);
+        assert_eq_slice(&input, Some(1), None, None, &['b', 'c', 'd', 'e']);
+
+        assert_eq_slice(&input, Some(4), Some(0), None, &[]);
+        assert_eq_slice(&input, Some(4), Some(4), None, &[]);
+        assert_eq_slice(&input, Some(4), Some(5), None, &['e']);
+        assert_eq_slice(&input, Some(4), Some(6), None, &['e']);
+        assert_eq_slice(&input, Some(4), None, None, &['e']);
+
+        assert_eq_slice(&input, Some(5), Some(0), None, &[]);
+        assert_eq_slice(&input, Some(5), Some(5), None, &[]);
+        assert_eq_slice(&input, Some(5), Some(6), None, &[]);
+        assert_eq_slice(&input, Some(5), None, None, &[]);
+
+        assert_eq_slice(&input, Some(6), Some(0), None, &[]);
+        assert_eq_slice(&input, Some(6), Some(6), None, &[]);
+        assert_eq_slice(&input, Some(6), None, None, &[]);
+    }
+
+    #[test]
+    fn py_slice_negatice_indices() {
+        let input = ['a', 'b', 'c', 'd', 'e'];
+
+        assert_eq_slice(&input, Some(-6), None, None, &['a', 'b', 'c', 'd', 'e']);
+        assert_eq_slice(&input, Some(-6), Some(-1), None, &['a', 'b', 'c', 'd']);
+        assert_eq_slice(&input, Some(-6), Some(-4), None, &['a']);
+        assert_eq_slice(&input, Some(-6), Some(-5), None, &[]);
+        assert_eq_slice(&input, Some(-6), Some(-6), None, &[]);
+        assert_eq_slice(&input, Some(-6), Some(-10), None, &[]);
+
+        assert_eq_slice(&input, Some(-5), None, None, &['a', 'b', 'c', 'd', 'e']);
+        assert_eq_slice(&input, Some(-5), Some(-1), None, &['a', 'b', 'c', 'd']);
+        assert_eq_slice(&input, Some(-5), Some(-4), None, &['a']);
+        assert_eq_slice(&input, Some(-5), Some(-5), None, &[]);
+        assert_eq_slice(&input, Some(-5), Some(-6), None, &[]);
+        assert_eq_slice(&input, Some(-5), Some(-10), None, &[]);
+
+        assert_eq_slice(&input, Some(-4), None, None, &['b', 'c', 'd', 'e']);
+        assert_eq_slice(&input, Some(-4), Some(-1), None, &['b', 'c', 'd']);
+        assert_eq_slice(&input, Some(-4), Some(-3), None, &['b']);
+        assert_eq_slice(&input, Some(-4), Some(-4), None, &[]);
+        assert_eq_slice(&input, Some(-4), Some(-10), None, &[]);
+
+        assert_eq_slice(&input, Some(-1), None, None, &['e']);
+        assert_eq_slice(&input, Some(-1), Some(-1), None, &[]);
+        assert_eq_slice(&input, Some(-1), Some(-10), None, &[]);
+
+        assert_eq_slice(&input, None, Some(-1), None, &['a', 'b', 'c', 'd']);
+        assert_eq_slice(&input, None, Some(-4), None, &['a']);
+        assert_eq_slice(&input, None, Some(-5), None, &[]);
+        assert_eq_slice(&input, None, Some(-6), None, &[]);
+    }
+
+    #[test]
+    fn py_slice_mixed_positive_negative_indices() {
+        let input = ['a', 'b', 'c', 'd', 'e'];
+
+        assert_eq_slice(&input, Some(0), Some(-1), None, &['a', 'b', 'c', 'd']);
+        assert_eq_slice(&input, Some(1), Some(-1), None, &['b', 'c', 'd']);
+        assert_eq_slice(&input, Some(3), Some(-1), None, &['d']);
+        assert_eq_slice(&input, Some(4), Some(-1), None, &[]);
+        assert_eq_slice(&input, Some(5), Some(-1), None, &[]);
+
+        assert_eq_slice(&input, Some(0), Some(-4), None, &['a']);
+        assert_eq_slice(&input, Some(1), Some(-4), None, &[]);
+        assert_eq_slice(&input, Some(3), Some(-4), None, &[]);
+
+        assert_eq_slice(&input, Some(0), Some(-5), None, &[]);
+        assert_eq_slice(&input, Some(1), Some(-5), None, &[]);
+        assert_eq_slice(&input, Some(3), Some(-5), None, &[]);
+
+        assert_eq_slice(&input, Some(0), Some(-6), None, &[]);
+        assert_eq_slice(&input, Some(1), Some(-6), None, &[]);
+
+        assert_eq_slice(&input, Some(-6), Some(6), None, &['a', 'b', 'c', 'd', 'e']);
+        assert_eq_slice(&input, Some(-6), Some(5), None, &['a', 'b', 'c', 'd', 'e']);
+        assert_eq_slice(&input, Some(-6), Some(4), None, &['a', 'b', 'c', 'd']);
+        assert_eq_slice(&input, Some(-6), Some(1), None, &['a']);
+        assert_eq_slice(&input, Some(-6), Some(0), None, &[]);
+
+        assert_eq_slice(&input, Some(-5), Some(6), None, &['a', 'b', 'c', 'd', 'e']);
+        assert_eq_slice(&input, Some(-5), Some(5), None, &['a', 'b', 'c', 'd', 'e']);
+        assert_eq_slice(&input, Some(-5), Some(4), None, &['a', 'b', 'c', 'd']);
+        assert_eq_slice(&input, Some(-5), Some(1), None, &['a']);
+        assert_eq_slice(&input, Some(-5), Some(0), None, &[]);
+
+        assert_eq_slice(&input, Some(-4), Some(6), None, &['b', 'c', 'd', 'e']);
+        assert_eq_slice(&input, Some(-4), Some(5), None, &['b', 'c', 'd', 'e']);
+        assert_eq_slice(&input, Some(-4), Some(4), None, &['b', 'c', 'd']);
+        assert_eq_slice(&input, Some(-4), Some(2), None, &['b']);
+        assert_eq_slice(&input, Some(-4), Some(1), None, &[]);
+        assert_eq_slice(&input, Some(-4), Some(0), None, &[]);
+
+        assert_eq_slice(&input, Some(-1), Some(6), None, &['e']);
+        assert_eq_slice(&input, Some(-1), Some(5), None, &['e']);
+        assert_eq_slice(&input, Some(-1), Some(4), None, &[]);
+        assert_eq_slice(&input, Some(-1), Some(1), None, &[]);
+    }
+
+    #[test]
+    fn py_slice_step_forward() {
+        // indices:   0    1    2    3    4    5    6
+        let input = ['a', 'b', 'c', 'd', 'e', 'f', 'g'];
+
+        // Step size zero is invalid:
+        assert_slice_returns_none(&input, Some(0), Some(5), Some(0));
+        assert_slice_returns_none(&input, Some(0), Some(0), Some(0));
+
+        assert_eq_slice(&input, Some(0), Some(8), Some(2), &['a', 'c', 'e', 'g']);
+        assert_eq_slice(&input, Some(0), Some(7), Some(2), &['a', 'c', 'e', 'g']);
+        assert_eq_slice(&input, Some(0), Some(6), Some(2), &['a', 'c', 'e']);
+        assert_eq_slice(&input, Some(0), Some(5), Some(2), &['a', 'c', 'e']);
+        assert_eq_slice(&input, Some(0), Some(4), Some(2), &['a', 'c']);
+        assert_eq_slice(&input, Some(0), Some(3), Some(2), &['a', 'c']);
+        assert_eq_slice(&input, Some(0), Some(2), Some(2), &['a']);
+        assert_eq_slice(&input, Some(0), Some(1), Some(2), &['a']);
+        assert_eq_slice(&input, Some(0), Some(0), Some(2), &[]);
+        assert_eq_slice(&input, Some(1), Some(5), Some(2), &['b', 'd']);
+
+        assert_eq_slice(&input, Some(0), Some(7), Some(3), &['a', 'd', 'g']);
+        assert_eq_slice(&input, Some(0), Some(6), Some(3), &['a', 'd']);
+    }
+
+    #[test]
+    fn py_slice_step_backward() {
+        // indices:   0    1    2    3    4    5    6
+        let input = ['a', 'b', 'c', 'd', 'e', 'f', 'g'];
+
+        assert_eq_slice(&input, Some(7), Some(0), Some(-2), &['g', 'e', 'c']);
+        assert_eq_slice(&input, Some(6), Some(0), Some(-2), &['g', 'e', 'c']);
+        assert_eq_slice(&input, Some(5), Some(0), Some(-2), &['f', 'd', 'b']);
+        assert_eq_slice(&input, Some(4), Some(0), Some(-2), &['e', 'c']);
+        assert_eq_slice(&input, Some(3), Some(0), Some(-2), &['d', 'b']);
+        assert_eq_slice(&input, Some(2), Some(0), Some(-2), &['c']);
+        assert_eq_slice(&input, Some(1), Some(0), Some(-2), &['b']);
+        assert_eq_slice(&input, Some(0), Some(0), Some(-2), &[]);
+
+        assert_eq_slice(&input, Some(7), None, Some(-2), &['g', 'e', 'c', 'a']);
+        assert_eq_slice(&input, None, None, Some(-2), &['g', 'e', 'c', 'a']);
+        assert_eq_slice(&input, None, Some(0), Some(-2), &['g', 'e', 'c']);
+
+        assert_eq_slice(&input, Some(5), Some(1), Some(-2), &['f', 'd']);
+        assert_eq_slice(&input, Some(5), Some(2), Some(-2), &['f', 'd']);
+        assert_eq_slice(&input, Some(5), Some(3), Some(-2), &['f']);
+        assert_eq_slice(&input, Some(5), Some(4), Some(-2), &['f']);
+        assert_eq_slice(&input, Some(5), Some(5), Some(-2), &[]);
     }
 }


### PR DESCRIPTION
## Summary

- Add a new `Type::SliceLiteral` variant
- Infer `SliceLiteral` types for slice expressions, such as `<int-literal>:<int-literal>:<int-literal>`.
- Infer "sliced" literal types for subscript expressions using slices, such as `<string-literal>[<slice-literal>]`.
- Infer types for expressions involving slices of tuples: `<tuple>[<slice-literal>]`.

closes #13853

## Eye candy

```py
t = (1, (), True, "a", None, b"b")

reveal_type(t[-2::-2])  # revealed: tuple[None, Literal[True], Literal[1]]
```

## Test Plan

- Unit tests for indexing/slicing utility functions
- Markdown-based tests for
  - Subscript expressions `tuple[slice]`
  - Subscript expressions `string_literal[slice]`
  - Subscript expressions `bytes_literal[slice]`