### PR TITLE
[`flake8-bugbear`] Fix `B028` to allow `stacklevel` to be explicitly assigned as a positional argument

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_bugbear/B028.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_bugbear/B028.py
@@ -11,3 +11,9 @@ warnings.warn("test", DeprecationWarning, source=None, stacklevel=2)
 warnings.warn("test", DeprecationWarning, stacklevel=1)
 warnings.warn("test", DeprecationWarning, 1)
 warnings.warn("test", category=DeprecationWarning, stacklevel=1)
+
+warnings.warn(
+        DeprecationWarning("test"),
+        # some comments here
+        source = None # no trailing comma
+    )

--- a/crates/ruff_linter/resources/test/fixtures/flake8_bugbear/B028.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_bugbear/B028.py
@@ -5,13 +5,9 @@ Should emit:
 B028 - on lines 8 and 9
 """
 
-warnings.warn(DeprecationWarning("test"))
-warnings.warn(DeprecationWarning("test"), source=None)
-warnings.warn(DeprecationWarning("test"), source=None, stacklevel=2)
-warnings.warn(DeprecationWarning("test"), stacklevel=1)
-
-warnings.warn(
-        DeprecationWarning("test"),
-        # some comments here
-        source = None # no trailing comma
-    )
+warnings.warn("test", DeprecationWarning)
+warnings.warn("test", DeprecationWarning, source=None)
+warnings.warn("test", DeprecationWarning, source=None, stacklevel=2)
+warnings.warn("test", DeprecationWarning, stacklevel=1)
+warnings.warn("test", DeprecationWarning, 1)
+warnings.warn("test", category=DeprecationWarning, stacklevel=1)

--- a/crates/ruff_linter/resources/test/fixtures/flake8_bugbear/B028.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_bugbear/B028.py
@@ -13,7 +13,8 @@ warnings.warn("test", DeprecationWarning, 1)
 warnings.warn("test", category=DeprecationWarning, stacklevel=1)
 
 warnings.warn(
-        DeprecationWarning("test"),
+        "test",
+        DeprecationWarning,
         # some comments here
         source = None # no trailing comma
     )

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/no_explicit_stacklevel.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/no_explicit_stacklevel.rs
@@ -60,7 +60,7 @@ pub(crate) fn no_explicit_stacklevel(checker: &mut Checker, call: &ast::ExprCall
         return;
     }
 
-    if call.arguments.find_keyword("stacklevel").is_some() {
+    if call.arguments.find_argument("stacklevel", 2).is_some() {
         return;
     }
     let mut diagnostic = Diagnostic::new(NoExplicitStacklevel, call.func.range());

--- a/crates/ruff_linter/src/rules/flake8_bugbear/snapshots/ruff_linter__rules__flake8_bugbear__tests__B028_B028.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/snapshots/ruff_linter__rules__flake8_bugbear__tests__B028_B028.py.snap
@@ -50,15 +50,15 @@ B028.py:15:1: B028 [*] No explicit `stacklevel` keyword argument found
 14 | 
 15 | warnings.warn(
    | ^^^^^^^^^^^^^ B028
-16 |         DeprecationWarning("test"),
-17 |         # some comments here
+16 |         "test",
+17 |         DeprecationWarning,
    |
    = help: Set `stacklevel=2`
 
 ℹ Unsafe fix
-15 15 | warnings.warn(
-16 16 |         DeprecationWarning("test"),
-17 17 |         # some comments here
-18    |-        source = None # no trailing comma
-   18 |+        source = None, stacklevel=2 # no trailing comma
-19 19 |     )
+16 16 |         "test",
+17 17 |         DeprecationWarning,
+18 18 |         # some comments here
+19    |-        source = None # no trailing comma
+   19 |+        source = None, stacklevel=2 # no trailing comma
+20 20 |     )

--- a/crates/ruff_linter/src/rules/flake8_bugbear/snapshots/ruff_linter__rules__flake8_bugbear__tests__B028_B028.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/snapshots/ruff_linter__rules__flake8_bugbear__tests__B028_B028.py.snap
@@ -43,3 +43,22 @@ B028.py:9:1: B028 [*] No explicit `stacklevel` keyword argument found
 11 11 | warnings.warn("test", DeprecationWarning, stacklevel=1)
 12 12 | warnings.warn("test", DeprecationWarning, 1)
 13 13 | warnings.warn("test", category=DeprecationWarning, stacklevel=1)
+
+B028.py:15:1: B028 [*] No explicit `stacklevel` keyword argument found
+   |
+13 | warnings.warn("test", category=DeprecationWarning, stacklevel=1)
+14 | 
+15 | warnings.warn(
+   | ^^^^^^^^^^^^^ B028
+16 |         DeprecationWarning("test"),
+17 |         # some comments here
+   |
+   = help: Set `stacklevel=2`
+
+ℹ Unsafe fix
+15 15 | warnings.warn(
+16 16 |         DeprecationWarning("test"),
+17 17 |         # some comments here
+18    |-        source = None # no trailing comma
+   18 |+        source = None, stacklevel=2 # no trailing comma
+19 19 |     )

--- a/crates/ruff_linter/src/rules/flake8_bugbear/snapshots/ruff_linter__rules__flake8_bugbear__tests__B028_B028.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/snapshots/ruff_linter__rules__flake8_bugbear__tests__B028_B028.py.snap
@@ -1,14 +1,15 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_bugbear/mod.rs
+snapshot_kind: text
 ---
 B028.py:8:1: B028 [*] No explicit `stacklevel` keyword argument found
    |
  6 | """
  7 | 
