### PR TITLE
[red-knot] Meta data for `Type::Todo`

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/annotations/starred.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/annotations/starred.md
@@ -9,10 +9,10 @@ Ts = TypeVarTuple("Ts")
 
 def append_int(*args: *Ts) -> tuple[*Ts, int]:
     # TODO: should show some representation of the variadic generic type
-    reveal_type(args)  # revealed: @Todo
+    reveal_type(args)  # revealed: @Todo(function parameter type)
 
     return (*args, 1)
 
 # TODO should be tuple[Literal[True], Literal["a"], int]
-reveal_type(append_int(True, "a"))  # revealed: @Todo
+reveal_type(append_int(True, "a"))  # revealed: @Todo(full tuple[...] support)
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/assignment/annotations.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/assignment/annotations.md
@@ -51,12 +51,12 @@ reveal_type(c)  # revealed: tuple[str, int]
 reveal_type(d)  # revealed: tuple[tuple[str, str], tuple[int, int]]
 
 # TODO: homogenous tuples, PEP-646 tuples
-reveal_type(e)  # revealed: @Todo
-reveal_type(f)  # revealed: @Todo
-reveal_type(g)  # revealed: @Todo
+reveal_type(e)  # revealed: @Todo(full tuple[...] support)
+reveal_type(f)  # revealed: @Todo(full tuple[...] support)
+reveal_type(g)  # revealed: @Todo(full tuple[...] support)
 
 # TODO: support more kinds of type expressions in annotations
-reveal_type(h)  # revealed: @Todo
+reveal_type(h)  # revealed: @Todo(full tuple[...] support)
 
 reveal_type(i)  # revealed: tuple[str | int, str | int]
 reveal_type(j)  # revealed: tuple[str | int]

--- a/crates/red_knot_python_semantic/resources/mdtest/binary/instances.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/binary/instances.md
@@ -317,7 +317,7 @@ reveal_type(1 + A())  # revealed: int
 reveal_type(A() + "foo")  # revealed: A
 # TODO should be `A` since `str.__add__` doesn't support `A` instances
 # TODO overloads
-reveal_type("foo" + A())  # revealed: @Todo
+reveal_type("foo" + A())  # revealed: @Todo(return type)
 
 reveal_type(A() + b"foo")  # revealed: A
 # TODO should be `A` since `bytes.__add__` doesn't support `A` instances
@@ -325,7 +325,7 @@ reveal_type(b"foo" + A())  # revealed: bytes
 
 reveal_type(A() + ())  # revealed: A
 # TODO this should be `A`, since `tuple.__add__` doesn't support `A` instances
-reveal_type(() + A())  # revealed: @Todo
+reveal_type(() + A())  # revealed: @Todo(return type)
 
 literal_string_instance = "foo" * 1_000_000_000
 # the test is not testing what it's meant to be testing if this isn't a `LiteralString`:
@@ -334,7 +334,7 @@ reveal_type(literal_string_instance)  # revealed: LiteralString
 reveal_type(A() + literal_string_instance)  # revealed: A
 # TODO should be `A` since `str.__add__` doesn't support `A` instances
 # TODO overloads
-reveal_type(literal_string_instance + A())  # revealed: @Todo
+reveal_type(literal_string_instance + A())  # revealed: @Todo(return type)
 ```
 
 ## Operations involving instances of classes inheriting from `Any`

--- a/crates/red_knot_python_semantic/resources/mdtest/call/function.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/call/function.md
@@ -16,7 +16,7 @@ async def get_int_async() -> int:
     return 42
 
 # TODO: we don't yet support `types.CoroutineType`, should be generic `Coroutine[Any, Any, int]`
-reveal_type(get_int_async())  # revealed: @Todo
+reveal_type(get_int_async())  # revealed: @Todo(generic types.CoroutineType)
 ```
 
 ## Generic
@@ -44,7 +44,7 @@ def bar() -> str:
     return "bar"
 
 # TODO: should reveal `int`, as the decorator replaces `bar` with `foo`
