### PR TITLE
Promote uv in installation guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,8 +120,8 @@ Ruff is available as [`ruff`](https://pypi.org/project/ruff/) on PyPI:
 
 ```shell
 # With uv.
-uv tool install ruff  # Global
-uv add --dev ruff  # Project
+uv add --dev ruff     # to add ruff to your project
+uv tool install ruff  # to install ruff globally
 
 # With pip.
 pip install ruff

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -223,8 +223,11 @@ Ruff is installable under any Python version from 3.7 onwards.
 Nope! Ruff is available as [`ruff`](https://pypi.org/project/ruff/) on PyPI:
 
 ```console
-$ uv tool install ruff  # Global
-$ uv add --dev ruff  # Project
+# With uv.
+$ uv add --dev ruff     # to add ruff to your project
+$ uv tool install ruff  # to install ruff globally
+
+# With pip
 $ pip install ruff
 ```
 


### PR DESCRIPTION
> [Because this is an Astral repository ;)](https://github.com/astral-sh/packse/pull/183)

[Originally reported](https://discord.com/channels/1039017663004942429/1039017663512449056/1302319421204729906) by clearfram3 on Discord.

`grep`ping for `pip install` in `.md` files reveals a few other places where the same fix might be applicable.