### PR TITLE
[red-knot] support `typing.Union` in type annotations

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/annotations/union.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/annotations/union.md
@@ -13,6 +13,7 @@ a2: Union[int, Union[float, str]]
 a3: Union[int, None]
 a4: Union[Union[float, str]]
 a5: Union[int]
+a6: Union[()]
 
 def f():
     # revealed: int | str
@@ -28,6 +29,8 @@ def f():
     reveal_type(a4)
     # revealed: int
     reveal_type(a5)
+    # revealed: Never
+    reveal_type(a6)
 ```
 
 ## Assignment

--- a/crates/red_knot_python_semantic/resources/mdtest/annotations/union.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/annotations/union.md
@@ -12,6 +12,7 @@ a1: Union[int, bool]
 a2: Union[int, Union[float, str]]
 a3: Union[int, None]
 a4: Union[Union[float, str]]
+a5: Union[int]
 
 def f():
     # revealed: int | str
@@ -25,6 +26,8 @@ def f():
     reveal_type(a3)
     # revealed: float | str
     reveal_type(a4)
+    # revealed: int
+    reveal_type(a5)
 ```
 
 ## Assignment
@@ -38,7 +41,7 @@ a = ""
 a1: Union[int, bool]
 a1 = 1
 a1 = True
-# error: [invalid-assignment] "Object of type `bytes` is not assignable to `int | str`"
+# error: [invalid-assignment] "Object of type `Literal[b""]` is not assignable to `int | str`"
 a = b""
 ```
 

--- a/crates/red_knot_python_semantic/resources/mdtest/annotations/union.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/annotations/union.md
@@ -17,8 +17,6 @@ def f():
     # revealed: int | str
     reveal_type(a)
     # Since bool is a subtype of int we merge both types to int here. But we do allow assigning boolean value
-    # TODO: Pyright and Mypy do show this as `int | bool`: https://pyright-play.net/?code=GYJw9gtgBALgngBwJYDsDmUkQWEMoCqKSYKAUGQIYBchxpA2qjADRQBGYYANgLoUATAKbAowABQBKamShyoIIQDchlbgH14CIeMqSgA
-    # Also mypy: https://mypy-play.net/?mypy=latest&python=3.12&gist=fd3c1609080ddc000d5247552c15b750
     # revealed: int
     reveal_type(a1)
     # revealed: int | float | str

--- a/crates/red_knot_python_semantic/resources/mdtest/annotations/union.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/annotations/union.md
@@ -11,6 +11,7 @@ a: Union[int, str]
 a1: Union[int, bool]
 a2: Union[int, Union[float, str]]
 a3: Union[int, None]
+a4: Union[Union[float, str]]
 
 def f():
     # revealed: int | str
@@ -24,6 +25,8 @@ def f():
     reveal_type(a2)
     # revealed: int | None
     reveal_type(a3)
+    # revealed: float | str
+    reveal_type(a4)
 ```
 
 ## Assignment

--- a/crates/red_knot_python_semantic/resources/mdtest/annotations/union.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/annotations/union.md
@@ -38,9 +38,8 @@ a = ""
 a1: Union[int, bool]
 a1 = 1
 a1 = True
