### PR TITLE
Add tests for python version compatibility

### DIFF
--- a/crates/red_knot/src/target_version.rs
+++ b/crates/red_knot/src/target_version.rs
@@ -4,8 +4,8 @@
 #[derive(Copy, Clone, Hash, Debug, PartialEq, Eq, PartialOrd, Ord, Default, clap::ValueEnum)]
 pub enum TargetVersion {
     Py37,
-    #[default]
     Py38,
+    #[default]
     Py39,
     Py310,
     Py311,
@@ -44,5 +44,19 @@ impl From<TargetVersion> for red_knot_python_semantic::PythonVersion {
             TargetVersion::Py312 => Self::PY312,
             TargetVersion::Py313 => Self::PY313,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::target_version::TargetVersion;
+    use red_knot_python_semantic::PythonVersion;
+
+    #[test]
+    fn same_default_as_python_version() {
+        assert_eq!(
+            PythonVersion::from(TargetVersion::default()),
+            PythonVersion::default()
+        );
     }
 }

--- a/crates/red_knot_wasm/src/lib.rs
+++ b/crates/red_knot_wasm/src/lib.rs
@@ -184,8 +184,8 @@ impl Settings {
 #[derive(Copy, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Default)]
 pub enum TargetVersion {
     Py37,
-    #[default]
     Py38,
+    #[default]
     Py39,
     Py310,
     Py311,
@@ -290,4 +290,18 @@ impl System for WasmSystem {
 
 fn not_found() -> std::io::Error {
     std::io::Error::new(std::io::ErrorKind::NotFound, "No such file or directory")
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::TargetVersion;
+    use red_knot_python_semantic::PythonVersion;
+
+    #[test]
+    fn same_default_as_python_version() {
+        assert_eq!(
+            PythonVersion::from(TargetVersion::default()),
+            PythonVersion::default()
+        );
+    }
 }

--- a/crates/ruff_linter/src/settings/types.rs
+++ b/crates/ruff_linter/src/settings/types.rs
@@ -68,6 +68,10 @@ impl PythonVersion {
         Self::Py313
     }
 
+    pub const fn minimal_supported() -> Self {
+        Self::Py37
+    }
+
     pub const fn as_tuple(&self) -> (u8, u8) {
         match self {
             Self::Py37 => (3, 7),

--- a/crates/ruff_python_formatter/src/options.rs
+++ b/crates/ruff_python_formatter/src/options.rs
@@ -475,4 +475,24 @@ impl PythonVersion {
     pub fn supports_pep_701(self) -> bool {
         self >= Self::Py312
     }
+
+    pub fn as_tuple(self) -> (u8, u8) {
+        match self {
+            Self::Py37 => (3, 7),
+            Self::Py38 => (3, 8),
+            Self::Py39 => (3, 9),
+            Self::Py310 => (3, 10),
+            Self::Py311 => (3, 11),
+            Self::Py312 => (3, 12),
+            Self::Py313 => (3, 13),
+        }
+    }
+
+    pub fn latest() -> Self {
+        Self::Py313
+    }
+
+    pub fn minimal_supported() -> Self {
+        Self::Py37
+    }
 }

--- a/crates/ruff_workspace/src/options.rs
+++ b/crates/ruff_workspace/src/options.rs
@@ -3408,7 +3408,9 @@ pub struct AnalyzeOptions {
 mod tests {
     use crate::options::Flake8SelfOptions;
     use ruff_linter::rules::flake8_self;
+    use ruff_linter::settings::types::PythonVersion as LinterPythonVersion;
     use ruff_python_ast::name::Name;
+    use ruff_python_formatter::PythonVersion as FormatterPythonVersion;
 
     #[test]
     fn flake8_self_options() {
@@ -3454,6 +3456,30 @@ mod tests {
         assert_eq!(
             settings.ignore_names,
             vec![Name::new_static("_foo"), Name::new_static("_bar")]
+        );
+    }
+
+    #[test]
+    fn formatter_and_linter_target_version_have_same_default() {
+        assert_eq!(
+            FormatterPythonVersion::default().as_tuple(),
+            LinterPythonVersion::default().as_tuple()
+        );
+    }
+
+    #[test]
+    fn formatter_and_linter_target_version_have_same_latest() {
+        assert_eq!(
+            FormatterPythonVersion::latest().as_tuple(),
+            LinterPythonVersion::latest().as_tuple()
+        );
+    }
+
+    #[test]
+    fn formatter_and_linter_target_version_have_same_minimal_supported() {
+        assert_eq!(
+            FormatterPythonVersion::minimal_supported().as_tuple(),
+            LinterPythonVersion::minimal_supported().as_tuple()
         );
     }
 }


### PR DESCRIPTION
## Summary

We have multiple types that all represent `PythonVersion` and keeping them all in sync
is error-prone. This PR adds a few tests that should warn developers if they miss updating one `default` implementation.

## Test Plan

Added tests
