### PR TITLE
Add missing config docstrings

### DIFF
--- a/crates/ruff_workspace/src/options.rs
+++ b/crates/ruff_workspace/src/options.rs
@@ -942,6 +942,7 @@ pub struct LintCommonOptions {
     // WARNING: Don't add new options to this type. Add them to `LintOptions` instead.
 }
 
+/// Options for the `flake8-annotations` plugin.
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[derive(
     Clone, Debug, PartialEq, Eq, Default, OptionsMetadata, CombineOptions, Serialize, Deserialize,
@@ -1011,6 +1012,7 @@ impl Flake8AnnotationsOptions {
     }
 }
 
+/// Options for the `flake8-bandit` plugin.
 #[derive(
     Clone, Debug, PartialEq, Eq, Default, Serialize, Deserialize, OptionsMetadata, CombineOptions,
 )]
@@ -1059,6 +1061,7 @@ impl Flake8BanditOptions {
     }
 }
 
+/// Options for the `flake8-boolean-trap` plugin
 #[derive(
     Clone, Debug, PartialEq, Eq, Default, Serialize, Deserialize, OptionsMetadata, CombineOptions,
 )]
@@ -1085,6 +1088,7 @@ impl Flake8BooleanTrapOptions {
     }
 }
 
+/// Options for the `flake8-bugbear` plugin.
 #[derive(
     Clone, Debug, PartialEq, Eq, Default, Serialize, Deserialize, OptionsMetadata, CombineOptions,
 )]
@@ -1115,6 +1119,8 @@ impl Flake8BugbearOptions {
         }
     }
 }
+
+/// Options for the `flake8-builtins` plugin.
 #[derive(
     Clone, Debug, PartialEq, Eq, Default, Serialize, Deserialize, OptionsMetadata, CombineOptions,
 )]
@@ -1145,6 +1151,8 @@ impl Flake8BuiltinsOptions {
         }
     }
 }
+
+/// Options for the `flake8-comprehensions` plugin.
 #[derive(
     Clone, Debug, PartialEq, Eq, Default, Serialize, Deserialize, OptionsMetadata, CombineOptions,
 )]
@@ -1170,6 +1178,7 @@ impl Flake8ComprehensionsOptions {
     }
 }
 
+/// Options for the `flake8-copyright` plugin.
 #[derive(
     Clone, Debug, PartialEq, Eq, Default, Serialize, Deserialize, OptionsMetadata, CombineOptions,
 )]
@@ -1225,6 +1234,7 @@ impl Flake8CopyrightOptions {
     }
 }
 
+/// Options for the `flake8-errmsg` plugin.
 #[derive(
     Clone, Debug, PartialEq, Eq, Default, Serialize, Deserialize, OptionsMetadata, CombineOptions,
 )]
@@ -1244,6 +1254,7 @@ impl Flake8ErrMsgOptions {
     }
 }
 
+/// Options for the `flake8-gettext` plugin.
 #[derive(
     Clone, Debug, PartialEq, Eq, Default, Serialize, Deserialize, OptionsMetadata, CombineOptions,
 )]
@@ -1281,6 +1292,7 @@ impl Flake8GetTextOptions {
     }
 }
 
+/// Options for the `flake8-implicit-str-concat` plugin
 #[derive(
     Clone, Debug, PartialEq, Eq, Default, Serialize, Deserialize, OptionsMetadata, CombineOptions,
 )]
@@ -1315,6 +1327,7 @@ impl Flake8ImplicitStrConcatOptions {
     }
 }
 
+/// Options for the `flake8-import-conventions` plugin
 #[derive(
     Clone, Debug, PartialEq, Eq, Default, Serialize, Deserialize, OptionsMetadata, CombineOptions,
 )]
@@ -1468,6 +1481,7 @@ impl Flake8ImportConventionsOptions {
     }
 }
 
