### PR TITLE
Allow `open` without context manager in `return` statement

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_simplify/SIM115.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_simplify/SIM115.py
@@ -256,3 +256,11 @@ dbm.sqlite3.open("foo.db").close()
 # SIM115
 f = dbm.sqlite3.open("foo.db")
 f.close()
+
+# OK
+def func(filepath, encoding):
+    return open(filepath, mode="rt", encoding=encoding)
+
+# OK
+def func(filepath, encoding):
+    return f(open(filepath, mode="rt", encoding=encoding))

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/open_file_with_context_handler.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/open_file_with_context_handler.rs
@@ -214,6 +214,11 @@ pub(crate) fn open_file_with_context_handler(checker: &mut Checker, call: &ast::
         return;
     }
 
+    // Ex) `return open("foo.txt")`
+    if semantic.current_statement().is_return_stmt() {
+        return;
+    }
+
     // Ex) `with contextlib.ExitStack() as exit_stack: ...`
     if match_exit_stack(semantic) {
         return;


### PR DESCRIPTION
## Summary

Closes https://github.com/astral-sh/ruff/issues/13862.
