### PR TITLE
Give non-existent files a durability of at least Medium

### DIFF
--- a/crates/ruff_db/src/files.rs
+++ b/crates/ruff_db/src/files.rs
@@ -102,7 +102,9 @@ impl Files {
                     Ok(metadata) if metadata.file_type().is_directory() => {
                         builder.status(FileStatus::IsADirectory)
                     }
-                    _ => builder.status(FileStatus::NotFound),
+                    _ => builder
+                        .status(FileStatus::NotFound)
+                        .status_durability(Durability::MEDIUM.max(durability)),
                 };
 
                 builder.new(db)


### PR DESCRIPTION
## Summary

Partially addresses https://github.com/astral-sh/ruff/issues/13169

The solution isn't ideal, but our problem is that the module resolves first queries if certain first-party files exist and only then resolves the standard library modules. The issue with that is that any query that depends on a resolved standard library module now depends on non-existing LOW durability files, negating the benefit of giving standard library files high durability. 

This PR changes the durability of the `File::status` to at least medium. This is still not perfect because it means that all standard library queries that depend on module resolution still have a MEDIUM durability instead of HIGH, but it's better than what we have today, and it should allow Salsa to take the "fast-incremental path" more often. 

This possibly helps with https://github.com/astral-sh/ruff/pull/14024

## Test Plan

See benchmarks
