### PR TITLE
Remove formatter incompatibility warning for ISC001

### DIFF
--- a/crates/ruff/tests/format.rs
+++ b/crates/ruff/tests/format.rs
@@ -877,7 +877,7 @@ indent-width = 2
 
 [lint]
 select = ["ALL"]
-ignore = ["D203", "D212"]
+ignore = ["D203", "D212", "ISC001"]
 
 [lint.isort]
 lines-after-imports = 3
@@ -890,6 +890,9 @@ split-on-trailing-comma = true
 inline-quotes = "single"
 docstring-quotes = "single"
 multiline-quotes = "single"
+
+[lint.flake8-implicit-str-concat]
+allow-multiline = false
 
 [format]
 skip-magic-trailing-comma = true
@@ -915,8 +918,9 @@ def say_hy(name: str):
     1 file reformatted
 
     ----- stderr -----
-    warning: The following rules may cause conflicts when used with the formatter: `COM812`, `ISC001`. To avoid unexpected behavior, we recommend disabling these rules, either by removing them from the `select` or `extend-select` configuration, or adding them to the `ignore` configuration.
+    warning: The following rule may cause conflicts when used with the formatter: `COM812`. To avoid unexpected behavior, we recommend disabling this rule, either by removing it from the `select` or `extend-select` configuration, or adding it to the `ignore` configuration.
     warning: The `format.indent-style="tab"` option is incompatible with `W191`, which lints against all uses of tabs. We recommend disabling these rules when using the formatter, which enforces a consistent indentation style. Alternatively, set the `format.indent-style` option to `"space"`.
+    warning: The `lint.flake8-implicit-str-concat.allow-multiline = false` option is incompatible with the formatter unless `ISC001` is enabled. We recommend enabling `ISC001` or setting `allow-multiline=true`.
     warning: The `format.indent-style="tab"` option is incompatible with `D206`, with requires space-based indentation. We recommend disabling these rules when using the formatter, which enforces a consistent indentation style. Alternatively, set the `format.indent-style` option to `"space"`.
     warning: The `flake8-quotes.inline-quotes="single"` option is incompatible with the formatter's `format.quote-style="double"`. We recommend disabling `Q000` and `Q003` when using the formatter, which enforces a consistent quote style. Alternatively, set both options to either `"single"` or `"double"`.
     warning: The `flake8-quotes.multiline-quotes="single"` option is incompatible with the formatter. We recommend disabling `Q001` when using the formatter, which enforces double quotes for multiline strings. Alternatively, set the `flake8-quotes.multiline-quotes` option to `"double"`.`
@@ -974,7 +978,7 @@ def say_hy(name: str):
     	print(f"Hy {name}")
 
     ----- stderr -----
-    warning: The following rules may cause conflicts when used with the formatter: `COM812`, `ISC001`. To avoid unexpected behavior, we recommend disabling these rules, either by removing them from the `select` or `extend-select` configuration, or adding them to the `ignore` configuration.
+    warning: The following rule may cause conflicts when used with the formatter: `COM812`. To avoid unexpected behavior, we recommend disabling this rule, either by removing it from the `select` or `extend-select` configuration, or adding it to the `ignore` configuration.
     warning: The `format.indent-style="tab"` option is incompatible with `W191`, which lints against all uses of tabs. We recommend disabling these rules when using the formatter, which enforces a consistent indentation style. Alternatively, set the `format.indent-style` option to `"space"`.
     warning: The `format.indent-style="tab"` option is incompatible with `D206`, with requires space-based indentation. We recommend disabling these rules when using the formatter, which enforces a consistent indentation style. Alternatively, set the `format.indent-style` option to `"space"`.
     warning: The `flake8-quotes.inline-quotes="single"` option is incompatible with the formatter's `format.quote-style="double"`. We recommend disabling `Q000` and `Q003` when using the formatter, which enforces a consistent quote style. Alternatively, set both options to either `"single"` or `"double"`.
@@ -1114,7 +1118,7 @@ def say_hy(name: str):
     ----- stderr -----
     warning: `incorrect-blank-line-before-class` (D203) and `no-blank-line-before-class` (D211) are incompatible. Ignoring `incorrect-blank-line-before-class`.
     warning: `multi-line-summary-first-line` (D212) and `multi-line-summary-second-line` (D213) are incompatible. Ignoring `multi-line-summary-second-line`.
-    warning: The following rules may cause conflicts when used with the formatter: `COM812`, `ISC001`. To avoid unexpected behavior, we recommend disabling these rules, either by removing them from the `select` or `extend-select` configuration, or adding them to the `ignore` configuration.
+    warning: The following rule may cause conflicts when used with the formatter: `COM812`. To avoid unexpected behavior, we recommend disabling this rule, either by removing it from the `select` or `extend-select` configuration, or adding it to the `ignore` configuration.
     ");
     Ok(())
 }

--- a/crates/ruff_linter/src/rules/flake8_implicit_str_concat/rules/implicit.rs
+++ b/crates/ruff_linter/src/rules/flake8_implicit_str_concat/rules/implicit.rs
@@ -34,21 +34,6 @@ use crate::Locator;
 /// ```python
 /// z = "The quick brown fox."
 /// ```
