### PR TITLE
[`airflow`] Remove additional spaces (`AIR302`)

### DIFF
--- a/crates/ruff_linter/src/rules/airflow/rules/removal_in_3.rs
+++ b/crates/ruff_linter/src/rules/airflow/rules/removal_in_3.rs
@@ -513,7 +513,7 @@ fn check_name(checker: &mut Checker, expr: &Expr, range: TextRange) {
             Replacement::Name("airflow.operators.python.ShortCircuitOperator")
         }
         ["airflow", "operators", "latest_only_operator", "LatestOnlyOperator"] => {
-            Replacement::Name("     airflow.operators.latest_only.LatestOnlyOperator")
+            Replacement::Name("airflow.operators.latest_only.LatestOnlyOperator")
         }
 
         // airflow.sensors

--- a/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_names.py.snap
+++ b/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_names.py.snap
@@ -555,7 +555,7 @@ AIR302_names.py:183:1: AIR302 `airflow.operators.latest_only_operator.LatestOnly
 184 | 
 185 | # airflow.operators.python_operator
     |
-    = help: Use `     airflow.operators.latest_only.LatestOnlyOperator` instead
+    = help: Use `airflow.operators.latest_only.LatestOnlyOperator` instead
 
 AIR302_names.py:186:1: AIR302 `airflow.operators.python_operator.BranchPythonOperator` is removed in Airflow 3.0
     |


### PR DESCRIPTION

<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

During https://github.com/astral-sh/ruff/pull/15209, additional spaces was accidentally added to the rule `airflow.operators.latest_only.LatestOnlyOperator`. This PR fixes this issue

## Test Plan

<!-- How was it tested? -->

A test fixture has been included for the rule.
