### PR TITLE
Extend `invalid-envvar-default (PLW1508)` to detect `os.environ.get`

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pylint/invalid_envvar_default.py
+++ b/crates/ruff_linter/resources/test/fixtures/pylint/invalid_envvar_default.py
@@ -12,3 +12,4 @@ os.getenv("AA", "GOOD %s" % "BAR")
 os.getenv("B", Z)
 os.getenv("AA", "GOOD" if Z else "BAR")
 os.getenv("AA", 1 if Z else "BAR")  # [invalid-envvar-default]
+os.environ.get("TEST", 12)  # [invalid-envvar-default]

--- a/crates/ruff_linter/src/rules/pylint/mod.rs
+++ b/crates/ruff_linter/src/rules/pylint/mod.rs
@@ -410,6 +410,7 @@ mod tests {
         Rule::RepeatedEqualityComparison,
         Path::new("repeated_equality_comparison.py")
     )]
+    #[test_case(Rule::InvalidEnvvarDefault, Path::new("invalid_envvar_default.py"))]
     fn preview_rules(rule_code: Rule, path: &Path) -> Result<()> {
         let snapshot = format!(
             "preview__{}_{}",

--- a/crates/ruff_linter/src/rules/pylint/rules/invalid_envvar_default.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/invalid_envvar_default.rs
@@ -51,7 +51,12 @@ pub(crate) fn invalid_envvar_default(checker: &mut Checker, call: &ast::ExprCall
     if checker
         .semantic()
         .resolve_qualified_name(&call.func)
-        .is_some_and(|qualified_name| matches!(qualified_name.segments(), ["os", "getenv"]))
+        .is_some_and(|qualified_name| {
+            matches!(
+                qualified_name.segments(),
+                ["os", "getenv"] | ["os", "environ", "get"]
+            )
+        })
     {
         // Find the `default` argument, if it exists.
         let Some(expr) = call.arguments.find_argument("default", 1) else {

--- a/crates/ruff_linter/src/rules/pylint/rules/invalid_envvar_default.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/invalid_envvar_default.rs
@@ -52,10 +52,14 @@ pub(crate) fn invalid_envvar_default(checker: &mut Checker, call: &ast::ExprCall
         .semantic()
         .resolve_qualified_name(&call.func)
         .is_some_and(|qualified_name| {
-            matches!(
-                qualified_name.segments(),
-                ["os", "getenv"] | ["os", "environ", "get"]
-            )
+            if checker.settings.preview.is_enabled() {
+                matches!(
+                    qualified_name.segments(),
+                    ["os", "getenv"] | ["os", "environ", "get"]
+                )
+            } else {
+                matches!(qualified_name.segments(), ["os", "getenv"])
+            }
         })
     {
         // Find the `default` argument, if it exists.

--- a/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLW1508_invalid_envvar_default.py.snap
+++ b/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLW1508_invalid_envvar_default.py.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/ruff_linter/src/rules/pylint/mod.rs
-snapshot_kind: text
 ---
 invalid_envvar_default.py:3:29: PLW1508 Invalid type for environment variable default; expected `str` or `None`
   |
@@ -48,4 +47,13 @@ invalid_envvar_default.py:14:17: PLW1508 Invalid type for environment variable d
 13 | os.getenv("AA", "GOOD" if Z else "BAR")
 14 | os.getenv("AA", 1 if Z else "BAR")  # [invalid-envvar-default]
    |                 ^^^^^^^^^^^^^^^^^ PLW1508
+15 | os.environ.get("TEST", 12)  # [invalid-envvar-default]
+   |
+
+invalid_envvar_default.py:15:24: PLW1508 Invalid type for environment variable default; expected `str` or `None`
+   |
+13 | os.getenv("AA", "GOOD" if Z else "BAR")
+14 | os.getenv("AA", 1 if Z else "BAR")  # [invalid-envvar-default]
+15 | os.environ.get("TEST", 12)  # [invalid-envvar-default]
+   |                        ^^ PLW1508
    |

--- a/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLW1508_invalid_envvar_default.py.snap
+++ b/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLW1508_invalid_envvar_default.py.snap
@@ -49,11 +49,3 @@ invalid_envvar_default.py:14:17: PLW1508 Invalid type for environment variable d
    |                 ^^^^^^^^^^^^^^^^^ PLW1508
 15 | os.environ.get("TEST", 12)  # [invalid-envvar-default]
    |
-
-invalid_envvar_default.py:15:24: PLW1508 Invalid type for environment variable default; expected `str` or `None`
-   |
-13 | os.getenv("AA", "GOOD" if Z else "BAR")
-14 | os.getenv("AA", 1 if Z else "BAR")  # [invalid-envvar-default]
-15 | os.environ.get("TEST", 12)  # [invalid-envvar-default]
-   |                        ^^ PLW1508
-   |

--- a/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLW1508_invalid_envvar_default.py.snap
+++ b/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLW1508_invalid_envvar_default.py.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/ruff_linter/src/rules/pylint/mod.rs
+snapshot_kind: text
 ---
 invalid_envvar_default.py:3:29: PLW1508 Invalid type for environment variable default; expected `str` or `None`
   |

--- a/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__preview__PLW1508_invalid_envvar_default.py.snap
+++ b/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__preview__PLW1508_invalid_envvar_default.py.snap
@@ -1,0 +1,59 @@
+---
+source: crates/ruff_linter/src/rules/pylint/mod.rs
+---
+invalid_envvar_default.py:3:29: PLW1508 Invalid type for environment variable default; expected `str` or `None`
+  |
+1 | import os
+2 | 
+3 | tempVar = os.getenv("TEST", 12)  # [invalid-envvar-default]
+  |                             ^^ PLW1508
+4 | goodVar = os.getenv("TESTING", None)
+5 | dictVarBad = os.getenv("AAA", {"a", 7})  # [invalid-envvar-default]
+  |
+
+invalid_envvar_default.py:5:31: PLW1508 Invalid type for environment variable default; expected `str` or `None`
+  |
+3 | tempVar = os.getenv("TEST", 12)  # [invalid-envvar-default]
+4 | goodVar = os.getenv("TESTING", None)
+5 | dictVarBad = os.getenv("AAA", {"a", 7})  # [invalid-envvar-default]
+  |                               ^^^^^^^^ PLW1508
+6 | print(os.getenv("TEST", False))  # [invalid-envvar-default]
+7 | os.getenv("AA", "GOOD")
+  |
+
+invalid_envvar_default.py:6:25: PLW1508 Invalid type for environment variable default; expected `str` or `None`
+  |
+4 | goodVar = os.getenv("TESTING", None)
+5 | dictVarBad = os.getenv("AAA", {"a", 7})  # [invalid-envvar-default]
+6 | print(os.getenv("TEST", False))  # [invalid-envvar-default]
+  |                         ^^^^^ PLW1508
+7 | os.getenv("AA", "GOOD")
+8 | os.getenv("AA", f"GOOD")
+  |
+
+invalid_envvar_default.py:10:17: PLW1508 Invalid type for environment variable default; expected `str` or `None`
+   |
+ 8 | os.getenv("AA", f"GOOD")
+ 9 | os.getenv("AA", "GOOD" + "BAR")
+10 | os.getenv("AA", "GOOD" + 1)
+   |                 ^^^^^^^^^^ PLW1508
+11 | os.getenv("AA", "GOOD %s" % "BAR")
+12 | os.getenv("B", Z)
+   |
+
+invalid_envvar_default.py:14:17: PLW1508 Invalid type for environment variable default; expected `str` or `None`
+   |
+12 | os.getenv("B", Z)
+13 | os.getenv("AA", "GOOD" if Z else "BAR")
+14 | os.getenv("AA", 1 if Z else "BAR")  # [invalid-envvar-default]
+   |                 ^^^^^^^^^^^^^^^^^ PLW1508
+15 | os.environ.get("TEST", 12)  # [invalid-envvar-default]
+   |
+
+invalid_envvar_default.py:15:24: PLW1508 Invalid type for environment variable default; expected `str` or `None`
+   |
+13 | os.getenv("AA", "GOOD" if Z else "BAR")
+14 | os.getenv("AA", 1 if Z else "BAR")  # [invalid-envvar-default]
+15 | os.environ.get("TEST", 12)  # [invalid-envvar-default]
+   |                        ^^ PLW1508
+   |

--- a/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__preview__PLW1508_invalid_envvar_default.py.snap
+++ b/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__preview__PLW1508_invalid_envvar_default.py.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/ruff_linter/src/rules/pylint/mod.rs
+snapshot_kind: text
 ---
 invalid_envvar_default.py:3:29: PLW1508 Invalid type for environment variable default; expected `str` or `None`
   |


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Fix `invalid-envvar-default (PLW1508)` to flag `os.environ.get`. 

```python
import os


os.getenv("a", 1)   # PLW1508
os.environ.get("a", 1)  # no PLW1508
```

## Test Plan

<!-- How was it tested? -->

New test case