### PR TITLE
Avoids unnecessary overhead for `TC004`, when `TC001-003` are disabled

### DIFF
--- a/crates/ruff_linter/src/checkers/ast/analyze/deferred_scopes.rs
+++ b/crates/ruff_linter/src/checkers/ast/analyze/deferred_scopes.rs
@@ -52,16 +52,13 @@ pub(crate) fn deferred_scopes(checker: &mut Checker) {
     // Identify any valid runtime imports. If a module is imported at runtime, and
     // used at runtime, then by default, we avoid flagging any other
     // imports from that model as typing-only.
-    // FIXME: This does not seem quite right, if only TC004 is enabled
-    //        then we don't need to collect the runtime imports
-    let enforce_typing_imports = !checker.source_type.is_stub()
+    let enforce_typing_only_imports = !checker.source_type.is_stub()
         && checker.any_enabled(&[
-            Rule::RuntimeImportInTypeCheckingBlock,
             Rule::TypingOnlyFirstPartyImport,
             Rule::TypingOnlyStandardLibraryImport,
             Rule::TypingOnlyThirdPartyImport,
         ]);
-    let runtime_imports: Vec<Vec<&Binding>> = if enforce_typing_imports {
+    let runtime_imports: Vec<Vec<&Binding>> = if enforce_typing_only_imports {
         checker
             .semantic
             .scopes
@@ -377,9 +374,14 @@ pub(crate) fn deferred_scopes(checker: &mut Checker) {
         }
 
         if matches!(scope.kind, ScopeKind::Function(_) | ScopeKind::Module) {
-            // FIXME: This does not seem quite right, if only TC004 is enabled
-            //        then we don't need to collect the runtime imports
-            if enforce_typing_imports {
+            if checker.enabled(Rule::RuntimeImportInTypeCheckingBlock) {
+                flake8_type_checking::rules::runtime_import_in_type_checking_block(
+                    checker,
+                    scope,
+                    &mut diagnostics,
+                );
+            }
+            if enforce_typing_only_imports {
                 let runtime_imports: Vec<&Binding> = checker
                     .semantic
                     .scopes
@@ -388,26 +390,12 @@ pub(crate) fn deferred_scopes(checker: &mut Checker) {
                     .copied()
                     .collect();
 
-                if checker.enabled(Rule::RuntimeImportInTypeCheckingBlock) {
-                    flake8_type_checking::rules::runtime_import_in_type_checking_block(
-                        checker,
-                        scope,
-                        &mut diagnostics,
-                    );
-                }
-
-                if checker.any_enabled(&[
-                    Rule::TypingOnlyFirstPartyImport,
-                    Rule::TypingOnlyStandardLibraryImport,
-                    Rule::TypingOnlyThirdPartyImport,
-                ]) {
-                    flake8_type_checking::rules::typing_only_runtime_import(
-                        checker,
-                        scope,
-                        &runtime_imports,
-                        &mut diagnostics,
-                    );
-                }
+                flake8_type_checking::rules::typing_only_runtime_import(
+                    checker,
+                    scope,
+                    &runtime_imports,
+                    &mut diagnostics,
+                );
             }
 
             if checker.enabled(Rule::UnusedImport) {

--- a/crates/ruff_linter/src/checkers/ast/analyze/deferred_scopes.rs
+++ b/crates/ruff_linter/src/checkers/ast/analyze/deferred_scopes.rs
@@ -374,7 +374,9 @@ pub(crate) fn deferred_scopes(checker: &mut Checker) {
         }
 
         if matches!(scope.kind, ScopeKind::Function(_) | ScopeKind::Module) {
-            if checker.enabled(Rule::RuntimeImportInTypeCheckingBlock) {
+            if !checker.source_type.is_stub()
+                && checker.enabled(Rule::RuntimeImportInTypeCheckingBlock)
+            {
                 flake8_type_checking::rules::runtime_import_in_type_checking_block(
                     checker,
                     scope,


### PR DESCRIPTION
## Summary

Another minor thing that came up as part of #12927

TC004 doesn't use the `runtime_imports` vector we're building during analysis of deferred scopes, so we don't need to do that work when it's the only typing import rule that is enabled.

## Test Plan

`cargo nextest run`
