### PR TITLE
Remove customizable reference enum names

### DIFF
--- a/crates/red_knot_python_semantic/src/semantic_index/ast_ids.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/ast_ids.rs
@@ -2,7 +2,7 @@ use rustc_hash::FxHashMap;
 
 use ruff_index::newtype_index;
 use ruff_python_ast as ast;
-use ruff_python_ast::ExpressionRef;
+use ruff_python_ast::ExprRef;
 
 use crate::semantic_index::ast_ids::node_key::ExpressionNodeKey;
 use crate::semantic_index::semantic_index;
@@ -60,12 +60,12 @@ pub trait HasScopedUseId {
 
 impl HasScopedUseId for ast::ExprName {
     fn scoped_use_id(&self, db: &dyn Db, scope: ScopeId) -> ScopedUseId {
-        let expression_ref = ExpressionRef::from(self);
+        let expression_ref = ExprRef::from(self);
         expression_ref.scoped_use_id(db, scope)
     }
 }
 
-impl HasScopedUseId for ast::ExpressionRef<'_> {
+impl HasScopedUseId for ast::ExprRef<'_> {
     fn scoped_use_id(&self, db: &dyn Db, scope: ScopeId) -> ScopedUseId {
         let ast_ids = ast_ids(db, scope);
         ast_ids.use_id(*self)
@@ -91,7 +91,7 @@ macro_rules! impl_has_scoped_expression_id {
     ($ty: ty) => {
         impl HasScopedExpressionId for $ty {
             fn scoped_expression_id(&self, db: &dyn Db, scope: ScopeId) -> ScopedExpressionId {
-                let expression_ref = ExpressionRef::from(self);
+                let expression_ref = ExprRef::from(self);
                 expression_ref.scoped_expression_id(db, scope)
             }
         }
@@ -132,7 +132,7 @@ impl_has_scoped_expression_id!(ast::ExprSlice);
 impl_has_scoped_expression_id!(ast::ExprIpyEscapeCommand);
 impl_has_scoped_expression_id!(ast::Expr);
 
-impl HasScopedExpressionId for ast::ExpressionRef<'_> {
+impl HasScopedExpressionId for ast::ExprRef<'_> {
     fn scoped_expression_id(&self, db: &dyn Db, scope: ScopeId) -> ScopedExpressionId {
         let ast_ids = ast_ids(db, scope);
         ast_ids.expression_id(*self)
@@ -184,8 +184,8 @@ pub(crate) mod node_key {
     #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
     pub(crate) struct ExpressionNodeKey(NodeKey);
 
-    impl From<ast::ExpressionRef<'_>> for ExpressionNodeKey {
-        fn from(value: ast::ExpressionRef<'_>) -> Self {
+    impl From<ast::ExprRef<'_>> for ExpressionNodeKey {
+        fn from(value: ast::ExprRef<'_>) -> Self {
             Self(NodeKey::from_node(value))
         }
     }

--- a/crates/red_knot_python_semantic/src/semantic_model.rs
+++ b/crates/red_knot_python_semantic/src/semantic_model.rs
@@ -1,7 +1,7 @@
 use ruff_db::files::{File, FilePath};
 use ruff_db::source::line_index;
 use ruff_python_ast as ast;
-use ruff_python_ast::{Expr, ExpressionRef};
+use ruff_python_ast::{Expr, ExprRef};
 use ruff_source_file::LineIndex;
 
 use crate::module_name::ModuleName;
@@ -48,7 +48,7 @@ pub trait HasTy {
     fn ty<'db>(&self, model: &SemanticModel<'db>) -> Type<'db>;
 }
 
-impl HasTy for ast::ExpressionRef<'_> {
+impl HasTy for ast::ExprRef<'_> {
     fn ty<'db>(&self, model: &SemanticModel<'db>) -> Type<'db> {
         let index = semantic_index(model.db, model.file);
         let file_scope = index.expression_scope_id(*self);
@@ -64,7 +64,7 @@ macro_rules! impl_expression_has_ty {
         impl HasTy for $ty {
             #[inline]
             fn ty<'db>(&self, model: &SemanticModel<'db>) -> Type<'db> {
-                let expression_ref = ExpressionRef::from(self);
+                let expression_ref = ExprRef::from(self);
                 expression_ref.ty(model)
             }
         }

--- a/crates/ruff_linter/src/rules/pylint/rules/non_augmented_assignment.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/non_augmented_assignment.rs
@@ -4,7 +4,7 @@ use ruff_macros::{derive_message_formats, ViolationMetadata};
 use ruff_python_ast as ast;
 use ruff_python_ast::comparable::ComparableExpr;
 use ruff_python_ast::parenthesize::parenthesized_range;
-use ruff_python_ast::{ExprBinOp, ExpressionRef, Operator};
+use ruff_python_ast::{ExprBinOp, ExprRef, Operator};
 use ruff_text_size::{Ranged, TextRange};
 
 use crate::checkers::ast::Checker;
@@ -146,7 +146,7 @@ fn augmented_assignment(
 ) -> Edit {
     let locator = checker.locator();
 
-    let right_operand_ref = ExpressionRef::from(right_operand);
+    let right_operand_ref = ExprRef::from(right_operand);
     let parent = original_expr.into();
     let comment_ranges = checker.comment_ranges();
     let source = checker.source();

--- a/crates/ruff_python_ast/ast.toml
+++ b/crates/ruff_python_ast/ast.toml
@@ -26,10 +26,6 @@
 #   Controls the name of the AnyNodeRef::is_foo_bar method.  The default is the
 #   group name in snake_case.
 #
-# ref_enum_ty:
-#   The name of the reference enum that we create for this group.  The default
-#   is the group name with `Ref` added to the end.
-#
 # rustdoc:
 #   A rustdoc comment that is added to the group's enums.
 #
@@ -51,7 +47,6 @@ ModExpression = {}
 add_suffix_to_is_methods = true
 anynode_is_label = "statement"
 rustdoc = "/// See also [stmt](https://docs.python.org/3/library/ast.html#ast.stmt)"
-ref_enum_ty = "StatementRef"
 
 [Stmt.nodes]
 StmtFunctionDef = {}
@@ -84,7 +79,6 @@ StmtIpyEscapeCommand = {}
 add_suffix_to_is_methods = true
 anynode_is_label = "expression"
 rustdoc = "/// See also [expr](https://docs.python.org/3/library/ast.html#ast.expr)"
-ref_enum_ty = "ExpressionRef"
 
 [Expr.nodes]
 ExprBoolOp = {}

--- a/crates/ruff_python_ast/generate.py
+++ b/crates/ruff_python_ast/generate.py
@@ -44,7 +44,6 @@ class Group:
     name: str
     nodes: list[Node]
     owned_enum_ty: str
-    ref_enum_ty: str
 
     add_suffix_to_is_methods: bool
     anynode_is_label: str
@@ -53,7 +52,7 @@ class Group:
     def __init__(self, group_name: str, group: dict[str, Any]) -> None:
         self.name = group_name
         self.owned_enum_ty = group_name
-        self.ref_enum_ty = group.get("ref_enum_ty", group_name + "Ref")
+        self.ref_enum_ty = group_name + "Ref"
         self.add_suffix_to_is_methods = group.get("add_suffix_to_is_methods", False)
         self.anynode_is_label = group.get("anynode_is_label", to_snake_case(group_name))
         self.rustdoc = group.get("rustdoc")
@@ -205,7 +204,6 @@ def write_ref_enum(out: list[str], groups: list[Group]) -> None:
     - `impl Ranged for TypeParamRef<'_>`
     - `fn TypeParamRef::is_type_var() -> bool`
 
-    The name of the enum can be customized via the `ref_enum_ty` group option.
     The name of each variant can be customized via the `variant` node option. If
     the `add_suffix_to_is_methods` group option is true, then the `is_type_var`
     method will be named `is_type_var_type_param`.

--- a/crates/ruff_python_ast/src/expression.rs
+++ b/crates/ruff_python_ast/src/expression.rs
@@ -3,13 +3,13 @@ use std::iter::FusedIterator;
 use ruff_text_size::{Ranged, TextRange};
 
 use crate::{
-    self as ast, AnyNodeRef, AnyStringFlags, Expr, ExprBytesLiteral, ExprFString,
-    ExprStringLiteral, ExpressionRef, StringFlags,
+    self as ast, AnyNodeRef, AnyStringFlags, Expr, ExprBytesLiteral, ExprFString, ExprRef,
+    ExprStringLiteral, StringFlags,
 };
 
-impl<'a> From<&'a Box<Expr>> for ExpressionRef<'a> {
+impl<'a> From<&'a Box<Expr>> for ExprRef<'a> {
     fn from(value: &'a Box<Expr>) -> Self {
-        ExpressionRef::from(value.as_ref())
+        ExprRef::from(value.as_ref())
     }
 }
 
@@ -111,11 +111,11 @@ impl<'a> StringLike<'a> {
         }
     }
 
-    pub const fn as_expression_ref(self) -> ExpressionRef<'a> {
+    pub const fn as_expression_ref(self) -> ExprRef<'a> {
         match self {
-            StringLike::String(expr) => ExpressionRef::StringLiteral(expr),
-            StringLike::Bytes(expr) => ExpressionRef::BytesLiteral(expr),
-            StringLike::FString(expr) => ExpressionRef::FString(expr),
+            StringLike::String(expr) => ExprRef::StringLiteral(expr),
+            StringLike::Bytes(expr) => ExprRef::BytesLiteral(expr),
+            StringLike::FString(expr) => ExprRef::FString(expr),
         }
     }
 }
