### PR TITLE
[`perflint`] Fix panic in `perf401`

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/perflint/PERF401.py
+++ b/crates/ruff_linter/resources/test/fixtures/perflint/PERF401.py
@@ -237,3 +237,10 @@ def f():
         print(a)
     for a in values:
         result.append(a + 1)  # PERF401
+
+def f():
+    values = [1, 2, 3]
+    def g():
+        for a in values:
+            result.append(a + 1)  # PERF401
+    result = []

--- a/crates/ruff_linter/src/rules/perflint/snapshots/ruff_linter__rules__perflint__tests__PERF401_PERF401.py.snap
+++ b/crates/ruff_linter/src/rules/perflint/snapshots/ruff_linter__rules__perflint__tests__PERF401_PERF401.py.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/ruff_linter/src/rules/perflint/mod.rs
-snapshot_kind: text
 ---
 PERF401.py:6:13: PERF401 Use a list comprehension to create a transformed list
   |
@@ -189,5 +188,17 @@ PERF401.py:239:9: PERF401 Use a list comprehension to create a transformed list
 238 |     for a in values:
 239 |         result.append(a + 1)  # PERF401
     |         ^^^^^^^^^^^^^^^^^^^^ PERF401
+240 | 
+241 | def f():
     |
     = help: Replace for loop with list comprehension
+
+PERF401.py:245:13: PERF401 Use `list.extend` to create a transformed list
+    |
+243 |     def g():
+244 |         for a in values:
+245 |             result.append(a + 1)  # PERF401
+    |             ^^^^^^^^^^^^^^^^^^^^ PERF401
+246 |     result = []
+    |
+    = help: Replace for loop with list.extend

--- a/crates/ruff_linter/src/rules/perflint/snapshots/ruff_linter__rules__perflint__tests__preview__PERF401_PERF401.py.snap
+++ b/crates/ruff_linter/src/rules/perflint/snapshots/ruff_linter__rules__perflint__tests__preview__PERF401_PERF401.py.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/ruff_linter/src/rules/perflint/mod.rs
-snapshot_kind: text
 ---
 PERF401.py:6:13: PERF401 [*] Use a list comprehension to create a transformed list
   |
@@ -448,6 +447,8 @@ PERF401.py:239:9: PERF401 [*] Use a list comprehension to create a transformed l
 238 |     for a in values:
 239 |         result.append(a + 1)  # PERF401
     |         ^^^^^^^^^^^^^^^^^^^^ PERF401
+240 | 
+241 | def f():
     |
     = help: Replace for loop with list comprehension
 
@@ -461,3 +462,25 @@ PERF401.py:239:9: PERF401 [*] Use a list comprehension to create a transformed l
 238     |-    for a in values:
 239     |-        result.append(a + 1)  # PERF401
     237 |+    result = [a + 1 for a in values]  # PERF401
+240 238 | 
+241 239 | def f():
+242 240 |     values = [1, 2, 3]
+
+PERF401.py:245:13: PERF401 [*] Use `list.extend` to create a transformed list
+    |
+243 |     def g():
+244 |         for a in values:
+245 |             result.append(a + 1)  # PERF401
+    |             ^^^^^^^^^^^^^^^^^^^^ PERF401
+246 |     result = []
+    |
+    = help: Replace for loop with list.extend
+
+ℹ Unsafe fix
+241 241 | def f():
+242 242 |     values = [1, 2, 3]
+243 243 |     def g():
+244     |-        for a in values:
+245     |-            result.append(a + 1)  # PERF401
+    244 |+        result.extend(a + 1 for a in values)  # PERF401
+246 245 |     result = []


### PR DESCRIPTION
Fixes #14969.

The issue was that this line:

```rust
let from_assign_to_loop = TextRange::new(binding_stmt.end(), for_stmt.start());
```

was not safe if the binding was after the target. The only way (at least that I can think of) this can happen is if they are in different scopes, so it now checks for that before checking if there are usages between the two. 