### PR TITLE
Remove `@` in `pytest.mark.parametrize` rule messages

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_pytest_style/rules/parametrize.rs
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/rules/parametrize.rs
@@ -93,7 +93,7 @@ impl Violation for PytestParametrizeNamesWrongType {
                 }
             }
         };
-        format!("Wrong type passed to first argument of `@pytest.mark.parametrize`; expected {expected_string}")
+        format!("Wrong type passed to first argument of `pytest.mark.parametrize`; expected {expected_string}")
     }
 
     fn fix_title(&self) -> Option<String> {
@@ -210,7 +210,7 @@ impl Violation for PytestParametrizeValuesWrongType {
     #[derive_message_formats]
     fn message(&self) -> String {
         let PytestParametrizeValuesWrongType { values, row } = self;
-        format!("Wrong values type in `@pytest.mark.parametrize` expected `{values}` of `{row}`")
+        format!("Wrong values type in `pytest.mark.parametrize` expected `{values}` of `{row}`")
     }
 
     fn fix_title(&self) -> Option<String> {
@@ -273,7 +273,7 @@ impl Violation for PytestDuplicateParametrizeTestCases {
     #[derive_message_formats]
     fn message(&self) -> String {
         let PytestDuplicateParametrizeTestCases { index } = self;
-        format!("Duplicate of test case at index {index} in `@pytest_mark.parametrize`")
+        format!("Duplicate of test case at index {index} in `pytest.mark.parametrize`")
     }
 
     fn fix_title(&self) -> Option<String> {

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/snapshots/ruff_linter__rules__flake8_pytest_style__tests__PT006_csv.snap
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/snapshots/ruff_linter__rules__flake8_pytest_style__tests__PT006_csv.snap
@@ -2,7 +2,7 @@
 source: crates/ruff_linter/src/rules/flake8_pytest_style/mod.rs
 snapshot_kind: text
 ---
-PT006.py:24:26: PT006 [*] Wrong type passed to first argument of `@pytest.mark.parametrize`; expected a string of comma-separated values
+PT006.py:24:26: PT006 [*] Wrong type passed to first argument of `pytest.mark.parametrize`; expected a string of comma-separated values
    |
 24 | @pytest.mark.parametrize(("param1", "param2"), [(1, 2), (3, 4)])
    |                          ^^^^^^^^^^^^^^^^^^^^ PT006
@@ -21,7 +21,7 @@ PT006.py:24:26: PT006 [*] Wrong type passed to first argument of `@pytest.mark.p
 26 26 |     ...
 27 27 | 
 
-PT006.py:29:26: PT006 [*] Wrong type passed to first argument of `@pytest.mark.parametrize`; expected `str`
+PT006.py:29:26: PT006 [*] Wrong type passed to first argument of `pytest.mark.parametrize`; expected `str`
    |
 29 | @pytest.mark.parametrize(("param1",), [1, 2, 3])
    |                          ^^^^^^^^^^^ PT006
@@ -40,7 +40,7 @@ PT006.py:29:26: PT006 [*] Wrong type passed to first argument of `@pytest.mark.p
 31 31 |     ...
 32 32 | 
 
-PT006.py:34:26: PT006 [*] Wrong type passed to first argument of `@pytest.mark.parametrize`; expected a string of comma-separated values
+PT006.py:34:26: PT006 [*] Wrong type passed to first argument of `pytest.mark.parametrize`; expected a string of comma-separated values
    |
 34 | @pytest.mark.parametrize(["param1", "param2"], [(1, 2), (3, 4)])
    |                          ^^^^^^^^^^^^^^^^^^^^ PT006
@@ -59,7 +59,7 @@ PT006.py:34:26: PT006 [*] Wrong type passed to first argument of `@pytest.mark.p
 36 36 |     ...
 37 37 | 
 
-PT006.py:39:26: PT006 [*] Wrong type passed to first argument of `@pytest.mark.parametrize`; expected `str`
+PT006.py:39:26: PT006 [*] Wrong type passed to first argument of `pytest.mark.parametrize`; expected `str`
    |
 39 | @pytest.mark.parametrize(["param1"], [1, 2, 3])
    |                          ^^^^^^^^^^ PT006
@@ -78,7 +78,7 @@ PT006.py:39:26: PT006 [*] Wrong type passed to first argument of `@pytest.mark.p
 41 41 |     ...
 42 42 | 
 
-PT006.py:44:26: PT006 Wrong type passed to first argument of `@pytest.mark.parametrize`; expected a string of comma-separated values
+PT006.py:44:26: PT006 Wrong type passed to first argument of `pytest.mark.parametrize`; expected a string of comma-separated values
    |
 44 | @pytest.mark.parametrize([some_expr, another_expr], [1, 2, 3])
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^ PT006
@@ -87,7 +87,7 @@ PT006.py:44:26: PT006 Wrong type passed to first argument of `@pytest.mark.param
    |
    = help: Use a string of comma-separated values for the first argument
 
-PT006.py:49:26: PT006 Wrong type passed to first argument of `@pytest.mark.parametrize`; expected a string of comma-separated values
+PT006.py:49:26: PT006 Wrong type passed to first argument of `pytest.mark.parametrize`; expected a string of comma-separated values
    |
 49 | @pytest.mark.parametrize([some_expr, "param2"], [1, 2, 3])
    |                          ^^^^^^^^^^^^^^^^^^^^^ PT006

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/snapshots/ruff_linter__rules__flake8_pytest_style__tests__PT006_default.snap
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/snapshots/ruff_linter__rules__flake8_pytest_style__tests__PT006_default.snap
@@ -2,7 +2,7 @@
 source: crates/ruff_linter/src/rules/flake8_pytest_style/mod.rs
 snapshot_kind: text
 ---
-PT006.py:9:26: PT006 [*] Wrong type passed to first argument of `@pytest.mark.parametrize`; expected `tuple`
+PT006.py:9:26: PT006 [*] Wrong type passed to first argument of `pytest.mark.parametrize`; expected `tuple`
    |
  9 | @pytest.mark.parametrize("param1,param2", [(1, 2), (3, 4)])
    |                          ^^^^^^^^^^^^^^^ PT006
@@ -21,7 +21,7 @@ PT006.py:9:26: PT006 [*] Wrong type passed to first argument of `@pytest.mark.pa
 11 11 |     ...
 12 12 | 
 
-PT006.py:14:26: PT006 [*] Wrong type passed to first argument of `@pytest.mark.parametrize`; expected `tuple`
+PT006.py:14:26: PT006 [*] Wrong type passed to first argument of `pytest.mark.parametrize`; expected `tuple`
    |
 14 | @pytest.mark.parametrize("   param1,   ,    param2   , ", [(1, 2), (3, 4)])
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PT006
@@ -40,7 +40,7 @@ PT006.py:14:26: PT006 [*] Wrong type passed to first argument of `@pytest.mark.p
 16 16 |     ...
 17 17 | 
 
-PT006.py:19:26: PT006 [*] Wrong type passed to first argument of `@pytest.mark.parametrize`; expected `tuple`
+PT006.py:19:26: PT006 [*] Wrong type passed to first argument of `pytest.mark.parametrize`; expected `tuple`
    |
 19 | @pytest.mark.parametrize("param1,param2", [(1, 2), (3, 4)])
    |                          ^^^^^^^^^^^^^^^ PT006
@@ -59,7 +59,7 @@ PT006.py:19:26: PT006 [*] Wrong type passed to first argument of `@pytest.mark.p
 21 21 |     ...
 22 22 | 
 
-PT006.py:29:26: PT006 [*] Wrong type passed to first argument of `@pytest.mark.parametrize`; expected `str`
+PT006.py:29:26: PT006 [*] Wrong type passed to first argument of `pytest.mark.parametrize`; expected `str`
    |
 29 | @pytest.mark.parametrize(("param1",), [1, 2, 3])
    |                          ^^^^^^^^^^^ PT006
@@ -78,7 +78,7 @@ PT006.py:29:26: PT006 [*] Wrong type passed to first argument of `@pytest.mark.p
 31 31 |     ...
 32 32 | 
 
-PT006.py:34:26: PT006 [*] Wrong type passed to first argument of `@pytest.mark.parametrize`; expected `tuple`
+PT006.py:34:26: PT006 [*] Wrong type passed to first argument of `pytest.mark.parametrize`; expected `tuple`
    |
 34 | @pytest.mark.parametrize(["param1", "param2"], [(1, 2), (3, 4)])
    |                          ^^^^^^^^^^^^^^^^^^^^ PT006
@@ -97,7 +97,7 @@ PT006.py:34:26: PT006 [*] Wrong type passed to first argument of `@pytest.mark.p
 36 36 |     ...
 37 37 | 
 
-PT006.py:39:26: PT006 [*] Wrong type passed to first argument of `@pytest.mark.parametrize`; expected `str`
+PT006.py:39:26: PT006 [*] Wrong type passed to first argument of `pytest.mark.parametrize`; expected `str`
    |
 39 | @pytest.mark.parametrize(["param1"], [1, 2, 3])
    |                          ^^^^^^^^^^ PT006
@@ -116,7 +116,7 @@ PT006.py:39:26: PT006 [*] Wrong type passed to first argument of `@pytest.mark.p
 41 41 |     ...
 42 42 | 
 
-PT006.py:44:26: PT006 [*] Wrong type passed to first argument of `@pytest.mark.parametrize`; expected `tuple`
+PT006.py:44:26: PT006 [*] Wrong type passed to first argument of `pytest.mark.parametrize`; expected `tuple`
    |
 44 | @pytest.mark.parametrize([some_expr, another_expr], [1, 2, 3])
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^ PT006
@@ -135,7 +135,7 @@ PT006.py:44:26: PT006 [*] Wrong type passed to first argument of `@pytest.mark.p
 46 46 |     ...
 47 47 | 
 
-PT006.py:49:26: PT006 [*] Wrong type passed to first argument of `@pytest.mark.parametrize`; expected `tuple`
+PT006.py:49:26: PT006 [*] Wrong type passed to first argument of `pytest.mark.parametrize`; expected `tuple`
    |
 49 | @pytest.mark.parametrize([some_expr, "param2"], [1, 2, 3])
    |                          ^^^^^^^^^^^^^^^^^^^^^ PT006
@@ -154,7 +154,7 @@ PT006.py:49:26: PT006 [*] Wrong type passed to first argument of `@pytest.mark.p
 51 51 |     ...
 52 52 | 
 
-PT006.py:54:26: PT006 [*] Wrong type passed to first argument of `@pytest.mark.parametrize`; expected `tuple`
+PT006.py:54:26: PT006 [*] Wrong type passed to first argument of `pytest.mark.parametrize`; expected `tuple`
    |
 54 | @pytest.mark.parametrize(("param1, " "param2, " "param3"), [(1, 2, 3), (4, 5, 6)])
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PT006
@@ -173,7 +173,7 @@ PT006.py:54:26: PT006 [*] Wrong type passed to first argument of `@pytest.mark.p
 56 56 |     ...
 57 57 | 
 
-PT006.py:59:26: PT006 [*] Wrong type passed to first argument of `@pytest.mark.parametrize`; expected `tuple`
+PT006.py:59:26: PT006 [*] Wrong type passed to first argument of `pytest.mark.parametrize`; expected `tuple`
    |
 59 | @pytest.mark.parametrize("param1, " "param2, " "param3", [(1, 2, 3), (4, 5, 6)])
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PT006
@@ -192,7 +192,7 @@ PT006.py:59:26: PT006 [*] Wrong type passed to first argument of `@pytest.mark.p
 61 61 |     ...
 62 62 | 
 
-PT006.py:64:26: PT006 [*] Wrong type passed to first argument of `@pytest.mark.parametrize`; expected `tuple`
+PT006.py:64:26: PT006 [*] Wrong type passed to first argument of `pytest.mark.parametrize`; expected `tuple`
    |
 64 | @pytest.mark.parametrize((("param1, " "param2, " "param3")), [(1, 2, 3), (4, 5, 6)])
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PT006
@@ -211,7 +211,7 @@ PT006.py:64:26: PT006 [*] Wrong type passed to first argument of `@pytest.mark.p
 66 66 |     ...
 67 67 | 
 
-PT006.py:69:26: PT006 [*] Wrong type passed to first argument of `@pytest.mark.parametrize`; expected `tuple`
+PT006.py:69:26: PT006 [*] Wrong type passed to first argument of `pytest.mark.parametrize`; expected `tuple`
    |
 69 | @pytest.mark.parametrize(("param1,param2"), [(1, 2), (3, 4)])
    |                          ^^^^^^^^^^^^^^^^^ PT006

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/snapshots/ruff_linter__rules__flake8_pytest_style__tests__PT006_list.snap
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/snapshots/ruff_linter__rules__flake8_pytest_style__tests__PT006_list.snap
@@ -2,7 +2,7 @@
 source: crates/ruff_linter/src/rules/flake8_pytest_style/mod.rs
 snapshot_kind: text
 ---
-PT006.py:9:26: PT006 [*] Wrong type passed to first argument of `@pytest.mark.parametrize`; expected `list`
+PT006.py:9:26: PT006 [*] Wrong type passed to first argument of `pytest.mark.parametrize`; expected `list`
    |
  9 | @pytest.mark.parametrize("param1,param2", [(1, 2), (3, 4)])
    |                          ^^^^^^^^^^^^^^^ PT006
@@ -21,7 +21,7 @@ PT006.py:9:26: PT006 [*] Wrong type passed to first argument of `@pytest.mark.pa
 11 11 |     ...
 12 12 | 
 
-PT006.py:14:26: PT006 [*] Wrong type passed to first argument of `@pytest.mark.parametrize`; expected `list`
+PT006.py:14:26: PT006 [*] Wrong type passed to first argument of `pytest.mark.parametrize`; expected `list`
    |
 14 | @pytest.mark.parametrize("   param1,   ,    param2   , ", [(1, 2), (3, 4)])
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PT006
@@ -40,7 +40,7 @@ PT006.py:14:26: PT006 [*] Wrong type passed to first argument of `@pytest.mark.p
 16 16 |     ...
 17 17 | 
 
-PT006.py:19:26: PT006 [*] Wrong type passed to first argument of `@pytest.mark.parametrize`; expected `list`
+PT006.py:19:26: PT006 [*] Wrong type passed to first argument of `pytest.mark.parametrize`; expected `list`
    |
 19 | @pytest.mark.parametrize("param1,param2", [(1, 2), (3, 4)])
    |                          ^^^^^^^^^^^^^^^ PT006
@@ -59,7 +59,7 @@ PT006.py:19:26: PT006 [*] Wrong type passed to first argument of `@pytest.mark.p
 21 21 |     ...
 22 22 | 
 
-PT006.py:24:26: PT006 [*] Wrong type passed to first argument of `@pytest.mark.parametrize`; expected `list`
+PT006.py:24:26: PT006 [*] Wrong type passed to first argument of `pytest.mark.parametrize`; expected `list`
    |
 24 | @pytest.mark.parametrize(("param1", "param2"), [(1, 2), (3, 4)])
    |                          ^^^^^^^^^^^^^^^^^^^^ PT006
@@ -78,7 +78,7 @@ PT006.py:24:26: PT006 [*] Wrong type passed to first argument of `@pytest.mark.p
 26 26 |     ...
 27 27 | 
 
-PT006.py:29:26: PT006 [*] Wrong type passed to first argument of `@pytest.mark.parametrize`; expected `str`
+PT006.py:29:26: PT006 [*] Wrong type passed to first argument of `pytest.mark.parametrize`; expected `str`
    |
 29 | @pytest.mark.parametrize(("param1",), [1, 2, 3])
    |                          ^^^^^^^^^^^ PT006
@@ -97,7 +97,7 @@ PT006.py:29:26: PT006 [*] Wrong type passed to first argument of `@pytest.mark.p
 31 31 |     ...
 32 32 | 
 
-PT006.py:39:26: PT006 [*] Wrong type passed to first argument of `@pytest.mark.parametrize`; expected `str`
+PT006.py:39:26: PT006 [*] Wrong type passed to first argument of `pytest.mark.parametrize`; expected `str`
    |
 39 | @pytest.mark.parametrize(["param1"], [1, 2, 3])
    |                          ^^^^^^^^^^ PT006
@@ -116,7 +116,7 @@ PT006.py:39:26: PT006 [*] Wrong type passed to first argument of `@pytest.mark.p
 41 41 |     ...
 42 42 | 
 
-PT006.py:54:26: PT006 [*] Wrong type passed to first argument of `@pytest.mark.parametrize`; expected `list`
+PT006.py:54:26: PT006 [*] Wrong type passed to first argument of `pytest.mark.parametrize`; expected `list`
    |
 54 | @pytest.mark.parametrize(("param1, " "param2, " "param3"), [(1, 2, 3), (4, 5, 6)])
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PT006
@@ -135,7 +135,7 @@ PT006.py:54:26: PT006 [*] Wrong type passed to first argument of `@pytest.mark.p
 56 56 |     ...
 57 57 | 
 
-PT006.py:59:26: PT006 [*] Wrong type passed to first argument of `@pytest.mark.parametrize`; expected `list`
+PT006.py:59:26: PT006 [*] Wrong type passed to first argument of `pytest.mark.parametrize`; expected `list`
    |
 59 | @pytest.mark.parametrize("param1, " "param2, " "param3", [(1, 2, 3), (4, 5, 6)])
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PT006
@@ -154,7 +154,7 @@ PT006.py:59:26: PT006 [*] Wrong type passed to first argument of `@pytest.mark.p
 61 61 |     ...
 62 62 | 
 
-PT006.py:64:26: PT006 [*] Wrong type passed to first argument of `@pytest.mark.parametrize`; expected `list`
+PT006.py:64:26: PT006 [*] Wrong type passed to first argument of `pytest.mark.parametrize`; expected `list`
    |
 64 | @pytest.mark.parametrize((("param1, " "param2, " "param3")), [(1, 2, 3), (4, 5, 6)])
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PT006
@@ -173,7 +173,7 @@ PT006.py:64:26: PT006 [*] Wrong type passed to first argument of `@pytest.mark.p
 66 66 |     ...
 67 67 | 
 
-PT006.py:69:26: PT006 [*] Wrong type passed to first argument of `@pytest.mark.parametrize`; expected `list`
+PT006.py:69:26: PT006 [*] Wrong type passed to first argument of `pytest.mark.parametrize`; expected `list`
    |
 69 | @pytest.mark.parametrize(("param1,param2"), [(1, 2), (3, 4)])
    |                          ^^^^^^^^^^^^^^^^^ PT006

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/snapshots/ruff_linter__rules__flake8_pytest_style__tests__PT007_list_of_lists.snap
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/snapshots/ruff_linter__rules__flake8_pytest_style__tests__PT007_list_of_lists.snap
@@ -2,7 +2,7 @@
 source: crates/ruff_linter/src/rules/flake8_pytest_style/mod.rs
 snapshot_kind: text
 ---
-PT007.py:4:35: PT007 [*] Wrong values type in `@pytest.mark.parametrize` expected `list` of `list`
+PT007.py:4:35: PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `list` of `list`
   |
 4 | @pytest.mark.parametrize("param", (1, 2))
   |                                   ^^^^^^ PT007
@@ -21,7 +21,7 @@ PT007.py:4:35: PT007 [*] Wrong values type in `@pytest.mark.parametrize` expecte
 6 6 |     ...
 7 7 | 
 
-PT007.py:11:5: PT007 [*] Wrong values type in `@pytest.mark.parametrize` expected `list` of `list`
+PT007.py:11:5: PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `list` of `list`
    |
  9 |   @pytest.mark.parametrize(
 10 |       ("param1", "param2"),
@@ -50,7 +50,7 @@ PT007.py:11:5: PT007 [*] Wrong values type in `@pytest.mark.parametrize` expecte
 16 16 | def test_tuple_of_tuples(param1, param2):
 17 17 |     ...
 
-PT007.py:12:9: PT007 [*] Wrong values type in `@pytest.mark.parametrize` expected `list` of `list`
+PT007.py:12:9: PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `list` of `list`
    |
 10 |     ("param1", "param2"),
 11 |     (
@@ -71,7 +71,7 @@ PT007.py:12:9: PT007 [*] Wrong values type in `@pytest.mark.parametrize` expecte
 14 14 |     ),
 15 15 | )
 
-PT007.py:13:9: PT007 [*] Wrong values type in `@pytest.mark.parametrize` expected `list` of `list`
+PT007.py:13:9: PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `list` of `list`
    |
 11 |     (
 12 |         (1, 2),
@@ -92,7 +92,7 @@ PT007.py:13:9: PT007 [*] Wrong values type in `@pytest.mark.parametrize` expecte
 15 15 | )
 16 16 | def test_tuple_of_tuples(param1, param2):
 
-PT007.py:22:5: PT007 [*] Wrong values type in `@pytest.mark.parametrize` expected `list` of `list`
+PT007.py:22:5: PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `list` of `list`
    |
 20 |   @pytest.mark.parametrize(
 21 |       ("param1", "param2"),
@@ -121,7 +121,7 @@ PT007.py:22:5: PT007 [*] Wrong values type in `@pytest.mark.parametrize` expecte
 27 27 | def test_tuple_of_lists(param1, param2):
 28 28 |     ...
 
-PT007.py:39:9: PT007 [*] Wrong values type in `@pytest.mark.parametrize` expected `list` of `list`
+PT007.py:39:9: PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `list` of `list`
    |
 37 |     ("param1", "param2"),
 38 |     [
@@ -142,7 +142,7 @@ PT007.py:39:9: PT007 [*] Wrong values type in `@pytest.mark.parametrize` expecte
 41 41 |     ],
 42 42 | )
 
-PT007.py:40:9: PT007 [*] Wrong values type in `@pytest.mark.parametrize` expected `list` of `list`
+PT007.py:40:9: PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `list` of `list`
    |
 38 |     [
 39 |         (1, 2),
@@ -163,7 +163,7 @@ PT007.py:40:9: PT007 [*] Wrong values type in `@pytest.mark.parametrize` expecte
 42 42 | )
 43 43 | def test_list_of_tuples(param1, param2):
 
-PT007.py:81:38: PT007 [*] Wrong values type in `@pytest.mark.parametrize` expected `list` of `list`
+PT007.py:81:38: PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `list` of `list`
    |
 80 | @pytest.mark.parametrize("a", [1, 2])
 81 | @pytest.mark.parametrize(("b", "c"), ((3, 4), (5, 6)))
@@ -183,7 +183,7 @@ PT007.py:81:38: PT007 [*] Wrong values type in `@pytest.mark.parametrize` expect
 83 83 | @pytest.mark.parametrize(
 84 84 |     "d",
 
-PT007.py:81:39: PT007 [*] Wrong values type in `@pytest.mark.parametrize` expected `list` of `list`
+PT007.py:81:39: PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `list` of `list`
    |
 80 | @pytest.mark.parametrize("a", [1, 2])
 81 | @pytest.mark.parametrize(("b", "c"), ((3, 4), (5, 6)))
@@ -203,7 +203,7 @@ PT007.py:81:39: PT007 [*] Wrong values type in `@pytest.mark.parametrize` expect
 83 83 | @pytest.mark.parametrize(
 84 84 |     "d",
 
-PT007.py:81:47: PT007 [*] Wrong values type in `@pytest.mark.parametrize` expected `list` of `list`
+PT007.py:81:47: PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `list` of `list`
    |
 80 | @pytest.mark.parametrize("a", [1, 2])
 81 | @pytest.mark.parametrize(("b", "c"), ((3, 4), (5, 6)))

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/snapshots/ruff_linter__rules__flake8_pytest_style__tests__PT007_list_of_tuples.snap
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/snapshots/ruff_linter__rules__flake8_pytest_style__tests__PT007_list_of_tuples.snap
@@ -2,7 +2,7 @@
 source: crates/ruff_linter/src/rules/flake8_pytest_style/mod.rs
 snapshot_kind: text
 ---
-PT007.py:4:35: PT007 [*] Wrong values type in `@pytest.mark.parametrize` expected `list` of `tuple`
+PT007.py:4:35: PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `list` of `tuple`
   |
 4 | @pytest.mark.parametrize("param", (1, 2))
   |                                   ^^^^^^ PT007
@@ -21,7 +21,7 @@ PT007.py:4:35: PT007 [*] Wrong values type in `@pytest.mark.parametrize` expecte
 6 6 |     ...
 7 7 | 
 
-PT007.py:11:5: PT007 [*] Wrong values type in `@pytest.mark.parametrize` expected `list` of `tuple`
+PT007.py:11:5: PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `list` of `tuple`
    |
  9 |   @pytest.mark.parametrize(
 10 |       ("param1", "param2"),
@@ -50,7 +50,7 @@ PT007.py:11:5: PT007 [*] Wrong values type in `@pytest.mark.parametrize` expecte
 16 16 | def test_tuple_of_tuples(param1, param2):
 17 17 |     ...
 
-PT007.py:22:5: PT007 [*] Wrong values type in `@pytest.mark.parametrize` expected `list` of `tuple`
+PT007.py:22:5: PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `list` of `tuple`
    |
 20 |   @pytest.mark.parametrize(
 21 |       ("param1", "param2"),
@@ -79,7 +79,7 @@ PT007.py:22:5: PT007 [*] Wrong values type in `@pytest.mark.parametrize` expecte
 27 27 | def test_tuple_of_lists(param1, param2):
 28 28 |     ...
 
-PT007.py:23:9: PT007 [*] Wrong values type in `@pytest.mark.parametrize` expected `list` of `tuple`
+PT007.py:23:9: PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `list` of `tuple`
    |
 21 |     ("param1", "param2"),
 22 |     (
@@ -100,7 +100,7 @@ PT007.py:23:9: PT007 [*] Wrong values type in `@pytest.mark.parametrize` expecte
 25 25 |     ),
 26 26 | )
 
-PT007.py:24:9: PT007 [*] Wrong values type in `@pytest.mark.parametrize` expected `list` of `tuple`
+PT007.py:24:9: PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `list` of `tuple`
    |
 22 |     (
 23 |         [1, 2],
@@ -121,7 +121,7 @@ PT007.py:24:9: PT007 [*] Wrong values type in `@pytest.mark.parametrize` expecte
 26 26 | )
 27 27 | def test_tuple_of_lists(param1, param2):
 
-PT007.py:50:9: PT007 [*] Wrong values type in `@pytest.mark.parametrize` expected `list` of `tuple`
+PT007.py:50:9: PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `list` of `tuple`
    |
 48 |     ("param1", "param2"),
 49 |     [
@@ -142,7 +142,7 @@ PT007.py:50:9: PT007 [*] Wrong values type in `@pytest.mark.parametrize` expecte
 52 52 |     ],
 53 53 | )
 
-PT007.py:51:9: PT007 [*] Wrong values type in `@pytest.mark.parametrize` expected `list` of `tuple`
+PT007.py:51:9: PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `list` of `tuple`
    |
 49 |     [
 50 |         [1, 2],
@@ -163,7 +163,7 @@ PT007.py:51:9: PT007 [*] Wrong values type in `@pytest.mark.parametrize` expecte
 53 53 | )
 54 54 | def test_list_of_lists(param1, param2):
 
-PT007.py:61:9: PT007 [*] Wrong values type in `@pytest.mark.parametrize` expected `list` of `tuple`
+PT007.py:61:9: PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `list` of `tuple`
    |
 59 |     "param1,param2",
 60 |     [
@@ -184,7 +184,7 @@ PT007.py:61:9: PT007 [*] Wrong values type in `@pytest.mark.parametrize` expecte
 63 63 |     ],
 64 64 | )
 
-PT007.py:62:9: PT007 [*] Wrong values type in `@pytest.mark.parametrize` expected `list` of `tuple`
+PT007.py:62:9: PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `list` of `tuple`
    |
 60 |     [
 61 |         [1, 2],
@@ -205,7 +205,7 @@ PT007.py:62:9: PT007 [*] Wrong values type in `@pytest.mark.parametrize` expecte
 64 64 | )
 65 65 | def test_csv_name_list_of_lists(param1, param2):
 
-PT007.py:81:38: PT007 [*] Wrong values type in `@pytest.mark.parametrize` expected `list` of `tuple`
+PT007.py:81:38: PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `list` of `tuple`
    |
 80 | @pytest.mark.parametrize("a", [1, 2])
 81 | @pytest.mark.parametrize(("b", "c"), ((3, 4), (5, 6)))

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/snapshots/ruff_linter__rules__flake8_pytest_style__tests__PT007_tuple_of_lists.snap
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/snapshots/ruff_linter__rules__flake8_pytest_style__tests__PT007_tuple_of_lists.snap
@@ -2,7 +2,7 @@
 source: crates/ruff_linter/src/rules/flake8_pytest_style/mod.rs
 snapshot_kind: text
 ---
-PT007.py:12:9: PT007 [*] Wrong values type in `@pytest.mark.parametrize` expected `tuple` of `list`
+PT007.py:12:9: PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple` of `list`
    |
 10 |     ("param1", "param2"),
 11 |     (
@@ -23,7 +23,7 @@ PT007.py:12:9: PT007 [*] Wrong values type in `@pytest.mark.parametrize` expecte
 14 14 |     ),
 15 15 | )
 
-PT007.py:13:9: PT007 [*] Wrong values type in `@pytest.mark.parametrize` expected `tuple` of `list`
+PT007.py:13:9: PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple` of `list`
    |
 11 |     (
 12 |         (1, 2),
@@ -44,7 +44,7 @@ PT007.py:13:9: PT007 [*] Wrong values type in `@pytest.mark.parametrize` expecte
 15 15 | )
 16 16 | def test_tuple_of_tuples(param1, param2):
 
-PT007.py:31:35: PT007 [*] Wrong values type in `@pytest.mark.parametrize` expected `tuple` of `list`
+PT007.py:31:35: PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple` of `list`
    |
 31 | @pytest.mark.parametrize("param", [1, 2])
    |                                   ^^^^^^ PT007
@@ -63,7 +63,7 @@ PT007.py:31:35: PT007 [*] Wrong values type in `@pytest.mark.parametrize` expect
 33 33 |     ...
 34 34 | 
 
-PT007.py:38:5: PT007 [*] Wrong values type in `@pytest.mark.parametrize` expected `tuple` of `list`
+PT007.py:38:5: PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple` of `list`
    |
 36 |   @pytest.mark.parametrize(
 37 |       ("param1", "param2"),
@@ -92,7 +92,7 @@ PT007.py:38:5: PT007 [*] Wrong values type in `@pytest.mark.parametrize` expecte
 43 43 | def test_list_of_tuples(param1, param2):
 44 44 |     ...
 
-PT007.py:39:9: PT007 [*] Wrong values type in `@pytest.mark.parametrize` expected `tuple` of `list`
+PT007.py:39:9: PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple` of `list`
    |
 37 |     ("param1", "param2"),
 38 |     [
@@ -113,7 +113,7 @@ PT007.py:39:9: PT007 [*] Wrong values type in `@pytest.mark.parametrize` expecte
 41 41 |     ],
 42 42 | )
 
-PT007.py:40:9: PT007 [*] Wrong values type in `@pytest.mark.parametrize` expected `tuple` of `list`
+PT007.py:40:9: PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple` of `list`
    |
 38 |     [
 39 |         (1, 2),
@@ -134,7 +134,7 @@ PT007.py:40:9: PT007 [*] Wrong values type in `@pytest.mark.parametrize` expecte
 42 42 | )
 43 43 | def test_list_of_tuples(param1, param2):
 
-PT007.py:49:5: PT007 [*] Wrong values type in `@pytest.mark.parametrize` expected `tuple` of `list`
+PT007.py:49:5: PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple` of `list`
    |
 47 |   @pytest.mark.parametrize(
 48 |       ("param1", "param2"),
@@ -163,7 +163,7 @@ PT007.py:49:5: PT007 [*] Wrong values type in `@pytest.mark.parametrize` expecte
 54 54 | def test_list_of_lists(param1, param2):
 55 55 |     ...
 
-PT007.py:60:5: PT007 [*] Wrong values type in `@pytest.mark.parametrize` expected `tuple` of `list`
+PT007.py:60:5: PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple` of `list`
    |
 58 |   @pytest.mark.parametrize(
 59 |       "param1,param2",
@@ -192,7 +192,7 @@ PT007.py:60:5: PT007 [*] Wrong values type in `@pytest.mark.parametrize` expecte
 65 65 | def test_csv_name_list_of_lists(param1, param2):
 66 66 |     ...
 
-PT007.py:71:5: PT007 [*] Wrong values type in `@pytest.mark.parametrize` expected `tuple` of `list`
+PT007.py:71:5: PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple` of `list`
    |
 69 |   @pytest.mark.parametrize(
 70 |       "param",
@@ -221,7 +221,7 @@ PT007.py:71:5: PT007 [*] Wrong values type in `@pytest.mark.parametrize` expecte
 76 76 | def test_single_list_of_lists(param):
 77 77 |     ...
 
-PT007.py:80:31: PT007 [*] Wrong values type in `@pytest.mark.parametrize` expected `tuple` of `list`
+PT007.py:80:31: PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple` of `list`
    |
 80 | @pytest.mark.parametrize("a", [1, 2])
    |                               ^^^^^^ PT007
@@ -240,7 +240,7 @@ PT007.py:80:31: PT007 [*] Wrong values type in `@pytest.mark.parametrize` expect
 82 82 | @pytest.mark.parametrize("d", [3,])
 83 83 | @pytest.mark.parametrize(
 
-PT007.py:81:39: PT007 [*] Wrong values type in `@pytest.mark.parametrize` expected `tuple` of `list`
+PT007.py:81:39: PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple` of `list`
    |
 80 | @pytest.mark.parametrize("a", [1, 2])
 81 | @pytest.mark.parametrize(("b", "c"), ((3, 4), (5, 6)))
@@ -260,7 +260,7 @@ PT007.py:81:39: PT007 [*] Wrong values type in `@pytest.mark.parametrize` expect
 83 83 | @pytest.mark.parametrize(
 84 84 |     "d",
 
-PT007.py:81:47: PT007 [*] Wrong values type in `@pytest.mark.parametrize` expected `tuple` of `list`
+PT007.py:81:47: PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple` of `list`
    |
 80 | @pytest.mark.parametrize("a", [1, 2])
 81 | @pytest.mark.parametrize(("b", "c"), ((3, 4), (5, 6)))
@@ -280,7 +280,7 @@ PT007.py:81:47: PT007 [*] Wrong values type in `@pytest.mark.parametrize` expect
 83 83 | @pytest.mark.parametrize(
 84 84 |     "d",
 
-PT007.py:82:31: PT007 [*] Wrong values type in `@pytest.mark.parametrize` expected `tuple` of `list`
+PT007.py:82:31: PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple` of `list`
    |
 80 | @pytest.mark.parametrize("a", [1, 2])
 81 | @pytest.mark.parametrize(("b", "c"), ((3, 4), (5, 6)))
@@ -301,7 +301,7 @@ PT007.py:82:31: PT007 [*] Wrong values type in `@pytest.mark.parametrize` expect
 84 84 |     "d",
 85 85 |     [("3", "4")],
 
-PT007.py:85:5: PT007 [*] Wrong values type in `@pytest.mark.parametrize` expected `tuple` of `list`
+PT007.py:85:5: PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple` of `list`
    |
 83 | @pytest.mark.parametrize(
 84 |     "d",
@@ -322,7 +322,7 @@ PT007.py:85:5: PT007 [*] Wrong values type in `@pytest.mark.parametrize` expecte
 87 87 | @pytest.mark.parametrize(
 88 88 |     "e",
 
-PT007.py:89:5: PT007 [*] Wrong values type in `@pytest.mark.parametrize` expected `tuple` of `list`
+PT007.py:89:5: PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple` of `list`
    |
 87 | @pytest.mark.parametrize(
 88 |     "e",

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/snapshots/ruff_linter__rules__flake8_pytest_style__tests__PT007_tuple_of_tuples.snap
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/snapshots/ruff_linter__rules__flake8_pytest_style__tests__PT007_tuple_of_tuples.snap
@@ -2,7 +2,7 @@
 source: crates/ruff_linter/src/rules/flake8_pytest_style/mod.rs
 snapshot_kind: text
 ---
-PT007.py:23:9: PT007 [*] Wrong values type in `@pytest.mark.parametrize` expected `tuple` of `tuple`
+PT007.py:23:9: PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple` of `tuple`
    |
 21 |     ("param1", "param2"),
 22 |     (
@@ -23,7 +23,7 @@ PT007.py:23:9: PT007 [*] Wrong values type in `@pytest.mark.parametrize` expecte
 25 25 |     ),
 26 26 | )
 
-PT007.py:24:9: PT007 [*] Wrong values type in `@pytest.mark.parametrize` expected `tuple` of `tuple`
+PT007.py:24:9: PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple` of `tuple`
    |
 22 |     (
 23 |         [1, 2],
@@ -44,7 +44,7 @@ PT007.py:24:9: PT007 [*] Wrong values type in `@pytest.mark.parametrize` expecte
 26 26 | )
 27 27 | def test_tuple_of_lists(param1, param2):
 
-PT007.py:31:35: PT007 [*] Wrong values type in `@pytest.mark.parametrize` expected `tuple` of `tuple`
+PT007.py:31:35: PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple` of `tuple`
    |
 31 | @pytest.mark.parametrize("param", [1, 2])
    |                                   ^^^^^^ PT007
@@ -63,7 +63,7 @@ PT007.py:31:35: PT007 [*] Wrong values type in `@pytest.mark.parametrize` expect
 33 33 |     ...
 34 34 | 
 
-PT007.py:38:5: PT007 [*] Wrong values type in `@pytest.mark.parametrize` expected `tuple` of `tuple`
+PT007.py:38:5: PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple` of `tuple`
    |
 36 |   @pytest.mark.parametrize(
 37 |       ("param1", "param2"),
@@ -92,7 +92,7 @@ PT007.py:38:5: PT007 [*] Wrong values type in `@pytest.mark.parametrize` expecte
 43 43 | def test_list_of_tuples(param1, param2):
 44 44 |     ...
 
-PT007.py:49:5: PT007 [*] Wrong values type in `@pytest.mark.parametrize` expected `tuple` of `tuple`
+PT007.py:49:5: PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple` of `tuple`
    |
 47 |   @pytest.mark.parametrize(
 48 |       ("param1", "param2"),
@@ -121,7 +121,7 @@ PT007.py:49:5: PT007 [*] Wrong values type in `@pytest.mark.parametrize` expecte
 54 54 | def test_list_of_lists(param1, param2):
 55 55 |     ...
 
-PT007.py:50:9: PT007 [*] Wrong values type in `@pytest.mark.parametrize` expected `tuple` of `tuple`
+PT007.py:50:9: PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple` of `tuple`
    |
 48 |     ("param1", "param2"),
 49 |     [
@@ -142,7 +142,7 @@ PT007.py:50:9: PT007 [*] Wrong values type in `@pytest.mark.parametrize` expecte
 52 52 |     ],
 53 53 | )
 
-PT007.py:51:9: PT007 [*] Wrong values type in `@pytest.mark.parametrize` expected `tuple` of `tuple`
+PT007.py:51:9: PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple` of `tuple`
    |
 49 |     [
 50 |         [1, 2],
@@ -163,7 +163,7 @@ PT007.py:51:9: PT007 [*] Wrong values type in `@pytest.mark.parametrize` expecte
 53 53 | )
 54 54 | def test_list_of_lists(param1, param2):
 
-PT007.py:60:5: PT007 [*] Wrong values type in `@pytest.mark.parametrize` expected `tuple` of `tuple`
+PT007.py:60:5: PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple` of `tuple`
    |
 58 |   @pytest.mark.parametrize(
 59 |       "param1,param2",
@@ -192,7 +192,7 @@ PT007.py:60:5: PT007 [*] Wrong values type in `@pytest.mark.parametrize` expecte
 65 65 | def test_csv_name_list_of_lists(param1, param2):
 66 66 |     ...
 
-PT007.py:61:9: PT007 [*] Wrong values type in `@pytest.mark.parametrize` expected `tuple` of `tuple`
+PT007.py:61:9: PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple` of `tuple`
    |
 59 |     "param1,param2",
 60 |     [
@@ -213,7 +213,7 @@ PT007.py:61:9: PT007 [*] Wrong values type in `@pytest.mark.parametrize` expecte
 63 63 |     ],
 64 64 | )
 
-PT007.py:62:9: PT007 [*] Wrong values type in `@pytest.mark.parametrize` expected `tuple` of `tuple`
+PT007.py:62:9: PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple` of `tuple`
    |
 60 |     [
 61 |         [1, 2],
@@ -234,7 +234,7 @@ PT007.py:62:9: PT007 [*] Wrong values type in `@pytest.mark.parametrize` expecte
 64 64 | )
 65 65 | def test_csv_name_list_of_lists(param1, param2):
 
-PT007.py:71:5: PT007 [*] Wrong values type in `@pytest.mark.parametrize` expected `tuple` of `tuple`
+PT007.py:71:5: PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple` of `tuple`
    |
 69 |   @pytest.mark.parametrize(
 70 |       "param",
@@ -263,7 +263,7 @@ PT007.py:71:5: PT007 [*] Wrong values type in `@pytest.mark.parametrize` expecte
 76 76 | def test_single_list_of_lists(param):
 77 77 |     ...
 
-PT007.py:80:31: PT007 [*] Wrong values type in `@pytest.mark.parametrize` expected `tuple` of `tuple`
+PT007.py:80:31: PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple` of `tuple`
    |
 80 | @pytest.mark.parametrize("a", [1, 2])
    |                               ^^^^^^ PT007
@@ -282,7 +282,7 @@ PT007.py:80:31: PT007 [*] Wrong values type in `@pytest.mark.parametrize` expect
 82 82 | @pytest.mark.parametrize("d", [3,])
 83 83 | @pytest.mark.parametrize(
 
-PT007.py:82:31: PT007 [*] Wrong values type in `@pytest.mark.parametrize` expected `tuple` of `tuple`
+PT007.py:82:31: PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple` of `tuple`
    |
 80 | @pytest.mark.parametrize("a", [1, 2])
 81 | @pytest.mark.parametrize(("b", "c"), ((3, 4), (5, 6)))
@@ -303,7 +303,7 @@ PT007.py:82:31: PT007 [*] Wrong values type in `@pytest.mark.parametrize` expect
 84 84 |     "d",
 85 85 |     [("3", "4")],
 
-PT007.py:85:5: PT007 [*] Wrong values type in `@pytest.mark.parametrize` expected `tuple` of `tuple`
+PT007.py:85:5: PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple` of `tuple`
    |
 83 | @pytest.mark.parametrize(
 84 |     "d",
@@ -324,7 +324,7 @@ PT007.py:85:5: PT007 [*] Wrong values type in `@pytest.mark.parametrize` expecte
 87 87 | @pytest.mark.parametrize(
 88 88 |     "e",
 
-PT007.py:89:5: PT007 [*] Wrong values type in `@pytest.mark.parametrize` expected `tuple` of `tuple`
+PT007.py:89:5: PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple` of `tuple`
    |
 87 | @pytest.mark.parametrize(
 88 |     "e",

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/snapshots/ruff_linter__rules__flake8_pytest_style__tests__PT014.snap
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/snapshots/ruff_linter__rules__flake8_pytest_style__tests__PT014.snap
@@ -2,7 +2,7 @@
 source: crates/ruff_linter/src/rules/flake8_pytest_style/mod.rs
 snapshot_kind: text
 ---
-PT014.py:4:35: PT014 [*] Duplicate of test case at index 0 in `@pytest_mark.parametrize`
+PT014.py:4:35: PT014 [*] Duplicate of test case at index 0 in `pytest.mark.parametrize`
   |
 4 | @pytest.mark.parametrize("x", [1, 1, 2])
   |                                   ^ PT014
@@ -21,7 +21,7 @@ PT014.py:4:35: PT014 [*] Duplicate of test case at index 0 in `@pytest_mark.para
 6 6 |     ...
 7 7 | 
 
-PT014.py:14:35: PT014 [*] Duplicate of test case at index 0 in `@pytest_mark.parametrize`
+PT014.py:14:35: PT014 [*] Duplicate of test case at index 0 in `pytest.mark.parametrize`
    |
 14 | @pytest.mark.parametrize("x", [a, a, b, b, b, c])
    |                                   ^ PT014
@@ -40,7 +40,7 @@ PT014.py:14:35: PT014 [*] Duplicate of test case at index 0 in `@pytest_mark.par
 16 16 |     ...
 17 17 | 
 
-PT014.py:14:41: PT014 [*] Duplicate of test case at index 2 in `@pytest_mark.parametrize`
+PT014.py:14:41: PT014 [*] Duplicate of test case at index 2 in `pytest.mark.parametrize`
    |
 14 | @pytest.mark.parametrize("x", [a, a, b, b, b, c])
    |                                         ^ PT014
@@ -59,7 +59,7 @@ PT014.py:14:41: PT014 [*] Duplicate of test case at index 2 in `@pytest_mark.par
 16 16 |     ...
 17 17 | 
 
-PT014.py:14:44: PT014 [*] Duplicate of test case at index 2 in `@pytest_mark.parametrize`
+PT014.py:14:44: PT014 [*] Duplicate of test case at index 2 in `pytest.mark.parametrize`
    |
 14 | @pytest.mark.parametrize("x", [a, a, b, b, b, c])
    |                                            ^ PT014
@@ -78,7 +78,7 @@ PT014.py:14:44: PT014 [*] Duplicate of test case at index 2 in `@pytest_mark.par
 16 16 |     ...
 17 17 | 
 
-PT014.py:24:9: PT014 Duplicate of test case at index 0 in `@pytest_mark.parametrize`
+PT014.py:24:9: PT014 Duplicate of test case at index 0 in `pytest.mark.parametrize`
    |
 22 |         (a, b),
 23 |         # comment
@@ -89,7 +89,7 @@ PT014.py:24:9: PT014 Duplicate of test case at index 0 in `@pytest_mark.parametr
    |
    = help: Remove duplicate test case
 
-PT014.py:32:39: PT014 [*] Duplicate of test case at index 0 in `@pytest_mark.parametrize`
+PT014.py:32:39: PT014 [*] Duplicate of test case at index 0 in `pytest.mark.parametrize`
    |
 32 | @pytest.mark.parametrize("x", [a, b, (a), c, ((a))])
    |                                       ^ PT014
@@ -108,7 +108,7 @@ PT014.py:32:39: PT014 [*] Duplicate of test case at index 0 in `@pytest_mark.par
 34 34 |     ...
 35 35 | 
 
-PT014.py:32:48: PT014 [*] Duplicate of test case at index 0 in `@pytest_mark.parametrize`
+PT014.py:32:48: PT014 [*] Duplicate of test case at index 0 in `pytest.mark.parametrize`
    |
 32 | @pytest.mark.parametrize("x", [a, b, (a), c, ((a))])
    |                                                ^ PT014
@@ -127,7 +127,7 @@ PT014.py:32:48: PT014 [*] Duplicate of test case at index 0 in `@pytest_mark.par
 34 34 |     ...
 35 35 | 
 
-PT014.py:42:10: PT014 [*] Duplicate of test case at index 0 in `@pytest_mark.parametrize`
+PT014.py:42:10: PT014 [*] Duplicate of test case at index 0 in `pytest.mark.parametrize`
    |
 40 |         a,
 41 |         b,
@@ -147,7 +147,7 @@ PT014.py:42:10: PT014 [*] Duplicate of test case at index 0 in `@pytest_mark.par
 44 43 |         ((a)),
 45 44 |     ],
 
-PT014.py:44:11: PT014 [*] Duplicate of test case at index 0 in `@pytest_mark.parametrize`
+PT014.py:44:11: PT014 [*] Duplicate of test case at index 0 in `pytest.mark.parametrize`
    |
 42 |         (a),
 43 |         c,
@@ -167,7 +167,7 @@ PT014.py:44:11: PT014 [*] Duplicate of test case at index 0 in `@pytest_mark.par
 46 45 | )
 47 46 | def test_error_parentheses_trailing_comma(x):
 
-PT014.py:56:53: PT014 [*] Duplicate of test case at index 0 in `@pytest_mark.parametrize`
+PT014.py:56:53: PT014 [*] Duplicate of test case at index 0 in `pytest.mark.parametrize`
    |
 56 | @pytest.mark.parametrize('data, spec', [(1.0, 1.0), (1.0, 1.0)])
    |                                                     ^^^^^^^^^^ PT014

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/snapshots/ruff_linter__rules__flake8_pytest_style__tests__preview__PT006_PT006.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/snapshots/ruff_linter__rules__flake8_pytest_style__tests__preview__PT006_PT006.py.snap
@@ -2,7 +2,7 @@
 source: crates/ruff_linter/src/rules/flake8_pytest_style/mod.rs
 snapshot_kind: text
 ---
-PT006.py:9:26: PT006 [*] Wrong type passed to first argument of `@pytest.mark.parametrize`; expected `tuple`
+PT006.py:9:26: PT006 [*] Wrong type passed to first argument of `pytest.mark.parametrize`; expected `tuple`
    |
  9 | @pytest.mark.parametrize("param1,param2", [(1, 2), (3, 4)])
    |                          ^^^^^^^^^^^^^^^ PT006
@@ -21,7 +21,7 @@ PT006.py:9:26: PT006 [*] Wrong type passed to first argument of `@pytest.mark.pa
 11 11 |     ...
 12 12 | 
 
-PT006.py:14:26: PT006 [*] Wrong type passed to first argument of `@pytest.mark.parametrize`; expected `tuple`
+PT006.py:14:26: PT006 [*] Wrong type passed to first argument of `pytest.mark.parametrize`; expected `tuple`
    |
 14 | @pytest.mark.parametrize("   param1,   ,    param2   , ", [(1, 2), (3, 4)])
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PT006
@@ -40,7 +40,7 @@ PT006.py:14:26: PT006 [*] Wrong type passed to first argument of `@pytest.mark.p
 16 16 |     ...
 17 17 | 
 
-PT006.py:19:26: PT006 [*] Wrong type passed to first argument of `@pytest.mark.parametrize`; expected `tuple`
+PT006.py:19:26: PT006 [*] Wrong type passed to first argument of `pytest.mark.parametrize`; expected `tuple`
    |
 19 | @pytest.mark.parametrize("param1,param2", [(1, 2), (3, 4)])
    |                          ^^^^^^^^^^^^^^^ PT006
@@ -59,7 +59,7 @@ PT006.py:19:26: PT006 [*] Wrong type passed to first argument of `@pytest.mark.p
 21 21 |     ...
 22 22 | 
 
-PT006.py:29:26: PT006 [*] Wrong type passed to first argument of `@pytest.mark.parametrize`; expected `str`
+PT006.py:29:26: PT006 [*] Wrong type passed to first argument of `pytest.mark.parametrize`; expected `str`
    |
 29 | @pytest.mark.parametrize(("param1",), [1, 2, 3])
    |                          ^^^^^^^^^^^ PT006
@@ -78,7 +78,7 @@ PT006.py:29:26: PT006 [*] Wrong type passed to first argument of `@pytest.mark.p
 31 31 |     ...
 32 32 | 
 
-PT006.py:34:26: PT006 [*] Wrong type passed to first argument of `@pytest.mark.parametrize`; expected `tuple`
+PT006.py:34:26: PT006 [*] Wrong type passed to first argument of `pytest.mark.parametrize`; expected `tuple`
    |
 34 | @pytest.mark.parametrize(["param1", "param2"], [(1, 2), (3, 4)])
    |                          ^^^^^^^^^^^^^^^^^^^^ PT006
@@ -97,7 +97,7 @@ PT006.py:34:26: PT006 [*] Wrong type passed to first argument of `@pytest.mark.p
 36 36 |     ...
 37 37 | 
 
-PT006.py:39:26: PT006 [*] Wrong type passed to first argument of `@pytest.mark.parametrize`; expected `str`
+PT006.py:39:26: PT006 [*] Wrong type passed to first argument of `pytest.mark.parametrize`; expected `str`
    |
 39 | @pytest.mark.parametrize(["param1"], [1, 2, 3])
    |                          ^^^^^^^^^^ PT006
@@ -116,7 +116,7 @@ PT006.py:39:26: PT006 [*] Wrong type passed to first argument of `@pytest.mark.p
 41 41 |     ...
 42 42 | 
 
-PT006.py:44:26: PT006 [*] Wrong type passed to first argument of `@pytest.mark.parametrize`; expected `tuple`
+PT006.py:44:26: PT006 [*] Wrong type passed to first argument of `pytest.mark.parametrize`; expected `tuple`
    |
 44 | @pytest.mark.parametrize([some_expr, another_expr], [1, 2, 3])
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^ PT006
@@ -135,7 +135,7 @@ PT006.py:44:26: PT006 [*] Wrong type passed to first argument of `@pytest.mark.p
 46 46 |     ...
 47 47 | 
 
-PT006.py:49:26: PT006 [*] Wrong type passed to first argument of `@pytest.mark.parametrize`; expected `tuple`
+PT006.py:49:26: PT006 [*] Wrong type passed to first argument of `pytest.mark.parametrize`; expected `tuple`
    |
 49 | @pytest.mark.parametrize([some_expr, "param2"], [1, 2, 3])
    |                          ^^^^^^^^^^^^^^^^^^^^^ PT006
@@ -154,7 +154,7 @@ PT006.py:49:26: PT006 [*] Wrong type passed to first argument of `@pytest.mark.p
 51 51 |     ...
 52 52 | 
 
-PT006.py:54:26: PT006 [*] Wrong type passed to first argument of `@pytest.mark.parametrize`; expected `tuple`
+PT006.py:54:26: PT006 [*] Wrong type passed to first argument of `pytest.mark.parametrize`; expected `tuple`
    |
 54 | @pytest.mark.parametrize(("param1, " "param2, " "param3"), [(1, 2, 3), (4, 5, 6)])
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PT006
@@ -173,7 +173,7 @@ PT006.py:54:26: PT006 [*] Wrong type passed to first argument of `@pytest.mark.p
 56 56 |     ...
 57 57 | 
 
-PT006.py:59:26: PT006 [*] Wrong type passed to first argument of `@pytest.mark.parametrize`; expected `tuple`
+PT006.py:59:26: PT006 [*] Wrong type passed to first argument of `pytest.mark.parametrize`; expected `tuple`
    |
 59 | @pytest.mark.parametrize("param1, " "param2, " "param3", [(1, 2, 3), (4, 5, 6)])
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PT006
@@ -192,7 +192,7 @@ PT006.py:59:26: PT006 [*] Wrong type passed to first argument of `@pytest.mark.p
 61 61 |     ...
 62 62 | 
 
-PT006.py:64:26: PT006 [*] Wrong type passed to first argument of `@pytest.mark.parametrize`; expected `tuple`
+PT006.py:64:26: PT006 [*] Wrong type passed to first argument of `pytest.mark.parametrize`; expected `tuple`
    |
 64 | @pytest.mark.parametrize((("param1, " "param2, " "param3")), [(1, 2, 3), (4, 5, 6)])
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PT006
@@ -211,7 +211,7 @@ PT006.py:64:26: PT006 [*] Wrong type passed to first argument of `@pytest.mark.p
 66 66 |     ...
 67 67 | 
 
-PT006.py:69:26: PT006 [*] Wrong type passed to first argument of `@pytest.mark.parametrize`; expected `tuple`
+PT006.py:69:26: PT006 [*] Wrong type passed to first argument of `pytest.mark.parametrize`; expected `tuple`
    |
 69 | @pytest.mark.parametrize(("param1,param2"), [(1, 2), (3, 4)])
    |                          ^^^^^^^^^^^^^^^^^ PT006
@@ -230,7 +230,7 @@ PT006.py:69:26: PT006 [*] Wrong type passed to first argument of `@pytest.mark.p
 71 71 |     ...
 72 72 | 
 
-PT006.py:74:39: PT006 [*] Wrong type passed to first argument of `@pytest.mark.parametrize`; expected `tuple`
+PT006.py:74:39: PT006 [*] Wrong type passed to first argument of `pytest.mark.parametrize`; expected `tuple`
    |
 74 | parametrize = pytest.mark.parametrize(("param1,param2"), [(1, 2), (3, 4)])
    |                                       ^^^^^^^^^^^^^^^^^ PT006
@@ -249,7 +249,7 @@ PT006.py:74:39: PT006 [*] Wrong type passed to first argument of `@pytest.mark.p
 76 76 | @parametrize
 77 77 | def test_not_decorator(param1, param2):
 
-PT006.py:81:35: PT006 [*] Wrong type passed to first argument of `@pytest.mark.parametrize`; expected `tuple`
+PT006.py:81:35: PT006 [*] Wrong type passed to first argument of `pytest.mark.parametrize`; expected `tuple`
    |
 81 | @pytest.mark.parametrize(argnames=("param1,param2"), argvalues=[(1, 2), (3, 4)])
    |                                   ^^^^^^^^^^^^^^^^^ PT006


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Related to #14515. The rules for `pytest.mark.parametrize` check calls now, not decorators. `@` in the message can be removed.

## Test Plan

<!-- How was it tested? -->

Existing tests