### PR TITLE
Mark UP043 fix unsafe when the type annotation contains any comments

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP043.py
+++ b/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP043.py
@@ -50,3 +50,10 @@ def func() -> Generator[str, None, None]:
 
 async def func() -> AsyncGenerator[str, None]:
     yield "hello"
+
+
+async def func() -> AsyncGenerator[  # type: ignore
+    str,
+    None
+]:
+    yield "hello"

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP043.py.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP043.py.snap
@@ -108,3 +108,28 @@ UP043.py:51:21: UP043 [*] Unnecessary default type arguments
 51    |-async def func() -> AsyncGenerator[str, None]:
    51 |+async def func() -> AsyncGenerator[str]:
 52 52 |     yield "hello"
+53 53 | 
+54 54 | 
+
+UP043.py:55:21: UP043 [*] Unnecessary default type arguments
+   |
+55 |   async def func() -> AsyncGenerator[  # type: ignore
+   |  _____________________^
+56 | |     str,
+57 | |     None
+58 | | ]:
+   | |_^ UP043
+59 |       yield "hello"
+   |
+   = help: Remove default type arguments
+
+ℹ Unsafe fix
+52 52 |     yield "hello"
+53 53 | 
+54 54 | 
+55    |-async def func() -> AsyncGenerator[  # type: ignore
+56    |-    str,
+57    |-    None
+58    |-]:
+   55 |+async def func() -> AsyncGenerator[str]:
+59 56 |     yield "hello"


### PR DESCRIPTION
## Summary

According to our fix safety guideline. Mark the fix as unsafe when there's a comment in the fix range.

## Test Plan

Added unit test
