### PR TITLE
[red-knot] Markdown test runner

### DIFF
--- a/crates/red_knot_python_semantic/mdtest.py
+++ b/crates/red_knot_python_semantic/mdtest.py
@@ -24,10 +24,11 @@ MDTEST_DIR: Final = CRATE_ROOT / "resources" / "mdtest"
 
 
 class MDTestRunner:
-    mdtest_executable: Path
+    mdtest_executable: Path | None
     console: Console
 
     def __init__(self) -> None:
+        self.mdtest_executable = None
         self.console = Console()
 
     def _run_cargo_test(self, message_format: Literal["human", "json"]) -> str:
@@ -84,8 +85,10 @@ class MDTestRunner:
             )
 
     def _run_mdtest(
-        self, arguments: list[str] | None = None, capture_output: bool = False
+        self, arguments: list[str] | None = None, *, capture_output: bool = False
     ) -> subprocess.CompletedProcess:
+        assert self.mdtest_executable is not None
+
         arguments = arguments or []
         return subprocess.run(
             [self.mdtest_executable, *arguments],

--- a/crates/red_knot_python_semantic/mdtest.py
+++ b/crates/red_knot_python_semantic/mdtest.py
@@ -1,0 +1,200 @@
+"""A runner for Markdown-based tests for Red Knot"""
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "rich",
+#     "watchfiles",
+# ]
+# ///
+
+import json
+import os
+import subprocess
+from pathlib import Path
+from typing import Literal, Never
+
+from rich.console import Console
+from watchfiles import Change, watch
+
+CRATE_NAME = "red_knot_python_semantic"
+CRATE_ROOT = Path(__file__).resolve().parent
+MDTEST_DIR = CRATE_ROOT / "resources" / "mdtest"
+
+
+class MDTestRunner:
+    mdtest_executable: Path
+    console: Console
+
+    def __init__(self) -> None:
+        self.console = Console()
+
+    def _run_cargo_test(self, message_format: Literal["human", "json"]) -> str:
+        return subprocess.check_output(
+            [
+                "cargo",
+                "test",
+                "--package",
+                CRATE_NAME,
+                "--no-run",
+                "--color=always",
+                "--message-format",
+                message_format,
+            ],
+            cwd=CRATE_ROOT,
+            env=dict(os.environ, CLI_COLOR="1"),
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+
+    def _recompile_tests(
+        self, status_message: str, message_on_success: bool = True
+    ) -> None:
+        with self.console.status(status_message):
+            # Run it with 'human' format in case there are errors:
+            try:
+                self._run_cargo_test(message_format="human")
+            except subprocess.CalledProcessError as e:
+                print(e.output)
+                return
+
+            # Run it again with 'json' format to find the mdtest executable:
+            json_output = self._run_cargo_test(message_format="json")
+
+            if json_output:
+                self._get_executable_path_from_json(json_output)
+
+        if message_on_success:
+            self.console.print("[dim]Tests compiled successfully[/dim]")
+
+    def _get_executable_path_from_json(self, json_output: str) -> None:
+        for json_line in json_output.splitlines():
+            try:
+                data = json.loads(json_line)
+            except json.JSONDecodeError:
+                continue
+            if data.get("target", {}).get("name") == "mdtest":
+                self.mdtest_executable = Path(data["executable"])
+                break
+        else:
+            raise RuntimeError(
+                "Could not find mdtest executable after successful compilation"
+            )
+
+    def _run_mdtest(
+        self, arguments: list[str] = [], capture_output: bool = False
+    ) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            [self.mdtest_executable, *arguments],
+            cwd=CRATE_ROOT,
+            env=dict(os.environ, CLICOLOR_FORCE="1"),
+            capture_output=capture_output,
+            text=True,
+            check=False,
+        )
+
+    def _run_mdtests_for_file(self, markdown_file: Path) -> None:
+        path_mangled = (
+            markdown_file.as_posix()
+            .replace("/", "_")
+            .replace("-", "_")
+            .removesuffix(".md")
+        )
+        test_name = f"mdtest__{path_mangled}"
+
+        output = self._run_mdtest(["--exact", test_name], capture_output=True)
+
+        if output.returncode == 0:
+            if "running 0 tests\n" in output.stdout:
+                self.console.log(
+                    f"[yellow]Warning[/yellow]: No tests were executed with filter '{test_name}'"
+                )
+            else:
+                self.console.print(
+                    f"Test for [bold green]{markdown_file}[/bold green] succeeded"
+                )
+        else:
+            self.console.print()
+            self.console.rule(
+                f"Test for [bold red]{markdown_file}[/bold red] failed",
+                style="gray",
+            )
+            # Skip 'cargo test' boilerplate at the beginning:
+            lines = output.stdout.splitlines()
+            start_index = 0
+            for i, line in enumerate(lines):
+                if f"{test_name} stdout" in line:
+                    start_index = i
+                    break
+
+            for line in lines[start_index + 1 :]:
+                if "MDTEST_TEST_FILTER" in line:
+                    continue
+                if line.strip() == "-" * 50:
+                    # Skip 'cargo test' boilerplate at the end
+                    break
+
+                print(line)
+
+    def _run_all_mdtests(self) -> None:
+        self._run_mdtest()
+
+    def watch(self) -> Never:
+        self._recompile_tests("Compiling tests...", message_on_success=False)
+        self.console.print("[dim]Ready to watch for changes...[/dim]")
+
+        for changes in watch(CRATE_ROOT):
+            new_md_files = set()
+            changed_md_files = set()
+            rust_code_has_changed = False
+
+            for change, path_str in changes:
+                path = Path(path_str)
+
+                if path.suffix == ".rs":
+                    rust_code_has_changed = True
+                    continue
+
+                if path.suffix != ".md":
+                    continue
+
+                try:
+                    relative_path = Path(path).relative_to(MDTEST_DIR)
+                except ValueError:
+                    continue
+
+                match change:
+                    case Change.added:
+                        # When saving a file, some editors (looking at you, Vim) might first
+                        # save the file with a temporary name (e.g. `file.md~`) and then rename
+                        # it to the final name. This creates a `deleted` and `added` change.
+                        # We treat those files as `changed` here.
+                        if (Change.deleted, path_str) in changes:
+                            changed_md_files.add(relative_path)
+                        else:
+                            new_md_files.add(relative_path)
+                    case Change.modified:
+                        changed_md_files.add(relative_path)
+
+            if rust_code_has_changed:
+                self._recompile_tests("Rust code has changed, recompiling tests...")
+                self._run_all_mdtests()
+            elif new_md_files:
+                files = " ".join(file.as_posix() for file in new_md_files)
+                self._recompile_tests(
+                    f"New Markdown test [yellow]{files}[/yellow] detected, recompiling tests..."
+                )
+
+            for path in new_md_files | changed_md_files:
+                self._run_mdtests_for_file(path)
+
+
+def main() -> None:
+    try:
+        runner = MDTestRunner()
+        runner.watch()
+    except KeyboardInterrupt:
+        print()
+
+
+if __name__ == "__main__":
+    main()

--- a/crates/red_knot_python_semantic/mdtest.py
+++ b/crates/red_knot_python_semantic/mdtest.py
@@ -7,6 +7,8 @@
 # ]
 # ///
 
+from __future__ import annotations
+
 import json
 import os
 import subprocess
@@ -82,8 +84,9 @@ class MDTestRunner:
             )
 
     def _run_mdtest(
-        self, arguments: list[str] = [], capture_output: bool = False
+        self, arguments: list[str] | None = None, capture_output: bool = False
     ) -> subprocess.CompletedProcess:
