### PR TITLE
[`pylint`] Do not wrap function calls in parentheses in the fix for unnecessary-dunder-call (PLC2801)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pylint/unnecessary_dunder_call.py
+++ b/crates/ruff_linter/resources/test/fixtures/pylint/unnecessary_dunder_call.py
@@ -102,3 +102,6 @@ blah = lambda: {"a": 1}.__delitem__("a")  # OK
 blah = dict[{"a": 1}.__delitem__("a")]  # OK
 
 "abc".__contains__("a")
+
+# https://github.com/astral-sh/ruff/issues/14597
+assert "abc".__str__() == "abc"

--- a/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLC2801_unnecessary_dunder_call.py.snap
+++ b/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLC2801_unnecessary_dunder_call.py.snap
@@ -1088,6 +1088,8 @@ unnecessary_dunder_call.py:104:1: PLC2801 [*] Unnecessary dunder call to `__cont
 103 | 
 104 | "abc".__contains__("a")
     | ^^^^^^^^^^^^^^^^^^^^^^^ PLC2801
+105 | 
+106 | # https://github.com/astral-sh/ruff/issues/14597
     |
     = help: Use `in` operator
 
@@ -1097,3 +1099,21 @@ unnecessary_dunder_call.py:104:1: PLC2801 [*] Unnecessary dunder call to `__cont
 103 103 | 
 104     |-"abc".__contains__("a")
     104 |+"a" in "abc"
+105 105 | 
+106 106 | # https://github.com/astral-sh/ruff/issues/14597
+107 107 | assert "abc".__str__() == "abc"
+
+unnecessary_dunder_call.py:107:8: PLC2801 [*] Unnecessary dunder call to `__str__`. Use `str()` builtin.
+    |
+106 | # https://github.com/astral-sh/ruff/issues/14597
+107 | assert "abc".__str__() == "abc"
+    |        ^^^^^^^^^^^^^^^ PLC2801
+    |
+    = help: Use `str()` builtin
+
+ℹ Unsafe fix
+104 104 | "abc".__contains__("a")
+105 105 | 
+106 106 | # https://github.com/astral-sh/ruff/issues/14597
+107     |-assert "abc".__str__() == "abc"
+    107 |+assert str("abc") == "abc"


### PR DESCRIPTION
In the fix for [unnecessary-dunder-call (PLC2801)](https://docs.astral.sh/ruff/rules/unnecessary-dunder-call/#unnecessary-dunder-call-plc2801), when replacing the dunder call for a builtin by the function call, we no longer wrap the function call in parentheses.

Closes #14597
