### PR TITLE
Minor followups to RUF052

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/ruff/RUF052.py
+++ b/crates/ruff_linter/resources/test/fixtures/ruff/RUF052.py
@@ -14,7 +14,7 @@ _valid_var_2 = 2
 _valid_var_3 = _valid_var_1 + _valid_var_2
 
 def _valid_fun():
-    pass    
+    pass
 
 _valid_fun()
 
@@ -35,7 +35,7 @@ def fun():
 def fun():
     global _x
     _x = "reassigned global"
-    return _x  
+    return _x
 
 class _ValidClass:
     pass
@@ -56,7 +56,7 @@ class ClassOk:
 
     def method(arg):
         _valid_unused_var = arg
-        return 
+        return
 
 def fun(x):
     _ = 1
@@ -104,3 +104,28 @@ def fun():
     x = "local"
     _x = "shadows local" # [RUF052]
     return _x
+
+
+GLOBAL_1 = "global 1"
+GLOBAL_1_ = "global 1 with trailing underscore"
+
+def unfixables():
+    _GLOBAL_1 = "foo"
+    # unfixable because the rename would shadow a global variable
+    print(_GLOBAL_1)  # [RUF052]
+
+    local = "local"
+    local_ = "local2"
+
+    # unfixable because the rename would shadow a local variable
+    _local = "local3"  # [RUF052]
+    print(_local)
+
+    def nested():
+        _GLOBAL_1 = "foo"
+        # unfixable because the rename would shadow a global variable
+        print(_GLOBAL_1)  # [RUF052]
+
+        # unfixable because the rename would shadow a variable from the outer function
+        _local = "local4"
+        print(_local)

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF052_RUF052.py.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF052_RUF052.py.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/ruff_linter/src/rules/ruff/mod.rs
-snapshot_kind: text
 ---
 RUF052.py:77:9: RUF052 [*] Local dummy variable `_var` is accessed
    |
@@ -130,3 +129,44 @@ RUF052.py:105:5: RUF052 [*] Local dummy variable `_x` is accessed
 106     |-    return _x
     105 |+    x_ = "shadows local" # [RUF052]
     106 |+    return x_
+107 107 | 
+108 108 | 
+109 109 | GLOBAL_1 = "global 1"
+
+RUF052.py:113:5: RUF052 Local dummy variable `_GLOBAL_1` is accessed
+    |
+112 | def unfixables():
+113 |     _GLOBAL_1 = "foo"
+    |     ^^^^^^^^^ RUF052
+114 |     # unfixable because the rename would shadow a global variable
+115 |     print(_GLOBAL_1)  # [RUF052]
+    |
+    = help: Prefer using trailing underscores to avoid shadowing a variable
+
+RUF052.py:121:5: RUF052 Local dummy variable `_local` is accessed
+    |
+120 |     # unfixable because the rename would shadow a local variable
+121 |     _local = "local3"  # [RUF052]
+    |     ^^^^^^ RUF052
+122 |     print(_local)
+    |
+    = help: Prefer using trailing underscores to avoid shadowing a variable
+
+RUF052.py:125:9: RUF052 Local dummy variable `_GLOBAL_1` is accessed
+    |
+124 |     def nested():
+125 |         _GLOBAL_1 = "foo"
+    |         ^^^^^^^^^ RUF052
+126 |         # unfixable because the rename would shadow a global variable
+127 |         print(_GLOBAL_1)  # [RUF052]
+    |
+    = help: Prefer using trailing underscores to avoid shadowing a variable
+
+RUF052.py:130:9: RUF052 Local dummy variable `_local` is accessed
+    |
+129 |         # unfixable because the rename would shadow a variable from the outer function
+130 |         _local = "local4"
+    |         ^^^^^^ RUF052
+131 |         print(_local)
+    |
+    = help: Prefer using trailing underscores to avoid shadowing a variable

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__custom_dummy_var_regexp_preset__RUF052_RUF052.py_1.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__custom_dummy_var_regexp_preset__RUF052_RUF052.py_1.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/ruff_linter/src/rules/ruff/mod.rs
-snapshot_kind: text
 ---
 RUF052.py:77:9: RUF052 [*] Local dummy variable `_var` is accessed
    |
@@ -130,3 +129,44 @@ RUF052.py:105:5: RUF052 [*] Local dummy variable `_x` is accessed
 106     |-    return _x
     105 |+    x_ = "shadows local" # [RUF052]
     106 |+    return x_
