### PR TITLE
Include more labels in CHANGELOG sections

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,12 +89,17 @@ force-exclude = '''
 major_labels = []  # Ruff never uses the major version number
 minor_labels = ["breaking"]   # Bump the minor version on breaking changes
 
-changelog_ignore_labels = ["internal", "ci", "red-knot"]
+changelog_ignore_labels = ["internal", "ci", "red-knot", "testing"]
 
 changelog_sections.breaking = "Breaking changes"
 changelog_sections.preview = "Preview features"
 changelog_sections.rule = "Rule changes"
+changelog_sections.diagnostics = "Rule changes"
+changelog_sections.docstring = "Rule changes"
+changelog_sections.fixes = "Rule changes"
 changelog_sections.formatter = "Formatter"
+changelog_sections.isort = "Rule changes"
+changelog_sections.performance = "Performance"
 changelog_sections.server = "Server"
 changelog_sections.cli = "CLI"
 changelog_sections.configuration = "Configuration"


### PR DESCRIPTION
## Summary

This PR updates Rooster config to include more labels, specifically:
* Include [`diagnostics`](https://github.com/astral-sh/ruff/labels/diagnostics), [`docstring`](https://github.com/astral-sh/ruff/labels/docstring), [`fixes`](https://github.com/astral-sh/ruff/labels/fixes) and [`isort`](https://github.com/astral-sh/ruff/labels/isort) for "Rule changes" section
* Use [`performance`](https://github.com/astral-sh/ruff/labels/performance) for "Performance" section. We already have included "Performance" section in various version, so let's make it official :)
* Ignore [`testing`](https://github.com/astral-sh/ruff/labels/testing) label

The following is open:
* [`suppression`](https://github.com/astral-sh/ruff/labels/suppression)