### PR TITLE
Handle maybe-unbound `__iadd__`-like operators in augmented assignments

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/assignment/augmented.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/assignment/augmented.md
@@ -85,7 +85,7 @@ f = Foo()
 # that `Foo.__iadd__` may be unbound as additional context.
 f += "Hello, world!"
 
-reveal_type(f)  # revealed: int
+reveal_type(f)  # revealed: int | @Todo
 ```
 
 ## Partially bound with `__add__`
@@ -104,8 +104,7 @@ class Foo:
 f = Foo()
 f += "Hello, world!"
 
-# TODO(charlie): This should be `int | str`, since `__iadd__` may be unbound.
-reveal_type(f)  # revealed: int
+reveal_type(f)  # revealed: int | str
 ```
 
 ## Partially bound target union

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -1594,10 +1594,10 @@ impl<'db> TypeInferenceBuilder<'db> {
                                 Type::Unknown
                             });
 
-                        UnionBuilder::new(self.db)
-                            .add(augmented_return_ty)
-                            .add(binary_return_ty)
-                            .build()
+                        UnionType::from_elements(
+                            self.db,
+                            [augmented_return_ty, binary_return_ty]
+                        )
                     }
                 };
             }

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -1594,10 +1594,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                                 Type::Unknown
                             });
 
-                        UnionType::from_elements(
-                            self.db,
-                            [augmented_return_ty, binary_return_ty]
-                        )
+                        UnionType::from_elements(self.db, [augmented_return_ty, binary_return_ty])
                     }
                 };
             }


### PR DESCRIPTION
## Summary

One of the follow-ups from augmented assignment inference, now that `Type::Unbound` has been removed.