### PR TITLE
Revert "Use Depot 16-core runner for testing on Linux"

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -115,7 +115,7 @@ jobs:
 
   cargo-test-linux:
     name: "cargo test (linux)"
-    runs-on: depot-ubuntu-22.04-16
+    runs-on: ubuntu-latest
     needs: determine_changes
     if: ${{ needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/main' }}
     timeout-minutes: 20


### PR DESCRIPTION
Reverts astral-sh/ruff#14460

The Linux CI job has been queued for 20 minutes on https://github.com/astral-sh/ruff/pull/14383, and this is the obvious thing that's changed recently with respect to our Linux CI