### PR TITLE
[ruff-0.8] [`ruff`] Stabilise `parenthesize-chained-operators` (`RUF021`)

### DIFF
--- a/crates/ruff_linter/src/codes.rs
+++ b/crates/ruff_linter/src/codes.rs
@@ -960,7 +960,7 @@ pub fn code_to_rule(linter: Linter, code: &str) -> Option<(RuleGroup, Rule)> {
         (Ruff, "018") => (RuleGroup::Stable, rules::ruff::rules::AssignmentInAssert),
         (Ruff, "019") => (RuleGroup::Stable, rules::ruff::rules::UnnecessaryKeyCheck),
         (Ruff, "020") => (RuleGroup::Stable, rules::ruff::rules::NeverUnion),
-        (Ruff, "021") => (RuleGroup::Preview, rules::ruff::rules::ParenthesizeChainedOperators),
+        (Ruff, "021") => (RuleGroup::Stable, rules::ruff::rules::ParenthesizeChainedOperators),
         (Ruff, "022") => (RuleGroup::Preview, rules::ruff::rules::UnsortedDunderAll),
         (Ruff, "023") => (RuleGroup::Preview, rules::ruff::rules::UnsortedDunderSlots),
         (Ruff, "024") => (RuleGroup::Stable, rules::ruff::rules::MutableFromkeysValue),


### PR DESCRIPTION
## Summary

This rule has been in preview for a long time and its implementation has been stable for a long time. There are no open issues about the rule and no known issues in the implementation. The documentation seems clear.

It's an opinionated stylistic rule, but also probably a change that most people would agree with (in our subjective opinion).

## Test Plan

We'll wait to see what the ecosystem check says!
