### PR TITLE
Fix `pytest-parametrize-names-wrong-type (PT006)` not to suggest a fix if both `argnames` and `argvalues` are single-element sequences

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_pytest_style/PT006.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_pytest_style/PT006.py
@@ -81,3 +81,13 @@ def test_not_decorator(param1, param2):
 @pytest.mark.parametrize(argnames=("param1,param2"), argvalues=[(1, 2), (3, 4)])
 def test_keyword_arguments(param1, param2):
     ...
+
+
+@pytest.mark.parametrize(("param",), [(1,), (2,)])
+def test_argvalues_single_element_tuple(param):
+    ...
+
+
+@pytest.mark.parametrize(("param",), [[1], [2]])
+def test_argvalues_single_element_list(param):
+    ...

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/snapshots/ruff_linter__rules__flake8_pytest_style__tests__PT006_csv.snap
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/snapshots/ruff_linter__rules__flake8_pytest_style__tests__PT006_csv.snap
@@ -95,3 +95,21 @@ PT006.py:49:26: PT006 Wrong type passed to first argument of `@pytest.mark.param
 51 |     ...
    |
    = help: Use a string of comma-separated values for the first argument
+
+PT006.py:86:26: PT006 Wrong type passed to first argument of `@pytest.mark.parametrize`; expected `str`
+   |
+86 | @pytest.mark.parametrize(("param",), [(1,), (2,)])
+   |                          ^^^^^^^^^^ PT006
+87 | def test_argvalues_single_element_tuple(param):
+88 |     ...
+   |
+   = help: Use a string for the first argument
+
+PT006.py:91:26: PT006 Wrong type passed to first argument of `@pytest.mark.parametrize`; expected `str`
+   |
+91 | @pytest.mark.parametrize(("param",), [[1], [2]])
+   |                          ^^^^^^^^^^ PT006
+92 | def test_argvalues_single_element_list(param):
+93 |     ...
+   |
+   = help: Use a string for the first argument

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/snapshots/ruff_linter__rules__flake8_pytest_style__tests__PT006_default.snap
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/snapshots/ruff_linter__rules__flake8_pytest_style__tests__PT006_default.snap
@@ -228,4 +228,22 @@ PT006.py:69:26: PT006 [*] Wrong type passed to first argument of `@pytest.mark.p
    69 |+@pytest.mark.parametrize(("param1", "param2"), [(1, 2), (3, 4)])
 70 70 | def test_csv_with_parens(param1, param2):
 71 71 |     ...
-72 72 |
+72 72 | 
+
+PT006.py:86:26: PT006 Wrong type passed to first argument of `@pytest.mark.parametrize`; expected `str`
+   |
+86 | @pytest.mark.parametrize(("param",), [(1,), (2,)])
+   |                          ^^^^^^^^^^ PT006
+87 | def test_argvalues_single_element_tuple(param):
+88 |     ...
+   |
+   = help: Use a string for the first argument
+
+PT006.py:91:26: PT006 Wrong type passed to first argument of `@pytest.mark.parametrize`; expected `str`
+   |
+91 | @pytest.mark.parametrize(("param",), [[1], [2]])
+   |                          ^^^^^^^^^^ PT006
+92 | def test_argvalues_single_element_list(param):
+93 |     ...
+   |
+   = help: Use a string for the first argument

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/snapshots/ruff_linter__rules__flake8_pytest_style__tests__PT006_list.snap
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/snapshots/ruff_linter__rules__flake8_pytest_style__tests__PT006_list.snap
@@ -190,4 +190,22 @@ PT006.py:69:26: PT006 [*] Wrong type passed to first argument of `@pytest.mark.p
    69 |+@pytest.mark.parametrize(["param1", "param2"], [(1, 2), (3, 4)])
 70 70 | def test_csv_with_parens(param1, param2):
 71 71 |     ...
-72 72 |
+72 72 | 
+
+PT006.py:86:26: PT006 Wrong type passed to first argument of `@pytest.mark.parametrize`; expected `str`
+   |
+86 | @pytest.mark.parametrize(("param",), [(1,), (2,)])
+   |                          ^^^^^^^^^^ PT006
+87 | def test_argvalues_single_element_tuple(param):
+88 |     ...
+   |
+   = help: Use a string for the first argument
+
+PT006.py:91:26: PT006 Wrong type passed to first argument of `@pytest.mark.parametrize`; expected `str`
+   |
+91 | @pytest.mark.parametrize(("param",), [[1], [2]])
+   |                          ^^^^^^^^^^ PT006
+92 | def test_argvalues_single_element_list(param):
+93 |     ...
+   |
+   = help: Use a string for the first argument

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/snapshots/ruff_linter__rules__flake8_pytest_style__tests__preview__PT006_PT006.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/snapshots/ruff_linter__rules__flake8_pytest_style__tests__preview__PT006_PT006.py.snap
@@ -266,3 +266,22 @@ PT006.py:81:35: PT006 [*] Wrong type passed to first argument of `@pytest.mark.p
    81 |+@pytest.mark.parametrize(argnames=("param1", "param2"), argvalues=[(1, 2), (3, 4)])
 82 82 | def test_keyword_arguments(param1, param2):
 83 83 |     ...
+84 84 | 
+
+PT006.py:86:26: PT006 Wrong type passed to first argument of `@pytest.mark.parametrize`; expected `str`
+   |
+86 | @pytest.mark.parametrize(("param",), [(1,), (2,)])
+   |                          ^^^^^^^^^^ PT006
+87 | def test_argvalues_single_element_tuple(param):
+88 |     ...
+   |
+   = help: Use a string for the first argument
+
+PT006.py:91:26: PT006 Wrong type passed to first argument of `@pytest.mark.parametrize`; expected `str`
+   |
+91 | @pytest.mark.parametrize(("param",), [[1], [2]])
+   |                          ^^^^^^^^^^ PT006
+92 | def test_argvalues_single_element_list(param):
+93 |     ...
+   |
+   = help: Use a string for the first argument


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Fix `pytest-parametrize-names-wrong-type (PT006)` not to suggest a fix if both `argnames` and `argvalues` are single-element sequences. Here's an example where the fix would break the test:

```python
@pytest.mark.parametrize(("x",), [(1,), (2,)])
                       # ^^^^^^
def test_foo(x):
    ...

# The test above is not equivalent to:

@pytest.mark.parametrize("x", [(1,), (2,)])
                       # ^^^
def test_foo(x):
    ...
```

## Test Plan

<!-- How was it tested? -->

New test cases
