### PR TITLE
enforce required imports even with useless alias

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/isort/required_imports/this_this.py
+++ b/crates/ruff_linter/resources/test/fixtures/isort/required_imports/this_this.py
@@ -1,0 +1,1 @@
+import this as this

--- a/crates/ruff_linter/resources/test/fixtures/isort/required_imports/this_this_from.py
+++ b/crates/ruff_linter/resources/test/fixtures/isort/required_imports/this_this_from.py
@@ -1,0 +1,1 @@
+from module import this as this

--- a/crates/ruff_linter/src/checkers/ast/analyze/statement.rs
+++ b/crates/ruff_linter/src/checkers/ast/analyze/statement.rs
@@ -1035,7 +1035,7 @@ pub(crate) fn statement(stmt: &Stmt, checker: &mut Checker) {
                     }
                     if !checker.source_type.is_stub() {
                         if checker.enabled(Rule::UselessImportAlias) {
-                            pylint::rules::useless_importfrom_alias(checker, alias, module, level);
+                            pylint::rules::useless_import_from_alias(checker, alias, module, level);
                         }
                     }
                 }

--- a/crates/ruff_linter/src/checkers/ast/analyze/statement.rs
+++ b/crates/ruff_linter/src/checkers/ast/analyze/statement.rs
@@ -1035,7 +1035,7 @@ pub(crate) fn statement(stmt: &Stmt, checker: &mut Checker) {
                     }
                     if !checker.source_type.is_stub() {
                         if checker.enabled(Rule::UselessImportAlias) {
-                            pylint::rules::useless_import_alias(checker, alias);
+                            pylint::rules::useless_importfrom_alias(checker, alias, module, level);
                         }
                     }
                 }

--- a/crates/ruff_linter/src/rules/isort/mod.rs
+++ b/crates/ruff_linter/src/rules/isort/mod.rs
@@ -855,6 +855,57 @@ mod tests {
         Ok(())
     }
 
+    #[test_case(Path::new("this_this_from.py"))]
+    fn required_importfrom_with_useless_alias(path: &Path) -> Result<()> {
+        let snapshot = format!(
+            "required_importfrom_with_useless_alias_{}",
+            path.to_string_lossy()
+        );
+        let diagnostics = test_path(
+            Path::new("isort/required_imports").join(path).as_path(),
+            &LinterSettings {
+                src: vec![test_resource_path("fixtures/isort")],
+                isort: super::settings::Settings {
+                    required_imports: BTreeSet::from_iter([NameImport::ImportFrom(
+                        MemberNameImport::alias(
+                            "module".to_string(),
+                            "this".to_string(),
+                            "this".to_string(),
+                        ),
+                    )]),
+                    ..super::settings::Settings::default()
+                },
+                ..LinterSettings::for_rules([Rule::MissingRequiredImport, Rule::UselessImportAlias])
+            },
+        )?;
+
+        assert_messages!(snapshot, diagnostics);
+        Ok(())
+    }
+
+    #[test_case(Path::new("this_this.py"))]
+    fn required_import_with_useless_alias(path: &Path) -> Result<()> {
+        let snapshot = format!(
+            "required_import_with_useless_alias_{}",
+            path.to_string_lossy()
+        );
+        let diagnostics = test_path(
+            Path::new("isort/required_imports").join(path).as_path(),
+            &LinterSettings {
+                src: vec![test_resource_path("fixtures/isort")],
+                isort: super::settings::Settings {
+                    required_imports: BTreeSet::from_iter([NameImport::Import(
+                        ModuleNameImport::alias("this".to_string(), "this".to_string()),
+                    )]),
+                    ..super::settings::Settings::default()
+                },
+                ..LinterSettings::for_rules([Rule::MissingRequiredImport, Rule::UselessImportAlias])
+            },
+        )?;
+        assert_messages!(snapshot, diagnostics);
+        Ok(())
+    }
+
     #[test_case(Path::new("docstring.py"))]
     #[test_case(Path::new("docstring.pyi"))]
     #[test_case(Path::new("docstring_only.py"))]

