### PR TITLE
Disallow single-line implicit concatenated strings

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/string.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/string.py
@@ -138,3 +138,60 @@ a = f"""\x1F"""
 a = """\x1F"""
 a = """\\x1F"""
 a = """\\\x1F"""
+
+
+##############################################################################
+# Implicit concatenated strings
+##############################################################################
+
+# In preview, don't collapse implicit concatenated strings that can't be joined into a single string
+# and that are multiline in the source.
+
+(
+    r"aaaaaaaaa"
+    r"bbbbbbbbbbbbbbbbbbbb"
+)
+
+(
+    r"aaaaaaaaa" r"bbbbbbbbbbbbbbbbbbbb"
+    "cccccccccccccccccccccc"
+)
+
+(
+    """aaaaaaaaa"""
+    """bbbbbbbbbbbbbbbbbbbb"""
+)
+
+(
+    f"""aaaa{
+    10}aaaaa"""
+    fr"""bbbbbbbbbbbbbbbbbbbb"""
+)
+
+if (
+       r"aaaaaaaaa"
+       r"bbbbbbbbbbbbbbbbbbbb"
+   ) + ["aaaaaaaaaa", "bbbbbbbbbbbbbbbb"]: ...
+
+
+
+# In preview, keep implicit concatenated strings on a single line if they fit and are not separate by line breaks in the source
+(
+    r"aaaaaaaaa" r"bbbbbbbbbbbbbbbbbbbb"
+)
+
+r"aaaaaaaaa" r"bbbbbbbbbbbbbbbbbbbb"
+
+(
+    f"aaaa{
+    10}aaaaa" fr"bbbbbbbbbbbbbbbbbbbb"
+)
+
+(
+    r"""aaaaaaaaa""" r"""bbbbbbbbbbbbbbbbbbbb"""
+)
+
+(
+    f"""aaaa{
+    10}aaaaa""" fr"""bbbbbbbbbbbbbbbbbbbb"""
+)

--- a/crates/ruff_python_formatter/src/statement/stmt_assign.rs
+++ b/crates/ruff_python_formatter/src/statement/stmt_assign.rs
@@ -20,6 +20,7 @@ use crate::preview::is_join_implicit_concatenated_string_enabled;
 use crate::statement::trailing_semicolon;
 use crate::string::implicit::{
     FormatImplicitConcatenatedStringExpanded, FormatImplicitConcatenatedStringFlat,
+    ImplicitConcatenatedLayout,
 };
 use crate::{has_skip_comment, prelude::*};
 
@@ -375,7 +376,13 @@ impl Format<PyFormatContext<'_>> for FormatStatementsLastExpression<'_> {
                             let f =
                                 &mut WithNodeLevel::new(NodeLevel::Expression(Some(group_id)), f);
 
-                            write!(f, [FormatImplicitConcatenatedStringExpanded::new(string)])
+                            write!(
+                                f,
+                                [FormatImplicitConcatenatedStringExpanded::new(
+                                    string,
+                                    ImplicitConcatenatedLayout::MaybeFlat
+                                )]
+                            )
                         });
 
                         // Join the implicit concatenated string if it fits on a single line
@@ -686,6 +693,7 @@ impl Format<PyFormatContext<'_>> for FormatStatementsLastExpression<'_> {
 
                         FormatImplicitConcatenatedStringExpanded::new(
                             StringLike::try_from(*value).unwrap(),
+                            ImplicitConcatenatedLayout::MaybeFlat,
                         )
                         .fmt(f)
                     })

--- a/crates/ruff_python_formatter/tests/snapshots/black_compatibility@cases__long_strings_flag_disabled.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/black_compatibility@cases__long_strings_flag_disabled.py.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/ruff_python_formatter/tests/fixtures.rs
 input_file: crates/ruff_python_formatter/resources/test/fixtures/black/cases/long_strings_flag_disabled.py
+snapshot_kind: text
 ---
 ## Input
 

--- a/crates/ruff_python_formatter/tests/snapshots/black_compatibility@cases__preview_long_strings.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/black_compatibility@cases__preview_long_strings.py.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/ruff_python_formatter/tests/fixtures.rs
 input_file: crates/ruff_python_formatter/resources/test/fixtures/black/cases/preview_long_strings.py
