### PR TITLE
[red-knot] Rename *_ty functions

### DIFF
--- a/crates/red_knot_project/tests/check.rs
+++ b/crates/red_knot_project/tests/check.rs
@@ -1,6 +1,6 @@
 use anyhow::{anyhow, Context};
 use red_knot_project::{ProjectDatabase, ProjectMetadata};
-use red_knot_python_semantic::{HasTy, SemanticModel};
+use red_knot_python_semantic::{HasType, SemanticModel};
 use ruff_db::files::{system_path_to_file, File};
 use ruff_db::parsed::parsed_module;
 use ruff_db::system::{SystemPath, SystemPathBuf, TestSystem};
@@ -197,10 +197,10 @@ impl SourceOrderVisitor<'_> for PullTypesVisitor<'_> {
     fn visit_stmt(&mut self, stmt: &Stmt) {
         match stmt {
             Stmt::FunctionDef(function) => {
-                let _ty = function.ty(&self.model);
+                let _ty = function.inferred_type(&self.model);
             }
             Stmt::ClassDef(class) => {
-                let _ty = class.ty(&self.model);
+                let _ty = class.inferred_type(&self.model);
             }
             Stmt::Assign(assign) => {
                 for target in &assign.targets {
@@ -243,25 +243,25 @@ impl SourceOrderVisitor<'_> for PullTypesVisitor<'_> {
     }
 
     fn visit_expr(&mut self, expr: &Expr) {
-        let _ty = expr.ty(&self.model);
+        let _ty = expr.inferred_type(&self.model);
 
         source_order::walk_expr(self, expr);
     }
 
     fn visit_parameter(&mut self, parameter: &Parameter) {
-        let _ty = parameter.ty(&self.model);
+        let _ty = parameter.inferred_type(&self.model);
 
         source_order::walk_parameter(self, parameter);
     }
 
     fn visit_parameter_with_default(&mut self, parameter_with_default: &ParameterWithDefault) {
-        let _ty = parameter_with_default.ty(&self.model);
+        let _ty = parameter_with_default.inferred_type(&self.model);
 
         source_order::walk_parameter_with_default(self, parameter_with_default);
     }
 
     fn visit_alias(&mut self, alias: &Alias) {
-        let _ty = alias.ty(&self.model);
+        let _ty = alias.inferred_type(&self.model);
 
         source_order::walk_alias(self, alias);
     }

--- a/crates/red_knot_python_semantic/src/lib.rs
+++ b/crates/red_knot_python_semantic/src/lib.rs
@@ -10,7 +10,7 @@ pub use module_resolver::{resolve_module, system_module_search_paths, KnownModul
 pub use program::{Program, ProgramSettings, SearchPathSettings, SitePackages};
 pub use python_platform::PythonPlatform;
 pub use python_version::PythonVersion;
-pub use semantic_model::{HasTy, SemanticModel};
+pub use semantic_model::{HasType, SemanticModel};
 
 pub mod ast_node_ref;
 mod db;

--- a/crates/red_knot_python_semantic/src/semantic_index/builder.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/builder.rs
@@ -603,8 +603,8 @@ impl<'db> SemanticIndexBuilder<'db> {
 
         let definition = self.add_definition(symbol, parameter);
 
-        // Insert a mapping from the inner Parameter node to the same definition.
-        // This ensures that calling `HasTy::ty` on the inner parameter returns
+        // Insert a mapping from the inner Parameter node to the same definition. This
+        // ensures that calling `HasType::inferred_type` on the inner parameter returns
         // a valid type (and doesn't panic)
         let existing_definition = self
             .definitions_by_node

--- a/crates/red_knot_python_semantic/src/semantic_model.rs
+++ b/crates/red_knot_python_semantic/src/semantic_model.rs
@@ -8,7 +8,7 @@ use crate::module_name::ModuleName;
 use crate::module_resolver::{resolve_module, Module};
 use crate::semantic_index::ast_ids::HasScopedExpressionId;
 use crate::semantic_index::semantic_index;
-use crate::types::{binding_ty, infer_scope_types, Type};
+use crate::types::{binding_type, infer_scope_types, Type};
 use crate::Db;
 
 pub struct SemanticModel<'db> {
@@ -40,117 +40,117 @@ impl<'db> SemanticModel<'db> {
     }
 }
 
-pub trait HasTy {
+pub trait HasType {
     /// Returns the inferred type of `self`.
     ///
     /// ## Panics
     /// May panic if `self` is from another file than `model`.
-    fn ty<'db>(&self, model: &SemanticModel<'db>) -> Type<'db>;
+    fn inferred_type<'db>(&self, model: &SemanticModel<'db>) -> Type<'db>;
 }
 
-impl HasTy for ast::ExprRef<'_> {
-    fn ty<'db>(&self, model: &SemanticModel<'db>) -> Type<'db> {
+impl HasType for ast::ExprRef<'_> {
+    fn inferred_type<'db>(&self, model: &SemanticModel<'db>) -> Type<'db> {
         let index = semantic_index(model.db, model.file);
         let file_scope = index.expression_scope_id(*self);
         let scope = file_scope.to_scope_id(model.db, model.file);
 
         let expression_id = self.scoped_expression_id(model.db, scope);
-        infer_scope_types(model.db, scope).expression_ty(expression_id)
+        infer_scope_types(model.db, scope).expression_type(expression_id)
     }
 }
 
-macro_rules! impl_expression_has_ty {
+macro_rules! impl_expression_has_type {
     ($ty: ty) => {
-        impl HasTy for $ty {
+        impl HasType for $ty {
             #[inline]
-            fn ty<'db>(&self, model: &SemanticModel<'db>) -> Type<'db> {
+            fn inferred_type<'db>(&self, model: &SemanticModel<'db>) -> Type<'db> {
                 let expression_ref = ExprRef::from(self);
-                expression_ref.ty(model)
+                expression_ref.inferred_type(model)
             }
         }
     };
 }
 
