### PR TITLE
Upgrade zizmor to the latest version in CI

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -23,6 +23,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 env:
   PACKAGE_NAME: ruff
   MODULE_NAME: ruff

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -23,8 +23,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-permissions:
-  contents: read
+permissions: {}
 
 env:
   PACKAGE_NAME: ruff

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,8 +36,6 @@ jobs:
       code: ${{ steps.changed.outputs.code_any_changed }}
       # Flag that is raised when any code that affects the fuzzer is changed
       fuzz: ${{ steps.changed.outputs.fuzz_any_changed }}
-    permissions:
-      pull-requests: read
     steps:
       - uses: actions/checkout@v4
         with:
@@ -102,8 +100,6 @@ jobs:
     name: "cargo fmt"
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    permissions:
-      contents: read
     steps:
       - uses: actions/checkout@v4
         with:
@@ -116,8 +112,6 @@ jobs:
     name: "cargo clippy"
     runs-on: ubuntu-latest
     needs: determine_changes
-    permissions:
-      contents: read
     if: ${{ needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/main' }}
     timeout-minutes: 20
     steps:
@@ -138,8 +132,6 @@ jobs:
     name: "cargo test (linux)"
     runs-on: depot-ubuntu-22.04-16
     needs: determine_changes
-    permissions:
-      contents: read
     if: ${{ needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/main' }}
     timeout-minutes: 20
     steps:
@@ -188,8 +180,6 @@ jobs:
     needs: determine_changes
     if: ${{ needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/main' }}
     timeout-minutes: 20
-    permissions:
-      contents: read
     steps:
       - uses: actions/checkout@v4
         with:
@@ -245,8 +235,6 @@ jobs:
     needs: determine_changes
     if: ${{ needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/main' }}
     timeout-minutes: 10
-    permissions:
-      contents: read
     steps:
       - uses: actions/checkout@v4
         with:
@@ -275,8 +263,6 @@ jobs:
     name: "cargo build (release)"
     runs-on: macos-latest
     if: ${{ github.ref == 'refs/heads/main' }}
-    permissions:
-      contents: read
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
@@ -294,8 +280,6 @@ jobs:
     name: "cargo build (msrv)"
     runs-on: ubuntu-latest
     needs: determine_changes
-    permissions:
-      contents: read
     if: ${{ needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/main' }}
     timeout-minutes: 20
     steps:
@@ -548,8 +532,6 @@ jobs:
     name: "cargo shear"
     runs-on: ubuntu-latest
     needs: determine_changes
-    permissions:
-      contents: read
     if: ${{ needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/main' }}
     steps:
       - uses: actions/checkout@v4
@@ -563,8 +545,6 @@ jobs:
     name: "python package"
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    permissions:
-      contents: read
     steps:
       - uses: actions/checkout@v4
         with:
@@ -592,8 +572,6 @@ jobs:
     name: "pre-commit"
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    permissions:
-      contents: read
     steps:
       - uses: actions/checkout@v4
         with:
@@ -736,8 +714,6 @@ jobs:
     needs: determine_changes
     if: ${{ github.repository == 'astral-sh/ruff' && (needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/main') }}
     timeout-minutes: 20
-    permissions:
-      contents: read
     steps:
       - name: "Checkout Branch"
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,7 @@
 name: CI
 
+permissions: {}
+
 on:
   push:
     branches: [main]
@@ -34,6 +36,8 @@ jobs:
       code: ${{ steps.changed.outputs.code_any_changed }}
       # Flag that is raised when any code that affects the fuzzer is changed
       fuzz: ${{ steps.changed.outputs.fuzz_any_changed }}
+    permissions:
+      pull-requests: read
     steps:
       - uses: actions/checkout@v4
         with:
@@ -98,6 +102,8 @@ jobs:
     name: "cargo fmt"
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
         with:
@@ -110,6 +116,8 @@ jobs:
     name: "cargo clippy"
     runs-on: ubuntu-latest
     needs: determine_changes
+    permissions:
+      contents: read
     if: ${{ needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/main' }}
     timeout-minutes: 20
     steps:
@@ -130,6 +138,8 @@ jobs:
     name: "cargo test (linux)"
     runs-on: depot-ubuntu-22.04-16
     needs: determine_changes
+    permissions:
+      contents: read
     if: ${{ needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/main' }}
     timeout-minutes: 20
     steps:
@@ -178,6 +188,8 @@ jobs:
     needs: determine_changes
     if: ${{ needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/main' }}
     timeout-minutes: 20
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
         with:
@@ -233,6 +245,8 @@ jobs:
     needs: determine_changes
     if: ${{ needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/main' }}
     timeout-minutes: 10
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
         with:
@@ -261,6 +275,8 @@ jobs:
     name: "cargo build (release)"
     runs-on: macos-latest
     if: ${{ github.ref == 'refs/heads/main' }}
+    permissions:
+      contents: read
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
@@ -278,6 +294,8 @@ jobs:
     name: "cargo build (msrv)"
     runs-on: ubuntu-latest
     needs: determine_changes
+    permissions:
+      contents: read
     if: ${{ needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/main' }}
     timeout-minutes: 20
     steps:
@@ -530,6 +548,8 @@ jobs:
     name: "cargo shear"
     runs-on: ubuntu-latest
     needs: determine_changes
+    permissions:
+      contents: read
     if: ${{ needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/main' }}
     steps:
       - uses: actions/checkout@v4
@@ -543,6 +563,8 @@ jobs:
     name: "python package"
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
         with:
@@ -570,6 +592,8 @@ jobs:
     name: "pre-commit"
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
         with:
@@ -712,6 +736,8 @@ jobs:
     needs: determine_changes
     if: ${{ github.repository == 'astral-sh/ruff' && (needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/main') }}
     timeout-minutes: 20
+    permissions:
+      contents: read
     steps:
       - name: "Checkout Branch"
         uses: actions/checkout@v4

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -11,6 +11,8 @@ rules:
       - build-docker.yml
       - publish-playground.yml
   excessive-permissions:
+    # it's hard to test what the impact of removing these ignores would be
+    # without actually running the release workflow...
     ignore:
       - build-docker.yml
       - publish-playground.yml

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -10,3 +10,8 @@ rules:
     ignore:
       - build-docker.yml
       - publish-playground.yml
+  excessive-permissions:
+    ignore:
+      - build-docker.yml
+      - publish-playground.yml
+      - publish-docs.yml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -91,7 +91,7 @@ repos:
   # zizmor detects security vulnerabilities in GitHub Actions workflows.
   # Additional configuration for the tool is found in `.github/zizmor.yml`
   - repo: https://github.com/woodruffw/zizmor-pre-commit
-    rev: v1.1.1
+    rev: v1.2.2
     hooks:
       - id: zizmor
 


### PR DESCRIPTION
## Summary

The latest version of zizmor points out that we have the default permissions set in several of our GitHub workflows that don't really need any permissions at all. These can be made more secure by restricting the permissions for these workflows.

## Test Plan

CI on this PR. All workflows being modified here are fully run as part of normal PR CI.
