### PR TITLE
Derive message formats macro support to string

### DIFF
--- a/crates/ruff_linter/src/rules/eradicate/rules/commented_out_code.rs
+++ b/crates/ruff_linter/src/rules/eradicate/rules/commented_out_code.rs
@@ -37,7 +37,7 @@ impl Violation for CommentedOutCode {
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Found commented-out code")
+        "Found commented-out code".to_string()
     }
 
     fn fix_title(&self) -> Option<String> {

--- a/crates/ruff_linter/src/rules/fastapi/rules/fastapi_non_annotated_dependency.rs
+++ b/crates/ruff_linter/src/rules/fastapi/rules/fastapi_non_annotated_dependency.rs
@@ -64,7 +64,7 @@ impl Violation for FastApiNonAnnotatedDependency {
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("FastAPI dependency without `Annotated`")
+        "FastAPI dependency without `Annotated`".to_string()
     }
 
     fn fix_title(&self) -> Option<String> {

--- a/crates/ruff_linter/src/rules/fastapi/rules/fastapi_redundant_response_model.rs
+++ b/crates/ruff_linter/src/rules/fastapi/rules/fastapi_redundant_response_model.rs
@@ -65,7 +65,7 @@ pub struct FastApiRedundantResponseModel;
 impl AlwaysFixableViolation for FastApiRedundantResponseModel {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("FastAPI route with redundant `response_model` argument")
+        "FastAPI route with redundant `response_model` argument".to_string()
     }
 
     fn fix_title(&self) -> String {

--- a/crates/ruff_linter/src/rules/flake8_2020/rules/compare.rs
+++ b/crates/ruff_linter/src/rules/flake8_2020/rules/compare.rs
@@ -46,7 +46,7 @@ pub struct SysVersionCmpStr3;
 impl Violation for SysVersionCmpStr3 {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("`sys.version` compared to string (python3.10), use `sys.version_info`")
+        "`sys.version` compared to string (python3.10), use `sys.version_info`".to_string()
     }
 }
 
@@ -93,7 +93,7 @@ pub struct SysVersionInfo0Eq3;
 impl Violation for SysVersionInfo0Eq3 {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("`sys.version_info[0] == 3` referenced (python4), use `>=`")
+        "`sys.version_info[0] == 3` referenced (python4), use `>=`".to_string()
     }
 }
 
@@ -133,10 +133,9 @@ pub struct SysVersionInfo1CmpInt;
 impl Violation for SysVersionInfo1CmpInt {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!(
-            "`sys.version_info[1]` compared to integer (python4), compare `sys.version_info` to \
+        "`sys.version_info[1]` compared to integer (python4), compare `sys.version_info` to \
              tuple"
-        )
+            .to_string()
     }
 }
 
@@ -176,10 +175,9 @@ pub struct SysVersionInfoMinorCmpInt;
 impl Violation for SysVersionInfoMinorCmpInt {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!(
-            "`sys.version_info.minor` compared to integer (python4), compare `sys.version_info` \
+        "`sys.version_info.minor` compared to integer (python4), compare `sys.version_info` \
              to tuple"
-        )
+            .to_string()
     }
 }
 
@@ -220,7 +218,7 @@ pub struct SysVersionCmpStr10;
 impl Violation for SysVersionCmpStr10 {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("`sys.version` compared to string (python10), use `sys.version_info`")
+        "`sys.version` compared to string (python10), use `sys.version_info`".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_2020/rules/name_or_attribute.rs
+++ b/crates/ruff_linter/src/rules/flake8_2020/rules/name_or_attribute.rs
@@ -41,7 +41,7 @@ pub struct SixPY3;
 impl Violation for SixPY3 {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("`six.PY3` referenced (python4), use `not six.PY2`")
+        "`six.PY3` referenced (python4), use `not six.PY2`".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_2020/rules/subscript.rs
+++ b/crates/ruff_linter/src/rules/flake8_2020/rules/subscript.rs
@@ -43,7 +43,7 @@ pub struct SysVersionSlice3;
 impl Violation for SysVersionSlice3 {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("`sys.version[:3]` referenced (python3.10), use `sys.version_info`")
+        "`sys.version[:3]` referenced (python3.10), use `sys.version_info`".to_string()
     }
 }
 
@@ -83,7 +83,7 @@ pub struct SysVersion2;
 impl Violation for SysVersion2 {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("`sys.version[2]` referenced (python3.10), use `sys.version_info`")
+        "`sys.version[2]` referenced (python3.10), use `sys.version_info`".to_string()
     }
 }
 
@@ -123,7 +123,7 @@ pub struct SysVersion0;
 impl Violation for SysVersion0 {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("`sys.version[0]` referenced (python10), use `sys.version_info`")
+        "`sys.version[0]` referenced (python10), use `sys.version_info`".to_string()
     }
 }
 
@@ -163,7 +163,7 @@ pub struct SysVersionSlice1;
 impl Violation for SysVersionSlice1 {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("`sys.version[:1]` referenced (python10), use `sys.version_info`")
+        "`sys.version[:1]` referenced (python10), use `sys.version_info`".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_async/rules/async_function_with_timeout.rs
+++ b/crates/ruff_linter/src/rules/flake8_async/rules/async_function_with_timeout.rs
@@ -71,7 +71,7 @@ pub struct AsyncFunctionWithTimeout {
 impl Violation for AsyncFunctionWithTimeout {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Async function definition with a `timeout` parameter")
+        "Async function definition with a `timeout` parameter".to_string()
     }
 
     fn fix_title(&self) -> Option<String> {

--- a/crates/ruff_linter/src/rules/flake8_async/rules/blocking_http_call.rs
+++ b/crates/ruff_linter/src/rules/flake8_async/rules/blocking_http_call.rs
@@ -37,7 +37,7 @@ pub struct BlockingHttpCallInAsyncFunction;
 impl Violation for BlockingHttpCallInAsyncFunction {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Async functions should not call blocking HTTP methods")
+        "Async functions should not call blocking HTTP methods".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_async/rules/blocking_open_call.rs
+++ b/crates/ruff_linter/src/rules/flake8_async/rules/blocking_open_call.rs
@@ -39,7 +39,7 @@ pub struct BlockingOpenCallInAsyncFunction;
 impl Violation for BlockingOpenCallInAsyncFunction {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Async functions should not open files with blocking methods like `open`")
+        "Async functions should not open files with blocking methods like `open`".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_async/rules/blocking_process_invocation.rs
+++ b/crates/ruff_linter/src/rules/flake8_async/rules/blocking_process_invocation.rs
@@ -36,7 +36,7 @@ pub struct CreateSubprocessInAsyncFunction;
 impl Violation for CreateSubprocessInAsyncFunction {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Async functions should not create subprocesses with blocking methods")
+        "Async functions should not create subprocesses with blocking methods".to_string()
     }
 }
 
@@ -68,7 +68,7 @@ pub struct RunProcessInAsyncFunction;
 impl Violation for RunProcessInAsyncFunction {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Async functions should not run processes with blocking methods")
+        "Async functions should not run processes with blocking methods".to_string()
     }
 }
 
@@ -104,7 +104,7 @@ pub struct WaitForProcessInAsyncFunction;
 impl Violation for WaitForProcessInAsyncFunction {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Async functions should not wait on processes with blocking methods")
+        "Async functions should not wait on processes with blocking methods".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_async/rules/blocking_sleep.rs
+++ b/crates/ruff_linter/src/rules/flake8_async/rules/blocking_sleep.rs
@@ -34,7 +34,7 @@ pub struct BlockingSleepInAsyncFunction;
 impl Violation for BlockingSleepInAsyncFunction {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Async functions should not call `time.sleep`")
+        "Async functions should not call `time.sleep`".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/assert_used.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/assert_used.rs
@@ -36,7 +36,7 @@ pub struct Assert;
 impl Violation for Assert {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Use of `assert` detected")
+        "Use of `assert` detected".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/bad_file_permissions.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/bad_file_permissions.rs
@@ -47,7 +47,9 @@ impl Violation for BadFilePermissions {
             Reason::Permissive(mask) => {
                 format!("`os.chmod` setting a permissive mask `{mask:#o}` on file or directory")
             }
-            Reason::Invalid => format!("`os.chmod` setting an invalid mask on file or directory"),
+            Reason::Invalid => {
+                "`os.chmod` setting an invalid mask on file or directory".to_string()
+            }
         }
     }
 }

--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/django_extra.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/django_extra.rs
@@ -39,7 +39,7 @@ pub struct DjangoExtra;
 impl Violation for DjangoExtra {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Use of Django `extra` can lead to SQL injection vulnerabilities")
+        "Use of Django `extra` can lead to SQL injection vulnerabilities".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/django_raw_sql.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/django_raw_sql.rs
@@ -30,7 +30,7 @@ pub struct DjangoRawSql;
 impl Violation for DjangoRawSql {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Use of `RawSQL` can lead to SQL injection vulnerabilities")
+        "Use of `RawSQL` can lead to SQL injection vulnerabilities".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/exec_used.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/exec_used.rs
@@ -27,7 +27,7 @@ pub struct ExecBuiltin;
 impl Violation for ExecBuiltin {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Use of `exec` detected")
+        "Use of `exec` detected".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/flask_debug_true.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/flask_debug_true.rs
@@ -42,7 +42,7 @@ pub struct FlaskDebugTrue;
 impl Violation for FlaskDebugTrue {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Use of `debug=True` in Flask app detected")
+        "Use of `debug=True` in Flask app detected".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/hardcoded_bind_all_interfaces.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/hardcoded_bind_all_interfaces.rs
@@ -32,7 +32,7 @@ pub struct HardcodedBindAllInterfaces;
 impl Violation for HardcodedBindAllInterfaces {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Possible binding to all interfaces")
+        "Possible binding to all interfaces".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/hardcoded_sql_expression.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/hardcoded_sql_expression.rs
@@ -41,7 +41,7 @@ pub struct HardcodedSQLExpression;
 impl Violation for HardcodedSQLExpression {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Possible SQL injection vector through string-based query construction")
+        "Possible SQL injection vector through string-based query construction".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/jinja2_autoescape_false.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/jinja2_autoescape_false.rs
@@ -42,17 +42,15 @@ pub struct Jinja2AutoescapeFalse {
 impl Violation for Jinja2AutoescapeFalse {
     #[derive_message_formats]
     fn message(&self) -> String {
-        let Jinja2AutoescapeFalse { value } = self;
-        match value {
-            true => format!(
-                "Using jinja2 templates with `autoescape=False` is dangerous and can lead to XSS. \
+        if self.value {
+            "Using jinja2 templates with `autoescape=False` is dangerous and can lead to XSS. \
                  Ensure `autoescape=True` or use the `select_autoescape` function."
-            ),
-            false => format!(
-                "By default, jinja2 sets `autoescape` to `False`. Consider using \
-                 `autoescape=True` or the `select_autoescape` function to mitigate XSS \
-                 vulnerabilities."
-            ),
+                .to_string()
+        } else {
+            "By default, jinja2 sets `autoescape` to `False`. Consider using \
+                `autoescape=True` or the `select_autoescape` function to mitigate XSS \
+                vulnerabilities."
+                .to_string()
         }
     }
 }

--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/logging_config_insecure_listen.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/logging_config_insecure_listen.rs
@@ -30,7 +30,7 @@ pub struct LoggingConfigInsecureListen;
 impl Violation for LoggingConfigInsecureListen {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Use of insecure `logging.config.listen` detected")
+        "Use of insecure `logging.config.listen` detected".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/mako_templates.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/mako_templates.rs
@@ -37,9 +37,7 @@ pub struct MakoTemplates;
 impl Violation for MakoTemplates {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!(
-            "Mako templates allow HTML and JavaScript rendering by default and are inherently open to XSS attacks"
-        )
+        "Mako templates allow HTML and JavaScript rendering by default and are inherently open to XSS attacks".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/paramiko_calls.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/paramiko_calls.rs
@@ -31,7 +31,8 @@ pub struct ParamikoCall;
 impl Violation for ParamikoCall {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Possible shell injection via Paramiko call; check inputs are properly sanitized")
+        "Possible shell injection via Paramiko call; check inputs are properly sanitized"
+            .to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/shell_injection.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/shell_injection.rs
@@ -46,14 +46,10 @@ impl Violation for SubprocessPopenWithShellEqualsTrue {
     #[derive_message_formats]
     fn message(&self) -> String {
         match (self.safety, self.is_exact) {
-            (Safety::SeemsSafe, true) => format!(
-                "`subprocess` call with `shell=True` seems safe, but may be changed in the future; consider rewriting without `shell`"
-            ),
-            (Safety::Unknown, true) => format!("`subprocess` call with `shell=True` identified, security issue"),
-            (Safety::SeemsSafe, false) => format!(
-                "`subprocess` call with truthy `shell` seems safe, but may be changed in the future; consider rewriting without `shell`"
-            ),
-            (Safety::Unknown, false) => format!("`subprocess` call with truthy `shell` identified, security issue"),
+            (Safety::SeemsSafe, true) => "`subprocess` call with `shell=True` seems safe, but may be changed in the future; consider rewriting without `shell`".to_string(),
+            (Safety::Unknown, true) => "`subprocess` call with `shell=True` identified, security issue".to_string(),
+            (Safety::SeemsSafe, false) => "`subprocess` call with truthy `shell` seems safe, but may be changed in the future; consider rewriting without `shell`".to_string(),
+            (Safety::Unknown, false) => "`subprocess` call with truthy `shell` identified, security issue".to_string(),
         }
     }
 }
@@ -88,7 +84,7 @@ pub struct SubprocessWithoutShellEqualsTrue;
 impl Violation for SubprocessWithoutShellEqualsTrue {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("`subprocess` call: check for execution of untrusted input")
+        "`subprocess` call: check for execution of untrusted input".to_string()
     }
 }
 
@@ -129,9 +125,9 @@ impl Violation for CallWithShellEqualsTrue {
     #[derive_message_formats]
     fn message(&self) -> String {
         if self.is_exact {
-            format!("Function call with `shell=True` parameter identified, security issue")
+            "Function call with `shell=True` parameter identified, security issue".to_string()
         } else {
-            format!("Function call with truthy `shell` parameter identified, security issue")
+            "Function call with truthy `shell` parameter identified, security issue".to_string()
         }
     }
 }
@@ -181,8 +177,8 @@ impl Violation for StartProcessWithAShell {
     #[derive_message_formats]
     fn message(&self) -> String {
         match self.safety {
-            Safety::SeemsSafe => format!("Starting a process with a shell: seems safe, but may be changed in the future; consider rewriting without `shell`"),
-            Safety::Unknown => format!("Starting a process with a shell, possible injection detected"),
+            Safety::SeemsSafe => "Starting a process with a shell: seems safe, but may be changed in the future; consider rewriting without `shell`".to_string(),
+            Safety::Unknown => "Starting a process with a shell, possible injection detected".to_string(),
         }
     }
 }
@@ -219,7 +215,7 @@ pub struct StartProcessWithNoShell;
 impl Violation for StartProcessWithNoShell {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Starting a process without a shell")
+        "Starting a process without a shell".to_string()
     }
 }
 
@@ -254,7 +250,7 @@ pub struct StartProcessWithPartialPath;
 impl Violation for StartProcessWithPartialPath {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Starting a process with a partial executable path")
+        "Starting a process with a partial executable path".to_string()
     }
 }
 
@@ -287,7 +283,7 @@ pub struct UnixCommandWildcardInjection;
 impl Violation for UnixCommandWildcardInjection {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Possible wildcard injection in call due to `*` usage")
+        "Possible wildcard injection in call due to `*` usage".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/snmp_insecure_version.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/snmp_insecure_version.rs
@@ -36,7 +36,7 @@ pub struct SnmpInsecureVersion;
 impl Violation for SnmpInsecureVersion {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("The use of SNMPv1 and SNMPv2 is insecure. Use SNMPv3 if able.")
+        "The use of SNMPv1 and SNMPv2 is insecure. Use SNMPv3 if able.".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/snmp_weak_cryptography.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/snmp_weak_cryptography.rs
@@ -34,9 +34,8 @@ pub struct SnmpWeakCryptography;
 impl Violation for SnmpWeakCryptography {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!(
-            "You should not use SNMPv3 without encryption. `noAuthNoPriv` & `authNoPriv` is insecure."
-        )
+        "You should not use SNMPv3 without encryption. `noAuthNoPriv` & `authNoPriv` is insecure."
+            .to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/ssh_no_host_key_verification.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/ssh_no_host_key_verification.rs
@@ -39,7 +39,7 @@ pub struct SSHNoHostKeyVerification;
 impl Violation for SSHNoHostKeyVerification {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Paramiko call with policy set to automatically trust the unknown host key")
+        "Paramiko call with policy set to automatically trust the unknown host key".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/ssl_with_no_version.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/ssl_with_no_version.rs
@@ -31,7 +31,7 @@ pub struct SslWithNoVersion;
 impl Violation for SslWithNoVersion {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("`ssl.wrap_socket` called without an `ssl_version``")
+        "`ssl.wrap_socket` called without an `ssl_version``".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/suspicious_function_call.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/suspicious_function_call.rs
@@ -52,7 +52,7 @@ pub struct SuspiciousPickleUsage;
 impl Violation for SuspiciousPickleUsage {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("`pickle` and modules that wrap it can be unsafe when used to deserialize untrusted data, possible security issue")
+        "`pickle` and modules that wrap it can be unsafe when used to deserialize untrusted data, possible security issue".to_string()
     }
 }
 
@@ -97,7 +97,7 @@ pub struct SuspiciousMarshalUsage;
 impl Violation for SuspiciousMarshalUsage {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Deserialization with the `marshal` module is possibly dangerous")
+        "Deserialization with the `marshal` module is possibly dangerous".to_string()
     }
 }
 
@@ -143,7 +143,7 @@ pub struct SuspiciousInsecureHashUsage;
 impl Violation for SuspiciousInsecureHashUsage {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Use of insecure MD2, MD4, MD5, or SHA1 hash function")
+        "Use of insecure MD2, MD4, MD5, or SHA1 hash function".to_string()
     }
 }
 
@@ -181,7 +181,7 @@ pub struct SuspiciousInsecureCipherUsage;
 impl Violation for SuspiciousInsecureCipherUsage {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Use of insecure cipher, replace with a known secure cipher such as AES")
+        "Use of insecure cipher, replace with a known secure cipher such as AES".to_string()
     }
 }
 
@@ -221,7 +221,8 @@ pub struct SuspiciousInsecureCipherModeUsage;
 impl Violation for SuspiciousInsecureCipherModeUsage {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Use of insecure block cipher mode, replace with a known secure mode such as CBC or CTR")
+        "Use of insecure block cipher mode, replace with a known secure mode such as CBC or CTR"
+            .to_string()
     }
 }
 
@@ -265,7 +266,7 @@ pub struct SuspiciousMktempUsage;
 impl Violation for SuspiciousMktempUsage {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Use of insecure and deprecated function (`mktemp`)")
+        "Use of insecure and deprecated function (`mktemp`)".to_string()
     }
 }
 
@@ -301,7 +302,7 @@ pub struct SuspiciousEvalUsage;
 impl Violation for SuspiciousEvalUsage {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Use of possibly insecure function; consider using `ast.literal_eval`")
+        "Use of possibly insecure function; consider using `ast.literal_eval`".to_string()
     }
 }
 
@@ -340,7 +341,7 @@ pub struct SuspiciousMarkSafeUsage;
 impl Violation for SuspiciousMarkSafeUsage {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Use of `mark_safe` may expose cross-site scripting vulnerabilities")
+        "Use of `mark_safe` may expose cross-site scripting vulnerabilities".to_string()
     }
 }
 
@@ -388,7 +389,7 @@ pub struct SuspiciousURLOpenUsage;
 impl Violation for SuspiciousURLOpenUsage {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Audit URL open for permitted schemes. Allowing use of `file:` or custom schemes is often unexpected.")
+        "Audit URL open for permitted schemes. Allowing use of `file:` or custom schemes is often unexpected.".to_string()
     }
 }
 
@@ -426,7 +427,7 @@ pub struct SuspiciousNonCryptographicRandomUsage;
 impl Violation for SuspiciousNonCryptographicRandomUsage {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Standard pseudo-random generators are not suitable for cryptographic purposes")
+        "Standard pseudo-random generators are not suitable for cryptographic purposes".to_string()
     }
 }
 
@@ -466,7 +467,7 @@ pub struct SuspiciousXMLCElementTreeUsage;
 impl Violation for SuspiciousXMLCElementTreeUsage {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Using `xml` to parse untrusted data is known to be vulnerable to XML attacks; use `defusedxml` equivalents")
+        "Using `xml` to parse untrusted data is known to be vulnerable to XML attacks; use `defusedxml` equivalents".to_string()
     }
 }
 
@@ -506,7 +507,7 @@ pub struct SuspiciousXMLElementTreeUsage;
 impl Violation for SuspiciousXMLElementTreeUsage {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Using `xml` to parse untrusted data is known to be vulnerable to XML attacks; use `defusedxml` equivalents")
+        "Using `xml` to parse untrusted data is known to be vulnerable to XML attacks; use `defusedxml` equivalents".to_string()
     }
 }
 
@@ -546,7 +547,7 @@ pub struct SuspiciousXMLExpatReaderUsage;
 impl Violation for SuspiciousXMLExpatReaderUsage {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Using `xml` to parse untrusted data is known to be vulnerable to XML attacks; use `defusedxml` equivalents")
+        "Using `xml` to parse untrusted data is known to be vulnerable to XML attacks; use `defusedxml` equivalents".to_string()
     }
 }
 
@@ -586,7 +587,7 @@ pub struct SuspiciousXMLExpatBuilderUsage;
 impl Violation for SuspiciousXMLExpatBuilderUsage {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Using `xml` to parse untrusted data is known to be vulnerable to XML attacks; use `defusedxml` equivalents")
+        "Using `xml` to parse untrusted data is known to be vulnerable to XML attacks; use `defusedxml` equivalents".to_string()
     }
 }
 
@@ -626,7 +627,7 @@ pub struct SuspiciousXMLSaxUsage;
 impl Violation for SuspiciousXMLSaxUsage {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Using `xml` to parse untrusted data is known to be vulnerable to XML attacks; use `defusedxml` equivalents")
+        "Using `xml` to parse untrusted data is known to be vulnerable to XML attacks; use `defusedxml` equivalents".to_string()
     }
 }
 
@@ -666,7 +667,7 @@ pub struct SuspiciousXMLMiniDOMUsage;
 impl Violation for SuspiciousXMLMiniDOMUsage {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Using `xml` to parse untrusted data is known to be vulnerable to XML attacks; use `defusedxml` equivalents")
+        "Using `xml` to parse untrusted data is known to be vulnerable to XML attacks; use `defusedxml` equivalents".to_string()
     }
 }
 
@@ -706,7 +707,7 @@ pub struct SuspiciousXMLPullDOMUsage;
 impl Violation for SuspiciousXMLPullDOMUsage {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Using `xml` to parse untrusted data is known to be vulnerable to XML attacks; use `defusedxml` equivalents")
+        "Using `xml` to parse untrusted data is known to be vulnerable to XML attacks; use `defusedxml` equivalents".to_string()
     }
 }
 
@@ -735,7 +736,7 @@ pub struct SuspiciousXMLETreeUsage;
 impl Violation for SuspiciousXMLETreeUsage {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Using `lxml` to parse untrusted data is known to be vulnerable to XML attacks")
+        "Using `lxml` to parse untrusted data is known to be vulnerable to XML attacks".to_string()
     }
 }
 
@@ -778,7 +779,7 @@ pub struct SuspiciousUnverifiedContextUsage;
 impl Violation for SuspiciousUnverifiedContextUsage {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Python allows using an insecure context via the `_create_unverified_context` that reverts to the previous behavior that does not validate certificates or perform hostname checks.")
+        "Python allows using an insecure context via the `_create_unverified_context` that reverts to the previous behavior that does not validate certificates or perform hostname checks.".to_string()
     }
 }
 
@@ -799,7 +800,7 @@ pub struct SuspiciousTelnetUsage;
 impl Violation for SuspiciousTelnetUsage {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Telnet-related functions are being called. Telnet is considered insecure. Use SSH or some other encrypted protocol.")
+        "Telnet-related functions are being called. Telnet is considered insecure. Use SSH or some other encrypted protocol.".to_string()
     }
 }
 
@@ -820,7 +821,7 @@ pub struct SuspiciousFTPLibUsage;
 impl Violation for SuspiciousFTPLibUsage {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("FTP-related functions are being called. FTP is considered insecure. Use SSH/SFTP/SCP or some other encrypted protocol.")
+        "FTP-related functions are being called. FTP is considered insecure. Use SSH/SFTP/SCP or some other encrypted protocol.".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/suspicious_imports.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/suspicious_imports.rs
@@ -26,7 +26,7 @@ pub struct SuspiciousTelnetlibImport;
 impl Violation for SuspiciousTelnetlibImport {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("`telnetlib` and related modules are considered insecure. Use SSH or another encrypted protocol.")
+        "`telnetlib` and related modules are considered insecure. Use SSH or another encrypted protocol.".to_string()
     }
 }
 
@@ -47,7 +47,7 @@ pub struct SuspiciousFtplibImport;
 impl Violation for SuspiciousFtplibImport {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("`ftplib` and related modules are considered insecure. Use SSH, SFTP, SCP, or another encrypted protocol.")
+        "`ftplib` and related modules are considered insecure. Use SSH, SFTP, SCP, or another encrypted protocol.".to_string()
     }
 }
 
@@ -71,7 +71,7 @@ pub struct SuspiciousPickleImport;
 impl Violation for SuspiciousPickleImport {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("`pickle`, `cPickle`, `dill`, and `shelve` modules are possibly insecure")
+        "`pickle`, `cPickle`, `dill`, and `shelve` modules are possibly insecure".to_string()
     }
 }
 
@@ -92,7 +92,7 @@ pub struct SuspiciousSubprocessImport;
 impl Violation for SuspiciousSubprocessImport {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("`subprocess` module is possibly insecure")
+        "`subprocess` module is possibly insecure".to_string()
     }
 }
 
@@ -115,7 +115,7 @@ pub struct SuspiciousXmlEtreeImport;
 impl Violation for SuspiciousXmlEtreeImport {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("`xml.etree` methods are vulnerable to XML attacks")
+        "`xml.etree` methods are vulnerable to XML attacks".to_string()
     }
 }
 
@@ -138,7 +138,7 @@ pub struct SuspiciousXmlSaxImport;
 impl Violation for SuspiciousXmlSaxImport {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("`xml.sax` methods are vulnerable to XML attacks")
+        "`xml.sax` methods are vulnerable to XML attacks".to_string()
     }
 }
 
@@ -161,7 +161,7 @@ pub struct SuspiciousXmlExpatImport;
 impl Violation for SuspiciousXmlExpatImport {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("`xml.dom.expatbuilder` is vulnerable to XML attacks")
+        "`xml.dom.expatbuilder` is vulnerable to XML attacks".to_string()
     }
 }
 
@@ -184,7 +184,7 @@ pub struct SuspiciousXmlMinidomImport;
 impl Violation for SuspiciousXmlMinidomImport {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("`xml.dom.minidom` is vulnerable to XML attacks")
+        "`xml.dom.minidom` is vulnerable to XML attacks".to_string()
     }
 }
 
@@ -207,7 +207,7 @@ pub struct SuspiciousXmlPulldomImport;
 impl Violation for SuspiciousXmlPulldomImport {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("`xml.dom.pulldom` is vulnerable to XML attacks")
+        "`xml.dom.pulldom` is vulnerable to XML attacks".to_string()
     }
 }
 
@@ -237,7 +237,7 @@ pub struct SuspiciousLxmlImport;
 impl Violation for SuspiciousLxmlImport {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("`lxml` is vulnerable to XML attacks")
+        "`lxml` is vulnerable to XML attacks".to_string()
     }
 }
 
@@ -260,7 +260,7 @@ pub struct SuspiciousXmlrpcImport;
 impl Violation for SuspiciousXmlrpcImport {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("XMLRPC is vulnerable to remote XML attacks")
+        "XMLRPC is vulnerable to remote XML attacks".to_string()
     }
 }
 
@@ -286,7 +286,7 @@ pub struct SuspiciousHttpoxyImport;
 impl Violation for SuspiciousHttpoxyImport {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("`httpoxy` is a set of vulnerabilities that affect application code running inCGI, or CGI-like environments. The use of CGI for web applications should be avoided")
+        "`httpoxy` is a set of vulnerabilities that affect application code running inCGI, or CGI-like environments. The use of CGI for web applications should be avoided".to_string()
     }
 }
 
@@ -311,9 +311,8 @@ pub struct SuspiciousPycryptoImport;
 impl Violation for SuspiciousPycryptoImport {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!(
-            "`pycrypto` library is known to have publicly disclosed buffer overflow vulnerability"
-        )
+        "`pycrypto` library is known to have publicly disclosed buffer overflow vulnerability"
+            .to_string()
     }
 }
 
