### PR TITLE
Avoid treating lowercase letters as `# noqa` codes

### DIFF
--- a/crates/ruff_linter/src/noqa.rs
+++ b/crates/ruff_linter/src/noqa.rs
@@ -183,9 +183,11 @@ impl<'a> Directive<'a> {
         // Extract, e.g., the `401` in `F401`.
         let suffix = line[prefix..]
             .chars()
-            .take_while(char::is_ascii_alphanumeric)
+            .take_while(char::is_ascii_digit)
             .count();
         if prefix > 0 && suffix > 0 {
+            // SAFETY: we can use `prefix` and `suffix` to index into `line` because we know that
+            // all characters in `line` are ASCII, i.e., a single byte.
             Some(&line[..prefix + suffix])
         } else {
             None
@@ -1206,6 +1208,12 @@ mod tests {
     #[test]
     fn noqa_empty_comma_space() {
         let source = "# noqa: F401, ,F841";
+        assert_debug_snapshot!(Directive::try_extract(source, TextSize::default()));
+    }
+
+    #[test]
+    fn noqa_non_code() {
+        let source = "# noqa: F401 We're ignoring an import";
         assert_debug_snapshot!(Directive::try_extract(source, TextSize::default()));
     }
 

--- a/crates/ruff_linter/src/snapshots/ruff_linter__noqa__tests__noqa_non_code.snap
+++ b/crates/ruff_linter/src/snapshots/ruff_linter__noqa__tests__noqa_non_code.snap
@@ -6,15 +6,11 @@ Ok(
     Some(
         Codes(
             Codes {
-                range: 0..16,
+                range: 0..12,
                 codes: [
                     Code {
                         code: "F401",
                         range: 8..12,
-                    },
-                    Code {
-                        code: "F841",
-                        range: 12..16,
                     },
                 ],
             },


### PR DESCRIPTION
## Summary

An oversight from the original implementation.

Closes https://github.com/astral-sh/ruff/issues/14228.