- 8 | warnings.warn(DeprecationWarning("test"))
+ 8 | warnings.warn("test", DeprecationWarning)
    | ^^^^^^^^^^^^^ B028
- 9 | warnings.warn(DeprecationWarning("test"), source=None)
-10 | warnings.warn(DeprecationWarning("test"), source=None, stacklevel=2)
+ 9 | warnings.warn("test", DeprecationWarning, source=None)
+10 | warnings.warn("test", DeprecationWarning, source=None, stacklevel=2)
    |
    = help: Set `stacklevel=2`
 
@@ -16,48 +17,29 @@ B028.py:8:1: B028 [*] No explicit `stacklevel` keyword argument found
 5 5 | B028 - on lines 8 and 9
 6 6 | """
 7 7 | 
-8   |-warnings.warn(DeprecationWarning("test"))
-  8 |+warnings.warn(DeprecationWarning("test"), stacklevel=2)
-9 9 | warnings.warn(DeprecationWarning("test"), source=None)
-10 10 | warnings.warn(DeprecationWarning("test"), source=None, stacklevel=2)
-11 11 | warnings.warn(DeprecationWarning("test"), stacklevel=1)
+8   |-warnings.warn("test", DeprecationWarning)
+  8 |+warnings.warn("test", DeprecationWarning, stacklevel=2)
+9 9 | warnings.warn("test", DeprecationWarning, source=None)
+10 10 | warnings.warn("test", DeprecationWarning, source=None, stacklevel=2)
+11 11 | warnings.warn("test", DeprecationWarning, stacklevel=1)
 
 B028.py:9:1: B028 [*] No explicit `stacklevel` keyword argument found
    |
- 8 | warnings.warn(DeprecationWarning("test"))
- 9 | warnings.warn(DeprecationWarning("test"), source=None)
+ 8 | warnings.warn("test", DeprecationWarning)
+ 9 | warnings.warn("test", DeprecationWarning, source=None)
    | ^^^^^^^^^^^^^ B028
-10 | warnings.warn(DeprecationWarning("test"), source=None, stacklevel=2)
-11 | warnings.warn(DeprecationWarning("test"), stacklevel=1)
+10 | warnings.warn("test", DeprecationWarning, source=None, stacklevel=2)
+11 | warnings.warn("test", DeprecationWarning, stacklevel=1)
    |
    = help: Set `stacklevel=2`
 
 ℹ Unsafe fix
 6  6  | """
 7  7  | 
-8  8  | warnings.warn(DeprecationWarning("test"))
-9     |-warnings.warn(DeprecationWarning("test"), source=None)
-10 9  | warnings.warn(DeprecationWarning("test"), source=None, stacklevel=2)
-   10 |+warnings.warn(DeprecationWarning("test"), source=None, stacklevel=2)
-11 11 | warnings.warn(DeprecationWarning("test"), stacklevel=1)
-12 12 | 
-13 13 | warnings.warn(
-
-B028.py:13:1: B028 [*] No explicit `stacklevel` keyword argument found
-   |
-11 | warnings.warn(DeprecationWarning("test"), stacklevel=1)
-12 | 
-13 | warnings.warn(
-   | ^^^^^^^^^^^^^ B028
-14 |         DeprecationWarning("test"),
-15 |         # some comments here
-   |
-   = help: Set `stacklevel=2`
-
-ℹ Unsafe fix
-13 13 | warnings.warn(
-14 14 |         DeprecationWarning("test"),
-15 15 |         # some comments here
-16    |-        source = None # no trailing comma
-   16 |+        source = None, stacklevel=2 # no trailing comma
-17 17 |     )
+8  8  | warnings.warn("test", DeprecationWarning)
+9     |-warnings.warn("test", DeprecationWarning, source=None)
+10 9  | warnings.warn("test", DeprecationWarning, source=None, stacklevel=2)
+   10 |+warnings.warn("test", DeprecationWarning, source=None, stacklevel=2)
+11 11 | warnings.warn("test", DeprecationWarning, stacklevel=1)
+12 12 | warnings.warn("test", DeprecationWarning, 1)
+13 13 | warnings.warn("test", category=DeprecationWarning, stacklevel=1)


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Applies https://github.com/PyCQA/flake8-bugbear/pull/374 to ruff.

## Test Plan

<!-- How was it tested? -->

 A new test case.