### PR TITLE
[red-knot] MDTests: Do not depend on precise public-symbol type inference

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/binary/booleans.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/binary/booleans.md
@@ -50,46 +50,44 @@ reveal_type(b | b)  # revealed: Literal[False]
 ## Arithmetic with a variable
 
 ```py
-a = True
-b = False
+def _(a: bool):
+    def lhs_is_int(x: int):
+        reveal_type(x + a)  # revealed: int
+        reveal_type(x - a)  # revealed: int
+        reveal_type(x * a)  # revealed: int
+        reveal_type(x // a)  # revealed: int
+        reveal_type(x / a)  # revealed: float
+        reveal_type(x % a)  # revealed: int
 
-def lhs_is_int(x: int):
-    reveal_type(x + a)  # revealed: int
-    reveal_type(x - a)  # revealed: int
-    reveal_type(x * a)  # revealed: int
-    reveal_type(x // a)  # revealed: int
-    reveal_type(x / a)  # revealed: float
-    reveal_type(x % a)  # revealed: int
+    def rhs_is_int(x: int):
+        reveal_type(a + x)  # revealed: int
+        reveal_type(a - x)  # revealed: int
+        reveal_type(a * x)  # revealed: int
+        reveal_type(a // x)  # revealed: int
+        reveal_type(a / x)  # revealed: float
+        reveal_type(a % x)  # revealed: int
 
-def rhs_is_int(x: int):
-    reveal_type(a + x)  # revealed: int
-    reveal_type(a - x)  # revealed: int
-    reveal_type(a * x)  # revealed: int
-    reveal_type(a // x)  # revealed: int
-    reveal_type(a / x)  # revealed: float
-    reveal_type(a % x)  # revealed: int
+    def lhs_is_bool(x: bool):
+        reveal_type(x + a)  # revealed: int
+        reveal_type(x - a)  # revealed: int
+        reveal_type(x * a)  # revealed: int
+        reveal_type(x // a)  # revealed: int
+        reveal_type(x / a)  # revealed: float
+        reveal_type(x % a)  # revealed: int
 
-def lhs_is_bool(x: bool):
-    reveal_type(x + a)  # revealed: int
-    reveal_type(x - a)  # revealed: int
-    reveal_type(x * a)  # revealed: int
-    reveal_type(x // a)  # revealed: int
-    reveal_type(x / a)  # revealed: float
-    reveal_type(x % a)  # revealed: int
+    def rhs_is_bool(x: bool):
+        reveal_type(a + x)  # revealed: int
+        reveal_type(a - x)  # revealed: int
+        reveal_type(a * x)  # revealed: int
+        reveal_type(a // x)  # revealed: int
+        reveal_type(a / x)  # revealed: float
+        reveal_type(a % x)  # revealed: int
 
-def rhs_is_bool(x: bool):
-    reveal_type(a + x)  # revealed: int
-    reveal_type(a - x)  # revealed: int
-    reveal_type(a * x)  # revealed: int
-    reveal_type(a // x)  # revealed: int
-    reveal_type(a / x)  # revealed: float
-    reveal_type(a % x)  # revealed: int
-
-def both_are_bool(x: bool, y: bool):
-    reveal_type(x + y)  # revealed: int
-    reveal_type(x - y)  # revealed: int
-    reveal_type(x * y)  # revealed: int
-    reveal_type(x // y)  # revealed: int
-    reveal_type(x / y)  # revealed: float
-    reveal_type(x % y)  # revealed: int
+    def both_are_bool(x: bool, y: bool):
+        reveal_type(x + y)  # revealed: int
+        reveal_type(x - y)  # revealed: int
+        reveal_type(x * y)  # revealed: int
+        reveal_type(x // y)  # revealed: int
+        reveal_type(x / y)  # revealed: float
+        reveal_type(x % y)  # revealed: int
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/import/conflicts.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/import/conflicts.md
@@ -9,7 +9,7 @@ reveal_type(a.b)  # revealed: <module 'a.b'>
 ```
 
 ```py path=a/__init__.py
-b = 42
+b: int = 42
 ```
 
 ```py path=a/b.py
@@ -20,11 +20,11 @@ b = 42
 ```py
 from a import b
 
-reveal_type(b)  # revealed: Literal[42]
+reveal_type(b)  # revealed: int
 ```
 
 ```py path=a/__init__.py
-b = 42
+b: int = 42
 ```
 
 ```py path=a/b.py
