### PR TITLE
[red-knot] Remove unneeded branch in `Type::is_equivalent_to()`

### DIFF
--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -1010,26 +1010,6 @@ impl<'db> Type<'db> {
             return false;
         }
 
-        // TODO: The following is a workaround that is required to unify the two different versions
-        // of `NoneType` and `NoDefaultType` in typeshed. This should not be required anymore once
-        // we understand `sys.version_info` branches.
-        if let (
-            Type::Instance(InstanceType { class: self_class }),
-            Type::Instance(InstanceType {
-                class: target_class,
-            }),
-        ) = (self, other)
-        {
-            let self_known = self_class.known(db);
-            if matches!(
-                self_known,
-                Some(KnownClass::NoneType | KnownClass::NoDefaultType)
-            ) && self_known == target_class.known(db)
-            {
-                return true;
-            }
-        }
-
         // type[object] ≡ type
         if let (
             Type::SubclassOf(SubclassOfType {


### PR DESCRIPTION
## Summary

We understand `sys.version_info` branches now! As such, I _believe_ this branch is no longer required; all tests pass without it. I also ran `QUICKCHECK_TESTS=100000 cargo test -p red_knot_python_semantic -- --ignored types::property_tests::stable`, and no tests failed except for the known issue with `Type::is_assignable_to()` (https://github.com/astral-sh/ruff/issues/14899)

## Test Plan

See above
