### PR TITLE
[airflow]: extend names moved from core to provider (AIR303)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/airflow/AIR303.py
+++ b/crates/ruff_linter/resources/test/fixtures/airflow/AIR303.py
@@ -6,7 +6,9 @@ from airflow.auth.managers.fab.api.auth.backend import (
 from airflow.auth.managers.fab.fab_auth_manager import FabAuthManager
 from airflow.auth.managers.fab.security_manager import override as fab_override
 from airflow.config_templates.default_celery import DEFAULT_CELERY_CONFIG
-from airflow.executors.celery_executor import app
+from airflow.executors.celery_executor import CeleryExecutor, app
+from airflow.executors.celery_kubernetes_executor import CeleryKubernetesExecutor
+from airflow.executors.dask_executor import DaskExecutor
 from airflow.executors.kubernetes_executor_types import (
     ALL_NAMESPACES,
     POD_EXECUTOR_DONE_KEY,
@@ -28,6 +30,11 @@ FabAirflowSecurityManagerOverride()
 # apache-airflow-providers-celery
 DEFAULT_CELERY_CONFIG
 app
+CeleryExecutor()
+CeleryKubernetesExecutor()
+
+# apache-airflow-providers-daskexecutor
+DaskExecutor()
 
 # apache-airflow-providers-common-sql
 ConnectorProtocol()

--- a/crates/ruff_linter/resources/test/fixtures/airflow/AIR303.py
+++ b/crates/ruff_linter/resources/test/fixtures/airflow/AIR303.py
@@ -109,6 +109,14 @@ from airflow.operators.sql import (
 )
 from airflow.operators.sql_branch_operator import BranchSqlOperator
 from airflow.operators.sqlite_operator import SqliteOperator
+from airflow.sensors.hive_partition_sensor import HivePartitionSensor
+from airflow.sensors.http_sensor import HttpSensor
+from airflow.sensors.metastore_partition_sensor import MetastorePartitionSensor
+from airflow.sensors.named_hive_partition_sensor import NamedHivePartitionSensor
+from airflow.sensors.s3_key_sensor import S3KeySensor
+from airflow.sensors.sql import SqlSensor
+from airflow.sensors.sql_sensor import SqlSensor2
+from airflow.sensors.web_hdfs_sensor import WebHdfsSensor
 from airflow.www.security import FabAirflowSecurityManagerOverride
 
 # apache-airflow-providers-fab
@@ -233,3 +241,11 @@ parse_boolean()
 BranchSQLOperator()
 BranchSqlOperator()
 SqliteOperator()
+HivePartitionSensor()
+HttpSensor()
+MetastorePartitionSensor()
+NamedHivePartitionSensor()
+S3KeySensor()
+SqlSensor()
+SqlSensor2()
+WebHdfsSensor()

--- a/crates/ruff_linter/resources/test/fixtures/airflow/AIR303.py
+++ b/crates/ruff_linter/resources/test/fixtures/airflow/AIR303.py
@@ -13,8 +13,31 @@ from airflow.executors.kubernetes_executor_types import (
     ALL_NAMESPACES,
     POD_EXECUTOR_DONE_KEY,
 )
+from airflow.hooks.base_hook import BaseHook
 from airflow.hooks.dbapi import ConnectorProtocol, DbApiHook
-from airflow.hooks.hive_hooks import HIVE_QUEUE_PRIORITIES
+from airflow.hooks.dbapi_hook import DbApiHook as DbApiHook2
+from airflow.hooks.docker_hook import DockerHook
+from airflow.hooks.druid_hook import DruidDbApiHook, DruidHook
+from airflow.hooks.hive_hooks import (
+    HIVE_QUEUE_PRIORITIES,
+    HiveCliHook,
+    HiveMetastoreHook,
+    HiveServer2Hook,
+)
+from airflow.hooks.http_hook import HttpHook
+from airflow.hooks.jdbc_hook import JdbcHook, jaydebeapi
+from airflow.hooks.mssql_hook import MsSqlHook
+from airflow.hooks.mysql_hook import MySqlHook
+from airflow.hooks.oracle_hook import OracleHook
+from airflow.hooks.pig_hook import PigCliHook
+from airflow.hooks.postgres_hook import PostgresHook
+from airflow.hooks.presto_hook import PrestoHook
+from airflow.hooks.S3_hook import S3Hook, provide_bucket_name
+from airflow.hooks.samba_hook import SambaHook
+from airflow.hooks.slack_hook import SlackHook
+from airflow.hooks.sqlite_hook import SqliteHook
+from airflow.hooks.webhdfs_hook import WebHDFSHook
+from airflow.hooks.zendesk_hook import ZendeskHook
 from airflow.macros.hive import closest_ds_partition, max_partition
 from airflow.www.security import FabAirflowSecurityManagerOverride
 
@@ -48,3 +71,30 @@ POD_EXECUTOR_DONE_KEY
 HIVE_QUEUE_PRIORITIES
 closest_ds_partition()
 max_partition()
+
+# TODO: reorganize
+S3Hook()
+provide_bucket_name()
+BaseHook()
+DbApiHook2()
+DockerHook()
+DruidDbApiHook()
+DruidHook()
+HIVE_QUEUE_PRIORITIES()
+HiveCliHook()
+HiveMetastoreHook()
+HiveServer2Hook()
+HttpHook()
+JdbcHook()
+jaydebeapi()
+MsSqlHook()
+MySqlHook()
+OracleHook()
+PigCliHook()
+PostgresHook()
+PrestoHook()
+SambaHook()
+SlackHook()
+SqliteHook()
+WebHDFSHook()
+ZendeskHook()

--- a/crates/ruff_linter/resources/test/fixtures/airflow/AIR303.py
+++ b/crates/ruff_linter/resources/test/fixtures/airflow/AIR303.py
@@ -39,6 +39,76 @@ from airflow.hooks.sqlite_hook import SqliteHook
 from airflow.hooks.webhdfs_hook import WebHDFSHook
 from airflow.hooks.zendesk_hook import ZendeskHook
 from airflow.macros.hive import closest_ds_partition, max_partition
+from airflow.operators.check_operator import (
+    CheckOperator,
+    IntervalCheckOperator,
+    SQLCheckOperator,
+    SQLIntervalCheckOperator,
+    SQLThresholdCheckOperator,
+    SQLValueCheckOperator,
+    ThresholdCheckOperator,
+    ValueCheckOperator,
+)
+from airflow.operators.docker_operator import DockerOperator
+from airflow.operators.druid_check_operator import DruidCheckOperator
+from airflow.operators.gcs_to_s3 import GCSToS3Operator
+from airflow.operators.google_api_to_s3_transfer import (
+    GoogleApiToS3Operator,
+    GoogleApiToS3Transfer,
+)
+from airflow.operators.hive_operator import HiveOperator
+from airflow.operators.hive_stats_operator import HiveStatsCollectionOperator
+from airflow.operators.hive_to_druid import HiveToDruidOperator, HiveToDruidTransfer
+from airflow.operators.hive_to_mysql import HiveToMySqlOperator, HiveToMySqlTransfer
+from airflow.operators.hive_to_samba_operator import HiveToSambaOperator
+from airflow.operators.http_operator import SimpleHttpOperator
+from airflow.operators.jdbc_operator import JdbcOperator
+from airflow.operators.latest_only_operator import LatestOnlyOperator
+from airflow.operators.mssql_operator import MsSqlOperator
+from airflow.operators.mssql_to_hive import MsSqlToHiveOperator, MsSqlToHiveTransfer
+from airflow.operators.mysql_operator import MySqlOperator
+from airflow.operators.mysql_to_hive import MySqlToHiveOperator, MySqlToHiveTransfer
+from airflow.operators.oracle_operator import OracleOperator
+from airflow.operators.papermill_operator import PapermillOperator
+from airflow.operators.pig_operator import PigOperator
+from airflow.operators.postgres_operator import Mapping, PostgresOperator
+from airflow.operators.presto_check_operator import (
+    PrestoCheckOperator,
+    PrestoIntervalCheckOperator,
+    PrestoValueCheckOperator,
+    SQLCheckOperator as SQLCheckOperator2,
+    SQLIntervalCheckOperator as SQLIntervalCheckOperator2,
+    SQLValueCheckOperator as SQLValueCheckOperator2,
+)
+from airflow.operators.presto_to_mysql import (
+    PrestoToMySqlOperator,
+    PrestoToMySqlTransfer,
+)
+from airflow.operators.redshift_to_s3_operator import (
+    RedshiftToS3Operator,
+    RedshiftToS3Transfer,
+)
+from airflow.operators.s3_file_transform_operator import S3FileTransformOperator
+from airflow.operators.s3_to_hive_operator import S3ToHiveOperator, S3ToHiveTransfer
+from airflow.operators.s3_to_redshift_operator import (
+    S3ToRedshiftOperator,
+    S3ToRedshiftTransfer,
+)
+from airflow.operators.slack_operator import SlackAPIOperator, SlackAPIPostOperator
+from airflow.operators.sql import (
+    BaseSQLOperator,
+    BranchSQLOperator,
+    SQLCheckOperator as SQLCheckOperator3,
+    SQLColumnCheckOperator as SQLColumnCheckOperator2,
+    SQLIntervalCheckOperator as SQLIntervalCheckOperator3,
+    SQLTableCheckOperator,
+    SQLThresholdCheckOperator as SQLThresholdCheckOperator2,
+    SQLValueCheckOperator as SQLValueCheckOperator3,
+    _convert_to_float_if_possible,
+    parse_boolean,
+)
+from airflow.operators.sql_branch_operator import BranchSqlOperator
+from airflow.operators.sqlite_operator import SqliteOperator
 from airflow.www.security import FabAirflowSecurityManagerOverride
 
 # apache-airflow-providers-fab
@@ -98,3 +168,68 @@ SlackHook()
 SqliteHook()
 WebHDFSHook()
 ZendeskHook()
+
+SQLCheckOperator()
+SQLIntervalCheckOperator()
+SQLThresholdCheckOperator()
+SQLValueCheckOperator()
+CheckOperator()
+IntervalCheckOperator()
+ThresholdCheckOperator()
+ValueCheckOperator()
+DockerOperator()
+DruidCheckOperator()
+GCSToS3Operator()
+GoogleApiToS3Operator()
+GoogleApiToS3Transfer()
+HiveOperator()
+HiveStatsCollectionOperator()
+HiveToDruidOperator()
+HiveToDruidTransfer()
+HiveToMySqlOperator()
+HiveToMySqlTransfer()
+HiveToSambaOperator()
+SimpleHttpOperator()
+JdbcOperator()
+LatestOnlyOperator()
+MsSqlOperator()
+MsSqlToHiveOperator()
+MsSqlToHiveTransfer()
+MySqlOperator()
+MySqlToHiveOperator()
+MySqlToHiveTransfer()
+OracleOperator()
+PapermillOperator()
+PigOperator()
+Mapping()
+PostgresOperator()
+SQLCheckOperator2()
+SQLIntervalCheckOperator2()
+SQLValueCheckOperator2()
+PrestoCheckOperator()
+PrestoIntervalCheckOperator()
+PrestoValueCheckOperator()
+PrestoToMySqlOperator()
+PrestoToMySqlTransfer()
+RedshiftToS3Operator()
+RedshiftToS3Transfer()
+S3FileTransformOperator()
+S3ToHiveOperator()
+S3ToHiveTransfer()
+S3ToRedshiftOperator()
+S3ToRedshiftTransfer()
+SlackAPIOperator()
+SlackAPIPostOperator()
+BaseSQLOperator()
+BranchSQLOperator()
+SQLCheckOperator3()
+SQLColumnCheckOperator2()
+SQLIntervalCheckOperator3()
+SQLTableCheckOperator()
+SQLThresholdCheckOperator2()
+SQLValueCheckOperator3()
+_convert_to_float_if_possible()
+parse_boolean()
+BranchSQLOperator()
+BranchSqlOperator()
+SqliteOperator()

--- a/crates/ruff_linter/resources/test/fixtures/airflow/AIR303.py
+++ b/crates/ruff_linter/resources/test/fixtures/airflow/AIR303.py
@@ -13,7 +13,6 @@ from airflow.executors.kubernetes_executor_types import (
     ALL_NAMESPACES,
     POD_EXECUTOR_DONE_KEY,
 )
-from airflow.hooks.base_hook import BaseHook
 from airflow.hooks.dbapi import ConnectorProtocol, DbApiHook
 from airflow.hooks.dbapi_hook import DbApiHook as DbApiHook2
 from airflow.hooks.docker_hook import DockerHook
@@ -63,7 +62,6 @@ from airflow.operators.hive_to_mysql import HiveToMySqlOperator, HiveToMySqlTran
 from airflow.operators.hive_to_samba_operator import HiveToSambaOperator
 from airflow.operators.http_operator import SimpleHttpOperator
 from airflow.operators.jdbc_operator import JdbcOperator
-from airflow.operators.latest_only_operator import LatestOnlyOperator
 from airflow.operators.mssql_operator import MsSqlOperator
 from airflow.operators.mssql_to_hive import MsSqlToHiveOperator, MsSqlToHiveTransfer
 from airflow.operators.mysql_operator import MySqlOperator
@@ -107,7 +105,6 @@ from airflow.operators.sql import (
     _convert_to_float_if_possible,
     parse_boolean,
 )
-from airflow.operators.sql_branch_operator import BranchSqlOperator
 from airflow.operators.sqlite_operator import SqliteOperator
 from airflow.sensors.hive_partition_sensor import HivePartitionSensor
 from airflow.sensors.http_sensor import HttpSensor
@@ -119,14 +116,18 @@ from airflow.sensors.sql_sensor import SqlSensor2
 from airflow.sensors.web_hdfs_sensor import WebHdfsSensor
 from airflow.www.security import FabAirflowSecurityManagerOverride
 
-# apache-airflow-providers-fab
-basic_auth, kerberos_auth
-auth_current_user
-backend_kerberos_auth
-fab_override
-
-FabAuthManager()
-FabAirflowSecurityManagerOverride()
+# apache-airflow-providers-amazon
+provide_bucket_name()
+GCSToS3Operator()
+GoogleApiToS3Operator()
+GoogleApiToS3Transfer()
+RedshiftToS3Operator()
+RedshiftToS3Transfer()
+S3FileTransformOperator()
+S3Hook()
+S3KeySensor()
+S3ToRedshiftOperator()
+S3ToRedshiftTransfer()
 
 # apache-airflow-providers-celery
 DEFAULT_CELERY_CONFIG
@@ -134,118 +135,139 @@ app
 CeleryExecutor()
 CeleryKubernetesExecutor()
 
+# apache-airflow-providers-common-sql
+_convert_to_float_if_possible()
+parse_boolean()
+BaseSQLOperator()
+BranchSQLOperator()
+CheckOperator()
+ConnectorProtocol()
+DbApiHook()
+DbApiHook2()
+IntervalCheckOperator()
+PrestoCheckOperator()
+PrestoIntervalCheckOperator()
+PrestoValueCheckOperator()
+SQLCheckOperator()
+SQLCheckOperator2()
+SQLCheckOperator3()
+SQLColumnCheckOperator2()
+SQLIntervalCheckOperator()
+SQLIntervalCheckOperator2()
+SQLIntervalCheckOperator3()
+SQLTableCheckOperator()
+SQLThresholdCheckOperator()
+SQLThresholdCheckOperator2()
+SQLValueCheckOperator()
+SQLValueCheckOperator2()
+SQLValueCheckOperator3()
+SqlSensor()
+SqlSensor2()
+ThresholdCheckOperator()
+ValueCheckOperator()
+
 # apache-airflow-providers-daskexecutor
 DaskExecutor()
 
-# apache-airflow-providers-common-sql
-ConnectorProtocol()
-DbApiHook()
+# apache-airflow-providers-docker
+DockerHook()
+DockerOperator()
 
-# apache-airflow-providers-cncf-kubernetes
-ALL_NAMESPACES
-POD_EXECUTOR_DONE_KEY
+# apache-airflow-providers-apache-druid
+DruidDbApiHook()
+DruidHook()
+DruidCheckOperator()
+
+# apache-airflow-providers-apache-hdfs
+WebHDFSHook()
+WebHdfsSensor()
 
 # apache-airflow-providers-apache-hive
 HIVE_QUEUE_PRIORITIES
 closest_ds_partition()
 max_partition()
-
-# TODO: reorganize
-S3Hook()
-provide_bucket_name()
-BaseHook()
-DbApiHook2()
-DockerHook()
-DruidDbApiHook()
-DruidHook()
-HIVE_QUEUE_PRIORITIES()
 HiveCliHook()
 HiveMetastoreHook()
-HiveServer2Hook()
-HttpHook()
-JdbcHook()
-jaydebeapi()
-MsSqlHook()
-MySqlHook()
-OracleHook()
-PigCliHook()
-PostgresHook()
-PrestoHook()
-SambaHook()
-SlackHook()
-SqliteHook()
-WebHDFSHook()
-ZendeskHook()
-
-SQLCheckOperator()
-SQLIntervalCheckOperator()
-SQLThresholdCheckOperator()
-SQLValueCheckOperator()
-CheckOperator()
-IntervalCheckOperator()
-ThresholdCheckOperator()
-ValueCheckOperator()
-DockerOperator()
-DruidCheckOperator()
-GCSToS3Operator()
-GoogleApiToS3Operator()
-GoogleApiToS3Transfer()
 HiveOperator()
+HivePartitionSensor()
+HiveServer2Hook()
 HiveStatsCollectionOperator()
 HiveToDruidOperator()
 HiveToDruidTransfer()
-HiveToMySqlOperator()
-HiveToMySqlTransfer()
 HiveToSambaOperator()
+S3ToHiveOperator()
+S3ToHiveTransfer()
+MetastorePartitionSensor()
+NamedHivePartitionSensor()
+
+# apache-airflow-providers-http
+HttpHook()
+HttpSensor()
 SimpleHttpOperator()
+
+# apache-airflow-providers-jdbc
+jaydebeapi
+JdbcHook()
 JdbcOperator()
-LatestOnlyOperator()
+
+# apache-airflow-providers-fab
+basic_auth, kerberos_auth
+auth_current_user
+backend_kerberos_auth
+fab_override
+FabAuthManager()
+FabAirflowSecurityManagerOverride()
+
+# apache-airflow-providers-cncf-kubernetes
+ALL_NAMESPACES
+POD_EXECUTOR_DONE_KEY
+
+# apache-airflow-providers-microsoft-mssql
+MsSqlHook()
 MsSqlOperator()
 MsSqlToHiveOperator()
 MsSqlToHiveTransfer()
+
+# apache-airflow-providers-mysql
+HiveToMySqlOperator()
+HiveToMySqlTransfer()
+MySqlHook()
 MySqlOperator()
 MySqlToHiveOperator()
 MySqlToHiveTransfer()
-OracleOperator()
-PapermillOperator()
-PigOperator()
-Mapping()
-PostgresOperator()
-SQLCheckOperator2()
-SQLIntervalCheckOperator2()
-SQLValueCheckOperator2()
-PrestoCheckOperator()
-PrestoIntervalCheckOperator()
-PrestoValueCheckOperator()
 PrestoToMySqlOperator()
 PrestoToMySqlTransfer()
-RedshiftToS3Operator()
-RedshiftToS3Transfer()
-S3FileTransformOperator()
-S3ToHiveOperator()
-S3ToHiveTransfer()
-S3ToRedshiftOperator()
-S3ToRedshiftTransfer()
+
+# apache-airflow-providers-oracle
+OracleHook()
+OracleOperator()
+
+# apache-airflow-providers-papermill
+PapermillOperator()
+
+# apache-airflow-providers-apache-pig
+PigCliHook()
+PigOperator()
+
+# apache-airflow-providers-postgres
+Mapping
+PostgresHook()
+PostgresOperator()
+
+# apache-airflow-providers-presto
+PrestoHook()
+
+# apache-airflow-providers-samba
+SambaHook()
+
+# apache-airflow-providers-slack
+SlackHook()
 SlackAPIOperator()
 SlackAPIPostOperator()
-BaseSQLOperator()
-BranchSQLOperator()
-SQLCheckOperator3()
-SQLColumnCheckOperator2()
-SQLIntervalCheckOperator3()
-SQLTableCheckOperator()
-SQLThresholdCheckOperator2()
-SQLValueCheckOperator3()
-_convert_to_float_if_possible()
-parse_boolean()
-BranchSQLOperator()
-BranchSqlOperator()
+
+# apache-airflow-providers-sqlite
+SqliteHook()
 SqliteOperator()
-HivePartitionSensor()
-HttpSensor()
-MetastorePartitionSensor()
-NamedHivePartitionSensor()
-S3KeySensor()
-SqlSensor()
-SqlSensor2()
-WebHdfsSensor()
+
+# apache-airflow-providers-zendesk
+ZendeskHook()

--- a/crates/ruff_linter/src/rules/airflow/rules/moved_to_provider_in_3.rs
+++ b/crates/ruff_linter/src/rules/airflow/rules/moved_to_provider_in_3.rs
@@ -483,6 +483,583 @@ fn moved_to_provider(checker: &mut Checker, expr: &Expr, ranged: impl Ranged) {
                 },
                 )),
 
+                ["airflow", "operators", "check_operator", "SQLCheckOperator"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "SQLCheckOperator",
+                        provider: "Common Sql",
+                        version: "TBD"
+                },
+                )),
+
+                ["airflow", "operators", "check_operator", "SQLIntervalCheckOperator"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "SQLIntervalCheckOperator",
+                        provider: "Common Sql",
+                        version: "TBD"
+                },
+                )),
+
+                ["airflow", "operators", "check_operator", "SQLThresholdCheckOperator"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "SQLThresholdCheckOperator",
+                        provider: "Common Sql",
+                        version: "TBD"
+                },
+                )),
+
+                ["airflow", "operators", "check_operator", "SQLValueCheckOperator"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "SQLValueCheckOperator",
+                        provider: "Common Sql",
+                        version: "TBD"
+                },
+                )),
+
+                ["airflow", "operators", "check_operator", "CheckOperator"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "CheckOperator",
+                        provider: "Common Sql",
+                        version: "TBD"
+                },
+                )),
+
+                ["airflow", "operators", "check_operator", "IntervalCheckOperator"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "IntervalCheckOperator",
+                        provider: "Common Sql",
+                        version: "TBD"
+                },
+                )),
+
+                ["airflow", "operators", "check_operator", "ThresholdCheckOperator"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "ThresholdCheckOperator",
+                        provider: "Common Sql",
+                        version: "TBD"
+                },
+                )),
+
+                ["airflow", "operators", "check_operator", "ValueCheckOperator"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "ValueCheckOperator",
+                        provider: "Common Sql",
+                        version: "TBD"
+                },
+                )),
+
+                ["airflow", "operators", "docker_operator", "DockerOperator"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "DockerOperator",
+                        provider: "Docker",
+                        version: "TBD"
+                },
+                )),
+
+                ["airflow", "operators", "druid_check_operator", "DruidCheckOperator"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "DruidCheckOperator",
+                        provider: "Apache Druid",
+                        version: "TBD"
+                },
+                )),
+
+                ["airflow", "operators", "gcs_to_s3", "GCSToS3Operator"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "GCSToS3Operator",
+                        provider: "Amazon",
+                        version: "TBD"
+                },
+                )),
+
+                ["airflow", "operators", "google_api_to_s3_transfer", "GoogleApiToS3Operator"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "GoogleApiToS3Operator",
+                        provider: "Amazon",
+                        version: "TBD"
+                },
+                )),
+
+                ["airflow", "operators", "google_api_to_s3_transfer", "GoogleApiToS3Transfer"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "GoogleApiToS3Transfer",
+                        provider: "Amazon",
+                        version: "TBD"
+                },
+                )),
+
+                ["airflow", "operators", "hive_operator", "HiveOperator"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "HiveOperator",
+                        provider: "Apache Hive",
+                        version: "TBD"
+                },
+                )),
+
+                ["airflow", "operators", "hive_stats_operator", "HiveStatsCollectionOperator"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "HiveStatsCollectionOperator",
+                        provider: "Apache Hive",
+                        version: "TBD"
+                },
+                )),
+
+                ["airflow", "operators", "hive_to_druid", "HiveToDruidOperator"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "HiveToDruidOperator",
+                        provider: "Apache Druid",
+                        version: "TBD"
+                },
+                )),
+
+                ["airflow", "operators", "hive_to_druid", "HiveToDruidTransfer"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "HiveToDruidTransfer",
+                        provider: "Apache Druid",
+                        version: "TBD"
+                },
+                )),
+
+                ["airflow", "operators", "hive_to_mysql", "HiveToMySqlOperator"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "HiveToMySqlOperator",
+                        provider: "Apache Hive",
+                        version: "TBD"
+                },
+                )),
+
+                ["airflow", "operators", "hive_to_mysql", "HiveToMySqlTransfer"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "HiveToMySqlTransfer",
+                        provider: "Apache Hive",
+                        version: "TBD"
+                },
+                )),
+
+                ["airflow", "operators", "hive_to_samba_operator", "HiveToSambaOperator"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "HiveToSambaOperator",
+                        provider: "Apache Hive",
+                        version: "TBD"
+                },
+                )),
+
+                ["airflow", "operators", "http_operator", "SimpleHttpOperator"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "SimpleHttpOperator",
+                        provider: "Http",
+                        version: "TBD"
+                },
+                )),
+
+                ["airflow", "operators", "jdbc_operator", "JdbcOperator"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "JdbcOperator",
+                        provider: "Jdbc",
+                        version: "TBD"
+                },
+                )),
+
+                ["airflow", "operators", "latest_only_operator", "LatestOnlyOperator"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "LatestOnlyOperator",
+                        provider: "Latest_only",
+                        version: "TBD"
+                },
+                )),
+
+                ["airflow", "operators", "mssql_operator", "MsSqlOperator"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "MsSqlOperator",
+                        provider: "Microsoft",
+                        version: "TBD"
+                },
+                )),
+
+                ["airflow", "operators", "mssql_to_hive", "MsSqlToHiveOperator"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "MsSqlToHiveOperator",
+                        provider: "Apache Hive",
+                        version: "TBD"
+                },
+                )),
+
+                ["airflow", "operators", "mssql_to_hive", "MsSqlToHiveTransfer"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "MsSqlToHiveTransfer",
+                        provider: "Apache Hive",
+                        version: "TBD"
+                },
+                )),
+
+                ["airflow", "operators", "mysql_operator", "MySqlOperator"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "MySqlOperator",
+                        provider: "Mysql",
+                        version: "TBD"
+                },
+                )),
+
+                ["airflow", "operators", "mysql_to_hive", "MySqlToHiveOperator"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "MySqlToHiveOperator",
+                        provider: "Apache Hive",
+                        version: "TBD"
+                },
+                )),
+
+                ["airflow", "operators", "mysql_to_hive", "MySqlToHiveTransfer"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "MySqlToHiveTransfer",
+                        provider: "Apache Hive",
+                        version: "TBD"
+                },
+                )),
+
+                ["airflow", "operators", "oracle_operator", "OracleOperator"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "OracleOperator",
+                        provider: "Oracle",
+                        version: "TBD"
+                },
+                )),
+
+                ["airflow", "operators", "papermill_operator", "PapermillOperator"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "PapermillOperator",
+                        provider: "Papermill",
+                        version: "TBD"
+                },
+                )),
+
+                ["airflow", "operators", "pig_operator", "PigOperator"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "PigOperator",
+                        provider: "Apache Pig",
+                        version: "TBD"
+                },
+                )),
+
+                ["airflow", "operators", "postgres_operator", "Mapping"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "Mapping",
+                        provider: "Postgres",
+                        version: "TBD"
+                },
+                )),
+
+                ["airflow", "operators", "postgres_operator", "PostgresOperator"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "PostgresOperator",
+                        provider: "Postgres",
+                        version: "TBD"
+                },
+                )),
+
+                ["airflow", "operators", "presto_check_operator", "SQLCheckOperator"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "SQLCheckOperator",
+                        provider: "Common Sql",
+                        version: "TBD"
+                },
+                )),
+
+                ["airflow", "operators", "presto_check_operator", "SQLIntervalCheckOperator"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "SQLIntervalCheckOperator",
+                        provider: "Common Sql",
+                        version: "TBD"
+                },
+                )),
+
+                ["airflow", "operators", "presto_check_operator", "SQLValueCheckOperator"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "SQLValueCheckOperator",
+                        provider: "Common Sql",
+                        version: "TBD"
+                },
+                )),
+
+                ["airflow", "operators", "presto_check_operator", "PrestoCheckOperator"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "PrestoCheckOperator",
+                        provider: "Common Sql",
+                        version: "TBD"
+                },
+                )),
+
+                ["airflow", "operators", "presto_check_operator", "PrestoIntervalCheckOperator"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "PrestoIntervalCheckOperator",
+                        provider: "Common Sql",
+                        version: "TBD"
+                },
+                )),
+
+                ["airflow", "operators", "presto_check_operator", "PrestoValueCheckOperator"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "PrestoValueCheckOperator",
+                        provider: "Common Sql",
+                        version: "TBD"
+                },
+                )),
+
+                ["airflow", "operators", "presto_to_mysql", "PrestoToMySqlOperator"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "PrestoToMySqlOperator",
+                        provider: "Mysql",
+                        version: "TBD"
+                },
+                )),
+
+                ["airflow", "operators", "presto_to_mysql", "PrestoToMySqlTransfer"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "PrestoToMySqlTransfer",
+                        provider: "Mysql",
+                        version: "TBD"
+                },
+                )),
+
+                ["airflow", "operators", "redshift_to_s3_operator", "RedshiftToS3Operator"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "RedshiftToS3Operator",
+                        provider: "Amazon",
+                        version: "TBD"
+                },
+                )),
+
+                ["airflow", "operators", "redshift_to_s3_operator", "RedshiftToS3Transfer"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "RedshiftToS3Transfer",
+                        provider: "Amazon",
+                        version: "TBD"
+                },
+                )),
+
+                ["airflow", "operators", "s3_file_transform_operator", "S3FileTransformOperator"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "S3FileTransformOperator",
+                        provider: "Amazon",
+                        version: "TBD"
+                },
+                )),
+
+                ["airflow", "operators", "s3_to_hive_operator", "S3ToHiveOperator"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "S3ToHiveOperator",
+                        provider: "Apache Hive",
+                        version: "TBD"
+                },
+                )),
+
+                ["airflow", "operators", "s3_to_hive_operator", "S3ToHiveTransfer"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "S3ToHiveTransfer",
+                        provider: "Apache Hive",
+                        version: "TBD"
+                },
+                )),
+
+                ["airflow", "operators", "s3_to_redshift_operator", "S3ToRedshiftOperator"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "S3ToRedshiftOperator",
+                        provider: "Amazon",
+                        version: "TBD"
+                },
+                )),
+
+                ["airflow", "operators", "s3_to_redshift_operator", "S3ToRedshiftTransfer"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "S3ToRedshiftTransfer",
+                        provider: "Amazon",
+                        version: "TBD"
+                },
+                )),
+
+                ["airflow", "operators", "slack_operator", "SlackAPIOperator"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "SlackAPIOperator",
+                        provider: "Slack",
+                        version: "TBD"
+                },
+                )),
+
+                ["airflow", "operators", "slack_operator", "SlackAPIPostOperator"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "SlackAPIPostOperator",
+                        provider: "Slack",
+                        version: "TBD"
+                },
+                )),
+
+                ["airflow", "operators", "sql", "BaseSQLOperator"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "BaseSQLOperator",
+                        provider: "Common Sql",
+                        version: "TBD"
+                },
+                )),
+
+                ["airflow", "operators", "sql", "BranchSQLOperator"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "BranchSQLOperator",
+                        provider: "Common Sql",
+                        version: "TBD"
+                },
+                )),
+
+                ["airflow", "operators", "sql", "SQLCheckOperator"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "SQLCheckOperator",
+                        provider: "Common Sql",
+                        version: "TBD"
+                },
+                )),
+
+                ["airflow", "operators", "sql", "SQLColumnCheckOperator"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "SQLColumnCheckOperator",
+                        provider: "Common Sql",
+                        version: "TBD"
+                },
+                )),
+
+                ["airflow", "operators", "sql", "SQLIntervalCheckOperator"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "SQLIntervalCheckOperator",
+                        provider: "Common Sql",
+                        version: "TBD"
+                },
+                )),
+
+                ["airflow", "operators", "sql", "SQLTableCheckOperator"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "SQLTableCheckOperator",
+                        provider: "Common Sql",
+                        version: "TBD"
+                },
+                )),
+
+                ["airflow", "operators", "sql", "SQLThresholdCheckOperator"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "SQLThresholdCheckOperator",
+                        provider: "Common Sql",
+                        version: "TBD"
+                },
+                )),
+
+                ["airflow", "operators", "sql", "SQLValueCheckOperator"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "SQLValueCheckOperator",
+                        provider: "Common Sql",
+                        version: "TBD"
+                },
+                )),
+
+                ["airflow", "operators", "sql", "_convert_to_float_if_possible"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "_convert_to_float_if_possible",
+                        provider: "Common Sql",
+                        version: "TBD"
+                },
+                )),
+
+                ["airflow", "operators", "sql", "parse_boolean"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "parse_boolean",
+                        provider: "Common Sql",
+                        version: "TBD"
+                },
+                )),
+
+                ["airflow", "operators", "sql_branch_operator", "BranchSQLOperator"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "BranchSQLOperator",
+                        provider: "Common Sql",
+                        version: "TBD"
+                },
+                )),
+
+                ["airflow", "operators", "sql_branch_operator", "BranchSqlOperator"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "BranchSqlOperator",
+                        provider: "Common Sql",
+                        version: "TBD"
+                },
+                )),
+
+                ["airflow", "operators", "sqlite_operator", "SqliteOperator"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "SqliteOperator",
+                        provider: "Sqlite",
+                        version: "TBD"
+                },
+                )),
+
+
                 _ => None,
             });
     if let Some((deprecated, replacement)) = result {

--- a/crates/ruff_linter/src/rules/airflow/rules/moved_to_provider_in_3.rs
+++ b/crates/ruff_linter/src/rules/airflow/rules/moved_to_provider_in_3.rs
@@ -6,21 +6,6 @@ use ruff_text_size::Ranged;
 
 use crate::checkers::ast::Checker;
 
-#[derive(Debug, Eq, PartialEq)]
-enum Replacement {
-    ProviderName {
-        name: &'static str,
-        provider: &'static str,
-        version: &'static str,
-    },
-    ImportPathMoved {
-        original_path: &'static str,
-        new_path: &'static str,
-        provider: &'static str,
-        version: &'static str,
-    },
-}
-
 /// ## What it does
 /// Checks for uses of Airflow functions and values that have been moved to it providers.
 /// (e.g., apache-airflow-providers-fab)
@@ -96,12 +81,491 @@ impl Violation for Airflow3MovedToProvider {
     }
 }
 
-fn moved_to_provider(checker: &mut Checker, expr: &Expr, ranged: impl Ranged) {
+/// AIR303
+pub(crate) fn moved_to_provider_in_3(checker: &mut Checker, expr: &Expr) {
+    if !checker.semantic().seen_module(Modules::AIRFLOW) {
+        return;
+    }
+
+    match expr {
+        Expr::Attribute(ExprAttribute { attr: ranged, .. }) => {
+            check_names_moved_to_provider(checker, expr, ranged);
+        }
+        ranged @ Expr::Name(_) => check_names_moved_to_provider(checker, expr, ranged),
+        _ => {}
+    }
+}
+
+#[derive(Debug, Eq, PartialEq)]
+enum Replacement {
+    ProviderName {
+        name: &'static str,
+        provider: &'static str,
+        version: &'static str,
+    },
+    ImportPathMoved {
+        original_path: &'static str,
+        new_path: &'static str,
+        provider: &'static str,
+        version: &'static str,
+    },
+}
+
+fn check_names_moved_to_provider(checker: &mut Checker, expr: &Expr, ranged: impl Ranged) {
     let result =
         checker
             .semantic()
             .resolve_qualified_name(expr)
             .and_then(|qualname| match qualname.segments() {
+                // apache-airflow-providers-amazon
+                ["airflow", "hooks", "S3_hook", "S3Hook"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "airflow.providers.amazon.aws.hooks.s3.S3Hook",
+                        provider: "amazon",
+                        version: "1.0.0"
+                },
+                )),
+                ["airflow", "hooks", "S3_hook", "provide_bucket_name"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "airflow.providers.amazon.aws.hooks.s3.provide_bucket_name",
+                        provider: "amazon",
+                        version: "1.0.0"
+                },
+                )),
+                ["airflow", "operators", "gcs_to_s3", "GCSToS3Operator"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "airflow.providers.amazon.aws.transfers.gcs_to_s3.GCSToS3Operator",
+                        provider: "amazon",
+                        version: "1.0.0"
+                },
+                )),
+                ["airflow", "operators", "google_api_to_s3_transfer", "GoogleApiToS3Operator"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "airflow.providers.amazon.aws.transfers.google_api_to_s3.GoogleApiToS3Operator",
+                        provider: "amazon",
+                        version: "1.0.0"
+                },
+                )),
+                ["airflow", "operators", "google_api_to_s3_transfer", "GoogleApiToS3Transfer"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "airflow.providers.amazon.aws.transfers.google_api_to_s3.GoogleApiToS3Operator",
+                        provider: "amazon",
+                        version: "1.0.0"
+                },
+                )),
+                ["airflow", "operators", "redshift_to_s3_operator", "RedshiftToS3Operator"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "airflow.providers.amazon.aws.transfers.redshift_to_s3.RedshiftToS3Operator",
+                        provider: "amazon",
+                        version: "1.0.0"
+                },
+                )),
+                ["airflow", "operators", "redshift_to_s3_operator", "RedshiftToS3Transfer"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "airflow.providers.amazon.aws.transfers.redshift_to_s3.RedshiftToS3Operator",
+                        provider: "amazon",
+                        version: "1.0.0"
+                },
+                )),
+                ["airflow", "operators", "s3_file_transform_operator", "S3FileTransformOperator"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "airflow.providers.amazon.aws.operators.s3_file_transform.S3FileTransformOperator",
+                        provider: "amazon",
+                        version: "1.0.0"
+                },
+                )),
+                ["airflow", "operators", "s3_to_redshift_operator", "S3ToRedshiftOperator"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "airflow.providers.amazon.aws.transfers.s3_to_redshift.S3ToRedshiftOperator",
+                        provider: "amazon",
+                        version: "1.0.0"
+                },
+                )),
+                ["airflow", "operators", "s3_to_redshift_operator", "S3ToRedshiftTransfer"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "airflow.providers.amazon.aws.transfers.s3_to_redshift.S3ToRedshiftOperator",
+                        provider: "amazon",
+                        version: "1.0.0"
+                },
+                )),
+                ["airflow", "sensors", "s3_key_sensor", "S3KeySensor"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "S3KeySensor",
+                        provider: "amazon",
+                        version: "1.0.0"
+                },
+                )),
+
+                // apache-airflow-providers-celery
+                ["airflow", "config_templates", "default_celery", "DEFAULT_CELERY_CONFIG"] => Some((
+                    qualname.to_string(),
+                    Replacement::ImportPathMoved{
+                        original_path: "airflow.config_templates.default_celery.DEFAULT_CELERY_CONFIG",
+                        new_path: "airflow.providers.celery.executors.default_celery.DEFAULT_CELERY_CONFIG",
+                        provider: "celery",
+                        version: "3.3.0"
+                },
+                )),
+                ["airflow", "executors", "celery_executor", "app"] => Some((
+                    qualname.to_string(),
+                    Replacement::ImportPathMoved{
+                        original_path: "airflow.executors.celery_executor.app",
+                        new_path: "airflow.providers.celery.executors.celery_executor_utils.app",
+                        provider: "celery",
+                        version: "3.3.0"
+                },
+                )),
+                ["airflow", "executors", "celery_executor", "CeleryExecutor"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "airflow.providers.celery.executors.celery_executor.CeleryExecutor",
+                        provider: "celery",
+                        version: "3.3.0"
+                },
+                )),
+                ["airflow", "executors", "celery_kubernetes_executor", "CeleryKubernetesExecutor"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "airflow.providers.celery.executors.celery_kubernetes_executor.CeleryKubernetesExecutor",
+                        provider: "celery",
+                        version: "3.3.0"
+                },
+                )),
+
+                // apache-airflow-providers-common-sql
+                ["airflow", "hooks", "dbapi", "ConnectorProtocol"] => Some((
+                    qualname.to_string(),
+                    Replacement::ImportPathMoved{
+                        original_path: "airflow.hooks.dbapi.ConnectorProtocol",
+                        new_path: "airflow.providers.common.sql.hooks.sql.ConnectorProtocol",
+                        provider: "common-sql",
+                        version: "1.0.0"
+                },
+                )),
+                ["airflow", "hooks", "dbapi", "DbApiHook"] => Some((
+                    qualname.to_string(),
+                    Replacement::ImportPathMoved{
+                        original_path: "airflow.hooks.dbapi.DbApiHook",
+                        new_path: "airflow.providers.common.sql.hooks.sql.DbApiHook",
+                        provider: "common-sql",
+                        version: "1.0.0"
+                },
+                )),
+                ["airflow", "hooks", "dbapi_hook", "DbApiHook"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "airflow.providers.common.sql.hooks.sql.DbApiHook",
+                        provider: "common-sql",
+                        version: "1.0.0"
+                },
+                )),
+                ["airflow", "operators", "check_operator", "SQLCheckOperator"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "airflow.providers.common.sql.operators.sql.SQLCheckOperator",
+                        provider: "common-sql",
+                        version: "1.1.0"
+                },
+                )),
+                ["airflow", "operators", "check_operator", "SQLIntervalCheckOperator"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "airflow.providers.common.sql.operators.sql.SQLIntervalCheckOperator",
+                        provider: "common-sql",
+                        version: "1.1.0"
+                },
+                )),
+                ["airflow", "operators", "check_operator", "SQLThresholdCheckOperator"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "airflow.providers.common.sql.operators.sql.SQLThresholdCheckOperator",
+                        provider: "common-sql",
+                        version: "1.1.0"
+                },
+                )),
+                ["airflow", "operators", "check_operator", "SQLValueCheckOperator"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "airflow.providers.common.sql.operators.sql.SQLValueCheckOperator",
+                        provider: "common-sql",
+                        version: "1.1.0"
+                },
+                )),
+                ["airflow", "operators", "check_operator", "CheckOperator"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "airflow.providers.common.sql.operators.sql.SQLCheckOperator",
+                        provider: "common-sql",
+                        version: "1.1.0"
+                },
+                )),
+                ["airflow", "operators", "check_operator", "IntervalCheckOperator"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "airflow.providers.common.sql.operators.sql.SQLIntervalCheckOperator",
+                        provider: "common-sql",
+                        version: "1.1.0"
+                },
+                )),
+                ["airflow", "operators", "check_operator", "ThresholdCheckOperator"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "airflow.providers.common.sql.operators.sql.SQLThresholdCheckOperator",
+                        provider: "common-sql",
+                        version: "1.1.0"
+                },
+                )),
+                ["airflow", "operators", "check_operator", "ValueCheckOperator"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "airflow.providers.common.sql.operators.sql.SQLValueCheckOperator",
+                        provider: "common-sql",
+                        version: "1.1.0"
+                },
+                )),
+                ["airflow", "operators", "presto_check_operator", "SQLCheckOperator"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "airflow.providers.common.sql.operators.sql.SQLCheckOperator",
+                        provider: "common-sql",
+                        version: "1.1.0"
+                },
+                )),
+                ["airflow", "operators", "presto_check_operator", "SQLIntervalCheckOperator"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "airflow.providers.common.sql.operators.sql.SQLIntervalCheckOperator",
+                        provider: "common-sql",
+                        version: "1.1.0"
+                },
+                )),
+                ["airflow", "operators", "presto_check_operator", "SQLValueCheckOperator"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "airflow.providers.common.sql.operators.sql.SQLValueCheckOperator",
+                        provider: "common-sql",
+                        version: "1.1.0"
+                },
+                )),
+                ["airflow", "operators", "presto_check_operator", "PrestoCheckOperator"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "airflow.providers.common.sql.operators.sql.SQLCheckOperator",
+                        provider: "common-sql",
+                        version: "1.1.0"
+                },
+                )),
+                ["airflow", "operators", "presto_check_operator", "PrestoIntervalCheckOperator"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "airflow.providers.common.sql.operators.sql.SQLIntervalCheckOperator",
+                        provider: "common-sql",
+                        version: "1.1.0"
+                },
+                )),
+                ["airflow", "operators", "presto_check_operator", "PrestoValueCheckOperator"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "airflow.providers.common.sql.operators.sql.SQLValueCheckOperator",
+                        provider: "common-sql",
+                        version: "1.1.0"
+                },
+                )),
+                ["airflow", "operators", "sql", "BaseSQLOperator"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "airflow.providers.common.sql.operators.sql.BaseSQLOperator",
+                        provider: "common-sql",
+                        version: "1.1.0"
+                },
+                )),
+                ["airflow", "operators", "sql", "BranchSQLOperator"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "airflow.providers.common.sql.operators.sql.BranchSQLOperator",
+                        provider: "common-sql",
+                        version: "1.1.0"
+                },
+                )),
+                ["airflow", "operators", "sql", "SQLCheckOperator"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "airflow.providers.common.sql.operators.sql.SQLCheckOperator",
+                        provider: "common-sql",
+                        version: "1.1.0"
+                },
+                )),
+                ["airflow", "operators", "sql", "SQLColumnCheckOperator"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "airflow.providers.common.sql.operators.sql.SQLColumnCheckOperator",
+                        provider: "common-sql",
+                        version: "1.0.0"
+                },
+                )),
+                ["airflow", "operators", "sql", "SQLIntervalCheckOperator"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "airflow.providers.common.sql.operators.sql.SQLIntervalCheckOperator",
+                        provider: "common-sql",
+                        version: "1.1.0"
+                },
+                )),
+                ["airflow", "operators", "sql", "SQLTablecheckOperator"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "SQLTableCheckOperator",
+                        provider: "common-sql",
+                        version: "1.0.0"
+                },
+                )),
+                ["airflow", "operators", "sql", "SQLThresholdCheckOperator"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "airflow.providers.common.sql.operators.sql.SQLTableCheckOperator",
+                        provider: "common-sql",
+                        version: "1.0.0"
+                },
+                )),
+                ["airflow", "operators", "sql", "SQLValueCheckOperator"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "airflow.providers.common.sql.operators.sql.SQLValueCheckOperator",
+                        provider: "common-sql",
+                        version: "1.0.0"
+                },
+                )),
+                ["airflow", "operators", "sql", "_convert_to_float_if_possible"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "airflow.providers.common.sql.operators.sql._convert_to_float_if_possible",
+                        provider: "common-sql",
+                        version: "1.0.0"
+                },
+                )),
+                ["airflow", "operators", "sql", "parse_boolean"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "airflow.providers.common.sql.operators.sql.parse_boolean",
+                        provider: "common-sql",
+                        version: "1.0.0"
+                },
+                )),
+                ["airflow", "operators", "sql_branch_operator", "BranchSQLOperator"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "airflow.providers.common.sql.operators.sql.BranchSQLOperator",
+                        provider: "common-sql",
+                        version: "1.1.0"
+                },
+                )),
+                ["airflow", "operators", "sql_branch_operator", "BranchSqlOperator"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "airflow.providers.common.sql.operators.sql.BranchSQLOperator",
+                        provider: "common-sql",
+                        version: "1.1.0"
+                },
+                )),
+                ["airflow", "sensors", "sql", "SqlSensor"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "airflow.providers.common.sql.sensors.sql.SqlSensor",
+                        provider: "common-sql",
+                        version: "1.0.0"
+                },
+                )),
+                ["airflow", "sensors", "sql_sensor", "SqlSensor"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "airflow.providers.common.sql.sensors.sql.SqlSensor",
+                        provider: "common-sql",
+                        version: "1.0.0"
+                },
+                )),
+
+                // apache-airflow-providers-daskexecutor
+                ["airflow", "executors", "dask_executor", "DaskExecutor"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "airflow.providers.daskexecutor.executors.dask_executor.DaskExecutor",
+                        provider: "daskexecutor",
+                        version: "1.0.0"
+                },
+                )),
+
+                // apache-airflow-providers-docker
+                ["airflow", "hooks", "docker_hook", "DockerHook"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "airflow.providers.docker.hooks.docker.DockerHook",
+                        provider: "docker",
+                        version: "1.0.0"
+                },
+                )),
+                ["airflow", "operators", "docker_operator", "DockerOperator"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "airflow.providers.docker.operators.docker.DockerOperator",
+                        provider: "docker",
+                        version: "1.0.0"
+                },
+                )),
+
+                // apache-airflow-providers-apache-druid
+                ["airflow", "hooks", "druid_hook", "DruidDbApiHook"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "DruidDbApiHook",
+                        provider: "apache-druid",
+                        version: "1.0.0"
+                },
+                )),
+                ["airflow", "hooks", "druid_hook", "DruidHook"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "DruidHook",
+                        provider: "apache-druid",
+                        version: "1.0.0"
+                },
+                )),
+                ["airflow", "operators", "druid_check_operator", "DruidCheckOperator"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "DruidCheckOperator",
+                        provider: "apache-druid",
+                        version: "1.0.0"
+                },
+                )),
+                ["airflow", "operators", "hive_to_druid", "HiveToDruidOperator"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "airflow.providers.apache.druid.transfers.hive_to_druid.HiveToDruidOperator",
+                        provider: "apache-druid",
+                        version: "1.0.0"
+                },
+                )),
+                ["airflow", "operators", "hive_to_druid", "HiveToDruidTransfer"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "airflow.providers.apache.druid.transfers.hive_to_druid.HiveToDruidOperator",
+                        provider: "apache-druid",
+                        version: "1.0.0"
+                },
+                )),
+
+
                 // apache-airflow-providers-fab
                 ["airflow", "www", "security", "FabAirflowSecurityManagerOverride"] => Some((
                     qualname.to_string(),
@@ -155,76 +619,247 @@ fn moved_to_provider(checker: &mut Checker, expr: &Expr, ranged: impl Ranged) {
                         version: "1.0.0"
                 },
                 )),
-                // apache-airflow-providers-celery
-                ["airflow", "config_templates", "default_celery", "DEFAULT_CELERY_CONFIG"] => Some((
-                    qualname.to_string(),
-                    Replacement::ImportPathMoved{
-                        original_path: "airflow.config_templates.default_celery.DEFAULT_CELERY_CONFIG",
-                        new_path: "airflow.providers.celery.executors.default_celery.DEFAULT_CELERY_CONFIG",
-                        provider: "celery",
-                        version: "3.3.0"
-                },
-                )),
-                ["airflow", "executors", "celery_executor", "app"] => Some((
-                    qualname.to_string(),
-                    Replacement::ImportPathMoved{
-                        original_path: "airflow.executors.celery_executor.app",
-                        new_path: "airflow.providers.celery.executors.celery_executor_utils.app",
-                        provider: "celery",
-                        version: "3.3.0"
-                },
-                )),
-                ["airflow", "executors", "celery_executor", "CeleryExecutor"] => Some((
+
+                // apache-airflow-providers-apache-hdfs
+                ["airflow", "hooks", "webhdfs_hook", "WebHDFSHook"] => Some((
                     qualname.to_string(),
                     Replacement::ProviderName{
-                        name: "airflow.providers.celery.executors.celery_executor.CeleryExecutor",
-                        provider: "celery",
-                        version: "3.3.0"
-                },
-                )),
-                ["airflow", "executors", "celery_kubernetes_executor", "CeleryKubernetesExecutor"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.celery.executors.celery_kubernetes_executor.CeleryKubernetesExecutor",
-                        provider: "celery",
-                        version: "3.3.0"
-                },
-                )),
-                // apache-airflow-providers-daskexecutor
-                ["airflow", "executors", "dask_executor", "DaskExecutor"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.daskexecutor.executors.dask_executor.DaskExecutor",
-                        provider: "daskexecutor",
+                        name: "airflow.providers.apache.hdfs.hooks.webhdfs.WebHDFSHook",
+                        provider: "apache-hdfs",
                         version: "1.0.0"
                 },
                 )),
-                // apache-airflow-providers-common-sql
-                ["airflow", "hooks", "dbapi", "ConnectorProtocol"] => Some((
+                ["airflow", "sensors", "web_hdfs_sensor", "WebHdfsSensor"] => Some((
                     qualname.to_string(),
-                    Replacement::ImportPathMoved{
-                        original_path: "airflow.hooks.dbapi.ConnectorProtocol",
-                        new_path: "airflow.providers.common.sql.hooks.sql.ConnectorProtocol",
-                        provider: "Common SQL",
+                    Replacement::ProviderName{
+                        name: "airflow.providers.apache.hdfs.sensors.web_hdfs.WebHdfsSensor",
+                        provider: "apache-hdfs",
                         version: "1.0.0"
                 },
                 )),
-                ["airflow", "hooks", "dbapi", "DbApiHook"] => Some((
+
+                // apache-airflow-providers-apache-hive
+                ["airflow", "hooks", "hive_hooks", "HIVE_QUEUE_PRIORITIES"] => Some((
                     qualname.to_string(),
-                    Replacement::ImportPathMoved{
-                        original_path: "airflow.hooks.dbapi.DbApiHook",
-                        new_path: "airflow.providers.common.sql.hooks.sql.DbApiHook",
-                        provider: "Common SQL",
+                    Replacement::ProviderName{
+                        name: "airflow.providers.apache.hive.hooks.hive.HIVE_QUEUE_PRIORITIES",
+                        provider: "apache-hive",
                         version: "1.0.0"
                 },
                 )),
+                ["airflow", "macros", "hive", "closest_ds_partition"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "airflow.providers.apache.hive.macros.hive.closest_ds_partition",
+                        provider: "apache-hive",
+                        version: "5.1.0"
+                },
+                )),
+                ["airflow", "macros", "hive", "max_partition"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "airflow.providers.apache.hive.macros.hive.max_partition",
+                        provider: "apache-hive",
+                        version: "5.1.0"
+                },
+                )),
+                ["airflow", "operators", "hive_to_mysql", "HiveToMySqlOperator"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "airflow.providers.apache.hive.transfers.hive_to_mysql.HiveToMySqlOperator",
+                        provider: "apache-hive",
+                        version: "1.0.0"
+                },
+                )),
+                ["airflow", "operators", "hive_to_mysql", "HiveToMySqlTransfer"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "airflow.providers.apache.hive.transfers.hive_to_mysql.HiveToMySqlOperator",
+                        provider: "apache-hive",
+                        version: "1.0.0"
+                },
+                )),
+                ["airflow", "operators", "hive_to_samba_operator", "HiveToSambaOperator"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "HiveToSambaOperator",
+                        provider: "apache-hive",
+                        version: "1.0.0"
+                },
+                )),
+                ["airflow", "operators", "mssql_to_hive", "MsSqlToHiveOperator"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "airflow.providers.apache.hive.transfers.mssql_to_hive.MsSqlToHiveOperator",
+                        provider: "apache-hive",
+                        version: "1.0.0"
+                },
+                )),
+                ["airflow", "operators", "mssql_to_hive", "MsSqlToHiveTransfer"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "airflow.providers.apache.hive.transfers.mssql_to_hive.MsSqlToHiveOperator",
+                        provider: "apache-hive",
+                        version: "1.0.0"
+                },
+                )),
+                ["airflow", "operators", "mysql_to_hive", "MySqlToHiveOperator"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "airflow.providers.apache.hive.transfers.mysql_to_hive.MySqlToHiveOperator",
+                        provider: "apache-hive",
+                        version: "1.0.0"
+                },
+                )),
+                ["airflow", "operators", "mysql_to_hive", "MySqlToHiveTransfer"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "airflow.providers.apache.hive.transfers.mysql_to_hive.MySqlToHiveOperator",
+                        provider: "apache-hive",
+                        version: "1.0.0"
+                },
+                )),
+                ["airflow", "operators", "s3_to_hive_operator", "S3ToHiveOperator"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "airflow.providers.apache.hive.transfers.s3_to_hive.S3ToHiveOperator",
+                        provider: "apache-hive",
+                        version: "1.0.0"
+                },
+                )),
+                ["airflow", "operators", "s3_to_hive_operator", "S3ToHiveTransfer"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "airflow.providers.apache.hive.transfers.s3_to_hive.S3ToHiveOperator",
+                        provider: "apache-hive",
+                        version: "1.0.0"
+                },
+                )),
+                ["airflow", "hooks", "hive_hooks", "HiveCliHook"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "airflow.providers.apache.hive.hooks.hive.HiveCliHook",
+                        provider: "apache-hive",
+                        version: "1.0.0"
+                    },
+                )),
+                ["airflow", "hooks", "hive_hooks", "HiveMetastoreHook"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "airflow.providers.apache.hive.hooks.hive.HiveMetastoreHook",
+                        provider: "apache-hive",
+                        version: "1.0.0"
+                    },
+                )),
+
+                ["airflow", "hooks", "hive_hooks", "HiveServer2Hook"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "airflow.providers.apache.hive.hooks.hive.HiveServer2Hook",
+                        provider: "apache-hive",
+                        version: "1.0.0"
+                },
+                )),
+                ["airflow", "operators", "hive_operator", "HiveOperator"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "airflow.providers.apache.hive.operators.hive.HiveOperator",
+                        provider: "apache-hive",
+                        version: "1.0.0"
+                },
+                )),
+                ["airflow", "operators", "hive_stats_operator", "HiveStatsCollectionOperator"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "airflow.providers.apache.hive.operators.hive_stats.HiveStatsCollectionOperator",
+                        provider: "apache-hive",
+                        version: "1.0.0"
+                },
+                )),
+                ["airflow", "sensors", "hive_partition_sensor", "HivePartitionSensor"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "airflow.providers.apache.hive.sensors.hive_partition.HivePartitionSensor",
+                        provider: "apache-hive",
+                        version: "1.0.0"
+                },
+                )),
+                ["airflow", "sensors", "metastore_partition_sensor", "MetastorePartitionSensor"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "airflow.providers.apache.hive.sensors.metastore_partition.MetastorePartitionSensor",
+                        provider: "apache-hive",
+                        version: "1.0.0"
+                },
+                )),
+                ["airflow", "sensors", "named_hive_partition_sensor", "NamedHivePartitionSensor"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "airflow.providers.apache.hive.sensors.named_hive_partition.NamedHivePartitionSensor",
+                        provider: "apache-hive",
+                        version: "1.0.0"
+                },
+                )),
+
+                // apache-airflow-providers-http
+                ["airflow", "hooks", "http_hook", "HttpHook"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "airflow.providers.http.hooks.http.HttpHook",
+                        provider: "http",
+                        version: "1.0.0"
+                },
+                )),
+                ["airflow", "operators", "http_operator", "SimpleHttpOperator"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "airflow.providers.http.operators.http.SimpleHttpOperator",
+                        provider: "http",
+                        version: "1.0.0"
+                },
+                )),
+                ["airflow", "sensors", "http_sensor", "HttpSensor"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "airflow.providers.http.sensors.http.HttpSensor",
+                        provider: "http",
+                        version: "1.0.0"
+                },
+                )),
+
+                // apache-airflow-providers-jdbc
+                ["airflow", "hooks", "jdbc_hook", "JdbcHook"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "airflow.providers.jdbc.hooks.jdbc.JdbcHook",
+                        provider: "jdbc",
+                        version: "1.0.0"
+                },
+                )),
+                ["airflow", "hooks", "jdbc_hook", "jaydebeapi"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "airflow.providers.jdbc.hooks.jdbc.jaydebeapi",
+                        provider: "jdbc",
+                        version: "1.0.0"
+                },
+                )),
+                ["airflow", "operators", "jdbc_operator", "JdbcOperator"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "airflow.providers.jdbc.operators.jdbc.JdbcOperator",
+                        provider: "jdbc",
+                        version: "1.0.0"
+                },
+                )),
+
                 // apache-airflow-providers-cncf-kubernetes
                 ["airflow", "executors", "kubernetes_executor_types", "ALL_NAMESPACES"] => Some((
                     qualname.to_string(),
                     Replacement::ImportPathMoved{
                         original_path: "airflow.executors.kubernetes_executor_types.ALL_NAMESPACES",
                         new_path: "airflow.providers.cncf.kubernetes.executors.kubernetes_executor_types.ALL_NAMESPACES",
-                        provider: "Kubernetes",
+                        provider: "kubernetes",
                         version: "7.4.0"
                 },
                 )),
@@ -233,903 +868,210 @@ fn moved_to_provider(checker: &mut Checker, expr: &Expr, ranged: impl Ranged) {
                     Replacement::ImportPathMoved{
                         original_path: "airflow.executors.kubernetes_executor_types.POD_EXECUTOR_DONE_KEY",
                         new_path: "airflow.providers.cncf.kubernetes.executors.kubernetes_executor_types.POD_EXECUTOR_DONE_KEY",
-                        provider: "Kubernetes",
+                        provider: "kubernetes",
                         version: "7.4.0"
                 },
                 )),
-                // apache-airflow-providers-apache-hive
-                ["airflow", "hooks", "hive_hooks", "HIVE_QUEUE_PRIORITIES"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "HIVE_QUEUE_PRIORITIES",
-                        provider: "Apache Hive",
-                        version: "1.0.0"
-                },
-                )),
-                ["airflow", "macros", "hive", "closest_ds_partition"] => Some((
-                    qualname.to_string(),
-                    Replacement::ImportPathMoved{
-                        original_path: "airflow.macros.hive.closest_ds_partition",
-                        new_path: "airflow.providers.apache.hive.macros.hive.closest_ds_partition",
-                        provider: "Apache Hive",
-                        version: "5.1.0"
-                },
-                )),
-                ["airflow", "macros", "hive", "max_partition"] => Some((
-                    qualname.to_string(),
-                    Replacement::ImportPathMoved{
-                        original_path: "airflow.macros.hive.max_partition",
-                        new_path: "airflow.providers.apache.hive.macros.hive.max_partition",
-                        provider: "Apache Hive",
-                        version: "5.1.0"
-                },
-                )),
 
-                // TODO: reorganize
-                ["airflow", "hooks", "S3_hook", "S3Hook"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "S3Hook",
-                        provider: "Amazon",
-                        version: "TBD"
-                },
-                )),
-
-                ["airflow", "hooks", "S3_hook", "provide_bucket_name"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "provide_bucket_name",
-                        provider: "Amazon",
-                        version: "TBD"
-                },
-                )),
-
-                ["airflow", "hooks", "base_hook", "BaseHook"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "BaseHook",
-                        provider: "Base",
-                        version: "TBD"
-                },
-                )),
-
-                ["airflow", "hooks", "dbapi_hook", "DbApiHook"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "DbApiHook",
-                        provider: "Common Sql",
-                        version: "TBD"
-                },
-                )),
-
-                ["airflow", "hooks", "docker_hook", "DockerHook"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "DockerHook",
-                        provider: "Docker",
-                        version: "TBD"
-                },
-                )),
-
-                ["airflow", "hooks", "druid_hook", "DruidDbApiHook"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "DruidDbApiHook",
-                        provider: "Apache Druid",
-                        version: "TBD"
-                },
-                )),
-
-                ["airflow", "hooks", "druid_hook", "DruidHook"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "DruidHook",
-                        provider: "Apache Druid",
-                        version: "TBD"
-                },
-                )),
-
-
-                ["airflow", "hooks", "hive_hooks", "HiveCliHook"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "HiveCliHook",
-                        provider: "Apache Hive",
-                        version: "TBD"
-                },
-                )),
-
-                ["airflow", "hooks", "hive_hooks", "HiveMetastoreHook"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "HiveMetastoreHook",
-                        provider: "Apache Hive",
-                        version: "TBD"
-                },
-                )),
-
-                ["airflow", "hooks", "hive_hooks", "HiveServer2Hook"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "HiveServer2Hook",
-                        provider: "Apache Hive",
-                        version: "TBD"
-                },
-                )),
-
-                ["airflow", "hooks", "http_hook", "HttpHook"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "HttpHook",
-                        provider: "Http",
-                        version: "TBD"
-                },
-                )),
-
-                ["airflow", "hooks", "jdbc_hook", "JdbcHook"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "JdbcHook",
-                        provider: "Jdbc",
-                        version: "TBD"
-                },
-                )),
-
-                ["airflow", "hooks", "jdbc_hook", "jaydebeapi"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "jaydebeapi",
-                        provider: "Jdbc",
-                        version: "TBD"
-                },
-                )),
-
+                // apache-airflow-providers-microsoft-mssql
                 ["airflow", "hooks", "mssql_hook", "MsSqlHook"] => Some((
                     qualname.to_string(),
                     Replacement::ProviderName{
-                        name: "MsSqlHook",
-                        provider: "Microsoft",
-                        version: "TBD"
+                        name: "airflow.providers.microsoft.mssql.hooks.mssql.MsSqlHook",
+                        provider: "microsoft-mssql",
+                        version: "1.0.0"
                 },
                 )),
-
-                ["airflow", "hooks", "mysql_hook", "MySqlHook"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "MySqlHook",
-                        provider: "Mysql",
-                        version: "TBD"
-                },
-                )),
-
-                ["airflow", "hooks", "oracle_hook", "OracleHook"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "OracleHook",
-                        provider: "Oracle",
-                        version: "TBD"
-                },
-                )),
-
-                ["airflow", "hooks", "pig_hook", "PigCliHook"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "PigCliHook",
-                        provider: "Apache Pig",
-                        version: "TBD"
-                },
-                )),
-
-                ["airflow", "hooks", "postgres_hook", "PostgresHook"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "PostgresHook",
-                        provider: "Postgres",
-                        version: "TBD"
-                },
-                )),
-
-                ["airflow", "hooks", "presto_hook", "PrestoHook"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "PrestoHook",
-                        provider: "Presto",
-                        version: "TBD"
-                },
-                )),
-
-                ["airflow", "hooks", "samba_hook", "SambaHook"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "SambaHook",
-                        provider: "Samba",
-                        version: "TBD"
-                },
-                )),
-
-                ["airflow", "hooks", "slack_hook", "SlackHook"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "SlackHook",
-                        provider: "Slack",
-                        version: "TBD"
-                },
-                )),
-
-                ["airflow", "hooks", "sqlite_hook", "SqliteHook"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "SqliteHook",
-                        provider: "Sqlite",
-                        version: "TBD"
-                },
-                )),
-
-                ["airflow", "hooks", "webhdfs_hook", "WebHDFSHook"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "WebHDFSHook",
-                        provider: "Apache Hdfs",
-                        version: "TBD"
-                },
-                )),
-
-                ["airflow", "hooks", "zendesk_hook", "ZendeskHook"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "ZendeskHook",
-                        provider: "Zendesk",
-                        version: "TBD"
-                },
-                )),
-
-                ["airflow", "operators", "check_operator", "SQLCheckOperator"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "SQLCheckOperator",
-                        provider: "Common Sql",
-                        version: "TBD"
-                },
-                )),
-
-                ["airflow", "operators", "check_operator", "SQLIntervalCheckOperator"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "SQLIntervalCheckOperator",
-                        provider: "Common Sql",
-                        version: "TBD"
-                },
-                )),
-
-                ["airflow", "operators", "check_operator", "SQLThresholdCheckOperator"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "SQLThresholdCheckOperator",
-                        provider: "Common Sql",
-                        version: "TBD"
-                },
-                )),
-
-                ["airflow", "operators", "check_operator", "SQLValueCheckOperator"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "SQLValueCheckOperator",
-                        provider: "Common Sql",
-                        version: "TBD"
-                },
-                )),
-
-                ["airflow", "operators", "check_operator", "CheckOperator"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "CheckOperator",
-                        provider: "Common Sql",
-                        version: "TBD"
-                },
-                )),
-
-                ["airflow", "operators", "check_operator", "IntervalCheckOperator"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "IntervalCheckOperator",
-                        provider: "Common Sql",
-                        version: "TBD"
-                },
-                )),
-
-                ["airflow", "operators", "check_operator", "ThresholdCheckOperator"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "ThresholdCheckOperator",
-                        provider: "Common Sql",
-                        version: "TBD"
-                },
-                )),
-
-                ["airflow", "operators", "check_operator", "ValueCheckOperator"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "ValueCheckOperator",
-                        provider: "Common Sql",
-                        version: "TBD"
-                },
-                )),
-
-                ["airflow", "operators", "docker_operator", "DockerOperator"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "DockerOperator",
-                        provider: "Docker",
-                        version: "TBD"
-                },
-                )),
-
-                ["airflow", "operators", "druid_check_operator", "DruidCheckOperator"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "DruidCheckOperator",
-                        provider: "Apache Druid",
-                        version: "TBD"
-                },
-                )),
-
-                ["airflow", "operators", "gcs_to_s3", "GCSToS3Operator"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "GCSToS3Operator",
-                        provider: "Amazon",
-                        version: "TBD"
-                },
-                )),
-
-                ["airflow", "operators", "google_api_to_s3_transfer", "GoogleApiToS3Operator"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "GoogleApiToS3Operator",
-                        provider: "Amazon",
-                        version: "TBD"
-                },
-                )),
-
-                ["airflow", "operators", "google_api_to_s3_transfer", "GoogleApiToS3Transfer"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "GoogleApiToS3Transfer",
-                        provider: "Amazon",
-                        version: "TBD"
-                },
-                )),
-
-                ["airflow", "operators", "hive_operator", "HiveOperator"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "HiveOperator",
-                        provider: "Apache Hive",
-                        version: "TBD"
-                },
-                )),
-
-                ["airflow", "operators", "hive_stats_operator", "HiveStatsCollectionOperator"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "HiveStatsCollectionOperator",
-                        provider: "Apache Hive",
-                        version: "TBD"
-                },
-                )),
-
-                ["airflow", "operators", "hive_to_druid", "HiveToDruidOperator"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "HiveToDruidOperator",
-                        provider: "Apache Druid",
-                        version: "TBD"
-                },
-                )),
-
-                ["airflow", "operators", "hive_to_druid", "HiveToDruidTransfer"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "HiveToDruidTransfer",
-                        provider: "Apache Druid",
-                        version: "TBD"
-                },
-                )),
-
-                ["airflow", "operators", "hive_to_mysql", "HiveToMySqlOperator"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "HiveToMySqlOperator",
-                        provider: "Apache Hive",
-                        version: "TBD"
-                },
-                )),
-
-                ["airflow", "operators", "hive_to_mysql", "HiveToMySqlTransfer"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "HiveToMySqlTransfer",
-                        provider: "Apache Hive",
-                        version: "TBD"
-                },
-                )),
-
-                ["airflow", "operators", "hive_to_samba_operator", "HiveToSambaOperator"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "HiveToSambaOperator",
-                        provider: "Apache Hive",
-                        version: "TBD"
-                },
-                )),
-
-                ["airflow", "operators", "http_operator", "SimpleHttpOperator"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "SimpleHttpOperator",
-                        provider: "Http",
-                        version: "TBD"
-                },
-                )),
-
-                ["airflow", "operators", "jdbc_operator", "JdbcOperator"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "JdbcOperator",
-                        provider: "Jdbc",
-                        version: "TBD"
-                },
-                )),
-
-                ["airflow", "operators", "latest_only_operator", "LatestOnlyOperator"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "LatestOnlyOperator",
-                        provider: "Latest_only",
-                        version: "TBD"
-                },
-                )),
-
                 ["airflow", "operators", "mssql_operator", "MsSqlOperator"] => Some((
                     qualname.to_string(),
                     Replacement::ProviderName{
-                        name: "MsSqlOperator",
-                        provider: "Microsoft",
-                        version: "TBD"
+                        name: "airflow.providers.microsoft.mssql.operators.mssql.MsSqlOperator",
+                        provider: "microsoft-mssql",
+                        version: "1.0.0"
                 },
                 )),
 
-                ["airflow", "operators", "mssql_to_hive", "MsSqlToHiveOperator"] => Some((
+                // apache-airflow-providers-mysql
+                ["airflow", "hooks", "mysql_hook", "MySqlHook"] => Some((
                     qualname.to_string(),
                     Replacement::ProviderName{
-                        name: "MsSqlToHiveOperator",
-                        provider: "Apache Hive",
-                        version: "TBD"
+                        name: "airflow.providers.mysql.hooks.mysql.MySqlHook",
+                        provider: "mysql",
+                        version: "1.0.0"
                 },
                 )),
-
-                ["airflow", "operators", "mssql_to_hive", "MsSqlToHiveTransfer"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "MsSqlToHiveTransfer",
-                        provider: "Apache Hive",
-                        version: "TBD"
-                },
-                )),
-
                 ["airflow", "operators", "mysql_operator", "MySqlOperator"] => Some((
                     qualname.to_string(),
                     Replacement::ProviderName{
-                        name: "MySqlOperator",
-                        provider: "Mysql",
-                        version: "TBD"
+                        name: "airflow.providers.mysql.operators.mysql.MySqlOperator",
+                        provider: "mysql",
+                        version: "1.0.0"
                 },
                 )),
-
-                ["airflow", "operators", "mysql_to_hive", "MySqlToHiveOperator"] => Some((
+                ["airflow", "operators", "presto_to_mysql", "PrestoToMySqlOperator"] => Some((
                     qualname.to_string(),
                     Replacement::ProviderName{
-                        name: "MySqlToHiveOperator",
-                        provider: "Apache Hive",
-                        version: "TBD"
+                        name: "airflow.providers.mysql.transfers.presto_to_mysql.PrestoToMySqlOperator",
+                        provider: "mysql",
+                        version: "1.0.0"
                 },
                 )),
-
-                ["airflow", "operators", "mysql_to_hive", "MySqlToHiveTransfer"] => Some((
+                ["airflow", "operators", "presto_to_mysql", "PrestoToMySqlTransfer"] => Some((
                     qualname.to_string(),
                     Replacement::ProviderName{
-                        name: "MySqlToHiveTransfer",
-                        provider: "Apache Hive",
-                        version: "TBD"
+                        name: "airflow.providers.mysql.transfers.presto_to_mysql.PrestoToMySqlOperator",
+                        provider: "mysql",
+                        version: "1.0.0"
                 },
                 )),
 
+                // apache-airflow-providers-oracle
+                ["airflow", "hooks", "oracle_hook", "OracleHook"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "airflow.providers.oracle.hooks.oracle.OracleHook",
+                        provider: "oracle",
+                        version: "1.0.0"
+                },
+                )),
                 ["airflow", "operators", "oracle_operator", "OracleOperator"] => Some((
                     qualname.to_string(),
                     Replacement::ProviderName{
-                        name: "OracleOperator",
-                        provider: "Oracle",
-                        version: "TBD"
+                        name: "airflow.providers.oracle.operators.oracle.OracleOperator",
+                        provider: "oracle",
+                        version: "1.0.0"
                 },
                 )),
 
+                // apache-airflow-providers-papermill
                 ["airflow", "operators", "papermill_operator", "PapermillOperator"] => Some((
                     qualname.to_string(),
                     Replacement::ProviderName{
-                        name: "PapermillOperator",
-                        provider: "Papermill",
-                        version: "TBD"
+                        name: "airflow.providers.papermill.operators.papermill.PapermillOperator",
+                        provider: "papermill",
+                        version: "1.0.0"
                 },
                 )),
 
+                // apache-airflow-providers-apache-pig
+                ["airflow", "hooks", "pig_hook", "PigCliHook"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "airflow.providers.apache.pig.hooks.pig.PigCliHook",
+                        provider: "apache-pig",
+                        version: "1.0.0"
+                },
+                )),
                 ["airflow", "operators", "pig_operator", "PigOperator"] => Some((
                     qualname.to_string(),
                     Replacement::ProviderName{
-                        name: "PigOperator",
-                        provider: "Apache Pig",
-                        version: "TBD"
+                        name: "airflow.providers.apache.pig.operators.pig.PigOperator",
+                        provider: "apache-pig",
+                        version: "1.0.0"
                 },
                 )),
 
+                // apache-airflow-providers-postgres
+                ["airflow", "hooks", "postgres_hook", "PostgresHook"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "airflow.providers.postgres.hooks.postgres.PostgresHook",
+                        provider: "postgres",
+                        version: "1.0.0"
+                },
+                )),
                 ["airflow", "operators", "postgres_operator", "Mapping"] => Some((
                     qualname.to_string(),
                     Replacement::ProviderName{
-                        name: "Mapping",
-                        provider: "Postgres",
-                        version: "TBD"
+                        name: "airflow.providers.postgres.operators.postgres.Mapping",
+                        provider: "postgres",
+                        version: "1.0.0"
                 },
                 )),
 
                 ["airflow", "operators", "postgres_operator", "PostgresOperator"] => Some((
                     qualname.to_string(),
                     Replacement::ProviderName{
-                        name: "PostgresOperator",
-                        provider: "Postgres",
-                        version: "TBD"
+                        name: "airflow.providers.postgres.operators.postgres.PostgresOperator",
+                        provider: "postgres",
+                        version: "1.0.0"
                 },
                 )),
 
-                ["airflow", "operators", "presto_check_operator", "SQLCheckOperator"] => Some((
+                // apache-airflow-providers-presto
+                ["airflow", "hooks", "presto_hook", "PrestoHook"] => Some((
                     qualname.to_string(),
                     Replacement::ProviderName{
-                        name: "SQLCheckOperator",
-                        provider: "Common Sql",
-                        version: "TBD"
+                        name: "airflow.providers.presto.hooks.presto.PrestoHook",
+                        provider: "presto",
+                        version: "1.0.0"
                 },
                 )),
 
-                ["airflow", "operators", "presto_check_operator", "SQLIntervalCheckOperator"] => Some((
+                // apache-airflow-providers-samba
+                ["airflow", "hooks", "samba_hook", "SambaHook"] => Some((
                     qualname.to_string(),
                     Replacement::ProviderName{
-                        name: "SQLIntervalCheckOperator",
-                        provider: "Common Sql",
-                        version: "TBD"
+                        name: "airflow.providers.samba.hooks.samba.SambaHook",
+                        provider: "samba",
+                        version: "1.0.0"
                 },
                 )),
 
-                ["airflow", "operators", "presto_check_operator", "SQLValueCheckOperator"] => Some((
+                // apache-airflow-providers-slack
+                ["airflow", "hooks", "slack_hook", "SlackHook"] => Some((
                     qualname.to_string(),
                     Replacement::ProviderName{
-                        name: "SQLValueCheckOperator",
-                        provider: "Common Sql",
-                        version: "TBD"
+                        name: "airflow.providers.slack.hooks.slack.SlackHook",
+                        provider: "slack",
+                        version: "1.0.0"
                 },
                 )),
-
-                ["airflow", "operators", "presto_check_operator", "PrestoCheckOperator"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "PrestoCheckOperator",
-                        provider: "Common Sql",
-                        version: "TBD"
-                },
-                )),
-
-                ["airflow", "operators", "presto_check_operator", "PrestoIntervalCheckOperator"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "PrestoIntervalCheckOperator",
-                        provider: "Common Sql",
-                        version: "TBD"
-                },
-                )),
-
-                ["airflow", "operators", "presto_check_operator", "PrestoValueCheckOperator"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "PrestoValueCheckOperator",
-                        provider: "Common Sql",
-                        version: "TBD"
-                },
-                )),
-
-                ["airflow", "operators", "presto_to_mysql", "PrestoToMySqlOperator"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "PrestoToMySqlOperator",
-                        provider: "Mysql",
-                        version: "TBD"
-                },
-                )),
-
-                ["airflow", "operators", "presto_to_mysql", "PrestoToMySqlTransfer"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "PrestoToMySqlTransfer",
-                        provider: "Mysql",
-                        version: "TBD"
-                },
-                )),
-
-                ["airflow", "operators", "redshift_to_s3_operator", "RedshiftToS3Operator"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "RedshiftToS3Operator",
-                        provider: "Amazon",
-                        version: "TBD"
-                },
-                )),
-
-                ["airflow", "operators", "redshift_to_s3_operator", "RedshiftToS3Transfer"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "RedshiftToS3Transfer",
-                        provider: "Amazon",
-                        version: "TBD"
-                },
-                )),
-
-                ["airflow", "operators", "s3_file_transform_operator", "S3FileTransformOperator"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "S3FileTransformOperator",
-                        provider: "Amazon",
-                        version: "TBD"
-                },
-                )),
-
-                ["airflow", "operators", "s3_to_hive_operator", "S3ToHiveOperator"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "S3ToHiveOperator",
-                        provider: "Apache Hive",
-                        version: "TBD"
-                },
-                )),
-
-                ["airflow", "operators", "s3_to_hive_operator", "S3ToHiveTransfer"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "S3ToHiveTransfer",
-                        provider: "Apache Hive",
-                        version: "TBD"
-                },
-                )),
-
-                ["airflow", "operators", "s3_to_redshift_operator", "S3ToRedshiftOperator"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "S3ToRedshiftOperator",
-                        provider: "Amazon",
-                        version: "TBD"
-                },
-                )),
-
-                ["airflow", "operators", "s3_to_redshift_operator", "S3ToRedshiftTransfer"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "S3ToRedshiftTransfer",
-                        provider: "Amazon",
-                        version: "TBD"
-                },
-                )),
-
                 ["airflow", "operators", "slack_operator", "SlackAPIOperator"] => Some((
                     qualname.to_string(),
                     Replacement::ProviderName{
-                        name: "SlackAPIOperator",
-                        provider: "Slack",
-                        version: "TBD"
+                        name: "airflow.providers.slack.operators.slack.SlackAPIOperator",
+                        provider: "slack",
+                        version: "1.0.0"
                 },
                 )),
-
                 ["airflow", "operators", "slack_operator", "SlackAPIPostOperator"] => Some((
                     qualname.to_string(),
                     Replacement::ProviderName{
-                        name: "SlackAPIPostOperator",
-                        provider: "Slack",
-                        version: "TBD"
+                        name: "airflow.providers.slack.operators.slack.SlackAPIPostOperator",
+                        provider: "slack",
+                        version: "1.0.0"
                 },
                 )),
 
-                ["airflow", "operators", "sql", "BaseSQLOperator"] => Some((
+                // apache-airflow-providers-sqlite
+                ["airflow", "hooks", "sqlite_hook", "SqliteHook"] => Some((
                     qualname.to_string(),
                     Replacement::ProviderName{
-                        name: "BaseSQLOperator",
-                        provider: "Common Sql",
-                        version: "TBD"
+                        name: "airflow.providers.sqlite.hooks.sqlite.SqliteHook",
+                        provider: "sqlite",
+                        version: "1.0.0"
                 },
                 )),
-
-                ["airflow", "operators", "sql", "BranchSQLOperator"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "BranchSQLOperator",
-                        provider: "Common Sql",
-                        version: "TBD"
-                },
-                )),
-
-                ["airflow", "operators", "sql", "SQLCheckOperator"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "SQLCheckOperator",
-                        provider: "Common Sql",
-                        version: "TBD"
-                },
-                )),
-
-                ["airflow", "operators", "sql", "SQLColumnCheckOperator"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "SQLColumnCheckOperator",
-                        provider: "Common Sql",
-                        version: "TBD"
-                },
-                )),
-
-                ["airflow", "operators", "sql", "SQLIntervalCheckOperator"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "SQLIntervalCheckOperator",
-                        provider: "Common Sql",
-                        version: "TBD"
-                },
-                )),
-
-                ["airflow", "operators", "sql", "SQLTableCheckOperator"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "SQLTableCheckOperator",
-                        provider: "Common Sql",
-                        version: "TBD"
-                },
-                )),
-
-                ["airflow", "operators", "sql", "SQLThresholdCheckOperator"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "SQLThresholdCheckOperator",
-                        provider: "Common Sql",
-                        version: "TBD"
-                },
-                )),
-
-                ["airflow", "operators", "sql", "SQLValueCheckOperator"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "SQLValueCheckOperator",
-                        provider: "Common Sql",
-                        version: "TBD"
-                },
-                )),
-
-                ["airflow", "operators", "sql", "_convert_to_float_if_possible"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "_convert_to_float_if_possible",
-                        provider: "Common Sql",
-                        version: "TBD"
-                },
-                )),
-
-                ["airflow", "operators", "sql", "parse_boolean"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "parse_boolean",
-                        provider: "Common Sql",
-                        version: "TBD"
-                },
-                )),
-
-                ["airflow", "operators", "sql_branch_operator", "BranchSQLOperator"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "BranchSQLOperator",
-                        provider: "Common Sql",
-                        version: "TBD"
-                },
-                )),
-
-                ["airflow", "operators", "sql_branch_operator", "BranchSqlOperator"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "BranchSqlOperator",
-                        provider: "Common Sql",
-                        version: "TBD"
-                },
-                )),
-
                 ["airflow", "operators", "sqlite_operator", "SqliteOperator"] => Some((
                     qualname.to_string(),
                     Replacement::ProviderName{
-                        name: "SqliteOperator",
-                        provider: "Sqlite",
-                        version: "TBD"
+                        name: "airflow.providers.sqlite.operators.sqlite.SqliteOperator",
+                        provider: "sqlite",
+                        version: "1.0.0"
                 },
                 )),
 
-                ["airflow", "sensors", "hive_partition_sensor", "HivePartitionSensor"] => Some((
+                // apache-airflow-providers-zendesk
+                ["airflow", "hooks", "zendesk_hook", "ZendeskHook"] => Some((
                     qualname.to_string(),
                     Replacement::ProviderName{
-                        name: "HivePartitionSensor",
-                        provider: "Apache Hive",
-                        version: "TBD"
+                        name: "airflow.providers.zendesk.hooks.zendesk.ZendeskHook",
+                        provider: "zendesk",
+                        version: "1.0.0"
                 },
                 )),
 
-                ["airflow", "sensors", "http_sensor", "HttpSensor"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "HttpSensor",
-                        provider: "Http",
-                        version: "TBD"
-                },
-                )),
-
-                ["airflow", "sensors", "metastore_partition_sensor", "MetastorePartitionSensor"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "MetastorePartitionSensor",
-                        provider: "Apache Hive",
-                        version: "TBD"
-                },
-                )),
-
-                ["airflow", "sensors", "named_hive_partition_sensor", "NamedHivePartitionSensor"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "NamedHivePartitionSensor",
-                        provider: "Apache Hive",
-                        version: "TBD"
-                },
-                )),
-
-                ["airflow", "sensors", "s3_key_sensor", "S3KeySensor"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "S3KeySensor",
-                        provider: "Amazon",
-                        version: "TBD"
-                },
-                )),
-
-                ["airflow", "sensors", "sql", "SqlSensor"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "SqlSensor",
-                        provider: "Common Sql",
-                        version: "TBD"
-                },
-                )),
-
-                ["airflow", "sensors", "sql_sensor", "SqlSensor"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "SqlSensor",
-                        provider: "Common Sql",
-                        version: "TBD"
-                },
-                )),
-
-                ["airflow", "sensors", "web_hdfs_sensor", "WebHdfsSensor"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "WebHdfsSensor",
-                        provider: "Apache Hdfs",
-                        version: "TBD"
-                },
-                )),
                 _ => None,
             });
     if let Some((deprecated, replacement)) = result {
@@ -1140,20 +1082,5 @@ fn moved_to_provider(checker: &mut Checker, expr: &Expr, ranged: impl Ranged) {
             },
             ranged.range(),
         ));
-    }
-}
-
-/// AIR303
-pub(crate) fn moved_to_provider_in_3(checker: &mut Checker, expr: &Expr) {
-    if !checker.semantic().seen_module(Modules::AIRFLOW) {
-        return;
-    }
-
-    match expr {
-        Expr::Attribute(ExprAttribute { attr: ranged, .. }) => {
-            moved_to_provider(checker, expr, ranged);
-        }
-        ranged @ Expr::Name(_) => moved_to_provider(checker, expr, ranged),
-        _ => {}
     }
 }

--- a/crates/ruff_linter/src/rules/airflow/rules/moved_to_provider_in_3.rs
+++ b/crates/ruff_linter/src/rules/airflow/rules/moved_to_provider_in_3.rs
@@ -1059,7 +1059,77 @@ fn moved_to_provider(checker: &mut Checker, expr: &Expr, ranged: impl Ranged) {
                 },
                 )),
 
+                ["airflow", "sensors", "hive_partition_sensor", "HivePartitionSensor"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "HivePartitionSensor",
+                        provider: "Apache Hive",
+                        version: "TBD"
+                },
+                )),
 
+                ["airflow", "sensors", "http_sensor", "HttpSensor"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "HttpSensor",
+                        provider: "Http",
+                        version: "TBD"
+                },
+                )),
+
+                ["airflow", "sensors", "metastore_partition_sensor", "MetastorePartitionSensor"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "MetastorePartitionSensor",
+                        provider: "Apache Hive",
+                        version: "TBD"
+                },
+                )),
+
+                ["airflow", "sensors", "named_hive_partition_sensor", "NamedHivePartitionSensor"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "NamedHivePartitionSensor",
+                        provider: "Apache Hive",
+                        version: "TBD"
+                },
+                )),
+
+                ["airflow", "sensors", "s3_key_sensor", "S3KeySensor"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "S3KeySensor",
+                        provider: "Amazon",
+                        version: "TBD"
+                },
+                )),
+
+                ["airflow", "sensors", "sql", "SqlSensor"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "SqlSensor",
+                        provider: "Common Sql",
+                        version: "TBD"
+                },
+                )),
+
+                ["airflow", "sensors", "sql_sensor", "SqlSensor"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "SqlSensor",
+                        provider: "Common Sql",
+                        version: "TBD"
+                },
+                )),
+
+                ["airflow", "sensors", "web_hdfs_sensor", "WebHdfsSensor"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "WebHdfsSensor",
+                        provider: "Apache Hdfs",
+                        version: "TBD"
+                },
+                )),
                 _ => None,
             });
     if let Some((deprecated, replacement)) = result {

--- a/crates/ruff_linter/src/rules/airflow/rules/moved_to_provider_in_3.rs
+++ b/crates/ruff_linter/src/rules/airflow/rules/moved_to_provider_in_3.rs
@@ -174,6 +174,31 @@ fn moved_to_provider(checker: &mut Checker, expr: &Expr, ranged: impl Ranged) {
                         version: "3.3.0"
                 },
                 )),
+                ["airflow", "executors", "celery_executor", "CeleryExecutor"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "airflow.providers.celery.executors.celery_executor.CeleryExecutor",
+                        provider: "celery",
+                        version: "3.3.0"
+                },
+                )),
+                ["airflow", "executors", "celery_kubernetes_executor", "CeleryKubernetesExecutor"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "airflow.providers.celery.executors.celery_kubernetes_executor.CeleryKubernetesExecutor",
+                        provider: "celery",
+                        version: "3.3.0"
+                },
+                )),
+                // apache-airflow-providers-daskexecutor
+                ["airflow", "executors", "dask_executor", "DaskExecutor"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "airflow.providers.daskexecutor.executors.dask_executor.DaskExecutor",
+                        provider: "daskexecutor",
+                        version: "1.0.0"
+                },
+                )),
                 // apache-airflow-providers-common-sql
                 ["airflow", "hooks", "dbapi", "ConnectorProtocol"] => Some((
                     qualname.to_string(),

--- a/crates/ruff_linter/src/rules/airflow/rules/moved_to_provider_in_3.rs
+++ b/crates/ruff_linter/src/rules/airflow/rules/moved_to_provider_in_3.rs
@@ -240,9 +240,8 @@ fn moved_to_provider(checker: &mut Checker, expr: &Expr, ranged: impl Ranged) {
                 // apache-airflow-providers-apache-hive
                 ["airflow", "hooks", "hive_hooks", "HIVE_QUEUE_PRIORITIES"] => Some((
                     qualname.to_string(),
-                    Replacement::ImportPathMoved{
-                        original_path: "airflow.hooks.hive_hooks.HIVE_QUEUE_PRIORITIES",
-                        new_path: "airflow.providers.apache.hive.hooks.hive.HIVE_QUEUE_PRIORITIES",
+                    Replacement::ProviderName{
+                        name: "HIVE_QUEUE_PRIORITIES",
                         provider: "Apache Hive",
                         version: "1.0.0"
                 },
@@ -265,6 +264,225 @@ fn moved_to_provider(checker: &mut Checker, expr: &Expr, ranged: impl Ranged) {
                         version: "5.1.0"
                 },
                 )),
+
+                // TODO: reorganize
+                ["airflow", "hooks", "S3_hook", "S3Hook"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "S3Hook",
+                        provider: "Amazon",
+                        version: "TBD"
+                },
+                )),
+
+                ["airflow", "hooks", "S3_hook", "provide_bucket_name"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "provide_bucket_name",
+                        provider: "Amazon",
+                        version: "TBD"
+                },
+                )),
+
+                ["airflow", "hooks", "base_hook", "BaseHook"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "BaseHook",
+                        provider: "Base",
+                        version: "TBD"
+                },
+                )),
+
+                ["airflow", "hooks", "dbapi_hook", "DbApiHook"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "DbApiHook",
+                        provider: "Common Sql",
+                        version: "TBD"
+                },
+                )),
+
+                ["airflow", "hooks", "docker_hook", "DockerHook"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "DockerHook",
+                        provider: "Docker",
+                        version: "TBD"
+                },
+                )),
+
+                ["airflow", "hooks", "druid_hook", "DruidDbApiHook"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "DruidDbApiHook",
+                        provider: "Apache Druid",
+                        version: "TBD"
+                },
+                )),
+
+                ["airflow", "hooks", "druid_hook", "DruidHook"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "DruidHook",
+                        provider: "Apache Druid",
+                        version: "TBD"
+                },
+                )),
+
+
+                ["airflow", "hooks", "hive_hooks", "HiveCliHook"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "HiveCliHook",
+                        provider: "Apache Hive",
+                        version: "TBD"
+                },
+                )),
+
+                ["airflow", "hooks", "hive_hooks", "HiveMetastoreHook"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "HiveMetastoreHook",
+                        provider: "Apache Hive",
+                        version: "TBD"
+                },
+                )),
+
+                ["airflow", "hooks", "hive_hooks", "HiveServer2Hook"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "HiveServer2Hook",
+                        provider: "Apache Hive",
+                        version: "TBD"
+                },
+                )),
+
+                ["airflow", "hooks", "http_hook", "HttpHook"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "HttpHook",
+                        provider: "Http",
+                        version: "TBD"
+                },
+                )),
+
+                ["airflow", "hooks", "jdbc_hook", "JdbcHook"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "JdbcHook",
+                        provider: "Jdbc",
+                        version: "TBD"
+                },
+                )),
+
+                ["airflow", "hooks", "jdbc_hook", "jaydebeapi"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "jaydebeapi",
+                        provider: "Jdbc",
+                        version: "TBD"
+                },
+                )),
+
+                ["airflow", "hooks", "mssql_hook", "MsSqlHook"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "MsSqlHook",
+                        provider: "Microsoft",
+                        version: "TBD"
+                },
+                )),
+
+                ["airflow", "hooks", "mysql_hook", "MySqlHook"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "MySqlHook",
+                        provider: "Mysql",
+                        version: "TBD"
+                },
+                )),
+
+                ["airflow", "hooks", "oracle_hook", "OracleHook"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "OracleHook",
+                        provider: "Oracle",
+                        version: "TBD"
+                },
+                )),
+
+                ["airflow", "hooks", "pig_hook", "PigCliHook"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "PigCliHook",
+                        provider: "Apache Pig",
+                        version: "TBD"
+                },
+                )),
+
+                ["airflow", "hooks", "postgres_hook", "PostgresHook"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "PostgresHook",
+                        provider: "Postgres",
+                        version: "TBD"
+                },
+                )),
+
+                ["airflow", "hooks", "presto_hook", "PrestoHook"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "PrestoHook",
+                        provider: "Presto",
+                        version: "TBD"
+                },
+                )),
+
+                ["airflow", "hooks", "samba_hook", "SambaHook"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "SambaHook",
+                        provider: "Samba",
+                        version: "TBD"
+                },
+                )),
+
+                ["airflow", "hooks", "slack_hook", "SlackHook"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "SlackHook",
+                        provider: "Slack",
+                        version: "TBD"
+                },
+                )),
+
+                ["airflow", "hooks", "sqlite_hook", "SqliteHook"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "SqliteHook",
+                        provider: "Sqlite",
+                        version: "TBD"
+                },
+                )),
+
+                ["airflow", "hooks", "webhdfs_hook", "WebHDFSHook"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "WebHDFSHook",
+                        provider: "Apache Hdfs",
+                        version: "TBD"
+                },
+                )),
+
+                ["airflow", "hooks", "zendesk_hook", "ZendeskHook"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "ZendeskHook",
+                        provider: "Zendesk",
+                        version: "TBD"
+                },
+                )),
+
                 _ => None,
             });
     if let Some((deprecated, replacement)) = result {

--- a/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR303_AIR303.py.snap
+++ b/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR303_AIR303.py.snap
@@ -2,468 +2,1170 @@
 source: crates/ruff_linter/src/rules/airflow/mod.rs
 snapshot_kind: text
 ---
-AIR303.py:45:1: AIR303 Import path `airflow.api.auth.backend.basic_auth` is moved into `fab` provider in Airflow 3.0;
-   |
-44 | # apache-airflow-providers-fab
-45 | basic_auth, kerberos_auth
-   | ^^^^^^^^^^ AIR303
-46 | auth_current_user
-47 | backend_kerberos_auth
-   |
-   = help: Install `apache-airflow-provider-fab>=1.0.0` and import from `airflow.providers.fab.auth_manager.api.auth.backend.basic_auth` instead.
-
-AIR303.py:45:13: AIR303 Import path `airflow.api.auth.backend.kerberos_auth` is moved into `fab` provider in Airflow 3.0;
-   |
-44 | # apache-airflow-providers-fab
-45 | basic_auth, kerberos_auth
-   |             ^^^^^^^^^^^^^ AIR303
-46 | auth_current_user
-47 | backend_kerberos_auth
-   |
-   = help: Install `apache-airflow-provider-fab>=1.0.0` and import from `airflow.providers.fab.auth_manager.api.auth.backend.kerberos_auth` instead.
-
-AIR303.py:46:1: AIR303 Import path `airflow.api.auth.backend.basic_auth` is moved into `fab` provider in Airflow 3.0;
-   |
-44 | # apache-airflow-providers-fab
-45 | basic_auth, kerberos_auth
-46 | auth_current_user
-   | ^^^^^^^^^^^^^^^^^ AIR303
-47 | backend_kerberos_auth
-48 | fab_override
-   |
-   = help: Install `apache-airflow-provider-fab>=1.0.0` and import from `airflow.providers.fab.auth_manager.api.auth.backend.basic_auth` instead.
-
-AIR303.py:47:1: AIR303 Import path `airflow.auth_manager.api.auth.backend.kerberos_auth` is moved into `fab` provider in Airflow 3.0;
-   |
-45 | basic_auth, kerberos_auth
-46 | auth_current_user
-47 | backend_kerberos_auth
-   | ^^^^^^^^^^^^^^^^^^^^^ AIR303
-48 | fab_override
-   |
-   = help: Install `apache-airflow-provider-fab>=1.0.0` and import from `airflow.providers.fab.auth_manager.api.auth.backend.kerberos_auth` instead.
-
-AIR303.py:48:1: AIR303 Import path `airflow.auth.managers.fab.security_managr.override` is moved into `fab` provider in Airflow 3.0;
-   |
-46 | auth_current_user
-47 | backend_kerberos_auth
-48 | fab_override
-   | ^^^^^^^^^^^^ AIR303
-49 | 
-50 | FabAuthManager()
-   |
-   = help: Install `apache-airflow-provider-fab>=1.0.0` and import from `airflow.providers.fab.auth_manager.security_manager.override` instead.
-
-AIR303.py:50:1: AIR303 `airflow.auth.managers.fab.fab_auth_manager.FabAuthManager` is moved into `fab` provider in Airflow 3.0;
-   |
-48 | fab_override
-49 | 
-50 | FabAuthManager()
-   | ^^^^^^^^^^^^^^ AIR303
-51 | FabAirflowSecurityManagerOverride()
-   |
-   = help: Install `apache-airflow-provider-fab>=1.0.0` and use `airflow.providers.fab.auth_manager.security_manager.FabAuthManager` instead.
-
-AIR303.py:51:1: AIR303 `airflow.www.security.FabAirflowSecurityManagerOverride` is moved into `fab` provider in Airflow 3.0;
-   |
-50 | FabAuthManager()
-51 | FabAirflowSecurityManagerOverride()
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR303
-52 | 
-53 | # apache-airflow-providers-celery
-   |
-   = help: Install `apache-airflow-provider-fab>=1.0.0` and use `airflow.providers.fab.auth_manager.security_manager.override.FabAirflowSecurityManagerOverride` instead.
-
-AIR303.py:54:1: AIR303 Import path `airflow.config_templates.default_celery.DEFAULT_CELERY_CONFIG` is moved into `celery` provider in Airflow 3.0;
-   |
-53 | # apache-airflow-providers-celery
-54 | DEFAULT_CELERY_CONFIG
-   | ^^^^^^^^^^^^^^^^^^^^^ AIR303
-55 | app
-56 | CeleryExecutor()
-   |
-   = help: Install `apache-airflow-provider-celery>=3.3.0` and import from `airflow.providers.celery.executors.default_celery.DEFAULT_CELERY_CONFIG` instead.
-
-AIR303.py:55:1: AIR303 Import path `airflow.executors.celery_executor.app` is moved into `celery` provider in Airflow 3.0;
-   |
-53 | # apache-airflow-providers-celery
-54 | DEFAULT_CELERY_CONFIG
-55 | app
-   | ^^^ AIR303
-56 | CeleryExecutor()
-57 | CeleryKubernetesExecutor()
-   |
-   = help: Install `apache-airflow-provider-celery>=3.3.0` and import from `airflow.providers.celery.executors.celery_executor_utils.app` instead.
-
-AIR303.py:56:1: AIR303 `airflow.executors.celery_executor.CeleryExecutor` is moved into `celery` provider in Airflow 3.0;
-   |
-54 | DEFAULT_CELERY_CONFIG
-55 | app
-56 | CeleryExecutor()
-   | ^^^^^^^^^^^^^^ AIR303
-57 | CeleryKubernetesExecutor()
-   |
-   = help: Install `apache-airflow-provider-celery>=3.3.0` and use `airflow.providers.celery.executors.celery_executor.CeleryExecutor` instead.
-
-AIR303.py:57:1: AIR303 `airflow.executors.celery_kubernetes_executor.CeleryKubernetesExecutor` is moved into `celery` provider in Airflow 3.0;
-   |
-55 | app
-56 | CeleryExecutor()
-57 | CeleryKubernetesExecutor()
-   | ^^^^^^^^^^^^^^^^^^^^^^^^ AIR303
-58 | 
-59 | # apache-airflow-providers-daskexecutor
-   |
-   = help: Install `apache-airflow-provider-celery>=3.3.0` and use `airflow.providers.celery.executors.celery_kubernetes_executor.CeleryKubernetesExecutor` instead.
-
-AIR303.py:60:1: AIR303 `airflow.executors.dask_executor.DaskExecutor` is moved into `daskexecutor` provider in Airflow 3.0;
-   |
-59 | # apache-airflow-providers-daskexecutor
-60 | DaskExecutor()
-   | ^^^^^^^^^^^^ AIR303
-61 | 
-62 | # apache-airflow-providers-common-sql
-   |
-   = help: Install `apache-airflow-provider-daskexecutor>=1.0.0` and use `airflow.providers.daskexecutor.executors.dask_executor.DaskExecutor` instead.
-
-AIR303.py:63:1: AIR303 Import path `airflow.hooks.dbapi.ConnectorProtocol` is moved into `Common SQL` provider in Airflow 3.0;
-   |
-62 | # apache-airflow-providers-common-sql
-63 | ConnectorProtocol()
-   | ^^^^^^^^^^^^^^^^^ AIR303
-64 | DbApiHook()
-   |
-   = help: Install `apache-airflow-provider-Common SQL>=1.0.0` and import from `airflow.providers.common.sql.hooks.sql.ConnectorProtocol` instead.
-
-AIR303.py:64:1: AIR303 Import path `airflow.hooks.dbapi.DbApiHook` is moved into `Common SQL` provider in Airflow 3.0;
-   |
-62 | # apache-airflow-providers-common-sql
-63 | ConnectorProtocol()
-64 | DbApiHook()
-   | ^^^^^^^^^ AIR303
-65 | 
-66 | # apache-airflow-providers-cncf-kubernetes
-   |
-   = help: Install `apache-airflow-provider-Common SQL>=1.0.0` and import from `airflow.providers.common.sql.hooks.sql.DbApiHook` instead.
-
-AIR303.py:67:1: AIR303 Import path `airflow.executors.kubernetes_executor_types.ALL_NAMESPACES` is moved into `Kubernetes` provider in Airflow 3.0;
-   |
-66 | # apache-airflow-providers-cncf-kubernetes
-67 | ALL_NAMESPACES
-   | ^^^^^^^^^^^^^^ AIR303
-68 | POD_EXECUTOR_DONE_KEY
-   |
-   = help: Install `apache-airflow-provider-Kubernetes>=7.4.0` and import from `airflow.providers.cncf.kubernetes.executors.kubernetes_executor_types.ALL_NAMESPACES` instead.
-
-AIR303.py:68:1: AIR303 Import path `airflow.executors.kubernetes_executor_types.POD_EXECUTOR_DONE_KEY` is moved into `Kubernetes` provider in Airflow 3.0;
-   |
-66 | # apache-airflow-providers-cncf-kubernetes
-67 | ALL_NAMESPACES
-68 | POD_EXECUTOR_DONE_KEY
-   | ^^^^^^^^^^^^^^^^^^^^^ AIR303
-69 | 
-70 | # apache-airflow-providers-apache-hive
-   |
-   = help: Install `apache-airflow-provider-Kubernetes>=7.4.0` and import from `airflow.providers.cncf.kubernetes.executors.kubernetes_executor_types.POD_EXECUTOR_DONE_KEY` instead.
-
-AIR303.py:71:1: AIR303 `airflow.hooks.hive_hooks.HIVE_QUEUE_PRIORITIES` is moved into `Apache Hive` provider in Airflow 3.0;
-   |
-70 | # apache-airflow-providers-apache-hive
-71 | HIVE_QUEUE_PRIORITIES
-   | ^^^^^^^^^^^^^^^^^^^^^ AIR303
-72 | closest_ds_partition()
-73 | max_partition()
-   |
-   = help: Install `apache-airflow-provider-Apache Hive>=1.0.0` and use `HIVE_QUEUE_PRIORITIES` instead.
-
-AIR303.py:72:1: AIR303 Import path `airflow.macros.hive.closest_ds_partition` is moved into `Apache Hive` provider in Airflow 3.0;
-   |
-70 | # apache-airflow-providers-apache-hive
-71 | HIVE_QUEUE_PRIORITIES
-72 | closest_ds_partition()
-   | ^^^^^^^^^^^^^^^^^^^^ AIR303
-73 | max_partition()
-   |
-   = help: Install `apache-airflow-provider-Apache Hive>=5.1.0` and import from `airflow.providers.apache.hive.macros.hive.closest_ds_partition` instead.
-
-AIR303.py:73:1: AIR303 Import path `airflow.macros.hive.max_partition` is moved into `Apache Hive` provider in Airflow 3.0;
-   |
-71 | HIVE_QUEUE_PRIORITIES
-72 | closest_ds_partition()
-73 | max_partition()
-   | ^^^^^^^^^^^^^ AIR303
-74 | 
-75 | # TODO: reorganize
-   |
-   = help: Install `apache-airflow-provider-Apache Hive>=5.1.0` and import from `airflow.providers.apache.hive.macros.hive.max_partition` instead.
-
-AIR303.py:76:1: AIR303 `airflow.hooks.S3_hook.S3Hook` is moved into `Amazon` provider in Airflow 3.0;
-   |
-75 | # TODO: reorganize
-76 | S3Hook()
-   | ^^^^^^ AIR303
-77 | provide_bucket_name()
-78 | BaseHook()
-   |
-   = help: Install `apache-airflow-provider-Amazon>=TBD` and use `S3Hook` instead.
-
-AIR303.py:77:1: AIR303 `airflow.hooks.S3_hook.provide_bucket_name` is moved into `Amazon` provider in Airflow 3.0;
-   |
-75 | # TODO: reorganize
-76 | S3Hook()
-77 | provide_bucket_name()
-   | ^^^^^^^^^^^^^^^^^^^ AIR303
-78 | BaseHook()
-79 | DbApiHook2()
-   |
-   = help: Install `apache-airflow-provider-Amazon>=TBD` and use `provide_bucket_name` instead.
-
-AIR303.py:78:1: AIR303 `airflow.hooks.base_hook.BaseHook` is moved into `Base` provider in Airflow 3.0;
-   |
-76 | S3Hook()
-77 | provide_bucket_name()
-78 | BaseHook()
-   | ^^^^^^^^ AIR303
-79 | DbApiHook2()
-80 | DockerHook()
-   |
-   = help: Install `apache-airflow-provider-Base>=TBD` and use `BaseHook` instead.
-
-AIR303.py:79:1: AIR303 `airflow.hooks.dbapi_hook.DbApiHook` is moved into `Common Sql` provider in Airflow 3.0;
-   |
-77 | provide_bucket_name()
-78 | BaseHook()
-79 | DbApiHook2()
-   | ^^^^^^^^^^ AIR303
-80 | DockerHook()
-81 | DruidDbApiHook()
-   |
-   = help: Install `apache-airflow-provider-Common Sql>=TBD` and use `DbApiHook` instead.
-
-AIR303.py:80:1: AIR303 `airflow.hooks.docker_hook.DockerHook` is moved into `Docker` provider in Airflow 3.0;
-   |
-78 | BaseHook()
-79 | DbApiHook2()
-80 | DockerHook()
-   | ^^^^^^^^^^ AIR303
-81 | DruidDbApiHook()
-82 | DruidHook()
-   |
-   = help: Install `apache-airflow-provider-Docker>=TBD` and use `DockerHook` instead.
-
-AIR303.py:81:1: AIR303 `airflow.hooks.druid_hook.DruidDbApiHook` is moved into `Apache Druid` provider in Airflow 3.0;
-   |
-79 | DbApiHook2()
-80 | DockerHook()
-81 | DruidDbApiHook()
-   | ^^^^^^^^^^^^^^ AIR303
-82 | DruidHook()
-83 | HIVE_QUEUE_PRIORITIES()
-   |
-   = help: Install `apache-airflow-provider-Apache Druid>=TBD` and use `DruidDbApiHook` instead.
-
-AIR303.py:82:1: AIR303 `airflow.hooks.druid_hook.DruidHook` is moved into `Apache Druid` provider in Airflow 3.0;
-   |
-80 | DockerHook()
-81 | DruidDbApiHook()
-82 | DruidHook()
-   | ^^^^^^^^^ AIR303
-83 | HIVE_QUEUE_PRIORITIES()
-84 | HiveCliHook()
-   |
-   = help: Install `apache-airflow-provider-Apache Druid>=TBD` and use `DruidHook` instead.
-
-AIR303.py:83:1: AIR303 `airflow.hooks.hive_hooks.HIVE_QUEUE_PRIORITIES` is moved into `Apache Hive` provider in Airflow 3.0;
-   |
-81 | DruidDbApiHook()
-82 | DruidHook()
-83 | HIVE_QUEUE_PRIORITIES()
-   | ^^^^^^^^^^^^^^^^^^^^^ AIR303
-84 | HiveCliHook()
-85 | HiveMetastoreHook()
-   |
-   = help: Install `apache-airflow-provider-Apache Hive>=1.0.0` and use `HIVE_QUEUE_PRIORITIES` instead.
-
-AIR303.py:84:1: AIR303 `airflow.hooks.hive_hooks.HiveCliHook` is moved into `Apache Hive` provider in Airflow 3.0;
-   |
-82 | DruidHook()
-83 | HIVE_QUEUE_PRIORITIES()
-84 | HiveCliHook()
-   | ^^^^^^^^^^^ AIR303
-85 | HiveMetastoreHook()
-86 | HiveServer2Hook()
-   |
-   = help: Install `apache-airflow-provider-Apache Hive>=TBD` and use `HiveCliHook` instead.
-
-AIR303.py:85:1: AIR303 `airflow.hooks.hive_hooks.HiveMetastoreHook` is moved into `Apache Hive` provider in Airflow 3.0;
-   |
-83 | HIVE_QUEUE_PRIORITIES()
-84 | HiveCliHook()
-85 | HiveMetastoreHook()
-   | ^^^^^^^^^^^^^^^^^ AIR303
-86 | HiveServer2Hook()
-87 | HttpHook()
-   |
-   = help: Install `apache-airflow-provider-Apache Hive>=TBD` and use `HiveMetastoreHook` instead.
-
-AIR303.py:86:1: AIR303 `airflow.hooks.hive_hooks.HiveServer2Hook` is moved into `Apache Hive` provider in Airflow 3.0;
-   |
-84 | HiveCliHook()
-85 | HiveMetastoreHook()
-86 | HiveServer2Hook()
-   | ^^^^^^^^^^^^^^^ AIR303
-87 | HttpHook()
-88 | JdbcHook()
-   |
-   = help: Install `apache-airflow-provider-Apache Hive>=TBD` and use `HiveServer2Hook` instead.
-
-AIR303.py:87:1: AIR303 `airflow.hooks.http_hook.HttpHook` is moved into `Http` provider in Airflow 3.0;
-   |
-85 | HiveMetastoreHook()
-86 | HiveServer2Hook()
-87 | HttpHook()
-   | ^^^^^^^^ AIR303
-88 | JdbcHook()
-89 | jaydebeapi()
-   |
-   = help: Install `apache-airflow-provider-Http>=TBD` and use `HttpHook` instead.
-
-AIR303.py:88:1: AIR303 `airflow.hooks.jdbc_hook.JdbcHook` is moved into `Jdbc` provider in Airflow 3.0;
-   |
-86 | HiveServer2Hook()
-87 | HttpHook()
-88 | JdbcHook()
-   | ^^^^^^^^ AIR303
-89 | jaydebeapi()
-90 | MsSqlHook()
-   |
-   = help: Install `apache-airflow-provider-Jdbc>=TBD` and use `JdbcHook` instead.
-
-AIR303.py:89:1: AIR303 `airflow.hooks.jdbc_hook.jaydebeapi` is moved into `Jdbc` provider in Airflow 3.0;
-   |
-87 | HttpHook()
-88 | JdbcHook()
-89 | jaydebeapi()
-   | ^^^^^^^^^^ AIR303
-90 | MsSqlHook()
-91 | MySqlHook()
-   |
-   = help: Install `apache-airflow-provider-Jdbc>=TBD` and use `jaydebeapi` instead.
-
-AIR303.py:90:1: AIR303 `airflow.hooks.mssql_hook.MsSqlHook` is moved into `Microsoft` provider in Airflow 3.0;
-   |
-88 | JdbcHook()
-89 | jaydebeapi()
-90 | MsSqlHook()
-   | ^^^^^^^^^ AIR303
-91 | MySqlHook()
-92 | OracleHook()
-   |
-   = help: Install `apache-airflow-provider-Microsoft>=TBD` and use `MsSqlHook` instead.
-
-AIR303.py:91:1: AIR303 `airflow.hooks.mysql_hook.MySqlHook` is moved into `Mysql` provider in Airflow 3.0;
-   |
-89 | jaydebeapi()
-90 | MsSqlHook()
-91 | MySqlHook()
-   | ^^^^^^^^^ AIR303
-92 | OracleHook()
-93 | PigCliHook()
-   |
-   = help: Install `apache-airflow-provider-Mysql>=TBD` and use `MySqlHook` instead.
-
-AIR303.py:92:1: AIR303 `airflow.hooks.oracle_hook.OracleHook` is moved into `Oracle` provider in Airflow 3.0;
-   |
-90 | MsSqlHook()
-91 | MySqlHook()
-92 | OracleHook()
-   | ^^^^^^^^^^ AIR303
-93 | PigCliHook()
-94 | PostgresHook()
-   |
-   = help: Install `apache-airflow-provider-Oracle>=TBD` and use `OracleHook` instead.
-
-AIR303.py:93:1: AIR303 `airflow.hooks.pig_hook.PigCliHook` is moved into `Apache Pig` provider in Airflow 3.0;
-   |
-91 | MySqlHook()
-92 | OracleHook()
-93 | PigCliHook()
-   | ^^^^^^^^^^ AIR303
-94 | PostgresHook()
-95 | PrestoHook()
-   |
-   = help: Install `apache-airflow-provider-Apache Pig>=TBD` and use `PigCliHook` instead.
-
-AIR303.py:94:1: AIR303 `airflow.hooks.postgres_hook.PostgresHook` is moved into `Postgres` provider in Airflow 3.0;
-   |
-92 | OracleHook()
-93 | PigCliHook()
-94 | PostgresHook()
-   | ^^^^^^^^^^^^ AIR303
-95 | PrestoHook()
-96 | SambaHook()
-   |
-   = help: Install `apache-airflow-provider-Postgres>=TBD` and use `PostgresHook` instead.
-
-AIR303.py:95:1: AIR303 `airflow.hooks.presto_hook.PrestoHook` is moved into `Presto` provider in Airflow 3.0;
-   |
-93 | PigCliHook()
-94 | PostgresHook()
-95 | PrestoHook()
-   | ^^^^^^^^^^ AIR303
-96 | SambaHook()
-97 | SlackHook()
-   |
-   = help: Install `apache-airflow-provider-Presto>=TBD` and use `PrestoHook` instead.
-
-AIR303.py:96:1: AIR303 `airflow.hooks.samba_hook.SambaHook` is moved into `Samba` provider in Airflow 3.0;
-   |
-94 | PostgresHook()
-95 | PrestoHook()
-96 | SambaHook()
-   | ^^^^^^^^^ AIR303
-97 | SlackHook()
-98 | SqliteHook()
-   |
-   = help: Install `apache-airflow-provider-Samba>=TBD` and use `SambaHook` instead.
-
-AIR303.py:97:1: AIR303 `airflow.hooks.slack_hook.SlackHook` is moved into `Slack` provider in Airflow 3.0;
-   |
-95 | PrestoHook()
-96 | SambaHook()
-97 | SlackHook()
-   | ^^^^^^^^^ AIR303
-98 | SqliteHook()
-99 | WebHDFSHook()
-   |
-   = help: Install `apache-airflow-provider-Slack>=TBD` and use `SlackHook` instead.
-
-AIR303.py:98:1: AIR303 `airflow.hooks.sqlite_hook.SqliteHook` is moved into `Sqlite` provider in Airflow 3.0;
+AIR303.py:111:1: AIR303 Import path `airflow.api.auth.backend.basic_auth` is moved into `fab` provider in Airflow 3.0;
     |
- 96 | SambaHook()
- 97 | SlackHook()
- 98 | SqliteHook()
+110 | # apache-airflow-providers-fab
+111 | basic_auth, kerberos_auth
     | ^^^^^^^^^^ AIR303
- 99 | WebHDFSHook()
-100 | ZendeskHook()
+112 | auth_current_user
+113 | backend_kerberos_auth
+    |
+    = help: Install `apache-airflow-provider-fab>=1.0.0` and import from `airflow.providers.fab.auth_manager.api.auth.backend.basic_auth` instead.
+
+AIR303.py:111:13: AIR303 Import path `airflow.api.auth.backend.kerberos_auth` is moved into `fab` provider in Airflow 3.0;
+    |
+110 | # apache-airflow-providers-fab
+111 | basic_auth, kerberos_auth
+    |             ^^^^^^^^^^^^^ AIR303
+112 | auth_current_user
+113 | backend_kerberos_auth
+    |
+    = help: Install `apache-airflow-provider-fab>=1.0.0` and import from `airflow.providers.fab.auth_manager.api.auth.backend.kerberos_auth` instead.
+
+AIR303.py:112:1: AIR303 Import path `airflow.api.auth.backend.basic_auth` is moved into `fab` provider in Airflow 3.0;
+    |
+110 | # apache-airflow-providers-fab
+111 | basic_auth, kerberos_auth
+112 | auth_current_user
+    | ^^^^^^^^^^^^^^^^^ AIR303
+113 | backend_kerberos_auth
+114 | fab_override
+    |
+    = help: Install `apache-airflow-provider-fab>=1.0.0` and import from `airflow.providers.fab.auth_manager.api.auth.backend.basic_auth` instead.
+
+AIR303.py:113:1: AIR303 Import path `airflow.auth_manager.api.auth.backend.kerberos_auth` is moved into `fab` provider in Airflow 3.0;
+    |
+111 | basic_auth, kerberos_auth
+112 | auth_current_user
+113 | backend_kerberos_auth
+    | ^^^^^^^^^^^^^^^^^^^^^ AIR303
+114 | fab_override
+    |
+    = help: Install `apache-airflow-provider-fab>=1.0.0` and import from `airflow.providers.fab.auth_manager.api.auth.backend.kerberos_auth` instead.
+
+AIR303.py:114:1: AIR303 Import path `airflow.auth.managers.fab.security_managr.override` is moved into `fab` provider in Airflow 3.0;
+    |
+112 | auth_current_user
+113 | backend_kerberos_auth
+114 | fab_override
+    | ^^^^^^^^^^^^ AIR303
+115 | 
+116 | FabAuthManager()
+    |
+    = help: Install `apache-airflow-provider-fab>=1.0.0` and import from `airflow.providers.fab.auth_manager.security_manager.override` instead.
+
+AIR303.py:116:1: AIR303 `airflow.auth.managers.fab.fab_auth_manager.FabAuthManager` is moved into `fab` provider in Airflow 3.0;
+    |
+114 | fab_override
+115 | 
+116 | FabAuthManager()
+    | ^^^^^^^^^^^^^^ AIR303
+117 | FabAirflowSecurityManagerOverride()
+    |
+    = help: Install `apache-airflow-provider-fab>=1.0.0` and use `airflow.providers.fab.auth_manager.security_manager.FabAuthManager` instead.
+
+AIR303.py:117:1: AIR303 `airflow.www.security.FabAirflowSecurityManagerOverride` is moved into `fab` provider in Airflow 3.0;
+    |
+116 | FabAuthManager()
+117 | FabAirflowSecurityManagerOverride()
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR303
+118 | 
+119 | # apache-airflow-providers-celery
+    |
+    = help: Install `apache-airflow-provider-fab>=1.0.0` and use `airflow.providers.fab.auth_manager.security_manager.override.FabAirflowSecurityManagerOverride` instead.
+
+AIR303.py:120:1: AIR303 Import path `airflow.config_templates.default_celery.DEFAULT_CELERY_CONFIG` is moved into `celery` provider in Airflow 3.0;
+    |
+119 | # apache-airflow-providers-celery
+120 | DEFAULT_CELERY_CONFIG
+    | ^^^^^^^^^^^^^^^^^^^^^ AIR303
+121 | app
+122 | CeleryExecutor()
+    |
+    = help: Install `apache-airflow-provider-celery>=3.3.0` and import from `airflow.providers.celery.executors.default_celery.DEFAULT_CELERY_CONFIG` instead.
+
+AIR303.py:121:1: AIR303 Import path `airflow.executors.celery_executor.app` is moved into `celery` provider in Airflow 3.0;
+    |
+119 | # apache-airflow-providers-celery
+120 | DEFAULT_CELERY_CONFIG
+121 | app
+    | ^^^ AIR303
+122 | CeleryExecutor()
+123 | CeleryKubernetesExecutor()
+    |
+    = help: Install `apache-airflow-provider-celery>=3.3.0` and import from `airflow.providers.celery.executors.celery_executor_utils.app` instead.
+
+AIR303.py:122:1: AIR303 `airflow.executors.celery_executor.CeleryExecutor` is moved into `celery` provider in Airflow 3.0;
+    |
+120 | DEFAULT_CELERY_CONFIG
+121 | app
+122 | CeleryExecutor()
+    | ^^^^^^^^^^^^^^ AIR303
+123 | CeleryKubernetesExecutor()
+    |
+    = help: Install `apache-airflow-provider-celery>=3.3.0` and use `airflow.providers.celery.executors.celery_executor.CeleryExecutor` instead.
+
+AIR303.py:123:1: AIR303 `airflow.executors.celery_kubernetes_executor.CeleryKubernetesExecutor` is moved into `celery` provider in Airflow 3.0;
+    |
+121 | app
+122 | CeleryExecutor()
+123 | CeleryKubernetesExecutor()
+    | ^^^^^^^^^^^^^^^^^^^^^^^^ AIR303
+124 | 
+125 | # apache-airflow-providers-daskexecutor
+    |
+    = help: Install `apache-airflow-provider-celery>=3.3.0` and use `airflow.providers.celery.executors.celery_kubernetes_executor.CeleryKubernetesExecutor` instead.
+
+AIR303.py:126:1: AIR303 `airflow.executors.dask_executor.DaskExecutor` is moved into `daskexecutor` provider in Airflow 3.0;
+    |
+125 | # apache-airflow-providers-daskexecutor
+126 | DaskExecutor()
+    | ^^^^^^^^^^^^ AIR303
+127 | 
+128 | # apache-airflow-providers-common-sql
+    |
+    = help: Install `apache-airflow-provider-daskexecutor>=1.0.0` and use `airflow.providers.daskexecutor.executors.dask_executor.DaskExecutor` instead.
+
+AIR303.py:129:1: AIR303 Import path `airflow.hooks.dbapi.ConnectorProtocol` is moved into `Common SQL` provider in Airflow 3.0;
+    |
+128 | # apache-airflow-providers-common-sql
+129 | ConnectorProtocol()
+    | ^^^^^^^^^^^^^^^^^ AIR303
+130 | DbApiHook()
+    |
+    = help: Install `apache-airflow-provider-Common SQL>=1.0.0` and import from `airflow.providers.common.sql.hooks.sql.ConnectorProtocol` instead.
+
+AIR303.py:130:1: AIR303 Import path `airflow.hooks.dbapi.DbApiHook` is moved into `Common SQL` provider in Airflow 3.0;
+    |
+128 | # apache-airflow-providers-common-sql
+129 | ConnectorProtocol()
+130 | DbApiHook()
+    | ^^^^^^^^^ AIR303
+131 | 
+132 | # apache-airflow-providers-cncf-kubernetes
+    |
+    = help: Install `apache-airflow-provider-Common SQL>=1.0.0` and import from `airflow.providers.common.sql.hooks.sql.DbApiHook` instead.
+
+AIR303.py:133:1: AIR303 Import path `airflow.executors.kubernetes_executor_types.ALL_NAMESPACES` is moved into `Kubernetes` provider in Airflow 3.0;
+    |
+132 | # apache-airflow-providers-cncf-kubernetes
+133 | ALL_NAMESPACES
+    | ^^^^^^^^^^^^^^ AIR303
+134 | POD_EXECUTOR_DONE_KEY
+    |
+    = help: Install `apache-airflow-provider-Kubernetes>=7.4.0` and import from `airflow.providers.cncf.kubernetes.executors.kubernetes_executor_types.ALL_NAMESPACES` instead.
+
+AIR303.py:134:1: AIR303 Import path `airflow.executors.kubernetes_executor_types.POD_EXECUTOR_DONE_KEY` is moved into `Kubernetes` provider in Airflow 3.0;
+    |
+132 | # apache-airflow-providers-cncf-kubernetes
+133 | ALL_NAMESPACES
+134 | POD_EXECUTOR_DONE_KEY
+    | ^^^^^^^^^^^^^^^^^^^^^ AIR303
+135 | 
+136 | # apache-airflow-providers-apache-hive
+    |
+    = help: Install `apache-airflow-provider-Kubernetes>=7.4.0` and import from `airflow.providers.cncf.kubernetes.executors.kubernetes_executor_types.POD_EXECUTOR_DONE_KEY` instead.
+
+AIR303.py:137:1: AIR303 `airflow.hooks.hive_hooks.HIVE_QUEUE_PRIORITIES` is moved into `Apache Hive` provider in Airflow 3.0;
+    |
+136 | # apache-airflow-providers-apache-hive
+137 | HIVE_QUEUE_PRIORITIES
+    | ^^^^^^^^^^^^^^^^^^^^^ AIR303
+138 | closest_ds_partition()
+139 | max_partition()
+    |
+    = help: Install `apache-airflow-provider-Apache Hive>=1.0.0` and use `HIVE_QUEUE_PRIORITIES` instead.
+
+AIR303.py:138:1: AIR303 Import path `airflow.macros.hive.closest_ds_partition` is moved into `Apache Hive` provider in Airflow 3.0;
+    |
+136 | # apache-airflow-providers-apache-hive
+137 | HIVE_QUEUE_PRIORITIES
+138 | closest_ds_partition()
+    | ^^^^^^^^^^^^^^^^^^^^ AIR303
+139 | max_partition()
+    |
+    = help: Install `apache-airflow-provider-Apache Hive>=5.1.0` and import from `airflow.providers.apache.hive.macros.hive.closest_ds_partition` instead.
+
+AIR303.py:139:1: AIR303 Import path `airflow.macros.hive.max_partition` is moved into `Apache Hive` provider in Airflow 3.0;
+    |
+137 | HIVE_QUEUE_PRIORITIES
+138 | closest_ds_partition()
+139 | max_partition()
+    | ^^^^^^^^^^^^^ AIR303
+140 | 
+141 | # TODO: reorganize
+    |
+    = help: Install `apache-airflow-provider-Apache Hive>=5.1.0` and import from `airflow.providers.apache.hive.macros.hive.max_partition` instead.
+
+AIR303.py:142:1: AIR303 `airflow.hooks.S3_hook.S3Hook` is moved into `Amazon` provider in Airflow 3.0;
+    |
+141 | # TODO: reorganize
+142 | S3Hook()
+    | ^^^^^^ AIR303
+143 | provide_bucket_name()
+144 | BaseHook()
+    |
+    = help: Install `apache-airflow-provider-Amazon>=TBD` and use `S3Hook` instead.
+
+AIR303.py:143:1: AIR303 `airflow.hooks.S3_hook.provide_bucket_name` is moved into `Amazon` provider in Airflow 3.0;
+    |
+141 | # TODO: reorganize
+142 | S3Hook()
+143 | provide_bucket_name()
+    | ^^^^^^^^^^^^^^^^^^^ AIR303
+144 | BaseHook()
+145 | DbApiHook2()
+    |
+    = help: Install `apache-airflow-provider-Amazon>=TBD` and use `provide_bucket_name` instead.
+
+AIR303.py:144:1: AIR303 `airflow.hooks.base_hook.BaseHook` is moved into `Base` provider in Airflow 3.0;
+    |
+142 | S3Hook()
+143 | provide_bucket_name()
+144 | BaseHook()
+    | ^^^^^^^^ AIR303
+145 | DbApiHook2()
+146 | DockerHook()
+    |
+    = help: Install `apache-airflow-provider-Base>=TBD` and use `BaseHook` instead.
+
+AIR303.py:145:1: AIR303 `airflow.hooks.dbapi_hook.DbApiHook` is moved into `Common Sql` provider in Airflow 3.0;
+    |
+143 | provide_bucket_name()
+144 | BaseHook()
+145 | DbApiHook2()
+    | ^^^^^^^^^^ AIR303
+146 | DockerHook()
+147 | DruidDbApiHook()
+    |
+    = help: Install `apache-airflow-provider-Common Sql>=TBD` and use `DbApiHook` instead.
+
+AIR303.py:146:1: AIR303 `airflow.hooks.docker_hook.DockerHook` is moved into `Docker` provider in Airflow 3.0;
+    |
+144 | BaseHook()
+145 | DbApiHook2()
+146 | DockerHook()
+    | ^^^^^^^^^^ AIR303
+147 | DruidDbApiHook()
+148 | DruidHook()
+    |
+    = help: Install `apache-airflow-provider-Docker>=TBD` and use `DockerHook` instead.
+
+AIR303.py:147:1: AIR303 `airflow.hooks.druid_hook.DruidDbApiHook` is moved into `Apache Druid` provider in Airflow 3.0;
+    |
+145 | DbApiHook2()
+146 | DockerHook()
+147 | DruidDbApiHook()
+    | ^^^^^^^^^^^^^^ AIR303
+148 | DruidHook()
+149 | HIVE_QUEUE_PRIORITIES()
+    |
+    = help: Install `apache-airflow-provider-Apache Druid>=TBD` and use `DruidDbApiHook` instead.
+
+AIR303.py:148:1: AIR303 `airflow.hooks.druid_hook.DruidHook` is moved into `Apache Druid` provider in Airflow 3.0;
+    |
+146 | DockerHook()
+147 | DruidDbApiHook()
+148 | DruidHook()
+    | ^^^^^^^^^ AIR303
+149 | HIVE_QUEUE_PRIORITIES()
+150 | HiveCliHook()
+    |
+    = help: Install `apache-airflow-provider-Apache Druid>=TBD` and use `DruidHook` instead.
+
+AIR303.py:149:1: AIR303 `airflow.hooks.hive_hooks.HIVE_QUEUE_PRIORITIES` is moved into `Apache Hive` provider in Airflow 3.0;
+    |
+147 | DruidDbApiHook()
+148 | DruidHook()
+149 | HIVE_QUEUE_PRIORITIES()
+    | ^^^^^^^^^^^^^^^^^^^^^ AIR303
+150 | HiveCliHook()
+151 | HiveMetastoreHook()
+    |
+    = help: Install `apache-airflow-provider-Apache Hive>=1.0.0` and use `HIVE_QUEUE_PRIORITIES` instead.
+
+AIR303.py:150:1: AIR303 `airflow.hooks.hive_hooks.HiveCliHook` is moved into `Apache Hive` provider in Airflow 3.0;
+    |
+148 | DruidHook()
+149 | HIVE_QUEUE_PRIORITIES()
+150 | HiveCliHook()
+    | ^^^^^^^^^^^ AIR303
+151 | HiveMetastoreHook()
+152 | HiveServer2Hook()
+    |
+    = help: Install `apache-airflow-provider-Apache Hive>=TBD` and use `HiveCliHook` instead.
+
+AIR303.py:151:1: AIR303 `airflow.hooks.hive_hooks.HiveMetastoreHook` is moved into `Apache Hive` provider in Airflow 3.0;
+    |
+149 | HIVE_QUEUE_PRIORITIES()
+150 | HiveCliHook()
+151 | HiveMetastoreHook()
+    | ^^^^^^^^^^^^^^^^^ AIR303
+152 | HiveServer2Hook()
+153 | HttpHook()
+    |
+    = help: Install `apache-airflow-provider-Apache Hive>=TBD` and use `HiveMetastoreHook` instead.
+
+AIR303.py:152:1: AIR303 `airflow.hooks.hive_hooks.HiveServer2Hook` is moved into `Apache Hive` provider in Airflow 3.0;
+    |
+150 | HiveCliHook()
+151 | HiveMetastoreHook()
+152 | HiveServer2Hook()
+    | ^^^^^^^^^^^^^^^ AIR303
+153 | HttpHook()
+154 | JdbcHook()
+    |
+    = help: Install `apache-airflow-provider-Apache Hive>=TBD` and use `HiveServer2Hook` instead.
+
+AIR303.py:153:1: AIR303 `airflow.hooks.http_hook.HttpHook` is moved into `Http` provider in Airflow 3.0;
+    |
+151 | HiveMetastoreHook()
+152 | HiveServer2Hook()
+153 | HttpHook()
+    | ^^^^^^^^ AIR303
+154 | JdbcHook()
+155 | jaydebeapi()
+    |
+    = help: Install `apache-airflow-provider-Http>=TBD` and use `HttpHook` instead.
+
+AIR303.py:154:1: AIR303 `airflow.hooks.jdbc_hook.JdbcHook` is moved into `Jdbc` provider in Airflow 3.0;
+    |
+152 | HiveServer2Hook()
+153 | HttpHook()
+154 | JdbcHook()
+    | ^^^^^^^^ AIR303
+155 | jaydebeapi()
+156 | MsSqlHook()
+    |
+    = help: Install `apache-airflow-provider-Jdbc>=TBD` and use `JdbcHook` instead.
+
+AIR303.py:155:1: AIR303 `airflow.hooks.jdbc_hook.jaydebeapi` is moved into `Jdbc` provider in Airflow 3.0;
+    |
+153 | HttpHook()
+154 | JdbcHook()
+155 | jaydebeapi()
+    | ^^^^^^^^^^ AIR303
+156 | MsSqlHook()
+157 | MySqlHook()
+    |
+    = help: Install `apache-airflow-provider-Jdbc>=TBD` and use `jaydebeapi` instead.
+
+AIR303.py:156:1: AIR303 `airflow.hooks.mssql_hook.MsSqlHook` is moved into `Microsoft` provider in Airflow 3.0;
+    |
+154 | JdbcHook()
+155 | jaydebeapi()
+156 | MsSqlHook()
+    | ^^^^^^^^^ AIR303
+157 | MySqlHook()
+158 | OracleHook()
+    |
+    = help: Install `apache-airflow-provider-Microsoft>=TBD` and use `MsSqlHook` instead.
+
+AIR303.py:157:1: AIR303 `airflow.hooks.mysql_hook.MySqlHook` is moved into `Mysql` provider in Airflow 3.0;
+    |
+155 | jaydebeapi()
+156 | MsSqlHook()
+157 | MySqlHook()
+    | ^^^^^^^^^ AIR303
+158 | OracleHook()
+159 | PigCliHook()
+    |
+    = help: Install `apache-airflow-provider-Mysql>=TBD` and use `MySqlHook` instead.
+
+AIR303.py:158:1: AIR303 `airflow.hooks.oracle_hook.OracleHook` is moved into `Oracle` provider in Airflow 3.0;
+    |
+156 | MsSqlHook()
+157 | MySqlHook()
+158 | OracleHook()
+    | ^^^^^^^^^^ AIR303
+159 | PigCliHook()
+160 | PostgresHook()
+    |
+    = help: Install `apache-airflow-provider-Oracle>=TBD` and use `OracleHook` instead.
+
+AIR303.py:159:1: AIR303 `airflow.hooks.pig_hook.PigCliHook` is moved into `Apache Pig` provider in Airflow 3.0;
+    |
+157 | MySqlHook()
+158 | OracleHook()
+159 | PigCliHook()
+    | ^^^^^^^^^^ AIR303
+160 | PostgresHook()
+161 | PrestoHook()
+    |
+    = help: Install `apache-airflow-provider-Apache Pig>=TBD` and use `PigCliHook` instead.
+
+AIR303.py:160:1: AIR303 `airflow.hooks.postgres_hook.PostgresHook` is moved into `Postgres` provider in Airflow 3.0;
+    |
+158 | OracleHook()
+159 | PigCliHook()
+160 | PostgresHook()
+    | ^^^^^^^^^^^^ AIR303
+161 | PrestoHook()
+162 | SambaHook()
+    |
+    = help: Install `apache-airflow-provider-Postgres>=TBD` and use `PostgresHook` instead.
+
+AIR303.py:161:1: AIR303 `airflow.hooks.presto_hook.PrestoHook` is moved into `Presto` provider in Airflow 3.0;
+    |
+159 | PigCliHook()
+160 | PostgresHook()
+161 | PrestoHook()
+    | ^^^^^^^^^^ AIR303
+162 | SambaHook()
+163 | SlackHook()
+    |
+    = help: Install `apache-airflow-provider-Presto>=TBD` and use `PrestoHook` instead.
+
+AIR303.py:162:1: AIR303 `airflow.hooks.samba_hook.SambaHook` is moved into `Samba` provider in Airflow 3.0;
+    |
+160 | PostgresHook()
+161 | PrestoHook()
+162 | SambaHook()
+    | ^^^^^^^^^ AIR303
+163 | SlackHook()
+164 | SqliteHook()
+    |
+    = help: Install `apache-airflow-provider-Samba>=TBD` and use `SambaHook` instead.
+
+AIR303.py:163:1: AIR303 `airflow.hooks.slack_hook.SlackHook` is moved into `Slack` provider in Airflow 3.0;
+    |
+161 | PrestoHook()
+162 | SambaHook()
+163 | SlackHook()
+    | ^^^^^^^^^ AIR303
+164 | SqliteHook()
+165 | WebHDFSHook()
+    |
+    = help: Install `apache-airflow-provider-Slack>=TBD` and use `SlackHook` instead.
+
+AIR303.py:164:1: AIR303 `airflow.hooks.sqlite_hook.SqliteHook` is moved into `Sqlite` provider in Airflow 3.0;
+    |
+162 | SambaHook()
+163 | SlackHook()
+164 | SqliteHook()
+    | ^^^^^^^^^^ AIR303
+165 | WebHDFSHook()
+166 | ZendeskHook()
     |
     = help: Install `apache-airflow-provider-Sqlite>=TBD` and use `SqliteHook` instead.
 
-AIR303.py:99:1: AIR303 `airflow.hooks.webhdfs_hook.WebHDFSHook` is moved into `Apache Hdfs` provider in Airflow 3.0;
+AIR303.py:165:1: AIR303 `airflow.hooks.webhdfs_hook.WebHDFSHook` is moved into `Apache Hdfs` provider in Airflow 3.0;
     |
- 97 | SlackHook()
- 98 | SqliteHook()
- 99 | WebHDFSHook()
+163 | SlackHook()
+164 | SqliteHook()
+165 | WebHDFSHook()
     | ^^^^^^^^^^^ AIR303
-100 | ZendeskHook()
+166 | ZendeskHook()
     |
     = help: Install `apache-airflow-provider-Apache Hdfs>=TBD` and use `WebHDFSHook` instead.
 
-AIR303.py:100:1: AIR303 `airflow.hooks.zendesk_hook.ZendeskHook` is moved into `Zendesk` provider in Airflow 3.0;
+AIR303.py:166:1: AIR303 `airflow.hooks.zendesk_hook.ZendeskHook` is moved into `Zendesk` provider in Airflow 3.0;
     |
- 98 | SqliteHook()
- 99 | WebHDFSHook()
-100 | ZendeskHook()
+164 | SqliteHook()
+165 | WebHDFSHook()
+166 | ZendeskHook()
     | ^^^^^^^^^^^ AIR303
+167 | 
+168 | SQLCheckOperator()
     |
     = help: Install `apache-airflow-provider-Zendesk>=TBD` and use `ZendeskHook` instead.
+
+AIR303.py:168:1: AIR303 `airflow.operators.sql.SQLCheckOperator` is moved into `Common Sql` provider in Airflow 3.0;
+    |
+166 | ZendeskHook()
+167 | 
+168 | SQLCheckOperator()
+    | ^^^^^^^^^^^^^^^^ AIR303
+169 | SQLIntervalCheckOperator()
+170 | SQLThresholdCheckOperator()
+    |
+    = help: Install `apache-airflow-provider-Common Sql>=TBD` and use `SQLCheckOperator` instead.
+
+AIR303.py:169:1: AIR303 `airflow.operators.sql.SQLIntervalCheckOperator` is moved into `Common Sql` provider in Airflow 3.0;
+    |
+168 | SQLCheckOperator()
+169 | SQLIntervalCheckOperator()
+    | ^^^^^^^^^^^^^^^^^^^^^^^^ AIR303
+170 | SQLThresholdCheckOperator()
+171 | SQLValueCheckOperator()
+    |
+    = help: Install `apache-airflow-provider-Common Sql>=TBD` and use `SQLIntervalCheckOperator` instead.
+
+AIR303.py:170:1: AIR303 `airflow.operators.sql.SQLThresholdCheckOperator` is moved into `Common Sql` provider in Airflow 3.0;
+    |
+168 | SQLCheckOperator()
+169 | SQLIntervalCheckOperator()
+170 | SQLThresholdCheckOperator()
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^ AIR303
+171 | SQLValueCheckOperator()
+172 | CheckOperator()
+    |
+    = help: Install `apache-airflow-provider-Common Sql>=TBD` and use `SQLThresholdCheckOperator` instead.
+
+AIR303.py:171:1: AIR303 `airflow.operators.sql.SQLValueCheckOperator` is moved into `Common Sql` provider in Airflow 3.0;
+    |
+169 | SQLIntervalCheckOperator()
+170 | SQLThresholdCheckOperator()
+171 | SQLValueCheckOperator()
+    | ^^^^^^^^^^^^^^^^^^^^^ AIR303
+172 | CheckOperator()
+173 | IntervalCheckOperator()
+    |
+    = help: Install `apache-airflow-provider-Common Sql>=TBD` and use `SQLValueCheckOperator` instead.
+
+AIR303.py:172:1: AIR303 `airflow.operators.check_operator.CheckOperator` is moved into `Common Sql` provider in Airflow 3.0;
+    |
+170 | SQLThresholdCheckOperator()
+171 | SQLValueCheckOperator()
+172 | CheckOperator()
+    | ^^^^^^^^^^^^^ AIR303
+173 | IntervalCheckOperator()
+174 | ThresholdCheckOperator()
+    |
+    = help: Install `apache-airflow-provider-Common Sql>=TBD` and use `CheckOperator` instead.
+
+AIR303.py:173:1: AIR303 `airflow.operators.check_operator.IntervalCheckOperator` is moved into `Common Sql` provider in Airflow 3.0;
+    |
+171 | SQLValueCheckOperator()
+172 | CheckOperator()
+173 | IntervalCheckOperator()
+    | ^^^^^^^^^^^^^^^^^^^^^ AIR303
+174 | ThresholdCheckOperator()
+175 | ValueCheckOperator()
+    |
+    = help: Install `apache-airflow-provider-Common Sql>=TBD` and use `IntervalCheckOperator` instead.
+
+AIR303.py:174:1: AIR303 `airflow.operators.check_operator.ThresholdCheckOperator` is moved into `Common Sql` provider in Airflow 3.0;
+    |
+172 | CheckOperator()
+173 | IntervalCheckOperator()
+174 | ThresholdCheckOperator()
+    | ^^^^^^^^^^^^^^^^^^^^^^ AIR303
+175 | ValueCheckOperator()
+176 | DockerOperator()
+    |
+    = help: Install `apache-airflow-provider-Common Sql>=TBD` and use `ThresholdCheckOperator` instead.
+
+AIR303.py:175:1: AIR303 `airflow.operators.check_operator.ValueCheckOperator` is moved into `Common Sql` provider in Airflow 3.0;
+    |
+173 | IntervalCheckOperator()
+174 | ThresholdCheckOperator()
+175 | ValueCheckOperator()
+    | ^^^^^^^^^^^^^^^^^^ AIR303
+176 | DockerOperator()
+177 | DruidCheckOperator()
+    |
+    = help: Install `apache-airflow-provider-Common Sql>=TBD` and use `ValueCheckOperator` instead.
+
+AIR303.py:176:1: AIR303 `airflow.operators.docker_operator.DockerOperator` is moved into `Docker` provider in Airflow 3.0;
+    |
+174 | ThresholdCheckOperator()
+175 | ValueCheckOperator()
+176 | DockerOperator()
+    | ^^^^^^^^^^^^^^ AIR303
+177 | DruidCheckOperator()
+178 | GCSToS3Operator()
+    |
+    = help: Install `apache-airflow-provider-Docker>=TBD` and use `DockerOperator` instead.
+
+AIR303.py:177:1: AIR303 `airflow.operators.druid_check_operator.DruidCheckOperator` is moved into `Apache Druid` provider in Airflow 3.0;
+    |
+175 | ValueCheckOperator()
+176 | DockerOperator()
+177 | DruidCheckOperator()
+    | ^^^^^^^^^^^^^^^^^^ AIR303
+178 | GCSToS3Operator()
+179 | GoogleApiToS3Operator()
+    |
+    = help: Install `apache-airflow-provider-Apache Druid>=TBD` and use `DruidCheckOperator` instead.
+
+AIR303.py:178:1: AIR303 `airflow.operators.gcs_to_s3.GCSToS3Operator` is moved into `Amazon` provider in Airflow 3.0;
+    |
+176 | DockerOperator()
+177 | DruidCheckOperator()
+178 | GCSToS3Operator()
+    | ^^^^^^^^^^^^^^^ AIR303
+179 | GoogleApiToS3Operator()
+180 | GoogleApiToS3Transfer()
+    |
+    = help: Install `apache-airflow-provider-Amazon>=TBD` and use `GCSToS3Operator` instead.
+
+AIR303.py:179:1: AIR303 `airflow.operators.google_api_to_s3_transfer.GoogleApiToS3Operator` is moved into `Amazon` provider in Airflow 3.0;
+    |
+177 | DruidCheckOperator()
+178 | GCSToS3Operator()
+179 | GoogleApiToS3Operator()
+    | ^^^^^^^^^^^^^^^^^^^^^ AIR303
+180 | GoogleApiToS3Transfer()
+181 | HiveOperator()
+    |
+    = help: Install `apache-airflow-provider-Amazon>=TBD` and use `GoogleApiToS3Operator` instead.
+
+AIR303.py:180:1: AIR303 `airflow.operators.google_api_to_s3_transfer.GoogleApiToS3Transfer` is moved into `Amazon` provider in Airflow 3.0;
+    |
+178 | GCSToS3Operator()
+179 | GoogleApiToS3Operator()
+180 | GoogleApiToS3Transfer()
+    | ^^^^^^^^^^^^^^^^^^^^^ AIR303
+181 | HiveOperator()
+182 | HiveStatsCollectionOperator()
+    |
+    = help: Install `apache-airflow-provider-Amazon>=TBD` and use `GoogleApiToS3Transfer` instead.
+
+AIR303.py:181:1: AIR303 `airflow.operators.hive_operator.HiveOperator` is moved into `Apache Hive` provider in Airflow 3.0;
+    |
+179 | GoogleApiToS3Operator()
+180 | GoogleApiToS3Transfer()
+181 | HiveOperator()
+    | ^^^^^^^^^^^^ AIR303
+182 | HiveStatsCollectionOperator()
+183 | HiveToDruidOperator()
+    |
+    = help: Install `apache-airflow-provider-Apache Hive>=TBD` and use `HiveOperator` instead.
+
+AIR303.py:182:1: AIR303 `airflow.operators.hive_stats_operator.HiveStatsCollectionOperator` is moved into `Apache Hive` provider in Airflow 3.0;
+    |
+180 | GoogleApiToS3Transfer()
+181 | HiveOperator()
+182 | HiveStatsCollectionOperator()
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR303
+183 | HiveToDruidOperator()
+184 | HiveToDruidTransfer()
+    |
+    = help: Install `apache-airflow-provider-Apache Hive>=TBD` and use `HiveStatsCollectionOperator` instead.
+
+AIR303.py:183:1: AIR303 `airflow.operators.hive_to_druid.HiveToDruidOperator` is moved into `Apache Druid` provider in Airflow 3.0;
+    |
+181 | HiveOperator()
+182 | HiveStatsCollectionOperator()
+183 | HiveToDruidOperator()
+    | ^^^^^^^^^^^^^^^^^^^ AIR303
+184 | HiveToDruidTransfer()
+185 | HiveToMySqlOperator()
+    |
+    = help: Install `apache-airflow-provider-Apache Druid>=TBD` and use `HiveToDruidOperator` instead.
+
+AIR303.py:184:1: AIR303 `airflow.operators.hive_to_druid.HiveToDruidTransfer` is moved into `Apache Druid` provider in Airflow 3.0;
+    |
+182 | HiveStatsCollectionOperator()
+183 | HiveToDruidOperator()
+184 | HiveToDruidTransfer()
+    | ^^^^^^^^^^^^^^^^^^^ AIR303
+185 | HiveToMySqlOperator()
+186 | HiveToMySqlTransfer()
+    |
+    = help: Install `apache-airflow-provider-Apache Druid>=TBD` and use `HiveToDruidTransfer` instead.
+
+AIR303.py:185:1: AIR303 `airflow.operators.hive_to_mysql.HiveToMySqlOperator` is moved into `Apache Hive` provider in Airflow 3.0;
+    |
+183 | HiveToDruidOperator()
+184 | HiveToDruidTransfer()
+185 | HiveToMySqlOperator()
+    | ^^^^^^^^^^^^^^^^^^^ AIR303
+186 | HiveToMySqlTransfer()
+187 | HiveToSambaOperator()
+    |
+    = help: Install `apache-airflow-provider-Apache Hive>=TBD` and use `HiveToMySqlOperator` instead.
+
+AIR303.py:186:1: AIR303 `airflow.operators.hive_to_mysql.HiveToMySqlTransfer` is moved into `Apache Hive` provider in Airflow 3.0;
+    |
+184 | HiveToDruidTransfer()
+185 | HiveToMySqlOperator()
+186 | HiveToMySqlTransfer()
+    | ^^^^^^^^^^^^^^^^^^^ AIR303
+187 | HiveToSambaOperator()
+188 | SimpleHttpOperator()
+    |
+    = help: Install `apache-airflow-provider-Apache Hive>=TBD` and use `HiveToMySqlTransfer` instead.
+
+AIR303.py:187:1: AIR303 `airflow.operators.hive_to_samba_operator.HiveToSambaOperator` is moved into `Apache Hive` provider in Airflow 3.0;
+    |
+185 | HiveToMySqlOperator()
+186 | HiveToMySqlTransfer()
+187 | HiveToSambaOperator()
+    | ^^^^^^^^^^^^^^^^^^^ AIR303
+188 | SimpleHttpOperator()
+189 | JdbcOperator()
+    |
+    = help: Install `apache-airflow-provider-Apache Hive>=TBD` and use `HiveToSambaOperator` instead.
+
+AIR303.py:188:1: AIR303 `airflow.operators.http_operator.SimpleHttpOperator` is moved into `Http` provider in Airflow 3.0;
+    |
+186 | HiveToMySqlTransfer()
+187 | HiveToSambaOperator()
+188 | SimpleHttpOperator()
+    | ^^^^^^^^^^^^^^^^^^ AIR303
+189 | JdbcOperator()
+190 | LatestOnlyOperator()
+    |
+    = help: Install `apache-airflow-provider-Http>=TBD` and use `SimpleHttpOperator` instead.
+
+AIR303.py:189:1: AIR303 `airflow.operators.jdbc_operator.JdbcOperator` is moved into `Jdbc` provider in Airflow 3.0;
+    |
+187 | HiveToSambaOperator()
+188 | SimpleHttpOperator()
+189 | JdbcOperator()
+    | ^^^^^^^^^^^^ AIR303
+190 | LatestOnlyOperator()
+191 | MsSqlOperator()
+    |
+    = help: Install `apache-airflow-provider-Jdbc>=TBD` and use `JdbcOperator` instead.
+
+AIR303.py:190:1: AIR303 `airflow.operators.latest_only_operator.LatestOnlyOperator` is moved into `Latest_only` provider in Airflow 3.0;
+    |
+188 | SimpleHttpOperator()
+189 | JdbcOperator()
+190 | LatestOnlyOperator()
+    | ^^^^^^^^^^^^^^^^^^ AIR303
+191 | MsSqlOperator()
+192 | MsSqlToHiveOperator()
+    |
+    = help: Install `apache-airflow-provider-Latest_only>=TBD` and use `LatestOnlyOperator` instead.
+
+AIR303.py:191:1: AIR303 `airflow.operators.mssql_operator.MsSqlOperator` is moved into `Microsoft` provider in Airflow 3.0;
+    |
+189 | JdbcOperator()
+190 | LatestOnlyOperator()
+191 | MsSqlOperator()
+    | ^^^^^^^^^^^^^ AIR303
+192 | MsSqlToHiveOperator()
+193 | MsSqlToHiveTransfer()
+    |
+    = help: Install `apache-airflow-provider-Microsoft>=TBD` and use `MsSqlOperator` instead.
+
+AIR303.py:192:1: AIR303 `airflow.operators.mssql_to_hive.MsSqlToHiveOperator` is moved into `Apache Hive` provider in Airflow 3.0;
+    |
+190 | LatestOnlyOperator()
+191 | MsSqlOperator()
+192 | MsSqlToHiveOperator()
+    | ^^^^^^^^^^^^^^^^^^^ AIR303
+193 | MsSqlToHiveTransfer()
+194 | MySqlOperator()
+    |
+    = help: Install `apache-airflow-provider-Apache Hive>=TBD` and use `MsSqlToHiveOperator` instead.
+
+AIR303.py:193:1: AIR303 `airflow.operators.mssql_to_hive.MsSqlToHiveTransfer` is moved into `Apache Hive` provider in Airflow 3.0;
+    |
+191 | MsSqlOperator()
+192 | MsSqlToHiveOperator()
+193 | MsSqlToHiveTransfer()
+    | ^^^^^^^^^^^^^^^^^^^ AIR303
+194 | MySqlOperator()
+195 | MySqlToHiveOperator()
+    |
+    = help: Install `apache-airflow-provider-Apache Hive>=TBD` and use `MsSqlToHiveTransfer` instead.
+
+AIR303.py:194:1: AIR303 `airflow.operators.mysql_operator.MySqlOperator` is moved into `Mysql` provider in Airflow 3.0;
+    |
+192 | MsSqlToHiveOperator()
+193 | MsSqlToHiveTransfer()
+194 | MySqlOperator()
+    | ^^^^^^^^^^^^^ AIR303
+195 | MySqlToHiveOperator()
+196 | MySqlToHiveTransfer()
+    |
+    = help: Install `apache-airflow-provider-Mysql>=TBD` and use `MySqlOperator` instead.
+
+AIR303.py:195:1: AIR303 `airflow.operators.mysql_to_hive.MySqlToHiveOperator` is moved into `Apache Hive` provider in Airflow 3.0;
+    |
+193 | MsSqlToHiveTransfer()
+194 | MySqlOperator()
+195 | MySqlToHiveOperator()
+    | ^^^^^^^^^^^^^^^^^^^ AIR303
+196 | MySqlToHiveTransfer()
+197 | OracleOperator()
+    |
+    = help: Install `apache-airflow-provider-Apache Hive>=TBD` and use `MySqlToHiveOperator` instead.
+
+AIR303.py:196:1: AIR303 `airflow.operators.mysql_to_hive.MySqlToHiveTransfer` is moved into `Apache Hive` provider in Airflow 3.0;
+    |
+194 | MySqlOperator()
+195 | MySqlToHiveOperator()
+196 | MySqlToHiveTransfer()
+    | ^^^^^^^^^^^^^^^^^^^ AIR303
+197 | OracleOperator()
+198 | PapermillOperator()
+    |
+    = help: Install `apache-airflow-provider-Apache Hive>=TBD` and use `MySqlToHiveTransfer` instead.
+
+AIR303.py:197:1: AIR303 `airflow.operators.oracle_operator.OracleOperator` is moved into `Oracle` provider in Airflow 3.0;
+    |
+195 | MySqlToHiveOperator()
+196 | MySqlToHiveTransfer()
+197 | OracleOperator()
+    | ^^^^^^^^^^^^^^ AIR303
+198 | PapermillOperator()
+199 | PigOperator()
+    |
+    = help: Install `apache-airflow-provider-Oracle>=TBD` and use `OracleOperator` instead.
+
+AIR303.py:198:1: AIR303 `airflow.operators.papermill_operator.PapermillOperator` is moved into `Papermill` provider in Airflow 3.0;
+    |
+196 | MySqlToHiveTransfer()
+197 | OracleOperator()
+198 | PapermillOperator()
+    | ^^^^^^^^^^^^^^^^^ AIR303
+199 | PigOperator()
+200 | Mapping()
+    |
+    = help: Install `apache-airflow-provider-Papermill>=TBD` and use `PapermillOperator` instead.
+
+AIR303.py:199:1: AIR303 `airflow.operators.pig_operator.PigOperator` is moved into `Apache Pig` provider in Airflow 3.0;
+    |
+197 | OracleOperator()
+198 | PapermillOperator()
+199 | PigOperator()
+    | ^^^^^^^^^^^ AIR303
+200 | Mapping()
+201 | PostgresOperator()
+    |
+    = help: Install `apache-airflow-provider-Apache Pig>=TBD` and use `PigOperator` instead.
+
+AIR303.py:200:1: AIR303 `airflow.operators.postgres_operator.Mapping` is moved into `Postgres` provider in Airflow 3.0;
+    |
+198 | PapermillOperator()
+199 | PigOperator()
+200 | Mapping()
+    | ^^^^^^^ AIR303
+201 | PostgresOperator()
+202 | SQLCheckOperator()
+    |
+    = help: Install `apache-airflow-provider-Postgres>=TBD` and use `Mapping` instead.
+
+AIR303.py:201:1: AIR303 `airflow.operators.postgres_operator.PostgresOperator` is moved into `Postgres` provider in Airflow 3.0;
+    |
+199 | PigOperator()
+200 | Mapping()
+201 | PostgresOperator()
+    | ^^^^^^^^^^^^^^^^ AIR303
+202 | SQLCheckOperator()
+203 | SQLIntervalCheckOperator()
+    |
+    = help: Install `apache-airflow-provider-Postgres>=TBD` and use `PostgresOperator` instead.
+
+AIR303.py:202:1: AIR303 `airflow.operators.sql.SQLCheckOperator` is moved into `Common Sql` provider in Airflow 3.0;
+    |
+200 | Mapping()
+201 | PostgresOperator()
+202 | SQLCheckOperator()
+    | ^^^^^^^^^^^^^^^^ AIR303
+203 | SQLIntervalCheckOperator()
+204 | SQLValueCheckOperator()
+    |
+    = help: Install `apache-airflow-provider-Common Sql>=TBD` and use `SQLCheckOperator` instead.
+
+AIR303.py:203:1: AIR303 `airflow.operators.sql.SQLIntervalCheckOperator` is moved into `Common Sql` provider in Airflow 3.0;
+    |
+201 | PostgresOperator()
+202 | SQLCheckOperator()
+203 | SQLIntervalCheckOperator()
+    | ^^^^^^^^^^^^^^^^^^^^^^^^ AIR303
+204 | SQLValueCheckOperator()
+205 | PrestoCheckOperator()
+    |
+    = help: Install `apache-airflow-provider-Common Sql>=TBD` and use `SQLIntervalCheckOperator` instead.
+
+AIR303.py:204:1: AIR303 `airflow.operators.sql.SQLValueCheckOperator` is moved into `Common Sql` provider in Airflow 3.0;
+    |
+202 | SQLCheckOperator()
+203 | SQLIntervalCheckOperator()
+204 | SQLValueCheckOperator()
+    | ^^^^^^^^^^^^^^^^^^^^^ AIR303
+205 | PrestoCheckOperator()
+206 | PrestoIntervalCheckOperator()
+    |
+    = help: Install `apache-airflow-provider-Common Sql>=TBD` and use `SQLValueCheckOperator` instead.
+
+AIR303.py:205:1: AIR303 `airflow.operators.presto_check_operator.PrestoCheckOperator` is moved into `Common Sql` provider in Airflow 3.0;
+    |
+203 | SQLIntervalCheckOperator()
+204 | SQLValueCheckOperator()
+205 | PrestoCheckOperator()
+    | ^^^^^^^^^^^^^^^^^^^ AIR303
+206 | PrestoIntervalCheckOperator()
+207 | PrestoValueCheckOperator()
+    |
+    = help: Install `apache-airflow-provider-Common Sql>=TBD` and use `PrestoCheckOperator` instead.
+
+AIR303.py:206:1: AIR303 `airflow.operators.presto_check_operator.PrestoIntervalCheckOperator` is moved into `Common Sql` provider in Airflow 3.0;
+    |
+204 | SQLValueCheckOperator()
+205 | PrestoCheckOperator()
+206 | PrestoIntervalCheckOperator()
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR303
+207 | PrestoValueCheckOperator()
+208 | PrestoToMySqlOperator()
+    |
+    = help: Install `apache-airflow-provider-Common Sql>=TBD` and use `PrestoIntervalCheckOperator` instead.
+
+AIR303.py:207:1: AIR303 `airflow.operators.presto_check_operator.PrestoValueCheckOperator` is moved into `Common Sql` provider in Airflow 3.0;
+    |
+205 | PrestoCheckOperator()
+206 | PrestoIntervalCheckOperator()
+207 | PrestoValueCheckOperator()
+    | ^^^^^^^^^^^^^^^^^^^^^^^^ AIR303
+208 | PrestoToMySqlOperator()
+209 | PrestoToMySqlTransfer()
+    |
+    = help: Install `apache-airflow-provider-Common Sql>=TBD` and use `PrestoValueCheckOperator` instead.
+
+AIR303.py:208:1: AIR303 `airflow.operators.presto_to_mysql.PrestoToMySqlOperator` is moved into `Mysql` provider in Airflow 3.0;
+    |
+206 | PrestoIntervalCheckOperator()
+207 | PrestoValueCheckOperator()
+208 | PrestoToMySqlOperator()
+    | ^^^^^^^^^^^^^^^^^^^^^ AIR303
+209 | PrestoToMySqlTransfer()
+210 | RedshiftToS3Operator()
+    |
+    = help: Install `apache-airflow-provider-Mysql>=TBD` and use `PrestoToMySqlOperator` instead.
+
+AIR303.py:209:1: AIR303 `airflow.operators.presto_to_mysql.PrestoToMySqlTransfer` is moved into `Mysql` provider in Airflow 3.0;
+    |
+207 | PrestoValueCheckOperator()
+208 | PrestoToMySqlOperator()
+209 | PrestoToMySqlTransfer()
+    | ^^^^^^^^^^^^^^^^^^^^^ AIR303
+210 | RedshiftToS3Operator()
+211 | RedshiftToS3Transfer()
+    |
+    = help: Install `apache-airflow-provider-Mysql>=TBD` and use `PrestoToMySqlTransfer` instead.
+
+AIR303.py:210:1: AIR303 `airflow.operators.redshift_to_s3_operator.RedshiftToS3Operator` is moved into `Amazon` provider in Airflow 3.0;
+    |
+208 | PrestoToMySqlOperator()
+209 | PrestoToMySqlTransfer()
+210 | RedshiftToS3Operator()
+    | ^^^^^^^^^^^^^^^^^^^^ AIR303
+211 | RedshiftToS3Transfer()
+212 | S3FileTransformOperator()
+    |
+    = help: Install `apache-airflow-provider-Amazon>=TBD` and use `RedshiftToS3Operator` instead.
+
+AIR303.py:211:1: AIR303 `airflow.operators.redshift_to_s3_operator.RedshiftToS3Transfer` is moved into `Amazon` provider in Airflow 3.0;
+    |
+209 | PrestoToMySqlTransfer()
+210 | RedshiftToS3Operator()
+211 | RedshiftToS3Transfer()
+    | ^^^^^^^^^^^^^^^^^^^^ AIR303
+212 | S3FileTransformOperator()
+213 | S3ToHiveOperator()
+    |
+    = help: Install `apache-airflow-provider-Amazon>=TBD` and use `RedshiftToS3Transfer` instead.
+
+AIR303.py:212:1: AIR303 `airflow.operators.s3_file_transform_operator.S3FileTransformOperator` is moved into `Amazon` provider in Airflow 3.0;
+    |
+210 | RedshiftToS3Operator()
+211 | RedshiftToS3Transfer()
+212 | S3FileTransformOperator()
+    | ^^^^^^^^^^^^^^^^^^^^^^^ AIR303
+213 | S3ToHiveOperator()
+214 | S3ToHiveTransfer()
+    |
+    = help: Install `apache-airflow-provider-Amazon>=TBD` and use `S3FileTransformOperator` instead.
+
+AIR303.py:213:1: AIR303 `airflow.operators.s3_to_hive_operator.S3ToHiveOperator` is moved into `Apache Hive` provider in Airflow 3.0;
+    |
+211 | RedshiftToS3Transfer()
+212 | S3FileTransformOperator()
+213 | S3ToHiveOperator()
+    | ^^^^^^^^^^^^^^^^ AIR303
+214 | S3ToHiveTransfer()
+215 | S3ToRedshiftOperator()
+    |
+    = help: Install `apache-airflow-provider-Apache Hive>=TBD` and use `S3ToHiveOperator` instead.
+
+AIR303.py:214:1: AIR303 `airflow.operators.s3_to_hive_operator.S3ToHiveTransfer` is moved into `Apache Hive` provider in Airflow 3.0;
+    |
+212 | S3FileTransformOperator()
+213 | S3ToHiveOperator()
+214 | S3ToHiveTransfer()
+    | ^^^^^^^^^^^^^^^^ AIR303
+215 | S3ToRedshiftOperator()
+216 | S3ToRedshiftTransfer()
+    |
+    = help: Install `apache-airflow-provider-Apache Hive>=TBD` and use `S3ToHiveTransfer` instead.
+
+AIR303.py:215:1: AIR303 `airflow.operators.s3_to_redshift_operator.S3ToRedshiftOperator` is moved into `Amazon` provider in Airflow 3.0;
+    |
+213 | S3ToHiveOperator()
+214 | S3ToHiveTransfer()
+215 | S3ToRedshiftOperator()
+    | ^^^^^^^^^^^^^^^^^^^^ AIR303
+216 | S3ToRedshiftTransfer()
+217 | SlackAPIOperator()
+    |
+    = help: Install `apache-airflow-provider-Amazon>=TBD` and use `S3ToRedshiftOperator` instead.
+
+AIR303.py:216:1: AIR303 `airflow.operators.s3_to_redshift_operator.S3ToRedshiftTransfer` is moved into `Amazon` provider in Airflow 3.0;
+    |
+214 | S3ToHiveTransfer()
+215 | S3ToRedshiftOperator()
+216 | S3ToRedshiftTransfer()
+    | ^^^^^^^^^^^^^^^^^^^^ AIR303
+217 | SlackAPIOperator()
+218 | SlackAPIPostOperator()
+    |
+    = help: Install `apache-airflow-provider-Amazon>=TBD` and use `S3ToRedshiftTransfer` instead.
+
+AIR303.py:217:1: AIR303 `airflow.operators.slack_operator.SlackAPIOperator` is moved into `Slack` provider in Airflow 3.0;
+    |
+215 | S3ToRedshiftOperator()
+216 | S3ToRedshiftTransfer()
+217 | SlackAPIOperator()
+    | ^^^^^^^^^^^^^^^^ AIR303
+218 | SlackAPIPostOperator()
+219 | BaseSQLOperator()
+    |
+    = help: Install `apache-airflow-provider-Slack>=TBD` and use `SlackAPIOperator` instead.
+
+AIR303.py:218:1: AIR303 `airflow.operators.slack_operator.SlackAPIPostOperator` is moved into `Slack` provider in Airflow 3.0;
+    |
+216 | S3ToRedshiftTransfer()
+217 | SlackAPIOperator()
+218 | SlackAPIPostOperator()
+    | ^^^^^^^^^^^^^^^^^^^^ AIR303
+219 | BaseSQLOperator()
+220 | BranchSQLOperator()
+    |
+    = help: Install `apache-airflow-provider-Slack>=TBD` and use `SlackAPIPostOperator` instead.
+
+AIR303.py:219:1: AIR303 `airflow.operators.sql.BaseSQLOperator` is moved into `Common Sql` provider in Airflow 3.0;
+    |
+217 | SlackAPIOperator()
+218 | SlackAPIPostOperator()
+219 | BaseSQLOperator()
+    | ^^^^^^^^^^^^^^^ AIR303
+220 | BranchSQLOperator()
+221 | SQLCheckOperator()
+    |
+    = help: Install `apache-airflow-provider-Common Sql>=TBD` and use `BaseSQLOperator` instead.
+
+AIR303.py:220:1: AIR303 `airflow.operators.sql_branch_operator.BranchSQLOperator` is moved into `Common Sql` provider in Airflow 3.0;
+    |
+218 | SlackAPIPostOperator()
+219 | BaseSQLOperator()
+220 | BranchSQLOperator()
+    | ^^^^^^^^^^^^^^^^^ AIR303
+221 | SQLCheckOperator()
+222 | SQLColumnCheckOperator()
+    |
+    = help: Install `apache-airflow-provider-Common Sql>=TBD` and use `BranchSQLOperator` instead.
+
+AIR303.py:221:1: AIR303 `airflow.operators.sql.SQLCheckOperator` is moved into `Common Sql` provider in Airflow 3.0;
+    |
+219 | BaseSQLOperator()
+220 | BranchSQLOperator()
+221 | SQLCheckOperator()
+    | ^^^^^^^^^^^^^^^^ AIR303
+222 | SQLColumnCheckOperator()
+223 | SQLIntervalCheckOperator()
+    |
+    = help: Install `apache-airflow-provider-Common Sql>=TBD` and use `SQLCheckOperator` instead.
+
+AIR303.py:222:1: AIR303 `airflow.operators.sql.SQLColumnCheckOperator` is moved into `Common Sql` provider in Airflow 3.0;
+    |
+220 | BranchSQLOperator()
+221 | SQLCheckOperator()
+222 | SQLColumnCheckOperator()
+    | ^^^^^^^^^^^^^^^^^^^^^^ AIR303
+223 | SQLIntervalCheckOperator()
+224 | SQLTableCheckOperator()
+    |
+    = help: Install `apache-airflow-provider-Common Sql>=TBD` and use `SQLColumnCheckOperator` instead.
+
+AIR303.py:223:1: AIR303 `airflow.operators.sql.SQLIntervalCheckOperator` is moved into `Common Sql` provider in Airflow 3.0;
+    |
+221 | SQLCheckOperator()
+222 | SQLColumnCheckOperator()
+223 | SQLIntervalCheckOperator()
+    | ^^^^^^^^^^^^^^^^^^^^^^^^ AIR303
+224 | SQLTableCheckOperator()
+225 | SQLThresholdCheckOperator()
+    |
+    = help: Install `apache-airflow-provider-Common Sql>=TBD` and use `SQLIntervalCheckOperator` instead.
+
+AIR303.py:224:1: AIR303 `airflow.operators.sql.SQLTableCheckOperator` is moved into `Common Sql` provider in Airflow 3.0;
+    |
+222 | SQLColumnCheckOperator()
+223 | SQLIntervalCheckOperator()
+224 | SQLTableCheckOperator()
+    | ^^^^^^^^^^^^^^^^^^^^^ AIR303
+225 | SQLThresholdCheckOperator()
+226 | SQLValueCheckOperator()
+    |
+    = help: Install `apache-airflow-provider-Common Sql>=TBD` and use `SQLTableCheckOperator` instead.
+
+AIR303.py:225:1: AIR303 `airflow.operators.sql.SQLThresholdCheckOperator` is moved into `Common Sql` provider in Airflow 3.0;
+    |
+223 | SQLIntervalCheckOperator()
+224 | SQLTableCheckOperator()
+225 | SQLThresholdCheckOperator()
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^ AIR303
+226 | SQLValueCheckOperator()
+227 | _convert_to_float_if_possible()
+    |
+    = help: Install `apache-airflow-provider-Common Sql>=TBD` and use `SQLThresholdCheckOperator` instead.
+
+AIR303.py:226:1: AIR303 `airflow.operators.sql.SQLValueCheckOperator` is moved into `Common Sql` provider in Airflow 3.0;
+    |
+224 | SQLTableCheckOperator()
+225 | SQLThresholdCheckOperator()
+226 | SQLValueCheckOperator()
+    | ^^^^^^^^^^^^^^^^^^^^^ AIR303
+227 | _convert_to_float_if_possible()
+228 | parse_boolean()
+    |
+    = help: Install `apache-airflow-provider-Common Sql>=TBD` and use `SQLValueCheckOperator` instead.
+
+AIR303.py:227:1: AIR303 `airflow.operators.sql._convert_to_float_if_possible` is moved into `Common Sql` provider in Airflow 3.0;
+    |
+225 | SQLThresholdCheckOperator()
+226 | SQLValueCheckOperator()
+227 | _convert_to_float_if_possible()
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR303
+228 | parse_boolean()
+229 | BranchSQLOperator()
+    |
+    = help: Install `apache-airflow-provider-Common Sql>=TBD` and use `_convert_to_float_if_possible` instead.
+
+AIR303.py:228:1: AIR303 `airflow.operators.sql.parse_boolean` is moved into `Common Sql` provider in Airflow 3.0;
+    |
+226 | SQLValueCheckOperator()
+227 | _convert_to_float_if_possible()
+228 | parse_boolean()
+    | ^^^^^^^^^^^^^ AIR303
+229 | BranchSQLOperator()
+230 | BranchSqlOperator()
+    |
+    = help: Install `apache-airflow-provider-Common Sql>=TBD` and use `parse_boolean` instead.
+
+AIR303.py:229:1: AIR303 `airflow.operators.sql_branch_operator.BranchSQLOperator` is moved into `Common Sql` provider in Airflow 3.0;
+    |
+227 | _convert_to_float_if_possible()
+228 | parse_boolean()
+229 | BranchSQLOperator()
+    | ^^^^^^^^^^^^^^^^^ AIR303
+230 | BranchSqlOperator()
+231 | SqliteOperator()
+    |
+    = help: Install `apache-airflow-provider-Common Sql>=TBD` and use `BranchSQLOperator` instead.
+
+AIR303.py:230:1: AIR303 `airflow.operators.sql_branch_operator.BranchSqlOperator` is moved into `Common Sql` provider in Airflow 3.0;
+    |
+228 | parse_boolean()
+229 | BranchSQLOperator()
+230 | BranchSqlOperator()
+    | ^^^^^^^^^^^^^^^^^ AIR303
+231 | SqliteOperator()
+    |
+    = help: Install `apache-airflow-provider-Common Sql>=TBD` and use `BranchSqlOperator` instead.
+
+AIR303.py:231:1: AIR303 `airflow.operators.sqlite_operator.SqliteOperator` is moved into `Sqlite` provider in Airflow 3.0;
+    |
+229 | BranchSQLOperator()
+230 | BranchSqlOperator()
+231 | SqliteOperator()
+    | ^^^^^^^^^^^^^^ AIR303
+    |
+    = help: Install `apache-airflow-provider-Sqlite>=TBD` and use `SqliteOperator` instead.

--- a/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR303_AIR303.py.snap
+++ b/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR303_AIR303.py.snap
@@ -2,163 +2,195 @@
 source: crates/ruff_linter/src/rules/airflow/mod.rs
 snapshot_kind: text
 ---
-AIR303.py:20:1: AIR303 Import path `airflow.api.auth.backend.basic_auth` is moved into `fab` provider in Airflow 3.0;
+AIR303.py:22:1: AIR303 Import path `airflow.api.auth.backend.basic_auth` is moved into `fab` provider in Airflow 3.0;
    |
-19 | # apache-airflow-providers-fab
-20 | basic_auth, kerberos_auth
+21 | # apache-airflow-providers-fab
+22 | basic_auth, kerberos_auth
    | ^^^^^^^^^^ AIR303
-21 | auth_current_user
-22 | backend_kerberos_auth
+23 | auth_current_user
+24 | backend_kerberos_auth
    |
    = help: Install `apache-airflow-provider-fab>=1.0.0` and import from `airflow.providers.fab.auth_manager.api.auth.backend.basic_auth` instead.
 
-AIR303.py:20:13: AIR303 Import path `airflow.api.auth.backend.kerberos_auth` is moved into `fab` provider in Airflow 3.0;
+AIR303.py:22:13: AIR303 Import path `airflow.api.auth.backend.kerberos_auth` is moved into `fab` provider in Airflow 3.0;
    |
-19 | # apache-airflow-providers-fab
-20 | basic_auth, kerberos_auth
+21 | # apache-airflow-providers-fab
+22 | basic_auth, kerberos_auth
    |             ^^^^^^^^^^^^^ AIR303
-21 | auth_current_user
-22 | backend_kerberos_auth
+23 | auth_current_user
+24 | backend_kerberos_auth
    |
    = help: Install `apache-airflow-provider-fab>=1.0.0` and import from `airflow.providers.fab.auth_manager.api.auth.backend.kerberos_auth` instead.
 
-AIR303.py:21:1: AIR303 Import path `airflow.api.auth.backend.basic_auth` is moved into `fab` provider in Airflow 3.0;
+AIR303.py:23:1: AIR303 Import path `airflow.api.auth.backend.basic_auth` is moved into `fab` provider in Airflow 3.0;
    |
-19 | # apache-airflow-providers-fab
-20 | basic_auth, kerberos_auth
-21 | auth_current_user
+21 | # apache-airflow-providers-fab
+22 | basic_auth, kerberos_auth
+23 | auth_current_user
    | ^^^^^^^^^^^^^^^^^ AIR303
-22 | backend_kerberos_auth
-23 | fab_override
+24 | backend_kerberos_auth
+25 | fab_override
    |
    = help: Install `apache-airflow-provider-fab>=1.0.0` and import from `airflow.providers.fab.auth_manager.api.auth.backend.basic_auth` instead.
 
-AIR303.py:22:1: AIR303 Import path `airflow.auth_manager.api.auth.backend.kerberos_auth` is moved into `fab` provider in Airflow 3.0;
+AIR303.py:24:1: AIR303 Import path `airflow.auth_manager.api.auth.backend.kerberos_auth` is moved into `fab` provider in Airflow 3.0;
    |
-20 | basic_auth, kerberos_auth
-21 | auth_current_user
-22 | backend_kerberos_auth
+22 | basic_auth, kerberos_auth
+23 | auth_current_user
+24 | backend_kerberos_auth
    | ^^^^^^^^^^^^^^^^^^^^^ AIR303
-23 | fab_override
+25 | fab_override
    |
    = help: Install `apache-airflow-provider-fab>=1.0.0` and import from `airflow.providers.fab.auth_manager.api.auth.backend.kerberos_auth` instead.
 
-AIR303.py:23:1: AIR303 Import path `airflow.auth.managers.fab.security_managr.override` is moved into `fab` provider in Airflow 3.0;
+AIR303.py:25:1: AIR303 Import path `airflow.auth.managers.fab.security_managr.override` is moved into `fab` provider in Airflow 3.0;
    |
-21 | auth_current_user
-22 | backend_kerberos_auth
-23 | fab_override
+23 | auth_current_user
+24 | backend_kerberos_auth
+25 | fab_override
    | ^^^^^^^^^^^^ AIR303
-24 | 
-25 | FabAuthManager()
+26 | 
+27 | FabAuthManager()
    |
    = help: Install `apache-airflow-provider-fab>=1.0.0` and import from `airflow.providers.fab.auth_manager.security_manager.override` instead.
 
-AIR303.py:25:1: AIR303 `airflow.auth.managers.fab.fab_auth_manager.FabAuthManager` is moved into `fab` provider in Airflow 3.0;
+AIR303.py:27:1: AIR303 `airflow.auth.managers.fab.fab_auth_manager.FabAuthManager` is moved into `fab` provider in Airflow 3.0;
    |
-23 | fab_override
-24 | 
-25 | FabAuthManager()
+25 | fab_override
+26 | 
+27 | FabAuthManager()
    | ^^^^^^^^^^^^^^ AIR303
-26 | FabAirflowSecurityManagerOverride()
+28 | FabAirflowSecurityManagerOverride()
    |
    = help: Install `apache-airflow-provider-fab>=1.0.0` and use `airflow.providers.fab.auth_manager.security_manager.FabAuthManager` instead.
 
-AIR303.py:26:1: AIR303 `airflow.www.security.FabAirflowSecurityManagerOverride` is moved into `fab` provider in Airflow 3.0;
+AIR303.py:28:1: AIR303 `airflow.www.security.FabAirflowSecurityManagerOverride` is moved into `fab` provider in Airflow 3.0;
    |
-25 | FabAuthManager()
-26 | FabAirflowSecurityManagerOverride()
+27 | FabAuthManager()
+28 | FabAirflowSecurityManagerOverride()
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR303
-27 | 
-28 | # apache-airflow-providers-celery
+29 | 
+30 | # apache-airflow-providers-celery
    |
    = help: Install `apache-airflow-provider-fab>=1.0.0` and use `airflow.providers.fab.auth_manager.security_manager.override.FabAirflowSecurityManagerOverride` instead.
 
-AIR303.py:29:1: AIR303 Import path `airflow.config_templates.default_celery.DEFAULT_CELERY_CONFIG` is moved into `celery` provider in Airflow 3.0;
+AIR303.py:31:1: AIR303 Import path `airflow.config_templates.default_celery.DEFAULT_CELERY_CONFIG` is moved into `celery` provider in Airflow 3.0;
    |
-28 | # apache-airflow-providers-celery
-29 | DEFAULT_CELERY_CONFIG
+30 | # apache-airflow-providers-celery
+31 | DEFAULT_CELERY_CONFIG
    | ^^^^^^^^^^^^^^^^^^^^^ AIR303
-30 | app
+32 | app
+33 | CeleryExecutor()
    |
    = help: Install `apache-airflow-provider-celery>=3.3.0` and import from `airflow.providers.celery.executors.default_celery.DEFAULT_CELERY_CONFIG` instead.
 
-AIR303.py:30:1: AIR303 Import path `airflow.executors.celery_executor.app` is moved into `celery` provider in Airflow 3.0;
+AIR303.py:32:1: AIR303 Import path `airflow.executors.celery_executor.app` is moved into `celery` provider in Airflow 3.0;
    |
-28 | # apache-airflow-providers-celery
-29 | DEFAULT_CELERY_CONFIG
-30 | app
+30 | # apache-airflow-providers-celery
+31 | DEFAULT_CELERY_CONFIG
+32 | app
    | ^^^ AIR303
-31 | 
-32 | # apache-airflow-providers-common-sql
+33 | CeleryExecutor()
+34 | CeleryKubernetesExecutor()
    |
    = help: Install `apache-airflow-provider-celery>=3.3.0` and import from `airflow.providers.celery.executors.celery_executor_utils.app` instead.
 
-AIR303.py:33:1: AIR303 Import path `airflow.hooks.dbapi.ConnectorProtocol` is moved into `Common SQL` provider in Airflow 3.0;
+AIR303.py:33:1: AIR303 `airflow.executors.celery_executor.CeleryExecutor` is moved into `celery` provider in Airflow 3.0;
    |
-32 | # apache-airflow-providers-common-sql
-33 | ConnectorProtocol()
+31 | DEFAULT_CELERY_CONFIG
+32 | app
+33 | CeleryExecutor()
+   | ^^^^^^^^^^^^^^ AIR303
+34 | CeleryKubernetesExecutor()
+   |
+   = help: Install `apache-airflow-provider-celery>=3.3.0` and use `airflow.providers.celery.executors.celery_executor.CeleryExecutor` instead.
+
+AIR303.py:34:1: AIR303 `airflow.executors.celery_kubernetes_executor.CeleryKubernetesExecutor` is moved into `celery` provider in Airflow 3.0;
+   |
+32 | app
+33 | CeleryExecutor()
+34 | CeleryKubernetesExecutor()
+   | ^^^^^^^^^^^^^^^^^^^^^^^^ AIR303
+35 | 
+36 | # apache-airflow-providers-daskexecutor
+   |
+   = help: Install `apache-airflow-provider-celery>=3.3.0` and use `airflow.providers.celery.executors.celery_kubernetes_executor.CeleryKubernetesExecutor` instead.
+
+AIR303.py:37:1: AIR303 `airflow.executors.dask_executor.DaskExecutor` is moved into `daskexecutor` provider in Airflow 3.0;
+   |
+36 | # apache-airflow-providers-daskexecutor
+37 | DaskExecutor()
+   | ^^^^^^^^^^^^ AIR303
+38 | 
+39 | # apache-airflow-providers-common-sql
+   |
+   = help: Install `apache-airflow-provider-daskexecutor>=1.0.0` and use `airflow.providers.daskexecutor.executors.dask_executor.DaskExecutor` instead.
+
+AIR303.py:40:1: AIR303 Import path `airflow.hooks.dbapi.ConnectorProtocol` is moved into `Common SQL` provider in Airflow 3.0;
+   |
+39 | # apache-airflow-providers-common-sql
+40 | ConnectorProtocol()
    | ^^^^^^^^^^^^^^^^^ AIR303
-34 | DbApiHook()
+41 | DbApiHook()
    |
    = help: Install `apache-airflow-provider-Common SQL>=1.0.0` and import from `airflow.providers.common.sql.hooks.sql.ConnectorProtocol` instead.
 
-AIR303.py:34:1: AIR303 Import path `airflow.hooks.dbapi.DbApiHook` is moved into `Common SQL` provider in Airflow 3.0;
+AIR303.py:41:1: AIR303 Import path `airflow.hooks.dbapi.DbApiHook` is moved into `Common SQL` provider in Airflow 3.0;
    |
-32 | # apache-airflow-providers-common-sql
-33 | ConnectorProtocol()
-34 | DbApiHook()
+39 | # apache-airflow-providers-common-sql
+40 | ConnectorProtocol()
+41 | DbApiHook()
    | ^^^^^^^^^ AIR303
-35 | 
-36 | # apache-airflow-providers-cncf-kubernetes
+42 | 
+43 | # apache-airflow-providers-cncf-kubernetes
    |
    = help: Install `apache-airflow-provider-Common SQL>=1.0.0` and import from `airflow.providers.common.sql.hooks.sql.DbApiHook` instead.
 
-AIR303.py:37:1: AIR303 Import path `airflow.executors.kubernetes_executor_types.ALL_NAMESPACES` is moved into `Kubernetes` provider in Airflow 3.0;
+AIR303.py:44:1: AIR303 Import path `airflow.executors.kubernetes_executor_types.ALL_NAMESPACES` is moved into `Kubernetes` provider in Airflow 3.0;
    |
-36 | # apache-airflow-providers-cncf-kubernetes
-37 | ALL_NAMESPACES
+43 | # apache-airflow-providers-cncf-kubernetes
+44 | ALL_NAMESPACES
    | ^^^^^^^^^^^^^^ AIR303
-38 | POD_EXECUTOR_DONE_KEY
+45 | POD_EXECUTOR_DONE_KEY
    |
    = help: Install `apache-airflow-provider-Kubernetes>=7.4.0` and import from `airflow.providers.cncf.kubernetes.executors.kubernetes_executor_types.ALL_NAMESPACES` instead.
 
-AIR303.py:38:1: AIR303 Import path `airflow.executors.kubernetes_executor_types.POD_EXECUTOR_DONE_KEY` is moved into `Kubernetes` provider in Airflow 3.0;
+AIR303.py:45:1: AIR303 Import path `airflow.executors.kubernetes_executor_types.POD_EXECUTOR_DONE_KEY` is moved into `Kubernetes` provider in Airflow 3.0;
    |
-36 | # apache-airflow-providers-cncf-kubernetes
-37 | ALL_NAMESPACES
-38 | POD_EXECUTOR_DONE_KEY
+43 | # apache-airflow-providers-cncf-kubernetes
+44 | ALL_NAMESPACES
+45 | POD_EXECUTOR_DONE_KEY
    | ^^^^^^^^^^^^^^^^^^^^^ AIR303
-39 | 
-40 | # apache-airflow-providers-apache-hive
+46 | 
+47 | # apache-airflow-providers-apache-hive
    |
    = help: Install `apache-airflow-provider-Kubernetes>=7.4.0` and import from `airflow.providers.cncf.kubernetes.executors.kubernetes_executor_types.POD_EXECUTOR_DONE_KEY` instead.
 
-AIR303.py:41:1: AIR303 Import path `airflow.hooks.hive_hooks.HIVE_QUEUE_PRIORITIES` is moved into `Apache Hive` provider in Airflow 3.0;
+AIR303.py:48:1: AIR303 Import path `airflow.hooks.hive_hooks.HIVE_QUEUE_PRIORITIES` is moved into `Apache Hive` provider in Airflow 3.0;
    |
-40 | # apache-airflow-providers-apache-hive
-41 | HIVE_QUEUE_PRIORITIES
+47 | # apache-airflow-providers-apache-hive
+48 | HIVE_QUEUE_PRIORITIES
    | ^^^^^^^^^^^^^^^^^^^^^ AIR303
-42 | closest_ds_partition()
-43 | max_partition()
+49 | closest_ds_partition()
+50 | max_partition()
    |
    = help: Install `apache-airflow-provider-Apache Hive>=1.0.0` and import from `airflow.providers.apache.hive.hooks.hive.HIVE_QUEUE_PRIORITIES` instead.
 
-AIR303.py:42:1: AIR303 Import path `airflow.macros.hive.closest_ds_partition` is moved into `Apache Hive` provider in Airflow 3.0;
+AIR303.py:49:1: AIR303 Import path `airflow.macros.hive.closest_ds_partition` is moved into `Apache Hive` provider in Airflow 3.0;
    |
-40 | # apache-airflow-providers-apache-hive
-41 | HIVE_QUEUE_PRIORITIES
-42 | closest_ds_partition()
+47 | # apache-airflow-providers-apache-hive
+48 | HIVE_QUEUE_PRIORITIES
+49 | closest_ds_partition()
    | ^^^^^^^^^^^^^^^^^^^^ AIR303
-43 | max_partition()
+50 | max_partition()
    |
    = help: Install `apache-airflow-provider-Apache Hive>=5.1.0` and import from `airflow.providers.apache.hive.macros.hive.closest_ds_partition` instead.
 
-AIR303.py:43:1: AIR303 Import path `airflow.macros.hive.max_partition` is moved into `Apache Hive` provider in Airflow 3.0;
+AIR303.py:50:1: AIR303 Import path `airflow.macros.hive.max_partition` is moved into `Apache Hive` provider in Airflow 3.0;
    |
-41 | HIVE_QUEUE_PRIORITIES
-42 | closest_ds_partition()
-43 | max_partition()
+48 | HIVE_QUEUE_PRIORITIES
+49 | closest_ds_partition()
+50 | max_partition()
    | ^^^^^^^^^^^^^ AIR303
    |
    = help: Install `apache-airflow-provider-Apache Hive>=5.1.0` and import from `airflow.providers.apache.hive.macros.hive.max_partition` instead.

--- a/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR303_AIR303.py.snap
+++ b/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR303_AIR303.py.snap
@@ -2,1248 +2,1157 @@
 source: crates/ruff_linter/src/rules/airflow/mod.rs
 snapshot_kind: text
 ---
-AIR303.py:123:1: AIR303 Import path `airflow.api.auth.backend.basic_auth` is moved into `fab` provider in Airflow 3.0;
+AIR303.py:120:1: AIR303 `airflow.hooks.S3_hook.provide_bucket_name` is moved into `amazon` provider in Airflow 3.0;
     |
-122 | # apache-airflow-providers-fab
-123 | basic_auth, kerberos_auth
-    | ^^^^^^^^^^ AIR303
-124 | auth_current_user
-125 | backend_kerberos_auth
+119 | # apache-airflow-providers-amazon
+120 | provide_bucket_name()
+    | ^^^^^^^^^^^^^^^^^^^ AIR303
+121 | GCSToS3Operator()
+122 | GoogleApiToS3Operator()
     |
-    = help: Install `apache-airflow-provider-fab>=1.0.0` and import from `airflow.providers.fab.auth_manager.api.auth.backend.basic_auth` instead.
+    = help: Install `apache-airflow-provider-amazon>=1.0.0` and use `airflow.providers.amazon.aws.hooks.s3.provide_bucket_name` instead.
 
-AIR303.py:123:13: AIR303 Import path `airflow.api.auth.backend.kerberos_auth` is moved into `fab` provider in Airflow 3.0;
+AIR303.py:121:1: AIR303 `airflow.operators.gcs_to_s3.GCSToS3Operator` is moved into `amazon` provider in Airflow 3.0;
     |
-122 | # apache-airflow-providers-fab
-123 | basic_auth, kerberos_auth
-    |             ^^^^^^^^^^^^^ AIR303
-124 | auth_current_user
-125 | backend_kerberos_auth
+119 | # apache-airflow-providers-amazon
+120 | provide_bucket_name()
+121 | GCSToS3Operator()
+    | ^^^^^^^^^^^^^^^ AIR303
+122 | GoogleApiToS3Operator()
+123 | GoogleApiToS3Transfer()
     |
-    = help: Install `apache-airflow-provider-fab>=1.0.0` and import from `airflow.providers.fab.auth_manager.api.auth.backend.kerberos_auth` instead.
+    = help: Install `apache-airflow-provider-amazon>=1.0.0` and use `airflow.providers.amazon.aws.transfers.gcs_to_s3.GCSToS3Operator` instead.
 
-AIR303.py:124:1: AIR303 Import path `airflow.api.auth.backend.basic_auth` is moved into `fab` provider in Airflow 3.0;
+AIR303.py:122:1: AIR303 `airflow.operators.google_api_to_s3_transfer.GoogleApiToS3Operator` is moved into `amazon` provider in Airflow 3.0;
     |
-122 | # apache-airflow-providers-fab
-123 | basic_auth, kerberos_auth
-124 | auth_current_user
-    | ^^^^^^^^^^^^^^^^^ AIR303
-125 | backend_kerberos_auth
-126 | fab_override
-    |
-    = help: Install `apache-airflow-provider-fab>=1.0.0` and import from `airflow.providers.fab.auth_manager.api.auth.backend.basic_auth` instead.
-
-AIR303.py:125:1: AIR303 Import path `airflow.auth_manager.api.auth.backend.kerberos_auth` is moved into `fab` provider in Airflow 3.0;
-    |
-123 | basic_auth, kerberos_auth
-124 | auth_current_user
-125 | backend_kerberos_auth
+120 | provide_bucket_name()
+121 | GCSToS3Operator()
+122 | GoogleApiToS3Operator()
     | ^^^^^^^^^^^^^^^^^^^^^ AIR303
-126 | fab_override
+123 | GoogleApiToS3Transfer()
+124 | RedshiftToS3Operator()
     |
-    = help: Install `apache-airflow-provider-fab>=1.0.0` and import from `airflow.providers.fab.auth_manager.api.auth.backend.kerberos_auth` instead.
+    = help: Install `apache-airflow-provider-amazon>=1.0.0` and use `airflow.providers.amazon.aws.transfers.google_api_to_s3.GoogleApiToS3Operator` instead.
 
-AIR303.py:126:1: AIR303 Import path `airflow.auth.managers.fab.security_managr.override` is moved into `fab` provider in Airflow 3.0;
+AIR303.py:123:1: AIR303 `airflow.operators.google_api_to_s3_transfer.GoogleApiToS3Transfer` is moved into `amazon` provider in Airflow 3.0;
     |
-124 | auth_current_user
-125 | backend_kerberos_auth
-126 | fab_override
-    | ^^^^^^^^^^^^ AIR303
-127 | 
-128 | FabAuthManager()
-    |
-    = help: Install `apache-airflow-provider-fab>=1.0.0` and import from `airflow.providers.fab.auth_manager.security_manager.override` instead.
-
-AIR303.py:128:1: AIR303 `airflow.auth.managers.fab.fab_auth_manager.FabAuthManager` is moved into `fab` provider in Airflow 3.0;
-    |
-126 | fab_override
-127 | 
-128 | FabAuthManager()
-    | ^^^^^^^^^^^^^^ AIR303
-129 | FabAirflowSecurityManagerOverride()
-    |
-    = help: Install `apache-airflow-provider-fab>=1.0.0` and use `airflow.providers.fab.auth_manager.security_manager.FabAuthManager` instead.
-
-AIR303.py:129:1: AIR303 `airflow.www.security.FabAirflowSecurityManagerOverride` is moved into `fab` provider in Airflow 3.0;
-    |
-128 | FabAuthManager()
-129 | FabAirflowSecurityManagerOverride()
-    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR303
-130 | 
-131 | # apache-airflow-providers-celery
-    |
-    = help: Install `apache-airflow-provider-fab>=1.0.0` and use `airflow.providers.fab.auth_manager.security_manager.override.FabAirflowSecurityManagerOverride` instead.
-
-AIR303.py:132:1: AIR303 Import path `airflow.config_templates.default_celery.DEFAULT_CELERY_CONFIG` is moved into `celery` provider in Airflow 3.0;
-    |
-131 | # apache-airflow-providers-celery
-132 | DEFAULT_CELERY_CONFIG
+121 | GCSToS3Operator()
+122 | GoogleApiToS3Operator()
+123 | GoogleApiToS3Transfer()
     | ^^^^^^^^^^^^^^^^^^^^^ AIR303
-133 | app
-134 | CeleryExecutor()
+124 | RedshiftToS3Operator()
+125 | RedshiftToS3Transfer()
+    |
+    = help: Install `apache-airflow-provider-amazon>=1.0.0` and use `airflow.providers.amazon.aws.transfers.google_api_to_s3.GoogleApiToS3Operator` instead.
+
+AIR303.py:124:1: AIR303 `airflow.operators.redshift_to_s3_operator.RedshiftToS3Operator` is moved into `amazon` provider in Airflow 3.0;
+    |
+122 | GoogleApiToS3Operator()
+123 | GoogleApiToS3Transfer()
+124 | RedshiftToS3Operator()
+    | ^^^^^^^^^^^^^^^^^^^^ AIR303
+125 | RedshiftToS3Transfer()
+126 | S3FileTransformOperator()
+    |
+    = help: Install `apache-airflow-provider-amazon>=1.0.0` and use `airflow.providers.amazon.aws.transfers.redshift_to_s3.RedshiftToS3Operator` instead.
+
+AIR303.py:125:1: AIR303 `airflow.operators.redshift_to_s3_operator.RedshiftToS3Transfer` is moved into `amazon` provider in Airflow 3.0;
+    |
+123 | GoogleApiToS3Transfer()
+124 | RedshiftToS3Operator()
+125 | RedshiftToS3Transfer()
+    | ^^^^^^^^^^^^^^^^^^^^ AIR303
+126 | S3FileTransformOperator()
+127 | S3Hook()
+    |
+    = help: Install `apache-airflow-provider-amazon>=1.0.0` and use `airflow.providers.amazon.aws.transfers.redshift_to_s3.RedshiftToS3Operator` instead.
+
+AIR303.py:126:1: AIR303 `airflow.operators.s3_file_transform_operator.S3FileTransformOperator` is moved into `amazon` provider in Airflow 3.0;
+    |
+124 | RedshiftToS3Operator()
+125 | RedshiftToS3Transfer()
+126 | S3FileTransformOperator()
+    | ^^^^^^^^^^^^^^^^^^^^^^^ AIR303
+127 | S3Hook()
+128 | S3KeySensor()
+    |
+    = help: Install `apache-airflow-provider-amazon>=1.0.0` and use `airflow.providers.amazon.aws.operators.s3_file_transform.S3FileTransformOperator` instead.
+
+AIR303.py:127:1: AIR303 `airflow.hooks.S3_hook.S3Hook` is moved into `amazon` provider in Airflow 3.0;
+    |
+125 | RedshiftToS3Transfer()
+126 | S3FileTransformOperator()
+127 | S3Hook()
+    | ^^^^^^ AIR303
+128 | S3KeySensor()
+129 | S3ToRedshiftOperator()
+    |
+    = help: Install `apache-airflow-provider-amazon>=1.0.0` and use `airflow.providers.amazon.aws.hooks.s3.S3Hook` instead.
+
+AIR303.py:128:1: AIR303 `airflow.sensors.s3_key_sensor.S3KeySensor` is moved into `amazon` provider in Airflow 3.0;
+    |
+126 | S3FileTransformOperator()
+127 | S3Hook()
+128 | S3KeySensor()
+    | ^^^^^^^^^^^ AIR303
+129 | S3ToRedshiftOperator()
+130 | S3ToRedshiftTransfer()
+    |
+    = help: Install `apache-airflow-provider-amazon>=1.0.0` and use `S3KeySensor` instead.
+
+AIR303.py:129:1: AIR303 `airflow.operators.s3_to_redshift_operator.S3ToRedshiftOperator` is moved into `amazon` provider in Airflow 3.0;
+    |
+127 | S3Hook()
+128 | S3KeySensor()
+129 | S3ToRedshiftOperator()
+    | ^^^^^^^^^^^^^^^^^^^^ AIR303
+130 | S3ToRedshiftTransfer()
+    |
+    = help: Install `apache-airflow-provider-amazon>=1.0.0` and use `airflow.providers.amazon.aws.transfers.s3_to_redshift.S3ToRedshiftOperator` instead.
+
+AIR303.py:130:1: AIR303 `airflow.operators.s3_to_redshift_operator.S3ToRedshiftTransfer` is moved into `amazon` provider in Airflow 3.0;
+    |
+128 | S3KeySensor()
+129 | S3ToRedshiftOperator()
+130 | S3ToRedshiftTransfer()
+    | ^^^^^^^^^^^^^^^^^^^^ AIR303
+131 | 
+132 | # apache-airflow-providers-celery
+    |
+    = help: Install `apache-airflow-provider-amazon>=1.0.0` and use `airflow.providers.amazon.aws.transfers.s3_to_redshift.S3ToRedshiftOperator` instead.
+
+AIR303.py:133:1: AIR303 Import path `airflow.config_templates.default_celery.DEFAULT_CELERY_CONFIG` is moved into `celery` provider in Airflow 3.0;
+    |
+132 | # apache-airflow-providers-celery
+133 | DEFAULT_CELERY_CONFIG
+    | ^^^^^^^^^^^^^^^^^^^^^ AIR303
+134 | app
+135 | CeleryExecutor()
     |
     = help: Install `apache-airflow-provider-celery>=3.3.0` and import from `airflow.providers.celery.executors.default_celery.DEFAULT_CELERY_CONFIG` instead.
 
-AIR303.py:133:1: AIR303 Import path `airflow.executors.celery_executor.app` is moved into `celery` provider in Airflow 3.0;
+AIR303.py:134:1: AIR303 Import path `airflow.executors.celery_executor.app` is moved into `celery` provider in Airflow 3.0;
     |
-131 | # apache-airflow-providers-celery
-132 | DEFAULT_CELERY_CONFIG
-133 | app
+132 | # apache-airflow-providers-celery
+133 | DEFAULT_CELERY_CONFIG
+134 | app
     | ^^^ AIR303
-134 | CeleryExecutor()
-135 | CeleryKubernetesExecutor()
+135 | CeleryExecutor()
+136 | CeleryKubernetesExecutor()
     |
     = help: Install `apache-airflow-provider-celery>=3.3.0` and import from `airflow.providers.celery.executors.celery_executor_utils.app` instead.
 
-AIR303.py:134:1: AIR303 `airflow.executors.celery_executor.CeleryExecutor` is moved into `celery` provider in Airflow 3.0;
+AIR303.py:135:1: AIR303 `airflow.executors.celery_executor.CeleryExecutor` is moved into `celery` provider in Airflow 3.0;
     |
-132 | DEFAULT_CELERY_CONFIG
-133 | app
-134 | CeleryExecutor()
+133 | DEFAULT_CELERY_CONFIG
+134 | app
+135 | CeleryExecutor()
     | ^^^^^^^^^^^^^^ AIR303
-135 | CeleryKubernetesExecutor()
+136 | CeleryKubernetesExecutor()
     |
     = help: Install `apache-airflow-provider-celery>=3.3.0` and use `airflow.providers.celery.executors.celery_executor.CeleryExecutor` instead.
 
-AIR303.py:135:1: AIR303 `airflow.executors.celery_kubernetes_executor.CeleryKubernetesExecutor` is moved into `celery` provider in Airflow 3.0;
+AIR303.py:136:1: AIR303 `airflow.executors.celery_kubernetes_executor.CeleryKubernetesExecutor` is moved into `celery` provider in Airflow 3.0;
     |
-133 | app
-134 | CeleryExecutor()
-135 | CeleryKubernetesExecutor()
+134 | app
+135 | CeleryExecutor()
+136 | CeleryKubernetesExecutor()
     | ^^^^^^^^^^^^^^^^^^^^^^^^ AIR303
-136 | 
-137 | # apache-airflow-providers-daskexecutor
+137 | 
+138 | # apache-airflow-providers-common-sql
     |
     = help: Install `apache-airflow-provider-celery>=3.3.0` and use `airflow.providers.celery.executors.celery_kubernetes_executor.CeleryKubernetesExecutor` instead.
 
-AIR303.py:138:1: AIR303 `airflow.executors.dask_executor.DaskExecutor` is moved into `daskexecutor` provider in Airflow 3.0;
+AIR303.py:139:1: AIR303 `airflow.operators.sql._convert_to_float_if_possible` is moved into `common-sql` provider in Airflow 3.0;
     |
-137 | # apache-airflow-providers-daskexecutor
-138 | DaskExecutor()
+138 | # apache-airflow-providers-common-sql
+139 | _convert_to_float_if_possible()
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR303
+140 | parse_boolean()
+141 | BaseSQLOperator()
+    |
+    = help: Install `apache-airflow-provider-common-sql>=1.0.0` and use `airflow.providers.common.sql.operators.sql._convert_to_float_if_possible` instead.
+
+AIR303.py:140:1: AIR303 `airflow.operators.sql.parse_boolean` is moved into `common-sql` provider in Airflow 3.0;
+    |
+138 | # apache-airflow-providers-common-sql
+139 | _convert_to_float_if_possible()
+140 | parse_boolean()
+    | ^^^^^^^^^^^^^ AIR303
+141 | BaseSQLOperator()
+142 | BranchSQLOperator()
+    |
+    = help: Install `apache-airflow-provider-common-sql>=1.0.0` and use `airflow.providers.common.sql.operators.sql.parse_boolean` instead.
+
+AIR303.py:141:1: AIR303 `airflow.operators.sql.BaseSQLOperator` is moved into `common-sql` provider in Airflow 3.0;
+    |
+139 | _convert_to_float_if_possible()
+140 | parse_boolean()
+141 | BaseSQLOperator()
+    | ^^^^^^^^^^^^^^^ AIR303
+142 | BranchSQLOperator()
+143 | CheckOperator()
+    |
+    = help: Install `apache-airflow-provider-common-sql>=1.1.0` and use `airflow.providers.common.sql.operators.sql.BaseSQLOperator` instead.
+
+AIR303.py:142:1: AIR303 `airflow.operators.sql.BranchSQLOperator` is moved into `common-sql` provider in Airflow 3.0;
+    |
+140 | parse_boolean()
+141 | BaseSQLOperator()
+142 | BranchSQLOperator()
+    | ^^^^^^^^^^^^^^^^^ AIR303
+143 | CheckOperator()
+144 | ConnectorProtocol()
+    |
+    = help: Install `apache-airflow-provider-common-sql>=1.1.0` and use `airflow.providers.common.sql.operators.sql.BranchSQLOperator` instead.
+
+AIR303.py:143:1: AIR303 `airflow.operators.check_operator.CheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+    |
+141 | BaseSQLOperator()
+142 | BranchSQLOperator()
+143 | CheckOperator()
+    | ^^^^^^^^^^^^^ AIR303
+144 | ConnectorProtocol()
+145 | DbApiHook()
+    |
+    = help: Install `apache-airflow-provider-common-sql>=1.1.0` and use `airflow.providers.common.sql.operators.sql.SQLCheckOperator` instead.
+
+AIR303.py:144:1: AIR303 Import path `airflow.hooks.dbapi.ConnectorProtocol` is moved into `common-sql` provider in Airflow 3.0;
+    |
+142 | BranchSQLOperator()
+143 | CheckOperator()
+144 | ConnectorProtocol()
+    | ^^^^^^^^^^^^^^^^^ AIR303
+145 | DbApiHook()
+146 | DbApiHook2()
+    |
+    = help: Install `apache-airflow-provider-common-sql>=1.0.0` and import from `airflow.providers.common.sql.hooks.sql.ConnectorProtocol` instead.
+
+AIR303.py:145:1: AIR303 Import path `airflow.hooks.dbapi.DbApiHook` is moved into `common-sql` provider in Airflow 3.0;
+    |
+143 | CheckOperator()
+144 | ConnectorProtocol()
+145 | DbApiHook()
+    | ^^^^^^^^^ AIR303
+146 | DbApiHook2()
+147 | IntervalCheckOperator()
+    |
+    = help: Install `apache-airflow-provider-common-sql>=1.0.0` and import from `airflow.providers.common.sql.hooks.sql.DbApiHook` instead.
+
+AIR303.py:146:1: AIR303 `airflow.hooks.dbapi_hook.DbApiHook` is moved into `common-sql` provider in Airflow 3.0;
+    |
+144 | ConnectorProtocol()
+145 | DbApiHook()
+146 | DbApiHook2()
+    | ^^^^^^^^^^ AIR303
+147 | IntervalCheckOperator()
+148 | PrestoCheckOperator()
+    |
+    = help: Install `apache-airflow-provider-common-sql>=1.0.0` and use `airflow.providers.common.sql.hooks.sql.DbApiHook` instead.
+
+AIR303.py:147:1: AIR303 `airflow.operators.check_operator.IntervalCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+    |
+145 | DbApiHook()
+146 | DbApiHook2()
+147 | IntervalCheckOperator()
+    | ^^^^^^^^^^^^^^^^^^^^^ AIR303
+148 | PrestoCheckOperator()
+149 | PrestoIntervalCheckOperator()
+    |
+    = help: Install `apache-airflow-provider-common-sql>=1.1.0` and use `airflow.providers.common.sql.operators.sql.SQLIntervalCheckOperator` instead.
+
+AIR303.py:148:1: AIR303 `airflow.operators.presto_check_operator.PrestoCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+    |
+146 | DbApiHook2()
+147 | IntervalCheckOperator()
+148 | PrestoCheckOperator()
+    | ^^^^^^^^^^^^^^^^^^^ AIR303
+149 | PrestoIntervalCheckOperator()
+150 | PrestoValueCheckOperator()
+    |
+    = help: Install `apache-airflow-provider-common-sql>=1.1.0` and use `airflow.providers.common.sql.operators.sql.SQLCheckOperator` instead.
+
+AIR303.py:149:1: AIR303 `airflow.operators.presto_check_operator.PrestoIntervalCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+    |
+147 | IntervalCheckOperator()
+148 | PrestoCheckOperator()
+149 | PrestoIntervalCheckOperator()
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR303
+150 | PrestoValueCheckOperator()
+151 | SQLCheckOperator()
+    |
+    = help: Install `apache-airflow-provider-common-sql>=1.1.0` and use `airflow.providers.common.sql.operators.sql.SQLIntervalCheckOperator` instead.
+
+AIR303.py:150:1: AIR303 `airflow.operators.presto_check_operator.PrestoValueCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+    |
+148 | PrestoCheckOperator()
+149 | PrestoIntervalCheckOperator()
+150 | PrestoValueCheckOperator()
+    | ^^^^^^^^^^^^^^^^^^^^^^^^ AIR303
+151 | SQLCheckOperator()
+152 | SQLCheckOperator2()
+    |
+    = help: Install `apache-airflow-provider-common-sql>=1.1.0` and use `airflow.providers.common.sql.operators.sql.SQLValueCheckOperator` instead.
+
+AIR303.py:151:1: AIR303 `airflow.operators.check_operator.SQLCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+    |
+149 | PrestoIntervalCheckOperator()
+150 | PrestoValueCheckOperator()
+151 | SQLCheckOperator()
+    | ^^^^^^^^^^^^^^^^ AIR303
+152 | SQLCheckOperator2()
+153 | SQLCheckOperator3()
+    |
+    = help: Install `apache-airflow-provider-common-sql>=1.1.0` and use `airflow.providers.common.sql.operators.sql.SQLCheckOperator` instead.
+
+AIR303.py:152:1: AIR303 `airflow.operators.presto_check_operator.SQLCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+    |
+150 | PrestoValueCheckOperator()
+151 | SQLCheckOperator()
+152 | SQLCheckOperator2()
+    | ^^^^^^^^^^^^^^^^^ AIR303
+153 | SQLCheckOperator3()
+154 | SQLColumnCheckOperator2()
+    |
+    = help: Install `apache-airflow-provider-common-sql>=1.1.0` and use `airflow.providers.common.sql.operators.sql.SQLCheckOperator` instead.
+
+AIR303.py:153:1: AIR303 `airflow.operators.sql.SQLCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+    |
+151 | SQLCheckOperator()
+152 | SQLCheckOperator2()
+153 | SQLCheckOperator3()
+    | ^^^^^^^^^^^^^^^^^ AIR303
+154 | SQLColumnCheckOperator2()
+155 | SQLIntervalCheckOperator()
+    |
+    = help: Install `apache-airflow-provider-common-sql>=1.1.0` and use `airflow.providers.common.sql.operators.sql.SQLCheckOperator` instead.
+
+AIR303.py:154:1: AIR303 `airflow.operators.sql.SQLColumnCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+    |
+152 | SQLCheckOperator2()
+153 | SQLCheckOperator3()
+154 | SQLColumnCheckOperator2()
+    | ^^^^^^^^^^^^^^^^^^^^^^^ AIR303
+155 | SQLIntervalCheckOperator()
+156 | SQLIntervalCheckOperator2()
+    |
+    = help: Install `apache-airflow-provider-common-sql>=1.0.0` and use `airflow.providers.common.sql.operators.sql.SQLColumnCheckOperator` instead.
+
+AIR303.py:155:1: AIR303 `airflow.operators.check_operator.SQLIntervalCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+    |
+153 | SQLCheckOperator3()
+154 | SQLColumnCheckOperator2()
+155 | SQLIntervalCheckOperator()
+    | ^^^^^^^^^^^^^^^^^^^^^^^^ AIR303
+156 | SQLIntervalCheckOperator2()
+157 | SQLIntervalCheckOperator3()
+    |
+    = help: Install `apache-airflow-provider-common-sql>=1.1.0` and use `airflow.providers.common.sql.operators.sql.SQLIntervalCheckOperator` instead.
+
+AIR303.py:156:1: AIR303 `airflow.operators.presto_check_operator.SQLIntervalCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+    |
+154 | SQLColumnCheckOperator2()
+155 | SQLIntervalCheckOperator()
+156 | SQLIntervalCheckOperator2()
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^ AIR303
+157 | SQLIntervalCheckOperator3()
+158 | SQLTableCheckOperator()
+    |
+    = help: Install `apache-airflow-provider-common-sql>=1.1.0` and use `airflow.providers.common.sql.operators.sql.SQLIntervalCheckOperator` instead.
+
+AIR303.py:157:1: AIR303 `airflow.operators.sql.SQLIntervalCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+    |
+155 | SQLIntervalCheckOperator()
+156 | SQLIntervalCheckOperator2()
+157 | SQLIntervalCheckOperator3()
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^ AIR303
+158 | SQLTableCheckOperator()
+159 | SQLThresholdCheckOperator()
+    |
+    = help: Install `apache-airflow-provider-common-sql>=1.1.0` and use `airflow.providers.common.sql.operators.sql.SQLIntervalCheckOperator` instead.
+
+AIR303.py:159:1: AIR303 `airflow.operators.check_operator.SQLThresholdCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+    |
+157 | SQLIntervalCheckOperator3()
+158 | SQLTableCheckOperator()
+159 | SQLThresholdCheckOperator()
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^ AIR303
+160 | SQLThresholdCheckOperator2()
+161 | SQLValueCheckOperator()
+    |
+    = help: Install `apache-airflow-provider-common-sql>=1.1.0` and use `airflow.providers.common.sql.operators.sql.SQLThresholdCheckOperator` instead.
+
+AIR303.py:160:1: AIR303 `airflow.operators.sql.SQLThresholdCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+    |
+158 | SQLTableCheckOperator()
+159 | SQLThresholdCheckOperator()
+160 | SQLThresholdCheckOperator2()
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR303
+161 | SQLValueCheckOperator()
+162 | SQLValueCheckOperator2()
+    |
+    = help: Install `apache-airflow-provider-common-sql>=1.0.0` and use `airflow.providers.common.sql.operators.sql.SQLTableCheckOperator` instead.
+
+AIR303.py:161:1: AIR303 `airflow.operators.check_operator.SQLValueCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+    |
+159 | SQLThresholdCheckOperator()
+160 | SQLThresholdCheckOperator2()
+161 | SQLValueCheckOperator()
+    | ^^^^^^^^^^^^^^^^^^^^^ AIR303
+162 | SQLValueCheckOperator2()
+163 | SQLValueCheckOperator3()
+    |
+    = help: Install `apache-airflow-provider-common-sql>=1.1.0` and use `airflow.providers.common.sql.operators.sql.SQLValueCheckOperator` instead.
+
+AIR303.py:162:1: AIR303 `airflow.operators.presto_check_operator.SQLValueCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+    |
+160 | SQLThresholdCheckOperator2()
+161 | SQLValueCheckOperator()
+162 | SQLValueCheckOperator2()
+    | ^^^^^^^^^^^^^^^^^^^^^^ AIR303
+163 | SQLValueCheckOperator3()
+164 | SqlSensor()
+    |
+    = help: Install `apache-airflow-provider-common-sql>=1.1.0` and use `airflow.providers.common.sql.operators.sql.SQLValueCheckOperator` instead.
+
+AIR303.py:163:1: AIR303 `airflow.operators.sql.SQLValueCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+    |
+161 | SQLValueCheckOperator()
+162 | SQLValueCheckOperator2()
+163 | SQLValueCheckOperator3()
+    | ^^^^^^^^^^^^^^^^^^^^^^ AIR303
+164 | SqlSensor()
+165 | SqlSensor2()
+    |
+    = help: Install `apache-airflow-provider-common-sql>=1.0.0` and use `airflow.providers.common.sql.operators.sql.SQLValueCheckOperator` instead.
+
+AIR303.py:164:1: AIR303 `airflow.sensors.sql.SqlSensor` is moved into `common-sql` provider in Airflow 3.0;
+    |
+162 | SQLValueCheckOperator2()
+163 | SQLValueCheckOperator3()
+164 | SqlSensor()
+    | ^^^^^^^^^ AIR303
+165 | SqlSensor2()
+166 | ThresholdCheckOperator()
+    |
+    = help: Install `apache-airflow-provider-common-sql>=1.0.0` and use `airflow.providers.common.sql.sensors.sql.SqlSensor` instead.
+
+AIR303.py:166:1: AIR303 `airflow.operators.check_operator.ThresholdCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+    |
+164 | SqlSensor()
+165 | SqlSensor2()
+166 | ThresholdCheckOperator()
+    | ^^^^^^^^^^^^^^^^^^^^^^ AIR303
+167 | ValueCheckOperator()
+    |
+    = help: Install `apache-airflow-provider-common-sql>=1.1.0` and use `airflow.providers.common.sql.operators.sql.SQLThresholdCheckOperator` instead.
+
+AIR303.py:167:1: AIR303 `airflow.operators.check_operator.ValueCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+    |
+165 | SqlSensor2()
+166 | ThresholdCheckOperator()
+167 | ValueCheckOperator()
+    | ^^^^^^^^^^^^^^^^^^ AIR303
+168 | 
+169 | # apache-airflow-providers-daskexecutor
+    |
+    = help: Install `apache-airflow-provider-common-sql>=1.1.0` and use `airflow.providers.common.sql.operators.sql.SQLValueCheckOperator` instead.
+
+AIR303.py:170:1: AIR303 `airflow.executors.dask_executor.DaskExecutor` is moved into `daskexecutor` provider in Airflow 3.0;
+    |
+169 | # apache-airflow-providers-daskexecutor
+170 | DaskExecutor()
     | ^^^^^^^^^^^^ AIR303
-139 | 
-140 | # apache-airflow-providers-common-sql
+171 | 
+172 | # apache-airflow-providers-docker
     |
     = help: Install `apache-airflow-provider-daskexecutor>=1.0.0` and use `airflow.providers.daskexecutor.executors.dask_executor.DaskExecutor` instead.
 
-AIR303.py:141:1: AIR303 Import path `airflow.hooks.dbapi.ConnectorProtocol` is moved into `Common SQL` provider in Airflow 3.0;
+AIR303.py:173:1: AIR303 `airflow.hooks.docker_hook.DockerHook` is moved into `docker` provider in Airflow 3.0;
     |
-140 | # apache-airflow-providers-common-sql
-141 | ConnectorProtocol()
-    | ^^^^^^^^^^^^^^^^^ AIR303
-142 | DbApiHook()
+172 | # apache-airflow-providers-docker
+173 | DockerHook()
+    | ^^^^^^^^^^ AIR303
+174 | DockerOperator()
     |
-    = help: Install `apache-airflow-provider-Common SQL>=1.0.0` and import from `airflow.providers.common.sql.hooks.sql.ConnectorProtocol` instead.
+    = help: Install `apache-airflow-provider-docker>=1.0.0` and use `airflow.providers.docker.hooks.docker.DockerHook` instead.
 
-AIR303.py:142:1: AIR303 Import path `airflow.hooks.dbapi.DbApiHook` is moved into `Common SQL` provider in Airflow 3.0;
+AIR303.py:174:1: AIR303 `airflow.operators.docker_operator.DockerOperator` is moved into `docker` provider in Airflow 3.0;
     |
-140 | # apache-airflow-providers-common-sql
-141 | ConnectorProtocol()
-142 | DbApiHook()
-    | ^^^^^^^^^ AIR303
-143 | 
-144 | # apache-airflow-providers-cncf-kubernetes
-    |
-    = help: Install `apache-airflow-provider-Common SQL>=1.0.0` and import from `airflow.providers.common.sql.hooks.sql.DbApiHook` instead.
-
-AIR303.py:145:1: AIR303 Import path `airflow.executors.kubernetes_executor_types.ALL_NAMESPACES` is moved into `Kubernetes` provider in Airflow 3.0;
-    |
-144 | # apache-airflow-providers-cncf-kubernetes
-145 | ALL_NAMESPACES
+172 | # apache-airflow-providers-docker
+173 | DockerHook()
+174 | DockerOperator()
     | ^^^^^^^^^^^^^^ AIR303
-146 | POD_EXECUTOR_DONE_KEY
+175 | 
+176 | # apache-airflow-providers-apache-druid
     |
-    = help: Install `apache-airflow-provider-Kubernetes>=7.4.0` and import from `airflow.providers.cncf.kubernetes.executors.kubernetes_executor_types.ALL_NAMESPACES` instead.
+    = help: Install `apache-airflow-provider-docker>=1.0.0` and use `airflow.providers.docker.operators.docker.DockerOperator` instead.
 
-AIR303.py:146:1: AIR303 Import path `airflow.executors.kubernetes_executor_types.POD_EXECUTOR_DONE_KEY` is moved into `Kubernetes` provider in Airflow 3.0;
+AIR303.py:177:1: AIR303 `airflow.hooks.druid_hook.DruidDbApiHook` is moved into `apache-druid` provider in Airflow 3.0;
     |
-144 | # apache-airflow-providers-cncf-kubernetes
-145 | ALL_NAMESPACES
-146 | POD_EXECUTOR_DONE_KEY
+176 | # apache-airflow-providers-apache-druid
+177 | DruidDbApiHook()
+    | ^^^^^^^^^^^^^^ AIR303
+178 | DruidHook()
+179 | DruidCheckOperator()
+    |
+    = help: Install `apache-airflow-provider-apache-druid>=1.0.0` and use `DruidDbApiHook` instead.
+
+AIR303.py:178:1: AIR303 `airflow.hooks.druid_hook.DruidHook` is moved into `apache-druid` provider in Airflow 3.0;
+    |
+176 | # apache-airflow-providers-apache-druid
+177 | DruidDbApiHook()
+178 | DruidHook()
+    | ^^^^^^^^^ AIR303
+179 | DruidCheckOperator()
+    |
+    = help: Install `apache-airflow-provider-apache-druid>=1.0.0` and use `DruidHook` instead.
+
+AIR303.py:179:1: AIR303 `airflow.operators.druid_check_operator.DruidCheckOperator` is moved into `apache-druid` provider in Airflow 3.0;
+    |
+177 | DruidDbApiHook()
+178 | DruidHook()
+179 | DruidCheckOperator()
+    | ^^^^^^^^^^^^^^^^^^ AIR303
+180 | 
+181 | # apache-airflow-providers-apache-hdfs
+    |
+    = help: Install `apache-airflow-provider-apache-druid>=1.0.0` and use `DruidCheckOperator` instead.
+
+AIR303.py:182:1: AIR303 `airflow.hooks.webhdfs_hook.WebHDFSHook` is moved into `apache-hdfs` provider in Airflow 3.0;
+    |
+181 | # apache-airflow-providers-apache-hdfs
+182 | WebHDFSHook()
+    | ^^^^^^^^^^^ AIR303
+183 | WebHdfsSensor()
+    |
+    = help: Install `apache-airflow-provider-apache-hdfs>=1.0.0` and use `airflow.providers.apache.hdfs.hooks.webhdfs.WebHDFSHook` instead.
+
+AIR303.py:183:1: AIR303 `airflow.sensors.web_hdfs_sensor.WebHdfsSensor` is moved into `apache-hdfs` provider in Airflow 3.0;
+    |
+181 | # apache-airflow-providers-apache-hdfs
+182 | WebHDFSHook()
+183 | WebHdfsSensor()
+    | ^^^^^^^^^^^^^ AIR303
+184 | 
+185 | # apache-airflow-providers-apache-hive
+    |
+    = help: Install `apache-airflow-provider-apache-hdfs>=1.0.0` and use `airflow.providers.apache.hdfs.sensors.web_hdfs.WebHdfsSensor` instead.
+
+AIR303.py:186:1: AIR303 `airflow.hooks.hive_hooks.HIVE_QUEUE_PRIORITIES` is moved into `apache-hive` provider in Airflow 3.0;
+    |
+185 | # apache-airflow-providers-apache-hive
+186 | HIVE_QUEUE_PRIORITIES
     | ^^^^^^^^^^^^^^^^^^^^^ AIR303
-147 | 
-148 | # apache-airflow-providers-apache-hive
+187 | closest_ds_partition()
+188 | max_partition()
     |
-    = help: Install `apache-airflow-provider-Kubernetes>=7.4.0` and import from `airflow.providers.cncf.kubernetes.executors.kubernetes_executor_types.POD_EXECUTOR_DONE_KEY` instead.
+    = help: Install `apache-airflow-provider-apache-hive>=1.0.0` and use `airflow.providers.apache.hive.hooks.hive.HIVE_QUEUE_PRIORITIES` instead.
 
-AIR303.py:149:1: AIR303 `airflow.hooks.hive_hooks.HIVE_QUEUE_PRIORITIES` is moved into `Apache Hive` provider in Airflow 3.0;
+AIR303.py:187:1: AIR303 `airflow.macros.hive.closest_ds_partition` is moved into `apache-hive` provider in Airflow 3.0;
     |
-148 | # apache-airflow-providers-apache-hive
-149 | HIVE_QUEUE_PRIORITIES
-    | ^^^^^^^^^^^^^^^^^^^^^ AIR303
-150 | closest_ds_partition()
-151 | max_partition()
-    |
-    = help: Install `apache-airflow-provider-Apache Hive>=1.0.0` and use `HIVE_QUEUE_PRIORITIES` instead.
-
-AIR303.py:150:1: AIR303 Import path `airflow.macros.hive.closest_ds_partition` is moved into `Apache Hive` provider in Airflow 3.0;
-    |
-148 | # apache-airflow-providers-apache-hive
-149 | HIVE_QUEUE_PRIORITIES
-150 | closest_ds_partition()
+185 | # apache-airflow-providers-apache-hive
+186 | HIVE_QUEUE_PRIORITIES
+187 | closest_ds_partition()
     | ^^^^^^^^^^^^^^^^^^^^ AIR303
-151 | max_partition()
+188 | max_partition()
+189 | HiveCliHook()
     |
-    = help: Install `apache-airflow-provider-Apache Hive>=5.1.0` and import from `airflow.providers.apache.hive.macros.hive.closest_ds_partition` instead.
+    = help: Install `apache-airflow-provider-apache-hive>=5.1.0` and use `airflow.providers.apache.hive.macros.hive.closest_ds_partition` instead.
 
-AIR303.py:151:1: AIR303 Import path `airflow.macros.hive.max_partition` is moved into `Apache Hive` provider in Airflow 3.0;
+AIR303.py:188:1: AIR303 `airflow.macros.hive.max_partition` is moved into `apache-hive` provider in Airflow 3.0;
     |
-149 | HIVE_QUEUE_PRIORITIES
-150 | closest_ds_partition()
-151 | max_partition()
+186 | HIVE_QUEUE_PRIORITIES
+187 | closest_ds_partition()
+188 | max_partition()
     | ^^^^^^^^^^^^^ AIR303
-152 | 
-153 | # TODO: reorganize
+189 | HiveCliHook()
+190 | HiveMetastoreHook()
     |
-    = help: Install `apache-airflow-provider-Apache Hive>=5.1.0` and import from `airflow.providers.apache.hive.macros.hive.max_partition` instead.
+    = help: Install `apache-airflow-provider-apache-hive>=5.1.0` and use `airflow.providers.apache.hive.macros.hive.max_partition` instead.
 
-AIR303.py:154:1: AIR303 `airflow.hooks.S3_hook.S3Hook` is moved into `Amazon` provider in Airflow 3.0;
+AIR303.py:189:1: AIR303 `airflow.hooks.hive_hooks.HiveCliHook` is moved into `apache-hive` provider in Airflow 3.0;
     |
-153 | # TODO: reorganize
-154 | S3Hook()
-    | ^^^^^^ AIR303
-155 | provide_bucket_name()
-156 | BaseHook()
-    |
-    = help: Install `apache-airflow-provider-Amazon>=TBD` and use `S3Hook` instead.
-
-AIR303.py:155:1: AIR303 `airflow.hooks.S3_hook.provide_bucket_name` is moved into `Amazon` provider in Airflow 3.0;
-    |
-153 | # TODO: reorganize
-154 | S3Hook()
-155 | provide_bucket_name()
-    | ^^^^^^^^^^^^^^^^^^^ AIR303
-156 | BaseHook()
-157 | DbApiHook2()
-    |
-    = help: Install `apache-airflow-provider-Amazon>=TBD` and use `provide_bucket_name` instead.
-
-AIR303.py:156:1: AIR303 `airflow.hooks.base_hook.BaseHook` is moved into `Base` provider in Airflow 3.0;
-    |
-154 | S3Hook()
-155 | provide_bucket_name()
-156 | BaseHook()
-    | ^^^^^^^^ AIR303
-157 | DbApiHook2()
-158 | DockerHook()
-    |
-    = help: Install `apache-airflow-provider-Base>=TBD` and use `BaseHook` instead.
-
-AIR303.py:157:1: AIR303 `airflow.hooks.dbapi_hook.DbApiHook` is moved into `Common Sql` provider in Airflow 3.0;
-    |
-155 | provide_bucket_name()
-156 | BaseHook()
-157 | DbApiHook2()
-    | ^^^^^^^^^^ AIR303
-158 | DockerHook()
-159 | DruidDbApiHook()
-    |
-    = help: Install `apache-airflow-provider-Common Sql>=TBD` and use `DbApiHook` instead.
-
-AIR303.py:158:1: AIR303 `airflow.hooks.docker_hook.DockerHook` is moved into `Docker` provider in Airflow 3.0;
-    |
-156 | BaseHook()
-157 | DbApiHook2()
-158 | DockerHook()
-    | ^^^^^^^^^^ AIR303
-159 | DruidDbApiHook()
-160 | DruidHook()
-    |
-    = help: Install `apache-airflow-provider-Docker>=TBD` and use `DockerHook` instead.
-
-AIR303.py:159:1: AIR303 `airflow.hooks.druid_hook.DruidDbApiHook` is moved into `Apache Druid` provider in Airflow 3.0;
-    |
-157 | DbApiHook2()
-158 | DockerHook()
-159 | DruidDbApiHook()
-    | ^^^^^^^^^^^^^^ AIR303
-160 | DruidHook()
-161 | HIVE_QUEUE_PRIORITIES()
-    |
-    = help: Install `apache-airflow-provider-Apache Druid>=TBD` and use `DruidDbApiHook` instead.
-
-AIR303.py:160:1: AIR303 `airflow.hooks.druid_hook.DruidHook` is moved into `Apache Druid` provider in Airflow 3.0;
-    |
-158 | DockerHook()
-159 | DruidDbApiHook()
-160 | DruidHook()
-    | ^^^^^^^^^ AIR303
-161 | HIVE_QUEUE_PRIORITIES()
-162 | HiveCliHook()
-    |
-    = help: Install `apache-airflow-provider-Apache Druid>=TBD` and use `DruidHook` instead.
-
-AIR303.py:161:1: AIR303 `airflow.hooks.hive_hooks.HIVE_QUEUE_PRIORITIES` is moved into `Apache Hive` provider in Airflow 3.0;
-    |
-159 | DruidDbApiHook()
-160 | DruidHook()
-161 | HIVE_QUEUE_PRIORITIES()
-    | ^^^^^^^^^^^^^^^^^^^^^ AIR303
-162 | HiveCliHook()
-163 | HiveMetastoreHook()
-    |
-    = help: Install `apache-airflow-provider-Apache Hive>=1.0.0` and use `HIVE_QUEUE_PRIORITIES` instead.
-
-AIR303.py:162:1: AIR303 `airflow.hooks.hive_hooks.HiveCliHook` is moved into `Apache Hive` provider in Airflow 3.0;
-    |
-160 | DruidHook()
-161 | HIVE_QUEUE_PRIORITIES()
-162 | HiveCliHook()
+187 | closest_ds_partition()
+188 | max_partition()
+189 | HiveCliHook()
     | ^^^^^^^^^^^ AIR303
-163 | HiveMetastoreHook()
-164 | HiveServer2Hook()
+190 | HiveMetastoreHook()
+191 | HiveOperator()
     |
-    = help: Install `apache-airflow-provider-Apache Hive>=TBD` and use `HiveCliHook` instead.
+    = help: Install `apache-airflow-provider-apache-hive>=1.0.0` and use `airflow.providers.apache.hive.hooks.hive.HiveCliHook` instead.
 
-AIR303.py:163:1: AIR303 `airflow.hooks.hive_hooks.HiveMetastoreHook` is moved into `Apache Hive` provider in Airflow 3.0;
+AIR303.py:190:1: AIR303 `airflow.hooks.hive_hooks.HiveMetastoreHook` is moved into `apache-hive` provider in Airflow 3.0;
     |
-161 | HIVE_QUEUE_PRIORITIES()
-162 | HiveCliHook()
-163 | HiveMetastoreHook()
+188 | max_partition()
+189 | HiveCliHook()
+190 | HiveMetastoreHook()
     | ^^^^^^^^^^^^^^^^^ AIR303
-164 | HiveServer2Hook()
-165 | HttpHook()
+191 | HiveOperator()
+192 | HivePartitionSensor()
     |
-    = help: Install `apache-airflow-provider-Apache Hive>=TBD` and use `HiveMetastoreHook` instead.
+    = help: Install `apache-airflow-provider-apache-hive>=1.0.0` and use `airflow.providers.apache.hive.hooks.hive.HiveMetastoreHook` instead.
 
-AIR303.py:164:1: AIR303 `airflow.hooks.hive_hooks.HiveServer2Hook` is moved into `Apache Hive` provider in Airflow 3.0;
+AIR303.py:191:1: AIR303 `airflow.operators.hive_operator.HiveOperator` is moved into `apache-hive` provider in Airflow 3.0;
     |
-162 | HiveCliHook()
-163 | HiveMetastoreHook()
-164 | HiveServer2Hook()
-    | ^^^^^^^^^^^^^^^ AIR303
-165 | HttpHook()
-166 | JdbcHook()
-    |
-    = help: Install `apache-airflow-provider-Apache Hive>=TBD` and use `HiveServer2Hook` instead.
-
-AIR303.py:165:1: AIR303 `airflow.hooks.http_hook.HttpHook` is moved into `Http` provider in Airflow 3.0;
-    |
-163 | HiveMetastoreHook()
-164 | HiveServer2Hook()
-165 | HttpHook()
-    | ^^^^^^^^ AIR303
-166 | JdbcHook()
-167 | jaydebeapi()
-    |
-    = help: Install `apache-airflow-provider-Http>=TBD` and use `HttpHook` instead.
-
-AIR303.py:166:1: AIR303 `airflow.hooks.jdbc_hook.JdbcHook` is moved into `Jdbc` provider in Airflow 3.0;
-    |
-164 | HiveServer2Hook()
-165 | HttpHook()
-166 | JdbcHook()
-    | ^^^^^^^^ AIR303
-167 | jaydebeapi()
-168 | MsSqlHook()
-    |
-    = help: Install `apache-airflow-provider-Jdbc>=TBD` and use `JdbcHook` instead.
-
-AIR303.py:167:1: AIR303 `airflow.hooks.jdbc_hook.jaydebeapi` is moved into `Jdbc` provider in Airflow 3.0;
-    |
-165 | HttpHook()
-166 | JdbcHook()
-167 | jaydebeapi()
-    | ^^^^^^^^^^ AIR303
-168 | MsSqlHook()
-169 | MySqlHook()
-    |
-    = help: Install `apache-airflow-provider-Jdbc>=TBD` and use `jaydebeapi` instead.
-
-AIR303.py:168:1: AIR303 `airflow.hooks.mssql_hook.MsSqlHook` is moved into `Microsoft` provider in Airflow 3.0;
-    |
-166 | JdbcHook()
-167 | jaydebeapi()
-168 | MsSqlHook()
-    | ^^^^^^^^^ AIR303
-169 | MySqlHook()
-170 | OracleHook()
-    |
-    = help: Install `apache-airflow-provider-Microsoft>=TBD` and use `MsSqlHook` instead.
-
-AIR303.py:169:1: AIR303 `airflow.hooks.mysql_hook.MySqlHook` is moved into `Mysql` provider in Airflow 3.0;
-    |
-167 | jaydebeapi()
-168 | MsSqlHook()
-169 | MySqlHook()
-    | ^^^^^^^^^ AIR303
-170 | OracleHook()
-171 | PigCliHook()
-    |
-    = help: Install `apache-airflow-provider-Mysql>=TBD` and use `MySqlHook` instead.
-
-AIR303.py:170:1: AIR303 `airflow.hooks.oracle_hook.OracleHook` is moved into `Oracle` provider in Airflow 3.0;
-    |
-168 | MsSqlHook()
-169 | MySqlHook()
-170 | OracleHook()
-    | ^^^^^^^^^^ AIR303
-171 | PigCliHook()
-172 | PostgresHook()
-    |
-    = help: Install `apache-airflow-provider-Oracle>=TBD` and use `OracleHook` instead.
-
-AIR303.py:171:1: AIR303 `airflow.hooks.pig_hook.PigCliHook` is moved into `Apache Pig` provider in Airflow 3.0;
-    |
-169 | MySqlHook()
-170 | OracleHook()
-171 | PigCliHook()
-    | ^^^^^^^^^^ AIR303
-172 | PostgresHook()
-173 | PrestoHook()
-    |
-    = help: Install `apache-airflow-provider-Apache Pig>=TBD` and use `PigCliHook` instead.
-
-AIR303.py:172:1: AIR303 `airflow.hooks.postgres_hook.PostgresHook` is moved into `Postgres` provider in Airflow 3.0;
-    |
-170 | OracleHook()
-171 | PigCliHook()
-172 | PostgresHook()
+189 | HiveCliHook()
+190 | HiveMetastoreHook()
+191 | HiveOperator()
     | ^^^^^^^^^^^^ AIR303
-173 | PrestoHook()
-174 | SambaHook()
+192 | HivePartitionSensor()
+193 | HiveServer2Hook()
     |
-    = help: Install `apache-airflow-provider-Postgres>=TBD` and use `PostgresHook` instead.
+    = help: Install `apache-airflow-provider-apache-hive>=1.0.0` and use `airflow.providers.apache.hive.operators.hive.HiveOperator` instead.
 
-AIR303.py:173:1: AIR303 `airflow.hooks.presto_hook.PrestoHook` is moved into `Presto` provider in Airflow 3.0;
+AIR303.py:192:1: AIR303 `airflow.sensors.hive_partition_sensor.HivePartitionSensor` is moved into `apache-hive` provider in Airflow 3.0;
     |
-171 | PigCliHook()
-172 | PostgresHook()
-173 | PrestoHook()
-    | ^^^^^^^^^^ AIR303
-174 | SambaHook()
-175 | SlackHook()
-    |
-    = help: Install `apache-airflow-provider-Presto>=TBD` and use `PrestoHook` instead.
-
-AIR303.py:174:1: AIR303 `airflow.hooks.samba_hook.SambaHook` is moved into `Samba` provider in Airflow 3.0;
-    |
-172 | PostgresHook()
-173 | PrestoHook()
-174 | SambaHook()
-    | ^^^^^^^^^ AIR303
-175 | SlackHook()
-176 | SqliteHook()
-    |
-    = help: Install `apache-airflow-provider-Samba>=TBD` and use `SambaHook` instead.
-
-AIR303.py:175:1: AIR303 `airflow.hooks.slack_hook.SlackHook` is moved into `Slack` provider in Airflow 3.0;
-    |
-173 | PrestoHook()
-174 | SambaHook()
-175 | SlackHook()
-    | ^^^^^^^^^ AIR303
-176 | SqliteHook()
-177 | WebHDFSHook()
-    |
-    = help: Install `apache-airflow-provider-Slack>=TBD` and use `SlackHook` instead.
-
-AIR303.py:176:1: AIR303 `airflow.hooks.sqlite_hook.SqliteHook` is moved into `Sqlite` provider in Airflow 3.0;
-    |
-174 | SambaHook()
-175 | SlackHook()
-176 | SqliteHook()
-    | ^^^^^^^^^^ AIR303
-177 | WebHDFSHook()
-178 | ZendeskHook()
-    |
-    = help: Install `apache-airflow-provider-Sqlite>=TBD` and use `SqliteHook` instead.
-
-AIR303.py:177:1: AIR303 `airflow.hooks.webhdfs_hook.WebHDFSHook` is moved into `Apache Hdfs` provider in Airflow 3.0;
-    |
-175 | SlackHook()
-176 | SqliteHook()
-177 | WebHDFSHook()
-    | ^^^^^^^^^^^ AIR303
-178 | ZendeskHook()
-    |
-    = help: Install `apache-airflow-provider-Apache Hdfs>=TBD` and use `WebHDFSHook` instead.
-
-AIR303.py:178:1: AIR303 `airflow.hooks.zendesk_hook.ZendeskHook` is moved into `Zendesk` provider in Airflow 3.0;
-    |
-176 | SqliteHook()
-177 | WebHDFSHook()
-178 | ZendeskHook()
-    | ^^^^^^^^^^^ AIR303
-179 | 
-180 | SQLCheckOperator()
-    |
-    = help: Install `apache-airflow-provider-Zendesk>=TBD` and use `ZendeskHook` instead.
-
-AIR303.py:180:1: AIR303 `airflow.operators.check_operator.SQLCheckOperator` is moved into `Common Sql` provider in Airflow 3.0;
-    |
-178 | ZendeskHook()
-179 | 
-180 | SQLCheckOperator()
-    | ^^^^^^^^^^^^^^^^ AIR303
-181 | SQLIntervalCheckOperator()
-182 | SQLThresholdCheckOperator()
-    |
-    = help: Install `apache-airflow-provider-Common Sql>=TBD` and use `SQLCheckOperator` instead.
-
-AIR303.py:181:1: AIR303 `airflow.operators.check_operator.SQLIntervalCheckOperator` is moved into `Common Sql` provider in Airflow 3.0;
-    |
-180 | SQLCheckOperator()
-181 | SQLIntervalCheckOperator()
-    | ^^^^^^^^^^^^^^^^^^^^^^^^ AIR303
-182 | SQLThresholdCheckOperator()
-183 | SQLValueCheckOperator()
-    |
-    = help: Install `apache-airflow-provider-Common Sql>=TBD` and use `SQLIntervalCheckOperator` instead.
-
-AIR303.py:182:1: AIR303 `airflow.operators.check_operator.SQLThresholdCheckOperator` is moved into `Common Sql` provider in Airflow 3.0;
-    |
-180 | SQLCheckOperator()
-181 | SQLIntervalCheckOperator()
-182 | SQLThresholdCheckOperator()
-    | ^^^^^^^^^^^^^^^^^^^^^^^^^ AIR303
-183 | SQLValueCheckOperator()
-184 | CheckOperator()
-    |
-    = help: Install `apache-airflow-provider-Common Sql>=TBD` and use `SQLThresholdCheckOperator` instead.
-
-AIR303.py:183:1: AIR303 `airflow.operators.check_operator.SQLValueCheckOperator` is moved into `Common Sql` provider in Airflow 3.0;
-    |
-181 | SQLIntervalCheckOperator()
-182 | SQLThresholdCheckOperator()
-183 | SQLValueCheckOperator()
-    | ^^^^^^^^^^^^^^^^^^^^^ AIR303
-184 | CheckOperator()
-185 | IntervalCheckOperator()
-    |
-    = help: Install `apache-airflow-provider-Common Sql>=TBD` and use `SQLValueCheckOperator` instead.
-
-AIR303.py:184:1: AIR303 `airflow.operators.check_operator.CheckOperator` is moved into `Common Sql` provider in Airflow 3.0;
-    |
-182 | SQLThresholdCheckOperator()
-183 | SQLValueCheckOperator()
-184 | CheckOperator()
-    | ^^^^^^^^^^^^^ AIR303
-185 | IntervalCheckOperator()
-186 | ThresholdCheckOperator()
-    |
-    = help: Install `apache-airflow-provider-Common Sql>=TBD` and use `CheckOperator` instead.
-
-AIR303.py:185:1: AIR303 `airflow.operators.check_operator.IntervalCheckOperator` is moved into `Common Sql` provider in Airflow 3.0;
-    |
-183 | SQLValueCheckOperator()
-184 | CheckOperator()
-185 | IntervalCheckOperator()
-    | ^^^^^^^^^^^^^^^^^^^^^ AIR303
-186 | ThresholdCheckOperator()
-187 | ValueCheckOperator()
-    |
-    = help: Install `apache-airflow-provider-Common Sql>=TBD` and use `IntervalCheckOperator` instead.
-
-AIR303.py:186:1: AIR303 `airflow.operators.check_operator.ThresholdCheckOperator` is moved into `Common Sql` provider in Airflow 3.0;
-    |
-184 | CheckOperator()
-185 | IntervalCheckOperator()
-186 | ThresholdCheckOperator()
-    | ^^^^^^^^^^^^^^^^^^^^^^ AIR303
-187 | ValueCheckOperator()
-188 | DockerOperator()
-    |
-    = help: Install `apache-airflow-provider-Common Sql>=TBD` and use `ThresholdCheckOperator` instead.
-
-AIR303.py:187:1: AIR303 `airflow.operators.check_operator.ValueCheckOperator` is moved into `Common Sql` provider in Airflow 3.0;
-    |
-185 | IntervalCheckOperator()
-186 | ThresholdCheckOperator()
-187 | ValueCheckOperator()
-    | ^^^^^^^^^^^^^^^^^^ AIR303
-188 | DockerOperator()
-189 | DruidCheckOperator()
-    |
-    = help: Install `apache-airflow-provider-Common Sql>=TBD` and use `ValueCheckOperator` instead.
-
-AIR303.py:188:1: AIR303 `airflow.operators.docker_operator.DockerOperator` is moved into `Docker` provider in Airflow 3.0;
-    |
-186 | ThresholdCheckOperator()
-187 | ValueCheckOperator()
-188 | DockerOperator()
-    | ^^^^^^^^^^^^^^ AIR303
-189 | DruidCheckOperator()
-190 | GCSToS3Operator()
-    |
-    = help: Install `apache-airflow-provider-Docker>=TBD` and use `DockerOperator` instead.
-
-AIR303.py:189:1: AIR303 `airflow.operators.druid_check_operator.DruidCheckOperator` is moved into `Apache Druid` provider in Airflow 3.0;
-    |
-187 | ValueCheckOperator()
-188 | DockerOperator()
-189 | DruidCheckOperator()
-    | ^^^^^^^^^^^^^^^^^^ AIR303
-190 | GCSToS3Operator()
-191 | GoogleApiToS3Operator()
-    |
-    = help: Install `apache-airflow-provider-Apache Druid>=TBD` and use `DruidCheckOperator` instead.
-
-AIR303.py:190:1: AIR303 `airflow.operators.gcs_to_s3.GCSToS3Operator` is moved into `Amazon` provider in Airflow 3.0;
-    |
-188 | DockerOperator()
-189 | DruidCheckOperator()
-190 | GCSToS3Operator()
-    | ^^^^^^^^^^^^^^^ AIR303
-191 | GoogleApiToS3Operator()
-192 | GoogleApiToS3Transfer()
-    |
-    = help: Install `apache-airflow-provider-Amazon>=TBD` and use `GCSToS3Operator` instead.
-
-AIR303.py:191:1: AIR303 `airflow.operators.google_api_to_s3_transfer.GoogleApiToS3Operator` is moved into `Amazon` provider in Airflow 3.0;
-    |
-189 | DruidCheckOperator()
-190 | GCSToS3Operator()
-191 | GoogleApiToS3Operator()
-    | ^^^^^^^^^^^^^^^^^^^^^ AIR303
-192 | GoogleApiToS3Transfer()
-193 | HiveOperator()
-    |
-    = help: Install `apache-airflow-provider-Amazon>=TBD` and use `GoogleApiToS3Operator` instead.
-
-AIR303.py:192:1: AIR303 `airflow.operators.google_api_to_s3_transfer.GoogleApiToS3Transfer` is moved into `Amazon` provider in Airflow 3.0;
-    |
-190 | GCSToS3Operator()
-191 | GoogleApiToS3Operator()
-192 | GoogleApiToS3Transfer()
-    | ^^^^^^^^^^^^^^^^^^^^^ AIR303
-193 | HiveOperator()
+190 | HiveMetastoreHook()
+191 | HiveOperator()
+192 | HivePartitionSensor()
+    | ^^^^^^^^^^^^^^^^^^^ AIR303
+193 | HiveServer2Hook()
 194 | HiveStatsCollectionOperator()
     |
-    = help: Install `apache-airflow-provider-Amazon>=TBD` and use `GoogleApiToS3Transfer` instead.
+    = help: Install `apache-airflow-provider-apache-hive>=1.0.0` and use `airflow.providers.apache.hive.sensors.hive_partition.HivePartitionSensor` instead.
 
-AIR303.py:193:1: AIR303 `airflow.operators.hive_operator.HiveOperator` is moved into `Apache Hive` provider in Airflow 3.0;
+AIR303.py:193:1: AIR303 `airflow.hooks.hive_hooks.HiveServer2Hook` is moved into `apache-hive` provider in Airflow 3.0;
     |
-191 | GoogleApiToS3Operator()
-192 | GoogleApiToS3Transfer()
-193 | HiveOperator()
-    | ^^^^^^^^^^^^ AIR303
+191 | HiveOperator()
+192 | HivePartitionSensor()
+193 | HiveServer2Hook()
+    | ^^^^^^^^^^^^^^^ AIR303
 194 | HiveStatsCollectionOperator()
 195 | HiveToDruidOperator()
     |
-    = help: Install `apache-airflow-provider-Apache Hive>=TBD` and use `HiveOperator` instead.
+    = help: Install `apache-airflow-provider-apache-hive>=1.0.0` and use `airflow.providers.apache.hive.hooks.hive.HiveServer2Hook` instead.
 
-AIR303.py:194:1: AIR303 `airflow.operators.hive_stats_operator.HiveStatsCollectionOperator` is moved into `Apache Hive` provider in Airflow 3.0;
+AIR303.py:194:1: AIR303 `airflow.operators.hive_stats_operator.HiveStatsCollectionOperator` is moved into `apache-hive` provider in Airflow 3.0;
     |
-192 | GoogleApiToS3Transfer()
-193 | HiveOperator()
+192 | HivePartitionSensor()
+193 | HiveServer2Hook()
 194 | HiveStatsCollectionOperator()
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR303
 195 | HiveToDruidOperator()
 196 | HiveToDruidTransfer()
     |
-    = help: Install `apache-airflow-provider-Apache Hive>=TBD` and use `HiveStatsCollectionOperator` instead.
+    = help: Install `apache-airflow-provider-apache-hive>=1.0.0` and use `airflow.providers.apache.hive.operators.hive_stats.HiveStatsCollectionOperator` instead.
 
-AIR303.py:195:1: AIR303 `airflow.operators.hive_to_druid.HiveToDruidOperator` is moved into `Apache Druid` provider in Airflow 3.0;
+AIR303.py:195:1: AIR303 `airflow.operators.hive_to_druid.HiveToDruidOperator` is moved into `apache-druid` provider in Airflow 3.0;
     |
-193 | HiveOperator()
+193 | HiveServer2Hook()
 194 | HiveStatsCollectionOperator()
 195 | HiveToDruidOperator()
     | ^^^^^^^^^^^^^^^^^^^ AIR303
 196 | HiveToDruidTransfer()
-197 | HiveToMySqlOperator()
+197 | HiveToSambaOperator()
     |
-    = help: Install `apache-airflow-provider-Apache Druid>=TBD` and use `HiveToDruidOperator` instead.
+    = help: Install `apache-airflow-provider-apache-druid>=1.0.0` and use `airflow.providers.apache.druid.transfers.hive_to_druid.HiveToDruidOperator` instead.
 
-AIR303.py:196:1: AIR303 `airflow.operators.hive_to_druid.HiveToDruidTransfer` is moved into `Apache Druid` provider in Airflow 3.0;
+AIR303.py:196:1: AIR303 `airflow.operators.hive_to_druid.HiveToDruidTransfer` is moved into `apache-druid` provider in Airflow 3.0;
     |
 194 | HiveStatsCollectionOperator()
 195 | HiveToDruidOperator()
 196 | HiveToDruidTransfer()
     | ^^^^^^^^^^^^^^^^^^^ AIR303
-197 | HiveToMySqlOperator()
-198 | HiveToMySqlTransfer()
+197 | HiveToSambaOperator()
+198 | S3ToHiveOperator()
     |
-    = help: Install `apache-airflow-provider-Apache Druid>=TBD` and use `HiveToDruidTransfer` instead.
+    = help: Install `apache-airflow-provider-apache-druid>=1.0.0` and use `airflow.providers.apache.druid.transfers.hive_to_druid.HiveToDruidOperator` instead.
 
-AIR303.py:197:1: AIR303 `airflow.operators.hive_to_mysql.HiveToMySqlOperator` is moved into `Apache Hive` provider in Airflow 3.0;
+AIR303.py:197:1: AIR303 `airflow.operators.hive_to_samba_operator.HiveToSambaOperator` is moved into `apache-hive` provider in Airflow 3.0;
     |
 195 | HiveToDruidOperator()
 196 | HiveToDruidTransfer()
-197 | HiveToMySqlOperator()
+197 | HiveToSambaOperator()
     | ^^^^^^^^^^^^^^^^^^^ AIR303
-198 | HiveToMySqlTransfer()
-199 | HiveToSambaOperator()
+198 | S3ToHiveOperator()
+199 | S3ToHiveTransfer()
     |
-    = help: Install `apache-airflow-provider-Apache Hive>=TBD` and use `HiveToMySqlOperator` instead.
+    = help: Install `apache-airflow-provider-apache-hive>=1.0.0` and use `HiveToSambaOperator` instead.
 
-AIR303.py:198:1: AIR303 `airflow.operators.hive_to_mysql.HiveToMySqlTransfer` is moved into `Apache Hive` provider in Airflow 3.0;
+AIR303.py:198:1: AIR303 `airflow.operators.s3_to_hive_operator.S3ToHiveOperator` is moved into `apache-hive` provider in Airflow 3.0;
     |
 196 | HiveToDruidTransfer()
-197 | HiveToMySqlOperator()
-198 | HiveToMySqlTransfer()
-    | ^^^^^^^^^^^^^^^^^^^ AIR303
-199 | HiveToSambaOperator()
-200 | SimpleHttpOperator()
+197 | HiveToSambaOperator()
+198 | S3ToHiveOperator()
+    | ^^^^^^^^^^^^^^^^ AIR303
+199 | S3ToHiveTransfer()
+200 | MetastorePartitionSensor()
     |
-    = help: Install `apache-airflow-provider-Apache Hive>=TBD` and use `HiveToMySqlTransfer` instead.
+    = help: Install `apache-airflow-provider-apache-hive>=1.0.0` and use `airflow.providers.apache.hive.transfers.s3_to_hive.S3ToHiveOperator` instead.
 
-AIR303.py:199:1: AIR303 `airflow.operators.hive_to_samba_operator.HiveToSambaOperator` is moved into `Apache Hive` provider in Airflow 3.0;
+AIR303.py:199:1: AIR303 `airflow.operators.s3_to_hive_operator.S3ToHiveTransfer` is moved into `apache-hive` provider in Airflow 3.0;
     |
-197 | HiveToMySqlOperator()
-198 | HiveToMySqlTransfer()
-199 | HiveToSambaOperator()
-    | ^^^^^^^^^^^^^^^^^^^ AIR303
-200 | SimpleHttpOperator()
-201 | JdbcOperator()
+197 | HiveToSambaOperator()
+198 | S3ToHiveOperator()
+199 | S3ToHiveTransfer()
+    | ^^^^^^^^^^^^^^^^ AIR303
+200 | MetastorePartitionSensor()
+201 | NamedHivePartitionSensor()
     |
-    = help: Install `apache-airflow-provider-Apache Hive>=TBD` and use `HiveToSambaOperator` instead.
+    = help: Install `apache-airflow-provider-apache-hive>=1.0.0` and use `airflow.providers.apache.hive.transfers.s3_to_hive.S3ToHiveOperator` instead.
 
-AIR303.py:200:1: AIR303 `airflow.operators.http_operator.SimpleHttpOperator` is moved into `Http` provider in Airflow 3.0;
+AIR303.py:200:1: AIR303 `airflow.sensors.metastore_partition_sensor.MetastorePartitionSensor` is moved into `apache-hive` provider in Airflow 3.0;
     |
-198 | HiveToMySqlTransfer()
-199 | HiveToSambaOperator()
-200 | SimpleHttpOperator()
+198 | S3ToHiveOperator()
+199 | S3ToHiveTransfer()
+200 | MetastorePartitionSensor()
+    | ^^^^^^^^^^^^^^^^^^^^^^^^ AIR303
+201 | NamedHivePartitionSensor()
+    |
+    = help: Install `apache-airflow-provider-apache-hive>=1.0.0` and use `airflow.providers.apache.hive.sensors.metastore_partition.MetastorePartitionSensor` instead.
+
+AIR303.py:201:1: AIR303 `airflow.sensors.named_hive_partition_sensor.NamedHivePartitionSensor` is moved into `apache-hive` provider in Airflow 3.0;
+    |
+199 | S3ToHiveTransfer()
+200 | MetastorePartitionSensor()
+201 | NamedHivePartitionSensor()
+    | ^^^^^^^^^^^^^^^^^^^^^^^^ AIR303
+202 | 
+203 | # apache-airflow-providers-http
+    |
+    = help: Install `apache-airflow-provider-apache-hive>=1.0.0` and use `airflow.providers.apache.hive.sensors.named_hive_partition.NamedHivePartitionSensor` instead.
+
+AIR303.py:204:1: AIR303 `airflow.hooks.http_hook.HttpHook` is moved into `http` provider in Airflow 3.0;
+    |
+203 | # apache-airflow-providers-http
+204 | HttpHook()
+    | ^^^^^^^^ AIR303
+205 | HttpSensor()
+206 | SimpleHttpOperator()
+    |
+    = help: Install `apache-airflow-provider-http>=1.0.0` and use `airflow.providers.http.hooks.http.HttpHook` instead.
+
+AIR303.py:205:1: AIR303 `airflow.sensors.http_sensor.HttpSensor` is moved into `http` provider in Airflow 3.0;
+    |
+203 | # apache-airflow-providers-http
+204 | HttpHook()
+205 | HttpSensor()
+    | ^^^^^^^^^^ AIR303
+206 | SimpleHttpOperator()
+    |
+    = help: Install `apache-airflow-provider-http>=1.0.0` and use `airflow.providers.http.sensors.http.HttpSensor` instead.
+
+AIR303.py:206:1: AIR303 `airflow.operators.http_operator.SimpleHttpOperator` is moved into `http` provider in Airflow 3.0;
+    |
+204 | HttpHook()
+205 | HttpSensor()
+206 | SimpleHttpOperator()
     | ^^^^^^^^^^^^^^^^^^ AIR303
-201 | JdbcOperator()
-202 | LatestOnlyOperator()
+207 | 
+208 | # apache-airflow-providers-jdbc
     |
-    = help: Install `apache-airflow-provider-Http>=TBD` and use `SimpleHttpOperator` instead.
+    = help: Install `apache-airflow-provider-http>=1.0.0` and use `airflow.providers.http.operators.http.SimpleHttpOperator` instead.
 
-AIR303.py:201:1: AIR303 `airflow.operators.jdbc_operator.JdbcOperator` is moved into `Jdbc` provider in Airflow 3.0;
+AIR303.py:209:1: AIR303 `airflow.hooks.jdbc_hook.jaydebeapi` is moved into `jdbc` provider in Airflow 3.0;
     |
-199 | HiveToSambaOperator()
-200 | SimpleHttpOperator()
-201 | JdbcOperator()
+208 | # apache-airflow-providers-jdbc
+209 | jaydebeapi
+    | ^^^^^^^^^^ AIR303
+210 | JdbcHook()
+211 | JdbcOperator()
+    |
+    = help: Install `apache-airflow-provider-jdbc>=1.0.0` and use `airflow.providers.jdbc.hooks.jdbc.jaydebeapi` instead.
+
+AIR303.py:210:1: AIR303 `airflow.hooks.jdbc_hook.JdbcHook` is moved into `jdbc` provider in Airflow 3.0;
+    |
+208 | # apache-airflow-providers-jdbc
+209 | jaydebeapi
+210 | JdbcHook()
+    | ^^^^^^^^ AIR303
+211 | JdbcOperator()
+    |
+    = help: Install `apache-airflow-provider-jdbc>=1.0.0` and use `airflow.providers.jdbc.hooks.jdbc.JdbcHook` instead.
+
+AIR303.py:211:1: AIR303 `airflow.operators.jdbc_operator.JdbcOperator` is moved into `jdbc` provider in Airflow 3.0;
+    |
+209 | jaydebeapi
+210 | JdbcHook()
+211 | JdbcOperator()
     | ^^^^^^^^^^^^ AIR303
-202 | LatestOnlyOperator()
-203 | MsSqlOperator()
+212 | 
+213 | # apache-airflow-providers-fab
     |
-    = help: Install `apache-airflow-provider-Jdbc>=TBD` and use `JdbcOperator` instead.
+    = help: Install `apache-airflow-provider-jdbc>=1.0.0` and use `airflow.providers.jdbc.operators.jdbc.JdbcOperator` instead.
 
-AIR303.py:202:1: AIR303 `airflow.operators.latest_only_operator.LatestOnlyOperator` is moved into `Latest_only` provider in Airflow 3.0;
+AIR303.py:214:1: AIR303 Import path `airflow.api.auth.backend.basic_auth` is moved into `fab` provider in Airflow 3.0;
     |
-200 | SimpleHttpOperator()
-201 | JdbcOperator()
-202 | LatestOnlyOperator()
-    | ^^^^^^^^^^^^^^^^^^ AIR303
-203 | MsSqlOperator()
-204 | MsSqlToHiveOperator()
+213 | # apache-airflow-providers-fab
+214 | basic_auth, kerberos_auth
+    | ^^^^^^^^^^ AIR303
+215 | auth_current_user
+216 | backend_kerberos_auth
     |
-    = help: Install `apache-airflow-provider-Latest_only>=TBD` and use `LatestOnlyOperator` instead.
+    = help: Install `apache-airflow-provider-fab>=1.0.0` and import from `airflow.providers.fab.auth_manager.api.auth.backend.basic_auth` instead.
 
-AIR303.py:203:1: AIR303 `airflow.operators.mssql_operator.MsSqlOperator` is moved into `Microsoft` provider in Airflow 3.0;
+AIR303.py:214:13: AIR303 Import path `airflow.api.auth.backend.kerberos_auth` is moved into `fab` provider in Airflow 3.0;
     |
-201 | JdbcOperator()
-202 | LatestOnlyOperator()
-203 | MsSqlOperator()
-    | ^^^^^^^^^^^^^ AIR303
-204 | MsSqlToHiveOperator()
-205 | MsSqlToHiveTransfer()
+213 | # apache-airflow-providers-fab
+214 | basic_auth, kerberos_auth
+    |             ^^^^^^^^^^^^^ AIR303
+215 | auth_current_user
+216 | backend_kerberos_auth
     |
-    = help: Install `apache-airflow-provider-Microsoft>=TBD` and use `MsSqlOperator` instead.
+    = help: Install `apache-airflow-provider-fab>=1.0.0` and import from `airflow.providers.fab.auth_manager.api.auth.backend.kerberos_auth` instead.
 
-AIR303.py:204:1: AIR303 `airflow.operators.mssql_to_hive.MsSqlToHiveOperator` is moved into `Apache Hive` provider in Airflow 3.0;
+AIR303.py:215:1: AIR303 Import path `airflow.api.auth.backend.basic_auth` is moved into `fab` provider in Airflow 3.0;
     |
-202 | LatestOnlyOperator()
-203 | MsSqlOperator()
-204 | MsSqlToHiveOperator()
-    | ^^^^^^^^^^^^^^^^^^^ AIR303
-205 | MsSqlToHiveTransfer()
-206 | MySqlOperator()
-    |
-    = help: Install `apache-airflow-provider-Apache Hive>=TBD` and use `MsSqlToHiveOperator` instead.
-
-AIR303.py:205:1: AIR303 `airflow.operators.mssql_to_hive.MsSqlToHiveTransfer` is moved into `Apache Hive` provider in Airflow 3.0;
-    |
-203 | MsSqlOperator()
-204 | MsSqlToHiveOperator()
-205 | MsSqlToHiveTransfer()
-    | ^^^^^^^^^^^^^^^^^^^ AIR303
-206 | MySqlOperator()
-207 | MySqlToHiveOperator()
-    |
-    = help: Install `apache-airflow-provider-Apache Hive>=TBD` and use `MsSqlToHiveTransfer` instead.
-
-AIR303.py:206:1: AIR303 `airflow.operators.mysql_operator.MySqlOperator` is moved into `Mysql` provider in Airflow 3.0;
-    |
-204 | MsSqlToHiveOperator()
-205 | MsSqlToHiveTransfer()
-206 | MySqlOperator()
-    | ^^^^^^^^^^^^^ AIR303
-207 | MySqlToHiveOperator()
-208 | MySqlToHiveTransfer()
-    |
-    = help: Install `apache-airflow-provider-Mysql>=TBD` and use `MySqlOperator` instead.
-
-AIR303.py:207:1: AIR303 `airflow.operators.mysql_to_hive.MySqlToHiveOperator` is moved into `Apache Hive` provider in Airflow 3.0;
-    |
-205 | MsSqlToHiveTransfer()
-206 | MySqlOperator()
-207 | MySqlToHiveOperator()
-    | ^^^^^^^^^^^^^^^^^^^ AIR303
-208 | MySqlToHiveTransfer()
-209 | OracleOperator()
-    |
-    = help: Install `apache-airflow-provider-Apache Hive>=TBD` and use `MySqlToHiveOperator` instead.
-
-AIR303.py:208:1: AIR303 `airflow.operators.mysql_to_hive.MySqlToHiveTransfer` is moved into `Apache Hive` provider in Airflow 3.0;
-    |
-206 | MySqlOperator()
-207 | MySqlToHiveOperator()
-208 | MySqlToHiveTransfer()
-    | ^^^^^^^^^^^^^^^^^^^ AIR303
-209 | OracleOperator()
-210 | PapermillOperator()
-    |
-    = help: Install `apache-airflow-provider-Apache Hive>=TBD` and use `MySqlToHiveTransfer` instead.
-
-AIR303.py:209:1: AIR303 `airflow.operators.oracle_operator.OracleOperator` is moved into `Oracle` provider in Airflow 3.0;
-    |
-207 | MySqlToHiveOperator()
-208 | MySqlToHiveTransfer()
-209 | OracleOperator()
-    | ^^^^^^^^^^^^^^ AIR303
-210 | PapermillOperator()
-211 | PigOperator()
-    |
-    = help: Install `apache-airflow-provider-Oracle>=TBD` and use `OracleOperator` instead.
-
-AIR303.py:210:1: AIR303 `airflow.operators.papermill_operator.PapermillOperator` is moved into `Papermill` provider in Airflow 3.0;
-    |
-208 | MySqlToHiveTransfer()
-209 | OracleOperator()
-210 | PapermillOperator()
+213 | # apache-airflow-providers-fab
+214 | basic_auth, kerberos_auth
+215 | auth_current_user
     | ^^^^^^^^^^^^^^^^^ AIR303
-211 | PigOperator()
-212 | Mapping()
+216 | backend_kerberos_auth
+217 | fab_override
     |
-    = help: Install `apache-airflow-provider-Papermill>=TBD` and use `PapermillOperator` instead.
+    = help: Install `apache-airflow-provider-fab>=1.0.0` and import from `airflow.providers.fab.auth_manager.api.auth.backend.basic_auth` instead.
 
-AIR303.py:211:1: AIR303 `airflow.operators.pig_operator.PigOperator` is moved into `Apache Pig` provider in Airflow 3.0;
+AIR303.py:216:1: AIR303 Import path `airflow.auth_manager.api.auth.backend.kerberos_auth` is moved into `fab` provider in Airflow 3.0;
     |
-209 | OracleOperator()
-210 | PapermillOperator()
-211 | PigOperator()
+214 | basic_auth, kerberos_auth
+215 | auth_current_user
+216 | backend_kerberos_auth
+    | ^^^^^^^^^^^^^^^^^^^^^ AIR303
+217 | fab_override
+218 | FabAuthManager()
+    |
+    = help: Install `apache-airflow-provider-fab>=1.0.0` and import from `airflow.providers.fab.auth_manager.api.auth.backend.kerberos_auth` instead.
+
+AIR303.py:217:1: AIR303 Import path `airflow.auth.managers.fab.security_managr.override` is moved into `fab` provider in Airflow 3.0;
+    |
+215 | auth_current_user
+216 | backend_kerberos_auth
+217 | fab_override
+    | ^^^^^^^^^^^^ AIR303
+218 | FabAuthManager()
+219 | FabAirflowSecurityManagerOverride()
+    |
+    = help: Install `apache-airflow-provider-fab>=1.0.0` and import from `airflow.providers.fab.auth_manager.security_manager.override` instead.
+
+AIR303.py:218:1: AIR303 `airflow.auth.managers.fab.fab_auth_manager.FabAuthManager` is moved into `fab` provider in Airflow 3.0;
+    |
+216 | backend_kerberos_auth
+217 | fab_override
+218 | FabAuthManager()
+    | ^^^^^^^^^^^^^^ AIR303
+219 | FabAirflowSecurityManagerOverride()
+    |
+    = help: Install `apache-airflow-provider-fab>=1.0.0` and use `airflow.providers.fab.auth_manager.security_manager.FabAuthManager` instead.
+
+AIR303.py:219:1: AIR303 `airflow.www.security.FabAirflowSecurityManagerOverride` is moved into `fab` provider in Airflow 3.0;
+    |
+217 | fab_override
+218 | FabAuthManager()
+219 | FabAirflowSecurityManagerOverride()
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR303
+220 | 
+221 | # apache-airflow-providers-cncf-kubernetes
+    |
+    = help: Install `apache-airflow-provider-fab>=1.0.0` and use `airflow.providers.fab.auth_manager.security_manager.override.FabAirflowSecurityManagerOverride` instead.
+
+AIR303.py:222:1: AIR303 Import path `airflow.executors.kubernetes_executor_types.ALL_NAMESPACES` is moved into `kubernetes` provider in Airflow 3.0;
+    |
+221 | # apache-airflow-providers-cncf-kubernetes
+222 | ALL_NAMESPACES
+    | ^^^^^^^^^^^^^^ AIR303
+223 | POD_EXECUTOR_DONE_KEY
+    |
+    = help: Install `apache-airflow-provider-kubernetes>=7.4.0` and import from `airflow.providers.cncf.kubernetes.executors.kubernetes_executor_types.ALL_NAMESPACES` instead.
+
+AIR303.py:223:1: AIR303 Import path `airflow.executors.kubernetes_executor_types.POD_EXECUTOR_DONE_KEY` is moved into `kubernetes` provider in Airflow 3.0;
+    |
+221 | # apache-airflow-providers-cncf-kubernetes
+222 | ALL_NAMESPACES
+223 | POD_EXECUTOR_DONE_KEY
+    | ^^^^^^^^^^^^^^^^^^^^^ AIR303
+224 | 
+225 | # apache-airflow-providers-microsoft-mssql
+    |
+    = help: Install `apache-airflow-provider-kubernetes>=7.4.0` and import from `airflow.providers.cncf.kubernetes.executors.kubernetes_executor_types.POD_EXECUTOR_DONE_KEY` instead.
+
+AIR303.py:226:1: AIR303 `airflow.hooks.mssql_hook.MsSqlHook` is moved into `microsoft-mssql` provider in Airflow 3.0;
+    |
+225 | # apache-airflow-providers-microsoft-mssql
+226 | MsSqlHook()
+    | ^^^^^^^^^ AIR303
+227 | MsSqlOperator()
+228 | MsSqlToHiveOperator()
+    |
+    = help: Install `apache-airflow-provider-microsoft-mssql>=1.0.0` and use `airflow.providers.microsoft.mssql.hooks.mssql.MsSqlHook` instead.
+
+AIR303.py:227:1: AIR303 `airflow.operators.mssql_operator.MsSqlOperator` is moved into `microsoft-mssql` provider in Airflow 3.0;
+    |
+225 | # apache-airflow-providers-microsoft-mssql
+226 | MsSqlHook()
+227 | MsSqlOperator()
+    | ^^^^^^^^^^^^^ AIR303
+228 | MsSqlToHiveOperator()
+229 | MsSqlToHiveTransfer()
+    |
+    = help: Install `apache-airflow-provider-microsoft-mssql>=1.0.0` and use `airflow.providers.microsoft.mssql.operators.mssql.MsSqlOperator` instead.
+
+AIR303.py:228:1: AIR303 `airflow.operators.mssql_to_hive.MsSqlToHiveOperator` is moved into `apache-hive` provider in Airflow 3.0;
+    |
+226 | MsSqlHook()
+227 | MsSqlOperator()
+228 | MsSqlToHiveOperator()
+    | ^^^^^^^^^^^^^^^^^^^ AIR303
+229 | MsSqlToHiveTransfer()
+    |
+    = help: Install `apache-airflow-provider-apache-hive>=1.0.0` and use `airflow.providers.apache.hive.transfers.mssql_to_hive.MsSqlToHiveOperator` instead.
+
+AIR303.py:229:1: AIR303 `airflow.operators.mssql_to_hive.MsSqlToHiveTransfer` is moved into `apache-hive` provider in Airflow 3.0;
+    |
+227 | MsSqlOperator()
+228 | MsSqlToHiveOperator()
+229 | MsSqlToHiveTransfer()
+    | ^^^^^^^^^^^^^^^^^^^ AIR303
+230 | 
+231 | # apache-airflow-providers-mysql
+    |
+    = help: Install `apache-airflow-provider-apache-hive>=1.0.0` and use `airflow.providers.apache.hive.transfers.mssql_to_hive.MsSqlToHiveOperator` instead.
+
+AIR303.py:232:1: AIR303 `airflow.operators.hive_to_mysql.HiveToMySqlOperator` is moved into `apache-hive` provider in Airflow 3.0;
+    |
+231 | # apache-airflow-providers-mysql
+232 | HiveToMySqlOperator()
+    | ^^^^^^^^^^^^^^^^^^^ AIR303
+233 | HiveToMySqlTransfer()
+234 | MySqlHook()
+    |
+    = help: Install `apache-airflow-provider-apache-hive>=1.0.0` and use `airflow.providers.apache.hive.transfers.hive_to_mysql.HiveToMySqlOperator` instead.
+
+AIR303.py:233:1: AIR303 `airflow.operators.hive_to_mysql.HiveToMySqlTransfer` is moved into `apache-hive` provider in Airflow 3.0;
+    |
+231 | # apache-airflow-providers-mysql
+232 | HiveToMySqlOperator()
+233 | HiveToMySqlTransfer()
+    | ^^^^^^^^^^^^^^^^^^^ AIR303
+234 | MySqlHook()
+235 | MySqlOperator()
+    |
+    = help: Install `apache-airflow-provider-apache-hive>=1.0.0` and use `airflow.providers.apache.hive.transfers.hive_to_mysql.HiveToMySqlOperator` instead.
+
+AIR303.py:234:1: AIR303 `airflow.hooks.mysql_hook.MySqlHook` is moved into `mysql` provider in Airflow 3.0;
+    |
+232 | HiveToMySqlOperator()
+233 | HiveToMySqlTransfer()
+234 | MySqlHook()
+    | ^^^^^^^^^ AIR303
+235 | MySqlOperator()
+236 | MySqlToHiveOperator()
+    |
+    = help: Install `apache-airflow-provider-mysql>=1.0.0` and use `airflow.providers.mysql.hooks.mysql.MySqlHook` instead.
+
+AIR303.py:235:1: AIR303 `airflow.operators.mysql_operator.MySqlOperator` is moved into `mysql` provider in Airflow 3.0;
+    |
+233 | HiveToMySqlTransfer()
+234 | MySqlHook()
+235 | MySqlOperator()
+    | ^^^^^^^^^^^^^ AIR303
+236 | MySqlToHiveOperator()
+237 | MySqlToHiveTransfer()
+    |
+    = help: Install `apache-airflow-provider-mysql>=1.0.0` and use `airflow.providers.mysql.operators.mysql.MySqlOperator` instead.
+
+AIR303.py:236:1: AIR303 `airflow.operators.mysql_to_hive.MySqlToHiveOperator` is moved into `apache-hive` provider in Airflow 3.0;
+    |
+234 | MySqlHook()
+235 | MySqlOperator()
+236 | MySqlToHiveOperator()
+    | ^^^^^^^^^^^^^^^^^^^ AIR303
+237 | MySqlToHiveTransfer()
+238 | PrestoToMySqlOperator()
+    |
+    = help: Install `apache-airflow-provider-apache-hive>=1.0.0` and use `airflow.providers.apache.hive.transfers.mysql_to_hive.MySqlToHiveOperator` instead.
+
+AIR303.py:237:1: AIR303 `airflow.operators.mysql_to_hive.MySqlToHiveTransfer` is moved into `apache-hive` provider in Airflow 3.0;
+    |
+235 | MySqlOperator()
+236 | MySqlToHiveOperator()
+237 | MySqlToHiveTransfer()
+    | ^^^^^^^^^^^^^^^^^^^ AIR303
+238 | PrestoToMySqlOperator()
+239 | PrestoToMySqlTransfer()
+    |
+    = help: Install `apache-airflow-provider-apache-hive>=1.0.0` and use `airflow.providers.apache.hive.transfers.mysql_to_hive.MySqlToHiveOperator` instead.
+
+AIR303.py:238:1: AIR303 `airflow.operators.presto_to_mysql.PrestoToMySqlOperator` is moved into `mysql` provider in Airflow 3.0;
+    |
+236 | MySqlToHiveOperator()
+237 | MySqlToHiveTransfer()
+238 | PrestoToMySqlOperator()
+    | ^^^^^^^^^^^^^^^^^^^^^ AIR303
+239 | PrestoToMySqlTransfer()
+    |
+    = help: Install `apache-airflow-provider-mysql>=1.0.0` and use `airflow.providers.mysql.transfers.presto_to_mysql.PrestoToMySqlOperator` instead.
+
+AIR303.py:239:1: AIR303 `airflow.operators.presto_to_mysql.PrestoToMySqlTransfer` is moved into `mysql` provider in Airflow 3.0;
+    |
+237 | MySqlToHiveTransfer()
+238 | PrestoToMySqlOperator()
+239 | PrestoToMySqlTransfer()
+    | ^^^^^^^^^^^^^^^^^^^^^ AIR303
+240 | 
+241 | # apache-airflow-providers-oracle
+    |
+    = help: Install `apache-airflow-provider-mysql>=1.0.0` and use `airflow.providers.mysql.transfers.presto_to_mysql.PrestoToMySqlOperator` instead.
+
+AIR303.py:242:1: AIR303 `airflow.hooks.oracle_hook.OracleHook` is moved into `oracle` provider in Airflow 3.0;
+    |
+241 | # apache-airflow-providers-oracle
+242 | OracleHook()
+    | ^^^^^^^^^^ AIR303
+243 | OracleOperator()
+    |
+    = help: Install `apache-airflow-provider-oracle>=1.0.0` and use `airflow.providers.oracle.hooks.oracle.OracleHook` instead.
+
+AIR303.py:243:1: AIR303 `airflow.operators.oracle_operator.OracleOperator` is moved into `oracle` provider in Airflow 3.0;
+    |
+241 | # apache-airflow-providers-oracle
+242 | OracleHook()
+243 | OracleOperator()
+    | ^^^^^^^^^^^^^^ AIR303
+244 | 
+245 | # apache-airflow-providers-papermill
+    |
+    = help: Install `apache-airflow-provider-oracle>=1.0.0` and use `airflow.providers.oracle.operators.oracle.OracleOperator` instead.
+
+AIR303.py:246:1: AIR303 `airflow.operators.papermill_operator.PapermillOperator` is moved into `papermill` provider in Airflow 3.0;
+    |
+245 | # apache-airflow-providers-papermill
+246 | PapermillOperator()
+    | ^^^^^^^^^^^^^^^^^ AIR303
+247 | 
+248 | # apache-airflow-providers-apache-pig
+    |
+    = help: Install `apache-airflow-provider-papermill>=1.0.0` and use `airflow.providers.papermill.operators.papermill.PapermillOperator` instead.
+
+AIR303.py:249:1: AIR303 `airflow.hooks.pig_hook.PigCliHook` is moved into `apache-pig` provider in Airflow 3.0;
+    |
+248 | # apache-airflow-providers-apache-pig
+249 | PigCliHook()
+    | ^^^^^^^^^^ AIR303
+250 | PigOperator()
+    |
+    = help: Install `apache-airflow-provider-apache-pig>=1.0.0` and use `airflow.providers.apache.pig.hooks.pig.PigCliHook` instead.
+
+AIR303.py:250:1: AIR303 `airflow.operators.pig_operator.PigOperator` is moved into `apache-pig` provider in Airflow 3.0;
+    |
+248 | # apache-airflow-providers-apache-pig
+249 | PigCliHook()
+250 | PigOperator()
     | ^^^^^^^^^^^ AIR303
-212 | Mapping()
-213 | PostgresOperator()
+251 | 
+252 | # apache-airflow-providers-postgres
     |
-    = help: Install `apache-airflow-provider-Apache Pig>=TBD` and use `PigOperator` instead.
+    = help: Install `apache-airflow-provider-apache-pig>=1.0.0` and use `airflow.providers.apache.pig.operators.pig.PigOperator` instead.
 
-AIR303.py:212:1: AIR303 `airflow.operators.postgres_operator.Mapping` is moved into `Postgres` provider in Airflow 3.0;
+AIR303.py:253:1: AIR303 `airflow.operators.postgres_operator.Mapping` is moved into `postgres` provider in Airflow 3.0;
     |
-210 | PapermillOperator()
-211 | PigOperator()
-212 | Mapping()
+252 | # apache-airflow-providers-postgres
+253 | Mapping
     | ^^^^^^^ AIR303
-213 | PostgresOperator()
-214 | SQLCheckOperator2()
+254 | PostgresHook()
+255 | PostgresOperator()
     |
-    = help: Install `apache-airflow-provider-Postgres>=TBD` and use `Mapping` instead.
+    = help: Install `apache-airflow-provider-postgres>=1.0.0` and use `airflow.providers.postgres.operators.postgres.Mapping` instead.
 
-AIR303.py:213:1: AIR303 `airflow.operators.postgres_operator.PostgresOperator` is moved into `Postgres` provider in Airflow 3.0;
+AIR303.py:254:1: AIR303 `airflow.hooks.postgres_hook.PostgresHook` is moved into `postgres` provider in Airflow 3.0;
     |
-211 | PigOperator()
-212 | Mapping()
-213 | PostgresOperator()
+252 | # apache-airflow-providers-postgres
+253 | Mapping
+254 | PostgresHook()
+    | ^^^^^^^^^^^^ AIR303
+255 | PostgresOperator()
+    |
+    = help: Install `apache-airflow-provider-postgres>=1.0.0` and use `airflow.providers.postgres.hooks.postgres.PostgresHook` instead.
+
+AIR303.py:255:1: AIR303 `airflow.operators.postgres_operator.PostgresOperator` is moved into `postgres` provider in Airflow 3.0;
+    |
+253 | Mapping
+254 | PostgresHook()
+255 | PostgresOperator()
     | ^^^^^^^^^^^^^^^^ AIR303
-214 | SQLCheckOperator2()
-215 | SQLIntervalCheckOperator2()
+256 | 
+257 | # apache-airflow-providers-presto
     |
-    = help: Install `apache-airflow-provider-Postgres>=TBD` and use `PostgresOperator` instead.
+    = help: Install `apache-airflow-provider-postgres>=1.0.0` and use `airflow.providers.postgres.operators.postgres.PostgresOperator` instead.
 
-AIR303.py:214:1: AIR303 `airflow.operators.presto_check_operator.SQLCheckOperator` is moved into `Common Sql` provider in Airflow 3.0;
+AIR303.py:258:1: AIR303 `airflow.hooks.presto_hook.PrestoHook` is moved into `presto` provider in Airflow 3.0;
     |
-212 | Mapping()
-213 | PostgresOperator()
-214 | SQLCheckOperator2()
-    | ^^^^^^^^^^^^^^^^^ AIR303
-215 | SQLIntervalCheckOperator2()
-216 | SQLValueCheckOperator2()
-    |
-    = help: Install `apache-airflow-provider-Common Sql>=TBD` and use `SQLCheckOperator` instead.
-
-AIR303.py:215:1: AIR303 `airflow.operators.presto_check_operator.SQLIntervalCheckOperator` is moved into `Common Sql` provider in Airflow 3.0;
-    |
-213 | PostgresOperator()
-214 | SQLCheckOperator2()
-215 | SQLIntervalCheckOperator2()
-    | ^^^^^^^^^^^^^^^^^^^^^^^^^ AIR303
-216 | SQLValueCheckOperator2()
-217 | PrestoCheckOperator()
-    |
-    = help: Install `apache-airflow-provider-Common Sql>=TBD` and use `SQLIntervalCheckOperator` instead.
-
-AIR303.py:216:1: AIR303 `airflow.operators.presto_check_operator.SQLValueCheckOperator` is moved into `Common Sql` provider in Airflow 3.0;
-    |
-214 | SQLCheckOperator2()
-215 | SQLIntervalCheckOperator2()
-216 | SQLValueCheckOperator2()
-    | ^^^^^^^^^^^^^^^^^^^^^^ AIR303
-217 | PrestoCheckOperator()
-218 | PrestoIntervalCheckOperator()
-    |
-    = help: Install `apache-airflow-provider-Common Sql>=TBD` and use `SQLValueCheckOperator` instead.
-
-AIR303.py:217:1: AIR303 `airflow.operators.presto_check_operator.PrestoCheckOperator` is moved into `Common Sql` provider in Airflow 3.0;
-    |
-215 | SQLIntervalCheckOperator2()
-216 | SQLValueCheckOperator2()
-217 | PrestoCheckOperator()
-    | ^^^^^^^^^^^^^^^^^^^ AIR303
-218 | PrestoIntervalCheckOperator()
-219 | PrestoValueCheckOperator()
-    |
-    = help: Install `apache-airflow-provider-Common Sql>=TBD` and use `PrestoCheckOperator` instead.
-
-AIR303.py:218:1: AIR303 `airflow.operators.presto_check_operator.PrestoIntervalCheckOperator` is moved into `Common Sql` provider in Airflow 3.0;
-    |
-216 | SQLValueCheckOperator2()
-217 | PrestoCheckOperator()
-218 | PrestoIntervalCheckOperator()
-    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR303
-219 | PrestoValueCheckOperator()
-220 | PrestoToMySqlOperator()
-    |
-    = help: Install `apache-airflow-provider-Common Sql>=TBD` and use `PrestoIntervalCheckOperator` instead.
-
-AIR303.py:219:1: AIR303 `airflow.operators.presto_check_operator.PrestoValueCheckOperator` is moved into `Common Sql` provider in Airflow 3.0;
-    |
-217 | PrestoCheckOperator()
-218 | PrestoIntervalCheckOperator()
-219 | PrestoValueCheckOperator()
-    | ^^^^^^^^^^^^^^^^^^^^^^^^ AIR303
-220 | PrestoToMySqlOperator()
-221 | PrestoToMySqlTransfer()
-    |
-    = help: Install `apache-airflow-provider-Common Sql>=TBD` and use `PrestoValueCheckOperator` instead.
-
-AIR303.py:220:1: AIR303 `airflow.operators.presto_to_mysql.PrestoToMySqlOperator` is moved into `Mysql` provider in Airflow 3.0;
-    |
-218 | PrestoIntervalCheckOperator()
-219 | PrestoValueCheckOperator()
-220 | PrestoToMySqlOperator()
-    | ^^^^^^^^^^^^^^^^^^^^^ AIR303
-221 | PrestoToMySqlTransfer()
-222 | RedshiftToS3Operator()
-    |
-    = help: Install `apache-airflow-provider-Mysql>=TBD` and use `PrestoToMySqlOperator` instead.
-
-AIR303.py:221:1: AIR303 `airflow.operators.presto_to_mysql.PrestoToMySqlTransfer` is moved into `Mysql` provider in Airflow 3.0;
-    |
-219 | PrestoValueCheckOperator()
-220 | PrestoToMySqlOperator()
-221 | PrestoToMySqlTransfer()
-    | ^^^^^^^^^^^^^^^^^^^^^ AIR303
-222 | RedshiftToS3Operator()
-223 | RedshiftToS3Transfer()
-    |
-    = help: Install `apache-airflow-provider-Mysql>=TBD` and use `PrestoToMySqlTransfer` instead.
-
-AIR303.py:222:1: AIR303 `airflow.operators.redshift_to_s3_operator.RedshiftToS3Operator` is moved into `Amazon` provider in Airflow 3.0;
-    |
-220 | PrestoToMySqlOperator()
-221 | PrestoToMySqlTransfer()
-222 | RedshiftToS3Operator()
-    | ^^^^^^^^^^^^^^^^^^^^ AIR303
-223 | RedshiftToS3Transfer()
-224 | S3FileTransformOperator()
-    |
-    = help: Install `apache-airflow-provider-Amazon>=TBD` and use `RedshiftToS3Operator` instead.
-
-AIR303.py:223:1: AIR303 `airflow.operators.redshift_to_s3_operator.RedshiftToS3Transfer` is moved into `Amazon` provider in Airflow 3.0;
-    |
-221 | PrestoToMySqlTransfer()
-222 | RedshiftToS3Operator()
-223 | RedshiftToS3Transfer()
-    | ^^^^^^^^^^^^^^^^^^^^ AIR303
-224 | S3FileTransformOperator()
-225 | S3ToHiveOperator()
-    |
-    = help: Install `apache-airflow-provider-Amazon>=TBD` and use `RedshiftToS3Transfer` instead.
-
-AIR303.py:224:1: AIR303 `airflow.operators.s3_file_transform_operator.S3FileTransformOperator` is moved into `Amazon` provider in Airflow 3.0;
-    |
-222 | RedshiftToS3Operator()
-223 | RedshiftToS3Transfer()
-224 | S3FileTransformOperator()
-    | ^^^^^^^^^^^^^^^^^^^^^^^ AIR303
-225 | S3ToHiveOperator()
-226 | S3ToHiveTransfer()
-    |
-    = help: Install `apache-airflow-provider-Amazon>=TBD` and use `S3FileTransformOperator` instead.
-
-AIR303.py:225:1: AIR303 `airflow.operators.s3_to_hive_operator.S3ToHiveOperator` is moved into `Apache Hive` provider in Airflow 3.0;
-    |
-223 | RedshiftToS3Transfer()
-224 | S3FileTransformOperator()
-225 | S3ToHiveOperator()
-    | ^^^^^^^^^^^^^^^^ AIR303
-226 | S3ToHiveTransfer()
-227 | S3ToRedshiftOperator()
-    |
-    = help: Install `apache-airflow-provider-Apache Hive>=TBD` and use `S3ToHiveOperator` instead.
-
-AIR303.py:226:1: AIR303 `airflow.operators.s3_to_hive_operator.S3ToHiveTransfer` is moved into `Apache Hive` provider in Airflow 3.0;
-    |
-224 | S3FileTransformOperator()
-225 | S3ToHiveOperator()
-226 | S3ToHiveTransfer()
-    | ^^^^^^^^^^^^^^^^ AIR303
-227 | S3ToRedshiftOperator()
-228 | S3ToRedshiftTransfer()
-    |
-    = help: Install `apache-airflow-provider-Apache Hive>=TBD` and use `S3ToHiveTransfer` instead.
-
-AIR303.py:227:1: AIR303 `airflow.operators.s3_to_redshift_operator.S3ToRedshiftOperator` is moved into `Amazon` provider in Airflow 3.0;
-    |
-225 | S3ToHiveOperator()
-226 | S3ToHiveTransfer()
-227 | S3ToRedshiftOperator()
-    | ^^^^^^^^^^^^^^^^^^^^ AIR303
-228 | S3ToRedshiftTransfer()
-229 | SlackAPIOperator()
-    |
-    = help: Install `apache-airflow-provider-Amazon>=TBD` and use `S3ToRedshiftOperator` instead.
-
-AIR303.py:228:1: AIR303 `airflow.operators.s3_to_redshift_operator.S3ToRedshiftTransfer` is moved into `Amazon` provider in Airflow 3.0;
-    |
-226 | S3ToHiveTransfer()
-227 | S3ToRedshiftOperator()
-228 | S3ToRedshiftTransfer()
-    | ^^^^^^^^^^^^^^^^^^^^ AIR303
-229 | SlackAPIOperator()
-230 | SlackAPIPostOperator()
-    |
-    = help: Install `apache-airflow-provider-Amazon>=TBD` and use `S3ToRedshiftTransfer` instead.
-
-AIR303.py:229:1: AIR303 `airflow.operators.slack_operator.SlackAPIOperator` is moved into `Slack` provider in Airflow 3.0;
-    |
-227 | S3ToRedshiftOperator()
-228 | S3ToRedshiftTransfer()
-229 | SlackAPIOperator()
-    | ^^^^^^^^^^^^^^^^ AIR303
-230 | SlackAPIPostOperator()
-231 | BaseSQLOperator()
-    |
-    = help: Install `apache-airflow-provider-Slack>=TBD` and use `SlackAPIOperator` instead.
-
-AIR303.py:230:1: AIR303 `airflow.operators.slack_operator.SlackAPIPostOperator` is moved into `Slack` provider in Airflow 3.0;
-    |
-228 | S3ToRedshiftTransfer()
-229 | SlackAPIOperator()
-230 | SlackAPIPostOperator()
-    | ^^^^^^^^^^^^^^^^^^^^ AIR303
-231 | BaseSQLOperator()
-232 | BranchSQLOperator()
-    |
-    = help: Install `apache-airflow-provider-Slack>=TBD` and use `SlackAPIPostOperator` instead.
-
-AIR303.py:231:1: AIR303 `airflow.operators.sql.BaseSQLOperator` is moved into `Common Sql` provider in Airflow 3.0;
-    |
-229 | SlackAPIOperator()
-230 | SlackAPIPostOperator()
-231 | BaseSQLOperator()
-    | ^^^^^^^^^^^^^^^ AIR303
-232 | BranchSQLOperator()
-233 | SQLCheckOperator3()
-    |
-    = help: Install `apache-airflow-provider-Common Sql>=TBD` and use `BaseSQLOperator` instead.
-
-AIR303.py:232:1: AIR303 `airflow.operators.sql.BranchSQLOperator` is moved into `Common Sql` provider in Airflow 3.0;
-    |
-230 | SlackAPIPostOperator()
-231 | BaseSQLOperator()
-232 | BranchSQLOperator()
-    | ^^^^^^^^^^^^^^^^^ AIR303
-233 | SQLCheckOperator3()
-234 | SQLColumnCheckOperator2()
-    |
-    = help: Install `apache-airflow-provider-Common Sql>=TBD` and use `BranchSQLOperator` instead.
-
-AIR303.py:233:1: AIR303 `airflow.operators.sql.SQLCheckOperator` is moved into `Common Sql` provider in Airflow 3.0;
-    |
-231 | BaseSQLOperator()
-232 | BranchSQLOperator()
-233 | SQLCheckOperator3()
-    | ^^^^^^^^^^^^^^^^^ AIR303
-234 | SQLColumnCheckOperator2()
-235 | SQLIntervalCheckOperator3()
-    |
-    = help: Install `apache-airflow-provider-Common Sql>=TBD` and use `SQLCheckOperator` instead.
-
-AIR303.py:234:1: AIR303 `airflow.operators.sql.SQLColumnCheckOperator` is moved into `Common Sql` provider in Airflow 3.0;
-    |
-232 | BranchSQLOperator()
-233 | SQLCheckOperator3()
-234 | SQLColumnCheckOperator2()
-    | ^^^^^^^^^^^^^^^^^^^^^^^ AIR303
-235 | SQLIntervalCheckOperator3()
-236 | SQLTableCheckOperator()
-    |
-    = help: Install `apache-airflow-provider-Common Sql>=TBD` and use `SQLColumnCheckOperator` instead.
-
-AIR303.py:235:1: AIR303 `airflow.operators.sql.SQLIntervalCheckOperator` is moved into `Common Sql` provider in Airflow 3.0;
-    |
-233 | SQLCheckOperator3()
-234 | SQLColumnCheckOperator2()
-235 | SQLIntervalCheckOperator3()
-    | ^^^^^^^^^^^^^^^^^^^^^^^^^ AIR303
-236 | SQLTableCheckOperator()
-237 | SQLThresholdCheckOperator2()
-    |
-    = help: Install `apache-airflow-provider-Common Sql>=TBD` and use `SQLIntervalCheckOperator` instead.
-
-AIR303.py:236:1: AIR303 `airflow.operators.sql.SQLTableCheckOperator` is moved into `Common Sql` provider in Airflow 3.0;
-    |
-234 | SQLColumnCheckOperator2()
-235 | SQLIntervalCheckOperator3()
-236 | SQLTableCheckOperator()
-    | ^^^^^^^^^^^^^^^^^^^^^ AIR303
-237 | SQLThresholdCheckOperator2()
-238 | SQLValueCheckOperator3()
-    |
-    = help: Install `apache-airflow-provider-Common Sql>=TBD` and use `SQLTableCheckOperator` instead.
-
-AIR303.py:237:1: AIR303 `airflow.operators.sql.SQLThresholdCheckOperator` is moved into `Common Sql` provider in Airflow 3.0;
-    |
-235 | SQLIntervalCheckOperator3()
-236 | SQLTableCheckOperator()
-237 | SQLThresholdCheckOperator2()
-    | ^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR303
-238 | SQLValueCheckOperator3()
-239 | _convert_to_float_if_possible()
-    |
-    = help: Install `apache-airflow-provider-Common Sql>=TBD` and use `SQLThresholdCheckOperator` instead.
-
-AIR303.py:238:1: AIR303 `airflow.operators.sql.SQLValueCheckOperator` is moved into `Common Sql` provider in Airflow 3.0;
-    |
-236 | SQLTableCheckOperator()
-237 | SQLThresholdCheckOperator2()
-238 | SQLValueCheckOperator3()
-    | ^^^^^^^^^^^^^^^^^^^^^^ AIR303
-239 | _convert_to_float_if_possible()
-240 | parse_boolean()
-    |
-    = help: Install `apache-airflow-provider-Common Sql>=TBD` and use `SQLValueCheckOperator` instead.
-
-AIR303.py:239:1: AIR303 `airflow.operators.sql._convert_to_float_if_possible` is moved into `Common Sql` provider in Airflow 3.0;
-    |
-237 | SQLThresholdCheckOperator2()
-238 | SQLValueCheckOperator3()
-239 | _convert_to_float_if_possible()
-    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR303
-240 | parse_boolean()
-241 | BranchSQLOperator()
-    |
-    = help: Install `apache-airflow-provider-Common Sql>=TBD` and use `_convert_to_float_if_possible` instead.
-
-AIR303.py:240:1: AIR303 `airflow.operators.sql.parse_boolean` is moved into `Common Sql` provider in Airflow 3.0;
-    |
-238 | SQLValueCheckOperator3()
-239 | _convert_to_float_if_possible()
-240 | parse_boolean()
-    | ^^^^^^^^^^^^^ AIR303
-241 | BranchSQLOperator()
-242 | BranchSqlOperator()
-    |
-    = help: Install `apache-airflow-provider-Common Sql>=TBD` and use `parse_boolean` instead.
-
-AIR303.py:241:1: AIR303 `airflow.operators.sql.BranchSQLOperator` is moved into `Common Sql` provider in Airflow 3.0;
-    |
-239 | _convert_to_float_if_possible()
-240 | parse_boolean()
-241 | BranchSQLOperator()
-    | ^^^^^^^^^^^^^^^^^ AIR303
-242 | BranchSqlOperator()
-243 | SqliteOperator()
-    |
-    = help: Install `apache-airflow-provider-Common Sql>=TBD` and use `BranchSQLOperator` instead.
-
-AIR303.py:242:1: AIR303 `airflow.operators.sql_branch_operator.BranchSqlOperator` is moved into `Common Sql` provider in Airflow 3.0;
-    |
-240 | parse_boolean()
-241 | BranchSQLOperator()
-242 | BranchSqlOperator()
-    | ^^^^^^^^^^^^^^^^^ AIR303
-243 | SqliteOperator()
-244 | HivePartitionSensor()
-    |
-    = help: Install `apache-airflow-provider-Common Sql>=TBD` and use `BranchSqlOperator` instead.
-
-AIR303.py:243:1: AIR303 `airflow.operators.sqlite_operator.SqliteOperator` is moved into `Sqlite` provider in Airflow 3.0;
-    |
-241 | BranchSQLOperator()
-242 | BranchSqlOperator()
-243 | SqliteOperator()
-    | ^^^^^^^^^^^^^^ AIR303
-244 | HivePartitionSensor()
-245 | HttpSensor()
-    |
-    = help: Install `apache-airflow-provider-Sqlite>=TBD` and use `SqliteOperator` instead.
-
-AIR303.py:244:1: AIR303 `airflow.sensors.hive_partition_sensor.HivePartitionSensor` is moved into `Apache Hive` provider in Airflow 3.0;
-    |
-242 | BranchSqlOperator()
-243 | SqliteOperator()
-244 | HivePartitionSensor()
-    | ^^^^^^^^^^^^^^^^^^^ AIR303
-245 | HttpSensor()
-246 | MetastorePartitionSensor()
-    |
-    = help: Install `apache-airflow-provider-Apache Hive>=TBD` and use `HivePartitionSensor` instead.
-
-AIR303.py:245:1: AIR303 `airflow.sensors.http_sensor.HttpSensor` is moved into `Http` provider in Airflow 3.0;
-    |
-243 | SqliteOperator()
-244 | HivePartitionSensor()
-245 | HttpSensor()
+257 | # apache-airflow-providers-presto
+258 | PrestoHook()
     | ^^^^^^^^^^ AIR303
-246 | MetastorePartitionSensor()
-247 | NamedHivePartitionSensor()
+259 | 
+260 | # apache-airflow-providers-samba
     |
-    = help: Install `apache-airflow-provider-Http>=TBD` and use `HttpSensor` instead.
+    = help: Install `apache-airflow-provider-presto>=1.0.0` and use `airflow.providers.presto.hooks.presto.PrestoHook` instead.
 
-AIR303.py:246:1: AIR303 `airflow.sensors.metastore_partition_sensor.MetastorePartitionSensor` is moved into `Apache Hive` provider in Airflow 3.0;
+AIR303.py:261:1: AIR303 `airflow.hooks.samba_hook.SambaHook` is moved into `samba` provider in Airflow 3.0;
     |
-244 | HivePartitionSensor()
-245 | HttpSensor()
-246 | MetastorePartitionSensor()
-    | ^^^^^^^^^^^^^^^^^^^^^^^^ AIR303
-247 | NamedHivePartitionSensor()
-248 | S3KeySensor()
-    |
-    = help: Install `apache-airflow-provider-Apache Hive>=TBD` and use `MetastorePartitionSensor` instead.
-
-AIR303.py:247:1: AIR303 `airflow.sensors.named_hive_partition_sensor.NamedHivePartitionSensor` is moved into `Apache Hive` provider in Airflow 3.0;
-    |
-245 | HttpSensor()
-246 | MetastorePartitionSensor()
-247 | NamedHivePartitionSensor()
-    | ^^^^^^^^^^^^^^^^^^^^^^^^ AIR303
-248 | S3KeySensor()
-249 | SqlSensor()
-    |
-    = help: Install `apache-airflow-provider-Apache Hive>=TBD` and use `NamedHivePartitionSensor` instead.
-
-AIR303.py:248:1: AIR303 `airflow.sensors.s3_key_sensor.S3KeySensor` is moved into `Amazon` provider in Airflow 3.0;
-    |
-246 | MetastorePartitionSensor()
-247 | NamedHivePartitionSensor()
-248 | S3KeySensor()
-    | ^^^^^^^^^^^ AIR303
-249 | SqlSensor()
-250 | SqlSensor2()
-    |
-    = help: Install `apache-airflow-provider-Amazon>=TBD` and use `S3KeySensor` instead.
-
-AIR303.py:249:1: AIR303 `airflow.sensors.sql.SqlSensor` is moved into `Common Sql` provider in Airflow 3.0;
-    |
-247 | NamedHivePartitionSensor()
-248 | S3KeySensor()
-249 | SqlSensor()
+260 | # apache-airflow-providers-samba
+261 | SambaHook()
     | ^^^^^^^^^ AIR303
-250 | SqlSensor2()
-251 | WebHdfsSensor()
+262 | 
+263 | # apache-airflow-providers-slack
     |
-    = help: Install `apache-airflow-provider-Common Sql>=TBD` and use `SqlSensor` instead.
+    = help: Install `apache-airflow-provider-samba>=1.0.0` and use `airflow.providers.samba.hooks.samba.SambaHook` instead.
 
-AIR303.py:251:1: AIR303 `airflow.sensors.web_hdfs_sensor.WebHdfsSensor` is moved into `Apache Hdfs` provider in Airflow 3.0;
+AIR303.py:264:1: AIR303 `airflow.hooks.slack_hook.SlackHook` is moved into `slack` provider in Airflow 3.0;
     |
-249 | SqlSensor()
-250 | SqlSensor2()
-251 | WebHdfsSensor()
-    | ^^^^^^^^^^^^^ AIR303
+263 | # apache-airflow-providers-slack
+264 | SlackHook()
+    | ^^^^^^^^^ AIR303
+265 | SlackAPIOperator()
+266 | SlackAPIPostOperator()
     |
-    = help: Install `apache-airflow-provider-Apache Hdfs>=TBD` and use `WebHdfsSensor` instead.
+    = help: Install `apache-airflow-provider-slack>=1.0.0` and use `airflow.providers.slack.hooks.slack.SlackHook` instead.
+
+AIR303.py:265:1: AIR303 `airflow.operators.slack_operator.SlackAPIOperator` is moved into `slack` provider in Airflow 3.0;
+    |
+263 | # apache-airflow-providers-slack
+264 | SlackHook()
+265 | SlackAPIOperator()
+    | ^^^^^^^^^^^^^^^^ AIR303
+266 | SlackAPIPostOperator()
+    |
+    = help: Install `apache-airflow-provider-slack>=1.0.0` and use `airflow.providers.slack.operators.slack.SlackAPIOperator` instead.
+
+AIR303.py:266:1: AIR303 `airflow.operators.slack_operator.SlackAPIPostOperator` is moved into `slack` provider in Airflow 3.0;
+    |
+264 | SlackHook()
+265 | SlackAPIOperator()
+266 | SlackAPIPostOperator()
+    | ^^^^^^^^^^^^^^^^^^^^ AIR303
+267 | 
+268 | # apache-airflow-providers-sqlite
+    |
+    = help: Install `apache-airflow-provider-slack>=1.0.0` and use `airflow.providers.slack.operators.slack.SlackAPIPostOperator` instead.
+
+AIR303.py:269:1: AIR303 `airflow.hooks.sqlite_hook.SqliteHook` is moved into `sqlite` provider in Airflow 3.0;
+    |
+268 | # apache-airflow-providers-sqlite
+269 | SqliteHook()
+    | ^^^^^^^^^^ AIR303
+270 | SqliteOperator()
+    |
+    = help: Install `apache-airflow-provider-sqlite>=1.0.0` and use `airflow.providers.sqlite.hooks.sqlite.SqliteHook` instead.
+
+AIR303.py:270:1: AIR303 `airflow.operators.sqlite_operator.SqliteOperator` is moved into `sqlite` provider in Airflow 3.0;
+    |
+268 | # apache-airflow-providers-sqlite
+269 | SqliteHook()
+270 | SqliteOperator()
+    | ^^^^^^^^^^^^^^ AIR303
+271 | 
+272 | # apache-airflow-providers-zendesk
+    |
+    = help: Install `apache-airflow-provider-sqlite>=1.0.0` and use `airflow.providers.sqlite.operators.sqlite.SqliteOperator` instead.
+
+AIR303.py:273:1: AIR303 `airflow.hooks.zendesk_hook.ZendeskHook` is moved into `zendesk` provider in Airflow 3.0;
+    |
+272 | # apache-airflow-providers-zendesk
+273 | ZendeskHook()
+    | ^^^^^^^^^^^ AIR303
+    |
+    = help: Install `apache-airflow-provider-zendesk>=1.0.0` and use `airflow.providers.zendesk.hooks.zendesk.ZendeskHook` instead.

--- a/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR303_AIR303.py.snap
+++ b/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR303_AIR303.py.snap
@@ -2,1170 +2,1248 @@
 source: crates/ruff_linter/src/rules/airflow/mod.rs
 snapshot_kind: text
 ---
-AIR303.py:111:1: AIR303 Import path `airflow.api.auth.backend.basic_auth` is moved into `fab` provider in Airflow 3.0;
+AIR303.py:123:1: AIR303 Import path `airflow.api.auth.backend.basic_auth` is moved into `fab` provider in Airflow 3.0;
     |
-110 | # apache-airflow-providers-fab
-111 | basic_auth, kerberos_auth
+122 | # apache-airflow-providers-fab
+123 | basic_auth, kerberos_auth
     | ^^^^^^^^^^ AIR303
-112 | auth_current_user
-113 | backend_kerberos_auth
+124 | auth_current_user
+125 | backend_kerberos_auth
     |
     = help: Install `apache-airflow-provider-fab>=1.0.0` and import from `airflow.providers.fab.auth_manager.api.auth.backend.basic_auth` instead.
 
-AIR303.py:111:13: AIR303 Import path `airflow.api.auth.backend.kerberos_auth` is moved into `fab` provider in Airflow 3.0;
+AIR303.py:123:13: AIR303 Import path `airflow.api.auth.backend.kerberos_auth` is moved into `fab` provider in Airflow 3.0;
     |
-110 | # apache-airflow-providers-fab
-111 | basic_auth, kerberos_auth
+122 | # apache-airflow-providers-fab
+123 | basic_auth, kerberos_auth
     |             ^^^^^^^^^^^^^ AIR303
-112 | auth_current_user
-113 | backend_kerberos_auth
+124 | auth_current_user
+125 | backend_kerberos_auth
     |
     = help: Install `apache-airflow-provider-fab>=1.0.0` and import from `airflow.providers.fab.auth_manager.api.auth.backend.kerberos_auth` instead.
 
-AIR303.py:112:1: AIR303 Import path `airflow.api.auth.backend.basic_auth` is moved into `fab` provider in Airflow 3.0;
+AIR303.py:124:1: AIR303 Import path `airflow.api.auth.backend.basic_auth` is moved into `fab` provider in Airflow 3.0;
     |
-110 | # apache-airflow-providers-fab
-111 | basic_auth, kerberos_auth
-112 | auth_current_user
+122 | # apache-airflow-providers-fab
+123 | basic_auth, kerberos_auth
+124 | auth_current_user
     | ^^^^^^^^^^^^^^^^^ AIR303
-113 | backend_kerberos_auth
-114 | fab_override
+125 | backend_kerberos_auth
+126 | fab_override
     |
     = help: Install `apache-airflow-provider-fab>=1.0.0` and import from `airflow.providers.fab.auth_manager.api.auth.backend.basic_auth` instead.
 
-AIR303.py:113:1: AIR303 Import path `airflow.auth_manager.api.auth.backend.kerberos_auth` is moved into `fab` provider in Airflow 3.0;
+AIR303.py:125:1: AIR303 Import path `airflow.auth_manager.api.auth.backend.kerberos_auth` is moved into `fab` provider in Airflow 3.0;
     |
-111 | basic_auth, kerberos_auth
-112 | auth_current_user
-113 | backend_kerberos_auth
+123 | basic_auth, kerberos_auth
+124 | auth_current_user
+125 | backend_kerberos_auth
     | ^^^^^^^^^^^^^^^^^^^^^ AIR303
-114 | fab_override
+126 | fab_override
     |
     = help: Install `apache-airflow-provider-fab>=1.0.0` and import from `airflow.providers.fab.auth_manager.api.auth.backend.kerberos_auth` instead.
 
-AIR303.py:114:1: AIR303 Import path `airflow.auth.managers.fab.security_managr.override` is moved into `fab` provider in Airflow 3.0;
+AIR303.py:126:1: AIR303 Import path `airflow.auth.managers.fab.security_managr.override` is moved into `fab` provider in Airflow 3.0;
     |
-112 | auth_current_user
-113 | backend_kerberos_auth
-114 | fab_override
+124 | auth_current_user
+125 | backend_kerberos_auth
+126 | fab_override
     | ^^^^^^^^^^^^ AIR303
-115 | 
-116 | FabAuthManager()
+127 | 
+128 | FabAuthManager()
     |
     = help: Install `apache-airflow-provider-fab>=1.0.0` and import from `airflow.providers.fab.auth_manager.security_manager.override` instead.
 
-AIR303.py:116:1: AIR303 `airflow.auth.managers.fab.fab_auth_manager.FabAuthManager` is moved into `fab` provider in Airflow 3.0;
+AIR303.py:128:1: AIR303 `airflow.auth.managers.fab.fab_auth_manager.FabAuthManager` is moved into `fab` provider in Airflow 3.0;
     |
-114 | fab_override
-115 | 
-116 | FabAuthManager()
+126 | fab_override
+127 | 
+128 | FabAuthManager()
     | ^^^^^^^^^^^^^^ AIR303
-117 | FabAirflowSecurityManagerOverride()
+129 | FabAirflowSecurityManagerOverride()
     |
     = help: Install `apache-airflow-provider-fab>=1.0.0` and use `airflow.providers.fab.auth_manager.security_manager.FabAuthManager` instead.
 
-AIR303.py:117:1: AIR303 `airflow.www.security.FabAirflowSecurityManagerOverride` is moved into `fab` provider in Airflow 3.0;
+AIR303.py:129:1: AIR303 `airflow.www.security.FabAirflowSecurityManagerOverride` is moved into `fab` provider in Airflow 3.0;
     |
-116 | FabAuthManager()
-117 | FabAirflowSecurityManagerOverride()
+128 | FabAuthManager()
+129 | FabAirflowSecurityManagerOverride()
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR303
-118 | 
-119 | # apache-airflow-providers-celery
+130 | 
+131 | # apache-airflow-providers-celery
     |
     = help: Install `apache-airflow-provider-fab>=1.0.0` and use `airflow.providers.fab.auth_manager.security_manager.override.FabAirflowSecurityManagerOverride` instead.
 
-AIR303.py:120:1: AIR303 Import path `airflow.config_templates.default_celery.DEFAULT_CELERY_CONFIG` is moved into `celery` provider in Airflow 3.0;
+AIR303.py:132:1: AIR303 Import path `airflow.config_templates.default_celery.DEFAULT_CELERY_CONFIG` is moved into `celery` provider in Airflow 3.0;
     |
-119 | # apache-airflow-providers-celery
-120 | DEFAULT_CELERY_CONFIG
+131 | # apache-airflow-providers-celery
+132 | DEFAULT_CELERY_CONFIG
     | ^^^^^^^^^^^^^^^^^^^^^ AIR303
-121 | app
-122 | CeleryExecutor()
+133 | app
+134 | CeleryExecutor()
     |
     = help: Install `apache-airflow-provider-celery>=3.3.0` and import from `airflow.providers.celery.executors.default_celery.DEFAULT_CELERY_CONFIG` instead.
 
-AIR303.py:121:1: AIR303 Import path `airflow.executors.celery_executor.app` is moved into `celery` provider in Airflow 3.0;
+AIR303.py:133:1: AIR303 Import path `airflow.executors.celery_executor.app` is moved into `celery` provider in Airflow 3.0;
     |
-119 | # apache-airflow-providers-celery
-120 | DEFAULT_CELERY_CONFIG
-121 | app
+131 | # apache-airflow-providers-celery
+132 | DEFAULT_CELERY_CONFIG
+133 | app
     | ^^^ AIR303
-122 | CeleryExecutor()
-123 | CeleryKubernetesExecutor()
+134 | CeleryExecutor()
+135 | CeleryKubernetesExecutor()
     |
     = help: Install `apache-airflow-provider-celery>=3.3.0` and import from `airflow.providers.celery.executors.celery_executor_utils.app` instead.
 
-AIR303.py:122:1: AIR303 `airflow.executors.celery_executor.CeleryExecutor` is moved into `celery` provider in Airflow 3.0;
+AIR303.py:134:1: AIR303 `airflow.executors.celery_executor.CeleryExecutor` is moved into `celery` provider in Airflow 3.0;
     |
-120 | DEFAULT_CELERY_CONFIG
-121 | app
-122 | CeleryExecutor()
+132 | DEFAULT_CELERY_CONFIG
+133 | app
+134 | CeleryExecutor()
     | ^^^^^^^^^^^^^^ AIR303
-123 | CeleryKubernetesExecutor()
+135 | CeleryKubernetesExecutor()
     |
     = help: Install `apache-airflow-provider-celery>=3.3.0` and use `airflow.providers.celery.executors.celery_executor.CeleryExecutor` instead.
 
-AIR303.py:123:1: AIR303 `airflow.executors.celery_kubernetes_executor.CeleryKubernetesExecutor` is moved into `celery` provider in Airflow 3.0;
+AIR303.py:135:1: AIR303 `airflow.executors.celery_kubernetes_executor.CeleryKubernetesExecutor` is moved into `celery` provider in Airflow 3.0;
     |
-121 | app
-122 | CeleryExecutor()
-123 | CeleryKubernetesExecutor()
+133 | app
+134 | CeleryExecutor()
+135 | CeleryKubernetesExecutor()
     | ^^^^^^^^^^^^^^^^^^^^^^^^ AIR303
-124 | 
-125 | # apache-airflow-providers-daskexecutor
+136 | 
+137 | # apache-airflow-providers-daskexecutor
     |
     = help: Install `apache-airflow-provider-celery>=3.3.0` and use `airflow.providers.celery.executors.celery_kubernetes_executor.CeleryKubernetesExecutor` instead.
 
-AIR303.py:126:1: AIR303 `airflow.executors.dask_executor.DaskExecutor` is moved into `daskexecutor` provider in Airflow 3.0;
+AIR303.py:138:1: AIR303 `airflow.executors.dask_executor.DaskExecutor` is moved into `daskexecutor` provider in Airflow 3.0;
     |
-125 | # apache-airflow-providers-daskexecutor
-126 | DaskExecutor()
+137 | # apache-airflow-providers-daskexecutor
+138 | DaskExecutor()
     | ^^^^^^^^^^^^ AIR303
-127 | 
-128 | # apache-airflow-providers-common-sql
+139 | 
+140 | # apache-airflow-providers-common-sql
     |
     = help: Install `apache-airflow-provider-daskexecutor>=1.0.0` and use `airflow.providers.daskexecutor.executors.dask_executor.DaskExecutor` instead.
 
-AIR303.py:129:1: AIR303 Import path `airflow.hooks.dbapi.ConnectorProtocol` is moved into `Common SQL` provider in Airflow 3.0;
+AIR303.py:141:1: AIR303 Import path `airflow.hooks.dbapi.ConnectorProtocol` is moved into `Common SQL` provider in Airflow 3.0;
     |
-128 | # apache-airflow-providers-common-sql
-129 | ConnectorProtocol()
+140 | # apache-airflow-providers-common-sql
+141 | ConnectorProtocol()
     | ^^^^^^^^^^^^^^^^^ AIR303
-130 | DbApiHook()
+142 | DbApiHook()
     |
     = help: Install `apache-airflow-provider-Common SQL>=1.0.0` and import from `airflow.providers.common.sql.hooks.sql.ConnectorProtocol` instead.
 
-AIR303.py:130:1: AIR303 Import path `airflow.hooks.dbapi.DbApiHook` is moved into `Common SQL` provider in Airflow 3.0;
+AIR303.py:142:1: AIR303 Import path `airflow.hooks.dbapi.DbApiHook` is moved into `Common SQL` provider in Airflow 3.0;
     |
-128 | # apache-airflow-providers-common-sql
-129 | ConnectorProtocol()
-130 | DbApiHook()
+140 | # apache-airflow-providers-common-sql
+141 | ConnectorProtocol()
+142 | DbApiHook()
     | ^^^^^^^^^ AIR303
-131 | 
-132 | # apache-airflow-providers-cncf-kubernetes
+143 | 
+144 | # apache-airflow-providers-cncf-kubernetes
     |
     = help: Install `apache-airflow-provider-Common SQL>=1.0.0` and import from `airflow.providers.common.sql.hooks.sql.DbApiHook` instead.
 
-AIR303.py:133:1: AIR303 Import path `airflow.executors.kubernetes_executor_types.ALL_NAMESPACES` is moved into `Kubernetes` provider in Airflow 3.0;
+AIR303.py:145:1: AIR303 Import path `airflow.executors.kubernetes_executor_types.ALL_NAMESPACES` is moved into `Kubernetes` provider in Airflow 3.0;
     |
-132 | # apache-airflow-providers-cncf-kubernetes
-133 | ALL_NAMESPACES
+144 | # apache-airflow-providers-cncf-kubernetes
+145 | ALL_NAMESPACES
     | ^^^^^^^^^^^^^^ AIR303
-134 | POD_EXECUTOR_DONE_KEY
+146 | POD_EXECUTOR_DONE_KEY
     |
     = help: Install `apache-airflow-provider-Kubernetes>=7.4.0` and import from `airflow.providers.cncf.kubernetes.executors.kubernetes_executor_types.ALL_NAMESPACES` instead.
 
-AIR303.py:134:1: AIR303 Import path `airflow.executors.kubernetes_executor_types.POD_EXECUTOR_DONE_KEY` is moved into `Kubernetes` provider in Airflow 3.0;
+AIR303.py:146:1: AIR303 Import path `airflow.executors.kubernetes_executor_types.POD_EXECUTOR_DONE_KEY` is moved into `Kubernetes` provider in Airflow 3.0;
     |
-132 | # apache-airflow-providers-cncf-kubernetes
-133 | ALL_NAMESPACES
-134 | POD_EXECUTOR_DONE_KEY
+144 | # apache-airflow-providers-cncf-kubernetes
+145 | ALL_NAMESPACES
+146 | POD_EXECUTOR_DONE_KEY
     | ^^^^^^^^^^^^^^^^^^^^^ AIR303
-135 | 
-136 | # apache-airflow-providers-apache-hive
+147 | 
+148 | # apache-airflow-providers-apache-hive
     |
     = help: Install `apache-airflow-provider-Kubernetes>=7.4.0` and import from `airflow.providers.cncf.kubernetes.executors.kubernetes_executor_types.POD_EXECUTOR_DONE_KEY` instead.
 
-AIR303.py:137:1: AIR303 `airflow.hooks.hive_hooks.HIVE_QUEUE_PRIORITIES` is moved into `Apache Hive` provider in Airflow 3.0;
+AIR303.py:149:1: AIR303 `airflow.hooks.hive_hooks.HIVE_QUEUE_PRIORITIES` is moved into `Apache Hive` provider in Airflow 3.0;
     |
-136 | # apache-airflow-providers-apache-hive
-137 | HIVE_QUEUE_PRIORITIES
+148 | # apache-airflow-providers-apache-hive
+149 | HIVE_QUEUE_PRIORITIES
     | ^^^^^^^^^^^^^^^^^^^^^ AIR303
-138 | closest_ds_partition()
-139 | max_partition()
+150 | closest_ds_partition()
+151 | max_partition()
     |
     = help: Install `apache-airflow-provider-Apache Hive>=1.0.0` and use `HIVE_QUEUE_PRIORITIES` instead.
 
-AIR303.py:138:1: AIR303 Import path `airflow.macros.hive.closest_ds_partition` is moved into `Apache Hive` provider in Airflow 3.0;
+AIR303.py:150:1: AIR303 Import path `airflow.macros.hive.closest_ds_partition` is moved into `Apache Hive` provider in Airflow 3.0;
     |
-136 | # apache-airflow-providers-apache-hive
-137 | HIVE_QUEUE_PRIORITIES
-138 | closest_ds_partition()
+148 | # apache-airflow-providers-apache-hive
+149 | HIVE_QUEUE_PRIORITIES
+150 | closest_ds_partition()
     | ^^^^^^^^^^^^^^^^^^^^ AIR303
-139 | max_partition()
+151 | max_partition()
     |
     = help: Install `apache-airflow-provider-Apache Hive>=5.1.0` and import from `airflow.providers.apache.hive.macros.hive.closest_ds_partition` instead.
 
-AIR303.py:139:1: AIR303 Import path `airflow.macros.hive.max_partition` is moved into `Apache Hive` provider in Airflow 3.0;
+AIR303.py:151:1: AIR303 Import path `airflow.macros.hive.max_partition` is moved into `Apache Hive` provider in Airflow 3.0;
     |
-137 | HIVE_QUEUE_PRIORITIES
-138 | closest_ds_partition()
-139 | max_partition()
+149 | HIVE_QUEUE_PRIORITIES
+150 | closest_ds_partition()
+151 | max_partition()
     | ^^^^^^^^^^^^^ AIR303
-140 | 
-141 | # TODO: reorganize
+152 | 
+153 | # TODO: reorganize
     |
     = help: Install `apache-airflow-provider-Apache Hive>=5.1.0` and import from `airflow.providers.apache.hive.macros.hive.max_partition` instead.
 
-AIR303.py:142:1: AIR303 `airflow.hooks.S3_hook.S3Hook` is moved into `Amazon` provider in Airflow 3.0;
+AIR303.py:154:1: AIR303 `airflow.hooks.S3_hook.S3Hook` is moved into `Amazon` provider in Airflow 3.0;
     |
-141 | # TODO: reorganize
-142 | S3Hook()
+153 | # TODO: reorganize
+154 | S3Hook()
     | ^^^^^^ AIR303
-143 | provide_bucket_name()
-144 | BaseHook()
+155 | provide_bucket_name()
+156 | BaseHook()
     |
     = help: Install `apache-airflow-provider-Amazon>=TBD` and use `S3Hook` instead.
 
-AIR303.py:143:1: AIR303 `airflow.hooks.S3_hook.provide_bucket_name` is moved into `Amazon` provider in Airflow 3.0;
+AIR303.py:155:1: AIR303 `airflow.hooks.S3_hook.provide_bucket_name` is moved into `Amazon` provider in Airflow 3.0;
     |
-141 | # TODO: reorganize
-142 | S3Hook()
-143 | provide_bucket_name()
+153 | # TODO: reorganize
+154 | S3Hook()
+155 | provide_bucket_name()
     | ^^^^^^^^^^^^^^^^^^^ AIR303
-144 | BaseHook()
-145 | DbApiHook2()
+156 | BaseHook()
+157 | DbApiHook2()
     |
     = help: Install `apache-airflow-provider-Amazon>=TBD` and use `provide_bucket_name` instead.
 
-AIR303.py:144:1: AIR303 `airflow.hooks.base_hook.BaseHook` is moved into `Base` provider in Airflow 3.0;
+AIR303.py:156:1: AIR303 `airflow.hooks.base_hook.BaseHook` is moved into `Base` provider in Airflow 3.0;
     |
-142 | S3Hook()
-143 | provide_bucket_name()
-144 | BaseHook()
+154 | S3Hook()
+155 | provide_bucket_name()
+156 | BaseHook()
     | ^^^^^^^^ AIR303
-145 | DbApiHook2()
-146 | DockerHook()
+157 | DbApiHook2()
+158 | DockerHook()
     |
     = help: Install `apache-airflow-provider-Base>=TBD` and use `BaseHook` instead.
 
-AIR303.py:145:1: AIR303 `airflow.hooks.dbapi_hook.DbApiHook` is moved into `Common Sql` provider in Airflow 3.0;
+AIR303.py:157:1: AIR303 `airflow.hooks.dbapi_hook.DbApiHook` is moved into `Common Sql` provider in Airflow 3.0;
     |
-143 | provide_bucket_name()
-144 | BaseHook()
-145 | DbApiHook2()
+155 | provide_bucket_name()
+156 | BaseHook()
+157 | DbApiHook2()
     | ^^^^^^^^^^ AIR303
-146 | DockerHook()
-147 | DruidDbApiHook()
+158 | DockerHook()
+159 | DruidDbApiHook()
     |
     = help: Install `apache-airflow-provider-Common Sql>=TBD` and use `DbApiHook` instead.
 
-AIR303.py:146:1: AIR303 `airflow.hooks.docker_hook.DockerHook` is moved into `Docker` provider in Airflow 3.0;
+AIR303.py:158:1: AIR303 `airflow.hooks.docker_hook.DockerHook` is moved into `Docker` provider in Airflow 3.0;
     |
-144 | BaseHook()
-145 | DbApiHook2()
-146 | DockerHook()
+156 | BaseHook()
+157 | DbApiHook2()
+158 | DockerHook()
     | ^^^^^^^^^^ AIR303
-147 | DruidDbApiHook()
-148 | DruidHook()
+159 | DruidDbApiHook()
+160 | DruidHook()
     |
     = help: Install `apache-airflow-provider-Docker>=TBD` and use `DockerHook` instead.
 
-AIR303.py:147:1: AIR303 `airflow.hooks.druid_hook.DruidDbApiHook` is moved into `Apache Druid` provider in Airflow 3.0;
+AIR303.py:159:1: AIR303 `airflow.hooks.druid_hook.DruidDbApiHook` is moved into `Apache Druid` provider in Airflow 3.0;
     |
-145 | DbApiHook2()
-146 | DockerHook()
-147 | DruidDbApiHook()
+157 | DbApiHook2()
+158 | DockerHook()
+159 | DruidDbApiHook()
     | ^^^^^^^^^^^^^^ AIR303
-148 | DruidHook()
-149 | HIVE_QUEUE_PRIORITIES()
+160 | DruidHook()
+161 | HIVE_QUEUE_PRIORITIES()
     |
     = help: Install `apache-airflow-provider-Apache Druid>=TBD` and use `DruidDbApiHook` instead.
 
-AIR303.py:148:1: AIR303 `airflow.hooks.druid_hook.DruidHook` is moved into `Apache Druid` provider in Airflow 3.0;
+AIR303.py:160:1: AIR303 `airflow.hooks.druid_hook.DruidHook` is moved into `Apache Druid` provider in Airflow 3.0;
     |
-146 | DockerHook()
-147 | DruidDbApiHook()
-148 | DruidHook()
+158 | DockerHook()
+159 | DruidDbApiHook()
+160 | DruidHook()
     | ^^^^^^^^^ AIR303
-149 | HIVE_QUEUE_PRIORITIES()
-150 | HiveCliHook()
+161 | HIVE_QUEUE_PRIORITIES()
+162 | HiveCliHook()
     |
     = help: Install `apache-airflow-provider-Apache Druid>=TBD` and use `DruidHook` instead.
 
-AIR303.py:149:1: AIR303 `airflow.hooks.hive_hooks.HIVE_QUEUE_PRIORITIES` is moved into `Apache Hive` provider in Airflow 3.0;
+AIR303.py:161:1: AIR303 `airflow.hooks.hive_hooks.HIVE_QUEUE_PRIORITIES` is moved into `Apache Hive` provider in Airflow 3.0;
     |
-147 | DruidDbApiHook()
-148 | DruidHook()
-149 | HIVE_QUEUE_PRIORITIES()
+159 | DruidDbApiHook()
+160 | DruidHook()
+161 | HIVE_QUEUE_PRIORITIES()
     | ^^^^^^^^^^^^^^^^^^^^^ AIR303
-150 | HiveCliHook()
-151 | HiveMetastoreHook()
+162 | HiveCliHook()
+163 | HiveMetastoreHook()
     |
     = help: Install `apache-airflow-provider-Apache Hive>=1.0.0` and use `HIVE_QUEUE_PRIORITIES` instead.
 
-AIR303.py:150:1: AIR303 `airflow.hooks.hive_hooks.HiveCliHook` is moved into `Apache Hive` provider in Airflow 3.0;
+AIR303.py:162:1: AIR303 `airflow.hooks.hive_hooks.HiveCliHook` is moved into `Apache Hive` provider in Airflow 3.0;
     |
-148 | DruidHook()
-149 | HIVE_QUEUE_PRIORITIES()
-150 | HiveCliHook()
+160 | DruidHook()
+161 | HIVE_QUEUE_PRIORITIES()
+162 | HiveCliHook()
     | ^^^^^^^^^^^ AIR303
-151 | HiveMetastoreHook()
-152 | HiveServer2Hook()
+163 | HiveMetastoreHook()
+164 | HiveServer2Hook()
     |
     = help: Install `apache-airflow-provider-Apache Hive>=TBD` and use `HiveCliHook` instead.
 
-AIR303.py:151:1: AIR303 `airflow.hooks.hive_hooks.HiveMetastoreHook` is moved into `Apache Hive` provider in Airflow 3.0;
+AIR303.py:163:1: AIR303 `airflow.hooks.hive_hooks.HiveMetastoreHook` is moved into `Apache Hive` provider in Airflow 3.0;
     |
-149 | HIVE_QUEUE_PRIORITIES()
-150 | HiveCliHook()
-151 | HiveMetastoreHook()
+161 | HIVE_QUEUE_PRIORITIES()
+162 | HiveCliHook()
+163 | HiveMetastoreHook()
     | ^^^^^^^^^^^^^^^^^ AIR303
-152 | HiveServer2Hook()
-153 | HttpHook()
+164 | HiveServer2Hook()
+165 | HttpHook()
     |
     = help: Install `apache-airflow-provider-Apache Hive>=TBD` and use `HiveMetastoreHook` instead.
 
-AIR303.py:152:1: AIR303 `airflow.hooks.hive_hooks.HiveServer2Hook` is moved into `Apache Hive` provider in Airflow 3.0;
+AIR303.py:164:1: AIR303 `airflow.hooks.hive_hooks.HiveServer2Hook` is moved into `Apache Hive` provider in Airflow 3.0;
     |
-150 | HiveCliHook()
-151 | HiveMetastoreHook()
-152 | HiveServer2Hook()
+162 | HiveCliHook()
+163 | HiveMetastoreHook()
+164 | HiveServer2Hook()
     | ^^^^^^^^^^^^^^^ AIR303
-153 | HttpHook()
-154 | JdbcHook()
+165 | HttpHook()
+166 | JdbcHook()
     |
     = help: Install `apache-airflow-provider-Apache Hive>=TBD` and use `HiveServer2Hook` instead.
 
-AIR303.py:153:1: AIR303 `airflow.hooks.http_hook.HttpHook` is moved into `Http` provider in Airflow 3.0;
+AIR303.py:165:1: AIR303 `airflow.hooks.http_hook.HttpHook` is moved into `Http` provider in Airflow 3.0;
     |
-151 | HiveMetastoreHook()
-152 | HiveServer2Hook()
-153 | HttpHook()
+163 | HiveMetastoreHook()
+164 | HiveServer2Hook()
+165 | HttpHook()
     | ^^^^^^^^ AIR303
-154 | JdbcHook()
-155 | jaydebeapi()
+166 | JdbcHook()
+167 | jaydebeapi()
     |
     = help: Install `apache-airflow-provider-Http>=TBD` and use `HttpHook` instead.
 
-AIR303.py:154:1: AIR303 `airflow.hooks.jdbc_hook.JdbcHook` is moved into `Jdbc` provider in Airflow 3.0;
+AIR303.py:166:1: AIR303 `airflow.hooks.jdbc_hook.JdbcHook` is moved into `Jdbc` provider in Airflow 3.0;
     |
-152 | HiveServer2Hook()
-153 | HttpHook()
-154 | JdbcHook()
+164 | HiveServer2Hook()
+165 | HttpHook()
+166 | JdbcHook()
     | ^^^^^^^^ AIR303
-155 | jaydebeapi()
-156 | MsSqlHook()
+167 | jaydebeapi()
+168 | MsSqlHook()
     |
     = help: Install `apache-airflow-provider-Jdbc>=TBD` and use `JdbcHook` instead.
 
-AIR303.py:155:1: AIR303 `airflow.hooks.jdbc_hook.jaydebeapi` is moved into `Jdbc` provider in Airflow 3.0;
+AIR303.py:167:1: AIR303 `airflow.hooks.jdbc_hook.jaydebeapi` is moved into `Jdbc` provider in Airflow 3.0;
     |
-153 | HttpHook()
-154 | JdbcHook()
-155 | jaydebeapi()
+165 | HttpHook()
+166 | JdbcHook()
+167 | jaydebeapi()
     | ^^^^^^^^^^ AIR303
-156 | MsSqlHook()
-157 | MySqlHook()
+168 | MsSqlHook()
+169 | MySqlHook()
     |
     = help: Install `apache-airflow-provider-Jdbc>=TBD` and use `jaydebeapi` instead.
 
-AIR303.py:156:1: AIR303 `airflow.hooks.mssql_hook.MsSqlHook` is moved into `Microsoft` provider in Airflow 3.0;
+AIR303.py:168:1: AIR303 `airflow.hooks.mssql_hook.MsSqlHook` is moved into `Microsoft` provider in Airflow 3.0;
     |
-154 | JdbcHook()
-155 | jaydebeapi()
-156 | MsSqlHook()
+166 | JdbcHook()
+167 | jaydebeapi()
+168 | MsSqlHook()
     | ^^^^^^^^^ AIR303
-157 | MySqlHook()
-158 | OracleHook()
+169 | MySqlHook()
+170 | OracleHook()
     |
     = help: Install `apache-airflow-provider-Microsoft>=TBD` and use `MsSqlHook` instead.
 
-AIR303.py:157:1: AIR303 `airflow.hooks.mysql_hook.MySqlHook` is moved into `Mysql` provider in Airflow 3.0;
+AIR303.py:169:1: AIR303 `airflow.hooks.mysql_hook.MySqlHook` is moved into `Mysql` provider in Airflow 3.0;
     |
-155 | jaydebeapi()
-156 | MsSqlHook()
-157 | MySqlHook()
+167 | jaydebeapi()
+168 | MsSqlHook()
+169 | MySqlHook()
     | ^^^^^^^^^ AIR303
-158 | OracleHook()
-159 | PigCliHook()
+170 | OracleHook()
+171 | PigCliHook()
     |
     = help: Install `apache-airflow-provider-Mysql>=TBD` and use `MySqlHook` instead.
 
-AIR303.py:158:1: AIR303 `airflow.hooks.oracle_hook.OracleHook` is moved into `Oracle` provider in Airflow 3.0;
+AIR303.py:170:1: AIR303 `airflow.hooks.oracle_hook.OracleHook` is moved into `Oracle` provider in Airflow 3.0;
     |
-156 | MsSqlHook()
-157 | MySqlHook()
-158 | OracleHook()
+168 | MsSqlHook()
+169 | MySqlHook()
+170 | OracleHook()
     | ^^^^^^^^^^ AIR303
-159 | PigCliHook()
-160 | PostgresHook()
+171 | PigCliHook()
+172 | PostgresHook()
     |
     = help: Install `apache-airflow-provider-Oracle>=TBD` and use `OracleHook` instead.
 
-AIR303.py:159:1: AIR303 `airflow.hooks.pig_hook.PigCliHook` is moved into `Apache Pig` provider in Airflow 3.0;
+AIR303.py:171:1: AIR303 `airflow.hooks.pig_hook.PigCliHook` is moved into `Apache Pig` provider in Airflow 3.0;
     |
-157 | MySqlHook()
-158 | OracleHook()
-159 | PigCliHook()
+169 | MySqlHook()
+170 | OracleHook()
+171 | PigCliHook()
     | ^^^^^^^^^^ AIR303
-160 | PostgresHook()
-161 | PrestoHook()
+172 | PostgresHook()
+173 | PrestoHook()
     |
     = help: Install `apache-airflow-provider-Apache Pig>=TBD` and use `PigCliHook` instead.
 
-AIR303.py:160:1: AIR303 `airflow.hooks.postgres_hook.PostgresHook` is moved into `Postgres` provider in Airflow 3.0;
+AIR303.py:172:1: AIR303 `airflow.hooks.postgres_hook.PostgresHook` is moved into `Postgres` provider in Airflow 3.0;
     |
-158 | OracleHook()
-159 | PigCliHook()
-160 | PostgresHook()
+170 | OracleHook()
+171 | PigCliHook()
+172 | PostgresHook()
     | ^^^^^^^^^^^^ AIR303
-161 | PrestoHook()
-162 | SambaHook()
+173 | PrestoHook()
+174 | SambaHook()
     |
     = help: Install `apache-airflow-provider-Postgres>=TBD` and use `PostgresHook` instead.
 
-AIR303.py:161:1: AIR303 `airflow.hooks.presto_hook.PrestoHook` is moved into `Presto` provider in Airflow 3.0;
+AIR303.py:173:1: AIR303 `airflow.hooks.presto_hook.PrestoHook` is moved into `Presto` provider in Airflow 3.0;
     |
-159 | PigCliHook()
-160 | PostgresHook()
-161 | PrestoHook()
+171 | PigCliHook()
+172 | PostgresHook()
+173 | PrestoHook()
     | ^^^^^^^^^^ AIR303
-162 | SambaHook()
-163 | SlackHook()
+174 | SambaHook()
+175 | SlackHook()
     |
     = help: Install `apache-airflow-provider-Presto>=TBD` and use `PrestoHook` instead.
 
-AIR303.py:162:1: AIR303 `airflow.hooks.samba_hook.SambaHook` is moved into `Samba` provider in Airflow 3.0;
+AIR303.py:174:1: AIR303 `airflow.hooks.samba_hook.SambaHook` is moved into `Samba` provider in Airflow 3.0;
     |
-160 | PostgresHook()
-161 | PrestoHook()
-162 | SambaHook()
+172 | PostgresHook()
+173 | PrestoHook()
+174 | SambaHook()
     | ^^^^^^^^^ AIR303
-163 | SlackHook()
-164 | SqliteHook()
+175 | SlackHook()
+176 | SqliteHook()
     |
     = help: Install `apache-airflow-provider-Samba>=TBD` and use `SambaHook` instead.
 
-AIR303.py:163:1: AIR303 `airflow.hooks.slack_hook.SlackHook` is moved into `Slack` provider in Airflow 3.0;
+AIR303.py:175:1: AIR303 `airflow.hooks.slack_hook.SlackHook` is moved into `Slack` provider in Airflow 3.0;
     |
-161 | PrestoHook()
-162 | SambaHook()
-163 | SlackHook()
+173 | PrestoHook()
+174 | SambaHook()
+175 | SlackHook()
     | ^^^^^^^^^ AIR303
-164 | SqliteHook()
-165 | WebHDFSHook()
+176 | SqliteHook()
+177 | WebHDFSHook()
     |
     = help: Install `apache-airflow-provider-Slack>=TBD` and use `SlackHook` instead.
 
-AIR303.py:164:1: AIR303 `airflow.hooks.sqlite_hook.SqliteHook` is moved into `Sqlite` provider in Airflow 3.0;
+AIR303.py:176:1: AIR303 `airflow.hooks.sqlite_hook.SqliteHook` is moved into `Sqlite` provider in Airflow 3.0;
     |
-162 | SambaHook()
-163 | SlackHook()
-164 | SqliteHook()
+174 | SambaHook()
+175 | SlackHook()
+176 | SqliteHook()
     | ^^^^^^^^^^ AIR303
-165 | WebHDFSHook()
-166 | ZendeskHook()
+177 | WebHDFSHook()
+178 | ZendeskHook()
     |
     = help: Install `apache-airflow-provider-Sqlite>=TBD` and use `SqliteHook` instead.
 
-AIR303.py:165:1: AIR303 `airflow.hooks.webhdfs_hook.WebHDFSHook` is moved into `Apache Hdfs` provider in Airflow 3.0;
+AIR303.py:177:1: AIR303 `airflow.hooks.webhdfs_hook.WebHDFSHook` is moved into `Apache Hdfs` provider in Airflow 3.0;
     |
-163 | SlackHook()
-164 | SqliteHook()
-165 | WebHDFSHook()
+175 | SlackHook()
+176 | SqliteHook()
+177 | WebHDFSHook()
     | ^^^^^^^^^^^ AIR303
-166 | ZendeskHook()
+178 | ZendeskHook()
     |
     = help: Install `apache-airflow-provider-Apache Hdfs>=TBD` and use `WebHDFSHook` instead.
 
-AIR303.py:166:1: AIR303 `airflow.hooks.zendesk_hook.ZendeskHook` is moved into `Zendesk` provider in Airflow 3.0;
+AIR303.py:178:1: AIR303 `airflow.hooks.zendesk_hook.ZendeskHook` is moved into `Zendesk` provider in Airflow 3.0;
     |
-164 | SqliteHook()
-165 | WebHDFSHook()
-166 | ZendeskHook()
+176 | SqliteHook()
+177 | WebHDFSHook()
+178 | ZendeskHook()
     | ^^^^^^^^^^^ AIR303
-167 | 
-168 | SQLCheckOperator()
+179 | 
+180 | SQLCheckOperator()
     |
     = help: Install `apache-airflow-provider-Zendesk>=TBD` and use `ZendeskHook` instead.
 
-AIR303.py:168:1: AIR303 `airflow.operators.sql.SQLCheckOperator` is moved into `Common Sql` provider in Airflow 3.0;
+AIR303.py:180:1: AIR303 `airflow.operators.check_operator.SQLCheckOperator` is moved into `Common Sql` provider in Airflow 3.0;
     |
-166 | ZendeskHook()
-167 | 
-168 | SQLCheckOperator()
+178 | ZendeskHook()
+179 | 
+180 | SQLCheckOperator()
     | ^^^^^^^^^^^^^^^^ AIR303
-169 | SQLIntervalCheckOperator()
-170 | SQLThresholdCheckOperator()
+181 | SQLIntervalCheckOperator()
+182 | SQLThresholdCheckOperator()
     |
     = help: Install `apache-airflow-provider-Common Sql>=TBD` and use `SQLCheckOperator` instead.
 
-AIR303.py:169:1: AIR303 `airflow.operators.sql.SQLIntervalCheckOperator` is moved into `Common Sql` provider in Airflow 3.0;
+AIR303.py:181:1: AIR303 `airflow.operators.check_operator.SQLIntervalCheckOperator` is moved into `Common Sql` provider in Airflow 3.0;
     |
-168 | SQLCheckOperator()
-169 | SQLIntervalCheckOperator()
+180 | SQLCheckOperator()
+181 | SQLIntervalCheckOperator()
     | ^^^^^^^^^^^^^^^^^^^^^^^^ AIR303
-170 | SQLThresholdCheckOperator()
-171 | SQLValueCheckOperator()
+182 | SQLThresholdCheckOperator()
+183 | SQLValueCheckOperator()
     |
     = help: Install `apache-airflow-provider-Common Sql>=TBD` and use `SQLIntervalCheckOperator` instead.
 
-AIR303.py:170:1: AIR303 `airflow.operators.sql.SQLThresholdCheckOperator` is moved into `Common Sql` provider in Airflow 3.0;
+AIR303.py:182:1: AIR303 `airflow.operators.check_operator.SQLThresholdCheckOperator` is moved into `Common Sql` provider in Airflow 3.0;
     |
-168 | SQLCheckOperator()
-169 | SQLIntervalCheckOperator()
-170 | SQLThresholdCheckOperator()
+180 | SQLCheckOperator()
+181 | SQLIntervalCheckOperator()
+182 | SQLThresholdCheckOperator()
     | ^^^^^^^^^^^^^^^^^^^^^^^^^ AIR303
-171 | SQLValueCheckOperator()
-172 | CheckOperator()
+183 | SQLValueCheckOperator()
+184 | CheckOperator()
     |
     = help: Install `apache-airflow-provider-Common Sql>=TBD` and use `SQLThresholdCheckOperator` instead.
 
-AIR303.py:171:1: AIR303 `airflow.operators.sql.SQLValueCheckOperator` is moved into `Common Sql` provider in Airflow 3.0;
+AIR303.py:183:1: AIR303 `airflow.operators.check_operator.SQLValueCheckOperator` is moved into `Common Sql` provider in Airflow 3.0;
     |
-169 | SQLIntervalCheckOperator()
-170 | SQLThresholdCheckOperator()
-171 | SQLValueCheckOperator()
+181 | SQLIntervalCheckOperator()
+182 | SQLThresholdCheckOperator()
+183 | SQLValueCheckOperator()
     | ^^^^^^^^^^^^^^^^^^^^^ AIR303
-172 | CheckOperator()
-173 | IntervalCheckOperator()
+184 | CheckOperator()
+185 | IntervalCheckOperator()
     |
     = help: Install `apache-airflow-provider-Common Sql>=TBD` and use `SQLValueCheckOperator` instead.
 
-AIR303.py:172:1: AIR303 `airflow.operators.check_operator.CheckOperator` is moved into `Common Sql` provider in Airflow 3.0;
+AIR303.py:184:1: AIR303 `airflow.operators.check_operator.CheckOperator` is moved into `Common Sql` provider in Airflow 3.0;
     |
-170 | SQLThresholdCheckOperator()
-171 | SQLValueCheckOperator()
-172 | CheckOperator()
+182 | SQLThresholdCheckOperator()
+183 | SQLValueCheckOperator()
+184 | CheckOperator()
     | ^^^^^^^^^^^^^ AIR303
-173 | IntervalCheckOperator()
-174 | ThresholdCheckOperator()
+185 | IntervalCheckOperator()
+186 | ThresholdCheckOperator()
     |
     = help: Install `apache-airflow-provider-Common Sql>=TBD` and use `CheckOperator` instead.
 
-AIR303.py:173:1: AIR303 `airflow.operators.check_operator.IntervalCheckOperator` is moved into `Common Sql` provider in Airflow 3.0;
+AIR303.py:185:1: AIR303 `airflow.operators.check_operator.IntervalCheckOperator` is moved into `Common Sql` provider in Airflow 3.0;
     |
-171 | SQLValueCheckOperator()
-172 | CheckOperator()
-173 | IntervalCheckOperator()
+183 | SQLValueCheckOperator()
+184 | CheckOperator()
+185 | IntervalCheckOperator()
     | ^^^^^^^^^^^^^^^^^^^^^ AIR303
-174 | ThresholdCheckOperator()
-175 | ValueCheckOperator()
+186 | ThresholdCheckOperator()
+187 | ValueCheckOperator()
     |
     = help: Install `apache-airflow-provider-Common Sql>=TBD` and use `IntervalCheckOperator` instead.
 
-AIR303.py:174:1: AIR303 `airflow.operators.check_operator.ThresholdCheckOperator` is moved into `Common Sql` provider in Airflow 3.0;
+AIR303.py:186:1: AIR303 `airflow.operators.check_operator.ThresholdCheckOperator` is moved into `Common Sql` provider in Airflow 3.0;
     |
-172 | CheckOperator()
-173 | IntervalCheckOperator()
-174 | ThresholdCheckOperator()
+184 | CheckOperator()
+185 | IntervalCheckOperator()
+186 | ThresholdCheckOperator()
     | ^^^^^^^^^^^^^^^^^^^^^^ AIR303
-175 | ValueCheckOperator()
-176 | DockerOperator()
+187 | ValueCheckOperator()
+188 | DockerOperator()
     |
     = help: Install `apache-airflow-provider-Common Sql>=TBD` and use `ThresholdCheckOperator` instead.
 
-AIR303.py:175:1: AIR303 `airflow.operators.check_operator.ValueCheckOperator` is moved into `Common Sql` provider in Airflow 3.0;
+AIR303.py:187:1: AIR303 `airflow.operators.check_operator.ValueCheckOperator` is moved into `Common Sql` provider in Airflow 3.0;
     |
-173 | IntervalCheckOperator()
-174 | ThresholdCheckOperator()
-175 | ValueCheckOperator()
+185 | IntervalCheckOperator()
+186 | ThresholdCheckOperator()
+187 | ValueCheckOperator()
     | ^^^^^^^^^^^^^^^^^^ AIR303
-176 | DockerOperator()
-177 | DruidCheckOperator()
+188 | DockerOperator()
+189 | DruidCheckOperator()
     |
     = help: Install `apache-airflow-provider-Common Sql>=TBD` and use `ValueCheckOperator` instead.
 
-AIR303.py:176:1: AIR303 `airflow.operators.docker_operator.DockerOperator` is moved into `Docker` provider in Airflow 3.0;
+AIR303.py:188:1: AIR303 `airflow.operators.docker_operator.DockerOperator` is moved into `Docker` provider in Airflow 3.0;
     |
-174 | ThresholdCheckOperator()
-175 | ValueCheckOperator()
-176 | DockerOperator()
+186 | ThresholdCheckOperator()
+187 | ValueCheckOperator()
+188 | DockerOperator()
     | ^^^^^^^^^^^^^^ AIR303
-177 | DruidCheckOperator()
-178 | GCSToS3Operator()
+189 | DruidCheckOperator()
+190 | GCSToS3Operator()
     |
     = help: Install `apache-airflow-provider-Docker>=TBD` and use `DockerOperator` instead.
 
-AIR303.py:177:1: AIR303 `airflow.operators.druid_check_operator.DruidCheckOperator` is moved into `Apache Druid` provider in Airflow 3.0;
+AIR303.py:189:1: AIR303 `airflow.operators.druid_check_operator.DruidCheckOperator` is moved into `Apache Druid` provider in Airflow 3.0;
     |
-175 | ValueCheckOperator()
-176 | DockerOperator()
-177 | DruidCheckOperator()
+187 | ValueCheckOperator()
+188 | DockerOperator()
+189 | DruidCheckOperator()
     | ^^^^^^^^^^^^^^^^^^ AIR303
-178 | GCSToS3Operator()
-179 | GoogleApiToS3Operator()
+190 | GCSToS3Operator()
+191 | GoogleApiToS3Operator()
     |
     = help: Install `apache-airflow-provider-Apache Druid>=TBD` and use `DruidCheckOperator` instead.
 
-AIR303.py:178:1: AIR303 `airflow.operators.gcs_to_s3.GCSToS3Operator` is moved into `Amazon` provider in Airflow 3.0;
+AIR303.py:190:1: AIR303 `airflow.operators.gcs_to_s3.GCSToS3Operator` is moved into `Amazon` provider in Airflow 3.0;
     |
-176 | DockerOperator()
-177 | DruidCheckOperator()
-178 | GCSToS3Operator()
+188 | DockerOperator()
+189 | DruidCheckOperator()
+190 | GCSToS3Operator()
     | ^^^^^^^^^^^^^^^ AIR303
-179 | GoogleApiToS3Operator()
-180 | GoogleApiToS3Transfer()
+191 | GoogleApiToS3Operator()
+192 | GoogleApiToS3Transfer()
     |
     = help: Install `apache-airflow-provider-Amazon>=TBD` and use `GCSToS3Operator` instead.
 
-AIR303.py:179:1: AIR303 `airflow.operators.google_api_to_s3_transfer.GoogleApiToS3Operator` is moved into `Amazon` provider in Airflow 3.0;
+AIR303.py:191:1: AIR303 `airflow.operators.google_api_to_s3_transfer.GoogleApiToS3Operator` is moved into `Amazon` provider in Airflow 3.0;
     |
-177 | DruidCheckOperator()
-178 | GCSToS3Operator()
-179 | GoogleApiToS3Operator()
+189 | DruidCheckOperator()
+190 | GCSToS3Operator()
+191 | GoogleApiToS3Operator()
     | ^^^^^^^^^^^^^^^^^^^^^ AIR303
-180 | GoogleApiToS3Transfer()
-181 | HiveOperator()
+192 | GoogleApiToS3Transfer()
+193 | HiveOperator()
     |
     = help: Install `apache-airflow-provider-Amazon>=TBD` and use `GoogleApiToS3Operator` instead.
 
-AIR303.py:180:1: AIR303 `airflow.operators.google_api_to_s3_transfer.GoogleApiToS3Transfer` is moved into `Amazon` provider in Airflow 3.0;
+AIR303.py:192:1: AIR303 `airflow.operators.google_api_to_s3_transfer.GoogleApiToS3Transfer` is moved into `Amazon` provider in Airflow 3.0;
     |
-178 | GCSToS3Operator()
-179 | GoogleApiToS3Operator()
-180 | GoogleApiToS3Transfer()
+190 | GCSToS3Operator()
+191 | GoogleApiToS3Operator()
+192 | GoogleApiToS3Transfer()
     | ^^^^^^^^^^^^^^^^^^^^^ AIR303
-181 | HiveOperator()
-182 | HiveStatsCollectionOperator()
+193 | HiveOperator()
+194 | HiveStatsCollectionOperator()
     |
     = help: Install `apache-airflow-provider-Amazon>=TBD` and use `GoogleApiToS3Transfer` instead.
 
-AIR303.py:181:1: AIR303 `airflow.operators.hive_operator.HiveOperator` is moved into `Apache Hive` provider in Airflow 3.0;
+AIR303.py:193:1: AIR303 `airflow.operators.hive_operator.HiveOperator` is moved into `Apache Hive` provider in Airflow 3.0;
     |
-179 | GoogleApiToS3Operator()
-180 | GoogleApiToS3Transfer()
-181 | HiveOperator()
+191 | GoogleApiToS3Operator()
+192 | GoogleApiToS3Transfer()
+193 | HiveOperator()
     | ^^^^^^^^^^^^ AIR303
-182 | HiveStatsCollectionOperator()
-183 | HiveToDruidOperator()
+194 | HiveStatsCollectionOperator()
+195 | HiveToDruidOperator()
     |
     = help: Install `apache-airflow-provider-Apache Hive>=TBD` and use `HiveOperator` instead.
 
-AIR303.py:182:1: AIR303 `airflow.operators.hive_stats_operator.HiveStatsCollectionOperator` is moved into `Apache Hive` provider in Airflow 3.0;
+AIR303.py:194:1: AIR303 `airflow.operators.hive_stats_operator.HiveStatsCollectionOperator` is moved into `Apache Hive` provider in Airflow 3.0;
     |
-180 | GoogleApiToS3Transfer()
-181 | HiveOperator()
-182 | HiveStatsCollectionOperator()
+192 | GoogleApiToS3Transfer()
+193 | HiveOperator()
+194 | HiveStatsCollectionOperator()
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR303
-183 | HiveToDruidOperator()
-184 | HiveToDruidTransfer()
+195 | HiveToDruidOperator()
+196 | HiveToDruidTransfer()
     |
     = help: Install `apache-airflow-provider-Apache Hive>=TBD` and use `HiveStatsCollectionOperator` instead.
 
-AIR303.py:183:1: AIR303 `airflow.operators.hive_to_druid.HiveToDruidOperator` is moved into `Apache Druid` provider in Airflow 3.0;
+AIR303.py:195:1: AIR303 `airflow.operators.hive_to_druid.HiveToDruidOperator` is moved into `Apache Druid` provider in Airflow 3.0;
     |
-181 | HiveOperator()
-182 | HiveStatsCollectionOperator()
-183 | HiveToDruidOperator()
+193 | HiveOperator()
+194 | HiveStatsCollectionOperator()
+195 | HiveToDruidOperator()
     | ^^^^^^^^^^^^^^^^^^^ AIR303
-184 | HiveToDruidTransfer()
-185 | HiveToMySqlOperator()
+196 | HiveToDruidTransfer()
+197 | HiveToMySqlOperator()
     |
     = help: Install `apache-airflow-provider-Apache Druid>=TBD` and use `HiveToDruidOperator` instead.
 
-AIR303.py:184:1: AIR303 `airflow.operators.hive_to_druid.HiveToDruidTransfer` is moved into `Apache Druid` provider in Airflow 3.0;
+AIR303.py:196:1: AIR303 `airflow.operators.hive_to_druid.HiveToDruidTransfer` is moved into `Apache Druid` provider in Airflow 3.0;
     |
-182 | HiveStatsCollectionOperator()
-183 | HiveToDruidOperator()
-184 | HiveToDruidTransfer()
+194 | HiveStatsCollectionOperator()
+195 | HiveToDruidOperator()
+196 | HiveToDruidTransfer()
     | ^^^^^^^^^^^^^^^^^^^ AIR303
-185 | HiveToMySqlOperator()
-186 | HiveToMySqlTransfer()
+197 | HiveToMySqlOperator()
+198 | HiveToMySqlTransfer()
     |
     = help: Install `apache-airflow-provider-Apache Druid>=TBD` and use `HiveToDruidTransfer` instead.
 
-AIR303.py:185:1: AIR303 `airflow.operators.hive_to_mysql.HiveToMySqlOperator` is moved into `Apache Hive` provider in Airflow 3.0;
+AIR303.py:197:1: AIR303 `airflow.operators.hive_to_mysql.HiveToMySqlOperator` is moved into `Apache Hive` provider in Airflow 3.0;
     |
-183 | HiveToDruidOperator()
-184 | HiveToDruidTransfer()
-185 | HiveToMySqlOperator()
+195 | HiveToDruidOperator()
+196 | HiveToDruidTransfer()
+197 | HiveToMySqlOperator()
     | ^^^^^^^^^^^^^^^^^^^ AIR303
-186 | HiveToMySqlTransfer()
-187 | HiveToSambaOperator()
+198 | HiveToMySqlTransfer()
+199 | HiveToSambaOperator()
     |
     = help: Install `apache-airflow-provider-Apache Hive>=TBD` and use `HiveToMySqlOperator` instead.
 
-AIR303.py:186:1: AIR303 `airflow.operators.hive_to_mysql.HiveToMySqlTransfer` is moved into `Apache Hive` provider in Airflow 3.0;
+AIR303.py:198:1: AIR303 `airflow.operators.hive_to_mysql.HiveToMySqlTransfer` is moved into `Apache Hive` provider in Airflow 3.0;
     |
-184 | HiveToDruidTransfer()
-185 | HiveToMySqlOperator()
-186 | HiveToMySqlTransfer()
+196 | HiveToDruidTransfer()
+197 | HiveToMySqlOperator()
+198 | HiveToMySqlTransfer()
     | ^^^^^^^^^^^^^^^^^^^ AIR303
-187 | HiveToSambaOperator()
-188 | SimpleHttpOperator()
+199 | HiveToSambaOperator()
+200 | SimpleHttpOperator()
     |
     = help: Install `apache-airflow-provider-Apache Hive>=TBD` and use `HiveToMySqlTransfer` instead.
 
-AIR303.py:187:1: AIR303 `airflow.operators.hive_to_samba_operator.HiveToSambaOperator` is moved into `Apache Hive` provider in Airflow 3.0;
+AIR303.py:199:1: AIR303 `airflow.operators.hive_to_samba_operator.HiveToSambaOperator` is moved into `Apache Hive` provider in Airflow 3.0;
     |
-185 | HiveToMySqlOperator()
-186 | HiveToMySqlTransfer()
-187 | HiveToSambaOperator()
+197 | HiveToMySqlOperator()
+198 | HiveToMySqlTransfer()
+199 | HiveToSambaOperator()
     | ^^^^^^^^^^^^^^^^^^^ AIR303
-188 | SimpleHttpOperator()
-189 | JdbcOperator()
+200 | SimpleHttpOperator()
+201 | JdbcOperator()
     |
     = help: Install `apache-airflow-provider-Apache Hive>=TBD` and use `HiveToSambaOperator` instead.
 
-AIR303.py:188:1: AIR303 `airflow.operators.http_operator.SimpleHttpOperator` is moved into `Http` provider in Airflow 3.0;
+AIR303.py:200:1: AIR303 `airflow.operators.http_operator.SimpleHttpOperator` is moved into `Http` provider in Airflow 3.0;
     |
-186 | HiveToMySqlTransfer()
-187 | HiveToSambaOperator()
-188 | SimpleHttpOperator()
+198 | HiveToMySqlTransfer()
+199 | HiveToSambaOperator()
+200 | SimpleHttpOperator()
     | ^^^^^^^^^^^^^^^^^^ AIR303
-189 | JdbcOperator()
-190 | LatestOnlyOperator()
+201 | JdbcOperator()
+202 | LatestOnlyOperator()
     |
     = help: Install `apache-airflow-provider-Http>=TBD` and use `SimpleHttpOperator` instead.
 
-AIR303.py:189:1: AIR303 `airflow.operators.jdbc_operator.JdbcOperator` is moved into `Jdbc` provider in Airflow 3.0;
+AIR303.py:201:1: AIR303 `airflow.operators.jdbc_operator.JdbcOperator` is moved into `Jdbc` provider in Airflow 3.0;
     |
-187 | HiveToSambaOperator()
-188 | SimpleHttpOperator()
-189 | JdbcOperator()
+199 | HiveToSambaOperator()
+200 | SimpleHttpOperator()
+201 | JdbcOperator()
     | ^^^^^^^^^^^^ AIR303
-190 | LatestOnlyOperator()
-191 | MsSqlOperator()
+202 | LatestOnlyOperator()
+203 | MsSqlOperator()
     |
     = help: Install `apache-airflow-provider-Jdbc>=TBD` and use `JdbcOperator` instead.
 
-AIR303.py:190:1: AIR303 `airflow.operators.latest_only_operator.LatestOnlyOperator` is moved into `Latest_only` provider in Airflow 3.0;
+AIR303.py:202:1: AIR303 `airflow.operators.latest_only_operator.LatestOnlyOperator` is moved into `Latest_only` provider in Airflow 3.0;
     |
-188 | SimpleHttpOperator()
-189 | JdbcOperator()
-190 | LatestOnlyOperator()
+200 | SimpleHttpOperator()
+201 | JdbcOperator()
+202 | LatestOnlyOperator()
     | ^^^^^^^^^^^^^^^^^^ AIR303
-191 | MsSqlOperator()
-192 | MsSqlToHiveOperator()
+203 | MsSqlOperator()
+204 | MsSqlToHiveOperator()
     |
     = help: Install `apache-airflow-provider-Latest_only>=TBD` and use `LatestOnlyOperator` instead.
 
-AIR303.py:191:1: AIR303 `airflow.operators.mssql_operator.MsSqlOperator` is moved into `Microsoft` provider in Airflow 3.0;
+AIR303.py:203:1: AIR303 `airflow.operators.mssql_operator.MsSqlOperator` is moved into `Microsoft` provider in Airflow 3.0;
     |
-189 | JdbcOperator()
-190 | LatestOnlyOperator()
-191 | MsSqlOperator()
+201 | JdbcOperator()
+202 | LatestOnlyOperator()
+203 | MsSqlOperator()
     | ^^^^^^^^^^^^^ AIR303
-192 | MsSqlToHiveOperator()
-193 | MsSqlToHiveTransfer()
+204 | MsSqlToHiveOperator()
+205 | MsSqlToHiveTransfer()
     |
     = help: Install `apache-airflow-provider-Microsoft>=TBD` and use `MsSqlOperator` instead.
 
-AIR303.py:192:1: AIR303 `airflow.operators.mssql_to_hive.MsSqlToHiveOperator` is moved into `Apache Hive` provider in Airflow 3.0;
+AIR303.py:204:1: AIR303 `airflow.operators.mssql_to_hive.MsSqlToHiveOperator` is moved into `Apache Hive` provider in Airflow 3.0;
     |
-190 | LatestOnlyOperator()
-191 | MsSqlOperator()
-192 | MsSqlToHiveOperator()
+202 | LatestOnlyOperator()
+203 | MsSqlOperator()
+204 | MsSqlToHiveOperator()
     | ^^^^^^^^^^^^^^^^^^^ AIR303
-193 | MsSqlToHiveTransfer()
-194 | MySqlOperator()
+205 | MsSqlToHiveTransfer()
+206 | MySqlOperator()
     |
     = help: Install `apache-airflow-provider-Apache Hive>=TBD` and use `MsSqlToHiveOperator` instead.
 
-AIR303.py:193:1: AIR303 `airflow.operators.mssql_to_hive.MsSqlToHiveTransfer` is moved into `Apache Hive` provider in Airflow 3.0;
+AIR303.py:205:1: AIR303 `airflow.operators.mssql_to_hive.MsSqlToHiveTransfer` is moved into `Apache Hive` provider in Airflow 3.0;
     |
-191 | MsSqlOperator()
-192 | MsSqlToHiveOperator()
-193 | MsSqlToHiveTransfer()
+203 | MsSqlOperator()
+204 | MsSqlToHiveOperator()
+205 | MsSqlToHiveTransfer()
     | ^^^^^^^^^^^^^^^^^^^ AIR303
-194 | MySqlOperator()
-195 | MySqlToHiveOperator()
+206 | MySqlOperator()
+207 | MySqlToHiveOperator()
     |
     = help: Install `apache-airflow-provider-Apache Hive>=TBD` and use `MsSqlToHiveTransfer` instead.
 
-AIR303.py:194:1: AIR303 `airflow.operators.mysql_operator.MySqlOperator` is moved into `Mysql` provider in Airflow 3.0;
+AIR303.py:206:1: AIR303 `airflow.operators.mysql_operator.MySqlOperator` is moved into `Mysql` provider in Airflow 3.0;
     |
-192 | MsSqlToHiveOperator()
-193 | MsSqlToHiveTransfer()
-194 | MySqlOperator()
+204 | MsSqlToHiveOperator()
+205 | MsSqlToHiveTransfer()
+206 | MySqlOperator()
     | ^^^^^^^^^^^^^ AIR303
-195 | MySqlToHiveOperator()
-196 | MySqlToHiveTransfer()
+207 | MySqlToHiveOperator()
+208 | MySqlToHiveTransfer()
     |
     = help: Install `apache-airflow-provider-Mysql>=TBD` and use `MySqlOperator` instead.
 
-AIR303.py:195:1: AIR303 `airflow.operators.mysql_to_hive.MySqlToHiveOperator` is moved into `Apache Hive` provider in Airflow 3.0;
+AIR303.py:207:1: AIR303 `airflow.operators.mysql_to_hive.MySqlToHiveOperator` is moved into `Apache Hive` provider in Airflow 3.0;
     |
-193 | MsSqlToHiveTransfer()
-194 | MySqlOperator()
-195 | MySqlToHiveOperator()
+205 | MsSqlToHiveTransfer()
+206 | MySqlOperator()
+207 | MySqlToHiveOperator()
     | ^^^^^^^^^^^^^^^^^^^ AIR303
-196 | MySqlToHiveTransfer()
-197 | OracleOperator()
+208 | MySqlToHiveTransfer()
+209 | OracleOperator()
     |
     = help: Install `apache-airflow-provider-Apache Hive>=TBD` and use `MySqlToHiveOperator` instead.
 
-AIR303.py:196:1: AIR303 `airflow.operators.mysql_to_hive.MySqlToHiveTransfer` is moved into `Apache Hive` provider in Airflow 3.0;
+AIR303.py:208:1: AIR303 `airflow.operators.mysql_to_hive.MySqlToHiveTransfer` is moved into `Apache Hive` provider in Airflow 3.0;
     |
-194 | MySqlOperator()
-195 | MySqlToHiveOperator()
-196 | MySqlToHiveTransfer()
+206 | MySqlOperator()
+207 | MySqlToHiveOperator()
+208 | MySqlToHiveTransfer()
     | ^^^^^^^^^^^^^^^^^^^ AIR303
-197 | OracleOperator()
-198 | PapermillOperator()
+209 | OracleOperator()
+210 | PapermillOperator()
     |
     = help: Install `apache-airflow-provider-Apache Hive>=TBD` and use `MySqlToHiveTransfer` instead.
 
-AIR303.py:197:1: AIR303 `airflow.operators.oracle_operator.OracleOperator` is moved into `Oracle` provider in Airflow 3.0;
+AIR303.py:209:1: AIR303 `airflow.operators.oracle_operator.OracleOperator` is moved into `Oracle` provider in Airflow 3.0;
     |
-195 | MySqlToHiveOperator()
-196 | MySqlToHiveTransfer()
-197 | OracleOperator()
+207 | MySqlToHiveOperator()
+208 | MySqlToHiveTransfer()
+209 | OracleOperator()
     | ^^^^^^^^^^^^^^ AIR303
-198 | PapermillOperator()
-199 | PigOperator()
+210 | PapermillOperator()
+211 | PigOperator()
     |
     = help: Install `apache-airflow-provider-Oracle>=TBD` and use `OracleOperator` instead.
 
-AIR303.py:198:1: AIR303 `airflow.operators.papermill_operator.PapermillOperator` is moved into `Papermill` provider in Airflow 3.0;
+AIR303.py:210:1: AIR303 `airflow.operators.papermill_operator.PapermillOperator` is moved into `Papermill` provider in Airflow 3.0;
     |
-196 | MySqlToHiveTransfer()
-197 | OracleOperator()
-198 | PapermillOperator()
+208 | MySqlToHiveTransfer()
+209 | OracleOperator()
+210 | PapermillOperator()
     | ^^^^^^^^^^^^^^^^^ AIR303
-199 | PigOperator()
-200 | Mapping()
+211 | PigOperator()
+212 | Mapping()
     |
     = help: Install `apache-airflow-provider-Papermill>=TBD` and use `PapermillOperator` instead.
 
-AIR303.py:199:1: AIR303 `airflow.operators.pig_operator.PigOperator` is moved into `Apache Pig` provider in Airflow 3.0;
+AIR303.py:211:1: AIR303 `airflow.operators.pig_operator.PigOperator` is moved into `Apache Pig` provider in Airflow 3.0;
     |
-197 | OracleOperator()
-198 | PapermillOperator()
-199 | PigOperator()
+209 | OracleOperator()
+210 | PapermillOperator()
+211 | PigOperator()
     | ^^^^^^^^^^^ AIR303
-200 | Mapping()
-201 | PostgresOperator()
+212 | Mapping()
+213 | PostgresOperator()
     |
     = help: Install `apache-airflow-provider-Apache Pig>=TBD` and use `PigOperator` instead.
 
-AIR303.py:200:1: AIR303 `airflow.operators.postgres_operator.Mapping` is moved into `Postgres` provider in Airflow 3.0;
+AIR303.py:212:1: AIR303 `airflow.operators.postgres_operator.Mapping` is moved into `Postgres` provider in Airflow 3.0;
     |
-198 | PapermillOperator()
-199 | PigOperator()
-200 | Mapping()
+210 | PapermillOperator()
+211 | PigOperator()
+212 | Mapping()
     | ^^^^^^^ AIR303
-201 | PostgresOperator()
-202 | SQLCheckOperator()
+213 | PostgresOperator()
+214 | SQLCheckOperator2()
     |
     = help: Install `apache-airflow-provider-Postgres>=TBD` and use `Mapping` instead.
 
-AIR303.py:201:1: AIR303 `airflow.operators.postgres_operator.PostgresOperator` is moved into `Postgres` provider in Airflow 3.0;
+AIR303.py:213:1: AIR303 `airflow.operators.postgres_operator.PostgresOperator` is moved into `Postgres` provider in Airflow 3.0;
     |
-199 | PigOperator()
-200 | Mapping()
-201 | PostgresOperator()
+211 | PigOperator()
+212 | Mapping()
+213 | PostgresOperator()
     | ^^^^^^^^^^^^^^^^ AIR303
-202 | SQLCheckOperator()
-203 | SQLIntervalCheckOperator()
+214 | SQLCheckOperator2()
+215 | SQLIntervalCheckOperator2()
     |
     = help: Install `apache-airflow-provider-Postgres>=TBD` and use `PostgresOperator` instead.
 
-AIR303.py:202:1: AIR303 `airflow.operators.sql.SQLCheckOperator` is moved into `Common Sql` provider in Airflow 3.0;
+AIR303.py:214:1: AIR303 `airflow.operators.presto_check_operator.SQLCheckOperator` is moved into `Common Sql` provider in Airflow 3.0;
     |
-200 | Mapping()
-201 | PostgresOperator()
-202 | SQLCheckOperator()
-    | ^^^^^^^^^^^^^^^^ AIR303
-203 | SQLIntervalCheckOperator()
-204 | SQLValueCheckOperator()
+212 | Mapping()
+213 | PostgresOperator()
+214 | SQLCheckOperator2()
+    | ^^^^^^^^^^^^^^^^^ AIR303
+215 | SQLIntervalCheckOperator2()
+216 | SQLValueCheckOperator2()
     |
     = help: Install `apache-airflow-provider-Common Sql>=TBD` and use `SQLCheckOperator` instead.
 
-AIR303.py:203:1: AIR303 `airflow.operators.sql.SQLIntervalCheckOperator` is moved into `Common Sql` provider in Airflow 3.0;
+AIR303.py:215:1: AIR303 `airflow.operators.presto_check_operator.SQLIntervalCheckOperator` is moved into `Common Sql` provider in Airflow 3.0;
     |
-201 | PostgresOperator()
-202 | SQLCheckOperator()
-203 | SQLIntervalCheckOperator()
-    | ^^^^^^^^^^^^^^^^^^^^^^^^ AIR303
-204 | SQLValueCheckOperator()
-205 | PrestoCheckOperator()
+213 | PostgresOperator()
+214 | SQLCheckOperator2()
+215 | SQLIntervalCheckOperator2()
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^ AIR303
+216 | SQLValueCheckOperator2()
+217 | PrestoCheckOperator()
     |
     = help: Install `apache-airflow-provider-Common Sql>=TBD` and use `SQLIntervalCheckOperator` instead.
 
-AIR303.py:204:1: AIR303 `airflow.operators.sql.SQLValueCheckOperator` is moved into `Common Sql` provider in Airflow 3.0;
+AIR303.py:216:1: AIR303 `airflow.operators.presto_check_operator.SQLValueCheckOperator` is moved into `Common Sql` provider in Airflow 3.0;
     |
-202 | SQLCheckOperator()
-203 | SQLIntervalCheckOperator()
-204 | SQLValueCheckOperator()
-    | ^^^^^^^^^^^^^^^^^^^^^ AIR303
-205 | PrestoCheckOperator()
-206 | PrestoIntervalCheckOperator()
+214 | SQLCheckOperator2()
+215 | SQLIntervalCheckOperator2()
+216 | SQLValueCheckOperator2()
+    | ^^^^^^^^^^^^^^^^^^^^^^ AIR303
+217 | PrestoCheckOperator()
+218 | PrestoIntervalCheckOperator()
     |
     = help: Install `apache-airflow-provider-Common Sql>=TBD` and use `SQLValueCheckOperator` instead.
 
-AIR303.py:205:1: AIR303 `airflow.operators.presto_check_operator.PrestoCheckOperator` is moved into `Common Sql` provider in Airflow 3.0;
+AIR303.py:217:1: AIR303 `airflow.operators.presto_check_operator.PrestoCheckOperator` is moved into `Common Sql` provider in Airflow 3.0;
     |
-203 | SQLIntervalCheckOperator()
-204 | SQLValueCheckOperator()
-205 | PrestoCheckOperator()
+215 | SQLIntervalCheckOperator2()
+216 | SQLValueCheckOperator2()
+217 | PrestoCheckOperator()
     | ^^^^^^^^^^^^^^^^^^^ AIR303
-206 | PrestoIntervalCheckOperator()
-207 | PrestoValueCheckOperator()
+218 | PrestoIntervalCheckOperator()
+219 | PrestoValueCheckOperator()
     |
     = help: Install `apache-airflow-provider-Common Sql>=TBD` and use `PrestoCheckOperator` instead.
 
-AIR303.py:206:1: AIR303 `airflow.operators.presto_check_operator.PrestoIntervalCheckOperator` is moved into `Common Sql` provider in Airflow 3.0;
+AIR303.py:218:1: AIR303 `airflow.operators.presto_check_operator.PrestoIntervalCheckOperator` is moved into `Common Sql` provider in Airflow 3.0;
     |
-204 | SQLValueCheckOperator()
-205 | PrestoCheckOperator()
-206 | PrestoIntervalCheckOperator()
+216 | SQLValueCheckOperator2()
+217 | PrestoCheckOperator()
+218 | PrestoIntervalCheckOperator()
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR303
-207 | PrestoValueCheckOperator()
-208 | PrestoToMySqlOperator()
+219 | PrestoValueCheckOperator()
+220 | PrestoToMySqlOperator()
     |
     = help: Install `apache-airflow-provider-Common Sql>=TBD` and use `PrestoIntervalCheckOperator` instead.
 
-AIR303.py:207:1: AIR303 `airflow.operators.presto_check_operator.PrestoValueCheckOperator` is moved into `Common Sql` provider in Airflow 3.0;
+AIR303.py:219:1: AIR303 `airflow.operators.presto_check_operator.PrestoValueCheckOperator` is moved into `Common Sql` provider in Airflow 3.0;
     |
-205 | PrestoCheckOperator()
-206 | PrestoIntervalCheckOperator()
-207 | PrestoValueCheckOperator()
+217 | PrestoCheckOperator()
+218 | PrestoIntervalCheckOperator()
+219 | PrestoValueCheckOperator()
     | ^^^^^^^^^^^^^^^^^^^^^^^^ AIR303
-208 | PrestoToMySqlOperator()
-209 | PrestoToMySqlTransfer()
+220 | PrestoToMySqlOperator()
+221 | PrestoToMySqlTransfer()
     |
     = help: Install `apache-airflow-provider-Common Sql>=TBD` and use `PrestoValueCheckOperator` instead.
 
-AIR303.py:208:1: AIR303 `airflow.operators.presto_to_mysql.PrestoToMySqlOperator` is moved into `Mysql` provider in Airflow 3.0;
+AIR303.py:220:1: AIR303 `airflow.operators.presto_to_mysql.PrestoToMySqlOperator` is moved into `Mysql` provider in Airflow 3.0;
     |
-206 | PrestoIntervalCheckOperator()
-207 | PrestoValueCheckOperator()
-208 | PrestoToMySqlOperator()
+218 | PrestoIntervalCheckOperator()
+219 | PrestoValueCheckOperator()
+220 | PrestoToMySqlOperator()
     | ^^^^^^^^^^^^^^^^^^^^^ AIR303
-209 | PrestoToMySqlTransfer()
-210 | RedshiftToS3Operator()
+221 | PrestoToMySqlTransfer()
+222 | RedshiftToS3Operator()
     |
     = help: Install `apache-airflow-provider-Mysql>=TBD` and use `PrestoToMySqlOperator` instead.
 
-AIR303.py:209:1: AIR303 `airflow.operators.presto_to_mysql.PrestoToMySqlTransfer` is moved into `Mysql` provider in Airflow 3.0;
+AIR303.py:221:1: AIR303 `airflow.operators.presto_to_mysql.PrestoToMySqlTransfer` is moved into `Mysql` provider in Airflow 3.0;
     |
-207 | PrestoValueCheckOperator()
-208 | PrestoToMySqlOperator()
-209 | PrestoToMySqlTransfer()
+219 | PrestoValueCheckOperator()
+220 | PrestoToMySqlOperator()
+221 | PrestoToMySqlTransfer()
     | ^^^^^^^^^^^^^^^^^^^^^ AIR303
-210 | RedshiftToS3Operator()
-211 | RedshiftToS3Transfer()
+222 | RedshiftToS3Operator()
+223 | RedshiftToS3Transfer()
     |
     = help: Install `apache-airflow-provider-Mysql>=TBD` and use `PrestoToMySqlTransfer` instead.
 
-AIR303.py:210:1: AIR303 `airflow.operators.redshift_to_s3_operator.RedshiftToS3Operator` is moved into `Amazon` provider in Airflow 3.0;
+AIR303.py:222:1: AIR303 `airflow.operators.redshift_to_s3_operator.RedshiftToS3Operator` is moved into `Amazon` provider in Airflow 3.0;
     |
-208 | PrestoToMySqlOperator()
-209 | PrestoToMySqlTransfer()
-210 | RedshiftToS3Operator()
+220 | PrestoToMySqlOperator()
+221 | PrestoToMySqlTransfer()
+222 | RedshiftToS3Operator()
     | ^^^^^^^^^^^^^^^^^^^^ AIR303
-211 | RedshiftToS3Transfer()
-212 | S3FileTransformOperator()
+223 | RedshiftToS3Transfer()
+224 | S3FileTransformOperator()
     |
     = help: Install `apache-airflow-provider-Amazon>=TBD` and use `RedshiftToS3Operator` instead.
 
-AIR303.py:211:1: AIR303 `airflow.operators.redshift_to_s3_operator.RedshiftToS3Transfer` is moved into `Amazon` provider in Airflow 3.0;
+AIR303.py:223:1: AIR303 `airflow.operators.redshift_to_s3_operator.RedshiftToS3Transfer` is moved into `Amazon` provider in Airflow 3.0;
     |
-209 | PrestoToMySqlTransfer()
-210 | RedshiftToS3Operator()
-211 | RedshiftToS3Transfer()
+221 | PrestoToMySqlTransfer()
+222 | RedshiftToS3Operator()
+223 | RedshiftToS3Transfer()
     | ^^^^^^^^^^^^^^^^^^^^ AIR303
-212 | S3FileTransformOperator()
-213 | S3ToHiveOperator()
+224 | S3FileTransformOperator()
+225 | S3ToHiveOperator()
     |
     = help: Install `apache-airflow-provider-Amazon>=TBD` and use `RedshiftToS3Transfer` instead.
 
-AIR303.py:212:1: AIR303 `airflow.operators.s3_file_transform_operator.S3FileTransformOperator` is moved into `Amazon` provider in Airflow 3.0;
+AIR303.py:224:1: AIR303 `airflow.operators.s3_file_transform_operator.S3FileTransformOperator` is moved into `Amazon` provider in Airflow 3.0;
     |
-210 | RedshiftToS3Operator()
-211 | RedshiftToS3Transfer()
-212 | S3FileTransformOperator()
+222 | RedshiftToS3Operator()
+223 | RedshiftToS3Transfer()
+224 | S3FileTransformOperator()
     | ^^^^^^^^^^^^^^^^^^^^^^^ AIR303
-213 | S3ToHiveOperator()
-214 | S3ToHiveTransfer()
+225 | S3ToHiveOperator()
+226 | S3ToHiveTransfer()
     |
     = help: Install `apache-airflow-provider-Amazon>=TBD` and use `S3FileTransformOperator` instead.
 
-AIR303.py:213:1: AIR303 `airflow.operators.s3_to_hive_operator.S3ToHiveOperator` is moved into `Apache Hive` provider in Airflow 3.0;
+AIR303.py:225:1: AIR303 `airflow.operators.s3_to_hive_operator.S3ToHiveOperator` is moved into `Apache Hive` provider in Airflow 3.0;
     |
-211 | RedshiftToS3Transfer()
-212 | S3FileTransformOperator()
-213 | S3ToHiveOperator()
+223 | RedshiftToS3Transfer()
+224 | S3FileTransformOperator()
+225 | S3ToHiveOperator()
     | ^^^^^^^^^^^^^^^^ AIR303
-214 | S3ToHiveTransfer()
-215 | S3ToRedshiftOperator()
+226 | S3ToHiveTransfer()
+227 | S3ToRedshiftOperator()
     |
     = help: Install `apache-airflow-provider-Apache Hive>=TBD` and use `S3ToHiveOperator` instead.
 
-AIR303.py:214:1: AIR303 `airflow.operators.s3_to_hive_operator.S3ToHiveTransfer` is moved into `Apache Hive` provider in Airflow 3.0;
+AIR303.py:226:1: AIR303 `airflow.operators.s3_to_hive_operator.S3ToHiveTransfer` is moved into `Apache Hive` provider in Airflow 3.0;
     |
-212 | S3FileTransformOperator()
-213 | S3ToHiveOperator()
-214 | S3ToHiveTransfer()
+224 | S3FileTransformOperator()
+225 | S3ToHiveOperator()
+226 | S3ToHiveTransfer()
     | ^^^^^^^^^^^^^^^^ AIR303
-215 | S3ToRedshiftOperator()
-216 | S3ToRedshiftTransfer()
+227 | S3ToRedshiftOperator()
+228 | S3ToRedshiftTransfer()
     |
     = help: Install `apache-airflow-provider-Apache Hive>=TBD` and use `S3ToHiveTransfer` instead.
 
-AIR303.py:215:1: AIR303 `airflow.operators.s3_to_redshift_operator.S3ToRedshiftOperator` is moved into `Amazon` provider in Airflow 3.0;
+AIR303.py:227:1: AIR303 `airflow.operators.s3_to_redshift_operator.S3ToRedshiftOperator` is moved into `Amazon` provider in Airflow 3.0;
     |
-213 | S3ToHiveOperator()
-214 | S3ToHiveTransfer()
-215 | S3ToRedshiftOperator()
+225 | S3ToHiveOperator()
+226 | S3ToHiveTransfer()
+227 | S3ToRedshiftOperator()
     | ^^^^^^^^^^^^^^^^^^^^ AIR303
-216 | S3ToRedshiftTransfer()
-217 | SlackAPIOperator()
+228 | S3ToRedshiftTransfer()
+229 | SlackAPIOperator()
     |
     = help: Install `apache-airflow-provider-Amazon>=TBD` and use `S3ToRedshiftOperator` instead.
 
-AIR303.py:216:1: AIR303 `airflow.operators.s3_to_redshift_operator.S3ToRedshiftTransfer` is moved into `Amazon` provider in Airflow 3.0;
+AIR303.py:228:1: AIR303 `airflow.operators.s3_to_redshift_operator.S3ToRedshiftTransfer` is moved into `Amazon` provider in Airflow 3.0;
     |
-214 | S3ToHiveTransfer()
-215 | S3ToRedshiftOperator()
-216 | S3ToRedshiftTransfer()
+226 | S3ToHiveTransfer()
+227 | S3ToRedshiftOperator()
+228 | S3ToRedshiftTransfer()
     | ^^^^^^^^^^^^^^^^^^^^ AIR303
-217 | SlackAPIOperator()
-218 | SlackAPIPostOperator()
+229 | SlackAPIOperator()
+230 | SlackAPIPostOperator()
     |
     = help: Install `apache-airflow-provider-Amazon>=TBD` and use `S3ToRedshiftTransfer` instead.
 
-AIR303.py:217:1: AIR303 `airflow.operators.slack_operator.SlackAPIOperator` is moved into `Slack` provider in Airflow 3.0;
+AIR303.py:229:1: AIR303 `airflow.operators.slack_operator.SlackAPIOperator` is moved into `Slack` provider in Airflow 3.0;
     |
-215 | S3ToRedshiftOperator()
-216 | S3ToRedshiftTransfer()
-217 | SlackAPIOperator()
+227 | S3ToRedshiftOperator()
+228 | S3ToRedshiftTransfer()
+229 | SlackAPIOperator()
     | ^^^^^^^^^^^^^^^^ AIR303
-218 | SlackAPIPostOperator()
-219 | BaseSQLOperator()
+230 | SlackAPIPostOperator()
+231 | BaseSQLOperator()
     |
     = help: Install `apache-airflow-provider-Slack>=TBD` and use `SlackAPIOperator` instead.
 
-AIR303.py:218:1: AIR303 `airflow.operators.slack_operator.SlackAPIPostOperator` is moved into `Slack` provider in Airflow 3.0;
+AIR303.py:230:1: AIR303 `airflow.operators.slack_operator.SlackAPIPostOperator` is moved into `Slack` provider in Airflow 3.0;
     |
-216 | S3ToRedshiftTransfer()
-217 | SlackAPIOperator()
-218 | SlackAPIPostOperator()
+228 | S3ToRedshiftTransfer()
+229 | SlackAPIOperator()
+230 | SlackAPIPostOperator()
     | ^^^^^^^^^^^^^^^^^^^^ AIR303
-219 | BaseSQLOperator()
-220 | BranchSQLOperator()
+231 | BaseSQLOperator()
+232 | BranchSQLOperator()
     |
     = help: Install `apache-airflow-provider-Slack>=TBD` and use `SlackAPIPostOperator` instead.
 
-AIR303.py:219:1: AIR303 `airflow.operators.sql.BaseSQLOperator` is moved into `Common Sql` provider in Airflow 3.0;
+AIR303.py:231:1: AIR303 `airflow.operators.sql.BaseSQLOperator` is moved into `Common Sql` provider in Airflow 3.0;
     |
-217 | SlackAPIOperator()
-218 | SlackAPIPostOperator()
-219 | BaseSQLOperator()
+229 | SlackAPIOperator()
+230 | SlackAPIPostOperator()
+231 | BaseSQLOperator()
     | ^^^^^^^^^^^^^^^ AIR303
-220 | BranchSQLOperator()
-221 | SQLCheckOperator()
+232 | BranchSQLOperator()
+233 | SQLCheckOperator3()
     |
     = help: Install `apache-airflow-provider-Common Sql>=TBD` and use `BaseSQLOperator` instead.
 
-AIR303.py:220:1: AIR303 `airflow.operators.sql_branch_operator.BranchSQLOperator` is moved into `Common Sql` provider in Airflow 3.0;
+AIR303.py:232:1: AIR303 `airflow.operators.sql.BranchSQLOperator` is moved into `Common Sql` provider in Airflow 3.0;
     |
-218 | SlackAPIPostOperator()
-219 | BaseSQLOperator()
-220 | BranchSQLOperator()
+230 | SlackAPIPostOperator()
+231 | BaseSQLOperator()
+232 | BranchSQLOperator()
     | ^^^^^^^^^^^^^^^^^ AIR303
-221 | SQLCheckOperator()
-222 | SQLColumnCheckOperator()
+233 | SQLCheckOperator3()
+234 | SQLColumnCheckOperator2()
     |
     = help: Install `apache-airflow-provider-Common Sql>=TBD` and use `BranchSQLOperator` instead.
 
-AIR303.py:221:1: AIR303 `airflow.operators.sql.SQLCheckOperator` is moved into `Common Sql` provider in Airflow 3.0;
+AIR303.py:233:1: AIR303 `airflow.operators.sql.SQLCheckOperator` is moved into `Common Sql` provider in Airflow 3.0;
     |
-219 | BaseSQLOperator()
-220 | BranchSQLOperator()
-221 | SQLCheckOperator()
-    | ^^^^^^^^^^^^^^^^ AIR303
-222 | SQLColumnCheckOperator()
-223 | SQLIntervalCheckOperator()
+231 | BaseSQLOperator()
+232 | BranchSQLOperator()
+233 | SQLCheckOperator3()
+    | ^^^^^^^^^^^^^^^^^ AIR303
+234 | SQLColumnCheckOperator2()
+235 | SQLIntervalCheckOperator3()
     |
     = help: Install `apache-airflow-provider-Common Sql>=TBD` and use `SQLCheckOperator` instead.
 
-AIR303.py:222:1: AIR303 `airflow.operators.sql.SQLColumnCheckOperator` is moved into `Common Sql` provider in Airflow 3.0;
+AIR303.py:234:1: AIR303 `airflow.operators.sql.SQLColumnCheckOperator` is moved into `Common Sql` provider in Airflow 3.0;
     |
-220 | BranchSQLOperator()
-221 | SQLCheckOperator()
-222 | SQLColumnCheckOperator()
-    | ^^^^^^^^^^^^^^^^^^^^^^ AIR303
-223 | SQLIntervalCheckOperator()
-224 | SQLTableCheckOperator()
+232 | BranchSQLOperator()
+233 | SQLCheckOperator3()
+234 | SQLColumnCheckOperator2()
+    | ^^^^^^^^^^^^^^^^^^^^^^^ AIR303
+235 | SQLIntervalCheckOperator3()
+236 | SQLTableCheckOperator()
     |
     = help: Install `apache-airflow-provider-Common Sql>=TBD` and use `SQLColumnCheckOperator` instead.
 
-AIR303.py:223:1: AIR303 `airflow.operators.sql.SQLIntervalCheckOperator` is moved into `Common Sql` provider in Airflow 3.0;
+AIR303.py:235:1: AIR303 `airflow.operators.sql.SQLIntervalCheckOperator` is moved into `Common Sql` provider in Airflow 3.0;
     |
-221 | SQLCheckOperator()
-222 | SQLColumnCheckOperator()
-223 | SQLIntervalCheckOperator()
-    | ^^^^^^^^^^^^^^^^^^^^^^^^ AIR303
-224 | SQLTableCheckOperator()
-225 | SQLThresholdCheckOperator()
+233 | SQLCheckOperator3()
+234 | SQLColumnCheckOperator2()
+235 | SQLIntervalCheckOperator3()
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^ AIR303
+236 | SQLTableCheckOperator()
+237 | SQLThresholdCheckOperator2()
     |
     = help: Install `apache-airflow-provider-Common Sql>=TBD` and use `SQLIntervalCheckOperator` instead.
 
-AIR303.py:224:1: AIR303 `airflow.operators.sql.SQLTableCheckOperator` is moved into `Common Sql` provider in Airflow 3.0;
+AIR303.py:236:1: AIR303 `airflow.operators.sql.SQLTableCheckOperator` is moved into `Common Sql` provider in Airflow 3.0;
     |
-222 | SQLColumnCheckOperator()
-223 | SQLIntervalCheckOperator()
-224 | SQLTableCheckOperator()
+234 | SQLColumnCheckOperator2()
+235 | SQLIntervalCheckOperator3()
+236 | SQLTableCheckOperator()
     | ^^^^^^^^^^^^^^^^^^^^^ AIR303
-225 | SQLThresholdCheckOperator()
-226 | SQLValueCheckOperator()
+237 | SQLThresholdCheckOperator2()
+238 | SQLValueCheckOperator3()
     |
     = help: Install `apache-airflow-provider-Common Sql>=TBD` and use `SQLTableCheckOperator` instead.
 
-AIR303.py:225:1: AIR303 `airflow.operators.sql.SQLThresholdCheckOperator` is moved into `Common Sql` provider in Airflow 3.0;
+AIR303.py:237:1: AIR303 `airflow.operators.sql.SQLThresholdCheckOperator` is moved into `Common Sql` provider in Airflow 3.0;
     |
-223 | SQLIntervalCheckOperator()
-224 | SQLTableCheckOperator()
-225 | SQLThresholdCheckOperator()
-    | ^^^^^^^^^^^^^^^^^^^^^^^^^ AIR303
-226 | SQLValueCheckOperator()
-227 | _convert_to_float_if_possible()
+235 | SQLIntervalCheckOperator3()
+236 | SQLTableCheckOperator()
+237 | SQLThresholdCheckOperator2()
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR303
+238 | SQLValueCheckOperator3()
+239 | _convert_to_float_if_possible()
     |
     = help: Install `apache-airflow-provider-Common Sql>=TBD` and use `SQLThresholdCheckOperator` instead.
 
-AIR303.py:226:1: AIR303 `airflow.operators.sql.SQLValueCheckOperator` is moved into `Common Sql` provider in Airflow 3.0;
+AIR303.py:238:1: AIR303 `airflow.operators.sql.SQLValueCheckOperator` is moved into `Common Sql` provider in Airflow 3.0;
     |
-224 | SQLTableCheckOperator()
-225 | SQLThresholdCheckOperator()
-226 | SQLValueCheckOperator()
-    | ^^^^^^^^^^^^^^^^^^^^^ AIR303
-227 | _convert_to_float_if_possible()
-228 | parse_boolean()
+236 | SQLTableCheckOperator()
+237 | SQLThresholdCheckOperator2()
+238 | SQLValueCheckOperator3()
+    | ^^^^^^^^^^^^^^^^^^^^^^ AIR303
+239 | _convert_to_float_if_possible()
+240 | parse_boolean()
     |
     = help: Install `apache-airflow-provider-Common Sql>=TBD` and use `SQLValueCheckOperator` instead.
 
-AIR303.py:227:1: AIR303 `airflow.operators.sql._convert_to_float_if_possible` is moved into `Common Sql` provider in Airflow 3.0;
+AIR303.py:239:1: AIR303 `airflow.operators.sql._convert_to_float_if_possible` is moved into `Common Sql` provider in Airflow 3.0;
     |
-225 | SQLThresholdCheckOperator()
-226 | SQLValueCheckOperator()
-227 | _convert_to_float_if_possible()
+237 | SQLThresholdCheckOperator2()
+238 | SQLValueCheckOperator3()
+239 | _convert_to_float_if_possible()
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR303
-228 | parse_boolean()
-229 | BranchSQLOperator()
+240 | parse_boolean()
+241 | BranchSQLOperator()
     |
     = help: Install `apache-airflow-provider-Common Sql>=TBD` and use `_convert_to_float_if_possible` instead.
 
-AIR303.py:228:1: AIR303 `airflow.operators.sql.parse_boolean` is moved into `Common Sql` provider in Airflow 3.0;
+AIR303.py:240:1: AIR303 `airflow.operators.sql.parse_boolean` is moved into `Common Sql` provider in Airflow 3.0;
     |
-226 | SQLValueCheckOperator()
-227 | _convert_to_float_if_possible()
-228 | parse_boolean()
+238 | SQLValueCheckOperator3()
+239 | _convert_to_float_if_possible()
+240 | parse_boolean()
     | ^^^^^^^^^^^^^ AIR303
-229 | BranchSQLOperator()
-230 | BranchSqlOperator()
+241 | BranchSQLOperator()
+242 | BranchSqlOperator()
     |
     = help: Install `apache-airflow-provider-Common Sql>=TBD` and use `parse_boolean` instead.
 
-AIR303.py:229:1: AIR303 `airflow.operators.sql_branch_operator.BranchSQLOperator` is moved into `Common Sql` provider in Airflow 3.0;
+AIR303.py:241:1: AIR303 `airflow.operators.sql.BranchSQLOperator` is moved into `Common Sql` provider in Airflow 3.0;
     |
-227 | _convert_to_float_if_possible()
-228 | parse_boolean()
-229 | BranchSQLOperator()
+239 | _convert_to_float_if_possible()
+240 | parse_boolean()
+241 | BranchSQLOperator()
     | ^^^^^^^^^^^^^^^^^ AIR303
-230 | BranchSqlOperator()
-231 | SqliteOperator()
+242 | BranchSqlOperator()
+243 | SqliteOperator()
     |
     = help: Install `apache-airflow-provider-Common Sql>=TBD` and use `BranchSQLOperator` instead.
 
-AIR303.py:230:1: AIR303 `airflow.operators.sql_branch_operator.BranchSqlOperator` is moved into `Common Sql` provider in Airflow 3.0;
+AIR303.py:242:1: AIR303 `airflow.operators.sql_branch_operator.BranchSqlOperator` is moved into `Common Sql` provider in Airflow 3.0;
     |
-228 | parse_boolean()
-229 | BranchSQLOperator()
-230 | BranchSqlOperator()
+240 | parse_boolean()
+241 | BranchSQLOperator()
+242 | BranchSqlOperator()
     | ^^^^^^^^^^^^^^^^^ AIR303
-231 | SqliteOperator()
+243 | SqliteOperator()
+244 | HivePartitionSensor()
     |
     = help: Install `apache-airflow-provider-Common Sql>=TBD` and use `BranchSqlOperator` instead.
 
-AIR303.py:231:1: AIR303 `airflow.operators.sqlite_operator.SqliteOperator` is moved into `Sqlite` provider in Airflow 3.0;
+AIR303.py:243:1: AIR303 `airflow.operators.sqlite_operator.SqliteOperator` is moved into `Sqlite` provider in Airflow 3.0;
     |
-229 | BranchSQLOperator()
-230 | BranchSqlOperator()
-231 | SqliteOperator()
+241 | BranchSQLOperator()
+242 | BranchSqlOperator()
+243 | SqliteOperator()
     | ^^^^^^^^^^^^^^ AIR303
+244 | HivePartitionSensor()
+245 | HttpSensor()
     |
     = help: Install `apache-airflow-provider-Sqlite>=TBD` and use `SqliteOperator` instead.
+
+AIR303.py:244:1: AIR303 `airflow.sensors.hive_partition_sensor.HivePartitionSensor` is moved into `Apache Hive` provider in Airflow 3.0;
+    |
+242 | BranchSqlOperator()
+243 | SqliteOperator()
+244 | HivePartitionSensor()
+    | ^^^^^^^^^^^^^^^^^^^ AIR303
+245 | HttpSensor()
+246 | MetastorePartitionSensor()
+    |
+    = help: Install `apache-airflow-provider-Apache Hive>=TBD` and use `HivePartitionSensor` instead.
+
+AIR303.py:245:1: AIR303 `airflow.sensors.http_sensor.HttpSensor` is moved into `Http` provider in Airflow 3.0;
+    |
+243 | SqliteOperator()
+244 | HivePartitionSensor()
+245 | HttpSensor()
+    | ^^^^^^^^^^ AIR303
+246 | MetastorePartitionSensor()
+247 | NamedHivePartitionSensor()
+    |
+    = help: Install `apache-airflow-provider-Http>=TBD` and use `HttpSensor` instead.
+
+AIR303.py:246:1: AIR303 `airflow.sensors.metastore_partition_sensor.MetastorePartitionSensor` is moved into `Apache Hive` provider in Airflow 3.0;
+    |
+244 | HivePartitionSensor()
+245 | HttpSensor()
+246 | MetastorePartitionSensor()
+    | ^^^^^^^^^^^^^^^^^^^^^^^^ AIR303
+247 | NamedHivePartitionSensor()
+248 | S3KeySensor()
+    |
+    = help: Install `apache-airflow-provider-Apache Hive>=TBD` and use `MetastorePartitionSensor` instead.
+
+AIR303.py:247:1: AIR303 `airflow.sensors.named_hive_partition_sensor.NamedHivePartitionSensor` is moved into `Apache Hive` provider in Airflow 3.0;
+    |
+245 | HttpSensor()
+246 | MetastorePartitionSensor()
+247 | NamedHivePartitionSensor()
+    | ^^^^^^^^^^^^^^^^^^^^^^^^ AIR303
+248 | S3KeySensor()
+249 | SqlSensor()
+    |
+    = help: Install `apache-airflow-provider-Apache Hive>=TBD` and use `NamedHivePartitionSensor` instead.
+
+AIR303.py:248:1: AIR303 `airflow.sensors.s3_key_sensor.S3KeySensor` is moved into `Amazon` provider in Airflow 3.0;
+    |
+246 | MetastorePartitionSensor()
+247 | NamedHivePartitionSensor()
+248 | S3KeySensor()
+    | ^^^^^^^^^^^ AIR303
+249 | SqlSensor()
+250 | SqlSensor2()
+    |
+    = help: Install `apache-airflow-provider-Amazon>=TBD` and use `S3KeySensor` instead.
+
+AIR303.py:249:1: AIR303 `airflow.sensors.sql.SqlSensor` is moved into `Common Sql` provider in Airflow 3.0;
+    |
+247 | NamedHivePartitionSensor()
+248 | S3KeySensor()
+249 | SqlSensor()
+    | ^^^^^^^^^ AIR303
+250 | SqlSensor2()
+251 | WebHdfsSensor()
+    |
+    = help: Install `apache-airflow-provider-Common Sql>=TBD` and use `SqlSensor` instead.
+
+AIR303.py:251:1: AIR303 `airflow.sensors.web_hdfs_sensor.WebHdfsSensor` is moved into `Apache Hdfs` provider in Airflow 3.0;
+    |
+249 | SqlSensor()
+250 | SqlSensor2()
+251 | WebHdfsSensor()
+    | ^^^^^^^^^^^^^ AIR303
+    |
+    = help: Install `apache-airflow-provider-Apache Hdfs>=TBD` and use `WebHdfsSensor` instead.

--- a/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR303_AIR303.py.snap
+++ b/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR303_AIR303.py.snap
@@ -2,195 +2,468 @@
 source: crates/ruff_linter/src/rules/airflow/mod.rs
 snapshot_kind: text
 ---
-AIR303.py:22:1: AIR303 Import path `airflow.api.auth.backend.basic_auth` is moved into `fab` provider in Airflow 3.0;
+AIR303.py:45:1: AIR303 Import path `airflow.api.auth.backend.basic_auth` is moved into `fab` provider in Airflow 3.0;
    |
-21 | # apache-airflow-providers-fab
-22 | basic_auth, kerberos_auth
+44 | # apache-airflow-providers-fab
+45 | basic_auth, kerberos_auth
    | ^^^^^^^^^^ AIR303
-23 | auth_current_user
-24 | backend_kerberos_auth
+46 | auth_current_user
+47 | backend_kerberos_auth
    |
    = help: Install `apache-airflow-provider-fab>=1.0.0` and import from `airflow.providers.fab.auth_manager.api.auth.backend.basic_auth` instead.
 
-AIR303.py:22:13: AIR303 Import path `airflow.api.auth.backend.kerberos_auth` is moved into `fab` provider in Airflow 3.0;
+AIR303.py:45:13: AIR303 Import path `airflow.api.auth.backend.kerberos_auth` is moved into `fab` provider in Airflow 3.0;
    |
-21 | # apache-airflow-providers-fab
-22 | basic_auth, kerberos_auth
+44 | # apache-airflow-providers-fab
+45 | basic_auth, kerberos_auth
    |             ^^^^^^^^^^^^^ AIR303
-23 | auth_current_user
-24 | backend_kerberos_auth
+46 | auth_current_user
+47 | backend_kerberos_auth
    |
    = help: Install `apache-airflow-provider-fab>=1.0.0` and import from `airflow.providers.fab.auth_manager.api.auth.backend.kerberos_auth` instead.
 
-AIR303.py:23:1: AIR303 Import path `airflow.api.auth.backend.basic_auth` is moved into `fab` provider in Airflow 3.0;
+AIR303.py:46:1: AIR303 Import path `airflow.api.auth.backend.basic_auth` is moved into `fab` provider in Airflow 3.0;
    |
-21 | # apache-airflow-providers-fab
-22 | basic_auth, kerberos_auth
-23 | auth_current_user
+44 | # apache-airflow-providers-fab
+45 | basic_auth, kerberos_auth
+46 | auth_current_user
    | ^^^^^^^^^^^^^^^^^ AIR303
-24 | backend_kerberos_auth
-25 | fab_override
+47 | backend_kerberos_auth
+48 | fab_override
    |
    = help: Install `apache-airflow-provider-fab>=1.0.0` and import from `airflow.providers.fab.auth_manager.api.auth.backend.basic_auth` instead.
 
-AIR303.py:24:1: AIR303 Import path `airflow.auth_manager.api.auth.backend.kerberos_auth` is moved into `fab` provider in Airflow 3.0;
+AIR303.py:47:1: AIR303 Import path `airflow.auth_manager.api.auth.backend.kerberos_auth` is moved into `fab` provider in Airflow 3.0;
    |
-22 | basic_auth, kerberos_auth
-23 | auth_current_user
-24 | backend_kerberos_auth
+45 | basic_auth, kerberos_auth
+46 | auth_current_user
+47 | backend_kerberos_auth
    | ^^^^^^^^^^^^^^^^^^^^^ AIR303
-25 | fab_override
+48 | fab_override
    |
    = help: Install `apache-airflow-provider-fab>=1.0.0` and import from `airflow.providers.fab.auth_manager.api.auth.backend.kerberos_auth` instead.
 
-AIR303.py:25:1: AIR303 Import path `airflow.auth.managers.fab.security_managr.override` is moved into `fab` provider in Airflow 3.0;
+AIR303.py:48:1: AIR303 Import path `airflow.auth.managers.fab.security_managr.override` is moved into `fab` provider in Airflow 3.0;
    |
-23 | auth_current_user
-24 | backend_kerberos_auth
-25 | fab_override
+46 | auth_current_user
+47 | backend_kerberos_auth
+48 | fab_override
    | ^^^^^^^^^^^^ AIR303
-26 | 
-27 | FabAuthManager()
+49 | 
+50 | FabAuthManager()
    |
    = help: Install `apache-airflow-provider-fab>=1.0.0` and import from `airflow.providers.fab.auth_manager.security_manager.override` instead.
 
-AIR303.py:27:1: AIR303 `airflow.auth.managers.fab.fab_auth_manager.FabAuthManager` is moved into `fab` provider in Airflow 3.0;
+AIR303.py:50:1: AIR303 `airflow.auth.managers.fab.fab_auth_manager.FabAuthManager` is moved into `fab` provider in Airflow 3.0;
    |
-25 | fab_override
-26 | 
-27 | FabAuthManager()
+48 | fab_override
+49 | 
+50 | FabAuthManager()
    | ^^^^^^^^^^^^^^ AIR303
-28 | FabAirflowSecurityManagerOverride()
+51 | FabAirflowSecurityManagerOverride()
    |
    = help: Install `apache-airflow-provider-fab>=1.0.0` and use `airflow.providers.fab.auth_manager.security_manager.FabAuthManager` instead.
 
-AIR303.py:28:1: AIR303 `airflow.www.security.FabAirflowSecurityManagerOverride` is moved into `fab` provider in Airflow 3.0;
+AIR303.py:51:1: AIR303 `airflow.www.security.FabAirflowSecurityManagerOverride` is moved into `fab` provider in Airflow 3.0;
    |
-27 | FabAuthManager()
-28 | FabAirflowSecurityManagerOverride()
+50 | FabAuthManager()
+51 | FabAirflowSecurityManagerOverride()
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR303
-29 | 
-30 | # apache-airflow-providers-celery
+52 | 
+53 | # apache-airflow-providers-celery
    |
    = help: Install `apache-airflow-provider-fab>=1.0.0` and use `airflow.providers.fab.auth_manager.security_manager.override.FabAirflowSecurityManagerOverride` instead.
 
-AIR303.py:31:1: AIR303 Import path `airflow.config_templates.default_celery.DEFAULT_CELERY_CONFIG` is moved into `celery` provider in Airflow 3.0;
+AIR303.py:54:1: AIR303 Import path `airflow.config_templates.default_celery.DEFAULT_CELERY_CONFIG` is moved into `celery` provider in Airflow 3.0;
    |
-30 | # apache-airflow-providers-celery
-31 | DEFAULT_CELERY_CONFIG
+53 | # apache-airflow-providers-celery
+54 | DEFAULT_CELERY_CONFIG
    | ^^^^^^^^^^^^^^^^^^^^^ AIR303
-32 | app
-33 | CeleryExecutor()
+55 | app
+56 | CeleryExecutor()
    |
    = help: Install `apache-airflow-provider-celery>=3.3.0` and import from `airflow.providers.celery.executors.default_celery.DEFAULT_CELERY_CONFIG` instead.
 
-AIR303.py:32:1: AIR303 Import path `airflow.executors.celery_executor.app` is moved into `celery` provider in Airflow 3.0;
+AIR303.py:55:1: AIR303 Import path `airflow.executors.celery_executor.app` is moved into `celery` provider in Airflow 3.0;
    |
-30 | # apache-airflow-providers-celery
-31 | DEFAULT_CELERY_CONFIG
-32 | app
+53 | # apache-airflow-providers-celery
+54 | DEFAULT_CELERY_CONFIG
+55 | app
    | ^^^ AIR303
-33 | CeleryExecutor()
-34 | CeleryKubernetesExecutor()
+56 | CeleryExecutor()
+57 | CeleryKubernetesExecutor()
    |
    = help: Install `apache-airflow-provider-celery>=3.3.0` and import from `airflow.providers.celery.executors.celery_executor_utils.app` instead.
 
-AIR303.py:33:1: AIR303 `airflow.executors.celery_executor.CeleryExecutor` is moved into `celery` provider in Airflow 3.0;
+AIR303.py:56:1: AIR303 `airflow.executors.celery_executor.CeleryExecutor` is moved into `celery` provider in Airflow 3.0;
    |
-31 | DEFAULT_CELERY_CONFIG
-32 | app
-33 | CeleryExecutor()
+54 | DEFAULT_CELERY_CONFIG
+55 | app
+56 | CeleryExecutor()
    | ^^^^^^^^^^^^^^ AIR303
-34 | CeleryKubernetesExecutor()
+57 | CeleryKubernetesExecutor()
    |
    = help: Install `apache-airflow-provider-celery>=3.3.0` and use `airflow.providers.celery.executors.celery_executor.CeleryExecutor` instead.
 
-AIR303.py:34:1: AIR303 `airflow.executors.celery_kubernetes_executor.CeleryKubernetesExecutor` is moved into `celery` provider in Airflow 3.0;
+AIR303.py:57:1: AIR303 `airflow.executors.celery_kubernetes_executor.CeleryKubernetesExecutor` is moved into `celery` provider in Airflow 3.0;
    |
-32 | app
-33 | CeleryExecutor()
-34 | CeleryKubernetesExecutor()
+55 | app
+56 | CeleryExecutor()
+57 | CeleryKubernetesExecutor()
    | ^^^^^^^^^^^^^^^^^^^^^^^^ AIR303
-35 | 
-36 | # apache-airflow-providers-daskexecutor
+58 | 
+59 | # apache-airflow-providers-daskexecutor
    |
    = help: Install `apache-airflow-provider-celery>=3.3.0` and use `airflow.providers.celery.executors.celery_kubernetes_executor.CeleryKubernetesExecutor` instead.
 
-AIR303.py:37:1: AIR303 `airflow.executors.dask_executor.DaskExecutor` is moved into `daskexecutor` provider in Airflow 3.0;
+AIR303.py:60:1: AIR303 `airflow.executors.dask_executor.DaskExecutor` is moved into `daskexecutor` provider in Airflow 3.0;
    |
-36 | # apache-airflow-providers-daskexecutor
-37 | DaskExecutor()
+59 | # apache-airflow-providers-daskexecutor
+60 | DaskExecutor()
    | ^^^^^^^^^^^^ AIR303
-38 | 
-39 | # apache-airflow-providers-common-sql
+61 | 
+62 | # apache-airflow-providers-common-sql
    |
    = help: Install `apache-airflow-provider-daskexecutor>=1.0.0` and use `airflow.providers.daskexecutor.executors.dask_executor.DaskExecutor` instead.
 
-AIR303.py:40:1: AIR303 Import path `airflow.hooks.dbapi.ConnectorProtocol` is moved into `Common SQL` provider in Airflow 3.0;
+AIR303.py:63:1: AIR303 Import path `airflow.hooks.dbapi.ConnectorProtocol` is moved into `Common SQL` provider in Airflow 3.0;
    |
-39 | # apache-airflow-providers-common-sql
-40 | ConnectorProtocol()
+62 | # apache-airflow-providers-common-sql
+63 | ConnectorProtocol()
    | ^^^^^^^^^^^^^^^^^ AIR303
-41 | DbApiHook()
+64 | DbApiHook()
    |
    = help: Install `apache-airflow-provider-Common SQL>=1.0.0` and import from `airflow.providers.common.sql.hooks.sql.ConnectorProtocol` instead.
 
-AIR303.py:41:1: AIR303 Import path `airflow.hooks.dbapi.DbApiHook` is moved into `Common SQL` provider in Airflow 3.0;
+AIR303.py:64:1: AIR303 Import path `airflow.hooks.dbapi.DbApiHook` is moved into `Common SQL` provider in Airflow 3.0;
    |
-39 | # apache-airflow-providers-common-sql
-40 | ConnectorProtocol()
-41 | DbApiHook()
+62 | # apache-airflow-providers-common-sql
+63 | ConnectorProtocol()
+64 | DbApiHook()
    | ^^^^^^^^^ AIR303
-42 | 
-43 | # apache-airflow-providers-cncf-kubernetes
+65 | 
+66 | # apache-airflow-providers-cncf-kubernetes
    |
    = help: Install `apache-airflow-provider-Common SQL>=1.0.0` and import from `airflow.providers.common.sql.hooks.sql.DbApiHook` instead.
 
-AIR303.py:44:1: AIR303 Import path `airflow.executors.kubernetes_executor_types.ALL_NAMESPACES` is moved into `Kubernetes` provider in Airflow 3.0;
+AIR303.py:67:1: AIR303 Import path `airflow.executors.kubernetes_executor_types.ALL_NAMESPACES` is moved into `Kubernetes` provider in Airflow 3.0;
    |
-43 | # apache-airflow-providers-cncf-kubernetes
-44 | ALL_NAMESPACES
+66 | # apache-airflow-providers-cncf-kubernetes
+67 | ALL_NAMESPACES
    | ^^^^^^^^^^^^^^ AIR303
-45 | POD_EXECUTOR_DONE_KEY
+68 | POD_EXECUTOR_DONE_KEY
    |
    = help: Install `apache-airflow-provider-Kubernetes>=7.4.0` and import from `airflow.providers.cncf.kubernetes.executors.kubernetes_executor_types.ALL_NAMESPACES` instead.
 
-AIR303.py:45:1: AIR303 Import path `airflow.executors.kubernetes_executor_types.POD_EXECUTOR_DONE_KEY` is moved into `Kubernetes` provider in Airflow 3.0;
+AIR303.py:68:1: AIR303 Import path `airflow.executors.kubernetes_executor_types.POD_EXECUTOR_DONE_KEY` is moved into `Kubernetes` provider in Airflow 3.0;
    |
-43 | # apache-airflow-providers-cncf-kubernetes
-44 | ALL_NAMESPACES
-45 | POD_EXECUTOR_DONE_KEY
+66 | # apache-airflow-providers-cncf-kubernetes
+67 | ALL_NAMESPACES
+68 | POD_EXECUTOR_DONE_KEY
    | ^^^^^^^^^^^^^^^^^^^^^ AIR303
-46 | 
-47 | # apache-airflow-providers-apache-hive
+69 | 
+70 | # apache-airflow-providers-apache-hive
    |
    = help: Install `apache-airflow-provider-Kubernetes>=7.4.0` and import from `airflow.providers.cncf.kubernetes.executors.kubernetes_executor_types.POD_EXECUTOR_DONE_KEY` instead.
 
-AIR303.py:48:1: AIR303 Import path `airflow.hooks.hive_hooks.HIVE_QUEUE_PRIORITIES` is moved into `Apache Hive` provider in Airflow 3.0;
+AIR303.py:71:1: AIR303 `airflow.hooks.hive_hooks.HIVE_QUEUE_PRIORITIES` is moved into `Apache Hive` provider in Airflow 3.0;
    |
-47 | # apache-airflow-providers-apache-hive
-48 | HIVE_QUEUE_PRIORITIES
+70 | # apache-airflow-providers-apache-hive
+71 | HIVE_QUEUE_PRIORITIES
    | ^^^^^^^^^^^^^^^^^^^^^ AIR303
-49 | closest_ds_partition()
-50 | max_partition()
+72 | closest_ds_partition()
+73 | max_partition()
    |
-   = help: Install `apache-airflow-provider-Apache Hive>=1.0.0` and import from `airflow.providers.apache.hive.hooks.hive.HIVE_QUEUE_PRIORITIES` instead.
+   = help: Install `apache-airflow-provider-Apache Hive>=1.0.0` and use `HIVE_QUEUE_PRIORITIES` instead.
 
-AIR303.py:49:1: AIR303 Import path `airflow.macros.hive.closest_ds_partition` is moved into `Apache Hive` provider in Airflow 3.0;
+AIR303.py:72:1: AIR303 Import path `airflow.macros.hive.closest_ds_partition` is moved into `Apache Hive` provider in Airflow 3.0;
    |
-47 | # apache-airflow-providers-apache-hive
-48 | HIVE_QUEUE_PRIORITIES
-49 | closest_ds_partition()
+70 | # apache-airflow-providers-apache-hive
+71 | HIVE_QUEUE_PRIORITIES
+72 | closest_ds_partition()
    | ^^^^^^^^^^^^^^^^^^^^ AIR303
-50 | max_partition()
+73 | max_partition()
    |
    = help: Install `apache-airflow-provider-Apache Hive>=5.1.0` and import from `airflow.providers.apache.hive.macros.hive.closest_ds_partition` instead.
 
-AIR303.py:50:1: AIR303 Import path `airflow.macros.hive.max_partition` is moved into `Apache Hive` provider in Airflow 3.0;
+AIR303.py:73:1: AIR303 Import path `airflow.macros.hive.max_partition` is moved into `Apache Hive` provider in Airflow 3.0;
    |
-48 | HIVE_QUEUE_PRIORITIES
-49 | closest_ds_partition()
-50 | max_partition()
+71 | HIVE_QUEUE_PRIORITIES
+72 | closest_ds_partition()
+73 | max_partition()
    | ^^^^^^^^^^^^^ AIR303
+74 | 
+75 | # TODO: reorganize
    |
    = help: Install `apache-airflow-provider-Apache Hive>=5.1.0` and import from `airflow.providers.apache.hive.macros.hive.max_partition` instead.
+
+AIR303.py:76:1: AIR303 `airflow.hooks.S3_hook.S3Hook` is moved into `Amazon` provider in Airflow 3.0;
+   |
+75 | # TODO: reorganize
+76 | S3Hook()
+   | ^^^^^^ AIR303
+77 | provide_bucket_name()
+78 | BaseHook()
+   |
+   = help: Install `apache-airflow-provider-Amazon>=TBD` and use `S3Hook` instead.
+
+AIR303.py:77:1: AIR303 `airflow.hooks.S3_hook.provide_bucket_name` is moved into `Amazon` provider in Airflow 3.0;
+   |
+75 | # TODO: reorganize
+76 | S3Hook()
+77 | provide_bucket_name()
+   | ^^^^^^^^^^^^^^^^^^^ AIR303
+78 | BaseHook()
+79 | DbApiHook2()
+   |
+   = help: Install `apache-airflow-provider-Amazon>=TBD` and use `provide_bucket_name` instead.
+
+AIR303.py:78:1: AIR303 `airflow.hooks.base_hook.BaseHook` is moved into `Base` provider in Airflow 3.0;
+   |
+76 | S3Hook()
+77 | provide_bucket_name()
+78 | BaseHook()
+   | ^^^^^^^^ AIR303
+79 | DbApiHook2()
+80 | DockerHook()
+   |
+   = help: Install `apache-airflow-provider-Base>=TBD` and use `BaseHook` instead.
+
+AIR303.py:79:1: AIR303 `airflow.hooks.dbapi_hook.DbApiHook` is moved into `Common Sql` provider in Airflow 3.0;
+   |
+77 | provide_bucket_name()
+78 | BaseHook()
+79 | DbApiHook2()
+   | ^^^^^^^^^^ AIR303
+80 | DockerHook()
+81 | DruidDbApiHook()
+   |
+   = help: Install `apache-airflow-provider-Common Sql>=TBD` and use `DbApiHook` instead.
+
+AIR303.py:80:1: AIR303 `airflow.hooks.docker_hook.DockerHook` is moved into `Docker` provider in Airflow 3.0;
+   |
+78 | BaseHook()
+79 | DbApiHook2()
+80 | DockerHook()
+   | ^^^^^^^^^^ AIR303
+81 | DruidDbApiHook()
+82 | DruidHook()
+   |
+   = help: Install `apache-airflow-provider-Docker>=TBD` and use `DockerHook` instead.
+
+AIR303.py:81:1: AIR303 `airflow.hooks.druid_hook.DruidDbApiHook` is moved into `Apache Druid` provider in Airflow 3.0;
+   |
+79 | DbApiHook2()
+80 | DockerHook()
+81 | DruidDbApiHook()
+   | ^^^^^^^^^^^^^^ AIR303
+82 | DruidHook()
+83 | HIVE_QUEUE_PRIORITIES()
+   |
+   = help: Install `apache-airflow-provider-Apache Druid>=TBD` and use `DruidDbApiHook` instead.
+
+AIR303.py:82:1: AIR303 `airflow.hooks.druid_hook.DruidHook` is moved into `Apache Druid` provider in Airflow 3.0;
+   |
+80 | DockerHook()
+81 | DruidDbApiHook()
+82 | DruidHook()
+   | ^^^^^^^^^ AIR303
+83 | HIVE_QUEUE_PRIORITIES()
+84 | HiveCliHook()
+   |
+   = help: Install `apache-airflow-provider-Apache Druid>=TBD` and use `DruidHook` instead.
+
+AIR303.py:83:1: AIR303 `airflow.hooks.hive_hooks.HIVE_QUEUE_PRIORITIES` is moved into `Apache Hive` provider in Airflow 3.0;
+   |
+81 | DruidDbApiHook()
+82 | DruidHook()
+83 | HIVE_QUEUE_PRIORITIES()
+   | ^^^^^^^^^^^^^^^^^^^^^ AIR303
+84 | HiveCliHook()
+85 | HiveMetastoreHook()
+   |
+   = help: Install `apache-airflow-provider-Apache Hive>=1.0.0` and use `HIVE_QUEUE_PRIORITIES` instead.
+
+AIR303.py:84:1: AIR303 `airflow.hooks.hive_hooks.HiveCliHook` is moved into `Apache Hive` provider in Airflow 3.0;
+   |
+82 | DruidHook()
+83 | HIVE_QUEUE_PRIORITIES()
+84 | HiveCliHook()
+   | ^^^^^^^^^^^ AIR303
+85 | HiveMetastoreHook()
+86 | HiveServer2Hook()
+   |
+   = help: Install `apache-airflow-provider-Apache Hive>=TBD` and use `HiveCliHook` instead.
+
+AIR303.py:85:1: AIR303 `airflow.hooks.hive_hooks.HiveMetastoreHook` is moved into `Apache Hive` provider in Airflow 3.0;
+   |
+83 | HIVE_QUEUE_PRIORITIES()
+84 | HiveCliHook()
+85 | HiveMetastoreHook()
+   | ^^^^^^^^^^^^^^^^^ AIR303
+86 | HiveServer2Hook()
+87 | HttpHook()
+   |
+   = help: Install `apache-airflow-provider-Apache Hive>=TBD` and use `HiveMetastoreHook` instead.
+
+AIR303.py:86:1: AIR303 `airflow.hooks.hive_hooks.HiveServer2Hook` is moved into `Apache Hive` provider in Airflow 3.0;
+   |
+84 | HiveCliHook()
+85 | HiveMetastoreHook()
+86 | HiveServer2Hook()
+   | ^^^^^^^^^^^^^^^ AIR303
+87 | HttpHook()
+88 | JdbcHook()
+   |
+   = help: Install `apache-airflow-provider-Apache Hive>=TBD` and use `HiveServer2Hook` instead.
+
+AIR303.py:87:1: AIR303 `airflow.hooks.http_hook.HttpHook` is moved into `Http` provider in Airflow 3.0;
+   |
+85 | HiveMetastoreHook()
+86 | HiveServer2Hook()
+87 | HttpHook()
+   | ^^^^^^^^ AIR303
+88 | JdbcHook()
+89 | jaydebeapi()
+   |
+   = help: Install `apache-airflow-provider-Http>=TBD` and use `HttpHook` instead.
+
+AIR303.py:88:1: AIR303 `airflow.hooks.jdbc_hook.JdbcHook` is moved into `Jdbc` provider in Airflow 3.0;
+   |
+86 | HiveServer2Hook()
+87 | HttpHook()
+88 | JdbcHook()
+   | ^^^^^^^^ AIR303
+89 | jaydebeapi()
+90 | MsSqlHook()
+   |
+   = help: Install `apache-airflow-provider-Jdbc>=TBD` and use `JdbcHook` instead.
+
+AIR303.py:89:1: AIR303 `airflow.hooks.jdbc_hook.jaydebeapi` is moved into `Jdbc` provider in Airflow 3.0;
+   |
+87 | HttpHook()
+88 | JdbcHook()
+89 | jaydebeapi()
+   | ^^^^^^^^^^ AIR303
+90 | MsSqlHook()
+91 | MySqlHook()
+   |
+   = help: Install `apache-airflow-provider-Jdbc>=TBD` and use `jaydebeapi` instead.
+
+AIR303.py:90:1: AIR303 `airflow.hooks.mssql_hook.MsSqlHook` is moved into `Microsoft` provider in Airflow 3.0;
+   |
+88 | JdbcHook()
+89 | jaydebeapi()
+90 | MsSqlHook()
+   | ^^^^^^^^^ AIR303
+91 | MySqlHook()
+92 | OracleHook()
+   |
+   = help: Install `apache-airflow-provider-Microsoft>=TBD` and use `MsSqlHook` instead.
+
+AIR303.py:91:1: AIR303 `airflow.hooks.mysql_hook.MySqlHook` is moved into `Mysql` provider in Airflow 3.0;
+   |
+89 | jaydebeapi()
+90 | MsSqlHook()
+91 | MySqlHook()
+   | ^^^^^^^^^ AIR303
+92 | OracleHook()
+93 | PigCliHook()
+   |
+   = help: Install `apache-airflow-provider-Mysql>=TBD` and use `MySqlHook` instead.
+
+AIR303.py:92:1: AIR303 `airflow.hooks.oracle_hook.OracleHook` is moved into `Oracle` provider in Airflow 3.0;
+   |
+90 | MsSqlHook()
+91 | MySqlHook()
+92 | OracleHook()
+   | ^^^^^^^^^^ AIR303
+93 | PigCliHook()
+94 | PostgresHook()
+   |
+   = help: Install `apache-airflow-provider-Oracle>=TBD` and use `OracleHook` instead.
+
+AIR303.py:93:1: AIR303 `airflow.hooks.pig_hook.PigCliHook` is moved into `Apache Pig` provider in Airflow 3.0;
+   |
+91 | MySqlHook()
+92 | OracleHook()
+93 | PigCliHook()
+   | ^^^^^^^^^^ AIR303
+94 | PostgresHook()
+95 | PrestoHook()
+   |
+   = help: Install `apache-airflow-provider-Apache Pig>=TBD` and use `PigCliHook` instead.
+
+AIR303.py:94:1: AIR303 `airflow.hooks.postgres_hook.PostgresHook` is moved into `Postgres` provider in Airflow 3.0;
+   |
+92 | OracleHook()
+93 | PigCliHook()
+94 | PostgresHook()
+   | ^^^^^^^^^^^^ AIR303
+95 | PrestoHook()
+96 | SambaHook()
+   |
+   = help: Install `apache-airflow-provider-Postgres>=TBD` and use `PostgresHook` instead.
+
+AIR303.py:95:1: AIR303 `airflow.hooks.presto_hook.PrestoHook` is moved into `Presto` provider in Airflow 3.0;
+   |
+93 | PigCliHook()
+94 | PostgresHook()
+95 | PrestoHook()
+   | ^^^^^^^^^^ AIR303
+96 | SambaHook()
+97 | SlackHook()
+   |
+   = help: Install `apache-airflow-provider-Presto>=TBD` and use `PrestoHook` instead.
+
+AIR303.py:96:1: AIR303 `airflow.hooks.samba_hook.SambaHook` is moved into `Samba` provider in Airflow 3.0;
+   |
+94 | PostgresHook()
+95 | PrestoHook()
+96 | SambaHook()
+   | ^^^^^^^^^ AIR303
+97 | SlackHook()
+98 | SqliteHook()
+   |
+   = help: Install `apache-airflow-provider-Samba>=TBD` and use `SambaHook` instead.
+
+AIR303.py:97:1: AIR303 `airflow.hooks.slack_hook.SlackHook` is moved into `Slack` provider in Airflow 3.0;
+   |
+95 | PrestoHook()
+96 | SambaHook()
+97 | SlackHook()
+   | ^^^^^^^^^ AIR303
+98 | SqliteHook()
+99 | WebHDFSHook()
+   |
+   = help: Install `apache-airflow-provider-Slack>=TBD` and use `SlackHook` instead.
+
+AIR303.py:98:1: AIR303 `airflow.hooks.sqlite_hook.SqliteHook` is moved into `Sqlite` provider in Airflow 3.0;
+    |
+ 96 | SambaHook()
+ 97 | SlackHook()
+ 98 | SqliteHook()
+    | ^^^^^^^^^^ AIR303
+ 99 | WebHDFSHook()
+100 | ZendeskHook()
+    |
+    = help: Install `apache-airflow-provider-Sqlite>=TBD` and use `SqliteHook` instead.
+
+AIR303.py:99:1: AIR303 `airflow.hooks.webhdfs_hook.WebHDFSHook` is moved into `Apache Hdfs` provider in Airflow 3.0;
+    |
+ 97 | SlackHook()
+ 98 | SqliteHook()
+ 99 | WebHDFSHook()
+    | ^^^^^^^^^^^ AIR303
+100 | ZendeskHook()
+    |
+    = help: Install `apache-airflow-provider-Apache Hdfs>=TBD` and use `WebHDFSHook` instead.
+
+AIR303.py:100:1: AIR303 `airflow.hooks.zendesk_hook.ZendeskHook` is moved into `Zendesk` provider in Airflow 3.0;
+    |
+ 98 | SqliteHook()
+ 99 | WebHDFSHook()
+100 | ZendeskHook()
+    | ^^^^^^^^^^^ AIR303
+    |
+    = help: Install `apache-airflow-provider-Zendesk>=TBD` and use `ZendeskHook` instead.


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->


## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Many core Airflow features have been deprecated and moved to Airflow Providers since users might need to install an additional package (e.g., `apache-airflow-provider-fab==1.0.0`); a separate rule (AIR303) is created for this.

* `airflow.hooks.S3_hook.S3Hook` → `airflow.providers.amazon.aws.hooks.s3.S3Hook`
* `airflow.hooks.S3_hook.provide_bucket_name` → `airflow.providers.amazon.aws.hooks.s3.provide_bucket_name`
* `airflow.hooks.base_hook.BaseHook` → `airflow.hooks.base.BaseHook`
* `airflow.hooks.dbapi_hook.DbApiHook` → `airflow.providers.common.sql.hooks.sql.DbApiHook`
* `airflow.hooks.docker_hook.DockerHook` → `airflow.providers.docker.hooks.docker.DockerHook`
* `airflow.hooks.druid_hook.DruidDbApiHook` → `airflow.providers.apache.druid.hooks.druid.DruidDbApiHook`
* `airflow.hooks.druid_hook.DruidHook` → `airflow.providers.apache.druid.hooks.druid.DruidHook`
* `airflow.hooks.hive_hooks.HIVE_QUEUE_PRIORITIES` → `airflow.providers.apache.hive.hooks.hive.HIVE_QUEUE_PRIORITIES`
* `airflow.hooks.hive_hooks.HiveCliHook` → `airflow.providers.apache.hive.hooks.hive.HiveCliHook`
* `airflow.hooks.hive_hooks.HiveMetastoreHook` → `airflow.providers.apache.hive.hooks.hive.HiveMetastoreHook`
* `airflow.hooks.hive_hooks.HiveServer2Hook` → `airflow.providers.apache.hive.hooks.hive.HiveServer2Hook`
* `airflow.hooks.http_hook.HttpHook` → `airflow.providers.http.hooks.http.HttpHook`
* `airflow.hooks.jdbc_hook.JdbcHook` → `airflow.providers.jdbc.hooks.jdbc.JdbcHook`
* `airflow.hooks.jdbc_hook.jaydebeapi` → `airflow.providers.jdbc.hooks.jdbc.jaydebeapi`
* `airflow.hooks.mssql_hook.MsSqlHook` → `airflow.providers.microsoft.mssql.hooks.mssql.MsSqlHook`
* `airflow.hooks.mysql_hook.MySqlHook` → `airflow.providers.mysql.hooks.mysql.MySqlHook`
* `airflow.hooks.oracle_hook.OracleHook` → `airflow.providers.oracle.hooks.oracle.OracleHook`
* `airflow.hooks.pig_hook.PigCliHook` → `airflow.providers.apache.pig.hooks.pig.PigCliHook`
* `airflow.hooks.postgres_hook.PostgresHook` → `airflow.providers.postgres.hooks.postgres.PostgresHook`
* `airflow.hooks.presto_hook.PrestoHook` → `airflow.providers.presto.hooks.presto.PrestoHook`
* `airflow.hooks.samba_hook.SambaHook` → `airflow.providers.samba.hooks.samba.SambaHook`
* `airflow.hooks.slack_hook.SlackHook` → `airflow.providers.slack.hooks.slack.SlackHook`
* `airflow.hooks.sqlite_hook.SqliteHook` → `airflow.providers.sqlite.hooks.sqlite.SqliteHook`
* `airflow.hooks.webhdfs_hook.WebHDFSHook` → `airflow.providers.apache.hdfs.hooks.webhdfs.WebHDFSHook`
* `airflow.hooks.zendesk_hook.ZendeskHook` → `airflow.providers.zendesk.hooks.zendesk.ZendeskHook`
* `airflow.operators.check_operator.SQLCheckOperator` → `airflow.providers.common.sql.operators.sql.SQLCheckOperator`
* `airflow.operators.check_operator.SQLIntervalCheckOperator` → `airflow.providers.common.sql.operators.sql.SQLIntervalCheckOperator`
* `airflow.operators.check_operator.SQLThresholdCheckOperator` → `airflow.providers.common.sql.operators.sql.SQLThresholdCheckOperator`
* `airflow.operators.check_operator.SQLValueCheckOperator` → `airflow.providers.common.sql.operators.sql.SQLValueCheckOperator`
* `airflow.operators.check_operator.CheckOperator` → `airflow.providers.common.sql.operators.sql.SQLCheckOperator`
* `airflow.operators.check_operator.IntervalCheckOperator` → `airflow.providers.common.sql.operators.sql.SQLIntervalCheckOperator`
* `airflow.operators.check_operator.ThresholdCheckOperator` → `airflow.providers.common.sql.operators.sql.SQLThresholdCheckOperator`
* `airflow.operators.check_operator.ValueCheckOperator` → `airflow.providers.common.sql.operators.sql.SQLValueCheckOperator`
* `airflow.operators.docker_operator.DockerOperator` → `airflow.providers.docker.operators.docker.DockerOperator`
* `airflow.operators.druid_check_operator.DruidCheckOperator` → `airflow.providers.apache.druid.operators.druid_check.DruidCheckOperator`
* `airflow.operators.gcs_to_s3.GCSToS3Operator` → `airflow.providers.amazon.aws.transfers.gcs_to_s3.GCSToS3Operator`
* `airflow.operators.google_api_to_s3_transfer.GoogleApiToS3Operator` → `airflow.providers.amazon.aws.transfers.google_api_to_s3.GoogleApiToS3Operator`
* `airflow.operators.google_api_to_s3_transfer.GoogleApiToS3Transfer` → `airflow.providers.amazon.aws.transfers.google_api_to_s3.GoogleApiToS3Operator`
* `airflow.operators.hive_operator.HiveOperator` → `airflow.providers.apache.hive.operators.hive.HiveOperator`
* `airflow.operators.hive_stats_operator.HiveStatsCollectionOperator` → `airflow.providers.apache.hive.operators.hive_stats.HiveStatsCollectionOperator`
* `airflow.operators.hive_to_druid.HiveToDruidOperator` → `airflow.providers.apache.druid.transfers.hive_to_druid.HiveToDruidOperator`
* `airflow.operators.hive_to_druid.HiveToDruidTransfer` → `airflow.providers.apache.druid.transfers.hive_to_druid.HiveToDruidOperator`
* `airflow.operators.hive_to_mysql.HiveToMySqlOperator` → `airflow.providers.apache.hive.transfers.hive_to_mysql.HiveToMySqlOperator`
* `airflow.operators.hive_to_mysql.HiveToMySqlTransfer` → `airflow.providers.apache.hive.transfers.hive_to_mysql.HiveToMySqlOperator`
* `airflow.operators.hive_to_samba_operator.HiveToSambaOperator` → `airflow.providers.apache.hive.transfers.hive_to_samba.HiveToSambaOperator`
* `airflow.operators.http_operator.SimpleHttpOperator` → `airflow.providers.http.operators.http.SimpleHttpOperator`
* `airflow.operators.jdbc_operator.JdbcOperator` → `airflow.providers.jdbc.operators.jdbc.JdbcOperator`
* `airflow.operators.latest_only_operator.LatestOnlyOperator` → `airflow.operators.latest_only.LatestOnlyOperator`
* `airflow.operators.mssql_operator.MsSqlOperator` → `airflow.providers.microsoft.mssql.operators.mssql.MsSqlOperator`
* `airflow.operators.mssql_to_hive.MsSqlToHiveOperator` → `airflow.providers.apache.hive.transfers.mssql_to_hive.MsSqlToHiveOperator`
* `airflow.operators.mssql_to_hive.MsSqlToHiveTransfer` → `airflow.providers.apache.hive.transfers.mssql_to_hive.MsSqlToHiveOperator`
* `airflow.operators.mysql_operator.MySqlOperator` → `airflow.providers.mysql.operators.mysql.MySqlOperator`
* `airflow.operators.mysql_to_hive.MySqlToHiveOperator` → `airflow.providers.apache.hive.transfers.mysql_to_hive.MySqlToHiveOperator`
* `airflow.operators.mysql_to_hive.MySqlToHiveTransfer` → `airflow.providers.apache.hive.transfers.mysql_to_hive.MySqlToHiveOperator`
* `airflow.operators.oracle_operator.OracleOperator` → `airflow.providers.oracle.operators.oracle.OracleOperator`
* `airflow.operators.papermill_operator.PapermillOperator` → `airflow.providers.papermill.operators.papermill.PapermillOperator`
* `airflow.operators.pig_operator.PigOperator` → `airflow.providers.apache.pig.operators.pig.PigOperator`
* `airflow.operators.postgres_operator.Mapping` → `airflow.providers.postgres.operators.postgres.Mapping`
* `airflow.operators.postgres_operator.PostgresOperator` → `airflow.providers.postgres.operators.postgres.PostgresOperator`
* `airflow.operators.presto_check_operator.SQLCheckOperator` → `airflow.providers.common.sql.operators.sql.SQLCheckOperator`
* `airflow.operators.presto_check_operator.SQLIntervalCheckOperator` → `airflow.providers.common.sql.operators.sql.SQLIntervalCheckOperator`
* `airflow.operators.presto_check_operator.SQLValueCheckOperator` → `airflow.providers.common.sql.operators.sql.SQLValueCheckOperator`
* `airflow.operators.presto_check_operator.PrestoCheckOperator` → `airflow.providers.common.sql.operators.sql.SQLCheckOperator`
* `airflow.operators.presto_check_operator.PrestoIntervalCheckOperator` → `airflow.providers.common.sql.operators.sql.SQLIntervalCheckOperator`
* `airflow.operators.presto_check_operator.PrestoValueCheckOperator` → `airflow.providers.common.sql.operators.sql.SQLValueCheckOperator`
* `airflow.operators.presto_to_mysql.PrestoToMySqlOperator` → `airflow.providers.mysql.transfers.presto_to_mysql.PrestoToMySqlOperator`
* `airflow.operators.presto_to_mysql.PrestoToMySqlTransfer` → `airflow.providers.mysql.transfers.presto_to_mysql.PrestoToMySqlOperator`
* `airflow.operators.redshift_to_s3_operator.RedshiftToS3Operator` → `airflow.providers.amazon.aws.transfers.redshift_to_s3.RedshiftToS3Operator`
* `airflow.operators.redshift_to_s3_operator.RedshiftToS3Transfer` → `airflow.providers.amazon.aws.transfers.redshift_to_s3.RedshiftToS3Operator`
* `airflow.operators.s3_file_transform_operator.S3FileTransformOperator` → `airflow.providers.amazon.aws.operators.s3_file_transform.S3FileTransformOperator`
* `airflow.operators.s3_to_hive_operator.S3ToHiveOperator` → `airflow.providers.apache.hive.transfers.s3_to_hive.S3ToHiveOperator`
* `airflow.operators.s3_to_hive_operator.S3ToHiveTransfer` → `airflow.providers.apache.hive.transfers.s3_to_hive.S3ToHiveOperator`
* `airflow.operators.s3_to_redshift_operator.S3ToRedshiftOperator` → `airflow.providers.amazon.aws.transfers.s3_to_redshift.S3ToRedshiftOperator`
* `airflow.operators.s3_to_redshift_operator.S3ToRedshiftTransfer` → `airflow.providers.amazon.aws.transfers.s3_to_redshift.S3ToRedshiftOperator`
* `airflow.operators.slack_operator.SlackAPIOperator` → `airflow.providers.slack.operators.slack.SlackAPIOperator`
* `airflow.operators.slack_operator.SlackAPIPostOperator` → `airflow.providers.slack.operators.slack.SlackAPIPostOperator`
* `airflow.operators.sql.BaseSQLOperator` → `airflow.providers.common.sql.operators.sql.BaseSQLOperator`
* `airflow.operators.sql.BranchSQLOperator` → `airflow.providers.common.sql.operators.sql.BranchSQLOperator`
* `airflow.operators.sql.SQLCheckOperator` → `airflow.providers.common.sql.operators.sql.SQLCheckOperator`
* `airflow.operators.sql.SQLColumnCheckOperator` → `airflow.providers.common.sql.operators.sql.SQLColumnCheckOperator`
* `airflow.operators.sql.SQLIntervalCheckOperator` → `airflow.providers.common.sql.operators.sql.SQLIntervalCheckOperator`
* `airflow.operators.sql.SQLTableCheckOperator` → `airflow.providers.common.sql.operators.sql.SQLTableCheckOperator`
* `airflow.operators.sql.SQLThresholdCheckOperator` → `airflow.providers.common.sql.operators.sql.SQLThresholdCheckOperator`
* `airflow.operators.sql.SQLValueCheckOperator` → `airflow.providers.common.sql.operators.sql.SQLValueCheckOperator`
* `airflow.operators.sql._convert_to_float_if_possible` → `airflow.providers.common.sql.operators.sql._convert_to_float_if_possible`
* `airflow.operators.sql.parse_boolean` → `airflow.providers.common.sql.operators.sql.parse_boolean`
* `airflow.operators.sql_branch_operator.BranchSQLOperator` → `airflow.providers.common.sql.operators.sql.BranchSQLOperator`
* `airflow.operators.sql_branch_operator.BranchSqlOperator` → `airflow.providers.common.sql.operators.sql.BranchSQLOperator`
* `airflow.operators.sqlite_operator.SqliteOperator` → `airflow.providers.sqlite.operators.sqlite.SqliteOperator`
* `airflow.sensors.hive_partition_sensor.HivePartitionSensor` → `airflow.providers.apache.hive.sensors.hive_partition.HivePartitionSensor`
* `airflow.sensors.http_sensor.HttpSensor` → `airflow.providers.http.sensors.http.HttpSensor`
* `airflow.sensors.metastore_partition_sensor.MetastorePartitionSensor` → `airflow.providers.apache.hive.sensors.metastore_partition.MetastorePartitionSensor`
* `airflow.sensors.named_hive_partition_sensor.NamedHivePartitionSensor` → `airflow.providers.apache.hive.sensors.named_hive_partition.NamedHivePartitionSensor`
* `airflow.sensors.s3_key_sensor.S3KeySensor` → `airflow.providers.amazon.aws.sensors.s3.S3KeySensor`
* `airflow.sensors.sql.SqlSensor` → `airflow.providers.common.sql.sensors.sql.SqlSensor`
* `airflow.sensors.sql_sensor.SqlSensor` → `airflow.providers.common.sql.sensors.sql.SqlSensor`
* `airflow.sensors.web_hdfs_sensor.WebHdfsSensor` → `airflow.providers.apache.hdfs.sensors.web_hdfs.WebHdfsSensor`


## Test Plan

<!-- How was it tested? -->

A test fixture has been included for the rule.