### PR TITLE
[`ruff`] - fix false positive for decorators (`RUF028`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/ruff/RUF028.py
+++ b/crates/ruff_linter/resources/test/fixtures/ruff/RUF028.py
@@ -87,3 +87,17 @@ def match_case_and_elif():
                 pass
             elif string == "Hello": # fmt: skip
                 pass
+
+
+# Regression test for decorators
+import pytest
+
+@pytest.mark.parametrize(
+    "test_input,expected",
+     [
+          ("3+5",  8 ),
+          ("17+2", 19),
+     ],
+)  # fmt: skip
+def test_eval(test_input, expected):
+    assert eval(test_input) == expected

--- a/crates/ruff_linter/src/rules/ruff/rules/invalid_formatter_suppression_comment.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/invalid_formatter_suppression_comment.rs
@@ -278,6 +278,7 @@ const fn is_valid_enclosing_node(node: AnyNodeRef) -> bool {
         | AnyNodeRef::StmtIpyEscapeCommand(_)
         | AnyNodeRef::ExceptHandlerExceptHandler(_)
         | AnyNodeRef::MatchCase(_)
+        | AnyNodeRef::Decorator(_)
         | AnyNodeRef::ElifElseClause(_) => true,
 
         AnyNodeRef::ExprBoolOp(_)
@@ -333,7 +334,6 @@ const fn is_valid_enclosing_node(node: AnyNodeRef) -> bool {
         | AnyNodeRef::Keyword(_)
         | AnyNodeRef::Alias(_)
         | AnyNodeRef::WithItem(_)
-        | AnyNodeRef::Decorator(_)
         | AnyNodeRef::TypeParams(_)
         | AnyNodeRef::TypeParamTypeVar(_)
         | AnyNodeRef::TypeParamTypeVarTuple(_)


### PR DESCRIPTION
## Summary

Allows RUF028 to work for decorators. Fixes #11689

## Test Plan

`cargo test`
