### PR TITLE
[`flake8-bugbear`] - do not run `mutable-argument-default` on stubs (`B006`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_bugbear/B006_1.pyi
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_bugbear/B006_1.pyi
@@ -1,0 +1,10 @@
+# we disable this rule for pyi files
+
+def mquantiles(
+    a: _ArrayLikeFloat_co,
+    prob: _ArrayLikeFloat_co = [0.25, 0.5, 0.75],
+    alphap: AnyReal = 0.4,
+    betap: AnyReal = 0.4,
+    axis: CanIndex | None = None,
+    limit: tuple[AnyReal, AnyReal] | tuple[()] = (),
+) -> _MArrayND: ...

--- a/crates/ruff_linter/src/rules/flake8_bugbear/mod.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/mod.rs
@@ -43,6 +43,7 @@ mod tests {
     #[test_case(Rule::MutableArgumentDefault, Path::new("B006_7.py"))]
     #[test_case(Rule::MutableArgumentDefault, Path::new("B006_8.py"))]
     #[test_case(Rule::MutableArgumentDefault, Path::new("B006_B008.py"))]
+    #[test_case(Rule::MutableArgumentDefault, Path::new("B006_1.pyi"))]
     #[test_case(Rule::NoExplicitStacklevel, Path::new("B028.py"))]
     #[test_case(Rule::RaiseLiteral, Path::new("B016.py"))]
     #[test_case(Rule::RaiseWithoutFromInsideExcept, Path::new("B904.py"))]

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/mutable_argument_default.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/mutable_argument_default.rs
@@ -86,6 +86,11 @@ impl Violation for MutableArgumentDefault {
 
 /// B006
 pub(crate) fn mutable_argument_default(checker: &mut Checker, function_def: &ast::StmtFunctionDef) {
+    // Skip stub files
+    if checker.source_type.is_stub() {
+        return;
+    }
+
     for ParameterWithDefault {
         parameter,
         default,

--- a/crates/ruff_linter/src/rules/flake8_bugbear/snapshots/ruff_linter__rules__flake8_bugbear__tests__B006_B006_1.pyi.snap
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/snapshots/ruff_linter__rules__flake8_bugbear__tests__B006_B006_1.pyi.snap
@@ -1,0 +1,4 @@
+---
+source: crates/ruff_linter/src/rules/flake8_bugbear/mod.rs
+---
+


### PR DESCRIPTION
## Summary

Early-exits in `B006` when the file is a stub. Fixes #14026 

## Test Plan

`cargo test`