### PR TITLE
[red-knot] add call checking

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/assignment/augmented.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/assignment/augmented.md
@@ -40,9 +40,9 @@ class C:
         return 42
 
 x = C()
+# error: [invalid-argument-type]
 x -= 1
 
-# TODO: should error, once operand type check is implemented
 reveal_type(x)  # revealed: int
 ```
 

--- a/crates/red_knot_python_semantic/resources/mdtest/call/function.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/call/function.md
@@ -73,7 +73,7 @@ def _(flag: bool):
 def f(x: int) -> int:
     return 1
 
-# error: 15 [invalid-argument-type] "Object of type `Literal["foo"]` cannot be assigned to parameter `x` of function `f`; expected type `int`"
+# error: 15 [invalid-argument-type] "Object of type `Literal["foo"]` cannot be assigned to parameter 0 (`x`) of function `f`; expected type `int`"
 reveal_type(f("foo"))  # revealed: int
 ```
 

--- a/crates/red_knot_python_semantic/resources/mdtest/call/function.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/call/function.md
@@ -73,7 +73,7 @@ def _(flag: bool):
 def f(x: int) -> int:
     return 1
 
-# error: 15 [invalid-argument-type] "Object of type `Literal["foo"]` cannot be assigned to parameter 0 (`x`) of function `f`; expected type `int`"
+# error: 15 [invalid-argument-type] "Object of type `Literal["foo"]` cannot be assigned to parameter 1 (`x`) of function `f`; expected type `int`"
 reveal_type(f("foo"))  # revealed: int
 ```
 
@@ -83,7 +83,7 @@ reveal_type(f("foo"))  # revealed: int
 def f(x: int, /) -> int:
     return 1
 
-# error: 15 [invalid-argument-type] "Object of type `Literal["foo"]` cannot be assigned to parameter 0 (`x`) of function `f`; expected type `int`"
+# error: 15 [invalid-argument-type] "Object of type `Literal["foo"]` cannot be assigned to parameter 1 (`x`) of function `f`; expected type `int`"
 reveal_type(f("foo"))  # revealed: int
 ```
 

--- a/crates/red_knot_python_semantic/resources/mdtest/call/function.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/call/function.md
@@ -64,3 +64,186 @@ def _(flag: bool):
     # error: [possibly-unresolved-reference]
     reveal_type(foo())  # revealed: int
 ```
+
+## Wrong argument type
+
+### Positional argument, positional-or-keyword parameter
+
+```py
+def f(x: int) -> int:
+    return 1
+
+# error: 15 [invalid-argument-type] "Cannot assign type `Literal["foo"]` to parameter `x` of type `int`"
+reveal_type(f("foo"))  # revealed: int
+```
+
+### Positional argument, positional-only parameter
+
+```py
+def f(x: int, /) -> int:
+    return 1
+
+# error: 15 [invalid-argument-type] "Cannot assign type `Literal["foo"]` to parameter `x` of type `int`"
+reveal_type(f("foo"))  # revealed: int
+```
+
+### Positional argument, variadic parameter
+
+```py
+def f(*args: int) -> int:
+    return 1
+
+# error: 15 [invalid-argument-type] "Cannot assign type `Literal["foo"]` to parameter `args` of type `int`"
+reveal_type(f("foo"))  # revealed: int
+```
+
+### Keyword argument, positional-or-keyword parameter
+
+```py
+def f(x: int) -> int:
+    return 1
+
+# error: 15 [invalid-argument-type] "Cannot assign type `Literal["foo"]` to parameter `x` of type `int`"
+reveal_type(f(x="foo"))  # revealed: int
+```
+
+### Keyword argument, keyword-only parameter
+
+```py
+def f(*, x: int) -> int:
+    return 1
+
+# error: 15 [invalid-argument-type] "Cannot assign type `Literal["foo"]` to parameter `x` of type `int`"
+reveal_type(f(x="foo"))  # revealed: int
+```
+
+### Keyword argument, keywords parameter
+
+```py
+def f(**kwargs: int) -> int:
+    return 1
+
+# error: 15 [invalid-argument-type] "Cannot assign type `Literal["foo"]` to parameter `kwargs` of type `int`"
+reveal_type(f(x="foo"))  # revealed: int
+```
+
+### Correctly match keyword out-of-order
+
+```py
+def f(x: int = 1, y: str = "foo") -> int:
+    return 1
+
+# error: 15 [invalid-argument-type] "Cannot assign type `Literal[2]` to parameter `y` of type `str`"
+# error: 20 [invalid-argument-type] "Cannot assign type `Literal["bar"]` to parameter `x` of type `int`"
+reveal_type(f(y=2, x="bar"))  # revealed: int
+```
+
+## Too many positional arguments
+
+### One too many
+
+```py
+def f() -> int:
+    return 1
+
+# error: 15 [too-many-positional-arguments] "Too many positional arguments: expected 0, got 1"
+reveal_type(f("foo"))  # revealed: int
+```
+
+### Two too many
+
+```py
+def f() -> int:
+    return 1
+
+# error: 15 [too-many-positional-arguments] "Too many positional arguments: expected 0, got 2"
+reveal_type(f("foo", "bar"))  # revealed: int
+```
+
+### No too-many-positional if variadic is taken
+
+```py
+def f(*args: int) -> int:
+    return 1
+
+reveal_type(f(1, 2, 3))  # revealed: int
+```
+
+## Missing arguments
+
+### No defaults or variadic
+
+```py
+def f(x: int) -> int:
+    return 1
+
+# error: 13 [missing-argument] "No argument provided for required parameter `x`"
+reveal_type(f())  # revealed: int
+```
+
+### With default
+
+```py
+def f(x: int, y: str = "foo") -> int:
+    return 1
+
+# error: 13 [missing-argument] "No argument provided for required parameter `x`"
+reveal_type(f())  # revealed: int
+```
+
+### Defaulted argument is not required
+
+```py
+def f(x: int = 1) -> int:
+    return 1
+
+reveal_type(f())  # revealed: int
+```
+
+### With variadic
+
+```py
+def f(x: int, *y: str) -> int:
+    return 1
+
+# error: 13 [missing-argument] "No argument provided for required parameter `x`"
+reveal_type(f())  # revealed: int
+```
+
+### Variadic argument is not required
+
+```py
+def f(*args: int) -> int:
+    return 1
+
+reveal_type(f())  # revealed: int
+```
+
+### Keywords argument is not required
+
+```py
+def f(**kwargs: int) -> int:
+    return 1
+
+reveal_type(f())  # revealed: int
+```
+
+## Unknown argument
+
+```py
+def f(x: int) -> int:
+    return 1
+
+# error: 20 [unknown-argument] "Argument `y` does not match any known parameter"
+reveal_type(f(x=1, y=2))  # revealed: int
+```
+
+## Parameter already assigned
+
+```py
+def f(x: int) -> int:
+    return 1
+
+# error: 18 [parameter-already-assigned] "Parameter `x` is already assigned"
+reveal_type(f(1, x=2))  # revealed: int
+```

--- a/crates/red_knot_python_semantic/resources/mdtest/call/function.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/call/function.md
@@ -93,7 +93,7 @@ reveal_type(f("foo"))  # revealed: int
 def f(*args: int) -> int:
     return 1
 
-# error: 15 [invalid-argument-type] "Cannot assign type `Literal["foo"]` to parameter `args` of type `int`"
+# error: 15 [invalid-argument-type] "Cannot assign type `Literal["foo"]` to parameter `*args` of type `int`"
 reveal_type(f("foo"))  # revealed: int
 ```
 
@@ -123,7 +123,7 @@ reveal_type(f(x="foo"))  # revealed: int
 def f(**kwargs: int) -> int:
     return 1
 
-# error: 15 [invalid-argument-type] "Cannot assign type `Literal["foo"]` to parameter `kwargs` of type `int`"
+# error: 15 [invalid-argument-type] "Cannot assign type `Literal["foo"]` to parameter `**kwargs` of type `int`"
 reveal_type(f(x="foo"))  # revealed: int
 ```
 

--- a/crates/red_knot_python_semantic/resources/mdtest/call/function.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/call/function.md
@@ -146,7 +146,7 @@ reveal_type(f(y=2, x="bar"))  # revealed: int
 def f() -> int:
     return 1
 
-# error: 15 [too-many-positional-arguments] "Too many positional arguments: expected 0, got 1"
+# error: 15 [too-many-positional-arguments] "Too many positional arguments to function `f`: expected 0, got 1"
 reveal_type(f("foo"))  # revealed: int
 ```
 
@@ -156,7 +156,7 @@ reveal_type(f("foo"))  # revealed: int
 def f() -> int:
     return 1
 
-# error: 15 [too-many-positional-arguments] "Too many positional arguments: expected 0, got 2"
+# error: 15 [too-many-positional-arguments] "Too many positional arguments to function `f`: expected 0, got 2"
 reveal_type(f("foo", "bar"))  # revealed: int
 ```
 

--- a/crates/red_knot_python_semantic/resources/mdtest/call/function.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/call/function.md
@@ -177,7 +177,7 @@ reveal_type(f(1, 2, 3))  # revealed: int
 def f(x: int) -> int:
     return 1
 
-# error: 13 [missing-argument] "No argument provided for required parameter `x`"
+# error: 13 [missing-argument] "No argument provided for required parameter `x` of function `f`"
 reveal_type(f())  # revealed: int
 ```
 
@@ -187,7 +187,7 @@ reveal_type(f())  # revealed: int
 def f(x: int, y: str = "foo") -> int:
     return 1
 
-# error: 13 [missing-argument] "No argument provided for required parameter `x`"
+# error: 13 [missing-argument] "No argument provided for required parameter `x` of function `f`"
 reveal_type(f())  # revealed: int
 ```
 
@@ -206,7 +206,7 @@ reveal_type(f())  # revealed: int
 def f(x: int, *y: str) -> int:
     return 1
 
-# error: 13 [missing-argument] "No argument provided for required parameter `x`"
+# error: 13 [missing-argument] "No argument provided for required parameter `x` of function `f`"
 reveal_type(f())  # revealed: int
 ```
 
@@ -234,7 +234,7 @@ reveal_type(f())  # revealed: int
 def f(x: int, y: int) -> int:
     return 1
 
-# error: 13 [missing-argument] "No arguments provided for required parameters `x`, `y`"
+# error: 13 [missing-argument] "No arguments provided for required parameters `x`, `y` of function `f`"
 reveal_type(f())  # revealed: int
 ```
 
@@ -244,7 +244,7 @@ reveal_type(f())  # revealed: int
 def f(x: int) -> int:
     return 1
 
-# error: 20 [unknown-argument] "Argument `y` does not match any known parameter"
+# error: 20 [unknown-argument] "Argument `y` does not match any known parameter of function `f`"
 reveal_type(f(x=1, y=2))  # revealed: int
 ```
 
@@ -254,6 +254,6 @@ reveal_type(f(x=1, y=2))  # revealed: int
 def f(x: int) -> int:
     return 1
 
-# error: 18 [parameter-already-assigned] "Got multiple values for parameter `x` of function `f`"
+# error: 18 [parameter-already-assigned] "Multiple values provided for parameter `x` of function `f`"
 reveal_type(f(1, x=2))  # revealed: int
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/call/function.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/call/function.md
@@ -73,7 +73,7 @@ def _(flag: bool):
 def f(x: int) -> int:
     return 1
 
