### PR TITLE
TD003: remove issue code length restriction

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_todos/TD003.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_todos/TD003.py
@@ -8,8 +8,8 @@
 # TODO: the link has an issue code of the minimum length
 # T-001
 
-# TODO: the link has an issue code of the maximum length
-# ABCDEFGHIJKL-001
+# TODO: the issue code can be arbitrarily long
+# ABCDEFGHIJKLMNOPQRSTUVWXYZ-001
 
 # TDO003 - errors
 # TODO: this comment has no
@@ -35,6 +35,3 @@ def foo(x):
 # foo # TODO: no link!
 
 # TODO: here's a TODO on the last line with no link
-
-# TODO: the link has an issue code beyond the maximum length
-# ABCDEFGHIJKLM-001

--- a/crates/ruff_linter/resources/test/fixtures/flake8_todos/TD003.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_todos/TD003.py
@@ -5,6 +5,12 @@
 # TODO: this comment has an issue
 # TDO-3870
 
+# TODO: the link has an issue code of the minimum length
+# T-001
+
+# TODO: the link has an issue code of the maximum length
+# ABCDEFGHIJKL-001
+
 # TDO003 - errors
 # TODO: this comment has no
 # link after it
@@ -29,3 +35,6 @@ def foo(x):
 # foo # TODO: no link!
 
 # TODO: here's a TODO on the last line with no link
+
+# TODO: the link has an issue code beyond the maximum length
+# ABCDEFGHIJKLM-001

