### PR TITLE
[`pyupgrade`] Remove unreachable code in `UP015` implementation

### DIFF
--- a/crates/ruff_linter/src/rules/pyupgrade/rules/redundant_open_modes.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/redundant_open_modes.rs
@@ -71,24 +71,24 @@ pub(crate) fn redundant_open_modes(checker: &mut Checker, call: &ast::ExprCall) 
         return;
     }
 
-    match call.arguments.find_argument("mode", 1) {
-        None => {}
-        Some(mode_param) => {
-            if let Expr::StringLiteral(ast::ExprStringLiteral { value, .. }) = &mode_param {
-                if let Ok(mode) = OpenMode::from_chars(value.chars()) {
-                    let reduced = mode.reduce();
-                    if reduced != mode {
-                        checker.diagnostics.push(create_diagnostic(
-                            call,
-                            mode_param,
-                            reduced,
-                            checker.tokens(),
-                            checker.stylist(),
-                        ));
-                    }
-                }
-            }
-        }
+    let Some(mode_param) = call.arguments.find_argument("mode", 1) else {
+        return;
+    };
+    let Expr::StringLiteral(ast::ExprStringLiteral { value, .. }) = &mode_param else {
+        return;
+    };
+    let Ok(mode) = OpenMode::from_chars(value.chars()) else {
+        return;
+    };
+    let reduced = mode.reduce();
+    if reduced != mode {
+        checker.diagnostics.push(create_diagnostic(
+            call,
+            mode_param,
+            reduced,
+            checker.tokens(),
+            checker.stylist(),
+        ));
     }
 }
 

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/redundant_open_modes.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/redundant_open_modes.rs
@@ -72,30 +72,7 @@ pub(crate) fn redundant_open_modes(checker: &mut Checker, call: &ast::ExprCall) 
     }
 
     match call.arguments.find_argument("mode", 1) {
-        None => {
-            if !call.arguments.is_empty() {
-                if let Some(keyword) = call.arguments.find_keyword("mode") {
-                    if let Expr::StringLiteral(ast::ExprStringLiteral {
-                        value: mode_param_value,
-                        ..
-                    }) = &keyword.value
-                    {
-                        if let Ok(mode) = OpenMode::from_chars(mode_param_value.chars()) {
-                            let reduced = mode.reduce();
-                            if reduced != mode {
-                                checker.diagnostics.push(create_diagnostic(
-                                    call,
-                                    &keyword.value,
-                                    reduced,
-                                    checker.tokens(),
-                                    checker.stylist(),
-                                ));
-                            }
-                        }
-                    }
-                }
-            }
-        }
+        None => {}
         Some(mode_param) => {
             if let Expr::StringLiteral(ast::ExprStringLiteral { value, .. }) = &mode_param {
                 if let Ok(mode) = OpenMode::from_chars(value.chars()) {


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

`crates/ruff_linter/src/rules/pyupgrade/rules/redundant_open_modes.rs` has unreachable code. This PR removes it.

## Test Plan

<!-- How was it tested? -->

No behavior change. No test.
