### PR TITLE
 [airflow] extend and fix AIR302 rules

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/airflow/AIR302_names.py
+++ b/crates/ruff_linter/resources/test/fixtures/airflow/AIR302_names.py
@@ -66,7 +66,7 @@ from airflow.providers.openlineage.utils.utils import (
 )
 from airflow.providers.postgres.datasets import postgres
 from airflow.providers.trino.datasets import trino
-from airflow.secrets.local_filesystem import get_connection, load_connections
+from airflow.secrets.local_filesystem import LocalFilesystemBackend, load_connections
 from airflow.security.permissions import RESOURCE_DATASET
 from airflow.sensors.base_sensor_operator import BaseSensorOperator
 from airflow.sensors.date_time_sensor import DateTimeSensor
@@ -84,6 +84,7 @@ from airflow.timetables.simple import DatasetTriggeredTimetable
 from airflow.triggers.external_task import TaskStateTrigger
 from airflow.utils import dates
 from airflow.utils.dag_cycle_tester import test_cycle
+from airflow.utils.dag_parsing_context import get_parsing_context
 from airflow.utils.dates import (
     date_range,
     datetime_to_nano,
@@ -225,7 +226,10 @@ postgres.sanitize_uri
 trino.sanitize_uri
 
 # airflow.secrets
-get_connection, load_connections
+# get_connection
+lfb = LocalFilesystemBackend()
+lfb.get_connections()
+load_connections
 
 # airflow.security.permissions
 RESOURCE_DATASET
@@ -271,6 +275,9 @@ dates.datetime_to_nano
 
 # airflow.utils.dag_cycle_tester
 test_cycle
+
+# airflow.utils.dag_parsing_context
+get_parsing_context
 
 # airflow.utils.decorators
 apply_defaults

--- a/crates/ruff_linter/src/rules/airflow/rules/removal_in_3.rs
+++ b/crates/ruff_linter/src/rules/airflow/rules/removal_in_3.rs
@@ -548,7 +548,7 @@ fn check_name(checker: &mut Checker, expr: &Expr, range: TextRange) {
         }
 
         // airflow.utils.dates
-        ["airflow", "utils", "dates", "date_range"] => Replacement::Name("airflow.timetables."),
+        ["airflow", "utils", "dates", "date_range"] => Replacement::None,
         ["airflow", "utils", "dates", "days_ago"] => {
             Replacement::Name("pendulum.today('UTC').add(days=-N, ...)")
         }

--- a/crates/ruff_linter/src/rules/airflow/rules/removal_in_3.rs
+++ b/crates/ruff_linter/src/rules/airflow/rules/removal_in_3.rs
@@ -547,6 +547,10 @@ fn check_name(checker: &mut Checker, expr: &Expr, range: TextRange) {
             Replacement::Name("airflow.secrets.local_filesystem.load_connections_dict")
         }
 
+        // airflow.utils.dag_parsing_context
+        ["airflow", "utils", "dag_parsing_context", "get_parsing_context"] => {
+            Replacement::Name("airflow.sdk.get_parsing_context")
+        }
         // airflow.utils.dates
         ["airflow", "utils", "dates", "date_range"] => Replacement::None,
         ["airflow", "utils", "dates", "days_ago"] => {

--- a/crates/ruff_linter/src/rules/airflow/rules/removal_in_3.rs
+++ b/crates/ruff_linter/src/rules/airflow/rules/removal_in_3.rs
@@ -294,6 +294,11 @@ fn check_method(checker: &mut Checker, call_expr: &ExprCall) {
             )),
             _ => None,
         },
