### PR TITLE
[red-knot] Use itertools to clean up `SymbolState::merge`

### DIFF
--- a/crates/red_knot_python_semantic/src/semantic_index/use_def/bitset.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/use_def/bitset.rs
@@ -93,19 +93,6 @@ impl<const B: usize> BitSet<B> {
         }
     }
 
-    /// Union in-place with another [`BitSet`].
-    pub(super) fn union(&mut self, other: &BitSet<B>) {
-        let mut max_len = self.blocks().len();
-        let other_len = other.blocks().len();
-        if other_len > max_len {
-            max_len = other_len;
-            self.resize_blocks(max_len);
-        }
-        for (my_block, other_block) in self.blocks_mut().iter_mut().zip(other.blocks()) {
-            *my_block |= other_block;
-        }
-    }
-
     /// Return an iterator over the values (in ascending order) in this [`BitSet`].
     pub(super) fn iter(&self) -> BitSetIterator<'_, B> {
         let blocks = self.blocks();
@@ -233,59 +220,6 @@ mod tests {
 
         b1.intersect(&b2);
         assert_bitset(&b1, &[89]);
-    }
-
-    #[test]
-    fn union() {
-        let mut b1 = BitSet::<1>::with(2);
-        let b2 = BitSet::<1>::with(4);
-
-        b1.union(&b2);
-        assert_bitset(&b1, &[2, 4]);
-    }
-
-    #[test]
-    fn union_mixed_1() {
-        let mut b1 = BitSet::<1>::with(4);
-        let mut b2 = BitSet::<1>::with(4);
-        b1.insert(89);
-        b2.insert(5);
-
-        b1.union(&b2);
-        assert_bitset(&b1, &[4, 5, 89]);
-    }
-
-    #[test]
-    fn union_mixed_2() {
-        let mut b1 = BitSet::<1>::with(4);
-        let mut b2 = BitSet::<1>::with(4);
-        b1.insert(23);
-        b2.insert(89);
-
-        b1.union(&b2);
-        assert_bitset(&b1, &[4, 23, 89]);
-    }
-
-    #[test]
-    fn union_heap() {
-        let mut b1 = BitSet::<1>::with(4);
-        let mut b2 = BitSet::<1>::with(4);
-        b1.insert(89);
-        b2.insert(90);
-
-        b1.union(&b2);
-        assert_bitset(&b1, &[4, 89, 90]);
-    }
-
-    #[test]
-    fn union_heap_2() {
-        let mut b1 = BitSet::<1>::with(89);
-        let mut b2 = BitSet::<1>::with(89);
-        b1.insert(91);
-        b2.insert(90);
-
-        b1.union(&b2);
-        assert_bitset(&b1, &[89, 90, 91]);
     }
 
     #[test]

--- a/crates/red_knot_python_semantic/src/semantic_index/use_def/symbol_state.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/use_def/symbol_state.rs
@@ -173,8 +173,7 @@ impl SymbolDeclarations {
     }
 
     fn merge(&mut self, b: Self, visibility_constraints: &mut VisibilityConstraints) {
-        let mut a = Self::default();
-        std::mem::swap(&mut a, self);
+        let mut a = std::mem::take(self);
         self.live_declarations = a.live_declarations.clone();
         self.live_declarations.union(&b.live_declarations);
         let a = izip!(
@@ -277,8 +276,7 @@ impl SymbolBindings {
     }
 
     fn merge(&mut self, b: Self, visibility_constraints: &mut VisibilityConstraints) {
-        let mut a = Self::default();
-        std::mem::swap(&mut a, self);
+        let mut a = std::mem::take(self);
         self.live_bindings = a.live_bindings.clone();
         self.live_bindings.union(&b.live_bindings);
         let a = izip!(

--- a/crates/red_knot_python_semantic/src/semantic_index/use_def/symbol_state.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/use_def/symbol_state.rs
@@ -173,7 +173,7 @@ impl SymbolDeclarations {
     }
 
     fn merge(&mut self, b: Self, visibility_constraints: &mut VisibilityConstraints) {
-        let mut a = std::mem::take(self);
+        let a = std::mem::take(self);
         self.live_declarations = a.live_declarations.clone();
         self.live_declarations.union(&b.live_declarations);
         let a = izip!(
@@ -276,7 +276,7 @@ impl SymbolBindings {
     }
 
     fn merge(&mut self, b: Self, visibility_constraints: &mut VisibilityConstraints) {
-        let mut a = std::mem::take(self);
+        let a = std::mem::take(self);
         self.live_bindings = a.live_bindings.clone();
         self.live_bindings.union(&b.live_bindings);
         let a = izip!(

--- a/crates/red_knot_python_semantic/src/semantic_index/use_def/symbol_state.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/use_def/symbol_state.rs
@@ -184,21 +184,15 @@ impl SymbolDeclarations {
                 EitherOrBoth::Both((_, a_vis_constraint), (_, b_vis_constraint)) => {
                     let vis_constraint = visibility_constraints
                         .add_or_constraint(a_vis_constraint, b_vis_constraint);
-                    self.add_via_merge(vis_constraint);
+                    self.visibility_constraints.push(vis_constraint);
                 }
 
                 EitherOrBoth::Left((_, vis_constraint))
                 | EitherOrBoth::Right((_, vis_constraint)) => {
-                    self.add_via_merge(vis_constraint);
+                    self.visibility_constraints.push(vis_constraint);
                 }
             }
         }
-    }
-
-    fn add_via_merge(&mut self, vis_constraint: ScopedVisibilityConstraintId) {
-        // SAFETY: This can only be called from `merge`, since it assumes that we are adding
-        // elements in order, sorted by `decl`.
-        self.visibility_constraints.push(vis_constraint);
     }
 }
 
@@ -291,31 +285,21 @@ impl SymbolBindings {
                     // unioning the two paths, so we intersect the constraints.
                     let mut constraints = a_constraints;
                     constraints.intersect(&b_constraints);
+                    self.constraints.push(constraints);
 
                     // For visibility constraints, we merge them using a ternary OR operation:
                     let vis_constraint = visibility_constraints
                         .add_or_constraint(a_vis_constraint, b_vis_constraint);
-
-                    self.add_via_merge(constraints, vis_constraint);
+                    self.visibility_constraints.push(vis_constraint);
                 }
 
                 EitherOrBoth::Left(((_, constraints), vis_constraint))
                 | EitherOrBoth::Right(((_, constraints), vis_constraint)) => {
-                    self.add_via_merge(constraints, vis_constraint);
+                    self.constraints.push(constraints);
+                    self.visibility_constraints.push(vis_constraint);
                 }
             }
         }
-    }
-
-    fn add_via_merge(
-        &mut self,
-        constraints: Constraints,
-        vis_constraint: ScopedVisibilityConstraintId,
-    ) {
-        // SAFETY: This can only be called from `merge`, since it assumes that we are adding
-        // elements in order, sorted by `def`.
-        self.constraints.push(constraints);
-        self.visibility_constraints.push(vis_constraint);
     }
 }
 


### PR DESCRIPTION
[`merge_join_by`](https://docs.rs/itertools/latest/itertools/trait.Itertools.html#method.merge_join_by) handles the "merge two sorted iterators" bit, and `zip` handles iterating through the bindings/definitions along with their associated constraints.
