### PR TITLE
Attribute panics to the mdtests that cause them

### DIFF
--- a/crates/red_knot_test/src/lib.rs
+++ b/crates/red_knot_test/src/lib.rs
@@ -140,15 +140,10 @@ fn run_test(db: &mut db::Db, test: &parser::MarkdownTest) -> Result<(), Failures
             let type_diagnostics = match catch_unwind(|| check_types(db, test_file.file)) {
                 Ok(type_diagnostics) => type_diagnostics,
                 Err(info) => {
-                    eprintln!("panic in test");
                     let mut by_line = matcher::FailuresByLine::default();
                     by_line.push(
                         OneIndexed::from_zero_indexed(0),
-                        info.info
-                            .to_string()
-                            .split('\n')
-                            .map(String::from)
-                            .collect(),
+                        info.info.split('\n').map(String::from).collect(),
                     );
                     return Some(FileFailures {
                         backtick_offset: test_file.backtick_offset,

--- a/crates/red_knot_test/src/lib.rs
+++ b/crates/red_knot_test/src/lib.rs
@@ -6,10 +6,11 @@ use red_knot_python_semantic::types::check_types;
 use red_knot_python_semantic::Program;
 use ruff_db::diagnostic::{Diagnostic, ParseDiagnostic};
 use ruff_db::files::{system_path_to_file, File, Files};
+use ruff_db::panic::catch_unwind;
 use ruff_db::parsed::parsed_module;
 use ruff_db::system::{DbWithTestSystem, SystemPathBuf};
 use ruff_db::testing::{setup_logging, setup_logging_with_filter};
-use ruff_source_file::LineIndex;
+use ruff_source_file::{LineIndex, OneIndexed};
 use ruff_text_size::TextSize;
 use salsa::Setter;
 
@@ -136,7 +137,25 @@ fn run_test(db: &mut db::Db, test: &parser::MarkdownTest) -> Result<(), Failures
                 })
                 .collect();
 
-            let type_diagnostics = check_types(db, test_file.file);
+            let type_diagnostics = match catch_unwind(|| check_types(db, test_file.file)) {
+                Ok(type_diagnostics) => type_diagnostics,
+                Err(info) => {
+                    eprintln!("panic in test");
+                    let mut by_line = matcher::FailuresByLine::default();
+                    by_line.push(
+                        OneIndexed::from_zero_indexed(0),
+                        info.info
+                            .to_string()
+                            .split('\n')
+                            .map(String::from)
+                            .collect(),
+                    );
+                    return Some(FileFailures {
+                        backtick_offset: test_file.backtick_offset,
+                        by_line,
+                    });
+                }
+            };
             diagnostics.extend(type_diagnostics.into_iter().map(|diagnostic| {
                 let diagnostic: Box<dyn Diagnostic> = Box::new((*diagnostic).clone());
                 diagnostic

--- a/crates/red_knot_test/src/matcher.rs
+++ b/crates/red_knot_test/src/matcher.rs
@@ -27,7 +27,7 @@ impl FailuresByLine {
         })
     }
 
-    fn push(&mut self, line_number: OneIndexed, messages: Vec<String>) {
+    pub(super) fn push(&mut self, line_number: OneIndexed, messages: Vec<String>) {
         let start = self.failures.len();
         self.failures.extend(messages);
         self.lines.push(LineFailures {

--- a/crates/ruff/src/commands/check.rs
+++ b/crates/ruff/src/commands/check.rs
@@ -11,6 +11,7 @@ use log::{debug, error, warn};
 use rayon::prelude::*;
 use rustc_hash::FxHashMap;
 
+use ruff_db::panic::catch_unwind;
 use ruff_diagnostics::Diagnostic;
 use ruff_linter::message::Message;
 use ruff_linter::package::PackageRoot;
@@ -27,7 +28,6 @@ use ruff_workspace::resolver::{
 use crate::args::ConfigArguments;
 use crate::cache::{Cache, PackageCacheMap, PackageCaches};
 use crate::diagnostics::Diagnostics;
-use crate::panic::catch_unwind;
 
 /// Run the linter over a collection of files.
 #[allow(clippy::too_many_arguments)]

--- a/crates/ruff/src/commands/format.rs
+++ b/crates/ruff/src/commands/format.rs
@@ -15,6 +15,7 @@ use rustc_hash::FxHashSet;
 use thiserror::Error;
 use tracing::debug;
 
+use ruff_db::panic::{catch_unwind, PanicError};
 use ruff_diagnostics::SourceMap;
 use ruff_linter::fs;
 use ruff_linter::logging::{DisplayParseError, LogLevel};
@@ -32,7 +33,6 @@ use ruff_workspace::FormatterSettings;
 
 use crate::args::{ConfigArguments, FormatArguments, FormatRange};
 use crate::cache::{Cache, FileCacheKey, PackageCacheMap, PackageCaches};
-use crate::panic::{catch_unwind, PanicError};
 use crate::resolve::resolve;
 use crate::{resolve_default_files, ExitStatus};
 

--- a/crates/ruff/src/lib.rs
+++ b/crates/ruff/src/lib.rs
@@ -29,7 +29,6 @@ pub mod args;
 mod cache;
 mod commands;
 mod diagnostics;
-mod panic;
 mod printer;
 pub mod resolve;
 mod stdin;

--- a/crates/ruff_db/src/lib.rs
+++ b/crates/ruff_db/src/lib.rs
@@ -10,6 +10,7 @@ pub mod diagnostic;
 pub mod display;
 pub mod file_revision;
 pub mod files;
+pub mod panic;
 pub mod parsed;
 pub mod source;
 pub mod system;

--- a/crates/ruff_db/src/panic.rs
+++ b/crates/ruff_db/src/panic.rs
@@ -1,7 +1,7 @@
 #[derive(Default, Debug)]
-pub(crate) struct PanicError {
-    pub(crate) info: String,
-    pub(crate) backtrace: Option<std::backtrace::Backtrace>,
+pub struct PanicError {
+    pub info: String,
+    pub backtrace: Option<std::backtrace::Backtrace>,
 }
 
 impl std::fmt::Display for PanicError {
@@ -21,7 +21,7 @@ thread_local! {
 
 /// [`catch_unwind`](std::panic::catch_unwind) wrapper that sets a custom [`set_hook`](std::panic::set_hook)
 /// to extract the backtrace. The original panic-hook gets restored before returning.
-pub(crate) fn catch_unwind<F, R>(f: F) -> Result<R, PanicError>
+pub fn catch_unwind<F, R>(f: F) -> Result<R, PanicError>
 where
     F: FnOnce() -> R + std::panic::UnwindSafe,
 {


### PR DESCRIPTION
This updates the mdtest harness to catch any panics that occur during type checking, and to display the panic message as an mdtest failure.  (We don't know which specific line causes the failure, so we attribute panics to the first line of the test case.)

Sample output (for an artificial panic):

```
---- mdtest__unary_integers stdout ----

integers.md - Unary Operations - Unary Addition

  crates/red_knot_python_semantic/resources/mdtest/unary/integers.md:6 panicked at crates/red_knot_python_semantic/src/types/infer.rs:3264:66:
  crates/red_knot_python_semantic/resources/mdtest/unary/integers.md:6 bonk

To rerun this specific test, set the environment variable: MDTEST_TEST_FILTER="integers.md - Unary Operations - Unary Addition"
MDTEST_TEST_FILTER="integers.md - Unary Operations - Unary Addition" cargo test -p red_knot_python_semantic --test mdtest -- mdtest__unary_integers

integers.md - Unary Operations - Unary Subtraction

  crates/red_knot_python_semantic/resources/mdtest/unary/integers.md:14 panicked at crates/red_knot_python_semantic/src/types/infer.rs:3265:66:
  crates/red_knot_python_semantic/resources/mdtest/unary/integers.md:14 foobar

To rerun this specific test, set the environment variable: MDTEST_TEST_FILTER="integers.md - Unary Operations - Unary Subtraction"
MDTEST_TEST_FILTER="integers.md - Unary Operations - Unary Subtraction" cargo test -p red_knot_python_semantic --test mdtest -- mdtest__unary_integers
```

Closes #13899 