### PR TITLE
[`flake8-bandit`] Add missing single-line/dotall regex flag (`S608`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_bandit/S608.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_bandit/S608.py
@@ -154,3 +154,15 @@ FROM {var}.table
 # to be handled separately
 # query58 = f"SELECT\
 #  * FROM {var}.table"
+
+
+# https://github.com/astral-sh/ruff/issues/15653
+query59 = f"""
+    SELECT *, foo
+    FROM ({user_input}) raw
+"""
+query60 = f"""
+    SELECT *,
+        foo
+    FROM ({user_input}) raw
+"""

--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/hardcoded_sql_expression.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/hardcoded_sql_expression.rs
@@ -12,7 +12,16 @@ use crate::checkers::ast::Checker;
 use crate::Locator;
 
 static SQL_REGEX: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"(?i)\b(select\s+.*\s+from\s|delete\s+from\s|(insert|replace)\s+.*\s+values\s|update\s+.*\s+set\s)")
+    Regex::new(
+        r"(?isx)
+        \b
+        (select\s+.*\s+from\s
+        |delete\s+from\s
+        |(insert|replace)\s+.*\s+values\s
+        |update\s+.*\s+set\s
+        )
+    ",
+    )
     .unwrap()
 });
 

--- a/crates/ruff_linter/src/rules/flake8_bandit/snapshots/ruff_linter__rules__flake8_bandit__tests__S608_S608.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_bandit/snapshots/ruff_linter__rules__flake8_bandit__tests__S608_S608.py.snap
@@ -576,3 +576,29 @@ S608.py:144:11: S608 Possible SQL injection vector through string-based query co
 148 |
 149 |   query57 = f"""
     |
+
+S608.py:160:11: S608 Possible SQL injection vector through string-based query construction
+    |
+159 |   # https://github.com/astral-sh/ruff/issues/15653
+160 |   query59 = f"""
+    |  ___________^
+161 | |     SELECT *, foo
+162 | |     FROM ({user_input}) raw
+163 | | """
+    | |___^ S608
+164 |   query60 = f"""
+165 |       SELECT *,
+    |
+
+S608.py:164:11: S608 Possible SQL injection vector through string-based query construction
+    |
+162 |       FROM ({user_input}) raw
+163 |   """
+164 |   query60 = f"""
+    |  ___________^
+165 | |     SELECT *,
+166 | |         foo
+167 | |     FROM ({user_input}) raw
+168 | | """
+    | |___^ S608
+    |


### PR DESCRIPTION
## Summary

Resolves #15653.

## Test Plan

`cargo nextest run` and `cargo insta test`.