### PR TITLE
[red-knot] Narrowing For Truthiness Checks (`if x` or `if not x`)

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/narrow/truthiness.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/narrow/truthiness.md
@@ -1,0 +1,196 @@
+# Narrowing For Truthiness Checks (`if x` or `if not x`)
+
+## Value Literals
+
+```py
+def bool_instance() -> bool:
+    return True
+
+def foo() -> Literal[0, -1, True, False, "", "foo", b"", b"bar"] | None:
+    return 0
+
+x = foo()
+
+if x:
+    reveal_type(x)  # revealed: Literal[-1] | Literal[True] | Literal["foo"] | Literal[b"bar"]
+else:
+    reveal_type(x)  # revealed: Literal[0] | Literal[False] | Literal[""] | Literal[b""] | None
+
+if not x:
+    reveal_type(x)  # revealed: Literal[0] | Literal[False] | Literal[""] | Literal[b""] | None
+else:
+    reveal_type(x)  # revealed: Literal[-1] | Literal[True] | Literal["foo"] | Literal[b"bar"]
+
+if x and not x:
+    reveal_type(x)  # revealed: Never
+else:
+    reveal_type(x)  # revealed: Literal[-1, 0] | bool | Literal["", "foo"] | Literal[b"", b"bar"] | None
+
+if not (x and not x):
+    reveal_type(x)  # revealed: Literal[-1, 0] | bool | Literal["", "foo"] | Literal[b"", b"bar"] | None
+else:
+    reveal_type(x)  # revealed: Never
+
+if x or not x:
+    reveal_type(x)  # revealed: Literal[-1, 0] | bool | Literal["", "foo"] | Literal[b"", b"bar"] | None
+else:
+    reveal_type(x)  # revealed: Never
+
+if not (x or not x):
+    reveal_type(x)  # revealed: Never
+else:
+    reveal_type(x)  # revealed: Literal[-1, 0] | bool | Literal["", "foo"] | Literal[b"", b"bar"] | None
+
+if (isinstance(x, int) or isinstance(x, str)) and x:
+    reveal_type(x)  # revealed: Literal[-1] | Literal[True] | Literal["foo"]
+else:
+    reveal_type(x)  # revealed: Literal[b"", b"bar"] | None | Literal[0] | Literal[False] | Literal[""]
+```
+
+## Function Literals
+
+Basically functions are always truthy.
+
+```py
+def flag() -> bool:
+    return True
+
+def foo(hello: int) -> bytes:
+    return b""
+
+x = flag if flag() else foo
+
+if x:
+    reveal_type(x)  # revealed: Literal[flag, foo]
+else:
+    reveal_type(x)  # revealed: Never
+```
+
+## Ambiguous Truthiness
+
+The boolean value of an instance is not always consistent. For example, `__bool__` can be customized
+to return random values, or in the case of a `list()`, the result depends on the number of elements
+in the list. Therefore, these types should not be narrowed by `if x` or `if not x`.
+
+```py
+def foo() -> list | set | dict:
+    return list()
+
+x = foo()
+
+if x:
+    reveal_type(x)  # revealed: list | set | dict
+else:
+    reveal_type(x)  # revealed: list | set | dict
+
+if x and not x:
+    reveal_type(x)  # revealed: list | set | dict
+else:
+    reveal_type(x)  # revealed: list | set | dict
+
+if x or not x:
+    reveal_type(x)  # revealed: list | set | dict
+else:
+    reveal_type(x)  # revealed: list | set | dict
+
+class RandomBooleanInt(int):
+    def __bool__(self) -> bool:
+        return True
+
+y = RandomBooleanInt(10)
+
+if y:
+    reveal_type(y)  # revealed: RandomBooleanInt
+else:
+    reveal_type(y)  # revealed: RandomBooleanInt
+```
+
+## Class Literals
+
+We can customize the truthiness of a class using a metaclass. Thus, class literals are generally
+included in the category of AmbiguousTruthiness.
+
+```py
+def flag() -> bool:
+    return True
+
+x = int if flag() else str
+reveal_type(x)  # revealed: Literal[int, str]
+
+if x:
+    reveal_type(x)  # revealed: Literal[int, str]
+else:
+    reveal_type(x)  # revealed: Literal[int, str]
+
+class CustomTruthiness(type):
+    def __bool__(self) -> bool:
+        return True
+
+class A: ...
+class B(metaclass=CustomTruthiness): ...
+
+y = A if flag() else B
+
+if y:
+    reveal_type(y)  # revealed: Literal[A, B]
+else:
+    reveal_type(y)  # revealed: Literal[A, B]
+```
+
+## Narrowing Complex Intersection and Union
+
+```py
+class A: ...
+class B: ...
+
+def flag() -> bool:
+    return True
+
+def instance() -> A | B:
+    return A()
+
+def literals() -> Literal[0, 42, "", "hello"]:
+    return 42
+
+x = instance()
+y = literals()
+
+if isinstance(x, str) and not isinstance(x, B):
+    reveal_type(x)  # revealed: A & str & ~B
+    reveal_type(y)  # revealed: Literal[0, 42] | Literal["", "hello"]
+
+    z = x if flag() else y
+
+    reveal_type(z)  # revealed: A & str & ~B | Literal[0, 42] | Literal["", "hello"]
+
+    if z:
+        reveal_type(z)  # revealed: A & str & ~B | Literal[42] | Literal["hello"]
+    else:
+        reveal_type(z)  # revealed: A & str & ~B | Literal[0] | Literal[""]
+```
+
+## Narrowing Multiple Variables
+
+```py
+def flag() -> bool:
+    return True
+
+x = 0 if flag() else 1
+y = "" if flag() else "hello"
+
+if x and y and not x and not y:
+    reveal_type(x)  # revealed: Never
+    reveal_type(y)  # revealed: Never
+else:
+    # ~(x or not x) & ~(y or not y)
+    reveal_type(x)  # revealed: Literal[0, 1]
+    reveal_type(y)  # revealed: Literal["", "hello"]
+
+if (x or not x) and (y and not y):
+    reveal_type(x)  # revealed: Literal[0, 1]
+    reveal_type(y)  # revealed: Never
+else:
+    # ~(x or not x) or ~(y and not y)
+    reveal_type(x)  # revealed: Literal[0, 1]
+    reveal_type(y)  # revealed: Literal["", "hello"]
+```

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -243,7 +243,7 @@ fn bindings_ty<'db>(
                 constraint_tys
                     .fold(
                         IntersectionBuilder::new(db).add_positive(binding_ty),
-                        IntersectionBuilder::add_positive,
+                        |builder, element| builder.add_positive(element.evaluate(db, binding_ty)),
                     )
                     .build()
             } else {
@@ -1672,6 +1672,128 @@ impl<'db> Type<'db> {
             // TODO: handle more complex types
             _ => KnownClass::Str.to_instance(db),
         }
+    }
+
+    /// Implements the Falsy Intersection for a type within practical limitations.
+    /// The primary goal is to remove as much of the `AlwaysTruthy` set from the type as possible.
+    /// Note that (A & `Falsy`) = (A & ~`AlwaysTruthy`).
+    ///
+    /// The reason this function is named `exclude_always_truthy` is that it is not feasible to
+    /// implement (A & Falsy) directly. Instead of imperfectly extracting elements of the Falsy set
+    /// to create a subset of (A & Falsy), it is more appropriate to imperfectly remove `AlwaysTruthy`
+    /// elements to create a larger set that includes (A & Falsy).
+    ///
+    /// Common Pitfall:
+    /// A common misconception is to believe that the Falsy set can be determined solely
+    /// by `FalsyLiterals` (e.g., 0, False, "", b"", ...).
+    /// In reality, (A & Falsy) != (A & `FalsyLiterals`).
+    ///
+    /// One issue with this belief is that it does not account for subclasses.
+    /// Consider the following subclass of `int`:
+    ///
+    /// ```py
+    /// class SubclassInt(int):
+    ///     def __bool__(self) -> bool:
+    ///         return False
+    /// ```
+    ///
+    /// According to the Liskov Substitution Principle, instances of this subclass
+    /// can be assigned to the `int` type. Such an instance will successfully pass
+    /// `if not x`. Therefore, it is an element of (int & Falsy) but not an element of
+    /// (int & `FalsyLiterals`) = {0, False}.
+    ///
+    /// Similarly, this approach cannot handle mutable instances such as `list()`
+    /// or `set()`. For example, (list & `FalsyLiterals`) is just an empty set.
+    #[must_use]
+    pub fn exclude_always_truthy(self, db: &'db dyn Db) -> Type<'db> {
+        match self {
+            Type::Intersection(intersection) => {
+                // Case 1: Positives are not empty
+                // (A & ~B) & Falsy
+                // = (A & Falsy) & ~B
+                // ≈ A.exclude_always_truthy() & ~B
+                //
+                // Case 2: Positives are empty
+                // ~B & Falsy
+                // = ~(B | AlwaysTruthy)
+                // ≈ ~(B.include_always_truthy())
+                //
+                // Note: Calculating `(~B & Falsy)` = `~(B | AlwaysTruthy)` is extremely difficult.
+                // This set should include all elements where `bool(element)` is always True,
+                // regardless of the type of B. Examples include:
+                // { *(elements of B), True, 1, 2, ..., -1, -2, ..., *(instances of object), ... }.
+                //
+                // Attempting to represent this set via Union or Intersection
+                // could break type inference.
+                let mut builder = IntersectionBuilder::new(db);
+
+                // Theoretically, applying `intersection` to a single positive or to all positives
+                // should yield the same result. However, due to the limitations of the current type system,
+                // there is a possibility of losing information when applying it to only one positive.
+                // As a result, `exclude_always_truthy` is applied to all positives.
+                for element in intersection.positive(db) {
+                    builder = builder.add_positive(element.exclude_always_truthy(db));
+                }
+
+                for element in intersection.negative(db) {
+                    builder = builder.add_negative(*element);
+                }
+
+                debug_assert!(
+                    !intersection.positive(db).is_empty(),
+                    "negative-only-intersections can not use `exclude_always_truthy`"
+                );
+
+                builder.build()
+            }
+            Type::Union(union) => {
+                let mut builder = UnionBuilder::new(db);
+
+                for element in union.elements(db) {
+                    builder = builder.add(element.exclude_always_truthy(db));
+                }
+
+                builder.build()
+            }
+            // Since `bool` is a @final class, there is no need to worry about subclasses.
+            Type::Instance(instance) if instance.class.is_known(db, KnownClass::Bool) => {
+                Type::BooleanLiteral(false)
+            }
+            _ => {
+                if let Truthiness::AlwaysTrue = self.bool(db) {
+                    return Type::Never;
+                }
+
+                self
+            }
+        }
+    }
+
+    pub fn falsy_literals(db: &'db dyn Db) -> Type<'db> {
+        UnionBuilder::new(db)
+            .add(Type::none(db))
+            .add(Type::BooleanLiteral(false))
+            .add(Type::IntLiteral(0))
+            .add(Type::string_literal(db, ""))
+            .add(Type::bytes_literal(db, b""))
+            // TODO: tuple literal should be included
+            // .add(Type::tuple(db, &[]))
+            .build()
+    }
+
+    /// Implements the Truthy Intersection for a type within practical limitations.
+    /// This is the counterpart to `exclude_always_truthy`, focusing on excluding values
+    /// that are always falsy from the given type.
+    #[must_use]
+    pub fn exclude_always_falsy(self, db: &'db dyn Db) -> Type<'db> {
+        if let Truthiness::AlwaysFalse = self.bool(db) {
+            return Type::Never;
+        }
+
+        IntersectionBuilder::new(db)
+            .add_positive(self)
+            .add_negative(Type::falsy_literals(db))
+            .build()
     }
 }
 

--- a/crates/red_knot_python_semantic/src/types/narrow.rs
+++ b/crates/red_knot_python_semantic/src/types/narrow.rs
@@ -36,7 +36,7 @@ pub(crate) fn narrowing_constraint<'db>(
     db: &'db dyn Db,
     constraint: Constraint<'db>,
     definition: Definition<'db>,
-) -> Option<Type<'db>> {
+) -> Option<NarrowingType<'db>> {
     let constraints = match constraint.node {
         ConstraintNode::Expression(expression) => {
             if constraint.is_positive {
@@ -103,7 +103,174 @@ where
     }
 }
 
-type NarrowingConstraints<'db> = FxHashMap<ScopedSymbolId, Type<'db>>;
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
+pub(crate) enum NarrowingType<'db> {
+    Deferred(DeferredType),
+    Eager(Type<'db>),
+    Intersection(NarrowingIntersectionType<'db>),
+    Union(NarrowingUnionType<'db>),
+}
+
+impl<'db> NarrowingType<'db> {
+    /// A simplified version of `NarrowingIntersectionBuilder`.
+    ///
+    /// TODO: Further normalization needed (e.g., ignore if an identical `DeferredType` already exists).
+    fn intersection(
+        db: &'db dyn Db,
+        left: NarrowingType<'db>,
+        right: NarrowingType<'db>,
+    ) -> NarrowingType<'db> {
+        match (left, right) {
+            (NarrowingType::Deferred(deferred_left), NarrowingType::Deferred(deferred_right)) => {
+                deferred_left.intersection(db, deferred_right)
+            }
+            (NarrowingType::Eager(eager_left), NarrowingType::Eager(eager_right)) => {
+                NarrowingType::Eager(
+                    IntersectionBuilder::new(db)
+                        .add_positive(eager_left)
+                        .add_positive(eager_right)
+                        .build(),
+                )
+            }
+            (left, right) => NarrowingType::Intersection(NarrowingIntersectionType::new(
+                db,
+                Box::new([left, right]) as Box<[NarrowingType<'db>]>,
+            )),
+        }
+    }
+
+    /// A simplified version of `NarrowingUnionBuilder`.
+    ///
+    /// TODO: Further normalization needed (e.g., ignore if an identical `DeferredType` already exists).
+    fn union(
+        db: &'db dyn Db,
+        left: NarrowingType<'db>,
+        right: NarrowingType<'db>,
+    ) -> NarrowingType<'db> {
+        match (left, right) {
+            (NarrowingType::Deferred(deferred_left), NarrowingType::Deferred(deferred_right)) => {
+                deferred_left.union(db, deferred_right)
+            }
+            (NarrowingType::Eager(eager_left), NarrowingType::Eager(eager_right)) => {
+                NarrowingType::Eager(
+                    UnionBuilder::new(db)
+                        .add(eager_left)
+                        .add(eager_right)
+                        .build(),
+                )
+            }
+            (left, right) => NarrowingType::Union(NarrowingUnionType::new(
+                db,
+                Box::new([left, right]) as Box<[NarrowingType<'db>]>,
+            )),
+        }
+    }
+
+    pub(crate) fn evaluate(&self, db: &'db dyn Db, base_type: Type<'db>) -> Type<'db> {
+        match self {
+            NarrowingType::Deferred(deferred_type) => deferred_type.evaluate(db, base_type),
+            NarrowingType::Eager(ty) => *ty,
+            NarrowingType::Intersection(intersection) => {
+                let mut builder = IntersectionBuilder::new(db);
+                for element in intersection.elements(db) {
+                    builder = builder.add_positive(element.evaluate(db, base_type));
+                }
+                builder.build()
+            }
+            NarrowingType::Union(union) => {
+                let mut builder = UnionBuilder::new(db);
+                for element in union.elements(db) {
+                    builder = builder.add(element.evaluate(db, base_type));
+                }
+                builder.build()
+            }
+        }
+    }
+}
+
+/// A collection of temporary types that can only be used during the narrowing phase.
+/// The sets in this enum must meet the following criteria:
+/// - Represent sets that are difficult to express with a single `Type`.
+/// - Ensure no information is lost during the process of building narrowing constraints.
+///
+/// These enums remain unevaluated during the narrowing constraint building phase
+/// and are eventually intersected with bindings at the final stage.
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
+pub(crate) enum DeferredType {
+    // Truthiness Sets
+    Truthy, // AlwaysTruthy + AmbiguousTruthiness
+    Falsy,  // AlwaysFalsy + AmbiguousTruthiness
+            // TODO?: EqualTo Sets
+            // EqualTo(Type<'db>) ? // AlwaysEqualTo(..) + AmbiguousEqualTo(..)
+            // NotEqualTo(Type<'db>)  ? // NeverEqualTo(..) + AmbiguousEqualTo(..)
+}
+
+impl DeferredType {
+    fn evaluate<'db>(self, db: &'db dyn Db, base_type: Type<'db>) -> Type<'db> {
+        match self {
+            DeferredType::Truthy => base_type.exclude_always_falsy(db),
+            DeferredType::Falsy => base_type.exclude_always_truthy(db),
+        }
+    }
+
+    fn intersection<'db>(self, db: &'db dyn Db, other: DeferredType) -> NarrowingType<'db> {
+        match (self, other) {
+            (DeferredType::Truthy, DeferredType::Truthy)
+            | (DeferredType::Falsy, DeferredType::Falsy) => NarrowingType::Deferred(self),
+            (DeferredType::Truthy, DeferredType::Falsy)
+            | (DeferredType::Falsy, DeferredType::Truthy) => {
+                // (Truthy & Falsy) is not an empty set.
+                // The result will be an AmbiguousTruthiness set,
+                // which includes mutable instances like (`list()`, `set()`),
+                // or instances with custom __bool__ implementations that return random results.
+                NarrowingType::Intersection(NarrowingIntersectionType::<'db>::new(
+                    db,
+                    Box::new([
+                        NarrowingType::Deferred(self),
+                        NarrowingType::Deferred(other),
+                    ]) as Box<[NarrowingType<'db>]>,
+                ))
+            }
+        }
+    }
+
+    fn union(self, db: &'_ dyn Db, other: DeferredType) -> NarrowingType<'_> {
+        match (self, other) {
+            (DeferredType::Truthy, DeferredType::Truthy)
+            | (DeferredType::Falsy, DeferredType::Falsy) => NarrowingType::Deferred(self),
+            (DeferredType::Truthy, DeferredType::Falsy)
+            | (DeferredType::Falsy, DeferredType::Truthy) => {
+                NarrowingType::Eager(KnownClass::Object.to_instance(db))
+            }
+        }
+    }
+}
+
+#[salsa::interned]
+pub(crate) struct NarrowingIntersectionType<'db> {
+    #[return_ref]
+    elements_boxed: Box<[NarrowingType<'db>]>,
+}
+
+impl<'db> NarrowingIntersectionType<'db> {
+    fn elements(self, db: &'db dyn Db) -> &'db [NarrowingType<'db>] {
+        self.elements_boxed(db)
+    }
+}
+
+#[salsa::interned]
+pub(crate) struct NarrowingUnionType<'db> {
+    #[return_ref]
+    elements_boxed: Box<[NarrowingType<'db>]>,
+}
+
+impl<'db> NarrowingUnionType<'db> {
+    fn elements(self, db: &'db dyn Db) -> &'db [NarrowingType<'db>] {
+        self.elements_boxed(db)
+    }
+}
+
+type NarrowingConstraints<'db> = FxHashMap<ScopedSymbolId, NarrowingType<'db>>;
 
 fn merge_constraints_and<'db>(
     into: &mut NarrowingConstraints<'db>,
@@ -113,10 +280,7 @@ fn merge_constraints_and<'db>(
     for (key, value) in from {
         match into.entry(key) {
             Entry::Occupied(mut entry) => {
-                *entry.get_mut() = IntersectionBuilder::new(db)
-                    .add_positive(*entry.get())
-                    .add_positive(value)
-                    .build();
+                *entry.get_mut() = NarrowingType::intersection(db, *entry.get(), value);
             }
             Entry::Vacant(entry) => {
                 entry.insert(value);
@@ -133,16 +297,16 @@ fn merge_constraints_or<'db>(
     for (key, value) in from {
         match into.entry(*key) {
             Entry::Occupied(mut entry) => {
-                *entry.get_mut() = UnionBuilder::new(db).add(*entry.get()).add(*value).build();
+                *entry.get_mut() = NarrowingType::union(db, *entry.get(), *value);
             }
             Entry::Vacant(entry) => {
-                entry.insert(KnownClass::Object.to_instance(db));
+                entry.insert(NarrowingType::Eager(KnownClass::Object.to_instance(db)));
             }
         }
     }
     for (key, value) in into.iter_mut() {
         if !from.contains_key(key) {
-            *value = KnownClass::Object.to_instance(db);
+            *value = NarrowingType::Eager(KnownClass::Object.to_instance(db));
         }
     }
 }
@@ -193,6 +357,7 @@ impl<'db> NarrowingConstraintsBuilder<'db> {
         is_positive: bool,
     ) -> Option<NarrowingConstraints<'db>> {
         match expression_node {
+            ast::Expr::Name(name) => Some(self.evaluate_expr_name(name, is_positive)),
             ast::Expr::Compare(expr_compare) => {
                 self.evaluate_expr_compare(expr_compare, expression, is_positive)
             }
@@ -249,6 +414,28 @@ impl<'db> NarrowingConstraintsBuilder<'db> {
             ConstraintNode::Expression(expression) => expression.scope(self.db),
             ConstraintNode::Pattern(pattern) => pattern.scope(self.db),
         }
+    }
+
+    fn evaluate_expr_name(
+        &mut self,
+        expr_name: &ast::ExprName,
+        is_positive: bool,
+    ) -> NarrowingConstraints<'db> {
+        let ast::ExprName { id, .. } = expr_name;
+
+        let symbol = self
+            .symbols()
+            .symbol_id_by_name(id)
+            .expect("Should always have a symbol for every Name node");
+        let mut constraints = NarrowingConstraints::default();
+
+        if is_positive {
+            constraints.insert(symbol, NarrowingType::Deferred(DeferredType::Truthy));
+        } else {
+            constraints.insert(symbol, NarrowingType::Deferred(DeferredType::Falsy));
+        }
+
+        constraints
     }
 
     fn evaluate_expr_compare(
@@ -311,20 +498,20 @@ impl<'db> NarrowingConstraintsBuilder<'db> {
                                 let ty = IntersectionBuilder::new(self.db)
                                     .add_negative(rhs_ty)
                                     .build();
-                                constraints.insert(symbol, ty);
+                                constraints.insert(symbol, NarrowingType::Eager(ty));
                             } else {
                                 // Non-singletons cannot be safely narrowed using `is not`
                             }
                         }
                         ast::CmpOp::Is => {
-                            constraints.insert(symbol, rhs_ty);
+                            constraints.insert(symbol, NarrowingType::Eager(rhs_ty));
                         }
                         ast::CmpOp::NotEq => {
                             if rhs_ty.is_single_valued(self.db) {
                                 let ty = IntersectionBuilder::new(self.db)
                                     .add_negative(rhs_ty)
                                     .build();
-                                constraints.insert(symbol, ty);
+                                constraints.insert(symbol, NarrowingType::Eager(ty));
                             }
                         }
                         _ => {
@@ -367,7 +554,8 @@ impl<'db> NarrowingConstraintsBuilder<'db> {
                             .symbols()
                             .symbol_id_by_name(id)
                             .expect("Should always have a symbol for every Name node");
-                        constraints.insert(symbol, rhs_ty.to_instance(self.db));
+                        constraints
+                            .insert(symbol, NarrowingType::Eager(rhs_ty.to_instance(self.db)));
                     }
                 }
                 _ => {}
@@ -418,7 +606,10 @@ impl<'db> NarrowingConstraintsBuilder<'db> {
                     generate_classinfo_constraint(self.db, &class_info_ty, to_constraint).map(
                         |constraint| {
                             let mut constraints = NarrowingConstraints::default();
-                            constraints.insert(symbol, constraint.negate_if(self.db, !is_positive));
+                            constraints.insert(
+                                symbol,
+                                NarrowingType::Eager(constraint.negate_if(self.db, !is_positive)),
+                            );
                             constraints
                         },
                     )
@@ -445,7 +636,7 @@ impl<'db> NarrowingConstraintsBuilder<'db> {
                 ast::Singleton::False => Type::BooleanLiteral(false),
             };
             let mut constraints = NarrowingConstraints::default();
-            constraints.insert(symbol, ty);
+            constraints.insert(symbol, NarrowingType::Eager(ty));
             Some(constraints)
         } else {
             None


### PR DESCRIPTION


This turned out to be a really interesting but much trickier task than I expected. I thought this would be straightforward, but it was not.
While I am unsure if this PR will ultimately be merged, I believe it offers valuable insights.

**Before diving in, I recommend reading the comment organized by Carljm** ([link to the comment](https://github.com/astral-sh/ruff/issues/13694#issuecomment-2438438759)).  
Most of the content in this document comes from the ideas outlined in that comment.

---

### **Notation**

We often use the terms "Truthy" and "Falsy," but I think we might interpret them a little differently.
To make sure we’re all on the same page, let’s start by defining these terms. I’ll also include some basic set theory here, but don’t panic—grab a towel, and I’ll keep it as simple as possible.

- **Truthy:** Instances that pass `if x`.  
- **Falsy:** Instances that pass `if not x`.

These sets can include a infinite number of elements. But here are two key takeaways:

#### **1. AmbiguousTruthiness Exists**

There are instances that can pass both `if x` and `if not x`. Mutable objects like `list` and `set` are good examples.

We can define **AmbiguousTruthiness** as:
- The set of instances that can pass both `if x` and `if not x`.


#### **2. `int & Falsy != Literal[0, False]`**

Surprisingly, the intersection of `int` and `Falsy` cannot be represented by `{0, False}`. 
Why? Because the `int` also includes instances of subclasses, and these subclasses can override `__bool__`. Some of them can even return random results. For example:

```py
class RandomBooleanInt(int):
    def __bool__(self) -> bool:
        import random
        return bool(random.randint(0, 1))
```

---

### **Derived Sets**

We can use operations on `Truthy`, `Falsy`, and `AmbiguousTruthiness` to define some useful sets:

- **AlwaysTruthy** = Truthy & ~AmbiguousTruthiness  
- **AlwaysFalsy** = Falsy & ~AmbiguousTruthiness  

These definitions reinforce our intuition

- **Truthy** = AlwaysTruthy | AmbiguousTruthiness  
- **Falsy** = AlwaysFalsy | AmbiguousTruthiness  

Also:
- **Truthy & Falsy** = AmbiguousTruthiness  
- **Truthy | Falsy** = U (U is the Universal Set in set theory)

And:
- **~Truthy** = AlwaysFalsy  
- **~Falsy** = AlwaysTruthy  

---

### **Key Takeaways**

#### **1. Truthy & Falsy Isn’t Empty**

The intersection of `Truthy` and `Falsy` isn’t an empty set. For example, while `if x and not x` might look like it should reject everything, it can still pass with types like `RandomBooleanInt`.  
Here’s another example:

```py
x = [1]

if x and (x.clear() is None) and not x:
    ...
```

#### **2. ~Truthy ≠ Falsy**

The complement of `Truthy` isn’t the same as `Falsy`.  
This is because `Truthy` includes ambiguous instances, so the complement of `Truthy` is **AlwaysFalsy**.

This might feel counterintuitive. It even looks like it conflicts with Python code:

```py
x = list()
if x:
    reveal_type(x)  # revealed: list
else:
    reveal_type(x)  # revealed: list
```

But actually, there’s no conflict. Python’s `not` keyword flips the boolean value of an object; it doesn’t mean the set-theoretic complement.

Here’s how it works instead:
- For any ambiguous `x`, `(not x)` is also ambiguous.  
- For any Truthy `x`, `(not x)` is Falsy.

If we think of `not` as applying to every element of a set, it works like this:

```text
A = {1, 2, 3, ...}
not A = {not 1, not 2, not 3, ...}
```

So:
- **not Truthy** = Falsy  
- **not Ambiguous** = Ambiguous  

Just be careful to distinguish between complements and the `not` operator.

---

### **On Implementation**

The theory sounds great, but it’s not that easy to implement in practice.

For example, instead of directly extracting `int & Falsy`, it’s easier to focus on `(int & ~AlwaysTruthy)`—removing the AlwaysTruthy elements from int. A simpler approach is to use Truthy and Falsy Literals.
To calculate `A & Truthy`, we can try this:

```text
A & ~FalsyLiterals = A & ~(AlwaysFalsy & Literals)
                    = A & (~AlwaysFalsy | ~Literals)
                    = A & (Truthy | ~Literals)
                    = (A & Truthy) | (A & ~Literals)
```

This shows that `A & Truthy` is a subset of `(A & ~FalsyLiterals)`. While `(A & ~Literals)` might add some extra elements, that’s not a big problem since we can’t fully determine the boolean behavior of non-literal objects anyway.

---

### **Limitations**


- Adding `Truthy` and `Falsy` directly as variants in `Type` would make the system unnecessarily complicated. As Carljm pointed out, it’s best to keep their use limited to the Narrowing phase.
- Sometimes, evaluating `(A & Falsy)` as `(A & ~TruthyLiterals)` isn’t even possible. **TruthyLiterals** is basically an infinite set, Without encountering a proper A, we cannot clearly represent `(A & ~TruthyLiterals)` as a type enum. For example, something like `~Literal[0] & Falsy` = `(~Literal[0] & ~TruthyLiterals)` is just too tricky to represent as a simple variant in Type.
More generally, negative-only intersections because `(~B & ~TruthyLiterals)` = `~(B | TruthyLiterals)` essentially requires you to union together all the TruthyLiterals. Thankfully, if we stick to using this only during the Narrowing phase, it won’t be a huge problem since the type we’re narrowing will not be negative-only intersections.

---

### **What This PR Includes**

1. Expanded `NarrowingConstraints` to handle Truthy and Falsy.
2. Deferred evaluation of Truthy and Falsy constraints until they’re applied to `binding_ty`.
3. Added `Type::exclude_always_truthy()` and `Type::exclude_always_falsy()` to implement Truthy and Falsy logic.
4. Supporting Narrowing for `if x` and `if not x`

---

### **Areas to Review Carefully**

1. My understanding of `salsa` is limited, so I’d appreciate careful reviews of salsa-related code.  
2. I used `DeferredType` for lazy evaluation, along with `NarrowingUnion` and `NarrowingIntersection`. If you have ideas for a better approach, let’s discuss!  
2 - 1. Another option could be to pass `base_type` directly when creating `NarrowingConstraintsBuilder::new`, which would let us evaluate Truthy or Falsy eagerly. This would eliminate the need for `DeferredType`, `Union`, and `Intersection`, but it might significantly hurt performance by changing the cache key from `(expression)` to `(base_type, expression)`.

