### PR TITLE
[`flake8-pyi`] Implement autofix and handle nested unions with single element (`PYI041 `, `PYI055`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI016.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI016.py
@@ -85,7 +85,6 @@ field24: typing.Union[int, typing.Union[int, int]]  # PYI016: Duplicate union me
 # we incorrectly re-checked the nested union).
 field25: typing.Union[int, int | int]  # PYI016: Duplicate union member `int`
 
-
 # Should emit in cases with nested `typing.Union`
 field26: typing.Union[typing.Union[int, int]]  # PYI016: Duplicate union member `int`
 

--- a/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI016.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI016.py
@@ -84,3 +84,28 @@ field24: typing.Union[int, typing.Union[int, int]]  # PYI016: Duplicate union me
 # duplicates of the outer `int`), but not three times (which would indicate that
 # we incorrectly re-checked the nested union).
 field25: typing.Union[int, int | int]  # PYI016: Duplicate union member `int`
+
+
+# Should emit in cases with nested `typing.Union`
+field26: typing.Union[typing.Union[int, int]]  # PYI016: Duplicate union member `int`
+
+# Should emit in cases with nested `typing.Union`
+field27: typing.Union[typing.Union[typing.Union[int, int]]]  # PYI016: Duplicate union member `int`
+
+# Should emit in cases with mixed `typing.Union` and `|`
+field28: typing.Union[int | int]  # Error
+
+# Should emit twice in cases with multiple nested `typing.Union`
+field29: typing.Union[int, typing.Union[typing.Union[int, int]]]  # Error
+
+# Should emit once in cases with multiple nested `typing.Union`
+field30: typing.Union[int, typing.Union[typing.Union[int, str]]]  # Error
+
+# Should emit once, and fix to `typing.Union[float, int]`
+field31: typing.Union[float, typing.Union[int | int]]  # Error
+
+# Should emit once, and fix to `typing.Union[float, int]`
+field32: typing.Union[float, typing.Union[int | int | int]]  # Error
+
+# Test case for mixed union type fix
+field33: typing.Union[typing.Union[int | int] | typing.Union[int | int]] # Error

--- a/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI016.pyi
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI016.pyi
@@ -99,3 +99,9 @@ field29: typing.Union[int, typing.Union[typing.Union[int, int]]]  # Error
 
 # Should emit once in cases with multiple nested `typing.Union`
 field30: typing.Union[int, typing.Union[typing.Union[int, str]]]  # Error
+
+# Should emit once, and fix to `typing.Union[float, int]`
+field31: typing.Union[float, typing.Union[int | int]]  # Error
+
+# Should emit once, and fix to `typing.Union[float, int]`
+field32: typing.Union[float, typing.Union[int | int | int]]  # Error

--- a/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI016.pyi
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI016.pyi
@@ -105,3 +105,6 @@ field31: typing.Union[float, typing.Union[int | int]]  # Error
 
 # Should emit once, and fix to `typing.Union[float, int]`
 field32: typing.Union[float, typing.Union[int | int | int]]  # Error
+
+# ...
+field33: typing.Union[typing.Union[int | int] | typing.Union[int | int]] # Error

--- a/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI016.pyi
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI016.pyi
@@ -84,3 +84,18 @@ field24: typing.Union[int, typing.Union[int, int]]  # PYI016: Duplicate union me
 # duplicates of the outer `int`), but not three times (which would indicate that
 # we incorrectly re-checked the nested union).
 field25: typing.Union[int, int | int]  # PYI016: Duplicate union member `int`
+
+# Should emit in cases with nested `typing.Union`
+field26: typing.Union[typing.Union[int, int]]  # PYI016: Duplicate union member `int`
+
+# Should emit in cases with nested `typing.Union`
+field27: typing.Union[typing.Union[typing.Union[int, int]]]  # PYI016: Duplicate union member `int`
+
+# Should emit in cases with mixed `typing.Union` and `|`
+field28: typing.Union[int | int]  # Error
+
+# Should emit twice in cases with multiple nested `typing.Union`
+field29: typing.Union[int, typing.Union[typing.Union[int, int]]]  # Error
+
+# Should emit once in cases with multiple nested `typing.Union`
+field30: typing.Union[int, typing.Union[typing.Union[int, str]]]  # Error

--- a/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI016.pyi
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI016.pyi
@@ -106,5 +106,5 @@ field31: typing.Union[float, typing.Union[int | int]]  # Error
 # Should emit once, and fix to `typing.Union[float, int]`
 field32: typing.Union[float, typing.Union[int | int | int]]  # Error
 
-# ...
+# Test case for mixed union type fix
 field33: typing.Union[typing.Union[int | int] | typing.Union[int | int]] # Error

--- a/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI041.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI041.py
@@ -39,9 +39,55 @@ async def f4(**kwargs: int | int | float) -> None:
     ...
 
 
+
+def f5(arg1: int, *args: Union[int, int, float]) -> None: 
+    ...
+
+
+def f6(arg1: int, *args: Union[Union[int, int, float]]) -> None: 
+    ...
+
+
+def f7(arg1: int, *args: Union[Union[Union[int, int, float]]]) -> None: 
+    ...
+
+
+def f8(arg1: int, *args: Union[Union[Union[int | int | float]]]) -> None: 
+    ...
+
+
+def f9(
+    arg: Union[  # comment 
+        float, # another
+        complex, int]
+    ) -> None: 
+    ...
+
+def f10(
+    arg: (
+        int | # comment
+        float |  # another
+        complex
+    )    
+    ) -> None: 
+    ...
+
+
 class Foo:
     def good(self, arg: int) -> None:
         ...
 
     def bad(self, arg: int | float | complex) -> None:
+        ...
+
+    def bad2(self, arg: int | Union[float, complex]) -> None: 
+        ...
+
+    def bad3(self, arg: Union[Union[float, complex], int]) -> None: 
+        ...
+
+    def bad4(self, arg: Union[float | complex, int]) -> None: 
+        ...
+
+    def bad5(self, arg: int | (float | complex)) -> None: 
         ...

--- a/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI041.pyi
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI041.pyi
@@ -33,7 +33,21 @@ def f3(arg1: int, *args: Union[int | int | float]) -> None: ...  # PYI041
 async def f4(**kwargs: int | int | float) -> None: ...  # PYI041
 
 
+def f4(arg1: int, *args: Union[int, int, float]) -> None: ...  # PYI041
+
+
+def f5(arg1: int, *args: Union[Union[int, int, float]]) -> None: ...  # PYI041
+
+
 class Foo:
     def good(self, arg: int) -> None: ...
 
     def bad(self, arg: int | float | complex) -> None: ...  # PYI041
+
+    def bad2(self, arg: int | Union[float, complex]) -> None: ...  # PYI041
+
+    def bad3(self, arg: Union[Union[float, complex], int]) -> None: ...  # PYI041
+
+    def bad4(self, arg: Union[float | complex, int]) -> None: ...  # PYI041
+
+    def bad5(self, arg: int | (float | complex)) -> None: ...  # PYI041

--- a/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI041.pyi
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI041.pyi
@@ -33,25 +33,25 @@ def f3(arg1: int, *args: Union[int | int | float]) -> None: ...  # PYI041
 async def f4(**kwargs: int | int | float) -> None: ...  # PYI041
 
 
-def f4(arg1: int, *args: Union[int, int, float]) -> None: ...  # PYI041
+def f5(arg1: int, *args: Union[int, int, float]) -> None: ...  # PYI041
 
 
-def f5(arg1: int, *args: Union[Union[int, int, float]]) -> None: ...  # PYI041
+def f6(arg1: int, *args: Union[Union[int, int, float]]) -> None: ...  # PYI041
 
 
-def f6(arg1: int, *args: Union[Union[Union[int, int, float]]]) -> None: ...  # PYI041
+def f7(arg1: int, *args: Union[Union[Union[int, int, float]]]) -> None: ...  # PYI041
 
 
-def f7(arg1: int, *args: Union[Union[Union[int | int | float]]]) -> None: ...  # PYI041
+def f8(arg1: int, *args: Union[Union[Union[int | int | float]]]) -> None: ...  # PYI041
 
 
-def f8(
+def f9(
     arg: Union[  # comment 
         float, # another
         complex, int]
     ) -> None: ...  # PYI041
 
-def f9(
+def f10(
     arg: (
         int | # comment
         float |  # another

--- a/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI041.pyi
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI041.pyi
@@ -39,6 +39,12 @@ def f4(arg1: int, *args: Union[int, int, float]) -> None: ...  # PYI041
 def f5(arg1: int, *args: Union[Union[int, int, float]]) -> None: ...  # PYI041
 
 
+def f6(arg1: int, *args: Union[Union[Union[int, int, float]]]) -> None: ...  # PYI041
+
+
+def f7(arg1: int, *args: Union[Union[Union[int | int | float]]]) -> None: ...  # PYI041
+
+
 class Foo:
     def good(self, arg: int) -> None: ...
 

--- a/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI041.pyi
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI041.pyi
@@ -45,6 +45,20 @@ def f6(arg1: int, *args: Union[Union[Union[int, int, float]]]) -> None: ...  # P
 def f7(arg1: int, *args: Union[Union[Union[int | int | float]]]) -> None: ...  # PYI041
 
 
+def f8(
+    arg: Union[  # comment 
+        float, # another
+        complex, int]
+    ) -> None: ...  # PYI041
+
+def f9(
+    arg: (
+        int | # comment
+        float |  # another
+        complex
+    )    
+    ) -> None: ... # PYI041
+
 class Foo:
     def good(self, arg: int) -> None: ...
 

--- a/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI051.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI051.py
@@ -5,6 +5,9 @@ A: str | Literal["foo"]
 B: TypeAlias = typing.Union[Literal[b"bar", b"foo"], bytes, str]
 C: TypeAlias = typing.Union[Literal[5], int, typing.Union[Literal["foo"], str]]
 D: TypeAlias = typing.Union[Literal[b"str_bytes", 42], bytes, int]
+E: TypeAlias = typing.Union[typing.Union[typing.Union[typing.Union[Literal["foo"], str]]]]
+F: TypeAlias = typing.Union[str, typing.Union[typing.Union[typing.Union[Literal["foo"], int]]]]
+G: typing.Union[str, typing.Union[typing.Union[typing.Union[Literal["foo"], int]]]]
 
 def func(x: complex | Literal[1J], y: Union[Literal[3.14], float]): ...
 

--- a/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI051.pyi
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI051.pyi
@@ -5,6 +5,9 @@ A: str | Literal["foo"]
 B: TypeAlias = typing.Union[Literal[b"bar", b"foo"], bytes, str]
 C: TypeAlias = typing.Union[Literal[5], int, typing.Union[Literal["foo"], str]]
 D: TypeAlias = typing.Union[Literal[b"str_bytes", 42], bytes, int]
+E: TypeAlias = typing.Union[typing.Union[typing.Union[typing.Union[Literal["foo"], str]]]]
+F: TypeAlias = typing.Union[str, typing.Union[typing.Union[typing.Union[Literal["foo"], int]]]]
+G: typing.Union[str, typing.Union[typing.Union[typing.Union[Literal["foo"], int]]]]
 
 def func(x: complex | Literal[1J], y: Union[Literal[3.14], float]): ...
 

--- a/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI055.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI055.py
@@ -1,11 +1,14 @@
 import builtins
 from typing import Union
 
-w: builtins.type[int] | builtins.type[str] | builtins.type[complex]
-x: type[int] | type[str] | type[float]
-y: builtins.type[int] | type[str] | builtins.type[complex]
-z: Union[type[float], type[complex]]
-z: Union[type[float, int], type[complex]]
+s: builtins.type[int] | builtins.type[str] | builtins.type[complex]
+t: type[int] | type[str] | type[float]
+u: builtins.type[int] | type[str] | builtins.type[complex]
+v: Union[type[float], type[complex]]
+w: Union[type[float, int], type[complex]]
+x: Union[Union[type[float, int], type[complex]]]
+y: Union[Union[Union[type[float, int], type[complex]]]]
+z: Union[type[complex], Union[Union[type[float, int]]]]
 
 
 def func(arg: type[int] | str | type[float]) -> None:
@@ -30,6 +33,9 @@ def func():
     # PYI055
     x: type[requests_mock.Mocker] | type[httpretty] | type[str] = requests_mock.Mocker
     y: Union[type[requests_mock.Mocker], type[httpretty], type[str]] = requests_mock.Mocker
+    z: Union[  # comment
+        type[requests_mock.Mocker], # another comment
+        type[httpretty], type[str]] = requests_mock.Mocker
 
 
 def func():

--- a/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI055.pyi
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI055.pyi
@@ -19,10 +19,13 @@ z: Union[float, complex]
 
 def func(arg: type[int, float] | str) -> None: ...
 
-# OK
+# PYI055
 item: type[requests_mock.Mocker] | type[httpretty] = requests_mock.Mocker
 
 def func():
     # PYI055
     item: type[requests_mock.Mocker] | type[httpretty] | type[str] = requests_mock.Mocker
     item2: Union[type[requests_mock.Mocker], type[httpretty], type[str]] = requests_mock.Mocker
+    item3: Union[  # comment
+        type[requests_mock.Mocker], # another comment
+        type[httpretty], type[str]] = requests_mock.Mocker

--- a/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI055.pyi
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI055.pyi
@@ -1,11 +1,14 @@
 import builtins
 from typing import Union
 
-w: builtins.type[int] | builtins.type[str] | builtins.type[complex]
-x: type[int] | type[str] | type[float]
-y: builtins.type[int] | type[str] | builtins.type[complex]
-z: Union[type[float], type[complex]]
-z: Union[type[float, int], type[complex]]
+s: builtins.type[int] | builtins.type[str] | builtins.type[complex]
+t: type[int] | type[str] | type[float]
+u: builtins.type[int] | type[str] | builtins.type[complex]
+v: Union[type[float], type[complex]]
+w: Union[type[float, int], type[complex]]
+x: Union[Union[type[float, int], type[complex]]]
+y: Union[Union[Union[type[float, int], type[complex]]]]
+z: Union[type[complex], Union[Union[type[float, int]]]]
 
 def func(arg: type[int] | str | type[float]) -> None: ...
 

--- a/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI062.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI062.py
@@ -14,8 +14,20 @@ Literal[1, Literal[1], Literal[1]]  # twice
 Literal[1, Literal[2], Literal[2]]  # once
 t.Literal[1, t.Literal[2, t.Literal[1]]]  # once
 typing_extensions.Literal[1, 1, 1]  # twice
+Literal[
+    1, # comment
+    Literal[ # another comment
+        1
+    ]
+]  # once
 
 # Ensure issue is only raised once, even on nested literals
 MyType = Literal["foo", Literal[True, False, True], "bar"]  # PYI062
 
 n: Literal["No", "duplicates", "here", 1, "1"]
+
+
+# nested literals, all equivalent to `Literal[1]`
+Literal[Literal[1]]  # no duplicate
+Literal[Literal[Literal[1], Literal[1]]]  # once
+Literal[Literal[1], Literal[Literal[Literal[1]]]]  # once

--- a/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI062.pyi
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI062.pyi
@@ -2,11 +2,11 @@ from typing import Literal
 import typing as t
 import typing_extensions
 
-x: Literal[True, False, True, False]  # PY062 twice here
+x: Literal[True, False, True, False]  # PYI062 twice here
 
-y: Literal[1, print("hello"), 3, Literal[4, 1]]  # PY062 on the last 1
+y: Literal[1, print("hello"), 3, Literal[4, 1]]  # PYI062 on the last 1
 
-z: Literal[{1, 3, 5}, "foobar", {1,3,5}]  # PY062 on the set literal
+z: Literal[{1, 3, 5}, "foobar", {1,3,5}]  # PYI062 on the set literal
 
 Literal[1, Literal[1]]  # once
 Literal[1, 2, Literal[1, 2]]  # twice

--- a/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI062.pyi
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI062.pyi
@@ -1,4 +1,4 @@
-from typing import Literal, Union
+from typing import Literal
 import typing as t
 import typing_extensions
 
@@ -14,8 +14,6 @@ Literal[1, Literal[1], Literal[1]]  # twice
 Literal[1, Literal[2], Literal[2]]  # once
 t.Literal[1, t.Literal[2, t.Literal[1]]]  # once
 typing_extensions.Literal[1, 1, 1]  # twice
-Union[Literal[1], Literal[1]]  # once
-Union[Union[Literal[1], Literal[1]]]  # once
 Literal[
     1, # comment
     Literal[ # another comment
@@ -27,3 +25,9 @@ Literal[
 MyType = Literal["foo", Literal[True, False, True], "bar"]  # PYI062
 
 n: Literal["No", "duplicates", "here", 1, "1"]
+
+
+# nested literals, all equivalent to `Literal[1]`
+Literal[Literal[1]]  # no duplicate
+Literal[Literal[Literal[1], Literal[1]]]  # once
+Literal[Literal[1], Literal[Literal[Literal[1]]]]  # once

--- a/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI062.pyi
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI062.pyi
@@ -1,4 +1,4 @@
-from typing import Literal
+from typing import Literal, Union
 import typing as t
 import typing_extensions
 
@@ -14,6 +14,14 @@ Literal[1, Literal[1], Literal[1]]  # twice
 Literal[1, Literal[2], Literal[2]]  # once
 t.Literal[1, t.Literal[2, t.Literal[1]]]  # once
 typing_extensions.Literal[1, 1, 1]  # twice
+Union[Literal[1], Literal[1]]  # once
+Union[Union[Literal[1], Literal[1]]]  # once
+Literal[
+    1, # comment
+    Literal[ # another comment
+        1
+    ]
+]  # once
 
 # Ensure issue is only raised once, even on nested literals
 MyType = Literal["foo", Literal[True, False, True], "bar"]  # PYI062

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/duplicate_literal_member.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/duplicate_literal_member.rs
@@ -78,7 +78,6 @@ pub(crate) fn duplicate_literal_member<'a>(checker: &mut Checker, expr: &'a Expr
     }
 
     // If there's at least one diagnostic, create a fix to remove the duplicate members.
-    // TODO(SB): test if `Union[Literal[1], Literal[1]]`
     if let Expr::Subscript(subscript) = expr {
         let subscript = Expr::Subscript(ast::ExprSubscript {
             slice: Box::new(if let [elt] = unique_nodes.as_slice() {

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/duplicate_union_member.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/duplicate_union_member.rs
@@ -2,12 +2,12 @@ use std::collections::HashSet;
 
 use rustc_hash::FxHashSet;
 
-use ruff_diagnostics::{Diagnostic, Edit, Fix, FixAvailability, Violation};
+use ruff_diagnostics::{AlwaysFixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::comparable::ComparableExpr;
-use ruff_python_ast::{self as ast, Expr};
+use ruff_python_ast::{self as ast, Expr, ExprContext};
 use ruff_python_semantic::analyze::typing::traverse_union;
-use ruff_text_size::Ranged;
+use ruff_text_size::{Ranged, TextRange};
 
 use crate::checkers::ast::Checker;
 
@@ -27,6 +27,11 @@ use crate::checkers::ast::Checker;
 /// foo: str
 /// ```
 ///
+/// ## Fix safety
+/// This rule's fix is marked as safe; however, for duplicate members
+/// in non-PEP604 unions (i.e. `typing.Union`), the fix will flatten
+/// nested unions type expressions into a single top-level union.
+///
 /// ## References
 /// - [Python documentation: `typing.Union`](https://docs.python.org/3/library/typing.html#typing.Union)
 #[violation]
@@ -34,31 +39,29 @@ pub struct DuplicateUnionMember {
     duplicate_name: String,
 }
 
-impl Violation for DuplicateUnionMember {
-    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Sometimes;
-
+impl AlwaysFixableViolation for DuplicateUnionMember {
     #[derive_message_formats]
     fn message(&self) -> String {
         format!("Duplicate union member `{}`", self.duplicate_name)
     }
 
-    fn fix_title(&self) -> Option<String> {
-        Some(format!(
-            "Remove duplicate union member `{}`",
-            self.duplicate_name
-        ))
+    fn fix_title(&self) -> String {
+        format!("Remove duplicate union member `{}`", self.duplicate_name)
     }
 }
 
 /// PYI016
 pub(crate) fn duplicate_union_member<'a>(checker: &mut Checker, expr: &'a Expr) {
     let mut seen_nodes: HashSet<ComparableExpr<'_>, _> = FxHashSet::default();
+    let mut unique_nodes: Vec<&Expr> = Vec::new();
     let mut diagnostics: Vec<Diagnostic> = Vec::new();
 
     // Adds a member to `literal_exprs` if it is a `Literal` annotation
     let mut check_for_duplicate_members = |expr: &'a Expr, parent: &'a Expr| {
         // If we've already seen this union member, raise a violation.
-        if !seen_nodes.insert(expr.into()) {
+        if seen_nodes.insert(expr.into()) {
+            unique_nodes.push(expr);
+        } else {
             let mut diagnostic = Diagnostic::new(
                 DuplicateUnionMember {
                     duplicate_name: checker.generator().expr(expr),
@@ -68,7 +71,7 @@ pub(crate) fn duplicate_union_member<'a>(checker: &mut Checker, expr: &'a Expr) 
             // Delete the "|" character as well as the duplicate value by reconstructing the
             // parent without the duplicate.
 
-            // If the parent node is not a `BinOp` we will not perform a fix
+            // If the parent node is not a PEP604-style union (`a | b`) we will not perform a fix.
             if let Expr::BinOp(ast::ExprBinOp { left, right, .. }) = parent {
                 // Replace the parent with its non-duplicate child.
                 let child = if expr == left.as_ref() { right } else { left };
@@ -83,6 +86,37 @@ pub(crate) fn duplicate_union_member<'a>(checker: &mut Checker, expr: &'a Expr) 
 
     // Traverse the union, collect all diagnostic members
     traverse_union(&mut check_for_duplicate_members, checker.semantic(), expr);
+
+    // If any [`Violation`] has no [`Fix`].
+    if diagnostics.iter().any(|f| f.fix.is_none()) {
+        // Flatten the union with only unique elements.
+        if let Expr::Subscript(subscript) = expr {
+            let subscript = Expr::Subscript(ast::ExprSubscript {
+                slice: Box::new(if let [elt] = unique_nodes.as_slice() {
+                    (*elt).clone()
+                } else {
+                    Expr::Tuple(ast::ExprTuple {
+                        elts: unique_nodes.into_iter().cloned().collect(),
+                        range: TextRange::default(),
+                        ctx: ExprContext::Load,
+                        parenthesized: false,
+                    })
+                }),
+                value: subscript.value.clone(),
+                range: TextRange::default(),
+                ctx: ExprContext::Load,
+            });
+            let fix = Fix::safe_edit(Edit::range_replacement(
+                checker.generator().expr(&subscript),
+                expr.range(),
+            ));
+            for diagnostic in &mut diagnostics {
+                if diagnostic.fix.is_none() {
+                    diagnostic.set_fix(fix.clone());
+                }
+            }
+        }
+    }
 
     // Add all diagnostics to the checker
     checker.diagnostics.append(&mut diagnostics);

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/duplicate_union_member.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/duplicate_union_member.rs
@@ -1,15 +1,19 @@
 use std::collections::HashSet;
 
+use anyhow::Result;
+
+use ruff_python_ast::name::Name;
 use rustc_hash::FxHashSet;
 
 use ruff_diagnostics::{AlwaysFixableViolation, Applicability, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::comparable::ComparableExpr;
-use ruff_python_ast::{self as ast, Expr, ExprContext};
+use ruff_python_ast::{Expr, ExprBinOp, ExprContext, ExprName, ExprSubscript, ExprTuple, Operator};
 use ruff_python_semantic::analyze::typing::traverse_union;
 use ruff_text_size::{Ranged, TextRange};
 
 use crate::checkers::ast::Checker;
+use crate::importer::ImportRequest;
 
 /// ## What it does
 /// Checks for duplicate union members.
@@ -30,11 +34,8 @@ use crate::checkers::ast::Checker;
 /// ## Fix safety
 /// This rule's fix is marked as safe unless the union contains comments.
 ///
-/// For duplicate members in non-PEP604 unions (i.e. `typing.Union`),
-/// the fix will flatten nested unions type expressions into a single
+/// For nested union, the fix will flatten type expressions into a single
 /// top-level union.
-///
-///
 ///
 /// ## References
 /// - [Python documentation: `typing.Union`](https://docs.python.org/3/library/typing.html#typing.Union)
@@ -54,88 +55,161 @@ impl AlwaysFixableViolation for DuplicateUnionMember {
     }
 }
 
+// TODO(SB): why the previous approach was broken:
+
+// Ex) `typing.Union[int | int]`
+// Current fix: `Union[int]`
+// Ex) `typing.Union[float, typing.Union[int | int]]`
+// Current fix: `typing.Union[int, int]`
+// Ex) `int | (str | int)`
+// Current fix: `int | (str)`
+
 /// PYI016
 pub(crate) fn duplicate_union_member<'a>(checker: &mut Checker, expr: &'a Expr) {
     let mut seen_nodes: HashSet<ComparableExpr<'_>, _> = FxHashSet::default();
     let mut unique_nodes: Vec<&Expr> = Vec::new();
     let mut diagnostics: Vec<Diagnostic> = Vec::new();
 
+    let mut union_type = UnionKind::TypingUnion;
     // Adds a member to `literal_exprs` if it is a `Literal` annotation
     let mut check_for_duplicate_members = |expr: &'a Expr, parent: &'a Expr| {
+        if matches!(parent, Expr::BinOp(_)) {
+            union_type = UnionKind::PEP604;
+        }
+
         // If we've already seen this union member, raise a violation.
         if seen_nodes.insert(expr.into()) {
             unique_nodes.push(expr);
         } else {
-            let mut diagnostic = Diagnostic::new(
+            diagnostics.push(Diagnostic::new(
                 DuplicateUnionMember {
                     duplicate_name: checker.generator().expr(expr),
                 },
                 expr.range(),
-            );
-            // Delete the "|" character as well as the duplicate value by reconstructing the
-            // parent without the duplicate.
-
-            // If the parent node is not a PEP604-style union (`a | b`) we will not perform a fix.
-            if let Expr::BinOp(ast::ExprBinOp { left, right, .. }) = parent {
-                // Replace the parent with its non-duplicate child.
-                let child = if expr == left.as_ref() { right } else { left };
-                diagnostic.set_fix(Fix::safe_edit(Edit::range_replacement(
-                    checker.locator().slice(child.as_ref()).to_string(),
-                    parent.range(),
-                )));
-            }
-            diagnostics.push(diagnostic);
+            ));
         }
     };
 
     // Traverse the union, collect all diagnostic members
     traverse_union(&mut check_for_duplicate_members, checker.semantic(), expr);
 
-    // If any [`Violation`] has no [`Fix`].
-    if diagnostics.iter().any(|f| f.fix.is_none()) {
-        // Flatten the union with only unique elements.
-        if let Expr::Subscript(subscript) = expr {
-            let edit = if let &[node] = unique_nodes.as_slice() {
-                // Single element.
-                Edit::range_replacement(checker.generator().expr(node), expr.range())
-            } else {
-                // `typing.Union[a, b]`
-                let subscript = Expr::Subscript(ast::ExprSubscript {
-                    slice: Box::new(if let [elt] = unique_nodes.as_slice() {
-                        (*elt).clone()
-                    } else {
-                        Expr::Tuple(ast::ExprTuple {
-                            elts: unique_nodes.into_iter().cloned().collect(),
-                            range: TextRange::default(),
-                            ctx: ExprContext::Load,
-                            parenthesized: false,
-                        })
-                    }),
-                    value: subscript.value.clone(),
-                    range: TextRange::default(),
-                    ctx: ExprContext::Load,
-                });
-                Edit::range_replacement(checker.generator().expr(&subscript), expr.range())
-            };
+    if diagnostics.is_empty() {
+        return;
+    }
 
-            // Mark [`Fix`] as unsafe when comments are in range
-            let fix = Fix::applicable_edit(
-                edit,
-                if checker.comment_ranges().intersects(expr.range()) {
-                    Applicability::Unsafe
-                } else {
-                    Applicability::Safe
-                },
-            );
+    // Mark [`Fix`] as unsafe when comments are in range.
+    let applicability = if checker.comment_ranges().intersects(expr.range()) {
+        Applicability::Unsafe
+    } else {
+        Applicability::Safe
+    };
 
-            for diagnostic in &mut diagnostics {
-                if diagnostic.fix.is_none() {
-                    diagnostic.set_fix(fix.clone());
-                }
+    // Generate the flattened fix once.
+    let fix = if let &[edit_expr] = unique_nodes.as_slice() {
+        // Generate a [`Fix`] for a single type expression, e.g. `int`.
+        Fix::applicable_edit(
+            Edit::range_replacement(checker.generator().expr(edit_expr), expr.range()),
+            applicability,
+        )
+    } else {
+        match union_type {
+            // See redundant numeric union
+            UnionKind::PEP604 => generate_pep604_fix(checker, unique_nodes, expr, applicability),
+            UnionKind::TypingUnion => {
+                generate_union_fix(checker, unique_nodes, expr, applicability)
+                    .ok()
+                    .unwrap()
             }
         }
+    };
+
+    for diagnostic in &mut diagnostics {
+        diagnostic.set_fix(fix.clone());
     }
 
     // Add all diagnostics to the checker
     checker.diagnostics.append(&mut diagnostics);
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum UnionKind {
+    /// E.g., `typing.Union[int, str]`
+    TypingUnion,
+    /// E.g., `int | str`
+    PEP604,
+}
+
+// Generate a [`Fix`] for two or more type expressions, e.g. `int | float | complex`.
+fn generate_pep604_fix(
+    checker: &Checker,
+    nodes: Vec<&Expr>,
+    annotation: &Expr,
+    applicability: Applicability,
+) -> Fix {
+    debug_assert!(nodes.len() >= 2, "At least two nodes required");
+
+    let new_expr = nodes
+        .into_iter()
+        .fold(None, |acc: Option<Expr>, right: &Expr| {
+            if let Some(left) = acc {
+                Some(Expr::BinOp(ExprBinOp {
+                    left: Box::new(left),
+                    op: Operator::BitOr,
+                    right: Box::new(right.clone()),
+                    range: TextRange::default(),
+                }))
+            } else {
+                Some(right.clone())
+            }
+        })
+        .unwrap();
+
+    Fix::applicable_edit(
+        Edit::range_replacement(checker.generator().expr(&new_expr), annotation.range()),
+        applicability,
+    )
+}
+
+// Generate a [`Fix`] for two or more type expresisons, e.g. `typing.Union[int, float, complex]`.
+fn generate_union_fix(
+    checker: &Checker,
+    nodes: Vec<&Expr>,
+    annotation: &Expr,
+    applicability: Applicability,
+) -> Result<Fix> {
+    debug_assert!(nodes.len() >= 2, "At least two nodes required");
+
+    // Request `typing.Union`
+    let (import_edit, binding) = checker.importer().get_or_import_symbol(
+        &ImportRequest::import_from("typing", "Union"),
+        annotation.start(),
+        checker.semantic(),
+    )?;
+
+    // Construct the expression as `Subscript[typing.Union, Tuple[expr, [expr, ...]]]`
+    let new_expr = Expr::Subscript(ExprSubscript {
+        range: TextRange::default(),
+        value: Box::new(Expr::Name(ExprName {
+            id: Name::new(binding),
+            ctx: ExprContext::Store,
+            range: TextRange::default(),
+        })),
+        slice: Box::new(if let [elt] = nodes.as_slice() {
+            (*elt).clone()
+        } else {
+            Expr::Tuple(ExprTuple {
+                elts: nodes.into_iter().cloned().collect(),
+                range: TextRange::default(),
+                ctx: ExprContext::Load,
+                parenthesized: false,
+            })
+        }),
+        ctx: ExprContext::Load,
+    });
+
+    Ok(Fix::applicable_edits(
+        Edit::range_replacement(checker.generator().expr(&new_expr), annotation.range()),
+        [import_edit],
+        applicability,
+    ))
 }

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/exit_annotations.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/exit_annotations.rs
@@ -421,7 +421,7 @@ fn check_positional_args_for_overloaded_method(
     ));
 }
 
-/// Return the non-`None` annotation element of a PEP 604-style union or `Optional` annotation.
+/// Return the non-`None` annotation element of a PEP 604-style `Union` or `Optional` annotation.
 fn non_none_annotation_element<'a>(
     annotation: &'a Expr,
     semantic: &SemanticModel,

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/mod.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/mod.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 pub(crate) use any_eq_ne_annotation::*;
 pub(crate) use bad_generator_return_type::*;
 pub(crate) use bad_version_info_comparison::*;
@@ -27,7 +29,6 @@ pub(crate) use redundant_final_literal::*;
 pub(crate) use redundant_literal_union::*;
 pub(crate) use redundant_numeric_union::*;
 pub(crate) use simple_defaults::*;
-use std::fmt;
 pub(crate) use str_or_repr_defined_in_stub::*;
 pub(crate) use string_or_bytes_too_long::*;
 pub(crate) use stub_body_multiple_statements::*;

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/redundant_numeric_union.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/redundant_numeric_union.rs
@@ -155,9 +155,13 @@ enum Redundancy {
 impl Redundancy {
     pub(super) fn from_numeric_flags(numeric_flags: NumericFlags) -> Option<Self> {
         match numeric_flags.bits() {
-            0b0110 => Some(Self::FloatComplex),
+            // NumericFlags::INT | NumericFlags::FLOAT | NumericFlags::COMPLEX
             0b0111 => Some(Self::IntFloatComplex),
+            // NumericFlags::FLOAT | NumericFlags::COMPLEX
+            0b0110 => Some(Self::FloatComplex),
+            // NumericFlags::INT | NumericFlags::COMPLEX
             0b0101 => Some(Self::IntComplex),
+            // NumericFlags::INT | NumericFlags::FLOAT
             0b0011 => Some(Self::IntFloat),
             _ => None,
         }
@@ -168,11 +172,11 @@ bitflags! {
     #[derive(Copy, Clone, Debug, PartialEq, Eq)]
     pub(super) struct NumericFlags: u8 {
         /// `int`
-        const INT = 0b0001;
+        const INT = 1 << 0;
         /// `float`
-        const FLOAT = 0b0010;
+        const FLOAT = 1 << 1;
         /// `complex`
-        const COMPLEX = 0b0100;
+        const COMPLEX = 1 << 2;
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/redundant_numeric_union.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/redundant_numeric_union.rs
@@ -1,10 +1,17 @@
-use ruff_diagnostics::{Diagnostic, Violation};
-use ruff_macros::{derive_message_formats, violation};
-use ruff_python_ast::{AnyParameterRef, Expr, Parameters};
-use ruff_python_semantic::analyze::typing::traverse_union;
-use ruff_text_size::Ranged;
+use bitflags::bitflags;
 
-use crate::checkers::ast::Checker;
+use anyhow::Result;
+
+use ruff_diagnostics::{AlwaysFixableViolation, Diagnostic, Edit, Fix};
+use ruff_macros::{derive_message_formats, violation};
+use ruff_python_ast::{
+    name::Name, AnyParameterRef, Expr, ExprBinOp, ExprContext, ExprName, ExprSubscript, ExprTuple,
+    Operator, Parameters,
+};
+use ruff_python_semantic::analyze::typing::traverse_union;
+use ruff_text_size::{Ranged, TextRange};
+
+use crate::{checkers::ast::Checker, importer::ImportRequest};
 
 /// ## What it does
 /// Checks for parameter annotations that contain redundant unions between
@@ -37,6 +44,10 @@ use crate::checkers::ast::Checker;
 /// def foo(x: float | str) -> None: ...
 /// ```
 ///
+/// ## Fix safety
+/// This rule's fix is marked as safe; however, the fix will flatten nested
+/// unions type expressions into a single top-level union.
+///
 /// ## References
 /// - [Python documentation: The numeric tower](https://docs.python.org/3/library/numbers.html#the-numeric-tower)
 /// - [PEP 484: The numeric tower](https://peps.python.org/pep-0484/#the-numeric-tower)
@@ -47,15 +58,20 @@ pub struct RedundantNumericUnion {
     redundancy: Redundancy,
 }
 
-impl Violation for RedundantNumericUnion {
+impl AlwaysFixableViolation for RedundantNumericUnion {
     #[derive_message_formats]
     fn message(&self) -> String {
         let (subtype, supertype) = match self.redundancy {
+            Redundancy::IntFloatComplex => ("int | float", "complex"),
             Redundancy::FloatComplex => ("float", "complex"),
             Redundancy::IntComplex => ("int", "complex"),
             Redundancy::IntFloat => ("int", "float"),
         };
         format!("Use `{supertype}` instead of `{subtype} | {supertype}`")
+    }
+
+    fn fix_title(&self) -> String {
+        "Remove duplicates".to_string()
     }
 }
 
@@ -66,57 +82,189 @@ pub(crate) fn redundant_numeric_union(checker: &mut Checker, parameters: &Parame
     }
 }
 
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
-enum Redundancy {
-    FloatComplex,
-    IntComplex,
-    IntFloat,
-}
-
-fn check_annotation(checker: &mut Checker, annotation: &Expr) {
-    let mut has_float = false;
-    let mut has_complex = false;
-    let mut has_int = false;
+fn check_annotation<'a>(checker: &mut Checker, annotation: &'a Expr) {
+    let mut numeric_flags = NumericFlags::empty();
 
     let mut find_numeric_type = |expr: &Expr, _parent: &Expr| {
         let Some(builtin_type) = checker.semantic().resolve_builtin_symbol(expr) else {
             return;
         };
 
-        match builtin_type {
-            "int" => has_int = true,
-            "float" => has_float = true,
-            "complex" => has_complex = true,
-            _ => {}
+        numeric_flags.seen_builtin_type(builtin_type);
+    };
+
+    // Traverse the union, and remember which numeric types are found.
+    traverse_union(&mut find_numeric_type, checker.semantic(), annotation);
+
+    let Some(redundancy) = Redundancy::from_numeric_flags(numeric_flags) else {
+        return;
+    };
+
+    // Traverse the union a second time to construct the fix.
+    let mut flat_nodes: Vec<&Expr> = Vec::new();
+
+    let mut union_type = UnionLike::TypingUnion;
+    let mut remove_numeric_type = |expr: &'a Expr, parent: &'a Expr| {
+        let Some(builtin_type) = checker.semantic().resolve_builtin_symbol(expr) else {
+            // Keep type annotations that are not numeric.
+            flat_nodes.push(expr);
+            return;
+        };
+
+        if matches!(parent, Expr::BinOp(_)) {
+            union_type = UnionLike::BinOp;
+        }
+
+        // `int` is always dropped, since `float` or `complex` must be present.
+        // `float` is only dropped if `complex`` is present.
+        if (builtin_type == "float" && !numeric_flags.contains(NumericFlags::COMPLEX))
+            || (builtin_type != "float" && builtin_type != "int")
+        {
+            flat_nodes.push(expr);
         }
     };
 
-    traverse_union(&mut find_numeric_type, checker.semantic(), annotation);
+    // Traverse the union, and remember which numeric types are found.
+    traverse_union(&mut remove_numeric_type, checker.semantic(), annotation);
 
-    if has_complex {
-        if has_float {
-            checker.diagnostics.push(Diagnostic::new(
-                RedundantNumericUnion {
-                    redundancy: Redundancy::FloatComplex,
-                },
-                annotation.range(),
-            ));
+    // Generate the flattened fix once.
+    let fix = if let &[fix_expr] = flat_nodes.as_slice() {
+        generate_single_fix(checker, fix_expr, annotation)
+    } else {
+        match union_type {
+            UnionLike::BinOp => generate_bit_or_fix(checker, flat_nodes, annotation),
+            UnionLike::TypingUnion => generate_union_fix(checker, flat_nodes, annotation)
+                .ok()
+                .unwrap(),
         }
+    };
 
-        if has_int {
-            checker.diagnostics.push(Diagnostic::new(
-                RedundantNumericUnion {
-                    redundancy: Redundancy::IntComplex,
-                },
-                annotation.range(),
-            ));
+    checker.diagnostics.push(
+        Diagnostic::new(RedundantNumericUnion { redundancy }, annotation.range()).with_fix(fix),
+    );
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+enum Redundancy {
+    IntFloatComplex,
+    FloatComplex,
+    IntComplex,
+    IntFloat,
+}
+
+impl Redundancy {
+    pub(super) fn from_numeric_flags(numeric_flags: NumericFlags) -> Option<Self> {
+        match numeric_flags.bits() {
+            0b0110 => Some(Self::FloatComplex),
+            0b0111 => Some(Self::IntFloatComplex),
+            0b0101 => Some(Self::IntComplex),
+            0b0011 => Some(Self::IntFloat),
+            _ => None,
         }
-    } else if has_float && has_int {
-        checker.diagnostics.push(Diagnostic::new(
-            RedundantNumericUnion {
-                redundancy: Redundancy::IntFloat,
-            },
-            annotation.range(),
-        ));
     }
+}
+
+bitflags! {
+    #[derive(Copy, Clone, Debug, PartialEq, Eq)]
+    pub(super) struct NumericFlags: u8 {
+        /// `int`
+        const INT = 0b0001;
+        /// `float`
+        const FLOAT = 0b0010;
+        /// `complex`
+        const COMPLEX = 0b0100;
+    }
+}
+
+impl NumericFlags {
+    pub(super) fn seen_builtin_type(&mut self, name: &str) {
+        let flag: NumericFlags = match name {
+            "int" => NumericFlags::INT,
+            "float" => NumericFlags::FLOAT,
+            "complex" => NumericFlags::COMPLEX,
+            _ => {
+                return;
+            }
+        };
+        self.insert(flag);
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum UnionLike {
+    /// E.g., `typing.Union[int, str]`
+    TypingUnion,
+    /// E.g., `int | str`
+    BinOp,
+}
+
+// Generate a [`Fix`] for two or more type expressions, e.g. `int | float | complex`.
+fn generate_bit_or_fix(checker: &Checker, nodes: Vec<&Expr>, annotation: &Expr) -> Fix {
+    debug_assert!(nodes.len() >= 2, "At least two nodes required");
+
+    let new_expr = nodes
+        .into_iter()
+        .fold(None, |acc: Option<Expr>, right: &Expr| {
+            if let Some(left) = acc {
+                Some(Expr::BinOp(ExprBinOp {
+                    left: Box::new(left),
+                    op: Operator::BitOr,
+                    right: Box::new(right.clone()),
+                    range: TextRange::default(),
+                }))
+            } else {
+                Some(right.clone())
+            }
+        })
+        .unwrap();
+
+    Fix::safe_edit(Edit::range_replacement(
+        checker.generator().expr(&new_expr),
+        annotation.range(),
+    ))
+}
+
+// Generate a [`Fix`] for two or more type expresisons, e.g. `typing.Union[int, float, complex]`.
+fn generate_union_fix(checker: &Checker, nodes: Vec<&Expr>, annotation: &Expr) -> Result<Fix> {
+    debug_assert!(nodes.len() >= 2, "At least two nodes required");
+
+    // Request `typing.Union`
+    let (import_edit, binding) = checker.importer().get_or_import_symbol(
+        &ImportRequest::import_from("typing", "Union"),
+        annotation.start(),
+        checker.semantic(),
+    )?;
+
+    // Construct the expression as `Subscript[typing.Union, Tuple[expr, [expr, ...]]]`
+    let new_expr = Expr::Subscript(ExprSubscript {
+        range: TextRange::default(),
+        value: Box::new(Expr::Name(ExprName {
+            id: Name::new(binding),
+            ctx: ExprContext::Store,
+            range: TextRange::default(),
+        })),
+        slice: Box::new(if let [elt] = nodes.as_slice() {
+            (*elt).clone()
+        } else {
+            Expr::Tuple(ExprTuple {
+                elts: nodes.into_iter().cloned().collect(),
+                range: TextRange::default(),
+                ctx: ExprContext::Load,
+                parenthesized: false,
+            })
+        }),
+        ctx: ExprContext::Load,
+    });
+    Ok(Fix::safe_edits(
+        Edit::range_replacement(checker.generator().expr(&new_expr), annotation.range()),
+        [import_edit],
+    ))
+}
+
+// Generate a [`Fix`] for a single type expression, e.g. `int`.
+fn generate_single_fix(checker: &Checker, expr: &Expr, annotation: &Expr) -> Fix {
+    Fix::safe_edit(Edit::range_replacement(
+        checker.generator().expr(expr),
+        annotation.range(),
+    ))
 }

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/unnecessary_type_union.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/unnecessary_type_union.rs
@@ -25,6 +25,11 @@ use crate::checkers::ast::Checker;
 /// ```pyi
 /// field: type[int | float] | str
 /// ```
+///
+/// ## Fix safety
+///
+/// This rule's fix is marked as safe; however, the fix will flatten nested
+/// unions type expressions into a single top-level union.
 #[violation]
 pub struct UnnecessaryTypeUnion {
     members: Vec<Name>,
@@ -70,116 +75,132 @@ pub(crate) fn unnecessary_type_union<'a>(checker: &mut Checker, union: &'a Expr)
     let mut type_exprs: Vec<&Expr> = Vec::new();
     let mut other_exprs: Vec<&Expr> = Vec::new();
 
-    let mut collect_type_exprs = |expr: &'a Expr, _parent: &'a Expr| match expr {
-        Expr::Subscript(ast::ExprSubscript { slice, value, .. }) => {
-            if semantic.match_builtin_expr(value, "type") {
-                type_exprs.push(slice);
-            } else {
-                other_exprs.push(expr);
-            }
+    let mut has_pep604_union = false;
+    let mut collect_type_exprs = |expr: &'a Expr, parent: &'a Expr| {
+        if matches!(parent, Expr::BinOp(_)) {
+            has_pep604_union = true;
         }
-        _ => other_exprs.push(expr),
+        match expr {
+            Expr::Subscript(ast::ExprSubscript { slice, value, .. }) => {
+                if semantic.match_builtin_expr(value, "type") {
+                    type_exprs.push(slice);
+                } else {
+                    other_exprs.push(expr);
+                }
+            }
+            _ => other_exprs.push(expr),
+        }
     };
 
     traverse_union(&mut collect_type_exprs, semantic, union);
 
-    if type_exprs.len() > 1 {
-        let type_members: Vec<Name> = type_exprs
-            .clone()
-            .into_iter()
-            .map(|type_expr| Name::new(checker.locator().slice(type_expr)))
-            .collect();
-
-        let mut diagnostic = Diagnostic::new(
-            UnnecessaryTypeUnion {
-                members: type_members.clone(),
-                is_pep604_union: subscript.is_none(),
-            },
-            union.range(),
-        );
-
-        if semantic.has_builtin_binding("type") {
-            let content = if let Some(subscript) = subscript {
-                let types = &Expr::Subscript(ast::ExprSubscript {
-                    value: Box::new(Expr::Name(ast::ExprName {
-                        id: Name::new_static("type"),
-                        ctx: ExprContext::Load,
-                        range: TextRange::default(),
-                    })),
-                    slice: Box::new(Expr::Subscript(ast::ExprSubscript {
-                        value: subscript.value.clone(),
-                        slice: Box::new(Expr::Tuple(ast::ExprTuple {
-                            elts: type_members
-                                .into_iter()
-                                .map(|type_member| {
-                                    Expr::Name(ast::ExprName {
-                                        id: type_member,
-                                        ctx: ExprContext::Load,
-                                        range: TextRange::default(),
-                                    })
-                                })
-                                .collect(),
-                            ctx: ExprContext::Load,
-                            range: TextRange::default(),
-                            parenthesized: true,
-                        })),
-                        ctx: ExprContext::Load,
-                        range: TextRange::default(),
-                    })),
-                    ctx: ExprContext::Load,
-                    range: TextRange::default(),
-                });
-
-                if other_exprs.is_empty() {
-                    checker.generator().expr(types)
-                } else {
-                    let mut exprs = Vec::new();
-                    exprs.push(types);
-                    exprs.extend(other_exprs);
-
-                    let union = Expr::Subscript(ast::ExprSubscript {
-                        value: subscript.value.clone(),
-                        slice: Box::new(Expr::Tuple(ast::ExprTuple {
-                            elts: exprs.into_iter().cloned().collect(),
-                            ctx: ExprContext::Load,
-                            range: TextRange::default(),
-                            parenthesized: true,
-                        })),
-                        ctx: ExprContext::Load,
-                        range: TextRange::default(),
-                    });
-
-                    checker.generator().expr(&union)
-                }
-            } else {
-                let elts: Vec<Expr> = type_exprs.into_iter().cloned().collect();
-                let types = Expr::Subscript(ast::ExprSubscript {
-                    value: Box::new(Expr::Name(ast::ExprName {
-                        id: Name::new_static("type"),
-                        ctx: ExprContext::Load,
-                        range: TextRange::default(),
-                    })),
-                    slice: Box::new(pep_604_union(&elts)),
-                    ctx: ExprContext::Load,
-                    range: TextRange::default(),
-                });
-
-                if other_exprs.is_empty() {
-                    checker.generator().expr(&types)
-                } else {
-                    let elts: Vec<Expr> = std::iter::once(types)
-                        .chain(other_exprs.into_iter().cloned())
-                        .collect();
-                    checker.generator().expr(&pep_604_union(&elts))
-                }
-            };
-
-            diagnostic.set_fix(Fix::safe_edit(Edit::range_replacement(
-                content,
-                union.range(),
-            )));
-        }
-
-        checker.diagnostics.push(diagnostic);
+    // Return if zero or one `type` expressions are found.
+    if type_exprs.len() <= 1 {
+        return;
     }
+
+    let type_members: Vec<Name> = type_exprs
+        .clone()
+        .into_iter()
+        .map(|type_expr| Name::new(checker.locator().slice(type_expr)))
+        .collect();
+
+    let mut diagnostic = Diagnostic::new(
+        UnnecessaryTypeUnion {
+            members: type_members.clone(),
+            is_pep604_union: subscript.is_none(),
+        },
+        union.range(),
+    );
+
+    if semantic.has_builtin_binding("type") {
+        // Construct the content for the [`Fix`] based on if we encountered a PEP604 union.
+        #[allow(clippy::if_not_else)]
+        let content = if !has_pep604_union {
+            // `typing.Union`
+            let Some(subscript) = subscript else {
+                return;
+            };
+            let types = &Expr::Subscript(ast::ExprSubscript {
+                value: Box::new(Expr::Name(ast::ExprName {
+                    id: Name::new_static("type"),
+                    ctx: ExprContext::Load,
+                    range: TextRange::default(),
+                })),
+                slice: Box::new(Expr::Subscript(ast::ExprSubscript {
+                    value: subscript.value.clone(),
+                    slice: Box::new(Expr::Tuple(ast::ExprTuple {
+                        elts: type_members
+                            .into_iter()
+                            .map(|type_member| {
+                                Expr::Name(ast::ExprName {
+                                    id: type_member,
+                                    ctx: ExprContext::Load,
+                                    range: TextRange::default(),
+                                })
+                            })
+                            .collect(),
+                        ctx: ExprContext::Load,
+                        range: TextRange::default(),
+                        parenthesized: true,
+                    })),
+                    ctx: ExprContext::Load,
+                    range: TextRange::default(),
+                })),
+                ctx: ExprContext::Load,
+                range: TextRange::default(),
+            });
+
+            if other_exprs.is_empty() {
+                checker.generator().expr(types)
+            } else {
+                let mut exprs = Vec::new();
+                exprs.push(types);
+                exprs.extend(other_exprs);
+
+                let union = Expr::Subscript(ast::ExprSubscript {
+                    value: subscript.value.clone(),
+                    slice: Box::new(Expr::Tuple(ast::ExprTuple {
+                        elts: exprs.into_iter().cloned().collect(),
+                        ctx: ExprContext::Load,
+                        range: TextRange::default(),
+                        parenthesized: true,
+                    })),
+                    ctx: ExprContext::Load,
+                    range: TextRange::default(),
+                });
+
+                checker.generator().expr(&union)
+            }
+        } else {
+            // PEP604 union
+            let elts: Vec<Expr> = type_exprs.into_iter().cloned().collect();
+            let types = Expr::Subscript(ast::ExprSubscript {
+                value: Box::new(Expr::Name(ast::ExprName {
+                    id: Name::new_static("type"),
+                    ctx: ExprContext::Load,
+                    range: TextRange::default(),
+                })),
+                slice: Box::new(pep_604_union(&elts)),
+                ctx: ExprContext::Load,
+                range: TextRange::default(),
+            });
+
+            if other_exprs.is_empty() {
+                checker.generator().expr(&types)
+            } else {
+                let elts: Vec<Expr> = std::iter::once(types)
+                    .chain(other_exprs.into_iter().cloned())
+                    .collect();
+                checker.generator().expr(&pep_604_union(&elts))
+            }
+        };
+
+        diagnostic.set_fix(Fix::safe_edit(Edit::range_replacement(
+            content,
+            union.range(),
+        )));
+    }
+
+    checker.diagnostics.push(diagnostic);
 }

--- a/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI016_PYI016.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI016_PYI016.py.snap
@@ -611,6 +611,9 @@ PYI016.py:86:28: PYI016 [*] Duplicate union member `int`
 85 85 | # we incorrectly re-checked the nested union).
 86    |-field25: typing.Union[int, int | int]  # PYI016: Duplicate union member `int`
    86 |+field25: int  # PYI016: Duplicate union member `int`
+87 87 | 
+88 88 | 
+89 89 | # Should emit in cases with nested `typing.Union`
 
 PYI016.py:86:34: PYI016 [*] Duplicate union member `int`
    |
@@ -627,3 +630,231 @@ PYI016.py:86:34: PYI016 [*] Duplicate union member `int`
 85 85 | # we incorrectly re-checked the nested union).
 86    |-field25: typing.Union[int, int | int]  # PYI016: Duplicate union member `int`
    86 |+field25: int  # PYI016: Duplicate union member `int`
+87 87 | 
+88 88 | 
+89 89 | # Should emit in cases with nested `typing.Union`
+
+PYI016.py:90:41: PYI016 [*] Duplicate union member `int`
+   |
+89 | # Should emit in cases with nested `typing.Union`
+90 | field26: typing.Union[typing.Union[int, int]]  # PYI016: Duplicate union member `int`
+   |                                         ^^^ PYI016
+91 | 
+92 | # Should emit in cases with nested `typing.Union`
+   |
+   = help: Remove duplicate union member `int`
+
+ℹ Safe fix
+87 87 | 
+88 88 | 
+89 89 | # Should emit in cases with nested `typing.Union`
+90    |-field26: typing.Union[typing.Union[int, int]]  # PYI016: Duplicate union member `int`
+   90 |+field26: int  # PYI016: Duplicate union member `int`
+91 91 | 
+92 92 | # Should emit in cases with nested `typing.Union`
+93 93 | field27: typing.Union[typing.Union[typing.Union[int, int]]]  # PYI016: Duplicate union member `int`
+
+PYI016.py:93:54: PYI016 [*] Duplicate union member `int`
+   |
+92 | # Should emit in cases with nested `typing.Union`
+93 | field27: typing.Union[typing.Union[typing.Union[int, int]]]  # PYI016: Duplicate union member `int`
+   |                                                      ^^^ PYI016
+94 | 
+95 | # Should emit in cases with mixed `typing.Union` and `|`
+   |
+   = help: Remove duplicate union member `int`
+
+ℹ Safe fix
+90 90 | field26: typing.Union[typing.Union[int, int]]  # PYI016: Duplicate union member `int`
+91 91 | 
+92 92 | # Should emit in cases with nested `typing.Union`
+93    |-field27: typing.Union[typing.Union[typing.Union[int, int]]]  # PYI016: Duplicate union member `int`
+   93 |+field27: int  # PYI016: Duplicate union member `int`
+94 94 | 
+95 95 | # Should emit in cases with mixed `typing.Union` and `|`
+96 96 | field28: typing.Union[int | int]  # Error
+
+PYI016.py:96:29: PYI016 [*] Duplicate union member `int`
+   |
+95 | # Should emit in cases with mixed `typing.Union` and `|`
+96 | field28: typing.Union[int | int]  # Error
+   |                             ^^^ PYI016
+97 | 
+98 | # Should emit twice in cases with multiple nested `typing.Union`
+   |
+   = help: Remove duplicate union member `int`
+
+ℹ Safe fix
+93 93 | field27: typing.Union[typing.Union[typing.Union[int, int]]]  # PYI016: Duplicate union member `int`
+94 94 | 
+95 95 | # Should emit in cases with mixed `typing.Union` and `|`
+96    |-field28: typing.Union[int | int]  # Error
+   96 |+field28: int  # Error
+97 97 | 
+98 98 | # Should emit twice in cases with multiple nested `typing.Union`
+99 99 | field29: typing.Union[int, typing.Union[typing.Union[int, int]]]  # Error
+
+PYI016.py:99:54: PYI016 [*] Duplicate union member `int`
+    |
+ 98 | # Should emit twice in cases with multiple nested `typing.Union`
+ 99 | field29: typing.Union[int, typing.Union[typing.Union[int, int]]]  # Error
+    |                                                      ^^^ PYI016
+100 | 
+101 | # Should emit once in cases with multiple nested `typing.Union`
+    |
+    = help: Remove duplicate union member `int`
+
+ℹ Safe fix
+96  96  | field28: typing.Union[int | int]  # Error
+97  97  | 
+98  98  | # Should emit twice in cases with multiple nested `typing.Union`
+99      |-field29: typing.Union[int, typing.Union[typing.Union[int, int]]]  # Error
+    99  |+field29: int  # Error
+100 100 | 
+101 101 | # Should emit once in cases with multiple nested `typing.Union`
+102 102 | field30: typing.Union[int, typing.Union[typing.Union[int, str]]]  # Error
+
+PYI016.py:99:59: PYI016 [*] Duplicate union member `int`
+    |
+ 98 | # Should emit twice in cases with multiple nested `typing.Union`
+ 99 | field29: typing.Union[int, typing.Union[typing.Union[int, int]]]  # Error
+    |                                                           ^^^ PYI016
+100 | 
+101 | # Should emit once in cases with multiple nested `typing.Union`
+    |
+    = help: Remove duplicate union member `int`
+
+ℹ Safe fix
+96  96  | field28: typing.Union[int | int]  # Error
+97  97  | 
+98  98  | # Should emit twice in cases with multiple nested `typing.Union`
+99      |-field29: typing.Union[int, typing.Union[typing.Union[int, int]]]  # Error
+    99  |+field29: int  # Error
+100 100 | 
+101 101 | # Should emit once in cases with multiple nested `typing.Union`
+102 102 | field30: typing.Union[int, typing.Union[typing.Union[int, str]]]  # Error
+
+PYI016.py:102:54: PYI016 [*] Duplicate union member `int`
+    |
+101 | # Should emit once in cases with multiple nested `typing.Union`
+102 | field30: typing.Union[int, typing.Union[typing.Union[int, str]]]  # Error
+    |                                                      ^^^ PYI016
+103 | 
+104 | # Should emit once, and fix to `typing.Union[float, int]`
+    |
+    = help: Remove duplicate union member `int`
+
+ℹ Safe fix
+99  99  | field29: typing.Union[int, typing.Union[typing.Union[int, int]]]  # Error
+100 100 | 
+101 101 | # Should emit once in cases with multiple nested `typing.Union`
+102     |-field30: typing.Union[int, typing.Union[typing.Union[int, str]]]  # Error
+    102 |+field30: typing.Union[int, str]  # Error
+103 103 | 
+104 104 | # Should emit once, and fix to `typing.Union[float, int]`
+105 105 | field31: typing.Union[float, typing.Union[int | int]]  # Error
+
+PYI016.py:105:49: PYI016 [*] Duplicate union member `int`
+    |
+104 | # Should emit once, and fix to `typing.Union[float, int]`
+105 | field31: typing.Union[float, typing.Union[int | int]]  # Error
+    |                                                 ^^^ PYI016
+106 | 
+107 | # Should emit once, and fix to `typing.Union[float, int]`
+    |
+    = help: Remove duplicate union member `int`
+
+ℹ Safe fix
+102 102 | field30: typing.Union[int, typing.Union[typing.Union[int, str]]]  # Error
+103 103 | 
+104 104 | # Should emit once, and fix to `typing.Union[float, int]`
+105     |-field31: typing.Union[float, typing.Union[int | int]]  # Error
+    105 |+field31: float | int  # Error
+106 106 | 
+107 107 | # Should emit once, and fix to `typing.Union[float, int]`
+108 108 | field32: typing.Union[float, typing.Union[int | int | int]]  # Error
+
+PYI016.py:108:49: PYI016 [*] Duplicate union member `int`
+    |
+107 | # Should emit once, and fix to `typing.Union[float, int]`
+108 | field32: typing.Union[float, typing.Union[int | int | int]]  # Error
+    |                                                 ^^^ PYI016
+109 | 
+110 | # Test case for mixed union type fix
+    |
+    = help: Remove duplicate union member `int`
+
+ℹ Safe fix
+105 105 | field31: typing.Union[float, typing.Union[int | int]]  # Error
+106 106 | 
+107 107 | # Should emit once, and fix to `typing.Union[float, int]`
+108     |-field32: typing.Union[float, typing.Union[int | int | int]]  # Error
+    108 |+field32: float | int  # Error
+109 109 | 
+110 110 | # Test case for mixed union type fix
+111 111 | field33: typing.Union[typing.Union[int | int] | typing.Union[int | int]] # Error
+
+PYI016.py:108:55: PYI016 [*] Duplicate union member `int`
+    |
+107 | # Should emit once, and fix to `typing.Union[float, int]`
+108 | field32: typing.Union[float, typing.Union[int | int | int]]  # Error
+    |                                                       ^^^ PYI016
+109 | 
+110 | # Test case for mixed union type fix
+    |
+    = help: Remove duplicate union member `int`
+
+ℹ Safe fix
+105 105 | field31: typing.Union[float, typing.Union[int | int]]  # Error
+106 106 | 
+107 107 | # Should emit once, and fix to `typing.Union[float, int]`
+108     |-field32: typing.Union[float, typing.Union[int | int | int]]  # Error
+    108 |+field32: float | int  # Error
+109 109 | 
+110 110 | # Test case for mixed union type fix
+111 111 | field33: typing.Union[typing.Union[int | int] | typing.Union[int | int]] # Error
+
+PYI016.py:111:42: PYI016 [*] Duplicate union member `int`
+    |
+110 | # Test case for mixed union type fix
+111 | field33: typing.Union[typing.Union[int | int] | typing.Union[int | int]] # Error
+    |                                          ^^^ PYI016
+    |
+    = help: Remove duplicate union member `int`
+
+ℹ Safe fix
+108 108 | field32: typing.Union[float, typing.Union[int | int | int]]  # Error
+109 109 | 
+110 110 | # Test case for mixed union type fix
+111     |-field33: typing.Union[typing.Union[int | int] | typing.Union[int | int]] # Error
+    111 |+field33: int # Error
+
+PYI016.py:111:62: PYI016 [*] Duplicate union member `int`
+    |
+110 | # Test case for mixed union type fix
+111 | field33: typing.Union[typing.Union[int | int] | typing.Union[int | int]] # Error
+    |                                                              ^^^ PYI016
+    |
+    = help: Remove duplicate union member `int`
+
+ℹ Safe fix
+108 108 | field32: typing.Union[float, typing.Union[int | int | int]]  # Error
+109 109 | 
+110 110 | # Test case for mixed union type fix
+111     |-field33: typing.Union[typing.Union[int | int] | typing.Union[int | int]] # Error
+    111 |+field33: int # Error
+
+PYI016.py:111:68: PYI016 [*] Duplicate union member `int`
+    |
+110 | # Test case for mixed union type fix
+111 | field33: typing.Union[typing.Union[int | int] | typing.Union[int | int]] # Error
+    |                                                                    ^^^ PYI016
+    |
+    = help: Remove duplicate union member `int`
+
+ℹ Safe fix
+108 108 | field32: typing.Union[float, typing.Union[int | int | int]]  # Error
+109 109 | 
+110 110 | # Test case for mixed union type fix
+111     |-field33: typing.Union[typing.Union[int | int] | typing.Union[int | int]] # Error
+    111 |+field33: int # Error

--- a/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI016_PYI016.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI016_PYI016.py.snap
@@ -156,7 +156,7 @@ PYI016.py:27:22: PYI016 [*] Duplicate union member `int`
 25 25 | 
 26 26 | # Should emit for strangely-bracketed unions.
 27    |-field8: int | (str | int)  # PYI016: Duplicate union member `int`
-   27 |+field8: int | (str)  # PYI016: Duplicate union member `int`
+   27 |+field8: int | str  # PYI016: Duplicate union member `int`
 28 28 | 
 29 29 | # Should handle user brackets when fixing.
 30 30 | field9: int | (int | str)  # PYI016: Duplicate union member `int`
@@ -175,7 +175,7 @@ PYI016.py:30:16: PYI016 [*] Duplicate union member `int`
 28 28 | 
 29 29 | # Should handle user brackets when fixing.
 30    |-field9: int | (int | str)  # PYI016: Duplicate union member `int`
-   30 |+field9: int | (str)  # PYI016: Duplicate union member `int`
+   30 |+field9: int | str  # PYI016: Duplicate union member `int`
 31 31 | field10: (str | int) | str  # PYI016: Duplicate union member `str`
 32 32 | 
 33 33 | # Should emit for nested unions.
@@ -235,7 +235,7 @@ PYI016.py:37:16: PYI016 [*] Duplicate union member `int`
 35 35 | 
 36 36 | # Should emit for unions with more than two cases
 37    |-field12: int | int | int  # Error
-   37 |+field12: int | int  # Error
+   37 |+field12: int  # Error
 38 38 | field13: int | int | int | int  # Error
 39 39 | 
 40 40 | # Should emit for unions with more than two cases, even if not directly adjacent
@@ -254,7 +254,7 @@ PYI016.py:37:22: PYI016 [*] Duplicate union member `int`
 35 35 | 
 36 36 | # Should emit for unions with more than two cases
 37    |-field12: int | int | int  # Error
-   37 |+field12: int | int  # Error
+   37 |+field12: int  # Error
 38 38 | field13: int | int | int | int  # Error
 39 39 | 
 40 40 | # Should emit for unions with more than two cases, even if not directly adjacent
@@ -275,7 +275,7 @@ PYI016.py:38:16: PYI016 [*] Duplicate union member `int`
 36 36 | # Should emit for unions with more than two cases
 37 37 | field12: int | int | int  # Error
 38    |-field13: int | int | int | int  # Error
-   38 |+field13: int | int | int  # Error
+   38 |+field13: int  # Error
 39 39 | 
 40 40 | # Should emit for unions with more than two cases, even if not directly adjacent
 41 41 | field14: int | int | str | int  # Error
@@ -296,7 +296,7 @@ PYI016.py:38:22: PYI016 [*] Duplicate union member `int`
 36 36 | # Should emit for unions with more than two cases
 37 37 | field12: int | int | int  # Error
 38    |-field13: int | int | int | int  # Error
-   38 |+field13: int | int | int  # Error
+   38 |+field13: int  # Error
 39 39 | 
 40 40 | # Should emit for unions with more than two cases, even if not directly adjacent
 41 41 | field14: int | int | str | int  # Error
@@ -317,7 +317,7 @@ PYI016.py:38:28: PYI016 [*] Duplicate union member `int`
 36 36 | # Should emit for unions with more than two cases
 37 37 | field12: int | int | int  # Error
 38    |-field13: int | int | int | int  # Error
-   38 |+field13: int | int | int  # Error
+   38 |+field13: int  # Error
 39 39 | 
 40 40 | # Should emit for unions with more than two cases, even if not directly adjacent
 41 41 | field14: int | int | str | int  # Error
@@ -337,7 +337,7 @@ PYI016.py:41:16: PYI016 [*] Duplicate union member `int`
 39 39 | 
 40 40 | # Should emit for unions with more than two cases, even if not directly adjacent
 41    |-field14: int | int | str | int  # Error
-   41 |+field14: int | str | int  # Error
+   41 |+field14: int | str  # Error
 42 42 | 
 43 43 | # Should emit for duplicate literal types; also covered by PYI030
 44 44 | field15: typing.Literal[1] | typing.Literal[1]  # Error
@@ -357,7 +357,7 @@ PYI016.py:41:28: PYI016 [*] Duplicate union member `int`
 39 39 | 
 40 40 | # Should emit for unions with more than two cases, even if not directly adjacent
 41    |-field14: int | int | str | int  # Error
-   41 |+field14: int | int | str  # Error
+   41 |+field14: int | str  # Error
 42 42 | 
 43 43 | # Should emit for duplicate literal types; also covered by PYI030
 44 44 | field15: typing.Literal[1] | typing.Literal[1]  # Error
@@ -467,7 +467,7 @@ PYI016.py:69:28: PYI016 [*] Duplicate union member `int`
 67 67 | 
 68 68 | # Should emit in cases with mixed `typing.Union` and `|`
 69    |-field21: typing.Union[int, int | str]  # Error
-   69 |+field21: typing.Union[int, str]  # Error
+   69 |+field21: int | str  # Error
 70 70 | 
 71 71 | # Should emit only once in cases with multiple nested `typing.Union`
 72 72 | field22: typing.Union[int, typing.Union[int, typing.Union[int, int]]]  # Error
@@ -543,15 +543,16 @@ PYI016.py:76:12: PYI016 [*] Duplicate union member `set[int]`
    |
    = help: Remove duplicate union member `set[int]`
 
-ℹ Safe fix
+ℹ Unsafe fix
+72 72 | field22: typing.Union[int, typing.Union[int, typing.Union[int, int]]]  # Error
 73 73 | 
 74 74 | # Should emit in cases with newlines
-75 75 | field23: set[  # foo
+75    |-field23: set[  # foo
 76    |-    int] | set[int]
-   76 |+    int]
-77 77 | 
-78 78 | # Should emit twice (once for each `int` in the nested union, both of which are
-79 79 | # duplicates of the outer `int`), but not three times (which would indicate that
+   75 |+field23: set[int]
+77 76 | 
+78 77 | # Should emit twice (once for each `int` in the nested union, both of which are
+79 78 | # duplicates of the outer `int`), but not three times (which would indicate that
 
 PYI016.py:81:41: PYI016 [*] Duplicate union member `int`
    |
@@ -609,7 +610,7 @@ PYI016.py:86:28: PYI016 [*] Duplicate union member `int`
 84 84 | # duplicates of the outer `int`), but not three times (which would indicate that
 85 85 | # we incorrectly re-checked the nested union).
 86    |-field25: typing.Union[int, int | int]  # PYI016: Duplicate union member `int`
-   86 |+field25: typing.Union[int, int]  # PYI016: Duplicate union member `int`
+   86 |+field25: int  # PYI016: Duplicate union member `int`
 
 PYI016.py:86:34: PYI016 [*] Duplicate union member `int`
    |
@@ -625,4 +626,4 @@ PYI016.py:86:34: PYI016 [*] Duplicate union member `int`
 84 84 | # duplicates of the outer `int`), but not three times (which would indicate that
 85 85 | # we incorrectly re-checked the nested union).
 86    |-field25: typing.Union[int, int | int]  # PYI016: Duplicate union member `int`
-   86 |+field25: typing.Union[int, int]  # PYI016: Duplicate union member `int`
+   86 |+field25: int  # PYI016: Duplicate union member `int`

--- a/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI016_PYI016.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI016_PYI016.py.snap
@@ -395,7 +395,7 @@ PYI016.py:57:5: PYI016 [*] Duplicate union member `set[int]`
    |
    = help: Remove duplicate union member `set[int]`
 
-ℹ Safe fix
+ℹ Unsafe fix
 50 50 | field17: dict[int, int]  # OK
 51 51 | 
 52 52 | # Should emit in cases with newlines
@@ -407,7 +407,7 @@ PYI016.py:57:5: PYI016 [*] Duplicate union member `set[int]`
 58    |-        int  # bar
 59    |-    ],
 60    |-]  # Error, newline and comment will not be emitted in message
-   53 |+field18: typing.Union[set[int]]  # Error, newline and comment will not be emitted in message
+   53 |+field18: set[int]  # Error, newline and comment will not be emitted in message
 61 54 | 
 62 55 | # Should emit in cases with `typing.Union` instead of `|`
 63 56 | field19: typing.Union[int, int]  # Error
@@ -427,7 +427,7 @@ PYI016.py:63:28: PYI016 [*] Duplicate union member `int`
 61 61 | 
 62 62 | # Should emit in cases with `typing.Union` instead of `|`
 63    |-field19: typing.Union[int, int]  # Error
-   63 |+field19: typing.Union[int]  # Error
+   63 |+field19: int  # Error
 64 64 | 
 65 65 | # Should emit in cases with nested `typing.Union`
 66 66 | field20: typing.Union[int, typing.Union[int, str]]  # Error
@@ -487,7 +487,7 @@ PYI016.py:72:41: PYI016 [*] Duplicate union member `int`
 70 70 | 
 71 71 | # Should emit only once in cases with multiple nested `typing.Union`
 72    |-field22: typing.Union[int, typing.Union[int, typing.Union[int, int]]]  # Error
-   72 |+field22: typing.Union[int]  # Error
+   72 |+field22: int  # Error
 73 73 | 
 74 74 | # Should emit in cases with newlines
 75 75 | field23: set[  # foo
@@ -507,7 +507,7 @@ PYI016.py:72:59: PYI016 [*] Duplicate union member `int`
 70 70 | 
 71 71 | # Should emit only once in cases with multiple nested `typing.Union`
 72    |-field22: typing.Union[int, typing.Union[int, typing.Union[int, int]]]  # Error
-   72 |+field22: typing.Union[int]  # Error
+   72 |+field22: int  # Error
 73 73 | 
 74 74 | # Should emit in cases with newlines
 75 75 | field23: set[  # foo
@@ -527,7 +527,7 @@ PYI016.py:72:64: PYI016 [*] Duplicate union member `int`
 70 70 | 
 71 71 | # Should emit only once in cases with multiple nested `typing.Union`
 72    |-field22: typing.Union[int, typing.Union[int, typing.Union[int, int]]]  # Error
-   72 |+field22: typing.Union[int]  # Error
+   72 |+field22: int  # Error
 73 73 | 
 74 74 | # Should emit in cases with newlines
 75 75 | field23: set[  # foo
@@ -569,7 +569,7 @@ PYI016.py:81:41: PYI016 [*] Duplicate union member `int`
 79 79 | # duplicates of the outer `int`), but not three times (which would indicate that
 80 80 | # we incorrectly re-checked the nested union).
 81    |-field24: typing.Union[int, typing.Union[int, int]]  # PYI016: Duplicate union member `int`
-   81 |+field24: typing.Union[int]  # PYI016: Duplicate union member `int`
+   81 |+field24: int  # PYI016: Duplicate union member `int`
 82 82 | 
 83 83 | # Should emit twice (once for each `int` in the nested union, both of which are
 84 84 | # duplicates of the outer `int`), but not three times (which would indicate that
@@ -590,7 +590,7 @@ PYI016.py:81:46: PYI016 [*] Duplicate union member `int`
 79 79 | # duplicates of the outer `int`), but not three times (which would indicate that
 80 80 | # we incorrectly re-checked the nested union).
 81    |-field24: typing.Union[int, typing.Union[int, int]]  # PYI016: Duplicate union member `int`
-   81 |+field24: typing.Union[int]  # PYI016: Duplicate union member `int`
+   81 |+field24: int  # PYI016: Duplicate union member `int`
 82 82 | 
 83 83 | # Should emit twice (once for each `int` in the nested union, both of which are
 84 84 | # duplicates of the outer `int`), but not three times (which would indicate that

--- a/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI016_PYI016.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI016_PYI016.py.snap
@@ -382,7 +382,7 @@ PYI016.py:44:30: PYI016 [*] Duplicate union member `typing.Literal[1]`
 46 46 | # Shouldn't emit if in new parent type
 47 47 | field16: int | dict[int, str]  # OK
 
-PYI016.py:57:5: PYI016 Duplicate union member `set[int]`
+PYI016.py:57:5: PYI016 [*] Duplicate union member `set[int]`
    |
 55 |           int  # foo
 56 |       ],
@@ -395,7 +395,24 @@ PYI016.py:57:5: PYI016 Duplicate union member `set[int]`
    |
    = help: Remove duplicate union member `set[int]`
 
-PYI016.py:63:28: PYI016 Duplicate union member `int`
+ℹ Safe fix
+50 50 | field17: dict[int, int]  # OK
+51 51 | 
+52 52 | # Should emit in cases with newlines
+53    |-field18: typing.Union[
+54    |-    set[
+55    |-        int  # foo
+56    |-    ],
+57    |-    set[
+58    |-        int  # bar
+59    |-    ],
+60    |-]  # Error, newline and comment will not be emitted in message
+   53 |+field18: typing.Union[set[int]]  # Error, newline and comment will not be emitted in message
+61 54 | 
+62 55 | # Should emit in cases with `typing.Union` instead of `|`
+63 56 | field19: typing.Union[int, int]  # Error
+
+PYI016.py:63:28: PYI016 [*] Duplicate union member `int`
    |
 62 | # Should emit in cases with `typing.Union` instead of `|`
 63 | field19: typing.Union[int, int]  # Error
@@ -405,7 +422,17 @@ PYI016.py:63:28: PYI016 Duplicate union member `int`
    |
    = help: Remove duplicate union member `int`
 
-PYI016.py:66:41: PYI016 Duplicate union member `int`
+ℹ Safe fix
+60 60 | ]  # Error, newline and comment will not be emitted in message
+61 61 | 
+62 62 | # Should emit in cases with `typing.Union` instead of `|`
+63    |-field19: typing.Union[int, int]  # Error
+   63 |+field19: typing.Union[int]  # Error
+64 64 | 
+65 65 | # Should emit in cases with nested `typing.Union`
+66 66 | field20: typing.Union[int, typing.Union[int, str]]  # Error
+
+PYI016.py:66:41: PYI016 [*] Duplicate union member `int`
    |
 65 | # Should emit in cases with nested `typing.Union`
 66 | field20: typing.Union[int, typing.Union[int, str]]  # Error
@@ -414,6 +441,16 @@ PYI016.py:66:41: PYI016 Duplicate union member `int`
 68 | # Should emit in cases with mixed `typing.Union` and `|`
    |
    = help: Remove duplicate union member `int`
+
+ℹ Safe fix
+63 63 | field19: typing.Union[int, int]  # Error
+64 64 | 
+65 65 | # Should emit in cases with nested `typing.Union`
+66    |-field20: typing.Union[int, typing.Union[int, str]]  # Error
+   66 |+field20: typing.Union[int, str]  # Error
+67 67 | 
+68 68 | # Should emit in cases with mixed `typing.Union` and `|`
+69 69 | field21: typing.Union[int, int | str]  # Error
 
 PYI016.py:69:28: PYI016 [*] Duplicate union member `int`
    |
@@ -435,7 +472,7 @@ PYI016.py:69:28: PYI016 [*] Duplicate union member `int`
 71 71 | # Should emit only once in cases with multiple nested `typing.Union`
 72 72 | field22: typing.Union[int, typing.Union[int, typing.Union[int, int]]]  # Error
 
-PYI016.py:72:41: PYI016 Duplicate union member `int`
+PYI016.py:72:41: PYI016 [*] Duplicate union member `int`
    |
 71 | # Should emit only once in cases with multiple nested `typing.Union`
 72 | field22: typing.Union[int, typing.Union[int, typing.Union[int, int]]]  # Error
@@ -445,7 +482,17 @@ PYI016.py:72:41: PYI016 Duplicate union member `int`
    |
    = help: Remove duplicate union member `int`
 
-PYI016.py:72:59: PYI016 Duplicate union member `int`
+ℹ Safe fix
+69 69 | field21: typing.Union[int, int | str]  # Error
+70 70 | 
+71 71 | # Should emit only once in cases with multiple nested `typing.Union`
+72    |-field22: typing.Union[int, typing.Union[int, typing.Union[int, int]]]  # Error
+   72 |+field22: typing.Union[int]  # Error
+73 73 | 
+74 74 | # Should emit in cases with newlines
+75 75 | field23: set[  # foo
+
+PYI016.py:72:59: PYI016 [*] Duplicate union member `int`
    |
 71 | # Should emit only once in cases with multiple nested `typing.Union`
 72 | field22: typing.Union[int, typing.Union[int, typing.Union[int, int]]]  # Error
@@ -455,7 +502,17 @@ PYI016.py:72:59: PYI016 Duplicate union member `int`
    |
    = help: Remove duplicate union member `int`
 
-PYI016.py:72:64: PYI016 Duplicate union member `int`
+ℹ Safe fix
+69 69 | field21: typing.Union[int, int | str]  # Error
+70 70 | 
+71 71 | # Should emit only once in cases with multiple nested `typing.Union`
+72    |-field22: typing.Union[int, typing.Union[int, typing.Union[int, int]]]  # Error
+   72 |+field22: typing.Union[int]  # Error
+73 73 | 
+74 74 | # Should emit in cases with newlines
+75 75 | field23: set[  # foo
+
+PYI016.py:72:64: PYI016 [*] Duplicate union member `int`
    |
 71 | # Should emit only once in cases with multiple nested `typing.Union`
 72 | field22: typing.Union[int, typing.Union[int, typing.Union[int, int]]]  # Error
@@ -464,6 +521,16 @@ PYI016.py:72:64: PYI016 Duplicate union member `int`
 74 | # Should emit in cases with newlines
    |
    = help: Remove duplicate union member `int`
+
+ℹ Safe fix
+69 69 | field21: typing.Union[int, int | str]  # Error
+70 70 | 
+71 71 | # Should emit only once in cases with multiple nested `typing.Union`
+72    |-field22: typing.Union[int, typing.Union[int, typing.Union[int, int]]]  # Error
+   72 |+field22: typing.Union[int]  # Error
+73 73 | 
+74 74 | # Should emit in cases with newlines
+75 75 | field23: set[  # foo
 
 PYI016.py:76:12: PYI016 [*] Duplicate union member `set[int]`
    |
@@ -486,7 +553,7 @@ PYI016.py:76:12: PYI016 [*] Duplicate union member `set[int]`
 78 78 | # Should emit twice (once for each `int` in the nested union, both of which are
 79 79 | # duplicates of the outer `int`), but not three times (which would indicate that
 
-PYI016.py:81:41: PYI016 Duplicate union member `int`
+PYI016.py:81:41: PYI016 [*] Duplicate union member `int`
    |
 79 | # duplicates of the outer `int`), but not three times (which would indicate that
 80 | # we incorrectly re-checked the nested union).
@@ -497,7 +564,17 @@ PYI016.py:81:41: PYI016 Duplicate union member `int`
    |
    = help: Remove duplicate union member `int`
 
-PYI016.py:81:46: PYI016 Duplicate union member `int`
+ℹ Safe fix
+78 78 | # Should emit twice (once for each `int` in the nested union, both of which are
+79 79 | # duplicates of the outer `int`), but not three times (which would indicate that
+80 80 | # we incorrectly re-checked the nested union).
+81    |-field24: typing.Union[int, typing.Union[int, int]]  # PYI016: Duplicate union member `int`
+   81 |+field24: typing.Union[int]  # PYI016: Duplicate union member `int`
+82 82 | 
+83 83 | # Should emit twice (once for each `int` in the nested union, both of which are
+84 84 | # duplicates of the outer `int`), but not three times (which would indicate that
+
+PYI016.py:81:46: PYI016 [*] Duplicate union member `int`
    |
 79 | # duplicates of the outer `int`), but not three times (which would indicate that
 80 | # we incorrectly re-checked the nested union).
@@ -507,6 +584,16 @@ PYI016.py:81:46: PYI016 Duplicate union member `int`
 83 | # Should emit twice (once for each `int` in the nested union, both of which are
    |
    = help: Remove duplicate union member `int`
+
+ℹ Safe fix
+78 78 | # Should emit twice (once for each `int` in the nested union, both of which are
+79 79 | # duplicates of the outer `int`), but not three times (which would indicate that
+80 80 | # we incorrectly re-checked the nested union).
+81    |-field24: typing.Union[int, typing.Union[int, int]]  # PYI016: Duplicate union member `int`
+   81 |+field24: typing.Union[int]  # PYI016: Duplicate union member `int`
+82 82 | 
+83 83 | # Should emit twice (once for each `int` in the nested union, both of which are
+84 84 | # duplicates of the outer `int`), but not three times (which would indicate that
 
 PYI016.py:86:28: PYI016 [*] Duplicate union member `int`
    |
@@ -539,5 +626,3 @@ PYI016.py:86:34: PYI016 [*] Duplicate union member `int`
 85 85 | # we incorrectly re-checked the nested union).
 86    |-field25: typing.Union[int, int | int]  # PYI016: Duplicate union member `int`
    86 |+field25: typing.Union[int, int]  # PYI016: Duplicate union member `int`
-
-

--- a/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI016_PYI016.pyi.snap
+++ b/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI016_PYI016.pyi.snap
@@ -156,7 +156,7 @@ PYI016.pyi:27:22: PYI016 [*] Duplicate union member `int`
 25 25 | 
 26 26 | # Should emit for strangely-bracketed unions.
 27    |-field8: int | (str | int)  # PYI016: Duplicate union member `int`
-   27 |+field8: int | (str)  # PYI016: Duplicate union member `int`
+   27 |+field8: int | str  # PYI016: Duplicate union member `int`
 28 28 | 
 29 29 | # Should handle user brackets when fixing.
 30 30 | field9: int | (int | str)  # PYI016: Duplicate union member `int`
@@ -175,7 +175,7 @@ PYI016.pyi:30:16: PYI016 [*] Duplicate union member `int`
 28 28 | 
 29 29 | # Should handle user brackets when fixing.
 30    |-field9: int | (int | str)  # PYI016: Duplicate union member `int`
-   30 |+field9: int | (str)  # PYI016: Duplicate union member `int`
+   30 |+field9: int | str  # PYI016: Duplicate union member `int`
 31 31 | field10: (str | int) | str  # PYI016: Duplicate union member `str`
 32 32 | 
 33 33 | # Should emit for nested unions.
@@ -235,7 +235,7 @@ PYI016.pyi:37:16: PYI016 [*] Duplicate union member `int`
 35 35 | 
 36 36 | # Should emit for unions with more than two cases
 37    |-field12: int | int | int  # Error
-   37 |+field12: int | int  # Error
+   37 |+field12: int  # Error
 38 38 | field13: int | int | int | int  # Error
 39 39 | 
 40 40 | # Should emit for unions with more than two cases, even if not directly adjacent
@@ -254,7 +254,7 @@ PYI016.pyi:37:22: PYI016 [*] Duplicate union member `int`
 35 35 | 
 36 36 | # Should emit for unions with more than two cases
 37    |-field12: int | int | int  # Error
-   37 |+field12: int | int  # Error
+   37 |+field12: int  # Error
 38 38 | field13: int | int | int | int  # Error
 39 39 | 
 40 40 | # Should emit for unions with more than two cases, even if not directly adjacent
@@ -275,7 +275,7 @@ PYI016.pyi:38:16: PYI016 [*] Duplicate union member `int`
 36 36 | # Should emit for unions with more than two cases
 37 37 | field12: int | int | int  # Error
 38    |-field13: int | int | int | int  # Error
-   38 |+field13: int | int | int  # Error
+   38 |+field13: int  # Error
 39 39 | 
 40 40 | # Should emit for unions with more than two cases, even if not directly adjacent
 41 41 | field14: int | int | str | int  # Error
@@ -296,7 +296,7 @@ PYI016.pyi:38:22: PYI016 [*] Duplicate union member `int`
 36 36 | # Should emit for unions with more than two cases
 37 37 | field12: int | int | int  # Error
 38    |-field13: int | int | int | int  # Error
-   38 |+field13: int | int | int  # Error
+   38 |+field13: int  # Error
 39 39 | 
 40 40 | # Should emit for unions with more than two cases, even if not directly adjacent
 41 41 | field14: int | int | str | int  # Error
@@ -317,7 +317,7 @@ PYI016.pyi:38:28: PYI016 [*] Duplicate union member `int`
 36 36 | # Should emit for unions with more than two cases
 37 37 | field12: int | int | int  # Error
 38    |-field13: int | int | int | int  # Error
-   38 |+field13: int | int | int  # Error
+   38 |+field13: int  # Error
 39 39 | 
 40 40 | # Should emit for unions with more than two cases, even if not directly adjacent
 41 41 | field14: int | int | str | int  # Error
@@ -337,7 +337,7 @@ PYI016.pyi:41:16: PYI016 [*] Duplicate union member `int`
 39 39 | 
 40 40 | # Should emit for unions with more than two cases, even if not directly adjacent
 41    |-field14: int | int | str | int  # Error
-   41 |+field14: int | str | int  # Error
+   41 |+field14: int | str  # Error
 42 42 | 
 43 43 | # Should emit for duplicate literal types; also covered by PYI030
 44 44 | field15: typing.Literal[1] | typing.Literal[1]  # Error
@@ -357,7 +357,7 @@ PYI016.pyi:41:28: PYI016 [*] Duplicate union member `int`
 39 39 | 
 40 40 | # Should emit for unions with more than two cases, even if not directly adjacent
 41    |-field14: int | int | str | int  # Error
-   41 |+field14: int | int | str  # Error
+   41 |+field14: int | str  # Error
 42 42 | 
 43 43 | # Should emit for duplicate literal types; also covered by PYI030
 44 44 | field15: typing.Literal[1] | typing.Literal[1]  # Error
@@ -467,7 +467,7 @@ PYI016.pyi:69:28: PYI016 [*] Duplicate union member `int`
 67 67 | 
 68 68 | # Should emit in cases with mixed `typing.Union` and `|`
 69    |-field21: typing.Union[int, int | str]  # Error
-   69 |+field21: typing.Union[int, str]  # Error
+   69 |+field21: int | str  # Error
 70 70 | 
 71 71 | # Should emit only once in cases with multiple nested `typing.Union`
 72 72 | field22: typing.Union[int, typing.Union[int, typing.Union[int, int]]]  # Error
@@ -543,15 +543,16 @@ PYI016.pyi:76:12: PYI016 [*] Duplicate union member `set[int]`
    |
    = help: Remove duplicate union member `set[int]`
 
-ℹ Safe fix
+ℹ Unsafe fix
+72 72 | field22: typing.Union[int, typing.Union[int, typing.Union[int, int]]]  # Error
 73 73 | 
 74 74 | # Should emit in cases with newlines
-75 75 | field23: set[  # foo
+75    |-field23: set[  # foo
 76    |-    int] | set[int]
-   76 |+    int]
-77 77 | 
-78 78 | # Should emit twice (once for each `int` in the nested union, both of which are
-79 79 | # duplicates of the outer `int`), but not three times (which would indicate that
+   75 |+field23: set[int]
+77 76 | 
+78 77 | # Should emit twice (once for each `int` in the nested union, both of which are
+79 78 | # duplicates of the outer `int`), but not three times (which would indicate that
 
 PYI016.pyi:81:41: PYI016 [*] Duplicate union member `int`
    |
@@ -611,7 +612,7 @@ PYI016.pyi:86:28: PYI016 [*] Duplicate union member `int`
 84 84 | # duplicates of the outer `int`), but not three times (which would indicate that
 85 85 | # we incorrectly re-checked the nested union).
 86    |-field25: typing.Union[int, int | int]  # PYI016: Duplicate union member `int`
-   86 |+field25: typing.Union[int, int]  # PYI016: Duplicate union member `int`
+   86 |+field25: int  # PYI016: Duplicate union member `int`
 87 87 | 
 88 88 | # Should emit in cases with nested `typing.Union`
 89 89 | field26: typing.Union[typing.Union[int, int]]  # PYI016: Duplicate union member `int`
@@ -632,7 +633,7 @@ PYI016.pyi:86:34: PYI016 [*] Duplicate union member `int`
 84 84 | # duplicates of the outer `int`), but not three times (which would indicate that
 85 85 | # we incorrectly re-checked the nested union).
 86    |-field25: typing.Union[int, int | int]  # PYI016: Duplicate union member `int`
-   86 |+field25: typing.Union[int, int]  # PYI016: Duplicate union member `int`
+   86 |+field25: int  # PYI016: Duplicate union member `int`
 87 87 | 
 88 88 | # Should emit in cases with nested `typing.Union`
 89 89 | field26: typing.Union[typing.Union[int, int]]  # PYI016: Duplicate union member `int`
@@ -692,7 +693,7 @@ PYI016.pyi:95:29: PYI016 [*] Duplicate union member `int`
 93 93 | 
 94 94 | # Should emit in cases with mixed `typing.Union` and `|`
 95    |-field28: typing.Union[int | int]  # Error
-   95 |+field28: typing.Union[int]  # Error
+   95 |+field28: int  # Error
 96 96 | 
 97 97 | # Should emit twice in cases with multiple nested `typing.Union`
 98 98 | field29: typing.Union[int, typing.Union[typing.Union[int, int]]]  # Error
@@ -742,6 +743,8 @@ PYI016.pyi:101:54: PYI016 [*] Duplicate union member `int`
 100 | # Should emit once in cases with multiple nested `typing.Union`
 101 | field30: typing.Union[int, typing.Union[typing.Union[int, str]]]  # Error
     |                                                      ^^^ PYI016
+102 | 
+103 | # Should emit once, and fix to `typing.Union[float, int]`
     |
     = help: Remove duplicate union member `int`
 
@@ -751,3 +754,111 @@ PYI016.pyi:101:54: PYI016 [*] Duplicate union member `int`
 100 100 | # Should emit once in cases with multiple nested `typing.Union`
 101     |-field30: typing.Union[int, typing.Union[typing.Union[int, str]]]  # Error
     101 |+field30: typing.Union[int, str]  # Error
+102 102 | 
+103 103 | # Should emit once, and fix to `typing.Union[float, int]`
+104 104 | field31: typing.Union[float, typing.Union[int | int]]  # Error
+
+PYI016.pyi:104:49: PYI016 [*] Duplicate union member `int`
+    |
+103 | # Should emit once, and fix to `typing.Union[float, int]`
+104 | field31: typing.Union[float, typing.Union[int | int]]  # Error
+    |                                                 ^^^ PYI016
+105 | 
+106 | # Should emit once, and fix to `typing.Union[float, int]`
+    |
+    = help: Remove duplicate union member `int`
+
+ℹ Safe fix
+101 101 | field30: typing.Union[int, typing.Union[typing.Union[int, str]]]  # Error
+102 102 | 
+103 103 | # Should emit once, and fix to `typing.Union[float, int]`
+104     |-field31: typing.Union[float, typing.Union[int | int]]  # Error
+    104 |+field31: float | int  # Error
+105 105 | 
+106 106 | # Should emit once, and fix to `typing.Union[float, int]`
+107 107 | field32: typing.Union[float, typing.Union[int | int | int]]  # Error
+
+PYI016.pyi:107:49: PYI016 [*] Duplicate union member `int`
+    |
+106 | # Should emit once, and fix to `typing.Union[float, int]`
+107 | field32: typing.Union[float, typing.Union[int | int | int]]  # Error
+    |                                                 ^^^ PYI016
+108 | 
+109 | # ...
+    |
+    = help: Remove duplicate union member `int`
+
+ℹ Safe fix
+104 104 | field31: typing.Union[float, typing.Union[int | int]]  # Error
+105 105 | 
+106 106 | # Should emit once, and fix to `typing.Union[float, int]`
+107     |-field32: typing.Union[float, typing.Union[int | int | int]]  # Error
+    107 |+field32: float | int  # Error
+108 108 | 
+109 109 | # ...
+110 110 | field33: typing.Union[typing.Union[int | int] | typing.Union[int | int]] # Error
+
+PYI016.pyi:107:55: PYI016 [*] Duplicate union member `int`
+    |
+106 | # Should emit once, and fix to `typing.Union[float, int]`
+107 | field32: typing.Union[float, typing.Union[int | int | int]]  # Error
+    |                                                       ^^^ PYI016
+108 | 
+109 | # ...
+    |
+    = help: Remove duplicate union member `int`
+
+ℹ Safe fix
+104 104 | field31: typing.Union[float, typing.Union[int | int]]  # Error
+105 105 | 
+106 106 | # Should emit once, and fix to `typing.Union[float, int]`
+107     |-field32: typing.Union[float, typing.Union[int | int | int]]  # Error
+    107 |+field32: float | int  # Error
+108 108 | 
+109 109 | # ...
+110 110 | field33: typing.Union[typing.Union[int | int] | typing.Union[int | int]] # Error
+
+PYI016.pyi:110:42: PYI016 [*] Duplicate union member `int`
+    |
+109 | # ...
+110 | field33: typing.Union[typing.Union[int | int] | typing.Union[int | int]] # Error
+    |                                          ^^^ PYI016
+    |
+    = help: Remove duplicate union member `int`
+
+ℹ Safe fix
+107 107 | field32: typing.Union[float, typing.Union[int | int | int]]  # Error
+108 108 | 
+109 109 | # ...
+110     |-field33: typing.Union[typing.Union[int | int] | typing.Union[int | int]] # Error
+    110 |+field33: int # Error
+
+PYI016.pyi:110:62: PYI016 [*] Duplicate union member `int`
+    |
+109 | # ...
+110 | field33: typing.Union[typing.Union[int | int] | typing.Union[int | int]] # Error
+    |                                                              ^^^ PYI016
+    |
+    = help: Remove duplicate union member `int`
+
+ℹ Safe fix
+107 107 | field32: typing.Union[float, typing.Union[int | int | int]]  # Error
+108 108 | 
+109 109 | # ...
+110     |-field33: typing.Union[typing.Union[int | int] | typing.Union[int | int]] # Error
+    110 |+field33: int # Error
+
+PYI016.pyi:110:68: PYI016 [*] Duplicate union member `int`
+    |
+109 | # ...
+110 | field33: typing.Union[typing.Union[int | int] | typing.Union[int | int]] # Error
+    |                                                                    ^^^ PYI016
+    |
+    = help: Remove duplicate union member `int`
+
+ℹ Safe fix
+107 107 | field32: typing.Union[float, typing.Union[int | int | int]]  # Error
+108 108 | 
+109 109 | # ...
+110     |-field33: typing.Union[typing.Union[int | int] | typing.Union[int | int]] # Error
+    110 |+field33: int # Error

--- a/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI016_PYI016.pyi.snap
+++ b/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI016_PYI016.pyi.snap
@@ -514,6 +514,8 @@ PYI016.pyi:86:28: PYI016 [*] Duplicate union member `int`
 85 | # we incorrectly re-checked the nested union).
 86 | field25: typing.Union[int, int | int]  # PYI016: Duplicate union member `int`
    |                            ^^^ PYI016
+87 | 
+88 | # Should emit in cases with nested `typing.Union`
    |
    = help: Remove duplicate union member `int`
 
@@ -523,6 +525,9 @@ PYI016.pyi:86:28: PYI016 [*] Duplicate union member `int`
 85 85 | # we incorrectly re-checked the nested union).
 86    |-field25: typing.Union[int, int | int]  # PYI016: Duplicate union member `int`
    86 |+field25: typing.Union[int, int]  # PYI016: Duplicate union member `int`
+87 87 | 
+88 88 | # Should emit in cases with nested `typing.Union`
+89 89 | field26: typing.Union[typing.Union[int, int]]  # PYI016: Duplicate union member `int`
 
 PYI016.pyi:86:34: PYI016 [*] Duplicate union member `int`
    |
@@ -530,6 +535,8 @@ PYI016.pyi:86:34: PYI016 [*] Duplicate union member `int`
 85 | # we incorrectly re-checked the nested union).
 86 | field25: typing.Union[int, int | int]  # PYI016: Duplicate union member `int`
    |                                  ^^^ PYI016
+87 | 
+88 | # Should emit in cases with nested `typing.Union`
    |
    = help: Remove duplicate union member `int`
 
@@ -539,5 +546,74 @@ PYI016.pyi:86:34: PYI016 [*] Duplicate union member `int`
 85 85 | # we incorrectly re-checked the nested union).
 86    |-field25: typing.Union[int, int | int]  # PYI016: Duplicate union member `int`
    86 |+field25: typing.Union[int, int]  # PYI016: Duplicate union member `int`
+87 87 | 
+88 88 | # Should emit in cases with nested `typing.Union`
+89 89 | field26: typing.Union[typing.Union[int, int]]  # PYI016: Duplicate union member `int`
 
+PYI016.pyi:89:41: PYI016 Duplicate union member `int`
+   |
+88 | # Should emit in cases with nested `typing.Union`
+89 | field26: typing.Union[typing.Union[int, int]]  # PYI016: Duplicate union member `int`
+   |                                         ^^^ PYI016
+90 | 
+91 | # Should emit in cases with nested `typing.Union`
+   |
+   = help: Remove duplicate union member `int`
 
+PYI016.pyi:92:54: PYI016 Duplicate union member `int`
+   |
+91 | # Should emit in cases with nested `typing.Union`
+92 | field27: typing.Union[typing.Union[typing.Union[int, int]]]  # PYI016: Duplicate union member `int`
+   |                                                      ^^^ PYI016
+93 | 
+94 | # Should emit in cases with mixed `typing.Union` and `|`
+   |
+   = help: Remove duplicate union member `int`
+
+PYI016.pyi:95:29: PYI016 [*] Duplicate union member `int`
+   |
+94 | # Should emit in cases with mixed `typing.Union` and `|`
+95 | field28: typing.Union[int | int]  # Error
+   |                             ^^^ PYI016
+96 | 
+97 | # Should emit twice in cases with multiple nested `typing.Union`
+   |
+   = help: Remove duplicate union member `int`
+
+ℹ Safe fix
+92 92 | field27: typing.Union[typing.Union[typing.Union[int, int]]]  # PYI016: Duplicate union member `int`
+93 93 | 
+94 94 | # Should emit in cases with mixed `typing.Union` and `|`
+95    |-field28: typing.Union[int | int]  # Error
+   95 |+field28: typing.Union[int]  # Error
+96 96 | 
+97 97 | # Should emit twice in cases with multiple nested `typing.Union`
+98 98 | field29: typing.Union[int, typing.Union[typing.Union[int, int]]]  # Error
+
+PYI016.pyi:98:54: PYI016 Duplicate union member `int`
+    |
+ 97 | # Should emit twice in cases with multiple nested `typing.Union`
+ 98 | field29: typing.Union[int, typing.Union[typing.Union[int, int]]]  # Error
+    |                                                      ^^^ PYI016
+ 99 | 
+100 | # Should emit once in cases with multiple nested `typing.Union`
+    |
+    = help: Remove duplicate union member `int`
+
+PYI016.pyi:98:59: PYI016 Duplicate union member `int`
+    |
+ 97 | # Should emit twice in cases with multiple nested `typing.Union`
+ 98 | field29: typing.Union[int, typing.Union[typing.Union[int, int]]]  # Error
+    |                                                           ^^^ PYI016
+ 99 | 
+100 | # Should emit once in cases with multiple nested `typing.Union`
+    |
+    = help: Remove duplicate union member `int`
+
+PYI016.pyi:101:54: PYI016 Duplicate union member `int`
+    |
+100 | # Should emit once in cases with multiple nested `typing.Union`
+101 | field30: typing.Union[int, typing.Union[typing.Union[int, str]]]  # Error
+    |                                                      ^^^ PYI016
+    |
+    = help: Remove duplicate union member `int`

--- a/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI016_PYI016.pyi.snap
+++ b/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI016_PYI016.pyi.snap
@@ -784,7 +784,7 @@ PYI016.pyi:107:49: PYI016 [*] Duplicate union member `int`
 107 | field32: typing.Union[float, typing.Union[int | int | int]]  # Error
     |                                                 ^^^ PYI016
 108 | 
-109 | # ...
+109 | # Test case for mixed union type fix
     |
     = help: Remove duplicate union member `int`
 
@@ -795,7 +795,7 @@ PYI016.pyi:107:49: PYI016 [*] Duplicate union member `int`
 107     |-field32: typing.Union[float, typing.Union[int | int | int]]  # Error
     107 |+field32: float | int  # Error
 108 108 | 
-109 109 | # ...
+109 109 | # Test case for mixed union type fix
 110 110 | field33: typing.Union[typing.Union[int | int] | typing.Union[int | int]] # Error
 
 PYI016.pyi:107:55: PYI016 [*] Duplicate union member `int`
@@ -804,7 +804,7 @@ PYI016.pyi:107:55: PYI016 [*] Duplicate union member `int`
 107 | field32: typing.Union[float, typing.Union[int | int | int]]  # Error
     |                                                       ^^^ PYI016
 108 | 
-109 | # ...
+109 | # Test case for mixed union type fix
     |
     = help: Remove duplicate union member `int`
 
@@ -815,12 +815,12 @@ PYI016.pyi:107:55: PYI016 [*] Duplicate union member `int`
 107     |-field32: typing.Union[float, typing.Union[int | int | int]]  # Error
     107 |+field32: float | int  # Error
 108 108 | 
-109 109 | # ...
+109 109 | # Test case for mixed union type fix
 110 110 | field33: typing.Union[typing.Union[int | int] | typing.Union[int | int]] # Error
 
 PYI016.pyi:110:42: PYI016 [*] Duplicate union member `int`
     |
-109 | # ...
+109 | # Test case for mixed union type fix
 110 | field33: typing.Union[typing.Union[int | int] | typing.Union[int | int]] # Error
     |                                          ^^^ PYI016
     |
@@ -829,13 +829,13 @@ PYI016.pyi:110:42: PYI016 [*] Duplicate union member `int`
 ℹ Safe fix
 107 107 | field32: typing.Union[float, typing.Union[int | int | int]]  # Error
 108 108 | 
-109 109 | # ...
+109 109 | # Test case for mixed union type fix
 110     |-field33: typing.Union[typing.Union[int | int] | typing.Union[int | int]] # Error
     110 |+field33: int # Error
 
 PYI016.pyi:110:62: PYI016 [*] Duplicate union member `int`
     |
-109 | # ...
+109 | # Test case for mixed union type fix
 110 | field33: typing.Union[typing.Union[int | int] | typing.Union[int | int]] # Error
     |                                                              ^^^ PYI016
     |
@@ -844,13 +844,13 @@ PYI016.pyi:110:62: PYI016 [*] Duplicate union member `int`
 ℹ Safe fix
 107 107 | field32: typing.Union[float, typing.Union[int | int | int]]  # Error
 108 108 | 
-109 109 | # ...
+109 109 | # Test case for mixed union type fix
 110     |-field33: typing.Union[typing.Union[int | int] | typing.Union[int | int]] # Error
     110 |+field33: int # Error
 
 PYI016.pyi:110:68: PYI016 [*] Duplicate union member `int`
     |
-109 | # ...
+109 | # Test case for mixed union type fix
 110 | field33: typing.Union[typing.Union[int | int] | typing.Union[int | int]] # Error
     |                                                                    ^^^ PYI016
     |
@@ -859,6 +859,6 @@ PYI016.pyi:110:68: PYI016 [*] Duplicate union member `int`
 ℹ Safe fix
 107 107 | field32: typing.Union[float, typing.Union[int | int | int]]  # Error
 108 108 | 
-109 109 | # ...
+109 109 | # Test case for mixed union type fix
 110     |-field33: typing.Union[typing.Union[int | int] | typing.Union[int | int]] # Error
     110 |+field33: int # Error

--- a/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI016_PYI016.pyi.snap
+++ b/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI016_PYI016.pyi.snap
@@ -395,7 +395,7 @@ PYI016.pyi:57:5: PYI016 [*] Duplicate union member `set[int]`
    |
    = help: Remove duplicate union member `set[int]`
 
-ℹ Safe fix
+ℹ Unsafe fix
 50 50 | field17: dict[int, int]  # OK
 51 51 | 
 52 52 | # Should emit in cases with newlines
@@ -407,7 +407,7 @@ PYI016.pyi:57:5: PYI016 [*] Duplicate union member `set[int]`
 58    |-        int  # bar
 59    |-    ],
 60    |-]  # Error, newline and comment will not be emitted in message
-   53 |+field18: typing.Union[set[int]]  # Error, newline and comment will not be emitted in message
+   53 |+field18: set[int]  # Error, newline and comment will not be emitted in message
 61 54 | 
 62 55 | # Should emit in cases with `typing.Union` instead of `|`
 63 56 | field19: typing.Union[int, int]  # Error
@@ -427,7 +427,7 @@ PYI016.pyi:63:28: PYI016 [*] Duplicate union member `int`
 61 61 | 
 62 62 | # Should emit in cases with `typing.Union` instead of `|`
 63    |-field19: typing.Union[int, int]  # Error
-   63 |+field19: typing.Union[int]  # Error
+   63 |+field19: int  # Error
 64 64 | 
 65 65 | # Should emit in cases with nested `typing.Union`
 66 66 | field20: typing.Union[int, typing.Union[int, str]]  # Error
@@ -487,7 +487,7 @@ PYI016.pyi:72:41: PYI016 [*] Duplicate union member `int`
 70 70 | 
 71 71 | # Should emit only once in cases with multiple nested `typing.Union`
 72    |-field22: typing.Union[int, typing.Union[int, typing.Union[int, int]]]  # Error
-   72 |+field22: typing.Union[int]  # Error
+   72 |+field22: int  # Error
 73 73 | 
 74 74 | # Should emit in cases with newlines
 75 75 | field23: set[  # foo
@@ -507,7 +507,7 @@ PYI016.pyi:72:59: PYI016 [*] Duplicate union member `int`
 70 70 | 
 71 71 | # Should emit only once in cases with multiple nested `typing.Union`
 72    |-field22: typing.Union[int, typing.Union[int, typing.Union[int, int]]]  # Error
-   72 |+field22: typing.Union[int]  # Error
+   72 |+field22: int  # Error
 73 73 | 
 74 74 | # Should emit in cases with newlines
 75 75 | field23: set[  # foo
@@ -527,7 +527,7 @@ PYI016.pyi:72:64: PYI016 [*] Duplicate union member `int`
 70 70 | 
 71 71 | # Should emit only once in cases with multiple nested `typing.Union`
 72    |-field22: typing.Union[int, typing.Union[int, typing.Union[int, int]]]  # Error
-   72 |+field22: typing.Union[int]  # Error
+   72 |+field22: int  # Error
 73 73 | 
 74 74 | # Should emit in cases with newlines
 75 75 | field23: set[  # foo
@@ -569,7 +569,7 @@ PYI016.pyi:81:41: PYI016 [*] Duplicate union member `int`
 79 79 | # duplicates of the outer `int`), but not three times (which would indicate that
 80 80 | # we incorrectly re-checked the nested union).
 81    |-field24: typing.Union[int, typing.Union[int, int]]  # PYI016: Duplicate union member `int`
-   81 |+field24: typing.Union[int]  # PYI016: Duplicate union member `int`
+   81 |+field24: int  # PYI016: Duplicate union member `int`
 82 82 | 
 83 83 | # Should emit twice (once for each `int` in the nested union, both of which are
 84 84 | # duplicates of the outer `int`), but not three times (which would indicate that
@@ -590,7 +590,7 @@ PYI016.pyi:81:46: PYI016 [*] Duplicate union member `int`
 79 79 | # duplicates of the outer `int`), but not three times (which would indicate that
 80 80 | # we incorrectly re-checked the nested union).
 81    |-field24: typing.Union[int, typing.Union[int, int]]  # PYI016: Duplicate union member `int`
-   81 |+field24: typing.Union[int]  # PYI016: Duplicate union member `int`
+   81 |+field24: int  # PYI016: Duplicate union member `int`
 82 82 | 
 83 83 | # Should emit twice (once for each `int` in the nested union, both of which are
 84 84 | # duplicates of the outer `int`), but not three times (which would indicate that
@@ -652,7 +652,7 @@ PYI016.pyi:89:41: PYI016 [*] Duplicate union member `int`
 87 87 | 
 88 88 | # Should emit in cases with nested `typing.Union`
 89    |-field26: typing.Union[typing.Union[int, int]]  # PYI016: Duplicate union member `int`
-   89 |+field26: typing.Union[int]  # PYI016: Duplicate union member `int`
+   89 |+field26: int  # PYI016: Duplicate union member `int`
 90 90 | 
 91 91 | # Should emit in cases with nested `typing.Union`
 92 92 | field27: typing.Union[typing.Union[typing.Union[int, int]]]  # PYI016: Duplicate union member `int`
@@ -672,7 +672,7 @@ PYI016.pyi:92:54: PYI016 [*] Duplicate union member `int`
 90 90 | 
 91 91 | # Should emit in cases with nested `typing.Union`
 92    |-field27: typing.Union[typing.Union[typing.Union[int, int]]]  # PYI016: Duplicate union member `int`
-   92 |+field27: typing.Union[int]  # PYI016: Duplicate union member `int`
+   92 |+field27: int  # PYI016: Duplicate union member `int`
 93 93 | 
 94 94 | # Should emit in cases with mixed `typing.Union` and `|`
 95 95 | field28: typing.Union[int | int]  # Error
@@ -712,7 +712,7 @@ PYI016.pyi:98:54: PYI016 [*] Duplicate union member `int`
 96 96 | 
 97 97 | # Should emit twice in cases with multiple nested `typing.Union`
 98    |-field29: typing.Union[int, typing.Union[typing.Union[int, int]]]  # Error
-   98 |+field29: typing.Union[int]  # Error
+   98 |+field29: int  # Error
 99 99 | 
 100 100 | # Should emit once in cases with multiple nested `typing.Union`
 101 101 | field30: typing.Union[int, typing.Union[typing.Union[int, str]]]  # Error
@@ -732,7 +732,7 @@ PYI016.pyi:98:59: PYI016 [*] Duplicate union member `int`
 96 96 | 
 97 97 | # Should emit twice in cases with multiple nested `typing.Union`
 98    |-field29: typing.Union[int, typing.Union[typing.Union[int, int]]]  # Error
-   98 |+field29: typing.Union[int]  # Error
+   98 |+field29: int  # Error
 99 99 | 
 100 100 | # Should emit once in cases with multiple nested `typing.Union`
 101 101 | field30: typing.Union[int, typing.Union[typing.Union[int, str]]]  # Error

--- a/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI016_PYI016.pyi.snap
+++ b/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI016_PYI016.pyi.snap
@@ -382,7 +382,7 @@ PYI016.pyi:44:30: PYI016 [*] Duplicate union member `typing.Literal[1]`
 46 46 | # Shouldn't emit if in new parent type
 47 47 | field16: int | dict[int, str]  # OK
 
-PYI016.pyi:57:5: PYI016 Duplicate union member `set[int]`
+PYI016.pyi:57:5: PYI016 [*] Duplicate union member `set[int]`
    |
 55 |           int  # foo
 56 |       ],
@@ -395,7 +395,24 @@ PYI016.pyi:57:5: PYI016 Duplicate union member `set[int]`
    |
    = help: Remove duplicate union member `set[int]`
 
-PYI016.pyi:63:28: PYI016 Duplicate union member `int`
+ℹ Safe fix
+50 50 | field17: dict[int, int]  # OK
+51 51 | 
+52 52 | # Should emit in cases with newlines
+53    |-field18: typing.Union[
+54    |-    set[
+55    |-        int  # foo
+56    |-    ],
+57    |-    set[
+58    |-        int  # bar
+59    |-    ],
+60    |-]  # Error, newline and comment will not be emitted in message
+   53 |+field18: typing.Union[set[int]]  # Error, newline and comment will not be emitted in message
+61 54 | 
+62 55 | # Should emit in cases with `typing.Union` instead of `|`
+63 56 | field19: typing.Union[int, int]  # Error
+
+PYI016.pyi:63:28: PYI016 [*] Duplicate union member `int`
    |
 62 | # Should emit in cases with `typing.Union` instead of `|`
 63 | field19: typing.Union[int, int]  # Error
@@ -405,7 +422,17 @@ PYI016.pyi:63:28: PYI016 Duplicate union member `int`
    |
    = help: Remove duplicate union member `int`
 
-PYI016.pyi:66:41: PYI016 Duplicate union member `int`
+ℹ Safe fix
+60 60 | ]  # Error, newline and comment will not be emitted in message
+61 61 | 
+62 62 | # Should emit in cases with `typing.Union` instead of `|`
+63    |-field19: typing.Union[int, int]  # Error
+   63 |+field19: typing.Union[int]  # Error
+64 64 | 
+65 65 | # Should emit in cases with nested `typing.Union`
+66 66 | field20: typing.Union[int, typing.Union[int, str]]  # Error
+
+PYI016.pyi:66:41: PYI016 [*] Duplicate union member `int`
    |
 65 | # Should emit in cases with nested `typing.Union`
 66 | field20: typing.Union[int, typing.Union[int, str]]  # Error
@@ -414,6 +441,16 @@ PYI016.pyi:66:41: PYI016 Duplicate union member `int`
 68 | # Should emit in cases with mixed `typing.Union` and `|`
    |
    = help: Remove duplicate union member `int`
+
+ℹ Safe fix
+63 63 | field19: typing.Union[int, int]  # Error
+64 64 | 
+65 65 | # Should emit in cases with nested `typing.Union`
+66    |-field20: typing.Union[int, typing.Union[int, str]]  # Error
+   66 |+field20: typing.Union[int, str]  # Error
+67 67 | 
+68 68 | # Should emit in cases with mixed `typing.Union` and `|`
+69 69 | field21: typing.Union[int, int | str]  # Error
 
 PYI016.pyi:69:28: PYI016 [*] Duplicate union member `int`
    |
@@ -435,7 +472,7 @@ PYI016.pyi:69:28: PYI016 [*] Duplicate union member `int`
 71 71 | # Should emit only once in cases with multiple nested `typing.Union`
 72 72 | field22: typing.Union[int, typing.Union[int, typing.Union[int, int]]]  # Error
 
-PYI016.pyi:72:41: PYI016 Duplicate union member `int`
+PYI016.pyi:72:41: PYI016 [*] Duplicate union member `int`
    |
 71 | # Should emit only once in cases with multiple nested `typing.Union`
 72 | field22: typing.Union[int, typing.Union[int, typing.Union[int, int]]]  # Error
@@ -445,7 +482,17 @@ PYI016.pyi:72:41: PYI016 Duplicate union member `int`
    |
    = help: Remove duplicate union member `int`
 
-PYI016.pyi:72:59: PYI016 Duplicate union member `int`
+ℹ Safe fix
+69 69 | field21: typing.Union[int, int | str]  # Error
+70 70 | 
+71 71 | # Should emit only once in cases with multiple nested `typing.Union`
+72    |-field22: typing.Union[int, typing.Union[int, typing.Union[int, int]]]  # Error
+   72 |+field22: typing.Union[int]  # Error
+73 73 | 
+74 74 | # Should emit in cases with newlines
+75 75 | field23: set[  # foo
+
+PYI016.pyi:72:59: PYI016 [*] Duplicate union member `int`
    |
 71 | # Should emit only once in cases with multiple nested `typing.Union`
 72 | field22: typing.Union[int, typing.Union[int, typing.Union[int, int]]]  # Error
@@ -455,7 +502,17 @@ PYI016.pyi:72:59: PYI016 Duplicate union member `int`
    |
    = help: Remove duplicate union member `int`
 
-PYI016.pyi:72:64: PYI016 Duplicate union member `int`
+ℹ Safe fix
+69 69 | field21: typing.Union[int, int | str]  # Error
+70 70 | 
+71 71 | # Should emit only once in cases with multiple nested `typing.Union`
+72    |-field22: typing.Union[int, typing.Union[int, typing.Union[int, int]]]  # Error
+   72 |+field22: typing.Union[int]  # Error
+73 73 | 
+74 74 | # Should emit in cases with newlines
+75 75 | field23: set[  # foo
+
+PYI016.pyi:72:64: PYI016 [*] Duplicate union member `int`
    |
 71 | # Should emit only once in cases with multiple nested `typing.Union`
 72 | field22: typing.Union[int, typing.Union[int, typing.Union[int, int]]]  # Error
@@ -464,6 +521,16 @@ PYI016.pyi:72:64: PYI016 Duplicate union member `int`
 74 | # Should emit in cases with newlines
    |
    = help: Remove duplicate union member `int`
+
+ℹ Safe fix
+69 69 | field21: typing.Union[int, int | str]  # Error
+70 70 | 
+71 71 | # Should emit only once in cases with multiple nested `typing.Union`
+72    |-field22: typing.Union[int, typing.Union[int, typing.Union[int, int]]]  # Error
+   72 |+field22: typing.Union[int]  # Error
+73 73 | 
+74 74 | # Should emit in cases with newlines
+75 75 | field23: set[  # foo
 
 PYI016.pyi:76:12: PYI016 [*] Duplicate union member `set[int]`
    |
@@ -486,7 +553,7 @@ PYI016.pyi:76:12: PYI016 [*] Duplicate union member `set[int]`
 78 78 | # Should emit twice (once for each `int` in the nested union, both of which are
 79 79 | # duplicates of the outer `int`), but not three times (which would indicate that
 
-PYI016.pyi:81:41: PYI016 Duplicate union member `int`
+PYI016.pyi:81:41: PYI016 [*] Duplicate union member `int`
    |
 79 | # duplicates of the outer `int`), but not three times (which would indicate that
 80 | # we incorrectly re-checked the nested union).
@@ -497,7 +564,17 @@ PYI016.pyi:81:41: PYI016 Duplicate union member `int`
    |
    = help: Remove duplicate union member `int`
 
-PYI016.pyi:81:46: PYI016 Duplicate union member `int`
+ℹ Safe fix
+78 78 | # Should emit twice (once for each `int` in the nested union, both of which are
+79 79 | # duplicates of the outer `int`), but not three times (which would indicate that
+80 80 | # we incorrectly re-checked the nested union).
+81    |-field24: typing.Union[int, typing.Union[int, int]]  # PYI016: Duplicate union member `int`
+   81 |+field24: typing.Union[int]  # PYI016: Duplicate union member `int`
+82 82 | 
+83 83 | # Should emit twice (once for each `int` in the nested union, both of which are
+84 84 | # duplicates of the outer `int`), but not three times (which would indicate that
+
+PYI016.pyi:81:46: PYI016 [*] Duplicate union member `int`
    |
 79 | # duplicates of the outer `int`), but not three times (which would indicate that
 80 | # we incorrectly re-checked the nested union).
@@ -507,6 +584,16 @@ PYI016.pyi:81:46: PYI016 Duplicate union member `int`
 83 | # Should emit twice (once for each `int` in the nested union, both of which are
    |
    = help: Remove duplicate union member `int`
+
+ℹ Safe fix
+78 78 | # Should emit twice (once for each `int` in the nested union, both of which are
+79 79 | # duplicates of the outer `int`), but not three times (which would indicate that
+80 80 | # we incorrectly re-checked the nested union).
+81    |-field24: typing.Union[int, typing.Union[int, int]]  # PYI016: Duplicate union member `int`
+   81 |+field24: typing.Union[int]  # PYI016: Duplicate union member `int`
+82 82 | 
+83 83 | # Should emit twice (once for each `int` in the nested union, both of which are
+84 84 | # duplicates of the outer `int`), but not three times (which would indicate that
 
 PYI016.pyi:86:28: PYI016 [*] Duplicate union member `int`
    |
@@ -550,7 +637,7 @@ PYI016.pyi:86:34: PYI016 [*] Duplicate union member `int`
 88 88 | # Should emit in cases with nested `typing.Union`
 89 89 | field26: typing.Union[typing.Union[int, int]]  # PYI016: Duplicate union member `int`
 
-PYI016.pyi:89:41: PYI016 Duplicate union member `int`
+PYI016.pyi:89:41: PYI016 [*] Duplicate union member `int`
    |
 88 | # Should emit in cases with nested `typing.Union`
 89 | field26: typing.Union[typing.Union[int, int]]  # PYI016: Duplicate union member `int`
@@ -560,7 +647,17 @@ PYI016.pyi:89:41: PYI016 Duplicate union member `int`
    |
    = help: Remove duplicate union member `int`
 
-PYI016.pyi:92:54: PYI016 Duplicate union member `int`
+ℹ Safe fix
+86 86 | field25: typing.Union[int, int | int]  # PYI016: Duplicate union member `int`
+87 87 | 
+88 88 | # Should emit in cases with nested `typing.Union`
+89    |-field26: typing.Union[typing.Union[int, int]]  # PYI016: Duplicate union member `int`
+   89 |+field26: typing.Union[int]  # PYI016: Duplicate union member `int`
+90 90 | 
+91 91 | # Should emit in cases with nested `typing.Union`
+92 92 | field27: typing.Union[typing.Union[typing.Union[int, int]]]  # PYI016: Duplicate union member `int`
+
+PYI016.pyi:92:54: PYI016 [*] Duplicate union member `int`
    |
 91 | # Should emit in cases with nested `typing.Union`
 92 | field27: typing.Union[typing.Union[typing.Union[int, int]]]  # PYI016: Duplicate union member `int`
@@ -569,6 +666,16 @@ PYI016.pyi:92:54: PYI016 Duplicate union member `int`
 94 | # Should emit in cases with mixed `typing.Union` and `|`
    |
    = help: Remove duplicate union member `int`
+
+ℹ Safe fix
+89 89 | field26: typing.Union[typing.Union[int, int]]  # PYI016: Duplicate union member `int`
+90 90 | 
+91 91 | # Should emit in cases with nested `typing.Union`
+92    |-field27: typing.Union[typing.Union[typing.Union[int, int]]]  # PYI016: Duplicate union member `int`
+   92 |+field27: typing.Union[int]  # PYI016: Duplicate union member `int`
+93 93 | 
+94 94 | # Should emit in cases with mixed `typing.Union` and `|`
+95 95 | field28: typing.Union[int | int]  # Error
 
 PYI016.pyi:95:29: PYI016 [*] Duplicate union member `int`
    |
@@ -590,7 +697,7 @@ PYI016.pyi:95:29: PYI016 [*] Duplicate union member `int`
 97 97 | # Should emit twice in cases with multiple nested `typing.Union`
 98 98 | field29: typing.Union[int, typing.Union[typing.Union[int, int]]]  # Error
 
-PYI016.pyi:98:54: PYI016 Duplicate union member `int`
+PYI016.pyi:98:54: PYI016 [*] Duplicate union member `int`
     |
  97 | # Should emit twice in cases with multiple nested `typing.Union`
  98 | field29: typing.Union[int, typing.Union[typing.Union[int, int]]]  # Error
@@ -600,7 +707,17 @@ PYI016.pyi:98:54: PYI016 Duplicate union member `int`
     |
     = help: Remove duplicate union member `int`
 
-PYI016.pyi:98:59: PYI016 Duplicate union member `int`
+ℹ Safe fix
+95 95 | field28: typing.Union[int | int]  # Error
+96 96 | 
+97 97 | # Should emit twice in cases with multiple nested `typing.Union`
+98    |-field29: typing.Union[int, typing.Union[typing.Union[int, int]]]  # Error
+   98 |+field29: typing.Union[int]  # Error
+99 99 | 
+100 100 | # Should emit once in cases with multiple nested `typing.Union`
+101 101 | field30: typing.Union[int, typing.Union[typing.Union[int, str]]]  # Error
+
+PYI016.pyi:98:59: PYI016 [*] Duplicate union member `int`
     |
  97 | # Should emit twice in cases with multiple nested `typing.Union`
  98 | field29: typing.Union[int, typing.Union[typing.Union[int, int]]]  # Error
@@ -610,10 +727,27 @@ PYI016.pyi:98:59: PYI016 Duplicate union member `int`
     |
     = help: Remove duplicate union member `int`
 
-PYI016.pyi:101:54: PYI016 Duplicate union member `int`
+ℹ Safe fix
+95 95 | field28: typing.Union[int | int]  # Error
+96 96 | 
+97 97 | # Should emit twice in cases with multiple nested `typing.Union`
+98    |-field29: typing.Union[int, typing.Union[typing.Union[int, int]]]  # Error
+   98 |+field29: typing.Union[int]  # Error
+99 99 | 
+100 100 | # Should emit once in cases with multiple nested `typing.Union`
+101 101 | field30: typing.Union[int, typing.Union[typing.Union[int, str]]]  # Error
+
+PYI016.pyi:101:54: PYI016 [*] Duplicate union member `int`
     |
 100 | # Should emit once in cases with multiple nested `typing.Union`
 101 | field30: typing.Union[int, typing.Union[typing.Union[int, str]]]  # Error
     |                                                      ^^^ PYI016
     |
     = help: Remove duplicate union member `int`
+
+ℹ Safe fix
+98  98  | field29: typing.Union[int, typing.Union[typing.Union[int, int]]]  # Error
+99  99  | 
+100 100 | # Should emit once in cases with multiple nested `typing.Union`
+101     |-field30: typing.Union[int, typing.Union[typing.Union[int, str]]]  # Error
+    101 |+field30: typing.Union[int, str]  # Error

--- a/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI041_PYI041.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI041_PYI041.py.snap
@@ -91,20 +91,221 @@ PYI041.py:38:24: PYI041 [*] Use `float` instead of `int | float`
 40 40 | 
 41 41 | 
 
-PYI041.py:46:24: PYI041 [*] Use `complex` instead of `int | float | complex`
+PYI041.py:43:26: PYI041 [*] Use `float` instead of `int | float`
    |
-44 |         ...
-45 | 
-46 |     def bad(self, arg: int | float | complex) -> None:
-   |                        ^^^^^^^^^^^^^^^^^^^^^ PYI041
-47 |         ...
+43 | def f5(arg1: int, *args: Union[int, int, float]) -> None: 
+   |                          ^^^^^^^^^^^^^^^^^^^^^^ PYI041
+44 |     ...
    |
    = help: Remove duplicates
 
 ℹ Safe fix
-43 43 |     def good(self, arg: int) -> None:
-44 44 |         ...
+40 40 | 
+41 41 | 
+42 42 | 
+43    |-def f5(arg1: int, *args: Union[int, int, float]) -> None: 
+   43 |+def f5(arg1: int, *args: float) -> None: 
+44 44 |     ...
 45 45 | 
-46    |-    def bad(self, arg: int | float | complex) -> None:
-   46 |+    def bad(self, arg: complex) -> None:
-47 47 |         ...
+46 46 | 
+
+PYI041.py:47:26: PYI041 [*] Use `float` instead of `int | float`
+   |
+47 | def f6(arg1: int, *args: Union[Union[int, int, float]]) -> None: 
+   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI041
+48 |     ...
+   |
+   = help: Remove duplicates
+
+ℹ Safe fix
+44 44 |     ...
+45 45 | 
+46 46 | 
+47    |-def f6(arg1: int, *args: Union[Union[int, int, float]]) -> None: 
+   47 |+def f6(arg1: int, *args: float) -> None: 
+48 48 |     ...
+49 49 | 
+50 50 | 
+
+PYI041.py:51:26: PYI041 [*] Use `float` instead of `int | float`
+   |
+51 | def f7(arg1: int, *args: Union[Union[Union[int, int, float]]]) -> None: 
+   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI041
+52 |     ...
+   |
+   = help: Remove duplicates
+
+ℹ Safe fix
+48 48 |     ...
+49 49 | 
+50 50 | 
+51    |-def f7(arg1: int, *args: Union[Union[Union[int, int, float]]]) -> None: 
+   51 |+def f7(arg1: int, *args: float) -> None: 
+52 52 |     ...
+53 53 | 
+54 54 | 
+
+PYI041.py:55:26: PYI041 [*] Use `float` instead of `int | float`
+   |
+55 | def f8(arg1: int, *args: Union[Union[Union[int | int | float]]]) -> None: 
+   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI041
+56 |     ...
+   |
+   = help: Remove duplicates
+
+ℹ Safe fix
+52 52 |     ...
+53 53 | 
+54 54 | 
+55    |-def f8(arg1: int, *args: Union[Union[Union[int | int | float]]]) -> None: 
+   55 |+def f8(arg1: int, *args: float) -> None: 
+56 56 |     ...
+57 57 | 
+58 58 | 
+
+PYI041.py:60:10: PYI041 [*] Use `complex` instead of `int | float | complex`
+   |
+59 |   def f9(
+60 |       arg: Union[  # comment 
+   |  __________^
+61 | |         float, # another
+62 | |         complex, int]
+   | |_____________________^ PYI041
+63 |       ) -> None: 
+64 |       ...
+   |
+   = help: Remove duplicates
+
+ℹ Unsafe fix
+57 57 | 
+58 58 | 
+59 59 | def f9(
+60    |-    arg: Union[  # comment 
+61    |-        float, # another
+62    |-        complex, int]
+   60 |+    arg: complex
+63 61 |     ) -> None: 
+64 62 |     ...
+65 63 | 
+
+PYI041.py:68:9: PYI041 [*] Use `complex` instead of `int | float | complex`
+   |
+66 |   def f10(
+67 |       arg: (
+68 |           int | # comment
+   |  _________^
+69 | |         float |  # another
+70 | |         complex
+   | |_______________^ PYI041
+71 |       )    
+72 |       ) -> None: 
+   |
+   = help: Remove duplicates
+
+ℹ Unsafe fix
+65 65 | 
+66 66 | def f10(
+67 67 |     arg: (
+68    |-        int | # comment
+69    |-        float |  # another
+70 68 |         complex
+71 69 |     )    
+72 70 |     ) -> None: 
+
+PYI041.py:80:24: PYI041 [*] Use `complex` instead of `int | float | complex`
+   |
+78 |         ...
+79 | 
+80 |     def bad(self, arg: int | float | complex) -> None:
+   |                        ^^^^^^^^^^^^^^^^^^^^^ PYI041
+81 |         ...
+   |
+   = help: Remove duplicates
+
+ℹ Safe fix
+77 77 |     def good(self, arg: int) -> None:
+78 78 |         ...
+79 79 | 
+80    |-    def bad(self, arg: int | float | complex) -> None:
+   80 |+    def bad(self, arg: complex) -> None:
+81 81 |         ...
+82 82 | 
+83 83 |     def bad2(self, arg: int | Union[float, complex]) -> None: 
+
+PYI041.py:83:25: PYI041 [*] Use `complex` instead of `int | float | complex`
+   |
+81 |         ...
+82 | 
+83 |     def bad2(self, arg: int | Union[float, complex]) -> None: 
+   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI041
+84 |         ...
+   |
+   = help: Remove duplicates
+
+ℹ Safe fix
+80 80 |     def bad(self, arg: int | float | complex) -> None:
+81 81 |         ...
+82 82 | 
+83    |-    def bad2(self, arg: int | Union[float, complex]) -> None: 
+   83 |+    def bad2(self, arg: complex) -> None: 
+84 84 |         ...
+85 85 | 
+86 86 |     def bad3(self, arg: Union[Union[float, complex], int]) -> None: 
+
+PYI041.py:86:25: PYI041 [*] Use `complex` instead of `int | float | complex`
+   |
+84 |         ...
+85 | 
+86 |     def bad3(self, arg: Union[Union[float, complex], int]) -> None: 
+   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI041
+87 |         ...
+   |
+   = help: Remove duplicates
+
+ℹ Safe fix
+83 83 |     def bad2(self, arg: int | Union[float, complex]) -> None: 
+84 84 |         ...
+85 85 | 
+86    |-    def bad3(self, arg: Union[Union[float, complex], int]) -> None: 
+   86 |+    def bad3(self, arg: complex) -> None: 
+87 87 |         ...
+88 88 | 
+89 89 |     def bad4(self, arg: Union[float | complex, int]) -> None: 
+
+PYI041.py:89:25: PYI041 [*] Use `complex` instead of `int | float | complex`
+   |
+87 |         ...
+88 | 
+89 |     def bad4(self, arg: Union[float | complex, int]) -> None: 
+   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI041
+90 |         ...
+   |
+   = help: Remove duplicates
+
+ℹ Safe fix
+86 86 |     def bad3(self, arg: Union[Union[float, complex], int]) -> None: 
+87 87 |         ...
+88 88 | 
+89    |-    def bad4(self, arg: Union[float | complex, int]) -> None: 
+   89 |+    def bad4(self, arg: complex) -> None: 
+90 90 |         ...
+91 91 | 
+92 92 |     def bad5(self, arg: int | (float | complex)) -> None: 
+
+PYI041.py:92:25: PYI041 [*] Use `complex` instead of `int | float | complex`
+   |
+90 |         ...
+91 | 
+92 |     def bad5(self, arg: int | (float | complex)) -> None: 
+   |                         ^^^^^^^^^^^^^^^^^^^^^^^ PYI041
+93 |         ...
+   |
+   = help: Remove duplicates
+
+ℹ Safe fix
+89 89 |     def bad4(self, arg: Union[float | complex, int]) -> None: 
+90 90 |         ...
+91 91 | 
+92    |-    def bad5(self, arg: int | (float | complex)) -> None: 
+   92 |+    def bad5(self, arg: complex) -> None: 
+93 93 |         ...

--- a/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI041_PYI041.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI041_PYI041.py.snap
@@ -1,35 +1,97 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_pyi/mod.rs
 ---
-PYI041.py:22:14: PYI041 Use `float` instead of `int | float`
+PYI041.py:22:14: PYI041 [*] Use `float` instead of `int | float`
    |
 22 | def f0(arg1: float | int) -> None:
    |              ^^^^^^^^^^^ PYI041
 23 |     ...
    |
+   = help: Remove duplicates
 
-PYI041.py:26:30: PYI041 Use `complex` instead of `float | complex`
+ℹ Safe fix
+19 19 |     ...
+20 20 | 
+21 21 | 
+22    |-def f0(arg1: float | int) -> None:
+   22 |+def f0(arg1: float) -> None:
+23 23 |     ...
+24 24 | 
+25 25 | 
+
+PYI041.py:26:30: PYI041 [*] Use `complex` instead of `float | complex`
    |
 26 | def f1(arg1: float, *, arg2: float | list[str] | type[bool] | complex) -> None:
    |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI041
 27 |     ...
    |
+   = help: Remove duplicates
 
-PYI041.py:30:28: PYI041 Use `float` instead of `int | float`
+ℹ Safe fix
+23 23 |     ...
+24 24 | 
+25 25 | 
+26    |-def f1(arg1: float, *, arg2: float | list[str] | type[bool] | complex) -> None:
+   26 |+def f1(arg1: float, *, arg2: list[str] | type[bool] | complex) -> None:
+27 27 |     ...
+28 28 | 
+29 29 | 
+
+PYI041.py:30:28: PYI041 [*] Use `float` instead of `int | float`
    |
 30 | def f2(arg1: int, /, arg2: int | int | float) -> None:
    |                            ^^^^^^^^^^^^^^^^^ PYI041
 31 |     ...
    |
+   = help: Remove duplicates
 
-PYI041.py:38:24: PYI041 Use `float` instead of `int | float`
+ℹ Safe fix
+27 27 |     ...
+28 28 | 
+29 29 | 
+30    |-def f2(arg1: int, /, arg2: int | int | float) -> None:
+   30 |+def f2(arg1: int, /, arg2: float) -> None:
+31 31 |     ...
+32 32 | 
+33 33 | 
+
+PYI041.py:34:26: PYI041 [*] Use `float` instead of `int | float`
+   |
+34 | def f3(arg1: int, *args: Union[int | int | float]) -> None:
+   |                          ^^^^^^^^^^^^^^^^^^^^^^^^ PYI041
+35 |     ...
+   |
+   = help: Remove duplicates
+
+ℹ Safe fix
+31 31 |     ...
+32 32 | 
+33 33 | 
+34    |-def f3(arg1: int, *args: Union[int | int | float]) -> None:
+   34 |+def f3(arg1: int, *args: float) -> None:
+35 35 |     ...
+36 36 | 
+37 37 | 
+
+PYI041.py:38:24: PYI041 [*] Use `float` instead of `int | float`
    |
 38 | async def f4(**kwargs: int | int | float) -> None:
    |                        ^^^^^^^^^^^^^^^^^ PYI041
 39 |     ...
    |
+   = help: Remove duplicates
 
-PYI041.py:46:24: PYI041 Use `complex` instead of `float | complex`
+ℹ Safe fix
+35 35 |     ...
+36 36 | 
+37 37 | 
+38    |-async def f4(**kwargs: int | int | float) -> None:
+   38 |+async def f4(**kwargs: float) -> None:
+39 39 |     ...
+40 40 | 
+41 41 | 
+
+PYI041.py:46:24: PYI041 [*] Use `complex` instead of `int | float | complex`
    |
 44 |         ...
 45 | 
@@ -37,14 +99,12 @@ PYI041.py:46:24: PYI041 Use `complex` instead of `float | complex`
    |                        ^^^^^^^^^^^^^^^^^^^^^ PYI041
 47 |         ...
    |
+   = help: Remove duplicates
 
-PYI041.py:46:24: PYI041 Use `complex` instead of `int | complex`
-   |
-44 |         ...
-45 | 
-46 |     def bad(self, arg: int | float | complex) -> None:
-   |                        ^^^^^^^^^^^^^^^^^^^^^ PYI041
-47 |         ...
-   |
-
-
+ℹ Safe fix
+43 43 |     def good(self, arg: int) -> None:
+44 44 |         ...
+45 45 | 
+46    |-    def bad(self, arg: int | float | complex) -> None:
+   46 |+    def bad(self, arg: complex) -> None:
+47 47 |         ...

--- a/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI041_PYI041.pyi.snap
+++ b/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI041_PYI041.pyi.snap
@@ -118,103 +118,137 @@ PYI041.pyi:39:26: PYI041 [*] Use `float` instead of `int | float`
    39 |+def f5(arg1: int, *args: float) -> None: ...  # PYI041
 40 40 | 
 41 41 | 
-42 42 | class Foo:
+42 42 | def f6(arg1: int, *args: Union[Union[Union[int, int, float]]]) -> None: ...  # PYI041
 
-PYI041.pyi:45:24: PYI041 [*] Use `complex` instead of `int | float | complex`
+PYI041.pyi:42:26: PYI041 [*] Use `float` instead of `int | float`
    |
-43 |     def good(self, arg: int) -> None: ...
-44 | 
-45 |     def bad(self, arg: int | float | complex) -> None: ...  # PYI041
+42 | def f6(arg1: int, *args: Union[Union[Union[int, int, float]]]) -> None: ...  # PYI041
+   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI041
+   |
+   = help: Remove duplicates
+
+ℹ Safe fix
+39 39 | def f5(arg1: int, *args: Union[Union[int, int, float]]) -> None: ...  # PYI041
+40 40 | 
+41 41 | 
+42    |-def f6(arg1: int, *args: Union[Union[Union[int, int, float]]]) -> None: ...  # PYI041
+   42 |+def f6(arg1: int, *args: float) -> None: ...  # PYI041
+43 43 | 
+44 44 | 
+45 45 | def f7(arg1: int, *args: Union[Union[Union[int | int | float]]]) -> None: ...  # PYI041
+
+PYI041.pyi:45:26: PYI041 [*] Use `float` instead of `int | float`
+   |
+45 | def f7(arg1: int, *args: Union[Union[Union[int | int | float]]]) -> None: ...  # PYI041
+   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI041
+   |
+   = help: Remove duplicates
+
+ℹ Safe fix
+42 42 | def f6(arg1: int, *args: Union[Union[Union[int, int, float]]]) -> None: ...  # PYI041
+43 43 | 
+44 44 | 
+45    |-def f7(arg1: int, *args: Union[Union[Union[int | int | float]]]) -> None: ...  # PYI041
+   45 |+def f7(arg1: int, *args: float) -> None: ...  # PYI041
+46 46 | 
+47 47 | 
+48 48 | class Foo:
+
+PYI041.pyi:51:24: PYI041 [*] Use `complex` instead of `int | float | complex`
+   |
+49 |     def good(self, arg: int) -> None: ...
+50 | 
+51 |     def bad(self, arg: int | float | complex) -> None: ...  # PYI041
    |                        ^^^^^^^^^^^^^^^^^^^^^ PYI041
-46 | 
-47 |     def bad2(self, arg: int | Union[float, complex]) -> None: ...  # PYI041
-   |
-   = help: Remove duplicates
-
-ℹ Safe fix
-42 42 | class Foo:
-43 43 |     def good(self, arg: int) -> None: ...
-44 44 | 
-45    |-    def bad(self, arg: int | float | complex) -> None: ...  # PYI041
-   45 |+    def bad(self, arg: complex) -> None: ...  # PYI041
-46 46 | 
-47 47 |     def bad2(self, arg: int | Union[float, complex]) -> None: ...  # PYI041
-48 48 | 
-
-PYI041.pyi:47:25: PYI041 [*] Use `complex` instead of `int | float | complex`
-   |
-45 |     def bad(self, arg: int | float | complex) -> None: ...  # PYI041
-46 | 
-47 |     def bad2(self, arg: int | Union[float, complex]) -> None: ...  # PYI041
-   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI041
-48 | 
-49 |     def bad3(self, arg: Union[Union[float, complex], int]) -> None: ...  # PYI041
-   |
-   = help: Remove duplicates
-
-ℹ Safe fix
-44 44 | 
-45 45 |     def bad(self, arg: int | float | complex) -> None: ...  # PYI041
-46 46 | 
-47    |-    def bad2(self, arg: int | Union[float, complex]) -> None: ...  # PYI041
-   47 |+    def bad2(self, arg: complex) -> None: ...  # PYI041
-48 48 | 
-49 49 |     def bad3(self, arg: Union[Union[float, complex], int]) -> None: ...  # PYI041
-50 50 | 
-
-PYI041.pyi:49:25: PYI041 [*] Use `complex` instead of `int | float | complex`
-   |
-47 |     def bad2(self, arg: int | Union[float, complex]) -> None: ...  # PYI041
-48 | 
-49 |     def bad3(self, arg: Union[Union[float, complex], int]) -> None: ...  # PYI041
-   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI041
-50 | 
-51 |     def bad4(self, arg: Union[float | complex, int]) -> None: ...  # PYI041
-   |
-   = help: Remove duplicates
-
-ℹ Safe fix
-46 46 | 
-47 47 |     def bad2(self, arg: int | Union[float, complex]) -> None: ...  # PYI041
-48 48 | 
-49    |-    def bad3(self, arg: Union[Union[float, complex], int]) -> None: ...  # PYI041
-   49 |+    def bad3(self, arg: complex) -> None: ...  # PYI041
-50 50 | 
-51 51 |     def bad4(self, arg: Union[float | complex, int]) -> None: ...  # PYI041
-52 52 | 
-
-PYI041.pyi:51:25: PYI041 [*] Use `complex` instead of `int | float | complex`
-   |
-49 |     def bad3(self, arg: Union[Union[float, complex], int]) -> None: ...  # PYI041
-50 | 
-51 |     def bad4(self, arg: Union[float | complex, int]) -> None: ...  # PYI041
-   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI041
 52 | 
-53 |     def bad5(self, arg: int | (float | complex)) -> None: ...  # PYI041
+53 |     def bad2(self, arg: int | Union[float, complex]) -> None: ...  # PYI041
    |
    = help: Remove duplicates
 
 ℹ Safe fix
-48 48 | 
-49 49 |     def bad3(self, arg: Union[Union[float, complex], int]) -> None: ...  # PYI041
+48 48 | class Foo:
+49 49 |     def good(self, arg: int) -> None: ...
 50 50 | 
-51    |-    def bad4(self, arg: Union[float | complex, int]) -> None: ...  # PYI041
-   51 |+    def bad4(self, arg: complex) -> None: ...  # PYI041
+51    |-    def bad(self, arg: int | float | complex) -> None: ...  # PYI041
+   51 |+    def bad(self, arg: complex) -> None: ...  # PYI041
 52 52 | 
-53 53 |     def bad5(self, arg: int | (float | complex)) -> None: ...  # PYI041
+53 53 |     def bad2(self, arg: int | Union[float, complex]) -> None: ...  # PYI041
+54 54 | 
 
 PYI041.pyi:53:25: PYI041 [*] Use `complex` instead of `int | float | complex`
    |
-51 |     def bad4(self, arg: Union[float | complex, int]) -> None: ...  # PYI041
+51 |     def bad(self, arg: int | float | complex) -> None: ...  # PYI041
 52 | 
-53 |     def bad5(self, arg: int | (float | complex)) -> None: ...  # PYI041
+53 |     def bad2(self, arg: int | Union[float, complex]) -> None: ...  # PYI041
+   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI041
+54 | 
+55 |     def bad3(self, arg: Union[Union[float, complex], int]) -> None: ...  # PYI041
+   |
+   = help: Remove duplicates
+
+ℹ Safe fix
+50 50 | 
+51 51 |     def bad(self, arg: int | float | complex) -> None: ...  # PYI041
+52 52 | 
+53    |-    def bad2(self, arg: int | Union[float, complex]) -> None: ...  # PYI041
+   53 |+    def bad2(self, arg: complex) -> None: ...  # PYI041
+54 54 | 
+55 55 |     def bad3(self, arg: Union[Union[float, complex], int]) -> None: ...  # PYI041
+56 56 | 
+
+PYI041.pyi:55:25: PYI041 [*] Use `complex` instead of `int | float | complex`
+   |
+53 |     def bad2(self, arg: int | Union[float, complex]) -> None: ...  # PYI041
+54 | 
+55 |     def bad3(self, arg: Union[Union[float, complex], int]) -> None: ...  # PYI041
+   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI041
+56 | 
+57 |     def bad4(self, arg: Union[float | complex, int]) -> None: ...  # PYI041
+   |
+   = help: Remove duplicates
+
+ℹ Safe fix
+52 52 | 
+53 53 |     def bad2(self, arg: int | Union[float, complex]) -> None: ...  # PYI041
+54 54 | 
+55    |-    def bad3(self, arg: Union[Union[float, complex], int]) -> None: ...  # PYI041
+   55 |+    def bad3(self, arg: complex) -> None: ...  # PYI041
+56 56 | 
+57 57 |     def bad4(self, arg: Union[float | complex, int]) -> None: ...  # PYI041
+58 58 | 
+
+PYI041.pyi:57:25: PYI041 [*] Use `complex` instead of `int | float | complex`
+   |
+55 |     def bad3(self, arg: Union[Union[float, complex], int]) -> None: ...  # PYI041
+56 | 
+57 |     def bad4(self, arg: Union[float | complex, int]) -> None: ...  # PYI041
+   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI041
+58 | 
+59 |     def bad5(self, arg: int | (float | complex)) -> None: ...  # PYI041
+   |
+   = help: Remove duplicates
+
+ℹ Safe fix
+54 54 | 
+55 55 |     def bad3(self, arg: Union[Union[float, complex], int]) -> None: ...  # PYI041
+56 56 | 
+57    |-    def bad4(self, arg: Union[float | complex, int]) -> None: ...  # PYI041
+   57 |+    def bad4(self, arg: complex) -> None: ...  # PYI041
+58 58 | 
+59 59 |     def bad5(self, arg: int | (float | complex)) -> None: ...  # PYI041
+
+PYI041.pyi:59:25: PYI041 [*] Use `complex` instead of `int | float | complex`
+   |
+57 |     def bad4(self, arg: Union[float | complex, int]) -> None: ...  # PYI041
+58 | 
+59 |     def bad5(self, arg: int | (float | complex)) -> None: ...  # PYI041
    |                         ^^^^^^^^^^^^^^^^^^^^^^^ PYI041
    |
    = help: Remove duplicates
 
 ℹ Safe fix
-50 50 | 
-51 51 |     def bad4(self, arg: Union[float | complex, int]) -> None: ...  # PYI041
-52 52 | 
-53    |-    def bad5(self, arg: int | (float | complex)) -> None: ...  # PYI041
-   53 |+    def bad5(self, arg: complex) -> None: ...  # PYI041
+56 56 | 
+57 57 |     def bad4(self, arg: Union[float | complex, int]) -> None: ...  # PYI041
+58 58 | 
+59    |-    def bad5(self, arg: int | (float | complex)) -> None: ...  # PYI041
+   59 |+    def bad5(self, arg: complex) -> None: ...  # PYI041

--- a/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI041_PYI041.pyi.snap
+++ b/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI041_PYI041.pyi.snap
@@ -1,44 +1,220 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_pyi/mod.rs
 ---
-PYI041.pyi:21:14: PYI041 Use `float` instead of `int | float`
+PYI041.pyi:21:14: PYI041 [*] Use `float` instead of `int | float`
    |
 21 | def f0(arg1: float | int) -> None: ...  # PYI041
    |              ^^^^^^^^^^^ PYI041
    |
+   = help: Remove duplicates
 
-PYI041.pyi:24:30: PYI041 Use `complex` instead of `float | complex`
+ℹ Safe fix
+18 18 | def good2(arg: int, arg2: int | bool) -> None: ...
+19 19 | 
+20 20 | 
+21    |-def f0(arg1: float | int) -> None: ...  # PYI041
+   21 |+def f0(arg1: float) -> None: ...  # PYI041
+22 22 | 
+23 23 | 
+24 24 | def f1(arg1: float, *, arg2: float | list[str] | type[bool] | complex) -> None: ...  # PYI041
+
+PYI041.pyi:24:30: PYI041 [*] Use `complex` instead of `float | complex`
    |
 24 | def f1(arg1: float, *, arg2: float | list[str] | type[bool] | complex) -> None: ...  # PYI041
    |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI041
    |
+   = help: Remove duplicates
 
-PYI041.pyi:27:28: PYI041 Use `float` instead of `int | float`
+ℹ Safe fix
+21 21 | def f0(arg1: float | int) -> None: ...  # PYI041
+22 22 | 
+23 23 | 
+24    |-def f1(arg1: float, *, arg2: float | list[str] | type[bool] | complex) -> None: ...  # PYI041
+   24 |+def f1(arg1: float, *, arg2: list[str] | type[bool] | complex) -> None: ...  # PYI041
+25 25 | 
+26 26 | 
+27 27 | def f2(arg1: int, /, arg2: int | int | float) -> None: ...  # PYI041
+
+PYI041.pyi:27:28: PYI041 [*] Use `float` instead of `int | float`
    |
 27 | def f2(arg1: int, /, arg2: int | int | float) -> None: ...  # PYI041
    |                            ^^^^^^^^^^^^^^^^^ PYI041
    |
+   = help: Remove duplicates
 
-PYI041.pyi:33:24: PYI041 Use `float` instead of `int | float`
+ℹ Safe fix
+24 24 | def f1(arg1: float, *, arg2: float | list[str] | type[bool] | complex) -> None: ...  # PYI041
+25 25 | 
+26 26 | 
+27    |-def f2(arg1: int, /, arg2: int | int | float) -> None: ...  # PYI041
+   27 |+def f2(arg1: int, /, arg2: float) -> None: ...  # PYI041
+28 28 | 
+29 29 | 
+30 30 | def f3(arg1: int, *args: Union[int | int | float]) -> None: ...  # PYI041
+
+PYI041.pyi:30:26: PYI041 [*] Use `float` instead of `int | float`
+   |
+30 | def f3(arg1: int, *args: Union[int | int | float]) -> None: ...  # PYI041
+   |                          ^^^^^^^^^^^^^^^^^^^^^^^^ PYI041
+   |
+   = help: Remove duplicates
+
+ℹ Safe fix
+27 27 | def f2(arg1: int, /, arg2: int | int | float) -> None: ...  # PYI041
+28 28 | 
+29 29 | 
+30    |-def f3(arg1: int, *args: Union[int | int | float]) -> None: ...  # PYI041
+   30 |+def f3(arg1: int, *args: float) -> None: ...  # PYI041
+31 31 | 
+32 32 | 
+33 33 | async def f4(**kwargs: int | int | float) -> None: ...  # PYI041
+
+PYI041.pyi:33:24: PYI041 [*] Use `float` instead of `int | float`
    |
 33 | async def f4(**kwargs: int | int | float) -> None: ...  # PYI041
    |                        ^^^^^^^^^^^^^^^^^ PYI041
    |
+   = help: Remove duplicates
 
-PYI041.pyi:39:24: PYI041 Use `complex` instead of `float | complex`
+ℹ Safe fix
+30 30 | def f3(arg1: int, *args: Union[int | int | float]) -> None: ...  # PYI041
+31 31 | 
+32 32 | 
+33    |-async def f4(**kwargs: int | int | float) -> None: ...  # PYI041
+   33 |+async def f4(**kwargs: float) -> None: ...  # PYI041
+34 34 | 
+35 35 | 
+36 36 | def f4(arg1: int, *args: Union[int, int, float]) -> None: ...  # PYI041
+
+PYI041.pyi:36:26: PYI041 [*] Use `float` instead of `int | float`
    |
-37 |     def good(self, arg: int) -> None: ...
-38 | 
-39 |     def bad(self, arg: int | float | complex) -> None: ...  # PYI041
+36 | def f4(arg1: int, *args: Union[int, int, float]) -> None: ...  # PYI041
+   |                          ^^^^^^^^^^^^^^^^^^^^^^ PYI041
+   |
+   = help: Remove duplicates
+
+ℹ Safe fix
+33 33 | async def f4(**kwargs: int | int | float) -> None: ...  # PYI041
+34 34 | 
+35 35 | 
+36    |-def f4(arg1: int, *args: Union[int, int, float]) -> None: ...  # PYI041
+   36 |+def f4(arg1: int, *args: float) -> None: ...  # PYI041
+37 37 | 
+38 38 | 
+39 39 | def f5(arg1: int, *args: Union[Union[int, int, float]]) -> None: ...  # PYI041
+
+PYI041.pyi:39:26: PYI041 [*] Use `float` instead of `int | float`
+   |
+39 | def f5(arg1: int, *args: Union[Union[int, int, float]]) -> None: ...  # PYI041
+   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI041
+   |
+   = help: Remove duplicates
+
+ℹ Safe fix
+36 36 | def f4(arg1: int, *args: Union[int, int, float]) -> None: ...  # PYI041
+37 37 | 
+38 38 | 
+39    |-def f5(arg1: int, *args: Union[Union[int, int, float]]) -> None: ...  # PYI041
+   39 |+def f5(arg1: int, *args: float) -> None: ...  # PYI041
+40 40 | 
+41 41 | 
+42 42 | class Foo:
+
+PYI041.pyi:45:24: PYI041 [*] Use `complex` instead of `int | float | complex`
+   |
+43 |     def good(self, arg: int) -> None: ...
+44 | 
+45 |     def bad(self, arg: int | float | complex) -> None: ...  # PYI041
    |                        ^^^^^^^^^^^^^^^^^^^^^ PYI041
+46 | 
+47 |     def bad2(self, arg: int | Union[float, complex]) -> None: ...  # PYI041
    |
+   = help: Remove duplicates
 
-PYI041.pyi:39:24: PYI041 Use `complex` instead of `int | complex`
+ℹ Safe fix
+42 42 | class Foo:
+43 43 |     def good(self, arg: int) -> None: ...
+44 44 | 
+45    |-    def bad(self, arg: int | float | complex) -> None: ...  # PYI041
+   45 |+    def bad(self, arg: complex) -> None: ...  # PYI041
+46 46 | 
+47 47 |     def bad2(self, arg: int | Union[float, complex]) -> None: ...  # PYI041
+48 48 | 
+
+PYI041.pyi:47:25: PYI041 [*] Use `complex` instead of `int | float | complex`
    |
-37 |     def good(self, arg: int) -> None: ...
-38 | 
-39 |     def bad(self, arg: int | float | complex) -> None: ...  # PYI041
-   |                        ^^^^^^^^^^^^^^^^^^^^^ PYI041
+45 |     def bad(self, arg: int | float | complex) -> None: ...  # PYI041
+46 | 
+47 |     def bad2(self, arg: int | Union[float, complex]) -> None: ...  # PYI041
+   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI041
+48 | 
+49 |     def bad3(self, arg: Union[Union[float, complex], int]) -> None: ...  # PYI041
    |
+   = help: Remove duplicates
 
+ℹ Safe fix
+44 44 | 
+45 45 |     def bad(self, arg: int | float | complex) -> None: ...  # PYI041
+46 46 | 
+47    |-    def bad2(self, arg: int | Union[float, complex]) -> None: ...  # PYI041
+   47 |+    def bad2(self, arg: complex) -> None: ...  # PYI041
+48 48 | 
+49 49 |     def bad3(self, arg: Union[Union[float, complex], int]) -> None: ...  # PYI041
+50 50 | 
 
+PYI041.pyi:49:25: PYI041 [*] Use `complex` instead of `int | float | complex`
+   |
+47 |     def bad2(self, arg: int | Union[float, complex]) -> None: ...  # PYI041
+48 | 
+49 |     def bad3(self, arg: Union[Union[float, complex], int]) -> None: ...  # PYI041
+   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI041
+50 | 
+51 |     def bad4(self, arg: Union[float | complex, int]) -> None: ...  # PYI041
+   |
+   = help: Remove duplicates
+
+ℹ Safe fix
+46 46 | 
+47 47 |     def bad2(self, arg: int | Union[float, complex]) -> None: ...  # PYI041
+48 48 | 
+49    |-    def bad3(self, arg: Union[Union[float, complex], int]) -> None: ...  # PYI041
+   49 |+    def bad3(self, arg: complex) -> None: ...  # PYI041
+50 50 | 
+51 51 |     def bad4(self, arg: Union[float | complex, int]) -> None: ...  # PYI041
+52 52 | 
+
+PYI041.pyi:51:25: PYI041 [*] Use `complex` instead of `int | float | complex`
+   |
+49 |     def bad3(self, arg: Union[Union[float, complex], int]) -> None: ...  # PYI041
+50 | 
+51 |     def bad4(self, arg: Union[float | complex, int]) -> None: ...  # PYI041
+   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI041
+52 | 
+53 |     def bad5(self, arg: int | (float | complex)) -> None: ...  # PYI041
+   |
+   = help: Remove duplicates
+
+ℹ Safe fix
+48 48 | 
+49 49 |     def bad3(self, arg: Union[Union[float, complex], int]) -> None: ...  # PYI041
+50 50 | 
+51    |-    def bad4(self, arg: Union[float | complex, int]) -> None: ...  # PYI041
+   51 |+    def bad4(self, arg: complex) -> None: ...  # PYI041
+52 52 | 
+53 53 |     def bad5(self, arg: int | (float | complex)) -> None: ...  # PYI041
+
+PYI041.pyi:53:25: PYI041 [*] Use `complex` instead of `int | float | complex`
+   |
+51 |     def bad4(self, arg: Union[float | complex, int]) -> None: ...  # PYI041
+52 | 
+53 |     def bad5(self, arg: int | (float | complex)) -> None: ...  # PYI041
+   |                         ^^^^^^^^^^^^^^^^^^^^^^^ PYI041
+   |
+   = help: Remove duplicates
+
+ℹ Safe fix
+50 50 | 
+51 51 |     def bad4(self, arg: Union[float | complex, int]) -> None: ...  # PYI041
+52 52 | 
+53    |-    def bad5(self, arg: int | (float | complex)) -> None: ...  # PYI041
+   53 |+    def bad5(self, arg: complex) -> None: ...  # PYI041

--- a/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI041_PYI041.pyi.snap
+++ b/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI041_PYI041.pyi.snap
@@ -166,7 +166,7 @@ PYI041.pyi:49:10: PYI041 [*] Use `complex` instead of `int | float | complex`
    |
    = help: Remove duplicates
 
-ℹ Safe fix
+ℹ Unsafe fix
 46 46 | 
 47 47 | 
 48 48 | def f8(
@@ -192,7 +192,7 @@ PYI041.pyi:56:9: PYI041 [*] Use `complex` instead of `int | float | complex`
    |
    = help: Remove duplicates
 
-ℹ Safe fix
+ℹ Unsafe fix
 53 53 | 
 54 54 | def f9(
 55 55 |     arg: (

--- a/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI041_PYI041.pyi.snap
+++ b/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI041_PYI041.pyi.snap
@@ -84,11 +84,11 @@ PYI041.pyi:33:24: PYI041 [*] Use `float` instead of `int | float`
    33 |+async def f4(**kwargs: float) -> None: ...  # PYI041
 34 34 | 
 35 35 | 
-36 36 | def f4(arg1: int, *args: Union[int, int, float]) -> None: ...  # PYI041
+36 36 | def f5(arg1: int, *args: Union[int, int, float]) -> None: ...  # PYI041
 
 PYI041.pyi:36:26: PYI041 [*] Use `float` instead of `int | float`
    |
-36 | def f4(arg1: int, *args: Union[int, int, float]) -> None: ...  # PYI041
+36 | def f5(arg1: int, *args: Union[int, int, float]) -> None: ...  # PYI041
    |                          ^^^^^^^^^^^^^^^^^^^^^^ PYI041
    |
    = help: Remove duplicates
@@ -97,66 +97,66 @@ PYI041.pyi:36:26: PYI041 [*] Use `float` instead of `int | float`
 33 33 | async def f4(**kwargs: int | int | float) -> None: ...  # PYI041
 34 34 | 
 35 35 | 
-36    |-def f4(arg1: int, *args: Union[int, int, float]) -> None: ...  # PYI041
-   36 |+def f4(arg1: int, *args: float) -> None: ...  # PYI041
+36    |-def f5(arg1: int, *args: Union[int, int, float]) -> None: ...  # PYI041
+   36 |+def f5(arg1: int, *args: float) -> None: ...  # PYI041
 37 37 | 
 38 38 | 
-39 39 | def f5(arg1: int, *args: Union[Union[int, int, float]]) -> None: ...  # PYI041
+39 39 | def f6(arg1: int, *args: Union[Union[int, int, float]]) -> None: ...  # PYI041
 
 PYI041.pyi:39:26: PYI041 [*] Use `float` instead of `int | float`
    |
-39 | def f5(arg1: int, *args: Union[Union[int, int, float]]) -> None: ...  # PYI041
+39 | def f6(arg1: int, *args: Union[Union[int, int, float]]) -> None: ...  # PYI041
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI041
    |
    = help: Remove duplicates
 
 ℹ Safe fix
-36 36 | def f4(arg1: int, *args: Union[int, int, float]) -> None: ...  # PYI041
+36 36 | def f5(arg1: int, *args: Union[int, int, float]) -> None: ...  # PYI041
 37 37 | 
 38 38 | 
-39    |-def f5(arg1: int, *args: Union[Union[int, int, float]]) -> None: ...  # PYI041
-   39 |+def f5(arg1: int, *args: float) -> None: ...  # PYI041
+39    |-def f6(arg1: int, *args: Union[Union[int, int, float]]) -> None: ...  # PYI041
+   39 |+def f6(arg1: int, *args: float) -> None: ...  # PYI041
 40 40 | 
 41 41 | 
-42 42 | def f6(arg1: int, *args: Union[Union[Union[int, int, float]]]) -> None: ...  # PYI041
+42 42 | def f7(arg1: int, *args: Union[Union[Union[int, int, float]]]) -> None: ...  # PYI041
 
 PYI041.pyi:42:26: PYI041 [*] Use `float` instead of `int | float`
    |
-42 | def f6(arg1: int, *args: Union[Union[Union[int, int, float]]]) -> None: ...  # PYI041
+42 | def f7(arg1: int, *args: Union[Union[Union[int, int, float]]]) -> None: ...  # PYI041
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI041
    |
    = help: Remove duplicates
 
 ℹ Safe fix
-39 39 | def f5(arg1: int, *args: Union[Union[int, int, float]]) -> None: ...  # PYI041
+39 39 | def f6(arg1: int, *args: Union[Union[int, int, float]]) -> None: ...  # PYI041
 40 40 | 
 41 41 | 
-42    |-def f6(arg1: int, *args: Union[Union[Union[int, int, float]]]) -> None: ...  # PYI041
-   42 |+def f6(arg1: int, *args: float) -> None: ...  # PYI041
+42    |-def f7(arg1: int, *args: Union[Union[Union[int, int, float]]]) -> None: ...  # PYI041
+   42 |+def f7(arg1: int, *args: float) -> None: ...  # PYI041
 43 43 | 
 44 44 | 
-45 45 | def f7(arg1: int, *args: Union[Union[Union[int | int | float]]]) -> None: ...  # PYI041
+45 45 | def f8(arg1: int, *args: Union[Union[Union[int | int | float]]]) -> None: ...  # PYI041
 
 PYI041.pyi:45:26: PYI041 [*] Use `float` instead of `int | float`
    |
-45 | def f7(arg1: int, *args: Union[Union[Union[int | int | float]]]) -> None: ...  # PYI041
+45 | def f8(arg1: int, *args: Union[Union[Union[int | int | float]]]) -> None: ...  # PYI041
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI041
    |
    = help: Remove duplicates
 
 ℹ Safe fix
-42 42 | def f6(arg1: int, *args: Union[Union[Union[int, int, float]]]) -> None: ...  # PYI041
+42 42 | def f7(arg1: int, *args: Union[Union[Union[int, int, float]]]) -> None: ...  # PYI041
 43 43 | 
 44 44 | 
-45    |-def f7(arg1: int, *args: Union[Union[Union[int | int | float]]]) -> None: ...  # PYI041
-   45 |+def f7(arg1: int, *args: float) -> None: ...  # PYI041
+45    |-def f8(arg1: int, *args: Union[Union[Union[int | int | float]]]) -> None: ...  # PYI041
+   45 |+def f8(arg1: int, *args: float) -> None: ...  # PYI041
 46 46 | 
 47 47 | 
-48 48 | def f8(
+48 48 | def f9(
 
 PYI041.pyi:49:10: PYI041 [*] Use `complex` instead of `int | float | complex`
    |
-48 |   def f8(
+48 |   def f9(
 49 |       arg: Union[  # comment 
    |  __________^
 50 | |         float, # another
@@ -169,18 +169,18 @@ PYI041.pyi:49:10: PYI041 [*] Use `complex` instead of `int | float | complex`
 ℹ Unsafe fix
 46 46 | 
 47 47 | 
-48 48 | def f8(
+48 48 | def f9(
 49    |-    arg: Union[  # comment 
 50    |-        float, # another
 51    |-        complex, int]
    49 |+    arg: complex
 52 50 |     ) -> None: ...  # PYI041
 53 51 | 
-54 52 | def f9(
+54 52 | def f10(
 
 PYI041.pyi:56:9: PYI041 [*] Use `complex` instead of `int | float | complex`
    |
-54 |   def f9(
+54 |   def f10(
 55 |       arg: (
 56 |           int | # comment
    |  _________^
@@ -194,7 +194,7 @@ PYI041.pyi:56:9: PYI041 [*] Use `complex` instead of `int | float | complex`
 
 ℹ Unsafe fix
 53 53 | 
-54 54 | def f9(
+54 54 | def f10(
 55 55 |     arg: (
 56    |-        int | # comment
 57    |-        float |  # another

--- a/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI041_PYI041.pyi.snap
+++ b/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI041_PYI041.pyi.snap
@@ -152,103 +152,151 @@ PYI041.pyi:45:26: PYI041 [*] Use `float` instead of `int | float`
    45 |+def f7(arg1: int, *args: float) -> None: ...  # PYI041
 46 46 | 
 47 47 | 
-48 48 | class Foo:
+48 48 | def f8(
 
-PYI041.pyi:51:24: PYI041 [*] Use `complex` instead of `int | float | complex`
+PYI041.pyi:49:10: PYI041 [*] Use `complex` instead of `int | float | complex`
    |
-49 |     def good(self, arg: int) -> None: ...
-50 | 
-51 |     def bad(self, arg: int | float | complex) -> None: ...  # PYI041
+48 |   def f8(
+49 |       arg: Union[  # comment 
+   |  __________^
+50 | |         float, # another
+51 | |         complex, int]
+   | |_____________________^ PYI041
+52 |       ) -> None: ...  # PYI041
+   |
+   = help: Remove duplicates
+
+ℹ Safe fix
+46 46 | 
+47 47 | 
+48 48 | def f8(
+49    |-    arg: Union[  # comment 
+50    |-        float, # another
+51    |-        complex, int]
+   49 |+    arg: complex
+52 50 |     ) -> None: ...  # PYI041
+53 51 | 
+54 52 | def f9(
+
+PYI041.pyi:56:9: PYI041 [*] Use `complex` instead of `int | float | complex`
+   |
+54 |   def f9(
+55 |       arg: (
+56 |           int | # comment
+   |  _________^
+57 | |         float |  # another
+58 | |         complex
+   | |_______________^ PYI041
+59 |       )    
+60 |       ) -> None: ... # PYI041
+   |
+   = help: Remove duplicates
+
+ℹ Safe fix
+53 53 | 
+54 54 | def f9(
+55 55 |     arg: (
+56    |-        int | # comment
+57    |-        float |  # another
+58 56 |         complex
+59 57 |     )    
+60 58 |     ) -> None: ... # PYI041
+
+PYI041.pyi:65:24: PYI041 [*] Use `complex` instead of `int | float | complex`
+   |
+63 |     def good(self, arg: int) -> None: ...
+64 | 
+65 |     def bad(self, arg: int | float | complex) -> None: ...  # PYI041
    |                        ^^^^^^^^^^^^^^^^^^^^^ PYI041
-52 | 
-53 |     def bad2(self, arg: int | Union[float, complex]) -> None: ...  # PYI041
+66 | 
+67 |     def bad2(self, arg: int | Union[float, complex]) -> None: ...  # PYI041
    |
    = help: Remove duplicates
 
 ℹ Safe fix
-48 48 | class Foo:
-49 49 |     def good(self, arg: int) -> None: ...
-50 50 | 
-51    |-    def bad(self, arg: int | float | complex) -> None: ...  # PYI041
-   51 |+    def bad(self, arg: complex) -> None: ...  # PYI041
-52 52 | 
-53 53 |     def bad2(self, arg: int | Union[float, complex]) -> None: ...  # PYI041
-54 54 | 
+62 62 | class Foo:
+63 63 |     def good(self, arg: int) -> None: ...
+64 64 | 
+65    |-    def bad(self, arg: int | float | complex) -> None: ...  # PYI041
+   65 |+    def bad(self, arg: complex) -> None: ...  # PYI041
+66 66 | 
+67 67 |     def bad2(self, arg: int | Union[float, complex]) -> None: ...  # PYI041
+68 68 | 
 
-PYI041.pyi:53:25: PYI041 [*] Use `complex` instead of `int | float | complex`
+PYI041.pyi:67:25: PYI041 [*] Use `complex` instead of `int | float | complex`
    |
-51 |     def bad(self, arg: int | float | complex) -> None: ...  # PYI041
-52 | 
-53 |     def bad2(self, arg: int | Union[float, complex]) -> None: ...  # PYI041
+65 |     def bad(self, arg: int | float | complex) -> None: ...  # PYI041
+66 | 
+67 |     def bad2(self, arg: int | Union[float, complex]) -> None: ...  # PYI041
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI041
-54 | 
-55 |     def bad3(self, arg: Union[Union[float, complex], int]) -> None: ...  # PYI041
+68 | 
+69 |     def bad3(self, arg: Union[Union[float, complex], int]) -> None: ...  # PYI041
    |
    = help: Remove duplicates
 
 ℹ Safe fix
-50 50 | 
-51 51 |     def bad(self, arg: int | float | complex) -> None: ...  # PYI041
-52 52 | 
-53    |-    def bad2(self, arg: int | Union[float, complex]) -> None: ...  # PYI041
-   53 |+    def bad2(self, arg: complex) -> None: ...  # PYI041
-54 54 | 
-55 55 |     def bad3(self, arg: Union[Union[float, complex], int]) -> None: ...  # PYI041
-56 56 | 
+64 64 | 
+65 65 |     def bad(self, arg: int | float | complex) -> None: ...  # PYI041
+66 66 | 
+67    |-    def bad2(self, arg: int | Union[float, complex]) -> None: ...  # PYI041
+   67 |+    def bad2(self, arg: complex) -> None: ...  # PYI041
+68 68 | 
+69 69 |     def bad3(self, arg: Union[Union[float, complex], int]) -> None: ...  # PYI041
+70 70 | 
 
-PYI041.pyi:55:25: PYI041 [*] Use `complex` instead of `int | float | complex`
+PYI041.pyi:69:25: PYI041 [*] Use `complex` instead of `int | float | complex`
    |
-53 |     def bad2(self, arg: int | Union[float, complex]) -> None: ...  # PYI041
-54 | 
-55 |     def bad3(self, arg: Union[Union[float, complex], int]) -> None: ...  # PYI041
+67 |     def bad2(self, arg: int | Union[float, complex]) -> None: ...  # PYI041
+68 | 
+69 |     def bad3(self, arg: Union[Union[float, complex], int]) -> None: ...  # PYI041
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI041
-56 | 
-57 |     def bad4(self, arg: Union[float | complex, int]) -> None: ...  # PYI041
+70 | 
+71 |     def bad4(self, arg: Union[float | complex, int]) -> None: ...  # PYI041
    |
    = help: Remove duplicates
 
 ℹ Safe fix
-52 52 | 
-53 53 |     def bad2(self, arg: int | Union[float, complex]) -> None: ...  # PYI041
-54 54 | 
-55    |-    def bad3(self, arg: Union[Union[float, complex], int]) -> None: ...  # PYI041
-   55 |+    def bad3(self, arg: complex) -> None: ...  # PYI041
-56 56 | 
-57 57 |     def bad4(self, arg: Union[float | complex, int]) -> None: ...  # PYI041
-58 58 | 
+66 66 | 
+67 67 |     def bad2(self, arg: int | Union[float, complex]) -> None: ...  # PYI041
+68 68 | 
+69    |-    def bad3(self, arg: Union[Union[float, complex], int]) -> None: ...  # PYI041
+   69 |+    def bad3(self, arg: complex) -> None: ...  # PYI041
+70 70 | 
+71 71 |     def bad4(self, arg: Union[float | complex, int]) -> None: ...  # PYI041
+72 72 | 
 
-PYI041.pyi:57:25: PYI041 [*] Use `complex` instead of `int | float | complex`
+PYI041.pyi:71:25: PYI041 [*] Use `complex` instead of `int | float | complex`
    |
-55 |     def bad3(self, arg: Union[Union[float, complex], int]) -> None: ...  # PYI041
-56 | 
-57 |     def bad4(self, arg: Union[float | complex, int]) -> None: ...  # PYI041
+69 |     def bad3(self, arg: Union[Union[float, complex], int]) -> None: ...  # PYI041
+70 | 
+71 |     def bad4(self, arg: Union[float | complex, int]) -> None: ...  # PYI041
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI041
-58 | 
-59 |     def bad5(self, arg: int | (float | complex)) -> None: ...  # PYI041
+72 | 
+73 |     def bad5(self, arg: int | (float | complex)) -> None: ...  # PYI041
    |
    = help: Remove duplicates
 
 ℹ Safe fix
-54 54 | 
-55 55 |     def bad3(self, arg: Union[Union[float, complex], int]) -> None: ...  # PYI041
-56 56 | 
-57    |-    def bad4(self, arg: Union[float | complex, int]) -> None: ...  # PYI041
-   57 |+    def bad4(self, arg: complex) -> None: ...  # PYI041
-58 58 | 
-59 59 |     def bad5(self, arg: int | (float | complex)) -> None: ...  # PYI041
+68 68 | 
+69 69 |     def bad3(self, arg: Union[Union[float, complex], int]) -> None: ...  # PYI041
+70 70 | 
+71    |-    def bad4(self, arg: Union[float | complex, int]) -> None: ...  # PYI041
+   71 |+    def bad4(self, arg: complex) -> None: ...  # PYI041
+72 72 | 
+73 73 |     def bad5(self, arg: int | (float | complex)) -> None: ...  # PYI041
 
-PYI041.pyi:59:25: PYI041 [*] Use `complex` instead of `int | float | complex`
+PYI041.pyi:73:25: PYI041 [*] Use `complex` instead of `int | float | complex`
    |
-57 |     def bad4(self, arg: Union[float | complex, int]) -> None: ...  # PYI041
-58 | 
-59 |     def bad5(self, arg: int | (float | complex)) -> None: ...  # PYI041
+71 |     def bad4(self, arg: Union[float | complex, int]) -> None: ...  # PYI041
+72 | 
+73 |     def bad5(self, arg: int | (float | complex)) -> None: ...  # PYI041
    |                         ^^^^^^^^^^^^^^^^^^^^^^^ PYI041
    |
    = help: Remove duplicates
 
 ℹ Safe fix
-56 56 | 
-57 57 |     def bad4(self, arg: Union[float | complex, int]) -> None: ...  # PYI041
-58 58 | 
-59    |-    def bad5(self, arg: int | (float | complex)) -> None: ...  # PYI041
-   59 |+    def bad5(self, arg: complex) -> None: ...  # PYI041
+70 70 | 
+71 71 |     def bad4(self, arg: Union[float | complex, int]) -> None: ...  # PYI041
+72 72 | 
+73    |-    def bad5(self, arg: int | (float | complex)) -> None: ...  # PYI041
+   73 |+    def bad5(self, arg: complex) -> None: ...  # PYI041

--- a/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI051_PYI051.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI051_PYI051.py.snap
@@ -36,6 +36,7 @@ PYI051.py:6:37: PYI051 `Literal[5]` is redundant in a union with `int`
 6 | C: TypeAlias = typing.Union[Literal[5], int, typing.Union[Literal["foo"], str]]
   |                                     ^ PYI051
 7 | D: TypeAlias = typing.Union[Literal[b"str_bytes", 42], bytes, int]
+8 | E: TypeAlias = typing.Union[typing.Union[typing.Union[typing.Union[Literal["foo"], str]]]]
   |
 
 PYI051.py:6:67: PYI051 `Literal["foo"]` is redundant in a union with `str`
@@ -45,6 +46,7 @@ PYI051.py:6:67: PYI051 `Literal["foo"]` is redundant in a union with `str`
 6 | C: TypeAlias = typing.Union[Literal[5], int, typing.Union[Literal["foo"], str]]
   |                                                                   ^^^^^ PYI051
 7 | D: TypeAlias = typing.Union[Literal[b"str_bytes", 42], bytes, int]
+8 | E: TypeAlias = typing.Union[typing.Union[typing.Union[typing.Union[Literal["foo"], str]]]]
   |
 
 PYI051.py:7:37: PYI051 `Literal[b"str_bytes"]` is redundant in a union with `bytes`
@@ -53,8 +55,8 @@ PYI051.py:7:37: PYI051 `Literal[b"str_bytes"]` is redundant in a union with `byt
 6 | C: TypeAlias = typing.Union[Literal[5], int, typing.Union[Literal["foo"], str]]
 7 | D: TypeAlias = typing.Union[Literal[b"str_bytes", 42], bytes, int]
   |                                     ^^^^^^^^^^^^ PYI051
-8 | 
-9 | def func(x: complex | Literal[1J], y: Union[Literal[3.14], float]): ...
+8 | E: TypeAlias = typing.Union[typing.Union[typing.Union[typing.Union[Literal["foo"], str]]]]
+9 | F: TypeAlias = typing.Union[str, typing.Union[typing.Union[typing.Union[Literal["foo"], int]]]]
   |
 
 PYI051.py:7:51: PYI051 `Literal[42]` is redundant in a union with `int`
@@ -63,28 +65,55 @@ PYI051.py:7:51: PYI051 `Literal[42]` is redundant in a union with `int`
 6 | C: TypeAlias = typing.Union[Literal[5], int, typing.Union[Literal["foo"], str]]
 7 | D: TypeAlias = typing.Union[Literal[b"str_bytes", 42], bytes, int]
   |                                                   ^^ PYI051
-8 | 
-9 | def func(x: complex | Literal[1J], y: Union[Literal[3.14], float]): ...
+8 | E: TypeAlias = typing.Union[typing.Union[typing.Union[typing.Union[Literal["foo"], str]]]]
+9 | F: TypeAlias = typing.Union[str, typing.Union[typing.Union[typing.Union[Literal["foo"], int]]]]
   |
 
-PYI051.py:9:31: PYI051 `Literal[1J]` is redundant in a union with `complex`
+PYI051.py:8:76: PYI051 `Literal["foo"]` is redundant in a union with `str`
+   |
+ 6 | C: TypeAlias = typing.Union[Literal[5], int, typing.Union[Literal["foo"], str]]
+ 7 | D: TypeAlias = typing.Union[Literal[b"str_bytes", 42], bytes, int]
+ 8 | E: TypeAlias = typing.Union[typing.Union[typing.Union[typing.Union[Literal["foo"], str]]]]
+   |                                                                            ^^^^^ PYI051
+ 9 | F: TypeAlias = typing.Union[str, typing.Union[typing.Union[typing.Union[Literal["foo"], int]]]]
+10 | G: typing.Union[str, typing.Union[typing.Union[typing.Union[Literal["foo"], int]]]]
+   |
+
+PYI051.py:9:81: PYI051 `Literal["foo"]` is redundant in a union with `str`
    |
  7 | D: TypeAlias = typing.Union[Literal[b"str_bytes", 42], bytes, int]
- 8 | 
- 9 | def func(x: complex | Literal[1J], y: Union[Literal[3.14], float]): ...
+ 8 | E: TypeAlias = typing.Union[typing.Union[typing.Union[typing.Union[Literal["foo"], str]]]]
+ 9 | F: TypeAlias = typing.Union[str, typing.Union[typing.Union[typing.Union[Literal["foo"], int]]]]
+   |                                                                                 ^^^^^ PYI051
+10 | G: typing.Union[str, typing.Union[typing.Union[typing.Union[Literal["foo"], int]]]]
+   |
+
+PYI051.py:10:69: PYI051 `Literal["foo"]` is redundant in a union with `str`
+   |
+ 8 | E: TypeAlias = typing.Union[typing.Union[typing.Union[typing.Union[Literal["foo"], str]]]]
+ 9 | F: TypeAlias = typing.Union[str, typing.Union[typing.Union[typing.Union[Literal["foo"], int]]]]
+10 | G: typing.Union[str, typing.Union[typing.Union[typing.Union[Literal["foo"], int]]]]
+   |                                                                     ^^^^^ PYI051
+11 | 
+12 | def func(x: complex | Literal[1J], y: Union[Literal[3.14], float]): ...
+   |
+
+PYI051.py:12:31: PYI051 `Literal[1J]` is redundant in a union with `complex`
+   |
+10 | G: typing.Union[str, typing.Union[typing.Union[typing.Union[Literal["foo"], int]]]]
+11 | 
+12 | def func(x: complex | Literal[1J], y: Union[Literal[3.14], float]): ...
    |                               ^^ PYI051
-10 | 
-11 | # OK
+13 | 
+14 | # OK
    |
 
-PYI051.py:9:53: PYI051 `Literal[3.14]` is redundant in a union with `float`
+PYI051.py:12:53: PYI051 `Literal[3.14]` is redundant in a union with `float`
    |
- 7 | D: TypeAlias = typing.Union[Literal[b"str_bytes", 42], bytes, int]
- 8 | 
- 9 | def func(x: complex | Literal[1J], y: Union[Literal[3.14], float]): ...
+10 | G: typing.Union[str, typing.Union[typing.Union[typing.Union[Literal["foo"], int]]]]
+11 | 
+12 | def func(x: complex | Literal[1J], y: Union[Literal[3.14], float]): ...
    |                                                     ^^^^ PYI051
-10 | 
-11 | # OK
+13 | 
+14 | # OK
    |
-
-

--- a/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI051_PYI051.pyi.snap
+++ b/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI051_PYI051.pyi.snap
@@ -36,6 +36,7 @@ PYI051.pyi:6:37: PYI051 `Literal[5]` is redundant in a union with `int`
 6 | C: TypeAlias = typing.Union[Literal[5], int, typing.Union[Literal["foo"], str]]
   |                                     ^ PYI051
 7 | D: TypeAlias = typing.Union[Literal[b"str_bytes", 42], bytes, int]
+8 | E: TypeAlias = typing.Union[typing.Union[typing.Union[typing.Union[Literal["foo"], str]]]]
   |
 
 PYI051.pyi:6:67: PYI051 `Literal["foo"]` is redundant in a union with `str`
@@ -45,6 +46,7 @@ PYI051.pyi:6:67: PYI051 `Literal["foo"]` is redundant in a union with `str`
 6 | C: TypeAlias = typing.Union[Literal[5], int, typing.Union[Literal["foo"], str]]
   |                                                                   ^^^^^ PYI051
 7 | D: TypeAlias = typing.Union[Literal[b"str_bytes", 42], bytes, int]
+8 | E: TypeAlias = typing.Union[typing.Union[typing.Union[typing.Union[Literal["foo"], str]]]]
   |
 
 PYI051.pyi:7:37: PYI051 `Literal[b"str_bytes"]` is redundant in a union with `bytes`
@@ -53,8 +55,8 @@ PYI051.pyi:7:37: PYI051 `Literal[b"str_bytes"]` is redundant in a union with `by
 6 | C: TypeAlias = typing.Union[Literal[5], int, typing.Union[Literal["foo"], str]]
 7 | D: TypeAlias = typing.Union[Literal[b"str_bytes", 42], bytes, int]
   |                                     ^^^^^^^^^^^^ PYI051
-8 | 
-9 | def func(x: complex | Literal[1J], y: Union[Literal[3.14], float]): ...
+8 | E: TypeAlias = typing.Union[typing.Union[typing.Union[typing.Union[Literal["foo"], str]]]]
+9 | F: TypeAlias = typing.Union[str, typing.Union[typing.Union[typing.Union[Literal["foo"], int]]]]
   |
 
 PYI051.pyi:7:51: PYI051 `Literal[42]` is redundant in a union with `int`
@@ -63,28 +65,55 @@ PYI051.pyi:7:51: PYI051 `Literal[42]` is redundant in a union with `int`
 6 | C: TypeAlias = typing.Union[Literal[5], int, typing.Union[Literal["foo"], str]]
 7 | D: TypeAlias = typing.Union[Literal[b"str_bytes", 42], bytes, int]
   |                                                   ^^ PYI051
-8 | 
-9 | def func(x: complex | Literal[1J], y: Union[Literal[3.14], float]): ...
+8 | E: TypeAlias = typing.Union[typing.Union[typing.Union[typing.Union[Literal["foo"], str]]]]
+9 | F: TypeAlias = typing.Union[str, typing.Union[typing.Union[typing.Union[Literal["foo"], int]]]]
   |
 
-PYI051.pyi:9:31: PYI051 `Literal[1J]` is redundant in a union with `complex`
+PYI051.pyi:8:76: PYI051 `Literal["foo"]` is redundant in a union with `str`
+   |
+ 6 | C: TypeAlias = typing.Union[Literal[5], int, typing.Union[Literal["foo"], str]]
+ 7 | D: TypeAlias = typing.Union[Literal[b"str_bytes", 42], bytes, int]
+ 8 | E: TypeAlias = typing.Union[typing.Union[typing.Union[typing.Union[Literal["foo"], str]]]]
+   |                                                                            ^^^^^ PYI051
+ 9 | F: TypeAlias = typing.Union[str, typing.Union[typing.Union[typing.Union[Literal["foo"], int]]]]
+10 | G: typing.Union[str, typing.Union[typing.Union[typing.Union[Literal["foo"], int]]]]
+   |
+
+PYI051.pyi:9:81: PYI051 `Literal["foo"]` is redundant in a union with `str`
    |
  7 | D: TypeAlias = typing.Union[Literal[b"str_bytes", 42], bytes, int]
- 8 | 
- 9 | def func(x: complex | Literal[1J], y: Union[Literal[3.14], float]): ...
+ 8 | E: TypeAlias = typing.Union[typing.Union[typing.Union[typing.Union[Literal["foo"], str]]]]
+ 9 | F: TypeAlias = typing.Union[str, typing.Union[typing.Union[typing.Union[Literal["foo"], int]]]]
+   |                                                                                 ^^^^^ PYI051
+10 | G: typing.Union[str, typing.Union[typing.Union[typing.Union[Literal["foo"], int]]]]
+   |
+
+PYI051.pyi:10:69: PYI051 `Literal["foo"]` is redundant in a union with `str`
+   |
+ 8 | E: TypeAlias = typing.Union[typing.Union[typing.Union[typing.Union[Literal["foo"], str]]]]
+ 9 | F: TypeAlias = typing.Union[str, typing.Union[typing.Union[typing.Union[Literal["foo"], int]]]]
+10 | G: typing.Union[str, typing.Union[typing.Union[typing.Union[Literal["foo"], int]]]]
+   |                                                                     ^^^^^ PYI051
+11 | 
+12 | def func(x: complex | Literal[1J], y: Union[Literal[3.14], float]): ...
+   |
+
+PYI051.pyi:12:31: PYI051 `Literal[1J]` is redundant in a union with `complex`
+   |
+10 | G: typing.Union[str, typing.Union[typing.Union[typing.Union[Literal["foo"], int]]]]
+11 | 
+12 | def func(x: complex | Literal[1J], y: Union[Literal[3.14], float]): ...
    |                               ^^ PYI051
-10 | 
-11 | # OK
+13 | 
+14 | # OK
    |
 
-PYI051.pyi:9:53: PYI051 `Literal[3.14]` is redundant in a union with `float`
+PYI051.pyi:12:53: PYI051 `Literal[3.14]` is redundant in a union with `float`
    |
- 7 | D: TypeAlias = typing.Union[Literal[b"str_bytes", 42], bytes, int]
- 8 | 
- 9 | def func(x: complex | Literal[1J], y: Union[Literal[3.14], float]): ...
+10 | G: typing.Union[str, typing.Union[typing.Union[typing.Union[Literal["foo"], int]]]]
+11 | 
+12 | def func(x: complex | Literal[1J], y: Union[Literal[3.14], float]): ...
    |                                                     ^^^^ PYI051
-10 | 
-11 | # OK
+13 | 
+14 | # OK
    |
-
-

--- a/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI055_PYI055.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI055_PYI055.py.snap
@@ -79,12 +79,12 @@ PYI055.py:44:9: PYI055 [*] Multiple `type` members in a union. Combine them into
 46 46 |     ...
 47 47 | 
 
-PYI055.py:50:15: PYI055 [*] Multiple `type` members in a union. Combine them into one, e.g., `type[_T | Converter[_T]]`.
+PYI055.py:50:9: PYI055 [*] Multiple `type` members in a union. Combine them into one, e.g., `type[Union[_T, Converter[_T]]]`.
    |
 48 | def convert_union(union: UnionType) -> _T | None:
 49 |     converters: tuple[
 50 |         Union[type[_T] | type[Converter[_T]] | Converter[_T] | Callable[[str], _T]], ...  # PYI055
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI055
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI055
 51 |     ] = union.__args__
 52 |     ...
    |
@@ -95,17 +95,17 @@ PYI055.py:50:15: PYI055 [*] Multiple `type` members in a union. Combine them int
 48 48 | def convert_union(union: UnionType) -> _T | None:
 49 49 |     converters: tuple[
 50    |-        Union[type[_T] | type[Converter[_T]] | Converter[_T] | Callable[[str], _T]], ...  # PYI055
-   50 |+        Union[type[_T | Converter[_T]] | Converter[_T] | Callable[[str], _T]], ...  # PYI055
+   50 |+        type[_T | Converter[_T]] | Converter[_T] | Callable[[str], _T], ...  # PYI055
 51 51 |     ] = union.__args__
 52 52 |     ...
 53 53 | 
 
-PYI055.py:56:15: PYI055 [*] Multiple `type` members in a union. Combine them into one, e.g., `type[_T | Converter[_T]]`.
+PYI055.py:56:9: PYI055 [*] Multiple `type` members in a union. Combine them into one, e.g., `type[_T | Converter[_T]]`.
    |
 54 | def convert_union(union: UnionType) -> _T | None:
 55 |     converters: tuple[
 56 |         Union[type[_T] | type[Converter[_T]]] | Converter[_T] | Callable[[str], _T], ...  # PYI055
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI055
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI055
 57 |     ] = union.__args__
 58 |     ...
    |
@@ -116,17 +116,17 @@ PYI055.py:56:15: PYI055 [*] Multiple `type` members in a union. Combine them int
 54 54 | def convert_union(union: UnionType) -> _T | None:
 55 55 |     converters: tuple[
 56    |-        Union[type[_T] | type[Converter[_T]]] | Converter[_T] | Callable[[str], _T], ...  # PYI055
-   56 |+        Union[type[_T | Converter[_T]]] | Converter[_T] | Callable[[str], _T], ...  # PYI055
+   56 |+        type[_T | Converter[_T]] | Converter[_T] | Callable[[str], _T], ...  # PYI055
 57 57 |     ] = union.__args__
 58 58 |     ...
 59 59 | 
 
-PYI055.py:62:15: PYI055 [*] Multiple `type` members in a union. Combine them into one, e.g., `type[_T | Converter[_T]]`.
+PYI055.py:62:9: PYI055 [*] Multiple `type` members in a union. Combine them into one, e.g., `type[_T | Converter[_T]]`.
    |
 60 | def convert_union(union: UnionType) -> _T | None:
 61 |     converters: tuple[
 62 |         Union[type[_T] | type[Converter[_T]] | str] | Converter[_T] | Callable[[str], _T], ...  # PYI055
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI055
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI055
 63 |     ] = union.__args__
 64 |     ...
    |
@@ -137,8 +137,6 @@ PYI055.py:62:15: PYI055 [*] Multiple `type` members in a union. Combine them int
 60 60 | def convert_union(union: UnionType) -> _T | None:
 61 61 |     converters: tuple[
 62    |-        Union[type[_T] | type[Converter[_T]] | str] | Converter[_T] | Callable[[str], _T], ...  # PYI055
-   62 |+        Union[type[_T | Converter[_T]] | str] | Converter[_T] | Callable[[str], _T], ...  # PYI055
+   62 |+        type[_T | Converter[_T]] | str | Converter[_T] | Callable[[str], _T], ...  # PYI055
 63 63 |     ] = union.__args__
 64 64 |     ...
-
-

--- a/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI055_PYI055.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI055_PYI055.py.snap
@@ -79,7 +79,7 @@ PYI055.py:44:9: PYI055 [*] Multiple `type` members in a union. Combine them into
 46 46 |     ...
 47 47 | 
 
-PYI055.py:50:9: PYI055 [*] Multiple `type` members in a union. Combine them into one, e.g., `type[Union[_T, Converter[_T]]]`.
+PYI055.py:50:9: PYI055 [*] Multiple `type` members in a union. Combine them into one, e.g., `type[_T | Converter[_T]]`.
    |
 48 | def convert_union(union: UnionType) -> _T | None:
 49 |     converters: tuple[

--- a/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI055_PYI055.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI055_PYI055.py.snap
@@ -1,90 +1,96 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_pyi/mod.rs
 ---
-PYI055.py:31:8: PYI055 [*] Multiple `type` members in a union. Combine them into one, e.g., `type[requests_mock.Mocker | httpretty | str]`.
+PYI055.py:34:8: PYI055 [*] Multiple `type` members in a union. Combine them into one, e.g., `type[requests_mock.Mocker | httpretty | str]`.
    |
-29 | def func():
-30 |     # PYI055
-31 |     x: type[requests_mock.Mocker] | type[httpretty] | type[str] = requests_mock.Mocker
+32 | def func():
+33 |     # PYI055
+34 |     x: type[requests_mock.Mocker] | type[httpretty] | type[str] = requests_mock.Mocker
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI055
-32 |     y: Union[type[requests_mock.Mocker], type[httpretty], type[str]] = requests_mock.Mocker
+35 |     y: Union[type[requests_mock.Mocker], type[httpretty], type[str]] = requests_mock.Mocker
+36 |     z: Union[  # comment
    |
    = help: Combine multiple `type` members
 
 ℹ Safe fix
-28 28 | 
-29 29 | def func():
-30 30 |     # PYI055
-31    |-    x: type[requests_mock.Mocker] | type[httpretty] | type[str] = requests_mock.Mocker
-   31 |+    x: type[requests_mock.Mocker | httpretty | str] = requests_mock.Mocker
-32 32 |     y: Union[type[requests_mock.Mocker], type[httpretty], type[str]] = requests_mock.Mocker
-33 33 | 
-34 34 | 
+31 31 | 
+32 32 | def func():
+33 33 |     # PYI055
+34    |-    x: type[requests_mock.Mocker] | type[httpretty] | type[str] = requests_mock.Mocker
+   34 |+    x: type[requests_mock.Mocker | httpretty | str] = requests_mock.Mocker
+35 35 |     y: Union[type[requests_mock.Mocker], type[httpretty], type[str]] = requests_mock.Mocker
+36 36 |     z: Union[  # comment
+37 37 |         type[requests_mock.Mocker], # another comment
 
-PYI055.py:32:8: PYI055 [*] Multiple `type` members in a union. Combine them into one, e.g., `type[Union[requests_mock.Mocker, httpretty, str]]`.
+PYI055.py:35:8: PYI055 [*] Multiple `type` members in a union. Combine them into one, e.g., `type[Union[requests_mock.Mocker, httpretty, str]]`.
    |
-30 |     # PYI055
-31 |     x: type[requests_mock.Mocker] | type[httpretty] | type[str] = requests_mock.Mocker
-32 |     y: Union[type[requests_mock.Mocker], type[httpretty], type[str]] = requests_mock.Mocker
+33 |     # PYI055
+34 |     x: type[requests_mock.Mocker] | type[httpretty] | type[str] = requests_mock.Mocker
+35 |     y: Union[type[requests_mock.Mocker], type[httpretty], type[str]] = requests_mock.Mocker
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI055
+36 |     z: Union[  # comment
+37 |         type[requests_mock.Mocker], # another comment
+   |
+   = help: Combine multiple `type` members
+
+ℹ Safe fix
+32 32 | def func():
+33 33 |     # PYI055
+34 34 |     x: type[requests_mock.Mocker] | type[httpretty] | type[str] = requests_mock.Mocker
+35    |-    y: Union[type[requests_mock.Mocker], type[httpretty], type[str]] = requests_mock.Mocker
+   35 |+    y: type[Union[requests_mock.Mocker, httpretty, str]] = requests_mock.Mocker
+36 36 |     z: Union[  # comment
+37 37 |         type[requests_mock.Mocker], # another comment
+38 38 |         type[httpretty], type[str]] = requests_mock.Mocker
+
+PYI055.py:36:8: PYI055 [*] Multiple `type` members in a union. Combine them into one, e.g., `type[Union[requests_mock.Mocker, httpretty, str]]`.
+   |
+34 |       x: type[requests_mock.Mocker] | type[httpretty] | type[str] = requests_mock.Mocker
+35 |       y: Union[type[requests_mock.Mocker], type[httpretty], type[str]] = requests_mock.Mocker
+36 |       z: Union[  # comment
+   |  ________^
+37 | |         type[requests_mock.Mocker], # another comment
+38 | |         type[httpretty], type[str]] = requests_mock.Mocker
+   | |___________________________________^ PYI055
+   |
+   = help: Combine multiple `type` members
+
+ℹ Unsafe fix
+33 33 |     # PYI055
+34 34 |     x: type[requests_mock.Mocker] | type[httpretty] | type[str] = requests_mock.Mocker
+35 35 |     y: Union[type[requests_mock.Mocker], type[httpretty], type[str]] = requests_mock.Mocker
+36    |-    z: Union[  # comment
+37    |-        type[requests_mock.Mocker], # another comment
+38    |-        type[httpretty], type[str]] = requests_mock.Mocker
+   36 |+    z: type[Union[requests_mock.Mocker, httpretty, str]] = requests_mock.Mocker
+39 37 | 
+40 38 | 
+41 39 | def func():
+
+PYI055.py:45:8: PYI055 [*] Multiple `type` members in a union. Combine them into one, e.g., `type[Union[requests_mock.Mocker, httpretty, str]]`.
+   |
+44 |     # PYI055
+45 |     x: Union[type[requests_mock.Mocker], type[httpretty], type[str]] = requests_mock.Mocker
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI055
    |
    = help: Combine multiple `type` members
 
 ℹ Safe fix
-29 29 | def func():
-30 30 |     # PYI055
-31 31 |     x: type[requests_mock.Mocker] | type[httpretty] | type[str] = requests_mock.Mocker
-32    |-    y: Union[type[requests_mock.Mocker], type[httpretty], type[str]] = requests_mock.Mocker
-   32 |+    y: type[Union[requests_mock.Mocker, httpretty, str]] = requests_mock.Mocker
-33 33 | 
-34 34 | 
-35 35 | def func():
-
-PYI055.py:39:8: PYI055 [*] Multiple `type` members in a union. Combine them into one, e.g., `type[Union[requests_mock.Mocker, httpretty, str]]`.
-   |
-38 |     # PYI055
-39 |     x: Union[type[requests_mock.Mocker], type[httpretty], type[str]] = requests_mock.Mocker
-   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI055
-   |
-   = help: Combine multiple `type` members
-
-ℹ Safe fix
-36 36 |     from typing import Union as U
-37 37 | 
-38 38 |     # PYI055
-39    |-    x: Union[type[requests_mock.Mocker], type[httpretty], type[str]] = requests_mock.Mocker
-   39 |+    x: type[Union[requests_mock.Mocker, httpretty, str]] = requests_mock.Mocker
-40 40 | 
-41 41 | 
-42 42 | def convert_union(union: UnionType) -> _T | None:
-
-PYI055.py:44:9: PYI055 [*] Multiple `type` members in a union. Combine them into one, e.g., `type[_T | Converter[_T]]`.
-   |
-42 | def convert_union(union: UnionType) -> _T | None:
-43 |     converters: tuple[
-44 |         type[_T] | type[Converter[_T]] | Converter[_T] | Callable[[str], _T], ...  # PYI055
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI055
-45 |     ] = union.__args__
-46 |     ...
-   |
-   = help: Combine multiple `type` members
-
-ℹ Safe fix
-41 41 | 
-42 42 | def convert_union(union: UnionType) -> _T | None:
-43 43 |     converters: tuple[
-44    |-        type[_T] | type[Converter[_T]] | Converter[_T] | Callable[[str], _T], ...  # PYI055
-   44 |+        type[_T | Converter[_T]] | Converter[_T] | Callable[[str], _T], ...  # PYI055
-45 45 |     ] = union.__args__
-46 46 |     ...
+42 42 |     from typing import Union as U
+43 43 | 
+44 44 |     # PYI055
+45    |-    x: Union[type[requests_mock.Mocker], type[httpretty], type[str]] = requests_mock.Mocker
+   45 |+    x: type[Union[requests_mock.Mocker, httpretty, str]] = requests_mock.Mocker
+46 46 | 
 47 47 | 
+48 48 | def convert_union(union: UnionType) -> _T | None:
 
 PYI055.py:50:9: PYI055 [*] Multiple `type` members in a union. Combine them into one, e.g., `type[_T | Converter[_T]]`.
    |
 48 | def convert_union(union: UnionType) -> _T | None:
 49 |     converters: tuple[
-50 |         Union[type[_T] | type[Converter[_T]] | Converter[_T] | Callable[[str], _T]], ...  # PYI055
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI055
+50 |         type[_T] | type[Converter[_T]] | Converter[_T] | Callable[[str], _T], ...  # PYI055
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI055
 51 |     ] = union.__args__
 52 |     ...
    |
@@ -94,7 +100,7 @@ PYI055.py:50:9: PYI055 [*] Multiple `type` members in a union. Combine them into
 47 47 | 
 48 48 | def convert_union(union: UnionType) -> _T | None:
 49 49 |     converters: tuple[
-50    |-        Union[type[_T] | type[Converter[_T]] | Converter[_T] | Callable[[str], _T]], ...  # PYI055
+50    |-        type[_T] | type[Converter[_T]] | Converter[_T] | Callable[[str], _T], ...  # PYI055
    50 |+        type[_T | Converter[_T]] | Converter[_T] | Callable[[str], _T], ...  # PYI055
 51 51 |     ] = union.__args__
 52 52 |     ...
@@ -104,7 +110,7 @@ PYI055.py:56:9: PYI055 [*] Multiple `type` members in a union. Combine them into
    |
 54 | def convert_union(union: UnionType) -> _T | None:
 55 |     converters: tuple[
-56 |         Union[type[_T] | type[Converter[_T]]] | Converter[_T] | Callable[[str], _T], ...  # PYI055
+56 |         Union[type[_T] | type[Converter[_T]] | Converter[_T] | Callable[[str], _T]], ...  # PYI055
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI055
 57 |     ] = union.__args__
 58 |     ...
@@ -115,7 +121,7 @@ PYI055.py:56:9: PYI055 [*] Multiple `type` members in a union. Combine them into
 53 53 | 
 54 54 | def convert_union(union: UnionType) -> _T | None:
 55 55 |     converters: tuple[
-56    |-        Union[type[_T] | type[Converter[_T]]] | Converter[_T] | Callable[[str], _T], ...  # PYI055
+56    |-        Union[type[_T] | type[Converter[_T]] | Converter[_T] | Callable[[str], _T]], ...  # PYI055
    56 |+        type[_T | Converter[_T]] | Converter[_T] | Callable[[str], _T], ...  # PYI055
 57 57 |     ] = union.__args__
 58 58 |     ...
@@ -125,8 +131,8 @@ PYI055.py:62:9: PYI055 [*] Multiple `type` members in a union. Combine them into
    |
 60 | def convert_union(union: UnionType) -> _T | None:
 61 |     converters: tuple[
-62 |         Union[type[_T] | type[Converter[_T]] | str] | Converter[_T] | Callable[[str], _T], ...  # PYI055
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI055
+62 |         Union[type[_T] | type[Converter[_T]]] | Converter[_T] | Callable[[str], _T], ...  # PYI055
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI055
 63 |     ] = union.__args__
 64 |     ...
    |
@@ -136,7 +142,28 @@ PYI055.py:62:9: PYI055 [*] Multiple `type` members in a union. Combine them into
 59 59 | 
 60 60 | def convert_union(union: UnionType) -> _T | None:
 61 61 |     converters: tuple[
-62    |-        Union[type[_T] | type[Converter[_T]] | str] | Converter[_T] | Callable[[str], _T], ...  # PYI055
-   62 |+        type[_T | Converter[_T]] | str | Converter[_T] | Callable[[str], _T], ...  # PYI055
+62    |-        Union[type[_T] | type[Converter[_T]]] | Converter[_T] | Callable[[str], _T], ...  # PYI055
+   62 |+        type[_T | Converter[_T]] | Converter[_T] | Callable[[str], _T], ...  # PYI055
 63 63 |     ] = union.__args__
 64 64 |     ...
+65 65 | 
+
+PYI055.py:68:9: PYI055 [*] Multiple `type` members in a union. Combine them into one, e.g., `type[_T | Converter[_T]]`.
+   |
+66 | def convert_union(union: UnionType) -> _T | None:
+67 |     converters: tuple[
+68 |         Union[type[_T] | type[Converter[_T]] | str] | Converter[_T] | Callable[[str], _T], ...  # PYI055
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI055
+69 |     ] = union.__args__
+70 |     ...
+   |
+   = help: Combine multiple `type` members
+
+ℹ Safe fix
+65 65 | 
+66 66 | def convert_union(union: UnionType) -> _T | None:
+67 67 |     converters: tuple[
+68    |-        Union[type[_T] | type[Converter[_T]] | str] | Converter[_T] | Callable[[str], _T], ...  # PYI055
+   68 |+        type[_T | Converter[_T]] | str | Converter[_T] | Callable[[str], _T], ...  # PYI055
+69 69 |     ] = union.__args__
+70 70 |     ...

--- a/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI055_PYI055.pyi.snap
+++ b/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI055_PYI055.pyi.snap
@@ -190,7 +190,7 @@ PYI055.pyi:13:15: PYI055 [*] Multiple `type` members in a union. Combine them in
 
 PYI055.pyi:23:7: PYI055 [*] Multiple `type` members in a union. Combine them into one, e.g., `type[requests_mock.Mocker | httpretty]`.
    |
-22 | # OK
+22 | # PYI055
 23 | item: type[requests_mock.Mocker] | type[httpretty] = requests_mock.Mocker
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI055
 24 | 
@@ -201,7 +201,7 @@ PYI055.pyi:23:7: PYI055 [*] Multiple `type` members in a union. Combine them int
 ℹ Safe fix
 20 20 | def func(arg: type[int, float] | str) -> None: ...
 21 21 | 
-22 22 | # OK
+22 22 | # PYI055
 23    |-item: type[requests_mock.Mocker] | type[httpretty] = requests_mock.Mocker
    23 |+item: type[requests_mock.Mocker | httpretty] = requests_mock.Mocker
 24 24 | 
@@ -215,6 +215,7 @@ PYI055.pyi:27:11: PYI055 [*] Multiple `type` members in a union. Combine them in
 27 |     item: type[requests_mock.Mocker] | type[httpretty] | type[str] = requests_mock.Mocker
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI055
 28 |     item2: Union[type[requests_mock.Mocker], type[httpretty], type[str]] = requests_mock.Mocker
+29 |     item3: Union[  # comment
    |
    = help: Combine multiple `type` members
 
@@ -225,6 +226,8 @@ PYI055.pyi:27:11: PYI055 [*] Multiple `type` members in a union. Combine them in
 27    |-    item: type[requests_mock.Mocker] | type[httpretty] | type[str] = requests_mock.Mocker
    27 |+    item: type[requests_mock.Mocker | httpretty | str] = requests_mock.Mocker
 28 28 |     item2: Union[type[requests_mock.Mocker], type[httpretty], type[str]] = requests_mock.Mocker
+29 29 |     item3: Union[  # comment
+30 30 |         type[requests_mock.Mocker], # another comment
 
 PYI055.pyi:28:12: PYI055 [*] Multiple `type` members in a union. Combine them into one, e.g., `type[Union[requests_mock.Mocker, httpretty, str]]`.
    |
@@ -232,6 +235,8 @@ PYI055.pyi:28:12: PYI055 [*] Multiple `type` members in a union. Combine them in
 27 |     item: type[requests_mock.Mocker] | type[httpretty] | type[str] = requests_mock.Mocker
 28 |     item2: Union[type[requests_mock.Mocker], type[httpretty], type[str]] = requests_mock.Mocker
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI055
+29 |     item3: Union[  # comment
+30 |         type[requests_mock.Mocker], # another comment
    |
    = help: Combine multiple `type` members
 
@@ -241,3 +246,27 @@ PYI055.pyi:28:12: PYI055 [*] Multiple `type` members in a union. Combine them in
 27 27 |     item: type[requests_mock.Mocker] | type[httpretty] | type[str] = requests_mock.Mocker
 28    |-    item2: Union[type[requests_mock.Mocker], type[httpretty], type[str]] = requests_mock.Mocker
    28 |+    item2: type[Union[requests_mock.Mocker, httpretty, str]] = requests_mock.Mocker
+29 29 |     item3: Union[  # comment
+30 30 |         type[requests_mock.Mocker], # another comment
+31 31 |         type[httpretty], type[str]] = requests_mock.Mocker
+
+PYI055.pyi:29:12: PYI055 [*] Multiple `type` members in a union. Combine them into one, e.g., `type[Union[requests_mock.Mocker, httpretty, str]]`.
+   |
+27 |       item: type[requests_mock.Mocker] | type[httpretty] | type[str] = requests_mock.Mocker
+28 |       item2: Union[type[requests_mock.Mocker], type[httpretty], type[str]] = requests_mock.Mocker
+29 |       item3: Union[  # comment
+   |  ____________^
+30 | |         type[requests_mock.Mocker], # another comment
+31 | |         type[httpretty], type[str]] = requests_mock.Mocker
+   | |___________________________________^ PYI055
+   |
+   = help: Combine multiple `type` members
+
+ℹ Unsafe fix
+26 26 |     # PYI055
+27 27 |     item: type[requests_mock.Mocker] | type[httpretty] | type[str] = requests_mock.Mocker
+28 28 |     item2: Union[type[requests_mock.Mocker], type[httpretty], type[str]] = requests_mock.Mocker
+29    |-    item3: Union[  # comment
+30    |-        type[requests_mock.Mocker], # another comment
+31    |-        type[httpretty], type[str]] = requests_mock.Mocker
+   29 |+    item3: type[Union[requests_mock.Mocker, httpretty, str]] = requests_mock.Mocker

--- a/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI055_PYI055.pyi.snap
+++ b/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI055_PYI055.pyi.snap
@@ -5,10 +5,10 @@ PYI055.pyi:4:4: PYI055 [*] Multiple `type` members in a union. Combine them into
   |
 2 | from typing import Union
 3 | 
-4 | w: builtins.type[int] | builtins.type[str] | builtins.type[complex]
+4 | s: builtins.type[int] | builtins.type[str] | builtins.type[complex]
   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI055
-5 | x: type[int] | type[str] | type[float]
-6 | y: builtins.type[int] | type[str] | builtins.type[complex]
+5 | t: type[int] | type[str] | type[float]
+6 | u: builtins.type[int] | type[str] | builtins.type[complex]
   |
   = help: Combine multiple `type` members
 
@@ -16,167 +16,228 @@ PYI055.pyi:4:4: PYI055 [*] Multiple `type` members in a union. Combine them into
 1 1 | import builtins
 2 2 | from typing import Union
 3 3 | 
-4   |-w: builtins.type[int] | builtins.type[str] | builtins.type[complex]
-  4 |+w: type[int | str | complex]
-5 5 | x: type[int] | type[str] | type[float]
-6 6 | y: builtins.type[int] | type[str] | builtins.type[complex]
-7 7 | z: Union[type[float], type[complex]]
+4   |-s: builtins.type[int] | builtins.type[str] | builtins.type[complex]
+  4 |+s: type[int | str | complex]
+5 5 | t: type[int] | type[str] | type[float]
+6 6 | u: builtins.type[int] | type[str] | builtins.type[complex]
+7 7 | v: Union[type[float], type[complex]]
 
 PYI055.pyi:5:4: PYI055 [*] Multiple `type` members in a union. Combine them into one, e.g., `type[int | str | float]`.
   |
-4 | w: builtins.type[int] | builtins.type[str] | builtins.type[complex]
-5 | x: type[int] | type[str] | type[float]
+4 | s: builtins.type[int] | builtins.type[str] | builtins.type[complex]
+5 | t: type[int] | type[str] | type[float]
   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI055
-6 | y: builtins.type[int] | type[str] | builtins.type[complex]
-7 | z: Union[type[float], type[complex]]
+6 | u: builtins.type[int] | type[str] | builtins.type[complex]
+7 | v: Union[type[float], type[complex]]
   |
   = help: Combine multiple `type` members
 
 ℹ Safe fix
 2 2 | from typing import Union
 3 3 | 
-4 4 | w: builtins.type[int] | builtins.type[str] | builtins.type[complex]
-5   |-x: type[int] | type[str] | type[float]
-  5 |+x: type[int | str | float]
-6 6 | y: builtins.type[int] | type[str] | builtins.type[complex]
-7 7 | z: Union[type[float], type[complex]]
-8 8 | z: Union[type[float, int], type[complex]]
+4 4 | s: builtins.type[int] | builtins.type[str] | builtins.type[complex]
+5   |-t: type[int] | type[str] | type[float]
+  5 |+t: type[int | str | float]
+6 6 | u: builtins.type[int] | type[str] | builtins.type[complex]
+7 7 | v: Union[type[float], type[complex]]
+8 8 | w: Union[type[float, int], type[complex]]
 
 PYI055.pyi:6:4: PYI055 [*] Multiple `type` members in a union. Combine them into one, e.g., `type[int | str | complex]`.
   |
-4 | w: builtins.type[int] | builtins.type[str] | builtins.type[complex]
-5 | x: type[int] | type[str] | type[float]
-6 | y: builtins.type[int] | type[str] | builtins.type[complex]
+4 | s: builtins.type[int] | builtins.type[str] | builtins.type[complex]
+5 | t: type[int] | type[str] | type[float]
+6 | u: builtins.type[int] | type[str] | builtins.type[complex]
   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI055
-7 | z: Union[type[float], type[complex]]
-8 | z: Union[type[float, int], type[complex]]
+7 | v: Union[type[float], type[complex]]
+8 | w: Union[type[float, int], type[complex]]
   |
   = help: Combine multiple `type` members
 
 ℹ Safe fix
 3 3 | 
-4 4 | w: builtins.type[int] | builtins.type[str] | builtins.type[complex]
-5 5 | x: type[int] | type[str] | type[float]
-6   |-y: builtins.type[int] | type[str] | builtins.type[complex]
-  6 |+y: type[int | str | complex]
-7 7 | z: Union[type[float], type[complex]]
-8 8 | z: Union[type[float, int], type[complex]]
-9 9 | 
+4 4 | s: builtins.type[int] | builtins.type[str] | builtins.type[complex]
+5 5 | t: type[int] | type[str] | type[float]
+6   |-u: builtins.type[int] | type[str] | builtins.type[complex]
+  6 |+u: type[int | str | complex]
+7 7 | v: Union[type[float], type[complex]]
+8 8 | w: Union[type[float, int], type[complex]]
+9 9 | x: Union[Union[type[float, int], type[complex]]]
 
 PYI055.pyi:7:4: PYI055 [*] Multiple `type` members in a union. Combine them into one, e.g., `type[Union[float, complex]]`.
   |
-5 | x: type[int] | type[str] | type[float]
-6 | y: builtins.type[int] | type[str] | builtins.type[complex]
-7 | z: Union[type[float], type[complex]]
+5 | t: type[int] | type[str] | type[float]
+6 | u: builtins.type[int] | type[str] | builtins.type[complex]
+7 | v: Union[type[float], type[complex]]
   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI055
-8 | z: Union[type[float, int], type[complex]]
+8 | w: Union[type[float, int], type[complex]]
+9 | x: Union[Union[type[float, int], type[complex]]]
   |
   = help: Combine multiple `type` members
 
 ℹ Safe fix
-4 4 | w: builtins.type[int] | builtins.type[str] | builtins.type[complex]
-5 5 | x: type[int] | type[str] | type[float]
-6 6 | y: builtins.type[int] | type[str] | builtins.type[complex]
-7   |-z: Union[type[float], type[complex]]
-  7 |+z: type[Union[float, complex]]
-8 8 | z: Union[type[float, int], type[complex]]
-9 9 | 
-10 10 | def func(arg: type[int] | str | type[float]) -> None: ...
+4 4 | s: builtins.type[int] | builtins.type[str] | builtins.type[complex]
+5 5 | t: type[int] | type[str] | type[float]
+6 6 | u: builtins.type[int] | type[str] | builtins.type[complex]
+7   |-v: Union[type[float], type[complex]]
+  7 |+v: type[Union[float, complex]]
+8 8 | w: Union[type[float, int], type[complex]]
+9 9 | x: Union[Union[type[float, int], type[complex]]]
+10 10 | y: Union[Union[Union[type[float, int], type[complex]]]]
 
 PYI055.pyi:8:4: PYI055 [*] Multiple `type` members in a union. Combine them into one, e.g., `type[Union[float, int, complex]]`.
    |
- 6 | y: builtins.type[int] | type[str] | builtins.type[complex]
- 7 | z: Union[type[float], type[complex]]
- 8 | z: Union[type[float, int], type[complex]]
+ 6 | u: builtins.type[int] | type[str] | builtins.type[complex]
+ 7 | v: Union[type[float], type[complex]]
+ 8 | w: Union[type[float, int], type[complex]]
    |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI055
- 9 | 
-10 | def func(arg: type[int] | str | type[float]) -> None: ...
+ 9 | x: Union[Union[type[float, int], type[complex]]]
+10 | y: Union[Union[Union[type[float, int], type[complex]]]]
    |
    = help: Combine multiple `type` members
 
 ℹ Safe fix
-5 5 | x: type[int] | type[str] | type[float]
-6 6 | y: builtins.type[int] | type[str] | builtins.type[complex]
-7 7 | z: Union[type[float], type[complex]]
-8   |-z: Union[type[float, int], type[complex]]
-  8 |+z: type[Union[float, int, complex]]
-9 9 | 
-10 10 | def func(arg: type[int] | str | type[float]) -> None: ...
-11 11 | 
+5 5 | t: type[int] | type[str] | type[float]
+6 6 | u: builtins.type[int] | type[str] | builtins.type[complex]
+7 7 | v: Union[type[float], type[complex]]
+8   |-w: Union[type[float, int], type[complex]]
+  8 |+w: type[Union[float, int, complex]]
+9 9 | x: Union[Union[type[float, int], type[complex]]]
+10 10 | y: Union[Union[Union[type[float, int], type[complex]]]]
+11 11 | z: Union[type[complex], Union[Union[type[float, int]]]]
 
-PYI055.pyi:10:15: PYI055 [*] Multiple `type` members in a union. Combine them into one, e.g., `type[int | float]`.
+PYI055.pyi:9:4: PYI055 [*] Multiple `type` members in a union. Combine them into one, e.g., `type[Union[float, int, complex]]`.
    |
- 8 | z: Union[type[float, int], type[complex]]
- 9 | 
-10 | def func(arg: type[int] | str | type[float]) -> None: ...
+ 7 | v: Union[type[float], type[complex]]
+ 8 | w: Union[type[float, int], type[complex]]
+ 9 | x: Union[Union[type[float, int], type[complex]]]
+   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI055
+10 | y: Union[Union[Union[type[float, int], type[complex]]]]
+11 | z: Union[type[complex], Union[Union[type[float, int]]]]
+   |
+   = help: Combine multiple `type` members
+
+ℹ Safe fix
+6  6  | u: builtins.type[int] | type[str] | builtins.type[complex]
+7  7  | v: Union[type[float], type[complex]]
+8  8  | w: Union[type[float, int], type[complex]]
+9     |-x: Union[Union[type[float, int], type[complex]]]
+   9  |+x: type[Union[float, int, complex]]
+10 10 | y: Union[Union[Union[type[float, int], type[complex]]]]
+11 11 | z: Union[type[complex], Union[Union[type[float, int]]]]
+12 12 | 
+
+PYI055.pyi:10:4: PYI055 [*] Multiple `type` members in a union. Combine them into one, e.g., `type[Union[float, int, complex]]`.
+   |
+ 8 | w: Union[type[float, int], type[complex]]
+ 9 | x: Union[Union[type[float, int], type[complex]]]
+10 | y: Union[Union[Union[type[float, int], type[complex]]]]
+   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI055
+11 | z: Union[type[complex], Union[Union[type[float, int]]]]
+   |
+   = help: Combine multiple `type` members
+
+ℹ Safe fix
+7  7  | v: Union[type[float], type[complex]]
+8  8  | w: Union[type[float, int], type[complex]]
+9  9  | x: Union[Union[type[float, int], type[complex]]]
+10    |-y: Union[Union[Union[type[float, int], type[complex]]]]
+   10 |+y: type[Union[float, int, complex]]
+11 11 | z: Union[type[complex], Union[Union[type[float, int]]]]
+12 12 | 
+13 13 | def func(arg: type[int] | str | type[float]) -> None: ...
+
+PYI055.pyi:11:4: PYI055 [*] Multiple `type` members in a union. Combine them into one, e.g., `type[Union[complex, float, int]]`.
+   |
+ 9 | x: Union[Union[type[float, int], type[complex]]]
+10 | y: Union[Union[Union[type[float, int], type[complex]]]]
+11 | z: Union[type[complex], Union[Union[type[float, int]]]]
+   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI055
+12 | 
+13 | def func(arg: type[int] | str | type[float]) -> None: ...
+   |
+   = help: Combine multiple `type` members
+
+ℹ Safe fix
+8  8  | w: Union[type[float, int], type[complex]]
+9  9  | x: Union[Union[type[float, int], type[complex]]]
+10 10 | y: Union[Union[Union[type[float, int], type[complex]]]]
+11    |-z: Union[type[complex], Union[Union[type[float, int]]]]
+   11 |+z: type[Union[complex, float, int]]
+12 12 | 
+13 13 | def func(arg: type[int] | str | type[float]) -> None: ...
+14 14 | 
+
+PYI055.pyi:13:15: PYI055 [*] Multiple `type` members in a union. Combine them into one, e.g., `type[int | float]`.
+   |
+11 | z: Union[type[complex], Union[Union[type[float, int]]]]
+12 | 
+13 | def func(arg: type[int] | str | type[float]) -> None: ...
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI055
-11 | 
-12 | # OK
+14 | 
+15 | # OK
    |
    = help: Combine multiple `type` members
 
 ℹ Safe fix
-7  7  | z: Union[type[float], type[complex]]
-8  8  | z: Union[type[float, int], type[complex]]
-9  9  | 
-10    |-def func(arg: type[int] | str | type[float]) -> None: ...
-   10 |+def func(arg: type[int | float] | str) -> None: ...
-11 11 | 
-12 12 | # OK
-13 13 | x: type[int, str, float]
+10 10 | y: Union[Union[Union[type[float, int], type[complex]]]]
+11 11 | z: Union[type[complex], Union[Union[type[float, int]]]]
+12 12 | 
+13    |-def func(arg: type[int] | str | type[float]) -> None: ...
+   13 |+def func(arg: type[int | float] | str) -> None: ...
+14 14 | 
+15 15 | # OK
+16 16 | x: type[int, str, float]
 
-PYI055.pyi:20:7: PYI055 [*] Multiple `type` members in a union. Combine them into one, e.g., `type[requests_mock.Mocker | httpretty]`.
+PYI055.pyi:23:7: PYI055 [*] Multiple `type` members in a union. Combine them into one, e.g., `type[requests_mock.Mocker | httpretty]`.
    |
-19 | # OK
-20 | item: type[requests_mock.Mocker] | type[httpretty] = requests_mock.Mocker
+22 | # OK
+23 | item: type[requests_mock.Mocker] | type[httpretty] = requests_mock.Mocker
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI055
-21 | 
-22 | def func():
+24 | 
+25 | def func():
    |
    = help: Combine multiple `type` members
 
 ℹ Safe fix
-17 17 | def func(arg: type[int, float] | str) -> None: ...
-18 18 | 
-19 19 | # OK
-20    |-item: type[requests_mock.Mocker] | type[httpretty] = requests_mock.Mocker
-   20 |+item: type[requests_mock.Mocker | httpretty] = requests_mock.Mocker
+20 20 | def func(arg: type[int, float] | str) -> None: ...
 21 21 | 
-22 22 | def func():
-23 23 |     # PYI055
+22 22 | # OK
+23    |-item: type[requests_mock.Mocker] | type[httpretty] = requests_mock.Mocker
+   23 |+item: type[requests_mock.Mocker | httpretty] = requests_mock.Mocker
+24 24 | 
+25 25 | def func():
+26 26 |     # PYI055
 
-PYI055.pyi:24:11: PYI055 [*] Multiple `type` members in a union. Combine them into one, e.g., `type[requests_mock.Mocker | httpretty | str]`.
+PYI055.pyi:27:11: PYI055 [*] Multiple `type` members in a union. Combine them into one, e.g., `type[requests_mock.Mocker | httpretty | str]`.
    |
-22 | def func():
-23 |     # PYI055
-24 |     item: type[requests_mock.Mocker] | type[httpretty] | type[str] = requests_mock.Mocker
+25 | def func():
+26 |     # PYI055
+27 |     item: type[requests_mock.Mocker] | type[httpretty] | type[str] = requests_mock.Mocker
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI055
-25 |     item2: Union[type[requests_mock.Mocker], type[httpretty], type[str]] = requests_mock.Mocker
+28 |     item2: Union[type[requests_mock.Mocker], type[httpretty], type[str]] = requests_mock.Mocker
    |
    = help: Combine multiple `type` members
 
 ℹ Safe fix
-21 21 | 
-22 22 | def func():
-23 23 |     # PYI055
-24    |-    item: type[requests_mock.Mocker] | type[httpretty] | type[str] = requests_mock.Mocker
-   24 |+    item: type[requests_mock.Mocker | httpretty | str] = requests_mock.Mocker
-25 25 |     item2: Union[type[requests_mock.Mocker], type[httpretty], type[str]] = requests_mock.Mocker
+24 24 | 
+25 25 | def func():
+26 26 |     # PYI055
+27    |-    item: type[requests_mock.Mocker] | type[httpretty] | type[str] = requests_mock.Mocker
+   27 |+    item: type[requests_mock.Mocker | httpretty | str] = requests_mock.Mocker
+28 28 |     item2: Union[type[requests_mock.Mocker], type[httpretty], type[str]] = requests_mock.Mocker
 
-PYI055.pyi:25:12: PYI055 [*] Multiple `type` members in a union. Combine them into one, e.g., `type[Union[requests_mock.Mocker, httpretty, str]]`.
+PYI055.pyi:28:12: PYI055 [*] Multiple `type` members in a union. Combine them into one, e.g., `type[Union[requests_mock.Mocker, httpretty, str]]`.
    |
-23 |     # PYI055
-24 |     item: type[requests_mock.Mocker] | type[httpretty] | type[str] = requests_mock.Mocker
-25 |     item2: Union[type[requests_mock.Mocker], type[httpretty], type[str]] = requests_mock.Mocker
+26 |     # PYI055
+27 |     item: type[requests_mock.Mocker] | type[httpretty] | type[str] = requests_mock.Mocker
+28 |     item2: Union[type[requests_mock.Mocker], type[httpretty], type[str]] = requests_mock.Mocker
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI055
    |
    = help: Combine multiple `type` members
 
 ℹ Safe fix
-22 22 | def func():
-23 23 |     # PYI055
-24 24 |     item: type[requests_mock.Mocker] | type[httpretty] | type[str] = requests_mock.Mocker
-25    |-    item2: Union[type[requests_mock.Mocker], type[httpretty], type[str]] = requests_mock.Mocker
-   25 |+    item2: type[Union[requests_mock.Mocker, httpretty, str]] = requests_mock.Mocker
-
-
+25 25 | def func():
+26 26 |     # PYI055
+27 27 |     item: type[requests_mock.Mocker] | type[httpretty] | type[str] = requests_mock.Mocker
+28    |-    item2: Union[type[requests_mock.Mocker], type[httpretty], type[str]] = requests_mock.Mocker
+   28 |+    item2: type[Union[requests_mock.Mocker, httpretty, str]] = requests_mock.Mocker

--- a/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI062_PYI062.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI062_PYI062.py.snap
@@ -5,10 +5,10 @@ PYI062.py:5:25: PYI062 [*] Duplicate literal member `True`
   |
 3 | import typing_extensions
 4 | 
-5 | x: Literal[True, False, True, False]  # PYI062 twice here
+5 | x: Literal[True, False, True, False]  # PY062 twice here
   |                         ^^^^ PYI062
 6 | 
-7 | y: Literal[1, print("hello"), 3, Literal[4, 1]]  # PYI062 on the last 1
+7 | y: Literal[1, print("hello"), 3, Literal[4, 1]]  # PY062 on the last 1
   |
   = help: Remove duplicates
 
@@ -16,20 +16,20 @@ PYI062.py:5:25: PYI062 [*] Duplicate literal member `True`
 2 2 | import typing as t
 3 3 | import typing_extensions
 4 4 | 
-5   |-x: Literal[True, False, True, False]  # PYI062 twice here
-  5 |+x: Literal[True, False]  # PYI062 twice here
+5   |-x: Literal[True, False, True, False]  # PY062 twice here
+  5 |+x: Literal[True, False]  # PY062 twice here
 6 6 | 
-7 7 | y: Literal[1, print("hello"), 3, Literal[4, 1]]  # PYI062 on the last 1
+7 7 | y: Literal[1, print("hello"), 3, Literal[4, 1]]  # PY062 on the last 1
 8 8 | 
 
 PYI062.py:5:31: PYI062 [*] Duplicate literal member `False`
   |
 3 | import typing_extensions
 4 | 
-5 | x: Literal[True, False, True, False]  # PYI062 twice here
+5 | x: Literal[True, False, True, False]  # PY062 twice here
   |                               ^^^^^ PYI062
 6 | 
-7 | y: Literal[1, print("hello"), 3, Literal[4, 1]]  # PYI062 on the last 1
+7 | y: Literal[1, print("hello"), 3, Literal[4, 1]]  # PY062 on the last 1
   |
   = help: Remove duplicates
 
@@ -37,38 +37,38 @@ PYI062.py:5:31: PYI062 [*] Duplicate literal member `False`
 2 2 | import typing as t
 3 3 | import typing_extensions
 4 4 | 
-5   |-x: Literal[True, False, True, False]  # PYI062 twice here
-  5 |+x: Literal[True, False]  # PYI062 twice here
+5   |-x: Literal[True, False, True, False]  # PY062 twice here
+  5 |+x: Literal[True, False]  # PY062 twice here
 6 6 | 
-7 7 | y: Literal[1, print("hello"), 3, Literal[4, 1]]  # PYI062 on the last 1
+7 7 | y: Literal[1, print("hello"), 3, Literal[4, 1]]  # PY062 on the last 1
 8 8 | 
 
 PYI062.py:7:45: PYI062 [*] Duplicate literal member `1`
   |
-5 | x: Literal[True, False, True, False]  # PYI062 twice here
+5 | x: Literal[True, False, True, False]  # PY062 twice here
 6 | 
-7 | y: Literal[1, print("hello"), 3, Literal[4, 1]]  # PYI062 on the last 1
+7 | y: Literal[1, print("hello"), 3, Literal[4, 1]]  # PY062 on the last 1
   |                                             ^ PYI062
 8 | 
-9 | z: Literal[{1, 3, 5}, "foobar", {1,3,5}]  # PYI062 on the set literal
+9 | z: Literal[{1, 3, 5}, "foobar", {1,3,5}]  # PY062 on the set literal
   |
   = help: Remove duplicates
 
 ℹ Safe fix
 4 4 | 
-5 5 | x: Literal[True, False, True, False]  # PYI062 twice here
+5 5 | x: Literal[True, False, True, False]  # PY062 twice here
 6 6 | 
-7   |-y: Literal[1, print("hello"), 3, Literal[4, 1]]  # PYI062 on the last 1
-  7 |+y: Literal[1, print("hello"), 3, 4]  # PYI062 on the last 1
+7   |-y: Literal[1, print("hello"), 3, Literal[4, 1]]  # PY062 on the last 1
+  7 |+y: Literal[1, print("hello"), 3, 4]  # PY062 on the last 1
 8 8 | 
-9 9 | z: Literal[{1, 3, 5}, "foobar", {1,3,5}]  # PYI062 on the set literal
+9 9 | z: Literal[{1, 3, 5}, "foobar", {1,3,5}]  # PY062 on the set literal
 10 10 | 
 
 PYI062.py:9:33: PYI062 [*] Duplicate literal member `{1, 3, 5}`
    |
- 7 | y: Literal[1, print("hello"), 3, Literal[4, 1]]  # PYI062 on the last 1
+ 7 | y: Literal[1, print("hello"), 3, Literal[4, 1]]  # PY062 on the last 1
  8 | 
- 9 | z: Literal[{1, 3, 5}, "foobar", {1,3,5}]  # PYI062 on the set literal
+ 9 | z: Literal[{1, 3, 5}, "foobar", {1,3,5}]  # PY062 on the set literal
    |                                 ^^^^^^^ PYI062
 10 | 
 11 | Literal[1, Literal[1]]  # once
@@ -77,17 +77,17 @@ PYI062.py:9:33: PYI062 [*] Duplicate literal member `{1, 3, 5}`
 
 ℹ Safe fix
 6  6  | 
-7  7  | y: Literal[1, print("hello"), 3, Literal[4, 1]]  # PYI062 on the last 1
+7  7  | y: Literal[1, print("hello"), 3, Literal[4, 1]]  # PY062 on the last 1
 8  8  | 
-9     |-z: Literal[{1, 3, 5}, "foobar", {1,3,5}]  # PYI062 on the set literal
-   9  |+z: Literal[{1, 3, 5}, "foobar"]  # PYI062 on the set literal
+9     |-z: Literal[{1, 3, 5}, "foobar", {1,3,5}]  # PY062 on the set literal
+   9  |+z: Literal[{1, 3, 5}, "foobar"]  # PY062 on the set literal
 10 10 | 
 11 11 | Literal[1, Literal[1]]  # once
 12 12 | Literal[1, 2, Literal[1, 2]]  # twice
 
 PYI062.py:11:20: PYI062 [*] Duplicate literal member `1`
    |
- 9 | z: Literal[{1, 3, 5}, "foobar", {1,3,5}]  # PYI062 on the set literal
+ 9 | z: Literal[{1, 3, 5}, "foobar", {1,3,5}]  # PY062 on the set literal
 10 | 
 11 | Literal[1, Literal[1]]  # once
    |                    ^ PYI062
@@ -98,7 +98,7 @@ PYI062.py:11:20: PYI062 [*] Duplicate literal member `1`
 
 ℹ Safe fix
 8  8  | 
-9  9  | z: Literal[{1, 3, 5}, "foobar", {1,3,5}]  # PYI062 on the set literal
+9  9  | z: Literal[{1, 3, 5}, "foobar", {1,3,5}]  # PY062 on the set literal
 10 10 | 
 11    |-Literal[1, Literal[1]]  # once
    11 |+Literal[1]  # once
@@ -117,7 +117,7 @@ PYI062.py:12:23: PYI062 [*] Duplicate literal member `1`
    = help: Remove duplicates
 
 ℹ Safe fix
-9  9  | z: Literal[{1, 3, 5}, "foobar", {1,3,5}]  # PYI062 on the set literal
+9  9  | z: Literal[{1, 3, 5}, "foobar", {1,3,5}]  # PY062 on the set literal
 10 10 | 
 11 11 | Literal[1, Literal[1]]  # once
 12    |-Literal[1, 2, Literal[1, 2]]  # twice
@@ -137,7 +137,7 @@ PYI062.py:12:26: PYI062 [*] Duplicate literal member `2`
    = help: Remove duplicates
 
 ℹ Safe fix
-9  9  | z: Literal[{1, 3, 5}, "foobar", {1,3,5}]  # PYI062 on the set literal
+9  9  | z: Literal[{1, 3, 5}, "foobar", {1,3,5}]  # PY062 on the set literal
 10 10 | 
 11 11 | Literal[1, Literal[1]]  # once
 12    |-Literal[1, 2, Literal[1, 2]]  # twice
@@ -207,7 +207,7 @@ PYI062.py:14:32: PYI062 [*] Duplicate literal member `2`
    14 |+Literal[1, 2]  # once
 15 15 | t.Literal[1, t.Literal[2, t.Literal[1]]]  # once
 16 16 | typing_extensions.Literal[1, 1, 1]  # twice
-17 17 | 
+17 17 | Literal[
 
 PYI062.py:15:37: PYI062 [*] Duplicate literal member `1`
    |
@@ -216,6 +216,7 @@ PYI062.py:15:37: PYI062 [*] Duplicate literal member `1`
 15 | t.Literal[1, t.Literal[2, t.Literal[1]]]  # once
    |                                     ^ PYI062
 16 | typing_extensions.Literal[1, 1, 1]  # twice
+17 | Literal[
    |
    = help: Remove duplicates
 
@@ -226,8 +227,8 @@ PYI062.py:15:37: PYI062 [*] Duplicate literal member `1`
 15    |-t.Literal[1, t.Literal[2, t.Literal[1]]]  # once
    15 |+t.Literal[1, 2]  # once
 16 16 | typing_extensions.Literal[1, 1, 1]  # twice
-17 17 | 
-18 18 | # Ensure issue is only raised once, even on nested literals
+17 17 | Literal[
+18 18 |     1, # comment
 
 PYI062.py:16:30: PYI062 [*] Duplicate literal member `1`
    |
@@ -235,8 +236,8 @@ PYI062.py:16:30: PYI062 [*] Duplicate literal member `1`
 15 | t.Literal[1, t.Literal[2, t.Literal[1]]]  # once
 16 | typing_extensions.Literal[1, 1, 1]  # twice
    |                              ^ PYI062
-17 | 
-18 | # Ensure issue is only raised once, even on nested literals
+17 | Literal[
+18 |     1, # comment
    |
    = help: Remove duplicates
 
@@ -246,9 +247,9 @@ PYI062.py:16:30: PYI062 [*] Duplicate literal member `1`
 15 15 | t.Literal[1, t.Literal[2, t.Literal[1]]]  # once
 16    |-typing_extensions.Literal[1, 1, 1]  # twice
    16 |+typing_extensions.Literal[1]  # twice
-17 17 | 
-18 18 | # Ensure issue is only raised once, even on nested literals
-19 19 | MyType = Literal["foo", Literal[True, False, True], "bar"]  # PYI062
+17 17 | Literal[
+18 18 |     1, # comment
+19 19 |     Literal[ # another comment
 
 PYI062.py:16:33: PYI062 [*] Duplicate literal member `1`
    |
@@ -256,8 +257,8 @@ PYI062.py:16:33: PYI062 [*] Duplicate literal member `1`
 15 | t.Literal[1, t.Literal[2, t.Literal[1]]]  # once
 16 | typing_extensions.Literal[1, 1, 1]  # twice
    |                                 ^ PYI062
-17 | 
-18 | # Ensure issue is only raised once, even on nested literals
+17 | Literal[
+18 |     1, # comment
    |
    = help: Remove duplicates
 
@@ -267,25 +268,86 @@ PYI062.py:16:33: PYI062 [*] Duplicate literal member `1`
 15 15 | t.Literal[1, t.Literal[2, t.Literal[1]]]  # once
 16    |-typing_extensions.Literal[1, 1, 1]  # twice
    16 |+typing_extensions.Literal[1]  # twice
-17 17 | 
-18 18 | # Ensure issue is only raised once, even on nested literals
-19 19 | MyType = Literal["foo", Literal[True, False, True], "bar"]  # PYI062
+17 17 | Literal[
+18 18 |     1, # comment
+19 19 |     Literal[ # another comment
 
-PYI062.py:19:46: PYI062 [*] Duplicate literal member `True`
+PYI062.py:20:9: PYI062 [*] Duplicate literal member `1`
    |
-18 | # Ensure issue is only raised once, even on nested literals
-19 | MyType = Literal["foo", Literal[True, False, True], "bar"]  # PYI062
+18 |     1, # comment
+19 |     Literal[ # another comment
+20 |         1
+   |         ^ PYI062
+21 |     ]
+22 | ]  # once
+   |
+   = help: Remove duplicates
+
+ℹ Unsafe fix
+14 14 | Literal[1, Literal[2], Literal[2]]  # once
+15 15 | t.Literal[1, t.Literal[2, t.Literal[1]]]  # once
+16 16 | typing_extensions.Literal[1, 1, 1]  # twice
+17    |-Literal[
+18    |-    1, # comment
+19    |-    Literal[ # another comment
+20    |-        1
+21    |-    ]
+22    |-]  # once
+   17 |+Literal[1]  # once
+23 18 | 
+24 19 | # Ensure issue is only raised once, even on nested literals
+25 20 | MyType = Literal["foo", Literal[True, False, True], "bar"]  # PYI062
+
+PYI062.py:25:46: PYI062 [*] Duplicate literal member `True`
+   |
+24 | # Ensure issue is only raised once, even on nested literals
+25 | MyType = Literal["foo", Literal[True, False, True], "bar"]  # PYI062
    |                                              ^^^^ PYI062
-20 | 
-21 | n: Literal["No", "duplicates", "here", 1, "1"]
+26 | 
+27 | n: Literal["No", "duplicates", "here", 1, "1"]
    |
    = help: Remove duplicates
 
 ℹ Safe fix
-16 16 | typing_extensions.Literal[1, 1, 1]  # twice
-17 17 | 
-18 18 | # Ensure issue is only raised once, even on nested literals
-19    |-MyType = Literal["foo", Literal[True, False, True], "bar"]  # PYI062
-   19 |+MyType = Literal["foo", True, False, "bar"]  # PYI062
-20 20 | 
-21 21 | n: Literal["No", "duplicates", "here", 1, "1"]
+22 22 | ]  # once
+23 23 | 
+24 24 | # Ensure issue is only raised once, even on nested literals
+25    |-MyType = Literal["foo", Literal[True, False, True], "bar"]  # PYI062
+   25 |+MyType = Literal["foo", True, False, "bar"]  # PYI062
+26 26 | 
+27 27 | n: Literal["No", "duplicates", "here", 1, "1"]
+28 28 | 
+
+PYI062.py:32:37: PYI062 [*] Duplicate literal member `1`
+   |
+30 | # nested literals, all equivalent to `Literal[1]`
+31 | Literal[Literal[1]]  # no duplicate
+32 | Literal[Literal[Literal[1], Literal[1]]]  # once
+   |                                     ^ PYI062
+33 | Literal[Literal[1], Literal[Literal[Literal[1]]]]  # once
+   |
+   = help: Remove duplicates
+
+ℹ Safe fix
+29 29 | 
+30 30 | # nested literals, all equivalent to `Literal[1]`
+31 31 | Literal[Literal[1]]  # no duplicate
+32    |-Literal[Literal[Literal[1], Literal[1]]]  # once
+   32 |+Literal[1]  # once
+33 33 | Literal[Literal[1], Literal[Literal[Literal[1]]]]  # once
+
+PYI062.py:33:45: PYI062 [*] Duplicate literal member `1`
+   |
+31 | Literal[Literal[1]]  # no duplicate
+32 | Literal[Literal[Literal[1], Literal[1]]]  # once
+33 | Literal[Literal[1], Literal[Literal[Literal[1]]]]  # once
+   |                                             ^ PYI062
+   |
+   = help: Remove duplicates
+
+ℹ Safe fix
+30 30 | # nested literals, all equivalent to `Literal[1]`
+31 31 | Literal[Literal[1]]  # no duplicate
+32 32 | Literal[Literal[Literal[1], Literal[1]]]  # once
+33    |-Literal[Literal[1], Literal[Literal[Literal[1]]]]  # once
+   33 |+Literal[1]  # once

--- a/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI062_PYI062.pyi.snap
+++ b/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI062_PYI062.pyi.snap
@@ -333,24 +333,6 @@ PYI062.pyi:32:37: PYI062 [*] Duplicate literal member `1`
 30 30 | # nested literals, all equivalent to `Literal[1]`
 31 31 | Literal[Literal[1]]  # no duplicate
 32    |-Literal[Literal[Literal[1], Literal[1]]]  # once
-   32 |+Literal[Literal[1]]  # once
-33 33 | Literal[Literal[1], Literal[Literal[Literal[1]]]]  # once
-
-PYI062.pyi:32:37: PYI062 [*] Duplicate literal member `1`
-   |
-30 | # nested literals, all equivalent to `Literal[1]`
-31 | Literal[Literal[1]]  # no duplicate
-32 | Literal[Literal[Literal[1], Literal[1]]]  # once
-   |                                     ^ PYI062
-33 | Literal[Literal[1], Literal[Literal[Literal[1]]]]  # once
-   |
-   = help: Remove duplicates
-
-ℹ Safe fix
-29 29 | 
-30 30 | # nested literals, all equivalent to `Literal[1]`
-31 31 | Literal[Literal[1]]  # no duplicate
-32    |-Literal[Literal[Literal[1], Literal[1]]]  # once
    32 |+Literal[1]  # once
 33 33 | Literal[Literal[1], Literal[Literal[Literal[1]]]]  # once
 

--- a/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI062_PYI062.pyi.snap
+++ b/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI062_PYI062.pyi.snap
@@ -207,7 +207,7 @@ PYI062.pyi:14:32: PYI062 [*] Duplicate literal member `2`
    14 |+Literal[1, 2]  # once
 15 15 | t.Literal[1, t.Literal[2, t.Literal[1]]]  # once
 16 16 | typing_extensions.Literal[1, 1, 1]  # twice
-17 17 | 
+17 17 | Literal[
 
 PYI062.pyi:15:37: PYI062 [*] Duplicate literal member `1`
    |
@@ -216,6 +216,7 @@ PYI062.pyi:15:37: PYI062 [*] Duplicate literal member `1`
 15 | t.Literal[1, t.Literal[2, t.Literal[1]]]  # once
    |                                     ^ PYI062
 16 | typing_extensions.Literal[1, 1, 1]  # twice
+17 | Literal[
    |
    = help: Remove duplicates
 
@@ -226,8 +227,8 @@ PYI062.pyi:15:37: PYI062 [*] Duplicate literal member `1`
 15    |-t.Literal[1, t.Literal[2, t.Literal[1]]]  # once
    15 |+t.Literal[1, 2]  # once
 16 16 | typing_extensions.Literal[1, 1, 1]  # twice
-17 17 | 
-18 18 | # Ensure issue is only raised once, even on nested literals
+17 17 | Literal[
+18 18 |     1, # comment
 
 PYI062.pyi:16:30: PYI062 [*] Duplicate literal member `1`
    |
@@ -235,8 +236,8 @@ PYI062.pyi:16:30: PYI062 [*] Duplicate literal member `1`
 15 | t.Literal[1, t.Literal[2, t.Literal[1]]]  # once
 16 | typing_extensions.Literal[1, 1, 1]  # twice
    |                              ^ PYI062
-17 | 
-18 | # Ensure issue is only raised once, even on nested literals
+17 | Literal[
+18 |     1, # comment
    |
    = help: Remove duplicates
 
@@ -246,9 +247,9 @@ PYI062.pyi:16:30: PYI062 [*] Duplicate literal member `1`
 15 15 | t.Literal[1, t.Literal[2, t.Literal[1]]]  # once
 16    |-typing_extensions.Literal[1, 1, 1]  # twice
    16 |+typing_extensions.Literal[1]  # twice
-17 17 | 
-18 18 | # Ensure issue is only raised once, even on nested literals
-19 19 | MyType = Literal["foo", Literal[True, False, True], "bar"]  # PYI062
+17 17 | Literal[
+18 18 |     1, # comment
+19 19 |     Literal[ # another comment
 
 PYI062.pyi:16:33: PYI062 [*] Duplicate literal member `1`
    |
@@ -256,8 +257,8 @@ PYI062.pyi:16:33: PYI062 [*] Duplicate literal member `1`
 15 | t.Literal[1, t.Literal[2, t.Literal[1]]]  # once
 16 | typing_extensions.Literal[1, 1, 1]  # twice
    |                                 ^ PYI062
-17 | 
-18 | # Ensure issue is only raised once, even on nested literals
+17 | Literal[
+18 |     1, # comment
    |
    = help: Remove duplicates
 
@@ -267,25 +268,104 @@ PYI062.pyi:16:33: PYI062 [*] Duplicate literal member `1`
 15 15 | t.Literal[1, t.Literal[2, t.Literal[1]]]  # once
 16    |-typing_extensions.Literal[1, 1, 1]  # twice
    16 |+typing_extensions.Literal[1]  # twice
-17 17 | 
-18 18 | # Ensure issue is only raised once, even on nested literals
-19 19 | MyType = Literal["foo", Literal[True, False, True], "bar"]  # PYI062
+17 17 | Literal[
+18 18 |     1, # comment
+19 19 |     Literal[ # another comment
 
-PYI062.pyi:19:46: PYI062 [*] Duplicate literal member `True`
+PYI062.pyi:20:9: PYI062 [*] Duplicate literal member `1`
    |
-18 | # Ensure issue is only raised once, even on nested literals
-19 | MyType = Literal["foo", Literal[True, False, True], "bar"]  # PYI062
+18 |     1, # comment
+19 |     Literal[ # another comment
+20 |         1
+   |         ^ PYI062
+21 |     ]
+22 | ]  # once
+   |
+   = help: Remove duplicates
+
+ℹ Unsafe fix
+14 14 | Literal[1, Literal[2], Literal[2]]  # once
+15 15 | t.Literal[1, t.Literal[2, t.Literal[1]]]  # once
+16 16 | typing_extensions.Literal[1, 1, 1]  # twice
+17    |-Literal[
+18    |-    1, # comment
+19    |-    Literal[ # another comment
+20    |-        1
+21    |-    ]
+22    |-]  # once
+   17 |+Literal[1]  # once
+23 18 | 
+24 19 | # Ensure issue is only raised once, even on nested literals
+25 20 | MyType = Literal["foo", Literal[True, False, True], "bar"]  # PYI062
+
+PYI062.pyi:25:46: PYI062 [*] Duplicate literal member `True`
+   |
+24 | # Ensure issue is only raised once, even on nested literals
+25 | MyType = Literal["foo", Literal[True, False, True], "bar"]  # PYI062
    |                                              ^^^^ PYI062
-20 | 
-21 | n: Literal["No", "duplicates", "here", 1, "1"]
+26 | 
+27 | n: Literal["No", "duplicates", "here", 1, "1"]
    |
    = help: Remove duplicates
 
 ℹ Safe fix
-16 16 | typing_extensions.Literal[1, 1, 1]  # twice
-17 17 | 
-18 18 | # Ensure issue is only raised once, even on nested literals
-19    |-MyType = Literal["foo", Literal[True, False, True], "bar"]  # PYI062
-   19 |+MyType = Literal["foo", True, False, "bar"]  # PYI062
-20 20 | 
-21 21 | n: Literal["No", "duplicates", "here", 1, "1"]
+22 22 | ]  # once
+23 23 | 
+24 24 | # Ensure issue is only raised once, even on nested literals
+25    |-MyType = Literal["foo", Literal[True, False, True], "bar"]  # PYI062
+   25 |+MyType = Literal["foo", True, False, "bar"]  # PYI062
+26 26 | 
+27 27 | n: Literal["No", "duplicates", "here", 1, "1"]
+28 28 | 
+
+PYI062.pyi:32:37: PYI062 [*] Duplicate literal member `1`
+   |
+30 | # nested literals, all equivalent to `Literal[1]`
+31 | Literal[Literal[1]]  # no duplicate
+32 | Literal[Literal[Literal[1], Literal[1]]]  # once
+   |                                     ^ PYI062
+33 | Literal[Literal[1], Literal[Literal[Literal[1]]]]  # once
+   |
+   = help: Remove duplicates
+
+ℹ Safe fix
+29 29 | 
+30 30 | # nested literals, all equivalent to `Literal[1]`
+31 31 | Literal[Literal[1]]  # no duplicate
+32    |-Literal[Literal[Literal[1], Literal[1]]]  # once
+   32 |+Literal[Literal[1]]  # once
+33 33 | Literal[Literal[1], Literal[Literal[Literal[1]]]]  # once
+
+PYI062.pyi:32:37: PYI062 [*] Duplicate literal member `1`
+   |
+30 | # nested literals, all equivalent to `Literal[1]`
+31 | Literal[Literal[1]]  # no duplicate
+32 | Literal[Literal[Literal[1], Literal[1]]]  # once
+   |                                     ^ PYI062
+33 | Literal[Literal[1], Literal[Literal[Literal[1]]]]  # once
+   |
+   = help: Remove duplicates
+
+ℹ Safe fix
+29 29 | 
+30 30 | # nested literals, all equivalent to `Literal[1]`
+31 31 | Literal[Literal[1]]  # no duplicate
+32    |-Literal[Literal[Literal[1], Literal[1]]]  # once
+   32 |+Literal[1]  # once
+33 33 | Literal[Literal[1], Literal[Literal[Literal[1]]]]  # once
+
+PYI062.pyi:33:45: PYI062 [*] Duplicate literal member `1`
+   |
+31 | Literal[Literal[1]]  # no duplicate
+32 | Literal[Literal[Literal[1], Literal[1]]]  # once
+33 | Literal[Literal[1], Literal[Literal[Literal[1]]]]  # once
+   |                                             ^ PYI062
+   |
+   = help: Remove duplicates
+
+ℹ Safe fix
+30 30 | # nested literals, all equivalent to `Literal[1]`
+31 31 | Literal[Literal[1]]  # no duplicate
+32 32 | Literal[Literal[Literal[1], Literal[1]]]  # once
+33    |-Literal[Literal[1], Literal[Literal[Literal[1]]]]  # once
+   33 |+Literal[1]  # once

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/suppressible_exception.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/suppressible_exception.rs
@@ -131,8 +131,6 @@ pub(crate) fn suppressible_exception(
         .has_comments(stmt, checker.source())
     {
         diagnostic.try_set_fix(|| {
-            // let range = statement_range(stmt, checker.locator(), checker.indexer());
-
             let (import_edit, binding) = checker.importer().get_or_import_symbol(
                 &ImportRequest::import("contextlib", "suppress"),
                 stmt.start(),

--- a/crates/ruff_linter/src/rules/ruff/rules/never_union.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/never_union.rs
@@ -47,7 +47,7 @@ impl AlwaysFixableViolation for NeverUnion {
             union_like,
         } = self;
         match union_like {
-            UnionLike::BinOp => {
+            UnionLike::PEP604 => {
                 format!("`{never_like} | T` is equivalent to `T`")
             }
             UnionLike::TypingUnion => {
@@ -77,7 +77,7 @@ pub(crate) fn never_union(checker: &mut Checker, expr: &Expr) {
                 let mut diagnostic = Diagnostic::new(
                     NeverUnion {
                         never_like,
-                        union_like: UnionLike::BinOp,
+                        union_like: UnionLike::PEP604,
                     },
                     left.range(),
                 );
@@ -93,7 +93,7 @@ pub(crate) fn never_union(checker: &mut Checker, expr: &Expr) {
                 let mut diagnostic = Diagnostic::new(
                     NeverUnion {
                         never_like,
-                        union_like: UnionLike::BinOp,
+                        union_like: UnionLike::PEP604,
                     },
                     right.range(),
                 );
@@ -174,7 +174,7 @@ enum UnionLike {
     /// E.g., `typing.Union[int, str]`
     TypingUnion,
     /// E.g., `int | str`
-    BinOp,
+    PEP604,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/ruff_python_semantic/src/analyze/typing.rs
+++ b/crates/ruff_python_semantic/src/analyze/typing.rs
@@ -439,7 +439,7 @@ where
     ) where
         F: FnMut(&'a Expr, &'a Expr),
     {
-        // Ex) Literal[x, y]
+        // Ex) `Literal[x, y]`
         if let Expr::Subscript(ast::ExprSubscript { value, slice, .. }) = expr {
             if semantic.match_typing_expr(value, "Literal") {
                 match &**slice {
@@ -451,6 +451,7 @@ where
                         }
                     }
                     other => {
+                        // Ex) `Literal[Literal[...]]`
                         inner(func, semantic, other, Some(expr));
                     }
                 }

--- a/crates/ruff_python_semantic/src/analyze/typing.rs
+++ b/crates/ruff_python_semantic/src/analyze/typing.rs
@@ -407,6 +407,10 @@ where
                         .for_each(|elem| inner(func, semantic, elem, Some(expr)));
                     return;
                 }
+
+                // Ex) Union[Union[a, b]] and Union[a | b | c]
+                inner(func, semantic, slice, Some(expr));
+                return;
             }
         }
 

--- a/crates/ruff_python_semantic/src/model.rs
+++ b/crates/ruff_python_semantic/src/model.rs
@@ -1402,6 +1402,15 @@ impl<'a> SemanticModel<'a> {
             return true;
         }
 
+        // Ex) `Union[Union[int, int]]` or `Union[int | int]`
+        if self
+            .current_expression_parent()
+            .and_then(Expr::as_subscript_expr)
+            .is_some_and(|parent| self.match_typing_expr(&parent.value, "Union"))
+        {
+            return true;
+        }
+
         false
     }
 

--- a/crates/ruff_python_semantic/src/model.rs
+++ b/crates/ruff_python_semantic/src/model.rs
@@ -1417,8 +1417,19 @@ impl<'a> SemanticModel<'a> {
     /// Return `true` if the model is in a nested literal expression (e.g., the inner `Literal` in
     /// `Literal[Literal[int, str], float]`).
     pub fn in_nested_literal(&self) -> bool {
+        // Parent is union or tuple
         // Ex) `Literal[Literal[int, str], float]`
-        self.current_expression_grandparent()
+        if self
+            .current_expression_grandparent()
+            .and_then(Expr::as_subscript_expr)
+            .is_some_and(|parent| self.match_typing_expr(&parent.value, "Literal"))
+        {
+            return true;
+        }
+
+        // Parent is `Literal`
+        // Ex) `Literal[Literal[int]]`
+        self.current_expression_parent()
             .and_then(Expr::as_subscript_expr)
             .is_some_and(|parent| self.match_typing_expr(&parent.value, "Literal"))
     }


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

PR to implement autofix for `redundant-numeric-union` (`PYI041`) and `duplication-union-member` (`PYI016`)
https://github.com/astral-sh/ruff/issues/14185

There appears to be an issue with the nested union detection when the union is unary:

```python-console
>>> from typing import Union
>>> Union[int | int | float]
typing.Union[int, float]

>>> Union[Union[float, complex]]
typing.Union[float, complex]
```

This issue also affects at least `PYI055`.

Edit: the PR grew a bit bigger after finding issues with fix safety. I'll break up the PR into multiple for easier review.

## Test Plan

Extension of the test cases and `cargo test`