### PR TITLE
Fix bug where methods defined using lambdas were flagged by FURB118

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/refurb/FURB118.py
+++ b/crates/ruff_linter/resources/test/fixtures/refurb/FURB118.py
@@ -102,3 +102,21 @@ class Foo:
 
 class Bar:
     y = lambda self, other: self == other
+
+from typing import Callable
+class Baz:
+    z: Callable = lambda self, other: self == other
+
+
+# lambdas used in decorators do not constitute method definitions,
+# so these *should* be flagged:
+class TheLambdasHereAreNotMethods:
+    @pytest.mark.parametrize(
+        "slicer, expected",
+        [
+            (lambda x: x[-2:], "foo"),
+            (lambda x: x[-5:-3], "bar"),
+        ],
+    )
+    def test_inlet_asset_alias_extra_slice(self, slicer, expected):
+        assert slice("whatever") == expected

--- a/crates/ruff_linter/resources/test/fixtures/refurb/FURB118.py
+++ b/crates/ruff_linter/resources/test/fixtures/refurb/FURB118.py
@@ -108,6 +108,18 @@ class Baz:
     z: Callable = lambda self, other: self == other
 
 
+# Lambdas wrapped in function calls could also still be method definitions!
+# To avoid false positives, we shouldn't flag any of these either:
+from typing import final, override, no_type_check
+
+
+class Foo:
+    a = final(lambda self, other: self == other)
+    b = override(lambda self, other: self == other)
+    c = no_type_check(lambda self, other: self == other)
+    d = final(override(no_type_check(lambda self, other: self == other)))
+
+
 # lambdas used in decorators do not constitute method definitions,
 # so these *should* be flagged:
 class TheLambdasHereAreNotMethods:

--- a/crates/ruff_linter/resources/test/fixtures/refurb/FURB118.py
+++ b/crates/ruff_linter/resources/test/fixtures/refurb/FURB118.py
@@ -101,4 +101,4 @@ class Foo:
         return self == other
 
 class Bar:
-    y = lambda selfff, other: self == other
+    y = lambda self, other: self == other

--- a/crates/ruff_linter/resources/test/fixtures/refurb/FURB118.py
+++ b/crates/ruff_linter/resources/test/fixtures/refurb/FURB118.py
@@ -132,3 +132,12 @@ class TheLambdasHereAreNotMethods:
     )
     def test_inlet_asset_alias_extra_slice(self, slicer, expected):
         assert slice("whatever") == expected
+
+
+class NotAMethodButHardToDetect:
+    # in an ideal world, perhaps we'd flag this,
+    # but practically speaking it's hard to see how we'd accurately determine
+    # that the `lambda` is *not* a method definition
+    # without risking false positives elsewhere or introducing complex heuristics
+    # that users would find surprising and confusing
+    FOO = sorted([x for x in BAR], key=lambda x: x.baz)

--- a/crates/ruff_linter/resources/test/fixtures/refurb/FURB118.py
+++ b/crates/ruff_linter/resources/test/fixtures/refurb/FURB118.py
@@ -93,3 +93,12 @@ op_itemgetter = lambda x: x[1,          :]
 
 # Without a slice, trivia is retained
 op_itemgetter = lambda x: x[1,          2]
+
+
+# All methods in classes are ignored, even those defined using lambdas:
+class Foo:
+    def x(self, other):
+        return self == other
+
+class Bar:
+    y = lambda selfff, other: self == other

--- a/crates/ruff_linter/resources/test/fixtures/refurb/FURB118.py
+++ b/crates/ruff_linter/resources/test/fixtures/refurb/FURB118.py
@@ -135,8 +135,10 @@ class TheLambdasHereAreNotMethods:
 
 
 class NotAMethodButHardToDetect:
-    # in an ideal world, perhaps we'd flag this,
-    # but practically speaking it's hard to see how we'd accurately determine
+    # In an ideal world, perhaps we'd emit a diagnostic here,
+    # since this `lambda` is clearly not a method definition,
+    # and *could* be safely replaced with an `operator` function.
+    # Practically speaking, however, it's hard to see how we'd accurately determine
     # that the `lambda` is *not* a method definition
     # without risking false positives elsewhere or introducing complex heuristics
     # that users would find surprising and confusing

--- a/crates/ruff_linter/src/checkers/ast/analyze/deferred_lambdas.rs
+++ b/crates/ruff_linter/src/checkers/ast/analyze/deferred_lambdas.rs
@@ -2,7 +2,7 @@ use ruff_python_ast::Expr;
 
 use crate::checkers::ast::Checker;
 use crate::codes::Rule;
