### PR TITLE
Stop referring to early ruff versions

### DIFF
--- a/crates/ruff_python_formatter/README.md
+++ b/crates/ruff_python_formatter/README.md
@@ -23,4 +23,4 @@ For details, see [Black compatibility](https://docs.astral.sh/ruff/formatter/#bl
 
 ## Getting started
 
-The Ruff formatter is available as of Ruff v0.1.2. Head to [The Ruff Formatter](https://docs.astral.sh/ruff/formatter/) for usage instructions and a comparison to Black.
+Head to [The Ruff Formatter](https://docs.astral.sh/ruff/formatter/) for usage instructions and a comparison to Black.

--- a/docs/formatter.md
+++ b/docs/formatter.md
@@ -20,10 +20,6 @@ and instead exit with a non-zero status code upon detecting any unformatted file
 
 For the full list of supported options, run `ruff format --help`.
 
-!!! note
-    The `ruff format` command uses the current working directory (`.`) as the default path to format.
-    See [the file discovery documentation](configuration.md#python-file-discovery) for details.
-
 ## Philosophy
 
 The initial goal of the Ruff formatter is _not_ to innovate on code style, but rather, to innovate

--- a/docs/formatter.md
+++ b/docs/formatter.md
@@ -3,8 +3,6 @@
 The Ruff formatter is an extremely fast Python code formatter designed as a drop-in replacement for
 [Black](https://pypi.org/project/black/), available as part of the `ruff` CLI via `ruff format`.
 
-The Ruff formatter is available as of Ruff [v0.1.2](https://astral.sh/blog/the-ruff-formatter).
-
 ## `ruff format`
 
 `ruff format` is the primary entrypoint to the formatter. It accepts a list of files or
@@ -23,7 +21,7 @@ and instead exit with a non-zero status code upon detecting any unformatted file
 For the full list of supported options, run `ruff format --help`.
 
 !!! note
-    As of Ruff v0.1.7 the `ruff format` command uses the current working directory (`.`) as the default path to format.
+    The `ruff format` command uses the current working directory (`.`) as the default path to format.
     See [the file discovery documentation](configuration.md#python-file-discovery) for details.
 
 ## Philosophy

--- a/docs/linter.md
+++ b/docs/linter.md
@@ -20,7 +20,7 @@ $ ruff check path/to/code/    # Lint all files in `path/to/code` (and any subdir
 For the full list of supported options, run `ruff check --help`.
 
 !!! note
-    As of Ruff v0.1.7 the `ruff check` command uses the current working directory (`.`) as the default path to check.
+    The `ruff check` command uses the current working directory (`.`) as the default path to check.
     On older versions, you must provide this manually e.g. `ruff check .`.
     See [the file discovery documentation](configuration.md#python-file-discovery) for details.
 

--- a/docs/linter.md
+++ b/docs/linter.md
@@ -19,11 +19,6 @@ $ ruff check path/to/code/    # Lint all files in `path/to/code` (and any subdir
 
 For the full list of supported options, run `ruff check --help`.
 
-!!! note
-    The `ruff check` command uses the current working directory (`.`) as the default path to check.
-    On older versions, you must provide this manually e.g. `ruff check .`.
-    See [the file discovery documentation](configuration.md#python-file-discovery) for details.
-
 ## Rule selection
 
 The set of enabled rules is controlled via the [`lint.select`](settings.md#lint_select),

--- a/docs/preview.md
+++ b/docs/preview.md
@@ -12,7 +12,7 @@ Enabling preview mode does not on its own enable all preview rules. See the [rul
 Preview mode can be enabled with the `--preview` flag on the CLI or by setting `preview = true` in your Ruff
 configuration file.
 
-Preview mode can be configured separately for linting and formatting (requires Ruff v0.1.1+). To enable preview lint rules without preview style formatting:
+Preview mode can be configured separately for linting and formatting. To enable preview lint rules without preview style formatting:
 
 === "pyproject.toml"
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -349,7 +349,7 @@ This tutorial has focused on Ruff's command-line interface, but Ruff can also be
 ```yaml
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.
-  rev: v0.1.4
+  rev: v0.8.2
   hooks:
     # Run the linter.
     - id: ruff

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,6 +106,7 @@ changelog_contributors = false
 version_files = [
   "README.md",
   "docs/integrations.md",
+  "docs/tutorial.md",
   "crates/ruff/Cargo.toml",
   "crates/ruff_linter/Cargo.toml",
   "crates/ruff_wasm/Cargo.toml",


### PR DESCRIPTION
## Summary

Referring to old versions has become more distracting than useful.

## Test Plan

—