### PR TITLE
Fix incorrect doc in `shebang-not-executable (EXE001)` and add git+windows solution to executable bit

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_executable/rules/shebang_missing_executable_file.rs
+++ b/crates/ruff_linter/src/rules/flake8_executable/rules/shebang_missing_executable_file.rs
@@ -36,7 +36,7 @@ use crate::rules::flake8_executable::helpers::is_executable;
 ///
 /// ## References
 /// - [Python documentation: Executable Python Scripts](https://docs.python.org/3/tutorial/appendix.html#executable-python-scripts)
-/// - [Git documentation: git update-index --chmod](https://git-scm.com/docs/git-update-index#Documentation/git-update-index.txt---chmod-x)
+/// - [Git documentation: `git update-index --chmod`](https://git-scm.com/docs/git-update-index#Documentation/git-update-index.txt---chmod-x)
 #[derive(ViolationMetadata)]
 pub(crate) struct ShebangMissingExecutableFile;
 

--- a/crates/ruff_linter/src/rules/flake8_executable/rules/shebang_missing_executable_file.rs
+++ b/crates/ruff_linter/src/rules/flake8_executable/rules/shebang_missing_executable_file.rs
@@ -27,7 +27,8 @@ use crate::rules::flake8_executable::helpers::is_executable;
 /// #!/usr/bin/env python
 /// ```
 ///
-/// Otherwise, remove the executable bit from the file (e.g., `chmod -x __main__.py`).
+/// Otherwise, remove the executable bit from the file
+/// (e.g., `chmod -x __main__.py` or `git update-index --chmod=-x __main__.py`).
 ///
 /// A file is considered executable if it has the executable bit set (i.e., its
 /// permissions mode intersects with `0o111`). As such, _this rule is only
@@ -35,6 +36,7 @@ use crate::rules::flake8_executable::helpers::is_executable;
 ///
 /// ## References
 /// - [Python documentation: Executable Python Scripts](https://docs.python.org/3/tutorial/appendix.html#executable-python-scripts)
+/// - [Git documentation: git update-index --chmod](https://git-scm.com/docs/git-update-index#Documentation/git-update-index.txt---chmod-x)
 #[derive(ViolationMetadata)]
 pub(crate) struct ShebangMissingExecutableFile;
 

--- a/crates/ruff_linter/src/rules/flake8_executable/rules/shebang_not_executable.rs
+++ b/crates/ruff_linter/src/rules/flake8_executable/rules/shebang_not_executable.rs
@@ -22,11 +22,8 @@ use crate::rules::flake8_executable::helpers::is_executable;
 /// executable. If a file contains a shebang but is not executable, then the
 /// shebang is misleading, or the file is missing the executable bit.
 ///
-/// If the file is meant to be executable, add add the executable bit to the file
+/// If the file is meant to be executable, add the executable bit to the file
 /// (e.g., `chmod +x __main__.py` or `git update-index --chmod=+x __main__.py`).
-/// ```python
-/// #!/usr/bin/env python
-/// ```
 ///
 /// Otherwise, remove the shebang.
 ///
@@ -41,7 +38,7 @@ use crate::rules::flake8_executable::helpers::is_executable;
 ///
 /// ## References
 /// - [Python documentation: Executable Python Scripts](https://docs.python.org/3/tutorial/appendix.html#executable-python-scripts)
-/// - [Git documentation: git update-index --chmod](https://git-scm.com/docs/git-update-index#Documentation/git-update-index.txt---chmod-x)
+/// - [Git documentation: `git update-index --chmod`](https://git-scm.com/docs/git-update-index#Documentation/git-update-index.txt---chmod-x)
 #[derive(ViolationMetadata)]
 pub(crate) struct ShebangNotExecutable;
 

--- a/crates/ruff_linter/src/rules/flake8_executable/rules/shebang_not_executable.rs
+++ b/crates/ruff_linter/src/rules/flake8_executable/rules/shebang_not_executable.rs
@@ -22,12 +22,13 @@ use crate::rules::flake8_executable::helpers::is_executable;
 /// executable. If a file contains a shebang but is not executable, then the
 /// shebang is misleading, or the file is missing the executable bit.
 ///
-/// If the file is meant to be executable, add a shebang, as in:
+/// If the file is meant to be executable, add add the executable bit to the file
+/// (e.g., `chmod +x __main__.py` or `git update-index --chmod=+x __main__.py`).
 /// ```python
 /// #!/usr/bin/env python
 /// ```
 ///
-/// Otherwise, remove the executable bit from the file (e.g., `chmod -x __main__.py`).
+/// Otherwise, remove the shebang.
 ///
 /// A file is considered executable if it has the executable bit set (i.e., its
 /// permissions mode intersects with `0o111`). As such, _this rule is only
@@ -40,6 +41,7 @@ use crate::rules::flake8_executable::helpers::is_executable;
 ///
 /// ## References
 /// - [Python documentation: Executable Python Scripts](https://docs.python.org/3/tutorial/appendix.html#executable-python-scripts)
+/// - [Git documentation: git update-index --chmod](https://git-scm.com/docs/git-update-index#Documentation/git-update-index.txt---chmod-x)
 #[derive(ViolationMetadata)]
 pub(crate) struct ShebangNotExecutable;
 


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

I noticed that the solution mentioned in [shebang-not-executable (EXE001)](https://docs.astral.sh/ruff/rules/shebang-not-executable/#shebang-not-executable-exe001) was incorrect and likely copy-pasted from [shebang-missing-executable-file (EXE002)](https://docs.astral.sh/ruff/rules/shebang-missing-executable-file/#shebang-missing-executable-file-exe002)

It was telling users to remove the executable bit from a non-executable file. Which does nothing.

I also noticed locally that:
- `chmod` wouldn't cause any file change to be noticed by git (`EXE` was also passing locally) under WSL
- Using git allows anyone to fix this lint across OSes, for projects with CIs using git

So I added a solution using [git update-index --chmod](https://git-scm.com/docs/git-update-index#Documentation/git-update-index.txt---chmod-x)

## Test Plan

<!-- How was it tested? -->
No test plan, doc changes only.
As for running the chmod commands: https://github.com/python/typeshed/pull/13346