### PR TITLE
[red-knot] Improve `Symbol` API for callable types

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/call/callable_instance.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/call/callable_instance.md
@@ -55,5 +55,21 @@ class NonCallable:
 
 a = NonCallable()
 # error: "Object of type `NonCallable` is not callable"
-result = a()
+reveal_type(a())  # revealed: Unknown
+```
+
+## Possibly non-callable `__call__`
+
+```py
+def flag() -> bool: ...
+
+class NonCallable:
+    if flag():
+        __call__ = 1
+    else:
+        def __call__(self) -> int: ...
+
+a = NonCallable()
+# error: "Object of type `Literal[1] | Literal[__call__]` is not callable (due to union element `Literal[1]`)"
+reveal_type(a())  # revealed: Unknown | int
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/call/callable_instance.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/call/callable_instance.md
@@ -18,3 +18,42 @@ class Unit: ...
 b = Unit()(3.0)  # error: "Object of type `Unit` is not callable"
 reveal_type(b)  # revealed: Unknown
 ```
+
+## Possibly unbound `__call__` method
+
+```py
+def flag() -> bool: ...
+
+class PossiblyNotCallable:
+    if flag():
+        def __call__(self) -> int: ...
+
+a = PossiblyNotCallable()
+result = a()  # error: "Object of type `PossiblyNotCallable` is not callable (possibly unbound `__call__` method)"
+reveal_type(result)  # revealed: int
+```
+
+## Possibly unbound callable
+
+```py
+def flag() -> bool: ...
+
+if flag():
+    class PossiblyUnbound:
+        def __call__(self) -> int: ...
+
+# error: [possibly-unresolved-reference]
+a = PossiblyUnbound()
+reveal_type(a())  # revealed: int
+```
+
+## Non-callable `__call__`
+
+```py
+class NonCallable:
+    __call__ = 1
+
+a = NonCallable()
+# error: "Object of type `NonCallable` is not callable"
+result = a()
+```

--- a/crates/red_knot_python_semantic/resources/mdtest/call/function.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/call/function.md
@@ -44,3 +44,16 @@ reveal_type(bar())  # revealed: @Todo
 nonsense = 123
 x = nonsense()  # error: "Object of type `Literal[123]` is not callable"
 ```
+
+## Potentially unbound function
+
+```py
+def flag() -> bool: ...
+
+if flag():
+    def foo() -> int:
+        return 42
+
+# error: [possibly-unresolved-reference]
+reveal_type(foo())  # revealed: int
+```

--- a/crates/red_knot_python_semantic/resources/mdtest/loops/for_loop.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/loops/for_loop.md
@@ -238,7 +238,7 @@ class Test:
 def coinflip() -> bool:
     return True
 
