### PR TITLE
[red-knot] Infer value expr for empty list / tuple target

### DIFF
--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -1826,11 +1826,14 @@ impl<'db> TypeInferenceBuilder<'db> {
         }
     }
 
-    /// Infer the definition type involved in a `target` expression.
+    /// Infer the definition types involved in a `target` expression.
     ///
     /// This is used for assignment statements, for statements, etc. with a single or multiple
     /// targets (unpacking).
-    // TODO: Remove the `value` argument once we handle all possible assignment targets.
+    ///
+    /// # Panics
+    ///
+    /// If the `value` is not a standalone expression.
     fn infer_target(&mut self, target: &ast::Expr, value: &ast::Expr) {
         match target {
             ast::Expr::Name(name) => self.infer_definition(name),
@@ -1838,6 +1841,9 @@ impl<'db> TypeInferenceBuilder<'db> {
             | ast::Expr::Tuple(ast::ExprTuple { elts, .. }) => {
                 for element in elts {
                     self.infer_target(element, value);
+                }
+                if elts.is_empty() {
+                    self.infer_standalone_expression(value);
                 }
             }
             _ => {

--- a/crates/red_knot_workspace/tests/check.rs
+++ b/crates/red_knot_workspace/tests/check.rs
@@ -207,14 +207,12 @@ impl SourceOrderVisitor<'_> for PullTypesVisitor<'_> {
                 for target in &assign.targets {
                     self.visit_target(target);
                 }
-                // TODO
-                //self.visit_expr(&assign.value);
+                self.visit_expr(&assign.value);
                 return;
             }
             Stmt::For(for_stmt) => {
                 self.visit_target(&for_stmt.target);
-                // TODO
-                //self.visit_expr(&for_stmt.iter);
+                self.visit_expr(&for_stmt.iter);
                 self.visit_body(&for_stmt.body);
                 self.visit_body(&for_stmt.orelse);
                 return;


### PR DESCRIPTION
## Summary

This PR resolves https://github.com/astral-sh/ruff/pull/15058#discussion_r1893868406 by inferring the value expression even if there are no targets in the list / tuple expression.

## Test Plan

Remove TODO from corpus tests, making sure it doesn't panic.
