### PR TITLE
Extend test cases for `flake8-pyi`

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI016.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI016.py
@@ -84,3 +84,27 @@ field24: typing.Union[int, typing.Union[int, int]]  # PYI016: Duplicate union me
 # duplicates of the outer `int`), but not three times (which would indicate that
 # we incorrectly re-checked the nested union).
 field25: typing.Union[int, int | int]  # PYI016: Duplicate union member `int`
+
+# Should emit in cases with nested `typing.Union`
+field26: typing.Union[typing.Union[int, int]]  # PYI016: Duplicate union member `int`
+
+# Should emit in cases with nested `typing.Union`
+field27: typing.Union[typing.Union[typing.Union[int, int]]]  # PYI016: Duplicate union member `int`
+
+# Should emit in cases with mixed `typing.Union` and `|`
+field28: typing.Union[int | int]  # Error
+
+# Should emit twice in cases with multiple nested `typing.Union`
+field29: typing.Union[int, typing.Union[typing.Union[int, int]]]  # Error
+
+# Should emit once in cases with multiple nested `typing.Union`
+field30: typing.Union[int, typing.Union[typing.Union[int, str]]]  # Error
+
+# Should emit once, and fix to `typing.Union[float, int]`
+field31: typing.Union[float, typing.Union[int | int]]  # Error
+
+# Should emit once, and fix to `typing.Union[float, int]`
+field32: typing.Union[float, typing.Union[int | int | int]]  # Error
+
+# Test case for mixed union type fix
+field33: typing.Union[typing.Union[int | int] | typing.Union[int | int]] # Error

--- a/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI016.pyi
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI016.pyi
@@ -84,3 +84,27 @@ field24: typing.Union[int, typing.Union[int, int]]  # PYI016: Duplicate union me
 # duplicates of the outer `int`), but not three times (which would indicate that
 # we incorrectly re-checked the nested union).
 field25: typing.Union[int, int | int]  # PYI016: Duplicate union member `int`
+
+# Should emit in cases with nested `typing.Union`
+field26: typing.Union[typing.Union[int, int]]  # PYI016: Duplicate union member `int`
+
+# Should emit in cases with nested `typing.Union`
+field27: typing.Union[typing.Union[typing.Union[int, int]]]  # PYI016: Duplicate union member `int`
+
+# Should emit in cases with mixed `typing.Union` and `|`
+field28: typing.Union[int | int]  # Error
+
+# Should emit twice in cases with multiple nested `typing.Union`
+field29: typing.Union[int, typing.Union[typing.Union[int, int]]]  # Error
+
+# Should emit once in cases with multiple nested `typing.Union`
+field30: typing.Union[int, typing.Union[typing.Union[int, str]]]  # Error
+
+# Should emit once, and fix to `typing.Union[float, int]`
+field31: typing.Union[float, typing.Union[int | int]]  # Error
+
+# Should emit once, and fix to `typing.Union[float, int]`
+field32: typing.Union[float, typing.Union[int | int | int]]  # Error
+
+# Test case for mixed union type fix
+field33: typing.Union[typing.Union[int | int] | typing.Union[int | int]] # Error

--- a/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI041.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI041.py
@@ -39,14 +39,30 @@ async def f4(**kwargs: int | int | float) -> None:
     ...
 
 
