### PR TITLE
[red-knot] - Flow-control for boolean operations

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/boolean/short_circuit.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/boolean/short_circuit.md
@@ -3,18 +3,19 @@
 ## Not all boolean expressions must be evaluated
 
 In `or` expressions, if the left-hand side is truthy, the right-hand side is not evaluated.
-Similarly, in `and` expressions, if the left-hand side is falsy, the right-hand side is not evaluated.
+Similarly, in `and` expressions, if the left-hand side is falsy, the right-hand side is not
+evaluated.
 
 ```py
 def bool_instance() -> bool:
     return True
 
 if bool_instance() or (x := 1):
-    # error: "Name `x` used when possibly not defined"
+    # error: [possibly-unresolved-reference]
     reveal_type(x)  # revealed: Unbound | Literal[1]
 
 if bool_instance() and (x := 1):
-    # error: "Name `x` used when possibly not defined"
+    # error: [possibly-unresolved-reference]
     reveal_type(x)  # revealed: Unbound | Literal[1]
 ```
 
@@ -36,12 +37,12 @@ if (x := 1) and bool_instance():
 ```py
 if True or (x := 1):
     # TODO: infer that the second arm is never executed so type should be just "Unbound".
-    # error: "Name `x` used when possibly not defined"
+    # error: [possibly-unresolved-reference]
     reveal_type(x)  # revealed: Unbound | Literal[1]
 
 if True and (x := 1):
     # TODO: infer that the second arm is always executed so type should be just "Literal[1]".
-    # error: "Name `x` used when possibly not defined"
+    # error: [possibly-unresolved-reference]
     reveal_type(x)  # revealed: Unbound | Literal[1]
 ```
 
@@ -51,10 +52,10 @@ if True and (x := 1):
 def bool_instance() -> bool:
     return True
 
-_ = bool_instance() or (x := 1) or reveal_type(x)  # revealed: Literal[1]
+bool_instance() or (x := 1) or reveal_type(x)  # revealed: Literal[1]
 
