### PR TITLE
[red-knot] Add support for `@final` classes

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/final.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/final.md
@@ -11,10 +11,21 @@ from typing import final
 @final
 class A: ...
 
-class B(A): ...  # error: [subclass-of-final-class] "Class `B` cannot inherit from final class `A`"
+class B(A): ...  # error: 9 [subclass-of-final-class] "Class `B` cannot inherit from final class `A`"
 
 @typing_extensions.final
 class C: ...
 
 class D(C): ...  # error: [subclass-of-final-class]
+class E: ...
+class F: ...
+class G: ...
+
+# fmt: off
+class H(
+    E,
+    F,
+    A,  # error: [subclass-of-final-class]
+    G,
+): ...
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/final.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/final.md
@@ -1,0 +1,20 @@
+# Tests for the `@typing(_extensions).final` decorator
+
+## Cannot subclass
+
+Don't do this:
+
+```py
+import typing_extensions
+from typing import final
+
+@final
+class A: ...
+
+class B(A): ...  # error: [subclass-of-final-class] "Class `B` cannot inherit from final class `A`"
+
+@typing_extensions.final
+class C: ...
+
+class D(C): ...  # error: [subclass-of-final-class]
+```

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -2931,13 +2931,15 @@ pub enum KnownFunction {
     RevealType,
     /// `builtins.len`
     Len,
+    /// `typing(_extensions).final`
+    Final,
 }
 
 impl KnownFunction {
     pub fn constraint_function(self) -> Option<KnownConstraintFunction> {
         match self {
             Self::ConstraintFunction(f) => Some(f),
-            Self::RevealType | Self::Len => None,
+            Self::RevealType | Self::Len | Self::Final => None,
         }
     }
 
@@ -2955,6 +2957,7 @@ impl KnownFunction {
                 KnownFunction::ConstraintFunction(KnownConstraintFunction::IsSubclass),
             ),
             "len" if definition.is_builtin_definition(db) => Some(KnownFunction::Len),
+            "final" if definition.is_typing_definition(db) => Some(KnownFunction::Final),
             _ => None,
         }
     }
