### PR TITLE
[red-knot] No panic for illegal self-referential f-string annotations

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/annotations/string.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/annotations/string.md
@@ -125,7 +125,6 @@ def f7() -> "\x69nt":
 def f8() -> """int""":
     return 1
 
-# error: [annotation-byte-string] "Type expressions cannot use bytes literal"
 def f9() -> "b'int'":
     return 1
 

--- a/crates/red_knot_python_semantic/resources/mdtest/call/function.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/call/function.md
@@ -36,6 +36,8 @@ from typing import Callable
 def foo() -> int:
     return 42
 
+# TODO: This should be resolved once we understand `Callable` annotations
+# error: [annotation-with-invalid-expression]
 def decorator(func) -> Callable[[], int]:
     return foo
 

--- a/crates/red_knot_python_semantic/resources/mdtest/literal/literal.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/literal/literal.md
@@ -75,6 +75,8 @@ Literal: _SpecialForm
 ```py
 from other import Literal
 
+# TODO: we should not emit this error once we understand Literal[..] annotations
+# error: [annotation-with-invalid-expression]
 a1: Literal[26]
 
 def f():

--- a/crates/red_knot_python_semantic/resources/mdtest/literal/literal.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/literal/literal.md
@@ -75,7 +75,6 @@ Literal: _SpecialForm
 ```py
 from other import Literal
 
-# TODO: we should not emit this error once we understand Literal[..] annotations
 # error: [annotation-with-invalid-expression]
 a1: Literal[26]
 

--- a/crates/red_knot_workspace/tests/check.rs
+++ b/crates/red_knot_workspace/tests/check.rs
@@ -272,7 +272,4 @@ const KNOWN_FAILURES: &[(&str, bool, bool)] = &[
     ("crates/ruff_linter/resources/test/fixtures/pyupgrade/UP039.py", true, false),
     // related to circular references in type aliases (salsa cycle panic):
     ("crates/ruff_python_parser/resources/inline/err/type_alias_invalid_value_expr.py", true, true),
-    // related to circular references in f-string annotations (invalid syntax)
-    ("crates/ruff_linter/resources/test/fixtures/pyflakes/F821_15.py", true, true),
-    ("crates/ruff_linter/resources/test/fixtures/pyflakes/F821_14.py", false, true),
 ];

--- a/crates/ruff_benchmark/benches/red_knot.rs
+++ b/crates/ruff_benchmark/benches/red_knot.rs
@@ -27,13 +27,17 @@ static EXPECTED_DIAGNOSTICS: &[&str] = &[
     // We don't support `*` imports yet:
     "error[unresolved-import] /src/tomllib/_parser.py:7:29 Module `collections.abc` has no member `Iterable`",
     // We don't support terminal statements in control flow yet:
+    "error[annotation-with-invalid-expression] /src/tomllib/_parser.py:57:71 Invalid expression in type expression",
     "error[possibly-unresolved-reference] /src/tomllib/_parser.py:66:18 Name `s` used when possibly not defined",
+    "error[annotation-with-invalid-expression] /src/tomllib/_parser.py:69:66 Invalid expression in type expression",
     "error[possibly-unresolved-reference] /src/tomllib/_parser.py:98:12 Name `char` used when possibly not defined",
     "error[possibly-unresolved-reference] /src/tomllib/_parser.py:101:12 Name `char` used when possibly not defined",
     "error[possibly-unresolved-reference] /src/tomllib/_parser.py:104:14 Name `char` used when possibly not defined",
     "error[conflicting-declarations] /src/tomllib/_parser.py:108:17 Conflicting declared types for `second_char`: Unknown, str | None",
     "error[possibly-unresolved-reference] /src/tomllib/_parser.py:115:14 Name `char` used when possibly not defined",
     "error[possibly-unresolved-reference] /src/tomllib/_parser.py:126:12 Name `char` used when possibly not defined",
+    "error[annotation-with-invalid-expression] /src/tomllib/_parser.py:145:27 Invalid expression in type expression",
+    "error[annotation-with-invalid-expression] /src/tomllib/_parser.py:196:25 Invalid expression in type expression",
     "error[conflicting-declarations] /src/tomllib/_parser.py:267:9 Conflicting declared types for `char`: Unknown, str | None",
     "error[possibly-unresolved-reference] /src/tomllib/_parser.py:348:20 Name `nest` used when possibly not defined",
     "error[possibly-unresolved-reference] /src/tomllib/_parser.py:353:5 Name `nest` used when possibly not defined",


### PR DESCRIPTION
## Summary

I went down another rabbit hole trying to fix all sorts of panics related to illegal type expressions. Some highlights from the linter corpus:
```py
x: f"{x}"
x: (y := x)
x: lambda y: y
type X = Annotated[int, lambda: re.compile("x")]
```

This fixes the last two remaining entries in `KNOWN_FAILURES` except for those related to salsa-cycles. But I really don't know if the approach taken here — to infer `Type::Unknown` for sub-expressions of illegal expressions — is the right one. And even if it is, I'm not sure if my implementation of it is fully correct (see for example the exception for expressions with an inner scope). I thought I'd still open a PR so we can discuss the general problem.

Side remark: After having fixed a few of those panics over the last weeks, my impression is that our approach to upholding the invariant "we infer and store a type for each and every expression, even if illegal in this context" is extremely brittle. The only way we enforce it right now is through the corpus tests. But there is an exponentially large number of branches in type inference (or alternatively: an exponentially large number of weird edge cases like the above), which makes me think that we might need another way to enforce this constraint, e.g. at the (Rust) type-system level instead of the test level.

## Test Plan

```rs
cargo nextest run -p red_knot_workspace -- --ignored linter_af linter_gz
```