-impl_expression_has_ty!(ast::ExprBoolOp);
-impl_expression_has_ty!(ast::ExprNamed);
-impl_expression_has_ty!(ast::ExprBinOp);
-impl_expression_has_ty!(ast::ExprUnaryOp);
-impl_expression_has_ty!(ast::ExprLambda);
-impl_expression_has_ty!(ast::ExprIf);
-impl_expression_has_ty!(ast::ExprDict);
-impl_expression_has_ty!(ast::ExprSet);
-impl_expression_has_ty!(ast::ExprListComp);
-impl_expression_has_ty!(ast::ExprSetComp);
-impl_expression_has_ty!(ast::ExprDictComp);
-impl_expression_has_ty!(ast::ExprGenerator);
-impl_expression_has_ty!(ast::ExprAwait);
-impl_expression_has_ty!(ast::ExprYield);
-impl_expression_has_ty!(ast::ExprYieldFrom);
-impl_expression_has_ty!(ast::ExprCompare);
-impl_expression_has_ty!(ast::ExprCall);
-impl_expression_has_ty!(ast::ExprFString);
-impl_expression_has_ty!(ast::ExprStringLiteral);
-impl_expression_has_ty!(ast::ExprBytesLiteral);
-impl_expression_has_ty!(ast::ExprNumberLiteral);
-impl_expression_has_ty!(ast::ExprBooleanLiteral);
-impl_expression_has_ty!(ast::ExprNoneLiteral);
-impl_expression_has_ty!(ast::ExprEllipsisLiteral);
-impl_expression_has_ty!(ast::ExprAttribute);
-impl_expression_has_ty!(ast::ExprSubscript);
-impl_expression_has_ty!(ast::ExprStarred);
-impl_expression_has_ty!(ast::ExprName);
-impl_expression_has_ty!(ast::ExprList);
-impl_expression_has_ty!(ast::ExprTuple);
-impl_expression_has_ty!(ast::ExprSlice);
-impl_expression_has_ty!(ast::ExprIpyEscapeCommand);
+impl_expression_has_type!(ast::ExprBoolOp);
+impl_expression_has_type!(ast::ExprNamed);
+impl_expression_has_type!(ast::ExprBinOp);
+impl_expression_has_type!(ast::ExprUnaryOp);
+impl_expression_has_type!(ast::ExprLambda);
+impl_expression_has_type!(ast::ExprIf);
+impl_expression_has_type!(ast::ExprDict);
+impl_expression_has_type!(ast::ExprSet);
+impl_expression_has_type!(ast::ExprListComp);
+impl_expression_has_type!(ast::ExprSetComp);
+impl_expression_has_type!(ast::ExprDictComp);
+impl_expression_has_type!(ast::ExprGenerator);
+impl_expression_has_type!(ast::ExprAwait);
+impl_expression_has_type!(ast::ExprYield);
+impl_expression_has_type!(ast::ExprYieldFrom);
+impl_expression_has_type!(ast::ExprCompare);
+impl_expression_has_type!(ast::ExprCall);
+impl_expression_has_type!(ast::ExprFString);
+impl_expression_has_type!(ast::ExprStringLiteral);
+impl_expression_has_type!(ast::ExprBytesLiteral);
+impl_expression_has_type!(ast::ExprNumberLiteral);
+impl_expression_has_type!(ast::ExprBooleanLiteral);
+impl_expression_has_type!(ast::ExprNoneLiteral);
+impl_expression_has_type!(ast::ExprEllipsisLiteral);
+impl_expression_has_type!(ast::ExprAttribute);
+impl_expression_has_type!(ast::ExprSubscript);
+impl_expression_has_type!(ast::ExprStarred);
+impl_expression_has_type!(ast::ExprName);
+impl_expression_has_type!(ast::ExprList);
+impl_expression_has_type!(ast::ExprTuple);
+impl_expression_has_type!(ast::ExprSlice);
+impl_expression_has_type!(ast::ExprIpyEscapeCommand);
 
-impl HasTy for ast::Expr {
-    fn ty<'db>(&self, model: &SemanticModel<'db>) -> Type<'db> {
+impl HasType for ast::Expr {
+    fn inferred_type<'db>(&self, model: &SemanticModel<'db>) -> Type<'db> {
         match self {
-            Expr::BoolOp(inner) => inner.ty(model),
-            Expr::Named(inner) => inner.ty(model),
-            Expr::BinOp(inner) => inner.ty(model),
-            Expr::UnaryOp(inner) => inner.ty(model),
-            Expr::Lambda(inner) => inner.ty(model),
-            Expr::If(inner) => inner.ty(model),
-            Expr::Dict(inner) => inner.ty(model),
-            Expr::Set(inner) => inner.ty(model),
-            Expr::ListComp(inner) => inner.ty(model),
-            Expr::SetComp(inner) => inner.ty(model),
-            Expr::DictComp(inner) => inner.ty(model),
-            Expr::Generator(inner) => inner.ty(model),
-            Expr::Await(inner) => inner.ty(model),
-            Expr::Yield(inner) => inner.ty(model),
-            Expr::YieldFrom(inner) => inner.ty(model),
-            Expr::Compare(inner) => inner.ty(model),
-            Expr::Call(inner) => inner.ty(model),
-            Expr::FString(inner) => inner.ty(model),
-            Expr::StringLiteral(inner) => inner.ty(model),
-            Expr::BytesLiteral(inner) => inner.ty(model),
-            Expr::NumberLiteral(inner) => inner.ty(model),
-            Expr::BooleanLiteral(inner) => inner.ty(model),
-            Expr::NoneLiteral(inner) => inner.ty(model),
-            Expr::EllipsisLiteral(inner) => inner.ty(model),
-            Expr::Attribute(inner) => inner.ty(model),
-            Expr::Subscript(inner) => inner.ty(model),
-            Expr::Starred(inner) => inner.ty(model),
-            Expr::Name(inner) => inner.ty(model),
-            Expr::List(inner) => inner.ty(model),
-            Expr::Tuple(inner) => inner.ty(model),
-            Expr::Slice(inner) => inner.ty(model),
-            Expr::IpyEscapeCommand(inner) => inner.ty(model),
+            Expr::BoolOp(inner) => inner.inferred_type(model),
+            Expr::Named(inner) => inner.inferred_type(model),
+            Expr::BinOp(inner) => inner.inferred_type(model),
+            Expr::UnaryOp(inner) => inner.inferred_type(model),
+            Expr::Lambda(inner) => inner.inferred_type(model),
+            Expr::If(inner) => inner.inferred_type(model),
+            Expr::Dict(inner) => inner.inferred_type(model),
+            Expr::Set(inner) => inner.inferred_type(model),
+            Expr::ListComp(inner) => inner.inferred_type(model),
+            Expr::SetComp(inner) => inner.inferred_type(model),
+            Expr::DictComp(inner) => inner.inferred_type(model),
+            Expr::Generator(inner) => inner.inferred_type(model),
+            Expr::Await(inner) => inner.inferred_type(model),
+            Expr::Yield(inner) => inner.inferred_type(model),
+            Expr::YieldFrom(inner) => inner.inferred_type(model),
+            Expr::Compare(inner) => inner.inferred_type(model),
+            Expr::Call(inner) => inner.inferred_type(model),
+            Expr::FString(inner) => inner.inferred_type(model),
+            Expr::StringLiteral(inner) => inner.inferred_type(model),
+            Expr::BytesLiteral(inner) => inner.inferred_type(model),
+            Expr::NumberLiteral(inner) => inner.inferred_type(model),
+            Expr::BooleanLiteral(inner) => inner.inferred_type(model),
+            Expr::NoneLiteral(inner) => inner.inferred_type(model),
+            Expr::EllipsisLiteral(inner) => inner.inferred_type(model),
+            Expr::Attribute(inner) => inner.inferred_type(model),
+            Expr::Subscript(inner) => inner.inferred_type(model),
+            Expr::Starred(inner) => inner.inferred_type(model),
+            Expr::Name(inner) => inner.inferred_type(model),
+            Expr::List(inner) => inner.inferred_type(model),
+            Expr::Tuple(inner) => inner.inferred_type(model),
+            Expr::Slice(inner) => inner.inferred_type(model),
+            Expr::IpyEscapeCommand(inner) => inner.inferred_type(model),
         }
     }
 }
 
 macro_rules! impl_binding_has_ty {
     ($ty: ty) => {
-        impl HasTy for $ty {
+        impl HasType for $ty {
             #[inline]
-            fn ty<'db>(&self, model: &SemanticModel<'db>) -> Type<'db> {
+            fn inferred_type<'db>(&self, model: &SemanticModel<'db>) -> Type<'db> {
                 let index = semantic_index(model.db, model.file);
                 let binding = index.definition(self);
-                binding_ty(model.db, binding)
+                binding_type(model.db, binding)
             }
         }
     };
