### PR TITLE
Do not consider f-strings with escaped newlines as multiline

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/binary.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/binary.py
@@ -424,3 +424,10 @@ xxxxxxxxxxxxxxxx = f"aaaaaaaaaaaaaaaaaaaaa {
     expression } bbbbbbbbbbbbbbbbbbbbbbbb" + (
     yyyyyyyyyyyyyy + zzzzzzzzzzz
 )
+
+# This is not a multiline f-string, but the expression is too long so it should be
+# wrapped in parentheses.
+f"hellooooooooooooooooooooooo \
+        worlddddddddddddddddddddddddddddddddd" + (aaaaaaaaaaaaaaaaaaaaaaaaaa + bbbbbbbbbbbbbbbbbbb)
+aaaaaaaaaaa = f"hellooooooooooooooooooooooo \
+        worlddddddddddddddddddddddddddddddddd" + (aaaaaaaaaaaaaaaaaaaaaaaaaa + bbbbbbbbbbbbbbbbbbb)

--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/join_implicit_concatenated_string.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/join_implicit_concatenated_string.py
@@ -326,3 +326,24 @@ assert False, +"Implicit concatenated string" "uses {} layout on {} format".form
 "a" f'{1=: "abcd \'\'}'
 f'{1=: "abcd \'\'}' "a"
 f'{1=: "abcd \'\'}' f"{1=: 'abcd \"\"}"
+
+# These strings contains escaped newline characters and should be joined, they are
+# not multiline strings.
+f"aaaaaaaaaaaaaaaa \
+        bbbbbbbbbbb" "cccccccccccccc \
+               ddddddddddddddddddd"
+b"aaaaaaaaaaaaaaaa \
+        bbbbbbbbbbb" b"cccccccccccccc \
+               ddddddddddddddddddd"
+f"aaaaaaaaaaaaaaaa \
+        bbbbbbbbbbb" "cccccccccccccc \
+               ddddddddddddddddddd"  # comment 1
+(f"aaaaaaaaaaaaaaaa \
+        bbbbbbbbbbb" "cccccccccccccc \
+               ddddddddddddddddddd")  # comment 2
+(
+    f"aaaaaaaaaaaaaaaa \
+            bbbbbbbbbbb" # comment 3
+    "cccccccccccccc \
+            ddddddddddddddddddd"  # comment 4
+)

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__binary.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__binary.py.snap
@@ -430,6 +430,13 @@ xxxxxxxxxxxxxxxx = f"aaaaaaaaaaaaaaaaaaaaa {
     expression } bbbbbbbbbbbbbbbbbbbbbbbb" + (
     yyyyyyyyyyyyyy + zzzzzzzzzzz
 )
+
+# This is not a multiline f-string, but the expression is too long so it should be
+# wrapped in parentheses.
+f"hellooooooooooooooooooooooo \
+        worlddddddddddddddddddddddddddddddddd" + (aaaaaaaaaaaaaaaaaaaaaaaaaa + bbbbbbbbbbbbbbbbbbb)
+aaaaaaaaaaa = f"hellooooooooooooooooooooooo \
+        worlddddddddddddddddddddddddddddddddd" + (aaaaaaaaaaaaaaaaaaaaaaaaaa + bbbbbbbbbbbbbbbbbbb)
 ```
 
 ## Output
@@ -906,6 +913,17 @@ if True:
 # This f-string should be flattened
 xxxxxxxxxxxxxxxx = f"aaaaaaaaaaaaaaaaaaaaa {
     expression } bbbbbbbbbbbbbbbbbbbbbbbb" + (yyyyyyyyyyyyyy + zzzzzzzzzzz)
+
+# This is not a multiline f-string, but the expression is too long so it should be
+# wrapped in parentheses.
+f"hellooooooooooooooooooooooo \
+        worlddddddddddddddddddddddddddddddddd" + (
+    aaaaaaaaaaaaaaaaaaaaaaaaaa + bbbbbbbbbbbbbbbbbbb
+)
+aaaaaaaaaaa = f"hellooooooooooooooooooooooo \
+        worlddddddddddddddddddddddddddddddddd" + (
+    aaaaaaaaaaaaaaaaaaaaaaaaaa + bbbbbbbbbbbbbbbbbbb
+)
 ```
 
 
