### PR TITLE
[red-knot] Implement type narrowing for boolean conditionals

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/narrow/conditionals_boolean.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/narrow/conditionals_boolean.md
@@ -124,20 +124,19 @@ else:
 ```py
 class A: ...
 class B: ...
-class C: ...
 
-def instance() -> A | B | C:
+def instance() -> A | B:
     return A()
 
 x = instance()
 y = instance()
 
-if isinstance(x, A) or isinstance(y, B):
-    reveal_type(x)  # revealed:  A | B | C
-    reveal_type(y)  # revealed:  A | B | C
+if isinstance(x, A) or isinstance(y, A):
+    reveal_type(x)  # revealed:  A | B
+    reveal_type(y)  # revealed:  A | B
 else:
-    reveal_type(x)  # revealed:  B & ~A | C & ~A
-    reveal_type(y)  # revealed:  A & ~B | C & ~B
+    reveal_type(x)  # revealed:  B & ~A
+    reveal_type(y)  # revealed:  B & ~A
 ```
 
 ## mixing `and` and `not`

--- a/crates/red_knot_python_semantic/resources/mdtest/narrow/conditionals_boolean.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/narrow/conditionals_boolean.md
@@ -41,17 +41,46 @@ if bool_instance() and isinstance(x, A):
 else:
     reveal_type(x)  # revealed: A | B
 
-if True and isinstance(x, A):
-    reveal_type(x)  # revealed: A
-else:
-    # TODO: Consider statically known arms. Should be B & ~A
-    reveal_type(x)  # revealed: A | B
+reveal_type(x)  # revealed: A | B
+```
+
+## Statically known arms
+
+```py
+class A: ...
+class B: ...
+
+def instance() -> A | B:
+    return A()
+
+x = instance()
 
 if isinstance(x, A) and True:
     reveal_type(x)  # revealed: A
 else:
-    # TODO: Consider statically known arms. Should be B & ~A
+    reveal_type(x)  # revealed: B & ~A
+
+if True and isinstance(x, A):
+    reveal_type(x)  # revealed: A
+else:
+    reveal_type(x)  # revealed: B & ~A
+
+if False and isinstance(x, A):
+    # TODO: should emit an `unreachable code` diagnostic
+    reveal_type(x)  # revealed: A
+else:
     reveal_type(x)  # revealed: A | B
+
+if False or isinstance(x, A):
+    reveal_type(x)  # revealed: A
+else:
+    reveal_type(x)  # revealed: B & ~A
+
+if True or isinstance(x, A):
+    reveal_type(x)  # revealed: A | B
+else:
+    # TODO: should emit an `unreachable code` diagnostic
+    reveal_type(x)  # revealed: B & ~A
 
 reveal_type(x)  # revealed: A | B
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/narrow/conditionals_boolean.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/narrow/conditionals_boolean.md
@@ -84,7 +84,7 @@ else:
     reveal_type(x)  # revealed:  C & ~A & ~B
 ```
 
-## In `or`, All arms should add constraint in order to narrow
+## In `or`, all arms should add constraint in order to narrow
 
 ```py
 class A: ...
@@ -206,4 +206,24 @@ else:
     # ~A | (C & ~B) ->
     # ~A | (C & ~B)  The positive side of ~A is  A | B | C ->
     reveal_type(x)  # revealed:  B & ~A | C & ~A | C & ~B
