### PR TITLE
refactor(AIR303): move duplicate qualified_name.to_string() to Diagnostic argument

### DIFF
--- a/crates/ruff_linter/src/rules/airflow/rules/moved_to_provider_in_3.rs
+++ b/crates/ruff_linter/src/rules/airflow/rules/moved_to_provider_in_3.rs
@@ -3,6 +3,7 @@ use ruff_macros::{derive_message_formats, ViolationMetadata};
 use ruff_python_ast::{Expr, ExprAttribute};
 use ruff_python_semantic::Modules;
 use ruff_text_size::Ranged;
+use ruff_text_size::TextRange;
 
 use crate::checkers::ast::Checker;
 
@@ -88,10 +89,10 @@ pub(crate) fn moved_to_provider_in_3(checker: &mut Checker, expr: &Expr) {
     }
 
     match expr {
-        Expr::Attribute(ExprAttribute { attr: ranged, .. }) => {
-            check_names_moved_to_provider(checker, expr, ranged);
+        Expr::Attribute(ExprAttribute { attr, .. }) => {
+            check_names_moved_to_provider(checker, expr, attr.range());
         }
-        ranged @ Expr::Name(_) => check_names_moved_to_provider(checker, expr, ranged),
+        ranged @ Expr::Name(_) => check_names_moved_to_provider(checker, expr, ranged.range()),
         _ => {}
     }
 }
@@ -111,1272 +112,822 @@ enum Replacement {
     },
 }
 
-fn check_names_moved_to_provider(checker: &mut Checker, expr: &Expr, ranged: impl Ranged) {
-    let result =
-        checker
-            .semantic()
-            .resolve_qualified_name(expr)
-            .and_then(|qualname| match qualname.segments() {
-                // apache-airflow-providers-amazon
-                ["airflow", "hooks", "S3_hook", "S3Hook"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.amazon.aws.hooks.s3.S3Hook",
-                        provider: "amazon",
-                        version: "1.0.0"
-                },
-                )),
-                ["airflow", "hooks", "S3_hook", "provide_bucket_name"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.amazon.aws.hooks.s3.provide_bucket_name",
-                        provider: "amazon",
-                        version: "1.0.0"
-                },
-                )),
-                ["airflow", "operators", "gcs_to_s3", "GCSToS3Operator"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.amazon.aws.transfers.gcs_to_s3.GCSToS3Operator",
-                        provider: "amazon",
-                        version: "1.0.0"
-                },
-                )),
-                ["airflow", "operators", "google_api_to_s3_transfer", "GoogleApiToS3Operator"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.amazon.aws.transfers.google_api_to_s3.GoogleApiToS3Operator",
-                        provider: "amazon",
-                        version: "1.0.0"
-                },
-                )),
-                ["airflow", "operators", "google_api_to_s3_transfer", "GoogleApiToS3Transfer"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.amazon.aws.transfers.google_api_to_s3.GoogleApiToS3Operator",
-                        provider: "amazon",
-                        version: "1.0.0"
-                },
-                )),
-                ["airflow", "operators", "redshift_to_s3_operator", "RedshiftToS3Operator"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.amazon.aws.transfers.redshift_to_s3.RedshiftToS3Operator",
-                        provider: "amazon",
-                        version: "1.0.0"
-                },
-                )),
-                ["airflow", "operators", "redshift_to_s3_operator", "RedshiftToS3Transfer"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.amazon.aws.transfers.redshift_to_s3.RedshiftToS3Operator",
-                        provider: "amazon",
-                        version: "1.0.0"
-                },
-                )),
-                ["airflow", "operators", "s3_file_transform_operator", "S3FileTransformOperator"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.amazon.aws.operators.s3_file_transform.S3FileTransformOperator",
-                        provider: "amazon",
-                        version: "1.0.0"
-                },
-                )),
-                ["airflow", "operators", "s3_to_redshift_operator", "S3ToRedshiftOperator"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.amazon.aws.transfers.s3_to_redshift.S3ToRedshiftOperator",
-                        provider: "amazon",
-                        version: "1.0.0"
-                },
-                )),
-                ["airflow", "operators", "s3_to_redshift_operator", "S3ToRedshiftTransfer"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.amazon.aws.transfers.s3_to_redshift.S3ToRedshiftOperator",
-                        provider: "amazon",
-                        version: "1.0.0"
-                },
-                )),
-                ["airflow", "sensors", "s3_key_sensor", "S3KeySensor"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "S3KeySensor",
-                        provider: "amazon",
-                        version: "1.0.0"
-                },
-                )),
+fn check_names_moved_to_provider(checker: &mut Checker, expr: &Expr, ranged: TextRange) {
+    let Some(qualified_name) = checker.semantic().resolve_qualified_name(expr) else {
+        return;
+    };
 
-                // apache-airflow-providers-celery
-                ["airflow", "config_templates", "default_celery", "DEFAULT_CELERY_CONFIG"] => Some((
-                    qualname.to_string(),
-                    Replacement::ImportPathMoved{
-                        original_path: "airflow.config_templates.default_celery.DEFAULT_CELERY_CONFIG",
-                        new_path: "airflow.providers.celery.executors.default_celery.DEFAULT_CELERY_CONFIG",
-                        provider: "celery",
-                        version: "3.3.0"
-                },
-                )),
-                ["airflow", "executors", "celery_executor", "app"] => Some((
-                    qualname.to_string(),
-                    Replacement::ImportPathMoved{
-                        original_path: "airflow.executors.celery_executor.app",
-                        new_path: "airflow.providers.celery.executors.celery_executor_utils.app",
-                        provider: "celery",
-                        version: "3.3.0"
-                },
-                )),
-                ["airflow", "executors", "celery_executor", "CeleryExecutor"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.celery.executors.celery_executor.CeleryExecutor",
-                        provider: "celery",
-                        version: "3.3.0"
-                },
-                )),
-                ["airflow", "executors", "celery_kubernetes_executor", "CeleryKubernetesExecutor"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.celery.executors.celery_kubernetes_executor.CeleryKubernetesExecutor",
-                        provider: "celery",
-                        version: "3.3.0"
-                },
-                )),
+    let replacement = match qualified_name.segments() {
+        // apache-airflow-providers-amazon
+        ["airflow", "hooks", "S3_hook", "S3Hook"] => Replacement::ProviderName{
+            name: "airflow.providers.amazon.aws.hooks.s3.S3Hook",
+            provider: "amazon",
+            version: "1.0.0"
+        },
+        ["airflow", "hooks", "S3_hook", "provide_bucket_name"] => Replacement::ProviderName{
+            name: "airflow.providers.amazon.aws.hooks.s3.provide_bucket_name",
+            provider: "amazon",
+            version: "1.0.0"
+        },
+        ["airflow", "operators", "gcs_to_s3", "GCSToS3Operator"] => Replacement::ProviderName{
+            name: "airflow.providers.amazon.aws.transfers.gcs_to_s3.GCSToS3Operator",
+            provider: "amazon",
+            version: "1.0.0"
+        },
+        ["airflow", "operators", "google_api_to_s3_transfer", "GoogleApiToS3Operator"] => Replacement::ProviderName{
+            name: "airflow.providers.amazon.aws.transfers.google_api_to_s3.GoogleApiToS3Operator",
+            provider: "amazon",
+            version: "1.0.0"
+        },
+        ["airflow", "operators", "google_api_to_s3_transfer", "GoogleApiToS3Transfer"] => Replacement::ProviderName{
+            name: "airflow.providers.amazon.aws.transfers.google_api_to_s3.GoogleApiToS3Operator",
+            provider: "amazon",
+            version: "1.0.0"
+        },
+        ["airflow", "operators", "redshift_to_s3_operator", "RedshiftToS3Operator"] => Replacement::ProviderName{
+            name: "airflow.providers.amazon.aws.transfers.redshift_to_s3.RedshiftToS3Operator",
+            provider: "amazon",
+            version: "1.0.0"
+        },
+        ["airflow", "operators", "redshift_to_s3_operator", "RedshiftToS3Transfer"] => Replacement::ProviderName{
+            name: "airflow.providers.amazon.aws.transfers.redshift_to_s3.RedshiftToS3Operator",
+            provider: "amazon",
+            version: "1.0.0"
+        },
+        ["airflow", "operators", "s3_file_transform_operator", "S3FileTransformOperator"] => Replacement::ProviderName{
+            name: "airflow.providers.amazon.aws.operators.s3_file_transform.S3FileTransformOperator",
+            provider: "amazon",
+            version: "1.0.0"
+        },
+        ["airflow", "operators", "s3_to_redshift_operator", "S3ToRedshiftOperator"] => Replacement::ProviderName{
+            name: "airflow.providers.amazon.aws.transfers.s3_to_redshift.S3ToRedshiftOperator",
+            provider: "amazon",
+            version: "1.0.0"
+        },
+        ["airflow", "operators", "s3_to_redshift_operator", "S3ToRedshiftTransfer"] => Replacement::ProviderName{
+            name: "airflow.providers.amazon.aws.transfers.s3_to_redshift.S3ToRedshiftOperator",
+            provider: "amazon",
+            version: "1.0.0"
+        },
+        ["airflow", "sensors", "s3_key_sensor", "S3KeySensor"] => Replacement::ProviderName{
+            name: "S3KeySensor",
+            provider: "amazon",
+            version: "1.0.0"
+        },
 
-                // apache-airflow-providers-common-sql
-                ["airflow", "hooks", "dbapi", "ConnectorProtocol"] => Some((
-                    qualname.to_string(),
-                    Replacement::ImportPathMoved{
-                        original_path: "airflow.hooks.dbapi.ConnectorProtocol",
-                        new_path: "airflow.providers.common.sql.hooks.sql.ConnectorProtocol",
-                        provider: "common-sql",
-                        version: "1.0.0"
-                },
-                )),
-                ["airflow", "hooks", "dbapi", "DbApiHook"] => Some((
-                    qualname.to_string(),
-                    Replacement::ImportPathMoved{
-                        original_path: "airflow.hooks.dbapi.DbApiHook",
-                        new_path: "airflow.providers.common.sql.hooks.sql.DbApiHook",
-                        provider: "common-sql",
-                        version: "1.0.0"
-                },
-                )),
-                ["airflow", "hooks", "dbapi_hook", "DbApiHook"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.common.sql.hooks.sql.DbApiHook",
-                        provider: "common-sql",
-                        version: "1.0.0"
-                },
-                )),
-                ["airflow", "operators", "check_operator", "SQLCheckOperator"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.common.sql.operators.sql.SQLCheckOperator",
-                        provider: "common-sql",
-                        version: "1.1.0"
-                },
-                )),
-                ["airflow", "operators", "check_operator", "SQLIntervalCheckOperator"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.common.sql.operators.sql.SQLIntervalCheckOperator",
-                        provider: "common-sql",
-                        version: "1.1.0"
-                },
-                )),
-                ["airflow", "operators", "check_operator", "SQLThresholdCheckOperator"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.common.sql.operators.sql.SQLThresholdCheckOperator",
-                        provider: "common-sql",
-                        version: "1.1.0"
-                },
-                )),
-                ["airflow", "operators", "check_operator", "SQLValueCheckOperator"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.common.sql.operators.sql.SQLValueCheckOperator",
-                        provider: "common-sql",
-                        version: "1.1.0"
-                },
-                )),
-                ["airflow", "operators", "check_operator", "CheckOperator"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.common.sql.operators.sql.SQLCheckOperator",
-                        provider: "common-sql",
-                        version: "1.1.0"
-                },
-                )),
-                ["airflow", "operators", "check_operator", "IntervalCheckOperator"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.common.sql.operators.sql.SQLIntervalCheckOperator",
-                        provider: "common-sql",
-                        version: "1.1.0"
-                },
-                )),
-                ["airflow", "operators", "check_operator", "ThresholdCheckOperator"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.common.sql.operators.sql.SQLThresholdCheckOperator",
-                        provider: "common-sql",
-                        version: "1.1.0"
-                },
-                )),
-                ["airflow", "operators", "check_operator", "ValueCheckOperator"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.common.sql.operators.sql.SQLValueCheckOperator",
-                        provider: "common-sql",
-                        version: "1.1.0"
-                },
-                )),
-                ["airflow", "operators", "presto_check_operator", "SQLCheckOperator"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.common.sql.operators.sql.SQLCheckOperator",
-                        provider: "common-sql",
-                        version: "1.1.0"
-                },
-                )),
-                ["airflow", "operators", "presto_check_operator", "SQLIntervalCheckOperator"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.common.sql.operators.sql.SQLIntervalCheckOperator",
-                        provider: "common-sql",
-                        version: "1.1.0"
-                },
-                )),
-                ["airflow", "operators", "presto_check_operator", "SQLValueCheckOperator"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.common.sql.operators.sql.SQLValueCheckOperator",
-                        provider: "common-sql",
-                        version: "1.1.0"
-                },
-                )),
-                ["airflow", "operators", "presto_check_operator", "PrestoCheckOperator"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.common.sql.operators.sql.SQLCheckOperator",
-                        provider: "common-sql",
-                        version: "1.1.0"
-                },
-                )),
-                ["airflow", "operators", "presto_check_operator", "PrestoIntervalCheckOperator"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.common.sql.operators.sql.SQLIntervalCheckOperator",
-                        provider: "common-sql",
-                        version: "1.1.0"
-                },
-                )),
-                ["airflow", "operators", "presto_check_operator", "PrestoValueCheckOperator"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.common.sql.operators.sql.SQLValueCheckOperator",
-                        provider: "common-sql",
-                        version: "1.1.0"
-                },
-                )),
-                ["airflow", "operators", "sql", "BaseSQLOperator"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.common.sql.operators.sql.BaseSQLOperator",
-                        provider: "common-sql",
-                        version: "1.1.0"
-                },
-                )),
-                ["airflow", "operators", "sql", "BranchSQLOperator"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.common.sql.operators.sql.BranchSQLOperator",
-                        provider: "common-sql",
-                        version: "1.1.0"
-                },
-                )),
-                ["airflow", "operators", "sql", "SQLCheckOperator"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.common.sql.operators.sql.SQLCheckOperator",
-                        provider: "common-sql",
-                        version: "1.1.0"
-                },
-                )),
-                ["airflow", "operators", "sql", "SQLColumnCheckOperator"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.common.sql.operators.sql.SQLColumnCheckOperator",
-                        provider: "common-sql",
-                        version: "1.0.0"
-                },
-                )),
-                ["airflow", "operators", "sql", "SQLIntervalCheckOperator"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.common.sql.operators.sql.SQLIntervalCheckOperator",
-                        provider: "common-sql",
-                        version: "1.1.0"
-                },
-                )),
-                ["airflow", "operators", "sql", "SQLTablecheckOperator"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "SQLTableCheckOperator",
-                        provider: "common-sql",
-                        version: "1.0.0"
-                },
-                )),
-                ["airflow", "operators", "sql", "SQLThresholdCheckOperator"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.common.sql.operators.sql.SQLTableCheckOperator",
-                        provider: "common-sql",
-                        version: "1.0.0"
-                },
-                )),
-                ["airflow", "operators", "sql", "SQLValueCheckOperator"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.common.sql.operators.sql.SQLValueCheckOperator",
-                        provider: "common-sql",
-                        version: "1.0.0"
-                },
-                )),
-                ["airflow", "operators", "sql", "_convert_to_float_if_possible"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.common.sql.operators.sql._convert_to_float_if_possible",
-                        provider: "common-sql",
-                        version: "1.0.0"
-                },
-                )),
-                ["airflow", "operators", "sql", "parse_boolean"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.common.sql.operators.sql.parse_boolean",
-                        provider: "common-sql",
-                        version: "1.0.0"
-                },
-                )),
-                ["airflow", "operators", "sql_branch_operator", "BranchSQLOperator"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.common.sql.operators.sql.BranchSQLOperator",
-                        provider: "common-sql",
-                        version: "1.1.0"
-                },
-                )),
-                ["airflow", "operators", "sql_branch_operator", "BranchSqlOperator"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.common.sql.operators.sql.BranchSQLOperator",
-                        provider: "common-sql",
-                        version: "1.1.0"
-                },
-                )),
-                ["airflow", "sensors", "sql", "SqlSensor"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.common.sql.sensors.sql.SqlSensor",
-                        provider: "common-sql",
-                        version: "1.0.0"
-                },
-                )),
-                ["airflow", "sensors", "sql_sensor", "SqlSensor"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.common.sql.sensors.sql.SqlSensor",
-                        provider: "common-sql",
-                        version: "1.0.0"
-                },
-                )),
+        // apache-airflow-providers-celery
+        ["airflow", "config_templates", "default_celery", "DEFAULT_CELERY_CONFIG"] => Replacement::ImportPathMoved{
+            original_path: "airflow.config_templates.default_celery.DEFAULT_CELERY_CONFIG",
+            new_path: "airflow.providers.celery.executors.default_celery.DEFAULT_CELERY_CONFIG",
+            provider: "celery",
+            version: "3.3.0"
+        },
+        ["airflow", "executors", "celery_executor", "app"] => Replacement::ImportPathMoved{
+            original_path: "airflow.executors.celery_executor.app",
+            new_path: "airflow.providers.celery.executors.celery_executor_utils.app",
+            provider: "celery",
+            version: "3.3.0"
+        },
+        ["airflow", "executors", "celery_executor", "CeleryExecutor"] => Replacement::ProviderName{
+            name: "airflow.providers.celery.executors.celery_executor.CeleryExecutor",
+            provider: "celery",
+            version: "3.3.0"
+        },
+        ["airflow", "executors", "celery_kubernetes_executor", "CeleryKubernetesExecutor"] => Replacement::ProviderName{
+            name: "airflow.providers.celery.executors.celery_kubernetes_executor.CeleryKubernetesExecutor",
+            provider: "celery",
+            version: "3.3.0"
+        },
 
