### PR TITLE
Change `ProgramSettings::python_platform` to return a reference

### DIFF
--- a/crates/red_knot_python_semantic/src/program.rs
+++ b/crates/red_knot_python_semantic/src/program.rs
@@ -13,6 +13,7 @@ use crate::Db;
 pub struct Program {
     pub python_version: PythonVersion,
 
+    #[return_ref]
     pub python_platform: PythonPlatform,
 
     #[return_ref]


### PR DESCRIPTION
## Summary


`PythonPlatform` is now clone, we should return a reference instead of cloning it everytime the field is read.

## Test Plan

`cargo test`
