### PR TITLE
[red-knot] Add failing test for use of `type[]` as a base class

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/type_of/basic.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/type_of/basic.md
@@ -133,3 +133,14 @@ class B: ...
 # error: [invalid-type-form]
 _: type[A, B]
 ```
+
+## As a base class
+
+```py
+# TODO: this is a false positive
+# error: [invalid-base] "Invalid class base with type `GenericAlias` (all bases must be a class, `Any`, `Unknown` or `Todo`)"
+class Foo(type[int]): ...
+
+# TODO: should be `tuple[Literal[Foo], Literal[type], Literal[object]]
+reveal_type(Foo.__mro__)  # revealed: tuple[Literal[Foo], Unknown, Literal[object]]
+```


### PR DESCRIPTION
We support using `typing.Type[]` as a base class (and we have tests for it), but not yet `builtins.type[]`. At some point we should fix that, but I don't think it';s worth spending much time on now (and it might be easier once we've implemented generics?). This PR just adds a failing test with a TODO.