### PR TITLE
`type: ignore[codes]` and `knot: ignore`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2306,6 +2306,7 @@ dependencies = [
  "ruff_python_literal",
  "ruff_python_parser",
  "ruff_python_stdlib",
+ "ruff_python_trivia",
  "ruff_source_file",
  "ruff_text_size",
  "rustc-hash 2.1.0",

--- a/crates/red_knot_python_semantic/Cargo.toml
+++ b/crates/red_knot_python_semantic/Cargo.toml
@@ -20,6 +20,7 @@ ruff_python_stdlib = { workspace = true }
 ruff_source_file = { workspace = true }
 ruff_text_size = { workspace = true }
 ruff_python_literal = { workspace = true }
+ruff_python_trivia = { workspace = true }
 
 anyhow = { workspace = true }
 bitflags = { workspace = true }

--- a/crates/red_knot_python_semantic/resources/mdtest/suppressions/knot-ignore.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/suppressions/knot-ignore.md
@@ -1,0 +1,120 @@
+# Suppressing errors with `knot: ignore`
+
+Type check errors can be suppressed by a `knot: ignore` comment on the same line as the violation.
+
+## Simple `knot: ignore`
+
+```py
+a = 4 + test  # knot: ignore
+```
+
+## Suppressing a specific code
+
+```py
+a = 4 + test  # knot: ignore[unresolved-reference]
+```
+
+## Useless suppression
+
+TODO: Red Knot should emit an `unused-suppression` diagnostic for the
+`possibly-unresolved-reference` suppression.
+
+```py
+test = 10
+a = test + 3  # knot: ignore[possibly-unresolved-reference]
+```
+
+## Useless suppression if the error codes don't match
+
+TODO: Red Knot should emit a `unused-suppression` diagnostic for the `possibly-unresolved-reference`
+suppression because it doesn't match the actual `unresolved-reference` diagnostic.
+
+```py
+# error: [unresolved-reference]
+a = test + 3  # knot: ignore[possibly-unresolved-reference]
+```
+
+## Multiple suppressions
+
+```py
+# fmt: off
+def test(a: f"f-string type annotation", b: b"byte-string-type-annotation"): ...  # knot: ignore[fstring-type-annotation, byte-string-type-annotation]
+```
+
+## Can't suppress syntax errors
+
+<!-- blacken-docs:off -->
+
+```py
+# error: [invalid-syntax]
+def test(  # knot: ignore
+```
+
+<!-- blacken-docs:on -->
+
+## Can't suppress `revealed-type` diagnostics
+
+```py
+a = 10
+# revealed: Literal[10]
+reveal_type(a)  # knot: ignore
+```
+
+## Extra whitespace in type ignore comments is allowed
+
+```py
+a = 10 / 0  # knot   :   ignore
+a = 10 / 0  # knot: ignore  [    division-by-zero   ]
+```
+
+## Whitespace is optional
+
+```py
+# fmt: off
+a = 10 / 0  #knot:ignore[division-by-zero]
+```
+
+## Trailing codes comma
+
+Trailing commas in the codes section are allowed:
+
+```py
+a = 10 / 0  # knot: ignore[division-by-zero,]
+```
+
+## Invalid characters in codes
+
+```py
+# error: [division-by-zero]
+a = 10 / 0  # knot: ignore[*-*]
+```
+
+## Trailing whitespace
+
+<!-- blacken-docs:off -->
+
+```py
+a = 10 / 0  # knot: ignore[division-by-zero]      
+            #                               ^^^^^^ trailing whitespace
+```
+
+<!-- blacken-docs:on -->
+
+## Missing comma
+
+A missing comma results in an invalid suppression comment. We may want to recover from this in the
+future.
+
+```py
+# error: [unresolved-reference]
+a = x / 0  # knot: ignore[division-by-zero unresolved-reference]
+```
+
+## Empty codes
+
+An empty codes array suppresses no-diagnostics and is always useless
+
+```py
+# error: [division-by-zero]
+a = 4 / 0  # knot: ignore[]
+```

--- a/crates/red_knot_python_semantic/resources/mdtest/suppressions/type-ignore.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/suppressions/type-ignore.md
@@ -95,12 +95,8 @@ a = test  # type: ignore[name-defined]
 
 ## Nested comments
 
-TODO: We should support this for better interopability with other suppression comments.
-
 ```py
 # fmt: off
-# TODO this error should be suppressed
-# error: [unresolved-reference]
 a = test \
   + 2  # fmt: skip # type: ignore
 

--- a/crates/red_knot_python_semantic/src/db.rs
+++ b/crates/red_knot_python_semantic/src/db.rs
@@ -1,4 +1,4 @@
-use crate::lint::RuleSelection;
+use crate::lint::{LintRegistry, RuleSelection};
 use ruff_db::files::File;
 use ruff_db::{Db as SourceDb, Upcast};
 
@@ -8,6 +8,8 @@ pub trait Db: SourceDb + Upcast<dyn SourceDb> {
     fn is_file_open(&self, file: File) -> bool;
 
     fn rule_selection(&self) -> &RuleSelection;
+
+    fn lint_registry(&self) -> &LintRegistry;
 }
 
 #[cfg(test)]
@@ -19,7 +21,7 @@ pub(crate) mod tests {
     use crate::{default_lint_registry, ProgramSettings, PythonPlatform};
 
     use super::Db;
-    use crate::lint::RuleSelection;
+    use crate::lint::{LintRegistry, RuleSelection};
     use anyhow::Context;
     use ruff_db::files::{File, Files};
     use ruff_db::system::{DbWithTestSystem, System, SystemPathBuf, TestSystem};
@@ -45,7 +47,7 @@ pub(crate) mod tests {
                 vendored: red_knot_vendored::file_system().clone(),
                 events: Arc::default(),
                 files: Files::default(),
-                rule_selection: Arc::new(RuleSelection::from_registry(&default_lint_registry())),
+                rule_selection: Arc::new(RuleSelection::from_registry(default_lint_registry())),
             }
         }
 
@@ -111,6 +113,10 @@ pub(crate) mod tests {
 
         fn rule_selection(&self) -> &RuleSelection {
             &self.rule_selection
+        }
+
+        fn lint_registry(&self) -> &LintRegistry {
+            default_lint_registry()
         }
     }
 

--- a/crates/red_knot_python_semantic/src/lib.rs
+++ b/crates/red_knot_python_semantic/src/lib.rs
@@ -33,11 +33,15 @@ mod visibility_constraints;
 
 type FxOrderSet<V> = ordermap::set::OrderSet<V, BuildHasherDefault<FxHasher>>;
 
-/// Creates a new registry with all known semantic lints.
-pub fn default_lint_registry() -> LintRegistry {
-    let mut registry = LintRegistryBuilder::default();
-    register_lints(&mut registry);
-    registry.build()
+/// Returns the default registry with all known semantic lints.
+pub fn default_lint_registry() -> &'static LintRegistry {
+    static REGISTRY: std::sync::LazyLock<LintRegistry> = std::sync::LazyLock::new(|| {
+        let mut registry = LintRegistryBuilder::default();
+        register_lints(&mut registry);
+        registry.build()
+    });
+
+    &REGISTRY
 }
 
 /// Register all known semantic lints.

--- a/crates/red_knot_python_semantic/src/lint.rs
+++ b/crates/red_knot_python_semantic/src/lint.rs
@@ -321,7 +321,7 @@ impl LintRegistryBuilder {
     }
 }
 
-#[derive(Default, Debug)]
+#[derive(Default, Debug, Clone)]
 pub struct LintRegistry {
     lints: Vec<LintId>,
     by_name: FxHashMap<&'static str, LintEntry>,
@@ -385,7 +385,7 @@ pub enum GetLintError {
     Unknown(String),
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum LintEntry {
     /// An existing lint rule. Can be in preview, stable or deprecated.
     Lint(LintId),

--- a/crates/red_knot_test/src/db.rs
+++ b/crates/red_knot_test/src/db.rs
@@ -1,4 +1,4 @@
-use red_knot_python_semantic::lint::RuleSelection;
+use red_knot_python_semantic::lint::{LintRegistry, RuleSelection};
 use red_knot_python_semantic::{
     default_lint_registry, Db as SemanticDb, Program, ProgramSettings, PythonPlatform,
     PythonVersion, SearchPathSettings,
@@ -21,7 +21,7 @@ pub(crate) struct Db {
 
 impl Db {
     pub(crate) fn setup(workspace_root: SystemPathBuf) -> Self {
-        let rule_selection = RuleSelection::from_registry(&default_lint_registry());
+        let rule_selection = RuleSelection::from_registry(default_lint_registry());
 
         let db = Self {
             workspace_root,
@@ -96,6 +96,10 @@ impl SemanticDb for Db {
 
     fn rule_selection(&self) -> &RuleSelection {
         &self.rule_selection
+    }
+
+    fn lint_registry(&self) -> &LintRegistry {
+        default_lint_registry()
     }
 }
 

--- a/crates/red_knot_workspace/src/db.rs
+++ b/crates/red_knot_workspace/src/db.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use crate::workspace::{check_file, Workspace, WorkspaceMetadata};
 use crate::DEFAULT_LINT_REGISTRY;
-use red_knot_python_semantic::lint::RuleSelection;
+use red_knot_python_semantic::lint::{LintRegistry, RuleSelection};
 use red_knot_python_semantic::{Db as SemanticDb, Program};
 use ruff_db::diagnostic::Diagnostic;
 use ruff_db::files::{File, Files};
@@ -116,6 +116,10 @@ impl SemanticDb for RootDatabase {
     fn rule_selection(&self) -> &RuleSelection {
         &self.rule_selection
     }
+
+    fn lint_registry(&self) -> &LintRegistry {
+        &DEFAULT_LINT_REGISTRY
+    }
 }
 
 #[salsa::db]
@@ -162,7 +166,7 @@ pub(crate) mod tests {
 
     use salsa::Event;
 
-    use red_knot_python_semantic::lint::RuleSelection;
+    use red_knot_python_semantic::lint::{LintRegistry, RuleSelection};
     use red_knot_python_semantic::Db as SemanticDb;
     use ruff_db::files::Files;
     use ruff_db::system::{DbWithTestSystem, System, TestSystem};
@@ -267,6 +271,10 @@ pub(crate) mod tests {
 
         fn rule_selection(&self) -> &RuleSelection {
             &self.rule_selection
+        }
+
+        fn lint_registry(&self) -> &LintRegistry {
+            &DEFAULT_LINT_REGISTRY
         }
     }
 

--- a/crates/ruff_graph/src/db.rs
+++ b/crates/ruff_graph/src/db.rs
@@ -2,9 +2,10 @@ use anyhow::Result;
 use std::sync::Arc;
 use zip::CompressionMethod;
 
-use red_knot_python_semantic::lint::RuleSelection;
+use red_knot_python_semantic::lint::{LintRegistry, RuleSelection};
 use red_knot_python_semantic::{
-    Db, Program, ProgramSettings, PythonPlatform, PythonVersion, SearchPathSettings,
+    default_lint_registry, Db, Program, ProgramSettings, PythonPlatform, PythonVersion,
+    SearchPathSettings,
 };
 use ruff_db::files::{File, Files};
 use ruff_db::system::{OsSystem, System, SystemPathBuf};
@@ -92,6 +93,10 @@ impl Db for ModuleDb {
 
     fn rule_selection(&self) -> &RuleSelection {
         &self.rule_selection
+    }
+
+    fn lint_registry(&self) -> &LintRegistry {
+        default_lint_registry()
     }
 }
 

--- a/crates/ruff_python_trivia/src/cursor.rs
+++ b/crates/ruff_python_trivia/src/cursor.rs
@@ -56,10 +56,8 @@ impl<'a> Cursor<'a> {
         self.chars.clone().next_back().unwrap_or(EOF_CHAR)
     }
 
-    // SAFETY: The `source.text_len` call in `new` would panic if the string length is larger than a `u32`.
-    #[allow(clippy::cast_possible_truncation)]
     pub fn text_len(&self) -> TextSize {
-        TextSize::new(self.chars.as_str().len() as u32)
+        self.chars.as_str().text_len()
     }
 
     pub fn token_len(&self) -> TextSize {
@@ -97,6 +95,16 @@ impl<'a> Cursor<'a> {
     pub fn eat_char_back(&mut self, c: char) -> bool {
         if self.last() == c {
             self.bump_back();
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Eats the next character if `predicate` returns `true`.
+    pub fn eat_if(&mut self, mut predicate: impl FnMut(char) -> bool) -> bool {
+        if predicate(self.first()) && !self.is_eof() {
+            self.bump();
             true
         } else {
             false

--- a/fuzz/fuzz_targets/red_knot_check_invalid_syntax.rs
+++ b/fuzz/fuzz_targets/red_knot_check_invalid_syntax.rs
@@ -7,6 +7,7 @@ use std::sync::{Mutex, OnceLock};
 
 use libfuzzer_sys::{fuzz_target, Corpus};
 
+use red_knot_python_semantic::lint::LintRegistry;
 use red_knot_python_semantic::types::check_types;
 use red_knot_python_semantic::{
     default_lint_registry, lint::RuleSelection, Db as SemanticDb, Program, ProgramSettings,
@@ -40,7 +41,7 @@ impl TestDb {
             vendored: red_knot_vendored::file_system().clone(),
             events: std::sync::Arc::default(),
             files: Files::default(),
-            rule_selection: RuleSelection::from_registry(&default_lint_registry()).into(),
+            rule_selection: RuleSelection::from_registry(default_lint_registry()).into(),
         }
     }
 }
@@ -87,6 +88,10 @@ impl SemanticDb for TestDb {
 
     fn rule_selection(&self) -> &RuleSelection {
         &self.rule_selection
+    }
+
+    fn lint_registry(&self) -> &LintRegistry {
+        default_lint_registry()
     }
 }
 


### PR DESCRIPTION
## Summary

This PR adds support for parsing `type: ignore` comments that have an optional codes segment, e.g. `type: ignore[a, b, c]`. It also introduces the new `knot: ignore[codes]` suppression comment. 

The logic is split into two parts: 

* A suppression comment parser that parses a single `# type: ignore` comment 
* The logic that creates one or multiple `Suppressions` for each comment. 


I've decided to "flatten" ignore comments with multiple codes into multiple `Suppression` instances because I think it will simplify
the tracking of unused suppressions and it avoids a nested vector for the lint ids in `Suppression`.  

## Test Plan

Added md test
