### PR TITLE
Show errors for attempted fixes only when passed `--verbose`

### DIFF
--- a/crates/ruff/tests/integration_test.rs
+++ b/crates/ruff/tests/integration_test.rs
@@ -2132,9 +2132,18 @@ fn verbose_show_failed_fix_errors() {
     let mut cmd = RuffCheck::default()
         .args(["--select", "UP006", "--preview", "-v"])
         .build();
+
+    insta::with_settings!(
+            {
+                // the logs have timestamps we need to remove
+                filters => vec![(
+                    r"\[[\d:-]+]",
+                    ""
+                )]
+            },{
     assert_cmd_snapshot!(cmd
-        .pass_stdin("import typing\nCallable = 'abc'\ndef g() -> typing.Callable: ..."),
-            @r###"
+            .pass_stdin("import typing\nCallable = 'abc'\ndef g() -> typing.Callable: ..."),
+                @r###"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -2150,9 +2159,10 @@ fn verbose_show_failed_fix_errors() {
     Found 1 error.
 
     ----- stderr -----
-    [2025-01-03][00:40:50][ruff::resolve][DEBUG] Isolated mode, not reading any pyproject.toml
-    [2025-01-03][00:40:50][ruff_diagnostics::diagnostic][DEBUG] Failed to create fix for NonPEP585Annotation: Unable to insert `Callable` into scope due to name conflict
-    "###);
+    [ruff::resolve][DEBUG] Isolated mode, not reading any pyproject.toml
+    [ruff_diagnostics::diagnostic][DEBUG] Failed to create fix for NonPEP585Annotation: Unable to insert `Callable` into scope due to name conflict
+    "###);        }
+        );
 }
 
 #[test]

--- a/crates/ruff/tests/integration_test.rs
+++ b/crates/ruff/tests/integration_test.rs
@@ -2128,7 +2128,7 @@ unfixable = ["RUF"]
 }
 
 #[test]
-fn verbose_show_failed_fix_errors() -> Result<()> {
+fn verbose_show_failed_fix_errors() {
     let mut cmd = RuffCheck::default()
         .args(["--select", "UP006", "--preview", "-v"])
         .build();
@@ -2153,11 +2153,10 @@ fn verbose_show_failed_fix_errors() -> Result<()> {
     [2025-01-03][00:40:50][ruff::resolve][DEBUG] Isolated mode, not reading any pyproject.toml
     [2025-01-03][00:40:50][ruff_diagnostics::diagnostic][DEBUG] Failed to create fix for NonPEP585Annotation: Unable to insert `Callable` into scope due to name conflict
     "###);
-
-    Ok(())
 }
+
 #[test]
-fn no_verbose_hide_failed_fix_errors() -> Result<()> {
+fn no_verbose_hide_failed_fix_errors() {
     let mut cmd = RuffCheck::default()
         .args(["--select", "UP006", "--preview"])
         .build();
@@ -2180,6 +2179,4 @@ fn no_verbose_hide_failed_fix_errors() -> Result<()> {
 
     ----- stderr -----
     "###);
-
-    Ok(())
 }

--- a/crates/ruff/tests/integration_test.rs
+++ b/crates/ruff/tests/integration_test.rs
@@ -2126,3 +2126,60 @@ unfixable = ["RUF"]
 
     Ok(())
 }
+
+#[test]
+fn verbose_show_failed_fix_errors() -> Result<()> {
+    let mut cmd = RuffCheck::default()
+        .args(["--select", "UP006", "--preview", "-v"])
+        .build();
+    assert_cmd_snapshot!(cmd
+        .pass_stdin("import typing\nCallable = 'abc'\ndef g() -> typing.Callable: ..."),
+            @r###"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    -:3:12: UP006 Use `collections.abc.Callable` instead of `typing.Callable` for type annotation
+      |
+    1 | import typing
+    2 | Callable = 'abc'
+    3 | def g() -> typing.Callable: ...
+      |            ^^^^^^^^^^^^^^^ UP006
+      |
+      = help: Replace with `collections.abc.Callable`
+
+    Found 1 error.
+
+    ----- stderr -----
+    [2025-01-03][00:40:50][ruff::resolve][DEBUG] Isolated mode, not reading any pyproject.toml
+    [2025-01-03][00:40:50][ruff_diagnostics::diagnostic][DEBUG] Failed to create fix for NonPEP585Annotation: Unable to insert `Callable` into scope due to name conflict
+    "###);
+
+    Ok(())
+}
+#[test]
+fn no_verbose_hide_failed_fix_errors() -> Result<()> {
+    let mut cmd = RuffCheck::default()
+        .args(["--select", "UP006", "--preview"])
+        .build();
+    assert_cmd_snapshot!(cmd
+        .pass_stdin("import typing\nCallable = 'abc'\ndef g() -> typing.Callable: ..."),
+            @r###"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    -:3:12: UP006 Use `collections.abc.Callable` instead of `typing.Callable` for type annotation
+      |
+    1 | import typing
+    2 | Callable = 'abc'
+    3 | def g() -> typing.Callable: ...
+      |            ^^^^^^^^^^^^^^^ UP006
+      |
+      = help: Replace with `collections.abc.Callable`
+
+    Found 1 error.
+
+    ----- stderr -----
+    "###);
+
+    Ok(())
+}

--- a/crates/ruff_diagnostics/src/diagnostic.rs
+++ b/crates/ruff_diagnostics/src/diagnostic.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use log::error;
+use log::debug;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
@@ -56,7 +56,7 @@ impl Diagnostic {
     pub fn try_set_fix(&mut self, func: impl FnOnce() -> Result<Fix>) {
         match func() {
             Ok(fix) => self.fix = Some(fix),
-            Err(err) => error!("Failed to create fix for {}: {}", self.kind.name, err),
+            Err(err) => debug!("Failed to create fix for {}: {}", self.kind.name, err),
         }
     }
 
@@ -67,7 +67,7 @@ impl Diagnostic {
         match func() {
             Ok(None) => {}
             Ok(Some(fix)) => self.fix = Some(fix),
-            Err(err) => error!("Failed to create fix for {}: {}", self.kind.name, err),
+            Err(err) => debug!("Failed to create fix for {}: {}", self.kind.name, err),
         }
     }
 

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_with.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_with.rs
@@ -193,7 +193,7 @@ pub(crate) fn multiple_with_statements(
                     }
                     Err(err) => bail!("Failed to collapse `with`: {err}"),
                 }
-            })
+            });
         }
         checker.diagnostics.push(diagnostic);
     }

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/collapsible_if.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/collapsible_if.rs
@@ -136,7 +136,7 @@ pub(crate) fn nested_if_statements(
                 }
                 Err(err) => bail!("Failed to collapse `if`: {err}"),
             }
