### PR TITLE
Associate a trailing end-of-line comment in a parenthesized implicit concatenated string with the last literal

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/join_implicit_concatenated_string_assignment.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/join_implicit_concatenated_string_assignment.py
@@ -351,13 +351,13 @@ logger.error(
 )
 
 a = (10 +
-     "Exception in {call_back_name} when handling msg on "
-     f"'{msg.topic}': '{msg.payload}'"   # belongs to binary operation
+     "Exception in {call_back_name} "
+     f"'{msg}'"  # belongs to binary operation
 )
 
 a = 10 + (
-    "Exception in {call_back_name} when handling msg on "
-    f"'{msg.topic}': '{msg.payload}'"   # belongs to last-part
+    "Exception in {call_back_name} "
+    f"'{msg}'"  # belongs to f-string
 )
 
 self._attr_unique_id = (

--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/join_implicit_concatenated_string_assignment.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/join_implicit_concatenated_string_assignment.py
@@ -300,11 +300,36 @@ a = (
     "b"  # belongs to `b`
 )
 
+a: Literal[str] = (
+    "a"
+    "b"  # belongs to `b`
+)
+
+a += (
+    "a"
+    "b"  # belongs to `b`
+)
+
+a = (
+    r"a"
+    r"b"  # belongs to `b`
+)
+
 a = (
     "a"
     "b"
 )  # belongs to the assignment
 
+a = (((
+    "a"
+    "b"  # belongs to `b`
+)))
+
+a = (((
+    "a"
+    "b"
+) # belongs to the f-string expression
+))
 
 a = (
     "a" "b"  # belongs to the f-string expression
@@ -333,4 +358,16 @@ a = (10 +
 a = 10 + (
     "Exception in {call_back_name} when handling msg on "
     f"'{msg.topic}': '{msg.payload}'"   # belongs to last-part
+)
+
+self._attr_unique_id = (
+    f"{self._device.temperature.group_address_state}_"
+    f"{self._device.target_temperature.group_address_state}_"
+    f"{self._device.target_temperature.group_address}_"
+    f"{self._device._setpoint_shift.group_address}"  # noqa: SLF001
+)
+
+return (
+    f"Exception in {call_back_name} when handling msg on "
+    f"'{msg.topic}': '{msg.payload}'"  # type: ignore[str-bytes-safe]
 )

--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/join_implicit_concatenated_string_assignment.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/join_implicit_concatenated_string_assignment.py
@@ -291,3 +291,46 @@ aaaaa[aaaaaaaaaaa] = (
     f"testeeeeeeeeeeeeeeeeeeeeeeeee{a
     =}" "moreeeeeeeeeeeeeeeeeetest"  # comment
 )
+
+
+# Trailing last-part comments
+
+a = (
+    "a"
+    "b"  # belongs to `b`
+)
+
+a = (
+    "a"
+    "b"
+)  # belongs to the assignment
+
+
+a = (
+    "a" "b"  # belongs to the f-string expression
+)
+
+a = (
+    "a" "b"
+    # belongs to the f-string expression
+)
+
+a = (
+    "a"
+    "b" "c"  # belongs to the f-string expression
+)
+
+logger.error(
+    f"Failed to run task {task} for job"  
+    f"with id {str(job.id)}" # type: ignore[union-attr]
+)
+
+a = (10 +
+     "Exception in {call_back_name} when handling msg on "
+     f"'{msg.topic}': '{msg.payload}'"   # belongs to binary operation
+)
+
+a = 10 + (
+    "Exception in {call_back_name} when handling msg on "
+    f"'{msg.topic}': '{msg.payload}'"   # belongs to last-part
+)

--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/join_implicit_concatenated_string_assignment.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/join_implicit_concatenated_string_assignment.py
@@ -340,9 +340,13 @@ a = (
     # belongs to the f-string expression
 )
 
+# There's no "right" answer if some parts are on the same line while others are on separate lines.
+# This is likely a comment for one of the last two parts but could also just be a comment for the entire f-string expression.
+# Because there's no right answer, follow what we do elsewhere and associate the comment with the outer-most node which
+# is the f-string expression.
 a = (
     "a"
-    "b" "c"  # belongs to the f-string expression
+    "b" "ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"  # belongs to the f-string expression
 )
 
 logger.error(

--- a/crates/ruff_python_formatter/src/lib.rs
+++ b/crates/ruff_python_formatter/src/lib.rs
@@ -186,13 +186,12 @@ if True:
     #[test]
     fn quick_test() {
         let source = r#"
-def main() -> None:
-    if True:
-        some_very_long_variable_name_abcdefghijk = Foo()
-        some_very_long_variable_name_abcdefghijk = some_very_long_variable_name_abcdefghijk[
-            some_very_long_variable_name_abcdefghijk.some_very_long_attribute_name
-            == "This is a very long string abcdefghijk"
-        ]
+def test():
+    a = 10 + (
+        "Exception in {call_back_name} when handling msg on "
+        f"'{msg.topic}': '{msg.payload}'"   # type: ignore[str-bytes-safe]
+    )
+
 
 "#;
         let source_type = PySourceType::Python;

--- a/crates/ruff_python_formatter/src/lib.rs
+++ b/crates/ruff_python_formatter/src/lib.rs
@@ -186,12 +186,13 @@ if True:
     #[test]
     fn quick_test() {
         let source = r#"
-def test():
-    a = 10 + (
-        "Exception in {call_back_name} when handling msg on "
-        f"'{msg.topic}': '{msg.payload}'"   # type: ignore[str-bytes-safe]
-    )
-
+def main() -> None:
+    if True:
+        some_very_long_variable_name_abcdefghijk = Foo()
+        some_very_long_variable_name_abcdefghijk = some_very_long_variable_name_abcdefghijk[
+            some_very_long_variable_name_abcdefghijk.some_very_long_attribute_name
+            == "This is a very long string abcdefghijk"
+        ]
 
 "#;
         let source_type = PySourceType::Python;

--- a/crates/ruff_python_formatter/src/string/implicit.rs
+++ b/crates/ruff_python_formatter/src/string/implicit.rs
@@ -99,7 +99,7 @@ impl Format<PyFormatContext<'_>> for FormatImplicitConcatenatedStringExpanded<'_
                 StringLikePart::FString(part) => part.format().fmt(f),
             });
 
-            let part_comments = comments.leading_dangling_trailing(&part);
+            let part_comments = comments.leading_dangling_trailing(part);
             joiner.entry(&format_args![
                 leading_comments(part_comments.leading),
                 format_part,

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__fstring.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__fstring.py.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/ruff_python_formatter/tests/fixtures.rs
 input_file: crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/fstring.py
-snapshot_kind: text
 ---
 ## Input
 ```python
@@ -776,8 +775,7 @@ result_f = (
 )
 
 (
-    f"{1}"
-    f"{2}"  # comment 3
+    f"{1}{2}"  # comment 3
 )
 
 (
@@ -1551,8 +1549,7 @@ result_f = (
 )
 
 (
-    f"{1}"
-    f"{2}"  # comment 3
+    f"{1}{2}"  # comment 3
 )
 
 (

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__fstring.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__fstring.py.snap
@@ -776,7 +776,8 @@ result_f = (
 )
 
 (
-    f"{1}{2}"  # comment 3
+    f"{1}"
+    f"{2}"  # comment 3
 )
 
 (
@@ -1550,7 +1551,8 @@ result_f = (
 )
 
 (
-    f"{1}{2}"  # comment 3
+    f"{1}"
+    f"{2}"  # comment 3
 )
 
 (

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__join_implicit_concatenated_string_assignment.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__join_implicit_concatenated_string_assignment.py.snap
@@ -357,13 +357,13 @@ logger.error(
 )
 
 a = (10 +
-     "Exception in {call_back_name} when handling msg on "
-     f"'{msg.topic}': '{msg.payload}'"   # belongs to binary operation
+     "Exception in {call_back_name} "
+     f"'{msg}'"  # belongs to binary operation
 )
 
 a = 10 + (
-    "Exception in {call_back_name} when handling msg on "
-    f"'{msg.topic}': '{msg.payload}'"   # belongs to last-part
+    "Exception in {call_back_name} "
+    f"'{msg}'"  # belongs to f-string
 )
 
 self._attr_unique_id = (
@@ -745,13 +745,11 @@ logger.error(
 )
 
 a = (
-    10 + "Exception in {call_back_name} when handling msg on "
-    f"'{msg.topic}': '{msg.payload}'"  # belongs to binary operation
+    10 + f"Exception in {{call_back_name}} '{msg}'"  # belongs to binary operation
 )
 
 a = 10 + (
-    "Exception in {call_back_name} when handling msg on "
-    f"'{msg.topic}': '{msg.payload}'"  # belongs to last-part
+    f"Exception in {{call_back_name}} '{msg}'"  # belongs to f-string
 )
 
 self._attr_unique_id = (

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__join_implicit_concatenated_string_assignment.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__join_implicit_concatenated_string_assignment.py.snap
@@ -346,9 +346,13 @@ a = (
     # belongs to the f-string expression
 )
 
+# There's no "right" answer if some parts are on the same line while others are on separate lines.
+# This is likely a comment for one of the last two parts but could also just be a comment for the entire f-string expression.
+# Because there's no right answer, follow what we do elsewhere and associate the comment with the outer-most node which
+# is the f-string expression.
 a = (
     "a"
-    "b" "c"  # belongs to the f-string expression
+    "b" "ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"  # belongs to the f-string expression
 )
 
 logger.error(
@@ -738,7 +742,15 @@ a = (
     # belongs to the f-string expression
 )
 
-a = "abc"  # belongs to the f-string expression
+# There's no "right" answer if some parts are on the same line while others are on separate lines.
+# This is likely a comment for one of the last two parts but could also just be a comment for the entire f-string expression.
+# Because there's no right answer, follow what we do elsewhere and associate the comment with the outer-most node which
+# is the f-string expression.
+a = (
+    "a"
+    "b"
+    "ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+)  # belongs to the f-string expression
 
 logger.error(
     f"Failed to run task {task} for jobwith id {str(job.id)}"  # type: ignore[union-attr]

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__join_implicit_concatenated_string_assignment.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__join_implicit_concatenated_string_assignment.py.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/ruff_python_formatter/tests/fixtures.rs
 input_file: crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/join_implicit_concatenated_string_assignment.py
+snapshot_kind: text
 ---
 ## Input
 ```python
@@ -296,6 +297,49 @@ aaaaa[aaaaaaaaaaa] = (
 aaaaa[aaaaaaaaaaa] = (
     f"testeeeeeeeeeeeeeeeeeeeeeeeee{a
     =}" "moreeeeeeeeeeeeeeeeeetest"  # comment
+)
+
+
+# Trailing last-part comments
+
+a = (
+    "a"
+    "b"  # belongs to `b`
+)
+
+a = (
+    "a"
+    "b"
+)  # belongs to the assignment
+
+
+a = (
+    "a" "b"  # belongs to the f-string expression
+)
+
+a = (
+    "a" "b"
+    # belongs to the f-string expression
+)
+
+a = (
+    "a"
+    "b" "c"  # belongs to the f-string expression
+)
+
+logger.error(
+    f"Failed to run task {task} for job"  
+    f"with id {str(job.id)}" # type: ignore[union-attr]
+)
+
+a = (10 +
+     "Exception in {call_back_name} when handling msg on "
+     f"'{msg.topic}': '{msg.payload}'"   # belongs to binary operation
+)
+
+a = 10 + (
+    "Exception in {call_back_name} when handling msg on "
+    f"'{msg.topic}': '{msg.payload}'"   # belongs to last-part
 )
 ```
 
@@ -618,5 +662,40 @@ aaaaa[aaaaaaaaaaa] = (
     f"testeeeeeeeeeeeeeeeeeeeeeeeee{a
     =}"
     "moreeeeeeeeeeeeeeeeeetest"  # comment
+)
+
+
+# Trailing last-part comments
+
+a = (
+    "a"
+    "b"  # belongs to `b`
+)
+
+a = "ab"  # belongs to the assignment
+
+
+a = "ab"  # belongs to the f-string expression
+
+a = (
+    "ab"
+    # belongs to the f-string expression
+)
+
+a = "abc"  # belongs to the f-string expression
+
+logger.error(
+    f"Failed to run task {task} for job"
+    f"with id {str(job.id)}"  # type: ignore[union-attr]
+)
+
+a = (
+    10 + "Exception in {call_back_name} when handling msg on "
+    f"'{msg.topic}': '{msg.payload}'"  # belongs to binary operation
+)
+
+a = 10 + (
+    "Exception in {call_back_name} when handling msg on "
+    f"'{msg.topic}': '{msg.payload}'"  # belongs to last-part
 )
 ```

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__join_implicit_concatenated_string_assignment.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__join_implicit_concatenated_string_assignment.py.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/ruff_python_formatter/tests/fixtures.rs
 input_file: crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/join_implicit_concatenated_string_assignment.py
-snapshot_kind: text
 ---
 ## Input
 ```python
@@ -307,11 +306,36 @@ a = (
     "b"  # belongs to `b`
 )
 
+a: Literal[str] = (
+    "a"
+    "b"  # belongs to `b`
+)
+
+a += (
+    "a"
+    "b"  # belongs to `b`
+)
+
+a = (
+    r"a"
+    r"b"  # belongs to `b`
+)
+
 a = (
     "a"
     "b"
 )  # belongs to the assignment
 
+a = (((
+    "a"
+    "b"  # belongs to `b`
+)))
+
+a = (((
+    "a"
+    "b"
+) # belongs to the f-string expression
+))
 
 a = (
     "a" "b"  # belongs to the f-string expression
@@ -341,7 +365,18 @@ a = 10 + (
     "Exception in {call_back_name} when handling msg on "
     f"'{msg.topic}': '{msg.payload}'"   # belongs to last-part
 )
-```
+
+self._attr_unique_id = (
+    f"{self._device.temperature.group_address_state}_"
+    f"{self._device.target_temperature.group_address_state}_"
+    f"{self._device.target_temperature.group_address}_"
+    f"{self._device._setpoint_shift.group_address}"  # noqa: SLF001
+)
+
+return (
+    f"Exception in {call_back_name} when handling msg on "
+    f"'{msg.topic}': '{msg.payload}'"  # type: ignore[str-bytes-safe]
+)```
 
 ## Output
 ```python
@@ -672,8 +707,29 @@ a = (
     "b"  # belongs to `b`
 )
 
+a: Literal[str] = (
+    "a"
+    "b"  # belongs to `b`
+)
+
+a += (
+    "a"
+    "b"  # belongs to `b`
+)
+
+a = (
+    r"a"
+    r"b"  # belongs to `b`
+)
+
 a = "ab"  # belongs to the assignment
 
+a = (
+    "a"
+    "b"  # belongs to `b`
+)
+
+a = "ab"  # belongs to the f-string expression
 
 a = "ab"  # belongs to the f-string expression
 
@@ -685,8 +741,7 @@ a = (
 a = "abc"  # belongs to the f-string expression
 
 logger.error(
-    f"Failed to run task {task} for job"
-    f"with id {str(job.id)}"  # type: ignore[union-attr]
+    f"Failed to run task {task} for jobwith id {str(job.id)}"  # type: ignore[union-attr]
 )
 
 a = (
@@ -697,5 +752,17 @@ a = (
 a = 10 + (
     "Exception in {call_back_name} when handling msg on "
     f"'{msg.topic}': '{msg.payload}'"  # belongs to last-part
+)
+
+self._attr_unique_id = (
+    f"{self._device.temperature.group_address_state}_"
+    f"{self._device.target_temperature.group_address_state}_"
+    f"{self._device.target_temperature.group_address}_"
+    f"{self._device._setpoint_shift.group_address}"  # noqa: SLF001
+)
+
+return (
+    f"Exception in {call_back_name} when handling msg on "
+    f"'{msg.topic}': '{msg.payload}'"  # type: ignore[str-bytes-safe]
 )
 ```


### PR DESCRIPTION
## Summary

This PR implements a fix for the implicit concatenated string formatting. Specifically for strings where the last part has a trailing end-of-line comment and they're in the value position of an assignment (including type alias) or return statement.

For example:

```py
self._attr_unique_id = (
    f"{self._device.temperature.group_address_state}_"
    f"{self._device.target_temperature.group_address_state}_"
    f"{self._device.target_temperature.group_address}_"
    f"{self._device._setpoint_shift.group_address}"  # noqa: SLF001
)
```

got reformatted to 

```py
self._attr_unique_id = (
    f"{self._device.temperature.group_address_state}_"
    f"{self._device.target_temperature.group_address_state}_"
    f"{self._device.target_temperature.group_address}_"
    f"{self._device._setpoint_shift.group_address}"
)  # noqa: SLF001
```

which is undesired because the `noqa` comment is now misplaced. It's also impossible to move it back to the right place because the formatter keeps moving it out of the parentheses. 

The reason this is happening is because we try to match Black's formatting for assignments:

```py
a = (
	"a" "b"  # comment
)

# Get's formatted to 
a = "ab"  # comment
```

Notice how the comment gets moved out. 

The relevant logic for this behavior lives here

https://github.com/astral-sh/ruff/blob/424b720c192f8603123c1a105cf12f343e45de3f/crates/ruff_python_formatter/src/statement/stmt_assign.rs#L349-L449

and `inline_comments` stores all the comments that should either be moved in or outside the parentheses. 

Ideally, we would adjust this logic (and it's counterpart in https://github.com/astral-sh/ruff/blob/424b720c192f8603123c1a105cf12f343e45de3f/crates/ruff_python_formatter/src/statement/stmt_assign.rs#L759-L908) but this is going to be fairly involved and is something I consider too risky for a bugfix release. 

That's why I decided to instead implement it in `place_comment` and associate a comment in a parenthesized f-string expression that's on the same line as the last part with said part, but only if the last part is on its own line. 

This has two downsides:

1. Ideally, we'd collapse the following but we'll no longer be able to do that with the changes from this PR:
    ```py
    a = (
        "a"
        "b" # comment
    )
    
    # could be formatted to
    a = "ab" # comment
    ```

    This used to work before and works for implicit concatenated strings outside of assignment-value positions. I think this is acceptable.
2. This is directly related to the above limitation. I made this behavior specific to implicit concatenated strings in assignment value positions or return statements. That means that the behavior is somewhat inconsistent to how we e.g. handle implicit concatenated strings embedded in another expression (you can see an example in the snapshot changes)

I'm open to changing the behavior to all implicit concatenated strings. It might be the right move, but I'm not sure. There are trade offs ;) 


Fixes https://github.com/astral-sh/ruff/issues/15375

## Test Plan

Added snapshots

The ecosystem changes look good to me. 