### PR TITLE
Gate `is_multiline` change behind preview

### DIFF
--- a/crates/ruff_python_formatter/src/string/mod.rs
+++ b/crates/ruff_python_formatter/src/string/mod.rs
@@ -119,42 +119,35 @@ impl StringLikeExtensions for ast::StringLike<'_> {
                             context.source().contains_line_break(literal.range())
                         }
                         ast::FStringElement::Expression(expression) => {
-                            if is_f_string_formatting_enabled(context) {
-                                // Expressions containing comments can't be joined.
-                                //
-                                // Format specifiers needs to be checked as well. For example, the
-                                // following should be considered multiline because the literal
-                                // part of the format specifier contains a newline at the end
-                                // (`.3f\n`):
-                                //
-                                // ```py
-                                // x = f"hello {a + b + c + d:.3f
-                                // } world"
-                                // ```
-                                context.comments().contains_comments(expression.into())
-                                    || expression.format_spec.as_deref().is_some_and(|spec| {
-                                        contains_line_break_or_comments(&spec.elements, context)
-                                    })
-                                    || expression.debug_text.as_ref().is_some_and(|debug_text| {
-                                        memchr2(b'\n', b'\r', debug_text.leading.as_bytes())
+                            // Expressions containing comments can't be joined.
+                            //
+                            // Format specifiers needs to be checked as well. For example, the
+                            // following should be considered multiline because the literal
+                            // part of the format specifier contains a newline at the end
+                            // (`.3f\n`):
+                            //
+                            // ```py
+                            // x = f"hello {a + b + c + d:.3f
+                            // } world"
+                            // ```
+                            context.comments().contains_comments(expression.into())
+                                || expression.format_spec.as_deref().is_some_and(|spec| {
+                                    contains_line_break_or_comments(&spec.elements, context)
+                                })
+                                || expression.debug_text.as_ref().is_some_and(|debug_text| {
+                                    memchr2(b'\n', b'\r', debug_text.leading.as_bytes()).is_some()
+                                        || memchr2(b'\n', b'\r', debug_text.trailing.as_bytes())
                                             .is_some()
-                                            || memchr2(b'\n', b'\r', debug_text.trailing.as_bytes())
-                                                .is_some()
-                                    })
-                            } else {
-                                // Multiline f-string expressions can't be joined if the f-string
-                                // formatting is disabled because the string gets inserted in
-                                // verbatim preserving the newlines.
-                                //
-                                // We don't need to check format specifiers or debug text here
-                                // because the expression range already includes them.
-                                context.source().contains_line_break(expression.range())
-                            }
+                                })
                         }
                     })
                 }
 
-                contains_line_break_or_comments(&f_string.elements, context)
+                if is_f_string_formatting_enabled(context) {
+                    contains_line_break_or_comments(&f_string.elements, context)
+                } else {
+                    context.source().contains_line_break(f_string.range())
+                }
             }
         })
     }


### PR DESCRIPTION
## Summary

Ref: https://github.com/astral-sh/ruff/pull/14624#pullrequestreview-2464127254

## Test Plan

The test case in the follow-up PR showcases the difference between preview and non-preview formatting: https://github.com/astral-sh/ruff/pull/14624/files#diff-dc25bd4df280d9a9180598075b5bc2d0bac30af956767b373561029309c8f024
