### PR TITLE
[`flake8-comprehensions`] Skip `C416` if comprehension contains unpacking

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_comprehensions/C416.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_comprehensions/C416.py
@@ -8,6 +8,7 @@ d = {"a": 1, "b": 2, "c": 3}
 {k: v for k, v in y}
 {k: v for k, v in d.items()}
 [(k, v) for k, v in d.items()]
+[(k, v) for [k, v] in d.items()]
 {k: (a, b) for k, (a, b) in d.items()}
 
 [i for i, in z]

--- a/crates/ruff_linter/resources/test/fixtures/flake8_comprehensions/C416.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_comprehensions/C416.py
@@ -22,3 +22,6 @@ d = {"a": 1, "b": 2, "c": 3}
 
 # Regression test for: https://github.com/astral-sh/ruff/issues/7196
 any(len(symbol_table.get_by_type(symbol_type)) > 0 for symbol_type in[t for t in SymbolType])
+
+[(i,) for (i,) in z]
+{(i,) for (i,) in z}

--- a/crates/ruff_linter/resources/test/fixtures/flake8_comprehensions/C416.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_comprehensions/C416.py
@@ -23,5 +23,6 @@ d = {"a": 1, "b": 2, "c": 3}
 # Regression test for: https://github.com/astral-sh/ruff/issues/7196
 any(len(symbol_table.get_by_type(symbol_type)) > 0 for symbol_type in[t for t in SymbolType])
 
