### PR TITLE
[airflow]: extend moved names (AIR303)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/airflow/AIR303.py
+++ b/crates/ruff_linter/resources/test/fixtures/airflow/AIR303.py
@@ -3,6 +3,7 @@ from airflow.api.auth.backend.basic_auth import auth_current_user
 from airflow.auth.managers.fab.api.auth.backend import (
     kerberos_auth as backend_kerberos_auth,
 )
+from airflow.config_templates.default_celery import DEFAULT_CELERY_CONFIG
 from airflow.auth.managers.fab.fab_auth_manager import FabAuthManager
 from airflow.auth.managers.fab.security_manager import override as fab_override
 from airflow.www.security import FabAirflowSecurityManagerOverride
@@ -14,3 +15,5 @@ fab_override
 
 FabAuthManager
 FabAirflowSecurityManagerOverride
+
+DEFAULT_CELERY_CONFIG

--- a/crates/ruff_linter/src/rules/airflow/rules/moved_to_provider_in_3.rs
+++ b/crates/ruff_linter/src/rules/airflow/rules/moved_to_provider_in_3.rs
@@ -149,10 +149,20 @@ fn moved_to_provider(checker: &mut Checker, expr: &Expr, ranged: impl Ranged) {
                 ["airflow", "auth", "managers", "fab", "security_manager", "override", ..] => Some((
                     qualname.to_string(),
                     Replacement::ImportPathMoved{
-                        original_path: "airflow.auth.managers.fab.security_manager.override",
+                        original_path: "airflow.auth.managers.fab.security_managr.override",
                         new_path: "airflow.providers.fab.auth_manager.security_manager.override",
                         provider: "fab",
                         version: "1.0.0"
+                },
+                )),
+                // apache-airflow-providers-celery
+                ["airflow", "config_templates", "default_celery", "DEFAULT_CELERY_CONFIG"] => Some((
+                    qualname.to_string(),
+                    Replacement::ImportPathMoved{
+                        original_path: "airflow.config_templates.default_celery.DEFAULT_CELERY_CONFIG",
+                        new_path: "airflow.providers.celery.executors.default_celery.DEFAULT_CELERY_CONFIG",
+                        provider: "celery",
+                        version: "3.3.0"
                 },
                 )),
 

--- a/crates/ruff_linter/src/rules/airflow/rules/moved_to_provider_in_3.rs
+++ b/crates/ruff_linter/src/rules/airflow/rules/moved_to_provider_in_3.rs
@@ -111,7 +111,7 @@ fn moved_to_provider(checker: &mut Checker, expr: &Expr, ranged: impl Ranged) {
                         version: "1.0.0"
                     },
                 )),