-# error: "Name `y` used when not defined"
-_ = bool_instance() or reveal_type(y) or (y := 1)  # revealed: Unbound
+# error: [unresolved-reference]
+bool_instance() or reveal_type(y) or (y := 1)  # revealed: Unbound
 ```
 
 ## Nested expressions
@@ -70,8 +71,8 @@ if bool_instance() or ((x := 1) and bool_instance()):
 if ((y := 1) and bool_instance()) or bool_instance():
     reveal_type(y)  # revealed: Literal[1]
 
-# error: "Name `z` used when possibly not defined"
+# error: [possibly-unresolved-reference]
 if (bool_instance() and (z := 1)) or reveal_type(z):  # revealed: Unbound | Literal[1]
-    # error: "Name `z` used when possibly not defined"
+    # error: [possibly-unresolved-reference]
     reveal_type(z)  # revealed: Unbound | Literal[1]
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/boolean/short_circuit.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/boolean/short_circuit.md
@@ -1,0 +1,77 @@
+# Short-Circuit Evaluation
+
+## Not all boolean expressions must be evaluated
+
+In `or` expressions, if the left-hand side is truthy, the right-hand side is not evaluated.
+Similarly, in `and` expressions, if the left-hand side is falsy, the right-hand side is not evaluated.
+
+```py
+def bool_instance() -> bool:
+    return True
+
+if bool_instance() or (x := 1):
+    # error: "Name `x` used when possibly not defined"
+    reveal_type(x)  # revealed: Unbound | Literal[1]
+
+if bool_instance() and (x := 1):
+    # error: "Name `x` used when possibly not defined"
+    reveal_type(x)  # revealed: Unbound | Literal[1]
+```
+
+## First expression is always evaluated
+
+```py
+def bool_instance() -> bool:
+    return True
+
+if (x := 1) or bool_instance():
+    reveal_type(x)  # revealed: Literal[1]
+
+if (x := 1) and bool_instance():
+    reveal_type(x)  # revealed: Literal[1]
+```
+
+## Statically known truthiness
+
+```py
+if True or (x := 1):
+    # TODO: infer that the second arm is never executed so type should be just "Unbound".
+    # error: "Name `x` used when possibly not defined"
+    reveal_type(x)  # revealed: Unbound | Literal[1]
+
+if True and (x := 1):
+    # TODO: infer that the second arm is always executed so type should be just "Literal[1]".
+    # error: "Name `x` used when possibly not defined"
+    reveal_type(x)  # revealed: Unbound | Literal[1]
+```
+
+## Later expressions can always use variables from earlier expressions
+
+```py
+def bool_instance() -> bool:
+    return True
+
+_ = bool_instance() or (x := 1) or reveal_type(x)  # revealed: Literal[1]
+
+# error: "Name `y` used when not defined"
+_ = bool_instance() or reveal_type(y) or (y := 1)  # revealed: Unbound
+```
+
+## Nested expressions
+
+```py
+def bool_instance() -> bool:
+    return True
+
+if bool_instance() or ((x := 1) and bool_instance()):
+    # error: "Name `x` used when possibly not defined"
+    reveal_type(x)  # revealed: Unbound | Literal[1]
+
+if ((y := 1) and bool_instance()) or bool_instance():
+    reveal_type(y)  # revealed: Literal[1]
+
+# error: "Name `z` used when possibly not defined"
+if (bool_instance() and (z := 1)) or reveal_type(z):  # revealed: Unbound | Literal[1]
+    # error: "Name `z` used when possibly not defined"
+    reveal_type(z)  # revealed: Unbound | Literal[1]
+```

--- a/crates/red_knot_python_semantic/src/semantic_index/builder.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/builder.rs
@@ -1106,6 +1106,23 @@ where
                     },
                 );
             }
+            ast::Expr::BoolOp(ast::ExprBoolOp { values, .. }) => {
+                // TODO detect statically known truthy or falsy values (via type inference, not naive
+                // AST inspection, so we can't simplify here, need to record test expression for
+                // later checking)
+                let mut snapshots = vec![];
+
+                for (index, value) in values.iter().enumerate() {
+                    // The first item of BoolOp is always evaluated
+                    if index > 0 {
+                        snapshots.push(self.flow_snapshot());
+                    }
+                    self.visit_expr(value);
+                }
+                for snapshot in snapshots {
+                    self.flow_merge(snapshot);
+                }
+            }
             _ => {
                 walk_expr(self, expr);
             }

--- a/crates/red_knot_python_semantic/src/semantic_index/builder.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/builder.rs
@@ -1106,7 +1106,11 @@ where
                     },
                 );
             }
-            ast::Expr::BoolOp(ast::ExprBoolOp { values, .. }) => {
+            ast::Expr::BoolOp(ast::ExprBoolOp {
+                values,
+                range: _,
+                op: _,
+            }) => {
                 // TODO detect statically known truthy or falsy values (via type inference, not naive
                 // AST inspection, so we can't simplify here, need to record test expression for
                 // later checking)

--- a/crates/red_knot_test/src/parser.rs
+++ b/crates/red_knot_test/src/parser.rs
@@ -148,7 +148,7 @@ static HEADER_RE: LazyLock<Regex> =
 /// Matches a code block fenced by triple backticks, possibly with language and `key=val`
 /// configuration items following the opening backticks (in the "tag string" of the code block).
 static CODE_RE: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"^```(?<lang>(?-u:\w)+)?(?<config>(?: +\S+)*)\s*\n(?<code>(?:.|\n)*?)\n?```\s*\n")
+    Regex::new(r"^```(?<lang>(?-u:\w)+)?(?<config>(?: +\S+)*)\s*\n(?<code>(?:.|\n)*?)\n?```\s*\n?")
         .unwrap()
 });
 
@@ -403,6 +403,31 @@ mod tests {
             x = 1
             ```
             ",
+        );
+        let mf = super::parse("file.md", &source).unwrap();
+
+        let [test] = &mf.tests().collect::<Vec<_>>()[..] else {
+            panic!("expected one test");
+        };
+
+        assert_eq!(test.name(), "file.md");
+
+        let [file] = test.files().collect::<Vec<_>>()[..] else {
+            panic!("expected one file");
+        };
+
+        assert_eq!(file.path, "test.py");
+        assert_eq!(file.lang, "py");
+        assert_eq!(file.code, "x = 1");
+    }
+
+    #[test]
+    fn no_new_line_at_eof() {
+        let source = dedent(
+            "
+            ```py
+            x = 1
+            ```",
         );
         let mf = super::parse("file.md", &source).unwrap();
 


### PR DESCRIPTION
## Summary

As python uses short-circuiting boolean operations in runtime, we should mimic that logic in redknot as well.
For example, we should detect that in the following code `x` might be undefined inside the block:

```py
if flag or (x := 1):
    print(x) 
```

## Test Plan

Added mdtest suit for boolean expressions. 