-use crate::rules::{flake8_builtins, flake8_pie, pylint, refurb};
+use crate::rules::{flake8_builtins, flake8_pie, pylint};
 
 /// Run lint rules over all deferred lambdas in the [`SemanticModel`].
 pub(crate) fn deferred_lambdas(checker: &mut Checker) {
@@ -20,9 +20,6 @@ pub(crate) fn deferred_lambdas(checker: &mut Checker) {
             }
             if checker.enabled(Rule::ReimplementedContainerBuiltin) {
                 flake8_pie::rules::reimplemented_container_builtin(checker, lambda);
-            }
-            if checker.enabled(Rule::ReimplementedOperator) {
-                refurb::rules::reimplemented_operator(checker, &lambda.into());
             }
             if checker.enabled(Rule::BuiltinLambdaArgumentShadowing) {
                 flake8_builtins::rules::builtin_lambda_argument_shadowing(checker, lambda);

--- a/crates/ruff_linter/src/checkers/ast/analyze/expression.rs
+++ b/crates/ruff_linter/src/checkers/ast/analyze/expression.rs
@@ -1650,6 +1650,11 @@ pub(crate) fn expression(expr: &Expr, checker: &mut Checker) {
                 ruff::rules::assignment_in_assert(checker, expr);
             }
         }
+        Expr::Lambda(lambda_expr) => {
+            if checker.enabled(Rule::ReimplementedOperator) {
+                refurb::rules::reimplemented_operator(checker, &lambda_expr.into());
+            }
+        }
         _ => {}
     };
 }

