### PR TITLE
[red-knot] Infer `Literal` types from comparisons with `sys.version_info`

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/sys_version_info.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/sys_version_info.md
@@ -119,7 +119,13 @@ import sys
 
 reveal_type(sys.version_info[0] < 3)  # revealed: Literal[False]
 reveal_type(sys.version_info[1] > 8)  # revealed: Literal[False]
+
+# revealed: tuple[Literal[3], Literal[8], int, Literal["alpha", "beta", "candidate", "final"], int]
+reveal_type(sys.version_info[:5])
+
 reveal_type(sys.version_info[:2] >= (3, 8))  # revealed: Literal[True]
 reveal_type(sys.version_info[0:2] >= (3, 9))  # revealed: Literal[False]
 reveal_type(sys.version_info[:3] >= (3, 9, 1))  # revealed: Literal[False]
+reveal_type(sys.version_info[3] == "final")  # revealed: bool
+reveal_type(sys.version_info[3] == "finalllllll")  # revealed: Literal[False]
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/sys_version_info.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/sys_version_info.md
@@ -2,8 +2,11 @@
 
 ## The type of `sys.version_info`
 
-The type of `sys.version_info` is `sys._version_info`. This is quite a complicated type in typeshed,
-so there are many things we don't fully understand about the type yet:
+The type of `sys.version_info` is `sys._version_info`, at least according to typeshed's stubs (which
+we treat as the single source of truth for the standard library). This is quite a complicated type
+in typeshed, so there are many things we don't fully understand about the type yet; this is the
+source of several TODOs in this test file. Many of these TODOs should be naturally fixed as we
+implement more type-system features in the future.
 
 ```py
 import sys
@@ -52,6 +55,9 @@ reveal_type(sys.version_info >= (3, 8, 1, "final", 0))  # revealed: bool
 # TODO: this is an invalid comparison (`sys.version_info` is a tuple of length 5)
 # Should we issue a diagnostic here?
 reveal_type(sys.version_info >= (3, 8, 1, "final", 0, 5))  # revealed: bool
+
+# TODO: this should be `Literal[False]`; see #14279
+reveal_type(sys.version_info == (3, 8, 1, "finallllll", 0))  # revealed: bool
 ```
 
 ## Imports and aliases

--- a/crates/red_knot_python_semantic/src/stdlib.rs
+++ b/crates/red_knot_python_semantic/src/stdlib.rs
@@ -14,6 +14,7 @@ pub(crate) enum CoreStdlibModule {
     Typeshed,
     TypingExtensions,
     Typing,
+    Sys,
 }
 
 impl CoreStdlibModule {
@@ -24,6 +25,7 @@ impl CoreStdlibModule {
             Self::Typing => "typing",
             Self::Typeshed => "_typeshed",
             Self::TypingExtensions => "typing_extensions",
+            Self::Sys => "sys",
         }
     }
 

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -1443,6 +1443,11 @@ impl<'db> Type<'db> {
                 .iter()
                 .map(|level| Type::string_literal(db, level))
                 .collect();
+
+            // For most unions, it's better to go via `UnionType::from_elements` or use `UnionBuilder`;
+            // those techniques ensure that union elements are deduplicated and unions are eagerly simplified
+            // into other types where necessary. Here, however, we know that there are no duplicates
+            // in this union, so it's probably more efficient to use `UnionType::new()` directly.
             Type::Union(UnionType::new(db, elements))
         };
 

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -1432,7 +1432,7 @@ impl<'db> Type<'db> {
     /// Return the type of `tuple(sys.version_info)`.
     ///
     /// This is not exactly the type that `sys.version_info` has at runtime,
-    /// but it's a useful fallback for us in  order to infer `Literal` types from `sys.version_info` comparisons.
+    /// but it's a useful fallback for us in order to infer `Literal` types from `sys.version_info` comparisons.
     fn version_info_tuple(db: &'db dyn Db) -> Self {
         let target_version = Program::get(db).target_version(db);
         let int_instance_ty = KnownClass::Int.to_instance(db);

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -3724,7 +3724,7 @@ impl<'db> TypeInferenceBuilder<'db> {
         match (value_ty, slice_ty) {
             (
                 Type::Instance(InstanceType { class }),
-                Type::IntLiteral(0 | 1) | Type::BooleanLiteral(_) | Type::SliceLiteral(_),
+                Type::IntLiteral(_) | Type::BooleanLiteral(_) | Type::SliceLiteral(_),
             ) if class.is_known(self.db, KnownClass::VersionInfo) => self
                 .infer_subscript_expression_types(
                     value_node,


### PR DESCRIPTION
## Summary

`sys.version_info` is [annotated in typeshed as being an instance of `sys._version_info`](https://github.com/python/typeshed/blob/ea368c72696afba1eb4c12653123edd764c800bf/stdlib/sys/__init__.pyi#L225-L240). This is correct as far as it goes (or at least as correct as it _can_ be, given typeshed's constraints), but means that we have to work in some special casing for the `sys._version_info` class definition, so that in some situations we treat it the same as we would a heterogenous tuple. We also need to add special casing for `sys.version_info` anyway, so that we infer literal integers for the first two elements; this then enables us to infer that some `sys.version_info` branches are always truthy, and others are always falsey.

This PR adds the necessary special casing.

Helps with #14171 (but doesn't touch any of the control-flow parts of that task, which I think @sharkdp is planning to work on).

## Test Plan

mdtests added.
