### PR TITLE
[`ruff`] Adds an allowlist for `unsafe-markup-use` (`RUF035`)

### DIFF
--- a/crates/ruff/tests/snapshots/show_settings__display_default_settings.snap
+++ b/crates/ruff/tests/snapshots/show_settings__display_default_settings.snap
@@ -375,6 +375,7 @@ linter.pylint.max_locals = 15
 linter.pyupgrade.keep_runtime_typing = false
 linter.ruff.parenthesize_tuple_in_subscript = false
 linter.ruff.extend_markup_names = []
+linter.ruff.whitelisted_markup_calls = []
 
 # Formatter Settings
 formatter.exclude = []

--- a/crates/ruff/tests/snapshots/show_settings__display_default_settings.snap
+++ b/crates/ruff/tests/snapshots/show_settings__display_default_settings.snap
@@ -375,7 +375,7 @@ linter.pylint.max_locals = 15
 linter.pyupgrade.keep_runtime_typing = false
 linter.ruff.parenthesize_tuple_in_subscript = false
 linter.ruff.extend_markup_names = []
-linter.ruff.whitelisted_markup_calls = []
+linter.ruff.allowed_markup_calls = []
 
 # Formatter Settings
 formatter.exclude = []

--- a/crates/ruff_linter/resources/test/fixtures/ruff/RUF035_whitelisted_markup_calls.py
+++ b/crates/ruff_linter/resources/test/fixtures/ruff/RUF035_whitelisted_markup_calls.py
@@ -1,0 +1,9 @@
+from bleach import clean
+from markupsafe import Markup
+
+content = "<script>alert('Hello, world!')</script>"
+Markup(clean(content))
+
+# indirect assignments are currently not supported
+cleaned = clean(content)
+Markup(cleaned)  # RUF035

--- a/crates/ruff_linter/src/rules/ruff/mod.rs
+++ b/crates/ruff_linter/src/rules/ruff/mod.rs
@@ -91,6 +91,7 @@ mod tests {
                 ruff: super::settings::Settings {
                     parenthesize_tuple_in_subscript: true,
                     extend_markup_names: vec![],
+                    whitelisted_markup_calls: vec![],
                 },
                 ..LinterSettings::for_rule(Rule::IncorrectlyParenthesizedTupleInSubscript)
             },
