### PR TITLE
[red-knot] Implicit instance attributes

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/attributes.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/attributes.md
@@ -359,7 +359,11 @@ reveal_type(C().declared_and_bound)  # revealed: Unknown
 ```py
 class C:
     def __init__(self) -> None:
-        if 2 + 3 < 4:
+        # We use a "significantly complex" condition here (instead of just `False`)
+        # for a proper comparison with mypy and pyright, which distinguish between
+        # conditions that can be resolved from a simple pattern matching and those
+        # that need proper type inference.
+        if (2 + 3) < 4:
             self.x: str = "a"
 
 # TODO: Ideally, this would result in a `unresolved-attribute` error. But mypy and pyright

--- a/crates/red_knot_python_semantic/resources/mdtest/attributes.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/attributes.md
@@ -235,25 +235,33 @@ def returns_tuple() -> tuple[int, str]:
     return (1, "a")
 
 class C:
+    a1, b1 = (1, "a")
+    c1, d1 = returns_tuple()
+
     def __init__(self) -> None:
-        self.a, self.b = (1, "a")
-        self.x, self.y = returns_tuple()
+        self.a2, self.b2 = (1, "a")
+        self.c2, self.d2 = returns_tuple()
 
 c_instance = C()
 
+reveal_type(c_instance.a1)  # revealed: Unknown | Literal[1]
+reveal_type(c_instance.b1)  # revealed: Unknown | Literal["a"]
+reveal_type(c_instance.c1)  # revealed: Unknown | int
+reveal_type(c_instance.d1)  # revealed: Unknown | str
+
 # TODO: This should be supported (no error; type should be: `Unknown | Literal[1]`)
 # error: [unresolved-attribute]
-reveal_type(c_instance.a)  # revealed: Unknown
+reveal_type(c_instance.a2)  # revealed: Unknown
 
 # TODO: This should be supported (no error; type should be: `Unknown | Literal["a"]`)
 # error: [unresolved-attribute]
-reveal_type(c_instance.b)  # revealed: Unknown
+reveal_type(c_instance.b2)  # revealed: Unknown
 
-# TODO: Similar for these two (should be `int` and `str`, respectively)
+# TODO: Similar for these two (should be `Unknown | int` and `Unknown | str`, respectively)
 # error: [unresolved-attribute]
-reveal_type(c_instance.x)  # revealed: Unknown
+reveal_type(c_instance.c2)  # revealed: Unknown
 # error: [unresolved-attribute]
-reveal_type(c_instance.y)  # revealed: Unknown
+reveal_type(c_instance.d2)  # revealed: Unknown
 ```
 
 #### Attributes defined in for-loop (unpacking)

--- a/crates/red_knot_python_semantic/resources/mdtest/attributes.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/attributes.md
@@ -25,25 +25,21 @@ class C:
 
 c_instance = C(1)
 
-# TODO: Mypy/pyright infer `int | str` here. We want this to be `Unknown | Literal[1, "a"]`
-reveal_type(c_instance.inferred_from_value)  # revealed: @Todo(implicit instance attribute)
+reveal_type(c_instance.inferred_from_value)  # revealed: Unknown | Literal[1, "a"]
 
 # TODO: Same here. This should be `Unknown | Literal[1, "a"]`
-reveal_type(c_instance.inferred_from_other_attribute)  # revealed: @Todo(implicit instance attribute)
+reveal_type(c_instance.inferred_from_other_attribute)  # revealed: Unknown
 
 # TODO: should be `int | None`
-reveal_type(c_instance.inferred_from_param)  # revealed: @Todo(implicit instance attribute)
+reveal_type(c_instance.inferred_from_param)  # revealed: Unknown | int | None
 
-# TODO: should be `bytes`
-reveal_type(c_instance.declared_only)  # revealed: @Todo(implicit instance attribute)
+reveal_type(c_instance.declared_only)  # revealed: bytes
 
-# TODO: should be `bool`
-reveal_type(c_instance.declared_and_bound)  # revealed: @Todo(implicit instance attribute)
+reveal_type(c_instance.declared_and_bound)  # revealed: bool
 
-# TODO: should be `str`
 # We probably don't want to emit a diagnostic for this being possibly undeclared/unbound.
 # mypy and pyright do not show an error here.
-reveal_type(c_instance.possibly_undeclared_unbound)  # revealed: @Todo(implicit instance attribute)
+reveal_type(c_instance.possibly_undeclared_unbound)  # revealed: str
 
 # This assignment is fine, as we infer `Unknown | Literal[1, "a"]` for `inferred_from_value`.
 c_instance.inferred_from_value = "value set on instance"
