### PR TITLE
[red-knot] Improve `Type::is_disjoint_from()` for `KnownInstanceType`s

### DIFF
--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -1194,12 +1194,12 @@ impl<'db> Type<'db> {
                 ty.bool(db).is_always_true()
             }
 
-            (Type::SubclassOf(_), _) | (_, Type::SubclassOf(_)) => {
-                // TODO: Once we have support for final classes, we can determine disjointness in some cases
+            (Type::SubclassOf(_), other) | (other, Type::SubclassOf(_)) => {
+                // TODO: Once we have support for final classes, we can determine disjointness in more cases
                 // here. However, note that it might be better to turn `Type::SubclassOf('FinalClass')` into
                 // `Type::ClassLiteral('FinalClass')` during construction, instead of adding special cases for
                 // final classes inside `Type::SubclassOf` everywhere.
-                false
+                other.is_disjoint_from(db, KnownClass::Type.to_instance(db))
             }
 
             (Type::KnownInstance(known_instance), Type::Instance(InstanceType { class }))
@@ -4180,6 +4180,7 @@ pub(crate) mod tests {
     #[test_case(Ty::SubclassOfBuiltinClass("str"), Ty::LiteralString)]
     #[test_case(Ty::AlwaysFalsy, Ty::AlwaysTruthy)]
     #[test_case(Ty::Tuple(vec![]), Ty::TypingLiteral)]
+    #[test_case(Ty::TypingLiteral, Ty::SubclassOfBuiltinClass("object"))]
     fn is_disjoint_from(a: Ty, b: Ty) {
         let db = setup_db();
         let a = a.into_type(&db);

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -1207,13 +1207,10 @@ impl<'db> Type<'db> {
                 !known_instance.is_instance_of(db, class)
             }
 
-            (Type::KnownInstance(known_instance), Type::Tuple(_))
-            | (Type::Tuple(_), Type::KnownInstance(known_instance)) => KnownClass::Tuple
-                .to_class_literal(db)
-                .into_class_literal()
-                .is_some_and(|ClassLiteralType { class: tuple_class }| {
-                    !known_instance.class().is_subclass_of(db, tuple_class)
-                }),
+            (known_instance_ty @ Type::KnownInstance(_), Type::Tuple(_))
+            | (Type::Tuple(_), known_instance_ty @ Type::KnownInstance(_)) => {
+                known_instance_ty.is_disjoint_from(db, KnownClass::Tuple.to_instance(db))
+            }
 
             (
                 Type::Instance(InstanceType { class: class_none }),


### PR DESCRIPTION
## Summary

Two things are fixed here:
- If we have a known instance (e.g. `KnownInstance::TypingLiteral`) that was an instance of `typing._SpecialForm`, we currently don't recognise that this type is disjoint from a class `Foo` that is a subclass of `typing._SpecialForm`. This is a _bit_ theoretical, as `KnownInstance`s in our model are generally instances of classes that cannot be subclassed (at least, not easily). However, fixing this bug revealed (thanks to the property tests) that...
- We don't currently consider `Type::Tuple([])` to be disjoint from `Type::KnownInstance(KnownInstanceType::TypingLiteral)`.

## Test Plan

- Added a new unit test that ensures that `Type::Tuple([])` is now considered disjoint from `Type::KnownInstance(KnownInstanceType::TypingLiteral)`.
- Ran `QUICKCHECK_TESTS=200000 cargo test -p red_knot_python_semantic -- --ignored types::property_tests::stable` to ensure that there are no new failures in the property tests

