### PR TITLE
Ignore notebook with syntax error in ecosystem

### DIFF
--- a/python/ruff-ecosystem/ruff_ecosystem/defaults.py
+++ b/python/ruff-ecosystem/ruff_ecosystem/defaults.py
@@ -121,6 +121,7 @@ DEFAULT_TARGETS = [
             # These notebooks contain syntax errors because certain plain text / markdown
             # cells are marked as code cells.
             "exclude": [
+                "examples/Assistants_API_overview_python.ipynb",
                 "examples/Chat_finetuning_data_prep.ipynb",
                 "examples/chatgpt/gpt_actions_library/gpt_action_google_drive.ipynb",
                 "examples/chatgpt/gpt_actions_library/gpt_action_redshift.ipynb",


### PR DESCRIPTION
I'll open a PR in `openai/openai-cookbook` to fix these syntax errors later but for now let's just ignore the notebook.

<img width="2560" alt="Screenshot 2025-01-20 at 10 17 43 AM" src="https://github.com/user-attachments/assets/075127e4-956d-43f9-b175-b492600dbdee" />
