### PR TITLE
[`flake8-builtins`] Disapply `A005` to stub files

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_builtins/A005/modules/package/collections.pyi
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_builtins/A005/modules/package/collections.pyi
@@ -1,0 +1,1 @@
+# A005 does not apply to stub files!

--- a/crates/ruff_linter/src/rules/flake8_builtins/mod.rs
+++ b/crates/ruff_linter/src/rules/flake8_builtins/mod.rs
@@ -38,6 +38,10 @@ mod tests {
     )]
     #[test_case(
         Rule::StdlibModuleShadowing,
+        Path::new("A005/modules/package/collections.pyi")
+    )]
+    #[test_case(
+        Rule::StdlibModuleShadowing,
         Path::new("A005/modules/_abc/__init__.py")
     )]
     #[test_case(Rule::StdlibModuleShadowing, Path::new("A005/modules/package/xml.py"))]

--- a/crates/ruff_linter/src/rules/flake8_builtins/rules/stdlib_module_shadowing.rs
+++ b/crates/ruff_linter/src/rules/flake8_builtins/rules/stdlib_module_shadowing.rs
@@ -23,6 +23,10 @@ use crate::settings::types::PythonVersion;
 /// Standard-library modules can be marked as exceptions to this rule via the
 /// [`lint.flake8-builtins.builtins-allowed-modules`] configuration option.
 ///
+/// This rule is not applied to stub files, as the name of a stub module is out
+/// of the control of the author of the stub file. Instead, a stub should aim to
+/// faithfully emulate the runtime module it is stubbing.
+///
 /// ## Options
 /// - `lint.flake8-builtins.builtins-allowed-modules`
 #[derive(ViolationMetadata)]
@@ -45,7 +49,7 @@ pub(crate) fn stdlib_module_shadowing(
     allowed_modules: &[String],
     target_version: PythonVersion,
 ) -> Option<Diagnostic> {
-    if !PySourceType::try_from_path(path).is_some_and(PySourceType::is_py_file_or_stub) {
+    if !PySourceType::try_from_path(path).is_some_and(PySourceType::is_py_file) {
         return None;
     }
 

--- a/crates/ruff_linter/src/rules/flake8_builtins/snapshots/ruff_linter__rules__flake8_builtins__tests__A005_A005__modules__package__collections.pyi.snap
+++ b/crates/ruff_linter/src/rules/flake8_builtins/snapshots/ruff_linter__rules__flake8_builtins__tests__A005_A005__modules__package__collections.pyi.snap
@@ -1,0 +1,4 @@
+---
+source: crates/ruff_linter/src/rules/flake8_builtins/mod.rs
+---
+


### PR DESCRIPTION
## Summary

The rule doesn't make sense for stub files; the name of a module is outside the control of the stub author. See https://github.com/astral-sh/ruff/issues/15293

## Test Plan

`cargo test -p ruff_linter --lib`
