### PR TITLE
Add `unused-ignore-comment` rule

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/suppressions/knot-ignore.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/suppressions/knot-ignore.md
@@ -148,6 +148,7 @@ An empty codes array suppresses no-diagnostics and is always useless
 
 ```py
 # error: [division-by-zero]
+# error: [unused-ignore-comment] "Unused `knot: ignore` without a code"
 a = 4 / 0  # knot: ignore[]
 ```
 

--- a/crates/red_knot_python_semantic/resources/mdtest/suppressions/knot-ignore.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/suppressions/knot-ignore.md
@@ -14,24 +14,53 @@ a = 4 + test  # knot: ignore
 a = 4 + test  # knot: ignore[unresolved-reference]
 ```
 
-## Useless suppression
-
-TODO: Red Knot should emit an `unused-suppression` diagnostic for the
-`possibly-unresolved-reference` suppression.
+## Unused suppression
 
 ```py
 test = 10
+# error: [unused-ignore-comment] "Unused `knot: ignore` directive: 'possibly-unresolved-reference'"
 a = test + 3  # knot: ignore[possibly-unresolved-reference]
 ```
 
-## Useless suppression if the error codes don't match
-
-TODO: Red Knot should emit a `unused-suppression` diagnostic for the `possibly-unresolved-reference`
-suppression because it doesn't match the actual `unresolved-reference` diagnostic.
+## Unused suppression if the error codes don't match
 
 ```py
 # error: [unresolved-reference]
+# error: [unused-ignore-comment] "Unused `knot: ignore` directive: 'possibly-unresolved-reference'"
 a = test + 3  # knot: ignore[possibly-unresolved-reference]
+```
+
+## Suppressed unused comment
+
+```py
+# error: [unused-ignore-comment]
+a = 10 / 2  # knot: ignore[division-by-zero]
+a = 10 / 2  # knot: ignore[division-by-zero, unused-ignore-comment]
+a = 10 / 2  # knot: ignore[unused-ignore-comment, division-by-zero]
+a = 10 / 2  # knot: ignore[unused-ignore-comment] # type: ignore
+a = 10 / 2  # type: ignore # knot: ignore[unused-ignore-comment]
+```
+
+## Unused ignore comment
+
+```py
+# error: [unused-ignore-comment] "Unused `knot: ignore` directive: 'unused-ignore-comment'"
+a = 10 / 0  # knot: ignore[division-by-zero, unused-ignore-comment]
+```
+
+## Multiple unused comments
+
+Today, Red Knot emits a diagnostic for every unused code. We might want to group the codes by
+comment at some point in the future.
+
+```py
+# error: [unused-ignore-comment] "Unused `knot: ignore` directive: 'division-by-zero'"
+# error: [unused-ignore-comment] "Unused `knot: ignore` directive: 'unresolved-reference'"
+a = 10 / 2  # knot: ignore[division-by-zero, unresolved-reference]
+
+# error: [unused-ignore-comment] "Unused `knot: ignore` directive: 'invalid-assignment'"
+# error: [unused-ignore-comment] "Unused `knot: ignore` directive: 'unresolved-reference'"
+a = 10 / 0  # knot: ignore[invalid-assignment, division-by-zero, unresolved-reference]
 ```
 
 ## Multiple suppressions
@@ -47,6 +76,7 @@ def test(a: f"f-string type annotation", b: b"byte-string-type-annotation"): ...
 
 ```py
 # error: [invalid-syntax]