@@ -71,7 +67,7 @@ c_instance.declared_and_bound = False
 # in general (we don't know what else happened to `c_instance` between the assignment and the use
 # here), but mypy and pyright support this. In conclusion, this could be `bool` but should probably
 # be `Literal[False]`.
-reveal_type(c_instance.declared_and_bound)  # revealed: @Todo(implicit instance attribute)
+reveal_type(c_instance.declared_and_bound)  # revealed: bool
 ```
 
 #### Variable declared in class body and possibly bound in `__init__`
@@ -124,7 +120,44 @@ reveal_type(C.only_declared)  # revealed: str
 C.only_declared = "overwritten on class"
 ```
 
-#### Variable only defined in unrelated method
+#### Mixed declarations/bindings in class body and `__init__`
+
+```py
+class C:
+    only_declared_in_body: str | None
+    declared_in_body_and_init: str | None
+
+    declared_in_body_defined_in_init: str | None
+
+    bound_in_body_declared_in_init = "a"
+
+    bound_in_body_and_init = None
+
+    def __init__(self, flag) -> None:
+        self.only_declared_in_init: str | None
+        self.declared_in_body_and_init: str | None = None
+
+        self.declared_in_body_defined_in_init = "a"
+
+        self.bound_in_body_declared_in_init: str | None
+
+        if flag:
+            self.bound_in_body_and_init = "a"
+
+c_instance = C(True)
+
+reveal_type(c_instance.only_declared_in_body)  # revealed: str | None
+reveal_type(c_instance.only_declared_in_init)  # revealed: str | None
+reveal_type(c_instance.declared_in_body_and_init)  # revealed: str | None
+
+reveal_type(c_instance.declared_in_body_defined_in_init)  # revealed: str | None
+
+reveal_type(c_instance.bound_in_body_declared_in_init)  # revealed: str | None
+
+reveal_type(c_instance.bound_in_body_and_init)  # revealed: Unknown | None | Literal["a"]
+```
+
+#### Variable defined in non-`__init__` method
 
 We also recognize pure instance variables if they are defined in a method that is not `__init__`.
 
@@ -143,20 +176,17 @@ class C:
 
 c_instance = C(1)
 
-# TODO: Should be `Unknown | Literal[1, "a"]`
-reveal_type(c_instance.inferred_from_value)  # revealed: @Todo(implicit instance attribute)
+reveal_type(c_instance.inferred_from_value)  # revealed: Unknown | Literal[1, "a"]
 
 # TODO: Should be `Unknown | Literal[1, "a"]`
-reveal_type(c_instance.inferred_from_other_attribute)  # revealed: @Todo(implicit instance attribute)
+reveal_type(c_instance.inferred_from_other_attribute)  # revealed: Unknown
 
 # TODO: Should be `int | None`
-reveal_type(c_instance.inferred_from_param)  # revealed: @Todo(implicit instance attribute)
+reveal_type(c_instance.inferred_from_param)  # revealed: Unknown | int | None
 
-# TODO: Should be `bytes`
-reveal_type(c_instance.declared_only)  # revealed: @Todo(implicit instance attribute)
+reveal_type(c_instance.declared_only)  # revealed: bytes
 
-# TODO: Should be `bool`
-reveal_type(c_instance.declared_and_bound)  # revealed: @Todo(implicit instance attribute)
+reveal_type(c_instance.declared_and_bound)  # revealed: bool
 
 # TODO: We already show an error here, but the message might be improved?
 # error: [unresolved-attribute]
@@ -164,6 +194,130 @@ reveal_type(C.inferred_from_value)  # revealed: Unknown
 
 # TODO: this should be an error
 C.inferred_from_value = "overwritten on class"
