### PR TITLE
Autofix for `none-not-at-end-of-union (RUF036)`

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/ruff/RUF036.py
+++ b/crates/ruff_linter/resources/test/fixtures/ruff/RUF036.py
@@ -33,6 +33,22 @@ def func7() -> U[
     ...
 
 
+def func8(x: None | U[None ,int]):
+    ...
+
+
+def func9(x: int | (str | None) | list):
+    ...
+
+
+def func10(x: U[int, U[None, list | set]]):
+    ...
+
+
+def func11(x: None | int) -> None | int:
+    ...
+
+
 # Ok
 def good_func1(arg: int | None): 
     ...

--- a/crates/ruff_linter/resources/test/fixtures/ruff/RUF036.py
+++ b/crates/ruff_linter/resources/test/fixtures/ruff/RUF036.py
@@ -9,10 +9,6 @@ def func2() -> None | int:
     ...
 
 
-def func2() -> None | int: 
-    ...
-
-
 def func3(arg: None | None | int): 
     ...
 

--- a/crates/ruff_linter/resources/test/fixtures/ruff/RUF036.py
+++ b/crates/ruff_linter/resources/test/fixtures/ruff/RUF036.py
@@ -9,6 +9,10 @@ def func2() -> None | int:
     ...
 
 
+def func2() -> None | int: 
+    ...
+
+
 def func3(arg: None | None | int): 
     ...
 
@@ -22,6 +26,14 @@ def func5() -> U[None, int]:
 
 
 def func6(arg: U[None, None, int]): 
+    ...
+
+
+def func7() -> U[
+    None,
+    # comment
+    int
+]: 
     ...
 
 

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF036_RUF036.py.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF036_RUF036.py.snap
@@ -38,10 +38,18 @@ RUF036.py:8:16: RUF036 [*] `None` not at the end of the type annotation.
 10 10 | 
 11 11 | 
 
-RUF036.py:12:16: RUF036 [*] `None` not at the end of the type annotation.
+RUF036.py:12:16: RUF036 `None` not at the end of the type annotation.
    |
-12 | def func2() -> None | int: 
+12 | def func3(arg: None | None | int): 
    |                ^^^^ RUF036
+13 |     ...
+   |
+   = help: Move `None` to the end of the type annotation
+
+RUF036.py:12:23: RUF036 [*] `None` not at the end of the type annotation.
+   |
+12 | def func3(arg: None | None | int): 
+   |                       ^^^^ RUF036
 13 |     ...
    |
    = help: Move `None` to the end of the type annotation
@@ -50,24 +58,16 @@ RUF036.py:12:16: RUF036 [*] `None` not at the end of the type annotation.
 9  9  |     ...
 10 10 | 
 11 11 | 
-12    |-def func2() -> None | int: 
-   12 |+def func2() -> int | None: 
+12    |-def func3(arg: None | None | int): 
+   12 |+def func3(arg: int | None): 
 13 13 |     ...
 14 14 | 
 15 15 | 
 
-RUF036.py:16:16: RUF036 `None` not at the end of the type annotation.
+RUF036.py:16:18: RUF036 [*] `None` not at the end of the type annotation.
    |
-16 | def func3(arg: None | None | int): 
-   |                ^^^^ RUF036
-17 |     ...
-   |
-   = help: Move `None` to the end of the type annotation
-
-RUF036.py:16:23: RUF036 [*] `None` not at the end of the type annotation.
-   |
-16 | def func3(arg: None | None | int): 
-   |                       ^^^^ RUF036
+16 | def func4(arg: U[None, int]): 
+   |                  ^^^^ RUF036
 17 |     ...
    |
    = help: Move `None` to the end of the type annotation
@@ -76,15 +76,15 @@ RUF036.py:16:23: RUF036 [*] `None` not at the end of the type annotation.
 13 13 |     ...
 14 14 | 
 15 15 | 
-16    |-def func3(arg: None | None | int): 
-   16 |+def func3(arg: int | None): 
+16    |-def func4(arg: U[None, int]): 
+   16 |+def func4(arg: U[int, None]): 
 17 17 |     ...
 18 18 | 
 19 19 | 
 
 RUF036.py:20:18: RUF036 [*] `None` not at the end of the type annotation.
    |
-20 | def func4(arg: U[None, int]): 
+20 | def func5() -> U[None, int]: 
    |                  ^^^^ RUF036
 21 |     ...
    |
@@ -94,16 +94,24 @@ RUF036.py:20:18: RUF036 [*] `None` not at the end of the type annotation.
 17 17 |     ...
 18 18 | 
 19 19 | 
-20    |-def func4(arg: U[None, int]): 
-   20 |+def func4(arg: U[int, None]): 
+20    |-def func5() -> U[None, int]: 
+   20 |+def func5() -> U[int, None]: 
 21 21 |     ...
 22 22 | 
 23 23 | 
 
-RUF036.py:24:18: RUF036 [*] `None` not at the end of the type annotation.
+RUF036.py:24:18: RUF036 `None` not at the end of the type annotation.
    |
-24 | def func5() -> U[None, int]: 
+24 | def func6(arg: U[None, None, int]): 
    |                  ^^^^ RUF036
+25 |     ...
+   |
+   = help: Move `None` to the end of the type annotation
+
+RUF036.py:24:24: RUF036 [*] `None` not at the end of the type annotation.
+   |
+24 | def func6(arg: U[None, None, int]): 
+   |                        ^^^^ RUF036
 25 |     ...
    |
    = help: Move `None` to the end of the type annotation
@@ -112,56 +120,30 @@ RUF036.py:24:18: RUF036 [*] `None` not at the end of the type annotation.
 21 21 |     ...
 22 22 | 
 23 23 | 
-24    |-def func5() -> U[None, int]: 
-   24 |+def func5() -> U[int, None]: 
+24    |-def func6(arg: U[None, None, int]): 
+   24 |+def func6(arg: U[int, None]): 
 25 25 |     ...
 26 26 | 
 27 27 | 
 
-RUF036.py:28:18: RUF036 `None` not at the end of the type annotation.
+RUF036.py:29:5: RUF036 [*] `None` not at the end of the type annotation.
    |
-28 | def func6(arg: U[None, None, int]): 
-   |                  ^^^^ RUF036
-29 |     ...
-   |
-   = help: Move `None` to the end of the type annotation
-
-RUF036.py:28:24: RUF036 [*] `None` not at the end of the type annotation.
-   |
-28 | def func6(arg: U[None, None, int]): 
-   |                        ^^^^ RUF036
-29 |     ...
-   |
-   = help: Move `None` to the end of the type annotation
-
-ℹ Safe fix
-25 25 |     ...
-26 26 | 
-27 27 | 
-28    |-def func6(arg: U[None, None, int]): 
-   28 |+def func6(arg: U[int, None]): 
-29 29 |     ...
-30 30 | 
-31 31 | 
-
-RUF036.py:33:5: RUF036 [*] `None` not at the end of the type annotation.
-   |
-32 | def func7() -> U[
-33 |     None,
+28 | def func7() -> U[
+29 |     None,
    |     ^^^^ RUF036
-34 |     # comment
-35 |     int
+30 |     # comment
+31 |     int
    |
    = help: Move `None` to the end of the type annotation
 
 ℹ Unsafe fix
-30 30 | 
-31 31 | 
-32 32 | def func7() -> U[
-33    |-    None,
-34    |-    # comment
-35    |-    int
-   33 |+    int, None
-36 34 | ]: 
-37 35 |     ...
-38 36 |
+26 26 | 
+27 27 | 
+28 28 | def func7() -> U[
+29    |-    None,
+30    |-    # comment
+31    |-    int
+   29 |+    int, None
+32 30 | ]: 
+33 31 |     ...
+34 32 |

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF036_RUF036.py.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF036_RUF036.py.snap
@@ -146,4 +146,102 @@ RUF036.py:29:5: RUF036 [*] `None` not at the end of the type annotation.
    29 |+    int, None
 32 30 | ]: 
 33 31 |     ...
-34 32 |
+34 32 | 
+
+RUF036.py:36:14: RUF036 `None` not at the end of the type annotation.
+   |
+36 | def func8(x: None | U[None ,int]):
+   |              ^^^^ RUF036
+37 |     ...
+   |
+   = help: Move `None` to the end of the type annotation
+
+RUF036.py:36:23: RUF036 [*] `None` not at the end of the type annotation.
+   |
+36 | def func8(x: None | U[None ,int]):
+   |                       ^^^^ RUF036
+37 |     ...
+   |
+   = help: Move `None` to the end of the type annotation
+
+ℹ Safe fix
+33 33 |     ...
+34 34 | 
+35 35 | 
+36    |-def func8(x: None | U[None ,int]):
+   36 |+def func8(x: int | None):
+37 37 |     ...
+38 38 | 
+39 39 | 
+
+RUF036.py:40:27: RUF036 [*] `None` not at the end of the type annotation.
+   |
+40 | def func9(x: int | (str | None) | list):
+   |                           ^^^^ RUF036
+41 |     ...
+   |
+   = help: Move `None` to the end of the type annotation
+
+ℹ Safe fix
+37 37 |     ...
+38 38 | 
+39 39 | 
+40    |-def func9(x: int | (str | None) | list):
+   40 |+def func9(x: int | str | list | None):
+41 41 |     ...
+42 42 | 
+43 43 | 
+
+RUF036.py:44:24: RUF036 [*] `None` not at the end of the type annotation.
+   |
+44 | def func10(x: U[int, U[None, list | set]]):
+   |                        ^^^^ RUF036
+45 |     ...
+   |
+   = help: Move `None` to the end of the type annotation
+
+ℹ Safe fix
+41 41 |     ...
+42 42 | 
+43 43 | 
+44    |-def func10(x: U[int, U[None, list | set]]):
+   44 |+def func10(x: U[int, list, set, None]):
+45 45 |     ...
+46 46 | 
+47 47 | 
+
+RUF036.py:48:15: RUF036 [*] `None` not at the end of the type annotation.
+   |
+48 | def func11(x: None | int) -> None | int:
+   |               ^^^^ RUF036
+49 |     ...
+   |
+   = help: Move `None` to the end of the type annotation
+
+ℹ Safe fix
+45 45 |     ...
+46 46 | 
+47 47 | 
+48    |-def func11(x: None | int) -> None | int:
+   48 |+def func11(x: int | None) -> None | int:
+49 49 |     ...
+50 50 | 
+51 51 | 
+
+RUF036.py:48:30: RUF036 [*] `None` not at the end of the type annotation.
+   |
+48 | def func11(x: None | int) -> None | int:
+   |                              ^^^^ RUF036
+49 |     ...
+   |
+   = help: Move `None` to the end of the type annotation
+
+ℹ Safe fix
+45 45 |     ...
+46 46 | 
+47 47 | 
+48    |-def func11(x: None | int) -> None | int:
+   48 |+def func11(x: None | int) -> int | None:
+49 49 |     ...
+50 50 | 
+51 51 |

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF036_RUF036.py.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF036_RUF036.py.snap
@@ -2,58 +2,166 @@
 source: crates/ruff_linter/src/rules/ruff/mod.rs
 snapshot_kind: text
 ---
-RUF036.py:4:16: RUF036 `None` not at the end of the type annotation.
+RUF036.py:4:16: RUF036 [*] `None` not at the end of the type annotation.
   |
 4 | def func1(arg: None | int): 
   |                ^^^^ RUF036
 5 |     ...
   |
+  = help: Move `None` to the end of the type annotation
 
-RUF036.py:8:16: RUF036 `None` not at the end of the type annotation.
+ℹ Safe fix
+1 1 | from typing import Union as U
+2 2 | 
+3 3 | 
+4   |-def func1(arg: None | int): 
+  4 |+def func1(arg: int | None): 
+5 5 |     ...
+6 6 | 
+7 7 | 
+
+RUF036.py:8:16: RUF036 [*] `None` not at the end of the type annotation.
   |
 8 | def func2() -> None | int: 
   |                ^^^^ RUF036
 9 |     ...
   |
+  = help: Move `None` to the end of the type annotation
 
-RUF036.py:12:16: RUF036 `None` not at the end of the type annotation.
+ℹ Safe fix
+5 5 |     ...
+6 6 | 
+7 7 | 
+8   |-def func2() -> None | int: 
+  8 |+def func2() -> int | None: 
+9 9 |     ...
+10 10 | 
+11 11 | 
+
+RUF036.py:12:16: RUF036 [*] `None` not at the end of the type annotation.
    |
-12 | def func3(arg: None | None | int): 
+12 | def func2() -> None | int: 
    |                ^^^^ RUF036
 13 |     ...
    |
+   = help: Move `None` to the end of the type annotation
 
-RUF036.py:12:23: RUF036 `None` not at the end of the type annotation.
-   |
-12 | def func3(arg: None | None | int): 
-   |                       ^^^^ RUF036
-13 |     ...
-   |
+ℹ Safe fix
+9  9  |     ...
+10 10 | 
+11 11 | 
+12    |-def func2() -> None | int: 
+   12 |+def func2() -> int | None: 
+13 13 |     ...
+14 14 | 
+15 15 | 
 
-RUF036.py:16:18: RUF036 `None` not at the end of the type annotation.
+RUF036.py:16:16: RUF036 `None` not at the end of the type annotation.
    |
-16 | def func4(arg: U[None, int]): 
-   |                  ^^^^ RUF036
+16 | def func3(arg: None | None | int): 
+   |                ^^^^ RUF036
 17 |     ...
    |
+   = help: Move `None` to the end of the type annotation
 
-RUF036.py:20:18: RUF036 `None` not at the end of the type annotation.
+RUF036.py:16:23: RUF036 [*] `None` not at the end of the type annotation.
    |
-20 | def func5() -> U[None, int]: 
+16 | def func3(arg: None | None | int): 
+   |                       ^^^^ RUF036
+17 |     ...
+   |
+   = help: Move `None` to the end of the type annotation
+
+ℹ Safe fix
+13 13 |     ...
+14 14 | 
+15 15 | 
+16    |-def func3(arg: None | None | int): 
+   16 |+def func3(arg: int | None): 
+17 17 |     ...
+18 18 | 
+19 19 | 
+
+RUF036.py:20:18: RUF036 [*] `None` not at the end of the type annotation.
+   |
+20 | def func4(arg: U[None, int]): 
    |                  ^^^^ RUF036
 21 |     ...
    |
+   = help: Move `None` to the end of the type annotation
 
-RUF036.py:24:18: RUF036 `None` not at the end of the type annotation.
+ℹ Safe fix
+17 17 |     ...
+18 18 | 
+19 19 | 
+20    |-def func4(arg: U[None, int]): 
+   20 |+def func4(arg: U[int, None]): 
+21 21 |     ...
+22 22 | 
+23 23 | 
+
+RUF036.py:24:18: RUF036 [*] `None` not at the end of the type annotation.
    |
-24 | def func6(arg: U[None, None, int]): 
+24 | def func5() -> U[None, int]: 
    |                  ^^^^ RUF036
 25 |     ...
    |
+   = help: Move `None` to the end of the type annotation
 
-RUF036.py:24:24: RUF036 `None` not at the end of the type annotation.
+ℹ Safe fix
+21 21 |     ...
+22 22 | 
+23 23 | 
+24    |-def func5() -> U[None, int]: 
+   24 |+def func5() -> U[int, None]: 
+25 25 |     ...
+26 26 | 
+27 27 | 
+
+RUF036.py:28:18: RUF036 `None` not at the end of the type annotation.
    |
-24 | def func6(arg: U[None, None, int]): 
+28 | def func6(arg: U[None, None, int]): 
+   |                  ^^^^ RUF036
+29 |     ...
+   |
+   = help: Move `None` to the end of the type annotation
+
+RUF036.py:28:24: RUF036 [*] `None` not at the end of the type annotation.
+   |
+28 | def func6(arg: U[None, None, int]): 
    |                        ^^^^ RUF036
-25 |     ...
+29 |     ...
    |
+   = help: Move `None` to the end of the type annotation
+
+ℹ Safe fix
+25 25 |     ...
+26 26 | 
+27 27 | 
+28    |-def func6(arg: U[None, None, int]): 
+   28 |+def func6(arg: U[int, None]): 
+29 29 |     ...
+30 30 | 
+31 31 | 
+
+RUF036.py:33:5: RUF036 [*] `None` not at the end of the type annotation.
+   |
+32 | def func7() -> U[
+33 |     None,
+   |     ^^^^ RUF036
+34 |     # comment
+35 |     int
+   |
+   = help: Move `None` to the end of the type annotation
+
+ℹ Unsafe fix
+30 30 | 
+31 31 | 
+32 32 | def func7() -> U[
+33    |-    None,
+34    |-    # comment
+35    |-    int
+   33 |+    int, None
+36 34 | ]: 
+37 35 |     ...
+38 36 |

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF036_RUF036.pyi.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF036_RUF036.pyi.snap
@@ -2,15 +2,26 @@
 source: crates/ruff_linter/src/rules/ruff/mod.rs
 snapshot_kind: text
 ---
-RUF036.pyi:4:16: RUF036 `None` not at the end of the type annotation.
+RUF036.pyi:4:16: RUF036 [*] `None` not at the end of the type annotation.
   |
 4 | def func1(arg: None | int): ...
   |                ^^^^ RUF036
 5 | 
 6 | def func2() -> None | int: ...
   |
+  = help: Move `None` to the end of the type annotation
 
-RUF036.pyi:6:16: RUF036 `None` not at the end of the type annotation.
+ℹ Safe fix
+1 1 | from typing import Union as U
+2 2 | 
+3 3 | 
+4   |-def func1(arg: None | int): ...
+  4 |+def func1(arg: int | None): ...
+5 5 | 
+6 6 | def func2() -> None | int: ...
+7 7 | 
+
+RUF036.pyi:6:16: RUF036 [*] `None` not at the end of the type annotation.
   |
 4 | def func1(arg: None | int): ...
 5 | 
@@ -19,6 +30,17 @@ RUF036.pyi:6:16: RUF036 `None` not at the end of the type annotation.
 7 | 
 8 | def func3(arg: None | None | int): ...
   |
+  = help: Move `None` to the end of the type annotation
+
+ℹ Safe fix
+3 3 | 
+4 4 | def func1(arg: None | int): ...
+5 5 | 
+6   |-def func2() -> None | int: ...
+  6 |+def func2() -> int | None: ...
+7 7 | 
+8 8 | def func3(arg: None | None | int): ...
+9 9 | 
 
 RUF036.pyi:8:16: RUF036 `None` not at the end of the type annotation.
    |
@@ -29,8 +51,9 @@ RUF036.pyi:8:16: RUF036 `None` not at the end of the type annotation.
  9 | 
 10 | def func4(arg: U[None, int]): ...
    |
+   = help: Move `None` to the end of the type annotation
 
-RUF036.pyi:8:23: RUF036 `None` not at the end of the type annotation.
+RUF036.pyi:8:23: RUF036 [*] `None` not at the end of the type annotation.
    |
  6 | def func2() -> None | int: ...
  7 | 
@@ -39,8 +62,19 @@ RUF036.pyi:8:23: RUF036 `None` not at the end of the type annotation.
  9 | 
 10 | def func4(arg: U[None, int]): ...
    |
+   = help: Move `None` to the end of the type annotation
 
-RUF036.pyi:10:18: RUF036 `None` not at the end of the type annotation.
+ℹ Safe fix
+5 5 | 
+6 6 | def func2() -> None | int: ...
+7 7 | 
+8   |-def func3(arg: None | None | int): ...
+  8 |+def func3(arg: int | None): ...
+9 9 | 
+10 10 | def func4(arg: U[None, int]): ...
+11 11 | 
+
+RUF036.pyi:10:18: RUF036 [*] `None` not at the end of the type annotation.
    |
  8 | def func3(arg: None | None | int): ...
  9 | 
@@ -49,8 +83,19 @@ RUF036.pyi:10:18: RUF036 `None` not at the end of the type annotation.
 11 | 
 12 | def func5() -> U[None, int]: ...
    |
+   = help: Move `None` to the end of the type annotation
 
-RUF036.pyi:12:18: RUF036 `None` not at the end of the type annotation.
+ℹ Safe fix
+7  7  | 
+8  8  | def func3(arg: None | None | int): ...
+9  9  | 
+10    |-def func4(arg: U[None, int]): ...
+   10 |+def func4(arg: U[int, None]): ...
+11 11 | 
+12 12 | def func5() -> U[None, int]: ...
+13 13 | 
+
+RUF036.pyi:12:18: RUF036 [*] `None` not at the end of the type annotation.
    |
 10 | def func4(arg: U[None, int]): ...
 11 | 
@@ -59,6 +104,17 @@ RUF036.pyi:12:18: RUF036 `None` not at the end of the type annotation.
 13 | 
 14 | def func6(arg: U[None, None, int]): ...
    |
+   = help: Move `None` to the end of the type annotation
+
+ℹ Safe fix
+9  9  | 
+10 10 | def func4(arg: U[None, int]): ...
+11 11 | 
+12    |-def func5() -> U[None, int]: ...
+   12 |+def func5() -> U[int, None]: ...
+13 13 | 
+14 14 | def func6(arg: U[None, None, int]): ...
+15 15 | 
 
 RUF036.pyi:14:18: RUF036 `None` not at the end of the type annotation.
    |
@@ -69,8 +125,9 @@ RUF036.pyi:14:18: RUF036 `None` not at the end of the type annotation.
 15 | 
 16 | # Ok
    |
+   = help: Move `None` to the end of the type annotation
 
-RUF036.pyi:14:24: RUF036 `None` not at the end of the type annotation.
+RUF036.pyi:14:24: RUF036 [*] `None` not at the end of the type annotation.
    |
 12 | def func5() -> U[None, int]: ...
 13 | 
@@ -79,3 +136,14 @@ RUF036.pyi:14:24: RUF036 `None` not at the end of the type annotation.
 15 | 
 16 | # Ok
    |
+   = help: Move `None` to the end of the type annotation
+
+ℹ Safe fix
+11 11 | 
+12 12 | def func5() -> U[None, int]: ...
+13 13 | 
+14    |-def func6(arg: U[None, None, int]): ...
+   14 |+def func6(arg: U[int, None]): ...
+15 15 | 
+16 16 | # Ok
+17 17 | def good_func1(arg: int | None): ...


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Close #15136. Implement autofix for `none-not-at-end-of-union (RUF036)`

## Test Plan

<!-- How was it tested? -->

Existing and new tests