-reveal_type(bar())  # revealed: @Todo
+reveal_type(bar())  # revealed: @Todo(return type)
 ```
 
 ## Invalid callable

--- a/crates/red_knot_python_semantic/resources/mdtest/exception/basic.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/exception/basic.md
@@ -50,11 +50,11 @@ def foo(
         help()
     except x as e:
         # TODO: should be `AttributeError`
-        reveal_type(e)  # revealed: @Todo
+        reveal_type(e)  # revealed: @Todo(exception type)
     except y as f:
         # TODO: should be `OSError | RuntimeError`
-        reveal_type(f)  # revealed: @Todo
+        reveal_type(f)  # revealed: @Todo(exception type)
     except z as g:
         # TODO: should be `BaseException`
-        reveal_type(g)  # revealed: @Todo
+        reveal_type(g)  # revealed: @Todo(exception type)
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/generics.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/generics.md
@@ -18,7 +18,7 @@ box: MyBox[int] = MyBox(5)
 wrong_innards: MyBox[int] = MyBox("five")
 
 # TODO reveal int
-reveal_type(box.data)  # revealed: @Todo
+reveal_type(box.data)  # revealed: @Todo(instance attributes)
 
 reveal_type(MyBox.box_model_number)  # revealed: Literal[695]
 ```
@@ -39,7 +39,7 @@ class MySecureBox[T](MyBox[T]): ...
 secure_box: MySecureBox[int] = MySecureBox(5)
 reveal_type(secure_box)  # revealed: MySecureBox
 # TODO reveal int
-reveal_type(secure_box.data)  # revealed: @Todo
+reveal_type(secure_box.data)  # revealed: @Todo(instance attributes)
 ```
 
 ## Cyclical class definition

--- a/crates/red_knot_python_semantic/resources/mdtest/literal/literal.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/literal/literal.md
@@ -78,7 +78,7 @@ from other import Literal
 a1: Literal[26]
 
 def f():
-    reveal_type(a1)  # revealed: @Todo
+    reveal_type(a1)  # revealed: @Todo(generics)
 ```
 
 ## Detecting typing_extensions.Literal

--- a/crates/red_knot_python_semantic/resources/mdtest/loops/async_for.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/loops/async_for.md
@@ -18,7 +18,7 @@ async def foo():
         pass
 
     # TODO: should reveal `Unknown` because `__aiter__` is not defined
-    # revealed: @Todo
+    # revealed: @Todo(async iterables/iterators)
     # error: [possibly-unresolved-reference]
     reveal_type(x)
 ```
@@ -40,6 +40,6 @@ async def foo():
         pass
 
     # error: [possibly-unresolved-reference]
-    # revealed: @Todo
+    # revealed: @Todo(async iterables/iterators)
     reveal_type(x)
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/metaclass.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/metaclass.md
@@ -171,7 +171,7 @@ def f(*args, **kwargs) -> int: ...
 class A(metaclass=f): ...
 
 # TODO should be `type[int]`
-reveal_type(A.__class__)  # revealed: @Todo
+reveal_type(A.__class__)  # revealed: @Todo(metaclass not a class)
 ```
 
 ## Cyclic

--- a/crates/red_knot_python_semantic/resources/mdtest/scopes/moduletype_attrs.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/scopes/moduletype_attrs.md
@@ -17,8 +17,7 @@ reveal_type(__doc__)  # revealed: str | None
 # (needs support for `*` imports)
 reveal_type(__spec__)  # revealed: Unknown | None
 
-# TODO: generics
-reveal_type(__path__)  # revealed: @Todo
+reveal_type(__path__)  # revealed: @Todo(generics)
 
 class X:
     reveal_type(__name__)  # revealed: str
@@ -64,7 +63,7 @@ reveal_type(typing.__class__)  # revealed: Literal[type]
 
 # TODO: needs support for attribute access on instances, properties and generics;
 # should be `dict[str, Any]`
