### PR TITLE
[`flake8-bandit`] Typo in docs `suspicious-pickle-import` (`S403`)

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/suspicious_imports.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/suspicious_imports.rs
@@ -63,7 +63,7 @@ impl Violation for SuspiciousFtplibImport {
 /// ```python
 /// import pickle
 /// ```
-/// /// ## References
+/// ## References
 /// - [Python Docs](https://docs.python.org/3/library/pickle.html)
 #[violation]
 pub struct SuspiciousPickleImport;


### PR DESCRIPTION
Fixes a typo in the docs