### PR TITLE
[`ruff`] Parenthesize fix when argument spans multiple lines for `unnecessary-round` (`RUF057`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/ruff/RUF057.py
+++ b/crates/ruff_linter/resources/test/fixtures/ruff/RUF057.py
@@ -64,3 +64,20 @@ round(lorem, -2)                                  # No error
 round(lorem, inferred_int)                        # No error
 round(lorem, 3 + 4)                               # No error
 round(lorem, foo)                                 # No error
+
+# Fixes should preserve parentheses when argument
+# contains newline.
+# See https://github.com/astral-sh/ruff/issues/15598
+round(-
+1)
+round(1
+*1
+)
+
+# fix should be unsafe if comment is in call range
+round(# a comment
+17
+)
+round(
+    17 # a comment
+)

--- a/crates/ruff_linter/src/rules/ruff/rules/unnecessary_round.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/unnecessary_round.rs
@@ -60,7 +60,7 @@ pub(crate) fn unnecessary_round(checker: &mut Checker, call: &ExprCall) {
         return;
     }
 
-    let applicability = match rounded_value {
+    let mut applicability = match rounded_value {
         // ```python
         // some_int: int
         //
@@ -85,6 +85,10 @@ pub(crate) fn unnecessary_round(checker: &mut Checker, call: &ExprCall) {
         RoundedValue::Int(InferredType::AssignableTo) => Applicability::Unsafe,
 
         _ => return,
+    };
+
+    if checker.comment_ranges().intersects(call.range()) {
+        applicability = Applicability::Unsafe;
     };
 
     let edit = unwrap_round_call(call, rounded, checker.semantic(), checker.locator());

--- a/crates/ruff_linter/src/rules/ruff/rules/unnecessary_round.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/unnecessary_round.rs
@@ -6,6 +6,7 @@ use ruff_python_ast::{Arguments, Expr, ExprCall, ExprNumberLiteral, Number};
 use ruff_python_semantic::analyze::type_inference::{NumberLike, PythonType, ResolvedPythonType};
 use ruff_python_semantic::analyze::typing;
 use ruff_python_semantic::SemanticModel;
+use ruff_source_file::find_newline;
 use ruff_text_size::Ranged;
 
 /// ## What it does
@@ -196,13 +197,13 @@ fn unwrap_round_call(
     locator: &Locator,
 ) -> Edit {
     let rounded_expr = locator.slice(rounded.range());
-
     let has_parent_expr = semantic.current_expression_parent().is_some();
-    let new_content = if has_parent_expr || rounded.is_named_expr() {
-        format!("({rounded_expr})")
-    } else {
-        rounded_expr.to_string()
-    };
+    let new_content =
+        if has_parent_expr || rounded.is_named_expr() || find_newline(rounded_expr).is_some() {
+            format!("({rounded_expr})")
+        } else {
+            rounded_expr.to_string()
+        };
 
     Edit::range_replacement(new_content, call.range)
 }

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__preview__RUF057_RUF057.py.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__preview__RUF057_RUF057.py.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/ruff_linter/src/rules/ruff/mod.rs
-snapshot_kind: text
 ---
 RUF057.py:6:1: RUF057 [*] Value being rounded is already an integer
   |
@@ -181,3 +180,94 @@ RUF057.py:44:1: RUF057 [*] Value being rounded is already an integer
 45 45 | round(inferred_int, -2)                           # No error
 46 46 | round(inferred_int, inferred_int)                 # No error
 47 47 | round(inferred_int, 3 + 4)                        # No error
+
+RUF057.py:71:1: RUF057 [*] Value being rounded is already an integer
+   |
+69 |   # contains newline.
+70 |   # See https://github.com/astral-sh/ruff/issues/15598
+71 | / round(-
+72 | | 1)
+   | |__^ RUF057
+73 |   round(1
+74 |   *1
+   |
+   = help: Remove unnecessary `round` call
+
+ℹ Safe fix
+68 68 | # Fixes should preserve parentheses when argument
+69 69 | # contains newline.
+70 70 | # See https://github.com/astral-sh/ruff/issues/15598
+71    |-round(-
+   71 |+(-
+72 72 | 1)
+73 73 | round(1
+74 74 | *1
+
+RUF057.py:73:1: RUF057 [*] Value being rounded is already an integer
+   |
+71 |   round(-
+72 |   1)
+73 | / round(1
+74 | | *1
+75 | | )
+   | |_^ RUF057
+76 |
+77 |   # fix should be unsafe if comment is in call range
+   |
+   = help: Remove unnecessary `round` call
+
+ℹ Safe fix
+70 70 | # See https://github.com/astral-sh/ruff/issues/15598
+71 71 | round(-
+72 72 | 1)
+73    |-round(1
+74    |-*1
+75    |-)
+   73 |+(1
+   74 |+*1)
+76 75 | 
+77 76 | # fix should be unsafe if comment is in call range
+78 77 | round(# a comment
+
+RUF057.py:78:1: RUF057 [*] Value being rounded is already an integer
+   |
+77 |   # fix should be unsafe if comment is in call range
+78 | / round(# a comment
+79 | | 17
+80 | | )
+   | |_^ RUF057
+81 |   round(
+82 |       17 # a comment
+   |
+   = help: Remove unnecessary `round` call
+
+ℹ Unsafe fix
+75 75 | )
+76 76 | 
+77 77 | # fix should be unsafe if comment is in call range
+78    |-round(# a comment
+79 78 | 17
+80    |-)
+81 79 | round(
+82 80 |     17 # a comment
+83 81 | )
+
+RUF057.py:81:1: RUF057 [*] Value being rounded is already an integer
+   |
+79 |   17
+80 |   )
+81 | / round(
+82 | |     17 # a comment
+83 | | )
+   | |_^ RUF057
+   |
+   = help: Remove unnecessary `round` call
+
+ℹ Unsafe fix
+78 78 | round(# a comment
+79 79 | 17
+80 80 | )
+81    |-round(
+82    |-    17 # a comment
+83    |-)
+   81 |+17


### PR DESCRIPTION
As in the title. We also make the fix unsafe when the range of the call to `round()` intersects comments.

Closes #15598 
