### PR TITLE
Fix type subscript on older python versions

### DIFF
--- a/python/ruff/__main__.py
+++ b/python/ruff/__main__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import sys
 import sysconfig


### PR DESCRIPTION
## Summary

Python versions before Python 3.9 don't have subscriptable containers like `list`, which is being used in the annotation of `get_last_three_path_parts` here.  I believe Ruff supports Python 3.7 and Python 3.8?  In that case this needs to either use the container from the `typing` module, or use deferred annotations with `from __future__ import annotations` like I'm proposing here

Introduced by https://github.com/astral-sh/ruff/commit/60a2dc53e7b4407c3c0c14093fd8542879997ca8

## Test Plan

Currently the code path in `find_ruff_bin` that defines `get_last_three_path_parts` doesn't work on Python 3.8 or 3.9, it throws this:

```
>>> ruff.__main__.find_ruff_bin()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/aaron/miniconda3/envs/symforce/lib/python3.8/site-packages/ruff/__main__.py", line 77, in find_ruff_bin
    raise FileNotFoundError(scripts_path)
FileNotFoundError: /home/aaron/miniconda3/envs/symforce/bin/ruff
```

With this change it does work