### PR TITLE
Use tool specific function to perform exclude checks

### DIFF
--- a/crates/ruff_server/src/fix.rs
+++ b/crates/ruff_server/src/fix.rs
@@ -4,7 +4,7 @@ use rustc_hash::FxHashMap;
 
 use crate::{
     edit::{Replacement, ToRangeExt},
-    resolve::is_document_excluded,
+    resolve::is_document_excluded_for_linting,
     session::DocumentQuery,
     PositionEncoding,
 };
@@ -33,11 +33,10 @@ pub(crate) fn fix_all(
 
     // If the document is excluded, return an empty list of fixes.
     let package = if let Some(document_path) = document_path.as_ref() {
-        if is_document_excluded(
+        if is_document_excluded_for_linting(
             document_path,
             file_resolver_settings,
-            Some(linter_settings),
-            None,
+            linter_settings,
             query.text_document_language_id(),
         ) {
             return Ok(Fixes::default());

--- a/crates/ruff_server/src/lint.rs
+++ b/crates/ruff_server/src/lint.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     edit::{NotebookRange, ToRangeExt},
-    resolve::is_document_excluded,
+    resolve::is_document_excluded_for_linting,
     session::DocumentQuery,
     PositionEncoding, DIAGNOSTIC_NAME,
 };
@@ -73,11 +73,10 @@ pub(crate) fn check(
 
     // If the document is excluded, return an empty list of diagnostics.
     let package = if let Some(document_path) = document_path.as_ref() {
-        if is_document_excluded(
+        if is_document_excluded_for_linting(
             document_path,
             file_resolver_settings,
-            Some(linter_settings),
-            None,
+            linter_settings,
             query.text_document_language_id(),
         ) {
             return DiagnosticsMap::default();

--- a/crates/ruff_server/src/resolve.rs
+++ b/crates/ruff_server/src/resolve.rs
@@ -6,6 +6,38 @@ use ruff_workspace::{FileResolverSettings, FormatterSettings};
 
 use crate::edit::LanguageId;
 
+/// Return `true` if the document at the given [`Path`] should be excluded from linting.
+pub(crate) fn is_document_excluded_for_linting(
+    path: &Path,
+    resolver_settings: &FileResolverSettings,
+    linter_settings: &LinterSettings,
+    language_id: Option<LanguageId>,
+) -> bool {
+    is_document_excluded(
+        path,
+        resolver_settings,
+        Some(linter_settings),
+        None,
+        language_id,
+    )
+}
+
+/// Return `true` if the document at the given [`Path`] should be excluded from formatting.
+pub(crate) fn is_document_excluded_for_formatting(
+    path: &Path,
+    resolver_settings: &FileResolverSettings,
+    formatter_settings: &FormatterSettings,
+    language_id: Option<LanguageId>,
+) -> bool {
+    is_document_excluded(
+        path,
+        resolver_settings,
+        None,
+        Some(formatter_settings),
+        language_id,
+    )
+}
+
 /// Return `true` if the document at the given [`Path`] should be excluded.
 ///
 /// The tool-specific settings should be provided if the request for the document is specific to
@@ -16,7 +48,9 @@ use crate::edit::LanguageId;
 /// 1. Check for global `exclude` and `extend-exclude` options along with tool specific `exclude`
 ///    option (`lint.exclude`, `format.exclude`).
 /// 2. Check for global `include` and `extend-include` options.
-pub(crate) fn is_document_excluded(
+/// 3. Check if the language ID is Python, in which case the document is included.
+/// 4. If none of the above conditions are met, the document is excluded.
+fn is_document_excluded(
     path: &Path,
     resolver_settings: &FileResolverSettings,
     linter_settings: Option<&LinterSettings>,

--- a/crates/ruff_server/src/server/api/requests/format.rs
+++ b/crates/ruff_server/src/server/api/requests/format.rs
@@ -6,7 +6,7 @@ use ruff_source_file::LineIndex;
 
 use crate::edit::{Replacement, ToRangeExt};
 use crate::fix::Fixes;
-use crate::resolve::is_document_excluded;
+use crate::resolve::is_document_excluded_for_formatting;
 use crate::server::api::LSPResult;
 use crate::server::{client::Notifier, Result};
 use crate::session::{DocumentQuery, DocumentSnapshot};
@@ -87,11 +87,10 @@ fn format_text_document(
 
     // If the document is excluded, return early.
     if let Some(file_path) = query.file_path() {
-        if is_document_excluded(
+        if is_document_excluded_for_formatting(
             &file_path,
             file_resolver_settings,
-            None,
-            Some(formatter_settings),
+            formatter_settings,
             text_document.language_id(),
         ) {
             return Ok(None);

--- a/crates/ruff_server/src/server/api/requests/format_range.rs
+++ b/crates/ruff_server/src/server/api/requests/format_range.rs
@@ -2,7 +2,7 @@ use anyhow::Context;
 use lsp_types::{self as types, request as req, Range};
 
 use crate::edit::{RangeExt, ToRangeExt};
-use crate::resolve::is_document_excluded;
+use crate::resolve::is_document_excluded_for_formatting;
 use crate::server::api::LSPResult;
 use crate::server::{client::Notifier, Result};
 use crate::session::{DocumentQuery, DocumentSnapshot};
@@ -51,11 +51,10 @@ fn format_text_document_range(
 
     // If the document is excluded, return early.
     if let Some(file_path) = query.file_path() {
-        if is_document_excluded(
+        if is_document_excluded_for_formatting(
             &file_path,
             file_resolver_settings,
-            None,
-            Some(formatter_settings),
+            formatter_settings,
             text_document.language_id(),
         ) {
             return Ok(None);


### PR DESCRIPTION
## Summary

This PR creates separate functions to check whether the document path is excluded for linting or formatting. The main motivation is to avoid the double `Option` for the call sites and makes passing the correct settings simpler.
