### PR TITLE
[red-knot] Refactor `KnownFunction::takes_expression_arguments()`

### DIFF
--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -3428,35 +3428,75 @@ impl KnownFunction {
         }
     }
 
-    /// Returns a `u32` bitmask specifying whether or not
-    /// arguments given to a particular function
-    /// should be interpreted as type expressions or value expressions.
-    ///
-    /// The argument is treated as a type expression
-    /// when the corresponding bit is `1`.
-    /// The least-significant (right-most) bit corresponds to
-    /// the argument at the index 0 and so on.
-    ///
-    /// For example, `assert_type()` has the bitmask value of `0b10`.
-    /// This means the second argument is a type expression and the first a value expression.
-    const fn takes_type_expression_arguments(self) -> u32 {
-        const ALL_VALUES: u32 = 0b0;
-        const SINGLE_TYPE: u32 = 0b1;
-        const TYPE_TYPE: u32 = 0b11;
-        const VALUE_TYPE: u32 = 0b10;
-
+    /// Return the [`ParameterExpectations`] for this function.
+    const fn takes_type_expression_arguments(self) -> ParameterExpectations {
         match self {
-            KnownFunction::IsEquivalentTo => TYPE_TYPE,
-            KnownFunction::IsSubtypeOf => TYPE_TYPE,
-            KnownFunction::IsAssignableTo => TYPE_TYPE,
-            KnownFunction::IsDisjointFrom => TYPE_TYPE,
-            KnownFunction::IsFullyStatic => SINGLE_TYPE,
-            KnownFunction::IsSingleton => SINGLE_TYPE,
-            KnownFunction::IsSingleValued => SINGLE_TYPE,
-            KnownFunction::AssertType => VALUE_TYPE,
-            _ => ALL_VALUES,
+            Self::IsFullyStatic | Self::IsSingleton | Self::IsSingleValued => {
+                ParameterExpectations::SINGLE_TYPE_EXPRESSION
+            }
+
+            Self::IsEquivalentTo
+            | Self::IsSubtypeOf
+            | Self::IsAssignableTo
+            | Self::IsDisjointFrom => ParameterExpectations::TWO_TYPE_EXPRESSIONS,
+
+            Self::AssertType => ParameterExpectations::VALUE_EXPRESSION_AND_TYPE_EXPRESSION,
+
+            Self::ConstraintFunction(_)
+            | Self::Len
+            | Self::Final
+            | Self::NoTypeCheck
+            | Self::RevealType
+            | Self::StaticAssert => ParameterExpectations::AllValueExpressions,
         }
     }
+}
+
+/// Describes whether the parameters in a function expect value expressions or type expressions.
+///
+/// Whether a specific parameter in the function expects a type expression can be queried
+/// using [`ParameterExpectations::expectation_at_index`].
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Default)]
+enum ParameterExpectations {
+    /// All parameters in the function expect value expressions
+    #[default]
+    AllValueExpressions,
+    /// The function is special-cased by the type system: one or more parameters expect type expressions
+    /// rather than value expressions.
+    SpecialCased(&'static [ParameterExpectation]),
+}
+
+impl ParameterExpectations {
+    const SINGLE_TYPE_EXPRESSION: Self = Self::SpecialCased(&[ParameterExpectation::Type]);
+
+    const TWO_TYPE_EXPRESSIONS: Self =
+        Self::SpecialCased(&[ParameterExpectation::Type, ParameterExpectation::Type]);
+
+    const VALUE_EXPRESSION_AND_TYPE_EXPRESSION: Self =
+        Self::SpecialCased(&[ParameterExpectation::Value, ParameterExpectation::Type]);
+
+    /// Query whether the parameter at `parameter_index` expects a value expression or a type expression
+    fn expectation_at_index(self, parameter_index: usize) -> ParameterExpectation {
+        match self {
+            Self::AllValueExpressions => ParameterExpectation::Value,
+            Self::SpecialCased(expectations) => expectations
+                .get(parameter_index)
+                .copied()
+                .unwrap_or_default(),
+        }
+    }
+}
+
+/// Whether a single parameter in a given function expects a value expression or a [type expression]
+///
+/// [type expression]: https://typing.readthedocs.io/en/latest/spec/annotations.html#type-and-annotation-expressions
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Default)]
+enum ParameterExpectation {
+    /// The parameter expects a value expression
+    #[default]
+    Value,
+    /// The parameter expects a type expression
+    Type,
 }
 
 #[salsa::interned]

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -2609,8 +2609,8 @@ impl<'db> TypeInferenceBuilder<'db> {
             .enumerate()
             .map(|(index, arg_or_keyword)| {
                 let infer_argument_type = match parameter_expectations.expectation_at_index(index) {
-                    ParameterExpectation::Type => Self::infer_type_expression,
-                    ParameterExpectation::Value => Self::infer_expression,
+                    ParameterExpectation::TypeExpression => Self::infer_type_expression,
+                    ParameterExpectation::ValueExpression => Self::infer_expression,
                 };
 
                 match arg_or_keyword {
@@ -3155,13 +3155,13 @@ impl<'db> TypeInferenceBuilder<'db> {
 
         let function_type = self.infer_expression(func);
 
-        let infer_arguments_as_type_expressions = function_type
+        let parameter_expectations = function_type
             .into_function_literal()
             .and_then(|f| f.known(self.db()))
-            .map(KnownFunction::takes_type_expression_arguments)
+            .map(KnownFunction::parameter_expectations)
             .unwrap_or_default();
 
-        let call_arguments = self.infer_arguments(arguments, infer_arguments_as_type_expressions);
+        let call_arguments = self.infer_arguments(arguments, parameter_expectations);
         function_type
             .call(self.db(), &call_arguments)
             .unwrap_with_diagnostic(&self.context, call_expression.into())


### PR DESCRIPTION
## Summary

Refactors the `KnownFunction::takes_expression_arguments()`. By introducing a custom type rather than passing around a `u32` everywhere, we improve readability, the documentation of the code, and type safety, without introducing any allocation. 

## Test Plan

`cargo test -p red_knot_python_semantic`