### PR TITLE
[red-knot] Property tests: account non-fully-static types

### DIFF
--- a/crates/red_knot_python_semantic/src/types/property_tests.rs
+++ b/crates/red_knot_python_semantic/src/types/property_tests.rs
@@ -163,13 +163,13 @@ mod stable {
     // `T` is equivalent to itself.
     type_property_test!(
         equivalent_to_is_reflexive, db,
-        forall types t. t.is_equivalent_to(db, t)
+        forall types t. t.is_fully_static(db) => t.is_equivalent_to(db, t)
     );
 
     // `T` is a subtype of itself.
     type_property_test!(
         subtype_of_is_reflexive, db,
-        forall types t. t.is_subtype_of(db, t)
+        forall types t. t.is_fully_static(db) => t.is_subtype_of(db, t)
     );
 
     // `S <: T` and `T <: U` implies that `S <: U`.

--- a/crates/red_knot_python_semantic/src/types/property_tests.rs
+++ b/crates/red_knot_python_semantic/src/types/property_tests.rs
@@ -214,6 +214,12 @@ mod stable {
         forall types t. t.is_singleton(db) => t.is_single_valued(db)
     );
 
+    // If `T` contains a gradual form, it should not participate in equivalence
+    type_property_test!(
+        non_fully_static_types_do_not_participate_in_equivalence, db,
+        forall types s, t. !s.is_fully_static(db) => !s.is_equivalent_to(db, t) && !t.is_equivalent_to(db, s)
+    );
+
     // If `T` contains a gradual form, it should not participate in subtyping
     type_property_test!(
         non_fully_static_types_do_not_participate_in_subtyping, db,


### PR DESCRIPTION
## Summary

I probably broke these tests myself in #14758. I don't know how that happened because I even added a new property test there, but maybe I ran the tests with a filter. Anyway, adding a `is_fully_static` premise to these two tests seems like the right thing to do.

There is another (actual) problem with `assignable_to_is_reflexive` which we'll also need to address, I'll open a ticket.

## Test Plan

```
cargo test -p red_knot_python_semantic -- --ignored types::property_tests::stable
```
