### PR TITLE
[ruff-0.9] Stabilise two `flake8-builtins` rules

### DIFF
--- a/crates/ruff_linter/src/codes.rs
+++ b/crates/ruff_linter/src/codes.rs
@@ -316,8 +316,8 @@ pub fn code_to_rule(linter: Linter, code: &str) -> Option<(RuleGroup, Rule)> {
         (Flake8Builtins, "002") => (RuleGroup::Stable, rules::flake8_builtins::rules::BuiltinArgumentShadowing),
         (Flake8Builtins, "003") => (RuleGroup::Stable, rules::flake8_builtins::rules::BuiltinAttributeShadowing),
         (Flake8Builtins, "004") => (RuleGroup::Stable, rules::flake8_builtins::rules::BuiltinImportShadowing),
-        (Flake8Builtins, "005") => (RuleGroup::Preview, rules::flake8_builtins::rules::BuiltinModuleShadowing),
-        (Flake8Builtins, "006") => (RuleGroup::Preview, rules::flake8_builtins::rules::BuiltinLambdaArgumentShadowing),
+        (Flake8Builtins, "005") => (RuleGroup::Stable, rules::flake8_builtins::rules::BuiltinModuleShadowing),
+        (Flake8Builtins, "006") => (RuleGroup::Stable, rules::flake8_builtins::rules::BuiltinLambdaArgumentShadowing),
 
         // flake8-bugbear
         (Flake8Bugbear, "002") => (RuleGroup::Stable, rules::flake8_bugbear::rules::UnaryPrefixIncrementDecrement),

--- a/crates/ruff_linter/src/rules/flake8_builtins/rules/builtin_lambda_argument_shadowing.rs
+++ b/crates/ruff_linter/src/rules/flake8_builtins/rules/builtin_lambda_argument_shadowing.rs
@@ -11,9 +11,9 @@ use crate::rules::flake8_builtins::helpers::shadows_builtin;
 ///
 /// ## Why is this bad?
 /// Reusing a builtin name for the name of a lambda argument increases the
-/// difficulty of reading and maintaining the code, and can cause
-/// non-obvious errors, as readers may mistake the variable for the
-/// builtin and vice versa.
+/// difficulty of reading and maintaining the code and can cause
+/// non-obvious errors. Readers may mistake the variable for the
+/// builtin, and vice versa.
 ///
 /// Builtins can be marked as exceptions to this rule via the
 /// [`lint.flake8-builtins.builtins-ignorelist`] configuration option.


### PR DESCRIPTION
## Summary

This PR stabilises two `flake8-builtins` rules:
- `builtin-module-shadowing` (`A005`)
- `builtin-lambda-argument-shadowing` (`A006`)

There are no open issues or PRs about either rule except for https://github.com/astral-sh/ruff/issues/15293, which I think should probably not block stabilisation as it's a general problem that I think probably applies to many rules currently.

## Test Plan

Ecosystem check on this PR