@@ -107,6 +108,7 @@ mod tests {
                 ruff: super::settings::Settings {
                     parenthesize_tuple_in_subscript: false,
                     extend_markup_names: vec![],
+                    whitelisted_markup_calls: vec![],
                 },
                 target_version: PythonVersion::Py310,
                 ..LinterSettings::for_rule(Rule::IncorrectlyParenthesizedTupleInSubscript)
@@ -447,6 +449,30 @@ mod tests {
                 ruff: super::settings::Settings {
                     parenthesize_tuple_in_subscript: true,
                     extend_markup_names: vec!["webhelpers.html.literal".to_string()],
+                    whitelisted_markup_calls: vec![],
+                },
+                preview: PreviewMode::Enabled,
+                ..LinterSettings::for_rule(rule_code)
+            },
+        )?;
+        assert_messages!(snapshot, diagnostics);
+        Ok(())
+    }
+
+    #[test_case(Rule::UnsafeMarkupUse, Path::new("RUF035_whitelisted_markup_calls.py"))]
+    fn whitelisted_markup_calls(rule_code: Rule, path: &Path) -> Result<()> {
+        let snapshot = format!(
+            "whitelisted_markup_calls__{}_{}",
+            rule_code.noqa_code(),
+            path.to_string_lossy()
+        );
+        let diagnostics = test_path(
+            Path::new("ruff").join(path).as_path(),
+            &LinterSettings {
+                ruff: super::settings::Settings {
+                    parenthesize_tuple_in_subscript: true,
+                    extend_markup_names: vec![],
+                    whitelisted_markup_calls: vec!["bleach.clean".to_string()],
                 },
                 preview: PreviewMode::Enabled,
                 ..LinterSettings::for_rule(rule_code)

--- a/crates/ruff_linter/src/rules/ruff/mod.rs
+++ b/crates/ruff_linter/src/rules/ruff/mod.rs
@@ -91,7 +91,7 @@ mod tests {
                 ruff: super::settings::Settings {
                     parenthesize_tuple_in_subscript: true,
                     extend_markup_names: vec![],
-                    whitelisted_markup_calls: vec![],
+                    allowed_markup_calls: vec![],
                 },
                 ..LinterSettings::for_rule(Rule::IncorrectlyParenthesizedTupleInSubscript)
             },
@@ -108,7 +108,7 @@ mod tests {
                 ruff: super::settings::Settings {
                     parenthesize_tuple_in_subscript: false,
                     extend_markup_names: vec![],
-                    whitelisted_markup_calls: vec![],
+                    allowed_markup_calls: vec![],
                 },
                 target_version: PythonVersion::Py310,
                 ..LinterSettings::for_rule(Rule::IncorrectlyParenthesizedTupleInSubscript)
@@ -449,7 +449,7 @@ mod tests {
                 ruff: super::settings::Settings {
                     parenthesize_tuple_in_subscript: true,
                     extend_markup_names: vec!["webhelpers.html.literal".to_string()],
-                    whitelisted_markup_calls: vec![],
+                    allowed_markup_calls: vec![],
                 },
                 preview: PreviewMode::Enabled,
                 ..LinterSettings::for_rule(rule_code)
@@ -472,7 +472,7 @@ mod tests {
                 ruff: super::settings::Settings {
                     parenthesize_tuple_in_subscript: true,
                     extend_markup_names: vec![],
-                    whitelisted_markup_calls: vec!["bleach.clean".to_string()],
+                    allowed_markup_calls: vec!["bleach.clean".to_string()],
                 },
                 preview: PreviewMode::Enabled,
                 ..LinterSettings::for_rule(rule_code)

--- a/crates/ruff_linter/src/rules/ruff/rules/unsafe_markup_use.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/unsafe_markup_use.rs
@@ -24,7 +24,7 @@ use crate::{checkers::ast::Checker, settings::LinterSettings};
 /// This rule was originally inspired by [flake8-markupsafe] but doesn't carve
 /// out any exceptions for i18n related calls by default.
 ///
-/// You can use [`lint.ruff.whitelisted-markup-calls`] to specify exceptions.
+/// You can use [`lint.ruff.allowed-markup-calls`] to specify exceptions.
 ///
 /// ## Example
 /// Given:
@@ -66,7 +66,7 @@ use crate::{checkers::ast::Checker, settings::LinterSettings};
 /// ```
 /// ## Options
 /// - `lint.ruff.extend-markup-names`
-/// - `lint.ruff.whitelisted-markup-calls`
+/// - `lint.ruff.allowed-markup-calls`
 ///
 /// ## References
 /// - [MarkupSafe](https://pypi.org/project/MarkupSafe/)
@@ -151,7 +151,7 @@ fn is_whitelisted_call(expr: &Expr, semantic: &SemanticModel, settings: &LinterS
 
     settings
         .ruff
-        .whitelisted_markup_calls
+        .allowed_markup_calls
         .iter()
         .map(|target| QualifiedName::from_dotted_name(target))
         .any(|target| qualified_name == target)

--- a/crates/ruff_linter/src/rules/ruff/settings.rs
+++ b/crates/ruff_linter/src/rules/ruff/settings.rs
@@ -8,7 +8,7 @@ use std::fmt;
 pub struct Settings {
     pub parenthesize_tuple_in_subscript: bool,
     pub extend_markup_names: Vec<String>,
-    pub whitelisted_markup_calls: Vec<String>,
+    pub allowed_markup_calls: Vec<String>,
 }
 
 impl fmt::Display for Settings {
@@ -19,7 +19,7 @@ impl fmt::Display for Settings {
             fields = [
                 self.parenthesize_tuple_in_subscript,
                 self.extend_markup_names | array,
-                self.whitelisted_markup_calls | array,
+                self.allowed_markup_calls | array,
             ]
         }
         Ok(())

--- a/crates/ruff_linter/src/rules/ruff/settings.rs
+++ b/crates/ruff_linter/src/rules/ruff/settings.rs
@@ -8,6 +8,7 @@ use std::fmt;
 pub struct Settings {
     pub parenthesize_tuple_in_subscript: bool,
     pub extend_markup_names: Vec<String>,
+    pub whitelisted_markup_calls: Vec<String>,
 }
 
 impl fmt::Display for Settings {
@@ -18,6 +19,7 @@ impl fmt::Display for Settings {
             fields = [
                 self.parenthesize_tuple_in_subscript,
                 self.extend_markup_names | array,
+                self.whitelisted_markup_calls | array,
             ]
         }
         Ok(())

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__whitelisted_markup_calls__RUF035_RUF035_whitelisted_markup_calls.py.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__whitelisted_markup_calls__RUF035_RUF035_whitelisted_markup_calls.py.snap
@@ -1,0 +1,10 @@
+---
+source: crates/ruff_linter/src/rules/ruff/mod.rs
+---
+RUF035_whitelisted_markup_calls.py:9:1: RUF035 Unsafe use of `markupsafe.Markup` detected
+  |
+7 | # indirect assignments are currently not supported
+8 | cleaned = clean(content)
+9 | Markup(cleaned)  # RUF035
+  | ^^^^^^^^^^^^^^^ RUF035
+  |

--- a/crates/ruff_workspace/src/options.rs
+++ b/crates/ruff_workspace/src/options.rs
@@ -3079,12 +3079,11 @@ pub struct RuffOptions {
     )]
     pub parenthesize_tuple_in_subscript: Option<bool>,
 
-    /// A list of additional callable names that behave like [`markupsafe.Markup`].
+    /// A list of additional callable names that behave like
+    /// [`markupsafe.Markup`](https://markupsafe.palletsprojects.com/en/stable/escaping/#markupsafe.Markup).
     ///
     /// Expects to receive a list of fully-qualified names (e.g., `webhelpers.html.literal`, rather than
     /// `literal`).
-    ///
-    /// [`markupsafe.Markup`]: https://markupsafe.palletsprojects.com/en/stable/escaping/#markupsafe.Markup
     #[option(
         default = "[]",
         value_type = "list[str]",
@@ -3092,10 +3091,10 @@ pub struct RuffOptions {
     )]
     pub extend_markup_names: Option<Vec<String>>,
 
-    /// A list of callable names, whose result may be safely passed into [`markupsafe.Markup`].
+    /// A list of callable names, whose result may be safely passed into
+    /// [`markupsafe.Markup`](https://markupsafe.palletsprojects.com/en/stable/escaping/#markupsafe.Markup).
     ///
-    /// Expects to receive a list of fully-qualified names (e.g., [`bleach.clean`], rather than
-    /// `clean`).
+    /// Expects to receive a list of fully-qualified names (e.g., `bleach.clean`, rather than `clean`).
     ///
     /// This setting helps you avoid false positives in code like:
     ///
@@ -3106,20 +3105,17 @@ pub struct RuffOptions {
     /// cleaned_markup = Markup(clean(some_user_input))
     /// ```
     ///
-    /// Where the use of [`bleach.clean`] usually ensures that there's no XSS vulnerability.
+    /// Where the use of [`bleach.clean`](https://bleach.readthedocs.io/en/latest/clean.html)
+    /// usually ensures that there's no XSS vulnerability.
     ///
     /// Although it is not recommended, you may also use this setting to whitelist other
     /// kinds of calls, e.g. calls to i18n translation functions, where how safe that is
     /// will depend on the implementation and how well the translations are audited.
     ///
     /// Another common use-case is to wrap the output of functions that generate markup
-    /// like [`xml.etree.ElementTree.tostring`] or template rendering engines where
-    /// sanitization of potential user input is either already baked in or has to happen
-    /// before rendering.
-    ///
-    /// [`bleach.clean`]: https://bleach.readthedocs.io/en/latest/clean.html
-    /// [`markupsafe.Markup`]: https://markupsafe.palletsprojects.com/en/stable/escaping/#markupsafe.Markup
-    /// [`xml.etree.ElementTree.tostring`]: https://docs.python.org/3/library/xml.etree.elementtree.html#xml.etree.ElementTree.tostring
+    /// like [`xml.etree.ElementTree.tostring`](https://docs.python.org/3/library/xml.etree.elementtree.html#xml.etree.ElementTree.tostring)
+    /// or template rendering engines where sanitization of potential user input is either
+    /// already baked in or has to happen before rendering.
     #[option(
         default = "[]",
         value_type = "list[str]",

--- a/crates/ruff_workspace/src/options.rs
+++ b/crates/ruff_workspace/src/options.rs
@@ -3103,7 +3103,7 @@ pub struct RuffOptions {
     /// from bleach import clean
     /// from markupsafe import Markup
     ///
-    /// cleaned_markup = Markup(bleach.clean(some_user_input))
+    /// cleaned_markup = Markup(clean(some_user_input))
     /// ```
     ///
     /// Where the use of [`bleach.clean`] usually ensures that there's no XSS vulnerability.

--- a/crates/ruff_workspace/src/options.rs
+++ b/crates/ruff_workspace/src/options.rs
@@ -3123,9 +3123,9 @@ pub struct RuffOptions {
     #[option(
         default = "[]",
         value_type = "list[str]",
-        example = "whitelisted-markup-calls = [\"bleach.clean\", \"my_package.sanitize\"]"
+        example = "allowed-markup-calls = [\"bleach.clean\", \"my_package.sanitize\"]"
     )]
-    pub whitelisted_markup_calls: Option<Vec<String>>,
+    pub allowed_markup_calls: Option<Vec<String>>,
 }
 
 impl RuffOptions {
@@ -3135,7 +3135,7 @@ impl RuffOptions {
                 .parenthesize_tuple_in_subscript
                 .unwrap_or_default(),
             extend_markup_names: self.extend_markup_names.unwrap_or_default(),
-            whitelisted_markup_calls: self.whitelisted_markup_calls.unwrap_or_default(),
+            allowed_markup_calls: self.allowed_markup_calls.unwrap_or_default(),
         }
     }
 }

--- a/crates/ruff_workspace/src/options.rs
+++ b/crates/ruff_workspace/src/options.rs
@@ -3091,6 +3091,41 @@ pub struct RuffOptions {
         example = "extend-markup-names = [\"webhelpers.html.literal\", \"my_package.Markup\"]"
     )]
     pub extend_markup_names: Option<Vec<String>>,
+
+    /// A list of callable names, whose result may be safely passed into [`markupsafe.Markup`].
+    ///
+    /// Expects to receive a list of fully-qualified names (e.g., [`bleach.clean`], rather than
+    /// `clean`).
+    ///
+    /// This setting helps you avoid false positives in code like:
+    ///
+    /// ```python
+    /// from bleach import clean
+    /// from markupsafe import Markup
+    ///
+    /// cleaned_markup = Markup(bleach.clean(some_user_input))
+    /// ```
+    ///
+    /// Where the use of [`bleach.clean`] usually ensures that there's no XSS vulnerability.
+    ///
+    /// Although it is not recommended, you may also use this setting to whitelist other
+    /// kinds of calls, e.g. calls to i18n translation functions, where how safe that is
+    /// will depend on the implementation and how well the translations are audited.
+    ///
+    /// Another common use-case is to wrap the output of functions that generate markup
+    /// like [`xml.etree.ElementTree.tostring`] or template rendering engines where
+    /// sanitization of potential user input is either already baked in or has to happen
+    /// before rendering.
+    ///
+    /// [bleach.clean]: https://bleach.readthedocs.io/en/latest/clean.html
+    /// [markupsafe.Markup]: https://markupsafe.palletsprojects.com/en/stable/escaping/#markupsafe.Markup
+    /// [xml.etree.ElementTree.tostring]: https://docs.python.org/3/library/xml.etree.elementtree.html#xml.etree.ElementTree.tostring
+    #[option(
+        default = "[]",
+        value_type = "list[str]",
+        example = "whitelisted-markup-calls = [\"bleach.clean\", \"my_package.sanitize\"]"
+    )]
+    pub whitelisted_markup_calls: Option<Vec<String>>,
 }
 
 impl RuffOptions {
@@ -3100,6 +3135,7 @@ impl RuffOptions {
                 .parenthesize_tuple_in_subscript
                 .unwrap_or_default(),
             extend_markup_names: self.extend_markup_names.unwrap_or_default(),
+            whitelisted_markup_calls: self.whitelisted_markup_calls.unwrap_or_default(),
         }
     }
 }

--- a/crates/ruff_workspace/src/options.rs
+++ b/crates/ruff_workspace/src/options.rs
@@ -3084,7 +3084,7 @@ pub struct RuffOptions {
     /// Expects to receive a list of fully-qualified names (e.g., `webhelpers.html.literal`, rather than
     /// `literal`).
     ///
-    /// [markupsafe.Markup]: https://markupsafe.palletsprojects.com/en/stable/escaping/#markupsafe.Markup
+    /// [`markupsafe.Markup`]: https://markupsafe.palletsprojects.com/en/stable/escaping/#markupsafe.Markup
     #[option(
         default = "[]",
         value_type = "list[str]",
@@ -3117,9 +3117,9 @@ pub struct RuffOptions {
     /// sanitization of potential user input is either already baked in or has to happen
     /// before rendering.
     ///
-    /// [bleach.clean]: https://bleach.readthedocs.io/en/latest/clean.html
-    /// [markupsafe.Markup]: https://markupsafe.palletsprojects.com/en/stable/escaping/#markupsafe.Markup
-    /// [xml.etree.ElementTree.tostring]: https://docs.python.org/3/library/xml.etree.elementtree.html#xml.etree.ElementTree.tostring
+    /// [`bleach.clean`]: https://bleach.readthedocs.io/en/latest/clean.html
+    /// [`markupsafe.Markup`]: https://markupsafe.palletsprojects.com/en/stable/escaping/#markupsafe.Markup
+    /// [`xml.etree.ElementTree.tostring`]: https://docs.python.org/3/library/xml.etree.elementtree.html#xml.etree.ElementTree.tostring
     #[option(
         default = "[]",
         value_type = "list[str]",

--- a/ruff.schema.json
+++ b/ruff.schema.json
@@ -2759,7 +2759,7 @@
       "type": "object",
       "properties": {
         "allowed-markup-calls": {
-          "description": "A list of callable names, whose result may be safely passed into [`markupsafe.Markup`].\n\nExpects to receive a list of fully-qualified names (e.g., [`bleach.clean`], rather than `clean`).\n\nThis setting helps you avoid false positives in code like:\n\n```python from bleach import clean from markupsafe import Markup\n\ncleaned_markup = Markup(clean(some_user_input)) ```\n\nWhere the use of [`bleach.clean`] usually ensures that there's no XSS vulnerability.\n\nAlthough it is not recommended, you may also use this setting to whitelist other kinds of calls, e.g. calls to i18n translation functions, where how safe that is will depend on the implementation and how well the translations are audited.\n\nAnother common use-case is to wrap the output of functions that generate markup like [`xml.etree.ElementTree.tostring`] or template rendering engines where sanitization of potential user input is either already baked in or has to happen before rendering.\n\n[`bleach.clean`]: https://bleach.readthedocs.io/en/latest/clean.html [`markupsafe.Markup`]: https://markupsafe.palletsprojects.com/en/stable/escaping/#markupsafe.Markup [`xml.etree.ElementTree.tostring`]: https://docs.python.org/3/library/xml.etree.elementtree.html#xml.etree.ElementTree.tostring",
+          "description": "A list of callable names, whose result may be safely passed into [`markupsafe.Markup`](https://markupsafe.palletsprojects.com/en/stable/escaping/#markupsafe.Markup).\n\nExpects to receive a list of fully-qualified names (e.g., `bleach.clean`, rather than `clean`).\n\nThis setting helps you avoid false positives in code like:\n\n```python from bleach import clean from markupsafe import Markup\n\ncleaned_markup = Markup(clean(some_user_input)) ```\n\nWhere the use of [`bleach.clean`](https://bleach.readthedocs.io/en/latest/clean.html) usually ensures that there's no XSS vulnerability.\n\nAlthough it is not recommended, you may also use this setting to whitelist other kinds of calls, e.g. calls to i18n translation functions, where how safe that is will depend on the implementation and how well the translations are audited.\n\nAnother common use-case is to wrap the output of functions that generate markup like [`xml.etree.ElementTree.tostring`](https://docs.python.org/3/library/xml.etree.elementtree.html#xml.etree.ElementTree.tostring) or template rendering engines where sanitization of potential user input is either already baked in or has to happen before rendering.",
           "type": [
             "array",
             "null"
@@ -2769,7 +2769,7 @@
           }
         },
         "extend-markup-names": {
-          "description": "A list of additional callable names that behave like [`markupsafe.Markup`].\n\nExpects to receive a list of fully-qualified names (e.g., `webhelpers.html.literal`, rather than `literal`).\n\n[`markupsafe.Markup`]: https://markupsafe.palletsprojects.com/en/stable/escaping/#markupsafe.Markup",
+          "description": "A list of additional callable names that behave like [`markupsafe.Markup`](https://markupsafe.palletsprojects.com/en/stable/escaping/#markupsafe.Markup).\n\nExpects to receive a list of fully-qualified names (e.g., `webhelpers.html.literal`, rather than `literal`).",
           "type": [
             "array",
             "null"

--- a/ruff.schema.json
+++ b/ruff.schema.json
@@ -2759,7 +2759,7 @@
       "type": "object",
       "properties": {
         "allowed-markup-calls": {
-          "description": "A list of callable names, whose result may be safely passed into [`markupsafe.Markup`].\n\nExpects to receive a list of fully-qualified names (e.g., [`bleach.clean`], rather than `clean`).\n\nThis setting helps you avoid false positives in code like:\n\n```python from bleach import clean from markupsafe import Markup\n\ncleaned_markup = Markup(clean(some_user_input)) ```\n\nWhere the use of [`bleach.clean`] usually ensures that there's no XSS vulnerability.\n\nAlthough it is not recommended, you may also use this setting to whitelist other kinds of calls, e.g. calls to i18n translation functions, where how safe that is will depend on the implementation and how well the translations are audited.\n\nAnother common use-case is to wrap the output of functions that generate markup like [`xml.etree.ElementTree.tostring`] or template rendering engines where sanitization of potential user input is either already baked in or has to happen before rendering.\n\n[bleach.clean]: https://bleach.readthedocs.io/en/latest/clean.html [markupsafe.Markup]: https://markupsafe.palletsprojects.com/en/stable/escaping/#markupsafe.Markup [xml.etree.ElementTree.tostring]: https://docs.python.org/3/library/xml.etree.elementtree.html#xml.etree.ElementTree.tostring",
+          "description": "A list of callable names, whose result may be safely passed into [`markupsafe.Markup`].\n\nExpects to receive a list of fully-qualified names (e.g., [`bleach.clean`], rather than `clean`).\n\nThis setting helps you avoid false positives in code like:\n\n```python from bleach import clean from markupsafe import Markup\n\ncleaned_markup = Markup(clean(some_user_input)) ```\n\nWhere the use of [`bleach.clean`] usually ensures that there's no XSS vulnerability.\n\nAlthough it is not recommended, you may also use this setting to whitelist other kinds of calls, e.g. calls to i18n translation functions, where how safe that is will depend on the implementation and how well the translations are audited.\n\nAnother common use-case is to wrap the output of functions that generate markup like [`xml.etree.ElementTree.tostring`] or template rendering engines where sanitization of potential user input is either already baked in or has to happen before rendering.\n\n[`bleach.clean`]: https://bleach.readthedocs.io/en/latest/clean.html [`markupsafe.Markup`]: https://markupsafe.palletsprojects.com/en/stable/escaping/#markupsafe.Markup [`xml.etree.ElementTree.tostring`]: https://docs.python.org/3/library/xml.etree.elementtree.html#xml.etree.ElementTree.tostring",
           "type": [
             "array",
             "null"
@@ -2769,7 +2769,7 @@
           }
         },
         "extend-markup-names": {
-          "description": "A list of additional callable names that behave like [`markupsafe.Markup`].\n\nExpects to receive a list of fully-qualified names (e.g., `webhelpers.html.literal`, rather than `literal`).\n\n[markupsafe.Markup]: https://markupsafe.palletsprojects.com/en/stable/escaping/#markupsafe.Markup",
+          "description": "A list of additional callable names that behave like [`markupsafe.Markup`].\n\nExpects to receive a list of fully-qualified names (e.g., `webhelpers.html.literal`, rather than `literal`).\n\n[`markupsafe.Markup`]: https://markupsafe.palletsprojects.com/en/stable/escaping/#markupsafe.Markup",
           "type": [
             "array",
             "null"

--- a/ruff.schema.json
+++ b/ruff.schema.json
@@ -2774,6 +2774,16 @@
             "boolean",
             "null"
           ]
+        },
+        "whitelisted-markup-calls": {
+          "description": "A list of callable names, whose result may be safely passed into [`markupsafe.Markup`].\n\nExpects to receive a list of fully-qualified names (e.g., [`bleach.clean`], rather than `clean`).\n\nThis setting helps you avoid false positives in code like:\n\n```python from bleach import clean from markupsafe import Markup\n\ncleaned_markup = Markup(bleach.clean(some_user_input)) ```\n\nWhere the use of [`bleach.clean`] usually ensures that there's no XSS vulnerability.\n\nAlthough it is not recommended, you may also use this setting to whitelist other kinds of calls, e.g. calls to i18n translation functions, where how safe that is will depend on the implementation and how well the translations are audited.\n\nAnother common use-case is to wrap the output of functions that generate markup like [`xml.etree.ElementTree.tostring`] or template rendering engines where sanitization of potential user input is either already baked in or has to happen before rendering.\n\n[bleach.clean]: https://bleach.readthedocs.io/en/latest/clean.html [markupsafe.Markup]: https://markupsafe.palletsprojects.com/en/stable/escaping/#markupsafe.Markup [xml.etree.ElementTree.tostring]: https://docs.python.org/3/library/xml.etree.elementtree.html#xml.etree.ElementTree.tostring",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
         }
       },
       "additionalProperties": false

--- a/ruff.schema.json
+++ b/ruff.schema.json
@@ -2758,6 +2758,16 @@
     "RuffOptions": {
       "type": "object",
       "properties": {
+        "allowed-markup-calls": {
+          "description": "A list of callable names, whose result may be safely passed into [`markupsafe.Markup`].\n\nExpects to receive a list of fully-qualified names (e.g., [`bleach.clean`], rather than `clean`).\n\nThis setting helps you avoid false positives in code like:\n\n```python from bleach import clean from markupsafe import Markup\n\ncleaned_markup = Markup(clean(some_user_input)) ```\n\nWhere the use of [`bleach.clean`] usually ensures that there's no XSS vulnerability.\n\nAlthough it is not recommended, you may also use this setting to whitelist other kinds of calls, e.g. calls to i18n translation functions, where how safe that is will depend on the implementation and how well the translations are audited.\n\nAnother common use-case is to wrap the output of functions that generate markup like [`xml.etree.ElementTree.tostring`] or template rendering engines where sanitization of potential user input is either already baked in or has to happen before rendering.\n\n[bleach.clean]: https://bleach.readthedocs.io/en/latest/clean.html [markupsafe.Markup]: https://markupsafe.palletsprojects.com/en/stable/escaping/#markupsafe.Markup [xml.etree.ElementTree.tostring]: https://docs.python.org/3/library/xml.etree.elementtree.html#xml.etree.ElementTree.tostring",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
         "extend-markup-names": {
           "description": "A list of additional callable names that behave like [`markupsafe.Markup`].\n\nExpects to receive a list of fully-qualified names (e.g., `webhelpers.html.literal`, rather than `literal`).\n\n[markupsafe.Markup]: https://markupsafe.palletsprojects.com/en/stable/escaping/#markupsafe.Markup",
           "type": [
@@ -2774,16 +2784,6 @@
             "boolean",
             "null"
           ]
-        },
-        "whitelisted-markup-calls": {
-          "description": "A list of callable names, whose result may be safely passed into [`markupsafe.Markup`].\n\nExpects to receive a list of fully-qualified names (e.g., [`bleach.clean`], rather than `clean`).\n\nThis setting helps you avoid false positives in code like:\n\n```python from bleach import clean from markupsafe import Markup\n\ncleaned_markup = Markup(bleach.clean(some_user_input)) ```\n\nWhere the use of [`bleach.clean`] usually ensures that there's no XSS vulnerability.\n\nAlthough it is not recommended, you may also use this setting to whitelist other kinds of calls, e.g. calls to i18n translation functions, where how safe that is will depend on the implementation and how well the translations are audited.\n\nAnother common use-case is to wrap the output of functions that generate markup like [`xml.etree.ElementTree.tostring`] or template rendering engines where sanitization of potential user input is either already baked in or has to happen before rendering.\n\n[bleach.clean]: https://bleach.readthedocs.io/en/latest/clean.html [markupsafe.Markup]: https://markupsafe.palletsprojects.com/en/stable/escaping/#markupsafe.Markup [xml.etree.ElementTree.tostring]: https://docs.python.org/3/library/xml.etree.elementtree.html#xml.etree.ElementTree.tostring",
-          "type": [
-            "array",
-            "null"
-          ],
-          "items": {
-            "type": "string"
-          }
         }
       },
       "additionalProperties": false


### PR DESCRIPTION
Closes: #14523

## Summary

Adds a whitelist of calls allowed to be used within a `markupsafe.Markup` call.

## Test Plan

`cargo nextest run`
