### PR TITLE
feat: add new FullPath OutputFormat

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -1,0 +1,12 @@
+export RUFF_UPDATE_SCHEMA := "1"
+
+alias b:=build
+
+pre-commit *args:
+    cargo dev generate-all
+    cargo clippy --workspace --all-targets --all-features -- -D warnings
+    cargo test {{args}}
+    uvx pre-commit run --all-files --show-diff-on-failure
+
+build:
+    cargo build --release

--- a/crates/ruff_linter/src/message/text.rs
+++ b/crates/ruff_linter/src/message/text.rs
@@ -34,6 +34,7 @@ bitflags! {
 pub struct TextEmitter {
     flags: EmitterFlags,
     unsafe_fixes: UnsafeFixes,
+    full_path: bool,
 }
 
 impl TextEmitter {
@@ -61,6 +62,12 @@ impl TextEmitter {
         self.unsafe_fixes = unsafe_fixes;
         self
     }
+
+    #[must_use]
+    pub fn with_full_path(mut self, full_path: bool) -> Self {
+        self.full_path = full_path;
+        self
+    }
 }
 
 impl Emitter for TextEmitter {
@@ -71,12 +78,21 @@ impl Emitter for TextEmitter {
         context: &EmitterContext,
     ) -> anyhow::Result<()> {
         for message in messages {
-            write!(
-                writer,
-                "{path}{sep}",
-                path = relativize_path(message.filename()).bold(),
-                sep = ":".cyan(),
-            )?;
+            if self.full_path {
+                write!(
+                    writer,
+                    "{path}{sep}",
+                    path = message.filename(),
+                    sep = ":".cyan(),
+                )?;
+            } else {
+                write!(
+                    writer,
+                    "{path}{sep}",
+                    path = relativize_path(message.filename()).bold(),
+                    sep = ":".cyan(),
+                )?;
+            }
 
             let start_location = message.compute_start_location();
             let notebook_index = context.notebook_index(message.filename());

--- a/crates/ruff_linter/src/settings/types.rs
+++ b/crates/ruff_linter/src/settings/types.rs
@@ -526,6 +526,7 @@ pub enum OutputFormat {
     Rdjson,
     Azure,
     Sarif,
+    FullPath,
 }
 
 impl Display for OutputFormat {
@@ -543,6 +544,7 @@ impl Display for OutputFormat {
             Self::Rdjson => write!(f, "rdjson"),
             Self::Azure => write!(f, "azure"),
             Self::Sarif => write!(f, "sarif"),
+            Self::FullPath => write!(f, "full_path"),
         }
     }
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -591,7 +591,7 @@ Options:
           Output serialization format for violations. The default serialization
           format is "full" [env: RUFF_OUTPUT_FORMAT=] [possible values:
           concise, full, json, json-lines, junit, grouped, github, gitlab,
-          pylint, rdjson, azure, sarif]
+          pylint, rdjson, azure, sarif, full-path]
   -o, --output-file <OUTPUT_FILE>
           Specify file to write the linter output to (default: stdout) [env:
           RUFF_OUTPUT_FILE=]

--- a/ruff.schema.json
+++ b/ruff.schema.json
@@ -2406,7 +2406,8 @@
         "pylint",
         "rdjson",
         "azure",
-        "sarif"
+        "sarif",
+        "full-path"
       ]
     },
     "ParametrizeNameType": {


### PR DESCRIPTION
## Summary

Hi, I'm new to Rust and have been working on a feature for that allows retrieving full paths (ie: --output-format=full-path). I've put some time into implementing it, but I'd appreciate it if someone familiar with the Rust or Ruff codebase could give me some feedback to ensure I'm on the right track. Also, is this the appropriate channel to ask about Ruff PR reviews? Thanks in advance!

Here's the issue https://github.com/astral-sh/ruff/issues/9417

## Test Plan

Hoping someone familiar with the codebase could guide me through... still trying to finish it up