### PR TITLE
micha/structured diagnostics

### DIFF
--- a/crates/red_knot/src/main.rs
+++ b/crates/red_knot/src/main.rs
@@ -5,8 +5,6 @@ use anyhow::{anyhow, Context};
 use clap::Parser;
 use colored::Colorize;
 use crossbeam::channel as crossbeam_channel;
-use salsa::plumbing::ZalsaDatabase;
-
 use red_knot_python_semantic::SitePackages;
 use red_knot_server::run_server;
 use red_knot_workspace::db::RootDatabase;
@@ -14,7 +12,9 @@ use red_knot_workspace::watch;
 use red_knot_workspace::watch::WorkspaceWatcher;
 use red_knot_workspace::workspace::settings::Configuration;
 use red_knot_workspace::workspace::WorkspaceMetadata;
+use ruff_db::diagnostic::Diagnostic;
 use ruff_db::system::{OsSystem, System, SystemPath, SystemPathBuf};
+use salsa::plumbing::ZalsaDatabase;
 use target_version::TargetVersion;
 
 use crate::logging::{setup_tracing, Verbosity};
@@ -318,8 +318,9 @@ impl MainLoop {
                 } => {
                     let has_diagnostics = !result.is_empty();
                     if check_revision == revision {
+                        #[allow(clippy::print_stdout)]
                         for diagnostic in result {
-                            tracing::error!("{}", diagnostic);
+                            println!("{}", diagnostic.display(db));
                         }
                     } else {
                         tracing::debug!(
@@ -378,7 +379,10 @@ impl MainLoopCancellationToken {
 #[derive(Debug)]
 enum MainLoopMessage {
     CheckWorkspace,
-    CheckCompleted { result: Vec<String>, revision: u64 },
+    CheckCompleted {
+        result: Vec<Box<dyn Diagnostic>>,
+        revision: u64,
+    },
     ApplyChanges(Vec<watch::ChangeEvent>),
     Exit,
 }

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -34,8 +34,11 @@ mod mro;
 mod narrow;
 mod unpacker;
 
+#[salsa::tracked(return_ref)]
 pub fn check_types(db: &dyn Db, file: File) -> TypeCheckDiagnostics {
     let _span = tracing::trace_span!("check_types", file=?file.path(db)).entered();
+
+    tracing::debug!("Checking file '{path}'", path = file.path(db));
 
     let index = semantic_index(db, file);
     let mut diagnostics = TypeCheckDiagnostics::new();

--- a/crates/red_knot_python_semantic/src/types/diagnostic.rs
+++ b/crates/red_knot_python_semantic/src/types/diagnostic.rs
@@ -1,12 +1,13 @@
+use crate::types::{ClassLiteralType, Type};
+use crate::Db;
+use ruff_db::diagnostic::{Diagnostic, Severity};
 use ruff_db::files::File;
 use ruff_python_ast::{self as ast, AnyNodeRef};
 use ruff_text_size::{Ranged, TextRange};
+use std::borrow::Cow;
 use std::fmt::Formatter;
 use std::ops::Deref;
 use std::sync::Arc;
-
-use crate::types::{ClassLiteralType, Type};
-use crate::Db;
 
 #[derive(Debug, Eq, PartialEq, Clone)]
 pub struct TypeCheckDiagnostic {
@@ -28,6 +29,28 @@ impl TypeCheckDiagnostic {
 
     pub fn file(&self) -> File {
         self.file
+    }
+}
+
+impl Diagnostic for TypeCheckDiagnostic {
+    fn rule(&self) -> &str {
+        TypeCheckDiagnostic::rule(self)
+    }
+
+    fn message(&self) -> Cow<str> {
+        TypeCheckDiagnostic::message(self).into()
+    }
+
+    fn file(&self) -> File {
+        TypeCheckDiagnostic::file(self)
+    }
+
+    fn range(&self) -> Option<TextRange> {
+        Some(Ranged::range(self))
+    }
+
+    fn severity(&self) -> Severity {
+        Severity::Error
     }
 }
 

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -4516,7 +4516,7 @@ mod tests {
         let file = system_path_to_file(db, filename).unwrap();
         let diagnostics = check_types(db, file);
 
-        assert_diagnostic_messages(&diagnostics, expected);
+        assert_diagnostic_messages(diagnostics, expected);
     }
 
     #[test]

--- a/crates/red_knot_server/src/edit.rs
+++ b/crates/red_knot_server/src/edit.rs
@@ -6,7 +6,7 @@ mod text_document;
 
 use lsp_types::{PositionEncodingKind, Url};
 pub use notebook::NotebookDocument;
-pub(crate) use range::RangeExt;
+pub(crate) use range::{RangeExt, ToRangeExt};
 pub(crate) use text_document::DocumentVersion;
 pub use text_document::TextDocument;
 

--- a/crates/red_knot_server/src/server/api/requests/diagnostic.rs
+++ b/crates/red_knot_server/src/server/api/requests/diagnostic.rs
@@ -3,15 +3,17 @@ use std::borrow::Cow;
 use lsp_types::request::DocumentDiagnosticRequest;
 use lsp_types::{
     Diagnostic, DiagnosticSeverity, DocumentDiagnosticParams, DocumentDiagnosticReport,
-    DocumentDiagnosticReportResult, FullDocumentDiagnosticReport, Position, Range,
+    DocumentDiagnosticReportResult, FullDocumentDiagnosticReport, NumberOrString, Range,
     RelatedFullDocumentDiagnosticReport, Url,
 };
 
-use red_knot_workspace::db::RootDatabase;
-
+use crate::edit::ToRangeExt;
 use crate::server::api::traits::{BackgroundDocumentRequestHandler, RequestHandler};
 use crate::server::{client::Notifier, Result};
 use crate::session::DocumentSnapshot;
+use red_knot_workspace::db::{Db, RootDatabase};
+use ruff_db::diagnostic::Severity;
+use ruff_db::source::{line_index, source_text};
 
 pub(crate) struct DocumentDiagnosticRequestHandler;
 
@@ -64,36 +66,37 @@ fn compute_diagnostics(snapshot: &DocumentSnapshot, db: &RootDatabase) -> Vec<Di
     diagnostics
         .as_slice()
         .iter()
-        .map(|message| to_lsp_diagnostic(message))
+        .map(|message| to_lsp_diagnostic(db, message, snapshot.encoding()))
         .collect()
 }
 
-fn to_lsp_diagnostic(message: &str) -> Diagnostic {
-    let words = message.split(':').collect::<Vec<_>>();
+fn to_lsp_diagnostic(
+    db: &dyn Db,
+    diagnostic: &dyn ruff_db::diagnostic::Diagnostic,
+    encoding: crate::PositionEncoding,
+) -> Diagnostic {
+    let range = if let Some(range) = diagnostic.range() {
+        let index = line_index(db.upcast(), diagnostic.file());
+        let source = source_text(db.upcast(), diagnostic.file());
 
-    let (range, message) = match words.as_slice() {
-        [_, _, line, column, message] | [_, line, column, message] => {
-            let line = line.parse::<u32>().unwrap_or_default().saturating_sub(1);
-            let column = column.parse::<u32>().unwrap_or_default();
-            (
-                Range::new(
-                    Position::new(line, column.saturating_sub(1)),
-                    Position::new(line, column),
-                ),
-                message.trim(),
-            )
-        }
-        _ => (Range::default(), message),
+        range.to_range(&source, &index, encoding)
+    } else {
+        Range::default()
+    };
+
+    let severity = match diagnostic.severity() {
+        Severity::Info => DiagnosticSeverity::INFORMATION,
+        Severity::Error => DiagnosticSeverity::ERROR,
     };
 
     Diagnostic {
         range,
-        severity: Some(DiagnosticSeverity::ERROR),
+        severity: Some(severity),
         tags: None,
-        code: None,
+        code: Some(NumberOrString::String(diagnostic.rule().to_string())),
         code_description: None,
         source: Some("red-knot".into()),
-        message: message.to_string(),
+        message: diagnostic.message().into_owned(),
         related_information: None,
         data: None,
     }

--- a/crates/red_knot_test/src/lib.rs
+++ b/crates/red_knot_test/src/lib.rs
@@ -1,14 +1,13 @@
-use crate::diagnostic::Diagnostic;
 use colored::Colorize;
 use parser as test_parser;
 use red_knot_python_semantic::types::check_types;
+use ruff_db::diagnostic::{Diagnostic, ParseDiagnostic};
 use ruff_db::files::{system_path_to_file, File, Files};
 use ruff_db::parsed::parsed_module;
 use ruff_db::system::{DbWithTestSystem, SystemPathBuf};
 use ruff_source_file::LineIndex;
 use ruff_text_size::TextSize;
 use std::path::Path;
-use std::sync::Arc;
 
 mod assertion;
 mod db;
@@ -94,14 +93,15 @@ fn run_test(db: &mut db::Db, test: &parser::MarkdownTest) -> Result<(), Failures
                 .iter()
                 .cloned()
                 .map(|error| {
-                    let diagnostic: Box<dyn Diagnostic> = Box::new(error);
+                    let diagnostic: Box<dyn Diagnostic> =
+                        Box::new(ParseDiagnostic::new(test_file.file, error));
                     diagnostic
                 })
                 .collect();
 
             let type_diagnostics = check_types(db, test_file.file);
             diagnostics.extend(type_diagnostics.into_iter().map(|diagnostic| {
-                let diagnostic: Box<dyn Diagnostic> = Box::new(Arc::unwrap_or_clone(diagnostic));
+                let diagnostic: Box<dyn Diagnostic> = Box::new((*diagnostic).clone());
                 diagnostic
             }));
 

--- a/crates/red_knot_wasm/src/lib.rs
+++ b/crates/red_knot_wasm/src/lib.rs
@@ -6,6 +6,7 @@ use wasm_bindgen::prelude::*;
 use red_knot_workspace::db::RootDatabase;
 use red_knot_workspace::workspace::settings::Configuration;
 use red_knot_workspace::workspace::WorkspaceMetadata;
+use ruff_db::diagnostic::Diagnostic;
 use ruff_db::files::{system_path_to_file, File};
 use ruff_db::system::walk_directory::WalkDirectoryBuilder;
 use ruff_db::system::{
@@ -110,14 +111,20 @@ impl Workspace {
     pub fn check_file(&self, file_id: &FileHandle) -> Result<Vec<String>, Error> {
         let result = self.db.check_file(file_id.file).map_err(into_error)?;
 
-        Ok(result)
+        Ok(result
+            .into_iter()
+            .map(|diagnostic| diagnostic.display(&self.db).to_string())
+            .collect())
     }
 
     /// Checks all open files
     pub fn check(&self) -> Result<Vec<String>, Error> {
         let result = self.db.check().map_err(into_error)?;
 
-        Ok(result)
+        Ok(result
+            .into_iter()
+            .map(|diagnostic| diagnostic.display(&self.db).to_string())
+            .collect())
     }
 
     /// Returns the parsed AST for `path`

--- a/crates/red_knot_wasm/tests/api.rs
+++ b/crates/red_knot_wasm/tests/api.rs
@@ -19,6 +19,6 @@ fn check() {
 
     assert_eq!(
         result,
-        vec!["/test.py:1:8: Cannot resolve import `random22`"]
+        vec!["error[unresolved-import] /test.py:1:8 Cannot resolve import `random22`"]
     );
 }

--- a/crates/red_knot_workspace/src/db.rs
+++ b/crates/red_knot_workspace/src/db.rs
@@ -4,13 +4,13 @@ use std::sync::Arc;
 use salsa::plumbing::ZalsaDatabase;
 use salsa::{Cancelled, Event};
 
+use crate::workspace::{check_file, Workspace, WorkspaceMetadata};
 use red_knot_python_semantic::{Db as SemanticDb, Program};
+use ruff_db::diagnostic::Diagnostic;
 use ruff_db::files::{File, Files};
 use ruff_db::system::System;
 use ruff_db::vendored::VendoredFileSystem;
 use ruff_db::{Db as SourceDb, Upcast};
-
-use crate::workspace::{check_file, Workspace, WorkspaceMetadata};
 
 mod changes;
 
@@ -51,11 +51,11 @@ impl RootDatabase {
     }
 
     /// Checks all open files in the workspace and its dependencies.
-    pub fn check(&self) -> Result<Vec<String>, Cancelled> {
+    pub fn check(&self) -> Result<Vec<Box<dyn Diagnostic>>, Cancelled> {
         self.with_db(|db| db.workspace().check(db))
     }
 
-    pub fn check_file(&self, file: File) -> Result<Vec<String>, Cancelled> {
+    pub fn check_file(&self, file: File) -> Result<Vec<Box<dyn Diagnostic>>, Cancelled> {
         let _span = tracing::debug_span!("check_file", file=%file.path(self)).entered();
 
         self.with_db(|db| check_file(db, file))

--- a/crates/red_knot_workspace/src/workspace.rs
+++ b/crates/red_knot_workspace/src/workspace.rs
@@ -1,23 +1,23 @@
-use std::{collections::BTreeMap, sync::Arc};
-
 use rustc_hash::{FxBuildHasher, FxHashSet};
 use salsa::{Durability, Setter as _};
+use std::borrow::Cow;
+use std::{collections::BTreeMap, sync::Arc};
 
+use crate::db::Db;
+use crate::db::RootDatabase;
+use crate::workspace::files::{Index, Indexed, IndexedIter, PackageFiles};
 pub use metadata::{PackageMetadata, WorkspaceMetadata};
 use red_knot_python_semantic::types::check_types;
 use red_knot_python_semantic::SearchPathSettings;
+use ruff_db::diagnostic::{Diagnostic, ParseDiagnostic, Severity};
 use ruff_db::parsed::parsed_module;
-use ruff_db::source::{line_index, source_text, SourceDiagnostic};
+use ruff_db::source::{source_text, SourceTextError};
 use ruff_db::{
     files::{system_path_to_file, File},
     system::{walk_directory::WalkState, SystemPath, SystemPathBuf},
 };
 use ruff_python_ast::{name::Name, PySourceType};
-use ruff_text_size::Ranged;
-
-use crate::db::Db;
-use crate::db::RootDatabase;
-use crate::workspace::files::{Index, Indexed, IndexedIter, PackageFiles};
+use ruff_text_size::TextRange;
 
 mod files;
 mod metadata;
@@ -188,7 +188,7 @@ impl Workspace {
     }
 
     /// Checks all open files in the workspace and its dependencies.
-    pub fn check(self, db: &RootDatabase) -> Vec<String> {
+    pub fn check(self, db: &RootDatabase) -> Vec<Box<dyn Diagnostic>> {
         let workspace_span = tracing::debug_span!("check_workspace");
         let _span = workspace_span.enter();
 
@@ -378,47 +378,31 @@ impl Package {
     }
 }
 
-#[salsa::tracked]
-pub(super) fn check_file(db: &dyn Db, file: File) -> Vec<String> {
-    tracing::debug!("Checking file '{path}'", path = file.path(db));
-
-    let mut diagnostics = Vec::new();
-
-    let source_diagnostics = source_text::accumulated::<SourceDiagnostic>(db.upcast(), file);
-    // TODO(micha): Consider using a single accumulator for all diagnostics
-    diagnostics.extend(
-        source_diagnostics
-            .iter()
-            .map(std::string::ToString::to_string),
-    );
-
+pub(super) fn check_file(db: &dyn Db, file: File) -> Vec<Box<dyn Diagnostic>> {
+    let mut diagnostics: Vec<Box<dyn Diagnostic>> = Vec::new();
     // Abort checking if there are IO errors.
     let source = source_text(db.upcast(), file);
 
-    if source.has_read_error() {
+    if let Some(read_error) = source.read_error() {
+        diagnostics.push(Box::new(IOErrorDiagnostic {
+            file,
+            error: read_error.clone(),
+        }));
         return diagnostics;
     }
 
     let parsed = parsed_module(db.upcast(), file);
+    diagnostics.extend(parsed.errors().iter().map(|error| {
+        let diagnostic: Box<dyn Diagnostic> = Box::new(ParseDiagnostic::new(file, error.clone()));
+        diagnostic
+    }));
 
-    if !parsed.errors().is_empty() {
-        let path = file.path(db);
-        let line_index = line_index(db.upcast(), file);
-        diagnostics.extend(parsed.errors().iter().map(|err| {
-            let source_location = line_index.source_location(err.location.start(), source.as_str());
-            format!("{path}:{source_location}: {message}", message = err.error)
-        }));
-    }
+    diagnostics.extend(check_types(db.upcast(), file).iter().map(|diagnostic| {
+        let boxed: Box<dyn Diagnostic> = Box::new(diagnostic.clone());
+        boxed
+    }));
 
-    for diagnostic in check_types(db.upcast(), file) {
-        let index = line_index(db.upcast(), diagnostic.file());
-        let location = index.source_location(diagnostic.start(), source.as_str());
-        diagnostics.push(format!(
-            "{path}:{location}: {message}",
-            path = file.path(db),
-            message = diagnostic.message()
-        ));
-    }
+    diagnostics.sort_unstable_by_key(|diagnostic| diagnostic.range().unwrap_or_default().start());
 
     diagnostics
 }
@@ -533,16 +517,44 @@ impl Iterator for WorkspaceFilesIter<'_> {
     }
 }
 
+#[derive(Debug)]
+pub struct IOErrorDiagnostic {
+    file: File,
+    error: SourceTextError,
+}
+
+impl Diagnostic for IOErrorDiagnostic {
+    fn rule(&self) -> &str {
+        "io"
+    }
+
+    fn message(&self) -> Cow<str> {
+        self.error.to_string().into()
+    }
+
+    fn file(&self) -> File {
+        self.file
+    }
+
+    fn range(&self) -> Option<TextRange> {
+        None
+    }
+
+    fn severity(&self) -> Severity {
+        Severity::Error
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use crate::db::tests::TestDb;
+    use crate::workspace::check_file;
     use red_knot_python_semantic::types::check_types;
+    use ruff_db::diagnostic::Diagnostic;
     use ruff_db::files::system_path_to_file;
     use ruff_db::source::source_text;
     use ruff_db::system::{DbWithTestSystem, SystemPath};
     use ruff_db::testing::assert_function_query_was_not_run;
-
-    use crate::db::tests::TestDb;
-    use crate::workspace::check_file;
 
     #[test]
     fn check_file_skips_type_checking_when_file_cant_be_read() -> ruff_db::system::Result<()> {
@@ -558,7 +570,10 @@ mod tests {
 
         assert_eq!(source_text(&db, file).as_str(), "");
         assert_eq!(
-            check_file(&db, file),
+            check_file(&db, file)
+                .into_iter()
+                .map(|diagnostic| diagnostic.message().into_owned())
+                .collect::<Vec<_>>(),
             vec!["Failed to read file: No such file or directory".to_string()]
         );
 
@@ -570,7 +585,13 @@ mod tests {
         db.write_file(path, "").unwrap();
 
         assert_eq!(source_text(&db, file).as_str(), "");
-        assert_eq!(check_file(&db, file), vec![] as Vec<String>);
+        assert_eq!(
+            check_file(&db, file)
+                .into_iter()
+                .map(|diagnostic| diagnostic.message().into_owned())
+                .collect::<Vec<_>>(),
+            vec![] as Vec<String>
+        );
 
         Ok(())
     }

--- a/crates/ruff_benchmark/benches/red_knot.rs
+++ b/crates/ruff_benchmark/benches/red_knot.rs
@@ -8,6 +8,7 @@ use red_knot_workspace::workspace::settings::Configuration;
 use red_knot_workspace::workspace::WorkspaceMetadata;
 use ruff_benchmark::criterion::{criterion_group, criterion_main, BatchSize, Criterion};
 use ruff_benchmark::TestFile;
+use ruff_db::diagnostic::Diagnostic;
 use ruff_db::files::{system_path_to_file, File};
 use ruff_db::source::source_text;
 use ruff_db::system::{MemoryFileSystem, SystemPath, SystemPathBuf, TestSystem};
@@ -24,32 +25,32 @@ const TOMLLIB_312_URL: &str = "https://raw.githubusercontent.com/python/cpython/
 
 static EXPECTED_DIAGNOSTICS: &[&str] = &[
     // We don't support `*` imports yet:
-    "/src/tomllib/_parser.py:7:29: Module `collections.abc` has no member `Iterable`",
+    "error[unresolved-import] /src/tomllib/_parser.py:7:29 Module `collections.abc` has no member `Iterable`",
     // We don't support terminal statements in control flow yet:
-    "/src/tomllib/_parser.py:246:15: Method `__class_getitem__` of type `Literal[frozenset]` is possibly unbound",
-    "/src/tomllib/_parser.py:692:8354: Invalid class base with type `GenericAlias` (all bases must be a class, `Any`, `Unknown` or `Todo`)",
-    "/src/tomllib/_parser.py:66:18: Name `s` used when possibly not defined",
-    "/src/tomllib/_parser.py:98:12: Name `char` used when possibly not defined",
-    "/src/tomllib/_parser.py:101:12: Name `char` used when possibly not defined",
-    "/src/tomllib/_parser.py:104:14: Name `char` used when possibly not defined",
-    "/src/tomllib/_parser.py:108:17: Conflicting declared types for `second_char`: Unknown, str | None",
-    "/src/tomllib/_parser.py:115:14: Name `char` used when possibly not defined",
-    "/src/tomllib/_parser.py:126:12: Name `char` used when possibly not defined",
-    "/src/tomllib/_parser.py:267:9: Conflicting declared types for `char`: Unknown, str | None",
-    "/src/tomllib/_parser.py:348:20: Name `nest` used when possibly not defined",
-    "/src/tomllib/_parser.py:353:5: Name `nest` used when possibly not defined",
-    "/src/tomllib/_parser.py:364:9: Conflicting declared types for `char`: Unknown, str | None",
-    "/src/tomllib/_parser.py:381:13: Conflicting declared types for `char`: Unknown, str | None",
-    "/src/tomllib/_parser.py:395:9: Conflicting declared types for `char`: Unknown, str | None",
-    "/src/tomllib/_parser.py:453:24: Name `nest` used when possibly not defined",
-    "/src/tomllib/_parser.py:455:9: Name `nest` used when possibly not defined",
-    "/src/tomllib/_parser.py:482:16: Name `char` used when possibly not defined",
-    "/src/tomllib/_parser.py:566:12: Name `char` used when possibly not defined",
-    "/src/tomllib/_parser.py:573:12: Name `char` used when possibly not defined",
-    "/src/tomllib/_parser.py:579:12: Name `char` used when possibly not defined",
-    "/src/tomllib/_parser.py:580:63: Name `char` used when possibly not defined",
-    "/src/tomllib/_parser.py:590:9: Conflicting declared types for `char`: Unknown, str | None",
-    "/src/tomllib/_parser.py:629:38: Name `datetime_obj` used when possibly not defined",
+    "error[possibly-unresolved-reference] /src/tomllib/_parser.py:66:18 Name `s` used when possibly not defined",
+    "error[possibly-unresolved-reference] /src/tomllib/_parser.py:98:12 Name `char` used when possibly not defined",
+    "error[possibly-unresolved-reference] /src/tomllib/_parser.py:101:12 Name `char` used when possibly not defined",
+    "error[possibly-unresolved-reference] /src/tomllib/_parser.py:104:14 Name `char` used when possibly not defined",
+    "error[conflicting-declarations] /src/tomllib/_parser.py:108:17 Conflicting declared types for `second_char`: Unknown, str | None",
+    "error[possibly-unresolved-reference] /src/tomllib/_parser.py:115:14 Name `char` used when possibly not defined",
+    "error[possibly-unresolved-reference] /src/tomllib/_parser.py:126:12 Name `char` used when possibly not defined",
+    "error[call-possibly-unbound-method] /src/tomllib/_parser.py:246:15 Method `__class_getitem__` of type `Literal[frozenset]` is possibly unbound",
+    "error[conflicting-declarations] /src/tomllib/_parser.py:267:9 Conflicting declared types for `char`: Unknown, str | None",
+    "error[possibly-unresolved-reference] /src/tomllib/_parser.py:348:20 Name `nest` used when possibly not defined",
+    "error[possibly-unresolved-reference] /src/tomllib/_parser.py:353:5 Name `nest` used when possibly not defined",
+    "error[conflicting-declarations] /src/tomllib/_parser.py:364:9 Conflicting declared types for `char`: Unknown, str | None",
+    "error[conflicting-declarations] /src/tomllib/_parser.py:381:13 Conflicting declared types for `char`: Unknown, str | None",
+    "error[conflicting-declarations] /src/tomllib/_parser.py:395:9 Conflicting declared types for `char`: Unknown, str | None",
+    "error[possibly-unresolved-reference] /src/tomllib/_parser.py:453:24 Name `nest` used when possibly not defined",
+    "error[possibly-unresolved-reference] /src/tomllib/_parser.py:455:9 Name `nest` used when possibly not defined",
+    "error[possibly-unresolved-reference] /src/tomllib/_parser.py:482:16 Name `char` used when possibly not defined",
+    "error[possibly-unresolved-reference] /src/tomllib/_parser.py:566:12 Name `char` used when possibly not defined",
+    "error[possibly-unresolved-reference] /src/tomllib/_parser.py:573:12 Name `char` used when possibly not defined",
+    "error[possibly-unresolved-reference] /src/tomllib/_parser.py:579:12 Name `char` used when possibly not defined",
+    "error[possibly-unresolved-reference] /src/tomllib/_parser.py:580:63 Name `char` used when possibly not defined",
+    "error[conflicting-declarations] /src/tomllib/_parser.py:590:9 Conflicting declared types for `char`: Unknown, str | None",
+    "error[possibly-unresolved-reference] /src/tomllib/_parser.py:629:38 Name `datetime_obj` used when possibly not defined",
+    "error[invalid-base] /src/tomllib/_parser.py:692:8354 Invalid class base with type `GenericAlias` (all bases must be a class, `Any`, `Unknown` or `Todo`)",
 ];
 
 fn get_test_file(name: &str) -> TestFile {
@@ -123,7 +124,14 @@ fn setup_rayon() {
 fn benchmark_incremental(criterion: &mut Criterion) {
     fn setup() -> Case {
         let case = setup_case();
-        let result = case.db.check().unwrap();
+
+        let result: Vec<_> = case
+            .db
+            .check()
+            .unwrap()
+            .into_iter()
+            .map(|diagnostic| diagnostic.display(&case.db).to_string())
+            .collect();
 
         assert_eq!(result, EXPECTED_DIAGNOSTICS);
 
@@ -150,7 +158,7 @@ fn benchmark_incremental(criterion: &mut Criterion) {
 
         let result = db.check().unwrap();
 
-        assert_eq!(result, EXPECTED_DIAGNOSTICS);
+        assert_eq!(result.len(), EXPECTED_DIAGNOSTICS.len());
     }
 
     setup_rayon();
@@ -168,7 +176,12 @@ fn benchmark_cold(criterion: &mut Criterion) {
             setup_case,
             |case| {
                 let Case { db, .. } = case;
-                let result = db.check().unwrap();
+                let result: Vec<_> = db
+                    .check()
+                    .unwrap()
+                    .into_iter()
+                    .map(|diagnostic| diagnostic.display(db).to_string())
+                    .collect();
 
                 assert_eq!(result, EXPECTED_DIAGNOSTICS);
             },

--- a/crates/ruff_db/src/diagnostic.rs
+++ b/crates/ruff_db/src/diagnostic.rs
@@ -1,0 +1,180 @@
+use crate::{
+    files::File,
+    source::{line_index, source_text},
+    Db,
+};
+use ruff_python_parser::ParseError;
+use ruff_text_size::TextRange;
+use std::borrow::Cow;
+
+pub trait Diagnostic: Send + Sync + std::fmt::Debug {
+    fn rule(&self) -> &str;
+
+    fn message(&self) -> std::borrow::Cow<str>;
+
+    fn file(&self) -> File;
+
+    fn range(&self) -> Option<TextRange>;
+
+    fn severity(&self) -> Severity;
+
+    fn display<'a>(&'a self, db: &'a dyn Db) -> DisplayDiagnostic<'a>
+    where
+        Self: Sized,
+    {
+        DisplayDiagnostic {
+            db,
+            diagnostic: self,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum Severity {
+    Info,
+    Error,
+}
+
+pub struct DisplayDiagnostic<'db> {
+    db: &'db dyn Db,
+    diagnostic: &'db dyn Diagnostic,
+}
+
+impl<'db> DisplayDiagnostic<'db> {
+    pub fn new(db: &'db dyn Db, diagnostic: &'db dyn Diagnostic) -> Self {
+        Self { db, diagnostic }
+    }
+}
+
+impl std::fmt::Display for DisplayDiagnostic<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.diagnostic.severity() {
+            Severity::Info => f.write_str("info")?,
+            Severity::Error => f.write_str("error")?,
+        }
+
+        write!(
+            f,
+            "[{rule}] {path}",
+            rule = self.diagnostic.rule(),
+            path = self.diagnostic.file().path(self.db)
+        )?;
+
+        if let Some(range) = self.diagnostic.range() {
+            let index = line_index(self.db, self.diagnostic.file());
+            let source = source_text(self.db, self.diagnostic.file());
+
+            let start = index.source_location(range.start(), &source);
+
+            write!(f, ":{line}:{col}", line = start.row, col = start.column)?;
+        }
+
+        write!(f, " {message}", message = self.diagnostic.message())
+    }
+}
+
+impl<T> Diagnostic for Box<T>
+where
+    T: Diagnostic,
+{
+    fn rule(&self) -> &str {
+        (**self).rule()
+    }
+
+    fn message(&self) -> Cow<str> {
+        (**self).message()
+    }
+
+    fn file(&self) -> File {
+        (**self).file()
+    }
+
+    fn range(&self) -> Option<TextRange> {
+        (**self).range()
+    }
+
+    fn severity(&self) -> Severity {
+        (**self).severity()
+    }
+}
+
+impl<T> Diagnostic for std::sync::Arc<T>
+where
+    T: Diagnostic,
+{
+    fn rule(&self) -> &str {
+        (**self).rule()
+    }
+
+    fn message(&self) -> std::borrow::Cow<str> {
+        (**self).message()
+    }
+
+    fn file(&self) -> File {
+        (**self).file()
+    }
+
+    fn range(&self) -> Option<TextRange> {
+        (**self).range()
+    }
+
+    fn severity(&self) -> Severity {
+        (**self).severity()
+    }
+}
+
+impl Diagnostic for Box<dyn Diagnostic> {
+    fn rule(&self) -> &str {
+        (**self).rule()
+    }
+
+    fn message(&self) -> Cow<str> {
+        (**self).message()
+    }
+
+    fn file(&self) -> File {
+        (**self).file()
+    }
+
+    fn range(&self) -> Option<TextRange> {
+        (**self).range()
+    }
+
+    fn severity(&self) -> Severity {
+        (**self).severity()
+    }
+}
+
+#[derive(Debug)]
+pub struct ParseDiagnostic {
+    file: File,
+    error: ParseError,
+}
+
+impl ParseDiagnostic {
+    pub fn new(file: File, error: ParseError) -> Self {
+        Self { file, error }
+    }
+}
+
+impl Diagnostic for ParseDiagnostic {
+    fn rule(&self) -> &str {
+        "invalid-syntax"
+    }
+
+    fn message(&self) -> Cow<str> {
+        self.error.error.to_string().into()
+    }
+
+    fn file(&self) -> File {
+        self.file
+    }
+
+    fn range(&self) -> Option<TextRange> {
+        Some(self.error.location)
+    }
+
+    fn severity(&self) -> Severity {
+        Severity::Error
+    }
+}

--- a/crates/ruff_db/src/lib.rs
+++ b/crates/ruff_db/src/lib.rs
@@ -6,6 +6,7 @@ use crate::files::Files;
 use crate::system::System;
 use crate::vendored::VendoredFileSystem;
 
+pub mod diagnostic;
 pub mod display;
 pub mod file_revision;
 pub mod files;


### PR DESCRIPTION
## Summary

Extracts the `Diagnostic` trait from https://github.com/astral-sh/ruff/pull/14116. `check_file` (and workspace) now returns structured diagnostic information instead of a string. 