### PR TITLE
[red-knot] Avoid panic for generic type aliases

### DIFF
--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -1796,14 +1796,13 @@ impl<'db> TypeInferenceBuilder<'db> {
         let ast::StmtTypeAlias {
             range: _,
             name,
-            type_params,
+            type_params: _,
             value,
         } = type_alias_statement;
         self.infer_expression(value);
         self.infer_expression(name);
-        if let Some(type_params) = type_params {
-            self.infer_type_parameters(type_params);
-        }
+
+        // TODO: properly handle generic type aliases, which need their own annotation scope
     }
 
     fn infer_for_statement(&mut self, for_statement: &ast::StmtFor) {

--- a/crates/red_knot_workspace/resources/test/corpus/89_type_alias.py
+++ b/crates/red_knot_workspace/resources/test/corpus/89_type_alias.py
@@ -1,1 +1,2 @@
 type foo = int
+type ListOrSet[T] = list[T] | set[T]


### PR DESCRIPTION
## Summary

This avoids a panic inside `TypeInferenceBuilder::infer_type_parameters` when encountering generic type aliases:
```py
type ListOrSet[T] = list[T] | set[T]
```

I'm not sure if this is the right call. To fix this properly, I believe we would have to treat type aliases as being [their own annotation scope](https://docs.python.org/3/reference/compound_stmts.html#generic-type-aliases). The left hand side is a definition for the type parameter `T` which is being used in the special annotation scope on the right hand side. Similar to how it works for generic functions and classes. This is something I've started to look into — but it seems to require larger-scale changes and I'm not sure if this is the right time to work on them.

closes #14307

## Test Plan

Added new example to the corpus.
