### PR TITLE
[red-knot] knot benchmark: fix `--knot-path` arg

### DIFF
--- a/scripts/knot_benchmark/src/benchmark/cases.py
+++ b/scripts/knot_benchmark/src/benchmark/cases.py
@@ -154,12 +154,12 @@ class Venv:
         self.path = path
 
     @property
-    def name(self):
+    def name(self) -> str:
         """The name of the virtual environment directory."""
         return self.path.name
 
     @property
-    def python(self):
+    def python(self) -> Path:
         """Returns the path to the python executable"""
         return self.script("python")
 
@@ -193,7 +193,7 @@ class Venv:
         root = parent / "venv"
         return Venv(root)
 
-    def install(self, dependencies: list[str]):
+    def install(self, dependencies: list[str]) -> None:
         """Installs the dependencies required to type check the project."""
 
         logging.debug(f"Installing dependencies: {', '.join(dependencies)}")
@@ -202,7 +202,7 @@ class Venv:
             "pip",
             "install",
             "--python",
-            self.python,
+            self.python.as_posix(),
             "--quiet",
             # We pass `--exclude-newer` to ensure that type-checking of one of
             # our projects isn't unexpectedly broken by a change in the

--- a/scripts/knot_benchmark/src/benchmark/projects.py
+++ b/scripts/knot_benchmark/src/benchmark/projects.py
@@ -1,5 +1,4 @@
 import logging
-import os
 import subprocess
 import typing
 from pathlib import Path
@@ -30,9 +29,9 @@ class Project(typing.NamedTuple):
     mypy_arguments: list[str] | None = None
     """The arguments passed to mypy. Overrides `include` if set."""
 
-    def clone(self, checkout_dir: Path):
+    def clone(self, checkout_dir: Path) -> None:
         # Skip cloning if the project has already been cloned (the script doesn't yet support updating)
-        if os.path.exists(os.path.join(checkout_dir, ".git")):
+        if (checkout_dir / ".git").exists():
             return
 
         logging.debug(f"Cloning {self.repository} to {checkout_dir}")

--- a/scripts/knot_benchmark/src/benchmark/run.py
+++ b/scripts/knot_benchmark/src/benchmark/run.py
@@ -16,7 +16,7 @@ if typing.TYPE_CHECKING:
     from benchmark.cases import Tool
 
 
-def main():
+def main() -> None:
     """Run the benchmark."""
     parser = argparse.ArgumentParser(
         description="Benchmark knot against other packaging tools."
@@ -69,7 +69,7 @@ def main():
     )
     parser.add_argument(
         "--knot-path",
-        type=str,
+        type=Path,
         help="Path(s) to the red_knot binary to benchmark.",
         action="append",
     )
@@ -116,8 +116,8 @@ def main():
     ]
 
     for project in projects:
-        with tempfile.TemporaryDirectory() as cwd:
-            cwd = Path(cwd)
+        with tempfile.TemporaryDirectory() as tempdir:
+            cwd = Path(tempdir)
             project.clone(cwd)
 
             venv = Venv.create(cwd)


### PR DESCRIPTION
## Summary

Previously, this would fail with

```
AttributeError: 'str' object has no attribute 'is_file'
```

if I tried to use the `--knot-path` option. I wish we had a type checker for Python*.

## Test Plan

```sh
uv run benchmark --knot-path ~/.cargo-target/release/red_knot
```

\* to be fair, this would probably require special handling for `argparse` in the typechecker.