### PR TITLE
Specify the wasm-pack version explicitly

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -197,6 +197,8 @@ jobs:
           cache: "npm"
           cache-dependency-path: playground/package-lock.json
       - uses: jetli/wasm-pack-action@v0.4.0
+        with:
+          version: v0.13.1
       - uses: Swatinem/rust-cache@v2
       - name: "Test ruff_wasm"
         run: |


### PR DESCRIPTION
There is an upstream bug with latest version detection https://github.com/jetli/wasm-pack-action/issues/23

This causes random flakes of the wasm build job.