### PR TITLE
[red-knot] Add `--ignore`, `--warn`, and `--error` CLI arguments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,7 +30,7 @@ tracing-flamechart.svg
 tracing-flamegraph.svg
 
 # insta
-.rs.pending-snap
+*.rs.pending-snap
 
 
 ###

--- a/crates/red_knot/src/args.rs
+++ b/crates/red_knot/src/args.rs
@@ -119,17 +119,16 @@ impl clap::FromArgMatches for RulesArg {
             (lint::Level::Warn, "warn"),
             (lint::Level::Error, "error"),
         ] {
+            let indices = matches.indices_of(arg_id).into_iter().flatten();
+            let levels = matches.get_many::<String>(arg_id).into_iter().flatten();
             rules.extend(
-                matches
-                    .indices_of(arg_id)
-                    .into_iter()
-                    .flatten()
-                    .zip(matches.get_many::<String>(arg_id).into_iter().flatten())
+                indices
+                    .zip(levels)
                     .map(|(index, rule)| (index, rule, level)),
             );
         }
 
-        // Sorty by their index so that values specified later override earlier ones.
+        // Sort by their index so that values specified later override earlier ones.
         rules.sort_by_key(|(index, _, _)| *index);
 
         Ok(Self(
@@ -154,7 +153,7 @@ impl clap::Args for RulesArg {
             clap::Arg::new("error")
                 .long("error")
                 .action(ArgAction::Append)
-                .help("List of rules to enable with an error severity")
+                .help("Treat the given rule as having severity 'error'. Can be specified multiple times.")
                 .value_name("RULE")
                 .help_heading(HELP_HEADING),
         )
@@ -162,7 +161,7 @@ impl clap::Args for RulesArg {
             clap::Arg::new("warn")
                 .long("warn")
                 .action(ArgAction::Append)
-                .help("List of rules to enable with a warning severity")
+                .help("Treat the given rule as having severity 'warn'. Can be specified multiple times.")
                 .value_name("RULE")
                 .help_heading(HELP_HEADING),
         )
@@ -170,7 +169,7 @@ impl clap::Args for RulesArg {
             clap::Arg::new("ignore")
                 .long("ignore")
                 .action(ArgAction::Append)
-                .help("List of rule codes to disable")
+                .help("Disables the rule. Can be specified multiple times.")
                 .value_name("RULE")
                 .help_heading(HELP_HEADING),
         )

--- a/crates/red_knot/src/args.rs
+++ b/crates/red_knot/src/args.rs
@@ -1,0 +1,182 @@
+use crate::logging::Verbosity;
+use crate::python_version::PythonVersion;
+use crate::Command;
+use clap::{ArgAction, ArgMatches, Error, Parser};
+use red_knot_project::metadata::options::{EnvironmentOptions, Options};
+use red_knot_project::metadata::value::{RangedValue, RelativePathBuf};
+use red_knot_python_semantic::lint;
+use ruff_db::system::SystemPathBuf;
+
+#[derive(Debug, Parser)]
+#[command(
+    author,
+    name = "red-knot",
+    about = "An extremely fast Python type checker."
+)]
+#[command(version)]
+pub(crate) struct Args {
+    #[command(subcommand)]
+    pub(crate) command: Option<Command>,
+
+    /// Run the command within the given project directory.
+    ///
+    /// All `pyproject.toml` files will be discovered by walking up the directory tree from the given project directory,
+    /// as will the project's virtual environment (`.venv`) unless the `venv-path` option is set.
+    ///
+    /// Other command-line arguments (such as relative paths) will be resolved relative to the current working directory.
+    #[arg(long, value_name = "PROJECT")]
+    pub(crate) project: Option<SystemPathBuf>,
+
+    /// Path to the virtual environment the project uses.
+    ///
+    /// If provided, red-knot will use the `site-packages` directory of this virtual environment
+    /// to resolve type information for the project's third-party dependencies.
+    #[arg(long, value_name = "PATH")]
+    pub(crate) venv_path: Option<SystemPathBuf>,
+
+    /// Custom directory to use for stdlib typeshed stubs.
+    #[arg(long, value_name = "PATH", alias = "custom-typeshed-dir")]
+    pub(crate) typeshed: Option<SystemPathBuf>,
+
+    /// Additional path to use as a module-resolution source (can be passed multiple times).
+    #[arg(long, value_name = "PATH")]
+    pub(crate) extra_search_path: Option<Vec<SystemPathBuf>>,
+
+    /// Python version to assume when resolving types.
+    #[arg(long, value_name = "VERSION", alias = "target-version")]
+    pub(crate) python_version: Option<PythonVersion>,
+
+    #[clap(flatten)]
+    pub(crate) verbosity: Verbosity,
+
+    #[clap(flatten)]
+    pub(crate) rules: RulesArg,
+
+    /// Run in watch mode by re-running whenever files change.
+    #[arg(long, short = 'W')]
+    pub(crate) watch: bool,
+}
+
+impl Args {
+    pub(crate) fn to_options(&self) -> Options {
+        let rules = if self.rules.is_empty() {
+            None
+        } else {
+            Some(
+                self.rules
+                    .iter()
+                    .map(|(rule, level)| {
+                        (RangedValue::cli(rule.to_string()), RangedValue::cli(level))
+                    })
+                    .collect(),
+            )
+        };
+
+        Options {
+            environment: Some(EnvironmentOptions {
+                python_version: self
+                    .python_version
+                    .map(|version| RangedValue::cli(version.into())),
+                venv_path: self.venv_path.as_ref().map(RelativePathBuf::cli),
+                typeshed: self.typeshed.as_ref().map(RelativePathBuf::cli),
+                extra_paths: self.extra_search_path.as_ref().map(|extra_search_paths| {
+                    extra_search_paths
+                        .iter()
+                        .map(RelativePathBuf::cli)
+                        .collect()
+                }),
+                ..EnvironmentOptions::default()
+            }),
+            rules,
+            ..Default::default()
+        }
+    }
+}
+
+/// A list of rules to enable or disable with a given severity.
+///
+/// This type is used to parse the `--error`, `--warn`, and `--ignore` arguments
+/// while preserving the order in which they were specified (arguments last override previous severities).
+#[derive(Debug)]
+pub(crate) struct RulesArg(Vec<(String, lint::Level)>);
+
+impl RulesArg {
+    fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    fn iter(&self) -> impl Iterator<Item = (&str, lint::Level)> {
+        self.0.iter().map(|(rule, level)| (rule.as_str(), *level))
+    }
+}
+
+impl clap::FromArgMatches for RulesArg {
+    fn from_arg_matches(matches: &ArgMatches) -> Result<Self, Error> {
+        let mut rules = Vec::new();
+
+        for (level, arg_id) in [
+            (lint::Level::Ignore, "ignore"),
+            (lint::Level::Warn, "warn"),
+            (lint::Level::Error, "error"),
+        ] {
+            rules.extend(
+                matches
+                    .indices_of(arg_id)
+                    .into_iter()
+                    .flatten()
+                    .zip(matches.get_many::<String>(arg_id).into_iter().flatten())
+                    .map(|(index, rule)| (index, rule, level)),
+            );
+        }
+
+        // Sorty by their index so that values specified later override earlier ones.
+        rules.sort_by_key(|(index, _, _)| *index);
+
+        Ok(Self(
+            rules
+                .into_iter()
+                .map(|(_, rule, level)| (rule.to_owned(), level))
+                .collect(),
+        ))
+    }
+
+    fn update_from_arg_matches(&mut self, matches: &ArgMatches) -> Result<(), Error> {
+        self.0 = Self::from_arg_matches(matches)?.0;
+        Ok(())
+    }
+}
+
+impl clap::Args for RulesArg {
+    fn augment_args(cmd: clap::Command) -> clap::Command {
+        const HELP_HEADING: &str = "Enabling / disabling rules";
+
+        cmd.arg(
+            clap::Arg::new("error")
+                .long("error")
+                .action(ArgAction::Append)
+                .help("List of rules to enable with an error severity")
+                .value_name("RULE")
+                .help_heading(HELP_HEADING),
+        )
+        .arg(
+            clap::Arg::new("warn")
+                .long("warn")
+                .action(ArgAction::Append)
+                .help("List of rules to enable with a warning severity")
+                .value_name("RULE")
+                .help_heading(HELP_HEADING),
+        )
+        .arg(
+            clap::Arg::new("ignore")
+                .long("ignore")
+                .action(ArgAction::Append)
+                .help("List of rule codes to disable")
+                .value_name("RULE")
+                .help_heading(HELP_HEADING),
+        )
+    }
+
+    fn augment_args_for_update(cmd: clap::Command) -> clap::Command {
+        Self::augment_args(cmd)
+    }
+}

