### PR TITLE
[red-knot] Cleanup some `KnownClass` APIs

### DIFF
--- a/crates/red_knot_python_semantic/src/stdlib.rs
+++ b/crates/red_knot_python_semantic/src/stdlib.rs
@@ -8,7 +8,7 @@ use crate::Db;
 
 /// Enumeration of various core stdlib modules, for which we have dedicated Salsa queries.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum CoreStdlibModule {
+pub(crate) enum CoreStdlibModule {
     Builtins,
     Types,
     Typeshed,
@@ -17,23 +17,27 @@ enum CoreStdlibModule {
 }
 
 impl CoreStdlibModule {
-    fn name(self) -> ModuleName {
-        let module_name = match self {
+    pub(crate) const fn as_str(self) -> &'static str {
+        match self {
             Self::Builtins => "builtins",
             Self::Types => "types",
             Self::Typing => "typing",
             Self::Typeshed => "_typeshed",
             Self::TypingExtensions => "typing_extensions",
-        };
-        ModuleName::new_static(module_name)
-            .unwrap_or_else(|| panic!("{module_name} should be a valid module name!"))
+        }
+    }
+
+    pub(crate) fn name(self) -> ModuleName {
+        let self_as_str = self.as_str();
+        ModuleName::new_static(self_as_str)
+            .unwrap_or_else(|| panic!("{self_as_str} should be a valid module name!"))
     }
 }
 
 /// Lookup the type of `symbol` in a given core module
 ///
 /// Returns `Symbol::Unbound` if the given core module cannot be resolved for some reason
-fn core_module_symbol<'db>(
+pub(crate) fn core_module_symbol<'db>(
     db: &'db dyn Db,
     core_module: CoreStdlibModule,
     symbol: &str,
@@ -51,28 +55,13 @@ pub(crate) fn builtins_symbol<'db>(db: &'db dyn Db, symbol: &str) -> Symbol<'db>
     core_module_symbol(db, CoreStdlibModule::Builtins, symbol)
 }
 
-/// Lookup the type of `symbol` in the `types` module namespace.
-///
-/// Returns `Symbol::Unbound` if the `types` module isn't available for some reason.
-#[inline]
-pub(crate) fn types_symbol<'db>(db: &'db dyn Db, symbol: &str) -> Symbol<'db> {
-    core_module_symbol(db, CoreStdlibModule::Types, symbol)
-}
-
 /// Lookup the type of `symbol` in the `typing` module namespace.
 ///
 /// Returns `Symbol::Unbound` if the `typing` module isn't available for some reason.
 #[inline]
-#[allow(dead_code)] // currently only used in tests
+#[cfg(test)]
 pub(crate) fn typing_symbol<'db>(db: &'db dyn Db, symbol: &str) -> Symbol<'db> {
     core_module_symbol(db, CoreStdlibModule::Typing, symbol)
-}
-/// Lookup the type of `symbol` in the `_typeshed` module namespace.
-///
-/// Returns `Symbol::Unbound` if the `_typeshed` module isn't available for some reason.
-#[inline]
-pub(crate) fn typeshed_symbol<'db>(db: &'db dyn Db, symbol: &str) -> Symbol<'db> {
-    core_module_symbol(db, CoreStdlibModule::Typeshed, symbol)
 }
 
 /// Lookup the type of `symbol` in the `typing_extensions` module namespace.

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -1038,7 +1038,7 @@ impl<'db> TypeInferenceBuilder<'db> {
 
         let maybe_known_class = file_to_module(self.db, self.file)
             .as_ref()
-            .and_then(|module| KnownClass::maybe_from_module(module, name.as_str()));
+            .and_then(|module| KnownClass::try_from_module(module, name.as_str()));
 
         let class = Class::new(self.db, &*name.id, body_scope, maybe_known_class);
         let class_ty = Type::class_literal(class);

--- a/crates/red_knot_python_semantic/src/types/mro.rs
+++ b/crates/red_knot_python_semantic/src/types/mro.rs
@@ -340,7 +340,7 @@ impl<'db> ClassBase<'db> {
     /// Return a `ClassBase` representing the class `builtins.object`
     fn object(db: &'db dyn Db) -> Self {
         KnownClass::Object
-            .to_class(db)
+            .to_class_literal(db)
             .into_class_literal()
             .map_or(Self::Unknown, |ClassLiteralType { class }| {
                 Self::Class(class)


### PR DESCRIPTION
## Summary

- Rename `KnownClass::to_class` to `KnownClass::to_class_literal`. This is an oversight that should have been done as part of #14108.
- Rename KnownClass::maybe_from_module` to `KnownClass::try_from_module`. I think this fits better with typical Rust naming conventions.
- Inline `KnownClass::from_name`. I don't think it would ever produce desirable results if you called this method from outside of `KnownClass::try_from_module` (because you also need to check which module the class is coming from, for correctness), so inlining it seems best here.
- Make use of the `CoreStdlibModule` enum in `red_knot_python_semantic/src/stdlib.rs` to reduce code duplication and reduce hardcoded strings.

## Test Plan

`cargo test -p red_knot_python_semantic`
