### PR TITLE
[red-knot] Property tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -877,16 +877,6 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3"
-dependencies = [
- "log",
- "regex",
-]
-
-[[package]]
-name = "env_logger"
 version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13fa619b91fb2381732789fc5de83b45675e882f66623b7d8cb4f643017018d"
@@ -2189,8 +2179,6 @@ version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "588f6378e4dd99458b60ec275b4477add41ce4fa9f64dcba6f15adccb19b50d6"
 dependencies = [
- "env_logger 0.8.4",
- "log",
  "rand",
 ]
 
@@ -2952,7 +2940,7 @@ dependencies = [
 name = "ruff_python_resolver"
 version = "0.0.0"
 dependencies = [
- "env_logger 0.11.5",
+ "env_logger",
  "insta",
  "log",
  "tempfile",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -413,7 +413,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -693,7 +693,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.10.0",
- "syn",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -704,7 +704,7 @@ checksum = "a668eda54683121533a393014d8692171709ff57a7d61f187b6e782719f8933f"
 dependencies = [
  "darling_core",
  "quote",
- "syn",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -774,7 +774,7 @@ dependencies = [
  "glob",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -826,7 +826,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -870,6 +870,16 @@ name = "env_filter"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a009aa4810eb158359dda09d0c87378e4bbb89b5a801f016885a4707ba24f7ea"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3"
 dependencies = [
  "log",
  "regex",
@@ -1246,7 +1256,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -1420,7 +1430,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -1547,7 +1557,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2ae40017ac09cd2c6a53504cb3c871c7f2b41466eac5bc66ba63f39073b467b"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -2013,7 +2023,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -2174,6 +2184,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "quickcheck"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "588f6378e4dd99458b60ec275b4477add41ce4fa9f64dcba6f15adccb19b50d6"
+dependencies = [
+ "env_logger 0.8.4",
+ "log",
+ "rand",
+]
+
+[[package]]
+name = "quickcheck_macros"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b22a693222d716a9587786f37ac3f6b4faedb5b80c23914e7303ff5a1d8016e9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2273,6 +2305,8 @@ dependencies = [
  "itertools 0.13.0",
  "memchr",
  "ordermap",
+ "quickcheck",
+ "quickcheck_macros",
  "red_knot_test",
  "red_knot_vendored",
  "ruff_db",
@@ -2777,7 +2811,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "ruff_python_trivia",
- "syn",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -2918,7 +2952,7 @@ dependencies = [
 name = "ruff_python_resolver"
 version = "0.0.0"
 dependencies = [
- "env_logger",
+ "env_logger 0.11.5",
  "insta",
  "log",
  "tempfile",
@@ -3197,7 +3231,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.90",
  "synstructure",
 ]
 
@@ -3231,7 +3265,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -3280,7 +3314,7 @@ checksum = "ad1e866f866923f252f05c889987993144fb74e722403468a4ebd70c3cd756c0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -3291,7 +3325,7 @@ checksum = "330f01ce65a3a5fe59a60c82f3c9a024b573b8a6e875bd233fe5f934e71d54e3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -3314,7 +3348,7 @@ checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -3355,7 +3389,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -3463,7 +3497,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -3471,6 +3505,17 @@ name = "subtle"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "syn"
@@ -3491,7 +3536,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -3554,7 +3599,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -3565,7 +3610,7 @@ checksum = "5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.90",
  "test-case-core",
 ]
 
@@ -3595,7 +3640,7 @@ checksum = "b607164372e89797d78b8e23a6d67d5d1038c1c65efd52e1389ef8b77caba2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -3606,7 +3651,7 @@ checksum = "f077553d607adc1caf65430528a576c757a71ed73944b66ebb58ef2bbd243568"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -3728,7 +3773,7 @@ checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -4001,7 +4046,7 @@ checksum = "6b91f57fe13a38d0ce9e28a03463d8d3c2468ed03d75375110ec71d93b449a08"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -4096,7 +4141,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.90",
  "wasm-bindgen-shared",
 ]
 
@@ -4131,7 +4176,7 @@ checksum = "98c9ae5a76e46f4deecd0f0255cc223cfa18dc9b261213b8aa0c7b36f61b3f1d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.90",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -4165,7 +4210,7 @@ checksum = "222ebde6ea87fbfa6bdd2e9f1fd8a91d60aee5db68792632176c4e16a74fc7d8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -4468,7 +4513,7 @@ checksum = "28cc31741b18cb6f1d5ff12f5b7523e3d6eb0852bbbad19d73905511d9849b95"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.90",
  "synstructure",
 ]
 
@@ -4489,7 +4534,7 @@ checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -4509,7 +4554,7 @@ checksum = "0ea7b4a3637ea8669cedf0f1fd5c286a17f3de97b8dd5a70a6c167a1730e63a5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.90",
  "synstructure",
 ]
 
@@ -4538,7 +4583,7 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.90",
 ]
 
 [[package]]

--- a/crates/red_knot_python_semantic/Cargo.toml
+++ b/crates/red_knot_python_semantic/Cargo.toml
@@ -49,6 +49,11 @@ anyhow = { workspace = true }
 dir-test = { workspace = true }
 insta = { workspace = true }
 tempfile = { workspace = true }
+quickcheck = { version = "1.0.3" }
+quickcheck_macros = { version = "1.0.0" }
 
 [lints]
 workspace = true
+
+[features]
+property_tests = []

--- a/crates/red_knot_python_semantic/Cargo.toml
+++ b/crates/red_knot_python_semantic/Cargo.toml
@@ -49,7 +49,7 @@ anyhow = { workspace = true }
 dir-test = { workspace = true }
 insta = { workspace = true }
 tempfile = { workspace = true }
-quickcheck = { version = "1.0.3" }
+quickcheck = { version = "1.0.3", default-features = false }
 quickcheck_macros = { version = "1.0.0" }
 
 [lints]

--- a/crates/red_knot_python_semantic/Cargo.toml
+++ b/crates/red_knot_python_semantic/Cargo.toml
@@ -54,6 +54,3 @@ quickcheck_macros = { version = "1.0.0" }
 
 [lints]
 workspace = true
-
-[features]
-property_tests = []

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -40,6 +40,10 @@ mod signatures;
 mod string_annotation;
 mod unpacker;
 
+#[cfg(test)]
+#[cfg(feature = "property_tests")]
+mod property_tests;
+
 #[salsa::tracked(return_ref)]
 pub fn check_types(db: &dyn Db, file: File) -> TypeCheckDiagnostics {
     let _span = tracing::trace_span!("check_types", file=?file.path(db)).entered();
@@ -3086,8 +3090,8 @@ pub(crate) mod tests {
 
     /// A test representation of a type that can be transformed unambiguously into a real Type,
     /// given a db.
-    #[derive(Debug, Clone)]
-    enum Ty {
+    #[derive(Debug, Clone, PartialEq)]
+    pub(crate) enum Ty {
         Never,
         Unknown,
         None,
@@ -3111,7 +3115,7 @@ pub(crate) mod tests {
     }
 
     impl Ty {
-        fn into_type(self, db: &TestDb) -> Type<'_> {
+        pub(crate) fn into_type(self, db: &TestDb) -> Type<'_> {
             match self {
                 Ty::Never => Type::Never,
                 Ty::Unknown => Type::Unknown,

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -41,7 +41,6 @@ mod string_annotation;
 mod unpacker;
 
 #[cfg(test)]
-#[cfg(feature = "property_tests")]
 mod property_tests;
 
 #[salsa::tracked(return_ref)]

--- a/crates/red_knot_python_semantic/src/types/property_tests.rs
+++ b/crates/red_knot_python_semantic/src/types/property_tests.rs
@@ -1,0 +1,266 @@
+//! This module contains quickcheck-based property tests for `Type`s.
+//!
+//! These tests are feature-gated and disabled by default. You can run them using:
+//!
+//! ```sh
+//! cargo test -p red_knot_python_semantic --features property_tests types::property_tests
+//! ```
+//!
+//! You can control the number of tests (default: 100) by setting the `QUICKCHECK_TESTS`
+//! variable. For example:
+//!
+//! ```sh
+//! QUICKCHECK_TESTS=10000 cargo test …
+//! ```
+//!
+//! If you want to run these tests for a longer period of time, it's advisable to run them
+//! in release mode. As some tests are slower than others, it's advisable to run them in a
+//! loop until they fail:
+//!
+//! ```sh
+//! export QUICKCHECK_TESTS=100000
+//! while cargo test --release -p red_knot_python_semantic \
+//!   --features property_tests types::property_tests; do :; done
+//! ```
+
+use std::sync::{Arc, Mutex, MutexGuard, OnceLock};
+
+use super::tests::{setup_db, Ty};
+use super::Type;
+use crate::db::tests::TestDb;
+use crate::types::KnownClass;
+use crate::Db;
+use quickcheck::{Arbitrary, Gen};
+use quickcheck_macros::quickcheck;
+
+fn arbitrary_core_type(g: &mut Gen) -> Ty {
+    // We could select a random integer here, but this would make it much less
+    // likely to explore interesting edge cases:
+    let int_lit = Ty::IntLiteral(*g.choose(&[-2, -1, 0, 1, 2]).unwrap());
+    let bool_lit = Ty::BooleanLiteral(bool::arbitrary(g));
+    g.choose(&[
+        Ty::Never,
+        Ty::Unknown,
+        Ty::None,
+        Ty::Any,
+        int_lit,
+        bool_lit,
+        Ty::StringLiteral(""),
+        Ty::StringLiteral("a"),
+        Ty::LiteralString,
+        Ty::BytesLiteral(""),
+        Ty::BytesLiteral("\x00"),
+        Ty::KnownClassInstance(KnownClass::Object),
+        Ty::KnownClassInstance(KnownClass::Str),
+        Ty::KnownClassInstance(KnownClass::Int),
+        Ty::KnownClassInstance(KnownClass::Bool),
+        Ty::KnownClassInstance(KnownClass::List),
+        Ty::KnownClassInstance(KnownClass::Tuple),
+        Ty::KnownClassInstance(KnownClass::FunctionType),
+        Ty::KnownClassInstance(KnownClass::SpecialForm),
+        Ty::KnownClassInstance(KnownClass::TypeVar),
+        Ty::KnownClassInstance(KnownClass::TypeAliasType),
+        Ty::KnownClassInstance(KnownClass::NoDefaultType),
+        Ty::TypingLiteral,
+        Ty::BuiltinClassLiteral("str"),
+        Ty::BuiltinClassLiteral("int"),
+        Ty::BuiltinClassLiteral("bool"),
+        Ty::BuiltinClassLiteral("object"),
+    ])
+    .unwrap()
+    .clone()
+}
+
+/// Constructs an arbitrary type.
+///
+/// The `size` parameter controls the depth of the type tree. For example,
+/// a simple type like `int` has a size of 0, `Union[int, str]` has a size
+/// of 1, `tuple[int, Union[str, bytes]]` has a size of 2, etc.
+fn arbitrary_type(g: &mut Gen, size: u32) -> Ty {
+    if size == 0 {
+        arbitrary_core_type(g)
+    } else {
+        match u32::arbitrary(g) % 4 {
+            0 => arbitrary_core_type(g),
+            1 => Ty::Union(
+                (0..*g.choose(&[2, 3]).unwrap())
+                    .map(|_| arbitrary_type(g, size - 1))
+                    .collect(),
+            ),
+            2 => Ty::Tuple(
+                (0..*g.choose(&[0, 1, 2]).unwrap())
+                    .map(|_| arbitrary_type(g, size - 1))
+                    .collect(),
+            ),
+            3 => Ty::Intersection {
+                pos: (0..*g.choose(&[0, 1, 2]).unwrap())
+                    .map(|_| arbitrary_type(g, size - 1))
+                    .collect(),
+                neg: (0..*g.choose(&[0, 1, 2]).unwrap())
+                    .map(|_| arbitrary_type(g, size - 1))
+                    .collect(),
+            },
+            _ => unreachable!(),
+        }
+    }
+}
+
+impl Arbitrary for Ty {
+    fn arbitrary(g: &mut Gen) -> Ty {
+        const MAX_SIZE: u32 = 2;
+        arbitrary_type(g, MAX_SIZE)
+    }
+
+    fn shrink(&self) -> Box<dyn Iterator<Item = Self>> {
+        // This is incredibly naive. We can do much better here by
+        // trying various subsets of the elements in unions, tuples,
+        // and intersections. For now, we only try to shrink by
+        // reducing unions/tuples/intersections to a single element.
+        match self.clone() {
+            Ty::Union(types) => Box::new(types.into_iter()),
+            Ty::Tuple(types) => Box::new(types.into_iter()),
+            Ty::Intersection { pos, neg } => Box::new(pos.into_iter().chain(neg)),
+            _ => Box::new(std::iter::empty()),
+        }
+    }
+}
+
+impl<'db> Type<'db> {
+    /// Checks if a type contains `Never` in its tree.
+    ///
+    /// This is currently needed since we currently don't propagate/simplify types containing
+    /// `Never`. For example, the type `tuple[int, Never]` is equivalent to `Never`. Similarly,
+    /// we simplify `Never` in unions, but we would not simplify `str | tuple[int, Never]`, so
+    /// we need to descent into unions and intersections as well.
+    fn contains_never(&self, db: &'db dyn Db) -> bool {
+        match self {
+            Type::Never => true,
+            Type::Union(types) => types.elements(db).iter().any(|t| t.contains_never(db)),
+            Type::Tuple(types) => types.elements(db).iter().any(|t| t.contains_never(db)),
+            Type::Intersection(inner) => {
+                inner.positive(db).iter().any(|t| t.contains_never(db))
+                    || inner.negative(db).iter().any(|t| t.contains_never(db))
+            }
+            _ => false,
+        }
+    }
+}
+
+static CACHED_DB: OnceLock<Arc<Mutex<TestDb>>> = OnceLock::new();
+
+fn get_cached_db() -> MutexGuard<'static, TestDb> {
+    let db = CACHED_DB.get_or_init(|| Arc::new(Mutex::new(setup_db())));
+    db.lock().unwrap()
+}
+
+/// `T` is equivalent to itself.
+#[quickcheck]
+fn equivalent_to_is_reflexive(t: Ty) -> bool {
+    let db = get_cached_db();
+    let t = t.into_type(&db);
+
+    t.is_equivalent_to(&*db, t)
+}
+
+/// `T` is a subtype of itself.
+#[quickcheck]
+fn subtype_of_is_reflexive(t: Ty) -> bool {
+    let db = get_cached_db();
+    let t = t.into_type(&db);
+
+    t.is_subtype_of(&*db, t)
+}
+
+/// `S <: T` and `T <: S` implies that `S` is equivalent to `T`.
+#[quickcheck]
+#[ignore] // Produces too many false positives at the moment because `is_equivalent_to` can return false negative answers
+fn subtype_of_is_antisymmetric(s: Ty, t: Ty) -> bool {
+    let db = get_cached_db();
+    let s = s.into_type(&db);
+    let t = t.into_type(&db);
+
+    !(s.is_subtype_of(&*db, t) && t.is_subtype_of(&*db, s)) || (s.is_equivalent_to(&*db, t))
+}
+
+/// `S <: T` and `T <: U` implies that `S <: U`.
+#[quickcheck]
+fn subtype_of_is_transitive(s: Ty, t: Ty, u: Ty) -> bool {
+    let db = get_cached_db();
+    let s = s.into_type(&db);
+    let t = t.into_type(&db);
+    let u = u.into_type(&db);
+
+    !(s.is_subtype_of(&*db, t) && t.is_subtype_of(&*db, u)) || s.is_subtype_of(&*db, u)
+}
+
+/// `T` is not disjoint from itself, unless `T` is `Never`.
+#[quickcheck]
+fn disjoint_from_is_irreflexive(t: Ty) -> bool {
+    let db = get_cached_db();
+    let t = t.into_type(&db);
+
+    t.contains_never(&*db) || !t.is_disjoint_from(&*db, t)
+}
+
+/// `S` is disjoint from `T` implies that `T` is disjoint from `S`.
+#[quickcheck]
+fn disjoint_from_is_symmetric(s: Ty, t: Ty) -> bool {
+    let db = get_cached_db();
+    let s = s.into_type(&db);
+    let t = t.into_type(&db);
+
+    s.is_disjoint_from(&*db, t) == t.is_disjoint_from(&*db, s)
+}
+
+/// `S <: T` implies that `S` is not disjoint from `T`, unless `S` is `Never`.
+#[quickcheck]
+fn subtype_of_implies_not_disjoint_from(s: Ty, t: Ty) -> bool {
+    let db = get_cached_db();
+    let s = s.into_type(&db);
+    let t = t.into_type(&db);
+
+    if s.contains_never(&*db) {
+        return true;
+    }
+
+    !s.is_subtype_of(&*db, t) || !s.is_disjoint_from(&*db, t)
+}
+
+/// `T` can be assigned to itself.
+#[quickcheck]
+fn assignable_to_is_reflexive(t: Ty) -> bool {
+    let db = get_cached_db();
+    let t = t.into_type(&db);
+
+    t.is_assignable_to(&*db, t)
+}
+
+/// `S <: T` implies that `S` can be assigned to `T`.
+#[quickcheck]
+fn subtype_of_implies_assignable_to(s: Ty, t: Ty) -> bool {
+    let db = get_cached_db();
+
+    let s = s.into_type(&db);
+    let t = t.into_type(&db);
+
+    !s.is_subtype_of(&*db, t) || s.is_assignable_to(&*db, t)
+}
+
+/// If `T` is a singleton, it is also single-valued.
+#[quickcheck]
+fn singleton_implies_single_valued(t: Ty) -> bool {
+    let db = get_cached_db();
+    let t = t.into_type(&db);
+
+    !t.is_singleton(&*db) || t.is_single_valued(&*db)
+}
+
+/// Negating `T` twice is equivalent to `T`.
+#[quickcheck]
+#[ignore] // Produces too many false positives at the moment because `is_equivalent_to` can return false negative answers
+fn double_negation_is_identity(t: Ty) -> bool {
+    let db = get_cached_db();
+    let t = t.into_type(&db);
+
+    t.negate(&*db).negate(&*db).is_equivalent_to(&*db, t)
+}


### PR DESCRIPTION
## Summary

This PR adds a new `property_tests` module with quickcheck-based tests that verify certain properties of types. The following properties are currently checked:

* `is_equivalent_to`:
  * is reflexive: `T` is equivalent to itself
* `is_subtype_of`:
  * is reflexive: `T` is a subtype of `T`
  * is antisymmetric: if `S <: T` and `T <: S`, then `S` is equivalent to `T`
  * is transitive: `S <: T` & `T <: U` => `S <: U`
* `is_disjoint_from`:
  * is irreflexive: `T` is not disjoint from `T`
  * is symmetric: `S` disjoint from `T` => `T` disjoint from `S`
* `is_assignable_to`:
  * is reflexive
* `negate`:
  * is an involution: `T.negate().negate()` is equivalent to `T`

There are also some tests that validate higher-level properties like:

* `S <: T` implies that `S` is not disjoint from `T`
* `S <: T` implies that `S` is assignable to `T`
* A singleton type must also be single-valued

These tests found a few bugs so far:

- #14177 
- #14195 
- #14196 
- #14210
- #14731

Some additional notes:

- Quickcheck-based property tests are non-deterministic and finding counter-examples might take an arbitrary long time. This makes them bad candidates for running in CI (for every PR). We can think of running them in a cron-job way from time to time, similar to fuzzing. But for now, it's only possible to run them locally (see instructions in source code).
- Some tests currently find false positive "counterexamples" because our understanding of equivalence of types is not yet complete. We do not understand that `int | str` is the same as `str | int`, for example. These tests are in a separate `property_tests::flaky` module.
- Properties can not be formulated in every way possible, due to the fact that `is_disjoint_from` and `is_subtype_of` can produce false negative answers.
- The current shrinking implementation is very naive, which leads to counterexamples that are very long (`str & Any & ~tuple[Any] & ~tuple[Unknown] & ~Literal[""] & ~Literal["a"] | str & int & ~tuple[Any] & ~tuple[Unknown]`), requiring the developer to simplify manually. It has not been a major issue so far, but there is a comment in the code how this can be improved.
- The tests are currently implemented using a macro. This is a single commit on top which can easily be reverted, if we prefer the plain code instead. With the macro:
  ```rs
  // `S <: T` implies that `S` can be assigned to `T`.
  type_property_test!(
      subtype_of_implies_assignable_to, db,
      forall types s, t. s.is_subtype_of(db, t) => s.is_assignable_to(db, t)
  );
  ```
  without the macro:
  ```rs
  /// `S <: T` implies that `S` can be assigned to `T`.
  #[quickcheck]
  fn subtype_of_implies_assignable_to(s: Ty, t: Ty) -> bool {
      let db = get_cached_db();
  
      let s = s.into_type(&db);
      let t = t.into_type(&db);
  
      !s.is_subtype_of(&*db, t) || s.is_assignable_to(&*db, t)
  }
  ```

## Test Plan

```bash
while cargo test --release -p red_knot_python_semantic --features property_tests types::property_tests; do :; done
```