@@ -41,7 +41,7 @@ reveal_type(a.b)  # revealed: <module 'a.b'>
 ```
 
 ```py path=a/__init__.py
-b = 42
+b: int = 42
 ```
 
 ```py path=a/b.py
@@ -60,13 +60,13 @@ sees the submodule as the value of `b` instead of the integer.
 from a import b
 import a.b
 
-# Python would say `Literal[42]` for `b`
+# Python would say `int` for `b`
 reveal_type(b)  # revealed: <module 'a.b'>
 reveal_type(a.b)  # revealed: <module 'a.b'>
 ```
 
 ```py path=a/__init__.py
-b = 42
+b: int = 42
 ```
 
 ```py path=a/b.py

--- a/crates/red_knot_python_semantic/resources/mdtest/import/invalid_syntax.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/import/invalid_syntax.md
@@ -20,12 +20,12 @@ from a import b.c
 
 # TODO: Should these be inferred as Unknown?
 reveal_type(b)  # revealed: <module 'a.b'>
-reveal_type(b.c)  # revealed: Literal[1]
+reveal_type(b.c)  # revealed: int
 ```
 
 ```py path=a/__init__.py
 ```
 
 ```py path=a/b.py
-c = 1
+c: int = 1
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/import/relative.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/import/relative.md
@@ -17,13 +17,13 @@ reveal_type(X)  # revealed: Unknown
 ```
 
 ```py path=package/foo.py
-X = 42
+X: int = 42
 ```
 
 ```py path=package/bar.py
 from .foo import X
 
-reveal_type(X)  # revealed: Literal[42]
+reveal_type(X)  # revealed: int
 ```
 
 ## Dotted
@@ -32,25 +32,25 @@ reveal_type(X)  # revealed: Literal[42]
 ```
 
 ```py path=package/foo/bar/baz.py
-X = 42
+X: int = 42
 ```
 
 ```py path=package/bar.py
 from .foo.bar.baz import X
 
-reveal_type(X)  # revealed: Literal[42]
+reveal_type(X)  # revealed: int
 ```
 
 ## Bare to package
 
 ```py path=package/__init__.py
-X = 42
+X: int = 42
 ```
 
 ```py path=package/bar.py
 from . import X
 
-reveal_type(X)  # revealed: Literal[42]
+reveal_type(X)  # revealed: int
 ```
 
 ## Non-existent + bare to package
@@ -66,11 +66,11 @@ reveal_type(X)  # revealed: Unknown
 ```py path=package/__init__.py
 from .foo import X
 
-reveal_type(X)  # revealed: Literal[42]
+reveal_type(X)  # revealed: int
 ```
 
 ```py path=package/foo.py
-X = 42
+X: int = 42
 ```
 
 ## Non-existent + dunder init
@@ -87,13 +87,13 @@ reveal_type(X)  # revealed: Unknown
 ```
 
 ```py path=package/foo.py
-X = 42
+X: int = 42
 ```
 
 ```py path=package/subpackage/subsubpackage/bar.py
 from ...foo import X
 
-reveal_type(X)  # revealed: Literal[42]
+reveal_type(X)  # revealed: int
 ```
 
 ## Unbound symbol
@@ -117,13 +117,13 @@ reveal_type(x)  # revealed: Unknown
 ```
 
 ```py path=package/foo.py
-X = 42
+X: int = 42
 ```
 
 ```py path=package/bar.py
 from . import foo
 
-reveal_type(foo.X)  # revealed: Literal[42]
+reveal_type(foo.X)  # revealed: int
 ```
 
 ## Non-existent + bare to module
@@ -152,7 +152,7 @@ submodule via the attribute on its parent package.
 ```
 
 ```py path=package/foo.py
-X = 42
+X: int = 42
 ```
 
 ```py path=package/bar.py

--- a/crates/red_knot_python_semantic/resources/mdtest/scopes/builtin.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/scopes/builtin.md
@@ -10,10 +10,10 @@ def returns_bool() -> bool:
     return True
 
 if returns_bool():
-    chr = 1
+    chr: int = 1
 
 def f():
-    reveal_type(chr)  # revealed: Literal[chr] | Literal[1]
+    reveal_type(chr)  # revealed: Literal[chr] | int
 ```
 
 ## Conditionally global or builtin, with annotation

--- a/crates/red_knot_python_semantic/resources/mdtest/statically_known_branches.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/statically_known_branches.md
@@ -11,7 +11,7 @@ version:
 import sys
 
 if sys.version_info >= (3, 9):
-    SomeFeature = "available"
+    SomeFeature: str = "available"
 ```
 
 If we can statically determine that the condition is always true, then we can also understand that
