### PR TITLE
Cache the Rust toolchain in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -116,11 +116,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
+      - uses: Swatinem/rust-cache@v2
       - name: "Install Rust toolchain"
         run: |
           rustup component add clippy
           rustup target add wasm32-unknown-unknown
-      - uses: Swatinem/rust-cache@v2
       - name: "Clippy"
         run: cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
       - name: "Clippy (wasm)"
@@ -136,6 +136,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
+      - uses: Swatinem/rust-cache@v2
       - name: "Install Rust toolchain"
         run: rustup show
       - name: "Install mold"
@@ -148,7 +149,6 @@ jobs:
         uses: taiki-e/install-action@v2
         with:
           tool: cargo-insta
-      - uses: Swatinem/rust-cache@v2
       - name: "Run tests"
         shell: bash
         env:
@@ -182,6 +182,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
+      - uses: Swatinem/rust-cache@v2
       - name: "Install Rust toolchain"
         run: rustup show
       - name: "Install mold"
@@ -194,7 +195,6 @@ jobs:
         uses: taiki-e/install-action@v2
         with:
           tool: cargo-insta
-      - uses: Swatinem/rust-cache@v2
       - name: "Run tests"
         shell: bash
         env:
@@ -211,13 +211,13 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
+      - uses: Swatinem/rust-cache@v2
       - name: "Install Rust toolchain"
         run: rustup show
       - name: "Install cargo nextest"
         uses: taiki-e/install-action@v2
         with:
           tool: cargo-nextest
-      - uses: Swatinem/rust-cache@v2
       - name: "Run tests"
         shell: bash
         env:
@@ -237,6 +237,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
+      - uses: Swatinem/rust-cache@v2
       - name: "Install Rust toolchain"
         run: rustup target add wasm32-unknown-unknown
       - uses: actions/setup-node@v4
@@ -247,7 +248,6 @@ jobs:
       - uses: jetli/wasm-pack-action@v0.4.0
         with:
           version: v0.13.1
-      - uses: Swatinem/rust-cache@v2
       - name: "Test ruff_wasm"
         run: |
           cd crates/ruff_wasm
@@ -266,11 +266,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
+      - uses: Swatinem/rust-cache@v2
       - name: "Install Rust toolchain"
         run: rustup show
       - name: "Install mold"
         uses: rui314/setup-mold@v1
-      - uses: Swatinem/rust-cache@v2
       - name: "Build"
         run: cargo build --release --locked
 
@@ -289,6 +289,7 @@ jobs:
         with:
           file: "Cargo.toml"
           field: "workspace.package.rust-version"
+      - uses: Swatinem/rust-cache@v2
       - name: "Install Rust toolchain"
         env:
           MSRV: ${{ steps.msrv.outputs.value }}
@@ -303,7 +304,6 @@ jobs:
         uses: taiki-e/install-action@v2
         with:
           tool: cargo-insta
-      - uses: Swatinem/rust-cache@v2
       - name: "Run tests"
         shell: bash
         env:
@@ -321,11 +321,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
-      - name: "Install Rust toolchain"
-        run: rustup show
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: "fuzz -> target"
+      - name: "Install Rust toolchain"
+        run: rustup show
       - name: "Install cargo-binstall"
         uses: cargo-bins/cargo-binstall@main
         with:
@@ -383,9 +383,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
+      - uses: Swatinem/rust-cache@v2
       - name: "Install Rust toolchain"
         run: rustup component add rustfmt
-      - uses: Swatinem/rust-cache@v2
       # Run all code generation scripts, and verify that the current output is
       # already checked into git.
       - run: python crates/ruff_python_ast/generate.py
@@ -577,9 +577,9 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
+      - uses: Swatinem/rust-cache@v2
       - name: "Install Rust toolchain"
         run: rustup show
-      - uses: Swatinem/rust-cache@v2
       - name: "Install pre-commit"
         run: pip install pre-commit
       - name: "Cache pre-commit"
@@ -611,6 +611,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.13"
+      - uses: Swatinem/rust-cache@v2
       - name: "Add SSH key"
         if: ${{ env.MKDOCS_INSIDERS_SSH_KEY_EXISTS == 'true' }}
         uses: webfactory/ssh-agent@v0.9.0
@@ -620,7 +621,6 @@ jobs:
         run: rustup show
       - name: Install uv
         uses: astral-sh/setup-uv@v5
-      - uses: Swatinem/rust-cache@v2
       - name: "Install Insiders dependencies"
         if: ${{ env.MKDOCS_INSIDERS_SSH_KEY_EXISTS == 'true' }}
         run: uv pip install -r docs/requirements-insiders.txt --system
@@ -650,10 +650,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
+      - uses: Swatinem/rust-cache@v2
       - name: "Install Rust toolchain"
         run: rustup show
-      - name: "Cache rust"
-        uses: Swatinem/rust-cache@v2
       - name: "Run checks"
         run: scripts/formatter_ecosystem_checks.sh
       - name: "Github step summary"
@@ -718,6 +717,8 @@ jobs:
         with:
           persist-credentials: false
 
+      - uses: Swatinem/rust-cache@v2
+
       - name: "Install Rust toolchain"
         run: rustup show
 
@@ -725,8 +726,6 @@ jobs:
         uses: taiki-e/install-action@v2
         with:
           tool: cargo-codspeed
-
-      - uses: Swatinem/rust-cache@v2
 
       - name: "Build benchmarks"
         run: cargo codspeed build --features codspeed -p ruff_benchmark


### PR DESCRIPTION
We're spending a full 1.5m installing the Rust toolchain on Windows, e.g., https://github.com/astral-sh/ruff/actions/runs/12893749773/job/35950838258

In contrast, in uv this is instant (e.g. https://github.com/astral-sh/uv/actions/runs/12897572530/job/35962989190) because we are caching the toolchain.

This shifts the rust-cache action earlier in all the CI jobs.