### PR TITLE
mdtest: allow specifying a specific test inside a file

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/unpacking.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/unpacking.md
@@ -34,7 +34,7 @@ reveal_type(d)  # revealed: Literal[4]
 
 ```py
 a, b = c = 1, 2
-reveal_type(a)  # revealed: Literal[14]
+reveal_type(a)  # revealed: Literal[1]
 reveal_type(b)  # revealed: Literal[2]
 reveal_type(c)  # revealed: tuple[Literal[1], Literal[2]]
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/unpacking.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/unpacking.md
@@ -34,7 +34,7 @@ reveal_type(d)  # revealed: Literal[4]
 
 ```py
 a, b = c = 1, 2
-reveal_type(a)  # revealed: Literal[1]
+reveal_type(a)  # revealed: Literal[14]
 reveal_type(b)  # revealed: Literal[2]
 reveal_type(c)  # revealed: tuple[Literal[1], Literal[2]]
 ```

--- a/crates/red_knot_test/README.md
+++ b/crates/red_knot_test/README.md
@@ -184,8 +184,11 @@ The tests are run independently, in independent in-memory file systems and with 
 [Salsa](https://github.com/salsa-rs/salsa) databases. This means that each is a from-scratch run of
 the type checker, with no data persisting from any previous test.
 
-Due to `cargo test` limitations, an entire test suite (Markdown file) is run as a single Rust test,
-so it's not possible to select individual tests within it to run.
+It is possible to filter to individual tests within a single markdown file using the
+`MDTEST_TEST_FILTER` environment variable. This variable will match any tests which contain the
+value as a case-sensitive substring in its name. An example test name is
+`unpacking.md - Unpacking - Tuple - Multiple assignment`, which contains the name of the markdown
+file and its parent headers joined together with hyphens.
 
 ## Structured test suites
 

--- a/crates/red_knot_test/src/lib.rs
+++ b/crates/red_knot_test/src/lib.rs
@@ -15,7 +15,7 @@ mod diagnostic;
 mod matcher;
 mod parser;
 
-const MDTEST_FILE_FILTER: &str = "MDTEST_FILE_FILTER";
+const MDTEST_TEST_FILTER: &str = "MDTEST_TEST_FILTER";
 
 /// Run `path` as a markdown test suite with given `title`.
 ///
@@ -32,7 +32,7 @@ pub fn run(path: &Path, long_title: &str, short_title: &str) {
 
     let mut db = db::Db::setup(SystemPathBuf::from("/src"));
 
-    let filter = std::env::var(MDTEST_FILE_FILTER).ok();
+    let filter = std::env::var(MDTEST_TEST_FILTER).ok();
     let mut any_failures = false;
     for test in suite.tests() {
         if filter.as_ref().is_some_and(|f| !test.name().contains(f)) {
@@ -63,11 +63,11 @@ pub fn run(path: &Path, long_title: &str, short_title: &str) {
             }
 
             println!(
-                "\nTo rerun this specific test, add the environment variable: {MDTEST_FILE_FILTER}=\"{}\"",
+                "\nTo rerun this specific test, set the environment variable: {MDTEST_TEST_FILTER}=\"{}\"",
                 test.name()
             );
             println!(
-                "{MDTEST_FILE_FILTER}=\"{}\" cargo test -p red_knot_python_semantic --test mdtest",
+                "{MDTEST_TEST_FILTER}=\"{}\" cargo test -p red_knot_python_semantic --test mdtest",
                 test.name()
             );
         }

--- a/crates/red_knot_test/src/lib.rs
+++ b/crates/red_knot_test/src/lib.rs
@@ -15,6 +15,8 @@ mod diagnostic;
 mod matcher;
 mod parser;
 
+const MDTEST_FILE_FILTER: &str = "MDTEST_FILE_FILTER";
+
 /// Run `path` as a markdown test suite with given `title`.
 ///
 /// Panic on test failure, and print failure details.
@@ -30,8 +32,13 @@ pub fn run(path: &Path, long_title: &str, short_title: &str) {
 
     let mut db = db::Db::setup(SystemPathBuf::from("/src"));
 
+    let filter = std::env::var(MDTEST_FILE_FILTER).ok();
     let mut any_failures = false;
     for test in suite.tests() {
+        if filter.as_ref().is_some_and(|f| !test.name().contains(f)) {
+            continue;
+        }
+
         // Remove all files so that the db is in a "fresh" state.
         db.memory_file_system().remove_all();
         Files::sync_all(&mut db);
@@ -54,6 +61,15 @@ pub fn run(path: &Path, long_title: &str, short_title: &str) {
                     }
                 }
             }
+
+            println!(
+                "\nTo rerun this specific test, add the environment variable: {MDTEST_FILE_FILTER}=\"{}\"",
+                test.name()
+            );
+            println!(
+                "{MDTEST_FILE_FILTER}=\"{}\" cargo test -p red_knot_python_semantic --test mdtest",
+                test.name()
+            );
         }
     }
 


### PR DESCRIPTION
Resolves https://github.com/astral-sh/ruff/issues/13868 by adding an environment variable `MDTEST_FILE_FILTER` which can be used to specify a substring for tests to be filtered by. I was working around this when implementing another PR by deleting all the other tests in a file. 