### PR TITLE
Preserve multiline implicit concatenated strings in docstring positions

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/string.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/string.py
@@ -195,3 +195,20 @@ r"aaaaaaaaa" r"bbbbbbbbbbbbbbbbbbbb"
     f"""aaaa{
     10}aaaaa""" fr"""bbbbbbbbbbbbbbbbbbbb"""
 )
+
+# In docstring positions
+def docstring():
+    (
+        r"aaaaaaaaa"
+        "bbbbbbbbbbbbbbbbbbbb"
+    )
+
+def docstring_flat():
+    (
+        r"aaaaaaaaa" r"bbbbbbbbbbbbbbbbbbbb"
+    )
+
+def docstring_flat_overlong():
+    (
+        r"aaaaaaaaa" r"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    )

--- a/crates/ruff_python_formatter/src/expression/expr_string_literal.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_string_literal.rs
@@ -1,13 +1,16 @@
-use ruff_formatter::FormatRuleWithOptions;
-use ruff_python_ast::{AnyNodeRef, ExprStringLiteral, StringLike};
-
+use crate::builders::parenthesize_if_expands;
 use crate::expression::parentheses::{
     in_parentheses_only_group, NeedsParentheses, OptionalParentheses,
 };
 use crate::other::string_literal::StringLiteralKind;
 use crate::prelude::*;
-use crate::string::implicit::FormatImplicitConcatenatedStringFlat;
+use crate::string::implicit::{
+    FormatImplicitConcatenatedStringExpanded, FormatImplicitConcatenatedStringFlat,
+    ImplicitConcatenatedLayout,
+};
 use crate::string::{implicit::FormatImplicitConcatenatedString, StringLikeExtensions};
+use ruff_formatter::FormatRuleWithOptions;
+use ruff_python_ast::{AnyNodeRef, ExprStringLiteral, StringLike};
 
 #[derive(Default)]
 pub struct FormatExprStringLiteral {
@@ -37,6 +40,23 @@ impl FormatNodeRule<ExprStringLiteral> for FormatExprStringLiteral {
                 {
                     format_flat.set_docstring(self.kind.is_docstring());
                     return format_flat.fmt(f);
+                }
+
+                // ```py
+                // def test():
+                // (
+                //      r"a"
+                //      "b"
+                // )
+                // ```
+                if self.kind.is_docstring() {
+                    return parenthesize_if_expands(
+                        &FormatImplicitConcatenatedStringExpanded::new(
+                            item.into(),
+                            ImplicitConcatenatedLayout::Multipart,
+                        ),
+                    )
+                    .fmt(f);
                 }
             }
 

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__string.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__string.py.snap
@@ -202,6 +202,23 @@ r"aaaaaaaaa" r"bbbbbbbbbbbbbbbbbbbb"
     f"""aaaa{
     10}aaaaa""" fr"""bbbbbbbbbbbbbbbbbbbb"""
 )
+
+# In docstring positions
+def docstring():
+    (
+        r"aaaaaaaaa"
+        "bbbbbbbbbbbbbbbbbbbb"
+    )
+
+def docstring_flat():
+    (
+        r"aaaaaaaaa" r"bbbbbbbbbbbbbbbbbbbb"
+    )
+
+def docstring_flat_overlong():
+    (
+        r"aaaaaaaaa" r"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    )
 ```
 
 ## Outputs
@@ -429,6 +446,22 @@ r"aaaaaaaaa" r"bbbbbbbbbbbbbbbbbbbb"
     10}aaaaa"""
     rf"""bbbbbbbbbbbbbbbbbbbb"""
 )
+
+
+# In docstring positions
+def docstring():
+    r"aaaaaaaaa" "bbbbbbbbbbbbbbbbbbbb"
+
+
+def docstring_flat():
+    r"aaaaaaaaa" r"bbbbbbbbbbbbbbbbbbbb"
+
+
+def docstring_flat_overlong():
+    (
+        r"aaaaaaaaa"
+        r"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    )
 ```
 
 
@@ -495,7 +528,7 @@ r"aaaaaaaaa" r"bbbbbbbbbbbbbbbbbbbb"
      ...
  
  
-@@ -193,16 +205,8 @@
+@@ -193,24 +205,19 @@
  
  r"aaaaaaaaa" r"bbbbbbbbbbbbbbbbbbbb"
  
@@ -514,6 +547,18 @@ r"aaaaaaaaa" r"bbbbbbbbbbbbbbbbbbbb"
 -    rf"""bbbbbbbbbbbbbbbbbbbb"""
 -)
 +(f"""aaaa{10}aaaaa""" rf"""bbbbbbbbbbbbbbbbbbbb""")
+ 
+ 
+ # In docstring positions
+ def docstring():
+-    r"aaaaaaaaa" "bbbbbbbbbbbbbbbbbbbb"
++    (
++        r"aaaaaaaaa"
++        "bbbbbbbbbbbbbbbbbbbb"
++    )
+ 
+ 
+ def docstring_flat():
 ```
 
 
@@ -741,6 +786,22 @@ r'aaaaaaaaa' r'bbbbbbbbbbbbbbbbbbbb'
     10}aaaaa"""
     rf"""bbbbbbbbbbbbbbbbbbbb"""
 )
+
+
+# In docstring positions
+def docstring():
+    r'aaaaaaaaa' 'bbbbbbbbbbbbbbbbbbbb'
+
+
+def docstring_flat():
+    r'aaaaaaaaa' r'bbbbbbbbbbbbbbbbbbbb'
+
+
+def docstring_flat_overlong():
+    (
+        r'aaaaaaaaa'
+        r'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+    )
 ```
 
 
@@ -807,7 +868,7 @@ r'aaaaaaaaa' r'bbbbbbbbbbbbbbbbbbbb'
      ...
  
  
-@@ -193,16 +205,8 @@
+@@ -193,24 +205,19 @@
  
  r'aaaaaaaaa' r'bbbbbbbbbbbbbbbbbbbb'
  
@@ -826,4 +887,16 @@ r'aaaaaaaaa' r'bbbbbbbbbbbbbbbbbbbb'
 -    rf"""bbbbbbbbbbbbbbbbbbbb"""
 -)
 +(f"""aaaa{10}aaaaa""" rf"""bbbbbbbbbbbbbbbbbbbb""")
+ 
+ 
+ # In docstring positions
+ def docstring():
+-    r'aaaaaaaaa' 'bbbbbbbbbbbbbbbbbbbb'
++    (
++        r'aaaaaaaaa'
++        'bbbbbbbbbbbbbbbbbbbb'
++    )
+ 
+ 
+ def docstring_flat():
 ```


### PR DESCRIPTION
## Summary
This is a bug fix for https://github.com/astral-sh/ruff/pull/13928

I noticed this when writing up the black deviations document and was very confused until I realized... Oh, it's a docstring!

We failed to preserve multiline implicit concatenated
strings that can't be automatically joined in docstring positions:

```py
def test():
  (
     r"This is a docstring"
     "and Ruff can't automatically join it"
  )
```

## Test plan
Added formatter tests
