### PR TITLE
[`flake8-pyi`] Stabilize autofix for `redundant-numeric-union` (`PYI041`)

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI041_PYI041.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI041_PYI041.py.snap
@@ -1,7 +1,8 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_pyi/mod.rs
+snapshot_kind: text
 ---
-PYI041.py:22:14: PYI041 Use `float` instead of `int | float`
+PYI041.py:22:14: PYI041 [*] Use `float` instead of `int | float`
    |
 22 | def f0(arg1: float | int) -> None:
    |              ^^^^^^^^^^^ PYI041
@@ -9,7 +10,17 @@ PYI041.py:22:14: PYI041 Use `float` instead of `int | float`
    |
    = help: Remove redundant type
 
-PYI041.py:26:30: PYI041 Use `complex` instead of `float | complex`
+ℹ Safe fix
+19 19 |     ...
+20 20 | 
+21 21 | 
+22    |-def f0(arg1: float | int) -> None:
+   22 |+def f0(arg1: float) -> None:
+23 23 |     ...
+24 24 | 
+25 25 | 
+
+PYI041.py:26:30: PYI041 [*] Use `complex` instead of `float | complex`
    |
 26 | def f1(arg1: float, *, arg2: float | list[str] | type[bool] | complex) -> None:
    |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI041
@@ -17,7 +28,17 @@ PYI041.py:26:30: PYI041 Use `complex` instead of `float | complex`
    |
    = help: Remove redundant type
 
-PYI041.py:30:28: PYI041 Use `float` instead of `int | float`
+ℹ Safe fix
+23 23 |     ...
+24 24 | 
+25 25 | 
+26    |-def f1(arg1: float, *, arg2: float | list[str] | type[bool] | complex) -> None:
+   26 |+def f1(arg1: float, *, arg2: list[str] | type[bool] | complex) -> None:
+27 27 |     ...
+28 28 | 
+29 29 | 
+
+PYI041.py:30:28: PYI041 [*] Use `float` instead of `int | float`
    |
 30 | def f2(arg1: int, /, arg2: int | int | float) -> None:
    |                            ^^^^^^^^^^^^^^^^^ PYI041
@@ -25,7 +46,17 @@ PYI041.py:30:28: PYI041 Use `float` instead of `int | float`
    |
    = help: Remove redundant type
 
-PYI041.py:34:26: PYI041 Use `float` instead of `int | float`
+ℹ Safe fix
+27 27 |     ...
+28 28 | 
+29 29 | 
+30    |-def f2(arg1: int, /, arg2: int | int | float) -> None:
+   30 |+def f2(arg1: int, /, arg2: float) -> None:
+31 31 |     ...
+32 32 | 
+33 33 | 
+
+PYI041.py:34:26: PYI041 [*] Use `float` instead of `int | float`
    |
 34 | def f3(arg1: int, *args: Union[int | int | float]) -> None:
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^ PYI041
@@ -33,7 +64,17 @@ PYI041.py:34:26: PYI041 Use `float` instead of `int | float`
    |
    = help: Remove redundant type
 
-PYI041.py:38:24: PYI041 Use `float` instead of `int | float`
+ℹ Safe fix
+31 31 |     ...
+32 32 | 
+33 33 | 
+34    |-def f3(arg1: int, *args: Union[int | int | float]) -> None:
+   34 |+def f3(arg1: int, *args: float) -> None:
+35 35 |     ...
+36 36 | 
+37 37 | 
+
+PYI041.py:38:24: PYI041 [*] Use `float` instead of `int | float`
    |
 38 | async def f4(**kwargs: int | int | float) -> None:
    |                        ^^^^^^^^^^^^^^^^^ PYI041
@@ -41,7 +82,17 @@ PYI041.py:38:24: PYI041 Use `float` instead of `int | float`
    |
    = help: Remove redundant type
 