+# error: [unused-ignore-comment]
 def test(  # knot: ignore
 ```
 
@@ -54,10 +84,12 @@ def test(  # knot: ignore
 
 ## Can't suppress `revealed-type` diagnostics
 
+TODO: Emit an error that the rule code is unknown: `unknown-rule`
+
 ```py
 a = 10
 # revealed: Literal[10]
-reveal_type(a)  # knot: ignore
+reveal_type(a)  # knot: ignore[revealed-type]
 ```
 
 ## Extra whitespace in type ignore comments is allowed
@@ -126,6 +158,7 @@ if they should use a different syntax that also supports enabling rules or chang
 severity: `knot: possibly-undefined-reference=error`
 
 ```py
+# error: [unused-ignore-comment]
 # knot: ignore[division-by-zero]
 
 a = 4 / 0  # error: [division-by-zero]

--- a/crates/red_knot_python_semantic/resources/mdtest/suppressions/type-ignore.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/suppressions/type-ignore.md
@@ -153,7 +153,7 @@ File level suppressions must come before any non-trivia token,
 including module docstrings. 
 """
 
-# error: [unused-ignore-comment] "Unused blanked `type: ignore` directive"
+# error: [unused-ignore-comment] "Unused blanket `type: ignore` directive"
 # type: ignore
 
 a = 10 / 0  # error: [division-by-zero]

--- a/crates/red_knot_python_semantic/resources/mdtest/suppressions/type-ignore.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/suppressions/type-ignore.md
@@ -43,6 +43,8 @@ from typing import cast
 
 y = (
     cast(int, "test" +
+            # TODO: Remove the expected error after implementing `invalid-operator` for binary expressions
+            # error: [unused-ignore-comment]
             2 # type: ignore
     )
     + "other"  # TODO: expected-error[invalid-operator]
@@ -118,6 +120,7 @@ in Pyright. Neither Ruff, nor mypy support this and neither does Red Knot.
 
 ```py
 # fmt: off
+# error: [unused-ignore-comment]
 a = (  # type: ignore
     test + 4  # error: [unresolved-reference]
 )
@@ -150,6 +153,7 @@ File level suppressions must come before any non-trivia token,
 including module docstrings. 
 """
 
+# error: [unused-ignore-comment] "Unused blanked `type: ignore` directive"
 # type: ignore
 
 a = 10 / 0  # error: [division-by-zero]

--- a/crates/red_knot_python_semantic/src/lib.rs
+++ b/crates/red_knot_python_semantic/src/lib.rs
@@ -3,6 +3,7 @@ use std::hash::BuildHasherDefault;
 use rustc_hash::FxHasher;
 
 use crate::lint::{LintRegistry, LintRegistryBuilder};
+use crate::suppression::UNUSED_IGNORE_COMMENT;
 pub use db::Db;
 pub use module_name::ModuleName;
 pub use module_resolver::{resolve_module, system_module_search_paths, KnownModule, Module};
@@ -47,4 +48,5 @@ pub fn default_lint_registry() -> &'static LintRegistry {
 /// Register all known semantic lints.
 pub fn register_lints(registry: &mut LintRegistryBuilder) {
     types::register_lints(registry);
+    registry.register_lint(&UNUSED_IGNORE_COMMENT);
 }

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -27,6 +27,7 @@ use crate::semantic_index::{
     DeclarationsIterator,
 };
 use crate::stdlib::{builtins_symbol, known_module_symbol, typing_extensions_symbol};
+use crate::suppression::check_unused_suppressions;
 use crate::symbol::{Boundness, Symbol};
 use crate::types::call::{CallDunderResult, CallOutcome};
 use crate::types::class_base::ClassBase;
@@ -64,6 +65,8 @@ pub fn check_types(db: &dyn Db, file: File) -> TypeCheckDiagnostics {
         let result = infer_scope_types(db, scope_id);
         diagnostics.extend(result.diagnostics());
     }
+
+    check_unused_suppressions(db, file, &mut diagnostics);
 
     diagnostics
 }

--- a/crates/red_knot_python_semantic/src/types/diagnostic.rs
+++ b/crates/red_knot_python_semantic/src/types/diagnostic.rs
@@ -1,5 +1,7 @@
+use super::context::InferContext;
 use crate::declare_lint;
 use crate::lint::{Level, LintRegistryBuilder, LintStatus};
