### PR TITLE
Use salsa accumulators for diagnostics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2403,7 +2403,6 @@ dependencies = [
  "ruff_cache",
  "ruff_db",
  "ruff_python_ast",
- "ruff_text_size",
  "rustc-hash 2.1.0",
  "salsa",
  "serde",
@@ -2630,7 +2629,6 @@ dependencies = [
  "salsa",
  "serde",
  "tempfile",
- "thiserror 2.0.3",
  "tracing",
  "tracing-subscriber",
  "tracing-tree",
@@ -3189,7 +3187,7 @@ checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
 [[package]]
 name = "salsa"
 version = "0.18.0"
-source = "git+https://github.com/salsa-rs/salsa.git?rev=254c749b02cde2fd29852a7463a33e800b771758#254c749b02cde2fd29852a7463a33e800b771758"
+source = "git+https://github.com/salsa-rs/salsa.git?rev=e68679b3a9c2b5cfd8eab92de89edf4073b03601#e68679b3a9c2b5cfd8eab92de89edf4073b03601"
 dependencies = [
  "append-only-vec",
  "arc-swap",
@@ -3199,6 +3197,7 @@ dependencies = [
  "indexmap",
  "lazy_static",
  "parking_lot",
+ "rayon",
  "rustc-hash 2.1.0",
  "salsa-macro-rules",
  "salsa-macros",
@@ -3209,12 +3208,12 @@ dependencies = [
 [[package]]
 name = "salsa-macro-rules"
 version = "0.1.0"
-source = "git+https://github.com/salsa-rs/salsa.git?rev=254c749b02cde2fd29852a7463a33e800b771758#254c749b02cde2fd29852a7463a33e800b771758"
+source = "git+https://github.com/salsa-rs/salsa.git?rev=e68679b3a9c2b5cfd8eab92de89edf4073b03601#e68679b3a9c2b5cfd8eab92de89edf4073b03601"
 
 [[package]]
 name = "salsa-macros"
 version = "0.18.0"
-source = "git+https://github.com/salsa-rs/salsa.git?rev=254c749b02cde2fd29852a7463a33e800b771758#254c749b02cde2fd29852a7463a33e800b771758"
+source = "git+https://github.com/salsa-rs/salsa.git?rev=e68679b3a9c2b5cfd8eab92de89edf4073b03601#e68679b3a9c2b5cfd8eab92de89edf4073b03601"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,7 +118,7 @@ rand = { version = "0.8.5" }
 rayon = { version = "1.10.0" }
 regex = { version = "1.10.2" }
 rustc-hash = { version = "2.0.0" }
-salsa = { git = "https://github.com/salsa-rs/salsa.git", rev = "254c749b02cde2fd29852a7463a33e800b771758" }
+salsa = { git = "https://github.com/salsa-rs/salsa.git", rev = "e68679b3a9c2b5cfd8eab92de89edf4073b03601" }
 schemars = { version = "0.8.16" }
 seahash = { version = "4.1.0" }
 serde = { version = "1.0.197", features = ["derive"] }

--- a/crates/red_knot/src/main.rs
+++ b/crates/red_knot/src/main.rs
@@ -12,7 +12,7 @@ use red_knot_workspace::watch;
 use red_knot_workspace::watch::WorkspaceWatcher;
 use red_knot_workspace::workspace::settings::Configuration;
 use red_knot_workspace::workspace::WorkspaceMetadata;
-use ruff_db::diagnostic::Diagnostic;
+use ruff_db::diagnostic::CompileDiagnostic;
 use ruff_db::system::{OsSystem, System, SystemPath, SystemPathBuf};
 use salsa::plumbing::ZalsaDatabase;
 use target_version::TargetVersion;
@@ -297,7 +297,7 @@ impl MainLoop {
         while let Ok(message) = self.receiver.recv() {
             match message {
                 MainLoopMessage::CheckWorkspace => {
-                    let db = db.snapshot();
+                    let db = db.clone();
                     let sender = self.sender.clone();
 
                     // Spawn a new task that checks the workspace. This needs to be done in a separate thread
@@ -380,7 +380,7 @@ impl MainLoopCancellationToken {
 enum MainLoopMessage {
     CheckWorkspace,
     CheckCompleted {
-        result: Vec<Box<dyn Diagnostic>>,
+        result: Vec<CompileDiagnostic>,
         revision: u64,
     },
     ApplyChanges(Vec<watch::ChangeEvent>),

--- a/crates/red_knot_python_semantic/src/db.rs
+++ b/crates/red_knot_python_semantic/src/db.rs
@@ -19,6 +19,7 @@ pub(crate) mod tests {
     use super::Db;
 
     #[salsa::db]
+    #[derive(Clone)]
     pub(crate) struct TestDb {
         storage: salsa::Storage<Self>,
         files: Files,

--- a/crates/red_knot_python_semantic/src/semantic_index/definition.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/definition.rs
@@ -211,7 +211,6 @@ pub(crate) struct AssignmentDefinitionNodeRef<'a> {
     pub(crate) unpack: Option<Unpack<'a>>,
     pub(crate) value: &'a ast::Expr,
     pub(crate) name: &'a ast::ExprName,
-    pub(crate) first: bool,
 }
 
 #[derive(Copy, Clone, Debug)]
@@ -282,12 +281,10 @@ impl<'db> DefinitionNodeRef<'db> {
                 unpack,
                 value,
                 name,
-                first,
             }) => DefinitionKind::Assignment(AssignmentDefinitionKind {
                 target: TargetKind::from(unpack),
                 value: AstNodeRef::new(parsed.clone(), value),
                 name: AstNodeRef::new(parsed, name),
-                first,
             }),
             DefinitionNodeRef::AnnotatedAssignment(assign) => {
                 DefinitionKind::AnnotatedAssignment(AstNodeRef::new(parsed, assign))
@@ -374,7 +371,6 @@ impl<'db> DefinitionNodeRef<'db> {
                 value: _,
                 unpack: _,
                 name,
-                first: _,
             }) => name.into(),
             Self::AnnotatedAssignment(node) => node.into(),
             Self::AugmentedAssignment(node) => node.into(),
@@ -591,7 +587,6 @@ pub struct AssignmentDefinitionKind<'db> {
     target: TargetKind<'db>,
     value: AstNodeRef<ast::Expr>,
     name: AstNodeRef<ast::ExprName>,
-    first: bool,
 }
 
 impl<'db> AssignmentDefinitionKind<'db> {
@@ -605,10 +600,6 @@ impl<'db> AssignmentDefinitionKind<'db> {
 
     pub(crate) fn name(&self) -> &ast::ExprName {
         self.name.node()
-    }
-
-    pub(crate) fn is_first(&self) -> bool {
-        self.first
     }
 }
 

--- a/crates/red_knot_python_semantic/src/types/diagnostic.rs
+++ b/crates/red_knot_python_semantic/src/types/diagnostic.rs
@@ -1,16 +1,12 @@
 use crate::types::{ClassLiteralType, Type};
 use crate::Db;
-use ruff_db::diagnostic::{Diagnostic, Severity};
+use ruff_db::diagnostic::{CompileDiagnostic, Diagnostic, Severity};
 use ruff_db::files::File;
 use ruff_python_ast::{self as ast, AnyNodeRef};
 use ruff_text_size::{Ranged, TextRange};
 use std::borrow::Cow;
-use std::fmt::Formatter;
-use std::ops::Deref;
-use std::sync::Arc;
-
 #[derive(Debug, Eq, PartialEq, Clone)]
-pub struct TypeCheckDiagnostic {
+pub(crate) struct TypeCheckDiagnostic {
     // TODO: Don't use string keys for rules
     pub(super) rule: String,
     pub(super) message: String,
@@ -19,15 +15,15 @@ pub struct TypeCheckDiagnostic {
 }
 
 impl TypeCheckDiagnostic {
-    pub fn rule(&self) -> &str {
+    pub(crate) fn rule(&self) -> &str {
         &self.rule
     }
 
-    pub fn message(&self) -> &str {
+    pub(crate) fn message(&self) -> &str {
         &self.message
     }
 
-    pub fn file(&self) -> File {
+    pub(crate) fn file(&self) -> File {
         self.file
     }
 }
@@ -60,263 +56,209 @@ impl Ranged for TypeCheckDiagnostic {
     }
 }
 
-/// A collection of type check diagnostics.
-///
-/// The diagnostics are wrapped in an `Arc` because they need to be cloned multiple times
-/// when going from `infer_expression` to `check_file`. We could consider
-/// making [`TypeCheckDiagnostic`] a Salsa struct to have them Arena-allocated (once the Tables refactor is done).
-/// Using Salsa struct does have the downside that it leaks the Salsa dependency into diagnostics and
-/// each Salsa-struct comes with an overhead.
-#[derive(Default, Eq, PartialEq)]
-pub struct TypeCheckDiagnostics {
-    inner: Vec<std::sync::Arc<TypeCheckDiagnostic>>,
-}
-
-impl TypeCheckDiagnostics {
-    pub(super) fn push(&mut self, diagnostic: TypeCheckDiagnostic) {
-        self.inner.push(Arc::new(diagnostic));
-    }
-
-    pub(crate) fn shrink_to_fit(&mut self) {
-        self.inner.shrink_to_fit();
-    }
-}
-
-impl Extend<TypeCheckDiagnostic> for TypeCheckDiagnostics {
-    fn extend<T: IntoIterator<Item = TypeCheckDiagnostic>>(&mut self, iter: T) {
-        self.inner.extend(iter.into_iter().map(std::sync::Arc::new));
-    }
-}
-
-impl Extend<std::sync::Arc<TypeCheckDiagnostic>> for TypeCheckDiagnostics {
-    fn extend<T: IntoIterator<Item = Arc<TypeCheckDiagnostic>>>(&mut self, iter: T) {
-        self.inner.extend(iter);
-    }
-}
-
-impl<'a> Extend<&'a std::sync::Arc<TypeCheckDiagnostic>> for TypeCheckDiagnostics {
-    fn extend<T: IntoIterator<Item = &'a Arc<TypeCheckDiagnostic>>>(&mut self, iter: T) {
-        self.inner
-            .extend(iter.into_iter().map(std::sync::Arc::clone));
-    }
-}
-
-impl std::fmt::Debug for TypeCheckDiagnostics {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        self.inner.fmt(f)
-    }
-}
-
-impl Deref for TypeCheckDiagnostics {
-    type Target = [std::sync::Arc<TypeCheckDiagnostic>];
-
-    fn deref(&self) -> &Self::Target {
-        &self.inner
-    }
-}
-
-impl IntoIterator for TypeCheckDiagnostics {
-    type Item = Arc<TypeCheckDiagnostic>;
-    type IntoIter = std::vec::IntoIter<std::sync::Arc<TypeCheckDiagnostic>>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        self.inner.into_iter()
-    }
-}
-
-impl<'a> IntoIterator for &'a TypeCheckDiagnostics {
-    type Item = &'a Arc<TypeCheckDiagnostic>;
-    type IntoIter = std::slice::Iter<'a, std::sync::Arc<TypeCheckDiagnostic>>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        self.inner.iter()
-    }
-}
-
-pub(super) struct TypeCheckDiagnosticsBuilder<'db> {
-    db: &'db dyn Db,
+/// Emit a diagnostic declaring that the object represented by `node` is not iterable
+pub(super) fn report_not_iterable(
+    db: &dyn Db,
     file: File,
-    diagnostics: TypeCheckDiagnostics,
+    node: AnyNodeRef,
+    not_iterable_ty: Type,
+) {
+    report_type_diagnostic(
+        db,
+        file,
+        node,
+        "not-iterable",
+        format_args!(
+            "Object of type `{}` is not iterable",
+            not_iterable_ty.display(db)
+        ),
+    );
 }
 
-impl<'db> TypeCheckDiagnosticsBuilder<'db> {
-    pub(super) fn new(db: &'db dyn Db, file: File) -> Self {
-        Self {
-            db,
+/// Emit a diagnostic declaring that the object represented by `node` is not iterable
+/// because its `__iter__` method is possibly unbound.
+pub(super) fn report_not_iterable_possibly_unbound(
+    db: &dyn Db,
+    file: File,
+    node: AnyNodeRef,
+    element_ty: Type,
+) {
+    report_type_diagnostic(
+        db,
+        file,
+        node,
+        "not-iterable",
+        format_args!(
+            "Object of type `{}` is not iterable because its `__iter__` method is possibly unbound",
+            element_ty.display(db)
+        ),
+    );
+}
+
+/// Emit a diagnostic declaring that an index is out of bounds for a tuple.
+pub(super) fn report_index_out_of_bounds(
+    db: &dyn Db,
+    file: File,
+    kind: &'static str,
+    node: AnyNodeRef,
+    tuple_ty: Type,
+    length: usize,
+    index: i64,
+) {
+    report_type_diagnostic(
+        db,
+        file,
+        node,
+        "index-out-of-bounds",
+        format_args!(
+            "Index {index} is out of bounds for {kind} `{}` with length {length}",
+            tuple_ty.display(db)
+        ),
+    );
+}
+
+/// Emit a diagnostic declaring that a type does not support subscripting.
+pub(super) fn report_non_subscriptable(
+    db: &dyn Db,
+    file: File,
+    node: AnyNodeRef,
+    non_subscriptable_ty: Type,
+    method: &str,
+) {
+    report_type_diagnostic(
+        db,
+        file,
+        node,
+        "non-subscriptable",
+        format_args!(
+            "Cannot subscript object of type `{}` with no `{method}` method",
+            non_subscriptable_ty.display(db)
+        ),
+    );
+}
+
+pub(super) fn report_unresolved_module<'a>(
+    db: &dyn Db,
+    file: File,
+    import_node: impl Into<AnyNodeRef<'a>>,
+    level: u32,
+    module: Option<&str>,
+) {
+    report_type_diagnostic(
+        db,
+        file,
+        import_node.into(),
+        "unresolved-import",
+        format_args!(
+            "Cannot resolve import `{}{}`",
+            ".".repeat(level as usize),
+            module.unwrap_or_default()
+        ),
+    );
+}
+
+pub(super) fn report_slice_step_size_zero(db: &dyn Db, file: File, node: AnyNodeRef) {
+    report_type_diagnostic(
+        db,
+        file,
+        node,
+        "zero-stepsize-in-slice",
+        format_args!("Slice step size can not be zero"),
+    );
+}
+
+pub(super) fn report_invalid_assignment(
+    db: &dyn Db,
+    file: File,
+    node: AnyNodeRef,
+    declared_ty: Type,
+    assigned_ty: Type,
+) {
+    match declared_ty {
+        Type::ClassLiteral(ClassLiteralType { class }) => {
+            report_type_diagnostic(db, file, node, "invalid-assignment", format_args!(
+                "Implicit shadowing of class `{}`; annotate to make it explicit if this is intentional",
+                class.name(db)));
+        }
+        Type::FunctionLiteral(function) => {
+            report_type_diagnostic(db, file, node, "invalid-assignment", format_args!(
+                "Implicit shadowing of function `{}`; annotate to make it explicit if this is intentional",
+                function.name(db)));
+        }
+        _ => {
+            report_type_diagnostic(
+                db,
+                file,
+                node,
+                "invalid-assignment",
+                format_args!(
+                    "Object of type `{}` is not assignable to `{}`",
+                    assigned_ty.display(db),
+                    declared_ty.display(db),
+                ),
+            );
+        }
+    }
+}
+
+pub(super) fn report_possibly_unresolved_reference(
+    db: &dyn Db,
+    file: File,
+    expr_name_node: &ast::ExprName,
+) {
+    let ast::ExprName { id, .. } = expr_name_node;
+
+    report_type_diagnostic(
+        db,
+        file,
+        expr_name_node.into(),
+        "possibly-unresolved-reference",
+        format_args!("Name `{id}` used when possibly not defined"),
+    );
+}
+
+pub(super) fn report_unresolved_reference(db: &dyn Db, file: File, expr_name_node: &ast::ExprName) {
+    let ast::ExprName { id, .. } = expr_name_node;
+
+    report_type_diagnostic(
+        db,
+        file,
+        expr_name_node.into(),
+        "unresolved-reference",
+        format_args!("Name `{id}` used when not defined"),
+    );
+}
+
+/// Returns `true` if any diagnostic is enabled for this file.
+pub(crate) fn is_any_diagnostic_enabled(db: &dyn Db, file: File) -> bool {
+    db.is_file_open(file)
+}
+
+/// Reports a diagnostic for the given node and file if diagnostic reporting is enabled for this file.
+pub(crate) fn report_type_diagnostic(
+    db: &dyn Db,
+    file: File,
+    node: AnyNodeRef,
+    rule: &str,
+    message: std::fmt::Arguments,
+) {
+    if !is_any_diagnostic_enabled(db, file) {
+        return;
+    }
+
+    // TODO: Don't emit the diagnostic if:
+    // * The enclosing node contains any syntax errors
+    // * The rule is disabled for this file. We probably want to introduce a new query that
+    //   returns a rule selector for a given file that respects the package's settings,
+    //   any global pragma comments in the file, and any per-file-ignores.
+
+    CompileDiagnostic::report(
+        db.upcast(),
+        TypeCheckDiagnostic {
             file,
-            diagnostics: TypeCheckDiagnostics::default(),
-        }
-    }
-
-    /// Emit a diagnostic declaring that the object represented by `node` is not iterable
-    pub(super) fn add_not_iterable(&mut self, node: AnyNodeRef, not_iterable_ty: Type<'db>) {
-        self.add(
-            node,
-            "not-iterable",
-            format_args!(
-                "Object of type `{}` is not iterable",
-                not_iterable_ty.display(self.db)
-            ),
-        );
-    }
-
-    /// Emit a diagnostic declaring that the object represented by `node` is not iterable
-    /// because its `__iter__` method is possibly unbound.
-    pub(super) fn add_not_iterable_possibly_unbound(
-        &mut self,
-        node: AnyNodeRef,
-        element_ty: Type<'db>,
-    ) {
-        self.add(
-            node,
-            "not-iterable",
-            format_args!(
-                "Object of type `{}` is not iterable because its `__iter__` method is possibly unbound",
-                element_ty.display(self.db)
-            ),
-        );
-    }
-
-    /// Emit a diagnostic declaring that an index is out of bounds for a tuple.
-    pub(super) fn add_index_out_of_bounds(
-        &mut self,
-        kind: &'static str,
-        node: AnyNodeRef,
-        tuple_ty: Type<'db>,
-        length: usize,
-        index: i64,
-    ) {
-        self.add(
-            node,
-            "index-out-of-bounds",
-            format_args!(
-                "Index {index} is out of bounds for {kind} `{}` with length {length}",
-                tuple_ty.display(self.db)
-            ),
-        );
-    }
-
-    /// Emit a diagnostic declaring that a type does not support subscripting.
-    pub(super) fn add_non_subscriptable(
-        &mut self,
-        node: AnyNodeRef,
-        non_subscriptable_ty: Type<'db>,
-        method: &str,
-    ) {
-        self.add(
-            node,
-            "non-subscriptable",
-            format_args!(
-                "Cannot subscript object of type `{}` with no `{method}` method",
-                non_subscriptable_ty.display(self.db)
-            ),
-        );
-    }
-
-    pub(super) fn add_unresolved_module(
-        &mut self,
-        import_node: impl Into<AnyNodeRef<'db>>,
-        level: u32,
-        module: Option<&str>,
-    ) {
-        self.add(
-            import_node.into(),
-            "unresolved-import",
-            format_args!(
-                "Cannot resolve import `{}{}`",
-                ".".repeat(level as usize),
-                module.unwrap_or_default()
-            ),
-        );
-    }
-
-    pub(super) fn add_slice_step_size_zero(&mut self, node: AnyNodeRef) {
-        self.add(
-            node,
-            "zero-stepsize-in-slice",
-            format_args!("Slice step size can not be zero"),
-        );
-    }
-
-    pub(super) fn add_invalid_assignment(
-        &mut self,
-        node: AnyNodeRef,
-        declared_ty: Type<'db>,
-        assigned_ty: Type<'db>,
-    ) {
-        match declared_ty {
-            Type::ClassLiteral(ClassLiteralType { class }) => {
-                self.add(node, "invalid-assignment", format_args!(
-                        "Implicit shadowing of class `{}`; annotate to make it explicit if this is intentional",
-                        class.name(self.db)));
-            }
-            Type::FunctionLiteral(function) => {
-                self.add(node, "invalid-assignment", format_args!(
-                        "Implicit shadowing of function `{}`; annotate to make it explicit if this is intentional",
-                        function.name(self.db)));
-            }
-            _ => {
-                self.add(
-                    node,
-                    "invalid-assignment",
-                    format_args!(
-                        "Object of type `{}` is not assignable to `{}`",
-                        assigned_ty.display(self.db),
-                        declared_ty.display(self.db),
-                    ),
-                );
-            }
-        }
-    }
-
-    pub(super) fn add_possibly_unresolved_reference(&mut self, expr_name_node: &ast::ExprName) {
-        let ast::ExprName { id, .. } = expr_name_node;
-
-        self.add(
-            expr_name_node.into(),
-            "possibly-unresolved-reference",
-            format_args!("Name `{id}` used when possibly not defined"),
-        );
-    }
-
-    pub(super) fn add_unresolved_reference(&mut self, expr_name_node: &ast::ExprName) {
-        let ast::ExprName { id, .. } = expr_name_node;
-
-        self.add(
-            expr_name_node.into(),
-            "unresolved-reference",
-            format_args!("Name `{id}` used when not defined"),
-        );
-    }
-
-    /// Adds a new diagnostic.
-    ///
-    /// The diagnostic does not get added if the rule isn't enabled for this file.
-    pub(super) fn add(&mut self, node: AnyNodeRef, rule: &str, message: std::fmt::Arguments) {
-        if !self.db.is_file_open(self.file) {
-            return;
-        }
-
-        // TODO: Don't emit the diagnostic if:
-        // * The enclosing node contains any syntax errors
-        // * The rule is disabled for this file. We probably want to introduce a new query that
-        //   returns a rule selector for a given file that respects the package's settings,
-        //   any global pragma comments in the file, and any per-file-ignores.
-
-        self.diagnostics.push(TypeCheckDiagnostic {
-            file: self.file,
             rule: rule.to_string(),
             message: message.to_string(),
             range: node.range(),
-        });
-    }
-
-    pub(super) fn extend(&mut self, diagnostics: &TypeCheckDiagnostics) {
-        self.diagnostics.extend(diagnostics);
-    }
-
-    pub(super) fn finish(mut self) -> TypeCheckDiagnostics {
-        self.diagnostics.shrink_to_fit();
-        self.diagnostics
-    }
+        },
+    );
 }

--- a/crates/red_knot_server/src/server/api.rs
+++ b/crates/red_knot_server/src/server/api.rs
@@ -91,11 +91,11 @@ fn background_request_task<'a, R: traits::BackgroundDocumentRequestHandler>(
         let db = match path {
             AnySystemPath::System(path) => {
                 match session.workspace_db_for_path(path.as_std_path()) {
-                    Some(db) => db.snapshot(),
-                    None => session.default_workspace_db().snapshot(),
+                    Some(db) => db.clone(),
+                    None => session.default_workspace_db().clone(),
                 }
             }
-            AnySystemPath::SystemVirtual(_) => session.default_workspace_db().snapshot(),
+            AnySystemPath::SystemVirtual(_) => session.default_workspace_db().clone(),
         };
 
         let Some(snapshot) = session.take_snapshot(url) else {

--- a/crates/red_knot_test/src/db.rs
+++ b/crates/red_knot_test/src/db.rs
@@ -7,6 +7,7 @@ use ruff_db::vendored::VendoredFileSystem;
 use ruff_db::{Db as SourceDb, Upcast};
 
 #[salsa::db]
+#[derive(Clone)]
 pub(crate) struct Db {
     workspace_root: SystemPathBuf,
     storage: salsa::Storage<Self>,

--- a/crates/red_knot_wasm/src/lib.rs
+++ b/crates/red_knot_wasm/src/lib.rs
@@ -6,7 +6,6 @@ use wasm_bindgen::prelude::*;
 use red_knot_workspace::db::{Db, RootDatabase};
 use red_knot_workspace::workspace::settings::Configuration;
 use red_knot_workspace::workspace::WorkspaceMetadata;
-use ruff_db::diagnostic::Diagnostic;
 use ruff_db::files::{system_path_to_file, File};
 use ruff_db::system::walk_directory::WalkDirectoryBuilder;
 use ruff_db::system::{

--- a/crates/red_knot_workspace/Cargo.toml
+++ b/crates/red_knot_workspace/Cargo.toml
@@ -17,7 +17,6 @@ red_knot_python_semantic = { workspace = true }
 ruff_cache = { workspace = true }
 ruff_db = { workspace = true, features = ["os", "cache", "serde"] }
 ruff_python_ast = { workspace = true, features = ["serde"] }
-ruff_text_size = { workspace = true }
 red_knot_vendored = { workspace = true }
 
 anyhow = { workspace = true }

--- a/crates/red_knot_workspace/src/workspace.rs
+++ b/crates/red_knot_workspace/src/workspace.rs
@@ -1,24 +1,20 @@
 #![allow(clippy::ref_option)]
 
-use crate::db::Db;
-use crate::db::RootDatabase;
+use crate::db::{Db, RootDatabase};
 use crate::workspace::files::{Index, Indexed, IndexedIter, PackageFiles};
 pub use metadata::{PackageMetadata, WorkspaceDiscoveryError, WorkspaceMetadata};
 use red_knot_python_semantic::types::check_types;
 use red_knot_python_semantic::SearchPathSettings;
-use ruff_db::diagnostic::{Diagnostic, ParseDiagnostic, Severity};
-use ruff_db::parsed::parsed_module;
-use ruff_db::source::{source_text, SourceTextError};
+use ruff_db::diagnostic::{CompileDiagnostic, Diagnostic};
+use ruff_db::source::source_text;
 use ruff_db::system::FileType;
 use ruff_db::{
     files::{system_path_to_file, File},
     system::{walk_directory::WalkState, SystemPath, SystemPathBuf},
 };
 use ruff_python_ast::{name::Name, PySourceType};
-use ruff_text_size::TextRange;
 use rustc_hash::{FxBuildHasher, FxHashSet};
 use salsa::{Durability, Setter as _};
-use std::borrow::Cow;
 use std::iter::FusedIterator;
 use std::{collections::BTreeMap, sync::Arc};
 
@@ -109,6 +105,7 @@ pub struct Package {
     // TODO: Add the loaded settings.
 }
 
+#[salsa::tracked]
 impl Workspace {
     pub fn from_metadata(db: &dyn Db, metadata: WorkspaceMetadata) -> Self {
         let mut packages = BTreeMap::new();
@@ -186,35 +183,45 @@ impl Workspace {
     }
 
     /// Checks all open files in the workspace and its dependencies.
-    pub fn check(self, db: &RootDatabase) -> Vec<Box<dyn Diagnostic>> {
-        let workspace_span = tracing::debug_span!("check_workspace");
-        let _span = workspace_span.enter();
+    pub fn check(self, db: &RootDatabase) -> Vec<CompileDiagnostic> {
+        check_workspace_par(db, self);
 
-        tracing::debug!("Checking workspace");
-        let files = WorkspaceFiles::new(db, self);
-        let result = Arc::new(std::sync::Mutex::new(Vec::new()));
-        let inner_result = Arc::clone(&result);
+        let mut diagnostics: Vec<CompileDiagnostic> =
+            check_workspace_sync::accumulated::<CompileDiagnostic>(db, self);
 
-        let db = db.snapshot();
-        let workspace_span = workspace_span.clone();
+        diagnostics.sort_unstable_by(|a, b| {
+            let a_file = a.file();
+            let b_file = b.file();
 
-        rayon::scope(move |scope| {
-            for file in &files {
-                let result = inner_result.clone();
-                let db = db.snapshot();
-                let workspace_span = workspace_span.clone();
-
-                scope.spawn(move |_| {
-                    let check_file_span = tracing::debug_span!(parent: &workspace_span, "check_file", file=%file.path(&db));
-                    let _entered = check_file_span.entered();
-
-                    let file_diagnostics = check_file(&db, file);
-                    result.lock().unwrap().extend(file_diagnostics);
-                });
-            }
+            a_file.cmp(&b_file).then_with(|| {
+                a_file
+                    .path(db)
+                    .as_str()
+                    .cmp(b_file.path(db).as_str())
+                    .then_with(|| {
+                        a.range()
+                            .unwrap_or_default()
+                            .start()
+                            .cmp(&b.range().unwrap_or_default().start())
+                    })
+            })
         });
 
-        Arc::into_inner(result).unwrap().into_inner().unwrap()
+        diagnostics
+    }
+
+    pub fn check_file(self, db: &dyn Db, file: File) -> Vec<CompileDiagnostic> {
+        let mut diagnostics: Vec<CompileDiagnostic> =
+            check_file::accumulated::<CompileDiagnostic>(db, file);
+
+        // Salsa returns all diagnostics that were created while checking this file,
+        // including diagnostics from dependencies. Remove diagnostics that don't belong to this file.
+        diagnostics.retain(|diagnostic| diagnostic.file() == file);
+
+        diagnostics
+            .sort_unstable_by_key(|diagnostic| diagnostic.range().unwrap_or_default().start());
+
+        diagnostics
     }
 
     /// Opens a file in the workspace.
@@ -376,33 +383,53 @@ impl Package {
     }
 }
 
-pub(super) fn check_file(db: &dyn Db, file: File) -> Vec<Box<dyn Diagnostic>> {
-    let mut diagnostics: Vec<Box<dyn Diagnostic>> = Vec::new();
+/// Checks all workspace files in parallel.
+///
+/// This function should be merged with [`check_workspace_sync`] and use `salsa::par_map` once parallel-salsa is more stable.
+/// It is only necessary today because `check_workspace_sync::accumulated::<CompileDiagnostic>(db, self)`
+/// only passes a `&dyn Db` but we need a `&RootDatabase` to be able to clone the database for each thread.
+fn check_workspace_par(db: &RootDatabase, workspace: Workspace) {
+    let workspace_span = tracing::debug_span!("check_workspace");
+    let _span = workspace_span.enter();
+
+    tracing::debug!("Checking workspace");
+    let files = WorkspaceFiles::new(db, workspace);
+
+    let db = db.clone();
+    let workspace_span = workspace_span.clone();
+
+    rayon::scope(move |scope| {
+        for file in &files {
+            let db = db.clone();
+            let workspace_span = workspace_span.clone();
+            scope.spawn(move |_| {
+                let check_file_span = tracing::debug_span!(parent: &workspace_span, "check_file", file=%file.path(&db));
+                let _entered = check_file_span.entered();
+
+                check_file(&db, file);
+            });
+        }
+    });
+}
+
+#[salsa::tracked]
+fn check_workspace_sync(db: &dyn Db, workspace: Workspace) {
+    for file in &WorkspaceFiles::new(db, workspace) {
+        check_file(db, file);
+    }
+}
+
+#[salsa::tracked]
+pub(super) fn check_file(db: &dyn Db, file: File) {
     // Abort checking if there are IO errors.
     let source = source_text(db.upcast(), file);
 
-    if let Some(read_error) = source.read_error() {
-        diagnostics.push(Box::new(IOErrorDiagnostic {
-            file,
-            error: read_error.clone(),
-        }));
-        return diagnostics;
+    // Skip over files that failed to read.
+    if source.has_read_error() {
+        return;
     }
 
-    let parsed = parsed_module(db.upcast(), file);
-    diagnostics.extend(parsed.errors().iter().map(|error| {
-        let diagnostic: Box<dyn Diagnostic> = Box::new(ParseDiagnostic::new(file, error.clone()));
-        diagnostic
-    }));
-
-    diagnostics.extend(check_types(db.upcast(), file).iter().map(|diagnostic| {
-        let boxed: Box<dyn Diagnostic> = Box::new(diagnostic.clone());
-        boxed
-    }));
-
-    diagnostics.sort_unstable_by_key(|diagnostic| diagnostic.range().unwrap_or_default().start());
-
-    diagnostics
+    check_types(db.upcast(), file);
 }
 
 fn discover_package_files(db: &dyn Db, package: Package) -> FxHashSet<File> {
@@ -526,34 +553,6 @@ impl Iterator for WorkspaceFilesIter<'_> {
     }
 }
 
-#[derive(Debug)]
-pub struct IOErrorDiagnostic {
-    file: File,
-    error: SourceTextError,
-}
-
-impl Diagnostic for IOErrorDiagnostic {
-    fn rule(&self) -> &str {
-        "io"
-    }
-
-    fn message(&self) -> Cow<str> {
-        self.error.to_string().into()
-    }
-
-    fn file(&self) -> File {
-        self.file
-    }
-
-    fn range(&self) -> Option<TextRange> {
-        None
-    }
-
-    fn severity(&self) -> Severity {
-        Severity::Error
-    }
-}
-
 #[derive(Debug, Eq, PartialEq, Clone)]
 pub struct PackageTree(BTreeMap<SystemPathBuf, Package>);
 
@@ -612,7 +611,8 @@ impl FusedIterator for PackageTreeIter<'_> {}
 #[cfg(test)]
 mod tests {
     use crate::db::tests::TestDb;
-    use crate::workspace::{check_file, WorkspaceMetadata};
+    use crate::db::Db;
+    use crate::workspace::WorkspaceMetadata;
     use red_knot_python_semantic::types::check_types;
     use ruff_db::diagnostic::Diagnostic;
     use ruff_db::files::system_path_to_file;
@@ -637,7 +637,8 @@ mod tests {
 
         assert_eq!(source_text(&db, file).as_str(), "");
         assert_eq!(
-            check_file(&db, file)
+            db.workspace()
+                .check_file(&db, file)
                 .into_iter()
                 .map(|diagnostic| diagnostic.message().into_owned())
                 .collect::<Vec<_>>(),
@@ -653,7 +654,8 @@ mod tests {
 
         assert_eq!(source_text(&db, file).as_str(), "");
         assert_eq!(
-            check_file(&db, file)
+            db.workspace()
+                .check_file(&db, file)
                 .into_iter()
                 .map(|diagnostic| diagnostic.message().into_owned())
                 .collect::<Vec<_>>(),

--- a/crates/ruff/src/commands/analyze_graph.rs
+++ b/crates/ruff/src/commands/analyze_graph.rs
@@ -81,7 +81,7 @@ pub(crate) fn analyze_graph(
         // Collect and resolve the imports for each file.
         let result = Arc::new(Mutex::new(Vec::new()));
         let inner_result = Arc::clone(&result);
-        let db = db.snapshot();
+        let db = db.clone();
 
         rayon::scope(move |scope| {
             for resolved_file in paths {
@@ -137,7 +137,7 @@ pub(crate) fn analyze_graph(
                     continue;
                 };
 
-                let db = db.snapshot();
+                let db = db.clone();
                 let glob_resolver = glob_resolver.clone();
                 let root = root.clone();
                 let result = inner_result.clone();

--- a/crates/ruff_benchmark/benches/red_knot.rs
+++ b/crates/ruff_benchmark/benches/red_knot.rs
@@ -8,7 +8,7 @@ use red_knot_workspace::workspace::settings::Configuration;
 use red_knot_workspace::workspace::WorkspaceMetadata;
 use ruff_benchmark::criterion::{criterion_group, criterion_main, BatchSize, Criterion};
 use ruff_benchmark::TestFile;
-use ruff_db::diagnostic::Diagnostic;
+use ruff_db::diagnostic::CompileDiagnostic;
 use ruff_db::files::{system_path_to_file, File};
 use ruff_db::source::source_text;
 use ruff_db::system::{MemoryFileSystem, SystemPath, SystemPathBuf, TestSystem};
@@ -178,7 +178,7 @@ fn benchmark_cold(criterion: &mut Criterion) {
 }
 
 #[track_caller]
-fn assert_diagnostics(db: &dyn Db, diagnostics: Vec<Box<dyn Diagnostic>>) {
+fn assert_diagnostics(db: &dyn Db, diagnostics: Vec<CompileDiagnostic>) {
     let normalized: Vec<_> = diagnostics
         .into_iter()
         .map(|diagnostic| {

--- a/crates/ruff_db/Cargo.toml
+++ b/crates/ruff_db/Cargo.toml
@@ -30,7 +30,6 @@ matchit = { workspace = true }
 salsa = { workspace = true }
 serde = { workspace = true, optional = true }
 path-slash = { workspace = true }
-thiserror = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, optional = true }
 tracing-tree = { workspace = true, optional = true }

--- a/crates/ruff_db/src/files.rs
+++ b/crates/ruff_db/src/files.rs
@@ -48,7 +48,7 @@ pub fn vendored_path_to_file(
 }
 
 /// Lookup table that maps [file paths](`FilePath`) to salsa interned [`File`] instances.
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct Files {
     inner: Arc<FilesInner>,
 }
@@ -251,13 +251,6 @@ impl Files {
 
         for root in roots.all() {
             root.set_revision(db).to(FileRevision::now());
-        }
-    }
-
-    #[must_use]
-    pub fn snapshot(&self) -> Self {
-        Self {
-            inner: Arc::clone(&self.inner),
         }
     }
 }

--- a/crates/ruff_db/src/lib.rs
+++ b/crates/ruff_db/src/lib.rs
@@ -48,7 +48,7 @@ mod tests {
     ///
     /// Uses an in memory filesystem and it stubs out the vendored files by default.
     #[salsa::db]
-    #[derive(Default)]
+    #[derive(Default, Clone)]
     pub(crate) struct TestDb {
         storage: salsa::Storage<Self>,
         files: Files,

--- a/crates/ruff_graph/src/db.rs
+++ b/crates/ruff_graph/src/db.rs
@@ -14,7 +14,7 @@ static EMPTY_VENDORED: std::sync::LazyLock<VendoredFileSystem> = std::sync::Lazy
 });
 
 #[salsa::db]
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct ModuleDb {
     storage: salsa::Storage<Self>,
     files: Files,
@@ -51,16 +51,6 @@ impl ModuleDb {
         )?;
 
         Ok(db)
-    }
-
-    /// Create a snapshot of the current database.
-    #[must_use]
-    pub fn snapshot(&self) -> Self {
-        Self {
-            storage: self.storage.clone(),
-            system: self.system.clone(),
-            files: self.files.snapshot(),
-        }
     }
 }
 


### PR DESCRIPTION
## Summary

This is a reimplementation of https://github.com/astral-sh/ruff/pull/14116 now that Salsa [salsa accumulators are cheaper](https://github.com/salsa-rs/salsa/pull/615) (close to "free" for queries without diagnostics). 

The main benefit of salsa accumulators is that they're an easy way to emit a diagnostic from anywhere inside a salsa query, and salsa takes care to deduplicate diagnostics if the same query is called multiple times.

## Performance

This still significantly regresses the incremental performance. I created another [salsa PR](https://github.com/salsa-rs/salsa/pull/622) to reduce the regression to 9%. I don't think we can do much better except reducing the number of inputs by using [coarse-grained](https://github.com/salsa-rs/salsa/issues/598) salsa dependencies because:

* Salsa currently tracks reads on a per "field" level for salsa structs. This very fine-grained tracking costs us here because the accumulator has to iterate and resolve all of them to know if they have any accumulated values. The coarse-grained salsa feature will help with this (and reduce the overhead in other places as well)
* We only check 4 files (plus standard library files that are all unchanged and have no diagnostics). The regression would be less proportionally if there were more files without diagnostics.
* The diagnostics are from the largest file and, to make it worse, from the module scope, which has the most definitions.

Considering this, I'm still leaning towards migrating to salsa accumulators because of what they unlock: We can now emit diagnostics from any part of the code. This includes the module resolver (e.g. emit a warning if we find an invalid `pth` file?) 

## Other changes

This PR upgrades Salsa to a version with "cheap" accumulators. The new salsa version now requires that `Db` structs implement `Clone` for its parallel db support (which doesn't seem to work yet). 

## Test Plan

`cargo test`
