### PR TITLE
[red-knot] Add support for `typing.ClassVar`

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/attributes.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/attributes.md
@@ -186,7 +186,7 @@ reveal_type(c_instance.pure_class_variable1)  # revealed: str
 # TODO: Should be `Unknown | Literal[1]`.
 reveal_type(c_instance.pure_class_variable2)  # revealed: Unknown
 
-# error: [invalid-attribute-access] "Cannot assign to pure class variable `pure_class_variable1` from an instance of type `C`"
+# error: [invalid-attribute-access] "Cannot assign to ClassVar `pure_class_variable1` from an instance of type `C`"
 c_instance.pure_class_variable1 = "value set on instance"
 
 C.pure_class_variable1 = "overwritten on class"

--- a/crates/red_knot_python_semantic/resources/mdtest/attributes.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/attributes.md
@@ -169,6 +169,10 @@ class C:
     pure_class_variable1: ClassVar[str] = "value in class body"
     pure_class_variable2: ClassVar = 1
 
+    def method(self):
+        # TODO: this should be an error
+        self.pure_class_variable1 = "value set through instance"
+
 reveal_type(C.pure_class_variable1)  # revealed: str
 
 # TODO: this should be `Literal[1]`, or `Unknown | Literal[1]`.

--- a/crates/red_knot_python_semantic/resources/mdtest/attributes.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/attributes.md
@@ -182,7 +182,7 @@ reveal_type(c_instance.pure_class_variable1)  # revealed: str
 # TODO: Should be `Unknown | Literal[1]`.
 reveal_type(c_instance.pure_class_variable2)  # revealed: Unknown
 
-# TODO: should raise an error. It is not allowed to reassign a pure class variable on an instance.
+# error: [invalid-attribute-access] "Cannot assign to pure class variable `pure_class_variable1` from an instance"
 c_instance.pure_class_variable1 = "value set on instance"
 
 C.pure_class_variable1 = "overwritten on class"

--- a/crates/red_knot_python_semantic/resources/mdtest/attributes.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/attributes.md
@@ -182,7 +182,7 @@ reveal_type(c_instance.pure_class_variable1)  # revealed: str
 # TODO: Should be `Unknown | Literal[1]`.
 reveal_type(c_instance.pure_class_variable2)  # revealed: Unknown
 
-# error: [invalid-attribute-access] "Cannot assign to pure class variable `pure_class_variable1` from an instance"
+# error: [invalid-attribute-access] "Cannot assign to pure class variable `pure_class_variable1` from an instance of type `C`"
 c_instance.pure_class_variable1 = "value set on instance"
 
 C.pure_class_variable1 = "overwritten on class"

--- a/crates/red_knot_python_semantic/resources/mdtest/type_qualifiers/classvar.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/type_qualifiers/classvar.md
@@ -1,0 +1,49 @@
+# `typing.ClassVar`
+
+[`typing.ClassVar`] is a type qualifier that is used to indicate that a class variable may not be
+set on instances. For more details, see the [typing spec].
+
+This test mostly makes sure that we "see" the type qualifier in an annotation. For more details on
+the semantics, see the [test on attributes](../attributes.md) test.
+
+## Basic
+
+```py
+from typing import ClassVar, Annotated
+
+class C:
+    x: ClassVar[int] = 1
+    y: Annotated[ClassVar[int], "the annotation for y"] = 1
+    z: "ClassVar[int]" = 1
+
+reveal_type(C.x)  # revealed: int
+reveal_type(C.y)  # revealed: int
+reveal_type(C.z)  # revealed: int
+
+c = C()
+
+# error: [invalid-attribute-access]
+c.x = 2
+# error: [invalid-attribute-access]
+c.y = 2
+# error: [invalid-attribute-access]
+c.z = 2
+```
+
+## Too many arguments
+
+```py
+class C:
+    # error: [invalid-type-form] "Special form `typing.ClassVar` expected exactly one type parameter"
+    x: ClassVar[int, str] = 1
+```
+
+## Used outside of a class
+
+```py
+# TODO: this should be an error
+x: ClassVar[int] = 1
+```
+
+[typing spec]: https://typing.readthedocs.io/en/latest/spec/class-compat.html#classvar
+[`typing.classvar`]: https://docs.python.org/3/library/typing.html#typing.ClassVar