+```
+
+#### Variable defined in multiple methods
+
+If we see multiple un-annotated assignments to a single attribute (`self.x` below), we build the
+union of all inferred types (and `Unknown`). If we see multiple conflicting declarations of the same
+attribute, that should be an error.
+
+```py
+def get_int() -> int:
+    return 0
+
+def get_str() -> str:
+    return "a"
+
+class C:
+    def __init__(self) -> None:
+        self.x = get_int()
+        self.y: int = 1
+
+    def other_method(self):
+        self.x = get_str()
+
+        # TODO: this redeclaration should be an error
+        self.y: str = "a"
+
+c_instance = C()
+
+reveal_type(c_instance.x)  # revealed: Unknown | int | str
+
+# TODO: We should probably infer `int | str` here.
+reveal_type(c_instance.y)  # revealed: int
+```
+
+#### Attributes defined in tuple unpackings
+
+```py
+def returns_tuple() -> tuple[int, str]:
+    return (1, "a")
+
+class C:
+    def __init__(self) -> None:
+        self.a, self.b = (1, "a")
+        self.x, self.y = returns_tuple()
+
+c_instance = C()
+
+# TODO: This should be supported (no error; type should be: `Unknown | Literal[1]`)
+# error: [unresolved-attribute]
+reveal_type(c_instance.a)  # revealed: Unknown
+
+# TODO: This should be supported (no error; type should be: `Unknown | Literal["a"]`)
+# error: [unresolved-attribute]
+reveal_type(c_instance.b)  # revealed: Unknown
+
+# TODO: Similar for these two (should be `int` and `str`, respectively)
+# error: [unresolved-attribute]
+reveal_type(c_instance.x)  # revealed: Unknown
+# error: [unresolved-attribute]
+reveal_type(c_instance.y)  # revealed: Unknown
+```
+
+#### Attributes defined in for-loop (unpacking)
+
+```py
+class IntIterator:
+    def __next__(self) -> int:
+        return 1
+
+class IntIterable:
+    def __iter__(self) -> IntIterator:
+        return IntIterator()
+
+class TupleIterator:
+    def __next__(self) -> tuple[int, str]:
+        return (1, "a")
+
+class TupleIterable:
+    def __iter__(self) -> TupleIterator:
+        return TupleIterator()
+
+class C:
+    def __init__(self):
+        for self.x in IntIterable():
+            pass
+
+        for _, self.y in TupleIterable():
+            pass
+
+# TODO: Pyright fully supports these, mypy detects the presence of the attributes,
+# but infers type `Any` for both of them. We should infer `int` and `str` here:
+
+# error: [unresolved-attribute]
+reveal_type(C().x)  # revealed: Unknown
+
+# error: [unresolved-attribute]
+reveal_type(C().y)  # revealed: Unknown
+```
+
+#### Conditionally declared / bound attributes
+
+We currently do not raise a diagnostic or change behavior if an attribute is only conditionally
+defined. This is consistent with what mypy and pyright do.
+
+```py
+def flag() -> bool:
+    return True
+
+class C:
+    def f(self) -> None:
+        if flag():
+            self.a1: str | None = "a"
+            self.b1 = 1
+    if flag():
+        def f(self) -> None:
+            self.a2: str | None = "a"
+            self.b2 = 1
+
+c_instance = C()
+
+reveal_type(c_instance.a1)  # revealed: str | None
+reveal_type(c_instance.a2)  # revealed: str | None
+reveal_type(c_instance.b1)  # revealed: Unknown | Literal[1]
+reveal_type(c_instance.b2)  # revealed: Unknown | Literal[1]
 ```
 
 #### Methods that does not use `self` as a first parameter
@@ -175,8 +329,7 @@ class C:
     def __init__(this) -> None:
         this.declared_and_bound: str | None = "a"
 
-# TODO: should be `str | None`
-reveal_type(C().declared_and_bound)  # revealed: @Todo(implicit instance attribute)
+reveal_type(C().declared_and_bound)  # revealed: str | None
 ```
 
 #### Aliased `self` parameter
@@ -187,9 +340,24 @@ class C:
         this = self
         this.declared_and_bound: str | None = "a"
 
-# TODO: This would ideally be `str | None`, but mypy/pyright don't support this either,
+# This would ideally be `str | None`, but mypy/pyright don't support this either,
 # so `Unknown` + a diagnostic is also fine.
-reveal_type(C().declared_and_bound)  # revealed: @Todo(implicit instance attribute)
+# error: [unresolved-attribute]
+reveal_type(C().declared_and_bound)  # revealed: Unknown
+```
+
+#### Attributes defined in statically-known-to-be-false branches
+
+```py
+class C:
+    def __init__(self) -> None:
+        if 2 + 3 < 4:
+            self.x: str = "a"
+
+# TODO: Ideally, this would result in a `unresolved-attribute` error. But mypy and pyright
+# do not support this either (for conditions that can only be resolved to `False` in type
+# inference), so it does not seem to be particularly important.
+reveal_type(C().x)  # revealed: str
 ```
 
 ### Pure class variables (`ClassVar`)
@@ -266,7 +434,7 @@ reveal_type(C.pure_class_variable)  # revealed: Unknown
 
 c_instance = C()
 # TODO: should be `Literal["overwritten on class"]`
-reveal_type(c_instance.pure_class_variable)  # revealed: @Todo(implicit instance attribute)
+reveal_type(c_instance.pure_class_variable)  # revealed: Unknown | Literal["value set in class method"]
 
 # TODO: should raise an error.
 c_instance.pure_class_variable = "value set on instance"
@@ -360,8 +528,7 @@ reveal_type(Derived.declared_in_body)  # revealed: int | None
 
 reveal_type(Derived().declared_in_body)  # revealed: int | None
 
-# TODO: Should be `str | None`
-reveal_type(Derived().defined_in_init)  # revealed: @Todo(implicit instance attribute)
+reveal_type(Derived().defined_in_init)  # revealed: str | None
 ```
 
 ## Union of attributes