@@ -138,12 +138,12 @@ impl<'a> From<&'a ast::ExprFString> for StringLike<'a> {
     }
 }
 
-impl<'a> From<&StringLike<'a>> for ExpressionRef<'a> {
+impl<'a> From<&StringLike<'a>> for ExprRef<'a> {
     fn from(value: &StringLike<'a>) -> Self {
         match value {
-            StringLike::String(expr) => ExpressionRef::StringLiteral(expr),
-            StringLike::Bytes(expr) => ExpressionRef::BytesLiteral(expr),
-            StringLike::FString(expr) => ExpressionRef::FString(expr),
+            StringLike::String(expr) => ExprRef::StringLiteral(expr),
+            StringLike::Bytes(expr) => ExprRef::BytesLiteral(expr),
+            StringLike::FString(expr) => ExprRef::FString(expr),
         }
     }
 }

--- a/crates/ruff_python_ast/src/generated.rs
+++ b/crates/ruff_python_ast/src/generated.rs
@@ -1466,7 +1466,7 @@ impl ruff_text_size::Ranged for ModRef<'_> {
 
 /// See also [stmt](https://docs.python.org/3/library/ast.html#ast.stmt)
 #[derive(Clone, Copy, Debug, PartialEq, is_macro::Is)]
-pub enum StatementRef<'a> {
+pub enum StmtRef<'a> {
     #[is(name = "function_def_stmt")]
     FunctionDef(&'a crate::StmtFunctionDef),
     #[is(name = "class_def_stmt")]
@@ -1519,189 +1519,189 @@ pub enum StatementRef<'a> {
     IpyEscapeCommand(&'a crate::StmtIpyEscapeCommand),
 }
 
-impl<'a> From<&'a Stmt> for StatementRef<'a> {
+impl<'a> From<&'a Stmt> for StmtRef<'a> {
     fn from(node: &'a Stmt) -> Self {
         match node {
-            Stmt::FunctionDef(node) => StatementRef::FunctionDef(node),
-            Stmt::ClassDef(node) => StatementRef::ClassDef(node),
-            Stmt::Return(node) => StatementRef::Return(node),
-            Stmt::Delete(node) => StatementRef::Delete(node),
-            Stmt::TypeAlias(node) => StatementRef::TypeAlias(node),
-            Stmt::Assign(node) => StatementRef::Assign(node),
-            Stmt::AugAssign(node) => StatementRef::AugAssign(node),
-            Stmt::AnnAssign(node) => StatementRef::AnnAssign(node),
-            Stmt::For(node) => StatementRef::For(node),
-            Stmt::While(node) => StatementRef::While(node),
-            Stmt::If(node) => StatementRef::If(node),
-            Stmt::With(node) => StatementRef::With(node),
-            Stmt::Match(node) => StatementRef::Match(node),
-            Stmt::Raise(node) => StatementRef::Raise(node),
-            Stmt::Try(node) => StatementRef::Try(node),
-            Stmt::Assert(node) => StatementRef::Assert(node),
-            Stmt::Import(node) => StatementRef::Import(node),
-            Stmt::ImportFrom(node) => StatementRef::ImportFrom(node),
-            Stmt::Global(node) => StatementRef::Global(node),
-            Stmt::Nonlocal(node) => StatementRef::Nonlocal(node),
-            Stmt::Expr(node) => StatementRef::Expr(node),
-            Stmt::Pass(node) => StatementRef::Pass(node),
-            Stmt::Break(node) => StatementRef::Break(node),
-            Stmt::Continue(node) => StatementRef::Continue(node),
-            Stmt::IpyEscapeCommand(node) => StatementRef::IpyEscapeCommand(node),
+            Stmt::FunctionDef(node) => StmtRef::FunctionDef(node),
+            Stmt::ClassDef(node) => StmtRef::ClassDef(node),
+            Stmt::Return(node) => StmtRef::Return(node),
+            Stmt::Delete(node) => StmtRef::Delete(node),
+            Stmt::TypeAlias(node) => StmtRef::TypeAlias(node),
+            Stmt::Assign(node) => StmtRef::Assign(node),
+            Stmt::AugAssign(node) => StmtRef::AugAssign(node),
+            Stmt::AnnAssign(node) => StmtRef::AnnAssign(node),
+            Stmt::For(node) => StmtRef::For(node),
+            Stmt::While(node) => StmtRef::While(node),
+            Stmt::If(node) => StmtRef::If(node),
+            Stmt::With(node) => StmtRef::With(node),
+            Stmt::Match(node) => StmtRef::Match(node),
+            Stmt::Raise(node) => StmtRef::Raise(node),
+            Stmt::Try(node) => StmtRef::Try(node),
+            Stmt::Assert(node) => StmtRef::Assert(node),
+            Stmt::Import(node) => StmtRef::Import(node),
+            Stmt::ImportFrom(node) => StmtRef::ImportFrom(node),
+            Stmt::Global(node) => StmtRef::Global(node),
+            Stmt::Nonlocal(node) => StmtRef::Nonlocal(node),
+            Stmt::Expr(node) => StmtRef::Expr(node),
+            Stmt::Pass(node) => StmtRef::Pass(node),
+            Stmt::Break(node) => StmtRef::Break(node),
+            Stmt::Continue(node) => StmtRef::Continue(node),
+            Stmt::IpyEscapeCommand(node) => StmtRef::IpyEscapeCommand(node),
         }
     }
 }
 