-PYI041.py:42:26: PYI041 Use `float` instead of `int | float`
+ℹ Safe fix
+35 35 |     ...
+36 36 | 
+37 37 | 
+38    |-async def f4(**kwargs: int | int | float) -> None:
+   38 |+async def f4(**kwargs: float) -> None:
+39 39 |     ...
+40 40 | 
+41 41 | 
+
+PYI041.py:42:26: PYI041 [*] Use `float` instead of `int | float`
    |
 42 | def f5(arg1: int, *args: Union[int, int, float]) -> None: 
    |                          ^^^^^^^^^^^^^^^^^^^^^^ PYI041
@@ -49,7 +100,17 @@ PYI041.py:42:26: PYI041 Use `float` instead of `int | float`
    |
    = help: Remove redundant type
 
-PYI041.py:46:26: PYI041 Use `float` instead of `int | float`
+ℹ Safe fix
+39 39 |     ...
+40 40 | 
+41 41 | 
+42    |-def f5(arg1: int, *args: Union[int, int, float]) -> None: 
+   42 |+def f5(arg1: int, *args: float) -> None: 
+43 43 |     ...
+44 44 | 
+45 45 | 
+
+PYI041.py:46:26: PYI041 [*] Use `float` instead of `int | float`
    |
 46 | def f6(arg1: int, *args: Union[Union[int, int, float]]) -> None: 
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI041
@@ -57,7 +118,17 @@ PYI041.py:46:26: PYI041 Use `float` instead of `int | float`
    |
    = help: Remove redundant type
 
-PYI041.py:50:26: PYI041 Use `float` instead of `int | float`
+ℹ Safe fix
+43 43 |     ...
+44 44 | 
+45 45 | 
+46    |-def f6(arg1: int, *args: Union[Union[int, int, float]]) -> None: 
+   46 |+def f6(arg1: int, *args: float) -> None: 
+47 47 |     ...
+48 48 | 
+49 49 | 
+
+PYI041.py:50:26: PYI041 [*] Use `float` instead of `int | float`
    |
 50 | def f7(arg1: int, *args: Union[Union[Union[int, int, float]]]) -> None: 
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI041
@@ -65,7 +136,17 @@ PYI041.py:50:26: PYI041 Use `float` instead of `int | float`
    |
    = help: Remove redundant type
 
-PYI041.py:54:26: PYI041 Use `float` instead of `int | float`
+ℹ Safe fix
+47 47 |     ...
+48 48 | 
+49 49 | 
+50    |-def f7(arg1: int, *args: Union[Union[Union[int, int, float]]]) -> None: 
+   50 |+def f7(arg1: int, *args: float) -> None: 
+51 51 |     ...
+52 52 | 
+53 53 | 
+
+PYI041.py:54:26: PYI041 [*] Use `float` instead of `int | float`
    |
 54 | def f8(arg1: int, *args: Union[Union[Union[int | int | float]]]) -> None: 
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI041
@@ -73,7 +154,17 @@ PYI041.py:54:26: PYI041 Use `float` instead of `int | float`
    |
    = help: Remove redundant type
 
