### PR TITLE
[red-knot] Symbol API improvements, part 2

### DIFF
--- a/crates/red_knot_python_semantic/src/semantic_index/use_def.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/use_def.rs
@@ -277,7 +277,7 @@ impl<'db> UseDefMap<'db> {
 
     pub(crate) fn use_boundness(&self, use_id: ScopedUseId) -> Boundness {
         if self.bindings_by_use[use_id].may_be_unbound() {
-            Boundness::MayBeUnbound
+            Boundness::PossiblyUnbound
         } else {
             Boundness::Bound
         }
@@ -292,7 +292,7 @@ impl<'db> UseDefMap<'db> {
 
     pub(crate) fn public_boundness(&self, symbol: ScopedSymbolId) -> Boundness {
         if self.public_symbols[symbol].may_be_unbound() {
-            Boundness::MayBeUnbound
+            Boundness::PossiblyUnbound
         } else {
             Boundness::Bound
         }

--- a/crates/red_knot_python_semantic/src/symbol.rs
+++ b/crates/red_knot_python_semantic/src/symbol.rs
@@ -6,7 +6,7 @@ use crate::{
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum Boundness {
     Bound,
-    MayBeUnbound,
+    PossiblyUnbound,
 }
 
 /// The result of a symbol lookup, which can either be a (possibly unbound) type
@@ -17,14 +17,14 @@ pub(crate) enum Boundness {
 /// bound = 1
 ///
 /// if flag:
-///     maybe_unbound = 2
+///     possibly_unbound = 2
 /// ```
 ///
 /// If we look up symbols in this scope, we would get the following results:
 /// ```rs
-/// bound:          Symbol::Type(Type::IntLiteral(1), Boundness::Bound),
-/// maybe_unbound:  Symbol::Type(Type::IntLiteral(2), Boundness::MayBeUnbound),
-/// non_existent:   Symbol::Unbound,
+/// bound:             Symbol::Type(Type::IntLiteral(1), Boundness::Bound),
+/// possibly_unbound:  Symbol::Type(Type::IntLiteral(2), Boundness::PossiblyUnbound),
+/// non_existent:      Symbol::Unbound,
 /// ```
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) enum Symbol<'db> {
@@ -37,9 +37,9 @@ impl<'db> Symbol<'db> {
         matches!(self, Symbol::Unbound)
     }
 
-    pub(crate) fn may_be_unbound(&self) -> bool {
+    pub(crate) fn possibly_unbound(&self) -> bool {
         match self {
-            Symbol::Type(_, Boundness::MayBeUnbound) | Symbol::Unbound => true,
+            Symbol::Type(_, Boundness::PossiblyUnbound) | Symbol::Unbound => true,
             Symbol::Type(_, Boundness::Bound) => false,
         }
     }
@@ -72,7 +72,7 @@ impl<'db> Symbol<'db> {
             Symbol::Type(replacement, _) => Symbol::Type(
                 match self {
                     Symbol::Type(ty, Boundness::Bound) => ty,
-                    Symbol::Type(ty, Boundness::MayBeUnbound) => {
+                    Symbol::Type(ty, Boundness::PossiblyUnbound) => {
                         UnionType::from_elements(db, [*replacement, ty])
                     }
                     Symbol::Unbound => *replacement,

--- a/crates/red_knot_python_semantic/src/symbol.rs
+++ b/crates/red_knot_python_semantic/src/symbol.rs
@@ -72,15 +72,15 @@ impl<'db> Symbol<'db> {
     }
 
     #[must_use]
-    pub(crate) fn or_fall_back_to(self, db: &'db dyn Db, replacement: &Symbol<'db>) -> Symbol<'db> {
-        match replacement {
-            Symbol::Type(replacement_ty, replacement_boundness) => match self {
+    pub(crate) fn or_fall_back_to(self, db: &'db dyn Db, fallback: &Symbol<'db>) -> Symbol<'db> {
+        match fallback {
+            Symbol::Type(fallback_ty, fallback_boundness) => match self {
                 s @ Symbol::Type(_, Boundness::Bound) => s,
                 Symbol::Type(ty, boundness @ Boundness::PossiblyUnbound) => Symbol::Type(
-                    UnionType::from_elements(db, [*replacement_ty, ty]),
-                    boundness.or(*replacement_boundness),
+                    UnionType::from_elements(db, [*fallback_ty, ty]),
+                    fallback_boundness.or(boundness),
                 ),
-                Symbol::Unbound => replacement.clone(),
+                Symbol::Unbound => fallback.clone(),
             },
             Symbol::Unbound => self,
         }

--- a/crates/red_knot_python_semantic/src/symbol.rs
+++ b/crates/red_knot_python_semantic/src/symbol.rs
@@ -44,14 +44,11 @@ impl<'db> Symbol<'db> {
         }
     }
 
-    pub(crate) fn unwrap_or_unknown(&self) -> Type<'db> {
-        match self {
-            Symbol::Type(ty, _) => *ty,
-            Symbol::Unbound => Type::Unknown,
-        }
-    }
-
-    pub(crate) fn as_type(&self) -> Option<Type<'db>> {
+    /// Returns the type of the symbol, ignoring possible unboundness.
+    ///
+    /// If the symbol is *definitely* unbound, this function will return `None`. Otherwise,
+    /// if there is at least one control-flow path where the symbol is bound, return the type.
+    pub(crate) fn ignore_possibly_unbound(&self) -> Option<Type<'db>> {
         match self {
             Symbol::Type(ty, _) => Some(*ty),
             Symbol::Unbound => None,
@@ -61,7 +58,7 @@ impl<'db> Symbol<'db> {
     #[cfg(test)]
     #[track_caller]
     pub(crate) fn expect_type(self) -> Type<'db> {
-        self.as_type()
+        self.ignore_possibly_unbound()
             .expect("Expected a (possibly unbound) type, not an unbound symbol")
     }
 

--- a/crates/red_knot_python_semantic/src/symbol.rs
+++ b/crates/red_knot_python_semantic/src/symbol.rs
@@ -75,7 +75,7 @@ impl<'db> Symbol<'db> {
     pub(crate) fn or_fall_back_to(self, db: &'db dyn Db, fallback: &Symbol<'db>) -> Symbol<'db> {
         match fallback {
             Symbol::Type(fallback_ty, fallback_boundness) => match self {
-                s @ Symbol::Type(_, Boundness::Bound) => s,
+                Symbol::Type(_, Boundness::Bound) => self,
                 Symbol::Type(ty, boundness @ Boundness::PossiblyUnbound) => Symbol::Type(
                     UnionType::from_elements(db, [*fallback_ty, ty]),
                     fallback_boundness.or(boundness),

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -171,7 +171,7 @@ pub(crate) fn global_symbol<'db>(db: &'db dyn Db, file: File, name: &str) -> Sym
         // TODO: this should use `.to_instance(db)`. but we don't understand attribute access
         // on instance types yet.
         let module_type_member = KnownClass::ModuleType.to_class_literal(db).member(db, name);
-        return explicit_symbol.replace_unbound_with(db, &module_type_member);
+        return explicit_symbol.or_fall_back_to(db, &module_type_member);
     }
 
     explicit_symbol
@@ -1073,7 +1073,7 @@ impl<'db> Type<'db> {
                     // TODO: this should use `.to_instance()`, but we don't understand instance attribute yet
                     let module_type_instance_member =
                         KnownClass::ModuleType.to_class_literal(db).member(db, name);
-                    global_lookup.replace_unbound_with(db, &module_type_instance_member)
+                    global_lookup.or_fall_back_to(db, &module_type_instance_member)
                 } else {
                     global_lookup
                 }
@@ -2800,7 +2800,7 @@ impl<'db> TupleType<'db> {
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use super::*;
     use crate::db::tests::TestDb;
     use crate::program::{Program, SearchPathSettings};
@@ -2821,7 +2821,7 @@ mod tests {
         assert_eq!(size_of::<Type>(), 16);
     }
 
-    fn setup_db() -> TestDb {
+    pub(crate) fn setup_db() -> TestDb {
         let db = TestDb::new();
 
         let src_root = SystemPathBuf::from("/src");

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -1573,7 +1573,9 @@ impl<'db> KnownClass {
     }
 
     pub fn to_class_literal(self, db: &'db dyn Db) -> Type<'db> {
-        core_module_symbol(db, self.canonical_module(), self.as_str()).unwrap_or_unknown()
+        core_module_symbol(db, self.canonical_module(), self.as_str())
+            .ignore_possibly_unbound()
+            .unwrap_or(Type::Unknown)
     }
 
     /// Return the module in which we should look up the definition for this class

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -1089,17 +1089,17 @@ impl<'db> Type<'db> {
                 let mut builder = UnionBuilder::new(db);
 
                 let mut all_unbound = true;
-                let mut may_be_unbound = false;
+                let mut possibly_unbound = false;
                 for ty in union.elements(db) {
                     let ty_member = ty.member(db, name);
                     match ty_member {
                         Symbol::Unbound => {
-                            may_be_unbound = true;
+                            possibly_unbound = true;
                         }
                         Symbol::Type(ty_member, member_boundness) => {
                             // TODO: raise a diagnostic if member_boundness indicates potential unboundness
                             if member_boundness == Boundness::PossiblyUnbound {
-                                may_be_unbound = true;
+                                possibly_unbound = true;
                             }
 
                             all_unbound = false;
@@ -1113,7 +1113,7 @@ impl<'db> Type<'db> {
                 } else {
                     Symbol::Type(
                         builder.build(),
-                        if may_be_unbound {
+                        if possibly_unbound {
                             Boundness::PossiblyUnbound
                         } else {
                             Boundness::Bound

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -1237,7 +1237,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                 Type::Unknown
             }
             (Symbol::Type(enter_ty, enter_boundness), exit) => {
-                if enter_boundness == Boundness::MayBeUnbound {
+                if enter_boundness == Boundness::PossiblyUnbound {
                     self.diagnostics.add(
                         context_expression.into(),
                         "invalid-context-manager",
@@ -1276,7 +1276,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                     Symbol::Type(exit_ty, exit_boundness) => {
                         // TODO: Use the `exit_ty` to determine if any raised exception is suppressed.
 
-                        if exit_boundness == Boundness::MayBeUnbound {
+                        if exit_boundness == Boundness::PossiblyUnbound {
                             self.diagnostics.add(
                                 context_expression.into(),
                                 "invalid-context-manager",
@@ -1712,7 +1712,7 @@ impl<'db> TypeInferenceBuilder<'db> {
 
                     return match boundness {
                         Boundness::Bound => augmented_return_ty,
-                        Boundness::MayBeUnbound => {
+                        Boundness::PossiblyUnbound => {
                             let left_ty = target_type;
                             let right_ty = value_type;
 
@@ -2010,7 +2010,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                     } = alias;
 
                     // For possibly-unbound names, just eliminate Unbound from the type; we
-                    // must be in a bound path. TODO diagnostic for maybe-unbound import?
+                    // must be in a bound path. TODO diagnostic for possibly-unbound import?
                     module_ty
                         .member(self.db, &ast::name::Name::new(&name.id))
                         .ignore_possibly_unbound()
@@ -2693,7 +2693,7 @@ impl<'db> TypeInferenceBuilder<'db> {
             };
 
             // Fallback to builtins (without infinite recursion if we're already in builtins.)
-            if global_symbol.may_be_unbound()
+            if global_symbol.possibly_unbound()
                 && Some(self.scope()) != builtins_module_scope(self.db)
             {
                 let mut symbol = builtins_symbol(self.db, name);
@@ -2747,10 +2747,10 @@ impl<'db> TypeInferenceBuilder<'db> {
 
         let bindings_ty = bindings_ty(self.db, definitions);
 
-        if boundness == Boundness::MayBeUnbound {
+        if boundness == Boundness::PossiblyUnbound {
             match self.lookup_name(name) {
                 Symbol::Type(looked_up_ty, looked_up_boundness) => {
-                    if looked_up_boundness == Boundness::MayBeUnbound {
+                    if looked_up_boundness == Boundness::PossiblyUnbound {
                         self.diagnostics.add_possibly_unresolved_reference(name);
                     }
 
@@ -3836,7 +3836,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                 match value_meta_ty.member(self.db, "__getitem__") {
                     Symbol::Unbound => {}
                     Symbol::Type(dunder_getitem_method, boundness) => {
-                        if boundness == Boundness::MayBeUnbound {
+                        if boundness == Boundness::PossiblyUnbound {
                             self.diagnostics.add(
                                 value_node.into(),
                                 "call-possibly-unbound-method",
@@ -3880,7 +3880,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                     match dunder_class_getitem_method {
                         Symbol::Unbound => {}
                         Symbol::Type(ty, boundness) => {
-                            if boundness == Boundness::MayBeUnbound {
+                            if boundness == Boundness::PossiblyUnbound {
                                 self.diagnostics.add(
                                     value_node.into(),
                                     "call-possibly-unbound-method",

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -2696,18 +2696,18 @@ impl<'db> TypeInferenceBuilder<'db> {
             if global_symbol.possibly_unbound()
                 && Some(self.scope()) != builtins_module_scope(self.db)
             {
-                let mut symbol = builtins_symbol(self.db, name);
-                if symbol.is_unbound() && name == "reveal_type" {
+                let mut builtins_symbol = builtins_symbol(self.db, name);
+                if builtins_symbol.is_unbound() && name == "reveal_type" {
                     self.diagnostics.add(
                         name_node.into(),
                         "undefined-reveal",
                         format_args!(
                             "`reveal_type` used without importing it; this is allowed for debugging convenience but will fail at runtime"),
                     );
-                    symbol = typing_extensions_symbol(self.db, name);
+                    builtins_symbol = typing_extensions_symbol(self.db, name);
                 }
 
-                global_symbol.replace_unbound_with(self.db, &symbol)
+                global_symbol.or_fall_back_to(self.db, &builtins_symbol)
             } else {
                 global_symbol
             }


### PR DESCRIPTION
## Summary

Apart from one small functional change, this is mostly a refactoring of the `Symbol` API:

- Rename `as_type` to the more explicit `ignore_possibly_unbound`, no functional change
- Remove `unwrap_or_unknown` in favor of the more explicit `.ignore_possibly_unbound().unwrap_or(Type::Unknown)`, no functional change
- Consistently call it "possibly unbound" (not "may be unbound")
- Rename `replace_unbound_with` to `or_fall_back_to` and properly handle boundness of the fall back. This is the only functional change (did not have any impact on existing tests).

relates to: #14022

## Test Plan

New unit tests for `Symbol::or_fall_back_to`
