### PR TITLE
Only test release builds on main

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -213,7 +213,7 @@ jobs:
     name: "cargo build (release)"
     runs-on: macos-latest
     needs: determine_changes
-    if: ${{ needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/main' }}
+    if: ${{ github.ref == 'refs/heads/main' }}
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
This is one of the slowest remaining jobs in the pull request CI. We could use a larger runner for a trivial speed-up (in exchange for $$), but I don't think this is going to break often enough to merit testing on every pull request commit? It's not a required job, so I don't feel strongly about it, but it feels like a bit of a waste of compute.

Originally added in https://github.com/astral-sh/ruff/pull/11182