### PR TITLE
[`flake8-bugbear`] Skip `B028` if `warnings.warn` is called with `*args` or `**kwargs`

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_bugbear/B028.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_bugbear/B028.py
@@ -11,6 +11,13 @@ warnings.warn("test", DeprecationWarning, source=None, stacklevel=2)
 warnings.warn("test", DeprecationWarning, stacklevel=1)
 warnings.warn("test", DeprecationWarning, 1)
 warnings.warn("test", category=DeprecationWarning, stacklevel=1)
+args = ("test", DeprecationWarning, 1)
+warnings.warn(*args)
+kwargs = {"message": "test", "category": DeprecationWarning, "stacklevel": 1}
+warnings.warn(**kwargs)
+args = ("test", DeprecationWarning)
+kwargs = {"stacklevel": 1}
+warnings.warn(*args, **kwargs)
 
 warnings.warn(
         "test",

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/no_explicit_stacklevel.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/no_explicit_stacklevel.rs
@@ -60,7 +60,18 @@ pub(crate) fn no_explicit_stacklevel(checker: &mut Checker, call: &ast::ExprCall
         return;
     }
 
-    if call.arguments.find_argument("stacklevel", 2).is_some() {
+    if call.arguments.find_argument("stacklevel", 2).is_some()
+        || call
+            .arguments
+            .args
+            .iter()
+            .any(ruff_python_ast::Expr::is_starred_expr)
+        || call
+            .arguments
+            .keywords
+            .iter()
+            .any(|keyword| keyword.arg.is_none())
+    {
         return;
     }
     let mut diagnostic = Diagnostic::new(NoExplicitStacklevel, call.func.range());

--- a/crates/ruff_linter/src/rules/flake8_bugbear/snapshots/ruff_linter__rules__flake8_bugbear__tests__B028_B028.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/snapshots/ruff_linter__rules__flake8_bugbear__tests__B028_B028.py.snap
@@ -44,21 +44,21 @@ B028.py:9:1: B028 [*] No explicit `stacklevel` keyword argument found
 12 12 | warnings.warn("test", DeprecationWarning, 1)
 13 13 | warnings.warn("test", category=DeprecationWarning, stacklevel=1)
 
-B028.py:15:1: B028 [*] No explicit `stacklevel` keyword argument found
+B028.py:22:1: B028 [*] No explicit `stacklevel` keyword argument found
    |
-13 | warnings.warn("test", category=DeprecationWarning, stacklevel=1)
-14 | 
-15 | warnings.warn(
+20 | warnings.warn(*args, **kwargs)
+21 | 
+22 | warnings.warn(
    | ^^^^^^^^^^^^^ B028
-16 |         "test",
-17 |         DeprecationWarning,
+23 |         "test",
+24 |         DeprecationWarning,
    |
    = help: Set `stacklevel=2`
 
 ℹ Unsafe fix
-16 16 |         "test",
-17 17 |         DeprecationWarning,
-18 18 |         # some comments here
-19    |-        source = None # no trailing comma
-   19 |+        source = None, stacklevel=2 # no trailing comma
-20 20 |     )
+23 23 |         "test",
+24 24 |         DeprecationWarning,
+25 25 |         # some comments here
+26    |-        source = None # no trailing comma
+   26 |+        source = None, stacklevel=2 # no trailing comma
+27 27 |     )


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Applies https://github.com/PyCQA/flake8-bugbear/pull/501 to ruff. `B028` should be skipped if `warnings.warn` is called with `*args` or `**kwargs`.

## Test Plan

<!-- How was it tested? -->

New test cases