### PR TITLE
Fix `pytest.mark.parametrize` rules to check calls instead of decorators

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_pytest_style/PT006.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_pytest_style/PT006.py
@@ -69,3 +69,9 @@ def test_implicit_str_concat_with_multi_parens(param1, param2, param3):
 @pytest.mark.parametrize(("param1,param2"), [(1, 2), (3, 4)])
 def test_csv_with_parens(param1, param2):
     ...
+
+parametrize = pytest.mark.parametrize(("param1,param2"), [(1, 2), (3, 4)])
+
+@parametrize
+def test_csv_with_parens_decorator(param1, param2):
+    ...

--- a/crates/ruff_linter/resources/test/fixtures/flake8_pytest_style/PT006.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_pytest_style/PT006.py
@@ -70,6 +70,7 @@ def test_implicit_str_concat_with_multi_parens(param1, param2, param3):
 def test_csv_with_parens(param1, param2):
     ...
 
+
 parametrize = pytest.mark.parametrize(("param1,param2"), [(1, 2), (3, 4)])
 
 @parametrize

--- a/crates/ruff_linter/src/checkers/ast/analyze/expression.rs
+++ b/crates/ruff_linter/src/checkers/ast/analyze/expression.rs
@@ -856,6 +856,13 @@ pub(crate) fn expression(expr: &Expr, checker: &mut Checker) {
                     checker.diagnostics.push(diagnostic);
                 }
             }
+            if checker.any_enabled(&[
+                Rule::PytestParametrizeNamesWrongType,
+                Rule::PytestParametrizeValuesWrongType,
+                Rule::PytestDuplicateParametrizeTestCases,
+            ]) {
+                flake8_pytest_style::rules::parametrize(checker, call);
+            }
             if checker.enabled(Rule::PytestUnittestAssertion) {
                 if let Some(diagnostic) = flake8_pytest_style::rules::unittest_assertion(
                     checker, expr, func, args, keywords,

--- a/crates/ruff_linter/src/checkers/ast/analyze/statement.rs
+++ b/crates/ruff_linter/src/checkers/ast/analyze/statement.rs
@@ -310,13 +310,6 @@ pub(crate) fn statement(stmt: &Stmt, checker: &mut Checker) {
                 );
             }
             if checker.any_enabled(&[
-                Rule::PytestParametrizeNamesWrongType,
-                Rule::PytestParametrizeValuesWrongType,
-                Rule::PytestDuplicateParametrizeTestCases,
-            ]) {
-                flake8_pytest_style::rules::parametrize(checker, decorator_list);
-            }
-            if checker.any_enabled(&[
                 Rule::PytestIncorrectMarkParenthesesStyle,
                 Rule::PytestUseFixturesWithoutParameters,
             ]) {

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/rules/helpers.rs
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/rules/helpers.rs
@@ -2,7 +2,7 @@ use std::fmt;
 
 use ruff_python_ast::helpers::map_callable;
 use ruff_python_ast::name::UnqualifiedName;
-use ruff_python_ast::{self as ast, Decorator, Expr, Keyword};
+use ruff_python_ast::{self as ast, Decorator, Expr, ExprCall, Keyword};
 use ruff_python_semantic::SemanticModel;
 use ruff_python_trivia::PythonWhitespace;
 
@@ -38,9 +38,9 @@ pub(super) fn is_pytest_yield_fixture(decorator: &Decorator, semantic: &Semantic
         })
 }
 
