### PR TITLE
[`ruff`] Don't emit `used-dummy-variable` on function parameters (`RUF052`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/ruff/RUF052.py
+++ b/crates/ruff_linter/resources/test/fixtures/ruff/RUF052.py
@@ -77,7 +77,7 @@ class Class_:
         _var = "method variable" # [RUF052]
         return _var
 
-def fun(_var): # [RUF052]
+def fun(_var): # parameters are ignored
     return _var
 
 def fun():

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF052_RUF052.py.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF052_RUF052.py.snap
@@ -20,30 +20,8 @@ RUF052.py:77:9: RUF052 [*] Local dummy variable `_var` is accessed
    77 |+        var = "method variable" # [RUF052]
    78 |+        return var
 79 79 | 
-80 80 | def fun(_var): # [RUF052]
+80 80 | def fun(_var): # parameters are ignored
 81 81 |     return _var
-
-RUF052.py:80:9: RUF052 [*] Local dummy variable `_var` is accessed
-   |
-78 |         return _var
-79 | 
-80 | def fun(_var): # [RUF052]
-   |         ^^^^ RUF052
-81 |     return _var
-   |
-   = help: Remove leading underscores
-
-ℹ Safe fix
-77 77 |         _var = "method variable" # [RUF052]
-78 78 |         return _var
-79 79 | 
-80    |-def fun(_var): # [RUF052]
-81    |-    return _var
-   80 |+def fun(var): # [RUF052]
-   81 |+    return var
-82 82 | 
-83 83 | def fun():
-84 84 |     _list = "built-in" # [RUF052]
 
 RUF052.py:84:5: RUF052 [*] Local dummy variable `_list` is accessed
    |

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__custom_dummy_var_regexp_preset__RUF052_RUF052.py_1.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__custom_dummy_var_regexp_preset__RUF052_RUF052.py_1.snap
@@ -20,30 +20,8 @@ RUF052.py:77:9: RUF052 [*] Local dummy variable `_var` is accessed
    77 |+        var = "method variable" # [RUF052]
    78 |+        return var
 79 79 | 
-80 80 | def fun(_var): # [RUF052]
+80 80 | def fun(_var): # parameters are ignored
 81 81 |     return _var
-
-RUF052.py:80:9: RUF052 [*] Local dummy variable `_var` is accessed
-   |
-78 |         return _var
-79 | 
-80 | def fun(_var): # [RUF052]
-   |         ^^^^ RUF052
-81 |     return _var
-   |
-   = help: Remove leading underscores
-
-ℹ Safe fix
-77 77 |         _var = "method variable" # [RUF052]
-78 78 |         return _var
-79 79 | 
-80    |-def fun(_var): # [RUF052]
-81    |-    return _var
-   80 |+def fun(var): # [RUF052]
-   81 |+    return var
-82 82 | 
-83 83 | def fun():
-84 84 |     _list = "built-in" # [RUF052]
 
 RUF052.py:84:5: RUF052 [*] Local dummy variable `_list` is accessed
    |

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__custom_dummy_var_regexp_preset__RUF052_RUF052.py_2.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__custom_dummy_var_regexp_preset__RUF052_RUF052.py_2.snap
@@ -1,55 +1,6 @@
 ---
 source: crates/ruff_linter/src/rules/ruff/mod.rs
 ---
-RUF052.py:21:9: RUF052 Local dummy variable `arg` is accessed
-   |
-19 | _valid_fun()
-20 | 
-21 | def fun(arg):
-   |         ^^^ RUF052
-22 |     _valid_unused_var = arg
-23 |     pass
-   |
-
-RUF052.py:50:18: RUF052 Local dummy variable `self` is accessed
-   |
-48 |     print(_valid_private_cls_attr)
-49 | 
-50 |     def __init__(self):
-   |                  ^^^^ RUF052
-51 |         self._valid_private_ins_attr = 2
-52 |         print(self._valid_private_ins_attr)
-   |
-
-RUF052.py:54:23: RUF052 Local dummy variable `self` is accessed
-   |
-52 |         print(self._valid_private_ins_attr)
-53 | 
-54 |     def _valid_method(self):
-   |                       ^^^^ RUF052
-55 |         return self._valid_private_ins_attr
-   |
-
-RUF052.py:57:16: RUF052 Local dummy variable `arg` is accessed
-   |
-55 |         return self._valid_private_ins_attr
-56 | 
-57 |     def method(arg):
-   |                ^^^ RUF052
-58 |         _valid_unused_var = arg
-59 |         return
-   |
-
-RUF052.py:61:9: RUF052 Local dummy variable `x` is accessed
-   |
-59 |         return
-60 | 
-61 | def fun(x):
-   |         ^ RUF052
-62 |     _ = 1
-63 |     __ = 2
-   |
-
 RUF052.py:77:9: RUF052 Local dummy variable `_var` is accessed
    |
 75 | class Class_:
@@ -57,16 +8,6 @@ RUF052.py:77:9: RUF052 Local dummy variable `_var` is accessed
 77 |         _var = "method variable" # [RUF052]
    |         ^^^^ RUF052
 78 |         return _var
-   |
-   = help: Remove leading underscores
-
-RUF052.py:80:9: RUF052 Local dummy variable `_var` is accessed
-   |
-78 |         return _var
-79 | 
-80 | def fun(_var): # [RUF052]
-   |         ^^^^ RUF052
-81 |     return _var
    |
    = help: Remove leading underscores
 


### PR DESCRIPTION
## Summary

Fixes https://github.com/astral-sh/ruff/issues/14796.
Fixes https://github.com/astral-sh/ruff/issues/14790.
Fixes https://github.com/astral-sh/ruff/issues/14799.

There isn't nearly as much community consensus around the idea that using a leading underscore for a function parameter indicates the binding is meant to be "unused"; many people use this to indicate "private" parameters. Even if we decide that we don't believe that private parameters should be recognised as a concept by Ruff, I think emitting this lint on function parameters would still need to be behind a configuration flag (or maybe even a separate rule altogether), as it's just a lot more controversial than the other changes this rule makes IMO.

I agree with @zanieb's comment in https://github.com/astral-sh/ruff/issues/14796#issuecomment-2521618519 that the logical conclusion of this argument is that we should probably look into whether we should change the behaviour for `ARG001`. Unfortunately we'll only be able to do that in the next minor release, however, as it would be an increase in the scope of `ARG001`. I can open an issue for that after this PR is merged, so that we don't forget.

## Test Plan

`cargo test -p ruff_linter --lib`
