### PR TITLE
[red-knot] Introduce type parameters for InstanceType

### DIFF
--- a/crates/red_knot_python_semantic/src/types/builder.rs
+++ b/crates/red_knot_python_semantic/src/types/builder.rs
@@ -26,7 +26,7 @@
 //!     eliminate the supertype from the intersection).
 //!   * An intersection containing two non-overlapping types should simplify to [`Type::Never`].
 
-use crate::types::{InstanceType, IntersectionType, KnownClass, Type, UnionType};
+use crate::types::{IntersectionType, KnownClass, Type, UnionType};
 use crate::{Db, FxOrderSet};
 use smallvec::SmallVec;
 

--- a/crates/red_knot_python_semantic/src/types/builder.rs
+++ b/crates/red_knot_python_semantic/src/types/builder.rs
@@ -246,8 +246,8 @@ impl<'db> InnerIntersectionBuilder<'db> {
         } else {
             // ~Literal[True] & bool = Literal[False]
             // ~AlwaysTruthy & bool = Literal[False]
-            if let Type::Instance(InstanceType { class }) = new_positive {
-                if class.is_known(db, KnownClass::Bool) {
+            if let Type::Instance(instance) = new_positive {
+                if instance.class(db).is_known(db, KnownClass::Bool) {
                     if let Some(new_type) = self
                         .negative
                         .iter()

--- a/crates/red_knot_python_semantic/src/types/display.rs
+++ b/crates/red_knot_python_semantic/src/types/display.rs
@@ -68,11 +68,11 @@ impl Display for DisplayRepresentation<'_> {
             Type::Any => f.write_str("Any"),
             Type::Never => f.write_str("Never"),
             Type::Unknown => f.write_str("Unknown"),
-            Type::Instance(InstanceType { class }) => {
-                let representation = match class.known(self.db) {
+            Type::Instance(instance) => {
+                let representation = match instance.class(self.db).known(self.db) {
                     Some(KnownClass::NoneType) => "None",
                     Some(KnownClass::NoDefaultType) => "NoDefault",
-                    _ => class.name(self.db),
+                    _ => instance.class(self.db).name(self.db),
                 };
                 f.write_str(representation)
             }

--- a/crates/red_knot_python_semantic/src/types/display.rs
+++ b/crates/red_knot_python_semantic/src/types/display.rs
@@ -8,8 +8,8 @@ use ruff_python_literal::escape::AsciiEscape;
 
 use crate::types::class_base::ClassBase;
 use crate::types::{
-    ClassLiteralType, IntersectionType, KnownClass, StringLiteralType,
-    SubclassOfType, Type, UnionType,
+    ClassLiteralType, IntersectionType, KnownClass, StringLiteralType, SubclassOfType, Type,
+    UnionType,
 };
 use crate::Db;
 use rustc_hash::FxHashMap;

--- a/crates/red_knot_python_semantic/src/types/display.rs
+++ b/crates/red_knot_python_semantic/src/types/display.rs
@@ -8,7 +8,7 @@ use ruff_python_literal::escape::AsciiEscape;
 
 use crate::types::class_base::ClassBase;
 use crate::types::{
-    ClassLiteralType, InstanceType, IntersectionType, KnownClass, StringLiteralType,
+    ClassLiteralType, IntersectionType, KnownClass, StringLiteralType,
     SubclassOfType, Type, UnionType,
 };
 use crate::Db;

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -1932,7 +1932,10 @@ impl<'db> TypeInferenceBuilder<'db> {
 
         // Handle various singletons.
         if let Type::Instance(instance) = annotation_ty {
-            if instance.class(self.db()).is_known(self.db(), KnownClass::SpecialForm) {
+            if instance
+                .class(self.db())
+                .is_known(self.db(), KnownClass::SpecialForm)
+            {
                 if let Some(name_expr) = target.as_name_expr() {
                     if let Some(known_instance) = KnownInstanceType::try_from_file_and_name(
                         self.db(),
@@ -1985,8 +1988,9 @@ impl<'db> TypeInferenceBuilder<'db> {
                 })
             }
             Type::Instance(instance) => {
-                if let Symbol::Type(class_member, boundness) =
-                    instance.class(self.db()).class_member(self.db(), op.in_place_dunder())
+                if let Symbol::Type(class_member, boundness) = instance
+                    .class(self.db())
+                    .class_member(self.db(), op.in_place_dunder())
                 {
                     let call = class_member.call(self.db(), &[target_type, value_type]);
                     let augmented_return_ty = match call
@@ -3500,9 +3504,14 @@ impl<'db> TypeInferenceBuilder<'db> {
             (Type::Instance(left), Type::Instance(right), op) => {
                 if left != right && right.is_subtype_of(self.db(), left) {
                     let reflected_dunder = op.reflected_dunder();
-                    let rhs_reflected = right.class(self.db()).class_member(self.db(), reflected_dunder);
+                    let rhs_reflected = right
+                        .class(self.db())
+                        .class_member(self.db(), reflected_dunder);
                     if !rhs_reflected.is_unbound()
-                        && rhs_reflected != left.class(self.db()).class_member(self.db(), reflected_dunder)
+                        && rhs_reflected
+                            != left
+                                .class(self.db())
+                                .class_member(self.db(), reflected_dunder)
                     {
                         return right_ty
                             .call_dunder(self.db(), reflected_dunder, &[right_ty, left_ty])
@@ -3529,8 +3538,9 @@ impl<'db> TypeInferenceBuilder<'db> {
                     if left == right {
                         None
                     } else {
-                        if let Symbol::Type(class_member, _) =
-                            right.class(self.db()).class_member(self.db(), op.reflected_dunder())
+                        if let Symbol::Type(class_member, _) = right
+                            .class(self.db())
+                            .class_member(self.db(), op.reflected_dunder())
                         {
                             class_member
                                 .call(self.db(), &[right_ty, left_ty])
@@ -3970,12 +3980,16 @@ impl<'db> TypeInferenceBuilder<'db> {
                 KnownClass::Bytes.to_instance(self.db()),
             ),
             (Type::Tuple(_), Type::Instance(instance))
-                if instance.class(self.db()).is_known(self.db(), KnownClass::VersionInfo) =>
+                if instance
+                    .class(self.db())
+                    .is_known(self.db(), KnownClass::VersionInfo) =>
             {
                 self.infer_binary_type_comparison(left, op, Type::version_info_tuple(self.db()))
             }
             (Type::Instance(instance), Type::Tuple(_))
-                if instance.class(self.db()).is_known(self.db(), KnownClass::VersionInfo) =>
+                if instance
+                    .class(self.db())
+                    .is_known(self.db(), KnownClass::VersionInfo) =>
             {
                 self.infer_binary_type_comparison(Type::version_info_tuple(self.db()), op, right)
             }
@@ -4189,12 +4203,16 @@ impl<'db> TypeInferenceBuilder<'db> {
             (
                 Type::Instance(instance),
                 Type::IntLiteral(_) | Type::BooleanLiteral(_) | Type::SliceLiteral(_),
-            ) if instance.class(self.db()).is_known(self.db(), KnownClass::VersionInfo) => self
-                .infer_subscript_expression_types(
+            ) if instance
+                .class(self.db())
+                .is_known(self.db(), KnownClass::VersionInfo) =>
+            {
+                self.infer_subscript_expression_types(
                     value_node,
                     Type::version_info_tuple(self.db()),
                     slice_ty,
-                ),
+                )
+            }
 
             // Ex) Given `("a", "b", "c", "d")[1]`, return `"b"`
             (Type::Tuple(tuple_ty), Type::IntLiteral(int)) if i32::try_from(int).is_ok() => {
@@ -4440,7 +4458,9 @@ impl<'db> TypeInferenceBuilder<'db> {
             },
             Some(Type::BooleanLiteral(b)) => SliceArg::Arg(Some(i32::from(b))),
             Some(Type::Instance(instance))
-                if instance.class(self.db()).is_known(self.db(), KnownClass::NoneType) =>
+                if instance
+                    .class(self.db())
+                    .is_known(self.db(), KnownClass::NoneType) =>
             {
                 SliceArg::Arg(None)
             }

--- a/crates/red_knot_python_semantic/src/types/narrow.rs
+++ b/crates/red_knot_python_semantic/src/types/narrow.rs
@@ -93,7 +93,7 @@ fn generate_classinfo_constraint<'db, F>(
     to_constraint: F,
 ) -> Option<Type<'db>>
 where
-    F: Fn(ClassLiteralType<'db>) -> Type<'db> + Copy,
+    F: Fn(&'db dyn Db, ClassLiteralType<'db>) -> Type<'db> + Copy,
 {
     match classinfo {
         Type::Tuple(tuple) => {
@@ -103,7 +103,7 @@ where
             }
             Some(builder.build())
         }
-        Type::ClassLiteral(class_literal_type) => Some(to_constraint(*class_literal_type)),
+        Type::ClassLiteral(class_literal_type) => Some(to_constraint(db, *class_literal_type)),
         _ => None,
     }
 }
@@ -431,10 +431,12 @@ impl<'db> NarrowingConstraintsBuilder<'db> {
 
                 let to_constraint = match function {
                     KnownConstraintFunction::IsInstance => {
-                        |class_literal: ClassLiteralType<'db>| Type::instance(class_literal.class)
+                        |db: &'db dyn Db, class_literal: ClassLiteralType<'db>| {
+                            Type::instance(db, class_literal.class)
+                        }
                     }
                     KnownConstraintFunction::IsSubclass => {
-                        |class_literal: ClassLiteralType<'db>| {
+                        |db: &'db dyn Db, class_literal: ClassLiteralType<'db>| {
                             Type::subclass_of(class_literal.class)
                         }
                     }

--- a/crates/red_knot_python_semantic/src/types/narrow.rs
+++ b/crates/red_knot_python_semantic/src/types/narrow.rs
@@ -436,7 +436,7 @@ impl<'db> NarrowingConstraintsBuilder<'db> {
                         }
                     }
                     KnownConstraintFunction::IsSubclass => {
-                        |db: &'db dyn Db, class_literal: ClassLiteralType<'db>| {
+                        |_db: &'db dyn Db, class_literal: ClassLiteralType<'db>| {
                             Type::subclass_of(class_literal.class)
                         }
                     }


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

This PR introduces type parameters to InstanceType, so an instance of type like `dict[str, str]` can be represented.

I'm curious for feedback if this is the right way to do it or if there is a better way!

## Test Plan

<!-- How was it tested? -->
