### PR TITLE
[red-knot] Do not pull types for subexpressions of annotations

### DIFF
--- a/crates/red_knot_workspace/tests/check.rs
+++ b/crates/red_knot_workspace/tests/check.rs
@@ -259,6 +259,14 @@ impl SourceOrderVisitor<'_> for PullTypesVisitor<'_> {
 
         source_order::walk_alias(self, alias);
     }
+
+    fn visit_annotation(&mut self, annotation: &Expr) {
+        let _ty = annotation.ty(&self.model);
+
+        // Do not descend into annotation expressions, as we do not infer types
+        // for every *sub*expression of an annotation. For example: we can not
+        // infer a reasonable type for the ellipsis in `tuple[int, ...]`.
+    }
 }
 
 /// Whether or not the .py/.pyi version of this file is expected to fail
@@ -273,49 +281,17 @@ const KNOWN_FAILURES: &[(&str, bool, bool)] = &[
     ("crates/ruff_python_parser/resources/inline/ok/type_param_type_var_tuple.py", true, true),
     ("crates/ruff_python_parser/resources/inline/ok/type_param_type_var.py", true, true),
     ("crates/ruff_python_parser/resources/valid/statement/type.py", true, true),
-    // Fails for unknown reasons:
-    ("crates/ruff_linter/resources/test/fixtures/flake8_future_annotations/no_future_import_uses_union_inner.py", true, true),
-    ("crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI011.py", true, true),
-    ("crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI015.py", true, true),
-    ("crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI016.py", true, true),
-    ("crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI019.py", true, true),
-    ("crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI020.py", true, true),
-    ("crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI030.py", true, true),
-    ("crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI034.py", true, true),
-    ("crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI035.py", true, true),
-    ("crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI036.py", true, true),
-    ("crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI041.py", true, true),
-    ("crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI051.py", true, true),
-    ("crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI052.py", true, true),
-    ("crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI055.py", true, true),
-    ("crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI061.py", true, true),
-    ("crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI062.py", true, true),
-    ("crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI063.py", true, true),
-    ("crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI064.py", true, true),
-    ("crates/ruff_linter/resources/test/fixtures/flake8_type_checking/quote.py", true, true),
-    ("crates/ruff_linter/resources/test/fixtures/flake8_type_checking/quote2.py", true, true),
-    ("crates/ruff_linter/resources/test/fixtures/flake8_type_checking/quote3.py", true, true),
-    ("crates/ruff_linter/resources/test/fixtures/flake8_type_checking/TCH004_13.py", true, true),
     ("crates/ruff_linter/resources/test/fixtures/flake8_type_checking/TCH004_15.py", true, true),
     ("crates/ruff_linter/resources/test/fixtures/pyflakes/F401_19.py", true, true),
+    ("crates/ruff_linter/resources/test/fixtures/pyflakes/F821_14.py", false, true),
+    ("crates/ruff_linter/resources/test/fixtures/pyflakes/F821_17.py", true, true),
+    ("crates/ruff_linter/resources/test/fixtures/pyflakes/F821_15.py", true, true),
+    ("crates/ruff_linter/resources/test/fixtures/pyflakes/F821_20.py", true, true),
+    ("crates/ruff_linter/resources/test/fixtures/pyflakes/F821_26.py", true, false),
+    // Fails for unknown reasons:
     ("crates/ruff_linter/resources/test/fixtures/pyflakes/F541.py", true, true),
     ("crates/ruff_linter/resources/test/fixtures/pyflakes/F632.py", true, true),
     ("crates/ruff_linter/resources/test/fixtures/pyflakes/F811_19.py", true, false),
-    ("crates/ruff_linter/resources/test/fixtures/pyflakes/F821_0.py", true, true),
-    ("crates/ruff_linter/resources/test/fixtures/pyflakes/F821_14.py", false, true),
-    ("crates/ruff_linter/resources/test/fixtures/pyflakes/F821_15.py", true, true),
-    ("crates/ruff_linter/resources/test/fixtures/pyflakes/F821_17.py", true, true),
-    ("crates/ruff_linter/resources/test/fixtures/pyflakes/F821_2.py", true, true),
-    ("crates/ruff_linter/resources/test/fixtures/pyflakes/F821_20.py", true, true),
-    ("crates/ruff_linter/resources/test/fixtures/pyflakes/F821_26.py", true, false),
-    ("crates/ruff_linter/resources/test/fixtures/pyflakes/project/foo/bar.py", true, true),
-    ("crates/ruff_linter/resources/test/fixtures/pyflakes/project/foo/bop/baz.py", true, true),
-    ("crates/ruff_linter/resources/test/fixtures/pylint/single_string_slots.py", true, true),
-    ("crates/ruff_linter/resources/test/fixtures/pyupgrade/UP037_0.py", true, true),
     ("crates/ruff_linter/resources/test/fixtures/pyupgrade/UP039.py", true, false),
-    ("crates/ruff_linter/resources/test/fixtures/pyupgrade/UP044.py", true, true),
-    ("crates/ruff_linter/resources/test/fixtures/ruff/RUF013_0.py", true, true),
-    ("crates/ruff_linter/resources/test/fixtures/ruff/RUF013_3.py", true, true),
-    ("crates/ruff_linter/resources/test/fixtures/ruff/RUF022.py", true, true),
     ("crates/ruff_python_parser/resources/valid/expressions/f_string.py", true, true),
 ];


### PR DESCRIPTION
## Summary

As you can see from the drastically reduced `KNOWN_FAILURES` list, a lot of the remaining panics in the corpus test are caused by pulling types for every subexpression of a type annotation. Consider for example the type annotation `tuple[int, ...]`. If we insist on being able to infer types for each and every subexpression of annotations, then we also need to infer a type for the ellipsis.

In the current changeset, I simply stop the `PullTypesVisitor` from descending further into annotation expressions. This disables the check even for annotations like `int | str` where we can — and do — assign correct types to subexpressions.

I am aware that this might not be the right fix. I'm opening the PR to discuss how to proceed here. Two alternative approaches that I can think of:

1. Adapt type inference to infer types for each and every subexpressions of annotations. For the ellipsis in the example above, we would perhaps infer `Type::Unknown` (or maybe `tuple[int, …]`, somewhat recursively?).
1. Adapt type inference to infer types for *most* subexpressions of annotations, with certain exceptions. We adapt the `PullTypes` visitor to ignore those exceptional expressions.

## Test Plan

Ran corpus test with reduced known-failures list.