### PR TITLE
Don't run the linter ecosystem check on PRs that only touch red-knot crates

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,6 +61,7 @@ jobs:
               - Cargo.toml
               - Cargo.lock
               - crates/**
+              - "!crates/red_knot*/**"
               - "!crates/ruff_python_formatter/**"
               - "!crates/ruff_formatter/**"
               - "!crates/ruff_dev/**"


### PR DESCRIPTION
## Summary

At some point we'll hopefully setup a `mypy_primer`-like check for red-knot. Until that point, however, comments like https://github.com/astral-sh/ruff/pull/15683#issuecomment-2609273004 just cause noise and distraction through additional notifications, and it's a waste of our CI minutes.

## Test Plan

I used https://codepen.io/mrmlnc/pen/OXQjMe to check that the glob patterns listed here will match a path like `crates/ruff_linter/foo.rs` but will not match `crates/red_knot/foo.rs` or `crates/red_knot_python_semantic/foo.rs`. https://codepen.io/mrmlnc/pen/OXQjMe is linked to from the README of https://github.com/tj-actions/changed-files/tree/v45/ as a tool you can use to test glob patterns passed as inputs to the `changed-files` GitHub action.