### PR TITLE
[red-knot] Fix merged type after if-else without explicit else branch

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/narrow/conditionals/elif_else.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/narrow/conditionals/elif_else.md
@@ -55,21 +55,3 @@ else:
     # TODO should be Never
     reveal_type(x)  # revealed: Literal[1, 2]
 ```
-
-## After if-statement without explicit else branch, assume else branch with negative clause
-
-```py
-def optional_int() -> int | None: ...
-
-x = optional_int()
-y = optional_int()
-
-if x is None:
-    x = 0
-
-if y is None:
-    pass
-
-reveal_type(x)  # revealed: int
-reveal_type(y)  # revealed: int | None
-```

--- a/crates/red_knot_python_semantic/resources/mdtest/narrow/conditionals/elif_else.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/narrow/conditionals/elif_else.md
@@ -56,24 +56,11 @@ else:
     reveal_type(x)  # revealed: Literal[1, 2]
 ```
 
-## After if-else statement, final type is the merged type from body of all branches, with explicit else branch
+## After if-statement without explicit else branch, assume else branch with negative clause
 
 ```py
 def optional_int() -> int | None: ...
-x = optional_int()
 
-if x is None:
-    x = 0
-else:
-    pass
-
-reveal_type(x)  # revealed: int
-```
-
-## After if-else statement, final type is the merged type from body of all branches, without explicit else branch
-
-```py
-def optional_int() -> int | None: ...
 x = optional_int()
 
 if x is None:

--- a/crates/red_knot_python_semantic/resources/mdtest/narrow/conditionals/elif_else.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/narrow/conditionals/elif_else.md
@@ -55,3 +55,29 @@ else:
     # TODO should be Never
     reveal_type(x)  # revealed: Literal[1, 2]
 ```
+
+## After if-else statement, final type is the merged type from body of all branches, with explicit else branch
+
+```py
+def optional_int() -> int | None: ...
+x = optional_int()
+
+if x is None:
+    x = 0
+else:
+    pass
+
+reveal_type(x)  # revealed: int
+```
+
+## After if-else statement, final type is the merged type from body of all branches, without explicit else branch
+
+```py
+def optional_int() -> int | None: ...
+x = optional_int()
+
+if x is None:
+    x = 0
+
+reveal_type(x)  # revealed: int
+```

--- a/crates/red_knot_python_semantic/resources/mdtest/narrow/conditionals/elif_else.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/narrow/conditionals/elif_else.md
@@ -62,9 +62,14 @@ else:
 def optional_int() -> int | None: ...
 
 x = optional_int()
+y = optional_int()
 
 if x is None:
     x = 0
 
+if y is None:
+    pass
+
 reveal_type(x)  # revealed: int
+reveal_type(y)  # revealed: int | None
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/narrow/post_if_statement.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/narrow/post_if_statement.md
@@ -1,6 +1,6 @@
 # Consolidating narrowed types after if statement
 
-## After if-else statements, narrowing has no-effect if variable is not mutated
+## After if-else statements, narrowing has no effect if the variable is not mutated in any branch
 
 ```py
 def optional_int() -> int | None: ...

--- a/crates/red_knot_python_semantic/resources/mdtest/narrow/post_if_statement.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/narrow/post_if_statement.md
@@ -48,7 +48,7 @@ reveal_type(x)  # revealed: int
 reveal_type(y)  # revealed: int | None
 ```
 
-## if-elif without explicit else branch, act similar to empty else branch
+## An if-elif without an explicit else branch is equivalent to one with an empty else branch
 
 ```py
 def optional_int() -> int | None: ...

--- a/crates/red_knot_python_semantic/resources/mdtest/narrow/post_if_statement.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/narrow/post_if_statement.md
@@ -21,7 +21,6 @@ reveal_type(x)  # revealed: int | None
 def optional_int() -> int | None: ...
 
 x = optional_int()
-y = optional_int()
 
 if x is None:
     x = 10

--- a/crates/red_knot_python_semantic/resources/mdtest/narrow/post_if_statement.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/narrow/post_if_statement.md
@@ -30,7 +30,7 @@ else:
 reveal_type(x)  # revealed: int
 ```
 
-## if statement without explicit else branch, act similar to empty else branch
+## An if statement without an explicit `else` branch is equivalent to one with a no-op `else` branch
 
 ```py
 def optional_int() -> int | None: ...

--- a/crates/red_knot_python_semantic/resources/mdtest/narrow/post_if_statement.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/narrow/post_if_statement.md
@@ -1,0 +1,15 @@
+## After if-else statements, narrowing has an effect if variable is mutated
+
+```py
+def optional_int() -> int | None: ...
+
+x = optional_int()
+y = optional_int()
+
+if x is None:
+    x = 10
+else:
+    pass
+
+reveal_type(x)  # revealed: int
+```

--- a/crates/red_knot_python_semantic/resources/mdtest/narrow/post_if_statement.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/narrow/post_if_statement.md
@@ -15,7 +15,7 @@ else:
 reveal_type(x)  # revealed: int | None
 ```
 
-## After if-else statements, narrowing has an effect if variable is mutated
+## Narrowing can have a persistent effect if the variable is mutated in one branch
 
 ```py
 def optional_int() -> int | None: ...

--- a/crates/red_knot_python_semantic/resources/mdtest/narrow/post_if_statement.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/narrow/post_if_statement.md
@@ -1,3 +1,20 @@
+# Consolidating narrowed types after if statement
+
+## After if-else statements, narrowing has no-effect if variable is not mutated
+
+```py
+def optional_int() -> int | None: ...
+
+x = optional_int()
+
+if x is None:
+    pass
+else:
+    pass
+
+reveal_type(x)  # revealed: int | None
+```
+
 ## After if-else statements, narrowing has an effect if variable is mutated
 
 ```py
