### PR TITLE
Prioritize attribute in from/import statement

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/import/conflicts.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/import/conflicts.md
@@ -60,7 +60,7 @@ sees the submodule as the value of `b` instead of the integer.
 from a import b
 import a.b
 
-# Python would say Literal[42] for `b`
+# Python would say `Literal[42]` for `b`
 reveal_type(b)  # revealed: <module 'a.b'>
 reveal_type(a.b)  # revealed: <module 'a.b'>
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/import/conflicts.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/import/conflicts.md
@@ -37,6 +37,7 @@ import a.b
 from a import b
 
 reveal_type(b)  # revealed: <module 'a.b'>
+reveal_type(a.b)  # revealed: <module 'a.b'>
 ```
 
 ```py path=a/__init__.py
@@ -48,11 +49,22 @@ b = 42
 
 ## Via both (backwards)
 
+In this test, we infer a different type for `b` than the runtime behavior of the Python interpreter.
+The interpreter will not load the submodule `a.b` during the `from a import b` statement, since `a`
+contains a non-module attribute named `b`. (See the [definition][from-import] of a `from...import`
+statement for details.)  However, because our import tracking is flow-insensitive, we will see that
+`a.b` is imported somewhere in the file, and therefore assume that the `from...import` statement
+sees the submodule as the value of `b` instead of the integer.
+
+[from-import]: https://docs.python.org/3/reference/simple_stmts.html#the-import-statement
+
 ```py
 from a import b
 import a.b
 
+# Python would say Literal[42] for `b`
 reveal_type(b)  # revealed: <module 'a.b'>
+reveal_type(a.b)  # revealed: <module 'a.b'>
 ```
 
 ```py path=a/__init__.py

--- a/crates/red_knot_python_semantic/resources/mdtest/import/conflicts.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/import/conflicts.md
@@ -1,0 +1,63 @@
+# Conflicting attributes and submodules
+
+## Via import
+
+```py
+import a.b
+
+reveal_type(a.b)  # revealed: <module 'a.b'>
+```
+
+```py path=a/__init__.py
+b = 42
+```
+
+```py path=a/b.py
+```
+
+## Via from/import
+
+```py
+from a import b
+
+reveal_type(b)  # revealed: Literal[42]
+```
+
+```py path=a/__init__.py
+b = 42
+```
+
+```py path=a/b.py
+```
+
+## Via both
+
+```py
+import a.b
+from a import b
+
+reveal_type(b)  # revealed: <module 'a.b'>
+```
+
+```py path=a/__init__.py
+b = 42
+```
+
+```py path=a/b.py
+```
+
+## Via both (backwards)
+
+```py
+from a import b
+import a.b
+
+reveal_type(b)  # revealed: <module 'a.b'>
+```
+
+```py path=a/__init__.py
+b = 42
+```
+
+```py path=a/b.py
+```

--- a/crates/red_knot_python_semantic/resources/mdtest/import/conflicts.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/import/conflicts.md
@@ -52,11 +52,9 @@ b = 42
 In this test, we infer a different type for `b` than the runtime behavior of the Python interpreter.
 The interpreter will not load the submodule `a.b` during the `from a import b` statement, since `a`
 contains a non-module attribute named `b`. (See the [definition][from-import] of a `from...import`
-statement for details.)  However, because our import tracking is flow-insensitive, we will see that
+statement for details.) However, because our import tracking is flow-insensitive, we will see that
 `a.b` is imported somewhere in the file, and therefore assume that the `from...import` statement
 sees the submodule as the value of `b` instead of the integer.
-
-[from-import]: https://docs.python.org/3/reference/simple_stmts.html#the-import-statement
 
 ```py
 from a import b
@@ -73,3 +71,5 @@ b = 42
 
 ```py path=a/b.py
 ```
+
+[from-import]: https://docs.python.org/3/reference/simple_stmts.html#the-import-statement

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -2308,10 +2308,10 @@ impl<'db> TypeInferenceBuilder<'db> {
         } = alias;
 
         // First try loading the requested attribute from the module.
-        // TODO: Consider loading _both_ the attribute and any submodule and unioning them together
-        // if both exist.
         if let Symbol::Type(ty, boundness) = module_ty.member(self.db, name) {
             if boundness == Boundness::PossiblyUnbound {
+                // TODO: Consider loading _both_ the attribute and any submodule and unioning them
+                // together if the attribute exists but is possibly-unbound.
                 self.diagnostics.add_lint(
                     &POSSIBLY_UNBOUND_IMPORT,
                     AnyNodeRef::Alias(alias),

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -2308,6 +2308,8 @@ impl<'db> TypeInferenceBuilder<'db> {
         } = alias;
 
         // First try loading the requested attribute from the module.
+        // TODO: Consider loading _both_ the attribute and any submodule and unioning them together
+        // if both exist.
         if let Symbol::Type(ty, boundness) = module_ty.member(self.db, name) {
             if boundness == Boundness::PossiblyUnbound {
                 self.diagnostics.add_lint(


### PR DESCRIPTION
This tweaks the new semantics from #15026 a bit when a symbol could be interpreted both as an attribute and a submodule of a package.  For `from...import`, we should actually prioritize the attribute, because of how the statement itself [is implemented](https://docs.python.org/3/reference/simple_stmts.html#the-import-statement):

> 1. check if the imported module has an attribute by that name
> 2. if not, attempt to import a submodule with that name and then check the imported module again for that attribute