### PR TITLE
Remove semicolon after TypeScript interface definition

### DIFF
--- a/crates/ruff_wasm/src/lib.rs
+++ b/crates/ruff_wasm/src/lib.rs
@@ -53,7 +53,7 @@ export interface Diagnostic {
             };
         }[];
     } | null;
-};
+}
 "#;
 
 #[derive(Serialize, Deserialize, Eq, PartialEq, Debug)]


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

This PR removes a trailing semicolon after an interface definition in the custom TypeScript section of `ruff_wasm`.  Currently, this semicolon triggers the error "TS1036: Statements are not allowed in ambient contexts" when including the file and compiling with e.g `tsc`.

## Test Plan

I made the change, ran `wasm-pack` and copied the generated directory manually to my `node_modules` folder. I then compiled a file importing `@astral-sh/ruff-wasm-web` again and confirmed that the compilation error was gone.
