### PR TITLE
[red-knot] Mark LoggingGuard as `must_use`

### DIFF
--- a/crates/ruff_db/src/testing.rs
+++ b/crates/ruff_db/src/testing.rs
@@ -213,6 +213,7 @@ impl Default for LoggingBuilder {
     }
 }
 
+#[must_use = "Dropping the guard unregisters the tracing subscriber."]
 pub struct LoggingGuard {
     _guard: tracing::subscriber::DefaultGuard,
 }


### PR DESCRIPTION
## Summary

Prevents developers like me from trying to use
```rs
ruff_db::testing::setup_logging();
```
without capturing the returned guard in a variable:
```
warning: unused `LoggingGuard` that must be used
  --> crates/red_knot_workspace/tests/check.rs:24:5
   |
24 |     ruff_db::testing::setup_logging();
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: Dropping the guard unregisters the tracing subscriber.
   = note: `#[warn(unused_must_use)]` on by default
```

I'm not sure why the inner `tracing::subscriber::DefaultGuard` is not marked as `must_use` in `tracing`, but they do mark the return value of `tracing::subscriber::set_default` as `must_use`:

https://github.com/tokio-rs/tracing/blob/15600a3a67c418f53cb80ff21da57d89a5de0486/tracing/src/subscriber.rs#L57

That doesn't trigger anymore because we store the result in `LoggingBuilder::build()` here:

https://github.com/astral-sh/ruff/blob/1f82731856eb0f199c8b11f8e06c32020a6a9738/crates/ruff_db/src/testing.rs#L182-L206

An alternative might be to mark both `setup_logging` and `setup_logging_with_filter` as `must_use`.

## Test Plan

Run `cargo test` with the code above and observe the compiler warning.