### PR TITLE
[`pyflakes`] Treat arguments passed to the `default=` parameter of `TypeVar` as type expressions (`F821`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pyflakes/F821_32.pyi
+++ b/crates/ruff_linter/resources/test/fixtures/pyflakes/F821_32.pyi
@@ -1,0 +1,6 @@
+from typing import TypeVar
+
+# Forward references are okay for both `bound` and `default` in a stub file
+_P = TypeVar("_P", bound=X, default=X)
+
+class X: ...

--- a/crates/ruff_linter/src/checkers/ast/mod.rs
+++ b/crates/ruff_linter/src/checkers/ast/mod.rs
@@ -1326,7 +1326,7 @@ impl<'a> Visitor<'a> for Checker<'a> {
                                 range: _,
                             } = keyword;
                             if let Some(id) = arg {
-                                if id.as_str() == "bound" {
+                                if matches!(&**id, "bound" | "default") {
                                     self.visit_type_definition(value);
                                 } else {
                                     self.visit_non_type_definition(value);

--- a/crates/ruff_linter/src/rules/pyflakes/mod.rs
+++ b/crates/ruff_linter/src/rules/pyflakes/mod.rs
@@ -164,6 +164,7 @@ mod tests {
     #[test_case(Rule::UndefinedName, Path::new("F821_28.py"))]
     #[test_case(Rule::UndefinedName, Path::new("F821_30.py"))]
     #[test_case(Rule::UndefinedName, Path::new("F821_31.py"))]
+    #[test_case(Rule::UndefinedName, Path::new("F821_32.pyi"))]
     #[test_case(Rule::UndefinedExport, Path::new("F822_0.py"))]
     #[test_case(Rule::UndefinedExport, Path::new("F822_0.pyi"))]
     #[test_case(Rule::UndefinedExport, Path::new("F822_1.py"))]

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F821_F821_32.pyi.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F821_F821_32.pyi.snap
@@ -1,0 +1,4 @@
+---
+source: crates/ruff_linter/src/rules/pyflakes/mod.rs
+---
+


### PR DESCRIPTION
## Summary

Fixes https://github.com/astral-sh/ruff/issues/15677. The `default=` parameter was added to the `TypeVar` in Python 3.13 as part of PEP 696, but has also been backported to `typing_extensions.TypeVar`. It expects a type expression, just like the `bound=` parameter.

## Test Plan

new test added that fails on `main`
