### PR TITLE
Upgrade zizmor to the latest version in CI

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -48,11 +48,13 @@ jobs:
 
       - name: Check tag consistency
         if: ${{ inputs.plan != '' && !fromJson(inputs.plan).announcement_tag_is_implicit }}
+        env:
+          TAG: ${{ inputs.plan != '' && fromJson(inputs.plan).announcement_tag || 'dry-run' }}
         run: |
           version=$(grep "version = " pyproject.toml | sed -e 's/version = "\(.*\)"/\1/g')
-          if [ "${{ fromJson(inputs.plan).announcement_tag }}" != "${version}" ]; then
+          if [ "${TAG}" != "${version}" ]; then
             echo "The input tag does not match the version from pyproject.toml:" >&2
-            echo "${{ fromJson(inputs.plan).announcement_tag }}" >&2
+            echo "${TAG}" >&2
             echo "${version}" >&2
             exit 1
           else
@@ -175,6 +177,8 @@ jobs:
 
       - name: Generate Dynamic Dockerfile Tags
         shell: bash
+        env:
+          TAG_VALUE: ${{ fromJson(inputs.plan).announcement_tag }}
         run: |
           set -euo pipefail
 
@@ -195,8 +199,8 @@ jobs:
           # Loop through all base tags and append its docker metadata pattern to the list
           # Order is on purpose such that the label org.opencontainers.image.version has the first pattern with the full version
           IFS=','; for TAG in ${BASE_TAGS}; do
-            TAG_PATTERNS="${TAG_PATTERNS}type=pep440,pattern={{ version }},suffix=-${TAG},value=${{ fromJson(inputs.plan).announcement_tag }}\n"
-            TAG_PATTERNS="${TAG_PATTERNS}type=pep440,pattern={{ major }}.{{ minor }},suffix=-${TAG},value=${{ fromJson(inputs.plan).announcement_tag }}\n"
+            TAG_PATTERNS="${TAG_PATTERNS}type=pep440,pattern={{ version }},suffix=-${TAG},value=${TAG_VALUE}\n"
+            TAG_PATTERNS="${TAG_PATTERNS}type=pep440,pattern={{ major }}.{{ minor }},suffix=-${TAG},value=${TAG_VALUE}}\n"
             TAG_PATTERNS="${TAG_PATTERNS}type=raw,value=${TAG}\n"
           done
 

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -33,8 +33,9 @@ jobs:
           python-version: 3.12
 
       - name: "Set docs version"
+        env:
+          version: ${{ (inputs.plan != '' && fromJson(inputs.plan).announcement_tag) || inputs.ref }}
         run: |
-          version="${{ (inputs.plan != '' && fromJson(inputs.plan).announcement_tag) || inputs.ref }}"
           # if version is missing, use 'latest'
           if [ -z "$version" ]; then
             echo "Using 'latest' as version"

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,6 +1,12 @@
 # Configuration for the zizmor static analysis tool, run via pre-commit in CI
 # https://woodruffw.github.io/zizmor/configuration/
+#
+# TODO: can we remove the ignores here so that our workflows are more secure?
 rules:
   dangerous-triggers:
     ignore:
       - pr-comment.yaml
+  cache-poisoning:
+    ignore:
+      - build-docker.yml
+      - publish-playground.yml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -91,7 +91,7 @@ repos:
   # zizmor detects security vulnerabilities in GitHub Actions workflows.
   # Additional configuration for the tool is found in `.github/zizmor.yml`
   - repo: https://github.com/woodruffw/zizmor-pre-commit
-    rev: v0.10.0
+    rev: v1.0.0
     hooks:
       - id: zizmor
 


### PR DESCRIPTION
## Summary

This PR upgrades zizmor to the latest release in our CI. zizmor is a static analyzer checking for security issues in GitHub workflows. The new release finds some new issues in our workflows; this PR fixes some of the issues, and adds ignores for some other issues.

The issues fixed in this PR are new cases of zizmor's [`template-injection`](https://woodruffw.github.io/zizmor/audits/#template-injection) rule being emitted. The issues I'm ignoring for now are all to do with the [`cache-poisoning`](https://woodruffw.github.io/zizmor/audits/#cache-poisoning) rule. The main reason I'm fixing some but ignoring others is that I'm confident fixing the template-injection diagnostics won't have any impact on how our workflows operate in CI, but I'm worried that fixing the cache-poisoning diagnostics could slow down our CI a fair bit. I don't mind if somebody else is motivated to try to fix these diagnostics, but for now I think I'd prefer to just ignore them; it doesn't seem high-priority enough to try to fix them right now :-)

## Test Plan

- `uvx pre-commit run -a --hook-stage=manual` passes locally
- Let's see if CI passes on this PR...
