### PR TITLE
[`pylint`] Do not trigger `PLR6201` on empty collections

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pylint/literal_membership.py
+++ b/crates/ruff_linter/resources/test/fixtures/pylint/literal_membership.py
@@ -13,3 +13,5 @@ fruits in [[1, 2, 3], [4, 5, 6]]
 fruits in [1, 2, 3]
 1 in [[1, 2, 3], [4, 5, 6]]
 _ = {key: value for key, value in {"a": 1, "b": 2}.items() if key in (["a", "b"], ["c", "d"])}
+1 in []
+1 in ()

--- a/crates/ruff_linter/src/rules/pylint/rules/literal_membership.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/literal_membership.rs
@@ -65,6 +65,11 @@ pub(crate) fn literal_membership(checker: &mut Checker, compare: &ast::ExprCompa
         _ => return,
     };
 
+    // Skip empty collections (#15729).
+    if elts.is_empty() {
+        return;
+    }
+
     // If `left`, or any of the elements in `right`, are known to _not_ be hashable, return.
     if std::iter::once(compare.left.as_ref())
         .chain(elts)


### PR DESCRIPTION
Fixes #15729.