### PR TITLE
Use XDG (i.e. `~/.local/bin`) instead of the Cargo home directory in the installer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -303,4 +303,4 @@ github-custom-job-permissions = { "build-docker" = { packages = "write", content
 # Whether to install an updater program
 install-updater = false
 # Path that installers should place binaries in
-install-path = "CARGO_HOME"
+install-path = ["$XDG_BIN_HOME/", "$XDG_DATA_HOME/../bin", "~/.local/bin"]


### PR DESCRIPTION
Closes https://github.com/astral-sh/ruff/issues/13927

See https://github.com/astral-sh/uv/pull/8420 for details.