### PR TITLE
N811 & N814: eliminate false positives for single-letter names

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pep8_naming/N811.py
+++ b/crates/ruff_linter/resources/test/fixtures/pep8_naming/N811.py
@@ -1,7 +1,7 @@
-import mod.CON as c
 import mod.CONST as const
 from mod import CONSTANT as constant
 from mod import ANOTHER_CONSTANT as another_constant
+import mod.CON as c
 
 import django.db.models.Q as Query1
 from django.db.models import Q as Query2

--- a/crates/ruff_linter/resources/test/fixtures/pep8_naming/N811.py
+++ b/crates/ruff_linter/resources/test/fixtures/pep8_naming/N811.py
@@ -1,3 +1,8 @@
+# Error
 import mod.CONST as const
 from mod import CONSTANT as constant
 from mod import ANOTHER_CONSTANT as another_constant
+
+# Ok
+import django.db.models.Q as Query1
+from django.db.models import Q as Query2

--- a/crates/ruff_linter/resources/test/fixtures/pep8_naming/N811.py
+++ b/crates/ruff_linter/resources/test/fixtures/pep8_naming/N811.py
@@ -1,9 +1,7 @@
-# Error
 import mod.CON as c
 import mod.CONST as const
 from mod import CONSTANT as constant
 from mod import ANOTHER_CONSTANT as another_constant
 
-# Ok
 import django.db.models.Q as Query1
 from django.db.models import Q as Query2

--- a/crates/ruff_linter/resources/test/fixtures/pep8_naming/N811.py
+++ b/crates/ruff_linter/resources/test/fixtures/pep8_naming/N811.py
@@ -2,6 +2,8 @@ import mod.CONST as const
 from mod import CONSTANT as constant
 from mod import ANOTHER_CONSTANT as another_constant
 import mod.CON as c
+from mod import C as c
 
+# These are all OK:
 import django.db.models.Q as Query1
 from django.db.models import Q as Query2

--- a/crates/ruff_linter/resources/test/fixtures/pep8_naming/N811.py
+++ b/crates/ruff_linter/resources/test/fixtures/pep8_naming/N811.py
@@ -1,4 +1,5 @@
 # Error
+import mod.CON as c
 import mod.CONST as const
 from mod import CONSTANT as constant
 from mod import ANOTHER_CONSTANT as another_constant

--- a/crates/ruff_linter/resources/test/fixtures/pep8_naming/N814.py
+++ b/crates/ruff_linter/resources/test/fixtures/pep8_naming/N814.py
@@ -1,3 +1,8 @@
+# Error
 import mod.Camel as CAMEL
 from mod import CamelCase as CAMELCASE
 from mod import AnotherCamelCase as ANOTHER_CAMELCASE
+
+# Ok
+import mod.AppleFruit as A
+from mod import BananaFruit as B

--- a/crates/ruff_linter/resources/test/fixtures/pep8_naming/N814.py
+++ b/crates/ruff_linter/resources/test/fixtures/pep8_naming/N814.py
@@ -1,8 +1,6 @@
-# Error
 import mod.Camel as CAMEL
 from mod import CamelCase as CAMELCASE
 from mod import AnotherCamelCase as ANOTHER_CAMELCASE
 
-# Ok
 import mod.AppleFruit as A
 from mod import BananaFruit as B

--- a/crates/ruff_linter/resources/test/fixtures/pep8_naming/N814.py
+++ b/crates/ruff_linter/resources/test/fixtures/pep8_naming/N814.py
@@ -2,5 +2,6 @@ import mod.Camel as CAMEL
 from mod import CamelCase as CAMELCASE
 from mod import AnotherCamelCase as ANOTHER_CAMELCASE
 
+# These are all OK:
 import mod.AppleFruit as A
 from mod import BananaFruit as B

