### PR TITLE
[airflow]: extend removed names (AIR302)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/airflow/AIR302_names.py
+++ b/crates/ruff_linter/resources/test/fixtures/airflow/AIR302_names.py
@@ -40,6 +40,7 @@ from airflow.utils.dates import (
     round_time,
     scale_time_units,
 )
+from airflow.utils.decorators import apply_defaults
 from airflow.utils.file import TemporaryDirectory, mkdirs
 from airflow.utils.helpers import chain, cross_downstream
 from airflow.utils.state import SHUTDOWN, terminating_states
@@ -91,6 +92,8 @@ BaseSensorOperator
 DateTimeSensor
 (ExternalTaskMarker, ExternalTaskSensor, ExternalTaskSensorLink)
 TimeDeltaSensor
+
+apply_defaults
 
 TemporaryDirectory
 mkdirs

--- a/crates/ruff_linter/resources/test/fixtures/airflow/AIR302_names.py
+++ b/crates/ruff_linter/resources/test/fixtures/airflow/AIR302_names.py
@@ -10,6 +10,7 @@ from airflow.configuration import (
     as_dict,
     set,
 )
+from airflow.contrib.aws_athena_hook import AWSAthenaHook
 from airflow.metrics.validators import AllowListValidator
 from airflow.metrics.validators import BlockListValidator
 from airflow.secrets.local_filesystem import get_connection, load_connections
@@ -31,6 +32,7 @@ from airflow.www.auth import has_access
 from airflow.www.utils import get_sensitive_variables_fields, should_hide_value_for_key
 
 
+AWSAthenaHook
 TaskStateTrigger
 
 requires_access

--- a/crates/ruff_linter/resources/test/fixtures/airflow/AIR302_names.py
+++ b/crates/ruff_linter/resources/test/fixtures/airflow/AIR302_names.py
@@ -14,6 +14,20 @@ from airflow.contrib.aws_athena_hook import AWSAthenaHook
 from airflow.metrics.validators import AllowListValidator
 from airflow.metrics.validators import BlockListValidator
 from airflow.operators.subdag import SubDagOperator
