### PR TITLE
Fix unstable f-string formatting for expressions containing a trailing comma

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/fstring.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/fstring.py
@@ -719,6 +719,7 @@ print(f"{({1, 2, 3}) - ({2})}")
 print(f"{1, 2, {3} }")
 print(f"{(1, 2, {3})}")
 
+
 # Regression tests for https://github.com/astral-sh/ruff/issues/15535
 print(f"{ {}, }")  # A single item tuple gets parenthesized
 print(f"{ {}.values(), }")
@@ -726,3 +727,7 @@ print(f"{ {}, 1 }")  # A tuple with multiple elements doesn't get parenthesized
 print(f"{  # Tuple with multiple elements that doesn't fit on a single line gets parenthesized
     {}, 1,
 }")
+
+
+# Regression tests for https://github.com/astral-sh/ruff/issues/15536
+print(f"{ {}, 1, }")

--- a/crates/ruff_python_formatter/src/context.rs
+++ b/crates/ruff_python_formatter/src/context.rs
@@ -147,6 +147,17 @@ pub(crate) enum FStringState {
     Outside,
 }
 
+impl FStringState {
+    pub(crate) fn can_contain_line_breaks(self) -> Option<bool> {
+        match self {
+            FStringState::InsideExpressionElement(context) => {
+                Some(context.can_contain_line_breaks())
+            }
+            FStringState::Outside => None,
+        }
+    }
+}
+
 /// The position of a top-level statement in the module.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Default)]
 pub(crate) enum TopLevelStatementPosition {

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__fstring.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__fstring.py.snap
@@ -725,6 +725,7 @@ print(f"{({1, 2, 3}) - ({2})}")
 print(f"{1, 2, {3} }")
 print(f"{(1, 2, {3})}")
 
+
 # Regression tests for https://github.com/astral-sh/ruff/issues/15535
 print(f"{ {}, }")  # A single item tuple gets parenthesized
 print(f"{ {}.values(), }")
@@ -732,6 +733,10 @@ print(f"{ {}, 1 }")  # A tuple with multiple elements doesn't get parenthesized
 print(f"{  # Tuple with multiple elements that doesn't fit on a single line gets parenthesized
     {}, 1,
 }")
+
+
+# Regression tests for https://github.com/astral-sh/ruff/issues/15536
+print(f"{ {}, 1, }")
 ```
 
 ## Outputs
@@ -1515,6 +1520,7 @@ print(f"{({1, 2, 3}) - ({2})}")
 print(f"{1, 2, {3}}")
 print(f"{(1, 2, {3})}")
 
+
 # Regression tests for https://github.com/astral-sh/ruff/issues/15535
 print(f"{({},)}")  # A single item tuple gets parenthesized
 print(f"{({}.values(),)}")
@@ -1527,6 +1533,10 @@ print(
         )
     }"
 )
+
+
+# Regression tests for https://github.com/astral-sh/ruff/issues/15536
+print(f"{ {}, 1 }")
 ```
 
 
@@ -2310,6 +2320,7 @@ print(f"{({1, 2, 3}) - ({2})}")
 print(f"{1, 2, {3}}")
 print(f"{(1, 2, {3})}")
 
+
 # Regression tests for https://github.com/astral-sh/ruff/issues/15535
 print(f"{({},)}")  # A single item tuple gets parenthesized
 print(f"{({}.values(),)}")
@@ -2322,4 +2333,8 @@ print(
         )
     }"
 )
+
+
+# Regression tests for https://github.com/astral-sh/ruff/issues/15536
+print(f"{ {}, 1 }")
 ```


### PR DESCRIPTION
## Summary

Fixes https://github.com/astral-sh/ruff/issues/15536

The `RemoveSoftlinesBuffer` removes soft line breaks and `if_group_breaks` elements but it
doesn't remove `expand_parent` elements. This can lead to instable formatting
when f-strings are wrapped in a `group` because it makes that group expand. For example, 
`print(f"{ {}, 1, }")` first gets formatted to 

```py
print(
    f"{ {}, 1 }"
)
```

and only then converges at `print(f"{ {}, 1 }")`. 

I first tried to also remove `expand_parent` elemnents in the `RemoveSoftLinesBuffer`
but that results in many failing tests around assignment formatting because 
we rely on `Document::will_break` to determine if we should try the flat 
layout and that only returns `true` if the f-string formatting contains the `expand_parent` along the trailing comma.

I reviewed all `expand_parent` usages and realized that the trailing comma is the only 
usage in our expression formatting. That's why I decided to adjust the trailing comma
formatting instead to omit the trailing comma if we know that we're in a flat f-string.

This is also how Dhruv implemented it originally before I removed the check in https://github.com/astral-sh/ruff/pull/14489 because I thought it
it no longer necessary. 

## Test Plan

Added regression test
