### PR TITLE
Make unreachable a test rule for now

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -386,7 +386,7 @@ jobs:
       - name: "Install Rust toolchain"
         run: rustup component add rustfmt
       - uses: Swatinem/rust-cache@v2
-      - run: ./scripts/add_rule.py --name DoTheThing --prefix PL --code C0999 --linter pylint
+      - run: ./scripts/add_rule.py --name DoTheThing --prefix F --code 999 --linter pyflakes
       - run: cargo check
       - run: cargo fmt --all --check
       - run: |

--- a/crates/ruff_linter/src/checkers/ast/analyze/statement.rs
+++ b/crates/ruff_linter/src/checkers/ast/analyze/statement.rs
@@ -366,6 +366,7 @@ pub(crate) fn statement(stmt: &Stmt, checker: &mut Checker) {
             if checker.enabled(Rule::AsyncFunctionWithTimeout) {
                 flake8_async::rules::async_function_with_timeout(checker, function_def);
             }
+            #[cfg(any(feature = "test-rules", test))]
             if checker.enabled(Rule::UnreachableCode) {
                 checker
                     .diagnostics

--- a/crates/ruff_linter/src/codes.rs
+++ b/crates/ruff_linter/src/codes.rs
@@ -268,6 +268,7 @@ pub fn code_to_rule(linter: Linter, code: &str) -> Option<(RuleGroup, Rule)> {
         (Pylint, "R6104") => (RuleGroup::Preview, rules::pylint::rules::NonAugmentedAssignment),
         (Pylint, "R6201") => (RuleGroup::Preview, rules::pylint::rules::LiteralMembership),
         (Pylint, "R6301") => (RuleGroup::Preview, rules::pylint::rules::NoSelfUse),
+        #[cfg(any(feature = "test-rules", test))]
         (Pylint, "W0101") => (RuleGroup::Preview, rules::pylint::rules::UnreachableCode),
         (Pylint, "W0108") => (RuleGroup::Preview, rules::pylint::rules::UnnecessaryLambda),
         (Pylint, "W0177") => (RuleGroup::Preview, rules::pylint::rules::NanComparison),

--- a/crates/ruff_linter/src/rules/pylint/rules/mod.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/mod.rs
@@ -95,6 +95,7 @@ pub(crate) use unnecessary_direct_lambda_call::*;
 pub(crate) use unnecessary_dunder_call::*;
 pub(crate) use unnecessary_lambda::*;
 pub(crate) use unnecessary_list_index_lookup::*;
+#[cfg(any(feature = "test-rules", test))]
 pub(crate) use unreachable::*;
 pub(crate) use unspecified_encoding::*;
 pub(crate) use useless_else_on_loop::*;
@@ -202,6 +203,7 @@ mod unnecessary_direct_lambda_call;
 mod unnecessary_dunder_call;
 mod unnecessary_lambda;
 mod unnecessary_list_index_lookup;
+#[cfg(any(feature = "test-rules", test))]
 mod unreachable;
 mod unspecified_encoding;
 mod useless_else_on_loop;


### PR DESCRIPTION
## Summary

I want to do a bugfix release after we reverted the problematic changes with UP006 (see https://github.com/astral-sh/ruff/pull/15250) 
but I'm worried that the new unreachable rule results in infinite loops as reported here https://github.com/astral-sh/ruff/issues/15248

That's why I'm excluding the unreachable rule from the bugfix release for now. We should do some more fuzzing before promoting the rule to preview.

## Test Plan

`cargo test` and `cargo test --release`

the rule can no longer be selected: 

```shell
❯ cargo run -- check --select PLW0101
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.13s
     Running `target/debug/ruff check --select PLW0101`
error: invalid value 'PLW0101' for '--select <RULE_CODE>'

For more information, try '--help'.
```

There are no ecosystem changes because the ecosystem tests build with the test rules feature enabled.
