### PR TITLE
[`flake8-logging-format`] Fix invalid formatting value in docs of `logging-extra-attr-clash` (`G101`)

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_logging_format/violations.rs
+++ b/crates/ruff_linter/src/rules/flake8_logging_format/violations.rs
@@ -432,7 +432,7 @@ impl AlwaysFixableViolation for LoggingWarn {
 ///
 /// username = "Maria"
 ///
-/// logging.info("Something happened", extra=dict(user=username))
+/// logging.info("Something happened", extra=dict(user_id=username))
 /// ```
 ///
 /// ## Options


### PR DESCRIPTION
Fixes ValueError in example