### PR TITLE
[`flynt`] Do not offer a fix when the new string is too long (`FLY002`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flynt/FLY002.py
+++ b/crates/ruff_linter/resources/test/fixtures/flynt/FLY002.py
@@ -21,3 +21,12 @@ nok7 = "a".join([f"foo{8}", "bar"])  # Not OK (contains an f-string)
 # Regression test for: https://github.com/astral-sh/ruff/issues/7197
 def create_file_public_url(url, filename):
     return''.join([url, filename])
+
+
+# Regression test for: https://github.com/astral-sh/ruff/issues/5150
+expected = "\n".join(
+    [
+        "=== long text ======================================================================",
+        "=== long text ======================================================================",
+    ],
+)

--- a/crates/ruff_linter/src/rules/flynt/mod.rs
+++ b/crates/ruff_linter/src/rules/flynt/mod.rs
@@ -10,6 +10,7 @@ mod tests {
     use test_case::test_case;
 
     use crate::registry::Rule;
+    use crate::settings::types::PreviewMode;
     use crate::test::test_path;
     use crate::{assert_messages, settings};
 
@@ -19,6 +20,24 @@ mod tests {
         let diagnostics = test_path(
             Path::new("flynt").join(path).as_path(),
             &settings::LinterSettings::for_rule(rule_code),
+        )?;
+        assert_messages!(snapshot, diagnostics);
+        Ok(())
+    }
+
+    #[test_case(Rule::StaticJoinToFString, Path::new("FLY002.py"))]
+    fn preview_rules(rule_code: Rule, path: &Path) -> Result<()> {
+        let snapshot = format!(
+            "preview__{}_{}",
+            rule_code.noqa_code(),
+            path.to_string_lossy()
+        );
+        let diagnostics = test_path(
+            Path::new("flynt").join(path).as_path(),
+            &settings::LinterSettings {
+                preview: PreviewMode::Enabled,
+                ..settings::LinterSettings::for_rule(rule_code)
+            },
         )?;
         assert_messages!(snapshot, diagnostics);
         Ok(())

--- a/crates/ruff_linter/src/rules/flynt/snapshots/ruff_linter__rules__flynt__tests__preview__FLY002_FLY002.py.snap
+++ b/crates/ruff_linter/src/rules/flynt/snapshots/ruff_linter__rules__flynt__tests__preview__FLY002_FLY002.py.snap
@@ -144,7 +144,7 @@ FLY002.py:23:11: FLY002 [*] Consider `f"{url}{filename}"` instead of string join
 25 25 | 
 26 26 | # Regression test for: https://github.com/astral-sh/ruff/issues/5150
 
-FLY002.py:27:12: FLY002 [*] Consider f-string instead of string join
+FLY002.py:27:12: FLY002 Consider f-string instead of string join
    |
 26 |   # Regression test for: https://github.com/astral-sh/ruff/issues/5150
 27 |   expected = "\n".join(
@@ -157,15 +157,3 @@ FLY002.py:27:12: FLY002 [*] Consider f-string instead of string join
    | |_^ FLY002
    |
    = help: Replace with f-string
-
-ℹ Unsafe fix
-24 24 | 
-25 25 | 
-26 26 | # Regression test for: https://github.com/astral-sh/ruff/issues/5150
-27    |-expected = "\n".join(
-28    |-    [
-29    |-        "=== long text ======================================================================",
-30    |-        "=== long text ======================================================================",
-31    |-    ],
-32    |-)
-   27 |+expected = "=== long text ======================================================================\n=== long text ======================================================================"


### PR DESCRIPTION
## Summary

Resolves #5150.

## Test Plan

`cargo nextest run` and `cargo insta test`.
