### PR TITLE
[red-knot] handle synthetic 'self' argument in call-binding diagnostics

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/call/callable_instance.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/call/callable_instance.md
@@ -70,3 +70,32 @@ def _(flag: bool):
     # error: "Object of type `Literal[1] | Literal[__call__]` is not callable (due to union element `Literal[1]`)"
     reveal_type(a())  # revealed: Unknown | int
 ```
+
+## Call binding errors
+
+### Wrong argument type
+
+```py
+class C:
+    def __call__(self, x: int) -> int:
+        return 1
+
+c = C()
+
+# error: 15 [invalid-argument-type] "Object of type `Literal["foo"]` cannot be assigned to parameter 2 (`x`) of function `__call__`; expected type `int`"
+reveal_type(c("foo"))  # revealed: int
+```
+
+### Wrong argument type on `self`
+
+```py
+class C:
+    # TODO this definition should also be an error; `C` must be assignable to type of `self`
+    def __call__(self: int) -> int:
+        return 1
+
+c = C()
+
+# error: 13 [invalid-argument-type] "Object of type `C` cannot be assigned to parameter 1 (`self`) of function `__call__`; expected type `int`"
+reveal_type(c())  # revealed: int
+```

--- a/crates/red_knot_python_semantic/src/types/call/arguments.rs
+++ b/crates/red_knot_python_semantic/src/types/call/arguments.rs
@@ -16,7 +16,7 @@ impl<'a, 'db> CallArguments<'a, 'db> {
     /// Prepend an extra positional argument.
     pub(crate) fn with_self(&self, self_ty: Type<'db>) -> Self {
         let mut arguments = Vec::with_capacity(self.0.len() + 1);
-        arguments.push(Argument::Positional(self_ty));
+        arguments.push(Argument::Synthetic(self_ty));
         arguments.extend_from_slice(&self.0);
         Self(arguments)
     }
@@ -48,6 +48,8 @@ impl<'a, 'db> FromIterator<Argument<'a, 'db>> for CallArguments<'a, 'db> {
 
 #[derive(Clone, Debug)]
 pub(crate) enum Argument<'a, 'db> {
+    /// The synthetic `self` or `cls` argument, which doesn't appear explicitly at the call site.
+    Synthetic(Type<'db>),
     /// A positional argument.
     Positional(Type<'db>),
     /// A starred positional argument (e.g. `*args`).
@@ -61,6 +63,7 @@ pub(crate) enum Argument<'a, 'db> {
 impl<'db> Argument<'_, 'db> {
     fn ty(&self) -> Type<'db> {
         match self {
+            Self::Synthetic(ty) => *ty,
             Self::Positional(ty) => *ty,
             Self::Variadic(ty) => *ty,
             Self::Keyword { name: _, ty } => *ty,


### PR DESCRIPTION
## Summary

In binding calls, we store an argument index with argument-specific binding errors, so that we can emit the diagnostic on the specific argument node at the call site.

We need to account for the synthetic `self` argument for methods, or else our argument index is off by one and can result in a panic where we are looking for an argument node that doesn't exist in the call.

Fixes #15360

## Test Plan

Added mdtest.

Also verified that with this fix, red-knot can again run on Black codebase without panic.