-                ["airflow","auth","managers","fab","fab_auth_manager", "FabAuthManager"] => Some((
+                ["airflow", "auth", "managers", "fab", "fab_auth_manager", "FabAuthManager"] => Some((
                     qualname.to_string(),
                     Replacement::ProviderName{
                         name: "airflow.providers.fab.auth_manager.security_manager.FabAuthManager",
@@ -128,7 +128,7 @@ fn moved_to_provider(checker: &mut Checker, expr: &Expr, ranged: impl Ranged) {
                         version: "1.0.0"
                 },
                 )),
-                ["airflow", "api","auth","backend","kerberos_auth", ..] => Some((
+                ["airflow", "api", "auth", "backend", "kerberos_auth", ..] => Some((
                     qualname.to_string(),
                     Replacement::ImportPathMoved{
                         original_path:"airflow.api.auth.backend.kerberos_auth",
@@ -146,7 +146,7 @@ fn moved_to_provider(checker: &mut Checker, expr: &Expr, ranged: impl Ranged) {
                         version: "1.0.0"
                 },
                 )),
-                ["airflow","auth","managers","fab","security_manager","override", ..] => Some((
+                ["airflow", "auth", "managers", "fab", "security_manager", "override", ..] => Some((
                     qualname.to_string(),
                     Replacement::ImportPathMoved{
                         original_path: "airflow.auth.managers.fab.security_manager.override",

--- a/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR303_AIR303.py.snap
+++ b/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR303_AIR303.py.snap
@@ -2,73 +2,84 @@
 source: crates/ruff_linter/src/rules/airflow/mod.rs
 snapshot_kind: text
 ---
-AIR303.py:10:1: AIR303 Import path `airflow.api.auth.backend.basic_auth` is moved into `fab` provider in Airflow 3.0;
-   |
- 8 | from airflow.www.security import FabAirflowSecurityManagerOverride
- 9 | 
-10 | basic_auth, kerberos_auth
-   | ^^^^^^^^^^ AIR303
-11 | auth_current_user
-12 | backend_kerberos_auth
-   |
-   = help: Install `apache-airflow-provider-fab>=1.0.0` and import from `airflow.providers.fab.auth_manager.api.auth.backend.basic_auth` instead.
-
-AIR303.py:10:13: AIR303 Import path `airflow.api.auth.backend.kerberos_auth` is moved into `fab` provider in Airflow 3.0;
-   |
- 8 | from airflow.www.security import FabAirflowSecurityManagerOverride
- 9 | 
-10 | basic_auth, kerberos_auth
-   |             ^^^^^^^^^^^^^ AIR303
-11 | auth_current_user
-12 | backend_kerberos_auth
-   |
-   = help: Install `apache-airflow-provider-fab>=1.0.0` and import from `airflow.providers.fab.auth_manager.api.auth.backend.kerberos_auth` instead.
-
 AIR303.py:11:1: AIR303 Import path `airflow.api.auth.backend.basic_auth` is moved into `fab` provider in Airflow 3.0;
    |
-10 | basic_auth, kerberos_auth
-11 | auth_current_user
-   | ^^^^^^^^^^^^^^^^^ AIR303
-12 | backend_kerberos_auth
-13 | fab_override
+ 9 | from airflow.www.security import FabAirflowSecurityManagerOverride
+10 | 
+11 | basic_auth, kerberos_auth
+   | ^^^^^^^^^^ AIR303
+12 | auth_current_user
+13 | backend_kerberos_auth
    |
    = help: Install `apache-airflow-provider-fab>=1.0.0` and import from `airflow.providers.fab.auth_manager.api.auth.backend.basic_auth` instead.
 
-AIR303.py:12:1: AIR303 Import path `airflow.auth_manager.api.auth.backend.kerberos_auth` is moved into `fab` provider in Airflow 3.0;
+AIR303.py:11:13: AIR303 Import path `airflow.api.auth.backend.kerberos_auth` is moved into `fab` provider in Airflow 3.0;
    |
-10 | basic_auth, kerberos_auth
-11 | auth_current_user
-12 | backend_kerberos_auth
-   | ^^^^^^^^^^^^^^^^^^^^^ AIR303
-13 | fab_override
+ 9 | from airflow.www.security import FabAirflowSecurityManagerOverride
+10 | 
+11 | basic_auth, kerberos_auth
+   |             ^^^^^^^^^^^^^ AIR303
+12 | auth_current_user
+13 | backend_kerberos_auth
    |
    = help: Install `apache-airflow-provider-fab>=1.0.0` and import from `airflow.providers.fab.auth_manager.api.auth.backend.kerberos_auth` instead.
 
-AIR303.py:13:1: AIR303 Import path `airflow.auth.managers.fab.security_manager.override` is moved into `fab` provider in Airflow 3.0;
+AIR303.py:12:1: AIR303 Import path `airflow.api.auth.backend.basic_auth` is moved into `fab` provider in Airflow 3.0;
    |
-11 | auth_current_user
-12 | backend_kerberos_auth
-13 | fab_override
+11 | basic_auth, kerberos_auth
+12 | auth_current_user
+   | ^^^^^^^^^^^^^^^^^ AIR303
+13 | backend_kerberos_auth
+14 | fab_override
+   |
+   = help: Install `apache-airflow-provider-fab>=1.0.0` and import from `airflow.providers.fab.auth_manager.api.auth.backend.basic_auth` instead.
+
+AIR303.py:13:1: AIR303 Import path `airflow.auth_manager.api.auth.backend.kerberos_auth` is moved into `fab` provider in Airflow 3.0;
+   |
+11 | basic_auth, kerberos_auth
+12 | auth_current_user
+13 | backend_kerberos_auth
+   | ^^^^^^^^^^^^^^^^^^^^^ AIR303
+14 | fab_override
+   |
+   = help: Install `apache-airflow-provider-fab>=1.0.0` and import from `airflow.providers.fab.auth_manager.api.auth.backend.kerberos_auth` instead.
+
+AIR303.py:14:1: AIR303 Import path `airflow.auth.managers.fab.security_managr.override` is moved into `fab` provider in Airflow 3.0;
+   |
+12 | auth_current_user
+13 | backend_kerberos_auth
+14 | fab_override
    | ^^^^^^^^^^^^ AIR303
-14 | 
-15 | FabAuthManager
+15 | 
+16 | FabAuthManager
    |
    = help: Install `apache-airflow-provider-fab>=1.0.0` and import from `airflow.providers.fab.auth_manager.security_manager.override` instead.
 
-AIR303.py:15:1: AIR303 `airflow.auth.managers.fab.fab_auth_manager.FabAuthManager` is moved into `fab` provider in Airflow 3.0;
+AIR303.py:16:1: AIR303 `airflow.auth.managers.fab.fab_auth_manager.FabAuthManager` is moved into `fab` provider in Airflow 3.0;
    |
-13 | fab_override
-14 | 
-15 | FabAuthManager
+14 | fab_override
+15 | 
+16 | FabAuthManager
    | ^^^^^^^^^^^^^^ AIR303
-16 | FabAirflowSecurityManagerOverride
+17 | FabAirflowSecurityManagerOverride
    |
    = help: Install `apache-airflow-provider-fab>=1.0.0` and use `airflow.providers.fab.auth_manager.security_manager.FabAuthManager` instead.
 
-AIR303.py:16:1: AIR303 `airflow.www.security.FabAirflowSecurityManagerOverride` is moved into `fab` provider in Airflow 3.0;
+AIR303.py:17:1: AIR303 `airflow.www.security.FabAirflowSecurityManagerOverride` is moved into `fab` provider in Airflow 3.0;
    |
-15 | FabAuthManager
-16 | FabAirflowSecurityManagerOverride
+16 | FabAuthManager
+17 | FabAirflowSecurityManagerOverride
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR303
+18 | 
+19 | DEFAULT_CELERY_CONFIG
    |
    = help: Install `apache-airflow-provider-fab>=1.0.0` and use `airflow.providers.fab.auth_manager.security_manager.override.FabAirflowSecurityManagerOverride` instead.
+
+AIR303.py:19:1: AIR303 Import path `airflow.config_templates.default_celery.DEFAULT_CELERY_CONFIG` is moved into `celery` provider in Airflow 3.0;
+   |
+17 | FabAirflowSecurityManagerOverride
+18 | 
+19 | DEFAULT_CELERY_CONFIG
+   | ^^^^^^^^^^^^^^^^^^^^^ AIR303
+   |
+   = help: Install `apache-airflow-provider-celery>=3.3.0` and import from `airflow.providers.celery.executors.default_celery.DEFAULT_CELERY_CONFIG` instead.


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->


## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Many core Airflow features have been deprecated and moved to Airflow Providers since users might need to install an additional package (e.g., `apache-airflow-provider-fab==1.0.0`); a separate rule (AIR303) is created for this.

The following is the ones that has been moved to `apache-airflow-provider-celery==3.0.0`

* `airflow.config_templates.default_celery.DEFAULT_CELERY_CONFIG` → `airflow.providers.celery.executors.default_celery.DEFAULT_CELERY_CONFIG`


## Test Plan

<!-- How was it tested? -->

A test fixture has been included for the rule.