### PR TITLE
[red-knot] remove wrong typevar attribute implementations

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/generics.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/generics.md
@@ -60,52 +60,20 @@ reveal_type(S)  # revealed: Literal[S]
 
 ## Type params
 
-A PEP695 type variable defines a value of type `typing.TypeVar` with attributes `__name__`,
-`__bounds__`, `__constraints__`, and `__default__` (the latter three all lazily evaluated):
+A PEP695 type variable defines a value of type `typing.TypeVar`.
 
 ```py
-def f[T, U: A, V: (A, B), W = A, X: A = A1]():
+def f[T]():
     reveal_type(T)  # revealed: T
     reveal_type(T.__name__)  # revealed: Literal["T"]
-    reveal_type(T.__bound__)  # revealed: None
-    reveal_type(T.__constraints__)  # revealed: tuple[()]
-    reveal_type(T.__default__)  # revealed: NoDefault
-
-    reveal_type(U)  # revealed: U
-    reveal_type(U.__name__)  # revealed: Literal["U"]
-    reveal_type(U.__bound__)  # revealed: type[A]
-    reveal_type(U.__constraints__)  # revealed: tuple[()]
-    reveal_type(U.__default__)  # revealed: NoDefault
-
-    reveal_type(V)  # revealed: V
-    reveal_type(V.__name__)  # revealed: Literal["V"]
-    reveal_type(V.__bound__)  # revealed: None
-    reveal_type(V.__constraints__)  # revealed: tuple[type[A], type[B]]
-    reveal_type(V.__default__)  # revealed: NoDefault
-
-    reveal_type(W)  # revealed: W
-    reveal_type(W.__name__)  # revealed: Literal["W"]
-    reveal_type(W.__bound__)  # revealed: None
-    reveal_type(W.__constraints__)  # revealed: tuple[()]
-    reveal_type(W.__default__)  # revealed: type[A]
-
-    reveal_type(X)  # revealed: X
-    reveal_type(X.__name__)  # revealed: Literal["X"]
-    reveal_type(X.__bound__)  # revealed: type[A]
-    reveal_type(X.__constraints__)  # revealed: tuple[()]
-    reveal_type(X.__default__)  # revealed: type[A1]
-
-class A: ...
-class B: ...
-class A1(A): ...
 ```
 
 ## Minimum two constraints
 
-A typevar with less than two constraints emits a diagnostic and is treated as unconstrained:
+A typevar with less than two constraints emits a diagnostic:
 
 ```py
 # error: [invalid-typevar-constraints] "TypeVar must have at least two constrained types"
 def f[T: (int,)]():
-    reveal_type(T.__constraints__)  # revealed: tuple[()]
+    pass
 ```


### PR DESCRIPTION
## Summary

In #14182 I added "precise" per-TypeVar type inference for attributes of a typevar (`__bound__`, `__constraints__`, `__default__`). This wasn't motivated so much by the real-world need for this precise inference, as it was by wanting to test the correctness of our internal representation of the typevar, via an mdtest.

The implementation I added was unfortunately just wrong. The problem is that our internal representation cares about the bound/constraints/default inferred as a type expression, while the runtime attributes of the `TypeVar` object will return it as a value expression.

In the simplest case, this means that for a typevar `[T: A]`, while we might store the bound as the Instance type `A`, the value of the `__bound__` attribute should be typed as `type[A]`.

Beguiled by the simple case, I slapped on a `.to_meta_type()` and called it a day. But this is just wrong in more complex cases; the meta-type is not always the same thing as the "type form" type. For example, the meta-type of `A | B` is `type[A] | type[B]`, but the type-form type in this case would be an instance of `types.UnionType`.

In a future world with PEP 747 (`TypeForm`), where we have a typevar with a bound of `A | B` it would be correct for us to infer its `__bound__` attribute as `TypeForm[A | B]`, offering a nicer solution to this problem.

In the meantime, I think we should just follow the lead of other type checkers in falling back to the general typeshed types for these attributes, and I should bite the bullet and write a Rust test instead of an mdtest when I want to test internal representations of types that don't (yet, since we haven't implemented generics) have a visible effect in the type system.

## Test Plan

Re-wrote an mdtest as a Rust test.