### PR TITLE
Create Unknown rule diagnostics with a source range

### DIFF
--- a/crates/red_knot/src/main.rs
+++ b/crates/red_knot/src/main.rs
@@ -7,7 +7,7 @@ use colored::Colorize;
 use crossbeam::channel as crossbeam_channel;
 use python_version::PythonVersion;
 use red_knot_project::metadata::options::{EnvironmentOptions, Options};
-use red_knot_project::metadata::value::RelativePathBuf;
+use red_knot_project::metadata::value::{RangedValue, RelativePathBuf};
 use red_knot_project::watch;
 use red_knot_project::watch::ProjectWatcher;
 use red_knot_project::{ProjectDatabase, ProjectMetadata};
@@ -73,7 +73,9 @@ impl Args {
     fn to_options(&self) -> Options {
         Options {
             environment: Some(EnvironmentOptions {
-                python_version: self.python_version.map(Into::into),
+                python_version: self
+                    .python_version
+                    .map(|version| RangedValue::cli(version.into())),
                 venv_path: self.venv_path.as_ref().map(RelativePathBuf::cli),
                 typeshed: self.typeshed.as_ref().map(RelativePathBuf::cli),
                 extra_paths: self.extra_search_path.as_ref().map(|extra_search_paths| {

--- a/crates/red_knot/tests/cli.rs
+++ b/crates/red_knot/tests/cli.rs
@@ -287,7 +287,7 @@ division-by-zer = "warn" # incorrect rule name
         success: false
         exit_code: 1
         ----- stdout -----
-        warning[unknown-rule] Unknown lint rule `division-by-zer`
+        warning[unknown-rule] <temp_dir>/pyproject.toml:3:1 Unknown lint rule `division-by-zer`
 
         ----- stderr -----
         ");

--- a/crates/red_knot/tests/file_watching.rs
+++ b/crates/red_knot/tests/file_watching.rs
@@ -6,7 +6,7 @@ use std::time::{Duration, Instant};
 use anyhow::{anyhow, Context};
 use red_knot_project::metadata::options::{EnvironmentOptions, Options};
 use red_knot_project::metadata::pyproject::{PyProject, Tool};
-use red_knot_project::metadata::value::RelativePathBuf;
+use red_knot_project::metadata::value::{RangedValue, RelativePathBuf};
 use red_knot_project::watch::{directory_watcher, ChangeEvent, ProjectWatcher};
 use red_knot_project::{Db, ProjectDatabase, ProjectMetadata};
 use red_knot_python_semantic::{resolve_module, ModuleName, PythonPlatform, PythonVersion};
@@ -897,8 +897,10 @@ print(sys.last_exc, os.getegid())
         |_root_path, _project_path| {
             Some(Options {
                 environment: Some(EnvironmentOptions {
-                    python_version: Some(PythonVersion::PY311),
-                    python_platform: Some(PythonPlatform::Identifier("win32".to_string())),
+                    python_version: Some(RangedValue::cli(PythonVersion::PY311)),
+                    python_platform: Some(RangedValue::cli(PythonPlatform::Identifier(
+                        "win32".to_string(),
+                    ))),
                     ..EnvironmentOptions::default()
                 }),
                 ..Options::default()
@@ -921,8 +923,10 @@ print(sys.last_exc, os.getegid())
     // Change the python version
     case.update_options(Options {
         environment: Some(EnvironmentOptions {
-            python_version: Some(PythonVersion::PY312),
-            python_platform: Some(PythonPlatform::Identifier("linux".to_string())),
+            python_version: Some(RangedValue::cli(PythonVersion::PY312)),
+            python_platform: Some(RangedValue::cli(PythonPlatform::Identifier(
+                "linux".to_string(),
+            ))),
             ..EnvironmentOptions::default()
         }),
         ..Options::default()
@@ -1382,7 +1386,7 @@ mod unix {
                         extra_paths: Some(vec![RelativePathBuf::cli(
                             ".venv/lib/python3.12/site-packages",
                         )]),
-                        python_version: Some(PythonVersion::PY312),
+                        python_version: Some(RangedValue::cli(PythonVersion::PY312)),
                         ..EnvironmentOptions::default()
                     }),
                     ..Options::default()

--- a/crates/red_knot_project/src/metadata.rs
+++ b/crates/red_knot_project/src/metadata.rs
@@ -55,7 +55,7 @@ impl ProjectMetadata {
     ) -> Self {
         let name = project
             .and_then(|project| project.name.as_ref())
-            .map(|name| Name::new(&**name))
+            .map(|name| Name::new(&***name))
             .unwrap_or_else(|| Name::new(root.file_name().unwrap_or("root")));
 
         // TODO(https://github.com/astral-sh/ruff/issues/15491): Respect requires-python

--- a/crates/red_knot_project/src/metadata/pyproject.rs
+++ b/crates/red_knot_project/src/metadata/pyproject.rs
@@ -4,7 +4,7 @@ use std::ops::Deref;
 use thiserror::Error;
 
 use crate::metadata::options::Options;
-use crate::metadata::value::{ValueSource, ValueSourceGuard};
+use crate::metadata::value::{RangedValue, ValueSource, ValueSourceGuard};
 
 /// A `pyproject.toml` as specified in PEP 517.
 #[derive(Deserialize, Serialize, Debug, Default, Clone)]
@@ -48,11 +48,11 @@ pub struct Project {
     ///
     /// Note: Intentionally option to be more permissive during deserialization.
     /// `PackageMetadata::from_pyproject` reports missing names.
-    pub name: Option<PackageName>,
+    pub name: Option<RangedValue<PackageName>>,
     /// The version of the project
-    pub version: Option<Version>,
+    pub version: Option<RangedValue<Version>>,
     /// The Python versions this project is compatible with.
-    pub requires_python: Option<VersionSpecifiers>,
+    pub requires_python: Option<RangedValue<VersionSpecifiers>>,
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]

--- a/crates/red_knot_project/src/metadata/value.rs
+++ b/crates/red_knot_project/src/metadata/value.rs
@@ -139,7 +139,7 @@ where
     }
 }
 
-// The type already has a `into_iter` method thanks to `Deref`.
+// The type already has an `iter` method thanks to `Deref`.
 #[allow(clippy::into_iter_without_iter)]
 impl<'a, T> IntoIterator for &'a RangedValue<T>
 where

--- a/crates/red_knot_project/src/metadata/value.rs
+++ b/crates/red_knot_project/src/metadata/value.rs
@@ -1,11 +1,15 @@
-use ruff_db::system::{System, SystemPath, SystemPathBuf};
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use std::cell::RefCell;
-use std::hash::{Hash, Hasher};
-use std::sync::Arc;
-
 use crate::combine::Combine;
 use crate::Db;
+use ruff_db::system::{System, SystemPath, SystemPathBuf};
+use ruff_text_size::{TextRange, TextSize};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::cell::RefCell;
+use std::cmp::Ordering;
+use std::fmt;
+use std::hash::{Hash, Hasher};
+use std::ops::{Deref, DerefMut};
+use std::sync::Arc;
+use toml::Spanned;
 
 #[derive(Clone, Debug)]
 pub enum ValueSource {
@@ -49,6 +53,213 @@ impl Drop for ValueSourceGuard {
     }
 }
 
+/// A configuration value that tracks where it originates from and the range in the source document.
+///
+/// ## Equality, Hash, and Ordering
+/// The equality, hash, and ordering are solely based on the value. They disregard the value's range
+/// or source.
+///
+/// This ensures that two resolved configurations are identical even if the position of a value has changed
+/// or if the values were loaded from different sources.
+#[derive(Clone)]
+pub struct RangedValue<T> {
+    value: T,
+    source: ValueSource,
+    range: Option<TextRange>,
+}
+
+impl<T> RangedValue<T> {
+    pub fn new(value: T, source: ValueSource) -> Self {
+        Self::with_range(value, source, TextRange::default())
+    }
+
+    pub fn cli(value: T) -> Self {
+        Self::with_range(value, ValueSource::Cli, TextRange::default())
+    }
+
+    pub fn with_range(value: T, source: ValueSource, range: TextRange) -> Self {
+        Self {
+            value,
+            range: Some(range),
+            source,
+        }
+    }
+
+    pub fn range(&self) -> Option<TextRange> {
+        self.range
+    }
+
+    #[must_use]
+    pub fn with_source(mut self, source: ValueSource) -> Self {
+        self.source = source;
+        self
+    }
+
+    pub fn into_inner(self) -> T {
+        self.value
+    }
+}
+
+impl<T> Combine for RangedValue<T> {
+    fn combine(self, _other: Self) -> Self
+    where
+        Self: Sized,
+    {
+        self
+    }
+    fn combine_with(&mut self, _other: Self) {}
+}
+
+impl<T> IntoIterator for RangedValue<T>
+where
+    T: IntoIterator,
+{
+    type Item = T::Item;
+    type IntoIter = T::IntoIter;
+    fn into_iter(self) -> Self::IntoIter {
+        self.value.into_iter()
+    }
+}
+
+// The type already has a `into_iter` method thanks to `Deref`.
+#[allow(clippy::into_iter_without_iter)]
+impl<'a, T> IntoIterator for &'a RangedValue<T>
+where
+    &'a T: IntoIterator,
+{
+    type Item = <&'a T as IntoIterator>::Item;
+    type IntoIter = <&'a T as IntoIterator>::IntoIter;
+    fn into_iter(self) -> Self::IntoIter {
+        self.value.into_iter()
+    }
+}
+
+// The type already has a `into_iter_mut` method thanks to `DerefMut`.
+#[allow(clippy::into_iter_without_iter)]
+impl<'a, T> IntoIterator for &'a mut RangedValue<T>
+where
+    &'a mut T: IntoIterator,
+{
+    type Item = <&'a mut T as IntoIterator>::Item;
+    type IntoIter = <&'a mut T as IntoIterator>::IntoIter;
+    fn into_iter(self) -> Self::IntoIter {
+        self.value.into_iter()
+    }
+}
+
+impl<T> fmt::Debug for RangedValue<T>
+where
+    T: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.value.fmt(f)
+    }
+}
+
+impl<T> fmt::Display for RangedValue<T>
+where
+    T: fmt::Display,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.value.fmt(f)
+    }
+}
+
+impl<T> Deref for RangedValue<T> {
+    type Target = T;
+    fn deref(&self) -> &Self::Target {
+        &self.value
+    }
+}
+
+impl<T> DerefMut for RangedValue<T> {
+    fn deref_mut(&mut self) -> &mut T {
+        &mut self.value
+    }
+}
+
+impl<T, U: ?Sized> AsRef<U> for RangedValue<T>
+where
+    T: AsRef<U>,
+{
+    fn as_ref(&self) -> &U {
+        self.value.as_ref()
+    }
+}
+
+impl<T: PartialEq> PartialEq for RangedValue<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.value.eq(&other.value)
+    }
+}
+
+impl<T: PartialEq<T>> PartialEq<T> for RangedValue<T> {
+    fn eq(&self, other: &T) -> bool {
+        self.value.eq(other)
+    }
+}
+
+impl<T: Eq> Eq for RangedValue<T> {}
+
+impl<T: Hash> Hash for RangedValue<T> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.value.hash(state);
+    }
+}
+
+impl<T: PartialOrd> PartialOrd for RangedValue<T> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        self.value.partial_cmp(&other.value)
+    }
+}
+
+impl<T: PartialOrd<T>> PartialOrd<T> for RangedValue<T> {
+    fn partial_cmp(&self, other: &T) -> Option<Ordering> {
+        self.value.partial_cmp(other)
+    }
+}
+
+impl<T: Ord> Ord for RangedValue<T> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.value.cmp(&other.value)
+    }
+}
+
+impl<'de, T> Deserialize<'de> for RangedValue<T>
+where
+    T: Deserialize<'de>,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let spanned: Spanned<T> = Spanned::deserialize(deserializer)?;
+        let span = spanned.span();
+        let range = TextRange::new(
+            TextSize::try_from(span.start).expect("Configuration file to be smaller than 4GB"),
+            TextSize::try_from(span.end).expect("Configuration file to be smaller than 4GB"),
+        );
+
+        Ok(VALUE_SOURCE.with_borrow(|source| {
+            let source = source.clone().unwrap();
+
+            Self::with_range(spanned.into_inner(), source, range)
+        }))
+    }
+}
+
+impl<T> Serialize for RangedValue<T>
+where
+    T: Serialize,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        self.value.serialize(serializer)
+    }
+}
+
 /// A possibly relative path in a configuration file.
 ///
 /// Relative paths in configuration files or from CLI options
