### PR TITLE
[`flake8-pyi`, `ruff`] Fix traversal of nested literals and unions (`PYI016`, `PYI051`, `PYI055`, `PYI062`, `RUF041`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI016.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI016.py
@@ -108,3 +108,6 @@ field32: typing.Union[float, typing.Union[int | int | int]]  # Error
 
 # Test case for mixed union type fix
 field33: typing.Union[typing.Union[int | int] | typing.Union[int | int]] # Error
+
+# Test case for mixed union type
+field34: typing.Union[list[int], str] | typing.Union[bytes, list[int]]  # Error

--- a/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI016.pyi
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI016.pyi
@@ -108,3 +108,6 @@ field32: typing.Union[float, typing.Union[int | int | int]]  # Error
 
 # Test case for mixed union type fix
 field33: typing.Union[typing.Union[int | int] | typing.Union[int | int]] # Error
+
+# Test case for mixed union type
+field34: typing.Union[list[int], str] | typing.Union[bytes, list[int]]  # Error

--- a/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI016_PYI016.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI016_PYI016.py.snap
@@ -415,6 +415,8 @@ PYI016.py:110:42: PYI016 Duplicate union member `int`
 109 | # Test case for mixed union type fix
 110 | field33: typing.Union[typing.Union[int | int] | typing.Union[int | int]] # Error
     |                                          ^^^ PYI016
+111 | 
+112 | # Test case for mixed union type
     |
     = help: Remove duplicate union member `int`
 
@@ -423,6 +425,8 @@ PYI016.py:110:62: PYI016 Duplicate union member `int`
 109 | # Test case for mixed union type fix
 110 | field33: typing.Union[typing.Union[int | int] | typing.Union[int | int]] # Error
     |                                                              ^^^ PYI016
+111 | 
+112 | # Test case for mixed union type
     |
     = help: Remove duplicate union member `int`
 
@@ -431,5 +435,15 @@ PYI016.py:110:68: PYI016 Duplicate union member `int`
 109 | # Test case for mixed union type fix
 110 | field33: typing.Union[typing.Union[int | int] | typing.Union[int | int]] # Error
     |                                                                    ^^^ PYI016
+111 | 
+112 | # Test case for mixed union type
     |
     = help: Remove duplicate union member `int`
+
+PYI016.py:113:61: PYI016 Duplicate union member `list[int]`
+    |
+112 | # Test case for mixed union type
+113 | field34: typing.Union[list[int], str] | typing.Union[bytes, list[int]]  # Error
+    |                                                             ^^^^^^^^^ PYI016
+    |
+    = help: Remove duplicate union member `list[int]`

--- a/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI016_PYI016.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI016_PYI016.py.snap
@@ -330,6 +330,16 @@ PYI016.py:89:41: PYI016 Duplicate union member `int`
    |
    = help: Remove duplicate union member `int`
 
+PYI016.py:92:54: PYI016 Duplicate union member `int`
+   |
+91 | # Should emit in cases with nested `typing.Union`
+92 | field27: typing.Union[typing.Union[typing.Union[int, int]]]  # PYI016: Duplicate union member `int`
+   |                                                      ^^^ PYI016
+93 | 
+94 | # Should emit in cases with mixed `typing.Union` and `|`
+   |
+   = help: Remove duplicate union member `int`
+
 PYI016.py:95:29: PYI016 Duplicate union member `int`
    |
 94 | # Should emit in cases with mixed `typing.Union` and `|`
@@ -340,6 +350,16 @@ PYI016.py:95:29: PYI016 Duplicate union member `int`
    |
    = help: Remove duplicate union member `int`
 
+PYI016.py:98:54: PYI016 Duplicate union member `int`
+    |
+ 97 | # Should emit twice in cases with multiple nested `typing.Union`
+ 98 | field29: typing.Union[int, typing.Union[typing.Union[int, int]]]  # Error
+    |                                                      ^^^ PYI016
+ 99 | 
+100 | # Should emit once in cases with multiple nested `typing.Union`
+    |
+    = help: Remove duplicate union member `int`
+
 PYI016.py:98:59: PYI016 Duplicate union member `int`
     |
  97 | # Should emit twice in cases with multiple nested `typing.Union`
@@ -347,6 +367,16 @@ PYI016.py:98:59: PYI016 Duplicate union member `int`
     |                                                           ^^^ PYI016
  99 | 
 100 | # Should emit once in cases with multiple nested `typing.Union`
+    |
+    = help: Remove duplicate union member `int`
+
+PYI016.py:101:54: PYI016 Duplicate union member `int`
+    |
+100 | # Should emit once in cases with multiple nested `typing.Union`
+101 | field30: typing.Union[int, typing.Union[typing.Union[int, str]]]  # Error
+    |                                                      ^^^ PYI016
+102 | 
+103 | # Should emit once, and fix to `typing.Union[float, int]`
     |
     = help: Remove duplicate union member `int`
 
@@ -388,13 +418,13 @@ PYI016.py:110:42: PYI016 Duplicate union member `int`
     |
     = help: Remove duplicate union member `int`
 
-PYI016.py:110:49: PYI016 Duplicate union member `typing.Union[int | int]`
+PYI016.py:110:62: PYI016 Duplicate union member `int`
     |
 109 | # Test case for mixed union type fix
 110 | field33: typing.Union[typing.Union[int | int] | typing.Union[int | int]] # Error
-    |                                                 ^^^^^^^^^^^^^^^^^^^^^^^ PYI016
+    |                                                              ^^^ PYI016
     |
-    = help: Remove duplicate union member `typing.Union[int | int]`
+    = help: Remove duplicate union member `int`
 
 PYI016.py:110:68: PYI016 Duplicate union member `int`
     |

--- a/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI016_PYI016.pyi.snap
+++ b/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI016_PYI016.pyi.snap
@@ -415,6 +415,8 @@ PYI016.pyi:110:42: PYI016 Duplicate union member `int`
 109 | # Test case for mixed union type fix
 110 | field33: typing.Union[typing.Union[int | int] | typing.Union[int | int]] # Error
     |                                          ^^^ PYI016
+111 | 
+112 | # Test case for mixed union type
     |
     = help: Remove duplicate union member `int`
 
@@ -423,6 +425,8 @@ PYI016.pyi:110:62: PYI016 Duplicate union member `int`
 109 | # Test case for mixed union type fix
 110 | field33: typing.Union[typing.Union[int | int] | typing.Union[int | int]] # Error
     |                                                              ^^^ PYI016
+111 | 
+112 | # Test case for mixed union type
     |
     = help: Remove duplicate union member `int`
 
@@ -431,5 +435,15 @@ PYI016.pyi:110:68: PYI016 Duplicate union member `int`
 109 | # Test case for mixed union type fix
 110 | field33: typing.Union[typing.Union[int | int] | typing.Union[int | int]] # Error
     |                                                                    ^^^ PYI016
+111 | 
+112 | # Test case for mixed union type
     |
     = help: Remove duplicate union member `int`
+
+PYI016.pyi:113:61: PYI016 Duplicate union member `list[int]`
+    |
+112 | # Test case for mixed union type
+113 | field34: typing.Union[list[int], str] | typing.Union[bytes, list[int]]  # Error
+    |                                                             ^^^^^^^^^ PYI016
+    |
+    = help: Remove duplicate union member `list[int]`

--- a/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI016_PYI016.pyi.snap
+++ b/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI016_PYI016.pyi.snap
@@ -330,6 +330,16 @@ PYI016.pyi:89:41: PYI016 Duplicate union member `int`
    |
    = help: Remove duplicate union member `int`
 
+PYI016.pyi:92:54: PYI016 Duplicate union member `int`
+   |
+91 | # Should emit in cases with nested `typing.Union`
+92 | field27: typing.Union[typing.Union[typing.Union[int, int]]]  # PYI016: Duplicate union member `int`
+   |                                                      ^^^ PYI016
+93 | 
+94 | # Should emit in cases with mixed `typing.Union` and `|`
+   |
+   = help: Remove duplicate union member `int`
+
 PYI016.pyi:95:29: PYI016 Duplicate union member `int`
    |
 94 | # Should emit in cases with mixed `typing.Union` and `|`
@@ -340,6 +350,16 @@ PYI016.pyi:95:29: PYI016 Duplicate union member `int`
    |
    = help: Remove duplicate union member `int`
 
+PYI016.pyi:98:54: PYI016 Duplicate union member `int`
+    |
+ 97 | # Should emit twice in cases with multiple nested `typing.Union`
+ 98 | field29: typing.Union[int, typing.Union[typing.Union[int, int]]]  # Error
+    |                                                      ^^^ PYI016
+ 99 | 
+100 | # Should emit once in cases with multiple nested `typing.Union`
+    |
+    = help: Remove duplicate union member `int`
+
 PYI016.pyi:98:59: PYI016 Duplicate union member `int`
     |
  97 | # Should emit twice in cases with multiple nested `typing.Union`
@@ -347,6 +367,16 @@ PYI016.pyi:98:59: PYI016 Duplicate union member `int`
     |                                                           ^^^ PYI016
  99 | 
 100 | # Should emit once in cases with multiple nested `typing.Union`
+    |
+    = help: Remove duplicate union member `int`
+
+PYI016.pyi:101:54: PYI016 Duplicate union member `int`
+    |
+100 | # Should emit once in cases with multiple nested `typing.Union`
+101 | field30: typing.Union[int, typing.Union[typing.Union[int, str]]]  # Error
+    |                                                      ^^^ PYI016
+102 | 
+103 | # Should emit once, and fix to `typing.Union[float, int]`
     |
     = help: Remove duplicate union member `int`
 
@@ -388,13 +418,13 @@ PYI016.pyi:110:42: PYI016 Duplicate union member `int`
     |
     = help: Remove duplicate union member `int`
 
-PYI016.pyi:110:49: PYI016 Duplicate union member `typing.Union[int | int]`
+PYI016.pyi:110:62: PYI016 Duplicate union member `int`
     |
 109 | # Test case for mixed union type fix
 110 | field33: typing.Union[typing.Union[int | int] | typing.Union[int | int]] # Error
-    |                                                 ^^^^^^^^^^^^^^^^^^^^^^^ PYI016
+    |                                                              ^^^ PYI016
     |
-    = help: Remove duplicate union member `typing.Union[int | int]`
+    = help: Remove duplicate union member `int`
 
 PYI016.pyi:110:68: PYI016 Duplicate union member `int`
     |

--- a/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI041_PYI041.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI041_PYI041.py.snap
@@ -25,6 +25,14 @@ PYI041.py:30:28: PYI041 Use `float` instead of `int | float`
    |
    = help: Remove redundant type
 
+PYI041.py:34:26: PYI041 Use `float` instead of `int | float`
+   |
+34 | def f3(arg1: int, *args: Union[int | int | float]) -> None:
+   |                          ^^^^^^^^^^^^^^^^^^^^^^^^ PYI041
+35 |     ...
+   |
+   = help: Remove redundant type
+
 PYI041.py:38:24: PYI041 Use `float` instead of `int | float`
    |
 38 | async def f4(**kwargs: int | int | float) -> None:
@@ -38,6 +46,30 @@ PYI041.py:42:26: PYI041 Use `float` instead of `int | float`
 42 | def f5(arg1: int, *args: Union[int, int, float]) -> None: 
    |                          ^^^^^^^^^^^^^^^^^^^^^^ PYI041
 43 |     ...
+   |
+   = help: Remove redundant type
+
+PYI041.py:46:26: PYI041 Use `float` instead of `int | float`
+   |
+46 | def f6(arg1: int, *args: Union[Union[int, int, float]]) -> None: 
+   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI041
+47 |     ...
+   |
+   = help: Remove redundant type
+
+PYI041.py:50:26: PYI041 Use `float` instead of `int | float`
+   |
+50 | def f7(arg1: int, *args: Union[Union[Union[int, int, float]]]) -> None: 
+   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI041
+51 |     ...
+   |
+   = help: Remove redundant type
+
+PYI041.py:54:26: PYI041 Use `float` instead of `int | float`
+   |
+54 | def f8(arg1: int, *args: Union[Union[Union[int | int | float]]]) -> None: 
+   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI041
+55 |     ...
    |
    = help: Remove redundant type
 

--- a/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI041_PYI041.pyi.snap
+++ b/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI041_PYI041.pyi.snap
@@ -22,6 +22,13 @@ PYI041.pyi:27:28: PYI041 Use `float` instead of `int | float`
    |
    = help: Remove redundant type
 
+PYI041.pyi:30:26: PYI041 Use `float` instead of `int | float`
+   |
+30 | def f3(arg1: int, *args: Union[int | int | float]) -> None: ...  # PYI041
+   |                          ^^^^^^^^^^^^^^^^^^^^^^^^ PYI041
+   |
+   = help: Remove redundant type
+
 PYI041.pyi:33:24: PYI041 Use `float` instead of `int | float`
    |
 33 | async def f4(**kwargs: int | int | float) -> None: ...  # PYI041
@@ -63,6 +70,27 @@ PYI041.pyi:49:26: PYI041 Use `float` instead of `int | float`
 48 | 
 49 | def f5(arg1: int, *args: Union[int, int, float]) -> None: ...  # PYI041
    |                          ^^^^^^^^^^^^^^^^^^^^^^ PYI041
+   |
+   = help: Remove redundant type
+
+PYI041.pyi:52:26: PYI041 Use `float` instead of `int | float`
+   |
+52 | def f6(arg1: int, *args: Union[Union[int, int, float]]) -> None: ...  # PYI041
+   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI041
+   |
+   = help: Remove redundant type
+
+PYI041.pyi:55:26: PYI041 Use `float` instead of `int | float`
+   |
+55 | def f7(arg1: int, *args: Union[Union[Union[int, int, float]]]) -> None: ...  # PYI041
+   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI041
+   |
+   = help: Remove redundant type
+
+PYI041.pyi:58:26: PYI041 Use `float` instead of `int | float`
+   |
+58 | def f8(arg1: int, *args: Union[Union[Union[int | int | float]]]) -> None: ...  # PYI041
+   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI041
    |
    = help: Remove redundant type
 

--- a/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI051_PYI051.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI051_PYI051.py.snap
@@ -70,6 +70,35 @@ PYI051.py:7:51: PYI051 `Literal[42]` is redundant in a union with `int`
 9 | F: TypeAlias = typing.Union[str, typing.Union[typing.Union[typing.Union[Literal["foo"], int]]]]
   |
 
+PYI051.py:8:76: PYI051 `Literal["foo"]` is redundant in a union with `str`
+   |
+ 6 | C: TypeAlias = typing.Union[Literal[5], int, typing.Union[Literal["foo"], str]]
+ 7 | D: TypeAlias = typing.Union[Literal[b"str_bytes", 42], bytes, int]
+ 8 | E: TypeAlias = typing.Union[typing.Union[typing.Union[typing.Union[Literal["foo"], str]]]]
+   |                                                                            ^^^^^ PYI051
+ 9 | F: TypeAlias = typing.Union[str, typing.Union[typing.Union[typing.Union[Literal["foo"], int]]]]
+10 | G: typing.Union[str, typing.Union[typing.Union[typing.Union[Literal["foo"], int]]]]
+   |
+
+PYI051.py:9:81: PYI051 `Literal["foo"]` is redundant in a union with `str`
+   |
+ 7 | D: TypeAlias = typing.Union[Literal[b"str_bytes", 42], bytes, int]
+ 8 | E: TypeAlias = typing.Union[typing.Union[typing.Union[typing.Union[Literal["foo"], str]]]]
+ 9 | F: TypeAlias = typing.Union[str, typing.Union[typing.Union[typing.Union[Literal["foo"], int]]]]
+   |                                                                                 ^^^^^ PYI051
+10 | G: typing.Union[str, typing.Union[typing.Union[typing.Union[Literal["foo"], int]]]]
+   |
+
+PYI051.py:10:69: PYI051 `Literal["foo"]` is redundant in a union with `str`
+   |
+ 8 | E: TypeAlias = typing.Union[typing.Union[typing.Union[typing.Union[Literal["foo"], str]]]]
+ 9 | F: TypeAlias = typing.Union[str, typing.Union[typing.Union[typing.Union[Literal["foo"], int]]]]
+10 | G: typing.Union[str, typing.Union[typing.Union[typing.Union[Literal["foo"], int]]]]
+   |                                                                     ^^^^^ PYI051
+11 | 
+12 | def func(x: complex | Literal[1J], y: Union[Literal[3.14], float]): ...
+   |
+
 PYI051.py:12:31: PYI051 `Literal[1J]` is redundant in a union with `complex`
    |
 10 | G: typing.Union[str, typing.Union[typing.Union[typing.Union[Literal["foo"], int]]]]

--- a/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI051_PYI051.pyi.snap
+++ b/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI051_PYI051.pyi.snap
@@ -70,6 +70,35 @@ PYI051.pyi:7:51: PYI051 `Literal[42]` is redundant in a union with `int`
 9 | F: TypeAlias = typing.Union[str, typing.Union[typing.Union[typing.Union[Literal["foo"], int]]]]
   |
 
+PYI051.pyi:8:76: PYI051 `Literal["foo"]` is redundant in a union with `str`
+   |
+ 6 | C: TypeAlias = typing.Union[Literal[5], int, typing.Union[Literal["foo"], str]]
+ 7 | D: TypeAlias = typing.Union[Literal[b"str_bytes", 42], bytes, int]
+ 8 | E: TypeAlias = typing.Union[typing.Union[typing.Union[typing.Union[Literal["foo"], str]]]]
+   |                                                                            ^^^^^ PYI051
+ 9 | F: TypeAlias = typing.Union[str, typing.Union[typing.Union[typing.Union[Literal["foo"], int]]]]
+10 | G: typing.Union[str, typing.Union[typing.Union[typing.Union[Literal["foo"], int]]]]
+   |
+
+PYI051.pyi:9:81: PYI051 `Literal["foo"]` is redundant in a union with `str`
+   |
+ 7 | D: TypeAlias = typing.Union[Literal[b"str_bytes", 42], bytes, int]
+ 8 | E: TypeAlias = typing.Union[typing.Union[typing.Union[typing.Union[Literal["foo"], str]]]]
+ 9 | F: TypeAlias = typing.Union[str, typing.Union[typing.Union[typing.Union[Literal["foo"], int]]]]
+   |                                                                                 ^^^^^ PYI051
+10 | G: typing.Union[str, typing.Union[typing.Union[typing.Union[Literal["foo"], int]]]]
+   |
+
+PYI051.pyi:10:69: PYI051 `Literal["foo"]` is redundant in a union with `str`
+   |
+ 8 | E: TypeAlias = typing.Union[typing.Union[typing.Union[typing.Union[Literal["foo"], str]]]]
+ 9 | F: TypeAlias = typing.Union[str, typing.Union[typing.Union[typing.Union[Literal["foo"], int]]]]
+10 | G: typing.Union[str, typing.Union[typing.Union[typing.Union[Literal["foo"], int]]]]
+   |                                                                     ^^^^^ PYI051
+11 | 
+12 | def func(x: complex | Literal[1J], y: Union[Literal[3.14], float]): ...
+   |
+
 PYI051.pyi:12:31: PYI051 `Literal[1J]` is redundant in a union with `complex`
    |
 10 | G: typing.Union[str, typing.Union[typing.Union[typing.Union[Literal["foo"], int]]]]

--- a/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI055_PYI055.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI055_PYI055.py.snap
@@ -106,12 +106,12 @@ PYI055.py:50:9: PYI055 [*] Multiple `type` members in a union. Combine them into
 52 52 |     ...
 53 53 | 
 
-PYI055.py:56:15: PYI055 [*] Multiple `type` members in a union. Combine them into one, e.g., `type[_T | Converter[_T]]`.
+PYI055.py:56:9: PYI055 [*] Multiple `type` members in a union. Combine them into one, e.g., `type[_T | Converter[_T]]`.
    |
 54 | def convert_union(union: UnionType) -> _T | None:
 55 |     converters: tuple[
 56 |         Union[type[_T] | type[Converter[_T]] | Converter[_T] | Callable[[str], _T]], ...  # PYI055
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI055
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI055
 57 |     ] = union.__args__
 58 |     ...
    |
@@ -122,17 +122,17 @@ PYI055.py:56:15: PYI055 [*] Multiple `type` members in a union. Combine them int
 54 54 | def convert_union(union: UnionType) -> _T | None:
 55 55 |     converters: tuple[
 56    |-        Union[type[_T] | type[Converter[_T]] | Converter[_T] | Callable[[str], _T]], ...  # PYI055
-   56 |+        Union[type[_T | Converter[_T]] | Converter[_T] | Callable[[str], _T]], ...  # PYI055
+   56 |+        type[_T | Converter[_T]] | Converter[_T] | Callable[[str], _T], ...  # PYI055
 57 57 |     ] = union.__args__
 58 58 |     ...
 59 59 | 
 
-PYI055.py:62:15: PYI055 [*] Multiple `type` members in a union. Combine them into one, e.g., `type[_T | Converter[_T]]`.
+PYI055.py:62:9: PYI055 [*] Multiple `type` members in a union. Combine them into one, e.g., `type[_T | Converter[_T]]`.
    |
 60 | def convert_union(union: UnionType) -> _T | None:
 61 |     converters: tuple[
 62 |         Union[type[_T] | type[Converter[_T]]] | Converter[_T] | Callable[[str], _T], ...  # PYI055
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI055
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI055
 63 |     ] = union.__args__
 64 |     ...
    |
@@ -143,17 +143,17 @@ PYI055.py:62:15: PYI055 [*] Multiple `type` members in a union. Combine them int
 60 60 | def convert_union(union: UnionType) -> _T | None:
 61 61 |     converters: tuple[
 62    |-        Union[type[_T] | type[Converter[_T]]] | Converter[_T] | Callable[[str], _T], ...  # PYI055
-   62 |+        Union[type[_T | Converter[_T]]] | Converter[_T] | Callable[[str], _T], ...  # PYI055
+   62 |+        type[_T | Converter[_T]] | Converter[_T] | Callable[[str], _T], ...  # PYI055
 63 63 |     ] = union.__args__
 64 64 |     ...
 65 65 | 
 
-PYI055.py:68:15: PYI055 [*] Multiple `type` members in a union. Combine them into one, e.g., `type[_T | Converter[_T]]`.
+PYI055.py:68:9: PYI055 [*] Multiple `type` members in a union. Combine them into one, e.g., `type[_T | Converter[_T]]`.
    |
 66 | def convert_union(union: UnionType) -> _T | None:
 67 |     converters: tuple[
 68 |         Union[type[_T] | type[Converter[_T]] | str] | Converter[_T] | Callable[[str], _T], ...  # PYI055
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI055
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI055
 69 |     ] = union.__args__
 70 |     ...
    |
@@ -164,6 +164,6 @@ PYI055.py:68:15: PYI055 [*] Multiple `type` members in a union. Combine them int
 66 66 | def convert_union(union: UnionType) -> _T | None:
 67 67 |     converters: tuple[
 68    |-        Union[type[_T] | type[Converter[_T]] | str] | Converter[_T] | Callable[[str], _T], ...  # PYI055
-   68 |+        Union[type[_T | Converter[_T]] | str] | Converter[_T] | Callable[[str], _T], ...  # PYI055
+   68 |+        type[_T | Converter[_T]] | str | Converter[_T] | Callable[[str], _T], ...  # PYI055
 69 69 |     ] = union.__args__
 70 70 |     ...

--- a/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI055_PYI055.pyi.snap
+++ b/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI055_PYI055.pyi.snap
@@ -105,12 +105,12 @@ PYI055.pyi:8:4: PYI055 [*] Multiple `type` members in a union. Combine them into
 10 10 | y: Union[Union[Union[type[float, int], type[complex]]]]
 11 11 | z: Union[type[complex], Union[Union[type[float, int]]]]
 
-PYI055.pyi:9:10: PYI055 [*] Multiple `type` members in a union. Combine them into one, e.g., `type[Union[float, int, complex]]`.
+PYI055.pyi:9:4: PYI055 [*] Multiple `type` members in a union. Combine them into one, e.g., `type[Union[float, int, complex]]`.
    |
  7 | v: Union[type[float], type[complex]]
  8 | w: Union[type[float, int], type[complex]]
  9 | x: Union[Union[type[float, int], type[complex]]]
-   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI055
+   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI055
 10 | y: Union[Union[Union[type[float, int], type[complex]]]]
 11 | z: Union[type[complex], Union[Union[type[float, int]]]]
    |
@@ -121,10 +121,51 @@ PYI055.pyi:9:10: PYI055 [*] Multiple `type` members in a union. Combine them int
 7  7  | v: Union[type[float], type[complex]]
 8  8  | w: Union[type[float, int], type[complex]]
 9     |-x: Union[Union[type[float, int], type[complex]]]
-   9  |+x: Union[type[Union[float, int, complex]]]
+   9  |+x: type[Union[float, int, complex]]
 10 10 | y: Union[Union[Union[type[float, int], type[complex]]]]
 11 11 | z: Union[type[complex], Union[Union[type[float, int]]]]
 12 12 | 
+
+PYI055.pyi:10:4: PYI055 [*] Multiple `type` members in a union. Combine them into one, e.g., `type[Union[float, int, complex]]`.
+   |
+ 8 | w: Union[type[float, int], type[complex]]
+ 9 | x: Union[Union[type[float, int], type[complex]]]
+10 | y: Union[Union[Union[type[float, int], type[complex]]]]
+   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI055
+11 | z: Union[type[complex], Union[Union[type[float, int]]]]
+   |
+   = help: Combine multiple `type` members
+
+ℹ Safe fix
+7  7  | v: Union[type[float], type[complex]]
+8  8  | w: Union[type[float, int], type[complex]]
+9  9  | x: Union[Union[type[float, int], type[complex]]]
+10    |-y: Union[Union[Union[type[float, int], type[complex]]]]
+   10 |+y: type[Union[float, int, complex]]
+11 11 | z: Union[type[complex], Union[Union[type[float, int]]]]
+12 12 | 
+13 13 | def func(arg: type[int] | str | type[float]) -> None: ...
+
+PYI055.pyi:11:4: PYI055 [*] Multiple `type` members in a union. Combine them into one, e.g., `type[Union[complex, float, int]]`.
+   |
+ 9 | x: Union[Union[type[float, int], type[complex]]]
+10 | y: Union[Union[Union[type[float, int], type[complex]]]]
+11 | z: Union[type[complex], Union[Union[type[float, int]]]]
+   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI055
+12 | 
+13 | def func(arg: type[int] | str | type[float]) -> None: ...
+   |
+   = help: Combine multiple `type` members
+
+ℹ Safe fix
+8  8  | w: Union[type[float, int], type[complex]]
+9  9  | x: Union[Union[type[float, int], type[complex]]]
+10 10 | y: Union[Union[Union[type[float, int], type[complex]]]]
+11    |-z: Union[type[complex], Union[Union[type[float, int]]]]
+   11 |+z: type[Union[complex, float, int]]
+12 12 | 
+13 13 | def func(arg: type[int] | str | type[float]) -> None: ...
+14 14 | 
 
 PYI055.pyi:13:15: PYI055 [*] Multiple `type` members in a union. Combine them into one, e.g., `type[int | float]`.
    |

--- a/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI062_PYI062.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI062_PYI062.py.snap
@@ -333,24 +333,6 @@ PYI062.py:32:37: PYI062 [*] Duplicate literal member `1`
 30 30 | # nested literals, all equivalent to `Literal[1]`
 31 31 | Literal[Literal[1]]  # no duplicate
 32    |-Literal[Literal[Literal[1], Literal[1]]]  # once
-   32 |+Literal[Literal[1]]  # once
-33 33 | Literal[Literal[1], Literal[Literal[Literal[1]]]]  # once
-
-PYI062.py:32:37: PYI062 [*] Duplicate literal member `1`
-   |
-30 | # nested literals, all equivalent to `Literal[1]`
-31 | Literal[Literal[1]]  # no duplicate
-32 | Literal[Literal[Literal[1], Literal[1]]]  # once
-   |                                     ^ PYI062
-33 | Literal[Literal[1], Literal[Literal[Literal[1]]]]  # once
-   |
-   = help: Remove duplicates
-
-ℹ Safe fix
-29 29 | 
-30 30 | # nested literals, all equivalent to `Literal[1]`
-31 31 | Literal[Literal[1]]  # no duplicate
-32    |-Literal[Literal[Literal[1], Literal[1]]]  # once
    32 |+Literal[1]  # once
 33 33 | Literal[Literal[1], Literal[Literal[Literal[1]]]]  # once
 

--- a/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI062_PYI062.pyi.snap
+++ b/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI062_PYI062.pyi.snap
@@ -333,24 +333,6 @@ PYI062.pyi:32:37: PYI062 [*] Duplicate literal member `1`
 30 30 | # nested literals, all equivalent to `Literal[1]`
 31 31 | Literal[Literal[1]]  # no duplicate
 32    |-Literal[Literal[Literal[1], Literal[1]]]  # once
-   32 |+Literal[Literal[1]]  # once
-33 33 | Literal[Literal[1], Literal[Literal[Literal[1]]]]  # once
-
-PYI062.pyi:32:37: PYI062 [*] Duplicate literal member `1`
-   |
-30 | # nested literals, all equivalent to `Literal[1]`
-31 | Literal[Literal[1]]  # no duplicate
-32 | Literal[Literal[Literal[1], Literal[1]]]  # once
-   |                                     ^ PYI062
-33 | Literal[Literal[1], Literal[Literal[Literal[1]]]]  # once
-   |
-   = help: Remove duplicates
-
-ℹ Safe fix
-29 29 | 
-30 30 | # nested literals, all equivalent to `Literal[1]`
-31 31 | Literal[Literal[1]]  # no duplicate
-32    |-Literal[Literal[Literal[1], Literal[1]]]  # once
    32 |+Literal[1]  # once
 33 33 | Literal[Literal[1], Literal[Literal[Literal[1]]]]  # once
 

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF041_RUF041.py.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF041_RUF041.py.snap
@@ -216,26 +216,6 @@ RUF041.py:24:1: RUF041 [*] Unnecessary nested `Literal`
 26 26 | 
 27 27 | # OK
 
-RUF041.py:24:9: RUF041 [*] Unnecessary nested `Literal`
-   |
-22 | # nested literals, all equivalent to `Literal[1]`
-23 | Literal[Literal[1]]
-24 | Literal[Literal[Literal[1], Literal[1]]]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ RUF041
-25 | Literal[Literal[1], Literal[Literal[Literal[1]]]]
-   |
-   = help: Replace with flattened `Literal`
-
-ℹ Safe fix
-21 21 | 
-22 22 | # nested literals, all equivalent to `Literal[1]`
-23 23 | Literal[Literal[1]]
-24    |-Literal[Literal[Literal[1], Literal[1]]]
-   24 |+Literal[Literal[1, 1]]
-25 25 | Literal[Literal[1], Literal[Literal[Literal[1]]]]
-26 26 | 
-27 27 | # OK
-
 RUF041.py:25:1: RUF041 [*] Unnecessary nested `Literal`
    |
 23 | Literal[Literal[1]]
@@ -253,27 +233,6 @@ RUF041.py:25:1: RUF041 [*] Unnecessary nested `Literal`
 24 24 | Literal[Literal[Literal[1], Literal[1]]]
 25    |-Literal[Literal[1], Literal[Literal[Literal[1]]]]
    25 |+Literal[1, 1]
-26 26 | 
-27 27 | # OK
-28 28 | x: Literal[True, False, True, False]
-
-RUF041.py:25:29: RUF041 [*] Unnecessary nested `Literal`
-   |
-23 | Literal[Literal[1]]
-24 | Literal[Literal[Literal[1], Literal[1]]]
-25 | Literal[Literal[1], Literal[Literal[Literal[1]]]]
-   |                             ^^^^^^^^^^^^^^^^^^^ RUF041
-26 | 
-27 | # OK
-   |
-   = help: Replace with flattened `Literal`
-
-ℹ Safe fix
-22 22 | # nested literals, all equivalent to `Literal[1]`
-23 23 | Literal[Literal[1]]
-24 24 | Literal[Literal[Literal[1], Literal[1]]]
-25    |-Literal[Literal[1], Literal[Literal[Literal[1]]]]
-   25 |+Literal[Literal[1], Literal[Literal[1]]]
 26 26 | 
 27 27 | # OK
 28 28 | x: Literal[True, False, True, False]

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF041_RUF041.pyi.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF041_RUF041.pyi.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/ruff_linter/src/rules/ruff/mod.rs
-snapshot_kind: text
 ---
 RUF041.pyi:6:4: RUF041 [*] Unnecessary nested `Literal`
   |
@@ -216,26 +215,6 @@ RUF041.pyi:24:1: RUF041 [*] Unnecessary nested `Literal`
 26 26 | 
 27 27 | # OK
 
-RUF041.pyi:24:9: RUF041 [*] Unnecessary nested `Literal`
-   |
-22 | # nested literals, all equivalent to `Literal[1]`
-23 | Literal[Literal[1]]
-24 | Literal[Literal[Literal[1], Literal[1]]]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ RUF041
-25 | Literal[Literal[1], Literal[Literal[Literal[1]]]]
-   |
-   = help: Replace with flattened `Literal`
-
-ℹ Safe fix
-21 21 | 
-22 22 | # nested literals, all equivalent to `Literal[1]`
-23 23 | Literal[Literal[1]]
-24    |-Literal[Literal[Literal[1], Literal[1]]]
-   24 |+Literal[Literal[1, 1]]
-25 25 | Literal[Literal[1], Literal[Literal[Literal[1]]]]
-26 26 | 
-27 27 | # OK
-
 RUF041.pyi:25:1: RUF041 [*] Unnecessary nested `Literal`
    |
 23 | Literal[Literal[1]]
@@ -253,27 +232,6 @@ RUF041.pyi:25:1: RUF041 [*] Unnecessary nested `Literal`
 24 24 | Literal[Literal[Literal[1], Literal[1]]]
 25    |-Literal[Literal[1], Literal[Literal[Literal[1]]]]
    25 |+Literal[1, 1]
-26 26 | 
-27 27 | # OK
-28 28 | x: Literal[True, False, True, False]
-
-RUF041.pyi:25:29: RUF041 [*] Unnecessary nested `Literal`
-   |
-23 | Literal[Literal[1]]
-24 | Literal[Literal[Literal[1], Literal[1]]]
-25 | Literal[Literal[1], Literal[Literal[Literal[1]]]]
-   |                             ^^^^^^^^^^^^^^^^^^^ RUF041
-26 | 
-27 | # OK
-   |
-   = help: Replace with flattened `Literal`
-
-ℹ Safe fix
-22 22 | # nested literals, all equivalent to `Literal[1]`
-23 23 | Literal[Literal[1]]
-24 24 | Literal[Literal[Literal[1], Literal[1]]]
-25    |-Literal[Literal[1], Literal[Literal[Literal[1]]]]
-   25 |+Literal[Literal[1], Literal[Literal[1]]]
 26 26 | 
 27 27 | # OK
 28 28 | x: Literal[True, False, True, False]

--- a/crates/ruff_python_semantic/src/analyze/typing.rs
+++ b/crates/ruff_python_semantic/src/analyze/typing.rs
@@ -373,7 +373,7 @@ where
     ) where
         F: FnMut(&'a Expr, &'a Expr),
     {
-        // Ex) x | y
+        // Ex) `x | y`
         if let Expr::BinOp(ast::ExprBinOp {
             op: Operator::BitOr,
             left,
@@ -396,19 +396,19 @@ where
             return;
         }
 
-        // Ex) Union[x, y]
+        // Ex) `Union[x, y]`
         if let Expr::Subscript(ast::ExprSubscript { value, slice, .. }) = expr {
             if semantic.match_typing_expr(value, "Union") {
                 if let Expr::Tuple(tuple) = &**slice {
                     // Traverse each element of the tuple within the union recursively to handle cases
-                    // such as `Union[..., Union[...]]
+                    // such as `Union[..., Union[...]]`
                     tuple
                         .iter()
                         .for_each(|elem| inner(func, semantic, elem, Some(expr)));
                     return;
                 }
 
-                // Ex) Union[Union[a, b]] and Union[a | b | c]
+                // Ex) `Union[Union[a, b]]` and `Union[a | b | c]`
                 inner(func, semantic, slice, Some(expr));
                 return;
             }
@@ -445,7 +445,7 @@ where
                 match &**slice {
                     Expr::Tuple(tuple) => {
                         // Traverse each element of the tuple within the literal recursively to handle cases
-                        // such as `Literal[..., Literal[...]]
+                        // such as `Literal[..., Literal[...]]`
                         for element in tuple {
                             inner(func, semantic, element, Some(expr));
                         }

--- a/crates/ruff_python_semantic/src/analyze/typing.rs
+++ b/crates/ruff_python_semantic/src/analyze/typing.rs
@@ -407,6 +407,10 @@ where
                         .for_each(|elem| inner(func, semantic, elem, Some(expr)));
                     return;
                 }
+
+                // Ex) Union[Union[a, b]] and Union[a | b | c]
+                inner(func, semantic, slice, Some(expr));
+                return;
             }
         }
 
@@ -435,7 +439,7 @@ where
     ) where
         F: FnMut(&'a Expr, &'a Expr),
     {
-        // Ex) Literal[x, y]
+        // Ex) `Literal[x, y]`
         if let Expr::Subscript(ast::ExprSubscript { value, slice, .. }) = expr {
             if semantic.match_typing_expr(value, "Literal") {
                 match &**slice {
@@ -447,6 +451,7 @@ where
                         }
                     }
                     other => {
+                        // Ex) `Literal[Literal[...]]`
                         inner(func, semantic, other, Some(expr));
                     }
                 }


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

In previous work on PYI rules we found that the current traversal misses nested literals and unions.
These are rare but valid. As mentioned before, correctly handling these cases might be relevant for auto-generated stubs.

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

Added test cases in an earlier PR. Snapshots are updated and show nested literals and unions are now handled as expected.
No ecosystem changes.