### PR TITLE
[red-knot] mdtest: python version requirements

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/exception/except_star.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/exception/except_star.md
@@ -1,5 +1,12 @@
 # `except*`
 
+`except*` is only available in Python 3.11 and later:
+
+```toml
+[environment]
+python-version = "3.11"
+```
+
 ## `except*` with `BaseException`
 
 ```py

--- a/crates/red_knot_python_semantic/resources/mdtest/pep695_type_aliases.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/pep695_type_aliases.md
@@ -1,4 +1,11 @@
-# Type aliases
+# PEP 695 type aliases
+
+PEP 695 type aliases are only available in Python 3.12 and later:
+
+```toml
+[environment]
+python-version = "3.12"
+```
 
 ## Basic
 


### PR DESCRIPTION
## Summary

This is not strictly required yet, but makes these tests future-proof. They need a `python-version` requirement as they rely on language features that are not available in 3.9.