### PR TITLE
py-fuzzer: recommend using `uvx` rather than `uv run` to run the fuzzer

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -330,10 +330,9 @@ jobs:
           chmod +x ${{ steps.download-cached-binary.outputs.download-path }}/ruff
 
           (
-            uv run \
-            --no-project \
+            uvx \
             --python=${{ env.PYTHON_VERSION }} \
-            --with=./python/py-fuzzer \
+            --from=./python/py-fuzzer \
             fuzz \
             --test-executable=${{ steps.download-cached-binary.outputs.download-path }}/ruff \
             --bin=ruff \

--- a/.github/workflows/daily_fuzz.yaml
+++ b/.github/workflows/daily_fuzz.yaml
@@ -45,10 +45,9 @@ jobs:
       - name: Fuzz
         run: |
           (
-            uv run \
-            --no-project \
+            uvx \
             --python=3.12 \
-            --with=./python/py-fuzzer \
+            --from=./python/py-fuzzer \
             fuzz \
             --test-executable=target/debug/ruff \
             --bin=ruff \

--- a/crates/ruff_python_parser/CONTRIBUTING.md
+++ b/crates/ruff_python_parser/CONTRIBUTING.md
@@ -62,7 +62,7 @@ To run the fuzzer, execute the following command
 (requires [`uv`](https://github.com/astral-sh/uv) to be installed):
 
 ```sh
-uv run --no-project --with ./python/py-fuzzer fuzz
+uvx --from ./python/py-fuzzer fuzz
 ```
 
 Refer to the [py-fuzzer](https://github.com/astral-sh/ruff/blob/main/python/py-fuzzer/fuzz.py)

--- a/python/py-fuzzer/README.md
+++ b/python/py-fuzzer/README.md
@@ -3,6 +3,6 @@
 A fuzzer script to run Ruff executables on randomly generated
 (but syntactically valid) Python source-code files.
 
-Run `uv run --no-project --with ./python/py-fuzzer fuzz -h` from the repository root
+Run `uvx --from ./python/py-fuzzer fuzz -h` from the repository root
 for more information and example invocations
 (requires [`uv`](https://github.com/astral-sh/uv) to be installed).

--- a/python/py-fuzzer/fuzz.py
+++ b/python/py-fuzzer/fuzz.py
@@ -4,19 +4,19 @@ Python source-code files.
 
 This script can be installed into a virtual environment using
 `uv pip install -e ./python/py-fuzzer` from the Ruff repository root,
-or can be run using `uv run --no-project --with ./python/py-fuzzer`
+or can be run using `uvx --from ./python/py-fuzzer fuzz`
 (in which case the virtual environment does not need to be activated).
 
 Example invocations of the script using `uv`:
 - Run the fuzzer on Ruff's parser using seeds 0, 1, 2, 78 and 93 to generate the code:
-  `uv run --no-project --with ./python/py-fuzzer fuzz --bin ruff 0-2 78 93`
+  `uvx --from ./python/py-fuzzer fuzz --bin ruff 0-2 78 93`
 - Run the fuzzer concurrently using seeds in range 0-10 inclusive,
   but only reporting bugs that are new on your branch:
-  `uv run --no-project --with ./python/py-fuzzer fuzz --bin ruff 0-10 --new-bugs-only`
+  `uvx --from ./python/py-fuzzer fuzz --bin ruff 0-10 --new-bugs-only`
 - Run the fuzzer concurrently on 10,000 different Python source-code files,
   using a random selection of seeds, and only print a summary at the end
   (the `shuf` command is Unix-specific):
-  `uv run --no-project --with ./python/py-fuzzer fuzz --bin ruff $(shuf -i 0-1000000 -n 10000) --quiet
+  `uvx --from ./python/py-fuzzer fuzz --bin ruff $(shuf -i 0-1000000 -n 10000) --quiet
 """
 
 from __future__ import annotations


### PR DESCRIPTION
`uvx --from=foo bar` seems to accomplish the same thing as `uv run --no-project --with=foo bar`, but it's a fair bit less to type out on the command line