### PR TITLE
Switch to `uv publish`

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -21,14 +21,12 @@ jobs:
       # For PyPI's trusted publishing.
       id-token: write
     steps:
+      - name: "Install uv"
+        uses: astral-sh/setup-uv@v3
       - uses: actions/download-artifact@v4
         with:
           pattern: wheels-*
           path: wheels
           merge-multiple: true
       - name: Publish to PyPi
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          skip-existing: true
-          packages-dir: wheels
-          verbose: true
+        run: uv publish -v wheels/*


### PR DESCRIPTION
## Summary

Ref: https://github.com/astral-sh/uv/pull/8065

## Test Plan

Going to re-release `0.7.2` which failed: https://github.com/astral-sh/ruff/actions/runs/11630280069
