### PR TITLE
Add slow-test reporting to nextest in CI

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -6,3 +6,7 @@ failure-output = "immediate-final"
 fail-fast = false
 
 status-level = "skip"
+
+# Mark tests that take longer than 10s as slow.
+# Terminate after 90s as a stop-gap measure to terminate on deadlock.
+slow-timeout =  { period = "10s", terminate-after = 9 }

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -10,3 +10,6 @@ status-level = "skip"
 # Mark tests that take longer than 1s as slow.
 # Terminate after 60s as a stop-gap measure to terminate on deadlock.
 slow-timeout =  { period = "1s", terminate-after = 60 }
+
+# Show slow jobs in the final summary
+final-status-level = "slow"

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -7,6 +7,6 @@ fail-fast = false
 
 status-level = "skip"
 
-# Mark tests that take longer than 10s as slow.
-# Terminate after 90s as a stop-gap measure to terminate on deadlock.
-slow-timeout =  { period = "10s", terminate-after = 9 }
+# Mark tests that take longer than 1s as slow.
+# Terminate after 60s as a stop-gap measure to terminate on deadlock.
+slow-timeout =  { period = "1s", terminate-after = 60 }


### PR DESCRIPTION
This is helpful for spotting tests that are running slow. In uv, we use a 10s threshold. Here, it looks like we could use something smaller.

e.g.

<img width="964" alt="Screenshot 2025-01-21 at 6 08 00 PM" src="https://github.com/user-attachments/assets/b32bbc61-9815-4a43-938d-17cd0cf8b0de" />

