### PR TITLE
Fix docstring in ruff_annotate_snippets

### DIFF
--- a/crates/ruff_annotate_snippets/src/renderer/mod.rs
+++ b/crates/ruff_annotate_snippets/src/renderer/mod.rs
@@ -100,7 +100,7 @@ impl Renderer {
         self
     }
 
-    // Set the terminal width
+    /// Set the terminal width
     pub const fn term_width(mut self, term_width: usize) -> Self {
         self.term_width = term_width;
         self


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Found a comment that looks to be intended as docstring but accidentally is just a normal comment.

Didn't create an issue as the readme said it's not neccessary for trivial changes.

## Test Plan

<!-- How was it tested? -->
Can be tested by regenerating the docs.
