### PR TITLE
Avoid cloning live declarations

### DIFF
--- a/crates/red_knot_python_semantic/src/semantic_index/use_def/symbol_state.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/use_def/symbol_state.rs
@@ -310,7 +310,7 @@ impl SymbolState {
                 visibility_constraints: VisibilityConstraintPerBinding::default(),
             },
             declarations: SymbolDeclarations {
-                live_declarations: self.declarations.live_declarations.clone(),
+                live_declarations: Declarations::default(),
                 visibility_constraints: VisibilityConstraintPerDeclaration::default(),
             },
         };


### PR DESCRIPTION
## Summary

I don't know what I'm doing but all tests still pass ;)

The declarations get merged below so maybe this is no longer needed?

## Test Plan

`cargo test`