+/// Options for the `flake8-pytest-style` plugin
 #[derive(
     Clone, Debug, PartialEq, Eq, Default, Serialize, Deserialize, OptionsMetadata, CombineOptions,
 )]
@@ -1658,6 +1672,7 @@ impl Flake8PytestStyleOptions {
     }
 }
 
+/// Options for the `flake8-quotes` plugin.
 #[derive(
     Clone, Debug, PartialEq, Eq, Default, Serialize, Deserialize, OptionsMetadata, CombineOptions,
 )]
@@ -1730,6 +1745,7 @@ impl Flake8QuotesOptions {
     }
 }
 
+/// Options for the `flake8_self` plugin.
 #[derive(
     Clone, Debug, PartialEq, Eq, Default, Serialize, Deserialize, OptionsMetadata, CombineOptions,
 )]
@@ -1770,6 +1786,7 @@ impl Flake8SelfOptions {
     }
 }
 
+/// Options for the `flake8-tidy-imports` plugin
 #[derive(
     Clone, Debug, PartialEq, Eq, Default, Serialize, Deserialize, OptionsMetadata, CombineOptions,
 )]
@@ -1827,6 +1844,7 @@ impl Flake8TidyImportsOptions {
     }
 }
 
+/// Options for the `flake8-type-checking` plugin
 #[derive(
     Clone, Debug, PartialEq, Eq, Default, Serialize, Deserialize, OptionsMetadata, CombineOptions,
 )]
@@ -1971,6 +1989,7 @@ impl Flake8TypeCheckingOptions {
     }
 }
 
+/// Options for the `flake8-unused-arguments` plugin
 #[derive(
     Clone, Debug, PartialEq, Eq, Default, Serialize, Deserialize, OptionsMetadata, CombineOptions,
 )]
@@ -1994,6 +2013,7 @@ impl Flake8UnusedArgumentsOptions {
     }
 }
 
+/// Options for the `isort` plugin.
 #[derive(
     Clone, Debug, PartialEq, Eq, Default, Serialize, Deserialize, OptionsMetadata, CombineOptions,
 )]
@@ -2641,6 +2661,7 @@ impl IsortOptions {
     }
 }
 
+/// Options for the `mccabe` plugin.
 #[derive(
     Clone, Debug, PartialEq, Eq, Default, Serialize, Deserialize, OptionsMetadata, CombineOptions,
 )]
@@ -2669,6 +2690,7 @@ impl McCabeOptions {
     }
 }
 
+/// Options for the `pep8-naming` plugin.
 #[derive(
     Clone, Debug, PartialEq, Eq, Default, Serialize, Deserialize, OptionsMetadata, CombineOptions,
 )]
@@ -2761,6 +2783,7 @@ impl Pep8NamingOptions {
     }
 }
 
+/// Options for the `pycodestyle` plugin.
 #[derive(
     Clone, Debug, PartialEq, Eq, Default, Serialize, Deserialize, OptionsMetadata, CombineOptions,
 )]
@@ -2835,6 +2858,7 @@ impl PycodestyleOptions {
     }
 }
 
+/// Options for the `pydocstyle` plugin.
 #[derive(
     Clone, Debug, PartialEq, Eq, Default, Serialize, Deserialize, OptionsMetadata, CombineOptions,
 )]
@@ -2942,6 +2966,7 @@ impl PydocstyleOptions {
     }
 }
 
+/// Options for the `pydoclint` plugin.
 #[derive(
     Clone, Debug, PartialEq, Eq, Default, Serialize, Deserialize, OptionsMetadata, CombineOptions,
 )]
@@ -2971,6 +2996,7 @@ impl PydoclintOptions {
     }
 }
 
+/// Options for the `pyflakes` plugin.
 #[derive(
     Clone, Debug, PartialEq, Eq, Default, Serialize, Deserialize, OptionsMetadata, CombineOptions,
 )]
@@ -3015,6 +3041,7 @@ impl PyflakesOptions {
     }
 }
 
