### PR TITLE
Use CWD to resolve settings from `ruff.configuration`

### DIFF
--- a/crates/ruff_server/src/session/index/ruff_settings.rs
+++ b/crates/ruff_server/src/session/index/ruff_settings.rs
@@ -380,6 +380,10 @@ impl<'a> ConfigurationTransformer for EditorConfigurationTransformer<'a> {
 
         // Merge in the editor-specified configuration file, if it exists.
         let editor_configuration = if let Some(config_file_path) = configuration {
+            tracing::debug!(
+                "Combining settings from editor-specified configuration file at: {}",
+                config_file_path.display()
+            );
             match open_configuration_file(&config_file_path) {
                 Ok(config_from_file) => editor_configuration.combine(config_from_file),
                 Err(err) => {
@@ -406,7 +410,7 @@ impl<'a> ConfigurationTransformer for EditorConfigurationTransformer<'a> {
 fn open_configuration_file(config_path: &Path) -> crate::Result<Configuration> {
     ruff_workspace::resolver::resolve_configuration(
         config_path,
-        Relativity::Parent,
+        Relativity::Cwd,
         &IdentityTransformer,
     )
 }


### PR DESCRIPTION
## Summary

This PR fixes a bug in the Ruff language server where the editor-specified configuration was resolved relative to the configuration directory and not the current working directory.

The existing behavior is confusing given that this config file is specified by the user and is not _discovered_ by Ruff itself. The behavior of resolving this configuration file should be similar to that of the `--config` flag on the command-line which uses the current working directory: https://github.com/astral-sh/ruff/blob/3210f1a23bfe42c5d58c609b602861062eeed2ad/crates/ruff/src/resolve.rs#L34-L48

This creates problems where certain configuration options doesn't work because the paths resolved in that case are relative to the configuration directory and not the current working directory in which the editor is expected to be in. For example, the `lint.per-file-ignores` doesn't work as mentioned in the linked issue along with `exclude`, `extend-exclude`, etc.

fixes: #14282 

## Test Plan

Using the following directory tree structure:
```
.
├── .config
│   └── ruff.toml
└── src
    └── migrations
        └── versions
            └── a.py
```

where, the `ruff.toml` is:
```toml
# 1. Comment this out to test `per-file-ignores`
extend-exclude = ["**/versions/*.py"]

[lint]
select = ["D"]

# 2. Comment this out to test `extend-exclude`
[lint.per-file-ignores]
"**/versions/*.py" = ["D"]

# 3. Comment both `per-file-ignores` and `extend-exclude` to test selection works
```

And, the content of `a.py`:
```py
"""Test"""
```

And, the VS Code settings:
```jsonc
{
  "ruff.nativeServer": "on",
  "ruff.path": ["/Users/dhruv/work/astral/ruff/target/debug/ruff"],
  // For single-file mode where current working directory is `/`
  // "ruff.configuration": "/tmp/ruff-repro/.config/ruff.toml",
  // When a workspace is opened containing this path
  "ruff.configuration": "./.config/ruff.toml",
  "ruff.trace.server": "messages",
  "ruff.logLevel": "trace"
}
```

I also tested out just opening the file in single-file mode where the current working directory is `/` in VS Code. Here, the `ruff.configuration` needs to be updated to use absolute path as shown in the above VS Code settings.