### PR TITLE
Improve docs for ALE plugin for vim

### DIFF
--- a/docs/editors/setup.md
+++ b/docs/editors/setup.md
@@ -153,8 +153,11 @@ extension for [coc.nvim](https://github.com/neoclide/coc.nvim).
 " Linter
 let g:ale_linters = { "python": ["ruff"] }
 " Formatter
-let g:ale_fixers = { "python": ["ruff_format"] }
+let g:ale_fixers = { "python": ["ruff", "ruff_format"] }
 ```
+
+For the fixers, `ruff` will run `ruff check --fix` (to fix all auto-fixable problems) whereas
+`ruff_format` will run `ruff format`.
 
 </details>
 

--- a/docs/editors/setup.md
+++ b/docs/editors/setup.md
@@ -150,9 +150,9 @@ extension for [coc.nvim](https://github.com/neoclide/coc.nvim).
 <summary>With the <a href="https://github.com/dense-analysis/ale">ALE</a> plugin for Vim or Neovim.</summary>
 
 ```vim
-" Linter
+" Linters
 let g:ale_linters = { "python": ["ruff"] }
-" Formatter
+" Fixers
 let g:ale_fixers = { "python": ["ruff", "ruff_format"] }
 ```
 


### PR DESCRIPTION
2 different fixers are available in ALE :
 - ruff which runs `ruff check --fix` command (useful for example when isort is enabled in lint config),
 - ruff_format which runs `run format` command.

The documentation was missing `ruff` as a possible fixer in ALE.