### PR TITLE
[`ruff`] Omit diagnostic for shadowed private function parameters in `used-dummy-variable` (`RUF052`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/ruff/RUF052.py
+++ b/crates/ruff_linter/resources/test/fixtures/ruff/RUF052.py
@@ -145,3 +145,19 @@ def special_calls():
     _NotADynamicClass = type("_NotADynamicClass")
 
     print(_T, _P, _NT, _E, _NT2, _NT3, _DynamicClass, _NotADynamicClass)
+
+# Do not emit diagnostic if parameter is private
+# even if it is later shadowed in the body of the function
+# see https://github.com/astral-sh/ruff/issues/14968
+class Node:
+
+    connected: list[Node]
+
+    def recurse(self, *, _seen: set[Node] | None = None):
+        if _seen is None:
+            _seen = set()
+        elif self in _seen:
+            return
+        _seen.add(self)
+        for other in self.connected:
+            other.recurse(_seen=_seen)

--- a/crates/ruff_linter/src/checkers/ast/analyze/bindings.rs
+++ b/crates/ruff_linter/src/checkers/ast/analyze/bindings.rs
@@ -24,7 +24,7 @@ pub(crate) fn bindings(checker: &mut Checker) {
         return;
     }
 
-    for binding in &*checker.semantic.bindings {
+    for (binding_id, binding) in checker.semantic.bindings.iter_enumerated() {
         if checker.enabled(Rule::UnusedVariable) {
             if binding.kind.is_bound_exception()
                 && binding.is_unused()
@@ -90,7 +90,8 @@ pub(crate) fn bindings(checker: &mut Checker) {
             }
         }
         if checker.enabled(Rule::UsedDummyVariable) {
-            if let Some(diagnostic) = ruff::rules::used_dummy_variable(checker, binding) {
+            if let Some(diagnostic) = ruff::rules::used_dummy_variable(checker, binding, binding_id)
+            {
                 checker.diagnostics.push(diagnostic);
             }
         }

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF052_RUF052.py.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF052_RUF052.py.snap
@@ -175,6 +175,9 @@ RUF052.py:138:5: RUF052 [*] Local dummy variable `_P` is accessed
 146 146 | 
 147     |-    print(_T, _P, _NT, _E, _NT2, _NT3, _DynamicClass, _NotADynamicClass)
     147 |+    print(_T, P, _NT, _E, _NT2, _NT3, _DynamicClass, _NotADynamicClass)
+148 148 | 
+149 149 | # Do not emit diagnostic if parameter is private
+150 150 | # even if it is later shadowed in the body of the function
 
 RUF052.py:139:5: RUF052 [*] Local dummy variable `_T` is accessed
     |
@@ -201,6 +204,9 @@ RUF052.py:139:5: RUF052 [*] Local dummy variable `_T` is accessed
 146 146 | 
 147     |-    print(_T, _P, _NT, _E, _NT2, _NT3, _DynamicClass, _NotADynamicClass)
     147 |+    print(T, _P, _NT, _E, _NT2, _NT3, _DynamicClass, _NotADynamicClass)
+148 148 | 
+149 149 | # Do not emit diagnostic if parameter is private
+150 150 | # even if it is later shadowed in the body of the function
 
 RUF052.py:140:5: RUF052 [*] Local dummy variable `_NT` is accessed
     |
@@ -227,6 +233,9 @@ RUF052.py:140:5: RUF052 [*] Local dummy variable `_NT` is accessed
 146 146 | 
 147     |-    print(_T, _P, _NT, _E, _NT2, _NT3, _DynamicClass, _NotADynamicClass)
     147 |+    print(_T, _P, NT, _E, _NT2, _NT3, _DynamicClass, _NotADynamicClass)
+148 148 | 
+149 149 | # Do not emit diagnostic if parameter is private
+150 150 | # even if it is later shadowed in the body of the function
 
 RUF052.py:141:5: RUF052 [*] Local dummy variable `_E` is accessed
     |
@@ -252,6 +261,9 @@ RUF052.py:141:5: RUF052 [*] Local dummy variable `_E` is accessed
 146 146 | 
 147     |-    print(_T, _P, _NT, _E, _NT2, _NT3, _DynamicClass, _NotADynamicClass)
     147 |+    print(_T, _P, _NT, E, _NT2, _NT3, _DynamicClass, _NotADynamicClass)
+148 148 | 
+149 149 | # Do not emit diagnostic if parameter is private
+150 150 | # even if it is later shadowed in the body of the function
 
 RUF052.py:142:5: RUF052 [*] Local dummy variable `_NT2` is accessed
     |
@@ -276,6 +288,9 @@ RUF052.py:142:5: RUF052 [*] Local dummy variable `_NT2` is accessed
 146 146 | 
 147     |-    print(_T, _P, _NT, _E, _NT2, _NT3, _DynamicClass, _NotADynamicClass)
     147 |+    print(_T, _P, _NT, _E, NT2, _NT3, _DynamicClass, _NotADynamicClass)
+148 148 | 
+149 149 | # Do not emit diagnostic if parameter is private
+150 150 | # even if it is later shadowed in the body of the function
 
 RUF052.py:143:5: RUF052 [*] Local dummy variable `_NT3` is accessed
     |
@@ -299,6 +314,9 @@ RUF052.py:143:5: RUF052 [*] Local dummy variable `_NT3` is accessed
 146 146 | 
 147     |-    print(_T, _P, _NT, _E, _NT2, _NT3, _DynamicClass, _NotADynamicClass)
     147 |+    print(_T, _P, _NT, _E, _NT2, NT3, _DynamicClass, _NotADynamicClass)
+148 148 | 
+149 149 | # Do not emit diagnostic if parameter is private
+150 150 | # even if it is later shadowed in the body of the function
 
 RUF052.py:144:5: RUF052 [*] Local dummy variable `_DynamicClass` is accessed
     |
@@ -320,6 +338,9 @@ RUF052.py:144:5: RUF052 [*] Local dummy variable `_DynamicClass` is accessed
 146 146 | 
 147     |-    print(_T, _P, _NT, _E, _NT2, _NT3, _DynamicClass, _NotADynamicClass)
     147 |+    print(_T, _P, _NT, _E, _NT2, _NT3, DynamicClass, _NotADynamicClass)
+148 148 | 
+149 149 | # Do not emit diagnostic if parameter is private
+150 150 | # even if it is later shadowed in the body of the function
 
 RUF052.py:145:5: RUF052 [*] Local dummy variable `_NotADynamicClass` is accessed
     |
@@ -341,3 +362,6 @@ RUF052.py:145:5: RUF052 [*] Local dummy variable `_NotADynamicClass` is accessed
 146 146 | 
 147     |-    print(_T, _P, _NT, _E, _NT2, _NT3, _DynamicClass, _NotADynamicClass)
     147 |+    print(_T, _P, _NT, _E, _NT2, _NT3, _DynamicClass, NotADynamicClass)
+148 148 | 
+149 149 | # Do not emit diagnostic if parameter is private
+150 150 | # even if it is later shadowed in the body of the function

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__custom_dummy_var_regexp_preset__RUF052_RUF052.py_1.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__custom_dummy_var_regexp_preset__RUF052_RUF052.py_1.snap
@@ -175,6 +175,9 @@ RUF052.py:138:5: RUF052 [*] Local dummy variable `_P` is accessed
 146 146 | 
 147     |-    print(_T, _P, _NT, _E, _NT2, _NT3, _DynamicClass, _NotADynamicClass)
     147 |+    print(_T, P, _NT, _E, _NT2, _NT3, _DynamicClass, _NotADynamicClass)
+148 148 | 
+149 149 | # Do not emit diagnostic if parameter is private
+150 150 | # even if it is later shadowed in the body of the function
 
 RUF052.py:139:5: RUF052 [*] Local dummy variable `_T` is accessed
     |
@@ -201,6 +204,9 @@ RUF052.py:139:5: RUF052 [*] Local dummy variable `_T` is accessed
 146 146 | 
 147     |-    print(_T, _P, _NT, _E, _NT2, _NT3, _DynamicClass, _NotADynamicClass)
     147 |+    print(T, _P, _NT, _E, _NT2, _NT3, _DynamicClass, _NotADynamicClass)
+148 148 | 
+149 149 | # Do not emit diagnostic if parameter is private
+150 150 | # even if it is later shadowed in the body of the function
 
 RUF052.py:140:5: RUF052 [*] Local dummy variable `_NT` is accessed
     |
@@ -227,6 +233,9 @@ RUF052.py:140:5: RUF052 [*] Local dummy variable `_NT` is accessed
 146 146 | 
 147     |-    print(_T, _P, _NT, _E, _NT2, _NT3, _DynamicClass, _NotADynamicClass)
     147 |+    print(_T, _P, NT, _E, _NT2, _NT3, _DynamicClass, _NotADynamicClass)
+148 148 | 
+149 149 | # Do not emit diagnostic if parameter is private
+150 150 | # even if it is later shadowed in the body of the function
 
 RUF052.py:141:5: RUF052 [*] Local dummy variable `_E` is accessed
     |
@@ -252,6 +261,9 @@ RUF052.py:141:5: RUF052 [*] Local dummy variable `_E` is accessed
 146 146 | 
 147     |-    print(_T, _P, _NT, _E, _NT2, _NT3, _DynamicClass, _NotADynamicClass)
     147 |+    print(_T, _P, _NT, E, _NT2, _NT3, _DynamicClass, _NotADynamicClass)
+148 148 | 
+149 149 | # Do not emit diagnostic if parameter is private
+150 150 | # even if it is later shadowed in the body of the function
 
 RUF052.py:142:5: RUF052 [*] Local dummy variable `_NT2` is accessed
     |
@@ -276,6 +288,9 @@ RUF052.py:142:5: RUF052 [*] Local dummy variable `_NT2` is accessed
 146 146 | 
 147     |-    print(_T, _P, _NT, _E, _NT2, _NT3, _DynamicClass, _NotADynamicClass)
     147 |+    print(_T, _P, _NT, _E, NT2, _NT3, _DynamicClass, _NotADynamicClass)
+148 148 | 
+149 149 | # Do not emit diagnostic if parameter is private
+150 150 | # even if it is later shadowed in the body of the function
 
 RUF052.py:143:5: RUF052 [*] Local dummy variable `_NT3` is accessed
     |
@@ -299,6 +314,9 @@ RUF052.py:143:5: RUF052 [*] Local dummy variable `_NT3` is accessed
 146 146 | 
 147     |-    print(_T, _P, _NT, _E, _NT2, _NT3, _DynamicClass, _NotADynamicClass)
     147 |+    print(_T, _P, _NT, _E, _NT2, NT3, _DynamicClass, _NotADynamicClass)
+148 148 | 
+149 149 | # Do not emit diagnostic if parameter is private
+150 150 | # even if it is later shadowed in the body of the function
 
 RUF052.py:144:5: RUF052 [*] Local dummy variable `_DynamicClass` is accessed
     |
@@ -320,6 +338,9 @@ RUF052.py:144:5: RUF052 [*] Local dummy variable `_DynamicClass` is accessed
 146 146 | 
 147     |-    print(_T, _P, _NT, _E, _NT2, _NT3, _DynamicClass, _NotADynamicClass)
     147 |+    print(_T, _P, _NT, _E, _NT2, _NT3, DynamicClass, _NotADynamicClass)
+148 148 | 
+149 149 | # Do not emit diagnostic if parameter is private
+150 150 | # even if it is later shadowed in the body of the function
 
 RUF052.py:145:5: RUF052 [*] Local dummy variable `_NotADynamicClass` is accessed
     |
@@ -341,3 +362,6 @@ RUF052.py:145:5: RUF052 [*] Local dummy variable `_NotADynamicClass` is accessed
 146 146 | 
 147     |-    print(_T, _P, _NT, _E, _NT2, _NT3, _DynamicClass, _NotADynamicClass)
     147 |+    print(_T, _P, _NT, _E, _NT2, _NT3, _DynamicClass, NotADynamicClass)
+148 148 | 
+149 149 | # Do not emit diagnostic if parameter is private
+150 150 | # even if it is later shadowed in the body of the function


### PR DESCRIPTION
As discussed in #14818, we should skip [used-dummy-variable (RUF052)](https://docs.astral.sh/ruff/rules/used-dummy-variable/#used-dummy-variable-ruf052) for private function parameters. This PR extends the logic from loc. cit. and further skips the lint for bindings in the body of a function which shadow a private function parameter.

Closes #14968 
