### PR TITLE
Ignore more rules for stub files

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_boolean_trap/rules/boolean_default_value_positional_argument.rs
+++ b/crates/ruff_linter/src/rules/flake8_boolean_trap/rules/boolean_default_value_positional_argument.rs
@@ -106,6 +106,10 @@ pub(crate) fn boolean_default_value_positional_argument(
     decorator_list: &[Decorator],
     parameters: &Parameters,
 ) {
+    // https://github.com/astral-sh/ruff/issues/14535
+    if checker.source_type.is_stub() {
+        return;
+    }
     // Allow Boolean defaults in explicitly-allowed functions.
     if is_allowed_func_def(name) {
         return;

--- a/crates/ruff_linter/src/rules/flake8_boolean_trap/rules/boolean_positional_value_in_call.rs
+++ b/crates/ruff_linter/src/rules/flake8_boolean_trap/rules/boolean_positional_value_in_call.rs
@@ -52,6 +52,10 @@ impl Violation for BooleanPositionalValueInCall {
 }
 
 pub(crate) fn boolean_positional_value_in_call(checker: &mut Checker, call: &ast::ExprCall) {
+    // https://github.com/astral-sh/ruff/issues/14535
+    if checker.source_type.is_stub() {
+        return;
+    }
     if allow_boolean_trap(call, checker) {
         return;
     }

--- a/crates/ruff_linter/src/rules/flake8_boolean_trap/rules/boolean_positional_value_in_call.rs
+++ b/crates/ruff_linter/src/rules/flake8_boolean_trap/rules/boolean_positional_value_in_call.rs
@@ -52,10 +52,6 @@ impl Violation for BooleanPositionalValueInCall {
 }
 
 pub(crate) fn boolean_positional_value_in_call(checker: &mut Checker, call: &ast::ExprCall) {
-    // https://github.com/astral-sh/ruff/issues/14535
-    if checker.source_type.is_stub() {
-        return;
-    }
     if allow_boolean_trap(call, checker) {
         return;
     }

--- a/crates/ruff_linter/src/rules/flake8_boolean_trap/rules/boolean_type_hint_positional_argument.rs
+++ b/crates/ruff_linter/src/rules/flake8_boolean_trap/rules/boolean_type_hint_positional_argument.rs
@@ -115,6 +115,10 @@ pub(crate) fn boolean_type_hint_positional_argument(
     decorator_list: &[Decorator],
     parameters: &Parameters,
 ) {
+    // https://github.com/astral-sh/ruff/issues/14535
+    if checker.source_type.is_stub() {
+        return;
+    }
     // Allow Boolean type hints in explicitly-allowed functions.
     if is_allowed_func_def(name) {
         return;

--- a/crates/ruff_linter/src/rules/flake8_slots/rules/no_slots_in_namedtuple_subclass.rs
+++ b/crates/ruff_linter/src/rules/flake8_slots/rules/no_slots_in_namedtuple_subclass.rs
@@ -78,6 +78,10 @@ pub(crate) fn no_slots_in_namedtuple_subclass(
     stmt: &Stmt,
     class: &StmtClassDef,
 ) {
+    // https://github.com/astral-sh/ruff/issues/14535
+    if checker.source_type.is_stub() {
+        return;
+    }
     let Some(Arguments { args: bases, .. }) = class.arguments.as_deref() else {
         return;
     };

--- a/crates/ruff_linter/src/rules/flake8_slots/rules/no_slots_in_str_subclass.rs
+++ b/crates/ruff_linter/src/rules/flake8_slots/rules/no_slots_in_str_subclass.rs
@@ -50,6 +50,10 @@ impl Violation for NoSlotsInStrSubclass {
 
 /// SLOT000
 pub(crate) fn no_slots_in_str_subclass(checker: &mut Checker, stmt: &Stmt, class: &StmtClassDef) {
+    // https://github.com/astral-sh/ruff/issues/14535
+    if checker.source_type.is_stub() {
+        return;
+    }
     let Some(Arguments { args: bases, .. }) = class.arguments.as_deref() else {
         return;
     };

--- a/crates/ruff_linter/src/rules/flake8_slots/rules/no_slots_in_tuple_subclass.rs
+++ b/crates/ruff_linter/src/rules/flake8_slots/rules/no_slots_in_tuple_subclass.rs
@@ -51,6 +51,10 @@ impl Violation for NoSlotsInTupleSubclass {
 
 /// SLOT001
 pub(crate) fn no_slots_in_tuple_subclass(checker: &mut Checker, stmt: &Stmt, class: &StmtClassDef) {
+    // https://github.com/astral-sh/ruff/issues/14535
+    if checker.source_type.is_stub() {
+        return;
+    }
     let Some(Arguments { args: bases, .. }) = class.arguments.as_deref() else {
         return;
     };

--- a/crates/ruff_linter/src/rules/pylint/rules/bad_dunder_method_name.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/bad_dunder_method_name.rs
@@ -57,6 +57,10 @@ impl Violation for BadDunderMethodName {
 
 /// PLW3201
 pub(crate) fn bad_dunder_method_name(checker: &mut Checker, method: &ast::StmtFunctionDef) {
+    // https://github.com/astral-sh/ruff/issues/14535
+    if checker.source_type.is_stub() {
+        return;
+    }
     // If the name isn't a dunder, skip it.
     if !method.name.starts_with('_') || !method.name.ends_with('_') {
         return;

--- a/crates/ruff_linter/src/rules/pylint/rules/too_many_arguments.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/too_many_arguments.rs
@@ -59,6 +59,10 @@ impl Violation for TooManyArguments {
 
 /// PLR0913
 pub(crate) fn too_many_arguments(checker: &mut Checker, function_def: &ast::StmtFunctionDef) {
+    // https://github.com/astral-sh/ruff/issues/14535
+    if checker.source_type.is_stub() {
+        return;
+    }
     let semantic = checker.semantic();
 
     let num_arguments = function_def

--- a/crates/ruff_linter/src/rules/pylint/rules/too_many_positional_arguments.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/too_many_positional_arguments.rs
@@ -60,6 +60,10 @@ pub(crate) fn too_many_positional_arguments(
     checker: &mut Checker,
     function_def: &ast::StmtFunctionDef,
 ) {
+    // https://github.com/astral-sh/ruff/issues/14535
+    if checker.source_type.is_stub() {
+        return;
+    }
     let semantic = checker.semantic();
 
     // Count the number of positional arguments.

--- a/crates/ruff_linter/src/rules/pylint/rules/too_many_public_methods.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/too_many_public_methods.rs
@@ -105,6 +105,10 @@ pub(crate) fn too_many_public_methods(
     class_def: &ast::StmtClassDef,
     max_methods: usize,
 ) {
+    // https://github.com/astral-sh/ruff/issues/14535
+    if checker.source_type.is_stub() {
+        return;
+    }
     let methods = class_def
         .body
         .iter()


### PR DESCRIPTION
This PR causes the following rules to ignore stub files, on the grounds that it is not under the author's control to appease these lints:

- `PLR0904` https://docs.astral.sh/ruff/rules/too-many-public-methods/
- `PLR0913` https://docs.astral.sh/ruff/rules/too-many-arguments/
- `PLR0917` https://docs.astral.sh/ruff/rules/too-many-positional-arguments/
- `PLW3201` https://docs.astral.sh/ruff/rules/bad-dunder-method-name/
- `SLOT` https://docs.astral.sh/ruff/rules/#flake8-slots-slot
- `FBT` https://docs.astral.sh/ruff/rules/#flake8-boolean-trap-fbt (except for FBT003 since that involves a function call.)

Progress towards #14535
