### PR TITLE
Only build the `fuzz` crate on `main`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -257,11 +257,11 @@ jobs:
           NEXTEST_PROFILE: "ci"
         run: cargo +${{ steps.msrv.outputs.value }} insta test --all-features --unreferenced reject --test-runner nextest
 
-  cargo-fuzz:
-    name: "cargo fuzz"
+  cargo-fuzz-build:
+    name: "cargo fuzz build"
     runs-on: ubuntu-latest
     needs: determine_changes
-    if: ${{ needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/main' }}
+    if: ${{ github.ref == 'refs/heads/main' }}
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
It's not actually doing anything per pull request and it's pretty slow? xref #14469 

It seems useful to build on `main` still to find build regressions? e.g. https://github.com/astral-sh/ruff/issues/9368