### PR TITLE
Limit type size assertion to 64bit platforms

### DIFF
--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -2967,6 +2967,7 @@ impl<'db> TupleType<'db> {
 
 // Make sure that the `Type` enum does not grow unexpectedly.
 #[cfg(not(debug_assertions))]
+#[cfg(target_pointer_width = "64")]
 static_assertions::assert_eq_size!(Type, [u8; 16]);
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Fix 32bit release builds by limiting the `Type` size assertion to 64bit architectures. 

32 and 64 bit architectures have different sizes because the size of a string slice differs (because of pointer size)


