### PR TITLE
Fix duplicate unpack diagnostics

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/unpacking.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/unpacking.md
@@ -145,12 +145,8 @@ reveal_type(f)  # revealed: Unknown
 
 ### Non-iterable unpacking
 
-TODO: Remove duplicate diagnostics. This is happening because for a sequence-like assignment target,
-multiple definitions are created and the inference engine runs on each of them which results in
-duplicate diagnostics.
 
 ```py
-# error: "Object of type `Literal[1]` is not iterable"
 # error: "Object of type `Literal[1]` is not iterable"
 a, b = 1
 reveal_type(a)  # revealed: Unknown

--- a/crates/red_knot_python_semantic/resources/mdtest/unpacking.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/unpacking.md
@@ -145,7 +145,6 @@ reveal_type(f)  # revealed: Unknown
 
 ### Non-iterable unpacking
 
-
 ```py
 # error: "Object of type `Literal[1]` is not iterable"
 a, b = 1

--- a/crates/red_knot_python_semantic/src/semantic_index/definition.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/definition.rs
@@ -183,6 +183,7 @@ pub(crate) struct AssignmentDefinitionNodeRef<'a> {
     pub(crate) unpack: Option<Unpack<'a>>,
     pub(crate) value: &'a ast::Expr,
     pub(crate) name: &'a ast::ExprName,
+    pub(crate) first: bool,
 }
 
 #[derive(Copy, Clone, Debug)]
@@ -250,10 +251,12 @@ impl<'db> DefinitionNodeRef<'db> {
                 unpack,
                 value,
                 name,
+                first,
             }) => DefinitionKind::Assignment(AssignmentDefinitionKind {
                 target: TargetKind::from(unpack),
                 value: AstNodeRef::new(parsed.clone(), value),
                 name: AstNodeRef::new(parsed, name),
+                first,
             }),
             DefinitionNodeRef::AnnotatedAssignment(assign) => {
                 DefinitionKind::AnnotatedAssignment(AstNodeRef::new(parsed, assign))
@@ -330,6 +333,7 @@ impl<'db> DefinitionNodeRef<'db> {
                 value: _,
                 unpack: _,
                 name,
+                first: _,
             }) => name.into(),
             Self::AnnotatedAssignment(node) => node.into(),
             Self::AugmentedAssignment(node) => node.into(),
@@ -535,10 +539,11 @@ pub struct AssignmentDefinitionKind<'db> {
     target: TargetKind<'db>,
     value: AstNodeRef<ast::Expr>,
     name: AstNodeRef<ast::ExprName>,
+    first: bool,
 }
 
-impl AssignmentDefinitionKind<'_> {
-    pub(crate) fn target(&self) -> TargetKind {
+impl<'db> AssignmentDefinitionKind<'db> {
+    pub(crate) fn target(&self) -> TargetKind<'db> {
         self.target
     }
 
@@ -548,6 +553,10 @@ impl AssignmentDefinitionKind<'_> {
 
     pub(crate) fn name(&self) -> &ast::ExprName {
         self.name.node()
+    }
+
+    pub(crate) fn is_first(&self) -> bool {
+        self.first
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes the issue where we emitted duplicated diagnostics for unpack assignments. 

The solution is fairly simple. All we need is a deterministic way to know when we should add the
diagnostics. The approach I used here is only to add the diagnostics for the first unpacking.

This works because `check_types` pulls all types. 

What about accumulators. We may still want to use accumulators in the future, e.g. if other, non type checking queries start emitting diagnostics. However, we have to solve the performance regression first. I have an idea on how that could be done. See the [zulip discussion](https://salsa.zulipchat.com/#narrow/channel/333573-Contributing-to-Salsa/topic/Accumulator.20performance)

## Test Plan

See updated mdtest
