### PR TITLE
[red-knot] Add MRO resolution for classes (take 2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1162,12 +1162,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68b900aa2f7301e21c36462b170ee99994de34dff39a4a6a528e80e7376d07e5"
+checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.5",
+ "hashbrown 0.15.0",
  "serde",
 ]
 
@@ -2112,6 +2112,7 @@ dependencies = [
  "countme",
  "dir-test",
  "hashbrown 0.15.0",
+ "indexmap",
  "insta",
  "itertools 0.13.0",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,6 +81,7 @@ hashbrown = { version = "0.15.0", default-features = false, features = [
 ignore = { version = "0.4.22" }
 imara-diff = { version = "0.1.5" }
 imperative = { version = "1.0.4" }
+indexmap = {version = "2.6.0" }
 indicatif = { version = "0.17.8" }
 indoc = { version = "2.0.4" }
 insta = { version = "1.35.1" }

--- a/crates/red_knot_python_semantic/Cargo.toml
+++ b/crates/red_knot_python_semantic/Cargo.toml
@@ -24,7 +24,8 @@ bitflags = { workspace = true }
 camino = { workspace = true }
 compact_str = { workspace = true }
 countme = { workspace = true }
-itertools = { workspace = true}
+indexmap = { workspace = true }
+itertools = { workspace = true }
 ordermap = { workspace = true }
 salsa = { workspace = true }
 thiserror = { workspace = true }
@@ -43,10 +44,9 @@ red_knot_test = { workspace = true }
 red_knot_vendored = { workspace = true }
 
 anyhow = { workspace = true }
-dir-test = {workspace = true}
+dir-test = { workspace = true }
 insta = { workspace = true }
 tempfile = { workspace = true }
 
 [lints]
 workspace = true
-

--- a/crates/red_knot_python_semantic/resources/mdtest/assignment/augmented.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/assignment/augmented.md
@@ -85,7 +85,7 @@ f = Foo()
 # that `Foo.__iadd__` may be unbound as additional context.
 f += "Hello, world!"
 
-reveal_type(f)  # revealed: int | @Todo
+reveal_type(f)  # revealed: int | Unknown
 ```
 
 ## Partially bound with `__add__`

--- a/crates/red_knot_python_semantic/resources/mdtest/attributes.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/attributes.md
@@ -18,3 +18,38 @@ else:
 
 reveal_type(C.x)  # revealed: Literal[1, 2]
 ```
+
+## Inherited attributes
+
+```py
+class A:
+    X = "foo"
+
+class B(A): ...
+class C(B): ...
+
+reveal_type(C.X)  # revealed: Literal["foo"]
+```
+
+## Inherited attributes (multiple inheritance)
+
+```py
+class O: ...
+
+class F(O):
+    X = 56
+
+class E(O):
+    X = 42
+
+class D(O): ...
+class C(D, F): ...
+class B(E, D): ...
+class A(B, C): ...
+
+# revealed: tuple[Literal[A], Literal[B], Literal[E], Literal[C], Literal[D], Literal[F], Literal[O], Literal[object]]
+reveal_type(A.__mro__)
+
+# `E` is earlier in the MRO than `F`, so we should use the type of `E.X`
+reveal_type(A.X)  # revealed: Literal[42]
+```

--- a/crates/red_knot_python_semantic/resources/mdtest/binary/instances.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/binary/instances.md
@@ -202,11 +202,7 @@ reveal_type(A() + B())  # revealed: MyString
 # N.B. Still a subtype of `A`, even though `A` does not appear directly in the class's `__bases__`
 class C(B): ...
 
-# TODO: we currently only understand direct subclasses as subtypes of the superclass.
-# We need to iterate through the full MRO rather than just the class's bases;
-# if we do, we'll understand `C` as a subtype of `A`, and correctly understand this as being
-# `MyString` rather than `str`
-reveal_type(A() + C())  # revealed: str
+reveal_type(A() + C())  # revealed: MyString
 ```
 
 ## Reflected precedence 2

--- a/crates/red_knot_python_semantic/resources/mdtest/mro.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/mro.md
@@ -370,9 +370,9 @@ class Foo(Bar): ...  # error: [cyclic-class-def]
 class Bar(Baz): ...  # error: [cyclic-class-def]
 class Baz(Foo): ...  # error: [cyclic-class-def]
 
-reveal_type(Foo.__mro__)  # revealed: tuple[Literal[Foo], Literal[Bar], Unknown, Literal[object]]
-reveal_type(Bar.__mro__)  # revealed: tuple[Literal[Bar], Literal[Baz], Unknown, Literal[object]]
-reveal_type(Baz.__mro__)  # revealed: tuple[Literal[Baz], Literal[Foo], Unknown, Literal[object]]
+reveal_type(Foo.__mro__)  # revealed: tuple[Literal[Foo], Unknown, Literal[object]]
+reveal_type(Bar.__mro__)  # revealed: tuple[Literal[Bar], Unknown, Literal[object]]
+reveal_type(Baz.__mro__)  # revealed: tuple[Literal[Baz], Unknown, Literal[object]]
 ```
 
 ## Classes with cycles in their MROs, and multiple inheritance
@@ -383,8 +383,8 @@ class Foo(Bar): ...  # error: [cyclic-class-def]
 class Bar(Baz): ...  # error: [cyclic-class-def]
 class Baz(Foo, Spam): ...  # error: [cyclic-class-def]
 
-reveal_type(Foo.__mro__)  # revealed: tuple[Literal[Foo], Literal[Bar], Unknown, Literal[object]]
-reveal_type(Bar.__mro__)  # revealed: tuple[Literal[Bar], Literal[Baz], Unknown, Literal[object]]
+reveal_type(Foo.__mro__)  # revealed: tuple[Literal[Foo], Unknown, Literal[object]]
+reveal_type(Bar.__mro__)  # revealed: tuple[Literal[Bar], Unknown, Literal[object]]
 reveal_type(Baz.__mro__)  # revealed: tuple[Literal[Baz], Unknown, Literal[object]]
 ```
 
@@ -402,8 +402,8 @@ class Bar(Foo): ...
 class Baz(Bar, BarCycle): ...  # error: [cyclic-class-def]
 class Spam(Baz): ...  # error: [cyclic-class-def]
 
-reveal_type(FooCycle.__mro__)  # revealed: tuple[Literal[FooCycle], Literal[BarCycle], Unknown, Literal[object]]
-reveal_type(BarCycle.__mro__)  # revealed: tuple[Literal[BarCycle], Literal[FooCycle], Unknown, Literal[object]]
+reveal_type(FooCycle.__mro__)  # revealed: tuple[Literal[FooCycle], Unknown, Literal[object]]
+reveal_type(BarCycle.__mro__)  # revealed: tuple[Literal[BarCycle], Unknown, Literal[object]]
 reveal_type(Baz.__mro__)  # revealed: tuple[Literal[Baz], Unknown, Literal[object]]
-reveal_type(Spam.__mro__)  # revealed: tuple[Literal[Spam], Literal[Baz], Unknown, Literal[object]]
+reveal_type(Spam.__mro__)  # revealed: tuple[Literal[Spam], Unknown, Literal[object]]
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/mro.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/mro.md
@@ -1,0 +1,397 @@
+# Method Resolution Order tests
+
+Tests that assert that we can infer the correct type for a class's `__mro__` attribute.
+
+This attribute is rarely accessed directly at runtime. However, it's extremely important for *us* to
+know the precise possible values of a class's Method Resolution Order, or we won't be able to infer
+the correct type of attributes accessed from instances.
+
+For documentation on method resolution orders, see:
+
+- <https://docs.python.org/3/glossary.html#term-method-resolution-order>
+- <https://docs.python.org/3/howto/mro.html#python-2-3-mro>
+
+## No bases
+
+```py
+class C:
+    pass
+
+reveal_type(C.__mro__)  # revealed: tuple[Literal[C], Literal[object]]
+```
+
+## The special case: `object` itself
+
+```py
+reveal_type(object.__mro__)  # revealed: tuple[Literal[object]]
+```
+
+## Explicit inheritance from `object`
+
+```py
+class C(object):
+    pass
+
+reveal_type(C.__mro__)  # revealed: tuple[Literal[C], Literal[object]]
+```
+
+## Explicit inheritance from non-`object` single base
+
+```py
+class A:
+    pass
+
+class B(A):
+    pass
+
+reveal_type(B.__mro__)  # revealed: tuple[Literal[B], Literal[A], Literal[object]]
+```
+
+## Linearization of multiple bases
+
+```py
+class A:
+    pass
+
+class B:
+    pass
+
+class C(A, B):
+    pass
+
+reveal_type(C.__mro__)  # revealed: tuple[Literal[C], Literal[A], Literal[B], Literal[object]]
+```
+
+## Complex diamond inheritance (1)
+
+This is "ex_2" from <https://docs.python.org/3/howto/mro.html#the-end>
+
+```py
+class O:
+    pass
+
+class X(O):
+    pass
+
+class Y(O):
+    pass
+
+class A(X, Y):
+    pass
+
+class B(Y, X):
+    pass
+
+reveal_type(A.__mro__)  # revealed: tuple[Literal[A], Literal[X], Literal[Y], Literal[O], Literal[object]]
+reveal_type(B.__mro__)  # revealed: tuple[Literal[B], Literal[Y], Literal[X], Literal[O], Literal[object]]
+```
+
+## Complex diamond inheritance (2)
+
+This is "ex_5" from <https://docs.python.org/3/howto/mro.html#the-end>
+
+```py
+class O:
+    pass
+
+class F(O):
+    pass
+
+class E(O):
+    pass
+
+class D(O):
+    pass
+
+class C(D, F):
+    pass
+
+class B(D, E):
+    pass
+
+class A(B, C):
+    pass
+
+# revealed: tuple[Literal[C], Literal[D], Literal[F], Literal[O], Literal[object]]
+reveal_type(C.__mro__)
+# revealed: tuple[Literal[B], Literal[D], Literal[E], Literal[O], Literal[object]]
+reveal_type(B.__mro__)
+# revealed: tuple[Literal[A], Literal[B], Literal[C], Literal[D], Literal[E], Literal[F], Literal[O], Literal[object]]
+reveal_type(A.__mro__)
+```
+
+## Complex diamond inheritance (3)
+
+This is "ex_6" from <https://docs.python.org/3/howto/mro.html#the-end>
+
+```py
+class O:
+    pass
+
+class F(O):
+    pass
+
+class E(O):
+    pass
+
+class D(O):
+    pass
+
+class C(D, F):
+    pass
+
+class B(E, D):
+    pass
+
+class A(B, C):
+    pass
+
+# revealed: tuple[Literal[C], Literal[D], Literal[F], Literal[O], Literal[object]]
+reveal_type(C.__mro__)
+# revealed: tuple[Literal[B], Literal[E], Literal[D], Literal[O], Literal[object]]
+reveal_type(B.__mro__)
+# revealed: tuple[Literal[A], Literal[B], Literal[E], Literal[C], Literal[D], Literal[F], Literal[O], Literal[object]]
+reveal_type(A.__mro__)
+```
+
+## Complex diamond inheritance (4)
+
+This is "ex_9" from <https://docs.python.org/3/howto/mro.html#the-end>
+
+```py
+class O:
+    pass
+
+class A(O):
+    pass
+
+class B(O):
+    pass
+
+class C(O):
+    pass
+
+class D(O):
+    pass
+
+class E(O):
+    pass
+
+class K1(A, B, C):
+    pass
+
+class K2(D, B, E):
+    pass
+
+class K3(D, A):
+    pass
+
+class Z(K1, K2, K3):
+    pass
+
+# revealed: tuple[Literal[K1], Literal[A], Literal[B], Literal[C], Literal[O], Literal[object]]
+reveal_type(K1.__mro__)
+# revealed: tuple[Literal[K2], Literal[D], Literal[B], Literal[E], Literal[O], Literal[object]]
+reveal_type(K2.__mro__)
+# revealed: tuple[Literal[K3], Literal[D], Literal[A], Literal[O], Literal[object]]
+reveal_type(K3.__mro__)
+# revealed: tuple[Literal[Z], Literal[K1], Literal[K2], Literal[K3], Literal[D], Literal[A], Literal[B], Literal[C], Literal[E], Literal[O], Literal[object]]
+reveal_type(Z.__mro__)
+```
+
+## Inheritance from `Unknown`
+
+```py
+from does_not_exist import DoesNotExist  # error: [unresolved-import]
+
+class A(DoesNotExist):
+    pass
+
+class B:
+    pass
+
+class C:
+    pass
+
+class D(A, B, C):
+    pass
+
+class E(B, C):
+    pass
+
+class F(E, A):
+    pass
+
+reveal_type(A.__mro__)  # revealed: tuple[Literal[A], Unknown, Literal[object]]
+reveal_type(D.__mro__)  # revealed: tuple[Literal[D], Literal[A], Unknown, Literal[B], Literal[C], Literal[object]]
+reveal_type(E.__mro__)  # revealed: tuple[Literal[E], Literal[B], Literal[C], Literal[object]]
+reveal_type(F.__mro__)  # revealed: tuple[Literal[F], Literal[E], Literal[B], Literal[C], Literal[A], Unknown, Literal[object]]
+```
+
+## `__bases__` lists that cause errors at runtime
+
+If the class's `__bases__` cause an exception to be raised at runtime and therefore the class
+creation to fail, we infer the class's `__mro__` as being `[<class>, Unknown, object]`:
+
+```py
+# error: [inconsistent-mro] "Cannot create a consistent method resolution order (MRO) for class `Foo` with bases list `[<class 'object'>, <class 'int'>]`"
+class Foo(object, int):
+    pass
+
+reveal_type(Foo.__mro__)  # revealed: tuple[Literal[Foo], Unknown, Literal[object]]
+
+class Bar(Foo):
+    pass
+
+reveal_type(Bar.__mro__)  # revealed: tuple[Literal[Bar], Literal[Foo], Unknown, Literal[object]]
+
+# This is the `TypeError` at the bottom of "ex_2"
+# in the examples at <https://docs.python.org/3/howto/mro.html#the-end>
+
+class O:
+    pass
+
+class X(O):
+    pass
+
+class Y(O):
+    pass
+
+class A(X, Y):
+    pass
+
+class B(Y, X):
+    pass
+
+reveal_type(A.__mro__)  # revealed: tuple[Literal[A], Literal[X], Literal[Y], Literal[O], Literal[object]]
+reveal_type(B.__mro__)  # revealed: tuple[Literal[B], Literal[Y], Literal[X], Literal[O], Literal[object]]
+
+# error: [inconsistent-mro] "Cannot create a consistent method resolution order (MRO) for class `Z` with bases list `[<class 'A'>, <class 'B'>]`"
+class Z(A, B):
+    pass
+
+reveal_type(Z.__mro__)  # revealed: tuple[Literal[Z], Unknown, Literal[object]]
+
+class AA(Z):
+    pass
+
+reveal_type(AA.__mro__)  # revealed: tuple[Literal[AA], Literal[Z], Unknown, Literal[object]]
+```
+
+## `__bases__` includes a `Union`
+
+We don't support union types in a class's bases; a base must resolve to a single `ClassLiteralType`.
+If we find a union type in a class's bases, we infer the class's `__mro__` as being
+`[<class>, Unknown, object]`, the same as for MROs that cause errors at runtime.
+
+```py
+def returns_bool() -> bool:
+    return True
+
+class A:
+    pass
+
+class B:
+    pass
+
+if returns_bool():
+    x = A
+else:
+    x = B
+
+reveal_type(x)  # revealed: Literal[A, B]
+
+# error: [invalid-base] "Invalid class base with type `Literal[A, B]` (all bases must be a class, `Any`, `Unknown` or `Todo`)"
+class Foo(x):
+    pass
+
+reveal_type(Foo.__mro__)  # revealed: tuple[Literal[Foo], Unknown, Literal[object]]
+```
+
+## `__bases__` includes multiple `Union`s
+
+```py
+def returns_bool() -> bool:
+    return True
+
+class A:
+    pass
+
+class B:
+    pass
+
+class C:
+    pass
+
+class D:
+    pass
+
+if returns_bool():
+    x = A
+else:
+    x = B
+
+if returns_bool():
+    y = C
+else:
+    y = D
+
+reveal_type(x)  # revealed: Literal[A, B]
+reveal_type(y)  # revealed: Literal[C, D]
+
+# error: [invalid-base] "Invalid class base with type `Literal[A, B]` (all bases must be a class, `Any`, `Unknown` or `Todo`)"
+# error: [invalid-base] "Invalid class base with type `Literal[C, D]` (all bases must be a class, `Any`, `Unknown` or `Todo`)"
+class Foo(x, y):
+    pass
+
+reveal_type(Foo.__mro__)  # revealed: tuple[Literal[Foo], Unknown, Literal[object]]
+```
+
+## `__bases__` lists that cause errors... now with `Union`s
+
+```py
+def returns_bool() -> bool:
+    return True
+
+class O:
+    pass
+
+class X(O):
+    pass
+
+class Y(O):
+    pass
+
+if bool():
+    foo = Y
+else:
+    foo = object
+
+# error: [invalid-base] "Invalid class base with type `Literal[Y, object]` (all bases must be a class, `Any`, `Unknown` or `Todo`)"
+class PossibleError(foo, X):
+    pass
+
+reveal_type(PossibleError.__mro__)  # revealed: tuple[Literal[PossibleError], Unknown, Literal[object]]
+
+class A(X, Y):
+    pass
+
+reveal_type(A.__mro__)  # revealed: tuple[Literal[A], Literal[X], Literal[Y], Literal[O], Literal[object]]
+
+if returns_bool():
+    class B(X, Y):
+        pass
+
+else:
+    class B(Y, X):
+        pass
+
+# revealed: tuple[Literal[B], Literal[X], Literal[Y], Literal[O], Literal[object]] | tuple[Literal[B], Literal[Y], Literal[X], Literal[O], Literal[object]]
+reveal_type(B.__mro__)
+
+# error: [invalid-base] "Invalid class base with type `Literal[B, B]` (all bases must be a class, `Any`, `Unknown` or `Todo`)"
+class Z(A, B):
+    pass
+
+reveal_type(Z.__mro__)  # revealed: tuple[Literal[Z], Unknown, Literal[object]]
+```

--- a/crates/red_knot_python_semantic/resources/mdtest/mro.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/mro.md
@@ -14,8 +14,7 @@ For documentation on method resolution orders, see:
 ## No bases
 
 ```py
-class C:
-    pass
+class C: ...
 
 reveal_type(C.__mro__)  # revealed: tuple[Literal[C], Literal[object]]
 ```
@@ -29,8 +28,7 @@ reveal_type(object.__mro__)  # revealed: tuple[Literal[object]]
 ## Explicit inheritance from `object`
 
 ```py
-class C(object):
-    pass
+class C(object): ...
 
 reveal_type(C.__mro__)  # revealed: tuple[Literal[C], Literal[object]]
 ```
@@ -38,11 +36,8 @@ reveal_type(C.__mro__)  # revealed: tuple[Literal[C], Literal[object]]
 ## Explicit inheritance from non-`object` single base
 
 ```py
-class A:
-    pass
-
-class B(A):
-    pass
+class A: ...
+class B(A): ...
 
 reveal_type(B.__mro__)  # revealed: tuple[Literal[B], Literal[A], Literal[object]]
 ```
@@ -50,14 +45,9 @@ reveal_type(B.__mro__)  # revealed: tuple[Literal[B], Literal[A], Literal[object
 ## Linearization of multiple bases
 
 ```py
-class A:
-    pass
-
-class B:
-    pass
-
-class C(A, B):
-    pass
+class A: ...
+class B: ...
+class C(A, B): ...
 
 reveal_type(C.__mro__)  # revealed: tuple[Literal[C], Literal[A], Literal[B], Literal[object]]
 ```
@@ -67,20 +57,11 @@ reveal_type(C.__mro__)  # revealed: tuple[Literal[C], Literal[A], Literal[B], Li
 This is "ex_2" from <https://docs.python.org/3/howto/mro.html#the-end>
 
 ```py
-class O:
-    pass
-
-class X(O):
-    pass
-
-class Y(O):
-    pass
-
-class A(X, Y):
-    pass
-
-class B(Y, X):
-    pass
+class O: ...
+class X(O): ...
+class Y(O): ...
+class A(X, Y): ...
+class B(Y, X): ...
 
 reveal_type(A.__mro__)  # revealed: tuple[Literal[A], Literal[X], Literal[Y], Literal[O], Literal[object]]
 reveal_type(B.__mro__)  # revealed: tuple[Literal[B], Literal[Y], Literal[X], Literal[O], Literal[object]]
@@ -91,26 +72,13 @@ reveal_type(B.__mro__)  # revealed: tuple[Literal[B], Literal[Y], Literal[X], Li
 This is "ex_5" from <https://docs.python.org/3/howto/mro.html#the-end>
 
 ```py
-class O:
-    pass
-
-class F(O):
-    pass
-
-class E(O):
-    pass
-
-class D(O):
-    pass
-
-class C(D, F):
-    pass
-
-class B(D, E):
-    pass
-
-class A(B, C):
-    pass
+class O: ...
+class F(O): ...
+class E(O): ...
+class D(O): ...
+class C(D, F): ...
+class B(D, E): ...
+class A(B, C): ...
 
 # revealed: tuple[Literal[C], Literal[D], Literal[F], Literal[O], Literal[object]]
 reveal_type(C.__mro__)
@@ -125,26 +93,13 @@ reveal_type(A.__mro__)
 This is "ex_6" from <https://docs.python.org/3/howto/mro.html#the-end>
 
 ```py
-class O:
-    pass
-
-class F(O):
-    pass
-
-class E(O):
-    pass
-
-class D(O):
-    pass
-
-class C(D, F):
-    pass
-
-class B(E, D):
-    pass
-
-class A(B, C):
-    pass
+class O: ...
+class F(O): ...
+class E(O): ...
+class D(O): ...
+class C(D, F): ...
+class B(E, D): ...
+class A(B, C): ...
 
 # revealed: tuple[Literal[C], Literal[D], Literal[F], Literal[O], Literal[object]]
 reveal_type(C.__mro__)
@@ -159,35 +114,16 @@ reveal_type(A.__mro__)
 This is "ex_9" from <https://docs.python.org/3/howto/mro.html#the-end>
 
 ```py
-class O:
-    pass
-
-class A(O):
-    pass
-
-class B(O):
-    pass
-
-class C(O):
-    pass
-
-class D(O):
-    pass
-
-class E(O):
-    pass
-
-class K1(A, B, C):
-    pass
-
-class K2(D, B, E):
-    pass
-
-class K3(D, A):
-    pass
-
-class Z(K1, K2, K3):
-    pass
+class O: ...
+class A(O): ...
+class B(O): ...
+class C(O): ...
+class D(O): ...
+class E(O): ...
+class K1(A, B, C): ...
+class K2(D, B, E): ...
+class K3(D, A): ...
+class Z(K1, K2, K3): ...
 
 # revealed: tuple[Literal[K1], Literal[A], Literal[B], Literal[C], Literal[O], Literal[object]]
 reveal_type(K1.__mro__)
@@ -204,23 +140,12 @@ reveal_type(Z.__mro__)
 ```py
 from does_not_exist import DoesNotExist  # error: [unresolved-import]
 
-class A(DoesNotExist):
-    pass
-
-class B:
-    pass
-
-class C:
-    pass
-
-class D(A, B, C):
-    pass
-
-class E(B, C):
-    pass
-
-class F(E, A):
-    pass
+class A(DoesNotExist): ...
+class B: ...
+class C: ...
+class D(A, B, C): ...
+class E(B, C): ...
+class F(E, A): ...
 
 reveal_type(A.__mro__)  # revealed: tuple[Literal[A], Unknown, Literal[object]]
 reveal_type(D.__mro__)  # revealed: tuple[Literal[D], Literal[A], Unknown, Literal[B], Literal[C], Literal[object]]
@@ -235,45 +160,31 @@ creation to fail, we infer the class's `__mro__` as being `[<class>, Unknown, ob
 
 ```py
 # error: [inconsistent-mro] "Cannot create a consistent method resolution order (MRO) for class `Foo` with bases list `[<class 'object'>, <class 'int'>]`"
-class Foo(object, int):
-    pass
+class Foo(object, int): ...
 
 reveal_type(Foo.__mro__)  # revealed: tuple[Literal[Foo], Unknown, Literal[object]]
 
-class Bar(Foo):
-    pass
+class Bar(Foo): ...
 
 reveal_type(Bar.__mro__)  # revealed: tuple[Literal[Bar], Literal[Foo], Unknown, Literal[object]]
 
 # This is the `TypeError` at the bottom of "ex_2"
 # in the examples at <https://docs.python.org/3/howto/mro.html#the-end>
-
-class O:
-    pass
-
-class X(O):
-    pass
-
-class Y(O):
-    pass
-
-class A(X, Y):
-    pass
-
-class B(Y, X):
-    pass
+class O: ...
+class X(O): ...
+class Y(O): ...
+class A(X, Y): ...
+class B(Y, X): ...
 
 reveal_type(A.__mro__)  # revealed: tuple[Literal[A], Literal[X], Literal[Y], Literal[O], Literal[object]]
 reveal_type(B.__mro__)  # revealed: tuple[Literal[B], Literal[Y], Literal[X], Literal[O], Literal[object]]
 
 # error: [inconsistent-mro] "Cannot create a consistent method resolution order (MRO) for class `Z` with bases list `[<class 'A'>, <class 'B'>]`"
-class Z(A, B):
-    pass
+class Z(A, B): ...
 
 reveal_type(Z.__mro__)  # revealed: tuple[Literal[Z], Unknown, Literal[object]]
 
-class AA(Z):
-    pass
+class AA(Z): ...
 
 reveal_type(AA.__mro__)  # revealed: tuple[Literal[AA], Literal[Z], Unknown, Literal[object]]
 ```
@@ -288,11 +199,8 @@ If we find a union type in a class's bases, we infer the class's `__mro__` as be
 def returns_bool() -> bool:
     return True
 
-class A:
-    pass
-
-class B:
-    pass
+class A: ...
+class B: ...
 
 if returns_bool():
     x = A
@@ -302,8 +210,7 @@ else:
 reveal_type(x)  # revealed: Literal[A, B]
 
 # error: [invalid-base] "Invalid class base with type `Literal[A, B]` (all bases must be a class, `Any`, `Unknown` or `Todo`)"
-class Foo(x):
-    pass
+class Foo(x): ...
 
 reveal_type(Foo.__mro__)  # revealed: tuple[Literal[Foo], Unknown, Literal[object]]
 ```
@@ -314,17 +221,10 @@ reveal_type(Foo.__mro__)  # revealed: tuple[Literal[Foo], Unknown, Literal[objec
 def returns_bool() -> bool:
     return True
 
-class A:
-    pass
-
-class B:
-    pass
-
-class C:
-    pass
-
-class D:
-    pass
+class A: ...
+class B: ...
+class C: ...
+class D: ...
 
 if returns_bool():
     x = A
@@ -341,8 +241,7 @@ reveal_type(y)  # revealed: Literal[C, D]
 
 # error: [invalid-base] "Invalid class base with type `Literal[A, B]` (all bases must be a class, `Any`, `Unknown` or `Todo`)"
 # error: [invalid-base] "Invalid class base with type `Literal[C, D]` (all bases must be a class, `Any`, `Unknown` or `Todo`)"
-class Foo(x, y):
-    pass
+class Foo(x, y): ...
 
 reveal_type(Foo.__mro__)  # revealed: tuple[Literal[Foo], Unknown, Literal[object]]
 ```
@@ -353,14 +252,9 @@ reveal_type(Foo.__mro__)  # revealed: tuple[Literal[Foo], Unknown, Literal[objec
 def returns_bool() -> bool:
     return True
 
-class O:
-    pass
-
-class X(O):
-    pass
-
-class Y(O):
-    pass
+class O: ...
+class X(O): ...
+class Y(O): ...
 
 if bool():
     foo = Y
@@ -368,30 +262,98 @@ else:
     foo = object
 
 # error: [invalid-base] "Invalid class base with type `Literal[Y, object]` (all bases must be a class, `Any`, `Unknown` or `Todo`)"
-class PossibleError(foo, X):
-    pass
+class PossibleError(foo, X): ...
 
 reveal_type(PossibleError.__mro__)  # revealed: tuple[Literal[PossibleError], Unknown, Literal[object]]
 
-class A(X, Y):
-    pass
+class A(X, Y): ...
 
 reveal_type(A.__mro__)  # revealed: tuple[Literal[A], Literal[X], Literal[Y], Literal[O], Literal[object]]
 
 if returns_bool():
-    class B(X, Y):
-        pass
+    class B(X, Y): ...
 
 else:
-    class B(Y, X):
-        pass
+    class B(Y, X): ...
 
 # revealed: tuple[Literal[B], Literal[X], Literal[Y], Literal[O], Literal[object]] | tuple[Literal[B], Literal[Y], Literal[X], Literal[O], Literal[object]]
 reveal_type(B.__mro__)
 
 # error: [invalid-base] "Invalid class base with type `Literal[B, B]` (all bases must be a class, `Any`, `Unknown` or `Todo`)"
-class Z(A, B):
-    pass
+class Z(A, B): ...
 
 reveal_type(Z.__mro__)  # revealed: tuple[Literal[Z], Unknown, Literal[object]]
+```
+
+## `__bases__` lists with duplicate bases
+
+```py
+class Foo(str, str): ...  # error: [duplicate-base] "Duplicate base class `str`"
+
+reveal_type(Foo.__mro__)  # revealed: tuple[Literal[Foo], Unknown, Literal[object]]
+
+class Spam: ...
+class Eggs: ...
+
+# error: [duplicate-base] "Duplicate base class `Spam`"
+# error: [duplicate-base] "Duplicate base class `Eggs`"
+class Ham(Spam, Eggs, Spam, Eggs): ...
+
+reveal_type(Ham.__mro__)  # revealed: tuple[Literal[Ham], Unknown, Literal[object]]
+
+class Mushrooms: ...
+class Omelette(Spam, Eggs, Mushrooms, Mushrooms): ...  # error: [duplicate-base]
+
+reveal_type(Omelette.__mro__)  # revealed: tuple[Literal[Omelette], Unknown, Literal[object]]
+```
+
+## `__bases__` lists with duplicate `Unknown` bases
+
+```py
+# error: [unresolved-import]
+# error: [unresolved-import]
+from does_not_exist import unknown_object_1, unknown_object_2
+
+reveal_type(unknown_object_1)  # revealed: Unknown
+reveal_type(unknown_object_2)  # revealed: Unknown
+
+# We *should* emit an error here to warn the user that we have no idea
+# what the MRO of this class should really be.
+# However, we don't complain about "duplicate base classes" here,
+# even though two classes are both inferred as being `Unknown`.
+#
+# error: [inconsistent-mro] "Cannot create a consistent method resolution order (MRO) for class `Foo` with bases list `[Unknown, Unknown]`"
+class Foo(unknown_object_1, unknown_object_2): ...
+
+reveal_type(Foo.__mro__)  # revealed: tuple[Literal[Foo], Unknown, Literal[object]]
+```
+
+## Unrelated objects inferred as `Any`/`Unknown` do not have special `__mro__` attributes
+
+```py
+from does_not_exist import unknown_object  # error: [unresolved-import]
+
+reveal_type(unknown_object)  # revealed: Unknown
+reveal_type(unknown_object.__mro__)  # revealed: Unknown
+```
+
+## Classes that inherit from themselves
+
+These are invalid, but we need to be able to handle them gracefully without panicking.
+
+```py path=a.pyi
+# error: [cyclic-class-def] "Invalid class definition `Foo`: class cannot inherit from itself"
+class Foo(Foo): ...
+
+reveal_type(Foo)  # revealed: Literal[Foo]
+reveal_type(Foo.__mro__)  # revealed: tuple[Literal[Foo], Unknown, Literal[object]]
+
+class Bar: ...
+class Baz: ...
+
+# error: [cyclic-class-def] "Invalid class definition `Boz`: class cannot inherit from itself"
+class Boz(Bar, Baz, Boz): ...
+
+reveal_type(Boz)  # revealed: Literal[Boz]
+reveal_type(Boz.__mro__)  # revealed: tuple[Literal[Boz], Unknown, Literal[object]]
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/scopes/moduletype_attrs.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/scopes/moduletype_attrs.md
@@ -58,11 +58,10 @@ reveal_type(typing.__name__)  # revealed: str
 reveal_type(typing.__init__)  # revealed: Literal[__init__]
 
 # These come from `builtins.object`, not `types.ModuleType`:
-# TODO: we don't currently understand `types.ModuleType` as inheriting from `object`;
-# these should not reveal `Unknown`:
-reveal_type(typing.__eq__)  # revealed: Unknown
-reveal_type(typing.__class__)  # revealed: Unknown
-reveal_type(typing.__module__)  # revealed: Unknown
+reveal_type(typing.__eq__)  # revealed: Literal[__eq__]
+
+# TODO: understand properties
+reveal_type(typing.__class__)  # revealed: Literal[__class__]
 
 # TODO: needs support for attribute access on instances, properties and generics;
 # should be `dict[str, Any]`

--- a/crates/red_knot_python_semantic/resources/mdtest/stubs/class.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/stubs/class.md
@@ -8,8 +8,8 @@ In type stubs, classes can reference themselves in their base class definitions.
 ```py path=a.pyi
 class Foo[T]: ...
 
-# TODO we resolve `Foo[Bar]` to `Unknown` here without emitting a diagnostic.
-# (Ideally we'd understand generics, but failing that, we shouldn't *silently* infer `Unknown`)
+# TODO: actually is subscriptable
+# error: [non-subscriptable]
 class Bar(Foo[Bar]): ...
 
 reveal_type(Bar)  # revealed: Literal[Bar]

--- a/crates/red_knot_python_semantic/resources/mdtest/stubs/class.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/stubs/class.md
@@ -6,7 +6,12 @@ In type stubs, classes can reference themselves in their base class definitions.
 `typeshed`, we have `class str(Sequence[str]): ...`.
 
 ```py path=a.pyi
-class C(C): ...
+class Foo[T]: ...
 
-reveal_type(C)  # revealed: Literal[C]
+# TODO we resolve `Foo[Bar]` to `Unknown` here without emitting a diagnostic.
+# (Ideally we'd understand generics, but failing that, we shouldn't *silently* infer `Unknown`)
+class Bar(Foo[Bar]): ...
+
+reveal_type(Bar)  # revealed: Literal[Bar]
+reveal_type(Bar.__mro__)  # revealed: tuple[Literal[Bar], Unknown, Literal[object]]
 ```

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -1814,11 +1814,9 @@ pub struct ClassType<'db> {
 
 #[salsa::tracked]
 impl<'db> ClassType<'db> {
+    /// Return `true` if this class represents `known_class`
     pub fn is_known(self, db: &'db dyn Db, known_class: KnownClass) -> bool {
-        match self.known(db) {
-            Some(known) => known == known_class,
-            None => false,
-        }
+        self.known(db) == Some(known_class)
     }
 
     /// Return true if this class is a standard library type with given module name and name.
@@ -1829,7 +1827,7 @@ impl<'db> ClassType<'db> {
             })
     }
 
-    /// Return an iterator over the types of this class's explicit bases.
+    /// Return an iterator over the inferred types of this class's *explicit* bases.
     ///
     /// Note that any class (except for `object`) that has no explicit
     /// bases will implicitly inherit from `object` at runtime. Nonetheless,
@@ -1869,8 +1867,8 @@ impl<'db> ClassType<'db> {
 
     /// Iterate over the [method resolution order] ("MRO") of the class.
     ///
-    /// If the MRO could not be accurately resolved, this method falls back to
-    /// an MRO that has the class directly inheriting from `Unknown`. Use
+    /// If the MRO could not be accurately resolved, this method falls back to iterating
+    /// over an MRO that has the class directly inheriting from `Unknown`. Use
     /// [`ClassType::try_mro`] if you need to distinguish between the success and failure
     /// cases rather than simply iterating over the inferred resolution order for the class.
     ///
@@ -1879,6 +1877,7 @@ impl<'db> ClassType<'db> {
         MroIterator::new(db, self)
     }
 
+    /// Return `true` if `other` is present in this class's MRO.
     pub fn is_subclass_of(self, db: &'db dyn Db, other: ClassType) -> bool {
         // `is_subclass_of` is checking the subtype relation, in which gradual types do not
         // participate, so we should not return `True` if we find `Any/Unknown` in the MRO.

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -1827,7 +1827,7 @@ impl<'db> ClassType<'db> {
             })
     }
 
-    /// Iterate through the inferred types of the class's explicit bases.
+    /// Return an iterator over the types of this class's explicit bases.
     ///
     /// Note that any class (except for `object`) that has no explicit
     /// bases will implicitly inherit from `object` at runtime. Nonetheless,

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -1897,7 +1897,7 @@ impl<'db> ClassType<'db> {
             [()].into_iter()
                 .flat_map(move |()| match self.try_mro(db) {
                     Ok(mro) => mro.iter().copied(),
-                    Err(MroError { fallback_mro, .. }) => fallback_mro.iter().copied(),
+                    Err(error) => error.fallback_mro().iter().copied(),
                 })
                 .skip(1),
         )

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -1885,22 +1885,7 @@ impl<'db> ClassType<'db> {
             );
         }
 
-        let member = self.own_class_member(db, name);
-        if !member.is_unbound() {
-            return member;
-        }
-
-        self.inherited_class_member(db, name)
-    }
-
-    /// Returns the inferred type of the class member named `name`.
-    pub(crate) fn own_class_member(self, db: &'db dyn Db, name: &str) -> Symbol<'db> {
-        let scope = self.body_scope(db);
-        symbol(db, scope, name)
-    }
-
-    pub(crate) fn inherited_class_member(self, db: &'db dyn Db, name: &str) -> Symbol<'db> {
-        for superclass in self.mro(db).elements().skip(1) {
+        for superclass in self.mro(db).elements() {
             match superclass {
                 ClassBase::Any | ClassBase::Unknown | ClassBase::Todo => {
                     return Type::from(superclass).member(db, name)
@@ -1915,6 +1900,12 @@ impl<'db> ClassType<'db> {
         }
 
         Symbol::Unbound
+    }
+
+    /// Returns the inferred type of the class member named `name`.
+    pub(crate) fn own_class_member(self, db: &'db dyn Db, name: &str) -> Symbol<'db> {
+        let scope = self.body_scope(db);
+        symbol(db, scope, name)
     }
 }
 

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -62,6 +62,8 @@ use crate::unpack::Unpack;
 use crate::util::subscript::{PyIndex, PySlice};
 use crate::Db;
 
+use super::mro::MroError;
+
 /// Infer all types for a [`ScopeId`], including all definitions and expressions in that scope.
 /// Use when checking a scope, or needing to provide a type for an arbitrary expression in the
 /// scope.
@@ -438,13 +440,55 @@ impl<'db> TypeInferenceBuilder<'db> {
             for definition in self.types.declarations.keys() {
                 if infer_definition_types(self.db, *definition).has_deferred {
                     let deferred = infer_deferred_types(self.db, *definition);
-                    deferred_expression_types.extend(deferred.expressions.iter());
+                    deferred_expression_types.extend(&deferred.expressions);
                 }
             }
-            self.types
-                .expressions
-                .extend(deferred_expression_types.iter());
+            self.types.expressions.extend(deferred_expression_types);
         }
+
+        self.check_class_mros();
+    }
+
+    /// Iterate over all class definitions to check that Python will be able to create
+    /// a consistent "[method resolution order]" for each class at runtime. If not,
+    /// issue a diagnostic.
+    ///
+    /// [method resolution order]: https://docs.python.org/3/glossary.html#term-method-resolution-order
+    fn check_class_mros(&mut self) {
+        let declarations = std::mem::take(&mut self.types.declarations);
+        let class_definitions = declarations
+            .values()
+            .filter_map(|ty| ty.into_class_literal_type());
+
+        for class in class_definitions {
+            match class.try_mro(self.db) {
+                Ok(_) => continue,
+                Err(MroError::InvalidBases(bases)) => {
+                    for (index, base_ty) in bases {
+                        let base_node = &class.node(self.db).bases()[*index];
+                        self.diagnostics.add(
+                            base_node.into(),
+                            "invalid-base",
+                            format_args!(
+                                "Invalid class base with type `{}` (all bases must be a class, `Any`, `Unknown` or `Todo`)",
+                                base_ty.display(self.db)
+                            )
+                        );
+                    }
+                },
+                Err(MroError::UnresolvableMro(bases)) => self.diagnostics.add(
+                    class.node(self.db).into(),
+                    "inconsistent-mro",
+                    format_args!(
+                        "Cannot create a consistent method resolution order (MRO) for class `{}` with bases list `[{}]`",
+                        class.name(self.db),
+                        bases.iter().map(|base|base.display(self.db)).join(", ")
+                    )
+                )
+            }
+        }
+
+        self.types.declarations = declarations;
     }
 
     fn infer_region_definition(&mut self, definition: Definition<'db>) {
@@ -4155,7 +4199,8 @@ mod tests {
     use crate::semantic_index::symbol::FileScopeId;
     use crate::semantic_index::{global_scope, semantic_index, symbol_table, use_def_map};
     use crate::types::{
-        check_types, global_symbol, infer_definition_types, symbol, TypeCheckDiagnostics,
+        check_types, definition_expression_ty, global_symbol, infer_definition_types, symbol,
+        TypeCheckDiagnostics,
     };
     use crate::{HasTy, ProgramSettings, SemanticModel};
     use ruff_db::files::{system_path_to_file, File};
@@ -4164,7 +4209,7 @@ mod tests {
     use ruff_db::testing::assert_function_query_was_not_run;
     use ruff_python_ast::name::Name;
 
-    use super::TypeInferenceBuilder;
+    use super::*;
 
     fn setup_db() -> TestDb {
         let db = TestDb::new();
@@ -4297,8 +4342,15 @@ mod tests {
         let class = ty.expect_class_literal();
 
         let base_names: Vec<_> = class
-            .bases(&db)
-            .map(|base_ty| format!("{}", base_ty.display(&db)))
+            .node(&db)
+            .bases()
+            .iter()
+            .map(|base| {
+                format!(
+                    "{}",
+                    definition_expression_ty(&db, class.definition(&db), base).display(&db)
+                )
+            })
             .collect();
 
         assert_eq!(base_names, vec!["Literal[Base]"]);
@@ -4534,13 +4586,13 @@ mod tests {
         let a = system_path_to_file(&db, "src/a.py").expect("file to exist");
         let c_ty = global_symbol(&db, a, "C").expect_type();
         let c_class = c_ty.expect_class_literal();
-        let mut c_bases = c_class.bases(&db);
-        let b_ty = c_bases.next().unwrap();
-        let b_class = b_ty.expect_class_literal();
+        let c_mro = c_class.mro(&db);
+        let b_ty = c_mro[1];
+        let b_class = b_ty.expect_class();
         assert_eq!(b_class.name(&db), "B");
-        let mut b_bases = b_class.bases(&db);
-        let a_ty = b_bases.next().unwrap();
-        let a_class = a_ty.expect_class_literal();
+        let b_mro = b_class.mro(&db);
+        let a_ty = b_mro[1];
+        let a_class = a_ty.expect_class();
         assert_eq!(a_class.name(&db), "A");
 
         Ok(())
@@ -4689,15 +4741,8 @@ mod tests {
         db.write_file("/src/a.pyi", "class C(object): pass")?;
         let file = system_path_to_file(&db, "/src/a.pyi").unwrap();
         let ty = global_symbol(&db, file, "C").expect_type();
-
-        let base = ty
-            .expect_class_literal()
-            .bases(&db)
-            .next()
-            .expect("there should be at least one base");
-
-        assert_eq!(base.display(&db).to_string(), "Literal[object]");
-
+        let base = ty.expect_class_literal().mro(&db)[1];
+        assert_eq!(base.display(&db).to_string(), "<class 'object'>");
         Ok(())
     }
 

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -4218,10 +4218,7 @@ mod tests {
     use crate::semantic_index::definition::Definition;
     use crate::semantic_index::symbol::FileScopeId;
     use crate::semantic_index::{global_scope, semantic_index, symbol_table, use_def_map};
-    use crate::types::{
-        check_types, definition_expression_ty, global_symbol, infer_definition_types, symbol,
-        TypeCheckDiagnostics,
-    };
+    use crate::types::check_types;
     use crate::{HasTy, ProgramSettings, SemanticModel};
     use ruff_db::files::{system_path_to_file, File};
     use ruff_db::parsed::parsed_module;
@@ -4338,43 +4335,6 @@ mod tests {
         let mut db = setup_db();
         db.write_file("src/foo.py", "from import bar")?;
         assert_public_ty(&db, "src/foo.py", "bar", "Unknown");
-        Ok(())
-    }
-
-    #[test]
-    fn resolve_base_class_by_name() -> anyhow::Result<()> {
-        let mut db = setup_db();
-
-        db.write_dedented(
-            "src/mod.py",
-            "
-            class Base:
-                pass
-
-            class Sub(Base):
-                pass
-            ",
-        )?;
-
-        let mod_file = system_path_to_file(&db, "src/mod.py").expect("file to exist");
-        let ty = global_symbol(&db, mod_file, "Sub").expect_type();
-
-        let class = ty.expect_class_literal();
-
-        let base_names: Vec<_> = class
-            .node(&db)
-            .bases()
-            .iter()
-            .map(|base| {
-                format!(
-                    "{}",
-                    definition_expression_ty(&db, class.definition(&db), base).display(&db)
-                )
-            })
-            .collect();
-
-        assert_eq!(base_names, vec!["Literal[Base]"]);
-
         Ok(())
     }
 

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -4562,12 +4562,12 @@ mod tests {
         let a = system_path_to_file(&db, "src/a.py").expect("file to exist");
         let c_ty = global_symbol(&db, a, "C").expect_type();
         let c_class = c_ty.expect_class_literal();
-        let c_mro = c_class.mro(&db);
-        let b_ty = c_mro[1];
+        let mut c_mro = c_class.mro(&db);
+        let b_ty = c_mro.nth(1).unwrap();
         let b_class = b_ty.expect_class();
         assert_eq!(b_class.name(&db), "B");
-        let b_mro = b_class.mro(&db);
-        let a_ty = b_mro[1];
+        let mut b_mro = b_class.mro(&db);
+        let a_ty = b_mro.nth(1).unwrap();
         let a_class = a_ty.expect_class();
         assert_eq!(a_class.name(&db), "A");
 
@@ -4717,7 +4717,7 @@ mod tests {
         db.write_file("/src/a.pyi", "class C(object): pass")?;
         let file = system_path_to_file(&db, "/src/a.pyi").unwrap();
         let ty = global_symbol(&db, file, "C").expect_type();
-        let base = ty.expect_class_literal().mro(&db)[1];
+        let base = ty.expect_class_literal().mro(&db).nth(1).unwrap();
         assert_eq!(base.display(&db).to_string(), "<class 'object'>");
         Ok(())
     }

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -464,10 +464,9 @@ impl<'db> TypeInferenceBuilder<'db> {
         for class in class_definitions {
             match class.try_mro(self.db).as_ref().map_err(|err| &err.kind) {
                 Ok(_) => continue,
-                Err(MroErrorKind::CyclicClassDefinition{invalid_base_index: base_index}) => {
-                    let base = &class.node(self.db).bases()[*base_index];
+                Err(MroErrorKind::CyclicClassDefinition) => {
                     self.diagnostics.add(
-                        base.into(),
+                        class.node(self.db).into(),
                         "cyclic-class-def",
                         format_args!(
                             "Invalid class definition `{}`: class cannot inherit from itself",

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -447,9 +447,8 @@ impl<'db> TypeInferenceBuilder<'db> {
         self.check_class_definitions();
     }
 
-    /// Iterate over all class definitions to check that Python will be able to create
-    /// a consistent "[method resolution order]" for each class at runtime. If not,
-    /// issue a diagnostic.
+    /// Iterate over all class definitions to check that Python will be able to create a
+    /// consistent "[method resolution order]" for each class at runtime. If not, issue a diagnostic.
     ///
     /// [method resolution order]: https://docs.python.org/3/glossary.html#term-method-resolution-order
     fn check_class_definitions(&mut self) {

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -464,7 +464,7 @@ impl<'db> TypeInferenceBuilder<'db> {
         for class in class_definitions {
             match class.try_mro(self.db) {
                 Ok(_) => continue,
-                Err(MroError::CyclicClassDefinition(base_index)) => {
+                Err(MroError::CyclicClassDefinition{invalid_base_index: base_index}) => {
                     let base = &class.node(self.db).bases()[*base_index];
                     self.diagnostics.add(
                         base.into(),
@@ -498,13 +498,13 @@ impl<'db> TypeInferenceBuilder<'db> {
                         );
                     }
                 },
-                Err(MroError::UnresolvableMro(bases)) => self.diagnostics.add(
+                Err(MroError::UnresolvableMro{bases_list}) => self.diagnostics.add(
                     class.node(self.db).into(),
                     "inconsistent-mro",
                     format_args!(
                         "Cannot create a consistent method resolution order (MRO) for class `{}` with bases list `[{}]`",
                         class.name(self.db),
-                        bases.iter().map(|base|base.display(self.db)).join(", ")
+                        bases_list.iter().map(|base| base.display(self.db)).join(", ")
                     )
                 )
             }

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -433,17 +433,15 @@ impl<'db> TypeInferenceBuilder<'db> {
         }
 
         if self.types.has_deferred {
-            let mut deferred_expression_types: FxHashMap<ScopedExpressionId, Type<'db>> =
-                FxHashMap::default();
             // invariant: only annotations and base classes are deferred, and both of these only
             // occur within a declaration (annotated assignment, function or class definition)
             for definition in self.types.declarations.keys() {
                 if infer_definition_types(self.db, *definition).has_deferred {
                     let deferred = infer_deferred_types(self.db, *definition);
-                    deferred_expression_types.extend(&deferred.expressions);
+                    self.types.expressions.extend(&deferred.expressions);
+                    self.diagnostics.extend(&deferred.diagnostics);
                 }
             }
-            self.types.expressions.extend(deferred_expression_types);
         }
 
         self.check_class_definitions();

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -455,8 +455,9 @@ impl<'db> TypeInferenceBuilder<'db> {
     ///
     /// [method resolution order]: https://docs.python.org/3/glossary.html#term-method-resolution-order
     fn check_class_mros(&mut self) {
-        let declarations = std::mem::take(&mut self.types.declarations);
-        let class_definitions = declarations
+        let class_definitions = self
+            .types
+            .declarations
             .values()
             .filter_map(|ty| ty.into_class_literal_type());
 
@@ -508,8 +509,6 @@ impl<'db> TypeInferenceBuilder<'db> {
                 )
             }
         }
-
-        self.types.declarations = declarations;
     }
 
     fn infer_region_definition(&mut self, definition: Definition<'db>) {

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -4562,11 +4562,11 @@ mod tests {
         let a = system_path_to_file(&db, "src/a.py").expect("file to exist");
         let c_ty = global_symbol(&db, a, "C").expect_type();
         let c_class = c_ty.expect_class_literal();
-        let mut c_mro = c_class.mro(&db);
+        let mut c_mro = c_class.iter_mro(&db);
         let b_ty = c_mro.nth(1).unwrap();
         let b_class = b_ty.expect_class();
         assert_eq!(b_class.name(&db), "B");
-        let mut b_mro = b_class.mro(&db);
+        let mut b_mro = b_class.iter_mro(&db);
         let a_ty = b_mro.nth(1).unwrap();
         let a_class = a_ty.expect_class();
         assert_eq!(a_class.name(&db), "A");
@@ -4717,7 +4717,7 @@ mod tests {
         db.write_file("/src/a.pyi", "class C(object): pass")?;
         let file = system_path_to_file(&db, "/src/a.pyi").unwrap();
         let ty = global_symbol(&db, file, "C").expect_type();
-        let base = ty.expect_class_literal().mro(&db).nth(1).unwrap();
+        let base = ty.expect_class_literal().iter_mro(&db).nth(1).unwrap();
         assert_eq!(base.display(&db).to_string(), "<class 'object'>");
         Ok(())
     }

--- a/crates/red_knot_python_semantic/src/types/mro.rs
+++ b/crates/red_knot_python_semantic/src/types/mro.rs
@@ -13,7 +13,7 @@ use crate::{Db, HasTy, SemanticModel};
 /// The inferred method resolution order of a given class.
 ///
 /// See [`ClassType::mro`] for more details.
-#[derive(PartialEq, Eq, Default, Hash, Clone, Debug)]
+#[derive(PartialEq, Eq, Clone, Debug)]
 pub(super) struct Mro<'db>(Box<[ClassBase<'db>]>);
 
 impl<'db> Mro<'db> {
@@ -195,7 +195,7 @@ impl<'db> FromIterator<ClassBase<'db>> for Mro<'db> {
 }
 
 /// Possible ways in which attempting to resolve the MRO of a class might fail.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, PartialEq, Eq)]
 pub(super) enum MroError<'db> {
     /// The class inherits from one or more invalid bases.
     ///
@@ -229,7 +229,7 @@ pub(super) enum MroError<'db> {
 /// This is much more limited than the [`Type`] enum:
 /// all types that would be invalid to have as a class base are
 /// transformed into [`ClassBase::Unknown`]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub(super) enum ClassBase<'db> {
     Any,
     Unknown,

--- a/crates/red_knot_python_semantic/src/types/mro.rs
+++ b/crates/red_knot_python_semantic/src/types/mro.rs
@@ -1,0 +1,275 @@
+use std::borrow::Cow;
+use std::collections::VecDeque;
+use std::ops::Deref;
+
+use ruff_python_ast as ast;
+
+use super::{definition_expression_ty, ClassType, KnownClass, Type};
+use crate::semantic_index::definition::Definition;
+use crate::{Db, HasTy, SemanticModel};
+
+/// A single possible method resolution order of a given class.
+///
+/// See [`ClassType::mro_possibilities`] for more details.
+#[derive(PartialEq, Eq, Default, Hash, Clone, Debug)]
+pub(super) struct Mro<'db>(Box<[ClassBase<'db>]>);
+
+impl<'db> Mro<'db> {
+    /// In the event that a possible list of bases would (or could) lead to a
+    /// `TypeError` being raised at runtime due to an unresolvable MRO, we
+    /// infer the class as being `[<the class in question>, Unknown, object]`.
+    /// This seems most likely to reduce the possibility of cascading errors
+    /// elsewhere.
+    ///
+    /// (We emit a diagnostic warning about the runtime `TypeError` in
+    /// [`super::infer::TypeInferenceBuilder::infer_region_scope`].)
+    pub(super) fn from_error(db: &'db dyn Db, class: ClassType<'db>) -> Self {
+        Self::from([
+            ClassBase::Class(class),
+            ClassBase::Unknown,
+            ClassBase::object(db),
+        ])
+    }
+
+    pub(super) fn of_class(db: &'db dyn Db, class: ClassType<'db>) -> Result<Self, MroError<'db>> {
+        let class_stmt_node = class.node(db);
+
+        match class_stmt_node.bases() {
+            [] if class.is_known(db, KnownClass::Object) => {
+                Ok(Self::from([ClassBase::Class(class)]))
+            }
+            [] => Ok(Self::from([ClassBase::Class(class), ClassBase::object(db)])),
+            [single_base] => {
+                ClassBase::try_from_node(db, single_base, class_stmt_node, class.definition(db))
+                    .map(|base| {
+                        std::iter::once(ClassBase::Class(class))
+                            .chain(Mro::of_base(db, base).iter().copied())
+                            .collect()
+                    })
+                    .map_err(|base_ty| MroError::InvalidBases(Box::from([(0, base_ty)])))
+            }
+            multiple_bases => {
+                let definition = class.definition(db);
+                let mut valid_bases = vec![];
+                let mut invalid_bases = vec![];
+
+                for (i, base_node) in multiple_bases.iter().enumerate() {
+                    match ClassBase::try_from_node(db, base_node, class_stmt_node, definition) {
+                        Ok(valid_base) => valid_bases.push(valid_base),
+                        Err(invalid_base) => invalid_bases.push((i, invalid_base)),
+                    }
+                }
+
+                if !invalid_bases.is_empty() {
+                    return Err(MroError::InvalidBases(invalid_bases.into_boxed_slice()));
+                }
+
+                let mut seqs = vec![VecDeque::from([ClassBase::Class(class)])];
+                for base in &valid_bases {
+                    seqs.push(Mro::of_base(db, *base).iter().copied().collect());
+                }
+                seqs.push(valid_bases.iter().copied().collect());
+
+                c3_merge(seqs)
+                    .ok_or_else(|| MroError::UnresolvableMro(valid_bases.into_boxed_slice()))
+            }
+        }
+    }
+
+    pub(super) fn of_ty(db: &'db dyn Db, ty: Type<'db>) -> Option<Cow<'db, Self>> {
+        ClassBase::try_from_ty(ty).map(|as_base| Self::of_base(db, as_base))
+    }
+
+    fn of_base(db: &'db dyn Db, base: ClassBase<'db>) -> Cow<'db, Self> {
+        match base {
+            ClassBase::Any => Cow::Owned(Mro::from([ClassBase::Any, ClassBase::object(db)])),
+            ClassBase::Unknown => {
+                Cow::Owned(Mro::from([ClassBase::Unknown, ClassBase::object(db)]))
+            }
+            ClassBase::Todo => Cow::Owned(Mro::from([ClassBase::Todo, ClassBase::object(db)])),
+            ClassBase::Class(class) => class.mro(db),
+        }
+    }
+}
+
+impl<'db, const N: usize> From<[ClassBase<'db>; N]> for Mro<'db> {
+    fn from(value: [ClassBase<'db>; N]) -> Self {
+        Self(Box::from(value))
+    }
+}
+
+impl<'db> From<Vec<ClassBase<'db>>> for Mro<'db> {
+    fn from(value: Vec<ClassBase<'db>>) -> Self {
+        Self(value.into_boxed_slice())
+    }
+}
+
+impl<'db> Deref for Mro<'db> {
+    type Target = [ClassBase<'db>];
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<'db> FromIterator<ClassBase<'db>> for Mro<'db> {
+    fn from_iter<T: IntoIterator<Item = ClassBase<'db>>>(iter: T) -> Self {
+        Self(iter.into_iter().collect())
+    }
+}
+
+impl<'a, 'db> IntoIterator for &'a Mro<'db> {
+    type IntoIter = std::slice::Iter<'a, ClassBase<'db>>;
+    type Item = &'a ClassBase<'db>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.iter()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(super) enum MroError<'db> {
+    InvalidBases(Box<[(usize, Type<'db>)]>),
+    UnresolvableMro(Box<[ClassBase<'db>]>),
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub(super) enum ClassBase<'db> {
+    Any,
+    Unknown,
+    Todo,
+    Class(ClassType<'db>),
+}
+
+impl<'db> ClassBase<'db> {
+    fn object(db: &'db dyn Db) -> Self {
+        KnownClass::Object
+            .to_class(db)
+            .into_class_literal_type()
+            .map_or(Self::Unknown, Self::Class)
+    }
+
+    fn try_from_node(
+        db: &'db dyn Db,
+        base_node: &'db ast::Expr,
+        class_stmt_node: &'db ast::StmtClassDef,
+        definition: Definition<'db>,
+    ) -> Result<Self, Type<'db>> {
+        let base_ty = if class_stmt_node.type_params.is_some() {
+            // when we have a specialized scope, we'll look up the inference
+            // within that scope
+            let model = SemanticModel::new(db, definition.file(db));
+            base_node.ty(&model)
+        } else {
+            // Otherwise, we can do the lookup based on the definition scope
+            definition_expression_ty(db, definition, base_node)
+        };
+
+        Self::try_from_ty(base_ty).ok_or(base_ty)
+    }
+
+    fn try_from_ty(ty: Type<'db>) -> Option<Self> {
+        match ty {
+            Type::Any => Some(Self::Any),
+            Type::Unknown => Some(Self::Unknown),
+            Type::Todo => Some(Self::Todo),
+            Type::ClassLiteral(class) => Some(Self::Class(class)),
+            Type::Union(_) => None, // TODO -- forces consideration of multiple possible MROs?
+            Type::Intersection(_) => None, // TODO -- probably incorrect?
+            Type::Instance(_) => None, // TODO -- handle `__mro_entries__`?
+            Type::Never
+            | Type::None
+            | Type::BooleanLiteral(_)
+            | Type::FunctionLiteral(_)
+            | Type::BytesLiteral(_)
+            | Type::IntLiteral(_)
+            | Type::StringLiteral(_)
+            | Type::LiteralString
+            | Type::Tuple(_)
+            | Type::SliceLiteral(_)
+            | Type::ModuleLiteral(_) => None,
+        }
+    }
+
+    pub(super) fn display(self, db: &'db dyn Db) -> impl std::fmt::Display + 'db {
+        struct Display<'db> {
+            base: ClassBase<'db>,
+            db: &'db dyn Db,
+        }
+
+        impl std::fmt::Display for Display<'_> {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                match self.base {
+                    ClassBase::Any => f.write_str("Any"),
+                    ClassBase::Todo => f.write_str("Todo"),
+                    ClassBase::Unknown => f.write_str("Unknown"),
+                    ClassBase::Class(class) => write!(f, "<class '{}'>", class.name(self.db)),
+                }
+            }
+        }
+
+        Display { base: self, db }
+    }
+
+    #[cfg(test)]
+    #[track_caller]
+    pub(super) fn expect_class(self) -> ClassType<'db> {
+        match self {
+            ClassBase::Class(class) => class,
+            _ => panic!("Expected a `ClassBase::Class()` variant"),
+        }
+    }
+}
+
+impl<'db> From<ClassBase<'db>> for Type<'db> {
+    fn from(value: ClassBase<'db>) -> Self {
+        match value {
+            ClassBase::Any => Type::Any,
+            ClassBase::Todo => Type::Todo,
+            ClassBase::Unknown => Type::Unknown,
+            ClassBase::Class(class) => Type::ClassLiteral(class),
+        }
+    }
+}
+
+/// Implementation of the [C3-merge algorithm] for calculating a Python class's
+/// [method resolution order].
+///
+/// [C3-merge algorithm]: https://docs.python.org/3/howto/mro.html#python-2-3-mro
+/// [method resolution order]: https://docs.python.org/3/glossary.html#term-method-resolution-order
+fn c3_merge(mut sequences: Vec<VecDeque<ClassBase>>) -> Option<Mro> {
+    // Most MROs aren't that long...
+    let mut mro = Vec::with_capacity(8);
+
+    loop {
+        sequences.retain(|sequence| !sequence.is_empty());
+
+        if sequences.is_empty() {
+            return Some(Mro::from(mro));
+        }
+
+        // If the candidate exists "deeper down" in the inheritance hierarchy,
+        // we should refrain from adding it to the MRO for now. Add the first candidate
+        // for which this does not hold true. If this holds true for all candidates,
+        // return `None`; it will be impossible to find a consistent MRO for the class
+        // with the given bases.
+        let mro_entry = sequences.iter().find_map(|outer_sequence| {
+            let candidate = outer_sequence[0];
+
+            let not_head = sequences
+                .iter()
+                .all(|sequence| sequence.iter().skip(1).all(|base| base != &candidate));
+
+            not_head.then_some(candidate)
+        })?;
+
+        mro.push(mro_entry);
+
+        // Make sure we don't try to add the candidate to the MRO twice:
+        for sequence in &mut sequences {
+            if sequence[0] == mro_entry {
+                sequence.pop_front();
+            }
+        }
+    }
+}

--- a/crates/red_knot_python_semantic/src/types/mro.rs
+++ b/crates/red_knot_python_semantic/src/types/mro.rs
@@ -46,7 +46,7 @@ impl<'db> Mro<'db> {
 
             // All other classes in Python have an MRO with length >=2.
             // Even if a class has no explicit base classes,
-            // it will implicitly inherit from `objet` at runtime;
+            // it will implicitly inherit from `object` at runtime;
             // `object` will appear in the class's `__bases__` list and `__mro__`:
             //
             // ```pycon

--- a/crates/red_knot_python_semantic/src/types/mro.rs
+++ b/crates/red_knot_python_semantic/src/types/mro.rs
@@ -333,7 +333,7 @@ impl<'db> ClassBase<'db> {
                 Either::Left([ClassBase::Unknown, ClassBase::object(db)].into_iter())
             }
             ClassBase::Todo => Either::Left([ClassBase::Todo, ClassBase::object(db)].into_iter()),
-            ClassBase::Class(class) => Either::Right(class.mro(db)),
+            ClassBase::Class(class) => Either::Right(class.iter_mro(db)),
         }
     }
 }

