### PR TITLE
[red-knot] Narrowing for `type(x) is C` checks

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/narrow/type.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/narrow/type.md
@@ -6,7 +6,8 @@
 class A: ...
 class B: ...
 
-def get_a_or_b() -> A | B: ...
+def get_a_or_b() -> A | B:
+    return A()
 
 x = get_a_or_b()
 
@@ -25,7 +26,8 @@ else:
 class A: ...
 class B: ...
 
-def get_a_or_b() -> A | B: ...
+def get_a_or_b() -> A | B:
+    return A()
 
 x = get_a_or_b()
 
@@ -52,7 +54,8 @@ class IsEqualToEverything(type):
 class A(metaclass=IsEqualToEverything): ...
 class B(metaclass=IsEqualToEverything): ...
 
-def get_a_or_b() -> A | B: ...
+def get_a_or_b() -> A | B:
+    return B()
 
 x = get_a_or_b()
 
@@ -72,7 +75,8 @@ class B: ...
 def type(x):
     return int
 
-def get_a_or_b() -> A | B: ...
+def get_a_or_b() -> A | B:
+    return A()
 
 x = get_a_or_b()
 
@@ -87,7 +91,8 @@ else:
 No narrowing should occur if `type` is used to dynamically create a class:
 
 ```py
-def get_str_or_int() -> str | int: ...
+def get_str_or_int() -> str | int:
+    return "test"
 
 x = get_str_or_int()
 
@@ -105,7 +110,8 @@ class B: ...
 
 alias_for_type = type
 
-def get_a_or_b() -> A | B: ...
+def get_a_or_b() -> A | B:
+    return A()
 
 x = get_a_or_b()
 
@@ -119,7 +125,8 @@ if alias_for_type(x) is A:
 class Base: ...
 class Derived(Base): ...
 
-def get_base() -> Base: ...
+def get_base() -> Base:
+    return Base()
 
 x = get_base()
 

--- a/crates/red_knot_python_semantic/resources/mdtest/narrow/type.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/narrow/type.md
@@ -102,6 +102,21 @@ else:
     reveal_type(x)  # revealed: str | int
 ```
 
+## No narrowing for keyword arguments
+
+`type` can't be used with a keyword argument:
+
+```py
+def get_str_or_int() -> str | int:
+    return "test"
+
+x = get_str_or_int()
+
+# TODO: we could issue a diagnostic here
+if type(object=x) is str:
+    reveal_type(x)  # revealed: str | int
+```
+
 ## Narrowing if `type` is aliased
 
 ```py

--- a/crates/red_knot_python_semantic/resources/mdtest/narrow/type.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/narrow/type.md
@@ -1,0 +1,127 @@
+# Narrowing for checks involving `type(x)`
+
+## `type(x) is C`
+
+```py
+class A: ...
+class B: ...
+
+def get_a_or_b() -> A | B: ...
+
+x = get_a_or_b()
+
+if type(x) is A:
+    reveal_type(x)  # revealed: A
+else:
+    # It would be wrong to infer `B` here. The type
+    # of `x` could be a subclass of `A`, so we need
+    # to infer the full union type:
+    reveal_type(x)  # revealed: A | B
+```
+
+## `type(x) is not C`
+
+```py
+class A: ...
+class B: ...
+
+def get_a_or_b() -> A | B: ...
+
+x = get_a_or_b()
+
+if type(x) is not A:
+    # Same reasoning as above: no narrowing should occur here.
+    reveal_type(x)  # revealed: A | B
+else:
+    reveal_type(x)  # revealed: A
+```
+
+## `type(x) == C`, `type(x) != C`
+
+No narrowing can occur for equality comparisons, since there might be a custom `__eq__`
+implementation on the metaclass:
+
+```py
+class IsEqualToEverything(type):
+    def __eq__(cls, other):
+        return True
+
+class A(metaclass=IsEqualToEverything): ...
+class B(metaclass=IsEqualToEverything): ...
+
+def get_a_or_b() -> A | B: ...
+
+x = get_a_or_b()
+
+if type(x) == A:
+    reveal_type(x)  # revealed: A | B
+
+if type(x) != A:
+    reveal_type(x)  # revealed: A | B
+```
+
+## No narrowing for custom `type` callable
+
+```py
+class A: ...
+class B: ...
+
+def type(x):
+    return int
+
+def get_a_or_b() -> A | B: ...
+
+x = get_a_or_b()
+
+if type(x) is A:
+    reveal_type(x)  # revealed: A | B
+else:
+    reveal_type(x)  # revealed: A | B
+```
+
+## No narrowing for multiple arguments
+
+No narrowing should occur if `type` is used to dynamically create a class:
+
+```py
+def get_str_or_int() -> str | int: ...
+
+x = get_str_or_int()
+
+if type(x, (), {}) is str:
+    reveal_type(x)  # revealed: str | int
+else:
+    reveal_type(x)  # revealed: str | int
+```
+
+## Narrowing if `type` is aliased
+
+```py
+class A: ...
+class B: ...
+
+alias_for_type = type
+
+def get_a_or_b() -> A | B: ...
+
+x = get_a_or_b()
+
+if alias_for_type(x) is A:
+    reveal_type(x)  # revealed: A
+```
+
+## Limitations
+
+```py
+class Base: ...
+class Derived(Base): ...
+
+def get_base() -> Base: ...
+
+x = get_base()
+
+if type(x) is Base:
+    # Ideally, this could be narrower, but there is now way to
+    # express a constraint like `Base & ~ProperSubtypeOf[Base]`.
+    reveal_type(x)  # revealed: Base
+```

--- a/crates/red_knot_python_semantic/resources/mdtest/narrow/type.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/narrow/type.md
@@ -39,7 +39,10 @@ else:
 ## `type(x) == C`, `type(x) != C`
 
 No narrowing can occur for equality comparisons, since there might be a custom `__eq__`
-implementation on the metaclass:
+implementation on the metaclass.
+
+TODO: Narrowing might be possible in some cases where the classes themselves are `@final` or their
+metaclass is `@final`.
 
 ```py
 class IsEqualToEverything(type):

