### PR TITLE
Check `AIR001` from builtin or providers `operators` module

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/airflow/AIR001.py
+++ b/crates/ruff_linter/resources/test/fixtures/airflow/AIR001.py
@@ -1,4 +1,6 @@
 from airflow.operators import PythonOperator
+from airflow.providers.airbyte.operators.airbyte import AirbyteTriggerSyncOperator
+from airflow.providers.amazon.aws.operators.appflow import AppflowFlowRunOperator
 
 
 def my_callable():
@@ -6,11 +8,15 @@ def my_callable():
 
 
 my_task = PythonOperator(task_id="my_task", callable=my_callable)
-my_task_2 = PythonOperator(callable=my_callable, task_id="my_task_2")
+incorrect_name = PythonOperator(task_id="my_task")  # AIR001
 
-incorrect_name = PythonOperator(task_id="my_task")
-incorrect_name_2 = PythonOperator(callable=my_callable, task_id="my_task_2")
+my_task = AirbyteTriggerSyncOperator(task_id="my_task", callable=my_callable)
+incorrect_name = AirbyteTriggerSyncOperator(task_id="my_task")  # AIR001
 
-from my_module import MyClass
+my_task = AppflowFlowRunOperator(task_id="my_task", callable=my_callable)
+incorrect_name = AppflowFlowRunOperator(task_id="my_task")  # AIR001
 
-incorrect_name = MyClass(task_id="my_task")
+# Consider only from the `airflow.operators` (or providers operators) module
+from airflow import MyOperator
+
+incorrect_name = MyOperator(task_id="my_task")

--- a/crates/ruff_linter/src/checkers/ast/analyze/statement.rs
+++ b/crates/ruff_linter/src/checkers/ast/analyze/statement.rs
@@ -1554,11 +1554,7 @@ pub(crate) fn statement(stmt: &Stmt, checker: &mut Checker) {
                 .rules
                 .enabled(Rule::AirflowVariableNameTaskIdMismatch)
             {
-                if let Some(diagnostic) =
-                    airflow::rules::variable_name_task_id(checker, targets, value)
-                {
-                    checker.diagnostics.push(diagnostic);
-                }
+                airflow::rules::variable_name_task_id(checker, targets, value);
             }
             if checker.settings.rules.enabled(Rule::SelfAssigningVariable) {
                 pylint::rules::self_assignment(checker, assign);

--- a/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR001_AIR001.py.snap
+++ b/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR001_AIR001.py.snap
@@ -1,21 +1,29 @@
 ---
 source: crates/ruff_linter/src/rules/airflow/mod.rs
-snapshot_kind: text
 ---
 AIR001.py:11:1: AIR001 Task variable name should match the `task_id`: "my_task"
    |
- 9 | my_task_2 = PythonOperator(callable=my_callable, task_id="my_task_2")
-10 | 
-11 | incorrect_name = PythonOperator(task_id="my_task")
+10 | my_task = PythonOperator(task_id="my_task", callable=my_callable)
+11 | incorrect_name = PythonOperator(task_id="my_task")  # AIR001
    | ^^^^^^^^^^^^^^ AIR001
-12 | incorrect_name_2 = PythonOperator(callable=my_callable, task_id="my_task_2")
+12 | 
+13 | my_task = AirbyteTriggerSyncOperator(task_id="my_task", callable=my_callable)
    |
 
-AIR001.py:12:1: AIR001 Task variable name should match the `task_id`: "my_task_2"
+AIR001.py:14:1: AIR001 Task variable name should match the `task_id`: "my_task"
    |
-11 | incorrect_name = PythonOperator(task_id="my_task")
-12 | incorrect_name_2 = PythonOperator(callable=my_callable, task_id="my_task_2")
-   | ^^^^^^^^^^^^^^^^ AIR001
-13 | 
-14 | from my_module import MyClass
+13 | my_task = AirbyteTriggerSyncOperator(task_id="my_task", callable=my_callable)
+14 | incorrect_name = AirbyteTriggerSyncOperator(task_id="my_task")  # AIR001
+   | ^^^^^^^^^^^^^^ AIR001
+15 | 
+16 | my_task = AppflowFlowRunOperator(task_id="my_task", callable=my_callable)
+   |
+
+AIR001.py:17:1: AIR001 Task variable name should match the `task_id`: "my_task"
+   |
+16 | my_task = AppflowFlowRunOperator(task_id="my_task", callable=my_callable)
+17 | incorrect_name = AppflowFlowRunOperator(task_id="my_task")  # AIR001
+   | ^^^^^^^^^^^^^^ AIR001
+18 | 
+19 | # Consider only from the `airflow.operators` (or providers operators) module
    |


### PR DESCRIPTION
## Summary

This PR makes changes to the `AIR001` rule as per https://github.com/astral-sh/ruff/pull/14627#discussion_r1860212307.

Additionally,
* Avoid returning the `Diagnostic` and update the checker in the rule logic for consistency
* Remove test case for different keyword position (I don't think it's required here)

## Test Plan

Add test cases for multiple operators from various modules.
