### PR TITLE
[red-knot] Corrections and improvements to intersection simplification

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/intersection_types.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/intersection_types.md
@@ -671,6 +671,32 @@ def f(
     reveal_type(h)  # revealed: Never
 ```
 
+## Simplification of `LiteralString`, `AlwaysTruthy` and `AlwaysFalsy`
+
+Similarly, intersections between `LiteralString`, `AlwaysTruthy` and `AlwaysFalsy` can be
+simplified, due to the fact that a `LiteralString` inhabitant is known to have `__class__` set to
+exactly `str` (and not a subclass of `str`):
+
+```py
+from knot_extensions import Intersection, Not, AlwaysTruthy, AlwaysFalsy
+from typing_extensions import LiteralString
+
+def f(
+    a: Intersection[LiteralString, AlwaysTruthy],
+    b: Intersection[LiteralString, AlwaysFalsy],
+    c: Intersection[LiteralString, Not[AlwaysTruthy]],
+    d: Intersection[LiteralString, Not[AlwaysFalsy]],
+    e: Intersection[AlwaysFalsy, LiteralString],
+    f: Intersection[Not[AlwaysTruthy], LiteralString],
+):
+    reveal_type(a)  # revealed: LiteralString & ~Literal[""]
+    reveal_type(b)  # revealed: Literal[""]
+    reveal_type(c)  # revealed: Literal[""]
+    reveal_type(d)  # revealed: LiteralString & ~Literal[""]
+    reveal_type(e)  # revealed: Literal[""]
+    reveal_type(f)  # revealed: Literal[""]
+```
+
 ## Non fully-static types
 
 ### Negation of dynamic types

--- a/crates/red_knot_python_semantic/resources/mdtest/narrow/isinstance.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/narrow/isinstance.md
@@ -197,13 +197,25 @@ def f(
 ):
     if isinstance(a, bool):
         reveal_type(a)  # revealed: Never
+    else:
+        # TODO: `bool` is final, so `& ~bool` is redundant here
+        reveal_type(a)  # revealed: str & AlwaysTruthy & ~bool
 
     if isinstance(b, bool):
         reveal_type(b)  # revealed: Never
+    else:
+        # TODO: `bool` is final, so `& ~bool` is redundant here
+        reveal_type(b)  # revealed: str & AlwaysFalsy & ~bool
 
     if isinstance(c, bool):
         reveal_type(c)  # revealed: Never
+    else:
+        # TODO: `bool` is final, so `& ~bool` is redundant here
+        reveal_type(c)  # revealed: str & ~AlwaysTruthy & ~bool
 
     if isinstance(d, bool):
         reveal_type(d)  # revealed: Never
+    else:
+        # TODO: `bool` is final, so `& ~bool` is redundant here
+        reveal_type(d)  # revealed: str & ~AlwaysFalsy & ~bool
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/narrow/isinstance.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/narrow/isinstance.md
@@ -181,3 +181,29 @@ def _(x: object, y: type[int]):
     if isinstance(x, y):
         reveal_type(x)  # revealed: int
 ```
+
+## Adding a disjoint element to an existing intersection
+
+We used to incorrectly infer `Literal` booleans for some of these.
+
+```py
+from knot_extensions import Not, Intersection, AlwaysTruthy, AlwaysFalsy
+
+def f(
+    a: Intersection[str, AlwaysTruthy],
+    b: Intersection[str, AlwaysFalsy],
+    c: Intersection[str, Not[AlwaysTruthy]],
+    d: Intersection[str, Not[AlwaysFalsy]],
+):
+    if isinstance(a, bool):
+        reveal_type(a)  # revealed: Never
+
+    if isinstance(b, bool):
+        reveal_type(b)  # revealed: Never
+
+    if isinstance(c, bool):
+        reveal_type(c)  # revealed: Never
+
+    if isinstance(d, bool):
+        reveal_type(d)  # revealed: Never
+```

--- a/crates/red_knot_python_semantic/resources/mdtest/narrow/truthiness.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/narrow/truthiness.md
@@ -199,7 +199,7 @@ def f(x: Literal[0, 1], y: Literal["", "hello"]):
         reveal_type(y)  # revealed: Literal["", "hello"]
 ```
 
-## ControlFlow Merging
+## Control Flow Merging
 
 After merging control flows, when we take the union of all constraints applied in each branch, we
 should return to the original state.

--- a/crates/red_knot_python_semantic/resources/mdtest/narrow/truthiness.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/narrow/truthiness.md
@@ -312,3 +312,20 @@ def _(x: type[FalsyClass] | type[TruthyClass]):
     reveal_type(x or A())  # revealed: type[TruthyClass] | A
     reveal_type(x and A())  # revealed: type[FalsyClass] | A
 ```
+
+## Truthiness narrowing for `LiteralString`
+
+```py
+from typing_extensions import LiteralString
+
+def _(x: LiteralString):
+    if x:
+        reveal_type(x)  # revealed: LiteralString & ~Literal[""]
+    else:
+        reveal_type(x)  # revealed: Literal[""]
+
+    if not x:
+        reveal_type(x)  # revealed: Literal[""]
+    else:
+        reveal_type(x)  # revealed: LiteralString & ~Literal[""]
+```

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -671,6 +671,13 @@ impl<'db> Type<'db> {
             .expect("Expected a Type::IntLiteral variant")
     }
 
+    pub const fn into_instance(self) -> Option<InstanceType<'db>> {
+        match self {
+            Type::Instance(instance_type) => Some(instance_type),
+            _ => None,
+        }
+    }
+
     pub const fn into_known_instance(self) -> Option<KnownInstanceType<'db>> {
         match self {
             Type::KnownInstance(known_instance) => Some(known_instance),
@@ -2557,6 +2564,10 @@ pub enum KnownClass {
 }
 
 impl<'db> KnownClass {
+    pub const fn is_bool(self) -> bool {
+        matches!(self, Self::Bool)
+    }
+
     pub const fn as_str(&self) -> &'static str {
         match self {
             Self::Bool => "bool",


### PR DESCRIPTION
## Summary

I noticed that we were incorrectly oversimplifying certain intersections, for example:

```py
from knot_extensions import Intersection, Not, AlwaysTruthy

def g(
    x: Intersection[str, Not[AlwaysTruthy]]
):
    if isinstance(x, bool):
        reveal_type(x)  # revealed: Literal[False]
```

Here, `bool & ~AlwaysTruthy` can indeed be simplified to `Literal[False]`, and therefore `str & ~AlwaysTruthy & bool` can be simplified to `str & Literal[False]`, which then simplifies further to `Never` since `str` and `Literal[False]` are disjoint. But that's not what we're doing in the example above: instead, we're attempting to simplify `str` out of the intersection as part of the initial simplification, which then means that we never realise further along in the intersection simplification algorithm that the entire intersection simplifies to `Never`.

This PR fixes the bug, and also adds some more simplifications for intersections that we weren't doing previously:

- `bool & AlwaysTruthy` -> `Literal[True]`
- `bool & AlwaysFalsy` -> `Literal[False]`
- `LiteralString & AlwaysTruthy` -> `LiteralString & ~Literal[""]`
- `LiteralString & AlwaysFalsy` -> `Literal[""]`

This furthers our aim of having equivalent types use identical internal representations wherever it's feasible to do so.

## Test Plan

- `cargo test -p red_knot_python_semantic --test mdtest`
- `uvx pre-commit run -a`