+snapshot_kind: text
 ---
 ## Input
 

--- a/crates/ruff_python_formatter/tests/snapshots/black_compatibility@cases__preview_long_strings__regression.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/black_compatibility@cases__preview_long_strings__regression.py.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/ruff_python_formatter/tests/fixtures.rs
 input_file: crates/ruff_python_formatter/resources/test/fixtures/black/cases/preview_long_strings__regression.py
+snapshot_kind: text
 ---
 ## Input
 

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__fstring.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__fstring.py.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/ruff_python_formatter/tests/fixtures.rs
 input_file: crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/fstring.py
+snapshot_kind: text
 ---
 ## Input
 ```python

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__string.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__string.py.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/ruff_python_formatter/tests/fixtures.rs
 input_file: crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/string.py
+snapshot_kind: text
 ---
 ## Input
 ```python
@@ -144,6 +145,63 @@ a = f"""\x1F"""
 a = """\x1F"""
 a = """\\x1F"""
 a = """\\\x1F"""
+
+
+##############################################################################
+# Implicit concatenated strings
+##############################################################################
+
+# In preview, don't collapse implicit concatenated strings that can't be joined into a single string
+# and that are multiline in the source.
+
+(
+    r"aaaaaaaaa"
+    r"bbbbbbbbbbbbbbbbbbbb"
+)
+
+(
+    r"aaaaaaaaa" r"bbbbbbbbbbbbbbbbbbbb"
+    "cccccccccccccccccccccc"
+)
+
+(
+    """aaaaaaaaa"""
+    """bbbbbbbbbbbbbbbbbbbb"""
+)
+
+(
+    f"""aaaa{
+    10}aaaaa"""
+    fr"""bbbbbbbbbbbbbbbbbbbb"""
+)
+
+if (
+       r"aaaaaaaaa"
+       r"bbbbbbbbbbbbbbbbbbbb"
+   ) + ["aaaaaaaaaa", "bbbbbbbbbbbbbbbb"]: ...
+
+
+
+# In preview, keep implicit concatenated strings on a single line if they fit and are not separate by line breaks in the source
+(
+    r"aaaaaaaaa" r"bbbbbbbbbbbbbbbbbbbb"
+)
+
+r"aaaaaaaaa" r"bbbbbbbbbbbbbbbbbbbb"
+
+(
+    f"aaaa{
+    10}aaaaa" fr"bbbbbbbbbbbbbbbbbbbb"
+)
+
+(
+    r"""aaaaaaaaa""" r"""bbbbbbbbbbbbbbbbbbbb"""
+)
+
+(
+    f"""aaaa{
+    10}aaaaa""" fr"""bbbbbbbbbbbbbbbbbbbb"""
+)
 ```
 
 ## Outputs
@@ -328,6 +386,49 @@ a = f"""\x1f"""
 a = """\x1f"""
 a = """\\x1F"""
 a = """\\\x1f"""
+
+
+##############################################################################
+# Implicit concatenated strings
+##############################################################################
+
+# In preview, don't collapse implicit concatenated strings that can't be joined into a single string
+# and that are multiline in the source.
+
+(r"aaaaaaaaa" r"bbbbbbbbbbbbbbbbbbbb")
+
+(r"aaaaaaaaa" r"bbbbbbbbbbbbbbbbbbbb" "cccccccccccccccccccccc")
+
+("""aaaaaaaaa""" """bbbbbbbbbbbbbbbbbbbb""")
+
+(
+    f"""aaaa{
+    10}aaaaa"""
+    rf"""bbbbbbbbbbbbbbbbbbbb"""
+)
+
+if (r"aaaaaaaaa" r"bbbbbbbbbbbbbbbbbbbb") + ["aaaaaaaaaa", "bbbbbbbbbbbbbbbb"]:
+    ...
+
+
+# In preview, keep implicit concatenated strings on a single line if they fit and are not separate by line breaks in the source
+(r"aaaaaaaaa" r"bbbbbbbbbbbbbbbbbbbb")
+
+r"aaaaaaaaa" r"bbbbbbbbbbbbbbbbbbbb"
+
+(
+    f"aaaa{
+    10}aaaaa"
+    rf"bbbbbbbbbbbbbbbbbbbb"
+)
+
+(r"""aaaaaaaaa""" r"""bbbbbbbbbbbbbbbbbbbb""")
+
+(
+    f"""aaaa{
+    10}aaaaa"""
+    rf"""bbbbbbbbbbbbbbbbbbbb"""
+)
 ```
 
 
