### PR TITLE
[red-knot] Heterogeneous tuple types with differently ordered (but equivalent) unions at the same index should be considered equivalent

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/type_properties/is_equivalent_to.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/type_properties/is_equivalent_to.md
@@ -66,4 +66,22 @@ static_assert(is_equivalent_to(Intersection[Q, R, Not[P]], Intersection[Not[P], 
 static_assert(is_equivalent_to(Intersection[Q | R, Not[P | S]], Intersection[Not[S | P], R | Q]))
 ```
 
+## Tuples containing equivalent but differently ordered unions/intersections are equivalent
+
+```py
+from knot_extensions import is_equivalent_to, TypeOf, static_assert, Intersection, Not
+from typing import Literal
+
+class P: ...
+class Q: ...
+class R: ...
+class S: ...
+
+static_assert(is_equivalent_to(tuple[P | Q], tuple[Q | P]))
+static_assert(is_equivalent_to(tuple[P | None], tuple[None | P]))
+static_assert(
+    is_equivalent_to(tuple[Intersection[P, Q] | Intersection[R, Not[S]]], tuple[Intersection[Not[S], R] | Intersection[Q, P]])
+)
+```
+
 [the equivalence relation]: https://typing.readthedocs.io/en/latest/spec/glossary.html#term-equivalent


### PR DESCRIPTION
## Summary

Fixes https://github.com/astral-sh/ruff/issues/15636.

We considered `int | str` equivalent to `str | int`, but we failed to understand that `tuple[int | str]` was equivalent to `tuple[str | int]`. The property tests caught this, because we _did_ understand that `tuple[int | str]` was _gradually_ equivalent to `tuple[str | int]`, and the property tests realised that there was an internal inconsistency here since `tuple[int | str]` and `tuple[str | int]` are both fully static types.

## Test Plan

- New mdtests added.
- Ran `QUICKCHECK_TESTS=1000000 cargo test --release -p red_knot_python_semantic -- --ignored types::property_tests::stable` without any failures
