### PR TITLE
Fix panic when filling up types vector during unpacking

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/unpacking.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/unpacking.md
@@ -130,6 +130,19 @@ reveal_type(b)  # revealed: Literal[2]
 reveal_type(c)  # revealed: @Todo
 ```
 
+### Starred expression (6)
+
+```py
+# TODO: Add diagnostic (need more values to unpack)
+(a, b, c, *d, e, f) = (1,)
+reveal_type(a)  # revealed: Literal[1]
+reveal_type(b)  # revealed: Unknown
+reveal_type(c)  # revealed: Unknown
+reveal_type(d)  # revealed: @Todo
+reveal_type(e)  # revealed: Unknown
+reveal_type(f)  # revealed: Unknown
+```
+
 ### Non-iterable unpacking
 
 TODO: Remove duplicate diagnostics. This is happening because for a sequence-like

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -1257,6 +1257,10 @@ impl<'db> TypeInferenceBuilder<'db> {
                                 Cow::Owned(element_types)
                             } else {
                                 let mut element_types = tuple_ty.elements(builder.db).to_vec();
+                                // Subtract 1 to insert the starred expression type at the correct
+                                // index.
+                                element_types.resize(elts.len() - 1, Type::Unknown);
+                                // TODO: This should be `list[Unknown]`
                                 element_types.insert(starred_index, Type::Todo);
                                 Cow::Owned(element_types)
                             }


### PR DESCRIPTION
## Summary

This PR fixes a panic which can occur in an unpack assignment when:
* (number of target expressions) - (number of tuple types) > 2
* There's a starred expression

The reason being that the `insert` panics because the index is greater than the length.

This is an error case and so practically it should occur very rarely. The solution is to resize the types vector to match the number of expressions and then insert the starred expression type.

## Test Plan

Add a new test case.
