### PR TITLE
[`flake8-annotations`] Fix parsing of "complex" forward reference type annotations in `any-type` (ANN401)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_annotations/annotation_presence.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_annotations/annotation_presence.py
@@ -164,3 +164,32 @@ class Foo:
 class Class:
     def __init__(self):
         print(f"{self.attr=}")
+
+
+
+# Regression test for: https://github.com/astral-sh/ruff/issues/14695
+# Checked for being valid Python using `typing.get_type_hints`
+
+def f2(x: "'int'"): 
+    pass
+
+def f(x: "'in\x74'"): 
+    pass
+
+def f3(x: "'HelloWorld'"): 
+    pass
+
+def g(x: "'An\x79'"): 
+    pass
+
+def g2(x: "'Any'"): 
+    pass
+
+def g3(x: "An\x79"): 
+    pass
+
+def g4(x: "Any"): 
+    pass
+
+def h(x: "'Non\x65'"):
+    pass

--- a/crates/ruff_linter/resources/test/fixtures/flake8_annotations/annotation_presence.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_annotations/annotation_presence.py
@@ -193,3 +193,9 @@ def g4(x: "Any"):
 
 def h(x: "'Non\x65'"):
     pass
+
+def f4(x: "'in''\x74'"): 
+    pass
+
+def f5(x: "'An''\x79'"): 
+    pass

--- a/crates/ruff_linter/src/rules/flake8_annotations/snapshots/ruff_linter__rules__flake8_annotations__tests__defaults.snap
+++ b/crates/ruff_linter/src/rules/flake8_annotations/snapshots/ruff_linter__rules__flake8_annotations__tests__defaults.snap
@@ -494,3 +494,52 @@ annotation_presence.py:194:5: ANN201 [*] Missing return type annotation for publ
 194     |-def h(x: "'Non\x65'"):
     194 |+def h(x: "'Non\x65'") -> None:
 195 195 |     pass
+196 196 | 
+197 197 | def f4(x: "'in''\x74'"): 
+
+annotation_presence.py:197:5: ANN201 [*] Missing return type annotation for public function `f4`
+    |
+195 |     pass
+196 | 
+197 | def f4(x: "'in''\x74'"): 
+    |     ^^ ANN201
+198 |     pass
+    |
+    = help: Add return type annotation: `None`
+
+ℹ Unsafe fix
+194 194 | def h(x: "'Non\x65'"):
+195 195 |     pass
+196 196 | 
+197     |-def f4(x: "'in''\x74'"): 
+    197 |+def f4(x: "'in''\x74'") -> None: 
+198 198 |     pass
+199 199 | 
+200 200 | def f5(x: "'An''\x79'"): 
+
+annotation_presence.py:200:5: ANN201 [*] Missing return type annotation for public function `f5`
+    |
+198 |     pass
+199 | 
+200 | def f5(x: "'An''\x79'"): 
+    |     ^^ ANN201
+201 |     pass
+    |
+    = help: Add return type annotation: `None`
+
+ℹ Unsafe fix
+197 197 | def f4(x: "'in''\x74'"): 
+198 198 |     pass
+199 199 | 
+200     |-def f5(x: "'An''\x79'"): 
+    200 |+def f5(x: "'An''\x79'") -> None: 
+201 201 |     pass
+
+annotation_presence.py:200:11: ANN401 Dynamically typed expressions (typing.Any) are disallowed in `x`
+    |
+198 |     pass
+199 | 
+200 | def f5(x: "'An''\x79'"): 
+    |           ^^^^^^^^^^^^ ANN401
+201 |     pass
+    |

--- a/crates/ruff_linter/src/rules/flake8_annotations/snapshots/ruff_linter__rules__flake8_annotations__tests__defaults.snap
+++ b/crates/ruff_linter/src/rules/flake8_annotations/snapshots/ruff_linter__rules__flake8_annotations__tests__defaults.snap
@@ -298,3 +298,199 @@ annotation_presence.py:165:9: ANN204 [*] Missing return type annotation for spec
 165     |-    def __init__(self):
     165 |+    def __init__(self) -> None:
 166 166 |         print(f"{self.attr=}")
