### PR TITLE
Use new-style Windows runner tag

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -6,4 +6,5 @@ self-hosted-runner:
   labels:
     - depot-ubuntu-latest-8
     - depot-ubuntu-22.04-16
-    - windows-latest-xlarge
+    - github-windows-2025-x86_64-8
+    - github-windows-2025-x86_64-16

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -203,7 +203,7 @@ jobs:
 
   cargo-test-windows:
     name: "cargo test (windows)"
-    runs-on: windows-latest-xlarge
+    runs-on: github-windows-2025-x86_64-16
     needs: determine_changes
     if: ${{ needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/main' }}
     timeout-minutes: 20


### PR DESCRIPTION
I changed these org-wide to make it more obvious what runner it maps to; did not update here as I did in uv
