### PR TITLE
Detect items that hash to same value in duplicate sets

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_bugbear/B033.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_bugbear/B033.py
@@ -19,6 +19,7 @@ incorrect_set = {
     1,
     1,
 }
+incorrect_set = {False, 1, 0}
 
 ###
 # Non-errors.

--- a/crates/ruff_linter/resources/test/fixtures/pylint/iteration_over_set.py
+++ b/crates/ruff_linter/resources/test/fixtures/pylint/iteration_over_set.py
@@ -60,3 +60,6 @@ for item in {1, 2, 3, 4, 5, 6, int("7")}:  # calls in set literals are fine
 for item in {1, 2, 2}:  # duplicate literals will be ignored
     # B033 catches this
     print(f"I like {item}.")
+
+for item in {False, 0, 0.0, 0j, True, 1, 1.0}:
+    print(item)

--- a/crates/ruff_linter/src/rules/flake8_bugbear/snapshots/ruff_linter__rules__flake8_bugbear__tests__B033_B033.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/snapshots/ruff_linter__rules__flake8_bugbear__tests__B033_B033.py.snap
@@ -154,6 +154,7 @@ B033.py:20:5: B033 [*] Sets should not contain duplicate item `1`
 20 |     1,
    |     ^ B033
 21 | }
+22 | incorrect_set = {False, 1, 0}
    |
    = help: Remove duplicate item
 
@@ -163,7 +164,26 @@ B033.py:20:5: B033 [*] Sets should not contain duplicate item `1`
 19 19 |     1,
 20    |-    1,
 21 20 | }
-22 21 | 
-23 22 | ###
+22 21 | incorrect_set = {False, 1, 0}
+23 22 | 
 
+B033.py:22:28: B033 [*] Sets should not contain duplicate items, but `False` and `0` has the same value
+   |
+20 |     1,
+21 | }
+22 | incorrect_set = {False, 1, 0}
+   |                            ^ B033
+23 | 
+24 | ###
+   |
+   = help: Remove duplicate item
 
+ℹ Safe fix
+19 19 |     1,
+20 20 |     1,
+21 21 | }
+22    |-incorrect_set = {False, 1, 0}
+   22 |+incorrect_set = {False, 1}
+23 23 | 
+24 24 | ###
+25 25 | # Non-errors.

--- a/crates/ruff_linter/src/rules/pylint/rules/iteration_over_set.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/iteration_over_set.rs
@@ -1,8 +1,10 @@
+use rustc_hash::{FxBuildHasher, FxHashSet};
+
 use ruff_diagnostics::{AlwaysFixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
-use ruff_python_ast::{comparable::ComparableExpr, Expr};
+use ruff_python_ast::comparable::HashableExpr;
+use ruff_python_ast::Expr;
 use ruff_text_size::Ranged;
-use rustc_hash::{FxBuildHasher, FxHashSet};
 
 use crate::checkers::ast::Checker;
 
@@ -54,8 +56,7 @@ pub(crate) fn iteration_over_set(checker: &mut Checker, expr: &Expr) {
 
     let mut seen_values = FxHashSet::with_capacity_and_hasher(set.len(), FxBuildHasher);
     for value in set {
-        let comparable_value = ComparableExpr::from(value);
-        if !seen_values.insert(comparable_value) {
+        if !seen_values.insert(HashableExpr::from(value)) {
             // if the set contains a duplicate literal value, early exit.
             // rule `B033` can catch that.
             return;


### PR DESCRIPTION
## Summary

Like https://github.com/astral-sh/ruff/pull/14063, but ensures that we catch cases like `{1, True}` in which the items hash to the same value despite not being identical.
