### PR TITLE
[red-knot] Make `Diagnostic::file` optional

### DIFF
--- a/crates/red_knot_project/src/lib.rs
+++ b/crates/red_knot_project/src/lib.rs
@@ -402,8 +402,8 @@ impl Diagnostic for IOErrorDiagnostic {
         self.error.to_string().into()
     }
 
-    fn file(&self) -> File {
-        self.file
+    fn file(&self) -> Option<File> {
+        Some(self.file)
     }
 
     fn range(&self) -> Option<TextRange> {

--- a/crates/red_knot_project/src/metadata/options.rs
+++ b/crates/red_knot_project/src/metadata/options.rs
@@ -5,6 +5,7 @@ use red_knot_python_semantic::{
 use ruff_db::system::{System, SystemPath};
 use ruff_macros::Combine;
 use serde::{Deserialize, Serialize};
+use std::fmt::Debug;
 use thiserror::Error;
 
 /// The options for the project.

--- a/crates/red_knot_python_semantic/src/types/diagnostic.rs
+++ b/crates/red_knot_python_semantic/src/types/diagnostic.rs
@@ -802,8 +802,8 @@ impl Diagnostic for TypeCheckDiagnostic {
         TypeCheckDiagnostic::message(self).into()
     }
 
-    fn file(&self) -> File {
-        TypeCheckDiagnostic::file(self)
+    fn file(&self) -> Option<File> {
+        Some(TypeCheckDiagnostic::file(self))
     }
 
     fn range(&self) -> Option<TextRange> {

--- a/crates/red_knot_server/src/server/api/requests/diagnostic.rs
+++ b/crates/red_knot_server/src/server/api/requests/diagnostic.rs
@@ -75,9 +75,9 @@ fn to_lsp_diagnostic(
     diagnostic: &dyn ruff_db::diagnostic::Diagnostic,
     encoding: crate::PositionEncoding,
 ) -> Diagnostic {
-    let range = if let Some(range) = diagnostic.range() {
-        let index = line_index(db.upcast(), diagnostic.file());
-        let source = source_text(db.upcast(), diagnostic.file());
+    let range = if let (Some(file), Some(range)) = (diagnostic.file(), diagnostic.range()) {
+        let index = line_index(db.upcast(), file);
+        let source = source_text(db.upcast(), file);
 
         range.to_range(&source, &index, encoding)
     } else {

--- a/crates/red_knot_test/src/diagnostic.rs
+++ b/crates/red_knot_test/src/diagnostic.rs
@@ -198,8 +198,8 @@ mod tests {
             "dummy".into()
         }
 
-        fn file(&self) -> File {
-            self.file
+        fn file(&self) -> Option<File> {
+            Some(self.file)
         }
 
         fn range(&self) -> Option<TextRange> {

--- a/crates/red_knot_test/src/matcher.rs
+++ b/crates/red_knot_test/src/matcher.rs
@@ -385,8 +385,8 @@ mod tests {
             self.message.into()
         }
 
-        fn file(&self) -> File {
-            self.file
+        fn file(&self) -> Option<File> {
+            Some(self.file)
         }
 
         fn range(&self) -> Option<TextRange> {

--- a/crates/ruff_db/src/diagnostic.rs
+++ b/crates/ruff_db/src/diagnostic.rs
@@ -152,8 +152,18 @@ pub trait Diagnostic: Send + Sync + std::fmt::Debug {
 
     fn message(&self) -> Cow<str>;
 
+    /// The file this diagnostic is associated with.
+    ///
+    /// File can be `None` for diagnostics that don't originate from a file.
+    /// For example:
+    /// * A diagnostic indicating that a directory couldn't be read.
+    /// * A diagnostic related to a CLI argument
     fn file(&self) -> Option<File>;
 
+    /// The primary range of the diagnostic in `file`.
+    ///
+    /// The range can be `None` if the diagnostic doesn't have a file
+    /// or it applies to the entire file (e.g. the file should be executable but isn't).
     fn range(&self) -> Option<TextRange>;
 
     fn severity(&self) -> Severity;


### PR DESCRIPTION
## Summary

I'm working on adding a rules table to Red Knot's configuration. 
What's special about rules is that we intentionally want to defer validating
the rule names so that we can *warn* about incorrect rule names rather than just abort. 
By warning I mean we'd create a diagnostic. This is a functionality that has been requested for ruff (https://github.com/astral-sh/ruff/issues/14443).

The one problem I ran into when creating the diagnostic is that we don't always 
have a file. For example, the rule could have been enabled on the CLI. 
(actually, I didn't run into this yet but we will once we add `--ignore` and `--error` and `--warn` CLI flags).

This PR makes `file` an `Diagnostic` an `Option` to account for the case where we don't have a file.  Doing so has the disadvantage that it's now technically possible for a diagnostic to have a range but not an associated `File`. I intentionally decided not to design the "perfect" solution because the API is likely to change with @BurntSushi's work
on Diagnostics. 

## Test Plan

`cargo test`
