### PR TITLE
[red-knot] simplify type lookup in function/class definitions

### DIFF
--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -2502,11 +2502,8 @@ impl<'db> Class<'db> {
             .find_keyword("metaclass")?
             .value;
         let class_definition = semantic_index(db, self.file(db)).definition(class_stmt);
-        Some(definition_expression_ty(
-            db,
-            class_definition,
-            metaclass_node,
-        ))
+        let metaclass_ty = definition_expression_ty(db, class_definition, metaclass_node);
+        Some(metaclass_ty)
     }
 
     /// Return the metaclass of this class, or `Unknown` if the metaclass cannot be inferred.


### PR DESCRIPTION
When we look up the types of class bases or keywords (`metaclass`), we currently do this little dance: if there are type params, then look up the type using `SemanticModel` in the type-params scope, if not, look up the type directly in the definition's own scope, with support for deferred types.

With inference of function parameter types, I'm now adding another case of this same dance, so I'm motivated to make it a bit more ergonomic.

Add support to `definition_expression_ty` to handle any sub-expression of a definition, whether it is in the definition's own scope or in a type-params sub-scope.

Related to both #13693 and #14161.