### PR TITLE
Use `Result` for failed text document retrieval in LSP requests

### DIFF
--- a/crates/ruff_server/src/server/api/requests/format.rs
+++ b/crates/ruff_server/src/server/api/requests/format.rs
@@ -1,3 +1,4 @@
+use anyhow::Context;
 use lsp_types::{self as types, request as req};
 use types::TextEdit;
 
@@ -64,7 +65,7 @@ pub(super) fn format_document(snapshot: &DocumentSnapshot) -> Result<super::Form
     let text_document = snapshot
         .query()
         .as_single_document()
-        .map_err(|err| anyhow::anyhow!("Failed to get text document for the format request: {err}"))
+        .context("Failed to get text document for the format request")
         .unwrap();
     let query = snapshot.query();
     format_text_document(

--- a/crates/ruff_server/src/server/api/requests/format.rs
+++ b/crates/ruff_server/src/server/api/requests/format.rs
@@ -64,7 +64,8 @@ pub(super) fn format_document(snapshot: &DocumentSnapshot) -> Result<super::Form
     let text_document = snapshot
         .query()
         .as_single_document()
-        .expect("format should only be called on text documents or notebook cells");
+        .map_err(|err| anyhow::anyhow!("Failed to get text document for the format request: {err}"))
+        .unwrap();
     let query = snapshot.query();
     format_text_document(
         text_document,

--- a/crates/ruff_server/src/server/api/requests/format_range.rs
+++ b/crates/ruff_server/src/server/api/requests/format_range.rs
@@ -1,3 +1,4 @@
+use anyhow::Context;
 use lsp_types::{self as types, request as req, Range};
 
 use crate::edit::{RangeExt, ToRangeExt};
@@ -32,9 +33,7 @@ fn format_document_range(
     let text_document = snapshot
         .query()
         .as_single_document()
-        .map_err(|err| {
-            anyhow::anyhow!("Failed to get text document for the format range request: {err}")
-        })
+        .context("Failed to get text document for the format range request")
         .unwrap();
     let query = snapshot.query();
     format_text_document_range(text_document, range, query, snapshot.encoding())

--- a/crates/ruff_server/src/server/api/requests/format_range.rs
+++ b/crates/ruff_server/src/server/api/requests/format_range.rs
@@ -32,7 +32,10 @@ fn format_document_range(
     let text_document = snapshot
         .query()
         .as_single_document()
-        .expect("format should only be called on text documents or notebook cells");
+        .map_err(|err| {
+            anyhow::anyhow!("Failed to get text document for the format range request: {err}")
+        })
+        .unwrap();
     let query = snapshot.query();
     format_text_document_range(text_document, range, query, snapshot.encoding())
 }

--- a/crates/ruff_server/src/server/api/requests/hover.rs
+++ b/crates/ruff_server/src/server/api/requests/hover.rs
@@ -33,7 +33,8 @@ pub(crate) fn hover(
     let document = snapshot
         .query()
         .as_single_document()
-        .expect("hover should only be called on text documents or notebook cells");
+        .map_err(|err| anyhow::anyhow!("Failed to get text document for the hover request: {err}"))
+        .unwrap();
     let line_number: usize = position
         .position
         .line

--- a/crates/ruff_server/src/server/api/requests/hover.rs
+++ b/crates/ruff_server/src/server/api/requests/hover.rs
@@ -1,5 +1,6 @@
 use crate::server::{client::Notifier, Result};
 use crate::session::DocumentSnapshot;
+use anyhow::Context;
 use lsp_types::{self as types, request as req};
 use regex::Regex;
 use ruff_diagnostics::FixAvailability;
@@ -33,7 +34,7 @@ pub(crate) fn hover(
     let document = snapshot
         .query()
         .as_single_document()
-        .map_err(|err| anyhow::anyhow!("Failed to get text document for the hover request: {err}"))
+        .context("Failed to get text document for the hover request")
         .unwrap();
     let line_number: usize = position
         .position

--- a/crates/ruff_server/src/session/index.rs
+++ b/crates/ruff_server/src/session/index.rs
@@ -610,10 +610,10 @@ impl DocumentQuery {
                 if let Some(cell_uri) = cell_uri {
                     let cell = notebook
                         .cell_document_by_uri(cell_uri)
-                        .ok_or(SingleDocumentError::CellDoesNotExist(cell_uri))?;
+                        .ok_or_else(|| SingleDocumentError::CellDoesNotExist(cell_uri.clone()))?;
                     Ok(cell)
                 } else {
-                    Err(SingleDocumentError::Notebook(file_url))
+                    Err(SingleDocumentError::Notebook(file_url.clone()))
                 }
             }
         }
@@ -629,9 +629,9 @@ impl DocumentQuery {
 }
 
 #[derive(Debug, Error)]
-pub(crate) enum SingleDocumentError<'a> {
+pub(crate) enum SingleDocumentError {
     #[error("Expected a single text document, but found a notebook document: {0}")]
-    Notebook(&'a Url),
+    Notebook(Url),
     #[error("Cell with URL {0} does not exist in the internal notebook document")]
-    CellDoesNotExist(&'a Url),
+    CellDoesNotExist(Url),
 }

--- a/crates/ruff_server/src/session/index.rs
+++ b/crates/ruff_server/src/session/index.rs
@@ -6,6 +6,7 @@ use std::{collections::BTreeMap, path::Path, sync::Arc};
 use anyhow::anyhow;
 use lsp_types::Url;
 use rustc_hash::FxHashMap;
+use thiserror::Error;
 
 pub(crate) use ruff_settings::RuffSettings;
 
@@ -597,16 +598,24 @@ impl DocumentQuery {
 
     /// Attempt to access the single inner text document selected by the query.
     /// If this query is selecting an entire notebook document, this will return `None`.
-    pub(crate) fn as_single_document(&self) -> Option<&TextDocument> {
+    pub(crate) fn as_single_document(&self) -> Result<&TextDocument, SingleDocumentError> {
         match self {
-            Self::Text { document, .. } => Some(document),
+            Self::Text { document, .. } => Ok(document),
             Self::Notebook {
                 notebook,
+                file_url,
                 cell_url: cell_uri,
                 ..
-            } => cell_uri
-                .as_ref()
-                .and_then(|cell_uri| notebook.cell_document_by_uri(cell_uri)),
+            } => {
+                if let Some(cell_uri) = cell_uri {
+                    let cell = notebook
+                        .cell_document_by_uri(cell_uri)
+                        .ok_or(SingleDocumentError::CellDoesNotExist(cell_uri))?;
+                    Ok(cell)
+                } else {
+                    Err(SingleDocumentError::Notebook(file_url))
+                }
+            }
         }
     }
 
@@ -617,4 +626,12 @@ impl DocumentQuery {
             None
         }
     }
+}
+
+#[derive(Debug, Error)]
+pub(crate) enum SingleDocumentError<'a> {
+    #[error("Expected a single text document, but found a notebook document: {0}")]
+    Notebook(&'a Url),
+    #[error("Cell with URL {0} does not exist in the internal notebook document")]
+    CellDoesNotExist(&'a Url),
 }


### PR DESCRIPTION
## Summary

Ref: https://github.com/astral-sh/ruff-vscode/issues/644#issuecomment-2496588452

## Test Plan

Not sure how to test this as this is mainly to get more context on the panic that the server is raising.