@@ -21,7 +21,7 @@ If we can statically determine that the condition is always true, then we can al
 from module1 import SomeFeature
 
 # SomeFeature is unconditionally available here, because we are on Python 3.9 or newer:
-reveal_type(SomeFeature)  # revealed: Literal["available"]
+reveal_type(SomeFeature)  # revealed: str
 ```
 
 Another scenario where this is useful is for `typing.TYPE_CHECKING` branches, which are often used

--- a/crates/red_knot_python_semantic/resources/mdtest/subscript/bytes.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/subscript/bytes.md
@@ -31,7 +31,7 @@ def _(n: int):
 ## Slices
 
 ```py
-b = b"\x00abc\xff"
+b: bytes = b"\x00abc\xff"
 
 reveal_type(b[0:2])  # revealed: Literal[b"\x00a"]
 reveal_type(b[-3:])  # revealed: Literal[b"bc\xff"]

--- a/crates/red_knot_python_semantic/resources/mdtest/subscript/string.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/subscript/string.md
@@ -28,52 +28,52 @@ def _(n: int):
 ## Slices
 
 ```py
-s = "abcde"
-
-reveal_type(s[0:0])  # revealed: Literal[""]
-reveal_type(s[0:1])  # revealed: Literal["a"]
-reveal_type(s[0:2])  # revealed: Literal["ab"]
-reveal_type(s[0:5])  # revealed: Literal["abcde"]
-reveal_type(s[0:6])  # revealed: Literal["abcde"]
-reveal_type(s[1:3])  # revealed: Literal["bc"]
-
-reveal_type(s[-3:5])  # revealed: Literal["cde"]
-reveal_type(s[-4:-2])  # revealed: Literal["bc"]
-reveal_type(s[-10:10])  # revealed: Literal["abcde"]
-
-reveal_type(s[0:])  # revealed: Literal["abcde"]
-reveal_type(s[2:])  # revealed: Literal["cde"]
-reveal_type(s[5:])  # revealed: Literal[""]
-reveal_type(s[:2])  # revealed: Literal["ab"]
-reveal_type(s[:0])  # revealed: Literal[""]
-reveal_type(s[:2])  # revealed: Literal["ab"]
-reveal_type(s[:10])  # revealed: Literal["abcde"]
-reveal_type(s[:])  # revealed: Literal["abcde"]
-
-reveal_type(s[::-1])  # revealed: Literal["edcba"]
-reveal_type(s[::2])  # revealed: Literal["ace"]
-reveal_type(s[-2:-5:-1])  # revealed: Literal["dcb"]
-reveal_type(s[::-2])  # revealed: Literal["eca"]
-reveal_type(s[-1::-3])  # revealed: Literal["eb"]
-
-reveal_type(s[None:2:None])  # revealed: Literal["ab"]
-reveal_type(s[1:None:1])  # revealed: Literal["bcde"]
-reveal_type(s[None:None:None])  # revealed: Literal["abcde"]
-
-start = 1
-stop = None
-step = 2
-reveal_type(s[start:stop:step])  # revealed: Literal["bd"]
-
-reveal_type(s[False:True])  # revealed: Literal["a"]
-reveal_type(s[True:3])  # revealed: Literal["bc"]
-
-s[0:4:0]  # error: [zero-stepsize-in-slice]
-s[:4:0]  # error: [zero-stepsize-in-slice]
-s[0::0]  # error: [zero-stepsize-in-slice]
-s[::0]  # error: [zero-stepsize-in-slice]
-
 def _(m: int, n: int, s2: str):
+    s = "abcde"
+
+    reveal_type(s[0:0])  # revealed: Literal[""]
+    reveal_type(s[0:1])  # revealed: Literal["a"]
+    reveal_type(s[0:2])  # revealed: Literal["ab"]
+    reveal_type(s[0:5])  # revealed: Literal["abcde"]
+    reveal_type(s[0:6])  # revealed: Literal["abcde"]
+    reveal_type(s[1:3])  # revealed: Literal["bc"]
+
+    reveal_type(s[-3:5])  # revealed: Literal["cde"]
+    reveal_type(s[-4:-2])  # revealed: Literal["bc"]
+    reveal_type(s[-10:10])  # revealed: Literal["abcde"]
+
+    reveal_type(s[0:])  # revealed: Literal["abcde"]
+    reveal_type(s[2:])  # revealed: Literal["cde"]
+    reveal_type(s[5:])  # revealed: Literal[""]
+    reveal_type(s[:2])  # revealed: Literal["ab"]
+    reveal_type(s[:0])  # revealed: Literal[""]
+    reveal_type(s[:2])  # revealed: Literal["ab"]
+    reveal_type(s[:10])  # revealed: Literal["abcde"]
+    reveal_type(s[:])  # revealed: Literal["abcde"]
+
+    reveal_type(s[::-1])  # revealed: Literal["edcba"]
+    reveal_type(s[::2])  # revealed: Literal["ace"]
+    reveal_type(s[-2:-5:-1])  # revealed: Literal["dcb"]
+    reveal_type(s[::-2])  # revealed: Literal["eca"]
+    reveal_type(s[-1::-3])  # revealed: Literal["eb"]
+
+    reveal_type(s[None:2:None])  # revealed: Literal["ab"]
+    reveal_type(s[1:None:1])  # revealed: Literal["bcde"]
+    reveal_type(s[None:None:None])  # revealed: Literal["abcde"]
+
+    start = 1
+    stop = None
+    step = 2
+    reveal_type(s[start:stop:step])  # revealed: Literal["bd"]
+
+    reveal_type(s[False:True])  # revealed: Literal["a"]
+    reveal_type(s[True:3])  # revealed: Literal["bc"]
+
+    s[0:4:0]  # error: [zero-stepsize-in-slice]
+    s[:4:0]  # error: [zero-stepsize-in-slice]
+    s[0::0]  # error: [zero-stepsize-in-slice]
+    s[::0]  # error: [zero-stepsize-in-slice]
+
     substring1 = s[m:n]
     # TODO: Support overloads... Should be `LiteralString`
     reveal_type(substring1)  # revealed: @Todo(return type)

--- a/crates/red_knot_python_semantic/resources/mdtest/subscript/tuple.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/subscript/tuple.md
@@ -23,51 +23,51 @@ reveal_type(b)  # revealed: Unknown
 ## Slices
 
 ```py
