### PR TITLE
[red-knot] Cleanup various `todo_type!()` messages

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/annotations/literal_string.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/annotations/literal_string.md
@@ -73,12 +73,12 @@ qux = (foo, bar)
 reveal_type(qux)  # revealed: tuple[Literal["foo"], Literal["bar"]]
 
 # TODO: Infer "LiteralString"
-reveal_type(foo.join(qux))  # revealed: @Todo(call todo)
+reveal_type(foo.join(qux))  # revealed: @Todo(Attribute access on `StringLiteral` types)
 
 template: LiteralString = "{}, {}"
 reveal_type(template)  # revealed: Literal["{}, {}"]
 # TODO: Infer `LiteralString`
-reveal_type(template.format(foo, bar))  # revealed: @Todo(call todo)
+reveal_type(template.format(foo, bar))  # revealed: @Todo(Attribute access on `StringLiteral` types)
 ```
 
 ### Assignability

--- a/crates/red_knot_python_semantic/resources/mdtest/with/async.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/with/async.md
@@ -17,5 +17,5 @@ class Manager:
 
 async def test():
     async with Manager() as f:
-        reveal_type(f)  # revealed: @Todo(async with statement)
+        reveal_type(f)  # revealed: @Todo(async `with` statement)
 ```

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -5031,7 +5031,7 @@ impl<'db> TypeInferenceBuilder<'db> {
 
             KnownInstanceType::ReadOnly => {
                 self.infer_type_expression(arguments_slice);
-                todo_type!("`Required[]` type qualifier")
+                todo_type!("`ReadOnly[]` type qualifier")
             }
             KnownInstanceType::NotRequired => {
                 self.infer_type_expression(arguments_slice);


### PR DESCRIPTION
## Summary

No functional change here -- this just improves our `todo_type!()` messages in several places. At some locations, this involves propagating an existing TODO message instead of overwriting it with a worse one (or overwriting it with no TODO message at all)

## Test Plan

`cargo test -p red_knot_python_semantic`
