### PR TITLE
[red-knot] PEP 695 type aliases

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/type_alias.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/type_alias.md
@@ -7,7 +7,6 @@ type IntOrStr = int | str
 
 reveal_type(IntOrStr)  # revealed: typing.TypeAliasType
 reveal_type(IntOrStr.__name__)  # revealed: Literal["IntOrStr"]
-reveal_type(IntOrStr.__value__)  # revealed: int | str
 
 x: IntOrStr = 1
 
@@ -15,6 +14,17 @@ reveal_type(x)  # revealed: Literal[1]
 
 def f() -> None:
     reveal_type(x)  # revealed: int | str
+```
+
+## `__value__` attribute
+
+```py
+type IntOrStr = int | str
+
+# TODO: This should either fall back to the specified type from typeshed,
+# which is `Any`, or be the actual type of the runtime value expression
+# `int | str`, i.e. `types.UnionType`.
+reveal_type(IntOrStr.__value__)  # revealed: @Todo(instance attributes)
 ```
 
 ## Invalid assignment
@@ -32,17 +42,17 @@ x: OptionalInt = "1"
 type IntOrStr = int | str
 type IntOrStrOrBytes = IntOrStr | bytes
 
-reveal_type(IntOrStrOrBytes.__value__)  # revealed: int | str | bytes
+x: IntOrStrOrBytes = 1
+
+def f() -> None:
+    reveal_type(x)  # revealed: int | str | bytes
 ```
 
 ## Aliased type aliases
 
 ```py
 type IntOrStr = int | str
-
 MyIntOrStr = IntOrStr
-
-reveal_type(MyIntOrStr.__value__)  # revealed: int | str
 
 x: MyIntOrStr = 1
 
@@ -55,6 +65,7 @@ y: MyIntOrStr = None
 ```py
 type ListOrSet[T] = list[T] | set[T]
 
-# TODO: Should be tuple[typing.TypeVar | typing.ParamSpec | typing.TypeVarTuple, ...]
-reveal_type(ListOrSet.__type_params__)  # revealed: @Todo(TypeAliasType __type_params__)
+# TODO: Should be `tuple[typing.TypeVar | typing.ParamSpec | typing.TypeVarTuple, ...]`,
+# as specified in the `typeshed` stubs.
+reveal_type(ListOrSet.__type_params__)  # revealed: @Todo(instance attributes)
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/type_alias.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/type_alias.md
@@ -26,6 +26,30 @@ type OptionalInt = int | None
 x: OptionalInt = "1"
 ```
 
+## Type aliases in type aliases
+
+```py
+type IntOrStr = int | str
+type IntOrStrOrBytes = IntOrStr | bytes
+
+reveal_type(IntOrStrOrBytes.__value__)  # revealed: int | str | bytes
+```
+
+## Aliased type aliases
+
+```py
+type IntOrStr = int | str
+
+MyIntOrStr = IntOrStr
+
+reveal_type(MyIntOrStr.__value__)  # revealed: int | str
+
+x: MyIntOrStr = 1
+
+# error: [invalid-assignment]
+y: MyIntOrStr = None
+```
+
 ## Generic type aliases
 
 ```py

--- a/crates/red_knot_python_semantic/resources/mdtest/type_alias.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/type_alias.md
@@ -3,15 +3,16 @@
 ## Basic
 
 ```py
-type MyInt = int
+type IntOrStr = int | str
 
-# TODO: should be typing.TypeAliasType
-reveal_type(MyInt)  # revealed: MyInt
+reveal_type(IntOrStr)  # revealed: typing.TypeAliasType
+reveal_type(IntOrStr.__name__)  # revealed: Literal["IntOrStr"]
+reveal_type(IntOrStr.__value__)  # revealed: int | str
 
-x: MyInt = 1
+x: IntOrStr = 1
 
 reveal_type(x)  # revealed: Literal[1]
 
 def f() -> None:
-    reveal_type(x)  # revealed: int
+    reveal_type(x)  # revealed: int | str
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/type_alias.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/type_alias.md
@@ -16,3 +16,21 @@ reveal_type(x)  # revealed: Literal[1]
 def f() -> None:
     reveal_type(x)  # revealed: int | str
 ```
+
+## Invalid assignment
+
+```py
+type OptionalInt = int | None
+
+# error: [invalid-assignment]
+x: OptionalInt = "1"
+```
+
+## Generic type aliases
+
+```py
+type ListOrSet[T] = list[T] | set[T]
+
+# TODO: Should be tuple[typing.TypeVar | typing.ParamSpec | typing.TypeVarTuple, ...]
+reveal_type(ListOrSet.__type_params__)  # revealed: @Todo(TypeAliasType __type_params__)
+```

