### PR TITLE
Remove AST-node dependency from `FunctionType` and `ClassType`

### DIFF
--- a/crates/red_knot_python_semantic/src/semantic_index/definition.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/definition.rs
@@ -11,10 +11,10 @@ use crate::Db;
 
 /// A definition of a symbol.
 ///
-/// ## Module local type
-/// This type should not be used as part of any cross module API because
-/// it holds a reference to the AST node and range offset changes
-/// then propagate through all usages and deserialization requires
+/// ## Module-local type
+/// This type should not be used as part of any cross-module API because
+/// it holds a reference to the AST node. Range-offset changes
+/// then propagate through all usages, and deserialization requires
 /// reparsing the entire module.
 ///
 /// E.g. don't use this type in:

--- a/crates/red_knot_python_semantic/src/semantic_index/definition.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/definition.rs
@@ -9,6 +9,19 @@ use crate::semantic_index::symbol::{FileScopeId, ScopeId, ScopedSymbolId};
 use crate::unpack::Unpack;
 use crate::Db;
 
+/// A definition of a symbol.
+///
+/// ## Module local type
+/// This type should not be used as part of any cross module API because
+/// it holds a reference to the AST node and range offset changes
+/// then propagate through all usages and deserialization requires
+/// reparsing the entire module.
+///
+/// E.g. don't use this type in:
+///
+/// * a return type of a cross-module query
+/// * a field of a type that is a return type of a cross-module query
+/// * an argument of a cross-module query
 #[salsa::tracked]
 pub struct Definition<'db> {
     /// The file in which the definition occurs.

--- a/crates/red_knot_python_semantic/src/semantic_index/expression.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/expression.rs
@@ -9,10 +9,10 @@ use salsa;
 ///
 /// Includes constraint expressions (e.g. if tests) and the RHS of an unpacking assignment.
 ///
-/// ## Module local type
-/// This type should not be used as part of any cross module API because
-/// it holds a reference to the AST node and range offset changes
-/// then propagate through all usages and deserialization requires
+/// ## Module-local type
+/// This type should not be used as part of any cross-module API because
+/// it holds a reference to the AST node. Range-offset changes
+/// then propagate through all usages, and deserialization requires
 /// reparsing the entire module.
 ///
 /// E.g. don't use this type in:

--- a/crates/red_knot_python_semantic/src/semantic_index/expression.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/expression.rs
@@ -8,6 +8,18 @@ use salsa;
 /// An independently type-inferable expression.
 ///
 /// Includes constraint expressions (e.g. if tests) and the RHS of an unpacking assignment.
+///
+/// ## Module local type
+/// This type should not be used as part of any cross module API because
+/// it holds a reference to the AST node and range offset changes
+/// then propagate through all usages and deserialization requires
+/// reparsing the entire module.
+///
+/// E.g. don't use this type in:
+///
+/// * a return type of a cross-module query
+/// * a field of a type that is a return type of a cross-module query
+/// * an argument of a cross-module query
 #[salsa::tracked]
 pub(crate) struct Expression<'db> {
     /// The file in which the expression occurs.

--- a/crates/red_knot_python_semantic/src/semantic_index/symbol.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/symbol.rs
@@ -445,6 +445,20 @@ impl NodeWithScopeKind {
             | Self::GeneratorExpression(_) => ScopeKind::Comprehension,
         }
     }
+
+    pub fn expect_class(&self) -> &ast::StmtClassDef {
+        match self {
+            Self::Class(class) => class.node(),
+            _ => panic!("expected class"),
+        }
+    }
+
+    pub fn expect_function(&self) -> &ast::StmtFunctionDef {
+        match self {
+            Self::Function(function) => function.node(),
+            _ => panic!("expected function"),
+        }
+    }
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -6,7 +6,7 @@ use itertools::Itertools;
 
 use crate::module_resolver::file_to_module;
 use crate::semantic_index::ast_ids::HasScopedAstId;
