### PR TITLE
[red-knot] Ensure differently ordered unions and intersections are understood as equivalent even inside arbitrarily nested tuples

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/type_properties/is_equivalent_to.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/type_properties/is_equivalent_to.md
@@ -87,7 +87,7 @@ static_assert(
 ## Unions containing tuples containing tuples containing unions (etc.)
 
 ```py
-from knot_extensions import is_equivalent_to, static_assert
+from knot_extensions import is_equivalent_to, static_assert, Intersection
 
 class P: ...
 class Q: ...
@@ -96,6 +96,12 @@ static_assert(
     is_equivalent_to(
         tuple[tuple[tuple[P | Q]]] | P,
         tuple[tuple[tuple[Q | P]]] | P,
+    )
+)
+static_assert(
+    is_equivalent_to(
+        tuple[tuple[tuple[tuple[tuple[Intersection[P, Q]]]]]],
+        tuple[tuple[tuple[tuple[tuple[Intersection[Q, P]]]]]],
     )
 )
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/type_properties/is_equivalent_to.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/type_properties/is_equivalent_to.md
@@ -84,4 +84,20 @@ static_assert(
 )
 ```
 
+## Unions containing tuples containing tuples containing unions (etc.)
+
+```py
+from knot_extensions import is_equivalent_to, static_assert
+
+class P: ...
+class Q: ...
+
+static_assert(
+    is_equivalent_to(
+        tuple[tuple[tuple[P | Q]]] | P,
+        tuple[tuple[tuple[Q | P]]] | P,
+    )
+)
+```
+
 [the equivalence relation]: https://typing.readthedocs.io/en/latest/spec/glossary.html#term-equivalent


### PR DESCRIPTION
## Summary

On `main`, red-knot:
- Considers `P | Q` equivalent to `Q | P`
- Considered `tuple[P | Q]` equivalent to `tuple[Q | P]`
- Considers `tuple[P | tuple[P | Q]]` equivalent to `tuple[tuple[Q | P] | P]`
- ‼️ Does _not_ consider `tuple[tuple[P | Q]]` equivalent to `tuple[tuple[Q | P]]`

The key difference for the last one of these is that the union appears inside a tuple that is directly nested inside another tuple.

This PR fixes this so that differently ordered unions are considered equivalent even when they appear inside arbitrarily nested tuple types.

## Test Plan

- Added mdtests that fails on `main`
- Checked that all property tests continue to pass with this PR
