### PR TITLE
Apply redefinition fixes by source code order

### DIFF
--- a/crates/ruff_linter/src/fix/mod.rs
+++ b/crates/ruff_linter/src/fix/mod.rs
@@ -134,6 +134,7 @@ fn cmp_fix(rule1: Rule, rule2: Rule, fix1: &Fix, fix2: &Fix) -> std::cmp::Orderi
     // `< is transitive: a < b and b < c implies a < c. The same must hold for both == and >.`
     // See https://github.com/astral-sh/ruff/issues/12469#issuecomment-2244392085
     match (rule1, rule2) {
+        (Rule::RedefinedWhileUnused, Rule::RedefinedWhileUnused) => std::cmp::Ordering::Equal,
         (Rule::RedefinedWhileUnused, _) => std::cmp::Ordering::Less,
         (_, Rule::RedefinedWhileUnused) => std::cmp::Ordering::Greater,
         _ => std::cmp::Ordering::Equal,


### PR DESCRIPTION
## Summary

Right now, these are being applied in random order, since if we have two `RedefinitionWhileUnused`, it just takes the first-generated (whereas the next comparator in the sort here orders by location)... Which means we frequently have to re-run!
