### PR TITLE
Fix F811 false positive when a class field has the same name as an unused import

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pyflakes/F811_class_fields.py
+++ b/crates/ruff_linter/resources/test/fixtures/pyflakes/F811_class_fields.py
@@ -1,0 +1,9 @@
+"""Regression test for: https://github.com/astral-sh/ruff/issues/13930"""
+
+from queue import Empty
+
+class Types:
+    INVALID = 0
+    UINT = 1
+    HEX = 2
+    Empty = 3

--- a/crates/ruff_linter/src/checkers/ast/analyze/deferred_scopes.rs
+++ b/crates/ruff_linter/src/checkers/ast/analyze/deferred_scopes.rs
@@ -261,6 +261,14 @@ pub(crate) fn deferred_scopes(checker: &mut Checker) {
                         ) {
                             continue;
                         }
+
+                        // If the re-definition is a class member, abort.
+                        // from bar import foo
+                        // class Test:
+                        //      bar = 10 # Okay
+                        if scope.kind.is_class() {
+                            continue;
+                        }
                     }
 
                     // If the bindings are in different forks, abort.

--- a/crates/ruff_linter/src/rules/pyflakes/mod.rs
+++ b/crates/ruff_linter/src/rules/pyflakes/mod.rs
@@ -129,6 +129,7 @@ mod tests {
     #[test_case(Rule::RedefinedWhileUnused, Path::new("F811_29.pyi"))]
     #[test_case(Rule::RedefinedWhileUnused, Path::new("F811_30.py"))]
     #[test_case(Rule::RedefinedWhileUnused, Path::new("F811_31.py"))]
+    #[test_case(Rule::RedefinedWhileUnused, Path::new("F811_class_fields.py"))]
     #[test_case(Rule::UndefinedName, Path::new("F821_0.py"))]
     #[test_case(Rule::UndefinedName, Path::new("F821_1.py"))]
     #[test_case(Rule::UndefinedName, Path::new("F821_2.py"))]

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_class_fields.py.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_class_fields.py.snap
@@ -1,0 +1,4 @@
+---
+source: crates/ruff_linter/src/rules/pyflakes/mod.rs
+---
+


### PR DESCRIPTION
## Summary

Fixes https://github.com/astral-sh/ruff/issues/13930

Ruff incorrectly reports class fields as redefinitions when there's an unused import with the same name:

```python
from queue import Empty

class Types:
    INVALID = 0
    UINT = 1
    HEX = 2
    Empty = 3  # <-- reported as redefinition

# q = Empty() <- This disables the error if uncommented
```

This PR excludes fields from the redefinition checks. 

I'm not sure if this is the proper fix. Or maybe the diagnostic is even intentional? 

## Test Plan

Added test. 

I verified that Ruff doesn't detect redefined class fields today:

```python
class Types:
    INVALID = 0
    UINT = 1
    HEX = 2
    HEX = 4  # not raised
```

Ruff doesn't report a violation for the redeclared HEX field
