### PR TITLE
[red-knot] Add narrowing for `issubclass` checks

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/narrow/issubclass.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/narrow/issubclass.md
@@ -87,8 +87,7 @@ else:
 class A: ...
 class B: ...
 
-def flag() -> bool: ...
-def get_class() -> object: ...
+def get_class() -> type[object]: ...
 
 t = get_class()
 
@@ -97,7 +96,7 @@ if issubclass(t, A):
     if issubclass(t, B):
         reveal_type(t)  # revealed: type[A] & type[B]
 else:
-    reveal_type(t)  # revealed: object & ~type[A]
+    reveal_type(t)  # revealed: type[object] & ~type[A]
 ```
 
 ### Handling of `None`
@@ -135,6 +134,35 @@ else:
 ```
 
 ## Special cases
+
+### Emit a diagnostic if the first argument is of wrong type
+
+#### Too wide
+
+`type[object]` is a subtype of `object`, but not every `object` can be passed as the first argument
+to `issubclass`:
+
+```py
+class A: ...
+
+def get_object() -> object: ...
+
+t = get_object()
+
+# TODO: we should emit a diagnostic here
+if issubclass(t, A):
+    reveal_type(t)  # revealed: type[A]
+```
+
+#### Wrong
+
+```py
+t = 1
+
+# TODO: we should emit a diagnostic here
+if issubclass(t, int):
+    reveal_type(t)  # revealed: Never
+```
 
 ### Do not use custom `issubclass` for narrowing
 

--- a/crates/red_knot_python_semantic/resources/mdtest/narrow/issubclass.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/narrow/issubclass.md
@@ -156,6 +156,8 @@ if issubclass(t, A):
 
 #### Wrong
 
+`Literal[1]` and `type` are entirely disjoint, so the inferred type of `Literal[1] & type[int]` is eagerly simplified to `Never` as a result of the type narrowing in the `if issubclass(t, int)` branch:
+
 ```py
 t = 1
 

--- a/crates/red_knot_python_semantic/resources/mdtest/narrow/issubclass.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/narrow/issubclass.md
@@ -156,7 +156,9 @@ if issubclass(t, A):
 
 #### Wrong
 
-`Literal[1]` and `type` are entirely disjoint, so the inferred type of `Literal[1] & type[int]` is eagerly simplified to `Never` as a result of the type narrowing in the `if issubclass(t, int)` branch:
+`Literal[1]` and `type` are entirely disjoint, so the inferred type of `Literal[1] & type[int]` is
+eagerly simplified to `Never` as a result of the type narrowing in the `if issubclass(t, int)`
+branch:
 
 ```py
 t = 1

