### PR TITLE
[minor] Simplify some `ExprStringLiteral` creation logic

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/split_static_string.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/split_static_string.rs
@@ -3,8 +3,8 @@ use std::cmp::Ordering;
 use ruff_diagnostics::{Applicability, Diagnostic, Edit, Fix, FixAvailability, Violation};
 use ruff_macros::{derive_message_formats, ViolationMetadata};
 use ruff_python_ast::{
-    Expr, ExprCall, ExprContext, ExprList, ExprStringLiteral, ExprUnaryOp, StringLiteral,
-    StringLiteralFlags, StringLiteralValue, UnaryOp,
+    Expr, ExprCall, ExprContext, ExprList, ExprUnaryOp, StringLiteral, StringLiteralFlags,
+    StringLiteralValue, UnaryOp,
 };
 use ruff_text_size::{Ranged, TextRange};
 
@@ -120,13 +120,10 @@ fn construct_replacement(elts: &[&str], flags: StringLiteralFlags) -> Expr {
         elts: elts
             .iter()
             .map(|elt| {
-                Expr::StringLiteral(ExprStringLiteral {
-                    value: StringLiteralValue::single(StringLiteral {
-                        value: Box::from(*elt),
-                        range: TextRange::default(),
-                        flags,
-                    }),
+                Expr::from(StringLiteral {
+                    value: Box::from(*elt),
                     range: TextRange::default(),
+                    flags,
                 })
             })
             .collect(),

--- a/crates/ruff_linter/src/rules/ruff/rules/assert_with_print_message.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/assert_with_print_message.rs
@@ -90,9 +90,9 @@ pub(crate) fn assert_with_print_message(checker: &mut Checker, stmt: &ast::StmtA
 mod print_arguments {
     use itertools::Itertools;
     use ruff_python_ast::{
-        Arguments, ConversionFlag, Expr, ExprFString, ExprStringLiteral, FString, FStringElement,
-        FStringElements, FStringExpressionElement, FStringFlags, FStringLiteralElement,
-        FStringValue, StringLiteral, StringLiteralFlags, StringLiteralValue,
+        Arguments, ConversionFlag, Expr, ExprFString, FString, FStringElement, FStringElements,
+        FStringExpressionElement, FStringFlags, FStringLiteralElement, FStringValue, StringLiteral,
+        StringLiteralFlags,
     };
     use ruff_text_size::TextRange;
 
@@ -202,13 +202,10 @@ mod print_arguments {
             })
             .join(&sep_string);
 
-        Some(Expr::StringLiteral(ExprStringLiteral {
+        Some(Expr::from(StringLiteral {
+            value: combined_string.into(),
+            flags,
             range: TextRange::default(),
-            value: StringLiteralValue::single(StringLiteral {
-                value: combined_string.into(),
-                flags,
-                range: TextRange::default(),
-            }),
         }))
     }
 

--- a/crates/ruff_python_formatter/tests/normalizer.rs
+++ b/crates/ruff_python_formatter/tests/normalizer.rs
@@ -79,7 +79,7 @@ impl Transformer for Normalizer {
 
                     if can_join {
                         string.value = ast::StringLiteralValue::single(ast::StringLiteral {
-                            value: string.value.to_str().to_string().into_boxed_str(),
+                            value: Box::from(string.value.to_str()),
                             range: string.range,
                             flags: StringLiteralFlags::empty(),
                         });


### PR DESCRIPTION
## Summary

A couple of minor opportunities for simplification that I spotted as a result of reviewing https://github.com/astral-sh/ruff/pull/15726

## Test Plan

`cargo test`
