### PR TITLE
[red-knot] Minor simplifications to `types.rs`

### DIFF
--- a/crates/red_knot_python_semantic/src/types/class_base.rs
+++ b/crates/red_knot_python_semantic/src/types/class_base.rs
@@ -125,7 +125,7 @@ impl<'db> ClassBase<'db> {
         }
     }
 
-    pub(super) fn into_class_literal_type(self) -> Option<Class<'db>> {
+    pub(super) fn into_class(self) -> Option<Class<'db>> {
         match self {
             Self::Class(class) => Some(class),
             _ => None,

--- a/crates/red_knot_python_semantic/src/types/mro.rs
+++ b/crates/red_knot_python_semantic/src/types/mro.rs
@@ -117,7 +117,7 @@ impl<'db> Mro<'db> {
                     for (index, base) in valid_bases
                         .iter()
                         .enumerate()
-                        .filter_map(|(index, base)| Some((index, base.into_class_literal_type()?)))
+                        .filter_map(|(index, base)| Some((index, base.into_class()?)))
                     {
                         if !seen_bases.insert(base) {
                             duplicate_bases.push((index, base));


### PR DESCRIPTION
## Summary

Some minor simplification opportunities I spotted almost immediately after merging #14924.

## Test Plan

- `cargo test -p red_knot_python_semantic`
- `QUICKCHECK_TESTS=100000 cargo test -p red_knot_python_semantic -- --ignored types::property_tests::stable`