@@ -644,6 +811,90 @@ All attribute access on literal `bytes` types is currently delegated to `buitins
 ```py
 reveal_type(b"foo".join)  # revealed: @Todo(bound method)
 reveal_type(b"foo".endswith)  # revealed: @Todo(bound method)
+```
+
+## Instance attribute edge cases
+
+### Assignment to attribute that does not correspond to the instance
+
+```py
+class Other:
+    x: int = 1
+
+class C:
+    def __init__(self, other: Other) -> None:
+        other.x = 1
+
+def f(c: C):
+    # error: [unresolved-attribute]
+    reveal_type(c.x)  # revealed: Unknown
+```
+
+### Nested classes
+
+```py
+class Outer:
+    def __init__(self):
+        self.x: int = 1
+
+    class Middle:
+        # has no 'x' attribute
+
+        class Inner:
+            def __init__(self):
+                self.x: str = "a"
+
+reveal_type(Outer().x)  # revealed: int
+
+# error: [unresolved-attribute]
+Outer.Middle().x
+
+reveal_type(Outer.Middle.Inner().x)  # revealed: str
+```
+
+### Shadowing of `self`
+
+```py
+class Other:
+    x: int = 1
+
+class C:
+    def __init__(self) -> None:
+        # Redeclaration of self. `self` does not refer to the instance anymore.
+        self: Other = Other()
+        self.x: int = 1
+
+# TODO: this should be an error
+C().x
+```
+
+### Assignment to `self` after nested function
+
+```py
+class Other:
+    x: str = "a"
+
+class C:
+    def __init__(self) -> None:
+        def nested_function(self: Other):
+            self.x = "b"
+        self.x: int = 1
+
+reveal_type(C().x)  # revealed: int
+```
+
+### Assignment to `self` from nested function
+
+```py
+class C:
+    def __init__(self) -> None:
+        def set_attribute(value: str):
+            self.x: str = value
+        set_attribute("a")
+
+# TODO: ideally, this would be `str`. Mypy supports this, pyright does not.
+# error: [unresolved-attribute]
+reveal_type(C().x)  # revealed: Unknown
 ```
 
 ## References

--- a/crates/red_knot_python_semantic/src/semantic_index.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index.rs
@@ -144,7 +144,8 @@ pub(crate) struct SemanticIndex<'db> {
 
     /// Maps from class body scopes to attribute assignments that were found
     /// in methods of that class.
-    attribute_assignments: FxHashMap<FileScopeId, FxHashMap<String, Vec<AttributeAssignment<'db>>>>,
+    attribute_assignments:
+        FxHashMap<FileScopeId, FxHashMap<&'db str, Vec<AttributeAssignment<'db>>>>,
 }
 
 impl<'db> SemanticIndex<'db> {

--- a/crates/red_knot_python_semantic/src/semantic_index/attribute_assignment.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/attribute_assignment.rs
@@ -1,3 +1,5 @@
+use rustc_hash::FxHashMap;
+
 use crate::semantic_index::expression::Expression;
 
 /// Describes an (annotated) attribute assignment that we discovered in a method
@@ -11,3 +13,5 @@ pub(crate) enum AttributeAssignment<'db> {
     /// An attribute assignment without a type annotation, e.g. `self.x = <value>`.
     Unannotated { value: Expression<'db> },
 }
+
+pub(crate) type AttributeAssignments<'db> = FxHashMap<&'db str, Vec<AttributeAssignment<'db>>>;

--- a/crates/red_knot_python_semantic/src/semantic_index/attribute_assignment.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/attribute_assignment.rs
@@ -1,0 +1,13 @@
+use crate::semantic_index::expression::Expression;
+
+/// Describes an (annotated) attribute assignment that we discovered in a method
+/// body, typically of the form `self.x: int`, `self.x: int = …` or `self.x = …`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum AttributeAssignment<'db> {
+    /// An attribute assignment with an explicit type annotation, either
+    /// `self.x: <annotation>` or `self.x: <annotation> = …`.
+    Annotated { annotation: Expression<'db> },
+
+    /// An attribute assignment without a type annotation, e.g. `self.x = <value>`.
+    Unannotated { value: Expression<'db> },
+}

--- a/crates/red_knot_python_semantic/src/semantic_index/attribute_assignment.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/attribute_assignment.rs
@@ -1,6 +1,8 @@
-use rustc_hash::FxHashMap;
-
 use crate::semantic_index::expression::Expression;
+
+use ruff_python_ast::name::Name;
+
+use rustc_hash::FxHashMap;
 
 /// Describes an (annotated) attribute assignment that we discovered in a method
 /// body, typically of the form `self.x: int`, `self.x: int = …` or `self.x = …`.
@@ -14,4 +16,4 @@ pub(crate) enum AttributeAssignment<'db> {
     Unannotated { value: Expression<'db> },
 }
 
-pub(crate) type AttributeAssignments<'db> = FxHashMap<&'db str, Vec<AttributeAssignment<'db>>>;
+pub(crate) type AttributeAssignments<'db> = FxHashMap<Name, Vec<AttributeAssignment<'db>>>;

--- a/crates/red_knot_python_semantic/src/semantic_index/builder.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/builder.rs
@@ -14,7 +14,7 @@ use crate::ast_node_ref::AstNodeRef;
 use crate::module_name::ModuleName;
 use crate::semantic_index::ast_ids::node_key::ExpressionNodeKey;
 use crate::semantic_index::ast_ids::AstIdsBuilder;
-use crate::semantic_index::attribute_assignment::AttributeAssignment;
+use crate::semantic_index::attribute_assignment::{AttributeAssignment, AttributeAssignments};
 use crate::semantic_index::constraint::PatternConstraintKind;
 use crate::semantic_index::definition::{
     AssignmentDefinitionNodeRef, ComprehensionDefinitionNodeRef, Definition, DefinitionNodeKey,
@@ -92,8 +92,7 @@ pub(super) struct SemanticIndexBuilder<'db> {
     definitions_by_node: FxHashMap<DefinitionNodeKey, Definition<'db>>,
     expressions_by_node: FxHashMap<ExpressionNodeKey, Expression<'db>>,
     imported_modules: FxHashSet<ModuleName>,
-    attribute_assignments:
-        FxHashMap<FileScopeId, FxHashMap<&'db str, Vec<AttributeAssignment<'db>>>>,
+    attribute_assignments: FxHashMap<FileScopeId, AttributeAssignments<'db>>,
 }
 
 impl<'db> SemanticIndexBuilder<'db> {
@@ -744,7 +743,11 @@ impl<'db> SemanticIndexBuilder<'db> {
             use_def_maps,
             imported_modules: Arc::new(self.imported_modules),
             has_future_annotations: self.has_future_annotations,
-            attribute_assignments: self.attribute_assignments,
+            attribute_assignments: self
+                .attribute_assignments
+                .into_iter()
+                .map(|(k, v)| (k, Arc::new(v)))
+                .collect(),
         }
     }
 }

--- a/crates/red_knot_python_semantic/src/semantic_index/builder.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/builder.rs
@@ -457,7 +457,7 @@ impl<'db> SemanticIndexBuilder<'db> {
                 self.attribute_assignments
                     .entry(class_body_scope)
                     .or_default()
-                    .entry(attr.id().as_str())
+                    .entry(attr.id().clone())
                     .or_default()
                     .push(attribute_assignment);
             }

--- a/crates/red_knot_python_semantic/src/semantic_index/expression.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/expression.rs
@@ -5,6 +5,16 @@ use ruff_db::files::File;
 use ruff_python_ast as ast;
 use salsa;
 
+/// Whether or not this expression should be inferred as a normal expression or
+/// a type expression. For example, in `self.x: <annotation> = <value>`, the
+/// `<annotation>` is inferred as a type expression, while `<value>` is inferred
+/// as a normal expression.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) enum ExpressionKind {
+    Normal,
+    TypeExpression,
+}
+
 /// An independently type-inferable expression.
 ///
 /// Includes constraint expressions (e.g. if tests) and the RHS of an unpacking assignment.
@@ -35,12 +45,9 @@ pub(crate) struct Expression<'db> {
     #[return_ref]
     pub(crate) node_ref: AstNodeRef<ast::Expr>,
 
-    /// Whether or not this expression should be inferred as a type expression or
-    /// a normal expression. For example, in `self.x: <annotation> = <value>`, the
-    /// `<annotation>` is inferred as a type expression, while `<value>` is inferred
-    /// as a normal expression.
+    /// Should this expression be inferred as a normal expression or a type expression?
     #[id]
-    pub(crate) infer_as_type_expression: bool,
+    pub(crate) kind: ExpressionKind,
 
     #[no_eq]
     count: countme::Count<Expression<'static>>,

--- a/crates/red_knot_python_semantic/src/semantic_index/expression.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/expression.rs
@@ -35,6 +35,13 @@ pub(crate) struct Expression<'db> {
     #[return_ref]
     pub(crate) node_ref: AstNodeRef<ast::Expr>,
 
+    /// Whether or not this expression should be inferred as a type expression or
+    /// a normal expression. For example, in `self.x: <annotation> = <value>`, the
+    /// `<annotation>` is inferred as a type expression, while `<value>` is inferred
+    /// as a normal expression.
+    #[id]
+    pub(crate) infer_as_type_expression: bool,
+
     #[no_eq]
     count: countme::Count<Expression<'static>>,
 }

--- a/crates/red_knot_python_semantic/src/semantic_index/symbol.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/symbol.rs
@@ -119,6 +119,7 @@ impl<'db> ScopeId<'db> {
             self.node(db).scope_kind(),
             ScopeKind::Annotation
                 | ScopeKind::Function
+                | ScopeKind::Lambda
                 | ScopeKind::TypeAlias
                 | ScopeKind::Comprehension
         )
@@ -203,6 +204,7 @@ pub enum ScopeKind {
     Annotation,
     Class,
     Function,
+    Lambda,
     Comprehension,
     TypeAlias,
 }
@@ -443,7 +445,8 @@ impl NodeWithScopeKind {
         match self {
             Self::Module => ScopeKind::Module,
             Self::Class(_) => ScopeKind::Class,
-            Self::Function(_) | Self::Lambda(_) => ScopeKind::Function,
+            Self::Function(_) => ScopeKind::Function,
+            Self::Lambda(_) => ScopeKind::Lambda,
             Self::FunctionTypeParameters(_)
             | Self::ClassTypeParameters(_)
             | Self::TypeAliasTypeParameters(_) => ScopeKind::Annotation,

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -4147,6 +4147,11 @@ impl<'db> Class<'db> {
         inferred_type_from_class_body: Option<Type<'db>>,
     ) -> Symbol<'db> {
         let index = semantic_index(db, class_body_scope.file(db));
+
+        // If we do not see any declarations of an attribute, neither in the class body nor in
+        // any method, we build a union of `Unknown` with the inferred types of all bindings of
+        // that attribute. We include `Unknown` in that union to account for the fact that the
+        // attribute might be externally modified.
         let mut union_of_inferred_types = UnionBuilder::new(db).add(Type::unknown());
 
         if let Some(ty) = inferred_type_from_class_body {

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -23,6 +23,7 @@ pub use self::subclass_of::SubclassOfType;
 use crate::module_name::ModuleName;
 use crate::module_resolver::{file_to_module, resolve_module, KnownModule};
 use crate::semantic_index::ast_ids::HasScopedExpressionId;
+use crate::semantic_index::attribute_assignment::AttributeAssignment;
 use crate::semantic_index::definition::Definition;
 use crate::semantic_index::symbol::{self as symbol, ScopeId, ScopedSymbolId};
 use crate::semantic_index::{
@@ -4136,7 +4137,66 @@ impl<'db> Class<'db> {
 
         // TODO: The symbol is not present in any class body, but it could be implicitly
         // defined in `__init__` or other methods anywhere in the MRO.
-        todo_type!("implicit instance attribute").into()
+        SymbolAndQualifiers(Symbol::Unbound, TypeQualifiers::empty())
+    }
+
+    /// Tries to find declarations/bindings of an instance attribute named `name` that are only
+    /// "implicitly" defined in a method of the class that corresponds to `class_body_scope`.
+    fn implicit_instance_attribute(
+        db: &'db dyn Db,
+        class_body_scope: ScopeId<'db>,
+        name: &str,
+        inferred_type_from_class_body: Option<Type<'db>>,
+    ) -> Symbol<'db> {
+        let index = semantic_index(db, class_body_scope.file(db));
+        let mut union_of_inferred_types = UnionBuilder::new(db).add(Type::unknown());
+
+        if let Some(ty) = inferred_type_from_class_body {
+            union_of_inferred_types = union_of_inferred_types.add(ty);
+        }
+
+        let Some(attribute_assignments) = index.attribute_assignments(db, class_body_scope, name)
+        else {
+            if inferred_type_from_class_body.is_some() {
+                return union_of_inferred_types.build().into();
+            }
+            return Symbol::Unbound;
+        };
+
+        for attribute_assignment in attribute_assignments {
+            match attribute_assignment {
+                AttributeAssignment::Annotated { annotation } => {
+                    // We found an annotated assignment of one of the following forms (using 'self' in these
+                    // examples, but we support arbitrary names for the first parameters of methods):
+                    //
+                    //     self.name: <annotation>
+                    //     self.name: <annotation> = …
+
+                    let inference = infer_expression_types(db, *annotation);
+                    let expr_scope = annotation.scope(db);
+                    let annotation_ty = inference.expression_type(
+                        annotation.node_ref(db).scoped_expression_id(db, expr_scope),
+                    );
+
+                    // TODO: check if there are conflicting declarations
+                    return annotation_ty.into();
+                }
+                AttributeAssignment::Unannotated { value } => {
+                    // We found an un-annotated attribute assignment of the form:
+                    //
+                    //     self.name = <value>
+
+                    let inference = infer_expression_types(db, *value);
+                    let expr_scope = value.scope(db);
+                    let inferred_ty = inference
+                        .expression_type(value.node_ref(db).scoped_expression_id(db, expr_scope));
+
+                    union_of_inferred_types = union_of_inferred_types.add(inferred_ty);
+                }
+            }
+        }
+
+        union_of_inferred_types.build().into()
     }
 
     /// A helper function for `instance_member` that looks up the `name` attribute only on
@@ -4158,6 +4218,8 @@ impl<'db> Class<'db> {
 
             match symbol_from_declarations(db, declarations) {
                 Ok(SymbolAndQualifiers(Symbol::Type(declared_ty, _), qualifiers)) => {
+                    // The attribute is declared in the class body.
+
                     if let Some(function) = declared_ty.into_function_literal() {
                         // TODO: Eventually, we are going to process all decorators correctly. This is
                         // just a temporary heuristic to provide a broad categorization into properties
@@ -4171,22 +4233,26 @@ impl<'db> Class<'db> {
                         SymbolAndQualifiers(Symbol::Type(declared_ty, Boundness::Bound), qualifiers)
                     }
                 }
-                Ok(symbol @ SymbolAndQualifiers(Symbol::Unbound, qualifiers)) => {
+                Ok(SymbolAndQualifiers(Symbol::Unbound, _)) => {
+                    // The attribute is not *declared* in the class body. It could still be declared
+                    // in a method, and it could also be *bound* in the class body (and/or in a method).
+
                     let bindings = use_def.public_bindings(symbol_id);
                     let inferred = symbol_from_bindings(db, bindings);
+                    let inferred_ty = inferred.ignore_possibly_unbound();
 
-                    SymbolAndQualifiers(
-                        widen_type_for_undeclared_public_symbol(db, inferred, symbol.is_final()),
-                        qualifiers,
-                    )
+                    Self::implicit_instance_attribute(db, body_scope, name, inferred_ty).into()
                 }
                 Err((declared_ty, _conflicting_declarations)) => {
-                    // Ignore conflicting declarations
+                    // There are conflicting declarations for this attribute in the class body.
                     SymbolAndQualifiers(declared_ty.inner_type().into(), declared_ty.qualifiers())
                 }
             }
         } else {
-            Symbol::Unbound.into()
+            // This attribute is neither declared nor bound in the class body.
+            // It could still be implicitly defined in a method.
+
+            Self::implicit_instance_attribute(db, body_scope, name, None).into()
         }
     }
 

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -4135,8 +4135,6 @@ impl<'db> Class<'db> {
             }
         }
 
-        // TODO: The symbol is not present in any class body, but it could be implicitly
-        // defined in `__init__` or other methods anywhere in the MRO.
         SymbolAndQualifiers(Symbol::Unbound, TypeQualifiers::empty())
     }
 

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -44,7 +44,7 @@ use crate::semantic_index::definition::{
     AssignmentDefinitionKind, Definition, DefinitionKind, DefinitionNodeKey,
     ExceptHandlerDefinitionKind, ForStmtDefinitionKind, TargetKind,
 };
-use crate::semantic_index::expression::Expression;
+use crate::semantic_index::expression::{Expression, ExpressionKind};
 use crate::semantic_index::semantic_index;
 use crate::semantic_index::symbol::{NodeWithScopeKind, NodeWithScopeRef, ScopeId};
 use crate::semantic_index::SemanticIndex;
@@ -832,10 +832,13 @@ impl<'db> TypeInferenceBuilder<'db> {
     }
 
     fn infer_region_expression(&mut self, expression: Expression<'db>) {
-        if expression.infer_as_type_expression(self.db()) {
-            self.infer_type_expression(expression.node_ref(self.db()));
-        } else {
-            self.infer_expression_impl(expression.node_ref(self.db()));
+        match expression.kind(self.db()) {
+            ExpressionKind::Normal => {
+                self.infer_expression_impl(expression.node_ref(self.db()));
+            }
+            ExpressionKind::TypeExpression => {
+                self.infer_type_expression(expression.node_ref(self.db()));
+            }
         }
     }
 

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -832,7 +832,11 @@ impl<'db> TypeInferenceBuilder<'db> {
     }
 
     fn infer_region_expression(&mut self, expression: Expression<'db>) {
-        self.infer_expression_impl(expression.node_ref(self.db()));
+        if expression.infer_as_type_expression(self.db()) {
+            self.infer_type_expression(expression.node_ref(self.db()));
+        } else {
+            self.infer_expression_impl(expression.node_ref(self.db()));
+        }
     }
 
     /// Raise a diagnostic if the given type cannot be divided by zero.

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -6026,7 +6026,7 @@ mod tests {
     use crate::types::check_types;
     use ruff_db::files::{system_path_to_file, File};
     use ruff_db::system::DbWithTestSystem;
-    use ruff_db::testing::assert_function_query_was_not_run;
+    use ruff_db::testing::{assert_function_query_was_not_run, assert_function_query_was_run};
 
     use super::*;
 
@@ -6351,6 +6351,86 @@ mod tests {
             first_public_binding(&db, a, "x"),
             &events,
         );
+        Ok(())
+    }
+
+    #[test]
+    fn dependency_implicit_instance_attribute() -> anyhow::Result<()> {
+        fn x_rhs_expression(db: &TestDb) -> Expression<'_> {
+            let file_main = system_path_to_file(db, "/src/main.py").unwrap();
+            let ast = parsed_module(db, file_main);
+            // Get the second statement in `main.py` (x = …) and extract the expression
+            // node on the right-hand side:
+            let x_rhs_node = &ast.syntax().body[1].as_assign_stmt().unwrap().value;
+
+            let index = semantic_index(db, file_main);
+            index.expression(x_rhs_node.as_ref())
+        }
+
+        let mut db = setup_db();
+
+        db.write_dedented(
+            "/src/mod.py",
+            r#"
+            class C:
+                def f(self):
+                    self.attr: int | None = None
+            "#,
+        )?;
+        db.write_dedented(
+            "/src/main.py",
+            r#"
+            from mod import C
+            x = C().attr
+            "#,
+        )?;
+
+        let file_main = system_path_to_file(&db, "/src/main.py").unwrap();
+        let attr_ty = global_symbol(&db, file_main, "x").expect_type();
+        assert_eq!(attr_ty.display(&db).to_string(), "Unknown | int | None");
+
+        // Change the type of `attr` to `str | None`; this should trigger the type of `x` to be re-inferred
+        db.write_dedented(
+            "/src/mod.py",
+            r#"
+            class C:
+                def f(self):
+                    self.attr: str | None = None
+            "#,
+        )?;
+
+        let events = {
+            db.clear_salsa_events();
+            let attr_ty = global_symbol(&db, file_main, "x").expect_type();
+            assert_eq!(attr_ty.display(&db).to_string(), "Unknown | str | None");
+            db.take_salsa_events()
+        };
+        assert_function_query_was_run(&db, infer_expression_types, x_rhs_expression(&db), &events);
+
+        // Add a comment; this should not trigger the type of `x` to be re-inferred
+        db.write_dedented(
+            "/src/mod.py",
+            r#"
+            class C:
+                def f(self):
+                    # a comment!
+                    self.attr: str | None = None
+            "#,
+        )?;
+
+        let events = {
+            db.clear_salsa_events();
+            let attr_ty = global_symbol(&db, file_main, "x").expect_type();
+            assert_eq!(attr_ty.display(&db).to_string(), "Unknown | str | None");
+            db.take_salsa_events()
+        };
+        assert_function_query_was_not_run(
+            &db,
+            infer_expression_types,
+            x_rhs_expression(&db),
+            &events,
+        );
+
         Ok(())
     }
 }


### PR DESCRIPTION
## Summary

Add support for implicitly-defined instance attributes, i.e. support type inference for cases like this:
```py
class C:
    def __init__(self) -> None:
        self.x: int = 1
        self.y = None

