### PR TITLE
[`flake8-type-checking`] Fix some safe fixes being labeled unsafe

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_type_checking/TC006.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_type_checking/TC006.py
@@ -80,3 +80,12 @@ def f():
     from typing import cast, Annotated, Literal
 
     cast(list[Annotated["list['Literal[\"A\"]']", "Foo"]], ['A'])
+
+
+def f():
+    from typing import cast
+
+    cast(
+        int  # TC006
+        , 6.0
+    )

--- a/crates/ruff_linter/src/rules/flake8_type_checking/rules/runtime_cast_value.rs
+++ b/crates/ruff_linter/src/rules/flake8_type_checking/rules/runtime_cast_value.rs
@@ -69,10 +69,7 @@ pub(crate) fn runtime_cast_value(checker: &mut Checker, type_expr: &Expr) {
         checker.stylist(),
         checker.locator(),
     );
-    if checker
-        .comment_ranges()
-        .has_comments(type_expr, checker.source())
-    {
+    if checker.comment_ranges().intersects(type_expr.range()) {
         diagnostic.set_fix(Fix::unsafe_edit(edit));
     } else {
         diagnostic.set_fix(Fix::safe_edit(edit));

--- a/crates/ruff_linter/src/rules/flake8_type_checking/rules/type_alias_quotes.rs
+++ b/crates/ruff_linter/src/rules/flake8_type_checking/rules/type_alias_quotes.rs
@@ -289,10 +289,7 @@ pub(crate) fn quoted_type_alias(
     let range = annotation_expr.range();
     let mut diagnostic = Diagnostic::new(QuotedTypeAlias, range);
     let edit = Edit::range_replacement(annotation_expr.value.to_string(), range);
-    if checker
-        .comment_ranges()
-        .has_comments(expr, checker.source())
-    {
+    if checker.comment_ranges().intersects(range) {
         diagnostic.set_fix(Fix::unsafe_edit(edit));
     } else {
         diagnostic.set_fix(Fix::safe_edit(edit));

--- a/crates/ruff_linter/src/rules/flake8_type_checking/snapshots/ruff_linter__rules__flake8_type_checking__tests__runtime-cast-value_TC006.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_type_checking/snapshots/ruff_linter__rules__flake8_type_checking__tests__runtime-cast-value_TC006.py.snap
@@ -190,3 +190,25 @@ TC006.py:82:10: TC006 [*] Add quotes to type expression in `typing.cast()`
 81 81 | 
 82    |-    cast(list[Annotated["list['Literal[\"A\"]']", "Foo"]], ['A'])
    82 |+    cast("list[Annotated[list[Literal['A']], 'Foo']]", ['A'])
+83 83 | 
+84 84 | 
+85 85 | def f():
+
+TC006.py:89:9: TC006 [*] Add quotes to type expression in `typing.cast()`
+   |
+88 |     cast(
+89 |         int  # TC006
+   |         ^^^ TC006
+90 |         , 6.0
+91 |     )
+   |
+   = help: Add quotes
+
+ℹ Safe fix
+86 86 |     from typing import cast
+87 87 | 
+88 88 |     cast(
+89    |-        int  # TC006
+   89 |+        "int"  # TC006
+90 90 |         , 6.0
+91 91 |     )


### PR DESCRIPTION
## Summary

We were mistakenly using `CommentRanges::has_comments` to determine whether our edits
were safe, which sometimes expands the checked range to the end of a line. But in order to
determine safety we need to check exactly the range we're replacing.

This bug affected the rules `runtime-cast-value` (`TC006`) and `quoted-type-alias` (`TC008`)
although it was very unlikely to be hit for `TC006` and for `TC008` we never hit it because we
were checking the wrong expression.

## Test Plan

`cargo nextest run`
