### PR TITLE
[docs] Add rule short code to mkdocs tags

### DIFF
--- a/scripts/generate_mkdocs.py
+++ b/scripts/generate_mkdocs.py
@@ -104,13 +104,23 @@ def clean_file_content(content: str, title: str) -> str:
     return f"# {title}\n\n" + content
 
 
-def generate_rule_metadata(rule_doc: Path) -> str:
-    """Add metadata containing rule code & description to the rule doc."""
-    # Read the rule doc into lines
+def generate_rule_metadata(rule_doc: Path) -> None:
+    """Add frontmatter metadata containing a rule's code and description.
+
+    For example:
+    ```yaml
+    ---
+    description: Checks for abstract classes without abstract methods.
+    tags:
+    - B024
+    ---
+    ```
+    """
+    # Read the rule doc into lines.
     with rule_doc.open("r", encoding="utf-8") as f:
         lines = f.readlines()
 
-    # Get the description & rule code from the rule doc lines
+    # Get the description and rule code from the rule doc lines.
     rule_code = None
     description = None
     what_it_does_found = False
@@ -118,10 +128,13 @@ def generate_rule_metadata(rule_doc: Path) -> str:
         if line == "\n":
             continue
 
-        # Assume that the only first-level heading is the rule title & code
+        # Assume that the only first-level heading is the rule title and code.
+        #
+        # For example: given `# abstract-base-class-without-abstract-method (B024)`,
+        # extract the rule code (`B024`).
         if line.startswith("# "):
             rule_code = line.strip().rsplit("(", 1)
-            rule_code = rule_code[1][:-1]  # Remove the trailing )
+            rule_code = rule_code[1][:-1]
 
         if line.startswith("## What it does"):
             what_it_does_found = True


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->
This PR updates the metadata in the YAML frontmatter of the mkdocs documentation to include the rule short code as a tag, so it can be easily searched.
Ref: #13684

## Test Plan

<!-- How was it tested? -->
This has been tested locally using the documentation provided [here](https://docs.astral.sh/ruff/contributing/#mkdocs) for generating docs.

This generates docs that now have the tags section:
```markdown
---
description: Checks for abstract classes without abstract methods.
tags:
- B024
---

# abstract-base-class-without-abstract-method (B024)
... trimmed
```

I've also verified that this gives the ability to get straight to the page via search when serving mkdocs locally.
