### PR TITLE
[red-knot] Diagnostic for possibly unbound imports

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/import/conditional.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/import/conditional.md
@@ -21,7 +21,7 @@ reveal_type(y)
 ```
 
 ```py
-# error: [possibly-unbound-import] "The member `y` in module `maybe_unbound` is possibly unbound"
+# error: [possibly-unbound-import] "Member `y` of module `maybe_unbound` is possibly unbound"
 from maybe_unbound import x, y
 
 reveal_type(x)  # revealed: Literal[3]
@@ -51,7 +51,7 @@ reveal_type(y)
 Importing an annotated name prefers the declared type over the inferred type:
 
 ```py
-# error: [possibly-unbound-import] "The member `y` in module `maybe_unbound_annotated` is possibly unbound"
+# error: [possibly-unbound-import] "Member `y` of module `maybe_unbound_annotated` is possibly unbound"
 from maybe_unbound_annotated import x, y
 
 reveal_type(x)  # revealed: Literal[3]

--- a/crates/red_knot_python_semantic/resources/mdtest/import/conditional.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/import/conditional.md
@@ -21,6 +21,7 @@ reveal_type(y)
 ```
 
 ```py
+# error: [possibly-unbound-import] "The member `y` in module `maybe_unbound` is possibly unbound"
 from maybe_unbound import x, y
 
 reveal_type(x)  # revealed: Literal[3]
@@ -50,6 +51,7 @@ reveal_type(y)
 Importing an annotated name prefers the declared type over the inferred type:
 
 ```py
+# error: [possibly-unbound-import] "The member `y` in module `maybe_unbound_annotated` is possibly unbound"
 from maybe_unbound_annotated import x, y
 
 reveal_type(x)  # revealed: Literal[3]

--- a/crates/red_knot_python_semantic/resources/mdtest/narrow/issubclass.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/narrow/issubclass.md
@@ -104,7 +104,7 @@ else:
 ```py
 # TODO: this error should ideally go away once we (1) understand `sys.version_info` branches,
 # and (2) set the target Python version for this test to 3.10.
-# error: [possibly-unbound-import] "The member `NoneType` in module `types` is possibly unbound"
+# error: [possibly-unbound-import] "Member `NoneType` of module `types` is possibly unbound"
 from types import NoneType
 
 def flag() -> bool: ...

--- a/crates/red_knot_python_semantic/resources/mdtest/narrow/issubclass.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/narrow/issubclass.md
@@ -102,6 +102,8 @@ else:
 ### Handling of `None`
 
 ```py
+# TODO: this should go away once we understand sys.version_info branches
+# error: [possibly-unbound-import] "The member `NoneType` in module `types` is possibly unbound"
 from types import NoneType
 
 def flag() -> bool: ...

--- a/crates/red_knot_python_semantic/resources/mdtest/narrow/issubclass.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/narrow/issubclass.md
@@ -102,7 +102,8 @@ else:
 ### Handling of `None`
 
 ```py
-# TODO: this should go away once we understand sys.version_info branches
+# TODO: this error should ideally go away once we (1) understand `sys.version_info` branches,
+# and (2) set the target Python version for this test to 3.10.
 # error: [possibly-unbound-import] "The member `NoneType` in module `types` is possibly unbound"
 from types import NoneType
 

--- a/crates/red_knot_python_semantic/resources/mdtest/unary/not.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/unary/not.md
@@ -10,8 +10,6 @@ reveal_type(not not None)  # revealed: Literal[False]
 ## Function
 
 ```py
-from typing import reveal_type
-
 def f():
     return 1
 

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -2008,20 +2008,27 @@ impl<'db> TypeInferenceBuilder<'db> {
                         asname: _,
                     } = alias;
 
-                    // For possibly-unbound names, just eliminate Unbound from the type; we
-                    // must be in a bound path. TODO diagnostic for possibly-unbound import?
-                    module_ty
-                        .member(self.db, &ast::name::Name::new(&name.id))
-                        .ignore_possibly_unbound()
-                        .unwrap_or_else(|| {
+                    match module_ty.member(self.db, &ast::name::Name::new(&name.id)) {
+                        Symbol::Type(ty, boundness) => {
+                            if boundness == Boundness::PossiblyUnbound {
+                                self.diagnostics.add(
+                                    AnyNodeRef::Alias(alias),
+                                    "possibly-unbound-import",
+                                    format_args!("The member `{name}` in module `{module_name}` is possibly unbound",),
+                                );
+                            }
+
+                            ty
+                        }
+                        Symbol::Unbound => {
                             self.diagnostics.add(
                                 AnyNodeRef::Alias(alias),
                                 "unresolved-import",
                                 format_args!("Module `{module_name}` has no member `{name}`",),
                             );
-
                             Type::Unknown
-                        })
+                        }
+                    }
                 } else {
                     self.diagnostics
                         .add_unresolved_module(import_from, *level, module);

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -2014,7 +2014,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                                 self.diagnostics.add(
                                     AnyNodeRef::Alias(alias),
                                     "possibly-unbound-import",
-                                    format_args!("The member `{name}` in module `{module_name}` is possibly unbound",),
+                                    format_args!("Member `{name}` of module `{module_name}` is possibly unbound",),
                                 );
                             }
 


### PR DESCRIPTION
## Summary

This adds a new diagnostic when possibly unbound symbols are imported. The `TODO` comment had a question mark, do I'm not sure if this is really something that we want.

This does not touch the un*declared* case, yet.

relates to: #14022

## Test Plan

Updated already existing tests with new diagnostics
