### PR TITLE
[`perflint`] - Fix `manual-list-comprehension` for async generators (`PERF401`)

### DIFF
--- a/crates/ruff_linter/src/rules/isort/mod.rs
+++ b/crates/ruff_linter/src/rules/isort/mod.rs
@@ -25,7 +25,7 @@ use crate::Locator;
 mod annotate;
 pub(crate) mod block;
 pub mod categorize;
-mod comments;
+pub mod comments;
 mod format;
 mod helpers;
 mod normalize;

--- a/crates/ruff_linter/src/rules/perflint/rules/manual_list_comprehension.rs
+++ b/crates/ruff_linter/src/rules/perflint/rules/manual_list_comprehension.rs
@@ -430,7 +430,11 @@ fn convert_to_list_extend(
                 generator_str
             };
 
-            let comprehension_body = format!("{variable_name}.extend({generator_str})");
+            let comprehension_body = if for_stmt.is_async {
+                format!("{variable_name}.extend([{generator_str}])")
+            } else {
+                format!("{variable_name}.extend({generator_str})")
+            };
 
             let indentation = if for_loop_inline_comments.is_empty() {
                 String::new()


### PR DESCRIPTION
## Summary

Fixes a current bug in PERF401's preview autofix, where it tries to make an async generator within a list.extend, without wrapping the generator in a list, which does not implement `__iter__` which makes it an error.

## Test Plan

`cargo test`
