### PR TITLE
[red-knot] Rename and rework the `CoreStdlibModule` enum

### DIFF
--- a/crates/red_knot_python_semantic/src/lib.rs
+++ b/crates/red_knot_python_semantic/src/lib.rs
@@ -5,7 +5,7 @@ use rustc_hash::FxHasher;
 use crate::lint::{LintRegistry, LintRegistryBuilder};
 pub use db::Db;
 pub use module_name::ModuleName;
-pub use module_resolver::{resolve_module, system_module_search_paths, Module};
+pub use module_resolver::{resolve_module, system_module_search_paths, KnownModule, Module};
 pub use program::{Program, ProgramSettings, SearchPathSettings, SitePackages};
 pub use python_version::PythonVersion;
 pub use semantic_model::{HasTy, SemanticModel};

--- a/crates/red_knot_python_semantic/src/module_resolver/mod.rs
+++ b/crates/red_knot_python_semantic/src/module_resolver/mod.rs
@@ -1,6 +1,6 @@
 use std::iter::FusedIterator;
 
-pub use module::Module;
+pub use module::{KnownModule, Module};
 pub use resolver::resolve_module;
 pub(crate) use resolver::{file_to_module, SearchPaths};
 use ruff_db::system::SystemPath;

--- a/crates/red_knot_python_semantic/src/module_resolver/module.rs
+++ b/crates/red_knot_python_semantic/src/module_resolver/module.rs
@@ -19,7 +19,7 @@ impl Module {
         search_path: SearchPath,
         file: File,
     ) -> Self {
-        let known = KnownModule::try_from_name_and_search_path(&name, &search_path);
+        let known = KnownModule::try_from_search_path_and_name(&search_path, &name);
         Self {
             inner: Arc::new(ModuleInner {
                 name,
@@ -131,9 +131,9 @@ impl KnownModule {
             .unwrap_or_else(|| panic!("{self_as_str} should be a valid module name!"))
     }
 
-    pub(crate) fn try_from_name_and_search_path(
-        name: &ModuleName,
+    pub(crate) fn try_from_search_path_and_name(
         search_path: &SearchPath,
+        name: &ModuleName,
     ) -> Option<Self> {
         if !search_path.is_standard_library() {
             return None;

--- a/crates/red_knot_python_semantic/src/stdlib.rs
+++ b/crates/red_knot_python_semantic/src/stdlib.rs
@@ -1,55 +1,19 @@
-use crate::module_name::ModuleName;
-use crate::module_resolver::resolve_module;
+use crate::module_resolver::{resolve_module, KnownModule};
 use crate::semantic_index::global_scope;
 use crate::semantic_index::symbol::ScopeId;
 use crate::symbol::Symbol;
 use crate::types::global_symbol;
 use crate::Db;
 
-/// Enumeration of various core stdlib modules, for which we have dedicated Salsa queries.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum CoreStdlibModule {
-    Builtins,
-    Types,
-    Typeshed,
-    TypingExtensions,
-    Typing,
-    Sys,
-    #[allow(dead_code)]
-    Abc, // currently only used in tests
-    Collections,
-}
-
-impl CoreStdlibModule {
-    pub(crate) const fn as_str(self) -> &'static str {
-        match self {
-            Self::Builtins => "builtins",
-            Self::Types => "types",
-            Self::Typing => "typing",
-            Self::Typeshed => "_typeshed",
-            Self::TypingExtensions => "typing_extensions",
-            Self::Sys => "sys",
-            Self::Abc => "abc",
-            Self::Collections => "collections",
-        }
-    }
-
-    pub(crate) fn name(self) -> ModuleName {
-        let self_as_str = self.as_str();
-        ModuleName::new_static(self_as_str)
-            .unwrap_or_else(|| panic!("{self_as_str} should be a valid module name!"))
-    }
-}
-
-/// Lookup the type of `symbol` in a given core module
+/// Lookup the type of `symbol` in a given known module
 ///
-/// Returns `Symbol::Unbound` if the given core module cannot be resolved for some reason
-pub(crate) fn core_module_symbol<'db>(
+/// Returns `Symbol::Unbound` if the given known module cannot be resolved for some reason
+pub(crate) fn known_module_symbol<'db>(
     db: &'db dyn Db,
-    core_module: CoreStdlibModule,
+    known_module: KnownModule,
     symbol: &str,
 ) -> Symbol<'db> {
-    resolve_module(db, &core_module.name())
+    resolve_module(db, &known_module.name())
         .map(|module| global_symbol(db, module.file(), symbol))
         .unwrap_or(Symbol::Unbound)
 }
@@ -59,7 +23,7 @@ pub(crate) fn core_module_symbol<'db>(
 /// Returns `Symbol::Unbound` if the `builtins` module isn't available for some reason.
 #[inline]
 pub(crate) fn builtins_symbol<'db>(db: &'db dyn Db, symbol: &str) -> Symbol<'db> {
-    core_module_symbol(db, CoreStdlibModule::Builtins, symbol)
+    known_module_symbol(db, KnownModule::Builtins, symbol)
 }
 
 /// Lookup the type of `symbol` in the `typing` module namespace.
@@ -68,7 +32,7 @@ pub(crate) fn builtins_symbol<'db>(db: &'db dyn Db, symbol: &str) -> Symbol<'db>
 #[inline]
 #[cfg(test)]
 pub(crate) fn typing_symbol<'db>(db: &'db dyn Db, symbol: &str) -> Symbol<'db> {
