### PR TITLE
[red-knot] Derive more `Default` methods

### DIFF
--- a/crates/red_knot_python_semantic/src/semantic_index/ast_ids.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/ast_ids.rs
@@ -155,20 +155,13 @@ impl HasScopedAstId for ast::ExpressionRef<'_> {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub(super) struct AstIdsBuilder {
     expressions_map: FxHashMap<ExpressionNodeKey, ScopedExpressionId>,
     uses_map: FxHashMap<ExpressionNodeKey, ScopedUseId>,
 }
 
 impl AstIdsBuilder {
-    pub(super) fn new() -> Self {
-        Self {
-            expressions_map: FxHashMap::default(),
-            uses_map: FxHashMap::default(),
-        }
-    }
-
     /// Adds `expr` to the expression ids map and returns its id.
     pub(super) fn record_expression(&mut self, expr: &ast::Expr) -> ScopedExpressionId {
         let expression_id = self.expressions_map.len().into();

--- a/crates/red_knot_python_semantic/src/semantic_index/builder.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/builder.rs
@@ -124,9 +124,9 @@ impl<'db> SemanticIndexBuilder<'db> {
         self.try_node_context_stack_manager.enter_nested_scope();
 
         let file_scope_id = self.scopes.push(scope);
-        self.symbol_tables.push(SymbolTableBuilder::new());
-        self.use_def_maps.push(UseDefMapBuilder::new());
-        let ast_id_scope = self.ast_ids.push(AstIdsBuilder::new());
+        self.symbol_tables.push(SymbolTableBuilder::default());
+        self.use_def_maps.push(UseDefMapBuilder::default());
+        let ast_id_scope = self.ast_ids.push(AstIdsBuilder::default());
 
         let scope_id = ScopeId::new(self.db, self.file, file_scope_id, countme::Count::default());
 

--- a/crates/red_knot_python_semantic/src/semantic_index/symbol.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/symbol.rs
@@ -210,7 +210,7 @@ impl ScopeKind {
 }
 
 /// Symbol table for a specific [`Scope`].
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct SymbolTable {
     /// The symbols in this scope.
     symbols: IndexVec<ScopedSymbolId, Symbol>,
@@ -220,13 +220,6 @@ pub struct SymbolTable {
 }
 
 impl SymbolTable {
-    fn new() -> Self {
-        Self {
-            symbols: IndexVec::new(),
-            symbols_by_name: SymbolMap::default(),
-        }
-    }
-
     fn shrink_to_fit(&mut self) {
         self.symbols.shrink_to_fit();
     }
@@ -278,18 +271,12 @@ impl PartialEq for SymbolTable {
 
 impl Eq for SymbolTable {}
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub(super) struct SymbolTableBuilder {
     table: SymbolTable,
 }
 
 impl SymbolTableBuilder {
-    pub(super) fn new() -> Self {
-        Self {
-            table: SymbolTable::new(),
-        }
-    }
-
     pub(super) fn add_symbol(&mut self, name: Name) -> (ScopedSymbolId, bool) {
         let hash = SymbolTable::hash_name(&name);
         let entry = self

--- a/crates/red_knot_python_semantic/src/semantic_index/use_def.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/use_def.rs
@@ -459,10 +459,6 @@ pub(super) struct UseDefMapBuilder<'db> {
 }
 
 impl<'db> UseDefMapBuilder<'db> {
-    pub(super) fn new() -> Self {
-        Self::default()
-    }
-
     pub(super) fn add_symbol(&mut self, symbol: ScopedSymbolId) {
         let new_symbol = self.symbol_states.push(SymbolState::undefined());
         debug_assert_eq!(symbol, new_symbol);

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -47,7 +47,7 @@ pub fn check_types(db: &dyn Db, file: File) -> TypeCheckDiagnostics {
     tracing::debug!("Checking file '{path}'", path = file.path(db));
 
     let index = semantic_index(db, file);
-    let mut diagnostics = TypeCheckDiagnostics::new();
+    let mut diagnostics = TypeCheckDiagnostics::default();
 
     for scope_id in index.scope_ids() {
         let result = infer_scope_types(db, scope_id);

--- a/crates/red_knot_python_semantic/src/types/builder.rs
+++ b/crates/red_knot_python_semantic/src/types/builder.rs
@@ -128,7 +128,7 @@ impl<'db> IntersectionBuilder<'db> {
     pub(crate) fn new(db: &'db dyn Db) -> Self {
         Self {
             db,
-            intersections: vec![InnerIntersectionBuilder::new()],
+            intersections: vec![InnerIntersectionBuilder::default()],
         }
     }
 
@@ -231,10 +231,6 @@ struct InnerIntersectionBuilder<'db> {
 }
 
 impl<'db> InnerIntersectionBuilder<'db> {
-    fn new() -> Self {
-        Self::default()
-    }
-
     /// Adds a positive type to this intersection.
     fn add_positive(&mut self, db: &'db dyn Db, new_positive: Type<'db>) {
         if let Type::Intersection(other) = new_positive {
@@ -253,7 +249,7 @@ impl<'db> InnerIntersectionBuilder<'db> {
                         .iter()
                         .find(|element| element.is_boolean_literal())
                     {
-                        *self = Self::new();
+                        *self = Self::default();
                         self.positive.insert(Type::BooleanLiteral(!value));
                         return;
                     }
@@ -272,7 +268,7 @@ impl<'db> InnerIntersectionBuilder<'db> {
                 }
                 // A & B = Never    if A and B are disjoint
                 if new_positive.is_disjoint_from(db, *existing_positive) {
-                    *self = Self::new();
+                    *self = Self::default();
                     self.positive.insert(Type::Never);
                     return;
                 }
@@ -285,7 +281,7 @@ impl<'db> InnerIntersectionBuilder<'db> {
             for (index, existing_negative) in self.negative.iter().enumerate() {
                 // S & ~T = Never    if S <: T
                 if new_positive.is_subtype_of(db, *existing_negative) {
-                    *self = Self::new();
+                    *self = Self::default();
                     self.positive.insert(Type::Never);
                     return;
                 }
@@ -326,7 +322,7 @@ impl<'db> InnerIntersectionBuilder<'db> {
                     .iter()
                     .any(|pos| *pos == KnownClass::Bool.to_instance(db)) =>
             {
-                *self = Self::new();
+                *self = Self::default();
                 self.positive.insert(Type::BooleanLiteral(!bool));
             }
             _ => {
@@ -348,7 +344,7 @@ impl<'db> InnerIntersectionBuilder<'db> {
                 for existing_positive in &self.positive {
                     // S & ~T = Never    if S <: T
                     if existing_positive.is_subtype_of(db, new_negative) {
-                        *self = Self::new();
+                        *self = Self::default();
                         self.positive.insert(Type::Never);
                         return;
                     }

--- a/crates/red_knot_python_semantic/src/types/diagnostic.rs
+++ b/crates/red_knot_python_semantic/src/types/diagnostic.rs
@@ -73,10 +73,6 @@ pub struct TypeCheckDiagnostics {
 }
 
 impl TypeCheckDiagnostics {
-    pub fn new() -> Self {
-        Self { inner: Vec::new() }
-    }
-
     pub(super) fn push(&mut self, diagnostic: TypeCheckDiagnostic) {
         self.inner.push(Arc::new(diagnostic));
     }
@@ -148,7 +144,7 @@ impl<'db> TypeCheckDiagnosticsBuilder<'db> {
         Self {
             db,
             file,
-            diagnostics: TypeCheckDiagnostics::new(),
+            diagnostics: TypeCheckDiagnostics::default(),
         }
     }
 

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -4755,6 +4755,7 @@ enum ModuleNameResolutionError {
 ///
 /// If the formatted string contains an expression (with a representation unknown at compile time),
 /// infers an instance of `builtins.str`.
+#[derive(Debug)]
 struct StringPartsCollector {
     concatenated: Option<String>,
     expression: bool,


### PR DESCRIPTION
Just a small cleanup. We have lots of handwritten `new()` methods that can just be derived if we use `Default` instead.