### PR TITLE
Use double quotes consistently for shell scripts

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Normalize Platform Pair (replace / with -)
         run: |
           platform=${{ matrix.platform }}
-          echo "PLATFORM_TUPLE=${platform//\//-}" >> $GITHUB_ENV
+          echo "PLATFORM_TUPLE=${platform//\//-}" >> "$GITHUB_ENV"
 
       # Adapted from https://docs.docker.com/build/ci/github-actions/multi-platform/
       - name: Build and push by digest
@@ -143,8 +143,8 @@ jobs:
         # The final command becomes `docker buildx imagetools create -t tag1 -t tag2 ... <RUFF_BASE_IMG>@sha256:<sha256_1> <RUFF_BASE_IMG>@sha256:<sha256_2> ...`
         run: |
           docker buildx imagetools create \
-            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf '${RUFF_BASE_IMG}@sha256:%s ' *)
+            "$(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON")" \
+            "$(printf "${RUFF_BASE_IMG}@sha256:%s " *)"
 
   docker-publish-extra:
     name: Publish additional Docker image based on ${{ matrix.image-mapping }}
@@ -203,14 +203,14 @@ jobs:
           TAG_PATTERNS="${TAG_PATTERNS%\\n}"
 
           # Export image cache name
-          echo "IMAGE_REF=${BASE_IMAGE//:/-}" >> $GITHUB_ENV
+          echo "IMAGE_REF=${BASE_IMAGE//:/-}" >> "$GITHUB_ENV"
 
           # Export tag patterns using the multiline env var syntax
           {
             echo "TAG_PATTERNS<<EOF"
             echo -e "${TAG_PATTERNS}"
             echo EOF
-          } >> $GITHUB_ENV
+          } >> "$GITHUB_ENV"
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
@@ -288,5 +288,5 @@ jobs:
           readarray -t lines <<< "$DOCKER_METADATA_OUTPUT_ANNOTATIONS"; annotations=(); for line in "${lines[@]}"; do annotations+=(--annotation "$line"); done
           docker buildx imagetools create \
             "${annotations[@]}" \
-            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf '${RUFF_BASE_IMG}@sha256:%s ' *)
+            "$(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON")" \
+            "$(printf "${RUFF_BASE_IMG}@sha256:%s " *)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -268,9 +268,9 @@ jobs:
           RELEASE_COMMIT: "${{ github.sha }}"
         run: |
           # Write and read notes from a file to avoid quoting breaking things
-          echo "$ANNOUNCEMENT_BODY" > $RUNNER_TEMP/notes.txt
+          echo "$ANNOUNCEMENT_BODY" > "$RUNNER_TEMP/notes.txt"
 
-          gh release create "${{ needs.plan.outputs.tag }}" --target "$RELEASE_COMMIT" $PRERELEASE_FLAG --title "$ANNOUNCEMENT_TITLE" --notes-file "$RUNNER_TEMP/notes.txt" artifacts/*
+          gh release create "${{ needs.plan.outputs.tag }}" --target "$RELEASE_COMMIT" "$PRERELEASE_FLAG" --title "$ANNOUNCEMENT_TITLE" --notes-file "$RUNNER_TEMP/notes.txt" artifacts/*
 
   custom-notify-dependents:
     needs:


### PR DESCRIPTION
## Summary

The release failed (https://github.com/astral-sh/ruff/actions/runs/12298190472/job/34321509636) because the shell script in the Docker release workflow was using single quotes instead of double quotes.

This is related to https://www.shellcheck.net/wiki/SC2016. I found it via [`actionlint`](https://github.com/rhysd/actionlint). Related #14893.

I also went ahead and fixed https://www.shellcheck.net/wiki/SC2086 which were raised in a couple of places.
