### PR TITLE
Improve the documentation of E201/E202

### DIFF
--- a/crates/ruff_linter/src/rules/pycodestyle/rules/logical_lines/extraneous_whitespace.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/logical_lines/extraneous_whitespace.rs
@@ -11,7 +11,7 @@ use crate::checkers::logical_lines::LogicalLinesContext;
 use super::{LogicalLine, Whitespace};
 
 /// ## What it does
-/// Checks for the use of extraneous whitespace after "(".
+/// Checks for the use of extraneous whitespace after "(", "[" or "{".
 ///
 /// ## Why is this bad?
 /// [PEP 8] recommends the omission of whitespace in the following cases:
@@ -50,7 +50,7 @@ impl AlwaysFixableViolation for WhitespaceAfterOpenBracket {
 }
 
 /// ## What it does
-/// Checks for the use of extraneous whitespace before ")".
+/// Checks for the use of extraneous whitespace before ")", "]" or "}".
 ///
 /// ## Why is this bad?
 /// [PEP 8] recommends the omission of whitespace in the following cases:


### PR DESCRIPTION
## Summary

The summary is misleading, as well as the `whitespace-after-open-bracket` and `whitespace-before-close-bracket` names - it's not only brackets, but also parentheses and braces. Align the documentation with the actual behaviour.

Don't change the names, but align the documentation with the behaviour.

## Test Plan

No test (documentation).