### PR TITLE
Fix references for `async-busy-wait` 

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_async/rules/async_busy_wait.rs
+++ b/crates/ruff_linter/src/rules/flake8_async/rules/async_busy_wait.rs
@@ -35,8 +35,8 @@ use crate::rules::flake8_async::helpers::AsyncModule;
 ///
 /// ## References
 /// - [`asyncio` events](https://docs.python.org/3/library/asyncio-sync.html#asyncio.Event)
-/// - [`anyio` events](https://trio.readthedocs.io/en/latest/reference-core.html#trio.Event)
-/// - [`trio` events](https://anyio.readthedocs.io/en/latest/api.html#anyio.Event)
+/// - [`anyio` events](https://anyio.readthedocs.io/en/latest/api.html#anyio.Event)
+/// - [`trio` events](https://trio.readthedocs.io/en/latest/reference-core.html#trio.Event)
 #[derive(ViolationMetadata)]
 pub(crate) struct AsyncBusyWait {
     module: AsyncModule,


### PR DESCRIPTION
## Summary

This pull request fixes swapped documentation links for `anyio` and `trio` events, ensuring the correct references are provided for each library.

ref: https://docs.astral.sh/ruff/rules/async-busy-wait/#references

## Test Plan

No need
