### PR TITLE
[red-knot] Handle public symbols declared as `Unknown` like undeclared symbols

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/annotations/any.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/annotations/any.md
@@ -11,7 +11,7 @@ x: Any = 1
 x = "foo"
 
 def f():
-    reveal_type(x)  # revealed: Any
+    reveal_type(x)  # revealed: Any | Literal["foo"]
 ```
 
 ## Aliased to a different name
@@ -25,7 +25,7 @@ x: RenamedAny = 1
 x = "foo"
 
 def f():
-    reveal_type(x)  # revealed: Any
+    reveal_type(x)  # revealed: Any | Literal["foo"]
 ```
 
 ## Shadowed class

--- a/crates/red_knot_python_semantic/resources/mdtest/annotations/unsupported_special_forms.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/annotations/unsupported_special_forms.md
@@ -18,7 +18,7 @@ def f(*args: Unpack[Ts]) -> tuple[Unpack[Ts]]:
     # TODO: should understand the annotation
     reveal_type(args)  # revealed: tuple
 
-    reveal_type(Alias)  # revealed: @Todo(Unsupported or invalid type in a type expression)
+    reveal_type(Alias)  # revealed: @Todo(Unsupported or invalid type in a type expression) | Literal[int]
 
 def g() -> TypeGuard[int]: ...
 def h() -> TypeIs[int]: ...

--- a/crates/red_knot_python_semantic/resources/mdtest/assignment/annotations.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/assignment/annotations.md
@@ -49,12 +49,12 @@ reveal_type(c)  # revealed: tuple[str, int]
 reveal_type(d)  # revealed: tuple[tuple[str, str], tuple[int, int]]
 
 # TODO: homogeneous tuples, PEP-646 tuples
-reveal_type(e)  # revealed: @Todo(full tuple[...] support)
-reveal_type(f)  # revealed: @Todo(full tuple[...] support)
-reveal_type(g)  # revealed: @Todo(full tuple[...] support)
+reveal_type(e)  # revealed: @Todo(full tuple[...] support) | tuple[()]
+reveal_type(f)  # revealed: @Todo(full tuple[...] support) | tuple[Literal["42"], Literal[b"42"]]
+reveal_type(g)  # revealed: @Todo(full tuple[...] support) | tuple[Literal["42"], Literal[b"42"]]
 
 # TODO: support more kinds of type expressions in annotations
-reveal_type(h)  # revealed: @Todo(full tuple[...] support)
+reveal_type(h)  # revealed: @Todo(full tuple[...] support) | tuple[list, list]
 
 reveal_type(i)  # revealed: tuple[str | int, str | int]
 reveal_type(j)  # revealed: tuple[str | int]

--- a/crates/red_knot_python_semantic/resources/mdtest/attributes.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/attributes.md
@@ -175,16 +175,14 @@ class C:
 
 reveal_type(C.pure_class_variable1)  # revealed: str
 
-# TODO: Should be `Unknown | Literal[1]`.
-reveal_type(C.pure_class_variable2)  # revealed: Unknown
+reveal_type(C.pure_class_variable2)  # revealed: Unknown | Literal[1]
 
 c_instance = C()
 
 # It is okay to access a pure class variable on an instance.
 reveal_type(c_instance.pure_class_variable1)  # revealed: str
 
-# TODO: Should be `Unknown | Literal[1]`.
-reveal_type(c_instance.pure_class_variable2)  # revealed: Unknown
+reveal_type(c_instance.pure_class_variable2)  # revealed: Unknown | Literal[1]
 
 # error: [invalid-attribute-access] "Cannot assign to ClassVar `pure_class_variable1` from an instance of type `C`"
 c_instance.pure_class_variable1 = "value set on instance"

--- a/crates/red_knot_python_semantic/resources/mdtest/boundness_declaredness/public.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/boundness_declaredness/public.md
@@ -4,10 +4,10 @@ This document demonstrates how type-inference and diagnostics work for *public* 
 that is, a use of a symbol from another scope. If a symbol has a declared type in its local scope
 (e.g. `int`), we use that as the symbol's "public type" (the type of the symbol from the perspective
 of other scopes). If there is an inferred type in addition (i.e. if we also see bindings for this
-symbol, not just declarations), we build the union of the declared and inferred types. For fully-
-static types, the inferred type must be a subtype of the declared type (otherwise we would issue
-diagnostics). For dynamic types, however, this can lead to more precise types with lower bounds
-given by the inferred type (e.g. `Any | Literal[1]` for a symbol defined as `x: Any = 1`).
+symbol, not just declarations), we use `T_decl | T_decl & T_inf` as the public type, which
+simplifies to `T_decl` for `T_inf = Unknown` (the unbound case).
+
+[TODO: more explanation]
 
 If a symbol has no declared type, we use the union of `Unknown` with the inferred type as the public
 type. If there is no declaration, then the symbol can be reassigned to any type from another scope;
