### PR TITLE
[red-knot] Add diagnostic for invalid unpacking

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/unpacking.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/unpacking.md
@@ -61,7 +61,7 @@ reveal_type(c)  # revealed: Literal[4]
 ### Uneven unpacking (1)
 
 ```py
-# TODO: Add diagnostic (there aren't enough values to unpack)
+# error: [invalid-assignment] "Not enough values to unpack (expected 3, got 2)"
 (a, b, c) = (1, 2)
 reveal_type(a)  # revealed: Literal[1]
 reveal_type(b)  # revealed: Literal[2]
@@ -71,7 +71,7 @@ reveal_type(c)  # revealed: Unknown
 ### Uneven unpacking (2)
 
 ```py
-# TODO: Add diagnostic (too many values to unpack)
+# error: [invalid-assignment] "Too many values to unpack (expected 2, got 3)"
 (a, b) = (1, 2, 3)
 reveal_type(a)  # revealed: Literal[1]
 reveal_type(b)  # revealed: Literal[2]
@@ -80,7 +80,7 @@ reveal_type(b)  # revealed: Literal[2]
 ### Starred expression (1)
 
 ```py
-# TODO: Add diagnostic (need more values to unpack)
+# error: [invalid-assignment] "Not enough values to unpack (expected 3 or more, got 2)"
 [a, *b, c, d] = (1, 2)
 reveal_type(a)  # revealed: Literal[1]
 # TODO: Should be list[Any] once support for assigning to starred expression is added
@@ -133,7 +133,7 @@ reveal_type(c)  # revealed: @Todo(starred unpacking)
 ### Starred expression (6)
 
 ```py
-# TODO: Add diagnostic (need more values to unpack)
+# error: [invalid-assignment] "Not enough values to unpack (expected 5 or more, got 1)"
 (a, b, c, *d, e, f) = (1,)
 reveal_type(a)  # revealed: Literal[1]
 reveal_type(b)  # revealed: Unknown
@@ -199,7 +199,7 @@ reveal_type(b)  # revealed: LiteralString
 ### Uneven unpacking (1)
 
 ```py
-# TODO: Add diagnostic (there aren't enough values to unpack)
+# error: [invalid-assignment] "Not enough values to unpack (expected 3, got 2)"
 a, b, c = "ab"
 reveal_type(a)  # revealed: LiteralString
 reveal_type(b)  # revealed: LiteralString
@@ -209,7 +209,7 @@ reveal_type(c)  # revealed: Unknown
 ### Uneven unpacking (2)
 
 ```py
-# TODO: Add diagnostic (too many values to unpack)
+# error: [invalid-assignment] "Too many values to unpack (expected 2, got 3)"
 a, b = "abc"
 reveal_type(a)  # revealed: LiteralString
 reveal_type(b)  # revealed: LiteralString
@@ -218,7 +218,7 @@ reveal_type(b)  # revealed: LiteralString
 ### Starred expression (1)
 
 ```py
-# TODO: Add diagnostic (need more values to unpack)
+# error: [invalid-assignment] "Not enough values to unpack (expected 3 or more, got 2)"
 (a, *b, c, d) = "ab"
 reveal_type(a)  # revealed: LiteralString
 # TODO: Should be list[LiteralString] once support for assigning to starred expression is added
@@ -271,7 +271,7 @@ reveal_type(c)  # revealed: @Todo(starred unpacking)
 ### Unicode
 
 ```py
-# TODO: Add diagnostic (need more values to unpack)
+# error: [invalid-assignment] "Not enough values to unpack (expected 2, got 1)"
 (a, b) = "é"
 
 reveal_type(a)  # revealed: LiteralString
@@ -281,7 +281,7 @@ reveal_type(b)  # revealed: Unknown
 ### Unicode escape (1)
 
 ```py
-# TODO: Add diagnostic (need more values to unpack)
+# error: [invalid-assignment] "Not enough values to unpack (expected 2, got 1)"
 (a, b) = "\u9E6C"
 
 reveal_type(a)  # revealed: LiteralString
@@ -291,7 +291,7 @@ reveal_type(b)  # revealed: Unknown
 ### Unicode escape (2)
 
 ```py
-# TODO: Add diagnostic (need more values to unpack)
+# error: [invalid-assignment] "Not enough values to unpack (expected 2, got 1)"
 (a, b) = "\U0010FFFF"
 
 reveal_type(a)  # revealed: LiteralString
