### PR TITLE
[red-knot] More `Type` constructors

### DIFF
--- a/crates/red_knot_python_semantic/src/types/builder.rs
+++ b/crates/red_knot_python_semantic/src/types/builder.rs
@@ -383,7 +383,7 @@ mod tests {
     use crate::program::{Program, SearchPathSettings};
     use crate::python_version::PythonVersion;
     use crate::stdlib::typing_symbol;
-    use crate::types::{global_symbol, KnownClass, StringLiteralType, UnionBuilder};
+    use crate::types::{global_symbol, KnownClass, UnionBuilder};
     use crate::ProgramSettings;
     use ruff_db::files::system_path_to_file;
     use ruff_db::system::{DbWithTestSystem, SystemPathBuf};
@@ -775,7 +775,7 @@ mod tests {
             .build();
         assert_eq!(ty, s);
 
-        let literal = Type::StringLiteral(StringLiteralType::new(&db, "a"));
+        let literal = Type::string_literal(&db, "a");
         let expected = IntersectionBuilder::new(&db)
             .add_positive(s)
             .add_negative(literal)
@@ -878,7 +878,7 @@ mod tests {
 
         let ty = IntersectionBuilder::new(&db)
             .add_positive(s)
-            .add_negative(Type::StringLiteral(StringLiteralType::new(&db, "a")))
+            .add_negative(Type::string_literal(&db, "a"))
             .add_negative(t)
             .build();
         assert_eq!(ty, Type::Never);
@@ -912,7 +912,7 @@ mod tests {
         let db = setup_db();
 
         let t_p = KnownClass::Int.to_instance(&db);
-        let t_n = Type::StringLiteral(StringLiteralType::new(&db, "t_n"));
+        let t_n = Type::string_literal(&db, "t_n");
 
         let ty = IntersectionBuilder::new(&db)
             .add_positive(t_p)

--- a/crates/red_knot_python_semantic/src/types/display.rs
+++ b/crates/red_knot_python_semantic/src/types/display.rs
@@ -337,9 +337,7 @@ mod tests {
     use ruff_db::system::{DbWithTestSystem, SystemPathBuf};
 
     use crate::db::tests::TestDb;
-    use crate::types::{
-        global_symbol, BytesLiteralType, SliceLiteralType, StringLiteralType, Type, UnionType,
-    };
+    use crate::types::{global_symbol, SliceLiteralType, Type, UnionType};
     use crate::{Program, ProgramSettings, PythonVersion, SearchPathSettings};
 
     fn setup_db() -> TestDb {
@@ -385,12 +383,12 @@ mod tests {
             Type::Unknown,
             Type::IntLiteral(-1),
             global_symbol(&db, mod_file, "A").expect_type(),
-            Type::StringLiteral(StringLiteralType::new(&db, "A")),
-            Type::BytesLiteral(BytesLiteralType::new(&db, [0u8].as_slice())),
-            Type::BytesLiteral(BytesLiteralType::new(&db, [7u8].as_slice())),
+            Type::string_literal(&db, "A"),
+            Type::bytes_literal(&db, &[0u8]),
+            Type::bytes_literal(&db, &[7u8]),
             Type::IntLiteral(0),
             Type::IntLiteral(1),
-            Type::StringLiteral(StringLiteralType::new(&db, "B")),
+            Type::string_literal(&db, "B"),
             global_symbol(&db, mod_file, "foo").expect_type(),
             global_symbol(&db, mod_file, "bar").expect_type(),
             global_symbol(&db, mod_file, "B").expect_type(),

--- a/crates/red_knot_python_semantic/src/types/unpacker.rs
+++ b/crates/red_knot_python_semantic/src/types/unpacker.rs
@@ -6,7 +6,7 @@ use rustc_hash::FxHashMap;
 
 use crate::semantic_index::ast_ids::{HasScopedAstId, ScopedExpressionId};
 use crate::semantic_index::symbol::ScopeId;
-use crate::types::{TupleType, Type, TypeCheckDiagnostics, TypeCheckDiagnosticsBuilder};
+use crate::types::{Type, TypeCheckDiagnostics, TypeCheckDiagnosticsBuilder};
 use crate::Db;
 
 /// Unpacks the value expression type to their respective targets.
@@ -93,11 +93,10 @@ impl<'db> Unpacker<'db> {
                     // further and deconstruct to an array of `StringLiteral` with each
                     // individual character, instead of just an array of `LiteralString`, but
                     // there would be a cost and it's not clear that it's worth it.
-                    let value_ty = Type::Tuple(TupleType::new(
+                    let value_ty = Type::tuple(
                         self.db,
-                        vec![Type::LiteralString; string_literal_ty.len(self.db)]
-                            .into_boxed_slice(),
-                    ));
+                        &vec![Type::LiteralString; string_literal_ty.len(self.db)],
+                    );
                     self.unpack(target, value_ty, scope);
                 }
                 _ => {


### PR DESCRIPTION
## Summary

Followup to #14215. Adds convenience constructor methods for `Type::StringLiteral`, `Type::BytesLiteral` and `Type::Tuple`.

## Test Plan

`cargo test -p red_knot_python_semantic`
