### PR TITLE
[red-knot] Semantic index: handle invalid `break`s

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/loops/while_loop.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/loops/while_loop.md
@@ -52,3 +52,29 @@ else:
 reveal_type(x)  # revealed: Literal[2, 3]
 reveal_type(y)  # revealed: Literal[1, 2, 4]
 ```
+
+## Nested while loops
+
+```py
+def flag() -> bool:
+    return True
+
+x = 1
+
+while flag():
+    x = 2
+
+    while flag():
+        x = 3
+        if flag():
+            break
+    else:
+        x = 4
+
+    if flag():
+        break
+else:
+    x = 5
+
+reveal_type(x)  # revealed: Literal[3, 4, 5]
+```

--- a/crates/red_knot_python_semantic/src/semantic_index/builder.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/builder.rs
@@ -813,10 +813,10 @@ where
 
                 // TODO: definitions created inside the body should be fully visible
                 // to other statements/expressions inside the body --Alex/Carl
-                let in_nested_loop = self.loop_state();
+                let outer_loop_state = self.loop_state();
                 self.set_inside_loop(LoopState::InLoop);
                 self.visit_body(body);
-                self.set_inside_loop(in_nested_loop);
+                self.set_inside_loop(outer_loop_state);
 
                 // Get the break states from the body of this loop, and restore the saved outer
                 // ones.
@@ -884,10 +884,10 @@ where
                 // TODO: Definitions created by loop variables
                 // (and definitions created inside the body)
                 // are fully visible to other statements/expressions inside the body --Alex/Carl
-                let in_nested_loop = self.loop_state();
+                let outer_loop_state = self.loop_state();
                 self.set_inside_loop(LoopState::InLoop);
                 self.visit_body(body);
-                self.set_inside_loop(in_nested_loop);
+                self.set_inside_loop(outer_loop_state);
 
                 let break_states =
                     std::mem::replace(&mut self.loop_break_states, saved_break_states);

--- a/crates/red_knot_workspace/resources/test/corpus/15_while_break_invalid_in_class.py
+++ b/crates/red_knot_workspace/resources/test/corpus/15_while_break_invalid_in_class.py
@@ -1,0 +1,6 @@
+while True:
+
+    class A:
+        x: int
+
+        break

--- a/crates/red_knot_workspace/resources/test/corpus/15_while_break_invalid_in_func.py
+++ b/crates/red_knot_workspace/resources/test/corpus/15_while_break_invalid_in_func.py
@@ -1,0 +1,6 @@
+while True:
+
+    def b():
+        x: int
+
+        break

--- a/crates/red_knot_workspace/resources/test/corpus/16_for_break_invalid_in_class.py
+++ b/crates/red_knot_workspace/resources/test/corpus/16_for_break_invalid_in_class.py
@@ -1,0 +1,6 @@
+for _ in range(1):
+
+    class A:
+        x: int
+
+        break

--- a/crates/red_knot_workspace/resources/test/corpus/16_for_break_invalid_in_func.py
+++ b/crates/red_knot_workspace/resources/test/corpus/16_for_break_invalid_in_func.py
@@ -1,0 +1,6 @@
+for _ in range(1):
+
+    def b():
+        x: int
+
+        break


### PR DESCRIPTION
## Summary

This fix intends to address panics related to invalid syntax like the following where a `break` statement is used in a nested definition inside a loop:

```py
while True:

    def b():
        x: int

        break
```

> [!NOTE]  
> I don't like the fact that we add even more mutable state to `SemanticIndexBuilder`. There might very well be a better solution here. And maybe we need something more general to handle other cases of invalid syntax. I still thought it would be valuable to propose this change with relevant regression tests, so we can start thinking about what would be required to properly fix this.

closes #14342

## Test Plan

* New corpus regression tests.
* New unit test to make sure we handle nested while loops correctly. This test is passing on `main`, but can easily fail if the `is_inside_loop` state isn't properly saved/restored.