+        arguments = arguments or []
         return subprocess.run(
             [self.mdtest_executable, *arguments],
             cwd=CRATE_ROOT,

--- a/crates/red_knot_python_semantic/mdtest.py
+++ b/crates/red_knot_python_semantic/mdtest.py
@@ -13,7 +13,7 @@ import json
 import os
 import subprocess
 from pathlib import Path
-from typing import Final, Literal, Never
+from typing import Final, Literal, Never, assert_never
 
 from rich.console import Console
 from watchfiles import Change, watch
@@ -178,6 +178,11 @@ class MDTestRunner:
                             new_md_files.add(relative_path)
                     case Change.modified:
                         changed_md_files.add(relative_path)
+                    case Change.deleted:
+                        # No need to do anything when a Markdown test is deleted
+                        pass
+                    case _ as unreachable:
+                        assert_never(unreachable)
 
             if rust_code_has_changed:
                 if self._recompile_tests("Rust code has changed, recompiling tests..."):

--- a/crates/red_knot_python_semantic/mdtest.py
+++ b/crates/red_knot_python_semantic/mdtest.py
@@ -13,14 +13,14 @@ import json
 import os
 import subprocess
 from pathlib import Path
-from typing import Literal, Never
+from typing import Final, Literal, Never
 
 from rich.console import Console
 from watchfiles import Change, watch
 
-CRATE_NAME = "red_knot_python_semantic"
-CRATE_ROOT = Path(__file__).resolve().parent
-MDTEST_DIR = CRATE_ROOT / "resources" / "mdtest"
+CRATE_NAME: Final = "red_knot_python_semantic"
+CRATE_ROOT: Final = Path(__file__).resolve().parent
+MDTEST_DIR: Final = CRATE_ROOT / "resources" / "mdtest"
 
 
 class MDTestRunner:
@@ -49,7 +49,7 @@ class MDTestRunner:
         )
 
     def _recompile_tests(
-        self, status_message: str, message_on_success: bool = True
+        self, status_message: str, *, message_on_success: bool = True
     ) -> bool:
         with self.console.status(status_message):
             # Run it with 'human' format in case there are errors:

