### PR TITLE
Skip panda rules if panda module hasn't been seen

### DIFF
--- a/crates/ruff_linter/src/rules/pandas_vet/rules/attr.rs
+++ b/crates/ruff_linter/src/rules/pandas_vet/rules/attr.rs
@@ -1,6 +1,7 @@
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, ViolationMetadata};
 use ruff_python_ast::{self as ast, Expr};
+use ruff_python_semantic::Modules;
 use ruff_text_size::Ranged;
 
 use crate::checkers::ast::Checker;
@@ -44,6 +45,10 @@ impl Violation for PandasUseOfDotValues {
 
 /// PD011
 pub(crate) fn attr(checker: &mut Checker, attribute: &ast::ExprAttribute) {
+    if !checker.semantic().seen_module(Modules::PANDAS) {
+        return;
+    }
+
     // Avoid, e.g., `x.values = y`.
     if !attribute.ctx.is_load() {
         return;

--- a/crates/ruff_linter/src/rules/pandas_vet/rules/call.rs
+++ b/crates/ruff_linter/src/rules/pandas_vet/rules/call.rs
@@ -3,6 +3,7 @@ use ruff_python_ast::{self as ast, Expr};
 use ruff_diagnostics::Violation;
 use ruff_diagnostics::{Diagnostic, DiagnosticKind};
 use ruff_macros::{derive_message_formats, ViolationMetadata};
+use ruff_python_semantic::Modules;
 use ruff_text_size::Ranged;
 
 use crate::checkers::ast::Checker;
@@ -163,6 +164,10 @@ impl Violation for PandasUseOfDotStack {
 }
 
 pub(crate) fn call(checker: &mut Checker, func: &Expr) {
+    if !checker.semantic().seen_module(Modules::PANDAS) {
+        return;
+    }
+
     let Expr::Attribute(ast::ExprAttribute { value, attr, .. }) = func else {
         return;
     };

--- a/crates/ruff_linter/src/rules/pandas_vet/rules/nunique_constant_series_check.rs
+++ b/crates/ruff_linter/src/rules/pandas_vet/rules/nunique_constant_series_check.rs
@@ -2,6 +2,7 @@ use ruff_diagnostics::Diagnostic;
 use ruff_diagnostics::Violation;
 use ruff_macros::{derive_message_formats, ViolationMetadata};
 use ruff_python_ast::{self as ast, CmpOp, Expr, Int};
+use ruff_python_semantic::Modules;
 use ruff_text_size::Ranged;
 
 use crate::checkers::ast::Checker;
@@ -68,6 +69,10 @@ pub(crate) fn nunique_constant_series_check(
     ops: &[CmpOp],
     comparators: &[Expr],
 ) {
+    if !checker.semantic().seen_module(Modules::PANDAS) {
+        return;
+    }
+
     let ([op], [right]) = (ops, comparators) else {
         return;
     };

--- a/crates/ruff_linter/src/rules/pandas_vet/rules/pd_merge.rs
+++ b/crates/ruff_linter/src/rules/pandas_vet/rules/pd_merge.rs
@@ -3,6 +3,7 @@ use ruff_python_ast::{self as ast, Expr};
 use crate::checkers::ast::Checker;
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, ViolationMetadata};
+use ruff_python_semantic::Modules;
 use ruff_text_size::Ranged;
 
 /// ## What it does
@@ -55,6 +56,10 @@ impl Violation for PandasUseOfPdMerge {
 
 /// PD015
 pub(crate) fn use_of_pd_merge(checker: &mut Checker, func: &Expr) {
+    if !checker.semantic().seen_module(Modules::PANDAS) {
+        return;
+    }
+
     if let Expr::Attribute(ast::ExprAttribute { attr, value, .. }) = func {
         if let Expr::Name(ast::ExprName { id, .. }) = value.as_ref() {
             if id == "pd" && attr == "merge" {

--- a/crates/ruff_linter/src/rules/pandas_vet/rules/subscript.rs
+++ b/crates/ruff_linter/src/rules/pandas_vet/rules/subscript.rs
@@ -3,6 +3,7 @@ use ruff_python_ast::{self as ast, Expr};
 use ruff_diagnostics::Violation;
 use ruff_diagnostics::{Diagnostic, DiagnosticKind};
 use ruff_macros::{derive_message_formats, ViolationMetadata};
+use ruff_python_semantic::Modules;
 use ruff_text_size::Ranged;
 
 use crate::checkers::ast::Checker;
@@ -143,6 +144,10 @@ impl Violation for PandasUseOfDotIat {
 }
 
 pub(crate) fn subscript(checker: &mut Checker, value: &Expr, expr: &Expr) {
+    if !checker.semantic().seen_module(Modules::PANDAS) {
+        return;
+    }
+
     let Expr::Attribute(ast::ExprAttribute { attr, value, .. }) = value else {
         return;
     };


### PR DESCRIPTION
## Summary

Issues about `PD011` and other panda rules triggering on non-panda code are frequent: 

* https://github.com/astral-sh/ruff/issues/14669
* https://github.com/astral-sh/ruff/issues/14508
* https://github.com/astral-sh/ruff/issues/6432
* https://github.com/astral-sh/ruff/issues/11235
* https://github.com/astral-sh/ruff/issues/8846
* https://github.com/astral-sh/ruff/issues/11858
* https://github.com/astral-sh/ruff/issues/13495
* https://github.com/astral-sh/ruff/issues/3807
* https://github.com/astral-sh/ruff/issues/14301

And there are probably more. At this point, I consider the rule as harmful for the majority of users. 

This PR adds an `seen_module` check for all panda rules. This likely results in more false-negatives, but I consider
this the better outcome, considering how many users the rules confused in the past. 


## Test Plan

<!-- How was it tested? -->
