### PR TITLE
Fix joining of f-strings with different quotes when using quote style `Preserve`

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/join_implicit_concatenated_string_preserve.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/join_implicit_concatenated_string_preserve.py
@@ -11,3 +11,12 @@ a = "different '" 'quote "are fine"'  # join
 
 # Already invalid Pre Python 312
 f"{'Hy "User"'}" f'{"Hy 'User'"}'
+
+
+# Regression tests for https://github.com/astral-sh/ruff/issues/15514
+params = {}
+string = "this is my string with " f'"{params.get("mine")}"'
+string = f'"{params.get("mine")} ' f"with {'nested single quoted string'}"
+string = f"{'''inner ' '''}" f'{"""inner " """}'
+string = f"{10 + len('bar')=}" f"{10 + len('bar')=}"
+string = f"{10 + len('bar')=}" f'{10 + len("bar")=}'

--- a/crates/ruff_python_formatter/src/lib.rs
+++ b/crates/ruff_python_formatter/src/lib.rs
@@ -186,7 +186,14 @@ if True:
     #[test]
     fn quick_test() {
         let source = r#"
-string = "this is my string with " f'"{params.get("mine")}"'
+def main() -> None:
+    if True:
+        some_very_long_variable_name_abcdefghijk = Foo()
+        some_very_long_variable_name_abcdefghijk = some_very_long_variable_name_abcdefghijk[
+            some_very_long_variable_name_abcdefghijk.some_very_long_attribute_name
+            == "This is a very long string abcdefghijk"
+        ]
+
 "#;
         let source_type = PySourceType::Python;
 
@@ -194,8 +201,7 @@ string = "this is my string with " f'"{params.get("mine")}"'
         let source_path = "code_inline.py";
         let parsed = parse(source, source_type.as_mode()).unwrap();
         let comment_ranges = CommentRanges::from(parsed.tokens());
-        let options = PyFormatOptions::from_extension(Path::new(source_path))
-            .with_quote_style(crate::QuoteStyle::Preserve);
+        let options = PyFormatOptions::from_extension(Path::new(source_path));
         let formatted = format_module_ast(&parsed, &comment_ranges, source, options).unwrap();
 
         // Uncomment the `dbg` to print the IR.

--- a/crates/ruff_python_formatter/src/lib.rs
+++ b/crates/ruff_python_formatter/src/lib.rs
@@ -186,14 +186,7 @@ if True:
     #[test]
     fn quick_test() {
         let source = r#"
-def main() -> None:
-    if True:
-        some_very_long_variable_name_abcdefghijk = Foo()
-        some_very_long_variable_name_abcdefghijk = some_very_long_variable_name_abcdefghijk[
-            some_very_long_variable_name_abcdefghijk.some_very_long_attribute_name
-            == "This is a very long string abcdefghijk"
-        ]
-
+string = "this is my string with " f'"{params.get("mine")}"'
 "#;
         let source_type = PySourceType::Python;
 
@@ -201,7 +194,8 @@ def main() -> None:
         let source_path = "code_inline.py";
         let parsed = parse(source, source_type.as_mode()).unwrap();
         let comment_ranges = CommentRanges::from(parsed.tokens());
-        let options = PyFormatOptions::from_extension(Path::new(source_path));
+        let options = PyFormatOptions::from_extension(Path::new(source_path))
+            .with_quote_style(crate::QuoteStyle::Preserve);
         let formatted = format_module_ast(&parsed, &comment_ranges, source, options).unwrap();
 
         // Uncomment the `dbg` to print the IR.

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__join_implicit_concatenated_string_preserve.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__join_implicit_concatenated_string_preserve.py.snap
@@ -17,6 +17,15 @@ a = "different '" 'quote "are fine"'  # join
 
 # Already invalid Pre Python 312
 f"{'Hy "User"'}" f'{"Hy 'User'"}'
+
+
+# Regression tests for https://github.com/astral-sh/ruff/issues/15514
+params = {}
+string = "this is my string with " f'"{params.get("mine")}"'
+string = f'"{params.get("mine")} ' f"with {'nested single quoted string'}"
+string = f"{'''inner ' '''}" f'{"""inner " """}'
+string = f"{10 + len('bar')=}" f"{10 + len('bar')=}"
+string = f"{10 + len('bar')=}" f'{10 + len("bar")=}'
 ```
 
 ## Outputs
@@ -49,6 +58,15 @@ a = "different 'quote \"are fine\""  # join
 
 # Already invalid Pre Python 312
 f"{'Hy "User"'}{"Hy 'User'"}"
+
+
+# Regression tests for https://github.com/astral-sh/ruff/issues/15514
+params = {}
+string = f"this is my string with \"{params.get('mine')}\""
+string = f'"{params.get("mine")} with {"nested single quoted string"}'
+string = f"{'''inner ' '''}" f'{"""inner " """}'
+string = f"{10 + len('bar')=}{10 + len('bar')=}"
+string = f"{10 + len('bar')=}" f'{10 + len("bar")=}'
 ```
 
 
@@ -81,4 +99,13 @@ a = "different 'quote \"are fine\""  # join
 
 # Already invalid Pre Python 312
 f"{'Hy "User"'}{"Hy 'User'"}"
+
+
+# Regression tests for https://github.com/astral-sh/ruff/issues/15514
+params = {}
+string = f"this is my string with \"{params.get("mine")}\""
+string = f'"{params.get("mine")} with {'nested single quoted string'}'
+string = f"{'''inner ' '''}{"""inner " """}"
+string = f"{10 + len('bar')=}{10 + len('bar')=}"
+string = f"{10 + len('bar')=}{10 + len("bar")=}"
 ```


### PR DESCRIPTION
## Summary

Fixes https://github.com/astral-sh/ruff/issues/15514

Fixes joining implicit concatenated strings when using `quote-style="Preserve` if the parts use different quotes and at least one contains a nested string using quotes. 

The bug rooted from always returning `Preserve` in the `choose_quotes` function when using `quote-style="Preserve"` even in cases where f-strings are nested. 
This is fine for regular f-strings (because we can assume that the quotes were valid in the source) but it isn't sufficient when joining f-strings. 

## Test Plan

Added tests
