### PR TITLE
[`pycodestyle`] Handle f-strings properly for `invalid-escape-sequence (W605)`

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pycodestyle/W605_1.py
+++ b/crates/ruff_linter/resources/test/fixtures/pycodestyle/W605_1.py
@@ -63,3 +63,6 @@ total = 10
 ok = 7
 incomplete = 3
 s = f"TOTAL: {total}\nOK: {ok}\INCOMPLETE: {incomplete}\n"
+
+# Debug text (should trigger)
+t = f"{'\InHere'=}"

--- a/crates/ruff_linter/resources/test/fixtures/pycodestyle/W605_1.py
+++ b/crates/ruff_linter/resources/test/fixtures/pycodestyle/W605_1.py
@@ -57,3 +57,9 @@ value = f"{rf"\{1}"}"
 f"{{}}+-\d"
 f"\n{{}}+-\d+"
 f"\n{{}}�+-\d+"
+
+# See https://github.com/astral-sh/ruff/issues/11491
+total = 10
+ok = 7
+incomplete = 3
+s = f"TOTAL: {total}\nOK: {ok}\INCOMPLETE: {incomplete}\n"

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/invalid_escape_sequence.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/invalid_escape_sequence.rs
@@ -68,7 +68,7 @@ pub(crate) fn invalid_escape_sequence(checker: &mut Checker, string_like: String
         }
         let state = match part {
             StringLikePart::String(_) | StringLikePart::Bytes(_) => {
-                analyze_escape_chars(locator, part.range(), AnyStringFlags::from(part.flags()))
+                analyze_escape_chars(locator, part.range(), part.flags())
             }
             StringLikePart::FString(f_string) => {
                 let flags = AnyStringFlags::from(f_string.flags);

--- a/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__W605_W605_1.py.snap
+++ b/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__W605_W605_1.py.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/ruff_linter/src/rules/pycodestyle/mod.rs
-snapshot_kind: text
 ---
 W605_1.py:4:11: W605 [*] Invalid escape sequence: `\.`
   |
@@ -243,6 +242,7 @@ W605_1.py:57:9: W605 [*] Invalid escape sequence: `\d`
    57 |+rf"{{}}+-\d"
 58 58 | f"\n{{}}+-\d+"
 59 59 | f"\n{{}}�+-\d+"
+60 60 | 
 
 W605_1.py:58:11: W605 [*] Invalid escape sequence: `\d`
    |
@@ -261,6 +261,8 @@ W605_1.py:58:11: W605 [*] Invalid escape sequence: `\d`
 58    |-f"\n{{}}+-\d+"
    58 |+f"\n{{}}+-\\d+"
 59 59 | f"\n{{}}�+-\d+"
+60 60 | 
+61 61 | # See https://github.com/astral-sh/ruff/issues/11491
 
 W605_1.py:59:12: W605 [*] Invalid escape sequence: `\d`
    |
@@ -268,6 +270,8 @@ W605_1.py:59:12: W605 [*] Invalid escape sequence: `\d`
 58 | f"\n{{}}+-\d+"
 59 | f"\n{{}}�+-\d+"
    |            ^^ W605
+60 | 
+61 | # See https://github.com/astral-sh/ruff/issues/11491
    |
    = help: Add backslash to escape sequence
 
@@ -277,3 +281,22 @@ W605_1.py:59:12: W605 [*] Invalid escape sequence: `\d`
 58 58 | f"\n{{}}+-\d+"
 59    |-f"\n{{}}�+-\d+"
    59 |+f"\n{{}}�+-\\d+"
+60 60 | 
+61 61 | # See https://github.com/astral-sh/ruff/issues/11491
+62 62 | total = 10
+
+W605_1.py:65:31: W605 [*] Invalid escape sequence: `\I`
+   |
+63 | ok = 7
+64 | incomplete = 3
+65 | s = f"TOTAL: {total}\nOK: {ok}\INCOMPLETE: {incomplete}\n"
+   |                               ^^ W605
+   |
+   = help: Add backslash to escape sequence
+
+ℹ Safe fix
+62 62 | total = 10
+63 63 | ok = 7
+64 64 | incomplete = 3
+65    |-s = f"TOTAL: {total}\nOK: {ok}\INCOMPLETE: {incomplete}\n"
+   65 |+s = f"TOTAL: {total}\nOK: {ok}\\INCOMPLETE: {incomplete}\n"

--- a/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__W605_W605_1.py.snap
+++ b/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__W605_W605_1.py.snap
@@ -291,6 +291,8 @@ W605_1.py:65:31: W605 [*] Invalid escape sequence: `\I`
 64 | incomplete = 3
 65 | s = f"TOTAL: {total}\nOK: {ok}\INCOMPLETE: {incomplete}\n"
    |                               ^^ W605
+66 | 
+67 | # Debug text (should trigger)
    |
    = help: Add backslash to escape sequence
 
@@ -300,3 +302,21 @@ W605_1.py:65:31: W605 [*] Invalid escape sequence: `\I`
 64 64 | incomplete = 3
 65    |-s = f"TOTAL: {total}\nOK: {ok}\INCOMPLETE: {incomplete}\n"
    65 |+s = f"TOTAL: {total}\nOK: {ok}\\INCOMPLETE: {incomplete}\n"
+66 66 | 
+67 67 | # Debug text (should trigger)
+68 68 | t = f"{'\InHere'=}"
+
+W605_1.py:68:9: W605 [*] Invalid escape sequence: `\I`
+   |
+67 | # Debug text (should trigger)
+68 | t = f"{'\InHere'=}"
+   |         ^^ W605
+   |
+   = help: Use a raw string literal
+
+ℹ Safe fix
+65 65 | s = f"TOTAL: {total}\nOK: {ok}\INCOMPLETE: {incomplete}\n"
+66 66 | 
+67 67 | # Debug text (should trigger)
+68    |-t = f"{'\InHere'=}"
+   68 |+t = f"{r'\InHere'=}"


### PR DESCRIPTION
When fixing an invalid escape sequence in an f-string, each f-string element is analyzed for valid escape characters prior to creating the diagnostic and fix. This allows us to safely prefix with `r` to create a raw string if no valid escape characters were found anywhere in the f-string, and otherwise insert backslashes.

This fixes a bug in the original implementation: each "f-string part" was treated separately, so it was not possible to tell whether a valid escape character was or would be used elsewhere in the f-string.

Progress towards #11491 but format specifiers are not handled in this PR.

