### PR TITLE
[red-knot] Fix Boolean flags in mdtests

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/subscript/class.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/subscript/class.md
@@ -21,10 +21,11 @@ reveal_type(Identity[0])  # revealed: str
 ## Class getitem union
 
 ```py
-flag = True
+def bool_instance() -> bool:
+    return True
 
 class UnionClassGetItem:
-    if flag:
+    if bool_instance():
 
         def __class_getitem__(cls, item: int) -> str:
             return item
@@ -59,9 +60,10 @@ reveal_type(x[0])  # revealed: str | int
 ## Class getitem with unbound method union
 
 ```py
-flag = True
+def bool_instance() -> bool:
+    return True
 
-if flag:
+if bool_instance():
     class Spam:
         def __class_getitem__(self, x: int) -> str:
             return "foo"
@@ -77,9 +79,10 @@ reveal_type(Spam[42])
 ## TODO: Class getitem non-class union
 
 ```py
-flag = True
+def bool_instance() -> bool:
+    return True
 
-if flag:
+if bool_instance():
     class Eggs:
         def __class_getitem__(self, x: int) -> str:
             return "foo"

--- a/crates/red_knot_python_semantic/resources/mdtest/subscript/instance.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/subscript/instance.md
@@ -30,10 +30,11 @@ reveal_type(Identity()[0])  # revealed: int
 ## Getitem union
 
 ```py
-flag = True
+def bool_instance() -> bool:
+    return True
 
 class Identity:
-    if flag:
+    if bool_instance():
 
         def __getitem__(self, index: int) -> int:
             return index


### PR DESCRIPTION
## Summary

Similar to #14652, but now with conditions that are `Literal[True]` (instead of `Literal[False]`), where we want them to be `bool`. Red knot is becoming too powerful for this :smile:.