-use crate::semantic_index::definition::{Definition, DefinitionKind};
+use crate::semantic_index::definition::Definition;
 use crate::semantic_index::symbol::{self as symbol, ScopeId, ScopedSymbolId};
 use crate::semantic_index::{
     global_scope, semantic_index, symbol_table, use_def_map, BindingWithConstraints,
@@ -1109,11 +1109,11 @@ impl<'db> Type<'db> {
             Type::FunctionLiteral(function_type) => {
                 if function_type.is_known(db, KnownFunction::RevealType) {
                     CallOutcome::revealed(
-                        function_type.return_type(db),
+                        function_type.return_ty(db),
                         *arg_types.first().unwrap_or(&Type::Unknown),
                     )
                 } else {
-                    CallOutcome::callable(function_type.return_type(db))
+                    CallOutcome::callable(function_type.return_ty(db))
                 }
             }
 
@@ -1854,17 +1854,18 @@ pub struct FunctionType<'db> {
     /// Is this a function that we special-case somehow? If so, which one?
     known: Option<KnownFunction>,
 
-    definition: Definition<'db>,
+    body_scope: ScopeId<'db>,
 
     /// types of all decorators on this function
     decorators: Box<[Type<'db>]>,
 }
 
+#[salsa::tracked]
 impl<'db> FunctionType<'db> {
     /// Return true if this is a standard library function with given module name and name.
     pub(crate) fn is_stdlib_symbol(self, db: &'db dyn Db, module_name: &str, name: &str) -> bool {
         name == self.name(db)
-            && file_to_module(db, self.definition(db).file(db)).is_some_and(|module| {
+            && file_to_module(db, self.body_scope(db).file(db)).is_some_and(|module| {
                 module.search_path().is_standard_library() && module.name() == module_name
             })
     }
@@ -1874,11 +1875,18 @@ impl<'db> FunctionType<'db> {
     }
 
     /// inferred return type for this function
-    pub fn return_type(&self, db: &'db dyn Db) -> Type<'db> {
-        let definition = self.definition(db);
-        let DefinitionKind::Function(function_stmt_node) = definition.kind(db) else {
-            panic!("Function type definition must have `DefinitionKind::Function`")
-        };
+    ///
+    /// ## Why is this a salsa query?
+    ///
+    /// This is a salsa query to short-circuit the invalidation
+    /// when the function's AST node changes.
+    ///
+    /// Were this not a salsa query, then the calling query
+    /// would depend on the function's AST and rerun for every change in that file.
+    #[salsa::tracked]
+    pub fn return_ty(self, db: &'db dyn Db) -> Type<'db> {
+        let scope = self.body_scope(db);
+        let function_stmt_node = scope.node(db).expect_function();
 
         // TODO if a function `bar` is decorated by `foo`,
         // where `foo` is annotated as returning a type `X` that is a subtype of `Callable`,
@@ -1897,6 +1905,8 @@ impl<'db> FunctionType<'db> {
                     // TODO: generic `types.CoroutineType`!
                     Type::Todo
                 } else {
+                    let definition =
+                        semantic_index(db, scope.file(db)).definition(function_stmt_node);
                     definition_expression_ty(db, definition, returns.as_ref())
                 }
             })
@@ -1923,8 +1933,6 @@ pub struct ClassType<'db> {
     /// Name of the class at definition
     #[return_ref]
     pub name: ast::name::Name,
-
-    definition: Definition<'db>,
 
     body_scope: ScopeId<'db>,
 
@@ -1955,23 +1963,55 @@ impl<'db> ClassType<'db> {
     /// Note that any class (except for `object`) that has no explicit
     /// bases will implicitly inherit from `object` at runtime. Nonetheless,
     /// this method does *not* include `object` in the bases it iterates over.
-    fn explicit_bases(self, db: &'db dyn Db) -> impl Iterator<Item = Type<'db>> {
-        let definition = self.definition(db);
-        let class_stmt = self.node(db);
-        let has_type_params = class_stmt.type_params.is_some();
+    ///
+    /// ## Why is this a salsa query?
+    ///
+    /// This is a salsa query to short-circuit the invalidation
+    /// when the class's AST node changes.
+    ///
+    /// Were this not a salsa query, then the calling query
+    /// would depend on the class's AST and rerun for every change in that file.
+    fn explicit_bases(self, db: &'db dyn Db) -> &[Type<'db>] {
+        self.explicit_bases_query(db)
+    }
 
-        class_stmt
-            .bases()
-            .iter()
-            .map(move |base_node| infer_class_base_type(db, base_node, definition, has_type_params))
+    #[salsa::tracked(return_ref)]
+    fn explicit_bases_query(self, db: &'db dyn Db) -> Box<[Type<'db>]> {
+        let class_stmt = self.node(db);
+
+        if class_stmt.type_params.is_some() {
+            // when we have a specialized scope, we'll look up the inference
+            // within that scope
+            let model = SemanticModel::new(db, self.file(db));
+
+            class_stmt
+                .bases()
+                .iter()
+                .map(|base| base.ty(&model))
+                .collect()
+        } else {
+            // Otherwise, we can do the lookup based on the definition scope
+            let class_definition = semantic_index(db, self.file(db)).definition(class_stmt);
+
+            class_stmt
+                .bases()
+                .iter()
+                .map(|base_node| definition_expression_ty(db, class_definition, base_node))
+                .collect()
+        }
+    }
+
+    fn file(self, db: &dyn Db) -> File {
+        self.body_scope(db).file(db)
     }
 
     /// Return the original [`ast::StmtClassDef`] node associated with this class
+    ///
+    /// ## Note
+    /// Only call this function from queries in the same file or your
+    /// query depends on the AST of another file (bad!).
     fn node(self, db: &'db dyn Db) -> &'db ast::StmtClassDef {
-        match self.definition(db).kind(db) {
-            DefinitionKind::Class(class_stmt_node) => class_stmt_node,
-            _ => unreachable!("Class type definition should always have DefinitionKind::Class"),
-        }
+        self.body_scope(db).node(db).expect_class()
     }
 
     /// Attempt to resolve the [method resolution order] ("MRO") for this class.
@@ -2046,26 +2086,6 @@ impl<'db> ClassType<'db> {
     pub(crate) fn own_class_member(self, db: &'db dyn Db, name: &str) -> Symbol<'db> {
         let scope = self.body_scope(db);
         symbol(db, scope, name)
-    }
-}
-
-/// Infer the type of a node representing an explicit class base.
-///
-/// For example, infer the type of `Foo` in the statement `class Bar(Foo, Baz): ...`.
-fn infer_class_base_type<'db>(
-    db: &'db dyn Db,
-    base_node: &'db ast::Expr,
-    class_definition: Definition<'db>,
-    class_has_type_params: bool,
-) -> Type<'db> {
-    if class_has_type_params {
-        // when we have a specialized scope, we'll look up the inference
-        // within that scope
-        let model = SemanticModel::new(db, class_definition.file(db));
-        base_node.ty(&model)
-    } else {
-        // Otherwise, we can do the lookup based on the definition scope
-        definition_expression_ty(db, class_definition, base_node)
     }
 }
 

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -2666,7 +2666,7 @@ mod tests {
     /// Inferring the result of a call-expression shouldn't need to re-run after
     /// a trivial change to the function's file (e.g. by adding a docstring to the function).
     #[test]
-    fn call_type_doesnt_rerun_when_onlyh_callee_changed() -> anyhow::Result<()> {
+    fn call_type_doesnt_rerun_when_only_callee_changed() -> anyhow::Result<()> {
         let mut db = setup_db();
 
         db.write_dedented(

--- a/crates/red_knot_python_semantic/src/unpack.rs
+++ b/crates/red_knot_python_semantic/src/unpack.rs
@@ -12,6 +12,18 @@ use crate::Db;
 /// involved. It allows us to:
 /// 1. Avoid doing structural match multiple times for each definition
 /// 2. Avoid highlighting the same error multiple times
+///
+/// ## Module-local type
+/// This type should not be used as part of any cross-module API because
+/// it holds a reference to the AST node. Range-offset changes
+/// then propagate through all usages, and deserialization requires
+/// reparsing the entire module.
+///
+/// E.g. don't use this type in:
+///
+/// * a return type of a cross-module query
+/// * a field of a type that is a return type of a cross-module query
+/// * an argument of a cross-module query
 #[salsa::tracked]
 pub(crate) struct Unpack<'db> {
     #[id]


### PR DESCRIPTION
## Summary


This PR improves Red Knot's incremental computation by:

* Making `FunctionType::return_type` and `ClassType::explicit_bases` salsa queries. I suspect this is where the main performance improvement comes from. Making these two functions salsa queries prevents that the class or function's node (accessed through `definition.node`) is marked as a dependency at the callee side. Instead, the callee only depends on whatever the return type or bases are. 
* Removing `FunctionType::definition` and `ClassType::definition` and instead use `semantic_index.definition(..)` to lookup the type's definition lazily. This ensures that deserializing a type doesn't require deserializing the AST as well. 
* Remove `ScopeId::node` and move it to `Scope::node`. Same as for `FunctionType::definition`. Moving the `Node` from the `ScopeId` to the definition allows deserializing the `ScopeId` without deserializing the AST node. This is important because both `FunctionType` and `ClassType` have a `ScopeId` field.

Fixes https://github.com/astral-sh/ruff/issues/14054

## Test Plan

`cargo test`
