### PR TITLE
[red-knot] type[] is disjoint from None, LiteralString

### DIFF
--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -1058,10 +1058,7 @@ impl<'db> Type<'db> {
                 // multiply-inherit `type` or a subclass of it, and thus not be disjoint with
                 // `type[...]`.) Until we support finality, hardcode None, which is known to be
                 // final.
-                match instance.class.known(db) {
-                    Some(KnownClass::NoneType) => true,
-                    _ => false,
-                }
+                matches!(instance.class.known(db), Some(KnownClass::NoneType))
             }
 
             (

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -1053,9 +1053,11 @@ impl<'db> Type<'db> {
 
             (Type::SubclassOf(_), Type::Instance(instance))
             | (Type::Instance(instance), Type::SubclassOf(_)) => {
-                // TODO this should be based on whether the instance is of a final type which is
-                // not an instance of type, but until we support finality, hardcode None, which is
-                // known to be final.
+                // TODO this should be `true` if the instance is of a final type which is not a
+                // subclass of type, but until we support finality, hardcode None, which is known
+                // to be final. (With non-final types, we never know whether a subclass might
+                // multiply-inherit `type` or a subclass of it, and thus not be disjoint with
+                // `type[...]`.)
                 match instance.class.known(db) {
                     Some(KnownClass::NoneType) => true,
                     _ => false,

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -1054,10 +1054,10 @@ impl<'db> Type<'db> {
             (Type::SubclassOf(_), Type::Instance(instance))
             | (Type::Instance(instance), Type::SubclassOf(_)) => {
                 // TODO this should be `true` if the instance is of a final type which is not a
-                // subclass of type, but until we support finality, hardcode None, which is known
-                // to be final. (With non-final types, we never know whether a subclass might
+                // subclass of type. (With non-final types, we never know whether a subclass might
                 // multiply-inherit `type` or a subclass of it, and thus not be disjoint with
-                // `type[...]`.)
+                // `type[...]`.) Until we support finality, hardcode None, which is known to be
+                // final.
                 match instance.class.known(db) {
                     Some(KnownClass::NoneType) => true,
                     _ => false,


### PR DESCRIPTION
## Summary

Teach red-knot that `type[...]` is always disjoint from `None` and from `LiteralString`. Fixes #14925.

This should properly be generalized to "all instances of final types which are not subclasses of `type`", but until we support finality, hardcoding `None` (which is known to be final) allows us to fix the subtype transitivity property test.

## Test Plan

Existing tests pass, added new unit tests for `is_disjoint_from` and `is_subtype_of`.

`QUICKCHECK_TESTS=100000 cargo test -p red_knot_python_semantic -- --ignored types::property_tests::stable` fails only the "assignability is reflexive" test, which is known to fail on `main` (#14899).

The same command, with `property_tests.rs` edited to prevent generating intersection tests (the cause of #14899), passes all quickcheck tests.
