### PR TITLE
[red-knot] Rename `bindings_ty`, `declarations_ty`

### DIFF
--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -4116,9 +4116,9 @@ impl<'db> Class<'db> {
                 }
                 Ok(SymbolAndQualifiers(Symbol::Unbound, qualifiers)) => {
                     let bindings = use_def.public_bindings(symbol);
-                    let inferred_ty = symbol_from_bindings(db, bindings);
+                    let inferred = symbol_from_bindings(db, bindings);
 
-                    match inferred_ty {
+                    match inferred {
                         Symbol::Type(ty, _) => SymbolAndQualifiers(
                             Symbol::Type(
                                 UnionType::from_elements(db, [Type::unknown(), ty]),

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -285,9 +285,10 @@ fn definition_expression_ty<'db>(
     }
 }
 
-/// Infer the combined type of an iterator of bindings.
+/// Infer the combined type from an iterator of bindings, and return it
+/// together with boundness information in a [`Symbol`].
 ///
-/// Will return a union if there is more than one binding.
+/// Will return a union type if there is more than one binding.
 fn symbol_from_bindings<'db>(
     db: &'db dyn Db,
     bindings_with_constraints: BindingWithConstraintsIterator<'_, 'db>,

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -288,7 +288,7 @@ fn definition_expression_ty<'db>(
 /// Infer the combined type from an iterator of bindings, and return it
 /// together with boundness information in a [`Symbol`].
 ///
-/// Will return a union type if there is more than one binding.
+/// The type will be a union if there are multiple bindings with different types.
 fn symbol_from_bindings<'db>(
     db: &'db dyn Db,
     bindings_with_constraints: BindingWithConstraintsIterator<'_, 'db>,

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -62,13 +62,13 @@ use crate::types::diagnostic::{
 use crate::types::mro::MroErrorKind;
 use crate::types::unpacker::{UnpackResult, Unpacker};
 use crate::types::{
-    bindings_ty, builtins_symbol, declarations_ty, global_symbol, symbol, todo_type,
-    typing_extensions_symbol, Boundness, CallDunderResult, Class, ClassLiteralType, DynamicType,
-    FunctionType, InstanceType, IntersectionBuilder, IntersectionType, IterationOutcome,
-    KnownClass, KnownFunction, KnownInstanceType, MetaclassCandidate, MetaclassErrorKind,
-    SliceLiteralType, SubclassOfType, Symbol, SymbolAndQualifiers, Truthiness, TupleType, Type,
-    TypeAliasType, TypeAndQualifiers, TypeArrayDisplay, TypeQualifiers, TypeVarBoundOrConstraints,
-    TypeVarInstance, UnionBuilder, UnionType,
+    builtins_symbol, global_symbol, symbol, symbol_from_bindings, symbol_from_declarations,
+    todo_type, typing_extensions_symbol, Boundness, CallDunderResult, Class, ClassLiteralType,
+    DynamicType, FunctionType, InstanceType, IntersectionBuilder, IntersectionType,
+    IterationOutcome, KnownClass, KnownFunction, KnownInstanceType, MetaclassCandidate,
+    MetaclassErrorKind, SliceLiteralType, SubclassOfType, Symbol, SymbolAndQualifiers, Truthiness,
+    TupleType, Type, TypeAliasType, TypeAndQualifiers, TypeArrayDisplay, TypeQualifiers,
+    TypeVarBoundOrConstraints, TypeVarInstance, UnionBuilder, UnionType,
 };
 use crate::unpack::Unpack;
 use crate::util::subscript::{PyIndex, PySlice};
@@ -859,7 +859,7 @@ impl<'db> TypeInferenceBuilder<'db> {
         let use_def = self.index.use_def_map(binding.file_scope(self.db()));
         let declarations = use_def.declarations_at_binding(binding);
         let mut bound_ty = ty;
-        let declared_ty = declarations_ty(self.db(), declarations)
+        let declared_ty = symbol_from_declarations(self.db(), declarations)
             .map(|SymbolAndQualifiers(s, _)| s.ignore_possibly_unbound().unwrap_or(Type::unknown()))
             .unwrap_or_else(|(ty, conflicting)| {
                 // TODO point out the conflicting declarations in the diagnostic?
@@ -894,7 +894,7 @@ impl<'db> TypeInferenceBuilder<'db> {
         let use_def = self.index.use_def_map(declaration.file_scope(self.db()));
         let prior_bindings = use_def.bindings_at_declaration(declaration);
         // unbound_ty is Never because for this check we don't care about unbound
-        let inferred_ty = bindings_ty(self.db(), prior_bindings)
+        let inferred_ty = symbol_from_bindings(self.db(), prior_bindings)
             .ignore_possibly_unbound()
             .unwrap_or(Type::Never);
         let ty = if inferred_ty.is_assignable_to(self.db(), ty.inner_ty()) {
@@ -3310,9 +3310,9 @@ impl<'db> TypeInferenceBuilder<'db> {
         let use_def = self.index.use_def_map(file_scope_id);
 
         // If we're inferring types of deferred expressions, always treat them as public symbols
-        let bindings_ty = if self.is_deferred() {
+        let bindings_symbol = if self.is_deferred() {
             if let Some(symbol) = self.index.symbol_table(file_scope_id).symbol_id_by_name(id) {
-                bindings_ty(self.db(), use_def.public_bindings(symbol))
+                symbol_from_bindings(self.db(), use_def.public_bindings(symbol))
             } else {
                 assert!(
                     self.deferred_state.in_string_annotation(),
@@ -3322,10 +3322,10 @@ impl<'db> TypeInferenceBuilder<'db> {
             }
         } else {
             let use_id = name.scoped_use_id(self.db(), self.scope());
-            bindings_ty(self.db(), use_def.bindings_at_use(use_id))
+            symbol_from_bindings(self.db(), use_def.bindings_at_use(use_id))
         };
 
-        if let Symbol::Type(ty, Boundness::Bound) = bindings_ty {
+        if let Symbol::Type(ty, Boundness::Bound) = bindings_symbol {
             ty
         } else {
             match self.lookup_name(name) {
@@ -3334,12 +3334,12 @@ impl<'db> TypeInferenceBuilder<'db> {
                         report_possibly_unresolved_reference(&self.context, name);
                     }
 
-                    bindings_ty
+                    bindings_symbol
                         .ignore_possibly_unbound()
                         .map(|ty| UnionType::from_elements(self.db(), [ty, looked_up_ty]))
                         .unwrap_or(looked_up_ty)
                 }
-                Symbol::Unbound => match bindings_ty {
+                Symbol::Unbound => match bindings_symbol {
                     Symbol::Type(ty, Boundness::PossiblyUnbound) => {
                         report_possibly_unresolved_reference(&self.context, name);
                         ty

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -3310,7 +3310,7 @@ impl<'db> TypeInferenceBuilder<'db> {
         let use_def = self.index.use_def_map(file_scope_id);
 
         // If we're inferring types of deferred expressions, always treat them as public symbols
-        let bindings_symbol = if self.is_deferred() {
+        let inferred = if self.is_deferred() {
             if let Some(symbol) = self.index.symbol_table(file_scope_id).symbol_id_by_name(id) {
                 symbol_from_bindings(self.db(), use_def.public_bindings(symbol))
             } else {
@@ -3325,7 +3325,7 @@ impl<'db> TypeInferenceBuilder<'db> {
             symbol_from_bindings(self.db(), use_def.bindings_at_use(use_id))
         };
 
-        if let Symbol::Type(ty, Boundness::Bound) = bindings_symbol {
+        if let Symbol::Type(ty, Boundness::Bound) = inferred {
             ty
         } else {
             match self.lookup_name(name) {
@@ -3334,12 +3334,12 @@ impl<'db> TypeInferenceBuilder<'db> {
                         report_possibly_unresolved_reference(&self.context, name);
                     }
 
-                    bindings_symbol
+                    inferred
                         .ignore_possibly_unbound()
                         .map(|ty| UnionType::from_elements(self.db(), [ty, looked_up_ty]))
                         .unwrap_or(looked_up_ty)
                 }
-                Symbol::Unbound => match bindings_symbol {
+                Symbol::Unbound => match inferred {
                     Symbol::Type(ty, Boundness::PossiblyUnbound) => {
                         report_possibly_unresolved_reference(&self.context, name);
                         ty


### PR DESCRIPTION
## Summary

Rename two functions with outdated names (they used to return `Type`s):

* `bindings_ty` => `symbol_from_bindings` (returns `Symbol`)
* `declarations_ty` => `symbol_from_declarations` (returns a `SymbolAndQualifiers` result)

I chose `symbol_from_*` instead of `*_symbol` as I found the previous name quite confusing. Especially since `binding_ty` and `declaration_ty` also exist (singular).

## Test Plan

—