-# error: 15 [invalid-argument-type] "Cannot assign type `Literal["foo"]` to parameter `x` of type `int`"
+# error: 15 [invalid-argument-type] "Object of type `Literal["foo"]` cannot be assigned to parameter `x` of function `f`; expected type `int`"
 reveal_type(f("foo"))  # revealed: int
 ```
 
@@ -83,7 +83,7 @@ reveal_type(f("foo"))  # revealed: int
 def f(x: int, /) -> int:
     return 1
 
-# error: 15 [invalid-argument-type] "Cannot assign type `Literal["foo"]` to positional parameter 0 (`x`) of type `int`"
+# error: 15 [invalid-argument-type] "Object of type `Literal["foo"]` cannot be assigned to positional parameter 0 (`x`) of function `f`; expected type `int`"
 reveal_type(f("foo"))  # revealed: int
 ```
 
@@ -93,7 +93,7 @@ reveal_type(f("foo"))  # revealed: int
 def f(*args: int) -> int:
     return 1
 
-# error: 15 [invalid-argument-type] "Cannot assign type `Literal["foo"]` to parameter `*args` of type `int`"
+# error: 15 [invalid-argument-type] "Object of type `Literal["foo"]` cannot be assigned to parameter `*args` of function `f`; expected type `int`"
 reveal_type(f("foo"))  # revealed: int
 ```
 
@@ -103,7 +103,7 @@ reveal_type(f("foo"))  # revealed: int
 def f(x: int) -> int:
     return 1
 
-# error: 15 [invalid-argument-type] "Cannot assign type `Literal["foo"]` to parameter `x` of type `int`"
+# error: 15 [invalid-argument-type] "Object of type `Literal["foo"]` cannot be assigned to parameter `x` of function `f`; expected type `int`"
 reveal_type(f(x="foo"))  # revealed: int
 ```
 
@@ -113,7 +113,7 @@ reveal_type(f(x="foo"))  # revealed: int
 def f(*, x: int) -> int:
     return 1
 
-# error: 15 [invalid-argument-type] "Cannot assign type `Literal["foo"]` to parameter `x` of type `int`"
+# error: 15 [invalid-argument-type] "Object of type `Literal["foo"]` cannot be assigned to parameter `x` of function `f`; expected type `int`"
 reveal_type(f(x="foo"))  # revealed: int
 ```
 
@@ -123,7 +123,7 @@ reveal_type(f(x="foo"))  # revealed: int
 def f(**kwargs: int) -> int:
     return 1
 
-# error: 15 [invalid-argument-type] "Cannot assign type `Literal["foo"]` to parameter `**kwargs` of type `int`"
+# error: 15 [invalid-argument-type] "Object of type `Literal["foo"]` cannot be assigned to parameter `**kwargs` of function `f`; expected type `int`"
 reveal_type(f(x="foo"))  # revealed: int
 ```
 
@@ -133,8 +133,8 @@ reveal_type(f(x="foo"))  # revealed: int
 def f(x: int = 1, y: str = "foo") -> int:
     return 1
 
-# error: 15 [invalid-argument-type] "Cannot assign type `Literal[2]` to parameter `y` of type `str`"
-# error: 20 [invalid-argument-type] "Cannot assign type `Literal["bar"]` to parameter `x` of type `int`"
+# error: 15 [invalid-argument-type] "Object of type `Literal[2]` cannot be assigned to parameter `y` of function `f`; expected type `str`"
+# error: 20 [invalid-argument-type] "Object of type `Literal["bar"]` cannot be assigned to parameter `x` of function `f`; expected type `int`"
 reveal_type(f(y=2, x="bar"))  # revealed: int
 ```
 

--- a/crates/red_knot_python_semantic/resources/mdtest/call/function.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/call/function.md
@@ -83,7 +83,7 @@ reveal_type(f("foo"))  # revealed: int
 def f(x: int, /) -> int:
     return 1
 
-# error: 15 [invalid-argument-type] "Cannot assign type `Literal["foo"]` to parameter `x` of type `int`"
+# error: 15 [invalid-argument-type] "Cannot assign type `Literal["foo"]` to positional parameter 0 (`x`) of type `int`"
 reveal_type(f("foo"))  # revealed: int
 ```
 
@@ -244,6 +244,6 @@ reveal_type(f(x=1, y=2))  # revealed: int
 def f(x: int) -> int:
     return 1
 
-# error: 18 [parameter-already-assigned] "Parameter `x` is already assigned"
+# error: 18 [parameter-already-assigned] "Got multiple values for parameter `x`"
 reveal_type(f(1, x=2))  # revealed: int
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/call/function.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/call/function.md
@@ -83,7 +83,7 @@ reveal_type(f("foo"))  # revealed: int
 def f(x: int, /) -> int:
     return 1
 
-# error: 15 [invalid-argument-type] "Object of type `Literal["foo"]` cannot be assigned to positional parameter 0 (`x`) of function `f`; expected type `int`"
+# error: 15 [invalid-argument-type] "Object of type `Literal["foo"]` cannot be assigned to parameter 0 (`x`) of function `f`; expected type `int`"
 reveal_type(f("foo"))  # revealed: int
 ```
 
@@ -225,6 +225,16 @@ reveal_type(f())  # revealed: int
 def f(**kwargs: int) -> int:
     return 1
 
+reveal_type(f())  # revealed: int
+```
+
+### Multiple
+
+```py
+def f(x: int, y: int) -> int:
+    return 1
+
+# error: 13 [missing-argument] "No arguments provided for required parameters `x`, `y`"
 reveal_type(f())  # revealed: int
 ```
 

--- a/crates/red_knot_python_semantic/resources/mdtest/call/function.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/call/function.md
@@ -244,6 +244,6 @@ reveal_type(f(x=1, y=2))  # revealed: int
 def f(x: int) -> int:
     return 1
 
-# error: 18 [parameter-already-assigned] "Got multiple values for parameter `x`"
+# error: 18 [parameter-already-assigned] "Got multiple values for parameter `x` of function `f`"
 reveal_type(f(1, x=2))  # revealed: int
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/call/invalid_syntax.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/call/invalid_syntax.md
@@ -1,0 +1,44 @@
+# Invalid signatures
+
+## Multiple arguments with the same name
+
+We always map a keyword argument to the first parameter of that name.
+
+```py
+# error: [invalid-syntax] "Duplicate parameter "x""
+def f(x: int, x: str) -> int:
+    return 1
+
+# error: 13 [missing-argument] "No argument provided for required parameter `x` of function `f`"
+# error: 18 [parameter-already-assigned] "Multiple values provided for parameter `x` of function `f`"
+reveal_type(f(1, x=2))  # revealed: int
+```
+
+## Positional after non-positional
+
+When parameter kinds are given in an invalid order, we emit a diagnostic and implicitly reorder them
+to the valid order:
+
+```py
+# error: [invalid-syntax] "Parameter cannot follow var-keyword parameter"
+def f(**kw: int, x: str) -> int:
+    return 1
+
+# error: 15 [invalid-argument-type] "Object of type `Literal[1]` cannot be assigned to parameter 1 (`x`) of function `f`; expected type `str`"
+reveal_type(f(1))  # revealed: int
+```
+
+## Non-defaulted after defaulted
+
+We emit a syntax diagnostic for this, but it doesn't cause any problems for binding.
+
+```py
+# error: [invalid-syntax] "Parameter without a default cannot follow a parameter with a default"
+def f(x: int = 1, y: str) -> int:
+    return 1
+
+reveal_type(f(y="foo"))  # revealed: int
+# error: [invalid-argument-type] "Object of type `Literal["foo"]` cannot be assigned to parameter 1 (`x`) of function `f`; expected type `int`"
+# error: [missing-argument] "No argument provided for required parameter `y` of function `f`"
+reveal_type(f("foo"))  # revealed: int
+```

--- a/crates/red_knot_python_semantic/resources/mdtest/narrow/isinstance.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/narrow/isinstance.md
@@ -169,8 +169,7 @@ def _(flag: bool):
 def _(flag: bool):
     x = 1 if flag else "a"
 
-    # TODO: this should cause us to emit a diagnostic
-    # (`isinstance` has no `foo` parameter)
+    # error: [unknown-argument]
     if isinstance(x, int, foo="bar"):
         reveal_type(x)  # revealed: Literal[1] | Literal["a"]
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/narrow/issubclass.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/narrow/issubclass.md
@@ -146,7 +146,7 @@ class A: ...
 
 t = object()
 
-# TODO: we should emit a diagnostic here
+# error: [invalid-argument-type]
 if issubclass(t, A):
     reveal_type(t)  # revealed: type[A]
 ```
@@ -160,7 +160,7 @@ branch:
 ```py
 t = 1
 
