### PR TITLE
[red-knot] Import `LiteralString`/`Never` from `typing_extensions`

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/annotations/literal_string.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/annotations/literal_string.md
@@ -12,7 +12,7 @@ Parts of the testcases defined here were adapted from [the specification's examp
 It can be used anywhere a type is accepted:
 
 ```py
-from typing import LiteralString
+from typing_extensions import LiteralString
 
 x: LiteralString
 
@@ -25,7 +25,7 @@ def f():
 `LiteralString` cannot be used within `Literal`:
 
 ```py
-from typing import Literal, LiteralString
+from typing_extensions import Literal, LiteralString
 
 bad_union: Literal["hello", LiteralString]  # error: [invalid-literal-parameter]
 bad_nesting: Literal[LiteralString]  # error: [invalid-literal-parameter]
@@ -36,7 +36,7 @@ bad_nesting: Literal[LiteralString]  # error: [invalid-literal-parameter]
 `LiteralString` cannot be parametrized.
 
 ```py
-from typing import LiteralString
+from typing_extensions import LiteralString
 
 a: LiteralString[str]  # error: [invalid-type-parameter]
 b: LiteralString["foo"]  # error: [invalid-type-parameter]
@@ -47,7 +47,7 @@ b: LiteralString["foo"]  # error: [invalid-type-parameter]
 Subclassing `LiteralString` leads to a runtime error.
 
 ```py
-from typing import LiteralString
+from typing_extensions import LiteralString
 
 class C(LiteralString): ...  # error: [invalid-base]
 ```
@@ -57,6 +57,8 @@ class C(LiteralString): ...  # error: [invalid-base]
 ### Common operations
 
 ```py
+from typing_extensions import LiteralString
+
 foo: LiteralString = "foo"
 reveal_type(foo)  # revealed: Literal["foo"]
 
@@ -85,6 +87,8 @@ reveal_type(template.format(foo, bar))  # revealed: @Todo(call todo)
 vice versa.
 
 ```py
+from typing_extensions import Literal, LiteralString
+
 def coinflip() -> bool:
     return True
 
@@ -112,6 +116,8 @@ qux_3: LiteralString = baz_3  # error: [invalid-assignment]
 ### Narrowing
 
 ```py
+from typing_extensions import LiteralString
+
 lorem: LiteralString = "lorem" * 1_000_000_000
 
 reveal_type(lorem)  # revealed: LiteralString
@@ -123,6 +129,24 @@ reveal_type(lorem)  # revealed: LiteralString
 
 if "" < lorem == "ipsum":
     reveal_type(lorem)  # revealed: Literal["ipsum"]
+```
+
+## `typing.LiteralString`
+
+`typing.LiteralString` is only available in Python 3.11 and later:
+
+```toml
+[environment]
+target-version = "3.11"
+```
+
+```py
+from typing import LiteralString
+
+x: LiteralString = "foo"
+
+def f():
+    reveal_type(x)  # revealed: LiteralString
 ```
 
 [1]: https://typing.readthedocs.io/en/latest/spec/literal.html#literalstring

--- a/crates/red_knot_python_semantic/resources/mdtest/annotations/never.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/annotations/never.md
@@ -19,12 +19,11 @@ reveal_type(stop())
 ## Assignment
 
 ```py
-from typing import NoReturn, Never, Any
+from typing_extensions import NoReturn, Never, Any
 
 # error: [invalid-type-parameter] "Type `typing.Never` expected no type parameter"
 x: Never[int]
 a1: NoReturn
-# TODO: Test `Never` is only available in python >= 3.11
 a2: Never
 b1: Any
 b2: int
@@ -46,17 +45,20 @@ def f():
     v6: Never = 1
 ```
 
-## Typing Extensions
+## `typing.Never`
+
+`typing.Never` is only available in Python 3.11 and later:
+
+```toml
+[environment]
+target-version = "3.11"
+```
 
 ```py
-from typing_extensions import NoReturn, Never
+from typing import Never
 
-x: NoReturn
-y: Never
+x: Never
 
 def f():
-    # revealed: Never
-    reveal_type(x)
-    # revealed: Never
-    reveal_type(y)
+    reveal_type(x)  # revealed: Never
 ```


### PR DESCRIPTION
## Summary

`typing.Never` and `typing.LiteralString` are only conditionally exported from `typing` for Python versions 3.11 and later. We run the Markdown tests with the default Python version of 3.9, so here we change the import to `typing_extensions` instead, and add a new test to make sure we'll continue to understand the `typing`-version of these symbols for newer versions.

This didn't cause problems so far, as we don't understand `sys.version_info` branches yet.

## Test Plan

New Markdown tests to make sure this will continue to work in the future.
