### PR TITLE
[`flake8-type-checking`] Disable TC006 & TC007 in stub files

### DIFF
--- a/crates/ruff_linter/src/checkers/ast/analyze/bindings.rs
+++ b/crates/ruff_linter/src/checkers/ast/analyze/bindings.rs
@@ -77,7 +77,7 @@ pub(crate) fn bindings(checker: &mut Checker) {
                 checker.diagnostics.push(diagnostic);
             }
         }
-        if checker.enabled(Rule::UnquotedTypeAlias) {
+        if !checker.source_type.is_stub() && checker.enabled(Rule::UnquotedTypeAlias) {
             if let Some(diagnostics) =
                 flake8_type_checking::rules::unquoted_type_alias(checker, binding)
             {

--- a/crates/ruff_linter/src/checkers/ast/mod.rs
+++ b/crates/ruff_linter/src/checkers/ast/mod.rs
@@ -1282,7 +1282,7 @@ impl<'a> Visitor<'a> for Checker<'a> {
                         if let Some(arg) = args.next() {
                             self.visit_type_definition(arg);
 
-                            if self.enabled(Rule::RuntimeCastValue) {
+                            if !self.source_type.is_stub() && self.enabled(Rule::RuntimeCastValue) {
                                 flake8_type_checking::rules::runtime_cast_value(self, arg);
                             }
                         }


### PR DESCRIPTION
Fixes: #15176

## Summary

Neither of these rules make any sense in stub files. Technically TC007 should already not have triggered, due to the typing only context of the binding, but it's better to be explicit.

Keeping TC008 enabled on the other hand makes sense to me, although we could probably be more aggressive with unquoting in a typing runtime context.

## Test Plan

`cargo nextest run`
