### PR TITLE
[`pycodestyle`] Avoid false positives related to type aliases (`E252`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pycodestyle/E25.py
+++ b/crates/ruff_linter/resources/test/fixtures/pycodestyle/E25.py
@@ -79,3 +79,15 @@ class PEP696Good[A = int, B: object = str, C:object = memoryview]:
 
 # https://github.com/astral-sh/ruff/issues/15202
 type Coro[T: object = Any] = Coroutine[None, None, T]
+
+
+# https://github.com/astral-sh/ruff/issues/15339
+type A = Annotated[
+    str, Foo(lorem='ipsum')
+]
+type B = Annotated[
+    int, lambda a=1: ...
+]
+type C = Annotated[
+    int, lambda a: ..., lambda a=1: ...
+]

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/logical_lines/mod.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/logical_lines/mod.rs
@@ -531,7 +531,7 @@ impl DefinitionState {
             Self::NotInDefinition => return,
         };
         match token_kind {
-            TokenKind::Lpar if type_params_state_mut.before_type_params() => {
+            TokenKind::Lpar | TokenKind::Equal if type_params_state_mut.before_type_params() => {
                 *type_params_state_mut = TypeParamsState::TypeParamsEnded;
             }
             TokenKind::Lsqb => match type_params_state_mut {


### PR DESCRIPTION
## Summary

Resolves #15339.

## Test Plan

`cargo nextest run` and `cargo insta test`.