### PR TITLE
Remove unused flags and functions from the semantic model

### DIFF
--- a/crates/ruff_linter/src/checkers/ast/mod.rs
+++ b/crates/ruff_linter/src/checkers/ast/mod.rs
@@ -171,7 +171,7 @@ impl ExpectedDocstringKind {
     /// Returns the semantic model flag that represents the current docstring state.
     const fn as_flag(self) -> SemanticModelFlags {
         match self {
-            ExpectedDocstringKind::Attribute => SemanticModelFlags::empty(),
+            ExpectedDocstringKind::Attribute => SemanticModelFlags::ATTRIBUTE_DOCSTRING,
             _ => SemanticModelFlags::PEP_257_DOCSTRING,
         }
     }

--- a/crates/ruff_linter/src/checkers/ast/mod.rs
+++ b/crates/ruff_linter/src/checkers/ast/mod.rs
@@ -171,7 +171,7 @@ impl ExpectedDocstringKind {
     /// Returns the semantic model flag that represents the current docstring state.
     const fn as_flag(self) -> SemanticModelFlags {
         match self {
-            ExpectedDocstringKind::Attribute => SemanticModelFlags::ATTRIBUTE_DOCSTRING,
+            ExpectedDocstringKind::Attribute => SemanticModelFlags::empty(),
             _ => SemanticModelFlags::PEP_257_DOCSTRING,
         }
     }
@@ -1794,7 +1794,6 @@ impl<'a> Checker<'a> {
         self.visit_expr(&generator.iter);
         self.semantic.push_scope(ScopeKind::Generator(kind));
 
-        self.semantic.flags = flags | SemanticModelFlags::COMPREHENSION_ASSIGNMENT;
         self.visit_expr(&generator.target);
         self.semantic.flags = flags;
 
@@ -1805,7 +1804,6 @@ impl<'a> Checker<'a> {
         for generator in iterator {
             self.visit_expr(&generator.iter);
 
-            self.semantic.flags = flags | SemanticModelFlags::COMPREHENSION_ASSIGNMENT;
             self.visit_expr(&generator.target);
             self.semantic.flags = flags;
 

--- a/crates/ruff_linter/src/rules/flake8_type_checking/helpers.rs
+++ b/crates/ruff_linter/src/rules/flake8_type_checking/helpers.rs
@@ -23,8 +23,7 @@ pub(crate) fn is_typing_reference(reference: &ResolvedReference, settings: &Sett
         // type definition to be considered a typing reference
         || (reference.in_type_definition()
             && (reference.in_typing_only_annotation()
-                || reference.in_complex_string_type_definition()
-                || reference.in_simple_string_type_definition()
+                || reference.in_string_type_definition()
                 || (settings.quote_annotations && reference.in_runtime_evaluated_annotation())))
 }
 

--- a/crates/ruff_linter/src/rules/pylint/rules/import_private_name.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/import_private_name.rs
@@ -151,8 +151,7 @@ pub(crate) fn import_private_name(
 fn is_typing(reference: &ResolvedReference) -> bool {
     reference.in_type_checking_block()
         || reference.in_typing_only_annotation()
-        || reference.in_complex_string_type_definition()
-        || reference.in_simple_string_type_definition()
+        || reference.in_string_type_definition()
         || reference.in_runtime_evaluated_annotation()
 }
 

--- a/crates/ruff_python_semantic/src/model.rs
+++ b/crates/ruff_python_semantic/src/model.rs
@@ -1593,6 +1593,12 @@ impl<'a> SemanticModel<'a> {
             .intersects(SemanticModelFlags::RUNTIME_EVALUATED_ANNOTATION)
     }
 
+    /// Return `true` if the context is in a runtime-required type annotation.
+    pub const fn in_runtime_required_annotation(&self) -> bool {
+        self.flags
+            .intersects(SemanticModelFlags::RUNTIME_REQUIRED_ANNOTATION)
+    }
+
     /// Return `true` if the model is in a type definition.
     pub const fn in_type_definition(&self) -> bool {
         self.flags.intersects(SemanticModelFlags::TYPE_DEFINITION)
@@ -1605,6 +1611,13 @@ impl<'a> SemanticModel<'a> {
             .intersects(SemanticModelFlags::STRING_TYPE_DEFINITION)
     }
 
+    /// Return `true` if the model is visiting a "simple string type definition"
+    /// that was previously deferred when initially traversing the AST
+    pub const fn in_simple_string_type_definition(&self) -> bool {
+        self.flags
+            .intersects(SemanticModelFlags::SIMPLE_STRING_TYPE_DEFINITION)
+    }
+
     /// Return `true` if the model is visiting a "complex string type definition"
     /// that was previously deferred when initially traversing the AST
     pub const fn in_complex_string_type_definition(&self) -> bool {
@@ -1614,7 +1627,7 @@ impl<'a> SemanticModel<'a> {
 
     /// Return `true` if the model is visiting a "`__future__` type definition"
     /// that was previously deferred when initially traversing the AST
-    const fn in_future_type_definition(&self) -> bool {
+    pub const fn in_future_type_definition(&self) -> bool {
         self.flags
             .intersects(SemanticModelFlags::FUTURE_TYPE_DEFINITION)
     }
@@ -1641,7 +1654,7 @@ impl<'a> SemanticModel<'a> {
     /// cast("Thread", x)  # Forward reference
     /// cast(Thread, x)  # Non-forward reference
     /// ```
-    const fn in_forward_reference(&self) -> bool {
+    pub const fn in_forward_reference(&self) -> bool {
         self.in_string_type_definition()
             || (self.in_future_type_definition() && self.in_typing_only_annotation())
     }
@@ -1690,6 +1703,12 @@ impl<'a> SemanticModel<'a> {
         self.flags.intersects(SemanticModelFlags::PEP_257_DOCSTRING)
     }
 
+    /// Return `true` if the model is in an attribute docstring.
+    pub const fn in_attribute_docstring(&self) -> bool {
+        self.flags
+            .intersects(SemanticModelFlags::ATTRIBUTE_DOCSTRING)
+    }
+
     /// Return `true` if the model has traversed past the "top-of-file" import boundary.
     pub const fn seen_import_boundary(&self) -> bool {
         self.flags.intersects(SemanticModelFlags::IMPORT_BOUNDARY)
@@ -1713,7 +1732,7 @@ impl<'a> SemanticModel<'a> {
     }
 
     /// Return `true` if the model is in a stub file (i.e., a file with a `.pyi` extension).
-    const fn in_stub_file(&self) -> bool {
+    pub const fn in_stub_file(&self) -> bool {
         self.flags.intersects(SemanticModelFlags::STUB_FILE)
     }
 
@@ -1721,6 +1740,13 @@ impl<'a> SemanticModel<'a> {
     pub const fn in_named_expression_assignment(&self) -> bool {
         self.flags
             .intersects(SemanticModelFlags::NAMED_EXPRESSION_ASSIGNMENT)
+    }
+
+    /// Return `true` if the model is visiting the r.h.s. of an `__all__` definition
+    /// (e.g. `"foo"` in `__all__ = ["foo"]`)
+    pub const fn in_dunder_all_definition(&self) -> bool {
+        self.flags
+            .intersects(SemanticModelFlags::DUNDER_ALL_DEFINITION)
     }
 
     /// Return `true` if the model is visiting an item in a class's bases tuple
@@ -2164,6 +2190,31 @@ bitflags! {
         /// The model is visiting a class base that was initially deferred
         /// while traversing the AST. (This only happens in stub files.)
         const DEFERRED_CLASS_BASE = 1 << 24;
+
+        /// The model is in an attribute docstring.
+        ///
+        /// An attribute docstring is a string literal immediately following an assignment or an
+        /// annotated assignment statement. The context in which this is valid are:
+        /// 1. At the top level of a module
+        /// 2. At the top level of a class definition i.e., a class attribute
+        ///
+        /// For example:
+        /// ```python
+        /// a = 1
+        /// """This is an attribute docstring for `a` variable"""
+        ///
+        ///
+        /// class Foo:
+        ///     b = 1
+        ///     """This is an attribute docstring for `Foo.b` class variable"""
+        /// ```
+        ///
+        /// Unlike other kinds of docstrings as described in [PEP 257], attribute docstrings are
+        /// discarded at runtime. However, they are used by some documentation renderers and
+        /// static-analysis tools.
+        ///
+        /// [PEP 257]: https://peps.python.org/pep-0257/#what-is-a-docstring
+        const ATTRIBUTE_DOCSTRING = 1 << 25;
 
         /// The context is in any type annotation.
         const ANNOTATION = Self::TYPING_ONLY_ANNOTATION.bits() | Self::RUNTIME_EVALUATED_ANNOTATION.bits() | Self::RUNTIME_REQUIRED_ANNOTATION.bits();

--- a/crates/ruff_python_semantic/src/reference.rs
+++ b/crates/ruff_python_semantic/src/reference.rs
@@ -63,28 +63,10 @@ impl ResolvedReference {
             .intersects(SemanticModelFlags::RUNTIME_EVALUATED_ANNOTATION)
     }
 
-    /// Return `true` if the context is in a "simple" string type definition.
-    pub const fn in_simple_string_type_definition(&self) -> bool {
+    /// Return `true` if the context is in a string type definition.
+    pub const fn in_string_type_definition(&self) -> bool {
         self.flags
-            .intersects(SemanticModelFlags::SIMPLE_STRING_TYPE_DEFINITION)
-    }
-
-    /// Return `true` if the context is in a "complex" string type definition.
-    pub const fn in_complex_string_type_definition(&self) -> bool {
-        self.flags
-            .intersects(SemanticModelFlags::COMPLEX_STRING_TYPE_DEFINITION)
-    }
-
-    /// Return `true` if the context is in a `__future__` type definition.
-    pub const fn in_future_type_definition(&self) -> bool {
-        self.flags
-            .intersects(SemanticModelFlags::FUTURE_TYPE_DEFINITION)
-    }
-
-    /// Return `true` if the context is in any kind of deferred type definition.
-    pub const fn in_deferred_type_definition(&self) -> bool {
-        self.flags
-            .intersects(SemanticModelFlags::DEFERRED_TYPE_DEFINITION)
+            .intersects(SemanticModelFlags::STRING_TYPE_DEFINITION)
     }
 
     /// Return `true` if the context is in any kind of type definition.


### PR DESCRIPTION
## Summary

I noticed while reviewing https://github.com/astral-sh/ruff/pull/14311 that some of the functions publicly exposed by the semantic model are never used anywhere, and some of the semantic-model flags set by the AST visitor but never read.

I'm not sure if this PR is really a good idea or not... some of these flags and functions are not used right now, but there's a chance we might use them in the future? Not sure.

I feel most confident about the changes in `crates/ruff_python_semantic/src/reference.rs`, `crates/ruff_linter/src/rules/flake8_type_checking/helpers.rs` and `crates/ruff_linter/src/rules/pylint/rules/import_private_name.rs`, since the `ResolvedReference` struct already only exposes a subset of the interface exposed by the `SemanticModel`. It doesn't seem like we're trying with that struct to publicly expose information regarding all flags the `SemanticModel` stores internally.

## Test Plan

- `cargo test -p ruff_linter`
- `cargo test -p ruff_python_semantic`