### PR TITLE
[`pydoclint`] Extend `docstring-missing-exception` to empty exception descriptions (`DOC501`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pydoclint/DOC501_google.py
+++ b/crates/ruff_linter/resources/test/fixtures/pydoclint/DOC501_google.py
@@ -246,3 +246,23 @@ def foo():
         raise TypeError  # no DOC501 here because we already emitted a diagnostic for the earlier `raise TypeError`
     raise ValueError  # DOC501
     return 42
+
+
+# DOC501
+def calculate_speed(distance: float, time: float) -> float:
+    """Calculate speed as distance divided by time.
+
+    Args:
+        distance: Distance traveled.
+        time: Time spent traveling.
+
+    Returns:
+        Speed as distance divided by time.
+
+    Raises:
+        FasterThanLightError: 
+    """
+    try:
+        return distance / time
+    except ZeroDivisionError as exc:
+        raise FasterThanLightError from exc

--- a/crates/ruff_linter/resources/test/fixtures/pydoclint/DOC501_numpy.py
+++ b/crates/ruff_linter/resources/test/fixtures/pydoclint/DOC501_numpy.py
@@ -149,3 +149,100 @@ def foo():
         raise TypeError  # no DOC501 here because we already emitted a diagnostic for the earlier `raise TypeError`
     raise ValueError  # DOC501
     return 42
+
+
+
+# DOC501
+def calculate_speed(distance: float, time: float) -> float:
+    """
+    Calculate speed as distance divided by time.
+
+    Parameters
+    ----------
+    distance : float
+        Distance traveled.
+    time : float
+        Time spent traveling.
+
+    Returns
+    -------
+    float
+        Speed as distance divided by time.
+
+        Raises
+    ------
+    FasterThanLightError
+
+    """
+    try:
+        return distance / time
+    except ZeroDivisionError as exc:
+        raise FasterThanLightError from exc
+
+
+# DOC501
+def calculate_speed(distance: float, time: float) -> float:
+    """Calculate speed as distance divided by time.
+
+    ACalculate speed as distance divided by time.
+
+    Parameters
+    ----------
+    distance : float
+        Distance traveled.
+    time : float
+        Time spent traveling.
+
+    Returns
+    -------
+    float
+        Speed as distance divided by time.
+
+    Raises
+    ------
+    ZeroDivisionError
+    TypeError
+        Some type error
+    """
+    try:
+        return distance / time
+    except ZeroDivisionError:
+        print("Oh no, why would you divide something by zero?")
+        raise
+    except TypeError:
+        print("Not a number? Shame on you!")
+        raise
+
+
+# DOC501
+def calculate_speed(distance: float, time: float) -> float:
+    """Calculate speed as distance divided by time.
+
+    ACalculate speed as distance divided by time.
+
+    Parameters
+    ----------
+    distance : float
+        Distance traveled.
+    time : float
+        Time spent traveling.
+
+    Returns
+    -------
+    float
+        Speed as distance divided by time.
+
+    Raises
+    ------
+    ZeroDivisionError
+        If attempting to divide by zero.
+    TypeError
+    """
+    try:
+        return distance / time
+    except ZeroDivisionError:
+        print("Oh no, why would you divide something by zero?")
+        raise
+    except TypeError:
+        print("Not a number? Shame on you!")
+        raise

--- a/crates/ruff_linter/src/rules/pydoclint/snapshots/ruff_linter__rules__pydoclint__tests__docstring-extraneous-exception_DOC502_numpy.py.snap
+++ b/crates/ruff_linter/src/rules/pydoclint/snapshots/ruff_linter__rules__pydoclint__tests__docstring-extraneous-exception_DOC502_numpy.py.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/ruff_linter/src/rules/pydoclint/mod.rs
-snapshot_kind: text
 ---
 DOC502_numpy.py:7:5: DOC502 Raised exception is not explicitly raised: `FasterThanLightError`
    |

--- a/crates/ruff_linter/src/rules/pydoclint/snapshots/ruff_linter__rules__pydoclint__tests__docstring-missing-exception_DOC501_google.py.snap
+++ b/crates/ruff_linter/src/rules/pydoclint/snapshots/ruff_linter__rules__pydoclint__tests__docstring-missing-exception_DOC501_google.py.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/ruff_linter/src/rules/pydoclint/mod.rs
-snapshot_kind: text
 ---
 DOC501_google.py:34:5: DOC501 Raised exception `FasterThanLightError` missing from docstring
    |
@@ -167,3 +166,26 @@ DOC501_google.py:238:5: DOC501 Raised exception `ValueError` missing from docstr
 244 |           raise TypeError  # DOC501
     |
     = help: Add `ValueError` to the docstring
+
+DOC501_google.py:253:5: DOC501 Raised exception `FasterThanLightError` missing from docstring
+    |
+251 |   # DOC501
+252 |   def calculate_speed(distance: float, time: float) -> float:
+253 |       """Calculate speed as distance divided by time.
+    |  _____^
+254 | | 
+255 | |     Args:
+256 | |         distance: Distance traveled.
+257 | |         time: Time spent traveling.
+258 | | 
+259 | |     Returns:
+260 | |         Speed as distance divided by time.
+261 | | 
+262 | |     Raises:
+263 | |         FasterThanLightError: 
+264 | |     """
+    | |_______^ DOC501
+265 |       try:
+266 |           return distance / time
+    |
+    = help: Add `FasterThanLightError` to the docstring

--- a/crates/ruff_linter/src/rules/pydoclint/snapshots/ruff_linter__rules__pydoclint__tests__docstring-missing-exception_DOC501_numpy.py.snap
+++ b/crates/ruff_linter/src/rules/pydoclint/snapshots/ruff_linter__rules__pydoclint__tests__docstring-missing-exception_DOC501_numpy.py.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/ruff_linter/src/rules/pydoclint/mod.rs
-snapshot_kind: text
 ---
 DOC501_numpy.py:35:5: DOC501 Raised exception `FasterThanLightError` missing from docstring
    |
@@ -145,3 +144,100 @@ DOC501_numpy.py:139:5: DOC501 Raised exception `ValueError` missing from docstri
 147 |           raise TypeError  # DOC501
     |
     = help: Add `ValueError` to the docstring
+
+DOC501_numpy.py:157:5: DOC501 Raised exception `FasterThanLightError` missing from docstring
+    |
+155 |   # DOC501
+156 |   def calculate_speed(distance: float, time: float) -> float:
+157 |       """
+    |  _____^
+158 | |     Calculate speed as distance divided by time.
+159 | | 
+160 | |     Parameters
+161 | |     ----------
+162 | |     distance : float
+163 | |         Distance traveled.
+164 | |     time : float
+165 | |         Time spent traveling.
+166 | | 
+167 | |     Returns
+168 | |     -------
+169 | |     float
+170 | |         Speed as distance divided by time.
+171 | | 
+172 | |         Raises
+173 | |     ------
+174 | |     FasterThanLightError
+175 | | 
+176 | |     """
+    | |_______^ DOC501
+177 |       try:
+178 |           return distance / time
+    |
+    = help: Add `FasterThanLightError` to the docstring
+
+DOC501_numpy.py:185:5: DOC501 Raised exception `ZeroDivisionError` missing from docstring
+    |
+183 |   # DOC501
+184 |   def calculate_speed(distance: float, time: float) -> float:
+185 |       """Calculate speed as distance divided by time.
+    |  _____^
+186 | | 
+187 | |     ACalculate speed as distance divided by time.
+188 | | 
+189 | |     Parameters
+190 | |     ----------
+191 | |     distance : float
+192 | |         Distance traveled.
+193 | |     time : float
+194 | |         Time spent traveling.
+195 | | 
+196 | |     Returns
+197 | |     -------
+198 | |     float
+199 | |         Speed as distance divided by time.
+200 | | 
+201 | |     Raises
+202 | |     ------
+203 | |     ZeroDivisionError
+204 | |     TypeError
+205 | |         Some type error
+206 | |     """
+    | |_______^ DOC501
+207 |       try:
+208 |           return distance / time
+    |
+    = help: Add `ZeroDivisionError` to the docstring
+
+DOC501_numpy.py:219:5: DOC501 Raised exception `TypeError` missing from docstring
+    |
+217 |   # DOC501
+218 |   def calculate_speed(distance: float, time: float) -> float:
+219 |       """Calculate speed as distance divided by time.
+    |  _____^
+220 | | 
+221 | |     ACalculate speed as distance divided by time.
+222 | | 
+223 | |     Parameters
+224 | |     ----------
+225 | |     distance : float
+226 | |         Distance traveled.
+227 | |     time : float
+228 | |         Time spent traveling.
+229 | | 
+230 | |     Returns
+231 | |     -------
+232 | |     float
+233 | |         Speed as distance divided by time.
+234 | | 
+235 | |     Raises
+236 | |     ------
+237 | |     ZeroDivisionError
+238 | |         If attempting to divide by zero.
+239 | |     TypeError
+240 | |     """
+    | |_______^ DOC501
+241 |       try:
+242 |           return distance / time
+    |
+    = help: Add `TypeError` to the docstring


### PR DESCRIPTION


<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Resolves #14494.

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

<!-- How was it tested? -->

`cargo test`. Awaiting ecosystem checks.
