### PR TITLE
[ruff_python_ast] Add name and default functions to TypeParam.

### DIFF
--- a/crates/ruff_python_ast/src/nodes.rs
+++ b/crates/ruff_python_ast/src/nodes.rs
@@ -3387,7 +3387,7 @@ pub enum TypeParam {
 }
 
 impl TypeParam {
-    pub fn name(&self) -> &Identifier {
+    pub const fn name(&self) -> &Identifier {
         match self {
             Self::TypeVar(x) => &x.name,
             Self::ParamSpec(x) => &x.name,

--- a/crates/ruff_python_ast/src/nodes.rs
+++ b/crates/ruff_python_ast/src/nodes.rs
@@ -3386,6 +3386,24 @@ pub enum TypeParam {
     TypeVarTuple(TypeParamTypeVarTuple),
 }
 
+impl TypeParam {
+    pub fn name(&self) -> &Identifier {
+        match self {
+            Self::TypeVar(x) => &x.name,
+            Self::ParamSpec(x) => &x.name,
+            Self::TypeVarTuple(x) => &x.name,
+        }
+    }
+
+    pub fn default(&self) -> Option<&Expr> {
+        match self {
+            Self::TypeVar(x) => x.default.as_deref(),
+            Self::ParamSpec(x) => x.default.as_deref(),
+            Self::TypeVarTuple(x) => x.default.as_deref(),
+        }
+    }
+}
+
 /// See also [TypeVar](https://docs.python.org/3/library/ast.html#ast.TypeVar)
 #[derive(Clone, Debug, PartialEq)]
 pub struct TypeParamTypeVar {


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

This change adds `name` and `default` functions to `TypeParam` to access the corresponding attributes more conveniently. I currently have these as helper functions in code built on top of ruff_python_ast, and they seemed like they might be generally useful.

## Test Plan

Ran the checks listed in CONTRIBUTING.md#development.