### PR TITLE
[red-knot] Consider all definitions after terminal statements unreachable

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/terminal_statements.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/terminal_statements.md
@@ -1,0 +1,134 @@
+# Terminal statements
+
+## Introduction
+
+Terminal statements complicate a naive control-flow analysis.
+
+As a simple example:
+
+```py
+def f(cond: bool) -> str:
+    if cond:
+        x = "test"
+    else:
+        raise ValueError
+    # TODO: no error
+    # error: [possibly-unresolved-reference]
+    return x
+
+def g(cond: bool):
+    if cond:
+        x = "test"
+    else:
+        x = "unreachable"
+        raise ValueError
+    # TODO: Literal["test"]
+    reveal_type(x)  # revealed: Literal["test", "unreachable"]
+```
+
+In `f`, we should be able to determine that the `else` ends in a terminal statement, and that the
+`return` statement can only be executed when the condition is true. Even though `x` is only bound in
+the true branch, we should therefore consider the reference always bound.
+
+Similarly, in `g`, we should see that the assignment of the value `"unreachable"` can never be seen
+by the `reveal_type`.
+
+## `return` is terminal
+
+```py
+def f(cond: bool) -> str:
+    if cond:
+        x = "test"
+    else:
+        return "early"
+    # TODO: no error
+    # error: [possibly-unresolved-reference]
+    return x
+
+def g(cond: bool):
+    if cond:
+        x = "test"
+    else:
+        x = "unreachable"
+        return
+    # TODO: Literal["test"]
+    reveal_type(x)  # revealed: Literal["test", "unreachable"]
+```
+
+## `continue` is terminal within its loop scope
+
+```py
+def f(cond: bool) -> str:
+    while True:
+        if cond:
+            x = "test"
+        else:
+            continue
+        # TODO: no error
+        # error: [possibly-unresolved-reference]
+        return x
+
+def g(cond: bool):
+    while True:
+        if cond:
+            x = "test"
+        else:
+            x = "unreachable"
+            continue
+        # TODO: Literal["test"]
+        reveal_type(x)  # revealed: Literal["test", "unreachable"]
+```
+
+## `break` is terminal within its loop scope
+
+```py
+def f(cond: bool) -> str:
+    while True:
+        if cond:
+            x = "test"
+        else:
+            break
+        # TODO: no error
+        # error: [possibly-unresolved-reference]
+        return x
+    return "late"
+
+def g(cond: bool):
+    while True:
+        if cond:
+            x = "test"
+        else:
+            x = "unreachable"
+            break
+        # TODO: Literal["test"]
+        reveal_type(x)  # revealed: Literal["test", "unreachable"]
+```
+
+## `return` is terminal in nested scopes
+
+```py
+def f(cond1: bool, cond2: bool) -> str:
+    if cond1:
+        if cond2:
+            x = "test1"
+        else:
+            return "early"
+    else:
+        x = "test2"
+    # TODO: no error
+    # error: [possibly-unresolved-reference]
+    return x
+
+def g(cond1: bool, cond2: bool):
+    if cond1:
+        if cond2:
+            x = "test1"
+        else:
+            x = "unreachable"
+            return
+    else:
+        x = "test2"
+    # TODO: no error
+    # TODO: Literal["test"]
+    reveal_type(x)  # revealed: Literal["test1", "unreachable", "test2"]
+```

--- a/crates/red_knot_python_semantic/resources/mdtest/terminal_statements.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/terminal_statements.md
@@ -12,8 +12,6 @@ def f(cond: bool) -> str:
         x = "test"
     else:
         raise ValueError
-    # TODO: no error
-    # error: [possibly-unresolved-reference]
     return x
 
 def g(cond: bool):
@@ -22,8 +20,7 @@ def g(cond: bool):
     else:
         x = "unreachable"
         raise ValueError
-    # TODO: Literal["test"]
-    reveal_type(x)  # revealed: Literal["test", "unreachable"]
+    reveal_type(x)  # revealed: Literal["test"]
 ```
 
 In `f`, we should be able to determine that the `else` ends in a terminal statement, and that the
@@ -41,8 +38,6 @@ def f(cond: bool) -> str:
         x = "test"
     else:
         return "early"
-    # TODO: no error
-    # error: [possibly-unresolved-reference]
     return x
 
 def g(cond: bool):
@@ -51,8 +46,7 @@ def g(cond: bool):
     else:
         x = "unreachable"
         return
-    # TODO: Literal["test"]
-    reveal_type(x)  # revealed: Literal["test", "unreachable"]
+    reveal_type(x)  # revealed: Literal["test"]
 ```
 
 ## `continue` is terminal within its loop scope
