### PR TITLE
[red-knot] Ensure differently ordered unions are considered equivalent when they appear inside tuples inside top-level intersections

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/type_properties/is_equivalent_to.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/type_properties/is_equivalent_to.md
@@ -106,4 +106,16 @@ static_assert(
 )
 ```
 
+## Intersections containing tuples containing unions
+
+```py
+from knot_extensions import is_equivalent_to, static_assert, Intersection
+
+class P: ...
+class Q: ...
+class R: ...
+
+static_assert(is_equivalent_to(Intersection[tuple[P | Q], R], Intersection[tuple[Q | P], R]))
+```
+
 [the equivalence relation]: https://typing.readthedocs.io/en/latest/spec/glossary.html#term-equivalent

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -4516,21 +4516,33 @@ impl<'db> IntersectionType<'db> {
         }
 
         let self_positive = self.positive(db);
+
         if !all_fully_static(db, self_positive) {
             return false;
         }
 
-        let self_negative = self.negative(db);
-        if !all_fully_static(db, self_negative) {
+        let other_positive = other.positive(db);
+
+        if self_positive.len() != other_positive.len() {
             return false;
         }
 
-        let other_positive = other.positive(db);
         if !all_fully_static(db, other_positive) {
             return false;
         }
 
+        let self_negative = self.negative(db);
+
+        if !all_fully_static(db, self_negative) {
+            return false;
+        }
+
         let other_negative = other.negative(db);
+
+        if self_negative.len() != other_negative.len() {
+            return false;
+        }
+
         if !all_fully_static(db, other_negative) {
             return false;
         }
@@ -4539,7 +4551,13 @@ impl<'db> IntersectionType<'db> {
             return true;
         }
 
-        self_positive.set_eq(other_positive) && self_negative.set_eq(other_negative)
+        let sorted_self = self.to_sorted_intersection(db);
+
+        if sorted_self == other {
+            return true;
+        }
+
+        sorted_self == other.to_sorted_intersection(db)
     }
 
     /// Return `true` if `self` has exactly the same set of possible static materializations as `other`


### PR DESCRIPTION
## Summary

Another oversight in type equivalence, that I spotted by re-reading some of the code in `types.rs`. In this round of type-equivalence whackamole, we were not considering `tuple[P | Q] & R` to be equivalent to `tuple[Q | P] & R`. This bug only manifested if a union was nested directly inside a tuple nested directly inside a top-level intersection.

It sure would be easier to ensure we got all these cases right if unions only ever appeared in a canonical order 😉 I'm not _yet_ pushing for us to reconsider the direction we went in https://github.com/astral-sh/ruff/pull/15516, but there _is_ definitely a maintenance burden here.

## Test Plan

- New mdtest added that fails on `main`
- Checked that all stable property tests continue to pass