@@ -356,6 +457,63 @@ a = """\\\x1f"""
  
  
  # Regression test for https://github.com/astral-sh/ruff/issues/5893
+@@ -172,19 +172,31 @@
+ # In preview, don't collapse implicit concatenated strings that can't be joined into a single string
+ # and that are multiline in the source.
+ 
+-(r"aaaaaaaaa" r"bbbbbbbbbbbbbbbbbbbb")
++(
++    r"aaaaaaaaa"
++    r"bbbbbbbbbbbbbbbbbbbb"
++)
+ 
+-(r"aaaaaaaaa" r"bbbbbbbbbbbbbbbbbbbb" "cccccccccccccccccccccc")
++(
++    r"aaaaaaaaa"
++    r"bbbbbbbbbbbbbbbbbbbb"
++    "cccccccccccccccccccccc"
++)
+ 
+-("""aaaaaaaaa""" """bbbbbbbbbbbbbbbbbbbb""")
++(
++    """aaaaaaaaa"""
++    """bbbbbbbbbbbbbbbbbbbb"""
++)
+ 
+ (
+-    f"""aaaa{
+-    10}aaaaa"""
++    f"""aaaa{10}aaaaa"""
+     rf"""bbbbbbbbbbbbbbbbbbbb"""
+ )
+ 
+-if (r"aaaaaaaaa" r"bbbbbbbbbbbbbbbbbbbb") + ["aaaaaaaaaa", "bbbbbbbbbbbbbbbb"]:
++if (
++    r"aaaaaaaaa"
++    r"bbbbbbbbbbbbbbbbbbbb"
++) + ["aaaaaaaaaa", "bbbbbbbbbbbbbbbb"]:
+     ...
+ 
+ 
+@@ -193,16 +205,8 @@
+ 
+ r"aaaaaaaaa" r"bbbbbbbbbbbbbbbbbbbb"
+ 
+-(
+-    f"aaaa{
+-    10}aaaaa"
+-    rf"bbbbbbbbbbbbbbbbbbbb"
+-)
++(f"aaaa{10}aaaaa" rf"bbbbbbbbbbbbbbbbbbbb")
+ 
+ (r"""aaaaaaaaa""" r"""bbbbbbbbbbbbbbbbbbbb""")
+ 
+-(
+-    f"""aaaa{
+-    10}aaaaa"""
+-    rf"""bbbbbbbbbbbbbbbbbbbb"""
+-)
++(f"""aaaa{10}aaaaa""" rf"""bbbbbbbbbbbbbbbbbbbb""")
 ```
 
 
@@ -540,6 +698,49 @@ a = f"""\x1f"""
 a = """\x1f"""
 a = """\\x1F"""
 a = """\\\x1f"""
+
+
+##############################################################################
+# Implicit concatenated strings
+##############################################################################
+
+# In preview, don't collapse implicit concatenated strings that can't be joined into a single string
+# and that are multiline in the source.
+
+(r'aaaaaaaaa' r'bbbbbbbbbbbbbbbbbbbb')
+
+(r'aaaaaaaaa' r'bbbbbbbbbbbbbbbbbbbb' 'cccccccccccccccccccccc')
+
+("""aaaaaaaaa""" """bbbbbbbbbbbbbbbbbbbb""")
+
+(
+    f"""aaaa{
+    10}aaaaa"""
+    rf"""bbbbbbbbbbbbbbbbbbbb"""
+)
+
+if (r'aaaaaaaaa' r'bbbbbbbbbbbbbbbbbbbb') + ['aaaaaaaaaa', 'bbbbbbbbbbbbbbbb']:
+    ...
+
+
+# In preview, keep implicit concatenated strings on a single line if they fit and are not separate by line breaks in the source
+(r'aaaaaaaaa' r'bbbbbbbbbbbbbbbbbbbb')
+
+r'aaaaaaaaa' r'bbbbbbbbbbbbbbbbbbbb'
+
+(
+    f'aaaa{
+    10}aaaaa'
+    rf'bbbbbbbbbbbbbbbbbbbb'
+)
+
+(r"""aaaaaaaaa""" r"""bbbbbbbbbbbbbbbbbbbb""")
+
+(
+    f"""aaaa{
+    10}aaaaa"""
+    rf"""bbbbbbbbbbbbbbbbbbbb"""
+)
 ```
 
 
