### PR TITLE
Improve CI caching of fuzz dependencies

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -268,6 +268,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: "fuzz -> target"
+          cache-all-crates: "true"
       - name: "Install cargo-binstall"
         uses: cargo-bins/cargo-binstall@main
         with:


### PR DESCRIPTION
`cargo fuzz` does not appear to be using cached dependencies, and downloads and compiles everything, e.g., https://github.com/astral-sh/ruff/actions/runs/11923959306/job/33233394417

Presumably this is because the crates are not actually dependencies of this project, which the rust-cache action omits by default.