### PR TITLE
[red-knot] Fixup a few edge cases regarding `type[]`

### DIFF
--- a/crates/red_knot_python_semantic/src/stdlib.rs
+++ b/crates/red_knot_python_semantic/src/stdlib.rs
@@ -15,6 +15,8 @@ pub(crate) enum CoreStdlibModule {
     TypingExtensions,
     Typing,
     Sys,
+    #[allow(dead_code)]
+    Abc, // currently only used in tests
 }
 
 impl CoreStdlibModule {
@@ -26,6 +28,7 @@ impl CoreStdlibModule {
             Self::Typeshed => "_typeshed",
             Self::TypingExtensions => "typing_extensions",
             Self::Sys => "sys",
+            Self::Abc => "abc",
         }
     }
 


### PR DESCRIPTION
## Summary

There's a functional change here, and a few cosmetic changes.

The functional change is that we currently consider `Literal[str]` to be disjoint from `type[Any]`. But they're not disjoint: `Any` here could be materialized as `str` or `object`; in those materializations, the two types would clearly overlap, and therefore `type[Any]` overlaps with `Literal[str]`. This PR fixes our logic in `Type::is_disjoint_from` to reflect that.

Also included in this PR are cosmetic changes to `Type::is_subtype_of`. The main reason for these changes is that currently we have `Type::SubclassOf(target_class))` branches in `match` statements where the `target_class` variable actually has type `ClassBase` rather than `Class`; this is quite confusing. A secondary reason for these changes is that it should be impossible for us to encounter `Type::SubclassOf(SubclassOfType { base })` instances in this `match` statement where `base` is not a `ClassBase::Class()` variant, since all other `ClassBase::Class()` variants are not fully static exit, and therefore we immediately early in `is_subtype_of()` here if we encounter one of them:

https://github.com/astral-sh/ruff/blob/6e11086c981f0ffb179fdaa78fa0837aa0283cda/crates/red_knot_python_semantic/src/types.rs#L607-L612

The changes to `Type::is_subtype_of()` clarify that we shouldn't be dealing with any other `ClassBase::Class()` variants in this `match` statement; we should therefore be using `Class::is_subclass_of()` rather than `Class:is_subclass_of_base()`.

As a result of the above changes, `Class::is_subclass_of_base()` actually becomes unused, so this PR removes it as well. I think this is probably also for the best: a `ClassBase` and a `Class` are two different things, and it feels like it blurs the two concepts to have a method that asks whether a class is a "subclass of" a `ClassBase`. If we need to ask this question again in the future, it's not that much more verbose to just do `class.mro(db).contains(&base)`.

## Test Plan

`cargo test -p red_knot_python_semantic`. The new test case for the `is_not_disjoint_from` test is the only one added in this PR that fails on `main`, but the other added test cases seem useful anyway.