### PR TITLE
[`ruff`] Avoid false positives for RUF027 for typing context bindings.

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/ruff/RUF027_1.py
+++ b/crates/ruff_linter/resources/test/fixtures/ruff/RUF027_1.py
@@ -68,3 +68,9 @@ def negative_cases():
     @app.get("/items/{item_id}")
     async def read_item(item_id):
         return {"item_id": item_id}
+
+    from typing import TYPE_CHECKING
+    if TYPE_CHECKING:
+        from datetime import date
+
+    t = "foo/{date}"

--- a/crates/ruff_linter/src/rules/ruff/rules/missing_fstring_syntax.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/missing_fstring_syntax.rs
@@ -210,14 +210,13 @@ fn should_be_fstring(
                 }
                 if semantic
                     // the parsed expression nodes have incorrect ranges
-                    // so we create a dummy node which has a range that's
-                    // close enough to being correct in order for
-                    // `simulate_runtime_load` to return the correct result.
-                    .simulate_runtime_load(&ast::ExprName {
-                        id: id.clone(),
-                        range: literal.range(),
-                        ctx: ast::ExprContext::Load,
-                    })
+                    // so we need to use the range of the literal for the
+                    // lookup in order to get reasonable results.
+                    .simulate_runtime_load_at_location_in_scope(
+                        id,
+                        literal.range(),
+                        semantic.scope_id,
+                    )
                     .map_or(true, |id| semantic.binding(id).kind.is_builtin())
                 {
                     return false;

--- a/crates/ruff_linter/src/rules/ruff/rules/missing_fstring_syntax.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/missing_fstring_syntax.rs
@@ -209,7 +209,15 @@ fn should_be_fstring(
                     return false;
                 }
                 if semantic
-                    .lookup_symbol(id)
+                    // the parsed expression nodes have incorrect ranges
+                    // so we create a dummy node which has a range that's
+                    // close enough to being correct in order for
+                    // `simulate_runtime_load` to return the correct result.
+                    .simulate_runtime_load(&ast::ExprName {
+                        id: id.clone(),
+                        range: literal.range(),
+                        ctx: ast::ExprContext::Load,
+                    })
                     .map_or(true, |id| semantic.binding(id).kind.is_builtin())
                 {
                     return false;


### PR DESCRIPTION
Closes #14000 

## Summary

For typing context bindings we know that they won't be available at runtime. We shouldn't recommend a fix, that will result in name errors at runtime.

## Test Plan

`cargo nextest run`
