### PR TITLE
Rename `--current-directory` to `--project` in Red Knot benchmark script

### DIFF
--- a/scripts/knot_benchmark/src/benchmark/cases.py
+++ b/scripts/knot_benchmark/src/benchmark/cases.py
@@ -71,7 +71,7 @@ class Knot(Tool):
         assert len(project.include) < 2, "Knot doesn't support multiple source folders"
 
         if project.include:
-            command.extend(["--current-directory", project.include[0]])
+            command.extend(["--project", project.include[0]])
 
         command.extend(["--venv-path", str(venv.path)])
 


### PR DESCRIPTION
## Summary

I renamed `--current-directory` to `--project` to align with uv but forgot to update the red knot benchmark script.
The result was that all knot benchmarks completed in 5ms (instantely)

This PR updates the CLI option. 

## Test Plan

The benchmarks run successfully. 
