### PR TITLE
Add tests demonstrating f-strings with debug expressions in replacements that contain escaped characters

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/fstring_preview.options.json
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/fstring_preview.options.json
@@ -1,0 +1,5 @@
+[
+  {
+    "preview": "enabled"
+  }
+]

--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/fstring_preview.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/fstring_preview.py
@@ -1,0 +1,20 @@
+# This test is in its own file because it results in AST changes on stable.
+# We don't plan to fix it on stable because we plan on promoting f-string formatting soon.
+
+# Regression test for https://github.com/astral-sh/ruff/issues/14766
+# Don't change the casing of the escaped characters in the f-string because it would be observable in the debug expression.
+# >>> f"{r"\xFF"=}"
+# 'r"ÿ"=\'\\\\xFF\''
+# >>> f"{r"\xff"=}"
+# 'r"ÿ"=\'\\\\xff\''
+f"{r"\xFF"=}"
+f"{r"\xff"=}"
+
+
+# Test for https://github.com/astral-sh/ruff/issues/14926
+# We could change the casing of the escaped characters in non-raw f-string because Python interprets the inner string
+# before printing it as a debug expression. For now, we decided not to change the casing because it's fairly complicated
+# to implement and it seems uncommon (debug expressions are uncommon, escapes are uncommon).
+# These two strings could be formatted to the same output but we currently don't do that.
+f"{"\xFF\N{space}"=}"
+f"{"\xff\N{SPACE}"=}"

--- a/crates/ruff_python_formatter/tests/fixtures.rs
+++ b/crates/ruff_python_formatter/tests/fixtures.rs
@@ -177,12 +177,9 @@ fn format() {
     let test_file = |input_path: &Path| {
         let content = fs::read_to_string(input_path).unwrap();
 
-        let options = PyFormatOptions::from_extension(input_path);
-        let formatted_code = format_file(&content, &options, input_path);
-
         let mut snapshot = format!("## Input\n{}", CodeFrame::new("python", &content));
-
         let options_path = input_path.with_extension("options.json");
+
         if let Ok(options_file) = fs::File::open(options_path) {
             let reader = BufReader::new(options_file);
             let options: Vec<PyFormatOptions> =
@@ -228,6 +225,9 @@ fn format() {
             }
         } else {
             // We want to capture the differences in the preview style in our fixtures
+            let options = PyFormatOptions::from_extension(input_path);
+            let formatted_code = format_file(&content, &options, input_path);
+
             let options_preview = options.with_preview(PreviewMode::Enabled);
             let formatted_preview = format_file(&content, &options_preview, input_path);
 

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__fstring_preview.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__fstring_preview.py.snap
@@ -1,0 +1,67 @@
+---
+source: crates/ruff_python_formatter/tests/fixtures.rs
+input_file: crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/fstring_preview.py
+snapshot_kind: text
+---
+## Input
+```python
+# This test is in its own file because it results in AST changes on stable.
+# We don't plan to fix it on stable because we plan on promoting f-string formatting soon.
+
+# Regression test for https://github.com/astral-sh/ruff/issues/14766
+# Don't change the casing of the escaped characters in the f-string because it would be observable in the debug expression.
+# >>> f"{r"\xFF"=}"
+# 'r"ÿ"=\'\\\\xFF\''
+# >>> f"{r"\xff"=}"
+# 'r"ÿ"=\'\\\\xff\''
+f"{r"\xFF"=}"
+f"{r"\xff"=}"
+
+
+# Test for https://github.com/astral-sh/ruff/issues/14926
+# We could change the casing of the escaped characters in non-raw f-string because Python interprets the inner string
+# before printing it as a debug expression. For now, we decided not to change the casing because it's fairly complicated
+# to implement and it seems uncommon (debug expressions are uncommon, escapes are uncommon).
+# These two strings could be formatted to the same output but we currently don't do that.
+f"{"\xFF\N{space}"=}"
+f"{"\xff\N{SPACE}"=}"
+```
+
+## Outputs
+### Output 1
+```
+indent-style               = space
+line-width                 = 88
+indent-width               = 4
+quote-style                = Double
+line-ending                = LineFeed
+magic-trailing-comma       = Respect
+docstring-code             = Disabled
+docstring-code-line-width  = "dynamic"
+preview                    = Enabled
+target_version             = Py39
+source_type                = Python
+```
+
+```python
+# This test is in its own file because it results in AST changes on stable.
+# We don't plan to fix it on stable because we plan on promoting f-string formatting soon.
+
+# Regression test for https://github.com/astral-sh/ruff/issues/14766
+# Don't change the casing of the escaped characters in the f-string because it would be observable in the debug expression.
+# >>> f"{r"\xFF"=}"
+# 'r"ÿ"=\'\\\\xFF\''
+# >>> f"{r"\xff"=}"
+# 'r"ÿ"=\'\\\\xff\''
+f"{r"\xFF"=}"
+f"{r"\xff"=}"
+
+
+# Test for https://github.com/astral-sh/ruff/issues/14926
+# We could change the casing of the escaped characters in non-raw f-string because Python interprets the inner string
+# before printing it as a debug expression. For now, we decided not to change the casing because it's fairly complicated
+# to implement and it seems uncommon (debug expressions are uncommon, escapes are uncommon).
+# These two strings could be formatted to the same output but we currently don't do that.
+f"{"\xFF\N{space}"=}"
+f"{"\xff\N{SPACE}"=}"
+```


### PR DESCRIPTION
## Summary

This PR adds two test cases that were reported in https://github.com/astral-sh/ruff/issues/14766 and https://github.com/astral-sh/ruff/issues/14926

## Test Plan

`cargo test`
