### PR TITLE
[red-knot] Consolidate detection of cyclically defined classes

### DIFF
--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -2329,8 +2329,8 @@ impl<'db> Class<'db> {
 
         if base_classes.peek().is_some() && self.is_cyclically_defined(db) {
             // We emit diagnostics for cyclic class definitions elsewhere.
-            // Don't even try to infer the metaclass if the class is cyclically defined:
-            // it's impossible to do so without entering an infinite loop.
+            // Avoid attempting to infer the metaclass if the class is cyclically defined:
+            // it would be easy to enter an infinite loop.
             //
             // TODO: `type[Unknown]` might be better here?
             return Ok(Type::Unknown);

--- a/crates/red_knot_python_semantic/src/types/mro.rs
+++ b/crates/red_knot_python_semantic/src/types/mro.rs
@@ -1,7 +1,6 @@
 use std::collections::VecDeque;
 use std::ops::Deref;
 
-use indexmap::IndexSet;
 use itertools::Either;
 use rustc_hash::FxHashSet;
 
@@ -26,21 +25,29 @@ impl<'db> Mro<'db> {
     /// (We emit a diagnostic warning about the runtime `TypeError` in
     /// [`super::infer::TypeInferenceBuilder::infer_region_scope`].)
     pub(super) fn of_class(db: &'db dyn Db, class: Class<'db>) -> Result<Self, MroError<'db>> {
-        Self::of_class_impl(db, class).map_err(|error_kind| {
-            let fallback_mro = Self::from([
-                ClassBase::Class(class),
-                ClassBase::Unknown,
-                ClassBase::object(db),
-            ]);
-            MroError {
-                kind: error_kind,
-                fallback_mro,
-            }
+        Self::of_class_impl(db, class).map_err(|error_kind| MroError {
+            kind: error_kind,
+            fallback_mro: Self::from_error(db, class),
         })
+    }
+
+    pub(super) fn from_error(db: &'db dyn Db, class: Class<'db>) -> Self {
+        Self::from([
+            ClassBase::Class(class),
+            ClassBase::Unknown,
+            ClassBase::object(db),
+        ])
     }
 
     fn of_class_impl(db: &'db dyn Db, class: Class<'db>) -> Result<Self, MroErrorKind<'db>> {
         let class_bases = class.explicit_bases(db);
+
+        if !class_bases.is_empty() && class.is_cyclically_defined(db) {
+            // We emit errors for cyclically defined classes elsewhere.
+            // It's important that we don't even try to infer the MRO for a cyclically defined class,
+            // or we'll end up in an infinite loop.
+            return Ok(Mro::from_error(db, class));
+        }
 
         match class_bases {
             // `builtins.object` is the special case:
@@ -77,11 +84,6 @@ impl<'db> Mro<'db> {
                         Err(MroErrorKind::InvalidBases(bases_info))
                     },
                     |single_base| {
-                        if let ClassBase::Class(class_base) = single_base {
-                            if class_is_cyclically_defined(db, class_base) {
-                                return Err(MroErrorKind::CyclicClassDefinition);
-                            }
-                        }
                         let mro = std::iter::once(ClassBase::Class(class))
                             .chain(single_base.mro(db))
                             .collect();
@@ -96,10 +98,6 @@ impl<'db> Mro<'db> {
             // what MRO Python will give this class at runtime
             // (if an MRO is indeed resolvable at all!)
             multiple_bases => {
-                if class_is_cyclically_defined(db, class) {
-                    return Err(MroErrorKind::CyclicClassDefinition);
-                }
-
                 let mut valid_bases = vec![];
                 let mut invalid_bases = vec![];
 
@@ -282,13 +280,6 @@ pub(super) enum MroErrorKind<'db> {
     /// Each index is the index of a node representing an invalid base.
     InvalidBases(Box<[(usize, Type<'db>)]>),
 
-    /// The class inherits from itself!
-    ///
-    /// This is very unlikely to happen in working real-world code,
-    /// but it's important to explicitly account for it.
-    /// If we don't, there's a possibility of an infinite loop and a panic.
-    CyclicClassDefinition,
-
     /// The class has one or more duplicate bases.
     ///
     /// This variant records the indices and [`Class`]es
@@ -459,47 +450,4 @@ fn c3_merge(mut sequences: Vec<VecDeque<ClassBase>>) -> Option<Mro> {
             }
         }
     }
-}
-
-/// Return `true` if this class appears to be a cyclic definition,
-/// i.e., it inherits either directly or indirectly from itself.
-///
-/// A class definition like this will fail at runtime,
-/// but we must be resilient to it or we could panic.
-fn class_is_cyclically_defined(db: &dyn Db, class: Class) -> bool {
-    fn is_cyclically_defined_recursive<'db>(
-        db: &'db dyn Db,
-        class: Class<'db>,
-        classes_to_watch: &mut IndexSet<Class<'db>>,
-    ) -> bool {
-        if !classes_to_watch.insert(class) {
-            return true;
-        }
-        for explicit_base_class in class
-            .explicit_bases(db)
-            .iter()
-            .copied()
-            .filter_map(Type::into_class_literal)
-            .map(|ClassLiteralType { class }| class)
-        {
-            // Each base must be considered in isolation.
-            // This is due to the fact that if a class uses multiple inheritance,
-            // there could easily be a situation where two bases have the same class in their MROs;
-            // that isn't enough to constitute the class being cyclically defined.
-            let classes_to_watch_len = classes_to_watch.len();
-            if is_cyclically_defined_recursive(db, explicit_base_class, classes_to_watch) {
-                return true;
-            }
-            classes_to_watch.truncate(classes_to_watch_len);
-        }
-        false
-    }
-
-    class
-        .explicit_bases(db)
-        .iter()
-        .copied()
-        .filter_map(Type::into_class_literal)
-        .map(|ClassLiteralType { class }| class)
-        .any(|base_class| is_cyclically_defined_recursive(db, base_class, &mut IndexSet::default()))
 }


### PR DESCRIPTION
## Summary

Fixes #14141.

Attempting to infer the MRO or metaclass of a cyclically defined class must be avoided, or we'll end up in an infinite loop. As such, our logic for determining metaclasses and our logic for determining MROs both have logic included to detect if a class is cyclically defined and abort if so.

This PR moves the cycle-detection logic from `mro.rs` into a single method on `ClassType` that is queried by both the MRO-inference and metaclass-inference methods. This has several advantages:
- It means that for cyclically defined classes, we don't even need to call the `try_mro` and `try_metaclass` Salsa queries in `check_class_definitions`. We know that we won't be able to calculate either, so there's no need to do so. It doesn't cost us anything to eagerly check whether the class is cyclically defined in the `check_class_definitions` method, because we would need to do this check anyway before even attempting to check that the class's MRO or metaclass was resolvable.
- It gets rid of this awkward patch of code here, where we have to just ignore the error and move on, because we know it'll have already been handled by the MRO-checking logic immediately above: https://github.com/astral-sh/ruff/blob/953e862aca1449651d96036fcd35f7fab4ccda51/crates/red_knot_python_semantic/src/types/infer.rs#L567-L570
- It's a reasonably significant reduction in code quantity. It's also a reasonably significant reduction in code complexity: there's now no need for a recursive inner function in `try_metaclass`, for example.

The diff in the metaclass-inference logic is a bit hard to read -- sorry! -- but there's really not much changed overall. It's just all been dedented because there's no longer any need for the large recursive inner function.

## Can we use the `specify` Salsa functionality?

@carljm suggested in https://github.com/astral-sh/ruff/issues/14141 that we could use Salsa's `specify` functionality to let Salsa know that it didn't even need to call `try_mro` or `try_metaclass` if there was a cyclic class definition, since if there's a cyclic class definition we know we'll just return an error variant from these queries. I tried this, and it doesn't seem to work: Salsa complains that `Class` doesn't implement the `salsa::plumbing::TrackedStructInDb` trait if I make this change:

```diff
diff --git a/crates/red_knot_python_semantic/src/types.rs b/crates/red_knot_python_semantic/src/types.rs
index 2af8f1d9b..107305860 100644
--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -2322,7 +2322,7 @@ impl<'db> Class<'db> {
     }
 
     /// Return the metaclass of this class, or an error if the metaclass cannot be inferred.
-    #[salsa::tracked]
+    #[salsa::tracked(specify)]
     pub(crate) fn try_metaclass(self, db: &'db dyn Db) -> Result<Type<'db>, MetaclassError<'db>> {
```

I looked into this a little bit and I don't think it would be correct (and maybe not possible?) for `Class` to implement that trait, so I don't think we can use `specify` for Salsa-tracked methods on `Class`.

## Test Plan

Existing tests all pass.
