### PR TITLE
[`flake8-import-conventions`] Improve syntax check for aliases supplied in configuration for `unconventional-import-alias (ICN001)`

### DIFF
--- a/crates/ruff_workspace/src/options.rs
+++ b/crates/ruff_workspace/src/options.rs
@@ -1415,10 +1415,10 @@ impl<'de> Deserialize<'de> for Alias {
         D: Deserializer<'de>,
     {
         let name = String::deserialize(deserializer)?;
-        // Assignments to these names are SyntaxErrors
+        // Assigning to "__debug__" is a SyntaxError
         // see the note here:
         // https://docs.python.org/3/library/constants.html#debug__
-        if matches!(&*name, "__debug__" | "True" | "False" | "None") {
+        if &*name == "__debug__" {
             return Err(de::Error::invalid_value(
                 de::Unexpected::Str(&name),
                 &"an assignable Python identifier",

--- a/ruff.schema.json
+++ b/ruff.schema.json
@@ -1168,7 +1168,7 @@
             "null"
           ],
           "additionalProperties": {
-            "type": "string"
+            "$ref": "#/definitions/Alias"
           }
         }
       },


### PR DESCRIPTION
This PR improves on #14477 by:

- Ensuring user's do not require module aliases which are unassignable Python identifiers
- Validating the linter settings for `lint.flake8-import-conventions.extend-aliases` (whereas previously we only did this for `lint.flake8-import-conventions.aliases`).

Closes #14662
