### PR TITLE
Remove `Type::tuple` in favor of `TupleType::from_elements`

### DIFF
--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -3723,18 +3723,12 @@ impl<'db> TupleType<'db> {
     ) -> Type<'db> {
         let mut elements = vec![];
 
-        let mut is_never = false;
         for ty in types {
             let ty = ty.into();
             if ty.is_never() {
-                // We can not return early here because we need to consume the whole iterator,
-                // to ensure that all element types are inferred.
-                is_never = true;
+                return Type::Never;
             }
             elements.push(ty);
-        }
-        if is_never {
-            return Type::Never;
         }
 
         Type::Tuple(Self::new(db, elements.into_boxed_slice()))

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -3723,12 +3723,18 @@ impl<'db> TupleType<'db> {
     ) -> Type<'db> {
         let mut elements = vec![];
 
+        let mut is_never = false;
         for ty in types {
             let ty = ty.into();
             if ty.is_never() {
-                return Type::Never;
+                // We can not return early here because we need to consume the whole iterator,
+                // to ensure that all element types are inferred.
+                is_never = true;
             }
             elements.push(ty);
+        }
+        if is_never {
+            return Type::Never;
         }
 
         Type::Tuple(Self::new(db, elements.into_boxed_slice()))

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -2672,10 +2672,12 @@ impl<'db> TypeInferenceBuilder<'db> {
             parenthesized: _,
         } = tuple;
 
-        let db = self.db();
-        let element_types = elts.iter().map(|elt| self.infer_expression(elt));
+        // Collecting all elements is necessary to infer all sub-expressions even if some
+        // element types are `Never` (which leads `from_elements` to return early without
+        // consuming the whole iterator).
+        let element_types: Vec<_> = elts.iter().map(|elt| self.infer_expression(elt)).collect();
 
-        TupleType::from_elements(db, element_types)
+        TupleType::from_elements(self.db(), element_types)
     }
 
     fn infer_list_expression(&mut self, list: &ast::ExprList) -> Type<'db> {

--- a/crates/red_knot_python_semantic/src/types/unpacker.rs
+++ b/crates/red_knot_python_semantic/src/types/unpacker.rs
@@ -96,7 +96,7 @@ impl<'db> Unpacker<'db> {
                             // with each individual character, instead of just an array of
                             // `LiteralString`, but there would be a cost and it's not clear that
                             // it's worth it.
-                            Type::tuple(
+                            TupleType::from_elements(
                                 self.db(),
                                 std::iter::repeat(Type::LiteralString)
                                     .take(string_literal_ty.python_len(self.db())),

--- a/crates/red_knot_workspace/resources/test/corpus/88_regression_tuple_type_short_circuit.py
+++ b/crates/red_knot_workspace/resources/test/corpus/88_regression_tuple_type_short_circuit.py
@@ -1,0 +1,17 @@
+"""
+Regression test that makes sure we do not short-circuit here after
+determining that the overall type will be `Never` and still infer
+a type for the second tuple element `2`.
+
+Relevant discussion:
+https://github.com/astral-sh/ruff/pull/15218#discussion_r1900811073
+"""
+
+from typing_extensions import Never
+
+
+def never() -> Never:
+    return never()
+
+
+(never(), 2)


### PR DESCRIPTION
## Summary

Remove `Type::tuple` in favor of `TupleType::from_elements`, avoid a few intermediate `Vec`tors. Resolves an old [review comment](https://github.com/astral-sh/ruff/pull/14744#discussion_r1867493706).

## Test Plan

—
