### PR TITLE
[`pycodestyle`] Handle each cell separately for `too-many-newlines-at-end-of-file` (`W391`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pycodestyle/W391.ipynb
+++ b/crates/ruff_linter/resources/test/fixtures/pycodestyle/W391.ipynb
@@ -1,0 +1,92 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "True\n"
+     ]
+    }
+   ],
+   "source": [
+    "True"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# just a comment in this cell"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# a comment and some newlines\n",
+    "\n",
+    "\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "1 + 1\n",
+    "# a comment\n",
+    "\n",
+    "\n",
+    "\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "1+1\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "\n",
+    "\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/crates/ruff_linter/src/checkers/tokens.rs
+++ b/crates/ruff_linter/src/checkers/tokens.rs
@@ -183,7 +183,11 @@ pub(crate) fn check_tokens(
     }
 
     if settings.rules.enabled(Rule::TooManyNewlinesAtEndOfFile) {
-        pycodestyle::rules::too_many_newlines_at_end_of_file(&mut diagnostics, tokens);
+        pycodestyle::rules::too_many_newlines_at_end_of_file(
+            &mut diagnostics,
+            tokens,
+            cell_offsets,
+        );
     }
 
     diagnostics.retain(|diagnostic| settings.rules.enabled(diagnostic.kind.rule()));

--- a/crates/ruff_linter/src/rules/pycodestyle/mod.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/mod.rs
@@ -79,6 +79,7 @@ mod tests {
     #[test_case(Rule::TooManyNewlinesAtEndOfFile, Path::new("W391_2.py"))]
     #[test_case(Rule::TooManyNewlinesAtEndOfFile, Path::new("W391_3.py"))]
     #[test_case(Rule::TooManyNewlinesAtEndOfFile, Path::new("W391_4.py"))]
+    #[test_case(Rule::TooManyNewlinesAtEndOfFile, Path::new("W391.ipynb"))]
     fn preview_rules(rule_code: Rule, path: &Path) -> Result<()> {
         let snapshot = format!(
             "preview__{}_{}",

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/too_many_newlines_at_end_of_file.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/too_many_newlines_at_end_of_file.rs
@@ -1,6 +1,9 @@
+use std::iter::Peekable;
+
 use ruff_diagnostics::{AlwaysFixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, ViolationMetadata};
-use ruff_python_parser::{TokenKind, Tokens};
+use ruff_notebook::CellOffsets;
+use ruff_python_parser::{Token, TokenKind, Tokens};
 use ruff_text_size::{Ranged, TextRange, TextSize};
 
 /// ## What it does
@@ -48,42 +51,96 @@ impl AlwaysFixableViolation for TooManyNewlinesAtEndOfFile {
 }
 
 /// W391
-pub(crate) fn too_many_newlines_at_end_of_file(diagnostics: &mut Vec<Diagnostic>, tokens: &Tokens) {
-    let mut num_trailing_newlines = 0u32;
-    let mut start: Option<TextSize> = None;
-    let mut end: Option<TextSize> = None;
+pub(crate) fn too_many_newlines_at_end_of_file(
+    diagnostics: &mut Vec<Diagnostic>,
+    tokens: &Tokens,
+    cell_offsets: Option<&CellOffsets>,
+) {
+    let Some(last_token) = tokens.last() else {
+        return;
+    };
+    let last_textsize = last_token.end();
 
-    // Count the number of trailing newlines.
-    for token in tokens.iter().rev() {
-        match token.kind() {
-            TokenKind::NonLogicalNewline | TokenKind::Newline => {
-                if num_trailing_newlines == 0 {
-                    end = Some(token.end());
-                }
-                start = Some(token.end());
-                num_trailing_newlines += 1;
-            }
-            TokenKind::Dedent => continue,
-            _ => {
+    let tokens_iter = tokens.iter().rev().peekable();
+
+    let newline_diagnostics = if let Some(cell_offsets) = cell_offsets {
+        let offset_iter = cell_offsets.iter().rev().peekable();
+        collect_trailing_newlines_diagnostics(tokens_iter, offset_iter)
+    } else {
+        // To handle notebooks and ordinary source files uniformly,
+        // we "convert" the source type to a notebook by appending
+        // a newline.
+        let last_textsize = last_textsize + TextSize::from(1);
+        let offset_iter = std::iter::once(&last_textsize).peekable();
+        collect_trailing_newlines_diagnostics(tokens_iter, offset_iter)
+    };
+    diagnostics.extend(newline_diagnostics);
+}
+
+fn collect_trailing_newlines_diagnostics<'a>(
+    mut tokens_iter: Peekable<impl Iterator<Item = &'a Token>>,
+    offset_iter: Peekable<impl Iterator<Item = &'a TextSize>>,
+) -> Vec<Diagnostic> {
+    let mut results = Vec::new();
+
+    // NB: When interpreting the below, recall that the iterators
+    // passed into this function are reversed.
+    for &offset in offset_iter {
+        // Advance to the offset
+        while let Some(next_token) = tokens_iter.peek() {
+            if next_token.end() >= offset {
+                tokens_iter.next();
+            } else {
                 break;
             }
         }
-    }
 
-    if num_trailing_newlines == 0 || num_trailing_newlines == 1 {
-        return;
-    }
+        let mut num_trailing_newlines: u32 = 0;
+        let mut newline_range_start: Option<TextSize> = None;
+        let mut newline_range_end: Option<TextSize> = None;
 
-    let range = match (start, end) {
-        (Some(start), Some(end)) => TextRange::new(start, end),
-        _ => return,
-    };
-    let mut diagnostic = Diagnostic::new(
-        TooManyNewlinesAtEndOfFile {
-            num_trailing_newlines,
-        },
-        range,
-    );
-    diagnostic.set_fix(Fix::safe_edit(Edit::range_deletion(range)));
-    diagnostics.push(diagnostic);
+        while let Some(next_token) = tokens_iter.peek() {
+            match next_token.kind() {
+                TokenKind::Newline | TokenKind::NonLogicalNewline => {
+                    if newline_range_end.is_none() {
+                        newline_range_end = Some(next_token.end());
+                    }
+                    newline_range_start = Some(next_token.end());
+
+                    tokens_iter.next();
+                    num_trailing_newlines += 1;
+                }
+                TokenKind::Dedent => {
+                    tokens_iter.next();
+                }
+                _ => {
+                    break;
+                }
+            }
+        }
+
+        if num_trailing_newlines == 0 || num_trailing_newlines == 1 {
+            continue;
+        };
+
+        let Some((start, end)) = (match (newline_range_start, newline_range_end) {
+            (Some(s), Some(e)) => Some((s, e)),
+            _ => None,
+        }) else {
+            continue;
+        };
+
+        let diagnostic_range = TextRange::new(start, end);
+
+        results.push(
+            Diagnostic::new(
+                TooManyNewlinesAtEndOfFile {
+                    num_trailing_newlines,
+                },
+                diagnostic_range,
+            )
+            .with_fix(Fix::safe_edit(Edit::range_deletion(diagnostic_range))),
+        );
+    }
+    results
 }

--- a/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__preview__W391_W391.ipynb.snap
+++ b/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__preview__W391_W391.ipynb.snap
@@ -1,0 +1,74 @@
+---
+source: crates/ruff_linter/src/rules/pycodestyle/mod.rs
+---
+W391.ipynb:5:1: W391 [*] Too many newlines at end of file
+   |
+ 3 |   # just a comment in this cell
+ 4 |   # a comment and some newlines
+ 5 | / 
+ 6 | | 
+ 7 | | 
+ 8 | | 
+   | |_^ W391
+ 9 |   1 + 1
+10 |   # a comment
+   |
+   = help: Remove trailing newlines
+
+ℹ Safe fix
+3 3 | # just a comment in this cell
+4 4 | # a comment and some newlines
+5 5 | 
+6   |-
+7   |-
+8   |-
+9 6 | 1 + 1
+10 7 | # a comment
+11 8 | 
+
+W391.ipynb:11:1: W391 [*] Too many newlines at end of file
+   |
+ 9 |   1 + 1
+10 |   # a comment
+11 | / 
+12 | | 
+13 | | 
+14 | | 
+15 | | 
+   | |_^ W391
+16 |   1+1
+   |
+   = help: Remove trailing newlines
+
+ℹ Safe fix
+9  9  | 1 + 1
+10 10 | # a comment
+11 11 | 
+12    |-
+13    |-
+14    |-
+15    |-
+16 12 | 1+1
+17 13 | 
+18 14 | 
+
+W391.ipynb:17:1: W391 [*] Too many newlines at end of file
+   |
+16 |   1+1
+17 | / 
+18 | | 
+19 | | 
+20 | | 
+21 | | 
+   | |_^ W391
+   |
+   = help: Remove trailing newlines
+
+ℹ Safe fix
+15 15 | 
+16 16 | 1+1
+17 17 | 
+18    |-
+19    |-
+20    |-
+21    |-


### PR DESCRIPTION
Jupyter notebooks are converted into source files by joining with newlines, which confuses the check [too-many-newlines-at-end-of-file (W391)](https://docs.astral.sh/ruff/rules/too-many-newlines-at-end-of-file/#too-many-newlines-at-end-of-file-w391). This PR introduces logic to apply the check cell-wise (and, in particular, correctly handles empty cells.)

Closes #13763