--- a/crates/ruff_linter/src/rules/refurb/rules/reimplemented_operator.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/reimplemented_operator.rs
@@ -91,7 +91,9 @@ impl Violation for ReimplementedOperator {
 
 /// FURB118
 pub(crate) fn reimplemented_operator(checker: &mut Checker, target: &FunctionLike) {
-    // Ignore methods, whether defined using the `def` keyword or via a `lambda` assignment.
+    // Ignore methods.
+    // Methods can be defined via a `def` statement in a class scope,
+    // or via a lambda appearing on the right-hand side of an assignment in a class scope.
     if checker.semantic().current_scope().kind.is_class()
         && (target.is_function_def()
             || checker

--- a/crates/ruff_linter/src/rules/refurb/rules/reimplemented_operator.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/reimplemented_operator.rs
@@ -51,21 +51,21 @@ use crate::Locator;
 /// this rule.
 ///
 /// The first difference is that `operator` functions cannot be called with keyword arguments, but
-/// most user-defined functions can. If an `add` function is defined as `add = lambda x, y: x + y`
+/// most user-defined functions can. If an `add` function is defined as `add = lambda x, y: x + y`,
 /// replacing this function with `operator.add` will cause the later call to raise `TypeError` if
 /// the function is later called with keyword arguments, e.g. `add(x=1, y=2)`.
 ///
 /// The second difference is that user-defined functions are [descriptors], but this is not true of
 /// the functions defined in the `operator` module. Practically speaking, this means that defining
-/// a function in a class body (either using a `def` statement or assigning a `lambda` function to
-/// a variable) is a valid way of defining an instance method on that class; monkeypatching a
+/// a function in a class body (either by using a `def` statement or assigning a `lambda` function
+/// to a variable) is a valid way of defining an instance method on that class; monkeypatching a
 /// user-defined function onto a class after the class has been created also has the same effect.
-/// The same is not true of an `operator` function: assigning an operator function to a variable in
-/// a class body or monkeypatching it onto a class will not create a valid instance method. Ruff
-/// will refrain from emitting diagnostics for this rule on function definitions in class bodies;
-/// however, it does not currently have sophisticated enough type inference to avoid emitting this
-/// diagnostic if a user-defined function is being monkeypatched onto a class after the class has
-/// been constructed.
+/// The same is not true of an `operator` function: assigning an `operator` function to a variable
+/// in a class body or monkeypatching one onto a class will not create a valid instance method.
+/// Ruff will refrain from emitting diagnostics for this rule on function definitions in class
+/// bodies; however, it does not currently have sophisticated enough type inference to avoid
+/// emitting this diagnostic if a user-defined function is being monkeypatched onto a class after
+/// the class has been constructed.
 ///
 /// [descriptors]: https://docs.python.org/3/howto/descriptor.html
 #[derive(ViolationMetadata)]

--- a/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__FURB118_FURB118.py.snap
+++ b/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__FURB118_FURB118.py.snap
@@ -950,60 +950,60 @@ FURB118.py:95:17: FURB118 [*] Use `operator.itemgetter((1,          2))` instead
 97 98 | 
 98 99 | # All methods in classes are ignored, even those defined using lambdas:
 
-FURB118.py:117:14: FURB118 [*] Use `operator.itemgetter(slice(-2, None))` instead of defining a lambda
+FURB118.py:129:14: FURB118 [*] Use `operator.itemgetter(slice(-2, None))` instead of defining a lambda
     |
-115 |         "slicer, expected",
-116 |         [
-117 |             (lambda x: x[-2:], "foo"),
+127 |         "slicer, expected",
+128 |         [
+129 |             (lambda x: x[-2:], "foo"),
     |              ^^^^^^^^^^^^^^^^ FURB118
-118 |             (lambda x: x[-5:-3], "bar"),
-119 |         ],
+130 |             (lambda x: x[-5:-3], "bar"),
+131 |         ],
     |
     = help: Replace with `operator.itemgetter(slice(-2, None))`
 
 ℹ Unsafe fix
-104 104 |     y = lambda self, other: self == other
-105 105 | 
-106 106 | from typing import Callable
-    107 |+import operator
-107 108 | class Baz:
-108 109 |     z: Callable = lambda self, other: self == other
-109 110 | 
+111 111 | # Lambdas wrapped in function calls could also still be method definitions!
+112 112 | # To avoid false positives, we shouldn't flag any of these either:
+113 113 | from typing import final, override, no_type_check
+    114 |+import operator
+114 115 | 
+115 116 | 
+116 117 | class Foo:
 --------------------------------------------------------------------------------
-114 115 |     @pytest.mark.parametrize(
-115 116 |         "slicer, expected",
-116 117 |         [
-117     |-            (lambda x: x[-2:], "foo"),
-    118 |+            (operator.itemgetter(slice(-2, None)), "foo"),
-118 119 |             (lambda x: x[-5:-3], "bar"),
-119 120 |         ],
-120 121 |     )
+126 127 |     @pytest.mark.parametrize(
+127 128 |         "slicer, expected",
+128 129 |         [
+129     |-            (lambda x: x[-2:], "foo"),
+    130 |+            (operator.itemgetter(slice(-2, None)), "foo"),
+130 131 |             (lambda x: x[-5:-3], "bar"),
+131 132 |         ],
+132 133 |     )
 
-FURB118.py:118:14: FURB118 [*] Use `operator.itemgetter(slice(-5, -3))` instead of defining a lambda
+FURB118.py:130:14: FURB118 [*] Use `operator.itemgetter(slice(-5, -3))` instead of defining a lambda
     |
-116 |         [
-117 |             (lambda x: x[-2:], "foo"),
-118 |             (lambda x: x[-5:-3], "bar"),
+128 |         [
+129 |             (lambda x: x[-2:], "foo"),
+130 |             (lambda x: x[-5:-3], "bar"),
     |              ^^^^^^^^^^^^^^^^^^ FURB118
-119 |         ],
-120 |     )
+131 |         ],
+132 |     )
     |
     = help: Replace with `operator.itemgetter(slice(-5, -3))`
 
 ℹ Unsafe fix
-104 104 |     y = lambda self, other: self == other
-105 105 | 
-106 106 | from typing import Callable
-    107 |+import operator
-107 108 | class Baz:
-108 109 |     z: Callable = lambda self, other: self == other
-109 110 | 
+111 111 | # Lambdas wrapped in function calls could also still be method definitions!
+112 112 | # To avoid false positives, we shouldn't flag any of these either:
+113 113 | from typing import final, override, no_type_check
+    114 |+import operator
+114 115 | 
+115 116 | 
+116 117 | class Foo:
 --------------------------------------------------------------------------------
-115 116 |         "slicer, expected",
-116 117 |         [
-117 118 |             (lambda x: x[-2:], "foo"),
-118     |-            (lambda x: x[-5:-3], "bar"),
-    119 |+            (operator.itemgetter(slice(-5, -3)), "bar"),
-119 120 |         ],
-120 121 |     )
-121 122 |     def test_inlet_asset_alias_extra_slice(self, slicer, expected):
+127 128 |         "slicer, expected",
+128 129 |         [
+129 130 |             (lambda x: x[-2:], "foo"),
+130     |-            (lambda x: x[-5:-3], "bar"),
+    131 |+            (operator.itemgetter(slice(-5, -3)), "bar"),
+131 132 |         ],
+132 133 |     )
+133 134 |     def test_inlet_asset_alias_extra_slice(self, slicer, expected):

--- a/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__FURB118_FURB118.py.snap
+++ b/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__FURB118_FURB118.py.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/ruff_linter/src/rules/refurb/mod.rs
-snapshot_kind: text
 ---
 FURB118.py:2:13: FURB118 [*] Use `operator.invert` instead of defining a lambda
   |
