### PR TITLE
[red-knot] `Type::SubclassOf(SubclassOfType { base: ClassBase::Unknown }).to_instance()` should be `Unknown`, not `Any`

### DIFF
--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -1952,10 +1952,12 @@ impl<'db> Type<'db> {
             Type::Unknown => Type::Unknown,
             Type::Never => Type::Never,
             Type::ClassLiteral(ClassLiteralType { class }) => Type::instance(*class),
-            Type::SubclassOf(SubclassOfType {
-                base: ClassBase::Class(class),
-            }) => Type::instance(*class),
-            Type::SubclassOf(_) => Type::Any,
+            Type::SubclassOf(SubclassOfType { base }) => match base {
+                ClassBase::Class(class) => Type::instance(*class),
+                ClassBase::Any => Type::Any,
+                ClassBase::Unknown => Type::Unknown,
+                ClassBase::Todo(todo) => Type::Todo(*todo),
+            },
             Type::Union(union) => union.map(db, |element| element.to_instance(db)),
             Type::Intersection(_) => todo_type!("Type::Intersection.to_instance()"),
             // TODO: calling `.to_instance()` on any of these should result in a diagnostic,


### PR DESCRIPTION
## Summary

I noticed this micro-bug while working on something else.

## Test Plan

I haven't added a test here because:
- I don't know if there's currently a way to reproduce the bug from Python, so I'm not sure it's possible to write an mdtest for this
- I could add a unit test, but I'm not sure it would really be helpful. The logic being modified here is fairly trivial; adding a unit test just feels like it would make this code harder to refactor, if we ever did want to refactor the structure of `SubclassOfType`