-reveal_type(typing.__dict__)  # revealed: @Todo
+reveal_type(typing.__dict__)  # revealed: @Todo(instance attributes)
 ```
 
 Typeshed includes a fake `__getattr__` method in the stub for `types.ModuleType` to help out with
@@ -96,8 +95,8 @@ from foo import __dict__ as foo_dict
 
 # TODO: needs support for attribute access on instances, properties, and generics;
 # should be `dict[str, Any]` for both of these:
-reveal_type(foo.__dict__)  # revealed: @Todo
-reveal_type(foo_dict)  # revealed: @Todo
+reveal_type(foo.__dict__)  # revealed: @Todo(instance attributes)
+reveal_type(foo_dict)  # revealed: @Todo(instance attributes)
 ```
 
 ## Conditionally global or `ModuleType` attribute

--- a/crates/red_knot_python_semantic/resources/mdtest/subscript/bytes.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/subscript/bytes.md
@@ -27,7 +27,7 @@ def int_instance() -> int:
 
 a = b"abcde"[int_instance()]
 # TODO: Support overloads... Should be `bytes`
-reveal_type(a)  # revealed: @Todo
+reveal_type(a)  # revealed: @Todo(return type)
 ```
 
 ## Slices
@@ -47,11 +47,11 @@ def int_instance() -> int: ...
 
 byte_slice1 = b[int_instance() : int_instance()]
 # TODO: Support overloads... Should be `bytes`
-reveal_type(byte_slice1)  # revealed: @Todo
+reveal_type(byte_slice1)  # revealed: @Todo(return type)
 
 def bytes_instance() -> bytes: ...
 
 byte_slice2 = bytes_instance()[0:5]
 # TODO: Support overloads... Should be `bytes`
-reveal_type(byte_slice2)  # revealed: @Todo
+reveal_type(byte_slice2)  # revealed: @Todo(return type)
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/subscript/lists.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/subscript/lists.md
@@ -12,13 +12,13 @@ x = [1, 2, 3]
 reveal_type(x)  # revealed: list
 
 # TODO reveal int
-reveal_type(x[0])  # revealed: @Todo
+reveal_type(x[0])  # revealed: @Todo(return type)
 
 # TODO reveal list
-reveal_type(x[0:1])  # revealed: @Todo
+reveal_type(x[0:1])  # revealed: @Todo(return type)
 
 # TODO error
-reveal_type(x["a"])  # revealed: @Todo
+reveal_type(x["a"])  # revealed: @Todo(return type)
 ```
 
 ## Assignments within list assignment

--- a/crates/red_knot_python_semantic/resources/mdtest/subscript/string.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/subscript/string.md
@@ -23,7 +23,7 @@ def int_instance() -> int: ...
 
 a = "abcde"[int_instance()]
 # TODO: Support overloads... Should be `str`
-reveal_type(a)  # revealed: @Todo
+reveal_type(a)  # revealed: @Todo(return type)
 ```
 
 ## Slices
@@ -78,13 +78,13 @@ def int_instance() -> int: ...
 
 substring1 = s[int_instance() : int_instance()]
 # TODO: Support overloads... Should be `LiteralString`
-reveal_type(substring1)  # revealed: @Todo
+reveal_type(substring1)  # revealed: @Todo(return type)
 
 def str_instance() -> str: ...
 
 substring2 = str_instance()[0:5]
 # TODO: Support overloads... Should be `str`
-reveal_type(substring2)  # revealed: @Todo
+reveal_type(substring2)  # revealed: @Todo(return type)
 ```
 
 ## Unsupported slice types

--- a/crates/red_knot_python_semantic/resources/mdtest/subscript/tuple.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/subscript/tuple.md
@@ -71,5 +71,5 @@ def int_instance() -> int: ...
 
 tuple_slice = t[int_instance() : int_instance()]
 # TODO: Support overloads... Should be `tuple[Literal[1, 'a', b"b"] | None, ...]`
