### PR TITLE
[`pycodestyle`] Avoid false positives and negatives related to type parameter default syntax (`E225`, `E251`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pycodestyle/E22.py
+++ b/crates/ruff_linter/resources/test/fixtures/pycodestyle/E22.py
@@ -183,3 +183,8 @@ if i == -1:
 
 if a  ==  1:
     print(a)
+
+
+# No E225: `=` is not an operator in this case
+def _[T: str=None](): ...
+def _(t: str=None): ...

--- a/crates/ruff_linter/resources/test/fixtures/pycodestyle/E25.py
+++ b/crates/ruff_linter/resources/test/fixtures/pycodestyle/E25.py
@@ -75,3 +75,7 @@ def pep_696_good[A = int, B: object = str, C:object = memoryview]():
 class PEP696Good[A = int, B: object = str, C:object = memoryview]:
     def pep_696_good_method[A = int, B: object = str, C:object = memoryview](self):
         pass
+
+
+# https://github.com/astral-sh/ruff/issues/15202
+type Coro[T: object = Any] = Coroutine[None, None, T]

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/logical_lines/mod.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/logical_lines/mod.rs
@@ -480,7 +480,8 @@ struct Line {
 enum DefinitionState {
     InClass(TypeParamsState),
     InFunction(TypeParamsState),
-    NotInClassOrFunction,
+    InTypeAlias(TypeParamsState),
+    NotInDefinition,
 }
 
 impl DefinitionState {
@@ -494,11 +495,12 @@ impl DefinitionState {
                 TokenKind::Async if matches!(token_kinds.next(), Some(TokenKind::Def)) => {
                     Self::InFunction(TypeParamsState::default())
                 }
-                _ => Self::NotInClassOrFunction,
+                TokenKind::Type => Self::InTypeAlias(TypeParamsState::default()),
+                _ => Self::NotInDefinition,
             };
             return state;
         }
-        Self::NotInClassOrFunction
+        Self::NotInDefinition
     }
 
     const fn in_function_definition(self) -> bool {
@@ -507,8 +509,10 @@ impl DefinitionState {
 
     const fn type_params_state(self) -> Option<TypeParamsState> {
         match self {
-            Self::InClass(state) | Self::InFunction(state) => Some(state),
-            Self::NotInClassOrFunction => None,
+            Self::InClass(state) | Self::InFunction(state) | Self::InTypeAlias(state) => {
+                Some(state)
+            }
+            Self::NotInDefinition => None,
         }
     }
 
@@ -521,10 +525,10 @@ impl DefinitionState {
 
     fn visit_token_kind(&mut self, token_kind: TokenKind) {
         let type_params_state_mut = match self {
-            Self::InClass(type_params_state) | Self::InFunction(type_params_state) => {
-                type_params_state
-            }
-            Self::NotInClassOrFunction => return,
+            Self::InClass(type_params_state)
+            | Self::InFunction(type_params_state)
+            | Self::InTypeAlias(type_params_state) => type_params_state,
+            Self::NotInDefinition => return,
         };
         match token_kind {
             TokenKind::Lpar if type_params_state_mut.before_type_params() => {

--- a/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E221_E22.py.snap
+++ b/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E221_E22.py.snap
@@ -186,3 +186,5 @@ E22.py:184:5: E221 [*] Multiple spaces before operator
 184     |-if a  ==  1:
     184 |+if a ==  1:
 185 185 |     print(a)
+186 186 | 
+187 187 |

--- a/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E222_E22.py.snap
+++ b/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E222_E22.py.snap
@@ -123,3 +123,5 @@ E22.py:184:9: E222 [*] Multiple spaces after operator
 184     |-if a  ==  1:
     184 |+if a  == 1:
 185 185 |     print(a)
+186 186 | 
+187 187 |


### PR DESCRIPTION
## Summary

Resolves #15202.

## Test Plan

`cargo nextest run` and `cargo insta test`.
