### PR TITLE
[`flake8-type-checking`] Expands TC006 docs to better explain itself

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_type_checking/rules/runtime_cast_value.rs
+++ b/crates/ruff_linter/src/rules/flake8_type_checking/rules/runtime_cast_value.rs
@@ -8,14 +8,18 @@ use crate::checkers::ast::Checker;
 use crate::rules::flake8_type_checking::helpers::quote_type_expression;
 
 /// ## What it does
-/// Checks for an unquoted type expression in `typing.cast()` calls.
+/// Checks for unquoted type expressions in `typing.cast()` calls.
 ///
 /// ## Why is this bad?
-/// `typing.cast()` does not do anything at runtime, so the time spent
-/// on evaluating the potentially complex type expression is wasted.
-/// But it's also bad to be inconsistent, so this rule always quotes
-/// the type expression even if its contribution to import/evaluation
-/// time is negligible, as a matter of style.
+/// This rule helps enforce a consistent style across your codebase.
+///
+/// It's often necessary to quote the first argument passed to `cast()`,
+/// as type expressions can involve forward references, or references
+/// to symbols which are only imported in `typing.TYPE_CHECKING` blocks.
+/// This can lead to a visual inconsistency across different `cast()` calls,
+/// where some type expressions are quoted but others are not. By enabling
+/// this rule, you ensure that all type expressions passed to `cast()` are
+/// quoted, enforcing stylistic consistency across all of your `cast()` calls.
 ///
 /// ## Example
 /// ```python

--- a/crates/ruff_linter/src/rules/flake8_type_checking/rules/runtime_cast_value.rs
+++ b/crates/ruff_linter/src/rules/flake8_type_checking/rules/runtime_cast_value.rs
@@ -12,15 +12,10 @@ use crate::rules::flake8_type_checking::helpers::quote_type_expression;
 ///
 /// ## Why is this bad?
 /// `typing.cast()` does not do anything at runtime, so the time spent
-/// on evaluating the type expression is wasted.
-///
-/// In order to provide a consistent experience and keep this rule simple
-/// type expressions will be quoted, even if they're so simple, that their
-/// overhead becomes negligible (e.g. a single builtin name lookup like `str`).
-///
-/// This has the added benefit of making the type expression visually
-/// distinct from the value expression, making it easier to see at a glance
-/// where one ends and the other begins.
+/// on evaluating the potentially complex type expression is wasted.
+/// But it's also bad to be inconsistent, so this rule always quotes
+/// the type expression even if its contribution to import/evaluation
+/// time is negligible, as a matter of style.
 ///
 /// ## Example
 /// ```python

--- a/crates/ruff_linter/src/rules/flake8_type_checking/rules/runtime_cast_value.rs
+++ b/crates/ruff_linter/src/rules/flake8_type_checking/rules/runtime_cast_value.rs
@@ -21,6 +21,10 @@ use crate::rules::flake8_type_checking::helpers::quote_type_expression;
 /// this rule, you ensure that all type expressions passed to `cast()` are
 /// quoted, enforcing stylistic consistency across all of your `cast()` calls.
 ///
+/// In some cases where `cast()` is used in a hot loop, this rule may also
+/// help avoid overhead from repeatedly evaluating complex type expressions at
+/// runtime.
+///
 /// ## Example
 /// ```python
 /// from typing import cast

--- a/crates/ruff_linter/src/rules/flake8_type_checking/rules/runtime_cast_value.rs
+++ b/crates/ruff_linter/src/rules/flake8_type_checking/rules/runtime_cast_value.rs
@@ -14,6 +14,14 @@ use crate::rules::flake8_type_checking::helpers::quote_type_expression;
 /// `typing.cast()` does not do anything at runtime, so the time spent
 /// on evaluating the type expression is wasted.
 ///
+/// In order to provide a consistent experience and keep this rule simple
+/// type expressions will be quoted, even if they're so simple, that their
+/// overhead becomes negligible (e.g. a single builtin name lookup like `str`).
+///
+/// This has the added benefit of making the type expression visually
+/// distinct from the value expression, making it easier to see at a glance
+/// where one ends and the other begins.
+///
 /// ## Example
 /// ```python
 /// from typing import cast


### PR DESCRIPTION
Closes: #14676

I think the consensus generally was to keep the rule as-is, but expand the docs.

## Summary

Expands the docs for TC006 with an explanation for why the type expression is always quoted, including mention of another potential benefit to this style.