### PR TITLE
[red-knot] Add support for unpacking `for` target

### DIFF
--- a/crates/red_knot_python_semantic/src/semantic_index/definition.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/definition.rs
@@ -225,8 +225,10 @@ pub(crate) struct WithItemDefinitionNodeRef<'a> {
 
 #[derive(Copy, Clone, Debug)]
 pub(crate) struct ForStmtDefinitionNodeRef<'a> {
+    pub(crate) unpack: Option<Unpack<'a>>,
     pub(crate) iterable: &'a ast::Expr,
-    pub(crate) target: &'a ast::ExprName,
+    pub(crate) name: &'a ast::ExprName,
+    pub(crate) first: bool,
     pub(crate) is_async: bool,
 }
 
@@ -298,12 +300,16 @@ impl<'db> DefinitionNodeRef<'db> {
                 DefinitionKind::AugmentedAssignment(AstNodeRef::new(parsed, augmented_assignment))
             }
             DefinitionNodeRef::For(ForStmtDefinitionNodeRef {
+                unpack,
                 iterable,
-                target,
+                name,
+                first,
                 is_async,
             }) => DefinitionKind::For(ForStmtDefinitionKind {
+                target: TargetKind::from(unpack),
                 iterable: AstNodeRef::new(parsed.clone(), iterable),
-                target: AstNodeRef::new(parsed, target),
+                name: AstNodeRef::new(parsed, name),
+                first,
                 is_async,
             }),
             DefinitionNodeRef::Comprehension(ComprehensionDefinitionNodeRef {
@@ -382,10 +388,12 @@ impl<'db> DefinitionNodeRef<'db> {
             Self::AnnotatedAssignment(node) => node.into(),
             Self::AugmentedAssignment(node) => node.into(),
             Self::For(ForStmtDefinitionNodeRef {
+                unpack: _,
                 iterable: _,
-                target,
+                name,
+                first: _,
                 is_async: _,
-            }) => target.into(),
+            }) => name.into(),
             Self::Comprehension(ComprehensionDefinitionNodeRef { target, .. }) => target.into(),
             Self::VariadicPositionalParameter(node) => node.into(),
             Self::VariadicKeywordParameter(node) => node.into(),
@@ -452,7 +460,7 @@ pub enum DefinitionKind<'db> {
     Assignment(AssignmentDefinitionKind<'db>),
     AnnotatedAssignment(AstNodeRef<ast::StmtAnnAssign>),
     AugmentedAssignment(AstNodeRef<ast::StmtAugAssign>),
-    For(ForStmtDefinitionKind),
+    For(ForStmtDefinitionKind<'db>),
     Comprehension(ComprehensionDefinitionKind),
     VariadicPositionalParameter(AstNodeRef<ast::Parameter>),
     VariadicKeywordParameter(AstNodeRef<ast::Parameter>),
@@ -477,7 +485,7 @@ impl Ranged for DefinitionKind<'_> {
             DefinitionKind::Assignment(assignment) => assignment.name().range(),
             DefinitionKind::AnnotatedAssignment(assign) => assign.target.range(),
             DefinitionKind::AugmentedAssignment(aug_assign) => aug_assign.target.range(),
-            DefinitionKind::For(for_stmt) => for_stmt.target().range(),
+            DefinitionKind::For(for_stmt) => for_stmt.name().range(),
             DefinitionKind::Comprehension(comp) => comp.target().range(),
             DefinitionKind::VariadicPositionalParameter(parameter) => parameter.name.range(),
             DefinitionKind::VariadicKeywordParameter(parameter) => parameter.name.range(),
@@ -665,22 +673,32 @@ impl WithItemDefinitionKind {
 }
 
 #[derive(Clone, Debug)]
-pub struct ForStmtDefinitionKind {
+pub struct ForStmtDefinitionKind<'db> {
+    target: TargetKind<'db>,
     iterable: AstNodeRef<ast::Expr>,
-    target: AstNodeRef<ast::ExprName>,
+    name: AstNodeRef<ast::ExprName>,
+    first: bool,
     is_async: bool,
 }
 
-impl ForStmtDefinitionKind {
+impl<'db> ForStmtDefinitionKind<'db> {
     pub(crate) fn iterable(&self) -> &ast::Expr {
         self.iterable.node()
     }
 
-    pub(crate) fn target(&self) -> &ast::ExprName {
-        self.target.node()
+    pub(crate) fn target(&self) -> TargetKind<'db> {
+        self.target
     }
 
-    pub(crate) fn is_async(&self) -> bool {
+    pub(crate) fn name(&self) -> &ast::ExprName {
+        self.name.node()
+    }
+
+    pub(crate) const fn is_first(&self) -> bool {
+        self.first
+    }
+
+    pub(crate) const fn is_async(&self) -> bool {
         self.is_async
     }
 }
@@ -753,12 +771,6 @@ impl From<&ast::StmtAnnAssign> for DefinitionNodeKey {
 impl From<&ast::StmtAugAssign> for DefinitionNodeKey {
     fn from(node: &ast::StmtAugAssign) -> Self {
         Self(NodeKey::from_node(node))
-    }
-}
-
-impl From<&ast::StmtFor> for DefinitionNodeKey {
-    fn from(value: &ast::StmtFor) -> Self {
-        Self(NodeKey::from_node(value))
     }
 }
 

--- a/crates/red_knot_python_semantic/src/unpack.rs
+++ b/crates/red_knot_python_semantic/src/unpack.rs
@@ -1,7 +1,9 @@
 use ruff_db::files::File;
-use ruff_python_ast::{self as ast};
+use ruff_python_ast::{self as ast, AnyNodeRef};
+use ruff_text_size::{Ranged, TextRange};
 
 use crate::ast_node_ref::AstNodeRef;
+use crate::semantic_index::ast_ids::{HasScopedExpressionId, ScopedExpressionId};
 use crate::semantic_index::expression::Expression;
 use crate::semantic_index::symbol::{FileScopeId, ScopeId};
 use crate::Db;
@@ -41,7 +43,7 @@ pub(crate) struct Unpack<'db> {
     /// The ingredient representing the value expression of the unpacking. For example, in
     /// `(a, b) = (1, 2)`, the value expression is `(1, 2)`.
     #[no_eq]
-    pub(crate) value: Expression<'db>,
+    pub(crate) value: UnpackValue<'db>,
 
     #[no_eq]
     count: countme::Count<Unpack<'static>>,
@@ -51,5 +53,49 @@ impl<'db> Unpack<'db> {
     /// Returns the scope where the unpacking is happening.
     pub(crate) fn scope(self, db: &'db dyn Db) -> ScopeId<'db> {
         self.file_scope(db).to_scope_id(db, self.file(db))
+    }
+
+    /// Returns the range of the unpack target expression.
+    pub(crate) fn range(self, db: &'db dyn Db) -> TextRange {
+        self.target(db).range()
+    }
+}
+
+/// The expression that is being unpacked.
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum UnpackValue<'db> {
+    /// An iterable expression like the one in a `for` loop or a comprehension.
+    Iterable(Expression<'db>),
+    /// An expression that is being assigned to a target.
+    Assign(Expression<'db>),
+}
+
+impl<'db> UnpackValue<'db> {
+    /// Returns `true` if the value is an iterable expression.
+    pub(crate) const fn is_iterable(self) -> bool {
+        matches!(self, UnpackValue::Iterable(_))
+    }
+
+    /// Returns the underlying [`Expression`] that is being unpacked.
+    pub(crate) const fn expression(self) -> Expression<'db> {
+        match self {
+            UnpackValue::Assign(expr) | UnpackValue::Iterable(expr) => expr,
+        }
+    }
+
+    /// Returns the [`ScopedExpressionId`] of the underlying expression.
+    pub(crate) fn scoped_expression_id(
+        self,
+        db: &'db dyn Db,
+        scope: ScopeId<'db>,
+    ) -> ScopedExpressionId {
+        self.expression()
+            .node_ref(db)
+            .scoped_expression_id(db, scope)
+    }
+
+    /// Returns the expression as an [`AnyNodeRef`].
+    pub(crate) fn as_any_node_ref(self, db: &'db dyn Db) -> AnyNodeRef<'db> {
+        self.expression().node_ref(db).node().into()
     }
 }


### PR DESCRIPTION
## Summary

Related to #13773 

This PR adds support for unpacking `for` statement targets.

This involves updating the `value` field in the `Unpack` target to use an enum which specifies the "where did the value expression came from?". This is because for an iterable expression, we need to unpack the iterator type while for assignment statement we need to unpack the value type itself. And, this needs to be done in the unpack query.

### Question

One of the ways unpacking works in `for` statement is by looking at the union of the types because if the iterable expression is a tuple then the iterator type will be union of all the types in the tuple. This means that the test cases that will test the unpacking in `for` statement will also implicitly test the unpacking union logic. I was wondering if it makes sense to merge these cases and only add the ones that are specific to the union unpacking or for statement unpacking logic.

## Test Plan

Add test cases involving iterating over a tuple type. I've intentionally left out certain cases for now and I'm curious to know any thoughts on the above query.