-                // apache-airflow-providers-daskexecutor
-                ["airflow", "executors", "dask_executor", "DaskExecutor"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.daskexecutor.executors.dask_executor.DaskExecutor",
-                        provider: "daskexecutor",
-                        version: "1.0.0"
-                },
-                )),
+        // apache-airflow-providers-common-sql
+        ["airflow", "hooks", "dbapi", "ConnectorProtocol"] => Replacement::ImportPathMoved{
+            original_path: "airflow.hooks.dbapi.ConnectorProtocol",
+            new_path: "airflow.providers.common.sql.hooks.sql.ConnectorProtocol",
+            provider: "common-sql",
+            version: "1.0.0"
+        },
+        ["airflow", "hooks", "dbapi", "DbApiHook"] => Replacement::ImportPathMoved{
+            original_path: "airflow.hooks.dbapi.DbApiHook",
+            new_path: "airflow.providers.common.sql.hooks.sql.DbApiHook",
+            provider: "common-sql",
+            version: "1.0.0"
+        },
+        ["airflow", "hooks", "dbapi_hook", "DbApiHook"] => Replacement::ProviderName{
+            name: "airflow.providers.common.sql.hooks.sql.DbApiHook",
+            provider: "common-sql",
+            version: "1.0.0"
+        },
+        ["airflow", "operators", "check_operator", "SQLCheckOperator"] => Replacement::ProviderName{
+            name: "airflow.providers.common.sql.operators.sql.SQLCheckOperator",
+            provider: "common-sql",
+            version: "1.1.0"
+        },
+        ["airflow", "operators", "check_operator", "SQLIntervalCheckOperator"] => Replacement::ProviderName{
+            name: "airflow.providers.common.sql.operators.sql.SQLIntervalCheckOperator",
+            provider: "common-sql",
+            version: "1.1.0"
+        },
+        ["airflow", "operators", "check_operator", "SQLThresholdCheckOperator"] => Replacement::ProviderName{
+            name: "airflow.providers.common.sql.operators.sql.SQLThresholdCheckOperator",
+            provider: "common-sql",
+            version: "1.1.0"
+        },
+        ["airflow", "operators", "check_operator", "SQLValueCheckOperator"] => Replacement::ProviderName{
+            name: "airflow.providers.common.sql.operators.sql.SQLValueCheckOperator",
+            provider: "common-sql",
+            version: "1.1.0"
+        },
+        ["airflow", "operators", "check_operator", "CheckOperator"] => Replacement::ProviderName{
+            name: "airflow.providers.common.sql.operators.sql.SQLCheckOperator",
+            provider: "common-sql",
+            version: "1.1.0"
+        },
+        ["airflow", "operators", "check_operator", "IntervalCheckOperator"] => Replacement::ProviderName{
+            name: "airflow.providers.common.sql.operators.sql.SQLIntervalCheckOperator",
+            provider: "common-sql",
+            version: "1.1.0"
+        },
+        ["airflow", "operators", "check_operator", "ThresholdCheckOperator"] => Replacement::ProviderName{
+            name: "airflow.providers.common.sql.operators.sql.SQLThresholdCheckOperator",
+            provider: "common-sql",
+            version: "1.1.0"
+        },
+        ["airflow", "operators", "check_operator", "ValueCheckOperator"] => Replacement::ProviderName{
+            name: "airflow.providers.common.sql.operators.sql.SQLValueCheckOperator",
+            provider: "common-sql",
+            version: "1.1.0"
+        },
+        ["airflow", "operators", "presto_check_operator", "SQLCheckOperator"] => Replacement::ProviderName{
+            name: "airflow.providers.common.sql.operators.sql.SQLCheckOperator",
+            provider: "common-sql",
+            version: "1.1.0"
+        },
+        ["airflow", "operators", "presto_check_operator", "SQLIntervalCheckOperator"] => Replacement::ProviderName{
+            name: "airflow.providers.common.sql.operators.sql.SQLIntervalCheckOperator",
+            provider: "common-sql",
+            version: "1.1.0"
+        },
+        ["airflow", "operators", "presto_check_operator", "SQLValueCheckOperator"] => Replacement::ProviderName{
+            name: "airflow.providers.common.sql.operators.sql.SQLValueCheckOperator",
+            provider: "common-sql",
+            version: "1.1.0"
+        },
+        ["airflow", "operators", "presto_check_operator", "PrestoCheckOperator"] => Replacement::ProviderName{
+            name: "airflow.providers.common.sql.operators.sql.SQLCheckOperator",
+            provider: "common-sql",
+            version: "1.1.0"
+        },
+        ["airflow", "operators", "presto_check_operator", "PrestoIntervalCheckOperator"] => Replacement::ProviderName{
+            name: "airflow.providers.common.sql.operators.sql.SQLIntervalCheckOperator",
+            provider: "common-sql",
+            version: "1.1.0"
+        },
+        ["airflow", "operators", "presto_check_operator", "PrestoValueCheckOperator"] => Replacement::ProviderName{
+            name: "airflow.providers.common.sql.operators.sql.SQLValueCheckOperator",
+            provider: "common-sql",
+            version: "1.1.0"
+        },
+        ["airflow", "operators", "sql", "BaseSQLOperator"] => Replacement::ProviderName{
+            name: "airflow.providers.common.sql.operators.sql.BaseSQLOperator",
+            provider: "common-sql",
+            version: "1.1.0"
+        },
+        ["airflow", "operators", "sql", "BranchSQLOperator"] => Replacement::ProviderName{
+            name: "airflow.providers.common.sql.operators.sql.BranchSQLOperator",
+            provider: "common-sql",
+            version: "1.1.0"
+        },
+        ["airflow", "operators", "sql", "SQLCheckOperator"] => Replacement::ProviderName{
+            name: "airflow.providers.common.sql.operators.sql.SQLCheckOperator",
+            provider: "common-sql",
+            version: "1.1.0"
+        },
+        ["airflow", "operators", "sql", "SQLColumnCheckOperator"] => Replacement::ProviderName{
+            name: "airflow.providers.common.sql.operators.sql.SQLColumnCheckOperator",
+            provider: "common-sql",
+            version: "1.0.0"
+        },
+        ["airflow", "operators", "sql", "SQLIntervalCheckOperator"] => Replacement::ProviderName{
+            name: "airflow.providers.common.sql.operators.sql.SQLIntervalCheckOperator",
+            provider: "common-sql",
+            version: "1.1.0"
+        },
+        ["airflow", "operators", "sql", "SQLTablecheckOperator"] => Replacement::ProviderName{
+            name: "SQLTableCheckOperator",
+            provider: "common-sql",
+            version: "1.0.0"
+        },
+        ["airflow", "operators", "sql", "SQLThresholdCheckOperator"] => Replacement::ProviderName{
+            name: "airflow.providers.common.sql.operators.sql.SQLTableCheckOperator",
+            provider: "common-sql",
+            version: "1.0.0"
+        },
+        ["airflow", "operators", "sql", "SQLValueCheckOperator"] => Replacement::ProviderName{
+            name: "airflow.providers.common.sql.operators.sql.SQLValueCheckOperator",
+            provider: "common-sql",
+            version: "1.0.0"
+        },
+        ["airflow", "operators", "sql", "_convert_to_float_if_possible"] => Replacement::ProviderName{
+            name: "airflow.providers.common.sql.operators.sql._convert_to_float_if_possible",
+            provider: "common-sql",
+            version: "1.0.0"
+        },
+        ["airflow", "operators", "sql", "parse_boolean"] => Replacement::ProviderName{
+            name: "airflow.providers.common.sql.operators.sql.parse_boolean",
+            provider: "common-sql",
+            version: "1.0.0"
+        },
+        ["airflow", "operators", "sql_branch_operator", "BranchSQLOperator"] => Replacement::ProviderName{
+            name: "airflow.providers.common.sql.operators.sql.BranchSQLOperator",
+            provider: "common-sql",
+            version: "1.1.0"
+        },
+        ["airflow", "operators", "sql_branch_operator", "BranchSqlOperator"] => Replacement::ProviderName{
+            name: "airflow.providers.common.sql.operators.sql.BranchSQLOperator",
+            provider: "common-sql",
+            version: "1.1.0"
+        },
+        ["airflow", "sensors", "sql", "SqlSensor"] => Replacement::ProviderName{
+            name: "airflow.providers.common.sql.sensors.sql.SqlSensor",
+            provider: "common-sql",
+            version: "1.0.0"
+        },
+        ["airflow", "sensors", "sql_sensor", "SqlSensor"] => Replacement::ProviderName{
+            name: "airflow.providers.common.sql.sensors.sql.SqlSensor",
+            provider: "common-sql",
+            version: "1.0.0"
+        },
 