--- a/crates/ruff_linter/src/rules/isort/settings.rs
+++ b/crates/ruff_linter/src/rules/isort/settings.rs
@@ -13,7 +13,7 @@ use crate::display_settings;
 use crate::rules::isort::categorize::KnownModules;
 use crate::rules::isort::ImportType;
 use ruff_macros::CacheKey;
-use ruff_python_semantic::NameImport;
+use ruff_python_semantic::{Alias, MemberNameImport, ModuleNameImport, NameImport};
 
 use super::categorize::ImportSection;
 
@@ -73,6 +73,29 @@ pub struct Settings {
     pub from_first: bool,
     pub length_sort: bool,
     pub length_sort_straight: bool,
+}
+
+impl Settings {
+    pub fn requires_module_import(&self, name: String, as_name: Option<String>) -> bool {
+        self.required_imports
+            .contains(&NameImport::Import(ModuleNameImport {
+                name: Alias { name, as_name },
+            }))
+    }
+    pub fn requires_member_import(
+        &self,
+        module: Option<String>,
+        name: String,
+        as_name: Option<String>,
+        level: u32,
+    ) -> bool {
+        self.required_imports
+            .contains(&NameImport::ImportFrom(MemberNameImport {
+                module,
+                name: Alias { name, as_name },
+                level,
+            }))
+    }
 }
 
 impl Default for Settings {

--- a/crates/ruff_linter/src/rules/isort/snapshots/ruff_linter__rules__isort__tests__required_import_with_useless_alias_this_this.py.snap
+++ b/crates/ruff_linter/src/rules/isort/snapshots/ruff_linter__rules__isort__tests__required_import_with_useless_alias_this_this.py.snap
@@ -1,0 +1,9 @@
+---
+source: crates/ruff_linter/src/rules/isort/mod.rs
+---
+this_this.py:1:8: PLC0414 Required import does not rename original package.
+  |
+1 | import this as this
+  |        ^^^^^^^^^^^^ PLC0414
+  |
+  = help: Change required import or disable rule.

--- a/crates/ruff_linter/src/rules/isort/snapshots/ruff_linter__rules__isort__tests__required_importfrom_with_useless_alias_this_this_from.py.snap
+++ b/crates/ruff_linter/src/rules/isort/snapshots/ruff_linter__rules__isort__tests__required_importfrom_with_useless_alias_this_this_from.py.snap
@@ -1,0 +1,9 @@
+---
+source: crates/ruff_linter/src/rules/isort/mod.rs
+---
+this_this_from.py:1:20: PLC0414 Required import does not rename original package.
+  |
+1 | from module import this as this
+  |                    ^^^^^^^^^^^^ PLC0414
+  |
+  = help: Change required import or disable rule.

--- a/crates/ruff_linter/src/rules/pylint/rules/useless_import_alias.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/useless_import_alias.rs
@@ -63,6 +63,8 @@ pub(crate) fn useless_import_alias(checker: &mut Checker, alias: &Alias) {
         if required_imports.contains(&semantic::NameImport::Import(semantic::ModuleNameImport {
             name: semantic_alias,
         })) {
+            let diagnostic = Diagnostic::new(UselessImportAlias, alias.range());
+            checker.diagnostics.push(diagnostic);
             return;
         }
     }
@@ -105,6 +107,8 @@ pub(crate) fn useless_importfrom_alias(
                 level,
             },
         )) {
+            let diagnostic = Diagnostic::new(UselessImportAlias, alias.range());
+            checker.diagnostics.push(diagnostic);
             return;
         }
     }

