### PR TITLE
[`perflint`] Simplify finding the loop target in `perf401`

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/perflint/PERF401.py
+++ b/crates/ruff_linter/resources/test/fixtures/perflint/PERF401.py
@@ -244,3 +244,10 @@ def f():
         for a in values:
             result.append(a + 1)  # PERF401
     result = []
+
+def f():
+    values = [1, 2, 3]
+    result = []
+    for i in values:
+        result.append(i + 1)  # Ok
+    del i

--- a/crates/ruff_linter/src/rules/perflint/snapshots/ruff_linter__rules__perflint__tests__preview__PERF401_PERF401.py.snap
+++ b/crates/ruff_linter/src/rules/perflint/snapshots/ruff_linter__rules__perflint__tests__preview__PERF401_PERF401.py.snap
@@ -484,3 +484,5 @@ PERF401.py:245:13: PERF401 [*] Use `list.extend` to create a transformed list
 245     |-            result.append(a + 1)  # PERF401
     244 |+        result.extend(a + 1 for a in values)  # PERF401
 246 245 |     result = []
+247 246 | 
+248 247 | def f():


### PR DESCRIPTION
Fixes #15012.

```python
def f():
    # panics when the code can't find the loop variable
    values = [1, 2, 3]
    result = []
    for i in values:
        result.append(i + 1)
    del i
```

I'm not sure exactly why this test case panics, but I suspect the `del i` removes the binding from the semantic model's symbols.

I changed the code to search for the correct binding by directly iterating through the bindings. Since we know exactly which binding we want, this should find the loop variable without any complications.