### PR TITLE
Fix curly bracket spacing around curly f-string expressions

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/fstring.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/fstring.py
@@ -710,3 +710,11 @@ f'{x:a{y=:{z:hy "user"}}} \'\'\''
 f"""{1=: "this" is fine}"""
 f'''{1=: "this" is fine}'''  # Change quotes to double quotes because they're preferred
 f'{1=: {'ab"cd"'}}'  # It's okay if the quotes are in an expression part.
+
+
+# Regression tests for https://github.com/astral-sh/ruff/issues/15459
+print(f"{ {1, 2, 3} - {2} }")
+print(f"{ {1: 2}.keys() }")
+print(f"{({1, 2, 3}) - ({2})}")
+print(f"{1, 2, {3} }")
+print(f"{(1, 2, {3})}")

--- a/crates/ruff_python_formatter/src/other/f_string_element.rs
+++ b/crates/ruff_python_formatter/src/other/f_string_element.rs
@@ -9,6 +9,7 @@ use ruff_text_size::{Ranged, TextSlice};
 
 use crate::comments::{dangling_open_parenthesis_comments, trailing_comments};
 use crate::context::{FStringState, NodeLevel, WithFStringState, WithNodeLevel};
+use crate::expression::{left_most, right_most};
 use crate::prelude::*;
 use crate::string::normalize_string;
 use crate::verbatim::verbatim_text;
@@ -190,32 +191,37 @@ impl Format<PyFormatContext<'_>> for FormatFStringExpressionElement<'_> {
             let comments = f.context().comments().clone();
             let dangling_item_comments = comments.dangling(self.element);
 
-            let item = format_with(|f| {
-                let bracket_spacing = match expression.as_ref() {
-                    // If an expression starts with a `{`, we need to add a space before the
-                    // curly brace to avoid turning it into a literal curly with `{{`.
-                    //
-                    // For example,
-                    // ```python
-                    // f"{ {'x': 1, 'y': 2} }"
-                    // #  ^                ^
-                    // ```
-                    //
-                    // We need to preserve the space highlighted by `^`. The whitespace
-                    // before the closing curly brace is not strictly necessary, but it's
-                    // added to maintain consistency.
-                    Expr::Dict(_) | Expr::DictComp(_) | Expr::Set(_) | Expr::SetComp(_) => {
-                        Some(format_with(|f| {
-                            if self.context.can_contain_line_breaks() {
-                                soft_line_break_or_space().fmt(f)
-                            } else {
-                                space().fmt(f)
-                            }
-                        }))
+            // If an expression starts with a `{`, we need to add a space before the
+            // curly brace to avoid turning it into a literal curly with `{{`.
+            //
+            // For example,
+            // ```python
+            // f"{ {'x': 1, 'y': 2} }"
+            // #  ^                ^
+            // ```
+            //
+            // We need to preserve the space highlighted by `^`. The whitespace
+            // before the closing curly brace is not strictly necessary, but it's
+            // added to maintain consistency.
+            let bracket_spacing = if has_curly_parentheses(left_most(
+                expression,
+                comments.ranges(),
+                f.context().source(),
+            )) || has_curly_parentheses(right_most(
+                expression,
+                comments.ranges(),
+                f.context().source(),
+            )) {
+                Some(format_with(|f| {
+                    if self.context.can_contain_line_breaks() {
+                        soft_line_break_or_space().fmt(f)
+                    } else {
+                        space().fmt(f)
                     }
                     _ => None,
                 };
 
+            let item = format_with(|f: &mut PyFormatter| {
                 // Update the context to be inside the f-string expression element.
                 let f = &mut WithFStringState::new(
                     FStringState::InsideExpressionElement(self.context),

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__fstring.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__fstring.py.snap
@@ -1504,7 +1504,7 @@ f'{1=: {'ab"cd"'}}'  # It's okay if the quotes are in an expression part.
 print(f"{ {1, 2, 3} - {2} }")
 print(f"{ {1: 2}.keys() }")
 print(f"{({1, 2, 3}) - ({2})}")
-print(f"{ 1, 2, {3} }")
+print(f"{1, 2, {3}}")
 print(f"{(1, 2, {3})}")
 ```
 
@@ -2286,6 +2286,6 @@ f'{1=: {'ab"cd"'}}'  # It's okay if the quotes are in an expression part.
 print(f"{ {1, 2, 3} - {2} }")
 print(f"{ {1: 2}.keys() }")
 print(f"{({1, 2, 3}) - ({2})}")
-print(f"{ 1, 2, {3} }")
+print(f"{1, 2, {3}}")
 print(f"{(1, 2, {3})}")
 ```

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__fstring.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__fstring.py.snap
@@ -716,6 +716,14 @@ f'{x:a{y=:{z:hy "user"}}} \'\'\''
 f"""{1=: "this" is fine}"""
 f'''{1=: "this" is fine}'''  # Change quotes to double quotes because they're preferred
 f'{1=: {'ab"cd"'}}'  # It's okay if the quotes are in an expression part.
+
+
+# Regression tests for https://github.com/astral-sh/ruff/issues/15459
+print(f"{ {1, 2, 3} - {2} }")
+print(f"{ {1: 2}.keys() }")
+print(f"{({1, 2, 3}) - ({2})}")
+print(f"{1, 2, {3} }")
+print(f"{(1, 2, {3})}")
 ```
 
 ## Outputs
@@ -1490,6 +1498,14 @@ f'{x:a{y=:{z:hy "user"}}} \'\'\''
 f"""{1=: "this" is fine}"""
 f"""{1=: "this" is fine}"""  # Change quotes to double quotes because they're preferred
 f'{1=: {'ab"cd"'}}'  # It's okay if the quotes are in an expression part.
+
+
+# Regression tests for https://github.com/astral-sh/ruff/issues/15459
+print(f"{ {1, 2, 3} - {2} }")
+print(f"{ {1: 2}.keys() }")
+print(f"{({1, 2, 3}) - ({2})}")
+print(f"{ 1, 2, {3} }")
+print(f"{(1, 2, {3})}")
 ```
 
 
@@ -2264,4 +2280,12 @@ f'{x:a{y=:{z:hy "user"}}} \'\'\''
 f"""{1=: "this" is fine}"""
 f"""{1=: "this" is fine}"""  # Change quotes to double quotes because they're preferred
 f'{1=: {'ab"cd"'}}'  # It's okay if the quotes are in an expression part.
+
+
+# Regression tests for https://github.com/astral-sh/ruff/issues/15459
+print(f"{ {1, 2, 3} - {2} }")
+print(f"{ {1: 2}.keys() }")
+print(f"{({1, 2, 3}) - ({2})}")
+print(f"{ 1, 2, {3} }")
+print(f"{(1, 2, {3})}")
 ```


### PR DESCRIPTION
## Summary

Fixes https://github.com/astral-sh/ruff/issues/15459

F-string expression need to leave one space between the element's `{` or `}` and any curly braces inside the expression itself or it results in invalid syntax:

```python
f"{ {1, 2, 3} }"  # valid
f"{{ 1, 2, 3}}"  # invalid
```

The existing implementation handles this correctly if the expression itself has curly braces, but it doesn't add the necessary space if the expression starts or ends with an expression with curly parentheses:

```python
-print(f"{ {1, 2, 3} - {2} }")
-print(f"{ {1: 2}.keys() }")
+print(f"{{1, 2, 3} - {2}}")
+print(f"{{1: 2}.keys()}")
```

This PR changes the formatter to check if the left-most sub expression (if any) starts with curly parentheses instead of just checking the expression itself.

## Test Plan

Added snapshot tests.