--- a/crates/ruff_linter/src/rules/pylint/rules/useless_import_alias.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/useless_import_alias.rs
@@ -53,6 +53,7 @@ pub(crate) fn useless_import_alias(checker: &mut Checker, alias: &Alias) {
     if alias.name.as_str() != asname.as_str() {
         return;
     }
+
     // While the fix is specified as always available,
     // the presence of a user-specified required import (I002)
     // with a useless alias causes an infinite loop. So
@@ -82,7 +83,7 @@ pub(crate) fn useless_import_alias(checker: &mut Checker, alias: &Alias) {
 }
 
 /// PLC0414
-pub(crate) fn useless_importfrom_alias(
+pub(crate) fn useless_import_from_alias(
     checker: &mut Checker,
     alias: &Alias,
     module: Option<&str>,
@@ -97,6 +98,7 @@ pub(crate) fn useless_importfrom_alias(
     if alias.name.as_str() != asname.as_str() {
         return;
     }
+
     // While the fix is specified as always available,
     // the presence of a user-specified required import (I002)
     // with a useless alias causes an infinite loop. So

--- a/crates/ruff_linter/src/rules/pylint/rules/useless_import_alias.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/useless_import_alias.rs
@@ -37,6 +37,7 @@ impl Violation for UselessImportAlias {
 
     #[derive_message_formats]
     fn message(&self) -> String {
+        #[allow(clippy::if_not_else)]
         if !self.required_import_conflict {
             "Import alias does not rename original package".to_string()
         } else {
@@ -45,10 +46,10 @@ impl Violation for UselessImportAlias {
     }
 
     fn fix_title(&self) -> Option<String> {
-        if !self.required_import_conflict {
-            Some("Remove import alias".to_string())
-        } else {
+        if self.required_import_conflict {
             Some("Change required import or disable rule.".to_string())
+        } else {
+            Some("Remove import alias".to_string())
         }
     }
 }

--- a/crates/ruff_linter/src/rules/pylint/rules/useless_import_alias.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/useless_import_alias.rs
@@ -53,6 +53,10 @@ pub(crate) fn useless_import_alias(checker: &mut Checker, alias: &Alias) {
     if alias.name.as_str() != asname.as_str() {
         return;
     }
+    // While the fix is specified as always available,
+    // the presence of a user-specified required import (I002)
+    // with a useless alias causes an infinite loop. So
+    // in this case we keep the diagnostic but omit the fix.
     // See https://github.com/astral-sh/ruff/issues/14283
     let required_imports = &checker.settings.isort.required_imports;
     if !required_imports.is_empty() {
@@ -93,6 +97,10 @@ pub(crate) fn useless_importfrom_alias(
     if alias.name.as_str() != asname.as_str() {
         return;
     }
+    // While the fix is specified as always available,
+    // the presence of a user-specified required import (I002)
+    // with a useless alias causes an infinite loop. So
+    // in this case we keep the diagnostic but omit the fix.
     // See https://github.com/astral-sh/ruff/issues/14283
     let required_imports = &checker.settings.isort.required_imports;
     if !required_imports.is_empty() {


### PR DESCRIPTION
This PR handles a panic that occurs when applying unsafe fixes if a user inserts a required import (I002) that has a "useless alias" in it, like `import numpy as numpy`, and also selects PLC0414 (useless-import-alias)

In this case, the fixes alternate between adding the required import statement, then removing the alias, until the recursion limit is reached. See linked issue for an example.

# Tests to confirm panic resolved:

```console
$ echo 1 | cargo run --quiet -p ruff -- check --no-cache --isolated --select I002,PLC0414 --config 'lint.isort.required-imports = ["from module import this as this"]' - --unsafe-fixes --fix
from module import this as this
1
Found 1 error (1 fixed, 0 remaining).
```

```console
$ echo 1 | cargo run --quiet -p ruff -- check --no-cache --isolated --select I002,PLC0414 --config 'lint.isort.required-imports = ["import numpy as numpy"]' - --unsafe-fixes --fix
import numpy as numpy
1
Found 1 error (1 fixed, 0 remaining).
```

Closes #14283
