### PR TITLE
Preserve quotes in generated f-strings

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_simplify/SIM108.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_simplify/SIM108.py
@@ -194,3 +194,17 @@ if foo():
     z = not foo()
 else:
     z = other
+
+
+# These two cases double as tests for f-string quote preservation. The first
+# f-string should preserve its double quotes, and the second should preserve
+# single quotes
+if cond:
+    var = "str"
+else:
+    var = f"{first}-{second}"
+
+if cond:
+    var = "str"
+else:
+    var = f'{first}-{second}'

--- a/crates/ruff_linter/src/checkers/ast/mod.rs
+++ b/crates/ruff_linter/src/checkers/ast/mod.rs
@@ -315,6 +315,12 @@ impl<'a> Checker<'a> {
         ast::BytesLiteralFlags::empty().with_quote_style(self.preferred_quote())
     }
 
+    /// Return the default f-string flags a generated `FString` node should use, given where we are
+    /// in the AST.
+    pub(crate) fn default_fstring_flags(&self) -> ast::FStringFlags {
+        ast::FStringFlags::empty().with_quote_style(self.preferred_quote())
+    }
+
     /// Returns the appropriate quoting for f-string by reversing the one used outside of
     /// the f-string.
     ///

--- a/crates/ruff_linter/src/checkers/ast/mod.rs
+++ b/crates/ruff_linter/src/checkers/ast/mod.rs
@@ -294,11 +294,7 @@ impl<'a> Checker<'a> {
 
     /// Create a [`Generator`] to generate source code based on the current AST state.
     pub(crate) fn generator(&self) -> Generator {
-        Generator::new(
-            self.stylist.indentation(),
-            self.preferred_quote(),
-            self.stylist.line_ending(),
-        )
+        Generator::new(self.stylist.indentation(), self.stylist.line_ending())
     }
 
     /// Return the preferred quote for a generated `StringLiteral` node, given where we are in the

--- a/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__SIM108_SIM108.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__SIM108_SIM108.py.snap
@@ -301,3 +301,55 @@ SIM108.py:193:1: SIM108 [*] Use ternary operator `z = not foo() if foo() else ot
 195     |-else:
 196     |-    z = other
     193 |+z = not foo() if foo() else other
+197 194 | 
+198 195 | 
+199 196 | # These two cases double as tests for f-string quote preservation. The first
+
+SIM108.py:202:1: SIM108 [*] Use ternary operator `var = "str" if cond else f"{first}-{second}"` instead of `if`-`else`-block
+    |
+200 |   # f-string should preserve its double quotes, and the second should preserve
+201 |   # single quotes
+202 | / if cond:
+203 | |     var = "str"
+204 | | else:
+205 | |     var = f"{first}-{second}"
+    | |_____________________________^ SIM108
+206 |
+207 |   if cond:
+    |
+    = help: Replace `if`-`else`-block with `var = "str" if cond else f"{first}-{second}"`
+
+ℹ Unsafe fix
+199 199 | # These two cases double as tests for f-string quote preservation. The first
+200 200 | # f-string should preserve its double quotes, and the second should preserve
+201 201 | # single quotes
+202     |-if cond:
+203     |-    var = "str"
+204     |-else:
+205     |-    var = f"{first}-{second}"
+    202 |+var = "str" if cond else f"{first}-{second}"
+206 203 | 
+207 204 | if cond:
+208 205 |     var = "str"
+
+SIM108.py:207:1: SIM108 [*] Use ternary operator `var = "str" if cond else f'{first}-{second}'` instead of `if`-`else`-block
+    |
+205 |       var = f"{first}-{second}"
+206 |
+207 | / if cond:
+208 | |     var = "str"
+209 | | else:
+210 | |     var = f'{first}-{second}'
+    | |_____________________________^ SIM108
+    |
+    = help: Replace `if`-`else`-block with `var = "str" if cond else f'{first}-{second}'`
+
+ℹ Unsafe fix
+204 204 | else:
+205 205 |     var = f"{first}-{second}"
+206 206 | 
+207     |-if cond:
+208     |-    var = "str"
+209     |-else:
+210     |-    var = f'{first}-{second}'
+    207 |+var = "str" if cond else f'{first}-{second}'

--- a/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__preview__SIM108_SIM108.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__preview__SIM108_SIM108.py.snap
@@ -301,3 +301,55 @@ SIM108.py:193:1: SIM108 [*] Use ternary operator `z = not foo() if foo() else ot
 195     |-else:
 196     |-    z = other
     193 |+z = not foo() if foo() else other
+197 194 | 
+198 195 | 
+199 196 | # These two cases double as tests for f-string quote preservation. The first
+
+SIM108.py:202:1: SIM108 [*] Use ternary operator `var = "str" if cond else f"{first}-{second}"` instead of `if`-`else`-block
+    |
+200 |   # f-string should preserve its double quotes, and the second should preserve
+201 |   # single quotes
+202 | / if cond:
+203 | |     var = "str"
+204 | | else:
+205 | |     var = f"{first}-{second}"
+    | |_____________________________^ SIM108
+206 |
+207 |   if cond:
+    |
+    = help: Replace `if`-`else`-block with `var = "str" if cond else f"{first}-{second}"`
+
+ℹ Unsafe fix
+199 199 | # These two cases double as tests for f-string quote preservation. The first
+200 200 | # f-string should preserve its double quotes, and the second should preserve
+201 201 | # single quotes
+202     |-if cond:
+203     |-    var = "str"
+204     |-else:
+205     |-    var = f"{first}-{second}"
+    202 |+var = "str" if cond else f"{first}-{second}"
+206 203 | 
+207 204 | if cond:
+208 205 |     var = "str"
+
+SIM108.py:207:1: SIM108 [*] Use ternary operator `var = "str" if cond else f'{first}-{second}'` instead of `if`-`else`-block
+    |
+205 |       var = f"{first}-{second}"
+206 |
+207 | / if cond:
+208 | |     var = "str"
+209 | | else:
+210 | |     var = f'{first}-{second}'
+    | |_____________________________^ SIM108
+    |
+    = help: Replace `if`-`else`-block with `var = "str" if cond else f'{first}-{second}'`
+
+ℹ Unsafe fix
+204 204 | else:
+205 205 |     var = f"{first}-{second}"
+206 206 | 
+207     |-if cond:
+208     |-    var = "str"
+209     |-else:
+210     |-    var = f'{first}-{second}'
+    207 |+var = "str" if cond else f'{first}-{second}'

--- a/crates/ruff_linter/src/rules/flake8_type_checking/helpers.rs
+++ b/crates/ruff_linter/src/rules/flake8_type_checking/helpers.rs
@@ -363,11 +363,7 @@ impl<'a> QuoteAnnotator<'a> {
         let generator = Generator::from(self.stylist);
         // we first generate the annotation with the inverse quote, so we can
         // generate the string literal with the preferred quote
-        let subgenerator = Generator::new(
-            self.stylist.indentation(),
-            self.stylist.quote().opposite(),
-            self.stylist.line_ending(),
-        );
+        let subgenerator = Generator::new(self.stylist.indentation(), self.stylist.line_ending());
         let annotation = subgenerator.expr(&expr_without_forward_references);
         generator.expr(&Expr::from(ast::StringLiteral {
             range: TextRange::default(),

--- a/crates/ruff_linter/src/rules/flynt/helpers.rs
+++ b/crates/ruff_linter/src/rules/flynt/helpers.rs
@@ -15,7 +15,7 @@ fn to_f_string_expression_element(inner: &Expr) -> ast::FStringElement {
 /// Convert a string to a [`ast::FStringElement::Literal`].
 pub(super) fn to_f_string_literal_element(s: &str) -> ast::FStringElement {
     ast::FStringElement::Literal(ast::FStringLiteralElement {
-        value: s.to_string().into_boxed_str(),
+        value: s.into(),
         range: TextRange::default(),
     })
 }

--- a/crates/ruff_linter/src/rules/flynt/helpers.rs
+++ b/crates/ruff_linter/src/rules/flynt/helpers.rs
@@ -15,7 +15,7 @@ fn to_f_string_expression_element(inner: &Expr) -> ast::FStringElement {
 /// Convert a string to a [`ast::FStringElement::Literal`].
 pub(super) fn to_f_string_literal_element(s: &str) -> ast::FStringElement {
     ast::FStringElement::Literal(ast::FStringLiteralElement {
-        value: s.into(),
+        value: Box::from(s),
         range: TextRange::default(),
     })
 }

--- a/crates/ruff_linter/src/rules/flynt/rules/static_join_to_fstring.rs
+++ b/crates/ruff_linter/src/rules/flynt/rules/static_join_to_fstring.rs
@@ -1,10 +1,11 @@
 use ast::FStringFlags;
 use itertools::Itertools;
+use ruff_python_ast::str::Quote;
 
 use crate::fix::edits::pad;
 use ruff_diagnostics::{AlwaysFixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, ViolationMetadata};
-use ruff_python_ast::{self as ast, Arguments, Expr};
+use ruff_python_ast::{self as ast, Arguments, Expr, StringFlags};
 use ruff_text_size::{Ranged, TextRange};
 
 use crate::checkers::ast::Checker;
@@ -60,7 +61,8 @@ fn is_static_length(elts: &[Expr]) -> bool {
     elts.iter().all(|e| !e.is_starred_expr())
 }
 
-fn build_fstring(joiner: &str, joinees: &[Expr]) -> Option<Expr> {
+/// Build an f-string consisting of `joinees` joined by `joiner` and surrounded by `quote`.
+fn build_fstring(joiner: &str, joinees: &[Expr], quote: Quote) -> Option<Expr> {
     // If all elements are string constants, join them into a single string.
     if joinees.iter().all(Expr::is_string_literal_expr) {
         let mut flags = None;
@@ -104,7 +106,7 @@ fn build_fstring(joiner: &str, joinees: &[Expr]) -> Option<Expr> {
     let node = ast::FString {
         elements: f_string_elements.into(),
         range: TextRange::default(),
-        flags: FStringFlags::default(),
+        flags: FStringFlags::default().with_quote_style(quote),
     };
     Some(node.into())
 }
@@ -137,7 +139,8 @@ pub(crate) fn static_join_to_fstring(checker: &mut Checker, expr: &Expr, joiner:
 
     // Try to build the fstring (internally checks whether e.g. the elements are
     // convertible to f-string elements).
-    let Some(new_expr) = build_fstring(joiner, joinees) else {
+    let quote = checker.default_string_flags().quote_style();
+    let Some(new_expr) = build_fstring(joiner, joinees, quote) else {
         return;
     };
 

--- a/crates/ruff_linter/src/rules/flynt/rules/static_join_to_fstring.rs
+++ b/crates/ruff_linter/src/rules/flynt/rules/static_join_to_fstring.rs
@@ -4,7 +4,7 @@ use itertools::Itertools;
 use crate::fix::edits::pad;
 use ruff_diagnostics::{AlwaysFixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, ViolationMetadata};
-use ruff_python_ast::{self as ast, Arguments, Expr, };
+use ruff_python_ast::{self as ast, Arguments, Expr};
 use ruff_text_size::{Ranged, TextRange};
 
 use crate::checkers::ast::Checker;

--- a/crates/ruff_linter/src/rules/ruff/rules/assert_with_print_message.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/assert_with_print_message.rs
@@ -66,8 +66,7 @@ pub(crate) fn assert_with_print_message(checker: &mut Checker, stmt: &ast::StmtA
             diagnostic.set_fix(Fix::unsafe_edit(Edit::range_replacement(
                 checker.generator().stmt(&Stmt::Assert(ast::StmtAssert {
                     test: stmt.test.clone(),
-                    msg: print_arguments::to_expr(&call.arguments, checker.default_string_flags())
-                        .map(Box::new),
+                    msg: print_arguments::to_expr(&call.arguments, checker).map(Box::new),
                     range: TextRange::default(),
                 })),
                 // We have to replace the entire statement,
@@ -90,11 +89,13 @@ pub(crate) fn assert_with_print_message(checker: &mut Checker, stmt: &ast::StmtA
 mod print_arguments {
     use itertools::Itertools;
     use ruff_python_ast::{
-        str::Quote, Arguments, ConversionFlag, Expr, ExprFString, FString, FStringElement,
-        FStringElements, FStringExpressionElement, FStringFlags, FStringLiteralElement,
-        FStringValue, StringFlags, StringLiteral, StringLiteralFlags,
+        Arguments, ConversionFlag, Expr, ExprFString, FString, FStringElement, FStringElements,
+        FStringExpressionElement, FStringFlags, FStringLiteralElement, FStringValue, StringLiteral,
+        StringLiteralFlags,
     };
     use ruff_text_size::TextRange;
+
+    use crate::checkers::ast::Checker;
 
     /// Converts an expression to a list of `FStringElement`s.
     ///
@@ -222,7 +223,7 @@ mod print_arguments {
     fn args_to_fstring_expr(
         mut args: impl ExactSizeIterator<Item = Vec<FStringElement>>,
         sep: impl ExactSizeIterator<Item = FStringElement>,
-        quote: Quote,
+        flags: FStringFlags,
     ) -> Option<Expr> {
         // If there are no arguments, short-circuit and return `None`
         let first_arg = args.next()?;
@@ -237,7 +238,7 @@ mod print_arguments {
         Some(Expr::FString(ExprFString {
             value: FStringValue::single(FString {
                 elements: FStringElements::from(fstring_elements),
-                flags: FStringFlags::default().with_quote_style(quote),
+                flags,
                 range: TextRange::default(),
             }),
             range: TextRange::default(),
@@ -257,7 +258,7 @@ mod print_arguments {
     /// - [`Some`]<[`Expr::StringLiteral`]> if all arguments including `sep` are string literals.
     /// - [`Some`]<[`Expr::FString`]> if any of the arguments are not string literals.
     /// - [`None`] if the `print` contains no positional arguments at all.
-    pub(super) fn to_expr(arguments: &Arguments, flags: StringLiteralFlags) -> Option<Expr> {
+    pub(super) fn to_expr(arguments: &Arguments, checker: &Checker) -> Option<Expr> {
         // Convert the `sep` argument into `FStringElement`s
         let sep = arguments
             .find_keyword("sep")
@@ -287,8 +288,13 @@ mod print_arguments {
 
         // Attempt to convert the `sep` and `args` arguments to a string literal,
         // falling back to an f-string if the arguments are not all string literals.
-        args_to_string_literal_expr(args.iter(), sep.iter(), flags).or_else(|| {
-            args_to_fstring_expr(args.into_iter(), sep.into_iter(), flags.quote_style())
-        })
+        args_to_string_literal_expr(args.iter(), sep.iter(), checker.default_string_flags())
+            .or_else(|| {
+                args_to_fstring_expr(
+                    args.into_iter(),
+                    sep.into_iter(),
+                    checker.default_fstring_flags(),
+                )
+            })
     }
 }

--- a/crates/ruff_python_ast/src/nodes.rs
+++ b/crates/ruff_python_ast/src/nodes.rs
@@ -1063,10 +1063,32 @@ bitflags! {
 
 /// Flags that can be queried to obtain information
 /// regarding the prefixes and quotes used for an f-string.
-#[derive(Default, Copy, Clone, Eq, PartialEq, Hash)]
+///
+/// ## Notes on usage
+///
+/// If you're using a `Generator` from the `ruff_python_codegen` crate to generate a lint-rule fix
+/// from an existing f-string literal, consider passing along the [`FString::flags`] field. If you
+/// don't have an existing literal but have a `Checker` from the `ruff_linter` crate available,
+/// consider using `Checker::default_fstring_flags` to create instances of this struct; this method
+/// will properly handle nested f-strings. For usage that doesn't fit into one of these categories,
+/// the public constructor [`FStringFlags::empty`] can be used.
+#[derive(Copy, Clone, Eq, PartialEq, Hash)]
 pub struct FStringFlags(FStringFlagsInner);
 
 impl FStringFlags {
+    /// Construct a new [`FStringFlags`] with **no flags set**.
+    ///
+    /// See [`FStringFlags::with_quote_style`], [`FStringFlags::with_triple_quotes`], and
+    /// [`FStringFlags::with_prefix`] for ways of setting the quote style (single or double),
+    /// enabling triple quotes, and adding prefixes (such as `r`), respectively.
+    ///
+    /// See the documentation for [`FStringFlags`] for additional caveats on this constructor, and
+    /// situations in which alternative ways to construct this struct should be used, especially
+    /// when writing lint rules.
+    pub fn empty() -> Self {
+        Self(FStringFlagsInner::empty())
+    }
+
     #[must_use]
     pub fn with_quote_style(mut self, quote_style: Quote) -> Self {
         self.0
@@ -2229,7 +2251,7 @@ impl From<AnyStringFlags> for FStringFlags {
                 value.prefix()
             )
         };
-        let new = FStringFlags::default()
+        let new = FStringFlags::empty()
             .with_quote_style(value.quote_style())
             .with_prefix(fstring_prefix);
         if value.is_triple_quoted() {

--- a/crates/ruff_python_codegen/src/generator.rs
+++ b/crates/ruff_python_codegen/src/generator.rs
@@ -1813,19 +1813,18 @@ if True:
             };
         }
 
-        // setting Generator::quote works for f-strings
-        round_trip_with!(Quote::Double, r#"f"hello""#, r#"f"hello""#);
-        round_trip_with!(Quote::Single, r#"f"hello""#, r"f'hello'");
-        round_trip_with!(Quote::Double, r"f'hello'", r#"f"hello""#);
-        round_trip_with!(Quote::Single, r"f'hello'", r"f'hello'");
+        // setting Generator::quote no longer works because the quote values are taken from the
+        // string literals themselves
+        round_trip_with!(Quote::Double, r#"f"hello""#);
+        round_trip_with!(Quote::Single, r#"f"hello""#); // no effect
+        round_trip_with!(Quote::Double, r"f'hello'"); // no effect
+        round_trip_with!(Quote::Single, r"f'hello'");
 
-        // but not for bytestrings
         round_trip_with!(Quote::Double, r#"b"hello""#);
         round_trip_with!(Quote::Single, r#"b"hello""#); // no effect
         round_trip_with!(Quote::Double, r"b'hello'"); // no effect
         round_trip_with!(Quote::Single, r"b'hello'");
 
-        // or for string literals, where the `Quote` is taken directly from their flags
         round_trip_with!(Quote::Double, r#""hello""#);
         round_trip_with!(Quote::Single, r#""hello""#); // no effect
         round_trip_with!(Quote::Double, r"'hello'"); // no effect

--- a/crates/ruff_python_codegen/src/generator.rs
+++ b/crates/ruff_python_codegen/src/generator.rs
@@ -1771,14 +1771,11 @@ if True:
     #[test]
     fn set_quote() {
         macro_rules! round_trip_with {
-            ($start:expr, $end:expr) => {
+            ($start:expr) => {
                 assert_eq!(
                     round_trip_with(&Indentation::default(), LineEnding::default(), $start),
-                    $end,
+                    $start,
                 );
-            };
-            ($start:expr) => {
-                round_trip_with!($start, $start);
             };
         }
 

--- a/crates/ruff_python_codegen/src/generator.rs
+++ b/crates/ruff_python_codegen/src/generator.rs
@@ -1091,7 +1091,7 @@ impl<'a> Generator<'a> {
                 self.p(")");
             }
             Expr::FString(ast::ExprFString { value, .. }) => {
-                self.unparse_f_string_value(value, false);
+                self.unparse_f_string_value(value);
             }
             Expr::StringLiteral(ast::ExprStringLiteral { value, .. }) => {
                 self.unparse_string_literal_value(value);
@@ -1310,7 +1310,7 @@ impl<'a> Generator<'a> {
         }
     }
 
-    fn unparse_f_string_value(&mut self, value: &ast::FStringValue, is_spec: bool) {
+    fn unparse_f_string_value(&mut self, value: &ast::FStringValue) {
         let mut first = true;
         for f_string_part in value {
             self.p_delim(&mut first, " ");
@@ -1319,7 +1319,7 @@ impl<'a> Generator<'a> {
                     self.unparse_string_literal(string_literal);
                 }
                 ast::FStringPart::FString(f_string) => {
-                    self.unparse_f_string(&f_string.elements, is_spec);
+                    self.unparse_f_string(&f_string.elements, false);
                 }
             }
         }
@@ -1397,6 +1397,8 @@ impl<'a> Generator<'a> {
         self.p(&s);
     }
 
+    /// `is_spec` indicates whether we are inside of a format specifier (i.e. after the `:` in
+    /// `{var:...}`)
     fn unparse_f_string(&mut self, values: &[ast::FStringElement], is_spec: bool) {
         if is_spec {
             self.unparse_f_string_body(values);

--- a/crates/ruff_python_codegen/src/generator.rs
+++ b/crates/ruff_python_codegen/src/generator.rs
@@ -1719,6 +1719,9 @@ class Foo:
         assert_round_trip!(r"u'hello'");
         assert_round_trip!(r"r'hello'");
         assert_round_trip!(r"b'hello'");
+        assert_round_trip!(r#"b"hello""#);
+        assert_round_trip!(r"f'hello'");
+        assert_round_trip!(r#"f"hello""#);
         assert_eq!(round_trip(r#"("abc" "def" "ghi")"#), r#""abc" "def" "ghi""#);
         assert_eq!(round_trip(r#""he\"llo""#), r#"'he"llo'"#);
         assert_eq!(round_trip(r#"f"abc{'def'}{1}""#), r#"f"abc{'def'}{1}""#);
@@ -1765,35 +1768,6 @@ if True:
             .trim()
             .replace('\n', LineEnding::default().as_str())
         );
-    }
-
-    #[test]
-    fn set_quote() {
-        macro_rules! round_trip_with {
-            ($start:expr) => {
-                assert_eq!(
-                    round_trip_with(&Indentation::default(), LineEnding::default(), $start),
-                    $start,
-                );
-            };
-        }
-
-        // setting Generator::quote no longer works because the quote values are taken from the
-        // string literals themselves
-        round_trip_with!(r#"f"hello""#);
-        round_trip_with!(r#"f"hello""#); // no effect
-        round_trip_with!(r"f'hello'"); // no effect
-        round_trip_with!(r"f'hello'");
-
-        round_trip_with!(r#"b"hello""#);
-        round_trip_with!(r#"b"hello""#); // no effect
-        round_trip_with!(r"b'hello'"); // no effect
-        round_trip_with!(r"b'hello'");
-
-        round_trip_with!(r#""hello""#);
-        round_trip_with!(r#""hello""#); // no effect
-        round_trip_with!(r"'hello'"); // no effect
-        round_trip_with!(r"'hello'");
     }
 
     #[test]

--- a/crates/ruff_python_codegen/src/generator.rs
+++ b/crates/ruff_python_codegen/src/generator.rs
@@ -1312,8 +1312,7 @@ impl<'a> Generator<'a> {
                     self.unparse_string_literal(string_literal);
                 }
                 ast::FStringPart::FString(f_string) => {
-                    let quote = f_string.flags.quote_style();
-                    self.unparse_f_string(&f_string.elements, quote);
+                    self.unparse_f_string(&f_string.elements, f_string.flags.quote_style());
                 }
             }
         }

--- a/crates/ruff_python_formatter/tests/normalizer.rs
+++ b/crates/ruff_python_formatter/tests/normalizer.rs
@@ -181,7 +181,7 @@ impl Transformer for Normalizer {
                         fstring.value = ast::FStringValue::single(ast::FString {
                             elements: collector.elements.into(),
                             range: fstring.range,
-                            flags: FStringFlags::default(),
+                            flags: FStringFlags::empty(),
                         });
                     }
                 }


### PR DESCRIPTION
## Summary

This is another follow-up to #15726 and #15778, extending the quote-preserving behavior to f-strings and deleting the now-unused `Generator::quote` field.

## Details
I also made one unrelated change to `rules/flynt/helpers.rs` to remove a `to_string` call for making a `Box<str>` and tweaked some arguments to some of the `Generator::unparse_f_string` methods to make the code easier to follow, in my opinion. Happy to revert especially the latter of these if needed.

Unfortunately this still does not fix the issue in #9660, which appears to be more of an escaping issue than a quote-preservation issue. After #15726, the result is now `a = f'# {"".join([])}' if 1 else ""` instead of `a = f"# {''.join([])}" if 1 else ""` (single quotes on the outside now), but we still don't have the desired behavior of double quotes everywhere on Python 3.12+. I added a test for this but split it off into another branch since it ended up being unaddressed here, but my `dbg!` statements showed the correct preferred quotes going into [`UnicodeEscape::with_preferred_quote`](https://github.com/astral-sh/ruff/blob/main/crates/ruff_python_literal/src/escape.rs#L54).

## Test Plan

Existing rule and `Generator` tests.