@@ -947,3 +946,6 @@ FURB118.py:95:17: FURB118 [*] Use `operator.itemgetter((1,          2))` instead
 94 95 | # Without a slice, trivia is retained
 95    |-op_itemgetter = lambda x: x[1,          2]
    96 |+op_itemgetter = operator.itemgetter((1,          2))
+96 97 | 
+97 98 | 
+98 99 | # All methods in classes are ignored, even those defined using lambdas:

--- a/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__FURB118_FURB118.py.snap
+++ b/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__FURB118_FURB118.py.snap
@@ -949,3 +949,61 @@ FURB118.py:95:17: FURB118 [*] Use `operator.itemgetter((1,          2))` instead
 96 97 | 
 97 98 | 
 98 99 | # All methods in classes are ignored, even those defined using lambdas:
+
+FURB118.py:117:14: FURB118 [*] Use `operator.itemgetter(slice(-2, None))` instead of defining a lambda
+    |
+115 |         "slicer, expected",
+116 |         [
+117 |             (lambda x: x[-2:], "foo"),
+    |              ^^^^^^^^^^^^^^^^ FURB118
+118 |             (lambda x: x[-5:-3], "bar"),
+119 |         ],
+    |
+    = help: Replace with `operator.itemgetter(slice(-2, None))`
+
+ℹ Unsafe fix
+104 104 |     y = lambda self, other: self == other
+105 105 | 
+106 106 | from typing import Callable
+    107 |+import operator
+107 108 | class Baz:
+108 109 |     z: Callable = lambda self, other: self == other
+109 110 | 
+--------------------------------------------------------------------------------
+114 115 |     @pytest.mark.parametrize(
+115 116 |         "slicer, expected",
+116 117 |         [
+117     |-            (lambda x: x[-2:], "foo"),
+    118 |+            (operator.itemgetter(slice(-2, None)), "foo"),
+118 119 |             (lambda x: x[-5:-3], "bar"),
+119 120 |         ],
+120 121 |     )
+
+FURB118.py:118:14: FURB118 [*] Use `operator.itemgetter(slice(-5, -3))` instead of defining a lambda
+    |
+116 |         [
+117 |             (lambda x: x[-2:], "foo"),
+118 |             (lambda x: x[-5:-3], "bar"),
+    |              ^^^^^^^^^^^^^^^^^^ FURB118
+119 |         ],
+120 |     )
+    |
+    = help: Replace with `operator.itemgetter(slice(-5, -3))`
+
+ℹ Unsafe fix
+104 104 |     y = lambda self, other: self == other
+105 105 | 
+106 106 | from typing import Callable
+    107 |+import operator
+107 108 | class Baz:
+108 109 |     z: Callable = lambda self, other: self == other
+109 110 | 
+--------------------------------------------------------------------------------
+115 116 |         "slicer, expected",
+116 117 |         [
+117 118 |             (lambda x: x[-2:], "foo"),
+118     |-            (lambda x: x[-5:-3], "bar"),
+    119 |+            (operator.itemgetter(slice(-5, -3)), "bar"),
+119 120 |         ],
+120 121 |     )
+121 122 |     def test_inlet_asset_alias_extra_slice(self, slicer, expected):


### PR DESCRIPTION
## Summary

Fixes #13829.

Replacing an instance method definition with an `operator`-module function doesn't work, because instance methods need to be callable objects with `__get__` methods ("descriptors"), and while user-defined functions are descriptors, this is not true for the `operator`-module functions. We already avoid flagging user-defined methods that are defined using `def` statements, but we currently incorrectly flag user-defined functions that are defined by assigning `lambda`s to variables in class bodies. I.e., this is a perfectly valid definition of an instance method, and FURB118's suggestion to replace the lambda with `operator.eq` function would break it:

```py
class Spam:
    foo = lambda self, other: self == other
```

As a demonstration in the REPL:

```pycon
>>> class Spam:
...     foo = lambda self, other: self == other
...     
>>> Spam().foo(Spam())
False
>>> from operator import eq
>>> class Spam:
...     foo = eq
...     
>>> Spam().foo(Spam())
Traceback (most recent call last):
  File "<python-input-4>", line 1, in <module>
    Spam().foo(Spam())
    ~~~~~~~~~~^^^^^^^^
TypeError: eq expected 2 arguments, got 1
```

This PR fixes things so that `lambda` assignments in class bodies are considered off-limits for the rule in the same way as `def` statements in class bodies. It also makes the fix-safety docs more expansive, so that they're clearer that there's a wider range of reasons why the rule might be unsafe than just the keyword-argument issue.

## Test Plan

I added a new fixture that confirms that all function definitions in class bodies are ignored by the rule.
