### PR TITLE
[`ruff`] Avoid emitting `assignment-in-assert` when all references to the assigned variable are themselves inside `assert`s (`RUF018`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/ruff/RUF018.py
+++ b/crates/ruff_linter/resources/test/fixtures/ruff/RUF018.py
@@ -1,7 +1,20 @@
 # RUF018
 assert (x := 0) == 0
 assert x, (y := "error")
+print(x, y)
 
 # OK
 if z := 0:
     pass
+
+
+# These should not be flagged, because the only uses of the variables defined
+# are themselves within `assert` statements.
+
+# Here the `t` variable is referenced
+# from a later `assert` statement:
+assert (t:=cancel((F, G))) == (1, P, Q)
+assert isinstance(t, tuple)
+
+# Here the `g` variable is referenced from within the same `assert` statement:
+assert (g:=solve(groebner(eqs, s), dict=True)) == sol, g

--- a/crates/ruff_linter/src/checkers/ast/analyze/bindings.rs
+++ b/crates/ruff_linter/src/checkers/ast/analyze/bindings.rs
@@ -18,6 +18,7 @@ pub(crate) fn bindings(checker: &mut Checker) {
         Rule::UnsortedDunderSlots,
         Rule::UnusedVariable,
         Rule::UnquotedTypeAlias,
+        Rule::AssignmentInAssert,
     ]) {
         return;
     }
@@ -84,6 +85,11 @@ pub(crate) fn bindings(checker: &mut Checker) {
         }
         if checker.enabled(Rule::UnsortedDunderSlots) {
             if let Some(diagnostic) = ruff::rules::sort_dunder_slots(checker, binding) {
+                checker.diagnostics.push(diagnostic);
+            }
+        }
+        if checker.enabled(Rule::AssignmentInAssert) {
+            if let Some(diagnostic) = ruff::rules::assignment_in_assert(checker, binding) {
                 checker.diagnostics.push(diagnostic);
             }
         }

--- a/crates/ruff_linter/src/checkers/ast/analyze/expression.rs
+++ b/crates/ruff_linter/src/checkers/ast/analyze/expression.rs
@@ -1648,11 +1648,6 @@ pub(crate) fn expression(expr: &Expr, checker: &mut Checker) {
                 ruff::rules::parenthesize_chained_logical_operators(checker, bool_op);
             }
         }
-        Expr::Named(..) => {
-            if checker.enabled(Rule::AssignmentInAssert) {
-                ruff::rules::assignment_in_assert(checker, expr);
-            }
-        }
         Expr::Lambda(lambda_expr) => {
             if checker.enabled(Rule::ReimplementedOperator) {
                 refurb::rules::reimplemented_operator(checker, &lambda_expr.into());

--- a/crates/ruff_linter/src/checkers/ast/mod.rs
+++ b/crates/ruff_linter/src/checkers/ast/mod.rs
@@ -971,10 +971,13 @@ impl<'a> Visitor<'a> for Checker<'a> {
                 msg,
                 range: _,
             }) => {
+                let snapshot = self.semantic.flags;
+                self.semantic.flags |= SemanticModelFlags::ASSERT_STATEMENT;
                 self.visit_boolean_test(test);
                 if let Some(expr) = msg {
                     self.visit_expr(expr);
                 }
+                self.semantic.flags = snapshot;
             }
             Stmt::With(ast::StmtWith {
                 items,
@@ -1953,6 +1956,9 @@ impl<'a> Checker<'a> {
 
         if self.semantic.in_exception_handler() {
             flags |= BindingFlags::IN_EXCEPT_HANDLER;
+        }
+        if self.semantic.in_assert_statement() {
+            flags |= BindingFlags::IN_ASSERT_STATEMENT;
         }
 
         // Create the `Binding`.

--- a/crates/ruff_linter/src/rules/ruff/rules/assignment_in_assert.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/assignment_in_assert.rs
@@ -65,7 +65,7 @@ pub(crate) fn assignment_in_assert(checker: &Checker, binding: &Binding) -> Opti
 
     let semantic = checker.semantic();
 
-    let parent_expression = binding.parent_expression(semantic)?.as_named_expr()?;
+    let parent_expression = binding.expression(semantic)?.as_named_expr()?;
 
     if binding
         .references()

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF018_RUF018.py.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF018_RUF018.py.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/ruff_linter/src/rules/ruff/mod.rs
-snapshot_kind: text
 ---
 RUF018.py:2:9: RUF018 Avoid assignment expressions in `assert` statements
   |
@@ -8,6 +7,7 @@ RUF018.py:2:9: RUF018 Avoid assignment expressions in `assert` statements
 2 | assert (x := 0) == 0
   |         ^^^^^^ RUF018
 3 | assert x, (y := "error")
+4 | print(x, y)
   |
 
 RUF018.py:3:12: RUF018 Avoid assignment expressions in `assert` statements
@@ -16,6 +16,5 @@ RUF018.py:3:12: RUF018 Avoid assignment expressions in `assert` statements
 2 | assert (x := 0) == 0
 3 | assert x, (y := "error")
   |            ^^^^^^^^^^^^ RUF018
-4 | 
-5 | # OK
+4 | print(x, y)
   |

--- a/crates/ruff_python_semantic/src/binding.rs
+++ b/crates/ruff_python_semantic/src/binding.rs
@@ -275,10 +275,11 @@ impl<'a> Binding<'a> {
             .map(|statement_id| semantic.statement(statement_id))
     }
 
-    /// Returns the parent of the expression in which the binding was defined.
+    /// Returns the expression in which the binding was defined
+    /// (e.g. for the binding `x` in `y = (x := 1)`, return the node representing `x := 1`).
     ///
     /// This is only really applicable for assignment expressions.
-    pub fn parent_expression<'b>(&self, semantic: &SemanticModel<'b>) -> Option<&'b ast::Expr> {
+    pub fn expression<'b>(&self, semantic: &SemanticModel<'b>) -> Option<&'b ast::Expr> {
         self.source
             .and_then(|expression_id| semantic.parent_expression(expression_id))
     }

