### PR TITLE
[`unconventional-import-alias`] Fix infinite loop between ICN001 and I002 (`ICN001`)

### DIFF
--- a/crates/ruff/tests/lint.rs
+++ b/crates/ruff/tests/lint.rs
@@ -2160,3 +2160,30 @@ fn flake8_import_convention_invalid_aliases_config_module_name() -> Result<()> {
         "#);});
     Ok(())
 }
+
+#[test]
+fn flake8_import_convention_unused_aliased_import() -> Result<()> {
+    let tempdir = TempDir::new()?;
+    let ruff_toml = tempdir.path().join("ruff.toml");
+    fs::write(
+        &ruff_toml,
+        r#"lint.isort.required-imports = ["import pandas"]"#,
+    )?;
+
+    insta::with_settings!({
+        filters => vec![(tempdir_filter(&tempdir).as_str(), "[TMP]/")]
+    }, {
+        assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
+            .args(STDIN_BASE_OPTIONS)
+            .arg("--config")
+            .arg(&ruff_toml)
+            .args(["--select", "I002,ICN001,F401"])
+            .args(["--stdin-filename", "test.py"])
+            .arg("--unsafe-fixes")
+            .arg("--fix")
+            .arg("-")
+            .pass_stdin("1")
+        );
+    });
+    Ok(())
+}

--- a/crates/ruff/tests/lint.rs
+++ b/crates/ruff/tests/lint.rs
@@ -2162,28 +2162,15 @@ fn flake8_import_convention_invalid_aliases_config_module_name() -> Result<()> {
 }
 
 #[test]
-fn flake8_import_convention_unused_aliased_import() -> Result<()> {
-    let tempdir = TempDir::new()?;
-    let ruff_toml = tempdir.path().join("ruff.toml");
-    fs::write(
-        &ruff_toml,
-        r#"lint.isort.required-imports = ["import pandas"]"#,
-    )?;
-
-    insta::with_settings!({
-        filters => vec![(tempdir_filter(&tempdir).as_str(), "[TMP]/")]
-    }, {
-        assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
-            .args(STDIN_BASE_OPTIONS)
-            .arg("--config")
-            .arg(&ruff_toml)
-            .args(["--select", "I002,ICN001,F401"])
-            .args(["--stdin-filename", "test.py"])
-            .arg("--unsafe-fixes")
-            .arg("--fix")
-            .arg("-")
-            .pass_stdin("1")
-        );
-    });
-    Ok(())
+fn flake8_import_convention_unused_aliased_import() {
+    assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
+        .args(STDIN_BASE_OPTIONS)
+        .arg("--config")
+        .arg(r#"lint.isort.required-imports = ["import pandas"]"#)
+        .args(["--select", "I002,ICN001,F401"])
+        .args(["--stdin-filename", "test.py"])
+        .arg("--unsafe-fixes")
+        .arg("--fix")
+        .arg("-")
+        .pass_stdin("1"));
 }

--- a/crates/ruff/tests/snapshots/lint__flake8_import_convention_unused_aliased_import.snap
+++ b/crates/ruff/tests/snapshots/lint__flake8_import_convention_unused_aliased_import.snap
@@ -25,7 +25,7 @@ exit_code: 2
 
 ----- stderr -----
 ruff failed
-  Cause: Required import specified in `lint.isort.required-imports` (I002) conflicts with the required import alias specified in either `lint.flake8-import-conventions.aliases` or `lint.flake8-import-conventions.extend-aliases`(ICN001):
-    - pandas -> pd
+  Cause: Required import specified in `lint.isort.required-imports` (I002) conflicts with the required import alias specified in either `lint.flake8-import-conventions.aliases` or `lint.flake8-import-conventions.extend-aliases` (ICN001):
+    - `pandas` -> `pd`
 
 Help: Remove the required import or alias from your configuration.

--- a/crates/ruff/tests/snapshots/lint__flake8_import_convention_unused_aliased_import.snap
+++ b/crates/ruff/tests/snapshots/lint__flake8_import_convention_unused_aliased_import.snap
@@ -25,5 +25,7 @@ exit_code: 2
 
 ----- stderr -----
 ruff failed
-  Cause: isort required import (I002) conflicts with unconventional import alias (ICN001):
+  Cause: Required import specified in `lint.isort.required-imports` (I002) conflicts with the required import alias specified in either `lint.flake8-import-conventions.aliases` or `lint.flake8-import-conventions.extend-aliases`(ICN001):
     - pandas -> pd
+
+Help: Remove the required import or alias from your configuration.

--- a/crates/ruff/tests/snapshots/lint__flake8_import_convention_unused_aliased_import.snap
+++ b/crates/ruff/tests/snapshots/lint__flake8_import_convention_unused_aliased_import.snap
@@ -1,0 +1,30 @@
+---
+source: crates/ruff/tests/lint.rs
+info:
+  program: ruff
+  args:
+    - check
+    - "--no-cache"
+    - "--output-format"
+    - concise
+    - "--config"
+    - /tmp/.tmpW5pnSS/ruff.toml
+    - "--select"
+    - "I002,ICN001,F401"
+    - "--stdin-filename"
+    - test.py
+    - "--unsafe-fixes"
+    - "--fix"
+    - "-"
+  stdin: "1"
+snapshot_kind: text
+---
+success: false
+exit_code: 1
+----- stdout -----
+import pandas
+1
+----- stderr -----
+warning: (ICN001) requested alias (`pd`) for `pandas` conflicts with isort required import: `import pandas`
+test.py:1:8: ICN001 `pandas` should be imported as `pd`
+Found 2 errors (1 fixed, 1 remaining).

