### PR TITLE
Enable nursery rules: 'redundant_clone', 'debug_assert_with_mut_call', and 'unused_peekable'

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -202,6 +202,10 @@ get_unwrap = "warn"
 rc_buffer = "warn"
 rc_mutex = "warn"
 rest_pat_in_fully_bound_structs = "warn"
+# nursery rules
+redundant_clone = "warn"
+debug_assert_with_mut_call = "warn"
+unused_peekable = "warn"
 
 [profile.release]
 # Note that we set these explicitly, and these values

--- a/crates/red_knot/src/main.rs
+++ b/crates/red_knot/src/main.rs
@@ -144,7 +144,7 @@ pub fn main() -> ExitStatus {
 }
 
 fn run() -> anyhow::Result<ExitStatus> {
-    let args = Args::parse_from(std::env::args().collect::<Vec<_>>());
+    let args = Args::parse_from(std::env::args());
 
     if matches!(args.command, Some(Command::Server)) {
         return run_server().map(|()| ExitStatus::Success);

--- a/crates/red_knot_python_semantic/src/ast_node_ref.rs
+++ b/crates/red_knot_python_semantic/src/ast_node_ref.rs
@@ -132,7 +132,7 @@ mod tests {
     #[test]
     fn inequality() {
         let parsed_raw = parse_unchecked_source("1 + 2", PySourceType::Python);
-        let parsed = ParsedModule::new(parsed_raw.clone());
+        let parsed = ParsedModule::new(parsed_raw);
 
         let stmt = &parsed.syntax().body[0];
         let node = unsafe { AstNodeRef::new(parsed.clone(), stmt) };
@@ -150,7 +150,7 @@ mod tests {
     #[allow(unsafe_code)]
     fn debug() {
         let parsed_raw = parse_unchecked_source("1 + 2", PySourceType::Python);
-        let parsed = ParsedModule::new(parsed_raw.clone());
+        let parsed = ParsedModule::new(parsed_raw);
 
         let stmt = &parsed.syntax().body[0];
 

--- a/crates/red_knot_python_semantic/src/module_resolver/resolver.rs
+++ b/crates/red_knot_python_semantic/src/module_resolver/resolver.rs
@@ -1294,7 +1294,7 @@ mod tests {
                 search_paths: SearchPathSettings {
                     extra_paths: vec![],
                     src_root: src.clone(),
-                    custom_typeshed: Some(custom_typeshed.clone()),
+                    custom_typeshed: Some(custom_typeshed),
                     site_packages: SitePackages::Known(vec![site_packages]),
                 },
             },
@@ -1445,7 +1445,7 @@ mod tests {
         assert_function_query_was_not_run(
             &db,
             resolve_module_query,
-            ModuleNameIngredient::new(&db, functools_module_name.clone()),
+            ModuleNameIngredient::new(&db, functools_module_name),
             &events,
         );
         assert_eq!(functools_module.search_path(), &stdlib);

--- a/crates/red_knot_python_semantic/src/semantic_index/definition.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/definition.rs
@@ -296,7 +296,7 @@ impl DefinitionNodeRef<'_> {
                 handler,
                 is_star,
             }) => DefinitionKind::ExceptHandler(ExceptHandlerDefinitionKind {
-                handler: AstNodeRef::new(parsed.clone(), handler),
+                handler: AstNodeRef::new(parsed, handler),
                 is_star,
             }),
         }

--- a/crates/red_knot_python_semantic/src/util/subscript.rs
+++ b/crates/red_knot_python_semantic/src/util/subscript.rs
@@ -18,6 +18,7 @@ impl<I, T: DoubleEndedIterator<Item = I>> PythonSubscript for T {
 }
 
 #[cfg(test)]
+#[allow(clippy::redundant_clone)]
 mod tests {
     use super::PythonSubscript;
 

--- a/crates/red_knot_server/src/server/api/notifications/did_open_notebook.rs
+++ b/crates/red_knot_server/src/server/api/notifications/did_open_notebook.rs
@@ -37,7 +37,7 @@ impl SyncNotificationHandler for DidOpenNotebookHandler {
             params.cell_text_documents,
         )
         .with_failure_code(ErrorCode::InternalError)?;
-        session.open_notebook_document(params.notebook_document.uri.clone(), notebook);
+        session.open_notebook_document(params.notebook_document.uri, notebook);
 
         match path {
             AnySystemPath::System(path) => {

--- a/crates/red_knot_wasm/src/lib.rs
+++ b/crates/red_knot_wasm/src/lib.rs
@@ -110,14 +110,14 @@ impl Workspace {
     pub fn check_file(&self, file_id: &FileHandle) -> Result<Vec<String>, Error> {
         let result = self.db.check_file(file_id.file).map_err(into_error)?;
 
-        Ok(result.clone())
+        Ok(result)
     }
 
     /// Checks all open files
     pub fn check(&self) -> Result<Vec<String>, Error> {
         let result = self.db.check().map_err(into_error)?;
 
-        Ok(result.clone())
+        Ok(result)
     }
 
     /// Returns the parsed AST for `path`

--- a/crates/ruff_linter/src/rules/eradicate/rules/commented_out_code.rs
+++ b/crates/ruff_linter/src/rules/eradicate/rules/commented_out_code.rs
@@ -88,7 +88,7 @@ where
     let line_end = locator.full_line_end(script_start.end());
     let rest = locator.after(line_end);
     let mut end_offset = None;
-    let mut lines = UniversalNewlineIterator::with_offset(rest, line_end).peekable();
+    let mut lines = UniversalNewlineIterator::with_offset(rest, line_end);
 
     while let Some(line) = lines.next() {
         let Some(content) = script_line_content(&line) else {

--- a/crates/ruff_linter/src/rules/pydocstyle/rules/sections.rs
+++ b/crates/ruff_linter/src/rules/pydocstyle/rules/sections.rs
@@ -1850,7 +1850,7 @@ static GOOGLE_ARGS_REGEX: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"^\s*(\*?\*?\w+)\s*(\(.*?\))?\s*:(\r\n|\n)?\s*.+").unwrap());
 
 fn args_section(context: &SectionContext) -> FxHashSet<String> {
-    let mut following_lines = context.following_lines().peekable();
+    let mut following_lines = context.following_lines();
     let Some(first_line) = following_lines.next() else {
         return FxHashSet::default();
     };

--- a/crates/ruff_linter/src/rules/ruff/rules/test_rules.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/test_rules.rs
@@ -122,10 +122,7 @@ impl TestRule for StableTestRuleSafeFix {
         } else {
             Some(
                 Diagnostic::new(StableTestRuleSafeFix, ruff_text_size::TextRange::default())
-                    .with_fix(Fix::safe_edit(Edit::insertion(
-                        comment.to_string(),
-                        TextSize::new(0),
-                    ))),
+                    .with_fix(Fix::safe_edit(Edit::insertion(comment, TextSize::new(0)))),
             )
         }
     }
@@ -169,10 +166,7 @@ impl TestRule for StableTestRuleUnsafeFix {
                     StableTestRuleUnsafeFix,
                     ruff_text_size::TextRange::default(),
                 )
-                .with_fix(Fix::unsafe_edit(Edit::insertion(
-                    comment.to_string(),
-                    TextSize::new(0),
-                ))),
+                .with_fix(Fix::unsafe_edit(Edit::insertion(comment, TextSize::new(0)))),
             )
         }
     }
@@ -217,7 +211,7 @@ impl TestRule for StableTestRuleDisplayOnlyFix {
                     ruff_text_size::TextRange::default(),
                 )
                 .with_fix(Fix::display_only_edit(Edit::insertion(
-                    comment.to_string(),
+                    comment,
                     TextSize::new(0),
                 ))),
             )

--- a/crates/ruff_macros/src/config.rs
+++ b/crates/ruff_macros/src/config.rs
@@ -60,15 +60,13 @@ pub(crate) fn derive_impl(input: DeriveInput) -> syn::Result<TokenStream> {
                 }
             }
 
-            let docs: Vec<&Attribute> = struct_attributes
+            let docs = struct_attributes
                 .iter()
-                .filter(|attr| attr.path().is_ident("doc"))
-                .collect();
+                .filter(|attr| attr.path().is_ident("doc"));
 
             // Convert the list of `doc` attributes into a single string.
             let doc = dedent(
                 &docs
-                    .into_iter()
                     .map(parse_doc)
                     .collect::<syn::Result<Vec<_>>>()?
                     .join("\n"),

--- a/crates/ruff_python_trivia/src/tokenizer.rs
+++ b/crates/ruff_python_trivia/src/tokenizer.rs
@@ -30,7 +30,10 @@ pub fn find_only_token_in_range(
     let token = tokens.next().expect("Expected a token");
     debug_assert_eq!(token.kind(), token_kind);
     let mut tokens = tokens.skip_while(|token| token.kind == SimpleTokenKind::LParen);
-    debug_assert_eq!(tokens.next(), None);
+    #[allow(clippy::debug_assert_with_mut_call)]
+    {
+        debug_assert_eq!(tokens.next(), None);
+    }
     token
 }
 

--- a/crates/ruff_server/tests/notebook.rs
+++ b/crates/ruff_server/tests/notebook.rs
@@ -298,7 +298,7 @@ fn super_resolution_overview() {
             .unwrap();
     }
 
-    let snapshot = session.take_snapshot(file_url.clone()).unwrap();
+    let snapshot = session.take_snapshot(file_url).unwrap();
 
     insta::assert_snapshot!(
         "changed_notebook",

--- a/crates/ruff_workspace/src/configuration.rs
+++ b/crates/ruff_workspace/src/configuration.rs
@@ -2029,11 +2029,11 @@ mod tests {
         assert_override(
             vec![
                 RuleSelection {
-                    select: Some(vec![d417.clone()]),
+                    select: Some(vec![d417]),
                     ..RuleSelection::default()
                 },
                 RuleSelection {
-                    extend_select: vec![d41.clone()],
+                    extend_select: vec![d41],
                     ..RuleSelection::default()
                 },
             ],


### PR DESCRIPTION
## Summary

This PR makes clippy more pedantic ;) 

It enables three more clippy rules that capture code patterns that caused bugs in the past or that I noticed during code reviews:

* `redundant_clone`: It's easy to needlessly clone a value and this has come up in reviews. 
* `debug_assert_with_mut_call`: A first version of red knot contained debug asserts with mut calls and it broke downstream packaging because some of them ran our tests in release mode. This has also come up in contributions where it was unclear why the benchmark failed but all tests pass.
* `unused_peekable`: It's so easy to forget removing the `.peekable` call

## Test Plan

`cargo test`
