### PR TITLE
[`ruff`] Do not emit diagnostic when all arguments to `zip()` are variadic (`RUF058`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/ruff/RUF058.py
+++ b/crates/ruff_linter/resources/test/fixtures/ruff/RUF058.py
@@ -6,7 +6,7 @@ import itertools
 
 starmap(func, zip())
 starmap(func, zip([]))
-starmap(func, zip(*args))
+
 
 starmap(func, zip(a, b, c,),)
 
@@ -71,3 +71,7 @@ starmap(func, zip(a, b, c), lorem=ipsum)
 starmap(func, zip(a, b, c, strict=True))
 starmap(func, zip(a, b, c, strict=False))
 starmap(func, zip(a, b, c, strict=strict))
+
+# https://github.com/astral-sh/ruff/issues/15742
+starmap(func, zip(*a))
+starmap(func, zip(*a, *b))

--- a/crates/ruff_linter/src/rules/ruff/rules/starmap_zip.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/starmap_zip.rs
@@ -59,6 +59,13 @@ pub(crate) fn starmap_zip(checker: &mut Checker, call: &ExprCall) {
         return;
     }
 
+    let positionals = &iterable_call.arguments.args;
+
+    // `zip(*a)` where `a` is empty is valid, but `map(_, *a)` isn't.
+    if !positionals.is_empty() && positionals.iter().all(|arg| arg.is_starred_expr()) {
+        return;
+    }
+
     if !semantic
         .resolve_qualified_name(&call.func)
         .is_some_and(|it| matches!(it.segments(), ["itertools", "starmap"]))

--- a/crates/ruff_linter/src/rules/ruff/rules/starmap_zip.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/starmap_zip.rs
@@ -62,7 +62,7 @@ pub(crate) fn starmap_zip(checker: &mut Checker, call: &ExprCall) {
     let positionals = &iterable_call.arguments.args;
 
     // `zip(*a)` where `a` is empty is valid, but `map(_, *a)` isn't.
-    if !positionals.is_empty() && positionals.iter().all(|arg| arg.is_starred_expr()) {
+    if !positionals.is_empty() && positionals.iter().all(Expr::is_starred_expr) {
         return;
     }
 

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__preview__RUF058_RUF058.py.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__preview__RUF058_RUF058.py.snap
@@ -8,7 +8,6 @@ RUF058.py:7:1: RUF058 [*] `itertools.starmap` called on `zip` iterable
 7 | starmap(func, zip())
   | ^^^^^^^^^^^^^^^^^^^^ RUF058
 8 | starmap(func, zip([]))
-9 | starmap(func, zip(*args))
   |
   = help: Use `map` instead
 
@@ -19,7 +18,7 @@ RUF058.py:7:1: RUF058 [*] `itertools.starmap` called on `zip` iterable
 7   |-starmap(func, zip())
   7 |+map(func, [])
 8 8 | starmap(func, zip([]))
-9 9 | starmap(func, zip(*args))
+9 9 | 
 10 10 | 
 
 RUF058.py:8:1: RUF058 [*] `itertools.starmap` called on `zip` iterable
@@ -27,7 +26,6 @@ RUF058.py:8:1: RUF058 [*] `itertools.starmap` called on `zip` iterable
 7 | starmap(func, zip())
 8 | starmap(func, zip([]))
   | ^^^^^^^^^^^^^^^^^^^^^^ RUF058
-9 | starmap(func, zip(*args))
   |
   = help: Use `map` instead
 
@@ -37,35 +35,12 @@ RUF058.py:8:1: RUF058 [*] `itertools.starmap` called on `zip` iterable
 7 7 | starmap(func, zip())
 8   |-starmap(func, zip([]))
   8 |+map(func, [])
-9 9 | starmap(func, zip(*args))
+9 9 | 
 10 10 | 
 11 11 | starmap(func, zip(a, b, c,),)
-
-RUF058.py:9:1: RUF058 [*] `itertools.starmap` called on `zip` iterable
-   |
- 7 | starmap(func, zip())
- 8 | starmap(func, zip([]))
- 9 | starmap(func, zip(*args))
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^ RUF058
-10 |
-11 | starmap(func, zip(a, b, c,),)
-   |
-   = help: Use `map` instead
-
-ℹ Safe fix
-6  6  | 
-7  7  | starmap(func, zip())
-8  8  | starmap(func, zip([]))
-9     |-starmap(func, zip(*args))
-   9  |+map(func, *args)
-10 10 | 
-11 11 | starmap(func, zip(a, b, c,),)
-12 12 | 
 
 RUF058.py:11:1: RUF058 [*] `itertools.starmap` called on `zip` iterable
    |
- 9 | starmap(func, zip(*args))
-10 |
 11 | starmap(func, zip(a, b, c,),)
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ RUF058
    |
@@ -73,7 +48,7 @@ RUF058.py:11:1: RUF058 [*] `itertools.starmap` called on `zip` iterable
 
 ℹ Safe fix
 8  8  | starmap(func, zip([]))
-9  9  | starmap(func, zip(*args))
+9  9  | 
 10 10 | 
 11    |-starmap(func, zip(a, b, c,),)
    11 |+map(func, a, b, c,)


### PR DESCRIPTION
## Summary

Resolves #15742.

Previously, these would be considered violations:

```python
# All arguments are variadic
starmap(print, zip(*a))
starmap(print, zip(*a, *b))
```

It is possible, however, that the user is relying on the fact that `zip()` can be called without arguments. On the other hand, `map()` can't be called with less than two arguments.

Thus, after this change, the aforementioned cases are no longer reported.

## Test Plan

`cargo nextest run` and `cargo insta test`.
