### PR TITLE
[`flake8-no-pep420`] Stabilize: Detect empty implicit namespace packages (`INP001`)

### DIFF
--- a/crates/ruff/tests/lint.rs
+++ b/crates/ruff/tests/lint.rs
@@ -2016,26 +2016,11 @@ fn nested_implicit_namespace_package() -> Result<()> {
         .child("bop.py")
         .touch()?;
 
-    assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
-        .args(STDIN_BASE_OPTIONS)
-        .arg("--select")
-        .arg("INP")
-        .current_dir(&tempdir)
-        , @r"
-    success: true
-    exit_code: 0
-    ----- stdout -----
-    All checks passed!
-
-    ----- stderr -----
-    ");
-
     insta::with_settings!({filters => vec![(r"\\", "/")]}, {
         assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
             .args(STDIN_BASE_OPTIONS)
             .arg("--select")
             .arg("INP")
-            .arg("--preview")
             .current_dir(&tempdir)
             , @r"
         success: false

--- a/crates/ruff_linter/src/checkers/filesystem.rs
+++ b/crates/ruff_linter/src/checkers/filesystem.rs
@@ -29,7 +29,6 @@ pub(crate) fn check_file_path(
             comment_ranges,
             &settings.project_root,
             &settings.src,
-            settings.preview,
         ) {
             diagnostics.push(diagnostic);
         }


### PR DESCRIPTION
## Summary

I reconsidered and I think we shouldn't stabilize this today, considering that we already know that it isn't working in the LSP https://github.com/astral-sh/ruff/issues/14752

## Test Plan

<!-- How was it tested? -->
