### PR TITLE
[`airflow`] Extend names moved from core to provider (`AIR303`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/airflow/AIR303.py
+++ b/crates/ruff_linter/resources/test/fixtures/airflow/AIR303.py
@@ -37,6 +37,45 @@ from airflow.hooks.slack_hook import SlackHook
 from airflow.hooks.sqlite_hook import SqliteHook
 from airflow.hooks.webhdfs_hook import WebHDFSHook
 from airflow.hooks.zendesk_hook import ZendeskHook
+from airflow.kubernetes.k8s_model import K8SModel, append_to_pod
+from airflow.kubernetes.kube_client import _disable_verify_ssl, _enable_tcp_keepalive, get_kube_client
+from airflow.kubernetes.kubernetes_helper_functions import (
+    add_pod_suffix,
+    annotations_for_logging_task_metadata,
+    annotations_to_key,
+    create_pod_id,
+    get_logs_task_metadata,
+    rand_str,
+)
+from airflow.kubernetes.pod import Port, Resources
+from airflow.kubernetes.pod_generator import (
+    PodDefaults,
+    PodGenerator,
+    PodGeneratorDeprecated,
+    add_pod_suffix as add_pod_suffix2,
+    datetime_to_label_safe_datestring,
+    extend_object_field,
+    label_safe_datestring_to_datetime,
+    make_safe_label_value,
+    merge_objects,
+    rand_str as rand_str2,
+)
+from airflow.kubernetes.pod_generator_deprecated import (
+    PodDefaults as PodDefaults3,
+    PodGenerator as PodGenerator2,
+    make_safe_label_value as make_safe_label_value2,
+)
+from airflow.kubernetes.pod_launcher import PodLauncher, PodStatus
+from airflow.kubernetes.pod_launcher_deprecated import (
+    PodDefaults as PodDefaults2,
+    PodLauncher as PodLauncher2,
+    PodStatus as PodStatus2,
+    get_kube_client as get_kube_client2,
+)
+from airflow.kubernetes.pod_runtime_info_env import PodRuntimeInfoEnv
+from airflow.kubernetes.secret import K8SModel2, Secret
+from airflow.kubernetes.volume import Volume
+from airflow.kubernetes.volume_mount import VolumeMount
 from airflow.macros.hive import closest_ds_partition, max_partition
 from airflow.operators.check_operator import (
     CheckOperator,
@@ -221,6 +260,45 @@ FabAirflowSecurityManagerOverride()
 # apache-airflow-providers-cncf-kubernetes
 ALL_NAMESPACES
 POD_EXECUTOR_DONE_KEY
+_disable_verify_ssl()
+_enable_tcp_keepalive()
+append_to_pod()
+annotations_for_logging_task_metadata()
+annotations_to_key()
+create_pod_id()
+datetime_to_label_safe_datestring()
+extend_object_field()
+get_logs_task_metadata()
+label_safe_datestring_to_datetime()
+merge_objects()
+Port()
+Resources()
+PodRuntimeInfoEnv()
+PodGeneratorDeprecated()
+Volume()
+VolumeMount()
+Secret()
+
+add_pod_suffix()
+add_pod_suffix2()
+get_kube_client()
+get_kube_client2()
+make_safe_label_value()
+make_safe_label_value2()
+rand_str()
+rand_str2()
+K8SModel()
+K8SModel2()
+PodLauncher()
+PodLauncher2()
+PodStatus()
+PodStatus2()
+PodDefaults()
+PodDefaults2()
+PodDefaults3()
+PodGenerator()
+PodGenerator2()
+
 
 # apache-airflow-providers-microsoft-mssql
 MsSqlHook()

--- a/crates/ruff_linter/src/rules/airflow/rules/moved_to_provider_in_3.rs
+++ b/crates/ruff_linter/src/rules/airflow/rules/moved_to_provider_in_3.rs
@@ -859,7 +859,7 @@ fn check_names_moved_to_provider(checker: &mut Checker, expr: &Expr, ranged: imp
                     Replacement::ImportPathMoved{
                         original_path: "airflow.executors.kubernetes_executor_types.ALL_NAMESPACES",
                         new_path: "airflow.providers.cncf.kubernetes.executors.kubernetes_executor_types.ALL_NAMESPACES",
-                        provider: "kubernetes",
+                        provider: "cncf-kubernetes",
                         version: "7.4.0"
                 },
                 )),
@@ -868,10 +868,11 @@ fn check_names_moved_to_provider(checker: &mut Checker, expr: &Expr, ranged: imp
                     Replacement::ImportPathMoved{
                         original_path: "airflow.executors.kubernetes_executor_types.POD_EXECUTOR_DONE_KEY",
                         new_path: "airflow.providers.cncf.kubernetes.executors.kubernetes_executor_types.POD_EXECUTOR_DONE_KEY",
-                        provider: "kubernetes",
+                        provider: "cncf-kubernetes",
                         version: "7.4.0"
                 },
                 )),
+
 
                 // apache-airflow-providers-microsoft-mssql
                 ["airflow", "hooks", "mssql_hook", "MsSqlHook"] => Some((

--- a/crates/ruff_linter/src/rules/airflow/rules/moved_to_provider_in_3.rs
+++ b/crates/ruff_linter/src/rules/airflow/rules/moved_to_provider_in_3.rs
@@ -872,7 +872,302 @@ fn check_names_moved_to_provider(checker: &mut Checker, expr: &Expr, ranged: imp
                         version: "7.4.0"
                 },
                 )),