reveal_type(C().x)  # int
reveal_type(C().y)  # Unknown | None
```

A lot of things have been intentionally left out of this PR:
* Type inference for `self`
* Support attributes which are implicitly "declared" via their parameter types (`self.x = param`)
* Tuple-unpacking attribute assignments: `self.x, self.y = …`
* Diagnostic for conflicting declared types
* Attributes in statically-known-to-be-false branches are still visible:
   ```py
   class C:
       def __init__(self) -> None:
           if 2 + 3 < 4:
               self.x: str = "a"

   # # TODO: Ideally, this would result in a `unresolved-attribute` error. But mypy and pyright
   # do not support this either (for conditions that can only be resolved to `False` in type
   # inference), so it does not seem to be particularly important.
   reveal_type(C().x)  # revealed: str
   ```

## Benchmarks

Codspeed reports no change in a cold-cache benchmark, and a -1% regression in the incremental benchmark. On `black`'s `src` folder, I don't see a statistically significant difference between the branches (Reminder to self: always set the CPU frequency scaling governor to `performance` when benchmarking on a laptop):

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `./red_knot_main check --project /home/shark/black/src` | 133.7 ± 9.5 | 126.7 | 164.7 | 1.01 ± 0.08 |
| `./red_knot_feature check --project /home/shark/black/src` | 132.2 ± 5.1 | 118.1 | 140.9 | 1.00 |

## Test Plan

Updated and new Markdown tests