--- a/crates/red_knot_python_semantic/resources/mdtest/narrow/issubclass.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/narrow/issubclass.md
@@ -1,0 +1,215 @@
+# Narrowing for `issubclass` checks
+
+Narrowing for `issubclass(class, classinfo)` expressions.
+
+## `classinfo` is a single type
+
+### Basic example
+
+```py
+def flag() -> bool: ...
+
+t = int if flag() else str
+
+if issubclass(t, bytes):
+    reveal_type(t)  # revealed: Never
+
+if issubclass(t, object):
+    reveal_type(t)  # revealed: Literal[int, str]
+
+if issubclass(t, int):
+    reveal_type(t)  # revealed: Literal[int]
+else:
+    reveal_type(t)  # revealed: Literal[str]
+
+if issubclass(t, str):
+    reveal_type(t)  # revealed: Literal[str]
+    if issubclass(t, int):
+        reveal_type(t)  # revealed: Never
+```
+
+### Proper narrowing in `elif` and `else` branches
+
+```py
+def flag() -> bool: ...
+
+t = int if flag() else str if flag() else bytes
+
+if issubclass(t, int):
+    reveal_type(t)  # revealed: Literal[int]
+else:
+    reveal_type(t)  # revealed: Literal[str, bytes]
+
+if issubclass(t, int):
+    reveal_type(t)  # revealed: Literal[int]
+elif issubclass(t, str):
+    reveal_type(t)  # revealed: Literal[str]
+else:
+    reveal_type(t)  # revealed: Literal[bytes]
+```
+
+### Multiple derived classes
+
+```py
+class Base: ...
+class Derived1(Base): ...
+class Derived2(Base): ...
+class Unrelated: ...
+
+def flag() -> bool: ...
+
+t1 = Derived1 if flag() else Derived2
+
+if issubclass(t1, Base):
+    reveal_type(t1)  # revealed: Literal[Derived1, Derived2]
+
+if issubclass(t1, Derived1):
+    reveal_type(t1)  # revealed: Literal[Derived1]
+else:
+    reveal_type(t1)  # revealed: Literal[Derived2]
+
+t2 = Derived1 if flag() else Base
+
+if issubclass(t2, Base):
+    reveal_type(t2)  # revealed: Literal[Derived1, Base]
+
+t3 = Derived1 if flag() else Unrelated
+
+if issubclass(t3, Base):
+    reveal_type(t3)  # revealed: Literal[Derived1]
+else:
+    reveal_type(t3)  # revealed: Literal[Unrelated]
+```
+
+### Narrowing for non-literals
+
+```py
+class A: ...
+class B: ...
+
+def flag() -> bool: ...
+def get_class() -> type: ...
+
+t = get_class()
+
+if issubclass(t, A):
+    # TODO: this should be `type[A]`
+    reveal_type(t)  # revealed: type
+    if issubclass(t, B):
+        # TODO: this should be `type[A] & type[B]`
+        reveal_type(t)  # revealed: type
+else:
+    # TODO: this should be `~type[A]`
+    reveal_type(t)  # revealed: type
+```
+
+### Handling of `None`
+
+```py
+from types import NoneType
+
+def flag() -> bool: ...
+
+t = int if flag() else NoneType
+
+if issubclass(t, NoneType):
+    reveal_type(t)  # revealed: Literal[NoneType]
+
+if issubclass(t, type(None)):
+    # TODO: this should be just `Literal[NoneType]`
+    reveal_type(t)  # revealed: Literal[int, NoneType]
+```
+
+## `classinfo` contains multiple types
+
+### (Nested) tuples of types
+
+```py
+class Unrelated: ...
+
+def flag() -> bool: ...
+
+t = int if flag() else str if flag() else bytes
+
+if issubclass(t, (int, (Unrelated, (bytes,)))):
+    reveal_type(t)  # revealed: Literal[int, bytes]
+else:
+    reveal_type(t)  # revealed: Literal[str]
+```
+
+## Special cases
+
+### Do not use custom `issubclass` for narrowing
+
+```py
+def issubclass(c, ci):
+    return True
+
+def flag() -> bool: ...
+
+t = int if flag() else str
+if issubclass(t, int):
+    reveal_type(t)  # revealed: Literal[int, str]
+```
+
+### Do support narrowing if `issubclass` is aliased
+
+```py
+issubclass_alias = issubclass
+
+def flag() -> bool: ...
+
+t = int if flag() else str
+if issubclass_alias(t, int):
+    reveal_type(t)  # revealed: Literal[int]
+```
+
+### Do support narrowing if `issubclass` is imported
+
+```py
+from builtins import issubclass as imported_issubclass
+
+def flag() -> bool: ...
+
+t = int if flag() else str
+if imported_issubclass(t, int):
+    reveal_type(t)  # revealed: Literal[int]
+```
+
+### Do not narrow if second argument is not a proper `classinfo` argument
+
+```py
+from typing import Any
+
+def flag() -> bool: ...
+
+t = int if flag() else str
+
+# TODO: this should cause us to emit a diagnostic during
+# type checking
+if issubclass(t, "str"):
+    reveal_type(t)  # revealed: Literal[int, str]
+
+# TODO: this should cause us to emit a diagnostic during
+# type checking
+if issubclass(t, (bytes, "str")):
+    reveal_type(t)  # revealed: Literal[int, str]
+
+# TODO: this should cause us to emit a diagnostic during
+# type checking
+if issubclass(t, Any):
+    reveal_type(t)  # revealed: Literal[int, str]
+```
+
+### Do not narrow if there are keyword arguments
+
+```py
+def flag() -> bool: ...
+
+t = int if flag() else str
+
+# TODO: this should cause us to emit a diagnostic
+# (`issubclass` has no `foo` parameter)
+if issubclass(t, int, foo="bar"):
+    reveal_type(t)  # revealed: Literal[int, str]
+```