-impl<'a> From<&'a crate::StmtFunctionDef> for StatementRef<'a> {
+impl<'a> From<&'a crate::StmtFunctionDef> for StmtRef<'a> {
     fn from(node: &'a crate::StmtFunctionDef) -> Self {
         Self::FunctionDef(node)
     }
 }
 
-impl<'a> From<&'a crate::StmtClassDef> for StatementRef<'a> {
+impl<'a> From<&'a crate::StmtClassDef> for StmtRef<'a> {
     fn from(node: &'a crate::StmtClassDef) -> Self {
         Self::ClassDef(node)
     }
 }
 
-impl<'a> From<&'a crate::StmtReturn> for StatementRef<'a> {
+impl<'a> From<&'a crate::StmtReturn> for StmtRef<'a> {
     fn from(node: &'a crate::StmtReturn) -> Self {
         Self::Return(node)
     }
 }
 
-impl<'a> From<&'a crate::StmtDelete> for StatementRef<'a> {
+impl<'a> From<&'a crate::StmtDelete> for StmtRef<'a> {
     fn from(node: &'a crate::StmtDelete) -> Self {
         Self::Delete(node)
     }
 }
 
-impl<'a> From<&'a crate::StmtTypeAlias> for StatementRef<'a> {
+impl<'a> From<&'a crate::StmtTypeAlias> for StmtRef<'a> {
     fn from(node: &'a crate::StmtTypeAlias) -> Self {
         Self::TypeAlias(node)
     }
 }
 
-impl<'a> From<&'a crate::StmtAssign> for StatementRef<'a> {
+impl<'a> From<&'a crate::StmtAssign> for StmtRef<'a> {
     fn from(node: &'a crate::StmtAssign) -> Self {
         Self::Assign(node)
     }
 }
 
-impl<'a> From<&'a crate::StmtAugAssign> for StatementRef<'a> {
+impl<'a> From<&'a crate::StmtAugAssign> for StmtRef<'a> {
     fn from(node: &'a crate::StmtAugAssign) -> Self {
         Self::AugAssign(node)
     }
 }
 
-impl<'a> From<&'a crate::StmtAnnAssign> for StatementRef<'a> {
+impl<'a> From<&'a crate::StmtAnnAssign> for StmtRef<'a> {
     fn from(node: &'a crate::StmtAnnAssign) -> Self {
         Self::AnnAssign(node)
     }
 }
 
-impl<'a> From<&'a crate::StmtFor> for StatementRef<'a> {
+impl<'a> From<&'a crate::StmtFor> for StmtRef<'a> {
     fn from(node: &'a crate::StmtFor) -> Self {
         Self::For(node)
     }
 }
 
-impl<'a> From<&'a crate::StmtWhile> for StatementRef<'a> {
+impl<'a> From<&'a crate::StmtWhile> for StmtRef<'a> {
     fn from(node: &'a crate::StmtWhile) -> Self {
         Self::While(node)
     }
 }
 
-impl<'a> From<&'a crate::StmtIf> for StatementRef<'a> {
+impl<'a> From<&'a crate::StmtIf> for StmtRef<'a> {
     fn from(node: &'a crate::StmtIf) -> Self {
         Self::If(node)
     }
 }
 
-impl<'a> From<&'a crate::StmtWith> for StatementRef<'a> {
+impl<'a> From<&'a crate::StmtWith> for StmtRef<'a> {
     fn from(node: &'a crate::StmtWith) -> Self {
         Self::With(node)
     }
 }
 
-impl<'a> From<&'a crate::StmtMatch> for StatementRef<'a> {
+impl<'a> From<&'a crate::StmtMatch> for StmtRef<'a> {
     fn from(node: &'a crate::StmtMatch) -> Self {
         Self::Match(node)
     }
 }
 
-impl<'a> From<&'a crate::StmtRaise> for StatementRef<'a> {
+impl<'a> From<&'a crate::StmtRaise> for StmtRef<'a> {
     fn from(node: &'a crate::StmtRaise) -> Self {
         Self::Raise(node)
     }
 }
 
-impl<'a> From<&'a crate::StmtTry> for StatementRef<'a> {
+impl<'a> From<&'a crate::StmtTry> for StmtRef<'a> {
     fn from(node: &'a crate::StmtTry) -> Self {
         Self::Try(node)
     }
 }
 
-impl<'a> From<&'a crate::StmtAssert> for StatementRef<'a> {
+impl<'a> From<&'a crate::StmtAssert> for StmtRef<'a> {
     fn from(node: &'a crate::StmtAssert) -> Self {
         Self::Assert(node)
     }
 }
 
-impl<'a> From<&'a crate::StmtImport> for StatementRef<'a> {
+impl<'a> From<&'a crate::StmtImport> for StmtRef<'a> {
     fn from(node: &'a crate::StmtImport) -> Self {
         Self::Import(node)
     }
 }
 
-impl<'a> From<&'a crate::StmtImportFrom> for StatementRef<'a> {
+impl<'a> From<&'a crate::StmtImportFrom> for StmtRef<'a> {
     fn from(node: &'a crate::StmtImportFrom) -> Self {
         Self::ImportFrom(node)
     }
 }
 
-impl<'a> From<&'a crate::StmtGlobal> for StatementRef<'a> {
+impl<'a> From<&'a crate::StmtGlobal> for StmtRef<'a> {
     fn from(node: &'a crate::StmtGlobal) -> Self {
         Self::Global(node)
     }
 }
 
-impl<'a> From<&'a crate::StmtNonlocal> for StatementRef<'a> {
+impl<'a> From<&'a crate::StmtNonlocal> for StmtRef<'a> {
     fn from(node: &'a crate::StmtNonlocal) -> Self {
         Self::Nonlocal(node)
     }
 }
 
-impl<'a> From<&'a crate::StmtExpr> for StatementRef<'a> {
+impl<'a> From<&'a crate::StmtExpr> for StmtRef<'a> {
     fn from(node: &'a crate::StmtExpr) -> Self {
         Self::Expr(node)
     }
 }
 
