### PR TITLE
Use stripping block (`|-`) for page descriptions

### DIFF
--- a/scripts/generate_mkdocs.py
+++ b/scripts/generate_mkdocs.py
@@ -157,7 +157,8 @@ def generate_rule_metadata(rule_doc: Path) -> None:
             "\n".join(
                 [
                     "---",
-                    f"description: {description}",
+                    "description: |-",
+                    f"  {description}",
                     "tags:",
                     f"- {rule_code}",
                     "---",


### PR DESCRIPTION
## Summary

Resolves #14976.

Currently, we uses this "[plain scalar](https://yaml.org/spec/1.2.2/#733-plain-style)" format:

```yaml
description: Checks for `if key in dictionary: del dictionary[key]`.
```

Plain scalar must not contain the sequence `: `, however, so the above is invalid.

This PR changes that to:

```yaml
description: |-
  Checks for `if key in dictionary: del dictionary[key]`.
```

`|` denotes a "[block scalar](https://yaml.org/spec/1.2.2/#81-block-scalar-styles)", whereas [the `-` chomping indicator](https://yaml.org/spec/1.2.2/#8112-block-chomping-indicator) requires that a trailing newline, if any, must be stripped.

## Test Plan

![](https://github.com/user-attachments/assets/f00b606a-d6fe-46ac-a1c5-6a8665204ea3)