### PR TITLE
Fix `RUF200` doc to have name and email in single object

### DIFF
--- a/crates/ruff_linter/src/rules/ruff/rules/invalid_pyproject_toml.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/invalid_pyproject_toml.rs
@@ -21,8 +21,7 @@ use ruff_macros::{derive_message_formats, ViolationMetadata};
 /// name = "crab"
 /// version = "1.0.0"
 /// authors = [
-///   { email = "ferris@example.org" },
-///   { name = "Ferris the Crab"}
+///   { name = "Ferris the Crab", email = "ferris@example.org" }
 /// ]
 /// ```
 ///


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary
Closes #14975 by modifying the docstring of the InvalidPyprojectToml rule.  Previously the docs were incorrectly stating that author name and emails must be individual items in the authors list, rather than part of a single object for each respective author.  

## Test Plan
This was a docstring change, no tests needed.
