### PR TITLE
[`ruff`] Stabilize `post-init-default` (RUF033)

### DIFF
--- a/crates/ruff_linter/src/codes.rs
+++ b/crates/ruff_linter/src/codes.rs
@@ -981,7 +981,7 @@ pub fn code_to_rule(linter: Linter, code: &str) -> Option<(RuleGroup, Rule)> {
         (Ruff, "030") => (RuleGroup::Stable, rules::ruff::rules::AssertWithPrintMessage),
         (Ruff, "031") => (RuleGroup::Preview, rules::ruff::rules::IncorrectlyParenthesizedTupleInSubscript),
         (Ruff, "032") => (RuleGroup::Stable, rules::ruff::rules::DecimalFromFloatLiteral),
-        (Ruff, "033") => (RuleGroup::Preview, rules::ruff::rules::PostInitDefault),
+        (Ruff, "033") => (RuleGroup::Stable, rules::ruff::rules::PostInitDefault),
         (Ruff, "034") => (RuleGroup::Preview, rules::ruff::rules::UselessIfElse),
         (Ruff, "035") => (RuleGroup::Preview, rules::ruff::rules::UnsafeMarkupUse),
         (Ruff, "036") => (RuleGroup::Preview, rules::ruff::rules::NoneNotAtEndOfUnion),


### PR DESCRIPTION
## Summary

Stabilizes the [`post-init-default`](https://docs.astral.sh/ruff/rules/post-init-default/) rule

## Test Plan

There are no open issues or PRs related to this rule. 

There are no ecosystem changes... Makes this somewhat hard to judge.
