### PR TITLE
[red-knot] Remove an unnecessary branch and a confusing TODO comment

### DIFF
--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -1660,12 +1660,6 @@ impl<'db> Type<'db> {
             };
         }
 
-        if matches!(self, Type::Unknown | Type::Any | Type::Todo(_)) {
-            // Explicit handling of `Unknown` and `Any` necessary until `type[Unknown]` and
-            // `type[Any]` are not defined as `Todo` anymore.
-            return IterationOutcome::Iterable { element_ty: self };
-        }
-
         let dunder_iter_result = self.call_dunder(db, "__iter__", &[self]);
         match dunder_iter_result {
             CallDunderResult::CallOutcome(ref call_outcome)


### PR DESCRIPTION
## Summary

This branch seems no longer to be necessary; our tests all pass without it. It makes sense that it wouldn't be needed, because member access on an `Any`/`Unknown`/`Todo` type should produce `Any`/`Unknown`/`Todo`, and whether or not a type is iterable entirely depends on member access under the hood (we test whether it has an `__iter__` method, and whether the type returned by that `__iter__` method (for the "`__iter__` method of an `Any`/`Todo`/`Unknown` type", this will also be `Any`/`Unknown`/`Todo`) has a `__next__` method.

I don't fully understand the TODO comment here, but it is also true that we've now done the thing that the TODO comment says we needed to do.