+```
+
+## Boolean expression internal narrowing
+
+```py
+def optional_string() -> str | None:
+    return None
+
+x = optional_string()
+y = optional_string()
+
+if x is None and y is not x:
+    reveal_type(y)  # revealed: str
+
+# Neither of the conditions alone is sufficient for narrowing y's type:
+if x is None:
+    reveal_type(y)  # revealed: str | None
+
+if y is not x:
+    reveal_type(y)  # revealed: str | None
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/narrow/conditionals_boolean.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/narrow/conditionals_boolean.md
@@ -1,0 +1,209 @@
+# Narrowing for conditionals with boolean expressions
+
+## Narrowing in `and` conditional
+
+```py
+class A: ...
+class B: ...
+
+def instance() -> A | B:
+    return A()
+
+x = instance()
+
+if isinstance(x, A) and isinstance(x, B):
+    reveal_type(x)  # revealed:  A & B
+else:
+    reveal_type(x)  # revealed:  B & ~A | A & ~B
+```
+
+## Arms might not add narrowing constraints
+
+```py
+class A: ...
+class B: ...
+
+def instance() -> A | B:
+    return A()
+
+x = instance()
+
+if isinstance(x, A) and True:
+    reveal_type(x)  # revealed: A
+else:
+    reveal_type(x)  # revealed: A | B
+
+if True and isinstance(x, A):
+    reveal_type(x)  # revealed: A
+else:
+    reveal_type(x)  # revealed: A | B
+
+reveal_type(x)  # revealed: A | B
+```
+
+## The type of multiple symbols can be narrowed down
+
+```py
+class A: ...
+class B: ...
+
+def instance() -> A | B:
+    return A()
+
+x = instance()
+y = instance()
+
+if isinstance(x, A) and isinstance(y, B):
+    reveal_type(x)  # revealed: A
+    reveal_type(y)  # revealed: B
+else:
+    # No narrowing: Only-one or both checks might have failed
+    reveal_type(x)  # revealed: A | B
+    reveal_type(y)  # revealed: A | B
+
+reveal_type(x)  # revealed: A | B
+reveal_type(y)  # revealed: A | B
+```
+
+## Narrowing in `or` conditional
+
+```py
+class A: ...
+class B: ...
+class C: ...
+
+def instance() -> A | B | C:
+    return A()
+
+x = instance()
+
+if isinstance(x, A) or isinstance(x, B):
+    reveal_type(x)  # revealed:  A | B
+else:
+    # TODO: Should be simplified to C
+    reveal_type(x)  # revealed:  C & ~A & ~B
+```
+
+## In `or`, All arms should add constraint in order to narrow
+
+```py
+class A: ...
+class B: ...
+class C: ...
+
+def instance() -> A | B | C:
+    return A()
+
+def bool_instance() -> bool:
+    return True
+
+x = instance()
+
+if isinstance(x, A) or isinstance(x, B) or bool_instance():
+    reveal_type(x)  # revealed:  A | B | C
+else:
+    reveal_type(x)  # revealed:  C & ~A & ~B
+```
+
+## in `or`, all arms should narrow the same symbol
+
+```py
+class A: ...
+class B: ...
+class C: ...
+
+def instance() -> A | B | C:
+    return A()
+
+x = instance()
+y = instance()
+
+if isinstance(x, A) or isinstance(y, B):
+    reveal_type(x)  # revealed:  A | B | C
+    reveal_type(y)  # revealed:  A | B | C
+else:
+    reveal_type(x)  # revealed:  B & ~A | C & ~A
+    reveal_type(y)  # revealed:  A & ~B | C & ~B
+```
+
+## mixing `and` and `not`
+
+```py
+class A: ...
+class B: ...
+class C: ...
+
+def instance() -> A | B | C:
+    return A()
+
+x = instance()
+
+if isinstance(x, B) and not isinstance(x, C):
+    reveal_type(x)  # revealed:  B & ~C
+else:
+    # ~(B & ~C) -> ~B | C -> (A & ~B) | (C & ~B) | C -> (A & ~B) | C
+    reveal_type(x)  # revealed: A & ~B | C
+```
+
+## mixing `or` and `not`
+
+```py
+class A: ...
+class B: ...
+class C: ...
+
+def instance() -> A | B | C:
+    return A()
+
+x = instance()
+
+if isinstance(x, B) or not isinstance(x, C):
+    reveal_type(x)  # revealed: B | A & ~C
+else:
+    reveal_type(x)  # revealed: C & ~B
+```
+
+## `or` with nested `and`
+
+```py
+class A: ...
+class B: ...
+class C: ...
+
+def instance() -> A | B | C:
+    return A()
+
+x = instance()
+
+if isinstance(x, A) or (isinstance(x, B) and not isinstance(x, C)):
+    reveal_type(x)  # revealed:  A | B & ~C
+else:
+    # ~(A | (B & ~C)) -> ~A & ~(B & ~C) -> ~A & (~B | C) -> (~A & C) | (~A ~ B)
+    reveal_type(x)  # revealed:  C & ~A
+```
+
+## `and` with nested `or`
+
+```py
+class A: ...
+class B: ...
+class C: ...
+
+def instance() -> A | B | C:
+    return A()
+
+x = instance()
+
+if isinstance(x, A) and (isinstance(x, B) or not isinstance(x, C)):
+    # A & (B | ~C) -> (A & B) | (A & ~C)
+    reveal_type(x)  # revealed:  A & B | A & ~C
+else:
+    # ~((A & B) | (A & ~C)) ->
+    # ~(A & B) & ~(A & ~C) ->
+    # (~A | ~B) & (~A | C) ->
+    # [(~A | ~B) & ~A] | [(~A | ~B) & C] ->
+    # ~A | (~A & C) | (~B & C) ->
+    # ~A | (C & ~B) ->
+    # ~A | (C & ~B)  The positive side of ~A is  A | B | C ->
+    reveal_type(x)  # revealed:  B & ~A | C & ~A | C & ~B
+```