@@ -913,7 +931,7 @@ xxxxxxxxxxxxxxxx = f"aaaaaaaaaaaaaaaaaaaaa {
 ```diff
 --- Stable
 +++ Preview
-@@ -468,5 +468,6 @@
+@@ -468,16 +468,19 @@
                  )
  
  # This f-string should be flattened
@@ -922,4 +940,23 @@ xxxxxxxxxxxxxxxx = f"aaaaaaaaaaaaaaaaaaaaa {
 +xxxxxxxxxxxxxxxx = f"aaaaaaaaaaaaaaaaaaaaa {expression} bbbbbbbbbbbbbbbbbbbbbbbb" + (
 +    yyyyyyyyyyyyyy + zzzzzzzzzzz
 +)
+ 
+ # This is not a multiline f-string, but the expression is too long so it should be
+ # wrapped in parentheses.
+-f"hellooooooooooooooooooooooo \
+-        worlddddddddddddddddddddddddddddddddd" + (
+-    aaaaaaaaaaaaaaaaaaaaaaaaaa + bbbbbbbbbbbbbbbbbbb
++(
++    f"hellooooooooooooooooooooooo \
++        worlddddddddddddddddddddddddddddddddd"
++    + (aaaaaaaaaaaaaaaaaaaaaaaaaa + bbbbbbbbbbbbbbbbbbb)
+ )
+-aaaaaaaaaaa = f"hellooooooooooooooooooooooo \
+-        worlddddddddddddddddddddddddddddddddd" + (
+-    aaaaaaaaaaaaaaaaaaaaaaaaaa + bbbbbbbbbbbbbbbbbbb
++aaaaaaaaaaa = (
++    f"hellooooooooooooooooooooooo \
++        worlddddddddddddddddddddddddddddddddd"
++    + (aaaaaaaaaaaaaaaaaaaaaaaaaa + bbbbbbbbbbbbbbbbbbb)
+ )
 ```

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__join_implicit_concatenated_string.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__join_implicit_concatenated_string.py.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/ruff_python_formatter/tests/fixtures.rs
 input_file: crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/join_implicit_concatenated_string.py
-snapshot_kind: text
 ---
 ## Input
 ```python
@@ -333,6 +332,27 @@ assert False, +"Implicit concatenated string" "uses {} layout on {} format".form
 "a" f'{1=: "abcd \'\'}'
 f'{1=: "abcd \'\'}' "a"
 f'{1=: "abcd \'\'}' f"{1=: 'abcd \"\"}"
+
+# These strings contains escaped newline characters and should be joined, they are
+# not multiline strings.
+f"aaaaaaaaaaaaaaaa \
+        bbbbbbbbbbb" "cccccccccccccc \
+               ddddddddddddddddddd"
+b"aaaaaaaaaaaaaaaa \
+        bbbbbbbbbbb" b"cccccccccccccc \
+               ddddddddddddddddddd"
+f"aaaaaaaaaaaaaaaa \
+        bbbbbbbbbbb" "cccccccccccccc \
+               ddddddddddddddddddd"  # comment 1
+(f"aaaaaaaaaaaaaaaa \
+        bbbbbbbbbbb" "cccccccccccccc \
+               ddddddddddddddddddd")  # comment 2
+(
+    f"aaaaaaaaaaaaaaaa \
+            bbbbbbbbbbb" # comment 3
+    "cccccccccccccc \
+            ddddddddddddddddddd"  # comment 4
+)
 ```
 
 ## Outputs
@@ -747,4 +767,28 @@ assert False, +"Implicit concatenated stringuses {} layout on {} format".format(
 f'a{1=: "abcd \'\'}'
 f'{1=: "abcd \'\'}a'
 f'{1=: "abcd \'\'}' f"{1=: 'abcd \"\"}"
+
+# These strings contains escaped newline characters and should be joined, they are
+# not multiline strings.
+f"aaaaaaaaaaaaaaaa \
+        bbbbbbbbbbbcccccccccccccc \
+               ddddddddddddddddddd"
+b"aaaaaaaaaaaaaaaa \
+        bbbbbbbbbbbcccccccccccccc \
+               ddddddddddddddddddd"
+f"aaaaaaaaaaaaaaaa \
+        bbbbbbbbbbbcccccccccccccc \
+               ddddddddddddddddddd"  # comment 1
+(
+    f"aaaaaaaaaaaaaaaa \
+        bbbbbbbbbbb"
+    "cccccccccccccc \
+               ddddddddddddddddddd"
+)  # comment 2
+(
+    f"aaaaaaaaaaaaaaaa \
+            bbbbbbbbbbb"  # comment 3
+    "cccccccccccccc \
+            ddddddddddddddddddd"  # comment 4
+)
 ```


### PR DESCRIPTION
## Summary

This PR fixes a bug in the f-string formatting to not consider the escaped newlines for `is_multiline`. This is done by checking if the f-string is triple-quoted or not similar to normal string literals.

This is not required to be gated behind preview because the logic change for `is_multiline` was added in https://github.com/astral-sh/ruff/pull/14454.

## Test Plan

Add a test case which formats differently on `main`: https://play.ruff.rs/ea3c55c2-f0fe-474e-b6b8-e3365e0ede5e
