### PR TITLE
[red-knot] Add support for string annotations

### DIFF
--- a/crates/red_knot_python_semantic/Cargo.toml
+++ b/crates/red_knot_python_semantic/Cargo.toml
@@ -14,6 +14,7 @@ license = { workspace = true }
 ruff_db = { workspace = true }
 ruff_index = { workspace = true }
 ruff_python_ast = { workspace = true, features = ["salsa"] }
+ruff_python_parser = { workspace = true }
 ruff_python_stdlib = { workspace = true }
 ruff_source_file = { workspace = true }
 ruff_text_size = { workspace = true }

--- a/crates/red_knot_python_semantic/resources/mdtest/annotations/string.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/annotations/string.md
@@ -1,9 +1,191 @@
 # String annotations
 
+## Simple
+
 ```py
 def f() -> "int":
     return 1
 
-# TODO: We do not support string annotations, but we should not panic if we encounter them
-reveal_type(f())  # revealed: @Todo
+reveal_type(f())  # revealed: int
 ```
+
+## Nested
+
+```py
+def f() -> "'int'":
+    return 1
+
+reveal_type(f())  # revealed: int
+```
+
+## Type expression
+
+```py
+def f1() -> "int | str":
+    return 1
+
+def f2() -> "tuple[int, str]":
+    return 1
+
+reveal_type(f1())  # revealed: int | str
+reveal_type(f2())  # revealed: tuple[int, str]
+```
+
+## Partial
+
+```py
+def f() -> tuple[int, "str"]:
+    return 1
+
+reveal_type(f())  # revealed: tuple[int, str]
+```
+
+## Deferred
+
+```py
+def f() -> "Foo":
+    return Foo()
+
+class Foo:
+    pass
+
+reveal_type(f())  # revealed: Foo
+```
+
+## Deferred (undefined)
+
+```py
+# error: [unresolved-reference]
+def f() -> "Foo":
+    pass
+
+reveal_type(f())  # revealed: Unknown
+```
+
+## Partial deferred
+
+```py
+def f() -> int | "Foo":
+    return 1
+
+class Foo:
+    pass
+
+reveal_type(f())  # revealed: int | Foo
+```
+
+## `typing.Literal`
+
+```py
+from typing import Literal
+
+def f1() -> Literal["Foo", "Bar"]:
+    return "Foo"
+
+def f2() -> 'Literal["Foo", "Bar"]':
+    return "Foo"
+
+class Foo:
+    pass
+
+reveal_type(f1())  # revealed: Literal["Foo", "Bar"]
+reveal_type(f2())  # revealed: Literal["Foo", "Bar"]
+```
+
+## Various string kinds
+
+```py
+# error: [annotation-raw-string] "Type expressions cannot use raw string literal"
+def f1() -> r"int":
+    return 1
+
+# error: [annotation-f-string] "Type expressions cannot use f-strings"
+def f2() -> f"int":
+    return 1
+
+# error: [annotation-byte-string] "Type expressions cannot use bytes literal"
+def f3() -> b"int":
+    return 1
+
+def f4() -> "int":
+    return 1
+
+# error: [annotation-implicit-concat] "Type expressions cannot span multiple string literals"
+def f5() -> "in" "t":
+    return 1
+
+# error: [annotation-escape-character] "Type expressions cannot contain escape characters"
+def f6() -> "\N{LATIN SMALL LETTER I}nt":
+    return 1
+
+# error: [annotation-escape-character] "Type expressions cannot contain escape characters"
+def f7() -> "\x69nt":
+    return 1
+
+def f8() -> """int""":
+    return 1
+
+# error: [annotation-byte-string] "Type expressions cannot use bytes literal"
+def f9() -> "b'int'":
+    return 1
+
+reveal_type(f1())  # revealed: Unknown
+reveal_type(f2())  # revealed: Unknown
+reveal_type(f3())  # revealed: Unknown
+reveal_type(f4())  # revealed: int
+reveal_type(f5())  # revealed: Unknown
+reveal_type(f6())  # revealed: Unknown
+reveal_type(f7())  # revealed: Unknown
+reveal_type(f8())  # revealed: int
+reveal_type(f9())  # revealed: Unknown
+```
+
+## Various string kinds in `typing.Literal`
+
+```py
+from typing import Literal
+
+def f() -> Literal["a", r"b", b"c", "d" "e", "\N{LATIN SMALL LETTER F}", "\x67", """h"""]:
+    return "normal"
+
+reveal_type(f())  # revealed: Literal["a", "b", "de", "f", "g", "h"] | Literal[b"c"]
+```
+
+## Class variables
+
+```py
+MyType = int
+
+class Aliases:
+    MyType = str
+
+    forward: "MyType"
+    not_forward: MyType
+
+reveal_type(Aliases.forward)  # revealed: str
+reveal_type(Aliases.not_forward)  # revealed: str
+```
+
+## Annotated assignment
+
+```py
+a: "int" = 1
+b: "'int'" = 1
+c: "Foo"
+# error: [invalid-assignment] "Object of type `Literal[1]` is not assignable to `Foo`"
+d: "Foo" = 1
+
+class Foo:
+    pass
+
+c = Foo()
+
+reveal_type(a)  # revealed: Literal[1]
+reveal_type(b)  # revealed: Literal[1]
+reveal_type(c)  # revealed: Foo
+reveal_type(d)  # revealed: Foo
+```
+
+## Parameter
+
+TODO: Add tests once parameter inference is supported

