### PR TITLE
[ruff-0.9] Stabilise two `pydoclint` rules

### DIFF
--- a/crates/ruff_linter/src/codes.rs
+++ b/crates/ruff_linter/src/codes.rs
@@ -942,9 +942,9 @@ pub fn code_to_rule(linter: Linter, code: &str) -> Option<(RuleGroup, Rule)> {
 
         // pydoclint
         (Pydoclint, "201") => (RuleGroup::Preview, rules::pydoclint::rules::DocstringMissingReturns),
-        (Pydoclint, "202") => (RuleGroup::Preview, rules::pydoclint::rules::DocstringExtraneousReturns),
+        (Pydoclint, "202") => (RuleGroup::Stable, rules::pydoclint::rules::DocstringExtraneousReturns),
         (Pydoclint, "402") => (RuleGroup::Preview, rules::pydoclint::rules::DocstringMissingYields),
-        (Pydoclint, "403") => (RuleGroup::Preview, rules::pydoclint::rules::DocstringExtraneousYields),
+        (Pydoclint, "403") => (RuleGroup::Stable, rules::pydoclint::rules::DocstringExtraneousYields),
         (Pydoclint, "501") => (RuleGroup::Preview, rules::pydoclint::rules::DocstringMissingException),
         (Pydoclint, "502") => (RuleGroup::Preview, rules::pydoclint::rules::DocstringExtraneousException),
 


### PR DESCRIPTION
## Summary

Stabilise two `pydoclint` rules for Ruff 0.9:
- [`docstring-extraneous-returns`](https://docs.astral.sh/ruff/rules/docstring-extraneous-returns/) (`DOC202`)
- [`docstring-extraneous-yields`](https://docs.astral.sh/ruff/rules/docstring-extraneous-yields/) (`DOC403`)

There are no open issues about either of these, and they've been in preview for three months now. The only open PR about them is https://github.com/astral-sh/ruff/pull/13286, which could easily be a preview-only change; I don't think it needs to block the rules being stabilised.

## Test Plan

Ecosystem check on this PR.
