### PR TITLE
[red-knot] Make `is_subtype_of` exhaustive

### DIFF
--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -1201,19 +1201,17 @@ impl<'db> Type<'db> {
             }
 
             (Type::Tuple(tuple), Type::Tuple(other_tuple)) => {
-                if tuple.len(db) == other_tuple.len(db) {
-                    tuple
-                        .elements(db)
+                let self_elements = tuple.elements(db);
+                let other_elements = other_tuple.elements(db);
+                self_elements.len() != other_elements.len()
+                    || self_elements
                         .iter()
-                        .zip(other_tuple.elements(db))
+                        .zip(other_elements)
                         .any(|(e1, e2)| e1.is_disjoint_from(db, *e2))
-                } else {
-                    true
-                }
             }
 
             (Type::Tuple(..), Type::Instance(..)) | (Type::Instance(..), Type::Tuple(..)) => {
-                // We can not be sure if the tuple is disjoint from the instance because:
+                // We cannot be sure if the tuple is disjoint from the instance because:
                 //   - 'other' might be the homogeneous arbitrary-length tuple type
                 //     tuple[T, ...] (which we don't have support for yet); if all of
                 //     our element types are not disjoint with T, this is not disjoint

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -615,10 +615,10 @@ impl<'db> Type<'db> {
     ///
     /// [subtype of]: https://typing.readthedocs.io/en/latest/spec/concepts.html#subtype-supertype-and-type-equivalence
     pub(crate) fn is_subtype_of(self, db: &'db dyn Db, target: Type<'db>) -> bool {
-        // Two equivalent types are always equal to each other.
+        // Two equivalent types are always subtypes of each other.
         //
         // "Equivalent to" here means that the two types are both fully static
-        // and can be determined to point to exactly the same set of possible runtime objects.
+        // and point to exactly the same set of possible runtime objects.
         // For example, `int` is a subtype of `int` because `int` and `int` are equivalent to each other.
         // Equally, `type[object]` is a subtype of `type`,
         // because the former type expresses "all subclasses of `object`"
@@ -632,8 +632,8 @@ impl<'db> Type<'db> {
         //
         // Type `A` can only be a subtype of type `B` if the set of possible runtime objects
         // that `A` represents is a subset of the set of possible runtime objects that `B` represents.
-        // But the set of objects that a fully static type represents is (either partially or wholly) unknown,
-        // so the question is simply unanswerable for fully static types.
+        // But the set of objects described by a non-fully-static type is (either partially or wholly) unknown,
+        // so the question is simply unanswerable for non-fully-static types.
         if !self.is_fully_static(db) || !target.is_fully_static(db) {
             return false;
         }

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -618,7 +618,7 @@ impl<'db> Type<'db> {
         // Two equivalent types are always subtypes of each other.
         //
         // "Equivalent to" here means that the two types are both fully static
-        // and point to exactly the same set of possible runtime objects.
+        // and describe exactly the same set of possible runtime objects.
         // For example, `int` is a subtype of `int` because `int` and `int` are equivalent to each other.
         // Equally, `type[object]` is a subtype of `type`,
         // because the former type expresses "all subclasses of `object`"

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -3375,8 +3375,8 @@ impl<'db> TypeInferenceBuilder<'db> {
                 op,
             ),
 
-            (left_ty @ Type::Instance(left), right_ty @ Type::Instance(right), op) => {
-                if left != right && right.is_instance_of(self.db, left.class) {
+            (Type::Instance(left), Type::Instance(right), op) => {
+                if left != right && right.is_subtype_of(self.db, left) {
                     let reflected_dunder = op.reflected_dunder();
                     let rhs_reflected = right.class.class_member(self.db, reflected_dunder);
                     if !rhs_reflected.is_unbound()
@@ -5320,7 +5320,7 @@ fn perform_rich_comparison<'db>(
     };
 
     // The reflected dunder has priority if the right-hand side is a strict subclass of the left-hand side.
-    if left != right && right.is_instance_of(db, left.class) {
+    if left != right && right.is_subtype_of(db, left) {
         call_dunder(op.reflect(), right, left).or_else(|| call_dunder(op, left, right))
     } else {
         call_dunder(op, left, right).or_else(|| call_dunder(op.reflect(), right, left))


### PR DESCRIPTION
## Summary

This PR removes the fallback `_` branch at the end of `Type::is_subtype_of()`: the function now uses an exhaustive match over the first element of the `(self, target)` pair. This means that we can have much more confidence that we've covered all cases, and it means that it's impossible to forget to update this function if we add more variants to `Type` in the future (which we will).

The PR reworks our handling of most literal types in the `match` statement so that they explicitly fallback to builtin types. This has several advantages:
- We now understand that `Type::ModuleLiteral("typing")` is a subtype of `types.ModuleType`
- We now understand that `Type::SliceLiteral([:2])` is a subtype of `builtins.slice`
- We now understand that all heterogeneous tuple types are subtypes of `Type::Instance(Tuple)` (which represents the static set of all possible tuples, so in Python type annotations it would be written as `tuple[object, ...]`)
- We will naturally understand that all string literal types are subtypes of `typing.Sequence` as soon as we understand generics -- we won't have to make any manual updates to this function
- We can get rid of the explicit handling of `builtins.object` being the top type from the function; we now naturally understand this without any special-casing due to the fact that we understand that all classes have `object` in their MROs.

## Test Plan

Several new subtyping tests have been added, and all existing tests pass.
