### PR TITLE
Group redefinition fixes by source statement

### DIFF
--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_21.py.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_21.py.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/ruff_linter/src/rules/pyflakes/mod.rs
-snapshot_kind: text
 ---
 F811_21.py:32:5: F811 [*] Redefinition of unused `Sequence` from line 26
    |
@@ -13,12 +12,13 @@ F811_21.py:32:5: F811 [*] Redefinition of unused `Sequence` from line 26
    = help: Remove definition: `Sequence`
 
 ℹ Safe fix
+27 27 | )
+28 28 | 
 29 29 | # This should ignore the first error.
-30 30 | from typing import (
-31 31 |     List,  # noqa: F811
+30    |-from typing import (
+31    |-    List,  # noqa: F811
 32    |-    Sequence,
 33    |-)
-   32 |+    )
-34 33 | 
-35 34 | # This should ignore both errors.
-36 35 | from typing import (  # noqa
+34 30 | 
+35 31 | # This should ignore both errors.
+36 32 | from typing import (  # noqa


### PR DESCRIPTION
## Summary

Like unused imports, we should create a single fix for all redefined members in a single statement.

Closes https://github.com/astral-sh/ruff/issues/15182.
