### PR TITLE
[red-knot] `Any` cannot be parameterized

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/annotations/any.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/annotations/any.md
@@ -69,3 +69,15 @@ y: int = Subclass()  # error: [invalid-assignment]
 def _(s: Subclass):
     reveal_type(s)  # revealed: Subclass
 ```
+
+## Invalid
+
+`Any` cannot be parameterized:
+
+```py
+from typing import Any
+
+# error: [invalid-type-parameter] "Type `typing.Any` expected no type parameter"
+def f(x: Any[int]):
+    reveal_type(x)  # revealed: Unknown
+```

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -4863,7 +4863,17 @@ impl<'db> TypeInferenceBuilder<'db> {
             }
             KnownInstanceType::Type => self.infer_subclass_of_type_expression(parameters),
             KnownInstanceType::Tuple => self.infer_tuple_type_expression(parameters),
-            KnownInstanceType::Any => Type::Any,
+            KnownInstanceType::Any => {
+                self.diagnostics.add_lint(
+                    &INVALID_TYPE_PARAMETER,
+                    subscript.into(),
+                    format_args!(
+                        "Type `{}` expected no type parameter",
+                        known_instance.repr(self.db)
+                    ),
+                );
+                Type::Unknown
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

We currently infer that objects annotated with `Any[int]` have type `Any`, and we don't emit an error telling them it's an invalid type annotation. That's a bug.

## Test Plan

New mdtest added.
