### PR TITLE
[red-knot] Avoid panics for ipython magic commands

### DIFF
--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -2164,7 +2164,10 @@ impl<'db> TypeInferenceBuilder<'db> {
             ast::Expr::Yield(yield_expression) => self.infer_yield_expression(yield_expression),
             ast::Expr::YieldFrom(yield_from) => self.infer_yield_from_expression(yield_from),
             ast::Expr::Await(await_expression) => self.infer_await_expression(await_expression),
-            ast::Expr::IpyEscapeCommand(_) => todo!("Implement Ipy escape command support"),
+            ast::Expr::IpyEscapeCommand(_) => {
+                // TODO Implement Ipy escape command support
+                Type::Todo
+            }
         };
 
         self.store_expression_type(expression, ty);

--- a/crates/red_knot_workspace/resources/test/corpus/83_jupyter_notebook_ipython_magic.ipynb
+++ b/crates/red_knot_workspace/resources/test/corpus/83_jupyter_notebook_ipython_magic.ipynb
@@ -1,0 +1,1 @@
+../../../../ruff_notebook/resources/test/fixtures/jupyter/unused_variable.ipynb


### PR DESCRIPTION
## Summary

Avoids panics when encountering Jupyter notebooks with [IPython magic commands](https://ipython.readthedocs.io/en/stable/interactive/magics.html).

## Test Plan

Added Jupyter notebook to corpus.
