### PR TITLE
Fix docs highlight in `dict_iter_missing_items.rs`

### DIFF
--- a/crates/ruff_linter/src/rules/pylint/rules/dict_iter_missing_items.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/dict_iter_missing_items.rs
@@ -33,6 +33,7 @@ use crate::checkers::ast::Checker;
 ///
 /// for city, population in data.items():
 ///     print(f"{city} has population {population}.")
+/// ```
 ///
 /// ## Known problems
 /// If the dictionary key is a tuple, e.g.:


### PR DESCRIPTION
It used to be like this:
<img width="969" alt="Снимок экрана 2024-12-25 в 17 57 44" src="https://github.com/user-attachments/assets/b141b75d-71a7-4971-8e73-242839c44c6d" />
