### PR TITLE
[red-knot] Fixes to `Type::to_meta_type`

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/metaclass.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/metaclass.md
@@ -194,3 +194,26 @@ class A[T: str](metaclass=M): ...
 
 reveal_type(A.__class__)  # revealed: Literal[M]
 ```
+
+## Metaclasses of metaclasses
+
+```py
+class Foo(type): ...
+class Bar(type, metaclass=Foo): ...
+class Baz(type, metaclass=Bar): ...
+class Spam(metaclass=Baz): ...
+
+reveal_type(Spam.__class__)  # revealed: Literal[Baz]
+reveal_type(Spam.__class__.__class__)  # revealed: Literal[Bar]
+reveal_type(Spam.__class__.__class__.__class__)  # revealed: Literal[Foo]
+
+def test(x: Spam):
+    reveal_type(x.__class__)  # revealed: type[Spam]
+    reveal_type(x.__class__.__class__)  # revealed: type[Baz]
+    reveal_type(x.__class__.__class__.__class__)  # revealed: type[Bar]
+    reveal_type(x.__class__.__class__.__class__.__class__)  # revealed: type[Foo]
+    reveal_type(x.__class__.__class__.__class__.__class__.__class__)  # revealed: type[type]
+
+    # revealed: type[type]
+    reveal_type(x.__class__.__class__.__class__.__class__.__class__.__class__.__class__.__class__)
+```

--- a/crates/red_knot_python_semantic/resources/mdtest/type_of/any.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/type_of/any.md
@@ -1,4 +1,4 @@
-# type[Any]
+# `type[Any]`
 
 ## Simple
 
@@ -50,4 +50,23 @@ x: type[object] = object
 x: type[object] = type
 x: type[object] = A
 x: type[object] = A()  # error: [invalid-assignment]
+```
+
+## The type of `Any` is `type[Any]`
+
+`Any` represents an unknown set of possible runtime values. If `x` is of type `Any`, the type of
+`x.__class__` is also unknown and remains dynamic, *except* that we know it must be a class object
+of some kind. As such, the type of `x.__class__` is `type[Any]` rather than `Any`:
+
+```py
+from typing import Any
+from does_not_exist import SomethingUnknown  # error: [unresolved-import]
+
+reveal_type(SomethingUnknown)  # revealed: Unknown
+
+def test(x: Any, y: SomethingUnknown):
+    reveal_type(x.__class__)  # revealed: type[Any]
+    reveal_type(x.__class__.__class__.__class__.__class__)  # revealed: type[Any]
+    reveal_type(y.__class__)  # revealed: type[Unknown]
+    reveal_type(y.__class__.__class__.__class__.__class__)  # revealed: type[Unknown]
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/type_of/typing_dot_Type.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/type_of/typing_dot_Type.md
@@ -9,7 +9,7 @@ from typing import Type
 
 class A: ...
 
-def _(c: Type, d: Type[A], e: Type[A]):
+def _(c: Type, d: Type[A]):
     reveal_type(c)  # revealed: type
     reveal_type(d)  # revealed: type[A]
     c = d  # fine

--- a/crates/red_knot_python_semantic/src/types/mro.rs
+++ b/crates/red_knot_python_semantic/src/types/mro.rs
@@ -334,7 +334,7 @@ impl<'db> ClassBase<'db> {
     /// Attempt to resolve `ty` into a `ClassBase`.
     ///
     /// Return `None` if `ty` is not an acceptable type for a class base.
-    fn try_from_ty(db: &'db dyn Db, ty: Type<'db>) -> Option<Self> {
+    pub(super) fn try_from_ty(db: &'db dyn Db, ty: Type<'db>) -> Option<Self> {
         match ty {
             Type::Any => Some(Self::Any),
             Type::Unknown => Some(Self::Unknown),
@@ -446,6 +446,12 @@ impl<'db> From<ClassBase<'db>> for Type<'db> {
             ClassBase::Unknown => Type::Unknown,
             ClassBase::Class(class) => Type::class_literal(class),
         }
+    }
+}
+
+impl<'db> From<&ClassBase<'db>> for Type<'db> {
+    fn from(value: &ClassBase<'db>) -> Self {
+        Self::from(*value)
     }
 }
 


### PR DESCRIPTION
## Summary

If a symbol `x` has type `Any`, `x.__class__` should still be a dynamic, unknown type. However, that doesn't mean that it has to be `Any` _exactly_. We know that for any object `x`, `x.__class__` will be an instance of `type`; if `x` has type `Any`, this still holds true, we just don't know which _exact_ instance of `type` we have for `x.__class__`. This can be expressed using the type `type[Any]`.

To implement these semantics, this PR modifies `Type::to_meta_type` so that the meta-type of `Any` is `type[Any]`, the meta-type of `Unknown` is `type[Unknown]` and the meta-type of `Todo` is `type[Todo]`.

## Test Plan

New mdtests added