--- a/crates/red_knot_python_semantic/src/types/mro.rs
+++ b/crates/red_knot_python_semantic/src/types/mro.rs
@@ -185,8 +185,18 @@ impl<'db> FromIterator<ClassBase<'db>> for Mro<'db> {
 
 #[derive(Debug, PartialEq, Eq)]
 pub(super) struct MroError<'db> {
-    pub(super) kind: MroErrorKind<'db>,
-    pub(super) fallback_mro: Mro<'db>,
+    kind: MroErrorKind<'db>,
+    fallback_mro: Mro<'db>,
+}
+
+impl<'db> MroError<'db> {
+    pub(super) fn reason(&self) -> &MroErrorKind<'db> {
+        &self.kind
+    }
+
+    pub(super) fn fallback_mro(&self) -> &Mro<'db> {
+        &self.fallback_mro
+    }
 }
 
 /// Possible ways in which attempting to resolve the MRO of a class might fail.

--- a/crates/red_knot_python_semantic/src/types/mro.rs
+++ b/crates/red_knot_python_semantic/src/types/mro.rs
@@ -375,7 +375,6 @@ impl<'db> ClassBase<'db> {
             Type::Intersection(_) => None, // TODO -- probably incorrect?
             Type::Instance(_) => None, // TODO -- handle `__mro_entries__`?
             Type::Never
-            | Type::None
             | Type::BooleanLiteral(_)
             | Type::FunctionLiteral(_)
             | Type::BytesLiteral(_)

--- a/crates/ruff_benchmark/benches/red_knot.rs
+++ b/crates/ruff_benchmark/benches/red_knot.rs
@@ -27,6 +27,7 @@ static EXPECTED_DIAGNOSTICS: &[&str] = &[
     "/src/tomllib/_parser.py:7:29: Module `collections.abc` has no member `Iterable`",
     // We don't support terminal statements in control flow yet:
     "/src/tomllib/_parser.py:246:15: Method `__class_getitem__` of type `Literal[frozenset]` is possibly unbound",
+    "/src/tomllib/_parser.py:692:8354: Invalid class base with type `GenericAlias` (all bases must be a class, `Any`, `Unknown` or `Todo`)",
     "/src/tomllib/_parser.py:66:18: Name `s` used when possibly not defined",
     "/src/tomllib/_parser.py:98:12: Name `char` used when possibly not defined",
     "/src/tomllib/_parser.py:101:12: Name `char` used when possibly not defined",


### PR DESCRIPTION
A second attempt at implementing MRO resolution (see #13722 for the first attempt). Unlike the first attempt, this version does _not_ attempt to handle union types in a class's bases list (which would potentially mean that you would have to consider multiple possible MROs for any given class).

## Summary

A Python class's ["Method Resolution Order"](https://docs.python.org/3/glossary.html#term-method-resolution-order) ("MRO") is the order in which superclasses of that class are traversed by the Python runtime when searching for an attribute (which includes methods) on that class. Accurately inferring a class's MRO is essential for a type checker if it is going to be able to accurately lookup the types of attributes and methods accessed on that class (or instances of that class).

For simple classes, the MRO (which is accessible at runtime via the `__mro__` attribute on a class) is simple:

```pycon
>>> object.__mro__
(<class 'object'>,)
>>> class Foo: pass
... 
>>> Foo.__mro__  # classes without explicit bases implicitly inherit from `object`
(<class '__main__.Foo'>, <class 'object'>)
>>> class Bar(Foo): pass
... 
>>> Bar.__mro__
(<class '__main__.Bar'>, <class '__main__.Foo'>, <class 'object'>)
```

For more complex classes that use multiple inheritance, things can get a bit more complicated, however:

```pycon
>>> class Foo: pass
... 
>>> class Bar(Foo): pass
... 
>>> class Baz(Foo): pass
... 
>>> class Spam(Bar, Baz): pass
... 
>>> Spam.__mro__  # no class ever appears more than once in an `__mro__`
(<class '__main__.Spam'>, <class '__main__.Bar'>, <class '__main__.Baz'>, <class '__main__.Foo'>, <class 'object'>)
```

And for some classes, Python realises that it cannot determine which order the superclasses should be positioned in order to create the MRO at class creation time:

```pycon
>>> class Foo(object, int): pass
... 
Traceback (most recent call last):
  File "<python-input-12>", line 1, in <module>
    class Foo(object, int): pass
TypeError: Cannot create a consistent method resolution order (MRO) for bases object, int
>>> class A: pass
... 
>>> class B: pass
... 
>>> class C(A, B): pass
... 
>>> class D(B, A): pass
... 
>>> class E(C, D): pass
... 
Traceback (most recent call last):
  File "<python-input-17>", line 1, in <module>
    class E(C, D): pass
TypeError: Cannot create a consistent method resolution order (MRO) for bases A, B
```

The algorithm Python uses at runtime to determine what a class's MRO should be is known as the C3 linearisation algorithm. An in-depth description of the motivations and details of the algorithm can be found in [this article](https://docs.python.org/3/howto/mro.html#python-2-3-mro) in the Python docs. The article is quite old, however, and the algorithm given at the bottom of the page is written in Python 2. As part of working on this PR, I translated the algorithm first into Python 3 (see [this gist](https://gist.github.com/AlexWaygood/674db1fce6856a90f251f63e73853639)), and then into Rust (the `c3_merge` function in `mro.rs` in this PR). In order for us to correctly infer a class's MRO, we need our own implementation of the C3 linearisation algorithm.

As well as implementing the C3 linearisation algorithm in Rust, I also had to make some changes to account for the fact that a class might have a dynamic type in its bases: in our current model, we have three dynamic types, which are `Unknown`, `Any` and `Todo`. This PR takes the simple approach of deciding that the MRO of `Any` is `[Any, object]`, the MRO of `Unknown` is `[Unknown, object]`, and the MRO of `Todo` is `[Todo, object]`; other than that, they are not treated particularly specially by the C3 linearisation algorithm. Other than simplicity, this has a few advantages:
- It matches the runtime:
  ```pycon
  >>> from typing import Any
  >>> Any.__mro__
  (typing.Any, <class 'object'>)
  ```
- It means that they behave just like any other class base in Python: an invariant upheld by all other class bases in Python is that they all inherit from `object`.

Dynamic types will have to be treated specially when it comes to attribute and method access from these types; however, that is for a separate PR.

## Implementation strategy

The implementation is encapsulated in a new `red_knot_python_semantic` submodule, `types/mro.rs`. `ClassType::try_mro` attempts to resolve a class's MRO, and returns an error if it cannot; `ClassType::mro` is a wrapper around `ClassType::try_mro` that resolves the MRO to `[<class in question>, Unknown, builtins.object]` if no MRO for the class could be resolved.

It's necessary for us to emit a diagnostic if we can determine that a particular list of bases will (or could) cause a `TypeError` to be raised at runtime due to an unresolvable MRO. However, we can't do this while creating the `ClassType` and storing it in `self.types.declarations` in `infer.rs`, as we need to know the bases of the class in order to determine its MRO, and some of the bases may be deferred. This PR therefore iterates over all classes in a certain scope after all types (including deferred types) have been inferred, as part of `TypeInferenceBuilder::infer_region_scope`. For types that will (or could) raise an exception due to an invalid MRO, we infer the MRO as being `[<class in question>, Unknown, object]` as well as emitting the diagnostic.

We also emit diagnostics for classes that inherit from bases which would be too complicated for us to resolve an MRO for: anything except a class-literal, `Any`, `Unknown` or `Todo` is rejected.

I deleted the `ClassType::bases()` method, because:
- It's easier to calculate the MRO if you work directly from the AST rather than having an intermediate method that converts the slice of AST nodes into an iterator of types
- There are no direct uses of `ClassType::bases()` in `types.rs` or `infer.rs` anymore now (they all should have been iterating over the MRO all along!).
- The `bases()` method was something of a footgun: it only gave you the slice of the class's _explicit_ bases, and ignored the fact that a class will _implicitly_ have `object` in its bases list at runtime if it has no _explicit_ bases.

## Test Plan

Lots of mdtests added. Several tests taken from https://docs.python.org/3/howto/mro.html#python-2-3-mro.