-t = (1, "a", None, b"b")
-
-reveal_type(t[0:0])  # revealed: tuple[()]
-reveal_type(t[0:1])  # revealed: tuple[Literal[1]]
-reveal_type(t[0:2])  # revealed: tuple[Literal[1], Literal["a"]]
-reveal_type(t[0:4])  # revealed: tuple[Literal[1], Literal["a"], None, Literal[b"b"]]
-reveal_type(t[0:5])  # revealed: tuple[Literal[1], Literal["a"], None, Literal[b"b"]]
-reveal_type(t[1:3])  # revealed: tuple[Literal["a"], None]
-
-reveal_type(t[-2:4])  # revealed: tuple[None, Literal[b"b"]]
-reveal_type(t[-3:-1])  # revealed: tuple[Literal["a"], None]
-reveal_type(t[-10:10])  # revealed: tuple[Literal[1], Literal["a"], None, Literal[b"b"]]
-
-reveal_type(t[0:])  # revealed: tuple[Literal[1], Literal["a"], None, Literal[b"b"]]
-reveal_type(t[2:])  # revealed: tuple[None, Literal[b"b"]]
-reveal_type(t[4:])  # revealed: tuple[()]
-reveal_type(t[:0])  # revealed: tuple[()]
-reveal_type(t[:2])  # revealed: tuple[Literal[1], Literal["a"]]
-reveal_type(t[:10])  # revealed: tuple[Literal[1], Literal["a"], None, Literal[b"b"]]
-reveal_type(t[:])  # revealed: tuple[Literal[1], Literal["a"], None, Literal[b"b"]]
-
-reveal_type(t[::-1])  # revealed: tuple[Literal[b"b"], None, Literal["a"], Literal[1]]
-reveal_type(t[::2])  # revealed: tuple[Literal[1], None]
-reveal_type(t[-2:-5:-1])  # revealed: tuple[None, Literal["a"], Literal[1]]
-reveal_type(t[::-2])  # revealed: tuple[Literal[b"b"], Literal["a"]]
-reveal_type(t[-1::-3])  # revealed: tuple[Literal[b"b"], Literal[1]]
-
-reveal_type(t[None:2:None])  # revealed: tuple[Literal[1], Literal["a"]]
-reveal_type(t[1:None:1])  # revealed: tuple[Literal["a"], None, Literal[b"b"]]
-reveal_type(t[None:None:None])  # revealed: tuple[Literal[1], Literal["a"], None, Literal[b"b"]]
-
-start = 1
-stop = None
-step = 2
-reveal_type(t[start:stop:step])  # revealed: tuple[Literal["a"], Literal[b"b"]]
-
-reveal_type(t[False:True])  # revealed: tuple[Literal[1]]
-reveal_type(t[True:3])  # revealed: tuple[Literal["a"], None]
-
-t[0:4:0]  # error: [zero-stepsize-in-slice]
-t[:4:0]  # error: [zero-stepsize-in-slice]
-t[0::0]  # error: [zero-stepsize-in-slice]
-t[::0]  # error: [zero-stepsize-in-slice]
-
 def _(m: int, n: int):
