### PR TITLE
Standardise ruff config

### DIFF
--- a/crates/ruff_python_ast/generate.py
+++ b/crates/ruff_python_ast/generate.py
@@ -174,7 +174,7 @@ def write_owned_enum(out: list[str], groups: list[Group]) -> None:
         """)
         for node in group.nodes:
             out.append(
-                f"""{group.owned_enum_ty}::{node.variant}(node) => node.visit_source_order(visitor),"""  # noqa: E501
+                f"{group.owned_enum_ty}::{node.variant}(node) => node.visit_source_order(visitor),"
             )
         out.append("""
                     }
@@ -234,7 +234,7 @@ def write_ref_enum(out: list[str], groups: list[Group]) -> None:
         """)
         for node in group.nodes:
             out.append(
-                f"""{group.owned_enum_ty}::{node.variant}(node) => {group.ref_enum_ty}::{node.variant}(node),"""  # noqa: E501
+                f"{group.owned_enum_ty}::{node.variant}(node) => {group.ref_enum_ty}::{node.variant}(node),"
             )
         out.append("""
                     }
@@ -311,7 +311,7 @@ def write_anynoderef(out: list[str], groups: list[Group]) -> None:
             """)
             for node in group.nodes:
                 out.append(
-                    f"""{group.owned_enum_ty}::{node.variant}(node) => AnyNodeRef::{node.name}(node),"""  # noqa: E501
+                    f"{group.owned_enum_ty}::{node.variant}(node) => AnyNodeRef::{node.name}(node),"
                 )
             out.append("""
                     }
@@ -326,7 +326,7 @@ def write_anynoderef(out: list[str], groups: list[Group]) -> None:
             """)
             for node in group.nodes:
                 out.append(
-                    f"""{group.ref_enum_ty}::{node.variant}(node) => AnyNodeRef::{node.name}(node),"""  # noqa: E501
+                    f"{group.ref_enum_ty}::{node.variant}(node) => AnyNodeRef::{node.name}(node),"
                 )
             out.append("""
                     }
@@ -365,7 +365,7 @@ def write_anynoderef(out: list[str], groups: list[Group]) -> None:
     for group in groups:
         for node in group.nodes:
             out.append(
-                f"""AnyNodeRef::{node.name}(node) => std::ptr::NonNull::from(*node).cast(),"""  # noqa: E501
+                f"AnyNodeRef::{node.name}(node) => std::ptr::NonNull::from(*node).cast(),"
             )
     out.append("""
                 }
@@ -385,7 +385,7 @@ def write_anynoderef(out: list[str], groups: list[Group]) -> None:
     for group in groups:
         for node in group.nodes:
             out.append(
-                f"""AnyNodeRef::{node.name}(node) => node.visit_source_order(visitor),"""  # noqa: E501
+                f"AnyNodeRef::{node.name}(node) => node.visit_source_order(visitor),"
             )
     out.append("""
                 }

--- a/crates/ruff_python_ast/generate.py
+++ b/crates/ruff_python_ast/generate.py
@@ -174,7 +174,7 @@ def write_owned_enum(out: list[str], groups: list[Group]) -> None:
         """)
         for node in group.nodes:
             out.append(
-                f"""{group.owned_enum_ty}::{node.variant}(node) => node.visit_source_order(visitor),"""
+                f"""{group.owned_enum_ty}::{node.variant}(node) => node.visit_source_order(visitor),"""  # noqa: E501
             )
         out.append("""
                     }
@@ -234,7 +234,7 @@ def write_ref_enum(out: list[str], groups: list[Group]) -> None:
         """)
         for node in group.nodes:
             out.append(
-                f"""{group.owned_enum_ty}::{node.variant}(node) => {group.ref_enum_ty}::{node.variant}(node),"""
+                f"""{group.owned_enum_ty}::{node.variant}(node) => {group.ref_enum_ty}::{node.variant}(node),"""  # noqa: E501
             )
         out.append("""
                     }
