### PR TITLE
Check diagnostic refresh support from client capability

### DIFF
--- a/crates/ruff_server/src/session/capabilities.rs
+++ b/crates/ruff_server/src/session/capabilities.rs
@@ -37,18 +37,12 @@ impl ResolvedClientCapabilities {
             .and_then(|workspace_edit| workspace_edit.document_changes)
             .unwrap_or_default();
 
-        let workspace_refresh = true;
-
-        // TODO(jane): Once the bug involving workspace.diagnostic(s) deserialization has been fixed,
-        // uncomment this.
-        /*
         let workspace_refresh = client_capabilities
             .workspace
             .as_ref()
-            .and_then(|workspace| workspace.diagnostic.as_ref())
+            .and_then(|workspace| workspace.diagnostics.as_ref())
             .and_then(|diagnostic| diagnostic.refresh_support)
             .unwrap_or_default();
-        */
 
         let pull_diagnostics = client_capabilities
             .text_document


### PR DESCRIPTION
## Summary

Per the LSP spec, the property name is `workspace.diagnostics` with an `s` at the end but the `lsp-types` dependency uses `workspace.diagnostic` (without an `s`). Our fork contains this fix (https://github.com/astral-sh/lsp-types/commit/0f58d628799182647f688908ba752a33f854fb3a) so we should avoid the hardcoded value.

The implication of this is that the client which doesn't support workspace refresh capability didn't support the [dynamic configuration](https://docs.astral.sh/ruff/editors/features/#dynamic-configuration) feature because the server would _always_ send the workspace refresh request but the client would ignore it. We have a fallback logic to publish the diagnostics instead:

https://github.com/astral-sh/ruff/blob/5f6fc3988b5ce19790746921bd80cde9b646d690/crates/ruff_server/src/server/api/notifications/did_change_watched_files.rs#L28-L40

fixes: #15013 

## Test Plan

### VS Code

https://github.com/user-attachments/assets/61ac8e6f-aa20-41cc-b398-998e1866b5bc

### Neovim


https://github.com/user-attachments/assets/4131e13c-3fba-411c-9bb7-478d26eb8d56

