### PR TITLE
[`refurb`] Avoid `None | None` as well as better detection and fix (`FURB168`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/refurb/FURB168.py
+++ b/crates/ruff_linter/resources/test/fixtures/refurb/FURB168.py
@@ -11,10 +11,10 @@ if isinstance(foo, (type(None))):
 if isinstance(foo, (type(None), type(None), type(None))):
     pass
 
-if isinstance(foo, None | None):
+if isinstance(foo, type(None)) is True:
     pass
 
-if isinstance(foo, (None | None)):
+if -isinstance(foo, type(None)):
     pass
 
 if isinstance(foo, None | type(None)):
@@ -26,6 +26,12 @@ if isinstance(foo, (None | type(None))):
 # A bit contrived, but is both technically valid and equivalent to the above.
 if isinstance(foo, (type(None) | ((((type(None))))) | ((None | type(None))))):
     pass
+
+if isinstance(
+    foo,  # Comment
+    None
+):
+    ...
 
 
 # Okay.
@@ -49,3 +55,16 @@ if isinstance(foo, None):
 # This is also a TypeError, which the rule ignores.
 if isinstance(foo, (None,)):
     pass
+
+if isinstance(foo, None | None):
+    pass
+
+if isinstance(foo, (type(None) | ((((type(None))))) | ((None | None | type(None))))):
+    pass
+
+# https://github.com/astral-sh/ruff/issues/15776
+def _():
+    def type(*args): ...
+
+    if isinstance(foo, type(None)):
+        ...

--- a/crates/ruff_linter/resources/test/fixtures/refurb/FURB168.py
+++ b/crates/ruff_linter/resources/test/fixtures/refurb/FURB168.py
@@ -20,7 +20,7 @@ if -isinstance(foo, type(None)):
 if isinstance(foo, None | type(None)):
     pass
 
-if isinstance(foo, (None | type(None))):
+if isinstance(foo, type(None) | type(None)):
     pass
 
 # A bit contrived, but is both technically valid and equivalent to the above.
@@ -31,6 +31,17 @@ if isinstance(
     foo,  # Comment
     None
 ):
+    ...
+
+from typing import Union
+
+if isinstance(foo, Union[None]):
+    ...
+
+if isinstance(foo, Union[None, None]):
+    ...
+
+if isinstance(foo, Union[None, type(None)]):
     ...
 
 
@@ -47,6 +58,13 @@ if isinstance(foo, (int, str)):
 
 if isinstance(foo, (int, type(None), str)):
     pass
+    pass
+
+if isinstance(foo, str | None):
+    pass
+
+if isinstance(foo, Union[None, str]):
+    ...
 
 # This is a TypeError, which the rule ignores.
 if isinstance(foo, None):

--- a/crates/ruff_linter/resources/test/fixtures/refurb/FURB168.py
+++ b/crates/ruff_linter/resources/test/fixtures/refurb/FURB168.py
@@ -5,7 +5,7 @@ foo: object
 if isinstance(foo, type(None)):
     pass
 
-if isinstance(foo, (type(None))):
+if isinstance(foo and bar, type(None)):
     pass
 
 if isinstance(foo, (type(None), type(None), type(None))):
@@ -57,7 +57,6 @@ if isinstance(foo, (int, str)):
     pass
 
 if isinstance(foo, (int, type(None), str)):
-    pass
     pass
 
 if isinstance(foo, str | None):

--- a/crates/ruff_linter/src/rules/refurb/rules/isinstance_type_none.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/isinstance_type_none.rs
@@ -24,6 +24,9 @@ use crate::checkers::ast::Checker;
 /// obj is None
 /// ```
 ///
+/// ## Fix safety
+/// The fix will be marked as unsafe if there are any comments within the call.
+///
 /// ## References
 /// - [Python documentation: `isinstance`](https://docs.python.org/3/library/functions.html#isinstance)
 /// - [Python documentation: `None`](https://docs.python.org/3/library/constants.html#None)

--- a/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__FURB168_FURB168.py.snap
+++ b/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__FURB168_FURB168.py.snap
@@ -119,14 +119,14 @@ FURB168.py:20:4: FURB168 [*] Prefer `is` operator over `isinstance` to check if 
    20 |+if foo is None:
 21 21 |     pass
 22 22 | 
-23 23 | if isinstance(foo, (None | type(None))):
+23 23 | if isinstance(foo, type(None) | type(None)):
 
 FURB168.py:23:4: FURB168 [*] Prefer `is` operator over `isinstance` to check if an object is `None`
    |
 21 |     pass
 22 |
-23 | if isinstance(foo, (None | type(None))):
-   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FURB168
+23 | if isinstance(foo, type(None) | type(None)):
+   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FURB168
 24 |     pass
    |
    = help: Replace with `is` operator
@@ -135,7 +135,7 @@ FURB168.py:23:4: FURB168 [*] Prefer `is` operator over `isinstance` to check if 
 20 20 | if isinstance(foo, None | type(None)):
 21 21 |     pass
 22 22 | 
-23    |-if isinstance(foo, (None | type(None))):
+23    |-if isinstance(foo, type(None) | type(None)):
    23 |+if foo is None:
 24 24 |     pass
 25 25 | 
@@ -159,3 +159,63 @@ FURB168.py:27:4: FURB168 [*] Prefer `is` operator over `isinstance` to check if 
 28 28 |     pass
 29 29 | 
 30 30 | if isinstance(
+
+FURB168.py:38:4: FURB168 [*] Prefer `is` operator over `isinstance` to check if an object is `None`
+   |
+36 | from typing import Union
+37 |
+38 | if isinstance(foo, Union[None]):
+   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FURB168
+39 |     ...
+   |
+   = help: Replace with `is` operator
+
+ℹ Safe fix
+35 35 | 
+36 36 | from typing import Union
+37 37 | 
+38    |-if isinstance(foo, Union[None]):
+   38 |+if foo is None:
+39 39 |     ...
+40 40 | 
+41 41 | if isinstance(foo, Union[None, None]):
+
+FURB168.py:41:4: FURB168 [*] Prefer `is` operator over `isinstance` to check if an object is `None`
+   |
+39 |     ...
+40 |
+41 | if isinstance(foo, Union[None, None]):
+   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FURB168
+42 |     ...
+   |
+   = help: Replace with `is` operator
+
+ℹ Safe fix
+38 38 | if isinstance(foo, Union[None]):
+39 39 |     ...
+40 40 | 
+41    |-if isinstance(foo, Union[None, None]):
+   41 |+if foo is None:
+42 42 |     ...
+43 43 | 
+44 44 | if isinstance(foo, Union[None, type(None)]):
+
+FURB168.py:44:4: FURB168 [*] Prefer `is` operator over `isinstance` to check if an object is `None`
+   |
+42 |     ...
+43 |
+44 | if isinstance(foo, Union[None, type(None)]):
+   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FURB168
+45 |     ...
+   |
+   = help: Replace with `is` operator
+
+ℹ Safe fix
+41 41 | if isinstance(foo, Union[None, None]):
+42 42 |     ...
+43 43 | 
+44    |-if isinstance(foo, Union[None, type(None)]):
+   44 |+if foo is None:
+45 45 |     ...
+46 46 | 
+47 47 |

--- a/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__FURB168_FURB168.py.snap
+++ b/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__FURB168_FURB168.py.snap
@@ -59,14 +59,14 @@ FURB168.py:11:4: FURB168 [*] Prefer `is` operator over `isinstance` to check if 
    11 |+if foo is None:
 12 12 |     pass
 13 13 | 
-14 14 | if isinstance(foo, None | None):
+14 14 | if isinstance(foo, type(None)) is True:
 
 FURB168.py:14:4: FURB168 [*] Prefer `is` operator over `isinstance` to check if an object is `None`
    |
 12 |     pass
 13 |
-14 | if isinstance(foo, None | None):
-   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FURB168
+14 | if isinstance(foo, type(None)) is True:
+   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^ FURB168
 15 |     pass
    |
    = help: Replace with `is` operator
@@ -75,28 +75,28 @@ FURB168.py:14:4: FURB168 [*] Prefer `is` operator over `isinstance` to check if 
 11 11 | if isinstance(foo, (type(None), type(None), type(None))):
 12 12 |     pass
 13 13 | 
-14    |-if isinstance(foo, None | None):
-   14 |+if foo is None:
+14    |-if isinstance(foo, type(None)) is True:
+   14 |+if (foo is None) is True:
 15 15 |     pass
 16 16 | 
-17 17 | if isinstance(foo, (None | None)):
+17 17 | if -isinstance(foo, type(None)):
 
-FURB168.py:17:4: FURB168 [*] Prefer `is` operator over `isinstance` to check if an object is `None`
+FURB168.py:17:5: FURB168 [*] Prefer `is` operator over `isinstance` to check if an object is `None`
    |
 15 |     pass
 16 |
-17 | if isinstance(foo, (None | None)):
-   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FURB168
+17 | if -isinstance(foo, type(None)):
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ FURB168
 18 |     pass
    |
    = help: Replace with `is` operator
 
 ℹ Safe fix
-14 14 | if isinstance(foo, None | None):
+14 14 | if isinstance(foo, type(None)) is True:
 15 15 |     pass
 16 16 | 
-17    |-if isinstance(foo, (None | None)):
-   17 |+if foo is None:
+17    |-if -isinstance(foo, type(None)):
+   17 |+if -(foo is None):
 18 18 |     pass
 19 19 | 
 20 20 | if isinstance(foo, None | type(None)):
@@ -112,7 +112,7 @@ FURB168.py:20:4: FURB168 [*] Prefer `is` operator over `isinstance` to check if 
    = help: Replace with `is` operator
 
 ℹ Safe fix
-17 17 | if isinstance(foo, (None | None)):
+17 17 | if -isinstance(foo, type(None)):
 18 18 |     pass
 19 19 | 
 20    |-if isinstance(foo, None | type(None)):
@@ -158,4 +158,4 @@ FURB168.py:27:4: FURB168 [*] Prefer `is` operator over `isinstance` to check if 
    27 |+if foo is None:
 28 28 |     pass
 29 29 | 
-30 30 |
+30 30 | if isinstance(

--- a/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__FURB168_FURB168.py.snap
+++ b/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__FURB168_FURB168.py.snap
@@ -19,14 +19,14 @@ FURB168.py:5:4: FURB168 [*] Prefer `is` operator over `isinstance` to check if a
   5 |+if foo is None:
 6 6 |     pass
 7 7 | 
-8 8 | if isinstance(foo, (type(None))):
+8 8 | if isinstance(foo and bar, type(None)):
 
 FURB168.py:8:4: FURB168 [*] Prefer `is` operator over `isinstance` to check if an object is `None`
   |
 6 |     pass
 7 |
-8 | if isinstance(foo, (type(None))):
-  |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FURB168
+8 | if isinstance(foo and bar, type(None)):
+  |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FURB168
 9 |     pass
   |
   = help: Replace with `is` operator
@@ -35,8 +35,8 @@ FURB168.py:8:4: FURB168 [*] Prefer `is` operator over `isinstance` to check if a
 5 5 | if isinstance(foo, type(None)):
 6 6 |     pass
 7 7 | 
-8   |-if isinstance(foo, (type(None))):
-  8 |+if foo is None:
+8   |-if isinstance(foo and bar, type(None)):
+  8 |+if (foo and bar) is None:
 9 9 |     pass
 10 10 | 
 11 11 | if isinstance(foo, (type(None), type(None), type(None))):
@@ -52,7 +52,7 @@ FURB168.py:11:4: FURB168 [*] Prefer `is` operator over `isinstance` to check if 
    = help: Replace with `is` operator
 
 ℹ Safe fix
-8  8  | if isinstance(foo, (type(None))):
+8  8  | if isinstance(foo and bar, type(None)):
 9  9  |     pass
 10 10 | 
 11    |-if isinstance(foo, (type(None), type(None), type(None))):


### PR DESCRIPTION
## Summary

Resolves #15776.

The rule has been rewritten to address the problems discussed at the aforementioned issue. Additionally, `Union[]` is now detected and the fix marked as unsafe if there are any comments in the range.

## Test Plan

`cargo nextest run` and `cargo insta test`.