--- a/crates/ruff_python_semantic/src/binding.rs
+++ b/crates/ruff_python_semantic/src/binding.rs
@@ -135,6 +135,15 @@ impl<'a> Binding<'a> {
         self.flags.contains(BindingFlags::IN_EXCEPT_HANDLER)
     }
 
+    /// Return `true` if this [`Binding`] took place inside an `assert` statement,
+    /// e.g. `y` in:
+    /// ```python
+    /// assert (y := x**2), y
+    /// ```
+    pub const fn in_assert_statement(&self) -> bool {
+        self.flags.contains(BindingFlags::IN_ASSERT_STATEMENT)
+    }
+
     /// Return `true` if this [`Binding`] represents a [PEP 613] type alias
     /// e.g. `OptString` in:
     /// ```python
@@ -264,6 +273,14 @@ impl<'a> Binding<'a> {
     pub fn statement<'b>(&self, semantic: &SemanticModel<'b>) -> Option<&'b Stmt> {
         self.source
             .map(|statement_id| semantic.statement(statement_id))
+    }
+
+    /// Returns the parent of the expression in which the binding was defined.
+    ///
+    /// This is only really applicable for assignment expressions.
+    pub fn parent_expression<'b>(&self, semantic: &SemanticModel<'b>) -> Option<&'b ast::Expr> {
+        self.source
+            .and_then(|expression_id| semantic.parent_expression(expression_id))
     }
 
     /// Returns the range of the binding's parent.
@@ -405,6 +422,14 @@ bitflags! {
         ///
         /// [PEP 695]: https://peps.python.org/pep-0695/#generic-type-alias
         const DEFERRED_TYPE_ALIAS = 1 << 12;
+
+        /// The binding took place inside an `assert` statement
+        ///
+        /// For example, `x` in the following snippet:
+        /// ```python
+        /// assert (x := y**2) > 42, x
+        /// ```
+        const IN_ASSERT_STATEMENT = 1 << 13;
 
         /// The binding represents any type alias.
         const TYPE_ALIAS = Self::ANNOTATED_TYPE_ALIAS.bits() | Self::DEFERRED_TYPE_ALIAS.bits();

--- a/crates/ruff_python_semantic/src/model.rs
+++ b/crates/ruff_python_semantic/src/model.rs
@@ -1839,6 +1839,11 @@ impl<'a> SemanticModel<'a> {
         self.flags.intersects(SemanticModelFlags::EXCEPTION_HANDLER)
     }
 
+    /// Return `true` if the model is in an `assert` statement.
+    pub const fn in_assert_statement(&self) -> bool {
+        self.flags.intersects(SemanticModelFlags::ASSERT_STATEMENT)
+    }
+
     /// Return `true` if the model is in an f-string.
     pub const fn in_f_string(&self) -> bool {
         self.flags.intersects(SemanticModelFlags::F_STRING)
@@ -2431,6 +2436,14 @@ bitflags! {
         ///
         /// [PEP 695]: https://peps.python.org/pep-0695/#generic-type-alias
         const DEFERRED_TYPE_ALIAS = 1 << 28;
+
+        /// The model is visiting an `assert` statement.
+        ///
+        /// For example, the model might be visiting `y` in
+        /// ```python
+        /// assert (y := x**2) > 42, y
+        /// ```
+        const ASSERT_STATEMENT = 1 << 29;
 
         /// The context is in any type annotation.
         const ANNOTATION = Self::TYPING_ONLY_ANNOTATION.bits() | Self::RUNTIME_EVALUATED_ANNOTATION.bits() | Self::RUNTIME_REQUIRED_ANNOTATION.bits();

--- a/crates/ruff_python_semantic/src/reference.rs
+++ b/crates/ruff_python_semantic/src/reference.rs
@@ -93,6 +93,11 @@ impl ResolvedReference {
         self.flags
             .intersects(SemanticModelFlags::ANNOTATED_TYPE_ALIAS)
     }
+
+    /// Return `true` if the context is inside an `assert` statement
+    pub const fn in_assert_statement(&self) -> bool {
+        self.flags.intersects(SemanticModelFlags::ASSERT_STATEMENT)
+    }
 }
 
 impl Ranged for ResolvedReference {


### PR DESCRIPTION
## Summary

Fixes #14658.

The stated rationale for RUF018 is that it's unsafe to assign a variable using an assignment expression inside an `assert` statement, because if you run Python in optimised mode the assertion might be stripped out of the program at compilation time, meaning the variable is never actually defined. This concern is irrelevant, however, if the variable is only ever read from inside other `assert` statements: either all `assert` statements will be stripped from the Python program, or none will be. This PR therefore moves the rule to `bindings.rs` and modifies the rule so that it iterates through all references to the binding introduced by the assignment expression to see whether those references take place inside `assert` statements or not.

In order to determine whether a `Binding` or `ResolvedReference` took place inside an `assert` statement, it's necessary to add `SemanticModelFlags::ASSERT_STATEMENT` and `BindingFlags::IN_ASSERT_STATEMENT` to Ruff's semantic model.

## Test Plan

New fixtures added. `cargo test -p ruff_linter --lib`.