--- a/crates/red_knot_python_semantic/resources/mdtest/narrow/issubclass.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/narrow/issubclass.md
@@ -88,19 +88,16 @@ class A: ...
 class B: ...
 
 def flag() -> bool: ...
-def get_class() -> type: ...
+def get_class() -> object: ...
 
 t = get_class()
 
 if issubclass(t, A):
-    # TODO: this should be `type[A]`
-    reveal_type(t)  # revealed: type
+    reveal_type(t)  # revealed: type[A]
     if issubclass(t, B):
-        # TODO: this should be `type[A] & type[B]`
-        reveal_type(t)  # revealed: type
+        reveal_type(t)  # revealed: type[A] & type[B]
 else:
-    # TODO: this should be `~type[A]`
-    reveal_type(t)  # revealed: type
+    reveal_type(t)  # revealed: object & ~type[A]
 ```
 
 ### Handling of `None`

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -1291,7 +1291,6 @@ impl<'db> Type<'db> {
             | Type::SliceLiteral(_)
             | Type::Tuple(_)
             | Type::LiteralString => Type::Unknown,
-            //
             Type::Type(..) => Type::Unknown,
         }
     }

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -1322,7 +1322,13 @@ impl<'db> Type<'db> {
             Type::ModuleLiteral(_) => KnownClass::ModuleType.to_class(db),
             Type::Tuple(_) => KnownClass::Tuple.to_class(db),
             Type::ClassLiteral(ClassLiteralType { class }) => class.metaclass(db),
-            Type::Type(_) => Type::Type(KnownClass::Type.to_class(db).expect_class_literal()),
+            Type::Type(ClassLiteralType { class }) => Type::Type(
+                class
+                    .try_metaclass(db)
+                    .ok()
+                    .and_then(Type::into_class_literal)
+                    .unwrap_or(KnownClass::Type.to_class(db).expect_class_literal()),
+            ),
             Type::StringLiteral(_) | Type::LiteralString => KnownClass::Str.to_class(db),
             // TODO: `type[Any]`?
             Type::Any => Type::Any,

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -1091,7 +1091,10 @@ impl<'db> Type<'db> {
                 // More info in https://docs.python.org/3/library/stdtypes.html#truth-value-testing
                 Truthiness::Ambiguous
             }
-            Type::Type(_) => Truthiness::Ambiguous,
+            Type::Type(_) => {
+                // TODO: see above
+                Truthiness::Ambiguous
+            }
             Type::Instance(InstanceType { class, .. }) => {
                 // TODO: lookup `__bool__` and `__len__` methods on the instance's class
                 // More info in https://docs.python.org/3/library/stdtypes.html#truth-value-testing

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -2570,7 +2570,7 @@ mod tests {
         BytesLiteral(&'static str),
         // BuiltinInstance("str") corresponds to an instance of the builtin `str` class
         BuiltinInstance(&'static str),
-        // BuiltinClassLiteral("str") corresponds to the builtin `str` class itself
+        // BuiltinClassLiteral("str") corresponds to the builtin `str` class object itself
         BuiltinClassLiteral(&'static str),
         Union(Vec<Ty>),
         Intersection { pos: Vec<Ty>, neg: Vec<Ty> },

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -399,6 +399,15 @@ impl<'db> Type<'db> {
         IntersectionBuilder::new(db).add_negative(*self).build()
     }
 
+    #[must_use]
+    pub fn negate_if(&self, db: &'db dyn Db, yes: bool) -> Type<'db> {
+        if yes {
+            self.negate(db)
+        } else {
+            *self
+        }
+    }
+
     pub const fn into_union(self) -> Option<UnionType<'db>> {
         match self {
             Type::Union(union_type) => Some(union_type),

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -1915,6 +1915,8 @@ pub enum KnownFunction {
     RevealType,
     /// `builtins.isinstance`
     IsInstance,
+    /// `builtins.issubclass`
+    IsSubclass,
 }
 
 /// Representation of a runtime class object.

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -1279,6 +1279,7 @@ impl<'db> Type<'db> {
             Type::Unknown => Type::Unknown,
             Type::Never => Type::Never,
             Type::ClassLiteral(ClassLiteralType { class }) => Type::anonymous_instance(*class),
+            Type::Type(ClassLiteralType { class }) => Type::anonymous_instance(*class),
             Type::Union(union) => union.map(db, |element| element.to_instance(db)),
             // TODO: we can probably do better here: --Alex
             Type::Intersection(_) => Type::Todo,
@@ -1294,7 +1295,6 @@ impl<'db> Type<'db> {
             | Type::SliceLiteral(_)
             | Type::Tuple(_)
             | Type::LiteralString => Type::Unknown,
-            Type::Type(..) => Type::Unknown,
         }
     }
 

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -1997,16 +1997,30 @@ impl<'db> FunctionType<'db> {
     }
 }
 
-/// Non-exhaustive enumeration of known functions (e.g. `builtins.reveal_type`, ...) that might
-/// have special behavior.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum KnownFunction {
-    /// `builtins.reveal_type`, `typing.reveal_type` or `typing_extensions.reveal_type`
-    RevealType,
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum KnownConstraintFunction {
     /// `builtins.isinstance`
     IsInstance,
     /// `builtins.issubclass`
     IsSubclass,
+}
+
+/// Non-exhaustive enumeration of known functions (e.g. `builtins.reveal_type`, ...) that might
+/// have special behavior.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub enum KnownFunction {
+    ConstraintFunction(KnownConstraintFunction),
+    /// `builtins.reveal_type`, `typing.reveal_type` or `typing_extensions.reveal_type`
+    RevealType,
+}
+
+impl KnownFunction {
+    pub fn constraint_function(self) -> Option<KnownConstraintFunction> {
+        match self {
+            Self::ConstraintFunction(f) => Some(f),
+            Self::RevealType => None,
+        }
+    }
 }
 
 /// Representation of a runtime class object.

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -1000,11 +1000,7 @@ impl<'db> Type<'db> {
                     global_lookup
                 }
             }
-            Type::ClassLiteral(class_ty) => class_ty.member(db, name),
-            Type::Type(..) => {
-                // TODO: attribute lookup on Type[..] type
-                Type::Todo.into()
-            }
+            Type::ClassLiteral(class_ty) | Type::Type(class_ty) => class_ty.member(db, name),
             Type::Instance(_) => {
                 // TODO MRO? get_own_instance_member, get_instance_member
                 Type::Todo.into()
@@ -1315,10 +1311,8 @@ impl<'db> Type<'db> {
     pub fn to_meta_type(&self, db: &'db dyn Db) -> Type<'db> {
         match self {
             Type::Never => Type::Never,
-            // TODO: not really correct -- the meta-type of an `InstanceType { class: T }` should be `type[T]`
-            // (<https://docs.python.org/3/library/typing.html#the-type-of-class-objects>)
             Type::Instance(InstanceType { class, .. }) => {
-                Type::ClassLiteral(ClassLiteralType { class: *class })
+                Type::Type(ClassLiteralType { class: *class })
             }
             Type::Union(union) => union.map(db, |ty| ty.to_meta_type(db)),
             Type::BooleanLiteral(_) => KnownClass::Bool.to_class(db),

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -2661,6 +2661,7 @@ mod tests {
         .unwrap();
         let module = ruff_db::files::system_path_to_file(&db, "/src/module.py").unwrap();
 
+        // `literal_a` represents `Literal[A]`.
         let literal_a = super::global_symbol(&db, module, "A").expect_type();
         let literal_derived_from_a =
             super::global_symbol(&db, module, "DerivedFromA").expect_type();
@@ -2671,15 +2672,18 @@ mod tests {
         assert!(literal_a.is_subtype_of(&db, Ty::BuiltinInstance("object").into_type(&db)));
 
         assert!(literal_derived_from_a.is_class_literal());
-        // Construct the type `type[A]` from the class literal `A`:
+
+        // `type_a` represents `Type[A]`.
         let type_a = Type::Type(literal_a.expect_class_literal());
         assert!(literal_a.is_subtype_of(&db, type_a));
         assert!(literal_derived_from_a.is_subtype_of(&db, type_a));
 
         let type_derived_from_a = Type::Type(literal_derived_from_a.expect_class_literal());
         assert!(literal_derived_from_a.is_subtype_of(&db, type_derived_from_a));
-        assert!(type_derived_from_a.is_subtype_of(&db, type_a));
         assert!(!literal_a.is_subtype_of(&db, type_derived_from_a));
+
+        // Type[DerivedFromA] <: Type[A]
+        assert!(type_derived_from_a.is_subtype_of(&db, type_a));
 
         assert!(literal_u.is_union());
         assert!(literal_u.is_subtype_of(&db, Ty::BuiltinInstance("type").into_type(&db)));

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -1323,7 +1323,6 @@ impl<'db> Type<'db> {
             Type::Tuple(_) => KnownClass::Tuple.to_class(db),
             Type::ClassLiteral(ClassLiteralType { class }) => class.metaclass(db),
             Type::Type(_) => Type::Type(KnownClass::Type.to_class(db).expect_class_literal()),
-            // TODO can we do better here? `type[LiteralString]`?
             Type::StringLiteral(_) | Type::LiteralString => KnownClass::Str.to_class(db),
             // TODO: `type[Any]`?
             Type::Any => Type::Any,

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -2021,6 +2021,23 @@ impl KnownFunction {
             Self::RevealType => None,
         }
     }
+
+    fn from_definition<'db>(
+        db: &'db dyn Db,
+        definition: Definition<'db>,
+        name: &str,
+    ) -> Option<Self> {
+        match name {
+            "reveal_type" if definition.is_typing_definition(db) => Some(KnownFunction::RevealType),
+            "isinstance" if definition.is_builtin_definition(db) => Some(
+                KnownFunction::ConstraintFunction(KnownConstraintFunction::IsInstance),
+            ),
+            "issubclass" if definition.is_builtin_definition(db) => Some(
+                KnownFunction::ConstraintFunction(KnownConstraintFunction::IsSubclass),
+            ),
+            _ => None,
+        }
+    }
 }
 
 /// Representation of a runtime class object.

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -648,6 +648,9 @@ impl<'db> Type<'db> {
         // TODO equivalent but not identical structural types, differently-ordered unions and
         // intersections, other cases?
 
+        // TODO: Once we have support for final classes, we can establish that
+        // `Type::SubclassOf('FinalClass')` is equivalent to `Type::ClassLiteral('FinalClass')`.
+
         // TODO: The following is a workaround that is required to unify the two different
         // versions of `NoneType` in typeshed. This should not be required anymore once we
         // understand `sys.version_info` branches.
@@ -2702,7 +2705,7 @@ mod tests {
     #[test_case(Ty::Intersection{pos: vec![], neg: vec![Ty::IntLiteral(2)]}, Ty::Intersection{pos: vec![], neg: vec![Ty::BuiltinInstance("int")]})]
     #[test_case(Ty::BuiltinInstance("int"), Ty::Intersection{pos: vec![], neg: vec![Ty::IntLiteral(3)]})]
     #[test_case(Ty::IntLiteral(1), Ty::Intersection{pos: vec![Ty::BuiltinInstance("int")], neg: vec![Ty::IntLiteral(1)]})]
-    #[test_case(Ty::BuiltinClassLiteral("int"), Ty::BuiltinClassLiteral("str"))]
+    #[test_case(Ty::BuiltinClassLiteral("int"), Ty::BuiltinClassLiteral("object"))]
     #[test_case(Ty::BuiltinInstance("int"), Ty::BuiltinClassLiteral("int"))]
     fn is_not_subtype_of(from: Ty, to: Ty) {
         let db = setup_db();

--- a/crates/red_knot_python_semantic/src/types/display.rs
+++ b/crates/red_knot_python_semantic/src/types/display.rs
@@ -77,6 +77,9 @@ impl Display for DisplayRepresentation<'_> {
             }
             // TODO functions and classes should display using a fully qualified name
             Type::ClassLiteral(ClassLiteralType { class }) => f.write_str(class.name(self.db)),
+            Type::Type(ClassLiteralType { class }) => {
+                write!(f, "type[{}]", class.name(self.db))
+            }
             Type::Instance(InstanceType { class, known }) => f.write_str(match known {
                 Some(super::KnownInstance::Literal) => "Literal",
                 _ => class.name(self.db),

--- a/crates/red_knot_python_semantic/src/types/display.rs
+++ b/crates/red_knot_python_semantic/src/types/display.rs
@@ -6,7 +6,9 @@ use ruff_db::display::FormatterJoinExtension;
 use ruff_python_ast::str::Quote;
 use ruff_python_literal::escape::AsciiEscape;
 
-use crate::types::{ClassLiteralType, InstanceType, IntersectionType, KnownClass, Type, UnionType};
+use crate::types::{
+    ClassLiteralType, InstanceType, IntersectionType, KnownClass, SubclassOfType, Type, UnionType,
+};
 use crate::Db;
 use rustc_hash::FxHashMap;
 
@@ -77,7 +79,7 @@ impl Display for DisplayRepresentation<'_> {
             }
             // TODO functions and classes should display using a fully qualified name
             Type::ClassLiteral(ClassLiteralType { class }) => f.write_str(class.name(self.db)),
-            Type::Type(ClassLiteralType { class }) => {
+            Type::SubclassOf(SubclassOfType { class }) => {
                 write!(f, "type[{}]", class.name(self.db))
             }
             Type::Instance(InstanceType { class, known }) => f.write_str(match known {

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -868,6 +868,9 @@ impl<'db> TypeInferenceBuilder<'db> {
             "isinstance" if definition.is_builtin_definition(self.db) => {
                 Some(KnownFunction::IsInstance)
             }
+            "issubclass" if definition.is_builtin_definition(self.db) => {
+                Some(KnownFunction::IsSubclass)
+            }
             _ => None,
         };
 

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -57,9 +57,9 @@ use crate::types::unpacker::{UnpackResult, Unpacker};
 use crate::types::{
     bindings_ty, builtins_symbol, declarations_ty, global_symbol, symbol, typing_extensions_symbol,
     Boundness, BytesLiteralType, Class, ClassLiteralType, FunctionType, InstanceType,
-    IterationOutcome, KnownClass, KnownConstraintFunction, KnownFunction, KnownInstance,
-    MetaclassErrorKind, SliceLiteralType, StringLiteralType, Symbol, Truthiness, TupleType, Type,
-    TypeArrayDisplay, UnionBuilder, UnionType,
+    IterationOutcome, KnownClass, KnownFunction, KnownInstance, MetaclassErrorKind,
+    SliceLiteralType, StringLiteralType, Symbol, Truthiness, TupleType, Type, TypeArrayDisplay,
+    UnionBuilder, UnionType,
 };
 use crate::unpack::Unpack;
 use crate::util::subscript::{PyIndex, PySlice};
@@ -861,18 +861,7 @@ impl<'db> TypeInferenceBuilder<'db> {
             }
         }
 
-        let function_kind = match &**name {
-            "reveal_type" if definition.is_typing_definition(self.db) => {
-                Some(KnownFunction::RevealType)
-            }
-            "isinstance" if definition.is_builtin_definition(self.db) => Some(
-                KnownFunction::ConstraintFunction(KnownConstraintFunction::IsInstance),
-            ),
-            "issubclass" if definition.is_builtin_definition(self.db) => Some(
-                KnownFunction::ConstraintFunction(KnownConstraintFunction::IsSubclass),
-            ),
-            _ => None,
-        };
+        let function_kind = KnownFunction::from_definition(self.db, definition, name);
 
         let body_scope = self
             .index

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -3874,16 +3874,13 @@ impl<'db> TypeInferenceBuilder<'db> {
 
                 let value_ty = self.infer_expression(value);
 
-                match value_ty.into_class_literal() {
-                    Some(ClassLiteralType { class })
-                        if class.is_known(self.db, KnownClass::Tuple) =>
-                    {
-                        self.infer_tuple_type_expression(slice)
-                    }
-                    Some(ClassLiteralType { class })
-                        if class.is_known(self.db, KnownClass::Type) =>
-                    {
-                        self.infer_subclass_of_type_expression(slice)
+                match value_ty {
+                    Type::ClassLiteral(class_literal_ty) => {
+                        match class_literal_ty.class.known(self.db) {
+                            Some(KnownClass::Tuple) => self.infer_tuple_type_expression(slice),
+                            Some(KnownClass::Type) => self.infer_subclass_of_type_expression(slice),
+                            _ => self.infer_subscript_type_expression(subscript, value_ty),
+                        }
                     }
                     _ => self.infer_subscript_type_expression(subscript, value_ty),
                 }

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -57,9 +57,9 @@ use crate::types::unpacker::{UnpackResult, Unpacker};
 use crate::types::{
     bindings_ty, builtins_symbol, declarations_ty, global_symbol, symbol, typing_extensions_symbol,
     Boundness, BytesLiteralType, Class, ClassLiteralType, FunctionType, InstanceType,
-    IterationOutcome, KnownClass, KnownFunction, KnownInstance, MetaclassErrorKind,
-    SliceLiteralType, StringLiteralType, Symbol, Truthiness, TupleType, Type, TypeArrayDisplay,
-    UnionBuilder, UnionType,
+    IterationOutcome, KnownClass, KnownConstraintFunction, KnownFunction, KnownInstance,
+    MetaclassErrorKind, SliceLiteralType, StringLiteralType, Symbol, Truthiness, TupleType, Type,
+    TypeArrayDisplay, UnionBuilder, UnionType,
 };
 use crate::unpack::Unpack;
 use crate::util::subscript::{PyIndex, PySlice};
@@ -865,12 +865,12 @@ impl<'db> TypeInferenceBuilder<'db> {
             "reveal_type" if definition.is_typing_definition(self.db) => {
                 Some(KnownFunction::RevealType)
             }
-            "isinstance" if definition.is_builtin_definition(self.db) => {
-                Some(KnownFunction::IsInstance)
-            }
-            "issubclass" if definition.is_builtin_definition(self.db) => {
-                Some(KnownFunction::IsSubclass)
-            }
+            "isinstance" if definition.is_builtin_definition(self.db) => Some(
+                KnownFunction::ConstraintFunction(KnownConstraintFunction::IsInstance),
+            ),
+            "issubclass" if definition.is_builtin_definition(self.db) => Some(
+                KnownFunction::ConstraintFunction(KnownConstraintFunction::IsSubclass),
+            ),
             _ => None,
         };
 

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -4069,6 +4069,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                     Type::Todo
                 }
             }
+            // TODO: attributes, unions, subscripts, etc.
             _ => {
                 self.infer_type_expression(slice);
                 Type::Todo

--- a/crates/red_knot_python_semantic/src/types/mro.rs
+++ b/crates/red_knot_python_semantic/src/types/mro.rs
@@ -377,7 +377,8 @@ impl<'db> ClassBase<'db> {
             | Type::LiteralString
             | Type::Tuple(_)
             | Type::SliceLiteral(_)
-            | Type::ModuleLiteral(_) => None,
+            | Type::ModuleLiteral(_)
+            | Type::Type(_) => None,
         }
     }
 

--- a/crates/red_knot_python_semantic/src/types/mro.rs
+++ b/crates/red_knot_python_semantic/src/types/mro.rs
@@ -378,7 +378,7 @@ impl<'db> ClassBase<'db> {
             | Type::Tuple(_)
             | Type::SliceLiteral(_)
             | Type::ModuleLiteral(_)
-            | Type::Type(_) => None,
+            | Type::SubclassOf(_) => None,
         }
     }
 

--- a/crates/red_knot_python_semantic/src/types/narrow.rs
+++ b/crates/red_knot_python_semantic/src/types/narrow.rs
@@ -356,7 +356,9 @@ impl<'db> NarrowingConstraintsBuilder<'db> {
                         KnownFunction::IsInstance => |class_literal: ClassLiteralType<'db>| {
                             Type::anonymous_instance(class_literal.class)
                         },
-                        KnownFunction::IsSubclass => Type::Type,
+                        KnownFunction::IsSubclass => |class_literal: ClassLiteralType<'db>| {
+                            Type::SubclassOf(class_literal.to_subclass_of_type())
+                        },
                         _ => unreachable!(),
                     };
 


### PR DESCRIPTION
## Summary

- Adds basic support for `type[C]` as a red knot `Type`. Some things might not be supported yet, like `type[Any]`.
- Adds type narrowing for `issubclass` checks.

closes #14117 

## Test Plan

New Markdown-based tests