### PR TITLE
Avoid cloning `Name` when looking up function and class types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2637,6 +2637,7 @@ dependencies = [
  "ruff_source_file",
  "ruff_text_size",
  "rustc-hash 2.0.0",
+ "salsa",
  "schemars",
  "serde",
 ]

--- a/crates/red_knot_python_semantic/Cargo.toml
+++ b/crates/red_knot_python_semantic/Cargo.toml
@@ -13,7 +13,7 @@ license = { workspace = true }
 [dependencies]
 ruff_db = { workspace = true }
 ruff_index = { workspace = true }
-ruff_python_ast = { workspace = true }
+ruff_python_ast = { workspace = true, features = ["salsa"] }
 ruff_python_stdlib = { workspace = true }
 ruff_source_file = { workspace = true }
 ruff_text_size = { workspace = true }

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -766,7 +766,7 @@ impl<'db> TypeInferenceBuilder<'db> {
         };
         let function_ty = Type::FunctionLiteral(FunctionType::new(
             self.db,
-            name.id.clone(),
+            &*name.id,
             function_kind,
             definition,
             decorator_tys,
@@ -875,7 +875,7 @@ impl<'db> TypeInferenceBuilder<'db> {
 
         let class_ty = Type::ClassLiteral(ClassType::new(
             self.db,
-            name.id.clone(),
+            &*name.id,
             definition,
             body_scope,
             maybe_known_class,

--- a/crates/ruff_python_ast/Cargo.toml
+++ b/crates/ruff_python_ast/Cargo.toml
@@ -26,13 +26,20 @@ is-macro = { workspace = true }
 itertools = { workspace = true }
 memchr = { workspace = true }
 rustc-hash = { workspace = true }
+salsa = { workspace = true, optional = true }
 schemars = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
 
 [features]
 schemars = ["dep:schemars"]
 cache = ["dep:ruff_cache", "dep:ruff_macros"]
-serde = ["dep:serde", "ruff_text_size/serde", "dep:ruff_cache", "compact_str/serde"]
+serde = [
+  "dep:serde",
+  "ruff_text_size/serde",
+  "dep:ruff_cache",
+  "compact_str/serde",
+]
+salsa = ["dep:salsa"]
 
 [lints]
 workspace = true

--- a/crates/ruff_python_ast/src/name.rs
+++ b/crates/ruff_python_ast/src/name.rs
@@ -205,6 +205,21 @@ impl schemars::JsonSchema for Name {
     }
 }
 
+#[cfg(feature = "salsa")]
+impl salsa::plumbing::interned::Lookup<Name> for &str {
+    fn hash<H: Hasher>(&self, h: &mut H) {
+        std::hash::Hash::hash(self, h);
+    }
+
+    fn eq(&self, data: &Name) -> bool {
+        self == data
+    }
+
+    fn into_owned(self) -> Name {
+        Name::new(self)
+    }
+}
+
 /// A representation of a qualified name, like `typing.List`.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct QualifiedName<'a>(SegmentsVec<'a>);


### PR DESCRIPTION
## Summary

Uses Salsa's new `Lookup` functionality for `FunctionType` and `ClassType` names. 
The `Lookup` trait allows looking-up interned values by a borrowed value. In this case
we can lookup the interned type using the borrowed `str` and only allocate the owned `Name`` when 
the type doesn't already exist.

This was part of https://github.com/astral-sh/ruff/pull/14087 but I extracted it into its own PR to see if it is the reason for the significant incremental perf improvement.

## Test Plan

`cargo test`
