### PR TITLE
RUF012 exemption for SQLModel base class

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/ruff/RUF012.py
+++ b/crates/ruff_linter/resources/test/fixtures/ruff/RUF012.py
@@ -79,3 +79,16 @@ class H(BaseModel):
         without_annotation = []
         class_variable: ClassVar[list[int]] = []
         final_variable: Final[list[int]] = []
+
+
+from sqlmodel import SQLModel
+
+
+class I(SQLModel):
+    id: int
+    name: str
+
+
+class J(SQLModel):
+    id: int
+    i_s: list[I] = []

--- a/crates/ruff_linter/src/rules/ruff/rules/helpers.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/helpers.rs
@@ -187,6 +187,7 @@ pub(super) fn has_default_copy_semantics(
             ["pydantic", "BaseModel" | "BaseSettings" | "BaseConfig"]
                 | ["pydantic_settings", "BaseSettings"]
                 | ["msgspec", "Struct"]
+                | ["sqlmodel", "SQLModel"]
         )
     })
 }


### PR DESCRIPTION
## Summary

Closes https://github.com/astral-sh/ruff/issues/14892, by adding `sqlmodel.SQLModel` to the list of classes with default copy semantics. 

## Test Plan

Added a test into `RUF012.py` containing the example from the original issue.
