### PR TITLE
[red-knot] Fix assertion for invalid match pattern

### DIFF
--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -4084,16 +4084,19 @@ impl<'db> TypeInferenceBuilder<'db> {
         // https://typing.readthedocs.io/en/latest/spec/annotations.html#grammar-token-expression-grammar-type_expression
 
         match expression {
-            ast::Expr::Name(name) => {
-                debug_assert_eq!(name.ctx, ast::ExprContext::Load);
-                self.infer_name_expression(name).to_instance(self.db)
-            }
+            ast::Expr::Name(name) => match name.ctx {
+                ast::ExprContext::Load => self.infer_name_expression(name).to_instance(self.db),
+                ast::ExprContext::Invalid => Type::Unknown,
+                ast::ExprContext::Store | ast::ExprContext::Del => Type::Todo,
+            },
 
-            ast::Expr::Attribute(attribute_expression) => {
-                debug_assert_eq!(attribute_expression.ctx, ast::ExprContext::Load);
-                self.infer_attribute_expression(attribute_expression)
-                    .to_instance(self.db)
-            }
+            ast::Expr::Attribute(attribute_expression) => match attribute_expression.ctx {
+                ast::ExprContext::Load => self
+                    .infer_attribute_expression(attribute_expression)
+                    .to_instance(self.db),
+                ast::ExprContext::Invalid => Type::Unknown,
+                ast::ExprContext::Store | ast::ExprContext::Del => Type::Todo,
+            },
 
             ast::Expr::NoneLiteral(_literal) => Type::none(self.db),
 

--- a/crates/red_knot_workspace/resources/test/corpus/85_match_invalid.py
+++ b/crates/red_knot_workspace/resources/test/corpus/85_match_invalid.py
@@ -1,0 +1,3 @@
+match some_int:
+    case x:=2:
+        pass


### PR DESCRIPTION
## Summary

Fixes a failing debug assertion that triggers for the following code:
```py
match some_int:
    case x:=2:
        pass
```

closes #14305

## Test Plan

Added problematic code example to corpus.