-    core_module_symbol(db, CoreStdlibModule::Typing, symbol)
+    known_module_symbol(db, KnownModule::Typing, symbol)
 }
 
 /// Lookup the type of `symbol` in the `typing_extensions` module namespace.
@@ -76,13 +40,13 @@ pub(crate) fn typing_symbol<'db>(db: &'db dyn Db, symbol: &str) -> Symbol<'db> {
 /// Returns `Symbol::Unbound` if the `typing_extensions` module isn't available for some reason.
 #[inline]
 pub(crate) fn typing_extensions_symbol<'db>(db: &'db dyn Db, symbol: &str) -> Symbol<'db> {
-    core_module_symbol(db, CoreStdlibModule::TypingExtensions, symbol)
+    known_module_symbol(db, KnownModule::TypingExtensions, symbol)
 }
 
 /// Get the scope of a core stdlib module.
 ///
 /// Can return `None` if a custom typeshed is used that is missing the core module in question.
-fn core_module_scope(db: &dyn Db, core_module: CoreStdlibModule) -> Option<ScopeId<'_>> {
+fn core_module_scope(db: &dyn Db, core_module: KnownModule) -> Option<ScopeId<'_>> {
     resolve_module(db, &core_module.name()).map(|module| global_scope(db, module.file()))
 }
 
@@ -90,5 +54,5 @@ fn core_module_scope(db: &dyn Db, core_module: CoreStdlibModule) -> Option<Scope
 ///
 /// Can return `None` if a custom typeshed is used that is missing `builtins.pyi`.
 pub(crate) fn builtins_module_scope(db: &dyn Db) -> Option<ScopeId<'_>> {
-    core_module_scope(db, CoreStdlibModule::Builtins)
+    core_module_scope(db, KnownModule::Builtins)
 }

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -2360,7 +2360,7 @@ impl<'db> KnownClass {
         }
     }
 
