### PR TITLE
[`flake8-todos`] Allow VSCode GitHub PR extension style links in `missing-todo-link` (`TD003`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_todos/TD003.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_todos/TD003.py
@@ -34,4 +34,10 @@ def foo(x):
 
 # foo # TODO: no link!
 
+# TODO: https://github.com/astral-sh/ruff/pull/9627 A todo with a link on the same line
+
+# TODO: #9627 A todo with a number on the same line
+
+# TODO: A todo with a random number, 5431
+
 # TODO: here's a TODO on the last line with no link

--- a/crates/ruff_linter/src/rules/flake8_todos/rules/todos.rs
+++ b/crates/ruff_linter/src/rules/flake8_todos/rules/todos.rs
@@ -106,7 +106,7 @@ pub(crate) struct MissingTodoLink;
 impl Violation for MissingTodoLink {
     #[derive_message_formats]
     fn message(&self) -> String {
-        "Missing issue link on the line following this TODO".to_string()
+        "Missing issue link for this TODO".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_todos/rules/todos.rs
+++ b/crates/ruff_linter/src/rules/flake8_todos/rules/todos.rs
@@ -91,6 +91,12 @@ impl Violation for MissingTodoAuthor {
 /// # TODO(charlie): this comment has a 3-digit issue code
 /// # 003
 ///
+/// # TODO(charlie): https://github.com/astral-sh/ruff/issues/3870
+/// # this comment has an issue link
+///
+/// # TODO(charlie): #003 this comment has a 3-digit issue code
+/// # with leading character `#`
+///
 /// # TODO(charlie): this comment has an issue code (matches the regex `[A-Z]+\-?\d+`)
 /// # SIXCHR-003
 /// ```

--- a/crates/ruff_linter/src/rules/flake8_todos/snapshots/ruff_linter__rules__flake8_todos__tests__missing-todo-link_TD003.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_todos/snapshots/ruff_linter__rules__flake8_todos__tests__missing-todo-link_TD003.py.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_todos/mod.rs
 ---
-TD003.py:15:3: TD003 Missing issue link on the line following this TODO
+TD003.py:15:3: TD003 Missing issue link for this TODO
    |
 14 | # TDO003 - errors
 15 | # TODO: this comment has no
@@ -9,7 +9,7 @@ TD003.py:15:3: TD003 Missing issue link on the line following this TODO
 16 | # link after it
    |
 
-TD003.py:18:3: TD003 Missing issue link on the line following this TODO
+TD003.py:18:3: TD003 Missing issue link for this TODO
    |
 16 | # link after it
 17 |
@@ -19,7 +19,7 @@ TD003.py:18:3: TD003 Missing issue link on the line following this TODO
 20 |     return x
    |
 
-TD003.py:31:3: TD003 Missing issue link on the line following this TODO
+TD003.py:31:3: TD003 Missing issue link for this TODO
    |
 29 | # TDO-3870
 30 |
@@ -29,7 +29,7 @@ TD003.py:31:3: TD003 Missing issue link on the line following this TODO
 33 | # TDO-3870
    |
 
-TD003.py:35:9: TD003 Missing issue link on the line following this TODO
+TD003.py:35:9: TD003 Missing issue link for this TODO
    |
 33 | # TDO-3870
 34 |
@@ -39,7 +39,7 @@ TD003.py:35:9: TD003 Missing issue link on the line following this TODO
 37 | # TODO: https://github.com/astral-sh/ruff/pull/9627 A todo with a link on the same line
    |
 
-TD003.py:41:3: TD003 Missing issue link on the line following this TODO
+TD003.py:41:3: TD003 Missing issue link for this TODO
    |
 39 | # TODO: #9627 A todo with a number on the same line
 40 |
@@ -49,7 +49,7 @@ TD003.py:41:3: TD003 Missing issue link on the line following this TODO
 43 | # TODO: here's a TODO on the last line with no link
    |
 
-TD003.py:43:3: TD003 Missing issue link on the line following this TODO
+TD003.py:43:3: TD003 Missing issue link for this TODO
    |
 41 | # TODO: A todo with a random number, 5431
 42 |

--- a/crates/ruff_linter/src/rules/flake8_todos/snapshots/ruff_linter__rules__flake8_todos__tests__missing-todo-link_TD003.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_todos/snapshots/ruff_linter__rules__flake8_todos__tests__missing-todo-link_TD003.py.snap
@@ -36,13 +36,23 @@ TD003.py:35:9: TD003 Missing issue link on the line following this TODO
 35 | # foo # TODO: no link!
    |         ^^^^ TD003
 36 |
-37 | # TODO: here's a TODO on the last line with no link
+37 | # TODO: https://github.com/astral-sh/ruff/pull/9627 A todo with a link on the same line
    |
 
-TD003.py:37:3: TD003 Missing issue link on the line following this TODO
+TD003.py:41:3: TD003 Missing issue link on the line following this TODO
    |
-35 | # foo # TODO: no link!
-36 |
-37 | # TODO: here's a TODO on the last line with no link
+39 | # TODO: #9627 A todo with a number on the same line
+40 |
+41 | # TODO: A todo with a random number, 5431
+   |   ^^^^ TD003
+42 |
+43 | # TODO: here's a TODO on the last line with no link
+   |
+
+TD003.py:43:3: TD003 Missing issue link on the line following this TODO
+   |
+41 | # TODO: A todo with a random number, 5431
+42 |
+43 | # TODO: here's a TODO on the last line with no link
    |   ^^^^ TD003
    |


### PR DESCRIPTION
## Summary
Allow links to issues that appear on the same line as the TODO directive, if they conform to the format that VSCode's GitHub PR extension produces.

Revival of #9627 (the branch was stale enough that rebasing was a lot harder than just making the changes anew). Credit should go to the author of that PR though.

Closes #8061

Co-authored-by: Martin Bernstorff <martinbernstorff@gmail.com>