### PR TITLE
[red-knot] Infer `tuple` types from annotations

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/assignment/annotations.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/assignment/annotations.md
@@ -55,8 +55,9 @@ reveal_type(g)  # revealed: @Todo
 
 # TODO: support more kinds of type expressions in annotations
 reveal_type(h)  # revealed: @Todo
-reveal_type(i)  # revealed: tuple[@Todo, @Todo]
-reveal_type(j)  # revealed: tuple[@Todo]
+
+reveal_type(i)  # revealed: tuple[str | int, str | int]
+reveal_type(j)  # revealed: tuple[str | int]
 ```
 
 ## Incorrect tuple annotations are complained about
@@ -67,6 +68,9 @@ a: tuple[()] = (1, 2)
 
 # error: [invalid-assignment] "Object of type `tuple[Literal["foo"]]` is not assignable to `tuple[int]`"
 b: tuple[int] = ("foo",)
+
+# error: [invalid-assignment] "Object of type `tuple[list, Literal["foo"]]` is not assignable to `tuple[str | int, str]`"
+c: tuple[str | int, str] = ([], "foo")
 ```
 
 ## PEP-604 annotations are supported

--- a/crates/red_knot_python_semantic/resources/mdtest/assignment/annotations.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/assignment/annotations.md
@@ -23,6 +23,44 @@ x: int
 x = "foo"  # error: [invalid-assignment] "Object of type `Literal["foo"]` is not assignable to `int`"
 ```
 
+## Tuple annotations are understood
+
+```py path=module.py
+a: tuple[()] = ()
+b: tuple[int] = (42,)
+c: tuple[str, int] = ("42", 42)
+d: tuple[tuple[str, str], tuple[int, int]] = (("foo", "foo"), (42, 42))
+e: tuple[str, ...] = ()
+f: tuple[str, *tuple[int, ...], bytes] = ("42", b"42")
+g: tuple[list[int], list[int]] = ([], [])
+```
+
+```py path=script.py
+from module import a, b, c, d, e, f, g
+
+reveal_type(a)  # revealed: tuple[()]
+reveal_type(b)  # revealed: tuple[int]
+reveal_type(c)  # revealed: tuple[str, int]
+reveal_type(d)  # revealed: tuple[tuple[str, str], tuple[int, int]]
+
+# TODO: homogenous tuples
+reveal_type(e)  # revealed: @Todo
+reveal_type(f)  # revealed: @Todo
+
+# TODO: support more kinds of type expressions in annotations
+reveal_type(g)  # revealed: @Todo
+```
+
+## Incorrect tuple annotations are complained about
+
+```py
+# error: [invalid-assignment] "Object of type `tuple[Literal[1], Literal[2]]` is not assignable to `tuple[()]`"
+a: tuple[()] = (1, 2)
+
+# error: [invalid-assignment] "Object of type `tuple[Literal["foo"]]` is not assignable to `tuple[int]`"
+b: tuple[int] = ("foo",)
+```
+
 ## PEP-604 annotations are supported
 
 ```py

--- a/crates/red_knot_python_semantic/resources/mdtest/assignment/annotations.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/assignment/annotations.md
@@ -60,7 +60,7 @@ reveal_type(i)  # revealed: tuple[str | int, str | int]
 reveal_type(j)  # revealed: tuple[str | int]
 ```
 
-## Incorrect tuple annotations are complained about
+## Incorrect tuple assignments are complained about
 
 ```py
 # error: [invalid-assignment] "Object of type `tuple[Literal[1], Literal[2]]` is not assignable to `tuple[()]`"

--- a/crates/red_knot_python_semantic/resources/mdtest/assignment/annotations.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/assignment/annotations.md
@@ -26,29 +26,37 @@ x = "foo"  # error: [invalid-assignment] "Object of type `Literal["foo"]` is not
 ## Tuple annotations are understood
 
 ```py path=module.py
+from typing_extensions import Unpack
+
 a: tuple[()] = ()
 b: tuple[int] = (42,)
 c: tuple[str, int] = ("42", 42)
 d: tuple[tuple[str, str], tuple[int, int]] = (("foo", "foo"), (42, 42))
 e: tuple[str, ...] = ()
 f: tuple[str, *tuple[int, ...], bytes] = ("42", b"42")
-g: tuple[list[int], list[int]] = ([], [])
+g: tuple[str, Unpack[tuple[int, ...]], bytes] = ("42", b"42")
+h: tuple[list[int], list[int]] = ([], [])
+i: tuple[str | int, str | int] = (42, 42)
+j: tuple[str | int] = (42,)
 ```
 
 ```py path=script.py
-from module import a, b, c, d, e, f, g
+from module import a, b, c, d, e, f, g, h, i, j
 
 reveal_type(a)  # revealed: tuple[()]
 reveal_type(b)  # revealed: tuple[int]
 reveal_type(c)  # revealed: tuple[str, int]
 reveal_type(d)  # revealed: tuple[tuple[str, str], tuple[int, int]]
 
-# TODO: homogenous tuples
+# TODO: homogenous tuples, PEP-646 tuples
 reveal_type(e)  # revealed: @Todo
 reveal_type(f)  # revealed: @Todo
+reveal_type(g)  # revealed: @Todo
 
 # TODO: support more kinds of type expressions in annotations
-reveal_type(g)  # revealed: @Todo
+reveal_type(h)  # revealed: @Todo
+reveal_type(i)  # revealed: tuple[@Todo, @Todo]
+reveal_type(j)  # revealed: tuple[@Todo]
 ```
 
 ## Incorrect tuple annotations are complained about

--- a/crates/red_knot_python_semantic/resources/mdtest/generics.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/generics.md
@@ -16,10 +16,11 @@ class MyBox[T]:
     def __init__(self, data: T):
         self.data = data
 
-# TODO not error (should be subscriptable)
-box: MyBox[int] = MyBox(5)  # error: [non-subscriptable]
-# TODO error differently (str and int don't unify)
-wrong_innards: MyBox[int] = MyBox("five")  # error: [non-subscriptable]
+box: MyBox[int] = MyBox(5)
+
+# TODO should emit a diagnostic here (str and int don't unify)
+wrong_innards: MyBox[int] = MyBox("five")
+
 # TODO reveal int
 reveal_type(box.data)  # revealed: @Todo
 

--- a/crates/red_knot_python_semantic/resources/mdtest/generics.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/generics.md
@@ -18,7 +18,7 @@ class MyBox[T]:
 
 box: MyBox[int] = MyBox(5)
 
-# TODO should emit a diagnostic here (str and int don't unify)
+# TODO should emit a diagnostic here (str is not assignable to int)
 wrong_innards: MyBox[int] = MyBox("five")
 
 # TODO reveal int


### PR DESCRIPTION
## Summary

This PR adds support for heterogenous `tuple` annotations to red-knot.

I initially thought that this might be useful for `sys.version_info` support... now that I look again, I'm not sure that it _is_ actually useful for that. Anyway, still a useful feature, and one we'd have had to implement anyway!

The PR does the following:
- Extends `infer_type_expression` so that it understands tuple annotations
- Changes `infer_type_expression` so that `ExprStarred` nodes in type annotations are inferred as `Todo` rather than `Unknown` (they're valid in PEP-646 tuple annotations)
- Extends `Type::is_subtype_of` to understand when one heterogenous tuple type can be understood to be a subtype of another (without this change, the PR would have introduced new false-positive errors to some existing mdtests).

## Test Plan

- mdtests added to `assignment/annotations.md`
- `is_subtype_of` unit tests have been added to `types.rs`
- I verified that the PR produces no new false positives in the red-knot benchmarks.
