### PR TITLE
[red-knot] Explicitly test diagnostics are emitted for unresolvable submodule imports

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/import/basic.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/import/basic.md
@@ -91,3 +91,16 @@ reveal_type(c.C)  # revealed: Literal[C]
 ```py path=a/b/c.py
 class C: ...
 ```
+
+## Unresolvable submodule imports
+
+```py
+# Topmost component resolvable, submodule not resolvable:
+import a.foo  # error: [unresolved-import] "Cannot resolve import `a.foo`"
+
+# Topmost component unresolvable:
+import b.foo  # error: [unresolved-import] "Cannot resolve import `b.foo`"
+```
+
+```py path=a/__init__.py
+```


### PR DESCRIPTION
Everything's working as expected here, but we didn't have explicit tests for these; this PR just adds some missing cases