### PR TITLE
Fix `PLW1508` false positive for default string created via a mult operation

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pylint/invalid_envvar_default.py
+++ b/crates/ruff_linter/resources/test/fixtures/pylint/invalid_envvar_default.py
@@ -13,3 +13,5 @@ os.getenv("B", Z)
 os.getenv("AA", "GOOD" if Z else "BAR")
 os.getenv("AA", 1 if Z else "BAR")  # [invalid-envvar-default]
 os.environ.get("TEST", 12)  # [invalid-envvar-default]
+os.environ.get("TEST", "AA" * 12)
+os.environ.get("TEST", 13 * "AA")

--- a/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLW1508_invalid_envvar_default.py.snap
+++ b/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLW1508_invalid_envvar_default.py.snap
@@ -49,4 +49,5 @@ invalid_envvar_default.py:14:17: PLW1508 Invalid type for environment variable d
 14 | os.getenv("AA", 1 if Z else "BAR")  # [invalid-envvar-default]
    |                 ^^^^^^^^^^^^^^^^^ PLW1508
 15 | os.environ.get("TEST", 12)  # [invalid-envvar-default]
+16 | os.environ.get("TEST", "AA" * 12)
    |

--- a/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__preview__PLW1508_invalid_envvar_default.py.snap
+++ b/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__preview__PLW1508_invalid_envvar_default.py.snap
@@ -49,6 +49,7 @@ invalid_envvar_default.py:14:17: PLW1508 Invalid type for environment variable d
 14 | os.getenv("AA", 1 if Z else "BAR")  # [invalid-envvar-default]
    |                 ^^^^^^^^^^^^^^^^^ PLW1508
 15 | os.environ.get("TEST", 12)  # [invalid-envvar-default]
+16 | os.environ.get("TEST", "AA" * 12)
    |
 
 invalid_envvar_default.py:15:24: PLW1508 Invalid type for environment variable default; expected `str` or `None`
@@ -57,4 +58,6 @@ invalid_envvar_default.py:15:24: PLW1508 Invalid type for environment variable d
 14 | os.getenv("AA", 1 if Z else "BAR")  # [invalid-envvar-default]
 15 | os.environ.get("TEST", 12)  # [invalid-envvar-default]
    |                        ^^ PLW1508
+16 | os.environ.get("TEST", "AA" * 12)
+17 | os.environ.get("TEST", 13 * "AA")
    |


### PR DESCRIPTION
## Summary

Fix a false positive for default string created via a mult operation.
```python
MY_VAR = os.environ.get("MY_VAR", "0" * 32)
```

I find the `if matches!(op, Operator::Mult)` branch inside the `Operator::Mult` match quite inelegant but was not sure of the most idiomatic way to handle this.
## Test Plan

`cargo nextest run` and `cargo insta test`.