--- a/crates/ruff_linter/src/rules/flake8_todos/rules/todos.rs
+++ b/crates/ruff_linter/src/rules/flake8_todos/rules/todos.rs
@@ -91,7 +91,7 @@ impl Violation for MissingTodoAuthor {
 /// # TODO(charlie): this comment has a 3-digit issue code
 /// # 003
 ///
-/// # TODO(charlie): this comment has an issue code of (up to) 6 characters, then digits
+/// # TODO(charlie): this comment has an issue code (matches the regex `[A-Z]+\-?\d+`)
 /// # SIXCHR-003
 /// ```
 #[derive(ViolationMetadata)]
@@ -226,9 +226,9 @@ impl Violation for MissingSpaceAfterTodoColon {
 
 static ISSUE_LINK_REGEX_SET: LazyLock<RegexSet> = LazyLock::new(|| {
     RegexSet::new([
-        r"^#\s*(http|https)://.*",  // issue link
-        r"^#\s*\d+$",               // issue code - like "003"
-        r"^#\s*[A-Z]{1,12}\-?\d+$", // issue code - like "TD003"
+        r"^#\s*(http|https)://.*", // issue link
+        r"^#\s*\d+$",              // issue code - like "003"
+        r"^#\s*[A-Z]+\-?\d+$",     // issue code - like "TD003"
     ])
     .unwrap()
 });

--- a/crates/ruff_linter/src/rules/flake8_todos/rules/todos.rs
+++ b/crates/ruff_linter/src/rules/flake8_todos/rules/todos.rs
@@ -226,9 +226,9 @@ impl Violation for MissingSpaceAfterTodoColon {
 
 static ISSUE_LINK_REGEX_SET: LazyLock<RegexSet> = LazyLock::new(|| {
     RegexSet::new([
-        r"^#\s*(http|https)://.*", // issue link
-        r"^#\s*\d+$",              // issue code - like "003"
-        r"^#\s*[A-Z]{1,6}\-?\d+$", // issue code - like "TD003"
+        r"^#\s*(http|https)://.*",  // issue link
+        r"^#\s*\d+$",               // issue code - like "003"
+        r"^#\s*[A-Z]{1,12}\-?\d+$", // issue code - like "TD003"
     ])
     .unwrap()
 });

--- a/crates/ruff_linter/src/rules/flake8_todos/snapshots/ruff_linter__rules__flake8_todos__tests__missing-todo-link_TD003.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_todos/snapshots/ruff_linter__rules__flake8_todos__tests__missing-todo-link_TD003.py.snap
@@ -46,15 +46,4 @@ TD003.py:37:3: TD003 Missing issue link on the line following this TODO
 36 | 
 37 | # TODO: here's a TODO on the last line with no link
    |   ^^^^ TD003
-38 | 
-39 | # TODO: the link has an issue code beyond the maximum length
-   |
-
-TD003.py:39:3: TD003 Missing issue link on the line following this TODO
-   |
-37 | # TODO: here's a TODO on the last line with no link
-38 | 
-39 | # TODO: the link has an issue code beyond the maximum length
-   |   ^^^^ TD003
-40 | # ABCDEFGHIJKLM-001
    |

--- a/crates/ruff_linter/src/rules/flake8_todos/snapshots/ruff_linter__rules__flake8_todos__tests__missing-todo-link_TD003.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_todos/snapshots/ruff_linter__rules__flake8_todos__tests__missing-todo-link_TD003.py.snap
@@ -2,48 +2,59 @@
 source: crates/ruff_linter/src/rules/flake8_todos/mod.rs
 snapshot_kind: text
 ---
-TD003.py:9:3: TD003 Missing issue link on the line following this TODO
+TD003.py:15:3: TD003 Missing issue link on the line following this TODO
    |
- 8 | # TDO003 - errors
- 9 | # TODO: this comment has no
+14 | # TDO003 - errors
+15 | # TODO: this comment has no
    |   ^^^^ TD003
-10 | # link after it
+16 | # link after it
    |
 
-TD003.py:12:3: TD003 Missing issue link on the line following this TODO
+TD003.py:18:3: TD003 Missing issue link on the line following this TODO
    |
-10 | # link after it
-11 | 
-12 | # TODO: here's a TODO with no link after it
+16 | # link after it
+17 | 
+18 | # TODO: here's a TODO with no link after it
    |   ^^^^ TD003
-13 | def foo(x):
-14 |     return x
-   |
-
-TD003.py:25:3: TD003 Missing issue link on the line following this TODO
-   |
-23 | # TDO-3870
-24 | 
-25 | # TODO: here's a TODO without an issue link
-   |   ^^^^ TD003
-26 | # TODO: followed by a new TODO with an issue link
-27 | # TDO-3870
-   |
-
-TD003.py:29:9: TD003 Missing issue link on the line following this TODO
-   |
-27 | # TDO-3870
-28 | 
-29 | # foo # TODO: no link!
-   |         ^^^^ TD003
-30 | 
-31 | # TODO: here's a TODO on the last line with no link
+19 | def foo(x):
+20 |     return x
    |
 
 TD003.py:31:3: TD003 Missing issue link on the line following this TODO
    |
-29 | # foo # TODO: no link!
+29 | # TDO-3870
 30 | 
-31 | # TODO: here's a TODO on the last line with no link
+31 | # TODO: here's a TODO without an issue link
    |   ^^^^ TD003
+32 | # TODO: followed by a new TODO with an issue link
+33 | # TDO-3870
+   |
+
+TD003.py:35:9: TD003 Missing issue link on the line following this TODO
+   |
+33 | # TDO-3870
+34 | 
+35 | # foo # TODO: no link!
+   |         ^^^^ TD003
+36 | 
+37 | # TODO: here's a TODO on the last line with no link
+   |
+
+TD003.py:37:3: TD003 Missing issue link on the line following this TODO
+   |
+35 | # foo # TODO: no link!
+36 | 
+37 | # TODO: here's a TODO on the last line with no link
+   |   ^^^^ TD003
+38 | 
+39 | # TODO: the link has an issue code beyond the maximum length
+   |
+
+TD003.py:39:3: TD003 Missing issue link on the line following this TODO
+   |
+37 | # TODO: here's a TODO on the last line with no link
+38 | 
+39 | # TODO: the link has an issue code beyond the maximum length
+   |   ^^^^ TD003
+40 | # ABCDEFGHIJKLM-001
    |


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

My company has issue codes longer than 6 characters, and I imagine we're not the only ones. The current maximum value of 6 characters seems arbitrary (please correct me if I'm missing something), so I chose the value of 12, since that would easily cover every issue code my company uses (and I sincerely doubt there are very many users using codes longer than this).

## Test Plan

I added some additional snapshot checks which cover the new boundary conditions.