### PR TITLE
[WIP] Editing around comments

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_comprehensions/snapshots/ruff_linter__rules__flake8_comprehensions__tests__C409_C409.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/snapshots/ruff_linter__rules__flake8_comprehensions__tests__C409_C409.py.snap
@@ -130,10 +130,11 @@ C409.py:12:1: C409 [*] Unnecessary list literal passed to `tuple()` (rewrite as 
 12    |-tuple(  # comment
 13    |-    [1, 2]
 14    |-)
-   12 |+(1, 2)
-15 13 | 
-16 14 | tuple([  # comment
-17 15 |     1, 2
+   12 |+# comment
+   13 |+(1, 2)
+15 14 | 
+16 15 | tuple([  # comment
+17 16 |     1, 2
 
 C409.py:16:1: C409 [*] Unnecessary list literal passed to `tuple()` (rewrite as a tuple literal)
    |

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/snapshots/ruff_linter__rules__flake8_comprehensions__tests__C410_C410.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/snapshots/ruff_linter__rules__flake8_comprehensions__tests__C410_C410.py.snap
@@ -91,10 +91,11 @@ C410.py:7:1: C410 [*] Unnecessary list literal passed to `list()` (remove the ou
 7     |-list(  # comment
 8     |-    [1, 2]
 9     |-)
-   7  |+[1, 2]
-10 8  | 
-11 9  | list([  # comment
-12 10 |     1, 2
+   7  |+# comment
+   8  |+[1, 2]
+10 9  | 
+11 10 | list([  # comment
+12 11 |     1, 2
 
 C410.py:11:1: C410 [*] Unnecessary list literal passed to `list()` (remove the outer call to `list()`)
    |

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/snapshots/ruff_linter__rules__flake8_comprehensions__tests__preview__C409_C409.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/snapshots/ruff_linter__rules__flake8_comprehensions__tests__preview__C409_C409.py.snap
@@ -130,10 +130,11 @@ C409.py:12:1: C409 [*] Unnecessary list literal passed to `tuple()` (rewrite as 
 12    |-tuple(  # comment
 13    |-    [1, 2]
 14    |-)
-   12 |+(1, 2)
-15 13 | 
-16 14 | tuple([  # comment
-17 15 |     1, 2
+   12 |+# comment
+   13 |+(1, 2)
+15 14 | 
+16 15 | tuple([  # comment
+17 16 |     1, 2
 
 C409.py:16:1: C409 [*] Unnecessary list literal passed to `tuple()` (rewrite as a tuple literal)
    |


### PR DESCRIPTION
This is an attempt to introduce some helper functions for making edits without removing comments. The plan is to implement the new helper functions in a number of different rules, and see if the ecosystem check raises any alarms. If the approach starts to look reasonable, I will break this into separate PRs.

---------

In case anyone is interested, the rough idea is as follows:

1. First, handle deletions. If you are making a deletion edit in some range `[s0, e0]` and there are comment ranges in this interval, say `[s1,e1], [s2,e2], ..., [sn,en]`, then you could instead just delete each of the ranges `[s0,s1], [e1,s2], ..., [en,e0]`. There is some bookkeeping that needs to be done, however, around newlines and indentation (and probably more things I haven't thought of!), but that is the general idea.
2. Next: any range replacement can be written as a deletion following by an insertion. So use (1) and then insert. (Actually this is currently implemented a little differently, but this is morally what we do).
3. Insertions are already okay.

Finally, you probably shouldn't look at the implementation details at the moment - the code itself is ugly and probably not performant or memory-conscious, I'm just trying to get something logically correct first and then I'll try to make it pretty.

This may all be terribly misguided... we'll see...