--- a/crates/red_knot_python_semantic/resources/mdtest/type_alias.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/type_alias.md
@@ -1,0 +1,17 @@
+# Type aliases
+
+## Basic
+
+```py
+type MyInt = int
+
+# TODO: should be typing.TypeAliasType
+reveal_type(MyInt)  # revealed: MyInt
+
+x: MyInt = 1
+
+reveal_type(x)  # revealed: Literal[1]
+
+def f() -> None:
+    reveal_type(x)  # revealed: int
+```

--- a/crates/red_knot_python_semantic/src/semantic_index/builder.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/builder.rs
@@ -131,7 +131,8 @@ impl<'db> SemanticIndexBuilder<'db> {
         let scope_id = ScopeId::new(self.db, self.file, file_scope_id, countme::Count::default());
 
         self.scope_ids_by_scope.push(scope_id);
-        self.scopes_by_node.insert(node.node_key(), file_scope_id);
+        let previous = self.scopes_by_node.insert(node.node_key(), file_scope_id);
+        debug_assert_eq!(previous, None);
 
         debug_assert_eq!(ast_id_scope, file_scope_id);
 

--- a/crates/red_knot_python_semantic/src/semantic_index/builder.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/builder.rs
@@ -595,9 +595,8 @@ where
                     type_alias
                         .name
                         .as_name_expr()
-                        .expect("type alias name is a name expr") // TODO: does the parser guarantee this?
-                        .id
-                        .clone(),
+                        .map(|name| name.id.clone())
+                        .unwrap_or("<unknown>".into()),
                 );
                 self.add_definition(symbol, type_alias);
                 self.visit_expr(&type_alias.name);

--- a/crates/red_knot_python_semantic/src/semantic_index/builder.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/builder.rs
@@ -589,6 +589,28 @@ where
                     },
                 );
             }
