### PR TITLE
Switch off the `single_match_else` Clippy lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -188,8 +188,9 @@ missing_panics_doc = "allow"
 module_name_repetitions = "allow"
 must_use_candidate = "allow"
 similar_names = "allow"
+single_match_else = "allow"
 too_many_lines = "allow"
-# To allow `#[allow(clippy::all)]` in `crates/ruff_python_parser/src/python.rs`.
+# Without the hashes we run into a `rustfmt` bug in some snapshot tests, see #13250
 needless_raw_string_hashes = "allow"
 # Disallowed restriction lints
 print_stdout = "warn"

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -3666,7 +3666,6 @@ impl<'db> TypeInferenceBuilder<'db> {
             }
 
             ast::Expr::BinOp(binary) => {
-                #[allow(clippy::single_match_else)]
                 match binary.op {
                     // PEP-604 unions are okay, e.g., `int | str`
                     ast::Operator::BitOr => {


### PR DESCRIPTION
As discussed on Discord, this Clippy lint is pretty noisy and quite subjective. Sometimes it results in more concise/readable code, but sometimes you just want to use a `match` statement. Nobody seemed strongly in favour of keeping the lint.