-impl<'a> From<&'a crate::StmtPass> for StatementRef<'a> {
+impl<'a> From<&'a crate::StmtPass> for StmtRef<'a> {
     fn from(node: &'a crate::StmtPass) -> Self {
         Self::Pass(node)
     }
 }
 
-impl<'a> From<&'a crate::StmtBreak> for StatementRef<'a> {
+impl<'a> From<&'a crate::StmtBreak> for StmtRef<'a> {
     fn from(node: &'a crate::StmtBreak) -> Self {
         Self::Break(node)
     }
 }
 
-impl<'a> From<&'a crate::StmtContinue> for StatementRef<'a> {
+impl<'a> From<&'a crate::StmtContinue> for StmtRef<'a> {
     fn from(node: &'a crate::StmtContinue) -> Self {
         Self::Continue(node)
     }
 }
 
-impl<'a> From<&'a crate::StmtIpyEscapeCommand> for StatementRef<'a> {
+impl<'a> From<&'a crate::StmtIpyEscapeCommand> for StmtRef<'a> {
     fn from(node: &'a crate::StmtIpyEscapeCommand) -> Self {
         Self::IpyEscapeCommand(node)
     }
 }
 
-impl ruff_text_size::Ranged for StatementRef<'_> {
+impl ruff_text_size::Ranged for StmtRef<'_> {
     fn range(&self) -> ruff_text_size::TextRange {
         match self {
             Self::FunctionDef(node) => node.range(),
@@ -1735,7 +1735,7 @@ impl ruff_text_size::Ranged for StatementRef<'_> {
 
 /// See also [expr](https://docs.python.org/3/library/ast.html#ast.expr)
 #[derive(Clone, Copy, Debug, PartialEq, is_macro::Is)]
-pub enum ExpressionRef<'a> {
+pub enum ExprRef<'a> {
     #[is(name = "bool_op_expr")]
     BoolOp(&'a crate::ExprBoolOp),
     #[is(name = "named_expr")]
@@ -1802,238 +1802,238 @@ pub enum ExpressionRef<'a> {
     IpyEscapeCommand(&'a crate::ExprIpyEscapeCommand),
 }
 
-impl<'a> From<&'a Expr> for ExpressionRef<'a> {
+impl<'a> From<&'a Expr> for ExprRef<'a> {
     fn from(node: &'a Expr) -> Self {
         match node {
-            Expr::BoolOp(node) => ExpressionRef::BoolOp(node),
-            Expr::Named(node) => ExpressionRef::Named(node),
-            Expr::BinOp(node) => ExpressionRef::BinOp(node),
-            Expr::UnaryOp(node) => ExpressionRef::UnaryOp(node),
-            Expr::Lambda(node) => ExpressionRef::Lambda(node),
-            Expr::If(node) => ExpressionRef::If(node),
-            Expr::Dict(node) => ExpressionRef::Dict(node),
-            Expr::Set(node) => ExpressionRef::Set(node),
-            Expr::ListComp(node) => ExpressionRef::ListComp(node),
-            Expr::SetComp(node) => ExpressionRef::SetComp(node),
-            Expr::DictComp(node) => ExpressionRef::DictComp(node),
-            Expr::Generator(node) => ExpressionRef::Generator(node),
-            Expr::Await(node) => ExpressionRef::Await(node),
-            Expr::Yield(node) => ExpressionRef::Yield(node),
-            Expr::YieldFrom(node) => ExpressionRef::YieldFrom(node),
-            Expr::Compare(node) => ExpressionRef::Compare(node),
-            Expr::Call(node) => ExpressionRef::Call(node),
-            Expr::FString(node) => ExpressionRef::FString(node),
-            Expr::StringLiteral(node) => ExpressionRef::StringLiteral(node),
-            Expr::BytesLiteral(node) => ExpressionRef::BytesLiteral(node),
-            Expr::NumberLiteral(node) => ExpressionRef::NumberLiteral(node),
-            Expr::BooleanLiteral(node) => ExpressionRef::BooleanLiteral(node),
-            Expr::NoneLiteral(node) => ExpressionRef::NoneLiteral(node),
-            Expr::EllipsisLiteral(node) => ExpressionRef::EllipsisLiteral(node),
-            Expr::Attribute(node) => ExpressionRef::Attribute(node),
-            Expr::Subscript(node) => ExpressionRef::Subscript(node),
-            Expr::Starred(node) => ExpressionRef::Starred(node),
-            Expr::Name(node) => ExpressionRef::Name(node),
-            Expr::List(node) => ExpressionRef::List(node),
-            Expr::Tuple(node) => ExpressionRef::Tuple(node),
-            Expr::Slice(node) => ExpressionRef::Slice(node),
-            Expr::IpyEscapeCommand(node) => ExpressionRef::IpyEscapeCommand(node),
+            Expr::BoolOp(node) => ExprRef::BoolOp(node),
+            Expr::Named(node) => ExprRef::Named(node),
+            Expr::BinOp(node) => ExprRef::BinOp(node),
+            Expr::UnaryOp(node) => ExprRef::UnaryOp(node),
+            Expr::Lambda(node) => ExprRef::Lambda(node),
+            Expr::If(node) => ExprRef::If(node),
+            Expr::Dict(node) => ExprRef::Dict(node),
+            Expr::Set(node) => ExprRef::Set(node),
+            Expr::ListComp(node) => ExprRef::ListComp(node),
+            Expr::SetComp(node) => ExprRef::SetComp(node),
+            Expr::DictComp(node) => ExprRef::DictComp(node),
+            Expr::Generator(node) => ExprRef::Generator(node),
+            Expr::Await(node) => ExprRef::Await(node),
+            Expr::Yield(node) => ExprRef::Yield(node),
+            Expr::YieldFrom(node) => ExprRef::YieldFrom(node),
+            Expr::Compare(node) => ExprRef::Compare(node),
+            Expr::Call(node) => ExprRef::Call(node),
+            Expr::FString(node) => ExprRef::FString(node),
+            Expr::StringLiteral(node) => ExprRef::StringLiteral(node),
+            Expr::BytesLiteral(node) => ExprRef::BytesLiteral(node),
+            Expr::NumberLiteral(node) => ExprRef::NumberLiteral(node),
+            Expr::BooleanLiteral(node) => ExprRef::BooleanLiteral(node),
+            Expr::NoneLiteral(node) => ExprRef::NoneLiteral(node),
+            Expr::EllipsisLiteral(node) => ExprRef::EllipsisLiteral(node),
+            Expr::Attribute(node) => ExprRef::Attribute(node),
+            Expr::Subscript(node) => ExprRef::Subscript(node),
+            Expr::Starred(node) => ExprRef::Starred(node),
+            Expr::Name(node) => ExprRef::Name(node),
+            Expr::List(node) => ExprRef::List(node),
+            Expr::Tuple(node) => ExprRef::Tuple(node),
+            Expr::Slice(node) => ExprRef::Slice(node),
+            Expr::IpyEscapeCommand(node) => ExprRef::IpyEscapeCommand(node),
         }
     }
 }
 
-impl<'a> From<&'a crate::ExprBoolOp> for ExpressionRef<'a> {
+impl<'a> From<&'a crate::ExprBoolOp> for ExprRef<'a> {
     fn from(node: &'a crate::ExprBoolOp) -> Self {
         Self::BoolOp(node)
     }
 }
 
-impl<'a> From<&'a crate::ExprNamed> for ExpressionRef<'a> {
+impl<'a> From<&'a crate::ExprNamed> for ExprRef<'a> {
     fn from(node: &'a crate::ExprNamed) -> Self {
         Self::Named(node)
     }
 }
 