-[(i,) for (i,) in z]
-{(i,) for (i,) in z}
+zz = [[1], [2], [3]]
+[(i,) for (i,) in zz]  # != list(zz)
+{(i,) for (i,) in zz}  # != set(zz)

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_comprehension.rs
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_comprehension.rs
@@ -115,7 +115,6 @@ pub(crate) fn unnecessary_dict_comprehension(
     let Expr::Tuple(ast::ExprTuple { elts, .. }) = &generator.target else {
         return;
     };
-
     let [Expr::Name(ast::ExprName { id: target_key, .. }), Expr::Name(ast::ExprName {
         id: target_value, ..
     })] = elts.as_slice()
@@ -147,7 +146,6 @@ pub(crate) fn unnecessary_list_set_comprehension(
     if !generator.ifs.is_empty() || generator.is_async {
         return;
     }
-
     if is_dict_items(checker, &generator.iter) {
         match (&generator.target, elt) {
             // [(k, v) for k, v in dictionary.items()]j

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_comprehension.rs
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_comprehension.rs
@@ -148,7 +148,7 @@ pub(crate) fn unnecessary_list_set_comprehension(
     }
     if is_dict_items(checker, &generator.iter) {
         match (&generator.target, elt) {
-            // [(k, v) for k, v in dictionary.items()] or [(k, v) for [k, v] in dictionary.items()]
+            // [(k, v) for k, v in dict.items()] or [(k, v) for [k, v] in dict.items()]
             (
                 Expr::Tuple(ast::ExprTuple {
                     elts: target_elts, ..
@@ -173,7 +173,7 @@ pub(crate) fn unnecessary_list_set_comprehension(
                     add_diagnostic(checker, expr);
                 }
             }
-            // [x for x in dictionary.items()]
+            // [x for x in dict.items()]
             (
                 Expr::Name(ast::ExprName {
                     id: target_name, ..

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_comprehension.rs
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_comprehension.rs
@@ -125,13 +125,6 @@ pub(crate) fn unnecessary_dict_comprehension(
     else {
         return;
     };
-    let Expr::Name(ast::ExprName { id: key_name, .. }) = &key else {
-        return;
-    };
-    if target_key_name != key_name {
-        return;
-    }
-
     let Expr::Name(ast::ExprName {
         id: target_value_name,
         ..
@@ -139,11 +132,15 @@ pub(crate) fn unnecessary_dict_comprehension(
     else {
         return;
     };
+
+    let Expr::Name(ast::ExprName { id: key_name, .. }) = &key else {
+        return;
+    };
     let Expr::Name(ast::ExprName { id: value_name, .. }) = &value else {
         return;
     };
 
-    if target_value_name == value_name {
+    if target_key_name == key_name && target_value_name == value_name {
         add_diagnostic(checker, expr);
     }
 }

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_comprehension.rs
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_comprehension.rs
@@ -148,9 +148,12 @@ pub(crate) fn unnecessary_list_set_comprehension(
     }
     if is_dict_items(checker, &generator.iter) {
         match (&generator.target, elt) {
-            // [(k, v) for k, v in dictionary.items()]j
+            // [(k, v) for k, v in dictionary.items()] or [(k, v) for [k, v] in dictionary.items()]
             (
                 Expr::Tuple(ast::ExprTuple {
+                    elts: target_elts, ..
+                })
+                | Expr::List(ast::ExprList {
                     elts: target_elts, ..
                 }),
                 Expr::Tuple(ast::ExprTuple { elts, .. }),

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/snapshots/ruff_linter__rules__flake8_comprehensions__tests__C416_C416.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/snapshots/ruff_linter__rules__flake8_comprehensions__tests__C416_C416.py.snap
@@ -111,7 +111,7 @@ C416.py:24:70: C416 [*] Unnecessary list comprehension (rewrite using `list()`)
 24 | any(len(symbol_table.get_by_type(symbol_type)) > 0 for symbol_type in[t for t in SymbolType])
    |                                                                      ^^^^^^^^^^^^^^^^^^^^^^^ C416
 25 | 
-26 | [(i,) for (i,) in z]
+26 | zz = [[1], [2], [3]]
    |
    = help: Rewrite using `list()`
 
@@ -122,5 +122,5 @@ C416.py:24:70: C416 [*] Unnecessary list comprehension (rewrite using `list()`)
 24    |-any(len(symbol_table.get_by_type(symbol_type)) > 0 for symbol_type in[t for t in SymbolType])
    24 |+any(len(symbol_table.get_by_type(symbol_type)) > 0 for symbol_type in list(SymbolType))
 25 25 | 
-26 26 | [(i,) for (i,) in z]
-27 27 | {(i,) for (i,) in z}
+26 26 | zz = [[1], [2], [3]]
+27 27 | [(i,) for (i,) in zz]  # != list(zz)

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/snapshots/ruff_linter__rules__flake8_comprehensions__tests__C416_C416.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/snapshots/ruff_linter__rules__flake8_comprehensions__tests__C416_C416.py.snap
@@ -62,7 +62,7 @@ C416.py:8:1: C416 [*] Unnecessary dict comprehension (rewrite using `dict()`)
   8 |+dict(y)
 9 9 | {k: v for k, v in d.items()}
 10 10 | [(k, v) for k, v in d.items()]
-11 11 | {k: (a, b) for k, (a, b) in d.items()}
+11 11 | [(k, v) for [k, v] in d.items()]
 
 C416.py:9:1: C416 [*] Unnecessary dict comprehension (rewrite using `dict()`)
    |
@@ -71,7 +71,7 @@ C416.py:9:1: C416 [*] Unnecessary dict comprehension (rewrite using `dict()`)
  9 | {k: v for k, v in d.items()}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ C416
 10 | [(k, v) for k, v in d.items()]
-11 | {k: (a, b) for k, (a, b) in d.items()}
+11 | [(k, v) for [k, v] in d.items()]
    |
    = help: Rewrite using `dict()`
 
@@ -82,8 +82,8 @@ C416.py:9:1: C416 [*] Unnecessary dict comprehension (rewrite using `dict()`)
 9     |-{k: v for k, v in d.items()}
    9  |+dict(d.items())
 10 10 | [(k, v) for k, v in d.items()]
-11 11 | {k: (a, b) for k, (a, b) in d.items()}
-12 12 | 
+11 11 | [(k, v) for [k, v] in d.items()]
+12 12 | {k: (a, b) for k, (a, b) in d.items()}
 
 C416.py:10:1: C416 [*] Unnecessary list comprehension (rewrite using `list()`)
    |
@@ -91,7 +91,8 @@ C416.py:10:1: C416 [*] Unnecessary list comprehension (rewrite using `list()`)
  9 | {k: v for k, v in d.items()}
 10 | [(k, v) for k, v in d.items()]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ C416
-11 | {k: (a, b) for k, (a, b) in d.items()}
+11 | [(k, v) for [k, v] in d.items()]
+12 | {k: (a, b) for k, (a, b) in d.items()}
    |
    = help: Rewrite using `list()`
 
@@ -101,26 +102,46 @@ C416.py:10:1: C416 [*] Unnecessary list comprehension (rewrite using `list()`)
 9  9  | {k: v for k, v in d.items()}
 10    |-[(k, v) for k, v in d.items()]
    10 |+list(d.items())
-11 11 | {k: (a, b) for k, (a, b) in d.items()}
-12 12 | 
-13 13 | [i for i, in z]
+11 11 | [(k, v) for [k, v] in d.items()]
+12 12 | {k: (a, b) for k, (a, b) in d.items()}
+13 13 | 
 
-C416.py:24:70: C416 [*] Unnecessary list comprehension (rewrite using `list()`)
+C416.py:11:1: C416 [*] Unnecessary list comprehension (rewrite using `list()`)
    |
-23 | # Regression test for: https://github.com/astral-sh/ruff/issues/7196
-24 | any(len(symbol_table.get_by_type(symbol_type)) > 0 for symbol_type in[t for t in SymbolType])
-   |                                                                      ^^^^^^^^^^^^^^^^^^^^^^^ C416
-25 | 
-26 | zz = [[1], [2], [3]]
+ 9 | {k: v for k, v in d.items()}
+10 | [(k, v) for k, v in d.items()]
+11 | [(k, v) for [k, v] in d.items()]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ C416
+12 | {k: (a, b) for k, (a, b) in d.items()}
    |
    = help: Rewrite using `list()`
 
 ℹ Unsafe fix
-21 21 | {k: v if v else None for k, v in y}
-22 22 | 
-23 23 | # Regression test for: https://github.com/astral-sh/ruff/issues/7196
-24    |-any(len(symbol_table.get_by_type(symbol_type)) > 0 for symbol_type in[t for t in SymbolType])
-   24 |+any(len(symbol_table.get_by_type(symbol_type)) > 0 for symbol_type in list(SymbolType))
-25 25 | 
-26 26 | zz = [[1], [2], [3]]
-27 27 | [(i,) for (i,) in zz]  # != list(zz)
+8  8  | {k: v for k, v in y}
+9  9  | {k: v for k, v in d.items()}
+10 10 | [(k, v) for k, v in d.items()]
+11    |-[(k, v) for [k, v] in d.items()]
+   11 |+list(d.items())
+12 12 | {k: (a, b) for k, (a, b) in d.items()}
+13 13 | 
+14 14 | [i for i, in z]
+
+C416.py:25:70: C416 [*] Unnecessary list comprehension (rewrite using `list()`)
+   |
+24 | # Regression test for: https://github.com/astral-sh/ruff/issues/7196
+25 | any(len(symbol_table.get_by_type(symbol_type)) > 0 for symbol_type in[t for t in SymbolType])
+   |                                                                      ^^^^^^^^^^^^^^^^^^^^^^^ C416
+26 | 
+27 | zz = [[1], [2], [3]]
+   |
+   = help: Rewrite using `list()`
+
+ℹ Unsafe fix
+22 22 | {k: v if v else None for k, v in y}
+23 23 | 
+24 24 | # Regression test for: https://github.com/astral-sh/ruff/issues/7196
+25    |-any(len(symbol_table.get_by_type(symbol_type)) > 0 for symbol_type in[t for t in SymbolType])
+   25 |+any(len(symbol_table.get_by_type(symbol_type)) > 0 for symbol_type in list(SymbolType))
+26 26 | 
+27 27 | zz = [[1], [2], [3]]
+28 28 | [(i,) for (i,) in zz]  # != list(zz)

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/snapshots/ruff_linter__rules__flake8_comprehensions__tests__C416_C416.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/snapshots/ruff_linter__rules__flake8_comprehensions__tests__C416_C416.py.snap
@@ -85,6 +85,26 @@ C416.py:9:1: C416 [*] Unnecessary dict comprehension (rewrite using `dict()`)
 11 11 | {k: (a, b) for k, (a, b) in d.items()}
 12 12 | 
 
+C416.py:10:1: C416 [*] Unnecessary list comprehension (rewrite using `list()`)
+   |
+ 8 | {k: v for k, v in y}
+ 9 | {k: v for k, v in d.items()}
+10 | [(k, v) for k, v in d.items()]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ C416
+11 | {k: (a, b) for k, (a, b) in d.items()}
+   |
+   = help: Rewrite using `list()`
+
+ℹ Unsafe fix
+7  7  | {i for i in x}
+8  8  | {k: v for k, v in y}
+9  9  | {k: v for k, v in d.items()}
+10    |-[(k, v) for k, v in d.items()]
+   10 |+list(d.items())
+11 11 | {k: (a, b) for k, (a, b) in d.items()}
+12 12 | 
+13 13 | [i for i, in z]
+
 C416.py:24:70: C416 [*] Unnecessary list comprehension (rewrite using `list()`)
    |
 23 | # Regression test for: https://github.com/astral-sh/ruff/issues/7196

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/snapshots/ruff_linter__rules__flake8_comprehensions__tests__C416_C416.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/snapshots/ruff_linter__rules__flake8_comprehensions__tests__C416_C416.py.snap
@@ -110,6 +110,8 @@ C416.py:24:70: C416 [*] Unnecessary list comprehension (rewrite using `list()`)
 23 | # Regression test for: https://github.com/astral-sh/ruff/issues/7196
 24 | any(len(symbol_table.get_by_type(symbol_type)) > 0 for symbol_type in[t for t in SymbolType])
    |                                                                      ^^^^^^^^^^^^^^^^^^^^^^^ C416
+25 | 
+26 | [(i,) for (i,) in z]
    |
    = help: Rewrite using `list()`
 
@@ -119,3 +121,6 @@ C416.py:24:70: C416 [*] Unnecessary list comprehension (rewrite using `list()`)
 23 23 | # Regression test for: https://github.com/astral-sh/ruff/issues/7196
 24    |-any(len(symbol_table.get_by_type(symbol_type)) > 0 for symbol_type in[t for t in SymbolType])
    24 |+any(len(symbol_table.get_by_type(symbol_type)) > 0 for symbol_type in list(SymbolType))
+25 25 | 
+26 26 | [(i,) for (i,) in z]
+27 27 | {(i,) for (i,) in z}

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/snapshots/ruff_linter__rules__flake8_comprehensions__tests__C416_C416.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/snapshots/ruff_linter__rules__flake8_comprehensions__tests__C416_C416.py.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_comprehensions/mod.rs
+snapshot_kind: text
 ---
 C416.py:6:1: C416 [*] Unnecessary list comprehension (rewrite using `list()`)
   |
@@ -83,47 +84,6 @@ C416.py:9:1: C416 [*] Unnecessary dict comprehension (rewrite using `dict()`)
 10 10 | [(k, v) for k, v in d.items()]
 11 11 | {k: (a, b) for k, (a, b) in d.items()}
 12 12 | 
-
-C416.py:10:1: C416 [*] Unnecessary list comprehension (rewrite using `list()`)
-   |
- 8 | {k: v for k, v in y}
- 9 | {k: v for k, v in d.items()}
-10 | [(k, v) for k, v in d.items()]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ C416
-11 | {k: (a, b) for k, (a, b) in d.items()}
-   |
-   = help: Rewrite using `list()`
-
-ℹ Unsafe fix
-7  7  | {i for i in x}
-8  8  | {k: v for k, v in y}
-9  9  | {k: v for k, v in d.items()}
-10    |-[(k, v) for k, v in d.items()]
-   10 |+list(d.items())
-11 11 | {k: (a, b) for k, (a, b) in d.items()}
-12 12 | 
-13 13 | [i for i, in z]
-
-C416.py:11:1: C416 [*] Unnecessary dict comprehension (rewrite using `dict()`)
-   |
- 9 | {k: v for k, v in d.items()}
-10 | [(k, v) for k, v in d.items()]
-11 | {k: (a, b) for k, (a, b) in d.items()}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ C416
-12 | 
-13 | [i for i, in z]
-   |
-   = help: Rewrite using `dict()`
-
-ℹ Unsafe fix
-8  8  | {k: v for k, v in y}
-9  9  | {k: v for k, v in d.items()}
-10 10 | [(k, v) for k, v in d.items()]
-11    |-{k: (a, b) for k, (a, b) in d.items()}
-   11 |+dict(d.items())
-12 12 | 
-13 13 | [i for i, in z]
-14 14 | [i for i, j in y]
 
 C416.py:24:70: C416 [*] Unnecessary list comprehension (rewrite using `list()`)
    |


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Fix #11482. Applies https://github.com/adamchainz/flake8-comprehensions/pull/205 to ruff. `C416` should be skipped if comprehension contains unpacking. Here's an example:

```python
list_of_lists = [[1, 2], [3, 4]]

# ruff suggests `list(list_of_lists)` here, but that would change the result.
# `list(list_of_lists)` is not `[(1, 2), (3, 4)]`
a = [(x, y) for x, y in list_of_lists]

# This is equivalent to `list(list_of_lists)`
b = [x for x in list_of_lists]
```

## Test Plan

<!-- How was it tested? -->

Existing checks
