### PR TITLE
Add `invalid-ignore-comment` rule

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/suppressions/knot-ignore.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/suppressions/knot-ignore.md
@@ -117,6 +117,7 @@ a = 10 / 0  # knot: ignore[division-by-zero,]
 
 ```py
 # error: [division-by-zero]
+# error: [invalid-ignore-comment] "Invalid `knot: ignore` comment: expected a alphanumeric character or `-` or `_` as code"
 a = 10 / 0  # knot: ignore[*-*]
 ```
 
@@ -138,7 +139,16 @@ future.
 
 ```py
 # error: [unresolved-reference]
+# error: [invalid-ignore-comment] "Invalid `knot: ignore` comment: expected a comma separating the rule codes"
 a = x / 0  # knot: ignore[division-by-zero unresolved-reference]
+```
+
+## Missing closing bracket
+
+```py
+# error: [unresolved-reference] "Name `x` used when not defined"
+# error: [invalid-ignore-comment] "Invalid `knot: ignore` comment: expected a comma separating the rule codes"
+a = x / 2  # knot: ignore[unresolved-reference
 ```
 
 ## Empty codes

--- a/crates/red_knot_python_semantic/resources/mdtest/suppressions/type-ignore.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/suppressions/type-ignore.md
@@ -110,6 +110,7 @@ a = test \
 
 ```py
 # error: [unresolved-reference]
+# error: [invalid-ignore-comment]
 a = test + 2  # type: ignoree
 ```
 

--- a/crates/red_knot_python_semantic/src/lib.rs
+++ b/crates/red_knot_python_semantic/src/lib.rs
@@ -3,7 +3,7 @@ use std::hash::BuildHasherDefault;
 use rustc_hash::FxHasher;
 
 use crate::lint::{LintRegistry, LintRegistryBuilder};
-use crate::suppression::{UNKNOWN_RULE, UNUSED_IGNORE_COMMENT};
+use crate::suppression::{INVALID_IGNORE_COMMENT, UNKNOWN_RULE, UNUSED_IGNORE_COMMENT};
 pub use db::Db;
 pub use module_name::ModuleName;
 pub use module_resolver::{resolve_module, system_module_search_paths, KnownModule, Module};
@@ -50,4 +50,5 @@ pub fn register_lints(registry: &mut LintRegistryBuilder) {
     types::register_lints(registry);
     registry.register_lint(&UNUSED_IGNORE_COMMENT);
     registry.register_lint(&UNKNOWN_RULE);
+    registry.register_lint(&INVALID_IGNORE_COMMENT);
 }


### PR DESCRIPTION
## Summary

Red Knot skips over `type: ignore` and `knot: ignore` comments that are syntatically incorrect. This can lead to usless
wana be ignore comments lingering in the code base or confusion when users don't understand why their ignore comment doesn't work. 

This PR adds a new `invalid-ignore-comment` rule that flags ignore comments that are simply incorrect. 


## Design questions

The rule flags invalid `type: ignore[code code]` comments even though Red Knot itself ignores the code portion of it. I think this is the correct behavior because Red Knot would ignore an invalid `type: ignore` comment. This way users at least know that Red Knot doesn't understand it. However, there's an argument that we shouldn't be opinionated about ignore comments from other tools.

I think the "right" solution is adding an option to configure whether the `unused-ignore-comment` and `invalid-ignore-comment` should ignore `type: ignore` comments. If this turns out to be a problem in the future.

## Test Plan

Added mdtests
