### PR TITLE
Fix LSP show message macro to allow format args

### DIFF
--- a/crates/red_knot_server/src/message.rs
+++ b/crates/red_knot_server/src/message.rs
@@ -40,7 +40,7 @@ pub(super) fn try_show_message(
 /// Sends an error to the client with a formatted message. The error is sent in a
 /// `window/showMessage` notification.
 macro_rules! show_err_msg {
-    ($msg:expr$(, $($arg:tt),*)?) => {
-        crate::message::show_message(::core::format_args!($msg, $($($arg),*)?).to_string(), lsp_types::MessageType::ERROR)
+    ($msg:expr$(, $($arg:tt)*)?) => {
+        crate::message::show_message(::core::format_args!($msg$(, $($arg)*)?).to_string(), lsp_types::MessageType::ERROR)
     };
 }

--- a/crates/ruff_server/src/message.rs
+++ b/crates/ruff_server/src/message.rs
@@ -40,15 +40,15 @@ pub(super) fn try_show_message(
 /// Sends a request to display an error to the client with a formatted message. The error is sent
 /// in a `window/showMessage` notification.
 macro_rules! show_err_msg {
-    ($msg:expr$(, $($arg:tt),*)?) => {
-        crate::message::show_message(::core::format_args!($msg, $($($arg),*)?).to_string(), lsp_types::MessageType::ERROR)
+    ($msg:expr$(, $($arg:tt)*)?) => {
+        crate::message::show_message(::core::format_args!($msg$(, $($arg)*)?).to_string(), lsp_types::MessageType::ERROR)
     };
 }
 
 /// Sends a request to display a warning to the client with a formatted message. The warning is
 /// sent in a `window/showMessage` notification.
 macro_rules! show_warn_msg {
-    ($msg:expr$(, $($arg:tt),*)?) => {
-        crate::message::show_message(::core::format_args!($msg, $($($arg),*)?).to_string(), lsp_types::MessageType::WARNING)
+    ($msg:expr$(, $($arg:tt)*)?) => {
+        crate::message::show_message(::core::format_args!($msg$(, $($arg)*)?).to_string(), lsp_types::MessageType::WARNING)
     };
 }

--- a/crates/ruff_server/src/session/index/ruff_settings.rs
+++ b/crates/ruff_server/src/session/index/ruff_settings.rs
@@ -186,10 +186,9 @@ impl RuffSettingsIndex {
         // means for different editors.
         if is_default_workspace {
             if has_error {
-                let root = root.display();
                 show_err_msg!(
-                    "Error while resolving settings from workspace {root}. \
-                    Please refer to the logs for more details.",
+                    "Error while resolving settings from workspace {}. Please refer to the logs for more details.",
+                    root.display()
                 );
             }
 
@@ -300,9 +299,9 @@ impl RuffSettingsIndex {
         });
 
         if has_error.load(Ordering::Relaxed) {
-            let root = root.display();
             show_err_msg!(
-                "Error while resolving settings from workspace {root}. Please refer to the logs for more details.",
+                "Error while resolving settings from workspace {}. Please refer to the logs for more details.",
+                root.display()
             );
         }
 


### PR DESCRIPTION
## Summary

This PR fixes the `show_*_msg` macros to pass all the tokens instead of just a single token. This allows for using various expressions right in the macro similar to how it would be in `format_args!`.

## Test Plan

`cargo clippy`
