### PR TITLE
[red-knot] Fix intersection simplification for `~Any`/`~Unknown`

### DIFF
--- a/crates/red_knot_python_semantic/src/types/builder.rs
+++ b/crates/red_knot_python_semantic/src/types/builder.rs
@@ -317,7 +317,7 @@ impl<'db> InnerIntersectionBuilder<'db> {
                 // Adding any of these types to the negative side of an intersection
                 // is equivalent to adding it to the positive side. We do this to
                 // simplify the representation.
-                self.positive.insert(ty);
+                self.add_positive(db, ty);
             }
             // ~Literal[True] & bool = Literal[False]
             Type::BooleanLiteral(bool)
@@ -590,6 +590,22 @@ mod tests {
             .build();
 
         assert_eq!(ta_not_i0.display(&db).to_string(), "int & Any | Literal[1]");
+    }
+
+    #[test]
+    fn build_intersection_simplify_negative_any() {
+        let db = setup_db();
+
+        let ty = IntersectionBuilder::new(&db)
+            .add_negative(Type::Any)
+            .build();
+        assert_eq!(ty, Type::Any);
+
+        let ty = IntersectionBuilder::new(&db)
+            .add_positive(Type::Never)
+            .add_negative(Type::Any)
+            .build();
+        assert_eq!(ty, Type::Never);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Another bug found using [property testing](https://github.com/astral-sh/ruff/pull/14178).

## Test Plan

New unit test