### PR TITLE
Sort discovered workspace packages for consistent cross-platform package discovery

### DIFF
--- a/crates/red_knot_workspace/src/workspace/metadata.rs
+++ b/crates/red_knot_workspace/src/workspace/metadata.rs
@@ -349,6 +349,8 @@ fn collect_packages(
         packages.push(package);
     }
 
+    packages.sort_unstable_by(|a, b| a.root().cmp(b.root()));
+
     Ok(CollectedPackagesOrStandalone::Packages(packages))
 }
 


### PR DESCRIPTION
## Summary

Sort the packages discovered by `collect_packages` by path for 
consistent cross-platform package-ordering (instead of relying on globs ordering)

Fixes https://github.com/astral-sh/ruff/issues/14724

## Test Plan

`cargo test --target i686-pc-windows-msvc -p red_knot_workspace  -- workspace_non_unique_member_names`