--- a/crates/ruff/tests/snapshots/lint__flake8_import_convention_unused_aliased_import.snap
+++ b/crates/ruff/tests/snapshots/lint__flake8_import_convention_unused_aliased_import.snap
@@ -20,11 +20,10 @@ info:
 snapshot_kind: text
 ---
 success: false
-exit_code: 1
+exit_code: 2
 ----- stdout -----
-import pandas
-1
+
 ----- stderr -----
-warning: (ICN001) requested alias (`pd`) for `pandas` conflicts with isort required import: `import pandas`
-test.py:1:8: ICN001 `pandas` should be imported as `pd`
-Found 2 errors (1 fixed, 1 remaining).
+ruff failed
+  Cause: isort required import (I002) conflicts with unconventional import alias (ICN001):
+    - pandas -> pd

--- a/crates/ruff/tests/snapshots/lint__flake8_import_convention_unused_aliased_import.snap
+++ b/crates/ruff/tests/snapshots/lint__flake8_import_convention_unused_aliased_import.snap
@@ -8,7 +8,7 @@ info:
     - "--output-format"
     - concise
     - "--config"
-    - /tmp/.tmpW5pnSS/ruff.toml
+    - "lint.isort.required-imports = [\"import pandas\"]"
     - "--select"
     - "I002,ICN001,F401"
     - "--stdin-filename"

--- a/crates/ruff_linter/src/rules/flake8_import_conventions/rules/unconventional_import_alias.rs
+++ b/crates/ruff_linter/src/rules/flake8_import_conventions/rules/unconventional_import_alias.rs
@@ -8,7 +8,6 @@ use ruff_text_size::Ranged;
 use crate::checkers::ast::Checker;
 
 use crate::renamer::Renamer;
-use crate::warn_user_once_by_message;
 
 /// ## What it does
 /// Checks for imports that are typically imported using a common convention,
@@ -73,27 +72,11 @@ pub(crate) fn unconventional_import_alias(
 
     let mut diagnostic = Diagnostic::new(
         UnconventionalImportAlias {
-            name: qualified_name.clone(),
+            name: qualified_name,
             asname: expected_alias.to_string(),
         },
         binding.range(),
     );
-
-    if let Some(required_import) = checker
-        .settings
-        .isort
-        .required_imports
-        .iter()
-        .find(|name| name.matches(&qualified_name, &import))
-    {
-        warn_user_once_by_message!(
-            "(ICN001) requested alias (`{expected_alias}`) for \
-            `{qualified_name}` conflicts with isort required import: \
-            `{required_import}`"
-        );
-        return Some(diagnostic);
-    }
-
     if !import.is_submodule_import() {
         if checker.semantic().is_available(expected_alias) {
             diagnostic.try_set_fix(|| {

--- a/crates/ruff_python_semantic/src/imports.rs
+++ b/crates/ruff_python_semantic/src/imports.rs
@@ -57,7 +57,7 @@ impl NameImport {
     }
 
     /// Returns the [`QualifiedName`] of the imported name (e.g., given `from foo import bar as baz`, returns `["foo", "bar"]`).
-    fn qualified_name(&self) -> QualifiedName {
+    pub fn qualified_name(&self) -> QualifiedName {
         match self {
             NameImport::Import(import) => QualifiedName::user_defined(&import.name.name),
             NameImport::ImportFrom(import_from) => collect_import_from_member(

--- a/crates/ruff_workspace/src/configuration.rs
+++ b/crates/ruff_workspace/src/configuration.rs
@@ -1571,7 +1571,7 @@ fn conflicting_import_settings(
     for required_import in &isort.required_imports {
         let name = required_import.qualified_name().to_string();
         if let Some(alias) = flake8_import_conventions.aliases.get(&name) {
-            writeln!(err_body, "    - {name} -> {alias}").unwrap();
+            writeln!(err_body, "    - `{name}` -> `{alias}`").unwrap();
         }
     }
 

--- a/crates/ruff_workspace/src/configuration.rs
+++ b/crates/ruff_workspace/src/configuration.rs
@@ -1577,8 +1577,12 @@ fn conflicting_import_settings(
 
     if !err_body.is_empty() {
         return Err(anyhow!(
-            "isort required import (I002) conflicts with unconventional import alias (ICN001):\
-                \n{err_body}"
+            "Required import specified in `lint.isort.required-imports` (I002) \
+            conflicts with the required import alias specified in either \
+            `lint.flake8-import-conventions.aliases` or \
+            `lint.flake8-import-conventions.extend-aliases`(ICN001):\
+                \n{err_body}\n\
+            Help: Remove the required import or alias from your configuration."
         ));
     }
 

--- a/crates/ruff_workspace/src/configuration.rs
+++ b/crates/ruff_workspace/src/configuration.rs
@@ -1580,7 +1580,7 @@ fn conflicting_import_settings(
             "Required import specified in `lint.isort.required-imports` (I002) \
             conflicts with the required import alias specified in either \
             `lint.flake8-import-conventions.aliases` or \
-            `lint.flake8-import-conventions.extend-aliases`(ICN001):\
+            `lint.flake8-import-conventions.extend-aliases` (ICN001):\
                 \n{err_body}\n\
             Help: Remove the required import or alias from your configuration."
         ));


### PR DESCRIPTION
## Summary

This fixes the infinite loop reported in #14389 by raising an error to the user about conflicting ICN001 (`unconventional-import-alias`) and I002 (`missing-required-import`) configuration options.

## Test Plan

Added a CLI integration test reproducing the old behavior and then confirming the fix.

Closes #14389 