### PR TITLE
[red-knot] `type[T]` is disjoint from `type[S]` if the metaclass of `T` is disjoint from the metaclass of `S`

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/narrow/issubclass.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/narrow/issubclass.md
@@ -246,3 +246,27 @@ def _(x: type, y: type[int]):
     if issubclass(x, y):
         reveal_type(x)  # revealed: type[int]
 ```
+
+### Disjoint `type[]` types are narrowed to `Never`
+
+```py
+from typing import final
+
+@final
+class Meta1(type): ...
+
+class Meta2(type): ...
+class UsesMeta1(metaclass=Meta1): ...
+class UsesMeta2(metaclass=Meta2): ...
+
+def _(x: type[UsesMeta1], y: type[UsesMeta2]):
+    if issubclass(x, y):
+        reveal_type(x)  # revealed: Never
+    else:
+        reveal_type(x)  # revealed: type[UsesMeta1]
+
+    if issubclass(y, x):
+        reveal_type(y)  # revealed: Never
+    else:
+        reveal_type(y)  # revealed: type[UsesMeta2]
+```

--- a/crates/red_knot_python_semantic/resources/mdtest/type_properties/is_disjoint_from.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/type_properties/is_disjoint_from.md
@@ -37,3 +37,22 @@ class UsesMeta2(metaclass=Meta2): ...
 static_assert(not is_disjoint_from(Meta2, type[UsesMeta2]))
 static_assert(is_disjoint_from(Meta1, type[UsesMeta2]))
 ```
+
+## `type[T]` versus `type[S]`
+
+By the same token, `type[T]` is disjoint from `type[S]` if the metaclass of `T` is disjoint from the
+metaclass of `S`.
+
+```py
+from typing import final
+from knot_extensions import static_assert, is_disjoint_from
+
+@final
+class Meta1(type): ...
+
+class Meta2(type): ...
+class UsesMeta1(metaclass=Meta1): ...
+class UsesMeta2(metaclass=Meta2): ...
+
+static_assert(is_disjoint_from(type[UsesMeta1], type[UsesMeta2]))
+```

--- a/crates/red_knot_python_semantic/src/types/subclass_of.rs
+++ b/crates/red_knot_python_semantic/src/types/subclass_of.rs
@@ -68,6 +68,15 @@ impl<'db> SubclassOfType<'db> {
         Type::from(self.subclass_of).member(db, name)
     }
 
+    /// A class `T` is an instance of its metaclass `U`,
+    /// so the type `type[T]` is a strict subtype of the instance type `U`.
+    pub(crate) fn as_instance_type_of_metaclass(&self, db: &'db dyn Db) -> Type<'db> {
+        match self.subclass_of {
+            ClassBase::Dynamic(_) => KnownClass::Type.to_instance(db),
+            ClassBase::Class(class) => class.metaclass(db).to_instance(db),
+        }
+    }
+
     /// Return `true` if `self` is a subtype of `other`.
     ///
     /// This can only return `true` if `self.subclass_of` is a [`ClassBase::Class`] variant;


### PR DESCRIPTION
## Summary

This PR further extends the principles established in https://github.com/astral-sh/ruff/pull/15539 -- and allows us to get rid of even more special cases for `type[]` types in `Type::is_disjoint_from()`! A class definition `class A(B, C): ...` can only succeed if either the metaclass of `C` is a subclass of the metaclass of `B` or the metaclass of `B` is a subclass of the metaclass of `C`. As such, for two types `type[T]` and `type[S]`, we can conclude that the two types are disjoint if `T`'s metaclass and `S`'s metaclass are disjoint.

## Test Plan

- New mdtests added
- Ran `QUICKCHECK_TESTS=1000000 cargo test --release -p red_knot_python_semantic -- --ignored types::property_tests::stable`

@sharkdp -- we don't have _great_ coverage for this kind of thing in our property tests, because I know of no standard-library classes that have `@final` metaclasses, so it's hard for me to think of how to get the property tests to use some `type[]` types that have disjoint metaclasses. Maybe that just means that this kind of thing is an edge case that we don't need to worry about too much, though 🤷