### PR TITLE
[red-knot] Update KNOWN_FAILURES

### DIFF
--- a/crates/red_knot_workspace/tests/check.rs
+++ b/crates/red_knot_workspace/tests/check.rs
@@ -272,8 +272,7 @@ const KNOWN_FAILURES: &[(&str, bool, bool)] = &[
     ("crates/ruff_linter/resources/test/fixtures/pyupgrade/UP039.py", true, false),
     // related to circular references in type aliases (salsa cycle panic):
     ("crates/ruff_python_parser/resources/inline/err/type_alias_invalid_value_expr.py", true, true),
-    // related to string annotations (https://github.com/astral-sh/ruff/issues/14440)
+    // related to f-strings in annotations (invalid syntax)
     ("crates/ruff_linter/resources/test/fixtures/pyflakes/F821_15.py", true, true),
     ("crates/ruff_linter/resources/test/fixtures/pyflakes/F821_14.py", false, true),
-    ("crates/ruff_linter/resources/test/fixtures/pyflakes/F632.py", true, true),
 ];


### PR DESCRIPTION

## Summary

Remove entry that was prevously fixed in 5a30ec0df6478b98071004a1a9255e876c5d5c32.

## Test Plan

```sh
cargo test -p red_knot_workspace -- --ignored linter_af linter_gz
```