--- a/crates/red_knot_python_semantic/resources/mdtest/type_qualifiers/classvar.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/type_qualifiers/classvar.md
@@ -72,6 +72,17 @@ class C:
     x: ClassVar[int, str] = 1
 ```
 
+## Illegal `ClassVar` in type expression
+
+```py
+class C:
+    # error: [invalid-type-form] "Type qualifier `typing.ClassVar` is not allowed in type expressions (only in annotation expressions)"
+    x: ClassVar | int
+
+    # error: [invalid-type-form] "Type qualifier `typing.ClassVar` is not allowed in type expressions (only in annotation expressions)"
+    y: int | ClassVar[str]
+```
+
 ## Used outside of a class
 
 ```py

--- a/crates/red_knot_python_semantic/resources/mdtest/type_qualifiers/classvar.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/type_qualifiers/classvar.md
@@ -39,6 +39,31 @@ c.d = 2
 c.e = 2
 ```
 
+## Conflicting type qualifiers
+
+We currently ignore conflicting qualifiers and simply union them, which is more conservative than
+intersecting them. This means that we consider `a` to be a `ClassVar` here:
+
+```py
+from typing import ClassVar
+
+def flag() -> bool:
+    return True
+
+class C:
+    if flag():
+        a: ClassVar[int] = 1
+    else:
+        a: str
+
+reveal_type(C.a)  # revealed: int | str
+
+c = C()
+
+# error: [invalid-attribute-access]
+c.a = 2
+```
+
 ## Too many arguments
 
 ```py

--- a/crates/red_knot_python_semantic/resources/mdtest/type_qualifiers/classvar.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/type_qualifiers/classvar.md
@@ -68,7 +68,7 @@ c.a = 2
 
 ```py
 class C:
-    # error: [invalid-type-form] "Special form `typing.ClassVar` expected exactly one type parameter"
+    # error: [invalid-type-form] "Type qualifier `typing.ClassVar` expects exactly one type parameter"
     x: ClassVar[int, str] = 1
 ```
 

--- a/crates/red_knot_python_semantic/resources/mdtest/type_qualifiers/classvar.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/type_qualifiers/classvar.md
@@ -14,14 +14,16 @@ from typing import ClassVar, Annotated
 class C:
     a: ClassVar[int] = 1
     b: Annotated[ClassVar[int], "the annotation for b"] = 1
-    c: ClassVar = 1
-    d: "ClassVar[int]" = 1
+    c: ClassVar[Annotated[int, "the annotation for c"]] = 1
+    d: ClassVar = 1
+    e: "ClassVar[int]" = 1
 
 reveal_type(C.a)  # revealed: int
 reveal_type(C.b)  # revealed: int
+reveal_type(C.c)  # revealed: int
 # TODO: should be Unknown | Literal[1]
-reveal_type(C.c)  # revealed: Unknown
-reveal_type(C.d)  # revealed: int
+reveal_type(C.d)  # revealed: Unknown
+reveal_type(C.e)  # revealed: int
 
 c = C()
 
@@ -33,6 +35,8 @@ c.b = 2
 c.c = 2
 # error: [invalid-attribute-access]
 c.d = 2