--- a/crates/red_knot_python_semantic/resources/mdtest/narrow/conditionals_boolean.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/narrow/conditionals_boolean.md
@@ -80,7 +80,6 @@ x = instance()
 if isinstance(x, A) or isinstance(x, B):
     reveal_type(x)  # revealed:  A | B
 else:
-    # TODO: Should be simplified to C
     reveal_type(x)  # revealed:  C & ~A & ~B
 ```
 

--- a/crates/red_knot_python_semantic/resources/mdtest/narrow/conditionals_boolean.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/narrow/conditionals_boolean.md
@@ -119,24 +119,35 @@ else:
     reveal_type(x)  # revealed:  C & ~A & ~B
 ```
 
-## in `or`, all arms should narrow the same symbol
+## in `or`, all arms should narrow the same set of symbols
 
 ```py
 class A: ...
 class B: ...
+class C: ...
 
-def instance() -> A | B:
+def instance() -> A | B | C:
     return A()
 
 x = instance()
 y = instance()
 
 if isinstance(x, A) or isinstance(y, A):
+    # The predicate might be satisfied by the right side, so the type of `x` can’t be narrowed down here.
+    reveal_type(x)  # revealed:  A | B | C
+    # The same for `y`
+    reveal_type(y)  # revealed:  A | B | C
+else:
+    reveal_type(x)  # revealed:  B & ~A | C & ~A
+    reveal_type(y)  # revealed:  B & ~A | C & ~A
+
+if (isinstance(x, A) and isinstance(y, A)) or (isinstance(x, B) and isinstance(y, B)):
+    # Here, types of `x` and `y` can be narrowd since all `or` arms constraint them.
     reveal_type(x)  # revealed:  A | B
     reveal_type(y)  # revealed:  A | B
 else:
-    reveal_type(x)  # revealed:  B & ~A
-    reveal_type(y)  # revealed:  B & ~A
+    reveal_type(x)  # revealed:  A | B | C
+    reveal_type(y)  # revealed:  A | B | C
 ```
 
 ## mixing `and` and `not`

--- a/crates/red_knot_python_semantic/resources/mdtest/narrow/conditionals_boolean.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/narrow/conditionals_boolean.md
@@ -23,12 +23,20 @@ else:
 class A: ...
 class B: ...
 
+def bool_instance() -> bool:
+    return True
+
 def instance() -> A | B:
     return A()
 
 x = instance()
 
-if isinstance(x, A) and True:
+if isinstance(x, A) and bool_instance():
+    reveal_type(x)  # revealed: A
+else:
+    reveal_type(x)  # revealed: A | B
+
+if bool_instance() and isinstance(x, A):
     reveal_type(x)  # revealed: A
 else:
     reveal_type(x)  # revealed: A | B
@@ -36,6 +44,13 @@ else:
 if True and isinstance(x, A):
     reveal_type(x)  # revealed: A
 else:
