### PR TITLE
[red-knot] Improve ergonomics for the `PySlice` trait

### DIFF
--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -3228,7 +3228,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                 let elements = tuple_ty.elements(self.db);
                 let (start, stop, step) = slice_ty.as_tuple(self.db);
 
-                if let Ok(new_elements) = elements.as_ref().py_slice(start, stop, step) {
+                if let Ok(new_elements) = elements.py_slice(start, stop, step) {
                     let new_elements: Vec<_> = new_elements.copied().collect();
                     Type::Tuple(TupleType::new(self.db, new_elements.into_boxed_slice()))
                 } else {
@@ -3267,7 +3267,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                 let (start, stop, step) = slice_ty.as_tuple(self.db);
 
                 let chars: Vec<_> = literal_value.chars().collect();
-                let result = if let Ok(new_chars) = chars.as_slice().py_slice(start, stop, step) {
+                let result = if let Ok(new_chars) = chars.py_slice(start, stop, step) {
                     let literal: String = new_chars.collect();
                     Type::StringLiteral(StringLiteralType::new(self.db, literal.into_boxed_str()))
                 } else {
@@ -3303,7 +3303,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                 let literal_value = literal_ty.value(self.db);
                 let (start, stop, step) = slice_ty.as_tuple(self.db);
 
-                if let Ok(new_bytes) = literal_value.as_ref().py_slice(start, stop, step) {
+                if let Ok(new_bytes) = literal_value.py_slice(start, stop, step) {
                     let new_bytes: Vec<u8> = new_bytes.copied().collect();
                     Type::BytesLiteral(BytesLiteralType::new(self.db, new_bytes.into_boxed_slice()))
                 } else {

--- a/crates/red_knot_python_semantic/src/util/subscript.rs
+++ b/crates/red_knot_python_semantic/src/util/subscript.rs
@@ -106,7 +106,7 @@ pub(crate) trait PySlice {
     >;
 }
 
-impl<T> PySlice for &[T] {
+impl<T> PySlice for [T] {
     type Item = T;
 
     fn py_slice(
@@ -257,10 +257,7 @@ mod tests {
         step: Option<i32>,
         expected: &[char; M],
     ) {
-        assert_equal(
-            input.as_slice().py_slice(start, stop, step).unwrap(),
-            expected.iter(),
-        );
+        assert_equal(input.py_slice(start, stop, step).unwrap(), expected.iter());
     }
 
     #[test]
@@ -431,15 +428,15 @@ mod tests {
 
         // Step size zero is invalid:
         assert!(matches!(
-            input.as_slice().py_slice(None, None, Some(0)),
+            input.py_slice(None, None, Some(0)),
             Err(StepSizeZeroError)
         ));
         assert!(matches!(
-            input.as_slice().py_slice(Some(0), Some(5), Some(0)),
+            input.py_slice(Some(0), Some(5), Some(0)),
             Err(StepSizeZeroError)
         ));
         assert!(matches!(
-            input.as_slice().py_slice(Some(0), Some(0), Some(0)),
+            input.py_slice(Some(0), Some(0), Some(0)),
             Err(StepSizeZeroError)
         ));
 


### PR DESCRIPTION
## Summary

Just a minor change to improve the ergonomics of the `PySlice` trait. By implementing `PySlice` for `[T]` rather than `&[T]`, we can call it on `Vec<T>` and `Box<[T]>` without having to have intermediate calls to `.as_slice()` or `.as_ref()`. It can still be called on `&[T]` and `&Box<[T]>`, because the `py_slice` trait method takes `&self`.

## Test Plan

`cargo test -p red_knot_python_semantic`
