### PR TITLE
Watch for changes to the generated file during documentation serve

### DIFF
--- a/mkdocs.insiders.yml
+++ b/mkdocs.insiders.yml
@@ -1,1 +1,3 @@
 INHERIT: mkdocs.generated.yml
+watch:
+  - mkdocs.generated.yml

--- a/mkdocs.public.yml
+++ b/mkdocs.public.yml
@@ -2,3 +2,5 @@ INHERIT: mkdocs.generated.yml
 # Omit the `typeset` plugin which is only available in the Insiders version.
 plugins:
   - search
+watch:
+  - mkdocs.generated.yml


### PR DESCRIPTION
## Summary

Similar to https://github.com/astral-sh/uv/pull/9244, but we need to use the `mkdocs.generated.yml` file because the `scripts/generate_mkdocs.py` uses the `mkdocs.template.yml` to generate the final config.