### PR TITLE
[`pylint`] Fix missing parens in unsafe fix for `unnecessary-dunder-call` (`PLC2801`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pylint/unnecessary_dunder_call.py
+++ b/crates/ruff_linter/resources/test/fixtures/pylint/unnecessary_dunder_call.py
@@ -48,6 +48,21 @@ x = -(-a).__add__(3)  # PLC2801
 # Calls
 print(a.__call__())  # PLC2801 (no fix, intentional)
 
+class Foo:
+    def __init__(self, v):
+        self.v = v
+
+    def __add__(self, other):
+        self.v += other
+        return self
+
+    def get_v(self):
+        return self.v
+
+foo = Foo(1)
+foo.__add__(2).get_v()  # PLC2801
+
+
 # Lambda expressions
 blah = lambda: a.__add__(1)  # PLC2801
 
@@ -72,13 +87,22 @@ print(next(gen))
 
 # Subscripts
 print({"a": a.__add__(1)}["a"])  # PLC2801
+# https://github.com/astral-sh/ruff/issues/15745
+print("x".__add__("y")[0])  # PLC2801
 
 # Starred
 print(*[a.__add__(1)])  # PLC2801
 
+list1 = [1, 2, 3]
+list2 = [4, 5, 6]
+print([*list1.__add__(list2)])  # PLC2801
+
 # Slices
 print([a.__add__(1), a.__sub__(1)][0:1])  # PLC2801
 
+# Attribute access
+# https://github.com/astral-sh/ruff/issues/15745
+print(1j.__add__(1.0).real) # PLC2801
 
 class Thing:
     def __init__(self, stuff: Any) -> None:

--- a/crates/ruff_linter/src/rules/pylint/rules/unnecessary_dunder_call.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/unnecessary_dunder_call.rs
@@ -124,7 +124,7 @@ pub(crate) fn unnecessary_dunder_call(checker: &mut Checker, call: &ast::ExprCal
                         replacement,
                         checker.locator().slice(value.as_ref()),
                     ),
-                    ExprPrecedence::CallAttr,
+                    ExprPrecedence::CallAttribute,
                 ));
                 title = Some(message.to_string());
             }
