### PR TITLE
feat(AIR302): extend the following rules

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/airflow/AIR302_names.py
+++ b/crates/ruff_linter/resources/test/fixtures/airflow/AIR302_names.py
@@ -1,4 +1,13 @@
-from airflow import PY36, PY37, PY38, PY39, PY310, PY311, PY312, Dataset as DatasetFromRoot
+from airflow import (
+    PY36,
+    PY37,
+    PY38,
+    PY39,
+    PY310,
+    PY311,
+    PY312,
+    Dataset as DatasetFromRoot,
+)
 from airflow.api_connexion.security import requires_access, requires_access_dataset
 from airflow.auth.managers.base_auth_manager import is_authorized_dataset
 from airflow.auth.managers.models.resource_details import DatasetDetails
@@ -20,9 +29,13 @@ from airflow.datasets import (
     DatasetAll,
     DatasetAny,
     expand_alias_to_datasets,
-    metadata,
 )
-from airflow.datasets.manager import DatasetManager, dataset_manager, resolve_dataset_manager
+from airflow.datasets.metadata import Metadata
+from airflow.datasets.manager import (
+    DatasetManager,
+    dataset_manager,
+    resolve_dataset_manager,
+)
 from airflow.lineage.hook import DatasetLineageInfo
 from airflow.listeners.spec.dataset import on_dataset_changed, on_dataset_created
 from airflow.metrics.validators import AllowListValidator, BlockListValidator
@@ -38,7 +51,10 @@ from airflow.providers.common.io.datasets import file as common_io_file
 from airflow.providers.fab.auth_manager import fab_auth_manager
 from airflow.providers.google.datasets import bigquery, gcs
 from airflow.providers.mysql.datasets import mysql
-from airflow.providers.openlineage.utils.utils import DatasetInfo, translate_airflow_dataset
+from airflow.providers.openlineage.utils.utils import (
+    DatasetInfo,
+    translate_airflow_dataset,
+)
 from airflow.providers.postgres.datasets import postgres
 from airflow.providers.trino.datasets import trino
 from airflow.secrets.local_filesystem import get_connection, load_connections
@@ -101,7 +117,7 @@ DatasetAliasEvent
 DatasetAll
 DatasetAny
 expand_alias_to_datasets
-metadata
+Metadata
 
 # airflow.datasets.manager
 DatasetManager, dataset_manager, resolve_dataset_manager

--- a/crates/ruff_linter/resources/test/fixtures/airflow/AIR302_names.py
+++ b/crates/ruff_linter/resources/test/fixtures/airflow/AIR302_names.py
@@ -1,36 +1,38 @@
 from airflow import PY36, PY37, PY38, PY39, PY310, PY311, PY312
-from airflow.triggers.external_task import TaskStateTrigger
 from airflow.api_connexion.security import requires_access
 from airflow.configuration import (
+    as_dict,
     get,
     getboolean,
     getfloat,
     getint,
     has_option,
     remove_option,
-    as_dict,
     set,
 )
 from airflow.contrib.aws_athena_hook import AWSAthenaHook
-from airflow.metrics.validators import AllowListValidator
-from airflow.metrics.validators import BlockListValidator
-from airflow.operators.subdag import SubDagOperator
-from airflow.sensors.external_task import ExternalTaskSensorLink
+from airflow.metrics.validators import AllowListValidator, BlockListValidator
+from airflow.operators import dummy_operator
 from airflow.operators.bash_operator import BashOperator
 from airflow.operators.branch_operator import BaseBranchOperator
-from airflow.operators.dummy import EmptyOperator, DummyOperator
-from airflow.operators import dummy_operator
+from airflow.operators.dummy import DummyOperator, EmptyOperator
 from airflow.operators.email_operator import EmailOperator
+from airflow.operators.subdag import SubDagOperator
+from airflow.secrets.local_filesystem import get_connection, load_connections
 from airflow.sensors.base_sensor_operator import BaseSensorOperator
 from airflow.sensors.date_time_sensor import DateTimeSensor
+from airflow.sensors.external_task import (
+    ExternalTaskSensorLink as ExternalTaskSensorLinkFromExternalTask,
+)
 from airflow.sensors.external_task_sensor import (
     ExternalTaskMarker,
     ExternalTaskSensor,
-    ExternalTaskSensorLink,
+    ExternalTaskSensorLink as ExternalTaskSensorLinkFromExternalTaskSensor,
 )
 from airflow.sensors.time_delta_sensor import TimeDeltaSensor
-from airflow.secrets.local_filesystem import get_connection, load_connections
+from airflow.triggers.external_task import TaskStateTrigger
 from airflow.utils import dates
+from airflow.utils.dag_cycle_tester import test_cycle
 from airflow.utils.dates import (
     date_range,
     datetime_to_nano,
@@ -44,70 +46,104 @@ from airflow.utils.decorators import apply_defaults
 from airflow.utils.file import TemporaryDirectory, mkdirs
 from airflow.utils.helpers import chain, cross_downstream
 from airflow.utils.state import SHUTDOWN, terminating_states
-from airflow.utils.dag_cycle_tester import test_cycle
 from airflow.utils.trigger_rule import TriggerRule
 from airflow.www.auth import has_access
 from airflow.www.utils import get_sensitive_variables_fields, should_hide_value_for_key
 
+# airflow.PY\d{2}
 PY36, PY37, PY38, PY39, PY310, PY311, PY312
 
-AWSAthenaHook
-TaskStateTrigger
-
+# airflow.api_connexion.security
 requires_access
 
-AllowListValidator
-BlockListValidator
+# airflow.configuration
+get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
 
+
+# airflow.contrib.*
+AWSAthenaHook
+
+# airflow.metrics.validators
+AllowListValidator, BlockListValidator
+
+# airflow.operators.dummy_operator
+dummy_operator.EmptyOperator
+dummy_operator.DummyOperator
+
+# airflow.operators.bash_operator
+BashOperator
+
+# airflow.operators.branch_operator
+BaseBranchOperator
+
+# airflow.operators.dummy
+EmptyOperator, DummyOperator
+
+# airflow.operators.email_operator
+EmailOperator
+
+# airflow.operators.subdag.*
 SubDagOperator
 
+# airflow.secrets
+get_connection, load_connections
+
+# airflow.sensors.base_sensor_operator
+BaseSensorOperator
+
+# airflow.sensors.date_time_sensor
+DateTimeSensor
+
+# airflow.sensors.external_task
+ExternalTaskSensorLinkFromExternalTask
+
+# airflow.sensors.external_task_sensor
+ExternalTaskMarker
+ExternalTaskSensor
+ExternalTaskSensorLinkFromExternalTaskSensor
+
+# airflow.sensors.time_delta_sensor
+TimeDeltaSensor
+
+# airflow.triggers.external_task
+TaskStateTrigger
+
+# airflow.utils.date
 dates.date_range
 dates.days_ago
 
 date_range
 days_ago
+infer_time_unit
 parse_execution_date
 round_time
 scale_time_units
-infer_time_unit
-
 
 # This one was not deprecated.
 datetime_to_nano
 dates.datetime_to_nano
 
-get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+# airflow.utils.dag_cycle_tester
+test_cycle
 
-get_connection, load_connections
-
-
-ExternalTaskSensorLink
-BashOperator
-BaseBranchOperator
-EmptyOperator, DummyOperator
-dummy_operator.EmptyOperator
-dummy_operator.DummyOperator
-EmailOperator
-BaseSensorOperator
-DateTimeSensor
-(ExternalTaskMarker, ExternalTaskSensor, ExternalTaskSensorLink)
-TimeDeltaSensor
-
+# airflow.utils.decorators
 apply_defaults
 
-TemporaryDirectory
-mkdirs
+# airflow.utils.file
+TemporaryDirectory, mkdirs
 
-chain
-cross_downstream
+#  airflow.utils.helpers
+chain, cross_downstream
 
-SHUTDOWN
-terminating_states
+# airflow.utils.state
+SHUTDOWN, terminating_states
 
+#  airflow.utils.trigger_rule
 TriggerRule.DUMMY
 TriggerRule.NONE_FAILED_OR_SKIPPED
 
-test_cycle
-
+# airflow.www.auth
 has_access
+
+# airflow.www.utils
 get_sensitive_variables_fields, should_hide_value_for_key

--- a/crates/ruff_linter/src/rules/airflow/rules/removal_in_3.rs
+++ b/crates/ruff_linter/src/rules/airflow/rules/removal_in_3.rs
@@ -249,7 +249,12 @@ fn removed_name(checker: &mut Checker, expr: &Expr, ranged: impl Ranged) {
                     Replacement::Name("airflow.auth.managers.base_auth_manager.is_authorized_asset".to_string()),
                 )),
                 // airflow.contrib.*
