### PR TITLE
Docs: tweak rules documentation

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_annotations/rules/definition.rs
+++ b/crates/ruff_linter/src/rules/flake8_annotations/rules/definition.rs
@@ -469,7 +469,7 @@ impl Violation for MissingReturnTypeClassMethod {
 /// ```
 ///
 /// ## References
-/// - [Typing documentation: `Any`](https://typing.readthedocs.io/en/latest/spec/special-types.html#any)
+/// - [Typing spec: `Any`](https://typing.readthedocs.io/en/latest/spec/special-types.html#any)
 /// - [Python documentation: `typing.Any`](https://docs.python.org/3/library/typing.html#typing.Any)
 /// - [Mypy documentation: The Any type](https://mypy.readthedocs.io/en/stable/kinds_of_types.html#the-any-type)
 #[violation]

--- a/crates/ruff_linter/src/rules/flake8_annotations/rules/definition.rs
+++ b/crates/ruff_linter/src/rules/flake8_annotations/rules/definition.rs
@@ -469,7 +469,7 @@ impl Violation for MissingReturnTypeClassMethod {
 /// ```
 ///
 /// ## References
-/// - [PEP 484](https://www.python.org/dev/peps/pep-0484/#the-any-type)
+/// - [Typing documentation: `Any`](https://typing.readthedocs.io/en/latest/spec/special-types.html#any)
 /// - [Python documentation: `typing.Any`](https://docs.python.org/3/library/typing.html#typing.Any)
 /// - [Mypy documentation: The Any type](https://mypy.readthedocs.io/en/stable/kinds_of_types.html#the-any-type)
 #[violation]

--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/suspicious_imports.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/suspicious_imports.rs
@@ -10,16 +10,21 @@ use crate::checkers::ast::Checker;
 use crate::registry::AsRule;
 
 /// ## What it does
-/// Checks for imports of the`telnetlib` module.
+/// Checks for imports of the `telnetlib` module.
 ///
 /// ## Why is this bad?
-/// Telnet is considered insecure. Instead, use SSH or another encrypted
+/// Telnet is considered insecure. It is deprecated since version 3.11, and
+/// will be removed in version 3.13. Instead, use SSH or another encrypted
 /// protocol.
 ///
 /// ## Example
 /// ```python
 /// import telnetlib
 /// ```
+///
+/// ## References
+/// - [Python documentation: `telnetlib` - Telnet client](https://docs.python.org/3.12/library/telnetlib.html#module-telnetlib)
+/// - [PEP 594: `telnetlib`](https://peps.python.org/pep-0594/#telnetlib)
 #[violation]
 pub struct SuspiciousTelnetlibImport;
 
@@ -41,6 +46,9 @@ impl Violation for SuspiciousTelnetlibImport {
 /// ```python
 /// import ftplib
 /// ```
+///
+/// ## References
+/// - [Python documentation: `ftplib` - FTP protocol client](https://docs.python.org/3/library/ftplib.html)
 #[violation]
 pub struct SuspiciousFtplibImport;
 
@@ -63,8 +71,9 @@ impl Violation for SuspiciousFtplibImport {
 /// ```python
 /// import pickle
 /// ```
+///
 /// ## References
-/// - [Python Docs](https://docs.python.org/3/library/pickle.html)
+/// - [Python documentation: `pickle` — Python object serialization](https://docs.python.org/3/library/pickle.html)
 #[violation]
 pub struct SuspiciousPickleImport;
 

--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/suspicious_imports.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/suspicious_imports.rs
@@ -14,7 +14,7 @@ use crate::registry::AsRule;
 ///
 /// ## Why is this bad?
 /// Telnet is considered insecure. It is deprecated since version 3.11, and
-/// will be removed in version 3.13. Instead, use SSH or another encrypted
+/// was removed in version 3.13. Instead, use SSH or another encrypted
 /// protocol.
 ///
 /// ## Example

--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/tarfile_unsafe_members.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/tarfile_unsafe_members.rs
@@ -33,8 +33,8 @@ use ruff_text_size::Ranged;
 ///
 /// ## References
 /// - [Common Weakness Enumeration: CWE-22](https://cwe.mitre.org/data/definitions/22.html)
-/// - [Python Documentation: `TarFile.extractall`](https://docs.python.org/3/library/tarfile.html#tarfile.TarFile.extractall)
-/// - [Python Documentation: Extraction filters](https://docs.python.org/3/library/tarfile.html#tarfile-extraction-filter)
+/// - [Python documentation: `TarFile.extractall`](https://docs.python.org/3/library/tarfile.html#tarfile.TarFile.extractall)
+/// - [Python documentation: Extraction filters](https://docs.python.org/3/library/tarfile.html#tarfile-extraction-filter)
 ///
 /// [PEP 706]: https://peps.python.org/pep-0706/#backporting-forward-compatibility
 #[violation]

--- a/crates/ruff_linter/src/rules/flake8_blind_except/rules/blind_except.rs
+++ b/crates/ruff_linter/src/rules/flake8_blind_except/rules/blind_except.rs
@@ -60,7 +60,7 @@ use crate::checkers::ast::Checker;
 /// ## References
 /// - [Python documentation: The `try` statement](https://docs.python.org/3/reference/compound_stmts.html#the-try-statement)
 /// - [Python documentation: Exception hierarchy](https://docs.python.org/3/library/exceptions.html#exception-hierarchy)
-/// - [PEP8 Programming Recommendations on bare `except`](https://peps.python.org/pep-0008/#programming-recommendations)
+/// - [PEP 8: Programming Recommendations on bare `except`](https://peps.python.org/pep-0008/#programming-recommendations)
 #[violation]
 pub struct BlindExcept {
     name: String,

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/abstract_base_class.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/abstract_base_class.rs
@@ -88,7 +88,7 @@ impl Violation for AbstractBaseClassWithoutAbstractMethod {
 /// ```
 ///
 /// ## References
-/// - [Python documentation: abc](https://docs.python.org/3/library/abc.html)
+/// - [Python documentation: `abc`](https://docs.python.org/3/library/abc.html)
 #[violation]
 pub struct EmptyMethodWithoutAbstractDecorator {
     name: String,

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/f_string_docstring.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/f_string_docstring.rs
@@ -28,7 +28,7 @@ use crate::checkers::ast::Checker;
 /// ```
 ///
 /// ## References
-/// - [PEP 257](https://peps.python.org/pep-0257/)
+/// - [PEP 257 – Docstring Conventions](https://peps.python.org/pep-0257/)
 /// - [Python documentation: Formatted string literals](https://docs.python.org/3/reference/lexical_analysis.html#f-strings)
 #[violation]
 pub struct FStringDocstring;

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/function_uses_loop_variable.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/function_uses_loop_variable.rs
@@ -40,7 +40,7 @@ use crate::checkers::ast::Checker;
 ///
 /// ## References
 /// - [The Hitchhiker's Guide to Python: Late Binding Closures](https://docs.python-guide.org/writing/gotchas/#late-binding-closures)
-/// - [Python documentation: functools.partial](https://docs.python.org/3/library/functools.html#functools.partial)
+/// - [Python documentation: `functools.partial`](https://docs.python.org/3/library/functools.html#functools.partial)
 #[violation]
 pub struct FunctionUsesLoopVariable {
     name: String,

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/no_explicit_stacklevel.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/no_explicit_stacklevel.rs
@@ -26,6 +26,9 @@ use crate::checkers::ast::Checker;
 /// ```python
 /// warnings.warn("This is a warning", stacklevel=2)
 /// ```
+///
+/// ## References
+/// - [Python documentation: `warnings.warn`](https://docs.python.org/3/library/warnings.html#warnings.warn)
 #[violation]
 pub struct NoExplicitStacklevel;
 

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/useless_contextlib_suppress.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/useless_contextlib_suppress.rs
@@ -35,7 +35,7 @@ use crate::checkers::ast::Checker;
 /// ```
 ///
 /// ## References
-/// - [Python documentation: contextlib.suppress](https://docs.python.org/3/library/contextlib.html#contextlib.suppress)
+/// - [Python documentation: `contextlib.suppress`](https://docs.python.org/3/library/contextlib.html#contextlib.suppress)
 #[violation]
 pub struct UselessContextlibSuppress;
 

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_dict_comprehension_for_iterable.rs
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_dict_comprehension_for_iterable.rs
@@ -30,6 +30,9 @@ use crate::checkers::ast::Checker;
 /// dict.fromkeys(iterable)
 /// dict.fromkeys(iterable, 1)
 /// ```
+///
+/// ## References
+/// - [Python documentation: `dict.fromkeys`](https://docs.python.org/3/library/stdtypes.html#dict.fromkeys)
 #[violation]
 pub struct UnnecessaryDictComprehensionForIterable {
     is_value_none_literal: bool,
@@ -53,7 +56,7 @@ impl Violation for UnnecessaryDictComprehensionForIterable {
     }
 }
 
-/// RUF025
+/// C420
 pub(crate) fn unnecessary_dict_comprehension_for_iterable(
     checker: &mut Checker,
     dict_comp: &ast::ExprDictComp,

--- a/crates/ruff_linter/src/rules/flake8_gettext/rules/f_string_in_gettext_func_call.rs
+++ b/crates/ruff_linter/src/rules/flake8_gettext/rules/f_string_in_gettext_func_call.rs
@@ -39,7 +39,7 @@ use crate::checkers::ast::Checker;
 /// ```
 ///
 /// ## References
-/// - [Python documentation: gettext](https://docs.python.org/3/library/gettext.html)
+/// - [Python documentation: `gettext` — Multilingual internationalization services](https://docs.python.org/3/library/gettext.html)
 #[violation]
 pub struct FStringInGetTextFuncCall;
 

--- a/crates/ruff_linter/src/rules/flake8_gettext/rules/format_in_gettext_func_call.rs
+++ b/crates/ruff_linter/src/rules/flake8_gettext/rules/format_in_gettext_func_call.rs
@@ -39,7 +39,7 @@ use crate::checkers::ast::Checker;
 /// ```
 ///
 /// ## References
-/// - [Python documentation: gettext](https://docs.python.org/3/library/gettext.html)
+/// - [Python documentation: `gettext` — Multilingual internationalization services](https://docs.python.org/3/library/gettext.html)
 #[violation]
 pub struct FormatInGetTextFuncCall;
 

--- a/crates/ruff_linter/src/rules/flake8_gettext/rules/printf_in_gettext_func_call.rs
+++ b/crates/ruff_linter/src/rules/flake8_gettext/rules/printf_in_gettext_func_call.rs
@@ -38,7 +38,7 @@ use ruff_text_size::Ranged;
 /// ```
 ///
 /// ## References
-/// - [Python documentation: gettext](https://docs.python.org/3/library/gettext.html)
+/// - [Python documentation: `gettext` — Multilingual internationalization services](https://docs.python.org/3/library/gettext.html)
 #[violation]
 pub struct PrintfInGetTextFuncCall;
 

--- a/crates/ruff_linter/src/rules/flake8_no_pep420/rules/implicit_namespace_package.rs
+++ b/crates/ruff_linter/src/rules/flake8_no_pep420/rules/implicit_namespace_package.rs
@@ -22,7 +22,7 @@ use crate::Locator;
 ///
 /// Directories that lack an `__init__.py` file can still be imported, but
 /// they're indicative of a special kind of package, known as a "namespace
-/// package" (see: [PEP 420](https://www.python.org/dev/peps/pep-0420/)).
+/// package" (see: [PEP 420](https://peps.python.org/pep-0420/)).
 /// Namespace packages are less widely used, so a package that lacks an
 /// `__init__.py` file is typically meant to be a regular package, and
 /// the absence of the `__init__.py` file is probably an oversight.

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/complex_if_statement_in_stub.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/complex_if_statement_in_stub.rs
@@ -30,7 +30,7 @@ use crate::checkers::ast::Checker;
 /// ```
 ///
 /// ## References
-/// The [typing documentation on stub files](https://typing.readthedocs.io/en/latest/source/stubs.html#version-and-platform-checks)
+/// - [Typing documentation: Version and platform checking](https://typing.readthedocs.io/en/latest/spec/directives.html#version-and-platform-checks)
 #[violation]
 pub struct ComplexIfStatementInStub;
 

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/non_empty_stub_body.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/non_empty_stub_body.rs
@@ -26,8 +26,7 @@ use crate::checkers::ast::Checker;
 /// ```
 ///
 /// ## References
-/// - [The recommended style for stub functions and methods](https://typing.readthedocs.io/en/latest/source/stubs.html#id6)
-///   in the typing docs.
+/// - [Typing documentation - Writing and Maintaining Stub Files](https://typing.readthedocs.io/en/latest/guides/writing_stubs.html)
 #[violation]
 pub struct NonEmptyStubBody;
 

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/non_self_return_type.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/non_self_return_type.rs
@@ -71,7 +71,7 @@ use crate::checkers::ast::Checker;
 ///     def __iadd__(self, other: Foo) -> Self: ...
 /// ```
 /// ## References
-/// - [`typing.Self` documentation](https://docs.python.org/3/library/typing.html#typing.Self)
+/// - [Python documentation: `typing.Self`](https://docs.python.org/3/library/typing.html#typing.Self)
 #[violation]
 pub struct NonSelfReturnType {
     class_name: String,

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/pass_statement_stub_body.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/pass_statement_stub_body.rs
@@ -23,8 +23,7 @@ use crate::checkers::ast::Checker;
 /// ```
 ///
 /// ## References
-/// The [recommended style for functions and methods](https://typing.readthedocs.io/en/latest/source/stubs.html#functions-and-methods)
-/// in the typing docs.
+/// - [Typing documentation - Writing and Maintaining Stub Files](https://typing.readthedocs.io/en/latest/guides/writing_stubs.html)
 #[violation]
 pub struct PassStatementStubBody;
 

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/quoted_annotation_in_stub.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/quoted_annotation_in_stub.rs
@@ -27,7 +27,7 @@ use crate::checkers::ast::Checker;
 /// ```
 ///
 /// ## References
-/// - [Static Typing with Python: Type Stubs](https://typing.readthedocs.io/en/latest/source/stubs.html)
+/// - [Typing documentation - Writing and Maintaining Stub Files](https://typing.readthedocs.io/en/latest/guides/writing_stubs.html)
 #[violation]
 pub struct QuotedAnnotationInStub;
 

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/redundant_numeric_union.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/redundant_numeric_union.rs
@@ -38,7 +38,7 @@ use crate::checkers::ast::Checker;
 /// ```
 ///
 /// ## References
-/// - [The typing specification](https://docs.python.org/3/library/numbers.html#the-numeric-tower)
+/// - [Python documentation: The numeric tower](https://docs.python.org/3/library/numbers.html#the-numeric-tower)
 /// - [PEP 484: The numeric tower](https://peps.python.org/pep-0484/#the-numeric-tower)
 ///
 /// [typing specification]: https://typing.readthedocs.io/en/latest/spec/special-types.html#special-cases-for-float-and-complex

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/unrecognized_platform.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/unrecognized_platform.rs
@@ -40,7 +40,7 @@ use crate::registry::Rule;
 /// ```
 ///
 /// ## References
-/// - [Typing stubs documentation: Version and Platform Checks](https://typing.readthedocs.io/en/latest/source/stubs.html#version-and-platform-checks)
+/// - [Typing documentation: Version and Platform checking](https://typing.readthedocs.io/en/latest/spec/directives.html#version-and-platform-checks)
 #[violation]
 pub struct UnrecognizedPlatformCheck;
 
@@ -74,7 +74,7 @@ impl Violation for UnrecognizedPlatformCheck {
 /// ```
 ///
 /// ## References
-/// - [Typing stubs documentation: Version and Platform Checks](https://typing.readthedocs.io/en/latest/source/stubs.html#version-and-platform-checks)
+/// - [Typing documentation: Version and Platform checking](https://typing.readthedocs.io/en/latest/spec/directives.html#version-and-platform-checks)
 #[violation]
 pub struct UnrecognizedPlatformName {
     platform: String,

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/unrecognized_version_info.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/unrecognized_version_info.rs
@@ -31,7 +31,7 @@ use crate::registry::Rule;
 /// ```
 ///
 /// ## References
-/// - [Typing stubs documentation: Version and Platform Checks](https://typing.readthedocs.io/en/latest/source/stubs.html#version-and-platform-checks)
+/// - [Typing documentation: Version and Platform checking](https://typing.readthedocs.io/en/latest/spec/directives.html#version-and-platform-checks)
 #[violation]
 pub struct UnrecognizedVersionInfoCheck;
 
@@ -70,7 +70,7 @@ impl Violation for UnrecognizedVersionInfoCheck {
 /// ```
 ///
 /// ## References
-/// - [Typing stubs documentation: Version and Platform Checks](https://typing.readthedocs.io/en/latest/source/stubs.html#version-and-platform-checks)
+/// - [Typing documentation: Version and Platform checking](https://typing.readthedocs.io/en/latest/spec/directives.html#version-and-platform-checks)
 #[violation]
 pub struct PatchVersionComparison;
 
@@ -106,7 +106,7 @@ impl Violation for PatchVersionComparison {
 /// ```
 ///
 /// ## References
-/// - [Typing stubs documentation: Version and Platform Checks](https://typing.readthedocs.io/en/latest/source/stubs.html#version-and-platform-checks)
+/// - [Typing documentation: Version and Platform checking](https://typing.readthedocs.io/en/latest/spec/directives.html#version-and-platform-checks)
 #[violation]
 pub struct WrongTupleLengthVersionComparison {
     expected_length: usize,

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/rules/fixture.rs
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/rules/fixture.rs
@@ -590,7 +590,7 @@ impl AlwaysFixableViolation for PytestErroneousUseFixturesOnFixture {
 /// ```
 ///
 /// ## References
-/// - [`pytest-asyncio`](https://pypi.org/project/pytest-asyncio/)
+/// - [PyPI: `pytest-asyncio`](https://pypi.org/project/pytest-asyncio/)
 #[violation]
 pub struct PytestUnnecessaryAsyncioMarkOnFixture;
 

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/rules/patch.rs
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/rules/patch.rs
@@ -38,7 +38,7 @@ use ruff_text_size::Ranged;
 ///
 /// ## References
 /// - [Python documentation: `unittest.mock.patch`](https://docs.python.org/3/library/unittest.mock.html#unittest.mock.patch)
-/// - [`pytest-mock`](https://pypi.org/project/pytest-mock/)
+/// - [PyPI: `pytest-mock`](https://pypi.org/project/pytest-mock/)
 #[violation]
 pub struct PytestPatchWithLambda;
 

--- a/crates/ruff_linter/src/rules/flake8_type_checking/rules/empty_type_checking_block.rs
+++ b/crates/ruff_linter/src/rules/flake8_type_checking/rules/empty_type_checking_block.rs
@@ -31,7 +31,7 @@ use crate::fix;
 /// ```
 ///
 /// ## References
-/// - [PEP 535](https://peps.python.org/pep-0563/#runtime-annotation-resolution-and-type-checking)
+/// - [PEP 563: Runtime annotation resolution and `TYPE_CHECKING`](https://peps.python.org/pep-0563/#runtime-annotation-resolution-and-type-checking)
 #[violation]
 pub struct EmptyTypeCheckingBlock;
 

--- a/crates/ruff_linter/src/rules/flake8_type_checking/rules/runtime_import_in_type_checking_block.rs
+++ b/crates/ruff_linter/src/rules/flake8_type_checking/rules/runtime_import_in_type_checking_block.rs
@@ -51,7 +51,7 @@ use crate::rules::flake8_type_checking::imports::ImportBinding;
 /// - `lint.flake8-type-checking.quote-annotations`
 ///
 /// ## References
-/// - [PEP 535](https://peps.python.org/pep-0563/#runtime-annotation-resolution-and-type-checking)
+/// - [PEP 563: Runtime annotation resolution and `TYPE_CHECKING`](https://peps.python.org/pep-0563/#runtime-annotation-resolution-and-type-checking)
 #[violation]
 pub struct RuntimeImportInTypeCheckingBlock {
     qualified_name: String,

--- a/crates/ruff_linter/src/rules/flake8_type_checking/rules/runtime_string_union.rs
+++ b/crates/ruff_linter/src/rules/flake8_type_checking/rules/runtime_string_union.rs
@@ -37,8 +37,8 @@ use crate::checkers::ast::Checker;
 /// ```
 ///
 /// ## References
-/// - [PEP 535](https://peps.python.org/pep-0563/)
-/// - [PEP 604](https://peps.python.org/pep-0604/)
+/// - [PEP 563 - Postponed Evaluation of Annotations](https://peps.python.org/pep-0563/)
+/// - [PEP 604 – Allow writing union types as `X | Y`](https://peps.python.org/pep-0604/)
 ///
 /// [PEP 604]: https://peps.python.org/pep-0604/
 #[violation]

--- a/crates/ruff_linter/src/rules/flake8_type_checking/rules/typing_only_runtime_import.rs
+++ b/crates/ruff_linter/src/rules/flake8_type_checking/rules/typing_only_runtime_import.rs
@@ -71,7 +71,7 @@ use crate::rules::isort::{categorize, ImportSection, ImportType};
 /// - `lint.typing-modules`
 ///
 /// ## References
-/// - [PEP 536](https://peps.python.org/pep-0563/#runtime-annotation-resolution-and-type-checking)
+/// - [PEP 563: Runtime annotation resolution and `TYPE_CHECKING`](https://peps.python.org/pep-0563/#runtime-annotation-resolution-and-type-checking)
 #[violation]
 pub struct TypingOnlyFirstPartyImport {
     qualified_name: String,
@@ -146,7 +146,7 @@ impl Violation for TypingOnlyFirstPartyImport {
 /// - `lint.typing-modules`
 ///
 /// ## References
-/// - [PEP 536](https://peps.python.org/pep-0563/#runtime-annotation-resolution-and-type-checking)
+/// - [PEP 563: Runtime annotation resolution and `TYPE_CHECKING`](https://peps.python.org/pep-0563/#runtime-annotation-resolution-and-type-checking)
 #[violation]
 pub struct TypingOnlyThirdPartyImport {
     qualified_name: String,
@@ -221,7 +221,7 @@ impl Violation for TypingOnlyThirdPartyImport {
 /// - `lint.typing-modules`
 ///
 /// ## References
-/// - [PEP 536](https://peps.python.org/pep-0563/#runtime-annotation-resolution-and-type-checking)
+/// - [PEP 563: Runtime annotation resolution and `TYPE_CHECKING`](https://peps.python.org/pep-0563/#runtime-annotation-resolution-and-type-checking)
 #[violation]
 pub struct TypingOnlyStandardLibraryImport {
     qualified_name: String,

--- a/crates/ruff_linter/src/rules/flake8_unused_arguments/rules/unused_arguments.rs
+++ b/crates/ruff_linter/src/rules/flake8_unused_arguments/rules/unused_arguments.rs
@@ -19,6 +19,10 @@ use crate::registry::Rule;
 /// An argument that is defined but not used is likely a mistake, and should
 /// be removed to avoid confusion.
 ///
+/// If a variable is intentionally defined-but-not-used, it should be
+/// prefixed with an underscore, or some other value that adheres to the
+/// [`lint.dummy-variable-rgx`] pattern.
+///
 /// ## Example
 /// ```python
 /// def foo(bar, baz):
@@ -30,6 +34,9 @@ use crate::registry::Rule;
 /// def foo(bar):
 ///     return bar * 2
 /// ```
+///
+/// ## Options
+/// - `lint.dummy-variable-rgx`
 #[violation]
 pub struct UnusedFunctionArgument {
     name: String,
@@ -50,6 +57,10 @@ impl Violation for UnusedFunctionArgument {
 /// An argument that is defined but not used is likely a mistake, and should
 /// be removed to avoid confusion.
 ///
+/// If a variable is intentionally defined-but-not-used, it should be
+/// prefixed with an underscore, or some other value that adheres to the
+/// [`lint.dummy-variable-rgx`] pattern.
+///
 /// ## Example
 /// ```python
 /// class Class:
@@ -63,6 +74,9 @@ impl Violation for UnusedFunctionArgument {
 ///     def foo(self, arg1):
 ///         print(arg1)
 /// ```
+///
+/// ## Options
+/// - `lint.dummy-variable-rgx`
 #[violation]
 pub struct UnusedMethodArgument {
     name: String,
@@ -83,6 +97,10 @@ impl Violation for UnusedMethodArgument {
 /// An argument that is defined but not used is likely a mistake, and should
 /// be removed to avoid confusion.
 ///
+/// If a variable is intentionally defined-but-not-used, it should be
+/// prefixed with an underscore, or some other value that adheres to the
+/// [`lint.dummy-variable-rgx`] pattern.
+///
 /// ## Example
 /// ```python
 /// class Class:
@@ -98,6 +116,9 @@ impl Violation for UnusedMethodArgument {
 ///     def foo(cls, arg1):
 ///         print(arg1)
 /// ```
+///
+/// ## Options
+/// - `lint.dummy-variable-rgx`
 #[violation]
 pub struct UnusedClassMethodArgument {
     name: String,
@@ -118,6 +139,10 @@ impl Violation for UnusedClassMethodArgument {
 /// An argument that is defined but not used is likely a mistake, and should
 /// be removed to avoid confusion.
 ///
+/// If a variable is intentionally defined-but-not-used, it should be
+/// prefixed with an underscore, or some other value that adheres to the
+/// [`lint.dummy-variable-rgx`] pattern.
+///
 /// ## Example
 /// ```python
 /// class Class:
@@ -133,6 +158,9 @@ impl Violation for UnusedClassMethodArgument {
 ///     def foo(arg1):
 ///         print(arg1)
 /// ```
+///
+/// ## Options
+/// - `lint.dummy-variable-rgx`
 #[violation]
 pub struct UnusedStaticMethodArgument {
     name: String,
@@ -154,6 +182,10 @@ impl Violation for UnusedStaticMethodArgument {
 /// An argument that is defined but not used is likely a mistake, and should
 /// be removed to avoid confusion.
 ///
+/// If a variable is intentionally defined-but-not-used, it should be
+/// prefixed with an underscore, or some other value that adheres to the
+/// [`lint.dummy-variable-rgx`] pattern.
+///
 /// ## Example
 /// ```python
 /// my_list = [1, 2, 3, 4, 5]
@@ -165,6 +197,9 @@ impl Violation for UnusedStaticMethodArgument {
 /// my_list = [1, 2, 3, 4, 5]
 /// squares = map(lambda x: x**2, my_list)
 /// ```
+///
+/// ## Options
+/// - `lint.dummy-variable-rgx`
 #[violation]
 pub struct UnusedLambdaArgument {
     name: String,

--- a/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/os_path_getatime.rs
+++ b/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/os_path_getatime.rs
@@ -32,7 +32,7 @@ use ruff_macros::{derive_message_formats, violation};
 /// ## References
 /// - [Python documentation: `Path.stat`](https://docs.python.org/3/library/pathlib.html#pathlib.Path.stat)
 /// - [Python documentation: `os.path.getatime`](https://docs.python.org/3/library/os.path.html#os.path.getatime)
-/// - [PEP 428](https://peps.python.org/pep-0428/)
+/// - [PEP 428 – The pathlib module – object-oriented filesystem paths](https://peps.python.org/pep-0428/)
 /// - [Correspondence between `os` and `pathlib`](https://docs.python.org/3/library/pathlib.html#correspondence-to-tools-in-the-os-module)
 /// - [Why you should be using pathlib](https://treyhunner.com/2018/12/why-you-should-be-using-pathlib/)
 /// - [No really, pathlib is great](https://treyhunner.com/2019/01/no-really-pathlib-is-great/)

--- a/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/os_path_getctime.rs
+++ b/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/os_path_getctime.rs
@@ -32,7 +32,7 @@ use ruff_macros::{derive_message_formats, violation};
 /// ## References
 /// - [Python documentation: `Path.stat`](https://docs.python.org/3/library/pathlib.html#pathlib.Path.stat)
 /// - [Python documentation: `os.path.getctime`](https://docs.python.org/3/library/os.path.html#os.path.getctime)
-/// - [PEP 428](https://peps.python.org/pep-0428/)
+/// - [PEP 428 – The pathlib module – object-oriented filesystem paths](https://peps.python.org/pep-0428/)
 /// - [Correspondence between `os` and `pathlib`](https://docs.python.org/3/library/pathlib.html#correspondence-to-tools-in-the-os-module)
 /// - [Why you should be using pathlib](https://treyhunner.com/2018/12/why-you-should-be-using-pathlib/)
 /// - [No really, pathlib is great](https://treyhunner.com/2019/01/no-really-pathlib-is-great/)

--- a/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/os_path_getmtime.rs
+++ b/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/os_path_getmtime.rs
@@ -32,7 +32,7 @@ use ruff_macros::{derive_message_formats, violation};
 /// ## References
 /// - [Python documentation: `Path.stat`](https://docs.python.org/3/library/pathlib.html#pathlib.Path.stat)
 /// - [Python documentation: `os.path.getmtime`](https://docs.python.org/3/library/os.path.html#os.path.getmtime)
-/// - [PEP 428](https://peps.python.org/pep-0428/)
+/// - [PEP 428 – The pathlib module – object-oriented filesystem paths](https://peps.python.org/pep-0428/)
 /// - [Correspondence between `os` and `pathlib`](https://docs.python.org/3/library/pathlib.html#correspondence-to-tools-in-the-os-module)
 /// - [Why you should be using pathlib](https://treyhunner.com/2018/12/why-you-should-be-using-pathlib/)
 /// - [No really, pathlib is great](https://treyhunner.com/2019/01/no-really-pathlib-is-great/)

--- a/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/os_path_getsize.rs
+++ b/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/os_path_getsize.rs
@@ -32,7 +32,7 @@ use ruff_macros::{derive_message_formats, violation};
 /// ## References
 /// - [Python documentation: `Path.stat`](https://docs.python.org/3/library/pathlib.html#pathlib.Path.stat)
 /// - [Python documentation: `os.path.getsize`](https://docs.python.org/3/library/os.path.html#os.path.getsize)
-/// - [PEP 428](https://peps.python.org/pep-0428/)
+/// - [PEP 428 – The pathlib module – object-oriented filesystem paths](https://peps.python.org/pep-0428/)
 /// - [Correspondence between `os` and `pathlib`](https://docs.python.org/3/library/pathlib.html#correspondence-to-tools-in-the-os-module)
 /// - [Why you should be using pathlib](https://treyhunner.com/2018/12/why-you-should-be-using-pathlib/)
 /// - [No really, pathlib is great](https://treyhunner.com/2019/01/no-really-pathlib-is-great/)

--- a/crates/ruff_linter/src/rules/flake8_use_pathlib/violations.rs
+++ b/crates/ruff_linter/src/rules/flake8_use_pathlib/violations.rs
@@ -30,7 +30,7 @@ use ruff_macros::{derive_message_formats, violation};
 /// ## References
 /// - [Python documentation: `Path.resolve`](https://docs.python.org/3/library/pathlib.html#pathlib.Path.resolve)
 /// - [Python documentation: `os.path.abspath`](https://docs.python.org/3/library/os.path.html#os.path.abspath)
-/// - [PEP 428](https://peps.python.org/pep-0428/)
+/// - [PEP 428 – The pathlib module – object-oriented filesystem paths](https://peps.python.org/pep-0428/)
 /// - [Correspondence between `os` and `pathlib`](https://docs.python.org/3/library/pathlib.html#correspondence-to-tools-in-the-os-module)
 /// - [Why you should be using pathlib](https://treyhunner.com/2018/12/why-you-should-be-using-pathlib/)
 /// - [No really, pathlib is great](https://treyhunner.com/2019/01/no-really-pathlib-is-great/)
@@ -73,7 +73,7 @@ impl Violation for OsPathAbspath {
 /// ## References
 /// - [Python documentation: `Path.chmod`](https://docs.python.org/3/library/pathlib.html#pathlib.Path.chmod)
 /// - [Python documentation: `os.chmod`](https://docs.python.org/3/library/os.html#os.chmod)
-/// - [PEP 428](https://peps.python.org/pep-0428/)
+/// - [PEP 428 – The pathlib module – object-oriented filesystem paths](https://peps.python.org/pep-0428/)
 /// - [Correspondence between `os` and `pathlib`](https://docs.python.org/3/library/pathlib.html#correspondence-to-tools-in-the-os-module)
 /// - [Why you should be using pathlib](https://treyhunner.com/2018/12/why-you-should-be-using-pathlib/)
 /// - [No really, pathlib is great](https://treyhunner.com/2019/01/no-really-pathlib-is-great/)
@@ -116,7 +116,7 @@ impl Violation for OsChmod {
 /// ## References
 /// - [Python documentation: `Path.mkdir`](https://docs.python.org/3/library/pathlib.html#pathlib.Path.mkdir)
 /// - [Python documentation: `os.makedirs`](https://docs.python.org/3/library/os.html#os.makedirs)
-/// - [PEP 428](https://peps.python.org/pep-0428/)
+/// - [PEP 428 – The pathlib module – object-oriented filesystem paths](https://peps.python.org/pep-0428/)
 /// - [Correspondence between `os` and `pathlib`](https://docs.python.org/3/library/pathlib.html#correspondence-to-tools-in-the-os-module)
 /// - [Why you should be using pathlib](https://treyhunner.com/2018/12/why-you-should-be-using-pathlib/)
 /// - [No really, pathlib is great](https://treyhunner.com/2019/01/no-really-pathlib-is-great/)
@@ -159,7 +159,7 @@ impl Violation for OsMakedirs {
 /// ## References
 /// - [Python documentation: `Path.mkdir`](https://docs.python.org/3/library/pathlib.html#pathlib.Path.mkdir)
 /// - [Python documentation: `os.mkdir`](https://docs.python.org/3/library/os.html#os.mkdir)
-/// - [PEP 428](https://peps.python.org/pep-0428/)
+/// - [PEP 428 – The pathlib module – object-oriented filesystem paths](https://peps.python.org/pep-0428/)
 /// - [Correspondence between `os` and `pathlib`](https://docs.python.org/3/library/pathlib.html#correspondence-to-tools-in-the-os-module)
 /// - [Why you should be using pathlib](https://treyhunner.com/2018/12/why-you-should-be-using-pathlib/)
 /// - [No really, pathlib is great](https://treyhunner.com/2019/01/no-really-pathlib-is-great/)
@@ -202,7 +202,7 @@ impl Violation for OsMkdir {
 /// ## References
 /// - [Python documentation: `Path.rename`](https://docs.python.org/3/library/pathlib.html#pathlib.Path.rename)
 /// - [Python documentation: `os.rename`](https://docs.python.org/3/library/os.html#os.rename)
-/// - [PEP 428](https://peps.python.org/pep-0428/)
+/// - [PEP 428 – The pathlib module – object-oriented filesystem paths](https://peps.python.org/pep-0428/)
 /// - [Correspondence between `os` and `pathlib`](https://docs.python.org/3/library/pathlib.html#correspondence-to-tools-in-the-os-module)
 /// - [Why you should be using pathlib](https://treyhunner.com/2018/12/why-you-should-be-using-pathlib/)
 /// - [No really, pathlib is great](https://treyhunner.com/2019/01/no-really-pathlib-is-great/)
@@ -245,7 +245,7 @@ impl Violation for OsRename {
 /// ## References
 /// - [Python documentation: `Path.replace`](https://docs.python.org/3/library/pathlib.html#pathlib.Path.replace)
 /// - [Python documentation: `os.replace`](https://docs.python.org/3/library/os.html#os.replace)
-/// - [PEP 428](https://peps.python.org/pep-0428/)
+/// - [PEP 428 – The pathlib module – object-oriented filesystem paths](https://peps.python.org/pep-0428/)
 /// - [Correspondence between `os` and `pathlib`](https://docs.python.org/3/library/pathlib.html#correspondence-to-tools-in-the-os-module)
 /// - [Why you should be using pathlib](https://treyhunner.com/2018/12/why-you-should-be-using-pathlib/)
 /// - [No really, pathlib is great](https://treyhunner.com/2019/01/no-really-pathlib-is-great/)
@@ -288,7 +288,7 @@ impl Violation for OsReplace {
 /// ## References
 /// - [Python documentation: `Path.rmdir`](https://docs.python.org/3/library/pathlib.html#pathlib.Path.rmdir)
 /// - [Python documentation: `os.rmdir`](https://docs.python.org/3/library/os.html#os.rmdir)
-/// - [PEP 428](https://peps.python.org/pep-0428/)
+/// - [PEP 428 – The pathlib module – object-oriented filesystem paths](https://peps.python.org/pep-0428/)
 /// - [Correspondence between `os` and `pathlib`](https://docs.python.org/3/library/pathlib.html#correspondence-to-tools-in-the-os-module)
 /// - [Why you should be using pathlib](https://treyhunner.com/2018/12/why-you-should-be-using-pathlib/)
 /// - [No really, pathlib is great](https://treyhunner.com/2019/01/no-really-pathlib-is-great/)
@@ -331,7 +331,7 @@ impl Violation for OsRmdir {
 /// ## References
 /// - [Python documentation: `Path.unlink`](https://docs.python.org/3/library/pathlib.html#pathlib.Path.unlink)
 /// - [Python documentation: `os.remove`](https://docs.python.org/3/library/os.html#os.remove)
-/// - [PEP 428](https://peps.python.org/pep-0428/)
+/// - [PEP 428 – The pathlib module – object-oriented filesystem paths](https://peps.python.org/pep-0428/)
 /// - [Correspondence between `os` and `pathlib`](https://docs.python.org/3/library/pathlib.html#correspondence-to-tools-in-the-os-module)
 /// - [Why you should be using pathlib](https://treyhunner.com/2018/12/why-you-should-be-using-pathlib/)
 /// - [No really, pathlib is great](https://treyhunner.com/2019/01/no-really-pathlib-is-great/)
@@ -374,7 +374,7 @@ impl Violation for OsRemove {
 /// ## References
 /// - [Python documentation: `Path.unlink`](https://docs.python.org/3/library/pathlib.html#pathlib.Path.unlink)
 /// - [Python documentation: `os.unlink`](https://docs.python.org/3/library/os.html#os.unlink)
-/// - [PEP 428](https://peps.python.org/pep-0428/)
+/// - [PEP 428 – The pathlib module – object-oriented filesystem paths](https://peps.python.org/pep-0428/)
 /// - [Correspondence between `os` and `pathlib`](https://docs.python.org/3/library/pathlib.html#correspondence-to-tools-in-the-os-module)
 /// - [Why you should be using pathlib](https://treyhunner.com/2018/12/why-you-should-be-using-pathlib/)
 /// - [No really, pathlib is great](https://treyhunner.com/2019/01/no-really-pathlib-is-great/)
@@ -418,7 +418,7 @@ impl Violation for OsUnlink {
 /// - [Python documentation: `Path.cwd`](https://docs.python.org/3/library/pathlib.html#pathlib.Path.cwd)
 /// - [Python documentation: `os.getcwd`](https://docs.python.org/3/library/os.html#os.getcwd)
 /// - [Python documentation: `os.getcwdb`](https://docs.python.org/3/library/os.html#os.getcwdb)
-/// - [PEP 428](https://peps.python.org/pep-0428/)
+/// - [PEP 428 – The pathlib module – object-oriented filesystem paths](https://peps.python.org/pep-0428/)
 /// - [Correspondence between `os` and `pathlib`](https://docs.python.org/3/library/pathlib.html#correspondence-to-tools-in-the-os-module)
 /// - [Why you should be using pathlib](https://treyhunner.com/2018/12/why-you-should-be-using-pathlib/)
 /// - [No really, pathlib is great](https://treyhunner.com/2019/01/no-really-pathlib-is-great/)
@@ -461,7 +461,7 @@ impl Violation for OsGetcwd {
 /// ## References
 /// - [Python documentation: `Path.exists`](https://docs.python.org/3/library/pathlib.html#pathlib.Path.exists)
 /// - [Python documentation: `os.path.exists`](https://docs.python.org/3/library/os.path.html#os.path.exists)
-/// - [PEP 428](https://peps.python.org/pep-0428/)
+/// - [PEP 428 – The pathlib module – object-oriented filesystem paths](https://peps.python.org/pep-0428/)
 /// - [Correspondence between `os` and `pathlib`](https://docs.python.org/3/library/pathlib.html#correspondence-to-tools-in-the-os-module)
 /// - [Why you should be using pathlib](https://treyhunner.com/2018/12/why-you-should-be-using-pathlib/)
 /// - [No really, pathlib is great](https://treyhunner.com/2019/01/no-really-pathlib-is-great/)
@@ -504,7 +504,7 @@ impl Violation for OsPathExists {
 /// ## References
 /// - [Python documentation: `Path.expanduser`](https://docs.python.org/3/library/pathlib.html#pathlib.Path.expanduser)
 /// - [Python documentation: `os.path.expanduser`](https://docs.python.org/3/library/os.path.html#os.path.expanduser)
-/// - [PEP 428](https://peps.python.org/pep-0428/)
+/// - [PEP 428 – The pathlib module – object-oriented filesystem paths](https://peps.python.org/pep-0428/)
 /// - [Correspondence between `os` and `pathlib`](https://docs.python.org/3/library/pathlib.html#correspondence-to-tools-in-the-os-module)
 /// - [Why you should be using pathlib](https://treyhunner.com/2018/12/why-you-should-be-using-pathlib/)
 /// - [No really, pathlib is great](https://treyhunner.com/2019/01/no-really-pathlib-is-great/)
@@ -547,7 +547,7 @@ impl Violation for OsPathExpanduser {
 /// ## References
 /// - [Python documentation: `Path.is_dir`](https://docs.python.org/3/library/pathlib.html#pathlib.Path.is_dir)
 /// - [Python documentation: `os.path.isdir`](https://docs.python.org/3/library/os.path.html#os.path.isdir)
-/// - [PEP 428](https://peps.python.org/pep-0428/)
+/// - [PEP 428 – The pathlib module – object-oriented filesystem paths](https://peps.python.org/pep-0428/)
 /// - [Correspondence between `os` and `pathlib`](https://docs.python.org/3/library/pathlib.html#correspondence-to-tools-in-the-os-module)
 /// - [Why you should be using pathlib](https://treyhunner.com/2018/12/why-you-should-be-using-pathlib/)
 /// - [No really, pathlib is great](https://treyhunner.com/2019/01/no-really-pathlib-is-great/)
@@ -590,7 +590,7 @@ impl Violation for OsPathIsdir {
 /// ## References
 /// - [Python documentation: `Path.is_file`](https://docs.python.org/3/library/pathlib.html#pathlib.Path.is_file)
 /// - [Python documentation: `os.path.isfile`](https://docs.python.org/3/library/os.path.html#os.path.isfile)
-/// - [PEP 428](https://peps.python.org/pep-0428/)
+/// - [PEP 428 – The pathlib module – object-oriented filesystem paths](https://peps.python.org/pep-0428/)
 /// - [Correspondence between `os` and `pathlib`](https://docs.python.org/3/library/pathlib.html#correspondence-to-tools-in-the-os-module)
 /// - [Why you should be using pathlib](https://treyhunner.com/2018/12/why-you-should-be-using-pathlib/)
 /// - [No really, pathlib is great](https://treyhunner.com/2019/01/no-really-pathlib-is-great/)
@@ -633,7 +633,7 @@ impl Violation for OsPathIsfile {
 /// ## References
 /// - [Python documentation: `Path.is_symlink`](https://docs.python.org/3/library/pathlib.html#pathlib.Path.is_symlink)
 /// - [Python documentation: `os.path.islink`](https://docs.python.org/3/library/os.path.html#os.path.islink)
-/// - [PEP 428](https://peps.python.org/pep-0428/)
+/// - [PEP 428 – The pathlib module – object-oriented filesystem paths](https://peps.python.org/pep-0428/)
 /// - [Correspondence between `os` and `pathlib`](https://docs.python.org/3/library/pathlib.html#correspondence-to-tools-in-the-os-module)
 /// - [Why you should be using pathlib](https://treyhunner.com/2018/12/why-you-should-be-using-pathlib/)
 /// - [No really, pathlib is great](https://treyhunner.com/2019/01/no-really-pathlib-is-great/)
@@ -676,7 +676,7 @@ impl Violation for OsPathIslink {
 /// ## References
 /// - [Python documentation: `Path.readlink`](https://docs.python.org/3/library/pathlib.html#pathlib.Path.readline)
 /// - [Python documentation: `os.readlink`](https://docs.python.org/3/library/os.html#os.readlink)
-/// - [PEP 428](https://peps.python.org/pep-0428/)
+/// - [PEP 428 – The pathlib module – object-oriented filesystem paths](https://peps.python.org/pep-0428/)
 /// - [Correspondence between `os` and `pathlib`](https://docs.python.org/3/library/pathlib.html#correspondence-to-tools-in-the-os-module)
 /// - [Why you should be using pathlib](https://treyhunner.com/2018/12/why-you-should-be-using-pathlib/)
 /// - [No really, pathlib is great](https://treyhunner.com/2019/01/no-really-pathlib-is-great/)
@@ -728,7 +728,7 @@ impl Violation for OsReadlink {
 /// - [Python documentation: `Path.group`](https://docs.python.org/3/library/pathlib.html#pathlib.Path.group)
 /// - [Python documentation: `Path.owner`](https://docs.python.org/3/library/pathlib.html#pathlib.Path.owner)
 /// - [Python documentation: `os.stat`](https://docs.python.org/3/library/os.html#os.stat)
-/// - [PEP 428](https://peps.python.org/pep-0428/)
+/// - [PEP 428 – The pathlib module – object-oriented filesystem paths](https://peps.python.org/pep-0428/)
 /// - [Correspondence between `os` and `pathlib`](https://docs.python.org/3/library/pathlib.html#correspondence-to-tools-in-the-os-module)
 /// - [Why you should be using pathlib](https://treyhunner.com/2018/12/why-you-should-be-using-pathlib/)
 /// - [No really, pathlib is great](https://treyhunner.com/2019/01/no-really-pathlib-is-great/)
@@ -774,7 +774,7 @@ impl Violation for OsStat {
 /// ## References
 /// - [Python documentation: `PurePath.is_absolute`](https://docs.python.org/3/library/pathlib.html#pathlib.PurePath.is_absolute)
 /// - [Python documentation: `os.path.isabs`](https://docs.python.org/3/library/os.path.html#os.path.isabs)
-/// - [PEP 428](https://peps.python.org/pep-0428/)
+/// - [PEP 428 – The pathlib module – object-oriented filesystem paths](https://peps.python.org/pep-0428/)
 /// - [Correspondence between `os` and `pathlib`](https://docs.python.org/3/library/pathlib.html#correspondence-to-tools-in-the-os-module)
 /// - [Why you should be using pathlib](https://treyhunner.com/2018/12/why-you-should-be-using-pathlib/)
 /// - [No really, pathlib is great](https://treyhunner.com/2019/01/no-really-pathlib-is-great/)
@@ -817,7 +817,7 @@ impl Violation for OsPathIsabs {
 /// ## References
 /// - [Python documentation: `PurePath.joinpath`](https://docs.python.org/3/library/pathlib.html#pathlib.PurePath.joinpath)
 /// - [Python documentation: `os.path.join`](https://docs.python.org/3/library/os.path.html#os.path.join)
-/// - [PEP 428](https://peps.python.org/pep-0428/)
+/// - [PEP 428 – The pathlib module – object-oriented filesystem paths](https://peps.python.org/pep-0428/)
 /// - [Correspondence between `os` and `pathlib`](https://docs.python.org/3/library/pathlib.html#correspondence-to-tools-in-the-os-module)
 /// - [Why you should be using pathlib](https://treyhunner.com/2018/12/why-you-should-be-using-pathlib/)
 /// - [No really, pathlib is great](https://treyhunner.com/2019/01/no-really-pathlib-is-great/)
@@ -877,7 +877,7 @@ pub(crate) enum Joiner {
 /// ## References
 /// - [Python documentation: `PurePath.name`](https://docs.python.org/3/library/pathlib.html#pathlib.PurePath.name)
 /// - [Python documentation: `os.path.basename`](https://docs.python.org/3/library/os.path.html#os.path.basename)
-/// - [PEP 428](https://peps.python.org/pep-0428/)
+/// - [PEP 428 – The pathlib module – object-oriented filesystem paths](https://peps.python.org/pep-0428/)
 /// - [Correspondence between `os` and `pathlib`](https://docs.python.org/3/library/pathlib.html#correspondence-to-tools-in-the-os-module)
 /// - [Why you should be using pathlib](https://treyhunner.com/2018/12/why-you-should-be-using-pathlib/)
 /// - [No really, pathlib is great](https://treyhunner.com/2019/01/no-really-pathlib-is-great/)
@@ -920,7 +920,7 @@ impl Violation for OsPathBasename {
 /// ## References
 /// - [Python documentation: `PurePath.parent`](https://docs.python.org/3/library/pathlib.html#pathlib.PurePath.parent)
 /// - [Python documentation: `os.path.dirname`](https://docs.python.org/3/library/os.path.html#os.path.dirname)
-/// - [PEP 428](https://peps.python.org/pep-0428/)
+/// - [PEP 428 – The pathlib module – object-oriented filesystem paths](https://peps.python.org/pep-0428/)
 /// - [Correspondence between `os` and `pathlib`](https://docs.python.org/3/library/pathlib.html#correspondence-to-tools-in-the-os-module)
 /// - [Why you should be using pathlib](https://treyhunner.com/2018/12/why-you-should-be-using-pathlib/)
 /// - [No really, pathlib is great](https://treyhunner.com/2019/01/no-really-pathlib-is-great/)
@@ -963,7 +963,7 @@ impl Violation for OsPathDirname {
 /// ## References
 /// - [Python documentation: `Path.samefile`](https://docs.python.org/3/library/pathlib.html#pathlib.Path.samefile)
 /// - [Python documentation: `os.path.samefile`](https://docs.python.org/3/library/os.path.html#os.path.samefile)
-/// - [PEP 428](https://peps.python.org/pep-0428/)
+/// - [PEP 428 – The pathlib module – object-oriented filesystem paths](https://peps.python.org/pep-0428/)
 /// - [Correspondence between `os` and `pathlib`](https://docs.python.org/3/library/pathlib.html#correspondence-to-tools-in-the-os-module)
 /// - [Why you should be using pathlib](https://treyhunner.com/2018/12/why-you-should-be-using-pathlib/)
 /// - [No really, pathlib is great](https://treyhunner.com/2019/01/no-really-pathlib-is-great/)
@@ -1015,7 +1015,7 @@ impl Violation for OsPathSamefile {
 /// - [Python documentation: `Path.suffix`](https://docs.python.org/3/library/pathlib.html#pathlib.PurePath.suffix)
 /// - [Python documentation: `Path.suffixes`](https://docs.python.org/3/library/pathlib.html#pathlib.PurePath.suffixes)
 /// - [Python documentation: `os.path.splitext`](https://docs.python.org/3/library/os.path.html#os.path.splitext)
-/// - [PEP 428](https://peps.python.org/pep-0428/)
+/// - [PEP 428 – The pathlib module – object-oriented filesystem paths](https://peps.python.org/pep-0428/)
 /// - [Correspondence between `os` and `pathlib`](https://docs.python.org/3/library/pathlib.html#correspondence-to-tools-in-the-os-module)
 /// - [Why you should be using pathlib](https://treyhunner.com/2018/12/why-you-should-be-using-pathlib/)
 /// - [No really, pathlib is great](https://treyhunner.com/2019/01/no-really-pathlib-is-great/)
@@ -1055,7 +1055,7 @@ impl Violation for OsPathSplitext {
 /// ## References
 /// - [Python documentation: `Path.open`](https://docs.python.org/3/library/pathlib.html#pathlib.Path.open)
 /// - [Python documentation: `open`](https://docs.python.org/3/library/functions.html#open)
-/// - [PEP 428](https://peps.python.org/pep-0428/)
+/// - [PEP 428 – The pathlib module – object-oriented filesystem paths](https://peps.python.org/pep-0428/)
 /// - [Correspondence between `os` and `pathlib`](https://docs.python.org/3/library/pathlib.html#correspondence-to-tools-in-the-os-module)
 /// - [Why you should be using pathlib](https://treyhunner.com/2018/12/why-you-should-be-using-pathlib/)
 /// - [No really, pathlib is great](https://treyhunner.com/2019/01/no-really-pathlib-is-great/)

--- a/crates/ruff_linter/src/rules/pandas_vet/rules/inplace_argument.rs
+++ b/crates/ruff_linter/src/rules/pandas_vet/rules/inplace_argument.rs
@@ -33,7 +33,7 @@ use crate::Locator;
 /// ```
 ///
 /// ## References
-/// - [_Why You Should Probably Never Use pandas inplace=True_](https://towardsdatascience.com/why-you-should-probably-never-use-pandas-inplace-true-9f9f211849e4)
+/// - [_Why You Should Probably Never Use pandas `inplace=True`_](https://towardsdatascience.com/why-you-should-probably-never-use-pandas-inplace-true-9f9f211849e4)
 #[violation]
 pub struct PandasUseOfInplaceArgument;
 

--- a/crates/ruff_linter/src/rules/pep8_naming/rules/camelcase_imported_as_acronym.rs
+++ b/crates/ruff_linter/src/rules/pep8_naming/rules/camelcase_imported_as_acronym.rs
@@ -35,10 +35,10 @@ use crate::rules::pep8_naming::helpers;
 /// from example import MyClassName
 /// ```
 ///
-/// [PEP 8]: https://peps.python.org/pep-0008/
-///
 /// ## Options
 /// - `lint.flake8-import-conventions.aliases`
+///
+/// [PEP 8]: https://peps.python.org/pep-0008/
 #[violation]
 pub struct CamelcaseImportedAsAcronym {
     name: String,

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/blank_lines.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/blank_lines.rs
@@ -61,7 +61,7 @@ const BLANK_LINES_NESTED_LEVEL: u32 = 1;
 /// them. That's why this rule is not enabled in typing stub files.
 ///
 /// ## References
-/// - [PEP 8](https://peps.python.org/pep-0008/#blank-lines)
+/// - [PEP 8: Blank Lines](https://peps.python.org/pep-0008/#blank-lines)
 /// - [Flake 8 rule](https://www.flake8rules.com/rules/E301.html)
 /// - [Typing Style Guide](https://typing.readthedocs.io/en/latest/source/stubs.html#blank-lines)
 #[violation]
@@ -114,7 +114,7 @@ impl AlwaysFixableViolation for BlankLineBetweenMethods {
 /// - `lint.isort.lines-after-imports`
 ///
 /// ## References
-/// - [PEP 8](https://peps.python.org/pep-0008/#blank-lines)
+/// - [PEP 8: Blank Lines](https://peps.python.org/pep-0008/#blank-lines)
 /// - [Flake 8 rule](https://www.flake8rules.com/rules/E302.html)
 /// - [Typing Style Guide](https://typing.readthedocs.io/en/latest/source/stubs.html#blank-lines)
 #[violation]
@@ -181,7 +181,7 @@ impl AlwaysFixableViolation for BlankLinesTopLevel {
 /// - `lint.isort.lines-between-types`
 ///
 /// ## References
-/// - [PEP 8](https://peps.python.org/pep-0008/#blank-lines)
+/// - [PEP 8: Blank Lines](https://peps.python.org/pep-0008/#blank-lines)
 /// - [Flake 8 rule](https://www.flake8rules.com/rules/E303.html)
 /// - [Typing Style Guide](https://typing.readthedocs.io/en/latest/source/stubs.html#blank-lines)
 #[violation]
@@ -228,7 +228,7 @@ impl AlwaysFixableViolation for TooManyBlankLines {
 /// ```
 ///
 /// ## References
-/// - [PEP 8](https://peps.python.org/pep-0008/#blank-lines)
+/// - [PEP 8: Blank Lines](https://peps.python.org/pep-0008/#blank-lines)
 /// - [Flake 8 rule](https://www.flake8rules.com/rules/E304.html)
 #[violation]
 pub struct BlankLineAfterDecorator {
@@ -278,7 +278,7 @@ impl AlwaysFixableViolation for BlankLineAfterDecorator {
 /// them. That's why this rule is not enabled in typing stub files.
 ///
 /// ## References
-/// - [PEP 8](https://peps.python.org/pep-0008/#blank-lines)
+/// - [PEP 8: Blank Lines](https://peps.python.org/pep-0008/#blank-lines)
 /// - [Flake 8 rule](https://www.flake8rules.com/rules/E305.html)
 /// - [Typing Style Guide](https://typing.readthedocs.io/en/latest/source/stubs.html#blank-lines)
 #[violation]
@@ -332,7 +332,7 @@ impl AlwaysFixableViolation for BlankLinesAfterFunctionOrClass {
 /// them. That's why this rule is not enabled in typing stub files.
 ///
 /// ## References
-/// - [PEP 8](https://peps.python.org/pep-0008/#blank-lines)
+/// - [PEP 8: Blank Lines](https://peps.python.org/pep-0008/#blank-lines)
 /// - [Flake 8 rule](https://www.flake8rules.com/rules/E306.html)
 /// - [Typing Style Guide](https://typing.readthedocs.io/en/latest/source/stubs.html#blank-lines)
 #[violation]

--- a/crates/ruff_linter/src/rules/pyflakes/rules/f_string_missing_placeholders.rs
+++ b/crates/ruff_linter/src/rules/pyflakes/rules/f_string_missing_placeholders.rs
@@ -52,7 +52,7 @@ use crate::Locator;
 /// See [#10885](https://github.com/astral-sh/ruff/issues/10885) for more.
 ///
 /// ## References
-/// - [PEP 498](https://www.python.org/dev/peps/pep-0498/)
+/// - [PEP 498 – Literal String Interpolation](https://peps.python.org/pep-0498/)
 #[violation]
 pub struct FStringMissingPlaceholders;
 

--- a/crates/ruff_linter/src/rules/pyflakes/rules/forward_annotation_syntax_error.rs
+++ b/crates/ruff_linter/src/rules/pyflakes/rules/forward_annotation_syntax_error.rs
@@ -21,7 +21,7 @@ use ruff_macros::{derive_message_formats, violation};
 /// ```
 ///
 /// ## References
-/// - [PEP 563](https://www.python.org/dev/peps/pep-0563/)
+/// - [PEP 563 – Postponed Evaluation of Annotations](https://peps.python.org/pep-0563/)
 #[violation]
 pub struct ForwardAnnotationSyntaxError {
     pub body: String,

--- a/crates/ruff_linter/src/rules/pyflakes/rules/starred_expressions.rs
+++ b/crates/ruff_linter/src/rules/pyflakes/rules/starred_expressions.rs
@@ -13,6 +13,9 @@ use ruff_macros::{derive_message_formats, violation};
 /// In Python 3, no more than 1 << 8 assignments are allowed before a starred
 /// expression, and no more than 1 << 24 expressions are allowed after a starred
 /// expression.
+///
+/// ## References
+/// - [PEP 3132 – Extended Iterable Unpacking](https://peps.python.org/pep-3132/)
 #[violation]
 pub struct ExpressionsInStarAssignment;
 
@@ -38,7 +41,7 @@ impl Violation for ExpressionsInStarAssignment {
 /// ```
 ///
 /// ## References
-/// - [PEP 3132](https://peps.python.org/pep-3132/)
+/// - [PEP 3132 – Extended Iterable Unpacking](https://peps.python.org/pep-3132/)
 #[violation]
 pub struct MultipleStarredExpressions;
 

--- a/crates/ruff_linter/src/rules/pyflakes/rules/unused_annotation.rs
+++ b/crates/ruff_linter/src/rules/pyflakes/rules/unused_annotation.rs
@@ -19,7 +19,7 @@ use crate::checkers::ast::Checker;
 /// ```
 ///
 /// ## References
-/// - [PEP 484](https://peps.python.org/pep-0484/)
+/// - [PEP 484 – Type Hints](https://peps.python.org/pep-0484/)
 #[violation]
 pub struct UnusedAnnotation {
     name: String,

--- a/crates/ruff_linter/src/rules/pylint/rules/await_outside_async.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/await_outside_async.rs
@@ -32,7 +32,7 @@ use crate::checkers::ast::Checker;
 ///
 /// ## References
 /// - [Python documentation: Await expression](https://docs.python.org/3/reference/expressions.html#await)
-/// - [PEP 492](https://peps.python.org/pep-0492/#await-expression)
+/// - [PEP 492: Await Expression](https://peps.python.org/pep-0492/#await-expression)
 #[violation]
 pub struct AwaitOutsideAsync;
 

--- a/crates/ruff_linter/src/rules/pylint/rules/bidirectional_unicode.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/bidirectional_unicode.rs
@@ -13,7 +13,7 @@ const BIDI_UNICODE: [char; 10] = [
     '\u{2068}', //{FIRST STRONG ISOLATE}
     '\u{2069}', //{POP DIRECTIONAL ISOLATE}
     // The following was part of PEP 672:
-    // https://www.python.org/dev/peps/pep-0672/
+    // https://peps.python.org/pep-0672/
     // so the list above might not be complete
     '\u{200F}', //{RIGHT-TO-LEFT MARK}
                 // We don't use
@@ -40,7 +40,7 @@ const BIDI_UNICODE: [char; 10] = [
 /// ```
 ///
 /// ## References
-/// - [PEP 672](https://peps.python.org/pep-0672/#bidirectional-text)
+/// - [PEP 672: Bidirectional Text](https://peps.python.org/pep-0672/#bidirectional-text)
 #[violation]
 pub struct BidirectionalUnicode;
 

--- a/crates/ruff_linter/src/rules/pylint/rules/if_stmt_min_max.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/if_stmt_min_max.rs
@@ -30,8 +30,8 @@ use crate::fix::snippet::SourceCodeSnippet;
 /// ```
 ///
 /// ## References
-/// - [Python documentation: max function](https://docs.python.org/3/library/functions.html#max)
-/// - [Python documentation: min function](https://docs.python.org/3/library/functions.html#min)
+/// - [Python documentation: `max`](https://docs.python.org/3/library/functions.html#max)
+/// - [Python documentation: `min`](https://docs.python.org/3/library/functions.html#min)
 #[violation]
 pub struct IfStmtMinMax {
     min_max: MinMax,

--- a/crates/ruff_linter/src/rules/pylint/rules/import_private_name.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/import_private_name.rs
@@ -46,8 +46,8 @@ use crate::checkers::ast::Checker;
 /// - [PEP 8: Naming Conventions](https://peps.python.org/pep-0008/#naming-conventions)
 /// - [Semantic Versioning](https://semver.org/)
 ///
-/// [PEP 8]: https://www.python.org/dev/peps/pep-0008/
-/// [PEP 420]: https://www.python.org/dev/peps/pep-0420/
+/// [PEP 8]: https://peps.python.org/pep-0008/
+/// [PEP 420]: https://peps.python.org/pep-0420/
 #[violation]
 pub struct ImportPrivateName {
     name: String,

--- a/crates/ruff_linter/src/rules/pylint/rules/import_self.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/import_self.rs
@@ -9,7 +9,8 @@ use ruff_text_size::Ranged;
 /// Checks for import statements that import the current module.
 ///
 /// ## Why is this bad?
-/// Importing a module from itself is a circular dependency.
+/// Importing a module from itself is a circular dependency and results
+/// in an `ImportError` exception.
 ///
 /// ## Example
 ///

--- a/crates/ruff_linter/src/rules/pylint/rules/load_before_global_declaration.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/load_before_global_declaration.rs
@@ -14,7 +14,7 @@ use crate::checkers::ast::Checker;
 /// ## Why is this bad?
 /// The `global` declaration applies to the entire scope. Using a name that's
 /// declared as `global` in a given scope prior to the relevant `global`
-/// declaration is a syntax error.
+/// declaration is a `SyntaxError`.
 ///
 /// ## Example
 /// ```python

--- a/crates/ruff_linter/src/rules/pylint/rules/no_self_use.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/no_self_use.rs
@@ -28,6 +28,15 @@ use crate::checkers::ast::Checker;
 /// def greeting():
 ///     print("Greetings friend!")
 /// ```
+///
+/// or
+///
+/// ```python
+/// class Person:
+///     @staticmethod
+///     def greeting():
+///         print("Greetings friend!")
+/// ```
 #[violation]
 pub struct NoSelfUse {
     method_name: String,

--- a/crates/ruff_linter/src/rules/pylint/rules/nonlocal_without_binding.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/nonlocal_without_binding.rs
@@ -27,7 +27,7 @@ use ruff_macros::{derive_message_formats, violation};
 ///
 /// ## References
 /// - [Python documentation: The `nonlocal` statement](https://docs.python.org/3/reference/simple_stmts.html#nonlocal)
-/// - [PEP 3104](https://peps.python.org/pep-3104/)
+/// - [PEP 3104 – Access to Names in Outer Scopes](https://peps.python.org/pep-3104/)
 #[violation]
 pub struct NonlocalWithoutBinding {
     pub(crate) name: String,

--- a/crates/ruff_linter/src/rules/pylint/rules/type_name_incorrect_variance.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/type_name_incorrect_variance.rs
@@ -41,7 +41,7 @@ use crate::rules::pylint::helpers::type_param_name;
 /// - [PEP 483 – The Theory of Type Hints: Covariance and Contravariance](https://peps.python.org/pep-0483/#covariance-and-contravariance)
 /// - [PEP 484 – Type Hints: Covariance and contravariance](https://peps.python.org/pep-0484/#covariance-and-contravariance)
 ///
-/// [PEP 484]: https://www.python.org/dev/peps/pep-0484/
+/// [PEP 484]: https://peps.python.org/pep-0484/
 #[violation]
 pub struct TypeNameIncorrectVariance {
     kind: VarKind,

--- a/crates/ruff_linter/src/rules/pylint/rules/useless_import_alias.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/useless_import_alias.rs
@@ -21,6 +21,12 @@ use crate::checkers::ast::Checker;
 /// ```python
 /// import numpy as np
 /// ```
+///
+/// or
+///
+/// ```python
+/// import numpy
+/// ```
 #[violation]
 pub struct UselessImportAlias;
 

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/quoted_annotation.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/quoted_annotation.rs
@@ -55,7 +55,7 @@ use crate::checkers::ast::Checker;
 /// ```
 ///
 /// ## References
-/// - [PEP 563](https://peps.python.org/pep-0563/)
+/// - [PEP 563 – Postponed Evaluation of Annotations](https://peps.python.org/pep-0563/)
 /// - [Python documentation: `__future__`](https://docs.python.org/3/library/__future__.html#module-__future__)
 #[violation]
 pub struct QuotedAnnotation;

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/unnecessary_default_type_args.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/unnecessary_default_type_args.rs
@@ -45,11 +45,10 @@ use crate::checkers::ast::Checker;
 /// ```
 ///
 /// ## References
-///
 /// - [PEP 696 – Type Defaults for Type Parameters](https://peps.python.org/pep-0696/)
-/// - [Annotating generators and coroutines](https://docs.python.org/3.13/library/typing.html#annotating-generators-and-coroutines)
-/// - [typing.Generator](https://docs.python.org/3.13/library/typing.html#typing.Generator)
-/// - [typing.AsyncGenerator](https://docs.python.org/3.13/library/typing.html#typing.AsyncGenerator)
+/// - [Annotating generators and coroutines](https://docs.python.org/3/library/typing.html#annotating-generators-and-coroutines)
+/// - [Python documentation: `typing.Generator`](https://docs.python.org/3/library/typing.html#typing.Generator)
+/// - [Python documentation: `typing.AsyncGenerator`](https://docs.python.org/3/library/typing.html#typing.AsyncGenerator)
 #[violation]
 pub struct UnnecessaryDefaultTypeArgs;
 

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/useless_metaclass_type.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/useless_metaclass_type.rs
@@ -27,7 +27,7 @@ use crate::fix;
 /// ```
 ///
 /// ## References
-/// - [PEP 3115](https://www.python.org/dev/peps/pep-3115/)
+/// - [PEP 3115 – Metaclasses in Python 3000](https://peps.python.org/pep-3115/)
 #[violation]
 pub struct UselessMetaclassType;
 

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/useless_object_inheritance.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/useless_object_inheritance.rs
@@ -26,7 +26,7 @@ use crate::fix::edits::{remove_argument, Parentheses};
 /// ```
 ///
 /// ## References
-/// - [PEP 3115](https://www.python.org/dev/peps/pep-3115/)
+/// - [PEP 3115 – Metaclasses in Python 3000](https://peps.python.org/pep-3115/)
 #[violation]
 pub struct UselessObjectInheritance {
     name: String,

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/yield_in_for_loop.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/yield_in_for_loop.rs
@@ -36,7 +36,7 @@ use crate::checkers::ast::Checker;
 ///
 /// ## References
 /// - [Python documentation: The `yield` statement](https://docs.python.org/3/reference/simple_stmts.html#the-yield-statement)
-/// - [PEP 380](https://peps.python.org/pep-0380/)
+/// - [PEP 380 – Syntax for Delegating to a Subgenerator](https://peps.python.org/pep-0380/)
 #[violation]
 pub struct YieldInForLoop;
 


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Found these while experimenting with the categorisation:

- Use canonical PEP URLs (`https://peps.python.org/` instead of `https://www.python.org/dev/`)
- Provide a title to PEP references:
    - If the URL links to the full PEP, then use `PEP [code] - [page title]`
    - If the URL links to a specific section, then use `PEP [code]: [section title]` 
- Add references to the Python documentation in a few places.
- Ensure that titles to the Python documentation are consistent.
- Fix links to Typing documentation (page was moved).
- Various small extensions to examples.
