### PR TITLE
feat(AIR302): check whether removed context key "conf" is access through context.get(...)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/airflow/AIR302_context.py
+++ b/crates/ruff_linter/resources/test/fixtures/airflow/AIR302_context.py
@@ -1,0 +1,35 @@
+import pendulum
+
+from airflow.decorators import dag, task
+from airflow.providers.standard.operators.python import PythonOperator
+
+
+def access_invalid_key_in_context(**context):
+    print("access invalid key", context["conf"])
+
+
+@task
+def access_invalid_key_task_out_of_dag(**context):
+    print("access invalid key", context.get("conf"))
+
+
+@dag(
+    schedule=None,
+    start_date=pendulum.datetime(2021, 1, 1, tz="UTC"),
+    catchup=False,
+    tags=[""],
+)
+def invalid_dag():
+    @task()
+    def access_invalid_key_task(**context):
+        print("access invalid key", context.get("conf"))
+
+    task1 = PythonOperator(
+        task_id="task1",
+        python_callable=access_invalid_key_in_context,
+    )
+    access_invalid_key_task() >> task1
+    access_invalid_key_task_out_of_dag()
+
+
+invalid_dag()

--- a/crates/ruff_linter/src/rules/airflow/mod.rs
+++ b/crates/ruff_linter/src/rules/airflow/mod.rs
@@ -18,6 +18,7 @@ mod tests {
     #[test_case(Rule::Airflow3Removal, Path::new("AIR302_names.py"))]
     #[test_case(Rule::Airflow3Removal, Path::new("AIR302_class_attribute.py"))]
     #[test_case(Rule::Airflow3Removal, Path::new("AIR302_airflow_plugin.py"))]
+    #[test_case(Rule::Airflow3Removal, Path::new("AIR302_context.py"))]
     #[test_case(Rule::Airflow3MovedToProvider, Path::new("AIR303.py"))]
     fn rules(rule_code: Rule, path: &Path) -> Result<()> {
         let snapshot = format!("{}_{}", rule_code.noqa_code(), path.to_string_lossy());

--- a/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_args.py.snap
+++ b/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_args.py.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/ruff_linter/src/rules/airflow/mod.rs
+snapshot_kind: text
 ---
 AIR302_args.py:18:39: AIR302 [*] `schedule_interval` is removed in Airflow 3.0
    |

--- a/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_context.py.snap
+++ b/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_context.py.snap
@@ -1,0 +1,21 @@
+---
+source: crates/ruff_linter/src/rules/airflow/mod.rs
+snapshot_kind: text
+---
+AIR302_context.py:13:45: AIR302 `conf` is removed in Airflow 3.0
+   |
+11 | @task
+12 | def access_invalid_key_task_out_of_dag(**context):
+13 |     print("access invalid key", context.get("conf"))
+   |                                             ^^^^^^ AIR302
+   |
+
+AIR302_context.py:25:49: AIR302 `conf` is removed in Airflow 3.0
+   |
+23 |     @task()
+24 |     def access_invalid_key_task(**context):
+25 |         print("access invalid key", context.get("conf"))
+   |                                                 ^^^^^^ AIR302
+26 | 
+27 |     task1 = PythonOperator(
+   |


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

context key `conf` is removed in Airflow3. This PR handle the case that these keys are accessed through `context.get(...)`

e.g.,

```python
@task
def func(**context):
    context.get("conf")

@task()
def func(**context):
    context.get("conf")
```

## Test Plan

<!-- How was it tested? -->
A test fixture is included in the PR.
