### PR TITLE
better error messages while loading configuration `extend`s

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3237,6 +3237,7 @@ dependencies = [
  "glob",
  "globset",
  "ignore",
+ "indexmap",
  "is-macro",
  "itertools 0.14.0",
  "log",

--- a/crates/ruff/tests/format.rs
+++ b/crates/ruff/tests/format.rs
@@ -816,6 +816,7 @@ if True:
 
         ----- stderr -----
         ruff failed
+          Cause: Failed to load last configuration in chain: [RUFF-TOML-PATH]
           Cause: Failed to parse [RUFF-TOML-PATH]
           Cause: TOML parse error at line 1, column 1
           |
@@ -855,6 +856,7 @@ format = "json"
 
         ----- stderr -----
         ruff failed
+          Cause: Failed to load last configuration in chain: [RUFF-TOML-PATH]
           Cause: Failed to parse [RUFF-TOML-PATH]
           Cause: TOML parse error at line 2, column 10
           |

--- a/crates/ruff/tests/format.rs
+++ b/crates/ruff/tests/format.rs
@@ -816,7 +816,7 @@ if True:
 
         ----- stderr -----
         ruff failed
-          Cause: Failed to load last configuration in chain: [RUFF-TOML-PATH]
+          Cause: Failed to load configuration `[RUFF-TOML-PATH]`
           Cause: Failed to parse [RUFF-TOML-PATH]
           Cause: TOML parse error at line 1, column 1
           |
@@ -856,7 +856,7 @@ format = "json"
 
         ----- stderr -----
         ruff failed
-          Cause: Failed to load last configuration in chain: [RUFF-TOML-PATH]
+          Cause: Failed to load configuration `[RUFF-TOML-PATH]`
           Cause: Failed to parse [RUFF-TOML-PATH]
           Cause: TOML parse error at line 2, column 10
           |

--- a/crates/ruff/tests/lint.rs
+++ b/crates/ruff/tests/lint.rs
@@ -699,7 +699,7 @@ extend = "ruff.toml"
 
     ----- stderr -----
     ruff failed
-      Cause: Circular dependency detected in pyproject.toml: [TMP]/ruff.toml -> [TMP]/ruff2.toml -> [TMP]/ruff3.toml -> [TMP]/ruff.toml
+      Cause: Circular dependency detected: [TMP]/ruff.toml -> [TMP]/ruff2.toml -> [TMP]/ruff3.toml -> [TMP]/ruff.toml
     ");
     });
 

--- a/crates/ruff_workspace/Cargo.toml
+++ b/crates/ruff_workspace/Cargo.toml
@@ -21,12 +21,13 @@ ruff_macros = { workspace = true }
 ruff_python_ast = { workspace = true }
 ruff_python_formatter = { workspace = true, features = ["serde"] }
 ruff_python_semantic = { workspace = true, features = ["serde"] }
-ruff_python_stdlib = {workspace = true}
+ruff_python_stdlib = { workspace = true }
 ruff_source_file = { workspace = true }
 
 anyhow = { workspace = true }
 colored = { workspace = true }
 ignore = { workspace = true }
+indexmap = { workspace = true }
 is-macro = { workspace = true }
 itertools = { workspace = true }
 log = { workspace = true }
@@ -58,7 +59,12 @@ ignored = ["colored"]
 
 [features]
 default = []
-schemars = ["dep:schemars", "ruff_formatter/schemars", "ruff_python_formatter/schemars", "ruff_python_semantic/schemars"]
+schemars = [
+    "dep:schemars",
+    "ruff_formatter/schemars",
+    "ruff_python_formatter/schemars",
+    "ruff_python_semantic/schemars",
+]
 
 [lints]
 workspace = true

--- a/crates/ruff_workspace/src/resolver.rs
+++ b/crates/ruff_workspace/src/resolver.rs
@@ -310,7 +310,7 @@ pub fn resolve_configuration(
     while let Some(path) = next {
         if seen.contains(&path) {
             bail!(format!(
-                "Circular dependency detected in pyproject.toml: {}",
+                "Circular dependency detected: {}",
                 seen.iter().chain([&path]).map(|p| p.display()).join(" -> "),
             ));
         }

--- a/crates/ruff_workspace/src/resolver.rs
+++ b/crates/ruff_workspace/src/resolver.rs
@@ -306,24 +306,34 @@ pub fn resolve_configuration(
 ) -> Result<Configuration> {
     let mut seen = FxHashSet::default();
     let mut stack = vec![];
-    let mut next = Some(fs::normalize_path(pyproject));
-    while let Some(path) = next {
+    let mut next = Some((fs::normalize_path(pyproject), None::<PathBuf>));
+    while let Some((path, inherited_by)) = next {
         if seen.contains(&path) {
             bail!("Circular dependency detected in pyproject.toml");
         }
 
         // Resolve the current path.
-        let options = pyproject::load_options(&path)?;
+        let options = pyproject::load_options(&path).map_err(|err| match inherited_by {
+            Some(f) => err.context(format!(
+                "Failed to load path {} inherited by {}",
+                path.display(),
+                f.display(),
+            )),
+            None => err,
+        })?;
 
         let project_root = relativity.resolve(&path);
         let configuration = Configuration::from_options(options, Some(&path), project_root)?;
 
         // If extending, continue to collect.
         next = configuration.extend.as_ref().map(|extend| {
-            fs::normalize_path_to(
-                extend,
-                path.parent()
-                    .expect("Expected pyproject.toml file to be in parent directory"),
+            (
+                fs::normalize_path_to(
+                    extend,
+                    path.parent()
+                        .expect("Expected pyproject.toml file to be in parent directory"),
+                ),
+                Some(path.clone()),
             )
         });
 


### PR DESCRIPTION
Improves error messages during errors caused while extending a configuration using `extend`.

In the case of circular dependencies, it actually fixes the error too!

Old error messages:
```
# circular dependency - without even using pyproject.toml!
ruff failed
  Cause: Circular dependency detected in pyproject.toml

# file in "extends" doesn't exist
ruff failed
  Cause: Failed to read <path>/ruff4.toml
  Cause: No such file or directory (os error 2)
```

Now:
```
# circular dependency
ruff failed
  Cause: Circular dependency detected: <path>/ruff.toml -> <path>/ruff2.toml -> <path>/ruff3.toml -> <path>/ruff.toml

# circular dependency with a single file!
ruff failed
  Cause: Circular dependency detected: <path>/ruff.toml -> <path>/ruff.toml

# file in "extends" doesn't exist
ruff failed
  Cause: Failed to load last configuration in chain: <path>/ruff.toml -> <path>/ruff2.toml -> <path>/ruff3.toml -> <path>/ruff4.toml
  Cause: Failed to read <path>/ruff4.toml
  Cause: No such file or directory (os error 2)
```
