### PR TITLE
Avoid using `typing.Self` in stub files pre-Python 3.11

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/non_self_return_type.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/non_self_return_type.rs
@@ -191,7 +191,7 @@ fn add_diagnostic(
     /// Return an [`Edit`] that imports `typing.Self` from `typing` or `typing_extensions`.
     fn import_self(checker: &Checker, range: TextRange) -> Option<Edit> {
         let target_version = checker.settings.target_version.as_tuple();
-        let source_module = if checker.source_type.is_stub() || target_version >= (3, 11) {
+        let source_module = if target_version >= (3, 11) {
             "typing"
         } else {
             "typing_extensions"


### PR DESCRIPTION
## Summary

See: https://github.com/astral-sh/ruff/pull/14217#discussion_r1835340869.

This means we're recommending `typing_extensions` in non-stubs pre-3.11, which may not be a valid project dependency, but that's a separate issue (https://github.com/astral-sh/ruff/issues/9761).
