### PR TITLE
Support `typing.NoReturn` and `typing.Never`

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/annotations/never.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/annotations/never.md
@@ -37,7 +37,7 @@ def f():
     v3: Never = b1
     v4: Never = stop()
     v5: Any = b2
-    # error: Object of type `Literal[1]` is not assignable to `Never`
+    # error: [invalid-assignment] "Object of type `Literal[1]` is not assignable to `Never`"
     v6: Never = 1
 ```
 

--- a/crates/red_knot_python_semantic/resources/mdtest/annotations/never.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/annotations/never.md
@@ -9,6 +9,9 @@ interchangeably.
 ```py
 from typing import NoReturn, Never, Any
 
+# error: [invalid-type-parameter] "Type `typing.Never` expected no type parameter"
+x: Never[int]
+
 def stop() -> NoReturn:
     raise RuntimeError("no way")
 

--- a/crates/red_knot_python_semantic/resources/mdtest/annotations/never.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/annotations/never.md
@@ -1,23 +1,28 @@
 # NoReturn & Never
 
-## Annotation
-
 `NoReturn` to annotate functions that never return normally. `Never` represents the bottom type, a
 type that represents the empty set of Python objects. These two annotations can be used
 interchangeably.
 
-```py
-from typing import NoReturn, Never, Any
+## Function Return Type Annotation
 
-# error: [invalid-type-parameter] "Type `typing.Never` expected no type parameter"
-x: Never[int]
+```py
+from typing import NoReturn
 
 def stop() -> NoReturn:
     raise RuntimeError("no way")
 
 # revealed: Never
 reveal_type(stop())
+```
 
+## Assignment
+
+```py
+from typing import NoReturn, Never, Any
+
+# error: [invalid-type-parameter] "Type `typing.Never` expected no type parameter"
+x: Never[int]
 a1: NoReturn
 # TODO: Test `Never` is only available in python >= 3.11
 a2: Never
@@ -30,12 +35,12 @@ def f():
     # revealed: Never
     reveal_type(a2)
 
-    # Never is compatible with all types.
+    # Never is assignable to all types.
     v1: int = a1
     v2: str = a1
-    # Other types are not compatible with Never except for Never (and Any).
+    # Other types are not assignable to Never except for Never (and Any).
     v3: Never = b1
-    v4: Never = stop()
+    v4: Never = a2
     v5: Any = b2
     # error: [invalid-assignment] "Object of type `Literal[1]` is not assignable to `Never`"
     v6: Never = 1

--- a/crates/red_knot_python_semantic/resources/mdtest/annotations/never.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/annotations/never.md
@@ -1,0 +1,53 @@
+# NoReturn & Never
+
+## Annotation
+
+`NoReturn` to annotate functions that never return normally. `Never` represents the bottom type, a
+type that represents the empty set of Python objects. These two annotations can be used
+interchangeably.
+
+```py
+from typing import NoReturn, Never, Any
+
+def stop() -> NoReturn:
+    raise RuntimeError("no way")
+
+# revealed: Never
+reveal_type(stop())
+
+a1: NoReturn
+# TODO: Test `Never` is only available in python >= 3.11
+a2: Never
+b: Any
+c: int
+
+def f():
+    # revealed: Never
+    reveal_type(a1)
+    # revealed: Never
+    reveal_type(a2)
+
+    # Never is compatible with all types.
+    v1: int = a1
+    v2: str = a1
+    v3: list[str] = a1
+    # Other types are not compatible with Never except for Never (and Any).
+    v4: Never = b
+    v5: Never = stop()
+    v6: Any = c
+```
+
+## Typing Extensions
+
+```py
+from typing_extensions import NoReturn, Never
+
+x: NoReturn
+y: Never
+
+def f():
+    # revealed: Never
+    reveal_type(x)
+    # revealed: Never
+    reveal_type(y)
+```

--- a/crates/red_knot_python_semantic/resources/mdtest/annotations/never.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/annotations/never.md
@@ -18,8 +18,8 @@ reveal_type(stop())
 a1: NoReturn
 # TODO: Test `Never` is only available in python >= 3.11
 a2: Never
-b: Any
-c: int
+b1: Any
+b2: int
 
 def f():
     # revealed: Never
@@ -30,11 +30,12 @@ def f():
     # Never is compatible with all types.
     v1: int = a1
     v2: str = a1
-    v3: list[str] = a1
     # Other types are not compatible with Never except for Never (and Any).
