### PR TITLE
Fix formatting of single with-item with trailing comment

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/with.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/with.py
@@ -328,3 +328,42 @@ with aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa + bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
 if True:
     with anyio.CancelScope(shield=True) if get_running_loop() else contextlib.nullcontext() as b:
         pass
+
+
+# Regression test for https://github.com/astral-sh/ruff/issues/14001
+with (
+    open(
+        "some/path.txt",
+        "rb",
+    )
+    if True
+    else open("other/path.txt")
+    # Bar
+):
+    pass
+
+
+with (  # trailing comment
+    open(
+        "some/path.txt",
+        "rb",
+    )
+    if True
+    else open("other/path.txt")
+    # Bar
+):
+    pass
+
+
+with (
+    (
+        open(
+            "some/path.txt",
+            "rb",
+        )
+        if True
+        else open("other/path.txt")
+    )
+    # Bar
+):
+    pass

--- a/crates/ruff_python_formatter/src/preview.rs
+++ b/crates/ruff_python_formatter/src/preview.rs
@@ -72,3 +72,10 @@ pub(crate) fn is_docstring_code_block_in_docstring_indent_enabled(
 pub(crate) fn is_join_implicit_concatenated_string_enabled(context: &PyFormatContext) -> bool {
     context.is_preview()
 }
+
+/// Returns `true` if the bugfix for single-with items with a trailing comment targeting Python 3.9 or newer is enabled.
+///
+/// See [#14001](https://github.com/astral-sh/ruff/issues/14001)
+pub(crate) fn is_with_single_target_parentheses_enabled(context: &PyFormatContext) -> bool {
+    context.is_preview()
+}

--- a/crates/ruff_python_formatter/tests/snapshots/format@statement__with.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@statement__with.py.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/ruff_python_formatter/tests/fixtures.rs
 input_file: crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/with.py
+snapshot_kind: text
 ---
 ## Input
 ```python
@@ -334,6 +335,45 @@ with aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa + bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
 if True:
     with anyio.CancelScope(shield=True) if get_running_loop() else contextlib.nullcontext() as b:
         pass
+
+
+# Regression test for https://github.com/astral-sh/ruff/issues/14001
+with (
+    open(
+        "some/path.txt",
+        "rb",
+    )
+    if True
+    else open("other/path.txt")
+    # Bar
+):
+    pass
+
+
+with (  # trailing comment
+    open(
+        "some/path.txt",
+        "rb",
+    )
+    if True
+    else open("other/path.txt")
+    # Bar
+):
+    pass
+
+
+with (
+    (
+        open(
+            "some/path.txt",
+            "rb",
+        )
+        if True
+        else open("other/path.txt")
+    )
+    # Bar
+):
+    pass
 ```
 
 ## Outputs
@@ -710,6 +750,49 @@ if True:
         shield=True
     ) if get_running_loop() else contextlib.nullcontext() as b:
         pass
+
+
+# Regression test for https://github.com/astral-sh/ruff/issues/14001
+with (
+    (
+        open(
+            "some/path.txt",
+            "rb",
+        )
+        if True
+        else open("other/path.txt")
+    )
+    # Bar
+):
+    pass
+
+
+with (  # trailing comment
+    (
+        open(
+            "some/path.txt",
+            "rb",
+        )
+        if True
+        else open("other/path.txt")
+    )
+    # Bar
+):
+    pass
+
+
+with (
+    (
+        open(
+            "some/path.txt",
+            "rb",
+        )
+        if True
+        else open("other/path.txt")
+    )
+    # Bar
+):
+    pass
 ```
 
 
@@ -787,7 +870,7 @@ if True:
          pass
  
  with Child(aaaaaaaaa, bbbbbbbbbbbbbbb, cccccc), Document(
-@@ -344,14 +356,20 @@
+@@ -344,57 +356,57 @@
  ):
      pass
  
@@ -813,6 +896,64 @@ if True:
 +        else contextlib.nullcontext()
 +    ) as b:
          pass
+ 
+ 
+ # Regression test for https://github.com/astral-sh/ruff/issues/14001
+ with (
+-    (
+-        open(
+-            "some/path.txt",
+-            "rb",
+-        )
+-        if True
+-        else open("other/path.txt")
++    open(
++        "some/path.txt",
++        "rb",
+     )
++    if True
++    else open("other/path.txt")
+     # Bar
+ ):
+     pass
+ 
+ 
+ with (  # trailing comment
+-    (
+-        open(
+-            "some/path.txt",
+-            "rb",
+-        )
+-        if True
+-        else open("other/path.txt")
++    open(
++        "some/path.txt",
++        "rb",
+     )
++    if True
++    else open("other/path.txt")
+     # Bar
+ ):
+     pass
+ 
+ 
+ with (
+-    (
+-        open(
+-            "some/path.txt",
+-            "rb",
+-        )
+-        if True
+-        else open("other/path.txt")
++    open(
++        "some/path.txt",
++        "rb",
+     )
++    if True
++    else open("other/path.txt")
+     # Bar
+ ):
+     pass
 ```
 
 
@@ -1237,4 +1378,41 @@ if True:
         else contextlib.nullcontext() as b
     ):
         pass
+
+
+# Regression test for https://github.com/astral-sh/ruff/issues/14001
+with (
+    open(
+        "some/path.txt",
+        "rb",
+    )
+    if True
+    else open("other/path.txt")
+    # Bar
+):
+    pass
+
+
+with (  # trailing comment
+    open(
+        "some/path.txt",
+        "rb",
+    )
+    if True
+    else open("other/path.txt")
+    # Bar
+):
+    pass
+
+
+with (
+    open(
+        "some/path.txt",
+        "rb",
+    )
+    if True
+    else open("other/path.txt")
+    # Bar
+):
+    pass
 ```


### PR DESCRIPTION
## Summary

Fixes https://github.com/astral-sh/ruff/issues/14001


The root cause of the incorrect formatting is that `is_expression_parenthesized` returns true for `with (expression)` because it can't
determine that the parentheses belong to the with statement and not the expression. 

The fix is to disregard whether the expression is parenthesized when the with statement is parenthesized and it's a single item. 

## Preview

We need to gate this behind preview because the formatter now removes the unnecessary parentheses

## Test Plan

Added test