@@ -21,11 +21,11 @@ this behavior is questionable and might change in the future. See the TODOs in `
 In particular, we should raise errors in the "possibly-undeclared-and-unbound" as well as the
 "undeclared-and-possibly-unbound" cases (marked with a "?").
 
-| **Public type**  | declared                   | possibly-undeclared        | undeclared         |
-| ---------------- | -------------------------- | -------------------------- | ------------------ |
-| bound            | `T_decl \| T_decl & T_inf` | `T_decl \| T_decl & T_inf` | `Unknown \| T_inf` |
-| possibly-unbound | `T_decl \| T_decl & T_inf` | `T_decl \| T_decl & T_inf` | `Unknown \| T_inf` |
-| unbound          | `T_decl`                   | `T_decl`                   | `Unknown`          |
+| **Public type**  | declared                   | possibly-undeclared | undeclared         |
+| ---------------- | -------------------------- | ------------------- | ------------------ |
+| bound            | `T_decl \| T_decl & T_inf` | `T_decl \| T_inf`   | `Unknown \| T_inf` |
+| possibly-unbound | `T_decl \| T_decl & T_inf` | `T_decl \| T_inf`   | `Unknown \| T_inf` |
+| unbound          | `T_decl`                   | `T_decl`            | `Unknown`          |
 
 | **Diagnostic**   | declared | possibly-undeclared       | undeclared          |
 | ---------------- | -------- | ------------------------- | ------------------- |

--- a/crates/red_knot_python_semantic/resources/mdtest/type_qualifiers/classvar.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/type_qualifiers/classvar.md
@@ -21,8 +21,7 @@ class C:
 reveal_type(C.a)  # revealed: int
 reveal_type(C.b)  # revealed: int
 reveal_type(C.c)  # revealed: int
-# TODO: should be Unknown | Literal[1]
-reveal_type(C.d)  # revealed: Unknown
+reveal_type(C.d)  # revealed: Unknown | Literal[1]
 reveal_type(C.e)  # revealed: int
 
 c = C()


### PR DESCRIPTION
## Summary

For *definitely declared* symbols, we currently rely on the declared type only, even if we also see bindings for that symbol. This means that we handle the two cases (1) a symbol is undeclared and (2) a symbol is declared with type `Any`/`Unknown` differently, which seems inconsistent.

One potential solution to this problem is the following: Instead of returning `T_declared` as the public type of a declared symbol, we return `T_declared | T_declared & T_inferred` instead. This represents a type that is *no smaller than and no larger than* `T_declared`. For fully static types, this construct simplifies to `T_declared`. But for non-fully-static types, this can lead to more precise types. For example, if the declared type is `Any` (or `Unknown`), we now use `Any | Any & T` which can be simplified to `Any | T`. This represents the fact that the public type for this symbol must be at least as large as the inferred type `T`. This allows us to issue diagnostics in cases like the following:

```py
from typing import Any

class C:
    x: Any = 1

reveal_type(C.x)  # Any | Literal[1]    (previously: Any)

y: str = C.x  # error: [invalid-assignment]
```
Red knot (main), mypy and pyright issue no diagnostic in the last line here.

In the example given above, it looks like the intersection is not necessary. However, consider the following scenario. We still want to see `int` as the public type here. This is possible because `int | int & Any = int`:
```py
from typing import Any

def any() -> Any: ...

class C:
    x: int = any()

reveal_type(C.x)  # int
```

The same behavior should also apply to possibly-declared symbols.

### Why `(T_declared | T_declared & T_inferred)`?

The nice property of this expression is that it works for other cases in the matrix below as well.

#### Undeclared (`T_declared = Unknown`)

If a symbol is definitely undeclared, we can set `T_declared = Unknown`. In this case, the expression `T_declared | T_declared & T_inferred = Unknown | Unknown & T_inferred` simplifies to `Unknown | T_inferred`. This is exactly what we have in the **last column** of the matrix below (where the entry in the last *row* further simplifies because `Unknown | Unknown = Unknown`).

#### Unbound (`T_inferred = Unknown`)

If a symbol is definitely unbound, we can set `T_inferred = Unknown`. In this case, the expression `T_declared | T_declared & T_inferred = T_declared | T_declared & Unknown` simplifies to `T_declared`. This is exactly what we have in the **last row** of the matrix (where the entry in the last *column* simplifies because `T_declared` is `Unknown` in this case as well)

### Type inference matrix

(changes affect the first column only)

#### Before

| **Public type**  | declared                   | possibly-undeclared | undeclared         |
| ---------------- | -------------------------- | ------------------- | -------------------|
| bound            | `T_decl` &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | `T_decl \| T_inf`   | `Unknown \| T_inf` |
| possibly-unbound | `T_decl` | `T_decl \| T_inf`   | `Unknown \| T_inf` |
| unbound          | `T_decl`                   | `T_decl`            | `Unknown`          |

#### After

| **Public type**  | declared                   | possibly-undeclared  | undeclared         |
| ---------------- | -------------------------- | ---------------------| ------------------ |
| bound            | `T_decl \| T_decl & T_inf` | `T_decl \| T_inf`    | `Unknown \| T_inf` |
| possibly-unbound | `T_decl \| T_decl & T_inf` | `T_decl \| T_inf`    | `Unknown \| T_inf` |
| unbound          | `T_decl`                   | `T_decl`             | `Unknown`          |

### What about possibly-undeclared?

It would be great if we could replace `T_declared -> T_declared | Unknown` for this case (and similar for possibly unbound symbols). This is doable, but leads to lots of unions/intersections with `Unknown`, something that we don't fully simplify at the moment, so I have not fully looked into this yet. As it stands, our handling of possibly-undeclared symbols is at least debatable. For example, should we issue a diagnostic in the following example (we currently do not).
```py
def flag() -> bool: return True
def get_int() -> int: ...

class C:
    if flag():
        x: str
    else:
        x = get_int()

C.x = 1  # this seems to violate the `str` declaration?
```

## Test Plan

Updated existing tests.