### PR TITLE
[`pyupgrade`] - ignore kwarg unpacking for `UP044`

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP044.py
+++ b/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP044.py
@@ -17,3 +17,11 @@ def f(*args: Unpack[other.Type]): pass
 def foo(*args: Unpack[int | str]) -> None: pass
 def foo(*args: Unpack[int and str]) -> None: pass
 def foo(*args: Unpack[int > str]) -> None: pass
+
+# We do not use the shorthand unpacking syntax in the following cases
+from typing import TypedDict
+class KwargsDict(TypedDict):
+    x: int
+    y: int
+
+def foo(name: str, /, **kwargs: Unpack[KwargsDict]) -> None: pass

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/use_pep646_unpack.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/use_pep646_unpack.rs
@@ -58,6 +58,17 @@ pub(crate) fn use_pep646_unpack(checker: &mut Checker, expr: &ExprSubscript) {
         return;
     }
 
+    // ignore kwarg unpacks like `def f(**kwargs: Unpack[CustomTypedDict]):`
+    if checker
+        .semantic()
+        .current_statement()
+        .as_function_def_stmt()
+        .and_then(|stmt| stmt.parameters.kwarg.as_ref())
+        .map_or(false, |kwarg| kwarg.range.contains_range(expr.range))
+    {
+        return;
+    }
+
     let ExprSubscript {
         range,
         value,


### PR DESCRIPTION
## Summary

Fixes #14047 

## Test Plan

`catgo test`