### PR TITLE
Use multiple columns for repology badge

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -79,4 +79,4 @@ $ # Or, for Podman on SELinux.
 $ docker run -v .:/io:Z --rm ghcr.io/astral-sh/ruff check
 ```
 
-[![Packaging status](https://repology.org/badge/vertical-allrepos/ruff-python-linter.svg?exclude_unsupported=1)](https://repology.org/project/ruff-python-linter/versions)
+[![Packaging status](https://repology.org/badge/vertical-allrepos/ruff-python-linter.svg?exclude_unsupported=1&columns=3)](https://repology.org/project/ruff-python-linter/versions)


### PR DESCRIPTION
## Summary

These repology badges grow very "tall" over time. We can use a `columns` argument to make more use of the available space. Not sure if there are any `@media`-query breakpoint implications here (max allowed width of images or similar). So feel free to close if this is not desired for some reason.

### before (current version on https://docs.astral.sh/ruff/installation/):

[![Packaging status](https://repology.org/badge/vertical-allrepos/ruff-python-linter.svg?exclude_unsupported=1)](https://repology.org/project/ruff-python-linter/versions)

### after:

[![Packaging status](https://repology.org/badge/vertical-allrepos/ruff-python-linter.svg?exclude_unsupported=1&columns=3)](https://repology.org/project/ruff-python-linter/versions)