-reveal_type(tuple_slice)  # revealed: @Todo
+reveal_type(tuple_slice)  # revealed: @Todo(return type)
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/sys_version_info.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/sys_version_info.md
@@ -112,9 +112,9 @@ properties on instance types:
 ```py path=b.py
 import sys
 
-reveal_type(sys.version_info.micro)  # revealed: @Todo
-reveal_type(sys.version_info.releaselevel)  # revealed: @Todo
-reveal_type(sys.version_info.serial)  # revealed: @Todo
+reveal_type(sys.version_info.micro)  # revealed: @Todo(instance attributes)
+reveal_type(sys.version_info.releaselevel)  # revealed: @Todo(instance attributes)
+reveal_type(sys.version_info.serial)  # revealed: @Todo(instance attributes)
 ```
 
 ## Accessing fields by index/slice

--- a/crates/red_knot_python_semantic/resources/mdtest/unpacking.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/unpacking.md
@@ -84,7 +84,7 @@ reveal_type(b)  # revealed: Literal[2]
 [a, *b, c, d] = (1, 2)
 reveal_type(a)  # revealed: Literal[1]
 # TODO: Should be list[Any] once support for assigning to starred expression is added
-reveal_type(b)  # revealed: @Todo
+reveal_type(b)  # revealed: @Todo(starred unpacking)
 reveal_type(c)  # revealed: Literal[2]
 reveal_type(d)  # revealed: Unknown
 ```
@@ -95,7 +95,7 @@ reveal_type(d)  # revealed: Unknown
 [a, *b, c] = (1, 2)
 reveal_type(a)  # revealed: Literal[1]
 # TODO: Should be list[Any] once support for assigning to starred expression is added
-reveal_type(b)  # revealed: @Todo
+reveal_type(b)  # revealed: @Todo(starred unpacking)
 reveal_type(c)  # revealed: Literal[2]
 ```
 
@@ -105,7 +105,7 @@ reveal_type(c)  # revealed: Literal[2]
 [a, *b, c] = (1, 2, 3)
 reveal_type(a)  # revealed: Literal[1]
 # TODO: Should be list[int] once support for assigning to starred expression is added
-reveal_type(b)  # revealed: @Todo
+reveal_type(b)  # revealed: @Todo(starred unpacking)
 reveal_type(c)  # revealed: Literal[3]
 ```
 
@@ -115,7 +115,7 @@ reveal_type(c)  # revealed: Literal[3]
 [a, *b, c, d] = (1, 2, 3, 4, 5, 6)
 reveal_type(a)  # revealed: Literal[1]
 # TODO: Should be list[int] once support for assigning to starred expression is added
-reveal_type(b)  # revealed: @Todo
+reveal_type(b)  # revealed: @Todo(starred unpacking)
 reveal_type(c)  # revealed: Literal[5]
 reveal_type(d)  # revealed: Literal[6]
 ```
@@ -127,7 +127,7 @@ reveal_type(d)  # revealed: Literal[6]
 reveal_type(a)  # revealed: Literal[1]
 reveal_type(b)  # revealed: Literal[2]
 # TODO: Should be list[int] once support for assigning to starred expression is added
-reveal_type(c)  # revealed: @Todo
+reveal_type(c)  # revealed: @Todo(starred unpacking)
 ```
 
 ### Starred expression (6)
@@ -138,7 +138,7 @@ reveal_type(c)  # revealed: @Todo
 reveal_type(a)  # revealed: Literal[1]
 reveal_type(b)  # revealed: Unknown
 reveal_type(c)  # revealed: Unknown
-reveal_type(d)  # revealed: @Todo
+reveal_type(d)  # revealed: @Todo(starred unpacking)
 reveal_type(e)  # revealed: Unknown
 reveal_type(f)  # revealed: Unknown
 ```
