### PR TITLE
[red-knot] Implement disjointness for Instance types where the underlying class is `@final`

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/narrow/isinstance.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/narrow/isinstance.md
@@ -199,24 +199,20 @@ def f(
     if isinstance(a, bool):
         reveal_type(a)  # revealed: Never
     else:
-        # TODO: `bool` is final, so `& ~bool` is redundant here
-        reveal_type(a)  # revealed: P & AlwaysTruthy & ~bool
+        reveal_type(a)  # revealed: P & AlwaysTruthy
 
     if isinstance(b, bool):
         reveal_type(b)  # revealed: Never
     else:
-        # TODO: `bool` is final, so `& ~bool` is redundant here
-        reveal_type(b)  # revealed: P & AlwaysFalsy & ~bool
+        reveal_type(b)  # revealed: P & AlwaysFalsy
 
     if isinstance(c, bool):
         reveal_type(c)  # revealed: Never
     else:
-        # TODO: `bool` is final, so `& ~bool` is redundant here
-        reveal_type(c)  # revealed: P & ~AlwaysTruthy & ~bool
+        reveal_type(c)  # revealed: P & ~AlwaysTruthy
 
     if isinstance(d, bool):
         reveal_type(d)  # revealed: Never
     else:
-        # TODO: `bool` is final, so `& ~bool` is redundant here
-        reveal_type(d)  # revealed: P & ~AlwaysFalsy & ~bool
+        reveal_type(d)  # revealed: P & ~AlwaysFalsy
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/type_properties/is_disjoint_from.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/type_properties/is_disjoint_from.md
@@ -8,7 +8,7 @@ TODO: Most of our disjointness tests are still Rust tests; they should be moved 
 ## Instance types versus `type[T]` types
 
 An instance type is disjoint from a `type[T]` type if the instance type is `@final` and the
-associated class of the instance type is not a subclass of `T`'s metaclass.
+class of the instance type is not a subclass of `T`'s metaclass.
 
 ```py
 from typing import final

--- a/crates/red_knot_python_semantic/resources/mdtest/type_properties/is_disjoint_from.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/type_properties/is_disjoint_from.md
@@ -1,0 +1,36 @@
+# Tests for disjointness
+
+If two types can be disjoint, it means that it is known that no possible runtime object could ever inhabit both types simultaneously.
+
+TODO: Most of our disjointness tests are still Rust tests; they should be moved to this file.
+
+## Instance types versus `type[T]` types
+
+An instance type is disjoint from a `type[T]` type if the instance type is `@final`
+and the associated class of the instance type is not a subclass of `T`'s metaclass.
+
+```py
+from typing import final
+from knot_extensions import is_disjoint_from, static_assert
+
+@final
+class Foo: ...
+
+static_assert(is_disjoint_from(Foo, type[int]))
+static_assert(is_disjoint_from(type[object], Foo))
+static_assert(is_disjoint_from(type[dict], Foo))
+
+# Instance types can be disjoint from `type[]` types
+# even if the instance type is a subtype of `type`
+
+@final
+class Meta1(type): ...
+class UsesMeta1(metaclass=Meta1): ...
+
+static_assert(not is_disjoint_from(Meta1, type[UsesMeta1]))
+
+class Meta2(type): ...
+class UsesMeta2(metaclass=Meta2): ...
+static_assert(not is_disjoint_from(Meta2, type[UsesMeta2]))
+static_assert(is_disjoint_from(Meta1, type[UsesMeta2]))
+```

--- a/crates/red_knot_python_semantic/resources/mdtest/type_properties/is_disjoint_from.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/type_properties/is_disjoint_from.md
@@ -1,13 +1,14 @@
 # Tests for disjointness
 
-If two types can be disjoint, it means that it is known that no possible runtime object could ever inhabit both types simultaneously.
+If two types can be disjoint, it means that it is known that no possible runtime object could ever
+inhabit both types simultaneously.
 
 TODO: Most of our disjointness tests are still Rust tests; they should be moved to this file.
 
 ## Instance types versus `type[T]` types
 
-An instance type is disjoint from a `type[T]` type if the instance type is `@final`
-and the associated class of the instance type is not a subclass of `T`'s metaclass.
+An instance type is disjoint from a `type[T]` type if the instance type is `@final` and the
+associated class of the instance type is not a subclass of `T`'s metaclass.
 
 ```py
 from typing import final
@@ -25,12 +26,14 @@ static_assert(is_disjoint_from(type[dict], Foo))
 
 @final
 class Meta1(type): ...
+
 class UsesMeta1(metaclass=Meta1): ...
 
 static_assert(not is_disjoint_from(Meta1, type[UsesMeta1]))
 
 class Meta2(type): ...
 class UsesMeta2(metaclass=Meta2): ...
+
 static_assert(not is_disjoint_from(Meta2, type[UsesMeta2]))
 static_assert(is_disjoint_from(Meta1, type[UsesMeta2]))
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/type_properties/is_disjoint_from.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/type_properties/is_disjoint_from.md
@@ -7,8 +7,8 @@ TODO: Most of our disjointness tests are still Rust tests; they should be moved 
 
 ## Instance types versus `type[T]` types
 
-An instance type is disjoint from a `type[T]` type if the instance type is `@final` and the
-class of the instance type is not a subclass of `T`'s metaclass.
+An instance type is disjoint from a `type[T]` type if the instance type is `@final` and the class of
+the instance type is not a subclass of `T`'s metaclass.
 
 ```py
 from typing import final

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -4377,6 +4377,7 @@ pub(crate) mod tests {
     #[test_case(Ty::AlwaysFalsy, Ty::AlwaysTruthy)]
     #[test_case(Ty::Tuple(vec![]), Ty::TypingLiteral)]
     #[test_case(Ty::TypingLiteral, Ty::SubclassOfBuiltinClass("object"))]
+    #[test_case(Ty::BuiltinInstance("bool"), Ty::BuiltinInstance("type"))]  // bool is `@final`
     fn is_disjoint_from(a: Ty, b: Ty) {
         let db = setup_db();
         let a = a.into_type(&db);


### PR DESCRIPTION
## Summary

Closes https://github.com/astral-sh/ruff/issues/15508

For any two instance types `T` and `S`, we know they are disjoint if either `T` is final and `T` is not a subclass of `S` or `S` is final and `S` is not a subclass of `T`.

Correspondingly, for any two types `type[T]` and `S` where `S` is an instance type, `type[T]` can be said to be disjoint from `S` if `S` is disjoint from `U`, where `U` is the type that represents all instances of `T`'s metaclass.

And a heterogeneous tuple type can be said to be disjoint from an instance type if the instance type is disjoint from `tuple` (a type representing all instances of the `tuple` class at runtime).

## Test Plan

- A new mdtest added. Most of our `is_disjoint_from()` tests are not written as mdtests just yet, but it's pretty hard to test some of these edge cases from a Rust unit test!
- Ran `QUICKCHECK_TESTS=1000000 cargo test --release -p red_knot_python_semantic -- --ignored types::property_tests::stable`

Co-authored-by: Carl Meyer <carl@astral.sh>