-
+                ["airflow", "kubernetes", "kubernetes_helper_functions", "add_pod_suffix"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "airflow.providers.cncf.kubernetes.kubernetes_helper_functions.add_pod_suffix",
+                        provider: "cncf-kubernetes",
+                        version: "7.4.0"
+                },
+                )),
+                ["airflow", "kubernetes", "kubernetes_helper_functions", "annotations_for_logging_task_metadata"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "airflow.providers.cncf.kubernetes.kubernetes_helper_functions.annotations_for_logging_task_metadata",
+                        provider: "cncf-kubernetes",
+                        version: "7.4.0"
+                },
+                )),
+                ["airflow", "kubernetes", "kubernetes_helper_functions", "annotations_to_key"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "airflow.providers.cncf.kubernetes.kubernetes_helper_functions.annotations_to_key",
+                        provider: "cncf-kubernetes",
+                        version: "7.4.0"
+                },
+                )),
+                ["airflow", "kubernetes", "kubernetes_helper_functions", "create_pod_id"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "airflow.providers.cncf.kubernetes.kubernetes_helper_functions.create_pod_id",
+                        provider: "cncf-kubernetes",
+                        version: "7.4.0"
+                },
+                )),
+                ["airflow", "kubernetes", "kubernetes_helper_functions", "get_logs_task_metadata"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "airflow.providers.cncf.kubernetes.kubernetes_helper_functions.get_logs_task_metadata",
+                        provider: "cncf-kubernetes",
+                        version: "7.4.0"
+                },
+                )),
+                ["airflow", "kubernetes", "kubernetes_helper_functions", "rand_str"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "airflow.providers.cncf.kubernetes.kubernetes_helper_functions.rand_str",
+                        provider: "cncf-kubernetes",
+                        version: "7.4.0"
+                },
+                )),
+                ["airflow", "kubernetes", "pod", "Port"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "kubernetes.client.models.V1ContainerPort",
+                        provider: "cncf-kubernetes",
+                        version: "7.4.0"
+                },
+                )),
+                ["airflow", "kubernetes", "pod", "Resources"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "kubernetes.client.models.V1ResourceRequirements",
+                        provider: "cncf-kubernetes",
+                        version: "7.4.0"
+                },
+                )),
+                ["airflow", "kubernetes", "pod_launcher", "PodLauncher"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "airflow.providers.cncf.kubernetes.pod_launcher.PodLauncher",
+                        provider: "cncf-kubernetes",
+                        version: "7.4.0"
+                },
+                )),
+                ["airflow", "kubernetes", "pod_launcher", "PodStatus"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "airflow.providers.cncf.kubernetes.pod_launcher.PodStatus",
+                        provider: "cncf-kubernetes",
+                        version: "7.4.0"
+                },
+                )),
+                ["airflow", "kubernetes", "pod_launcher_deprecated", "PodLauncher"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "airflow.providers.cncf.kubernetes.pod_launcher_deprecated.PodLauncher",
+                        provider: "cncf-kubernetes",
+                        version: "7.4.0"
+                },
+                )),
+                ["airflow", "kubernetes", "pod_launcher_deprecated", "PodStatus"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "airflow.providers.cncf.kubernetes.pod_launcher_deprecated.PodStatus",
+                        provider: "cncf-kubernetes",
+                        version: "7.4.0"
+                },
+                )),
+                ["airflow", "kubernetes", "pod_launcher_deprecated", "get_kube_client"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "airflow.providers.cncf.kubernetes.kube_client.get_kube_client",
+                        provider: "cncf-kubernetes",
+                        version: "7.4.0"
+                },
+                )),
+                ["airflow", "kubernetes", "pod_launcher_deprecated", "PodDefaults"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "airflow.providers.cncf.kubernetes.pod_generator_deprecated.PodDefaults",
+                        provider: "cncf-kubernetes",
+                        version: "7.4.0"
+                },
+                )),
+                ["airflow", "kubernetes", "pod_runtime_info_env", "PodRuntimeInfoEnv"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "kubernetes.client.models.V1EnvVar",
+                        provider: "cncf-kubernetes",
+                        version: "7.4.0"
+                },
+                )),
+                ["airflow", "kubernetes", "volume", "Volume"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "kubernetes.client.models.V1Volume",
+                        provider: "cncf-kubernetes",
+                        version: "7.4.0"
+                },
+                )),
+                ["airflow", "kubernetes", "volume_mount", "VolumeMount"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "kubernetes.client.models.V1VolumeMount",
+                        provider: "cncf-kubernetes",
+                        version: "7.4.0"
+                },
+                )),
+                ["airflow", "kubernetes", "k8s_model", "K8SModel"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "airflow.providers.cncf.kubernetes.k8s_model.K8SModel",
+                        provider: "cncf-kubernetes",
+                        version: "7.4.0"
+                },
+                )),
+                ["airflow", "kubernetes", "k8s_model", "append_to_pod"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "airflow.providers.cncf.kubernetes.k8s_model.append_to_pod",
+                        provider: "cncf-kubernetes",
+                        version: "7.4.0"
+                },
+                )),
+                ["airflow", "kubernetes", "kube_client", "_disable_verify_ssl"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "airflow.kubernetes.airflow.providers.cncf.kubernetes.kube_client._disable_verify_ssl",
+                        provider: "cncf-kubernetes",
+                        version: "7.4.0"
+                },
+                )),
+                ["airflow", "kubernetes", "kube_client", "_enable_tcp_keepalive"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "airflow.kubernetes.airflow.providers.cncf.kubernetes.kube_client._enable_tcp_keepalive",
+                        provider: "cncf-kubernetes",
+                        version: "7.4.0"
+                },
+                )),
+                ["airflow", "kubernetes", "kube_client", "get_kube_client"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "airflow.kubernetes.airflow.providers.cncf.kubernetes.kube_client.get_kube_client",
+                        provider: "cncf-kubernetes",
+                        version: "7.4.0"
+                },
+                )),
+                ["airflow", "kubernetes", "pod_generator", "datetime_to_label_safe_datestring"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "airflow.providers.cncf.kubernetes.pod_generator.datetime_to_label_safe_datestring",
+                        provider: "cncf-kubernetes",
+                        version: "7.4.0"
+                },
+                )),
+                ["airflow", "kubernetes", "pod_generator", "extend_object_field"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "airflow.kubernetes.airflow.providers.cncf.kubernetes.pod_generator.extend_object_field",
+                        provider: "cncf-kubernetes",
+                        version: "7.4.0"
+                },
+                )),
+                ["airflow", "kubernetes", "pod_generator", "label_safe_datestring_to_datetime"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "airflow.providers.cncf.kubernetes.pod_generator.label_safe_datestring_to_datetime",
+                        provider: "cncf-kubernetes",
+                        version: "7.4.0"
+                },
+                )),
+                ["airflow", "kubernetes", "pod_generator", "make_safe_label_value"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "airflow.providers.cncf.kubernetes.pod_generator.make_safe_label_value",
+                        provider: "cncf-kubernetes",
+                        version: "7.4.0"
+                },
+                )),
+                ["airflow", "kubernetes", "pod_generator", "merge_objects"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "airflow.providers.cncf.kubernetes.pod_generator.merge_objects",
+                        provider: "cncf-kubernetes",
+                        version: "7.4.0"
+                },
+                )),
+                ["airflow", "kubernetes", "pod_generator", "PodGenerator"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "airflow.providers.cncf.kubernetes.pod_generator.PodGenerator",
+                        provider: "cncf-kubernetes",
+                        version: "7.4.0"
+                },
+                )),
+                ["airflow", "kubernetes", "pod_generator_deprecated", "make_safe_label_value"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "airflow.providers.cncf.kubernetes.pod_generator_deprecated.make_safe_label_value",
+                        provider: "cncf-kubernetes",
+                        version: "7.4.0"
+                },
+                )),
+                ["airflow", "kubernetes", "pod_generator_deprecated", "PodDefaults"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "airflow.providers.cncf.kubernetes.pod_generator_deprecated.PodDefaults",
+                        provider: "cncf-kubernetes",
+                        version: "7.4.0"
+                },
+                )),
+                ["airflow", "kubernetes", "pod_generator_deprecated", "PodGenerator"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "airflow.providers.cncf.kubernetes.pod_generator_deprecated.PodGenerator",
+                        provider: "cncf-kubernetes",
+                        version: "7.4.0"
+                },
+                )),
+                ["airflow", "kubernetes", "secret", "Secret"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "airflow.providers.cncf.kubernetes.secret.Secret",
+                        provider: "cncf-kubernetes",
+                        version: "7.4.0"
+                },
+                )),
+                ["airflow", "kubernetes", "pod_generator", "PodGeneratorDeprecated"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "airflow.providers.cncf.kubernetes.pod_generator.PodGenerator",
+                        provider: "cncf-kubernetes",
+                        version: "7.4.0"
+                },
+                )),
+                ["airflow", "kubernetes", "pod_generator", "PodDefaults"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "airflow.providers.cncf.kubernetes.pod_generator_deprecated.PodDefaults",
+                        provider: "cncf-kubernetes",
+                        version: "7.4.0"
+                },
+                )),
+                ["airflow", "kubernetes", "pod_generator", "add_pod_suffix"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "airflow.providers.cncf.kubernetes.kubernetes_helper_functions.add_pod_suffix",
+                        provider: "cncf-kubernetes",
+                        version: "7.4.0"
+                },
+                )),
+                ["airflow", "kubernetes", "pod_generator", "rand_str"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "airflow.providers.cncf.kubernetes.kubernetes_helper_functions.rand_str",
+                        provider: "cncf-kubernetes",
+                        version: "7.4.0"
+                },
+                )),
+                ["airflow", "kubernetes", "secret", "K8SModel"] => Some((
+                    qualname.to_string(),
+                    Replacement::ProviderName{
+                        name: "airflow.providers.cncf.kubernetes.k8s_model.K8SModel",
+                        provider: "cncf-kubernetes",
+                        version: "7.4.0"
+                },
+                )),
 
                 // apache-airflow-providers-microsoft-mssql
                 ["airflow", "hooks", "mssql_hook", "MsSqlHook"] => Some((

--- a/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR303_AIR303.py.snap
+++ b/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR303_AIR303.py.snap
@@ -849,16 +849,16 @@ AIR303.py:219:1: AIR303 `airflow.www.security.FabAirflowSecurityManagerOverride`
     |
     = help: Install `apache-airflow-provider-fab>=1.0.0` and use `airflow.providers.fab.auth_manager.security_manager.override.FabAirflowSecurityManagerOverride` instead.
 
-AIR303.py:222:1: AIR303 Import path `airflow.executors.kubernetes_executor_types.ALL_NAMESPACES` is moved into `kubernetes` provider in Airflow 3.0;
+AIR303.py:222:1: AIR303 Import path `airflow.executors.kubernetes_executor_types.ALL_NAMESPACES` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
 221 | # apache-airflow-providers-cncf-kubernetes
 222 | ALL_NAMESPACES
     | ^^^^^^^^^^^^^^ AIR303
 223 | POD_EXECUTOR_DONE_KEY
     |
-    = help: Install `apache-airflow-provider-kubernetes>=7.4.0` and import from `airflow.providers.cncf.kubernetes.executors.kubernetes_executor_types.ALL_NAMESPACES` instead.
+    = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and import from `airflow.providers.cncf.kubernetes.executors.kubernetes_executor_types.ALL_NAMESPACES` instead.
 
-AIR303.py:223:1: AIR303 Import path `airflow.executors.kubernetes_executor_types.POD_EXECUTOR_DONE_KEY` is moved into `kubernetes` provider in Airflow 3.0;
+AIR303.py:223:1: AIR303 Import path `airflow.executors.kubernetes_executor_types.POD_EXECUTOR_DONE_KEY` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
 221 | # apache-airflow-providers-cncf-kubernetes
 222 | ALL_NAMESPACES
@@ -867,7 +867,7 @@ AIR303.py:223:1: AIR303 Import path `airflow.executors.kubernetes_executor_types
 224 | 
 225 | # apache-airflow-providers-microsoft-mssql
     |
-    = help: Install `apache-airflow-provider-kubernetes>=7.4.0` and import from `airflow.providers.cncf.kubernetes.executors.kubernetes_executor_types.POD_EXECUTOR_DONE_KEY` instead.
+    = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and import from `airflow.providers.cncf.kubernetes.executors.kubernetes_executor_types.POD_EXECUTOR_DONE_KEY` instead.
 
 AIR303.py:226:1: AIR303 `airflow.hooks.mssql_hook.MsSqlHook` is moved into `microsoft-mssql` provider in Airflow 3.0;
     |

--- a/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR303_AIR303.py.snap
+++ b/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR303_AIR303.py.snap
@@ -2,1157 +2,1549 @@
 source: crates/ruff_linter/src/rules/airflow/mod.rs
 snapshot_kind: text
 ---
-AIR303.py:120:1: AIR303 `airflow.hooks.S3_hook.provide_bucket_name` is moved into `amazon` provider in Airflow 3.0;
+AIR303.py:159:1: AIR303 `airflow.hooks.S3_hook.provide_bucket_name` is moved into `amazon` provider in Airflow 3.0;
     |
-119 | # apache-airflow-providers-amazon
-120 | provide_bucket_name()
+158 | # apache-airflow-providers-amazon
+159 | provide_bucket_name()
     | ^^^^^^^^^^^^^^^^^^^ AIR303
-121 | GCSToS3Operator()
-122 | GoogleApiToS3Operator()
+160 | GCSToS3Operator()
+161 | GoogleApiToS3Operator()
     |
     = help: Install `apache-airflow-provider-amazon>=1.0.0` and use `airflow.providers.amazon.aws.hooks.s3.provide_bucket_name` instead.
 
-AIR303.py:121:1: AIR303 `airflow.operators.gcs_to_s3.GCSToS3Operator` is moved into `amazon` provider in Airflow 3.0;
+AIR303.py:160:1: AIR303 `airflow.operators.gcs_to_s3.GCSToS3Operator` is moved into `amazon` provider in Airflow 3.0;
     |
-119 | # apache-airflow-providers-amazon
-120 | provide_bucket_name()
-121 | GCSToS3Operator()
+158 | # apache-airflow-providers-amazon
+159 | provide_bucket_name()
+160 | GCSToS3Operator()
     | ^^^^^^^^^^^^^^^ AIR303
-122 | GoogleApiToS3Operator()
-123 | GoogleApiToS3Transfer()
+161 | GoogleApiToS3Operator()
+162 | GoogleApiToS3Transfer()
     |
     = help: Install `apache-airflow-provider-amazon>=1.0.0` and use `airflow.providers.amazon.aws.transfers.gcs_to_s3.GCSToS3Operator` instead.
 
-AIR303.py:122:1: AIR303 `airflow.operators.google_api_to_s3_transfer.GoogleApiToS3Operator` is moved into `amazon` provider in Airflow 3.0;
+AIR303.py:161:1: AIR303 `airflow.operators.google_api_to_s3_transfer.GoogleApiToS3Operator` is moved into `amazon` provider in Airflow 3.0;
     |
-120 | provide_bucket_name()
-121 | GCSToS3Operator()
-122 | GoogleApiToS3Operator()
+159 | provide_bucket_name()
+160 | GCSToS3Operator()
+161 | GoogleApiToS3Operator()
     | ^^^^^^^^^^^^^^^^^^^^^ AIR303
-123 | GoogleApiToS3Transfer()
-124 | RedshiftToS3Operator()
+162 | GoogleApiToS3Transfer()
+163 | RedshiftToS3Operator()
     |
     = help: Install `apache-airflow-provider-amazon>=1.0.0` and use `airflow.providers.amazon.aws.transfers.google_api_to_s3.GoogleApiToS3Operator` instead.
 
-AIR303.py:123:1: AIR303 `airflow.operators.google_api_to_s3_transfer.GoogleApiToS3Transfer` is moved into `amazon` provider in Airflow 3.0;
+AIR303.py:162:1: AIR303 `airflow.operators.google_api_to_s3_transfer.GoogleApiToS3Transfer` is moved into `amazon` provider in Airflow 3.0;
     |
-121 | GCSToS3Operator()
-122 | GoogleApiToS3Operator()
-123 | GoogleApiToS3Transfer()
+160 | GCSToS3Operator()
+161 | GoogleApiToS3Operator()
+162 | GoogleApiToS3Transfer()
     | ^^^^^^^^^^^^^^^^^^^^^ AIR303
-124 | RedshiftToS3Operator()
-125 | RedshiftToS3Transfer()
+163 | RedshiftToS3Operator()
+164 | RedshiftToS3Transfer()
     |
     = help: Install `apache-airflow-provider-amazon>=1.0.0` and use `airflow.providers.amazon.aws.transfers.google_api_to_s3.GoogleApiToS3Operator` instead.
 
-AIR303.py:124:1: AIR303 `airflow.operators.redshift_to_s3_operator.RedshiftToS3Operator` is moved into `amazon` provider in Airflow 3.0;
+AIR303.py:163:1: AIR303 `airflow.operators.redshift_to_s3_operator.RedshiftToS3Operator` is moved into `amazon` provider in Airflow 3.0;
     |
-122 | GoogleApiToS3Operator()
-123 | GoogleApiToS3Transfer()
-124 | RedshiftToS3Operator()
+161 | GoogleApiToS3Operator()
+162 | GoogleApiToS3Transfer()
+163 | RedshiftToS3Operator()
     | ^^^^^^^^^^^^^^^^^^^^ AIR303
-125 | RedshiftToS3Transfer()
-126 | S3FileTransformOperator()
+164 | RedshiftToS3Transfer()
+165 | S3FileTransformOperator()
     |
     = help: Install `apache-airflow-provider-amazon>=1.0.0` and use `airflow.providers.amazon.aws.transfers.redshift_to_s3.RedshiftToS3Operator` instead.
 
-AIR303.py:125:1: AIR303 `airflow.operators.redshift_to_s3_operator.RedshiftToS3Transfer` is moved into `amazon` provider in Airflow 3.0;
+AIR303.py:164:1: AIR303 `airflow.operators.redshift_to_s3_operator.RedshiftToS3Transfer` is moved into `amazon` provider in Airflow 3.0;
     |
-123 | GoogleApiToS3Transfer()
-124 | RedshiftToS3Operator()
-125 | RedshiftToS3Transfer()
+162 | GoogleApiToS3Transfer()
+163 | RedshiftToS3Operator()
+164 | RedshiftToS3Transfer()
     | ^^^^^^^^^^^^^^^^^^^^ AIR303
-126 | S3FileTransformOperator()
-127 | S3Hook()
+165 | S3FileTransformOperator()
+166 | S3Hook()
     |
     = help: Install `apache-airflow-provider-amazon>=1.0.0` and use `airflow.providers.amazon.aws.transfers.redshift_to_s3.RedshiftToS3Operator` instead.
 
-AIR303.py:126:1: AIR303 `airflow.operators.s3_file_transform_operator.S3FileTransformOperator` is moved into `amazon` provider in Airflow 3.0;
+AIR303.py:165:1: AIR303 `airflow.operators.s3_file_transform_operator.S3FileTransformOperator` is moved into `amazon` provider in Airflow 3.0;
     |
-124 | RedshiftToS3Operator()
-125 | RedshiftToS3Transfer()
-126 | S3FileTransformOperator()
+163 | RedshiftToS3Operator()
+164 | RedshiftToS3Transfer()
+165 | S3FileTransformOperator()
     | ^^^^^^^^^^^^^^^^^^^^^^^ AIR303
-127 | S3Hook()
-128 | S3KeySensor()
+166 | S3Hook()
+167 | S3KeySensor()
     |
     = help: Install `apache-airflow-provider-amazon>=1.0.0` and use `airflow.providers.amazon.aws.operators.s3_file_transform.S3FileTransformOperator` instead.
 
-AIR303.py:127:1: AIR303 `airflow.hooks.S3_hook.S3Hook` is moved into `amazon` provider in Airflow 3.0;
+AIR303.py:166:1: AIR303 `airflow.hooks.S3_hook.S3Hook` is moved into `amazon` provider in Airflow 3.0;
     |
-125 | RedshiftToS3Transfer()
-126 | S3FileTransformOperator()
-127 | S3Hook()
+164 | RedshiftToS3Transfer()
+165 | S3FileTransformOperator()
+166 | S3Hook()
     | ^^^^^^ AIR303
-128 | S3KeySensor()
-129 | S3ToRedshiftOperator()
+167 | S3KeySensor()
+168 | S3ToRedshiftOperator()
     |
     = help: Install `apache-airflow-provider-amazon>=1.0.0` and use `airflow.providers.amazon.aws.hooks.s3.S3Hook` instead.
 
-AIR303.py:128:1: AIR303 `airflow.sensors.s3_key_sensor.S3KeySensor` is moved into `amazon` provider in Airflow 3.0;
+AIR303.py:167:1: AIR303 `airflow.sensors.s3_key_sensor.S3KeySensor` is moved into `amazon` provider in Airflow 3.0;
     |
-126 | S3FileTransformOperator()
-127 | S3Hook()
-128 | S3KeySensor()
+165 | S3FileTransformOperator()
+166 | S3Hook()
+167 | S3KeySensor()
     | ^^^^^^^^^^^ AIR303
-129 | S3ToRedshiftOperator()
-130 | S3ToRedshiftTransfer()
+168 | S3ToRedshiftOperator()
+169 | S3ToRedshiftTransfer()
     |
     = help: Install `apache-airflow-provider-amazon>=1.0.0` and use `S3KeySensor` instead.
 
-AIR303.py:129:1: AIR303 `airflow.operators.s3_to_redshift_operator.S3ToRedshiftOperator` is moved into `amazon` provider in Airflow 3.0;
+AIR303.py:168:1: AIR303 `airflow.operators.s3_to_redshift_operator.S3ToRedshiftOperator` is moved into `amazon` provider in Airflow 3.0;
     |
-127 | S3Hook()
-128 | S3KeySensor()
-129 | S3ToRedshiftOperator()
+166 | S3Hook()
+167 | S3KeySensor()
+168 | S3ToRedshiftOperator()
     | ^^^^^^^^^^^^^^^^^^^^ AIR303
-130 | S3ToRedshiftTransfer()
+169 | S3ToRedshiftTransfer()
     |
     = help: Install `apache-airflow-provider-amazon>=1.0.0` and use `airflow.providers.amazon.aws.transfers.s3_to_redshift.S3ToRedshiftOperator` instead.
 
-AIR303.py:130:1: AIR303 `airflow.operators.s3_to_redshift_operator.S3ToRedshiftTransfer` is moved into `amazon` provider in Airflow 3.0;
+AIR303.py:169:1: AIR303 `airflow.operators.s3_to_redshift_operator.S3ToRedshiftTransfer` is moved into `amazon` provider in Airflow 3.0;
     |
-128 | S3KeySensor()
-129 | S3ToRedshiftOperator()
-130 | S3ToRedshiftTransfer()
+167 | S3KeySensor()
+168 | S3ToRedshiftOperator()
+169 | S3ToRedshiftTransfer()
     | ^^^^^^^^^^^^^^^^^^^^ AIR303
-131 | 
-132 | # apache-airflow-providers-celery
+170 | 
+171 | # apache-airflow-providers-celery
     |
     = help: Install `apache-airflow-provider-amazon>=1.0.0` and use `airflow.providers.amazon.aws.transfers.s3_to_redshift.S3ToRedshiftOperator` instead.
 
-AIR303.py:133:1: AIR303 Import path `airflow.config_templates.default_celery.DEFAULT_CELERY_CONFIG` is moved into `celery` provider in Airflow 3.0;
+AIR303.py:172:1: AIR303 Import path `airflow.config_templates.default_celery.DEFAULT_CELERY_CONFIG` is moved into `celery` provider in Airflow 3.0;
     |
-132 | # apache-airflow-providers-celery
-133 | DEFAULT_CELERY_CONFIG
+171 | # apache-airflow-providers-celery
+172 | DEFAULT_CELERY_CONFIG
     | ^^^^^^^^^^^^^^^^^^^^^ AIR303
-134 | app
-135 | CeleryExecutor()
+173 | app
+174 | CeleryExecutor()
     |
     = help: Install `apache-airflow-provider-celery>=3.3.0` and import from `airflow.providers.celery.executors.default_celery.DEFAULT_CELERY_CONFIG` instead.
 
-AIR303.py:134:1: AIR303 Import path `airflow.executors.celery_executor.app` is moved into `celery` provider in Airflow 3.0;
+AIR303.py:173:1: AIR303 Import path `airflow.executors.celery_executor.app` is moved into `celery` provider in Airflow 3.0;
     |
-132 | # apache-airflow-providers-celery
-133 | DEFAULT_CELERY_CONFIG
-134 | app
+171 | # apache-airflow-providers-celery
+172 | DEFAULT_CELERY_CONFIG
+173 | app
     | ^^^ AIR303
-135 | CeleryExecutor()
-136 | CeleryKubernetesExecutor()
+174 | CeleryExecutor()
+175 | CeleryKubernetesExecutor()
     |
     = help: Install `apache-airflow-provider-celery>=3.3.0` and import from `airflow.providers.celery.executors.celery_executor_utils.app` instead.
 
-AIR303.py:135:1: AIR303 `airflow.executors.celery_executor.CeleryExecutor` is moved into `celery` provider in Airflow 3.0;
+AIR303.py:174:1: AIR303 `airflow.executors.celery_executor.CeleryExecutor` is moved into `celery` provider in Airflow 3.0;
     |
-133 | DEFAULT_CELERY_CONFIG
-134 | app
-135 | CeleryExecutor()
+172 | DEFAULT_CELERY_CONFIG
+173 | app
+174 | CeleryExecutor()
     | ^^^^^^^^^^^^^^ AIR303
-136 | CeleryKubernetesExecutor()
+175 | CeleryKubernetesExecutor()
     |
     = help: Install `apache-airflow-provider-celery>=3.3.0` and use `airflow.providers.celery.executors.celery_executor.CeleryExecutor` instead.
 
-AIR303.py:136:1: AIR303 `airflow.executors.celery_kubernetes_executor.CeleryKubernetesExecutor` is moved into `celery` provider in Airflow 3.0;
+AIR303.py:175:1: AIR303 `airflow.executors.celery_kubernetes_executor.CeleryKubernetesExecutor` is moved into `celery` provider in Airflow 3.0;
     |
-134 | app
-135 | CeleryExecutor()
-136 | CeleryKubernetesExecutor()
+173 | app
+174 | CeleryExecutor()
+175 | CeleryKubernetesExecutor()
     | ^^^^^^^^^^^^^^^^^^^^^^^^ AIR303
-137 | 
-138 | # apache-airflow-providers-common-sql
+176 | 
+177 | # apache-airflow-providers-common-sql
     |
     = help: Install `apache-airflow-provider-celery>=3.3.0` and use `airflow.providers.celery.executors.celery_kubernetes_executor.CeleryKubernetesExecutor` instead.
 
-AIR303.py:139:1: AIR303 `airflow.operators.sql._convert_to_float_if_possible` is moved into `common-sql` provider in Airflow 3.0;
+AIR303.py:178:1: AIR303 `airflow.operators.sql._convert_to_float_if_possible` is moved into `common-sql` provider in Airflow 3.0;
     |
-138 | # apache-airflow-providers-common-sql
-139 | _convert_to_float_if_possible()
+177 | # apache-airflow-providers-common-sql
+178 | _convert_to_float_if_possible()
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR303
-140 | parse_boolean()
-141 | BaseSQLOperator()
+179 | parse_boolean()
+180 | BaseSQLOperator()
     |
     = help: Install `apache-airflow-provider-common-sql>=1.0.0` and use `airflow.providers.common.sql.operators.sql._convert_to_float_if_possible` instead.
 
-AIR303.py:140:1: AIR303 `airflow.operators.sql.parse_boolean` is moved into `common-sql` provider in Airflow 3.0;
+AIR303.py:179:1: AIR303 `airflow.operators.sql.parse_boolean` is moved into `common-sql` provider in Airflow 3.0;
     |
-138 | # apache-airflow-providers-common-sql
-139 | _convert_to_float_if_possible()
-140 | parse_boolean()
+177 | # apache-airflow-providers-common-sql
+178 | _convert_to_float_if_possible()
+179 | parse_boolean()
     | ^^^^^^^^^^^^^ AIR303
-141 | BaseSQLOperator()
-142 | BranchSQLOperator()
+180 | BaseSQLOperator()
+181 | BranchSQLOperator()
     |
     = help: Install `apache-airflow-provider-common-sql>=1.0.0` and use `airflow.providers.common.sql.operators.sql.parse_boolean` instead.
 
-AIR303.py:141:1: AIR303 `airflow.operators.sql.BaseSQLOperator` is moved into `common-sql` provider in Airflow 3.0;
+AIR303.py:180:1: AIR303 `airflow.operators.sql.BaseSQLOperator` is moved into `common-sql` provider in Airflow 3.0;
     |
-139 | _convert_to_float_if_possible()
-140 | parse_boolean()
-141 | BaseSQLOperator()
+178 | _convert_to_float_if_possible()
+179 | parse_boolean()
+180 | BaseSQLOperator()
     | ^^^^^^^^^^^^^^^ AIR303
-142 | BranchSQLOperator()
-143 | CheckOperator()
+181 | BranchSQLOperator()
+182 | CheckOperator()
     |
     = help: Install `apache-airflow-provider-common-sql>=1.1.0` and use `airflow.providers.common.sql.operators.sql.BaseSQLOperator` instead.
 
-AIR303.py:142:1: AIR303 `airflow.operators.sql.BranchSQLOperator` is moved into `common-sql` provider in Airflow 3.0;
+AIR303.py:181:1: AIR303 `airflow.operators.sql.BranchSQLOperator` is moved into `common-sql` provider in Airflow 3.0;
     |
-140 | parse_boolean()
-141 | BaseSQLOperator()
-142 | BranchSQLOperator()
+179 | parse_boolean()
+180 | BaseSQLOperator()
+181 | BranchSQLOperator()
     | ^^^^^^^^^^^^^^^^^ AIR303
-143 | CheckOperator()
-144 | ConnectorProtocol()
+182 | CheckOperator()
+183 | ConnectorProtocol()
     |
     = help: Install `apache-airflow-provider-common-sql>=1.1.0` and use `airflow.providers.common.sql.operators.sql.BranchSQLOperator` instead.
 
-AIR303.py:143:1: AIR303 `airflow.operators.check_operator.CheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+AIR303.py:182:1: AIR303 `airflow.operators.check_operator.CheckOperator` is moved into `common-sql` provider in Airflow 3.0;
     |
-141 | BaseSQLOperator()
-142 | BranchSQLOperator()
-143 | CheckOperator()
+180 | BaseSQLOperator()
+181 | BranchSQLOperator()
+182 | CheckOperator()
     | ^^^^^^^^^^^^^ AIR303
-144 | ConnectorProtocol()
-145 | DbApiHook()
+183 | ConnectorProtocol()
+184 | DbApiHook()
     |
     = help: Install `apache-airflow-provider-common-sql>=1.1.0` and use `airflow.providers.common.sql.operators.sql.SQLCheckOperator` instead.
 
-AIR303.py:144:1: AIR303 Import path `airflow.hooks.dbapi.ConnectorProtocol` is moved into `common-sql` provider in Airflow 3.0;
+AIR303.py:183:1: AIR303 Import path `airflow.hooks.dbapi.ConnectorProtocol` is moved into `common-sql` provider in Airflow 3.0;
     |
-142 | BranchSQLOperator()
-143 | CheckOperator()
-144 | ConnectorProtocol()
+181 | BranchSQLOperator()
+182 | CheckOperator()
+183 | ConnectorProtocol()
     | ^^^^^^^^^^^^^^^^^ AIR303
-145 | DbApiHook()
-146 | DbApiHook2()
+184 | DbApiHook()
+185 | DbApiHook2()
     |
     = help: Install `apache-airflow-provider-common-sql>=1.0.0` and import from `airflow.providers.common.sql.hooks.sql.ConnectorProtocol` instead.
 
-AIR303.py:145:1: AIR303 Import path `airflow.hooks.dbapi.DbApiHook` is moved into `common-sql` provider in Airflow 3.0;
+AIR303.py:184:1: AIR303 Import path `airflow.hooks.dbapi.DbApiHook` is moved into `common-sql` provider in Airflow 3.0;
     |
-143 | CheckOperator()
-144 | ConnectorProtocol()
-145 | DbApiHook()
+182 | CheckOperator()
+183 | ConnectorProtocol()
+184 | DbApiHook()
     | ^^^^^^^^^ AIR303
-146 | DbApiHook2()
-147 | IntervalCheckOperator()
+185 | DbApiHook2()
+186 | IntervalCheckOperator()
     |
     = help: Install `apache-airflow-provider-common-sql>=1.0.0` and import from `airflow.providers.common.sql.hooks.sql.DbApiHook` instead.
 
-AIR303.py:146:1: AIR303 `airflow.hooks.dbapi_hook.DbApiHook` is moved into `common-sql` provider in Airflow 3.0;
+AIR303.py:185:1: AIR303 `airflow.hooks.dbapi_hook.DbApiHook` is moved into `common-sql` provider in Airflow 3.0;
     |
-144 | ConnectorProtocol()
-145 | DbApiHook()
-146 | DbApiHook2()
+183 | ConnectorProtocol()
+184 | DbApiHook()
+185 | DbApiHook2()
     | ^^^^^^^^^^ AIR303
-147 | IntervalCheckOperator()
-148 | PrestoCheckOperator()
+186 | IntervalCheckOperator()
+187 | PrestoCheckOperator()
     |
     = help: Install `apache-airflow-provider-common-sql>=1.0.0` and use `airflow.providers.common.sql.hooks.sql.DbApiHook` instead.
 
-AIR303.py:147:1: AIR303 `airflow.operators.check_operator.IntervalCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+AIR303.py:186:1: AIR303 `airflow.operators.check_operator.IntervalCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
     |
-145 | DbApiHook()
-146 | DbApiHook2()
-147 | IntervalCheckOperator()
+184 | DbApiHook()
+185 | DbApiHook2()
+186 | IntervalCheckOperator()
     | ^^^^^^^^^^^^^^^^^^^^^ AIR303
-148 | PrestoCheckOperator()
-149 | PrestoIntervalCheckOperator()
+187 | PrestoCheckOperator()
+188 | PrestoIntervalCheckOperator()
     |
     = help: Install `apache-airflow-provider-common-sql>=1.1.0` and use `airflow.providers.common.sql.operators.sql.SQLIntervalCheckOperator` instead.
 
-AIR303.py:148:1: AIR303 `airflow.operators.presto_check_operator.PrestoCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+AIR303.py:187:1: AIR303 `airflow.operators.presto_check_operator.PrestoCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
     |
-146 | DbApiHook2()
-147 | IntervalCheckOperator()
-148 | PrestoCheckOperator()
+185 | DbApiHook2()
+186 | IntervalCheckOperator()
+187 | PrestoCheckOperator()
     | ^^^^^^^^^^^^^^^^^^^ AIR303
-149 | PrestoIntervalCheckOperator()
-150 | PrestoValueCheckOperator()
+188 | PrestoIntervalCheckOperator()
+189 | PrestoValueCheckOperator()
     |
     = help: Install `apache-airflow-provider-common-sql>=1.1.0` and use `airflow.providers.common.sql.operators.sql.SQLCheckOperator` instead.
 
-AIR303.py:149:1: AIR303 `airflow.operators.presto_check_operator.PrestoIntervalCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+AIR303.py:188:1: AIR303 `airflow.operators.presto_check_operator.PrestoIntervalCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
     |
-147 | IntervalCheckOperator()
-148 | PrestoCheckOperator()
-149 | PrestoIntervalCheckOperator()
+186 | IntervalCheckOperator()
+187 | PrestoCheckOperator()
+188 | PrestoIntervalCheckOperator()
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR303
-150 | PrestoValueCheckOperator()
-151 | SQLCheckOperator()
+189 | PrestoValueCheckOperator()
+190 | SQLCheckOperator()
     |
     = help: Install `apache-airflow-provider-common-sql>=1.1.0` and use `airflow.providers.common.sql.operators.sql.SQLIntervalCheckOperator` instead.
 
-AIR303.py:150:1: AIR303 `airflow.operators.presto_check_operator.PrestoValueCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+AIR303.py:189:1: AIR303 `airflow.operators.presto_check_operator.PrestoValueCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
     |
-148 | PrestoCheckOperator()
-149 | PrestoIntervalCheckOperator()
-150 | PrestoValueCheckOperator()
+187 | PrestoCheckOperator()
+188 | PrestoIntervalCheckOperator()
+189 | PrestoValueCheckOperator()
     | ^^^^^^^^^^^^^^^^^^^^^^^^ AIR303
-151 | SQLCheckOperator()
-152 | SQLCheckOperator2()
+190 | SQLCheckOperator()
+191 | SQLCheckOperator2()
     |
     = help: Install `apache-airflow-provider-common-sql>=1.1.0` and use `airflow.providers.common.sql.operators.sql.SQLValueCheckOperator` instead.
 
-AIR303.py:151:1: AIR303 `airflow.operators.check_operator.SQLCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+AIR303.py:190:1: AIR303 `airflow.operators.check_operator.SQLCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
     |
-149 | PrestoIntervalCheckOperator()
-150 | PrestoValueCheckOperator()
-151 | SQLCheckOperator()
+188 | PrestoIntervalCheckOperator()
+189 | PrestoValueCheckOperator()
+190 | SQLCheckOperator()
     | ^^^^^^^^^^^^^^^^ AIR303
-152 | SQLCheckOperator2()
-153 | SQLCheckOperator3()
+191 | SQLCheckOperator2()
+192 | SQLCheckOperator3()
     |
     = help: Install `apache-airflow-provider-common-sql>=1.1.0` and use `airflow.providers.common.sql.operators.sql.SQLCheckOperator` instead.
 
-AIR303.py:152:1: AIR303 `airflow.operators.presto_check_operator.SQLCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+AIR303.py:191:1: AIR303 `airflow.operators.presto_check_operator.SQLCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
     |
-150 | PrestoValueCheckOperator()
-151 | SQLCheckOperator()
-152 | SQLCheckOperator2()
+189 | PrestoValueCheckOperator()
+190 | SQLCheckOperator()
+191 | SQLCheckOperator2()
     | ^^^^^^^^^^^^^^^^^ AIR303
-153 | SQLCheckOperator3()
-154 | SQLColumnCheckOperator2()
+192 | SQLCheckOperator3()
+193 | SQLColumnCheckOperator2()
     |
     = help: Install `apache-airflow-provider-common-sql>=1.1.0` and use `airflow.providers.common.sql.operators.sql.SQLCheckOperator` instead.
 
-AIR303.py:153:1: AIR303 `airflow.operators.sql.SQLCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+AIR303.py:192:1: AIR303 `airflow.operators.sql.SQLCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
     |
-151 | SQLCheckOperator()
-152 | SQLCheckOperator2()
-153 | SQLCheckOperator3()
+190 | SQLCheckOperator()
+191 | SQLCheckOperator2()
+192 | SQLCheckOperator3()
     | ^^^^^^^^^^^^^^^^^ AIR303
-154 | SQLColumnCheckOperator2()
-155 | SQLIntervalCheckOperator()
+193 | SQLColumnCheckOperator2()
+194 | SQLIntervalCheckOperator()
     |
     = help: Install `apache-airflow-provider-common-sql>=1.1.0` and use `airflow.providers.common.sql.operators.sql.SQLCheckOperator` instead.
 
-AIR303.py:154:1: AIR303 `airflow.operators.sql.SQLColumnCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+AIR303.py:193:1: AIR303 `airflow.operators.sql.SQLColumnCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
     |
-152 | SQLCheckOperator2()
-153 | SQLCheckOperator3()
-154 | SQLColumnCheckOperator2()
+191 | SQLCheckOperator2()
+192 | SQLCheckOperator3()
+193 | SQLColumnCheckOperator2()
     | ^^^^^^^^^^^^^^^^^^^^^^^ AIR303
-155 | SQLIntervalCheckOperator()
-156 | SQLIntervalCheckOperator2()
+194 | SQLIntervalCheckOperator()
+195 | SQLIntervalCheckOperator2()
     |
     = help: Install `apache-airflow-provider-common-sql>=1.0.0` and use `airflow.providers.common.sql.operators.sql.SQLColumnCheckOperator` instead.
 
-AIR303.py:155:1: AIR303 `airflow.operators.check_operator.SQLIntervalCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+AIR303.py:194:1: AIR303 `airflow.operators.check_operator.SQLIntervalCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
     |
-153 | SQLCheckOperator3()
-154 | SQLColumnCheckOperator2()
-155 | SQLIntervalCheckOperator()
+192 | SQLCheckOperator3()
+193 | SQLColumnCheckOperator2()
+194 | SQLIntervalCheckOperator()
     | ^^^^^^^^^^^^^^^^^^^^^^^^ AIR303
-156 | SQLIntervalCheckOperator2()
-157 | SQLIntervalCheckOperator3()
+195 | SQLIntervalCheckOperator2()
+196 | SQLIntervalCheckOperator3()
     |
     = help: Install `apache-airflow-provider-common-sql>=1.1.0` and use `airflow.providers.common.sql.operators.sql.SQLIntervalCheckOperator` instead.
 
-AIR303.py:156:1: AIR303 `airflow.operators.presto_check_operator.SQLIntervalCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+AIR303.py:195:1: AIR303 `airflow.operators.presto_check_operator.SQLIntervalCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
     |
-154 | SQLColumnCheckOperator2()
-155 | SQLIntervalCheckOperator()
-156 | SQLIntervalCheckOperator2()
+193 | SQLColumnCheckOperator2()
+194 | SQLIntervalCheckOperator()
+195 | SQLIntervalCheckOperator2()
     | ^^^^^^^^^^^^^^^^^^^^^^^^^ AIR303
-157 | SQLIntervalCheckOperator3()
-158 | SQLTableCheckOperator()
+196 | SQLIntervalCheckOperator3()
+197 | SQLTableCheckOperator()
     |
     = help: Install `apache-airflow-provider-common-sql>=1.1.0` and use `airflow.providers.common.sql.operators.sql.SQLIntervalCheckOperator` instead.
 
-AIR303.py:157:1: AIR303 `airflow.operators.sql.SQLIntervalCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+AIR303.py:196:1: AIR303 `airflow.operators.sql.SQLIntervalCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
     |
-155 | SQLIntervalCheckOperator()
-156 | SQLIntervalCheckOperator2()
-157 | SQLIntervalCheckOperator3()
+194 | SQLIntervalCheckOperator()
+195 | SQLIntervalCheckOperator2()
+196 | SQLIntervalCheckOperator3()
     | ^^^^^^^^^^^^^^^^^^^^^^^^^ AIR303
-158 | SQLTableCheckOperator()
-159 | SQLThresholdCheckOperator()
+197 | SQLTableCheckOperator()
+198 | SQLThresholdCheckOperator()
     |
     = help: Install `apache-airflow-provider-common-sql>=1.1.0` and use `airflow.providers.common.sql.operators.sql.SQLIntervalCheckOperator` instead.
 
-AIR303.py:159:1: AIR303 `airflow.operators.check_operator.SQLThresholdCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+AIR303.py:198:1: AIR303 `airflow.operators.check_operator.SQLThresholdCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
     |
-157 | SQLIntervalCheckOperator3()
-158 | SQLTableCheckOperator()
-159 | SQLThresholdCheckOperator()
+196 | SQLIntervalCheckOperator3()
+197 | SQLTableCheckOperator()
+198 | SQLThresholdCheckOperator()
     | ^^^^^^^^^^^^^^^^^^^^^^^^^ AIR303
-160 | SQLThresholdCheckOperator2()
-161 | SQLValueCheckOperator()
+199 | SQLThresholdCheckOperator2()
+200 | SQLValueCheckOperator()
     |
     = help: Install `apache-airflow-provider-common-sql>=1.1.0` and use `airflow.providers.common.sql.operators.sql.SQLThresholdCheckOperator` instead.
 
-AIR303.py:160:1: AIR303 `airflow.operators.sql.SQLThresholdCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+AIR303.py:199:1: AIR303 `airflow.operators.sql.SQLThresholdCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
     |
-158 | SQLTableCheckOperator()
-159 | SQLThresholdCheckOperator()
-160 | SQLThresholdCheckOperator2()
+197 | SQLTableCheckOperator()
+198 | SQLThresholdCheckOperator()
+199 | SQLThresholdCheckOperator2()
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR303
-161 | SQLValueCheckOperator()
-162 | SQLValueCheckOperator2()
+200 | SQLValueCheckOperator()
+201 | SQLValueCheckOperator2()
     |
     = help: Install `apache-airflow-provider-common-sql>=1.0.0` and use `airflow.providers.common.sql.operators.sql.SQLTableCheckOperator` instead.
 
-AIR303.py:161:1: AIR303 `airflow.operators.check_operator.SQLValueCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+AIR303.py:200:1: AIR303 `airflow.operators.check_operator.SQLValueCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
     |
-159 | SQLThresholdCheckOperator()
-160 | SQLThresholdCheckOperator2()
-161 | SQLValueCheckOperator()
+198 | SQLThresholdCheckOperator()
+199 | SQLThresholdCheckOperator2()
+200 | SQLValueCheckOperator()
     | ^^^^^^^^^^^^^^^^^^^^^ AIR303
-162 | SQLValueCheckOperator2()
-163 | SQLValueCheckOperator3()
+201 | SQLValueCheckOperator2()
+202 | SQLValueCheckOperator3()
     |
     = help: Install `apache-airflow-provider-common-sql>=1.1.0` and use `airflow.providers.common.sql.operators.sql.SQLValueCheckOperator` instead.
 
-AIR303.py:162:1: AIR303 `airflow.operators.presto_check_operator.SQLValueCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+AIR303.py:201:1: AIR303 `airflow.operators.presto_check_operator.SQLValueCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
     |
-160 | SQLThresholdCheckOperator2()
-161 | SQLValueCheckOperator()
-162 | SQLValueCheckOperator2()
+199 | SQLThresholdCheckOperator2()
+200 | SQLValueCheckOperator()
+201 | SQLValueCheckOperator2()
     | ^^^^^^^^^^^^^^^^^^^^^^ AIR303
-163 | SQLValueCheckOperator3()
-164 | SqlSensor()
+202 | SQLValueCheckOperator3()
+203 | SqlSensor()
     |
     = help: Install `apache-airflow-provider-common-sql>=1.1.0` and use `airflow.providers.common.sql.operators.sql.SQLValueCheckOperator` instead.
 
-AIR303.py:163:1: AIR303 `airflow.operators.sql.SQLValueCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+AIR303.py:202:1: AIR303 `airflow.operators.sql.SQLValueCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
     |
-161 | SQLValueCheckOperator()
-162 | SQLValueCheckOperator2()
-163 | SQLValueCheckOperator3()
+200 | SQLValueCheckOperator()
+201 | SQLValueCheckOperator2()
+202 | SQLValueCheckOperator3()
     | ^^^^^^^^^^^^^^^^^^^^^^ AIR303
-164 | SqlSensor()
-165 | SqlSensor2()
+203 | SqlSensor()
+204 | SqlSensor2()
     |
     = help: Install `apache-airflow-provider-common-sql>=1.0.0` and use `airflow.providers.common.sql.operators.sql.SQLValueCheckOperator` instead.
 
-AIR303.py:164:1: AIR303 `airflow.sensors.sql.SqlSensor` is moved into `common-sql` provider in Airflow 3.0;
+AIR303.py:203:1: AIR303 `airflow.sensors.sql.SqlSensor` is moved into `common-sql` provider in Airflow 3.0;
     |
-162 | SQLValueCheckOperator2()
-163 | SQLValueCheckOperator3()
-164 | SqlSensor()
+201 | SQLValueCheckOperator2()
+202 | SQLValueCheckOperator3()
+203 | SqlSensor()
     | ^^^^^^^^^ AIR303
-165 | SqlSensor2()
-166 | ThresholdCheckOperator()
+204 | SqlSensor2()
+205 | ThresholdCheckOperator()
     |
     = help: Install `apache-airflow-provider-common-sql>=1.0.0` and use `airflow.providers.common.sql.sensors.sql.SqlSensor` instead.
 
-AIR303.py:166:1: AIR303 `airflow.operators.check_operator.ThresholdCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+AIR303.py:205:1: AIR303 `airflow.operators.check_operator.ThresholdCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
     |
-164 | SqlSensor()
-165 | SqlSensor2()
-166 | ThresholdCheckOperator()
+203 | SqlSensor()
+204 | SqlSensor2()
+205 | ThresholdCheckOperator()
     | ^^^^^^^^^^^^^^^^^^^^^^ AIR303
-167 | ValueCheckOperator()
+206 | ValueCheckOperator()
     |
     = help: Install `apache-airflow-provider-common-sql>=1.1.0` and use `airflow.providers.common.sql.operators.sql.SQLThresholdCheckOperator` instead.
 
-AIR303.py:167:1: AIR303 `airflow.operators.check_operator.ValueCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+AIR303.py:206:1: AIR303 `airflow.operators.check_operator.ValueCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
     |
-165 | SqlSensor2()
-166 | ThresholdCheckOperator()
-167 | ValueCheckOperator()
+204 | SqlSensor2()
+205 | ThresholdCheckOperator()
+206 | ValueCheckOperator()
     | ^^^^^^^^^^^^^^^^^^ AIR303
-168 | 
-169 | # apache-airflow-providers-daskexecutor
+207 | 
+208 | # apache-airflow-providers-daskexecutor
     |
     = help: Install `apache-airflow-provider-common-sql>=1.1.0` and use `airflow.providers.common.sql.operators.sql.SQLValueCheckOperator` instead.
 
-AIR303.py:170:1: AIR303 `airflow.executors.dask_executor.DaskExecutor` is moved into `daskexecutor` provider in Airflow 3.0;
+AIR303.py:209:1: AIR303 `airflow.executors.dask_executor.DaskExecutor` is moved into `daskexecutor` provider in Airflow 3.0;
     |
-169 | # apache-airflow-providers-daskexecutor
-170 | DaskExecutor()
+208 | # apache-airflow-providers-daskexecutor
+209 | DaskExecutor()
     | ^^^^^^^^^^^^ AIR303
-171 | 
-172 | # apache-airflow-providers-docker
+210 | 
+211 | # apache-airflow-providers-docker
     |
     = help: Install `apache-airflow-provider-daskexecutor>=1.0.0` and use `airflow.providers.daskexecutor.executors.dask_executor.DaskExecutor` instead.
 
-AIR303.py:173:1: AIR303 `airflow.hooks.docker_hook.DockerHook` is moved into `docker` provider in Airflow 3.0;
+AIR303.py:212:1: AIR303 `airflow.hooks.docker_hook.DockerHook` is moved into `docker` provider in Airflow 3.0;
     |
-172 | # apache-airflow-providers-docker
-173 | DockerHook()
+211 | # apache-airflow-providers-docker
+212 | DockerHook()
     | ^^^^^^^^^^ AIR303
-174 | DockerOperator()
+213 | DockerOperator()
     |
     = help: Install `apache-airflow-provider-docker>=1.0.0` and use `airflow.providers.docker.hooks.docker.DockerHook` instead.
 
-AIR303.py:174:1: AIR303 `airflow.operators.docker_operator.DockerOperator` is moved into `docker` provider in Airflow 3.0;
+AIR303.py:213:1: AIR303 `airflow.operators.docker_operator.DockerOperator` is moved into `docker` provider in Airflow 3.0;
     |
-172 | # apache-airflow-providers-docker
-173 | DockerHook()
-174 | DockerOperator()
+211 | # apache-airflow-providers-docker
+212 | DockerHook()
+213 | DockerOperator()
     | ^^^^^^^^^^^^^^ AIR303
-175 | 
-176 | # apache-airflow-providers-apache-druid
+214 | 
+215 | # apache-airflow-providers-apache-druid
     |
     = help: Install `apache-airflow-provider-docker>=1.0.0` and use `airflow.providers.docker.operators.docker.DockerOperator` instead.
 
-AIR303.py:177:1: AIR303 `airflow.hooks.druid_hook.DruidDbApiHook` is moved into `apache-druid` provider in Airflow 3.0;
+AIR303.py:216:1: AIR303 `airflow.hooks.druid_hook.DruidDbApiHook` is moved into `apache-druid` provider in Airflow 3.0;
     |
-176 | # apache-airflow-providers-apache-druid
-177 | DruidDbApiHook()
+215 | # apache-airflow-providers-apache-druid
+216 | DruidDbApiHook()
     | ^^^^^^^^^^^^^^ AIR303
-178 | DruidHook()
-179 | DruidCheckOperator()
+217 | DruidHook()
+218 | DruidCheckOperator()
     |
     = help: Install `apache-airflow-provider-apache-druid>=1.0.0` and use `DruidDbApiHook` instead.
 
-AIR303.py:178:1: AIR303 `airflow.hooks.druid_hook.DruidHook` is moved into `apache-druid` provider in Airflow 3.0;
+AIR303.py:217:1: AIR303 `airflow.hooks.druid_hook.DruidHook` is moved into `apache-druid` provider in Airflow 3.0;
     |
-176 | # apache-airflow-providers-apache-druid
-177 | DruidDbApiHook()
-178 | DruidHook()
+215 | # apache-airflow-providers-apache-druid
+216 | DruidDbApiHook()
+217 | DruidHook()
     | ^^^^^^^^^ AIR303
-179 | DruidCheckOperator()
+218 | DruidCheckOperator()
     |
     = help: Install `apache-airflow-provider-apache-druid>=1.0.0` and use `DruidHook` instead.
 
-AIR303.py:179:1: AIR303 `airflow.operators.druid_check_operator.DruidCheckOperator` is moved into `apache-druid` provider in Airflow 3.0;
+AIR303.py:218:1: AIR303 `airflow.operators.druid_check_operator.DruidCheckOperator` is moved into `apache-druid` provider in Airflow 3.0;
     |
-177 | DruidDbApiHook()
-178 | DruidHook()
-179 | DruidCheckOperator()
+216 | DruidDbApiHook()
+217 | DruidHook()
+218 | DruidCheckOperator()
     | ^^^^^^^^^^^^^^^^^^ AIR303
-180 | 
-181 | # apache-airflow-providers-apache-hdfs
+219 | 
+220 | # apache-airflow-providers-apache-hdfs
     |
     = help: Install `apache-airflow-provider-apache-druid>=1.0.0` and use `DruidCheckOperator` instead.
 
-AIR303.py:182:1: AIR303 `airflow.hooks.webhdfs_hook.WebHDFSHook` is moved into `apache-hdfs` provider in Airflow 3.0;
+AIR303.py:221:1: AIR303 `airflow.hooks.webhdfs_hook.WebHDFSHook` is moved into `apache-hdfs` provider in Airflow 3.0;
     |
-181 | # apache-airflow-providers-apache-hdfs
-182 | WebHDFSHook()
+220 | # apache-airflow-providers-apache-hdfs
+221 | WebHDFSHook()
     | ^^^^^^^^^^^ AIR303
-183 | WebHdfsSensor()
+222 | WebHdfsSensor()
     |
     = help: Install `apache-airflow-provider-apache-hdfs>=1.0.0` and use `airflow.providers.apache.hdfs.hooks.webhdfs.WebHDFSHook` instead.
 
-AIR303.py:183:1: AIR303 `airflow.sensors.web_hdfs_sensor.WebHdfsSensor` is moved into `apache-hdfs` provider in Airflow 3.0;
+AIR303.py:222:1: AIR303 `airflow.sensors.web_hdfs_sensor.WebHdfsSensor` is moved into `apache-hdfs` provider in Airflow 3.0;
     |
-181 | # apache-airflow-providers-apache-hdfs
-182 | WebHDFSHook()
-183 | WebHdfsSensor()
+220 | # apache-airflow-providers-apache-hdfs
+221 | WebHDFSHook()
+222 | WebHdfsSensor()
     | ^^^^^^^^^^^^^ AIR303
-184 | 
-185 | # apache-airflow-providers-apache-hive
+223 | 
+224 | # apache-airflow-providers-apache-hive
     |
     = help: Install `apache-airflow-provider-apache-hdfs>=1.0.0` and use `airflow.providers.apache.hdfs.sensors.web_hdfs.WebHdfsSensor` instead.
 
-AIR303.py:186:1: AIR303 `airflow.hooks.hive_hooks.HIVE_QUEUE_PRIORITIES` is moved into `apache-hive` provider in Airflow 3.0;
+AIR303.py:225:1: AIR303 `airflow.hooks.hive_hooks.HIVE_QUEUE_PRIORITIES` is moved into `apache-hive` provider in Airflow 3.0;
     |
-185 | # apache-airflow-providers-apache-hive
-186 | HIVE_QUEUE_PRIORITIES
+224 | # apache-airflow-providers-apache-hive
+225 | HIVE_QUEUE_PRIORITIES
     | ^^^^^^^^^^^^^^^^^^^^^ AIR303
-187 | closest_ds_partition()
-188 | max_partition()
+226 | closest_ds_partition()
+227 | max_partition()
     |
     = help: Install `apache-airflow-provider-apache-hive>=1.0.0` and use `airflow.providers.apache.hive.hooks.hive.HIVE_QUEUE_PRIORITIES` instead.
 
-AIR303.py:187:1: AIR303 `airflow.macros.hive.closest_ds_partition` is moved into `apache-hive` provider in Airflow 3.0;
+AIR303.py:226:1: AIR303 `airflow.macros.hive.closest_ds_partition` is moved into `apache-hive` provider in Airflow 3.0;
     |
-185 | # apache-airflow-providers-apache-hive
-186 | HIVE_QUEUE_PRIORITIES
-187 | closest_ds_partition()
+224 | # apache-airflow-providers-apache-hive
+225 | HIVE_QUEUE_PRIORITIES
+226 | closest_ds_partition()
     | ^^^^^^^^^^^^^^^^^^^^ AIR303
-188 | max_partition()
-189 | HiveCliHook()
+227 | max_partition()
+228 | HiveCliHook()
     |
     = help: Install `apache-airflow-provider-apache-hive>=5.1.0` and use `airflow.providers.apache.hive.macros.hive.closest_ds_partition` instead.
 
-AIR303.py:188:1: AIR303 `airflow.macros.hive.max_partition` is moved into `apache-hive` provider in Airflow 3.0;
+AIR303.py:227:1: AIR303 `airflow.macros.hive.max_partition` is moved into `apache-hive` provider in Airflow 3.0;
     |
-186 | HIVE_QUEUE_PRIORITIES
-187 | closest_ds_partition()
-188 | max_partition()
+225 | HIVE_QUEUE_PRIORITIES
+226 | closest_ds_partition()
+227 | max_partition()
     | ^^^^^^^^^^^^^ AIR303
-189 | HiveCliHook()
-190 | HiveMetastoreHook()
+228 | HiveCliHook()
+229 | HiveMetastoreHook()
     |
     = help: Install `apache-airflow-provider-apache-hive>=5.1.0` and use `airflow.providers.apache.hive.macros.hive.max_partition` instead.
 
-AIR303.py:189:1: AIR303 `airflow.hooks.hive_hooks.HiveCliHook` is moved into `apache-hive` provider in Airflow 3.0;
+AIR303.py:228:1: AIR303 `airflow.hooks.hive_hooks.HiveCliHook` is moved into `apache-hive` provider in Airflow 3.0;
     |
-187 | closest_ds_partition()
-188 | max_partition()
-189 | HiveCliHook()
+226 | closest_ds_partition()
+227 | max_partition()
+228 | HiveCliHook()
     | ^^^^^^^^^^^ AIR303
-190 | HiveMetastoreHook()
-191 | HiveOperator()
+229 | HiveMetastoreHook()
+230 | HiveOperator()
     |
     = help: Install `apache-airflow-provider-apache-hive>=1.0.0` and use `airflow.providers.apache.hive.hooks.hive.HiveCliHook` instead.
 
-AIR303.py:190:1: AIR303 `airflow.hooks.hive_hooks.HiveMetastoreHook` is moved into `apache-hive` provider in Airflow 3.0;
+AIR303.py:229:1: AIR303 `airflow.hooks.hive_hooks.HiveMetastoreHook` is moved into `apache-hive` provider in Airflow 3.0;
     |
-188 | max_partition()
-189 | HiveCliHook()
-190 | HiveMetastoreHook()
+227 | max_partition()
+228 | HiveCliHook()
+229 | HiveMetastoreHook()
     | ^^^^^^^^^^^^^^^^^ AIR303
-191 | HiveOperator()
-192 | HivePartitionSensor()
+230 | HiveOperator()
+231 | HivePartitionSensor()
     |
     = help: Install `apache-airflow-provider-apache-hive>=1.0.0` and use `airflow.providers.apache.hive.hooks.hive.HiveMetastoreHook` instead.
 
-AIR303.py:191:1: AIR303 `airflow.operators.hive_operator.HiveOperator` is moved into `apache-hive` provider in Airflow 3.0;
+AIR303.py:230:1: AIR303 `airflow.operators.hive_operator.HiveOperator` is moved into `apache-hive` provider in Airflow 3.0;
     |
-189 | HiveCliHook()
-190 | HiveMetastoreHook()
-191 | HiveOperator()
+228 | HiveCliHook()
+229 | HiveMetastoreHook()
+230 | HiveOperator()
     | ^^^^^^^^^^^^ AIR303
-192 | HivePartitionSensor()
-193 | HiveServer2Hook()
+231 | HivePartitionSensor()
+232 | HiveServer2Hook()
     |
     = help: Install `apache-airflow-provider-apache-hive>=1.0.0` and use `airflow.providers.apache.hive.operators.hive.HiveOperator` instead.
 
-AIR303.py:192:1: AIR303 `airflow.sensors.hive_partition_sensor.HivePartitionSensor` is moved into `apache-hive` provider in Airflow 3.0;
+AIR303.py:231:1: AIR303 `airflow.sensors.hive_partition_sensor.HivePartitionSensor` is moved into `apache-hive` provider in Airflow 3.0;
     |
-190 | HiveMetastoreHook()
-191 | HiveOperator()
-192 | HivePartitionSensor()
+229 | HiveMetastoreHook()
+230 | HiveOperator()
+231 | HivePartitionSensor()
     | ^^^^^^^^^^^^^^^^^^^ AIR303
-193 | HiveServer2Hook()
-194 | HiveStatsCollectionOperator()
+232 | HiveServer2Hook()
+233 | HiveStatsCollectionOperator()
     |
     = help: Install `apache-airflow-provider-apache-hive>=1.0.0` and use `airflow.providers.apache.hive.sensors.hive_partition.HivePartitionSensor` instead.
 
-AIR303.py:193:1: AIR303 `airflow.hooks.hive_hooks.HiveServer2Hook` is moved into `apache-hive` provider in Airflow 3.0;
+AIR303.py:232:1: AIR303 `airflow.hooks.hive_hooks.HiveServer2Hook` is moved into `apache-hive` provider in Airflow 3.0;
     |
-191 | HiveOperator()
-192 | HivePartitionSensor()
-193 | HiveServer2Hook()
+230 | HiveOperator()
+231 | HivePartitionSensor()
+232 | HiveServer2Hook()
     | ^^^^^^^^^^^^^^^ AIR303
-194 | HiveStatsCollectionOperator()
-195 | HiveToDruidOperator()
+233 | HiveStatsCollectionOperator()
+234 | HiveToDruidOperator()
     |
     = help: Install `apache-airflow-provider-apache-hive>=1.0.0` and use `airflow.providers.apache.hive.hooks.hive.HiveServer2Hook` instead.
 
-AIR303.py:194:1: AIR303 `airflow.operators.hive_stats_operator.HiveStatsCollectionOperator` is moved into `apache-hive` provider in Airflow 3.0;
+AIR303.py:233:1: AIR303 `airflow.operators.hive_stats_operator.HiveStatsCollectionOperator` is moved into `apache-hive` provider in Airflow 3.0;
     |
-192 | HivePartitionSensor()
-193 | HiveServer2Hook()
-194 | HiveStatsCollectionOperator()
+231 | HivePartitionSensor()
+232 | HiveServer2Hook()
+233 | HiveStatsCollectionOperator()
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR303
-195 | HiveToDruidOperator()
-196 | HiveToDruidTransfer()
+234 | HiveToDruidOperator()
+235 | HiveToDruidTransfer()
     |
     = help: Install `apache-airflow-provider-apache-hive>=1.0.0` and use `airflow.providers.apache.hive.operators.hive_stats.HiveStatsCollectionOperator` instead.
 
-AIR303.py:195:1: AIR303 `airflow.operators.hive_to_druid.HiveToDruidOperator` is moved into `apache-druid` provider in Airflow 3.0;
+AIR303.py:234:1: AIR303 `airflow.operators.hive_to_druid.HiveToDruidOperator` is moved into `apache-druid` provider in Airflow 3.0;
     |
-193 | HiveServer2Hook()
-194 | HiveStatsCollectionOperator()
-195 | HiveToDruidOperator()
+232 | HiveServer2Hook()
+233 | HiveStatsCollectionOperator()
+234 | HiveToDruidOperator()
     | ^^^^^^^^^^^^^^^^^^^ AIR303
-196 | HiveToDruidTransfer()
-197 | HiveToSambaOperator()
+235 | HiveToDruidTransfer()
+236 | HiveToSambaOperator()
     |
     = help: Install `apache-airflow-provider-apache-druid>=1.0.0` and use `airflow.providers.apache.druid.transfers.hive_to_druid.HiveToDruidOperator` instead.
 
-AIR303.py:196:1: AIR303 `airflow.operators.hive_to_druid.HiveToDruidTransfer` is moved into `apache-druid` provider in Airflow 3.0;
+AIR303.py:235:1: AIR303 `airflow.operators.hive_to_druid.HiveToDruidTransfer` is moved into `apache-druid` provider in Airflow 3.0;
     |
-194 | HiveStatsCollectionOperator()
-195 | HiveToDruidOperator()
-196 | HiveToDruidTransfer()
+233 | HiveStatsCollectionOperator()
+234 | HiveToDruidOperator()
+235 | HiveToDruidTransfer()
     | ^^^^^^^^^^^^^^^^^^^ AIR303
-197 | HiveToSambaOperator()
-198 | S3ToHiveOperator()
+236 | HiveToSambaOperator()
+237 | S3ToHiveOperator()
     |
     = help: Install `apache-airflow-provider-apache-druid>=1.0.0` and use `airflow.providers.apache.druid.transfers.hive_to_druid.HiveToDruidOperator` instead.
 
-AIR303.py:197:1: AIR303 `airflow.operators.hive_to_samba_operator.HiveToSambaOperator` is moved into `apache-hive` provider in Airflow 3.0;
+AIR303.py:236:1: AIR303 `airflow.operators.hive_to_samba_operator.HiveToSambaOperator` is moved into `apache-hive` provider in Airflow 3.0;
     |
-195 | HiveToDruidOperator()
-196 | HiveToDruidTransfer()
-197 | HiveToSambaOperator()
+234 | HiveToDruidOperator()
+235 | HiveToDruidTransfer()
+236 | HiveToSambaOperator()
     | ^^^^^^^^^^^^^^^^^^^ AIR303
-198 | S3ToHiveOperator()
-199 | S3ToHiveTransfer()
+237 | S3ToHiveOperator()
+238 | S3ToHiveTransfer()
     |
     = help: Install `apache-airflow-provider-apache-hive>=1.0.0` and use `HiveToSambaOperator` instead.
 
-AIR303.py:198:1: AIR303 `airflow.operators.s3_to_hive_operator.S3ToHiveOperator` is moved into `apache-hive` provider in Airflow 3.0;
+AIR303.py:237:1: AIR303 `airflow.operators.s3_to_hive_operator.S3ToHiveOperator` is moved into `apache-hive` provider in Airflow 3.0;
     |
-196 | HiveToDruidTransfer()
-197 | HiveToSambaOperator()
-198 | S3ToHiveOperator()
+235 | HiveToDruidTransfer()
+236 | HiveToSambaOperator()
+237 | S3ToHiveOperator()
     | ^^^^^^^^^^^^^^^^ AIR303
-199 | S3ToHiveTransfer()
-200 | MetastorePartitionSensor()
+238 | S3ToHiveTransfer()
+239 | MetastorePartitionSensor()
     |
     = help: Install `apache-airflow-provider-apache-hive>=1.0.0` and use `airflow.providers.apache.hive.transfers.s3_to_hive.S3ToHiveOperator` instead.
 
-AIR303.py:199:1: AIR303 `airflow.operators.s3_to_hive_operator.S3ToHiveTransfer` is moved into `apache-hive` provider in Airflow 3.0;
+AIR303.py:238:1: AIR303 `airflow.operators.s3_to_hive_operator.S3ToHiveTransfer` is moved into `apache-hive` provider in Airflow 3.0;
     |
-197 | HiveToSambaOperator()
-198 | S3ToHiveOperator()
-199 | S3ToHiveTransfer()
+236 | HiveToSambaOperator()
+237 | S3ToHiveOperator()
+238 | S3ToHiveTransfer()
     | ^^^^^^^^^^^^^^^^ AIR303
-200 | MetastorePartitionSensor()
-201 | NamedHivePartitionSensor()
+239 | MetastorePartitionSensor()
+240 | NamedHivePartitionSensor()
     |
     = help: Install `apache-airflow-provider-apache-hive>=1.0.0` and use `airflow.providers.apache.hive.transfers.s3_to_hive.S3ToHiveOperator` instead.
 
-AIR303.py:200:1: AIR303 `airflow.sensors.metastore_partition_sensor.MetastorePartitionSensor` is moved into `apache-hive` provider in Airflow 3.0;
+AIR303.py:239:1: AIR303 `airflow.sensors.metastore_partition_sensor.MetastorePartitionSensor` is moved into `apache-hive` provider in Airflow 3.0;
     |
-198 | S3ToHiveOperator()
-199 | S3ToHiveTransfer()
-200 | MetastorePartitionSensor()
+237 | S3ToHiveOperator()
+238 | S3ToHiveTransfer()
+239 | MetastorePartitionSensor()
     | ^^^^^^^^^^^^^^^^^^^^^^^^ AIR303
-201 | NamedHivePartitionSensor()
+240 | NamedHivePartitionSensor()
     |
     = help: Install `apache-airflow-provider-apache-hive>=1.0.0` and use `airflow.providers.apache.hive.sensors.metastore_partition.MetastorePartitionSensor` instead.
 
-AIR303.py:201:1: AIR303 `airflow.sensors.named_hive_partition_sensor.NamedHivePartitionSensor` is moved into `apache-hive` provider in Airflow 3.0;
+AIR303.py:240:1: AIR303 `airflow.sensors.named_hive_partition_sensor.NamedHivePartitionSensor` is moved into `apache-hive` provider in Airflow 3.0;
     |
-199 | S3ToHiveTransfer()
-200 | MetastorePartitionSensor()
-201 | NamedHivePartitionSensor()
+238 | S3ToHiveTransfer()
+239 | MetastorePartitionSensor()
+240 | NamedHivePartitionSensor()
     | ^^^^^^^^^^^^^^^^^^^^^^^^ AIR303
-202 | 
-203 | # apache-airflow-providers-http
+241 | 
+242 | # apache-airflow-providers-http
     |
     = help: Install `apache-airflow-provider-apache-hive>=1.0.0` and use `airflow.providers.apache.hive.sensors.named_hive_partition.NamedHivePartitionSensor` instead.
 
-AIR303.py:204:1: AIR303 `airflow.hooks.http_hook.HttpHook` is moved into `http` provider in Airflow 3.0;
+AIR303.py:243:1: AIR303 `airflow.hooks.http_hook.HttpHook` is moved into `http` provider in Airflow 3.0;
     |
-203 | # apache-airflow-providers-http
-204 | HttpHook()
+242 | # apache-airflow-providers-http
+243 | HttpHook()
     | ^^^^^^^^ AIR303
-205 | HttpSensor()
-206 | SimpleHttpOperator()
+244 | HttpSensor()
+245 | SimpleHttpOperator()
     |
     = help: Install `apache-airflow-provider-http>=1.0.0` and use `airflow.providers.http.hooks.http.HttpHook` instead.
 
-AIR303.py:205:1: AIR303 `airflow.sensors.http_sensor.HttpSensor` is moved into `http` provider in Airflow 3.0;
+AIR303.py:244:1: AIR303 `airflow.sensors.http_sensor.HttpSensor` is moved into `http` provider in Airflow 3.0;
     |
-203 | # apache-airflow-providers-http
-204 | HttpHook()
-205 | HttpSensor()
+242 | # apache-airflow-providers-http
+243 | HttpHook()
+244 | HttpSensor()
     | ^^^^^^^^^^ AIR303
-206 | SimpleHttpOperator()
+245 | SimpleHttpOperator()
     |
     = help: Install `apache-airflow-provider-http>=1.0.0` and use `airflow.providers.http.sensors.http.HttpSensor` instead.
 
-AIR303.py:206:1: AIR303 `airflow.operators.http_operator.SimpleHttpOperator` is moved into `http` provider in Airflow 3.0;
+AIR303.py:245:1: AIR303 `airflow.operators.http_operator.SimpleHttpOperator` is moved into `http` provider in Airflow 3.0;
     |
-204 | HttpHook()
-205 | HttpSensor()
-206 | SimpleHttpOperator()
+243 | HttpHook()
+244 | HttpSensor()
+245 | SimpleHttpOperator()
     | ^^^^^^^^^^^^^^^^^^ AIR303
-207 | 
-208 | # apache-airflow-providers-jdbc
+246 | 
+247 | # apache-airflow-providers-jdbc
     |
     = help: Install `apache-airflow-provider-http>=1.0.0` and use `airflow.providers.http.operators.http.SimpleHttpOperator` instead.
 
-AIR303.py:209:1: AIR303 `airflow.hooks.jdbc_hook.jaydebeapi` is moved into `jdbc` provider in Airflow 3.0;
+AIR303.py:248:1: AIR303 `airflow.hooks.jdbc_hook.jaydebeapi` is moved into `jdbc` provider in Airflow 3.0;
     |
-208 | # apache-airflow-providers-jdbc
-209 | jaydebeapi
+247 | # apache-airflow-providers-jdbc
+248 | jaydebeapi
     | ^^^^^^^^^^ AIR303
-210 | JdbcHook()
-211 | JdbcOperator()
+249 | JdbcHook()
+250 | JdbcOperator()
     |
     = help: Install `apache-airflow-provider-jdbc>=1.0.0` and use `airflow.providers.jdbc.hooks.jdbc.jaydebeapi` instead.
 
-AIR303.py:210:1: AIR303 `airflow.hooks.jdbc_hook.JdbcHook` is moved into `jdbc` provider in Airflow 3.0;
+AIR303.py:249:1: AIR303 `airflow.hooks.jdbc_hook.JdbcHook` is moved into `jdbc` provider in Airflow 3.0;
     |
-208 | # apache-airflow-providers-jdbc
-209 | jaydebeapi
-210 | JdbcHook()
+247 | # apache-airflow-providers-jdbc
+248 | jaydebeapi
+249 | JdbcHook()
     | ^^^^^^^^ AIR303
-211 | JdbcOperator()
+250 | JdbcOperator()
     |
     = help: Install `apache-airflow-provider-jdbc>=1.0.0` and use `airflow.providers.jdbc.hooks.jdbc.JdbcHook` instead.
 
-AIR303.py:211:1: AIR303 `airflow.operators.jdbc_operator.JdbcOperator` is moved into `jdbc` provider in Airflow 3.0;
+AIR303.py:250:1: AIR303 `airflow.operators.jdbc_operator.JdbcOperator` is moved into `jdbc` provider in Airflow 3.0;
     |
-209 | jaydebeapi
-210 | JdbcHook()
-211 | JdbcOperator()
+248 | jaydebeapi
+249 | JdbcHook()
+250 | JdbcOperator()
     | ^^^^^^^^^^^^ AIR303
-212 | 
-213 | # apache-airflow-providers-fab
+251 | 
+252 | # apache-airflow-providers-fab
     |
     = help: Install `apache-airflow-provider-jdbc>=1.0.0` and use `airflow.providers.jdbc.operators.jdbc.JdbcOperator` instead.
 
-AIR303.py:214:1: AIR303 Import path `airflow.api.auth.backend.basic_auth` is moved into `fab` provider in Airflow 3.0;
+AIR303.py:253:1: AIR303 Import path `airflow.api.auth.backend.basic_auth` is moved into `fab` provider in Airflow 3.0;
     |
-213 | # apache-airflow-providers-fab
-214 | basic_auth, kerberos_auth
+252 | # apache-airflow-providers-fab
+253 | basic_auth, kerberos_auth
     | ^^^^^^^^^^ AIR303
-215 | auth_current_user
-216 | backend_kerberos_auth
+254 | auth_current_user
+255 | backend_kerberos_auth
     |
     = help: Install `apache-airflow-provider-fab>=1.0.0` and import from `airflow.providers.fab.auth_manager.api.auth.backend.basic_auth` instead.
 
-AIR303.py:214:13: AIR303 Import path `airflow.api.auth.backend.kerberos_auth` is moved into `fab` provider in Airflow 3.0;
+AIR303.py:253:13: AIR303 Import path `airflow.api.auth.backend.kerberos_auth` is moved into `fab` provider in Airflow 3.0;
     |
-213 | # apache-airflow-providers-fab
-214 | basic_auth, kerberos_auth
+252 | # apache-airflow-providers-fab
+253 | basic_auth, kerberos_auth
     |             ^^^^^^^^^^^^^ AIR303
-215 | auth_current_user
-216 | backend_kerberos_auth
+254 | auth_current_user
+255 | backend_kerberos_auth
     |
     = help: Install `apache-airflow-provider-fab>=1.0.0` and import from `airflow.providers.fab.auth_manager.api.auth.backend.kerberos_auth` instead.
 
-AIR303.py:215:1: AIR303 Import path `airflow.api.auth.backend.basic_auth` is moved into `fab` provider in Airflow 3.0;
+AIR303.py:254:1: AIR303 Import path `airflow.api.auth.backend.basic_auth` is moved into `fab` provider in Airflow 3.0;
     |
-213 | # apache-airflow-providers-fab
-214 | basic_auth, kerberos_auth
-215 | auth_current_user
+252 | # apache-airflow-providers-fab
+253 | basic_auth, kerberos_auth
+254 | auth_current_user
     | ^^^^^^^^^^^^^^^^^ AIR303
-216 | backend_kerberos_auth
-217 | fab_override
+255 | backend_kerberos_auth
+256 | fab_override
     |
     = help: Install `apache-airflow-provider-fab>=1.0.0` and import from `airflow.providers.fab.auth_manager.api.auth.backend.basic_auth` instead.
 
-AIR303.py:216:1: AIR303 Import path `airflow.auth_manager.api.auth.backend.kerberos_auth` is moved into `fab` provider in Airflow 3.0;
+AIR303.py:255:1: AIR303 Import path `airflow.auth_manager.api.auth.backend.kerberos_auth` is moved into `fab` provider in Airflow 3.0;
     |
-214 | basic_auth, kerberos_auth
-215 | auth_current_user
-216 | backend_kerberos_auth
+253 | basic_auth, kerberos_auth
+254 | auth_current_user
+255 | backend_kerberos_auth
     | ^^^^^^^^^^^^^^^^^^^^^ AIR303
-217 | fab_override
-218 | FabAuthManager()
+256 | fab_override
+257 | FabAuthManager()
     |
     = help: Install `apache-airflow-provider-fab>=1.0.0` and import from `airflow.providers.fab.auth_manager.api.auth.backend.kerberos_auth` instead.
 
-AIR303.py:217:1: AIR303 Import path `airflow.auth.managers.fab.security_managr.override` is moved into `fab` provider in Airflow 3.0;
+AIR303.py:256:1: AIR303 Import path `airflow.auth.managers.fab.security_managr.override` is moved into `fab` provider in Airflow 3.0;
     |
-215 | auth_current_user
-216 | backend_kerberos_auth
-217 | fab_override
+254 | auth_current_user
+255 | backend_kerberos_auth
+256 | fab_override
     | ^^^^^^^^^^^^ AIR303
-218 | FabAuthManager()
-219 | FabAirflowSecurityManagerOverride()
+257 | FabAuthManager()
+258 | FabAirflowSecurityManagerOverride()
     |
     = help: Install `apache-airflow-provider-fab>=1.0.0` and import from `airflow.providers.fab.auth_manager.security_manager.override` instead.
 
-AIR303.py:218:1: AIR303 `airflow.auth.managers.fab.fab_auth_manager.FabAuthManager` is moved into `fab` provider in Airflow 3.0;
+AIR303.py:257:1: AIR303 `airflow.auth.managers.fab.fab_auth_manager.FabAuthManager` is moved into `fab` provider in Airflow 3.0;
     |
-216 | backend_kerberos_auth
-217 | fab_override
-218 | FabAuthManager()
+255 | backend_kerberos_auth
+256 | fab_override
+257 | FabAuthManager()
     | ^^^^^^^^^^^^^^ AIR303
-219 | FabAirflowSecurityManagerOverride()
+258 | FabAirflowSecurityManagerOverride()
     |
     = help: Install `apache-airflow-provider-fab>=1.0.0` and use `airflow.providers.fab.auth_manager.security_manager.FabAuthManager` instead.
 
-AIR303.py:219:1: AIR303 `airflow.www.security.FabAirflowSecurityManagerOverride` is moved into `fab` provider in Airflow 3.0;
+AIR303.py:258:1: AIR303 `airflow.www.security.FabAirflowSecurityManagerOverride` is moved into `fab` provider in Airflow 3.0;
     |
-217 | fab_override
-218 | FabAuthManager()
-219 | FabAirflowSecurityManagerOverride()
+256 | fab_override
+257 | FabAuthManager()
+258 | FabAirflowSecurityManagerOverride()
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR303
-220 | 
-221 | # apache-airflow-providers-cncf-kubernetes
+259 | 
+260 | # apache-airflow-providers-cncf-kubernetes
     |
     = help: Install `apache-airflow-provider-fab>=1.0.0` and use `airflow.providers.fab.auth_manager.security_manager.override.FabAirflowSecurityManagerOverride` instead.
 
-AIR303.py:222:1: AIR303 Import path `airflow.executors.kubernetes_executor_types.ALL_NAMESPACES` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR303.py:261:1: AIR303 Import path `airflow.executors.kubernetes_executor_types.ALL_NAMESPACES` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-221 | # apache-airflow-providers-cncf-kubernetes
-222 | ALL_NAMESPACES
+260 | # apache-airflow-providers-cncf-kubernetes
+261 | ALL_NAMESPACES
     | ^^^^^^^^^^^^^^ AIR303
-223 | POD_EXECUTOR_DONE_KEY
+262 | POD_EXECUTOR_DONE_KEY
+263 | _disable_verify_ssl()
     |
     = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and import from `airflow.providers.cncf.kubernetes.executors.kubernetes_executor_types.ALL_NAMESPACES` instead.
 
-AIR303.py:223:1: AIR303 Import path `airflow.executors.kubernetes_executor_types.POD_EXECUTOR_DONE_KEY` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR303.py:262:1: AIR303 Import path `airflow.executors.kubernetes_executor_types.POD_EXECUTOR_DONE_KEY` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-221 | # apache-airflow-providers-cncf-kubernetes
-222 | ALL_NAMESPACES
-223 | POD_EXECUTOR_DONE_KEY
+260 | # apache-airflow-providers-cncf-kubernetes
+261 | ALL_NAMESPACES
+262 | POD_EXECUTOR_DONE_KEY
     | ^^^^^^^^^^^^^^^^^^^^^ AIR303
-224 | 
-225 | # apache-airflow-providers-microsoft-mssql
+263 | _disable_verify_ssl()
+264 | _enable_tcp_keepalive()
     |
     = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and import from `airflow.providers.cncf.kubernetes.executors.kubernetes_executor_types.POD_EXECUTOR_DONE_KEY` instead.
 
-AIR303.py:226:1: AIR303 `airflow.hooks.mssql_hook.MsSqlHook` is moved into `microsoft-mssql` provider in Airflow 3.0;
+AIR303.py:263:1: AIR303 `airflow.kubernetes.kube_client._disable_verify_ssl` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-225 | # apache-airflow-providers-microsoft-mssql
-226 | MsSqlHook()
+261 | ALL_NAMESPACES
+262 | POD_EXECUTOR_DONE_KEY
+263 | _disable_verify_ssl()
+    | ^^^^^^^^^^^^^^^^^^^ AIR303
+264 | _enable_tcp_keepalive()
+265 | append_to_pod()
+    |
+    = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.kubernetes.airflow.providers.cncf.kubernetes.kube_client._disable_verify_ssl` instead.
+
+AIR303.py:264:1: AIR303 `airflow.kubernetes.kube_client._enable_tcp_keepalive` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+    |
+262 | POD_EXECUTOR_DONE_KEY
+263 | _disable_verify_ssl()
+264 | _enable_tcp_keepalive()
+    | ^^^^^^^^^^^^^^^^^^^^^ AIR303
+265 | append_to_pod()
+266 | annotations_for_logging_task_metadata()
+    |
+    = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.kubernetes.airflow.providers.cncf.kubernetes.kube_client._enable_tcp_keepalive` instead.
+
+AIR303.py:265:1: AIR303 `airflow.kubernetes.k8s_model.append_to_pod` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+    |
+263 | _disable_verify_ssl()
+264 | _enable_tcp_keepalive()
+265 | append_to_pod()
+    | ^^^^^^^^^^^^^ AIR303
+266 | annotations_for_logging_task_metadata()
+267 | annotations_to_key()
+    |
+    = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.providers.cncf.kubernetes.k8s_model.append_to_pod` instead.
+
+AIR303.py:266:1: AIR303 `airflow.kubernetes.kubernetes_helper_functions.annotations_for_logging_task_metadata` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+    |
+264 | _enable_tcp_keepalive()
+265 | append_to_pod()
+266 | annotations_for_logging_task_metadata()
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR303
+267 | annotations_to_key()
+268 | create_pod_id()
+    |
+    = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.providers.cncf.kubernetes.kubernetes_helper_functions.annotations_for_logging_task_metadata` instead.
+
+AIR303.py:267:1: AIR303 `airflow.kubernetes.kubernetes_helper_functions.annotations_to_key` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+    |
+265 | append_to_pod()
+266 | annotations_for_logging_task_metadata()
+267 | annotations_to_key()
+    | ^^^^^^^^^^^^^^^^^^ AIR303
+268 | create_pod_id()
+269 | datetime_to_label_safe_datestring()
+    |
+    = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.providers.cncf.kubernetes.kubernetes_helper_functions.annotations_to_key` instead.
+
+AIR303.py:268:1: AIR303 `airflow.kubernetes.kubernetes_helper_functions.create_pod_id` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+    |
+266 | annotations_for_logging_task_metadata()
+267 | annotations_to_key()
+268 | create_pod_id()
+    | ^^^^^^^^^^^^^ AIR303
+269 | datetime_to_label_safe_datestring()
+270 | extend_object_field()
+    |
+    = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.providers.cncf.kubernetes.kubernetes_helper_functions.create_pod_id` instead.
+
+AIR303.py:269:1: AIR303 `airflow.kubernetes.pod_generator.datetime_to_label_safe_datestring` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+    |
+267 | annotations_to_key()
+268 | create_pod_id()
+269 | datetime_to_label_safe_datestring()
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR303
+270 | extend_object_field()
+271 | get_logs_task_metadata()
+    |
+    = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.providers.cncf.kubernetes.pod_generator.datetime_to_label_safe_datestring` instead.
+
+AIR303.py:270:1: AIR303 `airflow.kubernetes.pod_generator.extend_object_field` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+    |
+268 | create_pod_id()
+269 | datetime_to_label_safe_datestring()
+270 | extend_object_field()
+    | ^^^^^^^^^^^^^^^^^^^ AIR303
+271 | get_logs_task_metadata()
+272 | label_safe_datestring_to_datetime()
+    |
+    = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.kubernetes.airflow.providers.cncf.kubernetes.pod_generator.extend_object_field` instead.
+
+AIR303.py:271:1: AIR303 `airflow.kubernetes.kubernetes_helper_functions.get_logs_task_metadata` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+    |
+269 | datetime_to_label_safe_datestring()
+270 | extend_object_field()
+271 | get_logs_task_metadata()
+    | ^^^^^^^^^^^^^^^^^^^^^^ AIR303
+272 | label_safe_datestring_to_datetime()
+273 | merge_objects()
+    |
+    = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.providers.cncf.kubernetes.kubernetes_helper_functions.get_logs_task_metadata` instead.
+
+AIR303.py:272:1: AIR303 `airflow.kubernetes.pod_generator.label_safe_datestring_to_datetime` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+    |
+270 | extend_object_field()
+271 | get_logs_task_metadata()
+272 | label_safe_datestring_to_datetime()
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR303
+273 | merge_objects()
+274 | Port()
+    |
+    = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.providers.cncf.kubernetes.pod_generator.label_safe_datestring_to_datetime` instead.
+
+AIR303.py:273:1: AIR303 `airflow.kubernetes.pod_generator.merge_objects` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+    |
+271 | get_logs_task_metadata()
+272 | label_safe_datestring_to_datetime()
+273 | merge_objects()
+    | ^^^^^^^^^^^^^ AIR303
+274 | Port()
+275 | Resources()
+    |
+    = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.providers.cncf.kubernetes.pod_generator.merge_objects` instead.
+
+AIR303.py:274:1: AIR303 `airflow.kubernetes.pod.Port` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+    |
+272 | label_safe_datestring_to_datetime()
+273 | merge_objects()
+274 | Port()
+    | ^^^^ AIR303
+275 | Resources()
+276 | PodRuntimeInfoEnv()
+    |
+    = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `kubernetes.client.models.V1ContainerPort` instead.
+
+AIR303.py:275:1: AIR303 `airflow.kubernetes.pod.Resources` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+    |
+273 | merge_objects()
+274 | Port()
+275 | Resources()
     | ^^^^^^^^^ AIR303
-227 | MsSqlOperator()
-228 | MsSqlToHiveOperator()
+276 | PodRuntimeInfoEnv()
+277 | PodGeneratorDeprecated()
+    |
+    = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `kubernetes.client.models.V1ResourceRequirements` instead.
+
+AIR303.py:276:1: AIR303 `airflow.kubernetes.pod_runtime_info_env.PodRuntimeInfoEnv` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+    |
+274 | Port()
+275 | Resources()
+276 | PodRuntimeInfoEnv()
+    | ^^^^^^^^^^^^^^^^^ AIR303
+277 | PodGeneratorDeprecated()
+278 | Volume()
+    |
+    = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `kubernetes.client.models.V1EnvVar` instead.
+
+AIR303.py:277:1: AIR303 `airflow.kubernetes.pod_generator.PodGeneratorDeprecated` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+    |
+275 | Resources()
+276 | PodRuntimeInfoEnv()
+277 | PodGeneratorDeprecated()
+    | ^^^^^^^^^^^^^^^^^^^^^^ AIR303
+278 | Volume()
+279 | VolumeMount()
+    |
+    = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.providers.cncf.kubernetes.pod_generator.PodGenerator` instead.
+
+AIR303.py:278:1: AIR303 `airflow.kubernetes.volume.Volume` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+    |
+276 | PodRuntimeInfoEnv()
+277 | PodGeneratorDeprecated()
+278 | Volume()
+    | ^^^^^^ AIR303
+279 | VolumeMount()
+280 | Secret()
+    |
+    = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `kubernetes.client.models.V1Volume` instead.
+
+AIR303.py:279:1: AIR303 `airflow.kubernetes.volume_mount.VolumeMount` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+    |
+277 | PodGeneratorDeprecated()
+278 | Volume()
+279 | VolumeMount()
+    | ^^^^^^^^^^^ AIR303
+280 | Secret()
+    |
+    = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `kubernetes.client.models.V1VolumeMount` instead.
+
+AIR303.py:280:1: AIR303 `airflow.kubernetes.secret.Secret` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+    |
+278 | Volume()
+279 | VolumeMount()
+280 | Secret()
+    | ^^^^^^ AIR303
+281 | 
+282 | add_pod_suffix()
+    |
+    = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.providers.cncf.kubernetes.secret.Secret` instead.
+
+AIR303.py:282:1: AIR303 `airflow.kubernetes.kubernetes_helper_functions.add_pod_suffix` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+    |
+280 | Secret()
+281 | 
+282 | add_pod_suffix()
+    | ^^^^^^^^^^^^^^ AIR303
+283 | add_pod_suffix2()
+284 | get_kube_client()
+    |
+    = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.providers.cncf.kubernetes.kubernetes_helper_functions.add_pod_suffix` instead.
+
+AIR303.py:283:1: AIR303 `airflow.kubernetes.pod_generator.add_pod_suffix` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+    |
+282 | add_pod_suffix()
+283 | add_pod_suffix2()
+    | ^^^^^^^^^^^^^^^ AIR303
+284 | get_kube_client()
+285 | get_kube_client2()
+    |
+    = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.providers.cncf.kubernetes.kubernetes_helper_functions.add_pod_suffix` instead.
+
+AIR303.py:284:1: AIR303 `airflow.kubernetes.kube_client.get_kube_client` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+    |
+282 | add_pod_suffix()
+283 | add_pod_suffix2()
+284 | get_kube_client()
+    | ^^^^^^^^^^^^^^^ AIR303
+285 | get_kube_client2()
+286 | make_safe_label_value()
+    |
+    = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.kubernetes.airflow.providers.cncf.kubernetes.kube_client.get_kube_client` instead.
+
+AIR303.py:285:1: AIR303 `airflow.kubernetes.pod_launcher_deprecated.get_kube_client` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+    |
+283 | add_pod_suffix2()
+284 | get_kube_client()
+285 | get_kube_client2()
+    | ^^^^^^^^^^^^^^^^ AIR303
+286 | make_safe_label_value()
+287 | make_safe_label_value2()
+    |
+    = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.providers.cncf.kubernetes.kube_client.get_kube_client` instead.
+
+AIR303.py:286:1: AIR303 `airflow.kubernetes.pod_generator.make_safe_label_value` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+    |
+284 | get_kube_client()
+285 | get_kube_client2()
+286 | make_safe_label_value()
+    | ^^^^^^^^^^^^^^^^^^^^^ AIR303
+287 | make_safe_label_value2()
+288 | rand_str()
+    |
+    = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.providers.cncf.kubernetes.pod_generator.make_safe_label_value` instead.
+
+AIR303.py:287:1: AIR303 `airflow.kubernetes.pod_generator_deprecated.make_safe_label_value` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+    |
+285 | get_kube_client2()
+286 | make_safe_label_value()
+287 | make_safe_label_value2()
+    | ^^^^^^^^^^^^^^^^^^^^^^ AIR303
+288 | rand_str()
+289 | rand_str2()
+    |
+    = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.providers.cncf.kubernetes.pod_generator_deprecated.make_safe_label_value` instead.
+
+AIR303.py:288:1: AIR303 `airflow.kubernetes.kubernetes_helper_functions.rand_str` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+    |
+286 | make_safe_label_value()
+287 | make_safe_label_value2()
+288 | rand_str()
+    | ^^^^^^^^ AIR303
+289 | rand_str2()
+290 | K8SModel()
+    |
+    = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.providers.cncf.kubernetes.kubernetes_helper_functions.rand_str` instead.
+
+AIR303.py:289:1: AIR303 `airflow.kubernetes.pod_generator.rand_str` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+    |
+287 | make_safe_label_value2()
+288 | rand_str()
+289 | rand_str2()
+    | ^^^^^^^^^ AIR303
+290 | K8SModel()
+291 | K8SModel2()
+    |
+    = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.providers.cncf.kubernetes.kubernetes_helper_functions.rand_str` instead.
+
+AIR303.py:290:1: AIR303 `airflow.kubernetes.k8s_model.K8SModel` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+    |
+288 | rand_str()
+289 | rand_str2()
+290 | K8SModel()
+    | ^^^^^^^^ AIR303
+291 | K8SModel2()
+292 | PodLauncher()
+    |
+    = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.providers.cncf.kubernetes.k8s_model.K8SModel` instead.
+
+AIR303.py:292:1: AIR303 `airflow.kubernetes.pod_launcher.PodLauncher` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+    |
+290 | K8SModel()
+291 | K8SModel2()
+292 | PodLauncher()
+    | ^^^^^^^^^^^ AIR303
+293 | PodLauncher2()
+294 | PodStatus()
+    |
+    = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.providers.cncf.kubernetes.pod_launcher.PodLauncher` instead.
+
+AIR303.py:293:1: AIR303 `airflow.kubernetes.pod_launcher_deprecated.PodLauncher` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+    |
+291 | K8SModel2()
+292 | PodLauncher()
+293 | PodLauncher2()
+    | ^^^^^^^^^^^^ AIR303
+294 | PodStatus()
+295 | PodStatus2()
+    |
+    = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.providers.cncf.kubernetes.pod_launcher_deprecated.PodLauncher` instead.
+
+AIR303.py:294:1: AIR303 `airflow.kubernetes.pod_launcher.PodStatus` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+    |
+292 | PodLauncher()
+293 | PodLauncher2()
+294 | PodStatus()
+    | ^^^^^^^^^ AIR303
+295 | PodStatus2()
+296 | PodDefaults()
+    |
+    = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.providers.cncf.kubernetes.pod_launcher.PodStatus` instead.
+
+AIR303.py:295:1: AIR303 `airflow.kubernetes.pod_launcher_deprecated.PodStatus` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+    |
+293 | PodLauncher2()
+294 | PodStatus()
+295 | PodStatus2()
+    | ^^^^^^^^^^ AIR303
+296 | PodDefaults()
+297 | PodDefaults2()
+    |
+    = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.providers.cncf.kubernetes.pod_launcher_deprecated.PodStatus` instead.
+
+AIR303.py:296:1: AIR303 `airflow.kubernetes.pod_generator.PodDefaults` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+    |
+294 | PodStatus()
+295 | PodStatus2()
+296 | PodDefaults()
+    | ^^^^^^^^^^^ AIR303
+297 | PodDefaults2()
+298 | PodDefaults3()
+    |
+    = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.providers.cncf.kubernetes.pod_generator_deprecated.PodDefaults` instead.
+
+AIR303.py:297:1: AIR303 `airflow.kubernetes.pod_launcher_deprecated.PodDefaults` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+    |
+295 | PodStatus2()
+296 | PodDefaults()
+297 | PodDefaults2()
+    | ^^^^^^^^^^^^ AIR303
+298 | PodDefaults3()
+299 | PodGenerator()
+    |
+    = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.providers.cncf.kubernetes.pod_generator_deprecated.PodDefaults` instead.
+
+AIR303.py:298:1: AIR303 `airflow.kubernetes.pod_generator_deprecated.PodDefaults` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+    |
+296 | PodDefaults()
+297 | PodDefaults2()
+298 | PodDefaults3()
+    | ^^^^^^^^^^^^ AIR303
+299 | PodGenerator()
+300 | PodGenerator2()
+    |
+    = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.providers.cncf.kubernetes.pod_generator_deprecated.PodDefaults` instead.
+
+AIR303.py:299:1: AIR303 `airflow.kubernetes.pod_generator.PodGenerator` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+    |
+297 | PodDefaults2()
+298 | PodDefaults3()
+299 | PodGenerator()
+    | ^^^^^^^^^^^^ AIR303
+300 | PodGenerator2()
+    |
+    = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.providers.cncf.kubernetes.pod_generator.PodGenerator` instead.
+
+AIR303.py:300:1: AIR303 `airflow.kubernetes.pod_generator_deprecated.PodGenerator` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+    |
+298 | PodDefaults3()
+299 | PodGenerator()
+300 | PodGenerator2()
+    | ^^^^^^^^^^^^^ AIR303
+    |
+    = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.providers.cncf.kubernetes.pod_generator_deprecated.PodGenerator` instead.
+
+AIR303.py:304:1: AIR303 `airflow.hooks.mssql_hook.MsSqlHook` is moved into `microsoft-mssql` provider in Airflow 3.0;
+    |
+303 | # apache-airflow-providers-microsoft-mssql
+304 | MsSqlHook()
+    | ^^^^^^^^^ AIR303
+305 | MsSqlOperator()
+306 | MsSqlToHiveOperator()
     |
     = help: Install `apache-airflow-provider-microsoft-mssql>=1.0.0` and use `airflow.providers.microsoft.mssql.hooks.mssql.MsSqlHook` instead.
 
-AIR303.py:227:1: AIR303 `airflow.operators.mssql_operator.MsSqlOperator` is moved into `microsoft-mssql` provider in Airflow 3.0;
+AIR303.py:305:1: AIR303 `airflow.operators.mssql_operator.MsSqlOperator` is moved into `microsoft-mssql` provider in Airflow 3.0;
     |
-225 | # apache-airflow-providers-microsoft-mssql
-226 | MsSqlHook()
-227 | MsSqlOperator()
+303 | # apache-airflow-providers-microsoft-mssql
+304 | MsSqlHook()
+305 | MsSqlOperator()
     | ^^^^^^^^^^^^^ AIR303
-228 | MsSqlToHiveOperator()
-229 | MsSqlToHiveTransfer()
+306 | MsSqlToHiveOperator()
+307 | MsSqlToHiveTransfer()
     |
     = help: Install `apache-airflow-provider-microsoft-mssql>=1.0.0` and use `airflow.providers.microsoft.mssql.operators.mssql.MsSqlOperator` instead.
 
-AIR303.py:228:1: AIR303 `airflow.operators.mssql_to_hive.MsSqlToHiveOperator` is moved into `apache-hive` provider in Airflow 3.0;
+AIR303.py:306:1: AIR303 `airflow.operators.mssql_to_hive.MsSqlToHiveOperator` is moved into `apache-hive` provider in Airflow 3.0;
     |
-226 | MsSqlHook()
-227 | MsSqlOperator()
-228 | MsSqlToHiveOperator()
+304 | MsSqlHook()
+305 | MsSqlOperator()
+306 | MsSqlToHiveOperator()
     | ^^^^^^^^^^^^^^^^^^^ AIR303
-229 | MsSqlToHiveTransfer()
+307 | MsSqlToHiveTransfer()
     |
     = help: Install `apache-airflow-provider-apache-hive>=1.0.0` and use `airflow.providers.apache.hive.transfers.mssql_to_hive.MsSqlToHiveOperator` instead.
 
-AIR303.py:229:1: AIR303 `airflow.operators.mssql_to_hive.MsSqlToHiveTransfer` is moved into `apache-hive` provider in Airflow 3.0;
+AIR303.py:307:1: AIR303 `airflow.operators.mssql_to_hive.MsSqlToHiveTransfer` is moved into `apache-hive` provider in Airflow 3.0;
     |
-227 | MsSqlOperator()
-228 | MsSqlToHiveOperator()
-229 | MsSqlToHiveTransfer()
+305 | MsSqlOperator()
+306 | MsSqlToHiveOperator()
+307 | MsSqlToHiveTransfer()
     | ^^^^^^^^^^^^^^^^^^^ AIR303
-230 | 
-231 | # apache-airflow-providers-mysql
+308 | 
+309 | # apache-airflow-providers-mysql
     |
     = help: Install `apache-airflow-provider-apache-hive>=1.0.0` and use `airflow.providers.apache.hive.transfers.mssql_to_hive.MsSqlToHiveOperator` instead.
 
-AIR303.py:232:1: AIR303 `airflow.operators.hive_to_mysql.HiveToMySqlOperator` is moved into `apache-hive` provider in Airflow 3.0;
+AIR303.py:310:1: AIR303 `airflow.operators.hive_to_mysql.HiveToMySqlOperator` is moved into `apache-hive` provider in Airflow 3.0;
     |
-231 | # apache-airflow-providers-mysql
-232 | HiveToMySqlOperator()
+309 | # apache-airflow-providers-mysql
+310 | HiveToMySqlOperator()
     | ^^^^^^^^^^^^^^^^^^^ AIR303
-233 | HiveToMySqlTransfer()
-234 | MySqlHook()
+311 | HiveToMySqlTransfer()
+312 | MySqlHook()
     |
     = help: Install `apache-airflow-provider-apache-hive>=1.0.0` and use `airflow.providers.apache.hive.transfers.hive_to_mysql.HiveToMySqlOperator` instead.
 
-AIR303.py:233:1: AIR303 `airflow.operators.hive_to_mysql.HiveToMySqlTransfer` is moved into `apache-hive` provider in Airflow 3.0;
+AIR303.py:311:1: AIR303 `airflow.operators.hive_to_mysql.HiveToMySqlTransfer` is moved into `apache-hive` provider in Airflow 3.0;
     |
-231 | # apache-airflow-providers-mysql
-232 | HiveToMySqlOperator()
-233 | HiveToMySqlTransfer()
+309 | # apache-airflow-providers-mysql
+310 | HiveToMySqlOperator()
+311 | HiveToMySqlTransfer()
     | ^^^^^^^^^^^^^^^^^^^ AIR303
-234 | MySqlHook()
-235 | MySqlOperator()
+312 | MySqlHook()
+313 | MySqlOperator()
     |
     = help: Install `apache-airflow-provider-apache-hive>=1.0.0` and use `airflow.providers.apache.hive.transfers.hive_to_mysql.HiveToMySqlOperator` instead.
 
-AIR303.py:234:1: AIR303 `airflow.hooks.mysql_hook.MySqlHook` is moved into `mysql` provider in Airflow 3.0;
+AIR303.py:312:1: AIR303 `airflow.hooks.mysql_hook.MySqlHook` is moved into `mysql` provider in Airflow 3.0;
     |
-232 | HiveToMySqlOperator()
-233 | HiveToMySqlTransfer()
-234 | MySqlHook()
+310 | HiveToMySqlOperator()
+311 | HiveToMySqlTransfer()
+312 | MySqlHook()
     | ^^^^^^^^^ AIR303
-235 | MySqlOperator()
-236 | MySqlToHiveOperator()
+313 | MySqlOperator()
+314 | MySqlToHiveOperator()
     |
     = help: Install `apache-airflow-provider-mysql>=1.0.0` and use `airflow.providers.mysql.hooks.mysql.MySqlHook` instead.
 
-AIR303.py:235:1: AIR303 `airflow.operators.mysql_operator.MySqlOperator` is moved into `mysql` provider in Airflow 3.0;
+AIR303.py:313:1: AIR303 `airflow.operators.mysql_operator.MySqlOperator` is moved into `mysql` provider in Airflow 3.0;
     |
-233 | HiveToMySqlTransfer()
-234 | MySqlHook()
-235 | MySqlOperator()
+311 | HiveToMySqlTransfer()
+312 | MySqlHook()
+313 | MySqlOperator()
     | ^^^^^^^^^^^^^ AIR303
-236 | MySqlToHiveOperator()
-237 | MySqlToHiveTransfer()
+314 | MySqlToHiveOperator()
+315 | MySqlToHiveTransfer()
     |
     = help: Install `apache-airflow-provider-mysql>=1.0.0` and use `airflow.providers.mysql.operators.mysql.MySqlOperator` instead.
 
-AIR303.py:236:1: AIR303 `airflow.operators.mysql_to_hive.MySqlToHiveOperator` is moved into `apache-hive` provider in Airflow 3.0;
+AIR303.py:314:1: AIR303 `airflow.operators.mysql_to_hive.MySqlToHiveOperator` is moved into `apache-hive` provider in Airflow 3.0;
     |
-234 | MySqlHook()
-235 | MySqlOperator()
-236 | MySqlToHiveOperator()
+312 | MySqlHook()
+313 | MySqlOperator()
+314 | MySqlToHiveOperator()
     | ^^^^^^^^^^^^^^^^^^^ AIR303
-237 | MySqlToHiveTransfer()
-238 | PrestoToMySqlOperator()
+315 | MySqlToHiveTransfer()
+316 | PrestoToMySqlOperator()
     |
     = help: Install `apache-airflow-provider-apache-hive>=1.0.0` and use `airflow.providers.apache.hive.transfers.mysql_to_hive.MySqlToHiveOperator` instead.
 
-AIR303.py:237:1: AIR303 `airflow.operators.mysql_to_hive.MySqlToHiveTransfer` is moved into `apache-hive` provider in Airflow 3.0;
+AIR303.py:315:1: AIR303 `airflow.operators.mysql_to_hive.MySqlToHiveTransfer` is moved into `apache-hive` provider in Airflow 3.0;
     |
-235 | MySqlOperator()
-236 | MySqlToHiveOperator()
-237 | MySqlToHiveTransfer()
+313 | MySqlOperator()
+314 | MySqlToHiveOperator()
+315 | MySqlToHiveTransfer()
     | ^^^^^^^^^^^^^^^^^^^ AIR303
-238 | PrestoToMySqlOperator()
-239 | PrestoToMySqlTransfer()
+316 | PrestoToMySqlOperator()
+317 | PrestoToMySqlTransfer()
     |
     = help: Install `apache-airflow-provider-apache-hive>=1.0.0` and use `airflow.providers.apache.hive.transfers.mysql_to_hive.MySqlToHiveOperator` instead.
 
-AIR303.py:238:1: AIR303 `airflow.operators.presto_to_mysql.PrestoToMySqlOperator` is moved into `mysql` provider in Airflow 3.0;
+AIR303.py:316:1: AIR303 `airflow.operators.presto_to_mysql.PrestoToMySqlOperator` is moved into `mysql` provider in Airflow 3.0;
     |
-236 | MySqlToHiveOperator()
-237 | MySqlToHiveTransfer()
-238 | PrestoToMySqlOperator()
+314 | MySqlToHiveOperator()
+315 | MySqlToHiveTransfer()
+316 | PrestoToMySqlOperator()
     | ^^^^^^^^^^^^^^^^^^^^^ AIR303
-239 | PrestoToMySqlTransfer()
+317 | PrestoToMySqlTransfer()
     |
     = help: Install `apache-airflow-provider-mysql>=1.0.0` and use `airflow.providers.mysql.transfers.presto_to_mysql.PrestoToMySqlOperator` instead.
 
-AIR303.py:239:1: AIR303 `airflow.operators.presto_to_mysql.PrestoToMySqlTransfer` is moved into `mysql` provider in Airflow 3.0;
+AIR303.py:317:1: AIR303 `airflow.operators.presto_to_mysql.PrestoToMySqlTransfer` is moved into `mysql` provider in Airflow 3.0;
     |
-237 | MySqlToHiveTransfer()
-238 | PrestoToMySqlOperator()
-239 | PrestoToMySqlTransfer()
+315 | MySqlToHiveTransfer()
+316 | PrestoToMySqlOperator()
+317 | PrestoToMySqlTransfer()
     | ^^^^^^^^^^^^^^^^^^^^^ AIR303
-240 | 
-241 | # apache-airflow-providers-oracle
+318 | 
+319 | # apache-airflow-providers-oracle
     |
     = help: Install `apache-airflow-provider-mysql>=1.0.0` and use `airflow.providers.mysql.transfers.presto_to_mysql.PrestoToMySqlOperator` instead.
 
-AIR303.py:242:1: AIR303 `airflow.hooks.oracle_hook.OracleHook` is moved into `oracle` provider in Airflow 3.0;
+AIR303.py:320:1: AIR303 `airflow.hooks.oracle_hook.OracleHook` is moved into `oracle` provider in Airflow 3.0;
     |
-241 | # apache-airflow-providers-oracle
-242 | OracleHook()
+319 | # apache-airflow-providers-oracle
+320 | OracleHook()
     | ^^^^^^^^^^ AIR303
-243 | OracleOperator()
+321 | OracleOperator()
     |
     = help: Install `apache-airflow-provider-oracle>=1.0.0` and use `airflow.providers.oracle.hooks.oracle.OracleHook` instead.
 
-AIR303.py:243:1: AIR303 `airflow.operators.oracle_operator.OracleOperator` is moved into `oracle` provider in Airflow 3.0;
+AIR303.py:321:1: AIR303 `airflow.operators.oracle_operator.OracleOperator` is moved into `oracle` provider in Airflow 3.0;
     |
-241 | # apache-airflow-providers-oracle
-242 | OracleHook()
-243 | OracleOperator()
+319 | # apache-airflow-providers-oracle
+320 | OracleHook()
+321 | OracleOperator()
     | ^^^^^^^^^^^^^^ AIR303
-244 | 
-245 | # apache-airflow-providers-papermill
+322 | 
+323 | # apache-airflow-providers-papermill
     |
     = help: Install `apache-airflow-provider-oracle>=1.0.0` and use `airflow.providers.oracle.operators.oracle.OracleOperator` instead.
 
-AIR303.py:246:1: AIR303 `airflow.operators.papermill_operator.PapermillOperator` is moved into `papermill` provider in Airflow 3.0;
+AIR303.py:324:1: AIR303 `airflow.operators.papermill_operator.PapermillOperator` is moved into `papermill` provider in Airflow 3.0;
     |
-245 | # apache-airflow-providers-papermill
-246 | PapermillOperator()
+323 | # apache-airflow-providers-papermill
+324 | PapermillOperator()
     | ^^^^^^^^^^^^^^^^^ AIR303
-247 | 
-248 | # apache-airflow-providers-apache-pig
+325 | 
+326 | # apache-airflow-providers-apache-pig
     |
     = help: Install `apache-airflow-provider-papermill>=1.0.0` and use `airflow.providers.papermill.operators.papermill.PapermillOperator` instead.
 
-AIR303.py:249:1: AIR303 `airflow.hooks.pig_hook.PigCliHook` is moved into `apache-pig` provider in Airflow 3.0;
+AIR303.py:327:1: AIR303 `airflow.hooks.pig_hook.PigCliHook` is moved into `apache-pig` provider in Airflow 3.0;
     |
-248 | # apache-airflow-providers-apache-pig
-249 | PigCliHook()
+326 | # apache-airflow-providers-apache-pig
+327 | PigCliHook()
     | ^^^^^^^^^^ AIR303
-250 | PigOperator()
+328 | PigOperator()
     |
     = help: Install `apache-airflow-provider-apache-pig>=1.0.0` and use `airflow.providers.apache.pig.hooks.pig.PigCliHook` instead.
 
-AIR303.py:250:1: AIR303 `airflow.operators.pig_operator.PigOperator` is moved into `apache-pig` provider in Airflow 3.0;
+AIR303.py:328:1: AIR303 `airflow.operators.pig_operator.PigOperator` is moved into `apache-pig` provider in Airflow 3.0;
     |
-248 | # apache-airflow-providers-apache-pig
-249 | PigCliHook()
-250 | PigOperator()
+326 | # apache-airflow-providers-apache-pig
+327 | PigCliHook()
+328 | PigOperator()
     | ^^^^^^^^^^^ AIR303
-251 | 
-252 | # apache-airflow-providers-postgres
+329 | 
+330 | # apache-airflow-providers-postgres
     |
     = help: Install `apache-airflow-provider-apache-pig>=1.0.0` and use `airflow.providers.apache.pig.operators.pig.PigOperator` instead.
 
-AIR303.py:253:1: AIR303 `airflow.operators.postgres_operator.Mapping` is moved into `postgres` provider in Airflow 3.0;
+AIR303.py:331:1: AIR303 `airflow.operators.postgres_operator.Mapping` is moved into `postgres` provider in Airflow 3.0;
     |
-252 | # apache-airflow-providers-postgres
-253 | Mapping
+330 | # apache-airflow-providers-postgres
+331 | Mapping
     | ^^^^^^^ AIR303
-254 | PostgresHook()
-255 | PostgresOperator()
+332 | PostgresHook()
+333 | PostgresOperator()
     |
     = help: Install `apache-airflow-provider-postgres>=1.0.0` and use `airflow.providers.postgres.operators.postgres.Mapping` instead.
 
-AIR303.py:254:1: AIR303 `airflow.hooks.postgres_hook.PostgresHook` is moved into `postgres` provider in Airflow 3.0;
+AIR303.py:332:1: AIR303 `airflow.hooks.postgres_hook.PostgresHook` is moved into `postgres` provider in Airflow 3.0;
     |
-252 | # apache-airflow-providers-postgres
-253 | Mapping
-254 | PostgresHook()
+330 | # apache-airflow-providers-postgres
+331 | Mapping
+332 | PostgresHook()
     | ^^^^^^^^^^^^ AIR303
-255 | PostgresOperator()
+333 | PostgresOperator()
     |
     = help: Install `apache-airflow-provider-postgres>=1.0.0` and use `airflow.providers.postgres.hooks.postgres.PostgresHook` instead.
 
-AIR303.py:255:1: AIR303 `airflow.operators.postgres_operator.PostgresOperator` is moved into `postgres` provider in Airflow 3.0;
+AIR303.py:333:1: AIR303 `airflow.operators.postgres_operator.PostgresOperator` is moved into `postgres` provider in Airflow 3.0;
     |
-253 | Mapping
-254 | PostgresHook()
-255 | PostgresOperator()
+331 | Mapping
+332 | PostgresHook()
+333 | PostgresOperator()
     | ^^^^^^^^^^^^^^^^ AIR303
-256 | 
-257 | # apache-airflow-providers-presto
+334 | 
+335 | # apache-airflow-providers-presto
     |
     = help: Install `apache-airflow-provider-postgres>=1.0.0` and use `airflow.providers.postgres.operators.postgres.PostgresOperator` instead.
 
-AIR303.py:258:1: AIR303 `airflow.hooks.presto_hook.PrestoHook` is moved into `presto` provider in Airflow 3.0;
+AIR303.py:336:1: AIR303 `airflow.hooks.presto_hook.PrestoHook` is moved into `presto` provider in Airflow 3.0;
     |
-257 | # apache-airflow-providers-presto
-258 | PrestoHook()
+335 | # apache-airflow-providers-presto
+336 | PrestoHook()
     | ^^^^^^^^^^ AIR303
-259 | 
-260 | # apache-airflow-providers-samba
+337 | 
+338 | # apache-airflow-providers-samba
     |
     = help: Install `apache-airflow-provider-presto>=1.0.0` and use `airflow.providers.presto.hooks.presto.PrestoHook` instead.
 
-AIR303.py:261:1: AIR303 `airflow.hooks.samba_hook.SambaHook` is moved into `samba` provider in Airflow 3.0;
+AIR303.py:339:1: AIR303 `airflow.hooks.samba_hook.SambaHook` is moved into `samba` provider in Airflow 3.0;
     |
-260 | # apache-airflow-providers-samba
-261 | SambaHook()
+338 | # apache-airflow-providers-samba
+339 | SambaHook()
     | ^^^^^^^^^ AIR303
-262 | 
-263 | # apache-airflow-providers-slack
+340 | 
+341 | # apache-airflow-providers-slack
     |
     = help: Install `apache-airflow-provider-samba>=1.0.0` and use `airflow.providers.samba.hooks.samba.SambaHook` instead.
 
-AIR303.py:264:1: AIR303 `airflow.hooks.slack_hook.SlackHook` is moved into `slack` provider in Airflow 3.0;
+AIR303.py:342:1: AIR303 `airflow.hooks.slack_hook.SlackHook` is moved into `slack` provider in Airflow 3.0;
     |
-263 | # apache-airflow-providers-slack
-264 | SlackHook()
+341 | # apache-airflow-providers-slack
+342 | SlackHook()
     | ^^^^^^^^^ AIR303
-265 | SlackAPIOperator()
-266 | SlackAPIPostOperator()
+343 | SlackAPIOperator()
+344 | SlackAPIPostOperator()
     |
     = help: Install `apache-airflow-provider-slack>=1.0.0` and use `airflow.providers.slack.hooks.slack.SlackHook` instead.
 
-AIR303.py:265:1: AIR303 `airflow.operators.slack_operator.SlackAPIOperator` is moved into `slack` provider in Airflow 3.0;
+AIR303.py:343:1: AIR303 `airflow.operators.slack_operator.SlackAPIOperator` is moved into `slack` provider in Airflow 3.0;
     |
-263 | # apache-airflow-providers-slack
-264 | SlackHook()
-265 | SlackAPIOperator()
+341 | # apache-airflow-providers-slack
+342 | SlackHook()
+343 | SlackAPIOperator()
     | ^^^^^^^^^^^^^^^^ AIR303
-266 | SlackAPIPostOperator()
+344 | SlackAPIPostOperator()
     |
     = help: Install `apache-airflow-provider-slack>=1.0.0` and use `airflow.providers.slack.operators.slack.SlackAPIOperator` instead.
 
-AIR303.py:266:1: AIR303 `airflow.operators.slack_operator.SlackAPIPostOperator` is moved into `slack` provider in Airflow 3.0;
+AIR303.py:344:1: AIR303 `airflow.operators.slack_operator.SlackAPIPostOperator` is moved into `slack` provider in Airflow 3.0;
     |
-264 | SlackHook()
-265 | SlackAPIOperator()
-266 | SlackAPIPostOperator()
+342 | SlackHook()
+343 | SlackAPIOperator()
+344 | SlackAPIPostOperator()
     | ^^^^^^^^^^^^^^^^^^^^ AIR303
-267 | 
-268 | # apache-airflow-providers-sqlite
+345 | 
+346 | # apache-airflow-providers-sqlite
     |
     = help: Install `apache-airflow-provider-slack>=1.0.0` and use `airflow.providers.slack.operators.slack.SlackAPIPostOperator` instead.
 
-AIR303.py:269:1: AIR303 `airflow.hooks.sqlite_hook.SqliteHook` is moved into `sqlite` provider in Airflow 3.0;
+AIR303.py:347:1: AIR303 `airflow.hooks.sqlite_hook.SqliteHook` is moved into `sqlite` provider in Airflow 3.0;
     |
-268 | # apache-airflow-providers-sqlite
-269 | SqliteHook()
+346 | # apache-airflow-providers-sqlite
+347 | SqliteHook()
     | ^^^^^^^^^^ AIR303
-270 | SqliteOperator()
+348 | SqliteOperator()
     |
     = help: Install `apache-airflow-provider-sqlite>=1.0.0` and use `airflow.providers.sqlite.hooks.sqlite.SqliteHook` instead.
 
-AIR303.py:270:1: AIR303 `airflow.operators.sqlite_operator.SqliteOperator` is moved into `sqlite` provider in Airflow 3.0;
+AIR303.py:348:1: AIR303 `airflow.operators.sqlite_operator.SqliteOperator` is moved into `sqlite` provider in Airflow 3.0;
     |
-268 | # apache-airflow-providers-sqlite
-269 | SqliteHook()
-270 | SqliteOperator()
+346 | # apache-airflow-providers-sqlite
+347 | SqliteHook()
+348 | SqliteOperator()
     | ^^^^^^^^^^^^^^ AIR303
-271 | 
-272 | # apache-airflow-providers-zendesk
+349 | 
+350 | # apache-airflow-providers-zendesk
     |
     = help: Install `apache-airflow-provider-sqlite>=1.0.0` and use `airflow.providers.sqlite.operators.sqlite.SqliteOperator` instead.
 
-AIR303.py:273:1: AIR303 `airflow.hooks.zendesk_hook.ZendeskHook` is moved into `zendesk` provider in Airflow 3.0;
+AIR303.py:351:1: AIR303 `airflow.hooks.zendesk_hook.ZendeskHook` is moved into `zendesk` provider in Airflow 3.0;
     |
-272 | # apache-airflow-providers-zendesk
-273 | ZendeskHook()
+350 | # apache-airflow-providers-zendesk
+351 | ZendeskHook()
     | ^^^^^^^^^^^ AIR303
     |
     = help: Install `apache-airflow-provider-zendesk>=1.0.0` and use `airflow.providers.zendesk.hooks.zendesk.ZendeskHook` instead.


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->


## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Many core Airflow features have been deprecated and moved to Airflow Providers since users might need to install an additional package (e.g., `apache-airflow-provider-fab==1.0.0`); a separate rule (AIR303) is created for this.

* `airflow.kubernetes.kubernetes_helper_functions.add_pod_suffix` → `airflow.providers.cncf.kubernetes.kubernetes_helper_functions.add_pod_suffix`
* `airflow.kubernetes.kubernetes_helper_functions.annotations_for_logging_task_metadata` → `airflow.providers.cncf.kubernetes.kubernetes_helper_functions.annotations_for_logging_task_metadata`
* `airflow.kubernetes.kubernetes_helper_functions.annotations_to_key` → `airflow.providers.cncf.kubernetes.kubernetes_helper_functions.annotations_to_key`
* `airflow.kubernetes.kubernetes_helper_functions.create_pod_id` → `airflow.providers.cncf.kubernetes.kubernetes_helper_functions.create_pod_id`
* `airflow.kubernetes.kubernetes_helper_functions.get_logs_task_metadata` → `airflow.providers.cncf.kubernetes.kubernetes_helper_functions.get_logs_task_metadata`
* `airflow.kubernetes.kubernetes_helper_functions.rand_str` → `airflow.providers.cncf.kubernetes.kubernetes_helper_functions.rand_str`
* `airflow.kubernetes.pod.Port` → `kubernetes.client.models.V1ContainerPort`
* `airflow.kubernetes.pod.Resources` → `kubernetes.client.models.V1ResourceRequirements`
* `airflow.kubernetes.pod_launcher.PodLauncher` → `airflow.providers.cncf.kubernetes.pod_launcher.PodLauncher`
* `airflow.kubernetes.pod_launcher.PodStatus` → `airflow.providers.cncf.kubernetes.pod_launcher.PodStatus`
* `airflow.kubernetes.pod_launcher_deprecated.PodLauncher` → `airflow.providers.cncf.kubernetes.pod_launcher_deprecated.PodLauncher`
* `airflow.kubernetes.pod_launcher_deprecated.PodStatus` → `airflow.providers.cncf.kubernetes.pod_launcher_deprecated.PodStatus`
* `airflow.kubernetes.pod_launcher_deprecated.get_kube_client` → `airflow.providers.cncf.kubernetes.kube_client.get_kube_client`
* `airflow.kubernetes.pod_launcher_deprecated.PodDefaults` → `airflow.providers.cncf.kubernetes.pod_generator_deprecated.PodDefaults`
* `airflow.kubernetes.pod_runtime_info_env.PodRuntimeInfoEnv` → `kubernetes.client.models.V1EnvVar`
* `airflow.kubernetes.volume.Volume` → `kubernetes.client.models.V1Volume`
* `airflow.kubernetes.volume_mount.VolumeMount` → `kubernetes.client.models.V1VolumeMount`
* `airflow.kubernetes.k8s_model.K8SModel` → `airflow.providers.cncf.kubernetes.k8s_model.K8SModel`
* `airflow.kubernetes.k8s_model.append_to_pod` → `airflow.providers.cncf.kubernetes.k8s_model.append_to_pod`
* `airflow.kubernetes.kube_client._disable_verify_ssl` → `airflow.kubernetes.airflow.providers.cncf.kubernetes.kube_client._disable_verify_ssl`
* `airflow.kubernetes.kube_client._enable_tcp_keepalive` → `airflow.kubernetes.airflow.providers.cncf.kubernetes.kube_client._enable_tcp_keepalive`
* `airflow.kubernetes.kube_client.get_kube_client` → `airflow.kubernetes.airflow.providers.cncf.kubernetes.kube_client.get_kube_client`
* `airflow.kubernetes.pod_generator.datetime_to_label_safe_datestring` → `airflow.providers.cncf.kubernetes.pod_generator.datetime_to_label_safe_datestring`
* `airflow.kubernetes.pod_generator.extend_object_field` → `airflow.kubernetes.airflow.providers.cncf.kubernetes.pod_generator.extend_object_field`
* `airflow.kubernetes.pod_generator.label_safe_datestring_to_datetime` → `airflow.providers.cncf.kubernetes.pod_generator.label_safe_datestring_to_datetime`
* `airflow.kubernetes.pod_generator.make_safe_label_value` → `airflow.providers.cncf.kubernetes.pod_generator.make_safe_label_value`
* `airflow.kubernetes.pod_generator.merge_objects` → `airflow.providers.cncf.kubernetes.pod_generator.merge_objects`
* `airflow.kubernetes.pod_generator.PodGenerator` → `airflow.providers.cncf.kubernetes.pod_generator.PodGenerator`
* `airflow.kubernetes.pod_generator.PodGeneratorDeprecated` → `airflow.providers.cncf.kubernetes.pod_generator.PodGenerator`
* `airflow.kubernetes.pod_generator.PodDefaults` → `airflow.providers.cncf.kubernetes.pod_generator_deprecated.PodDefaults`
* `airflow.kubernetes.pod_generator.add_pod_suffix` → `airflow.providers.cncf.kubernetes.kubernetes_helper_functions.add_pod_suffix`
* `airflow.kubernetes.pod_generator.rand_str` → `airflow.providers.cncf.kubernetes.kubernetes_helper_functions.rand_str`
* `airflow.kubernetes.pod_generator_deprecated.make_safe_label_value` → `airflow.providers.cncf.kubernetes.pod_generator_deprecated.make_safe_label_value`
* `airflow.kubernetes.pod_generator_deprecated.PodDefaults` → `airflow.providers.cncf.kubernetes.pod_generator_deprecated.PodDefaults`
* `airflow.kubernetes.pod_generator_deprecated.PodGenerator` → `airflow.providers.cncf.kubernetes.pod_generator_deprecated.PodGenerator`
* `airflow.kubernetes.secret.Secret` → `airflow.providers.cncf.kubernetes.secret.Secret`
* `airflow.kubernetes.secret.K8SModel` → `airflow.providers.cncf.kubernetes.k8s_model.K8SModel`



## Test Plan

<!-- How was it tested? -->

A test fixture has been included for the rule.