### PR TITLE
Fix stale File status in tests

### DIFF
--- a/crates/red_knot_python_semantic/src/module_resolver/resolver.rs
+++ b/crates/red_knot_python_semantic/src/module_resolver/resolver.rs
@@ -73,6 +73,15 @@ enum SystemOrVendoredPathRef<'a> {
     Vendored(&'a VendoredPath),
 }
 
+impl std::fmt::Display for SystemOrVendoredPathRef<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SystemOrVendoredPathRef::System(system) => system.fmt(f),
+            SystemOrVendoredPathRef::Vendored(vendored) => vendored.fmt(f),
+        }
+    }
+}
+
 /// Resolves the module for the file with the given id.
 ///
 /// Returns `None` if the file is not a module locatable via any of the known search paths.

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -124,7 +124,6 @@ pub(crate) fn infer_definition_types<'db>(
     let file = definition.file(db);
     let _span = tracing::trace_span!(
         "infer_definition_types",
-        definition = ?definition.as_id(),
         range = ?definition.kind(db).range(),
         file = %file.path(db)
     )


### PR DESCRIPTION
## Summary

Fixes https://github.com/astral-sh/ruff/issues/15027

The `MemoryFileSystem::write_file` API automatically creates non-existing ancestor directoryes 
but we failed to update the status of the now created ancestor directories in the `Files` data structure. 


## Test Plan

Tested that the case in https://github.com/astral-sh/ruff/issues/15027 now passes regardless of whether the *Simple* case is commented out or not
