### PR TITLE
[red-knot] Fix bugs relating to assignability of dynamic `type[]` types

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/type_of/dynamic.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/type_of/dynamic.md
@@ -1,6 +1,7 @@
 # `type[Any]`
 
-This file contains tests for non-fully-static `type[]` types, such as `type[Any]` and `type[Unknown]`.
+This file contains tests for non-fully-static `type[]` types, such as `type[Any]` and
+`type[Unknown]`.
 
 ## Simple
 
@@ -80,6 +81,7 @@ def test(x: Any, y: SomethingUnknown):
 ## `type[Unknown]` has similar properties to `type[Any]`
 
 ```py
+import abc
 from typing import Any
 from does_not_exist import SomethingUnknown  # error: [unresolved-import]
 
@@ -92,4 +94,9 @@ def test(a: type[Any], b: type[str], c: type[Any], d: type[str]):
     b = c
     c = has_unknown_type
     d = has_unknown_type
+
+def test2(a: type[Any], b: abc.ABCMeta):
+    """Instances of `type` subclasses are also assignable to `type[Any]` or `type[Unknown]`"""
+    b = a
+    b = has_unknown_type
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/type_of/dynamic.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/type_of/dynamic.md
@@ -11,9 +11,9 @@ def f(x: type[Any], y: type[str]):
     # TODO: could be `<object.__repr__ type> & Any`
     reveal_type(x.__repr__)  # revealed: Any
 
-    z = x
-    x = y
-    y = z
+    # type[str] and type[Any] are assignable to each other
+    a: type[str] = x
+    b: type[Any] = y
 
 class A: ...
 
@@ -88,15 +88,15 @@ from does_not_exist import SomethingUnknown  # error: [unresolved-import]
 has_unknown_type = SomethingUnknown.__class__
 reveal_type(has_unknown_type)  # revealed: type[Unknown]
 
-def test(a: type[Any], b: type[str], c: type[Any], d: type[str]):
+def test(x: type[str], y: type[Any]):
     """Both `type[Any]` and `type[Unknown]` are assignable to all `type[]` types"""
-    a = b
-    b = c
-    c = has_unknown_type
-    d = has_unknown_type
+    a: type[Any] = x
+    b: type[str] = y
+    c: type[Any] = has_unknown_type
+    d: type[str] = has_unknown_type
 
-def test2(a: type[Any], b: abc.ABCMeta):
-    """Instances of `type` subclasses are also assignable to `type[Any]` or `type[Unknown]`"""
-    b = a
-    b = has_unknown_type
+def test2(a: type[Any]):
+    """`type[Any]` and `type[Unknown]` are also assignable to all instances of `type` subclasses"""
+    b: abc.ABCMeta = a
+    b: abc.ABCMeta = has_unknown_type
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/type_of/dynamic.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/type_of/dynamic.md
@@ -1,12 +1,18 @@
 # `type[Any]`
 
+This file contains tests for non-fully-static `type[]` types, such as `type[Any]` and `type[Unknown]`.
+
 ## Simple
 
 ```py
-def f(x: type[Any]):
+def f(x: type[Any], y: type[str]):
     reveal_type(x)  # revealed: type[Any]
     # TODO: could be `<object.__repr__ type> & Any`
     reveal_type(x.__repr__)  # revealed: Any
+
+    z = x
+    x = y
+    y = z
 
 class A: ...
 
@@ -69,4 +75,21 @@ def test(x: Any, y: SomethingUnknown):
     reveal_type(x.__class__.__class__.__class__.__class__)  # revealed: type[Any]
     reveal_type(y.__class__)  # revealed: type[Unknown]
     reveal_type(y.__class__.__class__.__class__.__class__)  # revealed: type[Unknown]
