### PR TITLE
Use accumulator for diagnostics

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,6 +51,10 @@ repos:
       - id: blacken-docs
         args: ["--pyi", "--line-length", "130"]
         files: '^crates/.*/resources/mdtest/.*\.md'
+        exclude: |
+          (?x)^(
+            .*?invalid(_.+)_syntax.md
+          )$
         additional_dependencies:
           - black==24.10.0
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2432,7 +2432,6 @@ dependencies = [
  "salsa",
  "serde",
  "tempfile",
- "thiserror",
  "tracing",
  "tracing-subscriber",
  "tracing-tree",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2220,7 +2220,6 @@ dependencies = [
  "ruff_cache",
  "ruff_db",
  "ruff_python_ast",
- "ruff_text_size",
  "rustc-hash 2.0.0",
  "salsa",
  "tempfile",

--- a/crates/red_knot/src/main.rs
+++ b/crates/red_knot/src/main.rs
@@ -5,6 +5,7 @@ use anyhow::{anyhow, Context};
 use clap::Parser;
 use colored::Colorize;
 use crossbeam::channel as crossbeam_channel;
+use ruff_db::diagnostic::CompileDiagnostic;
 use salsa::plumbing::ZalsaDatabase;
 
 use red_knot_python_semantic::SitePackages;
@@ -318,8 +319,9 @@ impl MainLoop {
                 } => {
                     let has_diagnostics = !result.is_empty();
                     if check_revision == revision {
+                        #[allow(clippy::print_stdout)]
                         for diagnostic in result {
-                            tracing::error!("{}", diagnostic);
+                            println!("{}", diagnostic.display(db));
                         }
                     } else {
                         tracing::debug!(
@@ -378,7 +380,10 @@ impl MainLoopCancellationToken {
 #[derive(Debug)]
 enum MainLoopMessage {
     CheckWorkspace,
-    CheckCompleted { result: Vec<String>, revision: u64 },
+    CheckCompleted {
+        result: Vec<CompileDiagnostic>,
+        revision: u64,
+    },
     ApplyChanges(Vec<watch::ChangeEvent>),
     Exit,
 }

--- a/crates/red_knot_python_semantic/resources/mdtest/exception/invalid_exception_syntax.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/exception/invalid_exception_syntax.md
@@ -1,0 +1,12 @@
+# Exception Handling
+
+## Invalid syntax
+
+```py
+from typing_extensions import reveal_type
+
+try:
+    print
+except as e:  # error: [invalid-syntax]
+    reveal_type(e)  # revealed: Unknown
+```

--- a/crates/red_knot_python_semantic/resources/mdtest/unpacking.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/unpacking.md
@@ -145,12 +145,7 @@ reveal_type(f)  # revealed: Unknown
 
 ### Non-iterable unpacking
 
-TODO: Remove duplicate diagnostics. This is happening because for a sequence-like assignment target,
-multiple definitions are created and the inference engine runs on each of them which results in
-duplicate diagnostics.
-
 ```py
-# error: "Object of type `Literal[1]` is not iterable"
 # error: "Object of type `Literal[1]` is not iterable"
 a, b = 1
 reveal_type(a)  # revealed: Unknown

--- a/crates/red_knot_python_semantic/src/types/diagnostic.rs
+++ b/crates/red_knot_python_semantic/src/types/diagnostic.rs
@@ -1,12 +1,197 @@
+use ruff_db::diagnostic::{CompileDiagnostic, Diagnostic, Severity};
 use ruff_db::files::File;
 use ruff_python_ast::{self as ast, AnyNodeRef};
 use ruff_text_size::{Ranged, TextRange};
-use std::fmt::Formatter;
-use std::ops::Deref;
-use std::sync::Arc;
+use std::borrow::Cow;
 
 use crate::types::{ClassLiteralType, Type};
 use crate::Db;
+
+/// Returns `true` if any diagnostic is enabled for this file.
+pub(crate) fn is_any_diagnostic_enabled(db: &dyn Db, file: File) -> bool {
+    db.is_file_open(file)
+}
+
+pub(crate) fn report_type_diagnostic(
+    db: &dyn Db,
+    file: File,
+    node: AnyNodeRef,
+    rule: &str,
+    message: std::fmt::Arguments,
+) {
+    if !is_any_diagnostic_enabled(db, file) {
+        return;
+    }
+
+    // TODO: Don't emit the diagnostic if:
+    // * The enclosing node contains any syntax errors
+    // * The rule is disabled for this file. We probably want to introduce a new query that
+    //   returns a rule selector for a given file that respects the package's settings,
+    //   any global pragma comments in the file, and any per-file-ignores.
+
+    CompileDiagnostic::report(
+        db.upcast(),
+        TypeCheckDiagnostic {
+            file,
+            rule: rule.to_string(),
+            message: message.to_string(),
+            range: node.range(),
+        },
+    );
+}
+
+/// Emit a diagnostic declaring that the object represented by `node` is not iterable
+pub(super) fn report_not_iterable(
+    db: &dyn Db,
+    file: File,
+    node: AnyNodeRef,
+    not_iterable_ty: Type,
+) {
+    report_type_diagnostic(
+        db,
+        file,
+        node,
+        "not-iterable",
+        format_args!(
+            "Object of type `{}` is not iterable",
+            not_iterable_ty.display(db)
+        ),
+    );
+}
+
+/// Emit a diagnostic declaring that an index is out of bounds for a tuple.
+pub(super) fn report_index_out_of_bounds(
+    db: &dyn Db,
+    file: File,
+    kind: &'static str,
+    node: AnyNodeRef,
+    tuple_ty: Type,
+    length: usize,
+    index: i64,
+) {
+    report_type_diagnostic(
+        db,
+        file,
+        node,
+        "index-out-of-bounds",
+        format_args!(
+            "Index {index} is out of bounds for {kind} `{}` with length {length}",
+            tuple_ty.display(db)
+        ),
+    );
+}
+
+/// Emit a diagnostic declaring that a type does not support subscripting.
+pub(super) fn report_non_subscriptable(
+    db: &dyn Db,
+    file: File,
+    node: AnyNodeRef,
+    non_subscriptable_ty: Type,
+    method: &str,
+) {
+    report_type_diagnostic(
+        db,
+        file,
+        node,
+        "non-subscriptable",
+        format_args!(
+            "Cannot subscript object of type `{}` with no `{method}` method",
+            non_subscriptable_ty.display(db)
+        ),
+    );
+}
+
+pub(super) fn report_unresolved_module<'a>(
+    db: &dyn Db,
+    file: File,
+    import_node: impl Into<AnyNodeRef<'a>>,
+    level: u32,
+    module: Option<&str>,
+) {
+    report_type_diagnostic(
+        db,
+        file,
+        import_node.into(),
+        "unresolved-import",
+        format_args!(
+            "Cannot resolve import `{}{}`",
+            ".".repeat(level as usize),
+            module.unwrap_or_default()
+        ),
+    );
+}
+
+pub(super) fn report_slice_step_size_zero(db: &dyn Db, file: File, node: AnyNodeRef) {
+    report_type_diagnostic(
+        db,
+        file,
+        node,
+        "zero-stepsize-in-slice",
+        format_args!("Slice step size can not be zero"),
+    );
+}
+
+pub(super) fn report_invalid_assignment(
+    db: &dyn Db,
+    file: File,
+    node: AnyNodeRef,
+    declared_ty: Type,
+    assigned_ty: Type,
+) {
+    match declared_ty {
+        Type::ClassLiteral(ClassLiteralType { class }) => {
+            report_type_diagnostic(db, file, node, "invalid-assignment", format_args!(
+                    "Implicit shadowing of class `{}`; annotate to make it explicit if this is intentional",
+                    class.name(db)));
+        }
+        Type::FunctionLiteral(function) => {
+            report_type_diagnostic(db, file, node, "invalid-assignment", format_args!(
+                    "Implicit shadowing of function `{}`; annotate to make it explicit if this is intentional",
+                    function.name(db)));
+        }
+        _ => {
+            report_type_diagnostic(
+                db,
+                file,
+                node,
+                "invalid-assignment",
+                format_args!(
+                    "Object of type `{}` is not assignable to `{}`",
+                    assigned_ty.display(db),
+                    declared_ty.display(db),
+                ),
+            );
+        }
+    }
+}
+
+pub(super) fn report_possibly_unresolved_reference(
+    db: &dyn Db,
+    file: File,
+    expr_name_node: &ast::ExprName,
+) {
+    let ast::ExprName { id, .. } = expr_name_node;
+
+    report_type_diagnostic(
+        db,
+        file,
+        expr_name_node.into(),
+        "possibly-unresolved-reference",
+        format_args!("Name `{id}` used when possibly not defined"),
+    );
+}
+
+pub(super) fn report_unresolved_reference(db: &dyn Db, file: File, expr_name_node: &ast::ExprName) {
+    let ast::ExprName { id, .. } = expr_name_node;
+
+    report_type_diagnostic(
+        db,
+        file,
+        expr_name_node.into(),
+        "unresolved-reference",
+        format_args!("Name `{id}` used when not defined"),
+    );
+}
 
 #[derive(Debug, Eq, PartialEq)]
 pub struct TypeCheckDiagnostic {
@@ -22,265 +207,29 @@ impl TypeCheckDiagnostic {
         &self.rule
     }
 
-    pub fn message(&self) -> &str {
-        &self.message
-    }
-
-    pub fn file(&self) -> File {
-        self.file
-    }
-}
-
-impl Ranged for TypeCheckDiagnostic {
-    fn range(&self) -> TextRange {
+    pub fn range(&self) -> TextRange {
         self.range
     }
 }
 
-/// A collection of type check diagnostics.
-///
-/// The diagnostics are wrapped in an `Arc` because they need to be cloned multiple times
-/// when going from `infer_expression` to `check_file`. We could consider
-/// making [`TypeCheckDiagnostic`] a Salsa struct to have them Arena-allocated (once the Tables refactor is done).
-/// Using Salsa struct does have the downside that it leaks the Salsa dependency into diagnostics and
-/// each Salsa-struct comes with an overhead.
-#[derive(Default, Eq, PartialEq)]
-pub struct TypeCheckDiagnostics {
-    inner: Vec<std::sync::Arc<TypeCheckDiagnostic>>,
-}
-
-impl TypeCheckDiagnostics {
-    pub fn new() -> Self {
-        Self { inner: Vec::new() }
+impl Diagnostic for TypeCheckDiagnostic {
+    fn message(&self) -> std::borrow::Cow<str> {
+        Cow::Borrowed(&self.message)
     }
 
-    pub(super) fn push(&mut self, diagnostic: TypeCheckDiagnostic) {
-        self.inner.push(Arc::new(diagnostic));
+    fn file(&self) -> File {
+        self.file
     }
 
-    pub(crate) fn shrink_to_fit(&mut self) {
-        self.inner.shrink_to_fit();
-    }
-}
-
-impl Extend<TypeCheckDiagnostic> for TypeCheckDiagnostics {
-    fn extend<T: IntoIterator<Item = TypeCheckDiagnostic>>(&mut self, iter: T) {
-        self.inner.extend(iter.into_iter().map(std::sync::Arc::new));
-    }
-}
-
-impl Extend<std::sync::Arc<TypeCheckDiagnostic>> for TypeCheckDiagnostics {
-    fn extend<T: IntoIterator<Item = Arc<TypeCheckDiagnostic>>>(&mut self, iter: T) {
-        self.inner.extend(iter);
-    }
-}
-
-impl<'a> Extend<&'a std::sync::Arc<TypeCheckDiagnostic>> for TypeCheckDiagnostics {
-    fn extend<T: IntoIterator<Item = &'a Arc<TypeCheckDiagnostic>>>(&mut self, iter: T) {
-        self.inner
-            .extend(iter.into_iter().map(std::sync::Arc::clone));
-    }
-}
-
-impl std::fmt::Debug for TypeCheckDiagnostics {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        self.inner.fmt(f)
-    }
-}
-
-impl Deref for TypeCheckDiagnostics {
-    type Target = [std::sync::Arc<TypeCheckDiagnostic>];
-
-    fn deref(&self) -> &Self::Target {
-        &self.inner
-    }
-}
-
-impl IntoIterator for TypeCheckDiagnostics {
-    type Item = Arc<TypeCheckDiagnostic>;
-    type IntoIter = std::vec::IntoIter<std::sync::Arc<TypeCheckDiagnostic>>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        self.inner.into_iter()
-    }
-}
-
-impl<'a> IntoIterator for &'a TypeCheckDiagnostics {
-    type Item = &'a Arc<TypeCheckDiagnostic>;
-    type IntoIter = std::slice::Iter<'a, std::sync::Arc<TypeCheckDiagnostic>>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        self.inner.iter()
-    }
-}
-
-pub(super) struct TypeCheckDiagnosticsBuilder<'db> {
-    db: &'db dyn Db,
-    file: File,
-    diagnostics: TypeCheckDiagnostics,
-}
-
-impl<'db> TypeCheckDiagnosticsBuilder<'db> {
-    pub(super) fn new(db: &'db dyn Db, file: File) -> Self {
-        Self {
-            db,
-            file,
-            diagnostics: TypeCheckDiagnostics::new(),
-        }
+    fn range(&self) -> Option<TextRange> {
+        Some(self.range)
     }
 
-    /// Emit a diagnostic declaring that the object represented by `node` is not iterable
-    pub(super) fn add_not_iterable(&mut self, node: AnyNodeRef, not_iterable_ty: Type<'db>) {
-        self.add(
-            node,
-            "not-iterable",
-            format_args!(
-                "Object of type `{}` is not iterable",
-                not_iterable_ty.display(self.db)
-            ),
-        );
+    fn severity(&self) -> Severity {
+        Severity::Error
     }
 
-    /// Emit a diagnostic declaring that an index is out of bounds for a tuple.
-    pub(super) fn add_index_out_of_bounds(
-        &mut self,
-        kind: &'static str,
-        node: AnyNodeRef,
-        tuple_ty: Type<'db>,
-        length: usize,
-        index: i64,
-    ) {
-        self.add(
-            node,
-            "index-out-of-bounds",
-            format_args!(
-                "Index {index} is out of bounds for {kind} `{}` with length {length}",
-                tuple_ty.display(self.db)
-            ),
-        );
-    }
-
-    /// Emit a diagnostic declaring that a type does not support subscripting.
-    pub(super) fn add_non_subscriptable(
-        &mut self,
-        node: AnyNodeRef,
-        non_subscriptable_ty: Type<'db>,
-        method: &str,
-    ) {
-        self.add(
-            node,
-            "non-subscriptable",
-            format_args!(
-                "Cannot subscript object of type `{}` with no `{method}` method",
-                non_subscriptable_ty.display(self.db)
-            ),
-        );
-    }
-
-    pub(super) fn add_unresolved_module(
-        &mut self,
-        import_node: impl Into<AnyNodeRef<'db>>,
-        level: u32,
-        module: Option<&str>,
-    ) {
-        self.add(
-            import_node.into(),
-            "unresolved-import",
-            format_args!(
-                "Cannot resolve import `{}{}`",
-                ".".repeat(level as usize),
-                module.unwrap_or_default()
-            ),
-        );
-    }
-
-    pub(super) fn add_slice_step_size_zero(&mut self, node: AnyNodeRef) {
-        self.add(
-            node,
-            "zero-stepsize-in-slice",
-            format_args!("Slice step size can not be zero"),
-        );
-    }
-
-    pub(super) fn add_invalid_assignment(
-        &mut self,
-        node: AnyNodeRef,
-        declared_ty: Type<'db>,
-        assigned_ty: Type<'db>,
-    ) {
-        match declared_ty {
-            Type::ClassLiteral(ClassLiteralType { class }) => {
-                self.add(node, "invalid-assignment", format_args!(
-                        "Implicit shadowing of class `{}`; annotate to make it explicit if this is intentional",
-                        class.name(self.db)));
-            }
-            Type::FunctionLiteral(function) => {
-                self.add(node, "invalid-assignment", format_args!(
-                        "Implicit shadowing of function `{}`; annotate to make it explicit if this is intentional",
-                        function.name(self.db)));
-            }
-            _ => {
-                self.add(
-                    node,
-                    "invalid-assignment",
-                    format_args!(
-                        "Object of type `{}` is not assignable to `{}`",
-                        assigned_ty.display(self.db),
-                        declared_ty.display(self.db),
-                    ),
-                );
-            }
-        }
-    }
-
-    pub(super) fn add_possibly_unresolved_reference(&mut self, expr_name_node: &ast::ExprName) {
-        let ast::ExprName { id, .. } = expr_name_node;
-
-        self.add(
-            expr_name_node.into(),
-            "possibly-unresolved-reference",
-            format_args!("Name `{id}` used when possibly not defined"),
-        );
-    }
-
-    pub(super) fn add_unresolved_reference(&mut self, expr_name_node: &ast::ExprName) {
-        let ast::ExprName { id, .. } = expr_name_node;
-
-        self.add(
-            expr_name_node.into(),
-            "unresolved-reference",
-            format_args!("Name `{id}` used when not defined"),
-        );
-    }
-
-    /// Adds a new diagnostic.
-    ///
-    /// The diagnostic does not get added if the rule isn't enabled for this file.
-    pub(super) fn add(&mut self, node: AnyNodeRef, rule: &str, message: std::fmt::Arguments) {
-        if !self.db.is_file_open(self.file) {
-            return;
-        }
-
-        // TODO: Don't emit the diagnostic if:
-        // * The enclosing node contains any syntax errors
-        // * The rule is disabled for this file. We probably want to introduce a new query that
-        //   returns a rule selector for a given file that respects the package's settings,
-        //   any global pragma comments in the file, and any per-file-ignores.
-
-        self.diagnostics.push(TypeCheckDiagnostic {
-            file: self.file,
-            rule: rule.to_string(),
-            message: message.to_string(),
-            range: node.range(),
-        });
-    }
-
-    pub(super) fn extend(&mut self, diagnostics: &TypeCheckDiagnostics) {
-        self.diagnostics.extend(diagnostics);
-    }
-
-    pub(super) fn finish(mut self) -> TypeCheckDiagnostics {
-        self.diagnostics.shrink_to_fit();
-        self.diagnostics
+    fn rule(&self) -> &str {
+        &self.rule
     }
 }

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -5106,34 +5106,6 @@ mod tests {
     }
 
     #[test]
-    fn exception_handler_with_invalid_syntax() -> anyhow::Result<()> {
-        let mut db = setup_db();
-
-        db.write_dedented(
-            "src/a.py",
-            "
-            from typing_extensions import reveal_type
-
-            try:
-                print
-            except as e:
-                reveal_type(e)
-            ",
-        )?;
-
-        assert_file_diagnostics(
-            &db,
-            "src/a.py",
-            &[
-                "Expected one or more exception types",
-                "Revealed type is `Unknown`",
-            ],
-        );
-
-        Ok(())
-    }
-
-    #[test]
     fn basic_comprehension() -> anyhow::Result<()> {
         let mut db = setup_db();
 

--- a/crates/red_knot_server/src/edit.rs
+++ b/crates/red_knot_server/src/edit.rs
@@ -6,7 +6,7 @@ mod text_document;
 
 use lsp_types::{PositionEncodingKind, Url};
 pub use notebook::NotebookDocument;
-pub(crate) use range::RangeExt;
+pub(crate) use range::{RangeExt, ToRangeExt};
 pub(crate) use text_document::DocumentVersion;
 pub use text_document::TextDocument;
 

--- a/crates/red_knot_test/src/diagnostic.rs
+++ b/crates/red_knot_test/src/diagnostic.rs
@@ -3,8 +3,9 @@
 //! We don't assume that we will get the diagnostics in source order.
 
 use ruff_source_file::{LineIndex, OneIndexed};
-use ruff_text_size::Ranged;
 use std::ops::{Deref, Range};
+
+use crate::matcher::Diagnostic;
 
 /// All diagnostics for one embedded Python file, sorted and grouped by start line number.
 ///
@@ -19,7 +20,7 @@ pub(crate) struct SortedDiagnostics<T> {
 
 impl<T> SortedDiagnostics<T>
 where
-    T: Ranged + Clone,
+    T: Diagnostic,
 {
     pub(crate) fn new(diagnostics: impl IntoIterator<Item = T>, line_index: &LineIndex) -> Self {
         let mut diagnostics: Vec<_> = diagnostics
@@ -94,7 +95,7 @@ pub(crate) struct LineDiagnosticsIterator<'a, T> {
 
 impl<'a, T> Iterator for LineDiagnosticsIterator<'a, T>
 where
-    T: Ranged + Clone,
+    T: Diagnostic,
 {
     type Item = LineDiagnostics<'a, T>;
 
@@ -110,7 +111,7 @@ where
     }
 }
 
-impl<T> std::iter::FusedIterator for LineDiagnosticsIterator<'_, T> where T: Clone + Ranged {}
+impl<T> std::iter::FusedIterator for LineDiagnosticsIterator<'_, T> where T: Diagnostic {}
 
 /// All diagnostics that start on a single line of source code in one embedded Python file.
 #[derive(Debug)]
@@ -139,6 +140,7 @@ struct DiagnosticWithLine<T> {
 #[cfg(test)]
 mod tests {
     use crate::db::Db;
+    use crate::matcher::Diagnostic;
     use ruff_db::files::system_path_to_file;
     use ruff_db::source::line_index;
     use ruff_db::system::{DbWithTestSystem, SystemPathBuf};
@@ -152,13 +154,18 @@ mod tests {
         let file = system_path_to_file(&db, "/src/test.py").unwrap();
         let lines = line_index(&db, file);
 
-        let ranges = vec![
+        let ranges = [
             TextRange::new(TextSize::new(0), TextSize::new(1)),
             TextRange::new(TextSize::new(5), TextSize::new(10)),
             TextRange::new(TextSize::new(1), TextSize::new(7)),
         ];
 
-        let sorted = super::SortedDiagnostics::new(&ranges, &lines);
+        let diagnostics: Vec<_> = ranges
+            .into_iter()
+            .map(|range| DummyDiagnostic { range })
+            .collect();
+
+        let sorted = super::SortedDiagnostics::new(diagnostics, &lines);
         let grouped = sorted.iter_lines().collect::<Vec<_>>();
 
         let [line1, line2] = &grouped[..] else {
@@ -169,5 +176,23 @@ mod tests {
         assert_eq!(line1.diagnostics.len(), 2);
         assert_eq!(line2.line_number, OneIndexed::from_zero_indexed(1));
         assert_eq!(line2.diagnostics.len(), 1);
+    }
+
+    struct DummyDiagnostic {
+        range: TextRange,
+    }
+
+    impl Diagnostic for DummyDiagnostic {
+        fn rule(&self) -> &str {
+            "dummy"
+        }
+
+        fn message(&self) -> std::borrow::Cow<str> {
+            "Dummy error".into()
+        }
+
+        fn range(&self) -> TextRange {
+            self.range
+        }
     }
 }

--- a/crates/red_knot_test/src/lib.rs
+++ b/crates/red_knot_test/src/lib.rs
@@ -3,7 +3,6 @@ use parser as test_parser;
 use red_knot_python_semantic::types::check_types;
 use ruff_db::diagnostic::{CompileDiagnostic, Diagnostic as _};
 use ruff_db::files::{system_path_to_file, File, Files};
-use ruff_db::parsed::parsed_module;
 use ruff_db::system::{DbWithTestSystem, SystemPathBuf};
 use ruff_source_file::LineIndex;
 use ruff_text_size::TextSize;
@@ -86,19 +85,8 @@ fn run_test(db: &mut db::Db, test: &parser::MarkdownTest) -> Result<(), Failures
     let failures: Failures = test_files
         .into_iter()
         .filter_map(|test_file| {
-            let parsed = parsed_module(db, test_file.file);
-
-            // TODO allow testing against code with syntax errors
-            assert!(
-                parsed.errors().is_empty(),
-                "Python syntax errors in {}, {}: {:?}",
-                test.name(),
-                test_file.file.path(db),
-                parsed.errors()
-            );
-
             let diagnostics: Vec<_> =
-                // The accumulator returns all diagnostics from all files. We're only interested into
+                // The accumulator returns all diagnostics from all files. We're only interested in
                 // diagnostics from this file.
                 check_types::accumulated::<CompileDiagnostic>(db, test_file.file)
                     .into_iter()

--- a/crates/red_knot_test/src/matcher.rs
+++ b/crates/red_knot_test/src/matcher.rs
@@ -4,11 +4,10 @@ use crate::assertion::{Assertion, ErrorAssertion, InlineFileAssertions};
 use crate::db::Db;
 use crate::diagnostic::SortedDiagnostics;
 use colored::Colorize;
+use ruff_db::diagnostic::Diagnostic;
 use ruff_db::files::File;
 use ruff_db::source::{line_index, source_text, SourceText};
 use ruff_source_file::{LineIndex, OneIndexed};
-use ruff_text_size::{TextRange, TextSize};
-use std::borrow::Cow;
 use std::cmp::Ordering;
 use std::ops::Range;
 
@@ -54,7 +53,7 @@ pub(super) fn match_file<T>(
     diagnostics: impl IntoIterator<Item = T>,
 ) -> Result<(), FailuresByLine>
 where
-    T: Diagnostic + Clone,
+    T: Diagnostic,
 {
     // Parse assertions from comments in the file, and get diagnostics from the file; both
     // ordered by line number.
@@ -122,36 +121,6 @@ where
         Ok(())
     } else {
         Err(failures)
-    }
-}
-
-pub(super) trait Diagnostic {
-    /// Returns the diagnostic's rule code.
-    fn rule(&self) -> &str;
-
-    fn message(&self) -> Cow<str>;
-
-    fn range(&self) -> TextRange;
-
-    fn start(&self) -> TextSize {
-        self.range().start()
-    }
-}
-
-impl<T> Diagnostic for T
-where
-    T: ruff_db::diagnostic::Diagnostic,
-{
-    fn rule(&self) -> &str {
-        ruff_db::diagnostic::Diagnostic::rule(self)
-    }
-
-    fn message(&self) -> Cow<str> {
-        ruff_db::diagnostic::Diagnostic::message(self)
-    }
-
-    fn range(&self) -> TextRange {
-        ruff_db::diagnostic::Diagnostic::range(self).unwrap_or_default()
     }
 }
 
@@ -266,10 +235,15 @@ impl Matcher {
         }
     }
 
-    fn column<T: Diagnostic>(&self, ranged: &T) -> OneIndexed {
-        self.line_index
-            .source_location(ranged.start(), &self.source)
-            .column
+    fn column<T: Diagnostic>(&self, diagnostic: &T) -> OneIndexed {
+        diagnostic
+            .range()
+            .map(|range| {
+                self.line_index
+                    .source_location(range.start(), &self.source)
+                    .column
+            })
+            .unwrap_or(OneIndexed::from_zero_indexed(0))
     }
 
     /// Check if `assertion` matches any [`Diagnostic`]s in `unmatched`.
@@ -335,23 +309,23 @@ impl Matcher {
 
 #[cfg(test)]
 mod tests {
-    use std::borrow::Cow;
-
     use super::FailuresByLine;
-    use ruff_db::files::system_path_to_file;
+    use ruff_db::diagnostic::{Diagnostic, Severity};
+    use ruff_db::files::{system_path_to_file, File};
     use ruff_db::system::{DbWithTestSystem, SystemPathBuf};
     use ruff_python_trivia::textwrap::dedent;
     use ruff_source_file::OneIndexed;
     use ruff_text_size::TextRange;
+    use std::borrow::Cow;
 
     #[derive(Clone, Debug)]
-    struct TestDiagnostic {
+    struct ExpectedDiagnostic {
         rule: &'static str,
         message: &'static str,
         range: TextRange,
     }
 
-    impl TestDiagnostic {
+    impl ExpectedDiagnostic {
         fn new(rule: &'static str, message: &'static str, offset: usize) -> Self {
             let offset: u32 = offset.try_into().unwrap();
             Self {
@@ -360,9 +334,26 @@ mod tests {
                 range: TextRange::new(offset.into(), (offset + 1).into()),
             }
         }
+
+        fn into_diagnostic(self, file: File) -> TestDiagnostic {
+            TestDiagnostic {
+                file,
+                rule: self.rule,
+                message: self.message,
+                range: self.range,
+            }
+        }
     }
 
-    impl super::Diagnostic for TestDiagnostic {
+    #[derive(Debug)]
+    struct TestDiagnostic {
+        file: File,
+        rule: &'static str,
+        message: &'static str,
+        range: TextRange,
+    }
+
+    impl Diagnostic for TestDiagnostic {
         fn rule(&self) -> &str {
             self.rule
         }
@@ -371,17 +362,33 @@ mod tests {
             Cow::Borrowed(self.message)
         }
 
-        fn range(&self) -> ruff_text_size::TextRange {
-            self.range
+        fn file(&self) -> File {
+            self.file
+        }
+
+        fn range(&self) -> Option<TextRange> {
+            Some(self.range)
+        }
+
+        fn severity(&self) -> Severity {
+            Severity::Error
         }
     }
 
-    fn get_result(source: &str, diagnostics: Vec<TestDiagnostic>) -> Result<(), FailuresByLine> {
+    fn get_result(
+        source: &str,
+        diagnostics: Vec<ExpectedDiagnostic>,
+    ) -> Result<(), FailuresByLine> {
         colored::control::set_override(false);
 
         let mut db = crate::db::Db::setup(SystemPathBuf::from("/src"));
         db.write_file("/src/test.py", source).unwrap();
         let file = system_path_to_file(&db, "/src/test.py").unwrap();
+
+        let diagnostics: Vec<_> = diagnostics
+            .into_iter()
+            .map(|diagnostic| diagnostic.into_diagnostic(file))
+            .collect();
 
         super::match_file(&db, file, diagnostics)
     }
@@ -418,7 +425,7 @@ mod tests {
     fn revealed_match() {
         let result = get_result(
             "x # revealed: Foo",
-            vec![TestDiagnostic::new(
+            vec![ExpectedDiagnostic::new(
                 "revealed-type",
                 "Revealed type is `Foo`",
                 0,
@@ -432,7 +439,7 @@ mod tests {
     fn revealed_wrong_rule() {
         let result = get_result(
             "x # revealed: Foo",
-            vec![TestDiagnostic::new(
+            vec![ExpectedDiagnostic::new(
                 "not-revealed-type",
                 "Revealed type is `Foo`",
                 0,
@@ -455,7 +462,11 @@ mod tests {
     fn revealed_wrong_message() {
         let result = get_result(
             "x # revealed: Foo",
-            vec![TestDiagnostic::new("revealed-type", "Something else", 0)],
+            vec![ExpectedDiagnostic::new(
+                "revealed-type",
+                "Something else",
+                0,
+            )],
         );
 
         assert_fail(
@@ -482,8 +493,8 @@ mod tests {
         let result = get_result(
             "x # revealed: Foo",
             vec![
-                TestDiagnostic::new("revealed-type", "Revealed type is `Foo`", 0),
-                TestDiagnostic::new("undefined-reveal", "Doesn't matter", 0),
+                ExpectedDiagnostic::new("revealed-type", "Revealed type is `Foo`", 0),
+                ExpectedDiagnostic::new("undefined-reveal", "Doesn't matter", 0),
             ],
         );
 
@@ -494,7 +505,11 @@ mod tests {
     fn revealed_match_with_only_undefined() {
         let result = get_result(
             "x # revealed: Foo",
-            vec![TestDiagnostic::new("undefined-reveal", "Doesn't matter", 0)],
+            vec![ExpectedDiagnostic::new(
+                "undefined-reveal",
+                "Doesn't matter",
+                0,
+            )],
         );
 
         assert_fail(result, &[(0, &["unmatched assertion: revealed: Foo"])]);
@@ -505,8 +520,8 @@ mod tests {
         let result = get_result(
             "x # revealed: Foo",
             vec![
-                TestDiagnostic::new("revealed-type", "Revealed type is `Bar`", 0),
-                TestDiagnostic::new("undefined-reveal", "Doesn't matter", 0),
+                ExpectedDiagnostic::new("revealed-type", "Revealed type is `Bar`", 0),
+                ExpectedDiagnostic::new("undefined-reveal", "Doesn't matter", 0),
             ],
         );
 
@@ -527,8 +542,8 @@ mod tests {
         let result = get_result(
             "reveal_type(1)",
             vec![
-                TestDiagnostic::new("undefined-reveal", "undefined reveal message", 0),
-                TestDiagnostic::new("revealed-type", "Revealed type is `Literal[1]`", 12),
+                ExpectedDiagnostic::new("undefined-reveal", "undefined reveal message", 0),
+                ExpectedDiagnostic::new("revealed-type", "Revealed type is `Literal[1]`", 12),
             ],
         );
 
@@ -550,8 +565,8 @@ mod tests {
         let result = get_result(
             "reveal_type(1) # error: [something-else]",
             vec![
-                TestDiagnostic::new("undefined-reveal", "undefined reveal message", 0),
-                TestDiagnostic::new("revealed-type", "Revealed type is `Literal[1]`", 12),
+                ExpectedDiagnostic::new("undefined-reveal", "undefined reveal message", 0),
+                ExpectedDiagnostic::new("revealed-type", "Revealed type is `Literal[1]`", 12),
             ],
         );
 
@@ -580,7 +595,7 @@ mod tests {
     fn error_match_rule() {
         let result = get_result(
             "x # error: [some-rule]",
-            vec![TestDiagnostic::new("some-rule", "Any message", 0)],
+            vec![ExpectedDiagnostic::new("some-rule", "Any message", 0)],
         );
 
         assert_ok(&result);
@@ -590,7 +605,7 @@ mod tests {
     fn error_wrong_rule() {
         let result = get_result(
             "x # error: [some-rule]",
-            vec![TestDiagnostic::new("anything", "Any message", 0)],
+            vec![ExpectedDiagnostic::new("anything", "Any message", 0)],
         );
 
         assert_fail(
@@ -609,7 +624,11 @@ mod tests {
     fn error_match_message() {
         let result = get_result(
             r#"x # error: "contains this""#,
-            vec![TestDiagnostic::new("anything", "message contains this", 0)],
+            vec![ExpectedDiagnostic::new(
+                "anything",
+                "message contains this",
+                0,
+            )],
         );
 
         assert_ok(&result);
@@ -619,7 +638,7 @@ mod tests {
     fn error_wrong_message() {
         let result = get_result(
             r#"x # error: "contains this""#,
-            vec![TestDiagnostic::new("anything", "Any message", 0)],
+            vec![ExpectedDiagnostic::new("anything", "Any message", 0)],
         );
 
         assert_fail(
@@ -638,7 +657,7 @@ mod tests {
     fn error_match_column_and_rule() {
         let result = get_result(
             "x # error: 1 [some-rule]",
-            vec![TestDiagnostic::new("some-rule", "Any message", 0)],
+            vec![ExpectedDiagnostic::new("some-rule", "Any message", 0)],
         );
 
         assert_ok(&result);
@@ -648,7 +667,7 @@ mod tests {
     fn error_wrong_column() {
         let result = get_result(
             "x # error: 2 [rule]",
-            vec![TestDiagnostic::new("rule", "Any message", 0)],
+            vec![ExpectedDiagnostic::new("rule", "Any message", 0)],
         );
 
         assert_fail(
@@ -667,7 +686,11 @@ mod tests {
     fn error_match_column_and_message() {
         let result = get_result(
             r#"x # error: 1 "contains this""#,
-            vec![TestDiagnostic::new("anything", "message contains this", 0)],
+            vec![ExpectedDiagnostic::new(
+                "anything",
+                "message contains this",
+                0,
+            )],
         );
 
         assert_ok(&result);
@@ -677,7 +700,11 @@ mod tests {
     fn error_match_rule_and_message() {
         let result = get_result(
             r#"x # error: [a-rule] "contains this""#,
-            vec![TestDiagnostic::new("a-rule", "message contains this", 0)],
+            vec![ExpectedDiagnostic::new(
+                "a-rule",
+                "message contains this",
+                0,
+            )],
         );
 
         assert_ok(&result);
@@ -687,7 +714,11 @@ mod tests {
     fn error_match_all() {
         let result = get_result(
             r#"x # error: 1 [a-rule] "contains this""#,
-            vec![TestDiagnostic::new("a-rule", "message contains this", 0)],
+            vec![ExpectedDiagnostic::new(
+                "a-rule",
+                "message contains this",
+                0,
+            )],
         );
 
         assert_ok(&result);
@@ -697,7 +728,11 @@ mod tests {
     fn error_match_all_wrong_column() {
         let result = get_result(
             r#"x # error: 2 [some-rule] "contains this""#,
-            vec![TestDiagnostic::new("some-rule", "message contains this", 0)],
+            vec![ExpectedDiagnostic::new(
+                "some-rule",
+                "message contains this",
+                0,
+            )],
         );
 
         assert_fail(
@@ -716,7 +751,7 @@ mod tests {
     fn error_match_all_wrong_rule() {
         let result = get_result(
             r#"x # error: 1 [some-rule] "contains this""#,
-            vec![TestDiagnostic::new(
+            vec![ExpectedDiagnostic::new(
                 "other-rule",
                 "message contains this",
                 0,
@@ -739,7 +774,7 @@ mod tests {
     fn error_match_all_wrong_message() {
         let result = get_result(
             r#"x # error: 1 [some-rule] "contains this""#,
-            vec![TestDiagnostic::new("some-rule", "Any message", 0)],
+            vec![ExpectedDiagnostic::new("some-rule", "Any message", 0)],
         );
 
         assert_fail(
@@ -772,9 +807,9 @@ mod tests {
         let result = get_result(
             &source,
             vec![
-                TestDiagnostic::new("line-two", "msg", two),
-                TestDiagnostic::new("line-three", "msg", three),
-                TestDiagnostic::new("line-five", "msg", five),
+                ExpectedDiagnostic::new("line-two", "msg", two),
+                ExpectedDiagnostic::new("line-three", "msg", three),
+                ExpectedDiagnostic::new("line-five", "msg", five),
             ],
         );
 
@@ -803,8 +838,8 @@ mod tests {
         let result = get_result(
             &source,
             vec![
-                TestDiagnostic::new("line-one", "msg", one),
-                TestDiagnostic::new("line-two", "msg", two),
+                ExpectedDiagnostic::new("line-one", "msg", one),
+                ExpectedDiagnostic::new("line-two", "msg", two),
             ],
         );
 
@@ -824,8 +859,8 @@ mod tests {
         let result = get_result(
             &source,
             vec![
-                TestDiagnostic::new("one-rule", "msg", x),
-                TestDiagnostic::new("other-rule", "msg", x),
+                ExpectedDiagnostic::new("one-rule", "msg", x),
+                ExpectedDiagnostic::new("other-rule", "msg", x),
             ],
         );
 
@@ -845,8 +880,8 @@ mod tests {
         let result = get_result(
             &source,
             vec![
-                TestDiagnostic::new("one-rule", "msg", x),
-                TestDiagnostic::new("one-rule", "msg", x),
+                ExpectedDiagnostic::new("one-rule", "msg", x),
+                ExpectedDiagnostic::new("one-rule", "msg", x),
             ],
         );
 
@@ -866,9 +901,9 @@ mod tests {
         let result = get_result(
             &source,
             vec![
-                TestDiagnostic::new("one-rule", "msg", x),
-                TestDiagnostic::new("other-rule", "msg", x),
-                TestDiagnostic::new("third-rule", "msg", x),
+                ExpectedDiagnostic::new("one-rule", "msg", x),
+                ExpectedDiagnostic::new("other-rule", "msg", x),
+                ExpectedDiagnostic::new("third-rule", "msg", x),
             ],
         );
 
@@ -892,8 +927,8 @@ mod tests {
         let result = get_result(
             &source,
             vec![
-                TestDiagnostic::new("undefined-reveal", "msg", reveal),
-                TestDiagnostic::new("revealed-type", "Revealed type is `Literal[5]`", reveal),
+                ExpectedDiagnostic::new("undefined-reveal", "msg", reveal),
+                ExpectedDiagnostic::new("revealed-type", "Revealed type is `Literal[5]`", reveal),
             ],
         );
 
@@ -906,7 +941,7 @@ mod tests {
         let x = source.find('x').unwrap();
         let result = get_result(
             source,
-            vec![TestDiagnostic::new("some-rule", "some message", x)],
+            vec![ExpectedDiagnostic::new("some-rule", "some message", x)],
         );
 
         assert_fail(
@@ -927,7 +962,7 @@ mod tests {
         let x = source.find('x').unwrap();
         let result = get_result(
             source,
-            vec![TestDiagnostic::new("some-rule", "some message", x)],
+            vec![ExpectedDiagnostic::new("some-rule", "some message", x)],
         );
 
         assert_fail(

--- a/crates/red_knot_wasm/tests/api.rs
+++ b/crates/red_knot_wasm/tests/api.rs
@@ -19,6 +19,6 @@ fn check() {
 
     assert_eq!(
         result,
-        vec!["/test.py:1:8: Cannot resolve import `random22`"]
+        vec!["error[unresolved-import] /test.py:1:8 Cannot resolve import `random22`"]
     );
 }

--- a/crates/red_knot_workspace/Cargo.toml
+++ b/crates/red_knot_workspace/Cargo.toml
@@ -17,7 +17,6 @@ red_knot_python_semantic = { workspace = true }
 ruff_cache = { workspace = true }
 ruff_db = { workspace = true, features = ["os", "cache"] }
 ruff_python_ast = { workspace = true }
-ruff_text_size = { workspace = true }
 red_knot_vendored = { workspace = true }
 
 anyhow = { workspace = true }

--- a/crates/red_knot_workspace/src/db.rs
+++ b/crates/red_knot_workspace/src/db.rs
@@ -1,6 +1,7 @@
 use std::panic::RefUnwindSafe;
 use std::sync::Arc;
 
+use ruff_db::diagnostic::CompileDiagnostic;
 use salsa::plumbing::ZalsaDatabase;
 use salsa::{Cancelled, Event};
 
@@ -10,7 +11,7 @@ use ruff_db::system::System;
 use ruff_db::vendored::VendoredFileSystem;
 use ruff_db::{Db as SourceDb, Upcast};
 
-use crate::workspace::{check_file, Workspace, WorkspaceMetadata};
+use crate::workspace::{Workspace, WorkspaceMetadata};
 
 mod changes;
 
@@ -51,14 +52,14 @@ impl RootDatabase {
     }
 
     /// Checks all open files in the workspace and its dependencies.
-    pub fn check(&self) -> Result<Vec<String>, Cancelled> {
+    pub fn check(&self) -> Result<Vec<CompileDiagnostic>, Cancelled> {
         self.with_db(|db| db.workspace().check(db))
     }
 
-    pub fn check_file(&self, file: File) -> Result<Vec<String>, Cancelled> {
+    pub fn check_file(&self, file: File) -> Result<Vec<CompileDiagnostic>, Cancelled> {
         let _span = tracing::debug_span!("check_file", file=%file.path(self)).entered();
 
-        self.with_db(|db| check_file(db, file))
+        self.with_db(|db| db.workspace().check_file(db, file))
     }
 
     /// Returns a mutable reference to the system.

--- a/crates/ruff_benchmark/benches/red_knot.rs
+++ b/crates/ruff_benchmark/benches/red_knot.rs
@@ -24,32 +24,32 @@ const TOMLLIB_312_URL: &str = "https://raw.githubusercontent.com/python/cpython/
 
 static EXPECTED_DIAGNOSTICS: &[&str] = &[
     // We don't support `*` imports yet:
-    "/src/tomllib/_parser.py:7:29: Module `collections.abc` has no member `Iterable`",
+    "error[unresolved-import] /src/tomllib/_parser.py:7:29 Module `collections.abc` has no member `Iterable`",
     // We don't support terminal statements in control flow yet:
-    "/src/tomllib/_parser.py:246:15: Method `__class_getitem__` of type `Literal[frozenset]` is possibly unbound",
-    "/src/tomllib/_parser.py:692:8354: Invalid class base with type `GenericAlias` (all bases must be a class, `Any`, `Unknown` or `Todo`)",
-    "/src/tomllib/_parser.py:66:18: Name `s` used when possibly not defined",
-    "/src/tomllib/_parser.py:98:12: Name `char` used when possibly not defined",
-    "/src/tomllib/_parser.py:101:12: Name `char` used when possibly not defined",
-    "/src/tomllib/_parser.py:104:14: Name `char` used when possibly not defined",
-    "/src/tomllib/_parser.py:108:17: Conflicting declared types for `second_char`: Unknown, str | None",
-    "/src/tomllib/_parser.py:115:14: Name `char` used when possibly not defined",
-    "/src/tomllib/_parser.py:126:12: Name `char` used when possibly not defined",
-    "/src/tomllib/_parser.py:267:9: Conflicting declared types for `char`: Unknown, str | None",
-    "/src/tomllib/_parser.py:348:20: Name `nest` used when possibly not defined",
-    "/src/tomllib/_parser.py:353:5: Name `nest` used when possibly not defined",
-    "/src/tomllib/_parser.py:364:9: Conflicting declared types for `char`: Unknown, str | None",
-    "/src/tomllib/_parser.py:381:13: Conflicting declared types for `char`: Unknown, str | None",
-    "/src/tomllib/_parser.py:395:9: Conflicting declared types for `char`: Unknown, str | None",
-    "/src/tomllib/_parser.py:453:24: Name `nest` used when possibly not defined",
-    "/src/tomllib/_parser.py:455:9: Name `nest` used when possibly not defined",
-    "/src/tomllib/_parser.py:482:16: Name `char` used when possibly not defined",
-    "/src/tomllib/_parser.py:566:12: Name `char` used when possibly not defined",
-    "/src/tomllib/_parser.py:573:12: Name `char` used when possibly not defined",
-    "/src/tomllib/_parser.py:579:12: Name `char` used when possibly not defined",
-    "/src/tomllib/_parser.py:580:63: Name `char` used when possibly not defined",
-    "/src/tomllib/_parser.py:590:9: Conflicting declared types for `char`: Unknown, str | None",
-    "/src/tomllib/_parser.py:629:38: Name `datetime_obj` used when possibly not defined",
+    "error[possibly-unresolved-reference] /src/tomllib/_parser.py:66:18 Name `s` used when possibly not defined",
+    "error[possibly-unresolved-reference] /src/tomllib/_parser.py:98:12 Name `char` used when possibly not defined",
+    "error[possibly-unresolved-reference] /src/tomllib/_parser.py:101:12 Name `char` used when possibly not defined",
+    "error[possibly-unresolved-reference] /src/tomllib/_parser.py:104:14 Name `char` used when possibly not defined",
+    "error[conflicting-declarations] /src/tomllib/_parser.py:108:17 Conflicting declared types for `second_char`: Unknown, str | None",
+    "error[possibly-unresolved-reference] /src/tomllib/_parser.py:115:14 Name `char` used when possibly not defined",
+    "error[possibly-unresolved-reference] /src/tomllib/_parser.py:126:12 Name `char` used when possibly not defined",
+    "error[call-possibly-unbound-method] /src/tomllib/_parser.py:246:15 Method `__class_getitem__` of type `Literal[frozenset]` is possibly unbound",
+    "error[conflicting-declarations] /src/tomllib/_parser.py:267:9 Conflicting declared types for `char`: Unknown, str | None",
+    "error[possibly-unresolved-reference] /src/tomllib/_parser.py:348:20 Name `nest` used when possibly not defined",
+    "error[possibly-unresolved-reference] /src/tomllib/_parser.py:353:5 Name `nest` used when possibly not defined",
+    "error[conflicting-declarations] /src/tomllib/_parser.py:364:9 Conflicting declared types for `char`: Unknown, str | None",
+    "error[conflicting-declarations] /src/tomllib/_parser.py:381:13 Conflicting declared types for `char`: Unknown, str | None",
+    "error[conflicting-declarations] /src/tomllib/_parser.py:395:9 Conflicting declared types for `char`: Unknown, str | None",
+    "error[possibly-unresolved-reference] /src/tomllib/_parser.py:453:24 Name `nest` used when possibly not defined",
+    "error[possibly-unresolved-reference] /src/tomllib/_parser.py:455:9 Name `nest` used when possibly not defined",
+    "error[possibly-unresolved-reference] /src/tomllib/_parser.py:482:16 Name `char` used when possibly not defined",
+    "error[possibly-unresolved-reference] /src/tomllib/_parser.py:566:12 Name `char` used when possibly not defined",
+    "error[possibly-unresolved-reference] /src/tomllib/_parser.py:573:12 Name `char` used when possibly not defined",
+    "error[possibly-unresolved-reference] /src/tomllib/_parser.py:579:12 Name `char` used when possibly not defined",
+    "error[possibly-unresolved-reference] /src/tomllib/_parser.py:580:63 Name `char` used when possibly not defined",
+    "error[conflicting-declarations] /src/tomllib/_parser.py:590:9 Conflicting declared types for `char`: Unknown, str | None",
+    "error[possibly-unresolved-reference] /src/tomllib/_parser.py:629:38 Name `datetime_obj` used when possibly not defined",
+    "error[invalid-base] /src/tomllib/_parser.py:692:8354 Invalid class base with type `GenericAlias` (all bases must be a class, `Any`, `Unknown` or `Todo`)",
 ];
 
 fn get_test_file(name: &str) -> TestFile {
@@ -123,7 +123,13 @@ fn setup_rayon() {
 fn benchmark_incremental(criterion: &mut Criterion) {
     fn setup() -> Case {
         let case = setup_case();
-        let result = case.db.check().unwrap();
+        let result: Vec<_> = case
+            .db
+            .check()
+            .unwrap()
+            .into_iter()
+            .map(|diagnostic| diagnostic.display(&case.db).to_string())
+            .collect();
 
         assert_eq!(result, EXPECTED_DIAGNOSTICS);
 
@@ -150,7 +156,7 @@ fn benchmark_incremental(criterion: &mut Criterion) {
 
         let result = db.check().unwrap();
 
-        assert_eq!(result, EXPECTED_DIAGNOSTICS);
+        assert_eq!(result.len(), EXPECTED_DIAGNOSTICS.len());
     }
 
     setup_rayon();
@@ -168,7 +174,12 @@ fn benchmark_cold(criterion: &mut Criterion) {
             setup_case,
             |case| {
                 let Case { db, .. } = case;
-                let result = db.check().unwrap();
+                let result: Vec<_> = db
+                    .check()
+                    .unwrap()
+                    .into_iter()
+                    .map(|diagnostic| diagnostic.display(db).to_string())
+                    .collect();
 
                 assert_eq!(result, EXPECTED_DIAGNOSTICS);
             },

--- a/crates/ruff_db/Cargo.toml
+++ b/crates/ruff_db/Cargo.toml
@@ -28,7 +28,6 @@ matchit = { workspace = true }
 salsa = { workspace = true }
 serde = { workspace = true, optional = true }
 path-slash = { workspace = true }
-thiserror = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, optional = true }
 tracing-tree = { workspace = true, optional = true }

--- a/crates/ruff_db/src/diagnostic.rs
+++ b/crates/ruff_db/src/diagnostic.rs
@@ -1,0 +1,155 @@
+use ruff_text_size::TextRange;
+use salsa::Accumulator as _;
+
+use crate::{
+    files::File,
+    source::{line_index, source_text},
+    Db,
+};
+
+pub trait Diagnostic: Send + Sync + std::fmt::Debug {
+    fn rule(&self) -> &str;
+
+    fn message(&self) -> std::borrow::Cow<str>;
+
+    fn file(&self) -> File;
+
+    fn range(&self) -> Option<TextRange>;
+
+    fn severity(&self) -> Severity;
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum Severity {
+    Info,
+    Error,
+}
+
+#[salsa::accumulator]
+pub struct CompileDiagnostic(std::sync::Arc<dyn Diagnostic>);
+
+impl CompileDiagnostic {
+    pub fn report<T>(db: &dyn Db, diagnostic: T)
+    where
+        T: Diagnostic + 'static,
+    {
+        Self(std::sync::Arc::new(diagnostic)).accumulate(db);
+    }
+
+    pub fn display<'a>(&'a self, db: &'a dyn Db) -> DisplayDiagnostic<'a> {
+        DisplayDiagnostic {
+            db,
+            diagnostic: &*self.0,
+        }
+    }
+}
+
+impl Diagnostic for CompileDiagnostic {
+    fn rule(&self) -> &str {
+        self.0.rule()
+    }
+
+    fn message(&self) -> std::borrow::Cow<str> {
+        self.0.message()
+    }
+
+    fn file(&self) -> File {
+        self.0.file()
+    }
+
+    fn range(&self) -> Option<TextRange> {
+        self.0.range()
+    }
+
+    fn severity(&self) -> Severity {
+        self.0.severity()
+    }
+}
+
+pub struct DisplayDiagnostic<'db> {
+    db: &'db dyn Db,
+    diagnostic: &'db dyn Diagnostic,
+}
+
+impl<'db> DisplayDiagnostic<'db> {
+    pub fn new(db: &'db dyn Db, diagnostic: &'db dyn Diagnostic) -> Self {
+        Self { db, diagnostic }
+    }
+}
+
+impl std::fmt::Display for DisplayDiagnostic<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.diagnostic.severity() {
+            Severity::Info => f.write_str("info")?,
+            Severity::Error => f.write_str("error")?,
+        }
+
+        write!(
+            f,
+            "[{rule}] {path}",
+            rule = self.diagnostic.rule(),
+            path = self.diagnostic.file().path(self.db)
+        )?;
+
+        if let Some(range) = self.diagnostic.range() {
+            let index = line_index(self.db, self.diagnostic.file());
+            let source = source_text(self.db, self.diagnostic.file());
+
+            let start = index.source_location(range.start(), &source);
+
+            write!(f, ":{line}:{col}", line = start.row, col = start.column)?;
+        }
+
+        write!(f, " {message}", message = self.diagnostic.message())
+    }
+}
+
+impl<T> Diagnostic for Box<T>
+where
+    T: Diagnostic,
+{
+    fn rule(&self) -> &str {
+        (**self).rule()
+    }
+
+    fn message(&self) -> std::borrow::Cow<str> {
+        (**self).message()
+    }
+
+    fn file(&self) -> File {
+        (**self).file()
+    }
+
+    fn range(&self) -> Option<TextRange> {
+        (**self).range()
+    }
+
+    fn severity(&self) -> Severity {
+        (**self).severity()
+    }
+}
+
+impl<T> Diagnostic for std::sync::Arc<T>
+where
+    T: Diagnostic,
+{
+    fn rule(&self) -> &str {
+        (**self).rule()
+    }
+
+    fn message(&self) -> std::borrow::Cow<str> {
+        (**self).message()
+    }
+
+    fn file(&self) -> File {
+        (**self).file()
+    }
+
+    fn range(&self) -> Option<TextRange> {
+        (**self).range()
+    }
+
+    fn severity(&self) -> Severity {
+        (**self).severity()
+    }
+}

--- a/crates/ruff_db/src/lib.rs
+++ b/crates/ruff_db/src/lib.rs
@@ -6,6 +6,7 @@ use crate::files::Files;
 use crate::system::System;
 use crate::vendored::VendoredFileSystem;
 
+pub mod diagnostic;
 pub mod display;
 pub mod file_revision;
 pub mod files;

--- a/crates/ruff_db/src/parsed.rs
+++ b/crates/ruff_db/src/parsed.rs
@@ -98,7 +98,7 @@ pub struct ParseDiagnostic {
 
 impl Diagnostic for ParseDiagnostic {
     fn rule(&self) -> &str {
-        "syntax-error"
+        "invalid-syntax"
     }
 
     fn message(&self) -> std::borrow::Cow<str> {


### PR DESCRIPTION
## Summary

Use a Salsa accumulator for diagnostics to avoid double-emitting diagnostics for unpack assignments.

We now use a single `CompileDiagnostic` accumulator that stores all diagnostics. That includes IO errors, parse errors, and type check errors. I decided that we're beyond where `String` annotations are fun. That's why I introduced a `Diagnostic` trait with 5 implementations:

* `ParseDiagnostic` for parse errors
* `SourceTextDiagnostic` for IO errors
* `TypeCheckDiagnostic` for type inference errors
* `RevealedTypeDiagnostic` for `reveal_type` (info severity)
* `CompileDiagnostic` which is a cheap cloneable *any* diagnostic wrapper that implements salsa accumulator. 

Using a structured diagnostic has the advantage of no longer needing manual parsing in the LSP. 

A nice side effect of this is that mdtests now support tests with syntax errors because parse-errors are just another diagnostic :)

## Performance regression

I expect this to hit performance pretty bad, especially the incremental benchmark. The problem is that there's currently no way to run an accumulator concurrently. That's why I had to resort to a hack where we run type checking in parallel, and then collect the diagnostics. This has the downside that Salsa first runs all queries (in parallel) but then has to iterate over all of them again to collect the diagnostics (even if there are none!). The queries are all cached, but it is still expensive because the query dependency tree is somewhat large.

This overhead is especially noticeable in the cache case. We'll need https://github.com/salsa-rs/salsa/pull/568 to do the accumulation and checking in one go. 

## Test Plan

`cargo test`
