### PR TITLE
[red-knot] Simplify some traits in `ast_ids.rs`

### DIFF
--- a/crates/red_knot_python_semantic/src/semantic_index/ast_ids.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/ast_ids.rs
@@ -76,23 +76,23 @@ impl HasScopedUseId for ast::ExpressionRef<'_> {
 #[newtype_index]
 pub struct ScopedExpressionId;
 
-pub trait HasScopedAstId {
+pub trait HasScopedExpressionId {
     /// Returns the ID that uniquely identifies the node in `scope`.
-    fn scoped_ast_id(&self, db: &dyn Db, scope: ScopeId) -> ScopedExpressionId;
+    fn scoped_expression_id(&self, db: &dyn Db, scope: ScopeId) -> ScopedExpressionId;
 }
 
-impl<T: HasScopedAstId> HasScopedAstId for Box<T> {
-    fn scoped_ast_id(&self, db: &dyn Db, scope: ScopeId) -> ScopedExpressionId {
-        self.as_ref().scoped_ast_id(db, scope)
+impl<T: HasScopedExpressionId> HasScopedExpressionId for Box<T> {
+    fn scoped_expression_id(&self, db: &dyn Db, scope: ScopeId) -> ScopedExpressionId {
+        self.as_ref().scoped_expression_id(db, scope)
     }
 }
 
 macro_rules! impl_has_scoped_expression_id {
     ($ty: ty) => {
-        impl HasScopedAstId for $ty {
-            fn scoped_ast_id(&self, db: &dyn Db, scope: ScopeId) -> ScopedExpressionId {
+        impl HasScopedExpressionId for $ty {
+            fn scoped_expression_id(&self, db: &dyn Db, scope: ScopeId) -> ScopedExpressionId {
                 let expression_ref = ExpressionRef::from(self);
-                expression_ref.scoped_ast_id(db, scope)
+                expression_ref.scoped_expression_id(db, scope)
             }
         }
     };
@@ -132,8 +132,8 @@ impl_has_scoped_expression_id!(ast::ExprSlice);
 impl_has_scoped_expression_id!(ast::ExprIpyEscapeCommand);
 impl_has_scoped_expression_id!(ast::Expr);
 
-impl HasScopedAstId for ast::ExpressionRef<'_> {
-    fn scoped_ast_id(&self, db: &dyn Db, scope: ScopeId) -> ScopedExpressionId {
+impl HasScopedExpressionId for ast::ExpressionRef<'_> {
+    fn scoped_expression_id(&self, db: &dyn Db, scope: ScopeId) -> ScopedExpressionId {
         let ast_ids = ast_ids(db, scope);
         ast_ids.expression_id(*self)
     }

--- a/crates/red_knot_python_semantic/src/semantic_model.rs
+++ b/crates/red_knot_python_semantic/src/semantic_model.rs
@@ -6,7 +6,7 @@ use ruff_source_file::LineIndex;
 
 use crate::module_name::ModuleName;
 use crate::module_resolver::{resolve_module, Module};
-use crate::semantic_index::ast_ids::HasScopedAstId;
+use crate::semantic_index::ast_ids::HasScopedExpressionId;
 use crate::semantic_index::semantic_index;
 use crate::types::{binding_ty, infer_scope_types, Type};
 use crate::Db;
@@ -54,7 +54,7 @@ impl HasTy for ast::ExpressionRef<'_> {
         let file_scope = index.expression_scope_id(*self);
         let scope = file_scope.to_scope_id(model.db, model.file);
 
-        let expression_id = self.scoped_ast_id(model.db, scope);
+        let expression_id = self.scoped_expression_id(model.db, scope);
         infer_scope_types(model.db, scope).expression_ty(expression_id)
     }
 }

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -14,7 +14,7 @@ pub(crate) use self::infer::{
 };
 pub(crate) use self::signatures::Signature;
 use crate::module_resolver::file_to_module;
-use crate::semantic_index::ast_ids::HasScopedAstId;
+use crate::semantic_index::ast_ids::HasScopedExpressionId;
 use crate::semantic_index::definition::Definition;
 use crate::semantic_index::symbol::{self as symbol, ScopeId, ScopedSymbolId};
 use crate::semantic_index::{
@@ -207,7 +207,7 @@ fn definition_expression_ty<'db>(
     let index = semantic_index(db, file);
     let file_scope = index.expression_scope_id(expression);
     let scope = file_scope.to_scope_id(db, file);
-    let expr_id = expression.scoped_ast_id(db, scope);
+    let expr_id = expression.scoped_expression_id(db, scope);
     if scope == definition.scope(db) {
         // expression is in the definition scope
         let inference = infer_definition_types(db, definition);

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -2211,11 +2211,7 @@ impl<'db> TypeInferenceBuilder<'db> {
         ty
     }
 
-    fn store_expression_type(
-        &mut self,
-        expression: &impl HasScopedAstId<Id = ScopedExpressionId>,
-        ty: Type<'db>,
-    ) {
+    fn store_expression_type(&mut self, expression: &impl HasScopedAstId, ty: Type<'db>) {
         if self.deferred_state.in_string_annotation() {
             // Avoid storing the type of expressions that are part of a string annotation because
             // the expression ids don't exists in the semantic index. Instead, we'll store the type

--- a/crates/red_knot_python_semantic/src/types/narrow.rs
+++ b/crates/red_knot_python_semantic/src/types/narrow.rs
@@ -1,4 +1,4 @@
-use crate::semantic_index::ast_ids::HasScopedAstId;
+use crate::semantic_index::ast_ids::HasScopedExpressionId;
 use crate::semantic_index::constraint::{Constraint, ConstraintNode, PatternConstraint};
 use crate::semantic_index::definition::Definition;
 use crate::semantic_index::expression::Expression;
@@ -291,7 +291,7 @@ impl<'db> NarrowingConstraintsBuilder<'db> {
             {
                 // SAFETY: we should always have a symbol for every Name node.
                 let symbol = self.symbols().symbol_id_by_name(id).unwrap();
-                let rhs_ty = inference.expression_ty(right.scoped_ast_id(self.db, scope));
+                let rhs_ty = inference.expression_ty(right.scoped_expression_id(self.db, scope));
 
                 match if is_positive { *op } else { op.negate() } {
                     ast::CmpOp::IsNot => {
@@ -336,7 +336,7 @@ impl<'db> NarrowingConstraintsBuilder<'db> {
         // TODO: add support for PEP 604 union types on the right hand side of `isinstance`
         // and `issubclass`, for example `isinstance(x, str | (int | float))`.
         match inference
-            .expression_ty(expr_call.func.scoped_ast_id(self.db, scope))
+            .expression_ty(expr_call.func.scoped_expression_id(self.db, scope))
             .into_function_literal()
             .and_then(|f| f.known(self.db))
             .and_then(KnownFunction::constraint_function)
@@ -348,7 +348,7 @@ impl<'db> NarrowingConstraintsBuilder<'db> {
                     let symbol = self.symbols().symbol_id_by_name(id).unwrap();
 
                     let class_info_ty =
-                        inference.expression_ty(class_info.scoped_ast_id(self.db, scope));
+                        inference.expression_ty(class_info.scoped_expression_id(self.db, scope));
 
                     let to_constraint = match function {
                         KnownConstraintFunction::IsInstance => {
@@ -414,7 +414,7 @@ impl<'db> NarrowingConstraintsBuilder<'db> {
             // filter our arms with statically known truthiness
             .filter(|expr| {
                 inference
-                    .expression_ty(expr.scoped_ast_id(self.db, scope))
+                    .expression_ty(expr.scoped_expression_id(self.db, scope))
                     .bool(self.db)
                     != match expr_bool_op.op {
                         BoolOp::And => Truthiness::AlwaysTrue,

--- a/crates/red_knot_python_semantic/src/types/unpacker.rs
+++ b/crates/red_knot_python_semantic/src/types/unpacker.rs
@@ -4,7 +4,7 @@ use ruff_db::files::File;
 use ruff_python_ast::{self as ast, AnyNodeRef};
 use rustc_hash::FxHashMap;
 
-use crate::semantic_index::ast_ids::{HasScopedAstId, ScopedExpressionId};
+use crate::semantic_index::ast_ids::{HasScopedExpressionId, ScopedExpressionId};
 use crate::semantic_index::symbol::ScopeId;
 use crate::types::{Type, TypeCheckDiagnostics, TypeCheckDiagnosticsBuilder};
 use crate::Db;
@@ -29,7 +29,7 @@ impl<'db> Unpacker<'db> {
         match target {
             ast::Expr::Name(target_name) => {
                 self.targets
-                    .insert(target_name.scoped_ast_id(self.db, scope), value_ty);
+                    .insert(target_name.scoped_expression_id(self.db, scope), value_ty);
             }
             ast::Expr::Starred(ast::ExprStarred { value, .. }) => {
                 self.unpack(value, value_ty, scope);


### PR DESCRIPTION
## Summary

Another small cleanup I'm splitting out from the branch I have locally working towards https://github.com/astral-sh/ruff/issues/13933. The traits `HasScopedUseId` and `HasScopedAstId` don't need to be generic: for both traits, the `Id` associated type is the same for all implementations of the trait. We can remove some complexity here by removing the associated types and specifying concrete types in the trait definitions rather than associated types.

## Test Plan

`cargo test -p red_knot_python_semantic`
