### PR TITLE
Use bitshift consistently for bitflag definitions

### DIFF
--- a/crates/ruff/src/printer.rs
+++ b/crates/ruff/src/printer.rs
@@ -27,11 +27,11 @@ bitflags! {
     #[derive(Default, Debug, Copy, Clone)]
     pub(crate) struct Flags: u8 {
         /// Whether to show violations when emitting diagnostics.
-        const SHOW_VIOLATIONS = 0b0000_0001;
+        const SHOW_VIOLATIONS = 1 << 0;
         /// Whether to show a summary of the fixed violations when emitting diagnostics.
-        const SHOW_FIX_SUMMARY = 0b0000_0100;
+        const SHOW_FIX_SUMMARY = 1 << 1;
         /// Whether to show a diff of each fixed violation when emitting diagnostics.
-        const SHOW_FIX_DIFF = 0b0000_1000;
+        const SHOW_FIX_DIFF = 1 << 2;
     }
 }
 

--- a/crates/ruff_linter/src/directives.rs
+++ b/crates/ruff_linter/src/directives.rs
@@ -18,8 +18,8 @@ use crate::Locator;
 bitflags! {
     #[derive(Debug, Copy, Clone)]
     pub struct Flags: u8 {
-        const NOQA  = 0b0000_0001;
-        const ISORT = 0b0000_0010;
+        const NOQA  = 1 << 0;
+        const ISORT = 1 << 1;
     }
 }
 

--- a/crates/ruff_linter/src/message/text.rs
+++ b/crates/ruff_linter/src/message/text.rs
@@ -22,11 +22,11 @@ bitflags! {
     #[derive(Default)]
     struct EmitterFlags: u8 {
         /// Whether to show the fix status of a diagnostic.
-        const SHOW_FIX_STATUS    = 0b0000_0001;
+        const SHOW_FIX_STATUS   = 1 << 0;
         /// Whether to show the diff of a fix, for diagnostics that have a fix.
-        const SHOW_FIX_DIFF      = 0b0000_0010;
+        const SHOW_FIX_DIFF     = 1 << 1;
         /// Whether to show the source code of a diagnostic.
-        const SHOW_SOURCE        = 0b0000_0100;
+        const SHOW_SOURCE       = 1 << 2;
     }
 }
 

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/logical_lines/mod.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/logical_lines/mod.rs
@@ -37,18 +37,17 @@ bitflags! {
     #[derive(Default, Eq, PartialEq, Clone, Copy, Debug)]
     pub(crate) struct TokenFlags: u8 {
         /// Whether the logical line contains an operator.
-        const OPERATOR = 0b0000_0001;
+        const OPERATOR = 1 << 0;
         /// Whether the logical line contains a bracket.
-        const BRACKET = 0b0000_0010;
+        const BRACKET = 1 << 1;
         /// Whether the logical line contains a punctuation mark.
-        const PUNCTUATION = 0b0000_0100;
+        const PUNCTUATION = 1 << 2;
         /// Whether the logical line contains a keyword.
-        const KEYWORD = 0b0000_1000;
+        const KEYWORD = 1 << 3;
         /// Whether the logical line contains a comment.
-        const COMMENT = 0b0001_0000;
-
+        const COMMENT = 1 << 4;
         /// Whether the logical line contains any non trivia token (no comment, newline, or in/dedent)
-        const NON_TRIVIA = 0b0010_0000;
+        const NON_TRIVIA = 1 << 5;
     }
 }
 

--- a/crates/ruff_linter/src/rules/ruff/rules/ambiguous_unicode_character.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/ambiguous_unicode_character.rs
@@ -302,9 +302,9 @@ bitflags! {
     #[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
     pub struct WordFlags: u8 {
         /// The word contains at least one ASCII character (like `B`).
-        const ASCII = 0b0000_0001;
+        const ASCII = 1 << 0;
         /// The word contains at least one unambiguous unicode character (like `β`).
-        const UNAMBIGUOUS_UNICODE = 0b0000_0010;
+        const UNAMBIGUOUS_UNICODE = 1 << 1;
     }
 }
 

--- a/crates/ruff_python_literal/src/cformat.rs
+++ b/crates/ruff_python_literal/src/cformat.rs
@@ -89,11 +89,11 @@ impl From<CFormatQuantity> for CFormatPrecision {
 bitflags! {
     #[derive(Copy, Clone, Debug, PartialEq)]
     pub struct CConversionFlags: u32 {
-        const ALTERNATE_FORM = 0b0000_0001;
-        const ZERO_PAD = 0b0000_0010;
-        const LEFT_ADJUST = 0b0000_0100;
-        const BLANK_SIGN = 0b0000_1000;
-        const SIGN_CHAR = 0b0001_0000;
+        const ALTERNATE_FORM = 1 << 0;
+        const ZERO_PAD = 1 << 1;
+        const LEFT_ADJUST = 1 << 2;
+        const BLANK_SIGN = 1 << 3;
+        const SIGN_CHAR = 1 << 4;
     }
 }
 

--- a/crates/ruff_python_semantic/src/binding.rs
+++ b/crates/ruff_python_semantic/src/binding.rs
@@ -609,10 +609,10 @@ pub enum BindingKind<'a> {
 bitflags! {
     #[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
     pub struct Exceptions: u8 {
-        const NAME_ERROR = 0b0000_0001;
-        const MODULE_NOT_FOUND_ERROR = 0b0000_0010;
-        const IMPORT_ERROR = 0b0000_0100;
-        const ATTRIBUTE_ERROR = 0b000_100;
+        const NAME_ERROR = 1 << 0;
+        const MODULE_NOT_FOUND_ERROR = 1 << 1;
+        const IMPORT_ERROR = 1 << 2;
+        const ATTRIBUTE_ERROR = 1 << 3;
     }
 }
 

--- a/crates/ruff_python_stdlib/src/open_mode.rs
+++ b/crates/ruff_python_stdlib/src/open_mode.rs
@@ -2,21 +2,21 @@ bitflags::bitflags! {
     #[derive(Copy, Clone, Debug, PartialEq, Eq)]
     pub struct OpenMode: u8 {
         /// `r`
-        const READ = 0b0001;
+        const READ = 1 << 0;
         /// `w`
-        const WRITE = 0b0010;
+        const WRITE = 1 << 1;
         /// `a`
-        const APPEND = 0b0100;
+        const APPEND = 1 << 2;
         /// `x`
-        const CREATE = 0b1000;
+        const CREATE = 1 << 3;
         /// `b`
-        const BINARY = 0b10000;
+        const BINARY = 1 << 4;
         /// `t`
-        const TEXT = 0b10_0000;
+        const TEXT = 1 << 5;
         /// `+`
-        const PLUS = 0b100_0000;
+        const PLUS = 1 << 6;
         /// `U`
-        const UNIVERSAL_NEWLINES = 0b1000_0000;
+        const UNIVERSAL_NEWLINES = 1 << 7;
     }
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Most places in the code use bit shifts to set bitflag values, apart from these few.
Equivalent code, just more consistent and easier to add new flags.

Found these when defining new bitflags in another PR.

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

<!-- How was it tested? -->