+# error: [invalid-attribute-access]
+c.e = 2
 ```
 
 ## Too many arguments

--- a/crates/red_knot_python_semantic/resources/mdtest/type_qualifiers/classvar.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/type_qualifiers/classvar.md
@@ -1,10 +1,10 @@
 # `typing.ClassVar`
 
 [`typing.ClassVar`] is a type qualifier that is used to indicate that a class variable may not be
-set on instances.
+written to from instances of that class.
 
-This test mostly makes sure that we "see" the type qualifier in an annotation. For more details on
-the semantics, see the [test on attributes](../attributes.md) test.
+This test makes sure that we discover the type qualifier while inferring types from an annotation.
+For more details on the semantics of pure class variables, see [this test](../attributes.md).
 
 ## Basic
 

--- a/crates/red_knot_python_semantic/resources/mdtest/type_qualifiers/classvar.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/type_qualifiers/classvar.md
@@ -1,7 +1,7 @@
 # `typing.ClassVar`
 
 [`typing.ClassVar`] is a type qualifier that is used to indicate that a class variable may not be
-set on instances. For more details, see the [typing spec].
+set on instances.
 
 This test mostly makes sure that we "see" the type qualifier in an annotation. For more details on
 the semantics, see the [test on attributes](../attributes.md) test.
@@ -12,22 +12,27 @@ the semantics, see the [test on attributes](../attributes.md) test.
 from typing import ClassVar, Annotated
 
 class C:
-    x: ClassVar[int] = 1
-    y: Annotated[ClassVar[int], "the annotation for y"] = 1
-    z: "ClassVar[int]" = 1
+    a: ClassVar[int] = 1
+    b: Annotated[ClassVar[int], "the annotation for b"] = 1
+    c: ClassVar = 1
+    d: "ClassVar[int]" = 1
 
-reveal_type(C.x)  # revealed: int
-reveal_type(C.y)  # revealed: int
-reveal_type(C.z)  # revealed: int
+reveal_type(C.a)  # revealed: int
+reveal_type(C.b)  # revealed: int
+# TODO: should be Unknown | Literal[1]
+reveal_type(C.c)  # revealed: Unknown
+reveal_type(C.d)  # revealed: int
 
 c = C()
 
 # error: [invalid-attribute-access]
-c.x = 2
+c.a = 2
 # error: [invalid-attribute-access]
-c.y = 2
+c.b = 2
 # error: [invalid-attribute-access]
-c.z = 2
+c.c = 2
+# error: [invalid-attribute-access]
+c.d = 2
 ```
 
 ## Too many arguments
@@ -45,5 +50,4 @@ class C:
 x: ClassVar[int] = 1
 ```
 
-[typing spec]: https://typing.readthedocs.io/en/latest/spec/class-compat.html#classvar
 [`typing.classvar`]: https://docs.python.org/3/library/typing.html#typing.ClassVar

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -2336,6 +2336,12 @@ impl<'db> Type<'db> {
                 ],
                 fallback_type: Type::unknown(),
             }),
+            Type::KnownInstance(KnownInstanceType::Final) => Err(InvalidTypeExpressionError {
+                invalid_expressions: smallvec::smallvec![
+                    InvalidTypeExpression::FinalInTypeExpression
+                ],
+                fallback_type: Type::unknown(),
+            }),
             Type::KnownInstance(KnownInstanceType::Literal) => Err(InvalidTypeExpressionError {
                 invalid_expressions: smallvec::smallvec![InvalidTypeExpression::BareLiteral],
                 fallback_type: Type::unknown(),
@@ -2599,8 +2605,10 @@ enum InvalidTypeExpression {
     BareAnnotated,
     /// `x: Literal` is invalid as an annotation
     BareLiteral,
-    /// The `ClassVar` type qualifier was used in a type expression (but can only be used in an annotation expression)
+    /// The `ClassVar` type qualifier was used in a type expression
     ClassVarInTypeExpression,
+    /// The `Final` type qualifier was used in a type expression
+    FinalInTypeExpression,
 }
 
 impl InvalidTypeExpression {
@@ -2608,7 +2616,8 @@ impl InvalidTypeExpression {
         match self {
             Self::BareAnnotated => "`Annotated` requires at least two arguments when used in an annotation or type expression",
             Self::BareLiteral => "`Literal` requires at least one argument when used in a type expression",
-            Self::ClassVarInTypeExpression => "Type qualifier `ClassVar` is not allowed in type expressions (only in annotation expressions)",
+            Self::ClassVarInTypeExpression => "Type qualifier `typing.ClassVar` is not allowed in type expressions (only in annotation expressions)",
+            Self::FinalInTypeExpression => "Type qualifier `typing.Final` is not allowed in type expressions (only in annotation expressions)",
         }
     }
 }

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -2534,8 +2534,8 @@ bitflags! {
 /// control how a particular symbol can be accessed or modified. This struct holds a type and
 /// a set of type qualifiers.
 ///
-/// Example: `Annotated[ClassVar[tuple[int]], "metadata"]` would have type `tuple[int]` and
-/// qualifiers `CLASS_VAR | FINAL`.
+/// Example: `Annotated[ClassVar[tuple[int]], "metadata"]` would have type `tuple[int]` and the
+/// qualifier `ClassVar`.
 #[derive(Clone, Debug, Copy, Eq, PartialEq)]
 pub(crate) struct TypeAndQualifiers<'db> {
     inner: Type<'db>,

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -37,6 +37,7 @@ use crate::types::call::{
 };
 use crate::types::class_base::ClassBase;
 use crate::types::diagnostic::INVALID_TYPE_FORM;
+use crate::types::infer::QualifiedType;
 use crate::types::mro::{Mro, MroError, MroIterator};
 use crate::types::narrow::narrowing_constraint;
 use crate::{Db, FxOrderSet, Module, Program, PythonVersion};
@@ -246,7 +247,7 @@ pub(crate) fn binding_ty<'db>(db: &'db dyn Db, definition: Definition<'db>) -> T
 }
 
 /// Infer the type of a declaration.
-fn declaration_ty<'db>(db: &'db dyn Db, definition: Definition<'db>) -> Type<'db> {
+fn declaration_ty<'db>(db: &'db dyn Db, definition: Definition<'db>) -> QualifiedType<'db> {
     let inference = infer_definition_types(db, definition);
     inference.declaration_ty(definition)
 }
@@ -400,7 +401,7 @@ fn declarations_ty<'db>(
             if static_visibility.is_always_false() {
                 None
             } else {
-                Some(declaration_ty(db, declaration))
+                Some(declaration_ty(db, declaration).ignore_qualifiers())
             }
         },
     );

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -357,6 +357,18 @@ fn bindings_ty<'db>(
     }
 }
 
+/// A type with declaredness information, and a set of type qualifiers.
+///
+/// This is used to represent the result of looking up the declared type. Consider this
+/// example:
+/// ```py
+/// class C:
+///     if flag:
+///         variable: ClassVar[int]
+/// ```
+/// If we look up the declared type of `variable` in the scope of class `C`, we will get
+/// the type `int`, a "declaredness" of [`Boundness::PossiblyUnbound`], and the information
+/// that this comes with a [`TypeQualifiers::CLASS_VAR`] type qualifier.
 pub(crate) struct SymbolAndQualifiers<'db>(Symbol<'db>, TypeQualifiers);
 
 impl<'db> From<Symbol<'db>> for SymbolAndQualifiers<'db> {