-impl<'a> From<&'a crate::ExprBinOp> for ExpressionRef<'a> {
+impl<'a> From<&'a crate::ExprBinOp> for ExprRef<'a> {
     fn from(node: &'a crate::ExprBinOp) -> Self {
         Self::BinOp(node)
     }
 }
 
-impl<'a> From<&'a crate::ExprUnaryOp> for ExpressionRef<'a> {
+impl<'a> From<&'a crate::ExprUnaryOp> for ExprRef<'a> {
     fn from(node: &'a crate::ExprUnaryOp) -> Self {
         Self::UnaryOp(node)
     }
 }
 
-impl<'a> From<&'a crate::ExprLambda> for ExpressionRef<'a> {
+impl<'a> From<&'a crate::ExprLambda> for ExprRef<'a> {
     fn from(node: &'a crate::ExprLambda) -> Self {
         Self::Lambda(node)
     }
 }
 
-impl<'a> From<&'a crate::ExprIf> for ExpressionRef<'a> {
+impl<'a> From<&'a crate::ExprIf> for ExprRef<'a> {
     fn from(node: &'a crate::ExprIf) -> Self {
         Self::If(node)
     }
 }
 
-impl<'a> From<&'a crate::ExprDict> for ExpressionRef<'a> {
+impl<'a> From<&'a crate::ExprDict> for ExprRef<'a> {
     fn from(node: &'a crate::ExprDict) -> Self {
         Self::Dict(node)
     }
 }
 
-impl<'a> From<&'a crate::ExprSet> for ExpressionRef<'a> {
+impl<'a> From<&'a crate::ExprSet> for ExprRef<'a> {
     fn from(node: &'a crate::ExprSet) -> Self {
         Self::Set(node)
     }
 }
 
-impl<'a> From<&'a crate::ExprListComp> for ExpressionRef<'a> {
+impl<'a> From<&'a crate::ExprListComp> for ExprRef<'a> {
     fn from(node: &'a crate::ExprListComp) -> Self {
         Self::ListComp(node)
     }
 }
 
-impl<'a> From<&'a crate::ExprSetComp> for ExpressionRef<'a> {
+impl<'a> From<&'a crate::ExprSetComp> for ExprRef<'a> {
     fn from(node: &'a crate::ExprSetComp) -> Self {
         Self::SetComp(node)
     }
 }
 
-impl<'a> From<&'a crate::ExprDictComp> for ExpressionRef<'a> {
+impl<'a> From<&'a crate::ExprDictComp> for ExprRef<'a> {
     fn from(node: &'a crate::ExprDictComp) -> Self {
         Self::DictComp(node)
     }
 }
 
-impl<'a> From<&'a crate::ExprGenerator> for ExpressionRef<'a> {
+impl<'a> From<&'a crate::ExprGenerator> for ExprRef<'a> {
     fn from(node: &'a crate::ExprGenerator) -> Self {
         Self::Generator(node)
     }
 }
 
-impl<'a> From<&'a crate::ExprAwait> for ExpressionRef<'a> {
+impl<'a> From<&'a crate::ExprAwait> for ExprRef<'a> {
     fn from(node: &'a crate::ExprAwait) -> Self {
         Self::Await(node)
     }
 }
 
-impl<'a> From<&'a crate::ExprYield> for ExpressionRef<'a> {
+impl<'a> From<&'a crate::ExprYield> for ExprRef<'a> {
     fn from(node: &'a crate::ExprYield) -> Self {
         Self::Yield(node)
     }
 }
 
-impl<'a> From<&'a crate::ExprYieldFrom> for ExpressionRef<'a> {
+impl<'a> From<&'a crate::ExprYieldFrom> for ExprRef<'a> {
     fn from(node: &'a crate::ExprYieldFrom) -> Self {
         Self::YieldFrom(node)
     }
 }
 
-impl<'a> From<&'a crate::ExprCompare> for ExpressionRef<'a> {
+impl<'a> From<&'a crate::ExprCompare> for ExprRef<'a> {
     fn from(node: &'a crate::ExprCompare) -> Self {
         Self::Compare(node)
     }
 }
 
-impl<'a> From<&'a crate::ExprCall> for ExpressionRef<'a> {
+impl<'a> From<&'a crate::ExprCall> for ExprRef<'a> {
     fn from(node: &'a crate::ExprCall) -> Self {
         Self::Call(node)
     }
 }
 
-impl<'a> From<&'a crate::ExprFString> for ExpressionRef<'a> {
+impl<'a> From<&'a crate::ExprFString> for ExprRef<'a> {
     fn from(node: &'a crate::ExprFString) -> Self {
         Self::FString(node)
     }
 }
 
-impl<'a> From<&'a crate::ExprStringLiteral> for ExpressionRef<'a> {
+impl<'a> From<&'a crate::ExprStringLiteral> for ExprRef<'a> {
     fn from(node: &'a crate::ExprStringLiteral) -> Self {
         Self::StringLiteral(node)
     }
 }
 
-impl<'a> From<&'a crate::ExprBytesLiteral> for ExpressionRef<'a> {
+impl<'a> From<&'a crate::ExprBytesLiteral> for ExprRef<'a> {
     fn from(node: &'a crate::ExprBytesLiteral) -> Self {
         Self::BytesLiteral(node)
     }
 }
 
-impl<'a> From<&'a crate::ExprNumberLiteral> for ExpressionRef<'a> {
+impl<'a> From<&'a crate::ExprNumberLiteral> for ExprRef<'a> {
     fn from(node: &'a crate::ExprNumberLiteral) -> Self {
         Self::NumberLiteral(node)
     }
 }
 
-impl<'a> From<&'a crate::ExprBooleanLiteral> for ExpressionRef<'a> {
+impl<'a> From<&'a crate::ExprBooleanLiteral> for ExprRef<'a> {
     fn from(node: &'a crate::ExprBooleanLiteral) -> Self {
         Self::BooleanLiteral(node)
     }
 }
 
-impl<'a> From<&'a crate::ExprNoneLiteral> for ExpressionRef<'a> {
+impl<'a> From<&'a crate::ExprNoneLiteral> for ExprRef<'a> {
     fn from(node: &'a crate::ExprNoneLiteral) -> Self {
         Self::NoneLiteral(node)
     }
 }
 
-impl<'a> From<&'a crate::ExprEllipsisLiteral> for ExpressionRef<'a> {
+impl<'a> From<&'a crate::ExprEllipsisLiteral> for ExprRef<'a> {
     fn from(node: &'a crate::ExprEllipsisLiteral) -> Self {
         Self::EllipsisLiteral(node)
     }
 }
 
