### PR TITLE
[red-knot] Fix Leaking Narrowing Constraint in `ast::ExprIf`

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/expression/if.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/expression/if.md
@@ -27,7 +27,7 @@ reveal_type(1 if 0 else 2)  # revealed: Literal[2]
 
 (issue #14588)
 
-The test inside an if expression should not affect the scope outside of it.
+The test inside an if expression should not affect code outside of the block.
 
 ```py
 def bool_instance() -> bool:

--- a/crates/red_knot_python_semantic/resources/mdtest/expression/if.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/expression/if.md
@@ -22,3 +22,22 @@ reveal_type(1 if None else 2)  # revealed: Literal[2]
 reveal_type(1 if "" else 2)  # revealed: Literal[2]
 reveal_type(1 if 0 else 2)  # revealed: Literal[2]
 ```
+
+## Leaked Narrowing Constraint
+
+(issue #14588)
+
+The test inside an if expression should not affect the scope outside of it.
+
+```py
+def bool_instance() -> bool:
+    return True
+
+x: Literal[42, "hello"] = 42 if bool_instance() else "hello"
+
+reveal_type(x)  # revealed: Literal[42] | Literal["hello"]
+
+_ = ... if isinstance(x, str) else ...
+
+reveal_type(x)  # revealed: Literal[42] | Literal["hello"]
+```

--- a/crates/red_knot_python_semantic/src/semantic_index/builder.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/builder.rs
@@ -1189,8 +1189,8 @@ where
                 // AST inspection, so we can't simplify here, need to record test expression for
                 // later checking)
                 self.visit_expr(test);
-                let constraint = self.record_expression_constraint(test);
                 let pre_if = self.flow_snapshot();
+                let constraint = self.record_expression_constraint(test);
                 self.visit_expr(body);
                 let post_body = self.flow_snapshot();
                 self.flow_restore(pre_if);


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Closes #14588


```py
x: Literal[42, "hello"] = 42 if bool_instance() else "hello"
reveal_type(x)  # revealed: Literal[42] | Literal["hello"]

_ = ... if isinstance(x, str) else ...

# The `isinstance` test incorrectly narrows the type of `x`.
# As a result, `x` is revealed as Literal["hello"], but it should remain Literal[42, "hello"].
reveal_type(x)  # revealed: Literal["hello"]
```

## Test Plan
mdtest included!
