### PR TITLE
Apply `AIR302`-context check only in `@task` function

### DIFF
--- a/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_context.py.snap
+++ b/crates/ruff_linter/src/rules/airflow/snapshots/ruff_linter__rules__airflow__tests__AIR302_AIR302_context.py.snap
@@ -1,16 +1,6 @@
 ---
 source: crates/ruff_linter/src/rules/airflow/mod.rs
-snapshot_kind: text
 ---
-AIR302_context.py:15:41: AIR302 `conf` is removed in Airflow 3.0
-   |
-14 | def access_invalid_key_in_context(**context):
-15 |     print("access invalid key", context["conf"])
-   |                                         ^^^^^^ AIR302
-16 |
-17 | @task
-   |
-
 AIR302_context.py:19:45: AIR302 `conf` is removed in Airflow 3.0
    |
 17 | @task
@@ -19,26 +9,6 @@ AIR302_context.py:19:45: AIR302 `conf` is removed in Airflow 3.0
    |                                             ^^^^^^ AIR302
 20 |
 21 | @dag(
-   |
-
-AIR302_context.py:19:45: AIR302 `conf` is removed in Airflow 3.0
-   |
-17 | @task
-18 | def access_invalid_key_task_out_of_dag(**context):
-19 |     print("access invalid key", context.get("conf"))
-   |                                             ^^^^^^ AIR302
-20 |
-21 | @dag(
-   |
-
-AIR302_context.py:30:49: AIR302 `conf` is removed in Airflow 3.0
-   |
-28 |     @task()
-29 |     def access_invalid_key_task(**context):
-30 |         print("access invalid key", context.get("conf"))
-   |                                                 ^^^^^^ AIR302
-31 |
-32 |     task1 = PythonOperator(
    |
 
 AIR302_context.py:30:49: AIR302 `conf` is removed in Airflow 3.0
@@ -191,25 +161,6 @@ AIR302_context.py:65:13: AIR302 `airflow.operators.dummy.DummyOperator` is remov
    |
    = help: Use `airflow.operators.empty.EmptyOperator` instead
 
-AIR302_context.py:78:57: AIR302 `execution_date` is removed in Airflow 3.0
-   |
-76 |     name = "custom_macros"
-77 |     macros = {
-78 |         "execution_date_macro": lambda context: context["execution_date"],
-   |                                                         ^^^^^^^^^^^^^^^^ AIR302
-79 |         "next_ds_macro": lambda context: context["next_ds"]
-80 |     }
-   |
-
-AIR302_context.py:79:50: AIR302 `next_ds` is removed in Airflow 3.0
-   |
-77 |     macros = {
-78 |         "execution_date_macro": lambda context: context["execution_date"],
-79 |         "next_ds_macro": lambda context: context["next_ds"]
-   |                                                  ^^^^^^^^^ AIR302
-80 |     }
-   |
-
 AIR302_context.py:85:30: AIR302 `execution_date` is removed in Airflow 3.0
    |
 83 | def print_config():
@@ -319,115 +270,6 @@ AIR302_context.py:95:35: AIR302 `yesterday_ds_nodash` is removed in Airflow 3.0
 97 | class CustomOperator(BaseOperator):
    |
 
-AIR302_context.py:99:34: AIR302 `execution_date` is removed in Airflow 3.0
-    |
- 97 | class CustomOperator(BaseOperator):
- 98 |     def execute(self, context):
- 99 |         execution_date = context["execution_date"]
-    |                                  ^^^^^^^^^^^^^^^^ AIR302
-100 |         next_ds = context["next_ds"]
-101 |         next_ds_nodash = context["next_ds_nodash"]
-    |
-
-AIR302_context.py:100:27: AIR302 `next_ds` is removed in Airflow 3.0
-    |
- 98 |     def execute(self, context):
- 99 |         execution_date = context["execution_date"]
-100 |         next_ds = context["next_ds"]
-    |                           ^^^^^^^^^ AIR302
-101 |         next_ds_nodash = context["next_ds_nodash"]
-102 |         next_execution_date = context["next_execution_date"]
-    |
-
-AIR302_context.py:101:34: AIR302 `next_ds_nodash` is removed in Airflow 3.0
-    |
- 99 |         execution_date = context["execution_date"]
-100 |         next_ds = context["next_ds"]
-101 |         next_ds_nodash = context["next_ds_nodash"]
-    |                                  ^^^^^^^^^^^^^^^^ AIR302
-102 |         next_execution_date = context["next_execution_date"]
-103 |         prev_ds = context["prev_ds"]
-    |
-
-AIR302_context.py:102:39: AIR302 `next_execution_date` is removed in Airflow 3.0
-    |
-100 |         next_ds = context["next_ds"]
-101 |         next_ds_nodash = context["next_ds_nodash"]
-102 |         next_execution_date = context["next_execution_date"]
-    |                                       ^^^^^^^^^^^^^^^^^^^^^ AIR302
-103 |         prev_ds = context["prev_ds"]
-104 |         prev_ds_nodash = context["prev_ds_nodash"]
-    |
-
-AIR302_context.py:103:27: AIR302 `prev_ds` is removed in Airflow 3.0
-    |
-101 |         next_ds_nodash = context["next_ds_nodash"]
-102 |         next_execution_date = context["next_execution_date"]
-103 |         prev_ds = context["prev_ds"]
-    |                           ^^^^^^^^^ AIR302
-104 |         prev_ds_nodash = context["prev_ds_nodash"]
-105 |         prev_execution_date = context["prev_execution_date"]
-    |
-
-AIR302_context.py:104:34: AIR302 `prev_ds_nodash` is removed in Airflow 3.0
-    |
-102 |         next_execution_date = context["next_execution_date"]
-103 |         prev_ds = context["prev_ds"]
-104 |         prev_ds_nodash = context["prev_ds_nodash"]
-    |                                  ^^^^^^^^^^^^^^^^ AIR302
-105 |         prev_execution_date = context["prev_execution_date"]
-106 |         prev_execution_date_success = context["prev_execution_date_success"]
-    |
-
-AIR302_context.py:105:39: AIR302 `prev_execution_date` is removed in Airflow 3.0
-    |
-103 |         prev_ds = context["prev_ds"]
-104 |         prev_ds_nodash = context["prev_ds_nodash"]
-105 |         prev_execution_date = context["prev_execution_date"]
-    |                                       ^^^^^^^^^^^^^^^^^^^^^ AIR302
-106 |         prev_execution_date_success = context["prev_execution_date_success"]
-107 |         tomorrow_ds = context["tomorrow_ds"]
-    |
-
-AIR302_context.py:106:47: AIR302 `prev_execution_date_success` is removed in Airflow 3.0
-    |
-104 |         prev_ds_nodash = context["prev_ds_nodash"]
-105 |         prev_execution_date = context["prev_execution_date"]
-106 |         prev_execution_date_success = context["prev_execution_date_success"]
-    |                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AIR302
-107 |         tomorrow_ds = context["tomorrow_ds"]
-108 |         yesterday_ds = context["yesterday_ds"]
-    |
-
-AIR302_context.py:107:31: AIR302 `tomorrow_ds` is removed in Airflow 3.0
-    |
-105 |         prev_execution_date = context["prev_execution_date"]
-106 |         prev_execution_date_success = context["prev_execution_date_success"]
-107 |         tomorrow_ds = context["tomorrow_ds"]
-    |                               ^^^^^^^^^^^^^ AIR302
-108 |         yesterday_ds = context["yesterday_ds"]
-109 |         yesterday_ds_nodash = context["yesterday_ds_nodash"]
-    |
-
-AIR302_context.py:108:32: AIR302 `yesterday_ds` is removed in Airflow 3.0
-    |
-106 |         prev_execution_date_success = context["prev_execution_date_success"]
-107 |         tomorrow_ds = context["tomorrow_ds"]
-108 |         yesterday_ds = context["yesterday_ds"]
-    |                                ^^^^^^^^^^^^^^ AIR302
-109 |         yesterday_ds_nodash = context["yesterday_ds_nodash"]
-    |
-
-AIR302_context.py:109:39: AIR302 `yesterday_ds_nodash` is removed in Airflow 3.0
-    |
-107 |         tomorrow_ds = context["tomorrow_ds"]
-108 |         yesterday_ds = context["yesterday_ds"]
-109 |         yesterday_ds_nodash = context["yesterday_ds_nodash"]
-    |                                       ^^^^^^^^^^^^^^^^^^^^^ AIR302
-110 |
-111 | @task
-    |
-
 AIR302_context.py:112:45: AIR302 `execution_date` is removed in Airflow 3.0
     |
 111 | @task
@@ -444,16 +286,6 @@ AIR302_context.py:112:61: AIR302 `tomorrow_ds` is removed in Airflow 3.0
     |                                                             ^^^^^^^^^^^ AIR302
 113 |     print("execution date", execution_date)
 114 |     print("access invalid key", context.get("conf"))
-    |
-
-AIR302_context.py:114:45: AIR302 `conf` is removed in Airflow 3.0
-    |
-112 | def access_invalid_argument_task_out_of_dag(execution_date, tomorrow_ds, logical_date, **context):
-113 |     print("execution date", execution_date)
-114 |     print("access invalid key", context.get("conf"))
-    |                                             ^^^^^^ AIR302
-115 |
-116 | @task(task_id="print_the_context")
     |
 
 AIR302_context.py:114:45: AIR302 `conf` is removed in Airflow 3.0
@@ -484,31 +316,4 @@ AIR302_context.py:122:11: AIR302 `execution_date` is removed in Airflow 3.0
     |           ^^^^^^^^^^^^^^^^ AIR302
 123 |
 124 | class CustomOperatorNew(BaseOperator):
-    |
-
-AIR302_context.py:122:11: AIR302 `execution_date` is removed in Airflow 3.0
-    |
-120 |     print(kwargs.get("tomorrow_ds"))
-121 |     c = get_current_context()
-122 |     c.get("execution_date")
-    |           ^^^^^^^^^^^^^^^^ AIR302
-123 |
-124 | class CustomOperatorNew(BaseOperator):
-    |
-
-AIR302_context.py:126:38: AIR302 `execution_date` is removed in Airflow 3.0
-    |
-124 | class CustomOperatorNew(BaseOperator):
-125 |     def execute(self, context):
-126 |         execution_date = context.get("execution_date")
-    |                                      ^^^^^^^^^^^^^^^^ AIR302
-127 |         next_ds = context.get("next_ds")
-    |
-
-AIR302_context.py:127:31: AIR302 `next_ds` is removed in Airflow 3.0
-    |
-125 |     def execute(self, context):
-126 |         execution_date = context.get("execution_date")
-127 |         next_ds = context.get("next_ds")
-    |                               ^^^^^^^^^ AIR302
     |


### PR DESCRIPTION
This PR updates `AIR302` to only apply the context keys check in `@task` decorated function.

Ref: https://github.com/astral-sh/ruff/pull/15144