### PR TITLE
[red-knot] Narrowing - Not operator 

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/narrow/conditionals_not.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/narrow/conditionals_not.md
@@ -1,0 +1,33 @@
+# Narrowing for `not` conditionals
+
+Not operator negating the constraints made by other conditionals
+
+## `not is None`
+
+```py
+def bool_instance() -> bool:
+    return True
+
+x = None if bool_instance() else 1
+
+if not x is None:
+    reveal_type(x)  # revealed: Literal[1]
+else:
+    reveal_type(x)  # revealed: None
+
+reveal_type(x)  # revealed: None | Literal[1]
+```
+
+## `not isinstance`
+
+```py
+def bool_instance() -> bool:
+    return True
+
+x = 1 if bool_instance() else "a"
+
+if not isinstance(x, (int)):
+    reveal_type(x)  # revealed: Literal["a"]
+else:
+    reveal_type(x)  # revealed: Literal[1]
+```

--- a/crates/red_knot_python_semantic/resources/mdtest/narrow/conditionals_not.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/narrow/conditionals_not.md
@@ -1,6 +1,6 @@
 # Narrowing for `not` conditionals
 
-Not operator negating the constraints made by other conditionals
+The `not` operator negates a constraint.
 
 ## `not is None`
 


### PR DESCRIPTION
## Summary

After #13918 has landed, narrowing constraint negation became easy, so adding support for `not` operator.

## Test Plan

I added a new mdtest file for `not` expression, but maybe we should spread it over the other test files (by adding `not` cases to each one of them)? I'll be happy to hear your preference around that :)


