### PR TITLE
Replace `format!` without parameters with `.to_string()`

### DIFF
--- a/crates/ruff_linter/src/rules/eradicate/rules/commented_out_code.rs
+++ b/crates/ruff_linter/src/rules/eradicate/rules/commented_out_code.rs
@@ -41,7 +41,7 @@ impl Violation for CommentedOutCode {
     }
 
     fn fix_title(&self) -> Option<String> {
-        Some(format!("Remove commented-out code"))
+        Some("Remove commented-out code".to_string())
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_annotations/rules/definition.rs
+++ b/crates/ruff_linter/src/rules/flake8_annotations/rules/definition.rs
@@ -233,7 +233,7 @@ impl Violation for MissingReturnTypeUndocumentedPublicFunction {
         if let Some(annotation) = annotation {
             Some(format!("Add return type annotation: `{annotation}`"))
         } else {
-            Some(format!("Add return type annotation"))
+            Some("Add return type annotation".to_string())
         }
     }
 }
@@ -277,7 +277,7 @@ impl Violation for MissingReturnTypePrivateFunction {
         if let Some(annotation) = annotation {
             Some(format!("Add return type annotation: `{annotation}`"))
         } else {
-            Some(format!("Add return type annotation"))
+            Some("Add return type annotation".to_string())
         }
     }
 }
@@ -334,7 +334,7 @@ impl Violation for MissingReturnTypeSpecialMethod {
         if let Some(annotation) = annotation {
             Some(format!("Add return type annotation: `{annotation}`"))
         } else {
-            Some(format!("Add return type annotation"))
+            Some("Add return type annotation".to_string())
         }
     }
 }
@@ -382,7 +382,7 @@ impl Violation for MissingReturnTypeStaticMethod {
         if let Some(annotation) = annotation {
             Some(format!("Add return type annotation: `{annotation}`"))
         } else {
-            Some(format!("Add return type annotation"))
+            Some("Add return type annotation".to_string())
         }
     }
 }
@@ -430,7 +430,7 @@ impl Violation for MissingReturnTypeClassMethod {
         if let Some(annotation) = annotation {
             Some(format!("Add return type annotation: `{annotation}`"))
         } else {
-            Some(format!("Add return type annotation"))
+            Some("Add return type annotation".to_string())
         }
     }
 }

--- a/crates/ruff_linter/src/rules/flake8_annotations/rules/definition.rs
+++ b/crates/ruff_linter/src/rules/flake8_annotations/rules/definition.rs
@@ -229,12 +229,11 @@ impl Violation for MissingReturnTypeUndocumentedPublicFunction {
     }
 
     fn fix_title(&self) -> Option<String> {
-        let Self { annotation, .. } = self;
-        if let Some(annotation) = annotation {
-            Some(format!("Add return type annotation: `{annotation}`"))
-        } else {
-            Some("Add return type annotation".to_string())
-        }
+        let title = match &self.annotation {
+            Some(annotation) => format!("Add return type annotation: `{annotation}`"),
+            None => "Add return type annotation".to_string(),
+        };
+        Some(title)
     }
 }
 
@@ -273,12 +272,11 @@ impl Violation for MissingReturnTypePrivateFunction {
     }
 
     fn fix_title(&self) -> Option<String> {
-        let Self { annotation, .. } = self;
-        if let Some(annotation) = annotation {
-            Some(format!("Add return type annotation: `{annotation}`"))
-        } else {
-            Some("Add return type annotation".to_string())
-        }
+        let title = match &self.annotation {
+            Some(annotation) => format!("Add return type annotation: `{annotation}`"),
+            None => "Add return type annotation".to_string(),
+        };
+        Some(title)
     }
 }
 
@@ -330,12 +328,11 @@ impl Violation for MissingReturnTypeSpecialMethod {
     }
 
     fn fix_title(&self) -> Option<String> {
-        let Self { annotation, .. } = self;
-        if let Some(annotation) = annotation {
-            Some(format!("Add return type annotation: `{annotation}`"))
-        } else {
-            Some("Add return type annotation".to_string())
-        }
+        let title = match &self.annotation {
+            Some(annotation) => format!("Add return type annotation: `{annotation}`"),
+            None => "Add return type annotation".to_string(),
+        };
+        Some(title)
     }
 }
 
@@ -378,12 +375,11 @@ impl Violation for MissingReturnTypeStaticMethod {
     }
 
     fn fix_title(&self) -> Option<String> {
-        let Self { annotation, .. } = self;
-        if let Some(annotation) = annotation {
-            Some(format!("Add return type annotation: `{annotation}`"))
-        } else {
-            Some("Add return type annotation".to_string())
-        }
+        let title = match &self.annotation {
+            Some(annotation) => format!("Add return type annotation: `{annotation}`"),
+            None => "Add return type annotation".to_string(),
+        };
+        Some(title)
     }
 }
 
