### PR TITLE
[red-knot] Remove `Type::None`

### DIFF
--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -694,8 +694,9 @@ impl<'db> Type<'db> {
 
             (Type::Instance(..), Type::Instance(..)) => {
                 // TODO: once we have support for `final`, there might be some cases where
-                // we can determine that two types are disjoint. For non-final classes, we
-                // return false (multiple inheritance).
+                // we can determine that two types are disjoint. Once we do this, some cases
+                // above (e.g. NoneType) can be removed. For non-final classes, we return
+                // false (multiple inheritance).
 
                 // TODO: is there anything specific to do for instances of KnownClass::Type?
 

--- a/crates/red_knot_python_semantic/src/types/builder.rs
+++ b/crates/red_knot_python_semantic/src/types/builder.rs
@@ -675,8 +675,8 @@ mod tests {
     fn build_intersection_self_negation() {
         let db = setup_db();
         let ty = IntersectionBuilder::new(&db)
-            .add_positive(Type::None)
-            .add_negative(Type::None)
+            .add_positive(Type::none(&db))
+            .add_negative(Type::none(&db))
             .build();
 
         assert_eq!(ty, Type::Never);
@@ -686,18 +686,18 @@ mod tests {
     fn build_intersection_simplify_negative_never() {
         let db = setup_db();
         let ty = IntersectionBuilder::new(&db)
-            .add_positive(Type::None)
+            .add_positive(Type::none(&db))
             .add_negative(Type::Never)
             .build();
 
-        assert_eq!(ty, Type::None);
+        assert_eq!(ty, Type::none(&db));
     }
 
     #[test]
     fn build_intersection_simplify_positive_never() {
         let db = setup_db();
         let ty = IntersectionBuilder::new(&db)
-            .add_positive(Type::None)
+            .add_positive(Type::none(&db))
             .add_positive(Type::Never)
             .build();
 
@@ -709,14 +709,14 @@ mod tests {
         let db = setup_db();
 
         let ty = IntersectionBuilder::new(&db)
-            .add_negative(Type::None)
+            .add_negative(Type::none(&db))
             .add_positive(Type::IntLiteral(1))
             .build();
         assert_eq!(ty, Type::IntLiteral(1));
 
         let ty = IntersectionBuilder::new(&db)
             .add_positive(Type::IntLiteral(1))
-            .add_negative(Type::None)
+            .add_negative(Type::none(&db))
             .build();
         assert_eq!(ty, Type::IntLiteral(1));
     }
@@ -875,7 +875,7 @@ mod tests {
         let db = setup_db();
 
         let t1 = Type::IntLiteral(1);
-        let t2 = Type::None;
+        let t2 = Type::none(&db);
 
         let ty = IntersectionBuilder::new(&db)
             .add_positive(t1)

--- a/crates/red_knot_python_semantic/src/types/display.rs
+++ b/crates/red_knot_python_semantic/src/types/display.rs
@@ -6,7 +6,7 @@ use ruff_db::display::FormatterJoinExtension;
 use ruff_python_ast::str::Quote;
 use ruff_python_literal::escape::AsciiEscape;
 
-use crate::types::{IntersectionType, Type, UnionType};
+use crate::types::{IntersectionType, KnownClass, Type, UnionType};
 use crate::Db;
 use rustc_hash::FxHashMap;
 
@@ -64,7 +64,9 @@ impl Display for DisplayRepresentation<'_> {
             Type::Any => f.write_str("Any"),
             Type::Never => f.write_str("Never"),
             Type::Unknown => f.write_str("Unknown"),
-            Type::None => f.write_str("None"),
+            Type::Instance(class) if class.is_known(self.db, KnownClass::NoneType) => {
+                f.write_str("None")
+            }
             // `[Type::Todo]`'s display should be explicit that is not a valid display of
             // any other type
             Type::Todo => f.write_str("@Todo"),
@@ -380,7 +382,7 @@ mod tests {
             global_symbol(&db, mod_file, "bar").expect_type(),
             global_symbol(&db, mod_file, "B").expect_type(),
             Type::BooleanLiteral(true),
-            Type::None,
+            Type::none(&db),
         ];
         let union = UnionType::from_elements(&db, union_elements).expect_union();
         let display = format!("{}", union.display(&db));

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -3680,9 +3680,6 @@ impl<'db> TypeInferenceBuilder<'db> {
             Some(Type::Instance(class)) if class.is_known(self.db, KnownClass::NoneType) => {
                 SliceArg::Arg(None)
             }
-            Some(Type::Instance(class)) if class.is_known(self.db, KnownClass::NoneType) => {
-                SliceArg::Arg(None)
-            }
             None => SliceArg::Arg(None),
             _ => SliceArg::Unsupported,
         };

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -1125,7 +1125,12 @@ impl<'db> TypeInferenceBuilder<'db> {
                         if exit_ty
                             .call(
                                 self.db,
-                                &[context_manager_ty, Type::None, Type::None, Type::None],
+                                &[
+                                    context_manager_ty,
+                                    Type::none(self.db),
+                                    Type::none(self.db),
+                                    Type::none(self.db),
+                                ],
                             )
                             .return_ty_result(
                                 self.db,
@@ -1967,7 +1972,7 @@ impl<'db> TypeInferenceBuilder<'db> {
 
     fn infer_expression(&mut self, expression: &ast::Expr) -> Type<'db> {
         let ty = match expression {
-            ast::Expr::NoneLiteral(ast::ExprNoneLiteral { range: _ }) => Type::None,
+            ast::Expr::NoneLiteral(ast::ExprNoneLiteral { range: _ }) => Type::none(self.db),
             ast::Expr::NumberLiteral(literal) => self.infer_number_literal_expression(literal),
             ast::Expr::BooleanLiteral(literal) => self.infer_boolean_literal_expression(literal),
             ast::Expr::StringLiteral(literal) => self.infer_string_literal_expression(literal),
@@ -3672,7 +3677,9 @@ impl<'db> TypeInferenceBuilder<'db> {
                 Err(_) => SliceArg::Unsupported,
             },
             Some(Type::BooleanLiteral(b)) => SliceArg::Arg(Some(i32::from(b))),
-            Some(Type::None) => SliceArg::Arg(None),
+            Some(Type::Instance(class)) if class.is_known(self.db, KnownClass::NoneType) => {
+                SliceArg::Arg(None)
+            }
             Some(Type::Instance(class)) if class.is_known(self.db, KnownClass::NoneType) => {
                 SliceArg::Arg(None)
             }
@@ -3776,7 +3783,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                     .to_instance(self.db)
             }
 
-            ast::Expr::NoneLiteral(_literal) => Type::None,
+            ast::Expr::NoneLiteral(_literal) => Type::none(self.db),
 
             // TODO: parse the expression and check whether it is a string annotation.
             // https://typing.readthedocs.io/en/latest/spec/annotations.html#string-annotations

--- a/crates/red_knot_python_semantic/src/types/narrow.rs
+++ b/crates/red_knot_python_semantic/src/types/narrow.rs
@@ -242,7 +242,7 @@ impl<'db> NarrowingConstraintsBuilder<'db> {
 
                 match if is_positive { *op } else { op.negate() } {
                     ast::CmpOp::IsNot => {
-                        if rhs_ty.is_singleton() {
+                        if rhs_ty.is_singleton(self.db) {
                             let ty = IntersectionBuilder::new(self.db)
                                 .add_negative(rhs_ty)
                                 .build();
@@ -316,7 +316,7 @@ impl<'db> NarrowingConstraintsBuilder<'db> {
             let symbol = self.symbols().symbol_id_by_name(id).unwrap();
 
             let ty = match pattern.value {
-                ast::Singleton::None => Type::None,
+                ast::Singleton::None => Type::none(self.db),
                 ast::Singleton::True => Type::BooleanLiteral(true),
                 ast::Singleton::False => Type::BooleanLiteral(false),
             };


### PR DESCRIPTION
## Summary

Removes `Type::None` in favor of `KnownClass::NoneType.to_instance(…)`.

closes #13670

## Test Plan

Existing tests pass.