### PR TITLE
[red-knot] Avoid `Ranged` for definition target range

### DIFF
--- a/crates/red_knot_python_semantic/src/semantic_index/definition.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/definition.rs
@@ -465,8 +465,14 @@ pub enum DefinitionKind<'db> {
     TypeVarTuple(AstNodeRef<ast::TypeParamTypeVarTuple>),
 }
 
-impl Ranged for DefinitionKind<'_> {
-    fn range(&self) -> TextRange {
+impl DefinitionKind<'_> {
+    /// Returns the [`TextRange`] of the definition target.
+    ///
+    /// A definition target would mainly be the node representing the symbol being defined i.e.,
+    /// [`ast::ExprName`] or [`ast::Identifier`] but could also be other nodes.
+    ///
+    /// This is mainly used for logging and debugging purposes.
+    pub(crate) fn target_range(&self) -> TextRange {
         match self {
             DefinitionKind::Import(alias) => alias.range(),
             DefinitionKind::ImportFrom(import) => import.alias().range(),
@@ -490,9 +496,7 @@ impl Ranged for DefinitionKind<'_> {
             DefinitionKind::TypeVarTuple(type_var_tuple) => type_var_tuple.name.range(),
         }
     }
-}
 
-impl DefinitionKind<'_> {
     pub(crate) fn category(&self) -> DefinitionCategory {
         match self {
             // functions, classes, and imports always bind, and we consider them declarations

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -131,7 +131,7 @@ pub(crate) fn infer_definition_types<'db>(
     let file = definition.file(db);
     let _span = tracing::trace_span!(
         "infer_definition_types",
-        range = ?definition.kind(db).range(),
+        range = ?definition.kind(db).target_range(),
         file = %file.path(db)
     )
     .entered();
@@ -154,7 +154,7 @@ pub(crate) fn infer_deferred_types<'db>(
     let _span = tracing::trace_span!(
         "infer_deferred_types",
         definition = ?definition.as_id(),
-        range = ?definition.kind(db).range(),
+        range = ?definition.kind(db).target_range(),
         file = %file.path(db)
     )
     .entered();


### PR DESCRIPTION
## Summary

Ref: https://github.com/astral-sh/ruff/commit/3533d7f5b4617ae91bc5cc3c4d0bbef4677be431#r150651102

This PR removes the `Ranged` implementation on `DefinitionKind` and instead uses a method called `target_range` to avoid any confusion about what range this is for i.e., it's not the range of the node that represents the definition.