@@ -311,7 +311,7 @@ def write_anynoderef(out: list[str], groups: list[Group]) -> None:
             """)
             for node in group.nodes:
                 out.append(
-                    f"""{group.owned_enum_ty}::{node.variant}(node) => AnyNodeRef::{node.name}(node),"""
+                    f"""{group.owned_enum_ty}::{node.variant}(node) => AnyNodeRef::{node.name}(node),"""  # noqa: E501
                 )
             out.append("""
                     }
@@ -326,7 +326,7 @@ def write_anynoderef(out: list[str], groups: list[Group]) -> None:
             """)
             for node in group.nodes:
                 out.append(
-                    f"""{group.ref_enum_ty}::{node.variant}(node) => AnyNodeRef::{node.name}(node),"""
+                    f"""{group.ref_enum_ty}::{node.variant}(node) => AnyNodeRef::{node.name}(node),"""  # noqa: E501
                 )
             out.append("""
                     }
@@ -365,7 +365,7 @@ def write_anynoderef(out: list[str], groups: list[Group]) -> None:
     for group in groups:
         for node in group.nodes:
             out.append(
-                f"""AnyNodeRef::{node.name}(node) => std::ptr::NonNull::from(*node).cast(),"""
+                f"""AnyNodeRef::{node.name}(node) => std::ptr::NonNull::from(*node).cast(),"""  # noqa: E501
             )
     out.append("""
                 }
@@ -385,7 +385,7 @@ def write_anynoderef(out: list[str], groups: list[Group]) -> None:
     for group in groups:
         for node in group.nodes:
             out.append(
-                f"""AnyNodeRef::{node.name}(node) => node.visit_source_order(visitor),"""
+                f"""AnyNodeRef::{node.name}(node) => node.visit_source_order(visitor),"""  # noqa: E501
             )
     out.append("""
                 }

--- a/crates/ruff_python_formatter/generate.py
+++ b/crates/ruff_python_formatter/generate.py
@@ -113,7 +113,7 @@ for group, group_nodes in nodes_grouped.items():
                     write!(f, [verbatim_text(item)])
                 }}
             }}
-            """.strip()  # noqa: E501
+            """.strip()
 
         node_path.write_text(rustfmt(code))
 
@@ -128,7 +128,7 @@ use crate::{AsFormat, FormatNodeRule, IntoFormat, PyFormatter};
 use ruff_formatter::{FormatOwnedWithRule, FormatRefWithRule, FormatResult, FormatRule};
 use ruff_python_ast as ast;
 