+        ["airflow", "secrets", "local_filesystem", "LocalFilesystemBackend"] => match attr.as_str()
+        {
+            "get_connections" => Some(Replacement::Name("get_connection")),
+            _ => None,
+        },
         ["airflow", "datasets", ..] | ["airflow", "Dataset"] => match attr.as_str() {
             "iter_datasets" => Some(Replacement::Name("iter_assets")),
             "iter_dataset_aliases" => Some(Replacement::Name("iter_asset_aliases")),
@@ -541,9 +546,6 @@ fn check_name(checker: &mut Checker, expr: &Expr, range: TextRange) {
 
         // airflow.secrets
         ["airflow", "secrets", "local_filesystem", "load_connections"] => {
-            Replacement::Name("airflow.secrets.local_filesystem.load_connections_dict")
-        }
-        ["airflow", "secrets", "local_filesystem", "get_connection"] => {
             Replacement::Name("airflow.secrets.local_filesystem.load_connections_dict")
         }
 

--- a/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_names.py.snap
+++ b/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_names.py.snap
@@ -1,1102 +1,1112 @@
 ---
 source: crates/ruff_linter/src/rules/airflow/mod.rs
+snapshot_kind: text
 ---
-AIR302_names.py:105:1: AIR302 `airflow.PY36` is removed in Airflow 3.0
+AIR302_names.py:106:1: AIR302 `airflow.PY36` is removed in Airflow 3.0
     |
-104 | # airflow root
-105 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
+105 | # airflow root
+106 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
     | ^^^^ AIR302
-106 | DatasetFromRoot()
+107 | DatasetFromRoot()
     |
     = help: Use `sys.version_info` instead
 
-AIR302_names.py:105:7: AIR302 `airflow.PY37` is removed in Airflow 3.0
+AIR302_names.py:106:7: AIR302 `airflow.PY37` is removed in Airflow 3.0
     |
-104 | # airflow root
-105 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
+105 | # airflow root
+106 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
     |       ^^^^ AIR302
-106 | DatasetFromRoot()
+107 | DatasetFromRoot()
     |
     = help: Use `sys.version_info` instead
 
-AIR302_names.py:105:13: AIR302 `airflow.PY38` is removed in Airflow 3.0
+AIR302_names.py:106:13: AIR302 `airflow.PY38` is removed in Airflow 3.0
     |
-104 | # airflow root
-105 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
+105 | # airflow root
+106 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
     |             ^^^^ AIR302
-106 | DatasetFromRoot()
+107 | DatasetFromRoot()
     |
     = help: Use `sys.version_info` instead
 
-AIR302_names.py:105:19: AIR302 `airflow.PY39` is removed in Airflow 3.0
+AIR302_names.py:106:19: AIR302 `airflow.PY39` is removed in Airflow 3.0
     |
-104 | # airflow root
-105 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
+105 | # airflow root
+106 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
     |                   ^^^^ AIR302
-106 | DatasetFromRoot()
+107 | DatasetFromRoot()
     |
     = help: Use `sys.version_info` instead
 
-AIR302_names.py:105:25: AIR302 `airflow.PY310` is removed in Airflow 3.0
+AIR302_names.py:106:25: AIR302 `airflow.PY310` is removed in Airflow 3.0
     |
-104 | # airflow root
-105 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
+105 | # airflow root
+106 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
     |                         ^^^^^ AIR302
-106 | DatasetFromRoot()
+107 | DatasetFromRoot()
     |
     = help: Use `sys.version_info` instead
 
-AIR302_names.py:105:32: AIR302 `airflow.PY311` is removed in Airflow 3.0
+AIR302_names.py:106:32: AIR302 `airflow.PY311` is removed in Airflow 3.0
     |
-104 | # airflow root
-105 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
+105 | # airflow root
+106 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
     |                                ^^^^^ AIR302
-106 | DatasetFromRoot()
+107 | DatasetFromRoot()
     |
     = help: Use `sys.version_info` instead
 
-AIR302_names.py:105:39: AIR302 `airflow.PY312` is removed in Airflow 3.0
+AIR302_names.py:106:39: AIR302 `airflow.PY312` is removed in Airflow 3.0
     |
-104 | # airflow root
-105 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
+105 | # airflow root
+106 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
     |                                       ^^^^^ AIR302
-106 | DatasetFromRoot()
+107 | DatasetFromRoot()
     |
     = help: Use `sys.version_info` instead
 
-AIR302_names.py:106:1: AIR302 `airflow.Dataset` is removed in Airflow 3.0
+AIR302_names.py:107:1: AIR302 `airflow.Dataset` is removed in Airflow 3.0
     |
-104 | # airflow root
-105 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
-106 | DatasetFromRoot()
+105 | # airflow root
+106 | PY36, PY37, PY38, PY39, PY310, PY311, PY312
+107 | DatasetFromRoot()
     | ^^^^^^^^^^^^^^^ AIR302
-107 |
-108 | dataset_from_root = DatasetFromRoot()
+108 |
+109 | dataset_from_root = DatasetFromRoot()
     |
     = help: Use `airflow.sdk.definitions.asset.Asset` instead
 
-AIR302_names.py:108:21: AIR302 `airflow.Dataset` is removed in Airflow 3.0
+AIR302_names.py:109:21: AIR302 `airflow.Dataset` is removed in Airflow 3.0
     |
-106 | DatasetFromRoot()
-107 |
-108 | dataset_from_root = DatasetFromRoot()
+107 | DatasetFromRoot()
+108 |
+109 | dataset_from_root = DatasetFromRoot()
     |                     ^^^^^^^^^^^^^^^ AIR302
-109 | dataset_from_root.iter_datasets()
-110 | dataset_from_root.iter_dataset_aliases()
+110 | dataset_from_root.iter_datasets()
+111 | dataset_from_root.iter_dataset_aliases()
     |
     = help: Use `airflow.sdk.definitions.asset.Asset` instead
 
-AIR302_names.py:109:19: AIR302 `iter_datasets` is removed in Airflow 3.0
+AIR302_names.py:110:19: AIR302 `iter_datasets` is removed in Airflow 3.0
     |
-108 | dataset_from_root = DatasetFromRoot()
-109 | dataset_from_root.iter_datasets()
+109 | dataset_from_root = DatasetFromRoot()
+110 | dataset_from_root.iter_datasets()
     |                   ^^^^^^^^^^^^^ AIR302
-110 | dataset_from_root.iter_dataset_aliases()
+111 | dataset_from_root.iter_dataset_aliases()
     |
     = help: Use `iter_assets` instead
 
-AIR302_names.py:110:19: AIR302 `iter_dataset_aliases` is removed in Airflow 3.0
+AIR302_names.py:111:19: AIR302 `iter_dataset_aliases` is removed in Airflow 3.0
     |
-108 | dataset_from_root = DatasetFromRoot()
-109 | dataset_from_root.iter_datasets()
-110 | dataset_from_root.iter_dataset_aliases()
+109 | dataset_from_root = DatasetFromRoot()
+110 | dataset_from_root.iter_datasets()
+111 | dataset_from_root.iter_dataset_aliases()
     |                   ^^^^^^^^^^^^^^^^^^^^ AIR302
-111 |
-112 | # airflow.api_connexion.security
+112 |
+113 | # airflow.api_connexion.security
     |
     = help: Use `iter_asset_aliases` instead
 
-AIR302_names.py:113:1: AIR302 `airflow.api_connexion.security.requires_access` is removed in Airflow 3.0
+AIR302_names.py:114:1: AIR302 `airflow.api_connexion.security.requires_access` is removed in Airflow 3.0
     |
-112 | # airflow.api_connexion.security
-113 | requires_access, requires_access_dataset
+113 | # airflow.api_connexion.security
+114 | requires_access, requires_access_dataset
     | ^^^^^^^^^^^^^^^ AIR302
-114 |
-115 | # airflow.auth.managers
+115 |
+116 | # airflow.auth.managers
     |
     = help: Use `airflow.api_connexion.security.requires_access_*` instead
 
-AIR302_names.py:113:18: AIR302 `airflow.api_connexion.security.requires_access_dataset` is removed in Airflow 3.0
+AIR302_names.py:114:18: AIR302 `airflow.api_connexion.security.requires_access_dataset` is removed in Airflow 3.0
     |
-112 | # airflow.api_connexion.security
-113 | requires_access, requires_access_dataset
+113 | # airflow.api_connexion.security
+114 | requires_access, requires_access_dataset
     |                  ^^^^^^^^^^^^^^^^^^^^^^^ AIR302
-114 |
-115 | # airflow.auth.managers
+115 |
+116 | # airflow.auth.managers
     |
     = help: Use `airflow.api_connexion.security.requires_access_asset` instead
 
-AIR302_names.py:116:1: AIR302 `airflow.auth.managers.base_auth_manager.is_authorized_dataset` is removed in Airflow 3.0
+AIR302_names.py:117:1: AIR302 `airflow.auth.managers.base_auth_manager.is_authorized_dataset` is removed in Airflow 3.0
     |
-115 | # airflow.auth.managers
-116 | is_authorized_dataset
+116 | # airflow.auth.managers
+117 | is_authorized_dataset
     | ^^^^^^^^^^^^^^^^^^^^^ AIR302
-117 | DatasetDetails()
+118 | DatasetDetails()
     |
     = help: Use `airflow.auth.managers.base_auth_manager.is_authorized_asset` instead
 
-AIR302_names.py:117:1: AIR302 `airflow.auth.managers.models.resource_details.DatasetDetails` is removed in Airflow 3.0
+AIR302_names.py:118:1: AIR302 `airflow.auth.managers.models.resource_details.DatasetDetails` is removed in Airflow 3.0
     |
-115 | # airflow.auth.managers
-116 | is_authorized_dataset
-117 | DatasetDetails()
+116 | # airflow.auth.managers
+117 | is_authorized_dataset
+118 | DatasetDetails()
     | ^^^^^^^^^^^^^^ AIR302
-118 |
-119 | # airflow.configuration
+119 |
+120 | # airflow.configuration
     |
     = help: Use `airflow.auth.managers.models.resource_details.AssetDetails` instead
 
-AIR302_names.py:120:1: AIR302 `airflow.configuration.get` is removed in Airflow 3.0
+AIR302_names.py:121:1: AIR302 `airflow.configuration.get` is removed in Airflow 3.0
     |
-119 | # airflow.configuration
-120 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+120 | # airflow.configuration
+121 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
     | ^^^ AIR302
     |
     = help: Use `airflow.configuration.conf.get` instead
 
-AIR302_names.py:120:6: AIR302 `airflow.configuration.getboolean` is removed in Airflow 3.0
+AIR302_names.py:121:6: AIR302 `airflow.configuration.getboolean` is removed in Airflow 3.0
     |
-119 | # airflow.configuration
-120 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+120 | # airflow.configuration
+121 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
     |      ^^^^^^^^^^ AIR302
     |
     = help: Use `airflow.configuration.conf.getboolean` instead
 
-AIR302_names.py:120:18: AIR302 `airflow.configuration.getfloat` is removed in Airflow 3.0
+AIR302_names.py:121:18: AIR302 `airflow.configuration.getfloat` is removed in Airflow 3.0
     |
-119 | # airflow.configuration
-120 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+120 | # airflow.configuration
+121 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
     |                  ^^^^^^^^ AIR302
     |
     = help: Use `airflow.configuration.conf.getfloat` instead
 
-AIR302_names.py:120:28: AIR302 `airflow.configuration.getint` is removed in Airflow 3.0
+AIR302_names.py:121:28: AIR302 `airflow.configuration.getint` is removed in Airflow 3.0
     |
-119 | # airflow.configuration
-120 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+120 | # airflow.configuration
+121 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
     |                            ^^^^^^ AIR302
     |
     = help: Use `airflow.configuration.conf.getint` instead
 
-AIR302_names.py:120:36: AIR302 `airflow.configuration.has_option` is removed in Airflow 3.0
+AIR302_names.py:121:36: AIR302 `airflow.configuration.has_option` is removed in Airflow 3.0
     |
-119 | # airflow.configuration
-120 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+120 | # airflow.configuration
+121 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
     |                                    ^^^^^^^^^^ AIR302
     |
     = help: Use `airflow.configuration.conf.has_option` instead
 
-AIR302_names.py:120:48: AIR302 `airflow.configuration.remove_option` is removed in Airflow 3.0
+AIR302_names.py:121:48: AIR302 `airflow.configuration.remove_option` is removed in Airflow 3.0
     |
-119 | # airflow.configuration
-120 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+120 | # airflow.configuration
+121 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
     |                                                ^^^^^^^^^^^^^ AIR302
     |
     = help: Use `airflow.configuration.conf.remove_option` instead
 
-AIR302_names.py:120:63: AIR302 `airflow.configuration.as_dict` is removed in Airflow 3.0
+AIR302_names.py:121:63: AIR302 `airflow.configuration.as_dict` is removed in Airflow 3.0
     |
-119 | # airflow.configuration
-120 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+120 | # airflow.configuration
+121 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
     |                                                               ^^^^^^^ AIR302
     |
     = help: Use `airflow.configuration.conf.as_dict` instead
 
-AIR302_names.py:120:72: AIR302 `airflow.configuration.set` is removed in Airflow 3.0
+AIR302_names.py:121:72: AIR302 `airflow.configuration.set` is removed in Airflow 3.0
     |
-119 | # airflow.configuration
-120 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
+120 | # airflow.configuration
+121 | get, getboolean, getfloat, getint, has_option, remove_option, as_dict, set
     |                                                                        ^^^ AIR302
     |
     = help: Use `airflow.configuration.conf.set` instead
 
-AIR302_names.py:124:1: AIR302 `airflow.contrib.aws_athena_hook.AWSAthenaHook` is removed in Airflow 3.0; The whole `airflow.contrib` module has been removed.
+AIR302_names.py:125:1: AIR302 `airflow.contrib.aws_athena_hook.AWSAthenaHook` is removed in Airflow 3.0; The whole `airflow.contrib` module has been removed.
     |
-123 | # airflow.contrib.*
-124 | AWSAthenaHook()
+124 | # airflow.contrib.*
+125 | AWSAthenaHook()
     | ^^^^^^^^^^^^^ AIR302
-125 |
-126 | # airflow.datasets
+126 |
+127 | # airflow.datasets
     |
 
-AIR302_names.py:127:1: AIR302 `airflow.datasets.Dataset` is removed in Airflow 3.0
+AIR302_names.py:128:1: AIR302 `airflow.datasets.Dataset` is removed in Airflow 3.0
     |
-126 | # airflow.datasets
-127 | Dataset()
+127 | # airflow.datasets
+128 | Dataset()
     | ^^^^^^^ AIR302
-128 | DatasetAlias()
-129 | DatasetAliasEvent()
+129 | DatasetAlias()
+130 | DatasetAliasEvent()
     |
     = help: Use `airflow.sdk.definitions.asset.Asset` instead
 
-AIR302_names.py:128:1: AIR302 `airflow.datasets.DatasetAlias` is removed in Airflow 3.0
+AIR302_names.py:129:1: AIR302 `airflow.datasets.DatasetAlias` is removed in Airflow 3.0
     |
-126 | # airflow.datasets
-127 | Dataset()
-128 | DatasetAlias()
+127 | # airflow.datasets
+128 | Dataset()
+129 | DatasetAlias()
     | ^^^^^^^^^^^^ AIR302
-129 | DatasetAliasEvent()
-130 | DatasetAll()
+130 | DatasetAliasEvent()
+131 | DatasetAll()
     |
     = help: Use `airflow.sdk.definitions.asset.AssetAlias` instead
 
-AIR302_names.py:129:1: AIR302 `airflow.datasets.DatasetAliasEvent` is removed in Airflow 3.0
+AIR302_names.py:130:1: AIR302 `airflow.datasets.DatasetAliasEvent` is removed in Airflow 3.0
     |
-127 | Dataset()
-128 | DatasetAlias()
-129 | DatasetAliasEvent()
+128 | Dataset()
+129 | DatasetAlias()
+130 | DatasetAliasEvent()
     | ^^^^^^^^^^^^^^^^^ AIR302
-130 | DatasetAll()
-131 | DatasetAny()
+131 | DatasetAll()
+132 | DatasetAny()
     |
 
-AIR302_names.py:130:1: AIR302 `airflow.datasets.DatasetAll` is removed in Airflow 3.0
+AIR302_names.py:131:1: AIR302 `airflow.datasets.DatasetAll` is removed in Airflow 3.0
     |
-128 | DatasetAlias()
-129 | DatasetAliasEvent()
-130 | DatasetAll()
+129 | DatasetAlias()
+130 | DatasetAliasEvent()
+131 | DatasetAll()
     | ^^^^^^^^^^ AIR302
-131 | DatasetAny()
-132 | expand_alias_to_datasets
+132 | DatasetAny()
+133 | expand_alias_to_datasets
     |
     = help: Use `airflow.sdk.definitions.asset.AssetAll` instead
 
-AIR302_names.py:131:1: AIR302 `airflow.datasets.DatasetAny` is removed in Airflow 3.0
+AIR302_names.py:132:1: AIR302 `airflow.datasets.DatasetAny` is removed in Airflow 3.0
     |
-129 | DatasetAliasEvent()
-130 | DatasetAll()
-131 | DatasetAny()
+130 | DatasetAliasEvent()
+131 | DatasetAll()
+132 | DatasetAny()
     | ^^^^^^^^^^ AIR302
-132 | expand_alias_to_datasets
-133 | Metadata()
+133 | expand_alias_to_datasets
+134 | Metadata()
     |
     = help: Use `airflow.sdk.definitions.asset.AssetAny` instead
 
-AIR302_names.py:132:1: AIR302 `airflow.datasets.expand_alias_to_datasets` is removed in Airflow 3.0
+AIR302_names.py:133:1: AIR302 `airflow.datasets.expand_alias_to_datasets` is removed in Airflow 3.0
     |
-130 | DatasetAll()
-131 | DatasetAny()
-132 | expand_alias_to_datasets
+131 | DatasetAll()
+132 | DatasetAny()
+133 | expand_alias_to_datasets
     | ^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
-133 | Metadata()
+134 | Metadata()
     |
     = help: Use `airflow.sdk.definitions.asset.expand_alias_to_assets` instead
 
-AIR302_names.py:133:1: AIR302 `airflow.datasets.metadata.Metadata` is removed in Airflow 3.0
+AIR302_names.py:134:1: AIR302 `airflow.datasets.metadata.Metadata` is removed in Airflow 3.0
     |
-131 | DatasetAny()
-132 | expand_alias_to_datasets
-133 | Metadata()
+132 | DatasetAny()
+133 | expand_alias_to_datasets
+134 | Metadata()
     | ^^^^^^^^ AIR302
-134 |
-135 | dataset_to_test_method_call = Dataset()
+135 |
+136 | dataset_to_test_method_call = Dataset()
     |
     = help: Use `airflow.sdk.definitions.asset.metadata.Metadata` instead
 
-AIR302_names.py:135:31: AIR302 `airflow.datasets.Dataset` is removed in Airflow 3.0
+AIR302_names.py:136:31: AIR302 `airflow.datasets.Dataset` is removed in Airflow 3.0
     |
-133 | Metadata()
-134 |
-135 | dataset_to_test_method_call = Dataset()
+134 | Metadata()
+135 |
+136 | dataset_to_test_method_call = Dataset()
     |                               ^^^^^^^ AIR302
-136 | dataset_to_test_method_call.iter_datasets()
-137 | dataset_to_test_method_call.iter_dataset_aliases()
+137 | dataset_to_test_method_call.iter_datasets()
+138 | dataset_to_test_method_call.iter_dataset_aliases()
     |
     = help: Use `airflow.sdk.definitions.asset.Asset` instead
 
-AIR302_names.py:136:29: AIR302 `iter_datasets` is removed in Airflow 3.0
+AIR302_names.py:137:29: AIR302 `iter_datasets` is removed in Airflow 3.0
     |
-135 | dataset_to_test_method_call = Dataset()
-136 | dataset_to_test_method_call.iter_datasets()
+136 | dataset_to_test_method_call = Dataset()
+137 | dataset_to_test_method_call.iter_datasets()
     |                             ^^^^^^^^^^^^^ AIR302
-137 | dataset_to_test_method_call.iter_dataset_aliases()
+138 | dataset_to_test_method_call.iter_dataset_aliases()
     |
     = help: Use `iter_assets` instead
 
-AIR302_names.py:137:29: AIR302 `iter_dataset_aliases` is removed in Airflow 3.0
+AIR302_names.py:138:29: AIR302 `iter_dataset_aliases` is removed in Airflow 3.0
     |
-135 | dataset_to_test_method_call = Dataset()
-136 | dataset_to_test_method_call.iter_datasets()
-137 | dataset_to_test_method_call.iter_dataset_aliases()
+136 | dataset_to_test_method_call = Dataset()
+137 | dataset_to_test_method_call.iter_datasets()
+138 | dataset_to_test_method_call.iter_dataset_aliases()
     |                             ^^^^^^^^^^^^^^^^^^^^ AIR302
-138 |
-139 | alias_to_test_method_call = DatasetAlias()
+139 |
+140 | alias_to_test_method_call = DatasetAlias()
     |
     = help: Use `iter_asset_aliases` instead
 
-AIR302_names.py:139:29: AIR302 `airflow.datasets.DatasetAlias` is removed in Airflow 3.0
+AIR302_names.py:140:29: AIR302 `airflow.datasets.DatasetAlias` is removed in Airflow 3.0
     |
-137 | dataset_to_test_method_call.iter_dataset_aliases()
-138 |
-139 | alias_to_test_method_call = DatasetAlias()
+138 | dataset_to_test_method_call.iter_dataset_aliases()
+139 |
+140 | alias_to_test_method_call = DatasetAlias()
     |                             ^^^^^^^^^^^^ AIR302
-140 | alias_to_test_method_call.iter_datasets()
-141 | alias_to_test_method_call.iter_dataset_aliases()
+141 | alias_to_test_method_call.iter_datasets()
+142 | alias_to_test_method_call.iter_dataset_aliases()
     |
     = help: Use `airflow.sdk.definitions.asset.AssetAlias` instead
 
-AIR302_names.py:140:27: AIR302 `iter_datasets` is removed in Airflow 3.0
+AIR302_names.py:141:27: AIR302 `iter_datasets` is removed in Airflow 3.0
     |
-139 | alias_to_test_method_call = DatasetAlias()
-140 | alias_to_test_method_call.iter_datasets()
+140 | alias_to_test_method_call = DatasetAlias()
+141 | alias_to_test_method_call.iter_datasets()
     |                           ^^^^^^^^^^^^^ AIR302
-141 | alias_to_test_method_call.iter_dataset_aliases()
+142 | alias_to_test_method_call.iter_dataset_aliases()
     |
     = help: Use `iter_assets` instead
 
-AIR302_names.py:141:27: AIR302 `iter_dataset_aliases` is removed in Airflow 3.0
+AIR302_names.py:142:27: AIR302 `iter_dataset_aliases` is removed in Airflow 3.0
     |
-139 | alias_to_test_method_call = DatasetAlias()
-140 | alias_to_test_method_call.iter_datasets()
-141 | alias_to_test_method_call.iter_dataset_aliases()
+140 | alias_to_test_method_call = DatasetAlias()
+141 | alias_to_test_method_call.iter_datasets()
+142 | alias_to_test_method_call.iter_dataset_aliases()
     |                           ^^^^^^^^^^^^^^^^^^^^ AIR302
-142 |
-143 | any_to_test_method_call = DatasetAny()
+143 |
+144 | any_to_test_method_call = DatasetAny()
     |
     = help: Use `iter_asset_aliases` instead
 
-AIR302_names.py:143:27: AIR302 `airflow.datasets.DatasetAny` is removed in Airflow 3.0
+AIR302_names.py:144:27: AIR302 `airflow.datasets.DatasetAny` is removed in Airflow 3.0
     |
-141 | alias_to_test_method_call.iter_dataset_aliases()
-142 |
-143 | any_to_test_method_call = DatasetAny()
+142 | alias_to_test_method_call.iter_dataset_aliases()
+143 |
+144 | any_to_test_method_call = DatasetAny()
     |                           ^^^^^^^^^^ AIR302
-144 | any_to_test_method_call.iter_datasets()
-145 | any_to_test_method_call.iter_dataset_aliases()
+145 | any_to_test_method_call.iter_datasets()
+146 | any_to_test_method_call.iter_dataset_aliases()
     |
     = help: Use `airflow.sdk.definitions.asset.AssetAny` instead
 
-AIR302_names.py:144:25: AIR302 `iter_datasets` is removed in Airflow 3.0
+AIR302_names.py:145:25: AIR302 `iter_datasets` is removed in Airflow 3.0
     |
-143 | any_to_test_method_call = DatasetAny()
-144 | any_to_test_method_call.iter_datasets()
+144 | any_to_test_method_call = DatasetAny()
+145 | any_to_test_method_call.iter_datasets()
     |                         ^^^^^^^^^^^^^ AIR302
-145 | any_to_test_method_call.iter_dataset_aliases()
+146 | any_to_test_method_call.iter_dataset_aliases()
     |
     = help: Use `iter_assets` instead
 
-AIR302_names.py:145:25: AIR302 `iter_dataset_aliases` is removed in Airflow 3.0
+AIR302_names.py:146:25: AIR302 `iter_dataset_aliases` is removed in Airflow 3.0
     |
-143 | any_to_test_method_call = DatasetAny()
-144 | any_to_test_method_call.iter_datasets()
-145 | any_to_test_method_call.iter_dataset_aliases()
+144 | any_to_test_method_call = DatasetAny()
+145 | any_to_test_method_call.iter_datasets()
+146 | any_to_test_method_call.iter_dataset_aliases()
     |                         ^^^^^^^^^^^^^^^^^^^^ AIR302
-146 |
-147 | # airflow.datasets.manager
+147 |
+148 | # airflow.datasets.manager
     |
     = help: Use `iter_asset_aliases` instead
 
-AIR302_names.py:148:19: AIR302 `airflow.datasets.manager.dataset_manager` is removed in Airflow 3.0
+AIR302_names.py:149:19: AIR302 `airflow.datasets.manager.dataset_manager` is removed in Airflow 3.0
     |
-147 | # airflow.datasets.manager
-148 | DatasetManager(), dataset_manager, resolve_dataset_manager
+148 | # airflow.datasets.manager
+149 | DatasetManager(), dataset_manager, resolve_dataset_manager
     |                   ^^^^^^^^^^^^^^^ AIR302
-149 |
-150 | # airflow.hooks
+150 |
+151 | # airflow.hooks
     |
     = help: Use `airflow.assets.manager` instead
 
-AIR302_names.py:148:36: AIR302 `airflow.datasets.manager.resolve_dataset_manager` is removed in Airflow 3.0
+AIR302_names.py:149:36: AIR302 `airflow.datasets.manager.resolve_dataset_manager` is removed in Airflow 3.0
     |
-147 | # airflow.datasets.manager
-148 | DatasetManager(), dataset_manager, resolve_dataset_manager
+148 | # airflow.datasets.manager
+149 | DatasetManager(), dataset_manager, resolve_dataset_manager
     |                                    ^^^^^^^^^^^^^^^^^^^^^^^ AIR302
-149 |
-150 | # airflow.hooks
+150 |
+151 | # airflow.hooks
     |
     = help: Use `airflow.assets.resolve_asset_manager` instead
 
-AIR302_names.py:151:1: AIR302 `airflow.hooks.base_hook.BaseHook` is removed in Airflow 3.0
+AIR302_names.py:152:1: AIR302 `airflow.hooks.base_hook.BaseHook` is removed in Airflow 3.0
     |
-150 | # airflow.hooks
-151 | BaseHook()
+151 | # airflow.hooks
+152 | BaseHook()
     | ^^^^^^^^ AIR302
-152 |
-153 | # airflow.lineage.hook
+153 |
+154 | # airflow.lineage.hook
     |
     = help: Use `airflow.hooks.base.BaseHook` instead
 
-AIR302_names.py:154:1: AIR302 `airflow.lineage.hook.DatasetLineageInfo` is removed in Airflow 3.0
+AIR302_names.py:155:1: AIR302 `airflow.lineage.hook.DatasetLineageInfo` is removed in Airflow 3.0
     |
-153 | # airflow.lineage.hook
-154 | DatasetLineageInfo()
+154 | # airflow.lineage.hook
+155 | DatasetLineageInfo()
     | ^^^^^^^^^^^^^^^^^^ AIR302
-155 |
-156 | # airflow.listeners.spec.dataset
+156 |
+157 | # airflow.listeners.spec.dataset
     |
     = help: Use `airflow.lineage.hook.AssetLineageInfo` instead
 
-AIR302_names.py:157:1: AIR302 `airflow.listeners.spec.dataset.on_dataset_changed` is removed in Airflow 3.0
+AIR302_names.py:158:1: AIR302 `airflow.listeners.spec.dataset.on_dataset_changed` is removed in Airflow 3.0
     |
-156 | # airflow.listeners.spec.dataset
-157 | on_dataset_changed, on_dataset_created
+157 | # airflow.listeners.spec.dataset
+158 | on_dataset_changed, on_dataset_created
     | ^^^^^^^^^^^^^^^^^^ AIR302
-158 |
-159 | # airflow.metrics.validators
+159 |
+160 | # airflow.metrics.validators
     |
     = help: Use `airflow.listeners.spec.asset.on_asset_changed` instead
 
-AIR302_names.py:157:21: AIR302 `airflow.listeners.spec.dataset.on_dataset_created` is removed in Airflow 3.0
+AIR302_names.py:158:21: AIR302 `airflow.listeners.spec.dataset.on_dataset_created` is removed in Airflow 3.0
     |
-156 | # airflow.listeners.spec.dataset
-157 | on_dataset_changed, on_dataset_created
+157 | # airflow.listeners.spec.dataset
+158 | on_dataset_changed, on_dataset_created
     |                     ^^^^^^^^^^^^^^^^^^ AIR302
-158 |
-159 | # airflow.metrics.validators
+159 |
+160 | # airflow.metrics.validators
     |
     = help: Use `airflow.listeners.spec.asset.on_asset_created` instead
 
-AIR302_names.py:160:1: AIR302 `airflow.metrics.validators.AllowListValidator` is removed in Airflow 3.0
+AIR302_names.py:161:1: AIR302 `airflow.metrics.validators.AllowListValidator` is removed in Airflow 3.0
     |
-159 | # airflow.metrics.validators
-160 | AllowListValidator(), BlockListValidator()
+160 | # airflow.metrics.validators
+161 | AllowListValidator(), BlockListValidator()
     | ^^^^^^^^^^^^^^^^^^ AIR302
-161 |
-162 | # airflow.operators.dummy_operator
+162 |
+163 | # airflow.operators.dummy_operator
     |
     = help: Use `airflow.metrics.validators.PatternAllowListValidator` instead
 
-AIR302_names.py:160:23: AIR302 `airflow.metrics.validators.BlockListValidator` is removed in Airflow 3.0
+AIR302_names.py:161:23: AIR302 `airflow.metrics.validators.BlockListValidator` is removed in Airflow 3.0
     |
-159 | # airflow.metrics.validators
-160 | AllowListValidator(), BlockListValidator()
+160 | # airflow.metrics.validators
+161 | AllowListValidator(), BlockListValidator()
     |                       ^^^^^^^^^^^^^^^^^^ AIR302
-161 |
-162 | # airflow.operators.dummy_operator
+162 |
+163 | # airflow.operators.dummy_operator
     |
     = help: Use `airflow.metrics.validators.PatternBlockListValidator` instead
 
-AIR302_names.py:163:16: AIR302 `airflow.operators.dummy_operator.EmptyOperator` is removed in Airflow 3.0
+AIR302_names.py:164:16: AIR302 `airflow.operators.dummy_operator.EmptyOperator` is removed in Airflow 3.0
     |
-162 | # airflow.operators.dummy_operator
-163 | dummy_operator.EmptyOperator()
+163 | # airflow.operators.dummy_operator
+164 | dummy_operator.EmptyOperator()
     |                ^^^^^^^^^^^^^ AIR302
-164 | dummy_operator.DummyOperator()
+165 | dummy_operator.DummyOperator()
     |
     = help: Use `airflow.operators.empty.EmptyOperator` instead
 
-AIR302_names.py:164:16: AIR302 `airflow.operators.dummy_operator.DummyOperator` is removed in Airflow 3.0
+AIR302_names.py:165:16: AIR302 `airflow.operators.dummy_operator.DummyOperator` is removed in Airflow 3.0
     |
-162 | # airflow.operators.dummy_operator
-163 | dummy_operator.EmptyOperator()
-164 | dummy_operator.DummyOperator()
+163 | # airflow.operators.dummy_operator
+164 | dummy_operator.EmptyOperator()
+165 | dummy_operator.DummyOperator()
     |                ^^^^^^^^^^^^^ AIR302
-165 |
-166 | # airflow.operators.bash_operator
+166 |
+167 | # airflow.operators.bash_operator
     |
     = help: Use `airflow.operators.empty.EmptyOperator` instead
 
-AIR302_names.py:167:1: AIR302 `airflow.operators.bash_operator.BashOperator` is removed in Airflow 3.0
+AIR302_names.py:168:1: AIR302 `airflow.operators.bash_operator.BashOperator` is removed in Airflow 3.0
     |
-166 | # airflow.operators.bash_operator
-167 | BashOperator()
+167 | # airflow.operators.bash_operator
+168 | BashOperator()
     | ^^^^^^^^^^^^ AIR302
-168 |
-169 | # airflow.operators.branch_operator
+169 |
+170 | # airflow.operators.branch_operator
     |
     = help: Use `airflow.operators.bash.BashOperator` instead
 
-AIR302_names.py:170:1: AIR302 `airflow.operators.branch_operator.BaseBranchOperator` is removed in Airflow 3.0
+AIR302_names.py:171:1: AIR302 `airflow.operators.branch_operator.BaseBranchOperator` is removed in Airflow 3.0
     |
-169 | # airflow.operators.branch_operator
-170 | BaseBranchOperator()
+170 | # airflow.operators.branch_operator
+171 | BaseBranchOperator()
     | ^^^^^^^^^^^^^^^^^^ AIR302
-171 |
-172 | # airflow.operators.dagrun_operator
+172 |
+173 | # airflow.operators.dagrun_operator
     |
     = help: Use `airflow.operators.branch.BaseBranchOperator` instead
 
-AIR302_names.py:173:1: AIR302 `airflow.operators.dagrun_operator.TriggerDagRunLink` is removed in Airflow 3.0
+AIR302_names.py:174:1: AIR302 `airflow.operators.dagrun_operator.TriggerDagRunLink` is removed in Airflow 3.0
     |
-172 | # airflow.operators.dagrun_operator
-173 | TriggerDagRunLink()
+173 | # airflow.operators.dagrun_operator
+174 | TriggerDagRunLink()
     | ^^^^^^^^^^^^^^^^^ AIR302
-174 | TriggerDagRunOperator()
+175 | TriggerDagRunOperator()
     |
     = help: Use `airflow.operators.trigger_dagrun.TriggerDagRunLink` instead
 
-AIR302_names.py:174:1: AIR302 `airflow.operators.dagrun_operator.TriggerDagRunOperator` is removed in Airflow 3.0
+AIR302_names.py:175:1: AIR302 `airflow.operators.dagrun_operator.TriggerDagRunOperator` is removed in Airflow 3.0
     |
-172 | # airflow.operators.dagrun_operator
-173 | TriggerDagRunLink()
-174 | TriggerDagRunOperator()
+173 | # airflow.operators.dagrun_operator
+174 | TriggerDagRunLink()
+175 | TriggerDagRunOperator()
     | ^^^^^^^^^^^^^^^^^^^^^ AIR302
-175 |
-176 | # airflow.operators.dummy
+176 |
+177 | # airflow.operators.dummy
     |
     = help: Use `airflow.operators.trigger_dagrun.TriggerDagRunOperator` instead
 
-AIR302_names.py:177:18: AIR302 `airflow.operators.dummy.DummyOperator` is removed in Airflow 3.0
+AIR302_names.py:178:18: AIR302 `airflow.operators.dummy.DummyOperator` is removed in Airflow 3.0
     |
-176 | # airflow.operators.dummy
-177 | EmptyOperator(), DummyOperator()
+177 | # airflow.operators.dummy
+178 | EmptyOperator(), DummyOperator()
     |                  ^^^^^^^^^^^^^ AIR302
-178 |
-179 | # airflow.operators.email_operator
+179 |
+180 | # airflow.operators.email_operator
     |
     = help: Use `airflow.operators.empty.EmptyOperator` instead
 
-AIR302_names.py:180:1: AIR302 `airflow.operators.email_operator.EmailOperator` is removed in Airflow 3.0
+AIR302_names.py:181:1: AIR302 `airflow.operators.email_operator.EmailOperator` is removed in Airflow 3.0
     |
-179 | # airflow.operators.email_operator
-180 | EmailOperator()
+180 | # airflow.operators.email_operator
+181 | EmailOperator()
     | ^^^^^^^^^^^^^ AIR302
-181 |
-182 | # airflow.operators.latest_only_operator
+182 |
+183 | # airflow.operators.latest_only_operator
     |
     = help: Use `airflow.operators.email.EmailOperator` instead
 
-AIR302_names.py:183:1: AIR302 `airflow.operators.latest_only_operator.LatestOnlyOperator` is removed in Airflow 3.0
+AIR302_names.py:184:1: AIR302 `airflow.operators.latest_only_operator.LatestOnlyOperator` is removed in Airflow 3.0
     |
-182 | # airflow.operators.latest_only_operator
-183 | LatestOnlyOperator()
+183 | # airflow.operators.latest_only_operator
+184 | LatestOnlyOperator()
     | ^^^^^^^^^^^^^^^^^^ AIR302
-184 |
-185 | # airflow.operators.python_operator
+185 |
+186 | # airflow.operators.python_operator
     |
     = help: Use `airflow.operators.latest_only.LatestOnlyOperator` instead
 
-AIR302_names.py:186:1: AIR302 `airflow.operators.python_operator.BranchPythonOperator` is removed in Airflow 3.0
+AIR302_names.py:187:1: AIR302 `airflow.operators.python_operator.BranchPythonOperator` is removed in Airflow 3.0
     |
-185 | # airflow.operators.python_operator
-186 | BranchPythonOperator()
+186 | # airflow.operators.python_operator
+187 | BranchPythonOperator()
     | ^^^^^^^^^^^^^^^^^^^^ AIR302
-187 | PythonOperator()
-188 | PythonVirtualenvOperator()
+188 | PythonOperator()
+189 | PythonVirtualenvOperator()
     |
     = help: Use `airflow.operators.python.BranchPythonOperator` instead
 
-AIR302_names.py:187:1: AIR302 `airflow.operators.python_operator.PythonOperator` is removed in Airflow 3.0
+AIR302_names.py:188:1: AIR302 `airflow.operators.python_operator.PythonOperator` is removed in Airflow 3.0
     |
-185 | # airflow.operators.python_operator
-186 | BranchPythonOperator()
-187 | PythonOperator()
+186 | # airflow.operators.python_operator
+187 | BranchPythonOperator()
+188 | PythonOperator()
     | ^^^^^^^^^^^^^^ AIR302
-188 | PythonVirtualenvOperator()
-189 | ShortCircuitOperator()
+189 | PythonVirtualenvOperator()
+190 | ShortCircuitOperator()
     |
     = help: Use `airflow.operators.python.PythonOperator` instead
 
-AIR302_names.py:188:1: AIR302 `airflow.operators.python_operator.PythonVirtualenvOperator` is removed in Airflow 3.0
+AIR302_names.py:189:1: AIR302 `airflow.operators.python_operator.PythonVirtualenvOperator` is removed in Airflow 3.0
     |
-186 | BranchPythonOperator()
-187 | PythonOperator()
-188 | PythonVirtualenvOperator()
+187 | BranchPythonOperator()
+188 | PythonOperator()
+189 | PythonVirtualenvOperator()
     | ^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
-189 | ShortCircuitOperator()
+190 | ShortCircuitOperator()
     |
     = help: Use `airflow.operators.python.PythonVirtualenvOperator` instead
 
-AIR302_names.py:189:1: AIR302 `airflow.operators.python_operator.ShortCircuitOperator` is removed in Airflow 3.0
+AIR302_names.py:190:1: AIR302 `airflow.operators.python_operator.ShortCircuitOperator` is removed in Airflow 3.0
     |
-187 | PythonOperator()
-188 | PythonVirtualenvOperator()
-189 | ShortCircuitOperator()
+188 | PythonOperator()
+189 | PythonVirtualenvOperator()
+190 | ShortCircuitOperator()
     | ^^^^^^^^^^^^^^^^^^^^ AIR302
-190 |
-191 | # airflow.operators.subdag.*
+191 |
+192 | # airflow.operators.subdag.*
     |
     = help: Use `airflow.operators.python.ShortCircuitOperator` instead
 
-AIR302_names.py:192:1: AIR302 `airflow.operators.subdag.SubDagOperator` is removed in Airflow 3.0; The whole `airflow.subdag` module has been removed.
+AIR302_names.py:193:1: AIR302 `airflow.operators.subdag.SubDagOperator` is removed in Airflow 3.0; The whole `airflow.subdag` module has been removed.
     |
-191 | # airflow.operators.subdag.*
-192 | SubDagOperator()
+192 | # airflow.operators.subdag.*
+193 | SubDagOperator()
     | ^^^^^^^^^^^^^^ AIR302
-193 |
-194 | # airflow.providers.amazon
+194 |
+195 | # airflow.providers.amazon
     |
 
-AIR302_names.py:195:13: AIR302 `airflow.providers.amazon.auth_manager.avp.entities.AvpEntities.DATASET` is removed in Airflow 3.0
+AIR302_names.py:196:13: AIR302 `airflow.providers.amazon.auth_manager.avp.entities.AvpEntities.DATASET` is removed in Airflow 3.0
     |
-194 | # airflow.providers.amazon
-195 | AvpEntities.DATASET
+195 | # airflow.providers.amazon
+196 | AvpEntities.DATASET
     |             ^^^^^^^ AIR302
-196 | s3.create_dataset
-197 | s3.convert_dataset_to_openlineage
+197 | s3.create_dataset
+198 | s3.convert_dataset_to_openlineage
     |
     = help: Use `airflow.providers.amazon.auth_manager.avp.entities.AvpEntities.ASSET` instead
 
-AIR302_names.py:196:4: AIR302 `airflow.providers.amazon.aws.datasets.s3.create_dataset` is removed in Airflow 3.0
+AIR302_names.py:197:4: AIR302 `airflow.providers.amazon.aws.datasets.s3.create_dataset` is removed in Airflow 3.0
     |
-194 | # airflow.providers.amazon
-195 | AvpEntities.DATASET
-196 | s3.create_dataset
+195 | # airflow.providers.amazon
+196 | AvpEntities.DATASET
+197 | s3.create_dataset
     |    ^^^^^^^^^^^^^^ AIR302
-197 | s3.convert_dataset_to_openlineage
-198 | s3.sanitize_uri
+198 | s3.convert_dataset_to_openlineage
+199 | s3.sanitize_uri
     |
     = help: Use `airflow.providers.amazon.aws.assets.s3.create_asset` instead
 
-AIR302_names.py:197:4: AIR302 `airflow.providers.amazon.aws.datasets.s3.convert_dataset_to_openlineage` is removed in Airflow 3.0
+AIR302_names.py:198:4: AIR302 `airflow.providers.amazon.aws.datasets.s3.convert_dataset_to_openlineage` is removed in Airflow 3.0
     |
-195 | AvpEntities.DATASET
-196 | s3.create_dataset
-197 | s3.convert_dataset_to_openlineage
+196 | AvpEntities.DATASET
+197 | s3.create_dataset
+198 | s3.convert_dataset_to_openlineage
     |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
-198 | s3.sanitize_uri
+199 | s3.sanitize_uri
     |
     = help: Use `airflow.providers.amazon.aws.assets.s3.convert_asset_to_openlineage` instead
 
-AIR302_names.py:198:4: AIR302 `airflow.providers.amazon.aws.datasets.s3.sanitize_uri` is removed in Airflow 3.0
+AIR302_names.py:199:4: AIR302 `airflow.providers.amazon.aws.datasets.s3.sanitize_uri` is removed in Airflow 3.0
     |
-196 | s3.create_dataset
-197 | s3.convert_dataset_to_openlineage
-198 | s3.sanitize_uri
+197 | s3.create_dataset
+198 | s3.convert_dataset_to_openlineage
+199 | s3.sanitize_uri
     |    ^^^^^^^^^^^^ AIR302
-199 |
-200 | # airflow.providers.common.io
+200 |
+201 | # airflow.providers.common.io
     |
     = help: Use `airflow.providers.amazon.aws.assets.s3.sanitize_uri` instead
 
-AIR302_names.py:201:16: AIR302 `airflow.providers.common.io.datasets.file.convert_dataset_to_openlineage` is removed in Airflow 3.0
+AIR302_names.py:202:16: AIR302 `airflow.providers.common.io.datasets.file.convert_dataset_to_openlineage` is removed in Airflow 3.0
     |
-200 | # airflow.providers.common.io
-201 | common_io_file.convert_dataset_to_openlineage
+201 | # airflow.providers.common.io
+202 | common_io_file.convert_dataset_to_openlineage
     |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
-202 | common_io_file.create_dataset
-203 | common_io_file.sanitize_uri
+203 | common_io_file.create_dataset
+204 | common_io_file.sanitize_uri
     |
     = help: Use `airflow.providers.common.io.assets.file.convert_asset_to_openlineage` instead
 
-AIR302_names.py:202:16: AIR302 `airflow.providers.common.io.datasets.file.create_dataset` is removed in Airflow 3.0
+AIR302_names.py:203:16: AIR302 `airflow.providers.common.io.datasets.file.create_dataset` is removed in Airflow 3.0
     |
-200 | # airflow.providers.common.io
-201 | common_io_file.convert_dataset_to_openlineage
-202 | common_io_file.create_dataset
+201 | # airflow.providers.common.io
+202 | common_io_file.convert_dataset_to_openlineage
+203 | common_io_file.create_dataset
     |                ^^^^^^^^^^^^^^ AIR302
-203 | common_io_file.sanitize_uri
+204 | common_io_file.sanitize_uri
     |
     = help: Use `airflow.providers.common.io.assets.file.create_asset` instead
 
-AIR302_names.py:203:16: AIR302 `airflow.providers.common.io.datasets.file.sanitize_uri` is removed in Airflow 3.0
+AIR302_names.py:204:16: AIR302 `airflow.providers.common.io.datasets.file.sanitize_uri` is removed in Airflow 3.0
     |
-201 | common_io_file.convert_dataset_to_openlineage
-202 | common_io_file.create_dataset
-203 | common_io_file.sanitize_uri
+202 | common_io_file.convert_dataset_to_openlineage
+203 | common_io_file.create_dataset
+204 | common_io_file.sanitize_uri
     |                ^^^^^^^^^^^^ AIR302
-204 |
-205 | # airflow.providers.fab
+205 |
+206 | # airflow.providers.fab
     |
     = help: Use `airflow.providers.common.io.assets.file.sanitize_uri` instead
 
-AIR302_names.py:206:18: AIR302 `airflow.providers.fab.auth_manager.fab_auth_manager.is_authorized_dataset` is removed in Airflow 3.0
+AIR302_names.py:207:18: AIR302 `airflow.providers.fab.auth_manager.fab_auth_manager.is_authorized_dataset` is removed in Airflow 3.0
     |
-205 | # airflow.providers.fab
-206 | fab_auth_manager.is_authorized_dataset
+206 | # airflow.providers.fab
+207 | fab_auth_manager.is_authorized_dataset
     |                  ^^^^^^^^^^^^^^^^^^^^^ AIR302
-207 |
-208 | # airflow.providers.google
+208 |
+209 | # airflow.providers.google
     |
     = help: Use `airflow.providers.fab.auth_manager.fab_auth_manager.is_authorized_asset` instead
 
-AIR302_names.py:211:5: AIR302 `airflow.providers.google.datasets.gcs.create_dataset` is removed in Airflow 3.0
+AIR302_names.py:212:5: AIR302 `airflow.providers.google.datasets.gcs.create_dataset` is removed in Airflow 3.0
     |
-209 | bigquery.sanitize_uri
-210 |
-211 | gcs.create_dataset
+210 | bigquery.sanitize_uri
+211 |
+212 | gcs.create_dataset
     |     ^^^^^^^^^^^^^^ AIR302
-212 | gcs.sanitize_uri
-213 | gcs.convert_dataset_to_openlineage
+213 | gcs.sanitize_uri
+214 | gcs.convert_dataset_to_openlineage
     |
     = help: Use `airflow.providers.google.assets.gcs.create_asset` instead
 
-AIR302_names.py:212:5: AIR302 `airflow.providers.google.datasets.gcs.sanitize_uri` is removed in Airflow 3.0
+AIR302_names.py:213:5: AIR302 `airflow.providers.google.datasets.gcs.sanitize_uri` is removed in Airflow 3.0
     |
-211 | gcs.create_dataset
-212 | gcs.sanitize_uri
+212 | gcs.create_dataset
+213 | gcs.sanitize_uri
     |     ^^^^^^^^^^^^ AIR302
-213 | gcs.convert_dataset_to_openlineage
+214 | gcs.convert_dataset_to_openlineage
     |
     = help: Use `airflow.providers.google.assets.gcs.sanitize_uri` instead
 
-AIR302_names.py:213:5: AIR302 `airflow.providers.google.datasets.gcs.convert_dataset_to_openlineage` is removed in Airflow 3.0
+AIR302_names.py:214:5: AIR302 `airflow.providers.google.datasets.gcs.convert_dataset_to_openlineage` is removed in Airflow 3.0
     |
-211 | gcs.create_dataset
-212 | gcs.sanitize_uri
-213 | gcs.convert_dataset_to_openlineage
+212 | gcs.create_dataset
+213 | gcs.sanitize_uri
+214 | gcs.convert_dataset_to_openlineage
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
-214 |
-215 | # airflow.providers.mysql
+215 |
+216 | # airflow.providers.mysql
     |
     = help: Use `airflow.providers.google.assets.gcs.convert_asset_to_openlineage` instead
 
-AIR302_names.py:216:7: AIR302 `airflow.providers.mysql.datasets.mysql.sanitize_uri` is removed in Airflow 3.0
+AIR302_names.py:217:7: AIR302 `airflow.providers.mysql.datasets.mysql.sanitize_uri` is removed in Airflow 3.0
     |
-215 | # airflow.providers.mysql
-216 | mysql.sanitize_uri
+216 | # airflow.providers.mysql
+217 | mysql.sanitize_uri
     |       ^^^^^^^^^^^^ AIR302
-217 |
-218 | # airflow.providers.openlineage
+218 |
+219 | # airflow.providers.openlineage
     |
     = help: Use `airflow.providers.mysql.assets.mysql.sanitize_uri` instead
 
-AIR302_names.py:219:1: AIR302 `airflow.providers.openlineage.utils.utils.DatasetInfo` is removed in Airflow 3.0
+AIR302_names.py:220:1: AIR302 `airflow.providers.openlineage.utils.utils.DatasetInfo` is removed in Airflow 3.0
     |
-218 | # airflow.providers.openlineage
-219 | DatasetInfo(), translate_airflow_dataset
+219 | # airflow.providers.openlineage
+220 | DatasetInfo(), translate_airflow_dataset
     | ^^^^^^^^^^^ AIR302
-220 |
-221 | # airflow.providers.postgres
+221 |
+222 | # airflow.providers.postgres
     |
     = help: Use `airflow.providers.openlineage.utils.utils.AssetInfo` instead
 
-AIR302_names.py:219:16: AIR302 `airflow.providers.openlineage.utils.utils.translate_airflow_dataset` is removed in Airflow 3.0
+AIR302_names.py:220:16: AIR302 `airflow.providers.openlineage.utils.utils.translate_airflow_dataset` is removed in Airflow 3.0
     |
-218 | # airflow.providers.openlineage
-219 | DatasetInfo(), translate_airflow_dataset
+219 | # airflow.providers.openlineage
+220 | DatasetInfo(), translate_airflow_dataset
     |                ^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
-220 |
-221 | # airflow.providers.postgres
+221 |
+222 | # airflow.providers.postgres
     |
     = help: Use `airflow.providers.openlineage.utils.utils.translate_airflow_asset` instead
 
-AIR302_names.py:222:10: AIR302 `airflow.providers.postgres.datasets.postgres.sanitize_uri` is removed in Airflow 3.0
+AIR302_names.py:223:10: AIR302 `airflow.providers.postgres.datasets.postgres.sanitize_uri` is removed in Airflow 3.0
     |
-221 | # airflow.providers.postgres
-222 | postgres.sanitize_uri
+222 | # airflow.providers.postgres
+223 | postgres.sanitize_uri
     |          ^^^^^^^^^^^^ AIR302
-223 |
-224 | # airflow.providers.trino
+224 |
+225 | # airflow.providers.trino
     |
     = help: Use `airflow.providers.postgres.assets.postgres.sanitize_uri` instead
 
-AIR302_names.py:225:7: AIR302 `airflow.providers.trino.datasets.trino.sanitize_uri` is removed in Airflow 3.0
+AIR302_names.py:226:7: AIR302 `airflow.providers.trino.datasets.trino.sanitize_uri` is removed in Airflow 3.0
     |
-224 | # airflow.providers.trino
-225 | trino.sanitize_uri
+225 | # airflow.providers.trino
+226 | trino.sanitize_uri
     |       ^^^^^^^^^^^^ AIR302
-226 |
-227 | # airflow.secrets
+227 |
+228 | # airflow.secrets
     |
     = help: Use `airflow.providers.trino.assets.trino.sanitize_uri` instead
 
-AIR302_names.py:228:1: AIR302 `airflow.secrets.local_filesystem.get_connection` is removed in Airflow 3.0
+AIR302_names.py:231:5: AIR302 `get_connections` is removed in Airflow 3.0
     |
-227 | # airflow.secrets
-228 | get_connection, load_connections
-    | ^^^^^^^^^^^^^^ AIR302
-229 |
-230 | # airflow.security.permissions
+229 | # get_connection
+230 | lfb = LocalFilesystemBackend()
+231 | lfb.get_connections()
+    |     ^^^^^^^^^^^^^^^ AIR302
+232 | load_connections
     |
-    = help: Use `airflow.secrets.local_filesystem.load_connections_dict` instead
+    = help: Use `get_connection` instead
 
-AIR302_names.py:228:17: AIR302 `airflow.secrets.local_filesystem.load_connections` is removed in Airflow 3.0
+AIR302_names.py:232:1: AIR302 `airflow.secrets.local_filesystem.load_connections` is removed in Airflow 3.0
     |
-227 | # airflow.secrets
-228 | get_connection, load_connections
-    |                 ^^^^^^^^^^^^^^^^ AIR302
-229 |
-230 | # airflow.security.permissions
-    |
-    = help: Use `airflow.secrets.local_filesystem.load_connections_dict` instead
-
-AIR302_names.py:231:1: AIR302 `airflow.security.permissions.RESOURCE_DATASET` is removed in Airflow 3.0
-    |
-230 | # airflow.security.permissions
-231 | RESOURCE_DATASET
+230 | lfb = LocalFilesystemBackend()
+231 | lfb.get_connections()
+232 | load_connections
     | ^^^^^^^^^^^^^^^^ AIR302
-232 |
-233 | # airflow.sensors.base_sensor_operator
+233 |
+234 | # airflow.security.permissions
+    |
+    = help: Use `airflow.secrets.local_filesystem.load_connections_dict` instead
+
+AIR302_names.py:235:1: AIR302 `airflow.security.permissions.RESOURCE_DATASET` is removed in Airflow 3.0
+    |
+234 | # airflow.security.permissions
+235 | RESOURCE_DATASET
+    | ^^^^^^^^^^^^^^^^ AIR302
+236 |
+237 | # airflow.sensors.base_sensor_operator
     |
     = help: Use `airflow.security.permissions.RESOURCE_ASSET` instead
 
-AIR302_names.py:234:1: AIR302 `airflow.sensors.base_sensor_operator.BaseSensorOperator` is removed in Airflow 3.0
+AIR302_names.py:238:1: AIR302 `airflow.sensors.base_sensor_operator.BaseSensorOperator` is removed in Airflow 3.0
     |
-233 | # airflow.sensors.base_sensor_operator
-234 | BaseSensorOperator()
+237 | # airflow.sensors.base_sensor_operator
+238 | BaseSensorOperator()
     | ^^^^^^^^^^^^^^^^^^ AIR302
-235 |
-236 | # airflow.sensors.date_time_sensor
+239 |
+240 | # airflow.sensors.date_time_sensor
     |
     = help: Use `airflow.sensors.base.BaseSensorOperator` instead
 
-AIR302_names.py:237:1: AIR302 `airflow.sensors.date_time_sensor.DateTimeSensor` is removed in Airflow 3.0
+AIR302_names.py:241:1: AIR302 `airflow.sensors.date_time_sensor.DateTimeSensor` is removed in Airflow 3.0
     |
-236 | # airflow.sensors.date_time_sensor
-237 | DateTimeSensor()
+240 | # airflow.sensors.date_time_sensor
+241 | DateTimeSensor()
     | ^^^^^^^^^^^^^^ AIR302
-238 |
-239 | # airflow.sensors.external_task
+242 |
+243 | # airflow.sensors.external_task
     |
     = help: Use `airflow.sensors.date_time.DateTimeSensor` instead
 
-AIR302_names.py:240:1: AIR302 `airflow.sensors.external_task.ExternalTaskSensorLink` is removed in Airflow 3.0
+AIR302_names.py:244:1: AIR302 `airflow.sensors.external_task.ExternalTaskSensorLink` is removed in Airflow 3.0
     |
-239 | # airflow.sensors.external_task
-240 | ExternalTaskSensorLinkFromExternalTask()
+243 | # airflow.sensors.external_task
+244 | ExternalTaskSensorLinkFromExternalTask()
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
-241 |
-242 | # airflow.sensors.external_task_sensor
+245 |
+246 | # airflow.sensors.external_task_sensor
     |
     = help: Use `airflow.sensors.external_task.ExternalDagLink` instead
 
-AIR302_names.py:243:1: AIR302 `airflow.sensors.external_task_sensor.ExternalTaskMarker` is removed in Airflow 3.0
+AIR302_names.py:247:1: AIR302 `airflow.sensors.external_task_sensor.ExternalTaskMarker` is removed in Airflow 3.0
     |
-242 | # airflow.sensors.external_task_sensor
-243 | ExternalTaskMarker()
+246 | # airflow.sensors.external_task_sensor
+247 | ExternalTaskMarker()
     | ^^^^^^^^^^^^^^^^^^ AIR302
-244 | ExternalTaskSensor()
-245 | ExternalTaskSensorLinkFromExternalTaskSensor()
+248 | ExternalTaskSensor()
+249 | ExternalTaskSensorLinkFromExternalTaskSensor()
     |
     = help: Use `airflow.sensors.external_task.ExternalTaskMarker` instead
 
-AIR302_names.py:244:1: AIR302 `airflow.sensors.external_task_sensor.ExternalTaskSensor` is removed in Airflow 3.0
+AIR302_names.py:248:1: AIR302 `airflow.sensors.external_task_sensor.ExternalTaskSensor` is removed in Airflow 3.0
     |
-242 | # airflow.sensors.external_task_sensor
-243 | ExternalTaskMarker()
-244 | ExternalTaskSensor()
+246 | # airflow.sensors.external_task_sensor
+247 | ExternalTaskMarker()
+248 | ExternalTaskSensor()
     | ^^^^^^^^^^^^^^^^^^ AIR302
-245 | ExternalTaskSensorLinkFromExternalTaskSensor()
+249 | ExternalTaskSensorLinkFromExternalTaskSensor()
     |
     = help: Use `airflow.sensors.external_task.ExternalTaskSensor` instead
 
-AIR302_names.py:245:1: AIR302 `airflow.sensors.external_task_sensor.ExternalTaskSensorLink` is removed in Airflow 3.0
+AIR302_names.py:249:1: AIR302 `airflow.sensors.external_task_sensor.ExternalTaskSensorLink` is removed in Airflow 3.0
     |
-243 | ExternalTaskMarker()
-244 | ExternalTaskSensor()
-245 | ExternalTaskSensorLinkFromExternalTaskSensor()
+247 | ExternalTaskMarker()
+248 | ExternalTaskSensor()
+249 | ExternalTaskSensorLinkFromExternalTaskSensor()
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
-246 |
-247 | # airflow.sensors.time_delta_sensor
+250 |
+251 | # airflow.sensors.time_delta_sensor
     |
     = help: Use `airflow.sensors.external_task.ExternalDagLink` instead
 
-AIR302_names.py:248:1: AIR302 `airflow.sensors.time_delta_sensor.TimeDeltaSensor` is removed in Airflow 3.0
+AIR302_names.py:252:1: AIR302 `airflow.sensors.time_delta_sensor.TimeDeltaSensor` is removed in Airflow 3.0
     |
-247 | # airflow.sensors.time_delta_sensor
-248 | TimeDeltaSensor()
+251 | # airflow.sensors.time_delta_sensor
+252 | TimeDeltaSensor()
     | ^^^^^^^^^^^^^^^ AIR302
-249 |
-250 | # airflow.timetables
+253 |
+254 | # airflow.timetables
     |
     = help: Use `airflow.sensors.time_delta.TimeDeltaSensor` instead
 
-AIR302_names.py:251:1: AIR302 `airflow.timetables.datasets.DatasetOrTimeSchedule` is removed in Airflow 3.0
+AIR302_names.py:255:1: AIR302 `airflow.timetables.datasets.DatasetOrTimeSchedule` is removed in Airflow 3.0
     |
-250 | # airflow.timetables
-251 | DatasetOrTimeSchedule()
+254 | # airflow.timetables
+255 | DatasetOrTimeSchedule()
     | ^^^^^^^^^^^^^^^^^^^^^ AIR302
-252 | DatasetTriggeredTimetable()
+256 | DatasetTriggeredTimetable()
     |
     = help: Use `airflow.timetables.assets.AssetOrTimeSchedule` instead
 
-AIR302_names.py:252:1: AIR302 `airflow.timetables.simple.DatasetTriggeredTimetable` is removed in Airflow 3.0
+AIR302_names.py:256:1: AIR302 `airflow.timetables.simple.DatasetTriggeredTimetable` is removed in Airflow 3.0
     |
-250 | # airflow.timetables
-251 | DatasetOrTimeSchedule()
-252 | DatasetTriggeredTimetable()
+254 | # airflow.timetables
+255 | DatasetOrTimeSchedule()
+256 | DatasetTriggeredTimetable()
     | ^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
-253 |
-254 | # airflow.triggers.external_task
+257 |
+258 | # airflow.triggers.external_task
     |
     = help: Use `airflow.timetables.simple.AssetTriggeredTimetable` instead
 
-AIR302_names.py:255:1: AIR302 `airflow.triggers.external_task.TaskStateTrigger` is removed in Airflow 3.0
+AIR302_names.py:259:1: AIR302 `airflow.triggers.external_task.TaskStateTrigger` is removed in Airflow 3.0
     |
-254 | # airflow.triggers.external_task
-255 | TaskStateTrigger()
+258 | # airflow.triggers.external_task
+259 | TaskStateTrigger()
     | ^^^^^^^^^^^^^^^^ AIR302
-256 |
-257 | # airflow.utils.date
+260 |
+261 | # airflow.utils.date
     |
 
-AIR302_names.py:258:7: AIR302 `airflow.utils.dates.date_range` is removed in Airflow 3.0
+AIR302_names.py:262:7: AIR302 `airflow.utils.dates.date_range` is removed in Airflow 3.0
     |
-257 | # airflow.utils.date
-258 | dates.date_range
+261 | # airflow.utils.date
+262 | dates.date_range
     |       ^^^^^^^^^^ AIR302
-259 | dates.days_ago
+263 | dates.days_ago
     |
-    = help: Use `airflow.timetables.` instead
 
-AIR302_names.py:259:7: AIR302 `airflow.utils.dates.days_ago` is removed in Airflow 3.0
+AIR302_names.py:263:7: AIR302 `airflow.utils.dates.days_ago` is removed in Airflow 3.0
     |
-257 | # airflow.utils.date
-258 | dates.date_range
-259 | dates.days_ago
+261 | # airflow.utils.date
+262 | dates.date_range
+263 | dates.days_ago
     |       ^^^^^^^^ AIR302
-260 |
-261 | date_range
+264 |
+265 | date_range
     |
     = help: Use `pendulum.today('UTC').add(days=-N, ...)` instead
 
-AIR302_names.py:261:1: AIR302 `airflow.utils.dates.date_range` is removed in Airflow 3.0
+AIR302_names.py:265:1: AIR302 `airflow.utils.dates.date_range` is removed in Airflow 3.0
     |
-259 | dates.days_ago
-260 |
-261 | date_range
+263 | dates.days_ago
+264 |
+265 | date_range
     | ^^^^^^^^^^ AIR302
-262 | days_ago
-263 | infer_time_unit
+266 | days_ago
+267 | infer_time_unit
     |
-    = help: Use `airflow.timetables.` instead
 
-AIR302_names.py:262:1: AIR302 `airflow.utils.dates.days_ago` is removed in Airflow 3.0
+AIR302_names.py:266:1: AIR302 `airflow.utils.dates.days_ago` is removed in Airflow 3.0
     |
-261 | date_range
-262 | days_ago
+265 | date_range
+266 | days_ago
     | ^^^^^^^^ AIR302
-263 | infer_time_unit
-264 | parse_execution_date
+267 | infer_time_unit
+268 | parse_execution_date
     |
     = help: Use `pendulum.today('UTC').add(days=-N, ...)` instead
 
-AIR302_names.py:263:1: AIR302 `airflow.utils.dates.infer_time_unit` is removed in Airflow 3.0
+AIR302_names.py:267:1: AIR302 `airflow.utils.dates.infer_time_unit` is removed in Airflow 3.0
     |
-261 | date_range
-262 | days_ago
-263 | infer_time_unit
+265 | date_range
+266 | days_ago
+267 | infer_time_unit
     | ^^^^^^^^^^^^^^^ AIR302
-264 | parse_execution_date
-265 | round_time
+268 | parse_execution_date
+269 | round_time
     |
 
-AIR302_names.py:264:1: AIR302 `airflow.utils.dates.parse_execution_date` is removed in Airflow 3.0
+AIR302_names.py:268:1: AIR302 `airflow.utils.dates.parse_execution_date` is removed in Airflow 3.0
     |
-262 | days_ago
-263 | infer_time_unit
-264 | parse_execution_date
+266 | days_ago
+267 | infer_time_unit
+268 | parse_execution_date
     | ^^^^^^^^^^^^^^^^^^^^ AIR302
-265 | round_time
-266 | scale_time_units
+269 | round_time
+270 | scale_time_units
     |
 
-AIR302_names.py:265:1: AIR302 `airflow.utils.dates.round_time` is removed in Airflow 3.0
+AIR302_names.py:269:1: AIR302 `airflow.utils.dates.round_time` is removed in Airflow 3.0
     |
-263 | infer_time_unit
-264 | parse_execution_date
-265 | round_time
+267 | infer_time_unit
+268 | parse_execution_date
+269 | round_time
     | ^^^^^^^^^^ AIR302
-266 | scale_time_units
+270 | scale_time_units
     |
 
-AIR302_names.py:266:1: AIR302 `airflow.utils.dates.scale_time_units` is removed in Airflow 3.0
+AIR302_names.py:270:1: AIR302 `airflow.utils.dates.scale_time_units` is removed in Airflow 3.0
     |
-264 | parse_execution_date
-265 | round_time
-266 | scale_time_units
+268 | parse_execution_date
+269 | round_time
+270 | scale_time_units
     | ^^^^^^^^^^^^^^^^ AIR302
-267 |
-268 | # This one was not deprecated.
+271 |
+272 | # This one was not deprecated.
     |
 
-AIR302_names.py:273:1: AIR302 `airflow.utils.dag_cycle_tester.test_cycle` is removed in Airflow 3.0
+AIR302_names.py:277:1: AIR302 `airflow.utils.dag_cycle_tester.test_cycle` is removed in Airflow 3.0
     |
-272 | # airflow.utils.dag_cycle_tester
-273 | test_cycle
+276 | # airflow.utils.dag_cycle_tester
+277 | test_cycle
     | ^^^^^^^^^^ AIR302
-274 |
-275 | # airflow.utils.decorators
+278 |
+279 | # airflow.utils.dag_parsing_context
     |
 
-AIR302_names.py:276:1: AIR302 `airflow.utils.decorators.apply_defaults` is removed in Airflow 3.0; `apply_defaults` is now unconditionally done and can be safely removed.
+AIR302_names.py:280:1: AIR302 `airflow.utils.dag_parsing_context.get_parsing_context` is removed in Airflow 3.0
     |
-275 | # airflow.utils.decorators
-276 | apply_defaults
+279 | # airflow.utils.dag_parsing_context
+280 | get_parsing_context
+    | ^^^^^^^^^^^^^^^^^^^ AIR302
+281 |
+282 | # airflow.utils.decorators
+    |
+    = help: Use `airflow.sdk.get_parsing_context` instead
+
+AIR302_names.py:283:1: AIR302 `airflow.utils.decorators.apply_defaults` is removed in Airflow 3.0; `apply_defaults` is now unconditionally done and can be safely removed.
+    |
+282 | # airflow.utils.decorators
+283 | apply_defaults
     | ^^^^^^^^^^^^^^ AIR302
-277 |
-278 | # airflow.utils.file
+284 |
+285 | # airflow.utils.file
     |
 
-AIR302_names.py:279:22: AIR302 `airflow.utils.file.mkdirs` is removed in Airflow 3.0
+AIR302_names.py:286:22: AIR302 `airflow.utils.file.mkdirs` is removed in Airflow 3.0
     |
-278 | # airflow.utils.file
-279 | TemporaryDirector(), mkdirs
+285 | # airflow.utils.file
+286 | TemporaryDirector(), mkdirs
     |                      ^^^^^^ AIR302
-280 |
-281 | #  airflow.utils.helpers
+287 |
+288 | #  airflow.utils.helpers
     |
     = help: Use `pendulum.today('UTC').add(days=-N, ...)` instead
 
-AIR302_names.py:282:1: AIR302 `airflow.utils.helpers.chain` is removed in Airflow 3.0
+AIR302_names.py:289:1: AIR302 `airflow.utils.helpers.chain` is removed in Airflow 3.0
     |
-281 | #  airflow.utils.helpers
-282 | chain, cross_downstream
+288 | #  airflow.utils.helpers
+289 | chain, cross_downstream
     | ^^^^^ AIR302
-283 |
-284 | # airflow.utils.state
+290 |
+291 | # airflow.utils.state
     |
     = help: Use `airflow.models.baseoperator.chain` instead
 
-AIR302_names.py:282:8: AIR302 `airflow.utils.helpers.cross_downstream` is removed in Airflow 3.0
+AIR302_names.py:289:8: AIR302 `airflow.utils.helpers.cross_downstream` is removed in Airflow 3.0
     |
-281 | #  airflow.utils.helpers
-282 | chain, cross_downstream
+288 | #  airflow.utils.helpers
+289 | chain, cross_downstream
     |        ^^^^^^^^^^^^^^^^ AIR302
-283 |
-284 | # airflow.utils.state
+290 |
+291 | # airflow.utils.state
     |
     = help: Use `airflow.models.baseoperator.cross_downstream` instead
 
-AIR302_names.py:285:1: AIR302 `airflow.utils.state.SHUTDOWN` is removed in Airflow 3.0
+AIR302_names.py:292:1: AIR302 `airflow.utils.state.SHUTDOWN` is removed in Airflow 3.0
     |
-284 | # airflow.utils.state
-285 | SHUTDOWN, terminating_states
+291 | # airflow.utils.state
+292 | SHUTDOWN, terminating_states
     | ^^^^^^^^ AIR302
-286 |
-287 | #  airflow.utils.trigger_rule
+293 |
+294 | #  airflow.utils.trigger_rule
     |
 
-AIR302_names.py:285:11: AIR302 `airflow.utils.state.terminating_states` is removed in Airflow 3.0
+AIR302_names.py:292:11: AIR302 `airflow.utils.state.terminating_states` is removed in Airflow 3.0
     |
-284 | # airflow.utils.state
-285 | SHUTDOWN, terminating_states
+291 | # airflow.utils.state
+292 | SHUTDOWN, terminating_states
     |           ^^^^^^^^^^^^^^^^^^ AIR302
-286 |
-287 | #  airflow.utils.trigger_rule
+293 |
+294 | #  airflow.utils.trigger_rule
     |
 
-AIR302_names.py:288:13: AIR302 `airflow.utils.trigger_rule.TriggerRule.DUMMY` is removed in Airflow 3.0
+AIR302_names.py:295:13: AIR302 `airflow.utils.trigger_rule.TriggerRule.DUMMY` is removed in Airflow 3.0
     |
-287 | #  airflow.utils.trigger_rule
-288 | TriggerRule.DUMMY
+294 | #  airflow.utils.trigger_rule
+295 | TriggerRule.DUMMY
     |             ^^^^^ AIR302
-289 | TriggerRule.NONE_FAILED_OR_SKIPPED
+296 | TriggerRule.NONE_FAILED_OR_SKIPPED
     |
 
-AIR302_names.py:289:13: AIR302 `airflow.utils.trigger_rule.TriggerRule.NONE_FAILED_OR_SKIPPED` is removed in Airflow 3.0
+AIR302_names.py:296:13: AIR302 `airflow.utils.trigger_rule.TriggerRule.NONE_FAILED_OR_SKIPPED` is removed in Airflow 3.0
     |
-287 | #  airflow.utils.trigger_rule
-288 | TriggerRule.DUMMY
-289 | TriggerRule.NONE_FAILED_OR_SKIPPED
+294 | #  airflow.utils.trigger_rule
+295 | TriggerRule.DUMMY
+296 | TriggerRule.NONE_FAILED_OR_SKIPPED
     |             ^^^^^^^^^^^^^^^^^^^^^^ AIR302
-290 |
-291 | # airflow.www.auth
+297 |
+298 | # airflow.www.auth
     |
 
-AIR302_names.py:292:1: AIR302 `airflow.www.auth.has_access` is removed in Airflow 3.0
+AIR302_names.py:299:1: AIR302 `airflow.www.auth.has_access` is removed in Airflow 3.0
     |
-291 | # airflow.www.auth
-292 | has_access
+298 | # airflow.www.auth
+299 | has_access
     | ^^^^^^^^^^ AIR302
-293 | has_access_dataset
+300 | has_access_dataset
     |
     = help: Use `airflow.www.auth.has_access_*` instead
 
-AIR302_names.py:293:1: AIR302 `airflow.www.auth.has_access_dataset` is removed in Airflow 3.0
+AIR302_names.py:300:1: AIR302 `airflow.www.auth.has_access_dataset` is removed in Airflow 3.0
     |
-291 | # airflow.www.auth
-292 | has_access
-293 | has_access_dataset
+298 | # airflow.www.auth
+299 | has_access
+300 | has_access_dataset
     | ^^^^^^^^^^^^^^^^^^ AIR302
-294 |
-295 | # airflow.www.utils
+301 |
+302 | # airflow.www.utils
     |
     = help: Use `airflow.www.auth.has_access_dataset.has_access_asset` instead
 
-AIR302_names.py:296:1: AIR302 `airflow.www.utils.get_sensitive_variables_fields` is removed in Airflow 3.0
+AIR302_names.py:303:1: AIR302 `airflow.www.utils.get_sensitive_variables_fields` is removed in Airflow 3.0
     |
-295 | # airflow.www.utils
-296 | get_sensitive_variables_fields, should_hide_value_for_key
+302 | # airflow.www.utils
+303 | get_sensitive_variables_fields, should_hide_value_for_key
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
     |
     = help: Use `airflow.utils.log.secrets_masker.get_sensitive_variables_fields` instead
 
-AIR302_names.py:296:33: AIR302 `airflow.www.utils.should_hide_value_for_key` is removed in Airflow 3.0
+AIR302_names.py:303:33: AIR302 `airflow.www.utils.should_hide_value_for_key` is removed in Airflow 3.0
     |
-295 | # airflow.www.utils
-296 | get_sensitive_variables_fields, should_hide_value_for_key
+302 | # airflow.www.utils
+303 | get_sensitive_variables_fields, should_hide_value_for_key
     |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
     |
     = help: Use `airflow.utils.log.secrets_masker.should_hide_value_for_key` instead


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

* fix
    * `airflow.secrets.local_filesystem.get_connection` should be `airflow.secrets.local_filesystemLocalFilesystemBackend.get_connection` → `airflow.secrets.local_filesystemLocalFilesystemBackend.get_connections`
    * `airflow.utils.dates.date_range` does not have a replacement
* feat
    * `airflow.utils.dag_parsing_context.get_parsing_context` -> `airflow.sdk.get_parsing_context`


## Test Plan

<!-- How was it tested? -->
a test fixture has been updated