### PR TITLE
Fix failing tests for Ruff 0.8 branch

### DIFF
--- a/crates/ruff_linter/src/rules/pycodestyle/mod.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/mod.rs
@@ -74,8 +74,6 @@ mod tests {
 
     #[test_case(Rule::ModuleImportNotAtTopOfFile, Path::new("E402_3.py"))]
     #[test_case(Rule::RedundantBackslash, Path::new("E502.py"))]
-    // E741 has different behaviour for `.pyi` files in preview mode
-    #[test_case(Rule::AmbiguousVariableName, Path::new("E741.pyi"))]
     #[test_case(Rule::TooManyNewlinesAtEndOfFile, Path::new("W391_0.py"))]
     #[test_case(Rule::TooManyNewlinesAtEndOfFile, Path::new("W391_1.py"))]
     #[test_case(Rule::TooManyNewlinesAtEndOfFile, Path::new("W391_2.py"))]


### PR DESCRIPTION
## Summary

This fixes the CI failures for the Ruff 0.8 branch.

The root cause is a "merge" conflict that git didn't detect:

* https://github.com/astral-sh/ruff/pull/14405 removed the `preview_rules` tests for `AmbiguousVariableName` (delete change)
* https://github.com/astral-sh/ruff/pull/14474 moved the `test_case` attribute for the `AmbigiousVariableName`. This resulted in a delete change (the same as above) but also an add


This PR removes the tests because the behavior has been promoted to stabel

## Test Plan

`cargo test`
