### PR TITLE
Stabilize `A004`

### DIFF
--- a/crates/ruff_linter/src/checkers/ast/analyze/statement.rs
+++ b/crates/ruff_linter/src/checkers/ast/analyze/statement.rs
@@ -591,18 +591,7 @@ pub(crate) fn statement(stmt: &Stmt, checker: &mut Checker) {
                 if checker.enabled(Rule::NonAsciiImportName) {
                     pylint::rules::non_ascii_module_import(checker, alias);
                 }
-                // TODO(charlie): Remove when stabilizing A004.
-                if let Some(asname) = &alias.asname {
-                    if checker.settings.preview.is_disabled()
-                        && checker.enabled(Rule::BuiltinVariableShadowing)
-                    {
-                        flake8_builtins::rules::builtin_variable_shadowing(
-                            checker,
-                            asname,
-                            asname.range(),
-                        );
-                    }
-                }
+
                 if checker.enabled(Rule::Debugger) {
                     if let Some(diagnostic) =
                         flake8_debugger::rules::debugger_import(stmt, None, &alias.name)
@@ -911,19 +900,6 @@ pub(crate) fn statement(stmt: &Stmt, checker: &mut Checker) {
                             },
                             stmt.range(),
                         ));
-                    }
-                } else {
-                    // TODO(charlie): Remove when stabilizing A004.
-                    if let Some(asname) = &alias.asname {
-                        if checker.settings.preview.is_disabled()
-                            && checker.enabled(Rule::BuiltinVariableShadowing)
-                        {
-                            flake8_builtins::rules::builtin_variable_shadowing(
-                                checker,
-                                asname,
-                                asname.range(),
-                            );
-                        }
                     }
                 }
                 if checker.enabled(Rule::RelativeImports) {

--- a/crates/ruff_linter/src/codes.rs
+++ b/crates/ruff_linter/src/codes.rs
@@ -313,8 +313,7 @@ pub fn code_to_rule(linter: Linter, code: &str) -> Option<(RuleGroup, Rule)> {
         (Flake8Builtins, "001") => (RuleGroup::Stable, rules::flake8_builtins::rules::BuiltinVariableShadowing),
         (Flake8Builtins, "002") => (RuleGroup::Stable, rules::flake8_builtins::rules::BuiltinArgumentShadowing),
         (Flake8Builtins, "003") => (RuleGroup::Stable, rules::flake8_builtins::rules::BuiltinAttributeShadowing),
-        // TODO(charlie): When stabilizing, remove preview gating for A001's treatment of imports.
-        (Flake8Builtins, "004") => (RuleGroup::Preview, rules::flake8_builtins::rules::BuiltinImportShadowing),
+        (Flake8Builtins, "004") => (RuleGroup::Stable, rules::flake8_builtins::rules::BuiltinImportShadowing),
         (Flake8Builtins, "005") => (RuleGroup::Preview, rules::flake8_builtins::rules::BuiltinModuleShadowing),
         (Flake8Builtins, "006") => (RuleGroup::Preview, rules::flake8_builtins::rules::BuiltinLambdaArgumentShadowing),
 

--- a/crates/ruff_linter/src/rules/flake8_builtins/rules/builtin_import_shadowing.rs
+++ b/crates/ruff_linter/src/rules/flake8_builtins/rules/builtin_import_shadowing.rs
@@ -16,6 +16,27 @@ use crate::rules::flake8_builtins::helpers::shadows_builtin;
 /// Builtins can be marked as exceptions to this rule via the
 /// [`lint.flake8-builtins.builtins-ignorelist`] configuration option.
 ///
+/// ## Example
+/// ```python
+/// from rich import print
+///
+/// print("Some message")
+/// ```
+///
+/// Use instead:
+/// ```python
+/// from rich import print as rich_print
+///
+/// rich_print("Some message")
+/// ```
+///
+/// or:
+/// ```python
+/// import rich
+///
+/// rich.print("Some message")
+/// ```
+///
 /// ## Options
 /// - `lint.flake8-builtins.builtins-ignorelist`
 /// - `target-version`

--- a/crates/ruff_linter/src/rules/flake8_builtins/rules/builtin_import_shadowing.rs
+++ b/crates/ruff_linter/src/rules/flake8_builtins/rules/builtin_import_shadowing.rs
@@ -18,6 +18,8 @@ use crate::rules::flake8_builtins::helpers::shadows_builtin;
 ///
 /// ## Options
 /// - `lint.flake8-builtins.builtins-ignorelist`
+/// - `target-version`
+///
 #[violation]
 pub struct BuiltinImportShadowing {
     name: String,

--- a/crates/ruff_linter/src/rules/flake8_builtins/snapshots/ruff_linter__rules__flake8_builtins__tests__A001_A001.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_builtins/snapshots/ruff_linter__rules__flake8_builtins__tests__A001_A001.py.snap
@@ -2,32 +2,6 @@
 source: crates/ruff_linter/src/rules/flake8_builtins/mod.rs
 snapshot_kind: text
 ---
-A001.py:1:16: A001 Variable `sum` is shadowing a Python builtin
-  |
-1 | import some as sum
-  |                ^^^ A001
-2 | from some import other as int
-3 | from directory import new as dir
-  |
-
-A001.py:2:27: A001 Variable `int` is shadowing a Python builtin
-  |
-1 | import some as sum
-2 | from some import other as int
-  |                           ^^^ A001
-3 | from directory import new as dir
-  |
-
-A001.py:3:30: A001 Variable `dir` is shadowing a Python builtin
-  |
-1 | import some as sum
-2 | from some import other as int
-3 | from directory import new as dir
-  |                              ^^^ A001
-4 | 
-5 | print = 1
-  |
-
 A001.py:5:1: A001 Variable `print` is shadowing a Python builtin
   |
 3 | from directory import new as dir

--- a/crates/ruff_linter/src/rules/flake8_builtins/snapshots/ruff_linter__rules__flake8_builtins__tests__A001_A001.py_builtins_ignorelist.snap
+++ b/crates/ruff_linter/src/rules/flake8_builtins/snapshots/ruff_linter__rules__flake8_builtins__tests__A001_A001.py_builtins_ignorelist.snap
@@ -2,22 +2,6 @@
 source: crates/ruff_linter/src/rules/flake8_builtins/mod.rs
 snapshot_kind: text
 ---
-A001.py:1:16: A001 Variable `sum` is shadowing a Python builtin
-  |
-1 | import some as sum
-  |                ^^^ A001
-2 | from some import other as int
-3 | from directory import new as dir
-  |
-
-A001.py:2:27: A001 Variable `int` is shadowing a Python builtin
-  |
-1 | import some as sum
-2 | from some import other as int
-  |                           ^^^ A001
-3 | from directory import new as dir
-  |
-
 A001.py:5:1: A001 Variable `print` is shadowing a Python builtin
   |
 3 | from directory import new as dir


### PR DESCRIPTION
## Summary

Stabilize `A004`. 

Stabilizing `A004` requires a breaking change to `A001` (see https://github.com/astral-sh/ruff/pull/12546/)
Before, `A001` used to flag shadowed builtins for `import` and `from ... import` statements. 
Keep doing so now would overlap with `A004`. That's why this PR also stabilizes the behavior change to stop flaging `import` and `from ... import` builtin shadowing in `A001`. 

## Test Plan

I reviewed the test changes and verified that the no-longer flagged violations by `A001` are now flagged by `A004`
