### PR TITLE
[`flake8-type-checking`] Fix helper function which surrounds annotations in quotes

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_type_checking/helpers.rs
+++ b/crates/ruff_linter/src/rules/flake8_type_checking/helpers.rs
@@ -392,6 +392,24 @@ impl<'a> SourceOrderVisitor<'a> for QuoteAnnotator<'a> {
                 }
                 self.state.pop();
             }
+            Expr::List(ast::ExprList { elts, .. }) => {
+                let Some((first, remaining)) = elts.split_first() else {
+                    return;
+                };
+                self.annotation.push_str("[");
+                self.visit_expr(first);
+                if let Some(last) = self.state.last_mut() {
+                    if *last == QuoteAnnotatorState::AnnotatedFirst {
+                        *last = QuoteAnnotatorState::AnnotatedRest;
+                    }
+                }
+                for expr in remaining {
+                    self.annotation.push_str(", ");
+                    self.visit_expr(expr);
+                }
+                self.annotation.push_str("]");
+                self.state.pop();
+            }
             Expr::BinOp(ast::ExprBinOp {
                 left, op, right, ..
             }) => {

--- a/crates/ruff_linter/src/rules/flake8_type_checking/helpers.rs
+++ b/crates/ruff_linter/src/rules/flake8_type_checking/helpers.rs
@@ -396,7 +396,7 @@ impl<'a> SourceOrderVisitor<'a> for QuoteAnnotator<'a> {
                 let Some((first, remaining)) = elts.split_first() else {
                     return;
                 };
-                self.annotation.push_str("[");
+                self.annotation.push('[');
                 self.visit_expr(first);
                 if let Some(last) = self.state.last_mut() {
                     if *last == QuoteAnnotatorState::AnnotatedFirst {
@@ -407,7 +407,7 @@ impl<'a> SourceOrderVisitor<'a> for QuoteAnnotator<'a> {
                     self.annotation.push_str(", ");
                     self.visit_expr(expr);
                 }
-                self.annotation.push_str("]");
+                self.annotation.push(']');
                 self.state.pop();
             }
             Expr::BinOp(ast::ExprBinOp {

--- a/crates/ruff_linter/src/rules/flake8_type_checking/snapshots/ruff_linter__rules__flake8_type_checking__tests__quote_typing-only-third-party-import_quote3.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_type_checking/snapshots/ruff_linter__rules__flake8_type_checking__tests__quote_typing-only-third-party-import_quote3.py.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_type_checking/mod.rs
-snapshot_kind: text
 ---
 quote3.py:4:44: TCH002 [*] Move third-party import `django.contrib.auth.models.AbstractBaseUser` into a type-checking block
   |
@@ -55,7 +54,7 @@ quote3.py:13:44: TCH002 [*] Move third-party import `django.contrib.auth.models.
 13    |-    from django.contrib.auth.models import AbstractBaseUser
 14 17 | 
 15    |-    def test_callable_literal_mixed_quotes(callable_fn: AbstractBaseUser[Callable[["int", Literal['admin', "user"]], 'bool']]):
-   18 |+    def test_callable_literal_mixed_quotes(callable_fn: 'AbstractBaseUser[Callable[[int, Literal[admin, user]], bool]]'):
+   18 |+    def test_callable_literal_mixed_quotes(callable_fn: 'AbstractBaseUser[Callable[[int, Literal["admin", "user"]], bool]]'):
 16 19 |         pass
 17 20 | 
 18 21 | 
@@ -86,7 +85,7 @@ quote3.py:22:44: TCH002 [*] Move third-party import `django.contrib.auth.models.
 22    |-    from django.contrib.auth.models import AbstractBaseUser
 23 26 | 
 24    |-    def test_callable_annotated_literal(callable_fn: AbstractBaseUser[Callable[[int, Annotated[str, Literal['active', "inactive"]]], bool]]):
-   27 |+    def test_callable_annotated_literal(callable_fn: 'AbstractBaseUser[Callable[[int, Annotated[str, Literal[active, inactive]]], bool]]'):
+   27 |+    def test_callable_annotated_literal(callable_fn: 'AbstractBaseUser[Callable[[int, Annotated[str, Literal["active", "inactive"]]], bool]]'):
 25 28 |         pass
 26 29 | 
 27 30 | 


### PR DESCRIPTION
This PR adds corrected handling of  list expressions to the `Visitor` implementation of `QuotedAnnotator` in `flake8_type_checking::helpers`.

Closes #14368
