### PR TITLE
Extend `map-int-version-parsing (RUF048)` to flag `tuple(map(int, importlib.metadata.version("<package>").split(".")))`

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/ruff/RUF048.py
+++ b/crates/ruff_linter/resources/test/fixtures/ruff/RUF048.py
@@ -1,3 +1,5 @@
+import importlib.metadata
+
 __version__ = (0, 1, 0)
 
 
@@ -15,3 +17,5 @@ list(map(int, __version__.split(",")))
 # Multiple arguments
 tuple(map(int, __version__.split(".", 1)))
 list(map(int, __version__.split(".", maxsplit=2)))
+
+tuple(map(int, importlib.metadata.version("ruff").split(".")))


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Extend `map-int-version-parsing (RUF048)` to flag `tuple(map(int, importlib.metadata.version("<package>").split(".")))`

## Test Plan

<!-- How was it tested? -->

New test case

## Code search

A quick [code search](https://github.com/search?q=%2Ftuple%5C%28map%5C%28int%2C+importlib%5C.metadata%5C.version%5C%28%5C%22%5Cw%2B%22%5C%29.split%5C%28%5B%22%27%5D%5C.%5B%22%27%5D%5C%29%5C%29%5C%29%2F+language%3APython&type=code) shows a few results.