### PR TITLE
[red-knot] Add `Type` constructors for `Instance`, `ClassLiteral` and `SubclassOf` variants

### DIFF
--- a/crates/red_knot_python_semantic/src/types/mro.rs
+++ b/crates/red_knot_python_semantic/src/types/mro.rs
@@ -406,7 +406,7 @@ impl<'db> From<ClassBase<'db>> for Type<'db> {
             ClassBase::Any => Type::Any,
             ClassBase::Todo => Type::Todo,
             ClassBase::Unknown => Type::Unknown,
-            ClassBase::Class(class) => Type::ClassLiteral(ClassLiteralType { class }),
+            ClassBase::Class(class) => Type::class_literal(class),
         }
     }
 }

--- a/crates/red_knot_python_semantic/src/types/narrow.rs
+++ b/crates/red_knot_python_semantic/src/types/narrow.rs
@@ -5,7 +5,7 @@ use crate::semantic_index::expression::Expression;
 use crate::semantic_index::symbol::{ScopeId, ScopedSymbolId, SymbolTable};
 use crate::semantic_index::symbol_table;
 use crate::types::{
-    infer_expression_types, ClassLiteralType, InstanceType, IntersectionBuilder, KnownClass,
+    infer_expression_types, ClassLiteralType, IntersectionBuilder, KnownClass,
     KnownConstraintFunction, KnownFunction, Truthiness, Type, UnionBuilder,
 };
 use crate::Db;
@@ -353,14 +353,12 @@ impl<'db> NarrowingConstraintsBuilder<'db> {
                     let to_constraint = match function {
                         KnownConstraintFunction::IsInstance => {
                             |class_literal: ClassLiteralType<'db>| {
-                                Type::Instance(InstanceType {
-                                    class: class_literal.class,
-                                })
+                                Type::instance(class_literal.class)
                             }
                         }
                         KnownConstraintFunction::IsSubclass => {
                             |class_literal: ClassLiteralType<'db>| {
-                                Type::SubclassOf(class_literal.to_subclass_of_type())
+                                Type::subclass_of(class_literal.class)
                             }
                         }
                     };


### PR DESCRIPTION
## Summary

Reduces some repetetiveness and verbosity at callsites. Addresses @carljm's review comments at https://github.com/astral-sh/ruff/pull/14155/files#r1833252458

## Test Plan

`cargo test -p red_knot_python_semantic`
