### PR TITLE
[`flake8-logging`] Suggest `.getLogger(__name__)` instead of `.getLogger(__file__)` (`LOG015`)

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_logging/rules/root_logger_call.rs
+++ b/crates/ruff_linter/src/rules/flake8_logging/rules/root_logger_call.rs
@@ -24,7 +24,7 @@ use crate::checkers::ast::Checker;
 /// ```python
 /// import logging
 ///
-/// logger = logging.getLogger(__file__)
+/// logger = logging.getLogger(__name__)
 /// logger.info("Foobar")
 /// ```
 #[violation]


### PR DESCRIPTION
## Summary

Resolves #14390.

## Test Plan

Manual.
