### PR TITLE
[refurb] Parse more exotic decimal strings in `verbose-decimal-constructor (FURB157)`

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/refurb/FURB157.py
+++ b/crates/ruff_linter/resources/test/fixtures/refurb/FURB157.py
@@ -22,22 +22,16 @@ decimal.Decimal(0)
 # Errors
 Decimal("1_000")
 Decimal("__1____000") 
-Decimal("2e4")
-Decimal("2e+4")
-Decimal("2E4")
 
 # Ok
 Decimal("2e-4")
 Decimal("2E-4")
 Decimal("_1.234__")
+Decimal("2e4")
+Decimal("2e+4")
+Decimal("2E4")
+Decimal("1.2") 
 # Ok: even though this is equal to `Decimal(123)`,
 # we assume that a developer would
 # only write it this way if they meant to.
 Decimal("١٢٣") 
-# Ok: due to floating point errors
-# this is not equal to `Decimal(1.2)`.
-Decimal("1.2") 
-# Ok: This is an error of type `decimal.InvalidOperation`,
-# whereas `Decimal(2e4e4)` is a SyntaxError, so
-# we leave it as is.
-Decimal("2e4e4")

--- a/crates/ruff_linter/resources/test/fixtures/refurb/FURB157.py
+++ b/crates/ruff_linter/resources/test/fixtures/refurb/FURB157.py
@@ -15,3 +15,29 @@ decimal.Decimal("0")
 Decimal(0)
 Decimal("Infinity")
 decimal.Decimal(0)
+
+# Handle Python's Decimal parsing
+# See https://github.com/astral-sh/ruff/issues/13807
+
+# Errors
+Decimal("1_000")
+Decimal("__1____000") 
+Decimal("2e4")
+Decimal("2e+4")
+Decimal("2E4")
+
+# Ok
+Decimal("2e-4")
+Decimal("2E-4")
+Decimal("_1.234__")
+# Ok: even though this is equal to `Decimal(123)`,
+# we assume that a developer would
+# only write it this way if they meant to.
+Decimal("١٢٣") 
+# Ok: due to floating point errors
+# this is not equal to `Decimal(1.2)`.
+Decimal("1.2") 
+# Ok: This is an error of type `decimal.InvalidOperation`,
+# whereas `Decimal(2e4e4)` is a SyntaxError, so
+# we leave it as is.
+Decimal("2e4e4")

--- a/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__FURB157_FURB157.py.snap
+++ b/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__FURB157_FURB157.py.snap
@@ -166,3 +166,106 @@ FURB157.py:12:17: FURB157 [*] Verbose expression in `Decimal` constructor
 13 13 | 
 14 14 | # OK
 15 15 | Decimal(0)
+
+FURB157.py:23:9: FURB157 [*] Verbose expression in `Decimal` constructor
+   |
+22 | # Errors
+23 | Decimal("1_000")
+   |         ^^^^^^^ FURB157
+24 | Decimal("__1____000") 
+25 | Decimal("2e4")
+   |
+   = help: Replace with `1000`
+
+ℹ Safe fix
+20 20 | # See https://github.com/astral-sh/ruff/issues/13807
+21 21 | 
+22 22 | # Errors
+23    |-Decimal("1_000")
+   23 |+Decimal(1000)
+24 24 | Decimal("__1____000") 
+25 25 | Decimal("2e4")
+26 26 | Decimal("2e+4")
+
+FURB157.py:24:9: FURB157 [*] Verbose expression in `Decimal` constructor
+   |
+22 | # Errors
+23 | Decimal("1_000")
+24 | Decimal("__1____000") 
+   |         ^^^^^^^^^^^^ FURB157
+25 | Decimal("2e4")
+26 | Decimal("2e+4")
+   |
+   = help: Replace with `1000`
+
+ℹ Safe fix
+21 21 | 
+22 22 | # Errors
+23 23 | Decimal("1_000")
+24    |-Decimal("__1____000") 
+   24 |+Decimal(1000) 
+25 25 | Decimal("2e4")
+26 26 | Decimal("2e+4")
+27 27 | Decimal("2E4")
+
+FURB157.py:25:9: FURB157 [*] Verbose expression in `Decimal` constructor
+   |
+23 | Decimal("1_000")
+24 | Decimal("__1____000") 
+25 | Decimal("2e4")
+   |         ^^^^^ FURB157
+26 | Decimal("2e+4")
+27 | Decimal("2E4")
+   |
+   = help: Replace with `2e4`
+
+ℹ Safe fix
+22 22 | # Errors
+23 23 | Decimal("1_000")
+24 24 | Decimal("__1____000") 
+25    |-Decimal("2e4")
+   25 |+Decimal(2e4)
+26 26 | Decimal("2e+4")
+27 27 | Decimal("2E4")
+28 28 | 
+
+FURB157.py:26:9: FURB157 [*] Verbose expression in `Decimal` constructor
+   |
+24 | Decimal("__1____000") 
+25 | Decimal("2e4")
+26 | Decimal("2e+4")
+   |         ^^^^^^ FURB157
+27 | Decimal("2E4")
+   |
+   = help: Replace with `2e4`
+
+ℹ Safe fix
+23 23 | Decimal("1_000")
+24 24 | Decimal("__1____000") 
+25 25 | Decimal("2e4")
+26    |-Decimal("2e+4")
+   26 |+Decimal(2e4)
+27 27 | Decimal("2E4")
+28 28 | 
+29 29 | # Ok
+
+FURB157.py:27:9: FURB157 [*] Verbose expression in `Decimal` constructor
+   |
+25 | Decimal("2e4")
+26 | Decimal("2e+4")
+27 | Decimal("2E4")
+   |         ^^^^^ FURB157
+28 | 
+29 | # Ok
+   |
+   = help: Replace with `2E4`
+
+ℹ Safe fix
+24 24 | Decimal("__1____000") 
+25 25 | Decimal("2e4")
+26 26 | Decimal("2e+4")
+27    |-Decimal("2E4")
+   27 |+Decimal(2E4)
+28 28 | 
+29 29 | # Ok
+30 30 | Decimal("2e-4")