+    # TODO: Consider statically known arms. Should be B & ~A
+    reveal_type(x)  # revealed: A | B
+
+if isinstance(x, A) and True:
+    reveal_type(x)  # revealed: A
+else:
+    # TODO: Consider statically known arms. Should be B & ~A
     reveal_type(x)  # revealed: A | B
 
 reveal_type(x)  # revealed: A | B

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -559,15 +559,14 @@ impl<'db> Type<'db> {
                 .iter()
                 .any(|&elem_ty| elem_ty.is_subtype_of(db, ty)),
             (ty, Type::Intersection(intersection)) => {
-                let pos = intersection
+                intersection
                     .positive(db)
                     .iter()
-                    .all(|&pos_ty| ty.is_subtype_of(db, pos_ty));
-                let neg = intersection
-                    .negative(db)
-                    .iter()
-                    .all(|&neg_ty| neg_ty.is_disjoint_from(db, ty));
-                pos && neg
+                    .all(|&pos_ty| ty.is_subtype_of(db, pos_ty))
+                    && intersection
+                        .negative(db)
+                        .iter()
+                        .all(|&neg_ty| neg_ty.is_disjoint_from(db, ty))
             }
             (Type::Instance(self_class), Type::Instance(target_class)) => {
                 self_class.is_subclass_of(db, target_class)

--- a/crates/red_knot_python_semantic/src/types/builder.rs
+++ b/crates/red_knot_python_semantic/src/types/builder.rs
@@ -1012,7 +1012,9 @@ mod tests {
         let a = global_symbol(&db, file, "a").expect_type();
         let b = global_symbol(&db, file, "b").expect_type();
         let union = UnionBuilder::new(&db).add(a).add(b).build();
+        assert_eq!(union.display(&db).to_string(), "A | B");
         let reversed_union = UnionBuilder::new(&db).add(b).add(a).build();
+        assert_eq!(reversed_union.display(&db).to_string(), "B | A");
         let intersection = IntersectionBuilder::new(&db)
             .add_positive(union)
             .add_positive(reversed_union)

--- a/crates/red_knot_python_semantic/src/types/narrow.rs
+++ b/crates/red_knot_python_semantic/src/types/narrow.rs
@@ -168,12 +168,14 @@ impl<'db> NarrowingConstraintsBuilder<'db> {
     ) -> Option<NarrowingConstraints<'db>> {
         match expression_node {
             ast::Expr::Compare(expr_compare) => {
-                self.add_expr_compare(expr_compare, expression, is_positive)
+                self.evaluate_expr_compare(expr_compare, expression, is_positive)
             }
-            ast::Expr::Call(expr_call) => self.add_expr_call(expr_call, expression, is_positive),
+            ast::Expr::Call(expr_call) => {
+                self.evaluate_expr_call(expr_call, expression, is_positive)
+            }
             ast::Expr::UnaryOp(unary_op) if unary_op.op == ast::UnaryOp::Not => self
                 .evaluate_expression_node_constraint(&unary_op.operand, expression, !is_positive),
-            ast::Expr::BoolOp(bool_op) => self.add_bool_op(bool_op, expression, is_positive),
+            ast::Expr::BoolOp(bool_op) => self.evaluate_bool_op(bool_op, expression, is_positive),
             _ => None, // TODO other test expression kinds
         }
     }
@@ -189,7 +191,7 @@ impl<'db> NarrowingConstraintsBuilder<'db> {
                 None // TODO
             }
             ast::Pattern::MatchSingleton(singleton_pattern) => {
-                self.add_match_pattern_singleton(subject, singleton_pattern)
+                self.evaluate_match_pattern_singleton(subject, singleton_pattern)
             }
             ast::Pattern::MatchSequence(_) => {
                 None // TODO
@@ -223,7 +225,7 @@ impl<'db> NarrowingConstraintsBuilder<'db> {
         }
     }
 
-    fn add_expr_compare(
+    fn evaluate_expr_compare(
         &mut self,
         expr_compare: &ast::ExprCompare,
         expression: Expression<'db>,
@@ -296,7 +298,7 @@ impl<'db> NarrowingConstraintsBuilder<'db> {
         Some(constraints)
     }
 
-    fn add_expr_call(
+    fn evaluate_expr_call(
         &mut self,
         expr_call: &ast::ExprCall,
         expression: Expression<'db>,
@@ -335,7 +337,7 @@ impl<'db> NarrowingConstraintsBuilder<'db> {
         None
     }
 
-    fn add_match_pattern_singleton(
+    fn evaluate_match_pattern_singleton(
         &mut self,
         subject: &ast::Expr,
         pattern: &ast::PatternMatchSingleton,
@@ -357,7 +359,7 @@ impl<'db> NarrowingConstraintsBuilder<'db> {
         }
     }
 
-    fn add_bool_op(
+    fn evaluate_bool_op(
         &mut self,
         expr_bool_op: &ExprBoolOp,
         expression: Expression<'db>,

--- a/crates/red_knot_python_semantic/src/types/narrow.rs
+++ b/crates/red_knot_python_semantic/src/types/narrow.rs
@@ -112,7 +112,7 @@ fn merge_constraints<'db>(
                 *entry.get_mut() = IntersectionBuilder::new(db)
                     .add_positive(*entry.get())
                     .add_positive(value)
-                    .build()
+                    .build();
             }
             Entry::Vacant(entry) => {
                 entry.insert(value);


### PR DESCRIPTION
## Summary

This PR enables red-knot to support type narrowing based on `and` and `or` conditionals, including nested combinations and their negation (for `elif` / `else` blocks and for `not` operator). Part of #13694.

In order to address this properly (hopefully 😅), I had to run `NarrowingConstraintsBuilder` functions recursively. In the first commit I introduced a minor refactor - instead of mutating `self.constraints`, the new constraints are now returned as function return values. I also modified the constraints map to be optional, preventing unnecessary hashmap allocations.
Thanks @carljm for your support on this :)

The second commit contains the logic and tests for handling boolean ops, with improvements to intersections handling in `is_subtype_of` .

As I'm still new to Rust and the internals of type checkers, I’d be more than happy to hear any insights or suggestions.
Thank you!