+/// Options for the `pylint` plugin.
 #[derive(
     Clone, Debug, PartialEq, Eq, Default, Serialize, Deserialize, OptionsMetadata, CombineOptions,
 )]
@@ -3124,6 +3151,7 @@ impl PylintOptions {
     }
 }
 
+/// Options for the `pyupgrade` plugin.
 #[derive(
     Clone, Debug, PartialEq, Eq, Default, Serialize, Deserialize, OptionsMetadata, CombineOptions,
 )]
@@ -3179,6 +3207,7 @@ impl PyUpgradeOptions {
     }
 }
 
+/// Options for the `ruff` plugin
 #[derive(
     Clone, Debug, PartialEq, Eq, Default, Serialize, Deserialize, OptionsMetadata, CombineOptions,
 )]

--- a/ruff.schema.json
+++ b/ruff.schema.json
@@ -900,6 +900,7 @@
       "const": "dynamic"
     },
     "Flake8AnnotationsOptions": {
+      "description": "Options for the `flake8-annotations` plugin.",
       "type": "object",
       "properties": {
         "allow-star-arg-any": {
@@ -941,6 +942,7 @@
       "additionalProperties": false
     },
     "Flake8BanditOptions": {
+      "description": "Options for the `flake8-bandit` plugin.",
       "type": "object",
       "properties": {
         "check-typed-exception": {
@@ -974,6 +976,7 @@
       "additionalProperties": false
     },
     "Flake8BooleanTrapOptions": {
+      "description": "Options for the `flake8-boolean-trap` plugin",
       "type": "object",
       "properties": {
         "extend-allowed-calls": {
@@ -990,6 +993,7 @@
       "additionalProperties": false
     },
     "Flake8BugbearOptions": {
+      "description": "Options for the `flake8-bugbear` plugin.",
       "type": "object",
       "properties": {
         "extend-immutable-calls": {
@@ -1006,6 +1010,7 @@
       "additionalProperties": false
     },
     "Flake8BuiltinsOptions": {
+      "description": "Options for the `flake8-builtins` plugin.",
       "type": "object",
       "properties": {
         "builtins-allowed-modules": {
@@ -1032,6 +1037,7 @@
       "additionalProperties": false
     },
     "Flake8ComprehensionsOptions": {
+      "description": "Options for the `flake8-comprehensions` plugin.",
       "type": "object",
       "properties": {
         "allow-dict-calls-with-keyword-arguments": {
@@ -1045,6 +1051,7 @@
       "additionalProperties": false
     },
     "Flake8CopyrightOptions": {
+      "description": "Options for the `flake8-copyright` plugin.",
       "type": "object",
       "properties": {
         "author": {
@@ -1074,6 +1081,7 @@
       "additionalProperties": false
     },
     "Flake8ErrMsgOptions": {
+      "description": "Options for the `flake8-errmsg` plugin.",
       "type": "object",
       "properties": {
         "max-string-length": {
@@ -1089,6 +1097,7 @@
       "additionalProperties": false
     },
     "Flake8GetTextOptions": {
+      "description": "Options for the `flake8-gettext` plugin.",
       "type": "object",
       "properties": {
         "extend-function-names": {
@@ -1115,6 +1124,7 @@
       "additionalProperties": false
     },
     "Flake8ImplicitStrConcatOptions": {
+      "description": "Options for the `flake8-implicit-str-concat` plugin",
       "type": "object",
       "properties": {
         "allow-multiline": {
@@ -1128,6 +1138,7 @@
       "additionalProperties": false
     },
     "Flake8ImportConventionsOptions": {
+      "description": "Options for the `flake8-import-conventions` plugin",
       "type": "object",
       "properties": {
         "aliases": {
@@ -1175,6 +1186,7 @@
       "additionalProperties": false
     },
     "Flake8PytestStyleOptions": {
+      "description": "Options for the `flake8-pytest-style` plugin",
       "type": "object",
       "properties": {
         "fixture-parentheses": {
@@ -1268,6 +1280,7 @@
       "additionalProperties": false
     },
     "Flake8QuotesOptions": {
+      "description": "Options for the `flake8-quotes` plugin.",
       "type": "object",
       "properties": {
         "avoid-escape": {
@@ -1314,6 +1327,7 @@
       "additionalProperties": false
     },
     "Flake8SelfOptions": {
+      "description": "Options for the `flake8_self` plugin.",
       "type": "object",
       "properties": {
         "extend-ignore-names": {
@@ -1340,6 +1354,7 @@
       "additionalProperties": false
     },
     "Flake8TidyImportsOptions": {
+      "description": "Options for the `flake8-tidy-imports` plugin",
       "type": "object",
       "properties": {
         "ban-relative-imports": {
@@ -1377,6 +1392,7 @@
       "additionalProperties": false
     },
     "Flake8TypeCheckingOptions": {
+      "description": "Options for the `flake8-type-checking` plugin",
       "type": "object",
       "properties": {
         "exempt-modules": {
@@ -1427,6 +1443,7 @@
       "additionalProperties": false
     },
     "Flake8UnusedArgumentsOptions": {
+      "description": "Options for the `flake8-unused-arguments` plugin",
       "type": "object",
       "properties": {
         "ignore-variadic-names": {
@@ -1566,6 +1583,7 @@
       "minimum": 1.0
     },
     "IsortOptions": {
+      "description": "Options for the `isort` plugin.",
       "type": "object",
       "properties": {
         "case-sensitive": {
@@ -2406,6 +2424,7 @@
       "additionalProperties": false
     },
     "McCabeOptions": {
+      "description": "Options for the `mccabe` plugin.",
       "type": "object",
       "properties": {
         "max-complexity": {
@@ -2463,6 +2482,7 @@
       ]
     },
     "Pep8NamingOptions": {
+      "description": "Options for the `pep8-naming` plugin.",
       "type": "object",
       "properties": {
         "classmethod-decorators": {
@@ -2509,6 +2529,7 @@
       "additionalProperties": false
     },
     "PyUpgradeOptions": {
+      "description": "Options for the `pyupgrade` plugin.",
       "type": "object",
       "properties": {
         "keep-runtime-typing": {
@@ -2522,6 +2543,7 @@
       "additionalProperties": false
     },
     "PycodestyleOptions": {
+      "description": "Options for the `pycodestyle` plugin.",
       "type": "object",
       "properties": {
         "ignore-overlong-task-comments": {
@@ -2557,6 +2579,7 @@
       "additionalProperties": false
     },
     "PydoclintOptions": {
+      "description": "Options for the `pydoclint` plugin.",
       "type": "object",
       "properties": {
         "ignore-one-line-docstrings": {
@@ -2570,6 +2593,7 @@
       "additionalProperties": false
     },
     "PydocstyleOptions": {
+      "description": "Options for the `pydocstyle` plugin.",
       "type": "object",
       "properties": {
         "convention": {
@@ -2614,6 +2638,7 @@
       "additionalProperties": false
     },
     "PyflakesOptions": {
+      "description": "Options for the `pyflakes` plugin.",
       "type": "object",
       "properties": {
         "allowed-unused-imports": {
@@ -2640,6 +2665,7 @@
       "additionalProperties": false
     },
     "PylintOptions": {
+      "description": "Options for the `pylint` plugin.",
       "type": "object",
       "properties": {
         "allow-dunder-method-names": {
@@ -2807,6 +2833,7 @@
       "type": "string"
     },
     "RuffOptions": {
+      "description": "Options for the `ruff` plugin",
       "type": "object",
       "properties": {
         "allowed-markup-calls": {


### PR DESCRIPTION
## Summary

As promised in #15603 - the **highly** sophisticated change - adding missing config docstrings that are used in command completions.

## Test Plan

I actually made a local change to emit all empty items and verified there are none now, before opening the PR.