--- a/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__FURB157_FURB157.py.snap
+++ b/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__FURB157_FURB157.py.snap
@@ -173,7 +173,6 @@ FURB157.py:23:9: FURB157 [*] Verbose expression in `Decimal` constructor
 23 | Decimal("1_000")
    |         ^^^^^^^ FURB157
 24 | Decimal("__1____000") 
-25 | Decimal("2e4")
    |
    = help: Replace with `1000`
 
@@ -184,8 +183,8 @@ FURB157.py:23:9: FURB157 [*] Verbose expression in `Decimal` constructor
 23    |-Decimal("1_000")
    23 |+Decimal(1000)
 24 24 | Decimal("__1____000") 
-25 25 | Decimal("2e4")
-26 26 | Decimal("2e+4")
+25 25 | 
+26 26 | # Ok
 
 FURB157.py:24:9: FURB157 [*] Verbose expression in `Decimal` constructor
    |
@@ -193,8 +192,8 @@ FURB157.py:24:9: FURB157 [*] Verbose expression in `Decimal` constructor
 23 | Decimal("1_000")
 24 | Decimal("__1____000") 
    |         ^^^^^^^^^^^^ FURB157
-25 | Decimal("2e4")
-26 | Decimal("2e+4")
+25 | 
+26 | # Ok
    |
    = help: Replace with `1000`
 
@@ -204,68 +203,6 @@ FURB157.py:24:9: FURB157 [*] Verbose expression in `Decimal` constructor
 23 23 | Decimal("1_000")
 24    |-Decimal("__1____000") 
    24 |+Decimal(1000) 
-25 25 | Decimal("2e4")
-26 26 | Decimal("2e+4")
-27 27 | Decimal("2E4")
-
-FURB157.py:25:9: FURB157 [*] Verbose expression in `Decimal` constructor
-   |
-23 | Decimal("1_000")
-24 | Decimal("__1____000") 
-25 | Decimal("2e4")
-   |         ^^^^^ FURB157
-26 | Decimal("2e+4")
-27 | Decimal("2E4")
-   |
-   = help: Replace with `2e4`
-
-ℹ Safe fix
-22 22 | # Errors
-23 23 | Decimal("1_000")
-24 24 | Decimal("__1____000") 
-25    |-Decimal("2e4")
-   25 |+Decimal(2e4)
-26 26 | Decimal("2e+4")
-27 27 | Decimal("2E4")
-28 28 | 
-
-FURB157.py:26:9: FURB157 [*] Verbose expression in `Decimal` constructor
-   |
-24 | Decimal("__1____000") 
-25 | Decimal("2e4")
-26 | Decimal("2e+4")
-   |         ^^^^^^ FURB157
-27 | Decimal("2E4")
-   |
-   = help: Replace with `2e4`
-
-ℹ Safe fix
-23 23 | Decimal("1_000")
-24 24 | Decimal("__1____000") 
-25 25 | Decimal("2e4")
-26    |-Decimal("2e+4")
-   26 |+Decimal(2e4)
-27 27 | Decimal("2E4")
-28 28 | 
-29 29 | # Ok
-
-FURB157.py:27:9: FURB157 [*] Verbose expression in `Decimal` constructor
-   |
-25 | Decimal("2e4")
-26 | Decimal("2e+4")
-27 | Decimal("2E4")
-   |         ^^^^^ FURB157
-28 | 
-29 | # Ok
-   |
-   = help: Replace with `2E4`
-
-ℹ Safe fix
-24 24 | Decimal("__1____000") 
-25 25 | Decimal("2e4")
-26 26 | Decimal("2e+4")
-27    |-Decimal("2E4")
-   27 |+Decimal(2E4)
-28 28 | 
-29 29 | # Ok
-30 30 | Decimal("2e-4")
+25 25 | 
+26 26 | # Ok
+27 27 | Decimal("2e-4")


### PR DESCRIPTION
FURB157 suggests replacing expressions like `Decimal("123")` with `Decimal(123)`. This PR extends the rule to cover cases where the input string to `Decimal` can be easily transformed into an integer literal.

For example:

```python
Decimal("1__000")   # fix: `Decimal(1000)`
```

Note: we do not implement the full decimal parsing logic from CPython on the grounds that certain acceptable string inputs to the `Decimal` constructor may be presumed purposeful on the part of the developer. For example, as in the linked issue, `Decimal("١٢٣")` is valid and equal to `Decimal(123)`, but we do not suggest a replacement in this case.

Closes #13807 
