### PR TITLE
[red-knot] Introduce a new `ClassLiteralType` struct

### DIFF
--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -1913,6 +1913,10 @@ pub enum KnownFunction {
     IsInstance,
 }
 
+/// Representation of a runtime class object.
+///
+/// Does not in itself represent a type,
+/// but is used as the inner data for several structs that *do* represent types.
 #[salsa::interned]
 pub struct Class<'db> {
     /// Name of the class at definition

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -120,10 +120,7 @@ fn symbol<'db>(db: &'db dyn Db, scope: ScopeId<'db>, name: &str) -> Symbol<'db> 
 /// so the cost of hashing the names is likely to be more expensive than it's worth.
 #[salsa::tracked(return_ref)]
 fn module_type_symbols<'db>(db: &'db dyn Db) -> smallvec::SmallVec<[ast::name::Name; 8]> {
-    let Some(module_type) = KnownClass::ModuleType
-        .to_class(db)
-        .into_class_literal_type()
-    else {
+    let Some(module_type) = KnownClass::ModuleType.to_class(db).into_class_literal() else {
         // The most likely way we get here is if a user specified a `--custom-typeshed-dir`
         // without a `types.pyi` stub in the `stdlib/` directory
         return smallvec::SmallVec::default();
@@ -362,7 +359,7 @@ impl<'db> Type<'db> {
         matches!(self, Type::Todo)
     }
 
-    pub const fn into_class_literal_type(self) -> Option<ClassLiteralType<'db>> {
+    pub const fn into_class_literal(self) -> Option<ClassLiteralType<'db>> {
         match self {
             Type::ClassLiteral(class_type) => Some(class_type),
             _ => None,
@@ -371,7 +368,7 @@ impl<'db> Type<'db> {
 
     #[track_caller]
     pub fn expect_class_literal(self) -> ClassLiteralType<'db> {
-        self.into_class_literal_type()
+        self.into_class_literal()
             .expect("Expected a Type::ClassLiteral variant")
     }
 
@@ -379,7 +376,7 @@ impl<'db> Type<'db> {
         matches!(self, Type::ClassLiteral(..))
     }
 
-    pub const fn into_module_literal_type(self) -> Option<File> {
+    pub const fn into_module_literal(self) -> Option<File> {
         match self {
             Type::ModuleLiteral(file) => Some(file),
             _ => None,
@@ -388,7 +385,7 @@ impl<'db> Type<'db> {
 
     #[track_caller]
     pub fn expect_module_literal(self) -> File {
-        self.into_module_literal_type()
+        self.into_module_literal()
             .expect("Expected a Type::ModuleLiteral variant")
     }
 
@@ -397,7 +394,7 @@ impl<'db> Type<'db> {
         IntersectionBuilder::new(db).add_negative(*self).build()
     }
 
-    pub const fn into_union_type(self) -> Option<UnionType<'db>> {
+    pub const fn into_union(self) -> Option<UnionType<'db>> {
         match self {
             Type::Union(union_type) => Some(union_type),
             _ => None,
@@ -406,15 +403,14 @@ impl<'db> Type<'db> {
 
     #[track_caller]
     pub fn expect_union(self) -> UnionType<'db> {
-        self.into_union_type()
-            .expect("Expected a Type::Union variant")
+        self.into_union().expect("Expected a Type::Union variant")
     }
 
     pub const fn is_union(&self) -> bool {
         matches!(self, Type::Union(..))
     }
 
-    pub const fn into_intersection_type(self) -> Option<IntersectionType<'db>> {
+    pub const fn into_intersection(self) -> Option<IntersectionType<'db>> {
         match self {
             Type::Intersection(intersection_type) => Some(intersection_type),
             _ => None,
@@ -423,11 +419,11 @@ impl<'db> Type<'db> {
 
     #[track_caller]
     pub fn expect_intersection(self) -> IntersectionType<'db> {
-        self.into_intersection_type()
+        self.into_intersection()
             .expect("Expected a Type::Intersection variant")
     }
 
-    pub const fn into_function_literal_type(self) -> Option<FunctionType<'db>> {
+    pub const fn into_function_literal(self) -> Option<FunctionType<'db>> {
         match self {
             Type::FunctionLiteral(function_type) => Some(function_type),
             _ => None,
@@ -436,7 +432,7 @@ impl<'db> Type<'db> {
 
     #[track_caller]
     pub fn expect_function_literal(self) -> FunctionType<'db> {
-        self.into_function_literal_type()
+        self.into_function_literal()
             .expect("Expected a Type::FunctionLiteral variant")
     }
 
@@ -444,7 +440,7 @@ impl<'db> Type<'db> {
         matches!(self, Type::FunctionLiteral(..))
     }
 
-    pub const fn into_int_literal_type(self) -> Option<i64> {
+    pub const fn into_int_literal(self) -> Option<i64> {
         match self {
             Type::IntLiteral(value) => Some(value),
             _ => None,
@@ -453,7 +449,7 @@ impl<'db> Type<'db> {
 
     #[track_caller]
     pub fn expect_int_literal(self) -> i64 {
-        self.into_int_literal_type()
+        self.into_int_literal()
             .expect("Expected a Type::IntLiteral variant")
     }
 

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -1266,6 +1266,8 @@ impl<'db> Type<'db> {
     pub fn to_meta_type(&self, db: &'db dyn Db) -> Type<'db> {
         match self {
             Type::Never => Type::Never,
+            // TODO: not really correct -- the meta-type of an `InstanceType { class: T }` should be `type[T]`
+            // (<https://docs.python.org/3/library/typing.html#the-type-of-class-objects>)
             Type::Instance(InstanceType { class, .. }) => {
                 Type::ClassLiteral(ClassLiteralType { class: *class })
             }
@@ -2086,10 +2088,10 @@ impl<'db> From<ClassLiteralType<'db>> for Type<'db> {
 
 /// A type representing the set of runtime objects which are instances of a certain class.
 ///
-/// Some specific instances are important enough that they really constitute their own type
-/// which should compare and hash differently to other instances of the same class.
-/// Whether or not you're dealing with one of these symbols can be determined using the
-/// `known` field on the `InstanceType` struct.
+/// Some specific instances of some types need to be treated specially by the type system:
+/// for example, various special forms are instances of `typing._SpecialForm`,
+/// but need to be handled differently in annotations. These special instances are marked as such
+/// using the `known` field on this struct.
 ///
 /// Note that, for example, `InstanceType { class: typing._SpecialForm, known: None }`
 /// is a supertype of `InstanceType { class: typing._SpecialForm, known: KnownInstance::Literal }`.

--- a/crates/red_knot_python_semantic/src/types/diagnostic.rs
+++ b/crates/red_knot_python_semantic/src/types/diagnostic.rs
@@ -5,7 +5,7 @@ use std::fmt::Formatter;
 use std::ops::Deref;
 use std::sync::Arc;
 
-use crate::types::Type;
+use crate::types::{ClassLiteralType, Type};
 use crate::Db;
 
 #[derive(Debug, Eq, PartialEq)]
@@ -209,7 +209,7 @@ impl<'db> TypeCheckDiagnosticsBuilder<'db> {
         assigned_ty: Type<'db>,
     ) {
         match declared_ty {
-            Type::ClassLiteral(class) => {
+            Type::ClassLiteral(ClassLiteralType { class }) => {
                 self.add(node, "invalid-assignment", format_args!(
                         "Implicit shadowing of class `{}`; annotate to make it explicit if this is intentional",
                         class.name(self.db)));

--- a/crates/red_knot_python_semantic/src/types/display.rs
+++ b/crates/red_knot_python_semantic/src/types/display.rs
@@ -6,7 +6,7 @@ use ruff_db::display::FormatterJoinExtension;
 use ruff_python_ast::str::Quote;
 use ruff_python_literal::escape::AsciiEscape;
 
-use crate::types::{InstanceType, IntersectionType, KnownClass, Type, UnionType};
+use crate::types::{ClassLiteralType, InstanceType, IntersectionType, KnownClass, Type, UnionType};
 use crate::Db;
 use rustc_hash::FxHashMap;
 
@@ -76,7 +76,7 @@ impl Display for DisplayRepresentation<'_> {
                 write!(f, "<module '{:?}'>", file.path(self.db))
             }
             // TODO functions and classes should display using a fully qualified name
-            Type::ClassLiteral(class) => f.write_str(class.name(self.db)),
+            Type::ClassLiteral(ClassLiteralType { class }) => f.write_str(class.name(self.db)),
             Type::Instance(InstanceType { class, known }) => f.write_str(match known {
                 Some(super::KnownInstance::Literal) => "Literal",
                 _ => class.name(self.db),

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -1280,13 +1280,14 @@ impl<'db> TypeInferenceBuilder<'db> {
             // anything else is invalid and should lead to a diagnostic being reported --Alex
             match node_ty {
                 Type::Any | Type::Unknown => node_ty,
-                Type::ClassLiteral(class_ty) => Type::Instance(class_ty.to_instance_type()),
+                Type::ClassLiteral(ClassLiteralType { class }) => Type::anonymous_instance(class),
                 Type::Tuple(tuple) => UnionType::from_elements(
                     self.db,
                     tuple.elements(self.db).iter().map(|ty| {
-                        ty.into_class_literal().map_or(Type::Todo, |class_ty| {
-                            Type::Instance(class_ty.to_instance_type())
-                        })
+                        ty.into_class_literal()
+                            .map_or(Type::Todo, |ClassLiteralType { class }| {
+                                Type::anonymous_instance(class)
+                            })
                     }),
                 ),
                 _ => Type::Todo,

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -457,7 +457,7 @@ impl<'db> TypeInferenceBuilder<'db> {
             .types
             .declarations
             .values()
-            .filter_map(|ty| ty.into_class_literal_type())
+            .filter_map(|ty| ty.into_class_literal())
             .map(|class_ty| class_ty.class);
 
         let invalid_mros = class_definitions.filter_map(|class| {
@@ -1284,7 +1284,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                 Type::Tuple(tuple) => UnionType::from_elements(
                     self.db,
                     tuple.elements(self.db).iter().map(|ty| {
-                        ty.into_class_literal_type().map_or(Type::Todo, |class_ty| {
+                        ty.into_class_literal().map_or(Type::Todo, |class_ty| {
                             Type::Instance(class_ty.to_instance_type())
                         })
                     }),
@@ -3819,7 +3819,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                 let value_ty = self.infer_expression(value);
 
                 if value_ty
-                    .into_class_literal_type()
+                    .into_class_literal()
                     .is_some_and(|ClassLiteralType { class }| {
                         class.is_known(self.db, KnownClass::Tuple)
                     })

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -51,18 +51,18 @@ use crate::stdlib::builtins_module_scope;
 use crate::types::diagnostic::{
     TypeCheckDiagnostic, TypeCheckDiagnostics, TypeCheckDiagnosticsBuilder,
 };
+use crate::types::mro::MroErrorKind;
 use crate::types::unpacker::{UnpackResult, Unpacker};
 use crate::types::{
     bindings_ty, builtins_symbol, declarations_ty, global_symbol, symbol, typing_extensions_symbol,
-    Boundness, BytesLiteralType, ClassType, FunctionType, InstanceType, IterationOutcome,
-    KnownClass, KnownFunction, KnownInstance, SliceLiteralType, StringLiteralType, Symbol,
-    Truthiness, TupleType, Type, TypeArrayDisplay, UnionBuilder, UnionType,
+    Boundness, BytesLiteralType, Class, ClassLiteralType, FunctionType, InstanceType,
+    IterationOutcome, KnownClass, KnownFunction, KnownInstance, SliceLiteralType,
+    StringLiteralType, Symbol, Truthiness, TupleType, Type, TypeArrayDisplay, UnionBuilder,
+    UnionType,
 };
 use crate::unpack::Unpack;
 use crate::util::subscript::{PyIndex, PySlice};
 use crate::Db;
-
-use super::mro::MroErrorKind;
 
 /// Infer all types for a [`ScopeId`], including all definitions and expressions in that scope.
 /// Use when checking a scope, or needing to provide a type for an arbitrary expression in the
@@ -457,7 +457,8 @@ impl<'db> TypeInferenceBuilder<'db> {
             .types
             .declarations
             .values()
-            .filter_map(|ty| ty.into_class_literal_type());
+            .filter_map(|ty| ty.into_class_literal_type())
+            .map(|class_ty| class_ty.class);
 
         let invalid_mros = class_definitions.filter_map(|class| {
             class
@@ -947,7 +948,11 @@ impl<'db> TypeInferenceBuilder<'db> {
         self.infer_definition(class);
     }
 
-    fn infer_class_definition(&mut self, class: &ast::StmtClassDef, definition: Definition<'db>) {
+    fn infer_class_definition(
+        &mut self,
+        class_node: &ast::StmtClassDef,
+        definition: Definition<'db>,
+    ) {
         let ast::StmtClassDef {
             range: _,
             name,
@@ -955,7 +960,7 @@ impl<'db> TypeInferenceBuilder<'db> {
             decorator_list,
             arguments: _,
             body: _,
-        } = class;
+        } = class_node;
 
         for decorator in decorator_list {
             self.infer_decorator(decorator);
@@ -963,26 +968,22 @@ impl<'db> TypeInferenceBuilder<'db> {
 
         let body_scope = self
             .index
-            .node_scope(NodeWithScopeRef::Class(class))
+            .node_scope(NodeWithScopeRef::Class(class_node))
             .to_scope_id(self.db, self.file);
 
         let maybe_known_class = file_to_module(self.db, self.file)
             .as_ref()
             .and_then(|module| KnownClass::maybe_from_module(module, name.as_str()));
 
-        let class_ty = Type::ClassLiteral(ClassType::new(
-            self.db,
-            &*name.id,
-            body_scope,
-            maybe_known_class,
-        ));
+        let class = Class::new(self.db, &*name.id, body_scope, maybe_known_class);
+        let class_ty = Type::ClassLiteral(ClassLiteralType { class });
 
-        self.add_declaration_with_binding(class.into(), definition, class_ty, class_ty);
+        self.add_declaration_with_binding(class_node.into(), definition, class_ty, class_ty);
 
         // if there are type parameters, then the keywords and bases are within that scope
         // and we don't need to run inference here
         if type_params.is_none() {
-            for keyword in class.keywords() {
+            for keyword in class_node.keywords() {
                 self.infer_expression(&keyword.value);
             }
 
@@ -991,7 +992,7 @@ impl<'db> TypeInferenceBuilder<'db> {
             if self.are_all_types_deferred() {
                 self.types.has_deferred = true;
             } else {
-                for base in class.bases() {
+                for base in class_node.bases() {
                     self.infer_expression(base);
                 }
             }
@@ -1279,12 +1280,13 @@ impl<'db> TypeInferenceBuilder<'db> {
             // anything else is invalid and should lead to a diagnostic being reported --Alex
             match node_ty {
                 Type::Any | Type::Unknown => node_ty,
-                Type::ClassLiteral(class_ty) => class_ty.to_instance(),
+                Type::ClassLiteral(class_ty) => Type::Instance(class_ty.to_instance_type()),
                 Type::Tuple(tuple) => UnionType::from_elements(
                     self.db,
                     tuple.elements(self.db).iter().map(|ty| {
-                        ty.into_class_literal_type()
-                            .map_or(Type::Todo, ClassType::to_instance)
+                        ty.into_class_literal_type().map_or(Type::Todo, |class_ty| {
+                            Type::Instance(class_ty.to_instance_type())
+                        })
                     }),
                 ),
                 _ => Type::Todo,
@@ -3343,18 +3345,10 @@ impl<'db> TypeInferenceBuilder<'db> {
             }
 
             // Lookup the rich comparison `__dunder__` methods on instances
-            (
-                Type::Instance(InstanceType {
-                    class: left_class, ..
-                }),
-                Type::Instance(InstanceType {
-                    class: right_class, ..
-                }),
-            ) => {
-                let rich_comparison =
-                    |op| perform_rich_comparison(self.db, left_class, right_class, op);
+            (Type::Instance(left), Type::Instance(right)) => {
+                let rich_comparison = |op| perform_rich_comparison(self.db, left, right, op);
                 let membership_test_comparison =
-                    |op| perform_membership_test_comparison(self.db, left_class, right_class, op);
+                    |op| perform_membership_test_comparison(self.db, left, right, op);
                 match op {
                     ast::CmpOp::Eq => rich_comparison(RichCompareOperator::Eq),
                     ast::CmpOp::NotEq => rich_comparison(RichCompareOperator::Ne),
@@ -3645,7 +3639,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                         }
                     }
 
-                    if matches!(value_ty, Type::ClassLiteral(class) if class.is_known(self.db, KnownClass::Type))
+                    if matches!(value_ty, Type::ClassLiteral(ClassLiteralType { class }) if class.is_known(self.db, KnownClass::Type))
                     {
                         return KnownClass::GenericAlias.to_instance(self.db);
                     }
@@ -3782,10 +3776,10 @@ impl<'db> TypeInferenceBuilder<'db> {
 
 /// Type expressions
 impl<'db> TypeInferenceBuilder<'db> {
-    fn infer_type_expression(&mut self, expression: &ast::Expr) -> Type<'db> {
+    fn infer_type_expression_impl(&mut self, expression: &ast::Expr) -> Type<'db> {
         // https://typing.readthedocs.io/en/latest/spec/annotations.html#grammar-token-expression-grammar-type_expression
 
-        let ty = match expression {
+        match expression {
             ast::Expr::Name(name) => {
                 debug_assert_eq!(name.ctx, ast::ExprContext::Load);
                 self.infer_name_expression(name).to_instance(self.db)
@@ -3826,7 +3820,9 @@ impl<'db> TypeInferenceBuilder<'db> {
 
                 if value_ty
                     .into_class_literal_type()
-                    .is_some_and(|class| class.is_known(self.db, KnownClass::Tuple))
+                    .is_some_and(|ClassLiteralType { class }| {
+                        class.is_known(self.db, KnownClass::Tuple)
+                    })
                 {
                     self.infer_tuple_type_expression(slice)
                 } else {
@@ -3941,12 +3937,14 @@ impl<'db> TypeInferenceBuilder<'db> {
             }
 
             ast::Expr::IpyEscapeCommand(_) => todo!("Implement Ipy escape command support"),
-        };
+        }
+    }
 
+    fn infer_type_expression(&mut self, expression: &ast::Expr) -> Type<'db> {
+        let ty = self.infer_type_expression_impl(expression);
         let expr_id = expression.scoped_ast_id(self.db, self.scope());
         let previous = self.types.expressions.insert(expr_id, ty);
         assert!(previous.is_none());
-
         ty
     }
 
@@ -4268,8 +4266,8 @@ impl StringPartsCollector {
 /// see `<https://docs.python.org/3/reference/datamodel.html#object.__lt__>`
 fn perform_rich_comparison<'db>(
     db: &'db dyn Db,
-    left_class: ClassType<'db>,
-    right_class: ClassType<'db>,
+    left: InstanceType<'db>,
+    right: InstanceType<'db>,
     op: RichCompareOperator,
 ) -> Result<Type<'db>, CompareUnsupportedError<'db>> {
     // The following resource has details about the rich comparison algorithm:
@@ -4278,23 +4276,22 @@ fn perform_rich_comparison<'db>(
     // TODO: this currently gives the return type even if the arg types are invalid
     // (e.g. int.__lt__ with string instance should be errored, currently bool)
 
-    let call_dunder =
-        |op: RichCompareOperator, left_class: ClassType<'db>, right_class: ClassType<'db>| {
-            match left_class.class_member(db, op.dunder()) {
-                Symbol::Type(class_member_dunder, Boundness::Bound) => class_member_dunder
-                    .call(db, &[left_class.to_instance(), right_class.to_instance()])
-                    .return_ty(db),
-                _ => None,
-            }
-        };
+    let call_dunder = |op: RichCompareOperator,
+                       left: InstanceType<'db>,
+                       right: InstanceType<'db>| {
+        match left.class.class_member(db, op.dunder()) {
+            Symbol::Type(class_member_dunder, Boundness::Bound) => class_member_dunder
+                .call(db, &[Type::Instance(left), Type::Instance(right)])
+                .return_ty(db),
+            _ => None,
+        }
+    };
 
     // The reflected dunder has priority if the right-hand side is a strict subclass of the left-hand side.
-    if left_class != right_class && right_class.is_subclass_of(db, left_class) {
-        call_dunder(op.reflect(), right_class, left_class)
-            .or_else(|| call_dunder(op, left_class, right_class))
+    if left != right && right.is_instance_of(db, left.class) {
+        call_dunder(op.reflect(), right, left).or_else(|| call_dunder(op, left, right))
     } else {
-        call_dunder(op, left_class, right_class)
-            .or_else(|| call_dunder(op.reflect(), right_class, left_class))
+        call_dunder(op, left, right).or_else(|| call_dunder(op.reflect(), right, left))
     }
     .or_else(|| {
         // When no appropriate method returns any value other than NotImplemented,
@@ -4308,8 +4305,8 @@ fn perform_rich_comparison<'db>(
     })
     .ok_or_else(|| CompareUnsupportedError {
         op: op.into(),
-        left_ty: left_class.to_instance(),
-        right_ty: right_class.to_instance(),
+        left_ty: left.into(),
+        right_ty: right.into(),
     })
 }
 
@@ -4319,23 +4316,21 @@ fn perform_rich_comparison<'db>(
 /// and `<https://docs.python.org/3/reference/expressions.html#membership-test-details>`
 fn perform_membership_test_comparison<'db>(
     db: &'db dyn Db,
-    left_class: ClassType<'db>,
-    right_class: ClassType<'db>,
+    left: InstanceType<'db>,
+    right: InstanceType<'db>,
     op: MembershipTestCompareOperator,
 ) -> Result<Type<'db>, CompareUnsupportedError<'db>> {
-    let (left_instance, right_instance) = (left_class.to_instance(), right_class.to_instance());
-
-    let contains_dunder = right_class.class_member(db, "__contains__");
+    let contains_dunder = right.class.class_member(db, "__contains__");
     let compare_result_opt = match contains_dunder {
         Symbol::Type(contains_dunder, Boundness::Bound) => {
             // If `__contains__` is available, it is used directly for the membership test.
             contains_dunder
-                .call(db, &[right_instance, left_instance])
+                .call(db, &[Type::Instance(right), Type::Instance(left)])
                 .return_ty(db)
         }
         _ => {
             // iteration-based membership test
-            match right_instance.iterate(db) {
+            match Type::Instance(right).iterate(db) {
                 IterationOutcome::Iterable { .. } => Some(KnownClass::Bool.to_instance(db)),
                 IterationOutcome::NotIterable { .. } => None,
             }
@@ -4355,8 +4350,8 @@ fn perform_membership_test_comparison<'db>(
         })
         .ok_or_else(|| CompareUnsupportedError {
             op: op.into(),
-            left_ty: left_instance,
-            right_ty: right_instance,
+            left_ty: left.into(),
+            right_ty: right.into(),
         })
 }
 
@@ -4377,7 +4372,6 @@ mod tests {
     use ruff_db::parsed::parsed_module;
     use ruff_db::system::{DbWithTestSystem, SystemPathBuf};
     use ruff_db::testing::assert_function_query_was_not_run;
-    use ruff_python_ast::name::Name;
 
     use super::*;
 
@@ -4504,11 +4498,10 @@ mod tests {
         )?;
 
         let mod_file = system_path_to_file(&db, "src/mod.py").unwrap();
-        let ty = global_symbol(&db, mod_file, "C").expect_type();
-        let class_id = ty.expect_class_literal();
-        let member_ty = class_id
-            .class_member(&db, &Name::new_static("f"))
-            .expect_type();
+        let class_ty = global_symbol(&db, mod_file, "C")
+            .expect_type()
+            .expect_class_literal();
+        let member_ty = class_ty.member(&db, "f").expect_type();
         let func = member_ty.expect_function_literal();
 
         assert_eq!(func.name(&db), "f");
@@ -4718,14 +4711,14 @@ mod tests {
 
         let a = system_path_to_file(&db, "src/a.py").expect("file to exist");
         let c_ty = global_symbol(&db, a, "C").expect_type();
-        let c_class = c_ty.expect_class_literal();
+        let c_class = c_ty.expect_class_literal().class;
         let mut c_mro = c_class.iter_mro(&db);
         let b_ty = c_mro.nth(1).unwrap();
-        let b_class = b_ty.expect_class();
+        let b_class = b_ty.expect_class_base();
         assert_eq!(b_class.name(&db), "B");
         let mut b_mro = b_class.iter_mro(&db);
         let a_ty = b_mro.nth(1).unwrap();
-        let a_class = a_ty.expect_class();
+        let a_class = a_ty.expect_class_base();
         assert_eq!(a_class.name(&db), "A");
 
         Ok(())
@@ -4874,7 +4867,12 @@ mod tests {
         db.write_file("/src/a.pyi", "class C(object): pass")?;
         let file = system_path_to_file(&db, "/src/a.pyi").unwrap();
         let ty = global_symbol(&db, file, "C").expect_type();
-        let base = ty.expect_class_literal().iter_mro(&db).nth(1).unwrap();
+        let base = ty
+            .expect_class_literal()
+            .class
+            .iter_mro(&db)
+            .nth(1)
+            .unwrap();
         assert_eq!(base.display(&db).to_string(), "<class 'object'>");
         Ok(())
     }

--- a/crates/red_knot_python_semantic/src/types/mro.rs
+++ b/crates/red_knot_python_semantic/src/types/mro.rs
@@ -350,7 +350,7 @@ impl<'db> ClassBase<'db> {
     fn object(db: &'db dyn Db) -> Self {
         KnownClass::Object
             .to_class(db)
-            .into_class_literal_type()
+            .into_class_literal()
             .map_or(Self::Unknown, |ClassLiteralType { class }| {
                 Self::Class(class)
             })
@@ -475,7 +475,7 @@ fn class_is_cyclically_defined(db: &dyn Db, class: Class) -> bool {
             .explicit_bases(db)
             .iter()
             .copied()
-            .filter_map(Type::into_class_literal_type)
+            .filter_map(Type::into_class_literal)
             .map(|ClassLiteralType { class }| class)
         {
             // Each base must be considered in isolation.
@@ -495,7 +495,7 @@ fn class_is_cyclically_defined(db: &dyn Db, class: Class) -> bool {
         .explicit_bases(db)
         .iter()
         .copied()
-        .filter_map(Type::into_class_literal_type)
+        .filter_map(Type::into_class_literal)
         .map(|ClassLiteralType { class }| class)
         .any(|base_class| is_cyclically_defined_recursive(db, base_class, &mut IndexSet::default()))
 }

--- a/crates/red_knot_python_semantic/src/types/narrow.rs
+++ b/crates/red_knot_python_semantic/src/types/narrow.rs
@@ -332,7 +332,7 @@ impl<'db> NarrowingConstraintsBuilder<'db> {
 
         if let Some(func_type) = inference
             .expression_ty(expr_call.func.scoped_ast_id(self.db, scope))
-            .into_function_literal_type()
+            .into_function_literal()
         {
             if func_type.is_known(self.db, KnownFunction::IsInstance)
                 && expr_call.arguments.keywords.is_empty()

--- a/crates/red_knot_python_semantic/src/types/narrow.rs
+++ b/crates/red_knot_python_semantic/src/types/narrow.rs
@@ -88,7 +88,7 @@ fn generate_isinstance_constraint<'db>(
     classinfo: &Type<'db>,
 ) -> Option<Type<'db>> {
     match classinfo {
-        Type::ClassLiteral(class) => Some(class.to_instance()),
+        Type::ClassLiteral(class_ty) => Some(Type::Instance(class_ty.to_instance_type())),
         Type::Tuple(tuple) => {
             let mut builder = UnionBuilder::new(db);
             for element in tuple.elements(db) {

--- a/crates/red_knot_python_semantic/src/types/narrow.rs
+++ b/crates/red_knot_python_semantic/src/types/narrow.rs
@@ -5,8 +5,8 @@ use crate::semantic_index::expression::Expression;
 use crate::semantic_index::symbol::{ScopeId, ScopedSymbolId, SymbolTable};
 use crate::semantic_index::symbol_table;
 use crate::types::{
-    infer_expression_types, IntersectionBuilder, KnownClass, KnownFunction, Truthiness, Type,
-    UnionBuilder,
+    infer_expression_types, ClassLiteralType, IntersectionBuilder, KnownClass, KnownFunction,
+    Truthiness, Type, UnionBuilder,
 };
 use crate::Db;
 use itertools::Itertools;
@@ -88,7 +88,7 @@ fn generate_isinstance_constraint<'db>(
     classinfo: &Type<'db>,
 ) -> Option<Type<'db>> {
     match classinfo {
-        Type::ClassLiteral(class_ty) => Some(Type::Instance(class_ty.to_instance_type())),
+        Type::ClassLiteral(ClassLiteralType { class }) => Some(Type::anonymous_instance(*class)),
         Type::Tuple(tuple) => {
             let mut builder = UnionBuilder::new(db);
             for element in tuple.elements(db) {


### PR DESCRIPTION
## Summary

The struct on `main` called `ClassType` does not actually represent a type. It represents inner data for a type -- but exactly how the data should be interpreted depends on what kind of type is wrapping the inner data. `Type::ClassLiteral()` and `Type::Instance()` both wrap the struct-currently-known-as-ClassType, but they're very different kinds of types: the first is a singleton type representing a single class object at runtime, whereas the second represents a type of unknown size representing all (possible) instances of a single class object at runtime.

To clarify the situation here, this PR renames the class-currently-known-as-ClassType to `Class`. This reflects better the fact that it represents data representing a class object at runtime, but does not in itself represent a type. In the refactor that this PR proposes, we now have two `*Type` structs that wrap `Class`: `InstanceType` and `ClassLiteralType`. The `Type::ClassLiteral` enum variant wraps `ClassLiteralType` instead of wrapping `Class` directly.

This refactor allows us to pass around objects that unambiguously represent specific types without having to wrap the objects in variants the `Type` enum. In particular, the signatures of `perform_rich_comparison` and `perform_membership_test_comparison` become much more expressive and type-safe.

## Test Plan

`cargo test -p red_knot_python_semantic`
