### PR TITLE
[`eradicate`] ignore `# language=` in commented-out-code rule (ERA001)

### DIFF
--- a/crates/ruff_linter/src/rules/eradicate/detection.rs
+++ b/crates/ruff_linter/src/rules/eradicate/detection.rs
@@ -16,7 +16,7 @@ static CODE_INDICATORS: LazyLock<AhoCorasick> = LazyLock::new(|| {
 
 static ALLOWLIST_REGEX: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(
-        r"^(?i)(?:pylint|pyright|noqa|nosec|region|endregion|type:\s*ignore|fmt:\s*(on|off)|isort:\s*(on|off|skip|skip_file|split|dont-add-imports(:\s*\[.*?])?)|mypy:|SPDX-License-Identifier:|(?:en)?coding[:=][ \t]*([-_.a-zA-Z0-9]+))",
+        r"^(?i)(?:pylint|pyright|noqa|nosec|region|endregion|type:\s*ignore|fmt:\s*(on|off)|isort:\s*(on|off|skip|skip_file|split|dont-add-imports(:\s*\[.*?])?)|mypy:|SPDX-License-Identifier:|language=[a-zA-Z](?: ?[-_.a-zA-Z0-9]+)+(?:\s+prefix=\S+)?(?:\s+suffix=\S+)?|(?:en)?coding[:=][ \t]*([-_.a-zA-Z0-9]+))",
     ).unwrap()
 });
 
@@ -294,6 +294,23 @@ mod tests {
         assert!(!comment_contains_code(
             "# XXX: What ever",
             &["XXX".to_string()]
+        ));
+    }
+
+    #[test]
+    fn comment_contains_language_injection() {
+        assert!(comment_contains_code("# language=123", &[]));
+        assert!(comment_contains_code("# language=\"pt\"", &[]));
+        assert!(comment_contains_code("# language='en'", &[]));
+
+        assert!(!comment_contains_code("# language=xml", &[]));
+        assert!(!comment_contains_code(
+            "# language=HTML prefix=<body> suffix=</body>",
+            &[]
+        ));
+        assert!(!comment_contains_code(
+            "# language=ecma script level 4",
+            &[]
         ));
     }
 


### PR DESCRIPTION
Fixes one common case cited on #6019

<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

The `commented-out-code` rule (ERA001) from `eradicate` is currently flagging a very common idiom that marks Python strings as another language, to help with syntax highlighting:

![image](https://github.com/user-attachments/assets/d523e83d-95cb-4668-a793-45f01d162234)

This PR adds this idiom to the list of allowed exceptions to the rule.

## Test Plan

I've added some additional test cases.
