### PR TITLE
[`ruff`] Fix false positive on global keyword (`RUF052`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/ruff/RUF052.py
+++ b/crates/ruff_linter/resources/test/fixtures/ruff/RUF052.py
@@ -1,4 +1,6 @@
+##############
 # Correct
+##############
 
 for _ in range(5):
     pass
@@ -37,6 +39,17 @@ def fun():
     _x = "reassigned global"
     return _x
 
+# (we had a false positive when a global var is used like this in 2 functions)
+_num: int
+
+def set_num():
+    global _num
+    _num = 1
+
+def print_num():
+    print(_num)
+
+
 class _ValidClass:
     pass
 
@@ -70,7 +83,9 @@ def fun(x):
         return ___
     return x
 
+###########
 # Incorrect
+###########
 
 class Class_:
     def fun(self):

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF052_RUF052.py.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF052_RUF052.py.snap
@@ -1,367 +1,368 @@
 ---
 source: crates/ruff_linter/src/rules/ruff/mod.rs
+snapshot_kind: text
 ---
-RUF052.py:77:9: RUF052 [*] Local dummy variable `_var` is accessed
+RUF052.py:92:9: RUF052 [*] Local dummy variable `_var` is accessed
    |
-75 | class Class_:
-76 |     def fun(self):
-77 |         _var = "method variable" # [RUF052]
+90 | class Class_:
+91 |     def fun(self):
+92 |         _var = "method variable" # [RUF052]
    |         ^^^^ RUF052
-78 |         return _var
+93 |         return _var
    |
    = help: Remove leading underscores
 
 ℹ Unsafe fix
-74 74 | 
-75 75 | class Class_:
-76 76 |     def fun(self):
-77    |-        _var = "method variable" # [RUF052]
-78    |-        return _var
-   77 |+        var = "method variable" # [RUF052]
-   78 |+        return var
-79 79 | 
-80 80 | def fun(_var): # parameters are ignored
-81 81 |     return _var
+89 89 | 
+90 90 | class Class_:
+91 91 |     def fun(self):
+92    |-        _var = "method variable" # [RUF052]
+93    |-        return _var
+   92 |+        var = "method variable" # [RUF052]
+   93 |+        return var
+94 94 | 
+95 95 | def fun(_var): # parameters are ignored
+96 96 |     return _var
 
-RUF052.py:84:5: RUF052 [*] Local dummy variable `_list` is accessed
-   |
-83 | def fun():
-84 |     _list = "built-in" # [RUF052]
-   |     ^^^^^ RUF052
-85 |     return _list
-   |
-   = help: Prefer using trailing underscores to avoid shadowing a built-in
-
-ℹ Unsafe fix
-81 81 |     return _var
-82 82 | 
-83 83 | def fun():
-84    |-    _list = "built-in" # [RUF052]
-85    |-    return _list
-   84 |+    list_ = "built-in" # [RUF052]
-   85 |+    return list_
-86 86 | 
-87 87 | x = "global"
-88 88 | 
-
-RUF052.py:91:5: RUF052 [*] Local dummy variable `_x` is accessed
-   |
-89 | def fun():
-90 |     global x
-91 |     _x = "shadows global" # [RUF052]
-   |     ^^ RUF052
-92 |     return _x
-   |
-   = help: Prefer using trailing underscores to avoid shadowing a variable
-
-ℹ Unsafe fix
-88 88 | 
-89 89 | def fun():
-90 90 |     global x
-91    |-    _x = "shadows global" # [RUF052]
-92    |-    return _x
-   91 |+    x_ = "shadows global" # [RUF052]
-   92 |+    return x_
-93 93 | 
-94 94 | def foo():
-95 95 |   x = "outer"
-
-RUF052.py:98:5: RUF052 [*] Local dummy variable `_x` is accessed
+RUF052.py:99:5: RUF052 [*] Local dummy variable `_list` is accessed
     |
- 96 |   def bar():
- 97 |     nonlocal x
- 98 |     _x = "shadows nonlocal" # [RUF052]
+ 98 | def fun():
+ 99 |     _list = "built-in" # [RUF052]
+    |     ^^^^^ RUF052
+100 |     return _list
+    |
+    = help: Prefer using trailing underscores to avoid shadowing a built-in
+
+ℹ Unsafe fix
+96  96  |     return _var
+97  97  | 
+98  98  | def fun():
+99      |-    _list = "built-in" # [RUF052]
+100     |-    return _list
+    99  |+    list_ = "built-in" # [RUF052]
+    100 |+    return list_
+101 101 | 
+102 102 | x = "global"
+103 103 | 
+
+RUF052.py:106:5: RUF052 [*] Local dummy variable `_x` is accessed
+    |
+104 | def fun():
+105 |     global x
+106 |     _x = "shadows global" # [RUF052]
     |     ^^ RUF052
- 99 |     return _x
-100 |   bar()
+107 |     return _x
     |
     = help: Prefer using trailing underscores to avoid shadowing a variable
 
 ℹ Unsafe fix
-95  95  |   x = "outer"
-96  96  |   def bar():
-97  97  |     nonlocal x
-98      |-    _x = "shadows nonlocal" # [RUF052]
-99      |-    return _x
-    98  |+    x_ = "shadows nonlocal" # [RUF052]
-    99  |+    return x_
-100 100 |   bar()
-101 101 |   return x
-102 102 | 
-
-RUF052.py:105:5: RUF052 [*] Local dummy variable `_x` is accessed
-    |
-103 | def fun():
-104 |     x = "local"
-105 |     _x = "shadows local" # [RUF052]
-    |     ^^ RUF052
-106 |     return _x
-    |
-    = help: Prefer using trailing underscores to avoid shadowing a variable
-
-ℹ Unsafe fix
-102 102 | 
-103 103 | def fun():
-104 104 |     x = "local"
-105     |-    _x = "shadows local" # [RUF052]
-106     |-    return _x
-    105 |+    x_ = "shadows local" # [RUF052]
-    106 |+    return x_
-107 107 | 
+103 103 | 
+104 104 | def fun():
+105 105 |     global x
+106     |-    _x = "shadows global" # [RUF052]
+107     |-    return _x
+    106 |+    x_ = "shadows global" # [RUF052]
+    107 |+    return x_
 108 108 | 
-109 109 | GLOBAL_1 = "global 1"
+109 109 | def foo():
+110 110 |   x = "outer"
 
-RUF052.py:113:5: RUF052 Local dummy variable `_GLOBAL_1` is accessed
+RUF052.py:113:5: RUF052 [*] Local dummy variable `_x` is accessed
     |
-112 | def unfixables():
-113 |     _GLOBAL_1 = "foo"
+111 |   def bar():
+112 |     nonlocal x
+113 |     _x = "shadows nonlocal" # [RUF052]
+    |     ^^ RUF052
+114 |     return _x
+115 |   bar()
+    |
+    = help: Prefer using trailing underscores to avoid shadowing a variable
+
+ℹ Unsafe fix
+110 110 |   x = "outer"
+111 111 |   def bar():
+112 112 |     nonlocal x
+113     |-    _x = "shadows nonlocal" # [RUF052]
+114     |-    return _x
+    113 |+    x_ = "shadows nonlocal" # [RUF052]
+    114 |+    return x_
+115 115 |   bar()
+116 116 |   return x
+117 117 | 
+
+RUF052.py:120:5: RUF052 [*] Local dummy variable `_x` is accessed
+    |
+118 | def fun():
+119 |     x = "local"
+120 |     _x = "shadows local" # [RUF052]
+    |     ^^ RUF052
+121 |     return _x
+    |
+    = help: Prefer using trailing underscores to avoid shadowing a variable
+
+ℹ Unsafe fix
+117 117 | 
+118 118 | def fun():
+119 119 |     x = "local"
+120     |-    _x = "shadows local" # [RUF052]
+121     |-    return _x
+    120 |+    x_ = "shadows local" # [RUF052]
+    121 |+    return x_
+122 122 | 
+123 123 | 
+124 124 | GLOBAL_1 = "global 1"
+
+RUF052.py:128:5: RUF052 Local dummy variable `_GLOBAL_1` is accessed
+    |
+127 | def unfixables():
+128 |     _GLOBAL_1 = "foo"
     |     ^^^^^^^^^ RUF052
-114 |     # unfixable because the rename would shadow a global variable
-115 |     print(_GLOBAL_1)  # [RUF052]
+129 |     # unfixable because the rename would shadow a global variable
+130 |     print(_GLOBAL_1)  # [RUF052]
     |
     = help: Prefer using trailing underscores to avoid shadowing a variable
 
-RUF052.py:121:5: RUF052 Local dummy variable `_local` is accessed
+RUF052.py:136:5: RUF052 Local dummy variable `_local` is accessed
     |
-120 |     # unfixable because the rename would shadow a local variable
-121 |     _local = "local3"  # [RUF052]
+135 |     # unfixable because the rename would shadow a local variable
+136 |     _local = "local3"  # [RUF052]
     |     ^^^^^^ RUF052
-122 |     print(_local)
+137 |     print(_local)
     |
     = help: Prefer using trailing underscores to avoid shadowing a variable
 
-RUF052.py:125:9: RUF052 Local dummy variable `_GLOBAL_1` is accessed
+RUF052.py:140:9: RUF052 Local dummy variable `_GLOBAL_1` is accessed
     |
-124 |     def nested():
-125 |         _GLOBAL_1 = "foo"
+139 |     def nested():
+140 |         _GLOBAL_1 = "foo"
     |         ^^^^^^^^^ RUF052
-126 |         # unfixable because the rename would shadow a global variable
-127 |         print(_GLOBAL_1)  # [RUF052]
+141 |         # unfixable because the rename would shadow a global variable
+142 |         print(_GLOBAL_1)  # [RUF052]
     |
     = help: Prefer using trailing underscores to avoid shadowing a variable
 
-RUF052.py:130:9: RUF052 Local dummy variable `_local` is accessed
+RUF052.py:145:9: RUF052 Local dummy variable `_local` is accessed
     |
-129 |         # unfixable because the rename would shadow a variable from the outer function
-130 |         _local = "local4"
+144 |         # unfixable because the rename would shadow a variable from the outer function
+145 |         _local = "local4"
     |         ^^^^^^ RUF052
-131 |         print(_local)
+146 |         print(_local)
     |
     = help: Prefer using trailing underscores to avoid shadowing a variable
 
-RUF052.py:138:5: RUF052 [*] Local dummy variable `_P` is accessed
+RUF052.py:153:5: RUF052 [*] Local dummy variable `_P` is accessed
     |
-136 |     from collections import namedtuple
-137 | 
-138 |     _P = ParamSpec("_P")
+151 |     from collections import namedtuple
+152 | 
+153 |     _P = ParamSpec("_P")
     |     ^^ RUF052
-139 |     _T = TypeVar(name="_T", covariant=True, bound=int|str)
-140 |     _NT = NamedTuple("_NT", [("foo", int)])
+154 |     _T = TypeVar(name="_T", covariant=True, bound=int|str)
+155 |     _NT = NamedTuple("_NT", [("foo", int)])
     |
     = help: Remove leading underscores
 
 ℹ Unsafe fix
-135 135 |     from enum import Enum
-136 136 |     from collections import namedtuple
-137 137 | 
-138     |-    _P = ParamSpec("_P")
-    138 |+    P = ParamSpec("P")
-139 139 |     _T = TypeVar(name="_T", covariant=True, bound=int|str)
-140 140 |     _NT = NamedTuple("_NT", [("foo", int)])
-141 141 |     _E = Enum("_E", ["a", "b", "c"])
+150 150 |     from enum import Enum
+151 151 |     from collections import namedtuple
+152 152 | 
+153     |-    _P = ParamSpec("_P")
+    153 |+    P = ParamSpec("P")
+154 154 |     _T = TypeVar(name="_T", covariant=True, bound=int|str)
+155 155 |     _NT = NamedTuple("_NT", [("foo", int)])
+156 156 |     _E = Enum("_E", ["a", "b", "c"])
 --------------------------------------------------------------------------------
-144 144 |     _DynamicClass = type("_DynamicClass", (), {})
-145 145 |     _NotADynamicClass = type("_NotADynamicClass")
-146 146 | 
-147     |-    print(_T, _P, _NT, _E, _NT2, _NT3, _DynamicClass, _NotADynamicClass)
-    147 |+    print(_T, P, _NT, _E, _NT2, _NT3, _DynamicClass, _NotADynamicClass)
-148 148 | 
-149 149 | # Do not emit diagnostic if parameter is private
-150 150 | # even if it is later shadowed in the body of the function
+159 159 |     _DynamicClass = type("_DynamicClass", (), {})
+160 160 |     _NotADynamicClass = type("_NotADynamicClass")
+161 161 | 
+162     |-    print(_T, _P, _NT, _E, _NT2, _NT3, _DynamicClass, _NotADynamicClass)
+    162 |+    print(_T, P, _NT, _E, _NT2, _NT3, _DynamicClass, _NotADynamicClass)
+163 163 | 
+164 164 | # Do not emit diagnostic if parameter is private
+165 165 | # even if it is later shadowed in the body of the function
 
-RUF052.py:139:5: RUF052 [*] Local dummy variable `_T` is accessed
+RUF052.py:154:5: RUF052 [*] Local dummy variable `_T` is accessed
     |
-138 |     _P = ParamSpec("_P")
-139 |     _T = TypeVar(name="_T", covariant=True, bound=int|str)
+153 |     _P = ParamSpec("_P")
+154 |     _T = TypeVar(name="_T", covariant=True, bound=int|str)
     |     ^^ RUF052
-140 |     _NT = NamedTuple("_NT", [("foo", int)])
-141 |     _E = Enum("_E", ["a", "b", "c"])
+155 |     _NT = NamedTuple("_NT", [("foo", int)])
+156 |     _E = Enum("_E", ["a", "b", "c"])
     |
     = help: Remove leading underscores
 
 ℹ Unsafe fix
-136 136 |     from collections import namedtuple
-137 137 | 
-138 138 |     _P = ParamSpec("_P")
-139     |-    _T = TypeVar(name="_T", covariant=True, bound=int|str)
-    139 |+    T = TypeVar(name="T", covariant=True, bound=int|str)
-140 140 |     _NT = NamedTuple("_NT", [("foo", int)])
-141 141 |     _E = Enum("_E", ["a", "b", "c"])
-142 142 |     _NT2 = namedtuple("_NT2", ['x', 'y', 'z'])
+151 151 |     from collections import namedtuple
+152 152 | 
+153 153 |     _P = ParamSpec("_P")
+154     |-    _T = TypeVar(name="_T", covariant=True, bound=int|str)
+    154 |+    T = TypeVar(name="T", covariant=True, bound=int|str)
+155 155 |     _NT = NamedTuple("_NT", [("foo", int)])
+156 156 |     _E = Enum("_E", ["a", "b", "c"])
+157 157 |     _NT2 = namedtuple("_NT2", ['x', 'y', 'z'])
 --------------------------------------------------------------------------------
-144 144 |     _DynamicClass = type("_DynamicClass", (), {})
-145 145 |     _NotADynamicClass = type("_NotADynamicClass")
-146 146 | 
-147     |-    print(_T, _P, _NT, _E, _NT2, _NT3, _DynamicClass, _NotADynamicClass)
-    147 |+    print(T, _P, _NT, _E, _NT2, _NT3, _DynamicClass, _NotADynamicClass)
-148 148 | 
-149 149 | # Do not emit diagnostic if parameter is private
-150 150 | # even if it is later shadowed in the body of the function
+159 159 |     _DynamicClass = type("_DynamicClass", (), {})
+160 160 |     _NotADynamicClass = type("_NotADynamicClass")
+161 161 | 
+162     |-    print(_T, _P, _NT, _E, _NT2, _NT3, _DynamicClass, _NotADynamicClass)
+    162 |+    print(T, _P, _NT, _E, _NT2, _NT3, _DynamicClass, _NotADynamicClass)
+163 163 | 
+164 164 | # Do not emit diagnostic if parameter is private
+165 165 | # even if it is later shadowed in the body of the function
 
-RUF052.py:140:5: RUF052 [*] Local dummy variable `_NT` is accessed
+RUF052.py:155:5: RUF052 [*] Local dummy variable `_NT` is accessed
     |
-138 |     _P = ParamSpec("_P")
-139 |     _T = TypeVar(name="_T", covariant=True, bound=int|str)
-140 |     _NT = NamedTuple("_NT", [("foo", int)])
+153 |     _P = ParamSpec("_P")
+154 |     _T = TypeVar(name="_T", covariant=True, bound=int|str)
+155 |     _NT = NamedTuple("_NT", [("foo", int)])
     |     ^^^ RUF052
-141 |     _E = Enum("_E", ["a", "b", "c"])
-142 |     _NT2 = namedtuple("_NT2", ['x', 'y', 'z'])
+156 |     _E = Enum("_E", ["a", "b", "c"])
+157 |     _NT2 = namedtuple("_NT2", ['x', 'y', 'z'])
     |
     = help: Remove leading underscores
 
 ℹ Unsafe fix
-137 137 | 
-138 138 |     _P = ParamSpec("_P")
-139 139 |     _T = TypeVar(name="_T", covariant=True, bound=int|str)
-140     |-    _NT = NamedTuple("_NT", [("foo", int)])
-    140 |+    NT = NamedTuple("NT", [("foo", int)])
-141 141 |     _E = Enum("_E", ["a", "b", "c"])
-142 142 |     _NT2 = namedtuple("_NT2", ['x', 'y', 'z'])
-143 143 |     _NT3 = namedtuple(typename="_NT3", field_names=['x', 'y', 'z'])
-144 144 |     _DynamicClass = type("_DynamicClass", (), {})
-145 145 |     _NotADynamicClass = type("_NotADynamicClass")
-146 146 | 
-147     |-    print(_T, _P, _NT, _E, _NT2, _NT3, _DynamicClass, _NotADynamicClass)
-    147 |+    print(_T, _P, NT, _E, _NT2, _NT3, _DynamicClass, _NotADynamicClass)
-148 148 | 
-149 149 | # Do not emit diagnostic if parameter is private
-150 150 | # even if it is later shadowed in the body of the function
+152 152 | 
+153 153 |     _P = ParamSpec("_P")
+154 154 |     _T = TypeVar(name="_T", covariant=True, bound=int|str)
+155     |-    _NT = NamedTuple("_NT", [("foo", int)])
+    155 |+    NT = NamedTuple("NT", [("foo", int)])
+156 156 |     _E = Enum("_E", ["a", "b", "c"])
+157 157 |     _NT2 = namedtuple("_NT2", ['x', 'y', 'z'])
+158 158 |     _NT3 = namedtuple(typename="_NT3", field_names=['x', 'y', 'z'])
+159 159 |     _DynamicClass = type("_DynamicClass", (), {})
+160 160 |     _NotADynamicClass = type("_NotADynamicClass")
+161 161 | 
+162     |-    print(_T, _P, _NT, _E, _NT2, _NT3, _DynamicClass, _NotADynamicClass)
+    162 |+    print(_T, _P, NT, _E, _NT2, _NT3, _DynamicClass, _NotADynamicClass)
+163 163 | 
+164 164 | # Do not emit diagnostic if parameter is private
+165 165 | # even if it is later shadowed in the body of the function
 
-RUF052.py:141:5: RUF052 [*] Local dummy variable `_E` is accessed
+RUF052.py:156:5: RUF052 [*] Local dummy variable `_E` is accessed
     |
-139 |     _T = TypeVar(name="_T", covariant=True, bound=int|str)
-140 |     _NT = NamedTuple("_NT", [("foo", int)])
-141 |     _E = Enum("_E", ["a", "b", "c"])
+154 |     _T = TypeVar(name="_T", covariant=True, bound=int|str)
+155 |     _NT = NamedTuple("_NT", [("foo", int)])
+156 |     _E = Enum("_E", ["a", "b", "c"])
     |     ^^ RUF052
-142 |     _NT2 = namedtuple("_NT2", ['x', 'y', 'z'])
-143 |     _NT3 = namedtuple(typename="_NT3", field_names=['x', 'y', 'z'])
+157 |     _NT2 = namedtuple("_NT2", ['x', 'y', 'z'])
+158 |     _NT3 = namedtuple(typename="_NT3", field_names=['x', 'y', 'z'])
     |
     = help: Remove leading underscores
 
 ℹ Unsafe fix
-138 138 |     _P = ParamSpec("_P")
-139 139 |     _T = TypeVar(name="_T", covariant=True, bound=int|str)
-140 140 |     _NT = NamedTuple("_NT", [("foo", int)])
-141     |-    _E = Enum("_E", ["a", "b", "c"])
-    141 |+    E = Enum("E", ["a", "b", "c"])
-142 142 |     _NT2 = namedtuple("_NT2", ['x', 'y', 'z'])
-143 143 |     _NT3 = namedtuple(typename="_NT3", field_names=['x', 'y', 'z'])
-144 144 |     _DynamicClass = type("_DynamicClass", (), {})
-145 145 |     _NotADynamicClass = type("_NotADynamicClass")
-146 146 | 
-147     |-    print(_T, _P, _NT, _E, _NT2, _NT3, _DynamicClass, _NotADynamicClass)
-    147 |+    print(_T, _P, _NT, E, _NT2, _NT3, _DynamicClass, _NotADynamicClass)
-148 148 | 
-149 149 | # Do not emit diagnostic if parameter is private
-150 150 | # even if it is later shadowed in the body of the function
+153 153 |     _P = ParamSpec("_P")
+154 154 |     _T = TypeVar(name="_T", covariant=True, bound=int|str)
+155 155 |     _NT = NamedTuple("_NT", [("foo", int)])
+156     |-    _E = Enum("_E", ["a", "b", "c"])
+    156 |+    E = Enum("E", ["a", "b", "c"])
+157 157 |     _NT2 = namedtuple("_NT2", ['x', 'y', 'z'])
+158 158 |     _NT3 = namedtuple(typename="_NT3", field_names=['x', 'y', 'z'])
+159 159 |     _DynamicClass = type("_DynamicClass", (), {})
+160 160 |     _NotADynamicClass = type("_NotADynamicClass")
+161 161 | 
+162     |-    print(_T, _P, _NT, _E, _NT2, _NT3, _DynamicClass, _NotADynamicClass)
+    162 |+    print(_T, _P, _NT, E, _NT2, _NT3, _DynamicClass, _NotADynamicClass)
+163 163 | 
+164 164 | # Do not emit diagnostic if parameter is private
+165 165 | # even if it is later shadowed in the body of the function
 
-RUF052.py:142:5: RUF052 [*] Local dummy variable `_NT2` is accessed
+RUF052.py:157:5: RUF052 [*] Local dummy variable `_NT2` is accessed
     |
-140 |     _NT = NamedTuple("_NT", [("foo", int)])
-141 |     _E = Enum("_E", ["a", "b", "c"])
-142 |     _NT2 = namedtuple("_NT2", ['x', 'y', 'z'])
+155 |     _NT = NamedTuple("_NT", [("foo", int)])
+156 |     _E = Enum("_E", ["a", "b", "c"])
+157 |     _NT2 = namedtuple("_NT2", ['x', 'y', 'z'])
     |     ^^^^ RUF052
-143 |     _NT3 = namedtuple(typename="_NT3", field_names=['x', 'y', 'z'])
-144 |     _DynamicClass = type("_DynamicClass", (), {})
+158 |     _NT3 = namedtuple(typename="_NT3", field_names=['x', 'y', 'z'])
+159 |     _DynamicClass = type("_DynamicClass", (), {})
     |
     = help: Remove leading underscores
 
 ℹ Unsafe fix
-139 139 |     _T = TypeVar(name="_T", covariant=True, bound=int|str)
-140 140 |     _NT = NamedTuple("_NT", [("foo", int)])
-141 141 |     _E = Enum("_E", ["a", "b", "c"])
-142     |-    _NT2 = namedtuple("_NT2", ['x', 'y', 'z'])
-    142 |+    NT2 = namedtuple("NT2", ['x', 'y', 'z'])
-143 143 |     _NT3 = namedtuple(typename="_NT3", field_names=['x', 'y', 'z'])
-144 144 |     _DynamicClass = type("_DynamicClass", (), {})
-145 145 |     _NotADynamicClass = type("_NotADynamicClass")
-146 146 | 
-147     |-    print(_T, _P, _NT, _E, _NT2, _NT3, _DynamicClass, _NotADynamicClass)
-    147 |+    print(_T, _P, _NT, _E, NT2, _NT3, _DynamicClass, _NotADynamicClass)
-148 148 | 
-149 149 | # Do not emit diagnostic if parameter is private
-150 150 | # even if it is later shadowed in the body of the function
+154 154 |     _T = TypeVar(name="_T", covariant=True, bound=int|str)
+155 155 |     _NT = NamedTuple("_NT", [("foo", int)])
+156 156 |     _E = Enum("_E", ["a", "b", "c"])
+157     |-    _NT2 = namedtuple("_NT2", ['x', 'y', 'z'])
+    157 |+    NT2 = namedtuple("NT2", ['x', 'y', 'z'])
+158 158 |     _NT3 = namedtuple(typename="_NT3", field_names=['x', 'y', 'z'])
+159 159 |     _DynamicClass = type("_DynamicClass", (), {})
+160 160 |     _NotADynamicClass = type("_NotADynamicClass")
+161 161 | 
+162     |-    print(_T, _P, _NT, _E, _NT2, _NT3, _DynamicClass, _NotADynamicClass)
+    162 |+    print(_T, _P, _NT, _E, NT2, _NT3, _DynamicClass, _NotADynamicClass)
+163 163 | 
+164 164 | # Do not emit diagnostic if parameter is private
+165 165 | # even if it is later shadowed in the body of the function
 
-RUF052.py:143:5: RUF052 [*] Local dummy variable `_NT3` is accessed
+RUF052.py:158:5: RUF052 [*] Local dummy variable `_NT3` is accessed
     |
-141 |     _E = Enum("_E", ["a", "b", "c"])
-142 |     _NT2 = namedtuple("_NT2", ['x', 'y', 'z'])
-143 |     _NT3 = namedtuple(typename="_NT3", field_names=['x', 'y', 'z'])
+156 |     _E = Enum("_E", ["a", "b", "c"])
+157 |     _NT2 = namedtuple("_NT2", ['x', 'y', 'z'])
+158 |     _NT3 = namedtuple(typename="_NT3", field_names=['x', 'y', 'z'])
     |     ^^^^ RUF052
-144 |     _DynamicClass = type("_DynamicClass", (), {})
-145 |     _NotADynamicClass = type("_NotADynamicClass")
+159 |     _DynamicClass = type("_DynamicClass", (), {})
+160 |     _NotADynamicClass = type("_NotADynamicClass")
     |
     = help: Remove leading underscores
 
 ℹ Unsafe fix
-140 140 |     _NT = NamedTuple("_NT", [("foo", int)])
-141 141 |     _E = Enum("_E", ["a", "b", "c"])
-142 142 |     _NT2 = namedtuple("_NT2", ['x', 'y', 'z'])
-143     |-    _NT3 = namedtuple(typename="_NT3", field_names=['x', 'y', 'z'])
-    143 |+    NT3 = namedtuple(typename="NT3", field_names=['x', 'y', 'z'])
-144 144 |     _DynamicClass = type("_DynamicClass", (), {})
-145 145 |     _NotADynamicClass = type("_NotADynamicClass")
-146 146 | 
-147     |-    print(_T, _P, _NT, _E, _NT2, _NT3, _DynamicClass, _NotADynamicClass)
-    147 |+    print(_T, _P, _NT, _E, _NT2, NT3, _DynamicClass, _NotADynamicClass)
-148 148 | 
-149 149 | # Do not emit diagnostic if parameter is private
-150 150 | # even if it is later shadowed in the body of the function
+155 155 |     _NT = NamedTuple("_NT", [("foo", int)])
+156 156 |     _E = Enum("_E", ["a", "b", "c"])
+157 157 |     _NT2 = namedtuple("_NT2", ['x', 'y', 'z'])
+158     |-    _NT3 = namedtuple(typename="_NT3", field_names=['x', 'y', 'z'])
+    158 |+    NT3 = namedtuple(typename="NT3", field_names=['x', 'y', 'z'])
+159 159 |     _DynamicClass = type("_DynamicClass", (), {})
+160 160 |     _NotADynamicClass = type("_NotADynamicClass")
+161 161 | 
+162     |-    print(_T, _P, _NT, _E, _NT2, _NT3, _DynamicClass, _NotADynamicClass)
+    162 |+    print(_T, _P, _NT, _E, _NT2, NT3, _DynamicClass, _NotADynamicClass)
+163 163 | 
+164 164 | # Do not emit diagnostic if parameter is private
+165 165 | # even if it is later shadowed in the body of the function
 
-RUF052.py:144:5: RUF052 [*] Local dummy variable `_DynamicClass` is accessed
+RUF052.py:159:5: RUF052 [*] Local dummy variable `_DynamicClass` is accessed
     |
-142 |     _NT2 = namedtuple("_NT2", ['x', 'y', 'z'])
-143 |     _NT3 = namedtuple(typename="_NT3", field_names=['x', 'y', 'z'])
-144 |     _DynamicClass = type("_DynamicClass", (), {})
+157 |     _NT2 = namedtuple("_NT2", ['x', 'y', 'z'])
+158 |     _NT3 = namedtuple(typename="_NT3", field_names=['x', 'y', 'z'])
+159 |     _DynamicClass = type("_DynamicClass", (), {})
     |     ^^^^^^^^^^^^^ RUF052
-145 |     _NotADynamicClass = type("_NotADynamicClass")
+160 |     _NotADynamicClass = type("_NotADynamicClass")
     |
     = help: Remove leading underscores
 
 ℹ Unsafe fix
-141 141 |     _E = Enum("_E", ["a", "b", "c"])
-142 142 |     _NT2 = namedtuple("_NT2", ['x', 'y', 'z'])
-143 143 |     _NT3 = namedtuple(typename="_NT3", field_names=['x', 'y', 'z'])
-144     |-    _DynamicClass = type("_DynamicClass", (), {})
-    144 |+    DynamicClass = type("DynamicClass", (), {})
-145 145 |     _NotADynamicClass = type("_NotADynamicClass")
-146 146 | 
-147     |-    print(_T, _P, _NT, _E, _NT2, _NT3, _DynamicClass, _NotADynamicClass)
-    147 |+    print(_T, _P, _NT, _E, _NT2, _NT3, DynamicClass, _NotADynamicClass)
-148 148 | 
-149 149 | # Do not emit diagnostic if parameter is private
-150 150 | # even if it is later shadowed in the body of the function
+156 156 |     _E = Enum("_E", ["a", "b", "c"])
+157 157 |     _NT2 = namedtuple("_NT2", ['x', 'y', 'z'])
+158 158 |     _NT3 = namedtuple(typename="_NT3", field_names=['x', 'y', 'z'])
+159     |-    _DynamicClass = type("_DynamicClass", (), {})
+    159 |+    DynamicClass = type("DynamicClass", (), {})
+160 160 |     _NotADynamicClass = type("_NotADynamicClass")
+161 161 | 
+162     |-    print(_T, _P, _NT, _E, _NT2, _NT3, _DynamicClass, _NotADynamicClass)
+    162 |+    print(_T, _P, _NT, _E, _NT2, _NT3, DynamicClass, _NotADynamicClass)
+163 163 | 
+164 164 | # Do not emit diagnostic if parameter is private
+165 165 | # even if it is later shadowed in the body of the function
 
-RUF052.py:145:5: RUF052 [*] Local dummy variable `_NotADynamicClass` is accessed
+RUF052.py:160:5: RUF052 [*] Local dummy variable `_NotADynamicClass` is accessed
     |
-143 |     _NT3 = namedtuple(typename="_NT3", field_names=['x', 'y', 'z'])
-144 |     _DynamicClass = type("_DynamicClass", (), {})
-145 |     _NotADynamicClass = type("_NotADynamicClass")
+158 |     _NT3 = namedtuple(typename="_NT3", field_names=['x', 'y', 'z'])
+159 |     _DynamicClass = type("_DynamicClass", (), {})
+160 |     _NotADynamicClass = type("_NotADynamicClass")
     |     ^^^^^^^^^^^^^^^^^ RUF052
-146 | 
-147 |     print(_T, _P, _NT, _E, _NT2, _NT3, _DynamicClass, _NotADynamicClass)
+161 | 
+162 |     print(_T, _P, _NT, _E, _NT2, _NT3, _DynamicClass, _NotADynamicClass)
     |
     = help: Remove leading underscores
 
 ℹ Unsafe fix
-142 142 |     _NT2 = namedtuple("_NT2", ['x', 'y', 'z'])
-143 143 |     _NT3 = namedtuple(typename="_NT3", field_names=['x', 'y', 'z'])
-144 144 |     _DynamicClass = type("_DynamicClass", (), {})
-145     |-    _NotADynamicClass = type("_NotADynamicClass")
-    145 |+    NotADynamicClass = type("_NotADynamicClass")
-146 146 | 
-147     |-    print(_T, _P, _NT, _E, _NT2, _NT3, _DynamicClass, _NotADynamicClass)
-    147 |+    print(_T, _P, _NT, _E, _NT2, _NT3, _DynamicClass, NotADynamicClass)
-148 148 | 
-149 149 | # Do not emit diagnostic if parameter is private
-150 150 | # even if it is later shadowed in the body of the function
+157 157 |     _NT2 = namedtuple("_NT2", ['x', 'y', 'z'])
+158 158 |     _NT3 = namedtuple(typename="_NT3", field_names=['x', 'y', 'z'])
+159 159 |     _DynamicClass = type("_DynamicClass", (), {})
+160     |-    _NotADynamicClass = type("_NotADynamicClass")
+    160 |+    NotADynamicClass = type("_NotADynamicClass")
+161 161 | 
+162     |-    print(_T, _P, _NT, _E, _NT2, _NT3, _DynamicClass, _NotADynamicClass)
+    162 |+    print(_T, _P, _NT, _E, _NT2, _NT3, _DynamicClass, NotADynamicClass)
+163 163 | 
+164 164 | # Do not emit diagnostic if parameter is private
+165 165 | # even if it is later shadowed in the body of the function

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__custom_dummy_var_regexp_preset__RUF052_RUF052.py_1.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__custom_dummy_var_regexp_preset__RUF052_RUF052.py_1.snap
@@ -1,367 +1,368 @@
 ---
 source: crates/ruff_linter/src/rules/ruff/mod.rs
+snapshot_kind: text
 ---
-RUF052.py:77:9: RUF052 [*] Local dummy variable `_var` is accessed
+RUF052.py:92:9: RUF052 [*] Local dummy variable `_var` is accessed
    |
-75 | class Class_:
-76 |     def fun(self):
-77 |         _var = "method variable" # [RUF052]
+90 | class Class_:
+91 |     def fun(self):
+92 |         _var = "method variable" # [RUF052]
    |         ^^^^ RUF052
-78 |         return _var
+93 |         return _var
    |
    = help: Remove leading underscores
 
 ℹ Unsafe fix
-74 74 | 
-75 75 | class Class_:
-76 76 |     def fun(self):
-77    |-        _var = "method variable" # [RUF052]
-78    |-        return _var
-   77 |+        var = "method variable" # [RUF052]
-   78 |+        return var
-79 79 | 
-80 80 | def fun(_var): # parameters are ignored
-81 81 |     return _var
+89 89 | 
+90 90 | class Class_:
+91 91 |     def fun(self):
+92    |-        _var = "method variable" # [RUF052]
+93    |-        return _var
+   92 |+        var = "method variable" # [RUF052]
+   93 |+        return var
+94 94 | 
+95 95 | def fun(_var): # parameters are ignored
+96 96 |     return _var
 
-RUF052.py:84:5: RUF052 [*] Local dummy variable `_list` is accessed
-   |
-83 | def fun():
-84 |     _list = "built-in" # [RUF052]
-   |     ^^^^^ RUF052
-85 |     return _list
-   |
-   = help: Prefer using trailing underscores to avoid shadowing a built-in
-
-ℹ Unsafe fix
-81 81 |     return _var
-82 82 | 
-83 83 | def fun():
-84    |-    _list = "built-in" # [RUF052]
-85    |-    return _list
-   84 |+    list_ = "built-in" # [RUF052]
-   85 |+    return list_
-86 86 | 
-87 87 | x = "global"
-88 88 | 
-
-RUF052.py:91:5: RUF052 [*] Local dummy variable `_x` is accessed
-   |
-89 | def fun():
-90 |     global x
-91 |     _x = "shadows global" # [RUF052]
-   |     ^^ RUF052
-92 |     return _x
-   |
-   = help: Prefer using trailing underscores to avoid shadowing a variable
-
-ℹ Unsafe fix
-88 88 | 
-89 89 | def fun():
-90 90 |     global x
-91    |-    _x = "shadows global" # [RUF052]
-92    |-    return _x
-   91 |+    x_ = "shadows global" # [RUF052]
-   92 |+    return x_
-93 93 | 
-94 94 | def foo():
-95 95 |   x = "outer"
-
-RUF052.py:98:5: RUF052 [*] Local dummy variable `_x` is accessed
+RUF052.py:99:5: RUF052 [*] Local dummy variable `_list` is accessed
     |
- 96 |   def bar():
- 97 |     nonlocal x
- 98 |     _x = "shadows nonlocal" # [RUF052]
+ 98 | def fun():
+ 99 |     _list = "built-in" # [RUF052]
+    |     ^^^^^ RUF052
+100 |     return _list
+    |
+    = help: Prefer using trailing underscores to avoid shadowing a built-in
+
+ℹ Unsafe fix
+96  96  |     return _var
+97  97  | 
+98  98  | def fun():
+99      |-    _list = "built-in" # [RUF052]
+100     |-    return _list
+    99  |+    list_ = "built-in" # [RUF052]
+    100 |+    return list_
+101 101 | 
+102 102 | x = "global"
+103 103 | 
+
+RUF052.py:106:5: RUF052 [*] Local dummy variable `_x` is accessed
+    |
+104 | def fun():
+105 |     global x
+106 |     _x = "shadows global" # [RUF052]
     |     ^^ RUF052
- 99 |     return _x
-100 |   bar()
+107 |     return _x
     |
     = help: Prefer using trailing underscores to avoid shadowing a variable
 
 ℹ Unsafe fix
-95  95  |   x = "outer"
-96  96  |   def bar():
-97  97  |     nonlocal x
-98      |-    _x = "shadows nonlocal" # [RUF052]
-99      |-    return _x
-    98  |+    x_ = "shadows nonlocal" # [RUF052]
-    99  |+    return x_
-100 100 |   bar()
-101 101 |   return x
-102 102 | 
-
-RUF052.py:105:5: RUF052 [*] Local dummy variable `_x` is accessed
-    |
-103 | def fun():
-104 |     x = "local"
-105 |     _x = "shadows local" # [RUF052]
-    |     ^^ RUF052
-106 |     return _x
-    |
-    = help: Prefer using trailing underscores to avoid shadowing a variable
-
-ℹ Unsafe fix
-102 102 | 
-103 103 | def fun():
-104 104 |     x = "local"
-105     |-    _x = "shadows local" # [RUF052]
-106     |-    return _x
-    105 |+    x_ = "shadows local" # [RUF052]
-    106 |+    return x_
-107 107 | 
+103 103 | 
+104 104 | def fun():
+105 105 |     global x
+106     |-    _x = "shadows global" # [RUF052]
+107     |-    return _x
+    106 |+    x_ = "shadows global" # [RUF052]
+    107 |+    return x_
 108 108 | 
-109 109 | GLOBAL_1 = "global 1"
+109 109 | def foo():
+110 110 |   x = "outer"
 
-RUF052.py:113:5: RUF052 Local dummy variable `_GLOBAL_1` is accessed
+RUF052.py:113:5: RUF052 [*] Local dummy variable `_x` is accessed
     |
-112 | def unfixables():
-113 |     _GLOBAL_1 = "foo"
+111 |   def bar():
+112 |     nonlocal x
+113 |     _x = "shadows nonlocal" # [RUF052]
+    |     ^^ RUF052
+114 |     return _x
+115 |   bar()
+    |
+    = help: Prefer using trailing underscores to avoid shadowing a variable
+
+ℹ Unsafe fix
+110 110 |   x = "outer"
+111 111 |   def bar():
+112 112 |     nonlocal x
+113     |-    _x = "shadows nonlocal" # [RUF052]
+114     |-    return _x
+    113 |+    x_ = "shadows nonlocal" # [RUF052]
+    114 |+    return x_
+115 115 |   bar()
+116 116 |   return x
+117 117 | 
+
+RUF052.py:120:5: RUF052 [*] Local dummy variable `_x` is accessed
+    |
+118 | def fun():
+119 |     x = "local"
+120 |     _x = "shadows local" # [RUF052]
+    |     ^^ RUF052
+121 |     return _x
+    |
+    = help: Prefer using trailing underscores to avoid shadowing a variable
+
+ℹ Unsafe fix
+117 117 | 
+118 118 | def fun():
+119 119 |     x = "local"
+120     |-    _x = "shadows local" # [RUF052]
+121     |-    return _x
+    120 |+    x_ = "shadows local" # [RUF052]
+    121 |+    return x_
+122 122 | 
+123 123 | 
+124 124 | GLOBAL_1 = "global 1"
+
+RUF052.py:128:5: RUF052 Local dummy variable `_GLOBAL_1` is accessed
+    |
+127 | def unfixables():
+128 |     _GLOBAL_1 = "foo"
     |     ^^^^^^^^^ RUF052
-114 |     # unfixable because the rename would shadow a global variable
-115 |     print(_GLOBAL_1)  # [RUF052]
+129 |     # unfixable because the rename would shadow a global variable
+130 |     print(_GLOBAL_1)  # [RUF052]
     |
     = help: Prefer using trailing underscores to avoid shadowing a variable
 
-RUF052.py:121:5: RUF052 Local dummy variable `_local` is accessed
+RUF052.py:136:5: RUF052 Local dummy variable `_local` is accessed
     |
-120 |     # unfixable because the rename would shadow a local variable
-121 |     _local = "local3"  # [RUF052]
+135 |     # unfixable because the rename would shadow a local variable
+136 |     _local = "local3"  # [RUF052]
     |     ^^^^^^ RUF052
-122 |     print(_local)
+137 |     print(_local)
     |
     = help: Prefer using trailing underscores to avoid shadowing a variable
 
-RUF052.py:125:9: RUF052 Local dummy variable `_GLOBAL_1` is accessed
+RUF052.py:140:9: RUF052 Local dummy variable `_GLOBAL_1` is accessed
     |
-124 |     def nested():
-125 |         _GLOBAL_1 = "foo"
+139 |     def nested():
+140 |         _GLOBAL_1 = "foo"
     |         ^^^^^^^^^ RUF052
-126 |         # unfixable because the rename would shadow a global variable
-127 |         print(_GLOBAL_1)  # [RUF052]
+141 |         # unfixable because the rename would shadow a global variable
+142 |         print(_GLOBAL_1)  # [RUF052]
     |
     = help: Prefer using trailing underscores to avoid shadowing a variable
 
-RUF052.py:130:9: RUF052 Local dummy variable `_local` is accessed
+RUF052.py:145:9: RUF052 Local dummy variable `_local` is accessed
     |
-129 |         # unfixable because the rename would shadow a variable from the outer function
-130 |         _local = "local4"
+144 |         # unfixable because the rename would shadow a variable from the outer function
+145 |         _local = "local4"
     |         ^^^^^^ RUF052
-131 |         print(_local)
+146 |         print(_local)
     |
     = help: Prefer using trailing underscores to avoid shadowing a variable
 
-RUF052.py:138:5: RUF052 [*] Local dummy variable `_P` is accessed
+RUF052.py:153:5: RUF052 [*] Local dummy variable `_P` is accessed
     |
-136 |     from collections import namedtuple
-137 | 
-138 |     _P = ParamSpec("_P")
+151 |     from collections import namedtuple
+152 | 
+153 |     _P = ParamSpec("_P")
     |     ^^ RUF052
-139 |     _T = TypeVar(name="_T", covariant=True, bound=int|str)
-140 |     _NT = NamedTuple("_NT", [("foo", int)])
+154 |     _T = TypeVar(name="_T", covariant=True, bound=int|str)
+155 |     _NT = NamedTuple("_NT", [("foo", int)])
     |
     = help: Remove leading underscores
 
 ℹ Unsafe fix
-135 135 |     from enum import Enum
-136 136 |     from collections import namedtuple
-137 137 | 
-138     |-    _P = ParamSpec("_P")
-    138 |+    P = ParamSpec("P")
-139 139 |     _T = TypeVar(name="_T", covariant=True, bound=int|str)
-140 140 |     _NT = NamedTuple("_NT", [("foo", int)])
-141 141 |     _E = Enum("_E", ["a", "b", "c"])
+150 150 |     from enum import Enum
+151 151 |     from collections import namedtuple
+152 152 | 
+153     |-    _P = ParamSpec("_P")
+    153 |+    P = ParamSpec("P")
+154 154 |     _T = TypeVar(name="_T", covariant=True, bound=int|str)
+155 155 |     _NT = NamedTuple("_NT", [("foo", int)])
+156 156 |     _E = Enum("_E", ["a", "b", "c"])
 --------------------------------------------------------------------------------
-144 144 |     _DynamicClass = type("_DynamicClass", (), {})
-145 145 |     _NotADynamicClass = type("_NotADynamicClass")
-146 146 | 
-147     |-    print(_T, _P, _NT, _E, _NT2, _NT3, _DynamicClass, _NotADynamicClass)
-    147 |+    print(_T, P, _NT, _E, _NT2, _NT3, _DynamicClass, _NotADynamicClass)
-148 148 | 
-149 149 | # Do not emit diagnostic if parameter is private
-150 150 | # even if it is later shadowed in the body of the function
+159 159 |     _DynamicClass = type("_DynamicClass", (), {})
+160 160 |     _NotADynamicClass = type("_NotADynamicClass")
+161 161 | 
+162     |-    print(_T, _P, _NT, _E, _NT2, _NT3, _DynamicClass, _NotADynamicClass)
+    162 |+    print(_T, P, _NT, _E, _NT2, _NT3, _DynamicClass, _NotADynamicClass)
+163 163 | 
+164 164 | # Do not emit diagnostic if parameter is private
+165 165 | # even if it is later shadowed in the body of the function
 
-RUF052.py:139:5: RUF052 [*] Local dummy variable `_T` is accessed
+RUF052.py:154:5: RUF052 [*] Local dummy variable `_T` is accessed
     |
-138 |     _P = ParamSpec("_P")
-139 |     _T = TypeVar(name="_T", covariant=True, bound=int|str)
+153 |     _P = ParamSpec("_P")
+154 |     _T = TypeVar(name="_T", covariant=True, bound=int|str)
     |     ^^ RUF052
-140 |     _NT = NamedTuple("_NT", [("foo", int)])
-141 |     _E = Enum("_E", ["a", "b", "c"])
+155 |     _NT = NamedTuple("_NT", [("foo", int)])
+156 |     _E = Enum("_E", ["a", "b", "c"])
     |
     = help: Remove leading underscores
 
 ℹ Unsafe fix
-136 136 |     from collections import namedtuple
-137 137 | 
-138 138 |     _P = ParamSpec("_P")
-139     |-    _T = TypeVar(name="_T", covariant=True, bound=int|str)
-    139 |+    T = TypeVar(name="T", covariant=True, bound=int|str)
-140 140 |     _NT = NamedTuple("_NT", [("foo", int)])
-141 141 |     _E = Enum("_E", ["a", "b", "c"])
-142 142 |     _NT2 = namedtuple("_NT2", ['x', 'y', 'z'])
+151 151 |     from collections import namedtuple
+152 152 | 
+153 153 |     _P = ParamSpec("_P")
+154     |-    _T = TypeVar(name="_T", covariant=True, bound=int|str)
+    154 |+    T = TypeVar(name="T", covariant=True, bound=int|str)
+155 155 |     _NT = NamedTuple("_NT", [("foo", int)])
+156 156 |     _E = Enum("_E", ["a", "b", "c"])
+157 157 |     _NT2 = namedtuple("_NT2", ['x', 'y', 'z'])
 --------------------------------------------------------------------------------
-144 144 |     _DynamicClass = type("_DynamicClass", (), {})
-145 145 |     _NotADynamicClass = type("_NotADynamicClass")
-146 146 | 
-147     |-    print(_T, _P, _NT, _E, _NT2, _NT3, _DynamicClass, _NotADynamicClass)
-    147 |+    print(T, _P, _NT, _E, _NT2, _NT3, _DynamicClass, _NotADynamicClass)
-148 148 | 
-149 149 | # Do not emit diagnostic if parameter is private
-150 150 | # even if it is later shadowed in the body of the function
+159 159 |     _DynamicClass = type("_DynamicClass", (), {})
+160 160 |     _NotADynamicClass = type("_NotADynamicClass")
+161 161 | 
+162     |-    print(_T, _P, _NT, _E, _NT2, _NT3, _DynamicClass, _NotADynamicClass)
+    162 |+    print(T, _P, _NT, _E, _NT2, _NT3, _DynamicClass, _NotADynamicClass)
+163 163 | 
+164 164 | # Do not emit diagnostic if parameter is private
+165 165 | # even if it is later shadowed in the body of the function
 
-RUF052.py:140:5: RUF052 [*] Local dummy variable `_NT` is accessed
+RUF052.py:155:5: RUF052 [*] Local dummy variable `_NT` is accessed
     |
-138 |     _P = ParamSpec("_P")
-139 |     _T = TypeVar(name="_T", covariant=True, bound=int|str)
-140 |     _NT = NamedTuple("_NT", [("foo", int)])
+153 |     _P = ParamSpec("_P")
+154 |     _T = TypeVar(name="_T", covariant=True, bound=int|str)
+155 |     _NT = NamedTuple("_NT", [("foo", int)])
     |     ^^^ RUF052
-141 |     _E = Enum("_E", ["a", "b", "c"])
-142 |     _NT2 = namedtuple("_NT2", ['x', 'y', 'z'])
+156 |     _E = Enum("_E", ["a", "b", "c"])
+157 |     _NT2 = namedtuple("_NT2", ['x', 'y', 'z'])
     |
     = help: Remove leading underscores
 
 ℹ Unsafe fix
-137 137 | 
-138 138 |     _P = ParamSpec("_P")
-139 139 |     _T = TypeVar(name="_T", covariant=True, bound=int|str)
-140     |-    _NT = NamedTuple("_NT", [("foo", int)])
-    140 |+    NT = NamedTuple("NT", [("foo", int)])
-141 141 |     _E = Enum("_E", ["a", "b", "c"])
-142 142 |     _NT2 = namedtuple("_NT2", ['x', 'y', 'z'])
-143 143 |     _NT3 = namedtuple(typename="_NT3", field_names=['x', 'y', 'z'])
-144 144 |     _DynamicClass = type("_DynamicClass", (), {})
-145 145 |     _NotADynamicClass = type("_NotADynamicClass")
-146 146 | 
-147     |-    print(_T, _P, _NT, _E, _NT2, _NT3, _DynamicClass, _NotADynamicClass)
-    147 |+    print(_T, _P, NT, _E, _NT2, _NT3, _DynamicClass, _NotADynamicClass)
-148 148 | 
-149 149 | # Do not emit diagnostic if parameter is private
-150 150 | # even if it is later shadowed in the body of the function
+152 152 | 
+153 153 |     _P = ParamSpec("_P")
+154 154 |     _T = TypeVar(name="_T", covariant=True, bound=int|str)
+155     |-    _NT = NamedTuple("_NT", [("foo", int)])
+    155 |+    NT = NamedTuple("NT", [("foo", int)])
+156 156 |     _E = Enum("_E", ["a", "b", "c"])
+157 157 |     _NT2 = namedtuple("_NT2", ['x', 'y', 'z'])
+158 158 |     _NT3 = namedtuple(typename="_NT3", field_names=['x', 'y', 'z'])
+159 159 |     _DynamicClass = type("_DynamicClass", (), {})
+160 160 |     _NotADynamicClass = type("_NotADynamicClass")
+161 161 | 
+162     |-    print(_T, _P, _NT, _E, _NT2, _NT3, _DynamicClass, _NotADynamicClass)
+    162 |+    print(_T, _P, NT, _E, _NT2, _NT3, _DynamicClass, _NotADynamicClass)
+163 163 | 
+164 164 | # Do not emit diagnostic if parameter is private
+165 165 | # even if it is later shadowed in the body of the function
 
-RUF052.py:141:5: RUF052 [*] Local dummy variable `_E` is accessed
+RUF052.py:156:5: RUF052 [*] Local dummy variable `_E` is accessed
     |
-139 |     _T = TypeVar(name="_T", covariant=True, bound=int|str)
-140 |     _NT = NamedTuple("_NT", [("foo", int)])
-141 |     _E = Enum("_E", ["a", "b", "c"])
+154 |     _T = TypeVar(name="_T", covariant=True, bound=int|str)
+155 |     _NT = NamedTuple("_NT", [("foo", int)])
+156 |     _E = Enum("_E", ["a", "b", "c"])
     |     ^^ RUF052
-142 |     _NT2 = namedtuple("_NT2", ['x', 'y', 'z'])
-143 |     _NT3 = namedtuple(typename="_NT3", field_names=['x', 'y', 'z'])
+157 |     _NT2 = namedtuple("_NT2", ['x', 'y', 'z'])
+158 |     _NT3 = namedtuple(typename="_NT3", field_names=['x', 'y', 'z'])
     |
     = help: Remove leading underscores
 
 ℹ Unsafe fix
-138 138 |     _P = ParamSpec("_P")
-139 139 |     _T = TypeVar(name="_T", covariant=True, bound=int|str)
-140 140 |     _NT = NamedTuple("_NT", [("foo", int)])
-141     |-    _E = Enum("_E", ["a", "b", "c"])
-    141 |+    E = Enum("E", ["a", "b", "c"])
-142 142 |     _NT2 = namedtuple("_NT2", ['x', 'y', 'z'])
-143 143 |     _NT3 = namedtuple(typename="_NT3", field_names=['x', 'y', 'z'])
-144 144 |     _DynamicClass = type("_DynamicClass", (), {})
-145 145 |     _NotADynamicClass = type("_NotADynamicClass")
-146 146 | 
-147     |-    print(_T, _P, _NT, _E, _NT2, _NT3, _DynamicClass, _NotADynamicClass)
-    147 |+    print(_T, _P, _NT, E, _NT2, _NT3, _DynamicClass, _NotADynamicClass)
-148 148 | 
-149 149 | # Do not emit diagnostic if parameter is private
-150 150 | # even if it is later shadowed in the body of the function
+153 153 |     _P = ParamSpec("_P")
+154 154 |     _T = TypeVar(name="_T", covariant=True, bound=int|str)
+155 155 |     _NT = NamedTuple("_NT", [("foo", int)])
+156     |-    _E = Enum("_E", ["a", "b", "c"])
+    156 |+    E = Enum("E", ["a", "b", "c"])
+157 157 |     _NT2 = namedtuple("_NT2", ['x', 'y', 'z'])
+158 158 |     _NT3 = namedtuple(typename="_NT3", field_names=['x', 'y', 'z'])
+159 159 |     _DynamicClass = type("_DynamicClass", (), {})
+160 160 |     _NotADynamicClass = type("_NotADynamicClass")
+161 161 | 
+162     |-    print(_T, _P, _NT, _E, _NT2, _NT3, _DynamicClass, _NotADynamicClass)
+    162 |+    print(_T, _P, _NT, E, _NT2, _NT3, _DynamicClass, _NotADynamicClass)
+163 163 | 
+164 164 | # Do not emit diagnostic if parameter is private
+165 165 | # even if it is later shadowed in the body of the function
 
-RUF052.py:142:5: RUF052 [*] Local dummy variable `_NT2` is accessed
+RUF052.py:157:5: RUF052 [*] Local dummy variable `_NT2` is accessed
     |
-140 |     _NT = NamedTuple("_NT", [("foo", int)])
-141 |     _E = Enum("_E", ["a", "b", "c"])
-142 |     _NT2 = namedtuple("_NT2", ['x', 'y', 'z'])
+155 |     _NT = NamedTuple("_NT", [("foo", int)])
+156 |     _E = Enum("_E", ["a", "b", "c"])
+157 |     _NT2 = namedtuple("_NT2", ['x', 'y', 'z'])
     |     ^^^^ RUF052
-143 |     _NT3 = namedtuple(typename="_NT3", field_names=['x', 'y', 'z'])
-144 |     _DynamicClass = type("_DynamicClass", (), {})
+158 |     _NT3 = namedtuple(typename="_NT3", field_names=['x', 'y', 'z'])
+159 |     _DynamicClass = type("_DynamicClass", (), {})
     |
     = help: Remove leading underscores
 
 ℹ Unsafe fix
-139 139 |     _T = TypeVar(name="_T", covariant=True, bound=int|str)
-140 140 |     _NT = NamedTuple("_NT", [("foo", int)])
-141 141 |     _E = Enum("_E", ["a", "b", "c"])
-142     |-    _NT2 = namedtuple("_NT2", ['x', 'y', 'z'])
-    142 |+    NT2 = namedtuple("NT2", ['x', 'y', 'z'])
-143 143 |     _NT3 = namedtuple(typename="_NT3", field_names=['x', 'y', 'z'])
-144 144 |     _DynamicClass = type("_DynamicClass", (), {})
-145 145 |     _NotADynamicClass = type("_NotADynamicClass")
-146 146 | 
-147     |-    print(_T, _P, _NT, _E, _NT2, _NT3, _DynamicClass, _NotADynamicClass)
-    147 |+    print(_T, _P, _NT, _E, NT2, _NT3, _DynamicClass, _NotADynamicClass)
-148 148 | 
-149 149 | # Do not emit diagnostic if parameter is private
-150 150 | # even if it is later shadowed in the body of the function
+154 154 |     _T = TypeVar(name="_T", covariant=True, bound=int|str)
+155 155 |     _NT = NamedTuple("_NT", [("foo", int)])
+156 156 |     _E = Enum("_E", ["a", "b", "c"])
+157     |-    _NT2 = namedtuple("_NT2", ['x', 'y', 'z'])
+    157 |+    NT2 = namedtuple("NT2", ['x', 'y', 'z'])
+158 158 |     _NT3 = namedtuple(typename="_NT3", field_names=['x', 'y', 'z'])
+159 159 |     _DynamicClass = type("_DynamicClass", (), {})
+160 160 |     _NotADynamicClass = type("_NotADynamicClass")
+161 161 | 
+162     |-    print(_T, _P, _NT, _E, _NT2, _NT3, _DynamicClass, _NotADynamicClass)
+    162 |+    print(_T, _P, _NT, _E, NT2, _NT3, _DynamicClass, _NotADynamicClass)
+163 163 | 
+164 164 | # Do not emit diagnostic if parameter is private
+165 165 | # even if it is later shadowed in the body of the function
 
-RUF052.py:143:5: RUF052 [*] Local dummy variable `_NT3` is accessed
+RUF052.py:158:5: RUF052 [*] Local dummy variable `_NT3` is accessed
     |
-141 |     _E = Enum("_E", ["a", "b", "c"])
-142 |     _NT2 = namedtuple("_NT2", ['x', 'y', 'z'])
-143 |     _NT3 = namedtuple(typename="_NT3", field_names=['x', 'y', 'z'])
+156 |     _E = Enum("_E", ["a", "b", "c"])
+157 |     _NT2 = namedtuple("_NT2", ['x', 'y', 'z'])
+158 |     _NT3 = namedtuple(typename="_NT3", field_names=['x', 'y', 'z'])
     |     ^^^^ RUF052
-144 |     _DynamicClass = type("_DynamicClass", (), {})
-145 |     _NotADynamicClass = type("_NotADynamicClass")
+159 |     _DynamicClass = type("_DynamicClass", (), {})
+160 |     _NotADynamicClass = type("_NotADynamicClass")
     |
     = help: Remove leading underscores
 
 ℹ Unsafe fix
-140 140 |     _NT = NamedTuple("_NT", [("foo", int)])
-141 141 |     _E = Enum("_E", ["a", "b", "c"])
-142 142 |     _NT2 = namedtuple("_NT2", ['x', 'y', 'z'])
-143     |-    _NT3 = namedtuple(typename="_NT3", field_names=['x', 'y', 'z'])
-    143 |+    NT3 = namedtuple(typename="NT3", field_names=['x', 'y', 'z'])
-144 144 |     _DynamicClass = type("_DynamicClass", (), {})
-145 145 |     _NotADynamicClass = type("_NotADynamicClass")
-146 146 | 
-147     |-    print(_T, _P, _NT, _E, _NT2, _NT3, _DynamicClass, _NotADynamicClass)
-    147 |+    print(_T, _P, _NT, _E, _NT2, NT3, _DynamicClass, _NotADynamicClass)
-148 148 | 
-149 149 | # Do not emit diagnostic if parameter is private
-150 150 | # even if it is later shadowed in the body of the function
+155 155 |     _NT = NamedTuple("_NT", [("foo", int)])
+156 156 |     _E = Enum("_E", ["a", "b", "c"])
+157 157 |     _NT2 = namedtuple("_NT2", ['x', 'y', 'z'])
+158     |-    _NT3 = namedtuple(typename="_NT3", field_names=['x', 'y', 'z'])
+    158 |+    NT3 = namedtuple(typename="NT3", field_names=['x', 'y', 'z'])
+159 159 |     _DynamicClass = type("_DynamicClass", (), {})
+160 160 |     _NotADynamicClass = type("_NotADynamicClass")
+161 161 | 
+162     |-    print(_T, _P, _NT, _E, _NT2, _NT3, _DynamicClass, _NotADynamicClass)
+    162 |+    print(_T, _P, _NT, _E, _NT2, NT3, _DynamicClass, _NotADynamicClass)
+163 163 | 
+164 164 | # Do not emit diagnostic if parameter is private
+165 165 | # even if it is later shadowed in the body of the function
 
-RUF052.py:144:5: RUF052 [*] Local dummy variable `_DynamicClass` is accessed
+RUF052.py:159:5: RUF052 [*] Local dummy variable `_DynamicClass` is accessed
     |
-142 |     _NT2 = namedtuple("_NT2", ['x', 'y', 'z'])
-143 |     _NT3 = namedtuple(typename="_NT3", field_names=['x', 'y', 'z'])
-144 |     _DynamicClass = type("_DynamicClass", (), {})
+157 |     _NT2 = namedtuple("_NT2", ['x', 'y', 'z'])
+158 |     _NT3 = namedtuple(typename="_NT3", field_names=['x', 'y', 'z'])
+159 |     _DynamicClass = type("_DynamicClass", (), {})
     |     ^^^^^^^^^^^^^ RUF052
-145 |     _NotADynamicClass = type("_NotADynamicClass")
+160 |     _NotADynamicClass = type("_NotADynamicClass")
     |
     = help: Remove leading underscores
 
 ℹ Unsafe fix
-141 141 |     _E = Enum("_E", ["a", "b", "c"])
-142 142 |     _NT2 = namedtuple("_NT2", ['x', 'y', 'z'])
-143 143 |     _NT3 = namedtuple(typename="_NT3", field_names=['x', 'y', 'z'])
-144     |-    _DynamicClass = type("_DynamicClass", (), {})
-    144 |+    DynamicClass = type("DynamicClass", (), {})
-145 145 |     _NotADynamicClass = type("_NotADynamicClass")
-146 146 | 
-147     |-    print(_T, _P, _NT, _E, _NT2, _NT3, _DynamicClass, _NotADynamicClass)
-    147 |+    print(_T, _P, _NT, _E, _NT2, _NT3, DynamicClass, _NotADynamicClass)
-148 148 | 
-149 149 | # Do not emit diagnostic if parameter is private
-150 150 | # even if it is later shadowed in the body of the function
+156 156 |     _E = Enum("_E", ["a", "b", "c"])
+157 157 |     _NT2 = namedtuple("_NT2", ['x', 'y', 'z'])
+158 158 |     _NT3 = namedtuple(typename="_NT3", field_names=['x', 'y', 'z'])
+159     |-    _DynamicClass = type("_DynamicClass", (), {})
+    159 |+    DynamicClass = type("DynamicClass", (), {})
+160 160 |     _NotADynamicClass = type("_NotADynamicClass")
+161 161 | 
+162     |-    print(_T, _P, _NT, _E, _NT2, _NT3, _DynamicClass, _NotADynamicClass)
+    162 |+    print(_T, _P, _NT, _E, _NT2, _NT3, DynamicClass, _NotADynamicClass)
+163 163 | 
+164 164 | # Do not emit diagnostic if parameter is private
+165 165 | # even if it is later shadowed in the body of the function
 
-RUF052.py:145:5: RUF052 [*] Local dummy variable `_NotADynamicClass` is accessed
+RUF052.py:160:5: RUF052 [*] Local dummy variable `_NotADynamicClass` is accessed
     |
-143 |     _NT3 = namedtuple(typename="_NT3", field_names=['x', 'y', 'z'])
-144 |     _DynamicClass = type("_DynamicClass", (), {})
-145 |     _NotADynamicClass = type("_NotADynamicClass")
+158 |     _NT3 = namedtuple(typename="_NT3", field_names=['x', 'y', 'z'])
+159 |     _DynamicClass = type("_DynamicClass", (), {})
+160 |     _NotADynamicClass = type("_NotADynamicClass")
     |     ^^^^^^^^^^^^^^^^^ RUF052
-146 | 
-147 |     print(_T, _P, _NT, _E, _NT2, _NT3, _DynamicClass, _NotADynamicClass)
+161 | 
+162 |     print(_T, _P, _NT, _E, _NT2, _NT3, _DynamicClass, _NotADynamicClass)
     |
     = help: Remove leading underscores
 
 ℹ Unsafe fix
-142 142 |     _NT2 = namedtuple("_NT2", ['x', 'y', 'z'])
-143 143 |     _NT3 = namedtuple(typename="_NT3", field_names=['x', 'y', 'z'])
-144 144 |     _DynamicClass = type("_DynamicClass", (), {})
-145     |-    _NotADynamicClass = type("_NotADynamicClass")
-    145 |+    NotADynamicClass = type("_NotADynamicClass")
-146 146 | 
-147     |-    print(_T, _P, _NT, _E, _NT2, _NT3, _DynamicClass, _NotADynamicClass)
-    147 |+    print(_T, _P, _NT, _E, _NT2, _NT3, _DynamicClass, NotADynamicClass)
-148 148 | 
-149 149 | # Do not emit diagnostic if parameter is private
-150 150 | # even if it is later shadowed in the body of the function
+157 157 |     _NT2 = namedtuple("_NT2", ['x', 'y', 'z'])
+158 158 |     _NT3 = namedtuple(typename="_NT3", field_names=['x', 'y', 'z'])
+159 159 |     _DynamicClass = type("_DynamicClass", (), {})
+160     |-    _NotADynamicClass = type("_NotADynamicClass")
+    160 |+    NotADynamicClass = type("_NotADynamicClass")
+161 161 | 
+162     |-    print(_T, _P, _NT, _E, _NT2, _NT3, _DynamicClass, _NotADynamicClass)
+    162 |+    print(_T, _P, _NT, _E, _NT2, _NT3, _DynamicClass, NotADynamicClass)
+163 163 | 
+164 164 | # Do not emit diagnostic if parameter is private
+165 165 | # even if it is later shadowed in the body of the function

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__custom_dummy_var_regexp_preset__RUF052_RUF052.py_2.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__custom_dummy_var_regexp_preset__RUF052_RUF052.py_2.snap
@@ -1,185 +1,186 @@
 ---
 source: crates/ruff_linter/src/rules/ruff/mod.rs
+snapshot_kind: text
 ---
-RUF052.py:77:9: RUF052 Local dummy variable `_var` is accessed
+RUF052.py:92:9: RUF052 Local dummy variable `_var` is accessed
    |
-75 | class Class_:
-76 |     def fun(self):
-77 |         _var = "method variable" # [RUF052]
+90 | class Class_:
+91 |     def fun(self):
+92 |         _var = "method variable" # [RUF052]
    |         ^^^^ RUF052
-78 |         return _var
+93 |         return _var
    |
    = help: Remove leading underscores
 
-RUF052.py:84:5: RUF052 Local dummy variable `_list` is accessed
-   |
-83 | def fun():
-84 |     _list = "built-in" # [RUF052]
-   |     ^^^^^ RUF052
-85 |     return _list
-   |
-   = help: Prefer using trailing underscores to avoid shadowing a built-in
-
-RUF052.py:91:5: RUF052 Local dummy variable `_x` is accessed
-   |
-89 | def fun():
-90 |     global x
-91 |     _x = "shadows global" # [RUF052]
-   |     ^^ RUF052
-92 |     return _x
-   |
-   = help: Prefer using trailing underscores to avoid shadowing a variable
-
-RUF052.py:95:3: RUF052 Local dummy variable `x` is accessed
-   |
-94 | def foo():
-95 |   x = "outer"
-   |   ^ RUF052
-96 |   def bar():
-97 |     nonlocal x
-   |
-
-RUF052.py:98:5: RUF052 Local dummy variable `_x` is accessed
+RUF052.py:99:5: RUF052 Local dummy variable `_list` is accessed
     |
- 96 |   def bar():
- 97 |     nonlocal x
- 98 |     _x = "shadows nonlocal" # [RUF052]
+ 98 | def fun():
+ 99 |     _list = "built-in" # [RUF052]
+    |     ^^^^^ RUF052
+100 |     return _list
+    |
+    = help: Prefer using trailing underscores to avoid shadowing a built-in
+
+RUF052.py:106:5: RUF052 Local dummy variable `_x` is accessed
+    |
+104 | def fun():
+105 |     global x
+106 |     _x = "shadows global" # [RUF052]
     |     ^^ RUF052
- 99 |     return _x
-100 |   bar()
+107 |     return _x
     |
     = help: Prefer using trailing underscores to avoid shadowing a variable
 
-RUF052.py:105:5: RUF052 Local dummy variable `_x` is accessed
+RUF052.py:110:3: RUF052 Local dummy variable `x` is accessed
     |
-103 | def fun():
-104 |     x = "local"
-105 |     _x = "shadows local" # [RUF052]
+109 | def foo():
+110 |   x = "outer"
+    |   ^ RUF052
+111 |   def bar():
+112 |     nonlocal x
+    |
+
+RUF052.py:113:5: RUF052 Local dummy variable `_x` is accessed
+    |
+111 |   def bar():
+112 |     nonlocal x
+113 |     _x = "shadows nonlocal" # [RUF052]
     |     ^^ RUF052
-106 |     return _x
+114 |     return _x
+115 |   bar()
     |
     = help: Prefer using trailing underscores to avoid shadowing a variable
 
-RUF052.py:113:5: RUF052 Local dummy variable `_GLOBAL_1` is accessed
+RUF052.py:120:5: RUF052 Local dummy variable `_x` is accessed
     |
-112 | def unfixables():
-113 |     _GLOBAL_1 = "foo"
+118 | def fun():
+119 |     x = "local"
+120 |     _x = "shadows local" # [RUF052]
+    |     ^^ RUF052
+121 |     return _x
+    |
+    = help: Prefer using trailing underscores to avoid shadowing a variable
+
+RUF052.py:128:5: RUF052 Local dummy variable `_GLOBAL_1` is accessed
+    |
+127 | def unfixables():
+128 |     _GLOBAL_1 = "foo"
     |     ^^^^^^^^^ RUF052
-114 |     # unfixable because the rename would shadow a global variable
-115 |     print(_GLOBAL_1)  # [RUF052]
+129 |     # unfixable because the rename would shadow a global variable
+130 |     print(_GLOBAL_1)  # [RUF052]
     |
     = help: Prefer using trailing underscores to avoid shadowing a variable
 
-RUF052.py:121:5: RUF052 Local dummy variable `_local` is accessed
+RUF052.py:136:5: RUF052 Local dummy variable `_local` is accessed
     |
-120 |     # unfixable because the rename would shadow a local variable
-121 |     _local = "local3"  # [RUF052]
+135 |     # unfixable because the rename would shadow a local variable
+136 |     _local = "local3"  # [RUF052]
     |     ^^^^^^ RUF052
-122 |     print(_local)
+137 |     print(_local)
     |
     = help: Prefer using trailing underscores to avoid shadowing a variable
 
-RUF052.py:125:9: RUF052 Local dummy variable `_GLOBAL_1` is accessed
+RUF052.py:140:9: RUF052 Local dummy variable `_GLOBAL_1` is accessed
     |
-124 |     def nested():
-125 |         _GLOBAL_1 = "foo"
+139 |     def nested():
+140 |         _GLOBAL_1 = "foo"
     |         ^^^^^^^^^ RUF052
-126 |         # unfixable because the rename would shadow a global variable
-127 |         print(_GLOBAL_1)  # [RUF052]
+141 |         # unfixable because the rename would shadow a global variable
+142 |         print(_GLOBAL_1)  # [RUF052]
     |
     = help: Prefer using trailing underscores to avoid shadowing a variable
 
-RUF052.py:130:9: RUF052 Local dummy variable `_local` is accessed
+RUF052.py:145:9: RUF052 Local dummy variable `_local` is accessed
     |
-129 |         # unfixable because the rename would shadow a variable from the outer function
-130 |         _local = "local4"
+144 |         # unfixable because the rename would shadow a variable from the outer function
+145 |         _local = "local4"
     |         ^^^^^^ RUF052
-131 |         print(_local)
+146 |         print(_local)
     |
     = help: Prefer using trailing underscores to avoid shadowing a variable
 
-RUF052.py:138:5: RUF052 Local dummy variable `_P` is accessed
+RUF052.py:153:5: RUF052 Local dummy variable `_P` is accessed
     |
-136 |     from collections import namedtuple
-137 | 
-138 |     _P = ParamSpec("_P")
+151 |     from collections import namedtuple
+152 | 
+153 |     _P = ParamSpec("_P")
     |     ^^ RUF052
-139 |     _T = TypeVar(name="_T", covariant=True, bound=int|str)
-140 |     _NT = NamedTuple("_NT", [("foo", int)])
+154 |     _T = TypeVar(name="_T", covariant=True, bound=int|str)
+155 |     _NT = NamedTuple("_NT", [("foo", int)])
     |
     = help: Remove leading underscores
 
-RUF052.py:139:5: RUF052 Local dummy variable `_T` is accessed
+RUF052.py:154:5: RUF052 Local dummy variable `_T` is accessed
     |
-138 |     _P = ParamSpec("_P")
-139 |     _T = TypeVar(name="_T", covariant=True, bound=int|str)
+153 |     _P = ParamSpec("_P")
+154 |     _T = TypeVar(name="_T", covariant=True, bound=int|str)
     |     ^^ RUF052
-140 |     _NT = NamedTuple("_NT", [("foo", int)])
-141 |     _E = Enum("_E", ["a", "b", "c"])
+155 |     _NT = NamedTuple("_NT", [("foo", int)])
+156 |     _E = Enum("_E", ["a", "b", "c"])
     |
     = help: Remove leading underscores
 
-RUF052.py:140:5: RUF052 Local dummy variable `_NT` is accessed
+RUF052.py:155:5: RUF052 Local dummy variable `_NT` is accessed
     |
-138 |     _P = ParamSpec("_P")
-139 |     _T = TypeVar(name="_T", covariant=True, bound=int|str)
-140 |     _NT = NamedTuple("_NT", [("foo", int)])
+153 |     _P = ParamSpec("_P")
+154 |     _T = TypeVar(name="_T", covariant=True, bound=int|str)
+155 |     _NT = NamedTuple("_NT", [("foo", int)])
     |     ^^^ RUF052
-141 |     _E = Enum("_E", ["a", "b", "c"])
-142 |     _NT2 = namedtuple("_NT2", ['x', 'y', 'z'])
+156 |     _E = Enum("_E", ["a", "b", "c"])
+157 |     _NT2 = namedtuple("_NT2", ['x', 'y', 'z'])
     |
     = help: Remove leading underscores
 
-RUF052.py:141:5: RUF052 Local dummy variable `_E` is accessed
+RUF052.py:156:5: RUF052 Local dummy variable `_E` is accessed
     |
-139 |     _T = TypeVar(name="_T", covariant=True, bound=int|str)
-140 |     _NT = NamedTuple("_NT", [("foo", int)])
-141 |     _E = Enum("_E", ["a", "b", "c"])
+154 |     _T = TypeVar(name="_T", covariant=True, bound=int|str)
+155 |     _NT = NamedTuple("_NT", [("foo", int)])
+156 |     _E = Enum("_E", ["a", "b", "c"])
     |     ^^ RUF052
-142 |     _NT2 = namedtuple("_NT2", ['x', 'y', 'z'])
-143 |     _NT3 = namedtuple(typename="_NT3", field_names=['x', 'y', 'z'])
+157 |     _NT2 = namedtuple("_NT2", ['x', 'y', 'z'])
+158 |     _NT3 = namedtuple(typename="_NT3", field_names=['x', 'y', 'z'])
     |
     = help: Remove leading underscores
 
-RUF052.py:142:5: RUF052 Local dummy variable `_NT2` is accessed
+RUF052.py:157:5: RUF052 Local dummy variable `_NT2` is accessed
     |
-140 |     _NT = NamedTuple("_NT", [("foo", int)])
-141 |     _E = Enum("_E", ["a", "b", "c"])
-142 |     _NT2 = namedtuple("_NT2", ['x', 'y', 'z'])
+155 |     _NT = NamedTuple("_NT", [("foo", int)])
+156 |     _E = Enum("_E", ["a", "b", "c"])
+157 |     _NT2 = namedtuple("_NT2", ['x', 'y', 'z'])
     |     ^^^^ RUF052
-143 |     _NT3 = namedtuple(typename="_NT3", field_names=['x', 'y', 'z'])
-144 |     _DynamicClass = type("_DynamicClass", (), {})
+158 |     _NT3 = namedtuple(typename="_NT3", field_names=['x', 'y', 'z'])
+159 |     _DynamicClass = type("_DynamicClass", (), {})
     |
     = help: Remove leading underscores
 
-RUF052.py:143:5: RUF052 Local dummy variable `_NT3` is accessed
+RUF052.py:158:5: RUF052 Local dummy variable `_NT3` is accessed
     |
-141 |     _E = Enum("_E", ["a", "b", "c"])
-142 |     _NT2 = namedtuple("_NT2", ['x', 'y', 'z'])
-143 |     _NT3 = namedtuple(typename="_NT3", field_names=['x', 'y', 'z'])
+156 |     _E = Enum("_E", ["a", "b", "c"])
+157 |     _NT2 = namedtuple("_NT2", ['x', 'y', 'z'])
+158 |     _NT3 = namedtuple(typename="_NT3", field_names=['x', 'y', 'z'])
     |     ^^^^ RUF052
-144 |     _DynamicClass = type("_DynamicClass", (), {})
-145 |     _NotADynamicClass = type("_NotADynamicClass")
+159 |     _DynamicClass = type("_DynamicClass", (), {})
+160 |     _NotADynamicClass = type("_NotADynamicClass")
     |
     = help: Remove leading underscores
 
-RUF052.py:144:5: RUF052 Local dummy variable `_DynamicClass` is accessed
+RUF052.py:159:5: RUF052 Local dummy variable `_DynamicClass` is accessed
     |
-142 |     _NT2 = namedtuple("_NT2", ['x', 'y', 'z'])
-143 |     _NT3 = namedtuple(typename="_NT3", field_names=['x', 'y', 'z'])
-144 |     _DynamicClass = type("_DynamicClass", (), {})
+157 |     _NT2 = namedtuple("_NT2", ['x', 'y', 'z'])
+158 |     _NT3 = namedtuple(typename="_NT3", field_names=['x', 'y', 'z'])
+159 |     _DynamicClass = type("_DynamicClass", (), {})
     |     ^^^^^^^^^^^^^ RUF052
-145 |     _NotADynamicClass = type("_NotADynamicClass")
+160 |     _NotADynamicClass = type("_NotADynamicClass")
     |
     = help: Remove leading underscores
 
-RUF052.py:145:5: RUF052 Local dummy variable `_NotADynamicClass` is accessed
+RUF052.py:160:5: RUF052 Local dummy variable `_NotADynamicClass` is accessed
     |
-143 |     _NT3 = namedtuple(typename="_NT3", field_names=['x', 'y', 'z'])
-144 |     _DynamicClass = type("_DynamicClass", (), {})
-145 |     _NotADynamicClass = type("_NotADynamicClass")
+158 |     _NT3 = namedtuple(typename="_NT3", field_names=['x', 'y', 'z'])
+159 |     _DynamicClass = type("_DynamicClass", (), {})
+160 |     _NotADynamicClass = type("_NotADynamicClass")
     |     ^^^^^^^^^^^^^^^^^ RUF052
-146 | 
-147 |     print(_T, _P, _NT, _E, _NT2, _NT3, _DynamicClass, _NotADynamicClass)
+161 | 
+162 |     print(_T, _P, _NT, _E, _NT2, _NT3, _DynamicClass, _NotADynamicClass)
     |
     = help: Remove leading underscores

--- a/crates/ruff_python_semantic/src/binding.rs
+++ b/crates/ruff_python_semantic/src/binding.rs
@@ -445,7 +445,7 @@ impl Ranged for Binding<'_> {
 
 /// ID uniquely identifying a [Binding] in a program.
 ///
-/// Using a `u32` to identify [Binding]s should is sufficient because Ruff only supports documents with a
+/// Using a `u32` to identify [Binding]s should be sufficient because Ruff only supports documents with a
 /// size smaller than or equal to `u32::max`. A document with the size of `u32::max` must have fewer than `u32::max`
 /// bindings because bindings must be separated by whitespace (and have an assignment).
 #[newtype_index]

--- a/crates/ruff_python_semantic/src/model.rs
+++ b/crates/ruff_python_semantic/src/model.rs
@@ -1505,7 +1505,7 @@ impl<'a> SemanticModel<'a> {
                     kind: BindingKind::Assignment,
                     range: *range,
                     references: Vec::new(),
-                    scope: self.scope_id,
+                    scope: ScopeId::global(),
                     source: self.node_id,
                     context: self.execution_context(),
                     exceptions: self.exceptions(),


### PR DESCRIPTION
## Summary

Fixes #14996.  

BTW, the issue correctly reports a false positive given that [the docs](https://docs.astral.sh/ruff/rules/used-dummy-variable/#why-is-this-bad) say "Only local variables in function scopes are flagged by the rule".

## Test Plan

I added the false positive to the fixture and verified it indeed caused a false positive before my fix was done.