-impl<'a> From<&'a crate::ExprAttribute> for ExpressionRef<'a> {
+impl<'a> From<&'a crate::ExprAttribute> for ExprRef<'a> {
     fn from(node: &'a crate::ExprAttribute) -> Self {
         Self::Attribute(node)
     }
 }
 
-impl<'a> From<&'a crate::ExprSubscript> for ExpressionRef<'a> {
+impl<'a> From<&'a crate::ExprSubscript> for ExprRef<'a> {
     fn from(node: &'a crate::ExprSubscript) -> Self {
         Self::Subscript(node)
     }
 }
 
-impl<'a> From<&'a crate::ExprStarred> for ExpressionRef<'a> {
+impl<'a> From<&'a crate::ExprStarred> for ExprRef<'a> {
     fn from(node: &'a crate::ExprStarred) -> Self {
         Self::Starred(node)
     }
 }
 
-impl<'a> From<&'a crate::ExprName> for ExpressionRef<'a> {
+impl<'a> From<&'a crate::ExprName> for ExprRef<'a> {
     fn from(node: &'a crate::ExprName) -> Self {
         Self::Name(node)
     }
 }
 
-impl<'a> From<&'a crate::ExprList> for ExpressionRef<'a> {
+impl<'a> From<&'a crate::ExprList> for ExprRef<'a> {
     fn from(node: &'a crate::ExprList) -> Self {
         Self::List(node)
     }
 }
 
-impl<'a> From<&'a crate::ExprTuple> for ExpressionRef<'a> {
+impl<'a> From<&'a crate::ExprTuple> for ExprRef<'a> {
     fn from(node: &'a crate::ExprTuple) -> Self {
         Self::Tuple(node)
     }
 }
 
-impl<'a> From<&'a crate::ExprSlice> for ExpressionRef<'a> {
+impl<'a> From<&'a crate::ExprSlice> for ExprRef<'a> {
     fn from(node: &'a crate::ExprSlice) -> Self {
         Self::Slice(node)
     }
 }
 
-impl<'a> From<&'a crate::ExprIpyEscapeCommand> for ExpressionRef<'a> {
+impl<'a> From<&'a crate::ExprIpyEscapeCommand> for ExprRef<'a> {
     fn from(node: &'a crate::ExprIpyEscapeCommand) -> Self {
         Self::IpyEscapeCommand(node)
     }
 }
 
-impl ruff_text_size::Ranged for ExpressionRef<'_> {
+impl ruff_text_size::Ranged for ExprRef<'_> {
     fn range(&self) -> ruff_text_size::TextRange {
         match self {
             Self::BoolOp(node) => node.range(),
@@ -2431,34 +2431,34 @@ impl<'a> From<&'a Stmt> for AnyNodeRef<'a> {
     }
 }
 
-impl<'a> From<StatementRef<'a>> for AnyNodeRef<'a> {
-    fn from(node: StatementRef<'a>) -> AnyNodeRef<'a> {
+impl<'a> From<StmtRef<'a>> for AnyNodeRef<'a> {
+    fn from(node: StmtRef<'a>) -> AnyNodeRef<'a> {
         match node {
-            StatementRef::FunctionDef(node) => AnyNodeRef::StmtFunctionDef(node),
-            StatementRef::ClassDef(node) => AnyNodeRef::StmtClassDef(node),
-            StatementRef::Return(node) => AnyNodeRef::StmtReturn(node),
-            StatementRef::Delete(node) => AnyNodeRef::StmtDelete(node),
-            StatementRef::TypeAlias(node) => AnyNodeRef::StmtTypeAlias(node),
-            StatementRef::Assign(node) => AnyNodeRef::StmtAssign(node),
-            StatementRef::AugAssign(node) => AnyNodeRef::StmtAugAssign(node),
-            StatementRef::AnnAssign(node) => AnyNodeRef::StmtAnnAssign(node),
-            StatementRef::For(node) => AnyNodeRef::StmtFor(node),
-            StatementRef::While(node) => AnyNodeRef::StmtWhile(node),
-            StatementRef::If(node) => AnyNodeRef::StmtIf(node),
-            StatementRef::With(node) => AnyNodeRef::StmtWith(node),
-            StatementRef::Match(node) => AnyNodeRef::StmtMatch(node),
-            StatementRef::Raise(node) => AnyNodeRef::StmtRaise(node),
-            StatementRef::Try(node) => AnyNodeRef::StmtTry(node),
-            StatementRef::Assert(node) => AnyNodeRef::StmtAssert(node),
-            StatementRef::Import(node) => AnyNodeRef::StmtImport(node),
-            StatementRef::ImportFrom(node) => AnyNodeRef::StmtImportFrom(node),
-            StatementRef::Global(node) => AnyNodeRef::StmtGlobal(node),
-            StatementRef::Nonlocal(node) => AnyNodeRef::StmtNonlocal(node),
-            StatementRef::Expr(node) => AnyNodeRef::StmtExpr(node),
-            StatementRef::Pass(node) => AnyNodeRef::StmtPass(node),
-            StatementRef::Break(node) => AnyNodeRef::StmtBreak(node),
-            StatementRef::Continue(node) => AnyNodeRef::StmtContinue(node),
-            StatementRef::IpyEscapeCommand(node) => AnyNodeRef::StmtIpyEscapeCommand(node),
+            StmtRef::FunctionDef(node) => AnyNodeRef::StmtFunctionDef(node),
+            StmtRef::ClassDef(node) => AnyNodeRef::StmtClassDef(node),
+            StmtRef::Return(node) => AnyNodeRef::StmtReturn(node),
+            StmtRef::Delete(node) => AnyNodeRef::StmtDelete(node),
+            StmtRef::TypeAlias(node) => AnyNodeRef::StmtTypeAlias(node),
+            StmtRef::Assign(node) => AnyNodeRef::StmtAssign(node),
+            StmtRef::AugAssign(node) => AnyNodeRef::StmtAugAssign(node),
+            StmtRef::AnnAssign(node) => AnyNodeRef::StmtAnnAssign(node),
+            StmtRef::For(node) => AnyNodeRef::StmtFor(node),
+            StmtRef::While(node) => AnyNodeRef::StmtWhile(node),
+            StmtRef::If(node) => AnyNodeRef::StmtIf(node),
+            StmtRef::With(node) => AnyNodeRef::StmtWith(node),
+            StmtRef::Match(node) => AnyNodeRef::StmtMatch(node),
+            StmtRef::Raise(node) => AnyNodeRef::StmtRaise(node),
+            StmtRef::Try(node) => AnyNodeRef::StmtTry(node),
+            StmtRef::Assert(node) => AnyNodeRef::StmtAssert(node),
+            StmtRef::Import(node) => AnyNodeRef::StmtImport(node),
+            StmtRef::ImportFrom(node) => AnyNodeRef::StmtImportFrom(node),
+            StmtRef::Global(node) => AnyNodeRef::StmtGlobal(node),
+            StmtRef::Nonlocal(node) => AnyNodeRef::StmtNonlocal(node),
+            StmtRef::Expr(node) => AnyNodeRef::StmtExpr(node),
+            StmtRef::Pass(node) => AnyNodeRef::StmtPass(node),
+            StmtRef::Break(node) => AnyNodeRef::StmtBreak(node),
+            StmtRef::Continue(node) => AnyNodeRef::StmtContinue(node),
+            StmtRef::IpyEscapeCommand(node) => AnyNodeRef::StmtIpyEscapeCommand(node),
         }
     }
 }
@@ -2652,41 +2652,41 @@ impl<'a> From<&'a Expr> for AnyNodeRef<'a> {
     }
 }
 
