### PR TITLE
[red-knot] Invalid assignments to attributes

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/attributes.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/attributes.md
@@ -102,7 +102,7 @@ reveal_type(C.pure_instance_variable)  # revealed: str
 # and pyright allow this.
 C.pure_instance_variable = "overwritten on class"
 
-# TODO: this should be an error (incompatible types in assignment)
+# error: [invalid-assignment] "Object of type `Literal[1]` is not assignable to `str`"
 c_instance.pure_instance_variable = 1
 ```
 
@@ -191,7 +191,7 @@ c_instance.pure_class_variable1 = "value set on instance"
 
 C.pure_class_variable1 = "overwritten on class"
 
-# TODO: should raise an error (incompatible types in assignment)
+# error: [invalid-assignment] "Object of type `Literal[1]` is not assignable to `str`"
 C.pure_class_variable1 = 1
 
 class Subclass(C):
@@ -434,6 +434,22 @@ reveal_type(f.__class__)  # revealed: Literal[FunctionType]
 class Foo: ...
 
 reveal_type(Foo.__class__)  # revealed: Literal[type]
+```
+
+## Module attributes
+
+```py path=mod.py
+global_symbol: int = 1
+```
+
+```py
+import mod
+
+reveal_type(mod.global_symbol)  # revealed: int
+mod.global_symbol = 2
+
+# error: [invalid-assignment] "Object of type `Literal["1"]` is not assignable to `int`"
+mod.global_symbol = "1"
 ```
 
 ## Literal types

--- a/crates/red_knot_python_semantic/resources/mdtest/attributes.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/attributes.md
@@ -454,7 +454,7 @@ mod.global_symbol = 1
 # error: [invalid-assignment] "Object of type `Literal[1]` is not assignable to `str`"
 (_, mod.global_symbol) = (..., 1)
 
-# TODO: this should be an error, but we do not understand lists yet.
+# TODO: this should be an error, but we do not understand list unpackings yet.
 [_, mod.global_symbol] = [1, 2]
 
 class IntIterator:

--- a/crates/red_knot_python_semantic/resources/mdtest/attributes.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/attributes.md
@@ -439,17 +439,35 @@ reveal_type(Foo.__class__)  # revealed: Literal[type]
 ## Module attributes
 
 ```py path=mod.py
-global_symbol: int = 1
+global_symbol: str = "a"
 ```
 
 ```py
 import mod
 
-reveal_type(mod.global_symbol)  # revealed: int
-mod.global_symbol = 2
+reveal_type(mod.global_symbol)  # revealed: str
+mod.global_symbol = "b"
 
-# error: [invalid-assignment] "Object of type `Literal["1"]` is not assignable to `int`"
-mod.global_symbol = "1"
+# error: [invalid-assignment] "Object of type `Literal[1]` is not assignable to `str`"
+mod.global_symbol = 1
+
+# error: [invalid-assignment] "Object of type `Literal[1]` is not assignable to `str`"
+(_, mod.global_symbol) = (..., 1)
+
+# TODO: this should be an error, but we do not understand lists yet.
+[_, mod.global_symbol] = [1, 2]
+
+class IntIterator:
+    def __next__(self) -> int:
+        return 42
+
+class IntIterable:
+    def __iter__(self) -> IntIterator:
+        return IntIterator()
+
+# error: [invalid-assignment] "Object of type `int` is not assignable to `str`"
+for mod.global_symbol in IntIterable():
+    pass
 ```
 
 ## Literal types

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -3321,6 +3321,14 @@ impl<'db> IterationOutcome<'db> {
             }
         }
     }
+
+    fn unwrap_without_diagnostic(self) -> Type<'db> {
+        match self {
+            Self::Iterable { element_ty } => element_ty,
+            Self::NotIterable { .. } => Type::unknown(),
+            Self::PossiblyUnboundDunderIter { element_ty, .. } => element_ty,
+        }
+    }
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -1970,28 +1970,51 @@ impl<'db> TypeInferenceBuilder<'db> {
         } = assignment;
 
         for target in targets {
-            self.infer_target(target, value);
+            self.infer_target(target, value, |_, ty| ty);
         }
     }
 
