### PR TITLE
Fix a typo in `class.rs`

### DIFF
--- a/crates/ruff_python_semantic/src/analyze/class.rs
+++ b/crates/ruff_python_semantic/src/analyze/class.rs
@@ -172,7 +172,7 @@ pub fn is_metaclass(class_def: &ast::StmtClassDef, semantic: &SemanticModel) -> 
     }
 }
 
-/// Returns true if a class might generic.
+/// Returns true if a class might be generic.
 ///
 /// A class is considered generic if at least one of its direct bases
 /// is subscripted with a `TypeVar`-like,


### PR DESCRIPTION
(Accidentally introduced in #14801.)