-# TODO: we should emit a diagnostic here
+# error: [invalid-argument-type]
 if issubclass(t, int):
     reveal_type(t)  # revealed: Never
 ```
@@ -234,8 +234,7 @@ def flag() -> bool: ...
 
 t = int if flag() else str
 
-# TODO: this should cause us to emit a diagnostic
-# (`issubclass` has no `foo` parameter)
+# error: [unknown-argument]
 if issubclass(t, int, foo="bar"):
     reveal_type(t)  # revealed: Literal[int, str]
 ```

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -1809,11 +1809,7 @@ impl<'db> Type<'db> {
             }
 
             instance_ty @ Type::Instance(_) => {
-                match instance_ty.call_dunder(
-                    db,
-                    "__call__",
-                    &arguments.clone().with_self(instance_ty),
-                ) {
+                match instance_ty.call_dunder(db, "__call__", &arguments.with_self(instance_ty)) {
                     CallDunderResult::CallOutcome(CallOutcome::NotCallable { .. }) => {
                         // Turn "`<type of illegal '__call__'>` not callable" into
                         // "`X` not callable"

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -1772,7 +1772,7 @@ impl<'db> Type<'db> {
     fn call(self, db: &'db dyn Db, arguments: &CallArguments<'db>) -> CallOutcome<'db> {
         match self {
             Type::FunctionLiteral(function_type) => {
-                let mut binding = bind_call(db, arguments, function_type.signature(db));
+                let mut binding = bind_call(db, arguments, function_type.signature(db), Some(self));
                 match function_type.known(db) {
                     Some(KnownFunction::RevealType) => {
                         let revealed_ty = binding.first_parameter().unwrap_or(Type::Unknown);

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -1687,6 +1687,7 @@ impl<'db> Type<'db> {
                     {
                         bool_val.into()
                     } else {
+                        // TODO diagnostic if not assignable to bool
                         Truthiness::Ambiguous
                     }
                 }

--- a/crates/red_knot_python_semantic/src/types/call.rs
+++ b/crates/red_knot_python_semantic/src/types/call.rs
@@ -1,4 +1,3 @@
-#![allow(dead_code)]
 use super::context::InferContext;
 use super::diagnostic::CALL_NON_CALLABLE;
 use super::{Severity, Signature, Type, TypeArrayDisplay, UnionBuilder};

--- a/crates/red_knot_python_semantic/src/types/call/arguments.rs
+++ b/crates/red_knot_python_semantic/src/types/call/arguments.rs
@@ -1,0 +1,62 @@
+use super::Type;
+use ruff_python_ast::name::Name;
+use std::collections::VecDeque;
+
+/// Typed arguments for a single call, in source order.
+#[derive(Clone, Debug, Default)]
+pub(crate) struct CallArguments<'db>(VecDeque<Argument<'db>>);
+
+impl<'db> CallArguments<'db> {
+    /// Create a [`CallArguments`] from an iterator over [`Argument`]s.
+    pub(crate) fn from_arguments(arguments: impl IntoIterator<Item = Argument<'db>>) -> Self {
+        Self(arguments.into_iter().collect())
+    }
+
+    /// Create a [`CallArguments`] from an iterator over non-variadic positional argument types.
+    pub(crate) fn positional(positional_tys: impl IntoIterator<Item = Type<'db>>) -> Self {
+        Self::from_arguments(positional_tys.into_iter().map(Argument::Positional))
+    }
+
+    /// Prepend an extra positional argument.
+    pub(crate) fn with_self(mut self, self_ty: Type<'db>) -> Self {
+        self.0.push_front(Argument::Positional(self_ty));
+        self
+    }
+
+    // TODO this should be eliminated in favor of [`bind_call`]
+    pub(crate) fn first_argument(&self) -> Option<Type<'db>> {
+        self.0.front().map(Argument::ty)
+    }
+}
+
+impl<'db, 'a> IntoIterator for &'a CallArguments<'db> {
+    type Item = &'a Argument<'db>;
+    type IntoIter = std::collections::vec_deque::Iter<'a, Argument<'db>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.iter()
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(crate) enum Argument<'db> {
+    /// A positional argument.
+    Positional(Type<'db>),
+    /// A starred positional argument (e.g. `*args`).
+    Variadic(Type<'db>),
+    /// A keyword argument (e.g. `a=1`).
+    Keyword { name: Name, ty: Type<'db> },
+    /// The double-starred keywords argument (e.g. `**kwargs`).
+    Keywords(Type<'db>),
+}
+
+impl<'db> Argument<'db> {
+    fn ty(&self) -> Type<'db> {
+        match self {
+            Self::Positional(ty) => *ty,
+            Self::Variadic(ty) => *ty,
+            Self::Keyword { name: _, ty } => *ty,
+            Self::Keywords(ty) => *ty,
+        }
+    }
+}

--- a/crates/red_knot_python_semantic/src/types/call/arguments.rs
+++ b/crates/red_knot_python_semantic/src/types/call/arguments.rs
@@ -7,20 +7,22 @@ use std::collections::VecDeque;
 pub(crate) struct CallArguments<'db>(VecDeque<Argument<'db>>);
 
 impl<'db> CallArguments<'db> {
-    /// Create a [`CallArguments`] from an iterator over [`Argument`]s.
-    pub(crate) fn from_arguments(arguments: impl IntoIterator<Item = Argument<'db>>) -> Self {
-        Self(arguments.into_iter().collect())
-    }
-
     /// Create a [`CallArguments`] from an iterator over non-variadic positional argument types.
     pub(crate) fn positional(positional_tys: impl IntoIterator<Item = Type<'db>>) -> Self {
-        Self::from_arguments(positional_tys.into_iter().map(Argument::Positional))
+        positional_tys
+            .into_iter()
+            .map(Argument::Positional)
+            .collect()
     }
 
     /// Prepend an extra positional argument.
     pub(crate) fn with_self(mut self, self_ty: Type<'db>) -> Self {
         self.0.push_front(Argument::Positional(self_ty));
         self
+    }
+
+    pub(crate) fn iter(&self) -> impl Iterator<Item = &Argument<'db>> {
+        self.0.iter()
     }
 
     // TODO this should be eliminated in favor of [`bind_call`]
@@ -35,6 +37,12 @@ impl<'db, 'a> IntoIterator for &'a CallArguments<'db> {
 
     fn into_iter(self) -> Self::IntoIter {
         self.0.iter()
+    }
+}
+
+impl<'db> FromIterator<Argument<'db>> for CallArguments<'db> {
+    fn from_iter<T: IntoIterator<Item = Argument<'db>>>(iter: T) -> Self {
+        Self(iter.into_iter().collect())
     }
 }
 

--- a/crates/red_knot_python_semantic/src/types/call/bind.rs
+++ b/crates/red_knot_python_semantic/src/types/call/bind.rs
@@ -271,8 +271,13 @@ impl<'db> CallBindingError<'db> {
                     &TOO_MANY_POSITIONAL_ARGUMENTS,
                     Self::get_node(node, *first_excess_argument_index),
                     format_args!(
-                        "Too many positional arguments: expected \
-                        {expected_positional_count}, got {provided_positional_count}"
+                        "Too many positional arguments{}: expected \
+                        {expected_positional_count}, got {provided_positional_count}",
+                        if let Some(callable_name) = callable_name {
+                            format!(" to function `{callable_name}`")
+                        } else {
+                            String::new()
+                        }
                     ),
                 );
             }

--- a/crates/red_knot_python_semantic/src/types/call/bind.rs
+++ b/crates/red_knot_python_semantic/src/types/call/bind.rs
@@ -19,6 +19,7 @@ pub(crate) fn bind_call<'db>(
     callable_ty: Option<Type<'db>>,
 ) -> CallBinding<'db> {
     let parameters = signature.parameters();
+    // The type assigned to each parameter at this call site.
     let mut parameter_tys = vec![None; parameters.len()];
     let mut errors = vec![];
     let mut next_positional = 0;

--- a/crates/red_knot_python_semantic/src/types/call/bind.rs
+++ b/crates/red_knot_python_semantic/src/types/call/bind.rs
@@ -199,12 +199,12 @@ impl std::fmt::Display for ParameterContext {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         if let Some(name) = &self.name {
             if self.positional {
-                write!(f, "{} (`{name}`)", self.index)
+                write!(f, "{} (`{name}`)", self.index + 1)
             } else {
                 write!(f, "`{name}`")
             }
         } else {
-            write!(f, "{}", self.index)
+            write!(f, "{}", self.index + 1)
         }
     }
 }

--- a/crates/red_knot_python_semantic/src/types/call/bind.rs
+++ b/crates/red_knot_python_semantic/src/types/call/bind.rs
@@ -1,0 +1,278 @@
+#![allow(dead_code)]
+use super::{Argument, CallArguments, InferContext, Signature, Type};
+use crate::db::Db;
+use crate::types::diagnostic::{
+    INVALID_ARGUMENT_TYPE, MISSING_ARGUMENT, PARAMETER_ALREADY_ASSIGNED,
+    TOO_MANY_POSITIONAL_ARGUMENTS, UNKNOWN_ARGUMENT,
+};
+use crate::types::UnionType;
+use ruff_python_ast as ast;
+
+/// Bind a [`CallArguments`] against a callable [`Signature`].
+///
+/// The returned [`CallBinding`] provides the return type of the call, the bound types for all
+/// parameters, and any errors resulting from binding the call.
+pub(crate) fn bind_call<'db>(
+    db: &'db dyn Db,
+    arguments: &CallArguments<'db>,
+    signature: &Signature<'db>,
+) -> CallBinding<'db> {
+    let param_count = signature.parameter_count();
+    let mut parameter_tys = vec![None; param_count];
+    let mut errors = vec![];
+    let mut next_positional = 0;
+    let mut first_excess_positional = None;
+    for (argument_index, argument) in arguments.into_iter().enumerate() {
+        let (index, parameter, argument_ty) = match argument {
+            Argument::Positional(ty) => {
+                let Some((index, parameter)) = signature
+                    .positional_at_index(next_positional)
+                    .map(|param| (next_positional, param))
+                    .or_else(|| signature.variadic_parameter())
+                else {
+                    first_excess_positional.get_or_insert(argument_index);
+                    next_positional += 1;
+                    continue;
+                };
+                next_positional += 1;
+                (index, parameter, ty)
+            }
+            Argument::Keyword { name, ty } => {
+                let Some((index, parameter)) = signature
+                    .keyword_by_name(name)
+                    .or_else(|| signature.keywords_parameter())
+                else {
+                    errors.push(CallBindingError::UnknownArgument {
+                        unknown_name: name.clone(),
+                        unknown_argument_index: argument_index,
+                    });
+                    continue;
+                };
+                (index, parameter, ty)
+            }
+
+            Argument::Variadic(_) | Argument::Keywords(_) => {
+                // TODO
+                continue;
+            }
+        };
+        let expected_ty = parameter.annotated_ty();
+        if !argument_ty.is_assignable_to(db, expected_ty) {
+            errors.push(CallBindingError::InvalidArgumentType {
+                parameter_name: parameter.display_name(index),
+                argument_index,
+                expected_ty,
+                provided_ty: *argument_ty,
+            });
+        }
+        if let Some(existing) = parameter_tys[index].replace(*argument_ty) {
+            if parameter.is_variadic() {
+                let union = UnionType::from_elements(db, [existing, *argument_ty]);
+                parameter_tys[index].replace(union);
+            } else {
+                errors.push(CallBindingError::ParameterAlreadyAssigned {
+                    argument_index,
+                    parameter_name: parameter.display_name(index),
+                });
+            }
+        }
+    }
+    if let Some(first_excess_argument_index) = first_excess_positional {
+        errors.push(CallBindingError::TooManyPositionalArguments {
+            first_excess_argument_index,
+            expected_positional_count: signature.positional_parameter_count(),
+            provided_positional_count: next_positional,
+        });
+    }
+    for (index, bound_ty) in parameter_tys.iter().enumerate() {
+        if bound_ty.is_none() {
+            let param = signature
+                .parameter_at_index(index)
+                .expect("parameter_tys array should not be larger than number of parameters");
+            if param.is_variadic() || param.is_keywords() || param.default_ty().is_some() {
+                // variadic/keywords and defaulted arguments are not required
+                continue;
+            }
+            errors.push(CallBindingError::MissingArgument {
+                parameter_name: param.display_name(index),
+            });
+        }
+    }
+
+    CallBinding {
+        return_ty: signature.return_ty,
+        parameter_tys: parameter_tys
+            .into_iter()
+            .map(|opt_ty| opt_ty.unwrap_or(Type::Unknown))
+            .collect(),
+        errors,
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct CallBinding<'db> {
+    /// Return type of the call.
+    return_ty: Type<'db>,
+
+    /// Bound types for parameters, in parameter source order.
+    parameter_tys: Box<[Type<'db>]>,
+
+    /// Call binding errors, if any.
+    // TODO use SmallVec once variance bug is fixed
+    errors: Vec<CallBindingError<'db>>,
+}
+
+impl<'db> CallBinding<'db> {
+    // TODO remove this constructor and construct always from `bind_call`
+    pub(crate) fn from_return_ty(return_ty: Type<'db>) -> Self {
+        Self {
+            return_ty,
+            parameter_tys: Box::default(),
+            errors: vec![],
+        }
+    }
+
+    pub(crate) fn set_return_ty(&mut self, return_ty: Type<'db>) {
+        self.return_ty = return_ty;
+    }
+
+    pub(crate) fn return_ty(&self) -> Type<'db> {
+        self.return_ty
+    }
+
+    pub(crate) fn parameter_tys(&self) -> &[Type<'db>] {
+        &self.parameter_tys
+    }
+
+    pub(crate) fn first_parameter(&self) -> Option<Type<'db>> {
+        self.parameter_tys().first().copied()
+    }
+
+    pub(crate) fn errors(&self) -> std::slice::Iter<'_, CallBindingError<'db>> {
+        self.errors.iter()
+    }
+
+    pub(super) fn report_diagnostics(&self, context: &InferContext<'db>, node: ast::AnyNodeRef) {
+        for error in &self.errors {
+            error.report_diagnostic(context, node);
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum CallBindingError<'db> {
+    /// The type of an argument is not assignable to the annotated type of its corresponding
+    /// parameter.
+    InvalidArgumentType {
+        parameter_name: ast::name::Name,
+        argument_index: usize,
+        expected_ty: Type<'db>,
+        provided_ty: Type<'db>,
+    },
+    /// A required parameter (that is, one without a default) is not supplied by any argument.
+    MissingArgument { parameter_name: ast::name::Name },
+    /// A call argument can't be matched to any parameter.
+    UnknownArgument {
+        unknown_name: ast::name::Name,
+        unknown_argument_index: usize,
+    },
+    /// More positional arguments are provided in the call than can be handled by the signature.
+    TooManyPositionalArguments {
+        first_excess_argument_index: usize,
+        expected_positional_count: usize,
+        provided_positional_count: usize,
+    },
+    /// Multiple arguments were provided for a single parameter.
+    ParameterAlreadyAssigned {
+        argument_index: usize,
+        parameter_name: ast::name::Name,
+    },
+}
+
+impl<'db> CallBindingError<'db> {
+    pub(super) fn report_diagnostic(&self, context: &InferContext<'db>, node: ast::AnyNodeRef) {
+        match self {
+            Self::InvalidArgumentType {
+                parameter_name,
+                argument_index,
+                expected_ty,
+                provided_ty,
+            } => {
+                let provided_ty_display = provided_ty.display(context.db());
+                let expected_ty_display = expected_ty.display(context.db());
+                context.report_lint(
+                    &INVALID_ARGUMENT_TYPE,
+                    Self::get_node(node, *argument_index),
+                    format_args!(
+                        "Cannot assign type `{provided_ty_display}` to parameter \
+                        `{parameter_name}` of type `{expected_ty_display}`",
+                    ),
+                );
+            }
+
+            Self::TooManyPositionalArguments {
+                first_excess_argument_index,
+                expected_positional_count,
+                provided_positional_count,
+            } => {
+                context.report_lint(
+                    &TOO_MANY_POSITIONAL_ARGUMENTS,
+                    Self::get_node(node, *first_excess_argument_index),
+                    format_args!(
+                        "Too many positional arguments: expected \
+                        {expected_positional_count}, got {provided_positional_count}"
+                    ),
+                );
+            }
+
+            Self::MissingArgument { parameter_name } => {
+                context.report_lint(
+                    &MISSING_ARGUMENT,
+                    node,
+                    format_args!("No argument provided for required parameter `{parameter_name}`"),
+                );
+            }
+
+            Self::UnknownArgument {
+                unknown_name,
+                unknown_argument_index,
+            } => {
+                context.report_lint(
+                    &UNKNOWN_ARGUMENT,
+                    Self::get_node(node, *unknown_argument_index),
+                    format_args!("Argument `{unknown_name}` does not match any known parameter"),
+                );
+            }
+
+            Self::ParameterAlreadyAssigned {
+                argument_index,
+                parameter_name,
+            } => {
+                context.report_lint(
+                    &PARAMETER_ALREADY_ASSIGNED,
+                    Self::get_node(node, *argument_index),
+                    format_args!("Parameter `{parameter_name}` is already assigned"),
+                );
+            }
+        }
+    }
+
+    fn get_node(node: ast::AnyNodeRef, argument_index: usize) -> ast::AnyNodeRef {
+        // If we have a Call node, report the diagnostic on the correct argument node;
+        // otherwise, report it on the entire provided node.
+        match node {
+            ast::AnyNodeRef::ExprCall(call_node) => {
+                match call_node
+                    .arguments
+                    .arguments_source_order()
+                    .nth(argument_index)
+                    .expect("InvalidArgumentType argument_index should not be out of range")
+                {
+                    ast::ArgOrKeyword::Arg(expr) => expr.into(),
+                    ast::ArgOrKeyword::Keyword(keyword) => keyword.into(),
+                }
+            }
+            _ => node,
+        }
+    }
+}

--- a/crates/red_knot_python_semantic/src/types/call/bind.rs
+++ b/crates/red_knot_python_semantic/src/types/call/bind.rs
@@ -312,7 +312,14 @@ impl<'db> CallBindingError<'db> {
                 context.report_lint(
                     &MISSING_ARGUMENT,
                     node,
-                    format_args!("No argument{s} provided for required parameter{s} {parameters}",),
+                    format_args!(
+                        "No argument{s} provided for required parameter{s} {parameters}{}",
+                        if let Some(callable_name) = callable_name {
+                            format!(" of function `{callable_name}`")
+                        } else {
+                            String::new()
+                        }
+                    ),
                 );
             }
 
@@ -323,7 +330,14 @@ impl<'db> CallBindingError<'db> {
                 context.report_lint(
                     &UNKNOWN_ARGUMENT,
                     Self::get_node(node, *argument_index),
-                    format_args!("Argument `{argument_name}` does not match any known parameter"),
+                    format_args!(
+                        "Argument `{argument_name}` does not match any known parameter{}",
+                        if let Some(callable_name) = callable_name {
+                            format!(" of function `{callable_name}`")
+                        } else {
+                            String::new()
+                        }
+                    ),
                 );
             }
 
@@ -335,7 +349,7 @@ impl<'db> CallBindingError<'db> {
                     &PARAMETER_ALREADY_ASSIGNED,
                     Self::get_node(node, *argument_index),
                     format_args!(
-                        "Got multiple values for parameter {parameter}{}",
+                        "Multiple values provided for parameter {parameter}{}",
                         if let Some(callable_name) = callable_name {
                             format!(" of function `{callable_name}`")
                         } else {

--- a/crates/red_knot_python_semantic/src/types/call/bind.rs
+++ b/crates/red_knot_python_semantic/src/types/call/bind.rs
@@ -127,7 +127,6 @@ pub(crate) struct CallBinding<'db> {
     parameter_tys: Box<[Type<'db>]>,
 
     /// Call binding errors, if any.
-    // TODO use SmallVec once variance bug is fixed
     errors: Vec<CallBindingError<'db>>,
 }
 

--- a/crates/red_knot_python_semantic/src/types/call/bind.rs
+++ b/crates/red_knot_python_semantic/src/types/call/bind.rs
@@ -371,7 +371,7 @@ impl<'db> CallBindingError<'db> {
                     .arguments
                     .arguments_source_order()
                     .nth(argument_index)
-                    .expect("InvalidArgumentType argument_index should not be out of range")
+                    .expect("argument index should not be out of range")
                 {
                     ast::ArgOrKeyword::Arg(expr) => expr.into(),
                     ast::ArgOrKeyword::Keyword(keyword) => keyword.into(),

--- a/crates/red_knot_python_semantic/src/types/call/bind.rs
+++ b/crates/red_knot_python_semantic/src/types/call/bind.rs
@@ -1,4 +1,3 @@
-#![allow(dead_code)]
 use super::{Argument, CallArguments, InferContext, Signature, Type};
 use crate::db::Db;
 use crate::types::diagnostic::{
@@ -22,7 +21,7 @@ pub(crate) fn bind_call<'db>(
     let mut errors = vec![];
     let mut next_positional = 0;
     let mut first_excess_positional = None;
-    for (argument_index, argument) in arguments.into_iter().enumerate() {
+    for (argument_index, argument) in arguments.iter().enumerate() {
         let (index, parameter, argument_ty) = match argument {
             Argument::Positional(ty) => {
                 let Some((index, parameter)) = signature
@@ -146,10 +145,6 @@ impl<'db> CallBinding<'db> {
 
     pub(crate) fn first_parameter(&self) -> Option<Type<'db>> {
         self.parameter_tys().first().copied()
-    }
-
-    pub(crate) fn errors(&self) -> std::slice::Iter<'_, CallBindingError<'db>> {
-        self.errors.iter()
     }
 
     pub(super) fn report_diagnostics(&self, context: &InferContext<'db>, node: ast::AnyNodeRef) {

--- a/crates/red_knot_python_semantic/src/types/call/bind.rs
+++ b/crates/red_knot_python_semantic/src/types/call/bind.rs
@@ -57,14 +57,15 @@ pub(crate) fn bind_call<'db>(
                 continue;
             }
         };
-        let expected_ty = parameter.annotated_ty();
-        if !argument_ty.is_assignable_to(db, expected_ty) {
-            errors.push(CallBindingError::InvalidArgumentType {
-                parameter: ParameterContext::new(parameter, index),
-                argument_index,
-                expected_ty,
-                provided_ty: *argument_ty,
-            });
+        if let Some(expected_ty) = parameter.annotated_ty() {
+            if !argument_ty.is_assignable_to(db, expected_ty) {
+                errors.push(CallBindingError::InvalidArgumentType {
+                    parameter: ParameterContext::new(parameter, index),
+                    argument_index,
+                    expected_ty,
+                    provided_ty: *argument_ty,
+                });
+            }
         }
         if let Some(existing) = parameter_tys[index].replace(*argument_ty) {
             if parameter.is_variadic() {
@@ -105,7 +106,7 @@ pub(crate) fn bind_call<'db>(
 
     CallBinding {
         callable_ty,
-        return_ty: signature.return_ty,
+        return_ty: signature.return_ty.unwrap_or(Type::Unknown),
         parameter_tys: parameter_tys
             .into_iter()
             .map(|opt_ty| opt_ty.unwrap_or(Type::Unknown))

--- a/crates/red_knot_python_semantic/src/types/call/bind.rs
+++ b/crates/red_knot_python_semantic/src/types/call/bind.rs
@@ -82,7 +82,7 @@ pub(crate) fn bind_call<'db>(
     if let Some(first_excess_argument_index) = first_excess_positional {
         errors.push(CallBindingError::TooManyPositionalArguments {
             first_excess_argument_index,
-            expected_positional_count: parameters.positional_count(),
+            expected_positional_count: parameters.positional().count(),
             provided_positional_count: next_positional,
         });
     }

--- a/crates/red_knot_python_semantic/src/types/call/bind.rs
+++ b/crates/red_knot_python_semantic/src/types/call/bind.rs
@@ -44,8 +44,8 @@ pub(crate) fn bind_call<'db>(
                     .or_else(|| parameters.keyword_variadic())
                 else {
                     errors.push(CallBindingError::UnknownArgument {
-                        unknown_name: name.clone(),
-                        unknown_argument_index: argument_index,
+                        argument_name: name.clone(),
+                        argument_index,
                     });
                     continue;
                 };
@@ -236,8 +236,8 @@ pub(crate) enum CallBindingError<'db> {
     MissingArguments { parameters: ParameterContexts },
     /// A call argument can't be matched to any parameter.
     UnknownArgument {
-        unknown_name: ast::name::Name,
-        unknown_argument_index: usize,
+        argument_name: ast::name::Name,
+        argument_index: usize,
     },
     /// More positional arguments are provided in the call than can be handled by the signature.
     TooManyPositionalArguments {
@@ -313,13 +313,13 @@ impl<'db> CallBindingError<'db> {
             }
 
             Self::UnknownArgument {
-                unknown_name,
-                unknown_argument_index,
+                argument_name,
+                argument_index,
             } => {
                 context.report_lint(
                     &UNKNOWN_ARGUMENT,
-                    Self::get_node(node, *unknown_argument_index),
-                    format_args!("Argument `{unknown_name}` does not match any known parameter"),
+                    Self::get_node(node, *argument_index),
+                    format_args!("Argument `{argument_name}` does not match any known parameter"),
                 );
             }
 

--- a/crates/red_knot_python_semantic/src/types/call/bind.rs
+++ b/crates/red_knot_python_semantic/src/types/call/bind.rs
@@ -308,7 +308,14 @@ impl<'db> CallBindingError<'db> {
                 context.report_lint(
                     &PARAMETER_ALREADY_ASSIGNED,
                     Self::get_node(node, *argument_index),
-                    format_args!("Got multiple values for {parameter}"),
+                    format_args!(
+                        "Got multiple values for {parameter}{}",
+                        if let Some(callable_name) = callable_name {
+                            format!(" of function `{callable_name}`")
+                        } else {
+                            String::new()
+                        }
+                    ),
                 );
             }
         }

--- a/crates/red_knot_python_semantic/src/types/call/bind.rs
+++ b/crates/red_knot_python_semantic/src/types/call/bind.rs
@@ -91,7 +91,7 @@ pub(crate) fn bind_call<'db>(
     for (index, bound_ty) in parameter_tys.iter().enumerate() {
         if bound_ty.is_none() {
             let param = &parameters[index];
-            if param.is_variadic() || param.is_keywords() || param.default_ty().is_some() {
+            if param.is_variadic() || param.is_keyword_variadic() || param.default_ty().is_some() {
                 // variadic/keywords and defaulted arguments are not required
                 continue;
             }

--- a/crates/red_knot_python_semantic/src/types/diagnostic.rs
+++ b/crates/red_knot_python_semantic/src/types/diagnostic.rs
@@ -30,6 +30,7 @@ pub(crate) fn register_lints(registry: &mut LintRegistryBuilder) {
     registry.register_lint(&INCOMPATIBLE_SLOTS);
     registry.register_lint(&INCONSISTENT_MRO);
     registry.register_lint(&INDEX_OUT_OF_BOUNDS);
+    registry.register_lint(&INVALID_ARGUMENT_TYPE);
     registry.register_lint(&INVALID_ASSIGNMENT);
     registry.register_lint(&INVALID_BASE);
     registry.register_lint(&INVALID_CONTEXT_MANAGER);
@@ -39,13 +40,17 @@ pub(crate) fn register_lints(registry: &mut LintRegistryBuilder) {
     registry.register_lint(&INVALID_RAISE);
     registry.register_lint(&INVALID_TYPE_FORM);
     registry.register_lint(&INVALID_TYPE_VARIABLE_CONSTRAINTS);
+    registry.register_lint(&MISSING_ARGUMENT);
     registry.register_lint(&NON_SUBSCRIPTABLE);
     registry.register_lint(&NOT_ITERABLE);
+    registry.register_lint(&PARAMETER_ALREADY_ASSIGNED);
     registry.register_lint(&POSSIBLY_UNBOUND_ATTRIBUTE);
     registry.register_lint(&POSSIBLY_UNBOUND_IMPORT);
     registry.register_lint(&POSSIBLY_UNRESOLVED_REFERENCE);
     registry.register_lint(&SUBCLASS_OF_FINAL_CLASS);
+    registry.register_lint(&TOO_MANY_POSITIONAL_ARGUMENTS);
     registry.register_lint(&UNDEFINED_REVEAL);
+    registry.register_lint(&UNKNOWN_ARGUMENT);
     registry.register_lint(&UNRESOLVED_ATTRIBUTE);
     registry.register_lint(&UNRESOLVED_IMPORT);
     registry.register_lint(&UNRESOLVED_REFERENCE);
@@ -227,6 +232,27 @@ declare_lint! {
 }
 
 declare_lint! {
+    /// ## What it does
+    /// Detects call arguments whose type is not assignable to the corresponding typed parameter.
+    ///
+    /// ## Why is this bad?
+    /// Passing an argument of a type the function (or callable object) does not accept violates
+    /// the expectations of the function author and may cause unexpected runtime errors within the
+    /// body of the function.
+    ///
+    /// ## Examples
+    /// ```python
+    /// def func(x: int): ...
+    /// func("foo")  # error: [invalid-argument-type]
+    /// ```
+    pub(crate) static INVALID_ARGUMENT_TYPE = {
+        summary: "detects call arguments whose type is not assignable to the corresponding typed parameter",
+        status: LintStatus::preview("1.0.0"),
+        default_level: Level::Error,
+    }
+}
+
+declare_lint! {
     /// TODO #14889
     pub(crate) static INVALID_ASSIGNMENT = {
         summary: "detects invalid assignments",
@@ -377,6 +403,25 @@ declare_lint! {
 
 declare_lint! {
     /// ## What it does
+    /// Checks for missing required arguments in a call.
+    ///
+    /// ## Why is this bad?
+    /// Failing to provide a required argument will raise a `TypeError` at runtime.
+    ///
+    /// ## Examples
+    /// ```python
+    /// def func(x: int): ...
+    /// func()  # TypeError: func() missing 1 required positional argument: 'x'
+    /// ```
+    pub(crate) static MISSING_ARGUMENT = {
+        summary: "detects missing required arguments in a call",
+        status: LintStatus::preview("1.0.0"),
+        default_level: Level::Error,
+    }
+}
+
+declare_lint! {
+    /// ## What it does
     /// Checks for subscripting objects that do not support subscripting.
     ///
     /// ## Why is this bad?
@@ -408,6 +453,27 @@ declare_lint! {
     /// ```
     pub(crate) static NOT_ITERABLE = {
         summary: "detects iteration over an object that is not iterable",
+        status: LintStatus::preview("1.0.0"),
+        default_level: Level::Error,
+    }
+}
+
+declare_lint! {
+    /// ## What it does
+    /// Checks for calls which provide more than one argument for a single parameter.
+    ///
+    /// ## Why is this bad?
+    /// Providing multiple values for a single parameter will raise a `TypeError` at runtime.
+    ///
+    /// ## Examples
+    ///
+    /// ```python
+    /// def f(x: int) -> int: ...
+    ///
+    /// f(1, x=2)  # Error raised here
+    /// ```
+    pub(crate) static PARAMETER_ALREADY_ASSIGNED = {
+        summary: "detects multiple arguments for the same parameter",
         status: LintStatus::preview("1.0.0"),
         default_level: Level::Error,
     }
@@ -481,6 +547,27 @@ declare_lint! {
 
 declare_lint! {
     /// ## What it does
+    /// Checks for calls that pass more positional arguments than the callable can accept.
+    ///
+    /// ## Why is this bad?
+    /// Passing too many positional arguments will raise `TypeError` at runtime.
+    ///
+    /// ## Example
+    ///
+    /// ```python
+    /// def f(): ...
+    ///
+    /// f("foo")  # Error raised here
+    /// ```
+    pub(crate) static TOO_MANY_POSITIONAL_ARGUMENTS = {
+        summary: "detects calls passing too many positional arguments",
+        status: LintStatus::preview("1.0.0"),
+        default_level: Level::Error,
+    }
+}
+
+declare_lint! {
+    /// ## What it does
     /// Checks for calls to `reveal_type` without importing it.
     ///
     /// ## Why is this bad?
@@ -492,6 +579,27 @@ declare_lint! {
         summary: "detects usages of `reveal_type` without importing it",
         status: LintStatus::preview("1.0.0"),
         default_level: Level::Warn,
+    }
+}
+
+declare_lint! {
+    /// ## What it does
+    /// Checks for keyword arguments in calls that don't match any parameter of the callable.
+    ///
+    /// ## Why is this bad?
+    /// Providing an unknown keyword argument will raise `TypeError` at runtime.
+    ///
+    /// ## Example
+    ///
+    /// ```python
+    /// def f(x: int) -> int: ...
+    ///
+    /// f(x=1, y=2)  # Error raised here
+    /// ```
+    pub(crate) static UNKNOWN_ARGUMENT = {
+        summary: "detects unknown keyword arguments in calls",
+        status: LintStatus::preview("1.0.0"),
+        default_level: Level::Error,
     }
 }
 

--- a/crates/red_knot_python_semantic/src/types/signatures.rs
+++ b/crates/red_knot_python_semantic/src/types/signatures.rs
@@ -1,4 +1,3 @@
-#![allow(dead_code)]
 use super::{definition_expression_ty, Type};
 use crate::Db;
 use crate::{semantic_index::definition::Definition, types::todo_type};
@@ -7,6 +6,12 @@ use ruff_python_ast::{self as ast, name::Name};
 /// A typed callable signature.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct Signature<'db> {
+    /// Parameters, in source order.
+    ///
+    /// The ordering of parameters in a valid signature must be: first positional-only parameters,
+    /// then positional-or-keyword, then optionally the variadic parameter, then keyword-only
+    /// parameters, and last, optionally the variadic keywords parameter. Parameters with defaults
+    /// must come after parameters without defaults.
     parameters: Parameters<'db>,
 
     /// Annotated return type (Unknown if no annotation.)
@@ -49,45 +54,85 @@ impl<'db> Signature<'db> {
             return_ty,
         }
     }
+
+    /// Return number of parameters in this signature.
+    pub(crate) fn parameter_count(&self) -> usize {
+        self.parameters.0.len()
+    }
+
+    /// Return number of positional parameters this signature can accept.
+    ///
+    /// Doesn't account for variadic parameter.
+    pub(crate) fn positional_parameter_count(&self) -> usize {
+        self.parameters
+            .into_iter()
+            .take_while(|param| param.is_positional())
+            .count()
+    }
+
+    pub(crate) fn parameter_at_index(&self, index: usize) -> Option<&Parameter<'db>> {
+        self.parameters.0.get(index)
+    }
+
+    /// Return positional parameter at given index, or `None` if `index` is out of range.
+    ///
+    /// Does not return variadic parameter.
+    pub(crate) fn positional_at_index(&self, index: usize) -> Option<&Parameter<'db>> {
+        if let Some(candidate) = self.parameter_at_index(index) {
+            if candidate.is_positional() {
+                return Some(candidate);
+            }
+        }
+        None
+    }
+
+    /// Return the variadic parameter (`*args`), if any, and its index, or `None`.
+    pub(crate) fn variadic_parameter(&self) -> Option<(usize, &Parameter<'db>)> {
+        self.parameters
+            .into_iter()
+            .enumerate()
+            .find(|(_, parameter)| parameter.is_variadic())
+    }
+
+    /// Return parameter (with index) for given name, or `None` if no such parameter.
+    ///
+    /// Does not return keywords (`**kwargs`) parameter.
+    pub(crate) fn keyword_by_name(
+        &self,
+        name: &ast::name::Name,
+    ) -> Option<(usize, &Parameter<'db>)> {
+        self.parameters
+            .into_iter()
+            .enumerate()
+            .find(|(_, parameter)| parameter.callable_by_name(name))
+    }
+
+    /// Return the keywords parameter (`**kwargs`), if any, and its index, or `None`.
+    pub(crate) fn keywords_parameter(&self) -> Option<(usize, &Parameter<'db>)> {
+        self.parameters
+            .into_iter()
+            .enumerate()
+            .find(|(_, parameter)| parameter.is_keywords())
+    }
 }
 
-/// The parameters portion of a typed signature.
-///
-/// The ordering of parameters is always as given in this struct: first positional-only parameters,
-/// then positional-or-keyword, then optionally the variadic parameter, then keyword-only
-/// parameters, and last, optionally the variadic keywords parameter.
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
-pub(super) struct Parameters<'db> {
-    /// Parameters which may only be filled by positional arguments.
-    positional_only: Box<[ParameterWithDefault<'db>]>,
-
-    /// Parameters which may be filled by positional or keyword arguments.
-    positional_or_keyword: Box<[ParameterWithDefault<'db>]>,
-
-    /// The `*args` variadic parameter, if any.
-    variadic: Option<Parameter<'db>>,
-
-    /// Parameters which may only be filled by keyword arguments.
-    keyword_only: Box<[ParameterWithDefault<'db>]>,
-
-    /// The `**kwargs` variadic keywords parameter, if any.
-    keywords: Option<Parameter<'db>>,
-}
+// TODO: use SmallVec here once invariance bug is fixed
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(super) struct Parameters<'db>(Vec<Parameter<'db>>);
 
 impl<'db> Parameters<'db> {
     /// Return todo parameters: (*args: Todo, **kwargs: Todo)
     fn todo() -> Self {
-        Self {
-            variadic: Some(Parameter {
+        Self(vec![
+            Parameter::Variadic(Param {
                 name: Some(Name::new_static("args")),
-                annotated_ty: todo_type!(),
+                annotated_ty: todo_type!("todo signature *args"),
             }),
-            keywords: Some(Parameter {
+            Parameter::Keywords(Param {
                 name: Some(Name::new_static("kwargs")),
-                annotated_ty: todo_type!(),
+                annotated_ty: todo_type!("todo signature **kwargs"),
             }),
-            ..Default::default()
-        }
+        ])
     }
 
     fn from_parameters(
@@ -105,42 +150,125 @@ impl<'db> Parameters<'db> {
         } = parameters;
         let positional_only = posonlyargs
             .iter()
-            .map(|arg| ParameterWithDefault::from_node(db, definition, arg))
-            .collect();
-        let positional_or_keyword = args
-            .iter()
-            .map(|arg| ParameterWithDefault::from_node(db, definition, arg))
-            .collect();
+            .map(|arg| Parameter::PositionalOnly(ParamWithDefault::from_node(db, definition, arg)));
+        let positional_or_keyword = args.iter().map(|arg| {
+            Parameter::PositionalOrKeyword(ParamWithDefault::from_node(db, definition, arg))
+        });
         let variadic = vararg
             .as_ref()
-            .map(|arg| Parameter::from_node(db, definition, arg));
+            .map(|arg| Parameter::Variadic(Param::from_node(db, definition, arg)));
         let keyword_only = kwonlyargs
             .iter()
-            .map(|arg| ParameterWithDefault::from_node(db, definition, arg))
-            .collect();
+            .map(|arg| Parameter::KeywordOnly(ParamWithDefault::from_node(db, definition, arg)));
         let keywords = kwarg
             .as_ref()
-            .map(|arg| Parameter::from_node(db, definition, arg));
-        Self {
-            positional_only,
-            positional_or_keyword,
-            variadic,
-            keyword_only,
-            keywords,
+            .map(|arg| Parameter::Keywords(Param::from_node(db, definition, arg)));
+        Self(
+            positional_only
+                .chain(positional_or_keyword)
+                .chain(variadic)
+                .chain(keyword_only)
+                .chain(keywords)
+                .collect(),
+        )
+    }
+}
+
+impl<'db, 'a> IntoIterator for &'a Parameters<'db> {
+    type Item = &'a Parameter<'db>;
+    type IntoIter = std::slice::Iter<'a, Parameter<'db>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.iter()
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum Parameter<'db> {
+    /// Positional-only parameter, e.g. `def f(x, /): ...`
+    PositionalOnly(ParamWithDefault<'db>),
+    /// Positional-or-keyword parameter, e.g. `def f(x): ...`
+    PositionalOrKeyword(ParamWithDefault<'db>),
+    /// Variadic parameter, e.g. `def f(*args): ...`
+    Variadic(Param<'db>),
+    /// Keyword-only parameter, e.g. `def f(*, x): ...`
+    KeywordOnly(ParamWithDefault<'db>),
+    /// Variadic keywords parameter, e.g. `def f(**kwargs): ...`
+    Keywords(Param<'db>),
+}
+
+impl<'db> Parameter<'db> {
+    pub(crate) fn is_variadic(&self) -> bool {
+        matches!(self, Self::Variadic(_))
+    }
+
+    pub(crate) fn is_keywords(&self) -> bool {
+        matches!(self, Self::Keywords(_))
+    }
+
+    pub(crate) fn is_positional(&self) -> bool {
+        matches!(self, Self::PositionalOnly(_) | Self::PositionalOrKeyword(_))
+    }
+
+    pub(crate) fn callable_by_name(&self, name: &ast::name::Name) -> bool {
+        match self {
+            Self::PositionalOrKeyword(param) | Self::KeywordOnly(param) => param
+                .param
+                .name
+                .as_ref()
+                .is_some_and(|param_name| param_name == name),
+            _ => false,
         }
+    }
+
+    /// Annotated type of the parameter.
+    pub(crate) fn annotated_ty(&self) -> Type<'db> {
+        self.param().annotated_ty
+    }
+
+    /// Name of the parameter (if it has one).
+    pub(crate) fn name(&self) -> Option<&ast::name::Name> {
+        self.param().name.as_ref()
+    }
+
+    /// Display name of the parameter, with fallback if it doesn't have a name.
+    pub(crate) fn display_name(&self, index: usize) -> ast::name::Name {
+        self.name()
+            .cloned()
+            .unwrap_or_else(|| ast::name::Name::new(format!("positional parameter {index}")))
+    }
+
+    /// Default-value type of the parameter, if any.
+    pub(crate) fn default_ty(&self) -> Option<Type<'db>> {
+        match self {
+            Self::PositionalOnly(ParamWithDefault { default_ty, .. }) => *default_ty,
+            Self::PositionalOrKeyword(ParamWithDefault { default_ty, .. }) => *default_ty,
+            Self::Variadic(_) => None,
+            Self::KeywordOnly(ParamWithDefault { default_ty, .. }) => *default_ty,
+            Self::Keywords(_) => None,
+        }
+    }
+
+    fn param(&self) -> &Param<'db> {
+        let (Self::PositionalOnly(ParamWithDefault { param, .. })
+        | Self::PositionalOrKeyword(ParamWithDefault { param, .. })
+        | Self::Variadic(param)
+        | Self::KeywordOnly(ParamWithDefault { param, .. })
+        | Self::Keywords(param)) = self;
+        param
     }
 }
 
 /// A single parameter of a typed signature, with optional default value.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub(super) struct ParameterWithDefault<'db> {
-    parameter: Parameter<'db>,
+pub(crate) struct ParamWithDefault<'db> {
+    param: Param<'db>,
 
     /// Type of the default value, if any.
     default_ty: Option<Type<'db>>,
 }
 
-impl<'db> ParameterWithDefault<'db> {
+impl<'db> ParamWithDefault<'db> {
     fn from_node(
         db: &'db dyn Db,
         definition: Definition<'db>,
@@ -151,14 +279,14 @@ impl<'db> ParameterWithDefault<'db> {
                 .default
                 .as_deref()
                 .map(|default| definition_expression_ty(db, definition, default)),
-            parameter: Parameter::from_node(db, definition, &parameter_with_default.parameter),
+            param: Param::from_node(db, definition, &parameter_with_default.parameter),
         }
     }
 }
 
 /// A single parameter of a typed signature.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub(super) struct Parameter<'db> {
+pub(crate) struct Param<'db> {
     /// Parameter name.
     ///
     /// It is possible for signatures to be defined in ways that leave positional-only parameters
@@ -169,13 +297,13 @@ pub(super) struct Parameter<'db> {
     annotated_ty: Type<'db>,
 }
 
-impl<'db> Parameter<'db> {
+impl<'db> Param<'db> {
     fn from_node(
         db: &'db dyn Db,
         definition: Definition<'db>,
         parameter: &'db ast::Parameter,
     ) -> Self {
-        Parameter {
+        Param {
             name: Some(parameter.name.id.clone()),
             annotated_ty: parameter
                 .annotation
@@ -190,7 +318,7 @@ impl<'db> Parameter<'db> {
 mod tests {
     use super::*;
     use crate::db::tests::{setup_db, TestDb};
-    use crate::types::{global_symbol, FunctionType};
+    use crate::types::{global_symbol, FunctionType, KnownClass};
     use ruff_db::system::DbWithTestSystem;
 
     #[track_caller]
@@ -202,39 +330,8 @@ mod tests {
     }
 
     #[track_caller]
-    fn assert_param_with_default<'db>(
-        db: &'db TestDb,
-        param_with_default: &ParameterWithDefault<'db>,
-        expected_name: &'static str,
-        expected_annotation_ty_display: &'static str,
-        expected_default_ty_display: Option<&'static str>,
-    ) {
-        assert_eq!(
-            param_with_default
-                .default_ty
-                .map(|ty| ty.display(db).to_string()),
-            expected_default_ty_display.map(ToString::to_string)
-        );
-        assert_param(
-            db,
-            &param_with_default.parameter,
-            expected_name,
-            expected_annotation_ty_display,
-        );
-    }
-
-    #[track_caller]
-    fn assert_param<'db>(
-        db: &'db TestDb,
-        param: &Parameter<'db>,
-        expected_name: &'static str,
-        expected_annotation_ty_display: &'static str,
-    ) {
-        assert_eq!(param.name.as_ref().unwrap(), expected_name);
-        assert_eq!(
-            param.annotated_ty.display(db).to_string(),
-            expected_annotation_ty_display
-        );
+    fn assert_params<'db>(signature: &Signature<'db>, expected: &[Parameter<'db>]) {
+        assert_eq!(signature.parameters.0.as_slice(), expected);
     }
 
     #[test]
@@ -246,12 +343,7 @@ mod tests {
         let sig = func.internal_signature(&db);
 
         assert_eq!(sig.return_ty.display(&db).to_string(), "Unknown");
-        let params = sig.parameters;
-        assert!(params.positional_only.is_empty());
-        assert!(params.positional_or_keyword.is_empty());
-        assert!(params.variadic.is_none());
-        assert!(params.keyword_only.is_empty());
-        assert!(params.keywords.is_none());
+        assert_params(&sig, &[]);
     }
 
     #[test]
@@ -272,33 +364,75 @@ mod tests {
         let sig = func.internal_signature(&db);
 
         assert_eq!(sig.return_ty.display(&db).to_string(), "bytes");
-        let params = sig.parameters;
-        let [a, b, c, d] = &params.positional_only[..] else {
-            panic!("expected four positional-only parameters");
-        };
-        let [e, f] = &params.positional_or_keyword[..] else {
-            panic!("expected two positional-or-keyword parameters");
-        };
-        let Some(args) = params.variadic else {
-            panic!("expected a variadic parameter");
-        };
-        let [g, h] = &params.keyword_only[..] else {
-            panic!("expected two keyword-only parameters");
-        };
-        let Some(kwargs) = params.keywords else {
-            panic!("expected a kwargs parameter");
-        };
-
-        assert_param_with_default(&db, a, "a", "Unknown", None);
-        assert_param_with_default(&db, b, "b", "int", None);
-        assert_param_with_default(&db, c, "c", "Unknown", Some("Literal[1]"));
-        assert_param_with_default(&db, d, "d", "int", Some("Literal[2]"));
-        assert_param_with_default(&db, e, "e", "Unknown", Some("Literal[3]"));
-        assert_param_with_default(&db, f, "f", "Literal[4]", Some("Literal[4]"));
-        assert_param_with_default(&db, g, "g", "Unknown", Some("Literal[5]"));
-        assert_param_with_default(&db, h, "h", "Literal[6]", Some("Literal[6]"));
-        assert_param(&db, &args, "args", "object");
-        assert_param(&db, &kwargs, "kwargs", "str");
+        assert_params(
+            &sig,
+            &[
+                Parameter::PositionalOnly(ParamWithDefault {
+                    param: Param {
+                        name: Some(Name::new_static("a")),
+                        annotated_ty: Type::Unknown,
+                    },
+                    default_ty: None,
+                }),
+                Parameter::PositionalOnly(ParamWithDefault {
+                    param: Param {
+                        name: Some(Name::new_static("b")),
+                        annotated_ty: KnownClass::Int.to_instance(&db),
+                    },
+                    default_ty: None,
+                }),
+                Parameter::PositionalOnly(ParamWithDefault {
+                    param: Param {
+                        name: Some(Name::new_static("c")),
+                        annotated_ty: Type::Unknown,
+                    },
+                    default_ty: Some(Type::IntLiteral(1)),
+                }),
+                Parameter::PositionalOnly(ParamWithDefault {
+                    param: Param {
+                        name: Some(Name::new_static("d")),
+                        annotated_ty: KnownClass::Int.to_instance(&db),
+                    },
+                    default_ty: Some(Type::IntLiteral(2)),
+                }),
+                Parameter::PositionalOrKeyword(ParamWithDefault {
+                    param: Param {
+                        name: Some(Name::new_static("e")),
+                        annotated_ty: Type::Unknown,
+                    },
+                    default_ty: Some(Type::IntLiteral(3)),
+                }),
+                Parameter::PositionalOrKeyword(ParamWithDefault {
+                    param: Param {
+                        name: Some(Name::new_static("f")),
+                        annotated_ty: Type::IntLiteral(4),
+                    },
+                    default_ty: Some(Type::IntLiteral(4)),
+                }),
+                Parameter::Variadic(Param {
+                    name: Some(Name::new_static("args")),
+                    annotated_ty: KnownClass::Object.to_instance(&db),
+                }),
+                Parameter::KeywordOnly(ParamWithDefault {
+                    param: Param {
+                        name: Some(Name::new_static("g")),
+                        annotated_ty: Type::Unknown,
+                    },
+                    default_ty: Some(Type::IntLiteral(5)),
+                }),
+                Parameter::KeywordOnly(ParamWithDefault {
+                    param: Param {
+                        name: Some(Name::new_static("h")),
+                        annotated_ty: Type::IntLiteral(6),
+                    },
+                    default_ty: Some(Type::IntLiteral(6)),
+                }),
+                Parameter::Keywords(Param {
+                    name: Some(Name::new_static("kwargs")),
+                    annotated_ty: KnownClass::Str.to_instance(&db),
+                }),
+            ],
+        );
     }
 
     #[test]
@@ -322,11 +456,20 @@ mod tests {
 
         let sig = func.internal_signature(&db);
 
-        let [a] = &sig.parameters.positional_or_keyword[..] else {
+        let [Parameter::PositionalOrKeyword(ParamWithDefault {
+            param:
+                Param {
+                    name: Some(name),
+                    annotated_ty,
+                },
+            ..
+        })] = &sig.parameters.0[..]
+        else {
             panic!("expected one positional-or-keyword parameter");
         };
+        assert_eq!(name, "a");
         // Parameter resolution not deferred; we should see A not B
-        assert_param_with_default(&db, a, "a", "A", None);
+        assert_eq!(annotated_ty.display(&db).to_string(), "A");
     }
 
     #[test]
@@ -350,11 +493,20 @@ mod tests {
 
         let sig = func.internal_signature(&db);
 
-        let [a] = &sig.parameters.positional_or_keyword[..] else {
+        let [Parameter::PositionalOrKeyword(ParamWithDefault {
+            param:
+                Param {
+                    name: Some(name),
+                    annotated_ty,
+                },
+            default_ty: None,
+        })] = &sig.parameters.0[..]
+        else {
             panic!("expected one positional-or-keyword parameter");
         };
+        assert_eq!(name, "a");
         // Parameter resolution deferred; we should see B
-        assert_param_with_default(&db, a, "a", "B", None);
+        assert_eq!(annotated_ty.display(&db).to_string(), "B");
     }
 
     #[test]
@@ -378,12 +530,29 @@ mod tests {
 
         let sig = func.internal_signature(&db);
 
-        let [a, b] = &sig.parameters.positional_or_keyword[..] else {
+        let [Parameter::PositionalOrKeyword(ParamWithDefault {
+            param:
+                Param {
+                    name: Some(a_name),
+                    annotated_ty: a_annotated_ty,
+                },
+            default_ty: None,
+        }), Parameter::PositionalOrKeyword(ParamWithDefault {
+            param:
+                Param {
+                    name: Some(b_name),
+                    annotated_ty: b_annotated_ty,
+                },
+            default_ty: None,
+        })] = &sig.parameters.0[..]
+        else {
             panic!("expected two positional-or-keyword parameters");
         };
+        assert_eq!(a_name, "a");
+        assert_eq!(b_name, "b");
         // TODO resolution should not be deferred; we should see A not B
-        assert_param_with_default(&db, a, "a", "B", None);
-        assert_param_with_default(&db, b, "b", "T", None);
+        assert_eq!(a_annotated_ty.display(&db).to_string(), "B");
+        assert_eq!(b_annotated_ty.display(&db).to_string(), "T");
     }
 
     #[test]
@@ -407,12 +576,29 @@ mod tests {
 
         let sig = func.internal_signature(&db);
 
-        let [a, b] = &sig.parameters.positional_or_keyword[..] else {
+        let [Parameter::PositionalOrKeyword(ParamWithDefault {
+            param:
+                Param {
+                    name: Some(a_name),
+                    annotated_ty: a_annotated_ty,
+                },
+            default_ty: None,
+        }), Parameter::PositionalOrKeyword(ParamWithDefault {
+            param:
+                Param {
+                    name: Some(b_name),
+                    annotated_ty: b_annotated_ty,
+                },
+            default_ty: None,
+        })] = &sig.parameters.0[..]
+        else {
             panic!("expected two positional-or-keyword parameters");
         };
+        assert_eq!(a_name, "a");
+        assert_eq!(b_name, "b");
         // Parameter resolution deferred; we should see B
-        assert_param_with_default(&db, a, "a", "B", None);
-        assert_param_with_default(&db, b, "b", "T", None);
+        assert_eq!(a_annotated_ty.display(&db).to_string(), "B");
+        assert_eq!(b_annotated_ty.display(&db).to_string(), "T");
     }
 
     #[test]

--- a/crates/red_knot_python_semantic/src/types/signatures.rs
+++ b/crates/red_knot_python_semantic/src/types/signatures.rs
@@ -127,15 +127,8 @@ impl<'db> Parameters<'db> {
     /// For a valid signature, this will be all positional parameters. In an invalid signature,
     /// there could be non-initial positional parameters; effectively, we just won't consider those
     /// to be positional, which is fine.
-    pub(crate) fn positional_only(&self) -> impl Iterator<Item = &Parameter<'db>> {
+    pub(crate) fn positional(&self) -> impl Iterator<Item = &Parameter<'db>> {
         self.iter().take_while(|param| param.is_positional())
-    }
-
-    /// Return number of positional parameters this signature can accept.
-    ///
-    /// Doesn't account for variadic parameter.
-    pub(crate) fn positional_count(&self) -> usize {
-        self.positional_only().count()
     }
 
     /// Return parameter at given index, or `None` if index is out-of-range.
@@ -147,12 +140,8 @@ impl<'db> Parameters<'db> {
     ///
     /// Does not return variadic parameter.
     pub(crate) fn get_positional(&self, index: usize) -> Option<&Parameter<'db>> {
-        if let Some(candidate) = self.get(index) {
-            if candidate.is_positional() {
-                return Some(candidate);
-            }
-        }
-        None
+        self.get(index)
+            .and_then(|parameter| parameter.is_positional().then_some(parameter))
     }
 
     /// Return the variadic parameter (`*args`), if any, and its index, or `None`.

--- a/crates/red_knot_python_semantic/src/types/signatures.rs
+++ b/crates/red_knot_python_semantic/src/types/signatures.rs
@@ -226,10 +226,6 @@ impl<'db> Parameter<'db> {
         matches!(self, Self::PositionalOnly(_) | Self::PositionalOrKeyword(_))
     }
 
-    pub(crate) fn is_positional_only(&self) -> bool {
-        matches!(self, Self::PositionalOnly(_))
-    }
-
     pub(crate) fn callable_by_name(&self, name: &str) -> bool {
         match self {
             Self::PositionalOrKeyword(param) | Self::KeywordOnly(param) => param

--- a/crates/red_knot_python_semantic/src/types/signatures.rs
+++ b/crates/red_knot_python_semantic/src/types/signatures.rs
@@ -234,7 +234,11 @@ impl<'db> Parameter<'db> {
     /// Display name of the parameter, with fallback if it doesn't have a name.
     pub(crate) fn display_name(&self, index: usize) -> ast::name::Name {
         self.name()
-            .cloned()
+            .map(|name| match self {
+                Self::Variadic(_) => ast::name::Name::new(format!("*{name}")),
+                Self::Keywords(_) => ast::name::Name::new(format!("**{name}")),
+                _ => name.clone(),
+            })
             .unwrap_or_else(|| ast::name::Name::new(format!("positional parameter {index}")))
     }
 

--- a/crates/red_knot_python_semantic/src/types/signatures.rs
+++ b/crates/red_knot_python_semantic/src/types/signatures.rs
@@ -12,6 +12,8 @@ pub(crate) struct Signature<'db> {
     /// then positional-or-keyword, then optionally the variadic parameter, then keyword-only
     /// parameters, and last, optionally the variadic keywords parameter. Parameters with defaults
     /// must come after parameters without defaults.
+    ///
+    /// We may get invalid signatures, though, and need to handle them without panicking.
     parameters: Parameters<'db>,
 
     /// Annotated return type, if any.

--- a/crates/red_knot_python_semantic/src/types/signatures.rs
+++ b/crates/red_knot_python_semantic/src/types/signatures.rs
@@ -172,10 +172,7 @@ impl<'db> Parameters<'db> {
     ///
     /// In an invalid signature, there could be multiple parameters with the same name; we will
     /// just return the first that matches.
-    pub(crate) fn keyword_by_name(
-        &self,
-        name: &ast::name::Name,
-    ) -> Option<(usize, &Parameter<'db>)> {
+    pub(crate) fn keyword_by_name(&self, name: &str) -> Option<(usize, &Parameter<'db>)> {
         self.iter()
             .enumerate()
             .find(|(_, parameter)| parameter.callable_by_name(name))
@@ -237,7 +234,7 @@ impl<'db> Parameter<'db> {
         matches!(self, Self::PositionalOnly(_))
     }
 
-    pub(crate) fn callable_by_name(&self, name: &ast::name::Name) -> bool {
+    pub(crate) fn callable_by_name(&self, name: &str) -> bool {
         match self {
             Self::PositionalOrKeyword(param) | Self::KeywordOnly(param) => param
                 .param

--- a/crates/red_knot_python_semantic/src/types/signatures.rs
+++ b/crates/red_knot_python_semantic/src/types/signatures.rs
@@ -210,6 +210,10 @@ impl<'db> Parameter<'db> {
         matches!(self, Self::PositionalOnly(_) | Self::PositionalOrKeyword(_))
     }
 
+    pub(crate) fn is_positional_only(&self) -> bool {
+        matches!(self, Self::PositionalOnly(_))
+    }
+
     pub(crate) fn callable_by_name(&self, name: &ast::name::Name) -> bool {
         match self {
             Self::PositionalOrKeyword(param) | Self::KeywordOnly(param) => param
@@ -231,15 +235,13 @@ impl<'db> Parameter<'db> {
         self.param().name.as_ref()
     }
 
-    /// Display name of the parameter, with fallback if it doesn't have a name.
-    pub(crate) fn display_name(&self, index: usize) -> ast::name::Name {
-        self.name()
-            .map(|name| match self {
-                Self::Variadic(_) => ast::name::Name::new(format!("*{name}")),
-                Self::Keywords(_) => ast::name::Name::new(format!("**{name}")),
-                _ => name.clone(),
-            })
-            .unwrap_or_else(|| ast::name::Name::new(format!("positional parameter {index}")))
+    /// Display name of the parameter, if it has one.
+    pub(crate) fn display_name(&self) -> Option<ast::name::Name> {
+        self.name().map(|name| match self {
+            Self::Variadic(_) => ast::name::Name::new(format!("*{name}")),
+            Self::Keywords(_) => ast::name::Name::new(format!("**{name}")),
+            _ => name.clone(),
+        })
     }
 
     /// Default-value type of the parameter, if any.

--- a/crates/ruff_benchmark/benches/red_knot.rs
+++ b/crates/ruff_benchmark/benches/red_knot.rs
@@ -34,7 +34,7 @@ static EXPECTED_DIAGNOSTICS: &[&str] = &[
     "warning[lint:possibly-unresolved-reference] /src/tomllib/_parser.py:115:14 Name `char` used when possibly not defined",
     "warning[lint:possibly-unresolved-reference] /src/tomllib/_parser.py:126:12 Name `char` used when possibly not defined",
     // We don't handle intersections in `is_assignable_to` yet
-    "error[lint:invalid-argument-type] /src/tomllib/_parser.py:211:31 Cannot assign type `Unknown & object | @Todo` to parameter `obj` of type `object`",
+    "error[lint:invalid-argument-type] /src/tomllib/_parser.py:211:31 Object of type `Unknown & object | @Todo` cannot be assigned to parameter 0 (`obj`) of function `isinstance`; expected type `object`",
     "warning[lint:possibly-unresolved-reference] /src/tomllib/_parser.py:348:20 Name `nest` used when possibly not defined",
     "warning[lint:possibly-unresolved-reference] /src/tomllib/_parser.py:353:5 Name `nest` used when possibly not defined",
     "warning[lint:possibly-unresolved-reference] /src/tomllib/_parser.py:453:24 Name `nest` used when possibly not defined",
@@ -44,10 +44,10 @@ static EXPECTED_DIAGNOSTICS: &[&str] = &[
     "warning[lint:possibly-unresolved-reference] /src/tomllib/_parser.py:573:12 Name `char` used when possibly not defined",
     "warning[lint:possibly-unresolved-reference] /src/tomllib/_parser.py:579:12 Name `char` used when possibly not defined",
     "warning[lint:possibly-unresolved-reference] /src/tomllib/_parser.py:580:63 Name `char` used when possibly not defined",
-    "error[lint:invalid-argument-type] /src/tomllib/_parser.py:626:46 Cannot assign type `@Todo & ~AlwaysFalsy` to parameter `match` of type `Match`",
+    "error[lint:invalid-argument-type] /src/tomllib/_parser.py:626:46 Object of type `@Todo & ~AlwaysFalsy` cannot be assigned to parameter `match` of function `match_to_datetime`; expected type `Match`",
     "warning[lint:possibly-unresolved-reference] /src/tomllib/_parser.py:629:38 Name `datetime_obj` used when possibly not defined",
-    "error[lint:invalid-argument-type] /src/tomllib/_parser.py:632:58 Cannot assign type `@Todo & ~AlwaysFalsy` to parameter `match` of type `Match`",
-    "error[lint:invalid-argument-type] /src/tomllib/_parser.py:639:52 Cannot assign type `@Todo & ~AlwaysFalsy` to parameter `match` of type `Match`",
+    "error[lint:invalid-argument-type] /src/tomllib/_parser.py:632:58 Object of type `@Todo & ~AlwaysFalsy` cannot be assigned to parameter `match` of function `match_to_localtime`; expected type `Match`",
+    "error[lint:invalid-argument-type] /src/tomllib/_parser.py:639:52 Object of type `@Todo & ~AlwaysFalsy` cannot be assigned to parameter `match` of function `match_to_number`; expected type `Match`",
     "warning[lint:unused-ignore-comment] /src/tomllib/_parser.py:682:31 Unused blanket `type: ignore` directive",
 ];
 

--- a/crates/ruff_benchmark/benches/red_knot.rs
+++ b/crates/ruff_benchmark/benches/red_knot.rs
@@ -33,6 +33,8 @@ static EXPECTED_DIAGNOSTICS: &[&str] = &[
     "warning[lint:possibly-unresolved-reference] /src/tomllib/_parser.py:104:14 Name `char` used when possibly not defined",
     "warning[lint:possibly-unresolved-reference] /src/tomllib/_parser.py:115:14 Name `char` used when possibly not defined",
     "warning[lint:possibly-unresolved-reference] /src/tomllib/_parser.py:126:12 Name `char` used when possibly not defined",
+    // We don't handle intersections in `is_assignable_to` yet
+    "error[lint:invalid-argument-type] /src/tomllib/_parser.py:211:31 Cannot assign type `Unknown & object | @Todo` to parameter `obj` of type `object`",
     "warning[lint:possibly-unresolved-reference] /src/tomllib/_parser.py:348:20 Name `nest` used when possibly not defined",
     "warning[lint:possibly-unresolved-reference] /src/tomllib/_parser.py:353:5 Name `nest` used when possibly not defined",
     "warning[lint:possibly-unresolved-reference] /src/tomllib/_parser.py:453:24 Name `nest` used when possibly not defined",
@@ -42,8 +44,11 @@ static EXPECTED_DIAGNOSTICS: &[&str] = &[
     "warning[lint:possibly-unresolved-reference] /src/tomllib/_parser.py:573:12 Name `char` used when possibly not defined",
     "warning[lint:possibly-unresolved-reference] /src/tomllib/_parser.py:579:12 Name `char` used when possibly not defined",
     "warning[lint:possibly-unresolved-reference] /src/tomllib/_parser.py:580:63 Name `char` used when possibly not defined",
+    "error[lint:invalid-argument-type] /src/tomllib/_parser.py:626:46 Cannot assign type `@Todo & ~AlwaysFalsy` to parameter `match` of type `Match`",
     "warning[lint:possibly-unresolved-reference] /src/tomllib/_parser.py:629:38 Name `datetime_obj` used when possibly not defined",
-    "warning[lint:unused-ignore-comment] /src/tomllib/_parser.py:682:31 Unused blanket `type: ignore` directive"
+    "error[lint:invalid-argument-type] /src/tomllib/_parser.py:632:58 Cannot assign type `@Todo & ~AlwaysFalsy` to parameter `match` of type `Match`",
+    "error[lint:invalid-argument-type] /src/tomllib/_parser.py:639:52 Cannot assign type `@Todo & ~AlwaysFalsy` to parameter `match` of type `Match`",
+    "warning[lint:unused-ignore-comment] /src/tomllib/_parser.py:682:31 Unused blanket `type: ignore` directive",
 ];
 
 fn get_test_file(name: &str) -> TestFile {

--- a/crates/ruff_benchmark/benches/red_knot.rs
+++ b/crates/ruff_benchmark/benches/red_knot.rs
@@ -34,7 +34,7 @@ static EXPECTED_DIAGNOSTICS: &[&str] = &[
     "warning[lint:possibly-unresolved-reference] /src/tomllib/_parser.py:115:14 Name `char` used when possibly not defined",
     "warning[lint:possibly-unresolved-reference] /src/tomllib/_parser.py:126:12 Name `char` used when possibly not defined",
     // We don't handle intersections in `is_assignable_to` yet
-    "error[lint:invalid-argument-type] /src/tomllib/_parser.py:211:31 Object of type `Unknown & object | @Todo` cannot be assigned to parameter 0 (`obj`) of function `isinstance`; expected type `object`",
+    "error[lint:invalid-argument-type] /src/tomllib/_parser.py:211:31 Object of type `Unknown & object | @Todo` cannot be assigned to parameter 1 (`obj`) of function `isinstance`; expected type `object`",
     "warning[lint:possibly-unresolved-reference] /src/tomllib/_parser.py:348:20 Name `nest` used when possibly not defined",
     "warning[lint:possibly-unresolved-reference] /src/tomllib/_parser.py:353:5 Name `nest` used when possibly not defined",
     "warning[lint:possibly-unresolved-reference] /src/tomllib/_parser.py:453:24 Name `nest` used when possibly not defined",
@@ -44,10 +44,10 @@ static EXPECTED_DIAGNOSTICS: &[&str] = &[
     "warning[lint:possibly-unresolved-reference] /src/tomllib/_parser.py:573:12 Name `char` used when possibly not defined",
     "warning[lint:possibly-unresolved-reference] /src/tomllib/_parser.py:579:12 Name `char` used when possibly not defined",
     "warning[lint:possibly-unresolved-reference] /src/tomllib/_parser.py:580:63 Name `char` used when possibly not defined",
-    "error[lint:invalid-argument-type] /src/tomllib/_parser.py:626:46 Object of type `@Todo & ~AlwaysFalsy` cannot be assigned to parameter `match` of function `match_to_datetime`; expected type `Match`",
+    "error[lint:invalid-argument-type] /src/tomllib/_parser.py:626:46 Object of type `@Todo & ~AlwaysFalsy` cannot be assigned to parameter 1 (`match`) of function `match_to_datetime`; expected type `Match`",
     "warning[lint:possibly-unresolved-reference] /src/tomllib/_parser.py:629:38 Name `datetime_obj` used when possibly not defined",
-    "error[lint:invalid-argument-type] /src/tomllib/_parser.py:632:58 Object of type `@Todo & ~AlwaysFalsy` cannot be assigned to parameter `match` of function `match_to_localtime`; expected type `Match`",
-    "error[lint:invalid-argument-type] /src/tomllib/_parser.py:639:52 Object of type `@Todo & ~AlwaysFalsy` cannot be assigned to parameter `match` of function `match_to_number`; expected type `Match`",
+    "error[lint:invalid-argument-type] /src/tomllib/_parser.py:632:58 Object of type `@Todo & ~AlwaysFalsy` cannot be assigned to parameter 1 (`match`) of function `match_to_localtime`; expected type `Match`",
+    "error[lint:invalid-argument-type] /src/tomllib/_parser.py:639:52 Object of type `@Todo & ~AlwaysFalsy` cannot be assigned to parameter 1 (`match`) of function `match_to_number`; expected type `Match`",
     "warning[lint:unused-ignore-comment] /src/tomllib/_parser.py:682:31 Unused blanket `type: ignore` directive",
 ];
 


### PR DESCRIPTION
## Summary

This implements checking of calls.

I ended up following Micha's original suggestion from back when the signature representation was first introduced, and flattening it to a single array of parameters. This turned out to be easier to manage, because we can represent parameters using indices into that array, and represent the bound argument types as an array of the same length.

Starred and double-starred arguments are still TODO; these won't be very useful until we have generics.

The handling of diagnostics is just hacked into `return_ty_result`, which was already inconsistent about whether it emitted diagnostics or not; now it's even more inconsistent. This needs to be addressed, but could be a follow-up.

The new benchmark errors here surface the need for intersection support in `is_assignable_to`.

Fixes #14161.

## Test Plan

Added mdtests.