-impl<'a> From<ExpressionRef<'a>> for AnyNodeRef<'a> {
-    fn from(node: ExpressionRef<'a>) -> AnyNodeRef<'a> {
+impl<'a> From<ExprRef<'a>> for AnyNodeRef<'a> {
+    fn from(node: ExprRef<'a>) -> AnyNodeRef<'a> {
         match node {
-            ExpressionRef::BoolOp(node) => AnyNodeRef::ExprBoolOp(node),
-            ExpressionRef::Named(node) => AnyNodeRef::ExprNamed(node),
-            ExpressionRef::BinOp(node) => AnyNodeRef::ExprBinOp(node),
-            ExpressionRef::UnaryOp(node) => AnyNodeRef::ExprUnaryOp(node),
-            ExpressionRef::Lambda(node) => AnyNodeRef::ExprLambda(node),
-            ExpressionRef::If(node) => AnyNodeRef::ExprIf(node),
-            ExpressionRef::Dict(node) => AnyNodeRef::ExprDict(node),
-            ExpressionRef::Set(node) => AnyNodeRef::ExprSet(node),
-            ExpressionRef::ListComp(node) => AnyNodeRef::ExprListComp(node),
-            ExpressionRef::SetComp(node) => AnyNodeRef::ExprSetComp(node),
-            ExpressionRef::DictComp(node) => AnyNodeRef::ExprDictComp(node),
-            ExpressionRef::Generator(node) => AnyNodeRef::ExprGenerator(node),
-            ExpressionRef::Await(node) => AnyNodeRef::ExprAwait(node),
-            ExpressionRef::Yield(node) => AnyNodeRef::ExprYield(node),
-            ExpressionRef::YieldFrom(node) => AnyNodeRef::ExprYieldFrom(node),
-            ExpressionRef::Compare(node) => AnyNodeRef::ExprCompare(node),
-            ExpressionRef::Call(node) => AnyNodeRef::ExprCall(node),
-            ExpressionRef::FString(node) => AnyNodeRef::ExprFString(node),
-            ExpressionRef::StringLiteral(node) => AnyNodeRef::ExprStringLiteral(node),
-            ExpressionRef::BytesLiteral(node) => AnyNodeRef::ExprBytesLiteral(node),
-            ExpressionRef::NumberLiteral(node) => AnyNodeRef::ExprNumberLiteral(node),
-            ExpressionRef::BooleanLiteral(node) => AnyNodeRef::ExprBooleanLiteral(node),
-            ExpressionRef::NoneLiteral(node) => AnyNodeRef::ExprNoneLiteral(node),
-            ExpressionRef::EllipsisLiteral(node) => AnyNodeRef::ExprEllipsisLiteral(node),
-            ExpressionRef::Attribute(node) => AnyNodeRef::ExprAttribute(node),
-            ExpressionRef::Subscript(node) => AnyNodeRef::ExprSubscript(node),
-            ExpressionRef::Starred(node) => AnyNodeRef::ExprStarred(node),
-            ExpressionRef::Name(node) => AnyNodeRef::ExprName(node),
-            ExpressionRef::List(node) => AnyNodeRef::ExprList(node),
-            ExpressionRef::Tuple(node) => AnyNodeRef::ExprTuple(node),
-            ExpressionRef::Slice(node) => AnyNodeRef::ExprSlice(node),
-            ExpressionRef::IpyEscapeCommand(node) => AnyNodeRef::ExprIpyEscapeCommand(node),
+            ExprRef::BoolOp(node) => AnyNodeRef::ExprBoolOp(node),
+            ExprRef::Named(node) => AnyNodeRef::ExprNamed(node),
+            ExprRef::BinOp(node) => AnyNodeRef::ExprBinOp(node),
+            ExprRef::UnaryOp(node) => AnyNodeRef::ExprUnaryOp(node),
+            ExprRef::Lambda(node) => AnyNodeRef::ExprLambda(node),
+            ExprRef::If(node) => AnyNodeRef::ExprIf(node),
+            ExprRef::Dict(node) => AnyNodeRef::ExprDict(node),
+            ExprRef::Set(node) => AnyNodeRef::ExprSet(node),
+            ExprRef::ListComp(node) => AnyNodeRef::ExprListComp(node),
+            ExprRef::SetComp(node) => AnyNodeRef::ExprSetComp(node),
+            ExprRef::DictComp(node) => AnyNodeRef::ExprDictComp(node),
+            ExprRef::Generator(node) => AnyNodeRef::ExprGenerator(node),
+            ExprRef::Await(node) => AnyNodeRef::ExprAwait(node),
+            ExprRef::Yield(node) => AnyNodeRef::ExprYield(node),
+            ExprRef::YieldFrom(node) => AnyNodeRef::ExprYieldFrom(node),
+            ExprRef::Compare(node) => AnyNodeRef::ExprCompare(node),
+            ExprRef::Call(node) => AnyNodeRef::ExprCall(node),
+            ExprRef::FString(node) => AnyNodeRef::ExprFString(node),
+            ExprRef::StringLiteral(node) => AnyNodeRef::ExprStringLiteral(node),
+            ExprRef::BytesLiteral(node) => AnyNodeRef::ExprBytesLiteral(node),
+            ExprRef::NumberLiteral(node) => AnyNodeRef::ExprNumberLiteral(node),
+            ExprRef::BooleanLiteral(node) => AnyNodeRef::ExprBooleanLiteral(node),
+            ExprRef::NoneLiteral(node) => AnyNodeRef::ExprNoneLiteral(node),
+            ExprRef::EllipsisLiteral(node) => AnyNodeRef::ExprEllipsisLiteral(node),
+            ExprRef::Attribute(node) => AnyNodeRef::ExprAttribute(node),
+            ExprRef::Subscript(node) => AnyNodeRef::ExprSubscript(node),
+            ExprRef::Starred(node) => AnyNodeRef::ExprStarred(node),
+            ExprRef::Name(node) => AnyNodeRef::ExprName(node),
+            ExprRef::List(node) => AnyNodeRef::ExprList(node),
+            ExprRef::Tuple(node) => AnyNodeRef::ExprTuple(node),
+            ExprRef::Slice(node) => AnyNodeRef::ExprSlice(node),
+            ExprRef::IpyEscapeCommand(node) => AnyNodeRef::ExprIpyEscapeCommand(node),
         }
     }
 }

--- a/crates/ruff_python_ast/src/parenthesize.rs
+++ b/crates/ruff_python_ast/src/parenthesize.rs
@@ -2,7 +2,7 @@ use ruff_python_trivia::{BackwardsTokenizer, CommentRanges, SimpleTokenKind, Sim
 use ruff_text_size::{Ranged, TextLen, TextRange};
 
 use crate::AnyNodeRef;
-use crate::ExpressionRef;
+use crate::ExprRef;
 
 /// Returns an iterator over the ranges of the optional parentheses surrounding an expression.
 ///
@@ -12,7 +12,7 @@ use crate::ExpressionRef;
 /// parentheses around `a` even if the parentheses actually belong to `f`. That is why you should
 /// generally prefer [`parenthesized_range`].
 pub fn parentheses_iterator<'a>(
-    expr: ExpressionRef<'a>,
+    expr: ExprRef<'a>,
     parent: Option<AnyNodeRef>,
     comment_ranges: &'a CommentRanges,
     source: &'a str,
@@ -58,7 +58,7 @@ pub fn parentheses_iterator<'a>(
 /// Returns the [`TextRange`] of a given expression including parentheses, if the expression is
 /// parenthesized; or `None`, if the expression is not parenthesized.
 pub fn parenthesized_range(
-    expr: ExpressionRef,
+    expr: ExprRef,
     parent: AnyNodeRef,
     comment_ranges: &CommentRanges,
     source: &str,

--- a/crates/ruff_python_formatter/src/expression/mod.rs
+++ b/crates/ruff_python_formatter/src/expression/mod.rs
@@ -7,7 +7,7 @@ use ruff_formatter::{
 use ruff_python_ast::parenthesize::parentheses_iterator;
 use ruff_python_ast::visitor::source_order::{walk_expr, SourceOrderVisitor};
 use ruff_python_ast::{self as ast};
-use ruff_python_ast::{AnyNodeRef, Expr, ExpressionRef, Operator};
+use ruff_python_ast::{AnyNodeRef, Expr, ExprRef, Operator};
 use ruff_python_trivia::CommentRanges;
 use ruff_text_size::Ranged;
 
@@ -881,14 +881,14 @@ pub enum CallChainLayout {
 
 impl CallChainLayout {
     pub(crate) fn from_expression(
-        mut expr: ExpressionRef,
+        mut expr: ExprRef,
         comment_ranges: &CommentRanges,
         source: &str,
     ) -> Self {
         let mut attributes_after_parentheses = 0;
         loop {
             match expr {
-                ExpressionRef::Attribute(ast::ExprAttribute { value, .. }) => {
+                ExprRef::Attribute(ast::ExprAttribute { value, .. }) => {
                     // ```
                     // f().g
                     // ^^^ value
@@ -903,7 +903,7 @@ impl CallChainLayout {
                         attributes_after_parentheses += 1;
                     }
 
-                    expr = ExpressionRef::from(value.as_ref());
+                    expr = ExprRef::from(value.as_ref());
                 }
                 // ```
                 // f()
@@ -913,9 +913,9 @@ impl CallChainLayout {
                 // ^^^^^^^^^^ expr
                 // ^^^^ value
                 // ```
-                ExpressionRef::Call(ast::ExprCall { func: inner, .. })
-                | ExpressionRef::Subscript(ast::ExprSubscript { value: inner, .. }) => {
-                    expr = ExpressionRef::from(inner.as_ref());
+                ExprRef::Call(ast::ExprCall { func: inner, .. })
+                | ExprRef::Subscript(ast::ExprSubscript { value: inner, .. }) => {
+                    expr = ExprRef::from(inner.as_ref());
                 }
                 _ => {
                     // We to format the following in fluent style:
@@ -947,7 +947,7 @@ impl CallChainLayout {
     /// formatting
     pub(crate) fn apply_in_node<'a>(
         self,
-        item: impl Into<ExpressionRef<'a>>,
+        item: impl Into<ExprRef<'a>>,
         f: &mut PyFormatter,
     ) -> CallChainLayout {
         match self {

--- a/crates/ruff_python_formatter/src/expression/parentheses.rs
+++ b/crates/ruff_python_formatter/src/expression/parentheses.rs
@@ -1,7 +1,7 @@
 use ruff_formatter::prelude::tag::Condition;
 use ruff_formatter::{format_args, write, Argument, Arguments};
 use ruff_python_ast::AnyNodeRef;
-use ruff_python_ast::ExpressionRef;
+use ruff_python_ast::ExprRef;
 use ruff_python_trivia::CommentRanges;
 use ruff_python_trivia::{
     first_non_trivia_token, BackwardsTokenizer, SimpleToken, SimpleTokenKind,
@@ -93,9 +93,9 @@ pub enum Parentheses {
     Never,
 }
 
-/// Returns `true` if the [`ExpressionRef`] is enclosed by parentheses in the source code.
+/// Returns `true` if the [`ExprRef`] is enclosed by parentheses in the source code.
 pub(crate) fn is_expression_parenthesized(
-    expr: ExpressionRef,
+    expr: ExprRef,
     comment_ranges: &CommentRanges,
     contents: &str,
 ) -> bool {
@@ -449,7 +449,7 @@ impl Format<PyFormatContext<'_>> for FormatEmptyParenthesized<'_> {
 
 #[cfg(test)]
 mod tests {
-    use ruff_python_ast::ExpressionRef;
+    use ruff_python_ast::ExprRef;
     use ruff_python_parser::parse_expression;
     use ruff_python_trivia::CommentRanges;
 
@@ -460,7 +460,7 @@ mod tests {
         let expression = r#"(b().c("")).d()"#;
         let parsed = parse_expression(expression).unwrap();
         assert!(!is_expression_parenthesized(
-            ExpressionRef::from(parsed.expr()),
+            ExprRef::from(parsed.expr()),
             &CommentRanges::default(),
             expression
         ));

--- a/crates/ruff_python_semantic/src/nodes.rs
+++ b/crates/ruff_python_semantic/src/nodes.rs
@@ -79,7 +79,7 @@ impl<'a> Index<NodeId> for Nodes<'a> {
 ///
 /// TODO(charlie): Replace with [`ruff_python_ast::AnyNodeRef`]. This requires migrating
 /// the rest of the codebase to use [`ruff_python_ast::AnyNodeRef`] and related abstractions,
-/// like [`ruff_python_ast::ExpressionRef`] instead of [`Expr`].
+/// like [`ruff_python_ast::ExprRef`] instead of [`Expr`].
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub enum NodeRef<'a> {
     Stmt(&'a Stmt),


### PR DESCRIPTION
The AST generator creates a reference enum for each syntax group — an enum where each variant contains a reference to the relevant syntax node.  Previously you could customize the name of the reference enum for a group — primarily because there was an existing `ExpressionRef` type that wouldn't have lined up with the auto-derived name `ExprRef`.  This follow-up PR is a simple search/replace to switch over to the auto-derived name, so that we can remove this customization point.
