### PR TITLE
[red-knot] Improve type inference for except handlers

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/exception/basic.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/exception/basic.md
@@ -49,12 +49,44 @@ def foo(
     try:
         help()
     except x as e:
-        # TODO: should be `AttributeError`
-        reveal_type(e)  # revealed: @Todo(exception type)
+        reveal_type(e)  # revealed: AttributeError
     except y as f:
-        # TODO: should be `OSError | RuntimeError`
-        reveal_type(f)  # revealed: @Todo(exception type)
+        reveal_type(f)  # revealed: OSError | RuntimeError
     except z as g:
         # TODO: should be `BaseException`
-        reveal_type(g)  # revealed: @Todo(exception type)
+        reveal_type(g)  # revealed: @Todo(full tuple[...] support)
+```
+
+## Invalid exception handlers
+
+```py
+try:
+    pass
+# error: [invalid-exception] "Cannot catch object of type `Literal[3]` in an exception handler (must be a `BaseException` subclass or a tuple of `BaseException` subclasses)"
+except 3 as e:
+    reveal_type(e)  # revealed: Unknown
+
+try:
+    pass
+# error: [invalid-exception] "Cannot catch object of type `Literal["foo"]` in an exception handler (must be a `BaseException` subclass or a tuple of `BaseException` subclasses)"
+# error: [invalid-exception] "Cannot catch object of type `Literal[b"bar"]` in an exception handler (must be a `BaseException` subclass or a tuple of `BaseException` subclasses)"
+except (ValueError, OSError, "foo", b"bar") as e:
+    reveal_type(e)  # revealed: ValueError | OSError | Unknown
+
+def foo(
+    x: type[str],
+    y: tuple[type[OSError], type[RuntimeError], int],
+    z: tuple[type[str], ...],
+):
+    try:
+        help()
+    # error: [invalid-exception]
+    except x as e:
+        reveal_type(e)  # revealed: Unknown
+    # error: [invalid-exception]
+    except y as f:
+        reveal_type(f)  # revealed: OSError | RuntimeError | Unknown
+    except z as g:
+        # TODO: should emit a diagnostic here:
+        reveal_type(g)  # revealed: @Todo(full tuple[...] support)
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/exception/except_star.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/exception/except_star.md
@@ -1,30 +1,59 @@
-# Except star
+# `except*`
 
-## Except\* with BaseException
+## `except*` with `BaseException`
 
 ```py
 try:
     help()
 except* BaseException as e:
+    # TODO: should be `BaseExceptionGroup[BaseException]` --Alex
     reveal_type(e)  # revealed: BaseExceptionGroup
 ```
 
-## Except\* with specific exception
+## `except*` with specific exception
 
 ```py
 try:
     help()
 except* OSError as e:
-    # TODO(Alex): more precise would be `ExceptionGroup[OSError]`
+    # TODO: more precise would be `ExceptionGroup[OSError]` --Alex
+    # (needs homogenous tuples + generics)
     reveal_type(e)  # revealed: BaseExceptionGroup
 ```
 
-## Except\* with multiple exceptions
+## `except*` with multiple exceptions
 
 ```py
 try:
     help()
 except* (TypeError, AttributeError) as e:
-    # TODO(Alex): more precise would be `ExceptionGroup[TypeError | AttributeError]`.
+    # TODO: more precise would be `ExceptionGroup[TypeError | AttributeError]` --Alex
+    # (needs homogenous tuples + generics)
+    reveal_type(e)  # revealed: BaseExceptionGroup
+```
+
+## `except*` with mix of `Exception`s and `BaseException`s
+
+```py
+try:
+    help()
+except* (KeyboardInterrupt, AttributeError) as e:
+    # TODO: more precise would be `BaseExceptionGroup[KeyboardInterrupt | AttributeError]` --Alex
+    reveal_type(e)  # revealed: BaseExceptionGroup
+```
+
+## Invalid `except*` handlers
+
+```py
+try:
+    help()
+except* 3 as e:  # error: [invalid-exception]
+    # TODO: Should be `BaseExceptionGroup[Unknown]` --Alex
+    reveal_type(e)  # revealed: BaseExceptionGroup
+
+try:
+    help()
+except* (AttributeError, 42) as e:  # error: [invalid-exception]
+    # TODO: Should be `BaseExceptionGroup[AttributeError | Unknown]` --Alex
     reveal_type(e)  # revealed: BaseExceptionGroup
 ```

--- a/crates/red_knot_python_semantic/src/types/diagnostic.rs
+++ b/crates/red_knot_python_semantic/src/types/diagnostic.rs
@@ -289,6 +289,18 @@ impl<'db> TypeCheckDiagnosticsBuilder<'db> {
         );
     }
 
+    pub(super) fn add_invalid_exception(&mut self, db: &dyn Db, node: &ast::Expr, ty: Type) {
+        self.add(
+            node.into(),
+            "invalid-exception",
+            format_args!(
+                "Cannot catch object of type `{}` in an exception handler \
+                (must be a `BaseException` subclass or a tuple of `BaseException` subclasses)",
+                ty.display(db)
+            ),
+        );
+    }
+
     /// Adds a new diagnostic.
     ///
     /// The diagnostic does not get added if the rule isn't enabled for this file.


### PR DESCRIPTION
## Summary

I noticed in https://github.com/astral-sh/ruff/pull/14802#discussion_r1873187227 that there were some TODOs around type inference for exception handlers that we could now do, following @sharkdp's implementation of `Type::SubclassOf`. So this PR does them!

Features added in this PR:
- Diagnostics for invalid types caught in (sync or async) exception handlers
- Support for dynamic exception handlers (e.g. catching a value where the binding comes from a parameter annotated as `type[ValueError]` or `tuple[type[ValueError], type[OSError]]` is now supported)

## Test Plan

New mdtests added, and TODOs in existing mdtests removed.
