### PR TITLE
Respect hash-equivalent literals in `iteration-over-set`

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pylint/iteration_over_set.py
+++ b/crates/ruff_linter/resources/test/fixtures/pylint/iteration_over_set.py
@@ -60,3 +60,6 @@ for item in {1, 2, 3, 4, 5, 6, int("7")}:  # calls in set literals are fine
 for item in {1, 2, 2}:  # duplicate literals will be ignored
     # B033 catches this
     print(f"I like {item}.")
+
+for item in {False, 0, 0.0, 0j, True, 1, 1.0}:
+    print(item)

--- a/crates/ruff_linter/src/rules/pylint/rules/iteration_over_set.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/iteration_over_set.rs
@@ -1,8 +1,10 @@
+use rustc_hash::{FxBuildHasher, FxHashSet};
+
 use ruff_diagnostics::{AlwaysFixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
-use ruff_python_ast::{comparable::ComparableExpr, Expr};
+use ruff_python_ast::comparable::HashableExpr;
+use ruff_python_ast::Expr;
 use ruff_text_size::Ranged;
-use rustc_hash::{FxBuildHasher, FxHashSet};
 
 use crate::checkers::ast::Checker;
 
@@ -54,8 +56,7 @@ pub(crate) fn iteration_over_set(checker: &mut Checker, expr: &Expr) {
 
     let mut seen_values = FxHashSet::with_capacity_and_hasher(set.len(), FxBuildHasher);
     for value in set {
-        let comparable_value = ComparableExpr::from(value);
-        if !seen_values.insert(comparable_value) {
+        if !seen_values.insert(HashableExpr::from(value)) {
             // if the set contains a duplicate literal value, early exit.
             // rule `B033` can catch that.
             return;


### PR DESCRIPTION
## Summary

Closes https://github.com/astral-sh/ruff/issues/14049.