--- a/crates/red_knot/src/main.rs
+++ b/crates/red_knot/src/main.rs
@@ -1,13 +1,13 @@
 use std::process::{ExitCode, Termination};
 use std::sync::Mutex;
 
+use crate::args::Args;
+use crate::logging::setup_tracing;
 use anyhow::{anyhow, Context};
 use clap::Parser;
 use colored::Colorize;
 use crossbeam::channel as crossbeam_channel;
-use python_version::PythonVersion;
-use red_knot_project::metadata::options::{EnvironmentOptions, Options};
-use red_knot_project::metadata::value::{RangedValue, RelativePathBuf};
+use red_knot_project::metadata::options::Options;
 use red_knot_project::watch;
 use red_knot_project::watch::ProjectWatcher;
 use red_knot_project::{ProjectDatabase, ProjectMetadata};
@@ -16,80 +16,10 @@ use ruff_db::diagnostic::Diagnostic;
 use ruff_db::system::{OsSystem, System, SystemPath, SystemPathBuf};
 use salsa::plumbing::ZalsaDatabase;
 
-use crate::logging::{setup_tracing, Verbosity};
-
+mod args;
 mod logging;
 mod python_version;
 mod verbosity;
-
-#[derive(Debug, Parser)]
-#[command(
-    author,
-    name = "red-knot",
-    about = "An extremely fast Python type checker."
-)]
-#[command(version)]
-struct Args {
-    #[command(subcommand)]
-    pub(crate) command: Option<Command>,
-
-    /// Run the command within the given project directory.
-    ///
-    /// All `pyproject.toml` files will be discovered by walking up the directory tree from the given project directory,
-    /// as will the project's virtual environment (`.venv`) unless the `venv-path` option is set.
-    ///
-    /// Other command-line arguments (such as relative paths) will be resolved relative to the current working directory.
-    #[arg(long, value_name = "PROJECT")]
-    project: Option<SystemPathBuf>,
-
-    /// Path to the virtual environment the project uses.
-    ///
-    /// If provided, red-knot will use the `site-packages` directory of this virtual environment
-    /// to resolve type information for the project's third-party dependencies.
-    #[arg(long, value_name = "PATH")]
-    venv_path: Option<SystemPathBuf>,
-
-    /// Custom directory to use for stdlib typeshed stubs.
-    #[arg(long, value_name = "PATH", alias = "custom-typeshed-dir")]
-    typeshed: Option<SystemPathBuf>,
-
-    /// Additional path to use as a module-resolution source (can be passed multiple times).
-    #[arg(long, value_name = "PATH")]
-    extra_search_path: Option<Vec<SystemPathBuf>>,
-
-    /// Python version to assume when resolving types.
-    #[arg(long, value_name = "VERSION", alias = "target-version")]
-    python_version: Option<PythonVersion>,
-
-    #[clap(flatten)]
-    verbosity: Verbosity,
-
-    /// Run in watch mode by re-running whenever files change.
-    #[arg(long, short = 'W')]
-    watch: bool,
-}
-
-impl Args {
-    fn to_options(&self) -> Options {
-        Options {
-            environment: Some(EnvironmentOptions {
-                python_version: self
-                    .python_version
-                    .map(|version| RangedValue::cli(version.into())),
-                venv_path: self.venv_path.as_ref().map(RelativePathBuf::cli),
-                typeshed: self.typeshed.as_ref().map(RelativePathBuf::cli),
-                extra_paths: self.extra_search_path.as_ref().map(|extra_search_paths| {
-                    extra_search_paths
-                        .iter()
-                        .map(RelativePathBuf::cli)
-                        .collect()
-                }),
-                ..EnvironmentOptions::default()
-            }),
-            ..Default::default()
-        }
-    }
-}
 
 #[derive(Debug, clap::Subcommand)]
 pub enum Command {

--- a/crates/red_knot_project/src/metadata/options.rs
+++ b/crates/red_knot_project/src/metadata/options.rs
@@ -149,6 +149,16 @@ impl Options {
                             format!("Unknown lint rule `{rule_name}`"),
                             Severity::Warning,
                         ),
+                        GetLintError::PrefixedWithCategory { suggestion, .. } => {
+                            OptionDiagnostic::new(
+                                DiagnosticId::UnknownRule,
+                                format!(
+                                    "Unknown lint rule `{rule_name}`. Did you mean `{suggestion}`?"
+                                ),
+                                Severity::Warning,
+                            )
+                        }
+
                         GetLintError::Removed(_) => OptionDiagnostic::new(
                             DiagnosticId::UnknownRule,
                             format!("Unknown lint rule `{rule_name}`"),

--- a/crates/red_knot_project/src/metadata/options.rs
+++ b/crates/red_knot_project/src/metadata/options.rs
@@ -206,6 +206,16 @@ pub struct Rules {
     inner: FxHashMap<RangedValue<String>, RangedValue<Level>>,
 }
 
+impl FromIterator<(RangedValue<String>, RangedValue<Level>)> for Rules {
+    fn from_iter<T: IntoIterator<Item = (RangedValue<String>, RangedValue<Level>)>>(
+        iter: T,
+    ) -> Self {
+        Self {
+            inner: iter.into_iter().collect(),
+        }
+    }
+}
+
 #[derive(Error, Debug)]
 pub enum KnotTomlError {
     #[error(transparent)]

--- a/crates/red_knot_python_semantic/resources/mdtest/suppressions/knot_ignore.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/suppressions/knot_ignore.md
@@ -180,3 +180,11 @@ a = 4 / 0  # error: [division-by-zero]
 # error: [unknown-rule] "Unknown rule `is-equal-14`"
 a = 10 + 4  # knot: ignore[is-equal-14]
 ```
+
+## Code with `lint:` prefix
+
+```py
+# error:[unknown-rule] "Unknown rule `lint:division-by-zero`. Did you mean `division-by-zero`?"
+# error: [division-by-zero]
+a = 10 / 0  # knot: ignore[lint:division-by-zero]
+```

--- a/crates/red_knot_python_semantic/src/suppression.rs
+++ b/crates/red_knot_python_semantic/src/suppression.rs
@@ -163,6 +163,17 @@ fn check_unknown_rule(context: &mut CheckSuppressionsContext) {
                     format_args!("Unknown rule `{rule}`"),
                 );
             }
+
+            GetLintError::PrefixedWithCategory {
+                prefixed,
+                suggestion,
+            } => {
+                context.report_lint(
+                    &UNKNOWN_RULE,
+                    unknown.range,
+                    format_args!("Unknown rule `{prefixed}`. Did you mean `{suggestion}`?"),
+                );
+            }
         };
     }
 }
@@ -765,8 +776,9 @@ impl<'src> SuppressionParser<'src> {
 
     fn eat_word(&mut self) -> bool {
         if self.cursor.eat_if(char::is_alphabetic) {
+            // Allow `:` for better error recovery when someone uses `lint:code` instead of just `code`.
             self.cursor
-                .eat_while(|c| c.is_alphanumeric() || matches!(c, '_' | '-'));
+                .eat_while(|c| c.is_alphanumeric() || matches!(c, '_' | '-' | ':'));
             true
         } else {
             false

--- a/crates/ruff_db/src/diagnostic.rs
+++ b/crates/ruff_db/src/diagnostic.rs
@@ -94,6 +94,10 @@ impl DiagnosticId {
         matches!(self, DiagnosticId::Lint(self_name) if self_name == name)
     }
 
+    pub fn strip_category(code: &str) -> Option<&str> {
+        code.split_once(':').map(|(_, rest)| rest)
+    }
+
     /// Returns `true` if this `DiagnosticId` matches the given name.
     ///
     /// ## Examples


### PR DESCRIPTION
## Summary

Add support for enabling rules from the CLI and changing the rule's severity by adding
the `--warn`, `--error` and `--ignore` CLI arguments. 

The "tricky" part of this PR was that we need to preserve the order in which 
the arguments were specified so that e.g. `--ignore division-by-zero --error division-by-zero` resolves
to enabling the rule with an `error` severity because the `--error `argument comes last. 

The way this is solved is by manually implementing `Args` as [described here](https://docs.rs/clap/latest/clap/_derive/index.html#flattening-hand-implemented-args-into-a-derived-application)

## Test Plan

Added CLI tests, I did some manual testing as well. 
