### PR TITLE
[`airflow`] Add fix to remove deprecated keyword arguments (`AIR302`)

### DIFF
--- a/crates/ruff_linter/src/rules/airflow/rules/removal_in_3.rs
+++ b/crates/ruff_linter/src/rules/airflow/rules/removal_in_3.rs
@@ -92,9 +92,9 @@ fn diagnostic_for_argument(
             .map_or_else(|| keyword.range(), Ranged::range),
     );
 
-    if replacement.is_some() {
+    if let Some(replacement) = replacement {
         diagnostic.set_fix(Fix::unsafe_edit(Edit::range_replacement(
-            replacement?.to_string(),
+            replacement.to_string(),
             diagnostic.range,
         )));
     }

--- a/crates/ruff_linter/src/rules/airflow/rules/removal_in_3.rs
+++ b/crates/ruff_linter/src/rules/airflow/rules/removal_in_3.rs
@@ -54,7 +54,7 @@ impl Violation for Airflow3Removal {
         match replacement {
             Replacement::None => format!("`{deprecated}` is removed in Airflow 3.0"),
             Replacement::Name(_) => {
-                format!("`{deprecated}` is removed in Airflow 3.0.")
+                format!("`{deprecated}` is removed in Airflow 3.0")
             }
             Replacement::Message(message) => {
                 format!("`{deprecated}` is removed in Airflow 3.0; {message}")
@@ -65,7 +65,7 @@ impl Violation for Airflow3Removal {
     fn fix_title(&self) -> Option<String> {
         let Airflow3Removal { replacement, .. } = self;
         if let Replacement::Name(name) = replacement {
-            Some(format!("Use `{name}` instead."))
+            Some(format!("Use `{name}` instead"))
         } else {
             None
         }
@@ -93,7 +93,7 @@ fn diagnostic_for_argument(
     );
 
     if let Some(replacement) = replacement {
-        diagnostic.set_fix(Fix::unsafe_edit(Edit::range_replacement(
+        diagnostic.set_fix(Fix::safe_edit(Edit::range_replacement(
             replacement.to_string(),
             diagnostic.range,
         )));

--- a/crates/ruff_linter/src/rules/airflow/rules/removal_in_3.rs
+++ b/crates/ruff_linter/src/rules/airflow/rules/removal_in_3.rs
@@ -43,7 +43,7 @@ pub(crate) struct Airflow3Removal {
 }
 
 impl Violation for Airflow3Removal {
-    const FIX_AVAILABILITY : FixAvailability = FixAvailability::Sometimes;
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Sometimes;
 
     #[derive_message_formats]
     fn message(&self) -> String {
@@ -63,7 +63,7 @@ impl Violation for Airflow3Removal {
     }
 
     fn fix_title(&self) -> Option<String> {
-        return Some("Replace deprecated keywords in Airflow 3.0".to_string());
+        Some("Replace deprecated keywords in Airflow 3.0".to_string())
     }
 }
 
@@ -87,14 +87,14 @@ fn diagnostic_for_argument(
             .map_or_else(|| keyword.range(), Ranged::range),
     ));
 
-    match diagnostic {
-	Some(ref mut diagnostic) => {
-	    diagnostic.set_fix(Fix::unsafe_edit(Edit::range_replacement(replacement?.to_string(), diagnostic.range)))
-	}
-	None => {}
+    if let Some(ref mut diagnostic) = diagnostic {
+        diagnostic.set_fix(Fix::unsafe_edit(Edit::range_replacement(
+            replacement?.to_string(),
+            diagnostic.range,
+        )))
     }
 
-    return diagnostic
+    diagnostic
 }
 
 fn removed_argument(checker: &mut Checker, qualname: &QualifiedName, arguments: &Arguments) {

--- a/crates/ruff_linter/src/rules/airflow/rules/removal_in_3.rs
+++ b/crates/ruff_linter/src/rules/airflow/rules/removal_in_3.rs
@@ -92,10 +92,12 @@ fn diagnostic_for_argument(
             .map_or_else(|| keyword.range(), Ranged::range),
     );
 
-    diagnostic.set_fix(Fix::unsafe_edit(Edit::range_replacement(
-        replacement?.to_string(),
-        diagnostic.range,
-    )));
+    if replacement.is_some() {
+        diagnostic.set_fix(Fix::unsafe_edit(Edit::range_replacement(
+            replacement?.to_string(),
+            diagnostic.range,
+        )));
+    }
 
     Some(diagnostic)
 }

--- a/crates/ruff_linter/src/rules/airflow/rules/removal_in_3.rs
+++ b/crates/ruff_linter/src/rules/airflow/rules/removal_in_3.rs
@@ -91,7 +91,7 @@ fn diagnostic_for_argument(
         diagnostic.set_fix(Fix::unsafe_edit(Edit::range_replacement(
             replacement?.to_string(),
             diagnostic.range,
-        )))
+        )));
     }
 
     diagnostic

--- a/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_args.py.snap
+++ b/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_args.py.snap
@@ -2,7 +2,7 @@
 source: crates/ruff_linter/src/rules/airflow/mod.rs
 snapshot_kind: text
 ---
-AIR302_args.py:15:39: AIR302 `schedule_interval` is removed in Airflow 3.0; use `schedule` instead
+AIR302_args.py:15:39: AIR302 [*] `schedule_interval` is removed in Airflow 3.0; use `schedule` instead
    |
 13 | DAG(dag_id="class_schedule", schedule="@hourly")
 14 | 
@@ -11,46 +11,76 @@ AIR302_args.py:15:39: AIR302 `schedule_interval` is removed in Airflow 3.0; use 
 16 | 
 17 | DAG(dag_id="class_timetable", timetable=NullTimetable())
    |
+   = help: Replace deprecated keywords in Airflow 3.0
 
-AIR302_args.py:17:31: AIR302 `timetable` is removed in Airflow 3.0; use `schedule` instead
+ℹ Unsafe fix
+12 12 | 
+13 13 | DAG(dag_id="class_schedule", schedule="@hourly")
+14 14 | 
+15    |-DAG(dag_id="class_schedule_interval", schedule_interval="@hourly")
+   15 |+DAG(dag_id="class_schedule_interval", schedule="@hourly")
+16 16 | 
+17 17 | DAG(dag_id="class_timetable", timetable=NullTimetable())
+18 18 | 
+
+AIR302_args.py:17:31: AIR302 [*] `timetable` is removed in Airflow 3.0; use `schedule` instead
    |
 15 | DAG(dag_id="class_schedule_interval", schedule_interval="@hourly")
 16 | 
 17 | DAG(dag_id="class_timetable", timetable=NullTimetable())
    |                               ^^^^^^^^^ AIR302
    |
+   = help: Replace deprecated keywords in Airflow 3.0
 
-AIR302_args.py:24:34: AIR302 `sla_miss_callback` is removed in Airflow 3.0
-   |
-24 | DAG(dag_id="class_sla_callback", sla_miss_callback=sla_callback)
-   |                                  ^^^^^^^^^^^^^^^^^ AIR302
-   |
+ℹ Unsafe fix
+14 14 | 
+15 15 | DAG(dag_id="class_schedule_interval", schedule_interval="@hourly")
+16 16 | 
+17    |-DAG(dag_id="class_timetable", timetable=NullTimetable())
+   17 |+DAG(dag_id="class_timetable", schedule=NullTimetable())
+18 18 | 
+19 19 | 
+20 20 | def sla_callback(*arg, **kwargs):
 
-AIR302_args.py:32:6: AIR302 `schedule_interval` is removed in Airflow 3.0; use `schedule` instead
+AIR302_args.py:32:6: AIR302 [*] `schedule_interval` is removed in Airflow 3.0; use `schedule` instead
    |
 32 | @dag(schedule_interval="0 * * * *")
    |      ^^^^^^^^^^^^^^^^^ AIR302
 33 | def decorator_schedule_interval():
 34 |     pass
    |
+   = help: Replace deprecated keywords in Airflow 3.0
 
-AIR302_args.py:37:6: AIR302 `timetable` is removed in Airflow 3.0; use `schedule` instead
+ℹ Unsafe fix
+29 29 |     pass
+30 30 | 
+31 31 | 
+32    |-@dag(schedule_interval="0 * * * *")
+   32 |+@dag(schedule="0 * * * *")
+33 33 | def decorator_schedule_interval():
+34 34 |     pass
+35 35 | 
+
+AIR302_args.py:37:6: AIR302 [*] `timetable` is removed in Airflow 3.0; use `schedule` instead
    |
 37 | @dag(timetable=NullTimetable())
    |      ^^^^^^^^^ AIR302
 38 | def decorator_timetable():
 39 |     pass
    |
+   = help: Replace deprecated keywords in Airflow 3.0
 
-AIR302_args.py:42:6: AIR302 `sla_miss_callback` is removed in Airflow 3.0
-   |
-42 | @dag(sla_miss_callback=sla_callback)
-   |      ^^^^^^^^^^^^^^^^^ AIR302
-43 | def decorator_sla_callback():
-44 |     pass
-   |
+ℹ Unsafe fix
+34 34 |     pass
+35 35 | 
+36 36 | 
+37    |-@dag(timetable=NullTimetable())
+   37 |+@dag(schedule=NullTimetable())
+38 38 | def decorator_timetable():
+39 39 |     pass
+40 40 | 
 
-AIR302_args.py:50:39: AIR302 `execution_date` is removed in Airflow 3.0; use `logical_date` instead
+AIR302_args.py:50:39: AIR302 [*] `execution_date` is removed in Airflow 3.0; use `logical_date` instead
    |
 48 | def decorator_deprecated_operator_args():
 49 |     trigger_dagrun_op = trigger_dagrun.TriggerDagRunOperator(
@@ -59,8 +89,19 @@ AIR302_args.py:50:39: AIR302 `execution_date` is removed in Airflow 3.0; use `lo
 51 |     )
 52 |     trigger_dagrun_op2 = TriggerDagRunOperator(
    |
+   = help: Replace deprecated keywords in Airflow 3.0
 
-AIR302_args.py:53:39: AIR302 `execution_date` is removed in Airflow 3.0; use `logical_date` instead
+ℹ Unsafe fix
+47 47 | @dag()
+48 48 | def decorator_deprecated_operator_args():
+49 49 |     trigger_dagrun_op = trigger_dagrun.TriggerDagRunOperator(
+50    |-        task_id="trigger_dagrun_op1", execution_date="2024-12-04"
+   50 |+        task_id="trigger_dagrun_op1", logical_date="2024-12-04"
+51 51 |     )
+52 52 |     trigger_dagrun_op2 = TriggerDagRunOperator(
+53 53 |         task_id="trigger_dagrun_op2", execution_date="2024-12-04"
+
+AIR302_args.py:53:39: AIR302 [*] `execution_date` is removed in Airflow 3.0; use `logical_date` instead
    |
 51 |     )
 52 |     trigger_dagrun_op2 = TriggerDagRunOperator(
@@ -68,8 +109,19 @@ AIR302_args.py:53:39: AIR302 `execution_date` is removed in Airflow 3.0; use `lo
    |                                       ^^^^^^^^^^^^^^ AIR302
 54 |     )
    |
+   = help: Replace deprecated keywords in Airflow 3.0
 
-AIR302_args.py:57:33: AIR302 `use_task_execution_day` is removed in Airflow 3.0; use `use_task_logical_date` instead
+ℹ Unsafe fix
+50 50 |         task_id="trigger_dagrun_op1", execution_date="2024-12-04"
+51 51 |     )
+52 52 |     trigger_dagrun_op2 = TriggerDagRunOperator(
+53    |-        task_id="trigger_dagrun_op2", execution_date="2024-12-04"
+   53 |+        task_id="trigger_dagrun_op2", logical_date="2024-12-04"
+54 54 |     )
+55 55 | 
+56 56 |     branch_dt_op = datetime.BranchDateTimeOperator(
+
+AIR302_args.py:57:33: AIR302 [*] `use_task_execution_day` is removed in Airflow 3.0; use `use_task_logical_date` instead
    |
 56 |     branch_dt_op = datetime.BranchDateTimeOperator(
 57 |         task_id="branch_dt_op", use_task_execution_day=True
@@ -77,8 +129,19 @@ AIR302_args.py:57:33: AIR302 `use_task_execution_day` is removed in Airflow 3.0;
 58 |     )
 59 |     branch_dt_op2 = BranchDateTimeOperator(
    |
+   = help: Replace deprecated keywords in Airflow 3.0
 
-AIR302_args.py:60:34: AIR302 `use_task_execution_day` is removed in Airflow 3.0; use `use_task_logical_date` instead
+ℹ Unsafe fix
+54 54 |     )
+55 55 | 
+56 56 |     branch_dt_op = datetime.BranchDateTimeOperator(
+57    |-        task_id="branch_dt_op", use_task_execution_day=True
+   57 |+        task_id="branch_dt_op", use_task_logical_date=True
+58 58 |     )
+59 59 |     branch_dt_op2 = BranchDateTimeOperator(
+60 60 |         task_id="branch_dt_op2", use_task_execution_day=True
+
+AIR302_args.py:60:34: AIR302 [*] `use_task_execution_day` is removed in Airflow 3.0; use `use_task_logical_date` instead
    |
 58 |     )
 59 |     branch_dt_op2 = BranchDateTimeOperator(
@@ -86,3 +149,14 @@ AIR302_args.py:60:34: AIR302 `use_task_execution_day` is removed in Airflow 3.0;
    |                                  ^^^^^^^^^^^^^^^^^^^^^^ AIR302
 61 |     )
    |
+   = help: Replace deprecated keywords in Airflow 3.0
+
+ℹ Unsafe fix
+57 57 |         task_id="branch_dt_op", use_task_execution_day=True
+58 58 |     )
+59 59 |     branch_dt_op2 = BranchDateTimeOperator(
+60    |-        task_id="branch_dt_op2", use_task_execution_day=True
+   60 |+        task_id="branch_dt_op2", use_task_logical_date=True
+61 61 |     )
+62 62 | 
+63 63 |     dof_task_sensor = weekday.DayOfWeekSensor(

--- a/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_args.py.snap
+++ b/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_args.py.snap
@@ -2,7 +2,7 @@
 source: crates/ruff_linter/src/rules/airflow/mod.rs
 snapshot_kind: text
 ---
-AIR302_args.py:15:39: AIR302 [*] `schedule_interval` is removed in Airflow 3.0; use `schedule` instead
+AIR302_args.py:15:39: AIR302 [*] `schedule_interval` is removed in Airflow 3.0.
    |
 13 | DAG(dag_id="class_schedule", schedule="@hourly")
 14 | 
@@ -11,7 +11,7 @@ AIR302_args.py:15:39: AIR302 [*] `schedule_interval` is removed in Airflow 3.0; 
 16 | 
 17 | DAG(dag_id="class_timetable", timetable=NullTimetable())
    |
-   = help: Replace deprecated keywords in Airflow 3.0
+   = help: Use `schedule` instead.
 
 ℹ Unsafe fix
 12 12 | 
@@ -23,14 +23,14 @@ AIR302_args.py:15:39: AIR302 [*] `schedule_interval` is removed in Airflow 3.0; 
 17 17 | DAG(dag_id="class_timetable", timetable=NullTimetable())
 18 18 | 
 
-AIR302_args.py:17:31: AIR302 [*] `timetable` is removed in Airflow 3.0; use `schedule` instead
+AIR302_args.py:17:31: AIR302 [*] `timetable` is removed in Airflow 3.0.
    |
 15 | DAG(dag_id="class_schedule_interval", schedule_interval="@hourly")
 16 | 
 17 | DAG(dag_id="class_timetable", timetable=NullTimetable())
    |                               ^^^^^^^^^ AIR302
    |
-   = help: Replace deprecated keywords in Airflow 3.0
+   = help: Use `schedule` instead.
 
 ℹ Unsafe fix
 14 14 | 
@@ -42,14 +42,14 @@ AIR302_args.py:17:31: AIR302 [*] `timetable` is removed in Airflow 3.0; use `sch
 19 19 | 
 20 20 | def sla_callback(*arg, **kwargs):
 
-AIR302_args.py:32:6: AIR302 [*] `schedule_interval` is removed in Airflow 3.0; use `schedule` instead
+AIR302_args.py:32:6: AIR302 [*] `schedule_interval` is removed in Airflow 3.0.
    |
 32 | @dag(schedule_interval="0 * * * *")
    |      ^^^^^^^^^^^^^^^^^ AIR302
 33 | def decorator_schedule_interval():
 34 |     pass
    |
-   = help: Replace deprecated keywords in Airflow 3.0
+   = help: Use `schedule` instead.
 
 ℹ Unsafe fix
 29 29 |     pass
@@ -61,14 +61,14 @@ AIR302_args.py:32:6: AIR302 [*] `schedule_interval` is removed in Airflow 3.0; u
 34 34 |     pass
 35 35 | 
 
-AIR302_args.py:37:6: AIR302 [*] `timetable` is removed in Airflow 3.0; use `schedule` instead
+AIR302_args.py:37:6: AIR302 [*] `timetable` is removed in Airflow 3.0.
    |
 37 | @dag(timetable=NullTimetable())
    |      ^^^^^^^^^ AIR302
 38 | def decorator_timetable():
 39 |     pass
    |
-   = help: Replace deprecated keywords in Airflow 3.0
+   = help: Use `schedule` instead.
 
 ℹ Unsafe fix
 34 34 |     pass
@@ -80,7 +80,7 @@ AIR302_args.py:37:6: AIR302 [*] `timetable` is removed in Airflow 3.0; use `sche
 39 39 |     pass
 40 40 | 
 
-AIR302_args.py:50:39: AIR302 [*] `execution_date` is removed in Airflow 3.0; use `logical_date` instead
+AIR302_args.py:50:39: AIR302 [*] `execution_date` is removed in Airflow 3.0.
    |
 48 | def decorator_deprecated_operator_args():
 49 |     trigger_dagrun_op = trigger_dagrun.TriggerDagRunOperator(
@@ -89,7 +89,7 @@ AIR302_args.py:50:39: AIR302 [*] `execution_date` is removed in Airflow 3.0; use
 51 |     )
 52 |     trigger_dagrun_op2 = TriggerDagRunOperator(
    |
-   = help: Replace deprecated keywords in Airflow 3.0
+   = help: Use `logical_date` instead.
 
 ℹ Unsafe fix
 47 47 | @dag()
@@ -101,7 +101,7 @@ AIR302_args.py:50:39: AIR302 [*] `execution_date` is removed in Airflow 3.0; use
 52 52 |     trigger_dagrun_op2 = TriggerDagRunOperator(
 53 53 |         task_id="trigger_dagrun_op2", execution_date="2024-12-04"
 
-AIR302_args.py:53:39: AIR302 [*] `execution_date` is removed in Airflow 3.0; use `logical_date` instead
+AIR302_args.py:53:39: AIR302 [*] `execution_date` is removed in Airflow 3.0.
    |
 51 |     )
 52 |     trigger_dagrun_op2 = TriggerDagRunOperator(
@@ -109,7 +109,7 @@ AIR302_args.py:53:39: AIR302 [*] `execution_date` is removed in Airflow 3.0; use
    |                                       ^^^^^^^^^^^^^^ AIR302
 54 |     )
    |
-   = help: Replace deprecated keywords in Airflow 3.0
+   = help: Use `logical_date` instead.
 
 ℹ Unsafe fix
 50 50 |         task_id="trigger_dagrun_op1", execution_date="2024-12-04"
@@ -121,7 +121,7 @@ AIR302_args.py:53:39: AIR302 [*] `execution_date` is removed in Airflow 3.0; use
 55 55 | 
 56 56 |     branch_dt_op = datetime.BranchDateTimeOperator(
 
-AIR302_args.py:57:33: AIR302 [*] `use_task_execution_day` is removed in Airflow 3.0; use `use_task_logical_date` instead
+AIR302_args.py:57:33: AIR302 [*] `use_task_execution_day` is removed in Airflow 3.0.
    |
 56 |     branch_dt_op = datetime.BranchDateTimeOperator(
 57 |         task_id="branch_dt_op", use_task_execution_day=True
@@ -129,7 +129,7 @@ AIR302_args.py:57:33: AIR302 [*] `use_task_execution_day` is removed in Airflow 
 58 |     )
 59 |     branch_dt_op2 = BranchDateTimeOperator(
    |
-   = help: Replace deprecated keywords in Airflow 3.0
+   = help: Use `use_task_logical_date` instead.
 
 ℹ Unsafe fix
 54 54 |     )
@@ -141,7 +141,7 @@ AIR302_args.py:57:33: AIR302 [*] `use_task_execution_day` is removed in Airflow 
 59 59 |     branch_dt_op2 = BranchDateTimeOperator(
 60 60 |         task_id="branch_dt_op2", use_task_execution_day=True
 
-AIR302_args.py:60:34: AIR302 [*] `use_task_execution_day` is removed in Airflow 3.0; use `use_task_logical_date` instead
+AIR302_args.py:60:34: AIR302 [*] `use_task_execution_day` is removed in Airflow 3.0.
    |
 58 |     )
 59 |     branch_dt_op2 = BranchDateTimeOperator(
@@ -149,7 +149,7 @@ AIR302_args.py:60:34: AIR302 [*] `use_task_execution_day` is removed in Airflow 
    |                                  ^^^^^^^^^^^^^^^^^^^^^^ AIR302
 61 |     )
    |
-   = help: Replace deprecated keywords in Airflow 3.0
+   = help: Use `use_task_logical_date` instead.
 
 ℹ Unsafe fix
 57 57 |         task_id="branch_dt_op", use_task_execution_day=True

--- a/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_args.py.snap
+++ b/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_args.py.snap
@@ -42,6 +42,12 @@ AIR302_args.py:17:31: AIR302 [*] `timetable` is removed in Airflow 3.0.
 19 19 | 
 20 20 | def sla_callback(*arg, **kwargs):
 
+AIR302_args.py:24:34: AIR302 `sla_miss_callback` is removed in Airflow 3.0
+   |
+24 | DAG(dag_id="class_sla_callback", sla_miss_callback=sla_callback)
+   |                                  ^^^^^^^^^^^^^^^^^ AIR302
+   |
+
 AIR302_args.py:32:6: AIR302 [*] `schedule_interval` is removed in Airflow 3.0.
    |
 32 | @dag(schedule_interval="0 * * * *")
@@ -79,6 +85,14 @@ AIR302_args.py:37:6: AIR302 [*] `timetable` is removed in Airflow 3.0.
 38 38 | def decorator_timetable():
 39 39 |     pass
 40 40 | 
+
+AIR302_args.py:42:6: AIR302 `sla_miss_callback` is removed in Airflow 3.0
+   |
+42 | @dag(sla_miss_callback=sla_callback)
+   |      ^^^^^^^^^^^^^^^^^ AIR302
+43 | def decorator_sla_callback():
+44 |     pass
+   |
 
 AIR302_args.py:50:39: AIR302 [*] `execution_date` is removed in Airflow 3.0.
    |

--- a/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_args.py.snap
+++ b/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_args.py.snap
@@ -2,7 +2,7 @@
 source: crates/ruff_linter/src/rules/airflow/mod.rs
 snapshot_kind: text
 ---
-AIR302_args.py:15:39: AIR302 [*] `schedule_interval` is removed in Airflow 3.0.
+AIR302_args.py:15:39: AIR302 [*] `schedule_interval` is removed in Airflow 3.0
    |
 13 | DAG(dag_id="class_schedule", schedule="@hourly")
 14 | 
@@ -11,9 +11,9 @@ AIR302_args.py:15:39: AIR302 [*] `schedule_interval` is removed in Airflow 3.0.
 16 | 
 17 | DAG(dag_id="class_timetable", timetable=NullTimetable())
    |
-   = help: Use `schedule` instead.
+   = help: Use `schedule` instead
 
-ℹ Unsafe fix
+ℹ Safe fix
 12 12 | 
 13 13 | DAG(dag_id="class_schedule", schedule="@hourly")
 14 14 | 
@@ -23,16 +23,16 @@ AIR302_args.py:15:39: AIR302 [*] `schedule_interval` is removed in Airflow 3.0.
 17 17 | DAG(dag_id="class_timetable", timetable=NullTimetable())
 18 18 | 
 
-AIR302_args.py:17:31: AIR302 [*] `timetable` is removed in Airflow 3.0.
+AIR302_args.py:17:31: AIR302 [*] `timetable` is removed in Airflow 3.0
    |
 15 | DAG(dag_id="class_schedule_interval", schedule_interval="@hourly")
 16 | 
 17 | DAG(dag_id="class_timetable", timetable=NullTimetable())
    |                               ^^^^^^^^^ AIR302
    |
-   = help: Use `schedule` instead.
+   = help: Use `schedule` instead
 
-ℹ Unsafe fix
+ℹ Safe fix
 14 14 | 
 15 15 | DAG(dag_id="class_schedule_interval", schedule_interval="@hourly")
 16 16 | 
@@ -48,16 +48,16 @@ AIR302_args.py:24:34: AIR302 `sla_miss_callback` is removed in Airflow 3.0
    |                                  ^^^^^^^^^^^^^^^^^ AIR302
    |
 
-AIR302_args.py:32:6: AIR302 [*] `schedule_interval` is removed in Airflow 3.0.
+AIR302_args.py:32:6: AIR302 [*] `schedule_interval` is removed in Airflow 3.0
    |
 32 | @dag(schedule_interval="0 * * * *")
    |      ^^^^^^^^^^^^^^^^^ AIR302
 33 | def decorator_schedule_interval():
 34 |     pass
    |
-   = help: Use `schedule` instead.
+   = help: Use `schedule` instead
 
-ℹ Unsafe fix
+ℹ Safe fix
 29 29 |     pass
 30 30 | 
 31 31 | 
@@ -67,16 +67,16 @@ AIR302_args.py:32:6: AIR302 [*] `schedule_interval` is removed in Airflow 3.0.
 34 34 |     pass
 35 35 | 
 
-AIR302_args.py:37:6: AIR302 [*] `timetable` is removed in Airflow 3.0.
+AIR302_args.py:37:6: AIR302 [*] `timetable` is removed in Airflow 3.0
    |
 37 | @dag(timetable=NullTimetable())
    |      ^^^^^^^^^ AIR302
 38 | def decorator_timetable():
 39 |     pass
    |
-   = help: Use `schedule` instead.
+   = help: Use `schedule` instead
 
-ℹ Unsafe fix
+ℹ Safe fix
 34 34 |     pass
 35 35 | 
 36 36 | 
@@ -94,7 +94,7 @@ AIR302_args.py:42:6: AIR302 `sla_miss_callback` is removed in Airflow 3.0
 44 |     pass
    |
 
-AIR302_args.py:50:39: AIR302 [*] `execution_date` is removed in Airflow 3.0.
+AIR302_args.py:50:39: AIR302 [*] `execution_date` is removed in Airflow 3.0
    |
 48 | def decorator_deprecated_operator_args():
 49 |     trigger_dagrun_op = trigger_dagrun.TriggerDagRunOperator(
@@ -103,9 +103,9 @@ AIR302_args.py:50:39: AIR302 [*] `execution_date` is removed in Airflow 3.0.
 51 |     )
 52 |     trigger_dagrun_op2 = TriggerDagRunOperator(
    |
-   = help: Use `logical_date` instead.
+   = help: Use `logical_date` instead
 
-ℹ Unsafe fix
+ℹ Safe fix
 47 47 | @dag()
 48 48 | def decorator_deprecated_operator_args():
 49 49 |     trigger_dagrun_op = trigger_dagrun.TriggerDagRunOperator(
@@ -115,7 +115,7 @@ AIR302_args.py:50:39: AIR302 [*] `execution_date` is removed in Airflow 3.0.
 52 52 |     trigger_dagrun_op2 = TriggerDagRunOperator(
 53 53 |         task_id="trigger_dagrun_op2", execution_date="2024-12-04"
 
-AIR302_args.py:53:39: AIR302 [*] `execution_date` is removed in Airflow 3.0.
+AIR302_args.py:53:39: AIR302 [*] `execution_date` is removed in Airflow 3.0
    |
 51 |     )
 52 |     trigger_dagrun_op2 = TriggerDagRunOperator(
@@ -123,9 +123,9 @@ AIR302_args.py:53:39: AIR302 [*] `execution_date` is removed in Airflow 3.0.
    |                                       ^^^^^^^^^^^^^^ AIR302
 54 |     )
    |
-   = help: Use `logical_date` instead.
+   = help: Use `logical_date` instead
 
-ℹ Unsafe fix
+ℹ Safe fix
 50 50 |         task_id="trigger_dagrun_op1", execution_date="2024-12-04"
 51 51 |     )
 52 52 |     trigger_dagrun_op2 = TriggerDagRunOperator(
@@ -135,7 +135,7 @@ AIR302_args.py:53:39: AIR302 [*] `execution_date` is removed in Airflow 3.0.
 55 55 | 
 56 56 |     branch_dt_op = datetime.BranchDateTimeOperator(
 
-AIR302_args.py:57:33: AIR302 [*] `use_task_execution_day` is removed in Airflow 3.0.
+AIR302_args.py:57:33: AIR302 [*] `use_task_execution_day` is removed in Airflow 3.0
    |
 56 |     branch_dt_op = datetime.BranchDateTimeOperator(
 57 |         task_id="branch_dt_op", use_task_execution_day=True
@@ -143,9 +143,9 @@ AIR302_args.py:57:33: AIR302 [*] `use_task_execution_day` is removed in Airflow 
 58 |     )
 59 |     branch_dt_op2 = BranchDateTimeOperator(
    |
-   = help: Use `use_task_logical_date` instead.
+   = help: Use `use_task_logical_date` instead
 
-ℹ Unsafe fix
+ℹ Safe fix
 54 54 |     )
 55 55 | 
 56 56 |     branch_dt_op = datetime.BranchDateTimeOperator(
@@ -155,7 +155,7 @@ AIR302_args.py:57:33: AIR302 [*] `use_task_execution_day` is removed in Airflow 
 59 59 |     branch_dt_op2 = BranchDateTimeOperator(
 60 60 |         task_id="branch_dt_op2", use_task_execution_day=True
 
-AIR302_args.py:60:34: AIR302 [*] `use_task_execution_day` is removed in Airflow 3.0.
+AIR302_args.py:60:34: AIR302 [*] `use_task_execution_day` is removed in Airflow 3.0
    |
 58 |     )
 59 |     branch_dt_op2 = BranchDateTimeOperator(
@@ -163,9 +163,9 @@ AIR302_args.py:60:34: AIR302 [*] `use_task_execution_day` is removed in Airflow 
    |                                  ^^^^^^^^^^^^^^^^^^^^^^ AIR302
 61 |     )
    |
-   = help: Use `use_task_logical_date` instead.
+   = help: Use `use_task_logical_date` instead
 
-ℹ Unsafe fix
+ℹ Safe fix
 57 57 |         task_id="branch_dt_op", use_task_execution_day=True
 58 58 |     )
 59 59 |     branch_dt_op2 = BranchDateTimeOperator(

--- a/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_names.py.snap
+++ b/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_names.py.snap
@@ -2,7 +2,7 @@
 source: crates/ruff_linter/src/rules/airflow/mod.rs
 snapshot_kind: text
 ---
-AIR302_names.py:52:1: AIR302 `airflow.PY36` is removed in Airflow 3.0; use `sys.version_info` instead
+AIR302_names.py:52:1: AIR302 `airflow.PY36` is removed in Airflow 3.0.
    |
 50 | from airflow.www.utils import get_sensitive_variables_fields, should_hide_value_for_key
 51 | 
@@ -11,9 +11,9 @@ AIR302_names.py:52:1: AIR302 `airflow.PY36` is removed in Airflow 3.0; use `sys.
 53 | 
 54 | AWSAthenaHook
    |
-   = help: Replace deprecated keywords in Airflow 3.0
+   = help: Use `sys.version_info` instead.
 
-AIR302_names.py:52:7: AIR302 `airflow.PY37` is removed in Airflow 3.0; use `sys.version_info` instead
+AIR302_names.py:52:7: AIR302 `airflow.PY37` is removed in Airflow 3.0.
    |
 50 | from airflow.www.utils import get_sensitive_variables_fields, should_hide_value_for_key
 51 | 
@@ -22,9 +22,9 @@ AIR302_names.py:52:7: AIR302 `airflow.PY37` is removed in Airflow 3.0; use `sys.
 53 | 
 54 | AWSAthenaHook
    |
-   = help: Replace deprecated keywords in Airflow 3.0
+   = help: Use `sys.version_info` instead.
 
-AIR302_names.py:52:13: AIR302 `airflow.PY38` is removed in Airflow 3.0; use `sys.version_info` instead
+AIR302_names.py:52:13: AIR302 `airflow.PY38` is removed in Airflow 3.0.
    |
 50 | from airflow.www.utils import get_sensitive_variables_fields, should_hide_value_for_key
 51 | 
@@ -33,9 +33,9 @@ AIR302_names.py:52:13: AIR302 `airflow.PY38` is removed in Airflow 3.0; use `sys
 53 | 
 54 | AWSAthenaHook
    |
-   = help: Replace deprecated keywords in Airflow 3.0
+   = help: Use `sys.version_info` instead.
 
-AIR302_names.py:52:19: AIR302 `airflow.PY39` is removed in Airflow 3.0; use `sys.version_info` instead
+AIR302_names.py:52:19: AIR302 `airflow.PY39` is removed in Airflow 3.0.
    |
 50 | from airflow.www.utils import get_sensitive_variables_fields, should_hide_value_for_key
 51 | 
@@ -44,9 +44,9 @@ AIR302_names.py:52:19: AIR302 `airflow.PY39` is removed in Airflow 3.0; use `sys
 53 | 
 54 | AWSAthenaHook
    |
-   = help: Replace deprecated keywords in Airflow 3.0
+   = help: Use `sys.version_info` instead.
 
-AIR302_names.py:52:25: AIR302 `airflow.PY310` is removed in Airflow 3.0; use `sys.version_info` instead
+AIR302_names.py:52:25: AIR302 `airflow.PY310` is removed in Airflow 3.0.
    |
 50 | from airflow.www.utils import get_sensitive_variables_fields, should_hide_value_for_key
 51 | 
@@ -55,9 +55,9 @@ AIR302_names.py:52:25: AIR302 `airflow.PY310` is removed in Airflow 3.0; use `sy
 53 | 
 54 | AWSAthenaHook
    |
-   = help: Replace deprecated keywords in Airflow 3.0
+   = help: Use `sys.version_info` instead.
 
-AIR302_names.py:52:32: AIR302 `airflow.PY311` is removed in Airflow 3.0; use `sys.version_info` instead
+AIR302_names.py:52:32: AIR302 `airflow.PY311` is removed in Airflow 3.0.
    |
 50 | from airflow.www.utils import get_sensitive_variables_fields, should_hide_value_for_key
 51 | 
@@ -66,9 +66,9 @@ AIR302_names.py:52:32: AIR302 `airflow.PY311` is removed in Airflow 3.0; use `sy
 53 | 
 54 | AWSAthenaHook
    |
-   = help: Replace deprecated keywords in Airflow 3.0
+   = help: Use `sys.version_info` instead.
 
-AIR302_names.py:52:39: AIR302 `airflow.PY312` is removed in Airflow 3.0; use `sys.version_info` instead
+AIR302_names.py:52:39: AIR302 `airflow.PY312` is removed in Airflow 3.0.
    |
 50 | from airflow.www.utils import get_sensitive_variables_fields, should_hide_value_for_key
 51 | 
@@ -77,7 +77,7 @@ AIR302_names.py:52:39: AIR302 `airflow.PY312` is removed in Airflow 3.0; use `sy
 53 | 
 54 | AWSAthenaHook
    |
-   = help: Replace deprecated keywords in Airflow 3.0
+   = help: Use `sys.version_info` instead.
 
 AIR302_names.py:54:1: AIR302 `airflow.contrib.aws_athena_hook.AWSAthenaHook` is removed in Airflow 3.0
    |
@@ -87,7 +87,6 @@ AIR302_names.py:54:1: AIR302 `airflow.contrib.aws_athena_hook.AWSAthenaHook` is 
    | ^^^^^^^^^^^^^ AIR302
 55 | TaskStateTrigger
    |
-   = help: Replace deprecated keywords in Airflow 3.0
 
 AIR302_names.py:55:1: AIR302 `airflow.triggers.external_task.TaskStateTrigger` is removed in Airflow 3.0
    |
@@ -97,9 +96,8 @@ AIR302_names.py:55:1: AIR302 `airflow.triggers.external_task.TaskStateTrigger` i
 56 | 
 57 | requires_access
    |
-   = help: Replace deprecated keywords in Airflow 3.0
 
-AIR302_names.py:57:1: AIR302 `airflow.api_connexion.security.requires_access` is removed in Airflow 3.0; use `airflow.api_connexion.security.requires_access_*` instead
+AIR302_names.py:57:1: AIR302 `airflow.api_connexion.security.requires_access` is removed in Airflow 3.0.
    |
 55 | TaskStateTrigger
 56 | 
@@ -108,9 +106,9 @@ AIR302_names.py:57:1: AIR302 `airflow.api_connexion.security.requires_access` is
 58 | 
 59 | AllowListValidator
    |
-   = help: Replace deprecated keywords in Airflow 3.0
+   = help: Use `airflow.api_connexion.security.requires_access_*` instead.
 
-AIR302_names.py:59:1: AIR302 `airflow.metrics.validators.AllowListValidator` is removed in Airflow 3.0; use `airflow.metrics.validators.PatternAllowListValidator` instead
+AIR302_names.py:59:1: AIR302 `airflow.metrics.validators.AllowListValidator` is removed in Airflow 3.0.
    |
 57 | requires_access
 58 | 
@@ -118,9 +116,9 @@ AIR302_names.py:59:1: AIR302 `airflow.metrics.validators.AllowListValidator` is 
    | ^^^^^^^^^^^^^^^^^^ AIR302
 60 | BlockListValidator
    |
-   = help: Replace deprecated keywords in Airflow 3.0
+   = help: Use `airflow.metrics.validators.PatternAllowListValidator` instead.
 
-AIR302_names.py:60:1: AIR302 `airflow.metrics.validators.BlockListValidator` is removed in Airflow 3.0; use `airflow.metrics.validators.PatternBlockListValidator` instead
+AIR302_names.py:60:1: AIR302 `airflow.metrics.validators.BlockListValidator` is removed in Airflow 3.0.
    |
 59 | AllowListValidator
 60 | BlockListValidator
@@ -128,7 +126,7 @@ AIR302_names.py:60:1: AIR302 `airflow.metrics.validators.BlockListValidator` is 
 61 | 
 62 | SubDagOperator
    |
-   = help: Replace deprecated keywords in Airflow 3.0
+   = help: Use `airflow.metrics.validators.PatternBlockListValidator` instead.
 
 AIR302_names.py:62:1: AIR302 `airflow.operators.subdag.SubDagOperator` is removed in Airflow 3.0
    |
@@ -139,9 +137,8 @@ AIR302_names.py:62:1: AIR302 `airflow.operators.subdag.SubDagOperator` is remove
 63 | 
 64 | dates.date_range
    |
-   = help: Replace deprecated keywords in Airflow 3.0
 
-AIR302_names.py:64:7: AIR302 `airflow.utils.dates.date_range` is removed in Airflow 3.0; use `airflow.timetables.` instead
+AIR302_names.py:64:7: AIR302 `airflow.utils.dates.date_range` is removed in Airflow 3.0.
    |
 62 | SubDagOperator
 63 | 
@@ -149,9 +146,9 @@ AIR302_names.py:64:7: AIR302 `airflow.utils.dates.date_range` is removed in Airf
    |       ^^^^^^^^^^ AIR302
 65 | dates.days_ago
    |
-   = help: Replace deprecated keywords in Airflow 3.0
+   = help: Use `airflow.timetables.` instead.
 
-AIR302_names.py:65:7: AIR302 `airflow.utils.dates.days_ago` is removed in Airflow 3.0; use `pendulum.today('UTC').add(days=-N, ...)` instead
+AIR302_names.py:65:7: AIR302 `airflow.utils.dates.days_ago` is removed in Airflow 3.0.
    |
 64 | dates.date_range
 65 | dates.days_ago
@@ -159,9 +156,9 @@ AIR302_names.py:65:7: AIR302 `airflow.utils.dates.days_ago` is removed in Airflo
 66 | 
 67 | date_range
    |
-   = help: Replace deprecated keywords in Airflow 3.0
+   = help: Use `pendulum.today('UTC').add(days=-N, ...)` instead.
 
-AIR302_names.py:67:1: AIR302 `airflow.utils.dates.date_range` is removed in Airflow 3.0; use `airflow.timetables.` instead
+AIR302_names.py:67:1: AIR302 `airflow.utils.dates.date_range` is removed in Airflow 3.0.
    |
 65 | dates.days_ago
 66 | 
@@ -170,9 +167,9 @@ AIR302_names.py:67:1: AIR302 `airflow.utils.dates.date_range` is removed in Airf
 68 | days_ago
 69 | parse_execution_date
    |
-   = help: Replace deprecated keywords in Airflow 3.0
+   = help: Use `airflow.timetables.` instead.
 
-AIR302_names.py:68:1: AIR302 `airflow.utils.dates.days_ago` is removed in Airflow 3.0; use `pendulum.today('UTC').add(days=-N, ...)` instead
+AIR302_names.py:68:1: AIR302 `airflow.utils.dates.days_ago` is removed in Airflow 3.0.
    |
 67 | date_range
 68 | days_ago
@@ -180,7 +177,7 @@ AIR302_names.py:68:1: AIR302 `airflow.utils.dates.days_ago` is removed in Airflo
 69 | parse_execution_date
 70 | round_time
    |
-   = help: Replace deprecated keywords in Airflow 3.0
+   = help: Use `pendulum.today('UTC').add(days=-N, ...)` instead.
 
 AIR302_names.py:69:1: AIR302 `airflow.utils.dates.parse_execution_date` is removed in Airflow 3.0
    |
@@ -191,7 +188,6 @@ AIR302_names.py:69:1: AIR302 `airflow.utils.dates.parse_execution_date` is remov
 70 | round_time
 71 | scale_time_units
    |
-   = help: Replace deprecated keywords in Airflow 3.0
 
 AIR302_names.py:70:1: AIR302 `airflow.utils.dates.round_time` is removed in Airflow 3.0
    |
@@ -202,7 +198,6 @@ AIR302_names.py:70:1: AIR302 `airflow.utils.dates.round_time` is removed in Airf
 71 | scale_time_units
 72 | infer_time_unit
    |
-   = help: Replace deprecated keywords in Airflow 3.0
 
 AIR302_names.py:71:1: AIR302 `airflow.utils.dates.scale_time_units` is removed in Airflow 3.0
    |
@@ -212,7 +207,6 @@ AIR302_names.py:71:1: AIR302 `airflow.utils.dates.scale_time_units` is removed i
    | ^^^^^^^^^^^^^^^^ AIR302
 72 | infer_time_unit
    |
-   = help: Replace deprecated keywords in Airflow 3.0
 
 AIR302_names.py:72:1: AIR302 `airflow.utils.dates.infer_time_unit` is removed in Airflow 3.0
    |
@@ -221,9 +215,8 @@ AIR302_names.py:72:1: AIR302 `airflow.utils.dates.infer_time_unit` is removed in
 72 | infer_time_unit
    | ^^^^^^^^^^^^^^^ AIR302
    |
-   = help: Replace deprecated keywords in Airflow 3.0
 
-AIR302_names.py:79:1: AIR302 `airflow.configuration.get` is removed in Airflow 3.0; use `airflow.configuration.conf.get` instead
+AIR302_names.py:79:1: AIR302 `airflow.configuration.get` is removed in Airflow 3.0.
    |
 77 | dates.datetime_to_nano
 78 | 
@@ -232,9 +225,9 @@ AIR302_names.py:79:1: AIR302 `airflow.configuration.get` is removed in Airflow 3
 80 | 
 81 | get_connection, load_connections
    |
-   = help: Replace deprecated keywords in Airflow 3.0
+   = help: Use `airflow.configuration.conf.get` instead.
 
-AIR302_names.py:79:6: AIR302 `airflow.configuration.getboolean` is removed in Airflow 3.0; use `airflow.configuration.conf.getboolean` instead
+AIR302_names.py:79:6: AIR302 `airflow.configuration.getboolean` is removed in Airflow 3.0.
    |
 77 | dates.datetime_to_nano
 78 | 
@@ -243,9 +236,9 @@ AIR302_names.py:79:6: AIR302 `airflow.configuration.getboolean` is removed in Ai
 80 | 
 81 | get_connection, load_connections
    |
-   = help: Replace deprecated keywords in Airflow 3.0
+   = help: Use `airflow.configuration.conf.getboolean` instead.
 
-AIR302_names.py:79:18: AIR302 `airflow.configuration.getfloat` is removed in Airflow 3.0; use `airflow.configuration.conf.getfloat` instead
+AIR302_names.py:79:18: AIR302 `airflow.configuration.getfloat` is removed in Airflow 3.0.
    |
 77 | dates.datetime_to_nano
 78 | 
@@ -254,9 +247,9 @@ AIR302_names.py:79:18: AIR302 `airflow.configuration.getfloat` is removed in Air
 80 | 
 81 | get_connection, load_connections
    |
-   = help: Replace deprecated keywords in Airflow 3.0
+   = help: Use `airflow.configuration.conf.getfloat` instead.
 
-AIR302_names.py:79:28: AIR302 `airflow.configuration.getint` is removed in Airflow 3.0; use `airflow.configuration.conf.getint` instead
+AIR302_names.py:79:28: AIR302 `airflow.configuration.getint` is removed in Airflow 3.0.
    |
 77 | dates.datetime_to_nano
 78 | 
@@ -265,9 +258,9 @@ AIR302_names.py:79:28: AIR302 `airflow.configuration.getint` is removed in Airfl
 80 | 
 81 | get_connection, load_connections
    |
-   = help: Replace deprecated keywords in Airflow 3.0
+   = help: Use `airflow.configuration.conf.getint` instead.
 
-AIR302_names.py:79:36: AIR302 `airflow.configuration.has_option` is removed in Airflow 3.0; use `airflow.configuration.conf.has_option` instead
+AIR302_names.py:79:36: AIR302 `airflow.configuration.has_option` is removed in Airflow 3.0.
    |
 77 | dates.datetime_to_nano
 78 | 
@@ -276,9 +269,9 @@ AIR302_names.py:79:36: AIR302 `airflow.configuration.has_option` is removed in A
 80 | 
 81 | get_connection, load_connections
    |
-   = help: Replace deprecated keywords in Airflow 3.0
+   = help: Use `airflow.configuration.conf.has_option` instead.
 
-AIR302_names.py:79:48: AIR302 `airflow.configuration.remove_option` is removed in Airflow 3.0; use `airflow.configuration.conf.remove_option` instead
+AIR302_names.py:79:48: AIR302 `airflow.configuration.remove_option` is removed in Airflow 3.0.
    |
 77 | dates.datetime_to_nano
 78 | 
@@ -287,9 +280,9 @@ AIR302_names.py:79:48: AIR302 `airflow.configuration.remove_option` is removed i
 80 | 
 81 | get_connection, load_connections
    |
-   = help: Replace deprecated keywords in Airflow 3.0
+   = help: Use `airflow.configuration.conf.remove_option` instead.
 
-AIR302_names.py:79:63: AIR302 `airflow.configuration.as_dict` is removed in Airflow 3.0; use `airflow.configuration.conf.as_dict` instead
+AIR302_names.py:79:63: AIR302 `airflow.configuration.as_dict` is removed in Airflow 3.0.
    |
 77 | dates.datetime_to_nano
 78 | 
@@ -298,9 +291,9 @@ AIR302_names.py:79:63: AIR302 `airflow.configuration.as_dict` is removed in Airf
 80 | 
 81 | get_connection, load_connections
    |
-   = help: Replace deprecated keywords in Airflow 3.0
+   = help: Use `airflow.configuration.conf.as_dict` instead.
 
-AIR302_names.py:79:72: AIR302 `airflow.configuration.set` is removed in Airflow 3.0; use `airflow.configuration.conf.set` instead
+AIR302_names.py:79:72: AIR302 `airflow.configuration.set` is removed in Airflow 3.0.
    |
 77 | dates.datetime_to_nano
 78 | 
@@ -309,36 +302,36 @@ AIR302_names.py:79:72: AIR302 `airflow.configuration.set` is removed in Airflow 
 80 | 
 81 | get_connection, load_connections
    |
-   = help: Replace deprecated keywords in Airflow 3.0
+   = help: Use `airflow.configuration.conf.set` instead.
 
-AIR302_names.py:81:1: AIR302 `airflow.secrets.local_filesystem.get_connection` is removed in Airflow 3.0; use `airflow.secrets.local_filesystem.load_connections_dict` instead
+AIR302_names.py:81:1: AIR302 `airflow.secrets.local_filesystem.get_connection` is removed in Airflow 3.0.
    |
 79 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
 80 | 
 81 | get_connection, load_connections
    | ^^^^^^^^^^^^^^ AIR302
    |
-   = help: Replace deprecated keywords in Airflow 3.0
+   = help: Use `airflow.secrets.local_filesystem.load_connections_dict` instead.
 
-AIR302_names.py:81:17: AIR302 `airflow.secrets.local_filesystem.load_connections` is removed in Airflow 3.0; use `airflow.secrets.local_filesystem.load_connections_dict` instead
+AIR302_names.py:81:17: AIR302 `airflow.secrets.local_filesystem.load_connections` is removed in Airflow 3.0.
    |
 79 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
 80 | 
 81 | get_connection, load_connections
    |                 ^^^^^^^^^^^^^^^^ AIR302
    |
-   = help: Replace deprecated keywords in Airflow 3.0
+   = help: Use `airflow.secrets.local_filesystem.load_connections_dict` instead.
 
-AIR302_names.py:84:1: AIR302 `airflow.sensors.external_task_sensor.ExternalTaskSensorLink` is removed in Airflow 3.0; use `airflow.sensors.external_task.ExternalTaskSensorLink` instead
+AIR302_names.py:84:1: AIR302 `airflow.sensors.external_task_sensor.ExternalTaskSensorLink` is removed in Airflow 3.0.
    |
 84 | ExternalTaskSensorLink
    | ^^^^^^^^^^^^^^^^^^^^^^ AIR302
 85 | BashOperator
 86 | BaseBranchOperator
    |
-   = help: Replace deprecated keywords in Airflow 3.0
+   = help: Use `airflow.sensors.external_task.ExternalTaskSensorLink` instead.
 
-AIR302_names.py:85:1: AIR302 `airflow.operators.bash_operator.BashOperator` is removed in Airflow 3.0; use `airflow.operators.bash.BashOperator` instead
+AIR302_names.py:85:1: AIR302 `airflow.operators.bash_operator.BashOperator` is removed in Airflow 3.0.
    |
 84 | ExternalTaskSensorLink
 85 | BashOperator
@@ -346,9 +339,9 @@ AIR302_names.py:85:1: AIR302 `airflow.operators.bash_operator.BashOperator` is r
 86 | BaseBranchOperator
 87 | EmptyOperator, DummyOperator
    |
-   = help: Replace deprecated keywords in Airflow 3.0
+   = help: Use `airflow.operators.bash.BashOperator` instead.
 
-AIR302_names.py:86:1: AIR302 `airflow.operators.branch_operator.BaseBranchOperator` is removed in Airflow 3.0; use `airflow.operators.branch.BaseBranchOperator` instead
+AIR302_names.py:86:1: AIR302 `airflow.operators.branch_operator.BaseBranchOperator` is removed in Airflow 3.0.
    |
 84 | ExternalTaskSensorLink
 85 | BashOperator
@@ -357,9 +350,9 @@ AIR302_names.py:86:1: AIR302 `airflow.operators.branch_operator.BaseBranchOperat
 87 | EmptyOperator, DummyOperator
 88 | dummy_operator.EmptyOperator
    |
-   = help: Replace deprecated keywords in Airflow 3.0
+   = help: Use `airflow.operators.branch.BaseBranchOperator` instead.
 
-AIR302_names.py:87:16: AIR302 `airflow.operators.dummy.DummyOperator` is removed in Airflow 3.0; use `airflow.operators.empty.EmptyOperator` instead
+AIR302_names.py:87:16: AIR302 `airflow.operators.dummy.DummyOperator` is removed in Airflow 3.0.
    |
 85 | BashOperator
 86 | BaseBranchOperator
@@ -368,9 +361,9 @@ AIR302_names.py:87:16: AIR302 `airflow.operators.dummy.DummyOperator` is removed
 88 | dummy_operator.EmptyOperator
 89 | dummy_operator.DummyOperator
    |
-   = help: Replace deprecated keywords in Airflow 3.0
+   = help: Use `airflow.operators.empty.EmptyOperator` instead.
 
-AIR302_names.py:88:16: AIR302 `airflow.operators.dummy_operator.EmptyOperator` is removed in Airflow 3.0; use `airflow.operators.empty.EmptyOperator` instead
+AIR302_names.py:88:16: AIR302 `airflow.operators.dummy_operator.EmptyOperator` is removed in Airflow 3.0.
    |
 86 | BaseBranchOperator
 87 | EmptyOperator, DummyOperator
@@ -379,9 +372,9 @@ AIR302_names.py:88:16: AIR302 `airflow.operators.dummy_operator.EmptyOperator` i
 89 | dummy_operator.DummyOperator
 90 | EmailOperator
    |
-   = help: Replace deprecated keywords in Airflow 3.0
+   = help: Use `airflow.operators.empty.EmptyOperator` instead.
 
-AIR302_names.py:89:16: AIR302 `airflow.operators.dummy_operator.DummyOperator` is removed in Airflow 3.0; use `airflow.operators.empty.EmptyOperator` instead
+AIR302_names.py:89:16: AIR302 `airflow.operators.dummy_operator.DummyOperator` is removed in Airflow 3.0.
    |
 87 | EmptyOperator, DummyOperator
 88 | dummy_operator.EmptyOperator
@@ -390,9 +383,9 @@ AIR302_names.py:89:16: AIR302 `airflow.operators.dummy_operator.DummyOperator` i
 90 | EmailOperator
 91 | BaseSensorOperator
    |
-   = help: Replace deprecated keywords in Airflow 3.0
+   = help: Use `airflow.operators.empty.EmptyOperator` instead.
 
-AIR302_names.py:90:1: AIR302 `airflow.operators.email_operator.EmailOperator` is removed in Airflow 3.0; use `airflow.operators.email.EmailOperator` instead
+AIR302_names.py:90:1: AIR302 `airflow.operators.email_operator.EmailOperator` is removed in Airflow 3.0.
    |
 88 | dummy_operator.EmptyOperator
 89 | dummy_operator.DummyOperator
@@ -401,9 +394,9 @@ AIR302_names.py:90:1: AIR302 `airflow.operators.email_operator.EmailOperator` is
 91 | BaseSensorOperator
 92 | DateTimeSensor
    |
-   = help: Replace deprecated keywords in Airflow 3.0
+   = help: Use `airflow.operators.email.EmailOperator` instead.
 
-AIR302_names.py:91:1: AIR302 `airflow.sensors.base_sensor_operator.BaseSensorOperator` is removed in Airflow 3.0; use `airflow.sensors.base.BaseSensorOperator` instead
+AIR302_names.py:91:1: AIR302 `airflow.sensors.base_sensor_operator.BaseSensorOperator` is removed in Airflow 3.0.
    |
 89 | dummy_operator.DummyOperator
 90 | EmailOperator
@@ -412,9 +405,9 @@ AIR302_names.py:91:1: AIR302 `airflow.sensors.base_sensor_operator.BaseSensorOpe
 92 | DateTimeSensor
 93 | (ExternalTaskMarker, ExternalTaskSensor, ExternalTaskSensorLink)
    |
-   = help: Replace deprecated keywords in Airflow 3.0
+   = help: Use `airflow.sensors.base.BaseSensorOperator` instead.
 
-AIR302_names.py:92:1: AIR302 `airflow.sensors.date_time_sensor.DateTimeSensor` is removed in Airflow 3.0; use `airflow.sensors.date_time.DateTimeSensor` instead
+AIR302_names.py:92:1: AIR302 `airflow.sensors.date_time_sensor.DateTimeSensor` is removed in Airflow 3.0.
    |
 90 | EmailOperator
 91 | BaseSensorOperator
@@ -423,9 +416,9 @@ AIR302_names.py:92:1: AIR302 `airflow.sensors.date_time_sensor.DateTimeSensor` i
 93 | (ExternalTaskMarker, ExternalTaskSensor, ExternalTaskSensorLink)
 94 | TimeDeltaSensor
    |
-   = help: Replace deprecated keywords in Airflow 3.0
+   = help: Use `airflow.sensors.date_time.DateTimeSensor` instead.
 
-AIR302_names.py:93:2: AIR302 `airflow.sensors.external_task_sensor.ExternalTaskMarker` is removed in Airflow 3.0; use `airflow.sensors.external_task.ExternalTaskMarker` instead
+AIR302_names.py:93:2: AIR302 `airflow.sensors.external_task_sensor.ExternalTaskMarker` is removed in Airflow 3.0.
    |
 91 | BaseSensorOperator
 92 | DateTimeSensor
@@ -433,9 +426,9 @@ AIR302_names.py:93:2: AIR302 `airflow.sensors.external_task_sensor.ExternalTaskM
    |  ^^^^^^^^^^^^^^^^^^ AIR302
 94 | TimeDeltaSensor
    |
-   = help: Replace deprecated keywords in Airflow 3.0
+   = help: Use `airflow.sensors.external_task.ExternalTaskMarker` instead.
 
-AIR302_names.py:93:22: AIR302 `airflow.sensors.external_task_sensor.ExternalTaskSensor` is removed in Airflow 3.0; use `airflow.sensors.external_task.ExternalTaskSensor` instead
+AIR302_names.py:93:22: AIR302 `airflow.sensors.external_task_sensor.ExternalTaskSensor` is removed in Airflow 3.0.
    |
 91 | BaseSensorOperator
 92 | DateTimeSensor
@@ -443,9 +436,9 @@ AIR302_names.py:93:22: AIR302 `airflow.sensors.external_task_sensor.ExternalTask
    |                      ^^^^^^^^^^^^^^^^^^ AIR302
 94 | TimeDeltaSensor
    |
-   = help: Replace deprecated keywords in Airflow 3.0
+   = help: Use `airflow.sensors.external_task.ExternalTaskSensor` instead.
 
-AIR302_names.py:93:42: AIR302 `airflow.sensors.external_task_sensor.ExternalTaskSensorLink` is removed in Airflow 3.0; use `airflow.sensors.external_task.ExternalTaskSensorLink` instead
+AIR302_names.py:93:42: AIR302 `airflow.sensors.external_task_sensor.ExternalTaskSensorLink` is removed in Airflow 3.0.
    |
 91 | BaseSensorOperator
 92 | DateTimeSensor
@@ -453,9 +446,9 @@ AIR302_names.py:93:42: AIR302 `airflow.sensors.external_task_sensor.ExternalTask
    |                                          ^^^^^^^^^^^^^^^^^^^^^^ AIR302
 94 | TimeDeltaSensor
    |
-   = help: Replace deprecated keywords in Airflow 3.0
+   = help: Use `airflow.sensors.external_task.ExternalTaskSensorLink` instead.
 
-AIR302_names.py:94:1: AIR302 `airflow.sensors.time_delta_sensor.TimeDeltaSensor` is removed in Airflow 3.0; use `airflow.sensors.time_delta.TimeDeltaSensor` instead
+AIR302_names.py:94:1: AIR302 `airflow.sensors.time_delta_sensor.TimeDeltaSensor` is removed in Airflow 3.0.
    |
 92 | DateTimeSensor
 93 | (ExternalTaskMarker, ExternalTaskSensor, ExternalTaskSensorLink)
@@ -464,7 +457,7 @@ AIR302_names.py:94:1: AIR302 `airflow.sensors.time_delta_sensor.TimeDeltaSensor`
 95 | 
 96 | apply_defaults
    |
-   = help: Replace deprecated keywords in Airflow 3.0
+   = help: Use `airflow.sensors.time_delta.TimeDeltaSensor` instead.
 
 AIR302_names.py:96:1: AIR302 `airflow.utils.decorators.apply_defaults` is removed in Airflow 3.0; `apply_defaults` is now unconditionally done and can be safely removed.
    |
@@ -475,7 +468,6 @@ AIR302_names.py:96:1: AIR302 `airflow.utils.decorators.apply_defaults` is remove
 97 | 
 98 | TemporaryDirectory
    |
-   = help: Replace deprecated keywords in Airflow 3.0
 
 AIR302_names.py:98:1: AIR302 `airflow.utils.file.TemporaryDirectory` is removed in Airflow 3.0
    |
@@ -485,9 +477,8 @@ AIR302_names.py:98:1: AIR302 `airflow.utils.file.TemporaryDirectory` is removed 
    | ^^^^^^^^^^^^^^^^^^ AIR302
 99 | mkdirs
    |
-   = help: Replace deprecated keywords in Airflow 3.0
 
-AIR302_names.py:99:1: AIR302 `airflow.utils.file.mkdirs` is removed in Airflow 3.0; use `pendulum.today('UTC').add(days=-N, ...)` instead
+AIR302_names.py:99:1: AIR302 `airflow.utils.file.mkdirs` is removed in Airflow 3.0.
     |
  98 | TemporaryDirectory
  99 | mkdirs
@@ -495,9 +486,9 @@ AIR302_names.py:99:1: AIR302 `airflow.utils.file.mkdirs` is removed in Airflow 3
 100 | 
 101 | chain
     |
-    = help: Replace deprecated keywords in Airflow 3.0
+    = help: Use `pendulum.today('UTC').add(days=-N, ...)` instead.
 
-AIR302_names.py:101:1: AIR302 `airflow.utils.helpers.chain` is removed in Airflow 3.0; use `airflow.models.baseoperator.chain` instead
+AIR302_names.py:101:1: AIR302 `airflow.utils.helpers.chain` is removed in Airflow 3.0.
     |
  99 | mkdirs
 100 | 
@@ -505,9 +496,9 @@ AIR302_names.py:101:1: AIR302 `airflow.utils.helpers.chain` is removed in Airflo
     | ^^^^^ AIR302
 102 | cross_downstream
     |
-    = help: Replace deprecated keywords in Airflow 3.0
+    = help: Use `airflow.models.baseoperator.chain` instead.
 
-AIR302_names.py:102:1: AIR302 `airflow.utils.helpers.cross_downstream` is removed in Airflow 3.0; use `airflow.models.baseoperator.cross_downstream` instead
+AIR302_names.py:102:1: AIR302 `airflow.utils.helpers.cross_downstream` is removed in Airflow 3.0.
     |
 101 | chain
 102 | cross_downstream
@@ -515,7 +506,7 @@ AIR302_names.py:102:1: AIR302 `airflow.utils.helpers.cross_downstream` is remove
 103 | 
 104 | SHUTDOWN
     |
-    = help: Replace deprecated keywords in Airflow 3.0
+    = help: Use `airflow.models.baseoperator.cross_downstream` instead.
 
 AIR302_names.py:104:1: AIR302 `airflow.utils.state.SHUTDOWN` is removed in Airflow 3.0
     |
@@ -525,7 +516,6 @@ AIR302_names.py:104:1: AIR302 `airflow.utils.state.SHUTDOWN` is removed in Airfl
     | ^^^^^^^^ AIR302
 105 | terminating_states
     |
-    = help: Replace deprecated keywords in Airflow 3.0
 
 AIR302_names.py:105:1: AIR302 `airflow.utils.state.terminating_states` is removed in Airflow 3.0
     |
@@ -535,7 +525,6 @@ AIR302_names.py:105:1: AIR302 `airflow.utils.state.terminating_states` is remove
 106 | 
 107 | TriggerRule.DUMMY
     |
-    = help: Replace deprecated keywords in Airflow 3.0
 
 AIR302_names.py:107:13: AIR302 `airflow.utils.trigger_rule.TriggerRule.DUMMY` is removed in Airflow 3.0
     |
@@ -545,7 +534,6 @@ AIR302_names.py:107:13: AIR302 `airflow.utils.trigger_rule.TriggerRule.DUMMY` is
     |             ^^^^^ AIR302
 108 | TriggerRule.NONE_FAILED_OR_SKIPPED
     |
-    = help: Replace deprecated keywords in Airflow 3.0
 
 AIR302_names.py:108:13: AIR302 `airflow.utils.trigger_rule.TriggerRule.NONE_FAILED_OR_SKIPPED` is removed in Airflow 3.0
     |
@@ -555,7 +543,6 @@ AIR302_names.py:108:13: AIR302 `airflow.utils.trigger_rule.TriggerRule.NONE_FAIL
 109 | 
 110 | test_cycle
     |
-    = help: Replace deprecated keywords in Airflow 3.0
 
 AIR302_names.py:110:1: AIR302 `airflow.utils.dag_cycle_tester.test_cycle` is removed in Airflow 3.0
     |
@@ -566,9 +553,8 @@ AIR302_names.py:110:1: AIR302 `airflow.utils.dag_cycle_tester.test_cycle` is rem
 111 | 
 112 | has_access
     |
-    = help: Replace deprecated keywords in Airflow 3.0
 
-AIR302_names.py:112:1: AIR302 `airflow.www.auth.has_access` is removed in Airflow 3.0; use `airflow.www.auth.has_access_*` instead
+AIR302_names.py:112:1: AIR302 `airflow.www.auth.has_access` is removed in Airflow 3.0.
     |
 110 | test_cycle
 111 | 
@@ -576,20 +562,20 @@ AIR302_names.py:112:1: AIR302 `airflow.www.auth.has_access` is removed in Airflo
     | ^^^^^^^^^^ AIR302
 113 | get_sensitive_variables_fields, should_hide_value_for_key
     |
-    = help: Replace deprecated keywords in Airflow 3.0
+    = help: Use `airflow.www.auth.has_access_*` instead.
 
-AIR302_names.py:113:1: AIR302 `airflow.www.utils.get_sensitive_variables_fields` is removed in Airflow 3.0; use `airflow.utils.log.secrets_masker.get_sensitive_variables_fields` instead
+AIR302_names.py:113:1: AIR302 `airflow.www.utils.get_sensitive_variables_fields` is removed in Airflow 3.0.
     |
 112 | has_access
 113 | get_sensitive_variables_fields, should_hide_value_for_key
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
     |
-    = help: Replace deprecated keywords in Airflow 3.0
+    = help: Use `airflow.utils.log.secrets_masker.get_sensitive_variables_fields` instead.
 
-AIR302_names.py:113:33: AIR302 `airflow.www.utils.should_hide_value_for_key` is removed in Airflow 3.0; use `airflow.utils.log.secrets_masker.should_hide_value_for_key` instead
+AIR302_names.py:113:33: AIR302 `airflow.www.utils.should_hide_value_for_key` is removed in Airflow 3.0.
     |
 112 | has_access
 113 | get_sensitive_variables_fields, should_hide_value_for_key
     |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
     |
-    = help: Replace deprecated keywords in Airflow 3.0
+    = help: Use `airflow.utils.log.secrets_masker.should_hide_value_for_key` instead.

--- a/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_names.py.snap
+++ b/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_names.py.snap
@@ -2,7 +2,7 @@
 source: crates/ruff_linter/src/rules/airflow/mod.rs
 snapshot_kind: text
 ---
-AIR302_names.py:52:1: AIR302 `airflow.PY36` is removed in Airflow 3.0.
+AIR302_names.py:52:1: AIR302 `airflow.PY36` is removed in Airflow 3.0
    |
 50 | from airflow.www.utils import get_sensitive_variables_fields, should_hide_value_for_key
 51 | 
@@ -11,9 +11,9 @@ AIR302_names.py:52:1: AIR302 `airflow.PY36` is removed in Airflow 3.0.
 53 | 
 54 | AWSAthenaHook
    |
-   = help: Use `sys.version_info` instead.
+   = help: Use `sys.version_info` instead
 
-AIR302_names.py:52:7: AIR302 `airflow.PY37` is removed in Airflow 3.0.
+AIR302_names.py:52:7: AIR302 `airflow.PY37` is removed in Airflow 3.0
    |
 50 | from airflow.www.utils import get_sensitive_variables_fields, should_hide_value_for_key
 51 | 
@@ -22,9 +22,9 @@ AIR302_names.py:52:7: AIR302 `airflow.PY37` is removed in Airflow 3.0.
 53 | 
 54 | AWSAthenaHook
    |
-   = help: Use `sys.version_info` instead.
+   = help: Use `sys.version_info` instead
 
-AIR302_names.py:52:13: AIR302 `airflow.PY38` is removed in Airflow 3.0.
+AIR302_names.py:52:13: AIR302 `airflow.PY38` is removed in Airflow 3.0
    |
 50 | from airflow.www.utils import get_sensitive_variables_fields, should_hide_value_for_key
 51 | 
@@ -33,9 +33,9 @@ AIR302_names.py:52:13: AIR302 `airflow.PY38` is removed in Airflow 3.0.
 53 | 
 54 | AWSAthenaHook
    |
-   = help: Use `sys.version_info` instead.
+   = help: Use `sys.version_info` instead
 
-AIR302_names.py:52:19: AIR302 `airflow.PY39` is removed in Airflow 3.0.
+AIR302_names.py:52:19: AIR302 `airflow.PY39` is removed in Airflow 3.0
    |
 50 | from airflow.www.utils import get_sensitive_variables_fields, should_hide_value_for_key
 51 | 
@@ -44,9 +44,9 @@ AIR302_names.py:52:19: AIR302 `airflow.PY39` is removed in Airflow 3.0.
 53 | 
 54 | AWSAthenaHook
    |
-   = help: Use `sys.version_info` instead.
+   = help: Use `sys.version_info` instead
 
-AIR302_names.py:52:25: AIR302 `airflow.PY310` is removed in Airflow 3.0.
+AIR302_names.py:52:25: AIR302 `airflow.PY310` is removed in Airflow 3.0
    |
 50 | from airflow.www.utils import get_sensitive_variables_fields, should_hide_value_for_key
 51 | 
@@ -55,9 +55,9 @@ AIR302_names.py:52:25: AIR302 `airflow.PY310` is removed in Airflow 3.0.
 53 | 
 54 | AWSAthenaHook
    |
-   = help: Use `sys.version_info` instead.
+   = help: Use `sys.version_info` instead
 
-AIR302_names.py:52:32: AIR302 `airflow.PY311` is removed in Airflow 3.0.
+AIR302_names.py:52:32: AIR302 `airflow.PY311` is removed in Airflow 3.0
    |
 50 | from airflow.www.utils import get_sensitive_variables_fields, should_hide_value_for_key
 51 | 
@@ -66,9 +66,9 @@ AIR302_names.py:52:32: AIR302 `airflow.PY311` is removed in Airflow 3.0.
 53 | 
 54 | AWSAthenaHook
    |
-   = help: Use `sys.version_info` instead.
+   = help: Use `sys.version_info` instead
 
-AIR302_names.py:52:39: AIR302 `airflow.PY312` is removed in Airflow 3.0.
+AIR302_names.py:52:39: AIR302 `airflow.PY312` is removed in Airflow 3.0
    |
 50 | from airflow.www.utils import get_sensitive_variables_fields, should_hide_value_for_key
 51 | 
@@ -77,7 +77,7 @@ AIR302_names.py:52:39: AIR302 `airflow.PY312` is removed in Airflow 3.0.
 53 | 
 54 | AWSAthenaHook
    |
-   = help: Use `sys.version_info` instead.
+   = help: Use `sys.version_info` instead
 
 AIR302_names.py:54:1: AIR302 `airflow.contrib.aws_athena_hook.AWSAthenaHook` is removed in Airflow 3.0
    |
@@ -97,7 +97,7 @@ AIR302_names.py:55:1: AIR302 `airflow.triggers.external_task.TaskStateTrigger` i
 57 | requires_access
    |
 
-AIR302_names.py:57:1: AIR302 `airflow.api_connexion.security.requires_access` is removed in Airflow 3.0.
+AIR302_names.py:57:1: AIR302 `airflow.api_connexion.security.requires_access` is removed in Airflow 3.0
    |
 55 | TaskStateTrigger
 56 | 
@@ -106,9 +106,9 @@ AIR302_names.py:57:1: AIR302 `airflow.api_connexion.security.requires_access` is
 58 | 
 59 | AllowListValidator
    |
-   = help: Use `airflow.api_connexion.security.requires_access_*` instead.
+   = help: Use `airflow.api_connexion.security.requires_access_*` instead
 
-AIR302_names.py:59:1: AIR302 `airflow.metrics.validators.AllowListValidator` is removed in Airflow 3.0.
+AIR302_names.py:59:1: AIR302 `airflow.metrics.validators.AllowListValidator` is removed in Airflow 3.0
    |
 57 | requires_access
 58 | 
@@ -116,9 +116,9 @@ AIR302_names.py:59:1: AIR302 `airflow.metrics.validators.AllowListValidator` is 
    | ^^^^^^^^^^^^^^^^^^ AIR302
 60 | BlockListValidator
    |
-   = help: Use `airflow.metrics.validators.PatternAllowListValidator` instead.
+   = help: Use `airflow.metrics.validators.PatternAllowListValidator` instead
 
-AIR302_names.py:60:1: AIR302 `airflow.metrics.validators.BlockListValidator` is removed in Airflow 3.0.
+AIR302_names.py:60:1: AIR302 `airflow.metrics.validators.BlockListValidator` is removed in Airflow 3.0
    |
 59 | AllowListValidator
 60 | BlockListValidator
@@ -126,7 +126,7 @@ AIR302_names.py:60:1: AIR302 `airflow.metrics.validators.BlockListValidator` is 
 61 | 
 62 | SubDagOperator
    |
-   = help: Use `airflow.metrics.validators.PatternBlockListValidator` instead.
+   = help: Use `airflow.metrics.validators.PatternBlockListValidator` instead
 
 AIR302_names.py:62:1: AIR302 `airflow.operators.subdag.SubDagOperator` is removed in Airflow 3.0
    |
@@ -138,7 +138,7 @@ AIR302_names.py:62:1: AIR302 `airflow.operators.subdag.SubDagOperator` is remove
 64 | dates.date_range
    |
 
-AIR302_names.py:64:7: AIR302 `airflow.utils.dates.date_range` is removed in Airflow 3.0.
+AIR302_names.py:64:7: AIR302 `airflow.utils.dates.date_range` is removed in Airflow 3.0
    |
 62 | SubDagOperator
 63 | 
@@ -146,9 +146,9 @@ AIR302_names.py:64:7: AIR302 `airflow.utils.dates.date_range` is removed in Airf
    |       ^^^^^^^^^^ AIR302
 65 | dates.days_ago
    |
-   = help: Use `airflow.timetables.` instead.
+   = help: Use `airflow.timetables.` instead
 
-AIR302_names.py:65:7: AIR302 `airflow.utils.dates.days_ago` is removed in Airflow 3.0.
+AIR302_names.py:65:7: AIR302 `airflow.utils.dates.days_ago` is removed in Airflow 3.0
    |
 64 | dates.date_range
 65 | dates.days_ago
@@ -156,9 +156,9 @@ AIR302_names.py:65:7: AIR302 `airflow.utils.dates.days_ago` is removed in Airflo
 66 | 
 67 | date_range
    |
-   = help: Use `pendulum.today('UTC').add(days=-N, ...)` instead.
+   = help: Use `pendulum.today('UTC').add(days=-N, ...)` instead
 
-AIR302_names.py:67:1: AIR302 `airflow.utils.dates.date_range` is removed in Airflow 3.0.
+AIR302_names.py:67:1: AIR302 `airflow.utils.dates.date_range` is removed in Airflow 3.0
    |
 65 | dates.days_ago
 66 | 
@@ -167,9 +167,9 @@ AIR302_names.py:67:1: AIR302 `airflow.utils.dates.date_range` is removed in Airf
 68 | days_ago
 69 | parse_execution_date
    |
-   = help: Use `airflow.timetables.` instead.
+   = help: Use `airflow.timetables.` instead
 
-AIR302_names.py:68:1: AIR302 `airflow.utils.dates.days_ago` is removed in Airflow 3.0.
+AIR302_names.py:68:1: AIR302 `airflow.utils.dates.days_ago` is removed in Airflow 3.0
    |
 67 | date_range
 68 | days_ago
@@ -177,7 +177,7 @@ AIR302_names.py:68:1: AIR302 `airflow.utils.dates.days_ago` is removed in Airflo
 69 | parse_execution_date
 70 | round_time
    |
-   = help: Use `pendulum.today('UTC').add(days=-N, ...)` instead.
+   = help: Use `pendulum.today('UTC').add(days=-N, ...)` instead
 
 AIR302_names.py:69:1: AIR302 `airflow.utils.dates.parse_execution_date` is removed in Airflow 3.0
    |
@@ -216,7 +216,7 @@ AIR302_names.py:72:1: AIR302 `airflow.utils.dates.infer_time_unit` is removed in
    | ^^^^^^^^^^^^^^^ AIR302
    |
 
-AIR302_names.py:79:1: AIR302 `airflow.configuration.get` is removed in Airflow 3.0.
+AIR302_names.py:79:1: AIR302 `airflow.configuration.get` is removed in Airflow 3.0
    |
 77 | dates.datetime_to_nano
 78 | 
@@ -225,9 +225,9 @@ AIR302_names.py:79:1: AIR302 `airflow.configuration.get` is removed in Airflow 3
 80 | 
 81 | get_connection, load_connections
    |
-   = help: Use `airflow.configuration.conf.get` instead.
+   = help: Use `airflow.configuration.conf.get` instead
 
-AIR302_names.py:79:6: AIR302 `airflow.configuration.getboolean` is removed in Airflow 3.0.
+AIR302_names.py:79:6: AIR302 `airflow.configuration.getboolean` is removed in Airflow 3.0
    |
 77 | dates.datetime_to_nano
 78 | 
@@ -236,9 +236,9 @@ AIR302_names.py:79:6: AIR302 `airflow.configuration.getboolean` is removed in Ai
 80 | 
 81 | get_connection, load_connections
    |
-   = help: Use `airflow.configuration.conf.getboolean` instead.
+   = help: Use `airflow.configuration.conf.getboolean` instead
 
-AIR302_names.py:79:18: AIR302 `airflow.configuration.getfloat` is removed in Airflow 3.0.
+AIR302_names.py:79:18: AIR302 `airflow.configuration.getfloat` is removed in Airflow 3.0
    |
 77 | dates.datetime_to_nano
 78 | 
@@ -247,9 +247,9 @@ AIR302_names.py:79:18: AIR302 `airflow.configuration.getfloat` is removed in Air
 80 | 
 81 | get_connection, load_connections
    |
-   = help: Use `airflow.configuration.conf.getfloat` instead.
+   = help: Use `airflow.configuration.conf.getfloat` instead
 
-AIR302_names.py:79:28: AIR302 `airflow.configuration.getint` is removed in Airflow 3.0.
+AIR302_names.py:79:28: AIR302 `airflow.configuration.getint` is removed in Airflow 3.0
    |
 77 | dates.datetime_to_nano
 78 | 
@@ -258,9 +258,9 @@ AIR302_names.py:79:28: AIR302 `airflow.configuration.getint` is removed in Airfl
 80 | 
 81 | get_connection, load_connections
    |
-   = help: Use `airflow.configuration.conf.getint` instead.
+   = help: Use `airflow.configuration.conf.getint` instead
 
-AIR302_names.py:79:36: AIR302 `airflow.configuration.has_option` is removed in Airflow 3.0.
+AIR302_names.py:79:36: AIR302 `airflow.configuration.has_option` is removed in Airflow 3.0
    |
 77 | dates.datetime_to_nano
 78 | 
@@ -269,9 +269,9 @@ AIR302_names.py:79:36: AIR302 `airflow.configuration.has_option` is removed in A
 80 | 
 81 | get_connection, load_connections
    |
-   = help: Use `airflow.configuration.conf.has_option` instead.
+   = help: Use `airflow.configuration.conf.has_option` instead
 
-AIR302_names.py:79:48: AIR302 `airflow.configuration.remove_option` is removed in Airflow 3.0.
+AIR302_names.py:79:48: AIR302 `airflow.configuration.remove_option` is removed in Airflow 3.0
    |
 77 | dates.datetime_to_nano
 78 | 
@@ -280,9 +280,9 @@ AIR302_names.py:79:48: AIR302 `airflow.configuration.remove_option` is removed i
 80 | 
 81 | get_connection, load_connections
    |
-   = help: Use `airflow.configuration.conf.remove_option` instead.
+   = help: Use `airflow.configuration.conf.remove_option` instead
 
-AIR302_names.py:79:63: AIR302 `airflow.configuration.as_dict` is removed in Airflow 3.0.
+AIR302_names.py:79:63: AIR302 `airflow.configuration.as_dict` is removed in Airflow 3.0
    |
 77 | dates.datetime_to_nano
 78 | 
@@ -291,9 +291,9 @@ AIR302_names.py:79:63: AIR302 `airflow.configuration.as_dict` is removed in Airf
 80 | 
 81 | get_connection, load_connections
    |
-   = help: Use `airflow.configuration.conf.as_dict` instead.
+   = help: Use `airflow.configuration.conf.as_dict` instead
 
-AIR302_names.py:79:72: AIR302 `airflow.configuration.set` is removed in Airflow 3.0.
+AIR302_names.py:79:72: AIR302 `airflow.configuration.set` is removed in Airflow 3.0
    |
 77 | dates.datetime_to_nano
 78 | 
@@ -302,36 +302,36 @@ AIR302_names.py:79:72: AIR302 `airflow.configuration.set` is removed in Airflow 
 80 | 
 81 | get_connection, load_connections
    |
-   = help: Use `airflow.configuration.conf.set` instead.
+   = help: Use `airflow.configuration.conf.set` instead
 
-AIR302_names.py:81:1: AIR302 `airflow.secrets.local_filesystem.get_connection` is removed in Airflow 3.0.
+AIR302_names.py:81:1: AIR302 `airflow.secrets.local_filesystem.get_connection` is removed in Airflow 3.0
    |
 79 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
 80 | 
 81 | get_connection, load_connections
    | ^^^^^^^^^^^^^^ AIR302
    |
-   = help: Use `airflow.secrets.local_filesystem.load_connections_dict` instead.
+   = help: Use `airflow.secrets.local_filesystem.load_connections_dict` instead
 
-AIR302_names.py:81:17: AIR302 `airflow.secrets.local_filesystem.load_connections` is removed in Airflow 3.0.
+AIR302_names.py:81:17: AIR302 `airflow.secrets.local_filesystem.load_connections` is removed in Airflow 3.0
    |
 79 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
 80 | 
 81 | get_connection, load_connections
    |                 ^^^^^^^^^^^^^^^^ AIR302
    |
-   = help: Use `airflow.secrets.local_filesystem.load_connections_dict` instead.
+   = help: Use `airflow.secrets.local_filesystem.load_connections_dict` instead
 
-AIR302_names.py:84:1: AIR302 `airflow.sensors.external_task_sensor.ExternalTaskSensorLink` is removed in Airflow 3.0.
+AIR302_names.py:84:1: AIR302 `airflow.sensors.external_task_sensor.ExternalTaskSensorLink` is removed in Airflow 3.0
    |
 84 | ExternalTaskSensorLink
    | ^^^^^^^^^^^^^^^^^^^^^^ AIR302
 85 | BashOperator
 86 | BaseBranchOperator
    |
-   = help: Use `airflow.sensors.external_task.ExternalTaskSensorLink` instead.
+   = help: Use `airflow.sensors.external_task.ExternalTaskSensorLink` instead
 
-AIR302_names.py:85:1: AIR302 `airflow.operators.bash_operator.BashOperator` is removed in Airflow 3.0.
+AIR302_names.py:85:1: AIR302 `airflow.operators.bash_operator.BashOperator` is removed in Airflow 3.0
    |
 84 | ExternalTaskSensorLink
 85 | BashOperator
@@ -339,9 +339,9 @@ AIR302_names.py:85:1: AIR302 `airflow.operators.bash_operator.BashOperator` is r
 86 | BaseBranchOperator
 87 | EmptyOperator, DummyOperator
    |
-   = help: Use `airflow.operators.bash.BashOperator` instead.
+   = help: Use `airflow.operators.bash.BashOperator` instead
 
-AIR302_names.py:86:1: AIR302 `airflow.operators.branch_operator.BaseBranchOperator` is removed in Airflow 3.0.
+AIR302_names.py:86:1: AIR302 `airflow.operators.branch_operator.BaseBranchOperator` is removed in Airflow 3.0
    |
 84 | ExternalTaskSensorLink
 85 | BashOperator
@@ -350,9 +350,9 @@ AIR302_names.py:86:1: AIR302 `airflow.operators.branch_operator.BaseBranchOperat
 87 | EmptyOperator, DummyOperator
 88 | dummy_operator.EmptyOperator
    |
-   = help: Use `airflow.operators.branch.BaseBranchOperator` instead.
+   = help: Use `airflow.operators.branch.BaseBranchOperator` instead
 
-AIR302_names.py:87:16: AIR302 `airflow.operators.dummy.DummyOperator` is removed in Airflow 3.0.
+AIR302_names.py:87:16: AIR302 `airflow.operators.dummy.DummyOperator` is removed in Airflow 3.0
    |
 85 | BashOperator
 86 | BaseBranchOperator
@@ -361,9 +361,9 @@ AIR302_names.py:87:16: AIR302 `airflow.operators.dummy.DummyOperator` is removed
 88 | dummy_operator.EmptyOperator
 89 | dummy_operator.DummyOperator
    |
-   = help: Use `airflow.operators.empty.EmptyOperator` instead.
+   = help: Use `airflow.operators.empty.EmptyOperator` instead
 
-AIR302_names.py:88:16: AIR302 `airflow.operators.dummy_operator.EmptyOperator` is removed in Airflow 3.0.
+AIR302_names.py:88:16: AIR302 `airflow.operators.dummy_operator.EmptyOperator` is removed in Airflow 3.0
    |
 86 | BaseBranchOperator
 87 | EmptyOperator, DummyOperator
@@ -372,9 +372,9 @@ AIR302_names.py:88:16: AIR302 `airflow.operators.dummy_operator.EmptyOperator` i
 89 | dummy_operator.DummyOperator
 90 | EmailOperator
    |
-   = help: Use `airflow.operators.empty.EmptyOperator` instead.
+   = help: Use `airflow.operators.empty.EmptyOperator` instead
 
-AIR302_names.py:89:16: AIR302 `airflow.operators.dummy_operator.DummyOperator` is removed in Airflow 3.0.
+AIR302_names.py:89:16: AIR302 `airflow.operators.dummy_operator.DummyOperator` is removed in Airflow 3.0
    |
 87 | EmptyOperator, DummyOperator
 88 | dummy_operator.EmptyOperator
@@ -383,9 +383,9 @@ AIR302_names.py:89:16: AIR302 `airflow.operators.dummy_operator.DummyOperator` i
 90 | EmailOperator
 91 | BaseSensorOperator
    |
-   = help: Use `airflow.operators.empty.EmptyOperator` instead.
+   = help: Use `airflow.operators.empty.EmptyOperator` instead
 
-AIR302_names.py:90:1: AIR302 `airflow.operators.email_operator.EmailOperator` is removed in Airflow 3.0.
+AIR302_names.py:90:1: AIR302 `airflow.operators.email_operator.EmailOperator` is removed in Airflow 3.0
    |
 88 | dummy_operator.EmptyOperator
 89 | dummy_operator.DummyOperator
@@ -394,9 +394,9 @@ AIR302_names.py:90:1: AIR302 `airflow.operators.email_operator.EmailOperator` is
 91 | BaseSensorOperator
 92 | DateTimeSensor
    |
-   = help: Use `airflow.operators.email.EmailOperator` instead.
+   = help: Use `airflow.operators.email.EmailOperator` instead
 
-AIR302_names.py:91:1: AIR302 `airflow.sensors.base_sensor_operator.BaseSensorOperator` is removed in Airflow 3.0.
+AIR302_names.py:91:1: AIR302 `airflow.sensors.base_sensor_operator.BaseSensorOperator` is removed in Airflow 3.0
    |
 89 | dummy_operator.DummyOperator
 90 | EmailOperator
@@ -405,9 +405,9 @@ AIR302_names.py:91:1: AIR302 `airflow.sensors.base_sensor_operator.BaseSensorOpe
 92 | DateTimeSensor
 93 | (ExternalTaskMarker, ExternalTaskSensor, ExternalTaskSensorLink)
    |
-   = help: Use `airflow.sensors.base.BaseSensorOperator` instead.
+   = help: Use `airflow.sensors.base.BaseSensorOperator` instead
 
-AIR302_names.py:92:1: AIR302 `airflow.sensors.date_time_sensor.DateTimeSensor` is removed in Airflow 3.0.
+AIR302_names.py:92:1: AIR302 `airflow.sensors.date_time_sensor.DateTimeSensor` is removed in Airflow 3.0
    |
 90 | EmailOperator
 91 | BaseSensorOperator
@@ -416,9 +416,9 @@ AIR302_names.py:92:1: AIR302 `airflow.sensors.date_time_sensor.DateTimeSensor` i
 93 | (ExternalTaskMarker, ExternalTaskSensor, ExternalTaskSensorLink)
 94 | TimeDeltaSensor
    |
-   = help: Use `airflow.sensors.date_time.DateTimeSensor` instead.
+   = help: Use `airflow.sensors.date_time.DateTimeSensor` instead
 
-AIR302_names.py:93:2: AIR302 `airflow.sensors.external_task_sensor.ExternalTaskMarker` is removed in Airflow 3.0.
+AIR302_names.py:93:2: AIR302 `airflow.sensors.external_task_sensor.ExternalTaskMarker` is removed in Airflow 3.0
    |
 91 | BaseSensorOperator
 92 | DateTimeSensor
@@ -426,9 +426,9 @@ AIR302_names.py:93:2: AIR302 `airflow.sensors.external_task_sensor.ExternalTaskM
    |  ^^^^^^^^^^^^^^^^^^ AIR302
 94 | TimeDeltaSensor
    |
-   = help: Use `airflow.sensors.external_task.ExternalTaskMarker` instead.
+   = help: Use `airflow.sensors.external_task.ExternalTaskMarker` instead
 
-AIR302_names.py:93:22: AIR302 `airflow.sensors.external_task_sensor.ExternalTaskSensor` is removed in Airflow 3.0.
+AIR302_names.py:93:22: AIR302 `airflow.sensors.external_task_sensor.ExternalTaskSensor` is removed in Airflow 3.0
    |
 91 | BaseSensorOperator
 92 | DateTimeSensor
@@ -436,9 +436,9 @@ AIR302_names.py:93:22: AIR302 `airflow.sensors.external_task_sensor.ExternalTask
    |                      ^^^^^^^^^^^^^^^^^^ AIR302
 94 | TimeDeltaSensor
    |
-   = help: Use `airflow.sensors.external_task.ExternalTaskSensor` instead.
+   = help: Use `airflow.sensors.external_task.ExternalTaskSensor` instead
 
-AIR302_names.py:93:42: AIR302 `airflow.sensors.external_task_sensor.ExternalTaskSensorLink` is removed in Airflow 3.0.
+AIR302_names.py:93:42: AIR302 `airflow.sensors.external_task_sensor.ExternalTaskSensorLink` is removed in Airflow 3.0
    |
 91 | BaseSensorOperator
 92 | DateTimeSensor
@@ -446,9 +446,9 @@ AIR302_names.py:93:42: AIR302 `airflow.sensors.external_task_sensor.ExternalTask
    |                                          ^^^^^^^^^^^^^^^^^^^^^^ AIR302
 94 | TimeDeltaSensor
    |
-   = help: Use `airflow.sensors.external_task.ExternalTaskSensorLink` instead.
+   = help: Use `airflow.sensors.external_task.ExternalTaskSensorLink` instead
 
-AIR302_names.py:94:1: AIR302 `airflow.sensors.time_delta_sensor.TimeDeltaSensor` is removed in Airflow 3.0.
+AIR302_names.py:94:1: AIR302 `airflow.sensors.time_delta_sensor.TimeDeltaSensor` is removed in Airflow 3.0
    |
 92 | DateTimeSensor
 93 | (ExternalTaskMarker, ExternalTaskSensor, ExternalTaskSensorLink)
@@ -457,7 +457,7 @@ AIR302_names.py:94:1: AIR302 `airflow.sensors.time_delta_sensor.TimeDeltaSensor`
 95 | 
 96 | apply_defaults
    |
-   = help: Use `airflow.sensors.time_delta.TimeDeltaSensor` instead.
+   = help: Use `airflow.sensors.time_delta.TimeDeltaSensor` instead
 
 AIR302_names.py:96:1: AIR302 `airflow.utils.decorators.apply_defaults` is removed in Airflow 3.0; `apply_defaults` is now unconditionally done and can be safely removed.
    |
@@ -478,7 +478,7 @@ AIR302_names.py:98:1: AIR302 `airflow.utils.file.TemporaryDirectory` is removed 
 99 | mkdirs
    |
 
-AIR302_names.py:99:1: AIR302 `airflow.utils.file.mkdirs` is removed in Airflow 3.0.
+AIR302_names.py:99:1: AIR302 `airflow.utils.file.mkdirs` is removed in Airflow 3.0
     |
  98 | TemporaryDirectory
  99 | mkdirs
@@ -486,9 +486,9 @@ AIR302_names.py:99:1: AIR302 `airflow.utils.file.mkdirs` is removed in Airflow 3
 100 | 
 101 | chain
     |
-    = help: Use `pendulum.today('UTC').add(days=-N, ...)` instead.
+    = help: Use `pendulum.today('UTC').add(days=-N, ...)` instead
 
-AIR302_names.py:101:1: AIR302 `airflow.utils.helpers.chain` is removed in Airflow 3.0.
+AIR302_names.py:101:1: AIR302 `airflow.utils.helpers.chain` is removed in Airflow 3.0
     |
  99 | mkdirs
 100 | 
@@ -496,9 +496,9 @@ AIR302_names.py:101:1: AIR302 `airflow.utils.helpers.chain` is removed in Airflo
     | ^^^^^ AIR302
 102 | cross_downstream
     |
-    = help: Use `airflow.models.baseoperator.chain` instead.
+    = help: Use `airflow.models.baseoperator.chain` instead
 
-AIR302_names.py:102:1: AIR302 `airflow.utils.helpers.cross_downstream` is removed in Airflow 3.0.
+AIR302_names.py:102:1: AIR302 `airflow.utils.helpers.cross_downstream` is removed in Airflow 3.0
     |
 101 | chain
 102 | cross_downstream
@@ -506,7 +506,7 @@ AIR302_names.py:102:1: AIR302 `airflow.utils.helpers.cross_downstream` is remove
 103 | 
 104 | SHUTDOWN
     |
-    = help: Use `airflow.models.baseoperator.cross_downstream` instead.
+    = help: Use `airflow.models.baseoperator.cross_downstream` instead
 
 AIR302_names.py:104:1: AIR302 `airflow.utils.state.SHUTDOWN` is removed in Airflow 3.0
     |
@@ -554,7 +554,7 @@ AIR302_names.py:110:1: AIR302 `airflow.utils.dag_cycle_tester.test_cycle` is rem
 112 | has_access
     |
 
-AIR302_names.py:112:1: AIR302 `airflow.www.auth.has_access` is removed in Airflow 3.0.
+AIR302_names.py:112:1: AIR302 `airflow.www.auth.has_access` is removed in Airflow 3.0
     |
 110 | test_cycle
 111 | 
@@ -562,20 +562,20 @@ AIR302_names.py:112:1: AIR302 `airflow.www.auth.has_access` is removed in Airflo
     | ^^^^^^^^^^ AIR302
 113 | get_sensitive_variables_fields, should_hide_value_for_key
     |
-    = help: Use `airflow.www.auth.has_access_*` instead.
+    = help: Use `airflow.www.auth.has_access_*` instead
 
-AIR302_names.py:113:1: AIR302 `airflow.www.utils.get_sensitive_variables_fields` is removed in Airflow 3.0.
+AIR302_names.py:113:1: AIR302 `airflow.www.utils.get_sensitive_variables_fields` is removed in Airflow 3.0
     |
 112 | has_access
 113 | get_sensitive_variables_fields, should_hide_value_for_key
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
     |
-    = help: Use `airflow.utils.log.secrets_masker.get_sensitive_variables_fields` instead.
+    = help: Use `airflow.utils.log.secrets_masker.get_sensitive_variables_fields` instead
 
-AIR302_names.py:113:33: AIR302 `airflow.www.utils.should_hide_value_for_key` is removed in Airflow 3.0.
+AIR302_names.py:113:33: AIR302 `airflow.www.utils.should_hide_value_for_key` is removed in Airflow 3.0
     |
 112 | has_access
 113 | get_sensitive_variables_fields, should_hide_value_for_key
     |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
     |
-    = help: Use `airflow.utils.log.secrets_masker.should_hide_value_for_key` instead.
+    = help: Use `airflow.utils.log.secrets_masker.should_hide_value_for_key` instead

--- a/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_names.py.snap
+++ b/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_names.py.snap
@@ -11,6 +11,7 @@ AIR302_names.py:52:1: AIR302 `airflow.PY36` is removed in Airflow 3.0; use `sys.
 53 | 
 54 | AWSAthenaHook
    |
+   = help: Replace deprecated keywords in Airflow 3.0
 
 AIR302_names.py:52:7: AIR302 `airflow.PY37` is removed in Airflow 3.0; use `sys.version_info` instead
    |
@@ -21,6 +22,7 @@ AIR302_names.py:52:7: AIR302 `airflow.PY37` is removed in Airflow 3.0; use `sys.
 53 | 
 54 | AWSAthenaHook
    |
+   = help: Replace deprecated keywords in Airflow 3.0
 
 AIR302_names.py:52:13: AIR302 `airflow.PY38` is removed in Airflow 3.0; use `sys.version_info` instead
    |
@@ -31,6 +33,7 @@ AIR302_names.py:52:13: AIR302 `airflow.PY38` is removed in Airflow 3.0; use `sys
 53 | 
 54 | AWSAthenaHook
    |
+   = help: Replace deprecated keywords in Airflow 3.0
 
 AIR302_names.py:52:19: AIR302 `airflow.PY39` is removed in Airflow 3.0; use `sys.version_info` instead
    |
@@ -41,6 +44,7 @@ AIR302_names.py:52:19: AIR302 `airflow.PY39` is removed in Airflow 3.0; use `sys
 53 | 
 54 | AWSAthenaHook
    |
+   = help: Replace deprecated keywords in Airflow 3.0
 
 AIR302_names.py:52:25: AIR302 `airflow.PY310` is removed in Airflow 3.0; use `sys.version_info` instead
    |
@@ -51,6 +55,7 @@ AIR302_names.py:52:25: AIR302 `airflow.PY310` is removed in Airflow 3.0; use `sy
 53 | 
 54 | AWSAthenaHook
    |
+   = help: Replace deprecated keywords in Airflow 3.0
 
 AIR302_names.py:52:32: AIR302 `airflow.PY311` is removed in Airflow 3.0; use `sys.version_info` instead
    |
@@ -61,6 +66,7 @@ AIR302_names.py:52:32: AIR302 `airflow.PY311` is removed in Airflow 3.0; use `sy
 53 | 
 54 | AWSAthenaHook
    |
+   = help: Replace deprecated keywords in Airflow 3.0
 
 AIR302_names.py:52:39: AIR302 `airflow.PY312` is removed in Airflow 3.0; use `sys.version_info` instead
    |
@@ -71,6 +77,7 @@ AIR302_names.py:52:39: AIR302 `airflow.PY312` is removed in Airflow 3.0; use `sy
 53 | 
 54 | AWSAthenaHook
    |
+   = help: Replace deprecated keywords in Airflow 3.0
 
 AIR302_names.py:54:1: AIR302 `airflow.contrib.aws_athena_hook.AWSAthenaHook` is removed in Airflow 3.0
    |
@@ -80,6 +87,7 @@ AIR302_names.py:54:1: AIR302 `airflow.contrib.aws_athena_hook.AWSAthenaHook` is 
    | ^^^^^^^^^^^^^ AIR302
 55 | TaskStateTrigger
    |
+   = help: Replace deprecated keywords in Airflow 3.0
 
 AIR302_names.py:55:1: AIR302 `airflow.triggers.external_task.TaskStateTrigger` is removed in Airflow 3.0
    |
@@ -89,6 +97,7 @@ AIR302_names.py:55:1: AIR302 `airflow.triggers.external_task.TaskStateTrigger` i
 56 | 
 57 | requires_access
    |
+   = help: Replace deprecated keywords in Airflow 3.0
 
 AIR302_names.py:57:1: AIR302 `airflow.api_connexion.security.requires_access` is removed in Airflow 3.0; use `airflow.api_connexion.security.requires_access_*` instead
    |
@@ -99,6 +108,7 @@ AIR302_names.py:57:1: AIR302 `airflow.api_connexion.security.requires_access` is
 58 | 
 59 | AllowListValidator
    |
+   = help: Replace deprecated keywords in Airflow 3.0
 
 AIR302_names.py:59:1: AIR302 `airflow.metrics.validators.AllowListValidator` is removed in Airflow 3.0; use `airflow.metrics.validators.PatternAllowListValidator` instead
    |
@@ -108,6 +118,7 @@ AIR302_names.py:59:1: AIR302 `airflow.metrics.validators.AllowListValidator` is 
    | ^^^^^^^^^^^^^^^^^^ AIR302
 60 | BlockListValidator
    |
+   = help: Replace deprecated keywords in Airflow 3.0
 
 AIR302_names.py:60:1: AIR302 `airflow.metrics.validators.BlockListValidator` is removed in Airflow 3.0; use `airflow.metrics.validators.PatternBlockListValidator` instead
    |
@@ -117,6 +128,7 @@ AIR302_names.py:60:1: AIR302 `airflow.metrics.validators.BlockListValidator` is 
 61 | 
 62 | SubDagOperator
    |
+   = help: Replace deprecated keywords in Airflow 3.0
 
 AIR302_names.py:62:1: AIR302 `airflow.operators.subdag.SubDagOperator` is removed in Airflow 3.0
    |
@@ -127,6 +139,7 @@ AIR302_names.py:62:1: AIR302 `airflow.operators.subdag.SubDagOperator` is remove
 63 | 
 64 | dates.date_range
    |
+   = help: Replace deprecated keywords in Airflow 3.0
 
 AIR302_names.py:64:7: AIR302 `airflow.utils.dates.date_range` is removed in Airflow 3.0; use `airflow.timetables.` instead
    |
@@ -136,6 +149,7 @@ AIR302_names.py:64:7: AIR302 `airflow.utils.dates.date_range` is removed in Airf
    |       ^^^^^^^^^^ AIR302
 65 | dates.days_ago
    |
+   = help: Replace deprecated keywords in Airflow 3.0
 
 AIR302_names.py:65:7: AIR302 `airflow.utils.dates.days_ago` is removed in Airflow 3.0; use `pendulum.today('UTC').add(days=-N, ...)` instead
    |
@@ -145,6 +159,7 @@ AIR302_names.py:65:7: AIR302 `airflow.utils.dates.days_ago` is removed in Airflo
 66 | 
 67 | date_range
    |
+   = help: Replace deprecated keywords in Airflow 3.0
 
 AIR302_names.py:67:1: AIR302 `airflow.utils.dates.date_range` is removed in Airflow 3.0; use `airflow.timetables.` instead
    |
@@ -155,6 +170,7 @@ AIR302_names.py:67:1: AIR302 `airflow.utils.dates.date_range` is removed in Airf
 68 | days_ago
 69 | parse_execution_date
    |
+   = help: Replace deprecated keywords in Airflow 3.0
 
 AIR302_names.py:68:1: AIR302 `airflow.utils.dates.days_ago` is removed in Airflow 3.0; use `pendulum.today('UTC').add(days=-N, ...)` instead
    |
@@ -164,6 +180,7 @@ AIR302_names.py:68:1: AIR302 `airflow.utils.dates.days_ago` is removed in Airflo
 69 | parse_execution_date
 70 | round_time
    |
+   = help: Replace deprecated keywords in Airflow 3.0
 
 AIR302_names.py:69:1: AIR302 `airflow.utils.dates.parse_execution_date` is removed in Airflow 3.0
    |
@@ -174,6 +191,7 @@ AIR302_names.py:69:1: AIR302 `airflow.utils.dates.parse_execution_date` is remov
 70 | round_time
 71 | scale_time_units
    |
+   = help: Replace deprecated keywords in Airflow 3.0
 
 AIR302_names.py:70:1: AIR302 `airflow.utils.dates.round_time` is removed in Airflow 3.0
    |
@@ -184,6 +202,7 @@ AIR302_names.py:70:1: AIR302 `airflow.utils.dates.round_time` is removed in Airf
 71 | scale_time_units
 72 | infer_time_unit
    |
+   = help: Replace deprecated keywords in Airflow 3.0
 
 AIR302_names.py:71:1: AIR302 `airflow.utils.dates.scale_time_units` is removed in Airflow 3.0
    |
@@ -193,6 +212,7 @@ AIR302_names.py:71:1: AIR302 `airflow.utils.dates.scale_time_units` is removed i
    | ^^^^^^^^^^^^^^^^ AIR302
 72 | infer_time_unit
    |
+   = help: Replace deprecated keywords in Airflow 3.0
 
 AIR302_names.py:72:1: AIR302 `airflow.utils.dates.infer_time_unit` is removed in Airflow 3.0
    |
@@ -201,6 +221,7 @@ AIR302_names.py:72:1: AIR302 `airflow.utils.dates.infer_time_unit` is removed in
 72 | infer_time_unit
    | ^^^^^^^^^^^^^^^ AIR302
    |
+   = help: Replace deprecated keywords in Airflow 3.0
 
 AIR302_names.py:79:1: AIR302 `airflow.configuration.get` is removed in Airflow 3.0; use `airflow.configuration.conf.get` instead
    |
@@ -211,6 +232,7 @@ AIR302_names.py:79:1: AIR302 `airflow.configuration.get` is removed in Airflow 3
 80 | 
 81 | get_connection, load_connections
    |
+   = help: Replace deprecated keywords in Airflow 3.0
 
 AIR302_names.py:79:6: AIR302 `airflow.configuration.getboolean` is removed in Airflow 3.0; use `airflow.configuration.conf.getboolean` instead
    |
@@ -221,6 +243,7 @@ AIR302_names.py:79:6: AIR302 `airflow.configuration.getboolean` is removed in Ai
 80 | 
 81 | get_connection, load_connections
    |
+   = help: Replace deprecated keywords in Airflow 3.0
 
 AIR302_names.py:79:18: AIR302 `airflow.configuration.getfloat` is removed in Airflow 3.0; use `airflow.configuration.conf.getfloat` instead
    |
@@ -231,6 +254,7 @@ AIR302_names.py:79:18: AIR302 `airflow.configuration.getfloat` is removed in Air
 80 | 
 81 | get_connection, load_connections
    |
+   = help: Replace deprecated keywords in Airflow 3.0
 
 AIR302_names.py:79:28: AIR302 `airflow.configuration.getint` is removed in Airflow 3.0; use `airflow.configuration.conf.getint` instead
    |
@@ -241,6 +265,7 @@ AIR302_names.py:79:28: AIR302 `airflow.configuration.getint` is removed in Airfl
 80 | 
 81 | get_connection, load_connections
    |
+   = help: Replace deprecated keywords in Airflow 3.0
 
 AIR302_names.py:79:36: AIR302 `airflow.configuration.has_option` is removed in Airflow 3.0; use `airflow.configuration.conf.has_option` instead
    |
@@ -251,6 +276,7 @@ AIR302_names.py:79:36: AIR302 `airflow.configuration.has_option` is removed in A
 80 | 
 81 | get_connection, load_connections
    |
+   = help: Replace deprecated keywords in Airflow 3.0
 
 AIR302_names.py:79:48: AIR302 `airflow.configuration.remove_option` is removed in Airflow 3.0; use `airflow.configuration.conf.remove_option` instead
    |
@@ -261,6 +287,7 @@ AIR302_names.py:79:48: AIR302 `airflow.configuration.remove_option` is removed i
 80 | 
 81 | get_connection, load_connections
    |
+   = help: Replace deprecated keywords in Airflow 3.0
 
 AIR302_names.py:79:63: AIR302 `airflow.configuration.as_dict` is removed in Airflow 3.0; use `airflow.configuration.conf.as_dict` instead
    |
@@ -271,6 +298,7 @@ AIR302_names.py:79:63: AIR302 `airflow.configuration.as_dict` is removed in Airf
 80 | 
 81 | get_connection, load_connections
    |
+   = help: Replace deprecated keywords in Airflow 3.0
 
 AIR302_names.py:79:72: AIR302 `airflow.configuration.set` is removed in Airflow 3.0; use `airflow.configuration.conf.set` instead
    |
@@ -281,6 +309,7 @@ AIR302_names.py:79:72: AIR302 `airflow.configuration.set` is removed in Airflow 
 80 | 
 81 | get_connection, load_connections
    |
+   = help: Replace deprecated keywords in Airflow 3.0
 
 AIR302_names.py:81:1: AIR302 `airflow.secrets.local_filesystem.get_connection` is removed in Airflow 3.0; use `airflow.secrets.local_filesystem.load_connections_dict` instead
    |
@@ -289,6 +318,7 @@ AIR302_names.py:81:1: AIR302 `airflow.secrets.local_filesystem.get_connection` i
 81 | get_connection, load_connections
    | ^^^^^^^^^^^^^^ AIR302
    |
+   = help: Replace deprecated keywords in Airflow 3.0
 
 AIR302_names.py:81:17: AIR302 `airflow.secrets.local_filesystem.load_connections` is removed in Airflow 3.0; use `airflow.secrets.local_filesystem.load_connections_dict` instead
    |
@@ -297,6 +327,7 @@ AIR302_names.py:81:17: AIR302 `airflow.secrets.local_filesystem.load_connections
 81 | get_connection, load_connections
    |                 ^^^^^^^^^^^^^^^^ AIR302
    |
+   = help: Replace deprecated keywords in Airflow 3.0
 
 AIR302_names.py:84:1: AIR302 `airflow.sensors.external_task_sensor.ExternalTaskSensorLink` is removed in Airflow 3.0; use `airflow.sensors.external_task.ExternalTaskSensorLink` instead
    |
@@ -305,6 +336,7 @@ AIR302_names.py:84:1: AIR302 `airflow.sensors.external_task_sensor.ExternalTaskS
 85 | BashOperator
 86 | BaseBranchOperator
    |
+   = help: Replace deprecated keywords in Airflow 3.0
 
 AIR302_names.py:85:1: AIR302 `airflow.operators.bash_operator.BashOperator` is removed in Airflow 3.0; use `airflow.operators.bash.BashOperator` instead
    |
@@ -314,6 +346,7 @@ AIR302_names.py:85:1: AIR302 `airflow.operators.bash_operator.BashOperator` is r
 86 | BaseBranchOperator
 87 | EmptyOperator, DummyOperator
    |
+   = help: Replace deprecated keywords in Airflow 3.0
 
 AIR302_names.py:86:1: AIR302 `airflow.operators.branch_operator.BaseBranchOperator` is removed in Airflow 3.0; use `airflow.operators.branch.BaseBranchOperator` instead
    |
@@ -324,6 +357,7 @@ AIR302_names.py:86:1: AIR302 `airflow.operators.branch_operator.BaseBranchOperat
 87 | EmptyOperator, DummyOperator
 88 | dummy_operator.EmptyOperator
    |
+   = help: Replace deprecated keywords in Airflow 3.0
 
 AIR302_names.py:87:16: AIR302 `airflow.operators.dummy.DummyOperator` is removed in Airflow 3.0; use `airflow.operators.empty.EmptyOperator` instead
    |
@@ -334,6 +368,7 @@ AIR302_names.py:87:16: AIR302 `airflow.operators.dummy.DummyOperator` is removed
 88 | dummy_operator.EmptyOperator
 89 | dummy_operator.DummyOperator
    |
+   = help: Replace deprecated keywords in Airflow 3.0
 
 AIR302_names.py:88:16: AIR302 `airflow.operators.dummy_operator.EmptyOperator` is removed in Airflow 3.0; use `airflow.operators.empty.EmptyOperator` instead
    |
@@ -344,6 +379,7 @@ AIR302_names.py:88:16: AIR302 `airflow.operators.dummy_operator.EmptyOperator` i
 89 | dummy_operator.DummyOperator
 90 | EmailOperator
    |
+   = help: Replace deprecated keywords in Airflow 3.0
 
 AIR302_names.py:89:16: AIR302 `airflow.operators.dummy_operator.DummyOperator` is removed in Airflow 3.0; use `airflow.operators.empty.EmptyOperator` instead
    |
@@ -354,6 +390,7 @@ AIR302_names.py:89:16: AIR302 `airflow.operators.dummy_operator.DummyOperator` i
 90 | EmailOperator
 91 | BaseSensorOperator
    |
+   = help: Replace deprecated keywords in Airflow 3.0
 
 AIR302_names.py:90:1: AIR302 `airflow.operators.email_operator.EmailOperator` is removed in Airflow 3.0; use `airflow.operators.email.EmailOperator` instead
    |
@@ -364,6 +401,7 @@ AIR302_names.py:90:1: AIR302 `airflow.operators.email_operator.EmailOperator` is
 91 | BaseSensorOperator
 92 | DateTimeSensor
    |
+   = help: Replace deprecated keywords in Airflow 3.0
 
 AIR302_names.py:91:1: AIR302 `airflow.sensors.base_sensor_operator.BaseSensorOperator` is removed in Airflow 3.0; use `airflow.sensors.base.BaseSensorOperator` instead
    |
@@ -374,6 +412,7 @@ AIR302_names.py:91:1: AIR302 `airflow.sensors.base_sensor_operator.BaseSensorOpe
 92 | DateTimeSensor
 93 | (ExternalTaskMarker, ExternalTaskSensor, ExternalTaskSensorLink)
    |
+   = help: Replace deprecated keywords in Airflow 3.0
 
 AIR302_names.py:92:1: AIR302 `airflow.sensors.date_time_sensor.DateTimeSensor` is removed in Airflow 3.0; use `airflow.sensors.date_time.DateTimeSensor` instead
    |
@@ -384,6 +423,7 @@ AIR302_names.py:92:1: AIR302 `airflow.sensors.date_time_sensor.DateTimeSensor` i
 93 | (ExternalTaskMarker, ExternalTaskSensor, ExternalTaskSensorLink)
 94 | TimeDeltaSensor
    |
+   = help: Replace deprecated keywords in Airflow 3.0
 
 AIR302_names.py:93:2: AIR302 `airflow.sensors.external_task_sensor.ExternalTaskMarker` is removed in Airflow 3.0; use `airflow.sensors.external_task.ExternalTaskMarker` instead
    |
@@ -393,6 +433,7 @@ AIR302_names.py:93:2: AIR302 `airflow.sensors.external_task_sensor.ExternalTaskM
    |  ^^^^^^^^^^^^^^^^^^ AIR302
 94 | TimeDeltaSensor
    |
+   = help: Replace deprecated keywords in Airflow 3.0
 
 AIR302_names.py:93:22: AIR302 `airflow.sensors.external_task_sensor.ExternalTaskSensor` is removed in Airflow 3.0; use `airflow.sensors.external_task.ExternalTaskSensor` instead
    |
@@ -402,6 +443,7 @@ AIR302_names.py:93:22: AIR302 `airflow.sensors.external_task_sensor.ExternalTask
    |                      ^^^^^^^^^^^^^^^^^^ AIR302
 94 | TimeDeltaSensor
    |
+   = help: Replace deprecated keywords in Airflow 3.0
 
 AIR302_names.py:93:42: AIR302 `airflow.sensors.external_task_sensor.ExternalTaskSensorLink` is removed in Airflow 3.0; use `airflow.sensors.external_task.ExternalTaskSensorLink` instead
    |
@@ -411,6 +453,7 @@ AIR302_names.py:93:42: AIR302 `airflow.sensors.external_task_sensor.ExternalTask
    |                                          ^^^^^^^^^^^^^^^^^^^^^^ AIR302
 94 | TimeDeltaSensor
    |
+   = help: Replace deprecated keywords in Airflow 3.0
 
 AIR302_names.py:94:1: AIR302 `airflow.sensors.time_delta_sensor.TimeDeltaSensor` is removed in Airflow 3.0; use `airflow.sensors.time_delta.TimeDeltaSensor` instead
    |
@@ -421,6 +464,7 @@ AIR302_names.py:94:1: AIR302 `airflow.sensors.time_delta_sensor.TimeDeltaSensor`
 95 | 
 96 | apply_defaults
    |
+   = help: Replace deprecated keywords in Airflow 3.0
 
 AIR302_names.py:96:1: AIR302 `airflow.utils.decorators.apply_defaults` is removed in Airflow 3.0; `apply_defaults` is now unconditionally done and can be safely removed.
    |
@@ -431,6 +475,7 @@ AIR302_names.py:96:1: AIR302 `airflow.utils.decorators.apply_defaults` is remove
 97 | 
 98 | TemporaryDirectory
    |
+   = help: Replace deprecated keywords in Airflow 3.0
 
 AIR302_names.py:98:1: AIR302 `airflow.utils.file.TemporaryDirectory` is removed in Airflow 3.0
    |
@@ -440,6 +485,7 @@ AIR302_names.py:98:1: AIR302 `airflow.utils.file.TemporaryDirectory` is removed 
    | ^^^^^^^^^^^^^^^^^^ AIR302
 99 | mkdirs
    |
+   = help: Replace deprecated keywords in Airflow 3.0
 
 AIR302_names.py:99:1: AIR302 `airflow.utils.file.mkdirs` is removed in Airflow 3.0; use `pendulum.today('UTC').add(days=-N, ...)` instead
     |
@@ -449,6 +495,7 @@ AIR302_names.py:99:1: AIR302 `airflow.utils.file.mkdirs` is removed in Airflow 3
 100 | 
 101 | chain
     |
+    = help: Replace deprecated keywords in Airflow 3.0
 
 AIR302_names.py:101:1: AIR302 `airflow.utils.helpers.chain` is removed in Airflow 3.0; use `airflow.models.baseoperator.chain` instead
     |
@@ -458,6 +505,7 @@ AIR302_names.py:101:1: AIR302 `airflow.utils.helpers.chain` is removed in Airflo
     | ^^^^^ AIR302
 102 | cross_downstream
     |
+    = help: Replace deprecated keywords in Airflow 3.0
 
 AIR302_names.py:102:1: AIR302 `airflow.utils.helpers.cross_downstream` is removed in Airflow 3.0; use `airflow.models.baseoperator.cross_downstream` instead
     |
@@ -467,6 +515,7 @@ AIR302_names.py:102:1: AIR302 `airflow.utils.helpers.cross_downstream` is remove
 103 | 
 104 | SHUTDOWN
     |
+    = help: Replace deprecated keywords in Airflow 3.0
 
 AIR302_names.py:104:1: AIR302 `airflow.utils.state.SHUTDOWN` is removed in Airflow 3.0
     |
@@ -476,6 +525,7 @@ AIR302_names.py:104:1: AIR302 `airflow.utils.state.SHUTDOWN` is removed in Airfl
     | ^^^^^^^^ AIR302
 105 | terminating_states
     |
+    = help: Replace deprecated keywords in Airflow 3.0
 
 AIR302_names.py:105:1: AIR302 `airflow.utils.state.terminating_states` is removed in Airflow 3.0
     |
@@ -485,6 +535,7 @@ AIR302_names.py:105:1: AIR302 `airflow.utils.state.terminating_states` is remove
 106 | 
 107 | TriggerRule.DUMMY
     |
+    = help: Replace deprecated keywords in Airflow 3.0
 
 AIR302_names.py:107:13: AIR302 `airflow.utils.trigger_rule.TriggerRule.DUMMY` is removed in Airflow 3.0
     |
@@ -494,6 +545,7 @@ AIR302_names.py:107:13: AIR302 `airflow.utils.trigger_rule.TriggerRule.DUMMY` is
     |             ^^^^^ AIR302
 108 | TriggerRule.NONE_FAILED_OR_SKIPPED
     |
+    = help: Replace deprecated keywords in Airflow 3.0
 
 AIR302_names.py:108:13: AIR302 `airflow.utils.trigger_rule.TriggerRule.NONE_FAILED_OR_SKIPPED` is removed in Airflow 3.0
     |
@@ -503,6 +555,7 @@ AIR302_names.py:108:13: AIR302 `airflow.utils.trigger_rule.TriggerRule.NONE_FAIL
 109 | 
 110 | test_cycle
     |
+    = help: Replace deprecated keywords in Airflow 3.0
 
 AIR302_names.py:110:1: AIR302 `airflow.utils.dag_cycle_tester.test_cycle` is removed in Airflow 3.0
     |
@@ -513,6 +566,7 @@ AIR302_names.py:110:1: AIR302 `airflow.utils.dag_cycle_tester.test_cycle` is rem
 111 | 
 112 | has_access
     |
+    = help: Replace deprecated keywords in Airflow 3.0
 
 AIR302_names.py:112:1: AIR302 `airflow.www.auth.has_access` is removed in Airflow 3.0; use `airflow.www.auth.has_access_*` instead
     |
@@ -522,6 +576,7 @@ AIR302_names.py:112:1: AIR302 `airflow.www.auth.has_access` is removed in Airflo
     | ^^^^^^^^^^ AIR302
 113 | get_sensitive_variables_fields, should_hide_value_for_key
     |
+    = help: Replace deprecated keywords in Airflow 3.0
 
 AIR302_names.py:113:1: AIR302 `airflow.www.utils.get_sensitive_variables_fields` is removed in Airflow 3.0; use `airflow.utils.log.secrets_masker.get_sensitive_variables_fields` instead
     |
@@ -529,6 +584,7 @@ AIR302_names.py:113:1: AIR302 `airflow.www.utils.get_sensitive_variables_fields`
 113 | get_sensitive_variables_fields, should_hide_value_for_key
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
     |
+    = help: Replace deprecated keywords in Airflow 3.0
 
 AIR302_names.py:113:33: AIR302 `airflow.www.utils.should_hide_value_for_key` is removed in Airflow 3.0; use `airflow.utils.log.secrets_masker.should_hide_value_for_key` instead
     |
@@ -536,3 +592,4 @@ AIR302_names.py:113:33: AIR302 `airflow.www.utils.should_hide_value_for_key` is 
 113 | get_sensitive_variables_fields, should_hide_value_for_key
     |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
     |
+    = help: Replace deprecated keywords in Airflow 3.0


### PR DESCRIPTION
## Summary

Add replacement fixes to deprecated arguments of a DAG.

Ref #14582 #14626

## Test Plan

Diff was verified and snapshots were updated.