+use crate::suppression::FileSuppressionId;
 use crate::types::string_annotation::{
     BYTE_STRING_TYPE_ANNOTATION, ESCAPE_CHARACTER_IN_FORWARD_ANNOTATION, FSTRING_TYPE_ANNOTATION,
     IMPLICIT_CONCATENATED_STRING_TYPE_ANNOTATION, INVALID_SYNTAX_IN_FORWARD_ANNOTATION,
@@ -10,12 +12,11 @@ use ruff_db::diagnostic::{Diagnostic, DiagnosticId, Severity};
 use ruff_db::files::File;
 use ruff_python_ast::{self as ast, AnyNodeRef};
 use ruff_text_size::{Ranged, TextRange};
+use rustc_hash::FxHashSet;
 use std::borrow::Cow;
 use std::fmt::Formatter;
 use std::ops::Deref;
 use std::sync::Arc;
-
-use super::context::InferContext;
 
 /// Registers all known type check lints.
 pub(crate) fn register_lints(registry: &mut LintRegistryBuilder) {
@@ -512,11 +513,11 @@ declare_lint! {
 
 #[derive(Debug, Eq, PartialEq, Clone)]
 pub struct TypeCheckDiagnostic {
-    pub(super) id: DiagnosticId,
-    pub(super) message: String,
-    pub(super) range: TextRange,
-    pub(super) severity: Severity,
-    pub(super) file: File,
+    pub(crate) id: DiagnosticId,
+    pub(crate) message: String,
+    pub(crate) range: TextRange,
+    pub(crate) severity: Severity,
+    pub(crate) file: File,
 }
 
 impl TypeCheckDiagnostic {
@@ -570,41 +571,41 @@ impl Ranged for TypeCheckDiagnostic {
 /// each Salsa-struct comes with an overhead.
 #[derive(Default, Eq, PartialEq)]
 pub struct TypeCheckDiagnostics {
-    inner: Vec<std::sync::Arc<TypeCheckDiagnostic>>,
+    diagnostics: Vec<Arc<TypeCheckDiagnostic>>,
+    used_suppressions: FxHashSet<FileSuppressionId>,
 }
 
 impl TypeCheckDiagnostics {
-    pub(super) fn push(&mut self, diagnostic: TypeCheckDiagnostic) {
-        self.inner.push(Arc::new(diagnostic));
+    pub(crate) fn push(&mut self, diagnostic: TypeCheckDiagnostic) {
+        self.diagnostics.push(Arc::new(diagnostic));
+    }
+
+    pub(super) fn extend(&mut self, other: &TypeCheckDiagnostics) {
+        self.diagnostics.extend_from_slice(&other.diagnostics);
+        self.used_suppressions.extend(&other.used_suppressions);
+    }
+
+    pub(crate) fn mark_used(&mut self, suppression_id: FileSuppressionId) {
+        self.used_suppressions.insert(suppression_id);
+    }
+
+    pub(crate) fn is_used(&self, suppression_id: FileSuppressionId) -> bool {
+        self.used_suppressions.contains(&suppression_id)
+    }
+
+    pub(crate) fn used_len(&self) -> usize {
+        self.used_suppressions.len()
     }
 
     pub(crate) fn shrink_to_fit(&mut self) {
-        self.inner.shrink_to_fit();
-    }
-}
-
-impl Extend<TypeCheckDiagnostic> for TypeCheckDiagnostics {
-    fn extend<T: IntoIterator<Item = TypeCheckDiagnostic>>(&mut self, iter: T) {
-        self.inner.extend(iter.into_iter().map(std::sync::Arc::new));
-    }
-}
-
-impl Extend<std::sync::Arc<TypeCheckDiagnostic>> for TypeCheckDiagnostics {
-    fn extend<T: IntoIterator<Item = Arc<TypeCheckDiagnostic>>>(&mut self, iter: T) {
-        self.inner.extend(iter);
-    }
-}
-
-impl<'a> Extend<&'a std::sync::Arc<TypeCheckDiagnostic>> for TypeCheckDiagnostics {
-    fn extend<T: IntoIterator<Item = &'a Arc<TypeCheckDiagnostic>>>(&mut self, iter: T) {
-        self.inner
-            .extend(iter.into_iter().map(std::sync::Arc::clone));
+        self.used_suppressions.shrink_to_fit();
+        self.diagnostics.shrink_to_fit();
     }
 }
 
 impl std::fmt::Debug for TypeCheckDiagnostics {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        self.inner.fmt(f)
+        self.diagnostics.fmt(f)
     }
 }
 
@@ -612,7 +613,7 @@ impl Deref for TypeCheckDiagnostics {
     type Target = [std::sync::Arc<TypeCheckDiagnostic>];
 
     fn deref(&self) -> &Self::Target {
-        &self.inner
+        &self.diagnostics
     }
 }
 
@@ -621,7 +622,7 @@ impl IntoIterator for TypeCheckDiagnostics {
     type IntoIter = std::vec::IntoIter<std::sync::Arc<TypeCheckDiagnostic>>;
 
     fn into_iter(self) -> Self::IntoIter {
-        self.inner.into_iter()
+        self.diagnostics.into_iter()
     }
 }
 
@@ -630,7 +631,7 @@ impl<'a> IntoIterator for &'a TypeCheckDiagnostics {
     type IntoIter = std::slice::Iter<'a, std::sync::Arc<TypeCheckDiagnostic>>;
 
     fn into_iter(self) -> Self::IntoIter {
-        self.inner.iter()
+        self.diagnostics.iter()
     }
 }
 

--- a/crates/ruff_benchmark/benches/red_knot.rs
+++ b/crates/ruff_benchmark/benches/red_knot.rs
@@ -43,7 +43,7 @@ static EXPECTED_DIAGNOSTICS: &[&str] = &[
     "warning[lint:possibly-unresolved-reference] /src/tomllib/_parser.py:579:12 Name `char` used when possibly not defined",
     "warning[lint:possibly-unresolved-reference] /src/tomllib/_parser.py:580:63 Name `char` used when possibly not defined",
     "warning[lint:possibly-unresolved-reference] /src/tomllib/_parser.py:629:38 Name `datetime_obj` used when possibly not defined",
-    "warning[lint:unused-ignore-comment] /src/tomllib/_parser.py:682:31 Unused blanked `type: ignore` directive"
+    "warning[lint:unused-ignore-comment] /src/tomllib/_parser.py:682:31 Unused blanket `type: ignore` directive"
 ];
 
 fn get_test_file(name: &str) -> TestFile {

--- a/crates/ruff_benchmark/benches/red_knot.rs
+++ b/crates/ruff_benchmark/benches/red_knot.rs
@@ -43,6 +43,7 @@ static EXPECTED_DIAGNOSTICS: &[&str] = &[
     "warning[lint:possibly-unresolved-reference] /src/tomllib/_parser.py:579:12 Name `char` used when possibly not defined",
     "warning[lint:possibly-unresolved-reference] /src/tomllib/_parser.py:580:63 Name `char` used when possibly not defined",
     "warning[lint:possibly-unresolved-reference] /src/tomllib/_parser.py:629:38 Name `datetime_obj` used when possibly not defined",
+    "warning[lint:unused-ignore-comment] /src/tomllib/_parser.py:682:31 Unused blanked `type: ignore` directive"
 ];
 
 fn get_test_file(name: &str) -> TestFile {


### PR DESCRIPTION
## Summary

This PR implements a new Red Knot rule that reports unused `type: ignore` or `knot: ignore[code]` comments. 


The tricky part about this rule is that `unused-ignore-comment` can itself be suppressed by using an ignore comment. 
Ruff only supports suppressing `unused-noqa` warnings with a file-level `noqa` comment. Unfortunately, we
don't support file-level ignore comments other than `type: ignore` but we also want to warn about unused
file-level `type: ignore` comments. 

That's why this PR proposes that we allow suppressing `unused-ignore-comment` but only by using `knot: ignore[unused-ignore-comment]`. 

## Open questions

Ruff calls the rule `unused-noqa`, but I'm not sure if `unnecessary` or `useless` would be more fitting because you can't use an ignore code. But an ignore code can be useless (or unnecessary). 

## Test Plan

Added mdtests
