### PR TITLE
Remove pygments pin

### DIFF
--- a/docs/requirements-insiders.txt
+++ b/docs/requirements-insiders.txt
@@ -5,6 +5,3 @@ mkdocs-material @ git+ssh://git@github.com/astral-sh/mkdocs-material-insiders.gi
 mkdocs-redirects==1.2.2
 mdformat==0.7.21
 mdformat-mkdocs==4.1.1
-# Using a commit from pygments main branch so we get
-# https://github.com/pygments/pygments/pull/2773 before it's been released
-pygments @ git+https://github.com/pygments/pygments.git@67b460fdde6d9a00342b5102b37b3a8399f0e8ef

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,6 +5,3 @@ mkdocs-material==9.5.38
 mkdocs-redirects==1.2.2
 mdformat==0.7.21
 mdformat-mkdocs==4.1.1
-# Using a commit from pygments main branch so we get
-# https://github.com/pygments/pygments/pull/2773 before it's been released
-pygments @ git+https://github.com/pygments/pygments.git@67b460fdde6d9a00342b5102b37b3a8399f0e8ef


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

The recent release of Pygments ([2.19.1](https://github.com/pygments/pygments/releases/tag/2.19.1)) allows the pinned version to be removed as the PYI alias for Python syntax highlighting has been removed.

## Test Plan

- Follow the steps outlined in https://github.com/astral-sh/ruff/blob/main/CONTRIBUTING.md#mkdocs to get the documentation site running locally.
- Spot test rules pages that have PYI code blocks to ensure that syntax highlighting remains e.g. [http://127.0.0.1:8000/ruff/rules/complex-if-statement-in-stub/](http://127.0.0.1:8000/ruff/rules/complex-if-statement-in-stub/).

**Note:** I am unable to test the insiders build but would assume that it functions locally as I do not have access to MkDocs Insiders, but I would like to assume that it functions in the same way as the non-insiders build.