@@ -383,7 +383,8 @@ def _(arg: tuple[int, bytes, int] | tuple[int, int, str, int, bytes]):
 
 ```py
 def _(arg: tuple[int, bytes, int] | tuple[int, int, str, int, bytes]):
-    # TODO: Add diagnostic (too many values to unpack)
+    # error: [invalid-assignment] "Too many values to unpack (expected 2, got 3)"
+    # error: [invalid-assignment] "Too many values to unpack (expected 2, got 5)"
     a, b = arg
     reveal_type(a)  # revealed: int
     reveal_type(b)  # revealed: bytes | int
@@ -393,7 +394,8 @@ def _(arg: tuple[int, bytes, int] | tuple[int, int, str, int, bytes]):
 
 ```py
 def _(arg: tuple[int, bytes] | tuple[int, str]):
-    # TODO: Add diagnostic (there aren't enough values to unpack)
+    # error: [invalid-assignment] "Not enough values to unpack (expected 3, got 2)"
+    # error: [invalid-assignment] "Not enough values to unpack (expected 3, got 2)"
     a, b, c = arg
     reveal_type(a)  # revealed: int
     reveal_type(b)  # revealed: bytes | str
@@ -536,6 +538,7 @@ for a, b in ((1, 2), ("a", "b")):
 # error: "Object of type `Literal[1]` is not iterable"
 # error: "Object of type `Literal[2]` is not iterable"
 # error: "Object of type `Literal[4]` is not iterable"
+# error: [invalid-assignment] "Not enough values to unpack (expected 2, got 1)"
 for a, b in (1, 2, (3, "a"), 4, (5, "b"), "c"):
     reveal_type(a)  # revealed: Unknown | Literal[3, 5] | LiteralString
     reveal_type(b)  # revealed: Unknown | Literal["a", "b"]

--- a/crates/red_knot_python_semantic/src/types/display.rs
+++ b/crates/red_knot_python_semantic/src/types/display.rs
@@ -324,6 +324,12 @@ impl<'db> TypeArrayDisplay<'db> for Vec<Type<'db>> {
     }
 }
 
+impl<'db> TypeArrayDisplay<'db> for [Type<'db>] {
+    fn display(&self, db: &'db dyn Db) -> DisplayTypeArray {
+        DisplayTypeArray { types: self, db }
+    }
+}
+
 pub(crate) struct DisplayTypeArray<'b, 'db> {
     types: &'b [Type<'db>],
     db: &'db dyn Db,


### PR DESCRIPTION
## Summary

Part of #13773 

This PR adds diagnostics when there is a length mismatch during unpacking between the number of target expressions and the number of types for the unpack value expression.

There are 3 cases of diagnostics here where the first two occurs when there isn't a starred expression and the last one occurs when there's a starred expression:
1. Number of target expressions is **less** than the number of types that needs to be unpacked
2. Number of target expressions is **greater** then the number of types that needs to be unpacked
3. When there's a starred expression as one of the target expression and the number of target expressions is greater than the number of types

Examples for all each of the above cases:
```py
# red-knot: Too many values to unpack (expected 2, got 3) [lint:invalid-assignment]
a, b = (1, 2, 3)

# red-knot: Not enough values to unpack (expected 2, got 1) [lint:invalid-assignment]
a, b = (1,)

# red-knot: Not enough values to unpack (expected 3 or more, got 2) [lint:invalid-assignment]
a, *b, c, d = (1, 2)
```

The (3) case is a bit special because it uses a distinct wording "expected n or more" instead of "expected n" because of the starred expression.

### Location

The diagnostic location is the target expression that's being unpacked. For nested targets, the location will be the nested expression. For example:

```py
(a, (b, c), d) = (1, (2, 3, 4), 5)
#   ^^^^^^
#   red-knot: Too many values to unpack (expected 2, got 3) [lint:invalid-assignment]
```

For future improvements, it would be useful to show the context for why this unpacking failed. For example, for why the expected number of targets is `n`, we can highlight the relevant elements for the value expression.

In the **ecosystem**, **Pyright** uses the target expressions for location while **mypy** uses the value expression for the location. For example:

```py
if 1:
#          mypy: Too many values to unpack (2 expected, 3 provided)  [misc]
#          vvvvvvvvv
	a, b = (1, 2, 3)
#   ^^^^
#   Pyright: Expression with type "tuple[Literal[1], Literal[2], Literal[3]]" cannot be assigned to target tuple
#     Type "tuple[Literal[1], Literal[2], Literal[3]]" is incompatible with target tuple
#       Tuple size mismatch; expected 2 but received 3 [reportAssignmentType]
#   red-knot: Too many values to unpack (expected 2, got 3) [lint:invalid-assignment]
```

## Test Plan

Update existing test cases TODO with the error directives.
