### PR TITLE
[red-knot] Re-enable linter corpus tests

### DIFF
--- a/crates/red_knot_workspace/tests/check.rs
+++ b/crates/red_knot_workspace/tests/check.rs
@@ -42,7 +42,6 @@ fn parser_no_panic() -> anyhow::Result<()> {
 }
 
 #[test]
-#[ignore = "Enable running once there are fewer failures"]
 fn linter_af_no_panic() -> anyhow::Result<()> {
     let workspace_root = get_workspace_root()?;
     run_corpus_tests(&format!(
@@ -51,7 +50,6 @@ fn linter_af_no_panic() -> anyhow::Result<()> {
 }
 
 #[test]
-#[ignore = "Enable running once there are fewer failures"]
 fn linter_gz_no_panic() -> anyhow::Result<()> {
     let workspace_root = get_workspace_root()?;
     run_corpus_tests(&format!(
@@ -272,6 +270,7 @@ const KNOWN_FAILURES: &[(&str, bool, bool)] = &[
     ("crates/ruff_linter/resources/test/fixtures/pyupgrade/UP039.py", true, false),
     // related to circular references in type aliases (salsa cycle panic):
     ("crates/ruff_python_parser/resources/inline/err/type_alias_invalid_value_expr.py", true, true),
+    ("crates/ruff_linter/resources/test/fixtures/flake8_type_checking/TC008.py", true, true),
     // related to circular references in f-string annotations (invalid syntax)
     ("crates/ruff_linter/resources/test/fixtures/pyflakes/F821_15.py", true, true),
     ("crates/ruff_linter/resources/test/fixtures/pyflakes/F821_14.py", false, true),


### PR DESCRIPTION
## Summary

Given that no new failures appeared over the past two weeks, and seeing the fuzzing results from @dhruvmanila in #13778, I think we can re-enable these tests. We also had one regression that would have been caught by these tests, so there is some value in having them enabled.

