### PR TITLE
Treat return type of `singledispatch` as runtime-required

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_type_checking/singledispatch.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_type_checking/singledispatch.py
@@ -1,6 +1,7 @@
 """Test module."""
 from __future__ import annotations
 
+from collections.abc import Set
 from functools import singledispatch
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -36,19 +37,19 @@ def _(a: DataFrame) -> DataFrame:
 
 
 @singledispatch
-def process_path(a: int | str, p: Path) -> int:
+def process_path(a: int | str, p: Path) -> Set:
     """Convert arg to array or leaves it as sparse matrix."""
     msg = f"Unhandled type {type(a)}"
     raise NotImplementedError(msg)
 
 
 @process_path.register
-def _(a: int, p: Path) -> int:
+def _(a: int, p: Path) -> Set:
     return asarray(a)
 
 
 @process_path.register
-def _(a: str, p: Path) -> int:
+def _(a: str, p: Path) -> Set:
     return a
 
 

--- a/crates/ruff_linter/src/checkers/ast/mod.rs
+++ b/crates/ruff_linter/src/checkers/ast/mod.rs
@@ -764,15 +764,19 @@ impl<'a> Visitor<'a> for Checker<'a> {
                     }
                 }
                 if let Some(expr) = returns {
-                    match annotation {
-                        AnnotationContext::RuntimeRequired => {
-                            self.visit_runtime_required_annotation(expr);
-                        }
-                        AnnotationContext::RuntimeEvaluated => {
-                            self.visit_runtime_evaluated_annotation(expr);
-                        }
-                        AnnotationContext::TypingOnly => {
-                            self.visit_annotation(expr);
+                    if singledispatch {
+                        self.visit_runtime_required_annotation(expr);
+                    } else {
+                        match annotation {
+                            AnnotationContext::RuntimeRequired => {
+                                self.visit_runtime_required_annotation(expr);
+                            }
+                            AnnotationContext::RuntimeEvaluated => {
+                                self.visit_runtime_evaluated_annotation(expr);
+                            }
+                            AnnotationContext::TypingOnly => {
+                                self.visit_annotation(expr);
+                            }
                         }
                     }
                 }

--- a/crates/ruff_linter/src/rules/flake8_type_checking/snapshots/ruff_linter__rules__flake8_type_checking__tests__typing-only-third-party-import_singledispatch.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_type_checking/snapshots/ruff_linter__rules__flake8_type_checking__tests__typing-only-third-party-import_singledispatch.py.snap
@@ -1,25 +1,25 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_type_checking/mod.rs
 ---
-singledispatch.py:11:20: TCH002 [*] Move third-party import `pandas.DataFrame` into a type-checking block
+singledispatch.py:12:20: TCH002 [*] Move third-party import `pandas.DataFrame` into a type-checking block
    |
- 9 | from numpy.typing import ArrayLike
-10 | from scipy.sparse import spmatrix
-11 | from pandas import DataFrame
+10 | from numpy.typing import ArrayLike
+11 | from scipy.sparse import spmatrix
+12 | from pandas import DataFrame
    |                    ^^^^^^^^^ TCH002
-12 | 
-13 | if TYPE_CHECKING:
+13 | 
+14 | if TYPE_CHECKING:
    |
    = help: Move into type-checking block
 
 ℹ Unsafe fix
-8  8  | from numpy import asarray
-9  9  | from numpy.typing import ArrayLike
-10 10 | from scipy.sparse import spmatrix
-11    |-from pandas import DataFrame
-12 11 | 
-13 12 | if TYPE_CHECKING:
-   13 |+    from pandas import DataFrame
-14 14 |     from numpy import ndarray
-15 15 | 
-16 16 |
+9  9  | from numpy import asarray
+10 10 | from numpy.typing import ArrayLike
+11 11 | from scipy.sparse import spmatrix
+12    |-from pandas import DataFrame
+13 12 | 
+14 13 | if TYPE_CHECKING:
+   14 |+    from pandas import DataFrame
+15 15 |     from numpy import ndarray
+16 16 | 
+17 17 |


### PR DESCRIPTION
## Summary

fixes: #13955 

## Test Plan

Update existing test case to use a return type hint for which `main` flags `TCH003`.
