### PR TITLE
Separate grouped and ungrouped nodes more clearly in AST generator

### DIFF
--- a/crates/ruff_python_ast/generate.py
+++ b/crates/ruff_python_ast/generate.py
@@ -28,15 +28,39 @@ def to_snake_case(node: str) -> str:
 # Read AST description
 
 
-def load_ast(root: Path) -> list[Group]:
+def load_ast(root: Path) -> Ast:
     ast_path = root.joinpath("crates", "ruff_python_ast", "ast.toml")
     with ast_path.open("rb") as ast_file:
         ast = tomllib.load(ast_file)
-    return [Group(group_name, group) for group_name, group in ast.items()]
+    return Ast(ast)
 
 
 # ------------------------------------------------------------------------------
 # Preprocess
+
+
+@dataclass
+class Ast:
+    """
+    The parsed representation of the `ast.toml` file. Defines all of the Python
+    AST syntax nodes, and which groups (`Stmt`, `Expr`, etc.) they belong to.
+    """
+
+    groups: list[Group]
+    ungrouped_nodes: list[Node]
+    all_nodes: list[Node]
+
+    def __init__(self, ast: dict[str, Any]) -> None:
+        self.groups = []
+        self.ungrouped_nodes = []
+        self.all_nodes = []
+        for group_name, group in ast.items():
+            group = Group(group_name, group)
+            self.all_nodes.extend(group.nodes)
+            if group_name == "ungrouped":
+                self.ungrouped_nodes = group.nodes
+            else:
+                self.groups.append(group)
 
 
 @dataclass
@@ -89,7 +113,7 @@ def write_preamble(out: list[str]) -> None:
 # Owned enum
 
 
-def write_owned_enum(out: list[str], groups: list[Group]) -> None:
+def write_owned_enum(out: list[str], ast: Ast) -> None:
     """
     Create an enum for each group that contains an owned copy of a syntax node.
 
@@ -112,10 +136,7 @@ def write_owned_enum(out: list[str], groups: list[Group]) -> None:
     `is_type_var` method will be named `is_type_var_type_param`.
     """
 
-    for group in groups:
-        if group.name == "ungrouped":
-            continue
-
+    for group in ast.groups:
         out.append("")
         if group.rustdoc is not None:
             out.append(group.rustdoc)
