### PR TITLE
[red-knot] Precise inference for `__class__` attributes on objects of all types

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/attributes.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/attributes.md
@@ -115,3 +115,38 @@ def _(flag: bool):
     # error: [unresolved-attribute] "Type `Literal[C1, C2]` has no attribute `x`"
     reveal_type(C.x)  # revealed: Unknown
 ```
+
+## Objects of all types have a `__class__` method
+
+```py
+import typing
+
+reveal_type(typing.__class__)  # revealed: Literal[ModuleType]
+
+a = 42
+reveal_type(a.__class__)  # revealed: Literal[int]
+
+b = "42"
+reveal_type(b.__class__)  # revealed: Literal[str]
+
+c = b"42"
+reveal_type(c.__class__)  # revealed: Literal[bytes]
+
+d = True
+reveal_type(d.__class__)  # revealed: Literal[bool]
+
+e = (42, 42)
+reveal_type(e.__class__)  # revealed: Literal[tuple]
+
+def f(a: int, b: typing.LiteralString, c: type[str], d: int | str):
+    reveal_type(a.__class__)  # revealed: type[int]
+    reveal_type(b.__class__)  # revealed: Literal[str]
+    reveal_type(c.__class__)  # revealed: type[type]
+    reveal_type(d.__class__)  # revealed: type[int] | type[str]
+
+reveal_type(f.__class__)  # revealed: Literal[FunctionType]
+
+class Foo: ...
+
+reveal_type(Foo.__class__)  # revealed: Literal[type]
+```

--- a/crates/red_knot_python_semantic/resources/mdtest/attributes.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/attributes.md
@@ -138,11 +138,16 @@ reveal_type(d.__class__)  # revealed: Literal[bool]
 e = (42, 42)
 reveal_type(e.__class__)  # revealed: Literal[tuple]
 
-def f(a: int, b: typing.LiteralString, c: type[str], d: int | str):
+def f(a: int, b: typing.LiteralString, c: int | str, d: type[str]):
     reveal_type(a.__class__)  # revealed: type[int]
     reveal_type(b.__class__)  # revealed: Literal[str]
-    reveal_type(c.__class__)  # revealed: type[type]
-    reveal_type(d.__class__)  # revealed: type[int] | type[str]
+    reveal_type(c.__class__)  # revealed: type[int] | type[str]
+
+    # `type[type]`, a.k.a., either the class `type` or some subclass of `type`.
+    # It would be incorrect to infer `Literal[type]` here,
+    # as `c` could be some subclass of `str` with a custom metaclass.
+    # All we know is that the metaclass must be a (non-strict) subclass of `type`.
+    reveal_type(d.__class__)  # revealed: type[type]
 
 reveal_type(f.__class__)  # revealed: Literal[FunctionType]
 

--- a/crates/red_knot_python_semantic/resources/mdtest/scopes/moduletype_attrs.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/scopes/moduletype_attrs.md
@@ -59,7 +59,7 @@ reveal_type(typing.__init__)  # revealed: Literal[__init__]
 # These come from `builtins.object`, not `types.ModuleType`:
 reveal_type(typing.__eq__)  # revealed: Literal[__eq__]
 
-reveal_type(typing.__class__)  # revealed: Literal[type]
+reveal_type(typing.__class__)  # revealed: Literal[ModuleType]
 
 # TODO: needs support for attribute access on instances, properties and generics;
 # should be `dict[str, Any]`

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -1272,6 +1272,10 @@ impl<'db> Type<'db> {
     /// as accessed from instances of the `Bar` class.
     #[must_use]
     pub(crate) fn member(&self, db: &'db dyn Db, name: &str) -> Symbol<'db> {
+        if name == "__class__" {
+            return self.to_meta_type(db).into();
+        }
+
         match self {
             Type::Any => Type::Any.into(),
             Type::Never => {
@@ -2701,10 +2705,6 @@ impl<'db> Class<'db> {
         if name == "__mro__" {
             let tuple_elements: Vec<Type<'db>> = self.iter_mro(db).map(Type::from).collect();
             return Type::tuple(db, &tuple_elements).into();
-        }
-
-        if name == "__class__" {
-            return self.metaclass(db).into();
         }
 
         for superclass in self.iter_mro(db) {


### PR DESCRIPTION
## Summary

We have a special case for `__class__` carved out in `Class::class_member`. But all objects in Python have a `__class__` attribute, not just classes. This PR extends the special case to objects of all types, not just classes. Not only is this more precise, it also allows us to more easily introspect our own type inference in our mdtests.

## Test Plan

New mdtests added that fail on `main`
