### PR TITLE
Use Depot 8-core runner for ecosystem tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -331,7 +331,7 @@ jobs:
 
   ecosystem:
     name: "ecosystem"
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest-8
     needs:
       - cargo-test-linux
       - determine_changes


### PR DESCRIPTION
I noticed this was exceedingly slow.

Reduces to 3m from 14m