--- a/crates/ruff_linter/src/rules/pep8_naming/rules/camelcase_imported_as_constant.rs
+++ b/crates/ruff_linter/src/rules/pep8_naming/rules/camelcase_imported_as_constant.rs
@@ -32,10 +32,10 @@ use crate::rules::pep8_naming::settings::IgnoreNames;
 ///
 /// ## Note
 /// Identifiers consisting of a single uppercase character are ambiguous under
-/// the rules of [PEP 8], which specifies CamelCase for classes and
-/// ALL_CAPS_SNAKE_CASE for constants. Without a second character, it is not
+/// the rules of [PEP 8], which specifies `CamelCase` for classes and
+/// `ALL_CAPS_SNAKE_CASE` for constants. Without a second character, it is not
 /// possible to reliably guess whether the identifier is intended to be part
-/// of a CamelCase string for a class or an ALL_CAPS_SNAKE_CASE string for
+/// of a `CamelCase` string for a class or an `ALL_CAPS_SNAKE_CASE` string for
 /// a constant, since both conventions will produce the same output when given
 /// a single input character. Therefore, this lint rule does not apply to cases
 /// where the alias for the imported identifier consists of a single uppercase

--- a/crates/ruff_linter/src/rules/pep8_naming/rules/camelcase_imported_as_constant.rs
+++ b/crates/ruff_linter/src/rules/pep8_naming/rules/camelcase_imported_as_constant.rs
@@ -53,6 +53,11 @@ pub(crate) fn camelcase_imported_as_constant(
     stmt: &Stmt,
     ignore_names: &IgnoreNames,
 ) -> Option<Diagnostic> {
+    // Single-character names are ambiguous. It could be a class or a constant.
+    if asname.chars().count() == 1 {
+        return None;
+    }
+
     if helpers::is_camelcase(name)
         && !str::is_cased_lowercase(asname)
         && str::is_cased_uppercase(asname)

--- a/crates/ruff_linter/src/rules/pep8_naming/rules/camelcase_imported_as_constant.rs
+++ b/crates/ruff_linter/src/rules/pep8_naming/rules/camelcase_imported_as_constant.rs
@@ -32,10 +32,10 @@ use crate::rules::pep8_naming::settings::IgnoreNames;
 ///
 /// ## Note
 /// Identifiers consisting of a single uppercase character are ambiguous under
-/// the rules of PEP8, which specifies PascalCase for classes and
+/// the rules of [PEP 8], which specifies CamelCase for classes and
 /// ALL_CAPS_SNAKE_CASE for constants. Without a second character, it is not
 /// possible to reliably guess whether the identifier is intended to be part
-/// of a PascalCase string for a class or an ALL_CAPS_SNAKE_CASE string for
+/// of a CamelCase string for a class or an ALL_CAPS_SNAKE_CASE string for
 /// a constant, since both conventions will produce the same output when given
 /// a single input character. Therefore, this lint rule does not apply to cases
 /// where the alias for the imported identifier consists of a single uppercase

--- a/crates/ruff_linter/src/rules/pep8_naming/rules/camelcase_imported_as_constant.rs
+++ b/crates/ruff_linter/src/rules/pep8_naming/rules/camelcase_imported_as_constant.rs
@@ -31,7 +31,7 @@ use crate::rules::pep8_naming::settings::IgnoreNames;
 /// ```
 ///
 /// ## Note
-/// Identifiers consisting of a single uppercase character are ambigous under
+/// Identifiers consisting of a single uppercase character are ambiguous under
 /// the rules of PEP8, which specifies PascalCase for classes and
 /// ALL_CAPS_SNAKE_CASE for constants. Without a second character, it is not
 /// possible to reliably guess whether the identifier is intended to be part
@@ -68,7 +68,7 @@ pub(crate) fn camelcase_imported_as_constant(
     ignore_names: &IgnoreNames,
 ) -> Option<Diagnostic> {
     // Single-character names are ambiguous. It could be a class or a constant.
-    asname.chars().skip(1).next()?;
+    asname.chars().nth(1)?;
 
     if helpers::is_camelcase(name)
         && !str::is_cased_lowercase(asname)

--- a/crates/ruff_linter/src/rules/pep8_naming/rules/camelcase_imported_as_constant.rs
+++ b/crates/ruff_linter/src/rules/pep8_naming/rules/camelcase_imported_as_constant.rs
@@ -30,6 +30,20 @@ use crate::rules::pep8_naming::settings::IgnoreNames;
 /// from example import MyClassName
 /// ```
 ///
+/// ## Note
+/// Identifiers consisting of a single uppercase character are ambigous under
+/// the rules of PEP8, which specifies PascalCase for classes and
+/// ALL_CAPS_SNAKE_CASE for constants. Without a second character, it is not
+/// possible to reliably guess whether the identifier is intended to be part
+/// of a PascalCase string for a class or an ALL_CAPS_SNAKE_CASE string for
+/// a constant, since both conventions will produce the same output when given
+/// a single input character. Therefore, this lint rule does not apply to cases
+/// where the alias for the imported identifier consists of a single uppercase
+/// character.
+///
+/// A common example of a single uppercase character being used for a class
+/// name can be found in Django's `django.db.models.Q` class.
+///
 /// [PEP 8]: https://peps.python.org/pep-0008/
 #[violation]
 pub struct CamelcaseImportedAsConstant {

--- a/crates/ruff_linter/src/rules/pep8_naming/rules/camelcase_imported_as_constant.rs
+++ b/crates/ruff_linter/src/rules/pep8_naming/rules/camelcase_imported_as_constant.rs
@@ -54,9 +54,7 @@ pub(crate) fn camelcase_imported_as_constant(
     ignore_names: &IgnoreNames,
 ) -> Option<Diagnostic> {
     // Single-character names are ambiguous. It could be a class or a constant.
-    if asname.chars().count() == 1 {
-        return None;
-    }
+    asname.chars().skip(1).next()?;
 
     if helpers::is_camelcase(name)
         && !str::is_cased_lowercase(asname)

--- a/crates/ruff_linter/src/rules/pep8_naming/rules/constant_imported_as_non_constant.rs
+++ b/crates/ruff_linter/src/rules/pep8_naming/rules/constant_imported_as_non_constant.rs
@@ -30,7 +30,7 @@ use crate::rules::pep8_naming::settings::IgnoreNames;
 /// ```
 ///
 /// ## Note
-/// Identifiers consisting of a single uppercase character are ambigous under
+/// Identifiers consisting of a single uppercase character are ambiguous under
 /// the rules of PEP8, which specifies PascalCase for classes and
 /// ALL_CAPS_SNAKE_CASE for constants. Without a second character, it is not
 /// possible to reliably guess whether the identifier is intended to be part
@@ -66,7 +66,7 @@ pub(crate) fn constant_imported_as_non_constant(
     ignore_names: &IgnoreNames,
 ) -> Option<Diagnostic> {
     // Single-character names are ambiguous. It could be a class or a constant.
-    name.chars().skip(1).next()?;
+    name.chars().nth(1)?;
 
     if str::is_cased_uppercase(name) && !str::is_cased_uppercase(asname) {
         // Ignore any explicitly-allowed names.

--- a/crates/ruff_linter/src/rules/pep8_naming/rules/constant_imported_as_non_constant.rs
+++ b/crates/ruff_linter/src/rules/pep8_naming/rules/constant_imported_as_non_constant.rs
@@ -53,9 +53,7 @@ pub(crate) fn constant_imported_as_non_constant(
     ignore_names: &IgnoreNames,
 ) -> Option<Diagnostic> {
     // Single-character names are ambiguous. It could be a class or a constant.
-    if name.chars().count() == 1 {
-        return None;
-    }
+    name.chars().skip(1).next()?;
 
     if str::is_cased_uppercase(name) && !str::is_cased_uppercase(asname) {
         // Ignore any explicitly-allowed names.

--- a/crates/ruff_linter/src/rules/pep8_naming/rules/constant_imported_as_non_constant.rs
+++ b/crates/ruff_linter/src/rules/pep8_naming/rules/constant_imported_as_non_constant.rs
@@ -29,6 +29,19 @@ use crate::rules::pep8_naming::settings::IgnoreNames;
 /// from example import CONSTANT_VALUE
 /// ```
 ///
+/// ## Note
+/// Identifiers consisting of a single uppercase character are ambigous under
+/// the rules of PEP8, which specifies PascalCase for classes and
+/// ALL_CAPS_SNAKE_CASE for constants. Without a second character, it is not
+/// possible to reliably guess whether the identifier is intended to be part
+/// of a PascalCase string for a class or an ALL_CAPS_SNAKE_CASE string for
+/// a constant, since both conventions will produce the same output when given
+/// a single input character. Therefore, this lint rule does not apply to cases
+/// where the imported identifier consists of a single uppercase character.
+///
+/// A common example of a single uppercase character being used for a class
+/// name can be found in Django's `django.db.models.Q` class.
+///
 /// [PEP 8]: https://peps.python.org/pep-0008/
 #[violation]
 pub struct ConstantImportedAsNonConstant {

--- a/crates/ruff_linter/src/rules/pep8_naming/rules/constant_imported_as_non_constant.rs
+++ b/crates/ruff_linter/src/rules/pep8_naming/rules/constant_imported_as_non_constant.rs
@@ -31,10 +31,10 @@ use crate::rules::pep8_naming::settings::IgnoreNames;
 ///
 /// ## Note
 /// Identifiers consisting of a single uppercase character are ambiguous under
-/// the rules of PEP8, which specifies PascalCase for classes and
+/// the rules of [PEP 8], which specifies CamelCase for classes and
 /// ALL_CAPS_SNAKE_CASE for constants. Without a second character, it is not
 /// possible to reliably guess whether the identifier is intended to be part
-/// of a PascalCase string for a class or an ALL_CAPS_SNAKE_CASE string for
+/// of a CamelCase string for a class or an ALL_CAPS_SNAKE_CASE string for
 /// a constant, since both conventions will produce the same output when given
 /// a single input character. Therefore, this lint rule does not apply to cases
 /// where the imported identifier consists of a single uppercase character.

--- a/crates/ruff_linter/src/rules/pep8_naming/rules/constant_imported_as_non_constant.rs
+++ b/crates/ruff_linter/src/rules/pep8_naming/rules/constant_imported_as_non_constant.rs
@@ -31,10 +31,10 @@ use crate::rules::pep8_naming::settings::IgnoreNames;
 ///
 /// ## Note
 /// Identifiers consisting of a single uppercase character are ambiguous under
-/// the rules of [PEP 8], which specifies CamelCase for classes and
-/// ALL_CAPS_SNAKE_CASE for constants. Without a second character, it is not
+/// the rules of [PEP 8], which specifies `CamelCase` for classes and
+/// `ALL_CAPS_SNAKE_CASE` for constants. Without a second character, it is not
 /// possible to reliably guess whether the identifier is intended to be part
-/// of a CamelCase string for a class or an ALL_CAPS_SNAKE_CASE string for
+/// of a `CamelCase` string for a class or an `ALL_CAPS_SNAKE_CASE` string for
 /// a constant, since both conventions will produce the same output when given
 /// a single input character. Therefore, this lint rule does not apply to cases
 /// where the imported identifier consists of a single uppercase character.

--- a/crates/ruff_linter/src/rules/pep8_naming/rules/constant_imported_as_non_constant.rs
+++ b/crates/ruff_linter/src/rules/pep8_naming/rules/constant_imported_as_non_constant.rs
@@ -52,6 +52,11 @@ pub(crate) fn constant_imported_as_non_constant(
     stmt: &Stmt,
     ignore_names: &IgnoreNames,
 ) -> Option<Diagnostic> {
+    // Single-character names are ambiguous. It could be a class or a constant.
+    if name.chars().count() == 1 {
+        return None;
+    }
+
     if str::is_cased_uppercase(name) && !str::is_cased_uppercase(asname) {
         // Ignore any explicitly-allowed names.
         if ignore_names.matches(name) || ignore_names.matches(asname) {

--- a/crates/ruff_linter/src/rules/pep8_naming/snapshots/ruff_linter__rules__pep8_naming__tests__N811_N811.py.snap
+++ b/crates/ruff_linter/src/rules/pep8_naming/snapshots/ruff_linter__rules__pep8_naming__tests__N811_N811.py.snap
@@ -2,26 +2,30 @@
 source: crates/ruff_linter/src/rules/pep8_naming/mod.rs
 snapshot_kind: text
 ---
-N811.py:1:8: N811 Constant `CONST` imported as non-constant `const`
+N811.py:2:8: N811 Constant `CONST` imported as non-constant `const`
   |
-1 | import mod.CONST as const
+1 | # Error
+2 | import mod.CONST as const
   |        ^^^^^^^^^^^^^^^^^^ N811
-2 | from mod import CONSTANT as constant
-3 | from mod import ANOTHER_CONSTANT as another_constant
+3 | from mod import CONSTANT as constant
+4 | from mod import ANOTHER_CONSTANT as another_constant
   |
 
-N811.py:2:17: N811 Constant `CONSTANT` imported as non-constant `constant`
+N811.py:3:17: N811 Constant `CONSTANT` imported as non-constant `constant`
   |
-1 | import mod.CONST as const
-2 | from mod import CONSTANT as constant
+1 | # Error
+2 | import mod.CONST as const
+3 | from mod import CONSTANT as constant
   |                 ^^^^^^^^^^^^^^^^^^^^ N811
-3 | from mod import ANOTHER_CONSTANT as another_constant
+4 | from mod import ANOTHER_CONSTANT as another_constant
   |
 
-N811.py:3:17: N811 Constant `ANOTHER_CONSTANT` imported as non-constant `another_constant`
+N811.py:4:17: N811 Constant `ANOTHER_CONSTANT` imported as non-constant `another_constant`
   |
-1 | import mod.CONST as const
-2 | from mod import CONSTANT as constant
-3 | from mod import ANOTHER_CONSTANT as another_constant
+2 | import mod.CONST as const
+3 | from mod import CONSTANT as constant
+4 | from mod import ANOTHER_CONSTANT as another_constant
   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ N811
+5 | 
+6 | # Ok
   |

--- a/crates/ruff_linter/src/rules/pep8_naming/snapshots/ruff_linter__rules__pep8_naming__tests__N811_N811.py.snap
+++ b/crates/ruff_linter/src/rules/pep8_naming/snapshots/ruff_linter__rules__pep8_naming__tests__N811_N811.py.snap
@@ -2,30 +2,40 @@
 source: crates/ruff_linter/src/rules/pep8_naming/mod.rs
 snapshot_kind: text
 ---
-N811.py:2:8: N811 Constant `CONST` imported as non-constant `const`
+N811.py:2:8: N811 Constant `CON` imported as non-constant `c`
   |
 1 | # Error
-2 | import mod.CONST as const
+2 | import mod.CON as c
+  |        ^^^^^^^^^^^^ N811
+3 | import mod.CONST as const
+4 | from mod import CONSTANT as constant
+  |
+
+N811.py:3:8: N811 Constant `CONST` imported as non-constant `const`
+  |
+1 | # Error
+2 | import mod.CON as c
+3 | import mod.CONST as const
   |        ^^^^^^^^^^^^^^^^^^ N811
-3 | from mod import CONSTANT as constant
-4 | from mod import ANOTHER_CONSTANT as another_constant
+4 | from mod import CONSTANT as constant
+5 | from mod import ANOTHER_CONSTANT as another_constant
   |
 
-N811.py:3:17: N811 Constant `CONSTANT` imported as non-constant `constant`
+N811.py:4:17: N811 Constant `CONSTANT` imported as non-constant `constant`
   |
-1 | # Error
-2 | import mod.CONST as const
-3 | from mod import CONSTANT as constant
+2 | import mod.CON as c
+3 | import mod.CONST as const
+4 | from mod import CONSTANT as constant
   |                 ^^^^^^^^^^^^^^^^^^^^ N811
-4 | from mod import ANOTHER_CONSTANT as another_constant
+5 | from mod import ANOTHER_CONSTANT as another_constant
   |
 
-N811.py:4:17: N811 Constant `ANOTHER_CONSTANT` imported as non-constant `another_constant`
+N811.py:5:17: N811 Constant `ANOTHER_CONSTANT` imported as non-constant `another_constant`
   |
-2 | import mod.CONST as const
-3 | from mod import CONSTANT as constant
-4 | from mod import ANOTHER_CONSTANT as another_constant
+3 | import mod.CONST as const
+4 | from mod import CONSTANT as constant
+5 | from mod import ANOTHER_CONSTANT as another_constant
   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ N811
-5 | 
-6 | # Ok
+6 | 
+7 | # Ok
   |

--- a/crates/ruff_linter/src/rules/pep8_naming/snapshots/ruff_linter__rules__pep8_naming__tests__N811_N811.py.snap
+++ b/crates/ruff_linter/src/rules/pep8_naming/snapshots/ruff_linter__rules__pep8_naming__tests__N811_N811.py.snap
@@ -2,40 +2,38 @@
 source: crates/ruff_linter/src/rules/pep8_naming/mod.rs
 snapshot_kind: text
 ---
-N811.py:2:8: N811 Constant `CON` imported as non-constant `c`
+N811.py:1:8: N811 Constant `CONST` imported as non-constant `const`
   |
-1 | # Error
-2 | import mod.CON as c
-  |        ^^^^^^^^^^^^ N811
-3 | import mod.CONST as const
-4 | from mod import CONSTANT as constant
-  |
-
-N811.py:3:8: N811 Constant `CONST` imported as non-constant `const`
-  |
-1 | # Error
-2 | import mod.CON as c
-3 | import mod.CONST as const
+1 | import mod.CONST as const
   |        ^^^^^^^^^^^^^^^^^^ N811
-4 | from mod import CONSTANT as constant
-5 | from mod import ANOTHER_CONSTANT as another_constant
+2 | from mod import CONSTANT as constant
+3 | from mod import ANOTHER_CONSTANT as another_constant
   |
 
-N811.py:4:17: N811 Constant `CONSTANT` imported as non-constant `constant`
+N811.py:2:17: N811 Constant `CONSTANT` imported as non-constant `constant`
   |
-2 | import mod.CON as c
-3 | import mod.CONST as const
-4 | from mod import CONSTANT as constant
+1 | import mod.CONST as const
+2 | from mod import CONSTANT as constant
   |                 ^^^^^^^^^^^^^^^^^^^^ N811
-5 | from mod import ANOTHER_CONSTANT as another_constant
+3 | from mod import ANOTHER_CONSTANT as another_constant
+4 | import mod.CON as c
   |
 
-N811.py:5:17: N811 Constant `ANOTHER_CONSTANT` imported as non-constant `another_constant`
+N811.py:3:17: N811 Constant `ANOTHER_CONSTANT` imported as non-constant `another_constant`
   |
-3 | import mod.CONST as const
-4 | from mod import CONSTANT as constant
-5 | from mod import ANOTHER_CONSTANT as another_constant
+1 | import mod.CONST as const
+2 | from mod import CONSTANT as constant
+3 | from mod import ANOTHER_CONSTANT as another_constant
   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ N811
-6 | 
-7 | # Ok
+4 | import mod.CON as c
+  |
+
+N811.py:4:8: N811 Constant `CON` imported as non-constant `c`
+  |
+2 | from mod import CONSTANT as constant
+3 | from mod import ANOTHER_CONSTANT as another_constant
+4 | import mod.CON as c
+  |        ^^^^^^^^^^^^ N811
+5 | 
+6 | import django.db.models.Q as Query1
   |

--- a/crates/ruff_linter/src/rules/pep8_naming/snapshots/ruff_linter__rules__pep8_naming__tests__N811_N811.py.snap
+++ b/crates/ruff_linter/src/rules/pep8_naming/snapshots/ruff_linter__rules__pep8_naming__tests__N811_N811.py.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/ruff_linter/src/rules/pep8_naming/mod.rs
-snapshot_kind: text
 ---
 N811.py:1:8: N811 Constant `CONST` imported as non-constant `const`
   |
@@ -26,6 +25,7 @@ N811.py:3:17: N811 Constant `ANOTHER_CONSTANT` imported as non-constant `another
 3 | from mod import ANOTHER_CONSTANT as another_constant
   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ N811
 4 | import mod.CON as c
+5 | from mod import C as c
   |
 
 N811.py:4:8: N811 Constant `CON` imported as non-constant `c`
@@ -34,6 +34,15 @@ N811.py:4:8: N811 Constant `CON` imported as non-constant `c`
 3 | from mod import ANOTHER_CONSTANT as another_constant
 4 | import mod.CON as c
   |        ^^^^^^^^^^^^ N811
-5 | 
-6 | import django.db.models.Q as Query1
+5 | from mod import C as c
+  |
+
+N811.py:5:17: N811 Constant `C` imported as non-constant `c`
+  |
+3 | from mod import ANOTHER_CONSTANT as another_constant
+4 | import mod.CON as c
+5 | from mod import C as c
+  |                 ^^^^^^ N811
+6 | 
+7 | # These are all OK:
   |

--- a/crates/ruff_linter/src/rules/pep8_naming/snapshots/ruff_linter__rules__pep8_naming__tests__N814_N814.py.snap
+++ b/crates/ruff_linter/src/rules/pep8_naming/snapshots/ruff_linter__rules__pep8_naming__tests__N814_N814.py.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/ruff_linter/src/rules/pep8_naming/mod.rs
-snapshot_kind: text
 ---
 N814.py:1:8: N814 Camelcase `Camel` imported as constant `CAMEL`
   |
@@ -25,5 +24,5 @@ N814.py:3:17: N814 Camelcase `AnotherCamelCase` imported as constant `ANOTHER_CA
 3 | from mod import AnotherCamelCase as ANOTHER_CAMELCASE
   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ N814
 4 | 
-5 | import mod.AppleFruit as A
+5 | # These are all OK:
   |

--- a/crates/ruff_linter/src/rules/pep8_naming/snapshots/ruff_linter__rules__pep8_naming__tests__N814_N814.py.snap
+++ b/crates/ruff_linter/src/rules/pep8_naming/snapshots/ruff_linter__rules__pep8_naming__tests__N814_N814.py.snap
@@ -2,26 +2,30 @@
 source: crates/ruff_linter/src/rules/pep8_naming/mod.rs
 snapshot_kind: text
 ---
-N814.py:1:8: N814 Camelcase `Camel` imported as constant `CAMEL`
+N814.py:2:8: N814 Camelcase `Camel` imported as constant `CAMEL`
   |
-1 | import mod.Camel as CAMEL
+1 | # Error
+2 | import mod.Camel as CAMEL
   |        ^^^^^^^^^^^^^^^^^^ N814
-2 | from mod import CamelCase as CAMELCASE
-3 | from mod import AnotherCamelCase as ANOTHER_CAMELCASE
+3 | from mod import CamelCase as CAMELCASE
+4 | from mod import AnotherCamelCase as ANOTHER_CAMELCASE
   |
 
-N814.py:2:17: N814 Camelcase `CamelCase` imported as constant `CAMELCASE`
+N814.py:3:17: N814 Camelcase `CamelCase` imported as constant `CAMELCASE`
   |
-1 | import mod.Camel as CAMEL
-2 | from mod import CamelCase as CAMELCASE
+1 | # Error
+2 | import mod.Camel as CAMEL
+3 | from mod import CamelCase as CAMELCASE
   |                 ^^^^^^^^^^^^^^^^^^^^^^ N814
-3 | from mod import AnotherCamelCase as ANOTHER_CAMELCASE
+4 | from mod import AnotherCamelCase as ANOTHER_CAMELCASE
   |
 
-N814.py:3:17: N814 Camelcase `AnotherCamelCase` imported as constant `ANOTHER_CAMELCASE`
+N814.py:4:17: N814 Camelcase `AnotherCamelCase` imported as constant `ANOTHER_CAMELCASE`
   |
-1 | import mod.Camel as CAMEL
-2 | from mod import CamelCase as CAMELCASE
-3 | from mod import AnotherCamelCase as ANOTHER_CAMELCASE
+2 | import mod.Camel as CAMEL
+3 | from mod import CamelCase as CAMELCASE
+4 | from mod import AnotherCamelCase as ANOTHER_CAMELCASE
   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ N814
+5 | 
+6 | # Ok
   |

--- a/crates/ruff_linter/src/rules/pep8_naming/snapshots/ruff_linter__rules__pep8_naming__tests__N814_N814.py.snap
+++ b/crates/ruff_linter/src/rules/pep8_naming/snapshots/ruff_linter__rules__pep8_naming__tests__N814_N814.py.snap
@@ -2,30 +2,28 @@
 source: crates/ruff_linter/src/rules/pep8_naming/mod.rs
 snapshot_kind: text
 ---
-N814.py:2:8: N814 Camelcase `Camel` imported as constant `CAMEL`
+N814.py:1:8: N814 Camelcase `Camel` imported as constant `CAMEL`
   |
-1 | # Error
-2 | import mod.Camel as CAMEL
+1 | import mod.Camel as CAMEL
   |        ^^^^^^^^^^^^^^^^^^ N814
-3 | from mod import CamelCase as CAMELCASE
-4 | from mod import AnotherCamelCase as ANOTHER_CAMELCASE
+2 | from mod import CamelCase as CAMELCASE
+3 | from mod import AnotherCamelCase as ANOTHER_CAMELCASE
   |
 
-N814.py:3:17: N814 Camelcase `CamelCase` imported as constant `CAMELCASE`
+N814.py:2:17: N814 Camelcase `CamelCase` imported as constant `CAMELCASE`
   |
-1 | # Error
-2 | import mod.Camel as CAMEL
-3 | from mod import CamelCase as CAMELCASE
+1 | import mod.Camel as CAMEL
+2 | from mod import CamelCase as CAMELCASE
   |                 ^^^^^^^^^^^^^^^^^^^^^^ N814
-4 | from mod import AnotherCamelCase as ANOTHER_CAMELCASE
+3 | from mod import AnotherCamelCase as ANOTHER_CAMELCASE
   |
 
-N814.py:4:17: N814 Camelcase `AnotherCamelCase` imported as constant `ANOTHER_CAMELCASE`
+N814.py:3:17: N814 Camelcase `AnotherCamelCase` imported as constant `ANOTHER_CAMELCASE`
   |
-2 | import mod.Camel as CAMEL
-3 | from mod import CamelCase as CAMELCASE
-4 | from mod import AnotherCamelCase as ANOTHER_CAMELCASE
+1 | import mod.Camel as CAMEL
+2 | from mod import CamelCase as CAMELCASE
+3 | from mod import AnotherCamelCase as ANOTHER_CAMELCASE
   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ N814
-5 | 
-6 | # Ok
+4 | 
+5 | import mod.AppleFruit as A
   |


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Under PEP8, identifiers consisting of a single upper-case character could either be a class or a constant.

N811 (constant imported as non-constant) and N814 (camelcase imported as constant) are, however, incorrectly assuming these identifiers to always be constants, which leads to false-positives.

Although identifiers consisting of a single upper-case character are not advised under PEP8, it would be best if these cases were handled by more specific rule(s) that point out ambiguous identifiers and/or violations of PEP8, rather than rules that attempt to narrowly point out changes in identifier casing.

Addresses #11862.

## Test Plan

Additional fixture cases.