@@ -278,32 +278,32 @@ impl DunderReplacement {
             "__and__" => Some(Self::Operator(
                 "&",
                 "Use `&` operator",
-                ExprPrecedence::BitwiseAnd,
+                ExprPrecedence::BitAnd,
             )),
             "__contains__" => Some(Self::ROperator(
                 "in",
                 "Use `in` operator",
-                ExprPrecedence::Compare,
+                ExprPrecedence::ComparisonsMembershipIdentity,
             )),
             "__eq__" => Some(Self::Operator(
                 "==",
                 "Use `==` operator",
-                ExprPrecedence::Compare,
+                ExprPrecedence::ComparisonsMembershipIdentity,
             )),
             "__floordiv__" => Some(Self::Operator(
                 "//",
                 "Use `//` operator",
-                ExprPrecedence::MultDiv,
+                ExprPrecedence::MulDivRemain,
             )),
             "__ge__" => Some(Self::Operator(
                 ">=",
                 "Use `>=` operator",
-                ExprPrecedence::Compare,
+                ExprPrecedence::ComparisonsMembershipIdentity,
             )),
             "__gt__" => Some(Self::Operator(
                 ">",
                 "Use `>` operator",
-                ExprPrecedence::Compare,
+                ExprPrecedence::ComparisonsMembershipIdentity,
             )),
             "__iadd__" => Some(Self::Operator(
                 "+=",
@@ -368,42 +368,42 @@ impl DunderReplacement {
             "__le__" => Some(Self::Operator(
                 "<=",
                 "Use `<=` operator",
-                ExprPrecedence::Compare,
+                ExprPrecedence::ComparisonsMembershipIdentity,
             )),
             "__lshift__" => Some(Self::Operator(
                 "<<",
                 "Use `<<` operator",
-                ExprPrecedence::BitwiseShifts,
+                ExprPrecedence::LeftRightShift,
             )),
             "__lt__" => Some(Self::Operator(
                 "<",
                 "Use `<` operator",
-                ExprPrecedence::Compare,
+                ExprPrecedence::ComparisonsMembershipIdentity,
             )),
             "__mod__" => Some(Self::Operator(
                 "%",
                 "Use `%` operator",
-                ExprPrecedence::MultDiv,
+                ExprPrecedence::MulDivRemain,
             )),
             "__mul__" => Some(Self::Operator(
                 "*",
                 "Use `*` operator",
-                ExprPrecedence::MultDiv,
+                ExprPrecedence::MulDivRemain,
             )),
             "__ne__" => Some(Self::Operator(
                 "!=",
                 "Use `!=` operator",
-                ExprPrecedence::Compare,
+                ExprPrecedence::ComparisonsMembershipIdentity,
             )),
             "__or__" => Some(Self::Operator(
                 "|",
                 "Use `|` operator",
-                ExprPrecedence::BitwiseXorOr,
+                ExprPrecedence::BitXorOr,
             )),
             "__rshift__" => Some(Self::Operator(
                 ">>",
                 "Use `>>` operator",
-                ExprPrecedence::BitwiseShifts,
+                ExprPrecedence::LeftRightShift,
             )),
             "__sub__" => Some(Self::Operator(
                 "-",
@@ -413,12 +413,12 @@ impl DunderReplacement {
             "__truediv__" => Some(Self::Operator(
                 "/",
                 "Use `/` operator",
-                ExprPrecedence::MultDiv,
+                ExprPrecedence::MulDivRemain,
             )),
             "__xor__" => Some(Self::Operator(
                 "^",
                 "Use `^` operator",
-                ExprPrecedence::BitwiseXorOr,
+                ExprPrecedence::BitXorOr,
             )),
 
             "__radd__" => Some(Self::ROperator(
@@ -429,37 +429,37 @@ impl DunderReplacement {
             "__rand__" => Some(Self::ROperator(
                 "&",
                 "Use `&` operator",
-                ExprPrecedence::BitwiseAnd,
+                ExprPrecedence::BitAnd,
             )),
             "__rfloordiv__" => Some(Self::ROperator(
                 "//",
                 "Use `//` operator",
-                ExprPrecedence::MultDiv,
+                ExprPrecedence::MulDivRemain,
             )),
             "__rlshift__" => Some(Self::ROperator(
                 "<<",
                 "Use `<<` operator",
-                ExprPrecedence::BitwiseShifts,
+                ExprPrecedence::LeftRightShift,
             )),
             "__rmod__" => Some(Self::ROperator(
                 "%",
                 "Use `%` operator",
-                ExprPrecedence::MultDiv,
+                ExprPrecedence::MulDivRemain,
             )),
             "__rmul__" => Some(Self::ROperator(
                 "*",
                 "Use `*` operator",
-                ExprPrecedence::MultDiv,
+                ExprPrecedence::MulDivRemain,
             )),
             "__ror__" => Some(Self::ROperator(
                 "|",
                 "Use `|` operator",
-                ExprPrecedence::BitwiseXorOr,
+                ExprPrecedence::BitXorOr,
             )),
             "__rrshift__" => Some(Self::ROperator(
                 ">>",
                 "Use `>>` operator",
-                ExprPrecedence::BitwiseShifts,
+                ExprPrecedence::LeftRightShift,
             )),
             "__rsub__" => Some(Self::ROperator(
                 "-",
@@ -469,12 +469,12 @@ impl DunderReplacement {
             "__rtruediv__" => Some(Self::ROperator(
                 "/",
                 "Use `/` operator",
-                ExprPrecedence::MultDiv,
+                ExprPrecedence::MulDivRemain,
             )),
             "__rxor__" => Some(Self::ROperator(
                 "^",
                 "Use `^` operator",
-                ExprPrecedence::BitwiseXorOr,
+                ExprPrecedence::BitXorOr,
             )),
 
             "__aiter__" => Some(Self::Builtin("aiter", "Use `aiter()` builtin")),
@@ -573,30 +573,55 @@ fn in_dunder_method_definition(semantic: &SemanticModel) -> bool {
     })
 }
 
-#[repr(u8)]
+/// Represents the precedence levels for Python expressions.
+/// Variants at the top have lower precedence and variants at the bottom have
+/// higher precedence.
+///
+/// See: <https://docs.python.org/3/reference/expressions.html#operator-precedence>
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub(crate) enum ExprPrecedence {
-    /// The lowest (virtual) precedence level.
-    Min = 0,
-    Yield = 10,
-    Assign = 15,
-    Starred = 20,
-    Lambda = 25,
-    IfElse = 30,
-    BoolOr = 35,
-    BoolAnd = 40,
-    BoolNot = 45,
-    Compare = 50,
-    BitwiseXorOr = 55,
-    BitwiseAnd = 60,
-    BitwiseShifts = 65,
-    AddSub = 70,
-    MultDiv = 75,
-    Unary = 80,
-    Power = 85,
-    Await = 90,
-    CallAttr = 95,
-    Atomic = 100,
+    /// The lowest (virtual) precedence level
+    None,
+    /// Precedence of `yield` and `yield from` expressions.
+    Yield,
+    /// Precedence of assignment expressions (`name := expr`).
+    Assign,
+    /// Precedence of starred expressions (`*expr`).
+    Starred,
+    /// Precedence of lambda expressions (`lambda args: expr`).
+    Lambda,
+    /// Precedence of if/else expressions (`expr if cond else expr`).
+    IfElse,
+    /// Precedence of boolean `or` expressions.
+    Or,
+    /// Precedence of boolean `and` expressions.
+    And,
+    /// Precedence of boolean `not` expressions.
+    Not,
+    /// Precedence of comparisons (`<`, `<=`, `>`, `>=`, `!=`, `==`),
+    /// memberships (`in`, `not in`) and identity tests (`is`, `is not`).
+    ComparisonsMembershipIdentity,
+    /// Precedence of bitwise `|` and `^` operators.
+    BitXorOr,
+    /// Precedence of bitwise `&` operator.
+    BitAnd,
+    /// Precedence of left and right shift expressions (`<<`, `>>`).
+    LeftRightShift,
+    /// Precedence of addition and subtraction expressions (`+`, `-`).
+    AddSub,
+    /// Precedence of multiplication (`*`), matrix multiplication (`@`), division (`/`),
+    /// floor division (`//`) and remainder (`%`) expressions.
+    MulDivRemain,
+    /// Precedence of unary positive (`+`), negative (`-`), and bitwise NOT (`~`) expressions.
+    PosNegBitNot,
+    /// Precedence of exponentiation expressions (`**`).
+    Exponent,
+    /// Precedence of `await` expressions.
+    Await,
+    /// Precedence of call expressions (`()`), attribute access (`.`), and subscript (`[]`) expressions.
+    CallAttribute,
+    /// Precedence of atomic expressions (literals, names, containers).
+    Atomic,
 }
 
 /// A trait to determine the Python precedence of an expression.
@@ -632,19 +657,19 @@ impl Precedence for Expr {
             | Expr::FString(_) => ExprPrecedence::Atomic,
             // Subscription, slicing, call, attribute reference
             Expr::Attribute(_) | Expr::Subscript(_) | Expr::Call(_) | Expr::Slice(_) => {
-                ExprPrecedence::CallAttr
+                ExprPrecedence::CallAttribute
             }
 
             // Await expression
             Expr::Await(_) => ExprPrecedence::Await,
 
             // Exponentiation **
-            // 90. Handled below along with other binary operators
+            // Handled below along with other binary operators
 
             // Unary operators: +x, -x, ~x (except boolean not)
             Expr::UnaryOp(operator) => match operator.op {
-                UnaryOp::UAdd | UnaryOp::USub | UnaryOp::Invert => ExprPrecedence::Unary,
-                UnaryOp::Not => ExprPrecedence::BoolNot,
+                UnaryOp::UAdd | UnaryOp::USub | UnaryOp::Invert => ExprPrecedence::PosNegBitNot,
+                UnaryOp::Not => ExprPrecedence::Not,
             },
 
             // Math binary ops
@@ -655,28 +680,28 @@ impl Precedence for Expr {
                 | Operator::MatMult
                 | Operator::Div
                 | Operator::Mod
-                | Operator::FloorDiv => ExprPrecedence::MultDiv,
+                | Operator::FloorDiv => ExprPrecedence::MulDivRemain,
                 // Addition, subtraction
                 Operator::Add | Operator::Sub => ExprPrecedence::AddSub,
                 // Bitwise shifts: <<, >>
-                Operator::LShift | Operator::RShift => ExprPrecedence::BitwiseShifts,
+                Operator::LShift | Operator::RShift => ExprPrecedence::LeftRightShift,
                 // Bitwise operations: &, ^, |
-                Operator::BitAnd => ExprPrecedence::BitwiseAnd,
-                Operator::BitXor | Operator::BitOr => ExprPrecedence::BitwiseXorOr,
+                Operator::BitAnd => ExprPrecedence::BitAnd,
+                Operator::BitXor | Operator::BitOr => ExprPrecedence::BitXorOr,
                 // Exponentiation **
-                Operator::Pow => ExprPrecedence::Power,
+                Operator::Pow => ExprPrecedence::Exponent,
             },
 
             // Comparisons: <, <=, >, >=, ==, !=, in, not in, is, is not
-            Expr::Compare(_) => ExprPrecedence::Compare,
+            Expr::Compare(_) => ExprPrecedence::ComparisonsMembershipIdentity,
 
             // Boolean not
-            // 50. Handled above in unary operators
+            // Handled above in unary operators
 
             // Boolean operations: and, or
             Expr::BoolOp(operator) => match operator.op {
-                BoolOp::And => ExprPrecedence::BoolAnd,
-                BoolOp::Or => ExprPrecedence::BoolOr,
+                BoolOp::And => ExprPrecedence::And,
+                BoolOp::Or => ExprPrecedence::Or,
             },
 
             // Conditional expressions: x if y else z
@@ -700,7 +725,7 @@ impl Precedence for Expr {
             Expr::Yield(_) | Expr::YieldFrom(_) => ExprPrecedence::Yield,
 
             // Not a real python expression, so treat as lowest as well
-            Expr::IpyEscapeCommand(_) => ExprPrecedence::Min,
+            Expr::IpyEscapeCommand(_) => ExprPrecedence::None,
         }
     }
 }

--- a/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLC2801_unnecessary_dunder_call.py.snap
+++ b/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLC2801_unnecessary_dunder_call.py.snap
@@ -750,370 +750,455 @@ unnecessary_dunder_call.py:49:7: PLC2801 Unnecessary dunder call to `__call__`
 49 | print(a.__call__())  # PLC2801 (no fix, intentional)
    |       ^^^^^^^^^^^^ PLC2801
 50 |
-51 | # Lambda expressions
+51 | class Foo:
    |
 
-unnecessary_dunder_call.py:52:16: PLC2801 [*] Unnecessary dunder call to `__add__`. Use `+` operator.
+unnecessary_dunder_call.py:63:1: PLC2801 [*] Unnecessary dunder call to `__add__`. Use `+` operator.
    |
-51 | # Lambda expressions
-52 | blah = lambda: a.__add__(1)  # PLC2801
+62 | foo = Foo(1)
+63 | foo.__add__(2).get_v()  # PLC2801
+   | ^^^^^^^^^^^^^^ PLC2801
+   |
+   = help: Use `+` operator
+
+ℹ Unsafe fix
+60 60 |         return self.v
+61 61 | 
+62 62 | foo = Foo(1)
+63    |-foo.__add__(2).get_v()  # PLC2801
+   63 |+(foo + 2).get_v()  # PLC2801
+64 64 | 
+65 65 | 
+66 66 | # Lambda expressions
+
+unnecessary_dunder_call.py:67:16: PLC2801 [*] Unnecessary dunder call to `__add__`. Use `+` operator.
+   |
+66 | # Lambda expressions
+67 | blah = lambda: a.__add__(1)  # PLC2801
    |                ^^^^^^^^^^^^ PLC2801
-53 |
-54 | # If expressions
+68 |
+69 | # If expressions
    |
    = help: Use `+` operator
 
 ℹ Unsafe fix
-49 49 | print(a.__call__())  # PLC2801 (no fix, intentional)
-50 50 | 
-51 51 | # Lambda expressions
-52    |-blah = lambda: a.__add__(1)  # PLC2801
-   52 |+blah = lambda: a + 1  # PLC2801
-53 53 | 
-54 54 | # If expressions
-55 55 | print(a.__add__(1) if a > 0 else a.__sub__(1))  # PLC2801
+64 64 | 
+65 65 | 
+66 66 | # Lambda expressions
+67    |-blah = lambda: a.__add__(1)  # PLC2801
+   67 |+blah = lambda: a + 1  # PLC2801
+68 68 | 
+69 69 | # If expressions
+70 70 | print(a.__add__(1) if a > 0 else a.__sub__(1))  # PLC2801
 
-unnecessary_dunder_call.py:55:7: PLC2801 [*] Unnecessary dunder call to `__add__`. Use `+` operator.
+unnecessary_dunder_call.py:70:7: PLC2801 [*] Unnecessary dunder call to `__add__`. Use `+` operator.
    |
-54 | # If expressions
-55 | print(a.__add__(1) if a > 0 else a.__sub__(1))  # PLC2801
+69 | # If expressions
+70 | print(a.__add__(1) if a > 0 else a.__sub__(1))  # PLC2801
    |       ^^^^^^^^^^^^ PLC2801
-56 |
-57 | # Dict/Set/List/Tuple
+71 |
+72 | # Dict/Set/List/Tuple
    |
    = help: Use `+` operator
 
 ℹ Unsafe fix
-52 52 | blah = lambda: a.__add__(1)  # PLC2801
-53 53 | 
-54 54 | # If expressions
-55    |-print(a.__add__(1) if a > 0 else a.__sub__(1))  # PLC2801
-   55 |+print(a + 1 if a > 0 else a.__sub__(1))  # PLC2801
-56 56 | 
-57 57 | # Dict/Set/List/Tuple
-58 58 | print({"a": a.__add__(1)})  # PLC2801
+67 67 | blah = lambda: a.__add__(1)  # PLC2801
+68 68 | 
+69 69 | # If expressions
+70    |-print(a.__add__(1) if a > 0 else a.__sub__(1))  # PLC2801
+   70 |+print(a + 1 if a > 0 else a.__sub__(1))  # PLC2801
+71 71 | 
+72 72 | # Dict/Set/List/Tuple
+73 73 | print({"a": a.__add__(1)})  # PLC2801
 
-unnecessary_dunder_call.py:55:34: PLC2801 [*] Unnecessary dunder call to `__sub__`. Use `-` operator.
+unnecessary_dunder_call.py:70:34: PLC2801 [*] Unnecessary dunder call to `__sub__`. Use `-` operator.
    |
-54 | # If expressions
-55 | print(a.__add__(1) if a > 0 else a.__sub__(1))  # PLC2801
+69 | # If expressions
+70 | print(a.__add__(1) if a > 0 else a.__sub__(1))  # PLC2801
    |                                  ^^^^^^^^^^^^ PLC2801
-56 |
-57 | # Dict/Set/List/Tuple
+71 |
+72 | # Dict/Set/List/Tuple
    |
    = help: Use `-` operator
 
 ℹ Unsafe fix
-52 52 | blah = lambda: a.__add__(1)  # PLC2801
-53 53 | 
-54 54 | # If expressions
-55    |-print(a.__add__(1) if a > 0 else a.__sub__(1))  # PLC2801
-   55 |+print(a.__add__(1) if a > 0 else a - 1)  # PLC2801
-56 56 | 
-57 57 | # Dict/Set/List/Tuple
-58 58 | print({"a": a.__add__(1)})  # PLC2801
+67 67 | blah = lambda: a.__add__(1)  # PLC2801
+68 68 | 
+69 69 | # If expressions
+70    |-print(a.__add__(1) if a > 0 else a.__sub__(1))  # PLC2801
+   70 |+print(a.__add__(1) if a > 0 else a - 1)  # PLC2801
+71 71 | 
+72 72 | # Dict/Set/List/Tuple
+73 73 | print({"a": a.__add__(1)})  # PLC2801
 
-unnecessary_dunder_call.py:58:13: PLC2801 [*] Unnecessary dunder call to `__add__`. Use `+` operator.
+unnecessary_dunder_call.py:73:13: PLC2801 [*] Unnecessary dunder call to `__add__`. Use `+` operator.
    |
-57 | # Dict/Set/List/Tuple
-58 | print({"a": a.__add__(1)})  # PLC2801
+72 | # Dict/Set/List/Tuple
+73 | print({"a": a.__add__(1)})  # PLC2801
    |             ^^^^^^^^^^^^ PLC2801
-59 | print({a.__add__(1)})  # PLC2801
-60 | print([a.__add__(1)])  # PLC2801
+74 | print({a.__add__(1)})  # PLC2801
+75 | print([a.__add__(1)])  # PLC2801
    |
    = help: Use `+` operator
 
 ℹ Unsafe fix
-55 55 | print(a.__add__(1) if a > 0 else a.__sub__(1))  # PLC2801
-56 56 | 
-57 57 | # Dict/Set/List/Tuple
-58    |-print({"a": a.__add__(1)})  # PLC2801
-   58 |+print({"a": a + 1})  # PLC2801
-59 59 | print({a.__add__(1)})  # PLC2801
-60 60 | print([a.__add__(1)])  # PLC2801
-61 61 | print((a.__add__(1),))  # PLC2801
+70 70 | print(a.__add__(1) if a > 0 else a.__sub__(1))  # PLC2801
+71 71 | 
+72 72 | # Dict/Set/List/Tuple
+73    |-print({"a": a.__add__(1)})  # PLC2801
+   73 |+print({"a": (a + 1)})  # PLC2801
+74 74 | print({a.__add__(1)})  # PLC2801
+75 75 | print([a.__add__(1)])  # PLC2801
+76 76 | print((a.__add__(1),))  # PLC2801
 
-unnecessary_dunder_call.py:59:8: PLC2801 [*] Unnecessary dunder call to `__add__`. Use `+` operator.
+unnecessary_dunder_call.py:74:8: PLC2801 [*] Unnecessary dunder call to `__add__`. Use `+` operator.
    |
-57 | # Dict/Set/List/Tuple
-58 | print({"a": a.__add__(1)})  # PLC2801
-59 | print({a.__add__(1)})  # PLC2801
+72 | # Dict/Set/List/Tuple
+73 | print({"a": a.__add__(1)})  # PLC2801
+74 | print({a.__add__(1)})  # PLC2801
    |        ^^^^^^^^^^^^ PLC2801
-60 | print([a.__add__(1)])  # PLC2801
-61 | print((a.__add__(1),))  # PLC2801
+75 | print([a.__add__(1)])  # PLC2801
+76 | print((a.__add__(1),))  # PLC2801
    |
    = help: Use `+` operator
 
 ℹ Unsafe fix
-56 56 | 
-57 57 | # Dict/Set/List/Tuple
-58 58 | print({"a": a.__add__(1)})  # PLC2801
-59    |-print({a.__add__(1)})  # PLC2801
-   59 |+print({a + 1})  # PLC2801
-60 60 | print([a.__add__(1)])  # PLC2801
-61 61 | print((a.__add__(1),))  # PLC2801
-62 62 | 
+71 71 | 
+72 72 | # Dict/Set/List/Tuple
+73 73 | print({"a": a.__add__(1)})  # PLC2801
+74    |-print({a.__add__(1)})  # PLC2801
+   74 |+print({(a + 1)})  # PLC2801
+75 75 | print([a.__add__(1)])  # PLC2801
+76 76 | print((a.__add__(1),))  # PLC2801
+77 77 | 
 
-unnecessary_dunder_call.py:60:8: PLC2801 [*] Unnecessary dunder call to `__add__`. Use `+` operator.
+unnecessary_dunder_call.py:75:8: PLC2801 [*] Unnecessary dunder call to `__add__`. Use `+` operator.
    |
-58 | print({"a": a.__add__(1)})  # PLC2801
-59 | print({a.__add__(1)})  # PLC2801
-60 | print([a.__add__(1)])  # PLC2801
+73 | print({"a": a.__add__(1)})  # PLC2801
+74 | print({a.__add__(1)})  # PLC2801
+75 | print([a.__add__(1)])  # PLC2801
    |        ^^^^^^^^^^^^ PLC2801
-61 | print((a.__add__(1),))  # PLC2801
+76 | print((a.__add__(1),))  # PLC2801
    |
    = help: Use `+` operator
 
 ℹ Unsafe fix
-57 57 | # Dict/Set/List/Tuple
-58 58 | print({"a": a.__add__(1)})  # PLC2801
-59 59 | print({a.__add__(1)})  # PLC2801
-60    |-print([a.__add__(1)])  # PLC2801
-   60 |+print([a + 1])  # PLC2801
-61 61 | print((a.__add__(1),))  # PLC2801
-62 62 | 
-63 63 | # Comprehension variants
+72 72 | # Dict/Set/List/Tuple
+73 73 | print({"a": a.__add__(1)})  # PLC2801
+74 74 | print({a.__add__(1)})  # PLC2801
+75    |-print([a.__add__(1)])  # PLC2801
+   75 |+print([(a + 1)])  # PLC2801
+76 76 | print((a.__add__(1),))  # PLC2801
+77 77 | 
+78 78 | # Comprehension variants
 
-unnecessary_dunder_call.py:61:8: PLC2801 [*] Unnecessary dunder call to `__add__`. Use `+` operator.
+unnecessary_dunder_call.py:76:8: PLC2801 [*] Unnecessary dunder call to `__add__`. Use `+` operator.
    |
-59 | print({a.__add__(1)})  # PLC2801
-60 | print([a.__add__(1)])  # PLC2801
-61 | print((a.__add__(1),))  # PLC2801
+74 | print({a.__add__(1)})  # PLC2801
+75 | print([a.__add__(1)])  # PLC2801
+76 | print((a.__add__(1),))  # PLC2801
    |        ^^^^^^^^^^^^ PLC2801
-62 |
-63 | # Comprehension variants
+77 |
+78 | # Comprehension variants
    |
    = help: Use `+` operator
 
 ℹ Unsafe fix
-58 58 | print({"a": a.__add__(1)})  # PLC2801
-59 59 | print({a.__add__(1)})  # PLC2801
-60 60 | print([a.__add__(1)])  # PLC2801
-61    |-print((a.__add__(1),))  # PLC2801
-   61 |+print((a + 1,))  # PLC2801
-62 62 | 
-63 63 | # Comprehension variants
-64 64 | print({i: i.__add__(1) for i in range(5)})  # PLC2801
+73 73 | print({"a": a.__add__(1)})  # PLC2801
+74 74 | print({a.__add__(1)})  # PLC2801
+75 75 | print([a.__add__(1)])  # PLC2801
+76    |-print((a.__add__(1),))  # PLC2801
+   76 |+print(((a + 1),))  # PLC2801
+77 77 | 
+78 78 | # Comprehension variants
+79 79 | print({i: i.__add__(1) for i in range(5)})  # PLC2801
 
-unnecessary_dunder_call.py:64:11: PLC2801 [*] Unnecessary dunder call to `__add__`. Use `+` operator.
+unnecessary_dunder_call.py:79:11: PLC2801 [*] Unnecessary dunder call to `__add__`. Use `+` operator.
    |
-63 | # Comprehension variants
-64 | print({i: i.__add__(1) for i in range(5)})  # PLC2801
+78 | # Comprehension variants
+79 | print({i: i.__add__(1) for i in range(5)})  # PLC2801
    |           ^^^^^^^^^^^^ PLC2801
-65 | print({i.__add__(1) for i in range(5)})  # PLC2801
-66 | print([i.__add__(1) for i in range(5)])  # PLC2801
+80 | print({i.__add__(1) for i in range(5)})  # PLC2801
+81 | print([i.__add__(1) for i in range(5)])  # PLC2801
    |
    = help: Use `+` operator
 
 ℹ Unsafe fix
-61 61 | print((a.__add__(1),))  # PLC2801
-62 62 | 
-63 63 | # Comprehension variants
-64    |-print({i: i.__add__(1) for i in range(5)})  # PLC2801
-   64 |+print({i: i + 1 for i in range(5)})  # PLC2801
-65 65 | print({i.__add__(1) for i in range(5)})  # PLC2801
-66 66 | print([i.__add__(1) for i in range(5)])  # PLC2801
-67 67 | print((i.__add__(1) for i in range(5)))  # PLC2801
-
-unnecessary_dunder_call.py:65:8: PLC2801 [*] Unnecessary dunder call to `__add__`. Use `+` operator.
-   |
-63 | # Comprehension variants
-64 | print({i: i.__add__(1) for i in range(5)})  # PLC2801
-65 | print({i.__add__(1) for i in range(5)})  # PLC2801
-   |        ^^^^^^^^^^^^ PLC2801
-66 | print([i.__add__(1) for i in range(5)])  # PLC2801
-67 | print((i.__add__(1) for i in range(5)))  # PLC2801
-   |
-   = help: Use `+` operator
-
-ℹ Unsafe fix
-62 62 | 
-63 63 | # Comprehension variants
-64 64 | print({i: i.__add__(1) for i in range(5)})  # PLC2801
-65    |-print({i.__add__(1) for i in range(5)})  # PLC2801
-   65 |+print({i + 1 for i in range(5)})  # PLC2801
-66 66 | print([i.__add__(1) for i in range(5)])  # PLC2801
-67 67 | print((i.__add__(1) for i in range(5)))  # PLC2801
-68 68 | 
-
-unnecessary_dunder_call.py:66:8: PLC2801 [*] Unnecessary dunder call to `__add__`. Use `+` operator.
-   |
-64 | print({i: i.__add__(1) for i in range(5)})  # PLC2801
-65 | print({i.__add__(1) for i in range(5)})  # PLC2801
-66 | print([i.__add__(1) for i in range(5)])  # PLC2801
-   |        ^^^^^^^^^^^^ PLC2801
-67 | print((i.__add__(1) for i in range(5)))  # PLC2801
-   |
-   = help: Use `+` operator
-
-ℹ Unsafe fix
-63 63 | # Comprehension variants
-64 64 | print({i: i.__add__(1) for i in range(5)})  # PLC2801
-65 65 | print({i.__add__(1) for i in range(5)})  # PLC2801
-66    |-print([i.__add__(1) for i in range(5)])  # PLC2801
-   66 |+print([i + 1 for i in range(5)])  # PLC2801
-67 67 | print((i.__add__(1) for i in range(5)))  # PLC2801
-68 68 | 
-69 69 | # Generators
-
-unnecessary_dunder_call.py:67:8: PLC2801 [*] Unnecessary dunder call to `__add__`. Use `+` operator.
-   |
-65 | print({i.__add__(1) for i in range(5)})  # PLC2801
-66 | print([i.__add__(1) for i in range(5)])  # PLC2801
-67 | print((i.__add__(1) for i in range(5)))  # PLC2801
-   |        ^^^^^^^^^^^^ PLC2801
-68 |
-69 | # Generators
-   |
-   = help: Use `+` operator
-
-ℹ Unsafe fix
-64 64 | print({i: i.__add__(1) for i in range(5)})  # PLC2801
-65 65 | print({i.__add__(1) for i in range(5)})  # PLC2801
-66 66 | print([i.__add__(1) for i in range(5)])  # PLC2801
-67    |-print((i.__add__(1) for i in range(5)))  # PLC2801
-   67 |+print((i + 1 for i in range(5)))  # PLC2801
-68 68 | 
-69 69 | # Generators
-70 70 | gen = (i.__add__(1) for i in range(5))  # PLC2801
-
-unnecessary_dunder_call.py:70:8: PLC2801 [*] Unnecessary dunder call to `__add__`. Use `+` operator.
-   |
-69 | # Generators
-70 | gen = (i.__add__(1) for i in range(5))  # PLC2801
-   |        ^^^^^^^^^^^^ PLC2801
-71 | print(next(gen))
-   |
-   = help: Use `+` operator
-
-ℹ Unsafe fix
-67 67 | print((i.__add__(1) for i in range(5)))  # PLC2801
-68 68 | 
-69 69 | # Generators
-70    |-gen = (i.__add__(1) for i in range(5))  # PLC2801
-   70 |+gen = (i + 1 for i in range(5))  # PLC2801
-71 71 | print(next(gen))
-72 72 | 
-73 73 | # Subscripts
-
-unnecessary_dunder_call.py:74:13: PLC2801 [*] Unnecessary dunder call to `__add__`. Use `+` operator.
-   |
-73 | # Subscripts
-74 | print({"a": a.__add__(1)}["a"])  # PLC2801
-   |             ^^^^^^^^^^^^ PLC2801
-75 |
-76 | # Starred
-   |
-   = help: Use `+` operator
-
-ℹ Unsafe fix
-71 71 | print(next(gen))
-72 72 | 
-73 73 | # Subscripts
-74    |-print({"a": a.__add__(1)}["a"])  # PLC2801
-   74 |+print({"a": a + 1}["a"])  # PLC2801
-75 75 | 
-76 76 | # Starred
-77 77 | print(*[a.__add__(1)])  # PLC2801
-
-unnecessary_dunder_call.py:77:9: PLC2801 [*] Unnecessary dunder call to `__add__`. Use `+` operator.
-   |
-76 | # Starred
-77 | print(*[a.__add__(1)])  # PLC2801
-   |         ^^^^^^^^^^^^ PLC2801
-78 |
-79 | # Slices
-   |
-   = help: Use `+` operator
-
-ℹ Unsafe fix
-74 74 | print({"a": a.__add__(1)}["a"])  # PLC2801
-75 75 | 
-76 76 | # Starred
-77    |-print(*[a.__add__(1)])  # PLC2801
-   77 |+print(*[a + 1])  # PLC2801
-78 78 | 
-79 79 | # Slices
-80 80 | print([a.__add__(1), a.__sub__(1)][0:1])  # PLC2801
+76 76 | print((a.__add__(1),))  # PLC2801
+77 77 | 
+78 78 | # Comprehension variants
+79    |-print({i: i.__add__(1) for i in range(5)})  # PLC2801
+   79 |+print({i: (i + 1) for i in range(5)})  # PLC2801
+80 80 | print({i.__add__(1) for i in range(5)})  # PLC2801
+81 81 | print([i.__add__(1) for i in range(5)])  # PLC2801
+82 82 | print((i.__add__(1) for i in range(5)))  # PLC2801
 
 unnecessary_dunder_call.py:80:8: PLC2801 [*] Unnecessary dunder call to `__add__`. Use `+` operator.
    |
-79 | # Slices
-80 | print([a.__add__(1), a.__sub__(1)][0:1])  # PLC2801
+78 | # Comprehension variants
+79 | print({i: i.__add__(1) for i in range(5)})  # PLC2801
+80 | print({i.__add__(1) for i in range(5)})  # PLC2801
    |        ^^^^^^^^^^^^ PLC2801
+81 | print([i.__add__(1) for i in range(5)])  # PLC2801
+82 | print((i.__add__(1) for i in range(5)))  # PLC2801
    |
    = help: Use `+` operator
 
 ℹ Unsafe fix
-77 77 | print(*[a.__add__(1)])  # PLC2801
-78 78 | 
-79 79 | # Slices
-80    |-print([a.__add__(1), a.__sub__(1)][0:1])  # PLC2801
-   80 |+print([a + 1, a.__sub__(1)][0:1])  # PLC2801
-81 81 | 
-82 82 | 
-83 83 | class Thing:
+77 77 | 
+78 78 | # Comprehension variants
+79 79 | print({i: i.__add__(1) for i in range(5)})  # PLC2801
+80    |-print({i.__add__(1) for i in range(5)})  # PLC2801
+   80 |+print({(i + 1) for i in range(5)})  # PLC2801
+81 81 | print([i.__add__(1) for i in range(5)])  # PLC2801
+82 82 | print((i.__add__(1) for i in range(5)))  # PLC2801
+83 83 | 
 
-unnecessary_dunder_call.py:80:22: PLC2801 [*] Unnecessary dunder call to `__sub__`. Use `-` operator.
+unnecessary_dunder_call.py:81:8: PLC2801 [*] Unnecessary dunder call to `__add__`. Use `+` operator.
    |
-79 | # Slices
-80 | print([a.__add__(1), a.__sub__(1)][0:1])  # PLC2801
-   |                      ^^^^^^^^^^^^ PLC2801
+79 | print({i: i.__add__(1) for i in range(5)})  # PLC2801
+80 | print({i.__add__(1) for i in range(5)})  # PLC2801
+81 | print([i.__add__(1) for i in range(5)])  # PLC2801
+   |        ^^^^^^^^^^^^ PLC2801
+82 | print((i.__add__(1) for i in range(5)))  # PLC2801
    |
-   = help: Use `-` operator
+   = help: Use `+` operator
 
 ℹ Unsafe fix
-77 77 | print(*[a.__add__(1)])  # PLC2801
-78 78 | 
-79 79 | # Slices
-80    |-print([a.__add__(1), a.__sub__(1)][0:1])  # PLC2801
-   80 |+print([a.__add__(1), a - 1][0:1])  # PLC2801
-81 81 | 
-82 82 | 
-83 83 | class Thing:
+78 78 | # Comprehension variants
+79 79 | print({i: i.__add__(1) for i in range(5)})  # PLC2801
+80 80 | print({i.__add__(1) for i in range(5)})  # PLC2801
+81    |-print([i.__add__(1) for i in range(5)])  # PLC2801
+   81 |+print([(i + 1) for i in range(5)])  # PLC2801
+82 82 | print((i.__add__(1) for i in range(5)))  # PLC2801
+83 83 | 
+84 84 | # Generators
 
-unnecessary_dunder_call.py:92:16: PLC2801 Unnecessary dunder call to `__getattribute__`. Access attribute directly or use getattr built-in function.
+unnecessary_dunder_call.py:82:8: PLC2801 [*] Unnecessary dunder call to `__add__`. Use `+` operator.
    |
-91 |     def do_thing(self, item):
-92 |         return object.__getattribute__(self, item)  # PLC2801
-   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PLC2801
-93 |
-94 |     def use_descriptor(self, item):
+80 | print({i.__add__(1) for i in range(5)})  # PLC2801
+81 | print([i.__add__(1) for i in range(5)])  # PLC2801
+82 | print((i.__add__(1) for i in range(5)))  # PLC2801
+   |        ^^^^^^^^^^^^ PLC2801
+83 |
+84 | # Generators
    |
-   = help: Access attribute directly or use getattr built-in function
+   = help: Use `+` operator
 
-unnecessary_dunder_call.py:104:1: PLC2801 [*] Unnecessary dunder call to `__contains__`. Use `in` operator.
+ℹ Unsafe fix
+79 79 | print({i: i.__add__(1) for i in range(5)})  # PLC2801
+80 80 | print({i.__add__(1) for i in range(5)})  # PLC2801
+81 81 | print([i.__add__(1) for i in range(5)])  # PLC2801
+82    |-print((i.__add__(1) for i in range(5)))  # PLC2801
+   82 |+print(((i + 1) for i in range(5)))  # PLC2801
+83 83 | 
+84 84 | # Generators
+85 85 | gen = (i.__add__(1) for i in range(5))  # PLC2801
+
+unnecessary_dunder_call.py:85:8: PLC2801 [*] Unnecessary dunder call to `__add__`. Use `+` operator.
+   |
+84 | # Generators
+85 | gen = (i.__add__(1) for i in range(5))  # PLC2801
+   |        ^^^^^^^^^^^^ PLC2801
+86 | print(next(gen))
+   |
+   = help: Use `+` operator
+
+ℹ Unsafe fix
+82 82 | print((i.__add__(1) for i in range(5)))  # PLC2801
+83 83 | 
+84 84 | # Generators
+85    |-gen = (i.__add__(1) for i in range(5))  # PLC2801
+   85 |+gen = ((i + 1) for i in range(5))  # PLC2801
+86 86 | print(next(gen))
+87 87 | 
+88 88 | # Subscripts
+
+unnecessary_dunder_call.py:89:13: PLC2801 [*] Unnecessary dunder call to `__add__`. Use `+` operator.
+   |
+88 | # Subscripts
+89 | print({"a": a.__add__(1)}["a"])  # PLC2801
+   |             ^^^^^^^^^^^^ PLC2801
+90 | # https://github.com/astral-sh/ruff/issues/15745
+91 | print("x".__add__("y")[0])  # PLC2801
+   |
+   = help: Use `+` operator
+
+ℹ Unsafe fix
+86 86 | print(next(gen))
+87 87 | 
+88 88 | # Subscripts
+89    |-print({"a": a.__add__(1)}["a"])  # PLC2801
+   89 |+print({"a": (a + 1)}["a"])  # PLC2801
+90 90 | # https://github.com/astral-sh/ruff/issues/15745
+91 91 | print("x".__add__("y")[0])  # PLC2801
+92 92 | 
+
+unnecessary_dunder_call.py:91:7: PLC2801 [*] Unnecessary dunder call to `__add__`. Use `+` operator.
+   |
+89 | print({"a": a.__add__(1)}["a"])  # PLC2801
+90 | # https://github.com/astral-sh/ruff/issues/15745
+91 | print("x".__add__("y")[0])  # PLC2801
+   |       ^^^^^^^^^^^^^^^^ PLC2801
+92 |
+93 | # Starred
+   |
+   = help: Use `+` operator
+
+ℹ Unsafe fix
+88 88 | # Subscripts
+89 89 | print({"a": a.__add__(1)}["a"])  # PLC2801
+90 90 | # https://github.com/astral-sh/ruff/issues/15745
+91    |-print("x".__add__("y")[0])  # PLC2801
+   91 |+print(("x" + "y")[0])  # PLC2801
+92 92 | 
+93 93 | # Starred
+94 94 | print(*[a.__add__(1)])  # PLC2801
+
+unnecessary_dunder_call.py:94:9: PLC2801 [*] Unnecessary dunder call to `__add__`. Use `+` operator.
+   |
+93 | # Starred
+94 | print(*[a.__add__(1)])  # PLC2801
+   |         ^^^^^^^^^^^^ PLC2801
+95 |
+96 | list1 = [1, 2, 3]
+   |
+   = help: Use `+` operator
+
+ℹ Unsafe fix
+91 91 | print("x".__add__("y")[0])  # PLC2801
+92 92 | 
+93 93 | # Starred
+94    |-print(*[a.__add__(1)])  # PLC2801
+   94 |+print(*[(a + 1)])  # PLC2801
+95 95 | 
+96 96 | list1 = [1, 2, 3]
+97 97 | list2 = [4, 5, 6]
+
+unnecessary_dunder_call.py:98:9: PLC2801 [*] Unnecessary dunder call to `__add__`. Use `+` operator.
     |
-102 | blah = dict[{"a": 1}.__delitem__("a")]  # OK
-103 |
-104 | "abc".__contains__("a")
+ 96 | list1 = [1, 2, 3]
+ 97 | list2 = [4, 5, 6]
+ 98 | print([*list1.__add__(list2)])  # PLC2801
+    |         ^^^^^^^^^^^^^^^^^^^^ PLC2801
+ 99 |
+100 | # Slices
+    |
+    = help: Use `+` operator
+
+ℹ Unsafe fix
+95 95 | 
+96 96 | list1 = [1, 2, 3]
+97 97 | list2 = [4, 5, 6]
+98    |-print([*list1.__add__(list2)])  # PLC2801
+   98 |+print([*list1 + list2])  # PLC2801
+99 99 | 
+100 100 | # Slices
+101 101 | print([a.__add__(1), a.__sub__(1)][0:1])  # PLC2801
+
+unnecessary_dunder_call.py:101:8: PLC2801 [*] Unnecessary dunder call to `__add__`. Use `+` operator.
+    |
+100 | # Slices
+101 | print([a.__add__(1), a.__sub__(1)][0:1])  # PLC2801
+    |        ^^^^^^^^^^^^ PLC2801
+102 |
+103 | # Attribute access
+    |
+    = help: Use `+` operator
+
+ℹ Unsafe fix
+98  98  | print([*list1.__add__(list2)])  # PLC2801
+99  99  | 
+100 100 | # Slices
+101     |-print([a.__add__(1), a.__sub__(1)][0:1])  # PLC2801
+    101 |+print([(a + 1), a.__sub__(1)][0:1])  # PLC2801
+102 102 | 
+103 103 | # Attribute access
+104 104 | # https://github.com/astral-sh/ruff/issues/15745
+
+unnecessary_dunder_call.py:101:22: PLC2801 [*] Unnecessary dunder call to `__sub__`. Use `-` operator.
+    |
+100 | # Slices
+101 | print([a.__add__(1), a.__sub__(1)][0:1])  # PLC2801
+    |                      ^^^^^^^^^^^^ PLC2801
+102 |
+103 | # Attribute access
+    |
+    = help: Use `-` operator
+
+ℹ Unsafe fix
+98  98  | print([*list1.__add__(list2)])  # PLC2801
+99  99  | 
+100 100 | # Slices
+101     |-print([a.__add__(1), a.__sub__(1)][0:1])  # PLC2801
+    101 |+print([a.__add__(1), (a - 1)][0:1])  # PLC2801
+102 102 | 
+103 103 | # Attribute access
+104 104 | # https://github.com/astral-sh/ruff/issues/15745
+
+unnecessary_dunder_call.py:105:7: PLC2801 [*] Unnecessary dunder call to `__add__`. Use `+` operator.
+    |
+103 | # Attribute access
+104 | # https://github.com/astral-sh/ruff/issues/15745
+105 | print(1j.__add__(1.0).real) # PLC2801
+    |       ^^^^^^^^^^^^^^^ PLC2801
+106 |
+107 | class Thing:
+    |
+    = help: Use `+` operator
+
+ℹ Unsafe fix
+102 102 | 
+103 103 | # Attribute access
+104 104 | # https://github.com/astral-sh/ruff/issues/15745
+105     |-print(1j.__add__(1.0).real) # PLC2801
+    105 |+print((1j + 1.0).real) # PLC2801
+106 106 | 
+107 107 | class Thing:
+108 108 |     def __init__(self, stuff: Any) -> None:
+
+unnecessary_dunder_call.py:116:16: PLC2801 Unnecessary dunder call to `__getattribute__`. Access attribute directly or use getattr built-in function.
+    |
+115 |     def do_thing(self, item):
+116 |         return object.__getattribute__(self, item)  # PLC2801
+    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PLC2801
+117 |
+118 |     def use_descriptor(self, item):
+    |
+    = help: Access attribute directly or use getattr built-in function
+
+unnecessary_dunder_call.py:128:1: PLC2801 [*] Unnecessary dunder call to `__contains__`. Use `in` operator.
+    |
+126 | blah = dict[{"a": 1}.__delitem__("a")]  # OK
+127 |
+128 | "abc".__contains__("a")
     | ^^^^^^^^^^^^^^^^^^^^^^^ PLC2801
-105 |
-106 | # https://github.com/astral-sh/ruff/issues/14597
+129 |
+130 | # https://github.com/astral-sh/ruff/issues/14597
     |
     = help: Use `in` operator
 
 ℹ Unsafe fix
-101 101 | 
-102 102 | blah = dict[{"a": 1}.__delitem__("a")]  # OK
-103 103 | 
-104     |-"abc".__contains__("a")
-    104 |+"a" in "abc"
-105 105 | 
-106 106 | # https://github.com/astral-sh/ruff/issues/14597
-107 107 | assert "abc".__str__() == "abc"
+125 125 | 
+126 126 | blah = dict[{"a": 1}.__delitem__("a")]  # OK
+127 127 | 
+128     |-"abc".__contains__("a")
+    128 |+"a" in "abc"
+129 129 | 
+130 130 | # https://github.com/astral-sh/ruff/issues/14597
+131 131 | assert "abc".__str__() == "abc"
 
-unnecessary_dunder_call.py:107:8: PLC2801 [*] Unnecessary dunder call to `__str__`. Use `str()` builtin.
+unnecessary_dunder_call.py:131:8: PLC2801 [*] Unnecessary dunder call to `__str__`. Use `str()` builtin.
     |
-106 | # https://github.com/astral-sh/ruff/issues/14597
-107 | assert "abc".__str__() == "abc"
+130 | # https://github.com/astral-sh/ruff/issues/14597
+131 | assert "abc".__str__() == "abc"
     |        ^^^^^^^^^^^^^^^ PLC2801
     |
     = help: Use `str()` builtin
 
 ℹ Unsafe fix
-104 104 | "abc".__contains__("a")
-105 105 | 
-106 106 | # https://github.com/astral-sh/ruff/issues/14597
-107     |-assert "abc".__str__() == "abc"
-    107 |+assert str("abc") == "abc"
+128 128 | "abc".__contains__("a")
+129 129 | 
+130 130 | # https://github.com/astral-sh/ruff/issues/14597
+131     |-assert "abc".__str__() == "abc"
+    131 |+assert str("abc") == "abc"


### PR DESCRIPTION
## Summary

This fixes #15745

Also, I haven't found a trait/helper to get expression precedence. Even though at least 3 rules check precedence when generating fixes. Generally speaking, unless/until fixes are done via AST generation - many (all?) fixes involving expression rewrites would need to consult precedence to handle parens. Unless I am mistaken.

Thus, I've implemented an enum and a trait. But I didn't dare doing that in semantic/AST crates, although I believe it would be helpful to move them there.

@AlexWaygood @dylwil3 you'll know the codebase better, let me know if you think it should be elevated to some core base crate. If you do, I am happy to implement this, but will need your guidance on where you'd like it to reside.

## Test Plan

* Updated test case with 2 examples from the issue + a couple of mine, including one that would generate invalid python program before this fix
* cargo nextest run (check updated snapshot)
