### PR TITLE
[`ruff`] Stop parsing diagnostics from other sources for code action requests

### DIFF
--- a/crates/ruff_server/src/lint.rs
+++ b/crates/ruff_server/src/lint.rs
@@ -206,6 +206,7 @@ pub(crate) fn fixes_for_diagnostics(
 ) -> crate::Result<Vec<DiagnosticFix>> {
     diagnostics
         .into_iter()
+        .filter(|diagnostic| diagnostic.source.as_deref() == Some(DIAGNOSTIC_NAME))
         .map(move |mut diagnostic| {
             let Some(data) = diagnostic.data.take() else {
                 return Ok(None);


### PR DESCRIPTION
### Summary

This PR stops `ruff server` attempting to parse diagnostic data for diagnostics from other language servers.

### The issue

When using `ruff server` with [`typos-lsp`](https://github.com/tekumara/typos-lsp) in [`helix`](https://github.com/helix-editor/helix), it is impossible to apply code actions suggested by `typos-lsp`. 

### The cause

During a [`textDocument/codeAction`](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_codeAction) request, the editor will send [`Diagnostic`]()s to `ruff server` as part of the [`codeActionContext`](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#codeActionContext) - these may have been generated by other LSP servers.

According to the spec, the `Diagnostic.data` field can contain any data. However, `ruff server` attempts to parse all contextual diagnostics, and assumes the `data` field adheres to the data structure used by `ruff server`. 

Since other language servers are free to use their own data structure, parsing the diagnostics fails causing an error, which ultimately causes the code action request to fail.

### The fix

On code action requests, `ruff server` should only parse contextual diagnostics generated by `ruff server`.