-    v4: Never = b
-    v5: Never = stop()
-    v6: Any = c
+    v3: Never = b1
+    v4: Never = stop()
+    v5: Any = b2
+    # error: Object of type `Literal[1]` is not assignable to `Never`
+    v6: Never = 1
 ```
 
 ## Typing Extensions

--- a/crates/red_knot_python_semantic/resources/mdtest/annotations/never.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/annotations/never.md
@@ -1,7 +1,7 @@
 # NoReturn & Never
 
-`NoReturn` to annotate functions that never return normally. `Never` represents the bottom type, a
-type that represents the empty set of Python objects. These two annotations can be used
+`NoReturn` is used to annotate the return type for functions that never return. `Never` is the
+bottom type, representing the empty set of Python objects. These two annotations can be used
 interchangeably.
 
 ## Function Return Type Annotation

--- a/crates/red_knot_python_semantic/resources/mdtest/expression/if.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/expression/if.md
@@ -27,7 +27,7 @@ reveal_type(1 if 0 else 2)  # revealed: Literal[2]
 
 (issue #14588)
 
-The test inside an if expression should not affect code outside of the block.
+The test inside an if expression should not affect code outside of the expression.
 
 ```py
 def bool_instance() -> bool:

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -756,8 +756,6 @@ impl<'db> Type<'db> {
                         },
                     )
             }
-            (Type::Never, Type::Never) => false,
-            (_, Type::Never) => false,
             // TODO other types containing gradual forms (e.g. generics containing Any/Unknown)
             _ => self.is_subtype_of(db, target),
         }

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -4629,6 +4629,9 @@ impl<'db> TypeInferenceBuilder<'db> {
                 self.infer_type_expression(parameters);
                 todo_type!("generic type alias")
             }
+            KnownInstanceType::NoReturn | KnownInstanceType::Never => {
+                unreachable!("These are not subscriptible")
+            }
         }
     }
 

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -4574,12 +4574,9 @@ impl<'db> TypeInferenceBuilder<'db> {
         } = subscript;
 
         match value_ty {
-            Type::KnownInstance(known_instance) => self
-                .infer_parameterized_known_instance_type_expression(
-                    subscript,
-                    known_instance,
-                    slice,
-                ),
+            Type::KnownInstance(known_instance) => {
+                self.infer_parameterized_known_instance_type_expression(subscript, known_instance)
+            }
             _ => {
                 self.infer_type_expression(slice);
                 todo_type!("generics")
@@ -4591,8 +4588,8 @@ impl<'db> TypeInferenceBuilder<'db> {
         &mut self,
         subscript: &ast::ExprSubscript,
         known_instance: KnownInstanceType,
-        parameters: &ast::Expr,
     ) -> Type<'db> {
+        let parameters = &subscript.slice;
         match known_instance {
             KnownInstanceType::Literal => match self.infer_literal_parameter_type(parameters) {
                 Ok(ty) => ty,
@@ -4614,7 +4611,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                 let param_type = self.infer_type_expression(parameters);
                 UnionType::from_elements(self.db, [param_type, Type::none(self.db)])
             }
-            KnownInstanceType::Union => match parameters {
+            KnownInstanceType::Union => match parameters.as_ref() {
                 ast::Expr::Tuple(t) => {
                     let union_ty = UnionType::from_elements(
                         self.db,

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -4589,7 +4589,7 @@ impl<'db> TypeInferenceBuilder<'db> {
         subscript: &ast::ExprSubscript,
         known_instance: KnownInstanceType,
     ) -> Type<'db> {
-        let parameters = &subscript.slice;
+        let parameters = &*subscript.slice;
         match known_instance {
             KnownInstanceType::Literal => match self.infer_literal_parameter_type(parameters) {
                 Ok(ty) => ty,
@@ -4611,7 +4611,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                 let param_type = self.infer_type_expression(parameters);
                 UnionType::from_elements(self.db, [param_type, Type::none(self.db)])
             }
-            KnownInstanceType::Union => match parameters.as_ref() {
+            KnownInstanceType::Union => match parameters {
                 ast::Expr::Tuple(t) => {
                     let union_ty = UnionType::from_elements(
                         self.db,

--- a/crates/red_knot_python_semantic/src/types/mro.rs
+++ b/crates/red_knot_python_semantic/src/types/mro.rs
@@ -375,6 +375,8 @@ impl<'db> ClassBase<'db> {
                 | KnownInstanceType::TypeAliasType(_)
                 | KnownInstanceType::Literal
                 | KnownInstanceType::Union
+                | KnownInstanceType::NoReturn
+                | KnownInstanceType::Never
                 | KnownInstanceType::Optional => None,
             },
         }


### PR DESCRIPTION
Fix #14558 
## Summary

- Add `typing.NoReturn` and `typing.Never` to known instances and infer them as `Type::Never`
- Add `is_assignable_to` cases for `Type::Never`

I skipped emitting diagnostic for when a function is annotated as `NoReturn` but it actually returns.

## Test Plan

Added tests from
https://github.com/python/typing/blob/main/conformance/tests/specialtypes_never.py
except from generics and checking if the return value of the function and the annotations match.