@@ -168,10 +168,10 @@ mod tests {
     use ruff_db::parsed::parsed_module;
 
     use crate::db::tests::TestDbBuilder;
-    use crate::{HasTy, SemanticModel};
+    use crate::{HasType, SemanticModel};
 
     #[test]
-    fn function_ty() -> anyhow::Result<()> {
+    fn function_type() -> anyhow::Result<()> {
         let db = TestDbBuilder::new()
             .with_file("/src/foo.py", "def test(): pass")
             .build()?;
@@ -182,7 +182,7 @@ mod tests {
 
         let function = ast.suite()[0].as_function_def_stmt().unwrap();
         let model = SemanticModel::new(&db, foo);
-        let ty = function.ty(&model);
+        let ty = function.inferred_type(&model);
 
         assert!(ty.is_function_literal());
 
@@ -190,7 +190,7 @@ mod tests {
     }
 
     #[test]
-    fn class_ty() -> anyhow::Result<()> {
+    fn class_type() -> anyhow::Result<()> {
         let db = TestDbBuilder::new()
             .with_file("/src/foo.py", "class Test: pass")
             .build()?;
@@ -201,7 +201,7 @@ mod tests {
 
         let class = ast.suite()[0].as_class_def_stmt().unwrap();
         let model = SemanticModel::new(&db, foo);
-        let ty = class.ty(&model);
+        let ty = class.inferred_type(&model);
 
         assert!(ty.is_class_literal());
 
@@ -209,7 +209,7 @@ mod tests {
     }
 
     #[test]
-    fn alias_ty() -> anyhow::Result<()> {
+    fn alias_type() -> anyhow::Result<()> {
         let db = TestDbBuilder::new()
             .with_file("/src/foo.py", "class Test: pass")
             .with_file("/src/bar.py", "from foo import Test")
@@ -222,7 +222,7 @@ mod tests {
         let import = ast.suite()[0].as_import_from_stmt().unwrap();
         let alias = &import.names[0];
         let model = SemanticModel::new(&db, bar);
-        let ty = alias.ty(&model);
+        let ty = alias.inferred_type(&model);
 
         assert!(ty.is_class_literal());
 

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -129,7 +129,7 @@ fn symbol<'db>(db: &'db dyn Db, scope: ScopeId<'db>, name: &str) -> Symbol<'db> 
             Err((declared_ty, _)) => {
                 // Intentionally ignore conflicting declared types; that's not our problem,
                 // it's the problem of the module we are importing from.
-                declared_ty.inner_ty().into()
+                declared_ty.inner_type().into()
             }
         }
 
@@ -243,15 +243,15 @@ pub(crate) fn global_symbol<'db>(db: &'db dyn Db, file: File, name: &str) -> Sym
 }
 
 /// Infer the type of a binding.
-pub(crate) fn binding_ty<'db>(db: &'db dyn Db, definition: Definition<'db>) -> Type<'db> {
+pub(crate) fn binding_type<'db>(db: &'db dyn Db, definition: Definition<'db>) -> Type<'db> {
     let inference = infer_definition_types(db, definition);
-    inference.binding_ty(definition)
+    inference.binding_type(definition)
 }
 
 /// Infer the type of a declaration.
-fn declaration_ty<'db>(db: &'db dyn Db, definition: Definition<'db>) -> TypeAndQualifiers<'db> {
+fn declaration_type<'db>(db: &'db dyn Db, definition: Definition<'db>) -> TypeAndQualifiers<'db> {
     let inference = infer_definition_types(db, definition);
-    inference.declaration_ty(definition)
+    inference.declaration_type(definition)
 }
 
 /// Infer the type of a (possibly deferred) sub-expression of a [`Definition`].
@@ -260,7 +260,7 @@ fn declaration_ty<'db>(db: &'db dyn Db, definition: Definition<'db>) -> TypeAndQ
 ///
 /// ## Panics
 /// If the given expression is not a sub-expression of the given [`Definition`].
-fn definition_expression_ty<'db>(
+fn definition_expression_type<'db>(
     db: &'db dyn Db,
     definition: Definition<'db>,
     expression: &ast::Expr,
@@ -273,14 +273,14 @@ fn definition_expression_ty<'db>(
     if scope == definition.scope(db) {
         // expression is in the definition scope
         let inference = infer_definition_types(db, definition);
-        if let Some(ty) = inference.try_expression_ty(expr_id) {
+        if let Some(ty) = inference.try_expression_type(expr_id) {
             ty
         } else {
-            infer_deferred_types(db, definition).expression_ty(expr_id)
+            infer_deferred_types(db, definition).expression_type(expr_id)
         }
     } else {
         // expression is in a type-params sub-scope
-        infer_scope_types(db, scope).expression_ty(expr_id)
+        infer_scope_types(db, scope).expression_type(expr_id)
     }
 }
 
@@ -323,7 +323,7 @@ fn symbol_from_bindings<'db>(
                 .filter_map(|constraint| narrowing_constraint(db, constraint, binding))
                 .peekable();
 
-            let binding_ty = binding_ty(db, binding);
+            let binding_ty = binding_type(db, binding);
             if constraint_tys.peek().is_some() {
                 let intersection_ty = constraint_tys
                     .fold(
@@ -432,7 +432,7 @@ fn symbol_from_declarations<'db>(
             if static_visibility.is_always_false() {
                 None
             } else {
-                Some(declaration_ty(db, declaration))
+                Some(declaration_type(db, declaration))
             }
         },
     );
@@ -440,12 +440,12 @@ fn symbol_from_declarations<'db>(
     if let Some(first) = types.next() {
         let mut conflicting: Vec<Type<'db>> = vec![];
         let declared_ty = if let Some(second) = types.next() {
-            let ty_first = first.inner_ty();
+            let ty_first = first.inner_type();
             let mut qualifiers = first.qualifiers();
 
             let mut builder = UnionBuilder::new(db).add(ty_first);
             for other in std::iter::once(second).chain(types) {
-                let other_ty = other.inner_ty();
+                let other_ty = other.inner_type();
                 if !ty_first.is_equivalent_to(db, other_ty) {
                     conflicting.push(other_ty);
                 }
@@ -466,13 +466,13 @@ fn symbol_from_declarations<'db>(
             };
 
             Ok(SymbolAndQualifiers(
-                Symbol::Type(declared_ty.inner_ty(), boundness),
+                Symbol::Type(declared_ty.inner_type(), boundness),
                 declared_ty.qualifiers(),
             ))
         } else {
             Err((
                 declared_ty,
-                std::iter::once(first.inner_ty())
+                std::iter::once(first.inner_type())
                     .chain(conflicting)
                     .collect(),
             ))
@@ -1787,7 +1787,7 @@ impl<'db> Type<'db> {
 
                     if let Some(Type::BooleanLiteral(bool_val)) = bool_method
                         .call(db, &CallArguments::positional([*instance_ty]))
-                        .return_ty(db)
+                        .return_type(db)
                     {
                         bool_val.into()
                     } else {
@@ -1864,7 +1864,7 @@ impl<'db> Type<'db> {
             CallDunderResult::MethodNotAvailable => return None,
 
             CallDunderResult::CallOutcome(outcome) | CallDunderResult::PossiblyUnbound(outcome) => {
-                outcome.return_ty(db)?
+                outcome.return_type(db)?
             }
         };
 
@@ -1879,11 +1879,11 @@ impl<'db> Type<'db> {
                 let mut binding = bind_call(db, arguments, function_type.signature(db), Some(self));
                 match function_type.known(db) {
                     Some(KnownFunction::RevealType) => {
-                        let revealed_ty = binding.one_parameter_ty().unwrap_or(Type::unknown());
+                        let revealed_ty = binding.one_parameter_type().unwrap_or(Type::unknown());
                         CallOutcome::revealed(binding, revealed_ty)
                     }
                     Some(KnownFunction::StaticAssert) => {
-                        if let Some((parameter_ty, message)) = binding.two_parameter_tys() {
+                        if let Some((parameter_ty, message)) = binding.two_parameter_types() {
                             let truthiness = parameter_ty.bool(db);
 
                             if truthiness.is_always_true() {
@@ -1914,64 +1914,64 @@ impl<'db> Type<'db> {
                     }
                     Some(KnownFunction::IsEquivalentTo) => {
                         let (ty_a, ty_b) = binding
-                            .two_parameter_tys()
+                            .two_parameter_types()
                             .unwrap_or((Type::unknown(), Type::unknown()));
                         binding
-                            .set_return_ty(Type::BooleanLiteral(ty_a.is_equivalent_to(db, ty_b)));
+                            .set_return_type(Type::BooleanLiteral(ty_a.is_equivalent_to(db, ty_b)));
                         CallOutcome::callable(binding)
                     }
                     Some(KnownFunction::IsSubtypeOf) => {
                         let (ty_a, ty_b) = binding
-                            .two_parameter_tys()
+                            .two_parameter_types()
                             .unwrap_or((Type::unknown(), Type::unknown()));
-                        binding.set_return_ty(Type::BooleanLiteral(ty_a.is_subtype_of(db, ty_b)));
+                        binding.set_return_type(Type::BooleanLiteral(ty_a.is_subtype_of(db, ty_b)));
                         CallOutcome::callable(binding)
                     }
                     Some(KnownFunction::IsAssignableTo) => {
                         let (ty_a, ty_b) = binding
-                            .two_parameter_tys()
+                            .two_parameter_types()
                             .unwrap_or((Type::unknown(), Type::unknown()));
                         binding
-                            .set_return_ty(Type::BooleanLiteral(ty_a.is_assignable_to(db, ty_b)));
+                            .set_return_type(Type::BooleanLiteral(ty_a.is_assignable_to(db, ty_b)));
                         CallOutcome::callable(binding)
                     }
                     Some(KnownFunction::IsDisjointFrom) => {
                         let (ty_a, ty_b) = binding
-                            .two_parameter_tys()
+                            .two_parameter_types()
                             .unwrap_or((Type::unknown(), Type::unknown()));
                         binding
-                            .set_return_ty(Type::BooleanLiteral(ty_a.is_disjoint_from(db, ty_b)));
+                            .set_return_type(Type::BooleanLiteral(ty_a.is_disjoint_from(db, ty_b)));
                         CallOutcome::callable(binding)
                     }
                     Some(KnownFunction::IsGradualEquivalentTo) => {
                         let (ty_a, ty_b) = binding
-                            .two_parameter_tys()
+                            .two_parameter_types()
                             .unwrap_or((Type::unknown(), Type::unknown()));
-                        binding.set_return_ty(Type::BooleanLiteral(
+                        binding.set_return_type(Type::BooleanLiteral(
                             ty_a.is_gradual_equivalent_to(db, ty_b),
                         ));
                         CallOutcome::callable(binding)
                     }
                     Some(KnownFunction::IsFullyStatic) => {
-                        let ty = binding.one_parameter_ty().unwrap_or(Type::unknown());
-                        binding.set_return_ty(Type::BooleanLiteral(ty.is_fully_static(db)));
+                        let ty = binding.one_parameter_type().unwrap_or(Type::unknown());
+                        binding.set_return_type(Type::BooleanLiteral(ty.is_fully_static(db)));
                         CallOutcome::callable(binding)
                     }
                     Some(KnownFunction::IsSingleton) => {
-                        let ty = binding.one_parameter_ty().unwrap_or(Type::unknown());
-                        binding.set_return_ty(Type::BooleanLiteral(ty.is_singleton(db)));
+                        let ty = binding.one_parameter_type().unwrap_or(Type::unknown());
+                        binding.set_return_type(Type::BooleanLiteral(ty.is_singleton(db)));
                         CallOutcome::callable(binding)
                     }
                     Some(KnownFunction::IsSingleValued) => {
-                        let ty = binding.one_parameter_ty().unwrap_or(Type::unknown());
-                        binding.set_return_ty(Type::BooleanLiteral(ty.is_single_valued(db)));
+                        let ty = binding.one_parameter_type().unwrap_or(Type::unknown());
+                        binding.set_return_type(Type::BooleanLiteral(ty.is_single_valued(db)));
                         CallOutcome::callable(binding)
                     }
 
                     Some(KnownFunction::Len) => {
-                        if let Some(first_arg) = binding.one_parameter_ty() {
+                        if let Some(first_arg) = binding.one_parameter_type() {
                             if let Some(len_ty) = first_arg.len(db) {
-                                binding.set_return_ty(len_ty);
+                                binding.set_return_type(len_ty);
                             }
                         };
 
@@ -1979,15 +1979,15 @@ impl<'db> Type<'db> {
                     }
 
                     Some(KnownFunction::Repr) => {
-                        if let Some(first_arg) = binding.one_parameter_ty() {
-                            binding.set_return_ty(first_arg.repr(db));
+                        if let Some(first_arg) = binding.one_parameter_type() {
+                            binding.set_return_type(first_arg.repr(db));
                         };
 
                         CallOutcome::callable(binding)
                     }
 
                     Some(KnownFunction::AssertType) => {
-                        let Some((_, asserted_ty)) = binding.two_parameter_tys() else {
+                        let Some((_, asserted_ty)) = binding.two_parameter_types() else {
                             return CallOutcome::callable(binding);
                         };
 
@@ -1997,12 +1997,12 @@ impl<'db> Type<'db> {
                     Some(KnownFunction::Cast) => {
                         // TODO: Use `.two_parameter_tys()` exclusively
                         // when overloads are supported.
-                        if binding.two_parameter_tys().is_none() {
+                        if binding.two_parameter_types().is_none() {
                             return CallOutcome::callable(binding);
                         };
 
                         if let Some(casted_ty) = arguments.first_argument() {
-                            binding.set_return_ty(casted_ty);
+                            binding.set_return_type(casted_ty);
                         };
 
                         CallOutcome::callable(binding)
@@ -2015,7 +2015,7 @@ impl<'db> Type<'db> {
             // TODO annotated return type on `__new__` or metaclass `__call__`
             // TODO check call vs signatures of `__new__` and/or `__init__`
             Type::ClassLiteral(ClassLiteralType { class }) => {
-                CallOutcome::callable(CallBinding::from_return_ty(match class.known(db) {
+                CallOutcome::callable(CallBinding::from_return_type(match class.known(db) {
                     // If the class is the builtin-bool class (for example `bool(1)`), we try to
                     // return the specific truthiness value of the input arg, `Literal[True]` for
                     // the example above.
@@ -2061,7 +2061,7 @@ impl<'db> Type<'db> {
             }
 
             // Dynamic types are callable, and the return type is the same dynamic type
-            Type::Dynamic(_) => CallOutcome::callable(CallBinding::from_return_ty(self)),
+            Type::Dynamic(_) => CallOutcome::callable(CallBinding::from_return_type(self)),
 
             Type::Union(union) => CallOutcome::union(
                 self,
@@ -2071,7 +2071,7 @@ impl<'db> Type<'db> {
                     .map(|elem| elem.call(db, arguments)),
             ),
 
-            Type::Intersection(_) => CallOutcome::callable(CallBinding::from_return_ty(
+            Type::Intersection(_) => CallOutcome::callable(CallBinding::from_return_type(
                 todo_type!("Type::Intersection.call()"),
             )),
 
@@ -2117,7 +2117,7 @@ impl<'db> Type<'db> {
         match dunder_iter_result {
             CallDunderResult::CallOutcome(ref call_outcome)
             | CallDunderResult::PossiblyUnbound(ref call_outcome) => {
-                let Some(iterator_ty) = call_outcome.return_ty(db) else {
+                let Some(iterator_ty) = call_outcome.return_type(db) else {
                     return IterationOutcome::NotIterable {
                         not_iterable_ty: self,
                     };
@@ -2125,7 +2125,7 @@ impl<'db> Type<'db> {
 
                 return if let Some(element_ty) = iterator_ty
                     .call_dunder(db, "__next__", &CallArguments::positional([iterator_ty]))
-                    .return_ty(db)
+                    .return_type(db)
                 {
                     if matches!(dunder_iter_result, CallDunderResult::PossiblyUnbound(..)) {
                         IterationOutcome::PossiblyUnboundDunderIter {
@@ -2156,7 +2156,7 @@ impl<'db> Type<'db> {
                 "__getitem__",
                 &CallArguments::positional([self, KnownClass::Int.to_instance(db)]),
             )
-            .return_ty(db)
+            .return_type(db)
         {
             IterationOutcome::Iterable { element_ty }
         } else {
@@ -2262,7 +2262,9 @@ impl<'db> Type<'db> {
             Type::Dynamic(_) => Ok(*self),
             // TODO map this to a new `Type::TypeVar` variant
             Type::KnownInstance(KnownInstanceType::TypeVar(_)) => Ok(*self),
-            Type::KnownInstance(KnownInstanceType::TypeAliasType(alias)) => Ok(alias.value_ty(db)),
+            Type::KnownInstance(KnownInstanceType::TypeAliasType(alias)) => {
+                Ok(alias.value_type(db))
+            }
             Type::KnownInstance(KnownInstanceType::Never | KnownInstanceType::NoReturn) => {
                 Ok(Type::Never)
             }
@@ -2358,7 +2360,8 @@ impl<'db> Type<'db> {
                 ClassBase::Dynamic(_) => *self,
                 ClassBase::Class(class) => SubclassOfType::from(
                     db,
-                    ClassBase::try_from_ty(db, class.metaclass(db)).unwrap_or(ClassBase::unknown()),
+                    ClassBase::try_from_type(db, class.metaclass(db))
+                        .unwrap_or(ClassBase::unknown()),
                 ),
             },
 
@@ -2367,7 +2370,7 @@ impl<'db> Type<'db> {
             // TODO intersections
             Type::Intersection(_) => SubclassOfType::from(
                 db,
-                ClassBase::try_from_ty(db, todo_type!("Intersection meta-type"))
+                ClassBase::try_from_type(db, todo_type!("Intersection meta-type"))
                     .expect("Type::Todo should be a valid ClassBase"),
             ),
             Type::AlwaysTruthy | Type::AlwaysFalsy => KnownClass::Type.to_instance(db),
@@ -2491,7 +2494,7 @@ impl<'db> TypeAndQualifiers<'db> {
     }
 
     /// Forget about type qualifiers and only return the inner type.
-    pub(crate) fn inner_ty(&self) -> Type<'db> {
+    pub(crate) fn inner_type(&self) -> Type<'db> {
         self.inner
     }
 
@@ -3778,7 +3781,7 @@ impl<'db> Class<'db> {
         class_stmt
             .bases()
             .iter()
-            .map(|base_node| definition_expression_ty(db, class_definition, base_node))
+            .map(|base_node| definition_expression_type(db, class_definition, base_node))
             .collect()
     }
 
@@ -3807,7 +3810,7 @@ impl<'db> Class<'db> {
             .decorator_list
             .iter()
             .map(|decorator_node| {
-                definition_expression_ty(db, class_definition, &decorator_node.expression)
+                definition_expression_type(db, class_definition, &decorator_node.expression)
             })
             .collect()
     }
@@ -3866,7 +3869,7 @@ impl<'db> Class<'db> {
             .find_keyword("metaclass")?
             .value;
         let class_definition = semantic_index(db, self.file(db)).definition(class_stmt);
-        let metaclass_ty = definition_expression_ty(db, class_definition, metaclass_node);
+        let metaclass_ty = definition_expression_type(db, class_definition, metaclass_node);
         Some(metaclass_ty)
     }
 
@@ -3926,7 +3929,7 @@ impl<'db> Class<'db> {
                     let return_ty = outcomes
                         .iter()
                         .fold(None, |acc, outcome| {
-                            let ty = outcome.return_ty(db);
+                            let ty = outcome.return_type(db);
 
                             match (acc, ty) {
                                 (acc, None) => {
@@ -3957,7 +3960,7 @@ impl<'db> Class<'db> {
                 CallOutcome::Callable { binding }
                 | CallOutcome::RevealType { binding, .. }
                 | CallOutcome::StaticAssertionError { binding, .. }
-                | CallOutcome::AssertType { binding, .. } => Ok(binding.return_ty()),
+                | CallOutcome::AssertType { binding, .. } => Ok(binding.return_type()),
             };
 
             return return_ty_result.map(|ty| ty.to_meta_type(db));
@@ -4110,7 +4113,7 @@ impl<'db> Class<'db> {
                 }
                 Err((declared_ty, _conflicting_declarations)) => {
                     // Ignore conflicting declarations
-                    SymbolAndQualifiers(declared_ty.inner_ty().into(), declared_ty.qualifiers())
+                    SymbolAndQualifiers(declared_ty.inner_type().into(), declared_ty.qualifiers())
                 }
             }
         } else {
@@ -4176,13 +4179,13 @@ pub struct TypeAliasType<'db> {
 #[salsa::tracked]
 impl<'db> TypeAliasType<'db> {
     #[salsa::tracked]
-    pub fn value_ty(self, db: &'db dyn Db) -> Type<'db> {
+    pub fn value_type(self, db: &'db dyn Db) -> Type<'db> {
         let scope = self.rhs_scope(db);
 
         let type_alias_stmt_node = scope.node(db).expect_type_alias();
         let definition = semantic_index(db, scope.file(db)).definition(type_alias_stmt_node);
 
-        definition_expression_ty(db, definition, &type_alias_stmt_node.value)
+        definition_expression_type(db, definition, &type_alias_stmt_node.value)
     }
 }
 

--- a/crates/red_knot_python_semantic/src/types/call/bind.rs
+++ b/crates/red_knot_python_semantic/src/types/call/bind.rs
@@ -73,7 +73,7 @@ pub(crate) fn bind_call<'db>(
                 continue;
             }
         };
-        if let Some(expected_ty) = parameter.annotated_ty() {
+        if let Some(expected_ty) = parameter.annotated_type() {
             if !argument_ty.is_assignable_to(db, expected_ty) {
                 errors.push(CallBindingError::InvalidArgumentType {
                     parameter: ParameterContext::new(parameter, index, positional),
@@ -109,7 +109,8 @@ pub(crate) fn bind_call<'db>(
     for (index, bound_ty) in parameter_tys.iter().enumerate() {
         if bound_ty.is_none() {
             let param = &parameters[index];
-            if param.is_variadic() || param.is_keyword_variadic() || param.default_ty().is_some() {
+            if param.is_variadic() || param.is_keyword_variadic() || param.default_type().is_some()
+            {
                 // variadic/keywords and defaulted arguments are not required
                 continue;
             }
@@ -151,7 +152,7 @@ pub(crate) struct CallBinding<'db> {
 
 impl<'db> CallBinding<'db> {
     // TODO remove this constructor and construct always from `bind_call`
-    pub(crate) fn from_return_ty(return_ty: Type<'db>) -> Self {
+    pub(crate) fn from_return_type(return_ty: Type<'db>) -> Self {
         Self {
             callable_ty: None,
             return_ty,
@@ -160,27 +161,27 @@ impl<'db> CallBinding<'db> {
         }
     }
 
-    pub(crate) fn set_return_ty(&mut self, return_ty: Type<'db>) {
+    pub(crate) fn set_return_type(&mut self, return_ty: Type<'db>) {
         self.return_ty = return_ty;
     }
 
-    pub(crate) fn return_ty(&self) -> Type<'db> {
+    pub(crate) fn return_type(&self) -> Type<'db> {
         self.return_ty
     }
 
-    pub(crate) fn parameter_tys(&self) -> &[Type<'db>] {
+    pub(crate) fn parameter_types(&self) -> &[Type<'db>] {
         &self.parameter_tys
     }
 
-    pub(crate) fn one_parameter_ty(&self) -> Option<Type<'db>> {
-        match self.parameter_tys() {
+    pub(crate) fn one_parameter_type(&self) -> Option<Type<'db>> {
+        match self.parameter_types() {
             [ty] => Some(*ty),
             _ => None,
         }
     }
 
-    pub(crate) fn two_parameter_tys(&self) -> Option<(Type<'db>, Type<'db>)> {
-        match self.parameter_tys() {
+    pub(crate) fn two_parameter_types(&self) -> Option<(Type<'db>, Type<'db>)> {
+        match self.parameter_types() {
             [first, second] => Some((*first, *second)),
             _ => None,
         }

--- a/crates/red_knot_python_semantic/src/types/class_base.rs
+++ b/crates/red_knot_python_semantic/src/types/class_base.rs
@@ -62,7 +62,7 @@ impl<'db> ClassBase<'db> {
     /// Attempt to resolve `ty` into a `ClassBase`.
     ///
     /// Return `None` if `ty` is not an acceptable type for a class base.
-    pub(super) fn try_from_ty(db: &'db dyn Db, ty: Type<'db>) -> Option<Self> {
+    pub(super) fn try_from_type(db: &'db dyn Db, ty: Type<'db>) -> Option<Self> {
         match ty {
             Type::Dynamic(dynamic) => Some(Self::Dynamic(dynamic)),
             Type::ClassLiteral(ClassLiteralType { class }) => Some(Self::Class(class)),
@@ -112,40 +112,40 @@ impl<'db> ClassBase<'db> {
                 KnownInstanceType::Any => Some(Self::any()),
                 // TODO: Classes inheriting from `typing.Type` et al. also have `Generic` in their MRO
                 KnownInstanceType::Dict => {
-                    Self::try_from_ty(db, KnownClass::Dict.to_class_literal(db))
+                    Self::try_from_type(db, KnownClass::Dict.to_class_literal(db))
                 }
                 KnownInstanceType::List => {
-                    Self::try_from_ty(db, KnownClass::List.to_class_literal(db))
+                    Self::try_from_type(db, KnownClass::List.to_class_literal(db))
                 }
                 KnownInstanceType::Type => {
-                    Self::try_from_ty(db, KnownClass::Type.to_class_literal(db))
+                    Self::try_from_type(db, KnownClass::Type.to_class_literal(db))
                 }
                 KnownInstanceType::Tuple => {
-                    Self::try_from_ty(db, KnownClass::Tuple.to_class_literal(db))
+                    Self::try_from_type(db, KnownClass::Tuple.to_class_literal(db))
                 }
                 KnownInstanceType::Set => {
-                    Self::try_from_ty(db, KnownClass::Set.to_class_literal(db))
+                    Self::try_from_type(db, KnownClass::Set.to_class_literal(db))
                 }
                 KnownInstanceType::FrozenSet => {
-                    Self::try_from_ty(db, KnownClass::FrozenSet.to_class_literal(db))
+                    Self::try_from_type(db, KnownClass::FrozenSet.to_class_literal(db))
                 }
                 KnownInstanceType::ChainMap => {
-                    Self::try_from_ty(db, KnownClass::ChainMap.to_class_literal(db))
+                    Self::try_from_type(db, KnownClass::ChainMap.to_class_literal(db))
                 }
                 KnownInstanceType::Counter => {
-                    Self::try_from_ty(db, KnownClass::Counter.to_class_literal(db))
+                    Self::try_from_type(db, KnownClass::Counter.to_class_literal(db))
                 }
                 KnownInstanceType::DefaultDict => {
-                    Self::try_from_ty(db, KnownClass::DefaultDict.to_class_literal(db))
+                    Self::try_from_type(db, KnownClass::DefaultDict.to_class_literal(db))
                 }
                 KnownInstanceType::Deque => {
-                    Self::try_from_ty(db, KnownClass::Deque.to_class_literal(db))
+                    Self::try_from_type(db, KnownClass::Deque.to_class_literal(db))
                 }
                 KnownInstanceType::OrderedDict => {
-                    Self::try_from_ty(db, KnownClass::OrderedDict.to_class_literal(db))
+                    Self::try_from_type(db, KnownClass::OrderedDict.to_class_literal(db))
                 }
                 KnownInstanceType::Callable => {
-                    Self::try_from_ty(db, todo_type!("Support for Callable as a base class"))
+                    Self::try_from_type(db, todo_type!("Support for Callable as a base class"))
                 }
             },
         }

--- a/crates/red_knot_python_semantic/src/types/context.rs
+++ b/crates/red_knot_python_semantic/src/types/context.rs
@@ -8,7 +8,7 @@ use ruff_db::{
 use ruff_python_ast::AnyNodeRef;
 use ruff_text_size::Ranged;
 
-use super::{binding_ty, KnownFunction, TypeCheckDiagnostic, TypeCheckDiagnostics};
+use super::{binding_type, KnownFunction, TypeCheckDiagnostic, TypeCheckDiagnostics};
 
 use crate::semantic_index::semantic_index;
 use crate::semantic_index::symbol::ScopeId;
@@ -144,7 +144,7 @@ impl<'db> InferContext<'db> {
                     .ancestor_scopes(scope_id)
                     .filter_map(|(_, scope)| scope.node().as_function())
                     .filter_map(|function| {
-                        binding_ty(self.db, index.definition(function)).into_function_literal()
+                        binding_type(self.db, index.definition(function)).into_function_literal()
                     });
 
                 // Iterate over all functions and test if any is decorated with `@no_type_check`.

--- a/crates/red_knot_python_semantic/src/types/mro.rs
+++ b/crates/red_knot_python_semantic/src/types/mro.rs
@@ -76,7 +76,7 @@ impl<'db> Mro<'db> {
             // This *could* theoretically be handled by the final branch below,
             // but it's a common case (i.e., worth optimizing for),
             // and the `c3_merge` function requires lots of allocations.
-            [single_base] => ClassBase::try_from_ty(db, *single_base).map_or_else(
+            [single_base] => ClassBase::try_from_type(db, *single_base).map_or_else(
                 || Err(MroErrorKind::InvalidBases(Box::from([(0, *single_base)]))),
                 |single_base| {
                     Ok(std::iter::once(ClassBase::Class(class))
@@ -95,7 +95,7 @@ impl<'db> Mro<'db> {
                 let mut invalid_bases = vec![];
 
                 for (i, base) in multiple_bases.iter().enumerate() {
-                    match ClassBase::try_from_ty(db, *base) {
+                    match ClassBase::try_from_type(db, *base) {
                         Some(valid_base) => valid_bases.push(valid_base),
                         None => invalid_bases.push((i, *base)),
                     }

--- a/crates/red_knot_python_semantic/src/types/narrow.rs
+++ b/crates/red_knot_python_semantic/src/types/narrow.rs
@@ -322,9 +322,9 @@ impl<'db> NarrowingConstraintsBuilder<'db> {
 
         for (op, (left, right)) in std::iter::zip(&**ops, comparator_tuples) {
             let lhs_ty = last_rhs_ty.unwrap_or_else(|| {
-                inference.expression_ty(left.scoped_expression_id(self.db, scope))
+                inference.expression_type(left.scoped_expression_id(self.db, scope))
             });
-            let rhs_ty = inference.expression_ty(right.scoped_expression_id(self.db, scope));
+            let rhs_ty = inference.expression_type(right.scoped_expression_id(self.db, scope));
             last_rhs_ty = Some(rhs_ty);
 
             match left {
@@ -393,7 +393,7 @@ impl<'db> NarrowingConstraintsBuilder<'db> {
                     }
 
                     let callable_ty =
-                        inference.expression_ty(callable.scoped_expression_id(self.db, scope));
+                        inference.expression_type(callable.scoped_expression_id(self.db, scope));
 
                     if callable_ty
                         .into_class_literal()
@@ -422,7 +422,7 @@ impl<'db> NarrowingConstraintsBuilder<'db> {
         let inference = infer_expression_types(self.db, expression);
 
         let callable_ty =
-            inference.expression_ty(expr_call.func.scoped_expression_id(self.db, scope));
+            inference.expression_type(expr_call.func.scoped_expression_id(self.db, scope));
 
         // TODO: add support for PEP 604 union types on the right hand side of `isinstance`
         // and `issubclass`, for example `isinstance(x, str | (int | float))`.
@@ -441,7 +441,7 @@ impl<'db> NarrowingConstraintsBuilder<'db> {
                 let symbol = self.symbols().symbol_id_by_name(id).unwrap();
 
                 let class_info_ty =
-                    inference.expression_ty(class_info.scoped_expression_id(self.db, scope));
+                    inference.expression_type(class_info.scoped_expression_id(self.db, scope));
 
                 function
                     .generate_constraint(self.db, class_info_ty)
@@ -500,7 +500,7 @@ impl<'db> NarrowingConstraintsBuilder<'db> {
             let scope = self.scope();
             let inference = infer_expression_types(self.db, cls);
             let ty = inference
-                .expression_ty(cls.node_ref(self.db).scoped_expression_id(self.db, scope))
+                .expression_type(cls.node_ref(self.db).scoped_expression_id(self.db, scope))
                 .to_instance(self.db);
             let mut constraints = NarrowingConstraints::default();
             constraints.insert(symbol, ty);
@@ -524,7 +524,7 @@ impl<'db> NarrowingConstraintsBuilder<'db> {
             // filter our arms with statically known truthiness
             .filter(|expr| {
                 inference
-                    .expression_ty(expr.scoped_expression_id(self.db, scope))
+                    .expression_type(expr.scoped_expression_id(self.db, scope))
                     .bool(self.db)
                     != match expr_bool_op.op {
                         BoolOp::And => Truthiness::AlwaysTrue,

--- a/crates/red_knot_python_semantic/src/types/signatures.rs
+++ b/crates/red_knot_python_semantic/src/types/signatures.rs
@@ -1,4 +1,4 @@
-use super::{definition_expression_ty, Type};
+use super::{definition_expression_type, Type};
 use crate::Db;
 use crate::{semantic_index::definition::Definition, types::todo_type};
 use ruff_python_ast::{self as ast, name::Name};
@@ -39,7 +39,7 @@ impl<'db> Signature<'db> {
             if function_node.is_async {
                 todo_type!("generic types.CoroutineType")
             } else {
-                definition_expression_ty(db, definition, returns.as_ref())
+                definition_expression_type(db, definition, returns.as_ref())
             }
         });
 
@@ -97,7 +97,7 @@ impl<'db> Parameters<'db> {
             parameter_with_default
                 .default
                 .as_deref()
-                .map(|default| definition_expression_ty(db, definition, default))
+                .map(|default| definition_expression_type(db, definition, default))
         };
         let positional_only = posonlyargs.iter().map(|arg| {
             Parameter::from_node_and_kind(
@@ -245,7 +245,7 @@ impl<'db> Parameter<'db> {
             annotated_ty: parameter
                 .annotation
                 .as_deref()
-                .map(|annotation| definition_expression_ty(db, definition, annotation)),
+                .map(|annotation| definition_expression_type(db, definition, annotation)),
             kind,
         }
     }
@@ -276,7 +276,7 @@ impl<'db> Parameter<'db> {
     }
 
     /// Annotated type of the parameter, if annotated.
-    pub(crate) fn annotated_ty(&self) -> Option<Type<'db>> {
+    pub(crate) fn annotated_type(&self) -> Option<Type<'db>> {
         self.annotated_ty
     }
 
@@ -295,7 +295,7 @@ impl<'db> Parameter<'db> {
     }
 
     /// Default-value type of the parameter, if any.
-    pub(crate) fn default_ty(&self) -> Option<Type<'db>> {
+    pub(crate) fn default_type(&self) -> Option<Type<'db>> {
         match self.kind {
             ParameterKind::PositionalOnly { default_ty } => default_ty,
             ParameterKind::PositionalOrKeyword { default_ty } => default_ty,

--- a/crates/red_knot_python_semantic/src/types/unpacker.rs
+++ b/crates/red_knot_python_semantic/src/types/unpacker.rs
@@ -43,7 +43,7 @@ impl<'db> Unpacker<'db> {
         );
 
         let mut value_ty = infer_expression_types(self.db(), value.expression())
-            .expression_ty(value.scoped_expression_id(self.db(), self.scope));
+            .expression_type(value.scoped_expression_id(self.db(), self.scope));
 
         if value.is_assign()
             && self.context.in_stub()

--- a/crates/red_knot_python_semantic/src/visibility_constraints.rs
+++ b/crates/red_knot_python_semantic/src/visibility_constraints.rs
@@ -294,8 +294,8 @@ impl<'db> VisibilityConstraints<'db> {
             ConstraintNode::Expression(test_expr) => {
                 let inference = infer_expression_types(db, test_expr);
                 let scope = test_expr.scope(db);
-                let ty =
-                    inference.expression_ty(test_expr.node_ref(db).scoped_expression_id(db, scope));
+                let ty = inference
+                    .expression_type(test_expr.node_ref(db).scoped_expression_id(db, scope));
 
                 ty.bool(db).negate_if(!constraint.is_positive)
             }
@@ -304,7 +304,7 @@ impl<'db> VisibilityConstraints<'db> {
                     let subject_expression = inner.subject(db);
                     let inference = infer_expression_types(db, *subject_expression);
                     let scope = subject_expression.scope(db);
-                    let subject_ty = inference.expression_ty(
+                    let subject_ty = inference.expression_type(
                         subject_expression
                             .node_ref(db)
                             .scoped_expression_id(db, scope),
@@ -312,8 +312,8 @@ impl<'db> VisibilityConstraints<'db> {
 
                     let inference = infer_expression_types(db, *value);
                     let scope = value.scope(db);
-                    let value_ty =
-                        inference.expression_ty(value.node_ref(db).scoped_expression_id(db, scope));
+                    let value_ty = inference
+                        .expression_type(value.node_ref(db).scoped_expression_id(db, scope));
 
                     if subject_ty.is_single_valued(db) {
                         let truthiness =


### PR DESCRIPTION
## Summary

General rules:

* Change the `_ty` suffix of all functions to `_type`.
* `_type_and_qualifiers` suffixes seem too long, so we ignore the existence of qualifiers and still speak of "types"
* Functions only have a `_type` suffix if they return either `Type`, `Option<Type>`, or `TypeAndQualifiers`

Free functions:

* `binding_ty` => `binding_type`
* `declaration_ty` => `declaration_type`
* `definition_expression_ty` => `definition_expression_type`

Methods:

* `CallDunderResult::return_ty` => `return_type`
* `NotCallableError::return_ty` => `return_type`
* `NotCallableError::called_ty` => `called_type`
* `TypeAndQualifiers::inner_ty` => `inner_type`
* `TypeAliasType::value_ty` => `value_type`
* `TypeInference::expression_ty` => `expression_type`
* `TypeInference::try_expression_ty` => `try_expression_type`
* `TypeInference::binding_ty` => `binding_type`
* `TypeInference::declaration_ty` => `declaration_type` 
* `TypeInferenceBuilder::expression_ty` => `expression_type`
* `TypeInferenceBuilder::file_expression_ty` => `file_expression_type`
* `TypeInferenceBuilder::module_ty_from_name` => `module_type_from_name`
* `ClassBase::try_from_ty` => `try_from_type`
* `Parameter::annotated_ty` => `annotated_type`
* `Parameter::default_ty` => `default_type`
* `CallOutcome::return_ty` => `return_type`
* `CallOutcome::return_ty_result` => `return_type_result`
* `CallBinding::from_return_ty` => `from_return_type`
* `CallBinding::set_return_ty` => `set_return_type`
* `CallBinding::return_ty` => `return_type`
* `CallBinding::parameter_tys` => `parameter_types`
* `CallBinding::one_parameter_ty` => `one_parameter_type`
* `CallBinding::two_parameter_tys` => `two_parameter_types`
* `Unpacker::tuple_ty_elements` => `tuple_type_elements`
* `StringPartsCollector::ty` => `string_type`

Traits

* `HasTy` => `HasType`
* `HasTy::ty` => `inferred_type`

Test functions:

* `assert_public_ty` => `assert_public_type`
* `assert_scope_ty` => `assert_scope_type`

closes #15569

## Test Plan

—