@@ -367,8 +379,7 @@ impl<'db> From<Symbol<'db>> for SymbolAndQualifiers<'db> {
 
 impl<'db> From<Type<'db>> for SymbolAndQualifiers<'db> {
     fn from(ty: Type<'db>) -> Self {
-        let symbol: Symbol<'db> = ty.into();
-        symbol.into()
+        SymbolAndQualifiers(ty.into(), TypeQualifiers::empty())
     }
 }
 

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -371,6 +371,12 @@ fn bindings_ty<'db>(
 /// that this comes with a [`TypeQualifiers::CLASS_VAR`] type qualifier.
 pub(crate) struct SymbolAndQualifiers<'db>(Symbol<'db>, TypeQualifiers);
 
+impl SymbolAndQualifiers<'_> {
+    fn is_class_var(&self) -> bool {
+        self.1.contains(TypeQualifiers::CLASS_VAR)
+    }
+}
+
 impl<'db> From<Symbol<'db>> for SymbolAndQualifiers<'db> {
     fn from(symbol: Symbol<'db>) -> Self {
         SymbolAndQualifiers(symbol, TypeQualifiers::empty())
@@ -2516,12 +2522,6 @@ bitflags! {
         const CLASS_VAR = 1 << 0;
         /// `typing.Final`
         const FINAL     = 1 << 1;
-    }
-}
-
-impl TypeQualifiers {
-    pub(crate) fn is_class_var(self) -> bool {
-        self.contains(Self::CLASS_VAR)
     }
 }
 

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -124,7 +124,7 @@ fn symbol<'db>(db: &'db dyn Db, scope: ScopeId<'db>, name: &str) -> Symbol<'db> 
                 bindings_ty(db, bindings)
             }
             // Symbol is possibly undeclared
