### PR TITLE
[flake8-commas]: Make the recommended replacement actually a tuple

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_commas/rules/trailing_commas.rs
+++ b/crates/ruff_linter/src/rules/flake8_commas/rules/trailing_commas.rs
@@ -188,7 +188,7 @@ impl AlwaysFixableViolation for MissingTrailingComma {
 /// import json
 ///
 ///
-/// foo = (json.dumps({"bar": 1}))
+/// foo = (json.dumps({"bar": 1}),)
 /// ```
 #[derive(ViolationMetadata)]
 pub(crate) struct TrailingCommaOnBareTuple;


### PR DESCRIPTION
## Summary

Minor change for the documentation of COM818 rule. This was a block called “In the event that a tuple is intended”, but the suggested change did not produce a tuple.

## Test Plan

```python
>>> import json
>>> (json.dumps({"bar": 1}),)  # this is a tuple
('{"bar": 1}',)
>>> (json.dumps({"bar": 1}))  # not a tuple
'{"bar": 1}'
```