### PR TITLE
[`flake8-pyi`] Apply `redundant-numeric-union` to more type expressions (`PYI041`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI041.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI041.py
@@ -74,3 +74,6 @@ class Foo:
 
     def bad5(self, arg: int | (float | complex)) -> None: 
         ...
+
+    def bad6(self) -> int | (float | complex):
+        ...

--- a/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI041.pyi
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI041.pyi
@@ -58,3 +58,5 @@ class Foo:
     def bad4(self, arg: Union[float | complex, int]) -> None: ...  # PYI041
 
     def bad5(self, arg: int | (float | complex)) -> None: ...  # PYI041
+
+    def bad6(self) -> int | (float | complex): ...  # PYI041

--- a/crates/ruff_linter/src/checkers/ast/analyze/expression.rs
+++ b/crates/ruff_linter/src/checkers/ast/analyze/expression.rs
@@ -81,6 +81,7 @@ pub(crate) fn expression(expr: &Expr, checker: &mut Checker) {
                 Rule::RedundantLiteralUnion,
                 Rule::UnnecessaryTypeUnion,
                 Rule::NoneNotAtEndOfUnion,
+                Rule::RedundantNumericUnion,
             ]) {
                 // Avoid duplicate checks if the parent is a union, since these rules already
                 // traverse nested unions.
@@ -96,6 +97,9 @@ pub(crate) fn expression(expr: &Expr, checker: &mut Checker) {
                     }
                     if checker.enabled(Rule::UnnecessaryTypeUnion) {
                         flake8_pyi::rules::unnecessary_type_union(checker, expr);
+                    }
+                    if checker.enabled(Rule::RedundantNumericUnion) {
+                        flake8_pyi::rules::redundant_numeric_union(checker, expr);
                     }
                     if checker.enabled(Rule::NoneNotAtEndOfUnion) {
                         ruff::rules::none_not_at_end_of_union(checker, expr);
@@ -1312,6 +1316,9 @@ pub(crate) fn expression(expr: &Expr, checker: &mut Checker) {
                 }
                 if checker.enabled(Rule::RuntimeStringUnion) {
                     flake8_type_checking::rules::runtime_string_union(checker, expr);
+                }
+                if checker.enabled(Rule::RedundantNumericUnion) {
+                    flake8_pyi::rules::redundant_numeric_union(checker, expr);
                 }
                 if checker.enabled(Rule::NoneNotAtEndOfUnion) {
                     ruff::rules::none_not_at_end_of_union(checker, expr);

--- a/crates/ruff_linter/src/checkers/ast/analyze/statement.rs
+++ b/crates/ruff_linter/src/checkers/ast/analyze/statement.rs
@@ -177,9 +177,6 @@ pub(crate) fn statement(stmt: &Stmt, checker: &mut Checker) {
             if checker.enabled(Rule::BadExitAnnotation) {
                 flake8_pyi::rules::bad_exit_annotation(checker, function_def);
             }
-            if checker.enabled(Rule::RedundantNumericUnion) {
-                flake8_pyi::rules::redundant_numeric_union(checker, parameters);
-            }
             if checker.enabled(Rule::Pep484StylePositionalOnlyParameter) {
                 flake8_pyi::rules::pep_484_positional_parameter(checker, function_def);
             }

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/redundant_numeric_union.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/redundant_numeric_union.rs
@@ -5,8 +5,7 @@ use anyhow::Result;
 use ruff_diagnostics::{Applicability, Diagnostic, Edit, Fix, FixAvailability, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::{
-    name::Name, AnyParameterRef, Expr, ExprBinOp, ExprContext, ExprName, ExprSubscript, ExprTuple,
-    Operator, Parameters,
+    name::Name, Expr, ExprBinOp, ExprContext, ExprName, ExprSubscript, ExprTuple, Operator,
 };
 use ruff_python_semantic::analyze::typing::traverse_union;
 use ruff_text_size::{Ranged, TextRange};
@@ -81,13 +80,7 @@ impl Violation for RedundantNumericUnion {
 }
 
 /// PYI041
-pub(crate) fn redundant_numeric_union(checker: &mut Checker, parameters: &Parameters) {
-    for annotation in parameters.iter().filter_map(AnyParameterRef::annotation) {
-        check_annotation(checker, annotation);
-    }
-}
-
-fn check_annotation<'a>(checker: &mut Checker, annotation: &'a Expr) {
+pub(crate) fn redundant_numeric_union<'a>(checker: &mut Checker, annotation: &'a Expr) {
     let mut numeric_flags = NumericFlags::empty();
 
     let mut find_numeric_type = |expr: &Expr, _parent: &Expr| {

--- a/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI041_PYI041.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI041_PYI041.py.snap
@@ -1,6 +1,24 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_pyi/mod.rs
 ---
+PYI041.py:10:18: PYI041 Use `float` instead of `int | float`
+   |
+ 9 | TA0: TypeAlias = int
+10 | TA1: TypeAlias = int | float | bool
+   |                  ^^^^^^^^^^^^^^^^^^ PYI041
+11 | TA2: TypeAlias = Union[int, float, bool]
+   |
+   = help: Remove redundant type
+
+PYI041.py:11:18: PYI041 Use `float` instead of `int | float`
+   |
+ 9 | TA0: TypeAlias = int
+10 | TA1: TypeAlias = int | float | bool
+11 | TA2: TypeAlias = Union[int, float, bool]
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^ PYI041
+   |
+   = help: Remove redundant type
+
 PYI041.py:22:14: PYI041 Use `float` instead of `int | float`
    |
 22 | def f0(arg1: float | int) -> None:
@@ -22,6 +40,14 @@ PYI041.py:30:28: PYI041 Use `float` instead of `int | float`
 30 | def f2(arg1: int, /, arg2: int | int | float) -> None:
    |                            ^^^^^^^^^^^^^^^^^ PYI041
 31 |     ...
+   |
+   = help: Remove redundant type
+
+PYI041.py:34:32: PYI041 Use `float` instead of `int | float`
+   |
+34 | def f3(arg1: int, *args: Union[int | int | float]) -> None:
+   |                                ^^^^^^^^^^^^^^^^^ PYI041
+35 |     ...
    |
    = help: Remove redundant type
 
@@ -107,5 +133,15 @@ PYI041.py:75:25: PYI041 Use `complex` instead of `int | float | complex`
 75 |     def bad5(self, arg: int | (float | complex)) -> None: 
    |                         ^^^^^^^^^^^^^^^^^^^^^^^ PYI041
 76 |         ...
+   |
+   = help: Remove redundant type
+
+PYI041.py:78:23: PYI041 Use `complex` instead of `int | float | complex`
+   |
+76 |         ...
+77 | 
+78 |     def bad6(self) -> int | (float | complex):
+   |                       ^^^^^^^^^^^^^^^^^^^^^^^ PYI041
+79 |         ...
    |
    = help: Remove redundant type

--- a/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI041_PYI041.pyi.snap
+++ b/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI041_PYI041.pyi.snap
@@ -1,6 +1,25 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_pyi/mod.rs
 ---
+PYI041.pyi:11:18: PYI041 Use `float` instead of `int | float`
+   |
+ 9 | # Type aliases not flagged
+10 | TA0: TypeAlias = int
+11 | TA1: TypeAlias = int | float | bool
+   |                  ^^^^^^^^^^^^^^^^^^ PYI041
+12 | TA2: TypeAlias = Union[int, float, bool]
+   |
+   = help: Remove redundant type
+
+PYI041.pyi:12:18: PYI041 Use `float` instead of `int | float`
+   |
+10 | TA0: TypeAlias = int
+11 | TA1: TypeAlias = int | float | bool
+12 | TA2: TypeAlias = Union[int, float, bool]
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^ PYI041
+   |
+   = help: Remove redundant type
+
 PYI041.pyi:21:14: PYI041 Use `float` instead of `int | float`
    |
 21 | def f0(arg1: float | int) -> None: ...  # PYI041
@@ -19,6 +38,13 @@ PYI041.pyi:27:28: PYI041 Use `float` instead of `int | float`
    |
 27 | def f2(arg1: int, /, arg2: int | int | float) -> None: ...  # PYI041
    |                            ^^^^^^^^^^^^^^^^^ PYI041
+   |
+   = help: Remove redundant type
+
+PYI041.pyi:30:32: PYI041 Use `float` instead of `int | float`
+   |
+30 | def f3(arg1: int, *args: Union[int | int | float]) -> None: ...  # PYI041
+   |                                ^^^^^^^^^^^^^^^^^ PYI041
    |
    = help: Remove redundant type
 
@@ -107,5 +133,16 @@ PYI041.pyi:60:25: PYI041 Use `complex` instead of `int | float | complex`
 59 | 
 60 |     def bad5(self, arg: int | (float | complex)) -> None: ...  # PYI041
    |                         ^^^^^^^^^^^^^^^^^^^^^^^ PYI041
+61 | 
+62 |     def bad6(self) -> int | (float | complex): ...  # PYI041
+   |
+   = help: Remove redundant type
+
+PYI041.pyi:62:23: PYI041 Use `complex` instead of `int | float | complex`
+   |
+60 |     def bad5(self, arg: int | (float | complex)) -> None: ...  # PYI041
+61 | 
+62 |     def bad6(self) -> int | (float | complex): ...  # PYI041
+   |                       ^^^^^^^^^^^^^^^^^^^^^^^ PYI041
    |
    = help: Remove redundant type


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Fixes false negatives for redundant numeric unions in other places than function arguments, eg. return types, type aliases

Splitting this change of from https://github.com/astral-sh/ruff/pull/14273 (will rebase once that is merged)
<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

`cargo test` and reviewed ecosystem results
<!-- How was it tested? -->