-PYI041.py:59:10: PYI041 Use `complex` instead of `int | float | complex`
+ℹ Safe fix
+51 51 |     ...
+52 52 | 
+53 53 | 
+54    |-def f8(arg1: int, *args: Union[Union[Union[int | int | float]]]) -> None: 
+   54 |+def f8(arg1: int, *args: float) -> None: 
+55 55 |     ...
+56 56 | 
+57 57 | 
+
+PYI041.py:59:10: PYI041 [*] Use `complex` instead of `int | float | complex`
    |
 58 |   def f9(
 59 |       arg: Union[  # comment 
@@ -86,7 +177,19 @@ PYI041.py:59:10: PYI041 Use `complex` instead of `int | float | complex`
    |
    = help: Remove redundant type
 
-PYI041.py:67:9: PYI041 Use `complex` instead of `int | float | complex`
+ℹ Unsafe fix
+56 56 | 
+57 57 | 
+58 58 | def f9(
+59    |-    arg: Union[  # comment 
+60    |-        float, # another
+61    |-        complex, int]
+   59 |+    arg: complex
+62 60 |     ) -> None: 
+63 61 |     ...
+64 62 | 
+
+PYI041.py:67:9: PYI041 [*] Use `complex` instead of `int | float | complex`
    |
 65 |   def f10(
 66 |       arg: (
@@ -100,7 +203,17 @@ PYI041.py:67:9: PYI041 Use `complex` instead of `int | float | complex`
    |
    = help: Remove redundant type
 
-PYI041.py:79:24: PYI041 Use `complex` instead of `int | float | complex`
+ℹ Unsafe fix
+64 64 | 
+65 65 | def f10(
+66 66 |     arg: (
+67    |-        int | # comment
+68    |-        float |  # another
+69 67 |         complex
+70 68 |     )    
+71 69 |     ) -> None: 
+
+PYI041.py:79:24: PYI041 [*] Use `complex` instead of `int | float | complex`
    |
 77 |         ...
 78 | 
@@ -110,7 +223,17 @@ PYI041.py:79:24: PYI041 Use `complex` instead of `int | float | complex`
    |
    = help: Remove redundant type
 
-PYI041.py:82:25: PYI041 Use `complex` instead of `int | float | complex`
+ℹ Safe fix
+76 76 |     def good(self, arg: int) -> None:
+77 77 |         ...
+78 78 | 
+79    |-    def bad(self, arg: int | float | complex) -> None:
+   79 |+    def bad(self, arg: complex) -> None:
+80 80 |         ...
+81 81 | 
+82 82 |     def bad2(self, arg: int | Union[float, complex]) -> None: 
+
+PYI041.py:82:25: PYI041 [*] Use `complex` instead of `int | float | complex`
    |
 80 |         ...
 81 | 
@@ -120,7 +243,17 @@ PYI041.py:82:25: PYI041 Use `complex` instead of `int | float | complex`
    |
    = help: Remove redundant type
 
-PYI041.py:85:25: PYI041 Use `complex` instead of `int | float | complex`
+ℹ Safe fix
+79 79 |     def bad(self, arg: int | float | complex) -> None:
+80 80 |         ...
+81 81 | 
+82    |-    def bad2(self, arg: int | Union[float, complex]) -> None: 
+   82 |+    def bad2(self, arg: complex) -> None: 
+83 83 |         ...
+84 84 | 
+85 85 |     def bad3(self, arg: Union[Union[float, complex], int]) -> None: 
+
+PYI041.py:85:25: PYI041 [*] Use `complex` instead of `int | float | complex`
    |
 83 |         ...
 84 | 
@@ -130,7 +263,17 @@ PYI041.py:85:25: PYI041 Use `complex` instead of `int | float | complex`
    |
    = help: Remove redundant type
 
-PYI041.py:88:25: PYI041 Use `complex` instead of `int | float | complex`
+ℹ Safe fix
+82 82 |     def bad2(self, arg: int | Union[float, complex]) -> None: 
+83 83 |         ...
+84 84 | 
+85    |-    def bad3(self, arg: Union[Union[float, complex], int]) -> None: 
+   85 |+    def bad3(self, arg: complex) -> None: 
+86 86 |         ...
+87 87 | 
+88 88 |     def bad4(self, arg: Union[float | complex, int]) -> None: 
+
+PYI041.py:88:25: PYI041 [*] Use `complex` instead of `int | float | complex`
    |
 86 |         ...
 87 | 
@@ -140,7 +283,17 @@ PYI041.py:88:25: PYI041 Use `complex` instead of `int | float | complex`
    |
    = help: Remove redundant type
 
-PYI041.py:91:25: PYI041 Use `complex` instead of `int | float | complex`
+ℹ Safe fix
+85 85 |     def bad3(self, arg: Union[Union[float, complex], int]) -> None: 
+86 86 |         ...
+87 87 | 
+88    |-    def bad4(self, arg: Union[float | complex, int]) -> None: 
+   88 |+    def bad4(self, arg: complex) -> None: 
+89 89 |         ...
+90 90 | 
+91 91 |     def bad5(self, arg: int | (float | complex)) -> None: 
+
+PYI041.py:91:25: PYI041 [*] Use `complex` instead of `int | float | complex`
    |
 89 |         ...
 90 | 
@@ -149,3 +302,11 @@ PYI041.py:91:25: PYI041 Use `complex` instead of `int | float | complex`
 92 |         ...
    |
    = help: Remove redundant type
+
+ℹ Safe fix
+88 88 |     def bad4(self, arg: Union[float | complex, int]) -> None: 
+89 89 |         ...
+90 90 | 
+91    |-    def bad5(self, arg: int | (float | complex)) -> None: 
+   91 |+    def bad5(self, arg: complex) -> None: 
+92 92 |         ...

--- a/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI041_PYI041.pyi.snap
+++ b/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI041_PYI041.pyi.snap
@@ -1,35 +1,76 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_pyi/mod.rs
+snapshot_kind: text
 ---
-PYI041.pyi:21:14: PYI041 Use `float` instead of `int | float`
+PYI041.pyi:21:14: PYI041 [*] Use `float` instead of `int | float`
    |
 21 | def f0(arg1: float | int) -> None: ...  # PYI041
    |              ^^^^^^^^^^^ PYI041
    |
    = help: Remove redundant type
 
-PYI041.pyi:24:30: PYI041 Use `complex` instead of `float | complex`
+ℹ Safe fix
+18 18 | def good2(arg: int, arg2: int | bool) -> None: ...
+19 19 | 
+20 20 | 
+21    |-def f0(arg1: float | int) -> None: ...  # PYI041
+   21 |+def f0(arg1: float) -> None: ...  # PYI041
+22 22 | 
+23 23 | 
+24 24 | def f1(arg1: float, *, arg2: float | list[str] | type[bool] | complex) -> None: ...  # PYI041
+
+PYI041.pyi:24:30: PYI041 [*] Use `complex` instead of `float | complex`
    |
 24 | def f1(arg1: float, *, arg2: float | list[str] | type[bool] | complex) -> None: ...  # PYI041
    |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI041
    |
    = help: Remove redundant type
 
-PYI041.pyi:27:28: PYI041 Use `float` instead of `int | float`
+ℹ Safe fix
+21 21 | def f0(arg1: float | int) -> None: ...  # PYI041
+22 22 | 
+23 23 | 
+24    |-def f1(arg1: float, *, arg2: float | list[str] | type[bool] | complex) -> None: ...  # PYI041
+   24 |+def f1(arg1: float, *, arg2: list[str] | type[bool] | complex) -> None: ...  # PYI041
+25 25 | 
+26 26 | 
+27 27 | def f2(arg1: int, /, arg2: int | int | float) -> None: ...  # PYI041
+
+PYI041.pyi:27:28: PYI041 [*] Use `float` instead of `int | float`
    |
 27 | def f2(arg1: int, /, arg2: int | int | float) -> None: ...  # PYI041
    |                            ^^^^^^^^^^^^^^^^^ PYI041
    |
    = help: Remove redundant type
 
-PYI041.pyi:30:26: PYI041 Use `float` instead of `int | float`
+ℹ Safe fix
+24 24 | def f1(arg1: float, *, arg2: float | list[str] | type[bool] | complex) -> None: ...  # PYI041
+25 25 | 
+26 26 | 
+27    |-def f2(arg1: int, /, arg2: int | int | float) -> None: ...  # PYI041
+   27 |+def f2(arg1: int, /, arg2: float) -> None: ...  # PYI041
+28 28 | 
+29 29 | 
+30 30 | def f3(arg1: int, *args: Union[int | int | float]) -> None: ...  # PYI041
+
+PYI041.pyi:30:26: PYI041 [*] Use `float` instead of `int | float`
    |
 30 | def f3(arg1: int, *args: Union[int | int | float]) -> None: ...  # PYI041
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^ PYI041
    |
    = help: Remove redundant type
 
-PYI041.pyi:33:24: PYI041 Use `float` instead of `int | float`
+ℹ Safe fix
+27 27 | def f2(arg1: int, /, arg2: int | int | float) -> None: ...  # PYI041
+28 28 | 
+29 29 | 
+30    |-def f3(arg1: int, *args: Union[int | int | float]) -> None: ...  # PYI041
+   30 |+def f3(arg1: int, *args: float) -> None: ...  # PYI041
+31 31 | 
+32 32 | 
+33 33 | async def f4(**kwargs: int | int | float) -> None: ...  # PYI041
+
+PYI041.pyi:33:24: PYI041 [*] Use `float` instead of `int | float`
    |
 33 | async def f4(**kwargs: int | int | float) -> None: ...  # PYI041
    |                        ^^^^^^^^^^^^^^^^^ PYI041
@@ -38,7 +79,17 @@ PYI041.pyi:33:24: PYI041 Use `float` instead of `int | float`
    |
    = help: Remove redundant type
 
-PYI041.pyi:36:10: PYI041 Use `complex` instead of `int | float | complex`
+ℹ Safe fix
+30 30 | def f3(arg1: int, *args: Union[int | int | float]) -> None: ...  # PYI041
+31 31 | 
+32 32 | 
+33    |-async def f4(**kwargs: int | int | float) -> None: ...  # PYI041
+   33 |+async def f4(**kwargs: float) -> None: ...  # PYI041
+34 34 | 
+35 35 | def f5(
+36 36 |     arg: Union[  # comment 
+
+PYI041.pyi:36:10: PYI041 [*] Use `complex` instead of `int | float | complex`
    |
 35 |   def f5(
 36 |       arg: Union[  # comment 
@@ -50,7 +101,19 @@ PYI041.pyi:36:10: PYI041 Use `complex` instead of `int | float | complex`
    |
    = help: Remove redundant type
 
-PYI041.pyi:43:9: PYI041 Use `complex` instead of `int | float | complex`
+ℹ Unsafe fix
+33 33 | async def f4(**kwargs: int | int | float) -> None: ...  # PYI041
+34 34 | 
+35 35 | def f5(
+36    |-    arg: Union[  # comment 
+37    |-        float, # another
+38    |-        complex, int]
+   36 |+    arg: complex
+39 37 |     ) -> None: ...  # PYI041
+40 38 | 
+41 39 | def f6(
+
+PYI041.pyi:43:9: PYI041 [*] Use `complex` instead of `int | float | complex`
    |
 41 |   def f6(
 42 |       arg: (
@@ -64,7 +127,17 @@ PYI041.pyi:43:9: PYI041 Use `complex` instead of `int | float | complex`
    |
    = help: Remove redundant type
 
-PYI041.pyi:49:26: PYI041 Use `float` instead of `int | float`
+ℹ Unsafe fix
+40 40 | 
+41 41 | def f6(
+42 42 |     arg: (
+43    |-        int | # comment
+44    |-        float |  # another
+45 43 |         complex
+46 44 |     )    
+47 45 |     ) -> None: ... # PYI041
+
+PYI041.pyi:49:26: PYI041 [*] Use `float` instead of `int | float`
    |
 47 |     ) -> None: ... # PYI041
 48 | 
@@ -73,28 +146,68 @@ PYI041.pyi:49:26: PYI041 Use `float` instead of `int | float`
    |
    = help: Remove redundant type
 
-PYI041.pyi:52:26: PYI041 Use `float` instead of `int | float`
+ℹ Safe fix
+46 46 |     )    
+47 47 |     ) -> None: ... # PYI041
+48 48 | 
+49    |-def f5(arg1: int, *args: Union[int, int, float]) -> None: ...  # PYI041
+   49 |+def f5(arg1: int, *args: float) -> None: ...  # PYI041
+50 50 | 
+51 51 | 
+52 52 | def f6(arg1: int, *args: Union[Union[int, int, float]]) -> None: ...  # PYI041
+
+PYI041.pyi:52:26: PYI041 [*] Use `float` instead of `int | float`
    |
 52 | def f6(arg1: int, *args: Union[Union[int, int, float]]) -> None: ...  # PYI041
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI041
    |
    = help: Remove redundant type
 
-PYI041.pyi:55:26: PYI041 Use `float` instead of `int | float`
+ℹ Safe fix
+49 49 | def f5(arg1: int, *args: Union[int, int, float]) -> None: ...  # PYI041
+50 50 | 
+51 51 | 
+52    |-def f6(arg1: int, *args: Union[Union[int, int, float]]) -> None: ...  # PYI041
+   52 |+def f6(arg1: int, *args: float) -> None: ...  # PYI041
+53 53 | 
+54 54 | 
+55 55 | def f7(arg1: int, *args: Union[Union[Union[int, int, float]]]) -> None: ...  # PYI041
+
+PYI041.pyi:55:26: PYI041 [*] Use `float` instead of `int | float`
    |
 55 | def f7(arg1: int, *args: Union[Union[Union[int, int, float]]]) -> None: ...  # PYI041
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI041
    |
    = help: Remove redundant type
 
-PYI041.pyi:58:26: PYI041 Use `float` instead of `int | float`
+ℹ Safe fix
+52 52 | def f6(arg1: int, *args: Union[Union[int, int, float]]) -> None: ...  # PYI041
+53 53 | 
+54 54 | 
+55    |-def f7(arg1: int, *args: Union[Union[Union[int, int, float]]]) -> None: ...  # PYI041
+   55 |+def f7(arg1: int, *args: float) -> None: ...  # PYI041
+56 56 | 
+57 57 | 
+58 58 | def f8(arg1: int, *args: Union[Union[Union[int | int | float]]]) -> None: ...  # PYI041
+
+PYI041.pyi:58:26: PYI041 [*] Use `float` instead of `int | float`
    |
 58 | def f8(arg1: int, *args: Union[Union[Union[int | int | float]]]) -> None: ...  # PYI041
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI041
    |
    = help: Remove redundant type
 
-PYI041.pyi:64:24: PYI041 Use `complex` instead of `int | float | complex`
+ℹ Safe fix
+55 55 | def f7(arg1: int, *args: Union[Union[Union[int, int, float]]]) -> None: ...  # PYI041
+56 56 | 
+57 57 | 
+58    |-def f8(arg1: int, *args: Union[Union[Union[int | int | float]]]) -> None: ...  # PYI041
+   58 |+def f8(arg1: int, *args: float) -> None: ...  # PYI041
+59 59 | 
+60 60 | 
+61 61 | class Foo:
+
+PYI041.pyi:64:24: PYI041 [*] Use `complex` instead of `int | float | complex`
    |
 62 |     def good(self, arg: int) -> None: ...
 63 | 
@@ -105,7 +218,17 @@ PYI041.pyi:64:24: PYI041 Use `complex` instead of `int | float | complex`
    |
    = help: Remove redundant type
 
-PYI041.pyi:66:25: PYI041 Use `complex` instead of `int | float | complex`
+ℹ Safe fix
+61 61 | class Foo:
+62 62 |     def good(self, arg: int) -> None: ...
+63 63 | 
+64    |-    def bad(self, arg: int | float | complex) -> None: ...  # PYI041
+   64 |+    def bad(self, arg: complex) -> None: ...  # PYI041
+65 65 | 
+66 66 |     def bad2(self, arg: int | Union[float, complex]) -> None: ...  # PYI041
+67 67 | 
+
+PYI041.pyi:66:25: PYI041 [*] Use `complex` instead of `int | float | complex`
    |
 64 |     def bad(self, arg: int | float | complex) -> None: ...  # PYI041
 65 | 
@@ -116,7 +239,17 @@ PYI041.pyi:66:25: PYI041 Use `complex` instead of `int | float | complex`
    |
    = help: Remove redundant type
 
-PYI041.pyi:68:25: PYI041 Use `complex` instead of `int | float | complex`
+ℹ Safe fix
+63 63 | 
+64 64 |     def bad(self, arg: int | float | complex) -> None: ...  # PYI041
+65 65 | 
+66    |-    def bad2(self, arg: int | Union[float, complex]) -> None: ...  # PYI041
+   66 |+    def bad2(self, arg: complex) -> None: ...  # PYI041
+67 67 | 
+68 68 |     def bad3(self, arg: Union[Union[float, complex], int]) -> None: ...  # PYI041
+69 69 | 
+
+PYI041.pyi:68:25: PYI041 [*] Use `complex` instead of `int | float | complex`
    |
 66 |     def bad2(self, arg: int | Union[float, complex]) -> None: ...  # PYI041
 67 | 
@@ -127,7 +260,17 @@ PYI041.pyi:68:25: PYI041 Use `complex` instead of `int | float | complex`
    |
    = help: Remove redundant type
 
-PYI041.pyi:70:25: PYI041 Use `complex` instead of `int | float | complex`
+ℹ Safe fix
+65 65 | 
+66 66 |     def bad2(self, arg: int | Union[float, complex]) -> None: ...  # PYI041
+67 67 | 
+68    |-    def bad3(self, arg: Union[Union[float, complex], int]) -> None: ...  # PYI041
+   68 |+    def bad3(self, arg: complex) -> None: ...  # PYI041
+69 69 | 
+70 70 |     def bad4(self, arg: Union[float | complex, int]) -> None: ...  # PYI041
+71 71 | 
+
+PYI041.pyi:70:25: PYI041 [*] Use `complex` instead of `int | float | complex`
    |
 68 |     def bad3(self, arg: Union[Union[float, complex], int]) -> None: ...  # PYI041
 69 | 
@@ -138,7 +281,16 @@ PYI041.pyi:70:25: PYI041 Use `complex` instead of `int | float | complex`
    |
    = help: Remove redundant type
 
-PYI041.pyi:72:25: PYI041 Use `complex` instead of `int | float | complex`
+ℹ Safe fix
+67 67 | 
+68 68 |     def bad3(self, arg: Union[Union[float, complex], int]) -> None: ...  # PYI041
+69 69 | 
+70    |-    def bad4(self, arg: Union[float | complex, int]) -> None: ...  # PYI041
+   70 |+    def bad4(self, arg: complex) -> None: ...  # PYI041
+71 71 | 
+72 72 |     def bad5(self, arg: int | (float | complex)) -> None: ...  # PYI041
+
+PYI041.pyi:72:25: PYI041 [*] Use `complex` instead of `int | float | complex`
    |
 70 |     def bad4(self, arg: Union[float | complex, int]) -> None: ...  # PYI041
 71 | 
@@ -146,3 +298,10 @@ PYI041.pyi:72:25: PYI041 Use `complex` instead of `int | float | complex`
    |                         ^^^^^^^^^^^^^^^^^^^^^^^ PYI041
    |
    = help: Remove redundant type
+
+ℹ Safe fix
+69 69 | 
+70 70 |     def bad4(self, arg: Union[float | complex, int]) -> None: ...  # PYI041
+71 71 | 
+72    |-    def bad5(self, arg: int | (float | complex)) -> None: ...  # PYI041
+   72 |+    def bad5(self, arg: complex) -> None: ...  # PYI041


### PR DESCRIPTION
## Summary

Stabilizes the autofix introduced in https://github.com/astral-sh/ruff/pull/14273

## Test Plan

There are no open issues concerning this fix. ~~There are two open issues related to the rule:~~

* https://github.com/astral-sh/ruff/issues/9810 asks to extend the rule to include `bool`. This should not block stabilization because it's an extension of the rule
* https://github.com/astral-sh/ruff/issues/14185 is the issue that requested adding this specific fix. This should definitely not block stabilization ;)
