### PR TITLE
[`flake8-comprehensions`] Handle builtins at top of file correctly for `unnecessary-dict-comprehension-for-iterable` (`C420`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_comprehensions/C420_1.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_comprehensions/C420_1.py
@@ -1,0 +1,7 @@
+{x: NotImplemented for x in "XY"}
+
+
+# Builtin bindings are placed at top of file, but should not count as
+# an "expression defined within the comprehension". So the above
+# should trigger C420
+# See https://github.com/astral-sh/ruff/issues/15830

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/mod.rs
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/mod.rs
@@ -22,6 +22,7 @@ mod tests {
     #[test_case(Rule::UnnecessaryComprehensionInCall, Path::new("C419.py"))]
     #[test_case(Rule::UnnecessaryComprehensionInCall, Path::new("C419_2.py"))]
     #[test_case(Rule::UnnecessaryDictComprehensionForIterable, Path::new("C420.py"))]
+    #[test_case(Rule::UnnecessaryDictComprehensionForIterable, Path::new("C420_1.py"))]
     #[test_case(Rule::UnnecessaryDoubleCastOrProcess, Path::new("C414.py"))]
     #[test_case(Rule::UnnecessaryGeneratorDict, Path::new("C402.py"))]
     #[test_case(Rule::UnnecessaryGeneratorList, Path::new("C400.py"))]

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_dict_comprehension_for_iterable.rs
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_dict_comprehension_for_iterable.rs
@@ -99,6 +99,10 @@ pub(crate) fn unnecessary_dict_comprehension_for_iterable(
 
         let binding = checker.semantic().binding(id);
 
+        if binding.kind.is_builtin() {
+            return false;
+        }
+
         dict_comp.range().contains_range(binding.range())
     });
     if self_referential {

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/snapshots/ruff_linter__rules__flake8_comprehensions__tests__C420_C420_1.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/snapshots/ruff_linter__rules__flake8_comprehensions__tests__C420_C420_1.py.snap
@@ -1,0 +1,16 @@
+---
+source: crates/ruff_linter/src/rules/flake8_comprehensions/mod.rs
+---
+C420_1.py:1:1: C420 [*] Unnecessary dict comprehension for iterable; use `dict.fromkeys` instead
+  |
+1 | {x: NotImplemented for x in "XY"}
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ C420
+  |
+  = help: Replace with `dict.fromkeys(iterable)`)
+
+ℹ Safe fix
+1   |-{x: NotImplemented for x in "XY"}
+  1 |+dict.fromkeys("XY", NotImplemented)
+2 2 | 
+3 3 | 
+4 4 | # Builtin bindings are placed at top of file, but should not count as


### PR DESCRIPTION
Builtin bindings are given a range of `0..0`, which causes strange behavior when range checks are made at the top of the file. In this case, the logic of the rule demands that the value of the dict comprehension is not self-referential (i.e. it does not contain definitions for any of the variables used within it). This logic was confused by builtins which looked like they were defined "in the comprehension", if the comprehension appeared at the top of the file.

Closes #15830