-pub(super) fn is_pytest_parametrize(decorator: &Decorator, semantic: &SemanticModel) -> bool {
+pub(super) fn is_pytest_parametrize(call: &ExprCall, semantic: &SemanticModel) -> bool {
     semantic
-        .resolve_qualified_name(map_callable(&decorator.expression))
+        .resolve_qualified_name(&call.func)
         .is_some_and(|qualified_name| {
             matches!(qualified_name.segments(), ["pytest", "mark", "parametrize"])
         })

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/rules/parametrize.rs
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/rules/parametrize.rs
@@ -5,7 +5,7 @@ use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::comparable::ComparableExpr;
 use ruff_python_ast::parenthesize::parenthesized_range;
 use ruff_python_ast::AstNode;
-use ruff_python_ast::{self as ast, Arguments, Decorator, Expr, ExprContext};
+use ruff_python_ast::{self as ast, Expr, ExprCall, ExprContext};
 use ruff_python_codegen::Generator;
 use ruff_python_trivia::CommentRanges;
 use ruff_python_trivia::{SimpleTokenKind, SimpleTokenizer};
@@ -317,23 +317,21 @@ fn elts_to_csv(elts: &[Expr], generator: Generator) -> Option<String> {
 ///
 /// This method assumes that the first argument is a string.
 fn get_parametrize_name_range(
-    decorator: &Decorator,
+    call: &ExprCall,
     expr: &Expr,
     comment_ranges: &CommentRanges,
     source: &str,
 ) -> Option<TextRange> {
-    decorator.expression.as_call_expr().and_then(|call| {
-        parenthesized_range(
-            expr.into(),
-            call.arguments.as_any_node_ref(),
-            comment_ranges,
-            source,
-        )
-    })
+    parenthesized_range(
+        expr.into(),
+        call.arguments.as_any_node_ref(),
+        comment_ranges,
+        source,
+    )
 }
 
 /// PT006
-fn check_names(checker: &mut Checker, decorator: &Decorator, expr: &Expr) {
+fn check_names(checker: &mut Checker, call: &ExprCall, expr: &Expr) {
     let names_type = checker.settings.flake8_pytest_style.parametrize_names_type;
 
     match expr {
@@ -343,7 +341,7 @@ fn check_names(checker: &mut Checker, decorator: &Decorator, expr: &Expr) {
                 match names_type {
                     types::ParametrizeNameType::Tuple => {
                         let name_range = get_parametrize_name_range(
-                            decorator,
+                            call,
                             expr,
                             checker.comment_ranges(),
                             checker.locator().contents(),
@@ -378,7 +376,7 @@ fn check_names(checker: &mut Checker, decorator: &Decorator, expr: &Expr) {
                     }
                     types::ParametrizeNameType::List => {
                         let name_range = get_parametrize_name_range(
-                            decorator,
+                            call,
                             expr,
                             checker.comment_ranges(),
                             checker.locator().contents(),
@@ -797,30 +795,27 @@ fn handle_value_rows(
     }
 }
 
-pub(crate) fn parametrize(checker: &mut Checker, decorators: &[Decorator]) {
-    for decorator in decorators {
-        if is_pytest_parametrize(decorator, checker.semantic()) {
-            if let Expr::Call(ast::ExprCall {
-                arguments: Arguments { args, .. },
-                ..
-            }) = &decorator.expression
-            {
-                if checker.enabled(Rule::PytestParametrizeNamesWrongType) {
-                    if let [names, ..] = &**args {
-                        check_names(checker, decorator, names);
-                    }
-                }
-                if checker.enabled(Rule::PytestParametrizeValuesWrongType) {
-                    if let [names, values, ..] = &**args {
-                        check_values(checker, names, values);
-                    }
-                }
-                if checker.enabled(Rule::PytestDuplicateParametrizeTestCases) {
-                    if let [_, values, ..] = &**args {
-                        check_duplicates(checker, values);
-                    }
-                }
+pub(crate) fn parametrize(checker: &mut Checker, call: &ExprCall) {
+    if !is_pytest_parametrize(call, checker.semantic()) {
+        return;
+    }
+
+    let ExprCall { arguments, .. } = call;
+    if checker.enabled(Rule::PytestParametrizeNamesWrongType) {
+        if let Some(names) = arguments.find_argument("argnames", 0) {
+            check_names(checker, call, names);
+        }
+    }
+    if checker.enabled(Rule::PytestParametrizeValuesWrongType) {
+        if let Some(names) = arguments.find_argument("argnames", 0) {
+            if let Some(values) = arguments.find_argument("argvalues", 1) {
+                check_values(checker, names, values);
             }
+        }
+    }
+    if checker.enabled(Rule::PytestDuplicateParametrizeTestCases) {
+        if let Some(values) = arguments.find_argument("argvalues", 1) {
+            check_duplicates(checker, values);
         }
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Currently, rules for `pytest.mark.parametrize` (e.g. `/pytest-parametrize-names-wrong-type (PT006)`) only check decorators, but `pytest.mark.parametrize` can appear as a plan function call as show below.

```python
# To parametrize all tests in a module, you can assign to pytest mark


import pytest

pytestmark = pytest.mark.parametrize("n,expected", [(1, 2), (3, 4)])


class TestClass:
    def test_simple_case(self, n, expected):
        assert n + 1 == expected

    def test_weird_simple_case(self, n, expected):
        assert (n * 1) + 1 == expected
```

https://docs.pytest.org/en/stable/how-to/parametrize.html

## Test Plan

<!-- How was it tested? -->

Existing tests + a new test case