+167 167 | 
+168 168 | 
+
+annotation_presence.py:173:5: ANN201 [*] Missing return type annotation for public function `f2`
+    |
+171 | # Checked for being valid Python using `typing.get_type_hints`
+172 | 
+173 | def f2(x: "'int'"): 
+    |     ^^ ANN201
+174 |     pass
+    |
+    = help: Add return type annotation: `None`
+
+ℹ Unsafe fix
+170 170 | # Regression test for: https://github.com/astral-sh/ruff/issues/14695
+171 171 | # Checked for being valid Python using `typing.get_type_hints`
+172 172 | 
+173     |-def f2(x: "'int'"): 
+    173 |+def f2(x: "'int'") -> None: 
+174 174 |     pass
+175 175 | 
+176 176 | def f(x: "'in\x74'"): 
+
+annotation_presence.py:176:5: ANN201 [*] Missing return type annotation for public function `f`
+    |
+174 |     pass
+175 | 
+176 | def f(x: "'in\x74'"): 
+    |     ^ ANN201
+177 |     pass
+    |
+    = help: Add return type annotation: `None`
+
+ℹ Unsafe fix
+173 173 | def f2(x: "'int'"): 
+174 174 |     pass
+175 175 | 
+176     |-def f(x: "'in\x74'"): 
+    176 |+def f(x: "'in\x74'") -> None: 
+177 177 |     pass
+178 178 | 
+179 179 | def f3(x: "'HelloWorld'"): 
+
+annotation_presence.py:179:5: ANN201 [*] Missing return type annotation for public function `f3`
+    |
+177 |     pass
+178 | 
+179 | def f3(x: "'HelloWorld'"): 
+    |     ^^ ANN201
+180 |     pass
+    |
+    = help: Add return type annotation: `None`
+
+ℹ Unsafe fix
+176 176 | def f(x: "'in\x74'"): 
+177 177 |     pass
+178 178 | 
+179     |-def f3(x: "'HelloWorld'"): 
+    179 |+def f3(x: "'HelloWorld'") -> None: 
+180 180 |     pass
+181 181 | 
+182 182 | def g(x: "'An\x79'"): 
+
+annotation_presence.py:182:5: ANN201 [*] Missing return type annotation for public function `g`
+    |
+180 |     pass
+181 | 
+182 | def g(x: "'An\x79'"): 
+    |     ^ ANN201
+183 |     pass
+    |
+    = help: Add return type annotation: `None`
+
+ℹ Unsafe fix
+179 179 | def f3(x: "'HelloWorld'"): 
+180 180 |     pass
+181 181 | 
+182     |-def g(x: "'An\x79'"): 
+    182 |+def g(x: "'An\x79'") -> None: 
+183 183 |     pass
+184 184 | 
+185 185 | def g2(x: "'Any'"): 
+
+annotation_presence.py:182:10: ANN401 Dynamically typed expressions (typing.Any) are disallowed in `x`
+    |
+180 |     pass
+181 | 
+182 | def g(x: "'An\x79'"): 
+    |          ^^^^^^^^^^ ANN401
+183 |     pass
+    |
+
+annotation_presence.py:185:5: ANN201 [*] Missing return type annotation for public function `g2`
+    |
+183 |     pass
+184 | 
+185 | def g2(x: "'Any'"): 
+    |     ^^ ANN201
+186 |     pass
+    |
+    = help: Add return type annotation: `None`
+
+ℹ Unsafe fix
+182 182 | def g(x: "'An\x79'"): 
+183 183 |     pass
+184 184 | 
+185     |-def g2(x: "'Any'"): 
+    185 |+def g2(x: "'Any'") -> None: 
+186 186 |     pass
+187 187 | 
+188 188 | def g3(x: "An\x79"): 
+
+annotation_presence.py:185:11: ANN401 Dynamically typed expressions (typing.Any) are disallowed in `x`
+    |
+183 |     pass
+184 | 
+185 | def g2(x: "'Any'"): 
+    |           ^^^^^^^ ANN401
+186 |     pass
+    |
+
+annotation_presence.py:188:5: ANN201 [*] Missing return type annotation for public function `g3`
+    |
+186 |     pass
+187 | 
+188 | def g3(x: "An\x79"): 
+    |     ^^ ANN201
+189 |     pass
+    |
+    = help: Add return type annotation: `None`
+
+ℹ Unsafe fix
+185 185 | def g2(x: "'Any'"): 
+186 186 |     pass
+187 187 | 
+188     |-def g3(x: "An\x79"): 
+    188 |+def g3(x: "An\x79") -> None: 
+189 189 |     pass
+190 190 | 
+191 191 | def g4(x: "Any"): 
+
+annotation_presence.py:188:11: ANN401 Dynamically typed expressions (typing.Any) are disallowed in `x`
+    |
+186 |     pass
+187 | 
+188 | def g3(x: "An\x79"): 
+    |           ^^^^^^^^ ANN401
+189 |     pass
+    |
+
+annotation_presence.py:191:5: ANN201 [*] Missing return type annotation for public function `g4`
+    |
+189 |     pass
+190 | 
+191 | def g4(x: "Any"): 
+    |     ^^ ANN201
+192 |     pass
+    |
+    = help: Add return type annotation: `None`
+
+ℹ Unsafe fix
+188 188 | def g3(x: "An\x79"): 
+189 189 |     pass
+190 190 | 
+191     |-def g4(x: "Any"): 
+    191 |+def g4(x: "Any") -> None: 
+192 192 |     pass
+193 193 | 
+194 194 | def h(x: "'Non\x65'"):
+
+annotation_presence.py:191:11: ANN401 Dynamically typed expressions (typing.Any) are disallowed in `x`
+    |
+189 |     pass
+190 | 
+191 | def g4(x: "Any"): 
+    |           ^^^^^ ANN401
+192 |     pass
+    |
+
+annotation_presence.py:194:5: ANN201 [*] Missing return type annotation for public function `h`
+    |
+192 |     pass
+193 | 
+194 | def h(x: "'Non\x65'"):
+    |     ^ ANN201
+195 |     pass
+    |
+    = help: Add return type annotation: `None`
+
+ℹ Unsafe fix
+191 191 | def g4(x: "Any"): 
+192 192 |     pass
+193 193 | 
+194     |-def h(x: "'Non\x65'"):
+    194 |+def h(x: "'Non\x65'") -> None:
+195 195 |     pass

