### PR TITLE
Pin mdformat plugins in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,9 +26,9 @@ repos:
     hooks:
       - id: mdformat
         additional_dependencies:
-          - mdformat-mkdocs
-          - mdformat-admon
-          - mdformat-footnote
+          - mdformat-mkdocs<4.0.0
+          - mdformat-admon==2.0.6
+          - mdformat-footnote==0.1.1
         exclude: |
           (?x)^(
             docs/formatter/black\.md


### PR DESCRIPTION
The latest version of mdformat-mkdocs apparently conflicts with our other Markdown pre-commit hook, markdownlint. I haven't spent too much time figuring out if there's a way to make the latest versions of the two happy with each other, since the conflict is causing pre-commit to fail on the main branch.

I tested locally that pre-commit passes on this branch.