### PR TITLE
[red-knot] Simplify `object` out of intersections

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/comparison/intersections.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/comparison/intersections.md
@@ -92,8 +92,7 @@ def _(o: object):
     n = None
 
     if o is not None:
-        reveal_type(o)  # revealed: object & ~None
-
+        reveal_type(o)  # revealed:  ~None
         reveal_type(o is n)  # revealed: Literal[False]
         reveal_type(o is not n)  # revealed: Literal[True]
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/intersection_types.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/intersection_types.md
@@ -283,6 +283,21 @@ def _(
     reveal_type(not_object)  # revealed: Never
 ```
 
+### `object & ~T` is equivalent to `~T`
+
+A second consequence of the fact that `object` is the top type is that `object` is always redundant
+in intersections, and can be eagerly simplified out. `object & P` is equivalent to `P`;
+`object & ~P` is equivalent to `~P` for any type `P`.
+
+```py
+from knot_extensions import Intersection, Not, is_equivalent_to, static_assert
+
+class P: ...
+
+static_assert(is_equivalent_to(Intersection[object, P], P))
+static_assert(is_equivalent_to(Intersection[object, Not[P]], Not[P]))
+```
+
 ### Intersection of a type and its negation
 
 Continuing with more [complement laws], if we see both `P` and `~P` in an intersection, we can

--- a/crates/red_knot_python_semantic/resources/mdtest/narrow/isinstance.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/narrow/isinstance.md
@@ -91,8 +91,7 @@ if isinstance(x, (A, B)):
 elif isinstance(x, (A, C)):
     reveal_type(x)  # revealed: C & ~A & ~B
 else:
-    # TODO: Should be simplified to ~A & ~B & ~C
-    reveal_type(x)  # revealed: object & ~A & ~B & ~C
+    reveal_type(x)  # revealed: ~A & ~B & ~C
 ```
 
 ## No narrowing for instances of `builtins.type`

--- a/crates/red_knot_python_semantic/resources/mdtest/type_properties/is_equivalent_to.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/type_properties/is_equivalent_to.md
@@ -32,14 +32,4 @@ static_assert(not is_equivalent_to(Literal[1, 0], Literal[1, 2]))
 static_assert(not is_equivalent_to(Literal[1, 2, 3], Literal[1, 2]))
 ```
 
-## `object & ~T` is equivalent to `~T`
-
-```py
-from knot_extensions import Intersection, Not, is_equivalent_to, static_assert
-
-class P: ...
-
-static_assert(is_equivalent_to(Intersection[object, Not[P]], Not[P]))
-```
-
 [the equivalence relation]: https://typing.readthedocs.io/en/latest/spec/glossary.html#term-equivalent

--- a/crates/red_knot_python_semantic/resources/mdtest/type_properties/is_equivalent_to.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/type_properties/is_equivalent_to.md
@@ -32,4 +32,14 @@ static_assert(not is_equivalent_to(Literal[1, 0], Literal[1, 2]))
 static_assert(not is_equivalent_to(Literal[1, 2, 3], Literal[1, 2]))
 ```
 
+## `object & ~T` is equivalent to `~T`
+
+```py
+from knot_extensions import Intersection, Not, is_equivalent_to, static_assert
+
+class P: ...
+
+static_assert(is_equivalent_to(Intersection[object, Not[P]], Not[P]))
+```
+
 [the equivalence relation]: https://typing.readthedocs.io/en/latest/spec/glossary.html#term-equivalent

--- a/crates/red_knot_python_semantic/src/types/builder.rs
+++ b/crates/red_knot_python_semantic/src/types/builder.rs
@@ -288,12 +288,12 @@ impl<'db> InnerIntersectionBuilder<'db> {
                     .into_instance()
                     .and_then(|instance| instance.class.known(db));
 
-                let addition_is_bool_instance = match known_instance {
-                    // `object & T` -> `T`
-                    Some(KnownClass::Object) => return,
-                    Some(KnownClass::Bool) => true,
-                    _ => false,
-                };
+                if known_instance == Some(KnownClass::Object) {
+                    // `object & T` -> `T`; it is always redundant to add `object` to an intersection
+                    return;
+                }
+
+                let addition_is_bool_instance = known_instance == Some(KnownClass::Bool);
 
                 for (index, existing_positive) in self.positive.iter().enumerate() {
                     match existing_positive {

--- a/crates/red_knot_python_semantic/src/types/builder.rs
+++ b/crates/red_knot_python_semantic/src/types/builder.rs
@@ -284,10 +284,16 @@ impl<'db> InnerIntersectionBuilder<'db> {
                 }
             }
             _ => {
-                let addition_is_bool_instance = new_positive
+                let known_instance = new_positive
                     .into_instance()
-                    .and_then(|instance| instance.class.known(db))
-                    .is_some_and(KnownClass::is_bool);
+                    .and_then(|instance| instance.class.known(db));
+
+                let addition_is_bool_instance = match known_instance {
+                    // `object & T` -> `T`
+                    Some(KnownClass::Object) => return,
+                    Some(KnownClass::Bool) => true,
+                    _ => false,
+                };
 
                 for (index, existing_positive) in self.positive.iter().enumerate() {
                     match existing_positive {


### PR DESCRIPTION
## Summary

`object & int` is equivalent to `int`, `object & Unknown` is equivalent to `Unknown`, `object & ~int` is equivalent to `~int`... I could go on ;)

`object` is the top type, the supertype of everything, so it is always redundant in an intersection. Eagerly simplifying it out of intersections is easy, and fixes some property-test failures in another branch of mine.

## Test Plan

- `cargo test -p red_knot_python_semantic --test mdtest
- `QUICKCHECK_TESTS=200000 cargo test --release -p red_knot_python_semantic -- --ignored types::property_tests::stable`
- `uvx pre-commit run -a`
