### PR TITLE
Fix file watcher panic when event has no paths

### DIFF
--- a/crates/red_knot_workspace/src/watch/watcher.rs
+++ b/crates/red_knot_workspace/src/watch/watcher.rs
@@ -210,7 +210,15 @@ impl Debouncer {
         }
 
         let kind = event.kind;
-        let path = match SystemPathBuf::from_path_buf(event.paths.into_iter().next().unwrap()) {
+
+        // There are cases where paths can be empty.
+        // https://github.com/astral-sh/ruff/issues/14222
+        let Some(path) = event.paths.into_iter().next() else {
+            tracing::debug!("Ignoring change event with kind '{kind:?}' without a path",);
+            return;
+        };
+
+        let path = match SystemPathBuf::from_path_buf(path) {
             Ok(path) => path,
             Err(path) => {
                 tracing::debug!(


### PR DESCRIPTION
## Summary

Fixes https://github.com/astral-sh/ruff/issues/14222

I don't know how to test this. There's also no documentation saying whether this is expected for any event other than a rescan, which is explicitly handled above.

Either way, we should not panic, so let's remove the unwrap.

## Test Plan

`cargo test`
