### PR TITLE
Fixes minor bug in `SemanticModel::lookup_symbol`

### DIFF
--- a/crates/ruff_python_semantic/src/model.rs
+++ b/crates/ruff_python_semantic/src/model.rs
@@ -645,6 +645,7 @@ impl<'a> SemanticModel<'a> {
             }
 
             class_variables_visible = scope.kind.is_type() && index == 0;
+            seen_function |= scope.kind.is_function();
 
             if let Some(binding_id) = scope.get(symbol) {
                 match self.bindings[binding_id].kind {
@@ -661,9 +662,6 @@ impl<'a> SemanticModel<'a> {
                     return None;
                 }
             }
-
-            // FIXME: Shouldn't this happen above where `class_variables_visible` is set?
-            seen_function |= scope.kind.is_function();
         }
 
         None


### PR DESCRIPTION
## Summary

This came up as part of #12927 when implementing `SemanticModel::simulate_runtime_load`.

Should be fairly self-explanatory, if the scope returns a binding with `BindingKind::Annotation` the bottom part of the loop gets skipped, so there's no chance for `seen_function` to have been updated. So unless there's something subtle going on here, like function scopes never containing bindings with `BindingKind::Annotation`, this seems like a bug.

## Test Plan

`cargo nextest run`
