### PR TITLE
Use `Invalid` context when keyword used as identifier

### DIFF
--- a/crates/ruff_python_parser/src/parser/pattern.rs
+++ b/crates/ruff_python_parser/src/parser/pattern.rs
@@ -120,7 +120,7 @@ impl Parser<'_> {
                 self.add_error(ParseErrorType::InvalidStarPatternUsage, &lhs);
             }
 
-            let ident = self.parse_identifier();
+            let ident = self.parse_identifier().into_inner();
             lhs = Pattern::MatchAs(ast::PatternMatchAs {
                 range: self.node_range(start),
                 name: Some(ident),
@@ -183,7 +183,7 @@ impl Parser<'_> {
             let mapping_item_start = parser.node_start();
 
             if parser.eat(TokenKind::DoubleStar) {
-                let identifier = parser.parse_identifier();
+                let identifier = parser.parse_identifier().into_inner();
                 if rest.is_some() {
                     parser.add_error(
                         ParseErrorType::OtherError(
@@ -258,7 +258,7 @@ impl Parser<'_> {
         let start = self.node_start();
         self.bump(TokenKind::Star);
 
-        let ident = self.parse_identifier();
+        let ident = self.parse_identifier().into_inner();
 
         ast::PatternMatchStar {
             range: self.node_range(start),
@@ -490,7 +490,7 @@ impl Parser<'_> {
                         //     case case: ...
                         //     case match: ...
                         //     case type: ...
-                        let ident = self.parse_identifier();
+                        let ident = self.parse_identifier().into_inner();
 
                         // test_ok match_as_pattern
                         // match foo:

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@assert_invalid_test_expr.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@assert_invalid_test_expr.py.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/ruff_python_parser/tests/fixtures.rs
 input_file: crates/ruff_python_parser/resources/inline/err/assert_invalid_test_expr.py
-snapshot_kind: text
 ---
 ## AST
 
@@ -36,7 +35,7 @@ Module(
                         ExprName {
                             range: 17..23,
                             id: Name("assert"),
-                            ctx: Load,
+                            ctx: Invalid,
                         },
                     ),
                     msg: None,

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@aug_assign_stmt_invalid_target.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@aug_assign_stmt_invalid_target.py.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/ruff_python_parser/tests/fixtures.rs
 input_file: crates/ruff_python_parser/resources/inline/err/aug_assign_stmt_invalid_target.py
-snapshot_kind: text
 ---
 ## AST
 
@@ -134,7 +133,7 @@ Module(
                         ExprName {
                             range: 41..45,
                             id: Name("pass"),
-                            ctx: Load,
+                            ctx: Invalid,
                         },
                     ),
                 },

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@comprehension_missing_for_after_async.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@comprehension_missing_for_after_async.py.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/ruff_python_parser/tests/fixtures.rs
 input_file: crates/ruff_python_parser/resources/inline/err/comprehension_missing_for_after_async.py
-snapshot_kind: text
 ---
 ## AST
 
@@ -17,7 +16,7 @@ Module(
                         ExprName {
                             range: 1..6,
                             id: Name("async"),
-                            ctx: Load,
+                            ctx: Invalid,
                         },
                     ),
                 },

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__attribute__multiple_dots.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__attribute__multiple_dots.py.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/ruff_python_parser/tests/fixtures.rs
 input_file: crates/ruff_python_parser/resources/invalid/expressions/attribute/multiple_dots.py
-snapshot_kind: text
 ---
 ## AST
 
@@ -30,7 +29,7 @@ Module(
                                         id: Name(""),
                                         range: 6..6,
                                     },
-                                    ctx: Load,
+                                    ctx: Invalid,
                                 },
                             ),
                             attr: Identifier {
@@ -104,7 +103,7 @@ Module(
                                         id: Name(""),
                                         range: 40..40,
                                     },
-                                    ctx: Load,
+                                    ctx: Invalid,
                                 },
                             ),
                             attr: Identifier {

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__attribute__no_member.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__attribute__no_member.py.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/ruff_python_parser/tests/fixtures.rs
 input_file: crates/ruff_python_parser/resources/invalid/expressions/attribute/no_member.py
-snapshot_kind: text
 ---
 ## AST
 
@@ -27,7 +26,7 @@ Module(
                                 id: Name(""),
                                 range: 93..93,
                             },
-                            ctx: Load,
+                            ctx: Invalid,
                         },
                     ),
                 },
