### PR TITLE
Typeshed-sync workflow: add appropriate labels, link directly to failing run

### DIFF
--- a/.github/workflows/sync_typeshed.yaml
+++ b/.github/workflows/sync_typeshed.yaml
@@ -78,5 +78,6 @@ jobs:
               owner: "astral-sh",
               repo: "ruff",
               title: `Automated typeshed sync failed on ${new Date().toDateString()}`,
-              body: "Runs are listed here: https://github.com/astral-sh/ruff/actions/workflows/sync_typeshed.yaml",
+              body: "Run listed here: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+              labels: ["bug", "red-knot"],
             })


### PR DESCRIPTION
Incorporate improvements recently made to the daily-fuzz workflow and the daily-property-test workflow, in e.g. https://github.com/astral-sh/ruff/commit/b6562ed57e104b849b2673f4742e4afe98b27127