--- a/crates/red_knot_python_semantic/mdtest.py
+++ b/crates/red_knot_python_semantic/mdtest.py
@@ -31,7 +31,7 @@ class MDTestRunner:
         self.mdtest_executable = None
         self.console = Console()
 
-    def _run_cargo_test(self, message_format: Literal["human", "json"]) -> str:
+    def _run_cargo_test(self, *, message_format: Literal["human", "json"]) -> str:
         return subprocess.check_output(
             [
                 "cargo",

--- a/crates/red_knot_python_semantic/mdtest.py.lock
+++ b/crates/red_knot_python_semantic/mdtest.py.lock
@@ -1,0 +1,141 @@
+version = 1
+requires-python = ">=3.11"
+
+[manifest]
+requirements = [
+    { name = "rich" },
+    { name = "watchfiles" },
+]
+
+[[package]]
+name = "anyio"
+version = "4.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "sniffio" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/73/199a98fc2dae33535d6b8e8e6ec01f8c1d76c9adb096c6b7d64823038cde/anyio-4.8.0.tar.gz", hash = "sha256:1d9fe889df5212298c0c0723fa20479d1b94883a2df44bd3897aa91083316f7a", size = 181126 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/46/eb/e7f063ad1fec6b3178a3cd82d1a3c4de82cccf283fc42746168188e1cdd5/anyio-4.8.0-py3-none-any.whl", hash = "sha256:b5011f270ab5eb0abf13385f851315585cc37ef330dd88e27ec3d34d651fd47a", size = 96041 },
+]
+
+[[package]]
+name = "idna"
+version = "3.10"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f1/70/7703c29685631f5a7590aa73f1f1d3fa9a380e654b86af429e0934a32f7d/idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9", size = 190490 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3", size = 70442 },
+]
+
+[[package]]
+name = "markdown-it-py"
+version = "3.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/38/71/3b932df36c1a044d397a1f92d1cf91ee0a503d91e470cbd670aa66b07ed0/markdown-it-py-3.0.0.tar.gz", hash = "sha256:e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb", size = 74596 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/42/d7/1ec15b46af6af88f19b8e5ffea08fa375d433c998b8a7639e76935c14f1f/markdown_it_py-3.0.0-py3-none-any.whl", hash = "sha256:355216845c60bd96232cd8d8c40e8f9765cc86f46880e43a8fd22dc1a1a8cab1", size = 87528 },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979 },
+]
+
+[[package]]
+name = "pygments"
+version = "2.19.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7c/2d/c3338d48ea6cc0feb8446d8e6937e1408088a72a39937982cc6111d17f84/pygments-2.19.1.tar.gz", hash = "sha256:61c16d2a8576dc0649d9f39e089b5f02bcd27fba10d8fb4dcc28173f7a45151f", size = 4968581 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/0b/9fcc47d19c48b59121088dd6da2488a49d5f72dacf8262e2790a1d2c7d15/pygments-2.19.1-py3-none-any.whl", hash = "sha256:9ea1544ad55cecf4b8242fab6dd35a93bbce657034b0611ee383099054ab6d8c", size = 1225293 },
+]
+
+[[package]]
+name = "rich"
+version = "13.9.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ab/3a/0316b28d0761c6734d6bc14e770d85506c986c85ffb239e688eeaab2c2bc/rich-13.9.4.tar.gz", hash = "sha256:439594978a49a09530cff7ebc4b5c7103ef57baf48d5ea3184f21d9a2befa098", size = 223149 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/71/39c7c0d87f8d4e6c020a393182060eaefeeae6c01dab6a84ec346f2567df/rich-13.9.4-py3-none-any.whl", hash = "sha256:6049d5e6ec054bf2779ab3358186963bac2ea89175919d699e378b99738c2a90", size = 242424 },
+]
+
+[[package]]
+name = "sniffio"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235 },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.12.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/db/f35a00659bc03fec321ba8bce9420de607a1d37f8342eee1863174c69557/typing_extensions-4.12.2.tar.gz", hash = "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8", size = 85321 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/26/9f/ad63fc0248c5379346306f8668cda6e2e2e9c95e01216d2b8ffd9ff037d0/typing_extensions-4.12.2-py3-none-any.whl", hash = "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d", size = 37438 },
+]
+
+[[package]]
+name = "watchfiles"
+version = "1.0.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f5/26/c705fc77d0a9ecdb9b66f1e2976d95b81df3cae518967431e7dbf9b5e219/watchfiles-1.0.4.tar.gz", hash = "sha256:6ba473efd11062d73e4f00c2b730255f9c1bdd73cd5f9fe5b5da8dbd4a717205", size = 94625 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0f/bb/8461adc4b1fed009546fb797fc0d5698dcfe5e289cb37e1b8f16a93cdc30/watchfiles-1.0.4-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:2a9f93f8439639dc244c4d2902abe35b0279102bca7bbcf119af964f51d53c19", size = 394869 },
+    { url = "https://files.pythonhosted.org/packages/55/88/9ebf36b3547176d1709c320de78c1fa3263a46be31b5b1267571d9102686/watchfiles-1.0.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:9eea33ad8c418847dd296e61eb683cae1c63329b6d854aefcd412e12d94ee235", size = 384905 },
+    { url = "https://files.pythonhosted.org/packages/03/8a/04335ce23ef78d8c69f0913e8b20cf7d9233e3986543aeef95ef2d6e43d2/watchfiles-1.0.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:31f1a379c9dcbb3f09cf6be1b7e83b67c0e9faabed0471556d9438a4a4e14202", size = 449944 },
+    { url = "https://files.pythonhosted.org/packages/17/4e/c8d5dcd14fe637f4633616dabea8a4af0a10142dccf3b43e0f081ba81ab4/watchfiles-1.0.4-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ab594e75644421ae0a2484554832ca5895f8cab5ab62de30a1a57db460ce06c6", size = 456020 },
+    { url = "https://files.pythonhosted.org/packages/5e/74/3e91e09e1861dd7fbb1190ce7bd786700dc0fbc2ccd33bb9fff5de039229/watchfiles-1.0.4-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:fc2eb5d14a8e0d5df7b36288979176fbb39672d45184fc4b1c004d7c3ce29317", size = 482983 },
+    { url = "https://files.pythonhosted.org/packages/a1/3d/e64de2d1ce4eb6a574fd78ce3a28c279da263be9ef3cfcab6f708df192f2/watchfiles-1.0.4-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3f68d8e9d5a321163ddacebe97091000955a1b74cd43724e346056030b0bacee", size = 520320 },
+    { url = "https://files.pythonhosted.org/packages/2c/bd/52235f7063b57240c66a991696ed27e2a18bd6fcec8a1ea5a040b70d0611/watchfiles-1.0.4-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f9ce064e81fe79faa925ff03b9f4c1a98b0bbb4a1b8c1b015afa93030cb21a49", size = 500988 },
+    { url = "https://files.pythonhosted.org/packages/3a/b0/ff04194141a5fe650c150400dd9e42667916bc0f52426e2e174d779b8a74/watchfiles-1.0.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b77d5622ac5cc91d21ae9c2b284b5d5c51085a0bdb7b518dba263d0af006132c", size = 452573 },
+    { url = "https://files.pythonhosted.org/packages/3d/9d/966164332c5a178444ae6d165082d4f351bd56afd9c3ec828eecbf190e6a/watchfiles-1.0.4-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:1941b4e39de9b38b868a69b911df5e89dc43767feeda667b40ae032522b9b5f1", size = 615114 },
+    { url = "https://files.pythonhosted.org/packages/94/df/f569ae4c1877f96ad4086c153a8eee5a19a3b519487bf5c9454a3438c341/watchfiles-1.0.4-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:4f8c4998506241dedf59613082d1c18b836e26ef2a4caecad0ec41e2a15e4226", size = 613076 },
+    { url = "https://files.pythonhosted.org/packages/15/ae/8ce5f29e65d5fa5790e3c80c289819c55e12be2e1b9f5b6a0e55e169b97d/watchfiles-1.0.4-cp311-cp311-win32.whl", hash = "sha256:4ebbeca9360c830766b9f0df3640b791be569d988f4be6c06d6fae41f187f105", size = 271013 },
+    { url = "https://files.pythonhosted.org/packages/a4/c6/79dc4a7c598a978e5fafa135090aaf7bbb03b8dec7bada437dfbe578e7ed/watchfiles-1.0.4-cp311-cp311-win_amd64.whl", hash = "sha256:05d341c71f3d7098920f8551d4df47f7b57ac5b8dad56558064c3431bdfc0b74", size = 284229 },
+    { url = "https://files.pythonhosted.org/packages/37/3d/928633723211753f3500bfb138434f080363b87a1b08ca188b1ce54d1e05/watchfiles-1.0.4-cp311-cp311-win_arm64.whl", hash = "sha256:32b026a6ab64245b584acf4931fe21842374da82372d5c039cba6bf99ef722f3", size = 276824 },
+    { url = "https://files.pythonhosted.org/packages/5b/1a/8f4d9a1461709756ace48c98f07772bc6d4519b1e48b5fa24a4061216256/watchfiles-1.0.4-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:229e6ec880eca20e0ba2f7e2249c85bae1999d330161f45c78d160832e026ee2", size = 391345 },
+    { url = "https://files.pythonhosted.org/packages/bc/d2/6750b7b3527b1cdaa33731438432e7238a6c6c40a9924049e4cebfa40805/watchfiles-1.0.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:5717021b199e8353782dce03bd8a8f64438832b84e2885c4a645f9723bf656d9", size = 381515 },
+    { url = "https://files.pythonhosted.org/packages/4e/17/80500e42363deef1e4b4818729ed939aaddc56f82f4e72b2508729dd3c6b/watchfiles-1.0.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0799ae68dfa95136dde7c472525700bd48777875a4abb2ee454e3ab18e9fc712", size = 449767 },
+    { url = "https://files.pythonhosted.org/packages/10/37/1427fa4cfa09adbe04b1e97bced19a29a3462cc64c78630787b613a23f18/watchfiles-1.0.4-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:43b168bba889886b62edb0397cab5b6490ffb656ee2fcb22dec8bfeb371a9e12", size = 455677 },
+    { url = "https://files.pythonhosted.org/packages/c5/7a/39e9397f3a19cb549a7d380412fd9e507d4854eddc0700bfad10ef6d4dba/watchfiles-1.0.4-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:fb2c46e275fbb9f0c92e7654b231543c7bbfa1df07cdc4b99fa73bedfde5c844", size = 482219 },
+    { url = "https://files.pythonhosted.org/packages/45/2d/7113931a77e2ea4436cad0c1690c09a40a7f31d366f79c6f0a5bc7a4f6d5/watchfiles-1.0.4-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:857f5fc3aa027ff5e57047da93f96e908a35fe602d24f5e5d8ce64bf1f2fc733", size = 518830 },
+    { url = "https://files.pythonhosted.org/packages/f9/1b/50733b1980fa81ef3c70388a546481ae5fa4c2080040100cd7bf3bf7b321/watchfiles-1.0.4-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:55ccfd27c497b228581e2838d4386301227fc0cb47f5a12923ec2fe4f97b95af", size = 497997 },
+    { url = "https://files.pythonhosted.org/packages/2b/b4/9396cc61b948ef18943e7c85ecfa64cf940c88977d882da57147f62b34b1/watchfiles-1.0.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5c11ea22304d17d4385067588123658e9f23159225a27b983f343fcffc3e796a", size = 452249 },
+    { url = "https://files.pythonhosted.org/packages/fb/69/0c65a5a29e057ad0dc691c2fa6c23b2983c7dabaa190ba553b29ac84c3cc/watchfiles-1.0.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:74cb3ca19a740be4caa18f238298b9d472c850f7b2ed89f396c00a4c97e2d9ff", size = 614412 },
+    { url = "https://files.pythonhosted.org/packages/7f/b9/319fcba6eba5fad34327d7ce16a6b163b39741016b1996f4a3c96b8dd0e1/watchfiles-1.0.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:c7cce76c138a91e720d1df54014a047e680b652336e1b73b8e3ff3158e05061e", size = 611982 },
+    { url = "https://files.pythonhosted.org/packages/f1/47/143c92418e30cb9348a4387bfa149c8e0e404a7c5b0585d46d2f7031b4b9/watchfiles-1.0.4-cp312-cp312-win32.whl", hash = "sha256:b045c800d55bc7e2cadd47f45a97c7b29f70f08a7c2fa13241905010a5493f94", size = 271822 },
+    { url = "https://files.pythonhosted.org/packages/ea/94/b0165481bff99a64b29e46e07ac2e0df9f7a957ef13bec4ceab8515f44e3/watchfiles-1.0.4-cp312-cp312-win_amd64.whl", hash = "sha256:c2acfa49dd0ad0bf2a9c0bb9a985af02e89345a7189be1efc6baa085e0f72d7c", size = 285441 },
+    { url = "https://files.pythonhosted.org/packages/11/de/09fe56317d582742d7ca8c2ca7b52a85927ebb50678d9b0fa8194658f536/watchfiles-1.0.4-cp312-cp312-win_arm64.whl", hash = "sha256:22bb55a7c9e564e763ea06c7acea24fc5d2ee5dfc5dafc5cfbedfe58505e9f90", size = 277141 },
+    { url = "https://files.pythonhosted.org/packages/08/98/f03efabec64b5b1fa58c0daab25c68ef815b0f320e54adcacd0d6847c339/watchfiles-1.0.4-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:8012bd820c380c3d3db8435e8cf7592260257b378b649154a7948a663b5f84e9", size = 390954 },
+    { url = "https://files.pythonhosted.org/packages/16/09/4dd49ba0a32a45813debe5fb3897955541351ee8142f586303b271a02b40/watchfiles-1.0.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:aa216f87594f951c17511efe5912808dfcc4befa464ab17c98d387830ce07b60", size = 381133 },
+    { url = "https://files.pythonhosted.org/packages/76/59/5aa6fc93553cd8d8ee75c6247763d77c02631aed21551a97d94998bf1dae/watchfiles-1.0.4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:62c9953cf85529c05b24705639ffa390f78c26449e15ec34d5339e8108c7c407", size = 449516 },
+    { url = "https://files.pythonhosted.org/packages/4c/aa/df4b6fe14b6317290b91335b23c96b488d365d65549587434817e06895ea/watchfiles-1.0.4-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7cf684aa9bba4cd95ecb62c822a56de54e3ae0598c1a7f2065d51e24637a3c5d", size = 454820 },
+    { url = "https://files.pythonhosted.org/packages/5e/71/185f8672f1094ce48af33252c73e39b48be93b761273872d9312087245f6/watchfiles-1.0.4-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f44a39aee3cbb9b825285ff979ab887a25c5d336e5ec3574f1506a4671556a8d", size = 481550 },
+    { url = "https://files.pythonhosted.org/packages/85/d7/50ebba2c426ef1a5cb17f02158222911a2e005d401caf5d911bfca58f4c4/watchfiles-1.0.4-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a38320582736922be8c865d46520c043bff350956dfc9fbaee3b2df4e1740a4b", size = 518647 },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/4c009342e393c545d68987e8010b937f72f47937731225b2b29b7231428f/watchfiles-1.0.4-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:39f4914548b818540ef21fd22447a63e7be6e24b43a70f7642d21f1e73371590", size = 497547 },
+    { url = "https://files.pythonhosted.org/packages/0f/7c/1cf50b35412d5c72d63b2bf9a4fffee2e1549a245924960dd087eb6a6de4/watchfiles-1.0.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f12969a3765909cf5dc1e50b2436eb2c0e676a3c75773ab8cc3aa6175c16e902", size = 452179 },
+    { url = "https://files.pythonhosted.org/packages/d6/a9/3db1410e1c1413735a9a472380e4f431ad9a9e81711cda2aaf02b7f62693/watchfiles-1.0.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:0986902677a1a5e6212d0c49b319aad9cc48da4bd967f86a11bde96ad9676ca1", size = 614125 },
+    { url = "https://files.pythonhosted.org/packages/f2/e1/0025d365cf6248c4d1ee4c3d2e3d373bdd3f6aff78ba4298f97b4fad2740/watchfiles-1.0.4-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:308ac265c56f936636e3b0e3f59e059a40003c655228c131e1ad439957592303", size = 611911 },
+    { url = "https://files.pythonhosted.org/packages/55/55/035838277d8c98fc8c917ac9beeb0cd6c59d675dc2421df5f9fcf44a0070/watchfiles-1.0.4-cp313-cp313-win32.whl", hash = "sha256:aee397456a29b492c20fda2d8961e1ffb266223625346ace14e4b6d861ba9c80", size = 271152 },
+    { url = "https://files.pythonhosted.org/packages/f0/e5/96b8e55271685ddbadc50ce8bc53aa2dff278fb7ac4c2e473df890def2dc/watchfiles-1.0.4-cp313-cp313-win_amd64.whl", hash = "sha256:d6097538b0ae5c1b88c3b55afa245a66793a8fec7ada6755322e465fb1a0e8cc", size = 285216 },
+]

