### PR TITLE
[`flake8-pytest-style`] Tweak documentation and message

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_pytest_style/rules/raises.rs
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/rules/raises.rs
@@ -16,8 +16,9 @@ use super::helpers::is_empty_or_null_string;
 /// ## Why is this bad?
 /// When a `pytest.raises` is used as a context manager and contains multiple
 /// statements, it can lead to the test passing when it actually should fail.
-/// To avoid this, a `pytest.raises` context manager should only contain
-/// a single simple statement that raises the expected exception.
+///
+/// A `pytest.raises` context manager should only contain a single simple
+/// statement that raises the expected exception.
 ///
 /// ## Example
 /// ```python
@@ -147,7 +148,7 @@ pub(crate) struct PytestRaisesWithoutException;
 impl Violation for PytestRaisesWithoutException {
     #[derive_message_formats]
     fn message(&self) -> String {
-        "set the expected exception in `pytest.raises()`".to_string()
+        "Set the expected exception in `pytest.raises()`".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/rules/warns.rs
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/rules/warns.rs
@@ -25,11 +25,10 @@ use super::helpers::is_empty_or_null_string;
 /// import pytest
 ///
 ///
-/// def test_foo():
-///     with pytest.warns(MyWarning):
-///         setup()
-///         func_to_test()  # not executed if `setup()` triggers `MyWarning`
-///         assert foo()  # not executed
+/// def test_foo_warns():
+///     with pytest.warns(Warning):
+///         setup()  # False negative if setup triggers a warning but foo does not.
+///         foo()
 /// ```
 ///
 /// Use instead:
@@ -37,11 +36,10 @@ use super::helpers::is_empty_or_null_string;
 /// import pytest
 ///
 ///
-/// def test_foo():
+/// def test_foo_warns():
 ///     setup()
-///     with pytest.warning(MyWarning):
-///         func_to_test()
-///     assert foo()
+///     with pytest.warning(Warning):
+///         foo()
 /// ```
 ///
 /// ## References

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/snapshots/ruff_linter__rules__flake8_pytest_style__tests__PT010.snap
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/snapshots/ruff_linter__rules__flake8_pytest_style__tests__PT010.snap
@@ -2,7 +2,7 @@
 source: crates/ruff_linter/src/rules/flake8_pytest_style/mod.rs
 snapshot_kind: text
 ---
-PT010.py:5:10: PT010 set the expected exception in `pytest.raises()`
+PT010.py:5:10: PT010 Set the expected exception in `pytest.raises()`
   |
 4 | def test_ok():
 5 |     with pytest.raises():


### PR DESCRIPTION
## Summary

Makes tweaks suggested in #15444. Also replicates small tweaks made in review in corollary a `pytest.raises` rule.

## Test Plan

`cargo nextest run`
