### PR TITLE
 Refactor `crates/ruff_python_stdlib/src/builtins.rs` to make it easier to add support for new Python versions

### DIFF
--- a/crates/ruff_python_stdlib/src/builtins.rs
+++ b/crates/ruff_python_stdlib/src/builtins.rs
@@ -379,9 +379,9 @@ pub fn is_python_builtin(name: &str, minor_version: u8, is_notebook: bool) -> bo
                 | "type"
                 | "vars"
                 | "zip"
-        ) | (10..=13, "EncodingWarning" | "aiter" | "anext")
-            | (11..=13, "BaseExceptionGroup" | "ExceptionGroup")
-            | (13, "PythonFinalizationError")
+        ) | (10.., "EncodingWarning" | "aiter" | "anext")
+            | (11.., "BaseExceptionGroup" | "ExceptionGroup")
+            | (13.., "PythonFinalizationError")
     )
 }
 
@@ -489,8 +489,8 @@ pub fn is_exception(name: &str, minor_version: u8) -> bool {
                 | "SyntaxWarning"
                 | "UnicodeWarning"
                 | "UserWarning"
-        ) | (10..=13, "EncodingWarning")
-            | (11..=13, "BaseExceptionGroup" | "ExceptionGroup")
-            | (13, "PythonFinalizationError")
+        ) | (10.., "EncodingWarning")
+            | (11.., "BaseExceptionGroup" | "ExceptionGroup")
+            | (13.., "PythonFinalizationError")
     )
 }


### PR DESCRIPTION
## Summary

[Summary is now out of date, but is preserved for posterity. See conversation below.]

This PR adds Python 3.14 to the list of versions that we allow users to select for the `target-version` setting. The motivation is that this will allow us to detect if the target version is Python 3.14 or higher in #14623 and, if so, we can recommend using the faster function `Path.scandir()` in that rule rather than `Path.iterdir()`.

This PR _does not_ generally declare that Ruff _supports_ Python 3.14. I'm pretty hesitant to do that while Python 3.14 is still in its alpha period, since there might be many APIs (and even new syntax) added between now and the point when the first 3.14 beta is released. However, I don't see much harm in allowing users to _select_ Python 3.14 as their target version now, even if we don't yet officially declare that we support Python 3.14.

## Test Plan

`cargo test`
