### PR TITLE
[`flake8-pyi`] Skip all type definitions in `string-or-bytes-too-long (PYI053)`

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI053.pyi
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI053.pyi
@@ -67,5 +67,16 @@ def not_a_deprecated_function() -> None: ...
 
 fbaz: str = f"51 character {foo} stringgggggggggggggggggggggggggg"  # Error: PYI053
 
+from typing import TypeAlias, Literal, Annotated
+
 # see https://github.com/astral-sh/ruff/issues/12995
 def foo(bar: typing.Literal["a", "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"]):...
+
+# Ok
+def f(x: int) -> "AnnotationsForClassesWithVeryLongNamesInQuotesAsReturnTypes":...
+
+# Ok
+x: TypeAlias = Literal["fooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooO"]
+
+# Ok
+y: TypeAlias = Annotated[int, "metadataaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"]

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/string_or_bytes_too_long.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/string_or_bytes_too_long.rs
@@ -59,10 +59,7 @@ pub(crate) fn string_or_bytes_too_long(checker: &mut Checker, string: StringLike
         return;
     }
 
-    if semantic.in_type_definition()
-        | semantic.in_deferred_type_definition()
-        | semantic.in_typing_only_annotation()
-    {
+    if semantic.in_type_definition() | semantic.in_deferred_type_definition() {
         return;
     }
 

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/string_or_bytes_too_long.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/string_or_bytes_too_long.rs
@@ -59,7 +59,10 @@ pub(crate) fn string_or_bytes_too_long(checker: &mut Checker, string: StringLike
         return;
     }
 
-    if semantic.in_annotation() {
+    if semantic.in_type_definition()
+        | semantic.in_deferred_type_definition()
+        | semantic.in_typing_only_annotation()
+    {
         return;
     }
 

--- a/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI053_PYI053.pyi.snap
+++ b/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI053_PYI053.pyi.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_pyi/mod.rs
-snapshot_kind: text
 ---
 PYI053.pyi:7:14: PYI053 [*] String and bytes literals longer than 50 characters are not permitted
   |
@@ -154,7 +153,7 @@ PYI053.pyi:68:13: PYI053 [*] String and bytes literals longer than 50 characters
 68 | fbaz: str = f"51 character {foo} stringgggggggggggggggggggggggggg"  # Error: PYI053
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI053
 69 | 
-70 | # see https://github.com/astral-sh/ruff/issues/12995
+70 | from typing import TypeAlias, Literal, Annotated
    |
    = help: Replace with `...`
 
@@ -165,5 +164,5 @@ PYI053.pyi:68:13: PYI053 [*] String and bytes literals longer than 50 characters
 68    |-fbaz: str = f"51 character {foo} stringgggggggggggggggggggggggggg"  # Error: PYI053
    68 |+fbaz: str = ...  # Error: PYI053
 69 69 | 
-70 70 | # see https://github.com/astral-sh/ruff/issues/12995
-71 71 | def foo(bar: typing.Literal["a", "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"]):...
+70 70 | from typing import TypeAlias, Literal, Annotated
+71 71 |


### PR DESCRIPTION
This PR skips all type definitions (including annotations, quoted annotations, etc.) for the purposes of [string-or-bytes-too-long (PYI053)](https://docs.astral.sh/ruff/rules/string-or-bytes-too-long/#string-or-bytes-too-long-pyi053).

Closes #12995 (we hope)
Replaces #13020 
