### PR TITLE
[red-knot] Improve mdtest output

### DIFF
--- a/crates/red_knot_python_semantic/tests/mdtest.rs
+++ b/crates/red_knot_python_semantic/tests/mdtest.rs
@@ -1,6 +1,7 @@
-use dir_test::{dir_test, Fixture};
-use red_knot_test::run;
+use std::ffi::OsStr;
 use std::path::Path;
+
+use dir_test::{dir_test, Fixture};
 
 /// See `crates/red_knot_test/README.md` for documentation on these tests.
 #[dir_test(
@@ -9,16 +10,16 @@ use std::path::Path;
 )]
 #[allow(clippy::needless_pass_by_value)]
 fn mdtest(fixture: Fixture<&str>) {
-    let path = fixture.path();
+    let fixture_path = Path::new(fixture.path());
+    let crate_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let workspace_root = crate_dir.parent().and_then(Path::parent).unwrap();
 
-    let crate_dir = Path::new(env!("CARGO_MANIFEST_DIR"))
-        .join("resources/mdtest")
-        .canonicalize()
+    let long_title = fixture_path
+        .strip_prefix(workspace_root)
+        .unwrap()
+        .to_str()
         .unwrap();
+    let short_title = fixture_path.file_name().and_then(OsStr::to_str).unwrap();
 
-    let relative_path = path
-        .strip_prefix(crate_dir.to_str().unwrap())
-        .unwrap_or(path);
-
-    run(Path::new(path), relative_path);
+    red_knot_test::run(fixture_path, long_title, short_title);
 }

--- a/crates/red_knot_test/src/lib.rs
+++ b/crates/red_knot_test/src/lib.rs
@@ -19,9 +19,9 @@ mod parser;
 ///
 /// Panic on test failure, and print failure details.
 #[allow(clippy::print_stdout)]
-pub fn run(path: &Path, title: &str) {
+pub fn run(path: &Path, long_title: &str, short_title: &str) {
     let source = std::fs::read_to_string(path).unwrap();
-    let suite = match test_parser::parse(title, &source) {
+    let suite = match test_parser::parse(short_title, &source) {
         Ok(suite) => suite,
         Err(err) => {
             panic!("Error parsing `{}`: {err}", path.to_str().unwrap())
@@ -49,8 +49,8 @@ pub fn run(path: &Path, title: &str) {
                     for failure in failures {
                         let absolute_line_number =
                             backtick_line.checked_add(relative_line_number).unwrap();
-                        let line_info = format!("{title}:{absolute_line_number}").cyan();
-                        println!("    {line_info} {failure}");
+                        let line_info = format!("{long_title}:{absolute_line_number}").cyan();
+                        println!("  {line_info} {failure}");
                     }
                 }
             }


### PR DESCRIPTION
## Summary

Helps with #13875. Changes made:
- Paths given for the Markdown files are relative to the workspace root rather than the crate root. This enables you to copy-and-paste them straight from the terminal, and makes them clickable in more editors.
- Use shorter titles for the bold/underlined section titles: just the filename for the first part of the title, rather than the path of the Markdown file relative to `crates/red_knot_python_semantic/resources/mdtest`. I didn't get rid of these entirely, because I believe it's possible to have a Markdown test file that doesn't have any `#` headings in it, which I believe would result in an empty title if we got rid of the path from the title entirely.
- Reduce the indentation of the line-by-line error reports from 4 spaces to 2. I'm not wild about getting rid of these entirely for the reasons I gave in https://github.com/astral-sh/ruff/issues/13875#issuecomment-2433225174, but I think it makes sense to reduce them a bit.

Previous output:

<details>
<summary>Screenshot</summary>

![image](https://github.com/user-attachments/assets/ed5fab80-1800-4ad5-a0eb-89d13becaed0)

</details>

New output:

<details>
<summary>Screenshot</summary>

![image](https://github.com/user-attachments/assets/39f46474-7dc1-418a-8f96-d28db1e33d7b)

</details>

Diff to achieve these demo test failures:

<details>

````diff
--- a/crates/red_knot_python_semantic/resources/mdtest/comparison/identity_tests.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/comparison/identity_tests.md
@@ -1,5 +1,7 @@
 # Identity tests
 
+## Foo
+
 ```py
 class A: ...
 
@@ -14,7 +16,7 @@ n2 = None
 
 o = get_object()
 
-reveal_type(a1 is a1)  # revealed: bool
+reveal_type(a1 is a1)  # revealed: str
 reveal_type(a1 is a2)  # revealed: bool
 
 reveal_type(n1 is n1)  # revealed: Literal[True]
@@ -38,3 +40,9 @@ reveal_type(n1 is not a1)  # revealed: Literal[True]
 reveal_type(a1 is not o)  # revealed: bool
 reveal_type(n1 is not o)  # revealed: bool
 ```
+
+## Bar
+
+```py
+x
+```
````

</details>

## Test Plan

`cargo test`
