### PR TITLE
Modify parsing of raise with cause when exception is absent

### DIFF
--- a/crates/ruff_python_parser/resources/inline/err/raise_stmt_from_without_exc.py
+++ b/crates/ruff_python_parser/resources/inline/err/raise_stmt_from_without_exc.py
@@ -1,0 +1,2 @@
+raise from exc
+raise from None

--- a/crates/ruff_python_parser/src/parser/statement.rs
+++ b/crates/ruff_python_parser/src/parser/statement.rs
@@ -411,39 +411,41 @@ impl<'src> Parser<'src> {
         let start = self.node_start();
         self.bump(TokenKind::Raise);
 
-        let exc = if self.at(TokenKind::Newline) {
-            None
-        } else if self.at(TokenKind::From) {
-            // test_err raise_stmt_from_without_exc
-            // raise from exc
-            // raise from None
-            self.add_error(
-                ParseErrorType::OtherError(
-                    "Exception missing in `raise` statement with cause".to_string(),
-                ),
-                self.current_token_range(),
-            );
-            None
-        } else {
-            // test_err raise_stmt_invalid_exc
-            // raise *x
-            // raise yield x
-            // raise x := 1
-            let exc = self.parse_expression_list(ExpressionContext::default());
-
-            if let Some(ast::ExprTuple {
-                parenthesized: false,
-                ..
-            }) = exc.as_tuple_expr()
-            {
-                // test_err raise_stmt_unparenthesized_tuple_exc
-                // raise x,
-                // raise x, y
-                // raise x, y from z
-                self.add_error(ParseErrorType::UnparenthesizedTupleExpression, &exc);
+        let exc = match self.current_token_kind() {
+            TokenKind::Newline => None,
+            TokenKind::From => {
+                // test_err raise_stmt_from_without_exc
+                // raise from exc
+                // raise from None
+                self.add_error(
+                    ParseErrorType::OtherError(
+                        "Exception missing in `raise` statement with cause".to_string(),
+                    ),
+                    self.current_token_range(),
+                );
+                None
             }
+            _ => {
+                // test_err raise_stmt_invalid_exc
+                // raise *x
+                // raise yield x
+                // raise x := 1
+                let exc = self.parse_expression_list(ExpressionContext::default());
 
-            Some(Box::new(exc.expr))
+                if let Some(ast::ExprTuple {
+                    parenthesized: false,
+                    ..
+                }) = exc.as_tuple_expr()
+                {
+                    // test_err raise_stmt_unparenthesized_tuple_exc
+                    // raise x,
+                    // raise x, y
+                    // raise x, y from z
+                    self.add_error(ParseErrorType::UnparenthesizedTupleExpression, &exc);
+                }
+
+                Some(Box::new(exc.expr))
+            }
         };
 
         let cause = self.eat(TokenKind::From).then(|| {

--- a/crates/ruff_python_parser/src/parser/statement.rs
+++ b/crates/ruff_python_parser/src/parser/statement.rs
@@ -419,7 +419,7 @@ impl<'src> Parser<'src> {
             // raise from None
             self.add_error(
                 ParseErrorType::OtherError(
-                    "Exception missing in `raise ... from ...` statement.".to_string(),
+                    "Exception missing in `raise` statement with cause".to_string(),
                 ),
                 self.current_token_range(),
             );

--- a/crates/ruff_python_parser/src/parser/statement.rs
+++ b/crates/ruff_python_parser/src/parser/statement.rs
@@ -413,6 +413,17 @@ impl<'src> Parser<'src> {
 
         let exc = if self.at(TokenKind::Newline) {
             None
+        } else if self.at(TokenKind::From) {
+            // test_err raise_stmt_from_without_exc
+            // raise from exc
+            // raise from None
+            self.add_error(
+                ParseErrorType::OtherError(
+                    "Exception missing in `raise ... from ...` statement.".to_string(),
+                ),
+                self.current_token_range(),
+            );
+            None
         } else {
             // test_err raise_stmt_invalid_exc
             // raise *x
@@ -435,7 +446,7 @@ impl<'src> Parser<'src> {
             Some(Box::new(exc.expr))
         };
 
-        let cause = (exc.is_some() && self.eat(TokenKind::From)).then(|| {
+        let cause = self.eat(TokenKind::From).then(|| {
             // test_err raise_stmt_invalid_cause
             // raise x from *y
             // raise x from yield y

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@raise_stmt_from_without_exc.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@raise_stmt_from_without_exc.py.snap
@@ -45,7 +45,7 @@ Module(
 
   |
 1 | raise from exc
-  |       ^^^^ Syntax Error: Exception missing in `raise ... from ...` statement.
+  |       ^^^^ Syntax Error: Exception missing in `raise` statement with cause
 2 | raise from None
   |
 
@@ -53,5 +53,5 @@ Module(
   |
 1 | raise from exc
 2 | raise from None
-  |       ^^^^ Syntax Error: Exception missing in `raise ... from ...` statement.
+  |       ^^^^ Syntax Error: Exception missing in `raise` statement with cause
   |

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@raise_stmt_from_without_exc.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@raise_stmt_from_without_exc.py.snap
@@ -1,0 +1,57 @@
+---
+source: crates/ruff_python_parser/tests/fixtures.rs
+input_file: crates/ruff_python_parser/resources/inline/err/raise_stmt_from_without_exc.py
+---
+## AST
+
+```
+Module(
+    ModModule {
+        range: 0..31,
+        body: [
+            Raise(
+                StmtRaise {
+                    range: 0..14,
+                    exc: None,
+                    cause: Some(
+                        Name(
+                            ExprName {
+                                range: 11..14,
+                                id: Name("exc"),
+                                ctx: Load,
+                            },
+                        ),
+                    ),
+                },
+            ),
+            Raise(
+                StmtRaise {
+                    range: 15..30,
+                    exc: None,
+                    cause: Some(
+                        NoneLiteral(
+                            ExprNoneLiteral {
+                                range: 26..30,
+                            },
+                        ),
+                    ),
+                },
+            ),
+        ],
+    },
+)
+```
+## Errors
+
+  |
+1 | raise from exc
+  |       ^^^^ Syntax Error: Exception missing in `raise ... from ...` statement.
+2 | raise from None
+  |
+
+
+  |
+1 | raise from exc
+2 | raise from None
+  |       ^^^^ Syntax Error: Exception missing in `raise ... from ...` statement.
+  |


### PR DESCRIPTION
When confronted with `raise from exc` the parser will now create a `StmtRaise` that has `None` for the exception and `exc` for the cause. 

Before, the parser created a `StmtRaise` with `from` for the exception, no cause, and a spurious expression `exc` afterwards.
