### PR TITLE
[red-knot] Improve `match` mdtests

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/conditional/match.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/conditional/match.md
@@ -3,40 +3,43 @@
 ## With wildcard
 
 ```py
-match 0:
-    case 1:
-        y = 2
-    case _:
-        y = 3
+def _(target: int):
+    match target:
+        case 1:
+            y = 2
+        case _:
+            y = 3
 
-reveal_type(y)  # revealed: Literal[2, 3]
+    reveal_type(y)  # revealed: Literal[2, 3]
 ```
 
 ## Without wildcard
 
 ```py
-match 0:
-    case 1:
-        y = 2
-    case 2:
-        y = 3
+def _(target: int):
+    match target:
+        case 1:
+            y = 2
+        case 2:
+            y = 3
 
-# revealed: Literal[2, 3]
-# error: [possibly-unresolved-reference]
-reveal_type(y)
+    # revealed: Literal[2, 3]
+    # error: [possibly-unresolved-reference]
+    reveal_type(y)
 ```
 
 ## Basic match
 
 ```py
-y = 1
-y = 2
+def _(target: int):
+    y = 1
+    y = 2
 
-match 0:
-    case 1:
-        y = 3
-    case 2:
-        y = 4
+    match target:
+        case 1:
+            y = 3
+        case 2:
+            y = 4
 
-reveal_type(y)  # revealed: Literal[2, 3, 4]
+    reveal_type(y)  # revealed: Literal[2, 3, 4]
 ```


### PR DESCRIPTION
## Summary

Minor improvement for the `match` tests to make sure we can't infer statically whether or not a certain `case` applies.