@@ -568,4 +769,61 @@ a = """\\\x1f"""
  
  
  # Regression test for https://github.com/astral-sh/ruff/issues/5893
+@@ -172,19 +172,31 @@
+ # In preview, don't collapse implicit concatenated strings that can't be joined into a single string
+ # and that are multiline in the source.
+ 
+-(r'aaaaaaaaa' r'bbbbbbbbbbbbbbbbbbbb')
++(
++    r'aaaaaaaaa'
++    r'bbbbbbbbbbbbbbbbbbbb'
++)
+ 
+-(r'aaaaaaaaa' r'bbbbbbbbbbbbbbbbbbbb' 'cccccccccccccccccccccc')
++(
++    r'aaaaaaaaa'
++    r'bbbbbbbbbbbbbbbbbbbb'
++    'cccccccccccccccccccccc'
++)
+ 
+-("""aaaaaaaaa""" """bbbbbbbbbbbbbbbbbbbb""")
++(
++    """aaaaaaaaa"""
++    """bbbbbbbbbbbbbbbbbbbb"""
++)
+ 
+ (
+-    f"""aaaa{
+-    10}aaaaa"""
++    f"""aaaa{10}aaaaa"""
+     rf"""bbbbbbbbbbbbbbbbbbbb"""
+ )
+ 
+-if (r'aaaaaaaaa' r'bbbbbbbbbbbbbbbbbbbb') + ['aaaaaaaaaa', 'bbbbbbbbbbbbbbbb']:
++if (
++    r'aaaaaaaaa'
++    r'bbbbbbbbbbbbbbbbbbbb'
++) + ['aaaaaaaaaa', 'bbbbbbbbbbbbbbbb']:
+     ...
+ 
+ 
+@@ -193,16 +205,8 @@
+ 
+ r'aaaaaaaaa' r'bbbbbbbbbbbbbbbbbbbb'
+ 
+-(
+-    f'aaaa{
+-    10}aaaaa'
+-    rf'bbbbbbbbbbbbbbbbbbbb'
+-)
++(f'aaaa{10}aaaaa' rf'bbbbbbbbbbbbbbbbbbbb')
+ 
+ (r"""aaaaaaaaa""" r"""bbbbbbbbbbbbbbbbbbbb""")
+ 
+-(
+-    f"""aaaa{
+-    10}aaaaa"""
+-    rf"""bbbbbbbbbbbbbbbbbbbb"""
+-)
++(f"""aaaa{10}aaaaa""" rf"""bbbbbbbbbbbbbbbbbbbb""")
 ```


### PR DESCRIPTION
## Summary

Fixes https://github.com/astral-sh/ruff/issues/8272 

The formatter is incompatible with `ISC001` because it can introduce new single-line implicit concatenated strings if all parts fit on the line. The new implicit concatenated string formatting style already addresses this incompatibility for regular strings and most f-string but not for triple quoted strings and raw strings. 

This PR proposes to change the formatter style to **never** collapse the parts of an implicit concatenated string onto a single line unless it has been formatted on a single line by the author. 

```python
(
	r"aaaaaaa" "bbbbbbbbbbbb"
)
```

Is preserved as is because the author wrote the implicit concatenated string on a single line and it fits. The source i already incompatible with ISC001. 

```python
(
	r"aaaaaaa"
	"bbbbbbbbbbbb"
)
```

The current style collapses this string to match the example above. The style proposed in this PR preserves the multiline formatting in this case because there's a line break between the two parts. 

## Preview gating

It's technically not required to gate this change behind preview because it doesn't change the formatting of any existing code. But it fits nicely into the other implicit concatenated work that we've been doing and the new implicit concatenated string formatting also largely mitigates that this leads to slightly less consistent formatting (because it's up to the author whether the string remains multiline or not)

## Test Plan

Added tests