-        })
+        });
     }
     checker.diagnostics.push(diagnostic);
 }

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/deprecated_mock_import.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/deprecated_mock_import.rs
@@ -3,7 +3,7 @@ use libcst_native::{
     AsName, AssignTargetExpression, Attribute, Dot, Expression, Import, ImportAlias, ImportFrom,
     ImportNames, Name, NameOrAttribute, ParenthesizableWhitespace,
 };
-use log::error;
+use log::debug;
 
 use ruff_diagnostics::{AlwaysFixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, ViolationMetadata};
@@ -286,7 +286,7 @@ pub(crate) fn deprecated_mock_import(checker: &mut Checker, stmt: &Stmt) {
                     match format_import(stmt, indent, checker.locator(), checker.stylist()) {
                         Ok(content) => Some(content),
                         Err(e) => {
-                            error!("Failed to rewrite `mock` import: {e}");
+                            debug!("Failed to rewrite `mock` import: {e}");
                             None
                         }
                     }


### PR DESCRIPTION
The default logging level for diagnostics includes logs written using the `log` crate with level `error`, `warn`, and `info`. An unsuccessful fix attached to a diagnostic via `try_set_fix` or `try_set_optional_fix` was logged at level `error`. Note that the user would see these messages even without passing `--fix`, and possibly also on lines with `noqa` comments.

This PR changes the logging level here to a `debug`. We also found ad-hoc instances of error logging in the implementations of several rules, and have replaced those with either a `debug` or call to `try_set{_optional}_fix`.

Closes #15229