@@ -426,12 +422,11 @@ impl Violation for MissingReturnTypeClassMethod {
     }
 
     fn fix_title(&self) -> Option<String> {
-        let Self { annotation, .. } = self;
-        if let Some(annotation) = annotation {
-            Some(format!("Add return type annotation: `{annotation}`"))
-        } else {
-            Some("Add return type annotation".to_string())
-        }
+        let title = match &self.annotation {
+            Some(annotation) => format!("Add return type annotation: `{annotation}`"),
+            None => "Add return type annotation".to_string(),
+        };
+        Some(title)
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_async/rules/sync_call.rs
+++ b/crates/ruff_linter/src/rules/flake8_async/rules/sync_call.rs
@@ -46,7 +46,7 @@ impl Violation for TrioSyncCall {
     }
 
     fn fix_title(&self) -> Option<String> {
-        Some(format!("Add `await`"))
+        Some("Add `await`".to_string())
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/duplicate_value.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/duplicate_value.rs
@@ -50,7 +50,7 @@ impl Violation for DuplicateValue {
     }
 
     fn fix_title(&self) -> Option<String> {
-        Some(format!("Remove duplicate item"))
+        Some("Remove duplicate item".to_string())
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/mutable_argument_default.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/mutable_argument_default.rs
@@ -80,7 +80,7 @@ impl Violation for MutableArgumentDefault {
     }
 
     fn fix_title(&self) -> Option<String> {
-        Some(format!("Replace with `None`; initialize within function"))
+        Some("Replace with `None`; initialize within function".to_string())
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/unreliable_callable_check.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/unreliable_callable_check.rs
@@ -46,7 +46,7 @@ impl Violation for UnreliableCallableCheck {
     }
 
     fn fix_title(&self) -> Option<String> {
-        Some(format!("Replace with `callable()`"))
+        Some("Replace with `callable()`".to_string())
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_dict_comprehension_for_iterable.rs
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_dict_comprehension_for_iterable.rs
@@ -45,9 +45,9 @@ impl Violation for UnnecessaryDictComprehensionForIterable {
 
     fn fix_title(&self) -> Option<String> {
         if self.is_value_none_literal {
-            Some(format!("Replace with `dict.fromkeys(iterable, value)`)"))
+            Some("Replace with `dict.fromkeys(iterable, value)`)".to_string())
         } else {
-            Some(format!("Replace with `dict.fromkeys(iterable)`)"))
+            Some("Replace with `dict.fromkeys(iterable)`)".to_string())
         }
     }
 }

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_dict_comprehension_for_iterable.rs
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_dict_comprehension_for_iterable.rs
@@ -44,11 +44,12 @@ impl Violation for UnnecessaryDictComprehensionForIterable {
     }
 
     fn fix_title(&self) -> Option<String> {
-        if self.is_value_none_literal {
-            Some("Replace with `dict.fromkeys(iterable, value)`)".to_string())
+        let title = if self.is_value_none_literal {
+            "Replace with `dict.fromkeys(iterable, value)`)"
         } else {
-            Some("Replace with `dict.fromkeys(iterable)`)".to_string())
-        }
+            "Replace with `dict.fromkeys(iterable)`)"
+        };
+        Some(title.to_string())
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_executable/rules/shebang_leading_whitespace.rs
+++ b/crates/ruff_linter/src/rules/flake8_executable/rules/shebang_leading_whitespace.rs
@@ -39,7 +39,7 @@ impl AlwaysFixableViolation for ShebangLeadingWhitespace {
     }
 
     fn fix_title(&self) -> String {
-        format!("Remove whitespace before shebang")
+        "Remove whitespace before shebang".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_future_annotations/rules/future_required_type_annotation.rs
+++ b/crates/ruff_linter/src/rules/flake8_future_annotations/rules/future_required_type_annotation.rs
@@ -79,7 +79,7 @@ impl AlwaysFixableViolation for FutureRequiredTypeAnnotation {
     }
 
     fn fix_title(&self) -> String {
-        format!("Add `from __future__ import annotations`")
+        "Add `from __future__ import annotations`".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_logging/rules/direct_logger_instantiation.rs
+++ b/crates/ruff_linter/src/rules/flake8_logging/rules/direct_logger_instantiation.rs
@@ -49,7 +49,7 @@ impl Violation for DirectLoggerInstantiation {
     }
 
     fn fix_title(&self) -> Option<String> {
-        Some(format!("Replace with `logging.getLogger()`"))
+        Some("Replace with `logging.getLogger()`".to_string())
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_logging/rules/invalid_get_logger_argument.rs
+++ b/crates/ruff_linter/src/rules/flake8_logging/rules/invalid_get_logger_argument.rs
@@ -52,7 +52,7 @@ impl Violation for InvalidGetLoggerArgument {
     }
 
     fn fix_title(&self) -> Option<String> {
-        Some(format!("Replace with `__name__`"))
+        Some("Replace with `__name__`".to_string())
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_logging/rules/undocumented_warn.rs
+++ b/crates/ruff_linter/src/rules/flake8_logging/rules/undocumented_warn.rs
@@ -43,7 +43,7 @@ impl Violation for UndocumentedWarn {
     }
 
     fn fix_title(&self) -> Option<String> {
-        Some(format!("Replace `logging.WARN` with `logging.WARNING`"))
+        Some("Replace `logging.WARN` with `logging.WARNING`".to_string())
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_pie/rules/unnecessary_dict_kwargs.rs
+++ b/crates/ruff_linter/src/rules/flake8_pie/rules/unnecessary_dict_kwargs.rs
@@ -51,7 +51,7 @@ impl Violation for UnnecessaryDictKwargs {
     }
 
     fn fix_title(&self) -> Option<String> {
-        Some(format!("Remove unnecessary kwargs"))
+        Some("Remove unnecessary kwargs".to_string())
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_pie/rules/unnecessary_placeholder.rs
+++ b/crates/ruff_linter/src/rules/flake8_pie/rules/unnecessary_placeholder.rs
@@ -70,10 +70,11 @@ impl AlwaysFixableViolation for UnnecessaryPlaceholder {
 
     fn fix_title(&self) -> String {
         let Self { kind } = self;
-        match kind {
-            Placeholder::Pass => "Remove unnecessary `pass`".to_string(),
-            Placeholder::Ellipsis => "Remove unnecessary `...`".to_string(),
-        }
+        let title = match kind {
+            Placeholder::Pass => "Remove unnecessary `pass`",
+            Placeholder::Ellipsis => "Remove unnecessary `...`",
+        };
+        title.to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_pie/rules/unnecessary_placeholder.rs
+++ b/crates/ruff_linter/src/rules/flake8_pie/rules/unnecessary_placeholder.rs
@@ -61,16 +61,14 @@ pub struct UnnecessaryPlaceholder {
 impl AlwaysFixableViolation for UnnecessaryPlaceholder {
     #[derive_message_formats]
     fn message(&self) -> String {
-        let Self { kind } = self;
-        match kind {
+        match &self.kind {
             Placeholder::Pass => format!("Unnecessary `pass` statement"),
             Placeholder::Ellipsis => format!("Unnecessary `...` literal"),
         }
     }
 
     fn fix_title(&self) -> String {
-        let Self { kind } = self;
-        let title = match kind {
+        let title = match &self.kind {
             Placeholder::Pass => "Remove unnecessary `pass`",
             Placeholder::Ellipsis => "Remove unnecessary `...`",
         };

--- a/crates/ruff_linter/src/rules/flake8_pie/rules/unnecessary_placeholder.rs
+++ b/crates/ruff_linter/src/rules/flake8_pie/rules/unnecessary_placeholder.rs
@@ -71,8 +71,8 @@ impl AlwaysFixableViolation for UnnecessaryPlaceholder {
     fn fix_title(&self) -> String {
         let Self { kind } = self;
         match kind {
-            Placeholder::Pass => format!("Remove unnecessary `pass`"),
-            Placeholder::Ellipsis => format!("Remove unnecessary `...`"),
+            Placeholder::Pass => "Remove unnecessary `pass`".to_string(),
+            Placeholder::Ellipsis => "Remove unnecessary `...`".to_string(),
         }
     }
 }

--- a/crates/ruff_linter/src/rules/flake8_pie/rules/unnecessary_range_start.rs
+++ b/crates/ruff_linter/src/rules/flake8_pie/rules/unnecessary_range_start.rs
@@ -37,7 +37,7 @@ impl AlwaysFixableViolation for UnnecessaryRangeStart {
     }
 
     fn fix_title(&self) -> String {
-        format!("Remove `start` argument")
+        "Remove `start` argument".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_pie/rules/unnecessary_spread.rs
+++ b/crates/ruff_linter/src/rules/flake8_pie/rules/unnecessary_spread.rs
@@ -40,7 +40,7 @@ impl Violation for UnnecessarySpread {
     }
 
     fn fix_title(&self) -> Option<String> {
-        Some(format!("Remove unnecessary dict"))
+        Some("Remove unnecessary dict".to_string())
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/any_eq_ne_annotation.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/any_eq_ne_annotation.rs
@@ -54,7 +54,7 @@ impl AlwaysFixableViolation for AnyEqNeAnnotation {
     }
 
     fn fix_title(&self) -> String {
-        format!("Replace with `object`")
+        "Replace with `object`".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/collections_named_tuple.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/collections_named_tuple.rs
@@ -45,7 +45,7 @@ impl Violation for CollectionsNamedTuple {
     }
 
     fn fix_title(&self) -> Option<String> {
-        Some(format!("Replace with `typing.NamedTuple`"))
+        Some("Replace with `typing.NamedTuple`".to_string())
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/non_empty_stub_body.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/non_empty_stub_body.rs
@@ -38,7 +38,7 @@ impl AlwaysFixableViolation for NonEmptyStubBody {
     }
 
     fn fix_title(&self) -> String {
-        format!("Replace function body with `...`")
+        "Replace function body with `...`".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/pass_in_class_body.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/pass_in_class_body.rs
@@ -36,7 +36,7 @@ impl AlwaysFixableViolation for PassInClassBody {
     }
 
     fn fix_title(&self) -> String {
-        format!("Remove unnecessary `pass`")
+        "Remove unnecessary `pass`".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/pass_statement_stub_body.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/pass_statement_stub_body.rs
@@ -35,7 +35,7 @@ impl AlwaysFixableViolation for PassStatementStubBody {
     }
 
     fn fix_title(&self) -> String {
-        format!("Replace `pass` with `...`")
+        "Replace `pass` with `...`".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/unaliased_collections_abc_set_import.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/unaliased_collections_abc_set_import.rs
@@ -54,7 +54,7 @@ impl Violation for UnaliasedCollectionsAbcSetImport {
     }
 
     fn fix_title(&self) -> Option<String> {
-        Some(format!("Alias `Set` to `AbstractSet`"))
+        Some("Alias `Set` to `AbstractSet`".to_string())
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/unnecessary_type_union.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/unnecessary_type_union.rs
@@ -48,7 +48,7 @@ impl Violation for UnnecessaryTypeUnion {
     }
 
     fn fix_title(&self) -> Option<String> {
-        Some(format!("Combine multiple `type` members"))
+        Some("Combine multiple `type` members".to_string())
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_raise/rules/unnecessary_paren_on_raise_exception.rs
+++ b/crates/ruff_linter/src/rules/flake8_raise/rules/unnecessary_paren_on_raise_exception.rs
@@ -48,7 +48,7 @@ impl AlwaysFixableViolation for UnnecessaryParenOnRaiseException {
     }
 
     fn fix_title(&self) -> String {
-        format!("Remove unnecessary parentheses")
+        "Remove unnecessary parentheses".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_ifexp.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_ifexp.rs
@@ -50,9 +50,9 @@ impl Violation for IfExprWithTrueFalse {
     fn fix_title(&self) -> Option<String> {
         let IfExprWithTrueFalse { is_compare } = self;
         if *is_compare {
-            Some(format!("Remove unnecessary `True if ... else False`"))
+            Some("Remove unnecessary `True if ... else False`".to_string())
         } else {
-            Some(format!("Replace with `bool(...)"))
+            Some("Replace with `bool(...)".to_string())
         }
     }
 }

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_ifexp.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_ifexp.rs
@@ -49,11 +49,12 @@ impl Violation for IfExprWithTrueFalse {
 
     fn fix_title(&self) -> Option<String> {
         let IfExprWithTrueFalse { is_compare } = self;
-        if *is_compare {
-            Some("Remove unnecessary `True if ... else False`".to_string())
+        let title = if *is_compare {
+            "Remove unnecessary `True if ... else False`"
         } else {
-            Some("Replace with `bool(...)".to_string())
-        }
+            "Replace with `bool(...)"
+        };
+        Some(title.to_string())
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_ifexp.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_ifexp.rs
@@ -48,8 +48,7 @@ impl Violation for IfExprWithTrueFalse {
     }
 
     fn fix_title(&self) -> Option<String> {
-        let IfExprWithTrueFalse { is_compare } = self;
-        let title = if *is_compare {
+        let title = if self.is_compare {
             "Remove unnecessary `True if ... else False`"
         } else {
             "Replace with `bool(...)"

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/key_in_dict.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/key_in_dict.rs
@@ -51,7 +51,7 @@ impl AlwaysFixableViolation for InDictKeys {
 
     fn fix_title(&self) -> String {
         let InDictKeys { operator: _ } = self;
-        format!("Remove `.keys()`")
+        "Remove `.keys()`".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/key_in_dict.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/key_in_dict.rs
@@ -50,7 +50,6 @@ impl AlwaysFixableViolation for InDictKeys {
     }
 
     fn fix_title(&self) -> String {
-        let InDictKeys { operator: _ } = self;
         "Remove `.keys()`".to_string()
     }
 }

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/needless_bool.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/needless_bool.rs
@@ -72,7 +72,7 @@ impl Violation for NeedlessBool {
         if let Some(condition) = condition.as_ref().and_then(SourceCodeSnippet::full_display) {
             Some(format!("Replace with `return {condition}`"))
         } else {
-            Some(format!("Inline condition"))
+            Some("Inline condition".to_string())
         }
     }
 }

--- a/crates/ruff_linter/src/rules/flake8_type_checking/rules/empty_type_checking_block.rs
+++ b/crates/ruff_linter/src/rules/flake8_type_checking/rules/empty_type_checking_block.rs
@@ -42,7 +42,7 @@ impl AlwaysFixableViolation for EmptyTypeCheckingBlock {
     }
 
     fn fix_title(&self) -> String {
-        format!("Delete empty type-checking block")
+        "Delete empty type-checking block".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/flynt/rules/static_join_to_fstring.rs
+++ b/crates/ruff_linter/src/rules/flynt/rules/static_join_to_fstring.rs
@@ -51,7 +51,7 @@ impl AlwaysFixableViolation for StaticJoinToFString {
         if let Some(expression) = expression.full_display() {
             format!("Replace with `{expression}`")
         } else {
-            format!("Replace with f-string")
+            "Replace with f-string".to_string()
         }
     }
 }

--- a/crates/ruff_linter/src/rules/perflint/rules/unnecessary_list_cast.rs
+++ b/crates/ruff_linter/src/rules/perflint/rules/unnecessary_list_cast.rs
@@ -45,7 +45,7 @@ impl AlwaysFixableViolation for UnnecessaryListCast {
     }
 
     fn fix_title(&self) -> String {
-        format!("Remove `list()` cast")
+        "Remove `list()` cast".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/invalid_escape_sequence.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/invalid_escape_sequence.rs
@@ -52,8 +52,8 @@ impl AlwaysFixableViolation for InvalidEscapeSequence {
 
     fn fix_title(&self) -> String {
         match self.fix_title {
-            FixTitle::AddBackslash => format!("Add backslash to escape sequence"),
-            FixTitle::UseRawStringLiteral => format!("Use a raw string literal"),
+            FixTitle::AddBackslash => "Add backslash to escape sequence".to_string(),
+            FixTitle::UseRawStringLiteral => "Use a raw string literal".to_string(),
         }
     }
 }

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/logical_lines/missing_whitespace.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/logical_lines/missing_whitespace.rs
@@ -35,7 +35,7 @@ impl AlwaysFixableViolation for MissingWhitespace {
     }
 
     fn fix_title(&self) -> String {
-        format!("Add missing whitespace")
+        "Add missing whitespace".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/logical_lines/missing_whitespace_after_keyword.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/logical_lines/missing_whitespace_after_keyword.rs
@@ -36,7 +36,7 @@ impl AlwaysFixableViolation for MissingWhitespaceAfterKeyword {
     }
 
     fn fix_title(&self) -> String {
-        format!("Added missing whitespace after keyword")
+        "Added missing whitespace after keyword".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/logical_lines/missing_whitespace_around_operator.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/logical_lines/missing_whitespace_around_operator.rs
@@ -38,7 +38,7 @@ impl AlwaysFixableViolation for MissingWhitespaceAroundOperator {
     }
 
     fn fix_title(&self) -> String {
-        format!("Add missing whitespace")
+        "Add missing whitespace".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/logical_lines/space_around_operator.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/logical_lines/space_around_operator.rs
@@ -35,7 +35,7 @@ impl AlwaysFixableViolation for TabBeforeOperator {
     }
 
     fn fix_title(&self) -> String {
-        format!("Replace with single space")
+        "Replace with single space".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/logical_lines/whitespace_around_keywords.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/logical_lines/whitespace_around_keywords.rs
@@ -31,7 +31,7 @@ impl AlwaysFixableViolation for MultipleSpacesAfterKeyword {
     }
 
     fn fix_title(&self) -> String {
-        format!("Replace with single space")
+        "Replace with single space".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/logical_lines/whitespace_around_named_parameter_equals.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/logical_lines/whitespace_around_named_parameter_equals.rs
@@ -41,7 +41,7 @@ impl AlwaysFixableViolation for UnexpectedSpacesAroundKeywordParameterEquals {
     }
 
     fn fix_title(&self) -> String {
-        format!("Remove whitespace")
+        "Remove whitespace".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/logical_lines/whitespace_before_comment.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/logical_lines/whitespace_before_comment.rs
@@ -40,7 +40,7 @@ impl AlwaysFixableViolation for TooFewSpacesBeforeInlineComment {
     }
 
     fn fix_title(&self) -> String {
-        format!("Insert spaces")
+        "Insert spaces".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/multiple_imports_on_one_line.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/multiple_imports_on_one_line.rs
@@ -42,7 +42,7 @@ impl Violation for MultipleImportsOnOneLine {
     }
 
     fn fix_title(&self) -> Option<String> {
-        Some(format!("Split imports"))
+        Some("Split imports".to_string())
     }
 }
 

--- a/crates/ruff_linter/src/rules/pydoclint/rules/check_docstring.rs
+++ b/crates/ruff_linter/src/rules/pydoclint/rules/check_docstring.rs
@@ -65,7 +65,7 @@ impl Violation for DocstringMissingReturns {
     }
 
     fn fix_title(&self) -> Option<String> {
-        Some(format!("Add a \"Returns\" section to the docstring"))
+        Some("Add a \"Returns\" section to the docstring".to_string())
     }
 }
 

--- a/crates/ruff_linter/src/rules/pydocstyle/rules/triple_quotes.rs
+++ b/crates/ruff_linter/src/rules/pydocstyle/rules/triple_quotes.rs
@@ -57,8 +57,8 @@ impl Violation for TripleSingleQuotes {
     fn fix_title(&self) -> Option<String> {
         let TripleSingleQuotes { expected_quote } = self;
         Some(match expected_quote {
-            Quote::Double => format!("Convert to triple double quotes"),
-            Quote::Single => format!("Convert to triple single quotes"),
+            Quote::Double => "Convert to triple double quotes".to_string(),
+            Quote::Single => "Convert to triple single quotes".to_string(),
         })
     }
 }

--- a/crates/ruff_linter/src/rules/pydocstyle/rules/triple_quotes.rs
+++ b/crates/ruff_linter/src/rules/pydocstyle/rules/triple_quotes.rs
@@ -55,11 +55,11 @@ impl Violation for TripleSingleQuotes {
     }
 
     fn fix_title(&self) -> Option<String> {
-        let TripleSingleQuotes { expected_quote } = self;
-        Some(match expected_quote {
-            Quote::Double => "Convert to triple double quotes".to_string(),
-            Quote::Single => "Convert to triple single quotes".to_string(),
-        })
+        let title = match self.expected_quote {
+            Quote::Double => "Convert to triple double quotes",
+            Quote::Single => "Convert to triple single quotes",
+        };
+        Some(title.to_string())
     }
 }
 

--- a/crates/ruff_linter/src/rules/pyflakes/rules/repeated_keys.rs
+++ b/crates/ruff_linter/src/rules/pyflakes/rules/repeated_keys.rs
@@ -76,7 +76,7 @@ impl Violation for MultiValueRepeatedKeyLiteral {
         if let Some(name) = name.full_display() {
             Some(format!("Remove repeated key literal `{name}`"))
         } else {
-            Some(format!("Remove repeated key literal"))
+            Some("Remove repeated key literal".to_string())
         }
     }
 }
@@ -133,7 +133,7 @@ impl Violation for MultiValueRepeatedKeyVariable {
         if let Some(name) = name.full_display() {
             Some(format!("Remove repeated key `{name}`"))
         } else {
-            Some(format!("Remove repeated key"))
+            Some("Remove repeated key".to_string())
         }
     }
 }

--- a/crates/ruff_linter/src/rules/pyflakes/rules/repeated_keys.rs
+++ b/crates/ruff_linter/src/rules/pyflakes/rules/repeated_keys.rs
@@ -72,12 +72,11 @@ impl Violation for MultiValueRepeatedKeyLiteral {
     }
 
     fn fix_title(&self) -> Option<String> {
-        let MultiValueRepeatedKeyLiteral { name, .. } = self;
-        if let Some(name) = name.full_display() {
-            Some(format!("Remove repeated key literal `{name}`"))
-        } else {
-            Some("Remove repeated key literal".to_string())
-        }
+        let title = match self.name.full_display() {
+            Some(name) => format!("Remove repeated key literal `{name}`"),
+            None => "Remove repeated key literal".to_string(),
+        };
+        Some(title)
     }
 }
 
@@ -129,12 +128,11 @@ impl Violation for MultiValueRepeatedKeyVariable {
     }
 
     fn fix_title(&self) -> Option<String> {
-        let MultiValueRepeatedKeyVariable { name } = self;
-        if let Some(name) = name.full_display() {
-            Some(format!("Remove repeated key `{name}`"))
-        } else {
-            Some("Remove repeated key".to_string())
-        }
+        let title = match self.name.full_display() {
+            Some(name) => format!("Remove repeated key `{name}`"),
+            None => "Remove repeated key".to_string(),
+        };
+        Some(title)
     }
 }
 

--- a/crates/ruff_linter/src/rules/pygrep_hooks/rules/deprecated_log_warn.rs
+++ b/crates/ruff_linter/src/rules/pygrep_hooks/rules/deprecated_log_warn.rs
@@ -45,6 +45,6 @@ impl Violation for DeprecatedLogWarn {
     }
 
     fn fix_title(&self) -> Option<String> {
-        Some(format!("Replace with `warning`"))
+        Some("Replace with `warning`".to_string())
     }
 }

--- a/crates/ruff_linter/src/rules/pylint/rules/dict_iter_missing_items.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/dict_iter_missing_items.rs
@@ -59,7 +59,7 @@ impl AlwaysFixableViolation for DictIterMissingItems {
     }
 
     fn fix_title(&self) -> String {
-        format!("Add a call to `.items()`")
+        "Add a call to `.items()`".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/pylint/rules/empty_comment.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/empty_comment.rs
@@ -39,7 +39,7 @@ impl Violation for EmptyComment {
     }
 
     fn fix_title(&self) -> Option<String> {
-        Some(format!("Delete the empty comment"))
+        Some("Delete the empty comment".to_string())
     }
 }
 

--- a/crates/ruff_linter/src/rules/pylint/rules/iteration_over_set.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/iteration_over_set.rs
@@ -40,7 +40,7 @@ impl AlwaysFixableViolation for IterationOverSet {
     }
 
     fn fix_title(&self) -> String {
-        format!("Convert to `tuple`")
+        "Convert to `tuple`".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/pylint/rules/literal_membership.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/literal_membership.rs
@@ -41,7 +41,7 @@ impl AlwaysFixableViolation for LiteralMembership {
     }
 
     fn fix_title(&self) -> String {
-        format!("Convert to `set`")
+        "Convert to `set`".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/pylint/rules/no_method_decorator.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/no_method_decorator.rs
@@ -42,7 +42,7 @@ impl AlwaysFixableViolation for NoClassmethodDecorator {
     }
 
     fn fix_title(&self) -> String {
-        format!("Add @classmethod decorator")
+        "Add @classmethod decorator".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/pylint/rules/repeated_equality_comparison.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/repeated_equality_comparison.rs
@@ -63,7 +63,7 @@ impl AlwaysFixableViolation for RepeatedEqualityComparison {
     }
 
     fn fix_title(&self) -> String {
-        format!("Merge multiple comparisons")
+        "Merge multiple comparisons".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/pylint/rules/repeated_isinstance_calls.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/repeated_isinstance_calls.rs
@@ -70,7 +70,7 @@ impl AlwaysFixableViolation for RepeatedIsinstanceCalls {
         if let Some(expression) = expression.full_display() {
             format!("Replace with `{expression}`")
         } else {
-            format!("Replace with merged `isinstance` call")
+            "Replace with merged `isinstance` call".to_string()
         }
     }
 }

--- a/crates/ruff_linter/src/rules/pylint/rules/unnecessary_dict_index_lookup.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/unnecessary_dict_index_lookup.rs
@@ -40,7 +40,7 @@ impl AlwaysFixableViolation for UnnecessaryDictIndexLookup {
     }
 
     fn fix_title(&self) -> String {
-        format!("Use existing variable")
+        "Use existing variable".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/pylint/rules/unnecessary_list_index_lookup.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/unnecessary_list_index_lookup.rs
@@ -41,7 +41,7 @@ impl AlwaysFixableViolation for UnnecessaryListIndexLookup {
     }
 
     fn fix_title(&self) -> String {
-        format!("Use the loop variable directly")
+        "Use the loop variable directly".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/pylint/rules/unspecified_encoding.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/unspecified_encoding.rs
@@ -67,7 +67,7 @@ impl AlwaysFixableViolation for UnspecifiedEncoding {
     }
 
     fn fix_title(&self) -> String {
-        format!("Add explicit `encoding` argument")
+        "Add explicit `encoding` argument".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/pylint/rules/useless_exception_statement.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/useless_exception_statement.rs
@@ -45,7 +45,7 @@ impl Violation for UselessExceptionStatement {
     }
 
     fn fix_title(&self) -> Option<String> {
-        Some(format!("Add `raise` keyword"))
+        Some("Add `raise` keyword".to_string())
     }
 }
 

--- a/crates/ruff_linter/src/rules/pylint/rules/useless_return.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/useless_return.rs
@@ -38,7 +38,7 @@ impl AlwaysFixableViolation for UselessReturn {
     }
 
     fn fix_title(&self) -> String {
-        format!("Remove useless `return` statement")
+        "Remove useless `return` statement".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/unnecessary_default_type_args.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/unnecessary_default_type_args.rs
@@ -60,7 +60,7 @@ impl AlwaysFixableViolation for UnnecessaryDefaultTypeArgs {
     }
 
     fn fix_title(&self) -> String {
-        format!("Remove default type arguments")
+        "Remove default type arguments".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/refurb/rules/bit_count.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/bit_count.rs
@@ -50,7 +50,7 @@ impl AlwaysFixableViolation for BitCount {
         if let Some(replacement) = replacement.full_display() {
             format!("Replace with `{replacement}`")
         } else {
-            format!("Replace with `.bit_count()`")
+            "Replace with `.bit_count()`".to_string()
         }
     }
 }

--- a/crates/ruff_linter/src/rules/refurb/rules/fstring_number_format.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/fstring_number_format.rs
@@ -56,7 +56,7 @@ impl Violation for FStringNumberFormat {
         {
             Some(format!("Replace with `{display}`"))
         } else {
-            Some(format!("Replace with f-string"))
+            Some("Replace with f-string".to_string())
         }
     }
 }

--- a/crates/ruff_linter/src/rules/refurb/rules/fstring_number_format.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/fstring_number_format.rs
@@ -49,8 +49,8 @@ impl Violation for FStringNumberFormat {
     }
 
     fn fix_title(&self) -> Option<String> {
-        let FStringNumberFormat { replacement, .. } = self;
-        if let Some(display) = replacement
+        if let Some(display) = self
+            .replacement
             .as_ref()
             .and_then(SourceCodeSnippet::full_display)
         {

--- a/crates/ruff_linter/src/rules/refurb/rules/if_exp_instead_of_or_operator.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/if_exp_instead_of_or_operator.rs
@@ -50,7 +50,7 @@ impl Violation for IfExpInsteadOfOrOperator {
     }
 
     fn fix_title(&self) -> Option<String> {
-        Some(format!("Replace with `or` operator"))
+        Some("Replace with `or` operator".to_string())
     }
 }
 

--- a/crates/ruff_linter/src/rules/refurb/rules/int_on_sliced_str.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/int_on_sliced_str.rs
@@ -60,7 +60,7 @@ impl AlwaysFixableViolation for IntOnSlicedStr {
     }
 
     fn fix_title(&self) -> String {
-        format!("Replace with `base=0`")
+        "Replace with `base=0`".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/refurb/rules/metaclass_abcmeta.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/metaclass_abcmeta.rs
@@ -44,7 +44,7 @@ impl AlwaysFixableViolation for MetaClassABCMeta {
     }
 
     fn fix_title(&self) -> String {
-        format!("Replace with `abc.ABC`")
+        "Replace with `abc.ABC`".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/refurb/rules/reimplemented_starmap.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/reimplemented_starmap.rs
@@ -76,7 +76,7 @@ impl Violation for ReimplementedStarmap {
     }
 
     fn fix_title(&self) -> Option<String> {
-        Some(format!("Replace with `itertools.starmap`"))
+        Some("Replace with `itertools.starmap`".to_string())
     }
 }
 

--- a/crates/ruff_linter/src/rules/ruff/rules/collection_literal_concatenation.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/collection_literal_concatenation.rs
@@ -59,7 +59,7 @@ impl Violation for CollectionLiteralConcatenation {
         if let Some(expression) = expression.full_display() {
             Some(format!("Replace with `{expression}`"))
         } else {
-            Some(format!("Replace with iterable unpacking"))
+            Some("Replace with iterable unpacking".to_string())
         }
     }
 }

--- a/crates/ruff_linter/src/rules/ruff/rules/collection_literal_concatenation.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/collection_literal_concatenation.rs
@@ -55,12 +55,11 @@ impl Violation for CollectionLiteralConcatenation {
     }
 
     fn fix_title(&self) -> Option<String> {
-        let CollectionLiteralConcatenation { expression } = self;
-        if let Some(expression) = expression.full_display() {
-            Some(format!("Replace with `{expression}`"))
-        } else {
-            Some("Replace with iterable unpacking".to_string())
-        }
+        let title = match self.expression.full_display() {
+            Some(expression) => format!("Replace with `{expression}`"),
+            None => "Replace with iterable unpacking".to_string(),
+        };
+        Some(title)
     }
 }
 

--- a/crates/ruff_linter/src/rules/ruff/rules/invalid_formatter_suppression_comment.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/invalid_formatter_suppression_comment.rs
@@ -64,7 +64,7 @@ impl AlwaysFixableViolation for InvalidFormatterSuppressionComment {
     }
 
     fn fix_title(&self) -> String {
-        format!("Remove this comment")
+        "Remove this comment".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/ruff/rules/post_init_default.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/post_init_default.rs
@@ -78,7 +78,7 @@ impl Violation for PostInitDefault {
     }
 
     fn fix_title(&self) -> Option<String> {
-        Some(format!("Use `dataclasses.InitVar` instead"))
+        Some("Use `dataclasses.InitVar` instead".to_string())
     }
 }
 

--- a/crates/ruff_linter/src/rules/ruff/rules/quadratic_list_summation.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/quadratic_list_summation.rs
@@ -62,7 +62,7 @@ impl AlwaysFixableViolation for QuadraticListSummation {
     }
 
     fn fix_title(&self) -> String {
-        format!("Replace with `functools.reduce`")
+        "Replace with `functools.reduce`".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/ruff/rules/unnecessary_key_check.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/unnecessary_key_check.rs
@@ -38,7 +38,7 @@ impl AlwaysFixableViolation for UnnecessaryKeyCheck {
     }
 
     fn fix_title(&self) -> String {
-        format!("Replace with `dict.get`")
+        "Replace with `dict.get`".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/tryceratops/rules/error_instead_of_exception.rs
+++ b/crates/ruff_linter/src/rules/tryceratops/rules/error_instead_of_exception.rs
@@ -63,7 +63,7 @@ impl Violation for ErrorInsteadOfException {
     }
 
     fn fix_title(&self) -> Option<String> {
-        Some(format!("Replace with `exception`"))
+        Some("Replace with `exception`".to_string())
     }
 }
 

--- a/crates/ruff_linter/src/rules/tryceratops/rules/verbose_raise.rs
+++ b/crates/ruff_linter/src/rules/tryceratops/rules/verbose_raise.rs
@@ -45,7 +45,7 @@ impl AlwaysFixableViolation for VerboseRaise {
     }
 
     fn fix_title(&self) -> String {
-        format!("Remove exception name")
+        "Remove exception name".to_string()
     }
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

From https://github.com/astral-sh/ruff/pull/14008/commits/56047ffa53ffd0fb96737b977fcd0612c5103721 I realised that `to_string` is preferred over `format!` when no arguments are provided. This PR consistently does so for existing violations.

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

`cargo test`
<!-- How was it tested? -->
