### PR TITLE
Fix bracket spacing for single-element tuples in f-string expressions

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/fstring.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/fstring.py
@@ -718,3 +718,11 @@ print(f"{ {1: 2}.keys() }")
 print(f"{({1, 2, 3}) - ({2})}")
 print(f"{1, 2, {3} }")
 print(f"{(1, 2, {3})}")
+
+# Regression tests for https://github.com/astral-sh/ruff/issues/15535
+print(f"{ {}, }")  # A single item tuple gets parenthesized
+print(f"{ {}.values(), }")
+print(f"{ {}, 1 }")  # A tuple with multiple elements doesn't get parenthesized
+print(f"{  # Tuple with multiple elements that doesn't fit on a single line gets parenthesized
+    {}, 1,
+}")

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__fstring.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__fstring.py.snap
@@ -724,6 +724,14 @@ print(f"{ {1: 2}.keys() }")
 print(f"{({1, 2, 3}) - ({2})}")
 print(f"{1, 2, {3} }")
 print(f"{(1, 2, {3})}")
+
+# Regression tests for https://github.com/astral-sh/ruff/issues/15535
+print(f"{ {}, }")  # A single item tuple gets parenthesized
+print(f"{ {}.values(), }")
+print(f"{ {}, 1 }")  # A tuple with multiple elements doesn't get parenthesized
+print(f"{  # Tuple with multiple elements that doesn't fit on a single line gets parenthesized
+    {}, 1,
+}")
 ```
 
 ## Outputs
@@ -1506,6 +1514,19 @@ print(f"{ {1: 2}.keys() }")
 print(f"{({1, 2, 3}) - ({2})}")
 print(f"{1, 2, {3}}")
 print(f"{(1, 2, {3})}")
+
+# Regression tests for https://github.com/astral-sh/ruff/issues/15535
+print(f"{({},)}")  # A single item tuple gets parenthesized
+print(f"{({}.values(),)}")
+print(f"{ {}, 1 }")  # A tuple with multiple elements doesn't get parenthesized
+print(
+    f"{  # Tuple with multiple elements that doesn't fit on a single line gets parenthesized
+        (
+            {},
+            1,
+        )
+    }"
+)
 ```
 
 
@@ -2288,4 +2309,17 @@ print(f"{ {1: 2}.keys() }")
 print(f"{({1, 2, 3}) - ({2})}")
 print(f"{1, 2, {3}}")
 print(f"{(1, 2, {3})}")
+
+# Regression tests for https://github.com/astral-sh/ruff/issues/15535
+print(f"{({},)}")  # A single item tuple gets parenthesized
+print(f"{({}.values(),)}")
+print(f"{ {}, 1 }")  # A tuple with multiple elements doesn't get parenthesized
+print(
+    f"{  # Tuple with multiple elements that doesn't fit on a single line gets parenthesized
+        (
+            {},
+            1,
+        )
+    }"
+)
 ```


### PR DESCRIPTION
## Summary

Fixes https://github.com/astral-sh/ruff/issues/15535#issuecomment-2596286050

The formatter always parenthesizes single-element tuples even if they weren't in the source. 
This lead to an instability before where the formatter added spacing around the f-strings `{ {}, }` that
then were removed when reformatting the code because the tuple's now parenthesized `{({},)}`. 

## Test Plan

Added test. I reviewed our other expression formatting and I didn't find any
other, except generators, that introduce parentheses. For generators, unparenthesized
generators aren't allowed in an expression context. 