-                ["airflow", "contrib", ..] => Some((qualname.to_string(), Replacement::None)),
+                ["airflow", "contrib", ..] => Some((qualname.to_string(),
+                    Replacement::Message(
+                        "The whole `airflow.contrib` module has been removed."
+                            .to_string(),
+                    ),
+                )),
                 // airflow.metrics.validators
                 ["airflow", "metrics", "validators", "AllowListValidator"] => Some((
                     qualname.to_string(),
@@ -333,11 +338,16 @@ fn removed_name(checker: &mut Checker, expr: &Expr, ranged: impl Ranged) {
                 )),
                 // airflow.operators
                 ["airflow", "operators", "subdag", ..] => {
-                    Some((qualname.to_string(), Replacement::None))
-                }
-                ["airflow.sensors.external_task.ExternalTaskSensorLink"] => Some((
+                    Some((
+                        qualname.to_string(),
+                        Replacement::Message(
+                            "The whole `airflow.subdag` module has been removed.".to_string(),
+                        ),
+                    ))
+                },
+                ["airflow", "sensors", "external_task", "ExternalTaskSensorLink"] => Some((
                     qualname.to_string(),
-                    Replacement::Name("airflow.sensors.external_task.ExternalDagLin".to_string()),
+                    Replacement::Name("airflow.sensors.external_task.ExternalDagLink".to_string()),
                 )),
                 ["airflow", "operators", "bash_operator", "BashOperator"] => Some((
                     qualname.to_string(),
@@ -390,7 +400,7 @@ fn removed_name(checker: &mut Checker, expr: &Expr, ranged: impl Ranged) {
                 ["airflow", "sensors", "external_task_sensor", "ExternalTaskSensorLink"] => Some((
                     qualname.to_string(),
                     Replacement::Name(
-                        "airflow.sensors.external_task.ExternalTaskSensorLink".to_string(),
+                        "airflow.sensors.external_task.ExternalDagLink".to_string(),
                     ),
                 )),
                 ["airflow", "sensors", "time_delta_sensor", "TimeDeltaSensor"] => Some((

--- a/crates/ruff_linter/src/rules/airflow/rules/removal_in_3.rs
+++ b/crates/ruff_linter/src/rules/airflow/rules/removal_in_3.rs
@@ -296,9 +296,9 @@ fn removed_name(checker: &mut Checker, expr: &Expr, ranged: impl Ranged) {
                     qualname.to_string(),
                     Replacement::Name("airflow.sdk.definitions.asset.expand_alias_to_assets".to_string()),
                 )),
-                ["airflow", "datasets", "metadata"] => Some((
+                ["airflow", "datasets", "metadata", "Metadata"] => Some((
                     qualname.to_string(),
-                    Replacement::Name("airflow.sdk.definitions.asset.metadata".to_string()),
+                    Replacement::Name("airflow.sdk.definitions.asset.metadata.Metadata".to_string()),
                 )),
                 // airflow.datasets.manager
                 ["airflow", "datasets", "manager", "dataset_manager"] => Some((

--- a/crates/ruff_linter/src/rules/airflow/rules/removal_in_3.rs
+++ b/crates/ruff_linter/src/rules/airflow/rules/removal_in_3.rs
@@ -160,14 +160,22 @@ fn removed_name(checker: &mut Checker, expr: &Expr, ranged: impl Ranged) {
             .semantic()
             .resolve_qualified_name(expr)
             .and_then(|qualname| match qualname.segments() {
-                ["airflow", "triggers", "external_task", "TaskStateTrigger"] => {
-                    Some((qualname.to_string(), Replacement::None))
-                }
                 ["airflow", "api_connexion", "security", "requires_access"] => Some((
                     qualname.to_string(),
                     Replacement::Name(
                         "airflow.api_connexion.security.requires_access_*".to_string(),
                     ),
+                )),
+                ["airflow", "api_connexion", "security", "requires_access_dataset"] => Some((
+                    qualname.to_string(),
+                    Replacement::Name("airflow.api_connexion.security.requires_access_asset".to_string()),
+                )),
+                ["airflow", "triggers", "external_task", "TaskStateTrigger"] => {
+                    Some((qualname.to_string(), Replacement::None))
+                }
+                ["airflow", "security", "permissions", "RESOURCE_DATASET"] => Some((
+                    qualname.to_string(),
+                    Replacement::Name("airflow.security.permissions.RESOURCE_ASSET".to_string()),
                 )),
                 // airflow.PY\d{1,2}
                 ["airflow", "PY36"] => Some((
@@ -231,6 +239,15 @@ fn removed_name(checker: &mut Checker, expr: &Expr, ranged: impl Ranged) {
                     qualname.to_string(),
                     Replacement::Name("airflow.configuration.conf.set".to_string()),
                 )),
+                // airflow.auth.managers
+                ["airflow", "auth", "managers", "models", "resource_details", "DatasetDetails"] => Some((
+                    qualname.to_string(),
+                    Replacement::Name("airflow.auth.managers.models.resource_details.AssetDetails".to_string()),
+                )),
+                ["airflow", "auth", "managers", "base_auth_manager", "is_authorized_dataset"] => Some((
+                    qualname.to_string(),
+                    Replacement::Name("airflow.auth.managers.base_auth_manager.is_authorized_asset".to_string()),
+                )),
                 // airflow.contrib.*
                 ["airflow", "contrib", ..] => Some((qualname.to_string(), Replacement::None)),
                 // airflow.metrics.validators
@@ -245,6 +262,74 @@ fn removed_name(checker: &mut Checker, expr: &Expr, ranged: impl Ranged) {
                     Replacement::Name(
                         "airflow.metrics.validators.PatternBlockListValidator".to_string(),
                     ),
+                )),
+                // airflow.datasets
+                ["airflow", "Dataset"] => Some((
+                    qualname.to_string(),
+                    Replacement::Name("airflow.sdk.definitions.asset.Asset".to_string()),
+                )),
+                ["airflow", "datasets", "DatasetAliasEvent"] => {
+                    Some((qualname.to_string(), Replacement::None))
+                }
+                ["airflow", "datasets", "Dataset"] => Some((
+                    qualname.to_string(),
+                    Replacement::Name("airflow.sdk.definitions.asset.Asset".to_string()),
+                )),
+                ["airflow", "datasets", "DatasetAlias"] => Some((
+                    qualname.to_string(),
+                    Replacement::Name("airflow.sdk.definitions.asset.AssetAlias".to_string()),
+                )),
+                ["airflow", "datasets", "DatasetAll"] => Some((
+                    qualname.to_string(),
+                    Replacement::Name("airflow.sdk.definitions.asset.AssetAll".to_string()),
+                )),
+                ["airflow", "datasets", "DatasetAny"] => Some((
+                    qualname.to_string(),
+                    Replacement::Name("airflow.sdk.definitions.asset.AssetAny".to_string()),
+                )),
+                ["airflow", "datasets", "expand_alias_to_datasets"] => Some((
+                    qualname.to_string(),
+                    Replacement::Name("airflow.sdk.definitions.asset.expand_alias_to_assets".to_string()),
+                )),
+                ["airflow", "datasets", "metadata"] => Some((
+                    qualname.to_string(),
+                    Replacement::Name("airflow.sdk.definitions.asset.metadata".to_string()),
+                )),
+                // airflow.datasets.manager
+                ["airflow", "datasets", "manager", "dataset_manager"] => Some((
+                    qualname.to_string(),
+                    Replacement::Name("airflow.assets.manager".to_string()),
+                )),
+                ["airflow", "datasets", "manager", "resolve_dataset_manager"] => Some((
+                    qualname.to_string(),
+                    Replacement::Name("airflow.assets.resolve_asset_manager".to_string()),
+                )),
+                ["airflow", "datasets.manager", "DatasetManager"] => Some((
+                    qualname.to_string(),
+                    Replacement::Name("airflow.assets.AssetManager".to_string()),
+                )),
+                // airflow.listeners.spec
+                ["airflow", "listeners", "spec", "dataset", "on_dataset_created"] => Some((
+                    qualname.to_string(),
+                    Replacement::Name("airflow.listeners.spec.asset.on_asset_created".to_string()),
+                )),
+                ["airflow", "listeners", "spec", "dataset", "on_dataset_changed"] => Some((
+                    qualname.to_string(),
+                    Replacement::Name("airflow.listeners.spec.asset.on_asset_changed".to_string()),
+                )),
+                // airflow.timetables
+                ["airflow", "timetables", "datasets", "DatasetOrTimeSchedule"] => Some((
+                    qualname.to_string(),
+                    Replacement::Name("airflow.timetables.assets.AssetOrTimeSchedule".to_string()),
+                )),
+                ["airflow", "timetables", "simple", "DatasetTriggeredTimetable"] => Some((
+                    qualname.to_string(),
+                    Replacement::Name("airflow.timetables.simple.AssetTriggeredTimetable".to_string()),
+                )),
+                // airflow.lineage.hook
+                ["airflow", "lineage", "hook", "DatasetLineageInfo"] => Some((
+                    qualname.to_string(),
+                    Replacement::Name("airflow.lineage.hook.AssetLineageInfo".to_string()),
                 )),
                 // airflow.operators
                 ["airflow", "operators", "subdag", ..] => {
@@ -354,7 +439,6 @@ fn removed_name(checker: &mut Checker, expr: &Expr, ranged: impl Ranged) {
                     qualname.to_string(),
                     Replacement::Name("pendulum.today('UTC').add(days=-N, ...)".to_string()),
                 )),
-
                 // airflow.utils.helpers
                 ["airflow", "utils", "helpers", "chain"] => Some((
                     qualname.to_string(),
@@ -394,6 +478,10 @@ fn removed_name(checker: &mut Checker, expr: &Expr, ranged: impl Ranged) {
                     qualname.to_string(),
                     Replacement::Name("airflow.www.auth.has_access_*".to_string()),
                 )),
+                ["airflow", "www", "auth", "has_access_dataset"] => Some((
+                    qualname.to_string(),
+                    Replacement::Name("airflow.www.auth.has_access_dataset.has_access_asset".to_string()),
+                )),
                 ["airflow", "www", "utils", "get_sensitive_variables_fields"] => Some((
                     qualname.to_string(),
                     Replacement::Name(
@@ -406,6 +494,42 @@ fn removed_name(checker: &mut Checker, expr: &Expr, ranged: impl Ranged) {
                     Replacement::Name(
                         "airflow.utils.log.secrets_masker.should_hide_value_for_key".to_string(),
                     ),
+                )),
+                // airflow.providers.amazon
+                ["airflow", "providers", "amazon", "aws", "datasets", "s3", "create_dataset"] => Some((
+                    qualname.to_string(),
+                    Replacement::Name("airflow.providers.amazon.aws.assets.s3.create_asset".to_string()),
+                )),
+                ["airflow", "providers", "amazon", "aws", "datasets", "s3", "convert_dataset_to_openlineage"] => Some((
+                    qualname.to_string(),
+                    Replacement::Name("airflow.providers.amazon.aws.assets.s3.convert_asset_to_openlineage".to_string()),
+                )),
+                ["airflow", "providers", "amazon", "auth_manager", "avp", "entities", "AvpEntities", "DATASET"] => Some((
+                    qualname.to_string(),
+                    Replacement::Name("airflow.providers.amazon.auth_manager.avp.entities.AvpEntities.ASSET".to_string()),
+                )),
+                // airflow.providers.common.io
+                ["airflow", "providers", "common", "io", "datasets", "file", "create_dataset"] => Some((
+                    qualname.to_string(),
+                    Replacement::Name("airflow.providers.common.io.assets.file.create_asset".to_string()),
+                )),
+                ["airflow", "providers", "common", "io", "datasets", "file", "convert_dataset_to_openlineage"] => Some((
+                    qualname.to_string(),
+                    Replacement::Name("airflow.providers.common.io.assets.file.convert_asset_to_openlineage".to_string()),
+                )),
+                // airflow.providers.fab
+                ["airflow", "providers", "fab", "auth_manager", "fab_auth_manager", "is_authorized_dataset"] => Some((
+                    qualname.to_string(),
+                    Replacement::Name("airflow.providers.fab.auth_manager.fab_auth_manager.is_authorized_asset".to_string()),
+                )),
+                // airflow.providers.openlineage
+                ["airflow", "providers", "openlineage", "utils", "utils", "DatasetInfo"] => Some((
+                    qualname.to_string(),
+                    Replacement::Name("airflow.providers.openlineage.utils.utils.AssetInfo".to_string()),
+                )),
+                ["airflow", "providers", "openlineage", "utils", "utils", "translate_airflow_dataset"] => Some((
+                    qualname.to_string(),
+                    Replacement::Name("airflow.providers.openlineage.utils.utils.translate_airflow_asset".to_string()),
                 )),
                 _ => None,
             });

--- a/crates/ruff_linter/src/rules/airflow/rules/removal_in_3.rs
+++ b/crates/ruff_linter/src/rules/airflow/rules/removal_in_3.rs
@@ -504,6 +504,10 @@ fn removed_name(checker: &mut Checker, expr: &Expr, ranged: impl Ranged) {
                     qualname.to_string(),
                     Replacement::Name("airflow.providers.amazon.aws.assets.s3.convert_asset_to_openlineage".to_string()),
                 )),
+                ["airflow", "providers", "amazon", "aws", "datasets", "s3", "sanitize_uri"] => Some((
+                    qualname.to_string(),
+                    Replacement::Name("airflow.providers.amazon.aws.assets.s3.sanitize_uri".to_string()),
+                )),
                 ["airflow", "providers", "amazon", "auth_manager", "avp", "entities", "AvpEntities", "DATASET"] => Some((
                     qualname.to_string(),
                     Replacement::Name("airflow.providers.amazon.auth_manager.avp.entities.AvpEntities.ASSET".to_string()),
@@ -517,10 +521,41 @@ fn removed_name(checker: &mut Checker, expr: &Expr, ranged: impl Ranged) {
                     qualname.to_string(),
                     Replacement::Name("airflow.providers.common.io.assets.file.convert_asset_to_openlineage".to_string()),
                 )),
+                ["airflow", "providers", "common", "io", "datasets", "file", "sanitize_uri"] => Some((
+                    qualname.to_string(),
+                    Replacement::Name("airflow.providers.common.io.assets.file.sanitize_uri".to_string()),
+                )),
                 // airflow.providers.fab
                 ["airflow", "providers", "fab", "auth_manager", "fab_auth_manager", "is_authorized_dataset"] => Some((
                     qualname.to_string(),
                     Replacement::Name("airflow.providers.fab.auth_manager.fab_auth_manager.is_authorized_asset".to_string()),
+                )),
+                // airflow.providers.google
+                ["airflow", "providers", "google", "datasets", "bigquery", "create_dataset"] => Some((
+                    qualname.to_string(),
+                    Replacement::Name("airflow.providers.google.assets.bigquery.create_asset".to_string()),
+                )),
+                ["airflow", "providers", "google", "datasets", "gcs", "create_dataset"] => Some((
+                    qualname.to_string(),
+                    Replacement::Name("airflow.providers.google.assets.gcs.create_asset".to_string()),
+                )),
+                ["airflow", "providers", "google", "datasets", "gcs", "convert_dataset_to_openlineage"] => Some((
+                    qualname.to_string(),
+                    Replacement::Name("airflow.providers.google.assets.gcs.convert_asset_to_openlineage".to_string()),
+                )),
+                ["airflow", "providers", "google", "datasets", "gcs", "sanitize_uri"] => Some((
+                    qualname.to_string(),
+                    Replacement::Name("airflow.providers.google.assets.gcs.sanitize_uri".to_string()),
+                )),
+                // airflow.providers.mysql
+                ["airflow", "providers", "mysql", "datasets", "mysql", "sanitize_uri"] => Some((
+                    qualname.to_string(),
+                    Replacement::Name("airflow.providers.mysql.assets.mysql.sanitize_uri".to_string()),
+                )),
+                // airflow.providers.postgres
+                ["airflow", "providers", "postgres", "datasets", "postgres", "sanitize_uri"] => Some((
+                    qualname.to_string(),
+                    Replacement::Name("airflow.providers.postgres.assets.postgres.sanitize_uri".to_string()),
                 )),
                 // airflow.providers.openlineage
                 ["airflow", "providers", "openlineage", "utils", "utils", "DatasetInfo"] => Some((
@@ -530,6 +565,11 @@ fn removed_name(checker: &mut Checker, expr: &Expr, ranged: impl Ranged) {
                 ["airflow", "providers", "openlineage", "utils", "utils", "translate_airflow_dataset"] => Some((
                     qualname.to_string(),
                     Replacement::Name("airflow.providers.openlineage.utils.utils.translate_airflow_asset".to_string()),
+                )),
+                // airflow.providers.trino
+                ["airflow", "providers", "trino", "datasets", "trino", "sanitize_uri"] => Some((
+                    qualname.to_string(),
+                    Replacement::Name("airflow.providers.trino.assets.trino.sanitize_uri".to_string()),
                 )),
                 _ => None,
             });

--- a/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_names.py.snap
+++ b/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_names.py.snap
@@ -2,543 +2,905 @@
 source: crates/ruff_linter/src/rules/airflow/mod.rs
 snapshot_kind: text
 ---
-AIR302_names.py:54:1: AIR302 `airflow.PY36` is removed in Airflow 3.0
+AIR302_names.py:80:1: AIR302 `airflow.PY36` is removed in Airflow 3.0
    |
-53 | # airflow.PY\d{2}
-54 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
+79 | # airflow root
+80 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
    | ^^^^ AIR302
-55 | 
-56 | # airflow.api_connexion.security
+81 | DatasetFromRoot
    |
    = help: Use `sys.version_info` instead
 
-AIR302_names.py:54:7: AIR302 `airflow.PY37` is removed in Airflow 3.0
+AIR302_names.py:80:7: AIR302 `airflow.PY37` is removed in Airflow 3.0
    |
-53 | # airflow.PY\d{2}
-54 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
+79 | # airflow root
+80 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
    |       ^^^^ AIR302
-55 | 
-56 | # airflow.api_connexion.security
+81 | DatasetFromRoot
    |
    = help: Use `sys.version_info` instead
 
-AIR302_names.py:54:13: AIR302 `airflow.PY38` is removed in Airflow 3.0
+AIR302_names.py:80:13: AIR302 `airflow.PY38` is removed in Airflow 3.0
    |
-53 | # airflow.PY\d{2}
-54 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
+79 | # airflow root
+80 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
    |             ^^^^ AIR302
-55 | 
-56 | # airflow.api_connexion.security
+81 | DatasetFromRoot
    |
    = help: Use `sys.version_info` instead
 
-AIR302_names.py:54:19: AIR302 `airflow.PY39` is removed in Airflow 3.0
+AIR302_names.py:80:19: AIR302 `airflow.PY39` is removed in Airflow 3.0
    |
-53 | # airflow.PY\d{2}
-54 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
+79 | # airflow root
+80 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
    |                   ^^^^ AIR302
-55 | 
-56 | # airflow.api_connexion.security
+81 | DatasetFromRoot
    |
    = help: Use `sys.version_info` instead
 
-AIR302_names.py:54:25: AIR302 `airflow.PY310` is removed in Airflow 3.0
+AIR302_names.py:80:25: AIR302 `airflow.PY310` is removed in Airflow 3.0
    |
-53 | # airflow.PY\d{2}
-54 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
+79 | # airflow root
+80 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
    |                         ^^^^^ AIR302
-55 | 
-56 | # airflow.api_connexion.security
+81 | DatasetFromRoot
    |
    = help: Use `sys.version_info` instead
 
-AIR302_names.py:54:32: AIR302 `airflow.PY311` is removed in Airflow 3.0
+AIR302_names.py:80:32: AIR302 `airflow.PY311` is removed in Airflow 3.0
    |
-53 | # airflow.PY\d{2}
-54 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
+79 | # airflow root
+80 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
    |                                ^^^^^ AIR302
-55 | 
-56 | # airflow.api_connexion.security
+81 | DatasetFromRoot
    |
    = help: Use `sys.version_info` instead
 
-AIR302_names.py:54:39: AIR302 `airflow.PY312` is removed in Airflow 3.0
+AIR302_names.py:80:39: AIR302 `airflow.PY312` is removed in Airflow 3.0
    |
-53 | # airflow.PY\d{2}
-54 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
+79 | # airflow root
+80 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
    |                                       ^^^^^ AIR302
-55 | 
-56 | # airflow.api_connexion.security
+81 | DatasetFromRoot
    |
    = help: Use `sys.version_info` instead
 
-AIR302_names.py:57:1: AIR302 `airflow.api_connexion.security.requires_access` is removed in Airflow 3.0
+AIR302_names.py:81:1: AIR302 `airflow.Dataset` is removed in Airflow 3.0
    |
-56 | # airflow.api_connexion.security
-57 | requires_access
+79 | # airflow root
+80 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
+81 | DatasetFromRoot
    | ^^^^^^^^^^^^^^^ AIR302
-58 | 
-59 | # airflow.configuration
+82 | 
+83 | # airflow.api_connexion.security
+   |
+   = help: Use `airflow.sdk.definitions.asset.Asset` instead
+
+AIR302_names.py:84:1: AIR302 `airflow.api_connexion.security.requires_access` is removed in Airflow 3.0
+   |
+83 | # airflow.api_connexion.security
+84 | requires_access, requires_access_dataset
+   | ^^^^^^^^^^^^^^^ AIR302
+85 | 
+86 | # airflow.auth.managers
    |
    = help: Use `airflow.api_connexion.security.requires_access_*` instead
 
-AIR302_names.py:60:1: AIR302 `airflow.configuration.get` is removed in Airflow 3.0
+AIR302_names.py:84:18: AIR302 `airflow.api_connexion.security.requires_access_dataset` is removed in Airflow 3.0
    |
-59 | # airflow.configuration
-60 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+83 | # airflow.api_connexion.security
+84 | requires_access, requires_access_dataset
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^ AIR302
+85 | 
+86 | # airflow.auth.managers
+   |
+   = help: Use `airflow.api_connexion.security.requires_access_asset` instead
+
+AIR302_names.py:87:1: AIR302 `airflow.auth.managers.base_auth_manager.is_authorized_dataset` is removed in Airflow 3.0
+   |
+86 | # airflow.auth.managers
+87 | is_authorized_dataset
+   | ^^^^^^^^^^^^^^^^^^^^^ AIR302
+88 | DatasetDetails
+   |
+   = help: Use `airflow.auth.managers.base_auth_manager.is_authorized_asset` instead
+
+AIR302_names.py:88:1: AIR302 `airflow.auth.managers.models.resource_details.DatasetDetails` is removed in Airflow 3.0
+   |
+86 | # airflow.auth.managers
+87 | is_authorized_dataset
+88 | DatasetDetails
+   | ^^^^^^^^^^^^^^ AIR302
+89 | 
+90 | # airflow.configuration
+   |
+   = help: Use `airflow.auth.managers.models.resource_details.AssetDetails` instead
+
+AIR302_names.py:91:1: AIR302 `airflow.configuration.get` is removed in Airflow 3.0
+   |
+90 | # airflow.configuration
+91 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
    | ^^^ AIR302
    |
    = help: Use `airflow.configuration.conf.get` instead
 
-AIR302_names.py:60:6: AIR302 `airflow.configuration.getboolean` is removed in Airflow 3.0
+AIR302_names.py:91:6: AIR302 `airflow.configuration.getboolean` is removed in Airflow 3.0
    |
-59 | # airflow.configuration
-60 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+90 | # airflow.configuration
+91 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
    |      ^^^^^^^^^^ AIR302
    |
    = help: Use `airflow.configuration.conf.getboolean` instead
 
-AIR302_names.py:60:18: AIR302 `airflow.configuration.getfloat` is removed in Airflow 3.0
+AIR302_names.py:91:18: AIR302 `airflow.configuration.getfloat` is removed in Airflow 3.0
    |
-59 | # airflow.configuration
-60 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+90 | # airflow.configuration
+91 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
    |                  ^^^^^^^^ AIR302
    |
    = help: Use `airflow.configuration.conf.getfloat` instead
 
-AIR302_names.py:60:28: AIR302 `airflow.configuration.getint` is removed in Airflow 3.0
+AIR302_names.py:91:28: AIR302 `airflow.configuration.getint` is removed in Airflow 3.0
    |
-59 | # airflow.configuration
-60 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+90 | # airflow.configuration
+91 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
    |                            ^^^^^^ AIR302
    |
    = help: Use `airflow.configuration.conf.getint` instead
 
-AIR302_names.py:60:36: AIR302 `airflow.configuration.has_option` is removed in Airflow 3.0
+AIR302_names.py:91:36: AIR302 `airflow.configuration.has_option` is removed in Airflow 3.0
    |
-59 | # airflow.configuration
-60 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+90 | # airflow.configuration
+91 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
    |                                    ^^^^^^^^^^ AIR302
    |
    = help: Use `airflow.configuration.conf.has_option` instead
 
-AIR302_names.py:60:48: AIR302 `airflow.configuration.remove_option` is removed in Airflow 3.0
+AIR302_names.py:91:48: AIR302 `airflow.configuration.remove_option` is removed in Airflow 3.0
    |
-59 | # airflow.configuration
-60 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+90 | # airflow.configuration
+91 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
    |                                                ^^^^^^^^^^^^^ AIR302
    |
    = help: Use `airflow.configuration.conf.remove_option` instead
 
-AIR302_names.py:60:63: AIR302 `airflow.configuration.as_dict` is removed in Airflow 3.0
+AIR302_names.py:91:63: AIR302 `airflow.configuration.as_dict` is removed in Airflow 3.0
    |
-59 | # airflow.configuration
-60 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+90 | # airflow.configuration
+91 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
    |                                                               ^^^^^^^ AIR302
    |
    = help: Use `airflow.configuration.conf.as_dict` instead
 
-AIR302_names.py:60:72: AIR302 `airflow.configuration.set` is removed in Airflow 3.0
+AIR302_names.py:91:72: AIR302 `airflow.configuration.set` is removed in Airflow 3.0
    |
-59 | # airflow.configuration
-60 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+90 | # airflow.configuration
+91 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
    |                                                                        ^^^ AIR302
    |
    = help: Use `airflow.configuration.conf.set` instead
 
-AIR302_names.py:64:1: AIR302 `airflow.contrib.aws_athena_hook.AWSAthenaHook` is removed in Airflow 3.0; The whole `airflow.contrib` module has been removed.
+AIR302_names.py:95:1: AIR302 `airflow.contrib.aws_athena_hook.AWSAthenaHook` is removed in Airflow 3.0; The whole `airflow.contrib` module has been removed.
    |
-63 | # airflow.contrib.*
-64 | AWSAthenaHook
+94 | # airflow.contrib.*
+95 | AWSAthenaHook
    | ^^^^^^^^^^^^^ AIR302
-65 | 
-66 | # airflow.metrics.validators
-   |
-
-AIR302_names.py:67:1: AIR302 `airflow.metrics.validators.AllowListValidator` is removed in Airflow 3.0
-   |
-66 | # airflow.metrics.validators
-67 | AllowListValidator, BlockListValidator
-   | ^^^^^^^^^^^^^^^^^^ AIR302
-68 | 
-69 | # airflow.operators.dummy_operator
-   |
-   = help: Use `airflow.metrics.validators.PatternAllowListValidator` instead
-
-AIR302_names.py:67:21: AIR302 `airflow.metrics.validators.BlockListValidator` is removed in Airflow 3.0
-   |
-66 | # airflow.metrics.validators
-67 | AllowListValidator, BlockListValidator
-   |                     ^^^^^^^^^^^^^^^^^^ AIR302
-68 | 
-69 | # airflow.operators.dummy_operator
-   |
-   = help: Use `airflow.metrics.validators.PatternBlockListValidator` instead
-
-AIR302_names.py:70:16: AIR302 `airflow.operators.dummy_operator.EmptyOperator` is removed in Airflow 3.0
-   |
-69 | # airflow.operators.dummy_operator
-70 | dummy_operator.EmptyOperator
-   |                ^^^^^^^^^^^^^ AIR302
-71 | dummy_operator.DummyOperator
-   |
-   = help: Use `airflow.operators.empty.EmptyOperator` instead
-
-AIR302_names.py:71:16: AIR302 `airflow.operators.dummy_operator.DummyOperator` is removed in Airflow 3.0
-   |
-69 | # airflow.operators.dummy_operator
-70 | dummy_operator.EmptyOperator
-71 | dummy_operator.DummyOperator
-   |                ^^^^^^^^^^^^^ AIR302
-72 | 
-73 | # airflow.operators.bash_operator
-   |
-   = help: Use `airflow.operators.empty.EmptyOperator` instead
-
-AIR302_names.py:74:1: AIR302 `airflow.operators.bash_operator.BashOperator` is removed in Airflow 3.0
-   |
-73 | # airflow.operators.bash_operator
-74 | BashOperator
-   | ^^^^^^^^^^^^ AIR302
-75 | 
-76 | # airflow.operators.branch_operator
-   |
-   = help: Use `airflow.operators.bash.BashOperator` instead
-
-AIR302_names.py:77:1: AIR302 `airflow.operators.branch_operator.BaseBranchOperator` is removed in Airflow 3.0
-   |
-76 | # airflow.operators.branch_operator
-77 | BaseBranchOperator
-   | ^^^^^^^^^^^^^^^^^^ AIR302
-78 | 
-79 | # airflow.operators.dummy
-   |
-   = help: Use `airflow.operators.branch.BaseBranchOperator` instead
-
-AIR302_names.py:80:16: AIR302 `airflow.operators.dummy.DummyOperator` is removed in Airflow 3.0
-   |
-79 | # airflow.operators.dummy
-80 | EmptyOperator, DummyOperator
-   |                ^^^^^^^^^^^^^ AIR302
-81 | 
-82 | # airflow.operators.email_operator
-   |
-   = help: Use `airflow.operators.empty.EmptyOperator` instead
-
-AIR302_names.py:83:1: AIR302 `airflow.operators.email_operator.EmailOperator` is removed in Airflow 3.0
-   |
-82 | # airflow.operators.email_operator
-83 | EmailOperator
-   | ^^^^^^^^^^^^^ AIR302
-84 | 
-85 | # airflow.operators.subdag.*
-   |
-   = help: Use `airflow.operators.email.EmailOperator` instead
-
-AIR302_names.py:86:1: AIR302 `airflow.operators.subdag.SubDagOperator` is removed in Airflow 3.0; The whole `airflow.subdag` module has been removed.
-   |
-85 | # airflow.operators.subdag.*
-86 | SubDagOperator
-   | ^^^^^^^^^^^^^^ AIR302
-87 | 
-88 | # airflow.secrets
-   |
-
-AIR302_names.py:89:1: AIR302 `airflow.secrets.local_filesystem.get_connection` is removed in Airflow 3.0
-   |
-88 | # airflow.secrets
-89 | get_connection, load_connections
-   | ^^^^^^^^^^^^^^ AIR302
-90 | 
-91 | # airflow.sensors.base_sensor_operator
-   |
-   = help: Use `airflow.secrets.local_filesystem.load_connections_dict` instead
-
-AIR302_names.py:89:17: AIR302 `airflow.secrets.local_filesystem.load_connections` is removed in Airflow 3.0
-   |
-88 | # airflow.secrets
-89 | get_connection, load_connections
-   |                 ^^^^^^^^^^^^^^^^ AIR302
-90 | 
-91 | # airflow.sensors.base_sensor_operator
-   |
-   = help: Use `airflow.secrets.local_filesystem.load_connections_dict` instead
-
-AIR302_names.py:92:1: AIR302 `airflow.sensors.base_sensor_operator.BaseSensorOperator` is removed in Airflow 3.0
-   |
-91 | # airflow.sensors.base_sensor_operator
-92 | BaseSensorOperator
-   | ^^^^^^^^^^^^^^^^^^ AIR302
-93 | 
-94 | # airflow.sensors.date_time_sensor
-   |
-   = help: Use `airflow.sensors.base.BaseSensorOperator` instead
-
-AIR302_names.py:95:1: AIR302 `airflow.sensors.date_time_sensor.DateTimeSensor` is removed in Airflow 3.0
-   |
-94 | # airflow.sensors.date_time_sensor
-95 | DateTimeSensor
-   | ^^^^^^^^^^^^^^ AIR302
 96 | 
-97 | # airflow.sensors.external_task
+97 | # airflow.datasets
    |
-   = help: Use `airflow.sensors.date_time.DateTimeSensor` instead
 
-AIR302_names.py:98:1: AIR302 `airflow.sensors.external_task.ExternalTaskSensorLink` is removed in Airflow 3.0
+AIR302_names.py:98:1: AIR302 `airflow.datasets.Dataset` is removed in Airflow 3.0
     |
- 97 | # airflow.sensors.external_task
- 98 | ExternalTaskSensorLinkFromExternalTask
+ 97 | # airflow.datasets
+ 98 | Dataset
+    | ^^^^^^^ AIR302
+ 99 | DatasetAlias
+100 | DatasetAliasEvent
+    |
+    = help: Use `airflow.sdk.definitions.asset.Asset` instead
+
+AIR302_names.py:99:1: AIR302 `airflow.datasets.DatasetAlias` is removed in Airflow 3.0
+    |
+ 97 | # airflow.datasets
+ 98 | Dataset
+ 99 | DatasetAlias
+    | ^^^^^^^^^^^^ AIR302
+100 | DatasetAliasEvent
+101 | DatasetAll
+    |
+    = help: Use `airflow.sdk.definitions.asset.AssetAlias` instead
+
+AIR302_names.py:100:1: AIR302 `airflow.datasets.DatasetAliasEvent` is removed in Airflow 3.0
+    |
+ 98 | Dataset
+ 99 | DatasetAlias
+100 | DatasetAliasEvent
+    | ^^^^^^^^^^^^^^^^^ AIR302
+101 | DatasetAll
+102 | DatasetAny
+    |
+
+AIR302_names.py:101:1: AIR302 `airflow.datasets.DatasetAll` is removed in Airflow 3.0
+    |
+ 99 | DatasetAlias
+100 | DatasetAliasEvent
+101 | DatasetAll
+    | ^^^^^^^^^^ AIR302
+102 | DatasetAny
+103 | expand_alias_to_datasets
+    |
+    = help: Use `airflow.sdk.definitions.asset.AssetAll` instead
+
+AIR302_names.py:102:1: AIR302 `airflow.datasets.DatasetAny` is removed in Airflow 3.0
+    |
+100 | DatasetAliasEvent
+101 | DatasetAll
+102 | DatasetAny
+    | ^^^^^^^^^^ AIR302
+103 | expand_alias_to_datasets
+104 | metadata
+    |
+    = help: Use `airflow.sdk.definitions.asset.AssetAny` instead
+
+AIR302_names.py:103:1: AIR302 `airflow.datasets.expand_alias_to_datasets` is removed in Airflow 3.0
+    |
+101 | DatasetAll
+102 | DatasetAny
+103 | expand_alias_to_datasets
+    | ^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
+104 | metadata
+    |
+    = help: Use `airflow.sdk.definitions.asset.expand_alias_to_assets` instead
+
+AIR302_names.py:104:1: AIR302 `airflow.datasets.metadata` is removed in Airflow 3.0
+    |
+102 | DatasetAny
+103 | expand_alias_to_datasets
+104 | metadata
+    | ^^^^^^^^ AIR302
+105 | 
+106 | # airflow.datasets.manager
+    |
+    = help: Use `airflow.sdk.definitions.asset.metadata` instead
+
+AIR302_names.py:107:17: AIR302 `airflow.datasets.manager.dataset_manager` is removed in Airflow 3.0
+    |
+106 | # airflow.datasets.manager
+107 | DatasetManager, dataset_manager, resolve_dataset_manager
+    |                 ^^^^^^^^^^^^^^^ AIR302
+108 | 
+109 | # airflow.lineage.hook
+    |
+    = help: Use `airflow.assets.manager` instead
+
+AIR302_names.py:107:34: AIR302 `airflow.datasets.manager.resolve_dataset_manager` is removed in Airflow 3.0
+    |
+106 | # airflow.datasets.manager
+107 | DatasetManager, dataset_manager, resolve_dataset_manager
+    |                                  ^^^^^^^^^^^^^^^^^^^^^^^ AIR302
+108 | 
+109 | # airflow.lineage.hook
+    |
+    = help: Use `airflow.assets.resolve_asset_manager` instead
+
+AIR302_names.py:110:1: AIR302 `airflow.lineage.hook.DatasetLineageInfo` is removed in Airflow 3.0
+    |
+109 | # airflow.lineage.hook
+110 | DatasetLineageInfo
+    | ^^^^^^^^^^^^^^^^^^ AIR302
+111 | 
+112 | # airflow.listeners.spec.dataset
+    |
+    = help: Use `airflow.lineage.hook.AssetLineageInfo` instead
+
+AIR302_names.py:113:1: AIR302 `airflow.listeners.spec.dataset.on_dataset_changed` is removed in Airflow 3.0
+    |
+112 | # airflow.listeners.spec.dataset
+113 | on_dataset_changed, on_dataset_created
+    | ^^^^^^^^^^^^^^^^^^ AIR302
+114 | 
+115 | # airflow.metrics.validators
+    |
+    = help: Use `airflow.listeners.spec.asset.on_asset_changed` instead
+
+AIR302_names.py:113:21: AIR302 `airflow.listeners.spec.dataset.on_dataset_created` is removed in Airflow 3.0
+    |
+112 | # airflow.listeners.spec.dataset
+113 | on_dataset_changed, on_dataset_created
+    |                     ^^^^^^^^^^^^^^^^^^ AIR302
+114 | 
+115 | # airflow.metrics.validators
+    |
+    = help: Use `airflow.listeners.spec.asset.on_asset_created` instead
+
+AIR302_names.py:116:1: AIR302 `airflow.metrics.validators.AllowListValidator` is removed in Airflow 3.0
+    |
+115 | # airflow.metrics.validators
+116 | AllowListValidator, BlockListValidator
+    | ^^^^^^^^^^^^^^^^^^ AIR302
+117 | 
+118 | # airflow.operators.dummy_operator
+    |
+    = help: Use `airflow.metrics.validators.PatternAllowListValidator` instead
+
+AIR302_names.py:116:21: AIR302 `airflow.metrics.validators.BlockListValidator` is removed in Airflow 3.0
+    |
+115 | # airflow.metrics.validators
+116 | AllowListValidator, BlockListValidator
+    |                     ^^^^^^^^^^^^^^^^^^ AIR302
+117 | 
+118 | # airflow.operators.dummy_operator
+    |
+    = help: Use `airflow.metrics.validators.PatternBlockListValidator` instead
+
+AIR302_names.py:119:16: AIR302 `airflow.operators.dummy_operator.EmptyOperator` is removed in Airflow 3.0
+    |
+118 | # airflow.operators.dummy_operator
+119 | dummy_operator.EmptyOperator
+    |                ^^^^^^^^^^^^^ AIR302
+120 | dummy_operator.DummyOperator
+    |
+    = help: Use `airflow.operators.empty.EmptyOperator` instead
+
+AIR302_names.py:120:16: AIR302 `airflow.operators.dummy_operator.DummyOperator` is removed in Airflow 3.0
+    |
+118 | # airflow.operators.dummy_operator
+119 | dummy_operator.EmptyOperator
+120 | dummy_operator.DummyOperator
+    |                ^^^^^^^^^^^^^ AIR302
+121 | 
+122 | # airflow.operators.bash_operator
+    |
+    = help: Use `airflow.operators.empty.EmptyOperator` instead
+
+AIR302_names.py:123:1: AIR302 `airflow.operators.bash_operator.BashOperator` is removed in Airflow 3.0
+    |
+122 | # airflow.operators.bash_operator
+123 | BashOperator
+    | ^^^^^^^^^^^^ AIR302
+124 | 
+125 | # airflow.operators.branch_operator
+    |
+    = help: Use `airflow.operators.bash.BashOperator` instead
+
+AIR302_names.py:126:1: AIR302 `airflow.operators.branch_operator.BaseBranchOperator` is removed in Airflow 3.0
+    |
+125 | # airflow.operators.branch_operator
+126 | BaseBranchOperator
+    | ^^^^^^^^^^^^^^^^^^ AIR302
+127 | 
+128 | # airflow.operators.dummy
+    |
+    = help: Use `airflow.operators.branch.BaseBranchOperator` instead
+
+AIR302_names.py:129:16: AIR302 `airflow.operators.dummy.DummyOperator` is removed in Airflow 3.0
+    |
+128 | # airflow.operators.dummy
+129 | EmptyOperator, DummyOperator
+    |                ^^^^^^^^^^^^^ AIR302
+130 | 
+131 | # airflow.operators.email_operator
+    |
+    = help: Use `airflow.operators.empty.EmptyOperator` instead
+
+AIR302_names.py:132:1: AIR302 `airflow.operators.email_operator.EmailOperator` is removed in Airflow 3.0
+    |
+131 | # airflow.operators.email_operator
+132 | EmailOperator
+    | ^^^^^^^^^^^^^ AIR302
+133 | 
+134 | # airflow.operators.subdag.*
+    |
+    = help: Use `airflow.operators.email.EmailOperator` instead
+
+AIR302_names.py:135:1: AIR302 `airflow.operators.subdag.SubDagOperator` is removed in Airflow 3.0; The whole `airflow.subdag` module has been removed.
+    |
+134 | # airflow.operators.subdag.*
+135 | SubDagOperator
+    | ^^^^^^^^^^^^^^ AIR302
+136 | 
+137 | # airflow.providers.amazon
+    |
+
+AIR302_names.py:138:13: AIR302 `airflow.providers.amazon.auth_manager.avp.entities.AvpEntities.DATASET` is removed in Airflow 3.0
+    |
+137 | # airflow.providers.amazon
+138 | AvpEntities.DATASET
+    |             ^^^^^^^ AIR302
+139 | s3.create_dataset
+140 | s3.convert_dataset_to_openlineage
+    |
+    = help: Use `airflow.providers.amazon.auth_manager.avp.entities.AvpEntities.ASSET` instead
+
+AIR302_names.py:139:4: AIR302 `airflow.providers.amazon.aws.datasets.s3.create_dataset` is removed in Airflow 3.0
+    |
+137 | # airflow.providers.amazon
+138 | AvpEntities.DATASET
+139 | s3.create_dataset
+    |    ^^^^^^^^^^^^^^ AIR302
+140 | s3.convert_dataset_to_openlineage
+141 | s3.sanitize_uri
+    |
+    = help: Use `airflow.providers.amazon.aws.assets.s3.create_asset` instead
+
+AIR302_names.py:140:4: AIR302 `airflow.providers.amazon.aws.datasets.s3.convert_dataset_to_openlineage` is removed in Airflow 3.0
+    |
+138 | AvpEntities.DATASET
+139 | s3.create_dataset
+140 | s3.convert_dataset_to_openlineage
+    |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
+141 | s3.sanitize_uri
+    |
+    = help: Use `airflow.providers.amazon.aws.assets.s3.convert_asset_to_openlineage` instead
+
+AIR302_names.py:141:4: AIR302 `airflow.providers.amazon.aws.datasets.s3.sanitize_uri` is removed in Airflow 3.0
+    |
+139 | s3.create_dataset
+140 | s3.convert_dataset_to_openlineage
+141 | s3.sanitize_uri
+    |    ^^^^^^^^^^^^ AIR302
+142 | 
+143 | # airflow.providers.common.io
+    |
+    = help: Use `airflow.providers.amazon.aws.assets.s3.sanitize_uri` instead
+
+AIR302_names.py:144:16: AIR302 `airflow.providers.common.io.datasets.file.convert_dataset_to_openlineage` is removed in Airflow 3.0
+    |
+143 | # airflow.providers.common.io
+144 | common_io_file.convert_dataset_to_openlineage
+    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
+145 | common_io_file.create_dataset
+146 | common_io_file.sanitize_uri
+    |
+    = help: Use `airflow.providers.common.io.assets.file.convert_asset_to_openlineage` instead
+
+AIR302_names.py:145:16: AIR302 `airflow.providers.common.io.datasets.file.create_dataset` is removed in Airflow 3.0
+    |
+143 | # airflow.providers.common.io
+144 | common_io_file.convert_dataset_to_openlineage
+145 | common_io_file.create_dataset
+    |                ^^^^^^^^^^^^^^ AIR302
+146 | common_io_file.sanitize_uri
+    |
+    = help: Use `airflow.providers.common.io.assets.file.create_asset` instead
+
+AIR302_names.py:146:16: AIR302 `airflow.providers.common.io.datasets.file.sanitize_uri` is removed in Airflow 3.0
+    |
+144 | common_io_file.convert_dataset_to_openlineage
+145 | common_io_file.create_dataset
+146 | common_io_file.sanitize_uri
+    |                ^^^^^^^^^^^^ AIR302
+147 | 
+148 | # airflow.providers.fab
+    |
+    = help: Use `airflow.providers.common.io.assets.file.sanitize_uri` instead
+
+AIR302_names.py:149:18: AIR302 `airflow.providers.fab.auth_manager.fab_auth_manager.is_authorized_dataset` is removed in Airflow 3.0
+    |
+148 | # airflow.providers.fab
+149 | fab_auth_manager.is_authorized_dataset
+    |                  ^^^^^^^^^^^^^^^^^^^^^ AIR302
+150 | 
+151 | # airflow.providers.google
+    |
+    = help: Use `airflow.providers.fab.auth_manager.fab_auth_manager.is_authorized_asset` instead
+
+AIR302_names.py:154:5: AIR302 `airflow.providers.google.datasets.gcs.create_dataset` is removed in Airflow 3.0
+    |
+152 | bigquery.sanitize_uri
+153 | 
+154 | gcs.create_dataset
+    |     ^^^^^^^^^^^^^^ AIR302
+155 | gcs.sanitize_uri
+156 | gcs.convert_dataset_to_openlineage
+    |
+    = help: Use `airflow.providers.google.assets.gcs.create_asset` instead
+
+AIR302_names.py:155:5: AIR302 `airflow.providers.google.datasets.gcs.sanitize_uri` is removed in Airflow 3.0
+    |
+154 | gcs.create_dataset
+155 | gcs.sanitize_uri
+    |     ^^^^^^^^^^^^ AIR302
+156 | gcs.convert_dataset_to_openlineage
+    |
+    = help: Use `airflow.providers.google.assets.gcs.sanitize_uri` instead
+
+AIR302_names.py:156:5: AIR302 `airflow.providers.google.datasets.gcs.convert_dataset_to_openlineage` is removed in Airflow 3.0
+    |
+154 | gcs.create_dataset
+155 | gcs.sanitize_uri
+156 | gcs.convert_dataset_to_openlineage
+    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
+157 | 
+158 | # airflow.providers.mysql
+    |
+    = help: Use `airflow.providers.google.assets.gcs.convert_asset_to_openlineage` instead
+
+AIR302_names.py:159:7: AIR302 `airflow.providers.mysql.datasets.mysql.sanitize_uri` is removed in Airflow 3.0
+    |
+158 | # airflow.providers.mysql
+159 | mysql.sanitize_uri
+    |       ^^^^^^^^^^^^ AIR302
+160 | 
+161 | # airflow.providers.openlineage
+    |
+    = help: Use `airflow.providers.mysql.assets.mysql.sanitize_uri` instead
+
+AIR302_names.py:162:1: AIR302 `airflow.providers.openlineage.utils.utils.DatasetInfo` is removed in Airflow 3.0
+    |
+161 | # airflow.providers.openlineage
+162 | DatasetInfo, translate_airflow_dataset
+    | ^^^^^^^^^^^ AIR302
+163 | 
+164 | # airflow.providers.postgres
+    |
+    = help: Use `airflow.providers.openlineage.utils.utils.AssetInfo` instead
+
+AIR302_names.py:162:14: AIR302 `airflow.providers.openlineage.utils.utils.translate_airflow_dataset` is removed in Airflow 3.0
+    |
+161 | # airflow.providers.openlineage
+162 | DatasetInfo, translate_airflow_dataset
+    |              ^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
+163 | 
+164 | # airflow.providers.postgres
+    |
+    = help: Use `airflow.providers.openlineage.utils.utils.translate_airflow_asset` instead
+
+AIR302_names.py:165:10: AIR302 `airflow.providers.postgres.datasets.postgres.sanitize_uri` is removed in Airflow 3.0
+    |
+164 | # airflow.providers.postgres
+165 | postgres.sanitize_uri
+    |          ^^^^^^^^^^^^ AIR302
+166 | 
+167 | # airflow.providers.trino
+    |
+    = help: Use `airflow.providers.postgres.assets.postgres.sanitize_uri` instead
+
+AIR302_names.py:168:7: AIR302 `airflow.providers.trino.datasets.trino.sanitize_uri` is removed in Airflow 3.0
+    |
+167 | # airflow.providers.trino
+168 | trino.sanitize_uri
+    |       ^^^^^^^^^^^^ AIR302
+169 | 
+170 | # airflow.secrets
+    |
+    = help: Use `airflow.providers.trino.assets.trino.sanitize_uri` instead
+
+AIR302_names.py:171:1: AIR302 `airflow.secrets.local_filesystem.get_connection` is removed in Airflow 3.0
+    |
+170 | # airflow.secrets
+171 | get_connection, load_connections
+    | ^^^^^^^^^^^^^^ AIR302
+172 | 
+173 | # airflow.security.permissions
+    |
+    = help: Use `airflow.secrets.local_filesystem.load_connections_dict` instead
+
+AIR302_names.py:171:17: AIR302 `airflow.secrets.local_filesystem.load_connections` is removed in Airflow 3.0
+    |
+170 | # airflow.secrets
+171 | get_connection, load_connections
+    |                 ^^^^^^^^^^^^^^^^ AIR302
+172 | 
+173 | # airflow.security.permissions
+    |
+    = help: Use `airflow.secrets.local_filesystem.load_connections_dict` instead
+
+AIR302_names.py:174:1: AIR302 `airflow.security.permissions.RESOURCE_DATASET` is removed in Airflow 3.0
+    |
+173 | # airflow.security.permissions
+174 | RESOURCE_DATASET
+    | ^^^^^^^^^^^^^^^^ AIR302
+175 | 
+176 | # airflow.sensors.base_sensor_operator
+    |
+    = help: Use `airflow.security.permissions.RESOURCE_ASSET` instead
+
+AIR302_names.py:177:1: AIR302 `airflow.sensors.base_sensor_operator.BaseSensorOperator` is removed in Airflow 3.0
+    |
+176 | # airflow.sensors.base_sensor_operator
+177 | BaseSensorOperator
+    | ^^^^^^^^^^^^^^^^^^ AIR302
+178 | 
+179 | # airflow.sensors.date_time_sensor
+    |
+    = help: Use `airflow.sensors.base.BaseSensorOperator` instead
+
+AIR302_names.py:180:1: AIR302 `airflow.sensors.date_time_sensor.DateTimeSensor` is removed in Airflow 3.0
+    |
+179 | # airflow.sensors.date_time_sensor
+180 | DateTimeSensor
+    | ^^^^^^^^^^^^^^ AIR302
+181 | 
+182 | # airflow.sensors.external_task
+    |
+    = help: Use `airflow.sensors.date_time.DateTimeSensor` instead
+
+AIR302_names.py:183:1: AIR302 `airflow.sensors.external_task.ExternalTaskSensorLink` is removed in Airflow 3.0
+    |
+182 | # airflow.sensors.external_task
+183 | ExternalTaskSensorLinkFromExternalTask
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
- 99 | 
-100 | # airflow.sensors.external_task_sensor
+184 | 
+185 | # airflow.sensors.external_task_sensor
     |
     = help: Use `airflow.sensors.external_task.ExternalDagLink` instead
 
-AIR302_names.py:101:1: AIR302 `airflow.sensors.external_task_sensor.ExternalTaskMarker` is removed in Airflow 3.0
+AIR302_names.py:186:1: AIR302 `airflow.sensors.external_task_sensor.ExternalTaskMarker` is removed in Airflow 3.0
     |
-100 | # airflow.sensors.external_task_sensor
-101 | ExternalTaskMarker
+185 | # airflow.sensors.external_task_sensor
+186 | ExternalTaskMarker
     | ^^^^^^^^^^^^^^^^^^ AIR302
-102 | ExternalTaskSensor
-103 | ExternalTaskSensorLinkFromExternalTaskSensor
+187 | ExternalTaskSensor
+188 | ExternalTaskSensorLinkFromExternalTaskSensor
     |
     = help: Use `airflow.sensors.external_task.ExternalTaskMarker` instead
 
-AIR302_names.py:102:1: AIR302 `airflow.sensors.external_task_sensor.ExternalTaskSensor` is removed in Airflow 3.0
+AIR302_names.py:187:1: AIR302 `airflow.sensors.external_task_sensor.ExternalTaskSensor` is removed in Airflow 3.0
     |
-100 | # airflow.sensors.external_task_sensor
-101 | ExternalTaskMarker
-102 | ExternalTaskSensor
+185 | # airflow.sensors.external_task_sensor
+186 | ExternalTaskMarker
+187 | ExternalTaskSensor
     | ^^^^^^^^^^^^^^^^^^ AIR302
-103 | ExternalTaskSensorLinkFromExternalTaskSensor
+188 | ExternalTaskSensorLinkFromExternalTaskSensor
     |
     = help: Use `airflow.sensors.external_task.ExternalTaskSensor` instead
 
-AIR302_names.py:103:1: AIR302 `airflow.sensors.external_task_sensor.ExternalTaskSensorLink` is removed in Airflow 3.0
+AIR302_names.py:188:1: AIR302 `airflow.sensors.external_task_sensor.ExternalTaskSensorLink` is removed in Airflow 3.0
     |
-101 | ExternalTaskMarker
-102 | ExternalTaskSensor
-103 | ExternalTaskSensorLinkFromExternalTaskSensor
+186 | ExternalTaskMarker
+187 | ExternalTaskSensor
+188 | ExternalTaskSensorLinkFromExternalTaskSensor
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
-104 | 
-105 | # airflow.sensors.time_delta_sensor
+189 | 
+190 | # airflow.sensors.time_delta_sensor
     |
     = help: Use `airflow.sensors.external_task.ExternalDagLink` instead
 
-AIR302_names.py:106:1: AIR302 `airflow.sensors.time_delta_sensor.TimeDeltaSensor` is removed in Airflow 3.0
+AIR302_names.py:191:1: AIR302 `airflow.sensors.time_delta_sensor.TimeDeltaSensor` is removed in Airflow 3.0
     |
-105 | # airflow.sensors.time_delta_sensor
-106 | TimeDeltaSensor
+190 | # airflow.sensors.time_delta_sensor
+191 | TimeDeltaSensor
     | ^^^^^^^^^^^^^^^ AIR302
-107 | 
-108 | # airflow.triggers.external_task
+192 | 
+193 | # airflow.timetables
     |
     = help: Use `airflow.sensors.time_delta.TimeDeltaSensor` instead
 
-AIR302_names.py:109:1: AIR302 `airflow.triggers.external_task.TaskStateTrigger` is removed in Airflow 3.0
+AIR302_names.py:194:1: AIR302 `airflow.timetables.datasets.DatasetOrTimeSchedule` is removed in Airflow 3.0
     |
-108 | # airflow.triggers.external_task
-109 | TaskStateTrigger
+193 | # airflow.timetables
+194 | DatasetOrTimeSchedule
+    | ^^^^^^^^^^^^^^^^^^^^^ AIR302
+195 | DatasetTriggeredTimetable
+    |
+    = help: Use `airflow.timetables.assets.AssetOrTimeSchedule` instead
+
+AIR302_names.py:195:1: AIR302 `airflow.timetables.simple.DatasetTriggeredTimetable` is removed in Airflow 3.0
+    |
+193 | # airflow.timetables
+194 | DatasetOrTimeSchedule
+195 | DatasetTriggeredTimetable
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
+196 | 
+197 | # airflow.triggers.external_task
+    |
+    = help: Use `airflow.timetables.simple.AssetTriggeredTimetable` instead
+
+AIR302_names.py:198:1: AIR302 `airflow.triggers.external_task.TaskStateTrigger` is removed in Airflow 3.0
+    |
+197 | # airflow.triggers.external_task
+198 | TaskStateTrigger
     | ^^^^^^^^^^^^^^^^ AIR302
-110 | 
-111 | # airflow.utils.date
+199 | 
+200 | # airflow.utils.date
     |
 
-AIR302_names.py:112:7: AIR302 `airflow.utils.dates.date_range` is removed in Airflow 3.0
+AIR302_names.py:201:7: AIR302 `airflow.utils.dates.date_range` is removed in Airflow 3.0
     |
-111 | # airflow.utils.date
-112 | dates.date_range
+200 | # airflow.utils.date
+201 | dates.date_range
     |       ^^^^^^^^^^ AIR302
-113 | dates.days_ago
+202 | dates.days_ago
     |
     = help: Use `airflow.timetables.` instead
 
-AIR302_names.py:113:7: AIR302 `airflow.utils.dates.days_ago` is removed in Airflow 3.0
+AIR302_names.py:202:7: AIR302 `airflow.utils.dates.days_ago` is removed in Airflow 3.0
     |
-111 | # airflow.utils.date
-112 | dates.date_range
-113 | dates.days_ago
+200 | # airflow.utils.date
+201 | dates.date_range
+202 | dates.days_ago
     |       ^^^^^^^^ AIR302
-114 | 
-115 | date_range
+203 | 
+204 | date_range
     |
     = help: Use `pendulum.today('UTC').add(days=-N, ...)` instead
 
-AIR302_names.py:115:1: AIR302 `airflow.utils.dates.date_range` is removed in Airflow 3.0
+AIR302_names.py:204:1: AIR302 `airflow.utils.dates.date_range` is removed in Airflow 3.0
     |
-113 | dates.days_ago
-114 | 
-115 | date_range
+202 | dates.days_ago
+203 | 
+204 | date_range
     | ^^^^^^^^^^ AIR302
-116 | days_ago
-117 | infer_time_unit
+205 | days_ago
+206 | infer_time_unit
     |
     = help: Use `airflow.timetables.` instead
 
-AIR302_names.py:116:1: AIR302 `airflow.utils.dates.days_ago` is removed in Airflow 3.0
+AIR302_names.py:205:1: AIR302 `airflow.utils.dates.days_ago` is removed in Airflow 3.0
     |
-115 | date_range
-116 | days_ago
+204 | date_range
+205 | days_ago
     | ^^^^^^^^ AIR302
-117 | infer_time_unit
-118 | parse_execution_date
+206 | infer_time_unit
+207 | parse_execution_date
     |
     = help: Use `pendulum.today('UTC').add(days=-N, ...)` instead
 
-AIR302_names.py:117:1: AIR302 `airflow.utils.dates.infer_time_unit` is removed in Airflow 3.0
+AIR302_names.py:206:1: AIR302 `airflow.utils.dates.infer_time_unit` is removed in Airflow 3.0
     |
-115 | date_range
-116 | days_ago
-117 | infer_time_unit
+204 | date_range
+205 | days_ago
+206 | infer_time_unit
     | ^^^^^^^^^^^^^^^ AIR302
-118 | parse_execution_date
-119 | round_time
+207 | parse_execution_date
+208 | round_time
     |
 
-AIR302_names.py:118:1: AIR302 `airflow.utils.dates.parse_execution_date` is removed in Airflow 3.0
+AIR302_names.py:207:1: AIR302 `airflow.utils.dates.parse_execution_date` is removed in Airflow 3.0
     |
-116 | days_ago
-117 | infer_time_unit
-118 | parse_execution_date
+205 | days_ago
+206 | infer_time_unit
+207 | parse_execution_date
     | ^^^^^^^^^^^^^^^^^^^^ AIR302
-119 | round_time
-120 | scale_time_units
+208 | round_time
+209 | scale_time_units
     |
 
-AIR302_names.py:119:1: AIR302 `airflow.utils.dates.round_time` is removed in Airflow 3.0
+AIR302_names.py:208:1: AIR302 `airflow.utils.dates.round_time` is removed in Airflow 3.0
     |
-117 | infer_time_unit
-118 | parse_execution_date
-119 | round_time
+206 | infer_time_unit
+207 | parse_execution_date
+208 | round_time
     | ^^^^^^^^^^ AIR302
-120 | scale_time_units
+209 | scale_time_units
     |
 
-AIR302_names.py:120:1: AIR302 `airflow.utils.dates.scale_time_units` is removed in Airflow 3.0
+AIR302_names.py:209:1: AIR302 `airflow.utils.dates.scale_time_units` is removed in Airflow 3.0
     |
-118 | parse_execution_date
-119 | round_time
-120 | scale_time_units
+207 | parse_execution_date
+208 | round_time
+209 | scale_time_units
     | ^^^^^^^^^^^^^^^^ AIR302
-121 | 
-122 | # This one was not deprecated.
+210 | 
+211 | # This one was not deprecated.
     |
 
-AIR302_names.py:127:1: AIR302 `airflow.utils.dag_cycle_tester.test_cycle` is removed in Airflow 3.0
+AIR302_names.py:216:1: AIR302 `airflow.utils.dag_cycle_tester.test_cycle` is removed in Airflow 3.0
     |
-126 | # airflow.utils.dag_cycle_tester
-127 | test_cycle
+215 | # airflow.utils.dag_cycle_tester
+216 | test_cycle
     | ^^^^^^^^^^ AIR302
-128 | 
-129 | # airflow.utils.decorators
+217 | 
+218 | # airflow.utils.decorators
     |
 
-AIR302_names.py:130:1: AIR302 `airflow.utils.decorators.apply_defaults` is removed in Airflow 3.0; `apply_defaults` is now unconditionally done and can be safely removed.
+AIR302_names.py:219:1: AIR302 `airflow.utils.decorators.apply_defaults` is removed in Airflow 3.0; `apply_defaults` is now unconditionally done and can be safely removed.
     |
-129 | # airflow.utils.decorators
-130 | apply_defaults
+218 | # airflow.utils.decorators
+219 | apply_defaults
     | ^^^^^^^^^^^^^^ AIR302
-131 | 
-132 | # airflow.utils.file
+220 | 
+221 | # airflow.utils.file
     |
 
-AIR302_names.py:133:1: AIR302 `airflow.utils.file.TemporaryDirectory` is removed in Airflow 3.0
+AIR302_names.py:222:1: AIR302 `airflow.utils.file.TemporaryDirectory` is removed in Airflow 3.0
     |
-132 | # airflow.utils.file
-133 | TemporaryDirectory, mkdirs
+221 | # airflow.utils.file
+222 | TemporaryDirectory, mkdirs
     | ^^^^^^^^^^^^^^^^^^ AIR302
-134 | 
-135 | #  airflow.utils.helpers
+223 | 
+224 | #  airflow.utils.helpers
     |
 
-AIR302_names.py:133:21: AIR302 `airflow.utils.file.mkdirs` is removed in Airflow 3.0
+AIR302_names.py:222:21: AIR302 `airflow.utils.file.mkdirs` is removed in Airflow 3.0
     |
-132 | # airflow.utils.file
-133 | TemporaryDirectory, mkdirs
+221 | # airflow.utils.file
+222 | TemporaryDirectory, mkdirs
     |                     ^^^^^^ AIR302
-134 | 
-135 | #  airflow.utils.helpers
+223 | 
+224 | #  airflow.utils.helpers
     |
     = help: Use `pendulum.today('UTC').add(days=-N, ...)` instead
 
-AIR302_names.py:136:1: AIR302 `airflow.utils.helpers.chain` is removed in Airflow 3.0
+AIR302_names.py:225:1: AIR302 `airflow.utils.helpers.chain` is removed in Airflow 3.0
     |
-135 | #  airflow.utils.helpers
-136 | chain, cross_downstream
+224 | #  airflow.utils.helpers
+225 | chain, cross_downstream
     | ^^^^^ AIR302
-137 | 
-138 | # airflow.utils.state
+226 | 
+227 | # airflow.utils.state
     |
     = help: Use `airflow.models.baseoperator.chain` instead
 
-AIR302_names.py:136:8: AIR302 `airflow.utils.helpers.cross_downstream` is removed in Airflow 3.0
+AIR302_names.py:225:8: AIR302 `airflow.utils.helpers.cross_downstream` is removed in Airflow 3.0
     |
-135 | #  airflow.utils.helpers
-136 | chain, cross_downstream
+224 | #  airflow.utils.helpers
+225 | chain, cross_downstream
     |        ^^^^^^^^^^^^^^^^ AIR302
-137 | 
-138 | # airflow.utils.state
+226 | 
+227 | # airflow.utils.state
     |
     = help: Use `airflow.models.baseoperator.cross_downstream` instead
 
-AIR302_names.py:139:1: AIR302 `airflow.utils.state.SHUTDOWN` is removed in Airflow 3.0
+AIR302_names.py:228:1: AIR302 `airflow.utils.state.SHUTDOWN` is removed in Airflow 3.0
     |
-138 | # airflow.utils.state
-139 | SHUTDOWN, terminating_states
+227 | # airflow.utils.state
+228 | SHUTDOWN, terminating_states
     | ^^^^^^^^ AIR302
-140 | 
-141 | #  airflow.utils.trigger_rule
+229 | 
+230 | #  airflow.utils.trigger_rule
     |
 
-AIR302_names.py:139:11: AIR302 `airflow.utils.state.terminating_states` is removed in Airflow 3.0
+AIR302_names.py:228:11: AIR302 `airflow.utils.state.terminating_states` is removed in Airflow 3.0
     |
-138 | # airflow.utils.state
-139 | SHUTDOWN, terminating_states
+227 | # airflow.utils.state
+228 | SHUTDOWN, terminating_states
     |           ^^^^^^^^^^^^^^^^^^ AIR302
-140 | 
-141 | #  airflow.utils.trigger_rule
+229 | 
+230 | #  airflow.utils.trigger_rule
     |
 
-AIR302_names.py:142:13: AIR302 `airflow.utils.trigger_rule.TriggerRule.DUMMY` is removed in Airflow 3.0
+AIR302_names.py:231:13: AIR302 `airflow.utils.trigger_rule.TriggerRule.DUMMY` is removed in Airflow 3.0
     |
-141 | #  airflow.utils.trigger_rule
-142 | TriggerRule.DUMMY
+230 | #  airflow.utils.trigger_rule
+231 | TriggerRule.DUMMY
     |             ^^^^^ AIR302
-143 | TriggerRule.NONE_FAILED_OR_SKIPPED
+232 | TriggerRule.NONE_FAILED_OR_SKIPPED
     |
 
-AIR302_names.py:143:13: AIR302 `airflow.utils.trigger_rule.TriggerRule.NONE_FAILED_OR_SKIPPED` is removed in Airflow 3.0
+AIR302_names.py:232:13: AIR302 `airflow.utils.trigger_rule.TriggerRule.NONE_FAILED_OR_SKIPPED` is removed in Airflow 3.0
     |
-141 | #  airflow.utils.trigger_rule
-142 | TriggerRule.DUMMY
-143 | TriggerRule.NONE_FAILED_OR_SKIPPED
+230 | #  airflow.utils.trigger_rule
+231 | TriggerRule.DUMMY
+232 | TriggerRule.NONE_FAILED_OR_SKIPPED
     |             ^^^^^^^^^^^^^^^^^^^^^^ AIR302
-144 | 
-145 | # airflow.www.auth
+233 | 
+234 | # airflow.www.auth
     |
 
-AIR302_names.py:146:1: AIR302 `airflow.www.auth.has_access` is removed in Airflow 3.0
+AIR302_names.py:235:1: AIR302 `airflow.www.auth.has_access` is removed in Airflow 3.0
     |
-145 | # airflow.www.auth
-146 | has_access
+234 | # airflow.www.auth
+235 | has_access
     | ^^^^^^^^^^ AIR302
-147 | 
-148 | # airflow.www.utils
+236 | has_access_dataset
     |
     = help: Use `airflow.www.auth.has_access_*` instead
 
-AIR302_names.py:149:1: AIR302 `airflow.www.utils.get_sensitive_variables_fields` is removed in Airflow 3.0
+AIR302_names.py:236:1: AIR302 `airflow.www.auth.has_access_dataset` is removed in Airflow 3.0
     |
-148 | # airflow.www.utils
-149 | get_sensitive_variables_fields, should_hide_value_for_key
+234 | # airflow.www.auth
+235 | has_access
+236 | has_access_dataset
+    | ^^^^^^^^^^^^^^^^^^ AIR302
+237 | 
+238 | # airflow.www.utils
+    |
+    = help: Use `airflow.www.auth.has_access_dataset.has_access_asset` instead
+
+AIR302_names.py:239:1: AIR302 `airflow.www.utils.get_sensitive_variables_fields` is removed in Airflow 3.0
+    |
+238 | # airflow.www.utils
+239 | get_sensitive_variables_fields, should_hide_value_for_key
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
     |
     = help: Use `airflow.utils.log.secrets_masker.get_sensitive_variables_fields` instead
 
-AIR302_names.py:149:33: AIR302 `airflow.www.utils.should_hide_value_for_key` is removed in Airflow 3.0
+AIR302_names.py:239:33: AIR302 `airflow.www.utils.should_hide_value_for_key` is removed in Airflow 3.0
     |
-148 | # airflow.www.utils
-149 | get_sensitive_variables_fields, should_hide_value_for_key
+238 | # airflow.www.utils
+239 | get_sensitive_variables_fields, should_hide_value_for_key
     |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
     |
     = help: Use `airflow.utils.log.secrets_masker.should_hide_value_for_key` instead

--- a/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_names.py.snap
+++ b/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_names.py.snap
@@ -2,580 +2,543 @@
 source: crates/ruff_linter/src/rules/airflow/mod.rs
 snapshot_kind: text
 ---
-AIR302_names.py:52:1: AIR302 `airflow.PY36` is removed in Airflow 3.0
+AIR302_names.py:54:1: AIR302 `airflow.PY36` is removed in Airflow 3.0
    |
-50 | from airflow.www.utils import get_sensitive_variables_fields, should_hide_value_for_key
-51 | 
-52 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
+53 | # airflow.PY\d{2}
+54 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
    | ^^^^ AIR302
-53 | 
-54 | AWSAthenaHook
+55 | 
+56 | # airflow.api_connexion.security
    |
    = help: Use `sys.version_info` instead
 
-AIR302_names.py:52:7: AIR302 `airflow.PY37` is removed in Airflow 3.0
+AIR302_names.py:54:7: AIR302 `airflow.PY37` is removed in Airflow 3.0
    |
-50 | from airflow.www.utils import get_sensitive_variables_fields, should_hide_value_for_key
-51 | 
-52 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
+53 | # airflow.PY\d{2}
+54 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
    |       ^^^^ AIR302
-53 | 
-54 | AWSAthenaHook
+55 | 
+56 | # airflow.api_connexion.security
    |
    = help: Use `sys.version_info` instead
 
-AIR302_names.py:52:13: AIR302 `airflow.PY38` is removed in Airflow 3.0
+AIR302_names.py:54:13: AIR302 `airflow.PY38` is removed in Airflow 3.0
    |
-50 | from airflow.www.utils import get_sensitive_variables_fields, should_hide_value_for_key
-51 | 
-52 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
+53 | # airflow.PY\d{2}
+54 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
    |             ^^^^ AIR302
-53 | 
-54 | AWSAthenaHook
+55 | 
+56 | # airflow.api_connexion.security
    |
    = help: Use `sys.version_info` instead
 
-AIR302_names.py:52:19: AIR302 `airflow.PY39` is removed in Airflow 3.0
+AIR302_names.py:54:19: AIR302 `airflow.PY39` is removed in Airflow 3.0
    |
-50 | from airflow.www.utils import get_sensitive_variables_fields, should_hide_value_for_key
-51 | 
-52 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
+53 | # airflow.PY\d{2}
+54 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
    |                   ^^^^ AIR302
-53 | 
-54 | AWSAthenaHook
+55 | 
+56 | # airflow.api_connexion.security
    |
    = help: Use `sys.version_info` instead
 
-AIR302_names.py:52:25: AIR302 `airflow.PY310` is removed in Airflow 3.0
+AIR302_names.py:54:25: AIR302 `airflow.PY310` is removed in Airflow 3.0
    |
-50 | from airflow.www.utils import get_sensitive_variables_fields, should_hide_value_for_key
-51 | 
-52 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
+53 | # airflow.PY\d{2}
+54 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
    |                         ^^^^^ AIR302
-53 | 
-54 | AWSAthenaHook
+55 | 
+56 | # airflow.api_connexion.security
    |
    = help: Use `sys.version_info` instead
 
-AIR302_names.py:52:32: AIR302 `airflow.PY311` is removed in Airflow 3.0
+AIR302_names.py:54:32: AIR302 `airflow.PY311` is removed in Airflow 3.0
    |
-50 | from airflow.www.utils import get_sensitive_variables_fields, should_hide_value_for_key
-51 | 
-52 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
+53 | # airflow.PY\d{2}
+54 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
    |                                ^^^^^ AIR302
-53 | 
-54 | AWSAthenaHook
+55 | 
+56 | # airflow.api_connexion.security
    |
    = help: Use `sys.version_info` instead
 
-AIR302_names.py:52:39: AIR302 `airflow.PY312` is removed in Airflow 3.0
+AIR302_names.py:54:39: AIR302 `airflow.PY312` is removed in Airflow 3.0
    |
-50 | from airflow.www.utils import get_sensitive_variables_fields, should_hide_value_for_key
-51 | 
-52 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
+53 | # airflow.PY\d{2}
+54 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
    |                                       ^^^^^ AIR302
-53 | 
-54 | AWSAthenaHook
+55 | 
+56 | # airflow.api_connexion.security
    |
    = help: Use `sys.version_info` instead
-
-AIR302_names.py:54:1: AIR302 `airflow.contrib.aws_athena_hook.AWSAthenaHook` is removed in Airflow 3.0
-   |
-52 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
-53 | 
-54 | AWSAthenaHook
-   | ^^^^^^^^^^^^^ AIR302
-55 | TaskStateTrigger
-   |
-
-AIR302_names.py:55:1: AIR302 `airflow.triggers.external_task.TaskStateTrigger` is removed in Airflow 3.0
-   |
-54 | AWSAthenaHook
-55 | TaskStateTrigger
-   | ^^^^^^^^^^^^^^^^ AIR302
-56 | 
-57 | requires_access
-   |
 
 AIR302_names.py:57:1: AIR302 `airflow.api_connexion.security.requires_access` is removed in Airflow 3.0
    |
-55 | TaskStateTrigger
-56 | 
+56 | # airflow.api_connexion.security
 57 | requires_access
    | ^^^^^^^^^^^^^^^ AIR302
 58 | 
-59 | AllowListValidator
+59 | # airflow.configuration
    |
    = help: Use `airflow.api_connexion.security.requires_access_*` instead
 
-AIR302_names.py:59:1: AIR302 `airflow.metrics.validators.AllowListValidator` is removed in Airflow 3.0
+AIR302_names.py:60:1: AIR302 `airflow.configuration.get` is removed in Airflow 3.0
    |
-57 | requires_access
-58 | 
-59 | AllowListValidator
-   | ^^^^^^^^^^^^^^^^^^ AIR302
-60 | BlockListValidator
-   |
-   = help: Use `airflow.metrics.validators.PatternAllowListValidator` instead
-
-AIR302_names.py:60:1: AIR302 `airflow.metrics.validators.BlockListValidator` is removed in Airflow 3.0
-   |
-59 | AllowListValidator
-60 | BlockListValidator
-   | ^^^^^^^^^^^^^^^^^^ AIR302
-61 | 
-62 | SubDagOperator
-   |
-   = help: Use `airflow.metrics.validators.PatternBlockListValidator` instead
-
-AIR302_names.py:62:1: AIR302 `airflow.operators.subdag.SubDagOperator` is removed in Airflow 3.0
-   |
-60 | BlockListValidator
-61 | 
-62 | SubDagOperator
-   | ^^^^^^^^^^^^^^ AIR302
-63 | 
-64 | dates.date_range
-   |
-
-AIR302_names.py:64:7: AIR302 `airflow.utils.dates.date_range` is removed in Airflow 3.0
-   |
-62 | SubDagOperator
-63 | 
-64 | dates.date_range
-   |       ^^^^^^^^^^ AIR302
-65 | dates.days_ago
-   |
-   = help: Use `airflow.timetables.` instead
-
-AIR302_names.py:65:7: AIR302 `airflow.utils.dates.days_ago` is removed in Airflow 3.0
-   |
-64 | dates.date_range
-65 | dates.days_ago
-   |       ^^^^^^^^ AIR302
-66 | 
-67 | date_range
-   |
-   = help: Use `pendulum.today('UTC').add(days=-N, ...)` instead
-
-AIR302_names.py:67:1: AIR302 `airflow.utils.dates.date_range` is removed in Airflow 3.0
-   |
-65 | dates.days_ago
-66 | 
-67 | date_range
-   | ^^^^^^^^^^ AIR302
-68 | days_ago
-69 | parse_execution_date
-   |
-   = help: Use `airflow.timetables.` instead
-
-AIR302_names.py:68:1: AIR302 `airflow.utils.dates.days_ago` is removed in Airflow 3.0
-   |
-67 | date_range
-68 | days_ago
-   | ^^^^^^^^ AIR302
-69 | parse_execution_date
-70 | round_time
-   |
-   = help: Use `pendulum.today('UTC').add(days=-N, ...)` instead
-
-AIR302_names.py:69:1: AIR302 `airflow.utils.dates.parse_execution_date` is removed in Airflow 3.0
-   |
-67 | date_range
-68 | days_ago
-69 | parse_execution_date
-   | ^^^^^^^^^^^^^^^^^^^^ AIR302
-70 | round_time
-71 | scale_time_units
-   |
-
-AIR302_names.py:70:1: AIR302 `airflow.utils.dates.round_time` is removed in Airflow 3.0
-   |
-68 | days_ago
-69 | parse_execution_date
-70 | round_time
-   | ^^^^^^^^^^ AIR302
-71 | scale_time_units
-72 | infer_time_unit
-   |
-
-AIR302_names.py:71:1: AIR302 `airflow.utils.dates.scale_time_units` is removed in Airflow 3.0
-   |
-69 | parse_execution_date
-70 | round_time
-71 | scale_time_units
-   | ^^^^^^^^^^^^^^^^ AIR302
-72 | infer_time_unit
-   |
-
-AIR302_names.py:72:1: AIR302 `airflow.utils.dates.infer_time_unit` is removed in Airflow 3.0
-   |
-70 | round_time
-71 | scale_time_units
-72 | infer_time_unit
-   | ^^^^^^^^^^^^^^^ AIR302
-   |
-
-AIR302_names.py:79:1: AIR302 `airflow.configuration.get` is removed in Airflow 3.0
-   |
-77 | dates.datetime_to_nano
-78 | 
-79 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+59 | # airflow.configuration
+60 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
    | ^^^ AIR302
-80 | 
-81 | get_connection, load_connections
    |
    = help: Use `airflow.configuration.conf.get` instead
 
-AIR302_names.py:79:6: AIR302 `airflow.configuration.getboolean` is removed in Airflow 3.0
+AIR302_names.py:60:6: AIR302 `airflow.configuration.getboolean` is removed in Airflow 3.0
    |
-77 | dates.datetime_to_nano
-78 | 
-79 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+59 | # airflow.configuration
+60 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
    |      ^^^^^^^^^^ AIR302
-80 | 
-81 | get_connection, load_connections
    |
    = help: Use `airflow.configuration.conf.getboolean` instead
 
-AIR302_names.py:79:18: AIR302 `airflow.configuration.getfloat` is removed in Airflow 3.0
+AIR302_names.py:60:18: AIR302 `airflow.configuration.getfloat` is removed in Airflow 3.0
    |
-77 | dates.datetime_to_nano
-78 | 
-79 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+59 | # airflow.configuration
+60 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
    |                  ^^^^^^^^ AIR302
-80 | 
-81 | get_connection, load_connections
    |
    = help: Use `airflow.configuration.conf.getfloat` instead
 
-AIR302_names.py:79:28: AIR302 `airflow.configuration.getint` is removed in Airflow 3.0
+AIR302_names.py:60:28: AIR302 `airflow.configuration.getint` is removed in Airflow 3.0
    |
-77 | dates.datetime_to_nano
-78 | 
-79 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+59 | # airflow.configuration
+60 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
    |                            ^^^^^^ AIR302
-80 | 
-81 | get_connection, load_connections
    |
    = help: Use `airflow.configuration.conf.getint` instead
 
-AIR302_names.py:79:36: AIR302 `airflow.configuration.has_option` is removed in Airflow 3.0
+AIR302_names.py:60:36: AIR302 `airflow.configuration.has_option` is removed in Airflow 3.0
    |
-77 | dates.datetime_to_nano
-78 | 
-79 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+59 | # airflow.configuration
+60 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
    |                                    ^^^^^^^^^^ AIR302
-80 | 
-81 | get_connection, load_connections
    |
    = help: Use `airflow.configuration.conf.has_option` instead
 
-AIR302_names.py:79:48: AIR302 `airflow.configuration.remove_option` is removed in Airflow 3.0
+AIR302_names.py:60:48: AIR302 `airflow.configuration.remove_option` is removed in Airflow 3.0
    |
-77 | dates.datetime_to_nano
-78 | 
-79 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+59 | # airflow.configuration
+60 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
    |                                                ^^^^^^^^^^^^^ AIR302
-80 | 
-81 | get_connection, load_connections
    |
    = help: Use `airflow.configuration.conf.remove_option` instead
 
-AIR302_names.py:79:63: AIR302 `airflow.configuration.as_dict` is removed in Airflow 3.0
+AIR302_names.py:60:63: AIR302 `airflow.configuration.as_dict` is removed in Airflow 3.0
    |
-77 | dates.datetime_to_nano
-78 | 
-79 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+59 | # airflow.configuration
+60 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
    |                                                               ^^^^^^^ AIR302
-80 | 
-81 | get_connection, load_connections
    |
    = help: Use `airflow.configuration.conf.as_dict` instead
 
-AIR302_names.py:79:72: AIR302 `airflow.configuration.set` is removed in Airflow 3.0
+AIR302_names.py:60:72: AIR302 `airflow.configuration.set` is removed in Airflow 3.0
    |
-77 | dates.datetime_to_nano
-78 | 
-79 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+59 | # airflow.configuration
+60 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
    |                                                                        ^^^ AIR302
-80 | 
-81 | get_connection, load_connections
    |
    = help: Use `airflow.configuration.conf.set` instead
 
-AIR302_names.py:81:1: AIR302 `airflow.secrets.local_filesystem.get_connection` is removed in Airflow 3.0
+AIR302_names.py:64:1: AIR302 `airflow.contrib.aws_athena_hook.AWSAthenaHook` is removed in Airflow 3.0; The whole `airflow.contrib` module has been removed.
    |
-79 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
-80 | 
-81 | get_connection, load_connections
-   | ^^^^^^^^^^^^^^ AIR302
+63 | # airflow.contrib.*
+64 | AWSAthenaHook
+   | ^^^^^^^^^^^^^ AIR302
+65 | 
+66 | # airflow.metrics.validators
    |
-   = help: Use `airflow.secrets.local_filesystem.load_connections_dict` instead
 
-AIR302_names.py:81:17: AIR302 `airflow.secrets.local_filesystem.load_connections` is removed in Airflow 3.0
+AIR302_names.py:67:1: AIR302 `airflow.metrics.validators.AllowListValidator` is removed in Airflow 3.0
    |
-79 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
-80 | 
-81 | get_connection, load_connections
-   |                 ^^^^^^^^^^^^^^^^ AIR302
+66 | # airflow.metrics.validators
+67 | AllowListValidator, BlockListValidator
+   | ^^^^^^^^^^^^^^^^^^ AIR302
+68 | 
+69 | # airflow.operators.dummy_operator
    |
-   = help: Use `airflow.secrets.local_filesystem.load_connections_dict` instead
+   = help: Use `airflow.metrics.validators.PatternAllowListValidator` instead
 
-AIR302_names.py:84:1: AIR302 `airflow.sensors.external_task_sensor.ExternalTaskSensorLink` is removed in Airflow 3.0
+AIR302_names.py:67:21: AIR302 `airflow.metrics.validators.BlockListValidator` is removed in Airflow 3.0
    |
-84 | ExternalTaskSensorLink
-   | ^^^^^^^^^^^^^^^^^^^^^^ AIR302
-85 | BashOperator
-86 | BaseBranchOperator
+66 | # airflow.metrics.validators
+67 | AllowListValidator, BlockListValidator
+   |                     ^^^^^^^^^^^^^^^^^^ AIR302
+68 | 
+69 | # airflow.operators.dummy_operator
    |
-   = help: Use `airflow.sensors.external_task.ExternalTaskSensorLink` instead
+   = help: Use `airflow.metrics.validators.PatternBlockListValidator` instead
 
-AIR302_names.py:85:1: AIR302 `airflow.operators.bash_operator.BashOperator` is removed in Airflow 3.0
+AIR302_names.py:70:16: AIR302 `airflow.operators.dummy_operator.EmptyOperator` is removed in Airflow 3.0
    |
-84 | ExternalTaskSensorLink
-85 | BashOperator
+69 | # airflow.operators.dummy_operator
+70 | dummy_operator.EmptyOperator
+   |                ^^^^^^^^^^^^^ AIR302
+71 | dummy_operator.DummyOperator
+   |
+   = help: Use `airflow.operators.empty.EmptyOperator` instead
+
+AIR302_names.py:71:16: AIR302 `airflow.operators.dummy_operator.DummyOperator` is removed in Airflow 3.0
+   |
+69 | # airflow.operators.dummy_operator
+70 | dummy_operator.EmptyOperator
+71 | dummy_operator.DummyOperator
+   |                ^^^^^^^^^^^^^ AIR302
+72 | 
+73 | # airflow.operators.bash_operator
+   |
+   = help: Use `airflow.operators.empty.EmptyOperator` instead
+
+AIR302_names.py:74:1: AIR302 `airflow.operators.bash_operator.BashOperator` is removed in Airflow 3.0
+   |
+73 | # airflow.operators.bash_operator
+74 | BashOperator
    | ^^^^^^^^^^^^ AIR302
-86 | BaseBranchOperator
-87 | EmptyOperator, DummyOperator
+75 | 
+76 | # airflow.operators.branch_operator
    |
    = help: Use `airflow.operators.bash.BashOperator` instead
 
-AIR302_names.py:86:1: AIR302 `airflow.operators.branch_operator.BaseBranchOperator` is removed in Airflow 3.0
+AIR302_names.py:77:1: AIR302 `airflow.operators.branch_operator.BaseBranchOperator` is removed in Airflow 3.0
    |
-84 | ExternalTaskSensorLink
-85 | BashOperator
-86 | BaseBranchOperator
+76 | # airflow.operators.branch_operator
+77 | BaseBranchOperator
    | ^^^^^^^^^^^^^^^^^^ AIR302
-87 | EmptyOperator, DummyOperator
-88 | dummy_operator.EmptyOperator
+78 | 
+79 | # airflow.operators.dummy
    |
    = help: Use `airflow.operators.branch.BaseBranchOperator` instead
 
-AIR302_names.py:87:16: AIR302 `airflow.operators.dummy.DummyOperator` is removed in Airflow 3.0
+AIR302_names.py:80:16: AIR302 `airflow.operators.dummy.DummyOperator` is removed in Airflow 3.0
    |
-85 | BashOperator
-86 | BaseBranchOperator
-87 | EmptyOperator, DummyOperator
+79 | # airflow.operators.dummy
+80 | EmptyOperator, DummyOperator
    |                ^^^^^^^^^^^^^ AIR302
-88 | dummy_operator.EmptyOperator
-89 | dummy_operator.DummyOperator
+81 | 
+82 | # airflow.operators.email_operator
    |
    = help: Use `airflow.operators.empty.EmptyOperator` instead
 
-AIR302_names.py:88:16: AIR302 `airflow.operators.dummy_operator.EmptyOperator` is removed in Airflow 3.0
+AIR302_names.py:83:1: AIR302 `airflow.operators.email_operator.EmailOperator` is removed in Airflow 3.0
    |
-86 | BaseBranchOperator
-87 | EmptyOperator, DummyOperator
-88 | dummy_operator.EmptyOperator
-   |                ^^^^^^^^^^^^^ AIR302
-89 | dummy_operator.DummyOperator
-90 | EmailOperator
-   |
-   = help: Use `airflow.operators.empty.EmptyOperator` instead
-
-AIR302_names.py:89:16: AIR302 `airflow.operators.dummy_operator.DummyOperator` is removed in Airflow 3.0
-   |
-87 | EmptyOperator, DummyOperator
-88 | dummy_operator.EmptyOperator
-89 | dummy_operator.DummyOperator
-   |                ^^^^^^^^^^^^^ AIR302
-90 | EmailOperator
-91 | BaseSensorOperator
-   |
-   = help: Use `airflow.operators.empty.EmptyOperator` instead
-
-AIR302_names.py:90:1: AIR302 `airflow.operators.email_operator.EmailOperator` is removed in Airflow 3.0
-   |
-88 | dummy_operator.EmptyOperator
-89 | dummy_operator.DummyOperator
-90 | EmailOperator
+82 | # airflow.operators.email_operator
+83 | EmailOperator
    | ^^^^^^^^^^^^^ AIR302
-91 | BaseSensorOperator
-92 | DateTimeSensor
+84 | 
+85 | # airflow.operators.subdag.*
    |
    = help: Use `airflow.operators.email.EmailOperator` instead
 
-AIR302_names.py:91:1: AIR302 `airflow.sensors.base_sensor_operator.BaseSensorOperator` is removed in Airflow 3.0
+AIR302_names.py:86:1: AIR302 `airflow.operators.subdag.SubDagOperator` is removed in Airflow 3.0; The whole `airflow.subdag` module has been removed.
    |
-89 | dummy_operator.DummyOperator
-90 | EmailOperator
-91 | BaseSensorOperator
+85 | # airflow.operators.subdag.*
+86 | SubDagOperator
+   | ^^^^^^^^^^^^^^ AIR302
+87 | 
+88 | # airflow.secrets
+   |
+
+AIR302_names.py:89:1: AIR302 `airflow.secrets.local_filesystem.get_connection` is removed in Airflow 3.0
+   |
+88 | # airflow.secrets
+89 | get_connection, load_connections
+   | ^^^^^^^^^^^^^^ AIR302
+90 | 
+91 | # airflow.sensors.base_sensor_operator
+   |
+   = help: Use `airflow.secrets.local_filesystem.load_connections_dict` instead
+
+AIR302_names.py:89:17: AIR302 `airflow.secrets.local_filesystem.load_connections` is removed in Airflow 3.0
+   |
+88 | # airflow.secrets
+89 | get_connection, load_connections
+   |                 ^^^^^^^^^^^^^^^^ AIR302
+90 | 
+91 | # airflow.sensors.base_sensor_operator
+   |
+   = help: Use `airflow.secrets.local_filesystem.load_connections_dict` instead
+
+AIR302_names.py:92:1: AIR302 `airflow.sensors.base_sensor_operator.BaseSensorOperator` is removed in Airflow 3.0
+   |
+91 | # airflow.sensors.base_sensor_operator
+92 | BaseSensorOperator
    | ^^^^^^^^^^^^^^^^^^ AIR302
-92 | DateTimeSensor
-93 | (ExternalTaskMarker, ExternalTaskSensor, ExternalTaskSensorLink)
+93 | 
+94 | # airflow.sensors.date_time_sensor
    |
    = help: Use `airflow.sensors.base.BaseSensorOperator` instead
 
-AIR302_names.py:92:1: AIR302 `airflow.sensors.date_time_sensor.DateTimeSensor` is removed in Airflow 3.0
+AIR302_names.py:95:1: AIR302 `airflow.sensors.date_time_sensor.DateTimeSensor` is removed in Airflow 3.0
    |
-90 | EmailOperator
-91 | BaseSensorOperator
-92 | DateTimeSensor
+94 | # airflow.sensors.date_time_sensor
+95 | DateTimeSensor
    | ^^^^^^^^^^^^^^ AIR302
-93 | (ExternalTaskMarker, ExternalTaskSensor, ExternalTaskSensorLink)
-94 | TimeDeltaSensor
+96 | 
+97 | # airflow.sensors.external_task
    |
    = help: Use `airflow.sensors.date_time.DateTimeSensor` instead
 
-AIR302_names.py:93:2: AIR302 `airflow.sensors.external_task_sensor.ExternalTaskMarker` is removed in Airflow 3.0
-   |
-91 | BaseSensorOperator
-92 | DateTimeSensor
-93 | (ExternalTaskMarker, ExternalTaskSensor, ExternalTaskSensorLink)
-   |  ^^^^^^^^^^^^^^^^^^ AIR302
-94 | TimeDeltaSensor
-   |
-   = help: Use `airflow.sensors.external_task.ExternalTaskMarker` instead
-
-AIR302_names.py:93:22: AIR302 `airflow.sensors.external_task_sensor.ExternalTaskSensor` is removed in Airflow 3.0
-   |
-91 | BaseSensorOperator
-92 | DateTimeSensor
-93 | (ExternalTaskMarker, ExternalTaskSensor, ExternalTaskSensorLink)
-   |                      ^^^^^^^^^^^^^^^^^^ AIR302
-94 | TimeDeltaSensor
-   |
-   = help: Use `airflow.sensors.external_task.ExternalTaskSensor` instead
-
-AIR302_names.py:93:42: AIR302 `airflow.sensors.external_task_sensor.ExternalTaskSensorLink` is removed in Airflow 3.0
-   |
-91 | BaseSensorOperator
-92 | DateTimeSensor
-93 | (ExternalTaskMarker, ExternalTaskSensor, ExternalTaskSensorLink)
-   |                                          ^^^^^^^^^^^^^^^^^^^^^^ AIR302
-94 | TimeDeltaSensor
-   |
-   = help: Use `airflow.sensors.external_task.ExternalTaskSensorLink` instead
-
-AIR302_names.py:94:1: AIR302 `airflow.sensors.time_delta_sensor.TimeDeltaSensor` is removed in Airflow 3.0
-   |
-92 | DateTimeSensor
-93 | (ExternalTaskMarker, ExternalTaskSensor, ExternalTaskSensorLink)
-94 | TimeDeltaSensor
-   | ^^^^^^^^^^^^^^^ AIR302
-95 | 
-96 | apply_defaults
-   |
-   = help: Use `airflow.sensors.time_delta.TimeDeltaSensor` instead
-
-AIR302_names.py:96:1: AIR302 `airflow.utils.decorators.apply_defaults` is removed in Airflow 3.0; `apply_defaults` is now unconditionally done and can be safely removed.
-   |
-94 | TimeDeltaSensor
-95 | 
-96 | apply_defaults
-   | ^^^^^^^^^^^^^^ AIR302
-97 | 
-98 | TemporaryDirectory
-   |
-
-AIR302_names.py:98:1: AIR302 `airflow.utils.file.TemporaryDirectory` is removed in Airflow 3.0
-   |
-96 | apply_defaults
-97 | 
-98 | TemporaryDirectory
-   | ^^^^^^^^^^^^^^^^^^ AIR302
-99 | mkdirs
-   |
-
-AIR302_names.py:99:1: AIR302 `airflow.utils.file.mkdirs` is removed in Airflow 3.0
+AIR302_names.py:98:1: AIR302 `airflow.sensors.external_task.ExternalTaskSensorLink` is removed in Airflow 3.0
     |
- 98 | TemporaryDirectory
- 99 | mkdirs
-    | ^^^^^^ AIR302
-100 | 
-101 | chain
+ 97 | # airflow.sensors.external_task
+ 98 | ExternalTaskSensorLinkFromExternalTask
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
+ 99 | 
+100 | # airflow.sensors.external_task_sensor
+    |
+    = help: Use `airflow.sensors.external_task.ExternalDagLink` instead
+
+AIR302_names.py:101:1: AIR302 `airflow.sensors.external_task_sensor.ExternalTaskMarker` is removed in Airflow 3.0
+    |
+100 | # airflow.sensors.external_task_sensor
+101 | ExternalTaskMarker
+    | ^^^^^^^^^^^^^^^^^^ AIR302
+102 | ExternalTaskSensor
+103 | ExternalTaskSensorLinkFromExternalTaskSensor
+    |
+    = help: Use `airflow.sensors.external_task.ExternalTaskMarker` instead
+
+AIR302_names.py:102:1: AIR302 `airflow.sensors.external_task_sensor.ExternalTaskSensor` is removed in Airflow 3.0
+    |
+100 | # airflow.sensors.external_task_sensor
+101 | ExternalTaskMarker
+102 | ExternalTaskSensor
+    | ^^^^^^^^^^^^^^^^^^ AIR302
+103 | ExternalTaskSensorLinkFromExternalTaskSensor
+    |
+    = help: Use `airflow.sensors.external_task.ExternalTaskSensor` instead
+
+AIR302_names.py:103:1: AIR302 `airflow.sensors.external_task_sensor.ExternalTaskSensorLink` is removed in Airflow 3.0
+    |
+101 | ExternalTaskMarker
+102 | ExternalTaskSensor
+103 | ExternalTaskSensorLinkFromExternalTaskSensor
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
+104 | 
+105 | # airflow.sensors.time_delta_sensor
+    |
+    = help: Use `airflow.sensors.external_task.ExternalDagLink` instead
+
+AIR302_names.py:106:1: AIR302 `airflow.sensors.time_delta_sensor.TimeDeltaSensor` is removed in Airflow 3.0
+    |
+105 | # airflow.sensors.time_delta_sensor
+106 | TimeDeltaSensor
+    | ^^^^^^^^^^^^^^^ AIR302
+107 | 
+108 | # airflow.triggers.external_task
+    |
+    = help: Use `airflow.sensors.time_delta.TimeDeltaSensor` instead
+
+AIR302_names.py:109:1: AIR302 `airflow.triggers.external_task.TaskStateTrigger` is removed in Airflow 3.0
+    |
+108 | # airflow.triggers.external_task
+109 | TaskStateTrigger
+    | ^^^^^^^^^^^^^^^^ AIR302
+110 | 
+111 | # airflow.utils.date
+    |
+
+AIR302_names.py:112:7: AIR302 `airflow.utils.dates.date_range` is removed in Airflow 3.0
+    |
+111 | # airflow.utils.date
+112 | dates.date_range
+    |       ^^^^^^^^^^ AIR302
+113 | dates.days_ago
+    |
+    = help: Use `airflow.timetables.` instead
+
+AIR302_names.py:113:7: AIR302 `airflow.utils.dates.days_ago` is removed in Airflow 3.0
+    |
+111 | # airflow.utils.date
+112 | dates.date_range
+113 | dates.days_ago
+    |       ^^^^^^^^ AIR302
+114 | 
+115 | date_range
     |
     = help: Use `pendulum.today('UTC').add(days=-N, ...)` instead
 
-AIR302_names.py:101:1: AIR302 `airflow.utils.helpers.chain` is removed in Airflow 3.0
+AIR302_names.py:115:1: AIR302 `airflow.utils.dates.date_range` is removed in Airflow 3.0
     |
- 99 | mkdirs
-100 | 
-101 | chain
+113 | dates.days_ago
+114 | 
+115 | date_range
+    | ^^^^^^^^^^ AIR302
+116 | days_ago
+117 | infer_time_unit
+    |
+    = help: Use `airflow.timetables.` instead
+
+AIR302_names.py:116:1: AIR302 `airflow.utils.dates.days_ago` is removed in Airflow 3.0
+    |
+115 | date_range
+116 | days_ago
+    | ^^^^^^^^ AIR302
+117 | infer_time_unit
+118 | parse_execution_date
+    |
+    = help: Use `pendulum.today('UTC').add(days=-N, ...)` instead
+
+AIR302_names.py:117:1: AIR302 `airflow.utils.dates.infer_time_unit` is removed in Airflow 3.0
+    |
+115 | date_range
+116 | days_ago
+117 | infer_time_unit
+    | ^^^^^^^^^^^^^^^ AIR302
+118 | parse_execution_date
+119 | round_time
+    |
+
+AIR302_names.py:118:1: AIR302 `airflow.utils.dates.parse_execution_date` is removed in Airflow 3.0
+    |
+116 | days_ago
+117 | infer_time_unit
+118 | parse_execution_date
+    | ^^^^^^^^^^^^^^^^^^^^ AIR302
+119 | round_time
+120 | scale_time_units
+    |
+
+AIR302_names.py:119:1: AIR302 `airflow.utils.dates.round_time` is removed in Airflow 3.0
+    |
+117 | infer_time_unit
+118 | parse_execution_date
+119 | round_time
+    | ^^^^^^^^^^ AIR302
+120 | scale_time_units
+    |
+
+AIR302_names.py:120:1: AIR302 `airflow.utils.dates.scale_time_units` is removed in Airflow 3.0
+    |
+118 | parse_execution_date
+119 | round_time
+120 | scale_time_units
+    | ^^^^^^^^^^^^^^^^ AIR302
+121 | 
+122 | # This one was not deprecated.
+    |
+
+AIR302_names.py:127:1: AIR302 `airflow.utils.dag_cycle_tester.test_cycle` is removed in Airflow 3.0
+    |
+126 | # airflow.utils.dag_cycle_tester
+127 | test_cycle
+    | ^^^^^^^^^^ AIR302
+128 | 
+129 | # airflow.utils.decorators
+    |
+
+AIR302_names.py:130:1: AIR302 `airflow.utils.decorators.apply_defaults` is removed in Airflow 3.0; `apply_defaults` is now unconditionally done and can be safely removed.
+    |
+129 | # airflow.utils.decorators
+130 | apply_defaults
+    | ^^^^^^^^^^^^^^ AIR302
+131 | 
+132 | # airflow.utils.file
+    |
+
+AIR302_names.py:133:1: AIR302 `airflow.utils.file.TemporaryDirectory` is removed in Airflow 3.0
+    |
+132 | # airflow.utils.file
+133 | TemporaryDirectory, mkdirs
+    | ^^^^^^^^^^^^^^^^^^ AIR302
+134 | 
+135 | #  airflow.utils.helpers
+    |
+
+AIR302_names.py:133:21: AIR302 `airflow.utils.file.mkdirs` is removed in Airflow 3.0
+    |
+132 | # airflow.utils.file
+133 | TemporaryDirectory, mkdirs
+    |                     ^^^^^^ AIR302
+134 | 
+135 | #  airflow.utils.helpers
+    |
+    = help: Use `pendulum.today('UTC').add(days=-N, ...)` instead
+
+AIR302_names.py:136:1: AIR302 `airflow.utils.helpers.chain` is removed in Airflow 3.0
+    |
+135 | #  airflow.utils.helpers
+136 | chain, cross_downstream
     | ^^^^^ AIR302
-102 | cross_downstream
+137 | 
+138 | # airflow.utils.state
     |
     = help: Use `airflow.models.baseoperator.chain` instead
 
-AIR302_names.py:102:1: AIR302 `airflow.utils.helpers.cross_downstream` is removed in Airflow 3.0
+AIR302_names.py:136:8: AIR302 `airflow.utils.helpers.cross_downstream` is removed in Airflow 3.0
     |
-101 | chain
-102 | cross_downstream
-    | ^^^^^^^^^^^^^^^^ AIR302
-103 | 
-104 | SHUTDOWN
+135 | #  airflow.utils.helpers
+136 | chain, cross_downstream
+    |        ^^^^^^^^^^^^^^^^ AIR302
+137 | 
+138 | # airflow.utils.state
     |
     = help: Use `airflow.models.baseoperator.cross_downstream` instead
 
-AIR302_names.py:104:1: AIR302 `airflow.utils.state.SHUTDOWN` is removed in Airflow 3.0
+AIR302_names.py:139:1: AIR302 `airflow.utils.state.SHUTDOWN` is removed in Airflow 3.0
     |
-102 | cross_downstream
-103 | 
-104 | SHUTDOWN
+138 | # airflow.utils.state
+139 | SHUTDOWN, terminating_states
     | ^^^^^^^^ AIR302
-105 | terminating_states
+140 | 
+141 | #  airflow.utils.trigger_rule
     |
 
-AIR302_names.py:105:1: AIR302 `airflow.utils.state.terminating_states` is removed in Airflow 3.0
+AIR302_names.py:139:11: AIR302 `airflow.utils.state.terminating_states` is removed in Airflow 3.0
     |
-104 | SHUTDOWN
-105 | terminating_states
-    | ^^^^^^^^^^^^^^^^^^ AIR302
-106 | 
-107 | TriggerRule.DUMMY
+138 | # airflow.utils.state
+139 | SHUTDOWN, terminating_states
+    |           ^^^^^^^^^^^^^^^^^^ AIR302
+140 | 
+141 | #  airflow.utils.trigger_rule
     |
 
-AIR302_names.py:107:13: AIR302 `airflow.utils.trigger_rule.TriggerRule.DUMMY` is removed in Airflow 3.0
+AIR302_names.py:142:13: AIR302 `airflow.utils.trigger_rule.TriggerRule.DUMMY` is removed in Airflow 3.0
     |
-105 | terminating_states
-106 | 
-107 | TriggerRule.DUMMY
+141 | #  airflow.utils.trigger_rule
+142 | TriggerRule.DUMMY
     |             ^^^^^ AIR302
-108 | TriggerRule.NONE_FAILED_OR_SKIPPED
+143 | TriggerRule.NONE_FAILED_OR_SKIPPED
     |
 
-AIR302_names.py:108:13: AIR302 `airflow.utils.trigger_rule.TriggerRule.NONE_FAILED_OR_SKIPPED` is removed in Airflow 3.0
+AIR302_names.py:143:13: AIR302 `airflow.utils.trigger_rule.TriggerRule.NONE_FAILED_OR_SKIPPED` is removed in Airflow 3.0
     |
-107 | TriggerRule.DUMMY
-108 | TriggerRule.NONE_FAILED_OR_SKIPPED
+141 | #  airflow.utils.trigger_rule
+142 | TriggerRule.DUMMY
+143 | TriggerRule.NONE_FAILED_OR_SKIPPED
     |             ^^^^^^^^^^^^^^^^^^^^^^ AIR302
-109 | 
-110 | test_cycle
+144 | 
+145 | # airflow.www.auth
     |
 
-AIR302_names.py:110:1: AIR302 `airflow.utils.dag_cycle_tester.test_cycle` is removed in Airflow 3.0
+AIR302_names.py:146:1: AIR302 `airflow.www.auth.has_access` is removed in Airflow 3.0
     |
-108 | TriggerRule.NONE_FAILED_OR_SKIPPED
-109 | 
-110 | test_cycle
+145 | # airflow.www.auth
+146 | has_access
     | ^^^^^^^^^^ AIR302
-111 | 
-112 | has_access
-    |
-
-AIR302_names.py:112:1: AIR302 `airflow.www.auth.has_access` is removed in Airflow 3.0
-    |
-110 | test_cycle
-111 | 
-112 | has_access
-    | ^^^^^^^^^^ AIR302
-113 | get_sensitive_variables_fields, should_hide_value_for_key
+147 | 
+148 | # airflow.www.utils
     |
     = help: Use `airflow.www.auth.has_access_*` instead
 
-AIR302_names.py:113:1: AIR302 `airflow.www.utils.get_sensitive_variables_fields` is removed in Airflow 3.0
+AIR302_names.py:149:1: AIR302 `airflow.www.utils.get_sensitive_variables_fields` is removed in Airflow 3.0
     |
-112 | has_access
-113 | get_sensitive_variables_fields, should_hide_value_for_key
+148 | # airflow.www.utils
+149 | get_sensitive_variables_fields, should_hide_value_for_key
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
     |
     = help: Use `airflow.utils.log.secrets_masker.get_sensitive_variables_fields` instead
 
-AIR302_names.py:113:33: AIR302 `airflow.www.utils.should_hide_value_for_key` is removed in Airflow 3.0
+AIR302_names.py:149:33: AIR302 `airflow.www.utils.should_hide_value_for_key` is removed in Airflow 3.0
     |
-112 | has_access
-113 | get_sensitive_variables_fields, should_hide_value_for_key
+148 | # airflow.www.utils
+149 | get_sensitive_variables_fields, should_hide_value_for_key
     |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
     |
     = help: Use `airflow.utils.log.secrets_masker.should_hide_value_for_key` instead

--- a/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_names.py.snap
+++ b/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_names.py.snap
@@ -2,905 +2,905 @@
 source: crates/ruff_linter/src/rules/airflow/mod.rs
 snapshot_kind: text
 ---
-AIR302_names.py:80:1: AIR302 `airflow.PY36` is removed in Airflow 3.0
+AIR302_names.py:96:1: AIR302 `airflow.PY36` is removed in Airflow 3.0
    |
-79 | # airflow root
-80 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
+95 | # airflow root
+96 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
    | ^^^^ AIR302
-81 | DatasetFromRoot
+97 | DatasetFromRoot
    |
    = help: Use `sys.version_info` instead
 
-AIR302_names.py:80:7: AIR302 `airflow.PY37` is removed in Airflow 3.0
+AIR302_names.py:96:7: AIR302 `airflow.PY37` is removed in Airflow 3.0
    |
-79 | # airflow root
-80 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
+95 | # airflow root
+96 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
    |       ^^^^ AIR302
-81 | DatasetFromRoot
+97 | DatasetFromRoot
    |
    = help: Use `sys.version_info` instead
 
-AIR302_names.py:80:13: AIR302 `airflow.PY38` is removed in Airflow 3.0
+AIR302_names.py:96:13: AIR302 `airflow.PY38` is removed in Airflow 3.0
    |
-79 | # airflow root
-80 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
+95 | # airflow root
+96 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
    |             ^^^^ AIR302
-81 | DatasetFromRoot
+97 | DatasetFromRoot
    |
    = help: Use `sys.version_info` instead
 
-AIR302_names.py:80:19: AIR302 `airflow.PY39` is removed in Airflow 3.0
+AIR302_names.py:96:19: AIR302 `airflow.PY39` is removed in Airflow 3.0
    |
-79 | # airflow root
-80 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
+95 | # airflow root
+96 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
    |                   ^^^^ AIR302
-81 | DatasetFromRoot
+97 | DatasetFromRoot
    |
    = help: Use `sys.version_info` instead
 
-AIR302_names.py:80:25: AIR302 `airflow.PY310` is removed in Airflow 3.0
+AIR302_names.py:96:25: AIR302 `airflow.PY310` is removed in Airflow 3.0
    |
-79 | # airflow root
-80 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
+95 | # airflow root
+96 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
    |                         ^^^^^ AIR302
-81 | DatasetFromRoot
+97 | DatasetFromRoot
    |
    = help: Use `sys.version_info` instead
 
-AIR302_names.py:80:32: AIR302 `airflow.PY311` is removed in Airflow 3.0
+AIR302_names.py:96:32: AIR302 `airflow.PY311` is removed in Airflow 3.0
    |
-79 | # airflow root
-80 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
+95 | # airflow root
+96 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
    |                                ^^^^^ AIR302
-81 | DatasetFromRoot
+97 | DatasetFromRoot
    |
    = help: Use `sys.version_info` instead
 
-AIR302_names.py:80:39: AIR302 `airflow.PY312` is removed in Airflow 3.0
+AIR302_names.py:96:39: AIR302 `airflow.PY312` is removed in Airflow 3.0
    |
-79 | # airflow root
-80 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
+95 | # airflow root
+96 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
    |                                       ^^^^^ AIR302
-81 | DatasetFromRoot
+97 | DatasetFromRoot
    |
    = help: Use `sys.version_info` instead
 
-AIR302_names.py:81:1: AIR302 `airflow.Dataset` is removed in Airflow 3.0
+AIR302_names.py:97:1: AIR302 `airflow.Dataset` is removed in Airflow 3.0
    |
-79 | # airflow root
-80 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
-81 | DatasetFromRoot
+95 | # airflow root
+96 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
+97 | DatasetFromRoot
    | ^^^^^^^^^^^^^^^ AIR302
-82 | 
-83 | # airflow.api_connexion.security
+98 | 
+99 | # airflow.api_connexion.security
    |
    = help: Use `airflow.sdk.definitions.asset.Asset` instead
 
-AIR302_names.py:84:1: AIR302 `airflow.api_connexion.security.requires_access` is removed in Airflow 3.0
-   |
-83 | # airflow.api_connexion.security
-84 | requires_access, requires_access_dataset
-   | ^^^^^^^^^^^^^^^ AIR302
-85 | 
-86 | # airflow.auth.managers
-   |
-   = help: Use `airflow.api_connexion.security.requires_access_*` instead
-
-AIR302_names.py:84:18: AIR302 `airflow.api_connexion.security.requires_access_dataset` is removed in Airflow 3.0
-   |
-83 | # airflow.api_connexion.security
-84 | requires_access, requires_access_dataset
-   |                  ^^^^^^^^^^^^^^^^^^^^^^^ AIR302
-85 | 
-86 | # airflow.auth.managers
-   |
-   = help: Use `airflow.api_connexion.security.requires_access_asset` instead
-
-AIR302_names.py:87:1: AIR302 `airflow.auth.managers.base_auth_manager.is_authorized_dataset` is removed in Airflow 3.0
-   |
-86 | # airflow.auth.managers
-87 | is_authorized_dataset
-   | ^^^^^^^^^^^^^^^^^^^^^ AIR302
-88 | DatasetDetails
-   |
-   = help: Use `airflow.auth.managers.base_auth_manager.is_authorized_asset` instead
-
-AIR302_names.py:88:1: AIR302 `airflow.auth.managers.models.resource_details.DatasetDetails` is removed in Airflow 3.0
-   |
-86 | # airflow.auth.managers
-87 | is_authorized_dataset
-88 | DatasetDetails
-   | ^^^^^^^^^^^^^^ AIR302
-89 | 
-90 | # airflow.configuration
-   |
-   = help: Use `airflow.auth.managers.models.resource_details.AssetDetails` instead
-
-AIR302_names.py:91:1: AIR302 `airflow.configuration.get` is removed in Airflow 3.0
-   |
-90 | # airflow.configuration
-91 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
-   | ^^^ AIR302
-   |
-   = help: Use `airflow.configuration.conf.get` instead
-
-AIR302_names.py:91:6: AIR302 `airflow.configuration.getboolean` is removed in Airflow 3.0
-   |
-90 | # airflow.configuration
-91 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
-   |      ^^^^^^^^^^ AIR302
-   |
-   = help: Use `airflow.configuration.conf.getboolean` instead
-
-AIR302_names.py:91:18: AIR302 `airflow.configuration.getfloat` is removed in Airflow 3.0
-   |
-90 | # airflow.configuration
-91 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
-   |                  ^^^^^^^^ AIR302
-   |
-   = help: Use `airflow.configuration.conf.getfloat` instead
-
-AIR302_names.py:91:28: AIR302 `airflow.configuration.getint` is removed in Airflow 3.0
-   |
-90 | # airflow.configuration
-91 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
-   |                            ^^^^^^ AIR302
-   |
-   = help: Use `airflow.configuration.conf.getint` instead
-
-AIR302_names.py:91:36: AIR302 `airflow.configuration.has_option` is removed in Airflow 3.0
-   |
-90 | # airflow.configuration
-91 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
-   |                                    ^^^^^^^^^^ AIR302
-   |
-   = help: Use `airflow.configuration.conf.has_option` instead
-
-AIR302_names.py:91:48: AIR302 `airflow.configuration.remove_option` is removed in Airflow 3.0
-   |
-90 | # airflow.configuration
-91 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
-   |                                                ^^^^^^^^^^^^^ AIR302
-   |
-   = help: Use `airflow.configuration.conf.remove_option` instead
-
-AIR302_names.py:91:63: AIR302 `airflow.configuration.as_dict` is removed in Airflow 3.0
-   |
-90 | # airflow.configuration
-91 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
-   |                                                               ^^^^^^^ AIR302
-   |
-   = help: Use `airflow.configuration.conf.as_dict` instead
-
-AIR302_names.py:91:72: AIR302 `airflow.configuration.set` is removed in Airflow 3.0
-   |
-90 | # airflow.configuration
-91 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
-   |                                                                        ^^^ AIR302
-   |
-   = help: Use `airflow.configuration.conf.set` instead
-
-AIR302_names.py:95:1: AIR302 `airflow.contrib.aws_athena_hook.AWSAthenaHook` is removed in Airflow 3.0; The whole `airflow.contrib` module has been removed.
-   |
-94 | # airflow.contrib.*
-95 | AWSAthenaHook
-   | ^^^^^^^^^^^^^ AIR302
-96 | 
-97 | # airflow.datasets
-   |
-
-AIR302_names.py:98:1: AIR302 `airflow.datasets.Dataset` is removed in Airflow 3.0
+AIR302_names.py:100:1: AIR302 `airflow.api_connexion.security.requires_access` is removed in Airflow 3.0
     |
- 97 | # airflow.datasets
- 98 | Dataset
+ 99 | # airflow.api_connexion.security
+100 | requires_access, requires_access_dataset
+    | ^^^^^^^^^^^^^^^ AIR302
+101 | 
+102 | # airflow.auth.managers
+    |
+    = help: Use `airflow.api_connexion.security.requires_access_*` instead
+
+AIR302_names.py:100:18: AIR302 `airflow.api_connexion.security.requires_access_dataset` is removed in Airflow 3.0
+    |
+ 99 | # airflow.api_connexion.security
+100 | requires_access, requires_access_dataset
+    |                  ^^^^^^^^^^^^^^^^^^^^^^^ AIR302
+101 | 
+102 | # airflow.auth.managers
+    |
+    = help: Use `airflow.api_connexion.security.requires_access_asset` instead
+
+AIR302_names.py:103:1: AIR302 `airflow.auth.managers.base_auth_manager.is_authorized_dataset` is removed in Airflow 3.0
+    |
+102 | # airflow.auth.managers
+103 | is_authorized_dataset
+    | ^^^^^^^^^^^^^^^^^^^^^ AIR302
+104 | DatasetDetails
+    |
+    = help: Use `airflow.auth.managers.base_auth_manager.is_authorized_asset` instead
+
+AIR302_names.py:104:1: AIR302 `airflow.auth.managers.models.resource_details.DatasetDetails` is removed in Airflow 3.0
+    |
+102 | # airflow.auth.managers
+103 | is_authorized_dataset
+104 | DatasetDetails
+    | ^^^^^^^^^^^^^^ AIR302
+105 | 
+106 | # airflow.configuration
+    |
+    = help: Use `airflow.auth.managers.models.resource_details.AssetDetails` instead
+
+AIR302_names.py:107:1: AIR302 `airflow.configuration.get` is removed in Airflow 3.0
+    |
+106 | # airflow.configuration
+107 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+    | ^^^ AIR302
+    |
+    = help: Use `airflow.configuration.conf.get` instead
+
+AIR302_names.py:107:6: AIR302 `airflow.configuration.getboolean` is removed in Airflow 3.0
+    |
+106 | # airflow.configuration
+107 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+    |      ^^^^^^^^^^ AIR302
+    |
+    = help: Use `airflow.configuration.conf.getboolean` instead
+
+AIR302_names.py:107:18: AIR302 `airflow.configuration.getfloat` is removed in Airflow 3.0
+    |
+106 | # airflow.configuration
+107 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+    |                  ^^^^^^^^ AIR302
+    |
+    = help: Use `airflow.configuration.conf.getfloat` instead
+
+AIR302_names.py:107:28: AIR302 `airflow.configuration.getint` is removed in Airflow 3.0
+    |
+106 | # airflow.configuration
+107 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+    |                            ^^^^^^ AIR302
+    |
+    = help: Use `airflow.configuration.conf.getint` instead
+
+AIR302_names.py:107:36: AIR302 `airflow.configuration.has_option` is removed in Airflow 3.0
+    |
+106 | # airflow.configuration
+107 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+    |                                    ^^^^^^^^^^ AIR302
+    |
+    = help: Use `airflow.configuration.conf.has_option` instead
+
+AIR302_names.py:107:48: AIR302 `airflow.configuration.remove_option` is removed in Airflow 3.0
+    |
+106 | # airflow.configuration
+107 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+    |                                                ^^^^^^^^^^^^^ AIR302
+    |
+    = help: Use `airflow.configuration.conf.remove_option` instead
+
+AIR302_names.py:107:63: AIR302 `airflow.configuration.as_dict` is removed in Airflow 3.0
+    |
+106 | # airflow.configuration
+107 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+    |                                                               ^^^^^^^ AIR302
+    |
+    = help: Use `airflow.configuration.conf.as_dict` instead
+
+AIR302_names.py:107:72: AIR302 `airflow.configuration.set` is removed in Airflow 3.0
+    |
+106 | # airflow.configuration
+107 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+    |                                                                        ^^^ AIR302
+    |
+    = help: Use `airflow.configuration.conf.set` instead
+
+AIR302_names.py:111:1: AIR302 `airflow.contrib.aws_athena_hook.AWSAthenaHook` is removed in Airflow 3.0; The whole `airflow.contrib` module has been removed.
+    |
+110 | # airflow.contrib.*
+111 | AWSAthenaHook
+    | ^^^^^^^^^^^^^ AIR302
+112 | 
+113 | # airflow.datasets
+    |
+
+AIR302_names.py:114:1: AIR302 `airflow.datasets.Dataset` is removed in Airflow 3.0
+    |
+113 | # airflow.datasets
+114 | Dataset
     | ^^^^^^^ AIR302
- 99 | DatasetAlias
-100 | DatasetAliasEvent
+115 | DatasetAlias
+116 | DatasetAliasEvent
     |
     = help: Use `airflow.sdk.definitions.asset.Asset` instead
 
-AIR302_names.py:99:1: AIR302 `airflow.datasets.DatasetAlias` is removed in Airflow 3.0
+AIR302_names.py:115:1: AIR302 `airflow.datasets.DatasetAlias` is removed in Airflow 3.0
     |
- 97 | # airflow.datasets
- 98 | Dataset
- 99 | DatasetAlias
+113 | # airflow.datasets
+114 | Dataset
+115 | DatasetAlias
     | ^^^^^^^^^^^^ AIR302
-100 | DatasetAliasEvent
-101 | DatasetAll
+116 | DatasetAliasEvent
+117 | DatasetAll
     |
     = help: Use `airflow.sdk.definitions.asset.AssetAlias` instead
 
-AIR302_names.py:100:1: AIR302 `airflow.datasets.DatasetAliasEvent` is removed in Airflow 3.0
+AIR302_names.py:116:1: AIR302 `airflow.datasets.DatasetAliasEvent` is removed in Airflow 3.0
     |
- 98 | Dataset
- 99 | DatasetAlias
-100 | DatasetAliasEvent
+114 | Dataset
+115 | DatasetAlias
+116 | DatasetAliasEvent
     | ^^^^^^^^^^^^^^^^^ AIR302
-101 | DatasetAll
-102 | DatasetAny
+117 | DatasetAll
+118 | DatasetAny
     |
 
-AIR302_names.py:101:1: AIR302 `airflow.datasets.DatasetAll` is removed in Airflow 3.0
+AIR302_names.py:117:1: AIR302 `airflow.datasets.DatasetAll` is removed in Airflow 3.0
     |
- 99 | DatasetAlias
-100 | DatasetAliasEvent
-101 | DatasetAll
+115 | DatasetAlias
+116 | DatasetAliasEvent
+117 | DatasetAll
     | ^^^^^^^^^^ AIR302
-102 | DatasetAny
-103 | expand_alias_to_datasets
+118 | DatasetAny
+119 | expand_alias_to_datasets
     |
     = help: Use `airflow.sdk.definitions.asset.AssetAll` instead
 
-AIR302_names.py:102:1: AIR302 `airflow.datasets.DatasetAny` is removed in Airflow 3.0
+AIR302_names.py:118:1: AIR302 `airflow.datasets.DatasetAny` is removed in Airflow 3.0
     |
-100 | DatasetAliasEvent
-101 | DatasetAll
-102 | DatasetAny
+116 | DatasetAliasEvent
+117 | DatasetAll
+118 | DatasetAny
     | ^^^^^^^^^^ AIR302
-103 | expand_alias_to_datasets
-104 | metadata
+119 | expand_alias_to_datasets
+120 | Metadata
     |
     = help: Use `airflow.sdk.definitions.asset.AssetAny` instead
 
-AIR302_names.py:103:1: AIR302 `airflow.datasets.expand_alias_to_datasets` is removed in Airflow 3.0
+AIR302_names.py:119:1: AIR302 `airflow.datasets.expand_alias_to_datasets` is removed in Airflow 3.0
     |
-101 | DatasetAll
-102 | DatasetAny
-103 | expand_alias_to_datasets
+117 | DatasetAll
+118 | DatasetAny
+119 | expand_alias_to_datasets
     | ^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
-104 | metadata
+120 | Metadata
     |
     = help: Use `airflow.sdk.definitions.asset.expand_alias_to_assets` instead
 
-AIR302_names.py:104:1: AIR302 `airflow.datasets.metadata` is removed in Airflow 3.0
+AIR302_names.py:120:1: AIR302 `airflow.datasets.metadata.Metadata` is removed in Airflow 3.0
     |
-102 | DatasetAny
-103 | expand_alias_to_datasets
-104 | metadata
+118 | DatasetAny
+119 | expand_alias_to_datasets
+120 | Metadata
     | ^^^^^^^^ AIR302
-105 | 
-106 | # airflow.datasets.manager
+121 | 
+122 | # airflow.datasets.manager
     |
-    = help: Use `airflow.sdk.definitions.asset.metadata` instead
+    = help: Use `airflow.sdk.definitions.asset.metadata.Metadata` instead
 
-AIR302_names.py:107:17: AIR302 `airflow.datasets.manager.dataset_manager` is removed in Airflow 3.0
+AIR302_names.py:123:17: AIR302 `airflow.datasets.manager.dataset_manager` is removed in Airflow 3.0
     |
-106 | # airflow.datasets.manager
-107 | DatasetManager, dataset_manager, resolve_dataset_manager
+122 | # airflow.datasets.manager
+123 | DatasetManager, dataset_manager, resolve_dataset_manager
     |                 ^^^^^^^^^^^^^^^ AIR302
-108 | 
-109 | # airflow.lineage.hook
+124 | 
+125 | # airflow.lineage.hook
     |
     = help: Use `airflow.assets.manager` instead
 
-AIR302_names.py:107:34: AIR302 `airflow.datasets.manager.resolve_dataset_manager` is removed in Airflow 3.0
+AIR302_names.py:123:34: AIR302 `airflow.datasets.manager.resolve_dataset_manager` is removed in Airflow 3.0
     |
-106 | # airflow.datasets.manager
-107 | DatasetManager, dataset_manager, resolve_dataset_manager
+122 | # airflow.datasets.manager
+123 | DatasetManager, dataset_manager, resolve_dataset_manager
     |                                  ^^^^^^^^^^^^^^^^^^^^^^^ AIR302
-108 | 
-109 | # airflow.lineage.hook
+124 | 
+125 | # airflow.lineage.hook
     |
     = help: Use `airflow.assets.resolve_asset_manager` instead
 
-AIR302_names.py:110:1: AIR302 `airflow.lineage.hook.DatasetLineageInfo` is removed in Airflow 3.0
+AIR302_names.py:126:1: AIR302 `airflow.lineage.hook.DatasetLineageInfo` is removed in Airflow 3.0
     |
-109 | # airflow.lineage.hook
-110 | DatasetLineageInfo
+125 | # airflow.lineage.hook
+126 | DatasetLineageInfo
     | ^^^^^^^^^^^^^^^^^^ AIR302
-111 | 
-112 | # airflow.listeners.spec.dataset
+127 | 
+128 | # airflow.listeners.spec.dataset
     |
     = help: Use `airflow.lineage.hook.AssetLineageInfo` instead
 
-AIR302_names.py:113:1: AIR302 `airflow.listeners.spec.dataset.on_dataset_changed` is removed in Airflow 3.0
+AIR302_names.py:129:1: AIR302 `airflow.listeners.spec.dataset.on_dataset_changed` is removed in Airflow 3.0
     |
-112 | # airflow.listeners.spec.dataset
-113 | on_dataset_changed, on_dataset_created
+128 | # airflow.listeners.spec.dataset
+129 | on_dataset_changed, on_dataset_created
     | ^^^^^^^^^^^^^^^^^^ AIR302
-114 | 
-115 | # airflow.metrics.validators
+130 | 
+131 | # airflow.metrics.validators
     |
     = help: Use `airflow.listeners.spec.asset.on_asset_changed` instead
 
-AIR302_names.py:113:21: AIR302 `airflow.listeners.spec.dataset.on_dataset_created` is removed in Airflow 3.0
+AIR302_names.py:129:21: AIR302 `airflow.listeners.spec.dataset.on_dataset_created` is removed in Airflow 3.0
     |
-112 | # airflow.listeners.spec.dataset
-113 | on_dataset_changed, on_dataset_created
+128 | # airflow.listeners.spec.dataset
+129 | on_dataset_changed, on_dataset_created
     |                     ^^^^^^^^^^^^^^^^^^ AIR302
-114 | 
-115 | # airflow.metrics.validators
+130 | 
+131 | # airflow.metrics.validators
     |
     = help: Use `airflow.listeners.spec.asset.on_asset_created` instead
 
-AIR302_names.py:116:1: AIR302 `airflow.metrics.validators.AllowListValidator` is removed in Airflow 3.0
+AIR302_names.py:132:1: AIR302 `airflow.metrics.validators.AllowListValidator` is removed in Airflow 3.0
     |
-115 | # airflow.metrics.validators
-116 | AllowListValidator, BlockListValidator
+131 | # airflow.metrics.validators
+132 | AllowListValidator, BlockListValidator
     | ^^^^^^^^^^^^^^^^^^ AIR302
-117 | 
-118 | # airflow.operators.dummy_operator
+133 | 
+134 | # airflow.operators.dummy_operator
     |
     = help: Use `airflow.metrics.validators.PatternAllowListValidator` instead
 
-AIR302_names.py:116:21: AIR302 `airflow.metrics.validators.BlockListValidator` is removed in Airflow 3.0
+AIR302_names.py:132:21: AIR302 `airflow.metrics.validators.BlockListValidator` is removed in Airflow 3.0
     |
-115 | # airflow.metrics.validators
-116 | AllowListValidator, BlockListValidator
+131 | # airflow.metrics.validators
+132 | AllowListValidator, BlockListValidator
     |                     ^^^^^^^^^^^^^^^^^^ AIR302
-117 | 
-118 | # airflow.operators.dummy_operator
+133 | 
+134 | # airflow.operators.dummy_operator
     |
     = help: Use `airflow.metrics.validators.PatternBlockListValidator` instead
 
-AIR302_names.py:119:16: AIR302 `airflow.operators.dummy_operator.EmptyOperator` is removed in Airflow 3.0
+AIR302_names.py:135:16: AIR302 `airflow.operators.dummy_operator.EmptyOperator` is removed in Airflow 3.0
     |
-118 | # airflow.operators.dummy_operator
-119 | dummy_operator.EmptyOperator
+134 | # airflow.operators.dummy_operator
+135 | dummy_operator.EmptyOperator
     |                ^^^^^^^^^^^^^ AIR302
-120 | dummy_operator.DummyOperator
+136 | dummy_operator.DummyOperator
     |
     = help: Use `airflow.operators.empty.EmptyOperator` instead
 
-AIR302_names.py:120:16: AIR302 `airflow.operators.dummy_operator.DummyOperator` is removed in Airflow 3.0
+AIR302_names.py:136:16: AIR302 `airflow.operators.dummy_operator.DummyOperator` is removed in Airflow 3.0
     |
-118 | # airflow.operators.dummy_operator
-119 | dummy_operator.EmptyOperator
-120 | dummy_operator.DummyOperator
+134 | # airflow.operators.dummy_operator
+135 | dummy_operator.EmptyOperator
+136 | dummy_operator.DummyOperator
     |                ^^^^^^^^^^^^^ AIR302
-121 | 
-122 | # airflow.operators.bash_operator
+137 | 
+138 | # airflow.operators.bash_operator
     |
     = help: Use `airflow.operators.empty.EmptyOperator` instead
 
-AIR302_names.py:123:1: AIR302 `airflow.operators.bash_operator.BashOperator` is removed in Airflow 3.0
+AIR302_names.py:139:1: AIR302 `airflow.operators.bash_operator.BashOperator` is removed in Airflow 3.0
     |
-122 | # airflow.operators.bash_operator
-123 | BashOperator
+138 | # airflow.operators.bash_operator
+139 | BashOperator
     | ^^^^^^^^^^^^ AIR302
-124 | 
-125 | # airflow.operators.branch_operator
+140 | 
+141 | # airflow.operators.branch_operator
     |
     = help: Use `airflow.operators.bash.BashOperator` instead
 
-AIR302_names.py:126:1: AIR302 `airflow.operators.branch_operator.BaseBranchOperator` is removed in Airflow 3.0
+AIR302_names.py:142:1: AIR302 `airflow.operators.branch_operator.BaseBranchOperator` is removed in Airflow 3.0
     |
-125 | # airflow.operators.branch_operator
-126 | BaseBranchOperator
+141 | # airflow.operators.branch_operator
+142 | BaseBranchOperator
     | ^^^^^^^^^^^^^^^^^^ AIR302
-127 | 
-128 | # airflow.operators.dummy
+143 | 
+144 | # airflow.operators.dummy
     |
     = help: Use `airflow.operators.branch.BaseBranchOperator` instead
 
-AIR302_names.py:129:16: AIR302 `airflow.operators.dummy.DummyOperator` is removed in Airflow 3.0
+AIR302_names.py:145:16: AIR302 `airflow.operators.dummy.DummyOperator` is removed in Airflow 3.0
     |
-128 | # airflow.operators.dummy
-129 | EmptyOperator, DummyOperator
+144 | # airflow.operators.dummy
+145 | EmptyOperator, DummyOperator
     |                ^^^^^^^^^^^^^ AIR302
-130 | 
-131 | # airflow.operators.email_operator
+146 | 
+147 | # airflow.operators.email_operator
     |
     = help: Use `airflow.operators.empty.EmptyOperator` instead
 
-AIR302_names.py:132:1: AIR302 `airflow.operators.email_operator.EmailOperator` is removed in Airflow 3.0
+AIR302_names.py:148:1: AIR302 `airflow.operators.email_operator.EmailOperator` is removed in Airflow 3.0
     |
-131 | # airflow.operators.email_operator
-132 | EmailOperator
+147 | # airflow.operators.email_operator
+148 | EmailOperator
     | ^^^^^^^^^^^^^ AIR302
-133 | 
-134 | # airflow.operators.subdag.*
+149 | 
+150 | # airflow.operators.subdag.*
     |
     = help: Use `airflow.operators.email.EmailOperator` instead
 
-AIR302_names.py:135:1: AIR302 `airflow.operators.subdag.SubDagOperator` is removed in Airflow 3.0; The whole `airflow.subdag` module has been removed.
+AIR302_names.py:151:1: AIR302 `airflow.operators.subdag.SubDagOperator` is removed in Airflow 3.0; The whole `airflow.subdag` module has been removed.
     |
-134 | # airflow.operators.subdag.*
-135 | SubDagOperator
+150 | # airflow.operators.subdag.*
+151 | SubDagOperator
     | ^^^^^^^^^^^^^^ AIR302
-136 | 
-137 | # airflow.providers.amazon
+152 | 
+153 | # airflow.providers.amazon
     |
 
-AIR302_names.py:138:13: AIR302 `airflow.providers.amazon.auth_manager.avp.entities.AvpEntities.DATASET` is removed in Airflow 3.0
+AIR302_names.py:154:13: AIR302 `airflow.providers.amazon.auth_manager.avp.entities.AvpEntities.DATASET` is removed in Airflow 3.0
     |
-137 | # airflow.providers.amazon
-138 | AvpEntities.DATASET
+153 | # airflow.providers.amazon
+154 | AvpEntities.DATASET
     |             ^^^^^^^ AIR302
-139 | s3.create_dataset
-140 | s3.convert_dataset_to_openlineage
+155 | s3.create_dataset
+156 | s3.convert_dataset_to_openlineage
     |
     = help: Use `airflow.providers.amazon.auth_manager.avp.entities.AvpEntities.ASSET` instead
 
-AIR302_names.py:139:4: AIR302 `airflow.providers.amazon.aws.datasets.s3.create_dataset` is removed in Airflow 3.0
+AIR302_names.py:155:4: AIR302 `airflow.providers.amazon.aws.datasets.s3.create_dataset` is removed in Airflow 3.0
     |
-137 | # airflow.providers.amazon
-138 | AvpEntities.DATASET
-139 | s3.create_dataset
+153 | # airflow.providers.amazon
+154 | AvpEntities.DATASET
+155 | s3.create_dataset
     |    ^^^^^^^^^^^^^^ AIR302
-140 | s3.convert_dataset_to_openlineage
-141 | s3.sanitize_uri
+156 | s3.convert_dataset_to_openlineage
+157 | s3.sanitize_uri
     |
     = help: Use `airflow.providers.amazon.aws.assets.s3.create_asset` instead
 
-AIR302_names.py:140:4: AIR302 `airflow.providers.amazon.aws.datasets.s3.convert_dataset_to_openlineage` is removed in Airflow 3.0
+AIR302_names.py:156:4: AIR302 `airflow.providers.amazon.aws.datasets.s3.convert_dataset_to_openlineage` is removed in Airflow 3.0
     |
-138 | AvpEntities.DATASET
-139 | s3.create_dataset
-140 | s3.convert_dataset_to_openlineage
+154 | AvpEntities.DATASET
+155 | s3.create_dataset
+156 | s3.convert_dataset_to_openlineage
     |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
-141 | s3.sanitize_uri
+157 | s3.sanitize_uri
     |
     = help: Use `airflow.providers.amazon.aws.assets.s3.convert_asset_to_openlineage` instead
 
-AIR302_names.py:141:4: AIR302 `airflow.providers.amazon.aws.datasets.s3.sanitize_uri` is removed in Airflow 3.0
+AIR302_names.py:157:4: AIR302 `airflow.providers.amazon.aws.datasets.s3.sanitize_uri` is removed in Airflow 3.0
     |
-139 | s3.create_dataset
-140 | s3.convert_dataset_to_openlineage
-141 | s3.sanitize_uri
+155 | s3.create_dataset
+156 | s3.convert_dataset_to_openlineage
+157 | s3.sanitize_uri
     |    ^^^^^^^^^^^^ AIR302
-142 | 
-143 | # airflow.providers.common.io
+158 | 
+159 | # airflow.providers.common.io
     |
     = help: Use `airflow.providers.amazon.aws.assets.s3.sanitize_uri` instead
 
-AIR302_names.py:144:16: AIR302 `airflow.providers.common.io.datasets.file.convert_dataset_to_openlineage` is removed in Airflow 3.0
+AIR302_names.py:160:16: AIR302 `airflow.providers.common.io.datasets.file.convert_dataset_to_openlineage` is removed in Airflow 3.0
     |
-143 | # airflow.providers.common.io
-144 | common_io_file.convert_dataset_to_openlineage
+159 | # airflow.providers.common.io
+160 | common_io_file.convert_dataset_to_openlineage
     |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
-145 | common_io_file.create_dataset
-146 | common_io_file.sanitize_uri
+161 | common_io_file.create_dataset
+162 | common_io_file.sanitize_uri
     |
     = help: Use `airflow.providers.common.io.assets.file.convert_asset_to_openlineage` instead
 
-AIR302_names.py:145:16: AIR302 `airflow.providers.common.io.datasets.file.create_dataset` is removed in Airflow 3.0
+AIR302_names.py:161:16: AIR302 `airflow.providers.common.io.datasets.file.create_dataset` is removed in Airflow 3.0
     |
-143 | # airflow.providers.common.io
-144 | common_io_file.convert_dataset_to_openlineage
-145 | common_io_file.create_dataset
+159 | # airflow.providers.common.io
+160 | common_io_file.convert_dataset_to_openlineage
+161 | common_io_file.create_dataset
     |                ^^^^^^^^^^^^^^ AIR302
-146 | common_io_file.sanitize_uri
+162 | common_io_file.sanitize_uri
     |
     = help: Use `airflow.providers.common.io.assets.file.create_asset` instead
 
-AIR302_names.py:146:16: AIR302 `airflow.providers.common.io.datasets.file.sanitize_uri` is removed in Airflow 3.0
+AIR302_names.py:162:16: AIR302 `airflow.providers.common.io.datasets.file.sanitize_uri` is removed in Airflow 3.0
     |
-144 | common_io_file.convert_dataset_to_openlineage
-145 | common_io_file.create_dataset
-146 | common_io_file.sanitize_uri
+160 | common_io_file.convert_dataset_to_openlineage
+161 | common_io_file.create_dataset
+162 | common_io_file.sanitize_uri
     |                ^^^^^^^^^^^^ AIR302
-147 | 
-148 | # airflow.providers.fab
+163 | 
+164 | # airflow.providers.fab
     |
     = help: Use `airflow.providers.common.io.assets.file.sanitize_uri` instead
 
-AIR302_names.py:149:18: AIR302 `airflow.providers.fab.auth_manager.fab_auth_manager.is_authorized_dataset` is removed in Airflow 3.0
+AIR302_names.py:165:18: AIR302 `airflow.providers.fab.auth_manager.fab_auth_manager.is_authorized_dataset` is removed in Airflow 3.0
     |
-148 | # airflow.providers.fab
-149 | fab_auth_manager.is_authorized_dataset
+164 | # airflow.providers.fab
+165 | fab_auth_manager.is_authorized_dataset
     |                  ^^^^^^^^^^^^^^^^^^^^^ AIR302
-150 | 
-151 | # airflow.providers.google
+166 | 
+167 | # airflow.providers.google
     |
     = help: Use `airflow.providers.fab.auth_manager.fab_auth_manager.is_authorized_asset` instead
 
-AIR302_names.py:154:5: AIR302 `airflow.providers.google.datasets.gcs.create_dataset` is removed in Airflow 3.0
+AIR302_names.py:170:5: AIR302 `airflow.providers.google.datasets.gcs.create_dataset` is removed in Airflow 3.0
     |
-152 | bigquery.sanitize_uri
-153 | 
-154 | gcs.create_dataset
+168 | bigquery.sanitize_uri
+169 | 
+170 | gcs.create_dataset
     |     ^^^^^^^^^^^^^^ AIR302
-155 | gcs.sanitize_uri
-156 | gcs.convert_dataset_to_openlineage
+171 | gcs.sanitize_uri
+172 | gcs.convert_dataset_to_openlineage
     |
     = help: Use `airflow.providers.google.assets.gcs.create_asset` instead
 
-AIR302_names.py:155:5: AIR302 `airflow.providers.google.datasets.gcs.sanitize_uri` is removed in Airflow 3.0
+AIR302_names.py:171:5: AIR302 `airflow.providers.google.datasets.gcs.sanitize_uri` is removed in Airflow 3.0
     |
-154 | gcs.create_dataset
-155 | gcs.sanitize_uri
+170 | gcs.create_dataset
+171 | gcs.sanitize_uri
     |     ^^^^^^^^^^^^ AIR302
-156 | gcs.convert_dataset_to_openlineage
+172 | gcs.convert_dataset_to_openlineage
     |
     = help: Use `airflow.providers.google.assets.gcs.sanitize_uri` instead
 
-AIR302_names.py:156:5: AIR302 `airflow.providers.google.datasets.gcs.convert_dataset_to_openlineage` is removed in Airflow 3.0
+AIR302_names.py:172:5: AIR302 `airflow.providers.google.datasets.gcs.convert_dataset_to_openlineage` is removed in Airflow 3.0
     |
-154 | gcs.create_dataset
-155 | gcs.sanitize_uri
-156 | gcs.convert_dataset_to_openlineage
+170 | gcs.create_dataset
+171 | gcs.sanitize_uri
+172 | gcs.convert_dataset_to_openlineage
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
-157 | 
-158 | # airflow.providers.mysql
+173 | 
+174 | # airflow.providers.mysql
     |
     = help: Use `airflow.providers.google.assets.gcs.convert_asset_to_openlineage` instead
 
-AIR302_names.py:159:7: AIR302 `airflow.providers.mysql.datasets.mysql.sanitize_uri` is removed in Airflow 3.0
+AIR302_names.py:175:7: AIR302 `airflow.providers.mysql.datasets.mysql.sanitize_uri` is removed in Airflow 3.0
     |
-158 | # airflow.providers.mysql
-159 | mysql.sanitize_uri
+174 | # airflow.providers.mysql
+175 | mysql.sanitize_uri
     |       ^^^^^^^^^^^^ AIR302
-160 | 
-161 | # airflow.providers.openlineage
+176 | 
+177 | # airflow.providers.openlineage
     |
     = help: Use `airflow.providers.mysql.assets.mysql.sanitize_uri` instead
 
-AIR302_names.py:162:1: AIR302 `airflow.providers.openlineage.utils.utils.DatasetInfo` is removed in Airflow 3.0
+AIR302_names.py:178:1: AIR302 `airflow.providers.openlineage.utils.utils.DatasetInfo` is removed in Airflow 3.0
     |
-161 | # airflow.providers.openlineage
-162 | DatasetInfo, translate_airflow_dataset
+177 | # airflow.providers.openlineage
+178 | DatasetInfo, translate_airflow_dataset
     | ^^^^^^^^^^^ AIR302
-163 | 
-164 | # airflow.providers.postgres
+179 | 
+180 | # airflow.providers.postgres
     |
     = help: Use `airflow.providers.openlineage.utils.utils.AssetInfo` instead
 
-AIR302_names.py:162:14: AIR302 `airflow.providers.openlineage.utils.utils.translate_airflow_dataset` is removed in Airflow 3.0
+AIR302_names.py:178:14: AIR302 `airflow.providers.openlineage.utils.utils.translate_airflow_dataset` is removed in Airflow 3.0
     |
-161 | # airflow.providers.openlineage
-162 | DatasetInfo, translate_airflow_dataset
+177 | # airflow.providers.openlineage
+178 | DatasetInfo, translate_airflow_dataset
     |              ^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
-163 | 
-164 | # airflow.providers.postgres
+179 | 
+180 | # airflow.providers.postgres
     |
     = help: Use `airflow.providers.openlineage.utils.utils.translate_airflow_asset` instead
 
-AIR302_names.py:165:10: AIR302 `airflow.providers.postgres.datasets.postgres.sanitize_uri` is removed in Airflow 3.0
+AIR302_names.py:181:10: AIR302 `airflow.providers.postgres.datasets.postgres.sanitize_uri` is removed in Airflow 3.0
     |
-164 | # airflow.providers.postgres
-165 | postgres.sanitize_uri
+180 | # airflow.providers.postgres
+181 | postgres.sanitize_uri
     |          ^^^^^^^^^^^^ AIR302
-166 | 
-167 | # airflow.providers.trino
+182 | 
+183 | # airflow.providers.trino
     |
     = help: Use `airflow.providers.postgres.assets.postgres.sanitize_uri` instead
 
-AIR302_names.py:168:7: AIR302 `airflow.providers.trino.datasets.trino.sanitize_uri` is removed in Airflow 3.0
+AIR302_names.py:184:7: AIR302 `airflow.providers.trino.datasets.trino.sanitize_uri` is removed in Airflow 3.0
     |
-167 | # airflow.providers.trino
-168 | trino.sanitize_uri
+183 | # airflow.providers.trino
+184 | trino.sanitize_uri
     |       ^^^^^^^^^^^^ AIR302
-169 | 
-170 | # airflow.secrets
+185 | 
+186 | # airflow.secrets
     |
     = help: Use `airflow.providers.trino.assets.trino.sanitize_uri` instead
 
-AIR302_names.py:171:1: AIR302 `airflow.secrets.local_filesystem.get_connection` is removed in Airflow 3.0
+AIR302_names.py:187:1: AIR302 `airflow.secrets.local_filesystem.get_connection` is removed in Airflow 3.0
     |
-170 | # airflow.secrets
-171 | get_connection, load_connections
+186 | # airflow.secrets
+187 | get_connection, load_connections
     | ^^^^^^^^^^^^^^ AIR302
-172 | 
-173 | # airflow.security.permissions
+188 | 
+189 | # airflow.security.permissions
     |
     = help: Use `airflow.secrets.local_filesystem.load_connections_dict` instead
 
-AIR302_names.py:171:17: AIR302 `airflow.secrets.local_filesystem.load_connections` is removed in Airflow 3.0
+AIR302_names.py:187:17: AIR302 `airflow.secrets.local_filesystem.load_connections` is removed in Airflow 3.0
     |
-170 | # airflow.secrets
-171 | get_connection, load_connections
+186 | # airflow.secrets
+187 | get_connection, load_connections
     |                 ^^^^^^^^^^^^^^^^ AIR302
-172 | 
-173 | # airflow.security.permissions
+188 | 
+189 | # airflow.security.permissions
     |
     = help: Use `airflow.secrets.local_filesystem.load_connections_dict` instead
 
-AIR302_names.py:174:1: AIR302 `airflow.security.permissions.RESOURCE_DATASET` is removed in Airflow 3.0
+AIR302_names.py:190:1: AIR302 `airflow.security.permissions.RESOURCE_DATASET` is removed in Airflow 3.0
     |
-173 | # airflow.security.permissions
-174 | RESOURCE_DATASET
+189 | # airflow.security.permissions
+190 | RESOURCE_DATASET
     | ^^^^^^^^^^^^^^^^ AIR302
-175 | 
-176 | # airflow.sensors.base_sensor_operator
+191 | 
+192 | # airflow.sensors.base_sensor_operator
     |
     = help: Use `airflow.security.permissions.RESOURCE_ASSET` instead
 
-AIR302_names.py:177:1: AIR302 `airflow.sensors.base_sensor_operator.BaseSensorOperator` is removed in Airflow 3.0
+AIR302_names.py:193:1: AIR302 `airflow.sensors.base_sensor_operator.BaseSensorOperator` is removed in Airflow 3.0
     |
-176 | # airflow.sensors.base_sensor_operator
-177 | BaseSensorOperator
+192 | # airflow.sensors.base_sensor_operator
+193 | BaseSensorOperator
     | ^^^^^^^^^^^^^^^^^^ AIR302
-178 | 
-179 | # airflow.sensors.date_time_sensor
+194 | 
+195 | # airflow.sensors.date_time_sensor
     |
     = help: Use `airflow.sensors.base.BaseSensorOperator` instead
 
-AIR302_names.py:180:1: AIR302 `airflow.sensors.date_time_sensor.DateTimeSensor` is removed in Airflow 3.0
+AIR302_names.py:196:1: AIR302 `airflow.sensors.date_time_sensor.DateTimeSensor` is removed in Airflow 3.0
     |
-179 | # airflow.sensors.date_time_sensor
-180 | DateTimeSensor
+195 | # airflow.sensors.date_time_sensor
+196 | DateTimeSensor
     | ^^^^^^^^^^^^^^ AIR302
-181 | 
-182 | # airflow.sensors.external_task
+197 | 
+198 | # airflow.sensors.external_task
     |
     = help: Use `airflow.sensors.date_time.DateTimeSensor` instead
 
-AIR302_names.py:183:1: AIR302 `airflow.sensors.external_task.ExternalTaskSensorLink` is removed in Airflow 3.0
+AIR302_names.py:199:1: AIR302 `airflow.sensors.external_task.ExternalTaskSensorLink` is removed in Airflow 3.0
     |
-182 | # airflow.sensors.external_task
-183 | ExternalTaskSensorLinkFromExternalTask
+198 | # airflow.sensors.external_task
+199 | ExternalTaskSensorLinkFromExternalTask
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
-184 | 
-185 | # airflow.sensors.external_task_sensor
+200 | 
+201 | # airflow.sensors.external_task_sensor
     |
     = help: Use `airflow.sensors.external_task.ExternalDagLink` instead
 
-AIR302_names.py:186:1: AIR302 `airflow.sensors.external_task_sensor.ExternalTaskMarker` is removed in Airflow 3.0
+AIR302_names.py:202:1: AIR302 `airflow.sensors.external_task_sensor.ExternalTaskMarker` is removed in Airflow 3.0
     |
-185 | # airflow.sensors.external_task_sensor
-186 | ExternalTaskMarker
+201 | # airflow.sensors.external_task_sensor
+202 | ExternalTaskMarker
     | ^^^^^^^^^^^^^^^^^^ AIR302
-187 | ExternalTaskSensor
-188 | ExternalTaskSensorLinkFromExternalTaskSensor
+203 | ExternalTaskSensor
+204 | ExternalTaskSensorLinkFromExternalTaskSensor
     |
     = help: Use `airflow.sensors.external_task.ExternalTaskMarker` instead
 
-AIR302_names.py:187:1: AIR302 `airflow.sensors.external_task_sensor.ExternalTaskSensor` is removed in Airflow 3.0
+AIR302_names.py:203:1: AIR302 `airflow.sensors.external_task_sensor.ExternalTaskSensor` is removed in Airflow 3.0
     |
-185 | # airflow.sensors.external_task_sensor
-186 | ExternalTaskMarker
-187 | ExternalTaskSensor
+201 | # airflow.sensors.external_task_sensor
+202 | ExternalTaskMarker
+203 | ExternalTaskSensor
     | ^^^^^^^^^^^^^^^^^^ AIR302
-188 | ExternalTaskSensorLinkFromExternalTaskSensor
+204 | ExternalTaskSensorLinkFromExternalTaskSensor
     |
     = help: Use `airflow.sensors.external_task.ExternalTaskSensor` instead
 
-AIR302_names.py:188:1: AIR302 `airflow.sensors.external_task_sensor.ExternalTaskSensorLink` is removed in Airflow 3.0
+AIR302_names.py:204:1: AIR302 `airflow.sensors.external_task_sensor.ExternalTaskSensorLink` is removed in Airflow 3.0
     |
-186 | ExternalTaskMarker
-187 | ExternalTaskSensor
-188 | ExternalTaskSensorLinkFromExternalTaskSensor
+202 | ExternalTaskMarker
+203 | ExternalTaskSensor
+204 | ExternalTaskSensorLinkFromExternalTaskSensor
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
-189 | 
-190 | # airflow.sensors.time_delta_sensor
+205 | 
+206 | # airflow.sensors.time_delta_sensor
     |
     = help: Use `airflow.sensors.external_task.ExternalDagLink` instead
 
-AIR302_names.py:191:1: AIR302 `airflow.sensors.time_delta_sensor.TimeDeltaSensor` is removed in Airflow 3.0
+AIR302_names.py:207:1: AIR302 `airflow.sensors.time_delta_sensor.TimeDeltaSensor` is removed in Airflow 3.0
     |
-190 | # airflow.sensors.time_delta_sensor
-191 | TimeDeltaSensor
+206 | # airflow.sensors.time_delta_sensor
+207 | TimeDeltaSensor
     | ^^^^^^^^^^^^^^^ AIR302
-192 | 
-193 | # airflow.timetables
+208 | 
+209 | # airflow.timetables
     |
     = help: Use `airflow.sensors.time_delta.TimeDeltaSensor` instead
 
-AIR302_names.py:194:1: AIR302 `airflow.timetables.datasets.DatasetOrTimeSchedule` is removed in Airflow 3.0
+AIR302_names.py:210:1: AIR302 `airflow.timetables.datasets.DatasetOrTimeSchedule` is removed in Airflow 3.0
     |
-193 | # airflow.timetables
-194 | DatasetOrTimeSchedule
+209 | # airflow.timetables
+210 | DatasetOrTimeSchedule
     | ^^^^^^^^^^^^^^^^^^^^^ AIR302
-195 | DatasetTriggeredTimetable
+211 | DatasetTriggeredTimetable
     |
     = help: Use `airflow.timetables.assets.AssetOrTimeSchedule` instead
 
-AIR302_names.py:195:1: AIR302 `airflow.timetables.simple.DatasetTriggeredTimetable` is removed in Airflow 3.0
+AIR302_names.py:211:1: AIR302 `airflow.timetables.simple.DatasetTriggeredTimetable` is removed in Airflow 3.0
     |
-193 | # airflow.timetables
-194 | DatasetOrTimeSchedule
-195 | DatasetTriggeredTimetable
+209 | # airflow.timetables
+210 | DatasetOrTimeSchedule
+211 | DatasetTriggeredTimetable
     | ^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
-196 | 
-197 | # airflow.triggers.external_task
+212 | 
+213 | # airflow.triggers.external_task
     |
     = help: Use `airflow.timetables.simple.AssetTriggeredTimetable` instead
 
-AIR302_names.py:198:1: AIR302 `airflow.triggers.external_task.TaskStateTrigger` is removed in Airflow 3.0
+AIR302_names.py:214:1: AIR302 `airflow.triggers.external_task.TaskStateTrigger` is removed in Airflow 3.0
     |
-197 | # airflow.triggers.external_task
-198 | TaskStateTrigger
+213 | # airflow.triggers.external_task
+214 | TaskStateTrigger
     | ^^^^^^^^^^^^^^^^ AIR302
-199 | 
-200 | # airflow.utils.date
+215 | 
+216 | # airflow.utils.date
     |
 
-AIR302_names.py:201:7: AIR302 `airflow.utils.dates.date_range` is removed in Airflow 3.0
+AIR302_names.py:217:7: AIR302 `airflow.utils.dates.date_range` is removed in Airflow 3.0
     |
-200 | # airflow.utils.date
-201 | dates.date_range
+216 | # airflow.utils.date
+217 | dates.date_range
     |       ^^^^^^^^^^ AIR302
-202 | dates.days_ago
+218 | dates.days_ago
     |
     = help: Use `airflow.timetables.` instead
 
-AIR302_names.py:202:7: AIR302 `airflow.utils.dates.days_ago` is removed in Airflow 3.0
+AIR302_names.py:218:7: AIR302 `airflow.utils.dates.days_ago` is removed in Airflow 3.0
     |
-200 | # airflow.utils.date
-201 | dates.date_range
-202 | dates.days_ago
+216 | # airflow.utils.date
+217 | dates.date_range
+218 | dates.days_ago
     |       ^^^^^^^^ AIR302
-203 | 
-204 | date_range
+219 | 
+220 | date_range
     |
     = help: Use `pendulum.today('UTC').add(days=-N, ...)` instead
 
-AIR302_names.py:204:1: AIR302 `airflow.utils.dates.date_range` is removed in Airflow 3.0
+AIR302_names.py:220:1: AIR302 `airflow.utils.dates.date_range` is removed in Airflow 3.0
     |
-202 | dates.days_ago
-203 | 
-204 | date_range
+218 | dates.days_ago
+219 | 
+220 | date_range
     | ^^^^^^^^^^ AIR302
-205 | days_ago
-206 | infer_time_unit
+221 | days_ago
+222 | infer_time_unit
     |
     = help: Use `airflow.timetables.` instead
 
-AIR302_names.py:205:1: AIR302 `airflow.utils.dates.days_ago` is removed in Airflow 3.0
+AIR302_names.py:221:1: AIR302 `airflow.utils.dates.days_ago` is removed in Airflow 3.0
     |
-204 | date_range
-205 | days_ago
+220 | date_range
+221 | days_ago
     | ^^^^^^^^ AIR302
-206 | infer_time_unit
-207 | parse_execution_date
+222 | infer_time_unit
+223 | parse_execution_date
     |
     = help: Use `pendulum.today('UTC').add(days=-N, ...)` instead
 
-AIR302_names.py:206:1: AIR302 `airflow.utils.dates.infer_time_unit` is removed in Airflow 3.0
+AIR302_names.py:222:1: AIR302 `airflow.utils.dates.infer_time_unit` is removed in Airflow 3.0
     |
-204 | date_range
-205 | days_ago
-206 | infer_time_unit
+220 | date_range
+221 | days_ago
+222 | infer_time_unit
     | ^^^^^^^^^^^^^^^ AIR302
-207 | parse_execution_date
-208 | round_time
+223 | parse_execution_date
+224 | round_time
     |
 
-AIR302_names.py:207:1: AIR302 `airflow.utils.dates.parse_execution_date` is removed in Airflow 3.0
+AIR302_names.py:223:1: AIR302 `airflow.utils.dates.parse_execution_date` is removed in Airflow 3.0
     |
-205 | days_ago
-206 | infer_time_unit
-207 | parse_execution_date
+221 | days_ago
+222 | infer_time_unit
+223 | parse_execution_date
     | ^^^^^^^^^^^^^^^^^^^^ AIR302
-208 | round_time
-209 | scale_time_units
+224 | round_time
+225 | scale_time_units
     |
 
-AIR302_names.py:208:1: AIR302 `airflow.utils.dates.round_time` is removed in Airflow 3.0
+AIR302_names.py:224:1: AIR302 `airflow.utils.dates.round_time` is removed in Airflow 3.0
     |
-206 | infer_time_unit
-207 | parse_execution_date
-208 | round_time
+222 | infer_time_unit
+223 | parse_execution_date
+224 | round_time
     | ^^^^^^^^^^ AIR302
-209 | scale_time_units
+225 | scale_time_units
     |
 
-AIR302_names.py:209:1: AIR302 `airflow.utils.dates.scale_time_units` is removed in Airflow 3.0
+AIR302_names.py:225:1: AIR302 `airflow.utils.dates.scale_time_units` is removed in Airflow 3.0
     |
-207 | parse_execution_date
-208 | round_time
-209 | scale_time_units
+223 | parse_execution_date
+224 | round_time
+225 | scale_time_units
     | ^^^^^^^^^^^^^^^^ AIR302
-210 | 
-211 | # This one was not deprecated.
+226 | 
+227 | # This one was not deprecated.
     |
 
-AIR302_names.py:216:1: AIR302 `airflow.utils.dag_cycle_tester.test_cycle` is removed in Airflow 3.0
+AIR302_names.py:232:1: AIR302 `airflow.utils.dag_cycle_tester.test_cycle` is removed in Airflow 3.0
     |
-215 | # airflow.utils.dag_cycle_tester
-216 | test_cycle
+231 | # airflow.utils.dag_cycle_tester
+232 | test_cycle
     | ^^^^^^^^^^ AIR302
-217 | 
-218 | # airflow.utils.decorators
+233 | 
+234 | # airflow.utils.decorators
     |
 
-AIR302_names.py:219:1: AIR302 `airflow.utils.decorators.apply_defaults` is removed in Airflow 3.0; `apply_defaults` is now unconditionally done and can be safely removed.
+AIR302_names.py:235:1: AIR302 `airflow.utils.decorators.apply_defaults` is removed in Airflow 3.0; `apply_defaults` is now unconditionally done and can be safely removed.
     |
-218 | # airflow.utils.decorators
-219 | apply_defaults
+234 | # airflow.utils.decorators
+235 | apply_defaults
     | ^^^^^^^^^^^^^^ AIR302
-220 | 
-221 | # airflow.utils.file
+236 | 
+237 | # airflow.utils.file
     |
 
-AIR302_names.py:222:1: AIR302 `airflow.utils.file.TemporaryDirectory` is removed in Airflow 3.0
+AIR302_names.py:238:1: AIR302 `airflow.utils.file.TemporaryDirectory` is removed in Airflow 3.0
     |
-221 | # airflow.utils.file
-222 | TemporaryDirectory, mkdirs
+237 | # airflow.utils.file
+238 | TemporaryDirectory, mkdirs
     | ^^^^^^^^^^^^^^^^^^ AIR302
-223 | 
-224 | #  airflow.utils.helpers
+239 | 
+240 | #  airflow.utils.helpers
     |
 
-AIR302_names.py:222:21: AIR302 `airflow.utils.file.mkdirs` is removed in Airflow 3.0
+AIR302_names.py:238:21: AIR302 `airflow.utils.file.mkdirs` is removed in Airflow 3.0
     |
-221 | # airflow.utils.file
-222 | TemporaryDirectory, mkdirs
+237 | # airflow.utils.file
+238 | TemporaryDirectory, mkdirs
     |                     ^^^^^^ AIR302
-223 | 
-224 | #  airflow.utils.helpers
+239 | 
+240 | #  airflow.utils.helpers
     |
     = help: Use `pendulum.today('UTC').add(days=-N, ...)` instead
 
-AIR302_names.py:225:1: AIR302 `airflow.utils.helpers.chain` is removed in Airflow 3.0
+AIR302_names.py:241:1: AIR302 `airflow.utils.helpers.chain` is removed in Airflow 3.0
     |
-224 | #  airflow.utils.helpers
-225 | chain, cross_downstream
+240 | #  airflow.utils.helpers
+241 | chain, cross_downstream
     | ^^^^^ AIR302
-226 | 
-227 | # airflow.utils.state
+242 | 
+243 | # airflow.utils.state
     |
     = help: Use `airflow.models.baseoperator.chain` instead
 
-AIR302_names.py:225:8: AIR302 `airflow.utils.helpers.cross_downstream` is removed in Airflow 3.0
+AIR302_names.py:241:8: AIR302 `airflow.utils.helpers.cross_downstream` is removed in Airflow 3.0
     |
-224 | #  airflow.utils.helpers
-225 | chain, cross_downstream
+240 | #  airflow.utils.helpers
+241 | chain, cross_downstream
     |        ^^^^^^^^^^^^^^^^ AIR302
-226 | 
-227 | # airflow.utils.state
+242 | 
+243 | # airflow.utils.state
     |
     = help: Use `airflow.models.baseoperator.cross_downstream` instead
 
-AIR302_names.py:228:1: AIR302 `airflow.utils.state.SHUTDOWN` is removed in Airflow 3.0
+AIR302_names.py:244:1: AIR302 `airflow.utils.state.SHUTDOWN` is removed in Airflow 3.0
     |
-227 | # airflow.utils.state
-228 | SHUTDOWN, terminating_states
+243 | # airflow.utils.state
+244 | SHUTDOWN, terminating_states
     | ^^^^^^^^ AIR302
-229 | 
-230 | #  airflow.utils.trigger_rule
+245 | 
+246 | #  airflow.utils.trigger_rule
     |
 
-AIR302_names.py:228:11: AIR302 `airflow.utils.state.terminating_states` is removed in Airflow 3.0
+AIR302_names.py:244:11: AIR302 `airflow.utils.state.terminating_states` is removed in Airflow 3.0
     |
-227 | # airflow.utils.state
-228 | SHUTDOWN, terminating_states
+243 | # airflow.utils.state
+244 | SHUTDOWN, terminating_states
     |           ^^^^^^^^^^^^^^^^^^ AIR302
-229 | 
-230 | #  airflow.utils.trigger_rule
+245 | 
+246 | #  airflow.utils.trigger_rule
     |
 
-AIR302_names.py:231:13: AIR302 `airflow.utils.trigger_rule.TriggerRule.DUMMY` is removed in Airflow 3.0
+AIR302_names.py:247:13: AIR302 `airflow.utils.trigger_rule.TriggerRule.DUMMY` is removed in Airflow 3.0
     |
-230 | #  airflow.utils.trigger_rule
-231 | TriggerRule.DUMMY
+246 | #  airflow.utils.trigger_rule
+247 | TriggerRule.DUMMY
     |             ^^^^^ AIR302
-232 | TriggerRule.NONE_FAILED_OR_SKIPPED
+248 | TriggerRule.NONE_FAILED_OR_SKIPPED
     |
 
-AIR302_names.py:232:13: AIR302 `airflow.utils.trigger_rule.TriggerRule.NONE_FAILED_OR_SKIPPED` is removed in Airflow 3.0
+AIR302_names.py:248:13: AIR302 `airflow.utils.trigger_rule.TriggerRule.NONE_FAILED_OR_SKIPPED` is removed in Airflow 3.0
     |
-230 | #  airflow.utils.trigger_rule
-231 | TriggerRule.DUMMY
-232 | TriggerRule.NONE_FAILED_OR_SKIPPED
+246 | #  airflow.utils.trigger_rule
+247 | TriggerRule.DUMMY
+248 | TriggerRule.NONE_FAILED_OR_SKIPPED
     |             ^^^^^^^^^^^^^^^^^^^^^^ AIR302
-233 | 
-234 | # airflow.www.auth
+249 | 
+250 | # airflow.www.auth
     |
 
-AIR302_names.py:235:1: AIR302 `airflow.www.auth.has_access` is removed in Airflow 3.0
+AIR302_names.py:251:1: AIR302 `airflow.www.auth.has_access` is removed in Airflow 3.0
     |
-234 | # airflow.www.auth
-235 | has_access
+250 | # airflow.www.auth
+251 | has_access
     | ^^^^^^^^^^ AIR302
-236 | has_access_dataset
+252 | has_access_dataset
     |
     = help: Use `airflow.www.auth.has_access_*` instead
 
-AIR302_names.py:236:1: AIR302 `airflow.www.auth.has_access_dataset` is removed in Airflow 3.0
+AIR302_names.py:252:1: AIR302 `airflow.www.auth.has_access_dataset` is removed in Airflow 3.0
     |
-234 | # airflow.www.auth
-235 | has_access
-236 | has_access_dataset
+250 | # airflow.www.auth
+251 | has_access
+252 | has_access_dataset
     | ^^^^^^^^^^^^^^^^^^ AIR302
-237 | 
-238 | # airflow.www.utils
+253 | 
+254 | # airflow.www.utils
     |
     = help: Use `airflow.www.auth.has_access_dataset.has_access_asset` instead
 
-AIR302_names.py:239:1: AIR302 `airflow.www.utils.get_sensitive_variables_fields` is removed in Airflow 3.0
+AIR302_names.py:255:1: AIR302 `airflow.www.utils.get_sensitive_variables_fields` is removed in Airflow 3.0
     |
-238 | # airflow.www.utils
-239 | get_sensitive_variables_fields, should_hide_value_for_key
+254 | # airflow.www.utils
+255 | get_sensitive_variables_fields, should_hide_value_for_key
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
     |
     = help: Use `airflow.utils.log.secrets_masker.get_sensitive_variables_fields` instead
 
-AIR302_names.py:239:33: AIR302 `airflow.www.utils.should_hide_value_for_key` is removed in Airflow 3.0
+AIR302_names.py:255:33: AIR302 `airflow.www.utils.should_hide_value_for_key` is removed in Airflow 3.0
     |
-238 | # airflow.www.utils
-239 | get_sensitive_variables_fields, should_hide_value_for_key
+254 | # airflow.www.utils
+255 | get_sensitive_variables_fields, should_hide_value_for_key
     |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
     |
     = help: Use `airflow.utils.log.secrets_masker.should_hide_value_for_key` instead


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Airflow 3.0 removes various deprecated functions, members, modules, and other values. They have been deprecated in 2.x, but the removal causes incompatibilities that we want to detect. This PR deprecates the following names.

* `airflow.api_connexion.security.requires_access_dataset` → `airflow.api_connexion.security.requires_access_asset`
* `airflow.auth.managers.base_auth_manager.is_authorized_dataset` → `airflow.auth.managers.base_auth_manager.is_authorized_asset`
* `airflow.auth.managers.models.resource_details.DatasetDetails` → `airflow.auth.managers.models.resource_details.AssetDetails`
* `airflow.lineage.hook.DatasetLineageInfo` → `airflow.lineage.hook.AssetLineageInfo`
* `airflow.security.permissions.RESOURCE_DATASET` → `airflow.security.permissions.RESOURCE_ASSET`
* `airflow.www.auth.has_access_dataset` → `airflow.www.auth.has_access_dataset.has_access_asset`
* remove `airflow.datasets.DatasetAliasEvent`
* `airflow.datasets.Dataset` → `airflow.sdk.definitions.asset.Asset`
* `airflow.Dataset` → `airflow.sdk.definitions.asset.Asset`
* `airflow.datasets.DatasetAlias` → `airflow.sdk.definitions.asset.AssetAlias`
* `airflow.datasets.DatasetAll` → `airflow.sdk.definitions.asset.AssetAll`
* `airflow.datasets.DatasetAny` → `airflow.sdk.definitions.asset.AssetAny`
* `airflow.datasets.metadata` → `airflow.sdk.definitions.asset.metadata`
* `airflow.datasets.expand_alias_to_datasets` → `airflow.sdk.definitions.asset.expand_alias_to_assets`
* `airflow.datasets.manager.dataset_manager` → `airflow.assets.manager`
* `airflow.datasets.manager.resolve_dataset_manager` → `airflow.assets.resolve_asset_manager`
* `airflow.datasets.manager.DatasetManager` → `airflow.assets.AssetManager`
* `airflow.listeners.spec.dataset.on_dataset_created` → `airflow.listeners.spec.asset.on_asset_created`
* `airflow.listeners.spec.dataset.on_dataset_changed` → `airflow.listeners.spec.asset.on_asset_changed`
* `airflow.timetables.simple.DatasetTriggeredTimetable` → `airflow.timetables.simple.AssetTriggeredTimetable`
* `airflow.timetables.datasets.DatasetOrTimeSchedule` → `airflow.timetables.assets.AssetOrTimeSchedule`
* `airflow.providers.amazon.auth_manager.avp.entities.AvpEntities.DATASET` → `airflow.providers.amazon.auth_manager.avp.entities.AvpEntities.ASSET`
* `airflow.providers.amazon.aws.datasets.s3.create_dataset` → `airflow.providers.amazon.aws.assets.s3.create_asset`
* `airflow.providers.amazon.aws.datasets.s3.convert_dataset_to_openlineage` → `airflow.providers.amazon.aws.datasets.s3.convert_dataset_to_openlineage`
* `airflow.providers.amazon.aws.datasets.s3.sanitize_uri` → `airflow.providers.amazon.aws.assets.s3.sanitize_uri`
* `airflow.providers.common.io.datasets.file.convert_dataset_to_openlineage` → `airflow.providers.common.io.assets.file.convert_asset_to_openlineage`
* `airflow.providers.common.io.datasets.file.sanitize_uri` → `airflow.providers.common.io.assets.file.sanitize_uri`
* `airflow.providers.common.io.datasets.file.create_dataset` → `airflow.providers.common.io.assets.file.create_asset`
* `airflow.providers.google.datasets.bigquery.sanitize_uri` → `airflow.providers.google.assets.bigquery.sanitize_uri`
* `airflow.providers.google.datasets.gcs.create_dataset` → `airflow.providers.google.assets.gcs.create_asset`
* `airflow.providers.google.datasets.gcs.sanitize_uri` → `airflow.providers.google.assets.gcs.sanitize_uri`
* `airflow.providers.google.datasets.gcs.convert_dataset_to_openlineage` → `airflow.providers.google.assets.gcs.convert_asset_to_openlineage`
* `airflow.providers.fab.auth_manager.fab_auth_manager.is_authorized_dataset` → `airflow.providers.fab.auth_manager.fab_auth_manager.is_authorized_asset`
* `airflow.providers.openlineage.utils.utils.DatasetInfo` → `airflow.providers.openlineage.utils.utils.AssetInfo`
* `airflow.providers.openlineage.utils.utils.translate_airflow_dataset` → `airflow.providers.openlineage.utils.utils.translate_airflow_asset`
* `airflow.providers.postgres.datasets.postgres.sanitize_uri` → `airflow.providers.postgres.assets.postgres.sanitize_uri`
* `airflow.providers.mysql.datasets.mysql.sanitize_uri` → `airflow.providers.mysql.assets.mysql.sanitize_uri`
* `airflow.providers.trino.datasets.trino.sanitize_uri` → `airflow.providers.trino.assets.trino.sanitize_uri`

In additional to the newly added rules above, the message for `airflow.contrib.*` and `airflow.subdag.*` has been extended, `airflow.sensors.external_task.ExternalTaskSensorLink` error has been fixed and the test fixture has been reorganized

## Test Plan

<!-- How was it tested? -->
A test fixture is included in the PR.
