### PR TITLE
[`formatter`] do not emit warnings that the formatter conflicts with rule `missing-trailing-comma` if no conflicts

### DIFF
--- a/crates/ruff/src/commands/format.rs
+++ b/crates/ruff/src/commands/format.rs
@@ -787,7 +787,7 @@ pub(super) fn warn_incompatible_formatter_settings(resolver: &Resolver) {
     // First, collect all rules that are incompatible regardless of the linter-specific settings.
     let mut incompatible_rules = FxHashSet::default();
     for setting in resolver.settings() {
-        for rule in [
+        for (rule, is_conflicting) in [
             // Flags missing trailing commas when all arguments are on its own line:
             // ```python
             // def args(
@@ -795,11 +795,14 @@ pub(super) fn warn_incompatible_formatter_settings(resolver: &Resolver) {
             // ):
             //     pass
             // ```
-            Rule::MissingTrailingComma,
+            (
+                Rule::MissingTrailingComma,                         // adds trailing commas
+                setting.formatter.magic_trailing_comma.is_ignore(), // ignores trailing commas
+            ),
             // The formatter always removes blank lines before the docstring.
-            Rule::IncorrectBlankLineBeforeClass,
+            (Rule::IncorrectBlankLineBeforeClass, true),
         ] {
-            if setting.linter.rules.enabled(rule) {
+            if is_conflicting && setting.linter.rules.enabled(rule) {
                 incompatible_rules.insert(rule);
             }
         }

--- a/crates/ruff/tests/format.rs
+++ b/crates/ruff/tests/format.rs
@@ -783,7 +783,6 @@ if condition:
     	print('Should change quotes')
 
     ----- stderr -----
-    warning: The following rule may cause conflicts when used with the formatter: `COM812`. To avoid unexpected behavior, we recommend disabling this rule, either by removing it from the `select` or `extend-select` configuration, or adding it to the `ignore` configuration.
     "#);
     Ok(())
 }
@@ -1118,7 +1117,6 @@ def say_hy(name: str):
     ----- stderr -----
     warning: `incorrect-blank-line-before-class` (D203) and `no-blank-line-before-class` (D211) are incompatible. Ignoring `incorrect-blank-line-before-class`.
     warning: `multi-line-summary-first-line` (D212) and `multi-line-summary-second-line` (D213) are incompatible. Ignoring `multi-line-summary-second-line`.
-    warning: The following rule may cause conflicts when used with the formatter: `COM812`. To avoid unexpected behavior, we recommend disabling this rule, either by removing it from the `select` or `extend-select` configuration, or adding it to the `ignore` configuration.
     ");
     Ok(())
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Only emit a warning if the formatter's setting [skip-magic-trailing-comma](https://docs.astral.sh/ruff/settings/#format_skip-magic-trailing-comma) is conflicting with the linter rule [missing-trailing-comma (COM812)](https://docs.astral.sh/ruff/rules/missing-trailing-comma/#missing-trailing-comma-com812).

The following settings can co-exist with each other.

```toml
[lint]
select = [
    "COM",  # flake8-commas
]

[formatter]
skip-magic-trailing-comma = false  # the default value
```

## Test Plan

<!-- How was it tested? -->

CI