### PR TITLE
fix double inference of standalone expressions

### DIFF
--- a/crates/red_knot_python_semantic/src/semantic_index.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index.rs
@@ -125,6 +125,7 @@ impl<'db> SemanticIndex<'db> {
     ///
     /// Use the Salsa cached [`symbol_table()`] query if you only need the
     /// symbol table for a single scope.
+    #[track_caller]
     pub(super) fn symbol_table(&self, scope_id: FileScopeId) -> Arc<SymbolTable> {
         self.symbol_tables[scope_id].clone()
     }
@@ -133,15 +134,18 @@ impl<'db> SemanticIndex<'db> {
     ///
     /// Use the Salsa cached [`use_def_map()`] query if you only need the
     /// use-def map for a single scope.
+    #[track_caller]
     pub(super) fn use_def_map(&self, scope_id: FileScopeId) -> Arc<UseDefMap> {
         self.use_def_maps[scope_id].clone()
     }
 
+    #[track_caller]
     pub(crate) fn ast_ids(&self, scope_id: FileScopeId) -> &AstIds {
         &self.ast_ids[scope_id]
     }
 
     /// Returns the ID of the `expression`'s enclosing scope.
+    #[track_caller]
     pub(crate) fn expression_scope_id(
         &self,
         expression: impl Into<ExpressionNodeKey>,
@@ -151,11 +155,13 @@ impl<'db> SemanticIndex<'db> {
 
     /// Returns the [`Scope`] of the `expression`'s enclosing scope.
     #[allow(unused)]
+    #[track_caller]
     pub(crate) fn expression_scope(&self, expression: impl Into<ExpressionNodeKey>) -> &Scope {
         &self.scopes[self.expression_scope_id(expression)]
     }
 
     /// Returns the [`Scope`] with the given id.
+    #[track_caller]
     pub(crate) fn scope(&self, id: FileScopeId) -> &Scope {
         &self.scopes[id]
     }
@@ -172,6 +178,7 @@ impl<'db> SemanticIndex<'db> {
 
     /// Returns the parent scope of `scope_id`.
     #[allow(unused)]
+    #[track_caller]
     pub(crate) fn parent_scope(&self, scope_id: FileScopeId) -> Option<&Scope> {
         Some(&self.scopes[self.parent_scope_id(scope_id)?])
     }
@@ -195,6 +202,7 @@ impl<'db> SemanticIndex<'db> {
     }
 
     /// Returns the [`Definition`] salsa ingredient for `definition_key`.
+    #[track_caller]
     pub(crate) fn definition(
         &self,
         definition_key: impl Into<DefinitionNodeKey>,
@@ -206,6 +214,7 @@ impl<'db> SemanticIndex<'db> {
     /// Panics if we have no expression ingredient for that node. We can only call this method for
     /// standalone-inferable expressions, which we call `add_standalone_expression` for in
     /// [`SemanticIndexBuilder`].
+    #[track_caller]
     pub(crate) fn expression(
         &self,
         expression_key: impl Into<ExpressionNodeKey>,
@@ -213,8 +222,18 @@ impl<'db> SemanticIndex<'db> {
         self.expressions_by_node[&expression_key.into()]
     }
 
+    pub(crate) fn try_expression(
+        &self,
+        expression_key: impl Into<ExpressionNodeKey>,
+    ) -> Option<Expression<'db>> {
+        self.expressions_by_node
+            .get(&expression_key.into())
+            .copied()
+    }
+
     /// Returns the id of the scope that `node` creates. This is different from [`Definition::scope`] which
     /// returns the scope in which that definition is defined in.
+    #[track_caller]
     pub(crate) fn node_scope(&self, node: NodeWithScopeRef) -> FileScopeId {
         self.scopes_by_node[&node.node_key()]
     }

--- a/crates/red_knot_python_semantic/src/semantic_index/builder.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/builder.rs
@@ -1088,10 +1088,13 @@ where
                 // AST inspection, so we can't simplify here, need to record test expression for
                 // later checking)
                 self.visit_expr(test);
+                let constraint = self.record_expression_constraint(test);
                 let pre_if = self.flow_snapshot();
                 self.visit_expr(body);
                 let post_body = self.flow_snapshot();
                 self.flow_restore(pre_if);
+
+                self.record_negated_constraint(constraint);
                 self.visit_expr(orelse);
                 self.flow_merge(post_body);
             }


### PR DESCRIPTION
## Summary

I noticed that migrating to salsa accumulators resulted in duplicated diagnostics because a lot of type inference code incorrectly called `self.infer_expression` instead of `infer_expression_types` for standalone expressions. 

This PR adds a debug assertion to `infer_expression` that throws when called for a standalone expression and it fixes all call sites to correctly use `infer_standalone_expression` instead.

## Test Plan

`cargo test`
