### PR TITLE
Fix `await-outside-async` to allow `await` at the top-level scope of a notebook

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pylint/await_outside_async.ipynb
+++ b/crates/ruff_linter/resources/test/fixtures/pylint/await_outside_async.ipynb
@@ -1,0 +1,42 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import asyncio\n",
+    "\n",
+    "await asyncio.sleep(1)  # This is okay\n",
+    "\n",
+    "if True:\n",
+    "    await asyncio.sleep(1)  # This is okay\n",
+    "\n",
+    "def foo():\n",
+    "    await asyncio.sleep(1)  # # [await-outside-async]"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "base",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/crates/ruff_linter/src/rules/pylint/mod.rs
+++ b/crates/ruff_linter/src/rules/pylint/mod.rs
@@ -27,6 +27,7 @@ mod tests {
     )]
     #[test_case(Rule::AssertOnStringLiteral, Path::new("assert_on_string_literal.py"))]
     #[test_case(Rule::AwaitOutsideAsync, Path::new("await_outside_async.py"))]
+    #[test_case(Rule::AwaitOutsideAsync, Path::new("await_outside_async.ipynb"))]
     #[test_case(Rule::BadOpenMode, Path::new("bad_open_mode.py"))]
     #[test_case(
         Rule::BadStringFormatCharacter,

--- a/crates/ruff_linter/src/rules/pylint/rules/await_outside_async.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/await_outside_async.rs
@@ -21,7 +21,6 @@ use crate::checkers::ast::Checker;
 ///
 /// def foo():
 ///     await asyncio.sleep(1)
-///
 /// ```
 ///
 /// Use instead:

--- a/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLE1142_await_outside_async.ipynb.snap
+++ b/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLE1142_await_outside_async.ipynb.snap
@@ -1,0 +1,11 @@
+---
+source: crates/ruff_linter/src/rules/pylint/mod.rs
+assertion_line: 236
+snapshot_kind: text
+---
+await_outside_async.ipynb:9:5: PLE1142 `await` should be used within an async function
+  |
+8 | def foo():
+9 |     await asyncio.sleep(1)  # # [await-outside-async]
+  |     ^^^^^^^^^^^^^^^^^^^^^^ PLE1142
+  |


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Fix `await-outside-async` to allow `await` at the top-level scope of a notebook.

```python
# foo.ipynb

await asyncio.sleep(1)  # should be allowed
```

## Test Plan

<!-- How was it tested? -->

A unit test