### PR TITLE
Set `NEXTEST_PROFILE=ci` on Windows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -221,6 +221,7 @@ jobs:
       - name: "Run tests"
         shell: bash
         env:
+          NEXTEST_PROFILE: "ci"
           # Workaround for <https://github.com/nextest-rs/nextest/issues/1493>.
           RUSTUP_WINDOWS_PATH_ADD_BIN: 1
         run: |


### PR DESCRIPTION
This is set in the other jobs, perhaps an oversight here
