### PR TITLE
Cached inference of all definitions in an unpacking

### DIFF
--- a/crates/red_knot_python_semantic/src/lib.rs
+++ b/crates/red_knot_python_semantic/src/lib.rs
@@ -22,6 +22,7 @@ pub(crate) mod site_packages;
 mod stdlib;
 pub(crate) mod symbol;
 pub mod types;
+mod unpack;
 mod util;
 
 type FxOrderSet<V> = ordermap::set::OrderSet<V, BuildHasherDefault<FxHasher>>;

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -27,7 +27,7 @@ mod diagnostic;
 mod display;
 mod infer;
 mod narrow;
-mod unpack;
+mod unpacker;
 
 pub fn check_types(db: &dyn Db, file: File) -> TypeCheckDiagnostics {
     let _span = tracing::trace_span!("check_types", file=?file.path(db)).entered();

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -27,6 +27,7 @@ mod diagnostic;
 mod display;
 mod infer;
 mod narrow;
+mod unpack;
 
 pub fn check_types(db: &dyn Db, file: File) -> TypeCheckDiagnostics {
     let _span = tracing::trace_span!("check_types", file=?file.path(db)).entered();

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -26,7 +26,6 @@
 //! stringified annotations. We have a fourth Salsa query for inferring the deferred types
 //! associated with a particular definition. Scope-level inference infers deferred types for all
 //! definitions once the rest of the types in the scope have been inferred.
-use std::borrow::Cow;
 use std::num::NonZeroU32;
 
 use itertools::Itertools;
@@ -52,6 +51,7 @@ use crate::stdlib::builtins_module_scope;
 use crate::types::diagnostic::{
     TypeCheckDiagnostic, TypeCheckDiagnostics, TypeCheckDiagnosticsBuilder,
 };
+use crate::types::unpack::{Unpack, UnpackResult, Unpacker};
 use crate::types::{
     bindings_ty, builtins_symbol, declarations_ty, global_symbol, symbol, typing_extensions_symbol,
     Boundness, BytesLiteralType, ClassType, FunctionType, IterationOutcome, KnownClass,
@@ -159,6 +159,18 @@ pub(crate) fn infer_expression_types<'db>(
     let index = semantic_index(db, file);
 
     TypeInferenceBuilder::new(db, InferenceRegion::Expression(expression), index).finish()
+}
+
+#[salsa::tracked(return_ref)]
+fn infer_unpack_types<'db>(db: &'db dyn Db, unpack: Unpack<'db>) -> UnpackResult<'db> {
+    let file = unpack.file(db);
+    let _span =
+        tracing::trace_span!("infer_unpack_types", unpack=?unpack.as_id(), file=%file.path(db))
+            .entered();
+
+    let mut unpacker = Unpacker::new(db, file);
+    unpacker.unpack(unpack);
+    unpacker.finish()
 }
 
 /// A region within which we can infer types.
@@ -440,7 +452,6 @@ impl<'db> TypeInferenceBuilder<'db> {
             }
             DefinitionKind::Assignment(assignment) => {
                 self.infer_assignment_definition(
-                    assignment.target(),
                     assignment.value(),
                     assignment.name(),
                     assignment.kind(),
@@ -1321,7 +1332,6 @@ impl<'db> TypeInferenceBuilder<'db> {
 
     fn infer_assignment_definition(
         &mut self,
-        target: &ast::Expr,
         value: &ast::Expr,
         name: &ast::ExprName,
         kind: AssignmentKind,
@@ -1332,132 +1342,28 @@ impl<'db> TypeInferenceBuilder<'db> {
         self.extend(result);
 
         let value_ty = self.expression_ty(value);
+        let name_ast_id = name.scoped_ast_id(self.db, self.scope());
 
         let target_ty = match kind {
-            AssignmentKind::Sequence => self.infer_sequence_unpacking(target, value_ty, name),
+            AssignmentKind::Sequence => {
+                let target = definition.kind(self.db).as_unpack_target().unwrap();
+                let unpack = Unpack::new(
+                    self.db,
+                    self.file,
+                    definition.file_scope(self.db),
+                    target,
+                    value_ty,
+                    countme::Count::default(),
+                );
+                let unpacked = infer_unpack_types(self.db, unpack);
+                self.diagnostics.extend(unpacked.diagnostics());
+                unpacked.get(name_ast_id).unwrap_or(Type::Unknown)
+            }
             AssignmentKind::Name => value_ty,
         };
 
         self.add_binding(name.into(), definition, target_ty);
-        self.types
-            .expressions
-            .insert(name.scoped_ast_id(self.db, self.scope()), target_ty);
-    }
-
-    fn infer_sequence_unpacking(
-        &mut self,
-        target: &ast::Expr,
-        value_ty: Type<'db>,
-        name: &ast::ExprName,
-    ) -> Type<'db> {
-        // The inner function is recursive and only differs in the return type which is an `Option`
-        // where if the variable is found, the corresponding type is returned otherwise `None`.
-        fn inner<'db>(
-            builder: &mut TypeInferenceBuilder<'db>,
-            target: &ast::Expr,
-            value_ty: Type<'db>,
-            name: &ast::ExprName,
-        ) -> Option<Type<'db>> {
-            match target {
-                ast::Expr::Name(target_name) if target_name == name => {
-                    return Some(value_ty);
-                }
-                ast::Expr::Starred(ast::ExprStarred { value, .. }) => {
-                    return inner(builder, value, value_ty, name);
-                }
-                ast::Expr::List(ast::ExprList { elts, .. })
-                | ast::Expr::Tuple(ast::ExprTuple { elts, .. }) => match value_ty {
-                    Type::Tuple(tuple_ty) => {
-                        let starred_index = elts.iter().position(ast::Expr::is_starred_expr);
-
-                        let element_types = if let Some(starred_index) = starred_index {
-                            if tuple_ty.len(builder.db) >= elts.len() - 1 {
-                                let mut element_types = Vec::with_capacity(elts.len());
-                                element_types.extend_from_slice(
-                                    // SAFETY: Safe because of the length check above.
-                                    &tuple_ty.elements(builder.db)[..starred_index],
-                                );
-
-                                // E.g., in `(a, *b, c, d) = ...`, the index of starred element `b`
-                                // is 1 and the remaining elements after that are 2.
-                                let remaining = elts.len() - (starred_index + 1);
-                                // This index represents the type of the last element that belongs
-                                // to the starred expression, in an exclusive manner.
-                                let starred_end_index = tuple_ty.len(builder.db) - remaining;
-                                // SAFETY: Safe because of the length check above.
-                                let _starred_element_types = &tuple_ty.elements(builder.db)
-                                    [starred_index..starred_end_index];
-                                // TODO: Combine the types into a list type. If the
-                                // starred_element_types is empty, then it should be `List[Any]`.
-                                // combine_types(starred_element_types);
-                                element_types.push(Type::Todo);
-
-                                element_types.extend_from_slice(
-                                    // SAFETY: Safe because of the length check above.
-                                    &tuple_ty.elements(builder.db)[starred_end_index..],
-                                );
-                                Cow::Owned(element_types)
-                            } else {
-                                let mut element_types = tuple_ty.elements(builder.db).to_vec();
-                                // Subtract 1 to insert the starred expression type at the correct
-                                // index.
-                                element_types.resize(elts.len() - 1, Type::Unknown);
-                                // TODO: This should be `list[Unknown]`
-                                element_types.insert(starred_index, Type::Todo);
-                                Cow::Owned(element_types)
-                            }
-                        } else {
-                            Cow::Borrowed(tuple_ty.elements(builder.db).as_ref())
-                        };
-
-                        for (index, element) in elts.iter().enumerate() {
-                            if let Some(ty) = inner(
-                                builder,
-                                element,
-                                element_types.get(index).copied().unwrap_or(Type::Unknown),
-                                name,
-                            ) {
-                                return Some(ty);
-                            }
-                        }
-                    }
-                    Type::StringLiteral(string_literal_ty) => {
-                        // Deconstruct the string literal to delegate the inference back to the
-                        // tuple type for correct handling of starred expressions. We could go
-                        // further and deconstruct to an array of `StringLiteral` with each
-                        // individual character, instead of just an array of `LiteralString`, but
-                        // there would be a cost and it's not clear that it's worth it.
-                        let value_ty = Type::Tuple(TupleType::new(
-                            builder.db,
-                            vec![Type::LiteralString; string_literal_ty.len(builder.db)]
-                                .into_boxed_slice(),
-                        ));
-                        if let Some(ty) = inner(builder, target, value_ty, name) {
-                            return Some(ty);
-                        }
-                    }
-                    _ => {
-                        let value_ty = if value_ty.is_literal_string() {
-                            Type::LiteralString
-                        } else {
-                            value_ty.iterate(builder.db).unwrap_with_diagnostic(
-                                AnyNodeRef::from(target),
-                                &mut builder.diagnostics,
-                            )
-                        };
-                        for element in elts {
-                            if let Some(ty) = inner(builder, element, value_ty, name) {
-                                return Some(ty);
-                            }
-                        }
-                    }
-                },
-                _ => {}
-            }
-            None
-        }
-
-        inner(self, target, value_ty, name).unwrap_or(Type::Unknown)
+        self.types.expressions.insert(name_ast_id, target_ty);
     }
 
     fn infer_annotated_assignment_statement(&mut self, assignment: &ast::StmtAnnAssign) {

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -162,6 +162,12 @@ pub(crate) fn infer_expression_types<'db>(
     TypeInferenceBuilder::new(db, InferenceRegion::Expression(expression), index).finish()
 }
 
+/// Infer the types for an [`Unpack`] operation.
+///
+/// This infers the expression type and performs structural match against the target expression
+/// involved in an unpacking operation. It returns a result-like object that can be used to get the
+/// type of the variables involved in this unpacking along with any violations that are detected
+/// during this unpacking.
 #[salsa::tracked(return_ref)]
 fn infer_unpack_types<'db>(db: &'db dyn Db, unpack: Unpack<'db>) -> UnpackResult<'db> {
     let file = unpack.file(db);

--- a/crates/red_knot_python_semantic/src/types/unpack.rs
+++ b/crates/red_knot_python_semantic/src/types/unpack.rs
@@ -4,8 +4,8 @@ use ruff_db::files::File;
 use ruff_python_ast::{self as ast, AnyNodeRef};
 use rustc_hash::FxHashMap;
 
+use crate::ast_node_ref::AstNodeRef;
 use crate::semantic_index::ast_ids::{HasScopedAstId, ScopedExpressionId};
-use crate::semantic_index::definition::UnpackTarget;
 use crate::semantic_index::symbol::{FileScopeId, ScopeId};
 use crate::types::{TupleType, Type, TypeCheckDiagnostics, TypeCheckDiagnosticsBuilder};
 use crate::Db;
@@ -20,7 +20,7 @@ pub struct Unpack<'db> {
 
     #[no_eq]
     #[return_ref]
-    pub(crate) target: UnpackTarget,
+    pub(crate) target: AstNodeRef<ast::Expr>,
 
     #[no_eq]
     pub(crate) value_ty: Type<'db>,
@@ -52,7 +52,7 @@ impl<'db> Unpacker<'db> {
 
     pub(crate) fn unpack(&mut self, unpack: Unpack<'db>) {
         self.unpack_inner(
-            unpack.target(self.db).node(),
+            unpack.target(self.db),
             unpack.value_ty(self.db),
             unpack.scope(self.db),
         );

--- a/crates/red_knot_python_semantic/src/types/unpacker.rs
+++ b/crates/red_knot_python_semantic/src/types/unpacker.rs
@@ -9,6 +9,7 @@ use crate::semantic_index::symbol::ScopeId;
 use crate::types::{TupleType, Type, TypeCheckDiagnostics, TypeCheckDiagnosticsBuilder};
 use crate::Db;
 
+/// Unpacks the value expression type to their respective targets.
 pub(crate) struct Unpacker<'db> {
     db: &'db dyn Db,
     targets: FxHashMap<ScopedExpressionId, Type<'db>>,
@@ -23,14 +24,6 @@ impl<'db> Unpacker<'db> {
             diagnostics: TypeCheckDiagnosticsBuilder::new(db, file),
         }
     }
-
-    //pub(crate) fn unpack(&mut self, unpack: Unpack<'db>) {
-    //    self.unpack_inner(
-    //        unpack.target(self.db),
-    //        unpack.value_ty(self.db),
-    //        unpack.scope(self.db),
-    //    );
-    //}
 
     pub(crate) fn unpack(&mut self, target: &ast::Expr, value_ty: Type<'db>, scope: ScopeId<'db>) {
         match target {

--- a/crates/red_knot_python_semantic/src/unpack.rs
+++ b/crates/red_knot_python_semantic/src/unpack.rs
@@ -6,6 +6,12 @@ use crate::semantic_index::expression::Expression;
 use crate::semantic_index::symbol::{FileScopeId, ScopeId};
 use crate::Db;
 
+/// This ingredient represents a single unpacking.
+///
+/// This is required to make use of salsa to cache the complete unpacking of multiple variables
+/// involved. It allows us to:
+/// 1. Avoid doing structural match multiple times for each definition
+/// 2. Avoid highlighting the same error multiple times
 #[salsa::tracked]
 pub(crate) struct Unpack<'db> {
     #[id]
@@ -14,10 +20,14 @@ pub(crate) struct Unpack<'db> {
     #[id]
     pub(crate) file_scope: FileScopeId,
 
+    /// The target expression that is being unpacked. For example, in `(a, b) = (1, 2)`, the target
+    /// expression is `(a, b)`.
     #[no_eq]
     #[return_ref]
     pub(crate) target: AstNodeRef<ast::Expr>,
 
+    /// The ingredient representing the value expression of the unpacking. For example, in
+    /// `(a, b) = (1, 2)`, the value expression is `(1, 2)`.
     #[no_eq]
     pub(crate) value: Expression<'db>,
 
@@ -26,6 +36,7 @@ pub(crate) struct Unpack<'db> {
 }
 
 impl<'db> Unpack<'db> {
+    /// Returns the scope where the unpacking is happening.
     pub(crate) fn scope(self, db: &'db dyn Db) -> ScopeId<'db> {
         self.file_scope(db).to_scope_id(db, self.file(db))
     }

--- a/crates/red_knot_python_semantic/src/unpack.rs
+++ b/crates/red_knot_python_semantic/src/unpack.rs
@@ -1,0 +1,32 @@
+use ruff_db::files::File;
+use ruff_python_ast::{self as ast};
+
+use crate::ast_node_ref::AstNodeRef;
+use crate::semantic_index::expression::Expression;
+use crate::semantic_index::symbol::{FileScopeId, ScopeId};
+use crate::Db;
+
+#[salsa::tracked]
+pub(crate) struct Unpack<'db> {
+    #[id]
+    pub(crate) file: File,
+
+    #[id]
+    pub(crate) file_scope: FileScopeId,
+
+    #[no_eq]
+    #[return_ref]
+    pub(crate) target: AstNodeRef<ast::Expr>,
+
+    #[no_eq]
+    pub(crate) value: Expression<'db>,
+
+    #[no_eq]
+    count: countme::Count<Unpack<'static>>,
+}
+
+impl<'db> Unpack<'db> {
+    pub(crate) fn scope(self, db: &'db dyn Db) -> ScopeId<'db> {
+        self.file_scope(db).to_scope_id(db, self.file(db))
+    }
+}


### PR DESCRIPTION
## Summary

This PR adds a new salsa query and an ingredient to resolve all the variables involved in an unpacking assignment like `(a, b) = (1, 2)` at once. Previously, we'd recursively try to match the correct type for each definition individually which will result in creating duplicate diagnostics. 

This PR still doesn't solve the duplicate diagnostics issue because that requires a different solution like using salsa accumulator or de-duplicating the diagnostics manually.

Related: #13773 

## Test Plan

Make sure that all unpack assignment test cases pass, there are no panics in the corpus tests.

## Todo

- [x] Look at the performance regression