### PR TITLE
uses: astral-sh/ruff-action@v3, not v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: astral-sh/ruff-action@v1
+      - uses: astral-sh/ruff-action@v3
 ```
 
 ### Configuration<a id="configuration"></a>

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -46,13 +46,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: astral-sh/ruff-action@v2
+      - uses: astral-sh/ruff-action@v3
 ```
 
 Alternatively, you can include `ruff-action` as a step in any other workflow file:
 
 ```yaml
-      - uses: astral-sh/ruff-action@v2
+      - uses: astral-sh/ruff-action@v3
 ```
 
 `ruff-action` accepts optional configuration parameters via `with:`, including:
@@ -64,7 +64,7 @@ Alternatively, you can include `ruff-action` as a step in any other workflow fil
 For example, to run `ruff check --select B ./src` using Ruff version `0.8.0`:
 
 ```yaml
-- uses: astral-sh/ruff-action@v2
+- uses: astral-sh/ruff-action@v3
   with:
     version: 0.8.0
     args: check --select B


### PR DESCRIPTION
## Summary
https://docs.astral.sh/ruff/integrations/#github-actions upgraded for https://github.com/astral-sh/ruff-action/releases

```diff
- - uses: astral-sh/ruff-action@v2
+ - uses: astral-sh/ruff-action@v3
```
* #14800 

## Test Plan
@eifinger Your review, please.