+107 107 | 
+108 108 | 
+109 109 | GLOBAL_1 = "global 1"
+
+RUF052.py:113:5: RUF052 Local dummy variable `_GLOBAL_1` is accessed
+    |
+112 | def unfixables():
+113 |     _GLOBAL_1 = "foo"
+    |     ^^^^^^^^^ RUF052
+114 |     # unfixable because the rename would shadow a global variable
+115 |     print(_GLOBAL_1)  # [RUF052]
+    |
+    = help: Prefer using trailing underscores to avoid shadowing a variable
+
+RUF052.py:121:5: RUF052 Local dummy variable `_local` is accessed
+    |
+120 |     # unfixable because the rename would shadow a local variable
+121 |     _local = "local3"  # [RUF052]
+    |     ^^^^^^ RUF052
+122 |     print(_local)
+    |
+    = help: Prefer using trailing underscores to avoid shadowing a variable
+
+RUF052.py:125:9: RUF052 Local dummy variable `_GLOBAL_1` is accessed
+    |
+124 |     def nested():
+125 |         _GLOBAL_1 = "foo"
+    |         ^^^^^^^^^ RUF052
+126 |         # unfixable because the rename would shadow a global variable
+127 |         print(_GLOBAL_1)  # [RUF052]
+    |
+    = help: Prefer using trailing underscores to avoid shadowing a variable
+
+RUF052.py:130:9: RUF052 Local dummy variable `_local` is accessed
+    |
+129 |         # unfixable because the rename would shadow a variable from the outer function
+130 |         _local = "local4"
+    |         ^^^^^^ RUF052
+131 |         print(_local)
+    |
+    = help: Prefer using trailing underscores to avoid shadowing a variable

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__custom_dummy_var_regexp_preset__RUF052_RUF052.py_2.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__custom_dummy_var_regexp_preset__RUF052_RUF052.py_2.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/ruff_linter/src/rules/ruff/mod.rs
-snapshot_kind: text
 ---
 RUF052.py:21:9: RUF052 Local dummy variable `arg` is accessed
    |
@@ -38,12 +37,12 @@ RUF052.py:57:16: RUF052 Local dummy variable `arg` is accessed
 57 |     def method(arg):
    |                ^^^ RUF052
 58 |         _valid_unused_var = arg
-59 |         return 
+59 |         return
    |
 
 RUF052.py:61:9: RUF052 Local dummy variable `x` is accessed
    |
-59 |         return 
+59 |         return
 60 | 
 61 | def fun(x):
    |         ^ RUF052
@@ -117,5 +116,43 @@ RUF052.py:105:5: RUF052 Local dummy variable `_x` is accessed
 105 |     _x = "shadows local" # [RUF052]
     |     ^^ RUF052
 106 |     return _x
+    |
+    = help: Prefer using trailing underscores to avoid shadowing a variable
+
+RUF052.py:113:5: RUF052 Local dummy variable `_GLOBAL_1` is accessed
+    |
+112 | def unfixables():
+113 |     _GLOBAL_1 = "foo"
+    |     ^^^^^^^^^ RUF052
+114 |     # unfixable because the rename would shadow a global variable
+115 |     print(_GLOBAL_1)  # [RUF052]
+    |
+    = help: Prefer using trailing underscores to avoid shadowing a variable
+
+RUF052.py:121:5: RUF052 Local dummy variable `_local` is accessed
+    |
+120 |     # unfixable because the rename would shadow a local variable
+121 |     _local = "local3"  # [RUF052]
+    |     ^^^^^^ RUF052
+122 |     print(_local)
+    |
+    = help: Prefer using trailing underscores to avoid shadowing a variable
+
+RUF052.py:125:9: RUF052 Local dummy variable `_GLOBAL_1` is accessed
+    |
+124 |     def nested():
+125 |         _GLOBAL_1 = "foo"
+    |         ^^^^^^^^^ RUF052
+126 |         # unfixable because the rename would shadow a global variable
+127 |         print(_GLOBAL_1)  # [RUF052]
+    |
+    = help: Prefer using trailing underscores to avoid shadowing a variable
+
+RUF052.py:130:9: RUF052 Local dummy variable `_local` is accessed
+    |
+129 |         # unfixable because the rename would shadow a variable from the outer function
+130 |         _local = "local4"
+    |         ^^^^^^ RUF052
+131 |         print(_local)
     |
     = help: Prefer using trailing underscores to avoid shadowing a variable


### PR DESCRIPTION
## Summary

Just some minor followups to the recently merged RUF052 rule, that was added in bf0fd04:
- Some small tweaks to the docs
- A minor code-style nit
- Some more tests for my peace of mind, just to check that the new methods on the semantic model are working correctly

I'm adding the "internal" label as this doesn't deserve a changelog entry. RUF052 is a new rule that hasn't been released yet.

## Test Plan

`cargo test -p ruff_linter`
