### PR TITLE
[red-knot] all types are assignable to object

### DIFF
--- a/crates/red_knot_python_semantic/src/types/property_tests.rs
+++ b/crates/red_knot_python_semantic/src/types/property_tests.rs
@@ -297,7 +297,7 @@ mod stable {
     // And for fully static types, they should also be subtypes of `object`
     type_property_test!(
         all_fully_static_types_subtype_of_object, db,
-        forall types t. t.is_fully_static() => t.is_subtype_of(db, KnownClass::Object.to_instance(db))
+        forall types t. t.is_fully_static(db) => t.is_subtype_of(db, KnownClass::Object.to_instance(db))
     );
 }
 

--- a/crates/red_knot_python_semantic/src/types/property_tests.rs
+++ b/crates/red_knot_python_semantic/src/types/property_tests.rs
@@ -293,6 +293,12 @@ mod stable {
         all_types_assignable_to_object, db,
         forall types t. t.is_assignable_to(db, KnownClass::Object.to_instance(db))
     );
+
+    // And for fully static types, they should also be subtypes of `object`
+    type_property_test!(
+        all_fully_static_types_subtype_of_object, db,
+        forall types t. t.is_fully_static() => t.is_subtype_of(db, KnownClass::Object.to_instance(db))
+    );
 }
 
 /// This module contains property tests that currently lead to many false positives.

--- a/crates/red_knot_python_semantic/src/types/property_tests.rs
+++ b/crates/red_knot_python_semantic/src/types/property_tests.rs
@@ -220,6 +220,8 @@ macro_rules! type_property_test {
 }
 
 mod stable {
+    use super::KnownClass;
+
     // `T` is equivalent to itself.
     type_property_test!(
         equivalent_to_is_reflexive, db,
@@ -284,6 +286,12 @@ mod stable {
     type_property_test!(
         non_fully_static_types_do_not_participate_in_subtyping, db,
         forall types s, t. !s.is_fully_static(db) => !s.is_subtype_of(db, t) && !t.is_subtype_of(db, s)
+    );
+
+    // All types should be assignable to `object`
+    type_property_test!(
+        all_types_assignable_to_object, db,
+        forall types t. t.is_assignable_to(db, KnownClass::Object.to_instance(db))
     );
 }
 

--- a/crates/ruff_benchmark/benches/red_knot.rs
+++ b/crates/ruff_benchmark/benches/red_knot.rs
@@ -33,8 +33,6 @@ static EXPECTED_DIAGNOSTICS: &[&str] = &[
     "warning[lint:possibly-unresolved-reference] /src/tomllib/_parser.py:104:14 Name `char` used when possibly not defined",
     "warning[lint:possibly-unresolved-reference] /src/tomllib/_parser.py:115:14 Name `char` used when possibly not defined",
     "warning[lint:possibly-unresolved-reference] /src/tomllib/_parser.py:126:12 Name `char` used when possibly not defined",
-    // We don't handle intersections in `is_assignable_to` yet
-    "error[lint:invalid-argument-type] /src/tomllib/_parser.py:211:31 Object of type `Unknown & object | @Todo` cannot be assigned to parameter 1 (`obj`) of function `isinstance`; expected type `object`",
     "warning[lint:possibly-unresolved-reference] /src/tomllib/_parser.py:348:20 Name `nest` used when possibly not defined",
     "warning[lint:possibly-unresolved-reference] /src/tomllib/_parser.py:353:5 Name `nest` used when possibly not defined",
     "warning[lint:possibly-unresolved-reference] /src/tomllib/_parser.py:453:24 Name `nest` used when possibly not defined",
@@ -44,6 +42,7 @@ static EXPECTED_DIAGNOSTICS: &[&str] = &[
     "warning[lint:possibly-unresolved-reference] /src/tomllib/_parser.py:573:12 Name `char` used when possibly not defined",
     "warning[lint:possibly-unresolved-reference] /src/tomllib/_parser.py:579:12 Name `char` used when possibly not defined",
     "warning[lint:possibly-unresolved-reference] /src/tomllib/_parser.py:580:63 Name `char` used when possibly not defined",
+    // We don't handle intersections in `is_assignable_to` yet
     "error[lint:invalid-argument-type] /src/tomllib/_parser.py:626:46 Object of type `@Todo & ~AlwaysFalsy` cannot be assigned to parameter 1 (`match`) of function `match_to_datetime`; expected type `Match`",
     "warning[lint:possibly-unresolved-reference] /src/tomllib/_parser.py:629:38 Name `datetime_obj` used when possibly not defined",
     "error[lint:invalid-argument-type] /src/tomllib/_parser.py:632:58 Object of type `@Todo & ~AlwaysFalsy` cannot be assigned to parameter 1 (`match`) of function `match_to_localtime`; expected type `Match`",


### PR DESCRIPTION
## Summary

`Type[Any]` should be assignable to `object`. All types should be assignable to `object`.

We specifically didn't understand the former; this PR adds a test for it, and a case to ensure that `Type[Any]` is assignable to anything that `type` is assignable to (which includes `object`).

This PR also adds a property test that all types are assignable to object. In order to make it pass, I added a special case to check early if we are assigning to `object` and just return `true`. In principle, once we get all the more general cases correct, this special case might be removable. But having the special case for now allows the property test to pass.

And we add a property test that all types are subtypes of object. This failed for the case of an intersection with no positive elements (that is, a negation type). This really does need to be a special case for `object`, because there is no other type we can know that a negation type is a subtype of.

## Test Plan

Added unit test and property test.
