### PR TITLE
[red-knot] Simplify tuples containing `Never`

### DIFF
--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -4537,7 +4537,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                 if element_could_alter_type_of_whole_tuple(single_element, single_element_ty) {
                     todo_type!()
                 } else {
-                    Type::tuple(self.db, &[single_element_ty])
+                    Type::tuple(self.db, [single_element_ty])
                 }
             }
         }

--- a/crates/red_knot_python_semantic/src/types/unpacker.rs
+++ b/crates/red_knot_python_semantic/src/types/unpacker.rs
@@ -95,7 +95,7 @@ impl<'db> Unpacker<'db> {
                     // there would be a cost and it's not clear that it's worth it.
                     let value_ty = Type::tuple(
                         self.db,
-                        &vec![Type::LiteralString; string_literal_ty.len(self.db)],
+                        std::iter::repeat(Type::LiteralString).take(string_literal_ty.len(self.db)),
                     );
                     self.unpack(target, value_ty, scope);
                 }


### PR DESCRIPTION
## Summary

Simplify tuples containing `Never` to `Never`:

```py
from typing import Never

def never() -> Never: ...

reveal_type((1, never(), "foo"))  # revealed: Never
```

I should note that mypy and pyright do *not* perform this simplification. I don't know why.


There is [only one place](https://github.com/astral-sh/ruff/blob/5137fcc9c81610f687b6cb45413ef83c2c5eea73/crates/red_knot_python_semantic/src/types/infer.rs#L1477-L1484) where we use `TupleType::new` directly (instead of `Type::tuple`, which changes behavior here). This appears when creating `TypeVar` constraints, and it looks to me like it should stay this way, because we're using `TupleType` to store a list of constraints there, instead of an actual type. We also store `tuple[constraint1, constraint2, …]` as the type for the `constraint1, constraint2, …` tuple expression. This would mean that we infer a type of `tuple[str, Never]` for the following type variable constraints, without simplifying it to `Never`. This seems like a weird edge case that's maybe not worth looking further into?!
```py
from typing import Never

#         vvvvvvvvvv
def f[T: (str, Never)](x: T):
    pass
```

## Test Plan

- Added a new unit test. Did not add additional Markdown tests as that seems superfluous.
- Tested the example above using red knot, mypy, pyright.
- Verified that this allows us to remove `contains_never` from the property tests (https://github.com/astral-sh/ruff/pull/14178#discussion_r1866473192)