@@ -222,7 +222,7 @@ reveal_type(b)  # revealed: LiteralString
 (a, *b, c, d) = "ab"
 reveal_type(a)  # revealed: LiteralString
 # TODO: Should be list[LiteralString] once support for assigning to starred expression is added
-reveal_type(b)  # revealed: @Todo
+reveal_type(b)  # revealed: @Todo(starred unpacking)
 reveal_type(c)  # revealed: LiteralString
 reveal_type(d)  # revealed: Unknown
 ```
@@ -233,7 +233,7 @@ reveal_type(d)  # revealed: Unknown
 (a, *b, c) = "ab"
 reveal_type(a)  # revealed: LiteralString
 # TODO: Should be list[Any] once support for assigning to starred expression is added
-reveal_type(b)  # revealed: @Todo
+reveal_type(b)  # revealed: @Todo(starred unpacking)
 reveal_type(c)  # revealed: LiteralString
 ```
 
@@ -243,7 +243,7 @@ reveal_type(c)  # revealed: LiteralString
 (a, *b, c) = "abc"
 reveal_type(a)  # revealed: LiteralString
 # TODO: Should be list[LiteralString] once support for assigning to starred expression is added
-reveal_type(b)  # revealed: @Todo
+reveal_type(b)  # revealed: @Todo(starred unpacking)
 reveal_type(c)  # revealed: LiteralString
 ```
 
@@ -253,7 +253,7 @@ reveal_type(c)  # revealed: LiteralString
 (a, *b, c, d) = "abcdef"
 reveal_type(a)  # revealed: LiteralString
 # TODO: Should be list[LiteralString] once support for assigning to starred expression is added
-reveal_type(b)  # revealed: @Todo
+reveal_type(b)  # revealed: @Todo(starred unpacking)
 reveal_type(c)  # revealed: LiteralString
 reveal_type(d)  # revealed: LiteralString
 ```
@@ -265,5 +265,5 @@ reveal_type(d)  # revealed: LiteralString
 reveal_type(a)  # revealed: LiteralString
 reveal_type(b)  # revealed: LiteralString
 # TODO: Should be list[int] once support for assigning to starred expression is added
-reveal_type(c)  # revealed: @Todo
+reveal_type(c)  # revealed: @Todo(starred unpacking)
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/with/async.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/with/async.md
@@ -17,5 +17,5 @@ class Manager:
 
 async def test():
     async with Manager() as f:
