### PR TITLE
Improve docs for some pycodestyle rules

### DIFF
--- a/crates/ruff_linter/src/rules/pycodestyle/rules/line_too_long.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/line_too_long.rs
@@ -12,8 +12,8 @@ use crate::settings::LinterSettings;
 /// ## Why is this bad?
 /// Overlong lines can hurt readability. [PEP 8], for example, recommends
 /// limiting lines to 79 characters. By default, this rule enforces a limit
-/// of 88 characters for compatibility with Black, though that limit is
-/// configurable via the [`line-length`] setting.
+/// of 88 characters for compatibility with Black and the Ruff formatter,
+/// though that limit is configurable via the [`line-length`] setting.
 ///
 /// In the interest of pragmatism, this rule makes a few exceptions when
 /// determining whether a line is overlong. Namely, it:

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/logical_lines/space_around_operator.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/logical_lines/space_around_operator.rs
@@ -169,7 +169,8 @@ impl AlwaysFixableViolation for TabAfterComma {
 /// Checks for extraneous whitespace after a comma.
 ///
 /// ## Why is this bad?
-/// According to the `black` code style, commas should be followed by a single space.
+/// Consistency is good. This rule helps ensure you have a consistent
+/// formatting style across your project.
 ///
 /// ## Example
 /// ```python


### PR DESCRIPTION
We received a report on Discord that the mention of `Black` in the docs for `MultipleSpacesAfterComma` was a bit confusing