@@ -3105,6 +3108,31 @@ impl<'db> Class<'db> {
     /// query depends on the AST of another file (bad!).
     fn node(self, db: &'db dyn Db) -> &'db ast::StmtClassDef {
         self.body_scope(db).node(db).expect_class()
+    }
+
+    /// Return the types of the decorators on this class
+    #[salsa::tracked(return_ref)]
+    fn decorators(self, db: &'db dyn Db) -> Box<[Type<'db>]> {
+        let class_stmt = self.node(db);
+        if class_stmt.decorator_list.is_empty() {
+            return Box::new([]);
+        }
+        let class_definition = semantic_index(db, self.file(db)).definition(class_stmt);
+        class_stmt
+            .decorator_list
+            .iter()
+            .map(|decorator_node| {
+                definition_expression_ty(db, class_definition, &decorator_node.expression)
+            })
+            .collect()
+    }
+
+    /// Is this class final?
+    fn is_final(self, db: &'db dyn Db) -> bool {
+        self.decorators(db)
+            .iter()
+            .filter_map(|deco| deco.into_function_literal())
+            .any(|decorator| decorator.is_known(db, KnownFunction::Final))
     }
 
     /// Attempt to resolve the [method resolution order] ("MRO") for this class.

--- a/crates/red_knot_python_semantic/src/types/diagnostic.rs
+++ b/crates/red_knot_python_semantic/src/types/diagnostic.rs
@@ -42,6 +42,7 @@ pub(crate) fn register_lints(registry: &mut LintRegistryBuilder) {
     registry.register_lint(&POSSIBLY_UNBOUND_ATTRIBUTE);
     registry.register_lint(&POSSIBLY_UNBOUND_IMPORT);
     registry.register_lint(&POSSIBLY_UNRESOLVED_REFERENCE);
+    registry.register_lint(&SUBCLASS_OF_FINAL_CLASS);
     registry.register_lint(&UNDEFINED_REVEAL);
     registry.register_lint(&UNRESOLVED_ATTRIBUTE);
     registry.register_lint(&UNRESOLVED_IMPORT);
@@ -392,6 +393,29 @@ declare_lint! {
         summary: "detects references to possibly undefined names",
         status: LintStatus::preview("1.0.0"),
         default_level: Level::Warn,
+    }
+}
+
+declare_lint! {
+    /// ## What it does
+    /// Checks for classes that subclass final classes.
+    ///
+    /// ## Why is this bad?
+    /// Decorating a class with `@final` declares to the type checker that it should not be subclassed.
+    ///
+    /// ## Example
+    ///
+    /// ```python
+    /// from typing import final
+    ///
+    /// @final
+    /// class A: ...
+    /// class B(A): ...  # Error raised here
+    /// ```
+    pub(crate) static SUBCLASS_OF_FINAL_CLASS = {
+        summary: "detects subclasses of final classes",
+        status: LintStatus::preview("1.0.0"),
+        default_level: Level::Error,
     }
 }
 

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -77,6 +77,7 @@ use super::diagnostic::{
     report_index_out_of_bounds, report_invalid_exception_caught, report_invalid_exception_cause,
     report_invalid_exception_raised, report_non_subscriptable,
     report_possibly_unresolved_reference, report_slice_step_size_zero, report_unresolved_reference,
+    SUBCLASS_OF_FINAL_CLASS,
 };
 use super::string_annotation::{
     parse_string_annotation, BYTE_STRING_TYPE_ANNOTATION, FSTRING_TYPE_ANNOTATION,
@@ -568,7 +569,28 @@ impl<'db> TypeInferenceBuilder<'db> {
                 continue;
             }
 
-            // (2) Check that the class's MRO is resolvable
+            // (2) Check for classes that inherit from `@final` classes
+            for (i, base_class) in class.explicit_bases(self.db()).iter().enumerate() {
+                // dynamic/unknown bases are never `@final`
+                let Some(ClassLiteralType { class: base_class }) = base_class.into_class_literal()
+                else {
+                    continue;
+                };
+                if !base_class.is_final(self.db()) {
+                    continue;
+                }
+                self.context.report_lint(
+                    &SUBCLASS_OF_FINAL_CLASS,
+                    (&class_node.bases()[i]).into(),
+                    format_args!(
+                        "Class `{}` cannot inherit from final class `{}`",
+                        class.name(self.db()),
+                        base_class.name(self.db()),
+                    ),
+                );
+            }
+
+            // (3) Check that the class's MRO is resolvable
             if let Err(mro_error) = class.try_mro(self.db()).as_ref() {
                 match mro_error.reason() {
                     MroErrorKind::DuplicateBases(duplicates) => {
@@ -606,7 +628,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                 }
             }
 
-            // (3) Check that the class's metaclass can be determined without error.
+            // (4) Check that the class's metaclass can be determined without error.
             if let Err(metaclass_error) = class.try_metaclass(self.db()) {
                 match metaclass_error.reason() {
                     MetaclassErrorKind::Conflict {


### PR DESCRIPTION
## Summary

This PR adds support for the `@final` decorator on classes. The `@final` decorator can also be applied to methods; this PR does not add support for that yet.

`@final` is specified here: https://typing.readthedocs.io/en/latest/spec/qualifiers.html#final. When applied to a class, it declares to the type checker that the class cannot be subclassed, and that the type checker should emit an error if it sees the class being subclassed. This information is extremely valuable to a type checker, as it rules out certain multiple inheritance possibilities, allows for more precise inference in some cases, and improves analysis of whether or not certain blocks of code are reachable.

This PR doesn't yet make use of these extra capabilities that an understanding of `@final` opens up to us; it just adds a basic understanding of finality, and adds a rule such that we emit a diagnostic if we see a final class being subclassed.

## Test Plan

New mdtests added to `final.md`.

Co-authored-by: Carl Meyer <carl@astral.sh>