### PR TITLE
[red-knot] Treat bare `ClassVar` annotation as `ClassVar[Unknown]`

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/attributes.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/attributes.md
@@ -175,7 +175,7 @@ class C:
 
 reveal_type(C.pure_class_variable1)  # revealed: str
 
-# TODO: Should be `Unknown | Literal[1]`.
+# Bare `ClassVar` is equivalent to `ClassVar[Unknown]`:
 reveal_type(C.pure_class_variable2)  # revealed: Unknown
 
 c_instance = C()
@@ -183,7 +183,6 @@ c_instance = C()
 # It is okay to access a pure class variable on an instance.
 reveal_type(c_instance.pure_class_variable1)  # revealed: str
 
-# TODO: Should be `Unknown | Literal[1]`.
 reveal_type(c_instance.pure_class_variable2)  # revealed: Unknown
 
 # error: [invalid-attribute-access] "Cannot assign to ClassVar `pure_class_variable1` from an instance of type `C`"

--- a/crates/red_knot_python_semantic/resources/mdtest/type_qualifiers/classvar.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/type_qualifiers/classvar.md
@@ -21,7 +21,6 @@ class C:
 reveal_type(C.a)  # revealed: int
 reveal_type(C.b)  # revealed: int
 reveal_type(C.c)  # revealed: int
-# TODO: should be Unknown | Literal[1]
 reveal_type(C.d)  # revealed: Unknown
 reveal_type(C.e)  # revealed: int
 


### PR DESCRIPTION
## Summary

See #15767: If we decide to go with the option: bare `ClassVar` should be allowed, and the public type of a `var: ClassVar = 1` annotation should be `Unknown`, then we can simply remove the corresponding TODOs.

