### PR TITLE
[red-knot] Extend instance-attribute tests

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/attributes.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/attributes.md
@@ -330,7 +330,10 @@ class Base:
         self.defined_in_init: str | None = "value in base"
 
 class Intermediate(Base):
-    # TODO: This should be an error
+    # TODO: Mypy does not report an error here, but pyright does:
+    # "… overrides symbol of same name in class "Base". Variable is mutable so its type is invariant"
+    # We should introduce a diagnostic for this. Whether or not that should be enabled by default can
+    # still be discussed.
     can_not_be_redeclared: str = "a"
 
     def __init__(self) -> None:


### PR DESCRIPTION
## Summary

When we discussed the plan on how to proceed with instance attributes, we said that we should first extend our research into the behavior of existing type checkers. The result of this research is summarized in the newly added / modified tests in this PR. The TODO comments align with existing behavior of other type checkers. If we deviate from the behavior, it is described in a comment.