-a2: int
-# error: [invalid-assignment] "Object of type `Literal[""]` is not assignable to `int`"
-a2 = a
+# error: [invalid-assignment] "Object of type `bytes` is not assignable to `int | str`"
+a = b""
 ```
 
 ## Typing Extensions

--- a/crates/red_knot_python_semantic/resources/mdtest/annotations/union.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/annotations/union.md
@@ -17,7 +17,7 @@ a5: Union[int]
 def f():
     # revealed: int | str
     reveal_type(a)
-    # Since bool is a subtype of int we merge both types to int here. But we do allow assigning boolean value
+    # Since bool is a subtype of int we simplify to int here. But we do allow assigning boolean values (see below).
     # revealed: int
     reveal_type(a1)
     # revealed: int | float | str

--- a/crates/red_knot_python_semantic/resources/mdtest/annotations/union.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/annotations/union.md
@@ -1,0 +1,55 @@
+# Union
+
+## Annotation
+
+`typing.Union` can be used to construct union types same as `|` operator.
+
+```py
+from typing import Union
+
+a: Union[int, str]
+a1: Union[int, bool]
+a2: Union[int, Union[float, str]]
+a3: Union[int, None]
+
+def f():
+    # revealed: int | str
+    reveal_type(a)
+    # Since bool is a subtype of int we merge both types to int here. But we do allow assigning boolean value
+    # TODO: Pyright and Mypy do show this as `int | bool`: https://pyright-play.net/?code=GYJw9gtgBALgngBwJYDsDmUkQWEMoCqKSYKAUGQIYBchxpA2qjADRQBGYYANgLoUATAKbAowABQBKamShyoIIQDchlbgH14CIeMqSgA
+    # Also mypy: https://mypy-play.net/?mypy=latest&python=3.12&gist=fd3c1609080ddc000d5247552c15b750
+    # revealed: int
+    reveal_type(a1)
+    # revealed: int | float | str
+    reveal_type(a2)
+    # revealed: int | None
+    reveal_type(a3)
+```
+
+## Assignment
+
+```py
+from typing import Union
+
+a: Union[int, str]
+a = 1
+a = ""
+a1: Union[int, bool]
+a1 = 1
+a1 = True
+a2: int
+# error: [invalid-assignment] "Object of type `Literal[""]` is not assignable to `int`"
+a2 = a
+```
+
+## Typing Extensions
+
+```py
+from typing_extensions import Union
+
+a: Union[int, str]
+
+def f():
+    # revealed: int | str
+    reveal_type(a)
+```

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -1809,6 +1809,8 @@ pub enum KnownInstanceType<'db> {
     Literal,
     /// The symbol `typing.Optional` (which can also be found as `typing_extensions.Optional`)
     Optional,
+    /// The symbol `typing.Union` (which can also be found as `typing_extensions.Literal`)
+    Union,
     /// A single instance of `typing.TypeVar`
     TypeVar(TypeVarInstance<'db>),
     // TODO: fill this enum out with more special forms, etc.
@@ -1819,6 +1821,7 @@ impl<'db> KnownInstanceType<'db> {
         match self {
             KnownInstanceType::Literal => "Literal",
             KnownInstanceType::Optional => "Optional",
+            KnownInstanceType::Union => "Union",
             KnownInstanceType::TypeVar(_) => "TypeVar",
         }
     }
@@ -1826,7 +1829,9 @@ impl<'db> KnownInstanceType<'db> {
     /// Evaluate the known instance in boolean context
     pub const fn bool(self) -> Truthiness {
         match self {
-            Self::Literal | Self::Optional | Self::TypeVar(_) => Truthiness::AlwaysTrue,
+            Self::Literal | Self::Optional | Self::TypeVar(_) | Self::Union => {
+                Truthiness::AlwaysTrue
+            }
         }
     }
 
@@ -1835,6 +1840,7 @@ impl<'db> KnownInstanceType<'db> {
         match self {
             Self::Literal => "typing.Literal",
             Self::Optional => "typing.Optional",
+            Self::Union => "typing.Union",
             Self::TypeVar(typevar) => typevar.name(db),
         }
     }
@@ -1844,6 +1850,7 @@ impl<'db> KnownInstanceType<'db> {
         match self {
             Self::Literal => KnownClass::SpecialForm,
             Self::Optional => KnownClass::SpecialForm,
+            Self::Union => KnownClass::SpecialForm,
             Self::TypeVar(_) => KnownClass::TypeVar,
         }
     }
@@ -1864,6 +1871,7 @@ impl<'db> KnownInstanceType<'db> {
         match (module.name().as_str(), instance_name) {
             ("typing" | "typing_extensions", "Literal") => Some(Self::Literal),
             ("typing" | "typing_extensions", "Optional") => Some(Self::Optional),
+            ("typing" | "typing_extensions", "Union") => Some(Self::Union),
             _ => None,
         }
     }

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -1809,7 +1809,7 @@ pub enum KnownInstanceType<'db> {
     Literal,
     /// The symbol `typing.Optional` (which can also be found as `typing_extensions.Optional`)
     Optional,
-    /// The symbol `typing.Union` (which can also be found as `typing_extensions.Literal`)
+    /// The symbol `typing.Union` (which can also be found as `typing_extensions.Union`)
     Union,
     /// A single instance of `typing.TypeVar`
     TypeVar(TypeVarInstance<'db>),

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -4570,7 +4570,7 @@ impl<'db> TypeInferenceBuilder<'db> {
             KnownInstanceType::Union => match parameters {
                 ast::Expr::Tuple(t) => UnionType::from_elements(
                     self.db,
-                    t.elts.iter().map(|elt| self.infer_type_expression(elt)),
+                    t.iter().map(|elt| self.infer_type_expression(elt)),
                 ),
                 _ => self.infer_type_expression(parameters),
             },

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -4567,20 +4567,13 @@ impl<'db> TypeInferenceBuilder<'db> {
                 let param_type = self.infer_type_expression(parameters);
                 UnionType::from_elements(self.db, [param_type, Type::none(self.db)])
             }
-            KnownInstanceType::Union => {
-                let mut builder = UnionBuilder::new(self.db);
-                match parameters {
-                    ast::Expr::Tuple(t) => {
-                        builder = t
-                            .elts
-                            .iter()
-                            .map(|elt| self.infer_type_expression(elt))
-                            .fold(builder, super::builder::UnionBuilder::add);
-                        builder.build()
-                    }
-                    _ => self.infer_type_expression(parameters),
-                }
-            }
+            KnownInstanceType::Union => match parameters {
+                ast::Expr::Tuple(t) => UnionType::from_elements(
+                    self.db,
+                    t.elts.iter().map(|elt| self.infer_type_expression(elt)),
+                ),
+                _ => self.infer_type_expression(parameters),
+            },
             KnownInstanceType::TypeVar(_) => Type::Todo,
         }
     }

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -4570,19 +4570,18 @@ impl<'db> TypeInferenceBuilder<'db> {
             KnownInstanceType::Union => {
                 let mut builder = UnionBuilder::new(self.db);
                 match parameters {
-                    ast::Expr::Name(_) => {
-                        builder = builder.add(self.infer_type_expression(parameters));
-                    }
                     ast::Expr::Tuple(t) => {
                         builder = t
                             .elts
                             .iter()
                             .map(|elt| self.infer_type_expression(elt))
                             .fold(builder, super::builder::UnionBuilder::add);
+                        builder.build()
                     }
-                    _ => {}
+                    _ => {
+                        UnionType::from_elements(self.db, [self.infer_type_expression(parameters)])
+                    }
                 }
-                builder.build()
             }
             KnownInstanceType::TypeVar(_) => Type::Todo,
         }

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -4578,9 +4578,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                             .fold(builder, super::builder::UnionBuilder::add);
                         builder.build()
                     }
-                    _ => {
-                        UnionType::from_elements(self.db, [self.infer_type_expression(parameters)])
-                    }
+                    _ => self.infer_type_expression(parameters),
                 }
             }
             KnownInstanceType::TypeVar(_) => Type::Todo,

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -4567,6 +4567,29 @@ impl<'db> TypeInferenceBuilder<'db> {
                 let param_type = self.infer_type_expression(parameters);
                 UnionType::from_elements(self.db, [param_type, Type::none(self.db)])
             }
+            KnownInstanceType::Union => {
+                let mut builder = UnionBuilder::new(self.db);
+                match parameters {
+                    ast::Expr::Name(_) => {
+                        builder =
+                            builder.add(self.infer_annotation_expression(
+                                parameters,
+                                DeferredExpressionState::None,
+                            ))
+                    }
+                    ast::Expr::Tuple(t) => {
+                        for elt in t.elts.iter() {
+                            builder =
+                                builder.add(self.infer_annotation_expression(
+                                    &elt,
+                                    DeferredExpressionState::None,
+                                ))
+                        }
+                    }
+                    _ => {}
+                }
+                builder.build()
+            }
             KnownInstanceType::TypeVar(_) => Type::Todo,
         }
     }

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -4571,14 +4571,14 @@ impl<'db> TypeInferenceBuilder<'db> {
                 let mut builder = UnionBuilder::new(self.db);
                 match parameters {
                     ast::Expr::Name(_) => {
-                        builder = builder.add(self.infer_type_expression(parameters))
+                        builder = builder.add(self.infer_type_expression(parameters));
                     }
                     ast::Expr::Tuple(t) => {
                         builder = t
                             .elts
                             .iter()
                             .map(|elt| self.infer_type_expression(elt))
-                            .fold(builder, |builder, ty| builder.add(ty));
+                            .fold(builder, super::builder::UnionBuilder::add);
                     }
                     _ => {}
                 }

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -4571,20 +4571,14 @@ impl<'db> TypeInferenceBuilder<'db> {
                 let mut builder = UnionBuilder::new(self.db);
                 match parameters {
                     ast::Expr::Name(_) => {
-                        builder =
-                            builder.add(self.infer_annotation_expression(
-                                parameters,
-                                DeferredExpressionState::None,
-                            ))
+                        builder = builder.add(self.infer_type_expression(parameters))
                     }
                     ast::Expr::Tuple(t) => {
-                        for elt in t.elts.iter() {
-                            builder =
-                                builder.add(self.infer_annotation_expression(
-                                    &elt,
-                                    DeferredExpressionState::None,
-                                ))
-                        }
+                        builder = t
+                            .elts
+                            .iter()
+                            .map(|elt| self.infer_type_expression(elt))
+                            .fold(builder, |builder, ty| builder.add(ty));
                     }
                     _ => {}
                 }

--- a/crates/red_knot_python_semantic/src/types/mro.rs
+++ b/crates/red_knot_python_semantic/src/types/mro.rs
@@ -373,6 +373,7 @@ impl<'db> ClassBase<'db> {
             Type::KnownInstance(known_instance) => match known_instance {
                 KnownInstanceType::TypeVar(_)
                 | KnownInstanceType::Literal
+                | KnownInstanceType::Union
                 | KnownInstanceType::Optional => None,
             },
         }


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

Fix #14498

## Summary

This PR adds `typing.Union` support

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

<!-- How was it tested? -->

I created new tests in mdtest.
