### PR TITLE
[`airflow`] Extend `AIR303` with more symbols

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/airflow/AIR303.py
+++ b/crates/ruff_linter/resources/test/fixtures/airflow/AIR303.py
@@ -17,6 +17,7 @@ from airflow.hooks.dbapi import ConnectorProtocol, DbApiHook
 from airflow.hooks.dbapi_hook import DbApiHook as DbApiHook2
 from airflow.hooks.docker_hook import DockerHook
 from airflow.hooks.druid_hook import DruidDbApiHook, DruidHook
+from airflow.hooks.filesystem import FSHook
 from airflow.hooks.hive_hooks import (
     HIVE_QUEUE_PRIORITIES,
     HiveCliHook,
@@ -28,6 +29,7 @@ from airflow.hooks.jdbc_hook import JdbcHook, jaydebeapi
 from airflow.hooks.mssql_hook import MsSqlHook
 from airflow.hooks.mysql_hook import MySqlHook
 from airflow.hooks.oracle_hook import OracleHook
+from airflow.hooks.package_index import PackageIndexHook
 from airflow.hooks.pig_hook import PigCliHook
 from airflow.hooks.postgres_hook import PostgresHook
 from airflow.hooks.presto_hook import PrestoHook
@@ -35,6 +37,7 @@ from airflow.hooks.S3_hook import S3Hook, provide_bucket_name
 from airflow.hooks.samba_hook import SambaHook
 from airflow.hooks.slack_hook import SlackHook
 from airflow.hooks.sqlite_hook import SqliteHook
+from airflow.hooks.subprocess import SubprocessHook
 from airflow.hooks.webhdfs_hook import WebHDFSHook
 from airflow.hooks.zendesk_hook import ZendeskHook
 from airflow.kubernetes.k8s_model import K8SModel, append_to_pod
@@ -87,6 +90,7 @@ from airflow.operators.check_operator import (
     ThresholdCheckOperator,
     ValueCheckOperator,
 )
+from airflow.operators.datetime import BranchDateTimeOperator
 from airflow.operators.docker_operator import DockerOperator
 from airflow.operators.druid_check_operator import DruidCheckOperator
 from airflow.operators.gcs_to_s3 import GCSToS3Operator
@@ -145,6 +149,11 @@ from airflow.operators.sql import (
     parse_boolean,
 )
 from airflow.operators.sqlite_operator import SqliteOperator
+from airflow.operators.trigger_dagrun import TriggerDagRunOperator
+from airflow.operators.weekday import BranchDayOfWeekOperator
+from airflow.sensors.date_time import DateTimeSensor
+from airflow.sensors.external_task import ExternalTaskMarker, ExternalTaskSensor
+from airflow.sensors.filesystem import FileSensor
 from airflow.sensors.hive_partition_sensor import HivePartitionSensor
 from airflow.sensors.http_sensor import HttpSensor
 from airflow.sensors.metastore_partition_sensor import MetastorePartitionSensor
@@ -152,7 +161,13 @@ from airflow.sensors.named_hive_partition_sensor import NamedHivePartitionSensor
 from airflow.sensors.s3_key_sensor import S3KeySensor
 from airflow.sensors.sql import SqlSensor
 from airflow.sensors.sql_sensor import SqlSensor2
+from airflow.sensors.time_delta import TimeDeltaSensor
+from airflow.sensors.time_sensor import TimeSensor
 from airflow.sensors.web_hdfs_sensor import WebHdfsSensor
+from airflow.sensors.weekday import DayOfWeekSensor
+from airflow.triggers.external_task import WorkflowTrigger
+from airflow.triggers.file import FileTrigger
+from airflow.triggers.temporal import DateTimeTrigger
 from airflow.www.security import FabAirflowSecurityManagerOverride
 
 # apache-airflow-providers-amazon
@@ -349,3 +364,20 @@ SqliteOperator()
 
 # apache-airflow-providers-zendesk
 ZendeskHook()
+
+# apache-airflow-providers-standard
+FileSensor()
+TriggerDagRunOperator()
+ExternalTaskMarker(), ExternalTaskSensor()
+BranchDateTimeOperator()
+BranchDayOfWeekOperator()
+DateTimeSensor()
+TimeSensor()
+TimeDeltaSensor()
+DayOfWeekSensor()
+FSHook()
+PackageIndexHook()
+SubprocessHook()
+WorkflowTrigger()
+FileTrigger()
+DateTimeTrigger()

--- a/crates/ruff_linter/src/rules/airflow/rules/moved_to_provider_in_3.rs
+++ b/crates/ruff_linter/src/rules/airflow/rules/moved_to_provider_in_3.rs
@@ -902,6 +902,101 @@ fn check_names_moved_to_provider(checker: &mut Checker, expr: &Expr, ranged: Tex
             version: "1.0.0"
         },
 
+        // apache-airflow-providers-standard
+        ["airflow", "operators", "datetime"] => Replacement::ImportPathMoved{
+            original_path: "airflow.operators.datetime",
+            new_path: "airflow.providers.standard.time.operators.datetime",
+            provider: "standard",
+            version: "0.0.1"
+        },
+        ["airflow", "operators", "weekday"] => Replacement::ImportPathMoved{
+            original_path: "airflow.operators.weekday",
+            new_path: "airflow.providers.standard.time.operators.weekday",
+            provider: "standard",
+            version: "0.0.1"
+        },
+        ["airflow", "sensors", "date_time"] => Replacement::ImportPathMoved{
+            original_path: "airflow.sensors.date_time",
+            new_path: "airflow.providers.standard.time.sensors.date_time",
+            provider: "standard",
+            version: "0.0.1"
+        },
+        ["airflow", "sensors", "time_sensor"] => Replacement::ImportPathMoved{
+            original_path: "airflow.sensors.time_sensor",
+            new_path: "airflow.providers.standard.time.sensors.time",
+            provider: "standard",
+            version: "0.0.1"
+        },
+        ["airflow", "sensors", "time_delta"] => Replacement::ImportPathMoved{
+            original_path: "airflow.sensors.time_delta",
+            new_path: "airflow.providers.standard.time.sensors.time_delta",
+            provider: "standard",
+            version: "0.0.1"
+        },
+        ["airflow", "sensors", "weekday"] => Replacement::ImportPathMoved{
+            original_path: "airflow.sensors.weekday",
+            new_path: "airflow.providers.standard.time.sensors.weekday",
+            provider: "standard",
+            version: "0.0.1"
+        },
+        ["airflow", "hooks", "filesystem"] => Replacement::ImportPathMoved{
+            original_path: "airflow.hooks.filesystem",
+            new_path: "airflow.providers.standard.hooks.filesystem",
+            provider: "standard",
+            version: "0.0.1"
+        },
+        ["airflow", "hooks", "package_index"] => Replacement::ImportPathMoved{
+            original_path: "airflow.hooks.package_index",
+            new_path: "airflow.providers.standard.hooks.package_index",
+            provider: "standard",
+            version: "0.0.1"
+        },
+        ["airflow", "hooks", "subprocess"] => Replacement::ImportPathMoved{
+            original_path: "airflow.hooks.subprocess",
+            new_path: "airflow.providers.standard.hooks.subprocess",
+            provider: "standard",
+            version: "0.0.1"
+        },
+
+        ["airflow", "triggers", "external_task"] => Replacement::ImportPathMoved{
+            original_path: "airflow.triggers.external_task",
+            new_path: "airflow.providers.standard.triggers.external_task",
+            provider: "standard",
+            version: "0.0.3"
+        },
+        ["airflow", "triggers", "file"] => Replacement::ImportPathMoved{
+            original_path: "airflow.triggers.file",
+            new_path: "airflow.providers.standard.triggers.file",
+            provider: "standard",
+            version: "0.0.3"
+        },
+        ["airflow", "triggers", "temporal"] => Replacement::ImportPathMoved{
+            original_path: "airflow.triggers.temporal",
+            new_path: "airflow.providers.standard.triggers.temporal",
+            provider: "standard",
+            version: "0.0.3"
+        },
+        ["airflow", "sensors", "filesystem", "FileSensor"] => Replacement::ProviderName{
+            name: "airflow.providers.standard.sensors.filesystem.FileSensor",
+            provider: "standard",
+            version: "0.0.2"
+        },
+        ["airflow", "operators", "trigger_dagrun", "TriggerDagRunOperator"] => Replacement::ProviderName{
+            name: "airflow.providers.standard.operators.trigger_dagrun.TriggerDagRunOperator",
+            provider: "standard",
+            version: "0.0.2"
+        },
+        ["airflow", "sensors", "external_task", "ExternalTaskMarker"] => Replacement::ProviderName{
+            name: "airflow.providers.standard.sensors.external_task.ExternalTaskMarker",
+            provider: "standard",
+            version: "0.0.3"
+        },
+        ["airflow", "sensors", "external_task", "ExternalTaskSensor"] => Replacement::ProviderName{
+            name: "airflow.providers.standard.sensors.external_task.ExternalTaskSensor",
+            provider: "standard",
+            version: "0.0.3"
+        },
+
         // apache-airflow-providers-sqlite
         ["airflow", "hooks", "sqlite_hook", "SqliteHook"] => Replacement::ProviderName{
             name: "airflow.providers.sqlite.hooks.sqlite.SqliteHook",

--- a/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR303_AIR303.py.snap
+++ b/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR303_AIR303.py.snap
@@ -1,1549 +1,1595 @@
 ---
 source: crates/ruff_linter/src/rules/airflow/mod.rs
+snapshot_kind: text
 ---
-AIR303.py:159:1: AIR303 `airflow.hooks.S3_hook.provide_bucket_name` is moved into `amazon` provider in Airflow 3.0;
+AIR303.py:174:1: AIR303 `airflow.hooks.S3_hook.provide_bucket_name` is moved into `amazon` provider in Airflow 3.0;
     |
-158 | # apache-airflow-providers-amazon
-159 | provide_bucket_name()
+173 | # apache-airflow-providers-amazon
+174 | provide_bucket_name()
     | ^^^^^^^^^^^^^^^^^^^ AIR303
-160 | GCSToS3Operator()
-161 | GoogleApiToS3Operator()
+175 | GCSToS3Operator()
+176 | GoogleApiToS3Operator()
     |
     = help: Install `apache-airflow-provider-amazon>=1.0.0` and use `airflow.providers.amazon.aws.hooks.s3.provide_bucket_name` instead.
 
-AIR303.py:160:1: AIR303 `airflow.operators.gcs_to_s3.GCSToS3Operator` is moved into `amazon` provider in Airflow 3.0;
+AIR303.py:175:1: AIR303 `airflow.operators.gcs_to_s3.GCSToS3Operator` is moved into `amazon` provider in Airflow 3.0;
     |
-158 | # apache-airflow-providers-amazon
-159 | provide_bucket_name()
-160 | GCSToS3Operator()
+173 | # apache-airflow-providers-amazon
+174 | provide_bucket_name()
+175 | GCSToS3Operator()
     | ^^^^^^^^^^^^^^^ AIR303
-161 | GoogleApiToS3Operator()
-162 | GoogleApiToS3Transfer()
+176 | GoogleApiToS3Operator()
+177 | GoogleApiToS3Transfer()
     |
     = help: Install `apache-airflow-provider-amazon>=1.0.0` and use `airflow.providers.amazon.aws.transfers.gcs_to_s3.GCSToS3Operator` instead.
 
-AIR303.py:161:1: AIR303 `airflow.operators.google_api_to_s3_transfer.GoogleApiToS3Operator` is moved into `amazon` provider in Airflow 3.0;
+AIR303.py:176:1: AIR303 `airflow.operators.google_api_to_s3_transfer.GoogleApiToS3Operator` is moved into `amazon` provider in Airflow 3.0;
     |
-159 | provide_bucket_name()
-160 | GCSToS3Operator()
-161 | GoogleApiToS3Operator()
+174 | provide_bucket_name()
+175 | GCSToS3Operator()
+176 | GoogleApiToS3Operator()
     | ^^^^^^^^^^^^^^^^^^^^^ AIR303
-162 | GoogleApiToS3Transfer()
-163 | RedshiftToS3Operator()
+177 | GoogleApiToS3Transfer()
+178 | RedshiftToS3Operator()
     |
     = help: Install `apache-airflow-provider-amazon>=1.0.0` and use `airflow.providers.amazon.aws.transfers.google_api_to_s3.GoogleApiToS3Operator` instead.
 
-AIR303.py:162:1: AIR303 `airflow.operators.google_api_to_s3_transfer.GoogleApiToS3Transfer` is moved into `amazon` provider in Airflow 3.0;
+AIR303.py:177:1: AIR303 `airflow.operators.google_api_to_s3_transfer.GoogleApiToS3Transfer` is moved into `amazon` provider in Airflow 3.0;
     |
-160 | GCSToS3Operator()
-161 | GoogleApiToS3Operator()
-162 | GoogleApiToS3Transfer()
+175 | GCSToS3Operator()
+176 | GoogleApiToS3Operator()
+177 | GoogleApiToS3Transfer()
     | ^^^^^^^^^^^^^^^^^^^^^ AIR303
-163 | RedshiftToS3Operator()
-164 | RedshiftToS3Transfer()
+178 | RedshiftToS3Operator()
+179 | RedshiftToS3Transfer()
     |
     = help: Install `apache-airflow-provider-amazon>=1.0.0` and use `airflow.providers.amazon.aws.transfers.google_api_to_s3.GoogleApiToS3Operator` instead.
 
-AIR303.py:163:1: AIR303 `airflow.operators.redshift_to_s3_operator.RedshiftToS3Operator` is moved into `amazon` provider in Airflow 3.0;
+AIR303.py:178:1: AIR303 `airflow.operators.redshift_to_s3_operator.RedshiftToS3Operator` is moved into `amazon` provider in Airflow 3.0;
     |
-161 | GoogleApiToS3Operator()
-162 | GoogleApiToS3Transfer()
-163 | RedshiftToS3Operator()
+176 | GoogleApiToS3Operator()
+177 | GoogleApiToS3Transfer()
+178 | RedshiftToS3Operator()
     | ^^^^^^^^^^^^^^^^^^^^ AIR303
-164 | RedshiftToS3Transfer()
-165 | S3FileTransformOperator()
+179 | RedshiftToS3Transfer()
+180 | S3FileTransformOperator()
     |
     = help: Install `apache-airflow-provider-amazon>=1.0.0` and use `airflow.providers.amazon.aws.transfers.redshift_to_s3.RedshiftToS3Operator` instead.
 
-AIR303.py:164:1: AIR303 `airflow.operators.redshift_to_s3_operator.RedshiftToS3Transfer` is moved into `amazon` provider in Airflow 3.0;
+AIR303.py:179:1: AIR303 `airflow.operators.redshift_to_s3_operator.RedshiftToS3Transfer` is moved into `amazon` provider in Airflow 3.0;
     |
-162 | GoogleApiToS3Transfer()
-163 | RedshiftToS3Operator()
-164 | RedshiftToS3Transfer()
+177 | GoogleApiToS3Transfer()
+178 | RedshiftToS3Operator()
+179 | RedshiftToS3Transfer()
     | ^^^^^^^^^^^^^^^^^^^^ AIR303
-165 | S3FileTransformOperator()
-166 | S3Hook()
+180 | S3FileTransformOperator()
+181 | S3Hook()
     |
     = help: Install `apache-airflow-provider-amazon>=1.0.0` and use `airflow.providers.amazon.aws.transfers.redshift_to_s3.RedshiftToS3Operator` instead.
 
-AIR303.py:165:1: AIR303 `airflow.operators.s3_file_transform_operator.S3FileTransformOperator` is moved into `amazon` provider in Airflow 3.0;
+AIR303.py:180:1: AIR303 `airflow.operators.s3_file_transform_operator.S3FileTransformOperator` is moved into `amazon` provider in Airflow 3.0;
     |
-163 | RedshiftToS3Operator()
-164 | RedshiftToS3Transfer()
-165 | S3FileTransformOperator()
+178 | RedshiftToS3Operator()
+179 | RedshiftToS3Transfer()
+180 | S3FileTransformOperator()
     | ^^^^^^^^^^^^^^^^^^^^^^^ AIR303
-166 | S3Hook()
-167 | S3KeySensor()
+181 | S3Hook()
+182 | S3KeySensor()
     |
     = help: Install `apache-airflow-provider-amazon>=1.0.0` and use `airflow.providers.amazon.aws.operators.s3_file_transform.S3FileTransformOperator` instead.
 
-AIR303.py:166:1: AIR303 `airflow.hooks.S3_hook.S3Hook` is moved into `amazon` provider in Airflow 3.0;
+AIR303.py:181:1: AIR303 `airflow.hooks.S3_hook.S3Hook` is moved into `amazon` provider in Airflow 3.0;
     |
-164 | RedshiftToS3Transfer()
-165 | S3FileTransformOperator()
-166 | S3Hook()
+179 | RedshiftToS3Transfer()
+180 | S3FileTransformOperator()
+181 | S3Hook()
     | ^^^^^^ AIR303
-167 | S3KeySensor()
-168 | S3ToRedshiftOperator()
+182 | S3KeySensor()
+183 | S3ToRedshiftOperator()
     |
     = help: Install `apache-airflow-provider-amazon>=1.0.0` and use `airflow.providers.amazon.aws.hooks.s3.S3Hook` instead.
 
-AIR303.py:167:1: AIR303 `airflow.sensors.s3_key_sensor.S3KeySensor` is moved into `amazon` provider in Airflow 3.0;
+AIR303.py:182:1: AIR303 `airflow.sensors.s3_key_sensor.S3KeySensor` is moved into `amazon` provider in Airflow 3.0;
     |
-165 | S3FileTransformOperator()
-166 | S3Hook()
-167 | S3KeySensor()
+180 | S3FileTransformOperator()
+181 | S3Hook()
+182 | S3KeySensor()
     | ^^^^^^^^^^^ AIR303
-168 | S3ToRedshiftOperator()
-169 | S3ToRedshiftTransfer()
+183 | S3ToRedshiftOperator()
+184 | S3ToRedshiftTransfer()
     |
     = help: Install `apache-airflow-provider-amazon>=1.0.0` and use `S3KeySensor` instead.
 
-AIR303.py:168:1: AIR303 `airflow.operators.s3_to_redshift_operator.S3ToRedshiftOperator` is moved into `amazon` provider in Airflow 3.0;
+AIR303.py:183:1: AIR303 `airflow.operators.s3_to_redshift_operator.S3ToRedshiftOperator` is moved into `amazon` provider in Airflow 3.0;
     |
-166 | S3Hook()
-167 | S3KeySensor()
-168 | S3ToRedshiftOperator()
+181 | S3Hook()
+182 | S3KeySensor()
+183 | S3ToRedshiftOperator()
     | ^^^^^^^^^^^^^^^^^^^^ AIR303
-169 | S3ToRedshiftTransfer()
+184 | S3ToRedshiftTransfer()
     |
     = help: Install `apache-airflow-provider-amazon>=1.0.0` and use `airflow.providers.amazon.aws.transfers.s3_to_redshift.S3ToRedshiftOperator` instead.
 
-AIR303.py:169:1: AIR303 `airflow.operators.s3_to_redshift_operator.S3ToRedshiftTransfer` is moved into `amazon` provider in Airflow 3.0;
+AIR303.py:184:1: AIR303 `airflow.operators.s3_to_redshift_operator.S3ToRedshiftTransfer` is moved into `amazon` provider in Airflow 3.0;
     |
-167 | S3KeySensor()
-168 | S3ToRedshiftOperator()
-169 | S3ToRedshiftTransfer()
+182 | S3KeySensor()
+183 | S3ToRedshiftOperator()
+184 | S3ToRedshiftTransfer()
     | ^^^^^^^^^^^^^^^^^^^^ AIR303
-170 |
-171 | # apache-airflow-providers-celery
+185 |
+186 | # apache-airflow-providers-celery
     |
     = help: Install `apache-airflow-provider-amazon>=1.0.0` and use `airflow.providers.amazon.aws.transfers.s3_to_redshift.S3ToRedshiftOperator` instead.
 
-AIR303.py:172:1: AIR303 Import path `airflow.config_templates.default_celery.DEFAULT_CELERY_CONFIG` is moved into `celery` provider in Airflow 3.0;
+AIR303.py:187:1: AIR303 Import path `airflow.config_templates.default_celery.DEFAULT_CELERY_CONFIG` is moved into `celery` provider in Airflow 3.0;
     |
-171 | # apache-airflow-providers-celery
-172 | DEFAULT_CELERY_CONFIG
+186 | # apache-airflow-providers-celery
+187 | DEFAULT_CELERY_CONFIG
     | ^^^^^^^^^^^^^^^^^^^^^ AIR303
-173 | app
-174 | CeleryExecutor()
+188 | app
+189 | CeleryExecutor()
     |
     = help: Install `apache-airflow-provider-celery>=3.3.0` and import from `airflow.providers.celery.executors.default_celery.DEFAULT_CELERY_CONFIG` instead.
 
-AIR303.py:173:1: AIR303 Import path `airflow.executors.celery_executor.app` is moved into `celery` provider in Airflow 3.0;
+AIR303.py:188:1: AIR303 Import path `airflow.executors.celery_executor.app` is moved into `celery` provider in Airflow 3.0;
     |
-171 | # apache-airflow-providers-celery
-172 | DEFAULT_CELERY_CONFIG
-173 | app
+186 | # apache-airflow-providers-celery
+187 | DEFAULT_CELERY_CONFIG
+188 | app
     | ^^^ AIR303
-174 | CeleryExecutor()
-175 | CeleryKubernetesExecutor()
+189 | CeleryExecutor()
+190 | CeleryKubernetesExecutor()
     |
     = help: Install `apache-airflow-provider-celery>=3.3.0` and import from `airflow.providers.celery.executors.celery_executor_utils.app` instead.
 
-AIR303.py:174:1: AIR303 `airflow.executors.celery_executor.CeleryExecutor` is moved into `celery` provider in Airflow 3.0;
+AIR303.py:189:1: AIR303 `airflow.executors.celery_executor.CeleryExecutor` is moved into `celery` provider in Airflow 3.0;
     |
-172 | DEFAULT_CELERY_CONFIG
-173 | app
-174 | CeleryExecutor()
+187 | DEFAULT_CELERY_CONFIG
+188 | app
+189 | CeleryExecutor()
     | ^^^^^^^^^^^^^^ AIR303
-175 | CeleryKubernetesExecutor()
+190 | CeleryKubernetesExecutor()
     |
     = help: Install `apache-airflow-provider-celery>=3.3.0` and use `airflow.providers.celery.executors.celery_executor.CeleryExecutor` instead.
 
-AIR303.py:175:1: AIR303 `airflow.executors.celery_kubernetes_executor.CeleryKubernetesExecutor` is moved into `celery` provider in Airflow 3.0;
+AIR303.py:190:1: AIR303 `airflow.executors.celery_kubernetes_executor.CeleryKubernetesExecutor` is moved into `celery` provider in Airflow 3.0;
     |
-173 | app
-174 | CeleryExecutor()
-175 | CeleryKubernetesExecutor()
+188 | app
+189 | CeleryExecutor()
+190 | CeleryKubernetesExecutor()
     | ^^^^^^^^^^^^^^^^^^^^^^^^ AIR303
-176 |
-177 | # apache-airflow-providers-common-sql
+191 |
+192 | # apache-airflow-providers-common-sql
     |
     = help: Install `apache-airflow-provider-celery>=3.3.0` and use `airflow.providers.celery.executors.celery_kubernetes_executor.CeleryKubernetesExecutor` instead.
 
-AIR303.py:178:1: AIR303 `airflow.operators.sql._convert_to_float_if_possible` is moved into `common-sql` provider in Airflow 3.0;
+AIR303.py:193:1: AIR303 `airflow.operators.sql._convert_to_float_if_possible` is moved into `common-sql` provider in Airflow 3.0;
     |
-177 | # apache-airflow-providers-common-sql
-178 | _convert_to_float_if_possible()
+192 | # apache-airflow-providers-common-sql
+193 | _convert_to_float_if_possible()
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR303
-179 | parse_boolean()
-180 | BaseSQLOperator()
+194 | parse_boolean()
+195 | BaseSQLOperator()
     |
     = help: Install `apache-airflow-provider-common-sql>=1.0.0` and use `airflow.providers.common.sql.operators.sql._convert_to_float_if_possible` instead.
 
-AIR303.py:179:1: AIR303 `airflow.operators.sql.parse_boolean` is moved into `common-sql` provider in Airflow 3.0;
+AIR303.py:194:1: AIR303 `airflow.operators.sql.parse_boolean` is moved into `common-sql` provider in Airflow 3.0;
     |
-177 | # apache-airflow-providers-common-sql
-178 | _convert_to_float_if_possible()
-179 | parse_boolean()
+192 | # apache-airflow-providers-common-sql
+193 | _convert_to_float_if_possible()
+194 | parse_boolean()
     | ^^^^^^^^^^^^^ AIR303
-180 | BaseSQLOperator()
-181 | BranchSQLOperator()
+195 | BaseSQLOperator()
+196 | BranchSQLOperator()
     |
     = help: Install `apache-airflow-provider-common-sql>=1.0.0` and use `airflow.providers.common.sql.operators.sql.parse_boolean` instead.
 
-AIR303.py:180:1: AIR303 `airflow.operators.sql.BaseSQLOperator` is moved into `common-sql` provider in Airflow 3.0;
+AIR303.py:195:1: AIR303 `airflow.operators.sql.BaseSQLOperator` is moved into `common-sql` provider in Airflow 3.0;
     |
-178 | _convert_to_float_if_possible()
-179 | parse_boolean()
-180 | BaseSQLOperator()
+193 | _convert_to_float_if_possible()
+194 | parse_boolean()
+195 | BaseSQLOperator()
     | ^^^^^^^^^^^^^^^ AIR303
-181 | BranchSQLOperator()
-182 | CheckOperator()
+196 | BranchSQLOperator()
+197 | CheckOperator()
     |
     = help: Install `apache-airflow-provider-common-sql>=1.1.0` and use `airflow.providers.common.sql.operators.sql.BaseSQLOperator` instead.
 
-AIR303.py:181:1: AIR303 `airflow.operators.sql.BranchSQLOperator` is moved into `common-sql` provider in Airflow 3.0;
+AIR303.py:196:1: AIR303 `airflow.operators.sql.BranchSQLOperator` is moved into `common-sql` provider in Airflow 3.0;
     |
-179 | parse_boolean()
-180 | BaseSQLOperator()
-181 | BranchSQLOperator()
+194 | parse_boolean()
+195 | BaseSQLOperator()
+196 | BranchSQLOperator()
     | ^^^^^^^^^^^^^^^^^ AIR303
-182 | CheckOperator()
-183 | ConnectorProtocol()
+197 | CheckOperator()
+198 | ConnectorProtocol()
     |
     = help: Install `apache-airflow-provider-common-sql>=1.1.0` and use `airflow.providers.common.sql.operators.sql.BranchSQLOperator` instead.
 
-AIR303.py:182:1: AIR303 `airflow.operators.check_operator.CheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+AIR303.py:197:1: AIR303 `airflow.operators.check_operator.CheckOperator` is moved into `common-sql` provider in Airflow 3.0;
     |
-180 | BaseSQLOperator()
-181 | BranchSQLOperator()
-182 | CheckOperator()
+195 | BaseSQLOperator()
+196 | BranchSQLOperator()
+197 | CheckOperator()
     | ^^^^^^^^^^^^^ AIR303
-183 | ConnectorProtocol()
-184 | DbApiHook()
+198 | ConnectorProtocol()
+199 | DbApiHook()
     |
     = help: Install `apache-airflow-provider-common-sql>=1.1.0` and use `airflow.providers.common.sql.operators.sql.SQLCheckOperator` instead.
 
-AIR303.py:183:1: AIR303 Import path `airflow.hooks.dbapi.ConnectorProtocol` is moved into `common-sql` provider in Airflow 3.0;
+AIR303.py:198:1: AIR303 Import path `airflow.hooks.dbapi.ConnectorProtocol` is moved into `common-sql` provider in Airflow 3.0;
     |
-181 | BranchSQLOperator()
-182 | CheckOperator()
-183 | ConnectorProtocol()
+196 | BranchSQLOperator()
+197 | CheckOperator()
+198 | ConnectorProtocol()
     | ^^^^^^^^^^^^^^^^^ AIR303
-184 | DbApiHook()
-185 | DbApiHook2()
+199 | DbApiHook()
+200 | DbApiHook2()
     |
     = help: Install `apache-airflow-provider-common-sql>=1.0.0` and import from `airflow.providers.common.sql.hooks.sql.ConnectorProtocol` instead.
 
-AIR303.py:184:1: AIR303 Import path `airflow.hooks.dbapi.DbApiHook` is moved into `common-sql` provider in Airflow 3.0;
+AIR303.py:199:1: AIR303 Import path `airflow.hooks.dbapi.DbApiHook` is moved into `common-sql` provider in Airflow 3.0;
     |
-182 | CheckOperator()
-183 | ConnectorProtocol()
-184 | DbApiHook()
+197 | CheckOperator()
+198 | ConnectorProtocol()
+199 | DbApiHook()
     | ^^^^^^^^^ AIR303
-185 | DbApiHook2()
-186 | IntervalCheckOperator()
+200 | DbApiHook2()
+201 | IntervalCheckOperator()
     |
     = help: Install `apache-airflow-provider-common-sql>=1.0.0` and import from `airflow.providers.common.sql.hooks.sql.DbApiHook` instead.
 
-AIR303.py:185:1: AIR303 `airflow.hooks.dbapi_hook.DbApiHook` is moved into `common-sql` provider in Airflow 3.0;
+AIR303.py:200:1: AIR303 `airflow.hooks.dbapi_hook.DbApiHook` is moved into `common-sql` provider in Airflow 3.0;
     |
-183 | ConnectorProtocol()
-184 | DbApiHook()
-185 | DbApiHook2()
+198 | ConnectorProtocol()
+199 | DbApiHook()
+200 | DbApiHook2()
     | ^^^^^^^^^^ AIR303
-186 | IntervalCheckOperator()
-187 | PrestoCheckOperator()
+201 | IntervalCheckOperator()
+202 | PrestoCheckOperator()
     |
     = help: Install `apache-airflow-provider-common-sql>=1.0.0` and use `airflow.providers.common.sql.hooks.sql.DbApiHook` instead.
 
-AIR303.py:186:1: AIR303 `airflow.operators.check_operator.IntervalCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+AIR303.py:201:1: AIR303 `airflow.operators.check_operator.IntervalCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
     |
-184 | DbApiHook()
-185 | DbApiHook2()
-186 | IntervalCheckOperator()
+199 | DbApiHook()
+200 | DbApiHook2()
+201 | IntervalCheckOperator()
     | ^^^^^^^^^^^^^^^^^^^^^ AIR303
-187 | PrestoCheckOperator()
-188 | PrestoIntervalCheckOperator()
+202 | PrestoCheckOperator()
+203 | PrestoIntervalCheckOperator()
     |
     = help: Install `apache-airflow-provider-common-sql>=1.1.0` and use `airflow.providers.common.sql.operators.sql.SQLIntervalCheckOperator` instead.
 
-AIR303.py:187:1: AIR303 `airflow.operators.presto_check_operator.PrestoCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+AIR303.py:202:1: AIR303 `airflow.operators.presto_check_operator.PrestoCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
     |
-185 | DbApiHook2()
-186 | IntervalCheckOperator()
-187 | PrestoCheckOperator()
+200 | DbApiHook2()
+201 | IntervalCheckOperator()
+202 | PrestoCheckOperator()
     | ^^^^^^^^^^^^^^^^^^^ AIR303
-188 | PrestoIntervalCheckOperator()
-189 | PrestoValueCheckOperator()
+203 | PrestoIntervalCheckOperator()
+204 | PrestoValueCheckOperator()
     |
     = help: Install `apache-airflow-provider-common-sql>=1.1.0` and use `airflow.providers.common.sql.operators.sql.SQLCheckOperator` instead.
 
-AIR303.py:188:1: AIR303 `airflow.operators.presto_check_operator.PrestoIntervalCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+AIR303.py:203:1: AIR303 `airflow.operators.presto_check_operator.PrestoIntervalCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
     |
-186 | IntervalCheckOperator()
-187 | PrestoCheckOperator()
-188 | PrestoIntervalCheckOperator()
+201 | IntervalCheckOperator()
+202 | PrestoCheckOperator()
+203 | PrestoIntervalCheckOperator()
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR303
-189 | PrestoValueCheckOperator()
-190 | SQLCheckOperator()
+204 | PrestoValueCheckOperator()
+205 | SQLCheckOperator()
     |
     = help: Install `apache-airflow-provider-common-sql>=1.1.0` and use `airflow.providers.common.sql.operators.sql.SQLIntervalCheckOperator` instead.
 
-AIR303.py:189:1: AIR303 `airflow.operators.presto_check_operator.PrestoValueCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+AIR303.py:204:1: AIR303 `airflow.operators.presto_check_operator.PrestoValueCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
     |
-187 | PrestoCheckOperator()
-188 | PrestoIntervalCheckOperator()
-189 | PrestoValueCheckOperator()
+202 | PrestoCheckOperator()
+203 | PrestoIntervalCheckOperator()
+204 | PrestoValueCheckOperator()
     | ^^^^^^^^^^^^^^^^^^^^^^^^ AIR303
-190 | SQLCheckOperator()
-191 | SQLCheckOperator2()
+205 | SQLCheckOperator()
+206 | SQLCheckOperator2()
     |
     = help: Install `apache-airflow-provider-common-sql>=1.1.0` and use `airflow.providers.common.sql.operators.sql.SQLValueCheckOperator` instead.
 
-AIR303.py:190:1: AIR303 `airflow.operators.check_operator.SQLCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+AIR303.py:205:1: AIR303 `airflow.operators.check_operator.SQLCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
     |
-188 | PrestoIntervalCheckOperator()
-189 | PrestoValueCheckOperator()
-190 | SQLCheckOperator()
+203 | PrestoIntervalCheckOperator()
+204 | PrestoValueCheckOperator()
+205 | SQLCheckOperator()
     | ^^^^^^^^^^^^^^^^ AIR303
-191 | SQLCheckOperator2()
-192 | SQLCheckOperator3()
+206 | SQLCheckOperator2()
+207 | SQLCheckOperator3()
     |
     = help: Install `apache-airflow-provider-common-sql>=1.1.0` and use `airflow.providers.common.sql.operators.sql.SQLCheckOperator` instead.
 
-AIR303.py:191:1: AIR303 `airflow.operators.presto_check_operator.SQLCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+AIR303.py:206:1: AIR303 `airflow.operators.presto_check_operator.SQLCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
     |
-189 | PrestoValueCheckOperator()
-190 | SQLCheckOperator()
-191 | SQLCheckOperator2()
+204 | PrestoValueCheckOperator()
+205 | SQLCheckOperator()
+206 | SQLCheckOperator2()
     | ^^^^^^^^^^^^^^^^^ AIR303
-192 | SQLCheckOperator3()
-193 | SQLColumnCheckOperator2()
+207 | SQLCheckOperator3()
+208 | SQLColumnCheckOperator2()
     |
     = help: Install `apache-airflow-provider-common-sql>=1.1.0` and use `airflow.providers.common.sql.operators.sql.SQLCheckOperator` instead.
 
-AIR303.py:192:1: AIR303 `airflow.operators.sql.SQLCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+AIR303.py:207:1: AIR303 `airflow.operators.sql.SQLCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
     |
-190 | SQLCheckOperator()
-191 | SQLCheckOperator2()
-192 | SQLCheckOperator3()
+205 | SQLCheckOperator()
+206 | SQLCheckOperator2()
+207 | SQLCheckOperator3()
     | ^^^^^^^^^^^^^^^^^ AIR303
-193 | SQLColumnCheckOperator2()
-194 | SQLIntervalCheckOperator()
+208 | SQLColumnCheckOperator2()
+209 | SQLIntervalCheckOperator()
     |
     = help: Install `apache-airflow-provider-common-sql>=1.1.0` and use `airflow.providers.common.sql.operators.sql.SQLCheckOperator` instead.
 
-AIR303.py:193:1: AIR303 `airflow.operators.sql.SQLColumnCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+AIR303.py:208:1: AIR303 `airflow.operators.sql.SQLColumnCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
     |
-191 | SQLCheckOperator2()
-192 | SQLCheckOperator3()
-193 | SQLColumnCheckOperator2()
+206 | SQLCheckOperator2()
+207 | SQLCheckOperator3()
+208 | SQLColumnCheckOperator2()
     | ^^^^^^^^^^^^^^^^^^^^^^^ AIR303
-194 | SQLIntervalCheckOperator()
-195 | SQLIntervalCheckOperator2()
+209 | SQLIntervalCheckOperator()
+210 | SQLIntervalCheckOperator2()
     |
     = help: Install `apache-airflow-provider-common-sql>=1.0.0` and use `airflow.providers.common.sql.operators.sql.SQLColumnCheckOperator` instead.
 
-AIR303.py:194:1: AIR303 `airflow.operators.check_operator.SQLIntervalCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+AIR303.py:209:1: AIR303 `airflow.operators.check_operator.SQLIntervalCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
     |
-192 | SQLCheckOperator3()
-193 | SQLColumnCheckOperator2()
-194 | SQLIntervalCheckOperator()
+207 | SQLCheckOperator3()
+208 | SQLColumnCheckOperator2()
+209 | SQLIntervalCheckOperator()
     | ^^^^^^^^^^^^^^^^^^^^^^^^ AIR303
-195 | SQLIntervalCheckOperator2()
-196 | SQLIntervalCheckOperator3()
+210 | SQLIntervalCheckOperator2()
+211 | SQLIntervalCheckOperator3()
     |
     = help: Install `apache-airflow-provider-common-sql>=1.1.0` and use `airflow.providers.common.sql.operators.sql.SQLIntervalCheckOperator` instead.
 
-AIR303.py:195:1: AIR303 `airflow.operators.presto_check_operator.SQLIntervalCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+AIR303.py:210:1: AIR303 `airflow.operators.presto_check_operator.SQLIntervalCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
     |
-193 | SQLColumnCheckOperator2()
-194 | SQLIntervalCheckOperator()
-195 | SQLIntervalCheckOperator2()
+208 | SQLColumnCheckOperator2()
+209 | SQLIntervalCheckOperator()
+210 | SQLIntervalCheckOperator2()
     | ^^^^^^^^^^^^^^^^^^^^^^^^^ AIR303
-196 | SQLIntervalCheckOperator3()
-197 | SQLTableCheckOperator()
+211 | SQLIntervalCheckOperator3()
+212 | SQLTableCheckOperator()
     |
     = help: Install `apache-airflow-provider-common-sql>=1.1.0` and use `airflow.providers.common.sql.operators.sql.SQLIntervalCheckOperator` instead.
 
-AIR303.py:196:1: AIR303 `airflow.operators.sql.SQLIntervalCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+AIR303.py:211:1: AIR303 `airflow.operators.sql.SQLIntervalCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
     |
-194 | SQLIntervalCheckOperator()
-195 | SQLIntervalCheckOperator2()
-196 | SQLIntervalCheckOperator3()
+209 | SQLIntervalCheckOperator()
+210 | SQLIntervalCheckOperator2()
+211 | SQLIntervalCheckOperator3()
     | ^^^^^^^^^^^^^^^^^^^^^^^^^ AIR303
-197 | SQLTableCheckOperator()
-198 | SQLThresholdCheckOperator()
+212 | SQLTableCheckOperator()
+213 | SQLThresholdCheckOperator()
     |
     = help: Install `apache-airflow-provider-common-sql>=1.1.0` and use `airflow.providers.common.sql.operators.sql.SQLIntervalCheckOperator` instead.
 
-AIR303.py:198:1: AIR303 `airflow.operators.check_operator.SQLThresholdCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+AIR303.py:213:1: AIR303 `airflow.operators.check_operator.SQLThresholdCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
     |
-196 | SQLIntervalCheckOperator3()
-197 | SQLTableCheckOperator()
-198 | SQLThresholdCheckOperator()
+211 | SQLIntervalCheckOperator3()
+212 | SQLTableCheckOperator()
+213 | SQLThresholdCheckOperator()
     | ^^^^^^^^^^^^^^^^^^^^^^^^^ AIR303
-199 | SQLThresholdCheckOperator2()
-200 | SQLValueCheckOperator()
+214 | SQLThresholdCheckOperator2()
+215 | SQLValueCheckOperator()
     |
     = help: Install `apache-airflow-provider-common-sql>=1.1.0` and use `airflow.providers.common.sql.operators.sql.SQLThresholdCheckOperator` instead.
 
-AIR303.py:199:1: AIR303 `airflow.operators.sql.SQLThresholdCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+AIR303.py:214:1: AIR303 `airflow.operators.sql.SQLThresholdCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
     |
-197 | SQLTableCheckOperator()
-198 | SQLThresholdCheckOperator()
-199 | SQLThresholdCheckOperator2()
+212 | SQLTableCheckOperator()
+213 | SQLThresholdCheckOperator()
+214 | SQLThresholdCheckOperator2()
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR303
-200 | SQLValueCheckOperator()
-201 | SQLValueCheckOperator2()
+215 | SQLValueCheckOperator()
+216 | SQLValueCheckOperator2()
     |
     = help: Install `apache-airflow-provider-common-sql>=1.0.0` and use `airflow.providers.common.sql.operators.sql.SQLTableCheckOperator` instead.
 
-AIR303.py:200:1: AIR303 `airflow.operators.check_operator.SQLValueCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+AIR303.py:215:1: AIR303 `airflow.operators.check_operator.SQLValueCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
     |
-198 | SQLThresholdCheckOperator()
-199 | SQLThresholdCheckOperator2()
-200 | SQLValueCheckOperator()
+213 | SQLThresholdCheckOperator()
+214 | SQLThresholdCheckOperator2()
+215 | SQLValueCheckOperator()
     | ^^^^^^^^^^^^^^^^^^^^^ AIR303
-201 | SQLValueCheckOperator2()
-202 | SQLValueCheckOperator3()
+216 | SQLValueCheckOperator2()
+217 | SQLValueCheckOperator3()
     |
     = help: Install `apache-airflow-provider-common-sql>=1.1.0` and use `airflow.providers.common.sql.operators.sql.SQLValueCheckOperator` instead.
 
-AIR303.py:201:1: AIR303 `airflow.operators.presto_check_operator.SQLValueCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+AIR303.py:216:1: AIR303 `airflow.operators.presto_check_operator.SQLValueCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
     |
-199 | SQLThresholdCheckOperator2()
-200 | SQLValueCheckOperator()
-201 | SQLValueCheckOperator2()
+214 | SQLThresholdCheckOperator2()
+215 | SQLValueCheckOperator()
+216 | SQLValueCheckOperator2()
     | ^^^^^^^^^^^^^^^^^^^^^^ AIR303
-202 | SQLValueCheckOperator3()
-203 | SqlSensor()
+217 | SQLValueCheckOperator3()
+218 | SqlSensor()
     |
     = help: Install `apache-airflow-provider-common-sql>=1.1.0` and use `airflow.providers.common.sql.operators.sql.SQLValueCheckOperator` instead.
 
-AIR303.py:202:1: AIR303 `airflow.operators.sql.SQLValueCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+AIR303.py:217:1: AIR303 `airflow.operators.sql.SQLValueCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
     |
-200 | SQLValueCheckOperator()
-201 | SQLValueCheckOperator2()
-202 | SQLValueCheckOperator3()
+215 | SQLValueCheckOperator()
+216 | SQLValueCheckOperator2()
+217 | SQLValueCheckOperator3()
     | ^^^^^^^^^^^^^^^^^^^^^^ AIR303
-203 | SqlSensor()
-204 | SqlSensor2()
+218 | SqlSensor()
+219 | SqlSensor2()
     |
     = help: Install `apache-airflow-provider-common-sql>=1.0.0` and use `airflow.providers.common.sql.operators.sql.SQLValueCheckOperator` instead.
 
-AIR303.py:203:1: AIR303 `airflow.sensors.sql.SqlSensor` is moved into `common-sql` provider in Airflow 3.0;
+AIR303.py:218:1: AIR303 `airflow.sensors.sql.SqlSensor` is moved into `common-sql` provider in Airflow 3.0;
     |
-201 | SQLValueCheckOperator2()
-202 | SQLValueCheckOperator3()
-203 | SqlSensor()
+216 | SQLValueCheckOperator2()
+217 | SQLValueCheckOperator3()
+218 | SqlSensor()
     | ^^^^^^^^^ AIR303
-204 | SqlSensor2()
-205 | ThresholdCheckOperator()
+219 | SqlSensor2()
+220 | ThresholdCheckOperator()
     |
     = help: Install `apache-airflow-provider-common-sql>=1.0.0` and use `airflow.providers.common.sql.sensors.sql.SqlSensor` instead.
 
-AIR303.py:205:1: AIR303 `airflow.operators.check_operator.ThresholdCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+AIR303.py:220:1: AIR303 `airflow.operators.check_operator.ThresholdCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
     |
-203 | SqlSensor()
-204 | SqlSensor2()
-205 | ThresholdCheckOperator()
+218 | SqlSensor()
+219 | SqlSensor2()
+220 | ThresholdCheckOperator()
     | ^^^^^^^^^^^^^^^^^^^^^^ AIR303
-206 | ValueCheckOperator()
+221 | ValueCheckOperator()
     |
     = help: Install `apache-airflow-provider-common-sql>=1.1.0` and use `airflow.providers.common.sql.operators.sql.SQLThresholdCheckOperator` instead.
 
-AIR303.py:206:1: AIR303 `airflow.operators.check_operator.ValueCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
+AIR303.py:221:1: AIR303 `airflow.operators.check_operator.ValueCheckOperator` is moved into `common-sql` provider in Airflow 3.0;
     |
-204 | SqlSensor2()
-205 | ThresholdCheckOperator()
-206 | ValueCheckOperator()
+219 | SqlSensor2()
+220 | ThresholdCheckOperator()
+221 | ValueCheckOperator()
     | ^^^^^^^^^^^^^^^^^^ AIR303
-207 |
-208 | # apache-airflow-providers-daskexecutor
+222 |
+223 | # apache-airflow-providers-daskexecutor
     |
     = help: Install `apache-airflow-provider-common-sql>=1.1.0` and use `airflow.providers.common.sql.operators.sql.SQLValueCheckOperator` instead.
 
-AIR303.py:209:1: AIR303 `airflow.executors.dask_executor.DaskExecutor` is moved into `daskexecutor` provider in Airflow 3.0;
+AIR303.py:224:1: AIR303 `airflow.executors.dask_executor.DaskExecutor` is moved into `daskexecutor` provider in Airflow 3.0;
     |
-208 | # apache-airflow-providers-daskexecutor
-209 | DaskExecutor()
+223 | # apache-airflow-providers-daskexecutor
+224 | DaskExecutor()
     | ^^^^^^^^^^^^ AIR303
-210 |
-211 | # apache-airflow-providers-docker
+225 |
+226 | # apache-airflow-providers-docker
     |
     = help: Install `apache-airflow-provider-daskexecutor>=1.0.0` and use `airflow.providers.daskexecutor.executors.dask_executor.DaskExecutor` instead.
 
-AIR303.py:212:1: AIR303 `airflow.hooks.docker_hook.DockerHook` is moved into `docker` provider in Airflow 3.0;
+AIR303.py:227:1: AIR303 `airflow.hooks.docker_hook.DockerHook` is moved into `docker` provider in Airflow 3.0;
     |
-211 | # apache-airflow-providers-docker
-212 | DockerHook()
+226 | # apache-airflow-providers-docker
+227 | DockerHook()
     | ^^^^^^^^^^ AIR303
-213 | DockerOperator()
+228 | DockerOperator()
     |
     = help: Install `apache-airflow-provider-docker>=1.0.0` and use `airflow.providers.docker.hooks.docker.DockerHook` instead.
 
-AIR303.py:213:1: AIR303 `airflow.operators.docker_operator.DockerOperator` is moved into `docker` provider in Airflow 3.0;
+AIR303.py:228:1: AIR303 `airflow.operators.docker_operator.DockerOperator` is moved into `docker` provider in Airflow 3.0;
     |
-211 | # apache-airflow-providers-docker
-212 | DockerHook()
-213 | DockerOperator()
+226 | # apache-airflow-providers-docker
+227 | DockerHook()
+228 | DockerOperator()
     | ^^^^^^^^^^^^^^ AIR303
-214 |
-215 | # apache-airflow-providers-apache-druid
+229 |
+230 | # apache-airflow-providers-apache-druid
     |
     = help: Install `apache-airflow-provider-docker>=1.0.0` and use `airflow.providers.docker.operators.docker.DockerOperator` instead.
 
-AIR303.py:216:1: AIR303 `airflow.hooks.druid_hook.DruidDbApiHook` is moved into `apache-druid` provider in Airflow 3.0;
+AIR303.py:231:1: AIR303 `airflow.hooks.druid_hook.DruidDbApiHook` is moved into `apache-druid` provider in Airflow 3.0;
     |
-215 | # apache-airflow-providers-apache-druid
-216 | DruidDbApiHook()
+230 | # apache-airflow-providers-apache-druid
+231 | DruidDbApiHook()
     | ^^^^^^^^^^^^^^ AIR303
-217 | DruidHook()
-218 | DruidCheckOperator()
+232 | DruidHook()
+233 | DruidCheckOperator()
     |
     = help: Install `apache-airflow-provider-apache-druid>=1.0.0` and use `DruidDbApiHook` instead.
 
-AIR303.py:217:1: AIR303 `airflow.hooks.druid_hook.DruidHook` is moved into `apache-druid` provider in Airflow 3.0;
+AIR303.py:232:1: AIR303 `airflow.hooks.druid_hook.DruidHook` is moved into `apache-druid` provider in Airflow 3.0;
     |
-215 | # apache-airflow-providers-apache-druid
-216 | DruidDbApiHook()
-217 | DruidHook()
+230 | # apache-airflow-providers-apache-druid
+231 | DruidDbApiHook()
+232 | DruidHook()
     | ^^^^^^^^^ AIR303
-218 | DruidCheckOperator()
+233 | DruidCheckOperator()
     |
     = help: Install `apache-airflow-provider-apache-druid>=1.0.0` and use `DruidHook` instead.
 
-AIR303.py:218:1: AIR303 `airflow.operators.druid_check_operator.DruidCheckOperator` is moved into `apache-druid` provider in Airflow 3.0;
+AIR303.py:233:1: AIR303 `airflow.operators.druid_check_operator.DruidCheckOperator` is moved into `apache-druid` provider in Airflow 3.0;
     |
-216 | DruidDbApiHook()
-217 | DruidHook()
-218 | DruidCheckOperator()
+231 | DruidDbApiHook()
+232 | DruidHook()
+233 | DruidCheckOperator()
     | ^^^^^^^^^^^^^^^^^^ AIR303
-219 |
-220 | # apache-airflow-providers-apache-hdfs
+234 |
+235 | # apache-airflow-providers-apache-hdfs
     |
     = help: Install `apache-airflow-provider-apache-druid>=1.0.0` and use `DruidCheckOperator` instead.
 
-AIR303.py:221:1: AIR303 `airflow.hooks.webhdfs_hook.WebHDFSHook` is moved into `apache-hdfs` provider in Airflow 3.0;
+AIR303.py:236:1: AIR303 `airflow.hooks.webhdfs_hook.WebHDFSHook` is moved into `apache-hdfs` provider in Airflow 3.0;
     |
-220 | # apache-airflow-providers-apache-hdfs
-221 | WebHDFSHook()
+235 | # apache-airflow-providers-apache-hdfs
+236 | WebHDFSHook()
     | ^^^^^^^^^^^ AIR303
-222 | WebHdfsSensor()
+237 | WebHdfsSensor()
     |
     = help: Install `apache-airflow-provider-apache-hdfs>=1.0.0` and use `airflow.providers.apache.hdfs.hooks.webhdfs.WebHDFSHook` instead.
 
-AIR303.py:222:1: AIR303 `airflow.sensors.web_hdfs_sensor.WebHdfsSensor` is moved into `apache-hdfs` provider in Airflow 3.0;
+AIR303.py:237:1: AIR303 `airflow.sensors.web_hdfs_sensor.WebHdfsSensor` is moved into `apache-hdfs` provider in Airflow 3.0;
     |
-220 | # apache-airflow-providers-apache-hdfs
-221 | WebHDFSHook()
-222 | WebHdfsSensor()
+235 | # apache-airflow-providers-apache-hdfs
+236 | WebHDFSHook()
+237 | WebHdfsSensor()
     | ^^^^^^^^^^^^^ AIR303
-223 |
-224 | # apache-airflow-providers-apache-hive
+238 |
+239 | # apache-airflow-providers-apache-hive
     |
     = help: Install `apache-airflow-provider-apache-hdfs>=1.0.0` and use `airflow.providers.apache.hdfs.sensors.web_hdfs.WebHdfsSensor` instead.
 
-AIR303.py:225:1: AIR303 `airflow.hooks.hive_hooks.HIVE_QUEUE_PRIORITIES` is moved into `apache-hive` provider in Airflow 3.0;
+AIR303.py:240:1: AIR303 `airflow.hooks.hive_hooks.HIVE_QUEUE_PRIORITIES` is moved into `apache-hive` provider in Airflow 3.0;
     |
-224 | # apache-airflow-providers-apache-hive
-225 | HIVE_QUEUE_PRIORITIES
+239 | # apache-airflow-providers-apache-hive
+240 | HIVE_QUEUE_PRIORITIES
     | ^^^^^^^^^^^^^^^^^^^^^ AIR303
-226 | closest_ds_partition()
-227 | max_partition()
+241 | closest_ds_partition()
+242 | max_partition()
     |
     = help: Install `apache-airflow-provider-apache-hive>=1.0.0` and use `airflow.providers.apache.hive.hooks.hive.HIVE_QUEUE_PRIORITIES` instead.
 
-AIR303.py:226:1: AIR303 `airflow.macros.hive.closest_ds_partition` is moved into `apache-hive` provider in Airflow 3.0;
+AIR303.py:241:1: AIR303 `airflow.macros.hive.closest_ds_partition` is moved into `apache-hive` provider in Airflow 3.0;
     |
-224 | # apache-airflow-providers-apache-hive
-225 | HIVE_QUEUE_PRIORITIES
-226 | closest_ds_partition()
+239 | # apache-airflow-providers-apache-hive
+240 | HIVE_QUEUE_PRIORITIES
+241 | closest_ds_partition()
     | ^^^^^^^^^^^^^^^^^^^^ AIR303
-227 | max_partition()
-228 | HiveCliHook()
+242 | max_partition()
+243 | HiveCliHook()
     |
     = help: Install `apache-airflow-provider-apache-hive>=5.1.0` and use `airflow.providers.apache.hive.macros.hive.closest_ds_partition` instead.
 
-AIR303.py:227:1: AIR303 `airflow.macros.hive.max_partition` is moved into `apache-hive` provider in Airflow 3.0;
+AIR303.py:242:1: AIR303 `airflow.macros.hive.max_partition` is moved into `apache-hive` provider in Airflow 3.0;
     |
-225 | HIVE_QUEUE_PRIORITIES
-226 | closest_ds_partition()
-227 | max_partition()
+240 | HIVE_QUEUE_PRIORITIES
+241 | closest_ds_partition()
+242 | max_partition()
     | ^^^^^^^^^^^^^ AIR303
-228 | HiveCliHook()
-229 | HiveMetastoreHook()
+243 | HiveCliHook()
+244 | HiveMetastoreHook()
     |
     = help: Install `apache-airflow-provider-apache-hive>=5.1.0` and use `airflow.providers.apache.hive.macros.hive.max_partition` instead.
 
-AIR303.py:228:1: AIR303 `airflow.hooks.hive_hooks.HiveCliHook` is moved into `apache-hive` provider in Airflow 3.0;
+AIR303.py:243:1: AIR303 `airflow.hooks.hive_hooks.HiveCliHook` is moved into `apache-hive` provider in Airflow 3.0;
     |
-226 | closest_ds_partition()
-227 | max_partition()
-228 | HiveCliHook()
+241 | closest_ds_partition()
+242 | max_partition()
+243 | HiveCliHook()
     | ^^^^^^^^^^^ AIR303
-229 | HiveMetastoreHook()
-230 | HiveOperator()
+244 | HiveMetastoreHook()
+245 | HiveOperator()
     |
     = help: Install `apache-airflow-provider-apache-hive>=1.0.0` and use `airflow.providers.apache.hive.hooks.hive.HiveCliHook` instead.
 
-AIR303.py:229:1: AIR303 `airflow.hooks.hive_hooks.HiveMetastoreHook` is moved into `apache-hive` provider in Airflow 3.0;
+AIR303.py:244:1: AIR303 `airflow.hooks.hive_hooks.HiveMetastoreHook` is moved into `apache-hive` provider in Airflow 3.0;
     |
-227 | max_partition()
-228 | HiveCliHook()
-229 | HiveMetastoreHook()
+242 | max_partition()
+243 | HiveCliHook()
+244 | HiveMetastoreHook()
     | ^^^^^^^^^^^^^^^^^ AIR303
-230 | HiveOperator()
-231 | HivePartitionSensor()
+245 | HiveOperator()
+246 | HivePartitionSensor()
     |
     = help: Install `apache-airflow-provider-apache-hive>=1.0.0` and use `airflow.providers.apache.hive.hooks.hive.HiveMetastoreHook` instead.
 
-AIR303.py:230:1: AIR303 `airflow.operators.hive_operator.HiveOperator` is moved into `apache-hive` provider in Airflow 3.0;
+AIR303.py:245:1: AIR303 `airflow.operators.hive_operator.HiveOperator` is moved into `apache-hive` provider in Airflow 3.0;
     |
-228 | HiveCliHook()
-229 | HiveMetastoreHook()
-230 | HiveOperator()
+243 | HiveCliHook()
+244 | HiveMetastoreHook()
+245 | HiveOperator()
     | ^^^^^^^^^^^^ AIR303
-231 | HivePartitionSensor()
-232 | HiveServer2Hook()
+246 | HivePartitionSensor()
+247 | HiveServer2Hook()
     |
     = help: Install `apache-airflow-provider-apache-hive>=1.0.0` and use `airflow.providers.apache.hive.operators.hive.HiveOperator` instead.
 
-AIR303.py:231:1: AIR303 `airflow.sensors.hive_partition_sensor.HivePartitionSensor` is moved into `apache-hive` provider in Airflow 3.0;
+AIR303.py:246:1: AIR303 `airflow.sensors.hive_partition_sensor.HivePartitionSensor` is moved into `apache-hive` provider in Airflow 3.0;
     |
-229 | HiveMetastoreHook()
-230 | HiveOperator()
-231 | HivePartitionSensor()
+244 | HiveMetastoreHook()
+245 | HiveOperator()
+246 | HivePartitionSensor()
     | ^^^^^^^^^^^^^^^^^^^ AIR303
-232 | HiveServer2Hook()
-233 | HiveStatsCollectionOperator()
+247 | HiveServer2Hook()
+248 | HiveStatsCollectionOperator()
     |
     = help: Install `apache-airflow-provider-apache-hive>=1.0.0` and use `airflow.providers.apache.hive.sensors.hive_partition.HivePartitionSensor` instead.
 
-AIR303.py:232:1: AIR303 `airflow.hooks.hive_hooks.HiveServer2Hook` is moved into `apache-hive` provider in Airflow 3.0;
+AIR303.py:247:1: AIR303 `airflow.hooks.hive_hooks.HiveServer2Hook` is moved into `apache-hive` provider in Airflow 3.0;
     |
-230 | HiveOperator()
-231 | HivePartitionSensor()
-232 | HiveServer2Hook()
+245 | HiveOperator()
+246 | HivePartitionSensor()
+247 | HiveServer2Hook()
     | ^^^^^^^^^^^^^^^ AIR303
-233 | HiveStatsCollectionOperator()
-234 | HiveToDruidOperator()
+248 | HiveStatsCollectionOperator()
+249 | HiveToDruidOperator()
     |
     = help: Install `apache-airflow-provider-apache-hive>=1.0.0` and use `airflow.providers.apache.hive.hooks.hive.HiveServer2Hook` instead.
 
-AIR303.py:233:1: AIR303 `airflow.operators.hive_stats_operator.HiveStatsCollectionOperator` is moved into `apache-hive` provider in Airflow 3.0;
+AIR303.py:248:1: AIR303 `airflow.operators.hive_stats_operator.HiveStatsCollectionOperator` is moved into `apache-hive` provider in Airflow 3.0;
     |
-231 | HivePartitionSensor()
-232 | HiveServer2Hook()
-233 | HiveStatsCollectionOperator()
+246 | HivePartitionSensor()
+247 | HiveServer2Hook()
+248 | HiveStatsCollectionOperator()
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR303
-234 | HiveToDruidOperator()
-235 | HiveToDruidTransfer()
+249 | HiveToDruidOperator()
+250 | HiveToDruidTransfer()
     |
     = help: Install `apache-airflow-provider-apache-hive>=1.0.0` and use `airflow.providers.apache.hive.operators.hive_stats.HiveStatsCollectionOperator` instead.
 
-AIR303.py:234:1: AIR303 `airflow.operators.hive_to_druid.HiveToDruidOperator` is moved into `apache-druid` provider in Airflow 3.0;
+AIR303.py:249:1: AIR303 `airflow.operators.hive_to_druid.HiveToDruidOperator` is moved into `apache-druid` provider in Airflow 3.0;
     |
-232 | HiveServer2Hook()
-233 | HiveStatsCollectionOperator()
-234 | HiveToDruidOperator()
+247 | HiveServer2Hook()
+248 | HiveStatsCollectionOperator()
+249 | HiveToDruidOperator()
     | ^^^^^^^^^^^^^^^^^^^ AIR303
-235 | HiveToDruidTransfer()
-236 | HiveToSambaOperator()
+250 | HiveToDruidTransfer()
+251 | HiveToSambaOperator()
     |
     = help: Install `apache-airflow-provider-apache-druid>=1.0.0` and use `airflow.providers.apache.druid.transfers.hive_to_druid.HiveToDruidOperator` instead.
 
-AIR303.py:235:1: AIR303 `airflow.operators.hive_to_druid.HiveToDruidTransfer` is moved into `apache-druid` provider in Airflow 3.0;
+AIR303.py:250:1: AIR303 `airflow.operators.hive_to_druid.HiveToDruidTransfer` is moved into `apache-druid` provider in Airflow 3.0;
     |
-233 | HiveStatsCollectionOperator()
-234 | HiveToDruidOperator()
-235 | HiveToDruidTransfer()
+248 | HiveStatsCollectionOperator()
+249 | HiveToDruidOperator()
+250 | HiveToDruidTransfer()
     | ^^^^^^^^^^^^^^^^^^^ AIR303
-236 | HiveToSambaOperator()
-237 | S3ToHiveOperator()
+251 | HiveToSambaOperator()
+252 | S3ToHiveOperator()
     |
     = help: Install `apache-airflow-provider-apache-druid>=1.0.0` and use `airflow.providers.apache.druid.transfers.hive_to_druid.HiveToDruidOperator` instead.
 
-AIR303.py:236:1: AIR303 `airflow.operators.hive_to_samba_operator.HiveToSambaOperator` is moved into `apache-hive` provider in Airflow 3.0;
+AIR303.py:251:1: AIR303 `airflow.operators.hive_to_samba_operator.HiveToSambaOperator` is moved into `apache-hive` provider in Airflow 3.0;
     |
-234 | HiveToDruidOperator()
-235 | HiveToDruidTransfer()
-236 | HiveToSambaOperator()
+249 | HiveToDruidOperator()
+250 | HiveToDruidTransfer()
+251 | HiveToSambaOperator()
     | ^^^^^^^^^^^^^^^^^^^ AIR303
-237 | S3ToHiveOperator()
-238 | S3ToHiveTransfer()
+252 | S3ToHiveOperator()
+253 | S3ToHiveTransfer()
     |
     = help: Install `apache-airflow-provider-apache-hive>=1.0.0` and use `HiveToSambaOperator` instead.
 
-AIR303.py:237:1: AIR303 `airflow.operators.s3_to_hive_operator.S3ToHiveOperator` is moved into `apache-hive` provider in Airflow 3.0;
+AIR303.py:252:1: AIR303 `airflow.operators.s3_to_hive_operator.S3ToHiveOperator` is moved into `apache-hive` provider in Airflow 3.0;
     |
-235 | HiveToDruidTransfer()
-236 | HiveToSambaOperator()
-237 | S3ToHiveOperator()
+250 | HiveToDruidTransfer()
+251 | HiveToSambaOperator()
+252 | S3ToHiveOperator()
     | ^^^^^^^^^^^^^^^^ AIR303
-238 | S3ToHiveTransfer()
-239 | MetastorePartitionSensor()
+253 | S3ToHiveTransfer()
+254 | MetastorePartitionSensor()
     |
     = help: Install `apache-airflow-provider-apache-hive>=1.0.0` and use `airflow.providers.apache.hive.transfers.s3_to_hive.S3ToHiveOperator` instead.
 
-AIR303.py:238:1: AIR303 `airflow.operators.s3_to_hive_operator.S3ToHiveTransfer` is moved into `apache-hive` provider in Airflow 3.0;
+AIR303.py:253:1: AIR303 `airflow.operators.s3_to_hive_operator.S3ToHiveTransfer` is moved into `apache-hive` provider in Airflow 3.0;
     |
-236 | HiveToSambaOperator()
-237 | S3ToHiveOperator()
-238 | S3ToHiveTransfer()
+251 | HiveToSambaOperator()
+252 | S3ToHiveOperator()
+253 | S3ToHiveTransfer()
     | ^^^^^^^^^^^^^^^^ AIR303
-239 | MetastorePartitionSensor()
-240 | NamedHivePartitionSensor()
+254 | MetastorePartitionSensor()
+255 | NamedHivePartitionSensor()
     |
     = help: Install `apache-airflow-provider-apache-hive>=1.0.0` and use `airflow.providers.apache.hive.transfers.s3_to_hive.S3ToHiveOperator` instead.
 
-AIR303.py:239:1: AIR303 `airflow.sensors.metastore_partition_sensor.MetastorePartitionSensor` is moved into `apache-hive` provider in Airflow 3.0;
+AIR303.py:254:1: AIR303 `airflow.sensors.metastore_partition_sensor.MetastorePartitionSensor` is moved into `apache-hive` provider in Airflow 3.0;
     |
-237 | S3ToHiveOperator()
-238 | S3ToHiveTransfer()
-239 | MetastorePartitionSensor()
+252 | S3ToHiveOperator()
+253 | S3ToHiveTransfer()
+254 | MetastorePartitionSensor()
     | ^^^^^^^^^^^^^^^^^^^^^^^^ AIR303
-240 | NamedHivePartitionSensor()
+255 | NamedHivePartitionSensor()
     |
     = help: Install `apache-airflow-provider-apache-hive>=1.0.0` and use `airflow.providers.apache.hive.sensors.metastore_partition.MetastorePartitionSensor` instead.
 
-AIR303.py:240:1: AIR303 `airflow.sensors.named_hive_partition_sensor.NamedHivePartitionSensor` is moved into `apache-hive` provider in Airflow 3.0;
+AIR303.py:255:1: AIR303 `airflow.sensors.named_hive_partition_sensor.NamedHivePartitionSensor` is moved into `apache-hive` provider in Airflow 3.0;
     |
-238 | S3ToHiveTransfer()
-239 | MetastorePartitionSensor()
-240 | NamedHivePartitionSensor()
+253 | S3ToHiveTransfer()
+254 | MetastorePartitionSensor()
+255 | NamedHivePartitionSensor()
     | ^^^^^^^^^^^^^^^^^^^^^^^^ AIR303
-241 |
-242 | # apache-airflow-providers-http
+256 |
+257 | # apache-airflow-providers-http
     |
     = help: Install `apache-airflow-provider-apache-hive>=1.0.0` and use `airflow.providers.apache.hive.sensors.named_hive_partition.NamedHivePartitionSensor` instead.
 
-AIR303.py:243:1: AIR303 `airflow.hooks.http_hook.HttpHook` is moved into `http` provider in Airflow 3.0;
+AIR303.py:258:1: AIR303 `airflow.hooks.http_hook.HttpHook` is moved into `http` provider in Airflow 3.0;
     |
-242 | # apache-airflow-providers-http
-243 | HttpHook()
+257 | # apache-airflow-providers-http
+258 | HttpHook()
     | ^^^^^^^^ AIR303
-244 | HttpSensor()
-245 | SimpleHttpOperator()
+259 | HttpSensor()
+260 | SimpleHttpOperator()
     |
     = help: Install `apache-airflow-provider-http>=1.0.0` and use `airflow.providers.http.hooks.http.HttpHook` instead.
 
-AIR303.py:244:1: AIR303 `airflow.sensors.http_sensor.HttpSensor` is moved into `http` provider in Airflow 3.0;
+AIR303.py:259:1: AIR303 `airflow.sensors.http_sensor.HttpSensor` is moved into `http` provider in Airflow 3.0;
     |
-242 | # apache-airflow-providers-http
-243 | HttpHook()
-244 | HttpSensor()
+257 | # apache-airflow-providers-http
+258 | HttpHook()
+259 | HttpSensor()
     | ^^^^^^^^^^ AIR303
-245 | SimpleHttpOperator()
+260 | SimpleHttpOperator()
     |
     = help: Install `apache-airflow-provider-http>=1.0.0` and use `airflow.providers.http.sensors.http.HttpSensor` instead.
 
-AIR303.py:245:1: AIR303 `airflow.operators.http_operator.SimpleHttpOperator` is moved into `http` provider in Airflow 3.0;
+AIR303.py:260:1: AIR303 `airflow.operators.http_operator.SimpleHttpOperator` is moved into `http` provider in Airflow 3.0;
     |
-243 | HttpHook()
-244 | HttpSensor()
-245 | SimpleHttpOperator()
+258 | HttpHook()
+259 | HttpSensor()
+260 | SimpleHttpOperator()
     | ^^^^^^^^^^^^^^^^^^ AIR303
-246 |
-247 | # apache-airflow-providers-jdbc
+261 |
+262 | # apache-airflow-providers-jdbc
     |
     = help: Install `apache-airflow-provider-http>=1.0.0` and use `airflow.providers.http.operators.http.SimpleHttpOperator` instead.
 
-AIR303.py:248:1: AIR303 `airflow.hooks.jdbc_hook.jaydebeapi` is moved into `jdbc` provider in Airflow 3.0;
+AIR303.py:263:1: AIR303 `airflow.hooks.jdbc_hook.jaydebeapi` is moved into `jdbc` provider in Airflow 3.0;
     |
-247 | # apache-airflow-providers-jdbc
-248 | jaydebeapi
+262 | # apache-airflow-providers-jdbc
+263 | jaydebeapi
     | ^^^^^^^^^^ AIR303
-249 | JdbcHook()
-250 | JdbcOperator()
+264 | JdbcHook()
+265 | JdbcOperator()
     |
     = help: Install `apache-airflow-provider-jdbc>=1.0.0` and use `airflow.providers.jdbc.hooks.jdbc.jaydebeapi` instead.
 
-AIR303.py:249:1: AIR303 `airflow.hooks.jdbc_hook.JdbcHook` is moved into `jdbc` provider in Airflow 3.0;
+AIR303.py:264:1: AIR303 `airflow.hooks.jdbc_hook.JdbcHook` is moved into `jdbc` provider in Airflow 3.0;
     |
-247 | # apache-airflow-providers-jdbc
-248 | jaydebeapi
-249 | JdbcHook()
+262 | # apache-airflow-providers-jdbc
+263 | jaydebeapi
+264 | JdbcHook()
     | ^^^^^^^^ AIR303
-250 | JdbcOperator()
+265 | JdbcOperator()
     |
     = help: Install `apache-airflow-provider-jdbc>=1.0.0` and use `airflow.providers.jdbc.hooks.jdbc.JdbcHook` instead.
 
-AIR303.py:250:1: AIR303 `airflow.operators.jdbc_operator.JdbcOperator` is moved into `jdbc` provider in Airflow 3.0;
+AIR303.py:265:1: AIR303 `airflow.operators.jdbc_operator.JdbcOperator` is moved into `jdbc` provider in Airflow 3.0;
     |
-248 | jaydebeapi
-249 | JdbcHook()
-250 | JdbcOperator()
+263 | jaydebeapi
+264 | JdbcHook()
+265 | JdbcOperator()
     | ^^^^^^^^^^^^ AIR303
-251 |
-252 | # apache-airflow-providers-fab
+266 |
+267 | # apache-airflow-providers-fab
     |
     = help: Install `apache-airflow-provider-jdbc>=1.0.0` and use `airflow.providers.jdbc.operators.jdbc.JdbcOperator` instead.
 
-AIR303.py:253:1: AIR303 Import path `airflow.api.auth.backend.basic_auth` is moved into `fab` provider in Airflow 3.0;
+AIR303.py:268:1: AIR303 Import path `airflow.api.auth.backend.basic_auth` is moved into `fab` provider in Airflow 3.0;
     |
-252 | # apache-airflow-providers-fab
-253 | basic_auth, kerberos_auth
+267 | # apache-airflow-providers-fab
+268 | basic_auth, kerberos_auth
     | ^^^^^^^^^^ AIR303
-254 | auth_current_user
-255 | backend_kerberos_auth
+269 | auth_current_user
+270 | backend_kerberos_auth
     |
     = help: Install `apache-airflow-provider-fab>=1.0.0` and import from `airflow.providers.fab.auth_manager.api.auth.backend.basic_auth` instead.
 
-AIR303.py:253:13: AIR303 Import path `airflow.api.auth.backend.kerberos_auth` is moved into `fab` provider in Airflow 3.0;
+AIR303.py:268:13: AIR303 Import path `airflow.api.auth.backend.kerberos_auth` is moved into `fab` provider in Airflow 3.0;
     |
-252 | # apache-airflow-providers-fab
-253 | basic_auth, kerberos_auth
+267 | # apache-airflow-providers-fab
+268 | basic_auth, kerberos_auth
     |             ^^^^^^^^^^^^^ AIR303
-254 | auth_current_user
-255 | backend_kerberos_auth
+269 | auth_current_user
+270 | backend_kerberos_auth
     |
     = help: Install `apache-airflow-provider-fab>=1.0.0` and import from `airflow.providers.fab.auth_manager.api.auth.backend.kerberos_auth` instead.
 
-AIR303.py:254:1: AIR303 Import path `airflow.api.auth.backend.basic_auth` is moved into `fab` provider in Airflow 3.0;
+AIR303.py:269:1: AIR303 Import path `airflow.api.auth.backend.basic_auth` is moved into `fab` provider in Airflow 3.0;
     |
-252 | # apache-airflow-providers-fab
-253 | basic_auth, kerberos_auth
-254 | auth_current_user
+267 | # apache-airflow-providers-fab
+268 | basic_auth, kerberos_auth
+269 | auth_current_user
     | ^^^^^^^^^^^^^^^^^ AIR303
-255 | backend_kerberos_auth
-256 | fab_override
+270 | backend_kerberos_auth
+271 | fab_override
     |
     = help: Install `apache-airflow-provider-fab>=1.0.0` and import from `airflow.providers.fab.auth_manager.api.auth.backend.basic_auth` instead.
 
-AIR303.py:255:1: AIR303 Import path `airflow.auth_manager.api.auth.backend.kerberos_auth` is moved into `fab` provider in Airflow 3.0;
+AIR303.py:270:1: AIR303 Import path `airflow.auth_manager.api.auth.backend.kerberos_auth` is moved into `fab` provider in Airflow 3.0;
     |
-253 | basic_auth, kerberos_auth
-254 | auth_current_user
-255 | backend_kerberos_auth
+268 | basic_auth, kerberos_auth
+269 | auth_current_user
+270 | backend_kerberos_auth
     | ^^^^^^^^^^^^^^^^^^^^^ AIR303
-256 | fab_override
-257 | FabAuthManager()
+271 | fab_override
+272 | FabAuthManager()
     |
     = help: Install `apache-airflow-provider-fab>=1.0.0` and import from `airflow.providers.fab.auth_manager.api.auth.backend.kerberos_auth` instead.
 
-AIR303.py:256:1: AIR303 Import path `airflow.auth.managers.fab.security_manager.override` is moved into `fab` provider in Airflow 3.0;
+AIR303.py:271:1: AIR303 Import path `airflow.auth.managers.fab.security_manager.override` is moved into `fab` provider in Airflow 3.0;
     |
-254 | auth_current_user
-255 | backend_kerberos_auth
-256 | fab_override
+269 | auth_current_user
+270 | backend_kerberos_auth
+271 | fab_override
     | ^^^^^^^^^^^^ AIR303
-257 | FabAuthManager()
-258 | FabAirflowSecurityManagerOverride()
+272 | FabAuthManager()
+273 | FabAirflowSecurityManagerOverride()
     |
     = help: Install `apache-airflow-provider-fab>=1.0.0` and import from `airflow.providers.fab.auth_manager.security_manager.override` instead.
 
-AIR303.py:257:1: AIR303 `airflow.auth.managers.fab.fab_auth_manager.FabAuthManager` is moved into `fab` provider in Airflow 3.0;
+AIR303.py:272:1: AIR303 `airflow.auth.managers.fab.fab_auth_manager.FabAuthManager` is moved into `fab` provider in Airflow 3.0;
     |
-255 | backend_kerberos_auth
-256 | fab_override
-257 | FabAuthManager()
+270 | backend_kerberos_auth
+271 | fab_override
+272 | FabAuthManager()
     | ^^^^^^^^^^^^^^ AIR303
-258 | FabAirflowSecurityManagerOverride()
+273 | FabAirflowSecurityManagerOverride()
     |
     = help: Install `apache-airflow-provider-fab>=1.0.0` and use `airflow.providers.fab.auth_manager.security_manager.FabAuthManager` instead.
 
-AIR303.py:258:1: AIR303 `airflow.www.security.FabAirflowSecurityManagerOverride` is moved into `fab` provider in Airflow 3.0;
+AIR303.py:273:1: AIR303 `airflow.www.security.FabAirflowSecurityManagerOverride` is moved into `fab` provider in Airflow 3.0;
     |
-256 | fab_override
-257 | FabAuthManager()
-258 | FabAirflowSecurityManagerOverride()
+271 | fab_override
+272 | FabAuthManager()
+273 | FabAirflowSecurityManagerOverride()
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR303
-259 |
-260 | # apache-airflow-providers-cncf-kubernetes
+274 |
+275 | # apache-airflow-providers-cncf-kubernetes
     |
     = help: Install `apache-airflow-provider-fab>=1.0.0` and use `airflow.providers.fab.auth_manager.security_manager.override.FabAirflowSecurityManagerOverride` instead.
 
-AIR303.py:261:1: AIR303 Import path `airflow.executors.kubernetes_executor_types.ALL_NAMESPACES` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR303.py:276:1: AIR303 Import path `airflow.executors.kubernetes_executor_types.ALL_NAMESPACES` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-260 | # apache-airflow-providers-cncf-kubernetes
-261 | ALL_NAMESPACES
+275 | # apache-airflow-providers-cncf-kubernetes
+276 | ALL_NAMESPACES
     | ^^^^^^^^^^^^^^ AIR303
-262 | POD_EXECUTOR_DONE_KEY
-263 | _disable_verify_ssl()
+277 | POD_EXECUTOR_DONE_KEY
+278 | _disable_verify_ssl()
     |
     = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and import from `airflow.providers.cncf.kubernetes.executors.kubernetes_executor_types.ALL_NAMESPACES` instead.
 
-AIR303.py:262:1: AIR303 Import path `airflow.executors.kubernetes_executor_types.POD_EXECUTOR_DONE_KEY` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR303.py:277:1: AIR303 Import path `airflow.executors.kubernetes_executor_types.POD_EXECUTOR_DONE_KEY` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-260 | # apache-airflow-providers-cncf-kubernetes
-261 | ALL_NAMESPACES
-262 | POD_EXECUTOR_DONE_KEY
+275 | # apache-airflow-providers-cncf-kubernetes
+276 | ALL_NAMESPACES
+277 | POD_EXECUTOR_DONE_KEY
     | ^^^^^^^^^^^^^^^^^^^^^ AIR303
-263 | _disable_verify_ssl()
-264 | _enable_tcp_keepalive()
+278 | _disable_verify_ssl()
+279 | _enable_tcp_keepalive()
     |
     = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and import from `airflow.providers.cncf.kubernetes.executors.kubernetes_executor_types.POD_EXECUTOR_DONE_KEY` instead.
 
-AIR303.py:263:1: AIR303 `airflow.kubernetes.kube_client._disable_verify_ssl` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR303.py:278:1: AIR303 `airflow.kubernetes.kube_client._disable_verify_ssl` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-261 | ALL_NAMESPACES
-262 | POD_EXECUTOR_DONE_KEY
-263 | _disable_verify_ssl()
+276 | ALL_NAMESPACES
+277 | POD_EXECUTOR_DONE_KEY
+278 | _disable_verify_ssl()
     | ^^^^^^^^^^^^^^^^^^^ AIR303
-264 | _enable_tcp_keepalive()
-265 | append_to_pod()
+279 | _enable_tcp_keepalive()
+280 | append_to_pod()
     |
     = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.kubernetes.airflow.providers.cncf.kubernetes.kube_client._disable_verify_ssl` instead.
 
-AIR303.py:264:1: AIR303 `airflow.kubernetes.kube_client._enable_tcp_keepalive` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR303.py:279:1: AIR303 `airflow.kubernetes.kube_client._enable_tcp_keepalive` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-262 | POD_EXECUTOR_DONE_KEY
-263 | _disable_verify_ssl()
-264 | _enable_tcp_keepalive()
+277 | POD_EXECUTOR_DONE_KEY
+278 | _disable_verify_ssl()
+279 | _enable_tcp_keepalive()
     | ^^^^^^^^^^^^^^^^^^^^^ AIR303
-265 | append_to_pod()
-266 | annotations_for_logging_task_metadata()
+280 | append_to_pod()
+281 | annotations_for_logging_task_metadata()
     |
     = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.kubernetes.airflow.providers.cncf.kubernetes.kube_client._enable_tcp_keepalive` instead.
 
-AIR303.py:265:1: AIR303 `airflow.kubernetes.k8s_model.append_to_pod` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR303.py:280:1: AIR303 `airflow.kubernetes.k8s_model.append_to_pod` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-263 | _disable_verify_ssl()
-264 | _enable_tcp_keepalive()
-265 | append_to_pod()
+278 | _disable_verify_ssl()
+279 | _enable_tcp_keepalive()
+280 | append_to_pod()
     | ^^^^^^^^^^^^^ AIR303
-266 | annotations_for_logging_task_metadata()
-267 | annotations_to_key()
+281 | annotations_for_logging_task_metadata()
+282 | annotations_to_key()
     |
     = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.providers.cncf.kubernetes.k8s_model.append_to_pod` instead.
 
-AIR303.py:266:1: AIR303 `airflow.kubernetes.kubernetes_helper_functions.annotations_for_logging_task_metadata` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR303.py:281:1: AIR303 `airflow.kubernetes.kubernetes_helper_functions.annotations_for_logging_task_metadata` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-264 | _enable_tcp_keepalive()
-265 | append_to_pod()
-266 | annotations_for_logging_task_metadata()
+279 | _enable_tcp_keepalive()
+280 | append_to_pod()
+281 | annotations_for_logging_task_metadata()
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR303
-267 | annotations_to_key()
-268 | create_pod_id()
+282 | annotations_to_key()
+283 | create_pod_id()
     |
     = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.providers.cncf.kubernetes.kubernetes_helper_functions.annotations_for_logging_task_metadata` instead.
 
-AIR303.py:267:1: AIR303 `airflow.kubernetes.kubernetes_helper_functions.annotations_to_key` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR303.py:282:1: AIR303 `airflow.kubernetes.kubernetes_helper_functions.annotations_to_key` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-265 | append_to_pod()
-266 | annotations_for_logging_task_metadata()
-267 | annotations_to_key()
+280 | append_to_pod()
+281 | annotations_for_logging_task_metadata()
+282 | annotations_to_key()
     | ^^^^^^^^^^^^^^^^^^ AIR303
-268 | create_pod_id()
-269 | datetime_to_label_safe_datestring()
+283 | create_pod_id()
+284 | datetime_to_label_safe_datestring()
     |
     = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.providers.cncf.kubernetes.kubernetes_helper_functions.annotations_to_key` instead.
 
-AIR303.py:268:1: AIR303 `airflow.kubernetes.kubernetes_helper_functions.create_pod_id` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR303.py:283:1: AIR303 `airflow.kubernetes.kubernetes_helper_functions.create_pod_id` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-266 | annotations_for_logging_task_metadata()
-267 | annotations_to_key()
-268 | create_pod_id()
+281 | annotations_for_logging_task_metadata()
+282 | annotations_to_key()
+283 | create_pod_id()
     | ^^^^^^^^^^^^^ AIR303
-269 | datetime_to_label_safe_datestring()
-270 | extend_object_field()
+284 | datetime_to_label_safe_datestring()
+285 | extend_object_field()
     |
     = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.providers.cncf.kubernetes.kubernetes_helper_functions.create_pod_id` instead.
 
-AIR303.py:269:1: AIR303 `airflow.kubernetes.pod_generator.datetime_to_label_safe_datestring` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR303.py:284:1: AIR303 `airflow.kubernetes.pod_generator.datetime_to_label_safe_datestring` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-267 | annotations_to_key()
-268 | create_pod_id()
-269 | datetime_to_label_safe_datestring()
+282 | annotations_to_key()
+283 | create_pod_id()
+284 | datetime_to_label_safe_datestring()
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR303
-270 | extend_object_field()
-271 | get_logs_task_metadata()
+285 | extend_object_field()
+286 | get_logs_task_metadata()
     |
     = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.providers.cncf.kubernetes.pod_generator.datetime_to_label_safe_datestring` instead.
 
-AIR303.py:270:1: AIR303 `airflow.kubernetes.pod_generator.extend_object_field` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR303.py:285:1: AIR303 `airflow.kubernetes.pod_generator.extend_object_field` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-268 | create_pod_id()
-269 | datetime_to_label_safe_datestring()
-270 | extend_object_field()
+283 | create_pod_id()
+284 | datetime_to_label_safe_datestring()
+285 | extend_object_field()
     | ^^^^^^^^^^^^^^^^^^^ AIR303
-271 | get_logs_task_metadata()
-272 | label_safe_datestring_to_datetime()
+286 | get_logs_task_metadata()
+287 | label_safe_datestring_to_datetime()
     |
     = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.kubernetes.airflow.providers.cncf.kubernetes.pod_generator.extend_object_field` instead.
 
-AIR303.py:271:1: AIR303 `airflow.kubernetes.kubernetes_helper_functions.get_logs_task_metadata` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR303.py:286:1: AIR303 `airflow.kubernetes.kubernetes_helper_functions.get_logs_task_metadata` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-269 | datetime_to_label_safe_datestring()
-270 | extend_object_field()
-271 | get_logs_task_metadata()
+284 | datetime_to_label_safe_datestring()
+285 | extend_object_field()
+286 | get_logs_task_metadata()
     | ^^^^^^^^^^^^^^^^^^^^^^ AIR303
-272 | label_safe_datestring_to_datetime()
-273 | merge_objects()
+287 | label_safe_datestring_to_datetime()
+288 | merge_objects()
     |
     = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.providers.cncf.kubernetes.kubernetes_helper_functions.get_logs_task_metadata` instead.
 
-AIR303.py:272:1: AIR303 `airflow.kubernetes.pod_generator.label_safe_datestring_to_datetime` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR303.py:287:1: AIR303 `airflow.kubernetes.pod_generator.label_safe_datestring_to_datetime` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-270 | extend_object_field()
-271 | get_logs_task_metadata()
-272 | label_safe_datestring_to_datetime()
+285 | extend_object_field()
+286 | get_logs_task_metadata()
+287 | label_safe_datestring_to_datetime()
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR303
-273 | merge_objects()
-274 | Port()
+288 | merge_objects()
+289 | Port()
     |
     = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.providers.cncf.kubernetes.pod_generator.label_safe_datestring_to_datetime` instead.
 
-AIR303.py:273:1: AIR303 `airflow.kubernetes.pod_generator.merge_objects` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR303.py:288:1: AIR303 `airflow.kubernetes.pod_generator.merge_objects` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-271 | get_logs_task_metadata()
-272 | label_safe_datestring_to_datetime()
-273 | merge_objects()
+286 | get_logs_task_metadata()
+287 | label_safe_datestring_to_datetime()
+288 | merge_objects()
     | ^^^^^^^^^^^^^ AIR303
-274 | Port()
-275 | Resources()
+289 | Port()
+290 | Resources()
     |
     = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.providers.cncf.kubernetes.pod_generator.merge_objects` instead.
 
-AIR303.py:274:1: AIR303 `airflow.kubernetes.pod.Port` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR303.py:289:1: AIR303 `airflow.kubernetes.pod.Port` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-272 | label_safe_datestring_to_datetime()
-273 | merge_objects()
-274 | Port()
+287 | label_safe_datestring_to_datetime()
+288 | merge_objects()
+289 | Port()
     | ^^^^ AIR303
-275 | Resources()
-276 | PodRuntimeInfoEnv()
+290 | Resources()
+291 | PodRuntimeInfoEnv()
     |
     = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `kubernetes.client.models.V1ContainerPort` instead.
 
-AIR303.py:275:1: AIR303 `airflow.kubernetes.pod.Resources` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR303.py:290:1: AIR303 `airflow.kubernetes.pod.Resources` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-273 | merge_objects()
-274 | Port()
-275 | Resources()
+288 | merge_objects()
+289 | Port()
+290 | Resources()
     | ^^^^^^^^^ AIR303
-276 | PodRuntimeInfoEnv()
-277 | PodGeneratorDeprecated()
+291 | PodRuntimeInfoEnv()
+292 | PodGeneratorDeprecated()
     |
     = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `kubernetes.client.models.V1ResourceRequirements` instead.
 
-AIR303.py:276:1: AIR303 `airflow.kubernetes.pod_runtime_info_env.PodRuntimeInfoEnv` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR303.py:291:1: AIR303 `airflow.kubernetes.pod_runtime_info_env.PodRuntimeInfoEnv` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-274 | Port()
-275 | Resources()
-276 | PodRuntimeInfoEnv()
+289 | Port()
+290 | Resources()
+291 | PodRuntimeInfoEnv()
     | ^^^^^^^^^^^^^^^^^ AIR303
-277 | PodGeneratorDeprecated()
-278 | Volume()
+292 | PodGeneratorDeprecated()
+293 | Volume()
     |
     = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `kubernetes.client.models.V1EnvVar` instead.
 
-AIR303.py:277:1: AIR303 `airflow.kubernetes.pod_generator.PodGeneratorDeprecated` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR303.py:292:1: AIR303 `airflow.kubernetes.pod_generator.PodGeneratorDeprecated` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-275 | Resources()
-276 | PodRuntimeInfoEnv()
-277 | PodGeneratorDeprecated()
+290 | Resources()
+291 | PodRuntimeInfoEnv()
+292 | PodGeneratorDeprecated()
     | ^^^^^^^^^^^^^^^^^^^^^^ AIR303
-278 | Volume()
-279 | VolumeMount()
+293 | Volume()
+294 | VolumeMount()
     |
     = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.providers.cncf.kubernetes.pod_generator.PodGenerator` instead.
 
-AIR303.py:278:1: AIR303 `airflow.kubernetes.volume.Volume` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR303.py:293:1: AIR303 `airflow.kubernetes.volume.Volume` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-276 | PodRuntimeInfoEnv()
-277 | PodGeneratorDeprecated()
-278 | Volume()
+291 | PodRuntimeInfoEnv()
+292 | PodGeneratorDeprecated()
+293 | Volume()
     | ^^^^^^ AIR303
-279 | VolumeMount()
-280 | Secret()
+294 | VolumeMount()
+295 | Secret()
     |
     = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `kubernetes.client.models.V1Volume` instead.
 
-AIR303.py:279:1: AIR303 `airflow.kubernetes.volume_mount.VolumeMount` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR303.py:294:1: AIR303 `airflow.kubernetes.volume_mount.VolumeMount` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-277 | PodGeneratorDeprecated()
-278 | Volume()
-279 | VolumeMount()
+292 | PodGeneratorDeprecated()
+293 | Volume()
+294 | VolumeMount()
     | ^^^^^^^^^^^ AIR303
-280 | Secret()
+295 | Secret()
     |
     = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `kubernetes.client.models.V1VolumeMount` instead.
 
-AIR303.py:280:1: AIR303 `airflow.kubernetes.secret.Secret` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR303.py:295:1: AIR303 `airflow.kubernetes.secret.Secret` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-278 | Volume()
-279 | VolumeMount()
-280 | Secret()
+293 | Volume()
+294 | VolumeMount()
+295 | Secret()
     | ^^^^^^ AIR303
-281 |
-282 | add_pod_suffix()
+296 |
+297 | add_pod_suffix()
     |
     = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.providers.cncf.kubernetes.secret.Secret` instead.
 
-AIR303.py:282:1: AIR303 `airflow.kubernetes.kubernetes_helper_functions.add_pod_suffix` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR303.py:297:1: AIR303 `airflow.kubernetes.kubernetes_helper_functions.add_pod_suffix` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-280 | Secret()
-281 |
-282 | add_pod_suffix()
+295 | Secret()
+296 |
+297 | add_pod_suffix()
     | ^^^^^^^^^^^^^^ AIR303
-283 | add_pod_suffix2()
-284 | get_kube_client()
+298 | add_pod_suffix2()
+299 | get_kube_client()
     |
     = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.providers.cncf.kubernetes.kubernetes_helper_functions.add_pod_suffix` instead.
 
-AIR303.py:283:1: AIR303 `airflow.kubernetes.pod_generator.add_pod_suffix` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR303.py:298:1: AIR303 `airflow.kubernetes.pod_generator.add_pod_suffix` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-282 | add_pod_suffix()
-283 | add_pod_suffix2()
+297 | add_pod_suffix()
+298 | add_pod_suffix2()
     | ^^^^^^^^^^^^^^^ AIR303
-284 | get_kube_client()
-285 | get_kube_client2()
+299 | get_kube_client()
+300 | get_kube_client2()
     |
     = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.providers.cncf.kubernetes.kubernetes_helper_functions.add_pod_suffix` instead.
 
-AIR303.py:284:1: AIR303 `airflow.kubernetes.kube_client.get_kube_client` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR303.py:299:1: AIR303 `airflow.kubernetes.kube_client.get_kube_client` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-282 | add_pod_suffix()
-283 | add_pod_suffix2()
-284 | get_kube_client()
+297 | add_pod_suffix()
+298 | add_pod_suffix2()
+299 | get_kube_client()
     | ^^^^^^^^^^^^^^^ AIR303
-285 | get_kube_client2()
-286 | make_safe_label_value()
+300 | get_kube_client2()
+301 | make_safe_label_value()
     |
     = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.kubernetes.airflow.providers.cncf.kubernetes.kube_client.get_kube_client` instead.
 
-AIR303.py:285:1: AIR303 `airflow.kubernetes.pod_launcher_deprecated.get_kube_client` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR303.py:300:1: AIR303 `airflow.kubernetes.pod_launcher_deprecated.get_kube_client` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-283 | add_pod_suffix2()
-284 | get_kube_client()
-285 | get_kube_client2()
+298 | add_pod_suffix2()
+299 | get_kube_client()
+300 | get_kube_client2()
     | ^^^^^^^^^^^^^^^^ AIR303
-286 | make_safe_label_value()
-287 | make_safe_label_value2()
+301 | make_safe_label_value()
+302 | make_safe_label_value2()
     |
     = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.providers.cncf.kubernetes.kube_client.get_kube_client` instead.
 
-AIR303.py:286:1: AIR303 `airflow.kubernetes.pod_generator.make_safe_label_value` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR303.py:301:1: AIR303 `airflow.kubernetes.pod_generator.make_safe_label_value` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-284 | get_kube_client()
-285 | get_kube_client2()
-286 | make_safe_label_value()
+299 | get_kube_client()
+300 | get_kube_client2()
+301 | make_safe_label_value()
     | ^^^^^^^^^^^^^^^^^^^^^ AIR303
-287 | make_safe_label_value2()
-288 | rand_str()
+302 | make_safe_label_value2()
+303 | rand_str()
     |
     = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.providers.cncf.kubernetes.pod_generator.make_safe_label_value` instead.
 
-AIR303.py:287:1: AIR303 `airflow.kubernetes.pod_generator_deprecated.make_safe_label_value` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR303.py:302:1: AIR303 `airflow.kubernetes.pod_generator_deprecated.make_safe_label_value` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-285 | get_kube_client2()
-286 | make_safe_label_value()
-287 | make_safe_label_value2()
+300 | get_kube_client2()
+301 | make_safe_label_value()
+302 | make_safe_label_value2()
     | ^^^^^^^^^^^^^^^^^^^^^^ AIR303
-288 | rand_str()
-289 | rand_str2()
+303 | rand_str()
+304 | rand_str2()
     |
     = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.providers.cncf.kubernetes.pod_generator_deprecated.make_safe_label_value` instead.
 
-AIR303.py:288:1: AIR303 `airflow.kubernetes.kubernetes_helper_functions.rand_str` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR303.py:303:1: AIR303 `airflow.kubernetes.kubernetes_helper_functions.rand_str` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-286 | make_safe_label_value()
-287 | make_safe_label_value2()
-288 | rand_str()
+301 | make_safe_label_value()
+302 | make_safe_label_value2()
+303 | rand_str()
     | ^^^^^^^^ AIR303
-289 | rand_str2()
-290 | K8SModel()
+304 | rand_str2()
+305 | K8SModel()
     |
     = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.providers.cncf.kubernetes.kubernetes_helper_functions.rand_str` instead.
 
-AIR303.py:289:1: AIR303 `airflow.kubernetes.pod_generator.rand_str` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR303.py:304:1: AIR303 `airflow.kubernetes.pod_generator.rand_str` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-287 | make_safe_label_value2()
-288 | rand_str()
-289 | rand_str2()
+302 | make_safe_label_value2()
+303 | rand_str()
+304 | rand_str2()
     | ^^^^^^^^^ AIR303
-290 | K8SModel()
-291 | K8SModel2()
+305 | K8SModel()
+306 | K8SModel2()
     |
     = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.providers.cncf.kubernetes.kubernetes_helper_functions.rand_str` instead.
 
-AIR303.py:290:1: AIR303 `airflow.kubernetes.k8s_model.K8SModel` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR303.py:305:1: AIR303 `airflow.kubernetes.k8s_model.K8SModel` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-288 | rand_str()
-289 | rand_str2()
-290 | K8SModel()
+303 | rand_str()
+304 | rand_str2()
+305 | K8SModel()
     | ^^^^^^^^ AIR303
-291 | K8SModel2()
-292 | PodLauncher()
+306 | K8SModel2()
+307 | PodLauncher()
     |
     = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.providers.cncf.kubernetes.k8s_model.K8SModel` instead.
 
-AIR303.py:292:1: AIR303 `airflow.kubernetes.pod_launcher.PodLauncher` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR303.py:307:1: AIR303 `airflow.kubernetes.pod_launcher.PodLauncher` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-290 | K8SModel()
-291 | K8SModel2()
-292 | PodLauncher()
+305 | K8SModel()
+306 | K8SModel2()
+307 | PodLauncher()
     | ^^^^^^^^^^^ AIR303
-293 | PodLauncher2()
-294 | PodStatus()
+308 | PodLauncher2()
+309 | PodStatus()
     |
     = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.providers.cncf.kubernetes.pod_launcher.PodLauncher` instead.
 
-AIR303.py:293:1: AIR303 `airflow.kubernetes.pod_launcher_deprecated.PodLauncher` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR303.py:308:1: AIR303 `airflow.kubernetes.pod_launcher_deprecated.PodLauncher` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-291 | K8SModel2()
-292 | PodLauncher()
-293 | PodLauncher2()
+306 | K8SModel2()
+307 | PodLauncher()
+308 | PodLauncher2()
     | ^^^^^^^^^^^^ AIR303
-294 | PodStatus()
-295 | PodStatus2()
+309 | PodStatus()
+310 | PodStatus2()
     |
     = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.providers.cncf.kubernetes.pod_launcher_deprecated.PodLauncher` instead.
 
-AIR303.py:294:1: AIR303 `airflow.kubernetes.pod_launcher.PodStatus` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR303.py:309:1: AIR303 `airflow.kubernetes.pod_launcher.PodStatus` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-292 | PodLauncher()
-293 | PodLauncher2()
-294 | PodStatus()
+307 | PodLauncher()
+308 | PodLauncher2()
+309 | PodStatus()
     | ^^^^^^^^^ AIR303
-295 | PodStatus2()
-296 | PodDefaults()
+310 | PodStatus2()
+311 | PodDefaults()
     |
     = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.providers.cncf.kubernetes.pod_launcher.PodStatus` instead.
 
-AIR303.py:295:1: AIR303 `airflow.kubernetes.pod_launcher_deprecated.PodStatus` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR303.py:310:1: AIR303 `airflow.kubernetes.pod_launcher_deprecated.PodStatus` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-293 | PodLauncher2()
-294 | PodStatus()
-295 | PodStatus2()
+308 | PodLauncher2()
+309 | PodStatus()
+310 | PodStatus2()
     | ^^^^^^^^^^ AIR303
-296 | PodDefaults()
-297 | PodDefaults2()
+311 | PodDefaults()
+312 | PodDefaults2()
     |
     = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.providers.cncf.kubernetes.pod_launcher_deprecated.PodStatus` instead.
 
-AIR303.py:296:1: AIR303 `airflow.kubernetes.pod_generator.PodDefaults` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR303.py:311:1: AIR303 `airflow.kubernetes.pod_generator.PodDefaults` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-294 | PodStatus()
-295 | PodStatus2()
-296 | PodDefaults()
+309 | PodStatus()
+310 | PodStatus2()
+311 | PodDefaults()
     | ^^^^^^^^^^^ AIR303
-297 | PodDefaults2()
-298 | PodDefaults3()
+312 | PodDefaults2()
+313 | PodDefaults3()
     |
     = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.providers.cncf.kubernetes.pod_generator_deprecated.PodDefaults` instead.
 
-AIR303.py:297:1: AIR303 `airflow.kubernetes.pod_launcher_deprecated.PodDefaults` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR303.py:312:1: AIR303 `airflow.kubernetes.pod_launcher_deprecated.PodDefaults` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-295 | PodStatus2()
-296 | PodDefaults()
-297 | PodDefaults2()
+310 | PodStatus2()
+311 | PodDefaults()
+312 | PodDefaults2()
     | ^^^^^^^^^^^^ AIR303
-298 | PodDefaults3()
-299 | PodGenerator()
+313 | PodDefaults3()
+314 | PodGenerator()
     |
     = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.providers.cncf.kubernetes.pod_generator_deprecated.PodDefaults` instead.
 
-AIR303.py:298:1: AIR303 `airflow.kubernetes.pod_generator_deprecated.PodDefaults` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR303.py:313:1: AIR303 `airflow.kubernetes.pod_generator_deprecated.PodDefaults` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-296 | PodDefaults()
-297 | PodDefaults2()
-298 | PodDefaults3()
+311 | PodDefaults()
+312 | PodDefaults2()
+313 | PodDefaults3()
     | ^^^^^^^^^^^^ AIR303
-299 | PodGenerator()
-300 | PodGenerator2()
+314 | PodGenerator()
+315 | PodGenerator2()
     |
     = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.providers.cncf.kubernetes.pod_generator_deprecated.PodDefaults` instead.
 
-AIR303.py:299:1: AIR303 `airflow.kubernetes.pod_generator.PodGenerator` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR303.py:314:1: AIR303 `airflow.kubernetes.pod_generator.PodGenerator` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-297 | PodDefaults2()
-298 | PodDefaults3()
-299 | PodGenerator()
+312 | PodDefaults2()
+313 | PodDefaults3()
+314 | PodGenerator()
     | ^^^^^^^^^^^^ AIR303
-300 | PodGenerator2()
+315 | PodGenerator2()
     |
     = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.providers.cncf.kubernetes.pod_generator.PodGenerator` instead.
 
-AIR303.py:300:1: AIR303 `airflow.kubernetes.pod_generator_deprecated.PodGenerator` is moved into `cncf-kubernetes` provider in Airflow 3.0;
+AIR303.py:315:1: AIR303 `airflow.kubernetes.pod_generator_deprecated.PodGenerator` is moved into `cncf-kubernetes` provider in Airflow 3.0;
     |
-298 | PodDefaults3()
-299 | PodGenerator()
-300 | PodGenerator2()
+313 | PodDefaults3()
+314 | PodGenerator()
+315 | PodGenerator2()
     | ^^^^^^^^^^^^^ AIR303
     |
     = help: Install `apache-airflow-provider-cncf-kubernetes>=7.4.0` and use `airflow.providers.cncf.kubernetes.pod_generator_deprecated.PodGenerator` instead.
 
-AIR303.py:304:1: AIR303 `airflow.hooks.mssql_hook.MsSqlHook` is moved into `microsoft-mssql` provider in Airflow 3.0;
+AIR303.py:319:1: AIR303 `airflow.hooks.mssql_hook.MsSqlHook` is moved into `microsoft-mssql` provider in Airflow 3.0;
     |
-303 | # apache-airflow-providers-microsoft-mssql
-304 | MsSqlHook()
+318 | # apache-airflow-providers-microsoft-mssql
+319 | MsSqlHook()
     | ^^^^^^^^^ AIR303
-305 | MsSqlOperator()
-306 | MsSqlToHiveOperator()
+320 | MsSqlOperator()
+321 | MsSqlToHiveOperator()
     |
     = help: Install `apache-airflow-provider-microsoft-mssql>=1.0.0` and use `airflow.providers.microsoft.mssql.hooks.mssql.MsSqlHook` instead.
 
-AIR303.py:305:1: AIR303 `airflow.operators.mssql_operator.MsSqlOperator` is moved into `microsoft-mssql` provider in Airflow 3.0;
+AIR303.py:320:1: AIR303 `airflow.operators.mssql_operator.MsSqlOperator` is moved into `microsoft-mssql` provider in Airflow 3.0;
     |
-303 | # apache-airflow-providers-microsoft-mssql
-304 | MsSqlHook()
-305 | MsSqlOperator()
+318 | # apache-airflow-providers-microsoft-mssql
+319 | MsSqlHook()
+320 | MsSqlOperator()
     | ^^^^^^^^^^^^^ AIR303
-306 | MsSqlToHiveOperator()
-307 | MsSqlToHiveTransfer()
+321 | MsSqlToHiveOperator()
+322 | MsSqlToHiveTransfer()
     |
     = help: Install `apache-airflow-provider-microsoft-mssql>=1.0.0` and use `airflow.providers.microsoft.mssql.operators.mssql.MsSqlOperator` instead.
 
-AIR303.py:306:1: AIR303 `airflow.operators.mssql_to_hive.MsSqlToHiveOperator` is moved into `apache-hive` provider in Airflow 3.0;
+AIR303.py:321:1: AIR303 `airflow.operators.mssql_to_hive.MsSqlToHiveOperator` is moved into `apache-hive` provider in Airflow 3.0;
     |
-304 | MsSqlHook()
-305 | MsSqlOperator()
-306 | MsSqlToHiveOperator()
+319 | MsSqlHook()
+320 | MsSqlOperator()
+321 | MsSqlToHiveOperator()
     | ^^^^^^^^^^^^^^^^^^^ AIR303
-307 | MsSqlToHiveTransfer()
+322 | MsSqlToHiveTransfer()
     |
     = help: Install `apache-airflow-provider-apache-hive>=1.0.0` and use `airflow.providers.apache.hive.transfers.mssql_to_hive.MsSqlToHiveOperator` instead.
 
-AIR303.py:307:1: AIR303 `airflow.operators.mssql_to_hive.MsSqlToHiveTransfer` is moved into `apache-hive` provider in Airflow 3.0;
+AIR303.py:322:1: AIR303 `airflow.operators.mssql_to_hive.MsSqlToHiveTransfer` is moved into `apache-hive` provider in Airflow 3.0;
     |
-305 | MsSqlOperator()
-306 | MsSqlToHiveOperator()
-307 | MsSqlToHiveTransfer()
+320 | MsSqlOperator()
+321 | MsSqlToHiveOperator()
+322 | MsSqlToHiveTransfer()
     | ^^^^^^^^^^^^^^^^^^^ AIR303
-308 |
-309 | # apache-airflow-providers-mysql
+323 |
+324 | # apache-airflow-providers-mysql
     |
     = help: Install `apache-airflow-provider-apache-hive>=1.0.0` and use `airflow.providers.apache.hive.transfers.mssql_to_hive.MsSqlToHiveOperator` instead.
 
-AIR303.py:310:1: AIR303 `airflow.operators.hive_to_mysql.HiveToMySqlOperator` is moved into `apache-hive` provider in Airflow 3.0;
+AIR303.py:325:1: AIR303 `airflow.operators.hive_to_mysql.HiveToMySqlOperator` is moved into `apache-hive` provider in Airflow 3.0;
     |
-309 | # apache-airflow-providers-mysql
-310 | HiveToMySqlOperator()
+324 | # apache-airflow-providers-mysql
+325 | HiveToMySqlOperator()
     | ^^^^^^^^^^^^^^^^^^^ AIR303
-311 | HiveToMySqlTransfer()
-312 | MySqlHook()
+326 | HiveToMySqlTransfer()
+327 | MySqlHook()
     |
     = help: Install `apache-airflow-provider-apache-hive>=1.0.0` and use `airflow.providers.apache.hive.transfers.hive_to_mysql.HiveToMySqlOperator` instead.
 
-AIR303.py:311:1: AIR303 `airflow.operators.hive_to_mysql.HiveToMySqlTransfer` is moved into `apache-hive` provider in Airflow 3.0;
+AIR303.py:326:1: AIR303 `airflow.operators.hive_to_mysql.HiveToMySqlTransfer` is moved into `apache-hive` provider in Airflow 3.0;
     |
-309 | # apache-airflow-providers-mysql
-310 | HiveToMySqlOperator()
-311 | HiveToMySqlTransfer()
+324 | # apache-airflow-providers-mysql
+325 | HiveToMySqlOperator()
+326 | HiveToMySqlTransfer()
     | ^^^^^^^^^^^^^^^^^^^ AIR303
-312 | MySqlHook()
-313 | MySqlOperator()
+327 | MySqlHook()
+328 | MySqlOperator()
     |
     = help: Install `apache-airflow-provider-apache-hive>=1.0.0` and use `airflow.providers.apache.hive.transfers.hive_to_mysql.HiveToMySqlOperator` instead.
 
-AIR303.py:312:1: AIR303 `airflow.hooks.mysql_hook.MySqlHook` is moved into `mysql` provider in Airflow 3.0;
+AIR303.py:327:1: AIR303 `airflow.hooks.mysql_hook.MySqlHook` is moved into `mysql` provider in Airflow 3.0;
     |
-310 | HiveToMySqlOperator()
-311 | HiveToMySqlTransfer()
-312 | MySqlHook()
+325 | HiveToMySqlOperator()
+326 | HiveToMySqlTransfer()
+327 | MySqlHook()
     | ^^^^^^^^^ AIR303
-313 | MySqlOperator()
-314 | MySqlToHiveOperator()
+328 | MySqlOperator()
+329 | MySqlToHiveOperator()
     |
     = help: Install `apache-airflow-provider-mysql>=1.0.0` and use `airflow.providers.mysql.hooks.mysql.MySqlHook` instead.
 
-AIR303.py:313:1: AIR303 `airflow.operators.mysql_operator.MySqlOperator` is moved into `mysql` provider in Airflow 3.0;
+AIR303.py:328:1: AIR303 `airflow.operators.mysql_operator.MySqlOperator` is moved into `mysql` provider in Airflow 3.0;
     |
-311 | HiveToMySqlTransfer()
-312 | MySqlHook()
-313 | MySqlOperator()
+326 | HiveToMySqlTransfer()
+327 | MySqlHook()
+328 | MySqlOperator()
     | ^^^^^^^^^^^^^ AIR303
-314 | MySqlToHiveOperator()
-315 | MySqlToHiveTransfer()
+329 | MySqlToHiveOperator()
+330 | MySqlToHiveTransfer()
     |
     = help: Install `apache-airflow-provider-mysql>=1.0.0` and use `airflow.providers.mysql.operators.mysql.MySqlOperator` instead.
 
-AIR303.py:314:1: AIR303 `airflow.operators.mysql_to_hive.MySqlToHiveOperator` is moved into `apache-hive` provider in Airflow 3.0;
+AIR303.py:329:1: AIR303 `airflow.operators.mysql_to_hive.MySqlToHiveOperator` is moved into `apache-hive` provider in Airflow 3.0;
     |
-312 | MySqlHook()
-313 | MySqlOperator()
-314 | MySqlToHiveOperator()
+327 | MySqlHook()
+328 | MySqlOperator()
+329 | MySqlToHiveOperator()
     | ^^^^^^^^^^^^^^^^^^^ AIR303
-315 | MySqlToHiveTransfer()
-316 | PrestoToMySqlOperator()
+330 | MySqlToHiveTransfer()
+331 | PrestoToMySqlOperator()
     |
     = help: Install `apache-airflow-provider-apache-hive>=1.0.0` and use `airflow.providers.apache.hive.transfers.mysql_to_hive.MySqlToHiveOperator` instead.
 
-AIR303.py:315:1: AIR303 `airflow.operators.mysql_to_hive.MySqlToHiveTransfer` is moved into `apache-hive` provider in Airflow 3.0;
+AIR303.py:330:1: AIR303 `airflow.operators.mysql_to_hive.MySqlToHiveTransfer` is moved into `apache-hive` provider in Airflow 3.0;
     |
-313 | MySqlOperator()
-314 | MySqlToHiveOperator()
-315 | MySqlToHiveTransfer()
+328 | MySqlOperator()
+329 | MySqlToHiveOperator()
+330 | MySqlToHiveTransfer()
     | ^^^^^^^^^^^^^^^^^^^ AIR303
-316 | PrestoToMySqlOperator()
-317 | PrestoToMySqlTransfer()
+331 | PrestoToMySqlOperator()
+332 | PrestoToMySqlTransfer()
     |
     = help: Install `apache-airflow-provider-apache-hive>=1.0.0` and use `airflow.providers.apache.hive.transfers.mysql_to_hive.MySqlToHiveOperator` instead.
 
-AIR303.py:316:1: AIR303 `airflow.operators.presto_to_mysql.PrestoToMySqlOperator` is moved into `mysql` provider in Airflow 3.0;
+AIR303.py:331:1: AIR303 `airflow.operators.presto_to_mysql.PrestoToMySqlOperator` is moved into `mysql` provider in Airflow 3.0;
     |
-314 | MySqlToHiveOperator()
-315 | MySqlToHiveTransfer()
-316 | PrestoToMySqlOperator()
+329 | MySqlToHiveOperator()
+330 | MySqlToHiveTransfer()
+331 | PrestoToMySqlOperator()
     | ^^^^^^^^^^^^^^^^^^^^^ AIR303
-317 | PrestoToMySqlTransfer()
+332 | PrestoToMySqlTransfer()
     |
     = help: Install `apache-airflow-provider-mysql>=1.0.0` and use `airflow.providers.mysql.transfers.presto_to_mysql.PrestoToMySqlOperator` instead.
 
-AIR303.py:317:1: AIR303 `airflow.operators.presto_to_mysql.PrestoToMySqlTransfer` is moved into `mysql` provider in Airflow 3.0;
+AIR303.py:332:1: AIR303 `airflow.operators.presto_to_mysql.PrestoToMySqlTransfer` is moved into `mysql` provider in Airflow 3.0;
     |
-315 | MySqlToHiveTransfer()
-316 | PrestoToMySqlOperator()
-317 | PrestoToMySqlTransfer()
+330 | MySqlToHiveTransfer()
+331 | PrestoToMySqlOperator()
+332 | PrestoToMySqlTransfer()
     | ^^^^^^^^^^^^^^^^^^^^^ AIR303
-318 |
-319 | # apache-airflow-providers-oracle
+333 |
+334 | # apache-airflow-providers-oracle
     |
     = help: Install `apache-airflow-provider-mysql>=1.0.0` and use `airflow.providers.mysql.transfers.presto_to_mysql.PrestoToMySqlOperator` instead.
 
-AIR303.py:320:1: AIR303 `airflow.hooks.oracle_hook.OracleHook` is moved into `oracle` provider in Airflow 3.0;
+AIR303.py:335:1: AIR303 `airflow.hooks.oracle_hook.OracleHook` is moved into `oracle` provider in Airflow 3.0;
     |
-319 | # apache-airflow-providers-oracle
-320 | OracleHook()
+334 | # apache-airflow-providers-oracle
+335 | OracleHook()
     | ^^^^^^^^^^ AIR303
-321 | OracleOperator()
+336 | OracleOperator()
     |
     = help: Install `apache-airflow-provider-oracle>=1.0.0` and use `airflow.providers.oracle.hooks.oracle.OracleHook` instead.
 
-AIR303.py:321:1: AIR303 `airflow.operators.oracle_operator.OracleOperator` is moved into `oracle` provider in Airflow 3.0;
+AIR303.py:336:1: AIR303 `airflow.operators.oracle_operator.OracleOperator` is moved into `oracle` provider in Airflow 3.0;
     |
-319 | # apache-airflow-providers-oracle
-320 | OracleHook()
-321 | OracleOperator()
+334 | # apache-airflow-providers-oracle
+335 | OracleHook()
+336 | OracleOperator()
     | ^^^^^^^^^^^^^^ AIR303
-322 |
-323 | # apache-airflow-providers-papermill
+337 |
+338 | # apache-airflow-providers-papermill
     |
     = help: Install `apache-airflow-provider-oracle>=1.0.0` and use `airflow.providers.oracle.operators.oracle.OracleOperator` instead.
 
-AIR303.py:324:1: AIR303 `airflow.operators.papermill_operator.PapermillOperator` is moved into `papermill` provider in Airflow 3.0;
+AIR303.py:339:1: AIR303 `airflow.operators.papermill_operator.PapermillOperator` is moved into `papermill` provider in Airflow 3.0;
     |
-323 | # apache-airflow-providers-papermill
-324 | PapermillOperator()
+338 | # apache-airflow-providers-papermill
+339 | PapermillOperator()
     | ^^^^^^^^^^^^^^^^^ AIR303
-325 |
-326 | # apache-airflow-providers-apache-pig
+340 |
+341 | # apache-airflow-providers-apache-pig
     |
     = help: Install `apache-airflow-provider-papermill>=1.0.0` and use `airflow.providers.papermill.operators.papermill.PapermillOperator` instead.
 
-AIR303.py:327:1: AIR303 `airflow.hooks.pig_hook.PigCliHook` is moved into `apache-pig` provider in Airflow 3.0;
+AIR303.py:342:1: AIR303 `airflow.hooks.pig_hook.PigCliHook` is moved into `apache-pig` provider in Airflow 3.0;
     |
-326 | # apache-airflow-providers-apache-pig
-327 | PigCliHook()
+341 | # apache-airflow-providers-apache-pig
+342 | PigCliHook()
     | ^^^^^^^^^^ AIR303
-328 | PigOperator()
+343 | PigOperator()
     |
     = help: Install `apache-airflow-provider-apache-pig>=1.0.0` and use `airflow.providers.apache.pig.hooks.pig.PigCliHook` instead.
 
-AIR303.py:328:1: AIR303 `airflow.operators.pig_operator.PigOperator` is moved into `apache-pig` provider in Airflow 3.0;
+AIR303.py:343:1: AIR303 `airflow.operators.pig_operator.PigOperator` is moved into `apache-pig` provider in Airflow 3.0;
     |
-326 | # apache-airflow-providers-apache-pig
-327 | PigCliHook()
-328 | PigOperator()
+341 | # apache-airflow-providers-apache-pig
+342 | PigCliHook()
+343 | PigOperator()
     | ^^^^^^^^^^^ AIR303
-329 |
-330 | # apache-airflow-providers-postgres
+344 |
+345 | # apache-airflow-providers-postgres
     |
     = help: Install `apache-airflow-provider-apache-pig>=1.0.0` and use `airflow.providers.apache.pig.operators.pig.PigOperator` instead.
 
-AIR303.py:331:1: AIR303 `airflow.operators.postgres_operator.Mapping` is moved into `postgres` provider in Airflow 3.0;
+AIR303.py:346:1: AIR303 `airflow.operators.postgres_operator.Mapping` is moved into `postgres` provider in Airflow 3.0;
     |
-330 | # apache-airflow-providers-postgres
-331 | Mapping
+345 | # apache-airflow-providers-postgres
+346 | Mapping
     | ^^^^^^^ AIR303
-332 | PostgresHook()
-333 | PostgresOperator()
+347 | PostgresHook()
+348 | PostgresOperator()
     |
     = help: Install `apache-airflow-provider-postgres>=1.0.0` and use `airflow.providers.postgres.operators.postgres.Mapping` instead.
 
-AIR303.py:332:1: AIR303 `airflow.hooks.postgres_hook.PostgresHook` is moved into `postgres` provider in Airflow 3.0;
+AIR303.py:347:1: AIR303 `airflow.hooks.postgres_hook.PostgresHook` is moved into `postgres` provider in Airflow 3.0;
     |
-330 | # apache-airflow-providers-postgres
-331 | Mapping
-332 | PostgresHook()
+345 | # apache-airflow-providers-postgres
+346 | Mapping
+347 | PostgresHook()
     | ^^^^^^^^^^^^ AIR303
-333 | PostgresOperator()
+348 | PostgresOperator()
     |
     = help: Install `apache-airflow-provider-postgres>=1.0.0` and use `airflow.providers.postgres.hooks.postgres.PostgresHook` instead.
 
-AIR303.py:333:1: AIR303 `airflow.operators.postgres_operator.PostgresOperator` is moved into `postgres` provider in Airflow 3.0;
+AIR303.py:348:1: AIR303 `airflow.operators.postgres_operator.PostgresOperator` is moved into `postgres` provider in Airflow 3.0;
     |
-331 | Mapping
-332 | PostgresHook()
-333 | PostgresOperator()
+346 | Mapping
+347 | PostgresHook()
+348 | PostgresOperator()
     | ^^^^^^^^^^^^^^^^ AIR303
-334 |
-335 | # apache-airflow-providers-presto
+349 |
+350 | # apache-airflow-providers-presto
     |
     = help: Install `apache-airflow-provider-postgres>=1.0.0` and use `airflow.providers.postgres.operators.postgres.PostgresOperator` instead.
 
-AIR303.py:336:1: AIR303 `airflow.hooks.presto_hook.PrestoHook` is moved into `presto` provider in Airflow 3.0;
+AIR303.py:351:1: AIR303 `airflow.hooks.presto_hook.PrestoHook` is moved into `presto` provider in Airflow 3.0;
     |
-335 | # apache-airflow-providers-presto
-336 | PrestoHook()
+350 | # apache-airflow-providers-presto
+351 | PrestoHook()
     | ^^^^^^^^^^ AIR303
-337 |
-338 | # apache-airflow-providers-samba
+352 |
+353 | # apache-airflow-providers-samba
     |
     = help: Install `apache-airflow-provider-presto>=1.0.0` and use `airflow.providers.presto.hooks.presto.PrestoHook` instead.
 
-AIR303.py:339:1: AIR303 `airflow.hooks.samba_hook.SambaHook` is moved into `samba` provider in Airflow 3.0;
+AIR303.py:354:1: AIR303 `airflow.hooks.samba_hook.SambaHook` is moved into `samba` provider in Airflow 3.0;
     |
-338 | # apache-airflow-providers-samba
-339 | SambaHook()
+353 | # apache-airflow-providers-samba
+354 | SambaHook()
     | ^^^^^^^^^ AIR303
-340 |
-341 | # apache-airflow-providers-slack
+355 |
+356 | # apache-airflow-providers-slack
     |
     = help: Install `apache-airflow-provider-samba>=1.0.0` and use `airflow.providers.samba.hooks.samba.SambaHook` instead.
 
-AIR303.py:342:1: AIR303 `airflow.hooks.slack_hook.SlackHook` is moved into `slack` provider in Airflow 3.0;
+AIR303.py:357:1: AIR303 `airflow.hooks.slack_hook.SlackHook` is moved into `slack` provider in Airflow 3.0;
     |
-341 | # apache-airflow-providers-slack
-342 | SlackHook()
+356 | # apache-airflow-providers-slack
+357 | SlackHook()
     | ^^^^^^^^^ AIR303
-343 | SlackAPIOperator()
-344 | SlackAPIPostOperator()
+358 | SlackAPIOperator()
+359 | SlackAPIPostOperator()
     |
     = help: Install `apache-airflow-provider-slack>=1.0.0` and use `airflow.providers.slack.hooks.slack.SlackHook` instead.
 
-AIR303.py:343:1: AIR303 `airflow.operators.slack_operator.SlackAPIOperator` is moved into `slack` provider in Airflow 3.0;
+AIR303.py:358:1: AIR303 `airflow.operators.slack_operator.SlackAPIOperator` is moved into `slack` provider in Airflow 3.0;
     |
-341 | # apache-airflow-providers-slack
-342 | SlackHook()
-343 | SlackAPIOperator()
+356 | # apache-airflow-providers-slack
+357 | SlackHook()
+358 | SlackAPIOperator()
     | ^^^^^^^^^^^^^^^^ AIR303
-344 | SlackAPIPostOperator()
+359 | SlackAPIPostOperator()
     |
     = help: Install `apache-airflow-provider-slack>=1.0.0` and use `airflow.providers.slack.operators.slack.SlackAPIOperator` instead.
 
-AIR303.py:344:1: AIR303 `airflow.operators.slack_operator.SlackAPIPostOperator` is moved into `slack` provider in Airflow 3.0;
+AIR303.py:359:1: AIR303 `airflow.operators.slack_operator.SlackAPIPostOperator` is moved into `slack` provider in Airflow 3.0;
     |
-342 | SlackHook()
-343 | SlackAPIOperator()
-344 | SlackAPIPostOperator()
+357 | SlackHook()
+358 | SlackAPIOperator()
+359 | SlackAPIPostOperator()
     | ^^^^^^^^^^^^^^^^^^^^ AIR303
-345 |
-346 | # apache-airflow-providers-sqlite
+360 |
+361 | # apache-airflow-providers-sqlite
     |
     = help: Install `apache-airflow-provider-slack>=1.0.0` and use `airflow.providers.slack.operators.slack.SlackAPIPostOperator` instead.
 
-AIR303.py:347:1: AIR303 `airflow.hooks.sqlite_hook.SqliteHook` is moved into `sqlite` provider in Airflow 3.0;
+AIR303.py:362:1: AIR303 `airflow.hooks.sqlite_hook.SqliteHook` is moved into `sqlite` provider in Airflow 3.0;
     |
-346 | # apache-airflow-providers-sqlite
-347 | SqliteHook()
+361 | # apache-airflow-providers-sqlite
+362 | SqliteHook()
     | ^^^^^^^^^^ AIR303
-348 | SqliteOperator()
+363 | SqliteOperator()
     |
     = help: Install `apache-airflow-provider-sqlite>=1.0.0` and use `airflow.providers.sqlite.hooks.sqlite.SqliteHook` instead.
 
-AIR303.py:348:1: AIR303 `airflow.operators.sqlite_operator.SqliteOperator` is moved into `sqlite` provider in Airflow 3.0;
+AIR303.py:363:1: AIR303 `airflow.operators.sqlite_operator.SqliteOperator` is moved into `sqlite` provider in Airflow 3.0;
     |
-346 | # apache-airflow-providers-sqlite
-347 | SqliteHook()
-348 | SqliteOperator()
+361 | # apache-airflow-providers-sqlite
+362 | SqliteHook()
+363 | SqliteOperator()
     | ^^^^^^^^^^^^^^ AIR303
-349 |
-350 | # apache-airflow-providers-zendesk
+364 |
+365 | # apache-airflow-providers-zendesk
     |
     = help: Install `apache-airflow-provider-sqlite>=1.0.0` and use `airflow.providers.sqlite.operators.sqlite.SqliteOperator` instead.
 
-AIR303.py:351:1: AIR303 `airflow.hooks.zendesk_hook.ZendeskHook` is moved into `zendesk` provider in Airflow 3.0;
+AIR303.py:366:1: AIR303 `airflow.hooks.zendesk_hook.ZendeskHook` is moved into `zendesk` provider in Airflow 3.0;
     |
-350 | # apache-airflow-providers-zendesk
-351 | ZendeskHook()
+365 | # apache-airflow-providers-zendesk
+366 | ZendeskHook()
     | ^^^^^^^^^^^ AIR303
+367 |
+368 | # apache-airflow-providers-standard
     |
     = help: Install `apache-airflow-provider-zendesk>=1.0.0` and use `airflow.providers.zendesk.hooks.zendesk.ZendeskHook` instead.
+
+AIR303.py:369:1: AIR303 `airflow.sensors.filesystem.FileSensor` is moved into `standard` provider in Airflow 3.0;
+    |
+368 | # apache-airflow-providers-standard
+369 | FileSensor()
+    | ^^^^^^^^^^ AIR303
+370 | TriggerDagRunOperator()
+371 | ExternalTaskMarker(), ExternalTaskSensor()
+    |
+    = help: Install `apache-airflow-provider-standard>=0.0.2` and use `airflow.providers.standard.sensors.filesystem.FileSensor` instead.
+
+AIR303.py:370:1: AIR303 `airflow.operators.trigger_dagrun.TriggerDagRunOperator` is moved into `standard` provider in Airflow 3.0;
+    |
+368 | # apache-airflow-providers-standard
+369 | FileSensor()
+370 | TriggerDagRunOperator()
+    | ^^^^^^^^^^^^^^^^^^^^^ AIR303
+371 | ExternalTaskMarker(), ExternalTaskSensor()
+372 | BranchDateTimeOperator()
+    |
+    = help: Install `apache-airflow-provider-standard>=0.0.2` and use `airflow.providers.standard.operators.trigger_dagrun.TriggerDagRunOperator` instead.
+
+AIR303.py:371:1: AIR303 `airflow.sensors.external_task.ExternalTaskMarker` is moved into `standard` provider in Airflow 3.0;
+    |
+369 | FileSensor()
+370 | TriggerDagRunOperator()
+371 | ExternalTaskMarker(), ExternalTaskSensor()
+    | ^^^^^^^^^^^^^^^^^^ AIR303
+372 | BranchDateTimeOperator()
+373 | BranchDayOfWeekOperator()
+    |
+    = help: Install `apache-airflow-provider-standard>=0.0.3` and use `airflow.providers.standard.sensors.external_task.ExternalTaskMarker` instead.
+
+AIR303.py:371:23: AIR303 `airflow.sensors.external_task.ExternalTaskSensor` is moved into `standard` provider in Airflow 3.0;
+    |
+369 | FileSensor()
+370 | TriggerDagRunOperator()
+371 | ExternalTaskMarker(), ExternalTaskSensor()
+    |                       ^^^^^^^^^^^^^^^^^^ AIR303
+372 | BranchDateTimeOperator()
+373 | BranchDayOfWeekOperator()
+    |
+    = help: Install `apache-airflow-provider-standard>=0.0.3` and use `airflow.providers.standard.sensors.external_task.ExternalTaskSensor` instead.


### PR DESCRIPTION


<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Extend AIR303 with the following rules

* `airflow.operators.datetime.*` → `airflow.providers.standard.time.operators.datetime.*`
* `airflow.operators.weekday.*` → `airflow.providers.standard.time.operators.weekday.*`
* `airflow.sensors.date_time.*` → `airflow.providers.standard.time.sensors.date_time.*`
* `airflow.sensors.time_sensor.*` → `airflow.providers.standard.time.sensors.time.*`
* `airflow.sensors.time_delta.*` → `airflow.providers.standard.time.sensors.time_delta.*`
* `airflow.sensors.weekday.*` → `airflow.providers.standard.time.sensors.weekday.*`
* `airflow.hooks.filesystem.*` → `airflow.providers.standard.hooks.filesystem.*`
* `airflow.hooks.package_index.*` → `airflow.providers.standard.hooks.package_index.*`
* `airflow.hooks.subprocess.*` → `airflow.providers.standard.hooks.subprocess.*`
* `airflow.triggers.external_task.*` → `airflow.providers.standard.triggers.external_task.*`
* `airflow.triggers.file.*` → `airflow.providers.standard.triggers.file.*`
* `airflow.triggers.temporal.*` → `airflow.providers.standard.triggers.temporal.*`
* `airflow.sensors.filesystem.FileSensor` → `airflow.providers.standard.sensors.filesystem.FileSensor`
* `airflow.operators.trigger_dagrun.TriggerDagRunOperator` → `airflow.providers.standard.operators.trigger_dagrun.TriggerDagRunOperator`
* `airflow.sensors.external_task.ExternalTaskMarker` → `airflow.providers.standard.sensors.external_task.ExternalTaskMarker`
* `airflow.sensors.external_task.ExternalTaskSensor` → `airflow.providers.standard.sensors.external_task.ExternalTaskSensor`

## Test Plan

<!-- How was it tested? -->
a test fixture has been updated