### PR TITLE
[`pyupgrade`] Ignore `is_typeddict` and `TypedDict` for `deprecated-import` (`UP035`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP035.py
+++ b/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP035.py
@@ -109,3 +109,7 @@ from typing_extensions import CapsuleType
 
 # UP035 on py313+ only
 from typing_extensions import deprecated
+
+
+# https://github.com/astral-sh/ruff/issues/15780
+from typing_extensions import is_typeddict

--- a/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP035.py
+++ b/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP035.py
@@ -113,3 +113,5 @@ from typing_extensions import deprecated
 
 # https://github.com/astral-sh/ruff/issues/15780
 from typing_extensions import is_typeddict
+# https://github.com/astral-sh/ruff/pull/15800#pullrequestreview-2580704217
+from typing_extensions import TypedDict

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/deprecated_import.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/deprecated_import.rs
@@ -308,7 +308,9 @@ const TYPING_EXTENSIONS_TO_TYPING_310: &[&str] = &[
     "TypeGuard",
     "get_args",
     "get_origin",
-    "is_typeddict",
+    // Introduced in Python 3.10, but `typing_extensions` equivalent
+    // also checks for `typing_extensions.TypedDict` in addition to `typing.TypedDict`.
+    // "is_typeddict",
 ];
 
 // Python 3.11+

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/deprecated_import.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/deprecated_import.rs
@@ -384,13 +384,14 @@ const TYPING_EXTENSIONS_TO_TYPING_313: &[&str] = &[
     // Introduced in Python 3.8, but typing_extensions
     // backports features and bugfixes from py313:
     "Protocol",
-    "TypedDict",
     "runtime_checkable",
     // Introduced in earlier Python versions,
     // but typing_extensions backports PEP-696:
     "ParamSpec",
     "TypeVar",
     "TypeVarTuple",
+    // `typing_extensions` backports PEP 728 (TypedDict with Typed Extra Items)
+    // "TypedDict",
 ];
 
 // Members of `typing_extensions` that were moved to `types`.

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP035.py.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP035.py.snap
@@ -1188,3 +1188,6 @@ UP035.py:111:1: UP035 [*] Import from `warnings` instead: `deprecated`
 110 110 | # UP035 on py313+ only
 111     |-from typing_extensions import deprecated
     111 |+from warnings import deprecated
+112 112 | 
+113 113 | 
+114 114 | # https://github.com/astral-sh/ruff/issues/15780


### PR DESCRIPTION
## Summary

Resolves #15780.

`is_typeddict` and `TypedDict` are now listed as known exceptions to the rule. The former will presumably stay until 3.9 reaches its end-of-life circa this October.

## Test Plan

`cargo nextest run` and `cargo insta test`.