-def f5(
+def f5(arg1: int, *args: Union[int, int, float]) -> None: 
+    ...
+
+
+def f6(arg1: int, *args: Union[Union[int, int, float]]) -> None: 
+    ...
+
+
+def f7(arg1: int, *args: Union[Union[Union[int, int, float]]]) -> None: 
+    ...
+
+
+def f8(arg1: int, *args: Union[Union[Union[int | int | float]]]) -> None: 
+    ...
+
+
+def f9(
     arg: Union[  # comment 
         float, # another
         complex, int]
     ) -> None: 
     ...
 
-def f6(
+def f10(
     arg: (
         int | # comment
         float |  # another

--- a/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI041.pyi
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI041.pyi
@@ -46,6 +46,18 @@ def f6(
     )    
     ) -> None: ... # PYI041
 
+def f5(arg1: int, *args: Union[int, int, float]) -> None: ...  # PYI041
+
+
+def f6(arg1: int, *args: Union[Union[int, int, float]]) -> None: ...  # PYI041
+
+
+def f7(arg1: int, *args: Union[Union[Union[int, int, float]]]) -> None: ...  # PYI041
+
+
+def f8(arg1: int, *args: Union[Union[Union[int | int | float]]]) -> None: ...  # PYI041
+
+
 class Foo:
     def good(self, arg: int) -> None: ...
 

--- a/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI051.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI051.py
@@ -5,6 +5,9 @@ A: str | Literal["foo"]
 B: TypeAlias = typing.Union[Literal[b"bar", b"foo"], bytes, str]
 C: TypeAlias = typing.Union[Literal[5], int, typing.Union[Literal["foo"], str]]
 D: TypeAlias = typing.Union[Literal[b"str_bytes", 42], bytes, int]
+E: TypeAlias = typing.Union[typing.Union[typing.Union[typing.Union[Literal["foo"], str]]]]
+F: TypeAlias = typing.Union[str, typing.Union[typing.Union[typing.Union[Literal["foo"], int]]]]
+G: typing.Union[str, typing.Union[typing.Union[typing.Union[Literal["foo"], int]]]]
 
 def func(x: complex | Literal[1J], y: Union[Literal[3.14], float]): ...
 

--- a/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI051.pyi
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI051.pyi
@@ -5,6 +5,9 @@ A: str | Literal["foo"]
 B: TypeAlias = typing.Union[Literal[b"bar", b"foo"], bytes, str]
 C: TypeAlias = typing.Union[Literal[5], int, typing.Union[Literal["foo"], str]]
 D: TypeAlias = typing.Union[Literal[b"str_bytes", 42], bytes, int]
+E: TypeAlias = typing.Union[typing.Union[typing.Union[typing.Union[Literal["foo"], str]]]]
+F: TypeAlias = typing.Union[str, typing.Union[typing.Union[typing.Union[Literal["foo"], int]]]]
+G: typing.Union[str, typing.Union[typing.Union[typing.Union[Literal["foo"], int]]]]
 
 def func(x: complex | Literal[1J], y: Union[Literal[3.14], float]): ...
 

--- a/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI055.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI055.py
@@ -1,11 +1,14 @@
 import builtins
 from typing import Union
 
-w: builtins.type[int] | builtins.type[str] | builtins.type[complex]
-x: type[int] | type[str] | type[float]
-y: builtins.type[int] | type[str] | builtins.type[complex]
-z: Union[type[float], type[complex]]
-z: Union[type[float, int], type[complex]]
+s: builtins.type[int] | builtins.type[str] | builtins.type[complex]
+t: type[int] | type[str] | type[float]
+u: builtins.type[int] | type[str] | builtins.type[complex]
+v: Union[type[float], type[complex]]
+w: Union[type[float, int], type[complex]]
+x: Union[Union[type[float, int], type[complex]]]
+y: Union[Union[Union[type[float, int], type[complex]]]]
+z: Union[type[complex], Union[Union[type[float, int]]]]
 
 
 def func(arg: type[int] | str | type[float]) -> None:

--- a/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI055.pyi
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI055.pyi
@@ -1,11 +1,14 @@
 import builtins
 from typing import Union
 
-w: builtins.type[int] | builtins.type[str] | builtins.type[complex]
-x: type[int] | type[str] | type[float]
-y: builtins.type[int] | type[str] | builtins.type[complex]
-z: Union[type[float], type[complex]]
-z: Union[type[float, int], type[complex]]
+s: builtins.type[int] | builtins.type[str] | builtins.type[complex]
+t: type[int] | type[str] | type[float]
+u: builtins.type[int] | type[str] | builtins.type[complex]
+v: Union[type[float], type[complex]]
+w: Union[type[float, int], type[complex]]
+x: Union[Union[type[float, int], type[complex]]]
+y: Union[Union[Union[type[float, int], type[complex]]]]
+z: Union[type[complex], Union[Union[type[float, int]]]]
 
 def func(arg: type[int] | str | type[float]) -> None: ...
 

--- a/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI062.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI062.py
@@ -25,3 +25,9 @@ Literal[
 MyType = Literal["foo", Literal[True, False, True], "bar"]  # PYI062
 
 n: Literal["No", "duplicates", "here", 1, "1"]
+
+
+# nested literals, all equivalent to `Literal[1]`
+Literal[Literal[1]]  # no duplicate
+Literal[Literal[Literal[1], Literal[1]]]  # once
+Literal[Literal[1], Literal[Literal[Literal[1]]]]  # once

--- a/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI062.pyi
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI062.pyi
@@ -25,3 +25,9 @@ Literal[
 MyType = Literal["foo", Literal[True, False, True], "bar"]  # PYI062
 
 n: Literal["No", "duplicates", "here", 1, "1"]
+
+
+# nested literals, all equivalent to `Literal[1]`
+Literal[Literal[1]]  # no duplicate
+Literal[Literal[Literal[1], Literal[1]]]  # once
+Literal[Literal[1], Literal[Literal[Literal[1]]]]  # once

--- a/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI016_PYI016.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI016_PYI016.py.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_pyi/mod.rs
-snapshot_kind: text
 ---
 PYI016.py:7:15: PYI016 Duplicate union member `str`
   |
@@ -305,6 +304,8 @@ PYI016.py:86:28: PYI016 Duplicate union member `int`
 85 | # we incorrectly re-checked the nested union).
 86 | field25: typing.Union[int, int | int]  # PYI016: Duplicate union member `int`
    |                            ^^^ PYI016
+87 | 
+88 | # Should emit in cases with nested `typing.Union`
    |
    = help: Remove duplicate union member `int`
 
@@ -314,5 +315,91 @@ PYI016.py:86:34: PYI016 Duplicate union member `int`
 85 | # we incorrectly re-checked the nested union).
 86 | field25: typing.Union[int, int | int]  # PYI016: Duplicate union member `int`
    |                                  ^^^ PYI016
+87 | 
+88 | # Should emit in cases with nested `typing.Union`
    |
    = help: Remove duplicate union member `int`
+
+PYI016.py:89:41: PYI016 Duplicate union member `int`
+   |
+88 | # Should emit in cases with nested `typing.Union`
+89 | field26: typing.Union[typing.Union[int, int]]  # PYI016: Duplicate union member `int`
+   |                                         ^^^ PYI016
+90 | 
+91 | # Should emit in cases with nested `typing.Union`
+   |
+   = help: Remove duplicate union member `int`
+
+PYI016.py:95:29: PYI016 Duplicate union member `int`
+   |
+94 | # Should emit in cases with mixed `typing.Union` and `|`
+95 | field28: typing.Union[int | int]  # Error
+   |                             ^^^ PYI016
+96 | 
+97 | # Should emit twice in cases with multiple nested `typing.Union`
+   |
+   = help: Remove duplicate union member `int`
+
+PYI016.py:98:59: PYI016 Duplicate union member `int`
+    |
+ 97 | # Should emit twice in cases with multiple nested `typing.Union`
+ 98 | field29: typing.Union[int, typing.Union[typing.Union[int, int]]]  # Error
+    |                                                           ^^^ PYI016
+ 99 | 
+100 | # Should emit once in cases with multiple nested `typing.Union`
+    |
+    = help: Remove duplicate union member `int`
+
+PYI016.py:104:49: PYI016 Duplicate union member `int`
+    |
+103 | # Should emit once, and fix to `typing.Union[float, int]`
+104 | field31: typing.Union[float, typing.Union[int | int]]  # Error
+    |                                                 ^^^ PYI016
+105 | 
+106 | # Should emit once, and fix to `typing.Union[float, int]`
+    |
+    = help: Remove duplicate union member `int`
+
+PYI016.py:107:49: PYI016 Duplicate union member `int`
+    |
+106 | # Should emit once, and fix to `typing.Union[float, int]`
+107 | field32: typing.Union[float, typing.Union[int | int | int]]  # Error
+    |                                                 ^^^ PYI016
+108 | 
+109 | # Test case for mixed union type fix
+    |
+    = help: Remove duplicate union member `int`
+
+PYI016.py:107:55: PYI016 Duplicate union member `int`
+    |
+106 | # Should emit once, and fix to `typing.Union[float, int]`
+107 | field32: typing.Union[float, typing.Union[int | int | int]]  # Error
+    |                                                       ^^^ PYI016
+108 | 
+109 | # Test case for mixed union type fix
+    |
+    = help: Remove duplicate union member `int`
+
+PYI016.py:110:42: PYI016 Duplicate union member `int`
+    |
+109 | # Test case for mixed union type fix
+110 | field33: typing.Union[typing.Union[int | int] | typing.Union[int | int]] # Error
+    |                                          ^^^ PYI016
+    |
+    = help: Remove duplicate union member `int`
+
+PYI016.py:110:49: PYI016 Duplicate union member `typing.Union[int | int]`
+    |
+109 | # Test case for mixed union type fix
+110 | field33: typing.Union[typing.Union[int | int] | typing.Union[int | int]] # Error
+    |                                                 ^^^^^^^^^^^^^^^^^^^^^^^ PYI016
+    |
+    = help: Remove duplicate union member `typing.Union[int | int]`
+
+PYI016.py:110:68: PYI016 Duplicate union member `int`
+    |
+109 | # Test case for mixed union type fix
+110 | field33: typing.Union[typing.Union[int | int] | typing.Union[int | int]] # Error
+    |                                                                    ^^^ PYI016
+    |
+    = help: Remove duplicate union member `int`

--- a/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI016_PYI016.pyi.snap
+++ b/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI016_PYI016.pyi.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_pyi/mod.rs
-snapshot_kind: text
 ---
 PYI016.pyi:7:15: PYI016 Duplicate union member `str`
   |
@@ -305,6 +304,8 @@ PYI016.pyi:86:28: PYI016 Duplicate union member `int`
 85 | # we incorrectly re-checked the nested union).
 86 | field25: typing.Union[int, int | int]  # PYI016: Duplicate union member `int`
    |                            ^^^ PYI016
+87 | 
+88 | # Should emit in cases with nested `typing.Union`
    |
    = help: Remove duplicate union member `int`
 
@@ -314,5 +315,91 @@ PYI016.pyi:86:34: PYI016 Duplicate union member `int`
 85 | # we incorrectly re-checked the nested union).
 86 | field25: typing.Union[int, int | int]  # PYI016: Duplicate union member `int`
    |                                  ^^^ PYI016
+87 | 
+88 | # Should emit in cases with nested `typing.Union`
    |
    = help: Remove duplicate union member `int`
+
+PYI016.pyi:89:41: PYI016 Duplicate union member `int`
+   |
+88 | # Should emit in cases with nested `typing.Union`
+89 | field26: typing.Union[typing.Union[int, int]]  # PYI016: Duplicate union member `int`
+   |                                         ^^^ PYI016
+90 | 
+91 | # Should emit in cases with nested `typing.Union`
+   |
+   = help: Remove duplicate union member `int`
+
+PYI016.pyi:95:29: PYI016 Duplicate union member `int`
+   |
+94 | # Should emit in cases with mixed `typing.Union` and `|`
+95 | field28: typing.Union[int | int]  # Error
+   |                             ^^^ PYI016
+96 | 
+97 | # Should emit twice in cases with multiple nested `typing.Union`
+   |
+   = help: Remove duplicate union member `int`
+
+PYI016.pyi:98:59: PYI016 Duplicate union member `int`
+    |
+ 97 | # Should emit twice in cases with multiple nested `typing.Union`
+ 98 | field29: typing.Union[int, typing.Union[typing.Union[int, int]]]  # Error
+    |                                                           ^^^ PYI016
+ 99 | 
+100 | # Should emit once in cases with multiple nested `typing.Union`
+    |
+    = help: Remove duplicate union member `int`
+
+PYI016.pyi:104:49: PYI016 Duplicate union member `int`
+    |
+103 | # Should emit once, and fix to `typing.Union[float, int]`
+104 | field31: typing.Union[float, typing.Union[int | int]]  # Error
+    |                                                 ^^^ PYI016
+105 | 
+106 | # Should emit once, and fix to `typing.Union[float, int]`
+    |
+    = help: Remove duplicate union member `int`
+
+PYI016.pyi:107:49: PYI016 Duplicate union member `int`
+    |
+106 | # Should emit once, and fix to `typing.Union[float, int]`
+107 | field32: typing.Union[float, typing.Union[int | int | int]]  # Error
+    |                                                 ^^^ PYI016
+108 | 
+109 | # Test case for mixed union type fix
+    |
+    = help: Remove duplicate union member `int`
+
+PYI016.pyi:107:55: PYI016 Duplicate union member `int`
+    |
+106 | # Should emit once, and fix to `typing.Union[float, int]`
+107 | field32: typing.Union[float, typing.Union[int | int | int]]  # Error
+    |                                                       ^^^ PYI016
+108 | 
+109 | # Test case for mixed union type fix
+    |
+    = help: Remove duplicate union member `int`
+
+PYI016.pyi:110:42: PYI016 Duplicate union member `int`
+    |
+109 | # Test case for mixed union type fix
+110 | field33: typing.Union[typing.Union[int | int] | typing.Union[int | int]] # Error
+    |                                          ^^^ PYI016
+    |
+    = help: Remove duplicate union member `int`
+
+PYI016.pyi:110:49: PYI016 Duplicate union member `typing.Union[int | int]`
+    |
+109 | # Test case for mixed union type fix
+110 | field33: typing.Union[typing.Union[int | int] | typing.Union[int | int]] # Error
+    |                                                 ^^^^^^^^^^^^^^^^^^^^^^^ PYI016
+    |
+    = help: Remove duplicate union member `typing.Union[int | int]`
+
+PYI016.pyi:110:68: PYI016 Duplicate union member `int`
+    |
+109 | # Test case for mixed union type fix
+110 | field33: typing.Union[typing.Union[int | int] | typing.Union[int | int]] # Error
+    |                                                                    ^^^ PYI016
+    |
+    = help: Remove duplicate union member `int`

--- a/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI041_PYI041.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI041_PYI041.py.snap
@@ -33,79 +33,87 @@ PYI041.py:38:24: PYI041 Use `float` instead of `int | float`
    |
    = help: Remove redundant type
 
-PYI041.py:43:10: PYI041 Use `complex` instead of `int | float | complex`
+PYI041.py:42:26: PYI041 Use `float` instead of `int | float`
    |
-42 |   def f5(
-43 |       arg: Union[  # comment 
+42 | def f5(arg1: int, *args: Union[int, int, float]) -> None: 
+   |                          ^^^^^^^^^^^^^^^^^^^^^^ PYI041
+43 |     ...
+   |
+   = help: Remove redundant type
+
+PYI041.py:59:10: PYI041 Use `complex` instead of `int | float | complex`
+   |
+58 |   def f9(
+59 |       arg: Union[  # comment 
    |  __________^
-44 | |         float, # another
-45 | |         complex, int]
+60 | |         float, # another
+61 | |         complex, int]
    | |_____________________^ PYI041
-46 |       ) -> None: 
-47 |       ...
+62 |       ) -> None: 
+63 |       ...
    |
    = help: Remove redundant type
 
-PYI041.py:51:9: PYI041 Use `complex` instead of `int | float | complex`
+PYI041.py:67:9: PYI041 Use `complex` instead of `int | float | complex`
    |
-49 |   def f6(
-50 |       arg: (
-51 |           int | # comment
+65 |   def f10(
+66 |       arg: (
+67 |           int | # comment
    |  _________^
-52 | |         float |  # another
-53 | |         complex
+68 | |         float |  # another
+69 | |         complex
    | |_______________^ PYI041
-54 |       )    
-55 |       ) -> None: 
+70 |       )    
+71 |       ) -> None: 
    |
    = help: Remove redundant type
 
-PYI041.py:63:24: PYI041 Use `complex` instead of `int | float | complex`
+PYI041.py:79:24: PYI041 Use `complex` instead of `int | float | complex`
    |
-61 |         ...
-62 | 
-63 |     def bad(self, arg: int | float | complex) -> None:
+77 |         ...
+78 | 
+79 |     def bad(self, arg: int | float | complex) -> None:
    |                        ^^^^^^^^^^^^^^^^^^^^^ PYI041
-64 |         ...
+80 |         ...
    |
    = help: Remove redundant type
 
-PYI041.py:66:25: PYI041 Use `complex` instead of `int | float | complex`
+PYI041.py:82:25: PYI041 Use `complex` instead of `int | float | complex`
    |
-64 |         ...
-65 | 
-66 |     def bad2(self, arg: int | Union[float, complex]) -> None: 
+80 |         ...
+81 | 
+82 |     def bad2(self, arg: int | Union[float, complex]) -> None: 
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI041
-67 |         ...
+83 |         ...
    |
    = help: Remove redundant type
 
-PYI041.py:69:25: PYI041 Use `complex` instead of `int | float | complex`
+PYI041.py:85:25: PYI041 Use `complex` instead of `int | float | complex`
    |
-67 |         ...
-68 | 
-69 |     def bad3(self, arg: Union[Union[float, complex], int]) -> None: 
+83 |         ...
+84 | 
+85 |     def bad3(self, arg: Union[Union[float, complex], int]) -> None: 
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI041
-70 |         ...
+86 |         ...
    |
    = help: Remove redundant type
 
-PYI041.py:72:25: PYI041 Use `complex` instead of `int | float | complex`
+PYI041.py:88:25: PYI041 Use `complex` instead of `int | float | complex`
    |
-70 |         ...
-71 | 
-72 |     def bad4(self, arg: Union[float | complex, int]) -> None: 
+86 |         ...
+87 | 
+88 |     def bad4(self, arg: Union[float | complex, int]) -> None: 
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI041
-73 |         ...
+89 |         ...
    |
    = help: Remove redundant type
 
-PYI041.py:75:25: PYI041 Use `complex` instead of `int | float | complex`
+PYI041.py:91:25: PYI041 Use `complex` instead of `int | float | complex`
    |
-73 |         ...
-74 | 
-75 |     def bad5(self, arg: int | (float | complex)) -> None: 
+89 |         ...
+90 | 
+91 |     def bad5(self, arg: int | (float | complex)) -> None: 
    |                         ^^^^^^^^^^^^^^^^^^^^^^^ PYI041
-76 |         ...
+92 |         ...
    |
    = help: Remove redundant type

--- a/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI041_PYI041.pyi.snap
+++ b/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI041_PYI041.pyi.snap
@@ -57,55 +57,64 @@ PYI041.pyi:43:9: PYI041 Use `complex` instead of `int | float | complex`
    |
    = help: Remove redundant type
 
-PYI041.pyi:52:24: PYI041 Use `complex` instead of `int | float | complex`
+PYI041.pyi:49:26: PYI041 Use `float` instead of `int | float`
    |
-50 |     def good(self, arg: int) -> None: ...
-51 | 
-52 |     def bad(self, arg: int | float | complex) -> None: ...  # PYI041
+47 |     ) -> None: ... # PYI041
+48 | 
+49 | def f5(arg1: int, *args: Union[int, int, float]) -> None: ...  # PYI041
+   |                          ^^^^^^^^^^^^^^^^^^^^^^ PYI041
+   |
+   = help: Remove redundant type
+
+PYI041.pyi:64:24: PYI041 Use `complex` instead of `int | float | complex`
+   |
+62 |     def good(self, arg: int) -> None: ...
+63 | 
+64 |     def bad(self, arg: int | float | complex) -> None: ...  # PYI041
    |                        ^^^^^^^^^^^^^^^^^^^^^ PYI041
-53 | 
-54 |     def bad2(self, arg: int | Union[float, complex]) -> None: ...  # PYI041
+65 | 
+66 |     def bad2(self, arg: int | Union[float, complex]) -> None: ...  # PYI041
    |
    = help: Remove redundant type
 
-PYI041.pyi:54:25: PYI041 Use `complex` instead of `int | float | complex`
+PYI041.pyi:66:25: PYI041 Use `complex` instead of `int | float | complex`
    |
-52 |     def bad(self, arg: int | float | complex) -> None: ...  # PYI041
-53 | 
-54 |     def bad2(self, arg: int | Union[float, complex]) -> None: ...  # PYI041
+64 |     def bad(self, arg: int | float | complex) -> None: ...  # PYI041
+65 | 
+66 |     def bad2(self, arg: int | Union[float, complex]) -> None: ...  # PYI041
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI041
-55 | 
-56 |     def bad3(self, arg: Union[Union[float, complex], int]) -> None: ...  # PYI041
+67 | 
+68 |     def bad3(self, arg: Union[Union[float, complex], int]) -> None: ...  # PYI041
    |
    = help: Remove redundant type
 
-PYI041.pyi:56:25: PYI041 Use `complex` instead of `int | float | complex`
+PYI041.pyi:68:25: PYI041 Use `complex` instead of `int | float | complex`
    |
-54 |     def bad2(self, arg: int | Union[float, complex]) -> None: ...  # PYI041
-55 | 
-56 |     def bad3(self, arg: Union[Union[float, complex], int]) -> None: ...  # PYI041
+66 |     def bad2(self, arg: int | Union[float, complex]) -> None: ...  # PYI041
+67 | 
+68 |     def bad3(self, arg: Union[Union[float, complex], int]) -> None: ...  # PYI041
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI041
-57 | 
-58 |     def bad4(self, arg: Union[float | complex, int]) -> None: ...  # PYI041
+69 | 
+70 |     def bad4(self, arg: Union[float | complex, int]) -> None: ...  # PYI041
    |
    = help: Remove redundant type
 
-PYI041.pyi:58:25: PYI041 Use `complex` instead of `int | float | complex`
+PYI041.pyi:70:25: PYI041 Use `complex` instead of `int | float | complex`
    |
-56 |     def bad3(self, arg: Union[Union[float, complex], int]) -> None: ...  # PYI041
-57 | 
-58 |     def bad4(self, arg: Union[float | complex, int]) -> None: ...  # PYI041
+68 |     def bad3(self, arg: Union[Union[float, complex], int]) -> None: ...  # PYI041
+69 | 
+70 |     def bad4(self, arg: Union[float | complex, int]) -> None: ...  # PYI041
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI041
-59 | 
-60 |     def bad5(self, arg: int | (float | complex)) -> None: ...  # PYI041
+71 | 
+72 |     def bad5(self, arg: int | (float | complex)) -> None: ...  # PYI041
    |
    = help: Remove redundant type
 
-PYI041.pyi:60:25: PYI041 Use `complex` instead of `int | float | complex`
+PYI041.pyi:72:25: PYI041 Use `complex` instead of `int | float | complex`
    |
-58 |     def bad4(self, arg: Union[float | complex, int]) -> None: ...  # PYI041
-59 | 
-60 |     def bad5(self, arg: int | (float | complex)) -> None: ...  # PYI041
+70 |     def bad4(self, arg: Union[float | complex, int]) -> None: ...  # PYI041
+71 | 
+72 |     def bad5(self, arg: int | (float | complex)) -> None: ...  # PYI041
    |                         ^^^^^^^^^^^^^^^^^^^^^^^ PYI041
    |
    = help: Remove redundant type

--- a/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI051_PYI051.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI051_PYI051.py.snap
@@ -37,6 +37,7 @@ PYI051.py:6:37: PYI051 `Literal[5]` is redundant in a union with `int`
 6 | C: TypeAlias = typing.Union[Literal[5], int, typing.Union[Literal["foo"], str]]
   |                                     ^ PYI051
 7 | D: TypeAlias = typing.Union[Literal[b"str_bytes", 42], bytes, int]
+8 | E: TypeAlias = typing.Union[typing.Union[typing.Union[typing.Union[Literal["foo"], str]]]]
   |
 
 PYI051.py:6:67: PYI051 `Literal["foo"]` is redundant in a union with `str`
@@ -46,6 +47,7 @@ PYI051.py:6:67: PYI051 `Literal["foo"]` is redundant in a union with `str`
 6 | C: TypeAlias = typing.Union[Literal[5], int, typing.Union[Literal["foo"], str]]
   |                                                                   ^^^^^ PYI051
 7 | D: TypeAlias = typing.Union[Literal[b"str_bytes", 42], bytes, int]
+8 | E: TypeAlias = typing.Union[typing.Union[typing.Union[typing.Union[Literal["foo"], str]]]]
   |
 
 PYI051.py:7:37: PYI051 `Literal[b"str_bytes"]` is redundant in a union with `bytes`
@@ -54,8 +56,8 @@ PYI051.py:7:37: PYI051 `Literal[b"str_bytes"]` is redundant in a union with `byt
 6 | C: TypeAlias = typing.Union[Literal[5], int, typing.Union[Literal["foo"], str]]
 7 | D: TypeAlias = typing.Union[Literal[b"str_bytes", 42], bytes, int]
   |                                     ^^^^^^^^^^^^ PYI051
-8 | 
-9 | def func(x: complex | Literal[1J], y: Union[Literal[3.14], float]): ...
+8 | E: TypeAlias = typing.Union[typing.Union[typing.Union[typing.Union[Literal["foo"], str]]]]
+9 | F: TypeAlias = typing.Union[str, typing.Union[typing.Union[typing.Union[Literal["foo"], int]]]]
   |
 
 PYI051.py:7:51: PYI051 `Literal[42]` is redundant in a union with `int`
@@ -64,26 +66,26 @@ PYI051.py:7:51: PYI051 `Literal[42]` is redundant in a union with `int`
 6 | C: TypeAlias = typing.Union[Literal[5], int, typing.Union[Literal["foo"], str]]
 7 | D: TypeAlias = typing.Union[Literal[b"str_bytes", 42], bytes, int]
   |                                                   ^^ PYI051
-8 | 
-9 | def func(x: complex | Literal[1J], y: Union[Literal[3.14], float]): ...
+8 | E: TypeAlias = typing.Union[typing.Union[typing.Union[typing.Union[Literal["foo"], str]]]]
+9 | F: TypeAlias = typing.Union[str, typing.Union[typing.Union[typing.Union[Literal["foo"], int]]]]
   |
 
-PYI051.py:9:31: PYI051 `Literal[1J]` is redundant in a union with `complex`
+PYI051.py:12:31: PYI051 `Literal[1J]` is redundant in a union with `complex`
    |
- 7 | D: TypeAlias = typing.Union[Literal[b"str_bytes", 42], bytes, int]
- 8 | 
- 9 | def func(x: complex | Literal[1J], y: Union[Literal[3.14], float]): ...
+10 | G: typing.Union[str, typing.Union[typing.Union[typing.Union[Literal["foo"], int]]]]
+11 | 
+12 | def func(x: complex | Literal[1J], y: Union[Literal[3.14], float]): ...
    |                               ^^ PYI051
-10 | 
-11 | # OK
+13 | 
+14 | # OK
    |
 
-PYI051.py:9:53: PYI051 `Literal[3.14]` is redundant in a union with `float`
+PYI051.py:12:53: PYI051 `Literal[3.14]` is redundant in a union with `float`
    |
- 7 | D: TypeAlias = typing.Union[Literal[b"str_bytes", 42], bytes, int]
- 8 | 
- 9 | def func(x: complex | Literal[1J], y: Union[Literal[3.14], float]): ...
+10 | G: typing.Union[str, typing.Union[typing.Union[typing.Union[Literal["foo"], int]]]]
+11 | 
+12 | def func(x: complex | Literal[1J], y: Union[Literal[3.14], float]): ...
    |                                                     ^^^^ PYI051
-10 | 
-11 | # OK
+13 | 
+14 | # OK
    |

--- a/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI051_PYI051.pyi.snap
+++ b/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI051_PYI051.pyi.snap
@@ -37,6 +37,7 @@ PYI051.pyi:6:37: PYI051 `Literal[5]` is redundant in a union with `int`
 6 | C: TypeAlias = typing.Union[Literal[5], int, typing.Union[Literal["foo"], str]]
   |                                     ^ PYI051
 7 | D: TypeAlias = typing.Union[Literal[b"str_bytes", 42], bytes, int]
+8 | E: TypeAlias = typing.Union[typing.Union[typing.Union[typing.Union[Literal["foo"], str]]]]
   |
 
 PYI051.pyi:6:67: PYI051 `Literal["foo"]` is redundant in a union with `str`
@@ -46,6 +47,7 @@ PYI051.pyi:6:67: PYI051 `Literal["foo"]` is redundant in a union with `str`
 6 | C: TypeAlias = typing.Union[Literal[5], int, typing.Union[Literal["foo"], str]]
   |                                                                   ^^^^^ PYI051
 7 | D: TypeAlias = typing.Union[Literal[b"str_bytes", 42], bytes, int]
+8 | E: TypeAlias = typing.Union[typing.Union[typing.Union[typing.Union[Literal["foo"], str]]]]
   |
 
 PYI051.pyi:7:37: PYI051 `Literal[b"str_bytes"]` is redundant in a union with `bytes`
@@ -54,8 +56,8 @@ PYI051.pyi:7:37: PYI051 `Literal[b"str_bytes"]` is redundant in a union with `by
 6 | C: TypeAlias = typing.Union[Literal[5], int, typing.Union[Literal["foo"], str]]
 7 | D: TypeAlias = typing.Union[Literal[b"str_bytes", 42], bytes, int]
   |                                     ^^^^^^^^^^^^ PYI051
-8 | 
-9 | def func(x: complex | Literal[1J], y: Union[Literal[3.14], float]): ...
+8 | E: TypeAlias = typing.Union[typing.Union[typing.Union[typing.Union[Literal["foo"], str]]]]
+9 | F: TypeAlias = typing.Union[str, typing.Union[typing.Union[typing.Union[Literal["foo"], int]]]]
   |
 
 PYI051.pyi:7:51: PYI051 `Literal[42]` is redundant in a union with `int`
@@ -64,26 +66,26 @@ PYI051.pyi:7:51: PYI051 `Literal[42]` is redundant in a union with `int`
 6 | C: TypeAlias = typing.Union[Literal[5], int, typing.Union[Literal["foo"], str]]
 7 | D: TypeAlias = typing.Union[Literal[b"str_bytes", 42], bytes, int]
   |                                                   ^^ PYI051
-8 | 
-9 | def func(x: complex | Literal[1J], y: Union[Literal[3.14], float]): ...
+8 | E: TypeAlias = typing.Union[typing.Union[typing.Union[typing.Union[Literal["foo"], str]]]]
+9 | F: TypeAlias = typing.Union[str, typing.Union[typing.Union[typing.Union[Literal["foo"], int]]]]
   |
 
-PYI051.pyi:9:31: PYI051 `Literal[1J]` is redundant in a union with `complex`
+PYI051.pyi:12:31: PYI051 `Literal[1J]` is redundant in a union with `complex`
    |
- 7 | D: TypeAlias = typing.Union[Literal[b"str_bytes", 42], bytes, int]
- 8 | 
- 9 | def func(x: complex | Literal[1J], y: Union[Literal[3.14], float]): ...
+10 | G: typing.Union[str, typing.Union[typing.Union[typing.Union[Literal["foo"], int]]]]
+11 | 
+12 | def func(x: complex | Literal[1J], y: Union[Literal[3.14], float]): ...
    |                               ^^ PYI051
-10 | 
-11 | # OK
+13 | 
+14 | # OK
    |
 
-PYI051.pyi:9:53: PYI051 `Literal[3.14]` is redundant in a union with `float`
+PYI051.pyi:12:53: PYI051 `Literal[3.14]` is redundant in a union with `float`
    |
- 7 | D: TypeAlias = typing.Union[Literal[b"str_bytes", 42], bytes, int]
- 8 | 
- 9 | def func(x: complex | Literal[1J], y: Union[Literal[3.14], float]): ...
+10 | G: typing.Union[str, typing.Union[typing.Union[typing.Union[Literal["foo"], int]]]]
+11 | 
+12 | def func(x: complex | Literal[1J], y: Union[Literal[3.14], float]): ...
    |                                                     ^^^^ PYI051
-10 | 
-11 | # OK
+13 | 
+14 | # OK
    |

--- a/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI055_PYI055.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI055_PYI055.py.snap
@@ -1,170 +1,169 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_pyi/mod.rs
-snapshot_kind: text
 ---
-PYI055.py:31:8: PYI055 [*] Multiple `type` members in a union. Combine them into one, e.g., `type[requests_mock.Mocker | httpretty | str]`.
+PYI055.py:34:8: PYI055 [*] Multiple `type` members in a union. Combine them into one, e.g., `type[requests_mock.Mocker | httpretty | str]`.
    |
-29 | def func():
-30 |     # PYI055
-31 |     x: type[requests_mock.Mocker] | type[httpretty] | type[str] = requests_mock.Mocker
+32 | def func():
+33 |     # PYI055
+34 |     x: type[requests_mock.Mocker] | type[httpretty] | type[str] = requests_mock.Mocker
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI055
-32 |     y: Union[type[requests_mock.Mocker], type[httpretty], type[str]] = requests_mock.Mocker
-33 |     z: Union[  # comment
+35 |     y: Union[type[requests_mock.Mocker], type[httpretty], type[str]] = requests_mock.Mocker
+36 |     z: Union[  # comment
    |
    = help: Combine multiple `type` members
 
 ℹ Safe fix
-28 28 | 
-29 29 | def func():
-30 30 |     # PYI055
-31    |-    x: type[requests_mock.Mocker] | type[httpretty] | type[str] = requests_mock.Mocker
-   31 |+    x: type[requests_mock.Mocker | httpretty | str] = requests_mock.Mocker
-32 32 |     y: Union[type[requests_mock.Mocker], type[httpretty], type[str]] = requests_mock.Mocker
-33 33 |     z: Union[  # comment
-34 34 |         type[requests_mock.Mocker], # another comment
+31 31 | 
+32 32 | def func():
+33 33 |     # PYI055
+34    |-    x: type[requests_mock.Mocker] | type[httpretty] | type[str] = requests_mock.Mocker
+   34 |+    x: type[requests_mock.Mocker | httpretty | str] = requests_mock.Mocker
+35 35 |     y: Union[type[requests_mock.Mocker], type[httpretty], type[str]] = requests_mock.Mocker
+36 36 |     z: Union[  # comment
+37 37 |         type[requests_mock.Mocker], # another comment
 
-PYI055.py:32:8: PYI055 [*] Multiple `type` members in a union. Combine them into one, e.g., `type[Union[requests_mock.Mocker, httpretty, str]]`.
+PYI055.py:35:8: PYI055 [*] Multiple `type` members in a union. Combine them into one, e.g., `type[Union[requests_mock.Mocker, httpretty, str]]`.
    |
-30 |     # PYI055
-31 |     x: type[requests_mock.Mocker] | type[httpretty] | type[str] = requests_mock.Mocker
-32 |     y: Union[type[requests_mock.Mocker], type[httpretty], type[str]] = requests_mock.Mocker
+33 |     # PYI055
+34 |     x: type[requests_mock.Mocker] | type[httpretty] | type[str] = requests_mock.Mocker
+35 |     y: Union[type[requests_mock.Mocker], type[httpretty], type[str]] = requests_mock.Mocker
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI055
-33 |     z: Union[  # comment
-34 |         type[requests_mock.Mocker], # another comment
+36 |     z: Union[  # comment
+37 |         type[requests_mock.Mocker], # another comment
    |
    = help: Combine multiple `type` members
 
 ℹ Safe fix
-29 29 | def func():
-30 30 |     # PYI055
-31 31 |     x: type[requests_mock.Mocker] | type[httpretty] | type[str] = requests_mock.Mocker
-32    |-    y: Union[type[requests_mock.Mocker], type[httpretty], type[str]] = requests_mock.Mocker
-   32 |+    y: type[Union[requests_mock.Mocker, httpretty, str]] = requests_mock.Mocker
-33 33 |     z: Union[  # comment
-34 34 |         type[requests_mock.Mocker], # another comment
-35 35 |         type[httpretty], type[str]] = requests_mock.Mocker
+32 32 | def func():
+33 33 |     # PYI055
+34 34 |     x: type[requests_mock.Mocker] | type[httpretty] | type[str] = requests_mock.Mocker
+35    |-    y: Union[type[requests_mock.Mocker], type[httpretty], type[str]] = requests_mock.Mocker
+   35 |+    y: type[Union[requests_mock.Mocker, httpretty, str]] = requests_mock.Mocker
+36 36 |     z: Union[  # comment
+37 37 |         type[requests_mock.Mocker], # another comment
+38 38 |         type[httpretty], type[str]] = requests_mock.Mocker
 
-PYI055.py:33:8: PYI055 [*] Multiple `type` members in a union. Combine them into one, e.g., `type[Union[requests_mock.Mocker, httpretty, str]]`.
+PYI055.py:36:8: PYI055 [*] Multiple `type` members in a union. Combine them into one, e.g., `type[Union[requests_mock.Mocker, httpretty, str]]`.
    |
-31 |       x: type[requests_mock.Mocker] | type[httpretty] | type[str] = requests_mock.Mocker
-32 |       y: Union[type[requests_mock.Mocker], type[httpretty], type[str]] = requests_mock.Mocker
-33 |       z: Union[  # comment
+34 |       x: type[requests_mock.Mocker] | type[httpretty] | type[str] = requests_mock.Mocker
+35 |       y: Union[type[requests_mock.Mocker], type[httpretty], type[str]] = requests_mock.Mocker
+36 |       z: Union[  # comment
    |  ________^
-34 | |         type[requests_mock.Mocker], # another comment
-35 | |         type[httpretty], type[str]] = requests_mock.Mocker
+37 | |         type[requests_mock.Mocker], # another comment
+38 | |         type[httpretty], type[str]] = requests_mock.Mocker
    | |___________________________________^ PYI055
    |
    = help: Combine multiple `type` members
 
 ℹ Unsafe fix
-30 30 |     # PYI055
-31 31 |     x: type[requests_mock.Mocker] | type[httpretty] | type[str] = requests_mock.Mocker
-32 32 |     y: Union[type[requests_mock.Mocker], type[httpretty], type[str]] = requests_mock.Mocker
-33    |-    z: Union[  # comment
-34    |-        type[requests_mock.Mocker], # another comment
-35    |-        type[httpretty], type[str]] = requests_mock.Mocker
-   33 |+    z: type[Union[requests_mock.Mocker, httpretty, str]] = requests_mock.Mocker
-36 34 | 
-37 35 | 
-38 36 | def func():
+33 33 |     # PYI055
+34 34 |     x: type[requests_mock.Mocker] | type[httpretty] | type[str] = requests_mock.Mocker
+35 35 |     y: Union[type[requests_mock.Mocker], type[httpretty], type[str]] = requests_mock.Mocker
+36    |-    z: Union[  # comment
+37    |-        type[requests_mock.Mocker], # another comment
+38    |-        type[httpretty], type[str]] = requests_mock.Mocker
+   36 |+    z: type[Union[requests_mock.Mocker, httpretty, str]] = requests_mock.Mocker
+39 37 | 
+40 38 | 
+41 39 | def func():
 
-PYI055.py:42:8: PYI055 [*] Multiple `type` members in a union. Combine them into one, e.g., `type[Union[requests_mock.Mocker, httpretty, str]]`.
+PYI055.py:45:8: PYI055 [*] Multiple `type` members in a union. Combine them into one, e.g., `type[Union[requests_mock.Mocker, httpretty, str]]`.
    |
-41 |     # PYI055
-42 |     x: Union[type[requests_mock.Mocker], type[httpretty], type[str]] = requests_mock.Mocker
+44 |     # PYI055
+45 |     x: Union[type[requests_mock.Mocker], type[httpretty], type[str]] = requests_mock.Mocker
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI055
    |
    = help: Combine multiple `type` members
 
 ℹ Safe fix
-39 39 |     from typing import Union as U
-40 40 | 
-41 41 |     # PYI055
-42    |-    x: Union[type[requests_mock.Mocker], type[httpretty], type[str]] = requests_mock.Mocker
-   42 |+    x: type[Union[requests_mock.Mocker, httpretty, str]] = requests_mock.Mocker
+42 42 |     from typing import Union as U
 43 43 | 
-44 44 | 
-45 45 | def convert_union(union: UnionType) -> _T | None:
+44 44 |     # PYI055
+45    |-    x: Union[type[requests_mock.Mocker], type[httpretty], type[str]] = requests_mock.Mocker
+   45 |+    x: type[Union[requests_mock.Mocker, httpretty, str]] = requests_mock.Mocker
+46 46 | 
+47 47 | 
+48 48 | def convert_union(union: UnionType) -> _T | None:
 
-PYI055.py:47:9: PYI055 [*] Multiple `type` members in a union. Combine them into one, e.g., `type[_T | Converter[_T]]`.
+PYI055.py:50:9: PYI055 [*] Multiple `type` members in a union. Combine them into one, e.g., `type[_T | Converter[_T]]`.
    |
-45 | def convert_union(union: UnionType) -> _T | None:
-46 |     converters: tuple[
-47 |         type[_T] | type[Converter[_T]] | Converter[_T] | Callable[[str], _T], ...  # PYI055
+48 | def convert_union(union: UnionType) -> _T | None:
+49 |     converters: tuple[
+50 |         type[_T] | type[Converter[_T]] | Converter[_T] | Callable[[str], _T], ...  # PYI055
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI055
-48 |     ] = union.__args__
-49 |     ...
+51 |     ] = union.__args__
+52 |     ...
    |
    = help: Combine multiple `type` members
 
 ℹ Safe fix
-44 44 | 
-45 45 | def convert_union(union: UnionType) -> _T | None:
-46 46 |     converters: tuple[
-47    |-        type[_T] | type[Converter[_T]] | Converter[_T] | Callable[[str], _T], ...  # PYI055
-   47 |+        type[_T | Converter[_T]] | Converter[_T] | Callable[[str], _T], ...  # PYI055
-48 48 |     ] = union.__args__
-49 49 |     ...
-50 50 | 
+47 47 | 
+48 48 | def convert_union(union: UnionType) -> _T | None:
+49 49 |     converters: tuple[
+50    |-        type[_T] | type[Converter[_T]] | Converter[_T] | Callable[[str], _T], ...  # PYI055
+   50 |+        type[_T | Converter[_T]] | Converter[_T] | Callable[[str], _T], ...  # PYI055
+51 51 |     ] = union.__args__
+52 52 |     ...
+53 53 | 
 
-PYI055.py:53:15: PYI055 [*] Multiple `type` members in a union. Combine them into one, e.g., `type[_T | Converter[_T]]`.
+PYI055.py:56:15: PYI055 [*] Multiple `type` members in a union. Combine them into one, e.g., `type[_T | Converter[_T]]`.
    |
-51 | def convert_union(union: UnionType) -> _T | None:
-52 |     converters: tuple[
-53 |         Union[type[_T] | type[Converter[_T]] | Converter[_T] | Callable[[str], _T]], ...  # PYI055
+54 | def convert_union(union: UnionType) -> _T | None:
+55 |     converters: tuple[
+56 |         Union[type[_T] | type[Converter[_T]] | Converter[_T] | Callable[[str], _T]], ...  # PYI055
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI055
-54 |     ] = union.__args__
-55 |     ...
+57 |     ] = union.__args__
+58 |     ...
    |
    = help: Combine multiple `type` members
 
 ℹ Safe fix
-50 50 | 
-51 51 | def convert_union(union: UnionType) -> _T | None:
-52 52 |     converters: tuple[
-53    |-        Union[type[_T] | type[Converter[_T]] | Converter[_T] | Callable[[str], _T]], ...  # PYI055
-   53 |+        Union[type[_T | Converter[_T]] | Converter[_T] | Callable[[str], _T]], ...  # PYI055
-54 54 |     ] = union.__args__
-55 55 |     ...
-56 56 | 
+53 53 | 
+54 54 | def convert_union(union: UnionType) -> _T | None:
+55 55 |     converters: tuple[
+56    |-        Union[type[_T] | type[Converter[_T]] | Converter[_T] | Callable[[str], _T]], ...  # PYI055
+   56 |+        Union[type[_T | Converter[_T]] | Converter[_T] | Callable[[str], _T]], ...  # PYI055
+57 57 |     ] = union.__args__
+58 58 |     ...
+59 59 | 
 
-PYI055.py:59:15: PYI055 [*] Multiple `type` members in a union. Combine them into one, e.g., `type[_T | Converter[_T]]`.
+PYI055.py:62:15: PYI055 [*] Multiple `type` members in a union. Combine them into one, e.g., `type[_T | Converter[_T]]`.
    |
-57 | def convert_union(union: UnionType) -> _T | None:
-58 |     converters: tuple[
-59 |         Union[type[_T] | type[Converter[_T]]] | Converter[_T] | Callable[[str], _T], ...  # PYI055
+60 | def convert_union(union: UnionType) -> _T | None:
+61 |     converters: tuple[
+62 |         Union[type[_T] | type[Converter[_T]]] | Converter[_T] | Callable[[str], _T], ...  # PYI055
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI055
-60 |     ] = union.__args__
-61 |     ...
+63 |     ] = union.__args__
+64 |     ...
    |
    = help: Combine multiple `type` members
 
 ℹ Safe fix
-56 56 | 
-57 57 | def convert_union(union: UnionType) -> _T | None:
-58 58 |     converters: tuple[
-59    |-        Union[type[_T] | type[Converter[_T]]] | Converter[_T] | Callable[[str], _T], ...  # PYI055
-   59 |+        Union[type[_T | Converter[_T]]] | Converter[_T] | Callable[[str], _T], ...  # PYI055
-60 60 |     ] = union.__args__
-61 61 |     ...
-62 62 | 
+59 59 | 
+60 60 | def convert_union(union: UnionType) -> _T | None:
+61 61 |     converters: tuple[
+62    |-        Union[type[_T] | type[Converter[_T]]] | Converter[_T] | Callable[[str], _T], ...  # PYI055
+   62 |+        Union[type[_T | Converter[_T]]] | Converter[_T] | Callable[[str], _T], ...  # PYI055
+63 63 |     ] = union.__args__
+64 64 |     ...
+65 65 | 
 
-PYI055.py:65:15: PYI055 [*] Multiple `type` members in a union. Combine them into one, e.g., `type[_T | Converter[_T]]`.
+PYI055.py:68:15: PYI055 [*] Multiple `type` members in a union. Combine them into one, e.g., `type[_T | Converter[_T]]`.
    |
-63 | def convert_union(union: UnionType) -> _T | None:
-64 |     converters: tuple[
-65 |         Union[type[_T] | type[Converter[_T]] | str] | Converter[_T] | Callable[[str], _T], ...  # PYI055
+66 | def convert_union(union: UnionType) -> _T | None:
+67 |     converters: tuple[
+68 |         Union[type[_T] | type[Converter[_T]] | str] | Converter[_T] | Callable[[str], _T], ...  # PYI055
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI055
-66 |     ] = union.__args__
-67 |     ...
+69 |     ] = union.__args__
+70 |     ...
    |
    = help: Combine multiple `type` members
 
 ℹ Safe fix
-62 62 | 
-63 63 | def convert_union(union: UnionType) -> _T | None:
-64 64 |     converters: tuple[
-65    |-        Union[type[_T] | type[Converter[_T]] | str] | Converter[_T] | Callable[[str], _T], ...  # PYI055
-   65 |+        Union[type[_T | Converter[_T]] | str] | Converter[_T] | Callable[[str], _T], ...  # PYI055
-66 66 |     ] = union.__args__
-67 67 |     ...
+65 65 | 
+66 66 | def convert_union(union: UnionType) -> _T | None:
+67 67 |     converters: tuple[
+68    |-        Union[type[_T] | type[Converter[_T]] | str] | Converter[_T] | Callable[[str], _T], ...  # PYI055
+   68 |+        Union[type[_T | Converter[_T]] | str] | Converter[_T] | Callable[[str], _T], ...  # PYI055
+69 69 |     ] = union.__args__
+70 70 |     ...

--- a/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI055_PYI055.pyi.snap
+++ b/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI055_PYI055.pyi.snap
@@ -1,15 +1,14 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_pyi/mod.rs
-snapshot_kind: text
 ---
 PYI055.pyi:4:4: PYI055 [*] Multiple `type` members in a union. Combine them into one, e.g., `type[int | str | complex]`.
   |
 2 | from typing import Union
 3 | 
-4 | w: builtins.type[int] | builtins.type[str] | builtins.type[complex]
+4 | s: builtins.type[int] | builtins.type[str] | builtins.type[complex]
   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI055
-5 | x: type[int] | type[str] | type[float]
-6 | y: builtins.type[int] | type[str] | builtins.type[complex]
+5 | t: type[int] | type[str] | type[float]
+6 | u: builtins.type[int] | type[str] | builtins.type[complex]
   |
   = help: Combine multiple `type` members
 
@@ -17,194 +16,216 @@ PYI055.pyi:4:4: PYI055 [*] Multiple `type` members in a union. Combine them into
 1 1 | import builtins
 2 2 | from typing import Union
 3 3 | 
-4   |-w: builtins.type[int] | builtins.type[str] | builtins.type[complex]
-  4 |+w: type[int | str | complex]
-5 5 | x: type[int] | type[str] | type[float]
-6 6 | y: builtins.type[int] | type[str] | builtins.type[complex]
-7 7 | z: Union[type[float], type[complex]]
+4   |-s: builtins.type[int] | builtins.type[str] | builtins.type[complex]
+  4 |+s: type[int | str | complex]
+5 5 | t: type[int] | type[str] | type[float]
+6 6 | u: builtins.type[int] | type[str] | builtins.type[complex]
+7 7 | v: Union[type[float], type[complex]]
 
 PYI055.pyi:5:4: PYI055 [*] Multiple `type` members in a union. Combine them into one, e.g., `type[int | str | float]`.
   |
-4 | w: builtins.type[int] | builtins.type[str] | builtins.type[complex]
-5 | x: type[int] | type[str] | type[float]
+4 | s: builtins.type[int] | builtins.type[str] | builtins.type[complex]
+5 | t: type[int] | type[str] | type[float]
   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI055
-6 | y: builtins.type[int] | type[str] | builtins.type[complex]
-7 | z: Union[type[float], type[complex]]
+6 | u: builtins.type[int] | type[str] | builtins.type[complex]
+7 | v: Union[type[float], type[complex]]
   |
   = help: Combine multiple `type` members
 
 ℹ Safe fix
 2 2 | from typing import Union
 3 3 | 
-4 4 | w: builtins.type[int] | builtins.type[str] | builtins.type[complex]
-5   |-x: type[int] | type[str] | type[float]
-  5 |+x: type[int | str | float]
-6 6 | y: builtins.type[int] | type[str] | builtins.type[complex]
-7 7 | z: Union[type[float], type[complex]]
-8 8 | z: Union[type[float, int], type[complex]]
+4 4 | s: builtins.type[int] | builtins.type[str] | builtins.type[complex]
+5   |-t: type[int] | type[str] | type[float]
+  5 |+t: type[int | str | float]
+6 6 | u: builtins.type[int] | type[str] | builtins.type[complex]
+7 7 | v: Union[type[float], type[complex]]
+8 8 | w: Union[type[float, int], type[complex]]
 
 PYI055.pyi:6:4: PYI055 [*] Multiple `type` members in a union. Combine them into one, e.g., `type[int | str | complex]`.
   |
-4 | w: builtins.type[int] | builtins.type[str] | builtins.type[complex]
-5 | x: type[int] | type[str] | type[float]
-6 | y: builtins.type[int] | type[str] | builtins.type[complex]
+4 | s: builtins.type[int] | builtins.type[str] | builtins.type[complex]
+5 | t: type[int] | type[str] | type[float]
+6 | u: builtins.type[int] | type[str] | builtins.type[complex]
   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI055
-7 | z: Union[type[float], type[complex]]
-8 | z: Union[type[float, int], type[complex]]
+7 | v: Union[type[float], type[complex]]
+8 | w: Union[type[float, int], type[complex]]
   |
   = help: Combine multiple `type` members
 
 ℹ Safe fix
 3 3 | 
-4 4 | w: builtins.type[int] | builtins.type[str] | builtins.type[complex]
-5 5 | x: type[int] | type[str] | type[float]
-6   |-y: builtins.type[int] | type[str] | builtins.type[complex]
-  6 |+y: type[int | str | complex]
-7 7 | z: Union[type[float], type[complex]]
-8 8 | z: Union[type[float, int], type[complex]]
-9 9 | 
+4 4 | s: builtins.type[int] | builtins.type[str] | builtins.type[complex]
+5 5 | t: type[int] | type[str] | type[float]
+6   |-u: builtins.type[int] | type[str] | builtins.type[complex]
+  6 |+u: type[int | str | complex]
+7 7 | v: Union[type[float], type[complex]]
+8 8 | w: Union[type[float, int], type[complex]]
+9 9 | x: Union[Union[type[float, int], type[complex]]]
 
 PYI055.pyi:7:4: PYI055 [*] Multiple `type` members in a union. Combine them into one, e.g., `type[Union[float, complex]]`.
   |
-5 | x: type[int] | type[str] | type[float]
-6 | y: builtins.type[int] | type[str] | builtins.type[complex]
-7 | z: Union[type[float], type[complex]]
+5 | t: type[int] | type[str] | type[float]
+6 | u: builtins.type[int] | type[str] | builtins.type[complex]
+7 | v: Union[type[float], type[complex]]
   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI055
-8 | z: Union[type[float, int], type[complex]]
+8 | w: Union[type[float, int], type[complex]]
+9 | x: Union[Union[type[float, int], type[complex]]]
   |
   = help: Combine multiple `type` members
 
 ℹ Safe fix
-4 4 | w: builtins.type[int] | builtins.type[str] | builtins.type[complex]
-5 5 | x: type[int] | type[str] | type[float]
-6 6 | y: builtins.type[int] | type[str] | builtins.type[complex]
-7   |-z: Union[type[float], type[complex]]
-  7 |+z: type[Union[float, complex]]
-8 8 | z: Union[type[float, int], type[complex]]
-9 9 | 
-10 10 | def func(arg: type[int] | str | type[float]) -> None: ...
+4 4 | s: builtins.type[int] | builtins.type[str] | builtins.type[complex]
+5 5 | t: type[int] | type[str] | type[float]
+6 6 | u: builtins.type[int] | type[str] | builtins.type[complex]
+7   |-v: Union[type[float], type[complex]]
+  7 |+v: type[Union[float, complex]]
+8 8 | w: Union[type[float, int], type[complex]]
+9 9 | x: Union[Union[type[float, int], type[complex]]]
+10 10 | y: Union[Union[Union[type[float, int], type[complex]]]]
 
 PYI055.pyi:8:4: PYI055 [*] Multiple `type` members in a union. Combine them into one, e.g., `type[Union[float, int, complex]]`.
    |
- 6 | y: builtins.type[int] | type[str] | builtins.type[complex]
- 7 | z: Union[type[float], type[complex]]
- 8 | z: Union[type[float, int], type[complex]]
+ 6 | u: builtins.type[int] | type[str] | builtins.type[complex]
+ 7 | v: Union[type[float], type[complex]]
+ 8 | w: Union[type[float, int], type[complex]]
    |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI055
- 9 | 
-10 | def func(arg: type[int] | str | type[float]) -> None: ...
+ 9 | x: Union[Union[type[float, int], type[complex]]]
+10 | y: Union[Union[Union[type[float, int], type[complex]]]]
    |
    = help: Combine multiple `type` members
 
 ℹ Safe fix
-5 5 | x: type[int] | type[str] | type[float]
-6 6 | y: builtins.type[int] | type[str] | builtins.type[complex]
-7 7 | z: Union[type[float], type[complex]]
-8   |-z: Union[type[float, int], type[complex]]
-  8 |+z: type[Union[float, int, complex]]
-9 9 | 
-10 10 | def func(arg: type[int] | str | type[float]) -> None: ...
-11 11 | 
+5 5 | t: type[int] | type[str] | type[float]
+6 6 | u: builtins.type[int] | type[str] | builtins.type[complex]
+7 7 | v: Union[type[float], type[complex]]
+8   |-w: Union[type[float, int], type[complex]]
+  8 |+w: type[Union[float, int, complex]]
+9 9 | x: Union[Union[type[float, int], type[complex]]]
+10 10 | y: Union[Union[Union[type[float, int], type[complex]]]]
+11 11 | z: Union[type[complex], Union[Union[type[float, int]]]]
 
-PYI055.pyi:10:15: PYI055 [*] Multiple `type` members in a union. Combine them into one, e.g., `type[int | float]`.
+PYI055.pyi:9:10: PYI055 [*] Multiple `type` members in a union. Combine them into one, e.g., `type[Union[float, int, complex]]`.
    |
- 8 | z: Union[type[float, int], type[complex]]
- 9 | 
-10 | def func(arg: type[int] | str | type[float]) -> None: ...
+ 7 | v: Union[type[float], type[complex]]
+ 8 | w: Union[type[float, int], type[complex]]
+ 9 | x: Union[Union[type[float, int], type[complex]]]
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI055
+10 | y: Union[Union[Union[type[float, int], type[complex]]]]
+11 | z: Union[type[complex], Union[Union[type[float, int]]]]
+   |
+   = help: Combine multiple `type` members
+
+ℹ Safe fix
+6  6  | u: builtins.type[int] | type[str] | builtins.type[complex]
+7  7  | v: Union[type[float], type[complex]]
+8  8  | w: Union[type[float, int], type[complex]]
+9     |-x: Union[Union[type[float, int], type[complex]]]
+   9  |+x: Union[type[Union[float, int, complex]]]
+10 10 | y: Union[Union[Union[type[float, int], type[complex]]]]
+11 11 | z: Union[type[complex], Union[Union[type[float, int]]]]
+12 12 | 
+
+PYI055.pyi:13:15: PYI055 [*] Multiple `type` members in a union. Combine them into one, e.g., `type[int | float]`.
+   |
+11 | z: Union[type[complex], Union[Union[type[float, int]]]]
+12 | 
+13 | def func(arg: type[int] | str | type[float]) -> None: ...
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI055
-11 | 
-12 | # OK
+14 | 
+15 | # OK
    |
    = help: Combine multiple `type` members
 
 ℹ Safe fix
-7  7  | z: Union[type[float], type[complex]]
-8  8  | z: Union[type[float, int], type[complex]]
-9  9  | 
-10    |-def func(arg: type[int] | str | type[float]) -> None: ...
-   10 |+def func(arg: type[int | float] | str) -> None: ...
-11 11 | 
-12 12 | # OK
-13 13 | x: type[int, str, float]
+10 10 | y: Union[Union[Union[type[float, int], type[complex]]]]
+11 11 | z: Union[type[complex], Union[Union[type[float, int]]]]
+12 12 | 
+13    |-def func(arg: type[int] | str | type[float]) -> None: ...
+   13 |+def func(arg: type[int | float] | str) -> None: ...
+14 14 | 
+15 15 | # OK
+16 16 | x: type[int, str, float]
 
-PYI055.pyi:20:7: PYI055 [*] Multiple `type` members in a union. Combine them into one, e.g., `type[requests_mock.Mocker | httpretty]`.
+PYI055.pyi:23:7: PYI055 [*] Multiple `type` members in a union. Combine them into one, e.g., `type[requests_mock.Mocker | httpretty]`.
    |
-19 | # PYI055
-20 | item: type[requests_mock.Mocker] | type[httpretty] = requests_mock.Mocker
+22 | # PYI055
+23 | item: type[requests_mock.Mocker] | type[httpretty] = requests_mock.Mocker
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI055
-21 | 
-22 | def func():
+24 | 
+25 | def func():
    |
    = help: Combine multiple `type` members
 
 ℹ Safe fix
-17 17 | def func(arg: type[int, float] | str) -> None: ...
-18 18 | 
-19 19 | # PYI055
-20    |-item: type[requests_mock.Mocker] | type[httpretty] = requests_mock.Mocker
-   20 |+item: type[requests_mock.Mocker | httpretty] = requests_mock.Mocker
+20 20 | def func(arg: type[int, float] | str) -> None: ...
 21 21 | 
-22 22 | def func():
-23 23 |     # PYI055
+22 22 | # PYI055
+23    |-item: type[requests_mock.Mocker] | type[httpretty] = requests_mock.Mocker
+   23 |+item: type[requests_mock.Mocker | httpretty] = requests_mock.Mocker
+24 24 | 
+25 25 | def func():
+26 26 |     # PYI055
 
-PYI055.pyi:24:11: PYI055 [*] Multiple `type` members in a union. Combine them into one, e.g., `type[requests_mock.Mocker | httpretty | str]`.
+PYI055.pyi:27:11: PYI055 [*] Multiple `type` members in a union. Combine them into one, e.g., `type[requests_mock.Mocker | httpretty | str]`.
    |
-22 | def func():
-23 |     # PYI055
-24 |     item: type[requests_mock.Mocker] | type[httpretty] | type[str] = requests_mock.Mocker
+25 | def func():
+26 |     # PYI055
+27 |     item: type[requests_mock.Mocker] | type[httpretty] | type[str] = requests_mock.Mocker
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI055
-25 |     item2: Union[type[requests_mock.Mocker], type[httpretty], type[str]] = requests_mock.Mocker
-26 |     item3: Union[  # comment
+28 |     item2: Union[type[requests_mock.Mocker], type[httpretty], type[str]] = requests_mock.Mocker
+29 |     item3: Union[  # comment
    |
    = help: Combine multiple `type` members
 
 ℹ Safe fix
-21 21 | 
-22 22 | def func():
-23 23 |     # PYI055
-24    |-    item: type[requests_mock.Mocker] | type[httpretty] | type[str] = requests_mock.Mocker
-   24 |+    item: type[requests_mock.Mocker | httpretty | str] = requests_mock.Mocker
-25 25 |     item2: Union[type[requests_mock.Mocker], type[httpretty], type[str]] = requests_mock.Mocker
-26 26 |     item3: Union[  # comment
-27 27 |         type[requests_mock.Mocker], # another comment
+24 24 | 
+25 25 | def func():
+26 26 |     # PYI055
+27    |-    item: type[requests_mock.Mocker] | type[httpretty] | type[str] = requests_mock.Mocker
+   27 |+    item: type[requests_mock.Mocker | httpretty | str] = requests_mock.Mocker
+28 28 |     item2: Union[type[requests_mock.Mocker], type[httpretty], type[str]] = requests_mock.Mocker
+29 29 |     item3: Union[  # comment
+30 30 |         type[requests_mock.Mocker], # another comment
 
-PYI055.pyi:25:12: PYI055 [*] Multiple `type` members in a union. Combine them into one, e.g., `type[Union[requests_mock.Mocker, httpretty, str]]`.
+PYI055.pyi:28:12: PYI055 [*] Multiple `type` members in a union. Combine them into one, e.g., `type[Union[requests_mock.Mocker, httpretty, str]]`.
    |
-23 |     # PYI055
-24 |     item: type[requests_mock.Mocker] | type[httpretty] | type[str] = requests_mock.Mocker
-25 |     item2: Union[type[requests_mock.Mocker], type[httpretty], type[str]] = requests_mock.Mocker
+26 |     # PYI055
+27 |     item: type[requests_mock.Mocker] | type[httpretty] | type[str] = requests_mock.Mocker
+28 |     item2: Union[type[requests_mock.Mocker], type[httpretty], type[str]] = requests_mock.Mocker
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI055
-26 |     item3: Union[  # comment
-27 |         type[requests_mock.Mocker], # another comment
+29 |     item3: Union[  # comment
+30 |         type[requests_mock.Mocker], # another comment
    |
    = help: Combine multiple `type` members
 
 ℹ Safe fix
-22 22 | def func():
-23 23 |     # PYI055
-24 24 |     item: type[requests_mock.Mocker] | type[httpretty] | type[str] = requests_mock.Mocker
-25    |-    item2: Union[type[requests_mock.Mocker], type[httpretty], type[str]] = requests_mock.Mocker
-   25 |+    item2: type[Union[requests_mock.Mocker, httpretty, str]] = requests_mock.Mocker
-26 26 |     item3: Union[  # comment
-27 27 |         type[requests_mock.Mocker], # another comment
-28 28 |         type[httpretty], type[str]] = requests_mock.Mocker
+25 25 | def func():
+26 26 |     # PYI055
+27 27 |     item: type[requests_mock.Mocker] | type[httpretty] | type[str] = requests_mock.Mocker
+28    |-    item2: Union[type[requests_mock.Mocker], type[httpretty], type[str]] = requests_mock.Mocker
+   28 |+    item2: type[Union[requests_mock.Mocker, httpretty, str]] = requests_mock.Mocker
+29 29 |     item3: Union[  # comment
+30 30 |         type[requests_mock.Mocker], # another comment
+31 31 |         type[httpretty], type[str]] = requests_mock.Mocker
 
-PYI055.pyi:26:12: PYI055 [*] Multiple `type` members in a union. Combine them into one, e.g., `type[Union[requests_mock.Mocker, httpretty, str]]`.
+PYI055.pyi:29:12: PYI055 [*] Multiple `type` members in a union. Combine them into one, e.g., `type[Union[requests_mock.Mocker, httpretty, str]]`.
    |
-24 |       item: type[requests_mock.Mocker] | type[httpretty] | type[str] = requests_mock.Mocker
-25 |       item2: Union[type[requests_mock.Mocker], type[httpretty], type[str]] = requests_mock.Mocker
-26 |       item3: Union[  # comment
+27 |       item: type[requests_mock.Mocker] | type[httpretty] | type[str] = requests_mock.Mocker
+28 |       item2: Union[type[requests_mock.Mocker], type[httpretty], type[str]] = requests_mock.Mocker
+29 |       item3: Union[  # comment
    |  ____________^
-27 | |         type[requests_mock.Mocker], # another comment
-28 | |         type[httpretty], type[str]] = requests_mock.Mocker
+30 | |         type[requests_mock.Mocker], # another comment
+31 | |         type[httpretty], type[str]] = requests_mock.Mocker
    | |___________________________________^ PYI055
    |
    = help: Combine multiple `type` members
 
 ℹ Unsafe fix
-23 23 |     # PYI055
-24 24 |     item: type[requests_mock.Mocker] | type[httpretty] | type[str] = requests_mock.Mocker
-25 25 |     item2: Union[type[requests_mock.Mocker], type[httpretty], type[str]] = requests_mock.Mocker
-26    |-    item3: Union[  # comment
-27    |-        type[requests_mock.Mocker], # another comment
-28    |-        type[httpretty], type[str]] = requests_mock.Mocker
-   26 |+    item3: type[Union[requests_mock.Mocker, httpretty, str]] = requests_mock.Mocker
+26 26 |     # PYI055
+27 27 |     item: type[requests_mock.Mocker] | type[httpretty] | type[str] = requests_mock.Mocker
+28 28 |     item2: Union[type[requests_mock.Mocker], type[httpretty], type[str]] = requests_mock.Mocker
+29    |-    item3: Union[  # comment
+30    |-        type[requests_mock.Mocker], # another comment
+31    |-        type[httpretty], type[str]] = requests_mock.Mocker
+   29 |+    item3: type[Union[requests_mock.Mocker, httpretty, str]] = requests_mock.Mocker

--- a/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI062_PYI062.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI062_PYI062.py.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_pyi/mod.rs
-snapshot_kind: text
 ---
 PYI062.py:5:25: PYI062 [*] Duplicate literal member `True`
   |
@@ -317,3 +316,56 @@ PYI062.py:25:46: PYI062 [*] Duplicate literal member `True`
    25 |+MyType = Literal["foo", True, False, "bar"]  # PYI062
 26 26 | 
 27 27 | n: Literal["No", "duplicates", "here", 1, "1"]
+28 28 | 
+
+PYI062.py:32:37: PYI062 [*] Duplicate literal member `1`
+   |
+30 | # nested literals, all equivalent to `Literal[1]`
+31 | Literal[Literal[1]]  # no duplicate
+32 | Literal[Literal[Literal[1], Literal[1]]]  # once
+   |                                     ^ PYI062
+33 | Literal[Literal[1], Literal[Literal[Literal[1]]]]  # once
+   |
+   = help: Remove duplicates
+
+ℹ Safe fix
+29 29 | 
+30 30 | # nested literals, all equivalent to `Literal[1]`
+31 31 | Literal[Literal[1]]  # no duplicate
+32    |-Literal[Literal[Literal[1], Literal[1]]]  # once
+   32 |+Literal[Literal[1]]  # once
+33 33 | Literal[Literal[1], Literal[Literal[Literal[1]]]]  # once
+
+PYI062.py:32:37: PYI062 [*] Duplicate literal member `1`
+   |
+30 | # nested literals, all equivalent to `Literal[1]`
+31 | Literal[Literal[1]]  # no duplicate
+32 | Literal[Literal[Literal[1], Literal[1]]]  # once
+   |                                     ^ PYI062
+33 | Literal[Literal[1], Literal[Literal[Literal[1]]]]  # once
+   |
+   = help: Remove duplicates
+
+ℹ Safe fix
+29 29 | 
+30 30 | # nested literals, all equivalent to `Literal[1]`
+31 31 | Literal[Literal[1]]  # no duplicate
+32    |-Literal[Literal[Literal[1], Literal[1]]]  # once
+   32 |+Literal[1]  # once
+33 33 | Literal[Literal[1], Literal[Literal[Literal[1]]]]  # once
+
+PYI062.py:33:45: PYI062 [*] Duplicate literal member `1`
+   |
+31 | Literal[Literal[1]]  # no duplicate
+32 | Literal[Literal[Literal[1], Literal[1]]]  # once
+33 | Literal[Literal[1], Literal[Literal[Literal[1]]]]  # once
+   |                                             ^ PYI062
+   |
+   = help: Remove duplicates
+
+ℹ Safe fix
+30 30 | # nested literals, all equivalent to `Literal[1]`
+31 31 | Literal[Literal[1]]  # no duplicate
+32 32 | Literal[Literal[Literal[1], Literal[1]]]  # once
+33    |-Literal[Literal[1], Literal[Literal[Literal[1]]]]  # once
+   33 |+Literal[1]  # once

--- a/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI062_PYI062.pyi.snap
+++ b/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI062_PYI062.pyi.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_pyi/mod.rs
-snapshot_kind: text
 ---
 PYI062.pyi:5:25: PYI062 [*] Duplicate literal member `True`
   |
@@ -317,3 +316,56 @@ PYI062.pyi:25:46: PYI062 [*] Duplicate literal member `True`
    25 |+MyType = Literal["foo", True, False, "bar"]  # PYI062
 26 26 | 
 27 27 | n: Literal["No", "duplicates", "here", 1, "1"]
+28 28 | 
+
+PYI062.pyi:32:37: PYI062 [*] Duplicate literal member `1`
+   |
+30 | # nested literals, all equivalent to `Literal[1]`
+31 | Literal[Literal[1]]  # no duplicate
+32 | Literal[Literal[Literal[1], Literal[1]]]  # once
+   |                                     ^ PYI062
+33 | Literal[Literal[1], Literal[Literal[Literal[1]]]]  # once
+   |
+   = help: Remove duplicates
+
+ℹ Safe fix
+29 29 | 
+30 30 | # nested literals, all equivalent to `Literal[1]`
+31 31 | Literal[Literal[1]]  # no duplicate
+32    |-Literal[Literal[Literal[1], Literal[1]]]  # once
+   32 |+Literal[Literal[1]]  # once
+33 33 | Literal[Literal[1], Literal[Literal[Literal[1]]]]  # once
+
+PYI062.pyi:32:37: PYI062 [*] Duplicate literal member `1`
+   |
+30 | # nested literals, all equivalent to `Literal[1]`
+31 | Literal[Literal[1]]  # no duplicate
+32 | Literal[Literal[Literal[1], Literal[1]]]  # once
+   |                                     ^ PYI062
+33 | Literal[Literal[1], Literal[Literal[Literal[1]]]]  # once
+   |
+   = help: Remove duplicates
+
+ℹ Safe fix
+29 29 | 
+30 30 | # nested literals, all equivalent to `Literal[1]`
+31 31 | Literal[Literal[1]]  # no duplicate
+32    |-Literal[Literal[Literal[1], Literal[1]]]  # once
+   32 |+Literal[1]  # once
+33 33 | Literal[Literal[1], Literal[Literal[Literal[1]]]]  # once
+
+PYI062.pyi:33:45: PYI062 [*] Duplicate literal member `1`
+   |
+31 | Literal[Literal[1]]  # no duplicate
+32 | Literal[Literal[Literal[1], Literal[1]]]  # once
+33 | Literal[Literal[1], Literal[Literal[Literal[1]]]]  # once
+   |                                             ^ PYI062
+   |
+   = help: Remove duplicates
+
+ℹ Safe fix
+30 30 | # nested literals, all equivalent to `Literal[1]`
+31 31 | Literal[Literal[1]]  # no duplicate
+32 32 | Literal[Literal[Literal[1], Literal[1]]]  # once
+33    |-Literal[Literal[1], Literal[Literal[Literal[1]]]]  # once
+   33 |+Literal[1]  # once


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

This PR extends the test cases for a couple of flake8-pyi rules with nested and mixed union annotations.
Although these are rare, they are valid:

```python-console
>>> from typing import Union
>>> Union[int | int | float]
typing.Union[int, float]

>>> Union[Union[float, complex]]
typing.Union[float, complex]
```

We should be able to handle them anyhow, as users or fixes might write these accidentally.

## Test Plan

<!-- How was it tested? -->

The snapshots are updated with the as-is behaviour. 
I'll follow up with a change to the nested union logic. Having these tests in place before makes it easier to review the diff.