@@ -61,7 +60,7 @@ Module(
                                 id: Name(""),
                                 range: 141..141,
                             },
-                            ctx: Load,
+                            ctx: Invalid,
                         },
                     ),
                 },

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__compare__invalid_order.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__compare__invalid_order.py.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/ruff_python_parser/tests/fixtures.rs
 input_file: crates/ruff_python_parser/resources/invalid/expressions/compare/invalid_order.py
-snapshot_kind: text
 ---
 ## AST
 
@@ -106,7 +105,7 @@ Module(
                                 ExprName {
                                     range: 126..128,
                                     id: Name("is"),
-                                    ctx: Load,
+                                    ctx: Invalid,
                                 },
                             ),
                         },

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__dict__double_star_comprehension.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__dict__double_star_comprehension.py.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/ruff_python_parser/tests/fixtures.rs
 input_file: crates/ruff_python_parser/resources/invalid/expressions/dict/double_star_comprehension.py
-snapshot_kind: text
 ---
 ## AST
 
@@ -41,7 +40,7 @@ Module(
                                         ExprName {
                                             range: 130..133,
                                             id: Name("for"),
-                                            ctx: Load,
+                                            ctx: Invalid,
                                         },
                                     ),
                                 },

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__dict__missing_closing_brace_0.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__dict__missing_closing_brace_0.py.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/ruff_python_parser/tests/fixtures.rs
 input_file: crates/ruff_python_parser/resources/invalid/expressions/dict/missing_closing_brace_0.py
-snapshot_kind: text
 ---
 ## AST
 
@@ -31,7 +30,7 @@ Module(
                                         ExprName {
                                             range: 5..8,
                                             id: Name("def"),
-                                            ctx: Load,
+                                            ctx: Invalid,
                                         },
                                     ),
                                 },
@@ -59,7 +58,7 @@ Module(
                                         ExprName {
                                             range: 20..24,
                                             id: Name("pass"),
-                                            ctx: Load,
+                                            ctx: Invalid,
                                         },
                                     ),
                                 },

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__named__missing_expression_2.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__named__missing_expression_2.py.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/ruff_python_parser/tests/fixtures.rs
 input_file: crates/ruff_python_parser/resources/invalid/expressions/named/missing_expression_2.py
-snapshot_kind: text
 ---
 ## AST
 
@@ -27,7 +26,7 @@ Module(
                                 ExprName {
                                     range: 68..71,
                                     id: Name("def"),
-                                    ctx: Load,
+                                    ctx: Invalid,
                                 },
                             ),
                         },
@@ -58,7 +57,7 @@ Module(
                         ExprName {
                             range: 83..87,
                             id: Name("pass"),
-                            ctx: Load,
+                            ctx: Invalid,
                         },
                     ),
                     value: None,

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__subscript__unclosed_slice_1.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__subscript__unclosed_slice_1.py.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/ruff_python_parser/tests/fixtures.rs
 input_file: crates/ruff_python_parser/resources/invalid/expressions/subscript/unclosed_slice_1.py
-snapshot_kind: text
 ---
 ## AST
 
@@ -33,7 +32,7 @@ Module(
                                             ExprName {
                                                 range: 6..9,
                                                 id: Name("def"),
-                                                ctx: Load,
+                                                ctx: Invalid,
                                             },
                                         ),
                                     ),
@@ -68,7 +67,7 @@ Module(
                         ExprName {
                             range: 21..25,
                             id: Name("pass"),
-                            ctx: Load,
+                            ctx: Invalid,
                         },
                     ),
                     value: None,


### PR DESCRIPTION
## Summary

This PR is related to #13778 and updates the return type of `parse_identifier` in the parser to return a result-like structure where both `Ok` and `Err` variant uses an `Identifier`. The type of the variant will indicate the type of `ExprContext` to use by the caller.

Previously, the `ctx` field on `ExprName` would only be set to `Invalid` when the identifier itself was invalid or missing. But, in case a keyword was found, then it would still set it to `Load` / `Store`. This becomes problematic because red knot will start displaying diagnostics for unresolved reference:

```py
# Name `pass` used when not defined
for x in pass:
	pass
```

This PR resolves that by setting the `Invalid` context even in those scenarios so that the semantic model will avoid recording a use of this "keyword as identifier".

## Test Plan

<!-- How was it tested? -->
