### PR TITLE
Re-enable clippy `useless-format`

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/return_in_generator.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/return_in_generator.rs
@@ -85,7 +85,8 @@ pub struct ReturnInGenerator;
 impl Violation for ReturnInGenerator {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Using `yield` and `return {{value}}` in a generator function can lead to confusing behavior")
+        "Using `yield` and `return {value}` in a generator function can lead to confusing behavior"
+            .to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/unnecessary_literal_union.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/unnecessary_literal_union.rs
@@ -47,7 +47,7 @@ impl Violation for UnnecessaryLiteralUnion {
     }
 
     fn fix_title(&self) -> Option<String> {
-        Some(format!("Replace with a single `Literal`",))
+        Some("Replace with a single `Literal`".to_string())
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/unnecessary_type_union.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/unnecessary_type_union.rs
@@ -37,7 +37,7 @@ impl Violation for UnnecessaryTypeUnion {
     #[derive_message_formats]
     fn message(&self) -> String {
         let union_str = if self.is_pep604_union {
-            format!("{}", self.members.join(" | "))
+            self.members.join(" | ")
         } else {
             format!("Union[{}]", self.members.join(", "))
         };

--- a/crates/ruff_linter/src/rules/mod.rs
+++ b/crates/ruff_linter/src/rules/mod.rs
@@ -1,4 +1,3 @@
-#![allow(clippy::useless_format)]
 pub mod airflow;
 pub mod eradicate;
 pub mod fastapi;

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/errors.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/errors.rs
@@ -30,6 +30,8 @@ pub struct IOError {
 
 /// E902
 impl Violation for IOError {
+    // The format message is used by the `derive_message_formats` macro.
+    #![allow(clippy::useless_format)]
     #[derive_message_formats]
     fn message(&self) -> String {
         let IOError { message } = self;

--- a/crates/ruff_linter/src/rules/pydocstyle/rules/backslashes.rs
+++ b/crates/ruff_linter/src/rules/pydocstyle/rules/backslashes.rs
@@ -53,7 +53,7 @@ impl Violation for EscapeSequenceInDocstring {
     }
 
     fn fix_title(&self) -> Option<String> {
-        Some(format!(r#"Add `r` prefix"#))
+        Some(r#"Add `r` prefix"#.to_string())
     }
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

@MichaReiser was faster with merging than I could push this final commit on "useless" format calls 😄 (https://github.com/astral-sh/ruff/pull/14093)

Now that we've eliminated most `format!` calls without arguments, we can re-enable the clippy lint:

https://rust-lang.github.io/rust-clippy/master/#useless_format

## Test Plan

`cargo clippy --workspace --all-targets --all-features -- -D warnings`