### PR TITLE
Revert disjointness->disjointedness

### DIFF
--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -956,7 +956,7 @@ impl<'db> Type<'db> {
                 Type::SubclassOf(_),
             ) => true,
             (Type::SubclassOf(_), _) | (_, Type::SubclassOf(_)) => {
-                // TODO: Once we have support for final classes, we can determine disjointedness in some cases
+                // TODO: Once we have support for final classes, we can determine disjointness in some cases
                 // here. However, note that it might be better to turn `Type::SubclassOf('FinalClass')` into
                 // `Type::ClassLiteral('FinalClass')` during construction, instead of adding special cases for
                 // final classes inside `Type::SubclassOf` everywhere.


### PR DESCRIPTION
## Summary

Partially revert #14880. While `disjointness` is missing from the [OED](https://www.oed.com/search/dictionary/?q=disjointness) and [SCOWL (And Friends)](http://app.aspell.net/lookup?dict=en_US-large;words=disjointness), it is commonly used in mathematics to describe disjoint sets.

## Test Plan

CI tests.
