### PR TITLE
[`flake8-bugbear`] Exempt `NewType` calls where the original type is immutable (`B008`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_bugbear/B008_extended.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_bugbear/B008_extended.py
@@ -35,3 +35,14 @@ def okay(obj=Class()):
 
 def error(obj=OtherClass()):
     ...
+
+
+# https://github.com/astral-sh/ruff/issues/12717
+
+from typing import NewType
+
+N = NewType("N", int)
+L = NewType("L", list[str])
+
+def okay(obj = N()): ...
+def error(obj = L()): ...

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/function_call_in_argument_default.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/function_call_in_argument_default.rs
@@ -13,6 +13,7 @@ use ruff_python_semantic::analyze::typing::{
 use ruff_python_semantic::SemanticModel;
 
 use crate::checkers::ast::Checker;
+use crate::rules::ruff::rules::is_immutable_newtype_call;
 
 /// ## What it does
 /// Checks for function calls in default function arguments.
@@ -105,6 +106,7 @@ impl Visitor<'_> for ArgumentDefaultVisitor<'_, '_> {
             Expr::Call(ast::ExprCall { func, .. }) => {
                 if !is_mutable_func(func, self.semantic)
                     && !is_immutable_func(func, self.semantic, self.extend_immutable_calls)
+                    && !is_immutable_newtype_call(func, self.semantic, &self.extend_immutable_calls)
                 {
                     self.diagnostics.push((
                         FunctionCallInDefaultArgument {

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/function_call_in_argument_default.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/function_call_in_argument_default.rs
@@ -105,7 +105,9 @@ impl Visitor<'_> for ArgumentDefaultVisitor<'_, '_> {
             Expr::Call(ast::ExprCall { func, .. }) => {
                 if !is_mutable_func(func, self.semantic)
                     && !is_immutable_func(func, self.semantic, self.extend_immutable_calls)
-                    && !is_immutable_newtype_call(func, self.semantic, self.extend_immutable_calls)
+                    && !func.as_name_expr().is_some_and(|name| {
+                        is_immutable_newtype_call(name, self.semantic, self.extend_immutable_calls)
+                    })
                 {
                     self.diagnostics.push((
                         FunctionCallInDefaultArgument {

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/function_call_in_argument_default.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/function_call_in_argument_default.rs
@@ -106,7 +106,7 @@ impl Visitor<'_> for ArgumentDefaultVisitor<'_, '_> {
             Expr::Call(ast::ExprCall { func, .. }) => {
                 if !is_mutable_func(func, self.semantic)
                     && !is_immutable_func(func, self.semantic, self.extend_immutable_calls)
-                    && !is_immutable_newtype_call(func, self.semantic, &self.extend_immutable_calls)
+                    && !is_immutable_newtype_call(func, self.semantic, self.extend_immutable_calls)
                 {
                     self.diagnostics.push((
                         FunctionCallInDefaultArgument {

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/function_call_in_argument_default.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/function_call_in_argument_default.rs
@@ -8,12 +8,11 @@ use ruff_python_ast::name::{QualifiedName, UnqualifiedName};
 use ruff_python_ast::visitor;
 use ruff_python_ast::visitor::Visitor;
 use ruff_python_semantic::analyze::typing::{
-    is_immutable_annotation, is_immutable_func, is_mutable_func,
+    is_immutable_annotation, is_immutable_func, is_immutable_newtype_call, is_mutable_func,
 };
 use ruff_python_semantic::SemanticModel;
 
 use crate::checkers::ast::Checker;
-use crate::rules::ruff::rules::is_immutable_newtype_call;
 
 /// ## What it does
 /// Checks for function calls in default function arguments.
@@ -23,12 +22,12 @@ use crate::rules::ruff::rules::is_immutable_newtype_call;
 /// once, at definition time. The returned value will then be reused by all
 /// calls to the function, which can lead to unexpected behaviour.
 ///
-/// Calls can be marked as an exception to this rule with the
-/// [`lint.flake8-bugbear.extend-immutable-calls`] configuration option.
+/// Parameters with immutable type annotations will be ignored by this rule.
+/// Those whose default arguments are `NewType` calls where the original type
+/// is immutable are also ignored.
 ///
-/// Arguments with immutable type annotations will be ignored by this rule.
-/// Types outside of the standard library can be marked as immutable with the
-/// [`lint.flake8-bugbear.extend-immutable-calls`] configuration option as well.
+/// Calls and types outside of the standard library can be marked as an exception
+/// to this rule with the [`lint.flake8-bugbear.extend-immutable-calls`] configuration option.
 ///
 /// ## Example
 ///

--- a/crates/ruff_linter/src/rules/flake8_bugbear/snapshots/ruff_linter__rules__flake8_bugbear__tests__extend_immutable_calls_arg_default.snap
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/snapshots/ruff_linter__rules__flake8_bugbear__tests__extend_immutable_calls_arg_default.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_bugbear/mod.rs
-snapshot_kind: text
 ---
 B008_extended.py:24:51: B008 Do not perform function call `Depends` in argument defaults; instead, perform the call within the function, or read the default from a module-level singleton variable
    |
@@ -14,4 +13,11 @@ B008_extended.py:36:15: B008 Do not perform function call `OtherClass` in argume
 36 | def error(obj=OtherClass()):
    |               ^^^^^^^^^^^^ B008
 37 |     ...
+   |
+
+B008_extended.py:48:17: B008 Do not perform function call `L` in argument defaults; instead, perform the call within the function, or read the default from a module-level singleton variable
+   |
+47 | def okay(obj = N()): ...
+48 | def error(obj = L()): ...
+   |                 ^^^ B008
    |

--- a/crates/ruff_linter/src/rules/ruff/rules/function_call_in_dataclass_default.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/function_call_in_dataclass_default.rs
@@ -159,7 +159,7 @@ fn any_annotated(class_body: &[Stmt]) -> bool {
         .any(|stmt| matches!(stmt, Stmt::AnnAssign(..)))
 }
 
-fn is_immutable_newtype_call(
+pub(crate) fn is_immutable_newtype_call(
     func: &Expr,
     semantic: &SemanticModel,
     extend_immutable_calls: &[QualifiedName],

--- a/crates/ruff_linter/src/rules/ruff/rules/function_call_in_dataclass_default.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/function_call_in_dataclass_default.rs
@@ -140,7 +140,9 @@ pub(crate) fn function_call_in_dataclass_default(
             || is_class_var_annotation(annotation, checker.semantic())
             || is_immutable_func(func, checker.semantic(), &extend_immutable_calls)
             || is_descriptor_class(func, checker.semantic())
-            || is_immutable_newtype_call(func, checker.semantic(), &extend_immutable_calls)
+            || func.as_name_expr().is_some_and(|name| {
+                is_immutable_newtype_call(name, checker.semantic(), &extend_immutable_calls)
+            })
         {
             continue;
         }

--- a/crates/ruff_linter/src/rules/ruff/rules/function_call_in_dataclass_default.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/function_call_in_dataclass_default.rs
@@ -1,10 +1,9 @@
-use ruff_python_ast::{self as ast, Expr, ExprCall, Stmt, StmtAssign};
+use ruff_python_ast::{self as ast, Expr, Stmt};
 
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, ViolationMetadata};
 use ruff_python_ast::name::{QualifiedName, UnqualifiedName};
-use ruff_python_semantic::analyze::typing::{is_immutable_annotation, is_immutable_func};
-use ruff_python_semantic::SemanticModel;
+use ruff_python_semantic::analyze::typing::{is_immutable_func, is_immutable_newtype_call};
 use ruff_text_size::Ranged;
 
 use crate::checkers::ast::Checker;
@@ -24,6 +23,9 @@ use crate::rules::ruff::rules::helpers::{
 ///
 /// If a field needs to be initialized with a mutable object, use the
 /// `field(default_factory=...)` pattern.
+///
+/// Attributes whose default arguments are `NewType` calls
+/// where the original type is immutable are ignored.
 ///
 /// ## Examples
 /// ```python
@@ -157,47 +159,4 @@ fn any_annotated(class_body: &[Stmt]) -> bool {
     class_body
         .iter()
         .any(|stmt| matches!(stmt, Stmt::AnnAssign(..)))
-}
-
-pub(crate) fn is_immutable_newtype_call(
-    func: &Expr,
-    semantic: &SemanticModel,
-    extend_immutable_calls: &[QualifiedName],
-) -> bool {
-    let Expr::Name(name) = func else {
-        return false;
-    };
-
-    let Some(binding) = semantic.only_binding(name).map(|id| semantic.binding(id)) else {
-        return false;
-    };
-
-    if !binding.kind.is_assignment() {
-        return false;
-    }
-
-    let Some(Stmt::Assign(StmtAssign { value, .. })) = binding.statement(semantic) else {
-        return false;
-    };
-
-    let Expr::Call(ExprCall {
-        func, arguments, ..
-    }) = value.as_ref()
-    else {
-        return false;
-    };
-
-    if !semantic.match_typing_expr(func, "NewType") {
-        return false;
-    }
-
-    if arguments.len() != 2 {
-        return false;
-    }
-
-    let Some(original_type) = arguments.find_argument_value("tp", 1) else {
-        return false;
-    };
-
-    is_immutable_annotation(original_type, semantic, extend_immutable_calls)
 }

--- a/crates/ruff_python_semantic/src/analyze/typing.rs
+++ b/crates/ruff_python_semantic/src/analyze/typing.rs
@@ -303,15 +303,22 @@ pub fn is_immutable_func(
         })
 }
 
+/// Return `true` if `name` is bound to the `typing.NewType` call where the original type is
+/// immutable.
+///
+/// For example:
+/// ```python
+/// from typing import NewType
+///
+/// UserId = NewType("UserId", int)
+/// ```
+///
+/// Here, `name` would be `UserId`.
 pub fn is_immutable_newtype_call(
-    func: &Expr,
+    name: &ast::ExprName,
     semantic: &SemanticModel,
     extend_immutable_calls: &[QualifiedName],
 ) -> bool {
-    let Expr::Name(name) = func else {
-        return false;
-    };
-
     let Some(binding) = semantic.only_binding(name).map(|id| semantic.binding(id)) else {
         return false;
     };


### PR DESCRIPTION
## Summary

Resolves #12717.

This change incorporates the logic added in #15588.

## Test Plan

`cargo nextest run` and `cargo insta test`.
