### PR TITLE
B901 catches yields in subexprs and more sensitive B901

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_bugbear/B901.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_bugbear/B901.py
@@ -1,6 +1,6 @@
 """
 Should emit:
-B901 - on lines 9, 36
+B901 - on lines 9, 36, 56, 61, 72, 83, 87
 """
 
 
@@ -52,16 +52,16 @@ def not_broken5():
     yield inner()
 
 
-def not_broken6():
+def broken3():
     return (yield from [])
 
 
-def not_broken7():
+def broken4():
     x = yield from []
     return x
 
 
-def not_broken8():
+def not_broken6():
     x = None
 
     def inner(ex):
@@ -72,7 +72,19 @@ def not_broken8():
     return x
 
 
-class NotBroken9(object):
+class NotBroken7(object):
     def __await__(self):
         yield from function()
         return 42
+
+def broken5():
+    x = yield
+    print(x)
+    return 42
+
+def broken6():
+    if True:
+        return 42
+
+    for i in range(10):
+        (yield a for a in range(i))

--- a/crates/ruff_linter/src/rules/flake8_bugbear/snapshots/ruff_linter__rules__flake8_bugbear__tests__B901_B901.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/snapshots/ruff_linter__rules__flake8_bugbear__tests__B901_B901.py.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_bugbear/mod.rs
-snapshot_kind: text
 ---
 B901.py:9:9: B901 Using `yield` and `return {value}` in a generator function can lead to confusing behavior
    |
@@ -19,4 +18,46 @@ B901.py:36:5: B901 Using `yield` and `return {value}` in a generator function ca
    |     ^^^^^^^^^^^^^^^^ B901
 37 | 
 38 |     yield from not_broken()
+   |
+
+B901.py:56:5: B901 Using `yield` and `return {value}` in a generator function can lead to confusing behavior
+   |
+55 | def broken3():
+56 |     return (yield from [])
+   |     ^^^^^^^^^^^^^^^^^^^^^^ B901
+   |
+
+B901.py:61:5: B901 Using `yield` and `return {value}` in a generator function can lead to confusing behavior
+   |
+59 | def broken4():
+60 |     x = yield from []
+61 |     return x
+   |     ^^^^^^^^ B901
+   |
+
+B901.py:72:5: B901 Using `yield` and `return {value}` in a generator function can lead to confusing behavior
+   |
+71 |     inner((yield from []))
+72 |     return x
+   |     ^^^^^^^^ B901
+   |
+
+B901.py:83:5: B901 Using `yield` and `return {value}` in a generator function can lead to confusing behavior
+   |
+81 |     x = yield
+82 |     print(x)
+83 |     return 42
+   |     ^^^^^^^^^ B901
+84 | 
+85 | def broken6():
+   |
+
+B901.py:87:9: B901 Using `yield` and `return {value}` in a generator function can lead to confusing behavior
+   |
+85 | def broken6():
+86 |     if True:
+87 |         return 42
+   |         ^^^^^^^^^ B901
+88 | 
+89 |     for i in range(10):
    |


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary
Closes #14453 by updating the implementation of the B901 lint rule.  The changes ensure that:
	1.	The visitor now traverses all expressions within statements, ensuring yield expressions embedded are correctly flagged even if they are not the expression of an `ExprStmt`.
	2.     The rule now correctly identifies yield and yield from expressions when they appear as the right-hand side of assignment statements (e.g., x = yield or x = yield from []); this catches the case mentioned in the original issue by @AlexWaygood.
	3.     We still do not recurse into lambda expressions or nested function defs as these are evaluated separately.

Possible point of contention:
For the purposes of deciding whether or not to flag B901, the previous code basically treats `yield from []` as if it isn't a yield statement.  e.g. the following two examples did not flag B901 in the B901 snapshot tests:
```python
def broken3():
    return (yield from [])


def broken4():
    x = yield from []
    return x
```
In my opinion, code that yields from an empty iterable (along with a return) should flag B901, and I have modified it so that it does (and accordingly updated the tests).  The description of B901 in the docs say the following:

> The combination of yield and return can lead to confusing behavior, as the return statement will cause the generator to raise StopIteration with the value provided, rather than returning the value to the caller.

To me, this implies that regardless of the fact that `yield from []` is very predictable given the explicit empty iterable, that doesn't sidestep the lack of clarity present given both `return` and `yield from` being used in a single function.  If a user really wants to do this, they should have to suppress B901 imo.  

## Test Plan
I added the tests mentioned by @MichaReiser and @AlexWaygood in the original issue into `test/fixtures/flake8_bugbear/B901.py` and updated the related snapshot.

<!-- How was it tested? -->
