### PR TITLE
red-knot: adapt fuzz-parser to work with red-knot

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -309,7 +309,7 @@ jobs:
           # Make executable, since artifact download doesn't preserve this
           chmod +x ${{ steps.download-cached-binary.outputs.download-path }}/ruff
 
-          python scripts/fuzz-parser/fuzz.py 0-500 --test-executable ${{ steps.download-cached-binary.outputs.download-path }}/ruff
+          python scripts/fuzz-parser/fuzz.py --bin ruff 0-500 --test-executable ${{ steps.download-cached-binary.outputs.download-path }}/ruff
 
   scripts:
     name: "test scripts"

--- a/.github/workflows/daily_fuzz.yaml
+++ b/.github/workflows/daily_fuzz.yaml
@@ -49,7 +49,7 @@ jobs:
         # but this is outweighed by the fact that a release build takes *much* longer to compile in CI
         run: cargo build --locked
       - name: Fuzz
-        run: python scripts/fuzz-parser/fuzz.py $(shuf -i 0-9999999999999999999 -n 1000) --test-executable target/debug/ruff
+        run: python scripts/fuzz-parser/fuzz.py --bin ruff $(shuf -i 0-9999999999999999999 -n 1000) --test-executable target/debug/ruff
 
   create-issue-on-failure:
     name: Create an issue if the daily fuzz surfaced any bugs

--- a/crates/red_knot/src/main.rs
+++ b/crates/red_knot/src/main.rs
@@ -83,14 +83,6 @@ to resolve type information for the project's third-party dependencies.",
         short = 'W'
     )]
     watch: bool,
-
-    #[arg(
-        long,
-        hide = true,
-        help = "Return a successful status code even when type-checking fails. \
-                Useful for finding bugs in the type-checker itself"
-    )]
-    ignore_errors: bool,
 }
 
 impl Args {
@@ -222,10 +214,6 @@ fn run() -> anyhow::Result<ExitStatus> {
     tracing::trace!("Counts for entire CLI run:\n{}", countme::get_all());
 
     std::mem::forget(db);
-
-    if args.ignore_errors {
-        return Ok(ExitStatus::Success);
-    }
 
     Ok(exit_status)
 }

--- a/crates/red_knot/src/main.rs
+++ b/crates/red_knot/src/main.rs
@@ -83,6 +83,14 @@ to resolve type information for the project's third-party dependencies.",
         short = 'W'
     )]
     watch: bool,
+
+    #[arg(
+        long,
+        hide = true,
+        help = "Return a successful status code even when type-checking fails. \
+                Useful for finding bugs in the type-checker itself"
+    )]
+    ignore_errors: bool,
 }
 
 impl Args {
@@ -214,6 +222,10 @@ fn run() -> anyhow::Result<ExitStatus> {
     tracing::trace!("Counts for entire CLI run:\n{}", countme::get_all());
 
     std::mem::forget(db);
+
+    if args.ignore_errors {
+        return Ok(ExitStatus::Success);
+    }
 
     Ok(exit_status)
 }

--- a/scripts/fuzz-parser/fuzz.py
+++ b/scripts/fuzz-parser/fuzz.py
@@ -283,8 +283,9 @@ def parse_args() -> ResolvedCliArgs:
     )
     parser.add_argument(
         "--bin",
-        help=("Name of executable to test. E.g. `ruff` or `red_knot`."),
+        help="Name of executable to test. E.g. `ruff` or `red_knot`.",
         required=True,
+        choices=["ruff", "red_knot"],
     )
 
     args = parser.parse_args()
@@ -314,8 +315,8 @@ def parse_args() -> ResolvedCliArgs:
         except FileNotFoundError:
             parser.error(
                 "`--only-new-bugs` was specified without specifying a baseline "
-                f"executable, and no released version of {bin} appears to be installed "
-                "in your Python environment"
+                f"executable, and no released version of `{bin}` appears to be "
+                "installed in your Python environment"
             )
         else:
             if not args.quiet:
@@ -323,8 +324,8 @@ def parse_args() -> ResolvedCliArgs:
                 print(
                     f"`--only-new-bugs` was specified without specifying a baseline "
                     f"executable; falling back to using `{bin}=={version}` as the "
-                    f"baseline (the version of {bin} installed in your current Python "
-                    f"environment)"
+                    f"baseline (the version of `{bin}` installed in your current "
+                    f"Python environment)"
                 )
         args.baseline_executable = bin
 

--- a/scripts/fuzz-parser/fuzz.py
+++ b/scripts/fuzz-parser/fuzz.py
@@ -283,7 +283,7 @@ def parse_args() -> ResolvedCliArgs:
     )
     parser.add_argument(
         "--bin",
-        help="Name of executable to test. E.g. `ruff` or `red_knot`.",
+        help="Name of executable to test.",
         required=True,
         choices=["ruff", "red_knot"],
     )

--- a/scripts/fuzz-parser/fuzz.py
+++ b/scripts/fuzz-parser/fuzz.py
@@ -47,11 +47,11 @@ def redknot_contains_bug(code: str, *, red_knot_executable: str) -> bool:
             pyfile.write(code)
 
         completed_process = subprocess.run(
-            [red_knot_executable, "--ignore-errors", "--current-directory", tempdir],
+            [red_knot_executable, "--current-directory", tempdir],
             capture_output=True,
             text=True,
         )
-        return completed_process.returncode != 0
+        return completed_process.returncode != 0 and completed_process.returncode != 1
 
 
 def ruff_contains_bug(code: str, *, ruff_executable: str) -> bool:


### PR DESCRIPTION
Adds a `--bin` argument to the `fuzz-parser` script, which makes it possible to fuzz either `ruff` or `red_knot`.

This fuzzing finds a few panics already in some seeds:

```sh
>>> python scripts/fuzz-parser/fuzz.py --bin red_knot 0-9
Running `cargo build --release` since no test executable was specified...
Concurrently running the fuzzer on 10 randomly generated source-code files...
Ran fuzzer successfully on seed 1                            [1/10]
Ran fuzzer successfully on seed 8                            [2/10]
Ran fuzzer successfully on seed 5                            [3/10]
Ran fuzzer successfully on seed 0                            [4/10]
Ran fuzzer successfully on seed 2                            [5/10]
Ran fuzzer successfully on seed 6                            [6/10]
Ran fuzzer successfully on seed 3                            [7/10]
Ran fuzzer on seed 7                                         [8/10]
The following code triggers a bug:

async def name_0[*name_1](name_2: name_0(), /):
    pass

Ran fuzzer on seed 9                                         [9/10]
The following code triggers a bug:

class name_5[**name_1](name_5[name_3]):
    pass

Ran fuzzer on seed 4                                        [10/10]
The following code triggers a bug:

class name_2[name_0](*name_2):
    pass

Bugs found in the following seeds:
4 7 9
```

This was tested manually by running the above command for `--bin ruff` and `--bin red_knot`.

Resolves https://github.com/astral-sh/ruff/issues/14157, though does not add the fuzzing to CI due to the existing failures.