### PR TITLE
[red-knot] Review remaining 'possibly unbound' call sites

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/assignment/unbound.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/assignment/unbound.md
@@ -35,6 +35,7 @@ class C:
     if flag:
         x = 2
 
+# error: [possibly-unbound-attribute] "The attribute `x` on type `Literal[C]` is possibly unbound"
 reveal_type(C.x)  # revealed: Literal[2]
 reveal_type(C.y)  # revealed: Literal[1]
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/assignment/unbound.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/assignment/unbound.md
@@ -35,7 +35,7 @@ class C:
     if flag:
         x = 2
 
-# error: [possibly-unbound-attribute] "The attribute `x` on type `Literal[C]` is possibly unbound"
+# error: [possibly-unbound-attribute] "Attribute `x` on type `Literal[C]` is possibly unbound"
 reveal_type(C.x)  # revealed: Literal[2]
 reveal_type(C.y)  # revealed: Literal[1]
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/expression/attribute.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/expression/attribute.md
@@ -1,0 +1,28 @@
+# Attribute access
+
+## Boundness
+
+```py
+def flag() -> bool: ...
+
+class A:
+    always_bound = 1
+
+    if flag():
+        union = 1
+    else:
+        union = "abc"
+
+    if flag():
+        possibly_unbound = "abc"
+
+reveal_type(A.always_bound)  # revealed: Literal[1]
+
+reveal_type(A.union)  # revealed: Literal[1] | Literal["abc"]
+
+# error: [possibly-unbound-attribute] "The attribute `possibly_unbound` on type `Literal[A]` is possibly unbound"
+reveal_type(A.possibly_unbound)  # revealed: Literal["abc"]
+
+# error: [unresolved-attribute] "Type `Literal[A]` has no attribute `non_existent`"
+reveal_type(A.non_existent)  # revealed: Unknown
+```

--- a/crates/red_knot_python_semantic/resources/mdtest/expression/attribute.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/expression/attribute.md
@@ -20,7 +20,7 @@ reveal_type(A.always_bound)  # revealed: Literal[1]
 
 reveal_type(A.union)  # revealed: Literal[1] | Literal["abc"]
 
-# error: [possibly-unbound-attribute] "The attribute `possibly_unbound` on type `Literal[A]` is possibly unbound"
+# error: [possibly-unbound-attribute] "Attribute `possibly_unbound` on type `Literal[A]` is possibly unbound"
 reveal_type(A.possibly_unbound)  # revealed: Literal["abc"]
 
 # error: [unresolved-attribute] "Type `Literal[A]` has no attribute `non_existent`"

--- a/crates/red_knot_python_semantic/resources/mdtest/scopes/moduletype_attrs.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/scopes/moduletype_attrs.md
@@ -74,6 +74,7 @@ we're dealing with:
 ```py path=__getattr__.py
 import typing
 
+# error: [unresolved-attribute]
 reveal_type(typing.__getattr__)  # revealed: Unknown
 ```
 

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -31,7 +31,6 @@ use std::num::NonZeroU32;
 use itertools::Itertools;
 use ruff_db::files::File;
 use ruff_db::parsed::parsed_module;
-use ruff_python_ast::name::Name;
 use ruff_python_ast::{self as ast, AnyNodeRef, Expr, ExprContext, UnaryOp};
 use rustc_hash::FxHashMap;
 use salsa;
@@ -2789,14 +2788,14 @@ impl<'db> TypeInferenceBuilder<'db> {
         } = attribute;
 
         let value_ty = self.infer_expression(value);
-        match value_ty.member(self.db, &Name::new(&attr.id)) {
+        match value_ty.member(self.db, &attr.id) {
             Symbol::Type(member_ty, boundness) => {
                 if boundness == Boundness::PossiblyUnbound {
                     self.diagnostics.add(
                         attribute.into(),
                         "possibly-unbound-attribute",
                         format_args!(
-                            "The attribute `{}` on type `{}` is possibly unbound",
+                            "Attribute `{}` on type `{}` is possibly unbound",
                             attr.id,
                             value_ty.display(self.db),
                         ),
@@ -5466,7 +5465,7 @@ mod tests {
         let x = get_symbol(&db, "src/a.py", &["<listcomp>"], "x");
         assert!(x.is_unbound());
 
-        // Iterating over an `Unbound` yields `Unknown`:
+        // Iterating over an unbound iterable yields `Unknown`:
         assert_scope_ty(&db, "src/a.py", &["<listcomp>"], "z", "Unknown");
 
         assert_file_diagnostics(&db, "src/a.py", &["Name `x` used when not defined"]);

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -4751,6 +4751,7 @@ mod tests {
         );
     }
 
+    #[track_caller]
     fn get_symbol<'db>(
         db: &'db TestDb,
         file_name: &str,


### PR DESCRIPTION
## Summary

- Emit diagnostics when looking up (possibly) unbound attributes
- More explicit test assertions for unbound symbols
- Review remaining call sites of `Symbol::ignore_possibly_unbound`. Most of them are something like `builtins_symbol(self.db, "Ellipsis").ignore_possibly_unbound().unwrap_or(Type::Unknown)` which look okay to me, unless we want to emit additional diagnostics. There is one additional case in enum literal handling, which has a TODO comment anyway.

part of #14022

## Test Plan

New MD tests for (possibly) unbound attributes.