### PR TITLE
Understand `typing.Optional` in annotations

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/annotations/optional.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/annotations/optional.md
@@ -1,0 +1,47 @@
+# Optional
+
+## Annotation
+
+`typing.Optional` is equivalent to using the type with a None in a Union.
+
+```py
+from typing import Optional
+
+a: Optional[int]
+a1: Optional[bool]
+a2: Optional[Optional[bool]]
+a3: Optional[None]
+
+def f():
+    # revealed: int | None
+    reveal_type(a)
+    # revealed: bool | None
+    reveal_type(a1)
+    # revealed: bool | None
+    reveal_type(a2)
+    # revealed: None
+    reveal_type(a3)
+```
+
+## Assignment
+
+```py
+from typing import Optional
+
+a: Optional[int] = 1
+a = None
+# error: [invalid-assignment] "Object of type `Literal[""]` is not assignable to `int | None`"
+a = ""
+```
+
+## Typing Extensions
+
+```py
+from typing_extensions import Optional
+
+a: Optional[int]
+
+def f():
+    # revealed: int | None
+    reveal_type(a)
+```

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -1826,8 +1826,7 @@ impl<'db> KnownInstanceType<'db> {
     /// Evaluate the known instance in boolean context
     pub const fn bool(self) -> Truthiness {
         match self {
-            Self::Literal | Self::Optional => Truthiness::AlwaysTrue,
-            Self::TypeVar(_) => Truthiness::AlwaysTrue,
+            Self::Literal | Self::Optional | Self::TypeVar(_) => Truthiness::AlwaysTrue,
         }
     }
 

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -1807,6 +1807,8 @@ impl<'db> KnownClass {
 pub enum KnownInstanceType<'db> {
     /// The symbol `typing.Literal` (which can also be found as `typing_extensions.Literal`)
     Literal,
+    /// The symbol `typing.Optional` (which can also be found as `typing_extensions.Literal`)
+    Optional,
     /// A single instance of `typing.TypeVar`
     TypeVar(TypeVarInstance<'db>),
     // TODO: fill this enum out with more special forms, etc.
@@ -1816,6 +1818,7 @@ impl<'db> KnownInstanceType<'db> {
     pub const fn as_str(self) -> &'static str {
         match self {
             KnownInstanceType::Literal => "Literal",
+            KnownInstanceType::Optional => "Optional",
             KnownInstanceType::TypeVar(_) => "TypeVar",
         }
     }
@@ -1823,7 +1826,7 @@ impl<'db> KnownInstanceType<'db> {
     /// Evaluate the known instance in boolean context
     pub const fn bool(self) -> Truthiness {
         match self {
-            Self::Literal => Truthiness::AlwaysTrue,
+            Self::Literal | Self::Optional => Truthiness::AlwaysTrue,
             Self::TypeVar(_) => Truthiness::AlwaysTrue,
         }
     }
@@ -1832,6 +1835,7 @@ impl<'db> KnownInstanceType<'db> {
     pub fn repr(self, db: &'db dyn Db) -> &'db str {
         match self {
             Self::Literal => "typing.Literal",
+            Self::Optional => "typing.Optional",
             Self::TypeVar(typevar) => typevar.name(db),
         }
     }
@@ -1840,6 +1844,7 @@ impl<'db> KnownInstanceType<'db> {
     pub const fn class(self) -> KnownClass {
         match self {
             Self::Literal => KnownClass::SpecialForm,
+            Self::Optional => KnownClass::SpecialForm,
             Self::TypeVar(_) => KnownClass::TypeVar,
         }
     }
@@ -1859,6 +1864,7 @@ impl<'db> KnownInstanceType<'db> {
         }
         match (module.name().as_str(), instance_name) {
             ("typing" | "typing_extensions", "Literal") => Some(Self::Literal),
+            ("typing" | "typing_extensions", "Optional") => Some(Self::Optional),
             _ => None,
         }
     }

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -4525,10 +4525,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                 }
             },
             KnownInstanceType::Optional => {
-                let param_type = self.infer_annotation_expression(
-                    parameters,
-                    DeferredExpressionState::from(self.are_all_types_deferred()),
-                );
+                let param_type = self.infer_type_expression(parameters);
                 UnionType::from_elements(self.db, [param_type, Type::none(self.db)])
             }
             KnownInstanceType::TypeVar(_) => Type::Todo,

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -4525,8 +4525,10 @@ impl<'db> TypeInferenceBuilder<'db> {
                 }
             },
             KnownInstanceType::Optional => {
-                let param_type =
-                    self.infer_annotation_expression(parameters, DeferredExpressionState::None);
+                let param_type = self.infer_annotation_expression(
+                    parameters,
+                    DeferredExpressionState::from(self.are_all_types_deferred()),
+                );
                 UnionType::from_elements(self.db, [param_type, Type::none(self.db)])
             }
             KnownInstanceType::TypeVar(_) => Type::Todo,

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -4524,6 +4524,11 @@ impl<'db> TypeInferenceBuilder<'db> {
                     Type::Unknown
                 }
             },
+            KnownInstanceType::Optional => {
+                let param_type =
+                    self.infer_annotation_expression(parameters, DeferredExpressionState::None);
+                UnionType::from_elements(self.db, [param_type, Type::none(self.db)])
+            }
             KnownInstanceType::TypeVar(_) => Type::Todo,
         }
     }

--- a/crates/red_knot_python_semantic/src/types/mro.rs
+++ b/crates/red_knot_python_semantic/src/types/mro.rs
@@ -371,8 +371,9 @@ impl<'db> ClassBase<'db> {
             | Type::ModuleLiteral(_)
             | Type::SubclassOf(_) => None,
             Type::KnownInstance(known_instance) => match known_instance {
-                KnownInstanceType::Literal | KnownInstanceType::Optional => None,
-                KnownInstanceType::TypeVar(_) => None,
+                KnownInstanceType::TypeVar(_)
+                | KnownInstanceType::Literal
+                | KnownInstanceType::Optional => None,
             },
         }
     }

--- a/crates/red_knot_python_semantic/src/types/mro.rs
+++ b/crates/red_knot_python_semantic/src/types/mro.rs
@@ -371,7 +371,7 @@ impl<'db> ClassBase<'db> {
             | Type::ModuleLiteral(_)
             | Type::SubclassOf(_) => None,
             Type::KnownInstance(known_instance) => match known_instance {
-                KnownInstanceType::Literal => None,
+                KnownInstanceType::Literal | KnownInstanceType::Optional => None,
                 KnownInstanceType::TypeVar(_) => None,
             },
         }


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->
Fix: #14354

## Summary

Recognize `Optional` special form in annotation. Both `typing` and `typing_extensions` modules are valid for importing `Optional`.
The result type is a Union with `None`.

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

Added tests for importing from modules and assignability and different combinations for the `Optional` parameter.

<!-- How was it tested? -->