@@ -337,7 +336,8 @@ pub struct SuspiciousPyghmiImport;
 impl Violation for SuspiciousPyghmiImport {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("An IPMI-related module is being imported. Prefer an encrypted protocol over IPMI.")
+        "An IPMI-related module is being imported. Prefer an encrypted protocol over IPMI."
+            .to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/tarfile_unsafe_members.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/tarfile_unsafe_members.rs
@@ -43,7 +43,7 @@ pub struct TarfileUnsafeMembers;
 impl Violation for TarfileUnsafeMembers {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Uses of `tarfile.extractall()`")
+        "Uses of `tarfile.extractall()`".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/try_except_continue.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/try_except_continue.rs
@@ -47,7 +47,7 @@ pub struct TryExceptContinue;
 impl Violation for TryExceptContinue {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("`try`-`except`-`continue` detected, consider logging the exception")
+        "`try`-`except`-`continue` detected, consider logging the exception".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/try_except_pass.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/try_except_pass.rs
@@ -43,7 +43,7 @@ pub struct TryExceptPass;
 impl Violation for TryExceptPass {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("`try`-`except`-`pass` detected, consider logging the exception")
+        "`try`-`except`-`pass` detected, consider logging the exception".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/unsafe_yaml_load.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/unsafe_yaml_load.rs
@@ -42,18 +42,18 @@ pub struct UnsafeYAMLLoad {
 impl Violation for UnsafeYAMLLoad {
     #[derive_message_formats]
     fn message(&self) -> String {
-        let UnsafeYAMLLoad { loader } = self;
-        match loader {
+        match &self.loader {
             Some(name) => {
                 format!(
                     "Probable use of unsafe loader `{name}` with `yaml.load`. Allows \
                      instantiation of arbitrary objects. Consider `yaml.safe_load`."
                 )
             }
-            None => format!(
+            None => {
                 "Probable use of unsafe `yaml.load`. Allows instantiation of arbitrary objects. \
                  Consider `yaml.safe_load`."
-            ),
+                    .to_string()
+            }
         }
     }
 }

--- a/crates/ruff_linter/src/rules/flake8_boolean_trap/rules/boolean_default_value_positional_argument.rs
+++ b/crates/ruff_linter/src/rules/flake8_boolean_trap/rules/boolean_default_value_positional_argument.rs
@@ -95,7 +95,7 @@ pub struct BooleanDefaultValuePositionalArgument;
 impl Violation for BooleanDefaultValuePositionalArgument {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Boolean default positional argument in function definition")
+        "Boolean default positional argument in function definition".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_boolean_trap/rules/boolean_positional_value_in_call.rs
+++ b/crates/ruff_linter/src/rules/flake8_boolean_trap/rules/boolean_positional_value_in_call.rs
@@ -47,7 +47,7 @@ pub struct BooleanPositionalValueInCall;
 impl Violation for BooleanPositionalValueInCall {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Boolean positional value in function call")
+        "Boolean positional value in function call".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_boolean_trap/rules/boolean_type_hint_positional_argument.rs
+++ b/crates/ruff_linter/src/rules/flake8_boolean_trap/rules/boolean_type_hint_positional_argument.rs
@@ -101,7 +101,7 @@ pub struct BooleanTypeHintPositionalArgument;
 impl Violation for BooleanTypeHintPositionalArgument {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Boolean-typed positional argument in function definition")
+        "Boolean-typed positional argument in function definition".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/assert_false.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/assert_false.rs
@@ -40,7 +40,8 @@ pub struct AssertFalse;
 impl AlwaysFixableViolation for AssertFalse {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Do not `assert False` (`python -O` removes these calls), raise `AssertionError()`")
+        "Do not `assert False` (`python -O` removes these calls), raise `AssertionError()`"
+            .to_string()
     }
 
     fn fix_title(&self) -> String {

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/assignment_to_os_environ.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/assignment_to_os_environ.rs
@@ -45,7 +45,7 @@ pub struct AssignmentToOsEnviron;
 impl Violation for AssignmentToOsEnviron {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Assigning to `os.environ` doesn't clear the environment")
+        "Assigning to `os.environ` doesn't clear the environment".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/cached_instance_method.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/cached_instance_method.rs
@@ -68,9 +68,8 @@ pub struct CachedInstanceMethod;
 impl Violation for CachedInstanceMethod {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!(
-            "Use of `functools.lru_cache` or `functools.cache` on methods can lead to memory leaks"
-        )
+        "Use of `functools.lru_cache` or `functools.cache` on methods can lead to memory leaks"
+            .to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/except_with_empty_tuple.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/except_with_empty_tuple.rs
@@ -39,7 +39,8 @@ pub struct ExceptWithEmptyTuple;
 impl Violation for ExceptWithEmptyTuple {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Using `except ():` with an empty tuple does not catch anything; add exceptions to handle")
+        "Using `except ():` with an empty tuple does not catch anything; add exceptions to handle"
+            .to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/except_with_non_exception_classes.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/except_with_non_exception_classes.rs
@@ -40,7 +40,8 @@ pub struct ExceptWithNonExceptionClasses;
 impl Violation for ExceptWithNonExceptionClasses {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("`except` handlers should only be exception classes or tuples of exception classes")
+        "`except` handlers should only be exception classes or tuples of exception classes"
+            .to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/f_string_docstring.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/f_string_docstring.rs
@@ -36,9 +36,7 @@ pub struct FStringDocstring;
 impl Violation for FStringDocstring {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!(
-            "f-string used as docstring. Python will interpret this as a joined string, rather than a docstring."
-        )
+        "f-string used as docstring. Python will interpret this as a joined string, rather than a docstring.".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/function_call_in_argument_default.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/function_call_in_argument_default.rs
@@ -72,11 +72,10 @@ pub struct FunctionCallInDefaultArgument {
 impl Violation for FunctionCallInDefaultArgument {
     #[derive_message_formats]
     fn message(&self) -> String {
-        let FunctionCallInDefaultArgument { name } = self;
-        if let Some(name) = name {
+        if let Some(name) = &self.name {
             format!("Do not perform function call `{name}` in argument defaults; instead, perform the call within the function, or read the default from a module-level singleton variable")
         } else {
-            format!("Do not perform function call in argument defaults; instead, perform the call within the function, or read the default from a module-level singleton variable")
+            "Do not perform function call in argument defaults; instead, perform the call within the function, or read the default from a module-level singleton variable".to_string()
         }
     }
 }

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/getattr_with_constant.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/getattr_with_constant.rs
@@ -37,10 +37,9 @@ pub struct GetAttrWithConstant;
 impl AlwaysFixableViolation for GetAttrWithConstant {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!(
-            "Do not call `getattr` with a constant attribute value. It is not any safer than \
-             normal property access."
-        )
+        "Do not call `getattr` with a constant attribute value. It is not any safer than \
+            normal property access."
+            .to_string()
     }
 
     fn fix_title(&self) -> String {

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/loop_iterator_mutation.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/loop_iterator_mutation.rs
@@ -44,12 +44,10 @@ pub struct LoopIteratorMutation {
 impl Violation for LoopIteratorMutation {
     #[derive_message_formats]
     fn message(&self) -> String {
-        let LoopIteratorMutation { name } = self;
-
-        if let Some(name) = name.as_ref().and_then(SourceCodeSnippet::full_display) {
+        if let Some(name) = self.name.as_ref().and_then(SourceCodeSnippet::full_display) {
             format!("Mutation to loop iterable `{name}` during iteration")
         } else {
-            format!("Mutation to loop iterable during iteration")
+            "Mutation to loop iterable during iteration".to_string()
         }
     }
 }

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/mutable_argument_default.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/mutable_argument_default.rs
@@ -76,7 +76,7 @@ impl Violation for MutableArgumentDefault {
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Do not use mutable data structures for argument defaults")
+        "Do not use mutable data structures for argument defaults".to_string()
     }
 
     fn fix_title(&self) -> Option<String> {

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/mutable_contextvar_default.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/mutable_contextvar_default.rs
@@ -58,7 +58,7 @@ pub struct MutableContextvarDefault;
 impl Violation for MutableContextvarDefault {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Do not use mutable data structures for `ContextVar` defaults")
+        "Do not use mutable data structures for `ContextVar` defaults".to_string()
     }
 
     fn fix_title(&self) -> Option<String> {

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/no_explicit_stacklevel.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/no_explicit_stacklevel.rs
@@ -32,7 +32,7 @@ pub struct NoExplicitStacklevel;
 impl Violation for NoExplicitStacklevel {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("No explicit `stacklevel` keyword argument found")
+        "No explicit `stacklevel` keyword argument found".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/raise_literal.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/raise_literal.rs
@@ -32,7 +32,7 @@ pub struct RaiseLiteral;
 impl Violation for RaiseLiteral {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Cannot raise a literal. Did you intend to return it or raise an Exception?")
+        "Cannot raise a literal. Did you intend to return it or raise an Exception?".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/raise_without_from_inside_except.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/raise_without_from_inside_except.rs
@@ -52,10 +52,9 @@ pub struct RaiseWithoutFromInsideExcept;
 impl Violation for RaiseWithoutFromInsideExcept {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!(
-            "Within an `except` clause, raise exceptions with `raise ... from err` or `raise ... \
+        "Within an `except` clause, raise exceptions with `raise ... from err` or `raise ... \
              from None` to distinguish them from errors in exception handling"
-        )
+            .to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/redundant_tuple_in_exception_handler.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/redundant_tuple_in_exception_handler.rs
@@ -43,7 +43,7 @@ pub struct RedundantTupleInExceptionHandler {
 impl AlwaysFixableViolation for RedundantTupleInExceptionHandler {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("A length-one tuple literal is redundant in exception handlers")
+        "A length-one tuple literal is redundant in exception handlers".to_string()
     }
 
     fn fix_title(&self) -> String {

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/reuse_of_groupby_generator.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/reuse_of_groupby_generator.rs
@@ -39,7 +39,7 @@ pub struct ReuseOfGroupbyGenerator;
 impl Violation for ReuseOfGroupbyGenerator {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Using the generator returned from `itertools.groupby()` more than once will do nothing on the second usage")
+        "Using the generator returned from `itertools.groupby()` more than once will do nothing on the second usage".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/setattr_with_constant.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/setattr_with_constant.rs
@@ -36,10 +36,9 @@ pub struct SetAttrWithConstant;
 impl AlwaysFixableViolation for SetAttrWithConstant {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!(
-            "Do not call `setattr` with a constant attribute value. It is not any safer than \
+        "Do not call `setattr` with a constant attribute value. It is not any safer than \
              normal property access."
-        )
+            .to_string()
     }
 
     fn fix_title(&self) -> String {

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/star_arg_unpacking_after_keyword_arg.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/star_arg_unpacking_after_keyword_arg.rs
@@ -51,7 +51,7 @@ pub struct StarArgUnpackingAfterKeywordArg;
 impl Violation for StarArgUnpackingAfterKeywordArg {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Star-arg unpacking after a keyword argument is strongly discouraged")
+        "Star-arg unpacking after a keyword argument is strongly discouraged".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/static_key_dict_comprehension.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/static_key_dict_comprehension.rs
@@ -38,11 +38,10 @@ pub struct StaticKeyDictComprehension {
 impl Violation for StaticKeyDictComprehension {
     #[derive_message_formats]
     fn message(&self) -> String {
-        let StaticKeyDictComprehension { key } = self;
-        if let Some(key) = key.full_display() {
+        if let Some(key) = self.key.full_display() {
             format!("Dictionary comprehension uses static key: `{key}`")
         } else {
-            format!("Dictionary comprehension uses static key")
+            "Dictionary comprehension uses static key".to_string()
         }
     }
 }

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/strip_with_multi_characters.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/strip_with_multi_characters.rs
@@ -50,7 +50,7 @@ pub struct StripWithMultiCharacters;
 impl Violation for StripWithMultiCharacters {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Using `.strip()` with multi-character strings is misleading")
+        "Using `.strip()` with multi-character strings is misleading".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/unary_prefix_increment_decrement.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/unary_prefix_increment_decrement.rs
@@ -38,13 +38,12 @@ pub struct UnaryPrefixIncrementDecrement {
 impl Violation for UnaryPrefixIncrementDecrement {
     #[derive_message_formats]
     fn message(&self) -> String {
-        let UnaryPrefixIncrementDecrement { operator } = self;
-        match operator {
+        match self.operator {
             UnaryPrefixOperatorType::Increment => {
-                format!("Python does not support the unary prefix increment operator (`++`)")
+                "Python does not support the unary prefix increment operator (`++`)".to_string()
             }
             UnaryPrefixOperatorType::Decrement => {
-                format!("Python does not support the unary prefix decrement operator (`--`)")
+                "Python does not support the unary prefix decrement operator (`--`)".to_string()
             }
         }
     }

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/unintentional_type_annotation.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/unintentional_type_annotation.rs
@@ -28,9 +28,8 @@ pub struct UnintentionalTypeAnnotation;
 impl Violation for UnintentionalTypeAnnotation {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!(
-            "Possible unintentional type annotation (using `:`). Did you mean to assign (using `=`)?"
-        )
+        "Possible unintentional type annotation (using `:`). Did you mean to assign (using `=`)?"
+            .to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/unreliable_callable_check.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/unreliable_callable_check.rs
@@ -39,10 +39,9 @@ impl Violation for UnreliableCallableCheck {
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!(
-            "Using `hasattr(x, \"__call__\")` to test if x is callable is unreliable. Use \
+        "Using `hasattr(x, \"__call__\")` to test if x is callable is unreliable. Use \
              `callable(x)` for consistent results."
-        )
+            .to_string()
     }
 
     fn fix_title(&self) -> Option<String> {

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/useless_comparison.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/useless_comparison.rs
@@ -42,14 +42,16 @@ impl Violation for UselessComparison {
     #[derive_message_formats]
     fn message(&self) -> String {
         match self.at {
-            ComparisonLocationAt::MiddleBody => format!(
+            ComparisonLocationAt::MiddleBody => {
                 "Pointless comparison. Did you mean to assign a value? \
                 Otherwise, prepend `assert` or remove it."
-            ),
-            ComparisonLocationAt::EndOfFunction => format!(
+                    .to_string()
+            }
+            ComparisonLocationAt::EndOfFunction => {
                 "Pointless comparison at end of function scope. Did you mean \
                 to return the expression result?"
-            ),
+                    .to_string()
+            }
         }
     }
 }

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/useless_contextlib_suppress.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/useless_contextlib_suppress.rs
@@ -42,10 +42,9 @@ pub struct UselessContextlibSuppress;
 impl Violation for UselessContextlibSuppress {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!(
-            "No arguments passed to `contextlib.suppress`. No exceptions will be suppressed and \
-             therefore this context manager is redundant"
-        )
+        "No arguments passed to `contextlib.suppress`. No exceptions will be suppressed and \
+            therefore this context manager is redundant"
+            .to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/useless_expression.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/useless_expression.rs
@@ -60,12 +60,11 @@ impl Violation for UselessExpression {
     fn message(&self) -> String {
         match self.kind {
             Kind::Expression => {
-                format!("Found useless expression. Either assign it to a variable or remove it.")
+                "Found useless expression. Either assign it to a variable or remove it.".to_string()
             }
             Kind::Attribute => {
-                format!(
-                    "Found useless attribute access. Either assign it to a variable or remove it."
-                )
+                "Found useless attribute access. Either assign it to a variable or remove it."
+                    .to_string()
             }
         }
     }

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/zip_without_explicit_strict.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/zip_without_explicit_strict.rs
@@ -43,7 +43,7 @@ pub struct ZipWithoutExplicitStrict;
 impl AlwaysFixableViolation for ZipWithoutExplicitStrict {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("`zip()` without an explicit `strict=` parameter")
+        "`zip()` without an explicit `strict=` parameter".to_string()
     }
 
     fn fix_title(&self) -> String {

--- a/crates/ruff_linter/src/rules/flake8_commas/rules/trailing_commas.rs
+++ b/crates/ruff_linter/src/rules/flake8_commas/rules/trailing_commas.rs
@@ -145,7 +145,7 @@ pub struct MissingTrailingComma;
 impl AlwaysFixableViolation for MissingTrailingComma {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Trailing comma missing")
+        "Trailing comma missing".to_string()
     }
 
     fn fix_title(&self) -> String {
@@ -190,7 +190,7 @@ pub struct TrailingCommaOnBareTuple;
 impl Violation for TrailingCommaOnBareTuple {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Trailing comma on bare tuple prohibited")
+        "Trailing comma on bare tuple prohibited".to_string()
     }
 }
 
@@ -216,7 +216,7 @@ pub struct ProhibitedTrailingComma;
 impl AlwaysFixableViolation for ProhibitedTrailingComma {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Trailing comma prohibited")
+        "Trailing comma prohibited".to_string()
     }
 
     fn fix_title(&self) -> String {

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_comprehension_in_call.rs
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_comprehension_in_call.rs
@@ -76,8 +76,8 @@ impl Violation for UnnecessaryComprehensionInCall {
     #[derive_message_formats]
     fn message(&self) -> String {
         match self.comprehension_kind {
-            ComprehensionKind::List => format!("Unnecessary list comprehension"),
-            ComprehensionKind::Set => format!("Unnecessary set comprehension"),
+            ComprehensionKind::List => "Unnecessary list comprehension".to_string(),
+            ComprehensionKind::Set => "Unnecessary set comprehension".to_string(),
         }
     }
 

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_dict_comprehension_for_iterable.rs
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_dict_comprehension_for_iterable.rs
@@ -40,7 +40,7 @@ impl Violation for UnnecessaryDictComprehensionForIterable {
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Unnecessary dict comprehension for iterable; use `dict.fromkeys` instead")
+        "Unnecessary dict comprehension for iterable; use `dict.fromkeys` instead".to_string()
     }
 
     fn fix_title(&self) -> Option<String> {

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_generator_dict.rs
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_generator_dict.rs
@@ -37,7 +37,7 @@ pub struct UnnecessaryGeneratorDict;
 impl AlwaysFixableViolation for UnnecessaryGeneratorDict {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Unnecessary generator (rewrite as a `dict` comprehension)")
+        "Unnecessary generator (rewrite as a `dict` comprehension)".to_string()
     }
 
     fn fix_title(&self) -> String {

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_generator_list.rs
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_generator_list.rs
@@ -49,9 +49,9 @@ impl AlwaysFixableViolation for UnnecessaryGeneratorList {
     #[derive_message_formats]
     fn message(&self) -> String {
         if self.short_circuit {
-            format!("Unnecessary generator (rewrite using `list()`)")
+            "Unnecessary generator (rewrite using `list()`)".to_string()
         } else {
-            format!("Unnecessary generator (rewrite as a `list` comprehension)")
+            "Unnecessary generator (rewrite as a `list` comprehension)".to_string()
         }
     }
 

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_generator_set.rs
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_generator_set.rs
@@ -47,9 +47,9 @@ impl AlwaysFixableViolation for UnnecessaryGeneratorSet {
     #[derive_message_formats]
     fn message(&self) -> String {
         if self.short_circuit {
-            format!("Unnecessary generator (rewrite using `set()`)")
+            "Unnecessary generator (rewrite using `set()`)".to_string()
         } else {
-            format!("Unnecessary generator (rewrite as a `set` comprehension)")
+            "Unnecessary generator (rewrite as a `set` comprehension)".to_string()
         }
     }
 

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_list_call.rs
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_list_call.rs
@@ -35,7 +35,7 @@ pub struct UnnecessaryListCall;
 impl AlwaysFixableViolation for UnnecessaryListCall {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Unnecessary `list` call (remove the outer call to `list()`)")
+        "Unnecessary `list` call (remove the outer call to `list()`)".to_string()
     }
 
     fn fix_title(&self) -> String {

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_list_comprehension_dict.rs
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_list_comprehension_dict.rs
@@ -35,7 +35,7 @@ pub struct UnnecessaryListComprehensionDict;
 impl AlwaysFixableViolation for UnnecessaryListComprehensionDict {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Unnecessary `list` comprehension (rewrite as a `dict` comprehension)")
+        "Unnecessary `list` comprehension (rewrite as a `dict` comprehension)".to_string()
     }
 
     fn fix_title(&self) -> String {

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_list_comprehension_set.rs
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_list_comprehension_set.rs
@@ -34,7 +34,7 @@ pub struct UnnecessaryListComprehensionSet;
 impl AlwaysFixableViolation for UnnecessaryListComprehensionSet {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Unnecessary `list` comprehension (rewrite as a `set` comprehension)")
+        "Unnecessary `list` comprehension (rewrite as a `set` comprehension)".to_string()
     }
 
     fn fix_title(&self) -> String {

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_literal_within_tuple_call.rs
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_literal_within_tuple_call.rs
@@ -54,31 +54,26 @@ pub struct UnnecessaryLiteralWithinTupleCall {
 impl AlwaysFixableViolation for UnnecessaryLiteralWithinTupleCall {
     #[derive_message_formats]
     fn message(&self) -> String {
-        let UnnecessaryLiteralWithinTupleCall { literal_kind } = self;
-        match literal_kind {
+        match self.literal_kind {
             TupleLiteralKind::List => {
-                format!(
-                    "Unnecessary `list` literal passed to `tuple()` (rewrite as a `tuple` literal)"
-                )
+                "Unnecessary `list` literal passed to `tuple()` (rewrite as a `tuple` literal)".to_string()
             }
             TupleLiteralKind::Tuple => {
-                format!("Unnecessary `tuple` literal passed to `tuple()` (remove the outer call to `tuple()`)")
+                "Unnecessary `tuple` literal passed to `tuple()` (remove the outer call to `tuple()`)".to_string()
             }
             TupleLiteralKind::ListComp => {
-                format!(
-                    "Unnecessary list comprehension passed to `tuple()` (rewrite as a generator)"
-                )
+                "Unnecessary list comprehension passed to `tuple()` (rewrite as a generator)".to_string()
             }
         }
     }
 
     fn fix_title(&self) -> String {
-        let UnnecessaryLiteralWithinTupleCall { literal_kind } = self;
-        match literal_kind {
-            TupleLiteralKind::List => "Rewrite as a `tuple` literal".to_string(),
-            TupleLiteralKind::Tuple => "Remove the outer call to `tuple()`".to_string(),
-            TupleLiteralKind::ListComp => "Rewrite as a generator".to_string(),
-        }
+        let title = match self.literal_kind {
+            TupleLiteralKind::List => "Rewrite as a `tuple` literal",
+            TupleLiteralKind::Tuple => "Remove the outer call to `tuple()`",
+            TupleLiteralKind::ListComp => "Rewrite as a generator",
+        };
+        title.to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_copyright/rules/missing_copyright_notice.rs
+++ b/crates/ruff_linter/src/rules/flake8_copyright/rules/missing_copyright_notice.rs
@@ -19,7 +19,7 @@ pub struct MissingCopyrightNotice;
 impl Violation for MissingCopyrightNotice {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Missing copyright notice at top of file")
+        "Missing copyright notice at top of file".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_datetimez/rules/call_date_fromtimestamp.rs
+++ b/crates/ruff_linter/src/rules/flake8_datetimez/rules/call_date_fromtimestamp.rs
@@ -50,7 +50,7 @@ pub struct CallDateFromtimestamp;
 impl Violation for CallDateFromtimestamp {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("`datetime.date.fromtimestamp()` used")
+        "`datetime.date.fromtimestamp()` used".to_string()
     }
 
     fn fix_title(&self) -> Option<String> {

--- a/crates/ruff_linter/src/rules/flake8_datetimez/rules/call_date_today.rs
+++ b/crates/ruff_linter/src/rules/flake8_datetimez/rules/call_date_today.rs
@@ -49,7 +49,7 @@ pub struct CallDateToday;
 impl Violation for CallDateToday {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("`datetime.date.today()` used")
+        "`datetime.date.today()` used".to_string()
     }
 
     fn fix_title(&self) -> Option<String> {

--- a/crates/ruff_linter/src/rules/flake8_datetimez/rules/call_datetime_fromtimestamp.rs
+++ b/crates/ruff_linter/src/rules/flake8_datetimez/rules/call_datetime_fromtimestamp.rs
@@ -56,10 +56,10 @@ impl Violation for CallDatetimeFromtimestamp {
         let CallDatetimeFromtimestamp(antipattern) = self;
         match antipattern {
             DatetimeModuleAntipattern::NoTzArgumentPassed => {
-                format!("`datetime.datetime.fromtimestamp()` called without a `tz` argument")
+                "`datetime.datetime.fromtimestamp()` called without a `tz` argument".to_string()
             }
             DatetimeModuleAntipattern::NonePassedToTzArgument => {
-                format!("`tz=None` passed to `datetime.datetime.fromtimestamp()`")
+                "`tz=None` passed to `datetime.datetime.fromtimestamp()`".to_string()
             }
         }
     }

--- a/crates/ruff_linter/src/rules/flake8_datetimez/rules/call_datetime_now_without_tzinfo.rs
+++ b/crates/ruff_linter/src/rules/flake8_datetimez/rules/call_datetime_now_without_tzinfo.rs
@@ -54,10 +54,10 @@ impl Violation for CallDatetimeNowWithoutTzinfo {
         let CallDatetimeNowWithoutTzinfo(antipattern) = self;
         match antipattern {
             DatetimeModuleAntipattern::NoTzArgumentPassed => {
-                format!("`datetime.datetime.now()` called without a `tz` argument")
+                "`datetime.datetime.now()` called without a `tz` argument".to_string()
             }
             DatetimeModuleAntipattern::NonePassedToTzArgument => {
-                format!("`tz=None` passed to `datetime.datetime.now()`")
+                "`tz=None` passed to `datetime.datetime.now()`".to_string()
             }
         }
     }

--- a/crates/ruff_linter/src/rules/flake8_datetimez/rules/call_datetime_strptime_without_zone.rs
+++ b/crates/ruff_linter/src/rules/flake8_datetimez/rules/call_datetime_strptime_without_zone.rs
@@ -58,27 +58,28 @@ impl Violation for CallDatetimeStrptimeWithoutZone {
     fn message(&self) -> String {
         let CallDatetimeStrptimeWithoutZone(antipattern) = self;
         match antipattern {
-            DatetimeModuleAntipattern::NoTzArgumentPassed => format!(
+            DatetimeModuleAntipattern::NoTzArgumentPassed => {
                 "Naive datetime constructed using `datetime.datetime.strptime()` without %z"
-            ),
+                    .to_string()
+            }
             DatetimeModuleAntipattern::NonePassedToTzArgument => {
-                format!("`datetime.datetime.strptime(...).replace(tz=None)` used")
+                "`datetime.datetime.strptime(...).replace(tz=None)` used".to_string()
             }
         }
     }
 
     fn fix_title(&self) -> Option<String> {
         let CallDatetimeStrptimeWithoutZone(antipattern) = self;
-        match antipattern {
-            DatetimeModuleAntipattern::NoTzArgumentPassed => Some(
+        let title = match antipattern {
+            DatetimeModuleAntipattern::NoTzArgumentPassed => {
                 "Call `.replace(tzinfo=<timezone>)` or `.astimezone()` \
                 to convert to an aware datetime"
-                    .to_string(),
-            ),
-            DatetimeModuleAntipattern::NonePassedToTzArgument => {
-                Some("Pass a `datetime.timezone` object to the `tzinfo` parameter".to_string())
             }
-        }
+            DatetimeModuleAntipattern::NonePassedToTzArgument => {
+                "Pass a `datetime.timezone` object to the `tzinfo` parameter"
+            }
+        };
+        Some(title.to_string())
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_datetimez/rules/call_datetime_today.rs
+++ b/crates/ruff_linter/src/rules/flake8_datetimez/rules/call_datetime_today.rs
@@ -48,7 +48,7 @@ pub struct CallDatetimeToday;
 impl Violation for CallDatetimeToday {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("`datetime.datetime.today()` used")
+        "`datetime.datetime.today()` used".to_string()
     }
 
     fn fix_title(&self) -> Option<String> {

--- a/crates/ruff_linter/src/rules/flake8_datetimez/rules/call_datetime_utcfromtimestamp.rs
+++ b/crates/ruff_linter/src/rules/flake8_datetimez/rules/call_datetime_utcfromtimestamp.rs
@@ -52,7 +52,7 @@ pub struct CallDatetimeUtcfromtimestamp;
 impl Violation for CallDatetimeUtcfromtimestamp {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("`datetime.datetime.utcfromtimestamp()` used")
+        "`datetime.datetime.utcfromtimestamp()` used".to_string()
     }
 
     fn fix_title(&self) -> Option<String> {

--- a/crates/ruff_linter/src/rules/flake8_datetimez/rules/call_datetime_utcnow.rs
+++ b/crates/ruff_linter/src/rules/flake8_datetimez/rules/call_datetime_utcnow.rs
@@ -51,7 +51,7 @@ pub struct CallDatetimeUtcnow;
 impl Violation for CallDatetimeUtcnow {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("`datetime.datetime.utcnow()` used")
+        "`datetime.datetime.utcnow()` used".to_string()
     }
 
     fn fix_title(&self) -> Option<String> {

--- a/crates/ruff_linter/src/rules/flake8_datetimez/rules/call_datetime_without_tzinfo.rs
+++ b/crates/ruff_linter/src/rules/flake8_datetimez/rules/call_datetime_without_tzinfo.rs
@@ -50,10 +50,10 @@ impl Violation for CallDatetimeWithoutTzinfo {
         let CallDatetimeWithoutTzinfo(antipattern) = self;
         match antipattern {
             DatetimeModuleAntipattern::NoTzArgumentPassed => {
-                format!("`datetime.datetime()` called without a `tzinfo` argument")
+                "`datetime.datetime()` called without a `tzinfo` argument".to_string()
             }
             DatetimeModuleAntipattern::NonePassedToTzArgument => {
-                format!("`tzinfo=None` passed to `datetime.datetime()`")
+                "`tzinfo=None` passed to `datetime.datetime()`".to_string()
             }
         }
     }

--- a/crates/ruff_linter/src/rules/flake8_django/rules/all_with_model_form.rs
+++ b/crates/ruff_linter/src/rules/flake8_django/rules/all_with_model_form.rs
@@ -43,7 +43,7 @@ pub struct DjangoAllWithModelForm;
 impl Violation for DjangoAllWithModelForm {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Do not use `__all__` with `ModelForm`, use `fields` instead")
+        "Do not use `__all__` with `ModelForm`, use `fields` instead".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_django/rules/exclude_with_model_form.rs
+++ b/crates/ruff_linter/src/rules/flake8_django/rules/exclude_with_model_form.rs
@@ -41,7 +41,7 @@ pub struct DjangoExcludeWithModelForm;
 impl Violation for DjangoExcludeWithModelForm {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Do not use `exclude` with `ModelForm`, use `fields` instead")
+        "Do not use `exclude` with `ModelForm`, use `fields` instead".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_django/rules/locals_in_render_function.rs
+++ b/crates/ruff_linter/src/rules/flake8_django/rules/locals_in_render_function.rs
@@ -39,7 +39,7 @@ pub struct DjangoLocalsInRenderFunction;
 impl Violation for DjangoLocalsInRenderFunction {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Avoid passing `locals()` as context to a `render` function")
+        "Avoid passing `locals()` as context to a `render` function".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_django/rules/model_without_dunder_str.rs
+++ b/crates/ruff_linter/src/rules/flake8_django/rules/model_without_dunder_str.rs
@@ -46,7 +46,7 @@ pub struct DjangoModelWithoutDunderStr;
 impl Violation for DjangoModelWithoutDunderStr {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Model does not define `__str__` method")
+        "Model does not define `__str__` method".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_django/rules/non_leading_receiver_decorator.rs
+++ b/crates/ruff_linter/src/rules/flake8_django/rules/non_leading_receiver_decorator.rs
@@ -46,7 +46,7 @@ pub struct DjangoNonLeadingReceiverDecorator;
 impl Violation for DjangoNonLeadingReceiverDecorator {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("`@receiver` decorator must be on top of all the other decorators")
+        "`@receiver` decorator must be on top of all the other decorators".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_errmsg/rules/string_in_exception.rs
+++ b/crates/ruff_linter/src/rules/flake8_errmsg/rules/string_in_exception.rs
@@ -55,7 +55,7 @@ impl Violation for RawStringInException {
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Exception must not use a string literal, assign to variable first")
+        "Exception must not use a string literal, assign to variable first".to_string()
     }
 
     fn fix_title(&self) -> Option<String> {
@@ -110,7 +110,7 @@ impl Violation for FStringInException {
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Exception must not use an f-string literal, assign to variable first")
+        "Exception must not use an f-string literal, assign to variable first".to_string()
     }
 
     fn fix_title(&self) -> Option<String> {
@@ -166,7 +166,7 @@ impl Violation for DotFormatInException {
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Exception must not use a `.format()` string directly, assign to variable first")
+        "Exception must not use a `.format()` string directly, assign to variable first".to_string()
     }
 
     fn fix_title(&self) -> Option<String> {

--- a/crates/ruff_linter/src/rules/flake8_executable/rules/shebang_leading_whitespace.rs
+++ b/crates/ruff_linter/src/rules/flake8_executable/rules/shebang_leading_whitespace.rs
@@ -35,7 +35,7 @@ pub struct ShebangLeadingWhitespace;
 impl AlwaysFixableViolation for ShebangLeadingWhitespace {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Avoid whitespace before shebang")
+        "Avoid whitespace before shebang".to_string()
     }
 
     fn fix_title(&self) -> String {

--- a/crates/ruff_linter/src/rules/flake8_executable/rules/shebang_missing_executable_file.rs
+++ b/crates/ruff_linter/src/rules/flake8_executable/rules/shebang_missing_executable_file.rs
@@ -41,7 +41,7 @@ pub struct ShebangMissingExecutableFile;
 impl Violation for ShebangMissingExecutableFile {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("The file is executable but no shebang is present")
+        "The file is executable but no shebang is present".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_executable/rules/shebang_missing_python.rs
+++ b/crates/ruff_linter/src/rules/flake8_executable/rules/shebang_missing_python.rs
@@ -36,7 +36,7 @@ pub struct ShebangMissingPython;
 impl Violation for ShebangMissingPython {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Shebang should contain `python`")
+        "Shebang should contain `python`".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_executable/rules/shebang_not_executable.rs
+++ b/crates/ruff_linter/src/rules/flake8_executable/rules/shebang_not_executable.rs
@@ -46,7 +46,7 @@ pub struct ShebangNotExecutable;
 impl Violation for ShebangNotExecutable {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Shebang is present but file is not executable")
+        "Shebang is present but file is not executable".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_executable/rules/shebang_not_first_line.rs
+++ b/crates/ruff_linter/src/rules/flake8_executable/rules/shebang_not_first_line.rs
@@ -37,7 +37,7 @@ pub struct ShebangNotFirstLine;
 impl Violation for ShebangNotFirstLine {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Shebang should be at the beginning of the file")
+        "Shebang should be at the beginning of the file".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_fixme/rules/todos.rs
+++ b/crates/ruff_linter/src/rules/flake8_fixme/rules/todos.rs
@@ -26,7 +26,7 @@ pub struct LineContainsTodo;
 impl Violation for LineContainsTodo {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Line contains TODO, consider resolving the issue")
+        "Line contains TODO, consider resolving the issue".to_string()
     }
 }
 
@@ -52,7 +52,7 @@ pub struct LineContainsFixme;
 impl Violation for LineContainsFixme {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Line contains FIXME, consider resolving the issue")
+        "Line contains FIXME, consider resolving the issue".to_string()
     }
 }
 
@@ -75,7 +75,7 @@ pub struct LineContainsXxx;
 impl Violation for LineContainsXxx {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Line contains XXX, consider resolving the issue")
+        "Line contains XXX, consider resolving the issue".to_string()
     }
 }
 
@@ -110,7 +110,7 @@ pub struct LineContainsHack;
 impl Violation for LineContainsHack {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Line contains HACK, consider resolving the issue")
+        "Line contains HACK, consider resolving the issue".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_gettext/rules/f_string_in_gettext_func_call.rs
+++ b/crates/ruff_linter/src/rules/flake8_gettext/rules/f_string_in_gettext_func_call.rs
@@ -46,7 +46,7 @@ pub struct FStringInGetTextFuncCall;
 impl Violation for FStringInGetTextFuncCall {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("f-string is resolved before function call; consider `_(\"string %s\") % arg`")
+        "f-string is resolved before function call; consider `_(\"string %s\") % arg`".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_gettext/rules/format_in_gettext_func_call.rs
+++ b/crates/ruff_linter/src/rules/flake8_gettext/rules/format_in_gettext_func_call.rs
@@ -46,7 +46,7 @@ pub struct FormatInGetTextFuncCall;
 impl Violation for FormatInGetTextFuncCall {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("`format` method argument is resolved before function call; consider `_(\"string %s\") % arg`")
+        "`format` method argument is resolved before function call; consider `_(\"string %s\") % arg`".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_gettext/rules/printf_in_gettext_func_call.rs
+++ b/crates/ruff_linter/src/rules/flake8_gettext/rules/printf_in_gettext_func_call.rs
@@ -45,7 +45,8 @@ pub struct PrintfInGetTextFuncCall;
 impl Violation for PrintfInGetTextFuncCall {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("printf-style format is resolved before function call; consider `_(\"string %s\") % arg`")
+        "printf-style format is resolved before function call; consider `_(\"string %s\") % arg`"
+            .to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_implicit_str_concat/rules/explicit.rs
+++ b/crates/ruff_linter/src/rules/flake8_implicit_str_concat/rules/explicit.rs
@@ -37,7 +37,7 @@ pub struct ExplicitStringConcatenation;
 impl Violation for ExplicitStringConcatenation {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Explicitly concatenated string should be implicitly concatenated")
+        "Explicitly concatenated string should be implicitly concatenated".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_implicit_str_concat/rules/implicit.rs
+++ b/crates/ruff_linter/src/rules/flake8_implicit_str_concat/rules/implicit.rs
@@ -42,7 +42,7 @@ impl Violation for SingleLineImplicitStringConcatenation {
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Implicitly concatenated string literals on one line")
+        "Implicitly concatenated string literals on one line".to_string()
     }
 
     fn fix_title(&self) -> Option<String> {
@@ -88,7 +88,7 @@ pub struct MultiLineImplicitStringConcatenation;
 impl Violation for MultiLineImplicitStringConcatenation {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Implicitly concatenated string literals over multiple lines")
+        "Implicitly concatenated string literals over multiple lines".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_logging/rules/direct_logger_instantiation.rs
+++ b/crates/ruff_linter/src/rules/flake8_logging/rules/direct_logger_instantiation.rs
@@ -45,7 +45,7 @@ impl Violation for DirectLoggerInstantiation {
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Use `logging.getLogger()` to instantiate loggers")
+        "Use `logging.getLogger()` to instantiate loggers".to_string()
     }
 
     fn fix_title(&self) -> Option<String> {

--- a/crates/ruff_linter/src/rules/flake8_logging/rules/exception_without_exc_info.rs
+++ b/crates/ruff_linter/src/rules/flake8_logging/rules/exception_without_exc_info.rs
@@ -36,7 +36,7 @@ pub struct ExceptionWithoutExcInfo;
 impl Violation for ExceptionWithoutExcInfo {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Use of `logging.exception` with falsy `exc_info`")
+        "Use of `logging.exception` with falsy `exc_info`".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_logging/rules/invalid_get_logger_argument.rs
+++ b/crates/ruff_linter/src/rules/flake8_logging/rules/invalid_get_logger_argument.rs
@@ -48,7 +48,7 @@ impl Violation for InvalidGetLoggerArgument {
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Use `__name__` with `logging.getLogger()`")
+        "Use `__name__` with `logging.getLogger()`".to_string()
     }
 
     fn fix_title(&self) -> Option<String> {

--- a/crates/ruff_linter/src/rules/flake8_logging/rules/undocumented_warn.rs
+++ b/crates/ruff_linter/src/rules/flake8_logging/rules/undocumented_warn.rs
@@ -37,9 +37,10 @@ pub struct UndocumentedWarn;
 
 impl Violation for UndocumentedWarn {
     const FIX_AVAILABILITY: FixAvailability = FixAvailability::Sometimes;
+
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Use of undocumented `logging.WARN` constant")
+        "Use of undocumented `logging.WARN` constant".to_string()
     }
 
     fn fix_title(&self) -> Option<String> {

--- a/crates/ruff_linter/src/rules/flake8_logging_format/violations.rs
+++ b/crates/ruff_linter/src/rules/flake8_logging_format/violations.rs
@@ -79,7 +79,7 @@ pub struct LoggingStringFormat;
 impl Violation for LoggingStringFormat {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Logging statement uses `str.format`")
+        "Logging statement uses `str.format`".to_string()
     }
 }
 
@@ -163,7 +163,7 @@ pub struct LoggingPercentFormat;
 impl Violation for LoggingPercentFormat {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Logging statement uses `%`")
+        "Logging statement uses `%`".to_string()
     }
 }
 
@@ -246,7 +246,7 @@ pub struct LoggingStringConcat;
 impl Violation for LoggingStringConcat {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Logging statement uses `+`")
+        "Logging statement uses `+`".to_string()
     }
 }
 
@@ -328,7 +328,7 @@ pub struct LoggingFString;
 impl Violation for LoggingFString {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Logging statement uses f-string")
+        "Logging statement uses f-string".to_string()
     }
 }
 
@@ -379,7 +379,7 @@ pub struct LoggingWarn;
 impl AlwaysFixableViolation for LoggingWarn {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Logging statement uses `warn` instead of `warning`")
+        "Logging statement uses `warn` instead of `warning`".to_string()
     }
 
     fn fix_title(&self) -> String {
@@ -508,7 +508,8 @@ pub struct LoggingExcInfo;
 impl Violation for LoggingExcInfo {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Logging `.exception(...)` should be used instead of `.error(..., exc_info=True)`")
+        "Logging `.exception(...)` should be used instead of `.error(..., exc_info=True)`"
+            .to_string()
     }
 }
 
@@ -569,6 +570,6 @@ pub struct LoggingRedundantExcInfo;
 impl Violation for LoggingRedundantExcInfo {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Logging statement has redundant `exc_info`")
+        "Logging statement has redundant `exc_info`".to_string()
     }
 }

--- a/crates/ruff_linter/src/rules/flake8_pie/rules/unnecessary_dict_kwargs.rs
+++ b/crates/ruff_linter/src/rules/flake8_pie/rules/unnecessary_dict_kwargs.rs
@@ -47,7 +47,7 @@ impl Violation for UnnecessaryDictKwargs {
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Unnecessary `dict` kwargs")
+        "Unnecessary `dict` kwargs".to_string()
     }
 
     fn fix_title(&self) -> Option<String> {

--- a/crates/ruff_linter/src/rules/flake8_pie/rules/unnecessary_placeholder.rs
+++ b/crates/ruff_linter/src/rules/flake8_pie/rules/unnecessary_placeholder.rs
@@ -62,8 +62,8 @@ impl AlwaysFixableViolation for UnnecessaryPlaceholder {
     #[derive_message_formats]
     fn message(&self) -> String {
         match &self.kind {
-            Placeholder::Pass => format!("Unnecessary `pass` statement"),
-            Placeholder::Ellipsis => format!("Unnecessary `...` literal"),
+            Placeholder::Pass => "Unnecessary `pass` statement".to_string(),
+            Placeholder::Ellipsis => "Unnecessary `...` literal".to_string(),
         }
     }
 

--- a/crates/ruff_linter/src/rules/flake8_pie/rules/unnecessary_range_start.rs
+++ b/crates/ruff_linter/src/rules/flake8_pie/rules/unnecessary_range_start.rs
@@ -33,7 +33,7 @@ pub struct UnnecessaryRangeStart;
 impl AlwaysFixableViolation for UnnecessaryRangeStart {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Unnecessary `start` argument in `range`")
+        "Unnecessary `start` argument in `range`".to_string()
     }
 
     fn fix_title(&self) -> String {

--- a/crates/ruff_linter/src/rules/flake8_pie/rules/unnecessary_spread.rs
+++ b/crates/ruff_linter/src/rules/flake8_pie/rules/unnecessary_spread.rs
@@ -36,7 +36,7 @@ impl Violation for UnnecessarySpread {
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Unnecessary spread `**`")
+        "Unnecessary spread `**`".to_string()
     }
 
     fn fix_title(&self) -> Option<String> {

--- a/crates/ruff_linter/src/rules/flake8_print/rules/print_call.rs
+++ b/crates/ruff_linter/src/rules/flake8_print/rules/print_call.rs
@@ -40,7 +40,7 @@ impl Violation for Print {
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("`print` found")
+        "`print` found".to_string()
     }
 
     fn fix_title(&self) -> Option<String> {
@@ -87,7 +87,7 @@ impl Violation for PPrint {
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("`pprint` found")
+        "`pprint` found".to_string()
     }
 
     fn fix_title(&self) -> Option<String> {

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/bad_version_info_comparison.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/bad_version_info_comparison.rs
@@ -56,7 +56,7 @@ pub struct BadVersionInfoComparison;
 impl Violation for BadVersionInfoComparison {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Use `<` or `>=` for `sys.version_info` comparisons")
+        "Use `<` or `>=` for `sys.version_info` comparisons".to_string()
     }
 }
 
@@ -101,7 +101,7 @@ pub struct BadVersionInfoOrder;
 impl Violation for BadVersionInfoOrder {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Use `>=` when using `if`-`else` with `sys.version_info` comparisons")
+        "Use `>=` when using `if`-`else` with `sys.version_info` comparisons".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/collections_named_tuple.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/collections_named_tuple.rs
@@ -41,7 +41,7 @@ pub struct CollectionsNamedTuple;
 impl Violation for CollectionsNamedTuple {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Use `typing.NamedTuple` instead of `collections.namedtuple`")
+        "Use `typing.NamedTuple` instead of `collections.namedtuple`".to_string()
     }
 
     fn fix_title(&self) -> Option<String> {

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/complex_assignment_in_stub.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/complex_assignment_in_stub.rs
@@ -47,7 +47,7 @@ pub struct ComplexAssignmentInStub;
 impl Violation for ComplexAssignmentInStub {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Stubs should not contain assignments to attributes or multiple targets")
+        "Stubs should not contain assignments to attributes or multiple targets".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/complex_if_statement_in_stub.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/complex_if_statement_in_stub.rs
@@ -37,9 +37,8 @@ pub struct ComplexIfStatementInStub;
 impl Violation for ComplexIfStatementInStub {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!(
-            "`if` test must be a simple comparison against `sys.platform` or `sys.version_info`"
-        )
+        "`if` test must be a simple comparison against `sys.platform` or `sys.version_info`"
+            .to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/docstring_in_stubs.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/docstring_in_stubs.rs
@@ -32,7 +32,7 @@ pub struct DocstringInStub;
 impl Violation for DocstringInStub {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Docstrings should not be included in stubs")
+        "Docstrings should not be included in stubs".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/ellipsis_in_non_empty_class_body.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/ellipsis_in_non_empty_class_body.rs
@@ -34,7 +34,7 @@ impl Violation for EllipsisInNonEmptyClassBody {
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Non-empty class body must not contain `...`")
+        "Non-empty class body must not contain `...`".to_string()
     }
 
     fn fix_title(&self) -> Option<String> {

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/future_annotations_in_stub.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/future_annotations_in_stub.rs
@@ -25,7 +25,7 @@ impl Violation for FutureAnnotationsInStub {
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("`from __future__ import annotations` has no effect in stub files, since type checkers automatically treat stubs as having those semantics")
+        "`from __future__ import annotations` has no effect in stub files, since type checkers automatically treat stubs as having those semantics".to_string()
     }
 
     fn fix_title(&self) -> Option<String> {

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/generic_not_last_base_class.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/generic_not_last_base_class.rs
@@ -55,7 +55,7 @@ impl Violation for GenericNotLastBaseClass {
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("`Generic[]` should always be the last base class")
+        "`Generic[]` should always be the last base class".to_string()
     }
 
     fn fix_title(&self) -> Option<String> {

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/iter_method_return_iterable.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/iter_method_return_iterable.rs
@@ -76,11 +76,11 @@ pub struct IterMethodReturnIterable {
 impl Violation for IterMethodReturnIterable {
     #[derive_message_formats]
     fn message(&self) -> String {
-        let IterMethodReturnIterable { is_async } = self;
-        if *is_async {
-            format!("`__aiter__` methods should return an `AsyncIterator`, not an `AsyncIterable`")
+        if self.is_async {
+            "`__aiter__` methods should return an `AsyncIterator`, not an `AsyncIterable`"
+                .to_string()
         } else {
-            format!("`__iter__` methods should return an `Iterator`, not an `Iterable`")
+            "`__iter__` methods should return an `Iterator`, not an `Iterable`".to_string()
         }
     }
 }

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/non_empty_stub_body.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/non_empty_stub_body.rs
@@ -34,7 +34,7 @@ pub struct NonEmptyStubBody;
 impl AlwaysFixableViolation for NonEmptyStubBody {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Function body must contain only `...`")
+        "Function body must contain only `...`".to_string()
     }
 
     fn fix_title(&self) -> String {
@@ -68,7 +68,7 @@ pub(crate) fn non_empty_stub_body(checker: &mut Checker, body: &[Stmt]) {
 
     let mut diagnostic = Diagnostic::new(NonEmptyStubBody, stmt.range());
     diagnostic.set_fix(Fix::safe_edit(Edit::range_replacement(
-        format!("..."),
+        "...".to_string(),
         stmt.range(),
     )));
     checker.diagnostics.push(diagnostic);

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/non_self_return_type.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/non_self_return_type.rs
@@ -86,7 +86,7 @@ impl Violation for NonSelfReturnType {
             method_name,
         } = self;
         if matches!(class_name.as_str(), "__new__") {
-            format!("`__new__` methods usually return `self` at runtime")
+            "`__new__` methods usually return `self` at runtime".to_string()
         } else {
             format!("`{method_name}` methods in classes like `{class_name}` usually return `self` at runtime")
         }

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/numeric_literal_too_long.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/numeric_literal_too_long.rs
@@ -35,7 +35,8 @@ pub struct NumericLiteralTooLong;
 impl AlwaysFixableViolation for NumericLiteralTooLong {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Numeric literals with a string representation longer than ten characters are not permitted")
+        "Numeric literals with a string representation longer than ten characters are not permitted"
+            .to_string()
     }
 
     fn fix_title(&self) -> String {

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/pass_in_class_body.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/pass_in_class_body.rs
@@ -32,7 +32,7 @@ pub struct PassInClassBody;
 impl AlwaysFixableViolation for PassInClassBody {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Class body must not contain `pass`")
+        "Class body must not contain `pass`".to_string()
     }
 
     fn fix_title(&self) -> String {

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/pass_statement_stub_body.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/pass_statement_stub_body.rs
@@ -31,7 +31,7 @@ pub struct PassStatementStubBody;
 impl AlwaysFixableViolation for PassStatementStubBody {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Empty body should contain `...`, not `pass`")
+        "Empty body should contain `...`, not `pass`".to_string()
     }
 
     fn fix_title(&self) -> String {
@@ -47,7 +47,7 @@ pub(crate) fn pass_statement_stub_body(checker: &mut Checker, body: &[Stmt]) {
 
     let mut diagnostic = Diagnostic::new(PassStatementStubBody, pass.range());
     diagnostic.set_fix(Fix::safe_edit(Edit::range_replacement(
-        format!("..."),
+        "...".to_string(),
         pass.range(),
     )));
     checker.diagnostics.push(diagnostic);

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/pre_pep570_positional_argument.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/pre_pep570_positional_argument.rs
@@ -35,7 +35,7 @@ pub struct PrePep570PositionalArgument;
 impl Violation for PrePep570PositionalArgument {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Use PEP 570 syntax for positional-only arguments")
+        "Use PEP 570 syntax for positional-only arguments".to_string()
     }
 
     fn fix_title(&self) -> Option<String> {

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/quoted_annotation_in_stub.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/quoted_annotation_in_stub.rs
@@ -34,7 +34,7 @@ pub struct QuotedAnnotationInStub;
 impl AlwaysFixableViolation for QuotedAnnotationInStub {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Quoted annotations should not be included in stubs")
+        "Quoted annotations should not be included in stubs".to_string()
     }
 
     fn fix_title(&self) -> String {

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/simple_defaults.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/simple_defaults.rs
@@ -49,7 +49,7 @@ pub struct TypedArgumentDefaultInStub;
 impl AlwaysFixableViolation for TypedArgumentDefaultInStub {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Only simple default values allowed for typed arguments")
+        "Only simple default values allowed for typed arguments".to_string()
     }
 
     fn fix_title(&self) -> String {
@@ -95,7 +95,7 @@ pub struct ArgumentDefaultInStub;
 impl AlwaysFixableViolation for ArgumentDefaultInStub {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Only simple default values allowed for arguments")
+        "Only simple default values allowed for arguments".to_string()
     }
 
     fn fix_title(&self) -> String {
@@ -139,7 +139,7 @@ pub struct AssignmentDefaultInStub;
 impl AlwaysFixableViolation for AssignmentDefaultInStub {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Only simple default values allowed for assignments")
+        "Only simple default values allowed for assignments".to_string()
     }
 
     fn fix_title(&self) -> String {

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/string_or_bytes_too_long.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/string_or_bytes_too_long.rs
@@ -38,7 +38,7 @@ pub struct StringOrBytesTooLong;
 impl AlwaysFixableViolation for StringOrBytesTooLong {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("String and bytes literals longer than 50 characters are not permitted")
+        "String and bytes literals longer than 50 characters are not permitted".to_string()
     }
 
     fn fix_title(&self) -> String {

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/stub_body_multiple_statements.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/stub_body_multiple_statements.rs
@@ -34,7 +34,7 @@ pub struct StubBodyMultipleStatements;
 impl Violation for StubBodyMultipleStatements {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Function body must contain exactly one statement")
+        "Function body must contain exactly one statement".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/type_comment_in_stub.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/type_comment_in_stub.rs
@@ -32,7 +32,7 @@ pub struct TypeCommentInStub;
 impl Violation for TypeCommentInStub {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Don't use type comments in stub file")
+        "Don't use type comments in stub file".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/unaliased_collections_abc_set_import.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/unaliased_collections_abc_set_import.rs
@@ -48,9 +48,7 @@ impl Violation for UnaliasedCollectionsAbcSetImport {
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!(
-            "Use `from collections.abc import Set as AbstractSet` to avoid confusion with the `set` builtin"
-        )
+        "Use `from collections.abc import Set as AbstractSet` to avoid confusion with the `set` builtin".to_string()
     }
 
     fn fix_title(&self) -> Option<String> {

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/unrecognized_platform.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/unrecognized_platform.rs
@@ -47,7 +47,7 @@ pub struct UnrecognizedPlatformCheck;
 impl Violation for UnrecognizedPlatformCheck {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Unrecognized `sys.platform` check")
+        "Unrecognized `sys.platform` check".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/unrecognized_version_info.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/unrecognized_version_info.rs
@@ -38,7 +38,7 @@ pub struct UnrecognizedVersionInfoCheck;
 impl Violation for UnrecognizedVersionInfoCheck {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Unrecognized `sys.version_info` check")
+        "Unrecognized `sys.version_info` check".to_string()
     }
 }
 
@@ -77,7 +77,7 @@ pub struct PatchVersionComparison;
 impl Violation for PatchVersionComparison {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Version comparison must use only major and minor version")
+        "Version comparison must use only major and minor version".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/rules/assertion.rs
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/rules/assertion.rs
@@ -66,7 +66,7 @@ impl Violation for PytestCompositeAssertion {
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Assertion should be broken down into multiple parts")
+        "Assertion should be broken down into multiple parts".to_string()
     }
 
     fn fix_title(&self) -> Option<String> {
@@ -152,7 +152,7 @@ pub struct PytestAssertAlwaysFalse;
 impl Violation for PytestAssertAlwaysFalse {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Assertion always fails, replace with `pytest.fail()`")
+        "Assertion always fails, replace with `pytest.fail()`".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/rules/fail.rs
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/rules/fail.rs
@@ -51,7 +51,7 @@ pub struct PytestFailWithoutMessage;
 impl Violation for PytestFailWithoutMessage {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("No message passed to `pytest.fail()`")
+        "No message passed to `pytest.fail()`".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/rules/fixture.rs
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/rules/fixture.rs
@@ -159,7 +159,7 @@ pub struct PytestExtraneousScopeFunction;
 impl AlwaysFixableViolation for PytestExtraneousScopeFunction {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("`scope='function'` is implied in `@pytest.fixture()`")
+        "`scope='function'` is implied in `@pytest.fixture()`".to_string()
     }
 
     fn fix_title(&self) -> String {
@@ -390,7 +390,7 @@ pub struct PytestDeprecatedYieldFixture;
 impl Violation for PytestDeprecatedYieldFixture {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("`@pytest.yield_fixture` is deprecated, use `@pytest.fixture`")
+        "`@pytest.yield_fixture` is deprecated, use `@pytest.fixture`".to_string()
     }
 }
 
@@ -449,7 +449,7 @@ pub struct PytestFixtureFinalizerCallback;
 impl Violation for PytestFixtureFinalizerCallback {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Use `yield` instead of `request.addfinalizer`")
+        "Use `yield` instead of `request.addfinalizer`".to_string()
     }
 }
 /// ## What it does
@@ -554,7 +554,7 @@ pub struct PytestErroneousUseFixturesOnFixture;
 impl AlwaysFixableViolation for PytestErroneousUseFixturesOnFixture {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("`pytest.mark.usefixtures` has no effect on fixtures")
+        "`pytest.mark.usefixtures` has no effect on fixtures".to_string()
     }
 
     fn fix_title(&self) -> String {
@@ -597,7 +597,7 @@ pub struct PytestUnnecessaryAsyncioMarkOnFixture;
 impl AlwaysFixableViolation for PytestUnnecessaryAsyncioMarkOnFixture {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("`pytest.mark.asyncio` is unnecessary for fixtures")
+        "`pytest.mark.asyncio` is unnecessary for fixtures".to_string()
     }
 
     fn fix_title(&self) -> String {

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/rules/imports.rs
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/rules/imports.rs
@@ -27,7 +27,7 @@ pub struct PytestIncorrectPytestImport;
 impl Violation for PytestIncorrectPytestImport {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Incorrect import of `pytest`; use `import pytest` instead")
+        "Incorrect import of `pytest`; use `import pytest` instead".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/rules/marks.rs
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/rules/marks.rs
@@ -111,7 +111,7 @@ pub struct PytestUseFixturesWithoutParameters;
 impl AlwaysFixableViolation for PytestUseFixturesWithoutParameters {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Useless `pytest.mark.usefixtures` without parameters")
+        "Useless `pytest.mark.usefixtures` without parameters".to_string()
     }
 
     fn fix_title(&self) -> String {

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/rules/patch.rs
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/rules/patch.rs
@@ -45,7 +45,7 @@ pub struct PytestPatchWithLambda;
 impl Violation for PytestPatchWithLambda {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Use `return_value=` instead of patching with `lambda`")
+        "Use `return_value=` instead of patching with `lambda`".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/rules/raises.rs
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/rules/raises.rs
@@ -51,7 +51,7 @@ pub struct PytestRaisesWithMultipleStatements;
 impl Violation for PytestRaisesWithMultipleStatements {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("`pytest.raises()` block should contain a single simple statement")
+        "`pytest.raises()` block should contain a single simple statement".to_string()
     }
 }
 
@@ -147,7 +147,7 @@ pub struct PytestRaisesWithoutException;
 impl Violation for PytestRaisesWithoutException {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("set the expected exception in `pytest.raises()`")
+        "set the expected exception in `pytest.raises()`".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_quotes/rules/avoidable_escaped_quote.rs
+++ b/crates/ruff_linter/src/rules/flake8_quotes/rules/avoidable_escaped_quote.rs
@@ -41,7 +41,7 @@ pub struct AvoidableEscapedQuote;
 impl AlwaysFixableViolation for AvoidableEscapedQuote {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Change outer quotes to avoid escaping inner quotes")
+        "Change outer quotes to avoid escaping inner quotes".to_string()
     }
 
     fn fix_title(&self) -> String {

--- a/crates/ruff_linter/src/rules/flake8_quotes/rules/check_string_quotes.rs
+++ b/crates/ruff_linter/src/rules/flake8_quotes/rules/check_string_quotes.rs
@@ -46,19 +46,18 @@ impl Violation for BadQuotesInlineString {
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        let BadQuotesInlineString { preferred_quote } = self;
-        match preferred_quote {
-            Quote::Double => format!("Single quotes found but double quotes preferred"),
-            Quote::Single => format!("Double quotes found but single quotes preferred"),
+        match self.preferred_quote {
+            Quote::Double => "Single quotes found but double quotes preferred".to_string(),
+            Quote::Single => "Double quotes found but single quotes preferred".to_string(),
         }
     }
 
     fn fix_title(&self) -> Option<String> {
-        let BadQuotesInlineString { preferred_quote } = self;
-        match preferred_quote {
-            Quote::Double => Some("Replace single quotes with double quotes".to_string()),
-            Quote::Single => Some("Replace double quotes with single quotes".to_string()),
-        }
+        let title = match self.preferred_quote {
+            Quote::Double => "Replace single quotes with double quotes",
+            Quote::Single => "Replace double quotes with single quotes",
+        };
+        Some(title.to_string())
     }
 }
 
@@ -104,8 +103,8 @@ impl AlwaysFixableViolation for BadQuotesMultilineString {
     fn message(&self) -> String {
         let BadQuotesMultilineString { preferred_quote } = self;
         match preferred_quote {
-            Quote::Double => format!("Single quote multiline found but double quotes preferred"),
-            Quote::Single => format!("Double quote multiline found but single quotes preferred"),
+            Quote::Double => "Single quote multiline found but double quotes preferred".to_string(),
+            Quote::Single => "Double quote multiline found but single quotes preferred".to_string(),
         }
     }
 
@@ -159,16 +158,14 @@ impl Violation for BadQuotesDocstring {
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        let BadQuotesDocstring { preferred_quote } = self;
-        match preferred_quote {
-            Quote::Double => format!("Single quote docstring found but double quotes preferred"),
-            Quote::Single => format!("Double quote docstring found but single quotes preferred"),
+        match self.preferred_quote {
+            Quote::Double => "Single quote docstring found but double quotes preferred".to_string(),
+            Quote::Single => "Double quote docstring found but single quotes preferred".to_string(),
         }
     }
 
     fn fix_title(&self) -> Option<String> {
-        let BadQuotesDocstring { preferred_quote } = self;
-        match preferred_quote {
+        match self.preferred_quote {
             Quote::Double => Some("Replace single quotes docstring with double quotes".to_string()),
             Quote::Single => Some("Replace double quotes docstring with single quotes".to_string()),
         }

--- a/crates/ruff_linter/src/rules/flake8_quotes/rules/unnecessary_escaped_quote.rs
+++ b/crates/ruff_linter/src/rules/flake8_quotes/rules/unnecessary_escaped_quote.rs
@@ -37,7 +37,7 @@ pub struct UnnecessaryEscapedQuote;
 impl AlwaysFixableViolation for UnnecessaryEscapedQuote {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Unnecessary escape on inner quote character")
+        "Unnecessary escape on inner quote character".to_string()
     }
 
     fn fix_title(&self) -> String {

--- a/crates/ruff_linter/src/rules/flake8_raise/rules/unnecessary_paren_on_raise_exception.rs
+++ b/crates/ruff_linter/src/rules/flake8_raise/rules/unnecessary_paren_on_raise_exception.rs
@@ -44,7 +44,7 @@ pub struct UnnecessaryParenOnRaiseException;
 impl AlwaysFixableViolation for UnnecessaryParenOnRaiseException {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Unnecessary parentheses on raised exception")
+        "Unnecessary parentheses on raised exception".to_string()
     }
 
     fn fix_title(&self) -> String {

--- a/crates/ruff_linter/src/rules/flake8_return/rules/function.rs
+++ b/crates/ruff_linter/src/rules/flake8_return/rules/function.rs
@@ -60,9 +60,8 @@ pub struct UnnecessaryReturnNone;
 impl AlwaysFixableViolation for UnnecessaryReturnNone {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!(
-            "Do not explicitly `return None` in function if it is the only possible return value"
-        )
+        "Do not explicitly `return None` in function if it is the only possible return value"
+            .to_string()
     }
 
     fn fix_title(&self) -> String {
@@ -102,7 +101,7 @@ pub struct ImplicitReturnValue;
 impl AlwaysFixableViolation for ImplicitReturnValue {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Do not implicitly `return None` in function able to return non-`None` value")
+        "Do not implicitly `return None` in function able to return non-`None` value".to_string()
     }
 
     fn fix_title(&self) -> String {
@@ -140,7 +139,8 @@ pub struct ImplicitReturn;
 impl AlwaysFixableViolation for ImplicitReturn {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Missing explicit `return` at the end of function able to return non-`None` value")
+        "Missing explicit `return` at the end of function able to return non-`None` value"
+            .to_string()
     }
 
     fn fix_title(&self) -> String {

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_bool_op.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_bool_op.rs
@@ -54,18 +54,15 @@ impl Violation for DuplicateIsinstanceCall {
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        let DuplicateIsinstanceCall { name } = self;
-        if let Some(name) = name {
+        if let Some(name) = &self.name {
             format!("Multiple `isinstance` calls for `{name}`, merge into a single call")
         } else {
-            format!("Multiple `isinstance` calls for expression, merge into a single call")
+            "Multiple `isinstance` calls for expression, merge into a single call".to_string()
         }
     }
 
     fn fix_title(&self) -> Option<String> {
-        let DuplicateIsinstanceCall { name } = self;
-
-        Some(if let Some(name) = name {
+        Some(if let Some(name) = &self.name {
             format!("Merge `isinstance` calls for `{name}`")
         } else {
             "Merge `isinstance` calls".to_string()

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_expr.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_expr.rs
@@ -51,7 +51,7 @@ impl Violation for UncapitalizedEnvironmentVariables {
         if let (Some(expected), Some(actual)) = (expected.full_display(), actual.full_display()) {
             format!("Use capitalized environment variable `{expected}` instead of `{actual}`")
         } else {
-            format!("Use capitalized environment variable")
+            "Use capitalized environment variable".to_string()
         }
     }
 
@@ -99,7 +99,7 @@ impl AlwaysFixableViolation for DictGetWithNoneDefault {
         if let (Some(expected), Some(actual)) = (expected.full_display(), actual.full_display()) {
             format!("Use `{expected}` instead of `{actual}`")
         } else {
-            format!("Use `dict.get()` without default value")
+            "Use `dict.get()` without default value".to_string()
         }
     }
 

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_ifexp.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_ifexp.rs
@@ -39,11 +39,10 @@ impl Violation for IfExprWithTrueFalse {
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        let IfExprWithTrueFalse { is_compare } = self;
-        if *is_compare {
-            format!("Remove unnecessary `True if ... else False`")
+        if self.is_compare {
+            "Remove unnecessary `True if ... else False`".to_string()
         } else {
-            format!("Use `bool(...)` instead of `True if ... else False`")
+            "Use `bool(...)` instead of `True if ... else False`".to_string()
         }
     }
 
@@ -84,11 +83,11 @@ pub struct IfExprWithFalseTrue;
 impl AlwaysFixableViolation for IfExprWithFalseTrue {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Use `not ...` instead of `False if ... else True`")
+        "Use `not ...` instead of `False if ... else True`".to_string()
     }
 
     fn fix_title(&self) -> String {
-        format!("Replace with `not ...`")
+        "Replace with `not ...`".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_with.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_with.rs
@@ -55,10 +55,9 @@ impl Violation for MultipleWithStatements {
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!(
-            "Use a single `with` statement with multiple contexts instead of nested `with` \
-             statements"
-        )
+        "Use a single `with` statement with multiple contexts instead of nested `with` \
+            statements"
+            .to_string()
     }
 
     fn fix_title(&self) -> Option<String> {

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/collapsible_if.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/collapsible_if.rs
@@ -54,7 +54,7 @@ impl Violation for CollapsibleIf {
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Use a single `if` statement instead of nested `if` statements")
+        "Use a single `if` statement instead of nested `if` statements".to_string()
     }
 
     fn fix_title(&self) -> Option<String> {

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/if_else_block_instead_of_dict_lookup.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/if_else_block_instead_of_dict_lookup.rs
@@ -36,7 +36,7 @@ pub struct IfElseBlockInsteadOfDictLookup;
 impl Violation for IfElseBlockInsteadOfDictLookup {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Use a dictionary instead of consecutive `if` statements")
+        "Use a dictionary instead of consecutive `if` statements".to_string()
     }
 }
 /// SIM116

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/if_with_same_arms.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/if_with_same_arms.rs
@@ -43,7 +43,7 @@ impl Violation for IfWithSameArms {
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Combine `if` branches using logical `or` operator")
+        "Combine `if` branches using logical `or` operator".to_string()
     }
 
     fn fix_title(&self) -> Option<String> {

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/needless_bool.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/needless_bool.rs
@@ -55,13 +55,10 @@ impl Violation for NeedlessBool {
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        if let Some(condition) = self
-            .condition
-            .as_ref()
-            .and_then(SourceCodeSnippet::full_display)
-        {
+        let NeedlessBool { condition, negate } = self;
+        if let Some(condition) = condition.as_ref().and_then(SourceCodeSnippet::full_display) {
             format!("Return the condition `{condition}` directly")
-        } else if self.negate {
+        } else if *negate {
             "Return the negated condition directly".to_string()
         } else {
             "Return the condition directly".to_string()
@@ -69,12 +66,9 @@ impl Violation for NeedlessBool {
     }
 
     fn fix_title(&self) -> Option<String> {
+        let NeedlessBool { condition, .. } = self;
         Some(
-            if let Some(condition) = self
-                .condition
-                .as_ref()
-                .and_then(SourceCodeSnippet::full_display)
-            {
+            if let Some(condition) = condition.as_ref().and_then(SourceCodeSnippet::full_display) {
                 format!("Replace with `return {condition}`")
             } else {
                 "Inline condition".to_string()

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/needless_bool.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/needless_bool.rs
@@ -55,25 +55,31 @@ impl Violation for NeedlessBool {
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        let NeedlessBool { condition, negate } = self;
-
-        if let Some(condition) = condition.as_ref().and_then(SourceCodeSnippet::full_display) {
+        if let Some(condition) = self
+            .condition
+            .as_ref()
+            .and_then(SourceCodeSnippet::full_display)
+        {
             format!("Return the condition `{condition}` directly")
-        } else if *negate {
-            format!("Return the negated condition directly")
+        } else if self.negate {
+            "Return the negated condition directly".to_string()
         } else {
-            format!("Return the condition directly")
+            "Return the condition directly".to_string()
         }
     }
 
     fn fix_title(&self) -> Option<String> {
-        let NeedlessBool { condition, .. } = self;
-
-        if let Some(condition) = condition.as_ref().and_then(SourceCodeSnippet::full_display) {
-            Some(format!("Replace with `return {condition}`"))
-        } else {
-            Some("Inline condition".to_string())
-        }
+        Some(
+            if let Some(condition) = self
+                .condition
+                .as_ref()
+                .and_then(SourceCodeSnippet::full_display)
+            {
+                format!("Replace with `return {condition}`")
+            } else {
+                "Inline condition".to_string()
+            },
+        )
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/open_file_with_context_handler.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/open_file_with_context_handler.rs
@@ -39,7 +39,7 @@ pub struct OpenFileWithContextHandler;
 impl Violation for OpenFileWithContextHandler {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Use a context manager for opening files")
+        "Use a context manager for opening files".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/return_in_try_except_finally.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/return_in_try_except_finally.rs
@@ -46,7 +46,7 @@ pub struct ReturnInTryExceptFinally;
 impl Violation for ReturnInTryExceptFinally {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Don't use `return` in `try`-`except` and `finally`")
+        "Don't use `return` in `try`-`except` and `finally`".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/split_static_string.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/split_static_string.rs
@@ -50,7 +50,7 @@ impl Violation for SplitStaticString {
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Consider using a list literal instead of `str.split`")
+        "Consider using a list literal instead of `str.split`".to_string()
     }
 
     fn fix_title(&self) -> Option<String> {

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/yoda_conditions.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/yoda_conditions.rs
@@ -57,7 +57,7 @@ impl Violation for YodaConditions {
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Yoda condition detected")
+        "Yoda condition detected".to_string()
     }
 
     fn fix_title(&self) -> Option<String> {

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/zip_dict_keys_and_values.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/zip_dict_keys_and_values.rs
@@ -40,9 +40,8 @@ pub struct ZipDictKeysAndValues {
 impl AlwaysFixableViolation for ZipDictKeysAndValues {
     #[derive_message_formats]
     fn message(&self) -> String {
-        if let (Some(expected), Some(actual)) =
-            (self.expected.full_display(), self.actual.full_display())
-        {
+        let ZipDictKeysAndValues { expected, actual } = self;
+        if let (Some(expected), Some(actual)) = (expected.full_display(), actual.full_display()) {
             format!("Use `{expected}` instead of `{actual}`")
         } else {
             "Use `dict.items()` instead of `zip(dict.keys(), dict.values())`".to_string()
@@ -50,9 +49,8 @@ impl AlwaysFixableViolation for ZipDictKeysAndValues {
     }
 
     fn fix_title(&self) -> String {
-        if let (Some(expected), Some(actual)) =
-            (self.expected.full_display(), self.actual.full_display())
-        {
+        let ZipDictKeysAndValues { expected, actual } = self;
+        if let (Some(expected), Some(actual)) = (expected.full_display(), actual.full_display()) {
             format!("Replace `{actual}` with `{expected}`")
         } else {
             "Replace `zip(dict.keys(), dict.values())` with `dict.items()`".to_string()

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/zip_dict_keys_and_values.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/zip_dict_keys_and_values.rs
@@ -40,17 +40,19 @@ pub struct ZipDictKeysAndValues {
 impl AlwaysFixableViolation for ZipDictKeysAndValues {
     #[derive_message_formats]
     fn message(&self) -> String {
-        let ZipDictKeysAndValues { expected, actual } = self;
-        if let (Some(expected), Some(actual)) = (expected.full_display(), actual.full_display()) {
+        if let (Some(expected), Some(actual)) =
+            (self.expected.full_display(), self.actual.full_display())
+        {
             format!("Use `{expected}` instead of `{actual}`")
         } else {
-            format!("Use `dict.items()` instead of `zip(dict.keys(), dict.values())`")
+            "Use `dict.items()` instead of `zip(dict.keys(), dict.values())`".to_string()
         }
     }
 
     fn fix_title(&self) -> String {
-        let ZipDictKeysAndValues { expected, actual } = self;
-        if let (Some(expected), Some(actual)) = (expected.full_display(), actual.full_display()) {
+        if let (Some(expected), Some(actual)) =
+            (self.expected.full_display(), self.actual.full_display())
+        {
             format!("Replace `{actual}` with `{expected}`")
         } else {
             "Replace `zip(dict.keys(), dict.values())` with `dict.items()`".to_string()

--- a/crates/ruff_linter/src/rules/flake8_slots/rules/no_slots_in_str_subclass.rs
+++ b/crates/ruff_linter/src/rules/flake8_slots/rules/no_slots_in_str_subclass.rs
@@ -44,7 +44,7 @@ pub struct NoSlotsInStrSubclass;
 impl Violation for NoSlotsInStrSubclass {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Subclasses of `str` should define `__slots__`")
+        "Subclasses of `str` should define `__slots__`".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_slots/rules/no_slots_in_tuple_subclass.rs
+++ b/crates/ruff_linter/src/rules/flake8_slots/rules/no_slots_in_tuple_subclass.rs
@@ -45,7 +45,7 @@ pub struct NoSlotsInTupleSubclass;
 impl Violation for NoSlotsInTupleSubclass {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Subclasses of `tuple` should define `__slots__`")
+        "Subclasses of `tuple` should define `__slots__`".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_tidy_imports/rules/relative_imports.rs
+++ b/crates/ruff_linter/src/rules/flake8_tidy_imports/rules/relative_imports.rs
@@ -57,9 +57,9 @@ impl Violation for RelativeImports {
     fn message(&self) -> String {
         match self.strictness {
             Strictness::Parents => {
-                format!("Prefer absolute imports over relative imports from parent modules")
+                "Prefer absolute imports over relative imports from parent modules".to_string()
             }
-            Strictness::All => format!("Prefer absolute imports over relative imports"),
+            Strictness::All => "Prefer absolute imports over relative imports".to_string(),
         }
     }
 

--- a/crates/ruff_linter/src/rules/flake8_todos/rules/todos.rs
+++ b/crates/ruff_linter/src/rules/flake8_todos/rules/todos.rs
@@ -65,7 +65,8 @@ pub struct MissingTodoAuthor;
 impl Violation for MissingTodoAuthor {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Missing author in TODO; try: `# TODO(<author_name>): ...` or `# TODO @<author_name>: ...`")
+        "Missing author in TODO; try: `# TODO(<author_name>): ...` or `# TODO @<author_name>: ...`"
+            .to_string()
     }
 }
 
@@ -99,7 +100,7 @@ pub struct MissingTodoLink;
 impl Violation for MissingTodoLink {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Missing issue link on the line following this TODO")
+        "Missing issue link on the line following this TODO".to_string()
     }
 }
 
@@ -128,7 +129,7 @@ pub struct MissingTodoColon;
 impl Violation for MissingTodoColon {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Missing colon in TODO")
+        "Missing colon in TODO".to_string()
     }
 }
 
@@ -155,7 +156,7 @@ pub struct MissingTodoDescription;
 impl Violation for MissingTodoDescription {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Missing issue description after `TODO`")
+        "Missing issue description after `TODO`".to_string()
     }
 }
 
@@ -219,7 +220,7 @@ pub struct MissingSpaceAfterTodoColon;
 impl Violation for MissingSpaceAfterTodoColon {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Missing space after colon in TODO")
+        "Missing space after colon in TODO".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_type_checking/rules/empty_type_checking_block.rs
+++ b/crates/ruff_linter/src/rules/flake8_type_checking/rules/empty_type_checking_block.rs
@@ -38,7 +38,7 @@ pub struct EmptyTypeCheckingBlock;
 impl AlwaysFixableViolation for EmptyTypeCheckingBlock {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Found empty type-checking block")
+        "Found empty type-checking block".to_string()
     }
 
     fn fix_title(&self) -> String {

--- a/crates/ruff_linter/src/rules/flake8_type_checking/rules/runtime_string_union.rs
+++ b/crates/ruff_linter/src/rules/flake8_type_checking/rules/runtime_string_union.rs
@@ -47,7 +47,7 @@ pub struct RuntimeStringUnion;
 impl Violation for RuntimeStringUnion {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Invalid string member in `X | Y`-style union type")
+        "Invalid string member in `X | Y`-style union type".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/os_path_getatime.rs
+++ b/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/os_path_getatime.rs
@@ -42,6 +42,6 @@ pub struct OsPathGetatime;
 impl Violation for OsPathGetatime {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("`os.path.getatime` should be replaced by `Path.stat().st_atime`")
+        "`os.path.getatime` should be replaced by `Path.stat().st_atime`".to_string()
     }
 }

--- a/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/os_path_getctime.rs
+++ b/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/os_path_getctime.rs
@@ -42,6 +42,6 @@ pub struct OsPathGetctime;
 impl Violation for OsPathGetctime {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("`os.path.getctime` should be replaced by `Path.stat().st_ctime`")
+        "`os.path.getctime` should be replaced by `Path.stat().st_ctime`".to_string()
     }
 }

--- a/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/os_path_getmtime.rs
+++ b/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/os_path_getmtime.rs
@@ -42,6 +42,6 @@ pub struct OsPathGetmtime;
 impl Violation for OsPathGetmtime {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("`os.path.getmtime` should be replaced by `Path.stat().st_mtime`")
+        "`os.path.getmtime` should be replaced by `Path.stat().st_mtime`".to_string()
     }
 }

--- a/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/os_path_getsize.rs
+++ b/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/os_path_getsize.rs
@@ -42,6 +42,6 @@ pub struct OsPathGetsize;
 impl Violation for OsPathGetsize {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("`os.path.getsize` should be replaced by `Path.stat().st_size`")
+        "`os.path.getsize` should be replaced by `Path.stat().st_size`".to_string()
     }
 }

--- a/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/os_sep_split.rs
+++ b/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/os_sep_split.rs
@@ -48,7 +48,7 @@ pub struct OsSepSplit;
 impl Violation for OsSepSplit {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Replace `.split(os.sep)` with `Path.parts`")
+        "Replace `.split(os.sep)` with `Path.parts`".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/path_constructor_current_directory.rs
+++ b/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/path_constructor_current_directory.rs
@@ -34,7 +34,7 @@ pub struct PathConstructorCurrentDirectory;
 impl AlwaysFixableViolation for PathConstructorCurrentDirectory {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Do not pass the current directory explicitly to `Path`")
+        "Do not pass the current directory explicitly to `Path`".to_string()
     }
 
     fn fix_title(&self) -> String {

--- a/crates/ruff_linter/src/rules/flake8_use_pathlib/violations.rs
+++ b/crates/ruff_linter/src/rules/flake8_use_pathlib/violations.rs
@@ -40,7 +40,7 @@ pub struct OsPathAbspath;
 impl Violation for OsPathAbspath {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("`os.path.abspath()` should be replaced by `Path.resolve()`")
+        "`os.path.abspath()` should be replaced by `Path.resolve()`".to_string()
     }
 }
 
@@ -83,7 +83,7 @@ pub struct OsChmod;
 impl Violation for OsChmod {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("`os.chmod()` should be replaced by `Path.chmod()`")
+        "`os.chmod()` should be replaced by `Path.chmod()`".to_string()
     }
 }
 
@@ -126,7 +126,7 @@ pub struct OsMakedirs;
 impl Violation for OsMakedirs {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("`os.makedirs()` should be replaced by `Path.mkdir(parents=True)`")
+        "`os.makedirs()` should be replaced by `Path.mkdir(parents=True)`".to_string()
     }
 }
 
@@ -169,7 +169,7 @@ pub struct OsMkdir;
 impl Violation for OsMkdir {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("`os.mkdir()` should be replaced by `Path.mkdir()`")
+        "`os.mkdir()` should be replaced by `Path.mkdir()`".to_string()
     }
 }
 
@@ -212,7 +212,7 @@ pub struct OsRename;
 impl Violation for OsRename {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("`os.rename()` should be replaced by `Path.rename()`")
+        "`os.rename()` should be replaced by `Path.rename()`".to_string()
     }
 }
 
@@ -255,7 +255,7 @@ pub struct OsReplace;
 impl Violation for OsReplace {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("`os.replace()` should be replaced by `Path.replace()`")
+        "`os.replace()` should be replaced by `Path.replace()`".to_string()
     }
 }
 
@@ -298,7 +298,7 @@ pub struct OsRmdir;
 impl Violation for OsRmdir {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("`os.rmdir()` should be replaced by `Path.rmdir()`")
+        "`os.rmdir()` should be replaced by `Path.rmdir()`".to_string()
     }
 }
 
@@ -341,7 +341,7 @@ pub struct OsRemove;
 impl Violation for OsRemove {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("`os.remove()` should be replaced by `Path.unlink()`")
+        "`os.remove()` should be replaced by `Path.unlink()`".to_string()
     }
 }
 
@@ -384,7 +384,7 @@ pub struct OsUnlink;
 impl Violation for OsUnlink {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("`os.unlink()` should be replaced by `Path.unlink()`")
+        "`os.unlink()` should be replaced by `Path.unlink()`".to_string()
     }
 }
 
@@ -428,7 +428,7 @@ pub struct OsGetcwd;
 impl Violation for OsGetcwd {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("`os.getcwd()` should be replaced by `Path.cwd()`")
+        "`os.getcwd()` should be replaced by `Path.cwd()`".to_string()
     }
 }
 
@@ -471,7 +471,7 @@ pub struct OsPathExists;
 impl Violation for OsPathExists {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("`os.path.exists()` should be replaced by `Path.exists()`")
+        "`os.path.exists()` should be replaced by `Path.exists()`".to_string()
     }
 }
 
@@ -514,7 +514,7 @@ pub struct OsPathExpanduser;
 impl Violation for OsPathExpanduser {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("`os.path.expanduser()` should be replaced by `Path.expanduser()`")
+        "`os.path.expanduser()` should be replaced by `Path.expanduser()`".to_string()
     }
 }
 
@@ -557,7 +557,7 @@ pub struct OsPathIsdir;
 impl Violation for OsPathIsdir {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("`os.path.isdir()` should be replaced by `Path.is_dir()`")
+        "`os.path.isdir()` should be replaced by `Path.is_dir()`".to_string()
     }
 }
 
@@ -600,7 +600,7 @@ pub struct OsPathIsfile;
 impl Violation for OsPathIsfile {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("`os.path.isfile()` should be replaced by `Path.is_file()`")
+        "`os.path.isfile()` should be replaced by `Path.is_file()`".to_string()
     }
 }
 
@@ -643,7 +643,7 @@ pub struct OsPathIslink;
 impl Violation for OsPathIslink {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("`os.path.islink()` should be replaced by `Path.is_symlink()`")
+        "`os.path.islink()` should be replaced by `Path.is_symlink()`".to_string()
     }
 }
 
@@ -686,7 +686,7 @@ pub struct OsReadlink;
 impl Violation for OsReadlink {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("`os.readlink()` should be replaced by `Path.readlink()`")
+        "`os.readlink()` should be replaced by `Path.readlink()`".to_string()
     }
 }
 
@@ -738,9 +738,8 @@ pub struct OsStat;
 impl Violation for OsStat {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!(
-            "`os.stat()` should be replaced by `Path.stat()`, `Path.owner()`, or `Path.group()`"
-        )
+        "`os.stat()` should be replaced by `Path.stat()`, `Path.owner()`, or `Path.group()`"
+            .to_string()
     }
 }
 
@@ -785,7 +784,7 @@ pub struct OsPathIsabs;
 impl Violation for OsPathIsabs {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("`os.path.isabs()` should be replaced by `Path.is_absolute()`")
+        "`os.path.isabs()` should be replaced by `Path.is_absolute()`".to_string()
     }
 }
 
@@ -888,7 +887,7 @@ pub struct OsPathBasename;
 impl Violation for OsPathBasename {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("`os.path.basename()` should be replaced by `Path.name`")
+        "`os.path.basename()` should be replaced by `Path.name`".to_string()
     }
 }
 
@@ -931,7 +930,7 @@ pub struct OsPathDirname;
 impl Violation for OsPathDirname {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("`os.path.dirname()` should be replaced by `Path.parent`")
+        "`os.path.dirname()` should be replaced by `Path.parent`".to_string()
     }
 }
 
@@ -974,7 +973,7 @@ pub struct OsPathSamefile;
 impl Violation for OsPathSamefile {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("`os.path.samefile()` should be replaced by `Path.samefile()`")
+        "`os.path.samefile()` should be replaced by `Path.samefile()`".to_string()
     }
 }
 
@@ -1026,7 +1025,8 @@ pub struct OsPathSplitext;
 impl Violation for OsPathSplitext {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("`os.path.splitext()` should be replaced by `Path.suffix`, `Path.stem`, and `Path.parent`")
+        "`os.path.splitext()` should be replaced by `Path.suffix`, `Path.stem`, and `Path.parent`"
+            .to_string()
     }
 }
 
@@ -1065,7 +1065,7 @@ pub struct BuiltinOpen;
 impl Violation for BuiltinOpen {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("`open()` should be replaced by `Path.open()`")
+        "`open()` should be replaced by `Path.open()`".to_string()
     }
 }
 
@@ -1100,6 +1100,6 @@ pub struct PyPath;
 impl Violation for PyPath {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("`py.path` is in maintenance mode, use `pathlib` instead")
+        "`py.path` is in maintenance mode, use `pathlib` instead".to_string()
     }
 }

--- a/crates/ruff_linter/src/rules/flynt/rules/static_join_to_fstring.rs
+++ b/crates/ruff_linter/src/rules/flynt/rules/static_join_to_fstring.rs
@@ -42,7 +42,7 @@ impl AlwaysFixableViolation for StaticJoinToFString {
         if let Some(expression) = expression.full_display() {
             format!("Consider `{expression}` instead of string join")
         } else {
-            format!("Consider f-string instead of string join")
+            "Consider f-string instead of string join".to_string()
         }
     }
 

--- a/crates/ruff_linter/src/rules/isort/rules/organize_imports.rs
+++ b/crates/ruff_linter/src/rules/isort/rules/organize_imports.rs
@@ -46,7 +46,7 @@ impl Violation for UnsortedImports {
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Import block is un-sorted or un-formatted")
+        "Import block is un-sorted or un-formatted".to_string()
     }
 
     fn fix_title(&self) -> Option<String> {

--- a/crates/ruff_linter/src/rules/pandas_vet/rules/assignment_to_df.rs
+++ b/crates/ruff_linter/src/rules/pandas_vet/rules/assignment_to_df.rs
@@ -33,7 +33,7 @@ pub struct PandasDfVariableName;
 impl Violation for PandasDfVariableName {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Avoid using the generic variable name `df` for DataFrames")
+        "Avoid using the generic variable name `df` for DataFrames".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/pandas_vet/rules/attr.rs
+++ b/crates/ruff_linter/src/rules/pandas_vet/rules/attr.rs
@@ -38,7 +38,7 @@ pub struct PandasUseOfDotValues;
 impl Violation for PandasUseOfDotValues {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Use `.to_numpy()` instead of `.values`")
+        "Use `.to_numpy()` instead of `.values`".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/pandas_vet/rules/call.rs
+++ b/crates/ruff_linter/src/rules/pandas_vet/rules/call.rs
@@ -45,7 +45,7 @@ pub struct PandasUseOfDotIsNull;
 impl Violation for PandasUseOfDotIsNull {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("`.isna` is preferred to `.isnull`; functionality is equivalent")
+        "`.isna` is preferred to `.isnull`; functionality is equivalent".to_string()
     }
 }
 
@@ -85,7 +85,7 @@ pub struct PandasUseOfDotNotNull;
 impl Violation for PandasUseOfDotNotNull {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("`.notna` is preferred to `.notnull`; functionality is equivalent")
+        "`.notna` is preferred to `.notnull`; functionality is equivalent".to_string()
     }
 }
 
@@ -121,9 +121,8 @@ pub struct PandasUseOfDotPivotOrUnstack;
 impl Violation for PandasUseOfDotPivotOrUnstack {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!(
-            "`.pivot_table` is preferred to `.pivot` or `.unstack`; provides same functionality"
-        )
+        "`.pivot_table` is preferred to `.pivot` or `.unstack`; provides same functionality"
+            .to_string()
     }
 }
 
@@ -159,7 +158,7 @@ pub struct PandasUseOfDotStack;
 impl Violation for PandasUseOfDotStack {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("`.melt` is preferred to `.stack`; provides same functionality")
+        "`.melt` is preferred to `.stack`; provides same functionality".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/pandas_vet/rules/inplace_argument.rs
+++ b/crates/ruff_linter/src/rules/pandas_vet/rules/inplace_argument.rs
@@ -42,7 +42,7 @@ impl Violation for PandasUseOfInplaceArgument {
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("`inplace=True` should be avoided; it has inconsistent behavior")
+        "`inplace=True` should be avoided; it has inconsistent behavior".to_string()
     }
 
     fn fix_title(&self) -> Option<String> {

--- a/crates/ruff_linter/src/rules/pandas_vet/rules/nunique_constant_series_check.rs
+++ b/crates/ruff_linter/src/rules/pandas_vet/rules/nunique_constant_series_check.rs
@@ -56,7 +56,7 @@ pub struct PandasNuniqueConstantSeriesCheck;
 impl Violation for PandasNuniqueConstantSeriesCheck {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Using `series.nunique()` for checking that a series is constant is inefficient")
+        "Using `series.nunique()` for checking that a series is constant is inefficient".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/pandas_vet/rules/pd_merge.rs
+++ b/crates/ruff_linter/src/rules/pandas_vet/rules/pd_merge.rs
@@ -47,10 +47,9 @@ pub struct PandasUseOfPdMerge;
 impl Violation for PandasUseOfPdMerge {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!(
-            "Use `.merge` method instead of `pd.merge` function. They have equivalent \
+        "Use `.merge` method instead of `pd.merge` function. They have equivalent \
              functionality."
-        )
+            .to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/pandas_vet/rules/read_table.rs
+++ b/crates/ruff_linter/src/rules/pandas_vet/rules/read_table.rs
@@ -41,7 +41,7 @@ pub struct PandasUseOfDotReadTable;
 impl Violation for PandasUseOfDotReadTable {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Use `.read_csv` instead of `.read_table` to read CSV files")
+        "Use `.read_csv` instead of `.read_table` to read CSV files".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/pandas_vet/rules/subscript.rs
+++ b/crates/ruff_linter/src/rules/pandas_vet/rules/subscript.rs
@@ -45,7 +45,7 @@ pub struct PandasUseOfDotIx;
 impl Violation for PandasUseOfDotIx {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("`.ix` is deprecated; use more explicit `.loc` or `.iloc`")
+        "`.ix` is deprecated; use more explicit `.loc` or `.iloc`".to_string()
     }
 }
 
@@ -87,7 +87,7 @@ pub struct PandasUseOfDotAt;
 impl Violation for PandasUseOfDotAt {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Use `.loc` instead of `.at`. If speed is important, use NumPy.")
+        "Use `.loc` instead of `.at`. If speed is important, use NumPy.".to_string()
     }
 }
 
@@ -138,7 +138,7 @@ pub struct PandasUseOfDotIat;
 impl Violation for PandasUseOfDotIat {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Use `.iloc` instead of `.iat`. If speed is important, use NumPy.")
+        "Use `.iloc` instead of `.iat`. If speed is important, use NumPy.".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/pep8_naming/rules/dunder_function_name.rs
+++ b/crates/ruff_linter/src/rules/pep8_naming/rules/dunder_function_name.rs
@@ -38,7 +38,7 @@ pub struct DunderFunctionName;
 impl Violation for DunderFunctionName {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Function name should not start and end with `__`")
+        "Function name should not start and end with `__`".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/pep8_naming/rules/invalid_first_argument_name.rs
+++ b/crates/ruff_linter/src/rules/pep8_naming/rules/invalid_first_argument_name.rs
@@ -69,7 +69,7 @@ impl Violation for InvalidFirstArgumentNameForMethod {
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("First argument of a method should be named `self`")
+        "First argument of a method should be named `self`".to_string()
     }
 
     fn fix_title(&self) -> Option<String> {
@@ -135,7 +135,7 @@ impl Violation for InvalidFirstArgumentNameForClassMethod {
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("First argument of a class method should be named `cls`")
+        "First argument of a class method should be named `cls`".to_string()
     }
 
     fn fix_title(&self) -> Option<String> {

--- a/crates/ruff_linter/src/rules/perflint/rules/manual_dict_comprehension.rs
+++ b/crates/ruff_linter/src/rules/perflint/rules/manual_dict_comprehension.rs
@@ -47,7 +47,7 @@ pub struct ManualDictComprehension;
 impl Violation for ManualDictComprehension {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Use a dictionary comprehension instead of a for-loop")
+        "Use a dictionary comprehension instead of a for-loop".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/perflint/rules/manual_list_comprehension.rs
+++ b/crates/ruff_linter/src/rules/perflint/rules/manual_list_comprehension.rs
@@ -51,10 +51,10 @@ pub struct ManualListComprehension {
 impl Violation for ManualListComprehension {
     #[derive_message_formats]
     fn message(&self) -> String {
-        let ManualListComprehension { is_async } = self;
-        match is_async {
-            false => format!("Use a list comprehension to create a transformed list"),
-            true => format!("Use an async list comprehension to create a transformed list"),
+        if self.is_async {
+            "Use an async list comprehension to create a transformed list".to_string()
+        } else {
+            "Use a list comprehension to create a transformed list".to_string()
         }
     }
 }

--- a/crates/ruff_linter/src/rules/perflint/rules/manual_list_copy.rs
+++ b/crates/ruff_linter/src/rules/perflint/rules/manual_list_copy.rs
@@ -40,7 +40,7 @@ pub struct ManualListCopy;
 impl Violation for ManualListCopy {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Use `list` or `list.copy` to create a copy of a list")
+        "Use `list` or `list.copy` to create a copy of a list".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/perflint/rules/try_except_in_loop.rs
+++ b/crates/ruff_linter/src/rules/perflint/rules/try_except_in_loop.rs
@@ -83,7 +83,7 @@ pub struct TryExceptInLoop;
 impl Violation for TryExceptInLoop {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("`try`-`except` within a loop incurs performance overhead")
+        "`try`-`except` within a loop incurs performance overhead".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/perflint/rules/unnecessary_list_cast.rs
+++ b/crates/ruff_linter/src/rules/perflint/rules/unnecessary_list_cast.rs
@@ -41,7 +41,7 @@ pub struct UnnecessaryListCast;
 impl AlwaysFixableViolation for UnnecessaryListCast {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Do not cast an iterable to `list` before iterating over it")
+        "Do not cast an iterable to `list` before iterating over it".to_string()
     }
 
     fn fix_title(&self) -> String {

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/bare_except.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/bare_except.rs
@@ -50,7 +50,7 @@ pub struct BareExcept;
 impl Violation for BareExcept {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Do not use bare `except`")
+        "Do not use bare `except`".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/blank_lines.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/blank_lines.rs
@@ -341,7 +341,7 @@ pub struct BlankLinesBeforeNestedDefinition;
 impl AlwaysFixableViolation for BlankLinesBeforeNestedDefinition {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Expected 1 blank line before a nested definition, found 0")
+        "Expected 1 blank line before a nested definition, found 0".to_string()
     }
 
     fn fix_title(&self) -> String {

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/compound_statements.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/compound_statements.rs
@@ -33,7 +33,7 @@ pub struct MultipleStatementsOnOneLineColon;
 impl Violation for MultipleStatementsOnOneLineColon {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Multiple statements on one line (colon)")
+        "Multiple statements on one line (colon)".to_string()
     }
 }
 
@@ -63,7 +63,7 @@ pub struct MultipleStatementsOnOneLineSemicolon;
 impl Violation for MultipleStatementsOnOneLineSemicolon {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Multiple statements on one line (semicolon)")
+        "Multiple statements on one line (semicolon)".to_string()
     }
 }
 
@@ -88,11 +88,11 @@ pub struct UselessSemicolon;
 impl AlwaysFixableViolation for UselessSemicolon {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Statement ends with an unnecessary semicolon")
+        "Statement ends with an unnecessary semicolon".to_string()
     }
 
     fn fix_title(&self) -> String {
-        format!("Remove unnecessary semicolon")
+        "Remove unnecessary semicolon".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/lambda_assignment.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/lambda_assignment.rs
@@ -44,7 +44,7 @@ impl Violation for LambdaAssignment {
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Do not assign a `lambda` expression, use a `def`")
+        "Do not assign a `lambda` expression, use a `def`".to_string()
     }
 
     fn fix_title(&self) -> Option<String> {

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/literal_comparisons.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/literal_comparisons.rs
@@ -65,17 +65,18 @@ impl AlwaysFixableViolation for NoneComparison {
     fn message(&self) -> String {
         let NoneComparison(op) = self;
         match op {
-            EqCmpOp::Eq => format!("Comparison to `None` should be `cond is None`"),
-            EqCmpOp::NotEq => format!("Comparison to `None` should be `cond is not None`"),
+            EqCmpOp::Eq => "Comparison to `None` should be `cond is None`".to_string(),
+            EqCmpOp::NotEq => "Comparison to `None` should be `cond is not None`".to_string(),
         }
     }
 
     fn fix_title(&self) -> String {
         let NoneComparison(op) = self;
-        match op {
-            EqCmpOp::Eq => "Replace with `cond is None`".to_string(),
-            EqCmpOp::NotEq => "Replace with `cond is not None`".to_string(),
-        }
+        let title = match op {
+            EqCmpOp::Eq => "Replace with `cond is None`",
+            EqCmpOp::NotEq => "Replace with `cond is not None`",
+        };
+        title.to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/logical_lines/indentation.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/logical_lines/indentation.rs
@@ -118,7 +118,7 @@ pub struct NoIndentedBlock;
 impl Violation for NoIndentedBlock {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Expected an indented block")
+        "Expected an indented block".to_string()
     }
 }
 
@@ -150,7 +150,7 @@ pub struct NoIndentedBlockComment;
 impl Violation for NoIndentedBlockComment {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Expected an indented block (comment)")
+        "Expected an indented block (comment)".to_string()
     }
 }
 
@@ -179,7 +179,7 @@ pub struct UnexpectedIndentation;
 impl Violation for UnexpectedIndentation {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Unexpected indentation")
+        "Unexpected indentation".to_string()
     }
 }
 
@@ -208,7 +208,7 @@ pub struct UnexpectedIndentationComment;
 impl Violation for UnexpectedIndentationComment {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Unexpected indentation (comment)")
+        "Unexpected indentation (comment)".to_string()
     }
 }
 
@@ -241,11 +241,10 @@ pub struct OverIndented {
 impl Violation for OverIndented {
     #[derive_message_formats]
     fn message(&self) -> String {
-        let OverIndented { is_comment } = self;
-        if *is_comment {
-            format!("Over-indented (comment)")
+        if self.is_comment {
+            "Over-indented (comment)".to_string()
         } else {
-            format!("Over-indented")
+            "Over-indented".to_string()
         }
     }
 }

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/logical_lines/missing_whitespace_after_keyword.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/logical_lines/missing_whitespace_after_keyword.rs
@@ -32,7 +32,7 @@ pub struct MissingWhitespaceAfterKeyword;
 impl AlwaysFixableViolation for MissingWhitespaceAfterKeyword {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Missing whitespace after keyword")
+        "Missing whitespace after keyword".to_string()
     }
 
     fn fix_title(&self) -> String {

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/logical_lines/missing_whitespace_around_operator.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/logical_lines/missing_whitespace_around_operator.rs
@@ -34,7 +34,7 @@ pub struct MissingWhitespaceAroundOperator;
 impl AlwaysFixableViolation for MissingWhitespaceAroundOperator {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Missing whitespace around operator")
+        "Missing whitespace around operator".to_string()
     }
 
     fn fix_title(&self) -> String {
@@ -67,11 +67,11 @@ pub struct MissingWhitespaceAroundArithmeticOperator;
 impl AlwaysFixableViolation for MissingWhitespaceAroundArithmeticOperator {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Missing whitespace around arithmetic operator")
+        "Missing whitespace around arithmetic operator".to_string()
     }
 
     fn fix_title(&self) -> String {
-        format!("Add missing whitespace")
+        "Add missing whitespace".to_string()
     }
 }
 
@@ -100,11 +100,11 @@ pub struct MissingWhitespaceAroundBitwiseOrShiftOperator;
 impl AlwaysFixableViolation for MissingWhitespaceAroundBitwiseOrShiftOperator {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Missing whitespace around bitwise or shift operator")
+        "Missing whitespace around bitwise or shift operator".to_string()
     }
 
     fn fix_title(&self) -> String {
-        format!("Add missing whitespace")
+        "Add missing whitespace".to_string()
     }
 }
 
@@ -133,11 +133,11 @@ pub struct MissingWhitespaceAroundModuloOperator;
 impl AlwaysFixableViolation for MissingWhitespaceAroundModuloOperator {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Missing whitespace around modulo operator")
+        "Missing whitespace around modulo operator".to_string()
     }
 
     fn fix_title(&self) -> String {
-        format!("Add missing whitespace")
+        "Add missing whitespace".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/logical_lines/redundant_backslash.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/logical_lines/redundant_backslash.rs
@@ -35,7 +35,7 @@ pub struct RedundantBackslash;
 impl AlwaysFixableViolation for RedundantBackslash {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Redundant backslash")
+        "Redundant backslash".to_string()
     }
 
     fn fix_title(&self) -> String {

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/logical_lines/space_around_operator.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/logical_lines/space_around_operator.rs
@@ -31,7 +31,7 @@ pub struct TabBeforeOperator;
 impl AlwaysFixableViolation for TabBeforeOperator {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Tab before operator")
+        "Tab before operator".to_string()
     }
 
     fn fix_title(&self) -> String {
@@ -63,11 +63,11 @@ pub struct MultipleSpacesBeforeOperator;
 impl AlwaysFixableViolation for MultipleSpacesBeforeOperator {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Multiple spaces before operator")
+        "Multiple spaces before operator".to_string()
     }
 
     fn fix_title(&self) -> String {
-        format!("Replace with single space")
+        "Replace with single space".to_string()
     }
 }
 
@@ -95,11 +95,11 @@ pub struct TabAfterOperator;
 impl AlwaysFixableViolation for TabAfterOperator {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Tab after operator")
+        "Tab after operator".to_string()
     }
 
     fn fix_title(&self) -> String {
-        format!("Replace with single space")
+        "Replace with single space".to_string()
     }
 }
 
@@ -127,11 +127,11 @@ pub struct MultipleSpacesAfterOperator;
 impl AlwaysFixableViolation for MultipleSpacesAfterOperator {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Multiple spaces after operator")
+        "Multiple spaces after operator".to_string()
     }
 
     fn fix_title(&self) -> String {
-        format!("Replace with single space")
+        "Replace with single space".to_string()
     }
 }
 
@@ -157,11 +157,11 @@ pub struct TabAfterComma;
 impl AlwaysFixableViolation for TabAfterComma {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Tab after comma")
+        "Tab after comma".to_string()
     }
 
     fn fix_title(&self) -> String {
-        format!("Replace with single space")
+        "Replace with single space".to_string()
     }
 }
 
@@ -186,11 +186,11 @@ pub struct MultipleSpacesAfterComma;
 impl AlwaysFixableViolation for MultipleSpacesAfterComma {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Multiple spaces after comma")
+        "Multiple spaces after comma".to_string()
     }
 
     fn fix_title(&self) -> String {
-        format!("Replace with single space")
+        "Replace with single space".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/logical_lines/whitespace_around_keywords.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/logical_lines/whitespace_around_keywords.rs
@@ -27,7 +27,7 @@ pub struct MultipleSpacesAfterKeyword;
 impl AlwaysFixableViolation for MultipleSpacesAfterKeyword {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Multiple spaces after keyword")
+        "Multiple spaces after keyword".to_string()
     }
 
     fn fix_title(&self) -> String {
@@ -56,11 +56,11 @@ pub struct MultipleSpacesBeforeKeyword;
 impl AlwaysFixableViolation for MultipleSpacesBeforeKeyword {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Multiple spaces before keyword")
+        "Multiple spaces before keyword".to_string()
     }
 
     fn fix_title(&self) -> String {
-        format!("Replace with single space")
+        "Replace with single space".to_string()
     }
 }
 
@@ -85,11 +85,11 @@ pub struct TabAfterKeyword;
 impl AlwaysFixableViolation for TabAfterKeyword {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Tab after keyword")
+        "Tab after keyword".to_string()
     }
 
     fn fix_title(&self) -> String {
-        format!("Replace with single space")
+        "Replace with single space".to_string()
     }
 }
 
@@ -114,11 +114,11 @@ pub struct TabBeforeKeyword;
 impl AlwaysFixableViolation for TabBeforeKeyword {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Tab before keyword")
+        "Tab before keyword".to_string()
     }
 
     fn fix_title(&self) -> String {
-        format!("Replace with single space")
+        "Replace with single space".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/logical_lines/whitespace_around_named_parameter_equals.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/logical_lines/whitespace_around_named_parameter_equals.rs
@@ -37,7 +37,7 @@ pub struct UnexpectedSpacesAroundKeywordParameterEquals;
 impl AlwaysFixableViolation for UnexpectedSpacesAroundKeywordParameterEquals {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Unexpected spaces around keyword / parameter equals")
+        "Unexpected spaces around keyword / parameter equals".to_string()
     }
 
     fn fix_title(&self) -> String {
@@ -76,11 +76,11 @@ pub struct MissingWhitespaceAroundParameterEquals;
 impl AlwaysFixableViolation for MissingWhitespaceAroundParameterEquals {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Missing whitespace around parameter equals")
+        "Missing whitespace around parameter equals".to_string()
     }
 
     fn fix_title(&self) -> String {
-        format!("Add missing whitespace")
+        "Add missing whitespace".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/logical_lines/whitespace_before_comment.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/logical_lines/whitespace_before_comment.rs
@@ -36,7 +36,7 @@ pub struct TooFewSpacesBeforeInlineComment;
 impl AlwaysFixableViolation for TooFewSpacesBeforeInlineComment {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Insert at least two spaces before an inline comment")
+        "Insert at least two spaces before an inline comment".to_string()
     }
 
     fn fix_title(&self) -> String {
@@ -72,11 +72,11 @@ pub struct NoSpaceAfterInlineComment;
 impl AlwaysFixableViolation for NoSpaceAfterInlineComment {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Inline comment should start with `# `")
+        "Inline comment should start with `# `".to_string()
     }
 
     fn fix_title(&self) -> String {
-        format!("Format space")
+        "Format space".to_string()
     }
 }
 
@@ -109,11 +109,11 @@ pub struct NoSpaceAfterBlockComment;
 impl AlwaysFixableViolation for NoSpaceAfterBlockComment {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Block comment should start with `# `")
+        "Block comment should start with `# `".to_string()
     }
 
     fn fix_title(&self) -> String {
-        format!("Format space")
+        "Format space".to_string()
     }
 }
 
@@ -155,11 +155,11 @@ pub struct MultipleLeadingHashesForBlockComment;
 impl AlwaysFixableViolation for MultipleLeadingHashesForBlockComment {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Too many leading `#` before block comment")
+        "Too many leading `#` before block comment".to_string()
     }
 
     fn fix_title(&self) -> String {
-        format!("Remove leading `#`")
+        "Remove leading `#`".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/missing_newline_at_end_of_file.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/missing_newline_at_end_of_file.rs
@@ -28,7 +28,7 @@ pub struct MissingNewlineAtEndOfFile;
 impl AlwaysFixableViolation for MissingNewlineAtEndOfFile {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("No newline at end of file")
+        "No newline at end of file".to_string()
     }
 
     fn fix_title(&self) -> String {

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/mixed_spaces_and_tabs.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/mixed_spaces_and_tabs.rs
@@ -31,7 +31,7 @@ pub struct MixedSpacesAndTabs;
 impl Violation for MixedSpacesAndTabs {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Indentation contains mixed spaces and tabs")
+        "Indentation contains mixed spaces and tabs".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/module_import_not_at_top_of_file.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/module_import_not_at_top_of_file.rs
@@ -48,9 +48,9 @@ impl Violation for ModuleImportNotAtTopOfFile {
     #[derive_message_formats]
     fn message(&self) -> String {
         if self.source_type.is_ipynb() {
-            format!("Module level import not at top of cell")
+            "Module level import not at top of cell".to_string()
         } else {
-            format!("Module level import not at top of file")
+            "Module level import not at top of file".to_string()
         }
     }
 }

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/multiple_imports_on_one_line.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/multiple_imports_on_one_line.rs
@@ -38,7 +38,7 @@ impl Violation for MultipleImportsOnOneLine {
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Multiple imports on one line")
+        "Multiple imports on one line".to_string()
     }
 
     fn fix_title(&self) -> Option<String> {

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/not_tests.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/not_tests.rs
@@ -33,7 +33,7 @@ pub struct NotInTest;
 impl AlwaysFixableViolation for NotInTest {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Test for membership should be `not in`")
+        "Test for membership should be `not in`".to_string()
     }
 
     fn fix_title(&self) -> String {
@@ -69,7 +69,7 @@ pub struct NotIsTest;
 impl AlwaysFixableViolation for NotIsTest {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Test for object identity should be `is not`")
+        "Test for object identity should be `is not`".to_string()
     }
 
     fn fix_title(&self) -> String {

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/tab_indentation.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/tab_indentation.rs
@@ -28,7 +28,7 @@ pub struct TabIndentation;
 impl Violation for TabIndentation {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Indentation contains tabs")
+        "Indentation contains tabs".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/too_many_newlines_at_end_of_file.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/too_many_newlines_at_end_of_file.rs
@@ -28,28 +28,22 @@ pub struct TooManyNewlinesAtEndOfFile {
 impl AlwaysFixableViolation for TooManyNewlinesAtEndOfFile {
     #[derive_message_formats]
     fn message(&self) -> String {
-        let TooManyNewlinesAtEndOfFile {
-            num_trailing_newlines,
-        } = self;
-
         // We expect a single trailing newline; so two trailing newlines is one too many, three
         // trailing newlines is two too many, etc.
-        if *num_trailing_newlines > 2 {
-            format!("Too many newlines at end of file")
+        if self.num_trailing_newlines > 2 {
+            "Too many newlines at end of file".to_string()
         } else {
-            format!("Extra newline at end of file")
+            "Extra newline at end of file".to_string()
         }
     }
 
     fn fix_title(&self) -> String {
-        let TooManyNewlinesAtEndOfFile {
-            num_trailing_newlines,
-        } = self;
-        if *num_trailing_newlines > 2 {
-            "Remove trailing newlines".to_string()
+        let title = if self.num_trailing_newlines > 2 {
+            "Remove trailing newlines"
         } else {
-            "Remove trailing newline".to_string()
-        }
+            "Remove trailing newline"
+        };
+        title.to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/trailing_whitespace.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/trailing_whitespace.rs
@@ -32,7 +32,7 @@ pub struct TrailingWhitespace;
 impl AlwaysFixableViolation for TrailingWhitespace {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Trailing whitespace")
+        "Trailing whitespace".to_string()
     }
 
     fn fix_title(&self) -> String {
@@ -64,7 +64,7 @@ pub struct BlankLineWithWhitespace;
 impl AlwaysFixableViolation for BlankLineWithWhitespace {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Blank line contains whitespace")
+        "Blank line contains whitespace".to_string()
     }
 
     fn fix_title(&self) -> String {

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/type_comparison.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/type_comparison.rs
@@ -54,9 +54,8 @@ pub struct TypeComparison;
 impl Violation for TypeComparison {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!(
-            "Use `is` and `is not` for type comparisons, or `isinstance()` for isinstance checks"
-        )
+        "Use `is` and `is not` for type comparisons, or `isinstance()` for isinstance checks"
+            .to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/whitespace_after_decorator.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/whitespace_after_decorator.rs
@@ -36,7 +36,7 @@ pub struct WhitespaceAfterDecorator;
 impl AlwaysFixableViolation for WhitespaceAfterDecorator {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Whitespace after decorator")
+        "Whitespace after decorator".to_string()
     }
 
     fn fix_title(&self) -> String {

--- a/crates/ruff_linter/src/rules/pydoclint/rules/check_docstring.rs
+++ b/crates/ruff_linter/src/rules/pydoclint/rules/check_docstring.rs
@@ -61,7 +61,7 @@ pub struct DocstringMissingReturns;
 impl Violation for DocstringMissingReturns {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("`return` is not documented in docstring")
+        "`return` is not documented in docstring".to_string()
     }
 
     fn fix_title(&self) -> Option<String> {
@@ -111,11 +111,12 @@ pub struct DocstringExtraneousReturns;
 impl Violation for DocstringExtraneousReturns {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Docstring should not have a returns section because the function doesn't return anything")
+        "Docstring should not have a returns section because the function doesn't return anything"
+            .to_string()
     }
 
     fn fix_title(&self) -> Option<String> {
-        Some(format!("Remove the \"Returns\" section"))
+        Some("Remove the \"Returns\" section".to_string())
     }
 }
 
@@ -162,11 +163,11 @@ pub struct DocstringMissingYields;
 impl Violation for DocstringMissingYields {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("`yield` is not documented in docstring")
+        "`yield` is not documented in docstring".to_string()
     }
 
     fn fix_title(&self) -> Option<String> {
-        Some(format!("Add a \"Yields\" section to the docstring"))
+        Some("Add a \"Yields\" section to the docstring".to_string())
     }
 }
 
@@ -212,11 +213,11 @@ pub struct DocstringExtraneousYields;
 impl Violation for DocstringExtraneousYields {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Docstring has a \"Yields\" section but the function doesn't yield anything")
+        "Docstring has a \"Yields\" section but the function doesn't yield anything".to_string()
     }
 
     fn fix_title(&self) -> Option<String> {
-        Some(format!("Remove the \"Yields\" section"))
+        Some("Remove the \"Yields\" section".to_string())
     }
 }
 

--- a/crates/ruff_linter/src/rules/pydocstyle/rules/backslashes.rs
+++ b/crates/ruff_linter/src/rules/pydocstyle/rules/backslashes.rs
@@ -49,7 +49,7 @@ impl Violation for EscapeSequenceInDocstring {
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!(r#"Use `r"""` if any backslashes in a docstring"#)
+        r#"Use `r"""` if any backslashes in a docstring"#.to_string()
     }
 
     fn fix_title(&self) -> Option<String> {

--- a/crates/ruff_linter/src/rules/pydocstyle/rules/blank_after_summary.rs
+++ b/crates/ruff_linter/src/rules/pydocstyle/rules/blank_after_summary.rs
@@ -52,7 +52,7 @@ impl Violation for BlankLineAfterSummary {
     fn message(&self) -> String {
         let BlankLineAfterSummary { num_lines } = self;
         if *num_lines == 0 {
-            format!("1 blank line required between summary line and description")
+            "1 blank line required between summary line and description".to_string()
         } else {
             format!(
                 "1 blank line required between summary line and description (found {num_lines})"

--- a/crates/ruff_linter/src/rules/pydocstyle/rules/blank_before_after_class.rs
+++ b/crates/ruff_linter/src/rules/pydocstyle/rules/blank_before_after_class.rs
@@ -48,7 +48,7 @@ pub struct OneBlankLineBeforeClass;
 impl AlwaysFixableViolation for OneBlankLineBeforeClass {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("1 blank line required before class docstring")
+        "1 blank line required before class docstring".to_string()
     }
 
     fn fix_title(&self) -> String {
@@ -100,7 +100,7 @@ pub struct OneBlankLineAfterClass;
 impl AlwaysFixableViolation for OneBlankLineAfterClass {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("1 blank line required after class docstring")
+        "1 blank line required after class docstring".to_string()
     }
 
     fn fix_title(&self) -> String {
@@ -147,7 +147,7 @@ pub struct BlankLineBeforeClass;
 impl AlwaysFixableViolation for BlankLineBeforeClass {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("No blank lines allowed before class docstring")
+        "No blank lines allowed before class docstring".to_string()
     }
 
     fn fix_title(&self) -> String {

--- a/crates/ruff_linter/src/rules/pydocstyle/rules/ends_with_period.rs
+++ b/crates/ruff_linter/src/rules/pydocstyle/rules/ends_with_period.rs
@@ -54,7 +54,7 @@ impl Violation for EndsInPeriod {
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("First line should end with a period")
+        "First line should end with a period".to_string()
     }
 
     fn fix_title(&self) -> Option<String> {

--- a/crates/ruff_linter/src/rules/pydocstyle/rules/ends_with_punctuation.rs
+++ b/crates/ruff_linter/src/rules/pydocstyle/rules/ends_with_punctuation.rs
@@ -53,7 +53,7 @@ impl Violation for EndsInPunctuation {
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("First line should end with a period, question mark, or exclamation point")
+        "First line should end with a period, question mark, or exclamation point".to_string()
     }
 
     fn fix_title(&self) -> Option<String> {

--- a/crates/ruff_linter/src/rules/pydocstyle/rules/if_needed.rs
+++ b/crates/ruff_linter/src/rules/pydocstyle/rules/if_needed.rs
@@ -72,7 +72,7 @@ pub struct OverloadWithDocstring;
 impl Violation for OverloadWithDocstring {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Function decorated with `@overload` shouldn't contain a docstring")
+        "Function decorated with `@overload` shouldn't contain a docstring".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/pydocstyle/rules/indent.rs
+++ b/crates/ruff_linter/src/rules/pydocstyle/rules/indent.rs
@@ -56,7 +56,7 @@ pub struct IndentWithSpaces;
 impl Violation for IndentWithSpaces {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Docstring should be indented with spaces, not tabs")
+        "Docstring should be indented with spaces, not tabs".to_string()
     }
 }
 
@@ -104,7 +104,7 @@ pub struct UnderIndentation;
 impl AlwaysFixableViolation for UnderIndentation {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Docstring is under-indented")
+        "Docstring is under-indented".to_string()
     }
 
     fn fix_title(&self) -> String {
@@ -156,7 +156,7 @@ pub struct OverIndentation;
 impl AlwaysFixableViolation for OverIndentation {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Docstring is over-indented")
+        "Docstring is over-indented".to_string()
     }
 
     fn fix_title(&self) -> String {

--- a/crates/ruff_linter/src/rules/pydocstyle/rules/multi_line_summary_start.rs
+++ b/crates/ruff_linter/src/rules/pydocstyle/rules/multi_line_summary_start.rs
@@ -64,7 +64,7 @@ pub struct MultiLineSummaryFirstLine;
 impl AlwaysFixableViolation for MultiLineSummaryFirstLine {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Multi-line docstring summary should start at the first line")
+        "Multi-line docstring summary should start at the first line".to_string()
     }
 
     fn fix_title(&self) -> String {
@@ -127,7 +127,7 @@ pub struct MultiLineSummarySecondLine;
 impl AlwaysFixableViolation for MultiLineSummarySecondLine {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Multi-line docstring summary should start at the second line")
+        "Multi-line docstring summary should start at the second line".to_string()
     }
 
     fn fix_title(&self) -> String {

--- a/crates/ruff_linter/src/rules/pydocstyle/rules/newline_after_last_paragraph.rs
+++ b/crates/ruff_linter/src/rules/pydocstyle/rules/newline_after_last_paragraph.rs
@@ -49,7 +49,7 @@ pub struct NewLineAfterLastParagraph;
 impl AlwaysFixableViolation for NewLineAfterLastParagraph {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Multi-line docstring closing quotes should be on a separate line")
+        "Multi-line docstring closing quotes should be on a separate line".to_string()
     }
 
     fn fix_title(&self) -> String {

--- a/crates/ruff_linter/src/rules/pydocstyle/rules/no_signature.rs
+++ b/crates/ruff_linter/src/rules/pydocstyle/rules/no_signature.rs
@@ -46,7 +46,7 @@ pub struct NoSignature;
 impl Violation for NoSignature {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("First line should not be the function's signature")
+        "First line should not be the function's signature".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/pydocstyle/rules/no_surrounding_whitespace.rs
+++ b/crates/ruff_linter/src/rules/pydocstyle/rules/no_surrounding_whitespace.rs
@@ -39,7 +39,7 @@ impl Violation for SurroundingWhitespace {
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("No whitespaces allowed surrounding docstring text")
+        "No whitespaces allowed surrounding docstring text".to_string()
     }
 
     fn fix_title(&self) -> Option<String> {

--- a/crates/ruff_linter/src/rules/pydocstyle/rules/not_empty.rs
+++ b/crates/ruff_linter/src/rules/pydocstyle/rules/not_empty.rs
@@ -35,7 +35,7 @@ pub struct EmptyDocstring;
 impl Violation for EmptyDocstring {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Docstring is empty")
+        "Docstring is empty".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/pydocstyle/rules/not_missing.rs
+++ b/crates/ruff_linter/src/rules/pydocstyle/rules/not_missing.rs
@@ -67,7 +67,7 @@ pub struct UndocumentedPublicModule;
 impl Violation for UndocumentedPublicModule {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Missing docstring in public module")
+        "Missing docstring in public module".to_string()
     }
 }
 
@@ -150,7 +150,7 @@ pub struct UndocumentedPublicClass;
 impl Violation for UndocumentedPublicClass {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Missing docstring in public class")
+        "Missing docstring in public class".to_string()
     }
 }
 
@@ -232,7 +232,7 @@ pub struct UndocumentedPublicMethod;
 impl Violation for UndocumentedPublicMethod {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Missing docstring in public method")
+        "Missing docstring in public method".to_string()
     }
 }
 
@@ -322,7 +322,7 @@ pub struct UndocumentedPublicFunction;
 impl Violation for UndocumentedPublicFunction {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Missing docstring in public function")
+        "Missing docstring in public function".to_string()
     }
 }
 
@@ -365,7 +365,7 @@ pub struct UndocumentedPublicPackage;
 impl Violation for UndocumentedPublicPackage {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Missing docstring in public package")
+        "Missing docstring in public package".to_string()
     }
 }
 
@@ -422,7 +422,7 @@ pub struct UndocumentedMagicMethod;
 impl Violation for UndocumentedMagicMethod {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Missing docstring in magic method")
+        "Missing docstring in magic method".to_string()
     }
 }
 
@@ -477,7 +477,7 @@ pub struct UndocumentedPublicNestedClass;
 impl Violation for UndocumentedPublicNestedClass {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Missing docstring in public nested class")
+        "Missing docstring in public nested class".to_string()
     }
 }
 
@@ -525,7 +525,7 @@ pub struct UndocumentedPublicInit;
 impl Violation for UndocumentedPublicInit {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Missing docstring in `__init__`")
+        "Missing docstring in `__init__`".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/pydocstyle/rules/one_liner.rs
+++ b/crates/ruff_linter/src/rules/pydocstyle/rules/one_liner.rs
@@ -40,7 +40,7 @@ impl Violation for FitsOnOneLine {
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("One-line docstring should fit on one line")
+        "One-line docstring should fit on one line".to_string()
     }
 
     fn fix_title(&self) -> Option<String> {

--- a/crates/ruff_linter/src/rules/pydocstyle/rules/starts_with_this.rs
+++ b/crates/ruff_linter/src/rules/pydocstyle/rules/starts_with_this.rs
@@ -45,7 +45,7 @@ pub struct DocstringStartsWithThis;
 impl Violation for DocstringStartsWithThis {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!(r#"First word of the docstring should not be "This""#)
+        r#"First word of the docstring should not be "This""#.to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/pydocstyle/rules/triple_quotes.rs
+++ b/crates/ruff_linter/src/rules/pydocstyle/rules/triple_quotes.rs
@@ -47,10 +47,9 @@ impl Violation for TripleSingleQuotes {
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        let TripleSingleQuotes { expected_quote } = self;
-        match expected_quote {
-            Quote::Double => format!(r#"Use triple double quotes `"""`"#),
-            Quote::Single => format!(r"Use triple single quotes `'''`"),
+        match self.expected_quote {
+            Quote::Double => r#"Use triple double quotes `"""`"#.to_string(),
+            Quote::Single => r"Use triple single quotes `'''`".to_string(),
         }
     }
 

--- a/crates/ruff_linter/src/rules/pyflakes/rules/assert_tuple.rs
+++ b/crates/ruff_linter/src/rules/pyflakes/rules/assert_tuple.rs
@@ -33,7 +33,7 @@ pub struct AssertTuple;
 impl Violation for AssertTuple {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Assert test is a non-empty tuple, which is always `True`")
+        "Assert test is a non-empty tuple, which is always `True`".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/pyflakes/rules/break_outside_loop.rs
+++ b/crates/ruff_linter/src/rules/pyflakes/rules/break_outside_loop.rs
@@ -25,7 +25,7 @@ pub struct BreakOutsideLoop;
 impl Violation for BreakOutsideLoop {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("`break` outside loop")
+        "`break` outside loop".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/pyflakes/rules/continue_outside_loop.rs
+++ b/crates/ruff_linter/src/rules/pyflakes/rules/continue_outside_loop.rs
@@ -25,7 +25,7 @@ pub struct ContinueOutsideLoop;
 impl Violation for ContinueOutsideLoop {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("`continue` not properly in loop")
+        "`continue` not properly in loop".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/pyflakes/rules/default_except_not_last.rs
+++ b/crates/ruff_linter/src/rules/pyflakes/rules/default_except_not_last.rs
@@ -49,7 +49,7 @@ pub struct DefaultExceptNotLast;
 impl Violation for DefaultExceptNotLast {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("An `except` block as not the last exception handler")
+        "An `except` block as not the last exception handler".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/pyflakes/rules/f_string_missing_placeholders.rs
+++ b/crates/ruff_linter/src/rules/pyflakes/rules/f_string_missing_placeholders.rs
@@ -59,7 +59,7 @@ pub struct FStringMissingPlaceholders;
 impl AlwaysFixableViolation for FStringMissingPlaceholders {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("f-string without any placeholders")
+        "f-string without any placeholders".to_string()
     }
 
     fn fix_title(&self) -> String {

--- a/crates/ruff_linter/src/rules/pyflakes/rules/if_tuple.rs
+++ b/crates/ruff_linter/src/rules/pyflakes/rules/if_tuple.rs
@@ -34,7 +34,7 @@ pub struct IfTuple;
 impl Violation for IfTuple {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("If test is a tuple, which is always `True`")
+        "If test is a tuple, which is always `True`".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/pyflakes/rules/imports.rs
+++ b/crates/ruff_linter/src/rules/pyflakes/rules/imports.rs
@@ -114,7 +114,7 @@ pub struct LateFutureImport;
 impl Violation for LateFutureImport {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("`from __future__` imports must occur at the beginning of the file")
+        "`from __future__` imports must occur at the beginning of the file".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/pyflakes/rules/invalid_literal_comparisons.rs
+++ b/crates/ruff_linter/src/rules/pyflakes/rules/invalid_literal_comparisons.rs
@@ -58,19 +58,18 @@ pub struct IsLiteral {
 impl AlwaysFixableViolation for IsLiteral {
     #[derive_message_formats]
     fn message(&self) -> String {
-        let IsLiteral { cmp_op } = self;
-        match cmp_op {
-            IsCmpOp::Is => format!("Use `==` to compare constant literals"),
-            IsCmpOp::IsNot => format!("Use `!=` to compare constant literals"),
+        match self.cmp_op {
+            IsCmpOp::Is => "Use `==` to compare constant literals".to_string(),
+            IsCmpOp::IsNot => "Use `!=` to compare constant literals".to_string(),
         }
     }
 
     fn fix_title(&self) -> String {
-        let IsLiteral { cmp_op } = self;
-        match cmp_op {
-            IsCmpOp::Is => "Replace `is` with `==`".to_string(),
-            IsCmpOp::IsNot => "Replace `is not` with `!=`".to_string(),
-        }
+        let title = match self.cmp_op {
+            IsCmpOp::Is => "Replace `is` with `==`",
+            IsCmpOp::IsNot => "Replace `is not` with `!=`",
+        };
+        title.to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/pyflakes/rules/invalid_print_syntax.rs
+++ b/crates/ruff_linter/src/rules/pyflakes/rules/invalid_print_syntax.rs
@@ -52,7 +52,7 @@ pub struct InvalidPrintSyntax;
 impl Violation for InvalidPrintSyntax {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Use of `>>` is invalid with `print` function")
+        "Use of `>>` is invalid with `print` function".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/pyflakes/rules/raise_not_implemented.rs
+++ b/crates/ruff_linter/src/rules/pyflakes/rules/raise_not_implemented.rs
@@ -42,7 +42,7 @@ impl Violation for RaiseNotImplemented {
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("`raise NotImplemented` should be `raise NotImplementedError`")
+        "`raise NotImplemented` should be `raise NotImplementedError`".to_string()
     }
 
     fn fix_title(&self) -> Option<String> {

--- a/crates/ruff_linter/src/rules/pyflakes/rules/repeated_keys.rs
+++ b/crates/ruff_linter/src/rules/pyflakes/rules/repeated_keys.rs
@@ -53,8 +53,7 @@ impl Violation for MultiValueRepeatedKeyLiteral {
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        let MultiValueRepeatedKeyLiteral { name, existing } = self;
-        match (name.full_display(), existing.full_display()) {
+        match (self.name.full_display(), self.existing.full_display()) {
             (Some(name), None) => {
                 format!("Dictionary key literal `{name}` repeated")
             }
@@ -67,7 +66,7 @@ impl Violation for MultiValueRepeatedKeyLiteral {
                     )
                 }
             }
-            _ => format!("Dictionary key literal repeated"),
+            _ => "Dictionary key literal repeated".to_string(),
         }
     }
 
@@ -119,11 +118,10 @@ impl Violation for MultiValueRepeatedKeyVariable {
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        let MultiValueRepeatedKeyVariable { name } = self;
-        if let Some(name) = name.full_display() {
+        if let Some(name) = self.name.full_display() {
             format!("Dictionary key `{name}` repeated")
         } else {
-            format!("Dictionary key repeated")
+            "Dictionary key repeated".to_string()
         }
     }
 

--- a/crates/ruff_linter/src/rules/pyflakes/rules/return_outside_function.rs
+++ b/crates/ruff_linter/src/rules/pyflakes/rules/return_outside_function.rs
@@ -28,7 +28,7 @@ pub struct ReturnOutsideFunction;
 impl Violation for ReturnOutsideFunction {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("`return` statement outside of a function/method")
+        "`return` statement outside of a function/method".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/pyflakes/rules/starred_expressions.rs
+++ b/crates/ruff_linter/src/rules/pyflakes/rules/starred_expressions.rs
@@ -19,7 +19,7 @@ pub struct ExpressionsInStarAssignment;
 impl Violation for ExpressionsInStarAssignment {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Too many expressions in star-unpacking assignment")
+        "Too many expressions in star-unpacking assignment".to_string()
     }
 }
 
@@ -45,7 +45,7 @@ pub struct MultipleStarredExpressions;
 impl Violation for MultipleStarredExpressions {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Two starred expressions in assignment")
+        "Two starred expressions in assignment".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/pyflakes/rules/strings.rs
+++ b/crates/ruff_linter/src/rules/pyflakes/rules/strings.rs
@@ -81,7 +81,7 @@ pub struct PercentFormatExpectedMapping;
 impl Violation for PercentFormatExpectedMapping {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("`%`-format string expected mapping but got sequence")
+        "`%`-format string expected mapping but got sequence".to_string()
     }
 }
 
@@ -117,7 +117,7 @@ pub struct PercentFormatExpectedSequence;
 impl Violation for PercentFormatExpectedSequence {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("`%`-format string expected sequence but got mapping")
+        "`%`-format string expected sequence but got mapping".to_string()
     }
 }
 
@@ -226,7 +226,7 @@ pub struct PercentFormatMixedPositionalAndNamed;
 impl Violation for PercentFormatMixedPositionalAndNamed {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("`%`-format string has mixed positional and named placeholders")
+        "`%`-format string has mixed positional and named placeholders".to_string()
     }
 }
 
@@ -294,7 +294,7 @@ pub struct PercentFormatStarRequiresSequence;
 impl Violation for PercentFormatStarRequiresSequence {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("`%`-format string `*` specifier requires sequence")
+        "`%`-format string `*` specifier requires sequence".to_string()
     }
 }
 
@@ -509,7 +509,7 @@ pub struct StringDotFormatMixingAutomatic;
 impl Violation for StringDotFormatMixingAutomatic {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("`.format` string mixes automatic and manual numbering")
+        "`.format` string mixes automatic and manual numbering".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/pygrep_hooks/rules/blanket_noqa.rs
+++ b/crates/ruff_linter/src/rules/pygrep_hooks/rules/blanket_noqa.rs
@@ -55,13 +55,18 @@ impl Violation for BlanketNOQA {
 
     #[derive_message_formats]
     fn message(&self) -> String {
+        let BlanketNOQA {
+            missing_colon,
+            space_before_colon,
+            file_exemption,
+        } = self;
         // This awkward branching is necessary to ensure that the generic message is picked up by
         // `derive_message_formats`.
-        if !self.missing_colon && !self.space_before_colon && !self.file_exemption {
+        if !missing_colon && !space_before_colon && !file_exemption {
             "Use specific rule codes when using `noqa`".to_string()
-        } else if self.file_exemption {
+        } else if *file_exemption {
             "Use specific rule codes when using `ruff: noqa`".to_string()
-        } else if self.missing_colon {
+        } else if *missing_colon {
             "Use a colon when specifying `noqa` rule codes".to_string()
         } else {
             "Do not add spaces between `noqa` and its colon".to_string()

--- a/crates/ruff_linter/src/rules/pygrep_hooks/rules/blanket_noqa.rs
+++ b/crates/ruff_linter/src/rules/pygrep_hooks/rules/blanket_noqa.rs
@@ -55,35 +55,23 @@ impl Violation for BlanketNOQA {
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        let BlanketNOQA {
-            missing_colon,
-            space_before_colon,
-            file_exemption,
-        } = self;
-
         // This awkward branching is necessary to ensure that the generic message is picked up by
         // `derive_message_formats`.
-        if !missing_colon && !space_before_colon && !file_exemption {
-            format!("Use specific rule codes when using `noqa`")
-        } else if *file_exemption {
-            format!("Use specific rule codes when using `ruff: noqa`")
-        } else if *missing_colon {
-            format!("Use a colon when specifying `noqa` rule codes")
+        if !self.missing_colon && !self.space_before_colon && !self.file_exemption {
+            "Use specific rule codes when using `noqa`".to_string()
+        } else if self.file_exemption {
+            "Use specific rule codes when using `ruff: noqa`".to_string()
+        } else if self.missing_colon {
+            "Use a colon when specifying `noqa` rule codes".to_string()
         } else {
-            format!("Do not add spaces between `noqa` and its colon")
+            "Do not add spaces between `noqa` and its colon".to_string()
         }
     }
 
     fn fix_title(&self) -> Option<String> {
-        let BlanketNOQA {
-            missing_colon,
-            space_before_colon,
-            ..
-        } = self;
-
-        if *missing_colon {
+        if self.missing_colon {
             Some("Add missing colon".to_string())
-        } else if *space_before_colon {
+        } else if self.space_before_colon {
             Some("Remove space(s) before colon".to_string())
         } else {
             None

--- a/crates/ruff_linter/src/rules/pygrep_hooks/rules/blanket_type_ignore.rs
+++ b/crates/ruff_linter/src/rules/pygrep_hooks/rules/blanket_type_ignore.rs
@@ -46,7 +46,7 @@ pub struct BlanketTypeIgnore;
 impl Violation for BlanketTypeIgnore {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Use specific rule codes when ignoring type issues")
+        "Use specific rule codes when ignoring type issues".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/pygrep_hooks/rules/deprecated_log_warn.rs
+++ b/crates/ruff_linter/src/rules/pygrep_hooks/rules/deprecated_log_warn.rs
@@ -41,7 +41,7 @@ impl Violation for DeprecatedLogWarn {
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("`warn` is deprecated in favor of `warning`")
+        "`warn` is deprecated in favor of `warning`".to_string()
     }
 
     fn fix_title(&self) -> Option<String> {

--- a/crates/ruff_linter/src/rules/pygrep_hooks/rules/no_eval.rs
+++ b/crates/ruff_linter/src/rules/pygrep_hooks/rules/no_eval.rs
@@ -36,6 +36,6 @@ pub struct Eval;
 impl Violation for Eval {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("No builtin `eval()` allowed")
+        "No builtin `eval()` allowed".to_string()
     }
 }

--- a/crates/ruff_linter/src/rules/pylint/rules/assert_on_string_literal.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/assert_on_string_literal.rs
@@ -33,11 +33,14 @@ pub struct AssertOnStringLiteral {
 impl Violation for AssertOnStringLiteral {
     #[derive_message_formats]
     fn message(&self) -> String {
-        let AssertOnStringLiteral { kind } = self;
-        match kind {
-            Kind::Empty => format!("Asserting on an empty string literal will never pass"),
-            Kind::NonEmpty => format!("Asserting on a non-empty string literal will always pass"),
-            Kind::Unknown => format!("Asserting on a string literal may have unintended results"),
+        match self.kind {
+            Kind::Empty => "Asserting on an empty string literal will never pass".to_string(),
+            Kind::NonEmpty => {
+                "Asserting on a non-empty string literal will always pass".to_string()
+            }
+            Kind::Unknown => {
+                "Asserting on a string literal may have unintended results".to_string()
+            }
         }
     }
 }

--- a/crates/ruff_linter/src/rules/pylint/rules/await_outside_async.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/await_outside_async.rs
@@ -39,7 +39,7 @@ pub struct AwaitOutsideAsync;
 impl Violation for AwaitOutsideAsync {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("`await` should be used within an async function")
+        "`await` should be used within an async function".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/pylint/rules/bad_string_format_type.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/bad_string_format_type.rs
@@ -33,7 +33,7 @@ pub struct BadStringFormatType;
 impl Violation for BadStringFormatType {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Format type does not match argument type")
+        "Format type does not match argument type".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/pylint/rules/bidirectional_unicode.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/bidirectional_unicode.rs
@@ -47,7 +47,7 @@ pub struct BidirectionalUnicode;
 impl Violation for BidirectionalUnicode {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Contains control characters that can permit obfuscated code")
+        "Contains control characters that can permit obfuscated code".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/pylint/rules/binary_op_exception.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/binary_op_exception.rs
@@ -54,10 +54,11 @@ pub struct BinaryOpException {
 impl Violation for BinaryOpException {
     #[derive_message_formats]
     fn message(&self) -> String {
-        let BinaryOpException { op } = self;
-        match op {
-            BoolOp::And => format!("Exception to catch is the result of a binary `and` operation"),
-            BoolOp::Or => format!("Exception to catch is the result of a binary `or` operation"),
+        match self.op {
+            BoolOp::And => {
+                "Exception to catch is the result of a binary `and` operation".to_string()
+            }
+            BoolOp::Or => "Exception to catch is the result of a binary `or` operation".to_string(),
         }
     }
 }

--- a/crates/ruff_linter/src/rules/pylint/rules/boolean_chained_comparison.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/boolean_chained_comparison.rs
@@ -43,7 +43,7 @@ impl Violation for BooleanChainedComparison {
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Contains chained boolean comparison that can be simplified")
+        "Contains chained boolean comparison that can be simplified".to_string()
     }
 
     fn fix_title(&self) -> Option<String> {

--- a/crates/ruff_linter/src/rules/pylint/rules/collapsible_else_if.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/collapsible_else_if.rs
@@ -53,7 +53,7 @@ impl Violation for CollapsibleElseIf {
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Use `elif` instead of `else` then `if`, to reduce indentation")
+        "Use `elif` instead of `else` then `if`, to reduce indentation".to_string()
     }
 
     fn fix_title(&self) -> Option<String> {

--- a/crates/ruff_linter/src/rules/pylint/rules/comparison_with_itself.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/comparison_with_itself.rs
@@ -38,11 +38,10 @@ pub struct ComparisonWithItself {
 impl Violation for ComparisonWithItself {
     #[derive_message_formats]
     fn message(&self) -> String {
-        let ComparisonWithItself { actual } = self;
-        if let Some(actual) = actual.full_display() {
+        if let Some(actual) = self.actual.full_display() {
             format!("Name compared with itself, consider replacing `{actual}`")
         } else {
-            format!("Name compared with itself")
+            "Name compared with itself".to_string()
         }
     }
 }

--- a/crates/ruff_linter/src/rules/pylint/rules/continue_in_finally.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/continue_in_finally.rs
@@ -42,7 +42,7 @@ pub struct ContinueInFinally;
 impl Violation for ContinueInFinally {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("`continue` not supported inside `finally` clause")
+        "`continue` not supported inside `finally` clause".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/pylint/rules/dict_index_missing_items.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/dict_index_missing_items.rs
@@ -53,7 +53,7 @@ pub struct DictIndexMissingItems;
 impl Violation for DictIndexMissingItems {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Extracting value from dictionary without calling `.items()`")
+        "Extracting value from dictionary without calling `.items()`".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/pylint/rules/dict_iter_missing_items.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/dict_iter_missing_items.rs
@@ -55,7 +55,7 @@ pub struct DictIterMissingItems;
 impl AlwaysFixableViolation for DictIterMissingItems {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Unpacking a dictionary in iteration without calling `.items()`")
+        "Unpacking a dictionary in iteration without calling `.items()`".to_string()
     }
 
     fn fix_title(&self) -> String {

--- a/crates/ruff_linter/src/rules/pylint/rules/empty_comment.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/empty_comment.rs
@@ -35,7 +35,7 @@ impl Violation for EmptyComment {
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Line with empty comment")
+        "Line with empty comment".to_string()
     }
 
     fn fix_title(&self) -> Option<String> {

--- a/crates/ruff_linter/src/rules/pylint/rules/eq_without_hash.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/eq_without_hash.rs
@@ -46,7 +46,7 @@ pub struct EqWithoutHash;
 impl Violation for EqWithoutHash {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Object does not implement `__hash__` method")
+        "Object does not implement `__hash__` method".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/pylint/rules/global_at_module_level.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/global_at_module_level.rs
@@ -20,7 +20,7 @@ pub struct GlobalAtModuleLevel;
 impl Violation for GlobalAtModuleLevel {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("`global` at module level is redundant")
+        "`global` at module level is redundant".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/pylint/rules/import_outside_top_level.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/import_outside_top_level.rs
@@ -48,7 +48,7 @@ pub struct ImportOutsideTopLevel;
 impl Violation for ImportOutsideTopLevel {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("`import` should be at the top-level of a file")
+        "`import` should be at the top-level of a file".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/pylint/rules/invalid_all_format.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/invalid_all_format.rs
@@ -31,7 +31,7 @@ pub struct InvalidAllFormat;
 impl Violation for InvalidAllFormat {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Invalid format for `__all__`, must be `tuple` or `list`")
+        "Invalid format for `__all__`, must be `tuple` or `list`".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/pylint/rules/invalid_all_object.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/invalid_all_object.rs
@@ -31,7 +31,7 @@ pub struct InvalidAllObject;
 impl Violation for InvalidAllObject {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Invalid object in `__all__`, must contain only strings")
+        "Invalid object in `__all__`, must contain only strings".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/pylint/rules/invalid_bool_return.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/invalid_bool_return.rs
@@ -40,7 +40,7 @@ pub struct InvalidBoolReturnType;
 impl Violation for InvalidBoolReturnType {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("`__bool__` does not return `bool`")
+        "`__bool__` does not return `bool`".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/pylint/rules/invalid_bytes_return.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/invalid_bytes_return.rs
@@ -40,7 +40,7 @@ pub struct InvalidBytesReturnType;
 impl Violation for InvalidBytesReturnType {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("`__bytes__` does not return `bytes`")
+        "`__bytes__` does not return `bytes`".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/pylint/rules/invalid_envvar_default.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/invalid_envvar_default.rs
@@ -38,7 +38,7 @@ pub struct InvalidEnvvarDefault;
 impl Violation for InvalidEnvvarDefault {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Invalid type for environment variable default; expected `str` or `None`")
+        "Invalid type for environment variable default; expected `str` or `None`".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/pylint/rules/invalid_envvar_value.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/invalid_envvar_value.rs
@@ -31,7 +31,7 @@ pub struct InvalidEnvvarValue;
 impl Violation for InvalidEnvvarValue {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Invalid type for initial `os.getenv` argument; expected `str`")
+        "Invalid type for initial `os.getenv` argument; expected `str`".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/pylint/rules/invalid_hash_return.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/invalid_hash_return.rs
@@ -44,7 +44,7 @@ pub struct InvalidHashReturnType;
 impl Violation for InvalidHashReturnType {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("`__hash__` does not return an integer")
+        "`__hash__` does not return an integer".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/pylint/rules/invalid_index_return.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/invalid_index_return.rs
@@ -46,7 +46,7 @@ pub struct InvalidIndexReturnType;
 impl Violation for InvalidIndexReturnType {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("`__index__` does not return an integer")
+        "`__index__` does not return an integer".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/pylint/rules/invalid_length_return.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/invalid_length_return.rs
@@ -45,7 +45,7 @@ pub struct InvalidLengthReturnType;
 impl Violation for InvalidLengthReturnType {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("`__len__` does not return a non-negative integer")
+        "`__len__` does not return a non-negative integer".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/pylint/rules/invalid_str_return.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/invalid_str_return.rs
@@ -40,7 +40,7 @@ pub struct InvalidStrReturnType;
 impl Violation for InvalidStrReturnType {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("`__str__` does not return `str`")
+        "`__str__` does not return `str`".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/pylint/rules/invalid_string_characters.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/invalid_string_characters.rs
@@ -32,7 +32,7 @@ pub struct InvalidCharacterBackspace;
 impl AlwaysFixableViolation for InvalidCharacterBackspace {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Invalid unescaped character backspace, use \"\\b\" instead")
+        "Invalid unescaped character backspace, use \"\\b\" instead".to_string()
     }
 
     fn fix_title(&self) -> String {
@@ -65,7 +65,7 @@ pub struct InvalidCharacterSub;
 impl AlwaysFixableViolation for InvalidCharacterSub {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Invalid unescaped character SUB, use \"\\x1A\" instead")
+        "Invalid unescaped character SUB, use \"\\x1A\" instead".to_string()
     }
 
     fn fix_title(&self) -> String {
@@ -98,7 +98,7 @@ pub struct InvalidCharacterEsc;
 impl AlwaysFixableViolation for InvalidCharacterEsc {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Invalid unescaped character ESC, use \"\\x1B\" instead")
+        "Invalid unescaped character ESC, use \"\\x1B\" instead".to_string()
     }
 
     fn fix_title(&self) -> String {
@@ -131,7 +131,7 @@ pub struct InvalidCharacterNul;
 impl AlwaysFixableViolation for InvalidCharacterNul {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Invalid unescaped character NUL, use \"\\0\" instead")
+        "Invalid unescaped character NUL, use \"\\0\" instead".to_string()
     }
 
     fn fix_title(&self) -> String {
@@ -163,7 +163,7 @@ pub struct InvalidCharacterZeroWidthSpace;
 impl AlwaysFixableViolation for InvalidCharacterZeroWidthSpace {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Invalid unescaped character zero-width-space, use \"\\u200B\" instead")
+        "Invalid unescaped character zero-width-space, use \"\\u200B\" instead".to_string()
     }
 
     fn fix_title(&self) -> String {

--- a/crates/ruff_linter/src/rules/pylint/rules/iteration_over_set.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/iteration_over_set.rs
@@ -36,7 +36,7 @@ pub struct IterationOverSet;
 impl AlwaysFixableViolation for IterationOverSet {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Use a sequence type instead of a `set` when iterating over values")
+        "Use a sequence type instead of a `set` when iterating over values".to_string()
     }
 
     fn fix_title(&self) -> String {

--- a/crates/ruff_linter/src/rules/pylint/rules/literal_membership.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/literal_membership.rs
@@ -37,7 +37,7 @@ pub struct LiteralMembership;
 impl AlwaysFixableViolation for LiteralMembership {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Use a set literal when testing for membership")
+        "Use a set literal when testing for membership".to_string()
     }
 
     fn fix_title(&self) -> String {

--- a/crates/ruff_linter/src/rules/pylint/rules/logging.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/logging.rs
@@ -42,7 +42,7 @@ pub struct LoggingTooFewArgs;
 impl Violation for LoggingTooFewArgs {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Not enough arguments for `logging` format string")
+        "Not enough arguments for `logging` format string".to_string()
     }
 }
 
@@ -79,7 +79,7 @@ pub struct LoggingTooManyArgs;
 impl Violation for LoggingTooManyArgs {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Too many arguments for `logging` format string")
+        "Too many arguments for `logging` format string".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/pylint/rules/misplaced_bare_raise.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/misplaced_bare_raise.rs
@@ -46,7 +46,7 @@ pub struct MisplacedBareRaise;
 impl Violation for MisplacedBareRaise {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Bare `raise` statement is not inside an exception handler")
+        "Bare `raise` statement is not inside an exception handler".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/pylint/rules/named_expr_without_context.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/named_expr_without_context.rs
@@ -30,7 +30,7 @@ pub struct NamedExprWithoutContext;
 impl Violation for NamedExprWithoutContext {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Named expression used without context")
+        "Named expression used without context".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/pylint/rules/nan_comparison.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/nan_comparison.rs
@@ -39,10 +39,9 @@ pub struct NanComparison {
 impl Violation for NanComparison {
     #[derive_message_formats]
     fn message(&self) -> String {
-        let NanComparison { nan } = self;
-        match nan {
-            Nan::Math => format!("Comparing against a NaN value; use `math.isnan` instead"),
-            Nan::NumPy => format!("Comparing against a NaN value; use `np.isnan` instead"),
+        match self.nan {
+            Nan::Math => "Comparing against a NaN value; use `math.isnan` instead".to_string(),
+            Nan::NumPy => "Comparing against a NaN value; use `np.isnan` instead".to_string(),
         }
     }
 }

--- a/crates/ruff_linter/src/rules/pylint/rules/no_method_decorator.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/no_method_decorator.rs
@@ -38,7 +38,7 @@ pub struct NoClassmethodDecorator;
 impl AlwaysFixableViolation for NoClassmethodDecorator {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Class method defined without decorator")
+        "Class method defined without decorator".to_string()
     }
 
     fn fix_title(&self) -> String {
@@ -74,11 +74,11 @@ pub struct NoStaticmethodDecorator;
 impl AlwaysFixableViolation for NoStaticmethodDecorator {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Static method defined without decorator")
+        "Static method defined without decorator".to_string()
     }
 
     fn fix_title(&self) -> String {
-        format!("Add @staticmethod decorator")
+        "Add @staticmethod decorator".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/pylint/rules/potential_index_error.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/potential_index_error.rs
@@ -24,7 +24,7 @@ pub struct PotentialIndexError;
 impl Violation for PotentialIndexError {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Expression is likely to raise `IndexError`")
+        "Expression is likely to raise `IndexError`".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/pylint/rules/property_with_parameters.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/property_with_parameters.rs
@@ -40,7 +40,7 @@ pub struct PropertyWithParameters;
 impl Violation for PropertyWithParameters {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Cannot have defined parameters for properties")
+        "Cannot have defined parameters for properties".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/pylint/rules/repeated_equality_comparison.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/repeated_equality_comparison.rs
@@ -50,15 +50,13 @@ pub struct RepeatedEqualityComparison {
 impl AlwaysFixableViolation for RepeatedEqualityComparison {
     #[derive_message_formats]
     fn message(&self) -> String {
-        let RepeatedEqualityComparison { expression } = self;
-        if let Some(expression) = expression.full_display() {
+        if let Some(expression) = self.expression.full_display() {
             format!(
                 "Consider merging multiple comparisons: `{expression}`. Use a `set` if the elements are hashable."
             )
         } else {
-            format!(
-                "Consider merging multiple comparisons. Use a `set` if the elements are hashable."
-            )
+            "Consider merging multiple comparisons. Use a `set` if the elements are hashable."
+                .to_string()
         }
     }
 

--- a/crates/ruff_linter/src/rules/pylint/rules/repeated_isinstance_calls.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/repeated_isinstance_calls.rs
@@ -57,17 +57,15 @@ pub struct RepeatedIsinstanceCalls {
 impl AlwaysFixableViolation for RepeatedIsinstanceCalls {
     #[derive_message_formats]
     fn message(&self) -> String {
-        let RepeatedIsinstanceCalls { expression } = self;
-        if let Some(expression) = expression.full_display() {
+        if let Some(expression) = self.expression.full_display() {
             format!("Merge `isinstance` calls: `{expression}`")
         } else {
-            format!("Merge `isinstance` calls")
+            "Merge `isinstance` calls".to_string()
         }
     }
 
     fn fix_title(&self) -> String {
-        let RepeatedIsinstanceCalls { expression } = self;
-        if let Some(expression) = expression.full_display() {
+        if let Some(expression) = self.expression.full_display() {
             format!("Replace with `{expression}`")
         } else {
             "Replace with merged `isinstance` call".to_string()

--- a/crates/ruff_linter/src/rules/pylint/rules/return_in_init.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/return_in_init.rs
@@ -40,7 +40,7 @@ pub struct ReturnInInit;
 impl Violation for ReturnInInit {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Explicit return in `__init__`")
+        "Explicit return in `__init__`".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/pylint/rules/single_string_slots.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/single_string_slots.rs
@@ -53,7 +53,7 @@ pub struct SingleStringSlots;
 impl Violation for SingleStringSlots {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Class `__slots__` should be a non-string iterable")
+        "Class `__slots__` should be a non-string iterable".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/pylint/rules/singledispatch_method.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/singledispatch_method.rs
@@ -50,7 +50,7 @@ impl Violation for SingledispatchMethod {
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("`@singledispatch` decorator should not be used on methods")
+        "`@singledispatch` decorator should not be used on methods".to_string()
     }
 
     fn fix_title(&self) -> Option<String> {

--- a/crates/ruff_linter/src/rules/pylint/rules/singledispatchmethod_function.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/singledispatchmethod_function.rs
@@ -48,7 +48,7 @@ impl Violation for SingledispatchmethodFunction {
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("`@singledispatchmethod` decorator should not be used on non-method functions")
+        "`@singledispatchmethod` decorator should not be used on non-method functions".to_string()
     }
 
     fn fix_title(&self) -> Option<String> {

--- a/crates/ruff_linter/src/rules/pylint/rules/subprocess_popen_preexec_fn.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/subprocess_popen_preexec_fn.rs
@@ -45,7 +45,7 @@ pub struct SubprocessPopenPreexecFn;
 impl Violation for SubprocessPopenPreexecFn {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("`preexec_fn` argument is unsafe when using threads")
+        "`preexec_fn` argument is unsafe when using threads".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/pylint/rules/subprocess_run_without_check.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/subprocess_run_without_check.rs
@@ -51,7 +51,7 @@ pub struct SubprocessRunWithoutCheck;
 impl AlwaysFixableViolation for SubprocessRunWithoutCheck {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("`subprocess.run` without explicit `check` argument")
+        "`subprocess.run` without explicit `check` argument".to_string()
     }
 
     fn fix_title(&self) -> String {

--- a/crates/ruff_linter/src/rules/pylint/rules/super_without_brackets.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/super_without_brackets.rs
@@ -52,7 +52,7 @@ pub struct SuperWithoutBrackets;
 impl AlwaysFixableViolation for SuperWithoutBrackets {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("`super` call is missing parentheses")
+        "`super` call is missing parentheses".to_string()
     }
 
     fn fix_title(&self) -> String {

--- a/crates/ruff_linter/src/rules/pylint/rules/unnecessary_dict_index_lookup.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/unnecessary_dict_index_lookup.rs
@@ -36,7 +36,7 @@ pub struct UnnecessaryDictIndexLookup;
 impl AlwaysFixableViolation for UnnecessaryDictIndexLookup {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Unnecessary lookup of dictionary value by key")
+        "Unnecessary lookup of dictionary value by key".to_string()
     }
 
     fn fix_title(&self) -> String {

--- a/crates/ruff_linter/src/rules/pylint/rules/unnecessary_direct_lambda_call.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/unnecessary_direct_lambda_call.rs
@@ -31,7 +31,7 @@ pub struct UnnecessaryDirectLambdaCall;
 impl Violation for UnnecessaryDirectLambdaCall {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Lambda expression called directly. Execute the expression inline instead.")
+        "Lambda expression called directly. Execute the expression inline instead.".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/pylint/rules/unnecessary_lambda.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/unnecessary_lambda.rs
@@ -49,7 +49,7 @@ pub struct UnnecessaryLambda;
 impl AlwaysFixableViolation for UnnecessaryLambda {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Lambda may be unnecessary; consider inlining inner function")
+        "Lambda may be unnecessary; consider inlining inner function".to_string()
     }
 
     fn fix_title(&self) -> String {

--- a/crates/ruff_linter/src/rules/pylint/rules/unnecessary_list_index_lookup.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/unnecessary_list_index_lookup.rs
@@ -37,7 +37,7 @@ pub struct UnnecessaryListIndexLookup;
 impl AlwaysFixableViolation for UnnecessaryListIndexLookup {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("List index lookup in `enumerate()` loop")
+        "List index lookup in `enumerate()` loop".to_string()
     }
 
     fn fix_title(&self) -> String {

--- a/crates/ruff_linter/src/rules/pylint/rules/useless_else_on_loop.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/useless_else_on_loop.rs
@@ -51,11 +51,10 @@ pub struct UselessElseOnLoop;
 
 impl Violation for UselessElseOnLoop {
     const FIX_AVAILABILITY: FixAvailability = FixAvailability::Sometimes;
+
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!(
-            "`else` clause on loop without a `break` statement; remove the `else` and dedent its contents"
-        )
+        "`else` clause on loop without a `break` statement; remove the `else` and dedent its contents".to_string()
     }
 
     fn fix_title(&self) -> Option<String> {

--- a/crates/ruff_linter/src/rules/pylint/rules/useless_exception_statement.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/useless_exception_statement.rs
@@ -41,7 +41,7 @@ impl Violation for UselessExceptionStatement {
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Missing `raise` statement on exception")
+        "Missing `raise` statement on exception".to_string()
     }
 
     fn fix_title(&self) -> Option<String> {

--- a/crates/ruff_linter/src/rules/pylint/rules/useless_import_alias.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/useless_import_alias.rs
@@ -27,7 +27,7 @@ pub struct UselessImportAlias;
 impl AlwaysFixableViolation for UselessImportAlias {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Import alias does not rename original package")
+        "Import alias does not rename original package".to_string()
     }
 
     fn fix_title(&self) -> String {

--- a/crates/ruff_linter/src/rules/pylint/rules/useless_return.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/useless_return.rs
@@ -34,7 +34,7 @@ pub struct UselessReturn;
 impl AlwaysFixableViolation for UselessReturn {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Useless `return` statement at end of function")
+        "Useless `return` statement at end of function".to_string()
     }
 
     fn fix_title(&self) -> String {

--- a/crates/ruff_linter/src/rules/pylint/rules/useless_with_lock.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/useless_with_lock.rs
@@ -53,7 +53,7 @@ pub struct UselessWithLock;
 impl Violation for UselessWithLock {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Threading lock directly created in `with` statement has no effect")
+        "Threading lock directly created in `with` statement has no effect".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/pylint/rules/yield_from_in_async_function.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/yield_from_in_async_function.rs
@@ -33,7 +33,7 @@ pub struct YieldFromInAsyncFunction;
 impl Violation for YieldFromInAsyncFunction {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("`yield from` statement in async function; use `async for` instead")
+        "`yield from` statement in async function; use `async for` instead".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/pylint/rules/yield_in_init.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/yield_in_init.rs
@@ -34,7 +34,7 @@ pub struct YieldInInit;
 impl Violation for YieldInInit {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("`__init__` method is a generator")
+        "`__init__` method is a generator".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/datetime_utc_alias.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/datetime_utc_alias.rs
@@ -41,7 +41,7 @@ impl Violation for DatetimeTimezoneUTC {
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Use `datetime.UTC` alias")
+        "Use `datetime.UTC` alias".to_string()
     }
 
     fn fix_title(&self) -> Option<String> {

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/deprecated_c_element_tree.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/deprecated_c_element_tree.rs
@@ -30,7 +30,7 @@ pub struct DeprecatedCElementTree;
 impl AlwaysFixableViolation for DeprecatedCElementTree {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("`cElementTree` is deprecated, use `ElementTree`")
+        "`cElementTree` is deprecated, use `ElementTree`".to_string()
     }
 
     fn fix_title(&self) -> String {

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/deprecated_mock_import.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/deprecated_mock_import.rs
@@ -55,7 +55,7 @@ pub struct DeprecatedMockImport {
 impl AlwaysFixableViolation for DeprecatedMockImport {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("`mock` is deprecated, use `unittest.mock`")
+        "`mock` is deprecated, use `unittest.mock`".to_string()
     }
 
     fn fix_title(&self) -> String {

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/extraneous_parentheses.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/extraneous_parentheses.rs
@@ -29,7 +29,7 @@ pub struct ExtraneousParentheses;
 impl AlwaysFixableViolation for ExtraneousParentheses {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Avoid extraneous parentheses")
+        "Avoid extraneous parentheses".to_string()
     }
 
     fn fix_title(&self) -> String {

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/f_strings.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/f_strings.rs
@@ -47,7 +47,7 @@ impl Violation for FString {
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Use f-string instead of `format` call")
+        "Use f-string instead of `format` call".to_string()
     }
 
     fn fix_title(&self) -> Option<String> {

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/format_literals.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/format_literals.rs
@@ -50,7 +50,7 @@ impl Violation for FormatLiterals {
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Use implicit references for positional format fields")
+        "Use implicit references for positional format fields".to_string()
     }
 
     fn fix_title(&self) -> Option<String> {

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/lru_cache_with_maxsize_none.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/lru_cache_with_maxsize_none.rs
@@ -46,7 +46,7 @@ pub struct LRUCacheWithMaxsizeNone;
 impl AlwaysFixableViolation for LRUCacheWithMaxsizeNone {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Use `@functools.cache` instead of `@functools.lru_cache(maxsize=None)`")
+        "Use `@functools.cache` instead of `@functools.lru_cache(maxsize=None)`".to_string()
     }
 
     fn fix_title(&self) -> String {

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/lru_cache_without_parameters.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/lru_cache_without_parameters.rs
@@ -44,7 +44,7 @@ pub struct LRUCacheWithoutParameters;
 impl AlwaysFixableViolation for LRUCacheWithoutParameters {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Unnecessary parentheses to `functools.lru_cache`")
+        "Unnecessary parentheses to `functools.lru_cache`".to_string()
     }
 
     fn fix_title(&self) -> String {

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/open_alias.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/open_alias.rs
@@ -37,7 +37,7 @@ impl Violation for OpenAlias {
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Use builtin `open`")
+        "Use builtin `open`".to_string()
     }
 
     fn fix_title(&self) -> Option<String> {

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/os_error_alias.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/os_error_alias.rs
@@ -42,7 +42,7 @@ pub struct OSErrorAlias {
 impl AlwaysFixableViolation for OSErrorAlias {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Replace aliased errors with `OSError`")
+        "Replace aliased errors with `OSError`".to_string()
     }
 
     fn fix_title(&self) -> String {

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/outdated_version_block.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/outdated_version_block.rs
@@ -56,18 +56,16 @@ impl Violation for OutdatedVersionBlock {
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        let OutdatedVersionBlock { reason } = self;
-        match reason {
+        match self.reason {
             Reason::AlwaysFalse | Reason::AlwaysTrue => {
-                format!("Version block is outdated for minimum Python version")
+                "Version block is outdated for minimum Python version".to_string()
             }
-            Reason::Invalid => format!("Version specifier is invalid"),
+            Reason::Invalid => "Version specifier is invalid".to_string(),
         }
     }
 
     fn fix_title(&self) -> Option<String> {
-        let OutdatedVersionBlock { reason } = self;
-        match reason {
+        match self.reason {
             Reason::AlwaysFalse | Reason::AlwaysTrue => {
                 Some("Remove outdated version block".to_string())
             }

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/printf_string_formatting.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/printf_string_formatting.rs
@@ -81,7 +81,7 @@ impl Violation for PrintfStringFormatting {
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Use format specifiers instead of percent format")
+        "Use format specifiers instead of percent format".to_string()
     }
 
     fn fix_title(&self) -> Option<String> {

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/quoted_annotation.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/quoted_annotation.rs
@@ -63,7 +63,7 @@ pub struct QuotedAnnotation;
 impl AlwaysFixableViolation for QuotedAnnotation {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Remove quotes from type annotation")
+        "Remove quotes from type annotation".to_string()
     }
 
     fn fix_title(&self) -> String {

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/redundant_open_modes.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/redundant_open_modes.rs
@@ -39,9 +39,8 @@ pub struct RedundantOpenModes {
 impl AlwaysFixableViolation for RedundantOpenModes {
     #[derive_message_formats]
     fn message(&self) -> String {
-        let RedundantOpenModes { replacement } = self;
-        match replacement {
-            None => format!("Unnecessary open mode parameters"),
+        match &self.replacement {
+            None => "Unnecessary open mode parameters".to_string(),
             Some(replacement) => {
                 format!("Unnecessary open mode parameters, use \"{replacement}\"")
             }
@@ -49,8 +48,7 @@ impl AlwaysFixableViolation for RedundantOpenModes {
     }
 
     fn fix_title(&self) -> String {
-        let RedundantOpenModes { replacement } = self;
-        match replacement {
+        match &self.replacement {
             None => "Remove open mode parameters".to_string(),
             Some(replacement) => {
                 format!("Replace with \"{replacement}\"")

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/replace_stdout_stderr.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/replace_stdout_stderr.rs
@@ -44,7 +44,7 @@ impl Violation for ReplaceStdoutStderr {
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Prefer `capture_output` over sending `stdout` and `stderr` to `PIPE`")
+        "Prefer `capture_output` over sending `stdout` and `stderr` to `PIPE`".to_string()
     }
 
     fn fix_title(&self) -> Option<String> {

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/replace_universal_newlines.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/replace_universal_newlines.rs
@@ -40,7 +40,7 @@ pub struct ReplaceUniversalNewlines;
 impl AlwaysFixableViolation for ReplaceUniversalNewlines {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("`universal_newlines` is deprecated, use `text`")
+        "`universal_newlines` is deprecated, use `text`".to_string()
     }
 
     fn fix_title(&self) -> String {

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/super_call_with_parameters.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/super_call_with_parameters.rs
@@ -49,7 +49,7 @@ pub struct SuperCallWithParameters;
 impl AlwaysFixableViolation for SuperCallWithParameters {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Use `super()` instead of `super(__class__, self)`")
+        "Use `super()` instead of `super(__class__, self)`".to_string()
     }
 
     fn fix_title(&self) -> String {

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/timeout_error_alias.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/timeout_error_alias.rs
@@ -45,7 +45,7 @@ pub struct TimeoutErrorAlias {
 impl AlwaysFixableViolation for TimeoutErrorAlias {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Replace aliased errors with `TimeoutError`")
+        "Replace aliased errors with `TimeoutError`".to_string()
     }
 
     fn fix_title(&self) -> String {

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/typing_text_str_alias.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/typing_text_str_alias.rs
@@ -37,7 +37,7 @@ impl Violation for TypingTextStrAlias {
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("`typing.Text` is deprecated, use `str`")
+        "`typing.Text` is deprecated, use `str`".to_string()
     }
 
     fn fix_title(&self) -> Option<String> {

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/unicode_kind_prefix.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/unicode_kind_prefix.rs
@@ -30,7 +30,7 @@ pub struct UnicodeKindPrefix;
 impl AlwaysFixableViolation for UnicodeKindPrefix {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Remove unicode literals from strings")
+        "Remove unicode literals from strings".to_string()
     }
 
     fn fix_title(&self) -> String {

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/unnecessary_class_parentheses.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/unnecessary_class_parentheses.rs
@@ -30,7 +30,7 @@ pub struct UnnecessaryClassParentheses;
 impl AlwaysFixableViolation for UnnecessaryClassParentheses {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Unnecessary parentheses after class definition")
+        "Unnecessary parentheses after class definition".to_string()
     }
 
     fn fix_title(&self) -> String {

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/unnecessary_coding_comment.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/unnecessary_coding_comment.rs
@@ -36,7 +36,7 @@ pub struct UTF8EncodingDeclaration;
 impl AlwaysFixableViolation for UTF8EncodingDeclaration {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("UTF-8 encoding declaration is unnecessary")
+        "UTF-8 encoding declaration is unnecessary".to_string()
     }
 
     fn fix_title(&self) -> String {

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/unnecessary_default_type_args.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/unnecessary_default_type_args.rs
@@ -56,7 +56,7 @@ pub struct UnnecessaryDefaultTypeArgs;
 impl AlwaysFixableViolation for UnnecessaryDefaultTypeArgs {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Unnecessary default type arguments")
+        "Unnecessary default type arguments".to_string()
     }
 
     fn fix_title(&self) -> String {

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/unnecessary_encode_utf8.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/unnecessary_encode_utf8.rs
@@ -36,8 +36,10 @@ impl AlwaysFixableViolation for UnnecessaryEncodeUTF8 {
     #[derive_message_formats]
     fn message(&self) -> String {
         match self.reason {
-            Reason::BytesLiteral => format!("Unnecessary call to `encode` as UTF-8"),
-            Reason::DefaultArgument => format!("Unnecessary UTF-8 `encoding` argument to `encode`"),
+            Reason::BytesLiteral => "Unnecessary call to `encode` as UTF-8".to_string(),
+            Reason::DefaultArgument => {
+                "Unnecessary UTF-8 `encoding` argument to `encode`".to_string()
+            }
         }
     }
 

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/unpacked_list_comprehension.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/unpacked_list_comprehension.rs
@@ -38,7 +38,7 @@ pub struct UnpackedListComprehension;
 impl AlwaysFixableViolation for UnpackedListComprehension {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Replace unpacked list comprehension with a generator expression")
+        "Replace unpacked list comprehension with a generator expression".to_string()
     }
 
     fn fix_title(&self) -> String {

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/use_pep604_annotation.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/use_pep604_annotation.rs
@@ -57,7 +57,7 @@ impl Violation for NonPEP604Annotation {
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Use `X | Y` for type annotations")
+        "Use `X | Y` for type annotations".to_string()
     }
 
     fn fix_title(&self) -> Option<String> {

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/use_pep646_unpack.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/use_pep646_unpack.rs
@@ -39,7 +39,7 @@ impl Violation for NonPEP646Unpack {
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Use `*` for unpacking")
+        "Use `*` for unpacking".to_string()
     }
 
     fn fix_title(&self) -> Option<String> {

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/useless_metaclass_type.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/useless_metaclass_type.rs
@@ -34,7 +34,7 @@ pub struct UselessMetaclassType;
 impl AlwaysFixableViolation for UselessMetaclassType {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("`__metaclass__ = type` is implied")
+        "`__metaclass__ = type` is implied".to_string()
     }
 
     fn fix_title(&self) -> String {

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/yield_in_for_loop.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/yield_in_for_loop.rs
@@ -43,7 +43,7 @@ pub struct YieldInForLoop;
 impl AlwaysFixableViolation for YieldInForLoop {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Replace `yield` over `for` loop with `yield from`")
+        "Replace `yield` over `for` loop with `yield from`".to_string()
     }
 
     fn fix_title(&self) -> String {

--- a/crates/ruff_linter/src/rules/refurb/rules/delete_full_slice.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/delete_full_slice.rs
@@ -51,7 +51,7 @@ impl Violation for DeleteFullSlice {
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Prefer `clear` over deleting a full slice")
+        "Prefer `clear` over deleting a full slice".to_string()
     }
 
     fn fix_title(&self) -> Option<String> {

--- a/crates/ruff_linter/src/rules/refurb/rules/hardcoded_string_charset.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/hardcoded_string_charset.rs
@@ -35,7 +35,7 @@ pub struct HardcodedStringCharset {
 impl AlwaysFixableViolation for HardcodedStringCharset {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Use of hardcoded string charset")
+        "Use of hardcoded string charset".to_string()
     }
 
     fn fix_title(&self) -> String {

--- a/crates/ruff_linter/src/rules/refurb/rules/hashlib_digest_hex.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/hashlib_digest_hex.rs
@@ -42,7 +42,7 @@ impl Violation for HashlibDigestHex {
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Use of hashlib's `.digest().hex()`")
+        "Use of hashlib's `.digest().hex()`".to_string()
     }
 
     fn fix_title(&self) -> Option<String> {

--- a/crates/ruff_linter/src/rules/refurb/rules/if_exp_instead_of_or_operator.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/if_exp_instead_of_or_operator.rs
@@ -46,7 +46,7 @@ impl Violation for IfExpInsteadOfOrOperator {
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Replace ternary `if` expression with `or` operator")
+        "Replace ternary `if` expression with `or` operator".to_string()
     }
 
     fn fix_title(&self) -> Option<String> {

--- a/crates/ruff_linter/src/rules/refurb/rules/implicit_cwd.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/implicit_cwd.rs
@@ -33,7 +33,7 @@ impl Violation for ImplicitCwd {
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Prefer `Path.cwd()` over `Path().resolve()` for current-directory lookups")
+        "Prefer `Path.cwd()` over `Path().resolve()` for current-directory lookups".to_string()
     }
 
     fn fix_title(&self) -> Option<String> {

--- a/crates/ruff_linter/src/rules/refurb/rules/isinstance_type_none.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/isinstance_type_none.rs
@@ -38,7 +38,7 @@ impl Violation for IsinstanceTypeNone {
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Prefer `is` operator over `isinstance` to check if an object is `None`")
+        "Prefer `is` operator over `isinstance` to check if an object is `None`".to_string()
     }
 
     fn fix_title(&self) -> Option<String> {

--- a/crates/ruff_linter/src/rules/refurb/rules/metaclass_abcmeta.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/metaclass_abcmeta.rs
@@ -40,7 +40,7 @@ pub struct MetaClassABCMeta;
 impl AlwaysFixableViolation for MetaClassABCMeta {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Use of `metaclass=abc.ABCMeta` to define abstract base class")
+        "Use of `metaclass=abc.ABCMeta` to define abstract base class".to_string()
     }
 
     fn fix_title(&self) -> String {

--- a/crates/ruff_linter/src/rules/refurb/rules/print_empty_string.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/print_empty_string.rs
@@ -52,21 +52,20 @@ impl Violation for PrintEmptyString {
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        let PrintEmptyString { reason } = self;
-        match reason {
-            Reason::EmptyArgument => format!("Unnecessary empty string passed to `print`"),
-            Reason::UselessSeparator => format!("Unnecessary separator passed to `print`"),
-            Reason::Both => format!("Unnecessary empty string and separator passed to `print`"),
+        match self.reason {
+            Reason::EmptyArgument => "Unnecessary empty string passed to `print`".to_string(),
+            Reason::UselessSeparator => "Unnecessary separator passed to `print`".to_string(),
+            Reason::Both => "Unnecessary empty string and separator passed to `print`".to_string(),
         }
     }
 
     fn fix_title(&self) -> Option<String> {
-        let PrintEmptyString { reason } = self;
-        match reason {
-            Reason::EmptyArgument => Some("Remove empty string".to_string()),
-            Reason::UselessSeparator => Some("Remove separator".to_string()),
-            Reason::Both => Some("Remove empty string and separator".to_string()),
-        }
+        let title = match self.reason {
+            Reason::EmptyArgument => "Remove empty string",
+            Reason::UselessSeparator => "Remove separator",
+            Reason::Both => "Remove empty string and separator",
+        };
+        Some(title.to_string())
     }
 }
 

--- a/crates/ruff_linter/src/rules/refurb/rules/readlines_in_for.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/readlines_in_for.rs
@@ -37,7 +37,7 @@ pub(crate) struct ReadlinesInFor;
 impl AlwaysFixableViolation for ReadlinesInFor {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Instead of calling `readlines()`, iterate over file object directly")
+        "Instead of calling `readlines()`, iterate over file object directly".to_string()
     }
 
     fn fix_title(&self) -> String {

--- a/crates/ruff_linter/src/rules/refurb/rules/reimplemented_starmap.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/reimplemented_starmap.rs
@@ -72,7 +72,7 @@ impl Violation for ReimplementedStarmap {
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Use `itertools.starmap` instead of the generator")
+        "Use `itertools.starmap` instead of the generator".to_string()
     }
 
     fn fix_title(&self) -> Option<String> {

--- a/crates/ruff_linter/src/rules/refurb/rules/single_item_membership_test.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/single_item_membership_test.rs
@@ -38,7 +38,7 @@ impl Violation for SingleItemMembershipTest {
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Membership test against single-item container")
+        "Membership test against single-item container".to_string()
     }
 
     fn fix_title(&self) -> Option<String> {

--- a/crates/ruff_linter/src/rules/refurb/rules/slice_copy.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/slice_copy.rs
@@ -44,7 +44,7 @@ impl Violation for SliceCopy {
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Prefer `copy` method over slicing")
+        "Prefer `copy` method over slicing".to_string()
     }
 
     fn fix_title(&self) -> Option<String> {

--- a/crates/ruff_linter/src/rules/refurb/rules/slice_to_remove_prefix_or_suffix.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/slice_to_remove_prefix_or_suffix.rs
@@ -47,10 +47,10 @@ impl AlwaysFixableViolation for SliceToRemovePrefixOrSuffix {
     fn message(&self) -> String {
         match self.affix_kind {
             AffixKind::StartsWith => {
-                format!("Prefer `removeprefix` over conditionally replacing with slice.")
+                "Prefer `removeprefix` over conditionally replacing with slice.".to_string()
             }
             AffixKind::EndsWith => {
-                format!("Prefer `removesuffix` over conditionally replacing with slice.")
+                "Prefer `removesuffix` over conditionally replacing with slice.".to_string()
             }
         }
     }

--- a/crates/ruff_linter/src/rules/refurb/rules/sorted_min_max.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/sorted_min_max.rs
@@ -57,23 +57,24 @@ impl Violation for SortedMinMax {
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        let Self { min_max } = self;
-        match min_max {
+        match self.min_max {
             MinMax::Min => {
-                format!("Prefer `min` over `sorted()` to compute the minimum value in a sequence")
+                "Prefer `min` over `sorted()` to compute the minimum value in a sequence"
+                    .to_string()
             }
             MinMax::Max => {
-                format!("Prefer `max` over `sorted()` to compute the maximum value in a sequence")
+                "Prefer `max` over `sorted()` to compute the maximum value in a sequence"
+                    .to_string()
             }
         }
     }
 
     fn fix_title(&self) -> Option<String> {
-        let Self { min_max } = self;
-        match min_max {
-            MinMax::Min => Some("Replace with `min`".to_string()),
-            MinMax::Max => Some("Replace with `max`".to_string()),
-        }
+        let title = match self.min_max {
+            MinMax::Min => "Replace with `min`",
+            MinMax::Max => "Replace with `max`",
+        };
+        Some(title.to_string())
     }
 }
 

--- a/crates/ruff_linter/src/rules/refurb/rules/unnecessary_enumerate.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/unnecessary_enumerate.rs
@@ -67,23 +67,22 @@ impl Violation for UnnecessaryEnumerate {
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        let UnnecessaryEnumerate { subset } = self;
-        match subset {
+        match self.subset {
             EnumerateSubset::Indices => {
-                format!("`enumerate` value is unused, use `for x in range(len(y))` instead")
+                "`enumerate` value is unused, use `for x in range(len(y))` instead".to_string()
             }
             EnumerateSubset::Values => {
-                format!("`enumerate` index is unused, use `for x in y` instead")
+                "`enumerate` index is unused, use `for x in y` instead".to_string()
             }
         }
     }
 
     fn fix_title(&self) -> Option<String> {
-        let UnnecessaryEnumerate { subset } = self;
-        match subset {
-            EnumerateSubset::Indices => Some("Replace with `range(len(...))`".to_string()),
-            EnumerateSubset::Values => Some("Remove `enumerate`".to_string()),
-        }
+        let title = match self.subset {
+            EnumerateSubset::Indices => "Replace with `range(len(...))`",
+            EnumerateSubset::Values => "Remove `enumerate`",
+        };
+        Some(title.to_string())
     }
 }
 

--- a/crates/ruff_linter/src/rules/refurb/rules/verbose_decimal_constructor.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/verbose_decimal_constructor.rs
@@ -46,7 +46,7 @@ impl Violation for VerboseDecimalConstructor {
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Verbose expression in `Decimal` constructor")
+        "Verbose expression in `Decimal` constructor".to_string()
     }
 
     fn fix_title(&self) -> Option<String> {

--- a/crates/ruff_linter/src/rules/ruff/rules/assert_with_print_message.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/assert_with_print_message.rs
@@ -41,7 +41,7 @@ pub struct AssertWithPrintMessage;
 impl AlwaysFixableViolation for AssertWithPrintMessage {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("`print()` expression in `assert` statement is likely unintentional")
+        "`print()` expression in `assert` statement is likely unintentional".to_string()
     }
 
     fn fix_title(&self) -> String {

--- a/crates/ruff_linter/src/rules/ruff/rules/assignment_in_assert.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/assignment_in_assert.rs
@@ -39,7 +39,7 @@ pub struct AssignmentInAssert;
 impl Violation for AssignmentInAssert {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Avoid assignment expressions in `assert` statements")
+        "Avoid assignment expressions in `assert` statements".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/ruff/rules/collection_literal_concatenation.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/collection_literal_concatenation.rs
@@ -46,11 +46,10 @@ impl Violation for CollectionLiteralConcatenation {
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        let CollectionLiteralConcatenation { expression } = self;
-        if let Some(expression) = expression.full_display() {
+        if let Some(expression) = self.expression.full_display() {
             format!("Consider `{expression}` instead of concatenation")
         } else {
-            format!("Consider iterable unpacking instead of concatenation")
+            "Consider iterable unpacking instead of concatenation".to_string()
         }
     }
 

--- a/crates/ruff_linter/src/rules/ruff/rules/decimal_from_float_literal.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/decimal_from_float_literal.rs
@@ -38,7 +38,7 @@ pub struct DecimalFromFloatLiteral;
 impl AlwaysFixableViolation for DecimalFromFloatLiteral {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("`Decimal()` called with float literal argument")
+        "`Decimal()` called with float literal argument".to_string()
     }
 
     fn fix_title(&self) -> String {

--- a/crates/ruff_linter/src/rules/ruff/rules/default_factory_kwarg.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/default_factory_kwarg.rs
@@ -59,7 +59,7 @@ impl Violation for DefaultFactoryKwarg {
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("`default_factory` is a positional-only argument to `defaultdict`")
+        "`default_factory` is a positional-only argument to `defaultdict`".to_string()
     }
 
     fn fix_title(&self) -> Option<String> {

--- a/crates/ruff_linter/src/rules/ruff/rules/explicit_f_string_type_conversion.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/explicit_f_string_type_conversion.rs
@@ -43,7 +43,7 @@ pub struct ExplicitFStringTypeConversion;
 impl AlwaysFixableViolation for ExplicitFStringTypeConversion {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Use explicit conversion flag")
+        "Use explicit conversion flag".to_string()
     }
 
     fn fix_title(&self) -> String {

--- a/crates/ruff_linter/src/rules/ruff/rules/function_call_in_dataclass_default.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/function_call_in_dataclass_default.rs
@@ -61,11 +61,10 @@ pub struct FunctionCallInDataclassDefaultArgument {
 impl Violation for FunctionCallInDataclassDefaultArgument {
     #[derive_message_formats]
     fn message(&self) -> String {
-        let FunctionCallInDataclassDefaultArgument { name } = self;
-        if let Some(name) = name {
+        if let Some(name) = &self.name {
             format!("Do not perform function call `{name}` in dataclass defaults")
         } else {
-            format!("Do not perform function call in dataclass defaults")
+            "Do not perform function call in dataclass defaults".to_string()
         }
     }
 }

--- a/crates/ruff_linter/src/rules/ruff/rules/implicit_optional.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/implicit_optional.rs
@@ -84,7 +84,7 @@ impl Violation for ImplicitOptional {
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("PEP 484 prohibits implicit `Optional`")
+        "PEP 484 prohibits implicit `Optional`".to_string()
     }
 
     fn fix_title(&self) -> Option<String> {

--- a/crates/ruff_linter/src/rules/ruff/rules/incorrectly_parenthesized_tuple_in_subscript.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/incorrectly_parenthesized_tuple_in_subscript.rs
@@ -46,9 +46,9 @@ impl AlwaysFixableViolation for IncorrectlyParenthesizedTupleInSubscript {
     #[derive_message_formats]
     fn message(&self) -> String {
         if self.prefer_parentheses {
-            format!("Use parentheses for tuples in subscripts")
+            "Use parentheses for tuples in subscripts".to_string()
         } else {
-            format!("Avoid parentheses for tuples in subscripts")
+            "Avoid parentheses for tuples in subscripts".to_string()
         }
     }
 

--- a/crates/ruff_linter/src/rules/ruff/rules/missing_fstring_syntax.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/missing_fstring_syntax.rs
@@ -61,7 +61,7 @@ pub struct MissingFStringSyntax;
 impl AlwaysFixableViolation for MissingFStringSyntax {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!(r"Possible f-string without an `f` prefix")
+        r"Possible f-string without an `f` prefix".to_string()
     }
 
     fn fix_title(&self) -> String {

--- a/crates/ruff_linter/src/rules/ruff/rules/mutable_class_default.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/mutable_class_default.rs
@@ -46,7 +46,7 @@ pub struct MutableClassDefault;
 impl Violation for MutableClassDefault {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Mutable class attributes should be annotated with `typing.ClassVar`")
+        "Mutable class attributes should be annotated with `typing.ClassVar`".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/ruff/rules/mutable_dataclass_default.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/mutable_dataclass_default.rs
@@ -60,7 +60,7 @@ pub struct MutableDataclassDefault;
 impl Violation for MutableDataclassDefault {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Do not use mutable default values for dataclass attributes")
+        "Do not use mutable default values for dataclass attributes".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/ruff/rules/mutable_fromkeys_value.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/mutable_fromkeys_value.rs
@@ -56,7 +56,7 @@ impl Violation for MutableFromkeysValue {
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Do not pass mutable objects as values to `dict.fromkeys`")
+        "Do not pass mutable objects as values to `dict.fromkeys`".to_string()
     }
 
     fn fix_title(&self) -> Option<String> {

--- a/crates/ruff_linter/src/rules/ruff/rules/parenthesize_logical_operators.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/parenthesize_logical_operators.rs
@@ -39,9 +39,7 @@ pub struct ParenthesizeChainedOperators;
 impl AlwaysFixableViolation for ParenthesizeChainedOperators {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!(
-            "Parenthesize `a and b` expressions when chaining `and` and `or` together, to make the precedence clear"
-        )
+        "Parenthesize `a and b` expressions when chaining `and` and `or` together, to make the precedence clear".to_string()
     }
 
     fn fix_title(&self) -> String {

--- a/crates/ruff_linter/src/rules/ruff/rules/post_init_default.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/post_init_default.rs
@@ -74,7 +74,7 @@ impl Violation for PostInitDefault {
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("`__post_init__` method with argument defaults")
+        "`__post_init__` method with argument defaults".to_string()
     }
 
     fn fix_title(&self) -> Option<String> {

--- a/crates/ruff_linter/src/rules/ruff/rules/quadratic_list_summation.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/quadratic_list_summation.rs
@@ -58,7 +58,7 @@ pub struct QuadraticListSummation;
 impl AlwaysFixableViolation for QuadraticListSummation {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Avoid quadratic list summation")
+        "Avoid quadratic list summation".to_string()
     }
 
     fn fix_title(&self) -> String {

--- a/crates/ruff_linter/src/rules/ruff/rules/sort_dunder_all.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/sort_dunder_all.rs
@@ -75,7 +75,7 @@ impl Violation for UnsortedDunderAll {
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("`__all__` is not sorted")
+        "`__all__` is not sorted".to_string()
     }
 
     fn fix_title(&self) -> Option<String> {

--- a/crates/ruff_linter/src/rules/ruff/rules/static_key_dict_comprehension.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/static_key_dict_comprehension.rs
@@ -32,6 +32,6 @@ pub struct RuffStaticKeyDictComprehension;
 impl Violation for RuffStaticKeyDictComprehension {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Dictionary comprehension uses static key")
+        "Dictionary comprehension uses static key".to_string()
     }
 }

--- a/crates/ruff_linter/src/rules/ruff/rules/test_rules.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/test_rules.rs
@@ -74,7 +74,7 @@ impl Violation for StableTestRule {
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Hey this is a stable test rule.")
+        "Hey this is a stable test rule.".to_string()
     }
 }
 
@@ -110,13 +110,13 @@ impl Violation for StableTestRuleSafeFix {
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Hey this is a stable test rule with a safe fix.")
+        "Hey this is a stable test rule with a safe fix.".to_string()
     }
 }
 
 impl TestRule for StableTestRuleSafeFix {
     fn diagnostic(locator: &Locator, comment_ranges: &CommentRanges) -> Option<Diagnostic> {
-        let comment = format!("# fix from stable-test-rule-safe-fix\n");
+        let comment = "# fix from stable-test-rule-safe-fix\n".to_string();
         if comment_exists(&comment, locator, comment_ranges) {
             None
         } else {
@@ -151,13 +151,13 @@ impl Violation for StableTestRuleUnsafeFix {
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Hey this is a stable test rule with an unsafe fix.")
+        "Hey this is a stable test rule with an unsafe fix.".to_string()
     }
 }
 
 impl TestRule for StableTestRuleUnsafeFix {
     fn diagnostic(locator: &Locator, comment_ranges: &CommentRanges) -> Option<Diagnostic> {
-        let comment = format!("# fix from stable-test-rule-unsafe-fix\n");
+        let comment = "# fix from stable-test-rule-unsafe-fix\n".to_string();
         if comment_exists(&comment, locator, comment_ranges) {
             None
         } else {
@@ -195,13 +195,13 @@ impl Violation for StableTestRuleDisplayOnlyFix {
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Hey this is a stable test rule with a display only fix.")
+        "Hey this is a stable test rule with a display only fix.".to_string()
     }
 }
 
 impl TestRule for StableTestRuleDisplayOnlyFix {
     fn diagnostic(locator: &Locator, comment_ranges: &CommentRanges) -> Option<Diagnostic> {
-        let comment = format!("# fix from stable-test-rule-display-only-fix\n");
+        let comment = "# fix from stable-test-rule-display-only-fix\n".to_string();
         if comment_exists(&comment, locator, comment_ranges) {
             None
         } else {
@@ -242,7 +242,7 @@ impl Violation for PreviewTestRule {
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Hey this is a preview test rule.")
+        "Hey this is a preview test rule.".to_string()
     }
 }
 
@@ -278,7 +278,7 @@ impl Violation for DeprecatedTestRule {
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Hey this is a deprecated test rule.")
+        "Hey this is a deprecated test rule.".to_string()
     }
 }
 
@@ -314,7 +314,7 @@ impl Violation for AnotherDeprecatedTestRule {
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Hey this is another deprecated test rule.")
+        "Hey this is another deprecated test rule.".to_string()
     }
 }
 
@@ -350,7 +350,7 @@ impl Violation for RemovedTestRule {
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Hey this is a removed test rule.")
+        "Hey this is a removed test rule.".to_string()
     }
 }
 
@@ -386,7 +386,7 @@ impl Violation for AnotherRemovedTestRule {
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Hey this is a another removed test rule.")
+        "Hey this is a another removed test rule.".to_string()
     }
 }
 
@@ -422,7 +422,7 @@ impl Violation for RedirectedFromTestRule {
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Hey this is a test rule that was redirected to another.")
+        "Hey this is a test rule that was redirected to another.".to_string()
     }
 }
 
@@ -458,7 +458,7 @@ impl Violation for RedirectedToTestRule {
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Hey this is a test rule that was redirected from another.")
+        "Hey this is a test rule that was redirected from another.".to_string()
     }
 }
 
@@ -494,7 +494,7 @@ impl Violation for RedirectedFromPrefixTestRule {
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Hey this is a test rule that was redirected to another by prefix.")
+        "Hey this is a test rule that was redirected to another by prefix.".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/ruff/rules/unnecessary_iterable_allocation_for_first_element.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/unnecessary_iterable_allocation_for_first_element.rs
@@ -61,14 +61,12 @@ pub(crate) struct UnnecessaryIterableAllocationForFirstElement {
 impl AlwaysFixableViolation for UnnecessaryIterableAllocationForFirstElement {
     #[derive_message_formats]
     fn message(&self) -> String {
-        let UnnecessaryIterableAllocationForFirstElement { iterable } = self;
-        let iterable = iterable.truncated_display();
+        let iterable = &self.iterable.truncated_display();
         format!("Prefer `next({iterable})` over single element slice")
     }
 
     fn fix_title(&self) -> String {
-        let UnnecessaryIterableAllocationForFirstElement { iterable } = self;
-        let iterable = iterable.truncated_display();
+        let iterable = &self.iterable.truncated_display();
         format!("Replace with `next({iterable})`")
     }
 }

--- a/crates/ruff_linter/src/rules/ruff/rules/unnecessary_key_check.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/unnecessary_key_check.rs
@@ -34,7 +34,7 @@ pub struct UnnecessaryKeyCheck;
 impl AlwaysFixableViolation for UnnecessaryKeyCheck {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Unnecessary key check before dictionary access")
+        "Unnecessary key check before dictionary access".to_string()
     }
 
     fn fix_title(&self) -> String {

--- a/crates/ruff_linter/src/rules/ruff/rules/unused_noqa.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/unused_noqa.rs
@@ -49,8 +49,7 @@ pub struct UnusedNOQA {
 impl AlwaysFixableViolation for UnusedNOQA {
     #[derive_message_formats]
     fn message(&self) -> String {
-        let UnusedNOQA { codes } = self;
-        match codes {
+        match &self.codes {
             Some(codes) => {
                 let mut codes_by_reason = vec![];
                 if !codes.unmatched.is_empty() {
@@ -94,12 +93,12 @@ impl AlwaysFixableViolation for UnusedNOQA {
                     ));
                 }
                 if codes_by_reason.is_empty() {
-                    format!("Unused `noqa` directive")
+                    "Unused `noqa` directive".to_string()
                 } else {
                     format!("Unused `noqa` directive ({})", codes_by_reason.join("; "))
                 }
             }
-            None => format!("Unused blanket `noqa` directive"),
+            None => "Unused blanket `noqa` directive".to_string(),
         }
     }
 

--- a/crates/ruff_linter/src/rules/ruff/rules/useless_if_else.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/useless_if_else.rs
@@ -31,7 +31,7 @@ pub struct UselessIfElse;
 impl Violation for UselessIfElse {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Useless `if`-`else` condition")
+        "Useless `if`-`else` condition".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/ruff/rules/zip_instead_of_pairwise.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/zip_instead_of_pairwise.rs
@@ -36,9 +36,11 @@ pub struct ZipInsteadOfPairwise;
 
 impl Violation for ZipInsteadOfPairwise {
     const FIX_AVAILABILITY: FixAvailability = FixAvailability::Sometimes;
+
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Prefer `itertools.pairwise()` over `zip()` when iterating over successive pairs")
+        "Prefer `itertools.pairwise()` over `zip()` when iterating over successive pairs"
+            .to_string()
     }
 
     fn fix_title(&self) -> Option<String> {

--- a/crates/ruff_linter/src/rules/tryceratops/rules/error_instead_of_exception.rs
+++ b/crates/ruff_linter/src/rules/tryceratops/rules/error_instead_of_exception.rs
@@ -59,7 +59,7 @@ impl Violation for ErrorInsteadOfException {
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Use `logging.exception` instead of `logging.error`")
+        "Use `logging.exception` instead of `logging.error`".to_string()
     }
 
     fn fix_title(&self) -> Option<String> {

--- a/crates/ruff_linter/src/rules/tryceratops/rules/raise_vanilla_args.rs
+++ b/crates/ruff_linter/src/rules/tryceratops/rules/raise_vanilla_args.rs
@@ -49,7 +49,7 @@ pub struct RaiseVanillaArgs;
 impl Violation for RaiseVanillaArgs {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Avoid specifying long messages outside the exception class")
+        "Avoid specifying long messages outside the exception class".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/tryceratops/rules/raise_vanilla_class.rs
+++ b/crates/ruff_linter/src/rules/tryceratops/rules/raise_vanilla_class.rs
@@ -58,7 +58,7 @@ pub struct RaiseVanillaClass;
 impl Violation for RaiseVanillaClass {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Create your own exception")
+        "Create your own exception".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/tryceratops/rules/raise_within_try.rs
+++ b/crates/ruff_linter/src/rules/tryceratops/rules/raise_within_try.rs
@@ -55,7 +55,7 @@ pub struct RaiseWithinTry;
 impl Violation for RaiseWithinTry {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Abstract `raise` to an inner function")
+        "Abstract `raise` to an inner function".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/tryceratops/rules/reraise_no_cause.rs
+++ b/crates/ruff_linter/src/rules/tryceratops/rules/reraise_no_cause.rs
@@ -42,6 +42,6 @@ pub struct ReraiseNoCause;
 impl Violation for ReraiseNoCause {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Use `raise from` to specify exception cause")
+        "Use `raise from` to specify exception cause".to_string()
     }
 }

--- a/crates/ruff_linter/src/rules/tryceratops/rules/try_consider_else.rs
+++ b/crates/ruff_linter/src/rules/tryceratops/rules/try_consider_else.rs
@@ -52,7 +52,7 @@ pub struct TryConsiderElse;
 impl Violation for TryConsiderElse {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Consider moving this statement to an `else` block")
+        "Consider moving this statement to an `else` block".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/tryceratops/rules/type_check_without_type_error.rs
+++ b/crates/ruff_linter/src/rules/tryceratops/rules/type_check_without_type_error.rs
@@ -41,7 +41,7 @@ pub struct TypeCheckWithoutTypeError;
 impl Violation for TypeCheckWithoutTypeError {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Prefer `TypeError` exception for invalid type")
+        "Prefer `TypeError` exception for invalid type".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/tryceratops/rules/useless_try_except.rs
+++ b/crates/ruff_linter/src/rules/tryceratops/rules/useless_try_except.rs
@@ -34,7 +34,7 @@ pub struct UselessTryExcept;
 impl Violation for UselessTryExcept {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Remove exception handler; error is immediately re-raised")
+        "Remove exception handler; error is immediately re-raised".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/tryceratops/rules/verbose_log_message.rs
+++ b/crates/ruff_linter/src/rules/tryceratops/rules/verbose_log_message.rs
@@ -39,7 +39,7 @@ pub struct VerboseLogMessage;
 impl Violation for VerboseLogMessage {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Redundant exception object included in `logging.exception` call")
+        "Redundant exception object included in `logging.exception` call".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/tryceratops/rules/verbose_raise.rs
+++ b/crates/ruff_linter/src/rules/tryceratops/rules/verbose_raise.rs
@@ -41,7 +41,7 @@ pub struct VerboseRaise;
 impl AlwaysFixableViolation for VerboseRaise {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Use `raise` without specifying exception name")
+        "Use `raise` without specifying exception name".to_string()
     }
 
     fn fix_title(&self) -> String {


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Follow-up of https://github.com/astral-sh/ruff/pull/14090: the `derive_message_formats` macro previously did not support `String::to_string`. This PR changes the macro to require `String::to_string` instead of `format!` when no formatting parameters are provided. 

There is room for further expansion of this macro, as this pattern used in #14090 is not yet supported for the message method:

```rust
let message = "message";
message.to_string();
```

## Test Plan

`cargo test` and `cargo expand`, e.g. `cargo expand rules::flake8_bandit::rules::jinja2_autoescape_false -p ruff_linter`
