### PR TITLE
Display context for `ruff.configuration` errors

### DIFF
--- a/crates/ruff_server/src/session/index/ruff_settings.rs
+++ b/crates/ruff_server/src/session/index/ruff_settings.rs
@@ -386,8 +386,12 @@ impl ConfigurationTransformer for EditorConfigurationTransformer<'_> {
             );
             match open_configuration_file(&config_file_path) {
                 Ok(config_from_file) => editor_configuration.combine(config_from_file),
-                Err(err) => {
-                    tracing::error!("Unable to find editor-specified configuration file: {err}");
+                err => {
+                    tracing::error!(
+                        "{:?}",
+                        err.context("Unable to load editor-specified configuration file")
+                            .unwrap_err()
+                    );
                     editor_configuration
                 }
             }


### PR DESCRIPTION
## Summary

I noticed this while trying out https://github.com/astral-sh/ruff-vscode/issues/665 that we use the `Display` implementation to show the error which hides the context. This PR changes it to use the `Debug` implementation and adds the message as a context.

## Test Plan

**Before:**

```
   0.001228084s ERROR main ruff_server::session::index::ruff_settings: Unable to find editor-specified configuration file: Failed to parse /private/tmp/hatch-test/ruff.toml
```

**After:**

```
   0.002348750s ERROR main ruff_server::session::index::ruff_settings: Unable to load editor-specified configuration file

Caused by:
    0: Failed to parse /private/tmp/hatch-test/ruff.toml
    1: TOML parse error at line 2, column 18
         |
       2 | extend-select = ["ASYNC101"]
         |                  ^^^^^^^^^^
       Unknown rule selector: `ASYNC101`
```