-///
-/// # Formatter compatibility
-/// Use of this rule alongside the [formatter] must be handled with care.
-/// Currently, the [formatter] can introduce new single-line implicitly
-/// concatenated strings, therefore we suggest rerunning the linter and
-/// [formatter] in the following order:
-/// 1. Run the linter with this rule (`ISC001`) disabled
-/// 2. Run the [formatter]
-/// 3. Rerun the linter with this rule (`ISC001`) enabled
-///
-/// This is one of very few cases where the [formatter] can produce code that
-/// contains lint violations. It is a known issue that should be resolved by the
-/// new 2025 style guide.
-///
-/// [formatter]:https://docs.astral.sh/ruff/formatter/
 #[derive(ViolationMetadata)]
 pub(crate) struct SingleLineImplicitStringConcatenation;
 
@@ -96,19 +81,13 @@ impl Violation for SingleLineImplicitStringConcatenation {
 /// ## Options
 /// - `lint.flake8-implicit-str-concat.allow-multiline`
 ///
-/// # Formatter compatibility
-/// Use of this rule alongside the [formatter] must be handled with care.
-/// Currently, the [formatter] can introduce new multi-line implicitly
-/// concatenated strings, therefore we suggest rerunning the linter and
-/// [formatter] in the following order:
+/// ## Formatter compatibility
+/// Using this rule with `allow-multiline = false` can be incompatible with the
+/// formatter because the [formatter] can introduce new multi-line implicitly
+/// concatenated strings. We recommend to either:
 ///
-/// 1. Run the linter with this rule (`ISC002`) disabled
-/// 2. Run the [formatter]
-/// 3. Rerun the linter with this rule (`ISC002`) enabled
-///
-/// This is one of very few cases where the [formatter] can produce code that
-/// contains lint violations. It is a known issue that should be resolved by the
-/// new 2025 style guide.
+/// * Enable `ISC001` to disallow all implicit concatenated strings
+/// * Setting `allow-multiline = true`
 ///
 /// [PEP 8]: https://peps.python.org/pep-0008/#maximum-line-length
 /// [formatter]:https://docs.astral.sh/ruff/formatter/

--- a/docs/formatter.md
+++ b/docs/formatter.md
@@ -330,8 +330,7 @@ When using Ruff as a formatter, we recommend avoiding the following lint rules:
 - [`avoidable-escaped-quote`](rules/avoidable-escaped-quote.md) (`Q003`)
 - [`missing-trailing-comma`](rules/missing-trailing-comma.md) (`COM812`)
 - [`prohibited-trailing-comma`](rules/prohibited-trailing-comma.md) (`COM819`)
-- [`single-line-implicit-string-concatenation`](rules/single-line-implicit-string-concatenation.md) (`ISC001`)
-- [`multi-line-implicit-string-concatenation`](rules/multi-line-implicit-string-concatenation.md) (`ISC002`)
+- [`multi-line-implicit-string-concatenation`](rules/multi-line-implicit-string-concatenation.md) (`ISC002`) if used without `ISC001` and `flake8-implicit-str-concat.allow-multiline = false`
 
 While the [`line-too-long`](rules/line-too-long.md) (`E501`) rule _can_ be used alongside the
 formatter, the formatter only makes a best-effort attempt to wrap lines at the configured


### PR DESCRIPTION
## Summary

Remove the formatter incompatility warning from `ISC001` because the formatter now:

* Tries to join implicit concatenated strings that fit on a single line
* Preserves implicit concatenated strings as mulitline for the few cases where the automatic-joining isn't supported


This PR adds a warning for `lint.flake8-implicit-str-concat.allow-multiline = false` if `ISC001` is disabled. 
This is not a new incompatibility, it's just that we forgot to add it. 

## Test Plan

See CLI tests
