### PR TITLE
Remove unnecessary `PreviewMode::Enabled` in tests

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_pytest_style/mod.rs
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/mod.rs
@@ -12,7 +12,6 @@ mod tests {
 
     use crate::registry::Rule;
     use crate::settings::types::IdentifierPattern;
-    use crate::settings::types::PreviewMode;
     use crate::test::test_path;
     use crate::{assert_messages, settings};
 
@@ -302,7 +301,6 @@ mod tests {
                 .join(Path::new("PT006_and_PT007.py"))
                 .as_path(),
             &settings::LinterSettings {
-                preview: PreviewMode::Enabled,
                 ..settings::LinterSettings::for_rules(vec![
                     Rule::PytestParametrizeNamesWrongType,
                     Rule::PytestParametrizeValuesWrongType,


### PR DESCRIPTION

## Summary

https://github.com/astral-sh/ruff/pull/15327 also stabilized the fix introduced by https://github.com/astral-sh/ruff/pull/14699

This PR cleans up the test setup to not use preview mode for the now stabilized behavior.

## Test Plan

<!-- How was it tested? -->