-    pub fn try_from_file_and_symbol(db: &dyn Db, file: File, class_name: &str) -> Option<Self> {
+    pub fn try_from_file_and_name(db: &dyn Db, file: File, class_name: &str) -> Option<Self> {
         // Note: if this becomes hard to maintain (as rust can't ensure at compile time that all
         // variants of `Self` are covered), we might use a macro (in-house or dependency)
         // See: https://stackoverflow.com/q/39070244
@@ -2666,12 +2666,8 @@ impl<'db> KnownInstanceType<'db> {
         self.class().to_instance(db)
     }
 
-    pub fn try_from_file_and_symbol(
-        db: &'db dyn Db,
-        file: File,
-        instance_name: &str,
-    ) -> Option<Self> {
-        let candidate = match instance_name {
+    pub fn try_from_file_and_name(db: &'db dyn Db, file: File, symbol_name: &str) -> Option<Self> {
+        let candidate = match symbol_name {
             "Any" => Self::Any,
             "ClassVar" => Self::ClassVar,
             "Deque" => Self::Deque,
@@ -2987,7 +2983,7 @@ impl KnownFunction {
         }
     }
 
-    fn from_definition<'db>(
+    fn try_from_definition_and_name<'db>(
         db: &'db dyn Db,
         definition: Definition<'db>,
         name: &str,

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -1251,7 +1251,7 @@ impl<'db> TypeInferenceBuilder<'db> {
             .node_scope(NodeWithScopeRef::Class(class_node))
             .to_scope_id(self.db(), self.file());
 
-        let maybe_known_class = KnownClass::try_from_file(self.db(), self.file(), name);
+        let maybe_known_class = KnownClass::try_from_file_and_symbol(self.db(), self.file(), name);
 
         let class = Class::new(self.db(), &name.id, body_scope, maybe_known_class);
         let class_ty = Type::class_literal(class);
@@ -1849,9 +1849,8 @@ impl<'db> TypeInferenceBuilder<'db> {
             TargetKind::Name => value_ty,
         };
 
-        if let Some(known_instance) = file_to_module(self.db(), definition.file(self.db()))
-            .as_ref()
-            .and_then(|module| KnownInstanceType::try_from_module_and_symbol(module, &name.id))
+        if let Some(known_instance) =
+            KnownInstanceType::try_from_file_and_symbol(self.db(), self.file(), &name.id)
         {
             target_ty = Type::KnownInstance(known_instance);
         }
@@ -1901,12 +1900,11 @@ impl<'db> TypeInferenceBuilder<'db> {
         if let Type::Instance(InstanceType { class }) = annotation_ty {
             if class.is_known(self.db(), KnownClass::SpecialForm) {
                 if let Some(name_expr) = target.as_name_expr() {
-                    if let Some(known_instance) = file_to_module(self.db(), self.file())
-                        .as_ref()
-                        .and_then(|module| {
-                            KnownInstanceType::try_from_module_and_symbol(module, &name_expr.id)
-                        })
-                    {
+                    if let Some(known_instance) = KnownInstanceType::try_from_file_and_symbol(
+                        self.db(),
+                        self.file(),
+                        &name_expr.id,
+                    ) {
                         annotation_ty = Type::KnownInstance(known_instance);
                     }
                 }

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -1036,7 +1036,8 @@ impl<'db> TypeInferenceBuilder<'db> {
             }
         }
 
-        let function_kind = KnownFunction::from_definition(self.db(), definition, name);
+        let function_kind =
+            KnownFunction::try_from_definition_and_name(self.db(), definition, name);
 
         let body_scope = self
             .index
@@ -1251,7 +1252,7 @@ impl<'db> TypeInferenceBuilder<'db> {
             .node_scope(NodeWithScopeRef::Class(class_node))
             .to_scope_id(self.db(), self.file());
 
-        let maybe_known_class = KnownClass::try_from_file_and_symbol(self.db(), self.file(), name);
+        let maybe_known_class = KnownClass::try_from_file_and_name(self.db(), self.file(), name);
 
         let class = Class::new(self.db(), &name.id, body_scope, maybe_known_class);
         let class_ty = Type::class_literal(class);
@@ -1850,7 +1851,7 @@ impl<'db> TypeInferenceBuilder<'db> {
         };
 
         if let Some(known_instance) =
-            KnownInstanceType::try_from_file_and_symbol(self.db(), self.file(), &name.id)
+            KnownInstanceType::try_from_file_and_name(self.db(), self.file(), &name.id)
         {
             target_ty = Type::KnownInstance(known_instance);
         }
@@ -1900,7 +1901,7 @@ impl<'db> TypeInferenceBuilder<'db> {
         if let Type::Instance(InstanceType { class }) = annotation_ty {
             if class.is_known(self.db(), KnownClass::SpecialForm) {
                 if let Some(name_expr) = target.as_name_expr() {
-                    if let Some(known_instance) = KnownInstanceType::try_from_file_and_symbol(
+                    if let Some(known_instance) = KnownInstanceType::try_from_file_and_name(
                         self.db(),
                         self.file(),
                         &name_expr.id,


### PR DESCRIPTION
## Summary

This PR does several things:
- Renames the `CoreStdlibModule` enum to `KnownModule`, since it is a parallel enum to `KnownClass`, `KnownFunction` and `KnownInstanceType`
- Moves the enum from `stdlib.rs` to `module_resolver::module.rs`. This allows it to be stored as a field on `ModuleInner` objects, and retrieved using a getter method from `Module` objects. This in turn means that we can then add `known()` and `is_known()` methods to the `Module` struct, which allows us to query whether a given `Module` represents a known module in much the same way we already do using `FunctionType::is_known` and `Class::is_known`.

These changes have several goals:
- Unify the API of the various `Known*` enums
- Put in one place the code required to check whether a `Module` really represents a specific module from the standard library. We had the same checks written out in several places, which was error-prone, since there are several things that needed to be checked and some are quite subtle. (One recent example: https://github.com/astral-sh/ruff/pull/15019#discussion_r1892793699.)
- Make our API less stringly typed, and therefore less error-prone (the changes in `definition.rs` are an example)
- Exploit some micro-optimisation opportunities in a few places

## Test Plan

`cargo test -p red_knot_python_semantic`. No new tests added -- this should be a pure refactor.
