### PR TITLE
[`flake8-bugbear`] Do not raise error if keyword argument is present and target-python version is less or equals than 3.9 (`B903`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_bugbear/class_as_data_structure.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_bugbear/class_as_data_structure.py
@@ -95,4 +95,10 @@ class WarningsWithDocstring:
         self.foo = foo
         self.bar = bar
 
+
+class KeywordOnly: # OK with python3.9 or less, not OK starting python3.10
+    def __init__(self, *, foo: int, bar: int):
+        self.foo = foo
+        self.bar = bar 
+
 # <-- end flake8-bugbear tests

--- a/crates/ruff_linter/src/rules/flake8_bugbear/mod.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/mod.rs
@@ -16,6 +16,8 @@ mod tests {
     use crate::settings::LinterSettings;
     use crate::test::test_path;
 
+    use crate::settings::types::PythonVersion;
+
     #[test_case(Rule::AbstractBaseClassWithoutAbstractMethod, Path::new("B024.py"))]
     #[test_case(Rule::AssertFalse, Path::new("B011.py"))]
     #[test_case(Rule::AssertRaisesException, Path::new("B017.py"))]
@@ -73,6 +75,34 @@ mod tests {
         let diagnostics = test_path(
             Path::new("flake8_bugbear").join(path).as_path(),
             &LinterSettings::for_rule(rule_code),
+        )?;
+        assert_messages!(snapshot, diagnostics);
+        Ok(())
+    }
+
+    #[test_case(
+        Rule::ClassAsDataStructure,
+        Path::new("class_as_data_structure.py"),
+        PythonVersion::Py39
+    )]
+    fn rules_with_target_version(
+        rule_code: Rule,
+        path: &Path,
+        target_version: PythonVersion,
+    ) -> Result<()> {
+        let snapshot = format!(
+            "{}_py{}{}_{}",
+            rule_code.noqa_code(),
+            target_version.major(),
+            target_version.minor(),
+            path.to_string_lossy(),
+        );
+        let diagnostics = test_path(
+            Path::new("flake8_bugbear").join(path).as_path(),
+            &LinterSettings {
+                target_version,
+                ..LinterSettings::for_rule(rule_code)
+            },
         )?;
         assert_messages!(snapshot, diagnostics);
         Ok(())

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/class_as_data_structure.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/class_as_data_structure.rs
@@ -5,6 +5,7 @@ use ruff_python_semantic::analyze::visibility::{self, Visibility::Public};
 use ruff_text_size::Ranged;
 
 use crate::checkers::ast::Checker;
+use crate::settings::types::PythonVersion;
 
 /// ## What it does
 /// Checks for classes that only have a public `__init__` method,
@@ -77,6 +78,7 @@ pub(crate) fn class_as_data_structure(checker: &mut Checker, class_def: &ast::St
                         // skip `self`
                         .skip(1)
                         .all(|param| param.annotation().is_some() && !param.is_variadic())
+                    && (func_def.parameters.kwonlyargs.is_empty() || checker.settings.target_version >= PythonVersion::Py310)
                     // `__init__` should not have complicated logic in it
                     // only assignments
                     && func_def

--- a/crates/ruff_linter/src/rules/flake8_bugbear/snapshots/ruff_linter__rules__flake8_bugbear__tests__B903_py39_class_as_data_structure.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/snapshots/ruff_linter__rules__flake8_bugbear__tests__B903_py39_class_as_data_structure.py.snap
@@ -67,14 +67,3 @@ class_as_data_structure.py:91:1: B903 Class could be dataclass or namedtuple
 96 | |         self.bar = bar
    | |______________________^ B903
    |
-
-class_as_data_structure.py:99:1: B903 Class could be dataclass or namedtuple
-    |
- 99 | / class KeywordOnly: # OK with python3.9 or less, not OK starting python3.10
-100 | |     def __init__(self, *, foo: int, bar: int):
-101 | |         self.foo = foo
-102 | |         self.bar = bar 
-    | |______________________^ B903
-103 |
-104 |   # <-- end flake8-bugbear tests
-    |


### PR DESCRIPTION
\[`flake8-bugbear`\] Do not raise error if keyword argument is present and target-python version is less or equals than 3.9 (`B903`)

<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

I have this piece of code in one of my repo

```py
class RuleMetadata:
    def __init__(
        self,
        *,
        function: Union[
            Callable[[Session, UserModel, RuleComputeFinaleFromGroupRank], None],
            Callable[[Session, UserModel, RuleComputePoints], None],
        ],
        attribute: str,
        required_admin: bool = False,
    ) -> None:
        self.function = function
        self.attribute = attribute
        self.required_admin = required_admin
```

When I did this, I started by using dataclass, although I wanted the 3 arguments of the __init__ function to be keywords only. As dataclass does not support kw_only before python 3.10 (reference https://docs.python.org/3/library/dataclasses.html#module-contents), I ended up writing the __init__ function myself.

With the current implementation of B903, this will raise an error. My suggestion would be not to raise error if an keyword only argument and target-version<=3.9.

Related github issue : https://github.com/astral-sh/ruff/issues/15548

## Test Plan

I added a new usecase in `class_as_data_structure.py`, a class with keyword only.
I tested this file with the target-version = latest python and with python3.9.
With the latest python, I'm expecting error and python3.9 no error should be raised.
