### PR TITLE
[`pep8-naming`] Avoid false positive for `class Bar(type(foo))` (`N804`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pep8_naming/N804.py
+++ b/crates/ruff_linter/resources/test/fixtures/pep8_naming/N804.py
@@ -76,3 +76,8 @@ class RenamingInMethodBodyClass(ABCMeta):
 
 def func(x):
     return x
+
+foo = {}
+class Bar(type(foo)):
+    def foo_method(self):
+        pass

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/non_self_return_type.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/non_self_return_type.rs
@@ -126,7 +126,7 @@ pub(crate) fn non_self_return_type(
     };
 
     // PEP 673 forbids the use of `typing(_extensions).Self` in metaclasses.
-    if analyze::class::is_metaclass(class_def, semantic) {
+    if analyze::class::is_metaclass(class_def, semantic).into() {
         return;
     }
 

--- a/crates/ruff_python_semantic/src/analyze/class.rs
+++ b/crates/ruff_python_semantic/src/analyze/class.rs
@@ -121,6 +121,7 @@ pub fn is_enumeration(class_def: &ast::StmtClassDef, semantic: &SemanticModel) -
     })
 }
 
+/// Whether or not a class is a metaclass. Constructed by [`is_metaclass`].
 pub enum IsMetaclass {
     Yes,
     No,
@@ -133,7 +134,9 @@ impl From<IsMetaclass> for bool {
     }
 }
 
-/// Returns `true` if the given class is a metaclass.
+/// Returns `IsMetaclass::Yes` if the given class is definitely a metaclass,
+/// `IsMetaclass::No` if it's definitely *not* a metaclass, and
+/// `IsMetaclass::Maybe` otherwise.
 pub fn is_metaclass(class_def: &ast::StmtClassDef, semantic: &SemanticModel) -> IsMetaclass {
     let mut maybe = false;
     let is_base_class = any_base_class(class_def, semantic, &mut |expr| match expr {

--- a/crates/ruff_python_semantic/src/analyze/class.rs
+++ b/crates/ruff_python_semantic/src/analyze/class.rs
@@ -12,7 +12,7 @@ pub fn any_qualified_base_class(
     semantic: &SemanticModel,
     func: &dyn Fn(QualifiedName) -> bool,
 ) -> bool {
-    any_base_class(class_def, semantic, &|expr| {
+    any_base_class(class_def, semantic, &mut |expr| {
         semantic
             .resolve_qualified_name(map_subscript(expr))
             .is_some_and(func)
@@ -23,12 +23,12 @@ pub fn any_qualified_base_class(
 pub fn any_base_class(
     class_def: &ast::StmtClassDef,
     semantic: &SemanticModel,
-    func: &dyn Fn(&Expr) -> bool,
+    func: &mut dyn FnMut(&Expr) -> bool,
 ) -> bool {
     fn inner(
         class_def: &ast::StmtClassDef,
         semantic: &SemanticModel,
-        func: &dyn Fn(&Expr) -> bool,
+        func: &mut dyn FnMut(&Expr) -> bool,
         seen: &mut FxHashSet<BindingId>,
     ) -> bool {
         class_def.bases().iter().any(|expr| {
@@ -121,12 +121,26 @@ pub fn is_enumeration(class_def: &ast::StmtClassDef, semantic: &SemanticModel) -
     })
 }
 
+pub enum IsMetaclass {
+    Yes,
+    No,
+    Maybe,
+}
+
+impl From<IsMetaclass> for bool {
+    fn from(value: IsMetaclass) -> Self {
+        matches!(value, IsMetaclass::Yes)
+    }
+}
+
 /// Returns `true` if the given class is a metaclass.
-pub fn is_metaclass(class_def: &ast::StmtClassDef, semantic: &SemanticModel) -> bool {
-    any_base_class(class_def, semantic, &|expr| match expr {
+pub fn is_metaclass(class_def: &ast::StmtClassDef, semantic: &SemanticModel) -> IsMetaclass {
+    let mut maybe = false;
+    let is_base_class = any_base_class(class_def, semantic, &mut |expr| match expr {
         Expr::Call(ast::ExprCall {
             func, arguments, ..
         }) => {
+            maybe = true;
             // Ex) `class Foo(type(Protocol)): ...`
             arguments.len() == 1 && semantic.match_builtin_expr(func.as_ref(), "type")
         }
@@ -144,5 +158,11 @@ pub fn is_metaclass(class_def: &ast::StmtClassDef, semantic: &SemanticModel) -> 
                         | ["enum", "EnumMeta" | "EnumType"]
                 )
             }),
-    })
+    });
+
+    match (is_base_class, maybe) {
+        (true, true) => IsMetaclass::Maybe,
+        (true, false) => IsMetaclass::Yes,
+        (false, _) => IsMetaclass::No,
+    }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->
Fixes #14675, which reports N804 (`invalid-first-argument-name-for-class-method`) for this code:

```python
foo = {}

class Bar(type(foo)):
    def foo_method(self):
        pass
```

I don't really love having to capture `maybe` in the closure, but this was the best way I could come up with to avoid propagating the new `IsMetaclass` return type through `any_base_class`. Another option along these lines, which at least avoids changing the `Fn`s to `FnMut`, is to let `maybe` be a `RefCell<bool>` and mutate it that way.

## Test Plan

<!-- How was it tested? -->
`cargo test` with the example above added to `N804.py`.
