### PR TITLE
[red-knot] Disable linter-corpus tests

### DIFF
--- a/crates/red_knot_workspace/tests/check.rs
+++ b/crates/red_knot_workspace/tests/check.rs
@@ -42,6 +42,7 @@ fn parser_no_panic() -> anyhow::Result<()> {
 }
 
 #[test]
+#[ignore = "Enable running once there are fewer failures"]
 fn linter_af_no_panic() -> anyhow::Result<()> {
     let workspace_root = get_workspace_root()?;
     run_corpus_tests(&format!(
@@ -50,6 +51,7 @@ fn linter_af_no_panic() -> anyhow::Result<()> {
 }
 
 #[test]
+#[ignore = "Enable running once there are fewer failures"]
 fn linter_gz_no_panic() -> anyhow::Result<()> {
     let workspace_root = get_workspace_root()?;
     run_corpus_tests(&format!(


### PR DESCRIPTION
## Summary

Disable the no-panic tests for the linter corpus, as there are too many problems right now, requiring linter-contributors to add their test files to the allow-list.

We can still run the tests using `--ignored`. This is also why I left the `crates/ruff_linter/` entries in the allow list for now, even if they will get out of sync. But let me know if I should rather remove them.