+    t = (1, "a", None, b"b")
+
+    reveal_type(t[0:0])  # revealed: tuple[()]
+    reveal_type(t[0:1])  # revealed: tuple[Literal[1]]
+    reveal_type(t[0:2])  # revealed: tuple[Literal[1], Literal["a"]]
+    reveal_type(t[0:4])  # revealed: tuple[Literal[1], Literal["a"], None, Literal[b"b"]]
+    reveal_type(t[0:5])  # revealed: tuple[Literal[1], Literal["a"], None, Literal[b"b"]]
+    reveal_type(t[1:3])  # revealed: tuple[Literal["a"], None]
+
+    reveal_type(t[-2:4])  # revealed: tuple[None, Literal[b"b"]]
+    reveal_type(t[-3:-1])  # revealed: tuple[Literal["a"], None]
+    reveal_type(t[-10:10])  # revealed: tuple[Literal[1], Literal["a"], None, Literal[b"b"]]
+
+    reveal_type(t[0:])  # revealed: tuple[Literal[1], Literal["a"], None, Literal[b"b"]]
+    reveal_type(t[2:])  # revealed: tuple[None, Literal[b"b"]]
+    reveal_type(t[4:])  # revealed: tuple[()]
+    reveal_type(t[:0])  # revealed: tuple[()]
+    reveal_type(t[:2])  # revealed: tuple[Literal[1], Literal["a"]]
+    reveal_type(t[:10])  # revealed: tuple[Literal[1], Literal["a"], None, Literal[b"b"]]
+    reveal_type(t[:])  # revealed: tuple[Literal[1], Literal["a"], None, Literal[b"b"]]
+
+    reveal_type(t[::-1])  # revealed: tuple[Literal[b"b"], None, Literal["a"], Literal[1]]
+    reveal_type(t[::2])  # revealed: tuple[Literal[1], None]
+    reveal_type(t[-2:-5:-1])  # revealed: tuple[None, Literal["a"], Literal[1]]
+    reveal_type(t[::-2])  # revealed: tuple[Literal[b"b"], Literal["a"]]
+    reveal_type(t[-1::-3])  # revealed: tuple[Literal[b"b"], Literal[1]]
+
+    reveal_type(t[None:2:None])  # revealed: tuple[Literal[1], Literal["a"]]
+    reveal_type(t[1:None:1])  # revealed: tuple[Literal["a"], None, Literal[b"b"]]
+    reveal_type(t[None:None:None])  # revealed: tuple[Literal[1], Literal["a"], None, Literal[b"b"]]
+
+    start = 1
+    stop = None
+    step = 2
+    reveal_type(t[start:stop:step])  # revealed: tuple[Literal["a"], Literal[b"b"]]
+
+    reveal_type(t[False:True])  # revealed: tuple[Literal[1]]
+    reveal_type(t[True:3])  # revealed: tuple[Literal["a"], None]
+
+    t[0:4:0]  # error: [zero-stepsize-in-slice]
+    t[:4:0]  # error: [zero-stepsize-in-slice]
+    t[0::0]  # error: [zero-stepsize-in-slice]
+    t[::0]  # error: [zero-stepsize-in-slice]
+
     tuple_slice = t[m:n]
     # TODO: Support overloads... Should be `tuple[Literal[1, 'a', b"b"] | None, ...]`
     reveal_type(tuple_slice)  # revealed: @Todo(return type)


### PR DESCRIPTION
## Summary

Another small PR to focus #15674 solely on the relevant changes. This makes our Markdown tests less dependent on precise types of public symbols, without actually changing anything semantically in these tests.

Best reviewed using ignore-whitespace-mode.

## Test Plan

Tested these changes on `main` and on the branch from #15674.