@@ -10,6 +27,39 @@ if x is None:
     x = 10
 else:
     pass
+
+reveal_type(x)  # revealed: int
+```
+
+## if statement without explicit else branch, act similar to empty else branch
+
+```py
+def optional_int() -> int | None: ...
+
+x = optional_int()
+y = optional_int()
+
+if x is None:
+    x = 0
+
+if y is None:
+    pass
+
+reveal_type(x)  # revealed: int
+reveal_type(y)  # revealed: int | None
+```
+
+## if-elif without explicit else branch, act similar to empty else branch
+
+```py
+def optional_int() -> int | None: ...
+
+x = optional_int()
+
+if x is None:
+    x = 0
+elif x > 50:
+    x = 50
 
 reveal_type(x)  # revealed: int
 ```

--- a/crates/red_knot_python_semantic/src/semantic_index/builder.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/builder.rs
@@ -784,7 +784,7 @@ where
                         constraints.push(self.record_expression_constraint(elif_test));
                     }
                     self.visit_body(&clause.body);
-                } 
+                }
                 let has_else = node
                     .elif_else_clauses
                     .last()

--- a/crates/red_knot_python_semantic/src/semantic_index/builder.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/builder.rs
@@ -777,15 +777,13 @@ where
                     .elif_else_clauses
                     .last()
                     .is_some_and(|clause| clause.test.is_none());
-                let elif_else_clauses = elif_else_clauses.chain(
-                    if has_else {
-                        // if there's an `else` clause already, we don't need to add another
-                        None 
-                    } else {
-                        // if there's no `else` branch, we should add a no-op `else` branch
-                        Some((&None, &[][..]))
-                    },
-                );
+                let elif_else_clauses = elif_else_clauses.chain(if has_else {
+                    // if there's an `else` clause already, we don't need to add another
+                    None
+                } else {
+                    // if there's no `else` branch, we should add a no-op `else` branch
+                    Some((&None, &[][..]))
+                });
                 for (clause_test, clause_body) in elif_else_clauses {
                     // snapshot after every block except the last; the last one will just become
                     // the state that we merge the other snapshots into

--- a/crates/red_knot_python_semantic/src/semantic_index/builder.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/builder.rs
@@ -772,7 +772,7 @@ where
                 let elif_else_clauses = node
                     .elif_else_clauses
                     .iter()
-                    .map(|clause| (&clause.test, &clause.body[..]));
+                    .map(|clause| (clause.test.as_ref(), clause.body.as_slice()));
                 let has_else = node
                     .elif_else_clauses
                     .last()
@@ -782,7 +782,7 @@ where
                     None
                 } else {
                     // if there's no `else` branch, we should add a no-op `else` branch
-                    Some((&None, &[][..]))
+                    Some((None, [].as_slice()))
                 });
                 for (clause_test, clause_body) in elif_else_clauses {
                     // snapshot after every block except the last; the last one will just become

--- a/crates/red_knot_python_semantic/src/semantic_index/builder.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/builder.rs
@@ -786,9 +786,7 @@ where
                         Some((&None, &[][..]))
                     },
                 );
-                for clause in elif_else_clauses {
-                    let clause_test = clause.0;
-                    let clause_body = clause.1;
+                for (clause_test, clause_body) in elif_else_clauses {
                     // snapshot after every block except the last; the last one will just become
                     // the state that we merge the other snapshots into
                     post_clauses.push(self.flow_snapshot());

--- a/crates/red_knot_python_semantic/src/semantic_index/builder.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/builder.rs
@@ -782,7 +782,7 @@ where
                     None
                 } else {
                     // if there's no `else` branch, we should add a no-op `else` branch
-                    Some((None, [].as_slice()))
+                    Some((None, Default::default()))
                 });
                 for (clause_test, clause_body) in elif_else_clauses {
                     // snapshot after every block except the last; the last one will just become

--- a/crates/red_knot_python_semantic/src/semantic_index/builder.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/builder.rs
@@ -769,8 +769,14 @@ where
                 let constraint = self.record_expression_constraint(&node.test);
                 let mut constraints = vec![constraint];
                 self.visit_body(&node.body);
-                let mut elif_else_clauses = node.elif_else_clauses.iter().map(|clause| (&clause.test, &clause.body[..])).collect_vec();
-                let has_else = elif_else_clauses.last().is_some_and(|clause| clause.0.is_none());
+                let mut elif_else_clauses = node
+                    .elif_else_clauses
+                    .iter()
+                    .map(|clause| (&clause.test, &clause.body[..]))
+                    .collect_vec();
+                let has_else = elif_else_clauses
+                    .last()
+                    .is_some_and(|clause| clause.0.is_none());
                 if !has_else {
                     // an if-elif statement without an explicit `else` branch is equivalent to one with a no-op `else` branch
                     elif_else_clauses.push((&None, &[]));


### PR DESCRIPTION
## Summary

Closes: https://github.com/astral-sh/ruff/issues/14593

The final type of a variable after if-statement without explicit else branch should  be similar to having an explicit else branch.

## Test Plan

Originally failed test cases from the bug are added.
