### PR TITLE
[`flake8-simplify`] Infer "unknown" truthiness for literal iterables whose items are all unpacks (`SIM222`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_simplify/SIM222.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_simplify/SIM222.py
@@ -167,3 +167,29 @@ print(f"{a}{b}" or "bar")
 print(f"{a}{''}" or "bar")
 print(f"{''}{''}" or "bar")
 print(f"{1}{''}" or "bar")
+
+
+# Regression test for: https://github.com/astral-sh/ruff/issues/14237
+for x in [*a] or [None]:
+    pass
+
+for x in {*a} or [None]:
+    pass
+
+for x in (*a,) or [None]:
+    pass
+
+for x in {**a} or [None]:
+    pass
+
+for x in [*a, *b] or [None]:
+    pass
+
+for x in {*a, *b} or [None]:
+    pass
+
+for x in (*a, *b) or [None]:
+    pass
+
+for x in {**a, **b} or [None]:
+    pass

--- a/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__SIM222_SIM222.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__SIM222_SIM222.py.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_simplify/mod.rs
+snapshot_kind: text
 ---
 SIM222.py:1:4: SIM222 [*] Use `True` instead of `... or True`
   |
@@ -1060,5 +1061,5 @@ SIM222.py:168:7: SIM222 [*] Use `"bar"` instead of `... or "bar"`
 168     |-print(f"{''}{''}" or "bar")
     168 |+print("bar")
 169 169 | print(f"{1}{''}" or "bar")
-
-
+170 170 | 
+171 171 |

--- a/crates/ruff_python_ast/src/helpers.rs
+++ b/crates/ruff_python_ast/src/helpers.rs
@@ -1203,7 +1203,7 @@ impl Truthiness {
                     return Self::Falsey;
                 }
 
-                let is_unpack = |item: &DictItem| {
+                if dict.items.iter().all(|item| {
                     matches!(
                         item,
                         DictItem {
@@ -1211,10 +1211,8 @@ impl Truthiness {
                             value: Expr::Name(..)
                         }
                     )
-                };
-
-                if dict.items.iter().all(is_unpack) {
-                    // {**a} / {**a, **b}
+                }) {
+                    // {**foo} / {**foo, **bar}
                     Self::Unknown
                 } else {
                     Self::Truthy

--- a/crates/ruff_python_ast/src/helpers.rs
+++ b/crates/ruff_python_ast/src/helpers.rs
@@ -1191,9 +1191,7 @@ impl Truthiness {
                     return Self::Falsey;
                 }
 
-                let is_unpack = |elt: &Expr| matches!(elt, Expr::Starred(..));
-
-                if elts.iter().all(is_unpack) {
+                if elts.iter().all(Expr::is_starred_expr) {
                     // [*foo] / [*foo, *bar]
                     Self::Unknown
                 } else {


### PR DESCRIPTION
## Summary

Resolves #14237.

## Test Plan

`cargo nextest run` and `cargo insta test`.