@@ -64,8 +58,6 @@ def f(cond: bool) -> str:
             x = "test"
         else:
             continue
-        # TODO: no error
-        # error: [possibly-unresolved-reference]
         return x
 
 def g(cond: bool):
@@ -75,8 +67,7 @@ def g(cond: bool):
         else:
             x = "unreachable"
             continue
-        # TODO: Literal["test"]
-        reveal_type(x)  # revealed: Literal["test", "unreachable"]
+        reveal_type(x)  # revealed: Literal["test"]
 ```
 
 ## `break` is terminal within its loop scope
@@ -88,8 +79,6 @@ def f(cond: bool) -> str:
             x = "test"
         else:
             break
-        # TODO: no error
-        # error: [possibly-unresolved-reference]
         return x
     return "late"
 
@@ -100,8 +89,7 @@ def g(cond: bool):
         else:
             x = "unreachable"
             break
-        # TODO: Literal["test"]
-        reveal_type(x)  # revealed: Literal["test", "unreachable"]
+        reveal_type(x)  # revealed: Literal["test"]
 ```
 
 ## `return` is terminal in nested scopes
@@ -115,8 +103,6 @@ def f(cond1: bool, cond2: bool) -> str:
             return "early"
     else:
         x = "test2"
-    # TODO: no error
-    # error: [possibly-unresolved-reference]
     return x
 
 def g(cond1: bool, cond2: bool):
@@ -128,7 +114,5 @@ def g(cond1: bool, cond2: bool):
             return
     else:
         x = "test2"
-    # TODO: no error
-    # TODO: Literal["test"]
-    reveal_type(x)  # revealed: Literal["test1", "unreachable", "test2"]
+    reveal_type(x)  # revealed: Literal["test1", "test2"]
 ```

--- a/crates/red_knot_python_semantic/src/semantic_index/builder.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/builder.rs
@@ -368,7 +368,8 @@ impl<'db> SemanticIndexBuilder<'db> {
             .record_visibility_constraint(VisibilityConstraint::VisibleIf(constraint))
     }
 
-    /// Records that all remaining statements in the current block are unreachable.
+    /// Records that all remaining statements in the current block are unreachable, and therefore
+    /// not visible.
     fn record_unreachable_visibility(&mut self) -> ScopedVisibilityConstraintId {
         let id = self.add_visibility_constraint(VisibilityConstraint::AlwaysTrue);
         self.record_negated_visibility_constraint(id)

--- a/crates/red_knot_python_semantic/src/semantic_index/builder.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/builder.rs
@@ -368,6 +368,12 @@ impl<'db> SemanticIndexBuilder<'db> {
             .record_visibility_constraint(VisibilityConstraint::VisibleIf(constraint))
     }
 
+    /// Records that all remaining statements in the current block are unreachable.
+    fn record_unreachable_visibility(&mut self) -> ScopedVisibilityConstraintId {
+        let id = self.add_visibility_constraint(VisibilityConstraint::AlwaysTrue);
+        self.record_negated_visibility_constraint(id)
+    }
+
     /// Records a [`VisibilityConstraint::Ambiguous`] constraint.
     fn record_ambiguous_visibility(&mut self) -> ScopedVisibilityConstraintId {
         self.current_use_def_map_mut()
@@ -1019,11 +1025,6 @@ where
                 }
                 self.visit_body(body);
             }
-            ast::Stmt::Break(_) => {
-                if self.loop_state().is_inside() {
-                    self.loop_break_states.push(self.flow_snapshot());
-                }
-            }
 
             ast::Stmt::For(
                 for_stmt @ ast::StmtFor {
@@ -1270,6 +1271,21 @@ where
                 // - https://github.com/astral-sh/ruff/pull/13633#discussion_r1788626702
                 self.visit_body(finalbody);
             }
+
+            ast::Stmt::Raise(_) | ast::Stmt::Return(_) | ast::Stmt::Continue(_) => {
+                walk_stmt(self, stmt);
+                // Everything in the current block after a terminal statement is unreachable.
+                self.record_unreachable_visibility();
+            }
+
+            ast::Stmt::Break(_) => {
+                if self.loop_state().is_inside() {
+                    self.loop_break_states.push(self.flow_snapshot());
+                }
+                // Everything in the current block after a terminal statement is unreachable.
+                self.record_unreachable_visibility();
+            }
+
             _ => {
                 walk_stmt(self, stmt);
             }


### PR DESCRIPTION
We can use the new statically known branches feature to address #14014, by adding an "always false" visibility constraint immediately after each terminal statement.

## Test Plan

The new mdtests failed (with incorrect `reveal_type` results, and spurious `possibly-unresolved-reference` errors) before adding the new visibility constraints.