### PR TITLE
Don't enforce `object-without-hash-method` in stubs

### DIFF
--- a/crates/ruff_linter/src/rules/pylint/rules/eq_without_hash.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/eq_without_hash.rs
@@ -111,6 +111,9 @@ impl Violation for EqWithoutHash {
 
 /// W1641
 pub(crate) fn object_without_hash_method(checker: &mut Checker, class: &StmtClassDef) {
+    if checker.source_type.is_stub() {
+        return;
+    }
     let eq_hash = EqHash::from_class(class);
     if matches!(
         eq_hash,


### PR DESCRIPTION
## Summary

Closes https://github.com/astral-sh/ruff/issues/15292.
