### PR TITLE
[red-knot] Ensure a gradual type can always be assigned to itself

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/type_properties/is_assignable_to.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/type_properties/is_assignable_to.md
@@ -263,15 +263,12 @@ static_assert(not is_assignable_to(int, Not[int]))
 static_assert(not is_assignable_to(int, Not[Literal[1]]))
 
 static_assert(not is_assignable_to(Intersection[Any, Parent], Unrelated))
+static_assert(is_assignable_to(Intersection[Unrelated, Any], Intersection[Unrelated, Any]))
+static_assert(is_assignable_to(Intersection[Unrelated, Any], Intersection[Unrelated, Not[Any]]))
 
 # TODO: The following assertions should not fail (see https://github.com/astral-sh/ruff/issues/14899)
 # error: [static-assert-error]
 static_assert(is_assignable_to(Intersection[Any, int], int))
-
-# error: [static-assert-error]
-static_assert(is_assignable_to(Intersection[Unrelated, Any], Intersection[Unrelated, Any]))
-# error: [static-assert-error]
-static_assert(is_assignable_to(Intersection[Unrelated, Any], Intersection[Unrelated, Not[Any]]))
 # error: [static-assert-error]
 static_assert(is_assignable_to(Intersection[Unrelated, Any], Not[tuple[Unrelated, Any]]))
 ```

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -1008,7 +1008,7 @@ impl<'db> Type<'db> {
     ///
     /// [assignable to]: https://typing.readthedocs.io/en/latest/spec/concepts.html#the-assignable-to-or-consistent-subtyping-relation
     pub(crate) fn is_assignable_to(self, db: &'db dyn Db, target: Type<'db>) -> bool {
-        if self.is_equivalent_to(db, target) {
+        if self.is_gradual_equivalent_to(db, target) {
             return true;
         }
         match (self, target) {

--- a/crates/red_knot_python_semantic/src/types/property_tests.rs
+++ b/crates/red_knot_python_semantic/src/types/property_tests.rs
@@ -461,6 +461,12 @@ mod stable {
         forall types s, t.
             s.is_fully_static(db) && s.is_gradual_equivalent_to(db, t) => s.is_equivalent_to(db, t)
     );
+
+    // `T` can be assigned to itself.
+    type_property_test!(
+        assignable_to_is_reflexive, db,
+        forall types t. t.is_assignable_to(db, t)
+    );
 }
 
 /// This module contains property tests that currently lead to many false positives.
@@ -474,13 +480,6 @@ mod flaky {
     use itertools::Itertools;
 
     use super::{intersection, union};
-
-    // Currently fails due to https://github.com/astral-sh/ruff/issues/14899
-    // `T` can be assigned to itself.
-    type_property_test!(
-        assignable_to_is_reflexive, db,
-        forall types t. t.is_assignable_to(db, t)
-    );
 
     // Negating `T` twice is equivalent to `T`.
     type_property_test!(


### PR DESCRIPTION
## Summary

This helps with https://github.com/astral-sh/ruff/issues/14899, and allows us to promote the `assignable_to_is_reflexive` test back to stable.

## Test Plan

- `cargo test -p red_knot_python_semantic`
- ``QUICKCHECK_TESTS=1000000 cargo test --release -p red_knot_python_semantic -- --ignored types::property_tests::stable`
- `QUICKCHECK_TESTS=3000000 cargo test --release -p red_knot_python_semantic -- --ignored types::property_tests::stable::assignable_to_is_reflexive`
