### PR TITLE
More typos found by codespell

### DIFF
--- a/crates/red_knot_python_semantic/src/semantic_index/use_def.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/use_def.rs
@@ -47,7 +47,7 @@
 //! The **declared type** represents the code author's declaration (usually through a type
 //! annotation) that a given variable should not be assigned any type outside the declared type. In
 //! our model, declared types are also control-flow-sensitive; we allow the code author to
-//! explicitly re-declare the same variable with a different type. So for a given binding of a
+//! explicitly redeclare the same variable with a different type. So for a given binding of a
 //! variable, we will want to ask which declarations of that variable can reach that binding, in
 //! order to determine whether the binding is permitted, or should be a type error. For example:
 //!
@@ -62,7 +62,7 @@
 //! assignable to `str`. This is the purpose of declared types: they prevent accidental assignment
 //! of the wrong type to a variable.
 //!
-//! But in some cases it is useful to "shadow" or "re-declare" a variable with a new type, and we
+//! But in some cases it is useful to "shadow" or "redeclare" a variable with a new type, and we
 //! permit this, as long as it is done with an explicit re-annotation. So `path: Path =
 //! Path(path)`, with the explicit `: Path` annotation, is permitted.
 //!

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -899,7 +899,7 @@ impl<'db> Type<'db> {
                 Type::SubclassOf(_),
             ) => true,
             (Type::SubclassOf(_), _) | (_, Type::SubclassOf(_)) => {
-                // TODO: Once we have support for final classes, we can determine disjointness in some cases
+                // TODO: Once we have support for final classes, we can determine disjointedness in some cases
                 // here. However, note that it might be better to turn `Type::SubclassOf('FinalClass')` into
                 // `Type::ClassLiteral('FinalClass')` during construction, instead of adding special cases for
                 // final classes inside `Type::SubclassOf` everywhere.

--- a/crates/ruff_formatter/src/buffer.rs
+++ b/crates/ruff_formatter/src/buffer.rs
@@ -656,7 +656,7 @@ where
         let elements = buffer.elements();
 
         let recorded = if self.start > elements.len() {
-            // May happen if buffer was rewinded.
+            // May happen if buffer was rewound.
             &[]
         } else {
             &elements[self.start..]

--- a/crates/ruff_linter/src/checkers/ast/mod.rs
+++ b/crates/ruff_linter/src/checkers/ast/mod.rs
@@ -282,7 +282,7 @@ impl<'a> Checker<'a> {
         // TODO(charlie): `noqa` directives are mostly enforced in `check_lines.rs`.
         // However, in rare cases, we need to check them here. For example, when
         // removing unused imports, we create a single fix that's applied to all
-        // unused members on a single import. We need to pre-emptively omit any
+        // unused members on a single import. We need to preemptively omit any
         // members from the fix that will eventually be excluded by a `noqa`.
         // Unfortunately, we _do_ want to register a `Diagnostic` for each
         // eventually-ignored import, so that our `noqa` counts are accurate.

--- a/crates/ruff_linter/src/rules/fastapi/rules/fastapi_unused_path_parameter.rs
+++ b/crates/ruff_linter/src/rules/fastapi/rules/fastapi_unused_path_parameter.rs
@@ -267,7 +267,7 @@ impl<'a> Iterator for PathParamIterator<'a> {
             if c == '{' {
                 if let Some((end, _)) = self.chars.by_ref().find(|&(_, ch)| ch == '}') {
                     let param_content = &self.input[start + 1..end];
-                    // We ignore text after a colon, since those are path convertors
+                    // We ignore text after a colon, since those are path converters
                     // See also: https://fastapi.tiangolo.com/tutorial/path-params/?h=path#path-convertor
                     let param_name_end = param_content.find(':').unwrap_or(param_content.len());
                     let param_name = &param_content[..param_name_end].trim();


### PR DESCRIPTION
## Summary

Fix more typos.

About `convertor` → `converter`, see for example https://thecontentauthority.com/blog/convertor-vs-converter.

## Test Plan

—