### PR TITLE
Fix `SyntaxError` in example replacement snippet in `nonlocal-without-binding`

### DIFF
--- a/crates/ruff_linter/src/rules/pylint/rules/nonlocal_without_binding.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/nonlocal_without_binding.rs
@@ -9,7 +9,7 @@ use ruff_macros::{derive_message_formats, ViolationMetadata};
 ///
 /// ## Example
 /// ```python
-/// class Foo:
+/// def foo():
 ///     def get_bar(self):
 ///         nonlocal bar
 ///         ...

--- a/crates/ruff_linter/src/rules/pylint/rules/nonlocal_without_binding.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/nonlocal_without_binding.rs
@@ -17,7 +17,7 @@ use ruff_macros::{derive_message_formats, ViolationMetadata};
 ///
 /// Use instead:
 /// ```python
-/// class Foo:
+/// def foo():
 ///     bar = 1
 ///
 ///     def get_bar(self):

--- a/crates/ruff_linter/src/rules/pylint/rules/nonlocal_without_binding.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/nonlocal_without_binding.rs
@@ -6,6 +6,7 @@ use ruff_macros::{derive_message_formats, ViolationMetadata};
 ///
 /// ## Why is this bad?
 /// `nonlocal` names must be bound to a name in an outer scope.
+/// Violating this rule leads to a `SyntaxError` at runtime.
 ///
 /// ## Example
 /// ```python


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Fixes #15154.

## Test Plan

Compiling the code.