-"""  # noqa: E501
+"""
 for node in nodes:
     text = f"""
         impl FormatRule<ast::{node}, PyFormatContext<'_>>
@@ -170,7 +170,7 @@ for node in nodes:
                 )
             }}
         }}
-    """  # noqa: E501
+    """
     generated += text
 
 out.write_text(rustfmt(generated))

--- a/crates/ruff_python_formatter/generate.py
+++ b/crates/ruff_python_formatter/generate.py
@@ -3,6 +3,7 @@
 """See CONTRIBUTING.md"""
 
 # %%
+from __future__ import annotations
 
 import re
 from collections import defaultdict
@@ -34,8 +35,8 @@ nodes = []
 for node_line in node_lines:
     node = node_line.split("(")[1].split(")")[0].split("::")[-1].removeprefix("&'a ")
     # `FString` has a custom implementation while the formatting for
-    # `FStringLiteralElement`, `FStringFormatSpec` and `FStringExpressionElement` are handled by the `FString`
-    # implementation.
+    # `FStringLiteralElement`, `FStringFormatSpec` and `FStringExpressionElement` are
+    # handled by the `FString` implementation.
     if node in (
         "FStringLiteralElement",
         "FStringExpressionElement",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,6 @@ extend-exclude = [
   "crates/ruff_python_formatter/resources/",
   "crates/ruff_python_parser/resources/"
 ]
-line-length = 88
 
 [tool.ruff.lint]
 select = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,31 +11,31 @@ readme = "README.md"
 requires-python = ">=3.7"
 license = { file = "LICENSE" }
 keywords = [
-  "automation",
-  "flake8",
-  "pycodestyle",
-  "pyflakes",
-  "pylint",
-  "clippy",
+    "automation",
+    "flake8",
+    "pycodestyle",
+    "pyflakes",
+    "pylint",
+    "clippy",
 ]
 classifiers = [
-  "Development Status :: 5 - Production/Stable",
-  "Environment :: Console",
-  "Intended Audience :: Developers",
-  "License :: OSI Approved :: MIT License",
-  "Operating System :: OS Independent",
-  "Programming Language :: Python",
-  "Programming Language :: Python :: 3.7",
-  "Programming Language :: Python :: 3.8",
-  "Programming Language :: Python :: 3.9",
-  "Programming Language :: Python :: 3.10",
-  "Programming Language :: Python :: 3.11",
-  "Programming Language :: Python :: 3.12",
-  "Programming Language :: Python :: 3.13",
-  "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Rust",
-  "Topic :: Software Development :: Libraries :: Python Modules",
-  "Topic :: Software Development :: Quality Assurance",
+    "Development Status :: 5 - Production/Stable",
+    "Environment :: Console",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Rust",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "Topic :: Software Development :: Quality Assurance",
 ]
 
 [project.urls]
@@ -50,45 +50,46 @@ module-name = "ruff"
 python-source = "python"
 strip = true
 exclude = [
-  "crates/ruff_linter/resources/test/fixtures/**/*",
-  "crates/ruff_linter/src/rules/*/snapshots/**/*"
+    "crates/ruff_linter/resources/test/fixtures/**/*",
+    "crates/ruff_linter/src/rules/*/snapshots/**/*"
 ]
 include = [
-  "rust-toolchain.toml"
+    "rust-toolchain.toml"
 ]
 
 [tool.ruff]
 target-version = "py38"
 extend-exclude = [
-  "crates/red_knot_vendored/vendor/",
-  "crates/ruff/resources/",
-  "crates/ruff_linter/resources/",
-  "crates/ruff_python_formatter/resources/",
-  "crates/ruff_python_parser/resources/"
+    "crates/red_knot_vendored/vendor/",
+    "crates/ruff/resources/",
+    "crates/ruff_linter/resources/",
+    "crates/ruff_python_formatter/resources/",
+    "crates/ruff_python_parser/resources/"
 ]
 
 [tool.ruff.lint]
 select = [
-  "E", # pycodestyle (error)
-  "F", # pyflakes
-  "B", # bugbear
-  "B9",
-  "C4", # flake8-comprehensions
-  "SIM", # flake8-simplify
-  "I", # isort
-  "UP", # pyupgrade
-  "PIE", # flake8-pie
-  "PGH", # pygrep-hooks
-  "PYI", # flake8-pyi
-  "RUF",
+    "E", # pycodestyle (error)
+    "F", # pyflakes
+    "B", # bugbear
+    "B9",
+    "C4", # flake8-comprehensions
+    "SIM", # flake8-simplify
+    "I", # isort
+    "UP", # pyupgrade
+    "PIE", # flake8-pie
+    "PGH", # pygrep-hooks
+    "PYI", # flake8-pyi
+    "RUF",
 ]
 
 ignore = [
-  # Conflicts with the formatter
-  "COM812",
-  # only relevant if you run a script with `python -0`,
-  # which seems unlikely for any of the scripts in this repo
-  "B011",
+    # only relevant if you run a script with `python -0`,
+    # which seems unlikely for any of the scripts in this repo
+    "B011",
+    # Leave it to the formatter to split long lines and
+    # the judgement of all of us.
+    "E501"
 ]
 
 [tool.ruff.lint.isort]
@@ -131,11 +132,11 @@ changelog_sections.__unknown__ = "Other changes"
 changelog_contributors = false
 
 version_files = [
-  "README.md",
-  "docs/integrations.md",
-  "docs/tutorial.md",
-  "crates/ruff/Cargo.toml",
-  "crates/ruff_linter/Cargo.toml",
-  "crates/ruff_wasm/Cargo.toml",
-  "scripts/benchmarks/pyproject.toml",
+    "README.md",
+    "docs/integrations.md",
+    "docs/tutorial.md",
+    "crates/ruff/Cargo.toml",
+    "crates/ruff_linter/Cargo.toml",
+    "crates/ruff_wasm/Cargo.toml",
+    "scripts/benchmarks/pyproject.toml",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ include = [
 ]
 
 [tool.ruff]
+target-version = "py39"
 extend-exclude = [
   "crates/red_knot_vendored/vendor/",
   "crates/ruff/resources/",
@@ -65,15 +66,35 @@ extend-exclude = [
   "crates/ruff_python_formatter/resources/",
   "crates/ruff_python_parser/resources/"
 ]
+line-length = 88
 
 [tool.ruff.lint]
+select = [
+  "E", # pycodestyle (error)
+  "F", # pyflakes
+  "B", # bugbear
+  "B9",
+  "C4", # flake8-comprehensions
+  "SIM", # flake8-simplify
+  "I", # isort
+  "UP", # pyupgrade
+  "PIE", # flake8-pie
+  "PGH", # pygrep-hooks
+  "PYI", # flake8-pyi
+  "RUF",
+]
+
 ignore = [
   # Conflicts with the formatter
-  "COM812", "ISC001"
+  "COM812",
+  "ISC001",
+  # only relevant if you run a script with `python -0`,
+  # which seems unlikely for any of the scripts in this directory
+  "B011",
 ]
-extend-select = [
-  "I",
-]
+
+[tool.ruff.lint.isort]
+required-imports = ["from __future__ import annotations"]
 
 [tool.black]
 force-exclude = '''

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ include = [
 ]
 
 [tool.ruff]
-target-version = "py39"
+target-version = "py38"
 extend-exclude = [
   "crates/red_knot_vendored/vendor/",
   "crates/ruff/resources/",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,7 @@ ignore = [
   "COM812",
   "ISC001",
   # only relevant if you run a script with `python -0`,
-  # which seems unlikely for any of the scripts in this directory
+  # which seems unlikely for any of the scripts in this repo
   "B011",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,7 +87,6 @@ select = [
 ignore = [
   # Conflicts with the formatter
   "COM812",
-  "ISC001",
   # only relevant if you run a script with `python -0`,
   # which seems unlikely for any of the scripts in this repo
   "B011",

--- a/scripts/check_ecosystem.py
+++ b/scripts/check_ecosystem.py
@@ -449,7 +449,7 @@ async def main(
 
                     if matches is None:
                         # Handle case where there are no regex matches e.g.
-                        # +                 "?application=AIRFLOW&authenticator=TEST_AUTH&role=TEST_ROLE&warehouse=TEST_WAREHOUSE" # noqa: E501
+                        # +                 "?application=AIRFLOW&authenticator=TEST_AUTH&role=TEST_ROLE&warehouse=TEST_WAREHOUSE"
                         # Which was found in local testing
                         continue
 

--- a/scripts/pyproject.toml
+++ b/scripts/pyproject.toml
@@ -8,29 +8,4 @@ requires-python = ">=3.11"
 line-length = 88
 
 [tool.ruff]
-line-length = 88
-
-[tool.ruff.lint]
-select = [
-  "E",   # pycodestyle (error)
-  "F",   # pyflakes
-  "B",   # bugbear
-  "B9",
-  "C4",  # flake8-comprehensions
-  "SIM", # flake8-simplify
-  "I",   # isort
-  "UP",  # pyupgrade
-  "PIE", # flake8-pie
-  "PGH", # pygrep-hooks
-  "PYI", # flake8-pyi
-  "RUF",
-]
-
-ignore = [
-  # only relevant if you run a script with `python -0`,
-  # which seems unlikely for any of the scripts in this directory
-  "B011"
-]
-
-[tool.ruff.lint.isort]
-required-imports = ["from __future__ import annotations"]
+extend = "../pyproject.toml"


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Follow up to #15544 and https://github.com/astral-sh/ruff/pull/15544#pullrequestreview-2559748582 to move the Ruff config used in scripts into the `pyproject.toml` in the root directory now that Python scripts are being added outwith the scripts directory.

Only changes required relate to line length. I have updated to split at 88 characters; however, if a `noqa` would be better in this instance, please let me know, and I can update.

## Test Plan

- Pre-commit ci stage to ensure that all changes identified by the new config are caught. 
- The new ci step added in #15544 (https://github.com/astral-sh/ruff/blob/main/.github/workflows/ci.yaml#L389-L393) to ensure that the updated line lengths don't produce an incorrect result.