### PR TITLE
[red-knot] Distribute intersections on negation

### DIFF
--- a/crates/red_knot_python_semantic/src/stdlib.rs
+++ b/crates/red_knot_python_semantic/src/stdlib.rs
@@ -10,6 +10,7 @@ use crate::Db;
 enum CoreStdlibModule {
     Builtins,
     Types,
+    Typing,
     Typeshed,
     TypingExtensions,
 }
@@ -19,6 +20,7 @@ impl CoreStdlibModule {
         let module_name = match self {
             Self::Builtins => "builtins",
             Self::Types => "types",
+            Self::Typing => "typing",
             Self::Typeshed => "_typeshed",
             Self::TypingExtensions => "typing_extensions",
         };
@@ -63,6 +65,13 @@ pub(crate) fn types_symbol_ty<'db>(db: &'db dyn Db, symbol: &str) -> Type<'db> {
     core_module_symbol_ty(db, CoreStdlibModule::Types, symbol)
 }
 
+/// Lookup the type of `symbol` in the `typing` module namespace.
+///
+/// Returns `Unbound` if the `types` module isn't available for some reason.
+#[inline]
+pub(crate) fn typing_symbol_ty<'db>(db: &'db dyn Db, symbol: &str) -> Type<'db> {
+    core_module_symbol_ty(db, CoreStdlibModule::Typing, symbol)
+}
 /// Lookup the type of `symbol` in the `_typeshed` module namespace.
 ///
 /// Returns `Unbound` if the `_typeshed` module isn't available for some reason.

--- a/crates/red_knot_python_semantic/src/stdlib.rs
+++ b/crates/red_knot_python_semantic/src/stdlib.rs
@@ -10,6 +10,8 @@ use crate::Db;
 enum CoreStdlibModule {
     Builtins,
     Types,
+    // the Typing enum is currently only used in tests
+    #[allow(dead_code)]
     Typing,
     Typeshed,
     TypingExtensions,
@@ -67,8 +69,9 @@ pub(crate) fn types_symbol_ty<'db>(db: &'db dyn Db, symbol: &str) -> Type<'db> {
 
 /// Lookup the type of `symbol` in the `typing` module namespace.
 ///
-/// Returns `Unbound` if the `types` module isn't available for some reason.
+/// Returns `Unbound` if the `typing` module isn't available for some reason.
 #[inline]
+#[allow(dead_code)] // currently only used in tests
 pub(crate) fn typing_symbol_ty<'db>(db: &'db dyn Db, symbol: &str) -> Type<'db> {
     core_module_symbol_ty(db, CoreStdlibModule::Typing, symbol)
 }

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -12,7 +12,6 @@ use crate::semantic_index::{
 };
 use crate::stdlib::{
     builtins_symbol_ty, types_symbol_ty, typeshed_symbol_ty, typing_extensions_symbol_ty,
-    typing_symbol_ty,
 };
 use crate::types::narrow::narrowing_constraint;
 use crate::{Db, FxOrderSet, HasTy, Module, SemanticModel};
@@ -741,9 +740,7 @@ impl<'db> Type<'db> {
                     | KnownClass::Dict
                     | KnownClass::GenericAlias
                     | KnownClass::ModuleType
-                    | KnownClass::FunctionType
-                    | KnownClass::Sized
-                    | KnownClass::Hashable,
+                    | KnownClass::FunctionType,
                 ) => false,
                 None => false,
             },
@@ -1135,9 +1132,6 @@ pub enum KnownClass {
     GenericAlias,
     ModuleType,
     FunctionType,
-    // Typing
-    Sized,
-    Hashable,
     // Typeshed
     NoneType, // Part of `types` for Python >= 3.10
 }
@@ -1159,8 +1153,6 @@ impl<'db> KnownClass {
             Self::GenericAlias => "GenericAlias",
             Self::ModuleType => "ModuleType",
             Self::FunctionType => "FunctionType",
-            Self::Sized => "Sized",
-            Self::Hashable => "Hashable",
             Self::NoneType => "NoneType",
         }
     }
@@ -1185,7 +1177,6 @@ impl<'db> KnownClass {
             Self::GenericAlias | Self::ModuleType | Self::FunctionType => {
                 types_symbol_ty(db, self.as_str())
             }
-            Self::Sized | Self::Hashable => typing_symbol_ty(db, self.as_str()),
 
             Self::NoneType => typeshed_symbol_ty(db, self.as_str()),
         }
@@ -1220,8 +1211,6 @@ impl<'db> KnownClass {
             "NoneType" => Some(Self::NoneType),
             "ModuleType" => Some(Self::ModuleType),
             "FunctionType" => Some(Self::FunctionType),
-            "Sized" => Some(Self::Sized),
-            "Hashable" => Some(Self::Hashable),
             _ => None,
         }
     }
@@ -1244,9 +1233,6 @@ impl<'db> KnownClass {
             | Self::Set
             | Self::Dict => module.name() == "builtins",
             Self::GenericAlias | Self::ModuleType | Self::FunctionType => module.name() == "types",
-            Self::Sized | Self::Hashable => {
-                matches!(module.name().as_str(), "typing" | "collections.abc")
-            }
             Self::NoneType => matches!(module.name().as_str(), "_typeshed" | "types"),
         }
     }


### PR DESCRIPTION
## Summary

This does two things:
- distribute negated intersections when building up intersections (i.e. going from `A & ~(B & C)` to `(A & ~B) | (A & ~C)`) (fixing #13931) 
- add some classes from `typing` to `KnownClass`

The second point was to enable writing a test for the first case using protocols defined in `typing` (here, `Sized` and `Hashable`). Was a bit worried about another test that could be susceptible to simplifications, and it was straightforward to pull in

## Test Plan

`cargo test`