--- a/crates/red_knot_python_semantic/src/types/narrow.rs
+++ b/crates/red_knot_python_semantic/src/types/narrow.rs
@@ -322,7 +322,7 @@ impl<'db> NarrowingConstraintsBuilder<'db> {
                     range: _,
                     func: callable,
                     arguments,
-                }) if arguments.len() == 1 => {
+                }) if arguments.args.len() == 1 && arguments.keywords.len() == 0 => {
                     let callable_ty =
                         inference.expression_ty(callable.scoped_expression_id(self.db, scope));
 

--- a/crates/red_knot_python_semantic/src/types/narrow.rs
+++ b/crates/red_knot_python_semantic/src/types/narrow.rs
@@ -286,8 +286,10 @@ impl<'db> NarrowingConstraintsBuilder<'db> {
                     id,
                     ctx: _,
                 }) => {
-                    // SAFETY: we should always have a symbol for every Name node.
-                    let symbol = self.symbols().symbol_id_by_name(id).unwrap();
+                    let symbol = self
+                        .symbols()
+                        .symbol_id_by_name(id)
+                        .expect("Should always have a symbol for every Name node");
 
                     match if is_positive { *op } else { op.negate() } {
                         ast::CmpOp::IsNot => {
@@ -326,12 +328,14 @@ impl<'db> NarrowingConstraintsBuilder<'db> {
 
                     if callable_ty
                         .into_class_literal()
-                        .map(|c| c.class.is_known(self.db, KnownClass::Type))
-                        .unwrap_or(false)
+                        .is_some_and(|c| c.class.is_known(self.db, KnownClass::Type))
                         && arguments.len() == 1
                     {
                         if let Some(id) = arguments.args[0].as_name_expr().map(|name| &name.id) {
-                            let symbol = self.symbols().symbol_id_by_name(id).unwrap();
+                            let symbol = self
+                                .symbols()
+                                .symbol_id_by_name(id)
+                                .expect("Should always have a symbol for every Name node");
                             if ast::CmpOp::Is == if is_positive { *op } else { op.negate() } {
                                 if rhs_ty.is_class_literal() {
                                     constraints.insert(symbol, rhs_ty.to_instance(self.db));

--- a/crates/red_knot_python_semantic/src/types/narrow.rs
+++ b/crates/red_knot_python_semantic/src/types/narrow.rs
@@ -322,14 +322,13 @@ impl<'db> NarrowingConstraintsBuilder<'db> {
                     range: _,
                     func: callable,
                     arguments,
-                }) => {
+                }) if arguments.len() == 1 => {
                     let callable_ty =
                         inference.expression_ty(callable.scoped_expression_id(self.db, scope));
 
                     if callable_ty
                         .into_class_literal()
                         .is_some_and(|c| c.class.is_known(self.db, KnownClass::Type))
-                        && arguments.len() == 1
                     {
                         if let Some(id) = arguments.args[0].as_name_expr().map(|name| &name.id) {
                             let symbol = self


### PR DESCRIPTION
## Summary

Add type narrowing for `type(x) is C` conditions (and `else` clauses of `type(x) is not C` conditionals):

```py
if type(x) is A:
    reveal_type(x)  # revealed: A
else:
    reveal_type(x)  # revealed: A | B
```

closes: #14431, part of: #13694

## Test Plan

New Markdown-based tests.