### PR TITLE
[red-knot] Reduce `Name` clones in call signature checking

### DIFF
--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -1827,7 +1827,7 @@ impl<'db> Type<'db> {
 
     /// Return the outcome of calling an object of this type.
     #[must_use]
-    fn call(self, db: &'db dyn Db, arguments: &CallArguments<'db>) -> CallOutcome<'db> {
+    fn call(self, db: &'db dyn Db, arguments: &CallArguments<'_, 'db>) -> CallOutcome<'db> {
         match self {
             Type::FunctionLiteral(function_type) => {
                 let mut binding = bind_call(db, arguments, function_type.signature(db), Some(self));
@@ -1995,7 +1995,7 @@ impl<'db> Type<'db> {
         self,
         db: &'db dyn Db,
         name: &str,
-        arguments: &CallArguments<'db>,
+        arguments: &CallArguments<'_, 'db>,
     ) -> CallDunderResult<'db> {
         match self.to_meta_type(db).member(db, name) {
             Symbol::Type(callable_ty, Boundness::Bound) => {

--- a/crates/red_knot_python_semantic/src/types/call/arguments.rs
+++ b/crates/red_knot_python_semantic/src/types/call/arguments.rs
@@ -1,11 +1,10 @@
 use super::Type;
-use ruff_python_ast::name::Name;
 
 /// Typed arguments for a single call, in source order.
 #[derive(Clone, Debug, Default)]
-pub(crate) struct CallArguments<'db>(Vec<Argument<'db>>);
+pub(crate) struct CallArguments<'a, 'db>(Vec<Argument<'a, 'db>>);
 
-impl<'db> CallArguments<'db> {
+impl<'a, 'db> CallArguments<'a, 'db> {
     /// Create a [`CallArguments`] from an iterator over non-variadic positional argument types.
     pub(crate) fn positional(positional_tys: impl IntoIterator<Item = Type<'db>>) -> Self {
         positional_tys
@@ -22,7 +21,7 @@ impl<'db> CallArguments<'db> {
         Self(arguments)
     }
 
-    pub(crate) fn iter(&self) -> impl Iterator<Item = &Argument<'db>> {
+    pub(crate) fn iter(&self) -> impl Iterator<Item = &Argument<'a, 'db>> {
         self.0.iter()
     }
 
@@ -32,34 +31,34 @@ impl<'db> CallArguments<'db> {
     }
 }
 
-impl<'db, 'a> IntoIterator for &'a CallArguments<'db> {
-    type Item = &'a Argument<'db>;
-    type IntoIter = std::slice::Iter<'a, Argument<'db>>;
+impl<'db, 'a, 'b> IntoIterator for &'b CallArguments<'a, 'db> {
+    type Item = &'b Argument<'a, 'db>;
+    type IntoIter = std::slice::Iter<'b, Argument<'a, 'db>>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.0.iter()
     }
 }
 
-impl<'db> FromIterator<Argument<'db>> for CallArguments<'db> {
-    fn from_iter<T: IntoIterator<Item = Argument<'db>>>(iter: T) -> Self {
+impl<'a, 'db> FromIterator<Argument<'a, 'db>> for CallArguments<'a, 'db> {
+    fn from_iter<T: IntoIterator<Item = Argument<'a, 'db>>>(iter: T) -> Self {
         Self(iter.into_iter().collect())
     }
 }
 
 #[derive(Clone, Debug)]
-pub(crate) enum Argument<'db> {
+pub(crate) enum Argument<'a, 'db> {
     /// A positional argument.
     Positional(Type<'db>),
     /// A starred positional argument (e.g. `*args`).
     Variadic(Type<'db>),
     /// A keyword argument (e.g. `a=1`).
-    Keyword { name: Name, ty: Type<'db> },
+    Keyword { name: &'a str, ty: Type<'db> },
     /// The double-starred keywords argument (e.g. `**kwargs`).
     Keywords(Type<'db>),
 }
 
-impl<'db> Argument<'db> {
+impl<'db> Argument<'_, 'db> {
     fn ty(&self) -> Type<'db> {
         match self {
             Self::Positional(ty) => *ty,

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -2523,11 +2523,11 @@ impl<'db> TypeInferenceBuilder<'db> {
         self.infer_expression(expression)
     }
 
-    fn infer_arguments(
+    fn infer_arguments<'a>(
         &mut self,
-        arguments: &ast::Arguments,
+        arguments: &'a ast::Arguments,
         infer_as_type_expressions: bool,
-    ) -> CallArguments<'db> {
+    ) -> CallArguments<'a, 'db> {
         let infer_argument_type = if infer_as_type_expressions {
             Self::infer_type_expression
         } else {
@@ -2558,10 +2558,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                     }) => {
                         let ty = infer_argument_type(self, value);
                         if let Some(arg) = arg {
-                            Argument::Keyword {
-                                name: arg.id.clone(),
-                                ty,
-                            }
+                            Argument::Keyword { name: &arg.id, ty }
                         } else {
                             // TODO diagnostic if not last
                             Argument::Keywords(ty)


### PR DESCRIPTION
## Summary

This gets rid of several `Name` clones in our implementation of call-signature checking, at the cost of quite a few more lifetime annotations. There may be a simpler way of doing this, but I couldn't immediately see it... using `'db` for everything did not work.

Not sure if this is the way to go, but figured I'd put it up for discussion as a proof-of-concept anyway

## Test Plan

`cargo test -p red_knot_python_semantic`
