### PR TITLE
[red-knot] Property test workflow: Fix issue label, link to CI run

### DIFF
--- a/.github/workflows/daily_fuzz.yaml
+++ b/.github/workflows/daily_fuzz.yaml
@@ -73,6 +73,6 @@ jobs:
               owner: "astral-sh",
               repo: "ruff",
               title: `Daily parser fuzz failed on ${new Date().toDateString()}`,
-              body: "Runs listed here: https://github.com/astral-sh/ruff/actions/workflows/daily_fuzz.yml",
+              body: "Run listed here: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}",
               labels: ["bug", "parser", "fuzzer"],
             })

--- a/.github/workflows/daily_property_tests.yaml
+++ b/.github/workflows/daily_property_tests.yaml
@@ -66,6 +66,6 @@ jobs:
               owner: "astral-sh",
               repo: "ruff",
               title: `Daily property test run failed on ${new Date().toDateString()}`,
-              body: "Runs listed here: https://github.com/astral-sh/ruff/actions/workflows/daily_property_tests.yaml",
-              labels: ["bug", "red_knot", "testing"],
+              body: "Run listed here: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+              labels: ["bug", "red-knot", "testing"],
             })


### PR DESCRIPTION
## Summary

See title. Had to make a minor change, because it failed the zizmor pre-commit check otherwise (FYI @AlexWaygood)

```
error[template-injection]: code injection via template expansion
  --> /home/shark/ruff/.github/workflows/daily_fuzz.yaml:68:9
   |
68 |          - uses: actions/github-script@v7
   |  __________^
69 | |          with:
70 | |            github-token: ${{ secrets.GITHUB_TOKEN }}
71 | |            script: |
   | | ___________^
72 | ||             await github.rest.issues.create({
...  ||
77 | ||               labels: ["bug", "parser", "fuzzer"],
78 | ||             })
   | ||               ^
   | ||_______________|
   |  |_______________this step
   |                  github.server_url may expand into attacker-controllable code
   |
   = note: audit confidence → High
```