-                // apache-airflow-providers-docker
-                ["airflow", "hooks", "docker_hook", "DockerHook"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.docker.hooks.docker.DockerHook",
-                        provider: "docker",
-                        version: "1.0.0"
-                },
-                )),
-                ["airflow", "operators", "docker_operator", "DockerOperator"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.docker.operators.docker.DockerOperator",
-                        provider: "docker",
-                        version: "1.0.0"
-                },
-                )),
+        // apache-airflow-providers-daskexecutor
+        ["airflow", "executors", "dask_executor", "DaskExecutor"] => Replacement::ProviderName{
+            name: "airflow.providers.daskexecutor.executors.dask_executor.DaskExecutor",
+            provider: "daskexecutor",
+            version: "1.0.0"
+        },
 
-                // apache-airflow-providers-apache-druid
-                ["airflow", "hooks", "druid_hook", "DruidDbApiHook"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "DruidDbApiHook",
-                        provider: "apache-druid",
-                        version: "1.0.0"
-                },
-                )),
-                ["airflow", "hooks", "druid_hook", "DruidHook"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "DruidHook",
-                        provider: "apache-druid",
-                        version: "1.0.0"
-                },
-                )),
-                ["airflow", "operators", "druid_check_operator", "DruidCheckOperator"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "DruidCheckOperator",
-                        provider: "apache-druid",
-                        version: "1.0.0"
-                },
-                )),
-                ["airflow", "operators", "hive_to_druid", "HiveToDruidOperator"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.apache.druid.transfers.hive_to_druid.HiveToDruidOperator",
-                        provider: "apache-druid",
-                        version: "1.0.0"
-                },
-                )),
-                ["airflow", "operators", "hive_to_druid", "HiveToDruidTransfer"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.apache.druid.transfers.hive_to_druid.HiveToDruidOperator",
-                        provider: "apache-druid",
-                        version: "1.0.0"
-                },
-                )),
+        // apache-airflow-providers-docker
+        ["airflow", "hooks", "docker_hook", "DockerHook"] => Replacement::ProviderName{
+            name: "airflow.providers.docker.hooks.docker.DockerHook",
+            provider: "docker",
+            version: "1.0.0"
+        },
+        ["airflow", "operators", "docker_operator", "DockerOperator"] => Replacement::ProviderName{
+            name: "airflow.providers.docker.operators.docker.DockerOperator",
+            provider: "docker",
+            version: "1.0.0"
+        },
+
+        // apache-airflow-providers-apache-druid
+        ["airflow", "hooks", "druid_hook", "DruidDbApiHook"] => Replacement::ProviderName{
+            name: "DruidDbApiHook",
+            provider: "apache-druid",
+            version: "1.0.0"
+        },
+        ["airflow", "hooks", "druid_hook", "DruidHook"] => Replacement::ProviderName{
+            name: "DruidHook",
+            provider: "apache-druid",
+            version: "1.0.0"
+        },
+        ["airflow", "operators", "druid_check_operator", "DruidCheckOperator"] => Replacement::ProviderName{
+            name: "DruidCheckOperator",
+            provider: "apache-druid",
+            version: "1.0.0"
+        },
+        ["airflow", "operators", "hive_to_druid", "HiveToDruidOperator"] => Replacement::ProviderName{
+            name: "airflow.providers.apache.druid.transfers.hive_to_druid.HiveToDruidOperator",
+            provider: "apache-druid",
+            version: "1.0.0"
+        },
+        ["airflow", "operators", "hive_to_druid", "HiveToDruidTransfer"] => Replacement::ProviderName{
+            name: "airflow.providers.apache.druid.transfers.hive_to_druid.HiveToDruidOperator",
+            provider: "apache-druid",
+            version: "1.0.0"
+        },
 
 
-                // apache-airflow-providers-fab
-                ["airflow", "www", "security", "FabAirflowSecurityManagerOverride"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName {
-                        name: "airflow.providers.fab.auth_manager.security_manager.override.FabAirflowSecurityManagerOverride",
-                        provider: "fab",
-                        version: "1.0.0"
-                    },
-                )),
-                ["airflow", "auth", "managers", "fab", "fab_auth_manager", "FabAuthManager"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.fab.auth_manager.security_manager.FabAuthManager",
-                        provider: "fab",
-                        version: "1.0.0"
-                },
-                )),
-                ["airflow", "api", "auth", "backend", "basic_auth", ..] => Some((
-                    qualname.to_string(),
-                    Replacement::ImportPathMoved{
-                        original_path: "airflow.api.auth.backend.basic_auth",
-                        new_path: "airflow.providers.fab.auth_manager.api.auth.backend.basic_auth",
-                        provider:"fab",
-                        version: "1.0.0"
-                },
-                )),
-                ["airflow", "api", "auth", "backend", "kerberos_auth", ..] => Some((
-                    qualname.to_string(),
-                    Replacement::ImportPathMoved{
-                        original_path:"airflow.api.auth.backend.kerberos_auth",
-                        new_path: "airflow.providers.fab.auth_manager.api.auth.backend.kerberos_auth",
-                        provider: "fab",
-                        version:"1.0.0"
-                },
-                )),
-                ["airflow", "auth", "managers", "fab", "api", "auth", "backend", "kerberos_auth", ..] => Some((
-                    qualname.to_string(),
-                    Replacement::ImportPathMoved{
-                        original_path: "airflow.auth_manager.api.auth.backend.kerberos_auth",
-                        new_path: "airflow.providers.fab.auth_manager.api.auth.backend.kerberos_auth",
-                        provider: "fab",
-                        version: "1.0.0"
-                },
-                )),
-                ["airflow", "auth", "managers", "fab", "security_manager", "override", ..] => Some((
-                    qualname.to_string(),
-                    Replacement::ImportPathMoved{
-                        original_path: "airflow.auth.managers.fab.security_managr.override",
-                        new_path: "airflow.providers.fab.auth_manager.security_manager.override",
-                        provider: "fab",
-                        version: "1.0.0"
-                },
-                )),
-
-                // apache-airflow-providers-apache-hdfs
-                ["airflow", "hooks", "webhdfs_hook", "WebHDFSHook"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.apache.hdfs.hooks.webhdfs.WebHDFSHook",
-                        provider: "apache-hdfs",
-                        version: "1.0.0"
-                },
-                )),
-                ["airflow", "sensors", "web_hdfs_sensor", "WebHdfsSensor"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.apache.hdfs.sensors.web_hdfs.WebHdfsSensor",
-                        provider: "apache-hdfs",
-                        version: "1.0.0"
-                },
-                )),
-
-                // apache-airflow-providers-apache-hive
-                ["airflow", "hooks", "hive_hooks", "HIVE_QUEUE_PRIORITIES"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.apache.hive.hooks.hive.HIVE_QUEUE_PRIORITIES",
-                        provider: "apache-hive",
-                        version: "1.0.0"
-                },
-                )),
-                ["airflow", "macros", "hive", "closest_ds_partition"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.apache.hive.macros.hive.closest_ds_partition",
-                        provider: "apache-hive",
-                        version: "5.1.0"
-                },
-                )),
-                ["airflow", "macros", "hive", "max_partition"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.apache.hive.macros.hive.max_partition",
-                        provider: "apache-hive",
-                        version: "5.1.0"
-                },
-                )),
-                ["airflow", "operators", "hive_to_mysql", "HiveToMySqlOperator"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.apache.hive.transfers.hive_to_mysql.HiveToMySqlOperator",
-                        provider: "apache-hive",
-                        version: "1.0.0"
-                },
-                )),
-                ["airflow", "operators", "hive_to_mysql", "HiveToMySqlTransfer"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.apache.hive.transfers.hive_to_mysql.HiveToMySqlOperator",
-                        provider: "apache-hive",
-                        version: "1.0.0"
-                },
-                )),
-                ["airflow", "operators", "hive_to_samba_operator", "HiveToSambaOperator"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "HiveToSambaOperator",
-                        provider: "apache-hive",
-                        version: "1.0.0"
-                },
-                )),
-                ["airflow", "operators", "mssql_to_hive", "MsSqlToHiveOperator"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.apache.hive.transfers.mssql_to_hive.MsSqlToHiveOperator",
-                        provider: "apache-hive",
-                        version: "1.0.0"
-                },
-                )),
-                ["airflow", "operators", "mssql_to_hive", "MsSqlToHiveTransfer"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.apache.hive.transfers.mssql_to_hive.MsSqlToHiveOperator",
-                        provider: "apache-hive",
-                        version: "1.0.0"
-                },
-                )),
-                ["airflow", "operators", "mysql_to_hive", "MySqlToHiveOperator"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.apache.hive.transfers.mysql_to_hive.MySqlToHiveOperator",
-                        provider: "apache-hive",
-                        version: "1.0.0"
-                },
-                )),
-                ["airflow", "operators", "mysql_to_hive", "MySqlToHiveTransfer"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.apache.hive.transfers.mysql_to_hive.MySqlToHiveOperator",
-                        provider: "apache-hive",
-                        version: "1.0.0"
-                },
-                )),
-                ["airflow", "operators", "s3_to_hive_operator", "S3ToHiveOperator"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.apache.hive.transfers.s3_to_hive.S3ToHiveOperator",
-                        provider: "apache-hive",
-                        version: "1.0.0"
-                },
-                )),
-                ["airflow", "operators", "s3_to_hive_operator", "S3ToHiveTransfer"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.apache.hive.transfers.s3_to_hive.S3ToHiveOperator",
-                        provider: "apache-hive",
-                        version: "1.0.0"
-                },
-                )),
-                ["airflow", "hooks", "hive_hooks", "HiveCliHook"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.apache.hive.hooks.hive.HiveCliHook",
-                        provider: "apache-hive",
-                        version: "1.0.0"
-                    },
-                )),
-                ["airflow", "hooks", "hive_hooks", "HiveMetastoreHook"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.apache.hive.hooks.hive.HiveMetastoreHook",
-                        provider: "apache-hive",
-                        version: "1.0.0"
-                    },
-                )),
-
-                ["airflow", "hooks", "hive_hooks", "HiveServer2Hook"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.apache.hive.hooks.hive.HiveServer2Hook",
-                        provider: "apache-hive",
-                        version: "1.0.0"
-                },
-                )),
-                ["airflow", "operators", "hive_operator", "HiveOperator"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.apache.hive.operators.hive.HiveOperator",
-                        provider: "apache-hive",
-                        version: "1.0.0"
-                },
-                )),
-                ["airflow", "operators", "hive_stats_operator", "HiveStatsCollectionOperator"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.apache.hive.operators.hive_stats.HiveStatsCollectionOperator",
-                        provider: "apache-hive",
-                        version: "1.0.0"
-                },
-                )),
-                ["airflow", "sensors", "hive_partition_sensor", "HivePartitionSensor"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.apache.hive.sensors.hive_partition.HivePartitionSensor",
-                        provider: "apache-hive",
-                        version: "1.0.0"
-                },
-                )),
-                ["airflow", "sensors", "metastore_partition_sensor", "MetastorePartitionSensor"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.apache.hive.sensors.metastore_partition.MetastorePartitionSensor",
-                        provider: "apache-hive",
-                        version: "1.0.0"
-                },
-                )),
-                ["airflow", "sensors", "named_hive_partition_sensor", "NamedHivePartitionSensor"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.apache.hive.sensors.named_hive_partition.NamedHivePartitionSensor",
-                        provider: "apache-hive",
-                        version: "1.0.0"
-                },
-                )),
-
-                // apache-airflow-providers-http
-                ["airflow", "hooks", "http_hook", "HttpHook"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.http.hooks.http.HttpHook",
-                        provider: "http",
-                        version: "1.0.0"
-                },
-                )),
-                ["airflow", "operators", "http_operator", "SimpleHttpOperator"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.http.operators.http.SimpleHttpOperator",
-                        provider: "http",
-                        version: "1.0.0"
-                },
-                )),
-                ["airflow", "sensors", "http_sensor", "HttpSensor"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.http.sensors.http.HttpSensor",
-                        provider: "http",
-                        version: "1.0.0"
-                },
-                )),
-
-                // apache-airflow-providers-jdbc
-                ["airflow", "hooks", "jdbc_hook", "JdbcHook"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.jdbc.hooks.jdbc.JdbcHook",
-                        provider: "jdbc",
-                        version: "1.0.0"
-                },
-                )),
-                ["airflow", "hooks", "jdbc_hook", "jaydebeapi"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.jdbc.hooks.jdbc.jaydebeapi",
-                        provider: "jdbc",
-                        version: "1.0.0"
-                },
-                )),
-                ["airflow", "operators", "jdbc_operator", "JdbcOperator"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.jdbc.operators.jdbc.JdbcOperator",
-                        provider: "jdbc",
-                        version: "1.0.0"
-                },
-                )),
-
-                // apache-airflow-providers-cncf-kubernetes
-                ["airflow", "executors", "kubernetes_executor_types", "ALL_NAMESPACES"] => Some((
-                    qualname.to_string(),
-                    Replacement::ImportPathMoved{
-                        original_path: "airflow.executors.kubernetes_executor_types.ALL_NAMESPACES",
-                        new_path: "airflow.providers.cncf.kubernetes.executors.kubernetes_executor_types.ALL_NAMESPACES",
-                        provider: "cncf-kubernetes",
-                        version: "7.4.0"
-                },
-                )),
-                ["airflow", "executors", "kubernetes_executor_types", "POD_EXECUTOR_DONE_KEY"] => Some((
-                    qualname.to_string(),
-                    Replacement::ImportPathMoved{
-                        original_path: "airflow.executors.kubernetes_executor_types.POD_EXECUTOR_DONE_KEY",
-                        new_path: "airflow.providers.cncf.kubernetes.executors.kubernetes_executor_types.POD_EXECUTOR_DONE_KEY",
-                        provider: "cncf-kubernetes",
-                        version: "7.4.0"
-                },
-                )),
-                ["airflow", "kubernetes", "kubernetes_helper_functions", "add_pod_suffix"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.cncf.kubernetes.kubernetes_helper_functions.add_pod_suffix",
-                        provider: "cncf-kubernetes",
-                        version: "7.4.0"
-                },
-                )),
-                ["airflow", "kubernetes", "kubernetes_helper_functions", "annotations_for_logging_task_metadata"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.cncf.kubernetes.kubernetes_helper_functions.annotations_for_logging_task_metadata",
-                        provider: "cncf-kubernetes",
-                        version: "7.4.0"
-                },
-                )),
-                ["airflow", "kubernetes", "kubernetes_helper_functions", "annotations_to_key"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.cncf.kubernetes.kubernetes_helper_functions.annotations_to_key",
-                        provider: "cncf-kubernetes",
-                        version: "7.4.0"
-                },
-                )),
-                ["airflow", "kubernetes", "kubernetes_helper_functions", "create_pod_id"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.cncf.kubernetes.kubernetes_helper_functions.create_pod_id",
-                        provider: "cncf-kubernetes",
-                        version: "7.4.0"
-                },
-                )),
-                ["airflow", "kubernetes", "kubernetes_helper_functions", "get_logs_task_metadata"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.cncf.kubernetes.kubernetes_helper_functions.get_logs_task_metadata",
-                        provider: "cncf-kubernetes",
-                        version: "7.4.0"
-                },
-                )),
-                ["airflow", "kubernetes", "kubernetes_helper_functions", "rand_str"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.cncf.kubernetes.kubernetes_helper_functions.rand_str",
-                        provider: "cncf-kubernetes",
-                        version: "7.4.0"
-                },
-                )),
-                ["airflow", "kubernetes", "pod", "Port"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "kubernetes.client.models.V1ContainerPort",
-                        provider: "cncf-kubernetes",
-                        version: "7.4.0"
-                },
-                )),
-                ["airflow", "kubernetes", "pod", "Resources"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "kubernetes.client.models.V1ResourceRequirements",
-                        provider: "cncf-kubernetes",
-                        version: "7.4.0"
-                },
-                )),
-                ["airflow", "kubernetes", "pod_launcher", "PodLauncher"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.cncf.kubernetes.pod_launcher.PodLauncher",
-                        provider: "cncf-kubernetes",
-                        version: "7.4.0"
-                },
-                )),
-                ["airflow", "kubernetes", "pod_launcher", "PodStatus"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.cncf.kubernetes.pod_launcher.PodStatus",
-                        provider: "cncf-kubernetes",
-                        version: "7.4.0"
-                },
-                )),
-                ["airflow", "kubernetes", "pod_launcher_deprecated", "PodLauncher"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.cncf.kubernetes.pod_launcher_deprecated.PodLauncher",
-                        provider: "cncf-kubernetes",
-                        version: "7.4.0"
-                },
-                )),
-                ["airflow", "kubernetes", "pod_launcher_deprecated", "PodStatus"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.cncf.kubernetes.pod_launcher_deprecated.PodStatus",
-                        provider: "cncf-kubernetes",
-                        version: "7.4.0"
-                },
-                )),
-                ["airflow", "kubernetes", "pod_launcher_deprecated", "get_kube_client"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.cncf.kubernetes.kube_client.get_kube_client",
-                        provider: "cncf-kubernetes",
-                        version: "7.4.0"
-                },
-                )),
-                ["airflow", "kubernetes", "pod_launcher_deprecated", "PodDefaults"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.cncf.kubernetes.pod_generator_deprecated.PodDefaults",
-                        provider: "cncf-kubernetes",
-                        version: "7.4.0"
-                },
-                )),
-                ["airflow", "kubernetes", "pod_runtime_info_env", "PodRuntimeInfoEnv"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "kubernetes.client.models.V1EnvVar",
-                        provider: "cncf-kubernetes",
-                        version: "7.4.0"
-                },
-                )),
-                ["airflow", "kubernetes", "volume", "Volume"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "kubernetes.client.models.V1Volume",
-                        provider: "cncf-kubernetes",
-                        version: "7.4.0"
-                },
-                )),
-                ["airflow", "kubernetes", "volume_mount", "VolumeMount"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "kubernetes.client.models.V1VolumeMount",
-                        provider: "cncf-kubernetes",
-                        version: "7.4.0"
-                },
-                )),
-                ["airflow", "kubernetes", "k8s_model", "K8SModel"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.cncf.kubernetes.k8s_model.K8SModel",
-                        provider: "cncf-kubernetes",
-                        version: "7.4.0"
-                },
-                )),
-                ["airflow", "kubernetes", "k8s_model", "append_to_pod"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.cncf.kubernetes.k8s_model.append_to_pod",
-                        provider: "cncf-kubernetes",
-                        version: "7.4.0"
-                },
-                )),
-                ["airflow", "kubernetes", "kube_client", "_disable_verify_ssl"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.kubernetes.airflow.providers.cncf.kubernetes.kube_client._disable_verify_ssl",
-                        provider: "cncf-kubernetes",
-                        version: "7.4.0"
-                },
-                )),
-                ["airflow", "kubernetes", "kube_client", "_enable_tcp_keepalive"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.kubernetes.airflow.providers.cncf.kubernetes.kube_client._enable_tcp_keepalive",
-                        provider: "cncf-kubernetes",
-                        version: "7.4.0"
-                },
-                )),
-                ["airflow", "kubernetes", "kube_client", "get_kube_client"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.kubernetes.airflow.providers.cncf.kubernetes.kube_client.get_kube_client",
-                        provider: "cncf-kubernetes",
-                        version: "7.4.0"
-                },
-                )),
-                ["airflow", "kubernetes", "pod_generator", "datetime_to_label_safe_datestring"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.cncf.kubernetes.pod_generator.datetime_to_label_safe_datestring",
-                        provider: "cncf-kubernetes",
-                        version: "7.4.0"
-                },
-                )),
-                ["airflow", "kubernetes", "pod_generator", "extend_object_field"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.kubernetes.airflow.providers.cncf.kubernetes.pod_generator.extend_object_field",
-                        provider: "cncf-kubernetes",
-                        version: "7.4.0"
-                },
-                )),
-                ["airflow", "kubernetes", "pod_generator", "label_safe_datestring_to_datetime"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.cncf.kubernetes.pod_generator.label_safe_datestring_to_datetime",
-                        provider: "cncf-kubernetes",
-                        version: "7.4.0"
-                },
-                )),
-                ["airflow", "kubernetes", "pod_generator", "make_safe_label_value"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.cncf.kubernetes.pod_generator.make_safe_label_value",
-                        provider: "cncf-kubernetes",
-                        version: "7.4.0"
-                },
-                )),
-                ["airflow", "kubernetes", "pod_generator", "merge_objects"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.cncf.kubernetes.pod_generator.merge_objects",
-                        provider: "cncf-kubernetes",
-                        version: "7.4.0"
-                },
-                )),
-                ["airflow", "kubernetes", "pod_generator", "PodGenerator"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.cncf.kubernetes.pod_generator.PodGenerator",
-                        provider: "cncf-kubernetes",
-                        version: "7.4.0"
-                },
-                )),
-                ["airflow", "kubernetes", "pod_generator_deprecated", "make_safe_label_value"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.cncf.kubernetes.pod_generator_deprecated.make_safe_label_value",
-                        provider: "cncf-kubernetes",
-                        version: "7.4.0"
-                },
-                )),
-                ["airflow", "kubernetes", "pod_generator_deprecated", "PodDefaults"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.cncf.kubernetes.pod_generator_deprecated.PodDefaults",
-                        provider: "cncf-kubernetes",
-                        version: "7.4.0"
-                },
-                )),
-                ["airflow", "kubernetes", "pod_generator_deprecated", "PodGenerator"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.cncf.kubernetes.pod_generator_deprecated.PodGenerator",
-                        provider: "cncf-kubernetes",
-                        version: "7.4.0"
-                },
-                )),
-                ["airflow", "kubernetes", "secret", "Secret"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.cncf.kubernetes.secret.Secret",
-                        provider: "cncf-kubernetes",
-                        version: "7.4.0"
-                },
-                )),
-                ["airflow", "kubernetes", "pod_generator", "PodGeneratorDeprecated"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.cncf.kubernetes.pod_generator.PodGenerator",
-                        provider: "cncf-kubernetes",
-                        version: "7.4.0"
-                },
-                )),
-                ["airflow", "kubernetes", "pod_generator", "PodDefaults"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.cncf.kubernetes.pod_generator_deprecated.PodDefaults",
-                        provider: "cncf-kubernetes",
-                        version: "7.4.0"
-                },
-                )),
-                ["airflow", "kubernetes", "pod_generator", "add_pod_suffix"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.cncf.kubernetes.kubernetes_helper_functions.add_pod_suffix",
-                        provider: "cncf-kubernetes",
-                        version: "7.4.0"
-                },
-                )),
-                ["airflow", "kubernetes", "pod_generator", "rand_str"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.cncf.kubernetes.kubernetes_helper_functions.rand_str",
-                        provider: "cncf-kubernetes",
-                        version: "7.4.0"
-                },
-                )),
-                ["airflow", "kubernetes", "secret", "K8SModel"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.cncf.kubernetes.k8s_model.K8SModel",
-                        provider: "cncf-kubernetes",
-                        version: "7.4.0"
-                },
-                )),
-
-                // apache-airflow-providers-microsoft-mssql
-                ["airflow", "hooks", "mssql_hook", "MsSqlHook"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.microsoft.mssql.hooks.mssql.MsSqlHook",
-                        provider: "microsoft-mssql",
-                        version: "1.0.0"
-                },
-                )),
-                ["airflow", "operators", "mssql_operator", "MsSqlOperator"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.microsoft.mssql.operators.mssql.MsSqlOperator",
-                        provider: "microsoft-mssql",
-                        version: "1.0.0"
-                },
-                )),
-
-                // apache-airflow-providers-mysql
-                ["airflow", "hooks", "mysql_hook", "MySqlHook"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.mysql.hooks.mysql.MySqlHook",
-                        provider: "mysql",
-                        version: "1.0.0"
-                },
-                )),
-                ["airflow", "operators", "mysql_operator", "MySqlOperator"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.mysql.operators.mysql.MySqlOperator",
-                        provider: "mysql",
-                        version: "1.0.0"
-                },
-                )),
-                ["airflow", "operators", "presto_to_mysql", "PrestoToMySqlOperator"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.mysql.transfers.presto_to_mysql.PrestoToMySqlOperator",
-                        provider: "mysql",
-                        version: "1.0.0"
-                },
-                )),
-                ["airflow", "operators", "presto_to_mysql", "PrestoToMySqlTransfer"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.mysql.transfers.presto_to_mysql.PrestoToMySqlOperator",
-                        provider: "mysql",
-                        version: "1.0.0"
-                },
-                )),
-
-                // apache-airflow-providers-oracle
-                ["airflow", "hooks", "oracle_hook", "OracleHook"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.oracle.hooks.oracle.OracleHook",
-                        provider: "oracle",
-                        version: "1.0.0"
-                },
-                )),
-                ["airflow", "operators", "oracle_operator", "OracleOperator"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.oracle.operators.oracle.OracleOperator",
-                        provider: "oracle",
-                        version: "1.0.0"
-                },
-                )),
-
-                // apache-airflow-providers-papermill
-                ["airflow", "operators", "papermill_operator", "PapermillOperator"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.papermill.operators.papermill.PapermillOperator",
-                        provider: "papermill",
-                        version: "1.0.0"
-                },
-                )),
-
-                // apache-airflow-providers-apache-pig
-                ["airflow", "hooks", "pig_hook", "PigCliHook"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.apache.pig.hooks.pig.PigCliHook",
-                        provider: "apache-pig",
-                        version: "1.0.0"
-                },
-                )),
-                ["airflow", "operators", "pig_operator", "PigOperator"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.apache.pig.operators.pig.PigOperator",
-                        provider: "apache-pig",
-                        version: "1.0.0"
-                },
-                )),
-
-                // apache-airflow-providers-postgres
-                ["airflow", "hooks", "postgres_hook", "PostgresHook"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.postgres.hooks.postgres.PostgresHook",
-                        provider: "postgres",
-                        version: "1.0.0"
-                },
-                )),
-                ["airflow", "operators", "postgres_operator", "Mapping"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.postgres.operators.postgres.Mapping",
-                        provider: "postgres",
-                        version: "1.0.0"
-                },
-                )),
-
-                ["airflow", "operators", "postgres_operator", "PostgresOperator"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.postgres.operators.postgres.PostgresOperator",
-                        provider: "postgres",
-                        version: "1.0.0"
-                },
-                )),
-
-                // apache-airflow-providers-presto
-                ["airflow", "hooks", "presto_hook", "PrestoHook"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.presto.hooks.presto.PrestoHook",
-                        provider: "presto",
-                        version: "1.0.0"
-                },
-                )),
-
-                // apache-airflow-providers-samba
-                ["airflow", "hooks", "samba_hook", "SambaHook"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.samba.hooks.samba.SambaHook",
-                        provider: "samba",
-                        version: "1.0.0"
-                },
-                )),
-
-                // apache-airflow-providers-slack
-                ["airflow", "hooks", "slack_hook", "SlackHook"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.slack.hooks.slack.SlackHook",
-                        provider: "slack",
-                        version: "1.0.0"
-                },
-                )),
-                ["airflow", "operators", "slack_operator", "SlackAPIOperator"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.slack.operators.slack.SlackAPIOperator",
-                        provider: "slack",
-                        version: "1.0.0"
-                },
-                )),
-                ["airflow", "operators", "slack_operator", "SlackAPIPostOperator"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.slack.operators.slack.SlackAPIPostOperator",
-                        provider: "slack",
-                        version: "1.0.0"
-                },
-                )),
-
-                // apache-airflow-providers-sqlite
-                ["airflow", "hooks", "sqlite_hook", "SqliteHook"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.sqlite.hooks.sqlite.SqliteHook",
-                        provider: "sqlite",
-                        version: "1.0.0"
-                },
-                )),
-                ["airflow", "operators", "sqlite_operator", "SqliteOperator"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.sqlite.operators.sqlite.SqliteOperator",
-                        provider: "sqlite",
-                        version: "1.0.0"
-                },
-                )),
-
-                // apache-airflow-providers-zendesk
-                ["airflow", "hooks", "zendesk_hook", "ZendeskHook"] => Some((
-                    qualname.to_string(),
-                    Replacement::ProviderName{
-                        name: "airflow.providers.zendesk.hooks.zendesk.ZendeskHook",
-                        provider: "zendesk",
-                        version: "1.0.0"
-                },
-                )),
-
-                _ => None,
-            });
-    if let Some((deprecated, replacement)) = result {
-        checker.diagnostics.push(Diagnostic::new(
-            Airflow3MovedToProvider {
-                deprecated,
-                replacement,
+        // apache-airflow-providers-fab
+        ["airflow", "www", "security", "FabAirflowSecurityManagerOverride"] => Replacement::ProviderName {
+            name: "airflow.providers.fab.auth_manager.security_manager.override.FabAirflowSecurityManagerOverride",
+            provider: "fab",
+            version: "1.0.0"
             },
-            ranged.range(),
-        ));
-    }
+        ["airflow", "auth", "managers", "fab", "fab_auth_manager", "FabAuthManager"] => Replacement::ProviderName{
+            name: "airflow.providers.fab.auth_manager.security_manager.FabAuthManager",
+            provider: "fab",
+            version: "1.0.0"
+        },
+        ["airflow", "api", "auth", "backend", "basic_auth", ..] => Replacement::ImportPathMoved{
+                original_path: "airflow.api.auth.backend.basic_auth",
+                new_path: "airflow.providers.fab.auth_manager.api.auth.backend.basic_auth",
+            provider:"fab",
+            version: "1.0.0"
+        },
+        ["airflow", "api", "auth", "backend", "kerberos_auth", ..] => Replacement::ImportPathMoved{
+                original_path:"airflow.api.auth.backend.kerberos_auth",
+                new_path: "airflow.providers.fab.auth_manager.api.auth.backend.kerberos_auth",
+            provider: "fab",
+            version:"1.0.0"
+        },
+        ["airflow", "auth", "managers", "fab", "api", "auth", "backend", "kerberos_auth", ..] => Replacement::ImportPathMoved{
+                original_path: "airflow.auth_manager.api.auth.backend.kerberos_auth",
+                new_path: "airflow.providers.fab.auth_manager.api.auth.backend.kerberos_auth",
+            provider: "fab",
+            version: "1.0.0"
+        },
+        ["airflow", "auth", "managers", "fab", "security_manager", "override", ..] => Replacement::ImportPathMoved{
+                original_path: "airflow.auth.managers.fab.security_managr.override",
+                new_path: "airflow.providers.fab.auth_manager.security_manager.override",
+            provider: "fab",
+            version: "1.0.0"
+        },
+
+        // apache-airflow-providers-apache-hdfs
+        ["airflow", "hooks", "webhdfs_hook", "WebHDFSHook"] => Replacement::ProviderName{
+            name: "airflow.providers.apache.hdfs.hooks.webhdfs.WebHDFSHook",
+            provider: "apache-hdfs",
+            version: "1.0.0"
+        },
+        ["airflow", "sensors", "web_hdfs_sensor", "WebHdfsSensor"] => Replacement::ProviderName{
+            name: "airflow.providers.apache.hdfs.sensors.web_hdfs.WebHdfsSensor",
+            provider: "apache-hdfs",
+            version: "1.0.0"
+        },
+
+        // apache-airflow-providers-apache-hive
+        ["airflow", "hooks", "hive_hooks", "HIVE_QUEUE_PRIORITIES"] => Replacement::ProviderName{
+            name: "airflow.providers.apache.hive.hooks.hive.HIVE_QUEUE_PRIORITIES",
+            provider: "apache-hive",
+            version: "1.0.0"
+        },
+        ["airflow", "macros", "hive", "closest_ds_partition"] => Replacement::ProviderName{
+            name: "airflow.providers.apache.hive.macros.hive.closest_ds_partition",
+            provider: "apache-hive",
+            version: "5.1.0"
+        },
+        ["airflow", "macros", "hive", "max_partition"] => Replacement::ProviderName{
+            name: "airflow.providers.apache.hive.macros.hive.max_partition",
+            provider: "apache-hive",
+            version: "5.1.0"
+        },
+        ["airflow", "operators", "hive_to_mysql", "HiveToMySqlOperator"] => Replacement::ProviderName{
+            name: "airflow.providers.apache.hive.transfers.hive_to_mysql.HiveToMySqlOperator",
+            provider: "apache-hive",
+            version: "1.0.0"
+        },
+        ["airflow", "operators", "hive_to_mysql", "HiveToMySqlTransfer"] => Replacement::ProviderName{
+            name: "airflow.providers.apache.hive.transfers.hive_to_mysql.HiveToMySqlOperator",
+            provider: "apache-hive",
+            version: "1.0.0"
+        },
+        ["airflow", "operators", "hive_to_samba_operator", "HiveToSambaOperator"] => Replacement::ProviderName{
+            name: "HiveToSambaOperator",
+            provider: "apache-hive",
+            version: "1.0.0"
+        },
+        ["airflow", "operators", "mssql_to_hive", "MsSqlToHiveOperator"] => Replacement::ProviderName{
+            name: "airflow.providers.apache.hive.transfers.mssql_to_hive.MsSqlToHiveOperator",
+            provider: "apache-hive",
+            version: "1.0.0"
+        },
+        ["airflow", "operators", "mssql_to_hive", "MsSqlToHiveTransfer"] => Replacement::ProviderName{
+            name: "airflow.providers.apache.hive.transfers.mssql_to_hive.MsSqlToHiveOperator",
+            provider: "apache-hive",
+            version: "1.0.0"
+        },
+        ["airflow", "operators", "mysql_to_hive", "MySqlToHiveOperator"] => Replacement::ProviderName{
+            name: "airflow.providers.apache.hive.transfers.mysql_to_hive.MySqlToHiveOperator",
+            provider: "apache-hive",
+            version: "1.0.0"
+        },
+        ["airflow", "operators", "mysql_to_hive", "MySqlToHiveTransfer"] => Replacement::ProviderName{
+            name: "airflow.providers.apache.hive.transfers.mysql_to_hive.MySqlToHiveOperator",
+            provider: "apache-hive",
+            version: "1.0.0"
+        },
+        ["airflow", "operators", "s3_to_hive_operator", "S3ToHiveOperator"] => Replacement::ProviderName{
+            name: "airflow.providers.apache.hive.transfers.s3_to_hive.S3ToHiveOperator",
+            provider: "apache-hive",
+            version: "1.0.0"
+        },
+        ["airflow", "operators", "s3_to_hive_operator", "S3ToHiveTransfer"] => Replacement::ProviderName{
+            name: "airflow.providers.apache.hive.transfers.s3_to_hive.S3ToHiveOperator",
+            provider: "apache-hive",
+            version: "1.0.0"
+        },
+        ["airflow", "hooks", "hive_hooks", "HiveCliHook"] => Replacement::ProviderName{
+            name: "airflow.providers.apache.hive.hooks.hive.HiveCliHook",
+            provider: "apache-hive",
+            version: "1.0.0"
+            },
+        ["airflow", "hooks", "hive_hooks", "HiveMetastoreHook"] => Replacement::ProviderName{
+            name: "airflow.providers.apache.hive.hooks.hive.HiveMetastoreHook",
+            provider: "apache-hive",
+            version: "1.0.0"
+        },
+        ["airflow", "hooks", "hive_hooks", "HiveServer2Hook"] => Replacement::ProviderName{
+            name: "airflow.providers.apache.hive.hooks.hive.HiveServer2Hook",
+            provider: "apache-hive",
+            version: "1.0.0"
+        },
+        ["airflow", "operators", "hive_operator", "HiveOperator"] => Replacement::ProviderName{
+            name: "airflow.providers.apache.hive.operators.hive.HiveOperator",
+            provider: "apache-hive",
+            version: "1.0.0"
+        },
+        ["airflow", "operators", "hive_stats_operator", "HiveStatsCollectionOperator"] => Replacement::ProviderName{
+            name: "airflow.providers.apache.hive.operators.hive_stats.HiveStatsCollectionOperator",
+            provider: "apache-hive",
+            version: "1.0.0"
+        },
+        ["airflow", "sensors", "hive_partition_sensor", "HivePartitionSensor"] => Replacement::ProviderName{
+            name: "airflow.providers.apache.hive.sensors.hive_partition.HivePartitionSensor",
+            provider: "apache-hive",
+            version: "1.0.0"
+        },
+        ["airflow", "sensors", "metastore_partition_sensor", "MetastorePartitionSensor"] => Replacement::ProviderName{
+            name: "airflow.providers.apache.hive.sensors.metastore_partition.MetastorePartitionSensor",
+            provider: "apache-hive",
+            version: "1.0.0"
+        },
+        ["airflow", "sensors", "named_hive_partition_sensor", "NamedHivePartitionSensor"] => Replacement::ProviderName{
+            name: "airflow.providers.apache.hive.sensors.named_hive_partition.NamedHivePartitionSensor",
+            provider: "apache-hive",
+            version: "1.0.0"
+        },
+
+        // apache-airflow-providers-http
+        ["airflow", "hooks", "http_hook", "HttpHook"] => Replacement::ProviderName{
+            name: "airflow.providers.http.hooks.http.HttpHook",
+            provider: "http",
+            version: "1.0.0"
+        },
+        ["airflow", "operators", "http_operator", "SimpleHttpOperator"] => Replacement::ProviderName{
+            name: "airflow.providers.http.operators.http.SimpleHttpOperator",
+            provider: "http",
+            version: "1.0.0"
+        },
+        ["airflow", "sensors", "http_sensor", "HttpSensor"] => Replacement::ProviderName{
+            name: "airflow.providers.http.sensors.http.HttpSensor",
+            provider: "http",
+            version: "1.0.0"
+        },
+
+        // apache-airflow-providers-jdbc
+        ["airflow", "hooks", "jdbc_hook", "JdbcHook"] => Replacement::ProviderName{
+            name: "airflow.providers.jdbc.hooks.jdbc.JdbcHook",
+            provider: "jdbc",
+            version: "1.0.0"
+        },
+        ["airflow", "hooks", "jdbc_hook", "jaydebeapi"] => Replacement::ProviderName{
+            name: "airflow.providers.jdbc.hooks.jdbc.jaydebeapi",
+            provider: "jdbc",
+            version: "1.0.0"
+        },
+        ["airflow", "operators", "jdbc_operator", "JdbcOperator"] => Replacement::ProviderName{
+            name: "airflow.providers.jdbc.operators.jdbc.JdbcOperator",
+            provider: "jdbc",
+            version: "1.0.0"
+        },
+
+        // apache-airflow-providers-cncf-kubernetes
+        ["airflow", "executors", "kubernetes_executor_types", "ALL_NAMESPACES"] => Replacement::ImportPathMoved{
+                original_path: "airflow.executors.kubernetes_executor_types.ALL_NAMESPACES",
+                new_path: "airflow.providers.cncf.kubernetes.executors.kubernetes_executor_types.ALL_NAMESPACES",
+            provider: "cncf-kubernetes",
+            version: "7.4.0"
+        },
+        ["airflow", "executors", "kubernetes_executor_types", "POD_EXECUTOR_DONE_KEY"] => Replacement::ImportPathMoved{
+                original_path: "airflow.executors.kubernetes_executor_types.POD_EXECUTOR_DONE_KEY",
+                new_path: "airflow.providers.cncf.kubernetes.executors.kubernetes_executor_types.POD_EXECUTOR_DONE_KEY",
+            provider: "cncf-kubernetes",
+            version: "7.4.0"
+        },
+        ["airflow", "kubernetes", "kubernetes_helper_functions", "add_pod_suffix"] => Replacement::ProviderName{
+            name: "airflow.providers.cncf.kubernetes.kubernetes_helper_functions.add_pod_suffix",
+            provider: "cncf-kubernetes",
+            version: "7.4.0"
+        },
+        ["airflow", "kubernetes", "kubernetes_helper_functions", "annotations_for_logging_task_metadata"] => Replacement::ProviderName{
+            name: "airflow.providers.cncf.kubernetes.kubernetes_helper_functions.annotations_for_logging_task_metadata",
+            provider: "cncf-kubernetes",
+            version: "7.4.0"
+        },
+        ["airflow", "kubernetes", "kubernetes_helper_functions", "annotations_to_key"] => Replacement::ProviderName{
+            name: "airflow.providers.cncf.kubernetes.kubernetes_helper_functions.annotations_to_key",
+            provider: "cncf-kubernetes",
+            version: "7.4.0"
+        },
+        ["airflow", "kubernetes", "kubernetes_helper_functions", "create_pod_id"] => Replacement::ProviderName{
+            name: "airflow.providers.cncf.kubernetes.kubernetes_helper_functions.create_pod_id",
+            provider: "cncf-kubernetes",
+            version: "7.4.0"
+        },
+        ["airflow", "kubernetes", "kubernetes_helper_functions", "get_logs_task_metadata"] => Replacement::ProviderName{
+            name: "airflow.providers.cncf.kubernetes.kubernetes_helper_functions.get_logs_task_metadata",
+            provider: "cncf-kubernetes",
+            version: "7.4.0"
+        },
+        ["airflow", "kubernetes", "kubernetes_helper_functions", "rand_str"] => Replacement::ProviderName{
+            name: "airflow.providers.cncf.kubernetes.kubernetes_helper_functions.rand_str",
+            provider: "cncf-kubernetes",
+            version: "7.4.0"
+        },
+        ["airflow", "kubernetes", "pod", "Port"] => Replacement::ProviderName{
+            name: "kubernetes.client.models.V1ContainerPort",
+            provider: "cncf-kubernetes",
+            version: "7.4.0"
+        },
+        ["airflow", "kubernetes", "pod", "Resources"] => Replacement::ProviderName{
+            name: "kubernetes.client.models.V1ResourceRequirements",
+            provider: "cncf-kubernetes",
+            version: "7.4.0"
+        },
+        ["airflow", "kubernetes", "pod_launcher", "PodLauncher"] => Replacement::ProviderName{
+            name: "airflow.providers.cncf.kubernetes.pod_launcher.PodLauncher",
+            provider: "cncf-kubernetes",
+            version: "7.4.0"
+        },
+        ["airflow", "kubernetes", "pod_launcher", "PodStatus"] => Replacement::ProviderName{
+            name: "airflow.providers.cncf.kubernetes.pod_launcher.PodStatus",
+            provider: "cncf-kubernetes",
+            version: "7.4.0"
+        },
+        ["airflow", "kubernetes", "pod_launcher_deprecated", "PodLauncher"] => Replacement::ProviderName{
+            name: "airflow.providers.cncf.kubernetes.pod_launcher_deprecated.PodLauncher",
+            provider: "cncf-kubernetes",
+            version: "7.4.0"
+        },
+        ["airflow", "kubernetes", "pod_launcher_deprecated", "PodStatus"] => Replacement::ProviderName{
+            name: "airflow.providers.cncf.kubernetes.pod_launcher_deprecated.PodStatus",
+            provider: "cncf-kubernetes",
+            version: "7.4.0"
+        },
+        ["airflow", "kubernetes", "pod_launcher_deprecated", "get_kube_client"] => Replacement::ProviderName{
+            name: "airflow.providers.cncf.kubernetes.kube_client.get_kube_client",
+            provider: "cncf-kubernetes",
+            version: "7.4.0"
+        },
+        ["airflow", "kubernetes", "pod_launcher_deprecated", "PodDefaults"] => Replacement::ProviderName{
+            name: "airflow.providers.cncf.kubernetes.pod_generator_deprecated.PodDefaults",
+            provider: "cncf-kubernetes",
+            version: "7.4.0"
+        },
+        ["airflow", "kubernetes", "pod_runtime_info_env", "PodRuntimeInfoEnv"] => Replacement::ProviderName{
+            name: "kubernetes.client.models.V1EnvVar",
+            provider: "cncf-kubernetes",
+            version: "7.4.0"
+        },
+        ["airflow", "kubernetes", "volume", "Volume"] => Replacement::ProviderName{
+            name: "kubernetes.client.models.V1Volume",
+            provider: "cncf-kubernetes",
+            version: "7.4.0"
+        },
+        ["airflow", "kubernetes", "volume_mount", "VolumeMount"] => Replacement::ProviderName{
+            name: "kubernetes.client.models.V1VolumeMount",
+            provider: "cncf-kubernetes",
+            version: "7.4.0"
+        },
+        ["airflow", "kubernetes", "k8s_model", "K8SModel"] => Replacement::ProviderName{
+            name: "airflow.providers.cncf.kubernetes.k8s_model.K8SModel",
+            provider: "cncf-kubernetes",
+            version: "7.4.0"
+        },
+        ["airflow", "kubernetes", "k8s_model", "append_to_pod"] => Replacement::ProviderName{
+            name: "airflow.providers.cncf.kubernetes.k8s_model.append_to_pod",
+            provider: "cncf-kubernetes",
+            version: "7.4.0"
+        },
+        ["airflow", "kubernetes", "kube_client", "_disable_verify_ssl"] => Replacement::ProviderName{
+            name: "airflow.kubernetes.airflow.providers.cncf.kubernetes.kube_client._disable_verify_ssl",
+            provider: "cncf-kubernetes",
+            version: "7.4.0"
+        },
+        ["airflow", "kubernetes", "kube_client", "_enable_tcp_keepalive"] => Replacement::ProviderName{
+            name: "airflow.kubernetes.airflow.providers.cncf.kubernetes.kube_client._enable_tcp_keepalive",
+            provider: "cncf-kubernetes",
+            version: "7.4.0"
+        },
+        ["airflow", "kubernetes", "kube_client", "get_kube_client"] => Replacement::ProviderName{
+            name: "airflow.kubernetes.airflow.providers.cncf.kubernetes.kube_client.get_kube_client",
+            provider: "cncf-kubernetes",
+            version: "7.4.0"
+        },
+        ["airflow", "kubernetes", "pod_generator", "datetime_to_label_safe_datestring"] => Replacement::ProviderName{
+            name: "airflow.providers.cncf.kubernetes.pod_generator.datetime_to_label_safe_datestring",
+            provider: "cncf-kubernetes",
+            version: "7.4.0"
+        },
+        ["airflow", "kubernetes", "pod_generator", "extend_object_field"] => Replacement::ProviderName{
+            name: "airflow.kubernetes.airflow.providers.cncf.kubernetes.pod_generator.extend_object_field",
+            provider: "cncf-kubernetes",
+            version: "7.4.0"
+        },
+        ["airflow", "kubernetes", "pod_generator", "label_safe_datestring_to_datetime"] => Replacement::ProviderName{
+            name: "airflow.providers.cncf.kubernetes.pod_generator.label_safe_datestring_to_datetime",
+            provider: "cncf-kubernetes",
+            version: "7.4.0"
+        },
+        ["airflow", "kubernetes", "pod_generator", "make_safe_label_value"] => Replacement::ProviderName{
+            name: "airflow.providers.cncf.kubernetes.pod_generator.make_safe_label_value",
+            provider: "cncf-kubernetes",
+            version: "7.4.0"
+        },
+        ["airflow", "kubernetes", "pod_generator", "merge_objects"] => Replacement::ProviderName{
+            name: "airflow.providers.cncf.kubernetes.pod_generator.merge_objects",
+            provider: "cncf-kubernetes",
+            version: "7.4.0"
+        },
+        ["airflow", "kubernetes", "pod_generator", "PodGenerator"] => Replacement::ProviderName{
+            name: "airflow.providers.cncf.kubernetes.pod_generator.PodGenerator",
+            provider: "cncf-kubernetes",
+            version: "7.4.0"
+        },
+        ["airflow", "kubernetes", "pod_generator_deprecated", "make_safe_label_value"] => Replacement::ProviderName{
+            name: "airflow.providers.cncf.kubernetes.pod_generator_deprecated.make_safe_label_value",
+            provider: "cncf-kubernetes",
+            version: "7.4.0"
+        },
+        ["airflow", "kubernetes", "pod_generator_deprecated", "PodDefaults"] => Replacement::ProviderName{
+            name: "airflow.providers.cncf.kubernetes.pod_generator_deprecated.PodDefaults",
+            provider: "cncf-kubernetes",
+            version: "7.4.0"
+        },
+        ["airflow", "kubernetes", "pod_generator_deprecated", "PodGenerator"] => Replacement::ProviderName{
+            name: "airflow.providers.cncf.kubernetes.pod_generator_deprecated.PodGenerator",
+            provider: "cncf-kubernetes",
+            version: "7.4.0"
+        },
+        ["airflow", "kubernetes", "secret", "Secret"] => Replacement::ProviderName{
+            name: "airflow.providers.cncf.kubernetes.secret.Secret",
+            provider: "cncf-kubernetes",
+            version: "7.4.0"
+        },
+        ["airflow", "kubernetes", "pod_generator", "PodGeneratorDeprecated"] => Replacement::ProviderName{
+            name: "airflow.providers.cncf.kubernetes.pod_generator.PodGenerator",
+            provider: "cncf-kubernetes",
+            version: "7.4.0"
+        },
+        ["airflow", "kubernetes", "pod_generator", "PodDefaults"] => Replacement::ProviderName{
+            name: "airflow.providers.cncf.kubernetes.pod_generator_deprecated.PodDefaults",
+            provider: "cncf-kubernetes",
+            version: "7.4.0"
+        },
+        ["airflow", "kubernetes", "pod_generator", "add_pod_suffix"] => Replacement::ProviderName{
+            name: "airflow.providers.cncf.kubernetes.kubernetes_helper_functions.add_pod_suffix",
+            provider: "cncf-kubernetes",
+            version: "7.4.0"
+        },
+        ["airflow", "kubernetes", "pod_generator", "rand_str"] => Replacement::ProviderName{
+            name: "airflow.providers.cncf.kubernetes.kubernetes_helper_functions.rand_str",
+            provider: "cncf-kubernetes",
+            version: "7.4.0"
+        },
+        ["airflow", "kubernetes", "secret", "K8SModel"] => Replacement::ProviderName{
+            name: "airflow.providers.cncf.kubernetes.k8s_model.K8SModel",
+            provider: "cncf-kubernetes",
+            version: "7.4.0"
+        },
+
+        // apache-airflow-providers-microsoft-mssql
+        ["airflow", "hooks", "mssql_hook", "MsSqlHook"] => Replacement::ProviderName{
+            name: "airflow.providers.microsoft.mssql.hooks.mssql.MsSqlHook",
+            provider: "microsoft-mssql",
+            version: "1.0.0"
+        },
+        ["airflow", "operators", "mssql_operator", "MsSqlOperator"] => Replacement::ProviderName{
+            name: "airflow.providers.microsoft.mssql.operators.mssql.MsSqlOperator",
+            provider: "microsoft-mssql",
+            version: "1.0.0"
+        },
+
+        // apache-airflow-providers-mysql
+        ["airflow", "hooks", "mysql_hook", "MySqlHook"] => Replacement::ProviderName{
+            name: "airflow.providers.mysql.hooks.mysql.MySqlHook",
+            provider: "mysql",
+            version: "1.0.0"
+        },
+        ["airflow", "operators", "mysql_operator", "MySqlOperator"] => Replacement::ProviderName{
+            name: "airflow.providers.mysql.operators.mysql.MySqlOperator",
+            provider: "mysql",
+            version: "1.0.0"
+        },
+        ["airflow", "operators", "presto_to_mysql", "PrestoToMySqlOperator"] => Replacement::ProviderName{
+            name: "airflow.providers.mysql.transfers.presto_to_mysql.PrestoToMySqlOperator",
+            provider: "mysql",
+            version: "1.0.0"
+        },
+        ["airflow", "operators", "presto_to_mysql", "PrestoToMySqlTransfer"] => Replacement::ProviderName{
+            name: "airflow.providers.mysql.transfers.presto_to_mysql.PrestoToMySqlOperator",
+            provider: "mysql",
+            version: "1.0.0"
+        },
+
+        // apache-airflow-providers-oracle
+        ["airflow", "hooks", "oracle_hook", "OracleHook"] => Replacement::ProviderName{
+            name: "airflow.providers.oracle.hooks.oracle.OracleHook",
+            provider: "oracle",
+            version: "1.0.0"
+        },
+        ["airflow", "operators", "oracle_operator", "OracleOperator"] => Replacement::ProviderName{
+            name: "airflow.providers.oracle.operators.oracle.OracleOperator",
+            provider: "oracle",
+            version: "1.0.0"
+        },
+
+        // apache-airflow-providers-papermill
+        ["airflow", "operators", "papermill_operator", "PapermillOperator"] => Replacement::ProviderName{
+            name: "airflow.providers.papermill.operators.papermill.PapermillOperator",
+            provider: "papermill",
+            version: "1.0.0"
+        },
+
+        // apache-airflow-providers-apache-pig
+        ["airflow", "hooks", "pig_hook", "PigCliHook"] => Replacement::ProviderName{
+            name: "airflow.providers.apache.pig.hooks.pig.PigCliHook",
+            provider: "apache-pig",
+            version: "1.0.0"
+        },
+        ["airflow", "operators", "pig_operator", "PigOperator"] => Replacement::ProviderName{
+            name: "airflow.providers.apache.pig.operators.pig.PigOperator",
+            provider: "apache-pig",
+            version: "1.0.0"
+        },
+
+        // apache-airflow-providers-postgres
+        ["airflow", "hooks", "postgres_hook", "PostgresHook"] => Replacement::ProviderName{
+            name: "airflow.providers.postgres.hooks.postgres.PostgresHook",
+            provider: "postgres",
+            version: "1.0.0"
+        },
+        ["airflow", "operators", "postgres_operator", "Mapping"] => Replacement::ProviderName{
+            name: "airflow.providers.postgres.operators.postgres.Mapping",
+            provider: "postgres",
+            version: "1.0.0"
+        },
+
+        ["airflow", "operators", "postgres_operator", "PostgresOperator"] => Replacement::ProviderName{
+            name: "airflow.providers.postgres.operators.postgres.PostgresOperator",
+            provider: "postgres",
+            version: "1.0.0"
+        },
+
+        // apache-airflow-providers-presto
+        ["airflow", "hooks", "presto_hook", "PrestoHook"] => Replacement::ProviderName{
+            name: "airflow.providers.presto.hooks.presto.PrestoHook",
+            provider: "presto",
+            version: "1.0.0"
+        },
+
+        // apache-airflow-providers-samba
+        ["airflow", "hooks", "samba_hook", "SambaHook"] => Replacement::ProviderName{
+            name: "airflow.providers.samba.hooks.samba.SambaHook",
+            provider: "samba",
+            version: "1.0.0"
+        },
+
+        // apache-airflow-providers-slack
+        ["airflow", "hooks", "slack_hook", "SlackHook"] => Replacement::ProviderName{
+            name: "airflow.providers.slack.hooks.slack.SlackHook",
+            provider: "slack",
+            version: "1.0.0"
+        },
+        ["airflow", "operators", "slack_operator", "SlackAPIOperator"] => Replacement::ProviderName{
+            name: "airflow.providers.slack.operators.slack.SlackAPIOperator",
+            provider: "slack",
+            version: "1.0.0"
+        },
+        ["airflow", "operators", "slack_operator", "SlackAPIPostOperator"] => Replacement::ProviderName{
+            name: "airflow.providers.slack.operators.slack.SlackAPIPostOperator",
+            provider: "slack",
+            version: "1.0.0"
+        },
+
+        // apache-airflow-providers-sqlite
+        ["airflow", "hooks", "sqlite_hook", "SqliteHook"] => Replacement::ProviderName{
+            name: "airflow.providers.sqlite.hooks.sqlite.SqliteHook",
+            provider: "sqlite",
+            version: "1.0.0"
+        },
+        ["airflow", "operators", "sqlite_operator", "SqliteOperator"] => Replacement::ProviderName{
+            name: "airflow.providers.sqlite.operators.sqlite.SqliteOperator",
+            provider: "sqlite",
+            version: "1.0.0"
+        },
+
+        // apache-airflow-providers-zendesk
+        ["airflow", "hooks", "zendesk_hook", "ZendeskHook"] =>
+            Replacement::ProviderName{
+            name: "airflow.providers.zendesk.hooks.zendesk.ZendeskHook",
+            provider: "zendesk",
+            version: "1.0.0"
+        },
+        _ => return,
+    };
+    checker.diagnostics.push(Diagnostic::new(
+        Airflow3MovedToProvider {
+            deprecated: qualified_name.to_string(),
+            replacement,
+        },
+        ranged.range(),
+    ));
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Refactor airflow rule logic like https://github.com/astral-sh/ruff/commit/86bdc2e7b1b3b6b8630a898fdcfc1071d5f7cb7d

## Test Plan

<!-- How was it tested? -->

No functionality change. Existing test cases work as it was
