### PR TITLE
[red-knot] Do not panic when encountering string annotations

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/annotations/string_annotations.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/annotations/string_annotations.md
@@ -1,0 +1,9 @@
+# String annotations
+
+```py
+def f() -> "int":
+    return 1
+
+# TODO: We do not support string annotations, but we should not panic if we encounter them
+reveal_type(f())  # revealed: @Todo
+```

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -192,7 +192,12 @@ fn definition_expression_ty<'db>(
     if let Some(ty) = inference.try_expression_ty(expr_id) {
         ty
     } else {
-        infer_deferred_types(db, definition).expression_ty(expr_id)
+        infer_deferred_types(db, definition)
+            .try_expression_ty(expr_id)
+            .unwrap_or(
+                // Some deferred cases like string annotations are not yet implemented
+                Type::Todo,
+            )
     }
 }
 

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -192,12 +192,7 @@ fn definition_expression_ty<'db>(
     if let Some(ty) = inference.try_expression_ty(expr_id) {
         ty
     } else {
-        infer_deferred_types(db, definition)
-            .try_expression_ty(expr_id)
-            .unwrap_or(
-                // Some deferred cases like string annotations are not yet implemented
-                Type::Todo,
-            )
+        infer_deferred_types(db, definition).expression_ty(expr_id)
     }
 }
 

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -3655,7 +3655,10 @@ impl<'db> TypeInferenceBuilder<'db> {
             // TODO: parse the expression and check whether it is a string annotation, since they
             // can be annotation expressions distinct from type expressions.
             // https://typing.readthedocs.io/en/latest/spec/annotations.html#string-annotations
-            ast::Expr::StringLiteral(_literal) => Type::Todo,
+            ast::Expr::StringLiteral(_literal) => {
+                self.store_expression_type(expression, Type::Todo);
+                Type::Todo
+            }
 
             // Annotation expressions also get special handling for `*args` and `**kwargs`.
             ast::Expr::Starred(starred) => self.infer_starred_expression(starred),


### PR DESCRIPTION
## Summary

Encountered this while running red-knot benchmarks on the `black` codebase.

Fixes two of the issues in #13478.

## Test Plan

Added a regression test.