+```
+
+## `type[Unknown]` has similar properties to `type[Any]`
+
+```py
+from typing import Any
+from does_not_exist import SomethingUnknown  # error: [unresolved-import]
+
+has_unknown_type = SomethingUnknown.__class__
+reveal_type(has_unknown_type)  # revealed: type[Unknown]
+
+def test(a: type[Any], b: type[str], c: type[Any], d: type[str]):
+    """Both `type[Any]` and `type[Unknown]` are assignable to all `type[]` types"""
+    a = b
+    b = c
+    c = has_unknown_type
+    d = has_unknown_type
 ```

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -863,13 +863,13 @@ impl<'db> Type<'db> {
                     base: ClassBase::Any | ClassBase::Todo(_) | ClassBase::Unknown,
                 }),
                 Type::Instance(_),
-            ) if target.is_subtype_of(db, KnownClass::Type.to_instance(db)) => true,
+            ) if target.is_assignable_to(db, KnownClass::Type.to_instance(db)) => true,
             (
                 Type::Instance(_),
                 Type::SubclassOf(SubclassOfType {
                     base: ClassBase::Any | ClassBase::Todo(_) | ClassBase::Unknown,
                 }),
-            ) if self.is_subtype_of(db, KnownClass::Type.to_instance(db)) => true,
+            ) if self.is_assignable_to(db, KnownClass::Type.to_instance(db)) => true,
             (
                 Type::ClassLiteral(_) | Type::SubclassOf(_),
                 Type::SubclassOf(SubclassOfType {

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -854,26 +854,26 @@ impl<'db> Type<'db> {
             }
             (
                 Type::SubclassOf(SubclassOfType {
-                    base: ClassBase::Any,
+                    base: ClassBase::Any | ClassBase::Todo(_) | ClassBase::Unknown,
                 }),
                 Type::SubclassOf(_),
             ) => true,
             (
                 Type::SubclassOf(SubclassOfType {
-                    base: ClassBase::Any,
+                    base: ClassBase::Any | ClassBase::Todo(_) | ClassBase::Unknown,
                 }),
-                Type::Instance(target),
-            ) if target.class.is_known(db, KnownClass::Type) => true,
+                Type::Instance(_),
+            ) if target.is_subtype_of(db, KnownClass::Type.to_instance(db)) => true,
             (
-                Type::Instance(class),
+                Type::Instance(_),
                 Type::SubclassOf(SubclassOfType {
-                    base: ClassBase::Any,
+                    base: ClassBase::Any | ClassBase::Todo(_) | ClassBase::Unknown,
                 }),
-            ) if class.class.is_known(db, KnownClass::Type) => true,
+            ) if self.is_subtype_of(db, KnownClass::Type.to_instance(db)) => true,
             (
                 Type::ClassLiteral(_) | Type::SubclassOf(_),
                 Type::SubclassOf(SubclassOfType {
-                    base: ClassBase::Any,
+                    base: ClassBase::Any | ClassBase::Todo(_) | ClassBase::Unknown,
                 }),
             ) => true,
             // TODO other types containing gradual forms (e.g. generics containing Any/Unknown)
@@ -3475,6 +3475,8 @@ pub(crate) mod tests {
     #[test_case(Ty::BuiltinClassLiteral("str"), Ty::SubclassOfAny)]
     #[test_case(Ty::SubclassOfBuiltinClass("str"), Ty::SubclassOfUnknown)]
     #[test_case(Ty::SubclassOfUnknown, Ty::SubclassOfBuiltinClass("str"))]
+    #[test_case(Ty::SubclassOfAny, Ty::AbcInstance("ABCMeta"))]
+    #[test_case(Ty::SubclassOfUnknown, Ty::AbcInstance("ABCMeta"))]
     fn is_assignable_to(from: Ty, to: Ty) {
         let db = setup_db();
         assert!(from.into_type(&db).is_assignable_to(&db, to.into_type(&db)));

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -3351,6 +3351,7 @@ pub(crate) mod tests {
         },
         Tuple(Vec<Ty>),
         SubclassOfAny,
+        SubclassOfUnknown,
         SubclassOfBuiltinClass(&'static str),
         StdlibModule(CoreStdlibModule),
         SliceLiteral(i32, i32, i32),
@@ -3398,6 +3399,7 @@ pub(crate) mod tests {
                     Type::tuple(db, elements)
                 }
                 Ty::SubclassOfAny => Type::subclass_of_base(ClassBase::Any),
+                Ty::SubclassOfUnknown => Type::subclass_of_base(ClassBase::Unknown),
                 Ty::SubclassOfBuiltinClass(s) => Type::subclass_of(
                     builtins_symbol(db, s)
                         .expect_type()
@@ -3471,6 +3473,8 @@ pub(crate) mod tests {
     #[test_case(Ty::BuiltinInstance("type"), Ty::SubclassOfBuiltinClass("object"))]
     #[test_case(Ty::BuiltinInstance("type"), Ty::BuiltinInstance("type"))]
     #[test_case(Ty::BuiltinClassLiteral("str"), Ty::SubclassOfAny)]
+    #[test_case(Ty::SubclassOfBuiltinClass("str"), Ty::SubclassOfUnknown)]
+    #[test_case(Ty::SubclassOfUnknown, Ty::SubclassOfBuiltinClass("str"))]
     fn is_assignable_to(from: Ty, to: Ty) {
         let db = setup_db();
         assert!(from.into_type(&db).is_assignable_to(&db, to.into_type(&db)));


### PR DESCRIPTION
## Summary

- `type[Unknown]` and `type[Todo]` should be considered assignable to all `type[]` types, just like `type[Any]`. Currently we do not treat them as such.
- `type[Any]` should be considered assignable to instances of subclasses of `type`. Currently we only consider it assignable to `Instance("builtins.type")`, and do not consider it assignable to `Instance("abc.ABCMeta")` -- but `ABCMeta` is a subclass of `type`.

## Test Plan

New unit tests and mdtests added. They fail on `main`.