--- a/crates/ruff_python_parser/src/typing.rs
+++ b/crates/ruff_python_parser/src/typing.rs
@@ -97,7 +97,7 @@ fn parse_complex_type_annotation(string_expr: &ExprStringLiteral) -> AnnotationP
     let range_excluding_quotes =
         if let Expr::StringLiteral(ExprStringLiteral { ref value, .. }) = *parsed.syntax.body {
             let string_parts = value.as_slice();
-            let start = string_parts[0].flags.closer_len();
+            let start = string_parts[0].flags.opener_len();
             let end = string_parts[string_parts.len() - 1].flags.closer_len();
             string_expr.range().add_start(start).sub_end(end)
         } else {

--- a/crates/ruff_python_parser/src/typing.rs
+++ b/crates/ruff_python_parser/src/typing.rs
@@ -96,14 +96,10 @@ fn parse_complex_type_annotation(string_expr: &ExprStringLiteral) -> AnnotationP
     // Remove quotes from nested forward reference type annotations
     let range_excluding_quotes =
         if let Expr::StringLiteral(ExprStringLiteral { ref value, .. }) = *parsed.syntax.body {
-            if let [sl] = value.as_slice() {
-                string_expr
-                    .range()
-                    .add_start(sl.flags.opener_len())
-                    .sub_end(sl.flags.closer_len())
-            } else {
-                string_expr.range()
-            }
+            let string_parts = value.as_slice();
+            let start = string_parts[0].flags.closer_len();
+            let end = string_parts[string_parts.len() - 1].flags.closer_len();
+            string_expr.range().add_start(start).sub_end(end)
         } else {
             string_expr.range()
         };


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Fixes #14695.

<!-- What's the purpose of the change? What does it do, and why? -->

The root cause was tricky to find. 
"Complex" forward reference type annotations are handled differently. Forward references are "complex" in this case when the raw contents (without quotes) of the expression with the parsed contents is not contained in the string literal.
https://github.com/astral-sh/ruff/blob/84748be16341b76e073d117329f7f5f4ee2941ad/crates/ruff_python_parser/src/typing.rs#L65

Annotations are recursively parsed, for instance:
`"'int'"` (complex) => `"int"` (simple)

The raw contents of the expression "in\x74" is not contained in the string literal `int` and hence requires multiple complex parsing steps: `"'in\x74'"` (complex) -> `"in\x74"` (complex). This is rare, and probably that's why the bug went unnoticed.

Parsed type annotations are cached by their start offset:
https://github.com/astral-sh/ruff/blob/84748be16341b76e073d117329f7f5f4ee2941ad/crates/ruff_linter/src/checkers/ast/mod.rs#L2544

As it turned out, for these complex annotations the starting offset was not properly updated (removing the quotes), as well already do for the simple annotations. This caused an infinite loop, and eventually a stack overflow.

## Test Plan

<!-- How was it tested? -->

Extended the test suite with regression tests.