### PR TITLE
[`pylint`] Remove check for dot in alias name in `useless-import-alias (PLC0414)`

### DIFF
--- a/crates/ruff_linter/src/rules/pylint/rules/useless_import_alias.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/useless_import_alias.rs
@@ -59,9 +59,6 @@ pub(crate) fn useless_import_alias(checker: &mut Checker, alias: &Alias) {
     let Some(asname) = &alias.asname else {
         return;
     };
-    if alias.name.contains('.') {
-        return;
-    }
     if alias.name.as_str() != asname.as_str() {
         return;
     }
@@ -97,9 +94,6 @@ pub(crate) fn useless_import_from_alias(
     let Some(asname) = &alias.asname else {
         return;
     };
-    if alias.name.contains('.') {
-        return;
-    }
     if alias.name.as_str() != asname.as_str() {
         return;
     }


### PR DESCRIPTION
Follow-up to #14287 : when checking that `name` is the same as `as_name` in `import name as as_name`, we do not need to first do an early return if `'.'` is found in `name`.