--- a/crates/red_knot_test/README.md
+++ b/crates/red_knot_test/README.md
@@ -257,6 +257,21 @@ x: int = "foo"  # error: [invalid-assignment]
 ```
 ````
 
+## Running the tests
+
+All Markdown-based tests are executed in a normal `cargo test` / `cargo run nextest` run. If you want to run the Markdown tests
+*only*, you can filter the tests using `mdtest__`:
+
+```bash
+cargo test -p red_knot_python_semantic -- mdtest__
+```
+
+Alternatively, you can use the `mdtest.py` runner which has a watch mode that will re-run corresponding tests when Markdown files change, and recompile automatically when Rust code changes:
+
+```bash
+uv -q run crates/red_knot_python_semantic/mdtest.py
+```
+
 ## Planned features
 
 There are some designed features that we intend for the test framework to have, but have not yet


### PR DESCRIPTION
## Summary

As more and more tests move to Markdown, running the mdtest suite becomes one of the most common tasks for developers working on Red Knot. There are a few pain points when doing so, however:

- The `build.rs` script enforces recompilation (~five seconds) whenever something changes in the `resource/mdtest` folder. This is strictly necessary, because whenever files are added or removed, the test harness needs to be updated. But this is very rarely the case! The most common scenario is that a Markdown file has *changed*, and in this case, no recompilation is necessary. It is currently not possible to distinguish these two cases using `cargo::rerun-if-changed`. One can work around this by running the test executable manually, but it requires finding the path to the correct `mdtest-<random-hash>` executable.
- All Markdown tests are run by default. This is needed whenever Rust code changes, but while working on the tests themselves, it is often much more convenient to only run the tests for a single file. This can be done by using a `mdtest__path_to_file` filter, but this needs to be manually spelled out or copied from the test output.
- `cargo`s test output for a failing Markdown test is often unnecessarily verbose. Unless there is an *actual* panic somewhere in the code, mdtests usually fail with the explicit [*"Some tests failed"* panic](https://github.com/astral-sh/ruff/blob/c616650dfa514c58ac86c5c60648d4d2dcf17d6d/crates/red_knot_test/src/lib.rs#L96) in the mdtest suite. But in those cases, we are not interested in the pointer to the source of this panic, but only in the mdtest suite output.

This PR adds a Markdown test runner tool that attempts to make the developer experience better.

Once it is started using
```bash
uv run -q crates/red_knot_python_semantic/mdtest.py
```
it will first recompile the tests once (if cargo requires it), find the path to the `mdtest` executable, and then enter into a mode where it watches for changes in the `red_knot_python_semantic` crate. Whenever …
* … a Markdown file changes, it will rerun the mdtest for this specific file automatically (no recompilation!). 
* … a Markdown file is added, it will recompile the tests and then run the mdtest for the new file
* … Rust code is changed, it will recompile the tests and run all of them

The tool also trims down `cargo test` output and only shows the actual mdtest errors.

The tool will certainly require a few more iterations before it becomes mature, but I'm curious to hear if there is any interest for something like this.

## Preview

![mdtest](https://github.com/user-attachments/assets/ebdb20a0-c12d-4657-94b1-ac0f38d79fe9)

## Test Plan

- Tested the new runner under various scenarios.