+            ast::Stmt::TypeAlias(type_alias) => {
+                let symbol = self.add_symbol(
+                    type_alias
+                        .name
+                        .as_name_expr()
+                        .expect("type alias name is a name expr") // TODO: does the parser guarantee this?
+                        .id
+                        .clone(),
+                );
+                self.add_definition(symbol, type_alias);
+                self.visit_expr(&type_alias.name);
+
+                self.with_type_params(
+                    NodeWithScopeRef::TypeAliasTypeParameters(type_alias),
+                    type_alias.type_params.as_ref(),
+                    |builder| {
+                        builder.push_scope(NodeWithScopeRef::TypeAlias(type_alias));
+                        builder.visit_expr(&type_alias.value);
+                        builder.pop_scope()
+                    },
+                );
+            }
             ast::Stmt::Import(node) => {
                 for alias in &node.names {
                     let symbol_name = if let Some(asname) = &alias.asname {

--- a/crates/red_knot_python_semantic/src/semantic_index/definition.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/definition.rs
@@ -83,6 +83,7 @@ pub(crate) enum DefinitionNodeRef<'a> {
     For(ForStmtDefinitionNodeRef<'a>),
     Function(&'a ast::StmtFunctionDef),
     Class(&'a ast::StmtClassDef),
+    TypeAlias(&'a ast::StmtTypeAlias),
     NamedExpression(&'a ast::ExprNamed),
     Assignment(AssignmentDefinitionNodeRef<'a>),
     AnnotatedAssignment(&'a ast::StmtAnnAssign),
@@ -106,6 +107,12 @@ impl<'a> From<&'a ast::StmtFunctionDef> for DefinitionNodeRef<'a> {
 impl<'a> From<&'a ast::StmtClassDef> for DefinitionNodeRef<'a> {
     fn from(node: &'a ast::StmtClassDef) -> Self {
         Self::Class(node)
+    }
+}
+
+impl<'a> From<&'a ast::StmtTypeAlias> for DefinitionNodeRef<'a> {
+    fn from(node: &'a ast::StmtTypeAlias) -> Self {
+        Self::TypeAlias(node)
     }
 }
 
@@ -265,6 +272,9 @@ impl<'db> DefinitionNodeRef<'db> {
             DefinitionNodeRef::Class(class) => {
                 DefinitionKind::Class(AstNodeRef::new(parsed, class))
             }
+            DefinitionNodeRef::TypeAlias(type_alias) => {
+                DefinitionKind::TypeAlias(AstNodeRef::new(parsed, type_alias))
+            }
             DefinitionNodeRef::NamedExpression(named) => {
                 DefinitionKind::NamedExpression(AstNodeRef::new(parsed, named))
             }
@@ -358,6 +368,7 @@ impl<'db> DefinitionNodeRef<'db> {
             }
             Self::Function(node) => node.into(),
             Self::Class(node) => node.into(),
+            Self::TypeAlias(node) => node.into(),
             Self::NamedExpression(node) => node.into(),
             Self::Assignment(AssignmentDefinitionNodeRef {
                 value: _,
@@ -434,6 +445,7 @@ pub enum DefinitionKind<'db> {
     ImportFrom(ImportFromDefinitionKind),
     Function(AstNodeRef<ast::StmtFunctionDef>),
     Class(AstNodeRef<ast::StmtClassDef>),
+    TypeAlias(AstNodeRef<ast::StmtTypeAlias>),
     NamedExpression(AstNodeRef<ast::ExprNamed>),
     Assignment(AssignmentDefinitionKind<'db>),
     AnnotatedAssignment(AstNodeRef<ast::StmtAnnAssign>),
@@ -456,6 +468,7 @@ impl DefinitionKind<'_> {
             // functions, classes, and imports always bind, and we consider them declarations
             DefinitionKind::Function(_)
             | DefinitionKind::Class(_)
+            | DefinitionKind::TypeAlias(_)
             | DefinitionKind::Import(_)
             | DefinitionKind::ImportFrom(_)
             | DefinitionKind::TypeVar(_)
@@ -678,6 +691,12 @@ impl From<&ast::StmtFunctionDef> for DefinitionNodeKey {
 
 impl From<&ast::StmtClassDef> for DefinitionNodeKey {
     fn from(node: &ast::StmtClassDef) -> Self {
+        Self(NodeKey::from_node(node))
+    }
+}
+
+impl From<&ast::StmtTypeAlias> for DefinitionNodeKey {
+    fn from(node: &ast::StmtTypeAlias) -> Self {
         Self(NodeKey::from_node(node))
     }
 }

--- a/crates/red_knot_python_semantic/src/semantic_index/symbol.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/symbol.rs
@@ -405,7 +405,7 @@ impl NodeWithScopeRef<'_> {
                 NodeWithScopeKey::ClassTypeParameters(NodeKey::from_node(class))
             }
             NodeWithScopeRef::TypeAlias(type_alias) => {
-                NodeWithScopeKey::TypeAliasTypeParameters(NodeKey::from_node(type_alias))
+                NodeWithScopeKey::TypeAlias(NodeKey::from_node(type_alias))
             }
             NodeWithScopeRef::TypeAliasTypeParameters(type_alias) => {
                 NodeWithScopeKey::TypeAliasTypeParameters(NodeKey::from_node(type_alias))
@@ -490,6 +490,7 @@ pub(crate) enum NodeWithScopeKey {
     ClassTypeParameters(NodeKey),
     Function(NodeKey),
     FunctionTypeParameters(NodeKey),
+    TypeAlias(NodeKey),
     TypeAliasTypeParameters(NodeKey),
     Lambda(NodeKey),
     ListComprehension(NodeKey),

--- a/crates/red_knot_python_semantic/src/semantic_index/symbol.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/symbol.rs
@@ -443,12 +443,11 @@ impl NodeWithScopeKind {
         match self {
             Self::Module => ScopeKind::Module,
             Self::Class(_) => ScopeKind::Class,
-            Self::Function(_) => ScopeKind::Function,
-            Self::TypeAlias(_) => ScopeKind::TypeAlias,
-            Self::Lambda(_) => ScopeKind::Function,
+            Self::Function(_) | Self::Lambda(_) => ScopeKind::Function,
             Self::FunctionTypeParameters(_)
             | Self::ClassTypeParameters(_)
             | Self::TypeAliasTypeParameters(_) => ScopeKind::Annotation,
+            Self::TypeAlias(_) => ScopeKind::TypeAlias,
             Self::ListComprehension(_)
             | Self::SetComprehension(_)
             | Self::DictComprehension(_)

--- a/crates/red_knot_python_semantic/src/semantic_index/symbol.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/symbol.rs
@@ -116,16 +116,11 @@ impl<'db> ScopeId<'db> {
         // Type parameter scopes behave like function scopes in terms of name resolution; CPython
         // symbol table also uses the term "function-like" for these scopes.
         matches!(
-            self.node(db),
-            NodeWithScopeKind::ClassTypeParameters(_)
-                | NodeWithScopeKind::FunctionTypeParameters(_)
-                | NodeWithScopeKind::Function(_)
-                | NodeWithScopeKind::TypeAlias(_)
-                | NodeWithScopeKind::TypeAliasTypeParameters(_)
-                | NodeWithScopeKind::ListComprehension(_)
-                | NodeWithScopeKind::SetComprehension(_)
-                | NodeWithScopeKind::DictComprehension(_)
-                | NodeWithScopeKind::GeneratorExpression(_)
+            self.node(db).scope_kind(),
+            ScopeKind::Annotation
+                | ScopeKind::Function
+                | ScopeKind::TypeAlias
+                | ScopeKind::Comprehension
         )
     }
 

--- a/crates/red_knot_python_semantic/src/semantic_index/symbol.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/symbol.rs
@@ -121,6 +121,7 @@ impl<'db> ScopeId<'db> {
                 | NodeWithScopeKind::FunctionTypeParameters(_)
                 | NodeWithScopeKind::Function(_)
                 | NodeWithScopeKind::TypeAlias(_)
+                | NodeWithScopeKind::TypeAliasTypeParameters(_)
                 | NodeWithScopeKind::ListComprehension(_)
                 | NodeWithScopeKind::SetComprehension(_)
                 | NodeWithScopeKind::DictComprehension(_)

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -1969,10 +1969,6 @@ impl<'db> KnownInstanceType<'db> {
                 .map(|ty| ty.to_meta_type(db))
                 .unwrap_or_else(|| KnownClass::NoDefaultType.to_instance(db)),
             (Self::TypeAliasType(alias), "__name__") => Type::string_literal(db, alias.name(db)),
-            (Self::TypeAliasType(alias), "__value__") => alias.value_ty(db),
-            (Self::TypeAliasType(_), "__type_params__") => {
-                todo_type!("TypeAliasType __type_params__")
-            }
             _ => return self.instance_fallback(db).member(db, name),
         };
         ty.into()

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -412,7 +412,7 @@ pub enum Type<'db> {
     Instance(InstanceType<'db>),
     /// A single Python object that requires special treatment in the type system
     KnownInstance(KnownInstanceType<'db>),
-    /// A type alias, with a name and corresponding type
+    /// A PEP 695 type alias, with a name and corresponding type
     TypeAlias(TypeAliasType<'db>),
     /// The set of objects in any of the types in the union
     Union(UnionType<'db>),

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -2799,8 +2799,10 @@ pub struct TypeAliasType<'db> {
     rhs_scope: ScopeId<'db>,
 }
 
-impl TypeAliasType<'_> {
-    pub fn value_ty(self, db: &dyn Db) -> Type {
+#[salsa::tracked]
+impl<'db> TypeAliasType<'db> {
+    #[salsa::tracked]
+    pub fn value_ty(self, db: &'db dyn Db) -> Type<'db> {
         let scope = self.rhs_scope(db);
 
         let type_alias_stmt_node = scope.node(db).expect_type_alias();

--- a/crates/red_knot_python_semantic/src/types/display.rs
+++ b/crates/red_knot_python_semantic/src/types/display.rs
@@ -88,7 +88,6 @@ impl Display for DisplayRepresentation<'_> {
             }
             Type::KnownInstance(known_instance) => f.write_str(known_instance.repr(self.db)),
             Type::FunctionLiteral(function) => f.write_str(function.name(self.db)),
-            Type::TypeAlias(alias) => f.write_str(alias.name(self.db)),
             Type::Union(union) => union.display(self.db).fmt(f),
             Type::Intersection(intersection) => intersection.display(self.db).fmt(f),
             Type::IntLiteral(n) => n.fmt(f),

--- a/crates/red_knot_python_semantic/src/types/display.rs
+++ b/crates/red_knot_python_semantic/src/types/display.rs
@@ -88,6 +88,7 @@ impl Display for DisplayRepresentation<'_> {
             }
             Type::KnownInstance(known_instance) => f.write_str(known_instance.repr(self.db)),
             Type::FunctionLiteral(function) => f.write_str(function.name(self.db)),
+            Type::TypeAlias(alias) => f.write_str(alias.name(self.db)),
             Type::Union(union) => union.display(self.db).fmt(f),
             Type::Intersection(intersection) => intersection.display(self.db).fmt(f),
             Type::IntLiteral(n) => n.fmt(f),

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -1142,11 +1142,12 @@ impl<'db> TypeInferenceBuilder<'db> {
             .node_scope(NodeWithScopeRef::TypeAlias(type_alias))
             .to_scope_id(self.db, self.file);
 
-        let type_alias_ty = Type::TypeAlias(TypeAliasType::new(
-            self.db,
-            &type_alias.name.as_name_expr().unwrap().id,
-            rhs_scope,
-        ));
+        let type_alias_ty =
+            Type::KnownInstance(KnownInstanceType::TypeAliasType(TypeAliasType::new(
+                self.db,
+                &type_alias.name.as_name_expr().unwrap().id,
+                rhs_scope,
+            )));
 
         self.add_declaration_with_binding(
             type_alias.into(),
@@ -4618,6 +4619,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                 _ => self.infer_type_expression(parameters),
             },
             KnownInstanceType::TypeVar(_) => todo_type!(),
+            KnownInstanceType::TypeAliasType(_) => todo_type!("generic type alias"),
         }
     }
 

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -867,7 +867,6 @@ impl<'db> TypeInferenceBuilder<'db> {
     }
 
     fn infer_type_alias(&mut self, type_alias: &ast::StmtTypeAlias) {
-        // TODO: what should the deferred state be here?
         self.infer_annotation_expression(&type_alias.value, DeferredExpressionState::Deferred);
     }
 

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -4618,8 +4618,14 @@ impl<'db> TypeInferenceBuilder<'db> {
                 }
                 _ => self.infer_type_expression(parameters),
             },
-            KnownInstanceType::TypeVar(_) => todo_type!(),
-            KnownInstanceType::TypeAliasType(_) => todo_type!("generic type alias"),
+            KnownInstanceType::TypeVar(_) => {
+                self.infer_type_expression(parameters);
+                todo_type!()
+            }
+            KnownInstanceType::TypeAliasType(_) => {
+                self.infer_type_expression(parameters);
+                todo_type!("generic type alias")
+            }
         }
     }
 

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -56,8 +56,8 @@ use crate::types::{
     typing_extensions_symbol, Boundness, Class, ClassLiteralType, FunctionType, InstanceType,
     IntersectionBuilder, IntersectionType, IterationOutcome, KnownClass, KnownFunction,
     KnownInstanceType, MetaclassCandidate, MetaclassErrorKind, SliceLiteralType, Symbol,
-    Truthiness, TupleType, Type, TypeArrayDisplay, TypeVarBoundOrConstraints, TypeVarInstance,
-    UnionBuilder, UnionType,
+    Truthiness, TupleType, Type, TypeAliasType, TypeArrayDisplay, TypeVarBoundOrConstraints,
+    TypeVarInstance, UnionBuilder, UnionType,
 };
 use crate::unpack::Unpack;
 use crate::util::subscript::{PyIndex, PySlice};
@@ -439,6 +439,12 @@ impl<'db> TypeInferenceBuilder<'db> {
             NodeWithScopeKind::FunctionTypeParameters(function) => {
                 self.infer_function_type_params(function.node());
             }
+            NodeWithScopeKind::TypeAliasTypeParameters(type_alias) => {
+                self.infer_type_alias_type_params(type_alias.node());
+            }
+            NodeWithScopeKind::TypeAlias(type_alias) => {
+                self.infer_type_alias(type_alias.node());
+            }
             NodeWithScopeKind::ListComprehension(comprehension) => {
                 self.infer_list_comprehension_expression_scope(comprehension.node());
             }
@@ -606,6 +612,9 @@ impl<'db> TypeInferenceBuilder<'db> {
                 self.infer_function_definition(function.node(), definition);
             }
             DefinitionKind::Class(class) => self.infer_class_definition(class.node(), definition),
+            DefinitionKind::TypeAlias(type_alias) => {
+                self.infer_type_alias_definition(type_alias.node(), definition);
+            }
             DefinitionKind::Import(import) => {
                 self.infer_import_definition(import.node(), definition);
             }
@@ -846,6 +855,20 @@ impl<'db> TypeInferenceBuilder<'db> {
         );
         self.infer_type_parameters(type_params);
         self.infer_parameters(&function.parameters);
+    }
+
+    fn infer_type_alias_type_params(&mut self, type_alias: &ast::StmtTypeAlias) {
+        let type_params = type_alias
+            .type_params
+            .as_ref()
+            .expect("type alias type params scope without type params");
+
+        self.infer_type_parameters(type_params);
+    }
+
+    fn infer_type_alias(&mut self, type_alias: &ast::StmtTypeAlias) {
+        // TODO: what should the deferred state be here?
+        self.infer_annotation_expression(&type_alias.value, DeferredExpressionState::Deferred);
     }
 
     fn infer_function_body(&mut self, function: &ast::StmtFunctionDef) {
@@ -1106,6 +1129,32 @@ impl<'db> TypeInferenceBuilder<'db> {
         for base in class.bases() {
             self.infer_expression(base);
         }
+    }
+
+    fn infer_type_alias_definition(
+        &mut self,
+        type_alias: &ast::StmtTypeAlias,
+        definition: Definition<'db>,
+    ) {
+        self.infer_expression(&type_alias.name);
+
+        let rhs_scope = self
+            .index
+            .node_scope(NodeWithScopeRef::TypeAlias(type_alias))
+            .to_scope_id(self.db, self.file);
+
+        let type_alias_ty = Type::TypeAlias(TypeAliasType::new(
+            self.db,
+            &type_alias.name.as_name_expr().unwrap().id,
+            rhs_scope,
+        ));
+
+        self.add_declaration_with_binding(
+            type_alias.into(),
+            definition,
+            type_alias_ty,
+            type_alias_ty,
+        );
     }
 
     fn infer_if_statement(&mut self, if_statement: &ast::StmtIf) {
@@ -1830,17 +1879,8 @@ impl<'db> TypeInferenceBuilder<'db> {
         self.infer_augmented_op(assignment, target_type, value_type)
     }
 
-    fn infer_type_alias_statement(&mut self, type_alias_statement: &ast::StmtTypeAlias) {
-        let ast::StmtTypeAlias {
-            range: _,
-            name,
-            type_params: _,
-            value,
-        } = type_alias_statement;
-        self.infer_expression(value);
-        self.infer_expression(name);
-
-        // TODO: properly handle generic type aliases, which need their own annotation scope
+    fn infer_type_alias_statement(&mut self, node: &ast::StmtTypeAlias) {
+        self.infer_definition(node);
     }
 
     fn infer_for_statement(&mut self, for_statement: &ast::StmtFor) {

--- a/crates/red_knot_python_semantic/src/types/mro.rs
+++ b/crates/red_knot_python_semantic/src/types/mro.rs
@@ -77,7 +77,7 @@ impl<'db> Mro<'db> {
             // but it's a common case (i.e., worth optimizing for),
             // and the `c3_merge` function requires lots of allocations.
             [single_base] => {
-                let single_base = ClassBase::try_from_ty(db, *single_base).ok_or(*single_base);
+                let single_base = ClassBase::try_from_ty(*single_base).ok_or(*single_base);
                 single_base.map_or_else(
                     |invalid_base_ty| {
                         let bases_info = Box::from([(0, invalid_base_ty)]);
@@ -102,7 +102,7 @@ impl<'db> Mro<'db> {
                 let mut invalid_bases = vec![];
 
                 for (i, base) in multiple_bases.iter().enumerate() {
-                    match ClassBase::try_from_ty(db, *base).ok_or(*base) {
+                    match ClassBase::try_from_ty(*base).ok_or(*base) {
                         Ok(valid_base) => valid_bases.push(valid_base),
                         Err(invalid_base) => invalid_bases.push((i, invalid_base)),
                     }
@@ -350,9 +350,8 @@ impl<'db> ClassBase<'db> {
     /// Attempt to resolve `ty` into a `ClassBase`.
     ///
     /// Return `None` if `ty` is not an acceptable type for a class base.
-    fn try_from_ty(db: &'db dyn Db, ty: Type<'db>) -> Option<Self> {
+    fn try_from_ty(ty: Type<'db>) -> Option<Self> {
         match ty {
-            Type::TypeAlias(alias) => Self::try_from_ty(db, alias.value_ty(db)),
             Type::Any => Some(Self::Any),
             Type::Unknown => Some(Self::Unknown),
             Type::Todo(_) => Some(Self::Todo),
@@ -373,6 +372,7 @@ impl<'db> ClassBase<'db> {
             | Type::SubclassOf(_) => None,
             Type::KnownInstance(known_instance) => match known_instance {
                 KnownInstanceType::TypeVar(_)
+                | KnownInstanceType::TypeAliasType(_)
                 | KnownInstanceType::Literal
                 | KnownInstanceType::Union
                 | KnownInstanceType::Optional => None,

--- a/crates/red_knot_python_semantic/src/types/mro.rs
+++ b/crates/red_knot_python_semantic/src/types/mro.rs
@@ -77,7 +77,7 @@ impl<'db> Mro<'db> {
             // but it's a common case (i.e., worth optimizing for),
             // and the `c3_merge` function requires lots of allocations.
             [single_base] => {
-                let single_base = ClassBase::try_from_ty(*single_base).ok_or(*single_base);
+                let single_base = ClassBase::try_from_ty(db, *single_base).ok_or(*single_base);
                 single_base.map_or_else(
                     |invalid_base_ty| {
                         let bases_info = Box::from([(0, invalid_base_ty)]);
@@ -102,7 +102,7 @@ impl<'db> Mro<'db> {
                 let mut invalid_bases = vec![];
 
                 for (i, base) in multiple_bases.iter().enumerate() {
-                    match ClassBase::try_from_ty(*base).ok_or(*base) {
+                    match ClassBase::try_from_ty(db, *base).ok_or(*base) {
                         Ok(valid_base) => valid_bases.push(valid_base),
                         Err(invalid_base) => invalid_bases.push((i, invalid_base)),
                     }
@@ -350,8 +350,9 @@ impl<'db> ClassBase<'db> {
     /// Attempt to resolve `ty` into a `ClassBase`.
     ///
     /// Return `None` if `ty` is not an acceptable type for a class base.
-    fn try_from_ty(ty: Type<'db>) -> Option<Self> {
+    fn try_from_ty(db: &'db dyn Db, ty: Type<'db>) -> Option<Self> {
         match ty {
+            Type::TypeAlias(alias) => Self::try_from_ty(db, alias.value(db)),
             Type::Any => Some(Self::Any),
             Type::Unknown => Some(Self::Unknown),
             Type::Todo(_) => Some(Self::Todo),

--- a/crates/red_knot_python_semantic/src/types/mro.rs
+++ b/crates/red_knot_python_semantic/src/types/mro.rs
@@ -352,7 +352,7 @@ impl<'db> ClassBase<'db> {
     /// Return `None` if `ty` is not an acceptable type for a class base.
     fn try_from_ty(db: &'db dyn Db, ty: Type<'db>) -> Option<Self> {
         match ty {
-            Type::TypeAlias(alias) => Self::try_from_ty(db, alias.value(db)),
+            Type::TypeAlias(alias) => Self::try_from_ty(db, alias.value_ty(db)),
             Type::Any => Some(Self::Any),
             Type::Unknown => Some(Self::Unknown),
             Type::Todo(_) => Some(Self::Todo),

--- a/crates/red_knot_workspace/resources/test/corpus/89_type_alias_invalid_bound.py
+++ b/crates/red_knot_workspace/resources/test/corpus/89_type_alias_invalid_bound.py
@@ -1,0 +1,1 @@
+../../../../ruff_python_parser/resources/inline/err/type_param_invalid_bound_expr.py

--- a/crates/red_knot_workspace/tests/check.rs
+++ b/crates/red_knot_workspace/tests/check.rs
@@ -264,26 +264,17 @@ impl SourceOrderVisitor<'_> for PullTypesVisitor<'_> {
 }
 
 /// Whether or not the .py/.pyi version of this file is expected to fail
+#[rustfmt::skip]
 const KNOWN_FAILURES: &[(&str, bool, bool)] = &[
-    // Probably related to missing support for type aliases / type params:
-    ("crates/ruff_python_parser/resources/inline/err/type_param_invalid_bound_expr.py", true, true),
-    ("crates/ruff_python_parser/resources/inline/err/type_param_param_spec_invalid_default_expr.py", true, true),
-    ("crates/ruff_python_parser/resources/inline/err/type_param_type_var_invalid_default_expr.py", true, true),
-    ("crates/ruff_python_parser/resources/inline/err/type_param_type_var_missing_default.py", true, true),
-    ("crates/ruff_python_parser/resources/inline/err/type_param_type_var_tuple_invalid_default_expr.py", true, true),
-    ("crates/ruff_python_parser/resources/inline/ok/type_param_param_spec.py", true, true),
-    ("crates/ruff_python_parser/resources/inline/ok/type_param_type_var_tuple.py", true, true),
-    ("crates/ruff_python_parser/resources/inline/ok/type_param_type_var.py", true, true),
-    ("crates/ruff_python_parser/resources/valid/statement/type.py", true, true),
-    ("crates/ruff_linter/resources/test/fixtures/flake8_type_checking/TCH004_15.py", true, true),
-    ("crates/ruff_linter/resources/test/fixtures/pyflakes/F401_19.py", true, true),
-    ("crates/ruff_linter/resources/test/fixtures/pyflakes/F821_14.py", false, true),
-    ("crates/ruff_linter/resources/test/fixtures/pyflakes/F821_15.py", true, true),
-    ("crates/ruff_linter/resources/test/fixtures/pyflakes/F821_17.py", true, true),
-    ("crates/ruff_linter/resources/test/fixtures/pyflakes/F821_20.py", true, true),
+    // Related to recursive class definition?
     ("crates/ruff_linter/resources/test/fixtures/pyflakes/F821_26.py", true, false),
-    // Fails for unknown reasons:
+    // fails with salsa cycle panic:
+    ("crates/ruff_python_parser/resources/inline/err/type_alias_invalid_value_expr.py", true, true),
+    // related to string annotations (https://github.com/astral-sh/ruff/issues/14440)
+    ("crates/ruff_linter/resources/test/fixtures/pyflakes/F821_15.py", true, true),
+    ("crates/ruff_linter/resources/test/fixtures/pyflakes/F821_14.py", false, true),
     ("crates/ruff_linter/resources/test/fixtures/pyflakes/F632.py", true, true),
+    // Fails for unknown reasons:
     ("crates/ruff_linter/resources/test/fixtures/pyflakes/F811_19.py", true, false),
     ("crates/ruff_linter/resources/test/fixtures/pyupgrade/UP039.py", true, false),
 ];

--- a/crates/red_knot_workspace/tests/check.rs
+++ b/crates/red_knot_workspace/tests/check.rs
@@ -268,7 +268,7 @@ impl SourceOrderVisitor<'_> for PullTypesVisitor<'_> {
 const KNOWN_FAILURES: &[(&str, bool, bool)] = &[
     // Related to recursive class definition?
     ("crates/ruff_linter/resources/test/fixtures/pyflakes/F821_26.py", true, false),
-    // fails with salsa cycle panic:
+    // fails with salsa cycle panic for something like `type x = x`:
     ("crates/ruff_python_parser/resources/inline/err/type_alias_invalid_value_expr.py", true, true),
     // related to string annotations (https://github.com/astral-sh/ruff/issues/14440)
     ("crates/ruff_linter/resources/test/fixtures/pyflakes/F821_15.py", true, true),

--- a/crates/red_knot_workspace/tests/check.rs
+++ b/crates/red_knot_workspace/tests/check.rs
@@ -266,15 +266,14 @@ impl SourceOrderVisitor<'_> for PullTypesVisitor<'_> {
 /// Whether or not the .py/.pyi version of this file is expected to fail
 #[rustfmt::skip]
 const KNOWN_FAILURES: &[(&str, bool, bool)] = &[
-    // Related to recursive class definition?
+    // related to circular references in class definitions
     ("crates/ruff_linter/resources/test/fixtures/pyflakes/F821_26.py", true, false),
-    // fails with salsa cycle panic for something like `type x = x`:
+    ("crates/ruff_linter/resources/test/fixtures/pyflakes/F811_19.py", true, false),
+    ("crates/ruff_linter/resources/test/fixtures/pyupgrade/UP039.py", true, false),
+    // related to circular references in type aliases (salsa cycle panic):
     ("crates/ruff_python_parser/resources/inline/err/type_alias_invalid_value_expr.py", true, true),
     // related to string annotations (https://github.com/astral-sh/ruff/issues/14440)
     ("crates/ruff_linter/resources/test/fixtures/pyflakes/F821_15.py", true, true),
     ("crates/ruff_linter/resources/test/fixtures/pyflakes/F821_14.py", false, true),
     ("crates/ruff_linter/resources/test/fixtures/pyflakes/F632.py", true, true),
-    // Fails for unknown reasons:
-    ("crates/ruff_linter/resources/test/fixtures/pyflakes/F811_19.py", true, false),
-    ("crates/ruff_linter/resources/test/fixtures/pyupgrade/UP039.py", true, false),
 ];


### PR DESCRIPTION
## Summary

Add support for (non-generic) type aliases. The main motivation behind this was to get rid of panics involving expressions in (generic) type aliases. But it turned out the best way to fix it was to implement (partial) support for type aliases.

```py
type IntOrStr = int | str

reveal_type(IntOrStr)  # revealed: typing.TypeAliasType
reveal_type(IntOrStr.__name__)  # revealed: Literal["IntOrStr"]

x: IntOrStr = 1

reveal_type(x)  # revealed: Literal[1]

def f() -> None:
    reveal_type(x)  # revealed: int | str
```

## Test Plan

- Updated corpus test allow list to reflect that we don't panic anymore.
- Added Markdown-based test for type aliases (`type_alias.md`)