### PR TITLE
Isolate `show_settings` test from Ruff's `pyproject.toml

### DIFF
--- a/crates/ruff/tests/snapshots/show_settings__display_default_settings.snap
+++ b/crates/ruff/tests/snapshots/show_settings__display_default_settings.snap
@@ -1,21 +1,20 @@
 ---
 source: crates/ruff/tests/show_settings.rs
-assertion_line: 30
 info:
   program: ruff
   args:
     - check
     - "--show-settings"
-    - unformatted.py
+    - test.py
 ---
 success: true
 exit_code: 0
 ----- stdout -----
-Resolved settings for: "[BASEPATH]/crates/ruff/resources/test/fixtures/unformatted.py"
-Settings path: "[BASEPATH]/pyproject.toml"
+Resolved settings for: "<temp_dir>/test.py"
+Settings path: "<temp_dir>/pyproject.toml"
 
 # General Settings
-cache_dir = "[BASEPATH]/.ruff_cache"
+cache_dir = "<temp_dir>/.ruff_cache"
 fix = false
 fix_only = false
 output_format = full
@@ -50,13 +49,7 @@ file_resolver.exclude = [
 	"site-packages",
 	"venv",
 ]
-file_resolver.extend_exclude = [
-	"crates/red_knot_vendored/vendor/",
-	"crates/ruff/resources/",
-	"crates/ruff_linter/resources/",
-	"crates/ruff_python_formatter/resources/",
-	"crates/ruff_python_parser/resources/",
-]
+file_resolver.extend_exclude = []
 file_resolver.force_exclude = false
 file_resolver.include = [
 	"*.py",
@@ -66,14 +59,12 @@ file_resolver.include = [
 ]
 file_resolver.extend_include = []
 file_resolver.respect_gitignore = true
-file_resolver.project_root = "[BASEPATH]"
+file_resolver.project_root = "<temp_dir>/"
 
 # Linter Settings
 linter.exclude = []
-linter.project_root = "[BASEPATH]"
+linter.project_root = "<temp_dir>/"
 linter.rules.enabled = [
-	unsorted-imports (I001),
-	missing-required-import (I002),
 	multiple-imports-on-one-line (E401),
 	module-import-not-at-top-of-file (E402),
 	multiple-statements-on-one-line-colon (E701),
@@ -135,8 +126,6 @@ linter.rules.enabled = [
 	raise-not-implemented (F901),
 ]
 linter.rules.should_fix = [
-	unsorted-imports (I001),
-	missing-required-import (I002),
 	multiple-imports-on-one-line (E401),
 	module-import-not-at-top-of-file (E402),
 	multiple-statements-on-one-line-colon (E701),
@@ -212,11 +201,11 @@ linter.ignore_init_module_imports = true
 linter.logger_objects = []
 linter.namespace_packages = []
 linter.src = [
-	"[BASEPATH]",
-	"[BASEPATH]/src",
+	"<temp_dir>/",
+	"<temp_dir>/src",
 ]
 linter.tab_size = 4
-linter.line_length = 88
+linter.line_length = 100
 linter.task_tags = [
 	TODO,
 	FIXME,
@@ -358,7 +347,7 @@ linter.pep8_naming.ignore_names = [
 ]
 linter.pep8_naming.classmethod_decorators = []
 linter.pep8_naming.staticmethod_decorators = []
-linter.pycodestyle.max_line_length = 88
+linter.pycodestyle.max_line_length = 100
 linter.pycodestyle.max_doc_length = none
 linter.pycodestyle.ignore_overlong_task_comments = false
 linter.pyflakes.extend_generics = []
@@ -385,7 +374,7 @@ linter.ruff.allowed_markup_calls = []
 formatter.exclude = []
 formatter.target_version = Py37
 formatter.preview = disabled
-formatter.line_width = 88
+formatter.line_width = 100
 formatter.line_ending = auto
 formatter.indent_style = space
 formatter.indent_width = 4


### PR DESCRIPTION
## Summary

In preperation for https://github.com/astral-sh/ruff/pull/15558

Isolate the `show_settings` test instead of reading Ruff's `pyproject.toml` for better test isolation.

## Test Plan

`cargo test`
