### PR TITLE
[red-knot] Separate invalid syntax code snippets

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/invalid_syntax.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/invalid_syntax.md
@@ -2,6 +2,13 @@
 
 Test cases to ensure that red knot does not panic if there are syntax errors in the source code.
 
+The parser cannot recover from certain syntax errors completely which is why the number of syntax
+errors could be more than expected in the following examples. For instance, if there's a keyword
+(like `for`) in the middle of another statement (like function definition), then it's more likely
+that the rest of the tokens are going to be part of the `for` statement and not the function
+definition. But, it's not necessary that the remaining tokens are valid in the context of a `for`
+statement.
+
 ## Keyword as identifiers
 
 When keywords are used as identifiers, the parser recovers from this syntax error by emitting an
@@ -9,14 +16,24 @@ error and including the text value of the keyword to create the `Identifier` nod
 
 ### Name expression
 
+#### Assignment
+
 ```py
 # error: [invalid-syntax]
 pass = 1
+```
 
+#### Type alias
+
+```py
 # error: [invalid-syntax]
 # error: [invalid-syntax]
 type pass = 1
+```
 
+#### Function definition
+
+```py
 # error: [invalid-syntax]
 # error: [invalid-syntax]
 # error: [invalid-syntax]
@@ -24,20 +41,32 @@ type pass = 1
 # error: [invalid-syntax]
 def True(for):
     # error: [invalid-syntax]
+    # error: [invalid-syntax]
     pass
+```
 
-# error: [invalid-syntax]
+#### For
+
+```py
 # error: [invalid-syntax]
 # error: [invalid-syntax]
 # error: [unresolved-reference] "Name `pass` used when not defined"
 for while in pass:
     pass
+```
 
+#### While
+
+```py
 # error: [invalid-syntax]
 # error: [unresolved-reference] "Name `in` used when not defined"
 while in:
     pass
+```
 
+#### Match
+
+```py
 # error: [invalid-syntax]
 # error: [invalid-syntax]
 # error: [unresolved-reference] "Name `match` used when not defined"


### PR DESCRIPTION
Ref: https://github.com/astral-sh/ruff/pull/14788#discussion_r1872242283

This PR:
* Separates code snippets as individual tests for the invalid syntax cases
* Adds a general comment explaining why the parser could emit more syntax errors than expected