@@ -150,19 +171,16 @@ def write_owned_enum(out: list[str], groups: list[Group]) -> None:
         }
         """)
 
-    for group in groups:
-        for node in group.nodes:
-            out.append(f"""
+    for node in ast.all_nodes:
+        out.append(f"""
             impl ruff_text_size::Ranged for {node.ty} {{
                 fn range(&self) -> ruff_text_size::TextRange {{
                     self.range
                 }}
             }}
-            """)
+        """)
 
-    for group in groups:
-        if group.name == "ungrouped":
-            continue
+    for group in ast.groups:
         out.append(f"""
             impl {group.owned_enum_ty} {{
                 #[allow(unused)]
@@ -187,7 +205,7 @@ def write_owned_enum(out: list[str], groups: list[Group]) -> None:
 # Ref enum
 
 
-def write_ref_enum(out: list[str], groups: list[Group]) -> None:
+def write_ref_enum(out: list[str], ast: Ast) -> None:
     """
     Create an enum for each group that contains a reference to a syntax node.
 
@@ -211,10 +229,7 @@ def write_ref_enum(out: list[str], groups: list[Group]) -> None:
     method will be named `is_type_var_type_param`.
     """
 
-    for group in groups:
-        if group.name == "ungrouped":
-            continue
-
+    for group in ast.groups:
         out.append("")
         if group.rustdoc is not None:
             out.append(group.rustdoc)
@@ -269,7 +284,7 @@ def write_ref_enum(out: list[str], groups: list[Group]) -> None:
 # AnyNodeRef
 
 
-def write_anynoderef(out: list[str], groups: list[Group]) -> None:
+def write_anynoderef(out: list[str], ast: Ast) -> None:
     """
     Create the AnyNodeRef type.
 
@@ -295,62 +310,59 @@ def write_anynoderef(out: list[str], groups: list[Group]) -> None:
     #[derive(Copy, Clone, Debug, is_macro::Is, PartialEq)]
     pub enum AnyNodeRef<'a> {
     """)
-    for group in groups:
-        for node in group.nodes:
-            out.append(f"""{node.name}(&'a {node.ty}),""")
+    for node in ast.all_nodes:
+        out.append(f"""{node.name}(&'a {node.ty}),""")
     out.append("""
     }
     """)
 
-    for group in groups:
-        if group.name != "ungrouped":
-            out.append(f"""
+    for group in ast.groups:
+        out.append(f"""
             impl<'a> From<&'a {group.owned_enum_ty}> for AnyNodeRef<'a> {{
                 fn from(node: &'a {group.owned_enum_ty}) -> AnyNodeRef<'a> {{
                     match node {{
-            """)
-            for node in group.nodes:
-                out.append(
-                    f"{group.owned_enum_ty}::{node.variant}(node) => AnyNodeRef::{node.name}(node),"
-                )
-            out.append("""
+        """)
+        for node in group.nodes:
+            out.append(
+                f"{group.owned_enum_ty}::{node.variant}(node) => AnyNodeRef::{node.name}(node),"
+            )
+        out.append("""
                     }
                 }
             }
-            """)
+        """)
 
-            out.append(f"""
+        out.append(f"""
             impl<'a> From<{group.ref_enum_ty}<'a>> for AnyNodeRef<'a> {{
                 fn from(node: {group.ref_enum_ty}<'a>) -> AnyNodeRef<'a> {{
                     match node {{
-            """)
-            for node in group.nodes:
-                out.append(
-                    f"{group.ref_enum_ty}::{node.variant}(node) => AnyNodeRef::{node.name}(node),"
-                )
-            out.append("""
+        """)
+        for node in group.nodes:
+            out.append(
+                f"{group.ref_enum_ty}::{node.variant}(node) => AnyNodeRef::{node.name}(node),"
+            )
+        out.append("""
                     }
                 }
             }
-            """)
+        """)
 
-        for node in group.nodes:
-            out.append(f"""
+    for node in ast.all_nodes:
+        out.append(f"""
             impl<'a> From<&'a {node.ty}> for AnyNodeRef<'a> {{
                 fn from(node: &'a {node.ty}) -> AnyNodeRef<'a> {{
                     AnyNodeRef::{node.name}(node)
                 }}
             }}
-            """)
+        """)
 
     out.append("""
         impl ruff_text_size::Ranged for AnyNodeRef<'_> {
             fn range(&self) -> ruff_text_size::TextRange {
                 match self {
     """)
-    for group in groups:
-        for node in group.nodes:
-            out.append(f"""AnyNodeRef::{node.name}(node) => node.range(),""")
+    for node in ast.all_nodes:
+        out.append(f"""AnyNodeRef::{node.name}(node) => node.range(),""")
     out.append("""
                 }
             }
@@ -362,11 +374,10 @@ def write_anynoderef(out: list[str], groups: list[Group]) -> None:
             pub fn as_ptr(&self) -> std::ptr::NonNull<()> {
                 match self {
     """)
-    for group in groups:
-        for node in group.nodes:
-            out.append(
-                f"AnyNodeRef::{node.name}(node) => std::ptr::NonNull::from(*node).cast(),"
-            )
+    for node in ast.all_nodes:
+        out.append(
+            f"AnyNodeRef::{node.name}(node) => std::ptr::NonNull::from(*node).cast(),"
+        )
     out.append("""
                 }
             }
@@ -382,20 +393,17 @@ def write_anynoderef(out: list[str], groups: list[Group]) -> None:
             {
                 match self {
     """)
-    for group in groups:
-        for node in group.nodes:
-            out.append(
-                f"AnyNodeRef::{node.name}(node) => node.visit_source_order(visitor),"
-            )
+    for node in ast.all_nodes:
+        out.append(
+            f"AnyNodeRef::{node.name}(node) => node.visit_source_order(visitor),"
+        )
     out.append("""
                 }
             }
         }
     """)
 
-    for group in groups:
-        if group.name == "ungrouped":
-            continue
+    for group in ast.groups:
         out.append(f"""
         impl AnyNodeRef<'_> {{
             pub const fn is_{group.anynode_is_label}(self) -> bool {{
@@ -416,7 +424,7 @@ def write_anynoderef(out: list[str], groups: list[Group]) -> None:
 # NodeKind
 
 
-def write_nodekind(out: list[str], groups: list[Group]) -> None:
+def write_nodekind(out: list[str], ast: Ast) -> None:
     """
     Create the NodeKind type.
 
@@ -437,9 +445,8 @@ def write_nodekind(out: list[str], groups: list[Group]) -> None:
     #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
     pub enum NodeKind {
     """)
-    for group in groups:
-        for node in group.nodes:
-            out.append(f"""{node.name},""")
+    for node in ast.all_nodes:
+        out.append(f"""{node.name},""")
     out.append("""
     }
     """)
@@ -449,9 +456,8 @@ def write_nodekind(out: list[str], groups: list[Group]) -> None:
         pub const fn kind(self) -> NodeKind {
             match self {
     """)
-    for group in groups:
-        for node in group.nodes:
-            out.append(f"""AnyNodeRef::{node.name}(_) => NodeKind::{node.name},""")
+    for node in ast.all_nodes:
+        out.append(f"""AnyNodeRef::{node.name}(_) => NodeKind::{node.name},""")
     out.append("""
             }
         }
@@ -463,13 +469,13 @@ def write_nodekind(out: list[str], groups: list[Group]) -> None:
 # Format and write output
 
 
-def generate(groups: list[Group]) -> list[str]:
+def generate(ast: Ast) -> list[str]:
     out = []
     write_preamble(out)
-    write_owned_enum(out, groups)
-    write_ref_enum(out, groups)
-    write_anynoderef(out, groups)
-    write_nodekind(out, groups)
+    write_owned_enum(out, ast)
+    write_ref_enum(out, ast)
+    write_anynoderef(out, ast)
+    write_nodekind(out, ast)
     return out
 
 
@@ -486,8 +492,8 @@ def main() -> None:
     root = Path(
         check_output(["git", "rev-parse", "--show-toplevel"], text=True).strip()
     )
-    groups = load_ast(root)
-    out = generate(groups)
+    ast = load_ast(root)
+    out = generate(ast)
     write_output(root, out)
 
 

--- a/crates/ruff_python_ast/src/generated.rs
+++ b/crates/ruff_python_ast/src/generated.rs
@@ -2387,18 +2387,6 @@ impl<'a> From<ModRef<'a>> for AnyNodeRef<'a> {
     }
 }
 
-impl<'a> From<&'a crate::ModModule> for AnyNodeRef<'a> {
-    fn from(node: &'a crate::ModModule) -> AnyNodeRef<'a> {
-        AnyNodeRef::ModModule(node)
-    }
-}
-
-impl<'a> From<&'a crate::ModExpression> for AnyNodeRef<'a> {
-    fn from(node: &'a crate::ModExpression) -> AnyNodeRef<'a> {
-        AnyNodeRef::ModExpression(node)
-    }
-}
-
 impl<'a> From<&'a Stmt> for AnyNodeRef<'a> {
     fn from(node: &'a Stmt) -> AnyNodeRef<'a> {
         match node {
@@ -2460,6 +2448,180 @@ impl<'a> From<StatementRef<'a>> for AnyNodeRef<'a> {
             StatementRef::Continue(node) => AnyNodeRef::StmtContinue(node),
             StatementRef::IpyEscapeCommand(node) => AnyNodeRef::StmtIpyEscapeCommand(node),
         }
+    }
+}
+
+impl<'a> From<&'a Expr> for AnyNodeRef<'a> {
+    fn from(node: &'a Expr) -> AnyNodeRef<'a> {
+        match node {
+            Expr::BoolOp(node) => AnyNodeRef::ExprBoolOp(node),
+            Expr::Named(node) => AnyNodeRef::ExprNamed(node),
+            Expr::BinOp(node) => AnyNodeRef::ExprBinOp(node),
+            Expr::UnaryOp(node) => AnyNodeRef::ExprUnaryOp(node),
+            Expr::Lambda(node) => AnyNodeRef::ExprLambda(node),
+            Expr::If(node) => AnyNodeRef::ExprIf(node),
+            Expr::Dict(node) => AnyNodeRef::ExprDict(node),
+            Expr::Set(node) => AnyNodeRef::ExprSet(node),
+            Expr::ListComp(node) => AnyNodeRef::ExprListComp(node),
+            Expr::SetComp(node) => AnyNodeRef::ExprSetComp(node),
+            Expr::DictComp(node) => AnyNodeRef::ExprDictComp(node),
+            Expr::Generator(node) => AnyNodeRef::ExprGenerator(node),
+            Expr::Await(node) => AnyNodeRef::ExprAwait(node),
+            Expr::Yield(node) => AnyNodeRef::ExprYield(node),
+            Expr::YieldFrom(node) => AnyNodeRef::ExprYieldFrom(node),
+            Expr::Compare(node) => AnyNodeRef::ExprCompare(node),
+            Expr::Call(node) => AnyNodeRef::ExprCall(node),
+            Expr::FString(node) => AnyNodeRef::ExprFString(node),
+            Expr::StringLiteral(node) => AnyNodeRef::ExprStringLiteral(node),
+            Expr::BytesLiteral(node) => AnyNodeRef::ExprBytesLiteral(node),
+            Expr::NumberLiteral(node) => AnyNodeRef::ExprNumberLiteral(node),
+            Expr::BooleanLiteral(node) => AnyNodeRef::ExprBooleanLiteral(node),
+            Expr::NoneLiteral(node) => AnyNodeRef::ExprNoneLiteral(node),
+            Expr::EllipsisLiteral(node) => AnyNodeRef::ExprEllipsisLiteral(node),
+            Expr::Attribute(node) => AnyNodeRef::ExprAttribute(node),
+            Expr::Subscript(node) => AnyNodeRef::ExprSubscript(node),
+            Expr::Starred(node) => AnyNodeRef::ExprStarred(node),
+            Expr::Name(node) => AnyNodeRef::ExprName(node),
+            Expr::List(node) => AnyNodeRef::ExprList(node),
+            Expr::Tuple(node) => AnyNodeRef::ExprTuple(node),
+            Expr::Slice(node) => AnyNodeRef::ExprSlice(node),
+            Expr::IpyEscapeCommand(node) => AnyNodeRef::ExprIpyEscapeCommand(node),
+        }
+    }
+}
+
+impl<'a> From<ExpressionRef<'a>> for AnyNodeRef<'a> {
+    fn from(node: ExpressionRef<'a>) -> AnyNodeRef<'a> {
+        match node {
+            ExpressionRef::BoolOp(node) => AnyNodeRef::ExprBoolOp(node),
+            ExpressionRef::Named(node) => AnyNodeRef::ExprNamed(node),
+            ExpressionRef::BinOp(node) => AnyNodeRef::ExprBinOp(node),
+            ExpressionRef::UnaryOp(node) => AnyNodeRef::ExprUnaryOp(node),
+            ExpressionRef::Lambda(node) => AnyNodeRef::ExprLambda(node),
+            ExpressionRef::If(node) => AnyNodeRef::ExprIf(node),
+            ExpressionRef::Dict(node) => AnyNodeRef::ExprDict(node),
+            ExpressionRef::Set(node) => AnyNodeRef::ExprSet(node),
+            ExpressionRef::ListComp(node) => AnyNodeRef::ExprListComp(node),
+            ExpressionRef::SetComp(node) => AnyNodeRef::ExprSetComp(node),
+            ExpressionRef::DictComp(node) => AnyNodeRef::ExprDictComp(node),
+            ExpressionRef::Generator(node) => AnyNodeRef::ExprGenerator(node),
+            ExpressionRef::Await(node) => AnyNodeRef::ExprAwait(node),
+            ExpressionRef::Yield(node) => AnyNodeRef::ExprYield(node),
+            ExpressionRef::YieldFrom(node) => AnyNodeRef::ExprYieldFrom(node),
+            ExpressionRef::Compare(node) => AnyNodeRef::ExprCompare(node),
+            ExpressionRef::Call(node) => AnyNodeRef::ExprCall(node),
+            ExpressionRef::FString(node) => AnyNodeRef::ExprFString(node),
+            ExpressionRef::StringLiteral(node) => AnyNodeRef::ExprStringLiteral(node),
+            ExpressionRef::BytesLiteral(node) => AnyNodeRef::ExprBytesLiteral(node),
+            ExpressionRef::NumberLiteral(node) => AnyNodeRef::ExprNumberLiteral(node),
+            ExpressionRef::BooleanLiteral(node) => AnyNodeRef::ExprBooleanLiteral(node),
+            ExpressionRef::NoneLiteral(node) => AnyNodeRef::ExprNoneLiteral(node),
+            ExpressionRef::EllipsisLiteral(node) => AnyNodeRef::ExprEllipsisLiteral(node),
+            ExpressionRef::Attribute(node) => AnyNodeRef::ExprAttribute(node),
+            ExpressionRef::Subscript(node) => AnyNodeRef::ExprSubscript(node),
+            ExpressionRef::Starred(node) => AnyNodeRef::ExprStarred(node),
+            ExpressionRef::Name(node) => AnyNodeRef::ExprName(node),
+            ExpressionRef::List(node) => AnyNodeRef::ExprList(node),
+            ExpressionRef::Tuple(node) => AnyNodeRef::ExprTuple(node),
+            ExpressionRef::Slice(node) => AnyNodeRef::ExprSlice(node),
+            ExpressionRef::IpyEscapeCommand(node) => AnyNodeRef::ExprIpyEscapeCommand(node),
+        }
+    }
+}
+
+impl<'a> From<&'a ExceptHandler> for AnyNodeRef<'a> {
+    fn from(node: &'a ExceptHandler) -> AnyNodeRef<'a> {
+        match node {
+            ExceptHandler::ExceptHandler(node) => AnyNodeRef::ExceptHandlerExceptHandler(node),
+        }
+    }
+}
+
+impl<'a> From<ExceptHandlerRef<'a>> for AnyNodeRef<'a> {
+    fn from(node: ExceptHandlerRef<'a>) -> AnyNodeRef<'a> {
+        match node {
+            ExceptHandlerRef::ExceptHandler(node) => AnyNodeRef::ExceptHandlerExceptHandler(node),
+        }
+    }
+}
+
+impl<'a> From<&'a FStringElement> for AnyNodeRef<'a> {
+    fn from(node: &'a FStringElement) -> AnyNodeRef<'a> {
+        match node {
+            FStringElement::Expression(node) => AnyNodeRef::FStringExpressionElement(node),
+            FStringElement::Literal(node) => AnyNodeRef::FStringLiteralElement(node),
+        }
+    }
+}
+
+impl<'a> From<FStringElementRef<'a>> for AnyNodeRef<'a> {
+    fn from(node: FStringElementRef<'a>) -> AnyNodeRef<'a> {
+        match node {
+            FStringElementRef::Expression(node) => AnyNodeRef::FStringExpressionElement(node),
+            FStringElementRef::Literal(node) => AnyNodeRef::FStringLiteralElement(node),
+        }
+    }
+}
+
+impl<'a> From<&'a Pattern> for AnyNodeRef<'a> {
+    fn from(node: &'a Pattern) -> AnyNodeRef<'a> {
+        match node {
+            Pattern::MatchValue(node) => AnyNodeRef::PatternMatchValue(node),
+            Pattern::MatchSingleton(node) => AnyNodeRef::PatternMatchSingleton(node),
+            Pattern::MatchSequence(node) => AnyNodeRef::PatternMatchSequence(node),
+            Pattern::MatchMapping(node) => AnyNodeRef::PatternMatchMapping(node),
+            Pattern::MatchClass(node) => AnyNodeRef::PatternMatchClass(node),
+            Pattern::MatchStar(node) => AnyNodeRef::PatternMatchStar(node),
+            Pattern::MatchAs(node) => AnyNodeRef::PatternMatchAs(node),
+            Pattern::MatchOr(node) => AnyNodeRef::PatternMatchOr(node),
+        }
+    }
+}
+
+impl<'a> From<PatternRef<'a>> for AnyNodeRef<'a> {
+    fn from(node: PatternRef<'a>) -> AnyNodeRef<'a> {
+        match node {
+            PatternRef::MatchValue(node) => AnyNodeRef::PatternMatchValue(node),
+            PatternRef::MatchSingleton(node) => AnyNodeRef::PatternMatchSingleton(node),
+            PatternRef::MatchSequence(node) => AnyNodeRef::PatternMatchSequence(node),
+            PatternRef::MatchMapping(node) => AnyNodeRef::PatternMatchMapping(node),
+            PatternRef::MatchClass(node) => AnyNodeRef::PatternMatchClass(node),
+            PatternRef::MatchStar(node) => AnyNodeRef::PatternMatchStar(node),
+            PatternRef::MatchAs(node) => AnyNodeRef::PatternMatchAs(node),
+            PatternRef::MatchOr(node) => AnyNodeRef::PatternMatchOr(node),
+        }
+    }
+}
+
+impl<'a> From<&'a TypeParam> for AnyNodeRef<'a> {
+    fn from(node: &'a TypeParam) -> AnyNodeRef<'a> {
+        match node {
+            TypeParam::TypeVar(node) => AnyNodeRef::TypeParamTypeVar(node),
+            TypeParam::TypeVarTuple(node) => AnyNodeRef::TypeParamTypeVarTuple(node),
+            TypeParam::ParamSpec(node) => AnyNodeRef::TypeParamParamSpec(node),
+        }
+    }
+}
+
+impl<'a> From<TypeParamRef<'a>> for AnyNodeRef<'a> {
+    fn from(node: TypeParamRef<'a>) -> AnyNodeRef<'a> {
+        match node {
+            TypeParamRef::TypeVar(node) => AnyNodeRef::TypeParamTypeVar(node),
+            TypeParamRef::TypeVarTuple(node) => AnyNodeRef::TypeParamTypeVarTuple(node),
+            TypeParamRef::ParamSpec(node) => AnyNodeRef::TypeParamParamSpec(node),
+        }
+    }
+}
+
+impl<'a> From<&'a crate::ModModule> for AnyNodeRef<'a> {
+    fn from(node: &'a crate::ModModule) -> AnyNodeRef<'a> {
+        AnyNodeRef::ModModule(node)
+    }
+}
+
+impl<'a> From<&'a crate::ModExpression> for AnyNodeRef<'a> {
+    fn from(node: &'a crate::ModExpression) -> AnyNodeRef<'a> {
+        AnyNodeRef::ModExpression(node)
     }
 }
 
@@ -2610,84 +2772,6 @@ impl<'a> From<&'a crate::StmtContinue> for AnyNodeRef<'a> {
 impl<'a> From<&'a crate::StmtIpyEscapeCommand> for AnyNodeRef<'a> {
     fn from(node: &'a crate::StmtIpyEscapeCommand) -> AnyNodeRef<'a> {
         AnyNodeRef::StmtIpyEscapeCommand(node)
-    }
-}
-
-impl<'a> From<&'a Expr> for AnyNodeRef<'a> {
-    fn from(node: &'a Expr) -> AnyNodeRef<'a> {
-        match node {
-            Expr::BoolOp(node) => AnyNodeRef::ExprBoolOp(node),
-            Expr::Named(node) => AnyNodeRef::ExprNamed(node),
-            Expr::BinOp(node) => AnyNodeRef::ExprBinOp(node),
-            Expr::UnaryOp(node) => AnyNodeRef::ExprUnaryOp(node),
-            Expr::Lambda(node) => AnyNodeRef::ExprLambda(node),
-            Expr::If(node) => AnyNodeRef::ExprIf(node),
-            Expr::Dict(node) => AnyNodeRef::ExprDict(node),
-            Expr::Set(node) => AnyNodeRef::ExprSet(node),
-            Expr::ListComp(node) => AnyNodeRef::ExprListComp(node),
-            Expr::SetComp(node) => AnyNodeRef::ExprSetComp(node),
-            Expr::DictComp(node) => AnyNodeRef::ExprDictComp(node),
-            Expr::Generator(node) => AnyNodeRef::ExprGenerator(node),
-            Expr::Await(node) => AnyNodeRef::ExprAwait(node),
-            Expr::Yield(node) => AnyNodeRef::ExprYield(node),
-            Expr::YieldFrom(node) => AnyNodeRef::ExprYieldFrom(node),
-            Expr::Compare(node) => AnyNodeRef::ExprCompare(node),
-            Expr::Call(node) => AnyNodeRef::ExprCall(node),
-            Expr::FString(node) => AnyNodeRef::ExprFString(node),
-            Expr::StringLiteral(node) => AnyNodeRef::ExprStringLiteral(node),
-            Expr::BytesLiteral(node) => AnyNodeRef::ExprBytesLiteral(node),
-            Expr::NumberLiteral(node) => AnyNodeRef::ExprNumberLiteral(node),
-            Expr::BooleanLiteral(node) => AnyNodeRef::ExprBooleanLiteral(node),
-            Expr::NoneLiteral(node) => AnyNodeRef::ExprNoneLiteral(node),
-            Expr::EllipsisLiteral(node) => AnyNodeRef::ExprEllipsisLiteral(node),
-            Expr::Attribute(node) => AnyNodeRef::ExprAttribute(node),
-            Expr::Subscript(node) => AnyNodeRef::ExprSubscript(node),
-            Expr::Starred(node) => AnyNodeRef::ExprStarred(node),
-            Expr::Name(node) => AnyNodeRef::ExprName(node),
-            Expr::List(node) => AnyNodeRef::ExprList(node),
-            Expr::Tuple(node) => AnyNodeRef::ExprTuple(node),
-            Expr::Slice(node) => AnyNodeRef::ExprSlice(node),
-            Expr::IpyEscapeCommand(node) => AnyNodeRef::ExprIpyEscapeCommand(node),
-        }
-    }
-}
-
-impl<'a> From<ExpressionRef<'a>> for AnyNodeRef<'a> {
-    fn from(node: ExpressionRef<'a>) -> AnyNodeRef<'a> {
-        match node {
-            ExpressionRef::BoolOp(node) => AnyNodeRef::ExprBoolOp(node),
-            ExpressionRef::Named(node) => AnyNodeRef::ExprNamed(node),
-            ExpressionRef::BinOp(node) => AnyNodeRef::ExprBinOp(node),
-            ExpressionRef::UnaryOp(node) => AnyNodeRef::ExprUnaryOp(node),
-            ExpressionRef::Lambda(node) => AnyNodeRef::ExprLambda(node),
-            ExpressionRef::If(node) => AnyNodeRef::ExprIf(node),
-            ExpressionRef::Dict(node) => AnyNodeRef::ExprDict(node),
-            ExpressionRef::Set(node) => AnyNodeRef::ExprSet(node),
-            ExpressionRef::ListComp(node) => AnyNodeRef::ExprListComp(node),
-            ExpressionRef::SetComp(node) => AnyNodeRef::ExprSetComp(node),
-            ExpressionRef::DictComp(node) => AnyNodeRef::ExprDictComp(node),
-            ExpressionRef::Generator(node) => AnyNodeRef::ExprGenerator(node),
-            ExpressionRef::Await(node) => AnyNodeRef::ExprAwait(node),
-            ExpressionRef::Yield(node) => AnyNodeRef::ExprYield(node),
-            ExpressionRef::YieldFrom(node) => AnyNodeRef::ExprYieldFrom(node),
-            ExpressionRef::Compare(node) => AnyNodeRef::ExprCompare(node),
-            ExpressionRef::Call(node) => AnyNodeRef::ExprCall(node),
-            ExpressionRef::FString(node) => AnyNodeRef::ExprFString(node),
-            ExpressionRef::StringLiteral(node) => AnyNodeRef::ExprStringLiteral(node),
-            ExpressionRef::BytesLiteral(node) => AnyNodeRef::ExprBytesLiteral(node),
-            ExpressionRef::NumberLiteral(node) => AnyNodeRef::ExprNumberLiteral(node),
-            ExpressionRef::BooleanLiteral(node) => AnyNodeRef::ExprBooleanLiteral(node),
-            ExpressionRef::NoneLiteral(node) => AnyNodeRef::ExprNoneLiteral(node),
-            ExpressionRef::EllipsisLiteral(node) => AnyNodeRef::ExprEllipsisLiteral(node),
-            ExpressionRef::Attribute(node) => AnyNodeRef::ExprAttribute(node),
-            ExpressionRef::Subscript(node) => AnyNodeRef::ExprSubscript(node),
-            ExpressionRef::Starred(node) => AnyNodeRef::ExprStarred(node),
-            ExpressionRef::Name(node) => AnyNodeRef::ExprName(node),
-            ExpressionRef::List(node) => AnyNodeRef::ExprList(node),
-            ExpressionRef::Tuple(node) => AnyNodeRef::ExprTuple(node),
-            ExpressionRef::Slice(node) => AnyNodeRef::ExprSlice(node),
-            ExpressionRef::IpyEscapeCommand(node) => AnyNodeRef::ExprIpyEscapeCommand(node),
-        }
     }
 }
 
@@ -2883,43 +2967,9 @@ impl<'a> From<&'a crate::ExprIpyEscapeCommand> for AnyNodeRef<'a> {
     }
 }
 
-impl<'a> From<&'a ExceptHandler> for AnyNodeRef<'a> {
-    fn from(node: &'a ExceptHandler) -> AnyNodeRef<'a> {
-        match node {
-            ExceptHandler::ExceptHandler(node) => AnyNodeRef::ExceptHandlerExceptHandler(node),
-        }
-    }
-}
-
-impl<'a> From<ExceptHandlerRef<'a>> for AnyNodeRef<'a> {
-    fn from(node: ExceptHandlerRef<'a>) -> AnyNodeRef<'a> {
-        match node {
-            ExceptHandlerRef::ExceptHandler(node) => AnyNodeRef::ExceptHandlerExceptHandler(node),
-        }
-    }
-}
-
 impl<'a> From<&'a crate::ExceptHandlerExceptHandler> for AnyNodeRef<'a> {
     fn from(node: &'a crate::ExceptHandlerExceptHandler) -> AnyNodeRef<'a> {
         AnyNodeRef::ExceptHandlerExceptHandler(node)
-    }
-}
-
-impl<'a> From<&'a FStringElement> for AnyNodeRef<'a> {
-    fn from(node: &'a FStringElement) -> AnyNodeRef<'a> {
-        match node {
-            FStringElement::Expression(node) => AnyNodeRef::FStringExpressionElement(node),
-            FStringElement::Literal(node) => AnyNodeRef::FStringLiteralElement(node),
-        }
-    }
-}
-
-impl<'a> From<FStringElementRef<'a>> for AnyNodeRef<'a> {
-    fn from(node: FStringElementRef<'a>) -> AnyNodeRef<'a> {
-        match node {
-            FStringElementRef::Expression(node) => AnyNodeRef::FStringExpressionElement(node),
-            FStringElementRef::Literal(node) => AnyNodeRef::FStringLiteralElement(node),
-        }
     }
 }
 
@@ -2932,36 +2982,6 @@ impl<'a> From<&'a crate::FStringExpressionElement> for AnyNodeRef<'a> {
 impl<'a> From<&'a crate::FStringLiteralElement> for AnyNodeRef<'a> {
     fn from(node: &'a crate::FStringLiteralElement) -> AnyNodeRef<'a> {
         AnyNodeRef::FStringLiteralElement(node)
-    }
-}
-
-impl<'a> From<&'a Pattern> for AnyNodeRef<'a> {
-    fn from(node: &'a Pattern) -> AnyNodeRef<'a> {
-        match node {
-            Pattern::MatchValue(node) => AnyNodeRef::PatternMatchValue(node),
-            Pattern::MatchSingleton(node) => AnyNodeRef::PatternMatchSingleton(node),
-            Pattern::MatchSequence(node) => AnyNodeRef::PatternMatchSequence(node),
-            Pattern::MatchMapping(node) => AnyNodeRef::PatternMatchMapping(node),
-            Pattern::MatchClass(node) => AnyNodeRef::PatternMatchClass(node),
-            Pattern::MatchStar(node) => AnyNodeRef::PatternMatchStar(node),
-            Pattern::MatchAs(node) => AnyNodeRef::PatternMatchAs(node),
-            Pattern::MatchOr(node) => AnyNodeRef::PatternMatchOr(node),
-        }
-    }
-}
-
-impl<'a> From<PatternRef<'a>> for AnyNodeRef<'a> {
-    fn from(node: PatternRef<'a>) -> AnyNodeRef<'a> {
-        match node {
-            PatternRef::MatchValue(node) => AnyNodeRef::PatternMatchValue(node),
-            PatternRef::MatchSingleton(node) => AnyNodeRef::PatternMatchSingleton(node),
-            PatternRef::MatchSequence(node) => AnyNodeRef::PatternMatchSequence(node),
-            PatternRef::MatchMapping(node) => AnyNodeRef::PatternMatchMapping(node),
-            PatternRef::MatchClass(node) => AnyNodeRef::PatternMatchClass(node),
-            PatternRef::MatchStar(node) => AnyNodeRef::PatternMatchStar(node),
-            PatternRef::MatchAs(node) => AnyNodeRef::PatternMatchAs(node),
-            PatternRef::MatchOr(node) => AnyNodeRef::PatternMatchOr(node),
-        }
     }
 }
 
@@ -3010,26 +3030,6 @@ impl<'a> From<&'a crate::PatternMatchAs> for AnyNodeRef<'a> {
 impl<'a> From<&'a crate::PatternMatchOr> for AnyNodeRef<'a> {
     fn from(node: &'a crate::PatternMatchOr) -> AnyNodeRef<'a> {
         AnyNodeRef::PatternMatchOr(node)
-    }
-}
-
-impl<'a> From<&'a TypeParam> for AnyNodeRef<'a> {
-    fn from(node: &'a TypeParam) -> AnyNodeRef<'a> {
-        match node {
-            TypeParam::TypeVar(node) => AnyNodeRef::TypeParamTypeVar(node),
-            TypeParam::TypeVarTuple(node) => AnyNodeRef::TypeParamTypeVarTuple(node),
-            TypeParam::ParamSpec(node) => AnyNodeRef::TypeParamParamSpec(node),
-        }
-    }
-}
-
-impl<'a> From<TypeParamRef<'a>> for AnyNodeRef<'a> {
-    fn from(node: TypeParamRef<'a>) -> AnyNodeRef<'a> {
-        match node {
-            TypeParamRef::TypeVar(node) => AnyNodeRef::TypeParamTypeVar(node),
-            TypeParamRef::TypeVarTuple(node) => AnyNodeRef::TypeParamTypeVarTuple(node),
-            TypeParamRef::ParamSpec(node) => AnyNodeRef::TypeParamParamSpec(node),
-        }
     }
 }
 


### PR DESCRIPTION
This is a minor cleanup to the AST generation script to make a clearer separation between nodes that do appear in a group enum, and those that don't.  There are some types and methods that we create for every syntax node, and others that refer to the group that the syntax node belongs to, and which therefore don't make sense for ungrouped nodes. This new separation makes it clearer which category each definition is in, since you're either inside of a `for group in ast.groups` loop, or a `for node in ast.all_nodes` loop.