-        reveal_type(f)  # revealed: @Todo
+        reveal_type(f)  # revealed: @Todo(async with statement)
 ```

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -324,7 +324,7 @@ fn declarations_ty<'db>(
     }
 }
 
-/// Meta data for `Type::Todo`, which represents a known limitation in the type system.
+/// Meta data for `Type::Todo`, which represents a known limitation in red-knot.
 #[cfg(debug_assertions)]
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub enum TodoType {
@@ -1236,7 +1236,7 @@ impl<'db> Type<'db> {
                 // TODO: implement tuple methods
                 todo_type!().into()
             }
-            Type::Todo(_) => todo_type!().into(),
+            &todo @ Type::Todo(_) => todo.into(),
         }
     }
 
@@ -3674,7 +3674,7 @@ pub(crate) mod tests {
         // A union of several `Todo` types collapses to a single `Todo` type:
         assert!(UnionType::from_elements(&db, vec![todo1, todo2, todo3, todo4]).is_todo());
 
-        // An similar for intersection types:
+        // And similar for intersection types:
         assert!(IntersectionBuilder::new(&db)
             .add_positive(todo1)
             .add_positive(todo2)

--- a/crates/red_knot_python_semantic/src/types/builder.rs
+++ b/crates/red_knot_python_semantic/src/types/builder.rs
@@ -309,7 +309,7 @@ impl<'db> InnerIntersectionBuilder<'db> {
                     self.add_positive(db, *neg);
                 }
             }
-            ty @ (Type::Any | Type::Unknown | Type::Todo) => {
+            ty @ (Type::Any | Type::Unknown | Type::Todo(_)) => {
                 // Adding any of these types to the negative side of an intersection
                 // is equivalent to adding it to the positive side. We do this to
                 // simplify the representation.
@@ -379,7 +379,7 @@ mod tests {
     use crate::program::{Program, SearchPathSettings};
     use crate::python_version::PythonVersion;
     use crate::stdlib::typing_symbol;
-    use crate::types::{global_symbol, KnownClass, UnionBuilder};
+    use crate::types::{global_symbol, todo_type, KnownClass, UnionBuilder};
     use crate::ProgramSettings;
     use ruff_db::files::system_path_to_file;
     use ruff_db::system::{DbWithTestSystem, SystemPathBuf};
@@ -987,7 +987,7 @@ mod tests {
 
     #[test_case(Type::Any)]
     #[test_case(Type::Unknown)]
-    #[test_case(Type::Todo)]
+    #[test_case(todo_type!())]
     fn build_intersection_t_and_negative_t_does_not_simplify(ty: Type) {
         let db = setup_db();
 

--- a/crates/red_knot_python_semantic/src/types/display.rs
+++ b/crates/red_knot_python_semantic/src/types/display.rs
@@ -77,7 +77,7 @@ impl Display for DisplayRepresentation<'_> {
             }
             // `[Type::Todo]`'s display should be explicit that is not a valid display of
             // any other type
-            Type::Todo => f.write_str("@Todo"),
+            Type::Todo(todo) => write!(f, "@Todo{todo}"),
             Type::ModuleLiteral(file) => {
                 write!(f, "<module '{:?}'>", file.path(self.db))
             }

--- a/crates/red_knot_python_semantic/src/types/mro.rs
+++ b/crates/red_knot_python_semantic/src/types/mro.rs
@@ -5,7 +5,7 @@ use itertools::Either;
 use rustc_hash::FxHashSet;
 
 use super::{Class, ClassLiteralType, KnownClass, KnownInstanceType, Type};
-use crate::Db;
+use crate::{types::todo_type, Db};
 
 /// The inferred method resolution order of a given class.
 ///
@@ -354,7 +354,7 @@ impl<'db> ClassBase<'db> {
         match ty {
             Type::Any => Some(Self::Any),
             Type::Unknown => Some(Self::Unknown),
-            Type::Todo => Some(Self::Todo),
+            Type::Todo(_) => Some(Self::Todo),
             Type::ClassLiteral(ClassLiteralType { class }) => Some(Self::Class(class)),
             Type::Union(_) => None, // TODO -- forces consideration of multiple possible MROs?
             Type::Intersection(_) => None, // TODO -- probably incorrect?
@@ -406,7 +406,7 @@ impl<'db> From<ClassBase<'db>> for Type<'db> {
     fn from(value: ClassBase<'db>) -> Self {
         match value {
             ClassBase::Any => Type::Any,
-            ClassBase::Todo => Type::Todo,
+            ClassBase::Todo => todo_type!(),
             ClassBase::Unknown => Type::Unknown,
             ClassBase::Class(class) => Type::class_literal(class),
         }

--- a/crates/red_knot_python_semantic/src/types/signatures.rs
+++ b/crates/red_knot_python_semantic/src/types/signatures.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code)]
 use super::{definition_expression_ty, Type};
-use crate::semantic_index::definition::Definition;
 use crate::Db;
+use crate::{semantic_index::definition::Definition, types::todo_type};
 use ruff_python_ast::{self as ast, name::Name};
 
 /// A typed callable signature.
@@ -18,7 +18,7 @@ impl<'db> Signature<'db> {
     pub(crate) fn todo() -> Self {
         Self {
             parameters: Parameters::todo(),
-            return_ty: Type::Todo,
+            return_ty: todo_type!("return type"),
         }
     }
 
@@ -33,8 +33,7 @@ impl<'db> Signature<'db> {
             .as_ref()
             .map(|returns| {
                 if function_node.is_async {
-                    // TODO: generic `types.CoroutineType`!
-                    Type::Todo
+                    todo_type!("generic types.CoroutineType")
                 } else {
                     definition_expression_ty(db, definition, returns.as_ref())
                 }
@@ -81,11 +80,11 @@ impl<'db> Parameters<'db> {
         Self {
             variadic: Some(Parameter {
                 name: Some(Name::new_static("args")),
-                annotated_ty: Type::Todo,
+                annotated_ty: todo_type!(),
             }),
             keywords: Some(Parameter {
                 name: Some(Name::new_static("kwargs")),
-                annotated_ty: Type::Todo,
+                annotated_ty: todo_type!(),
             }),
             ..Default::default()
         }

--- a/crates/red_knot_python_semantic/src/types/unpacker.rs
+++ b/crates/red_knot_python_semantic/src/types/unpacker.rs
@@ -6,7 +6,7 @@ use rustc_hash::FxHashMap;
 
 use crate::semantic_index::ast_ids::{HasScopedExpressionId, ScopedExpressionId};
 use crate::semantic_index::symbol::ScopeId;
-use crate::types::{Type, TypeCheckDiagnostics, TypeCheckDiagnosticsBuilder};
+use crate::types::{todo_type, Type, TypeCheckDiagnostics, TypeCheckDiagnosticsBuilder};
 use crate::Db;
 
 /// Unpacks the value expression type to their respective targets.
@@ -59,7 +59,7 @@ impl<'db> Unpacker<'db> {
                             // TODO: Combine the types into a list type. If the
                             // starred_element_types is empty, then it should be `List[Any]`.
                             // combine_types(starred_element_types);
-                            element_types.push(Type::Todo);
+                            element_types.push(todo_type!("starred unpacking"));
 
                             element_types.extend_from_slice(
                                 // SAFETY: Safe because of the length check above.
@@ -72,7 +72,7 @@ impl<'db> Unpacker<'db> {
                             // index.
                             element_types.resize(elts.len() - 1, Type::Unknown);
                             // TODO: This should be `list[Unknown]`
-                            element_types.insert(starred_index, Type::Todo);
+                            element_types.insert(starred_index, todo_type!("starred unpacking"));
                             Cow::Owned(element_types)
                         }
                     } else {


### PR DESCRIPTION
## Summary

Adds meta information to `Type::Todo`, allowing developers to easily trace back the origin of a particular `@Todo` type they encounter.

Instead of `Type::Todo`, we now write either `type_todo!()` which creates a `@Todo[path/to/source.rs:123]` type with file and line information, or using `type_todo!("PEP 604 unions not supported")`, which creates a variant with a custom message.

`Type::Todo` now contains a `TodoType` field. In release mode, this is just a zero-sized struct, in order not to create any overhead. In debug mode, this is an `enum` that contains the meta information.

`Type` implements `Copy`, which means that `TodoType` also needs to be copyable. This limits the design space. We could intern `TodoType`, but I discarded this option, as it would require us to have access to the salsa DB everywhere we want to use `Type::Todo`. And it would have made the macro invocations less ergonomic (requiring us to pass `db`).

So for now, the meta information is simply a `&'static str` / `u32` for the file/line variant, or a `&'static str` for the custom message. Anything involving a chain/backtrace of several `@Todo`s or similar is therefore currently not implemented. Also because we currently don't see any direct use cases for this, and because all of this will eventually go away.

Note that the size of `Type` increases from 16 to 24 bytes, but only in debug mode.

## Test Plan

- Observed the changes in Markdown tests.
- Added custom messages for all `Type::Todo`s that were revealed in the tests
- Ran red knot in release and debug mode on the following Python file:
  ```py
  def f(x: int) -> int:
      reveal_type(x)
  ```
  Prints `@Todo` in release mode and `@Todo(function parameter type)` in debug mode.
