### PR TITLE
Remove the optional salsa dependency from the AST crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2778,7 +2778,6 @@ dependencies = [
  "ruff_source_file",
  "ruff_text_size",
  "rustc-hash 2.0.0",
- "salsa",
  "schemars",
  "serde",
 ]

--- a/crates/red_knot_python_semantic/Cargo.toml
+++ b/crates/red_knot_python_semantic/Cargo.toml
@@ -13,7 +13,7 @@ license = { workspace = true }
 [dependencies]
 ruff_db = { workspace = true }
 ruff_index = { workspace = true }
-ruff_python_ast = { workspace = true, features = ["salsa"] }
+ruff_python_ast = { workspace = true }
 ruff_python_parser = { workspace = true }
 ruff_python_stdlib = { workspace = true }
 ruff_source_file = { workspace = true }

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -954,7 +954,7 @@ impl<'db> TypeInferenceBuilder<'db> {
 
         let function_ty = Type::FunctionLiteral(FunctionType::new(
             self.db,
-            &*name.id,
+            &name.id,
             function_kind,
             body_scope,
             decorator_tys,
@@ -1069,7 +1069,7 @@ impl<'db> TypeInferenceBuilder<'db> {
 
         let maybe_known_class = KnownClass::try_from_file(self.db, self.file, name);
 
-        let class = Class::new(self.db, &*name.id, body_scope, maybe_known_class);
+        let class = Class::new(self.db, &name.id, body_scope, maybe_known_class);
         let class_ty = Type::class_literal(class);
 
         self.add_declaration_with_binding(class_node.into(), definition, class_ty, class_ty);

--- a/crates/ruff_python_ast/Cargo.toml
+++ b/crates/ruff_python_ast/Cargo.toml
@@ -26,7 +26,6 @@ is-macro = { workspace = true }
 itertools = { workspace = true }
 memchr = { workspace = true }
 rustc-hash = { workspace = true }
-salsa = { workspace = true, optional = true }
 schemars = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
 
@@ -39,7 +38,6 @@ serde = [
   "dep:ruff_cache",
   "compact_str/serde",
 ]
-salsa = ["dep:salsa"]
 
 [lints]
 workspace = true

--- a/crates/ruff_python_ast/src/name.rs
+++ b/crates/ruff_python_ast/src/name.rs
@@ -205,21 +205,6 @@ impl schemars::JsonSchema for Name {
     }
 }
 
-#[cfg(feature = "salsa")]
-impl salsa::plumbing::interned::Lookup<Name> for &str {
-    fn hash<H: Hasher>(&self, h: &mut H) {
-        std::hash::Hash::hash(self, h);
-    }
-
-    fn eq(&self, data: &Name) -> bool {
-        self == data
-    }
-
-    fn into_owned(self) -> Name {
-        Name::new(self)
-    }
-}
-
 /// A representation of a qualified name, like `typing.List`.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct QualifiedName<'a>(SegmentsVec<'a>);


### PR DESCRIPTION

## Summary

I added the `Lookup` implementation to `Name` to allow `Class` and `FunctionType` lookups with a `&str`.
What I didn't realize is that all lookups have a `&Name` reference. We never have a case where we just have a `&str`. 

That's why I'm removing the `Lookup` implementation because I prefer if `ruff-python-ast` doesn't depend on salsa, even if optionally.

## Test Plan

`cargo test`
