### PR TITLE
Fix server panic when undoing an edit

### DIFF
--- a/crates/ruff_python_formatter/src/lib.rs
+++ b/crates/ruff_python_formatter/src/lib.rs
@@ -156,6 +156,7 @@ mod tests {
     use ruff_python_ast::PySourceType;
     use ruff_python_parser::{parse, AsMode};
     use ruff_python_trivia::CommentRanges;
+    use ruff_source_file::{LineIndex, OneIndexed};
     use ruff_text_size::{TextRange, TextSize};
 
     use crate::{format_module_ast, format_module_source, format_range, PyFormatOptions};

--- a/crates/ruff_python_formatter/src/lib.rs
+++ b/crates/ruff_python_formatter/src/lib.rs
@@ -156,7 +156,6 @@ mod tests {
     use ruff_python_ast::PySourceType;
     use ruff_python_parser::{parse, AsMode};
     use ruff_python_trivia::CommentRanges;
-    use ruff_source_file::{LineIndex, OneIndexed};
     use ruff_text_size::{TextRange, TextSize};
 
     use crate::{format_module_ast, format_module_source, format_range, PyFormatOptions};

--- a/crates/ruff_server/src/edit/text_document.rs
+++ b/crates/ruff_server/src/edit/text_document.rs
@@ -94,7 +94,6 @@ impl TextDocument {
             return;
         }
 
-        let old_contents = self.contents().to_string();
         let mut new_contents = self.contents().to_string();
         let mut active_index = self.index().clone();
 
@@ -115,15 +114,11 @@ impl TextDocument {
                 new_contents = change;
             }
 
-            if new_contents != old_contents {
-                active_index = LineIndex::from_source_text(&new_contents);
-            }
+            active_index = LineIndex::from_source_text(&new_contents);
         }
 
         self.modify_with_manual_index(|contents, version, index| {
-            if contents != &new_contents {
-                *index = active_index;
-            }
+            *index = active_index;
             *contents = new_contents;
             *version = new_version;
         });
@@ -151,5 +146,77 @@ impl TextDocument {
         let old_version = self.version;
         func(&mut self.contents, &mut self.version, &mut self.index);
         debug_assert!(self.version >= old_version);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{PositionEncoding, TextDocument};
+    use lsp_types::{Position, TextDocumentContentChangeEvent};
+
+    #[test]
+    fn redo_edit() {
+        let mut document = TextDocument::new(
+            r#""""
+测试comment
+一些测试内容
+"""
+import click
+
+
+@click.group()
+def interface():
+    pas
+"#
+            .to_string(),
+            0,
+        );
+
+        // Add an `s`, remove it again (back to the original code), and then re-add the `s`
+        document.apply_changes(
+            vec![
+                TextDocumentContentChangeEvent {
+                    range: Some(lsp_types::Range::new(
+                        Position::new(9, 7),
+                        Position::new(9, 7),
+                    )),
+                    range_length: Some(0),
+                    text: "s".to_string(),
+                },
+                TextDocumentContentChangeEvent {
+                    range: Some(lsp_types::Range::new(
+                        Position::new(9, 7),
+                        Position::new(9, 8),
+                    )),
+                    range_length: Some(1),
+                    text: "".to_string(),
+                },
+                TextDocumentContentChangeEvent {
+                    range: Some(lsp_types::Range::new(
+                        Position::new(9, 7),
+                        Position::new(9, 7),
+                    )),
+                    range_length: Some(0),
+                    text: "s".to_string(),
+                },
+            ],
+            1,
+            PositionEncoding::UTF16,
+        );
+
+        assert_eq!(
+            &document.contents,
+            r#""""
+测试comment
+一些测试内容
+"""
+import click
+
+
+@click.group()
+def interface():
+    pass
+"#
+        )
     }
 }

--- a/crates/ruff_server/src/edit/text_document.rs
+++ b/crates/ruff_server/src/edit/text_document.rs
@@ -189,7 +189,7 @@ def interface():
                         Position::new(9, 8),
                     )),
                     range_length: Some(1),
-                    text: "".to_string(),
+                    text: String::new(),
                 },
                 TextDocumentContentChangeEvent {
                     range: Some(lsp_types::Range::new(
@@ -217,6 +217,6 @@ import click
 def interface():
     pass
 "#
-        )
+        );
     }
 }


### PR DESCRIPTION
## Summary

Fixes https://github.com/astral-sh/ruff/issues/13674 and possibly https://github.com/astral-sh/ruff-vscode/issues/607

The `TextDocument::apply_changes` contained some naive logic to reuse the `LineIndex` if it happened that the content didn't change. 
Hower, that logic was incorrect because it compared the `new_content` with the **original** document content rather than the content
from the last iteration. This resulted in a stale `LineIndex` when an edit reverts the content to the **original** content. 

I decided to remove the optimization alltogether because it's too naive to be useful in practice. We could apply a logic similar
to Biome's, we avoid recomputing the LineIndex when the previous edits only changed lines further down in the document. [source](https://github.com/biomejs/biome/blob/3401663efea3a3c45a7d9240d72b92c981285fb2/crates/biome_lsp/src/utils.rs#L360-L363)
However, I don't think that this is a big perf bottlneck. Computing a `LineIndex` is relatively cheap.

## Test Plan

I added a unit test