@@ -56,18 +267,15 @@ impl Drop for ValueSourceGuard {
 ///
 /// * CLI: The path is relative to the current working directory
 /// * Configuration file: The path is relative to the project's root.
-#[derive(Debug, Clone)]
-pub struct RelativePathBuf {
-    path: SystemPathBuf,
-    source: ValueSource,
-}
+#[derive(
+    Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
+#[serde(transparent)]
+pub struct RelativePathBuf(RangedValue<SystemPathBuf>);
 
 impl RelativePathBuf {
     pub fn new(path: impl AsRef<SystemPath>, source: ValueSource) -> Self {
-        Self {
-            path: path.as_ref().to_path_buf(),
-            source,
-        }
+        Self(RangedValue::new(path.as_ref().to_path_buf(), source))
     }
 
     pub fn cli(path: impl AsRef<SystemPath>) -> Self {
@@ -76,12 +284,12 @@ impl RelativePathBuf {
 
     /// Returns the relative path as specified by the user.
     pub fn path(&self) -> &SystemPath {
-        &self.path
+        &self.0
     }
 
     /// Returns the owned relative path.
     pub fn into_path_buf(self) -> SystemPathBuf {
-        self.path
+        self.0.into_inner()
     }
 
     /// Resolves the absolute path for `self` based on its origin.
@@ -91,73 +299,21 @@ impl RelativePathBuf {
 
     /// Resolves the absolute path for `self` based on its origin.
     pub fn absolute(&self, project_root: &SystemPath, system: &dyn System) -> SystemPathBuf {
-        let relative_to = match &self.source {
+        let relative_to = match &self.0.source {
             ValueSource::File(_) => project_root,
             ValueSource::Cli => system.current_directory(),
         };
 
-        SystemPath::absolute(&self.path, relative_to)
+        SystemPath::absolute(&self.0, relative_to)
     }
 }
 
-// TODO(micha): Derive most of those implementations once `RelativePath` uses `Value`.
-//   and use `serde(transparent, deny_unknown_fields)`
 impl Combine for RelativePathBuf {
-    fn combine(self, _other: Self) -> Self {
-        self
+    fn combine(self, other: Self) -> Self {
+        Self(self.0.combine(other.0))
     }
 
-    #[inline(always)]
-    fn combine_with(&mut self, _other: Self) {}
-}
-
-impl Hash for RelativePathBuf {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.path.hash(state);
-    }
-}
-
-impl PartialEq for RelativePathBuf {
-    fn eq(&self, other: &Self) -> bool {
-        self.path.eq(&other.path)
-    }
-}
-
-impl Eq for RelativePathBuf {}
-
-impl PartialOrd for RelativePathBuf {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl Ord for RelativePathBuf {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        self.path.cmp(&other.path)
-    }
-}
-
-impl Serialize for RelativePathBuf {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        self.path.serialize(serializer)
-    }
-}
-
-impl<'de> Deserialize<'de> for RelativePathBuf {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let path = SystemPathBuf::deserialize(deserializer)?;
-        Ok(VALUE_SOURCE.with_borrow(|source| {
-            let source = source
-                .clone()
-                .expect("Thread local `VALUE_SOURCE` to be set. Use `ValueSourceGuard` to set the value source before calling serde/toml `from_str`.");
-
-            Self { path, source }
-        }))
+    fn combine_with(&mut self, other: Self) {
+        self.0.combine_with(other.0);
     }
 }

--- a/crates/red_knot_python_semantic/src/lint.rs
+++ b/crates/red_knot_python_semantic/src/lint.rs
@@ -414,7 +414,7 @@ pub struct RuleSelection {
     /// Map with the severity for each enabled lint rule.
     ///
     /// If a rule isn't present in this map, then it should be considered disabled.
-    lints: FxHashMap<LintId, Severity>,
+    lints: FxHashMap<LintId, (Severity, LintSource)>,
 }
 
 impl RuleSelection {
@@ -427,7 +427,7 @@ impl RuleSelection {
             .filter_map(|lint| {
                 Severity::try_from(lint.default_level())
                     .ok()
-                    .map(|severity| (*lint, severity))
+                    .map(|severity| (*lint, (severity, LintSource::Default)))
             })
             .collect();
 
@@ -441,12 +441,14 @@ impl RuleSelection {
 
     /// Returns an iterator over all enabled lints and their severity.
     pub fn iter(&self) -> impl ExactSizeIterator<Item = (LintId, Severity)> + '_ {
-        self.lints.iter().map(|(&lint, &severity)| (lint, severity))
+        self.lints
+            .iter()
+            .map(|(&lint, &(severity, _))| (lint, severity))
     }
 
     /// Returns the configured severity for the lint with the given id or `None` if the lint is disabled.
     pub fn severity(&self, lint: LintId) -> Option<Severity> {
-        self.lints.get(&lint).copied()
+        self.lints.get(&lint).map(|(severity, _)| *severity)
     }
 
     /// Returns `true` if the `lint` is enabled.
@@ -457,19 +459,25 @@ impl RuleSelection {
     /// Enables `lint` and configures with the given `severity`.
     ///
     /// Overrides any previous configuration for the lint.
-    pub fn enable(&mut self, lint: LintId, severity: Severity) {
-        self.lints.insert(lint, severity);
+    pub fn enable(&mut self, lint: LintId, severity: Severity, source: LintSource) {
+        self.lints.insert(lint, (severity, source));
     }
 
     /// Disables `lint` if it was previously enabled.
     pub fn disable(&mut self, lint: LintId) {
         self.lints.remove(&lint);
     }
+}
 
-    /// Merges the enabled lints from `other` into this selection.
-    ///
-    /// Lints from `other` will override any existing configuration.
-    pub fn merge(&mut self, other: &RuleSelection) {
-        self.lints.extend(other.iter());
-    }
+#[derive(Default, Copy, Clone, Debug, PartialEq, Eq)]
+pub enum LintSource {
+    /// The user didn't enable the rule explicitly, instead it's enabled by default.
+    #[default]
+    Default,
+
+    /// The rule was enabled by using a CLI argument
+    Cli,
+
+    /// The rule was enabled in a configuration file.
+    File,
 }

--- a/crates/red_knot_wasm/src/lib.rs
+++ b/crates/red_knot_wasm/src/lib.rs
@@ -4,6 +4,7 @@ use js_sys::Error;
 use wasm_bindgen::prelude::*;
 
 use red_knot_project::metadata::options::{EnvironmentOptions, Options};
+use red_knot_project::metadata::value::RangedValue;
 use red_knot_project::ProjectMetadata;
 use red_knot_project::{Db, ProjectDatabase};
 use ruff_db::diagnostic::Diagnostic;
@@ -48,7 +49,7 @@ impl Workspace {
 
         workspace.apply_cli_options(Options {
             environment: Some(EnvironmentOptions {
-                python_version: Some(settings.python_version.into()),
+                python_version: Some(RangedValue::cli(settings.python_version.into())),
                 ..EnvironmentOptions::default()
             }),
             ..Options::default()

--- a/crates/ruff_benchmark/benches/red_knot.rs
+++ b/crates/ruff_benchmark/benches/red_knot.rs
@@ -2,6 +2,7 @@
 
 use rayon::ThreadPoolBuilder;
 use red_knot_project::metadata::options::{EnvironmentOptions, Options};
+use red_knot_project::metadata::value::RangedValue;
 use red_knot_project::watch::{ChangeEvent, ChangedKind};
 use red_knot_project::{Db, ProjectDatabase, ProjectMetadata};
 use red_knot_python_semantic::PythonVersion;
@@ -76,7 +77,7 @@ fn setup_case() -> Case {
     let mut metadata = ProjectMetadata::discover(src_root, &system).unwrap();
     metadata.apply_cli_options(Options {
         environment: Some(EnvironmentOptions {
-            python_version: Some(PythonVersion::PY312),
+            python_version: Some(RangedValue::cli(PythonVersion::PY312)),
             ..EnvironmentOptions::default()
         }),
         ..Options::default()


### PR DESCRIPTION
## Summary

Track the source range of values deserialized from the TOML configuration and use the source range to create unknown-rule diagnostics that point to the right location in the configuration file. 

```
────────────┬───────────────────────────────────────────────────────────────────
    0     0 │ success: false
    1     1 │ exit_code: 1
    2     2 │ ----- stdout -----
    3       │-warning[unknown-rule] Unknown lint rule `division-by-zer`
          3 │+warning[unknown-rule] <temp_dir>/pyproject.toml:3:1 Unknown lint rule `division-by-zer`
    4     4 │ 
    5     5 │ ----- stderr -----
```

This PR makes use of [`toml`'s spanned](https://docs.rs/toml/latest/toml/struct.Spanned.html) functionality to get a text range for every deserialized value in combination with the `ValueSource` that I introduced in [previ](https://github.com/astral-sh/ruff/pull/15634). 

Toml's spanned feature has one significant drawback: It doesn't support `flatten` or `untagged`, at least when using the derived deserializer. The [`toml-span`](https://crates.io/crates/toml-span) crate explains why in more detail. 

I considered using `toml-span` instead, but it requires you to write all `Deserializer`s manually. I ultimately decided to go with `toml`'s span because:

* We can always migrate to `toml-span` if we **have** to use `flatten` or similar (either for the entire configuration or only the problematic values)
* Writing deserializer's manually brings the risk that the JSON schema and `Deserializer` diverge
* We want to avoid `flatten` as much as possible because it leads to very unhelpful error messages when the configuration can't be deserialized because of an unknown field or invalid type.
* It's simply easier :)


I do expect that using this approach will require some hackery to support e.g. a `string | vec<string>` value but this has been solved by [cargo-vet](https://github.com/Gankra/cargo-vet/blob/989b65b0d63bb3dfd974d737fce0ef7397825b00/src/serialization.rs#L26-L39). 


This PR is inspired by https://github.com/mozilla/cargo-vet/pull/230

Part of https://github.com/astral-sh/ruff/issues/15491

## Test Plan

See the changes in the CLI test