-    /// Infer the definition types involved in a `target` expression.
+    /// Infer the (definition) types involved in a `target` expression.
     ///
     /// This is used for assignment statements, for statements, etc. with a single or multiple
-    /// targets (unpacking).
+    /// targets (unpacking). If `target` is an attribute expression, we check that the assignment
+    /// is valid. For 'target's that are definitions, this check happens elsewhere.
+    ///
+    /// The `to_assigned_ty` function is used to convert the inferred type of the `value` expression
+    /// to the type that is eventually assigned to the `target`.
     ///
     /// # Panics
     ///
     /// If the `value` is not a standalone expression.
-    fn infer_target(&mut self, target: &ast::Expr, value: &ast::Expr) {
+    fn infer_target<F>(&mut self, target: &ast::Expr, value: &ast::Expr, to_assigned_ty: F)
+    where
+        F: Fn(&'db dyn Db, Type<'db>) -> Type<'db>,
+    {
+        let assigned_ty = match target {
+            ast::Expr::Name(_) => None,
+            _ => {
+                let value_ty = self.infer_standalone_expression(value);
+
+                Some(to_assigned_ty(self.db(), value_ty))
+            }
+        };
+        self.infer_target_impl(target, assigned_ty);
+    }
+
+    fn infer_target_impl(&mut self, target: &ast::Expr, assigned_ty: Option<Type<'db>>) {
         match target {
             ast::Expr::Name(name) => self.infer_definition(name),
             ast::Expr::List(ast::ExprList { elts, .. })
             | ast::Expr::Tuple(ast::ExprTuple { elts, .. }) => {
+                let mut assigned_tys = match assigned_ty {
+                    Some(Type::Tuple(tuple)) => {
+                        Either::Left(tuple.elements(self.db()).into_iter().copied())
+                    }
+                    Some(_) | None => Either::Right(std::iter::empty()),
+                };
+
                 for element in elts {
-                    self.infer_target(element, value);
-                }
-                if elts.is_empty() {
-                    self.infer_standalone_expression(value);
+                    self.infer_target_impl(element, assigned_tys.next());
                 }
             }
             ast::Expr::Attribute(
@@ -2000,18 +2023,22 @@ impl<'db> TypeInferenceBuilder<'db> {
                     ..
                 },
             ) => {
-                let lhs_ty = self.infer_attribute_expression(lhs_expr);
-                self.store_expression_type(target, lhs_ty);
+                let attribute_expr_ty = self.infer_attribute_expression(lhs_expr);
+                self.store_expression_type(target, attribute_expr_ty);
 
-                let rhs_ty = self.infer_standalone_expression(value);
-
-                if !rhs_ty.is_assignable_to(self.db(), lhs_ty) {
-                    report_invalid_assignment(&self.context, target.into(), lhs_ty, rhs_ty);
+                if let Some(assigned_ty) = assigned_ty {
+                    if !assigned_ty.is_assignable_to(self.db(), attribute_expr_ty) {
+                        report_invalid_assignment(
+                            &self.context,
+                            target.into(),
+                            attribute_expr_ty,
+                            assigned_ty,
+                        );
+                    }
                 }
             }
             _ => {
                 // TODO: Remove this once we handle all possible assignment targets.
-                self.infer_standalone_expression(value);
                 self.infer_expression(target);
             }
         }
@@ -2280,7 +2307,10 @@ impl<'db> TypeInferenceBuilder<'db> {
             is_async: _,
         } = for_statement;
 
-        self.infer_target(target, iter);
+        self.infer_target(target, iter, |db, iter_ty| {
+            iter_ty.iterate(db).unwrap_without_diagnostic()
+        });
+
         self.infer_body(body);
         self.infer_body(orelse);
     }


### PR DESCRIPTION
## Summary

Raise "invalid-assignment" diagnostics for incorrect assignments to attributes, for example:

```py
class C:
    var: str = "a"

C.var = 1  # error: "Object of type `Literal[1]` is not assignable to `str`"
```

closes #15456 

## Test Plan

- Updated test assertions
- New test for assignments to module-attributes