-            Err((declared_ty, _conflicting_types)) => {
+            Err((declared_ty, _)) => {
                 // Intentionally ignore conflicting declared types; that's not our problem,
                 // it's the problem of the module we are importing from.
                 declared_ty.inner_type().into()
@@ -2259,7 +2259,7 @@ impl<'db> Type<'db> {
     /// `Type::ClassLiteral(builtins.int)`, that is, it is the `int` class itself. As a type
     /// expression, it names the type `Type::Instance(builtins.int)`, that is, all objects whose
     /// `__class__` is `int`.
-    pub(crate) fn in_type_expression(
+    pub fn in_type_expression(
         &self,
         db: &'db dyn Db,
     ) -> Result<Type<'db>, InvalidTypeExpressionError<'db>> {

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -127,7 +127,7 @@ fn symbol<'db>(db: &'db dyn Db, scope: ScopeId<'db>, name: &str) -> Symbol<'db> 
             Err((declared_ty, _)) => {
                 // Intentionally ignore conflicting declared types; that's not our problem,
                 // it's the problem of the module we are importing from.
-                declared_ty.inner_type().into()
+                declared_ty.inner_ty().into()
             }
         }
 
@@ -437,12 +437,12 @@ fn declarations_ty<'db>(
     if let Some(first) = types.next() {
         let mut conflicting: Vec<Type<'db>> = vec![];
         let declared_ty = if let Some(second) = types.next() {
-            let ty_first = first.inner_type();
+            let ty_first = first.inner_ty();
             let mut qualifiers = first.qualifiers();
 
             let mut builder = UnionBuilder::new(db).add(ty_first);
             for other in std::iter::once(second).chain(types) {
-                let other_ty = other.inner_type();
+                let other_ty = other.inner_ty();
                 if !ty_first.is_equivalent_to(db, other_ty) {
                     conflicting.push(other_ty);
                 }
@@ -463,13 +463,13 @@ fn declarations_ty<'db>(
             };
 
             Ok(SymbolAndQualifiers(
-                Symbol::Type(declared_ty.inner_type(), boundness),
+                Symbol::Type(declared_ty.inner_ty(), boundness),
                 declared_ty.qualifiers(),
             ))
         } else {
             Err((
                 declared_ty,
-                std::iter::once(first.inner_type())
+                std::iter::once(first.inner_ty())
                     .chain(conflicting)
                     .collect(),
             ))
@@ -2548,7 +2548,7 @@ impl<'db> TypeAndQualifiers<'db> {
     }
 
     /// Forget about type qualifiers and only return the inner type.
-    pub(crate) fn inner_type(&self) -> Type<'db> {
+    pub(crate) fn inner_ty(&self) -> Type<'db> {
         self.inner
     }
 
@@ -4157,7 +4157,7 @@ impl<'db> Class<'db> {
                 }
                 Err((declared_ty, _conflicting_declarations)) => {
                     // Ignore conflicting declarations
-                    SymbolAndQualifiers(declared_ty.inner_type().into(), declared_ty.qualifiers())
+                    SymbolAndQualifiers(declared_ty.inner_ty().into(), declared_ty.qualifiers())
                 }
             }
         } else {

--- a/crates/red_knot_python_semantic/src/types/diagnostic.rs
+++ b/crates/red_knot_python_semantic/src/types/diagnostic.rs
@@ -753,7 +753,7 @@ declare_lint! {
 
 declare_lint! {
     /// ## What it does
-    /// Makes sure that the argument of `static_assert` is statically known to be true.
+    /// Makes sure that instance attribute accesses are valid.
     ///
     /// ## Examples
     /// ```python

--- a/crates/red_knot_python_semantic/src/types/diagnostic.rs
+++ b/crates/red_knot_python_semantic/src/types/diagnostic.rs
@@ -1,5 +1,4 @@
 use super::context::InferContext;
-use crate::declare_lint;
 use crate::lint::{Level, LintRegistryBuilder, LintStatus};
 use crate::suppression::FileSuppressionId;
 use crate::types::string_annotation::{
@@ -7,7 +6,8 @@ use crate::types::string_annotation::{
     IMPLICIT_CONCATENATED_STRING_TYPE_ANNOTATION, INVALID_SYNTAX_IN_FORWARD_ANNOTATION,
     RAW_STRING_TYPE_ANNOTATION,
 };
-use crate::types::{ClassLiteralType, Type};
+use crate::types::{ClassLiteralType, KnownInstanceType, Type};
+use crate::{declare_lint, Db};
 use ruff_db::diagnostic::{Diagnostic, DiagnosticId, Severity};
 use ruff_db::files::File;
 use ruff_python_ast::{self as ast, AnyNodeRef};
@@ -1078,5 +1078,20 @@ pub(crate) fn report_base_with_incompatible_slots(context: &InferContext, node: 
         &INCOMPATIBLE_SLOTS,
         node.into(),
         format_args!("Class base has incompatible `__slots__`"),
+    );
+}
+
+pub(crate) fn report_invalid_arguments_to_annotated<'db>(
+    db: &'db dyn Db,
+    context: &InferContext<'db>,
+    subscript: &ast::ExprSubscript,
+) {
+    context.report_lint(
+        &INVALID_TYPE_FORM,
+        subscript.into(),
+        format_args!(
+            "Special form `{}` expected at least 2 arguments (one type and at least one metadata element)",
+            KnownInstanceType::Annotated.repr(db)
+        ),
     );
 }

--- a/crates/red_knot_python_semantic/src/types/diagnostic.rs
+++ b/crates/red_knot_python_semantic/src/types/diagnostic.rs
@@ -59,6 +59,7 @@ pub(crate) fn register_lints(registry: &mut LintRegistryBuilder) {
     registry.register_lint(&UNSUPPORTED_OPERATOR);
     registry.register_lint(&ZERO_STEPSIZE_IN_SLICE);
     registry.register_lint(&STATIC_ASSERT_ERROR);
+    registry.register_lint(&INVALID_ATTRIBUTE_ACCESS);
 
     // String annotations
     registry.register_lint(&BYTE_STRING_TYPE_ANNOTATION);
@@ -745,6 +746,25 @@ declare_lint! {
     /// ```
     pub(crate) static STATIC_ASSERT_ERROR = {
         summary: "Failed static assertion",
+        status: LintStatus::preview("1.0.0"),
+        default_level: Level::Error,
+    }
+}
+
+declare_lint! {
+    /// ## What it does
+    /// Makes sure that the argument of `static_assert` is statically known to be true.
+    ///
+    /// ## Examples
+    /// ```python
+    /// class C:
+    ///   var: ClassVar[int] = 1
+    ///
+    /// C.var = 3  # okay
+    /// C().var = 3  # error: Cannot assign to class variable
+    /// ```
+    pub(crate) static INVALID_ATTRIBUTE_ACCESS = {
+        summary: "Invalid attribute access",
         status: LintStatus::preview("1.0.0"),
         default_level: Level::Error,
     }

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -66,8 +66,8 @@ use crate::types::{
     typing_extensions_symbol, Boundness, CallDunderResult, Class, ClassLiteralType, DynamicType,
     FunctionType, InstanceType, IntersectionBuilder, IntersectionType, IterationOutcome,
     KnownClass, KnownFunction, KnownInstanceType, MetaclassCandidate, MetaclassErrorKind,
-    SliceLiteralType, SubclassOfType, Symbol, Truthiness, TupleType, Type, TypeAliasType,
-    TypeAndQualifiers, TypeArrayDisplay, TypeQualifiers, TypeVarBoundOrConstraints,
+    SliceLiteralType, SubclassOfType, Symbol, SymbolAndQualifiers, Truthiness, TupleType, Type,
+    TypeAliasType, TypeAndQualifiers, TypeArrayDisplay, TypeQualifiers, TypeVarBoundOrConstraints,
     TypeVarInstance, UnionBuilder, UnionType,
 };
 use crate::unpack::Unpack;
@@ -859,8 +859,7 @@ impl<'db> TypeInferenceBuilder<'db> {
         let declarations = use_def.declarations_at_binding(binding);
         let mut bound_ty = ty;
         let declared_ty = declarations_ty(self.db(), declarations)
-            .map(|(ty, _)| ty)
-            .map(|s| s.ignore_possibly_unbound().unwrap_or(Type::unknown()))
+            .map(|SymbolAndQualifiers(s, _)| s.ignore_possibly_unbound().unwrap_or(Type::unknown()))
             .unwrap_or_else(|(ty, conflicting)| {
                 // TODO point out the conflicting declarations in the diagnostic?
                 let symbol_table = self.index.symbol_table(binding.file_scope(self.db()));

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -4884,7 +4884,7 @@ impl<'db> TypeInferenceBuilder<'db> {
 
 /// Type expressions
 impl<'db> TypeInferenceBuilder<'db> {
-    /// Infer the type of a type expression, including all type qualifiers such
+    /// Infer the type of a type expression, and collect all type qualifiers such
     /// as `ClassVar` or `Final`.
     fn infer_type_expression_with_qualifiers(
         &mut self,

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -3415,7 +3415,7 @@ impl<'db> TypeInferenceBuilder<'db> {
             ExprContext::Store => {
                 let value_ty = self.infer_expression(value);
 
-                if let (ast::ExprContext::Store, Type::Instance(instance)) = (ctx, value_ty) {
+                if let Type::Instance(instance) = value_ty {
                     let instance_member = instance.class.instance_member(self.db(), attr);
                     if instance_member.is_class_var() {
                         self.context.report_lint(

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -5422,7 +5422,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                         &INVALID_TYPE_FORM,
                         subscript.into(),
                         format_args!(
-                            "Special form `{}` expected exactly one type parameter",
+                            "Type qualifier `{}` expects exactly one type parameter",
                             known_instance.repr(self.db())
                         ),
                     );

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -4902,8 +4902,8 @@ impl<'db> TypeInferenceBuilder<'db> {
         ty
     }
 
-    /// Similar to [`infer_type_expression`], but accepts an optional
-    /// type expression and returns [`None`] if the expression is [`None`].
+    /// Similar to [`infer_type_expression`], but accepts an optional type expression and returns
+    /// [`None`] if the expression is [`None`].
     ///
     /// [`infer_type_expression`]: TypeInferenceBuilder::infer_type_expression
     fn infer_optional_type_expression(
@@ -4922,9 +4922,9 @@ impl<'db> TypeInferenceBuilder<'db> {
         deferred_state: DeferredExpressionState,
     ) -> Type<'db> {
         let previous_deferred_state = std::mem::replace(&mut self.deferred_state, deferred_state);
-        let type_expression_ty = self.infer_type_expression(expression);
+        let annotation_ty = self.infer_type_expression(expression);
         self.deferred_state = previous_deferred_state;
-        type_expression_ty
+        annotation_ty
     }
 
     /// Infer the type of a type expression without storing the result.

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -3422,7 +3422,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                             &INVALID_ATTRIBUTE_ACCESS,
                             attribute.into(),
                             format_args!(
-                                "Cannot assign to pure class variable `{attr}` from an instance of type `{ty}`",
+                                "Cannot assign to ClassVar `{attr}` from an instance of type `{ty}`",
                                 ty = value_ty.display(self.db()),
                             ),
                         );

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -2075,7 +2075,8 @@ impl<'db> TypeInferenceBuilder<'db> {
                             &INVALID_ATTRIBUTE_ACCESS,
                             expr_attr.into(),
                             format_args!(
-                                "Cannot assign to pure class variable `{attr}` from an instance",
+                                "Cannot assign to pure class variable `{attr}` from an instance of type `{ty}`",
+                                ty = attr_value_ty.display(self.db()),
                             ),
                         );
                     }

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -565,7 +565,7 @@ impl<'db> TypeInferenceBuilder<'db> {
             .filter_map(|(definition, ty)| {
                 // Filter out class literals that result from imports
                 if let DefinitionKind::Class(class) = definition.kind(self.db()) {
-                    ty.inner_type()
+                    ty.inner_ty()
                         .into_class_literal()
                         .map(|ty| (ty.class, class.node()))
                 } else {
@@ -872,7 +872,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                         conflicting.display(self.db())
                     ),
                 );
-                ty.inner_type()
+                ty.inner_ty()
             });
         if !bound_ty.is_assignable_to(self.db(), declared_ty) {
             report_invalid_assignment(&self.context, node, declared_ty, bound_ty);
@@ -896,7 +896,7 @@ impl<'db> TypeInferenceBuilder<'db> {
         let inferred_ty = bindings_ty(self.db(), prior_bindings)
             .ignore_possibly_unbound()
             .unwrap_or(Type::Never);
-        let ty = if inferred_ty.is_assignable_to(self.db(), ty.inner_type()) {
+        let ty = if inferred_ty.is_assignable_to(self.db(), ty.inner_ty()) {
             ty
         } else {
             self.context.report_lint(
@@ -904,7 +904,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                 node,
                 format_args!(
                     "Cannot declare type `{}` for inferred type `{}`",
-                    ty.inner_type().display(self.db()),
+                    ty.inner_ty().display(self.db()),
                     inferred_ty.display(self.db())
                 ),
             );
@@ -928,17 +928,17 @@ impl<'db> TypeInferenceBuilder<'db> {
                 declared_ty,
                 inferred_ty,
             } => {
-                if inferred_ty.is_assignable_to(self.db(), declared_ty.inner_type()) {
+                if inferred_ty.is_assignable_to(self.db(), declared_ty.inner_ty()) {
                     (declared_ty, inferred_ty)
                 } else {
                     report_invalid_assignment(
                         &self.context,
                         node,
-                        declared_ty.inner_type(),
+                        declared_ty.inner_ty(),
                         inferred_ty,
                     );
                     // if the assignment is invalid, fall back to assuming the annotation is correct
-                    (declared_ty, declared_ty.inner_type())
+                    (declared_ty, declared_ty.inner_ty())
                 }
             }
         };
@@ -2080,7 +2080,7 @@ impl<'db> TypeInferenceBuilder<'db> {
         );
 
         // Handle various singletons.
-        if let Type::Instance(InstanceType { class }) = declared_ty.inner_type() {
+        if let Type::Instance(InstanceType { class }) = declared_ty.inner_ty() {
             if class.is_known(self.db(), KnownClass::SpecialForm) {
                 if let Some(name_expr) = target.as_name_expr() {
                     if let Some(known_instance) = KnownInstanceType::try_from_file_and_name(
@@ -2097,7 +2097,7 @@ impl<'db> TypeInferenceBuilder<'db> {
         if let Some(value) = value.as_deref() {
             let inferred_ty = self.infer_expression(value);
             let inferred_ty = if self.in_stub() && value.is_ellipsis_literal_expr() {
-                declared_ty.inner_type()
+                declared_ty.inner_ty()
             } else {
                 inferred_ty
             };
@@ -4836,7 +4836,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                                 let inner_annotation_ty =
                                     self.infer_annotation_expression_impl(inner_annotation);
 
-                                self.store_expression_type(slice, inner_annotation_ty.inner_type());
+                                self.store_expression_type(slice, inner_annotation_ty.inner_ty());
                                 inner_annotation_ty
                             } else {
                                 self.infer_type_expression(slice);
@@ -4891,7 +4891,7 @@ impl<'db> TypeInferenceBuilder<'db> {
             type_expr => self.infer_type_expression_no_store(type_expr).into(),
         };
 
-        self.store_expression_type(annotation, annotation_ty.inner_type());
+        self.store_expression_type(annotation, annotation_ty.inner_ty());
 
         annotation_ty
     }

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -3418,8 +3418,8 @@ impl<'db> TypeInferenceBuilder<'db> {
                 let value_ty = self.infer_expression(value);
 
                 if let (ast::ExprContext::Store, Type::Instance(instance)) = (ctx, value_ty) {
-                    let qualifiers = instance.class.instance_member(self.db(), attr).1;
-                    if qualifiers.is_class_var() {
+                    let instance_member = instance.class.instance_member(self.db(), attr);
+                    if instance_member.is_class_var() {
                         self.context.report_lint(
                             &INVALID_ATTRIBUTE_ACCESS,
                             attribute.into(),


### PR DESCRIPTION
## Summary

Add support for `typing.ClassVar`, i.e. emit a diagnostic in this scenario:
```py
from typing import ClassVar

class C:
    x: ClassVar[int] = 1

c = C()
c.x = 3  # error: "Cannot assign to pure class variable `x` from an instance of type `C`"
```

## Test Plan

- New tests for the `typing.ClassVar` qualifier
- Fixed one TODO in `attributes.md`