-# TODO: we should emit a diagnostic here (it might not be iterable)
+# error: [not-iterable] "Object of type `Test | Literal[42]` is not iterable because its `__iter__` method is possibly unbound"
 for x in Test() if coinflip() else 42:
     reveal_type(x)  # revealed: int
 ```

--- a/crates/red_knot_python_semantic/src/symbol.rs
+++ b/crates/red_knot_python_semantic/src/symbol.rs
@@ -1,5 +1,5 @@
 use crate::{
-    types::{CallOutcome, Type, UnionType},
+    types::{Type, UnionType},
     Db,
 };
 
@@ -48,20 +48,6 @@ impl<'db> Symbol<'db> {
         match self {
             Symbol::Type(ty, _) => *ty,
             Symbol::Unbound => Type::Unknown,
-        }
-    }
-
-    pub(crate) fn call(self, db: &'db dyn Db, arg_types: &[Type<'db>]) -> CallOutcome<'db> {
-        match self {
-            Symbol::Type(callable_ty, Boundness::Bound) => callable_ty.call(db, arg_types),
-            Symbol::Type(callable_ty, Boundness::MayBeUnbound) => {
-                let return_ty = callable_ty.call(db, arg_types).return_ty(db);
-                CallOutcome::PossiblyUnbound {
-                    callable_ty,
-                    return_ty,
-                }
-            }
-            Symbol::Unbound => CallOutcome::Unbound,
         }
     }
 

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -1944,7 +1944,7 @@ impl<'db> NotCallableError<'db> {
     /// The resolved type that was not callable.
     ///
     /// For unions, returns the union type itself, which may contain a mix of callable and
-    /// non-callable types. Return `Unknown` if the callable was an unbound symbol.
+    /// non-callable types.
     fn called_ty(&self) -> Type<'db> {
         match self {
             Self::Type {

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -1209,9 +1209,6 @@ impl<'db> Type<'db> {
             }
 
             instance_ty @ Type::Instance(InstanceType { .. }) => {
-                // Since `__call__` is a dunder, we need to access it as an attribute on the class
-                // rather than the instance (matching runtime semantics).
-
                 let args = std::iter::once(self)
                     .chain(arg_types.iter().copied())
                     .collect::<Vec<_>>();
@@ -1319,7 +1316,7 @@ impl<'db> Type<'db> {
                 .return_ty(db)
             {
                 if boundness == Boundness::MayBeUnbound {
-                    IterationOutcome::PossiblyUnboundIterable {
+                    IterationOutcome::PossiblyUnboundDunderIter {
                         iterable_ty: self,
                         element_ty,
                     }
@@ -1968,7 +1965,7 @@ enum IterationOutcome<'db> {
     NotIterable {
         not_iterable_ty: Type<'db>,
     },
-    PossiblyUnboundIterable {
+    PossiblyUnboundDunderIter {
         iterable_ty: Type<'db>,
         element_ty: Type<'db>,
     },
@@ -1986,7 +1983,7 @@ impl<'db> IterationOutcome<'db> {
                 diagnostics.add_not_iterable(iterable_node, not_iterable_ty);
                 Type::Unknown
             }
-            Self::PossiblyUnboundIterable {
+            Self::PossiblyUnboundDunderIter {
                 iterable_ty,
                 element_ty,
             } => {

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -1706,7 +1706,7 @@ impl<'db> CallOutcome<'db> {
         }
     }
 
-    /// Get the return type of the call, or `None` if not callable
+    /// Get the return type of the call, or `None` if not callable.
     fn return_ty(&self, db: &'db dyn Db) -> Option<Type<'db>> {
         match self {
             Self::Callable { return_ty } => Some(*return_ty),

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -1180,7 +1180,7 @@ impl<'db> Type<'db> {
 
     /// Return the outcome of calling an object of this type.
     #[must_use]
-    pub(crate) fn call(self, db: &'db dyn Db, arg_types: &[Type<'db>]) -> CallOutcome<'db> {
+    fn call(self, db: &'db dyn Db, arg_types: &[Type<'db>]) -> CallOutcome<'db> {
         match self {
             // TODO validate typed call arguments vs callable signature
             Type::FunctionLiteral(function_type) => {
@@ -1264,7 +1264,7 @@ impl<'db> Type<'db> {
     }
 
     /// Look up a dunder method on the meta type of `self` and call it.
-    pub(crate) fn call_dunder(
+    fn call_dunder(
         self,
         db: &'db dyn Db,
         name: &str,
@@ -1655,7 +1655,7 @@ impl KnownInstance {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) enum CallOutcome<'db> {
+enum CallOutcome<'db> {
     Callable {
         return_ty: Type<'db>,
     },
@@ -1706,8 +1706,8 @@ impl<'db> CallOutcome<'db> {
         }
     }
 
-    /// Get the return type of the call, or `None` if not callable or (possibly) unbound.
-    pub(crate) fn return_ty(&self, db: &'db dyn Db) -> Option<Type<'db>> {
+    /// Get the return type of the call, or `None` if not callable
+    fn return_ty(&self, db: &'db dyn Db) -> Option<Type<'db>> {
         match self {
             Self::Callable { return_ty } => Some(*return_ty),
             Self::RevealType {
@@ -1889,7 +1889,7 @@ impl<'db> CallOutcome<'db> {
     }
 }
 
-pub(crate) enum CallDunderResult<'db> {
+enum CallDunderResult<'db> {
     CallOutcome(CallOutcome<'db>),
     PossiblyUnbound(CallOutcome<'db>),
     MethodNotAvailable,

--- a/crates/red_knot_python_semantic/src/types/diagnostic.rs
+++ b/crates/red_knot_python_semantic/src/types/diagnostic.rs
@@ -164,6 +164,23 @@ impl<'db> TypeCheckDiagnosticsBuilder<'db> {
         );
     }
 
+    /// Emit a diagnostic declaring that the object represented by `node` is not iterable
+    /// because its `__iter__` method is possibly unbound.
+    pub(super) fn add_not_iterable_possibly_unbound(
+        &mut self,
+        node: AnyNodeRef,
+        element_ty: Type<'db>,
+    ) {
+        self.add(
+            node,
+            "not-iterable",
+            format_args!(
+                "Object of type `{}` is not iterable because its `__iter__` method is possibly unbound",
+                element_ty.display(self.db)
+            ),
+        );
+    }
+
     /// Emit a diagnostic declaring that an index is out of bounds for a tuple.
     pub(super) fn add_index_out_of_bounds(
         &mut self,

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -2957,20 +2957,21 @@ impl<'db> TypeInferenceBuilder<'db> {
                 op,
             ),
 
-            (Type::Instance(left), Type::Instance(right), op) => {
+            (left_ty @ Type::Instance(left), right_ty @ Type::Instance(right), op) => {
                 if left != right && right.is_instance_of(self.db, left.class) {
                     let reflected_dunder = op.reflected_dunder();
                     let rhs_reflected = right.class.class_member(self.db, reflected_dunder);
                     if !rhs_reflected.is_unbound()
                         && rhs_reflected != left.class.class_member(self.db, reflected_dunder)
                     {
-                        return rhs_reflected
-                            .call(self.db, &[right_ty, left_ty])
+                        return right_ty
+                            .to_meta_type(self.db)
+                            .call_dunder(self.db, reflected_dunder, &[right_ty, left_ty])
                             .return_ty(self.db)
                             .or_else(|| {
-                                left.class
-                                    .class_member(self.db, op.dunder())
-                                    .call(self.db, &[left_ty, right_ty])
+                                left_ty
+                                    .to_meta_type(self.db)
+                                    .call_dunder(self.db, op.dunder(), &[left_ty, right_ty])
                                     .return_ty(self.db)
                             });
                     }

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -2965,12 +2965,10 @@ impl<'db> TypeInferenceBuilder<'db> {
                         && rhs_reflected != left.class.class_member(self.db, reflected_dunder)
                     {
                         return right_ty
-                            .to_meta_type(self.db)
                             .call_dunder(self.db, reflected_dunder, &[right_ty, left_ty])
                             .return_ty(self.db)
                             .or_else(|| {
                                 left_ty
-                                    .to_meta_type(self.db)
                                     .call_dunder(self.db, op.dunder(), &[left_ty, right_ty])
                                     .return_ty(self.db)
                             });

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -2965,11 +2965,13 @@ impl<'db> TypeInferenceBuilder<'db> {
                         && rhs_reflected != left.class.class_member(self.db, reflected_dunder)
                     {
                         return rhs_reflected
-                            .get_return_type_if_callable(self.db, &[right_ty, left_ty])
+                            .call(self.db, &[right_ty, left_ty])
+                            .return_ty(self.db)
                             .or_else(|| {
                                 left.class
                                     .class_member(self.db, op.dunder())
-                                    .get_return_type_if_callable(self.db, &[left_ty, right_ty])
+                                    .call(self.db, &[left_ty, right_ty])
+                                    .return_ty(self.db)
                             });
                     }
                 }

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -2965,15 +2965,11 @@ impl<'db> TypeInferenceBuilder<'db> {
                         && rhs_reflected != left.class.class_member(self.db, reflected_dunder)
                     {
                         return rhs_reflected
-                            .unwrap_or(Type::Never)
-                            .call(self.db, &[right_ty, left_ty])
-                            .return_ty(self.db)
+                            .get_return_type_if_callable(self.db, &[right_ty, left_ty])
                             .or_else(|| {
                                 left.class
                                     .class_member(self.db, op.dunder())
-                                    .unwrap_or(Type::Never)
-                                    .call(self.db, &[left_ty, right_ty])
-                                    .return_ty(self.db)
+                                    .get_return_type_if_callable(self.db, &[left_ty, right_ty])
                             });
                     }
                 }
@@ -4398,7 +4394,8 @@ fn perform_membership_test_comparison<'db>(
             // iteration-based membership test
             match Type::Instance(right).iterate(db) {
                 IterationOutcome::Iterable { .. } => Some(KnownClass::Bool.to_instance(db)),
-                IterationOutcome::NotIterable { .. } => None,
+                IterationOutcome::NotIterable { .. }
+                | IterationOutcome::PossiblyUnboundIterable { .. } => None,
             }
         }
     };

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -4396,7 +4396,7 @@ fn perform_membership_test_comparison<'db>(
             match Type::Instance(right).iterate(db) {
                 IterationOutcome::Iterable { .. } => Some(KnownClass::Bool.to_instance(db)),
                 IterationOutcome::NotIterable { .. }
-                | IterationOutcome::PossiblyUnboundIterable { .. } => None,
+                | IterationOutcome::PossiblyUnboundDunderIter { .. } => None,
             }
         }
     };


### PR DESCRIPTION
## Summary

- Get rid of `Symbol::unwrap_or` (unclear semantics, not needed anymore)
- Introduce `Type::call_dunder`
- Emit new diagnostic for possibly-unbound `__iter__` methods
- Better diagnostics for callables with possibly-unbound / possibly-non-callable `__call__` methods

part of: #14022 

closes #14016

## Test Plan

- Updated test for iterables with possibly-unbound `__iter__` methods.
- New tests for callables