### PR TITLE
Support `lint:<rule>` in mdtests

### DIFF
--- a/crates/ruff_db/src/diagnostic.rs
+++ b/crates/ruff_db/src/diagnostic.rs
@@ -91,10 +91,20 @@ impl DiagnosticId {
         matches!(self, DiagnosticId::Lint(self_name) if self_name == name)
     }
 
-    pub fn matches(&self, name: &str) -> bool {
+    /// Returns `true` if this `DiagnosticId` matches the given name.
+    ///
+    /// ## Examples
+    /// ```
+    /// use ruff_db::diagnostic::DiagnosticId;
+    ///
+    /// assert!(DiagnosticId::Io.matches("io"));
+    /// assert!(DiagnosticId::lint("test").matches("lint:test"));
+    /// assert!(!DiagnosticId::lint("test").matches("test"));
+    /// ```
+    pub fn matches(&self, expected_name: &str) -> bool {
         match self.as_str() {
-            Ok(id) => id == name,
-            Err(DiagnosticAsStrError::Category { category, name }) => name
+            Ok(id) => id == expected_name,
+            Err(DiagnosticAsStrError::Category { category, name }) => expected_name
                 .strip_prefix(category)
                 .and_then(|prefix| prefix.strip_prefix(":"))
                 .is_some_and(|rest| rest == name),


### PR DESCRIPTION
## Summary

Fixes a small scoping issue in `DiagnosticId::matches`

Note: I don't think we should use `lint:id` in mdtests just yet. I worry that it could lead to many unnecessary churns if we decide **not** to use `lint:<id>` as the format (e.g., `lint/id`). 

The reason why users even see `lint:<rule>` is because the mdtest framework uses the diagnostic infrastructure

Closes #14910

## Test Plan

Added tests
