### PR TITLE
[`refurb`] Use `UserString` instead of non-existent `UserStr`

### DIFF
--- a/crates/ruff_linter/src/rules/refurb/rules/subclass_builtin.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/subclass_builtin.rs
@@ -10,7 +10,7 @@ use crate::{checkers::ast::Checker, importer::ImportRequest};
 ///
 /// ## Why is this bad?
 /// Subclassing `dict`, `list`, or `str` objects can be error prone, use the
-/// `UserDict`, `UserList`, and `UserStr` objects from the `collections` module
+/// `UserDict`, `UserList`, and `UserString` objects from the `collections` module
 /// instead.
 ///
 /// ## Example
@@ -124,7 +124,7 @@ impl SupportedBuiltins {
         match self {
             SupportedBuiltins::Dict => "UserDict",
             SupportedBuiltins::List => "UserList",
-            SupportedBuiltins::Str => "UserStr",
+            SupportedBuiltins::Str => "UserString",
         }
     }
 }

--- a/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__FURB189_FURB189.py.snap
+++ b/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__FURB189_FURB189.py.snap
@@ -48,7 +48,7 @@ FURB189.py:20:9: FURB189 [*] Subclassing `list` can be error prone, use `collect
 22 22 | 
 23 23 | class S(str):
 
-FURB189.py:23:9: FURB189 [*] Subclassing `str` can be error prone, use `collections.UserStr` instead
+FURB189.py:23:9: FURB189 [*] Subclassing `str` can be error prone, use `collections.UserString` instead
    |
 21 |     pass
 22 | 
@@ -56,13 +56,13 @@ FURB189.py:23:9: FURB189 [*] Subclassing `str` can be error prone, use `collecti
    |         ^^^ FURB189
 24 |     pass
    |
-   = help: Replace with `collections.UserStr`
+   = help: Replace with `collections.UserString`
 
 ℹ Unsafe fix
 1  1  | # setup
 2  2  | from enum import Enum, EnumMeta
 3     |-from collections import UserList as UL
-   3  |+from collections import UserList as UL, UserStr
+   3  |+from collections import UserList as UL, UserString
 4  4  | 
 5  5  | class SetOnceMappingMixin:
 6  6  |     __slots__ = ()
@@ -71,7 +71,7 @@ FURB189.py:23:9: FURB189 [*] Subclassing `str` can be error prone, use `collecti
 21 21 |     pass
 22 22 | 
 23    |-class S(str):
-   23 |+class S(UserStr):
+   23 |+class S(UserString):
 24 24 |     pass
 25 25 | 
 26 26 | # currently not detected


### PR DESCRIPTION


<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

The class name is UserString, not a UserStr, see https://docs.python.org/3.9/library/collections.html#collections.UserString

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

<!-- How was it tested? -->