--- a/crates/red_knot_python_semantic/resources/mdtest/assignment/annotations.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/assignment/annotations.md
@@ -110,3 +110,29 @@ c: builtins.tuple[builtins.tuple[builtins.int, builtins.int], builtins.int] = ((
 # error: [invalid-assignment] "Object of type `Literal["foo"]` is not assignable to `tuple[tuple[int, int], int]`"
 c: builtins.tuple[builtins.tuple[builtins.int, builtins.int], builtins.int] = "foo"
 ```
+
+## Future annotations are deferred
+
+```py
+from __future__ import annotations
+
+x: Foo
+
+class Foo:
+    pass
+
+x = Foo()
+reveal_type(x)  # revealed: Foo
+```
+
+## Annotations in stub files are deferred
+
+```pyi path=main.pyi
+x: Foo
+
+class Foo:
+    pass
+
+x = Foo()
+reveal_type(x)  # revealed: Foo
+```

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -37,6 +37,7 @@ mod infer;
 mod mro;
 mod narrow;
 mod signatures;
+mod string_annotation;
 mod unpacker;
 
 #[salsa::tracked(return_ref)]
@@ -58,7 +59,7 @@ pub fn check_types(db: &dyn Db, file: File) -> TypeCheckDiagnostics {
 
 /// Infer the public type of a symbol (its type as seen from outside its scope).
 fn symbol_by_id<'db>(db: &'db dyn Db, scope: ScopeId<'db>, symbol: ScopedSymbolId) -> Symbol<'db> {
-    let _span = tracing::trace_span!("symbol_ty_by_id", ?symbol).entered();
+    let _span = tracing::trace_span!("symbol_by_id", ?symbol).entered();
 
     let use_def = use_def_map(db, scope);
 
@@ -182,13 +183,21 @@ pub(crate) fn global_symbol<'db>(db: &'db dyn Db, file: File, name: &str) -> Sym
 /// Infer the type of a binding.
 pub(crate) fn binding_ty<'db>(db: &'db dyn Db, definition: Definition<'db>) -> Type<'db> {
     let inference = infer_definition_types(db, definition);
-    inference.binding_ty(definition)
+    if inference.is_eagerly_deferred(definition) {
+        infer_deferred_types(db, definition).binding_ty(definition)
+    } else {
+        inference.binding_ty(definition)
+    }
 }
 
 /// Infer the type of a declaration.
 fn declaration_ty<'db>(db: &'db dyn Db, definition: Definition<'db>) -> Type<'db> {
     let inference = infer_definition_types(db, definition);
-    inference.declaration_ty(definition)
+    if inference.is_eagerly_deferred(definition) {
+        infer_deferred_types(db, definition).declaration_ty(definition)
+    } else {
+        inference.declaration_ty(definition)
+    }
 }
 
 /// Infer the type of a (possibly deferred) sub-expression of a [`Definition`].
@@ -2275,6 +2284,21 @@ impl<'db> IterationOutcome<'db> {
                 diagnostics.add_not_iterable_possibly_unbound(iterable_node, iterable_ty);
                 element_ty
             }
+        }
+    }
+}
+
+#[derive(Debug)]
+enum MaybeDeferred<'db> {
+    Type(Type<'db>),
+    Deferred,
+}
+
+impl<'db> MaybeDeferred<'db> {
+    fn expect_type(self) -> Type<'db> {
+        match self {
+            MaybeDeferred::Type(ty) => ty,
+            MaybeDeferred::Deferred => panic!("expected a type, but got a deferred annotation"),
         }
     }
 }

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -183,21 +183,13 @@ pub(crate) fn global_symbol<'db>(db: &'db dyn Db, file: File, name: &str) -> Sym
 /// Infer the type of a binding.
 pub(crate) fn binding_ty<'db>(db: &'db dyn Db, definition: Definition<'db>) -> Type<'db> {
     let inference = infer_definition_types(db, definition);
-    if inference.is_eagerly_deferred(definition) {
-        infer_deferred_types(db, definition).binding_ty(definition)
-    } else {
-        inference.binding_ty(definition)
-    }
+    inference.binding_ty(definition)
 }
 
 /// Infer the type of a declaration.
 fn declaration_ty<'db>(db: &'db dyn Db, definition: Definition<'db>) -> Type<'db> {
     let inference = infer_definition_types(db, definition);
-    if inference.is_eagerly_deferred(definition) {
-        infer_deferred_types(db, definition).declaration_ty(definition)
-    } else {
-        inference.declaration_ty(definition)
-    }
+    inference.declaration_ty(definition)
 }
 
 /// Infer the type of a (possibly deferred) sub-expression of a [`Definition`].
@@ -2284,21 +2276,6 @@ impl<'db> IterationOutcome<'db> {
                 diagnostics.add_not_iterable_possibly_unbound(iterable_node, iterable_ty);
                 element_ty
             }
-        }
-    }
-}
-
-#[derive(Debug)]
-enum MaybeDeferred<'db> {
-    Type(Type<'db>),
-    Deferred,
-}
-
-impl<'db> MaybeDeferred<'db> {
-    fn expect_type(self) -> Type<'db> {
-        match self {
-            MaybeDeferred::Type(ty) => ty,
-            MaybeDeferred::Deferred => panic!("expected a type, but got a deferred annotation"),
         }
     }
 }

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -4115,6 +4115,24 @@ impl<'db> TypeInferenceBuilder<'db> {
             // Annotation expressions also get special handling for `*args` and `**kwargs`.
             ast::Expr::Starred(starred) => self.infer_starred_expression(starred),
 
+            ast::Expr::BytesLiteral(bytes) => {
+                self.diagnostics.add(
+                    bytes.into(),
+                    "annotation-byte-string",
+                    format_args!("Type expressions cannot use bytes literal"),
+                );
+                Type::Unknown
+            }
+
+            ast::Expr::FString(fstring) => {
+                self.diagnostics.add(
+                    fstring.into(),
+                    "annotation-f-string",
+                    format_args!("Type expressions cannot use f-strings"),
+                );
+                Type::Unknown
+            }
+
             // All other annotation expressions are (possibly) valid type expressions, so handle
             // them there instead.
             type_expr => self.infer_type_expression_no_store(type_expr),

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -839,7 +839,10 @@ impl<'db> TypeInferenceBuilder<'db> {
             .as_deref()
             .expect("function type params scope without type params");
 
-        self.infer_optional_annotation_expression(function.returns.as_deref());
+        self.infer_optional_annotation_expression(
+            function.returns.as_deref(),
+            DeferredExpressionState::None,
+        );
         self.infer_type_parameters(type_params);
         self.infer_parameters(&function.parameters);
     }
@@ -988,7 +991,10 @@ impl<'db> TypeInferenceBuilder<'db> {
             default: _,
         } = parameter_with_default;
 
-        self.infer_optional_annotation_expression(parameter.annotation.as_deref());
+        self.infer_optional_annotation_expression(
+            parameter.annotation.as_deref(),
+            DeferredExpressionState::None,
+        );
     }
 
     fn infer_parameter(&mut self, parameter: &ast::Parameter) {
@@ -998,7 +1004,10 @@ impl<'db> TypeInferenceBuilder<'db> {
             annotation,
         } = parameter;
 
-        self.infer_optional_annotation_expression(annotation.as_deref());
+        self.infer_optional_annotation_expression(
+            annotation.as_deref(),
+            DeferredExpressionState::None,
+        );
     }
 
     fn infer_parameter_with_default_definition(
@@ -4099,7 +4108,7 @@ impl<'db> TypeInferenceBuilder<'db> {
 
 /// Annotation expressions.
 impl<'db> TypeInferenceBuilder<'db> {
-    /// Infer the type of an annotation expression with the given [`DeferredState`].
+    /// Infer the type of an annotation expression with the given [`DeferredExpressionState`].
     fn infer_annotation_expression(
         &mut self,
         annotation: &ast::Expr,
@@ -4201,7 +4210,7 @@ impl<'db> TypeInferenceBuilder<'db> {
         expression.map(|expr| self.infer_type_expression(expr))
     }
 
-    /// Similar to [`infer_type_expression`], but accepts a [`DeferredState`].
+    /// Similar to [`infer_type_expression`], but accepts a [`DeferredExpressionState`].
     ///
     /// [`infer_type_expression`]: TypeInferenceBuilder::infer_type_expression
     fn infer_type_expression_with_state(

--- a/crates/red_knot_python_semantic/src/types/string_annotation.rs
+++ b/crates/red_knot_python_semantic/src/types/string_annotation.rs
@@ -57,7 +57,7 @@ pub(crate) fn parse_string_annotation(
             }
         } else {
             // The raw contents of the string doesn't match the parsed content. This could be the
-            // case for annotations that contain escaped quotes.
+            // case for annotations that contain escape sequences.
             diagnostics.add(
                 string_expr.into(),
                 "annotation-escape-character",

--- a/crates/red_knot_python_semantic/src/types/string_annotation.rs
+++ b/crates/red_knot_python_semantic/src/types/string_annotation.rs
@@ -1,0 +1,76 @@
+use ruff_db::files::File;
+use ruff_db::source::source_text;
+use ruff_python_ast::str::raw_contents;
+use ruff_python_ast::{self as ast, ModExpression, StringFlags};
+use ruff_python_parser::{parse_expression_range, Parsed};
+use ruff_text_size::Ranged;
+
+use crate::types::diagnostic::{TypeCheckDiagnostics, TypeCheckDiagnosticsBuilder};
+use crate::Db;
+
+type AnnotationParseResult = Result<Parsed<ModExpression>, TypeCheckDiagnostics>;
+
+/// Parses the given expression as a string annotation.
+///
+/// # Panics
+///
+/// Panics if the expression is not a string literal.
+pub(crate) fn parse_string_annotation(
+    db: &dyn Db,
+    file: File,
+    string_expr: &ast::ExprStringLiteral,
+) -> AnnotationParseResult {
+    let _span = tracing::trace_span!("parse_string_annotation", string=?string_expr.range(), file=%file.path(db)).entered();
+
+    let source = source_text(db.upcast(), file);
+    let node_text = &source[string_expr.range()];
+    let mut diagnostics = TypeCheckDiagnosticsBuilder::new(db, file);
+
+    if let [string_literal] = string_expr.value.as_slice() {
+        let prefix = string_literal.flags.prefix();
+        if prefix.is_raw() {
+            diagnostics.add(
+                string_literal.into(),
+                "annotation-raw-string",
+                format_args!("Type expressions cannot be use raw string literal"),
+            );
+        }
+
+        // Compare the raw contents (without quotes) of the expression with the parsed contents
+        // contained in the string literal.
+        if raw_contents(node_text)
+            .is_some_and(|raw_contents| raw_contents == string_literal.as_str())
+        {
+            let range_excluding_quotes = string_literal
+                .range()
+                .add_start(string_literal.flags.opener_len())
+                .sub_end(string_literal.flags.closer_len());
+
+            match parse_expression_range(source.as_str(), range_excluding_quotes) {
+                Ok(parsed) => return Ok(parsed),
+                Err(parse_error) => diagnostics.add(
+                    string_literal.into(),
+                    "forward-annotation-syntax-error",
+                    format_args!("Syntax error in forward annotation: {}", parse_error.error),
+                ),
+            }
+        } else {
+            // The raw contents of the string doesn't match the parsed content. This could be the
+            // case for annotations that contain escaped quotes.
+            diagnostics.add(
+                string_expr.into(),
+                "annotation-escape-character",
+                format_args!("Type expressions cannot contain escape characters"),
+            );
+        }
+    } else {
+        // String is implicitly concatenated.
+        diagnostics.add(
+            string_expr.into(),
+            "annotation-implicit-concat",
+            format_args!("Type expressions cannot span multiple string literals"),
+        );
+    }
+
+    Err(diagnostics.finish())
+}

--- a/crates/ruff_db/src/parsed.rs
+++ b/crates/ruff_db/src/parsed.rs
@@ -2,7 +2,7 @@ use std::fmt::Formatter;
 use std::ops::Deref;
 use std::sync::Arc;
 
-use ruff_python_ast::{ModModule, PySourceType};
+use ruff_python_ast::{ModExpression, ModModule, PySourceType};
 use ruff_python_parser::{parse_unchecked_source, Parsed};
 
 use crate::files::{File, FilePath};
@@ -70,6 +70,41 @@ impl Deref for ParsedModule {
 impl std::fmt::Debug for ParsedModule {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         f.debug_tuple("ParsedModule").field(&self.inner).finish()
+    }
+}
+
+/// Cheap cloneable wrapper around the parsed expression.
+#[derive(Clone)]
+pub struct ParsedExpression {
+    inner: Arc<Parsed<ModExpression>>,
+}
+
+impl ParsedExpression {
+    pub fn new(parsed: Parsed<ModExpression>) -> Self {
+        Self {
+            inner: Arc::new(parsed),
+        }
+    }
+
+    /// Consumes `self` and returns the Arc storing the parsed expression.
+    pub fn into_arc(self) -> Arc<Parsed<ModExpression>> {
+        self.inner
+    }
+}
+
+impl Deref for ParsedExpression {
+    type Target = Parsed<ModExpression>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl std::fmt::Debug for ParsedExpression {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("ParsedExpression")
+            .field(&self.inner)
+            .finish()
     }
 }
 

--- a/crates/ruff_db/src/parsed.rs
+++ b/crates/ruff_db/src/parsed.rs
@@ -2,7 +2,7 @@ use std::fmt::Formatter;
 use std::ops::Deref;
 use std::sync::Arc;
 
-use ruff_python_ast::{ModExpression, ModModule, PySourceType};
+use ruff_python_ast::{ModModule, PySourceType};
 use ruff_python_parser::{parse_unchecked_source, Parsed};
 
 use crate::files::{File, FilePath};
@@ -70,41 +70,6 @@ impl Deref for ParsedModule {
 impl std::fmt::Debug for ParsedModule {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         f.debug_tuple("ParsedModule").field(&self.inner).finish()
-    }
-}
-
-/// Cheap cloneable wrapper around the parsed expression.
-#[derive(Clone)]
-pub struct ParsedExpression {
-    inner: Arc<Parsed<ModExpression>>,
-}
-
-impl ParsedExpression {
-    pub fn new(parsed: Parsed<ModExpression>) -> Self {
-        Self {
-            inner: Arc::new(parsed),
-        }
-    }
-
-    /// Consumes `self` and returns the Arc storing the parsed expression.
-    pub fn into_arc(self) -> Arc<Parsed<ModExpression>> {
-        self.inner
-    }
-}
-
-impl Deref for ParsedExpression {
-    type Target = Parsed<ModExpression>;
-
-    fn deref(&self) -> &Self::Target {
-        &self.inner
-    }
-}
-
-impl std::fmt::Debug for ParsedExpression {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        f.debug_tuple("ParsedExpression")
-            .field(&self.inner)
-            .finish()
     }
 }
 


### PR DESCRIPTION
## Summary

This PR adds support for parsing and inferring types within string annotations.

### Implementation (attempt 1)

This is preserved in https://github.com/astral-sh/ruff/pull/14151/commits/6217f48924f8f3f8a3d28c4929fe5aaad4ad0a59.

The implementation here would separate the inference of string annotations in the deferred query. This requires the following:
* Two ways of evaluating the deferred definitions - lazily and eagerly. 
	* An eager evaluation occurs right outside the definition query which in this case would be in `binding_ty` and `declaration_ty`.
	* A lazy evaluation occurs on demand like using the `definition_expression_ty` to determine the function return type and class bases.
* The above point means that when trying to get the binding type for a variable in an annotated assignment, the definition query won't include the type. So, it'll require going through the deferred query to get the type.

This has the following limitations:
* Nested string annotations, although not necessarily a useful feature, is difficult to implement unless we convert the implementation in an infinite loop
* Partial string annotations require complex layout because inferring the types for stringified and non-stringified parts of the annotation are done in separate queries. This means we need to maintain additional information

### Implementation (attempt 2)

This is the final diff in this PR.

The implementation here does the complete inference of string annotation in the same definition query by maintaining certain state while trying to infer different parts of an expression and take decisions accordingly. These are:
* Allow names that are part of a string annotation to not exists in the symbol table. For example, in `x: "Foo"`, if the "Foo" symbol is not defined then it won't exists in the symbol table even though it's being used. This is an invariant which is being allowed only for symbols in a string annotation.
* Similarly, lookup name is updated to do the same and if the symbol doesn't exists, then it's not bounded.
* Store the final type of a string annotation on the string expression itself and not for any of the sub-expressions that are created after parsing. This is because those sub-expressions won't exists in the semantic index.

Design document: https://www.notion.so/astral-sh/String-Annotations-12148797e1ca801197a9f146641e5b71?pvs=4

Closes: #13796 

## Test Plan

* Add various test cases in our markdown framework
* Run `red_knot` on LibCST (contains a lot of string annotations, specifically https://github.com/Instagram/LibCST/blob/main/libcst/matchers/_matcher_base.py), FastAPI (good amount of annotated code including `typing.Literal`) and compare against the `main` branch output