+from airflow.sensors.external_task import ExternalTaskSensorLink
+from airflow.operators.bash_operator import BashOperator
+from airflow.operators.branch_operator import BaseBranchOperator
+from airflow.operators.dummy import EmptyOperator, DummyOperator
+from airflow.operators import dummy_operator
+from airflow.operators.email_operator import EmailOperator
+from airflow.sensors.base_sensor_operator import BaseSensorOperator
+from airflow.sensors.date_time_sensor import DateTimeSensor
+from airflow.sensors.external_task_sensor import (
+    ExternalTaskMarker,
+    ExternalTaskSensor,
+    ExternalTaskSensorLink,
+)
+from airflow.sensors.time_delta_sensor import TimeDeltaSensor
 from airflow.secrets.local_filesystem import get_connection, load_connections
 from airflow.utils import dates
 from airflow.utils.dates import (
@@ -61,6 +75,19 @@ dates.datetime_to_nano
 get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
 
 get_connection, load_connections
+
+
+ExternalTaskSensorLink
+BashOperator
+BaseBranchOperator
+EmptyOperator, DummyOperator
+dummy_operator.EmptyOperator
+dummy_operator.DummyOperator
+EmailOperator
+BaseSensorOperator
+DateTimeSensor
+(ExternalTaskMarker, ExternalTaskSensor, ExternalTaskSensorLink)
+TimeDeltaSensor
 
 TemporaryDirectory
 mkdirs

--- a/crates/ruff_linter/resources/test/fixtures/airflow/AIR302_names.py
+++ b/crates/ruff_linter/resources/test/fixtures/airflow/AIR302_names.py
@@ -43,6 +43,7 @@ from airflow.utils.file import TemporaryDirectory, mkdirs
 from airflow.utils.helpers import chain, cross_downstream
 from airflow.utils.state import SHUTDOWN, terminating_states
 from airflow.utils.dag_cycle_tester import test_cycle
+from airflow.utils.trigger_rule import TriggerRule
 from airflow.www.auth import has_access
 from airflow.www.utils import get_sensitive_variables_fields, should_hide_value_for_key
 
@@ -97,6 +98,9 @@ cross_downstream
 
 SHUTDOWN
 terminating_states
+
+TriggerRule.DUMMY
+TriggerRule.NONE_FAILED_OR_SKIPPED
 
 test_cycle
 

--- a/crates/ruff_linter/resources/test/fixtures/airflow/AIR302_names.py
+++ b/crates/ruff_linter/resources/test/fixtures/airflow/AIR302_names.py
@@ -1,5 +1,4 @@
 from airflow.triggers.external_task import TaskStateTrigger
-from airflow.www.auth import has_access
 from airflow.api_connexion.security import requires_access
 from airflow.configuration import (
     get,
@@ -28,12 +27,12 @@ from airflow.utils.file import TemporaryDirectory, mkdirs
 from airflow.utils.helpers import chain, cross_downstream
 from airflow.utils.state import SHUTDOWN, terminating_states
 from airflow.utils.dag_cycle_tester import test_cycle
+from airflow.www.auth import has_access
+from airflow.www.utils import get_sensitive_variables_fields, should_hide_value_for_key
 
 
 TaskStateTrigger
 
-
-has_access
 requires_access
 
 AllowListValidator
@@ -68,3 +67,6 @@ SHUTDOWN
 terminating_states
 
 test_cycle
+
+has_access
+get_sensitive_variables_fields, should_hide_value_for_key

--- a/crates/ruff_linter/resources/test/fixtures/airflow/AIR302_names.py
+++ b/crates/ruff_linter/resources/test/fixtures/airflow/AIR302_names.py
@@ -14,6 +14,7 @@ from airflow.utils.dates import (
     scale_time_units,
 )
 from airflow.utils.file import TemporaryDirectory, mkdirs
+from airflow.utils.helpers import chain, cross_downstream
 from airflow.utils.state import SHUTDOWN, terminating_states
 from airflow.utils.dag_cycle_tester import test_cycle
 
@@ -45,8 +46,10 @@ dates.datetime_to_nano
 TemporaryDirectory
 mkdirs
 
+chain
+cross_downstream
+
 SHUTDOWN
 terminating_states
-
 
 test_cycle

--- a/crates/ruff_linter/resources/test/fixtures/airflow/AIR302_names.py
+++ b/crates/ruff_linter/resources/test/fixtures/airflow/AIR302_names.py
@@ -13,6 +13,7 @@ from airflow.configuration import (
 )
 from airflow.metrics.validators import AllowListValidator
 from airflow.metrics.validators import BlockListValidator
+from airflow.secrets.local_filesystem import get_connection, load_connections
 from airflow.utils import dates
 from airflow.utils.dates import (
     date_range,
@@ -54,6 +55,9 @@ datetime_to_nano
 dates.datetime_to_nano
 
 get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+
+get_connection, load_connections
+
 TemporaryDirectory
 mkdirs
 

--- a/crates/ruff_linter/resources/test/fixtures/airflow/AIR302_names.py
+++ b/crates/ruff_linter/resources/test/fixtures/airflow/AIR302_names.py
@@ -1,3 +1,4 @@
+from airflow import PY36, PY37, PY38, PY39, PY310, PY311, PY312
 from airflow.triggers.external_task import TaskStateTrigger
 from airflow.api_connexion.security import requires_access
 from airflow.configuration import (
@@ -47,6 +48,7 @@ from airflow.utils.trigger_rule import TriggerRule
 from airflow.www.auth import has_access
 from airflow.www.utils import get_sensitive_variables_fields, should_hide_value_for_key
 
+PY36, PY37, PY38, PY39, PY310, PY311, PY312
 
 AWSAthenaHook
 TaskStateTrigger

--- a/crates/ruff_linter/resources/test/fixtures/airflow/AIR302_names.py
+++ b/crates/ruff_linter/resources/test/fixtures/airflow/AIR302_names.py
@@ -1,6 +1,16 @@
 from airflow.triggers.external_task import TaskStateTrigger
 from airflow.www.auth import has_access
 from airflow.api_connexion.security import requires_access
+from airflow.configuration import (
+    get,
+    getboolean,
+    getfloat,
+    getint,
+    has_option,
+    remove_option,
+    as_dict,
+    set,
+)
 from airflow.metrics.validators import AllowListValidator
 from airflow.metrics.validators import BlockListValidator
 from airflow.utils import dates
@@ -43,6 +53,7 @@ infer_time_unit
 datetime_to_nano
 dates.datetime_to_nano
 
+get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
 TemporaryDirectory
 mkdirs
 

--- a/crates/ruff_linter/resources/test/fixtures/airflow/AIR302_names.py
+++ b/crates/ruff_linter/resources/test/fixtures/airflow/AIR302_names.py
@@ -13,6 +13,7 @@ from airflow.configuration import (
 from airflow.contrib.aws_athena_hook import AWSAthenaHook
 from airflow.metrics.validators import AllowListValidator
 from airflow.metrics.validators import BlockListValidator
+from airflow.operators.subdag import SubDagOperator
 from airflow.secrets.local_filesystem import get_connection, load_connections
 from airflow.utils import dates
 from airflow.utils.dates import (
@@ -39,6 +40,8 @@ requires_access
 
 AllowListValidator
 BlockListValidator
+
+SubDagOperator
 
 dates.date_range
 dates.days_ago

--- a/crates/ruff_linter/src/rules/airflow/rules/removal_in_3.rs
+++ b/crates/ruff_linter/src/rules/airflow/rules/removal_in_3.rs
@@ -160,6 +160,10 @@ fn removed_name(checker: &mut Checker, expr: &Expr, ranged: impl Ranged) {
                         "airflow.metrics.validators.PatternBlockListValidator".to_string(),
                     ),
                 )),
+                // airflow.operators
+                ["airflow", "operators", "subdag", ..] => {
+                    Some((qualname.to_string(), Replacement::None))
+                }
                 // airflow.secrets
                 ["airflow", "secrets", "local_filesystem", "load_connections"] => Some((
                     qualname.to_string(),

--- a/crates/ruff_linter/src/rules/airflow/rules/removal_in_3.rs
+++ b/crates/ruff_linter/src/rules/airflow/rules/removal_in_3.rs
@@ -112,6 +112,35 @@ fn removed_name(checker: &mut Checker, expr: &Expr, ranged: impl Ranged) {
                         "airflow.api_connexion.security.requires_access_*".to_string(),
                     ),
                 )),
+                // airflow.PY\d{1,2}
+                ["airflow", "PY36"] => Some((
+                    qualname.to_string(),
+                    Replacement::Name("sys.version_info".to_string()),
+                )),
+                ["airflow", "PY37"] => Some((
+                    qualname.to_string(),
+                    Replacement::Name("sys.version_info".to_string()),
+                )),
+                ["airflow", "PY38"] => Some((
+                    qualname.to_string(),
+                    Replacement::Name("sys.version_info".to_string()),
+                )),
+                ["airflow", "PY39"] => Some((
+                    qualname.to_string(),
+                    Replacement::Name("sys.version_info".to_string()),
+                )),
+                ["airflow", "PY310"] => Some((
+                    qualname.to_string(),
+                    Replacement::Name("sys.version_info".to_string()),
+                )),
+                ["airflow", "PY311"] => Some((
+                    qualname.to_string(),
+                    Replacement::Name("sys.version_info".to_string()),
+                )),
+                ["airflow", "PY312"] => Some((
+                    qualname.to_string(),
+                    Replacement::Name("sys.version_info".to_string()),
+                )),
                 // airflow.configuration
                 ["airflow", "configuration", "get"] => Some((
                     qualname.to_string(),

--- a/crates/ruff_linter/src/rules/airflow/rules/removal_in_3.rs
+++ b/crates/ruff_linter/src/rules/airflow/rules/removal_in_3.rs
@@ -106,10 +106,6 @@ fn removed_name(checker: &mut Checker, expr: &Expr, ranged: impl Ranged) {
                 ["airflow", "triggers", "external_task", "TaskStateTrigger"] => {
                     Some((qualname.to_string(), Replacement::None))
                 }
-                ["airflow", "www", "auth", "has_access"] => Some((
-                    qualname.to_string(),
-                    Replacement::Name("airflow.www.auth.has_access_*".to_string()),
-                )),
                 ["airflow", "api_connexion", "security", "requires_access"] => Some((
                     qualname.to_string(),
                     Replacement::Name(
@@ -149,6 +145,8 @@ fn removed_name(checker: &mut Checker, expr: &Expr, ranged: impl Ranged) {
                     qualname.to_string(),
                     Replacement::Name("airflow.configuration.conf.set".to_string()),
                 )),
+                // airflow.contrib.*
+                ["airflow", "contrib", ..] => Some((qualname.to_string(), Replacement::None)),
                 // airflow.metrics.validators
                 ["airflow", "metrics", "validators", "AllowListValidator"] => Some((
                     qualname.to_string(),
@@ -228,6 +226,10 @@ fn removed_name(checker: &mut Checker, expr: &Expr, ranged: impl Ranged) {
                     Some((qualname.to_string(), Replacement::None))
                 }
                 // airflow.www
+                ["airflow", "www", "auth", "has_access"] => Some((
+                    qualname.to_string(),
+                    Replacement::Name("airflow.www.auth.has_access_*".to_string()),
+                )),
                 ["airflow", "www", "utils", "get_sensitive_variables_fields"] => Some((
                     qualname.to_string(),
                     Replacement::Name(

--- a/crates/ruff_linter/src/rules/airflow/rules/removal_in_3.rs
+++ b/crates/ruff_linter/src/rules/airflow/rules/removal_in_3.rs
@@ -268,6 +268,7 @@ fn removed_name(checker: &mut Checker, expr: &Expr, ranged: impl Ranged) {
                     qualname.to_string(),
                     Replacement::Name("pendulum.today('UTC').add(days=-N, ...)".to_string()),
                 )),
+
                 // airflow.utils.helpers
                 ["airflow", "utils", "helpers", "chain"] => Some((
                     qualname.to_string(),
@@ -282,6 +283,13 @@ fn removed_name(checker: &mut Checker, expr: &Expr, ranged: impl Ranged) {
                     Some((qualname.to_string(), Replacement::None))
                 }
                 ["airflow", "utils", "state", "terminating_states"] => {
+                    Some((qualname.to_string(), Replacement::None))
+                }
+                // airflow.utils.trigger_rule
+                ["airflow", "utils", "trigger_rule", "TriggerRule", "DUMMY"] => {
+                    Some((qualname.to_string(), Replacement::None))
+                }
+                ["airflow", "utils", "trigger_rule", "TriggerRule", "NONE_FAILED_OR_SKIPPED"] => {
                     Some((qualname.to_string(), Replacement::None))
                 }
                 // airflow.uilts

--- a/crates/ruff_linter/src/rules/airflow/rules/removal_in_3.rs
+++ b/crates/ruff_linter/src/rules/airflow/rules/removal_in_3.rs
@@ -162,6 +162,19 @@ fn removed_name(checker: &mut Checker, expr: &Expr, ranged: impl Ranged) {
                         "airflow.metrics.validators.PatternBlockListValidator".to_string(),
                     ),
                 )),
+                // airflow.secrets
+                ["airflow", "secrets", "local_filesystem", "load_connections"] => Some((
+                    qualname.to_string(),
+                    Replacement::Name(
+                        "airflow.secrets.local_filesystem.load_connections_dict".to_string(),
+                    ),
+                )),
+                ["airflow", "secrets", "local_filesystem", "get_connection"] => Some((
+                    qualname.to_string(),
+                    Replacement::Name(
+                        "airflow.secrets.local_filesystem.load_connections_dict".to_string(),
+                    ),
+                )),
                 // airflow.utils.dates
                 ["airflow", "utils", "dates", "date_range"] => Some((
                     qualname.to_string(),

--- a/crates/ruff_linter/src/rules/airflow/rules/removal_in_3.rs
+++ b/crates/ruff_linter/src/rules/airflow/rules/removal_in_3.rs
@@ -10,6 +10,7 @@ use crate::checkers::ast::Checker;
 enum Replacement {
     None,
     Name(String),
+    Message(String),
 }
 
 /// ## What it does
@@ -52,6 +53,9 @@ impl Violation for Airflow3Removal {
             Replacement::None => format!("`{deprecated}` is removed in Airflow 3.0"),
             Replacement::Name(name) => {
                 format!("`{deprecated}` is removed in Airflow 3.0; use `{name}` instead")
+            }
+            Replacement::Message(message) => {
+                format!("`{deprecated}` is removed in Airflow 3.0; {message}")
             }
         }
     }
@@ -325,9 +329,13 @@ fn removed_name(checker: &mut Checker, expr: &Expr, ranged: impl Ranged) {
                 ["airflow", "utils", "dag_cycle_tester", "test_cycle"] => {
                     Some((qualname.to_string(), Replacement::None))
                 }
-                ["airflow", "utils", "decorators", "apply_defaults"] => {
-                    Some((qualname.to_string(), Replacement::None))
-                }
+                ["airflow", "utils", "decorators", "apply_defaults"] => Some((
+                    qualname.to_string(),
+                    Replacement::Message(
+                        "`apply_defaults` is now unconditionally done and can be safely removed."
+                            .to_string(),
+                    ),
+                )),
                 // airflow.www
                 ["airflow", "www", "auth", "has_access"] => Some((
                     qualname.to_string(),

--- a/crates/ruff_linter/src/rules/airflow/rules/removal_in_3.rs
+++ b/crates/ruff_linter/src/rules/airflow/rules/removal_in_3.rs
@@ -164,6 +164,68 @@ fn removed_name(checker: &mut Checker, expr: &Expr, ranged: impl Ranged) {
                 ["airflow", "operators", "subdag", ..] => {
                     Some((qualname.to_string(), Replacement::None))
                 }
+                ["airflow.sensors.external_task.ExternalTaskSensorLink"] => Some((
+                    qualname.to_string(),
+                    Replacement::Name("airflow.sensors.external_task.ExternalDagLin".to_string()),
+                )),
+                ["airflow", "operators", "bash_operator", "BashOperator"] => Some((
+                    qualname.to_string(),
+                    Replacement::Name("airflow.operators.bash.BashOperator".to_string()),
+                )),
+                ["airflow", "operators", "branch_operator", "BaseBranchOperator"] => Some((
+                    qualname.to_string(),
+                    Replacement::Name("airflow.operators.branch.BaseBranchOperator".to_string()),
+                )),
+                ["airflow", "operators", " dummy", "EmptyOperator"] => Some((
+                    qualname.to_string(),
+                    Replacement::Name("airflow.operators.empty.EmptyOperator".to_string()),
+                )),
+                ["airflow", "operators", "dummy", "DummyOperator"] => Some((
+                    qualname.to_string(),
+                    Replacement::Name("airflow.operators.empty.EmptyOperator".to_string()),
+                )),
+                ["airflow", "operators", "dummy_operator", "EmptyOperator"] => Some((
+                    qualname.to_string(),
+                    Replacement::Name("airflow.operators.empty.EmptyOperator".to_string()),
+                )),
+                ["airflow", "operators", "dummy_operator", "DummyOperator"] => Some((
+                    qualname.to_string(),
+                    Replacement::Name("airflow.operators.empty.EmptyOperator".to_string()),
+                )),
+                ["airflow", "operators", "email_operator", "EmailOperator"] => Some((
+                    qualname.to_string(),
+                    Replacement::Name("airflow.operators.email.EmailOperator".to_string()),
+                )),
+                ["airflow", "sensors", "base_sensor_operator", "BaseSensorOperator"] => Some((
+                    qualname.to_string(),
+                    Replacement::Name("airflow.sensors.base.BaseSensorOperator".to_string()),
+                )),
+                ["airflow", "sensors", "date_time_sensor", "DateTimeSensor"] => Some((
+                    qualname.to_string(),
+                    Replacement::Name("airflow.sensors.date_time.DateTimeSensor".to_string()),
+                )),
+                ["airflow", "sensors", "external_task_sensor", "ExternalTaskMarker"] => Some((
+                    qualname.to_string(),
+                    Replacement::Name(
+                        "airflow.sensors.external_task.ExternalTaskMarker".to_string(),
+                    ),
+                )),
+                ["airflow", "sensors", "external_task_sensor", "ExternalTaskSensor"] => Some((
+                    qualname.to_string(),
+                    Replacement::Name(
+                        "airflow.sensors.external_task.ExternalTaskSensor".to_string(),
+                    ),
+                )),
+                ["airflow", "sensors", "external_task_sensor", "ExternalTaskSensorLink"] => Some((
+                    qualname.to_string(),
+                    Replacement::Name(
+                        "airflow.sensors.external_task.ExternalTaskSensorLink".to_string(),
+                    ),
+                )),
+                ["airflow", "sensors", "time_delta_sensor", "TimeDeltaSensor"] => Some((
+                    qualname.to_string(),
+                    Replacement::Name("airflow.sensors.time_delta.TimeDeltaSensor".to_string()),
+                )),
                 // airflow.secrets
                 ["airflow", "secrets", "local_filesystem", "load_connections"] => Some((
                     qualname.to_string(),

--- a/crates/ruff_linter/src/rules/airflow/rules/removal_in_3.rs
+++ b/crates/ruff_linter/src/rules/airflow/rules/removal_in_3.rs
@@ -227,6 +227,20 @@ fn removed_name(checker: &mut Checker, expr: &Expr, ranged: impl Ranged) {
                 ["airflow", "utils", "decorators", "apply_defaults"] => {
                     Some((qualname.to_string(), Replacement::None))
                 }
+                // airflow.www
+                ["airflow", "www", "utils", "get_sensitive_variables_fields"] => Some((
+                    qualname.to_string(),
+                    Replacement::Name(
+                        "airflow.utils.log.secrets_masker.get_sensitive_variables_fields"
+                            .to_string(),
+                    ),
+                )),
+                ["airflow", "www", "utils", "should_hide_value_for_key"] => Some((
+                    qualname.to_string(),
+                    Replacement::Name(
+                        "airflow.utils.log.secrets_masker.should_hide_value_for_key".to_string(),
+                    ),
+                )),
                 _ => None,
             });
     if let Some((deprecated, replacement)) = result {

--- a/crates/ruff_linter/src/rules/airflow/rules/removal_in_3.rs
+++ b/crates/ruff_linter/src/rules/airflow/rules/removal_in_3.rs
@@ -116,6 +116,39 @@ fn removed_name(checker: &mut Checker, expr: &Expr, ranged: impl Ranged) {
                         "airflow.api_connexion.security.requires_access_*".to_string(),
                     ),
                 )),
+                // airflow.configuration
+                ["airflow", "configuration", "get"] => Some((
+                    qualname.to_string(),
+                    Replacement::Name("airflow.configuration.conf.get".to_string()),
+                )),
+                ["airflow", "configuration", "getboolean"] => Some((
+                    qualname.to_string(),
+                    Replacement::Name("airflow.configuration.conf.getboolean".to_string()),
+                )),
+                ["airflow", "configuration", "getfloat"] => Some((
+                    qualname.to_string(),
+                    Replacement::Name("airflow.configuration.conf.getfloat".to_string()),
+                )),
+                ["airflow", "configuration", "getint"] => Some((
+                    qualname.to_string(),
+                    Replacement::Name("airflow.configuration.conf.getint".to_string()),
+                )),
+                ["airflow", "configuration", "has_option"] => Some((
+                    qualname.to_string(),
+                    Replacement::Name("airflow.configuration.conf.has_option".to_string()),
+                )),
+                ["airflow", "configuration", "remove_option"] => Some((
+                    qualname.to_string(),
+                    Replacement::Name("airflow.configuration.conf.remove_option".to_string()),
+                )),
+                ["airflow", "configuration", "as_dict"] => Some((
+                    qualname.to_string(),
+                    Replacement::Name("airflow.configuration.conf.as_dict".to_string()),
+                )),
+                ["airflow", "configuration", "set"] => Some((
+                    qualname.to_string(),
+                    Replacement::Name("airflow.configuration.conf.set".to_string()),
+                )),
                 // airflow.metrics.validators
                 ["airflow", "metrics", "validators", "AllowListValidator"] => Some((
                     qualname.to_string(),

--- a/crates/ruff_linter/src/rules/airflow/rules/removal_in_3.rs
+++ b/crates/ruff_linter/src/rules/airflow/rules/removal_in_3.rs
@@ -158,6 +158,15 @@ fn removed_name(checker: &mut Checker, expr: &Expr, ranged: impl Ranged) {
                     qualname.to_string(),
                     Replacement::Name("pendulum.today('UTC').add(days=-N, ...)".to_string()),
                 )),
+                // airflow.utils.helpers
+                ["airflow", "utils", "helpers", "chain"] => Some((
+                    qualname.to_string(),
+                    Replacement::Name("airflow.models.baseoperator.chain".to_string()),
+                )),
+                ["airflow", "utils", "helpers", "cross_downstream"] => Some((
+                    qualname.to_string(),
+                    Replacement::Name("airflow.models.baseoperator.cross_downstream".to_string()),
+                )),
                 // airflow.utils.state
                 ["airflow", "utils", "state", "SHUTDOWN"] => {
                     Some((qualname.to_string(), Replacement::None))

--- a/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_names.py.snap
+++ b/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_names.py.snap
@@ -2,178 +2,258 @@
 source: crates/ruff_linter/src/rules/airflow/mod.rs
 snapshot_kind: text
 ---
-AIR302_names.py:22:1: AIR302 `airflow.triggers.external_task.TaskStateTrigger` is removed in Airflow 3.0
+AIR302_names.py:32:1: AIR302 `airflow.triggers.external_task.TaskStateTrigger` is removed in Airflow 3.0
    |
-22 | TaskStateTrigger
+32 | TaskStateTrigger
    | ^^^^^^^^^^^^^^^^ AIR302
    |
 
-AIR302_names.py:25:1: AIR302 `airflow.www.auth.has_access` is removed in Airflow 3.0; use `airflow.www.auth.has_access_*` instead
+AIR302_names.py:35:1: AIR302 `airflow.www.auth.has_access` is removed in Airflow 3.0; use `airflow.www.auth.has_access_*` instead
    |
-25 | has_access
+35 | has_access
    | ^^^^^^^^^^ AIR302
-26 | requires_access
+36 | requires_access
    |
 
-AIR302_names.py:26:1: AIR302 `airflow.api_connexion.security.requires_access` is removed in Airflow 3.0; use `airflow.api_connexion.security.requires_access_*` instead
+AIR302_names.py:36:1: AIR302 `airflow.api_connexion.security.requires_access` is removed in Airflow 3.0; use `airflow.api_connexion.security.requires_access_*` instead
    |
-25 | has_access
-26 | requires_access
+35 | has_access
+36 | requires_access
    | ^^^^^^^^^^^^^^^ AIR302
-27 | 
-28 | AllowListValidator
+37 | 
+38 | AllowListValidator
    |
 
-AIR302_names.py:28:1: AIR302 `airflow.metrics.validators.AllowListValidator` is removed in Airflow 3.0; use `airflow.metrics.validators.PatternAllowListValidator` instead
+AIR302_names.py:38:1: AIR302 `airflow.metrics.validators.AllowListValidator` is removed in Airflow 3.0; use `airflow.metrics.validators.PatternAllowListValidator` instead
    |
-26 | requires_access
-27 | 
-28 | AllowListValidator
+36 | requires_access
+37 | 
+38 | AllowListValidator
    | ^^^^^^^^^^^^^^^^^^ AIR302
-29 | BlockListValidator
+39 | BlockListValidator
    |
 
-AIR302_names.py:29:1: AIR302 `airflow.metrics.validators.BlockListValidator` is removed in Airflow 3.0; use `airflow.metrics.validators.PatternBlockListValidator` instead
+AIR302_names.py:39:1: AIR302 `airflow.metrics.validators.BlockListValidator` is removed in Airflow 3.0; use `airflow.metrics.validators.PatternBlockListValidator` instead
    |
-28 | AllowListValidator
-29 | BlockListValidator
+38 | AllowListValidator
+39 | BlockListValidator
    | ^^^^^^^^^^^^^^^^^^ AIR302
-30 | 
-31 | dates.date_range
+40 | 
+41 | dates.date_range
    |
 
-AIR302_names.py:31:7: AIR302 `airflow.utils.dates.date_range` is removed in Airflow 3.0; use `airflow.timetables.` instead
+AIR302_names.py:41:7: AIR302 `airflow.utils.dates.date_range` is removed in Airflow 3.0; use `airflow.timetables.` instead
    |
-29 | BlockListValidator
-30 | 
-31 | dates.date_range
+39 | BlockListValidator
+40 | 
+41 | dates.date_range
    |       ^^^^^^^^^^ AIR302
-32 | dates.days_ago
+42 | dates.days_ago
    |
 
-AIR302_names.py:32:7: AIR302 `airflow.utils.dates.days_ago` is removed in Airflow 3.0; use `pendulum.today('UTC').add(days=-N, ...)` instead
+AIR302_names.py:42:7: AIR302 `airflow.utils.dates.days_ago` is removed in Airflow 3.0; use `pendulum.today('UTC').add(days=-N, ...)` instead
    |
-31 | dates.date_range
-32 | dates.days_ago
+41 | dates.date_range
+42 | dates.days_ago
    |       ^^^^^^^^ AIR302
-33 | 
-34 | date_range
+43 | 
+44 | date_range
    |
 
-AIR302_names.py:34:1: AIR302 `airflow.utils.dates.date_range` is removed in Airflow 3.0; use `airflow.timetables.` instead
+AIR302_names.py:44:1: AIR302 `airflow.utils.dates.date_range` is removed in Airflow 3.0; use `airflow.timetables.` instead
    |
-32 | dates.days_ago
-33 | 
-34 | date_range
+42 | dates.days_ago
+43 | 
+44 | date_range
    | ^^^^^^^^^^ AIR302
-35 | days_ago
-36 | parse_execution_date
+45 | days_ago
+46 | parse_execution_date
    |
 
-AIR302_names.py:35:1: AIR302 `airflow.utils.dates.days_ago` is removed in Airflow 3.0; use `pendulum.today('UTC').add(days=-N, ...)` instead
+AIR302_names.py:45:1: AIR302 `airflow.utils.dates.days_ago` is removed in Airflow 3.0; use `pendulum.today('UTC').add(days=-N, ...)` instead
    |
-34 | date_range
-35 | days_ago
+44 | date_range
+45 | days_ago
    | ^^^^^^^^ AIR302
-36 | parse_execution_date
-37 | round_time
+46 | parse_execution_date
+47 | round_time
    |
 
-AIR302_names.py:36:1: AIR302 `airflow.utils.dates.parse_execution_date` is removed in Airflow 3.0
+AIR302_names.py:46:1: AIR302 `airflow.utils.dates.parse_execution_date` is removed in Airflow 3.0
    |
-34 | date_range
-35 | days_ago
-36 | parse_execution_date
+44 | date_range
+45 | days_ago
+46 | parse_execution_date
    | ^^^^^^^^^^^^^^^^^^^^ AIR302
-37 | round_time
-38 | scale_time_units
+47 | round_time
+48 | scale_time_units
    |
 
-AIR302_names.py:37:1: AIR302 `airflow.utils.dates.round_time` is removed in Airflow 3.0
+AIR302_names.py:47:1: AIR302 `airflow.utils.dates.round_time` is removed in Airflow 3.0
    |
-35 | days_ago
-36 | parse_execution_date
-37 | round_time
+45 | days_ago
+46 | parse_execution_date
+47 | round_time
    | ^^^^^^^^^^ AIR302
-38 | scale_time_units
-39 | infer_time_unit
+48 | scale_time_units
+49 | infer_time_unit
    |
 
-AIR302_names.py:38:1: AIR302 `airflow.utils.dates.scale_time_units` is removed in Airflow 3.0
+AIR302_names.py:48:1: AIR302 `airflow.utils.dates.scale_time_units` is removed in Airflow 3.0
    |
-36 | parse_execution_date
-37 | round_time
-38 | scale_time_units
+46 | parse_execution_date
+47 | round_time
+48 | scale_time_units
    | ^^^^^^^^^^^^^^^^ AIR302
-39 | infer_time_unit
+49 | infer_time_unit
    |
 
-AIR302_names.py:39:1: AIR302 `airflow.utils.dates.infer_time_unit` is removed in Airflow 3.0
+AIR302_names.py:49:1: AIR302 `airflow.utils.dates.infer_time_unit` is removed in Airflow 3.0
    |
-37 | round_time
-38 | scale_time_units
-39 | infer_time_unit
+47 | round_time
+48 | scale_time_units
+49 | infer_time_unit
    | ^^^^^^^^^^^^^^^ AIR302
    |
 
-AIR302_names.py:46:1: AIR302 `airflow.utils.file.TemporaryDirectory` is removed in Airflow 3.0
+AIR302_names.py:56:1: AIR302 `airflow.configuration.get` is removed in Airflow 3.0; use `airflow.configuration.conf.get` instead
    |
-44 | dates.datetime_to_nano
-45 | 
-46 | TemporaryDirectory
-   | ^^^^^^^^^^^^^^^^^^ AIR302
-47 | mkdirs
+54 | dates.datetime_to_nano
+55 | 
+56 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+   | ^^^ AIR302
+57 | TemporaryDirectory
+58 | mkdirs
    |
 
-AIR302_names.py:47:1: AIR302 `airflow.utils.file.mkdirs` is removed in Airflow 3.0; use `pendulum.today('UTC').add(days=-N, ...)` instead
+AIR302_names.py:56:6: AIR302 `airflow.configuration.getboolean` is removed in Airflow 3.0; use `airflow.configuration.conf.getboolean` instead
    |
-46 | TemporaryDirectory
-47 | mkdirs
+54 | dates.datetime_to_nano
+55 | 
+56 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+   |      ^^^^^^^^^^ AIR302
+57 | TemporaryDirectory
+58 | mkdirs
+   |
+
+AIR302_names.py:56:18: AIR302 `airflow.configuration.getfloat` is removed in Airflow 3.0; use `airflow.configuration.conf.getfloat` instead
+   |
+54 | dates.datetime_to_nano
+55 | 
+56 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+   |                  ^^^^^^^^ AIR302
+57 | TemporaryDirectory
+58 | mkdirs
+   |
+
+AIR302_names.py:56:28: AIR302 `airflow.configuration.getint` is removed in Airflow 3.0; use `airflow.configuration.conf.getint` instead
+   |
+54 | dates.datetime_to_nano
+55 | 
+56 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+   |                            ^^^^^^ AIR302
+57 | TemporaryDirectory
+58 | mkdirs
+   |
+
+AIR302_names.py:56:36: AIR302 `airflow.configuration.has_option` is removed in Airflow 3.0; use `airflow.configuration.conf.has_option` instead
+   |
+54 | dates.datetime_to_nano
+55 | 
+56 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+   |                                    ^^^^^^^^^^ AIR302
+57 | TemporaryDirectory
+58 | mkdirs
+   |
+
+AIR302_names.py:56:48: AIR302 `airflow.configuration.remove_option` is removed in Airflow 3.0; use `airflow.configuration.conf.remove_option` instead
+   |
+54 | dates.datetime_to_nano
+55 | 
+56 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+   |                                                ^^^^^^^^^^^^^ AIR302
+57 | TemporaryDirectory
+58 | mkdirs
+   |
+
+AIR302_names.py:56:63: AIR302 `airflow.configuration.as_dict` is removed in Airflow 3.0; use `airflow.configuration.conf.as_dict` instead
+   |
+54 | dates.datetime_to_nano
+55 | 
+56 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+   |                                                               ^^^^^^^ AIR302
+57 | TemporaryDirectory
+58 | mkdirs
+   |
+
+AIR302_names.py:56:72: AIR302 `airflow.configuration.set` is removed in Airflow 3.0; use `airflow.configuration.conf.set` instead
+   |
+54 | dates.datetime_to_nano
+55 | 
+56 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+   |                                                                        ^^^ AIR302
+57 | TemporaryDirectory
+58 | mkdirs
+   |
+
+AIR302_names.py:57:1: AIR302 `airflow.utils.file.TemporaryDirectory` is removed in Airflow 3.0
+   |
+56 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+57 | TemporaryDirectory
+   | ^^^^^^^^^^^^^^^^^^ AIR302
+58 | mkdirs
+   |
+
+AIR302_names.py:58:1: AIR302 `airflow.utils.file.mkdirs` is removed in Airflow 3.0; use `pendulum.today('UTC').add(days=-N, ...)` instead
+   |
+56 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+57 | TemporaryDirectory
+58 | mkdirs
    | ^^^^^^ AIR302
-48 | 
-49 | chain
+59 | 
+60 | chain
    |
 
-AIR302_names.py:49:1: AIR302 `airflow.utils.helpers.chain` is removed in Airflow 3.0; use `airflow.models.baseoperator.chain` instead
+AIR302_names.py:60:1: AIR302 `airflow.utils.helpers.chain` is removed in Airflow 3.0; use `airflow.models.baseoperator.chain` instead
    |
-47 | mkdirs
-48 | 
-49 | chain
+58 | mkdirs
+59 | 
+60 | chain
    | ^^^^^ AIR302
-50 | cross_downstream
+61 | cross_downstream
    |
 
-AIR302_names.py:50:1: AIR302 `airflow.utils.helpers.cross_downstream` is removed in Airflow 3.0; use `airflow.models.baseoperator.cross_downstream` instead
+AIR302_names.py:61:1: AIR302 `airflow.utils.helpers.cross_downstream` is removed in Airflow 3.0; use `airflow.models.baseoperator.cross_downstream` instead
    |
-49 | chain
-50 | cross_downstream
+60 | chain
+61 | cross_downstream
    | ^^^^^^^^^^^^^^^^ AIR302
-51 | 
-52 | SHUTDOWN
+62 | 
+63 | SHUTDOWN
    |
 
-AIR302_names.py:52:1: AIR302 `airflow.utils.state.SHUTDOWN` is removed in Airflow 3.0
+AIR302_names.py:63:1: AIR302 `airflow.utils.state.SHUTDOWN` is removed in Airflow 3.0
    |
-50 | cross_downstream
-51 | 
-52 | SHUTDOWN
+61 | cross_downstream
+62 | 
+63 | SHUTDOWN
    | ^^^^^^^^ AIR302
-53 | terminating_states
+64 | terminating_states
    |
 
-AIR302_names.py:53:1: AIR302 `airflow.utils.state.terminating_states` is removed in Airflow 3.0
+AIR302_names.py:64:1: AIR302 `airflow.utils.state.terminating_states` is removed in Airflow 3.0
    |
-52 | SHUTDOWN
-53 | terminating_states
+63 | SHUTDOWN
+64 | terminating_states
    | ^^^^^^^^^^^^^^^^^^ AIR302
-54 | 
-55 | test_cycle
+65 | 
+66 | test_cycle
    |
 
-AIR302_names.py:55:1: AIR302 `airflow.utils.dag_cycle_tester.test_cycle` is removed in Airflow 3.0
+AIR302_names.py:66:1: AIR302 `airflow.utils.dag_cycle_tester.test_cycle` is removed in Airflow 3.0
    |
-53 | terminating_states
-54 | 
-55 | test_cycle
+64 | terminating_states
+65 | 
+66 | test_cycle
    | ^^^^^^^^^^ AIR302
    |

--- a/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_names.py.snap
+++ b/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_names.py.snap
@@ -2,299 +2,307 @@
 source: crates/ruff_linter/src/rules/airflow/mod.rs
 snapshot_kind: text
 ---
-AIR302_names.py:34:1: AIR302 `airflow.triggers.external_task.TaskStateTrigger` is removed in Airflow 3.0
+AIR302_names.py:35:1: AIR302 `airflow.contrib.aws_athena_hook.AWSAthenaHook` is removed in Airflow 3.0
    |
-34 | TaskStateTrigger
+35 | AWSAthenaHook
+   | ^^^^^^^^^^^^^ AIR302
+36 | TaskStateTrigger
+   |
+
+AIR302_names.py:36:1: AIR302 `airflow.triggers.external_task.TaskStateTrigger` is removed in Airflow 3.0
+   |
+35 | AWSAthenaHook
+36 | TaskStateTrigger
    | ^^^^^^^^^^^^^^^^ AIR302
-35 | 
-36 | requires_access
+37 | 
+38 | requires_access
    |
 
-AIR302_names.py:36:1: AIR302 `airflow.api_connexion.security.requires_access` is removed in Airflow 3.0; use `airflow.api_connexion.security.requires_access_*` instead
+AIR302_names.py:38:1: AIR302 `airflow.api_connexion.security.requires_access` is removed in Airflow 3.0; use `airflow.api_connexion.security.requires_access_*` instead
    |
-34 | TaskStateTrigger
-35 | 
-36 | requires_access
+36 | TaskStateTrigger
+37 | 
+38 | requires_access
    | ^^^^^^^^^^^^^^^ AIR302
-37 | 
-38 | AllowListValidator
+39 | 
+40 | AllowListValidator
    |
 
-AIR302_names.py:38:1: AIR302 `airflow.metrics.validators.AllowListValidator` is removed in Airflow 3.0; use `airflow.metrics.validators.PatternAllowListValidator` instead
+AIR302_names.py:40:1: AIR302 `airflow.metrics.validators.AllowListValidator` is removed in Airflow 3.0; use `airflow.metrics.validators.PatternAllowListValidator` instead
    |
-36 | requires_access
-37 | 
-38 | AllowListValidator
+38 | requires_access
+39 | 
+40 | AllowListValidator
    | ^^^^^^^^^^^^^^^^^^ AIR302
-39 | BlockListValidator
+41 | BlockListValidator
    |
 
-AIR302_names.py:39:1: AIR302 `airflow.metrics.validators.BlockListValidator` is removed in Airflow 3.0; use `airflow.metrics.validators.PatternBlockListValidator` instead
+AIR302_names.py:41:1: AIR302 `airflow.metrics.validators.BlockListValidator` is removed in Airflow 3.0; use `airflow.metrics.validators.PatternBlockListValidator` instead
    |
-38 | AllowListValidator
-39 | BlockListValidator
+40 | AllowListValidator
+41 | BlockListValidator
    | ^^^^^^^^^^^^^^^^^^ AIR302
-40 | 
-41 | dates.date_range
+42 | 
+43 | dates.date_range
    |
 
-AIR302_names.py:41:7: AIR302 `airflow.utils.dates.date_range` is removed in Airflow 3.0; use `airflow.timetables.` instead
+AIR302_names.py:43:7: AIR302 `airflow.utils.dates.date_range` is removed in Airflow 3.0; use `airflow.timetables.` instead
    |
-39 | BlockListValidator
-40 | 
-41 | dates.date_range
+41 | BlockListValidator
+42 | 
+43 | dates.date_range
    |       ^^^^^^^^^^ AIR302
-42 | dates.days_ago
+44 | dates.days_ago
    |
 
-AIR302_names.py:42:7: AIR302 `airflow.utils.dates.days_ago` is removed in Airflow 3.0; use `pendulum.today('UTC').add(days=-N, ...)` instead
+AIR302_names.py:44:7: AIR302 `airflow.utils.dates.days_ago` is removed in Airflow 3.0; use `pendulum.today('UTC').add(days=-N, ...)` instead
    |
-41 | dates.date_range
-42 | dates.days_ago
+43 | dates.date_range
+44 | dates.days_ago
    |       ^^^^^^^^ AIR302
-43 | 
-44 | date_range
+45 | 
+46 | date_range
    |
 
-AIR302_names.py:44:1: AIR302 `airflow.utils.dates.date_range` is removed in Airflow 3.0; use `airflow.timetables.` instead
+AIR302_names.py:46:1: AIR302 `airflow.utils.dates.date_range` is removed in Airflow 3.0; use `airflow.timetables.` instead
    |
-42 | dates.days_ago
-43 | 
-44 | date_range
+44 | dates.days_ago
+45 | 
+46 | date_range
    | ^^^^^^^^^^ AIR302
-45 | days_ago
-46 | parse_execution_date
+47 | days_ago
+48 | parse_execution_date
    |
 
-AIR302_names.py:45:1: AIR302 `airflow.utils.dates.days_ago` is removed in Airflow 3.0; use `pendulum.today('UTC').add(days=-N, ...)` instead
+AIR302_names.py:47:1: AIR302 `airflow.utils.dates.days_ago` is removed in Airflow 3.0; use `pendulum.today('UTC').add(days=-N, ...)` instead
    |
-44 | date_range
-45 | days_ago
+46 | date_range
+47 | days_ago
    | ^^^^^^^^ AIR302
-46 | parse_execution_date
-47 | round_time
+48 | parse_execution_date
+49 | round_time
    |
 
-AIR302_names.py:46:1: AIR302 `airflow.utils.dates.parse_execution_date` is removed in Airflow 3.0
+AIR302_names.py:48:1: AIR302 `airflow.utils.dates.parse_execution_date` is removed in Airflow 3.0
    |
-44 | date_range
-45 | days_ago
-46 | parse_execution_date
+46 | date_range
+47 | days_ago
+48 | parse_execution_date
    | ^^^^^^^^^^^^^^^^^^^^ AIR302
-47 | round_time
-48 | scale_time_units
+49 | round_time
+50 | scale_time_units
    |
 
-AIR302_names.py:47:1: AIR302 `airflow.utils.dates.round_time` is removed in Airflow 3.0
+AIR302_names.py:49:1: AIR302 `airflow.utils.dates.round_time` is removed in Airflow 3.0
    |
-45 | days_ago
-46 | parse_execution_date
-47 | round_time
+47 | days_ago
+48 | parse_execution_date
+49 | round_time
    | ^^^^^^^^^^ AIR302
-48 | scale_time_units
-49 | infer_time_unit
+50 | scale_time_units
+51 | infer_time_unit
    |
 
-AIR302_names.py:48:1: AIR302 `airflow.utils.dates.scale_time_units` is removed in Airflow 3.0
+AIR302_names.py:50:1: AIR302 `airflow.utils.dates.scale_time_units` is removed in Airflow 3.0
    |
-46 | parse_execution_date
-47 | round_time
-48 | scale_time_units
+48 | parse_execution_date
+49 | round_time
+50 | scale_time_units
    | ^^^^^^^^^^^^^^^^ AIR302
-49 | infer_time_unit
+51 | infer_time_unit
    |
 
-AIR302_names.py:49:1: AIR302 `airflow.utils.dates.infer_time_unit` is removed in Airflow 3.0
+AIR302_names.py:51:1: AIR302 `airflow.utils.dates.infer_time_unit` is removed in Airflow 3.0
    |
-47 | round_time
-48 | scale_time_units
-49 | infer_time_unit
+49 | round_time
+50 | scale_time_units
+51 | infer_time_unit
    | ^^^^^^^^^^^^^^^ AIR302
    |
 
-AIR302_names.py:56:1: AIR302 `airflow.configuration.get` is removed in Airflow 3.0; use `airflow.configuration.conf.get` instead
+AIR302_names.py:58:1: AIR302 `airflow.configuration.get` is removed in Airflow 3.0; use `airflow.configuration.conf.get` instead
    |
-54 | dates.datetime_to_nano
-55 | 
-56 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+56 | dates.datetime_to_nano
+57 | 
+58 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
    | ^^^ AIR302
-57 | 
-58 | get_connection, load_connections
+59 | 
+60 | get_connection, load_connections
    |
 
-AIR302_names.py:56:6: AIR302 `airflow.configuration.getboolean` is removed in Airflow 3.0; use `airflow.configuration.conf.getboolean` instead
+AIR302_names.py:58:6: AIR302 `airflow.configuration.getboolean` is removed in Airflow 3.0; use `airflow.configuration.conf.getboolean` instead
    |
-54 | dates.datetime_to_nano
-55 | 
-56 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+56 | dates.datetime_to_nano
+57 | 
+58 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
    |      ^^^^^^^^^^ AIR302
-57 | 
-58 | get_connection, load_connections
+59 | 
+60 | get_connection, load_connections
    |
 
-AIR302_names.py:56:18: AIR302 `airflow.configuration.getfloat` is removed in Airflow 3.0; use `airflow.configuration.conf.getfloat` instead
+AIR302_names.py:58:18: AIR302 `airflow.configuration.getfloat` is removed in Airflow 3.0; use `airflow.configuration.conf.getfloat` instead
    |
-54 | dates.datetime_to_nano
-55 | 
-56 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+56 | dates.datetime_to_nano
+57 | 
+58 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
    |                  ^^^^^^^^ AIR302
-57 | 
-58 | get_connection, load_connections
+59 | 
+60 | get_connection, load_connections
    |
 
-AIR302_names.py:56:28: AIR302 `airflow.configuration.getint` is removed in Airflow 3.0; use `airflow.configuration.conf.getint` instead
+AIR302_names.py:58:28: AIR302 `airflow.configuration.getint` is removed in Airflow 3.0; use `airflow.configuration.conf.getint` instead
    |
-54 | dates.datetime_to_nano
-55 | 
-56 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+56 | dates.datetime_to_nano
+57 | 
+58 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
    |                            ^^^^^^ AIR302
-57 | 
-58 | get_connection, load_connections
+59 | 
+60 | get_connection, load_connections
    |
 
-AIR302_names.py:56:36: AIR302 `airflow.configuration.has_option` is removed in Airflow 3.0; use `airflow.configuration.conf.has_option` instead
+AIR302_names.py:58:36: AIR302 `airflow.configuration.has_option` is removed in Airflow 3.0; use `airflow.configuration.conf.has_option` instead
    |
-54 | dates.datetime_to_nano
-55 | 
-56 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+56 | dates.datetime_to_nano
+57 | 
+58 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
    |                                    ^^^^^^^^^^ AIR302
-57 | 
-58 | get_connection, load_connections
+59 | 
+60 | get_connection, load_connections
    |
 
-AIR302_names.py:56:48: AIR302 `airflow.configuration.remove_option` is removed in Airflow 3.0; use `airflow.configuration.conf.remove_option` instead
+AIR302_names.py:58:48: AIR302 `airflow.configuration.remove_option` is removed in Airflow 3.0; use `airflow.configuration.conf.remove_option` instead
    |
-54 | dates.datetime_to_nano
-55 | 
-56 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+56 | dates.datetime_to_nano
+57 | 
+58 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
    |                                                ^^^^^^^^^^^^^ AIR302
-57 | 
-58 | get_connection, load_connections
+59 | 
+60 | get_connection, load_connections
    |
 
-AIR302_names.py:56:63: AIR302 `airflow.configuration.as_dict` is removed in Airflow 3.0; use `airflow.configuration.conf.as_dict` instead
+AIR302_names.py:58:63: AIR302 `airflow.configuration.as_dict` is removed in Airflow 3.0; use `airflow.configuration.conf.as_dict` instead
    |
-54 | dates.datetime_to_nano
-55 | 
-56 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+56 | dates.datetime_to_nano
+57 | 
+58 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
    |                                                               ^^^^^^^ AIR302
-57 | 
-58 | get_connection, load_connections
+59 | 
+60 | get_connection, load_connections
    |
 
-AIR302_names.py:56:72: AIR302 `airflow.configuration.set` is removed in Airflow 3.0; use `airflow.configuration.conf.set` instead
+AIR302_names.py:58:72: AIR302 `airflow.configuration.set` is removed in Airflow 3.0; use `airflow.configuration.conf.set` instead
    |
-54 | dates.datetime_to_nano
-55 | 
-56 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+56 | dates.datetime_to_nano
+57 | 
+58 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
    |                                                                        ^^^ AIR302
-57 | 
-58 | get_connection, load_connections
+59 | 
+60 | get_connection, load_connections
    |
 
-AIR302_names.py:58:1: AIR302 `airflow.secrets.local_filesystem.get_connection` is removed in Airflow 3.0; use `airflow.secrets.local_filesystem.load_connections_dict` instead
+AIR302_names.py:60:1: AIR302 `airflow.secrets.local_filesystem.get_connection` is removed in Airflow 3.0; use `airflow.secrets.local_filesystem.load_connections_dict` instead
    |
-56 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
-57 | 
-58 | get_connection, load_connections
+58 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+59 | 
+60 | get_connection, load_connections
    | ^^^^^^^^^^^^^^ AIR302
-59 | 
-60 | TemporaryDirectory
+61 | 
+62 | TemporaryDirectory
    |
 
-AIR302_names.py:58:17: AIR302 `airflow.secrets.local_filesystem.load_connections` is removed in Airflow 3.0; use `airflow.secrets.local_filesystem.load_connections_dict` instead
+AIR302_names.py:60:17: AIR302 `airflow.secrets.local_filesystem.load_connections` is removed in Airflow 3.0; use `airflow.secrets.local_filesystem.load_connections_dict` instead
    |
-56 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
-57 | 
-58 | get_connection, load_connections
+58 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+59 | 
+60 | get_connection, load_connections
    |                 ^^^^^^^^^^^^^^^^ AIR302
-59 | 
-60 | TemporaryDirectory
+61 | 
+62 | TemporaryDirectory
    |
 
-AIR302_names.py:60:1: AIR302 `airflow.utils.file.TemporaryDirectory` is removed in Airflow 3.0
+AIR302_names.py:62:1: AIR302 `airflow.utils.file.TemporaryDirectory` is removed in Airflow 3.0
    |
-58 | get_connection, load_connections
-59 | 
-60 | TemporaryDirectory
+60 | get_connection, load_connections
+61 | 
+62 | TemporaryDirectory
    | ^^^^^^^^^^^^^^^^^^ AIR302
-61 | mkdirs
+63 | mkdirs
    |
 
-AIR302_names.py:61:1: AIR302 `airflow.utils.file.mkdirs` is removed in Airflow 3.0; use `pendulum.today('UTC').add(days=-N, ...)` instead
+AIR302_names.py:63:1: AIR302 `airflow.utils.file.mkdirs` is removed in Airflow 3.0; use `pendulum.today('UTC').add(days=-N, ...)` instead
    |
-60 | TemporaryDirectory
-61 | mkdirs
+62 | TemporaryDirectory
+63 | mkdirs
    | ^^^^^^ AIR302
-62 | 
-63 | chain
+64 | 
+65 | chain
    |
 
-AIR302_names.py:63:1: AIR302 `airflow.utils.helpers.chain` is removed in Airflow 3.0; use `airflow.models.baseoperator.chain` instead
+AIR302_names.py:65:1: AIR302 `airflow.utils.helpers.chain` is removed in Airflow 3.0; use `airflow.models.baseoperator.chain` instead
    |
-61 | mkdirs
-62 | 
-63 | chain
+63 | mkdirs
+64 | 
+65 | chain
    | ^^^^^ AIR302
-64 | cross_downstream
+66 | cross_downstream
    |
 
-AIR302_names.py:64:1: AIR302 `airflow.utils.helpers.cross_downstream` is removed in Airflow 3.0; use `airflow.models.baseoperator.cross_downstream` instead
+AIR302_names.py:66:1: AIR302 `airflow.utils.helpers.cross_downstream` is removed in Airflow 3.0; use `airflow.models.baseoperator.cross_downstream` instead
    |
-63 | chain
-64 | cross_downstream
+65 | chain
+66 | cross_downstream
    | ^^^^^^^^^^^^^^^^ AIR302
-65 | 
-66 | SHUTDOWN
+67 | 
+68 | SHUTDOWN
    |
 
-AIR302_names.py:66:1: AIR302 `airflow.utils.state.SHUTDOWN` is removed in Airflow 3.0
+AIR302_names.py:68:1: AIR302 `airflow.utils.state.SHUTDOWN` is removed in Airflow 3.0
    |
-64 | cross_downstream
-65 | 
-66 | SHUTDOWN
+66 | cross_downstream
+67 | 
+68 | SHUTDOWN
    | ^^^^^^^^ AIR302
-67 | terminating_states
+69 | terminating_states
    |
 
-AIR302_names.py:67:1: AIR302 `airflow.utils.state.terminating_states` is removed in Airflow 3.0
+AIR302_names.py:69:1: AIR302 `airflow.utils.state.terminating_states` is removed in Airflow 3.0
    |
-66 | SHUTDOWN
-67 | terminating_states
+68 | SHUTDOWN
+69 | terminating_states
    | ^^^^^^^^^^^^^^^^^^ AIR302
-68 | 
-69 | test_cycle
-   |
-
-AIR302_names.py:69:1: AIR302 `airflow.utils.dag_cycle_tester.test_cycle` is removed in Airflow 3.0
-   |
-67 | terminating_states
-68 | 
-69 | test_cycle
-   | ^^^^^^^^^^ AIR302
 70 | 
-71 | has_access
+71 | test_cycle
    |
 
-AIR302_names.py:71:1: AIR302 `airflow.www.auth.has_access` is removed in Airflow 3.0; use `airflow.www.auth.has_access_*` instead
+AIR302_names.py:71:1: AIR302 `airflow.utils.dag_cycle_tester.test_cycle` is removed in Airflow 3.0
    |
-69 | test_cycle
+69 | terminating_states
 70 | 
-71 | has_access
+71 | test_cycle
    | ^^^^^^^^^^ AIR302
-72 | get_sensitive_variables_fields, should_hide_value_for_key
+72 | 
+73 | has_access
    |
 
-AIR302_names.py:72:1: AIR302 `airflow.www.utils.get_sensitive_variables_fields` is removed in Airflow 3.0; use `airflow.utils.log.secrets_masker.get_sensitive_variables_fields` instead
+AIR302_names.py:73:1: AIR302 `airflow.www.auth.has_access` is removed in Airflow 3.0; use `airflow.www.auth.has_access_*` instead
    |
-71 | has_access
-72 | get_sensitive_variables_fields, should_hide_value_for_key
+71 | test_cycle
+72 | 
+73 | has_access
+   | ^^^^^^^^^^ AIR302
+74 | get_sensitive_variables_fields, should_hide_value_for_key
+   |
+
+AIR302_names.py:74:1: AIR302 `airflow.www.utils.get_sensitive_variables_fields` is removed in Airflow 3.0; use `airflow.utils.log.secrets_masker.get_sensitive_variables_fields` instead
+   |
+73 | has_access
+74 | get_sensitive_variables_fields, should_hide_value_for_key
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
    |
 
-AIR302_names.py:72:33: AIR302 `airflow.www.utils.should_hide_value_for_key` is removed in Airflow 3.0; use `airflow.utils.log.secrets_masker.should_hide_value_for_key` instead
+AIR302_names.py:74:33: AIR302 `airflow.www.utils.should_hide_value_for_key` is removed in Airflow 3.0; use `airflow.utils.log.secrets_masker.should_hide_value_for_key` instead
    |
-71 | has_access
-72 | get_sensitive_variables_fields, should_hide_value_for_key
+73 | has_access
+74 | get_sensitive_variables_fields, should_hide_value_for_key
    |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
    |

--- a/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_names.py.snap
+++ b/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_names.py.snap
@@ -2,455 +2,527 @@
 source: crates/ruff_linter/src/rules/airflow/mod.rs
 snapshot_kind: text
 ---
-AIR302_names.py:51:1: AIR302 `airflow.contrib.aws_athena_hook.AWSAthenaHook` is removed in Airflow 3.0
+AIR302_names.py:51:1: AIR302 `airflow.PY36` is removed in Airflow 3.0; use `sys.version_info` instead
    |
-51 | AWSAthenaHook
+49 | from airflow.www.utils import get_sensitive_variables_fields, should_hide_value_for_key
+50 | 
+51 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
+   | ^^^^ AIR302
+52 | 
+53 | AWSAthenaHook
+   |
+
+AIR302_names.py:51:7: AIR302 `airflow.PY37` is removed in Airflow 3.0; use `sys.version_info` instead
+   |
+49 | from airflow.www.utils import get_sensitive_variables_fields, should_hide_value_for_key
+50 | 
+51 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
+   |       ^^^^ AIR302
+52 | 
+53 | AWSAthenaHook
+   |
+
+AIR302_names.py:51:13: AIR302 `airflow.PY38` is removed in Airflow 3.0; use `sys.version_info` instead
+   |
+49 | from airflow.www.utils import get_sensitive_variables_fields, should_hide_value_for_key
+50 | 
+51 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
+   |             ^^^^ AIR302
+52 | 
+53 | AWSAthenaHook
+   |
+
+AIR302_names.py:51:19: AIR302 `airflow.PY39` is removed in Airflow 3.0; use `sys.version_info` instead
+   |
+49 | from airflow.www.utils import get_sensitive_variables_fields, should_hide_value_for_key
+50 | 
+51 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
+   |                   ^^^^ AIR302
+52 | 
+53 | AWSAthenaHook
+   |
+
+AIR302_names.py:51:25: AIR302 `airflow.PY310` is removed in Airflow 3.0; use `sys.version_info` instead
+   |
+49 | from airflow.www.utils import get_sensitive_variables_fields, should_hide_value_for_key
+50 | 
+51 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
+   |                         ^^^^^ AIR302
+52 | 
+53 | AWSAthenaHook
+   |
+
+AIR302_names.py:51:32: AIR302 `airflow.PY311` is removed in Airflow 3.0; use `sys.version_info` instead
+   |
+49 | from airflow.www.utils import get_sensitive_variables_fields, should_hide_value_for_key
+50 | 
+51 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
+   |                                ^^^^^ AIR302
+52 | 
+53 | AWSAthenaHook
+   |
+
+AIR302_names.py:51:39: AIR302 `airflow.PY312` is removed in Airflow 3.0; use `sys.version_info` instead
+   |
+49 | from airflow.www.utils import get_sensitive_variables_fields, should_hide_value_for_key
+50 | 
+51 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
+   |                                       ^^^^^ AIR302
+52 | 
+53 | AWSAthenaHook
+   |
+
+AIR302_names.py:53:1: AIR302 `airflow.contrib.aws_athena_hook.AWSAthenaHook` is removed in Airflow 3.0
+   |
+51 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
+52 | 
+53 | AWSAthenaHook
    | ^^^^^^^^^^^^^ AIR302
-52 | TaskStateTrigger
+54 | TaskStateTrigger
    |
 
-AIR302_names.py:52:1: AIR302 `airflow.triggers.external_task.TaskStateTrigger` is removed in Airflow 3.0
+AIR302_names.py:54:1: AIR302 `airflow.triggers.external_task.TaskStateTrigger` is removed in Airflow 3.0
    |
-51 | AWSAthenaHook
-52 | TaskStateTrigger
+53 | AWSAthenaHook
+54 | TaskStateTrigger
    | ^^^^^^^^^^^^^^^^ AIR302
-53 | 
-54 | requires_access
+55 | 
+56 | requires_access
    |
 
-AIR302_names.py:54:1: AIR302 `airflow.api_connexion.security.requires_access` is removed in Airflow 3.0; use `airflow.api_connexion.security.requires_access_*` instead
+AIR302_names.py:56:1: AIR302 `airflow.api_connexion.security.requires_access` is removed in Airflow 3.0; use `airflow.api_connexion.security.requires_access_*` instead
    |
-52 | TaskStateTrigger
-53 | 
-54 | requires_access
+54 | TaskStateTrigger
+55 | 
+56 | requires_access
    | ^^^^^^^^^^^^^^^ AIR302
-55 | 
-56 | AllowListValidator
+57 | 
+58 | AllowListValidator
    |
 
-AIR302_names.py:56:1: AIR302 `airflow.metrics.validators.AllowListValidator` is removed in Airflow 3.0; use `airflow.metrics.validators.PatternAllowListValidator` instead
+AIR302_names.py:58:1: AIR302 `airflow.metrics.validators.AllowListValidator` is removed in Airflow 3.0; use `airflow.metrics.validators.PatternAllowListValidator` instead
    |
-54 | requires_access
-55 | 
-56 | AllowListValidator
+56 | requires_access
+57 | 
+58 | AllowListValidator
    | ^^^^^^^^^^^^^^^^^^ AIR302
-57 | BlockListValidator
+59 | BlockListValidator
    |
 
-AIR302_names.py:57:1: AIR302 `airflow.metrics.validators.BlockListValidator` is removed in Airflow 3.0; use `airflow.metrics.validators.PatternBlockListValidator` instead
+AIR302_names.py:59:1: AIR302 `airflow.metrics.validators.BlockListValidator` is removed in Airflow 3.0; use `airflow.metrics.validators.PatternBlockListValidator` instead
    |
-56 | AllowListValidator
-57 | BlockListValidator
+58 | AllowListValidator
+59 | BlockListValidator
    | ^^^^^^^^^^^^^^^^^^ AIR302
-58 | 
-59 | SubDagOperator
+60 | 
+61 | SubDagOperator
    |
 
-AIR302_names.py:59:1: AIR302 `airflow.operators.subdag.SubDagOperator` is removed in Airflow 3.0
+AIR302_names.py:61:1: AIR302 `airflow.operators.subdag.SubDagOperator` is removed in Airflow 3.0
    |
-57 | BlockListValidator
-58 | 
-59 | SubDagOperator
+59 | BlockListValidator
+60 | 
+61 | SubDagOperator
    | ^^^^^^^^^^^^^^ AIR302
-60 | 
-61 | dates.date_range
+62 | 
+63 | dates.date_range
    |
 
-AIR302_names.py:61:7: AIR302 `airflow.utils.dates.date_range` is removed in Airflow 3.0; use `airflow.timetables.` instead
+AIR302_names.py:63:7: AIR302 `airflow.utils.dates.date_range` is removed in Airflow 3.0; use `airflow.timetables.` instead
    |
-59 | SubDagOperator
-60 | 
-61 | dates.date_range
+61 | SubDagOperator
+62 | 
+63 | dates.date_range
    |       ^^^^^^^^^^ AIR302
-62 | dates.days_ago
+64 | dates.days_ago
    |
 
-AIR302_names.py:62:7: AIR302 `airflow.utils.dates.days_ago` is removed in Airflow 3.0; use `pendulum.today('UTC').add(days=-N, ...)` instead
+AIR302_names.py:64:7: AIR302 `airflow.utils.dates.days_ago` is removed in Airflow 3.0; use `pendulum.today('UTC').add(days=-N, ...)` instead
    |
-61 | dates.date_range
-62 | dates.days_ago
+63 | dates.date_range
+64 | dates.days_ago
    |       ^^^^^^^^ AIR302
-63 | 
-64 | date_range
+65 | 
+66 | date_range
    |
 
-AIR302_names.py:64:1: AIR302 `airflow.utils.dates.date_range` is removed in Airflow 3.0; use `airflow.timetables.` instead
+AIR302_names.py:66:1: AIR302 `airflow.utils.dates.date_range` is removed in Airflow 3.0; use `airflow.timetables.` instead
    |
-62 | dates.days_ago
-63 | 
-64 | date_range
+64 | dates.days_ago
+65 | 
+66 | date_range
    | ^^^^^^^^^^ AIR302
-65 | days_ago
-66 | parse_execution_date
+67 | days_ago
+68 | parse_execution_date
    |
 
-AIR302_names.py:65:1: AIR302 `airflow.utils.dates.days_ago` is removed in Airflow 3.0; use `pendulum.today('UTC').add(days=-N, ...)` instead
+AIR302_names.py:67:1: AIR302 `airflow.utils.dates.days_ago` is removed in Airflow 3.0; use `pendulum.today('UTC').add(days=-N, ...)` instead
    |
-64 | date_range
-65 | days_ago
+66 | date_range
+67 | days_ago
    | ^^^^^^^^ AIR302
-66 | parse_execution_date
-67 | round_time
+68 | parse_execution_date
+69 | round_time
    |
 
-AIR302_names.py:66:1: AIR302 `airflow.utils.dates.parse_execution_date` is removed in Airflow 3.0
+AIR302_names.py:68:1: AIR302 `airflow.utils.dates.parse_execution_date` is removed in Airflow 3.0
    |
-64 | date_range
-65 | days_ago
-66 | parse_execution_date
+66 | date_range
+67 | days_ago
+68 | parse_execution_date
    | ^^^^^^^^^^^^^^^^^^^^ AIR302
-67 | round_time
-68 | scale_time_units
+69 | round_time
+70 | scale_time_units
    |
 
-AIR302_names.py:67:1: AIR302 `airflow.utils.dates.round_time` is removed in Airflow 3.0
+AIR302_names.py:69:1: AIR302 `airflow.utils.dates.round_time` is removed in Airflow 3.0
    |
-65 | days_ago
-66 | parse_execution_date
-67 | round_time
+67 | days_ago
+68 | parse_execution_date
+69 | round_time
    | ^^^^^^^^^^ AIR302
-68 | scale_time_units
-69 | infer_time_unit
+70 | scale_time_units
+71 | infer_time_unit
    |
 
-AIR302_names.py:68:1: AIR302 `airflow.utils.dates.scale_time_units` is removed in Airflow 3.0
+AIR302_names.py:70:1: AIR302 `airflow.utils.dates.scale_time_units` is removed in Airflow 3.0
    |
-66 | parse_execution_date
-67 | round_time
-68 | scale_time_units
+68 | parse_execution_date
+69 | round_time
+70 | scale_time_units
    | ^^^^^^^^^^^^^^^^ AIR302
-69 | infer_time_unit
+71 | infer_time_unit
    |
 
-AIR302_names.py:69:1: AIR302 `airflow.utils.dates.infer_time_unit` is removed in Airflow 3.0
+AIR302_names.py:71:1: AIR302 `airflow.utils.dates.infer_time_unit` is removed in Airflow 3.0
    |
-67 | round_time
-68 | scale_time_units
-69 | infer_time_unit
+69 | round_time
+70 | scale_time_units
+71 | infer_time_unit
    | ^^^^^^^^^^^^^^^ AIR302
    |
 
-AIR302_names.py:76:1: AIR302 `airflow.configuration.get` is removed in Airflow 3.0; use `airflow.configuration.conf.get` instead
+AIR302_names.py:78:1: AIR302 `airflow.configuration.get` is removed in Airflow 3.0; use `airflow.configuration.conf.get` instead
    |
-74 | dates.datetime_to_nano
-75 | 
-76 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+76 | dates.datetime_to_nano
+77 | 
+78 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
    | ^^^ AIR302
-77 | 
-78 | get_connection, load_connections
+79 | 
+80 | get_connection, load_connections
    |
 
-AIR302_names.py:76:6: AIR302 `airflow.configuration.getboolean` is removed in Airflow 3.0; use `airflow.configuration.conf.getboolean` instead
+AIR302_names.py:78:6: AIR302 `airflow.configuration.getboolean` is removed in Airflow 3.0; use `airflow.configuration.conf.getboolean` instead
    |
-74 | dates.datetime_to_nano
-75 | 
-76 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+76 | dates.datetime_to_nano
+77 | 
+78 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
    |      ^^^^^^^^^^ AIR302
-77 | 
-78 | get_connection, load_connections
+79 | 
+80 | get_connection, load_connections
    |
 
-AIR302_names.py:76:18: AIR302 `airflow.configuration.getfloat` is removed in Airflow 3.0; use `airflow.configuration.conf.getfloat` instead
+AIR302_names.py:78:18: AIR302 `airflow.configuration.getfloat` is removed in Airflow 3.0; use `airflow.configuration.conf.getfloat` instead
    |
-74 | dates.datetime_to_nano
-75 | 
-76 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+76 | dates.datetime_to_nano
+77 | 
+78 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
    |                  ^^^^^^^^ AIR302
-77 | 
-78 | get_connection, load_connections
+79 | 
+80 | get_connection, load_connections
    |
 
-AIR302_names.py:76:28: AIR302 `airflow.configuration.getint` is removed in Airflow 3.0; use `airflow.configuration.conf.getint` instead
+AIR302_names.py:78:28: AIR302 `airflow.configuration.getint` is removed in Airflow 3.0; use `airflow.configuration.conf.getint` instead
    |
-74 | dates.datetime_to_nano
-75 | 
-76 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+76 | dates.datetime_to_nano
+77 | 
+78 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
    |                            ^^^^^^ AIR302
-77 | 
-78 | get_connection, load_connections
+79 | 
+80 | get_connection, load_connections
    |
 
-AIR302_names.py:76:36: AIR302 `airflow.configuration.has_option` is removed in Airflow 3.0; use `airflow.configuration.conf.has_option` instead
+AIR302_names.py:78:36: AIR302 `airflow.configuration.has_option` is removed in Airflow 3.0; use `airflow.configuration.conf.has_option` instead
    |
-74 | dates.datetime_to_nano
-75 | 
-76 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+76 | dates.datetime_to_nano
+77 | 
+78 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
    |                                    ^^^^^^^^^^ AIR302
-77 | 
-78 | get_connection, load_connections
+79 | 
+80 | get_connection, load_connections
    |
 
-AIR302_names.py:76:48: AIR302 `airflow.configuration.remove_option` is removed in Airflow 3.0; use `airflow.configuration.conf.remove_option` instead
+AIR302_names.py:78:48: AIR302 `airflow.configuration.remove_option` is removed in Airflow 3.0; use `airflow.configuration.conf.remove_option` instead
    |
-74 | dates.datetime_to_nano
-75 | 
-76 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+76 | dates.datetime_to_nano
+77 | 
+78 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
    |                                                ^^^^^^^^^^^^^ AIR302
-77 | 
-78 | get_connection, load_connections
+79 | 
+80 | get_connection, load_connections
    |
 
-AIR302_names.py:76:63: AIR302 `airflow.configuration.as_dict` is removed in Airflow 3.0; use `airflow.configuration.conf.as_dict` instead
+AIR302_names.py:78:63: AIR302 `airflow.configuration.as_dict` is removed in Airflow 3.0; use `airflow.configuration.conf.as_dict` instead
    |
-74 | dates.datetime_to_nano
-75 | 
-76 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+76 | dates.datetime_to_nano
+77 | 
+78 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
    |                                                               ^^^^^^^ AIR302
-77 | 
-78 | get_connection, load_connections
+79 | 
+80 | get_connection, load_connections
    |
 
-AIR302_names.py:76:72: AIR302 `airflow.configuration.set` is removed in Airflow 3.0; use `airflow.configuration.conf.set` instead
+AIR302_names.py:78:72: AIR302 `airflow.configuration.set` is removed in Airflow 3.0; use `airflow.configuration.conf.set` instead
    |
-74 | dates.datetime_to_nano
-75 | 
-76 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+76 | dates.datetime_to_nano
+77 | 
+78 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
    |                                                                        ^^^ AIR302
-77 | 
-78 | get_connection, load_connections
+79 | 
+80 | get_connection, load_connections
    |
 
-AIR302_names.py:78:1: AIR302 `airflow.secrets.local_filesystem.get_connection` is removed in Airflow 3.0; use `airflow.secrets.local_filesystem.load_connections_dict` instead
+AIR302_names.py:80:1: AIR302 `airflow.secrets.local_filesystem.get_connection` is removed in Airflow 3.0; use `airflow.secrets.local_filesystem.load_connections_dict` instead
    |
-76 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
-77 | 
-78 | get_connection, load_connections
+78 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+79 | 
+80 | get_connection, load_connections
    | ^^^^^^^^^^^^^^ AIR302
    |
 
-AIR302_names.py:78:17: AIR302 `airflow.secrets.local_filesystem.load_connections` is removed in Airflow 3.0; use `airflow.secrets.local_filesystem.load_connections_dict` instead
+AIR302_names.py:80:17: AIR302 `airflow.secrets.local_filesystem.load_connections` is removed in Airflow 3.0; use `airflow.secrets.local_filesystem.load_connections_dict` instead
    |
-76 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
-77 | 
-78 | get_connection, load_connections
+78 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+79 | 
+80 | get_connection, load_connections
    |                 ^^^^^^^^^^^^^^^^ AIR302
    |
 
-AIR302_names.py:81:1: AIR302 `airflow.sensors.external_task_sensor.ExternalTaskSensorLink` is removed in Airflow 3.0; use `airflow.sensors.external_task.ExternalTaskSensorLink` instead
+AIR302_names.py:83:1: AIR302 `airflow.sensors.external_task_sensor.ExternalTaskSensorLink` is removed in Airflow 3.0; use `airflow.sensors.external_task.ExternalTaskSensorLink` instead
    |
-81 | ExternalTaskSensorLink
+83 | ExternalTaskSensorLink
    | ^^^^^^^^^^^^^^^^^^^^^^ AIR302
-82 | BashOperator
-83 | BaseBranchOperator
+84 | BashOperator
+85 | BaseBranchOperator
    |
 
-AIR302_names.py:82:1: AIR302 `airflow.operators.bash_operator.BashOperator` is removed in Airflow 3.0; use `airflow.operators.bash.BashOperator` instead
+AIR302_names.py:84:1: AIR302 `airflow.operators.bash_operator.BashOperator` is removed in Airflow 3.0; use `airflow.operators.bash.BashOperator` instead
    |
-81 | ExternalTaskSensorLink
-82 | BashOperator
+83 | ExternalTaskSensorLink
+84 | BashOperator
    | ^^^^^^^^^^^^ AIR302
-83 | BaseBranchOperator
-84 | EmptyOperator, DummyOperator
+85 | BaseBranchOperator
+86 | EmptyOperator, DummyOperator
    |
 
-AIR302_names.py:83:1: AIR302 `airflow.operators.branch_operator.BaseBranchOperator` is removed in Airflow 3.0; use `airflow.operators.branch.BaseBranchOperator` instead
+AIR302_names.py:85:1: AIR302 `airflow.operators.branch_operator.BaseBranchOperator` is removed in Airflow 3.0; use `airflow.operators.branch.BaseBranchOperator` instead
    |
-81 | ExternalTaskSensorLink
-82 | BashOperator
-83 | BaseBranchOperator
+83 | ExternalTaskSensorLink
+84 | BashOperator
+85 | BaseBranchOperator
    | ^^^^^^^^^^^^^^^^^^ AIR302
-84 | EmptyOperator, DummyOperator
-85 | dummy_operator.EmptyOperator
+86 | EmptyOperator, DummyOperator
+87 | dummy_operator.EmptyOperator
    |
 
-AIR302_names.py:84:16: AIR302 `airflow.operators.dummy.DummyOperator` is removed in Airflow 3.0; use `airflow.operators.empty.EmptyOperator` instead
+AIR302_names.py:86:16: AIR302 `airflow.operators.dummy.DummyOperator` is removed in Airflow 3.0; use `airflow.operators.empty.EmptyOperator` instead
    |
-82 | BashOperator
-83 | BaseBranchOperator
-84 | EmptyOperator, DummyOperator
+84 | BashOperator
+85 | BaseBranchOperator
+86 | EmptyOperator, DummyOperator
    |                ^^^^^^^^^^^^^ AIR302
-85 | dummy_operator.EmptyOperator
-86 | dummy_operator.DummyOperator
+87 | dummy_operator.EmptyOperator
+88 | dummy_operator.DummyOperator
    |
 
-AIR302_names.py:85:16: AIR302 `airflow.operators.dummy_operator.EmptyOperator` is removed in Airflow 3.0; use `airflow.operators.empty.EmptyOperator` instead
+AIR302_names.py:87:16: AIR302 `airflow.operators.dummy_operator.EmptyOperator` is removed in Airflow 3.0; use `airflow.operators.empty.EmptyOperator` instead
    |
-83 | BaseBranchOperator
-84 | EmptyOperator, DummyOperator
-85 | dummy_operator.EmptyOperator
+85 | BaseBranchOperator
+86 | EmptyOperator, DummyOperator
+87 | dummy_operator.EmptyOperator
    |                ^^^^^^^^^^^^^ AIR302
-86 | dummy_operator.DummyOperator
-87 | EmailOperator
+88 | dummy_operator.DummyOperator
+89 | EmailOperator
    |
 
-AIR302_names.py:86:16: AIR302 `airflow.operators.dummy_operator.DummyOperator` is removed in Airflow 3.0; use `airflow.operators.empty.EmptyOperator` instead
+AIR302_names.py:88:16: AIR302 `airflow.operators.dummy_operator.DummyOperator` is removed in Airflow 3.0; use `airflow.operators.empty.EmptyOperator` instead
    |
-84 | EmptyOperator, DummyOperator
-85 | dummy_operator.EmptyOperator
-86 | dummy_operator.DummyOperator
+86 | EmptyOperator, DummyOperator
+87 | dummy_operator.EmptyOperator
+88 | dummy_operator.DummyOperator
    |                ^^^^^^^^^^^^^ AIR302
-87 | EmailOperator
-88 | BaseSensorOperator
+89 | EmailOperator
+90 | BaseSensorOperator
    |
 
-AIR302_names.py:87:1: AIR302 `airflow.operators.email_operator.EmailOperator` is removed in Airflow 3.0; use `airflow.operators.email.EmailOperator` instead
+AIR302_names.py:89:1: AIR302 `airflow.operators.email_operator.EmailOperator` is removed in Airflow 3.0; use `airflow.operators.email.EmailOperator` instead
    |
-85 | dummy_operator.EmptyOperator
-86 | dummy_operator.DummyOperator
-87 | EmailOperator
+87 | dummy_operator.EmptyOperator
+88 | dummy_operator.DummyOperator
+89 | EmailOperator
    | ^^^^^^^^^^^^^ AIR302
-88 | BaseSensorOperator
-89 | DateTimeSensor
+90 | BaseSensorOperator
+91 | DateTimeSensor
    |
 
-AIR302_names.py:88:1: AIR302 `airflow.sensors.base_sensor_operator.BaseSensorOperator` is removed in Airflow 3.0; use `airflow.sensors.base.BaseSensorOperator` instead
+AIR302_names.py:90:1: AIR302 `airflow.sensors.base_sensor_operator.BaseSensorOperator` is removed in Airflow 3.0; use `airflow.sensors.base.BaseSensorOperator` instead
    |
-86 | dummy_operator.DummyOperator
-87 | EmailOperator
-88 | BaseSensorOperator
+88 | dummy_operator.DummyOperator
+89 | EmailOperator
+90 | BaseSensorOperator
    | ^^^^^^^^^^^^^^^^^^ AIR302
-89 | DateTimeSensor
-90 | (ExternalTaskMarker, ExternalTaskSensor, ExternalTaskSensorLink)
+91 | DateTimeSensor
+92 | (ExternalTaskMarker, ExternalTaskSensor, ExternalTaskSensorLink)
    |
 
-AIR302_names.py:89:1: AIR302 `airflow.sensors.date_time_sensor.DateTimeSensor` is removed in Airflow 3.0; use `airflow.sensors.date_time.DateTimeSensor` instead
+AIR302_names.py:91:1: AIR302 `airflow.sensors.date_time_sensor.DateTimeSensor` is removed in Airflow 3.0; use `airflow.sensors.date_time.DateTimeSensor` instead
    |
-87 | EmailOperator
-88 | BaseSensorOperator
-89 | DateTimeSensor
+89 | EmailOperator
+90 | BaseSensorOperator
+91 | DateTimeSensor
    | ^^^^^^^^^^^^^^ AIR302
-90 | (ExternalTaskMarker, ExternalTaskSensor, ExternalTaskSensorLink)
-91 | TimeDeltaSensor
+92 | (ExternalTaskMarker, ExternalTaskSensor, ExternalTaskSensorLink)
+93 | TimeDeltaSensor
    |
 
-AIR302_names.py:90:2: AIR302 `airflow.sensors.external_task_sensor.ExternalTaskMarker` is removed in Airflow 3.0; use `airflow.sensors.external_task.ExternalTaskMarker` instead
+AIR302_names.py:92:2: AIR302 `airflow.sensors.external_task_sensor.ExternalTaskMarker` is removed in Airflow 3.0; use `airflow.sensors.external_task.ExternalTaskMarker` instead
    |
-88 | BaseSensorOperator
-89 | DateTimeSensor
-90 | (ExternalTaskMarker, ExternalTaskSensor, ExternalTaskSensorLink)
+90 | BaseSensorOperator
+91 | DateTimeSensor
+92 | (ExternalTaskMarker, ExternalTaskSensor, ExternalTaskSensorLink)
    |  ^^^^^^^^^^^^^^^^^^ AIR302
-91 | TimeDeltaSensor
+93 | TimeDeltaSensor
    |
 
-AIR302_names.py:90:22: AIR302 `airflow.sensors.external_task_sensor.ExternalTaskSensor` is removed in Airflow 3.0; use `airflow.sensors.external_task.ExternalTaskSensor` instead
+AIR302_names.py:92:22: AIR302 `airflow.sensors.external_task_sensor.ExternalTaskSensor` is removed in Airflow 3.0; use `airflow.sensors.external_task.ExternalTaskSensor` instead
    |
-88 | BaseSensorOperator
-89 | DateTimeSensor
-90 | (ExternalTaskMarker, ExternalTaskSensor, ExternalTaskSensorLink)
+90 | BaseSensorOperator
+91 | DateTimeSensor
+92 | (ExternalTaskMarker, ExternalTaskSensor, ExternalTaskSensorLink)
    |                      ^^^^^^^^^^^^^^^^^^ AIR302
-91 | TimeDeltaSensor
+93 | TimeDeltaSensor
    |
 
-AIR302_names.py:90:42: AIR302 `airflow.sensors.external_task_sensor.ExternalTaskSensorLink` is removed in Airflow 3.0; use `airflow.sensors.external_task.ExternalTaskSensorLink` instead
+AIR302_names.py:92:42: AIR302 `airflow.sensors.external_task_sensor.ExternalTaskSensorLink` is removed in Airflow 3.0; use `airflow.sensors.external_task.ExternalTaskSensorLink` instead
    |
-88 | BaseSensorOperator
-89 | DateTimeSensor
-90 | (ExternalTaskMarker, ExternalTaskSensor, ExternalTaskSensorLink)
+90 | BaseSensorOperator
+91 | DateTimeSensor
+92 | (ExternalTaskMarker, ExternalTaskSensor, ExternalTaskSensorLink)
    |                                          ^^^^^^^^^^^^^^^^^^^^^^ AIR302
-91 | TimeDeltaSensor
+93 | TimeDeltaSensor
    |
 
-AIR302_names.py:91:1: AIR302 `airflow.sensors.time_delta_sensor.TimeDeltaSensor` is removed in Airflow 3.0; use `airflow.sensors.time_delta.TimeDeltaSensor` instead
+AIR302_names.py:93:1: AIR302 `airflow.sensors.time_delta_sensor.TimeDeltaSensor` is removed in Airflow 3.0; use `airflow.sensors.time_delta.TimeDeltaSensor` instead
    |
-89 | DateTimeSensor
-90 | (ExternalTaskMarker, ExternalTaskSensor, ExternalTaskSensorLink)
-91 | TimeDeltaSensor
+91 | DateTimeSensor
+92 | (ExternalTaskMarker, ExternalTaskSensor, ExternalTaskSensorLink)
+93 | TimeDeltaSensor
    | ^^^^^^^^^^^^^^^ AIR302
-92 | 
-93 | TemporaryDirectory
+94 | 
+95 | TemporaryDirectory
    |
 
-AIR302_names.py:93:1: AIR302 `airflow.utils.file.TemporaryDirectory` is removed in Airflow 3.0
+AIR302_names.py:95:1: AIR302 `airflow.utils.file.TemporaryDirectory` is removed in Airflow 3.0
    |
-91 | TimeDeltaSensor
-92 | 
-93 | TemporaryDirectory
+93 | TimeDeltaSensor
+94 | 
+95 | TemporaryDirectory
    | ^^^^^^^^^^^^^^^^^^ AIR302
-94 | mkdirs
+96 | mkdirs
    |
 
-AIR302_names.py:94:1: AIR302 `airflow.utils.file.mkdirs` is removed in Airflow 3.0; use `pendulum.today('UTC').add(days=-N, ...)` instead
+AIR302_names.py:96:1: AIR302 `airflow.utils.file.mkdirs` is removed in Airflow 3.0; use `pendulum.today('UTC').add(days=-N, ...)` instead
    |
-93 | TemporaryDirectory
-94 | mkdirs
+95 | TemporaryDirectory
+96 | mkdirs
    | ^^^^^^ AIR302
-95 | 
-96 | chain
+97 | 
+98 | chain
    |
 
-AIR302_names.py:96:1: AIR302 `airflow.utils.helpers.chain` is removed in Airflow 3.0; use `airflow.models.baseoperator.chain` instead
+AIR302_names.py:98:1: AIR302 `airflow.utils.helpers.chain` is removed in Airflow 3.0; use `airflow.models.baseoperator.chain` instead
    |
-94 | mkdirs
-95 | 
-96 | chain
+96 | mkdirs
+97 | 
+98 | chain
    | ^^^^^ AIR302
-97 | cross_downstream
+99 | cross_downstream
    |
 
-AIR302_names.py:97:1: AIR302 `airflow.utils.helpers.cross_downstream` is removed in Airflow 3.0; use `airflow.models.baseoperator.cross_downstream` instead
-   |
-96 | chain
-97 | cross_downstream
-   | ^^^^^^^^^^^^^^^^ AIR302
-98 | 
-99 | SHUTDOWN
-   |
-
-AIR302_names.py:99:1: AIR302 `airflow.utils.state.SHUTDOWN` is removed in Airflow 3.0
+AIR302_names.py:99:1: AIR302 `airflow.utils.helpers.cross_downstream` is removed in Airflow 3.0; use `airflow.models.baseoperator.cross_downstream` instead
     |
- 97 | cross_downstream
- 98 | 
- 99 | SHUTDOWN
+ 98 | chain
+ 99 | cross_downstream
+    | ^^^^^^^^^^^^^^^^ AIR302
+100 | 
+101 | SHUTDOWN
+    |
+
+AIR302_names.py:101:1: AIR302 `airflow.utils.state.SHUTDOWN` is removed in Airflow 3.0
+    |
+ 99 | cross_downstream
+100 | 
+101 | SHUTDOWN
     | ^^^^^^^^ AIR302
-100 | terminating_states
+102 | terminating_states
     |
 
-AIR302_names.py:100:1: AIR302 `airflow.utils.state.terminating_states` is removed in Airflow 3.0
+AIR302_names.py:102:1: AIR302 `airflow.utils.state.terminating_states` is removed in Airflow 3.0
     |
- 99 | SHUTDOWN
-100 | terminating_states
+101 | SHUTDOWN
+102 | terminating_states
     | ^^^^^^^^^^^^^^^^^^ AIR302
-101 | 
-102 | TriggerRule.DUMMY
+103 | 
+104 | TriggerRule.DUMMY
     |
 
-AIR302_names.py:102:13: AIR302 `airflow.utils.trigger_rule.TriggerRule.DUMMY` is removed in Airflow 3.0
+AIR302_names.py:104:13: AIR302 `airflow.utils.trigger_rule.TriggerRule.DUMMY` is removed in Airflow 3.0
     |
-100 | terminating_states
-101 | 
-102 | TriggerRule.DUMMY
+102 | terminating_states
+103 | 
+104 | TriggerRule.DUMMY
     |             ^^^^^ AIR302
-103 | TriggerRule.NONE_FAILED_OR_SKIPPED
+105 | TriggerRule.NONE_FAILED_OR_SKIPPED
     |
 
-AIR302_names.py:103:13: AIR302 `airflow.utils.trigger_rule.TriggerRule.NONE_FAILED_OR_SKIPPED` is removed in Airflow 3.0
+AIR302_names.py:105:13: AIR302 `airflow.utils.trigger_rule.TriggerRule.NONE_FAILED_OR_SKIPPED` is removed in Airflow 3.0
     |
-102 | TriggerRule.DUMMY
-103 | TriggerRule.NONE_FAILED_OR_SKIPPED
+104 | TriggerRule.DUMMY
+105 | TriggerRule.NONE_FAILED_OR_SKIPPED
     |             ^^^^^^^^^^^^^^^^^^^^^^ AIR302
-104 | 
-105 | test_cycle
-    |
-
-AIR302_names.py:105:1: AIR302 `airflow.utils.dag_cycle_tester.test_cycle` is removed in Airflow 3.0
-    |
-103 | TriggerRule.NONE_FAILED_OR_SKIPPED
-104 | 
-105 | test_cycle
-    | ^^^^^^^^^^ AIR302
 106 | 
-107 | has_access
+107 | test_cycle
     |
 
-AIR302_names.py:107:1: AIR302 `airflow.www.auth.has_access` is removed in Airflow 3.0; use `airflow.www.auth.has_access_*` instead
+AIR302_names.py:107:1: AIR302 `airflow.utils.dag_cycle_tester.test_cycle` is removed in Airflow 3.0
     |
-105 | test_cycle
+105 | TriggerRule.NONE_FAILED_OR_SKIPPED
 106 | 
-107 | has_access
+107 | test_cycle
     | ^^^^^^^^^^ AIR302
-108 | get_sensitive_variables_fields, should_hide_value_for_key
+108 | 
+109 | has_access
     |
 
-AIR302_names.py:108:1: AIR302 `airflow.www.utils.get_sensitive_variables_fields` is removed in Airflow 3.0; use `airflow.utils.log.secrets_masker.get_sensitive_variables_fields` instead
+AIR302_names.py:109:1: AIR302 `airflow.www.auth.has_access` is removed in Airflow 3.0; use `airflow.www.auth.has_access_*` instead
     |
-107 | has_access
-108 | get_sensitive_variables_fields, should_hide_value_for_key
+107 | test_cycle
+108 | 
+109 | has_access
+    | ^^^^^^^^^^ AIR302
+110 | get_sensitive_variables_fields, should_hide_value_for_key
+    |
+
+AIR302_names.py:110:1: AIR302 `airflow.www.utils.get_sensitive_variables_fields` is removed in Airflow 3.0; use `airflow.utils.log.secrets_masker.get_sensitive_variables_fields` instead
+    |
+109 | has_access
+110 | get_sensitive_variables_fields, should_hide_value_for_key
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
     |
 
-AIR302_names.py:108:33: AIR302 `airflow.www.utils.should_hide_value_for_key` is removed in Airflow 3.0; use `airflow.utils.log.secrets_masker.should_hide_value_for_key` instead
+AIR302_names.py:110:33: AIR302 `airflow.www.utils.should_hide_value_for_key` is removed in Airflow 3.0; use `airflow.utils.log.secrets_masker.should_hide_value_for_key` instead
     |
-107 | has_access
-108 | get_sensitive_variables_fields, should_hide_value_for_key
+109 | has_access
+110 | get_sensitive_variables_fields, should_hide_value_for_key
     |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
     |

--- a/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_names.py.snap
+++ b/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_names.py.snap
@@ -2,307 +2,317 @@
 source: crates/ruff_linter/src/rules/airflow/mod.rs
 snapshot_kind: text
 ---
-AIR302_names.py:35:1: AIR302 `airflow.contrib.aws_athena_hook.AWSAthenaHook` is removed in Airflow 3.0
+AIR302_names.py:36:1: AIR302 `airflow.contrib.aws_athena_hook.AWSAthenaHook` is removed in Airflow 3.0
    |
-35 | AWSAthenaHook
+36 | AWSAthenaHook
    | ^^^^^^^^^^^^^ AIR302
-36 | TaskStateTrigger
+37 | TaskStateTrigger
    |
 
-AIR302_names.py:36:1: AIR302 `airflow.triggers.external_task.TaskStateTrigger` is removed in Airflow 3.0
+AIR302_names.py:37:1: AIR302 `airflow.triggers.external_task.TaskStateTrigger` is removed in Airflow 3.0
    |
-35 | AWSAthenaHook
-36 | TaskStateTrigger
+36 | AWSAthenaHook
+37 | TaskStateTrigger
    | ^^^^^^^^^^^^^^^^ AIR302
-37 | 
-38 | requires_access
+38 | 
+39 | requires_access
    |
 
-AIR302_names.py:38:1: AIR302 `airflow.api_connexion.security.requires_access` is removed in Airflow 3.0; use `airflow.api_connexion.security.requires_access_*` instead
+AIR302_names.py:39:1: AIR302 `airflow.api_connexion.security.requires_access` is removed in Airflow 3.0; use `airflow.api_connexion.security.requires_access_*` instead
    |
-36 | TaskStateTrigger
-37 | 
-38 | requires_access
+37 | TaskStateTrigger
+38 | 
+39 | requires_access
    | ^^^^^^^^^^^^^^^ AIR302
-39 | 
-40 | AllowListValidator
+40 | 
+41 | AllowListValidator
    |
 
-AIR302_names.py:40:1: AIR302 `airflow.metrics.validators.AllowListValidator` is removed in Airflow 3.0; use `airflow.metrics.validators.PatternAllowListValidator` instead
+AIR302_names.py:41:1: AIR302 `airflow.metrics.validators.AllowListValidator` is removed in Airflow 3.0; use `airflow.metrics.validators.PatternAllowListValidator` instead
    |
-38 | requires_access
-39 | 
-40 | AllowListValidator
+39 | requires_access
+40 | 
+41 | AllowListValidator
    | ^^^^^^^^^^^^^^^^^^ AIR302
-41 | BlockListValidator
+42 | BlockListValidator
    |
 
-AIR302_names.py:41:1: AIR302 `airflow.metrics.validators.BlockListValidator` is removed in Airflow 3.0; use `airflow.metrics.validators.PatternBlockListValidator` instead
+AIR302_names.py:42:1: AIR302 `airflow.metrics.validators.BlockListValidator` is removed in Airflow 3.0; use `airflow.metrics.validators.PatternBlockListValidator` instead
    |
-40 | AllowListValidator
-41 | BlockListValidator
+41 | AllowListValidator
+42 | BlockListValidator
    | ^^^^^^^^^^^^^^^^^^ AIR302
-42 | 
-43 | dates.date_range
+43 | 
+44 | SubDagOperator
    |
 
-AIR302_names.py:43:7: AIR302 `airflow.utils.dates.date_range` is removed in Airflow 3.0; use `airflow.timetables.` instead
+AIR302_names.py:44:1: AIR302 `airflow.operators.subdag.SubDagOperator` is removed in Airflow 3.0
    |
-41 | BlockListValidator
-42 | 
-43 | dates.date_range
-   |       ^^^^^^^^^^ AIR302
-44 | dates.days_ago
-   |
-
-AIR302_names.py:44:7: AIR302 `airflow.utils.dates.days_ago` is removed in Airflow 3.0; use `pendulum.today('UTC').add(days=-N, ...)` instead
-   |
-43 | dates.date_range
-44 | dates.days_ago
-   |       ^^^^^^^^ AIR302
-45 | 
-46 | date_range
-   |
-
-AIR302_names.py:46:1: AIR302 `airflow.utils.dates.date_range` is removed in Airflow 3.0; use `airflow.timetables.` instead
-   |
-44 | dates.days_ago
-45 | 
-46 | date_range
-   | ^^^^^^^^^^ AIR302
-47 | days_ago
-48 | parse_execution_date
-   |
-
-AIR302_names.py:47:1: AIR302 `airflow.utils.dates.days_ago` is removed in Airflow 3.0; use `pendulum.today('UTC').add(days=-N, ...)` instead
-   |
-46 | date_range
-47 | days_ago
-   | ^^^^^^^^ AIR302
-48 | parse_execution_date
-49 | round_time
-   |
-
-AIR302_names.py:48:1: AIR302 `airflow.utils.dates.parse_execution_date` is removed in Airflow 3.0
-   |
-46 | date_range
-47 | days_ago
-48 | parse_execution_date
-   | ^^^^^^^^^^^^^^^^^^^^ AIR302
-49 | round_time
-50 | scale_time_units
-   |
-
-AIR302_names.py:49:1: AIR302 `airflow.utils.dates.round_time` is removed in Airflow 3.0
-   |
-47 | days_ago
-48 | parse_execution_date
-49 | round_time
-   | ^^^^^^^^^^ AIR302
-50 | scale_time_units
-51 | infer_time_unit
-   |
-
-AIR302_names.py:50:1: AIR302 `airflow.utils.dates.scale_time_units` is removed in Airflow 3.0
-   |
-48 | parse_execution_date
-49 | round_time
-50 | scale_time_units
-   | ^^^^^^^^^^^^^^^^ AIR302
-51 | infer_time_unit
-   |
-
-AIR302_names.py:51:1: AIR302 `airflow.utils.dates.infer_time_unit` is removed in Airflow 3.0
-   |
-49 | round_time
-50 | scale_time_units
-51 | infer_time_unit
-   | ^^^^^^^^^^^^^^^ AIR302
-   |
-
-AIR302_names.py:58:1: AIR302 `airflow.configuration.get` is removed in Airflow 3.0; use `airflow.configuration.conf.get` instead
-   |
-56 | dates.datetime_to_nano
-57 | 
-58 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
-   | ^^^ AIR302
-59 | 
-60 | get_connection, load_connections
-   |
-
-AIR302_names.py:58:6: AIR302 `airflow.configuration.getboolean` is removed in Airflow 3.0; use `airflow.configuration.conf.getboolean` instead
-   |
-56 | dates.datetime_to_nano
-57 | 
-58 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
-   |      ^^^^^^^^^^ AIR302
-59 | 
-60 | get_connection, load_connections
-   |
-
-AIR302_names.py:58:18: AIR302 `airflow.configuration.getfloat` is removed in Airflow 3.0; use `airflow.configuration.conf.getfloat` instead
-   |
-56 | dates.datetime_to_nano
-57 | 
-58 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
-   |                  ^^^^^^^^ AIR302
-59 | 
-60 | get_connection, load_connections
-   |
-
-AIR302_names.py:58:28: AIR302 `airflow.configuration.getint` is removed in Airflow 3.0; use `airflow.configuration.conf.getint` instead
-   |
-56 | dates.datetime_to_nano
-57 | 
-58 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
-   |                            ^^^^^^ AIR302
-59 | 
-60 | get_connection, load_connections
-   |
-
-AIR302_names.py:58:36: AIR302 `airflow.configuration.has_option` is removed in Airflow 3.0; use `airflow.configuration.conf.has_option` instead
-   |
-56 | dates.datetime_to_nano
-57 | 
-58 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
-   |                                    ^^^^^^^^^^ AIR302
-59 | 
-60 | get_connection, load_connections
-   |
-
-AIR302_names.py:58:48: AIR302 `airflow.configuration.remove_option` is removed in Airflow 3.0; use `airflow.configuration.conf.remove_option` instead
-   |
-56 | dates.datetime_to_nano
-57 | 
-58 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
-   |                                                ^^^^^^^^^^^^^ AIR302
-59 | 
-60 | get_connection, load_connections
-   |
-
-AIR302_names.py:58:63: AIR302 `airflow.configuration.as_dict` is removed in Airflow 3.0; use `airflow.configuration.conf.as_dict` instead
-   |
-56 | dates.datetime_to_nano
-57 | 
-58 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
-   |                                                               ^^^^^^^ AIR302
-59 | 
-60 | get_connection, load_connections
-   |
-
-AIR302_names.py:58:72: AIR302 `airflow.configuration.set` is removed in Airflow 3.0; use `airflow.configuration.conf.set` instead
-   |
-56 | dates.datetime_to_nano
-57 | 
-58 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
-   |                                                                        ^^^ AIR302
-59 | 
-60 | get_connection, load_connections
-   |
-
-AIR302_names.py:60:1: AIR302 `airflow.secrets.local_filesystem.get_connection` is removed in Airflow 3.0; use `airflow.secrets.local_filesystem.load_connections_dict` instead
-   |
-58 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
-59 | 
-60 | get_connection, load_connections
+42 | BlockListValidator
+43 | 
+44 | SubDagOperator
    | ^^^^^^^^^^^^^^ AIR302
-61 | 
-62 | TemporaryDirectory
+45 | 
+46 | dates.date_range
    |
 
-AIR302_names.py:60:17: AIR302 `airflow.secrets.local_filesystem.load_connections` is removed in Airflow 3.0; use `airflow.secrets.local_filesystem.load_connections_dict` instead
+AIR302_names.py:46:7: AIR302 `airflow.utils.dates.date_range` is removed in Airflow 3.0; use `airflow.timetables.` instead
    |
-58 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
-59 | 
-60 | get_connection, load_connections
-   |                 ^^^^^^^^^^^^^^^^ AIR302
-61 | 
-62 | TemporaryDirectory
-   |
-
-AIR302_names.py:62:1: AIR302 `airflow.utils.file.TemporaryDirectory` is removed in Airflow 3.0
-   |
-60 | get_connection, load_connections
-61 | 
-62 | TemporaryDirectory
-   | ^^^^^^^^^^^^^^^^^^ AIR302
-63 | mkdirs
+44 | SubDagOperator
+45 | 
+46 | dates.date_range
+   |       ^^^^^^^^^^ AIR302
+47 | dates.days_ago
    |
 
-AIR302_names.py:63:1: AIR302 `airflow.utils.file.mkdirs` is removed in Airflow 3.0; use `pendulum.today('UTC').add(days=-N, ...)` instead
+AIR302_names.py:47:7: AIR302 `airflow.utils.dates.days_ago` is removed in Airflow 3.0; use `pendulum.today('UTC').add(days=-N, ...)` instead
    |
-62 | TemporaryDirectory
-63 | mkdirs
-   | ^^^^^^ AIR302
-64 | 
-65 | chain
-   |
-
-AIR302_names.py:65:1: AIR302 `airflow.utils.helpers.chain` is removed in Airflow 3.0; use `airflow.models.baseoperator.chain` instead
-   |
-63 | mkdirs
-64 | 
-65 | chain
-   | ^^^^^ AIR302
-66 | cross_downstream
+46 | dates.date_range
+47 | dates.days_ago
+   |       ^^^^^^^^ AIR302
+48 | 
+49 | date_range
    |
 
-AIR302_names.py:66:1: AIR302 `airflow.utils.helpers.cross_downstream` is removed in Airflow 3.0; use `airflow.models.baseoperator.cross_downstream` instead
+AIR302_names.py:49:1: AIR302 `airflow.utils.dates.date_range` is removed in Airflow 3.0; use `airflow.timetables.` instead
    |
-65 | chain
-66 | cross_downstream
-   | ^^^^^^^^^^^^^^^^ AIR302
-67 | 
-68 | SHUTDOWN
+47 | dates.days_ago
+48 | 
+49 | date_range
+   | ^^^^^^^^^^ AIR302
+50 | days_ago
+51 | parse_execution_date
    |
 
-AIR302_names.py:68:1: AIR302 `airflow.utils.state.SHUTDOWN` is removed in Airflow 3.0
+AIR302_names.py:50:1: AIR302 `airflow.utils.dates.days_ago` is removed in Airflow 3.0; use `pendulum.today('UTC').add(days=-N, ...)` instead
    |
-66 | cross_downstream
-67 | 
-68 | SHUTDOWN
+49 | date_range
+50 | days_ago
    | ^^^^^^^^ AIR302
-69 | terminating_states
+51 | parse_execution_date
+52 | round_time
    |
 
-AIR302_names.py:69:1: AIR302 `airflow.utils.state.terminating_states` is removed in Airflow 3.0
+AIR302_names.py:51:1: AIR302 `airflow.utils.dates.parse_execution_date` is removed in Airflow 3.0
    |
-68 | SHUTDOWN
-69 | terminating_states
+49 | date_range
+50 | days_ago
+51 | parse_execution_date
+   | ^^^^^^^^^^^^^^^^^^^^ AIR302
+52 | round_time
+53 | scale_time_units
+   |
+
+AIR302_names.py:52:1: AIR302 `airflow.utils.dates.round_time` is removed in Airflow 3.0
+   |
+50 | days_ago
+51 | parse_execution_date
+52 | round_time
+   | ^^^^^^^^^^ AIR302
+53 | scale_time_units
+54 | infer_time_unit
+   |
+
+AIR302_names.py:53:1: AIR302 `airflow.utils.dates.scale_time_units` is removed in Airflow 3.0
+   |
+51 | parse_execution_date
+52 | round_time
+53 | scale_time_units
+   | ^^^^^^^^^^^^^^^^ AIR302
+54 | infer_time_unit
+   |
+
+AIR302_names.py:54:1: AIR302 `airflow.utils.dates.infer_time_unit` is removed in Airflow 3.0
+   |
+52 | round_time
+53 | scale_time_units
+54 | infer_time_unit
+   | ^^^^^^^^^^^^^^^ AIR302
+   |
+
+AIR302_names.py:61:1: AIR302 `airflow.configuration.get` is removed in Airflow 3.0; use `airflow.configuration.conf.get` instead
+   |
+59 | dates.datetime_to_nano
+60 | 
+61 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+   | ^^^ AIR302
+62 | 
+63 | get_connection, load_connections
+   |
+
+AIR302_names.py:61:6: AIR302 `airflow.configuration.getboolean` is removed in Airflow 3.0; use `airflow.configuration.conf.getboolean` instead
+   |
+59 | dates.datetime_to_nano
+60 | 
+61 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+   |      ^^^^^^^^^^ AIR302
+62 | 
+63 | get_connection, load_connections
+   |
+
+AIR302_names.py:61:18: AIR302 `airflow.configuration.getfloat` is removed in Airflow 3.0; use `airflow.configuration.conf.getfloat` instead
+   |
+59 | dates.datetime_to_nano
+60 | 
+61 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+   |                  ^^^^^^^^ AIR302
+62 | 
+63 | get_connection, load_connections
+   |
+
+AIR302_names.py:61:28: AIR302 `airflow.configuration.getint` is removed in Airflow 3.0; use `airflow.configuration.conf.getint` instead
+   |
+59 | dates.datetime_to_nano
+60 | 
+61 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+   |                            ^^^^^^ AIR302
+62 | 
+63 | get_connection, load_connections
+   |
+
+AIR302_names.py:61:36: AIR302 `airflow.configuration.has_option` is removed in Airflow 3.0; use `airflow.configuration.conf.has_option` instead
+   |
+59 | dates.datetime_to_nano
+60 | 
+61 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+   |                                    ^^^^^^^^^^ AIR302
+62 | 
+63 | get_connection, load_connections
+   |
+
+AIR302_names.py:61:48: AIR302 `airflow.configuration.remove_option` is removed in Airflow 3.0; use `airflow.configuration.conf.remove_option` instead
+   |
+59 | dates.datetime_to_nano
+60 | 
+61 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+   |                                                ^^^^^^^^^^^^^ AIR302
+62 | 
+63 | get_connection, load_connections
+   |
+
+AIR302_names.py:61:63: AIR302 `airflow.configuration.as_dict` is removed in Airflow 3.0; use `airflow.configuration.conf.as_dict` instead
+   |
+59 | dates.datetime_to_nano
+60 | 
+61 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+   |                                                               ^^^^^^^ AIR302
+62 | 
+63 | get_connection, load_connections
+   |
+
+AIR302_names.py:61:72: AIR302 `airflow.configuration.set` is removed in Airflow 3.0; use `airflow.configuration.conf.set` instead
+   |
+59 | dates.datetime_to_nano
+60 | 
+61 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+   |                                                                        ^^^ AIR302
+62 | 
+63 | get_connection, load_connections
+   |
+
+AIR302_names.py:63:1: AIR302 `airflow.secrets.local_filesystem.get_connection` is removed in Airflow 3.0; use `airflow.secrets.local_filesystem.load_connections_dict` instead
+   |
+61 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+62 | 
+63 | get_connection, load_connections
+   | ^^^^^^^^^^^^^^ AIR302
+64 | 
+65 | TemporaryDirectory
+   |
+
+AIR302_names.py:63:17: AIR302 `airflow.secrets.local_filesystem.load_connections` is removed in Airflow 3.0; use `airflow.secrets.local_filesystem.load_connections_dict` instead
+   |
+61 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+62 | 
+63 | get_connection, load_connections
+   |                 ^^^^^^^^^^^^^^^^ AIR302
+64 | 
+65 | TemporaryDirectory
+   |
+
+AIR302_names.py:65:1: AIR302 `airflow.utils.file.TemporaryDirectory` is removed in Airflow 3.0
+   |
+63 | get_connection, load_connections
+64 | 
+65 | TemporaryDirectory
    | ^^^^^^^^^^^^^^^^^^ AIR302
+66 | mkdirs
+   |
+
+AIR302_names.py:66:1: AIR302 `airflow.utils.file.mkdirs` is removed in Airflow 3.0; use `pendulum.today('UTC').add(days=-N, ...)` instead
+   |
+65 | TemporaryDirectory
+66 | mkdirs
+   | ^^^^^^ AIR302
+67 | 
+68 | chain
+   |
+
+AIR302_names.py:68:1: AIR302 `airflow.utils.helpers.chain` is removed in Airflow 3.0; use `airflow.models.baseoperator.chain` instead
+   |
+66 | mkdirs
+67 | 
+68 | chain
+   | ^^^^^ AIR302
+69 | cross_downstream
+   |
+
+AIR302_names.py:69:1: AIR302 `airflow.utils.helpers.cross_downstream` is removed in Airflow 3.0; use `airflow.models.baseoperator.cross_downstream` instead
+   |
+68 | chain
+69 | cross_downstream
+   | ^^^^^^^^^^^^^^^^ AIR302
 70 | 
-71 | test_cycle
+71 | SHUTDOWN
    |
 
-AIR302_names.py:71:1: AIR302 `airflow.utils.dag_cycle_tester.test_cycle` is removed in Airflow 3.0
+AIR302_names.py:71:1: AIR302 `airflow.utils.state.SHUTDOWN` is removed in Airflow 3.0
    |
-69 | terminating_states
+69 | cross_downstream
 70 | 
-71 | test_cycle
-   | ^^^^^^^^^^ AIR302
-72 | 
-73 | has_access
+71 | SHUTDOWN
+   | ^^^^^^^^ AIR302
+72 | terminating_states
    |
 
-AIR302_names.py:73:1: AIR302 `airflow.www.auth.has_access` is removed in Airflow 3.0; use `airflow.www.auth.has_access_*` instead
+AIR302_names.py:72:1: AIR302 `airflow.utils.state.terminating_states` is removed in Airflow 3.0
    |
-71 | test_cycle
-72 | 
-73 | has_access
-   | ^^^^^^^^^^ AIR302
-74 | get_sensitive_variables_fields, should_hide_value_for_key
+71 | SHUTDOWN
+72 | terminating_states
+   | ^^^^^^^^^^^^^^^^^^ AIR302
+73 | 
+74 | test_cycle
    |
 
-AIR302_names.py:74:1: AIR302 `airflow.www.utils.get_sensitive_variables_fields` is removed in Airflow 3.0; use `airflow.utils.log.secrets_masker.get_sensitive_variables_fields` instead
+AIR302_names.py:74:1: AIR302 `airflow.utils.dag_cycle_tester.test_cycle` is removed in Airflow 3.0
    |
-73 | has_access
-74 | get_sensitive_variables_fields, should_hide_value_for_key
+72 | terminating_states
+73 | 
+74 | test_cycle
+   | ^^^^^^^^^^ AIR302
+75 | 
+76 | has_access
+   |
+
+AIR302_names.py:76:1: AIR302 `airflow.www.auth.has_access` is removed in Airflow 3.0; use `airflow.www.auth.has_access_*` instead
+   |
+74 | test_cycle
+75 | 
+76 | has_access
+   | ^^^^^^^^^^ AIR302
+77 | get_sensitive_variables_fields, should_hide_value_for_key
+   |
+
+AIR302_names.py:77:1: AIR302 `airflow.www.utils.get_sensitive_variables_fields` is removed in Airflow 3.0; use `airflow.utils.log.secrets_masker.get_sensitive_variables_fields` instead
+   |
+76 | has_access
+77 | get_sensitive_variables_fields, should_hide_value_for_key
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
    |
 
-AIR302_names.py:74:33: AIR302 `airflow.www.utils.should_hide_value_for_key` is removed in Airflow 3.0; use `airflow.utils.log.secrets_masker.should_hide_value_for_key` instead
+AIR302_names.py:77:33: AIR302 `airflow.www.utils.should_hide_value_for_key` is removed in Airflow 3.0; use `airflow.utils.log.secrets_masker.should_hide_value_for_key` instead
    |
-73 | has_access
-74 | get_sensitive_variables_fields, should_hide_value_for_key
+76 | has_access
+77 | get_sensitive_variables_fields, should_hide_value_for_key
    |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
    |

--- a/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_names.py.snap
+++ b/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_names.py.snap
@@ -2,527 +2,537 @@
 source: crates/ruff_linter/src/rules/airflow/mod.rs
 snapshot_kind: text
 ---
-AIR302_names.py:51:1: AIR302 `airflow.PY36` is removed in Airflow 3.0; use `sys.version_info` instead
+AIR302_names.py:52:1: AIR302 `airflow.PY36` is removed in Airflow 3.0; use `sys.version_info` instead
    |
-49 | from airflow.www.utils import get_sensitive_variables_fields, should_hide_value_for_key
-50 | 
-51 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
+50 | from airflow.www.utils import get_sensitive_variables_fields, should_hide_value_for_key
+51 | 
+52 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
    | ^^^^ AIR302
-52 | 
-53 | AWSAthenaHook
+53 | 
+54 | AWSAthenaHook
    |
 
-AIR302_names.py:51:7: AIR302 `airflow.PY37` is removed in Airflow 3.0; use `sys.version_info` instead
+AIR302_names.py:52:7: AIR302 `airflow.PY37` is removed in Airflow 3.0; use `sys.version_info` instead
    |
-49 | from airflow.www.utils import get_sensitive_variables_fields, should_hide_value_for_key
-50 | 
-51 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
+50 | from airflow.www.utils import get_sensitive_variables_fields, should_hide_value_for_key
+51 | 
+52 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
    |       ^^^^ AIR302
-52 | 
-53 | AWSAthenaHook
+53 | 
+54 | AWSAthenaHook
    |
 
-AIR302_names.py:51:13: AIR302 `airflow.PY38` is removed in Airflow 3.0; use `sys.version_info` instead
+AIR302_names.py:52:13: AIR302 `airflow.PY38` is removed in Airflow 3.0; use `sys.version_info` instead
    |
-49 | from airflow.www.utils import get_sensitive_variables_fields, should_hide_value_for_key
-50 | 
-51 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
+50 | from airflow.www.utils import get_sensitive_variables_fields, should_hide_value_for_key
+51 | 
+52 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
    |             ^^^^ AIR302
-52 | 
-53 | AWSAthenaHook
+53 | 
+54 | AWSAthenaHook
    |
 
-AIR302_names.py:51:19: AIR302 `airflow.PY39` is removed in Airflow 3.0; use `sys.version_info` instead
+AIR302_names.py:52:19: AIR302 `airflow.PY39` is removed in Airflow 3.0; use `sys.version_info` instead
    |
-49 | from airflow.www.utils import get_sensitive_variables_fields, should_hide_value_for_key
-50 | 
-51 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
+50 | from airflow.www.utils import get_sensitive_variables_fields, should_hide_value_for_key
+51 | 
+52 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
    |                   ^^^^ AIR302
-52 | 
-53 | AWSAthenaHook
+53 | 
+54 | AWSAthenaHook
    |
 
-AIR302_names.py:51:25: AIR302 `airflow.PY310` is removed in Airflow 3.0; use `sys.version_info` instead
+AIR302_names.py:52:25: AIR302 `airflow.PY310` is removed in Airflow 3.0; use `sys.version_info` instead
    |
-49 | from airflow.www.utils import get_sensitive_variables_fields, should_hide_value_for_key
-50 | 
-51 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
+50 | from airflow.www.utils import get_sensitive_variables_fields, should_hide_value_for_key
+51 | 
+52 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
    |                         ^^^^^ AIR302
-52 | 
-53 | AWSAthenaHook
+53 | 
+54 | AWSAthenaHook
    |
 
-AIR302_names.py:51:32: AIR302 `airflow.PY311` is removed in Airflow 3.0; use `sys.version_info` instead
+AIR302_names.py:52:32: AIR302 `airflow.PY311` is removed in Airflow 3.0; use `sys.version_info` instead
    |
-49 | from airflow.www.utils import get_sensitive_variables_fields, should_hide_value_for_key
-50 | 
-51 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
+50 | from airflow.www.utils import get_sensitive_variables_fields, should_hide_value_for_key
+51 | 
+52 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
    |                                ^^^^^ AIR302
-52 | 
-53 | AWSAthenaHook
+53 | 
+54 | AWSAthenaHook
    |
 
-AIR302_names.py:51:39: AIR302 `airflow.PY312` is removed in Airflow 3.0; use `sys.version_info` instead
+AIR302_names.py:52:39: AIR302 `airflow.PY312` is removed in Airflow 3.0; use `sys.version_info` instead
    |
-49 | from airflow.www.utils import get_sensitive_variables_fields, should_hide_value_for_key
-50 | 
-51 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
+50 | from airflow.www.utils import get_sensitive_variables_fields, should_hide_value_for_key
+51 | 
+52 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
    |                                       ^^^^^ AIR302
-52 | 
-53 | AWSAthenaHook
+53 | 
+54 | AWSAthenaHook
    |
 
-AIR302_names.py:53:1: AIR302 `airflow.contrib.aws_athena_hook.AWSAthenaHook` is removed in Airflow 3.0
+AIR302_names.py:54:1: AIR302 `airflow.contrib.aws_athena_hook.AWSAthenaHook` is removed in Airflow 3.0
    |
-51 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
-52 | 
-53 | AWSAthenaHook
+52 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
+53 | 
+54 | AWSAthenaHook
    | ^^^^^^^^^^^^^ AIR302
-54 | TaskStateTrigger
+55 | TaskStateTrigger
    |
 
-AIR302_names.py:54:1: AIR302 `airflow.triggers.external_task.TaskStateTrigger` is removed in Airflow 3.0
+AIR302_names.py:55:1: AIR302 `airflow.triggers.external_task.TaskStateTrigger` is removed in Airflow 3.0
    |
-53 | AWSAthenaHook
-54 | TaskStateTrigger
+54 | AWSAthenaHook
+55 | TaskStateTrigger
    | ^^^^^^^^^^^^^^^^ AIR302
-55 | 
-56 | requires_access
+56 | 
+57 | requires_access
    |
 
-AIR302_names.py:56:1: AIR302 `airflow.api_connexion.security.requires_access` is removed in Airflow 3.0; use `airflow.api_connexion.security.requires_access_*` instead
+AIR302_names.py:57:1: AIR302 `airflow.api_connexion.security.requires_access` is removed in Airflow 3.0; use `airflow.api_connexion.security.requires_access_*` instead
    |
-54 | TaskStateTrigger
-55 | 
-56 | requires_access
+55 | TaskStateTrigger
+56 | 
+57 | requires_access
    | ^^^^^^^^^^^^^^^ AIR302
-57 | 
-58 | AllowListValidator
+58 | 
+59 | AllowListValidator
    |
 
-AIR302_names.py:58:1: AIR302 `airflow.metrics.validators.AllowListValidator` is removed in Airflow 3.0; use `airflow.metrics.validators.PatternAllowListValidator` instead
+AIR302_names.py:59:1: AIR302 `airflow.metrics.validators.AllowListValidator` is removed in Airflow 3.0; use `airflow.metrics.validators.PatternAllowListValidator` instead
    |
-56 | requires_access
-57 | 
-58 | AllowListValidator
+57 | requires_access
+58 | 
+59 | AllowListValidator
    | ^^^^^^^^^^^^^^^^^^ AIR302
-59 | BlockListValidator
+60 | BlockListValidator
    |
 
-AIR302_names.py:59:1: AIR302 `airflow.metrics.validators.BlockListValidator` is removed in Airflow 3.0; use `airflow.metrics.validators.PatternBlockListValidator` instead
+AIR302_names.py:60:1: AIR302 `airflow.metrics.validators.BlockListValidator` is removed in Airflow 3.0; use `airflow.metrics.validators.PatternBlockListValidator` instead
    |
-58 | AllowListValidator
-59 | BlockListValidator
+59 | AllowListValidator
+60 | BlockListValidator
    | ^^^^^^^^^^^^^^^^^^ AIR302
-60 | 
-61 | SubDagOperator
+61 | 
+62 | SubDagOperator
    |
 
-AIR302_names.py:61:1: AIR302 `airflow.operators.subdag.SubDagOperator` is removed in Airflow 3.0
+AIR302_names.py:62:1: AIR302 `airflow.operators.subdag.SubDagOperator` is removed in Airflow 3.0
    |
-59 | BlockListValidator
-60 | 
-61 | SubDagOperator
+60 | BlockListValidator
+61 | 
+62 | SubDagOperator
    | ^^^^^^^^^^^^^^ AIR302
-62 | 
-63 | dates.date_range
+63 | 
+64 | dates.date_range
    |
 
-AIR302_names.py:63:7: AIR302 `airflow.utils.dates.date_range` is removed in Airflow 3.0; use `airflow.timetables.` instead
+AIR302_names.py:64:7: AIR302 `airflow.utils.dates.date_range` is removed in Airflow 3.0; use `airflow.timetables.` instead
    |
-61 | SubDagOperator
-62 | 
-63 | dates.date_range
+62 | SubDagOperator
+63 | 
+64 | dates.date_range
    |       ^^^^^^^^^^ AIR302
-64 | dates.days_ago
+65 | dates.days_ago
    |
 
-AIR302_names.py:64:7: AIR302 `airflow.utils.dates.days_ago` is removed in Airflow 3.0; use `pendulum.today('UTC').add(days=-N, ...)` instead
+AIR302_names.py:65:7: AIR302 `airflow.utils.dates.days_ago` is removed in Airflow 3.0; use `pendulum.today('UTC').add(days=-N, ...)` instead
    |
-63 | dates.date_range
-64 | dates.days_ago
+64 | dates.date_range
+65 | dates.days_ago
    |       ^^^^^^^^ AIR302
-65 | 
-66 | date_range
+66 | 
+67 | date_range
    |
 
-AIR302_names.py:66:1: AIR302 `airflow.utils.dates.date_range` is removed in Airflow 3.0; use `airflow.timetables.` instead
+AIR302_names.py:67:1: AIR302 `airflow.utils.dates.date_range` is removed in Airflow 3.0; use `airflow.timetables.` instead
    |
-64 | dates.days_ago
-65 | 
-66 | date_range
+65 | dates.days_ago
+66 | 
+67 | date_range
    | ^^^^^^^^^^ AIR302
-67 | days_ago
-68 | parse_execution_date
+68 | days_ago
+69 | parse_execution_date
    |
 
-AIR302_names.py:67:1: AIR302 `airflow.utils.dates.days_ago` is removed in Airflow 3.0; use `pendulum.today('UTC').add(days=-N, ...)` instead
+AIR302_names.py:68:1: AIR302 `airflow.utils.dates.days_ago` is removed in Airflow 3.0; use `pendulum.today('UTC').add(days=-N, ...)` instead
    |
-66 | date_range
-67 | days_ago
+67 | date_range
+68 | days_ago
    | ^^^^^^^^ AIR302
-68 | parse_execution_date
-69 | round_time
+69 | parse_execution_date
+70 | round_time
    |
 
-AIR302_names.py:68:1: AIR302 `airflow.utils.dates.parse_execution_date` is removed in Airflow 3.0
+AIR302_names.py:69:1: AIR302 `airflow.utils.dates.parse_execution_date` is removed in Airflow 3.0
    |
-66 | date_range
-67 | days_ago
-68 | parse_execution_date
+67 | date_range
+68 | days_ago
+69 | parse_execution_date
    | ^^^^^^^^^^^^^^^^^^^^ AIR302
-69 | round_time
-70 | scale_time_units
+70 | round_time
+71 | scale_time_units
    |
 
-AIR302_names.py:69:1: AIR302 `airflow.utils.dates.round_time` is removed in Airflow 3.0
+AIR302_names.py:70:1: AIR302 `airflow.utils.dates.round_time` is removed in Airflow 3.0
    |
-67 | days_ago
-68 | parse_execution_date
-69 | round_time
+68 | days_ago
+69 | parse_execution_date
+70 | round_time
    | ^^^^^^^^^^ AIR302
-70 | scale_time_units
-71 | infer_time_unit
+71 | scale_time_units
+72 | infer_time_unit
    |
 
-AIR302_names.py:70:1: AIR302 `airflow.utils.dates.scale_time_units` is removed in Airflow 3.0
+AIR302_names.py:71:1: AIR302 `airflow.utils.dates.scale_time_units` is removed in Airflow 3.0
    |
-68 | parse_execution_date
-69 | round_time
-70 | scale_time_units
+69 | parse_execution_date
+70 | round_time
+71 | scale_time_units
    | ^^^^^^^^^^^^^^^^ AIR302
-71 | infer_time_unit
+72 | infer_time_unit
    |
 
-AIR302_names.py:71:1: AIR302 `airflow.utils.dates.infer_time_unit` is removed in Airflow 3.0
+AIR302_names.py:72:1: AIR302 `airflow.utils.dates.infer_time_unit` is removed in Airflow 3.0
    |
-69 | round_time
-70 | scale_time_units
-71 | infer_time_unit
+70 | round_time
+71 | scale_time_units
+72 | infer_time_unit
    | ^^^^^^^^^^^^^^^ AIR302
    |
 
-AIR302_names.py:78:1: AIR302 `airflow.configuration.get` is removed in Airflow 3.0; use `airflow.configuration.conf.get` instead
+AIR302_names.py:79:1: AIR302 `airflow.configuration.get` is removed in Airflow 3.0; use `airflow.configuration.conf.get` instead
    |
-76 | dates.datetime_to_nano
-77 | 
-78 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+77 | dates.datetime_to_nano
+78 | 
+79 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
    | ^^^ AIR302
-79 | 
-80 | get_connection, load_connections
+80 | 
+81 | get_connection, load_connections
    |
 
-AIR302_names.py:78:6: AIR302 `airflow.configuration.getboolean` is removed in Airflow 3.0; use `airflow.configuration.conf.getboolean` instead
+AIR302_names.py:79:6: AIR302 `airflow.configuration.getboolean` is removed in Airflow 3.0; use `airflow.configuration.conf.getboolean` instead
    |
-76 | dates.datetime_to_nano
-77 | 
-78 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+77 | dates.datetime_to_nano
+78 | 
+79 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
    |      ^^^^^^^^^^ AIR302
-79 | 
-80 | get_connection, load_connections
+80 | 
+81 | get_connection, load_connections
    |
 
-AIR302_names.py:78:18: AIR302 `airflow.configuration.getfloat` is removed in Airflow 3.0; use `airflow.configuration.conf.getfloat` instead
+AIR302_names.py:79:18: AIR302 `airflow.configuration.getfloat` is removed in Airflow 3.0; use `airflow.configuration.conf.getfloat` instead
    |
-76 | dates.datetime_to_nano
-77 | 
-78 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+77 | dates.datetime_to_nano
+78 | 
+79 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
    |                  ^^^^^^^^ AIR302
-79 | 
-80 | get_connection, load_connections
+80 | 
+81 | get_connection, load_connections
    |
 
-AIR302_names.py:78:28: AIR302 `airflow.configuration.getint` is removed in Airflow 3.0; use `airflow.configuration.conf.getint` instead
+AIR302_names.py:79:28: AIR302 `airflow.configuration.getint` is removed in Airflow 3.0; use `airflow.configuration.conf.getint` instead
    |
-76 | dates.datetime_to_nano
-77 | 
-78 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+77 | dates.datetime_to_nano
+78 | 
+79 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
    |                            ^^^^^^ AIR302
-79 | 
-80 | get_connection, load_connections
+80 | 
+81 | get_connection, load_connections
    |
 
-AIR302_names.py:78:36: AIR302 `airflow.configuration.has_option` is removed in Airflow 3.0; use `airflow.configuration.conf.has_option` instead
+AIR302_names.py:79:36: AIR302 `airflow.configuration.has_option` is removed in Airflow 3.0; use `airflow.configuration.conf.has_option` instead
    |
-76 | dates.datetime_to_nano
-77 | 
-78 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+77 | dates.datetime_to_nano
+78 | 
+79 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
    |                                    ^^^^^^^^^^ AIR302
-79 | 
-80 | get_connection, load_connections
+80 | 
+81 | get_connection, load_connections
    |
 
-AIR302_names.py:78:48: AIR302 `airflow.configuration.remove_option` is removed in Airflow 3.0; use `airflow.configuration.conf.remove_option` instead
+AIR302_names.py:79:48: AIR302 `airflow.configuration.remove_option` is removed in Airflow 3.0; use `airflow.configuration.conf.remove_option` instead
    |
-76 | dates.datetime_to_nano
-77 | 
-78 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+77 | dates.datetime_to_nano
+78 | 
+79 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
    |                                                ^^^^^^^^^^^^^ AIR302
-79 | 
-80 | get_connection, load_connections
+80 | 
+81 | get_connection, load_connections
    |
 
-AIR302_names.py:78:63: AIR302 `airflow.configuration.as_dict` is removed in Airflow 3.0; use `airflow.configuration.conf.as_dict` instead
+AIR302_names.py:79:63: AIR302 `airflow.configuration.as_dict` is removed in Airflow 3.0; use `airflow.configuration.conf.as_dict` instead
    |
-76 | dates.datetime_to_nano
-77 | 
-78 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+77 | dates.datetime_to_nano
+78 | 
+79 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
    |                                                               ^^^^^^^ AIR302
-79 | 
-80 | get_connection, load_connections
+80 | 
+81 | get_connection, load_connections
    |
 
-AIR302_names.py:78:72: AIR302 `airflow.configuration.set` is removed in Airflow 3.0; use `airflow.configuration.conf.set` instead
+AIR302_names.py:79:72: AIR302 `airflow.configuration.set` is removed in Airflow 3.0; use `airflow.configuration.conf.set` instead
    |
-76 | dates.datetime_to_nano
-77 | 
-78 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+77 | dates.datetime_to_nano
+78 | 
+79 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
    |                                                                        ^^^ AIR302
-79 | 
-80 | get_connection, load_connections
+80 | 
+81 | get_connection, load_connections
    |
 
-AIR302_names.py:80:1: AIR302 `airflow.secrets.local_filesystem.get_connection` is removed in Airflow 3.0; use `airflow.secrets.local_filesystem.load_connections_dict` instead
+AIR302_names.py:81:1: AIR302 `airflow.secrets.local_filesystem.get_connection` is removed in Airflow 3.0; use `airflow.secrets.local_filesystem.load_connections_dict` instead
    |
-78 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
-79 | 
-80 | get_connection, load_connections
+79 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+80 | 
+81 | get_connection, load_connections
    | ^^^^^^^^^^^^^^ AIR302
    |
 
-AIR302_names.py:80:17: AIR302 `airflow.secrets.local_filesystem.load_connections` is removed in Airflow 3.0; use `airflow.secrets.local_filesystem.load_connections_dict` instead
+AIR302_names.py:81:17: AIR302 `airflow.secrets.local_filesystem.load_connections` is removed in Airflow 3.0; use `airflow.secrets.local_filesystem.load_connections_dict` instead
    |
-78 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
-79 | 
-80 | get_connection, load_connections
+79 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+80 | 
+81 | get_connection, load_connections
    |                 ^^^^^^^^^^^^^^^^ AIR302
    |
 
-AIR302_names.py:83:1: AIR302 `airflow.sensors.external_task_sensor.ExternalTaskSensorLink` is removed in Airflow 3.0; use `airflow.sensors.external_task.ExternalTaskSensorLink` instead
+AIR302_names.py:84:1: AIR302 `airflow.sensors.external_task_sensor.ExternalTaskSensorLink` is removed in Airflow 3.0; use `airflow.sensors.external_task.ExternalTaskSensorLink` instead
    |
-83 | ExternalTaskSensorLink
+84 | ExternalTaskSensorLink
    | ^^^^^^^^^^^^^^^^^^^^^^ AIR302
-84 | BashOperator
-85 | BaseBranchOperator
+85 | BashOperator
+86 | BaseBranchOperator
    |
 
-AIR302_names.py:84:1: AIR302 `airflow.operators.bash_operator.BashOperator` is removed in Airflow 3.0; use `airflow.operators.bash.BashOperator` instead
+AIR302_names.py:85:1: AIR302 `airflow.operators.bash_operator.BashOperator` is removed in Airflow 3.0; use `airflow.operators.bash.BashOperator` instead
    |
-83 | ExternalTaskSensorLink
-84 | BashOperator
+84 | ExternalTaskSensorLink
+85 | BashOperator
    | ^^^^^^^^^^^^ AIR302
-85 | BaseBranchOperator
-86 | EmptyOperator, DummyOperator
+86 | BaseBranchOperator
+87 | EmptyOperator, DummyOperator
    |
 
-AIR302_names.py:85:1: AIR302 `airflow.operators.branch_operator.BaseBranchOperator` is removed in Airflow 3.0; use `airflow.operators.branch.BaseBranchOperator` instead
+AIR302_names.py:86:1: AIR302 `airflow.operators.branch_operator.BaseBranchOperator` is removed in Airflow 3.0; use `airflow.operators.branch.BaseBranchOperator` instead
    |
-83 | ExternalTaskSensorLink
-84 | BashOperator
-85 | BaseBranchOperator
+84 | ExternalTaskSensorLink
+85 | BashOperator
+86 | BaseBranchOperator
    | ^^^^^^^^^^^^^^^^^^ AIR302
-86 | EmptyOperator, DummyOperator
-87 | dummy_operator.EmptyOperator
+87 | EmptyOperator, DummyOperator
+88 | dummy_operator.EmptyOperator
    |
 
-AIR302_names.py:86:16: AIR302 `airflow.operators.dummy.DummyOperator` is removed in Airflow 3.0; use `airflow.operators.empty.EmptyOperator` instead
+AIR302_names.py:87:16: AIR302 `airflow.operators.dummy.DummyOperator` is removed in Airflow 3.0; use `airflow.operators.empty.EmptyOperator` instead
    |
-84 | BashOperator
-85 | BaseBranchOperator
-86 | EmptyOperator, DummyOperator
+85 | BashOperator
+86 | BaseBranchOperator
+87 | EmptyOperator, DummyOperator
    |                ^^^^^^^^^^^^^ AIR302
-87 | dummy_operator.EmptyOperator
-88 | dummy_operator.DummyOperator
+88 | dummy_operator.EmptyOperator
+89 | dummy_operator.DummyOperator
    |
 
-AIR302_names.py:87:16: AIR302 `airflow.operators.dummy_operator.EmptyOperator` is removed in Airflow 3.0; use `airflow.operators.empty.EmptyOperator` instead
+AIR302_names.py:88:16: AIR302 `airflow.operators.dummy_operator.EmptyOperator` is removed in Airflow 3.0; use `airflow.operators.empty.EmptyOperator` instead
    |
-85 | BaseBranchOperator
-86 | EmptyOperator, DummyOperator
-87 | dummy_operator.EmptyOperator
+86 | BaseBranchOperator
+87 | EmptyOperator, DummyOperator
+88 | dummy_operator.EmptyOperator
    |                ^^^^^^^^^^^^^ AIR302
-88 | dummy_operator.DummyOperator
-89 | EmailOperator
+89 | dummy_operator.DummyOperator
+90 | EmailOperator
    |
 
-AIR302_names.py:88:16: AIR302 `airflow.operators.dummy_operator.DummyOperator` is removed in Airflow 3.0; use `airflow.operators.empty.EmptyOperator` instead
+AIR302_names.py:89:16: AIR302 `airflow.operators.dummy_operator.DummyOperator` is removed in Airflow 3.0; use `airflow.operators.empty.EmptyOperator` instead
    |
-86 | EmptyOperator, DummyOperator
-87 | dummy_operator.EmptyOperator
-88 | dummy_operator.DummyOperator
+87 | EmptyOperator, DummyOperator
+88 | dummy_operator.EmptyOperator
+89 | dummy_operator.DummyOperator
    |                ^^^^^^^^^^^^^ AIR302
-89 | EmailOperator
-90 | BaseSensorOperator
+90 | EmailOperator
+91 | BaseSensorOperator
    |
 
-AIR302_names.py:89:1: AIR302 `airflow.operators.email_operator.EmailOperator` is removed in Airflow 3.0; use `airflow.operators.email.EmailOperator` instead
+AIR302_names.py:90:1: AIR302 `airflow.operators.email_operator.EmailOperator` is removed in Airflow 3.0; use `airflow.operators.email.EmailOperator` instead
    |
-87 | dummy_operator.EmptyOperator
-88 | dummy_operator.DummyOperator
-89 | EmailOperator
+88 | dummy_operator.EmptyOperator
+89 | dummy_operator.DummyOperator
+90 | EmailOperator
    | ^^^^^^^^^^^^^ AIR302
-90 | BaseSensorOperator
-91 | DateTimeSensor
+91 | BaseSensorOperator
+92 | DateTimeSensor
    |
 
-AIR302_names.py:90:1: AIR302 `airflow.sensors.base_sensor_operator.BaseSensorOperator` is removed in Airflow 3.0; use `airflow.sensors.base.BaseSensorOperator` instead
+AIR302_names.py:91:1: AIR302 `airflow.sensors.base_sensor_operator.BaseSensorOperator` is removed in Airflow 3.0; use `airflow.sensors.base.BaseSensorOperator` instead
    |
-88 | dummy_operator.DummyOperator
-89 | EmailOperator
-90 | BaseSensorOperator
+89 | dummy_operator.DummyOperator
+90 | EmailOperator
+91 | BaseSensorOperator
    | ^^^^^^^^^^^^^^^^^^ AIR302
-91 | DateTimeSensor
-92 | (ExternalTaskMarker, ExternalTaskSensor, ExternalTaskSensorLink)
+92 | DateTimeSensor
+93 | (ExternalTaskMarker, ExternalTaskSensor, ExternalTaskSensorLink)
    |
 
-AIR302_names.py:91:1: AIR302 `airflow.sensors.date_time_sensor.DateTimeSensor` is removed in Airflow 3.0; use `airflow.sensors.date_time.DateTimeSensor` instead
+AIR302_names.py:92:1: AIR302 `airflow.sensors.date_time_sensor.DateTimeSensor` is removed in Airflow 3.0; use `airflow.sensors.date_time.DateTimeSensor` instead
    |
-89 | EmailOperator
-90 | BaseSensorOperator
-91 | DateTimeSensor
+90 | EmailOperator
+91 | BaseSensorOperator
+92 | DateTimeSensor
    | ^^^^^^^^^^^^^^ AIR302
-92 | (ExternalTaskMarker, ExternalTaskSensor, ExternalTaskSensorLink)
-93 | TimeDeltaSensor
+93 | (ExternalTaskMarker, ExternalTaskSensor, ExternalTaskSensorLink)
+94 | TimeDeltaSensor
    |
 
-AIR302_names.py:92:2: AIR302 `airflow.sensors.external_task_sensor.ExternalTaskMarker` is removed in Airflow 3.0; use `airflow.sensors.external_task.ExternalTaskMarker` instead
+AIR302_names.py:93:2: AIR302 `airflow.sensors.external_task_sensor.ExternalTaskMarker` is removed in Airflow 3.0; use `airflow.sensors.external_task.ExternalTaskMarker` instead
    |
-90 | BaseSensorOperator
-91 | DateTimeSensor
-92 | (ExternalTaskMarker, ExternalTaskSensor, ExternalTaskSensorLink)
+91 | BaseSensorOperator
+92 | DateTimeSensor
+93 | (ExternalTaskMarker, ExternalTaskSensor, ExternalTaskSensorLink)
    |  ^^^^^^^^^^^^^^^^^^ AIR302
-93 | TimeDeltaSensor
+94 | TimeDeltaSensor
    |
 
-AIR302_names.py:92:22: AIR302 `airflow.sensors.external_task_sensor.ExternalTaskSensor` is removed in Airflow 3.0; use `airflow.sensors.external_task.ExternalTaskSensor` instead
+AIR302_names.py:93:22: AIR302 `airflow.sensors.external_task_sensor.ExternalTaskSensor` is removed in Airflow 3.0; use `airflow.sensors.external_task.ExternalTaskSensor` instead
    |
-90 | BaseSensorOperator
-91 | DateTimeSensor
-92 | (ExternalTaskMarker, ExternalTaskSensor, ExternalTaskSensorLink)
+91 | BaseSensorOperator
+92 | DateTimeSensor
+93 | (ExternalTaskMarker, ExternalTaskSensor, ExternalTaskSensorLink)
    |                      ^^^^^^^^^^^^^^^^^^ AIR302
-93 | TimeDeltaSensor
+94 | TimeDeltaSensor
    |
 
-AIR302_names.py:92:42: AIR302 `airflow.sensors.external_task_sensor.ExternalTaskSensorLink` is removed in Airflow 3.0; use `airflow.sensors.external_task.ExternalTaskSensorLink` instead
+AIR302_names.py:93:42: AIR302 `airflow.sensors.external_task_sensor.ExternalTaskSensorLink` is removed in Airflow 3.0; use `airflow.sensors.external_task.ExternalTaskSensorLink` instead
    |
-90 | BaseSensorOperator
-91 | DateTimeSensor
-92 | (ExternalTaskMarker, ExternalTaskSensor, ExternalTaskSensorLink)
+91 | BaseSensorOperator
+92 | DateTimeSensor
+93 | (ExternalTaskMarker, ExternalTaskSensor, ExternalTaskSensorLink)
    |                                          ^^^^^^^^^^^^^^^^^^^^^^ AIR302
-93 | TimeDeltaSensor
+94 | TimeDeltaSensor
    |
 
-AIR302_names.py:93:1: AIR302 `airflow.sensors.time_delta_sensor.TimeDeltaSensor` is removed in Airflow 3.0; use `airflow.sensors.time_delta.TimeDeltaSensor` instead
+AIR302_names.py:94:1: AIR302 `airflow.sensors.time_delta_sensor.TimeDeltaSensor` is removed in Airflow 3.0; use `airflow.sensors.time_delta.TimeDeltaSensor` instead
    |
-91 | DateTimeSensor
-92 | (ExternalTaskMarker, ExternalTaskSensor, ExternalTaskSensorLink)
-93 | TimeDeltaSensor
+92 | DateTimeSensor
+93 | (ExternalTaskMarker, ExternalTaskSensor, ExternalTaskSensorLink)
+94 | TimeDeltaSensor
    | ^^^^^^^^^^^^^^^ AIR302
-94 | 
-95 | TemporaryDirectory
+95 | 
+96 | apply_defaults
    |
 
-AIR302_names.py:95:1: AIR302 `airflow.utils.file.TemporaryDirectory` is removed in Airflow 3.0
+AIR302_names.py:96:1: AIR302 `airflow.utils.decorators.apply_defaults` is removed in Airflow 3.0; `apply_defaults` is now unconditionally done and can be safely removed.
    |
-93 | TimeDeltaSensor
-94 | 
-95 | TemporaryDirectory
+94 | TimeDeltaSensor
+95 | 
+96 | apply_defaults
+   | ^^^^^^^^^^^^^^ AIR302
+97 | 
+98 | TemporaryDirectory
+   |
+
+AIR302_names.py:98:1: AIR302 `airflow.utils.file.TemporaryDirectory` is removed in Airflow 3.0
+   |
+96 | apply_defaults
+97 | 
+98 | TemporaryDirectory
    | ^^^^^^^^^^^^^^^^^^ AIR302
-96 | mkdirs
+99 | mkdirs
    |
 
-AIR302_names.py:96:1: AIR302 `airflow.utils.file.mkdirs` is removed in Airflow 3.0; use `pendulum.today('UTC').add(days=-N, ...)` instead
-   |
-95 | TemporaryDirectory
-96 | mkdirs
-   | ^^^^^^ AIR302
-97 | 
-98 | chain
-   |
-
-AIR302_names.py:98:1: AIR302 `airflow.utils.helpers.chain` is removed in Airflow 3.0; use `airflow.models.baseoperator.chain` instead
-   |
-96 | mkdirs
-97 | 
-98 | chain
-   | ^^^^^ AIR302
-99 | cross_downstream
-   |
-
-AIR302_names.py:99:1: AIR302 `airflow.utils.helpers.cross_downstream` is removed in Airflow 3.0; use `airflow.models.baseoperator.cross_downstream` instead
+AIR302_names.py:99:1: AIR302 `airflow.utils.file.mkdirs` is removed in Airflow 3.0; use `pendulum.today('UTC').add(days=-N, ...)` instead
     |
- 98 | chain
- 99 | cross_downstream
+ 98 | TemporaryDirectory
+ 99 | mkdirs
+    | ^^^^^^ AIR302
+100 | 
+101 | chain
+    |
+
+AIR302_names.py:101:1: AIR302 `airflow.utils.helpers.chain` is removed in Airflow 3.0; use `airflow.models.baseoperator.chain` instead
+    |
+ 99 | mkdirs
+100 | 
+101 | chain
+    | ^^^^^ AIR302
+102 | cross_downstream
+    |
+
+AIR302_names.py:102:1: AIR302 `airflow.utils.helpers.cross_downstream` is removed in Airflow 3.0; use `airflow.models.baseoperator.cross_downstream` instead
+    |
+101 | chain
+102 | cross_downstream
     | ^^^^^^^^^^^^^^^^ AIR302
-100 | 
-101 | SHUTDOWN
+103 | 
+104 | SHUTDOWN
     |
 
-AIR302_names.py:101:1: AIR302 `airflow.utils.state.SHUTDOWN` is removed in Airflow 3.0
+AIR302_names.py:104:1: AIR302 `airflow.utils.state.SHUTDOWN` is removed in Airflow 3.0
     |
- 99 | cross_downstream
-100 | 
-101 | SHUTDOWN
+102 | cross_downstream
+103 | 
+104 | SHUTDOWN
     | ^^^^^^^^ AIR302
-102 | terminating_states
+105 | terminating_states
     |
 
-AIR302_names.py:102:1: AIR302 `airflow.utils.state.terminating_states` is removed in Airflow 3.0
+AIR302_names.py:105:1: AIR302 `airflow.utils.state.terminating_states` is removed in Airflow 3.0
     |
-101 | SHUTDOWN
-102 | terminating_states
+104 | SHUTDOWN
+105 | terminating_states
     | ^^^^^^^^^^^^^^^^^^ AIR302
-103 | 
-104 | TriggerRule.DUMMY
+106 | 
+107 | TriggerRule.DUMMY
     |
 
-AIR302_names.py:104:13: AIR302 `airflow.utils.trigger_rule.TriggerRule.DUMMY` is removed in Airflow 3.0
+AIR302_names.py:107:13: AIR302 `airflow.utils.trigger_rule.TriggerRule.DUMMY` is removed in Airflow 3.0
     |
-102 | terminating_states
-103 | 
-104 | TriggerRule.DUMMY
+105 | terminating_states
+106 | 
+107 | TriggerRule.DUMMY
     |             ^^^^^ AIR302
-105 | TriggerRule.NONE_FAILED_OR_SKIPPED
+108 | TriggerRule.NONE_FAILED_OR_SKIPPED
     |
 
-AIR302_names.py:105:13: AIR302 `airflow.utils.trigger_rule.TriggerRule.NONE_FAILED_OR_SKIPPED` is removed in Airflow 3.0
+AIR302_names.py:108:13: AIR302 `airflow.utils.trigger_rule.TriggerRule.NONE_FAILED_OR_SKIPPED` is removed in Airflow 3.0
     |
-104 | TriggerRule.DUMMY
-105 | TriggerRule.NONE_FAILED_OR_SKIPPED
+107 | TriggerRule.DUMMY
+108 | TriggerRule.NONE_FAILED_OR_SKIPPED
     |             ^^^^^^^^^^^^^^^^^^^^^^ AIR302
-106 | 
-107 | test_cycle
+109 | 
+110 | test_cycle
     |
 
-AIR302_names.py:107:1: AIR302 `airflow.utils.dag_cycle_tester.test_cycle` is removed in Airflow 3.0
+AIR302_names.py:110:1: AIR302 `airflow.utils.dag_cycle_tester.test_cycle` is removed in Airflow 3.0
     |
-105 | TriggerRule.NONE_FAILED_OR_SKIPPED
-106 | 
-107 | test_cycle
+108 | TriggerRule.NONE_FAILED_OR_SKIPPED
+109 | 
+110 | test_cycle
     | ^^^^^^^^^^ AIR302
-108 | 
-109 | has_access
+111 | 
+112 | has_access
     |
 
-AIR302_names.py:109:1: AIR302 `airflow.www.auth.has_access` is removed in Airflow 3.0; use `airflow.www.auth.has_access_*` instead
+AIR302_names.py:112:1: AIR302 `airflow.www.auth.has_access` is removed in Airflow 3.0; use `airflow.www.auth.has_access_*` instead
     |
-107 | test_cycle
-108 | 
-109 | has_access
+110 | test_cycle
+111 | 
+112 | has_access
     | ^^^^^^^^^^ AIR302
-110 | get_sensitive_variables_fields, should_hide_value_for_key
+113 | get_sensitive_variables_fields, should_hide_value_for_key
     |
 
-AIR302_names.py:110:1: AIR302 `airflow.www.utils.get_sensitive_variables_fields` is removed in Airflow 3.0; use `airflow.utils.log.secrets_masker.get_sensitive_variables_fields` instead
+AIR302_names.py:113:1: AIR302 `airflow.www.utils.get_sensitive_variables_fields` is removed in Airflow 3.0; use `airflow.utils.log.secrets_masker.get_sensitive_variables_fields` instead
     |
-109 | has_access
-110 | get_sensitive_variables_fields, should_hide_value_for_key
+112 | has_access
+113 | get_sensitive_variables_fields, should_hide_value_for_key
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
     |
 
-AIR302_names.py:110:33: AIR302 `airflow.www.utils.should_hide_value_for_key` is removed in Airflow 3.0; use `airflow.utils.log.secrets_masker.should_hide_value_for_key` instead
+AIR302_names.py:113:33: AIR302 `airflow.www.utils.should_hide_value_for_key` is removed in Airflow 3.0; use `airflow.utils.log.secrets_masker.should_hide_value_for_key` instead
     |
-109 | has_access
-110 | get_sensitive_variables_fields, should_hide_value_for_key
+112 | has_access
+113 | get_sensitive_variables_fields, should_hide_value_for_key
     |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
     |

--- a/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_names.py.snap
+++ b/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_names.py.snap
@@ -2,317 +2,437 @@
 source: crates/ruff_linter/src/rules/airflow/mod.rs
 snapshot_kind: text
 ---
-AIR302_names.py:36:1: AIR302 `airflow.contrib.aws_athena_hook.AWSAthenaHook` is removed in Airflow 3.0
+AIR302_names.py:50:1: AIR302 `airflow.contrib.aws_athena_hook.AWSAthenaHook` is removed in Airflow 3.0
    |
-36 | AWSAthenaHook
+50 | AWSAthenaHook
    | ^^^^^^^^^^^^^ AIR302
-37 | TaskStateTrigger
+51 | TaskStateTrigger
    |
 
-AIR302_names.py:37:1: AIR302 `airflow.triggers.external_task.TaskStateTrigger` is removed in Airflow 3.0
+AIR302_names.py:51:1: AIR302 `airflow.triggers.external_task.TaskStateTrigger` is removed in Airflow 3.0
    |
-36 | AWSAthenaHook
-37 | TaskStateTrigger
+50 | AWSAthenaHook
+51 | TaskStateTrigger
    | ^^^^^^^^^^^^^^^^ AIR302
-38 | 
-39 | requires_access
+52 | 
+53 | requires_access
    |
 
-AIR302_names.py:39:1: AIR302 `airflow.api_connexion.security.requires_access` is removed in Airflow 3.0; use `airflow.api_connexion.security.requires_access_*` instead
+AIR302_names.py:53:1: AIR302 `airflow.api_connexion.security.requires_access` is removed in Airflow 3.0; use `airflow.api_connexion.security.requires_access_*` instead
    |
-37 | TaskStateTrigger
-38 | 
-39 | requires_access
+51 | TaskStateTrigger
+52 | 
+53 | requires_access
    | ^^^^^^^^^^^^^^^ AIR302
-40 | 
-41 | AllowListValidator
+54 | 
+55 | AllowListValidator
    |
 
-AIR302_names.py:41:1: AIR302 `airflow.metrics.validators.AllowListValidator` is removed in Airflow 3.0; use `airflow.metrics.validators.PatternAllowListValidator` instead
+AIR302_names.py:55:1: AIR302 `airflow.metrics.validators.AllowListValidator` is removed in Airflow 3.0; use `airflow.metrics.validators.PatternAllowListValidator` instead
    |
-39 | requires_access
-40 | 
-41 | AllowListValidator
+53 | requires_access
+54 | 
+55 | AllowListValidator
    | ^^^^^^^^^^^^^^^^^^ AIR302
-42 | BlockListValidator
+56 | BlockListValidator
    |
 
-AIR302_names.py:42:1: AIR302 `airflow.metrics.validators.BlockListValidator` is removed in Airflow 3.0; use `airflow.metrics.validators.PatternBlockListValidator` instead
+AIR302_names.py:56:1: AIR302 `airflow.metrics.validators.BlockListValidator` is removed in Airflow 3.0; use `airflow.metrics.validators.PatternBlockListValidator` instead
    |
-41 | AllowListValidator
-42 | BlockListValidator
+55 | AllowListValidator
+56 | BlockListValidator
    | ^^^^^^^^^^^^^^^^^^ AIR302
-43 | 
-44 | SubDagOperator
+57 | 
+58 | SubDagOperator
    |
 
-AIR302_names.py:44:1: AIR302 `airflow.operators.subdag.SubDagOperator` is removed in Airflow 3.0
+AIR302_names.py:58:1: AIR302 `airflow.operators.subdag.SubDagOperator` is removed in Airflow 3.0
    |
-42 | BlockListValidator
-43 | 
-44 | SubDagOperator
+56 | BlockListValidator
+57 | 
+58 | SubDagOperator
    | ^^^^^^^^^^^^^^ AIR302
-45 | 
-46 | dates.date_range
+59 | 
+60 | dates.date_range
    |
 
-AIR302_names.py:46:7: AIR302 `airflow.utils.dates.date_range` is removed in Airflow 3.0; use `airflow.timetables.` instead
+AIR302_names.py:60:7: AIR302 `airflow.utils.dates.date_range` is removed in Airflow 3.0; use `airflow.timetables.` instead
    |
-44 | SubDagOperator
-45 | 
-46 | dates.date_range
+58 | SubDagOperator
+59 | 
+60 | dates.date_range
    |       ^^^^^^^^^^ AIR302
-47 | dates.days_ago
+61 | dates.days_ago
    |
 
-AIR302_names.py:47:7: AIR302 `airflow.utils.dates.days_ago` is removed in Airflow 3.0; use `pendulum.today('UTC').add(days=-N, ...)` instead
+AIR302_names.py:61:7: AIR302 `airflow.utils.dates.days_ago` is removed in Airflow 3.0; use `pendulum.today('UTC').add(days=-N, ...)` instead
    |
-46 | dates.date_range
-47 | dates.days_ago
+60 | dates.date_range
+61 | dates.days_ago
    |       ^^^^^^^^ AIR302
-48 | 
-49 | date_range
+62 | 
+63 | date_range
    |
 
-AIR302_names.py:49:1: AIR302 `airflow.utils.dates.date_range` is removed in Airflow 3.0; use `airflow.timetables.` instead
+AIR302_names.py:63:1: AIR302 `airflow.utils.dates.date_range` is removed in Airflow 3.0; use `airflow.timetables.` instead
    |
-47 | dates.days_ago
-48 | 
-49 | date_range
+61 | dates.days_ago
+62 | 
+63 | date_range
    | ^^^^^^^^^^ AIR302
-50 | days_ago
-51 | parse_execution_date
+64 | days_ago
+65 | parse_execution_date
    |
 
-AIR302_names.py:50:1: AIR302 `airflow.utils.dates.days_ago` is removed in Airflow 3.0; use `pendulum.today('UTC').add(days=-N, ...)` instead
+AIR302_names.py:64:1: AIR302 `airflow.utils.dates.days_ago` is removed in Airflow 3.0; use `pendulum.today('UTC').add(days=-N, ...)` instead
    |
-49 | date_range
-50 | days_ago
+63 | date_range
+64 | days_ago
    | ^^^^^^^^ AIR302
-51 | parse_execution_date
-52 | round_time
+65 | parse_execution_date
+66 | round_time
    |
 
-AIR302_names.py:51:1: AIR302 `airflow.utils.dates.parse_execution_date` is removed in Airflow 3.0
+AIR302_names.py:65:1: AIR302 `airflow.utils.dates.parse_execution_date` is removed in Airflow 3.0
    |
-49 | date_range
-50 | days_ago
-51 | parse_execution_date
+63 | date_range
+64 | days_ago
+65 | parse_execution_date
    | ^^^^^^^^^^^^^^^^^^^^ AIR302
-52 | round_time
-53 | scale_time_units
+66 | round_time
+67 | scale_time_units
    |
 
-AIR302_names.py:52:1: AIR302 `airflow.utils.dates.round_time` is removed in Airflow 3.0
+AIR302_names.py:66:1: AIR302 `airflow.utils.dates.round_time` is removed in Airflow 3.0
    |
-50 | days_ago
-51 | parse_execution_date
-52 | round_time
+64 | days_ago
+65 | parse_execution_date
+66 | round_time
    | ^^^^^^^^^^ AIR302
-53 | scale_time_units
-54 | infer_time_unit
+67 | scale_time_units
+68 | infer_time_unit
    |
 
-AIR302_names.py:53:1: AIR302 `airflow.utils.dates.scale_time_units` is removed in Airflow 3.0
+AIR302_names.py:67:1: AIR302 `airflow.utils.dates.scale_time_units` is removed in Airflow 3.0
    |
-51 | parse_execution_date
-52 | round_time
-53 | scale_time_units
+65 | parse_execution_date
+66 | round_time
+67 | scale_time_units
    | ^^^^^^^^^^^^^^^^ AIR302
-54 | infer_time_unit
+68 | infer_time_unit
    |
 
-AIR302_names.py:54:1: AIR302 `airflow.utils.dates.infer_time_unit` is removed in Airflow 3.0
+AIR302_names.py:68:1: AIR302 `airflow.utils.dates.infer_time_unit` is removed in Airflow 3.0
    |
-52 | round_time
-53 | scale_time_units
-54 | infer_time_unit
+66 | round_time
+67 | scale_time_units
+68 | infer_time_unit
    | ^^^^^^^^^^^^^^^ AIR302
    |
 
-AIR302_names.py:61:1: AIR302 `airflow.configuration.get` is removed in Airflow 3.0; use `airflow.configuration.conf.get` instead
+AIR302_names.py:75:1: AIR302 `airflow.configuration.get` is removed in Airflow 3.0; use `airflow.configuration.conf.get` instead
    |
-59 | dates.datetime_to_nano
-60 | 
-61 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+73 | dates.datetime_to_nano
+74 | 
+75 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
    | ^^^ AIR302
-62 | 
-63 | get_connection, load_connections
+76 | 
+77 | get_connection, load_connections
    |
 
-AIR302_names.py:61:6: AIR302 `airflow.configuration.getboolean` is removed in Airflow 3.0; use `airflow.configuration.conf.getboolean` instead
+AIR302_names.py:75:6: AIR302 `airflow.configuration.getboolean` is removed in Airflow 3.0; use `airflow.configuration.conf.getboolean` instead
    |
-59 | dates.datetime_to_nano
-60 | 
-61 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+73 | dates.datetime_to_nano
+74 | 
+75 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
    |      ^^^^^^^^^^ AIR302
-62 | 
-63 | get_connection, load_connections
+76 | 
+77 | get_connection, load_connections
    |
 
-AIR302_names.py:61:18: AIR302 `airflow.configuration.getfloat` is removed in Airflow 3.0; use `airflow.configuration.conf.getfloat` instead
+AIR302_names.py:75:18: AIR302 `airflow.configuration.getfloat` is removed in Airflow 3.0; use `airflow.configuration.conf.getfloat` instead
    |
-59 | dates.datetime_to_nano
-60 | 
-61 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+73 | dates.datetime_to_nano
+74 | 
+75 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
    |                  ^^^^^^^^ AIR302
-62 | 
-63 | get_connection, load_connections
+76 | 
+77 | get_connection, load_connections
    |
 
-AIR302_names.py:61:28: AIR302 `airflow.configuration.getint` is removed in Airflow 3.0; use `airflow.configuration.conf.getint` instead
+AIR302_names.py:75:28: AIR302 `airflow.configuration.getint` is removed in Airflow 3.0; use `airflow.configuration.conf.getint` instead
    |
-59 | dates.datetime_to_nano
-60 | 
-61 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+73 | dates.datetime_to_nano
+74 | 
+75 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
    |                            ^^^^^^ AIR302
-62 | 
-63 | get_connection, load_connections
+76 | 
+77 | get_connection, load_connections
    |
 
-AIR302_names.py:61:36: AIR302 `airflow.configuration.has_option` is removed in Airflow 3.0; use `airflow.configuration.conf.has_option` instead
+AIR302_names.py:75:36: AIR302 `airflow.configuration.has_option` is removed in Airflow 3.0; use `airflow.configuration.conf.has_option` instead
    |
-59 | dates.datetime_to_nano
-60 | 
-61 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+73 | dates.datetime_to_nano
+74 | 
+75 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
    |                                    ^^^^^^^^^^ AIR302
-62 | 
-63 | get_connection, load_connections
+76 | 
+77 | get_connection, load_connections
    |
 
-AIR302_names.py:61:48: AIR302 `airflow.configuration.remove_option` is removed in Airflow 3.0; use `airflow.configuration.conf.remove_option` instead
+AIR302_names.py:75:48: AIR302 `airflow.configuration.remove_option` is removed in Airflow 3.0; use `airflow.configuration.conf.remove_option` instead
    |
-59 | dates.datetime_to_nano
-60 | 
-61 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+73 | dates.datetime_to_nano
+74 | 
+75 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
    |                                                ^^^^^^^^^^^^^ AIR302
-62 | 
-63 | get_connection, load_connections
+76 | 
+77 | get_connection, load_connections
    |
 
-AIR302_names.py:61:63: AIR302 `airflow.configuration.as_dict` is removed in Airflow 3.0; use `airflow.configuration.conf.as_dict` instead
+AIR302_names.py:75:63: AIR302 `airflow.configuration.as_dict` is removed in Airflow 3.0; use `airflow.configuration.conf.as_dict` instead
    |
-59 | dates.datetime_to_nano
-60 | 
-61 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+73 | dates.datetime_to_nano
+74 | 
+75 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
    |                                                               ^^^^^^^ AIR302
-62 | 
-63 | get_connection, load_connections
+76 | 
+77 | get_connection, load_connections
    |
 
-AIR302_names.py:61:72: AIR302 `airflow.configuration.set` is removed in Airflow 3.0; use `airflow.configuration.conf.set` instead
+AIR302_names.py:75:72: AIR302 `airflow.configuration.set` is removed in Airflow 3.0; use `airflow.configuration.conf.set` instead
    |
-59 | dates.datetime_to_nano
-60 | 
-61 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+73 | dates.datetime_to_nano
+74 | 
+75 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
    |                                                                        ^^^ AIR302
-62 | 
-63 | get_connection, load_connections
+76 | 
+77 | get_connection, load_connections
    |
 
-AIR302_names.py:63:1: AIR302 `airflow.secrets.local_filesystem.get_connection` is removed in Airflow 3.0; use `airflow.secrets.local_filesystem.load_connections_dict` instead
+AIR302_names.py:77:1: AIR302 `airflow.secrets.local_filesystem.get_connection` is removed in Airflow 3.0; use `airflow.secrets.local_filesystem.load_connections_dict` instead
    |
-61 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
-62 | 
-63 | get_connection, load_connections
+75 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+76 | 
+77 | get_connection, load_connections
    | ^^^^^^^^^^^^^^ AIR302
-64 | 
-65 | TemporaryDirectory
    |
 
-AIR302_names.py:63:17: AIR302 `airflow.secrets.local_filesystem.load_connections` is removed in Airflow 3.0; use `airflow.secrets.local_filesystem.load_connections_dict` instead
+AIR302_names.py:77:17: AIR302 `airflow.secrets.local_filesystem.load_connections` is removed in Airflow 3.0; use `airflow.secrets.local_filesystem.load_connections_dict` instead
    |
-61 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
-62 | 
-63 | get_connection, load_connections
+75 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+76 | 
+77 | get_connection, load_connections
    |                 ^^^^^^^^^^^^^^^^ AIR302
-64 | 
-65 | TemporaryDirectory
    |
 
-AIR302_names.py:65:1: AIR302 `airflow.utils.file.TemporaryDirectory` is removed in Airflow 3.0
+AIR302_names.py:80:1: AIR302 `airflow.sensors.external_task_sensor.ExternalTaskSensorLink` is removed in Airflow 3.0; use `airflow.sensors.external_task.ExternalTaskSensorLink` instead
    |
-63 | get_connection, load_connections
-64 | 
-65 | TemporaryDirectory
+80 | ExternalTaskSensorLink
+   | ^^^^^^^^^^^^^^^^^^^^^^ AIR302
+81 | BashOperator
+82 | BaseBranchOperator
+   |
+
+AIR302_names.py:81:1: AIR302 `airflow.operators.bash_operator.BashOperator` is removed in Airflow 3.0; use `airflow.operators.bash.BashOperator` instead
+   |
+80 | ExternalTaskSensorLink
+81 | BashOperator
+   | ^^^^^^^^^^^^ AIR302
+82 | BaseBranchOperator
+83 | EmptyOperator, DummyOperator
+   |
+
+AIR302_names.py:82:1: AIR302 `airflow.operators.branch_operator.BaseBranchOperator` is removed in Airflow 3.0; use `airflow.operators.branch.BaseBranchOperator` instead
+   |
+80 | ExternalTaskSensorLink
+81 | BashOperator
+82 | BaseBranchOperator
    | ^^^^^^^^^^^^^^^^^^ AIR302
-66 | mkdirs
+83 | EmptyOperator, DummyOperator
+84 | dummy_operator.EmptyOperator
    |
 
-AIR302_names.py:66:1: AIR302 `airflow.utils.file.mkdirs` is removed in Airflow 3.0; use `pendulum.today('UTC').add(days=-N, ...)` instead
+AIR302_names.py:83:16: AIR302 `airflow.operators.dummy.DummyOperator` is removed in Airflow 3.0; use `airflow.operators.empty.EmptyOperator` instead
    |
-65 | TemporaryDirectory
-66 | mkdirs
+81 | BashOperator
+82 | BaseBranchOperator
+83 | EmptyOperator, DummyOperator
+   |                ^^^^^^^^^^^^^ AIR302
+84 | dummy_operator.EmptyOperator
+85 | dummy_operator.DummyOperator
+   |
+
+AIR302_names.py:84:16: AIR302 `airflow.operators.dummy_operator.EmptyOperator` is removed in Airflow 3.0; use `airflow.operators.empty.EmptyOperator` instead
+   |
+82 | BaseBranchOperator
+83 | EmptyOperator, DummyOperator
+84 | dummy_operator.EmptyOperator
+   |                ^^^^^^^^^^^^^ AIR302
+85 | dummy_operator.DummyOperator
+86 | EmailOperator
+   |
+
+AIR302_names.py:85:16: AIR302 `airflow.operators.dummy_operator.DummyOperator` is removed in Airflow 3.0; use `airflow.operators.empty.EmptyOperator` instead
+   |
+83 | EmptyOperator, DummyOperator
+84 | dummy_operator.EmptyOperator
+85 | dummy_operator.DummyOperator
+   |                ^^^^^^^^^^^^^ AIR302
+86 | EmailOperator
+87 | BaseSensorOperator
+   |
+
+AIR302_names.py:86:1: AIR302 `airflow.operators.email_operator.EmailOperator` is removed in Airflow 3.0; use `airflow.operators.email.EmailOperator` instead
+   |
+84 | dummy_operator.EmptyOperator
+85 | dummy_operator.DummyOperator
+86 | EmailOperator
+   | ^^^^^^^^^^^^^ AIR302
+87 | BaseSensorOperator
+88 | DateTimeSensor
+   |
+
+AIR302_names.py:87:1: AIR302 `airflow.sensors.base_sensor_operator.BaseSensorOperator` is removed in Airflow 3.0; use `airflow.sensors.base.BaseSensorOperator` instead
+   |
+85 | dummy_operator.DummyOperator
+86 | EmailOperator
+87 | BaseSensorOperator
+   | ^^^^^^^^^^^^^^^^^^ AIR302
+88 | DateTimeSensor
+89 | (ExternalTaskMarker, ExternalTaskSensor, ExternalTaskSensorLink)
+   |
+
+AIR302_names.py:88:1: AIR302 `airflow.sensors.date_time_sensor.DateTimeSensor` is removed in Airflow 3.0; use `airflow.sensors.date_time.DateTimeSensor` instead
+   |
+86 | EmailOperator
+87 | BaseSensorOperator
+88 | DateTimeSensor
+   | ^^^^^^^^^^^^^^ AIR302
+89 | (ExternalTaskMarker, ExternalTaskSensor, ExternalTaskSensorLink)
+90 | TimeDeltaSensor
+   |
+
+AIR302_names.py:89:2: AIR302 `airflow.sensors.external_task_sensor.ExternalTaskMarker` is removed in Airflow 3.0; use `airflow.sensors.external_task.ExternalTaskMarker` instead
+   |
+87 | BaseSensorOperator
+88 | DateTimeSensor
+89 | (ExternalTaskMarker, ExternalTaskSensor, ExternalTaskSensorLink)
+   |  ^^^^^^^^^^^^^^^^^^ AIR302
+90 | TimeDeltaSensor
+   |
+
+AIR302_names.py:89:22: AIR302 `airflow.sensors.external_task_sensor.ExternalTaskSensor` is removed in Airflow 3.0; use `airflow.sensors.external_task.ExternalTaskSensor` instead
+   |
+87 | BaseSensorOperator
+88 | DateTimeSensor
+89 | (ExternalTaskMarker, ExternalTaskSensor, ExternalTaskSensorLink)
+   |                      ^^^^^^^^^^^^^^^^^^ AIR302
+90 | TimeDeltaSensor
+   |
+
+AIR302_names.py:89:42: AIR302 `airflow.sensors.external_task_sensor.ExternalTaskSensorLink` is removed in Airflow 3.0; use `airflow.sensors.external_task.ExternalTaskSensorLink` instead
+   |
+87 | BaseSensorOperator
+88 | DateTimeSensor
+89 | (ExternalTaskMarker, ExternalTaskSensor, ExternalTaskSensorLink)
+   |                                          ^^^^^^^^^^^^^^^^^^^^^^ AIR302
+90 | TimeDeltaSensor
+   |
+
+AIR302_names.py:90:1: AIR302 `airflow.sensors.time_delta_sensor.TimeDeltaSensor` is removed in Airflow 3.0; use `airflow.sensors.time_delta.TimeDeltaSensor` instead
+   |
+88 | DateTimeSensor
+89 | (ExternalTaskMarker, ExternalTaskSensor, ExternalTaskSensorLink)
+90 | TimeDeltaSensor
+   | ^^^^^^^^^^^^^^^ AIR302
+91 | 
+92 | TemporaryDirectory
+   |
+
+AIR302_names.py:92:1: AIR302 `airflow.utils.file.TemporaryDirectory` is removed in Airflow 3.0
+   |
+90 | TimeDeltaSensor
+91 | 
+92 | TemporaryDirectory
+   | ^^^^^^^^^^^^^^^^^^ AIR302
+93 | mkdirs
+   |
+
+AIR302_names.py:93:1: AIR302 `airflow.utils.file.mkdirs` is removed in Airflow 3.0; use `pendulum.today('UTC').add(days=-N, ...)` instead
+   |
+92 | TemporaryDirectory
+93 | mkdirs
    | ^^^^^^ AIR302
-67 | 
-68 | chain
+94 | 
+95 | chain
    |
 
-AIR302_names.py:68:1: AIR302 `airflow.utils.helpers.chain` is removed in Airflow 3.0; use `airflow.models.baseoperator.chain` instead
+AIR302_names.py:95:1: AIR302 `airflow.utils.helpers.chain` is removed in Airflow 3.0; use `airflow.models.baseoperator.chain` instead
    |
-66 | mkdirs
-67 | 
-68 | chain
+93 | mkdirs
+94 | 
+95 | chain
    | ^^^^^ AIR302
-69 | cross_downstream
+96 | cross_downstream
    |
 
-AIR302_names.py:69:1: AIR302 `airflow.utils.helpers.cross_downstream` is removed in Airflow 3.0; use `airflow.models.baseoperator.cross_downstream` instead
+AIR302_names.py:96:1: AIR302 `airflow.utils.helpers.cross_downstream` is removed in Airflow 3.0; use `airflow.models.baseoperator.cross_downstream` instead
    |
-68 | chain
-69 | cross_downstream
+95 | chain
+96 | cross_downstream
    | ^^^^^^^^^^^^^^^^ AIR302
-70 | 
-71 | SHUTDOWN
+97 | 
+98 | SHUTDOWN
    |
 
-AIR302_names.py:71:1: AIR302 `airflow.utils.state.SHUTDOWN` is removed in Airflow 3.0
+AIR302_names.py:98:1: AIR302 `airflow.utils.state.SHUTDOWN` is removed in Airflow 3.0
    |
-69 | cross_downstream
-70 | 
-71 | SHUTDOWN
+96 | cross_downstream
+97 | 
+98 | SHUTDOWN
    | ^^^^^^^^ AIR302
-72 | terminating_states
+99 | terminating_states
    |
 
-AIR302_names.py:72:1: AIR302 `airflow.utils.state.terminating_states` is removed in Airflow 3.0
-   |
-71 | SHUTDOWN
-72 | terminating_states
-   | ^^^^^^^^^^^^^^^^^^ AIR302
-73 | 
-74 | test_cycle
-   |
+AIR302_names.py:99:1: AIR302 `airflow.utils.state.terminating_states` is removed in Airflow 3.0
+    |
+ 98 | SHUTDOWN
+ 99 | terminating_states
+    | ^^^^^^^^^^^^^^^^^^ AIR302
+100 | 
+101 | test_cycle
+    |
 
-AIR302_names.py:74:1: AIR302 `airflow.utils.dag_cycle_tester.test_cycle` is removed in Airflow 3.0
-   |
-72 | terminating_states
-73 | 
-74 | test_cycle
-   | ^^^^^^^^^^ AIR302
-75 | 
-76 | has_access
-   |
+AIR302_names.py:101:1: AIR302 `airflow.utils.dag_cycle_tester.test_cycle` is removed in Airflow 3.0
+    |
+ 99 | terminating_states
+100 | 
+101 | test_cycle
+    | ^^^^^^^^^^ AIR302
+102 | 
+103 | has_access
+    |
 
-AIR302_names.py:76:1: AIR302 `airflow.www.auth.has_access` is removed in Airflow 3.0; use `airflow.www.auth.has_access_*` instead
-   |
-74 | test_cycle
-75 | 
-76 | has_access
-   | ^^^^^^^^^^ AIR302
-77 | get_sensitive_variables_fields, should_hide_value_for_key
-   |
+AIR302_names.py:103:1: AIR302 `airflow.www.auth.has_access` is removed in Airflow 3.0; use `airflow.www.auth.has_access_*` instead
+    |
+101 | test_cycle
+102 | 
+103 | has_access
+    | ^^^^^^^^^^ AIR302
+104 | get_sensitive_variables_fields, should_hide_value_for_key
+    |
 
-AIR302_names.py:77:1: AIR302 `airflow.www.utils.get_sensitive_variables_fields` is removed in Airflow 3.0; use `airflow.utils.log.secrets_masker.get_sensitive_variables_fields` instead
-   |
-76 | has_access
-77 | get_sensitive_variables_fields, should_hide_value_for_key
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
-   |
+AIR302_names.py:104:1: AIR302 `airflow.www.utils.get_sensitive_variables_fields` is removed in Airflow 3.0; use `airflow.utils.log.secrets_masker.get_sensitive_variables_fields` instead
+    |
+103 | has_access
+104 | get_sensitive_variables_fields, should_hide_value_for_key
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
+    |
 
-AIR302_names.py:77:33: AIR302 `airflow.www.utils.should_hide_value_for_key` is removed in Airflow 3.0; use `airflow.utils.log.secrets_masker.should_hide_value_for_key` instead
-   |
-76 | has_access
-77 | get_sensitive_variables_fields, should_hide_value_for_key
-   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
-   |
+AIR302_names.py:104:33: AIR302 `airflow.www.utils.should_hide_value_for_key` is removed in Airflow 3.0; use `airflow.utils.log.secrets_masker.should_hide_value_for_key` instead
+    |
+103 | has_access
+104 | get_sensitive_variables_fields, should_hide_value_for_key
+    |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
+    |

--- a/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_names.py.snap
+++ b/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_names.py.snap
@@ -2,156 +2,178 @@
 source: crates/ruff_linter/src/rules/airflow/mod.rs
 snapshot_kind: text
 ---
-AIR302_names.py:21:1: AIR302 `airflow.triggers.external_task.TaskStateTrigger` is removed in Airflow 3.0
+AIR302_names.py:22:1: AIR302 `airflow.triggers.external_task.TaskStateTrigger` is removed in Airflow 3.0
    |
-21 | TaskStateTrigger
+22 | TaskStateTrigger
    | ^^^^^^^^^^^^^^^^ AIR302
    |
 
-AIR302_names.py:24:1: AIR302 `airflow.www.auth.has_access` is removed in Airflow 3.0; use `airflow.www.auth.has_access_*` instead
+AIR302_names.py:25:1: AIR302 `airflow.www.auth.has_access` is removed in Airflow 3.0; use `airflow.www.auth.has_access_*` instead
    |
-24 | has_access
+25 | has_access
    | ^^^^^^^^^^ AIR302
-25 | requires_access
+26 | requires_access
    |
 
-AIR302_names.py:25:1: AIR302 `airflow.api_connexion.security.requires_access` is removed in Airflow 3.0; use `airflow.api_connexion.security.requires_access_*` instead
+AIR302_names.py:26:1: AIR302 `airflow.api_connexion.security.requires_access` is removed in Airflow 3.0; use `airflow.api_connexion.security.requires_access_*` instead
    |
-24 | has_access
-25 | requires_access
+25 | has_access
+26 | requires_access
    | ^^^^^^^^^^^^^^^ AIR302
-26 | 
-27 | AllowListValidator
+27 | 
+28 | AllowListValidator
    |
 
-AIR302_names.py:27:1: AIR302 `airflow.metrics.validators.AllowListValidator` is removed in Airflow 3.0; use `airflow.metrics.validators.PatternAllowListValidator` instead
+AIR302_names.py:28:1: AIR302 `airflow.metrics.validators.AllowListValidator` is removed in Airflow 3.0; use `airflow.metrics.validators.PatternAllowListValidator` instead
    |
-25 | requires_access
-26 | 
-27 | AllowListValidator
+26 | requires_access
+27 | 
+28 | AllowListValidator
    | ^^^^^^^^^^^^^^^^^^ AIR302
-28 | BlockListValidator
+29 | BlockListValidator
    |
 
-AIR302_names.py:28:1: AIR302 `airflow.metrics.validators.BlockListValidator` is removed in Airflow 3.0; use `airflow.metrics.validators.PatternBlockListValidator` instead
+AIR302_names.py:29:1: AIR302 `airflow.metrics.validators.BlockListValidator` is removed in Airflow 3.0; use `airflow.metrics.validators.PatternBlockListValidator` instead
    |
-27 | AllowListValidator
-28 | BlockListValidator
+28 | AllowListValidator
+29 | BlockListValidator
    | ^^^^^^^^^^^^^^^^^^ AIR302
-29 | 
-30 | dates.date_range
+30 | 
+31 | dates.date_range
    |
 
-AIR302_names.py:30:7: AIR302 `airflow.utils.dates.date_range` is removed in Airflow 3.0; use `airflow.timetables.` instead
+AIR302_names.py:31:7: AIR302 `airflow.utils.dates.date_range` is removed in Airflow 3.0; use `airflow.timetables.` instead
    |
-28 | BlockListValidator
-29 | 
-30 | dates.date_range
+29 | BlockListValidator
+30 | 
+31 | dates.date_range
    |       ^^^^^^^^^^ AIR302
-31 | dates.days_ago
+32 | dates.days_ago
    |
 
-AIR302_names.py:31:7: AIR302 `airflow.utils.dates.days_ago` is removed in Airflow 3.0; use `pendulum.today('UTC').add(days=-N, ...)` instead
+AIR302_names.py:32:7: AIR302 `airflow.utils.dates.days_ago` is removed in Airflow 3.0; use `pendulum.today('UTC').add(days=-N, ...)` instead
    |
-30 | dates.date_range
-31 | dates.days_ago
+31 | dates.date_range
+32 | dates.days_ago
    |       ^^^^^^^^ AIR302
-32 | 
-33 | date_range
+33 | 
+34 | date_range
    |
 
-AIR302_names.py:33:1: AIR302 `airflow.utils.dates.date_range` is removed in Airflow 3.0; use `airflow.timetables.` instead
+AIR302_names.py:34:1: AIR302 `airflow.utils.dates.date_range` is removed in Airflow 3.0; use `airflow.timetables.` instead
    |
-31 | dates.days_ago
-32 | 
-33 | date_range
+32 | dates.days_ago
+33 | 
+34 | date_range
    | ^^^^^^^^^^ AIR302
-34 | days_ago
-35 | parse_execution_date
+35 | days_ago
+36 | parse_execution_date
    |
 
-AIR302_names.py:34:1: AIR302 `airflow.utils.dates.days_ago` is removed in Airflow 3.0; use `pendulum.today('UTC').add(days=-N, ...)` instead
+AIR302_names.py:35:1: AIR302 `airflow.utils.dates.days_ago` is removed in Airflow 3.0; use `pendulum.today('UTC').add(days=-N, ...)` instead
    |
-33 | date_range
-34 | days_ago
+34 | date_range
+35 | days_ago
    | ^^^^^^^^ AIR302
-35 | parse_execution_date
-36 | round_time
+36 | parse_execution_date
+37 | round_time
    |
 
-AIR302_names.py:35:1: AIR302 `airflow.utils.dates.parse_execution_date` is removed in Airflow 3.0
+AIR302_names.py:36:1: AIR302 `airflow.utils.dates.parse_execution_date` is removed in Airflow 3.0
    |
-33 | date_range
-34 | days_ago
-35 | parse_execution_date
+34 | date_range
+35 | days_ago
+36 | parse_execution_date
    | ^^^^^^^^^^^^^^^^^^^^ AIR302
-36 | round_time
-37 | scale_time_units
+37 | round_time
+38 | scale_time_units
    |
 
-AIR302_names.py:36:1: AIR302 `airflow.utils.dates.round_time` is removed in Airflow 3.0
+AIR302_names.py:37:1: AIR302 `airflow.utils.dates.round_time` is removed in Airflow 3.0
    |
-34 | days_ago
-35 | parse_execution_date
-36 | round_time
+35 | days_ago
+36 | parse_execution_date
+37 | round_time
    | ^^^^^^^^^^ AIR302
-37 | scale_time_units
-38 | infer_time_unit
+38 | scale_time_units
+39 | infer_time_unit
    |
 
-AIR302_names.py:37:1: AIR302 `airflow.utils.dates.scale_time_units` is removed in Airflow 3.0
+AIR302_names.py:38:1: AIR302 `airflow.utils.dates.scale_time_units` is removed in Airflow 3.0
    |
-35 | parse_execution_date
-36 | round_time
-37 | scale_time_units
+36 | parse_execution_date
+37 | round_time
+38 | scale_time_units
    | ^^^^^^^^^^^^^^^^ AIR302
-38 | infer_time_unit
+39 | infer_time_unit
    |
 
-AIR302_names.py:38:1: AIR302 `airflow.utils.dates.infer_time_unit` is removed in Airflow 3.0
+AIR302_names.py:39:1: AIR302 `airflow.utils.dates.infer_time_unit` is removed in Airflow 3.0
    |
-36 | round_time
-37 | scale_time_units
-38 | infer_time_unit
+37 | round_time
+38 | scale_time_units
+39 | infer_time_unit
    | ^^^^^^^^^^^^^^^ AIR302
    |
 
-AIR302_names.py:45:1: AIR302 `airflow.utils.file.TemporaryDirectory` is removed in Airflow 3.0
+AIR302_names.py:46:1: AIR302 `airflow.utils.file.TemporaryDirectory` is removed in Airflow 3.0
    |
-43 | dates.datetime_to_nano
-44 | 
-45 | TemporaryDirectory
+44 | dates.datetime_to_nano
+45 | 
+46 | TemporaryDirectory
    | ^^^^^^^^^^^^^^^^^^ AIR302
-46 | mkdirs
+47 | mkdirs
    |
 
-AIR302_names.py:46:1: AIR302 `airflow.utils.file.mkdirs` is removed in Airflow 3.0; use `pendulum.today('UTC').add(days=-N, ...)` instead
+AIR302_names.py:47:1: AIR302 `airflow.utils.file.mkdirs` is removed in Airflow 3.0; use `pendulum.today('UTC').add(days=-N, ...)` instead
    |
-45 | TemporaryDirectory
-46 | mkdirs
+46 | TemporaryDirectory
+47 | mkdirs
    | ^^^^^^ AIR302
-47 | 
-48 | SHUTDOWN
+48 | 
+49 | chain
    |
 
-AIR302_names.py:48:1: AIR302 `airflow.utils.state.SHUTDOWN` is removed in Airflow 3.0
+AIR302_names.py:49:1: AIR302 `airflow.utils.helpers.chain` is removed in Airflow 3.0; use `airflow.models.baseoperator.chain` instead
    |
-46 | mkdirs
-47 | 
-48 | SHUTDOWN
+47 | mkdirs
+48 | 
+49 | chain
+   | ^^^^^ AIR302
+50 | cross_downstream
+   |
+
+AIR302_names.py:50:1: AIR302 `airflow.utils.helpers.cross_downstream` is removed in Airflow 3.0; use `airflow.models.baseoperator.cross_downstream` instead
+   |
+49 | chain
+50 | cross_downstream
+   | ^^^^^^^^^^^^^^^^ AIR302
+51 | 
+52 | SHUTDOWN
+   |
+
+AIR302_names.py:52:1: AIR302 `airflow.utils.state.SHUTDOWN` is removed in Airflow 3.0
+   |
+50 | cross_downstream
+51 | 
+52 | SHUTDOWN
    | ^^^^^^^^ AIR302
-49 | terminating_states
+53 | terminating_states
    |
 
-AIR302_names.py:49:1: AIR302 `airflow.utils.state.terminating_states` is removed in Airflow 3.0
+AIR302_names.py:53:1: AIR302 `airflow.utils.state.terminating_states` is removed in Airflow 3.0
    |
-48 | SHUTDOWN
-49 | terminating_states
+52 | SHUTDOWN
+53 | terminating_states
    | ^^^^^^^^^^^^^^^^^^ AIR302
+54 | 
+55 | test_cycle
    |
 
-AIR302_names.py:52:1: AIR302 `airflow.utils.dag_cycle_tester.test_cycle` is removed in Airflow 3.0
+AIR302_names.py:55:1: AIR302 `airflow.utils.dag_cycle_tester.test_cycle` is removed in Airflow 3.0
    |
-52 | test_cycle
+53 | terminating_states
+54 | 
+55 | test_cycle
    | ^^^^^^^^^^ AIR302
    |

--- a/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_names.py.snap
+++ b/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_names.py.snap
@@ -2,437 +2,455 @@
 source: crates/ruff_linter/src/rules/airflow/mod.rs
 snapshot_kind: text
 ---
-AIR302_names.py:50:1: AIR302 `airflow.contrib.aws_athena_hook.AWSAthenaHook` is removed in Airflow 3.0
+AIR302_names.py:51:1: AIR302 `airflow.contrib.aws_athena_hook.AWSAthenaHook` is removed in Airflow 3.0
    |
-50 | AWSAthenaHook
+51 | AWSAthenaHook
    | ^^^^^^^^^^^^^ AIR302
-51 | TaskStateTrigger
+52 | TaskStateTrigger
    |
 
-AIR302_names.py:51:1: AIR302 `airflow.triggers.external_task.TaskStateTrigger` is removed in Airflow 3.0
+AIR302_names.py:52:1: AIR302 `airflow.triggers.external_task.TaskStateTrigger` is removed in Airflow 3.0
    |
-50 | AWSAthenaHook
-51 | TaskStateTrigger
+51 | AWSAthenaHook
+52 | TaskStateTrigger
    | ^^^^^^^^^^^^^^^^ AIR302
-52 | 
-53 | requires_access
+53 | 
+54 | requires_access
    |
 
-AIR302_names.py:53:1: AIR302 `airflow.api_connexion.security.requires_access` is removed in Airflow 3.0; use `airflow.api_connexion.security.requires_access_*` instead
+AIR302_names.py:54:1: AIR302 `airflow.api_connexion.security.requires_access` is removed in Airflow 3.0; use `airflow.api_connexion.security.requires_access_*` instead
    |
-51 | TaskStateTrigger
-52 | 
-53 | requires_access
+52 | TaskStateTrigger
+53 | 
+54 | requires_access
    | ^^^^^^^^^^^^^^^ AIR302
-54 | 
-55 | AllowListValidator
+55 | 
+56 | AllowListValidator
    |
 
-AIR302_names.py:55:1: AIR302 `airflow.metrics.validators.AllowListValidator` is removed in Airflow 3.0; use `airflow.metrics.validators.PatternAllowListValidator` instead
+AIR302_names.py:56:1: AIR302 `airflow.metrics.validators.AllowListValidator` is removed in Airflow 3.0; use `airflow.metrics.validators.PatternAllowListValidator` instead
    |
-53 | requires_access
-54 | 
-55 | AllowListValidator
+54 | requires_access
+55 | 
+56 | AllowListValidator
    | ^^^^^^^^^^^^^^^^^^ AIR302
-56 | BlockListValidator
+57 | BlockListValidator
    |
 
-AIR302_names.py:56:1: AIR302 `airflow.metrics.validators.BlockListValidator` is removed in Airflow 3.0; use `airflow.metrics.validators.PatternBlockListValidator` instead
+AIR302_names.py:57:1: AIR302 `airflow.metrics.validators.BlockListValidator` is removed in Airflow 3.0; use `airflow.metrics.validators.PatternBlockListValidator` instead
    |
-55 | AllowListValidator
-56 | BlockListValidator
+56 | AllowListValidator
+57 | BlockListValidator
    | ^^^^^^^^^^^^^^^^^^ AIR302
-57 | 
-58 | SubDagOperator
+58 | 
+59 | SubDagOperator
    |
 
-AIR302_names.py:58:1: AIR302 `airflow.operators.subdag.SubDagOperator` is removed in Airflow 3.0
+AIR302_names.py:59:1: AIR302 `airflow.operators.subdag.SubDagOperator` is removed in Airflow 3.0
    |
-56 | BlockListValidator
-57 | 
-58 | SubDagOperator
+57 | BlockListValidator
+58 | 
+59 | SubDagOperator
    | ^^^^^^^^^^^^^^ AIR302
-59 | 
-60 | dates.date_range
+60 | 
+61 | dates.date_range
    |
 
-AIR302_names.py:60:7: AIR302 `airflow.utils.dates.date_range` is removed in Airflow 3.0; use `airflow.timetables.` instead
+AIR302_names.py:61:7: AIR302 `airflow.utils.dates.date_range` is removed in Airflow 3.0; use `airflow.timetables.` instead
    |
-58 | SubDagOperator
-59 | 
-60 | dates.date_range
+59 | SubDagOperator
+60 | 
+61 | dates.date_range
    |       ^^^^^^^^^^ AIR302
-61 | dates.days_ago
+62 | dates.days_ago
    |
 
-AIR302_names.py:61:7: AIR302 `airflow.utils.dates.days_ago` is removed in Airflow 3.0; use `pendulum.today('UTC').add(days=-N, ...)` instead
+AIR302_names.py:62:7: AIR302 `airflow.utils.dates.days_ago` is removed in Airflow 3.0; use `pendulum.today('UTC').add(days=-N, ...)` instead
    |
-60 | dates.date_range
-61 | dates.days_ago
+61 | dates.date_range
+62 | dates.days_ago
    |       ^^^^^^^^ AIR302
-62 | 
-63 | date_range
+63 | 
+64 | date_range
    |
 
-AIR302_names.py:63:1: AIR302 `airflow.utils.dates.date_range` is removed in Airflow 3.0; use `airflow.timetables.` instead
+AIR302_names.py:64:1: AIR302 `airflow.utils.dates.date_range` is removed in Airflow 3.0; use `airflow.timetables.` instead
    |
-61 | dates.days_ago
-62 | 
-63 | date_range
+62 | dates.days_ago
+63 | 
+64 | date_range
    | ^^^^^^^^^^ AIR302
-64 | days_ago
-65 | parse_execution_date
+65 | days_ago
+66 | parse_execution_date
    |
 
-AIR302_names.py:64:1: AIR302 `airflow.utils.dates.days_ago` is removed in Airflow 3.0; use `pendulum.today('UTC').add(days=-N, ...)` instead
+AIR302_names.py:65:1: AIR302 `airflow.utils.dates.days_ago` is removed in Airflow 3.0; use `pendulum.today('UTC').add(days=-N, ...)` instead
    |
-63 | date_range
-64 | days_ago
+64 | date_range
+65 | days_ago
    | ^^^^^^^^ AIR302
-65 | parse_execution_date
-66 | round_time
+66 | parse_execution_date
+67 | round_time
    |
 
-AIR302_names.py:65:1: AIR302 `airflow.utils.dates.parse_execution_date` is removed in Airflow 3.0
+AIR302_names.py:66:1: AIR302 `airflow.utils.dates.parse_execution_date` is removed in Airflow 3.0
    |
-63 | date_range
-64 | days_ago
-65 | parse_execution_date
+64 | date_range
+65 | days_ago
+66 | parse_execution_date
    | ^^^^^^^^^^^^^^^^^^^^ AIR302
-66 | round_time
-67 | scale_time_units
+67 | round_time
+68 | scale_time_units
    |
 
-AIR302_names.py:66:1: AIR302 `airflow.utils.dates.round_time` is removed in Airflow 3.0
+AIR302_names.py:67:1: AIR302 `airflow.utils.dates.round_time` is removed in Airflow 3.0
    |
-64 | days_ago
-65 | parse_execution_date
-66 | round_time
+65 | days_ago
+66 | parse_execution_date
+67 | round_time
    | ^^^^^^^^^^ AIR302
-67 | scale_time_units
-68 | infer_time_unit
+68 | scale_time_units
+69 | infer_time_unit
    |
 
-AIR302_names.py:67:1: AIR302 `airflow.utils.dates.scale_time_units` is removed in Airflow 3.0
+AIR302_names.py:68:1: AIR302 `airflow.utils.dates.scale_time_units` is removed in Airflow 3.0
    |
-65 | parse_execution_date
-66 | round_time
-67 | scale_time_units
+66 | parse_execution_date
+67 | round_time
+68 | scale_time_units
    | ^^^^^^^^^^^^^^^^ AIR302
-68 | infer_time_unit
+69 | infer_time_unit
    |
 
-AIR302_names.py:68:1: AIR302 `airflow.utils.dates.infer_time_unit` is removed in Airflow 3.0
+AIR302_names.py:69:1: AIR302 `airflow.utils.dates.infer_time_unit` is removed in Airflow 3.0
    |
-66 | round_time
-67 | scale_time_units
-68 | infer_time_unit
+67 | round_time
+68 | scale_time_units
+69 | infer_time_unit
    | ^^^^^^^^^^^^^^^ AIR302
    |
 
-AIR302_names.py:75:1: AIR302 `airflow.configuration.get` is removed in Airflow 3.0; use `airflow.configuration.conf.get` instead
+AIR302_names.py:76:1: AIR302 `airflow.configuration.get` is removed in Airflow 3.0; use `airflow.configuration.conf.get` instead
    |
-73 | dates.datetime_to_nano
-74 | 
-75 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+74 | dates.datetime_to_nano
+75 | 
+76 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
    | ^^^ AIR302
-76 | 
-77 | get_connection, load_connections
+77 | 
+78 | get_connection, load_connections
    |
 
-AIR302_names.py:75:6: AIR302 `airflow.configuration.getboolean` is removed in Airflow 3.0; use `airflow.configuration.conf.getboolean` instead
+AIR302_names.py:76:6: AIR302 `airflow.configuration.getboolean` is removed in Airflow 3.0; use `airflow.configuration.conf.getboolean` instead
    |
-73 | dates.datetime_to_nano
-74 | 
-75 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+74 | dates.datetime_to_nano
+75 | 
+76 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
    |      ^^^^^^^^^^ AIR302
-76 | 
-77 | get_connection, load_connections
+77 | 
+78 | get_connection, load_connections
    |
 
-AIR302_names.py:75:18: AIR302 `airflow.configuration.getfloat` is removed in Airflow 3.0; use `airflow.configuration.conf.getfloat` instead
+AIR302_names.py:76:18: AIR302 `airflow.configuration.getfloat` is removed in Airflow 3.0; use `airflow.configuration.conf.getfloat` instead
    |
-73 | dates.datetime_to_nano
-74 | 
-75 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+74 | dates.datetime_to_nano
+75 | 
+76 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
    |                  ^^^^^^^^ AIR302
-76 | 
-77 | get_connection, load_connections
+77 | 
+78 | get_connection, load_connections
    |
 
-AIR302_names.py:75:28: AIR302 `airflow.configuration.getint` is removed in Airflow 3.0; use `airflow.configuration.conf.getint` instead
+AIR302_names.py:76:28: AIR302 `airflow.configuration.getint` is removed in Airflow 3.0; use `airflow.configuration.conf.getint` instead
    |
-73 | dates.datetime_to_nano
-74 | 
-75 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+74 | dates.datetime_to_nano
+75 | 
+76 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
    |                            ^^^^^^ AIR302
-76 | 
-77 | get_connection, load_connections
+77 | 
+78 | get_connection, load_connections
    |
 
-AIR302_names.py:75:36: AIR302 `airflow.configuration.has_option` is removed in Airflow 3.0; use `airflow.configuration.conf.has_option` instead
+AIR302_names.py:76:36: AIR302 `airflow.configuration.has_option` is removed in Airflow 3.0; use `airflow.configuration.conf.has_option` instead
    |
-73 | dates.datetime_to_nano
-74 | 
-75 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+74 | dates.datetime_to_nano
+75 | 
+76 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
    |                                    ^^^^^^^^^^ AIR302
-76 | 
-77 | get_connection, load_connections
+77 | 
+78 | get_connection, load_connections
    |
 
-AIR302_names.py:75:48: AIR302 `airflow.configuration.remove_option` is removed in Airflow 3.0; use `airflow.configuration.conf.remove_option` instead
+AIR302_names.py:76:48: AIR302 `airflow.configuration.remove_option` is removed in Airflow 3.0; use `airflow.configuration.conf.remove_option` instead
    |
-73 | dates.datetime_to_nano
-74 | 
-75 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+74 | dates.datetime_to_nano
+75 | 
+76 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
    |                                                ^^^^^^^^^^^^^ AIR302
-76 | 
-77 | get_connection, load_connections
+77 | 
+78 | get_connection, load_connections
    |
 
-AIR302_names.py:75:63: AIR302 `airflow.configuration.as_dict` is removed in Airflow 3.0; use `airflow.configuration.conf.as_dict` instead
+AIR302_names.py:76:63: AIR302 `airflow.configuration.as_dict` is removed in Airflow 3.0; use `airflow.configuration.conf.as_dict` instead
    |
-73 | dates.datetime_to_nano
-74 | 
-75 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+74 | dates.datetime_to_nano
+75 | 
+76 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
    |                                                               ^^^^^^^ AIR302
-76 | 
-77 | get_connection, load_connections
+77 | 
+78 | get_connection, load_connections
    |
 
-AIR302_names.py:75:72: AIR302 `airflow.configuration.set` is removed in Airflow 3.0; use `airflow.configuration.conf.set` instead
+AIR302_names.py:76:72: AIR302 `airflow.configuration.set` is removed in Airflow 3.0; use `airflow.configuration.conf.set` instead
    |
-73 | dates.datetime_to_nano
-74 | 
-75 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+74 | dates.datetime_to_nano
+75 | 
+76 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
    |                                                                        ^^^ AIR302
-76 | 
-77 | get_connection, load_connections
+77 | 
+78 | get_connection, load_connections
    |
 
-AIR302_names.py:77:1: AIR302 `airflow.secrets.local_filesystem.get_connection` is removed in Airflow 3.0; use `airflow.secrets.local_filesystem.load_connections_dict` instead
+AIR302_names.py:78:1: AIR302 `airflow.secrets.local_filesystem.get_connection` is removed in Airflow 3.0; use `airflow.secrets.local_filesystem.load_connections_dict` instead
    |
-75 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
-76 | 
-77 | get_connection, load_connections
+76 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+77 | 
+78 | get_connection, load_connections
    | ^^^^^^^^^^^^^^ AIR302
    |
 
-AIR302_names.py:77:17: AIR302 `airflow.secrets.local_filesystem.load_connections` is removed in Airflow 3.0; use `airflow.secrets.local_filesystem.load_connections_dict` instead
+AIR302_names.py:78:17: AIR302 `airflow.secrets.local_filesystem.load_connections` is removed in Airflow 3.0; use `airflow.secrets.local_filesystem.load_connections_dict` instead
    |
-75 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
-76 | 
-77 | get_connection, load_connections
+76 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+77 | 
+78 | get_connection, load_connections
    |                 ^^^^^^^^^^^^^^^^ AIR302
    |
 
-AIR302_names.py:80:1: AIR302 `airflow.sensors.external_task_sensor.ExternalTaskSensorLink` is removed in Airflow 3.0; use `airflow.sensors.external_task.ExternalTaskSensorLink` instead
+AIR302_names.py:81:1: AIR302 `airflow.sensors.external_task_sensor.ExternalTaskSensorLink` is removed in Airflow 3.0; use `airflow.sensors.external_task.ExternalTaskSensorLink` instead
    |
-80 | ExternalTaskSensorLink
+81 | ExternalTaskSensorLink
    | ^^^^^^^^^^^^^^^^^^^^^^ AIR302
-81 | BashOperator
-82 | BaseBranchOperator
+82 | BashOperator
+83 | BaseBranchOperator
    |
 
-AIR302_names.py:81:1: AIR302 `airflow.operators.bash_operator.BashOperator` is removed in Airflow 3.0; use `airflow.operators.bash.BashOperator` instead
+AIR302_names.py:82:1: AIR302 `airflow.operators.bash_operator.BashOperator` is removed in Airflow 3.0; use `airflow.operators.bash.BashOperator` instead
    |
-80 | ExternalTaskSensorLink
-81 | BashOperator
+81 | ExternalTaskSensorLink
+82 | BashOperator
    | ^^^^^^^^^^^^ AIR302
-82 | BaseBranchOperator
-83 | EmptyOperator, DummyOperator
+83 | BaseBranchOperator
+84 | EmptyOperator, DummyOperator
    |
 
-AIR302_names.py:82:1: AIR302 `airflow.operators.branch_operator.BaseBranchOperator` is removed in Airflow 3.0; use `airflow.operators.branch.BaseBranchOperator` instead
+AIR302_names.py:83:1: AIR302 `airflow.operators.branch_operator.BaseBranchOperator` is removed in Airflow 3.0; use `airflow.operators.branch.BaseBranchOperator` instead
    |
-80 | ExternalTaskSensorLink
-81 | BashOperator
-82 | BaseBranchOperator
+81 | ExternalTaskSensorLink
+82 | BashOperator
+83 | BaseBranchOperator
    | ^^^^^^^^^^^^^^^^^^ AIR302
-83 | EmptyOperator, DummyOperator
-84 | dummy_operator.EmptyOperator
+84 | EmptyOperator, DummyOperator
+85 | dummy_operator.EmptyOperator
    |
 
-AIR302_names.py:83:16: AIR302 `airflow.operators.dummy.DummyOperator` is removed in Airflow 3.0; use `airflow.operators.empty.EmptyOperator` instead
+AIR302_names.py:84:16: AIR302 `airflow.operators.dummy.DummyOperator` is removed in Airflow 3.0; use `airflow.operators.empty.EmptyOperator` instead
    |
-81 | BashOperator
-82 | BaseBranchOperator
-83 | EmptyOperator, DummyOperator
+82 | BashOperator
+83 | BaseBranchOperator
+84 | EmptyOperator, DummyOperator
    |                ^^^^^^^^^^^^^ AIR302
-84 | dummy_operator.EmptyOperator
-85 | dummy_operator.DummyOperator
+85 | dummy_operator.EmptyOperator
+86 | dummy_operator.DummyOperator
    |
 
-AIR302_names.py:84:16: AIR302 `airflow.operators.dummy_operator.EmptyOperator` is removed in Airflow 3.0; use `airflow.operators.empty.EmptyOperator` instead
+AIR302_names.py:85:16: AIR302 `airflow.operators.dummy_operator.EmptyOperator` is removed in Airflow 3.0; use `airflow.operators.empty.EmptyOperator` instead
    |
-82 | BaseBranchOperator
-83 | EmptyOperator, DummyOperator
-84 | dummy_operator.EmptyOperator
+83 | BaseBranchOperator
+84 | EmptyOperator, DummyOperator
+85 | dummy_operator.EmptyOperator
    |                ^^^^^^^^^^^^^ AIR302
-85 | dummy_operator.DummyOperator
-86 | EmailOperator
+86 | dummy_operator.DummyOperator
+87 | EmailOperator
    |
 
-AIR302_names.py:85:16: AIR302 `airflow.operators.dummy_operator.DummyOperator` is removed in Airflow 3.0; use `airflow.operators.empty.EmptyOperator` instead
+AIR302_names.py:86:16: AIR302 `airflow.operators.dummy_operator.DummyOperator` is removed in Airflow 3.0; use `airflow.operators.empty.EmptyOperator` instead
    |
-83 | EmptyOperator, DummyOperator
-84 | dummy_operator.EmptyOperator
-85 | dummy_operator.DummyOperator
+84 | EmptyOperator, DummyOperator
+85 | dummy_operator.EmptyOperator
+86 | dummy_operator.DummyOperator
    |                ^^^^^^^^^^^^^ AIR302
-86 | EmailOperator
-87 | BaseSensorOperator
+87 | EmailOperator
+88 | BaseSensorOperator
    |
 
-AIR302_names.py:86:1: AIR302 `airflow.operators.email_operator.EmailOperator` is removed in Airflow 3.0; use `airflow.operators.email.EmailOperator` instead
+AIR302_names.py:87:1: AIR302 `airflow.operators.email_operator.EmailOperator` is removed in Airflow 3.0; use `airflow.operators.email.EmailOperator` instead
    |
-84 | dummy_operator.EmptyOperator
-85 | dummy_operator.DummyOperator
-86 | EmailOperator
+85 | dummy_operator.EmptyOperator
+86 | dummy_operator.DummyOperator
+87 | EmailOperator
    | ^^^^^^^^^^^^^ AIR302
-87 | BaseSensorOperator
-88 | DateTimeSensor
+88 | BaseSensorOperator
+89 | DateTimeSensor
    |
 
-AIR302_names.py:87:1: AIR302 `airflow.sensors.base_sensor_operator.BaseSensorOperator` is removed in Airflow 3.0; use `airflow.sensors.base.BaseSensorOperator` instead
+AIR302_names.py:88:1: AIR302 `airflow.sensors.base_sensor_operator.BaseSensorOperator` is removed in Airflow 3.0; use `airflow.sensors.base.BaseSensorOperator` instead
    |
-85 | dummy_operator.DummyOperator
-86 | EmailOperator
-87 | BaseSensorOperator
+86 | dummy_operator.DummyOperator
+87 | EmailOperator
+88 | BaseSensorOperator
    | ^^^^^^^^^^^^^^^^^^ AIR302
-88 | DateTimeSensor
-89 | (ExternalTaskMarker, ExternalTaskSensor, ExternalTaskSensorLink)
+89 | DateTimeSensor
+90 | (ExternalTaskMarker, ExternalTaskSensor, ExternalTaskSensorLink)
    |
 
-AIR302_names.py:88:1: AIR302 `airflow.sensors.date_time_sensor.DateTimeSensor` is removed in Airflow 3.0; use `airflow.sensors.date_time.DateTimeSensor` instead
+AIR302_names.py:89:1: AIR302 `airflow.sensors.date_time_sensor.DateTimeSensor` is removed in Airflow 3.0; use `airflow.sensors.date_time.DateTimeSensor` instead
    |
-86 | EmailOperator
-87 | BaseSensorOperator
-88 | DateTimeSensor
+87 | EmailOperator
+88 | BaseSensorOperator
+89 | DateTimeSensor
    | ^^^^^^^^^^^^^^ AIR302
-89 | (ExternalTaskMarker, ExternalTaskSensor, ExternalTaskSensorLink)
-90 | TimeDeltaSensor
+90 | (ExternalTaskMarker, ExternalTaskSensor, ExternalTaskSensorLink)
+91 | TimeDeltaSensor
    |
 
-AIR302_names.py:89:2: AIR302 `airflow.sensors.external_task_sensor.ExternalTaskMarker` is removed in Airflow 3.0; use `airflow.sensors.external_task.ExternalTaskMarker` instead
+AIR302_names.py:90:2: AIR302 `airflow.sensors.external_task_sensor.ExternalTaskMarker` is removed in Airflow 3.0; use `airflow.sensors.external_task.ExternalTaskMarker` instead
    |
-87 | BaseSensorOperator
-88 | DateTimeSensor
-89 | (ExternalTaskMarker, ExternalTaskSensor, ExternalTaskSensorLink)
+88 | BaseSensorOperator
+89 | DateTimeSensor
+90 | (ExternalTaskMarker, ExternalTaskSensor, ExternalTaskSensorLink)
    |  ^^^^^^^^^^^^^^^^^^ AIR302
-90 | TimeDeltaSensor
+91 | TimeDeltaSensor
    |
 
-AIR302_names.py:89:22: AIR302 `airflow.sensors.external_task_sensor.ExternalTaskSensor` is removed in Airflow 3.0; use `airflow.sensors.external_task.ExternalTaskSensor` instead
+AIR302_names.py:90:22: AIR302 `airflow.sensors.external_task_sensor.ExternalTaskSensor` is removed in Airflow 3.0; use `airflow.sensors.external_task.ExternalTaskSensor` instead
    |
-87 | BaseSensorOperator
-88 | DateTimeSensor
-89 | (ExternalTaskMarker, ExternalTaskSensor, ExternalTaskSensorLink)
+88 | BaseSensorOperator
+89 | DateTimeSensor
+90 | (ExternalTaskMarker, ExternalTaskSensor, ExternalTaskSensorLink)
    |                      ^^^^^^^^^^^^^^^^^^ AIR302
-90 | TimeDeltaSensor
+91 | TimeDeltaSensor
    |
 
-AIR302_names.py:89:42: AIR302 `airflow.sensors.external_task_sensor.ExternalTaskSensorLink` is removed in Airflow 3.0; use `airflow.sensors.external_task.ExternalTaskSensorLink` instead
+AIR302_names.py:90:42: AIR302 `airflow.sensors.external_task_sensor.ExternalTaskSensorLink` is removed in Airflow 3.0; use `airflow.sensors.external_task.ExternalTaskSensorLink` instead
    |
-87 | BaseSensorOperator
-88 | DateTimeSensor
-89 | (ExternalTaskMarker, ExternalTaskSensor, ExternalTaskSensorLink)
+88 | BaseSensorOperator
+89 | DateTimeSensor
+90 | (ExternalTaskMarker, ExternalTaskSensor, ExternalTaskSensorLink)
    |                                          ^^^^^^^^^^^^^^^^^^^^^^ AIR302
-90 | TimeDeltaSensor
+91 | TimeDeltaSensor
    |
 
-AIR302_names.py:90:1: AIR302 `airflow.sensors.time_delta_sensor.TimeDeltaSensor` is removed in Airflow 3.0; use `airflow.sensors.time_delta.TimeDeltaSensor` instead
+AIR302_names.py:91:1: AIR302 `airflow.sensors.time_delta_sensor.TimeDeltaSensor` is removed in Airflow 3.0; use `airflow.sensors.time_delta.TimeDeltaSensor` instead
    |
-88 | DateTimeSensor
-89 | (ExternalTaskMarker, ExternalTaskSensor, ExternalTaskSensorLink)
-90 | TimeDeltaSensor
+89 | DateTimeSensor
+90 | (ExternalTaskMarker, ExternalTaskSensor, ExternalTaskSensorLink)
+91 | TimeDeltaSensor
    | ^^^^^^^^^^^^^^^ AIR302
-91 | 
-92 | TemporaryDirectory
+92 | 
+93 | TemporaryDirectory
    |
 
-AIR302_names.py:92:1: AIR302 `airflow.utils.file.TemporaryDirectory` is removed in Airflow 3.0
+AIR302_names.py:93:1: AIR302 `airflow.utils.file.TemporaryDirectory` is removed in Airflow 3.0
    |
-90 | TimeDeltaSensor
-91 | 
-92 | TemporaryDirectory
+91 | TimeDeltaSensor
+92 | 
+93 | TemporaryDirectory
    | ^^^^^^^^^^^^^^^^^^ AIR302
-93 | mkdirs
+94 | mkdirs
    |
 
-AIR302_names.py:93:1: AIR302 `airflow.utils.file.mkdirs` is removed in Airflow 3.0; use `pendulum.today('UTC').add(days=-N, ...)` instead
+AIR302_names.py:94:1: AIR302 `airflow.utils.file.mkdirs` is removed in Airflow 3.0; use `pendulum.today('UTC').add(days=-N, ...)` instead
    |
-92 | TemporaryDirectory
-93 | mkdirs
+93 | TemporaryDirectory
+94 | mkdirs
    | ^^^^^^ AIR302
-94 | 
-95 | chain
+95 | 
+96 | chain
    |
 
-AIR302_names.py:95:1: AIR302 `airflow.utils.helpers.chain` is removed in Airflow 3.0; use `airflow.models.baseoperator.chain` instead
+AIR302_names.py:96:1: AIR302 `airflow.utils.helpers.chain` is removed in Airflow 3.0; use `airflow.models.baseoperator.chain` instead
    |
-93 | mkdirs
-94 | 
-95 | chain
+94 | mkdirs
+95 | 
+96 | chain
    | ^^^^^ AIR302
-96 | cross_downstream
+97 | cross_downstream
    |
 
-AIR302_names.py:96:1: AIR302 `airflow.utils.helpers.cross_downstream` is removed in Airflow 3.0; use `airflow.models.baseoperator.cross_downstream` instead
+AIR302_names.py:97:1: AIR302 `airflow.utils.helpers.cross_downstream` is removed in Airflow 3.0; use `airflow.models.baseoperator.cross_downstream` instead
    |
-95 | chain
-96 | cross_downstream
+96 | chain
+97 | cross_downstream
    | ^^^^^^^^^^^^^^^^ AIR302
-97 | 
-98 | SHUTDOWN
+98 | 
+99 | SHUTDOWN
    |
 
-AIR302_names.py:98:1: AIR302 `airflow.utils.state.SHUTDOWN` is removed in Airflow 3.0
-   |
-96 | cross_downstream
-97 | 
-98 | SHUTDOWN
-   | ^^^^^^^^ AIR302
-99 | terminating_states
-   |
-
-AIR302_names.py:99:1: AIR302 `airflow.utils.state.terminating_states` is removed in Airflow 3.0
+AIR302_names.py:99:1: AIR302 `airflow.utils.state.SHUTDOWN` is removed in Airflow 3.0
     |
- 98 | SHUTDOWN
- 99 | terminating_states
+ 97 | cross_downstream
+ 98 | 
+ 99 | SHUTDOWN
+    | ^^^^^^^^ AIR302
+100 | terminating_states
+    |
+
+AIR302_names.py:100:1: AIR302 `airflow.utils.state.terminating_states` is removed in Airflow 3.0
+    |
+ 99 | SHUTDOWN
+100 | terminating_states
     | ^^^^^^^^^^^^^^^^^^ AIR302
-100 | 
-101 | test_cycle
+101 | 
+102 | TriggerRule.DUMMY
     |
 
-AIR302_names.py:101:1: AIR302 `airflow.utils.dag_cycle_tester.test_cycle` is removed in Airflow 3.0
+AIR302_names.py:102:13: AIR302 `airflow.utils.trigger_rule.TriggerRule.DUMMY` is removed in Airflow 3.0
     |
- 99 | terminating_states
-100 | 
-101 | test_cycle
+100 | terminating_states
+101 | 
+102 | TriggerRule.DUMMY
+    |             ^^^^^ AIR302
+103 | TriggerRule.NONE_FAILED_OR_SKIPPED
+    |
+
+AIR302_names.py:103:13: AIR302 `airflow.utils.trigger_rule.TriggerRule.NONE_FAILED_OR_SKIPPED` is removed in Airflow 3.0
+    |
+102 | TriggerRule.DUMMY
+103 | TriggerRule.NONE_FAILED_OR_SKIPPED
+    |             ^^^^^^^^^^^^^^^^^^^^^^ AIR302
+104 | 
+105 | test_cycle
+    |
+
+AIR302_names.py:105:1: AIR302 `airflow.utils.dag_cycle_tester.test_cycle` is removed in Airflow 3.0
+    |
+103 | TriggerRule.NONE_FAILED_OR_SKIPPED
+104 | 
+105 | test_cycle
     | ^^^^^^^^^^ AIR302
-102 | 
-103 | has_access
+106 | 
+107 | has_access
     |
 
-AIR302_names.py:103:1: AIR302 `airflow.www.auth.has_access` is removed in Airflow 3.0; use `airflow.www.auth.has_access_*` instead
+AIR302_names.py:107:1: AIR302 `airflow.www.auth.has_access` is removed in Airflow 3.0; use `airflow.www.auth.has_access_*` instead
     |
-101 | test_cycle
-102 | 
-103 | has_access
+105 | test_cycle
+106 | 
+107 | has_access
     | ^^^^^^^^^^ AIR302
-104 | get_sensitive_variables_fields, should_hide_value_for_key
+108 | get_sensitive_variables_fields, should_hide_value_for_key
     |
 
-AIR302_names.py:104:1: AIR302 `airflow.www.utils.get_sensitive_variables_fields` is removed in Airflow 3.0; use `airflow.utils.log.secrets_masker.get_sensitive_variables_fields` instead
+AIR302_names.py:108:1: AIR302 `airflow.www.utils.get_sensitive_variables_fields` is removed in Airflow 3.0; use `airflow.utils.log.secrets_masker.get_sensitive_variables_fields` instead
     |
-103 | has_access
-104 | get_sensitive_variables_fields, should_hide_value_for_key
+107 | has_access
+108 | get_sensitive_variables_fields, should_hide_value_for_key
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
     |
 
-AIR302_names.py:104:33: AIR302 `airflow.www.utils.should_hide_value_for_key` is removed in Airflow 3.0; use `airflow.utils.log.secrets_masker.should_hide_value_for_key` instead
+AIR302_names.py:108:33: AIR302 `airflow.www.utils.should_hide_value_for_key` is removed in Airflow 3.0; use `airflow.utils.log.secrets_masker.should_hide_value_for_key` instead
     |
-103 | has_access
-104 | get_sensitive_variables_fields, should_hide_value_for_key
+107 | has_access
+108 | get_sensitive_variables_fields, should_hide_value_for_key
     |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
     |

--- a/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_names.py.snap
+++ b/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_names.py.snap
@@ -2,258 +2,278 @@
 source: crates/ruff_linter/src/rules/airflow/mod.rs
 snapshot_kind: text
 ---
-AIR302_names.py:32:1: AIR302 `airflow.triggers.external_task.TaskStateTrigger` is removed in Airflow 3.0
+AIR302_names.py:33:1: AIR302 `airflow.triggers.external_task.TaskStateTrigger` is removed in Airflow 3.0
    |
-32 | TaskStateTrigger
+33 | TaskStateTrigger
    | ^^^^^^^^^^^^^^^^ AIR302
    |
 
-AIR302_names.py:35:1: AIR302 `airflow.www.auth.has_access` is removed in Airflow 3.0; use `airflow.www.auth.has_access_*` instead
+AIR302_names.py:36:1: AIR302 `airflow.www.auth.has_access` is removed in Airflow 3.0; use `airflow.www.auth.has_access_*` instead
    |
-35 | has_access
+36 | has_access
    | ^^^^^^^^^^ AIR302
-36 | requires_access
+37 | requires_access
    |
 
-AIR302_names.py:36:1: AIR302 `airflow.api_connexion.security.requires_access` is removed in Airflow 3.0; use `airflow.api_connexion.security.requires_access_*` instead
+AIR302_names.py:37:1: AIR302 `airflow.api_connexion.security.requires_access` is removed in Airflow 3.0; use `airflow.api_connexion.security.requires_access_*` instead
    |
-35 | has_access
-36 | requires_access
+36 | has_access
+37 | requires_access
    | ^^^^^^^^^^^^^^^ AIR302
-37 | 
-38 | AllowListValidator
+38 | 
+39 | AllowListValidator
    |
 
-AIR302_names.py:38:1: AIR302 `airflow.metrics.validators.AllowListValidator` is removed in Airflow 3.0; use `airflow.metrics.validators.PatternAllowListValidator` instead
+AIR302_names.py:39:1: AIR302 `airflow.metrics.validators.AllowListValidator` is removed in Airflow 3.0; use `airflow.metrics.validators.PatternAllowListValidator` instead
    |
-36 | requires_access
-37 | 
-38 | AllowListValidator
+37 | requires_access
+38 | 
+39 | AllowListValidator
    | ^^^^^^^^^^^^^^^^^^ AIR302
-39 | BlockListValidator
+40 | BlockListValidator
    |
 
-AIR302_names.py:39:1: AIR302 `airflow.metrics.validators.BlockListValidator` is removed in Airflow 3.0; use `airflow.metrics.validators.PatternBlockListValidator` instead
+AIR302_names.py:40:1: AIR302 `airflow.metrics.validators.BlockListValidator` is removed in Airflow 3.0; use `airflow.metrics.validators.PatternBlockListValidator` instead
    |
-38 | AllowListValidator
-39 | BlockListValidator
+39 | AllowListValidator
+40 | BlockListValidator
    | ^^^^^^^^^^^^^^^^^^ AIR302
-40 | 
-41 | dates.date_range
+41 | 
+42 | dates.date_range
    |
 
-AIR302_names.py:41:7: AIR302 `airflow.utils.dates.date_range` is removed in Airflow 3.0; use `airflow.timetables.` instead
+AIR302_names.py:42:7: AIR302 `airflow.utils.dates.date_range` is removed in Airflow 3.0; use `airflow.timetables.` instead
    |
-39 | BlockListValidator
-40 | 
-41 | dates.date_range
+40 | BlockListValidator
+41 | 
+42 | dates.date_range
    |       ^^^^^^^^^^ AIR302
-42 | dates.days_ago
+43 | dates.days_ago
    |
 
-AIR302_names.py:42:7: AIR302 `airflow.utils.dates.days_ago` is removed in Airflow 3.0; use `pendulum.today('UTC').add(days=-N, ...)` instead
+AIR302_names.py:43:7: AIR302 `airflow.utils.dates.days_ago` is removed in Airflow 3.0; use `pendulum.today('UTC').add(days=-N, ...)` instead
    |
-41 | dates.date_range
-42 | dates.days_ago
+42 | dates.date_range
+43 | dates.days_ago
    |       ^^^^^^^^ AIR302
-43 | 
-44 | date_range
+44 | 
+45 | date_range
    |
 
-AIR302_names.py:44:1: AIR302 `airflow.utils.dates.date_range` is removed in Airflow 3.0; use `airflow.timetables.` instead
+AIR302_names.py:45:1: AIR302 `airflow.utils.dates.date_range` is removed in Airflow 3.0; use `airflow.timetables.` instead
    |
-42 | dates.days_ago
-43 | 
-44 | date_range
+43 | dates.days_ago
+44 | 
+45 | date_range
    | ^^^^^^^^^^ AIR302
-45 | days_ago
-46 | parse_execution_date
+46 | days_ago
+47 | parse_execution_date
    |
 
-AIR302_names.py:45:1: AIR302 `airflow.utils.dates.days_ago` is removed in Airflow 3.0; use `pendulum.today('UTC').add(days=-N, ...)` instead
+AIR302_names.py:46:1: AIR302 `airflow.utils.dates.days_ago` is removed in Airflow 3.0; use `pendulum.today('UTC').add(days=-N, ...)` instead
    |
-44 | date_range
-45 | days_ago
+45 | date_range
+46 | days_ago
    | ^^^^^^^^ AIR302
-46 | parse_execution_date
-47 | round_time
+47 | parse_execution_date
+48 | round_time
    |
 
-AIR302_names.py:46:1: AIR302 `airflow.utils.dates.parse_execution_date` is removed in Airflow 3.0
+AIR302_names.py:47:1: AIR302 `airflow.utils.dates.parse_execution_date` is removed in Airflow 3.0
    |
-44 | date_range
-45 | days_ago
-46 | parse_execution_date
+45 | date_range
+46 | days_ago
+47 | parse_execution_date
    | ^^^^^^^^^^^^^^^^^^^^ AIR302
-47 | round_time
-48 | scale_time_units
+48 | round_time
+49 | scale_time_units
    |
 
-AIR302_names.py:47:1: AIR302 `airflow.utils.dates.round_time` is removed in Airflow 3.0
+AIR302_names.py:48:1: AIR302 `airflow.utils.dates.round_time` is removed in Airflow 3.0
    |
-45 | days_ago
-46 | parse_execution_date
-47 | round_time
+46 | days_ago
+47 | parse_execution_date
+48 | round_time
    | ^^^^^^^^^^ AIR302
-48 | scale_time_units
-49 | infer_time_unit
+49 | scale_time_units
+50 | infer_time_unit
    |
 
-AIR302_names.py:48:1: AIR302 `airflow.utils.dates.scale_time_units` is removed in Airflow 3.0
+AIR302_names.py:49:1: AIR302 `airflow.utils.dates.scale_time_units` is removed in Airflow 3.0
    |
-46 | parse_execution_date
-47 | round_time
-48 | scale_time_units
+47 | parse_execution_date
+48 | round_time
+49 | scale_time_units
    | ^^^^^^^^^^^^^^^^ AIR302
-49 | infer_time_unit
+50 | infer_time_unit
    |
 
-AIR302_names.py:49:1: AIR302 `airflow.utils.dates.infer_time_unit` is removed in Airflow 3.0
+AIR302_names.py:50:1: AIR302 `airflow.utils.dates.infer_time_unit` is removed in Airflow 3.0
    |
-47 | round_time
-48 | scale_time_units
-49 | infer_time_unit
+48 | round_time
+49 | scale_time_units
+50 | infer_time_unit
    | ^^^^^^^^^^^^^^^ AIR302
    |
 
-AIR302_names.py:56:1: AIR302 `airflow.configuration.get` is removed in Airflow 3.0; use `airflow.configuration.conf.get` instead
+AIR302_names.py:57:1: AIR302 `airflow.configuration.get` is removed in Airflow 3.0; use `airflow.configuration.conf.get` instead
    |
-54 | dates.datetime_to_nano
-55 | 
-56 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+55 | dates.datetime_to_nano
+56 | 
+57 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
    | ^^^ AIR302
-57 | TemporaryDirectory
-58 | mkdirs
+58 | 
+59 | get_connection, load_connections
    |
 
-AIR302_names.py:56:6: AIR302 `airflow.configuration.getboolean` is removed in Airflow 3.0; use `airflow.configuration.conf.getboolean` instead
+AIR302_names.py:57:6: AIR302 `airflow.configuration.getboolean` is removed in Airflow 3.0; use `airflow.configuration.conf.getboolean` instead
    |
-54 | dates.datetime_to_nano
-55 | 
-56 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+55 | dates.datetime_to_nano
+56 | 
+57 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
    |      ^^^^^^^^^^ AIR302
-57 | TemporaryDirectory
-58 | mkdirs
+58 | 
+59 | get_connection, load_connections
    |
 
-AIR302_names.py:56:18: AIR302 `airflow.configuration.getfloat` is removed in Airflow 3.0; use `airflow.configuration.conf.getfloat` instead
+AIR302_names.py:57:18: AIR302 `airflow.configuration.getfloat` is removed in Airflow 3.0; use `airflow.configuration.conf.getfloat` instead
    |
-54 | dates.datetime_to_nano
-55 | 
-56 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+55 | dates.datetime_to_nano
+56 | 
+57 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
    |                  ^^^^^^^^ AIR302
-57 | TemporaryDirectory
-58 | mkdirs
+58 | 
+59 | get_connection, load_connections
    |
 
-AIR302_names.py:56:28: AIR302 `airflow.configuration.getint` is removed in Airflow 3.0; use `airflow.configuration.conf.getint` instead
+AIR302_names.py:57:28: AIR302 `airflow.configuration.getint` is removed in Airflow 3.0; use `airflow.configuration.conf.getint` instead
    |
-54 | dates.datetime_to_nano
-55 | 
-56 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+55 | dates.datetime_to_nano
+56 | 
+57 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
    |                            ^^^^^^ AIR302
-57 | TemporaryDirectory
-58 | mkdirs
+58 | 
+59 | get_connection, load_connections
    |
 
-AIR302_names.py:56:36: AIR302 `airflow.configuration.has_option` is removed in Airflow 3.0; use `airflow.configuration.conf.has_option` instead
+AIR302_names.py:57:36: AIR302 `airflow.configuration.has_option` is removed in Airflow 3.0; use `airflow.configuration.conf.has_option` instead
    |
-54 | dates.datetime_to_nano
-55 | 
-56 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+55 | dates.datetime_to_nano
+56 | 
+57 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
    |                                    ^^^^^^^^^^ AIR302
-57 | TemporaryDirectory
-58 | mkdirs
+58 | 
+59 | get_connection, load_connections
    |
 
-AIR302_names.py:56:48: AIR302 `airflow.configuration.remove_option` is removed in Airflow 3.0; use `airflow.configuration.conf.remove_option` instead
+AIR302_names.py:57:48: AIR302 `airflow.configuration.remove_option` is removed in Airflow 3.0; use `airflow.configuration.conf.remove_option` instead
    |
-54 | dates.datetime_to_nano
-55 | 
-56 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+55 | dates.datetime_to_nano
+56 | 
+57 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
    |                                                ^^^^^^^^^^^^^ AIR302
-57 | TemporaryDirectory
-58 | mkdirs
+58 | 
+59 | get_connection, load_connections
    |
 
-AIR302_names.py:56:63: AIR302 `airflow.configuration.as_dict` is removed in Airflow 3.0; use `airflow.configuration.conf.as_dict` instead
+AIR302_names.py:57:63: AIR302 `airflow.configuration.as_dict` is removed in Airflow 3.0; use `airflow.configuration.conf.as_dict` instead
    |
-54 | dates.datetime_to_nano
-55 | 
-56 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+55 | dates.datetime_to_nano
+56 | 
+57 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
    |                                                               ^^^^^^^ AIR302
-57 | TemporaryDirectory
-58 | mkdirs
+58 | 
+59 | get_connection, load_connections
    |
 
-AIR302_names.py:56:72: AIR302 `airflow.configuration.set` is removed in Airflow 3.0; use `airflow.configuration.conf.set` instead
+AIR302_names.py:57:72: AIR302 `airflow.configuration.set` is removed in Airflow 3.0; use `airflow.configuration.conf.set` instead
    |
-54 | dates.datetime_to_nano
-55 | 
-56 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+55 | dates.datetime_to_nano
+56 | 
+57 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
    |                                                                        ^^^ AIR302
-57 | TemporaryDirectory
-58 | mkdirs
+58 | 
+59 | get_connection, load_connections
    |
 
-AIR302_names.py:57:1: AIR302 `airflow.utils.file.TemporaryDirectory` is removed in Airflow 3.0
+AIR302_names.py:59:1: AIR302 `airflow.secrets.local_filesystem.get_connection` is removed in Airflow 3.0; use `airflow.secrets.local_filesystem.load_connections_dict` instead
    |
-56 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
-57 | TemporaryDirectory
+57 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+58 | 
+59 | get_connection, load_connections
+   | ^^^^^^^^^^^^^^ AIR302
+60 | 
+61 | TemporaryDirectory
+   |
+
+AIR302_names.py:59:17: AIR302 `airflow.secrets.local_filesystem.load_connections` is removed in Airflow 3.0; use `airflow.secrets.local_filesystem.load_connections_dict` instead
+   |
+57 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+58 | 
+59 | get_connection, load_connections
+   |                 ^^^^^^^^^^^^^^^^ AIR302
+60 | 
+61 | TemporaryDirectory
+   |
+
+AIR302_names.py:61:1: AIR302 `airflow.utils.file.TemporaryDirectory` is removed in Airflow 3.0
+   |
+59 | get_connection, load_connections
+60 | 
+61 | TemporaryDirectory
    | ^^^^^^^^^^^^^^^^^^ AIR302
-58 | mkdirs
+62 | mkdirs
    |
 
-AIR302_names.py:58:1: AIR302 `airflow.utils.file.mkdirs` is removed in Airflow 3.0; use `pendulum.today('UTC').add(days=-N, ...)` instead
+AIR302_names.py:62:1: AIR302 `airflow.utils.file.mkdirs` is removed in Airflow 3.0; use `pendulum.today('UTC').add(days=-N, ...)` instead
    |
-56 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
-57 | TemporaryDirectory
-58 | mkdirs
+61 | TemporaryDirectory
+62 | mkdirs
    | ^^^^^^ AIR302
-59 | 
-60 | chain
+63 | 
+64 | chain
    |
 
-AIR302_names.py:60:1: AIR302 `airflow.utils.helpers.chain` is removed in Airflow 3.0; use `airflow.models.baseoperator.chain` instead
+AIR302_names.py:64:1: AIR302 `airflow.utils.helpers.chain` is removed in Airflow 3.0; use `airflow.models.baseoperator.chain` instead
    |
-58 | mkdirs
-59 | 
-60 | chain
+62 | mkdirs
+63 | 
+64 | chain
    | ^^^^^ AIR302
-61 | cross_downstream
+65 | cross_downstream
    |
 
-AIR302_names.py:61:1: AIR302 `airflow.utils.helpers.cross_downstream` is removed in Airflow 3.0; use `airflow.models.baseoperator.cross_downstream` instead
+AIR302_names.py:65:1: AIR302 `airflow.utils.helpers.cross_downstream` is removed in Airflow 3.0; use `airflow.models.baseoperator.cross_downstream` instead
    |
-60 | chain
-61 | cross_downstream
+64 | chain
+65 | cross_downstream
    | ^^^^^^^^^^^^^^^^ AIR302
-62 | 
-63 | SHUTDOWN
+66 | 
+67 | SHUTDOWN
    |
 
-AIR302_names.py:63:1: AIR302 `airflow.utils.state.SHUTDOWN` is removed in Airflow 3.0
+AIR302_names.py:67:1: AIR302 `airflow.utils.state.SHUTDOWN` is removed in Airflow 3.0
    |
-61 | cross_downstream
-62 | 
-63 | SHUTDOWN
+65 | cross_downstream
+66 | 
+67 | SHUTDOWN
    | ^^^^^^^^ AIR302
-64 | terminating_states
+68 | terminating_states
    |
 
-AIR302_names.py:64:1: AIR302 `airflow.utils.state.terminating_states` is removed in Airflow 3.0
+AIR302_names.py:68:1: AIR302 `airflow.utils.state.terminating_states` is removed in Airflow 3.0
    |
-63 | SHUTDOWN
-64 | terminating_states
+67 | SHUTDOWN
+68 | terminating_states
    | ^^^^^^^^^^^^^^^^^^ AIR302
-65 | 
-66 | test_cycle
+69 | 
+70 | test_cycle
    |
 
-AIR302_names.py:66:1: AIR302 `airflow.utils.dag_cycle_tester.test_cycle` is removed in Airflow 3.0
+AIR302_names.py:70:1: AIR302 `airflow.utils.dag_cycle_tester.test_cycle` is removed in Airflow 3.0
    |
-64 | terminating_states
-65 | 
-66 | test_cycle
+68 | terminating_states
+69 | 
+70 | test_cycle
    | ^^^^^^^^^^ AIR302
    |

--- a/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_names.py.snap
+++ b/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_names.py.snap
@@ -2,278 +2,299 @@
 source: crates/ruff_linter/src/rules/airflow/mod.rs
 snapshot_kind: text
 ---
-AIR302_names.py:33:1: AIR302 `airflow.triggers.external_task.TaskStateTrigger` is removed in Airflow 3.0
+AIR302_names.py:34:1: AIR302 `airflow.triggers.external_task.TaskStateTrigger` is removed in Airflow 3.0
    |
-33 | TaskStateTrigger
+34 | TaskStateTrigger
    | ^^^^^^^^^^^^^^^^ AIR302
+35 | 
+36 | requires_access
    |
 
-AIR302_names.py:36:1: AIR302 `airflow.www.auth.has_access` is removed in Airflow 3.0; use `airflow.www.auth.has_access_*` instead
+AIR302_names.py:36:1: AIR302 `airflow.api_connexion.security.requires_access` is removed in Airflow 3.0; use `airflow.api_connexion.security.requires_access_*` instead
    |
-36 | has_access
-   | ^^^^^^^^^^ AIR302
-37 | requires_access
-   |
-
-AIR302_names.py:37:1: AIR302 `airflow.api_connexion.security.requires_access` is removed in Airflow 3.0; use `airflow.api_connexion.security.requires_access_*` instead
-   |
-36 | has_access
-37 | requires_access
+34 | TaskStateTrigger
+35 | 
+36 | requires_access
    | ^^^^^^^^^^^^^^^ AIR302
-38 | 
-39 | AllowListValidator
+37 | 
+38 | AllowListValidator
    |
 
-AIR302_names.py:39:1: AIR302 `airflow.metrics.validators.AllowListValidator` is removed in Airflow 3.0; use `airflow.metrics.validators.PatternAllowListValidator` instead
+AIR302_names.py:38:1: AIR302 `airflow.metrics.validators.AllowListValidator` is removed in Airflow 3.0; use `airflow.metrics.validators.PatternAllowListValidator` instead
    |
-37 | requires_access
-38 | 
-39 | AllowListValidator
+36 | requires_access
+37 | 
+38 | AllowListValidator
    | ^^^^^^^^^^^^^^^^^^ AIR302
-40 | BlockListValidator
+39 | BlockListValidator
    |
 
-AIR302_names.py:40:1: AIR302 `airflow.metrics.validators.BlockListValidator` is removed in Airflow 3.0; use `airflow.metrics.validators.PatternBlockListValidator` instead
+AIR302_names.py:39:1: AIR302 `airflow.metrics.validators.BlockListValidator` is removed in Airflow 3.0; use `airflow.metrics.validators.PatternBlockListValidator` instead
    |
-39 | AllowListValidator
-40 | BlockListValidator
+38 | AllowListValidator
+39 | BlockListValidator
    | ^^^^^^^^^^^^^^^^^^ AIR302
-41 | 
-42 | dates.date_range
+40 | 
+41 | dates.date_range
    |
 
-AIR302_names.py:42:7: AIR302 `airflow.utils.dates.date_range` is removed in Airflow 3.0; use `airflow.timetables.` instead
+AIR302_names.py:41:7: AIR302 `airflow.utils.dates.date_range` is removed in Airflow 3.0; use `airflow.timetables.` instead
    |
-40 | BlockListValidator
-41 | 
-42 | dates.date_range
+39 | BlockListValidator
+40 | 
+41 | dates.date_range
    |       ^^^^^^^^^^ AIR302
-43 | dates.days_ago
+42 | dates.days_ago
    |
 
-AIR302_names.py:43:7: AIR302 `airflow.utils.dates.days_ago` is removed in Airflow 3.0; use `pendulum.today('UTC').add(days=-N, ...)` instead
+AIR302_names.py:42:7: AIR302 `airflow.utils.dates.days_ago` is removed in Airflow 3.0; use `pendulum.today('UTC').add(days=-N, ...)` instead
    |
-42 | dates.date_range
-43 | dates.days_ago
+41 | dates.date_range
+42 | dates.days_ago
    |       ^^^^^^^^ AIR302
-44 | 
-45 | date_range
+43 | 
+44 | date_range
    |
 
-AIR302_names.py:45:1: AIR302 `airflow.utils.dates.date_range` is removed in Airflow 3.0; use `airflow.timetables.` instead
+AIR302_names.py:44:1: AIR302 `airflow.utils.dates.date_range` is removed in Airflow 3.0; use `airflow.timetables.` instead
    |
-43 | dates.days_ago
-44 | 
-45 | date_range
+42 | dates.days_ago
+43 | 
+44 | date_range
    | ^^^^^^^^^^ AIR302
-46 | days_ago
-47 | parse_execution_date
+45 | days_ago
+46 | parse_execution_date
    |
 
-AIR302_names.py:46:1: AIR302 `airflow.utils.dates.days_ago` is removed in Airflow 3.0; use `pendulum.today('UTC').add(days=-N, ...)` instead
+AIR302_names.py:45:1: AIR302 `airflow.utils.dates.days_ago` is removed in Airflow 3.0; use `pendulum.today('UTC').add(days=-N, ...)` instead
    |
-45 | date_range
-46 | days_ago
+44 | date_range
+45 | days_ago
    | ^^^^^^^^ AIR302
-47 | parse_execution_date
-48 | round_time
+46 | parse_execution_date
+47 | round_time
    |
 
-AIR302_names.py:47:1: AIR302 `airflow.utils.dates.parse_execution_date` is removed in Airflow 3.0
+AIR302_names.py:46:1: AIR302 `airflow.utils.dates.parse_execution_date` is removed in Airflow 3.0
    |
-45 | date_range
-46 | days_ago
-47 | parse_execution_date
+44 | date_range
+45 | days_ago
+46 | parse_execution_date
    | ^^^^^^^^^^^^^^^^^^^^ AIR302
-48 | round_time
-49 | scale_time_units
+47 | round_time
+48 | scale_time_units
    |
 
-AIR302_names.py:48:1: AIR302 `airflow.utils.dates.round_time` is removed in Airflow 3.0
+AIR302_names.py:47:1: AIR302 `airflow.utils.dates.round_time` is removed in Airflow 3.0
    |
-46 | days_ago
-47 | parse_execution_date
-48 | round_time
+45 | days_ago
+46 | parse_execution_date
+47 | round_time
    | ^^^^^^^^^^ AIR302
-49 | scale_time_units
-50 | infer_time_unit
+48 | scale_time_units
+49 | infer_time_unit
    |
 
-AIR302_names.py:49:1: AIR302 `airflow.utils.dates.scale_time_units` is removed in Airflow 3.0
+AIR302_names.py:48:1: AIR302 `airflow.utils.dates.scale_time_units` is removed in Airflow 3.0
    |
-47 | parse_execution_date
-48 | round_time
-49 | scale_time_units
+46 | parse_execution_date
+47 | round_time
+48 | scale_time_units
    | ^^^^^^^^^^^^^^^^ AIR302
-50 | infer_time_unit
+49 | infer_time_unit
    |
 
-AIR302_names.py:50:1: AIR302 `airflow.utils.dates.infer_time_unit` is removed in Airflow 3.0
+AIR302_names.py:49:1: AIR302 `airflow.utils.dates.infer_time_unit` is removed in Airflow 3.0
    |
-48 | round_time
-49 | scale_time_units
-50 | infer_time_unit
+47 | round_time
+48 | scale_time_units
+49 | infer_time_unit
    | ^^^^^^^^^^^^^^^ AIR302
    |
 
-AIR302_names.py:57:1: AIR302 `airflow.configuration.get` is removed in Airflow 3.0; use `airflow.configuration.conf.get` instead
+AIR302_names.py:56:1: AIR302 `airflow.configuration.get` is removed in Airflow 3.0; use `airflow.configuration.conf.get` instead
    |
-55 | dates.datetime_to_nano
-56 | 
-57 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+54 | dates.datetime_to_nano
+55 | 
+56 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
    | ^^^ AIR302
-58 | 
-59 | get_connection, load_connections
+57 | 
+58 | get_connection, load_connections
    |
 
-AIR302_names.py:57:6: AIR302 `airflow.configuration.getboolean` is removed in Airflow 3.0; use `airflow.configuration.conf.getboolean` instead
+AIR302_names.py:56:6: AIR302 `airflow.configuration.getboolean` is removed in Airflow 3.0; use `airflow.configuration.conf.getboolean` instead
    |
-55 | dates.datetime_to_nano
-56 | 
-57 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+54 | dates.datetime_to_nano
+55 | 
+56 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
    |      ^^^^^^^^^^ AIR302
-58 | 
-59 | get_connection, load_connections
+57 | 
+58 | get_connection, load_connections
    |
 
-AIR302_names.py:57:18: AIR302 `airflow.configuration.getfloat` is removed in Airflow 3.0; use `airflow.configuration.conf.getfloat` instead
+AIR302_names.py:56:18: AIR302 `airflow.configuration.getfloat` is removed in Airflow 3.0; use `airflow.configuration.conf.getfloat` instead
    |
-55 | dates.datetime_to_nano
-56 | 
-57 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+54 | dates.datetime_to_nano
+55 | 
+56 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
    |                  ^^^^^^^^ AIR302
-58 | 
-59 | get_connection, load_connections
+57 | 
+58 | get_connection, load_connections
    |
 
-AIR302_names.py:57:28: AIR302 `airflow.configuration.getint` is removed in Airflow 3.0; use `airflow.configuration.conf.getint` instead
+AIR302_names.py:56:28: AIR302 `airflow.configuration.getint` is removed in Airflow 3.0; use `airflow.configuration.conf.getint` instead
    |
-55 | dates.datetime_to_nano
-56 | 
-57 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+54 | dates.datetime_to_nano
+55 | 
+56 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
    |                            ^^^^^^ AIR302
-58 | 
-59 | get_connection, load_connections
+57 | 
+58 | get_connection, load_connections
    |
 
-AIR302_names.py:57:36: AIR302 `airflow.configuration.has_option` is removed in Airflow 3.0; use `airflow.configuration.conf.has_option` instead
+AIR302_names.py:56:36: AIR302 `airflow.configuration.has_option` is removed in Airflow 3.0; use `airflow.configuration.conf.has_option` instead
    |
-55 | dates.datetime_to_nano
-56 | 
-57 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+54 | dates.datetime_to_nano
+55 | 
+56 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
    |                                    ^^^^^^^^^^ AIR302
-58 | 
-59 | get_connection, load_connections
+57 | 
+58 | get_connection, load_connections
    |
 
-AIR302_names.py:57:48: AIR302 `airflow.configuration.remove_option` is removed in Airflow 3.0; use `airflow.configuration.conf.remove_option` instead
+AIR302_names.py:56:48: AIR302 `airflow.configuration.remove_option` is removed in Airflow 3.0; use `airflow.configuration.conf.remove_option` instead
    |
-55 | dates.datetime_to_nano
-56 | 
-57 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+54 | dates.datetime_to_nano
+55 | 
+56 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
    |                                                ^^^^^^^^^^^^^ AIR302
-58 | 
-59 | get_connection, load_connections
+57 | 
+58 | get_connection, load_connections
    |
 
-AIR302_names.py:57:63: AIR302 `airflow.configuration.as_dict` is removed in Airflow 3.0; use `airflow.configuration.conf.as_dict` instead
+AIR302_names.py:56:63: AIR302 `airflow.configuration.as_dict` is removed in Airflow 3.0; use `airflow.configuration.conf.as_dict` instead
    |
-55 | dates.datetime_to_nano
-56 | 
-57 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+54 | dates.datetime_to_nano
+55 | 
+56 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
    |                                                               ^^^^^^^ AIR302
-58 | 
-59 | get_connection, load_connections
+57 | 
+58 | get_connection, load_connections
    |
 
-AIR302_names.py:57:72: AIR302 `airflow.configuration.set` is removed in Airflow 3.0; use `airflow.configuration.conf.set` instead
+AIR302_names.py:56:72: AIR302 `airflow.configuration.set` is removed in Airflow 3.0; use `airflow.configuration.conf.set` instead
    |
-55 | dates.datetime_to_nano
-56 | 
-57 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+54 | dates.datetime_to_nano
+55 | 
+56 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
    |                                                                        ^^^ AIR302
-58 | 
-59 | get_connection, load_connections
+57 | 
+58 | get_connection, load_connections
    |
 
-AIR302_names.py:59:1: AIR302 `airflow.secrets.local_filesystem.get_connection` is removed in Airflow 3.0; use `airflow.secrets.local_filesystem.load_connections_dict` instead
+AIR302_names.py:58:1: AIR302 `airflow.secrets.local_filesystem.get_connection` is removed in Airflow 3.0; use `airflow.secrets.local_filesystem.load_connections_dict` instead
    |
-57 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
-58 | 
-59 | get_connection, load_connections
+56 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+57 | 
+58 | get_connection, load_connections
    | ^^^^^^^^^^^^^^ AIR302
-60 | 
-61 | TemporaryDirectory
+59 | 
+60 | TemporaryDirectory
    |
 
-AIR302_names.py:59:17: AIR302 `airflow.secrets.local_filesystem.load_connections` is removed in Airflow 3.0; use `airflow.secrets.local_filesystem.load_connections_dict` instead
+AIR302_names.py:58:17: AIR302 `airflow.secrets.local_filesystem.load_connections` is removed in Airflow 3.0; use `airflow.secrets.local_filesystem.load_connections_dict` instead
    |
-57 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
-58 | 
-59 | get_connection, load_connections
+56 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+57 | 
+58 | get_connection, load_connections
    |                 ^^^^^^^^^^^^^^^^ AIR302
-60 | 
-61 | TemporaryDirectory
+59 | 
+60 | TemporaryDirectory
    |
 
-AIR302_names.py:61:1: AIR302 `airflow.utils.file.TemporaryDirectory` is removed in Airflow 3.0
+AIR302_names.py:60:1: AIR302 `airflow.utils.file.TemporaryDirectory` is removed in Airflow 3.0
    |
-59 | get_connection, load_connections
-60 | 
-61 | TemporaryDirectory
+58 | get_connection, load_connections
+59 | 
+60 | TemporaryDirectory
    | ^^^^^^^^^^^^^^^^^^ AIR302
-62 | mkdirs
+61 | mkdirs
    |
 
-AIR302_names.py:62:1: AIR302 `airflow.utils.file.mkdirs` is removed in Airflow 3.0; use `pendulum.today('UTC').add(days=-N, ...)` instead
+AIR302_names.py:61:1: AIR302 `airflow.utils.file.mkdirs` is removed in Airflow 3.0; use `pendulum.today('UTC').add(days=-N, ...)` instead
    |
-61 | TemporaryDirectory
-62 | mkdirs
+60 | TemporaryDirectory
+61 | mkdirs
    | ^^^^^^ AIR302
-63 | 
-64 | chain
+62 | 
+63 | chain
    |
 
-AIR302_names.py:64:1: AIR302 `airflow.utils.helpers.chain` is removed in Airflow 3.0; use `airflow.models.baseoperator.chain` instead
+AIR302_names.py:63:1: AIR302 `airflow.utils.helpers.chain` is removed in Airflow 3.0; use `airflow.models.baseoperator.chain` instead
    |
-62 | mkdirs
-63 | 
-64 | chain
+61 | mkdirs
+62 | 
+63 | chain
    | ^^^^^ AIR302
-65 | cross_downstream
+64 | cross_downstream
    |
 
-AIR302_names.py:65:1: AIR302 `airflow.utils.helpers.cross_downstream` is removed in Airflow 3.0; use `airflow.models.baseoperator.cross_downstream` instead
+AIR302_names.py:64:1: AIR302 `airflow.utils.helpers.cross_downstream` is removed in Airflow 3.0; use `airflow.models.baseoperator.cross_downstream` instead
    |
-64 | chain
-65 | cross_downstream
+63 | chain
+64 | cross_downstream
    | ^^^^^^^^^^^^^^^^ AIR302
-66 | 
-67 | SHUTDOWN
+65 | 
+66 | SHUTDOWN
    |
 
-AIR302_names.py:67:1: AIR302 `airflow.utils.state.SHUTDOWN` is removed in Airflow 3.0
+AIR302_names.py:66:1: AIR302 `airflow.utils.state.SHUTDOWN` is removed in Airflow 3.0
    |
-65 | cross_downstream
-66 | 
-67 | SHUTDOWN
+64 | cross_downstream
+65 | 
+66 | SHUTDOWN
    | ^^^^^^^^ AIR302
-68 | terminating_states
+67 | terminating_states
    |
 
-AIR302_names.py:68:1: AIR302 `airflow.utils.state.terminating_states` is removed in Airflow 3.0
+AIR302_names.py:67:1: AIR302 `airflow.utils.state.terminating_states` is removed in Airflow 3.0
    |
-67 | SHUTDOWN
-68 | terminating_states
+66 | SHUTDOWN
+67 | terminating_states
    | ^^^^^^^^^^^^^^^^^^ AIR302
-69 | 
-70 | test_cycle
+68 | 
+69 | test_cycle
    |
 
-AIR302_names.py:70:1: AIR302 `airflow.utils.dag_cycle_tester.test_cycle` is removed in Airflow 3.0
+AIR302_names.py:69:1: AIR302 `airflow.utils.dag_cycle_tester.test_cycle` is removed in Airflow 3.0
    |
-68 | terminating_states
-69 | 
-70 | test_cycle
+67 | terminating_states
+68 | 
+69 | test_cycle
    | ^^^^^^^^^^ AIR302
+70 | 
+71 | has_access
+   |
+
+AIR302_names.py:71:1: AIR302 `airflow.www.auth.has_access` is removed in Airflow 3.0; use `airflow.www.auth.has_access_*` instead
+   |
+69 | test_cycle
+70 | 
+71 | has_access
+   | ^^^^^^^^^^ AIR302
+72 | get_sensitive_variables_fields, should_hide_value_for_key
+   |
+
+AIR302_names.py:72:1: AIR302 `airflow.www.utils.get_sensitive_variables_fields` is removed in Airflow 3.0; use `airflow.utils.log.secrets_masker.get_sensitive_variables_fields` instead
+   |
+71 | has_access
+72 | get_sensitive_variables_fields, should_hide_value_for_key
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
+   |
+
+AIR302_names.py:72:33: AIR302 `airflow.www.utils.should_hide_value_for_key` is removed in Airflow 3.0; use `airflow.utils.log.secrets_masker.should_hide_value_for_key` instead
+   |
+71 | has_access
+72 | get_sensitive_variables_fields, should_hide_value_for_key
+   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
    |


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Airflow 3.0 removes various deprecated functions, members, modules, and other values. They have been deprecated in 2.x, but the removal causes incompatibilities that we want to detect. This PR deprecates the following names.
The full list of rules we will extend https://github.com/apache/airflow/issues/44556


#### package
* `airflow.contrib.*` 

#### module
* `airflow.operators.subdag.*` 

#### class
* `airflow.sensors.external_task.ExternalTaskSensorLink` → `airflow.sensors.external_task.ExternalDagLin` 
* `airflow.operators.bash_operator.BashOperator` → `airflow.operators.bash.BashOperator` 
* `airflow.operators.branch_operator.BaseBranchOperator` → `airflow.operators.branch.BaseBranchOperator` 
* `airflow.operators.dummy.EmptyOperator` → `airflow.operators.empty.EmptyOperator` 
* `airflow.operators.dummy.DummyOperator` → `airflow.operators.empty.EmptyOperator` 
* `airflow.operators.dummy_operator.EmptyOperator` → `airflow.operators.empty.EmptyOperator` 
* `airflow.operators.dummy_operator.DummyOperator` → `airflow.operators.empty.EmptyOperator` 
* `airflow.operators.email_operator.EmailOperator` → `airflow.operators.email.EmailOperator` 
* `airflow.sensors.base_sensor_operator.BaseSensorOperator` → `airflow.sensors.base.BaseSensorOperator` 
* `airflow.sensors.date_time_sensor.DateTimeSensor` → `airflow.sensors.date_time.DateTimeSensor` 
* `airflow.sensors.external_task_sensor.ExternalTaskMarker` → `airflow.sensors.external_task.ExternalTaskMarker` 
* `airflow.sensors.external_task_sensor.ExternalTaskSensor` → `airflow.sensors.external_task.ExternalTaskSensor` 
* `airflow.sensors.external_task_sensor.ExternalTaskSensorLink` → `airflow.sensors.external_task.ExternalTaskSensorLink` 
* `airflow.sensors.time_delta_sensor.TimeDeltaSensor` → `airflow.sensors.time_delta.TimeDeltaSensor` 

#### function
* `airflow.utils.decorators.apply_defaults`
* `airflow.www.utils.get_sensitive_variables_fields` → `airflow.utils.log.secrets_masker.get_sensitive_variables_fields` 
* `airflow.www.utils.should_hide_value_for_key` → `airflow.utils.log.secrets_masker.should_hide_value_for_key` 
* `airflow.configuration.get` → `airflow.configuration.conf.get` 
* `airflow.configuration.getboolean` → `airflow.configuration.conf.getboolean` 
* `airflow.configuration.getfloat` → `airflow.configuration.conf.getfloat` 
* `airflow.configuration.getint` → `airflow.configuration.conf.getint` 
* `airflow.configuration.has_option` → `airflow.configuration.conf.has_option` 
* `airflow.configuration.remove_option` → `airflow.configuration.conf.remove_option` 
* `airflow.configuration.as_dict` → `airflow.configuration.conf.as_dict` 
* `airflow.configuration.set` → `airflow.configuration.conf.set` 
* `airflow.secrets.local_filesystem.load_connections` → `airflow.secrets.local_filesystem.load_connections_dict` 
* `airflow.secrets.local_filesystem.get_connection` → `airflow.secrets.local_filesystem.load_connections_dict` 
* `airflow.utils.helpers.chain` → `airflow.models.baseoperator.chain` 
* `airflow.utils.helpers.cross_downstream` → `airflow.models.baseoperator.cross_downstream` 

#### attribute
* in `airflow.utils.trigger_rule.TriggerRule`
    * `DUMMY` 
    * `NONE_FAILED_OR_SKIPPED` 

#### constant / variable
* `airflow.PY\d\d` 

## Test Plan

<!-- How was it tested? -->
