### PR TITLE
[red-knot] follow-ups to typevar types

### DIFF
--- a/crates/red_knot_python_semantic/src/types/display.rs
+++ b/crates/red_knot_python_semantic/src/types/display.rs
@@ -66,15 +66,13 @@ impl Display for DisplayRepresentation<'_> {
             Type::Any => f.write_str("Any"),
             Type::Never => f.write_str("Never"),
             Type::Unknown => f.write_str("Unknown"),
-            Type::Instance(InstanceType { class })
-                if class.is_known(self.db, KnownClass::NoneType) =>
-            {
-                f.write_str("None")
-            }
-            Type::Instance(InstanceType { class })
-                if class.is_known(self.db, KnownClass::NoDefaultType) =>
-            {
-                f.write_str("NoDefault")
+            Type::Instance(InstanceType { class }) => {
+                let representation = match class.known(self.db) {
+                    Some(KnownClass::NoneType) => "None",
+                    Some(KnownClass::NoDefaultType) => "NoDefault",
+                    _ => class.name(self.db),
+                };
+                f.write_str(representation)
             }
             // `[Type::Todo]`'s display should be explicit that is not a valid display of
             // any other type
@@ -87,7 +85,6 @@ impl Display for DisplayRepresentation<'_> {
             Type::SubclassOf(SubclassOfType { class }) => {
                 write!(f, "type[{}]", class.name(self.db))
             }
-            Type::Instance(InstanceType { class }) => f.write_str(class.name(self.db)),
             Type::KnownInstance(known_instance) => f.write_str(known_instance.as_str()),
             Type::FunctionLiteral(function) => f.write_str(function.name(self.db)),
             Type::Union(union) => union.display(self.db).fmt(f),


### PR DESCRIPTION
A few follow-ups from post-land review of https://github.com/astral-sh/ruff/pull/14182.

The reason the special case for `NoDefaultType` in `Type::is_equivalent_to` wasn't needed to make the previous tests pass, is that `KnownClass::NoDefaultType.to_instance()` imports `typing_extensions._NoDefaultType` and then creates an instance type from it, rather than importing `typing_extensions.NoDefault` directly. Because `typing_extensions` does not import and re-export `typing._NoDefaultType` on versions where it exists (it only does this for `typing.NoDefault`), this means we only get `typing_extensions._NoDefaultType`, we never see `typing._NoDefaultType` at all.

This will require some further adjustments once we do understand `sys.version_info`, because then `typing_extensions._NoDefaultType` will be unbound on 3.13+ and we'll need an explicit fallback to import `typing._NoDefaultType` instead. (Or re-work this so that we import `NoDefault` directly -- that may be a reason to go back to using `KnownInstance` for this?) For now I just added a TODO for this, since we can't test any solutions here until we do have `sys.version_info` support.

The test I added here does fail without the special case in `is_equivalent_to`, because it directly imports the `NoDefault` singleton, so in the case where we import it from `typing_extensions`, we end up with an unsimplified union that displays as `NoDefault | NoDefault`.