### PR TITLE
Change `EnvironmentOptions::venv-path` to `Option<SystemPathBuf>`

### DIFF
--- a/crates/red_knot/src/main.rs
+++ b/crates/red_knot/src/main.rs
@@ -10,7 +10,6 @@ use red_knot_project::metadata::options::{EnvironmentOptions, Options};
 use red_knot_project::watch;
 use red_knot_project::watch::ProjectWatcher;
 use red_knot_project::{ProjectDatabase, ProjectMetadata};
-use red_knot_python_semantic::SitePackages;
 use red_knot_server::run_server;
 use ruff_db::diagnostic::Diagnostic;
 use ruff_db::system::{OsSystem, System, SystemPath, SystemPathBuf};
@@ -77,9 +76,7 @@ impl Args {
                 venv_path: self
                     .venv_path
                     .as_ref()
-                    .map(|venv_path| SitePackages::Derived {
-                        venv_path: SystemPath::absolute(venv_path, cli_cwd),
-                    }),
+                    .map(|venv_path| SystemPath::absolute(venv_path, cli_cwd)),
                 typeshed: self
                     .typeshed
                     .as_ref()

--- a/crates/red_knot_project/src/metadata/options.rs
+++ b/crates/red_knot_project/src/metadata/options.rs
@@ -74,7 +74,9 @@ impl Options {
             extra_paths: extra_paths.unwrap_or_default(),
             src_roots,
             typeshed,
-            site_packages: python.unwrap_or(SitePackages::Known(vec![])),
+            site_packages: python
+                .map(|venv_path| SitePackages::Derived { venv_path })
+                .unwrap_or(SitePackages::Known(vec![])),
         }
     }
 }
@@ -98,7 +100,7 @@ pub struct EnvironmentOptions {
 
     // TODO: Rename to python, see https://github.com/astral-sh/ruff/issues/15530
     /// The path to the user's `site-packages` directory, where third-party packages from ``PyPI`` are installed.
-    pub venv_path: Option<SitePackages>,
+    pub venv_path: Option<SystemPathBuf>,
 }
 
 #[derive(Debug, Default, Clone, Eq, PartialEq, Combine, Serialize, Deserialize)]

--- a/crates/red_knot_python_semantic/src/module_resolver/resolver.rs
+++ b/crates/red_knot_python_semantic/src/module_resolver/resolver.rs
@@ -223,7 +223,10 @@ impl SearchPaths {
 
         let site_packages_paths = match site_packages_paths {
             SitePackages::Derived { venv_path } => {
-                // TODO: Warn if venv python version isn't compatible.
+                // TODO: We may want to warn here if the venv's python version is older
+                //  than the one resolved in the program settings because it indicates
+                //  that the `target-version` is incorrectly configured or that the
+                //  venv is out of date.
                 VirtualEnvironment::new(venv_path, system)
                     .and_then(|venv| venv.site_packages_directories(system))?
             }

--- a/crates/red_knot_python_semantic/src/module_resolver/resolver.rs
+++ b/crates/red_knot_python_semantic/src/module_resolver/resolver.rs
@@ -222,8 +222,11 @@ impl SearchPaths {
         static_paths.push(stdlib_path);
 
         let site_packages_paths = match site_packages_paths {
-            SitePackages::Derived { venv_path } => VirtualEnvironment::new(venv_path, system)
-                .and_then(|venv| venv.site_packages_directories(system))?,
+            SitePackages::Derived { venv_path } => {
+                // TODO: Warn if venv python version isn't compatible.
+                VirtualEnvironment::new(venv_path, system)
+                    .and_then(|venv| venv.site_packages_directories(system))?
+            }
             SitePackages::Known(paths) => paths
                 .iter()
                 .map(|path| canonicalize(path, system))

--- a/crates/red_knot_python_semantic/src/program.rs
+++ b/crates/red_knot_python_semantic/src/program.rs
@@ -134,12 +134,3 @@ pub enum SitePackages {
     /// Resolved site packages paths
     Known(Vec<SystemPathBuf>),
 }
-
-impl SitePackages {
-    pub fn paths(&self) -> &[SystemPathBuf] {
-        match self {
-            SitePackages::Derived { venv_path } => std::slice::from_ref(venv_path),
-            SitePackages::Known(paths) => paths,
-        }
-    }
-}


### PR DESCRIPTION
## Summary

The `Options` struct is intended to capture the user's configuration options but
`EnvironmentOptions::venv_path` supports both a `SitePackages::Known` and `SitePackages::Derived`.

Users should only be able to provide `SitePackages::Derived`—they specify a path to a venv, and Red Knot derives the path to the site-packages directory. We'll only use the `Known` variant once we automatically discover the Python installation. 

That's why this PR changes `EnvironmentOptions::venv_path` from `Option<SitePackages>` to `Option<SystemPathBuf>`.

This requires making some changes to the file watcher test, and I decided to use `extra_paths` over venv path
because our venv validation is annoyingly correct -- making mocking a venv rather involved. 

## Test Plan

`cargo test`
