### PR TITLE
[docs] improve and fix entry for `analyze.include-dependencies`

### DIFF
--- a/crates/ruff_workspace/src/options.rs
+++ b/crates/ruff_workspace/src/options.rs
@@ -3462,17 +3462,15 @@ pub struct AnalyzeOptions {
         "#
     )]
     pub detect_string_imports: Option<bool>,
-    /// A map from file path to the list of file paths or globs that should be considered
-    /// dependencies of that file, regardless of whether relevant imports are detected.
-    /// These can also include non-Python files (for instance, if you want to mark a data
-    /// file as a dependency of a Python file that reads it)
+    /// A map from file path to the list of Python or non-Python file paths or globs that should be
+    /// considered dependencies of that file, regardless of whether relevant imports are detected.
     #[option(
         default = "{}",
         scope = "include-dependencies",
         value_type = "dict[str, list[str]]",
         example = r#"
             "foo/bar.py" = ["foo/baz/*.py"]
-            "foo/baz/bar_config_reader.py" = ["configs/bar.json"]
+            "foo/baz/reader.py" = ["configs/bar.json"]
         "#
     )]
     pub include_dependencies: Option<BTreeMap<PathBuf, Vec<String>>>,

--- a/crates/ruff_workspace/src/options.rs
+++ b/crates/ruff_workspace/src/options.rs
@@ -3464,13 +3464,15 @@ pub struct AnalyzeOptions {
     pub detect_string_imports: Option<bool>,
     /// A map from file path to the list of file paths or globs that should be considered
     /// dependencies of that file, regardless of whether relevant imports are detected.
+    /// These can also include non-Python files (for instance, if you want to mark a data
+    /// file as a dependency of a Python file that reads it)
     #[option(
         default = "{}",
+        scope = "include-dependencies",
         value_type = "dict[str, list[str]]",
         example = r#"
-            include-dependencies = {
-                "foo/bar.py": ["foo/baz/*.py"],
-            }
+            "foo/bar.py" = ["foo/baz/*.py"],
+            "foo/baz/bar_config_reader.py" = ["configs/bar.json"],
         "#
     )]
     pub include_dependencies: Option<BTreeMap<PathBuf, Vec<String>>>,

--- a/crates/ruff_workspace/src/options.rs
+++ b/crates/ruff_workspace/src/options.rs
@@ -3471,8 +3471,8 @@ pub struct AnalyzeOptions {
         scope = "include-dependencies",
         value_type = "dict[str, list[str]]",
         example = r#"
-            "foo/bar.py" = ["foo/baz/*.py"],
-            "foo/baz/bar_config_reader.py" = ["configs/bar.json"],
+            "foo/bar.py" = ["foo/baz/*.py"]
+            "foo/baz/bar_config_reader.py" = ["configs/bar.json"]
         "#
     )]
     pub include_dependencies: Option<BTreeMap<PathBuf, Vec<String>>>,

--- a/ruff.schema.json
+++ b/ruff.schema.json
@@ -781,7 +781,7 @@
           }
         },
         "include-dependencies": {
-          "description": "A map from file path to the list of file paths or globs that should be considered dependencies of that file, regardless of whether relevant imports are detected.",
+          "description": "A map from file path to the list of file paths or globs that should be considered dependencies of that file, regardless of whether relevant imports are detected. These can also include non-Python files (for instance, if you want to mark a data file as a dependency of a Python file that reads it)",
           "type": [
             "object",
             "null"

--- a/ruff.schema.json
+++ b/ruff.schema.json
@@ -781,7 +781,7 @@
           }
         },
         "include-dependencies": {
-          "description": "A map from file path to the list of file paths or globs that should be considered dependencies of that file, regardless of whether relevant imports are detected. These can also include non-Python files (for instance, if you want to mark a data file as a dependency of a Python file that reads it)",
+          "description": "A map from file path to the list of Python or non-Python file paths or globs that should be considered dependencies of that file, regardless of whether relevant imports are detected.",
           "type": [
             "object",
             "null"


### PR DESCRIPTION
## Summary

Changes two things about the entry:
* make the example valid TOML - inline tables must be a single line, at least till v1.1.0 is released, 
but also while in the future the toml version used by ruff might handle it, it would probably be 
good to stick to a spec that's readable by the vast majority of other tools and versions as well, 
especially if people are using `pyproject.toml`. The current example leads to `ruff` failure.
See https://github.com/toml-lang/toml/pull/904
* adds a line about the ability to add non-Python files to the map, which I think is a specific and 
important feature people should know about (in fact, I would assume this could potentially 
become the single biggest use-case for this).

## Test Plan

Ran doc creation as described in the [contribution](https://docs.astral.sh/ruff/contributing/#mkdocs) guide.