### PR TITLE
Use Python 3.12 for `fuzz-parser` in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ env:
   CARGO_TERM_COLOR: always
   RUSTUP_MAX_RETRIES: 10
   PACKAGE_NAME: ruff
-  PYTHON_VERSION: "3.11"
+  PYTHON_VERSION: "3.13"
 
 jobs:
   determine_changes:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ env:
   CARGO_TERM_COLOR: always
   RUSTUP_MAX_RETRIES: 10
   PACKAGE_NAME: ruff
-  PYTHON_VERSION: "3.13"
+  PYTHON_VERSION: "3.12"
 
 jobs:
   determine_changes:

--- a/.github/workflows/daily_fuzz.yaml
+++ b/.github/workflows/daily_fuzz.yaml
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
+          python-version: "3.12"
       - name: Install uv
         run: curl -LsSf https://astral.sh/uv/install.sh | sh
       - name: Install Python requirements

--- a/.github/workflows/daily_fuzz.yaml
+++ b/.github/workflows/daily_fuzz.yaml
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.13"
       - name: Install uv
         run: curl -LsSf https://astral.sh/uv/install.sh | sh
       - name: Install Python requirements


### PR DESCRIPTION
## Summary

Looks like merging #14156 broke CI on the `main` branch. I thought I was safe to enable automerge as I'd done extensive testing locally -- more fool me!

It looks like the problem is something to do with f-strings, so I'm guessing [PEP-701](https://peps.python.org/pep-0701/) is to blame. Let's see if upgrading our Python versions in CI to 3.13 (which is what I used for local testing) fixes things.
