### PR TITLE
[red-knot] Should A ∧ !A always be false?

### DIFF
--- a/crates/red_knot_python_semantic/src/semantic_index/builder.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/builder.rs
@@ -365,7 +365,7 @@ impl<'db> SemanticIndexBuilder<'db> {
         constraint: Constraint<'db>,
     ) -> ScopedVisibilityConstraintId {
         self.current_use_def_map_mut()
-            .record_visibility_constraint(VisibilityConstraint::VisibleIf(constraint))
+            .record_visibility_constraint(VisibilityConstraint::VisibleIf(constraint.into()))
     }
 
     /// Records that all remaining statements in the current block are unreachable, and therefore
@@ -1523,8 +1523,9 @@ where
                             ast::BoolOp::And => (constraint, self.add_constraint(constraint)),
                             ast::BoolOp::Or => self.add_negated_constraint(constraint),
                         };
-                        let visibility_constraint = self
-                            .add_visibility_constraint(VisibilityConstraint::VisibleIf(constraint));
+                        let visibility_constraint = self.add_visibility_constraint(
+                            VisibilityConstraint::VisibleIf(constraint.into()),
+                        );
 
                         let after_expr = self.flow_snapshot();
 

--- a/crates/red_knot_python_semantic/src/semantic_index/builder.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/builder.rs
@@ -29,7 +29,7 @@ use crate::semantic_index::use_def::{
 };
 use crate::semantic_index::SemanticIndex;
 use crate::unpack::{Unpack, UnpackValue};
-use crate::visibility_constraints::{VisibilityConstraint, VisibilityConstraintAtom};
+use crate::visibility_constraints::VisibilityConstraint;
 use crate::Db;
 
 use super::constraint::{Constraint, ConstraintNode, PatternConstraint};
@@ -365,7 +365,7 @@ impl<'db> SemanticIndexBuilder<'db> {
         constraint: Constraint<'db>,
     ) -> ScopedVisibilityConstraintId {
         self.current_use_def_map_mut()
-            .record_visibility_constraint(VisibilityConstraint::VisibleIf(constraint.into()))
+            .record_visibility_constraint(VisibilityConstraint::VisibleIf(constraint, 0))
     }
 
     /// Records that all remaining statements in the current block are unreachable, and therefore
@@ -974,13 +974,9 @@ where
                 // since we need to model situations where the first evaluation of the condition
                 // returns True, but a later evaluation returns False.
                 let first_vis_constraint_id =
-                    self.add_visibility_constraint(VisibilityConstraint::VisibleIf(
-                        VisibilityConstraintAtom::new_copy(constraint, 0),
-                    ));
+                    self.add_visibility_constraint(VisibilityConstraint::VisibleIf(constraint, 0));
                 let later_vis_constraint_id =
-                    self.add_visibility_constraint(VisibilityConstraint::VisibleIf(
-                        VisibilityConstraintAtom::new_copy(constraint, 1),
-                    ));
+                    self.add_visibility_constraint(VisibilityConstraint::VisibleIf(constraint, 1));
 
                 // Save aside any break states from an outer loop
                 let saved_break_states = std::mem::take(&mut self.loop_break_states);
@@ -1552,7 +1548,7 @@ where
                             ast::BoolOp::Or => self.add_negated_constraint(constraint),
                         };
                         let visibility_constraint = self.add_visibility_constraint(
-                            VisibilityConstraint::VisibleIf(constraint.into()),
+                            VisibilityConstraint::VisibleIf(constraint, 0),
                         );
 
                         let after_expr = self.flow_snapshot();

--- a/crates/red_knot_python_semantic/src/semantic_index/use_def.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/use_def.rs
@@ -488,7 +488,7 @@ pub(super) struct UseDefMapBuilder<'db> {
     all_constraints: AllConstraints<'db>,
 
     /// Append-only array of [`VisibilityConstraint`].
-    visibility_constraints: VisibilityConstraints<'db>,
+    pub(super) visibility_constraints: VisibilityConstraints<'db>,
 
     /// A constraint which describes the visibility of the unbound/undeclared state, i.e.
     /// whether or not the start of the scope is visible. This is important for cases like

--- a/crates/red_knot_python_semantic/src/semantic_index/use_def.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/use_def.rs
@@ -488,7 +488,7 @@ pub(super) struct UseDefMapBuilder<'db> {
     all_constraints: AllConstraints<'db>,
 
     /// Append-only array of [`VisibilityConstraint`].
-    pub(super) visibility_constraints: VisibilityConstraints<'db>,
+    visibility_constraints: VisibilityConstraints<'db>,
 
     /// A constraint which describes the visibility of the unbound/undeclared state, i.e.
     /// whether or not the start of the scope is visible. This is important for cases like

--- a/crates/red_knot_python_semantic/src/visibility_constraints.rs
+++ b/crates/red_knot_python_semantic/src/visibility_constraints.rs
@@ -187,30 +187,10 @@ const MAX_RECURSION_DEPTH: usize = 24;
 pub(crate) enum VisibilityConstraint<'db> {
     AlwaysTrue,
     Ambiguous,
-    VisibleIf(VisibilityConstraintAtom<'db>),
+    VisibleIf(Constraint<'db>, u8),
     VisibleIfNot(ScopedVisibilityConstraintId),
     KleeneAnd(ScopedVisibilityConstraintId, ScopedVisibilityConstraintId),
     KleeneOr(ScopedVisibilityConstraintId, ScopedVisibilityConstraintId),
-}
-
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub(crate) struct VisibilityConstraintAtom<'db> {
-    /// The [`Constraint`] that is evaluated
-    constraint: Constraint<'db>,
-    /// Disambiguates different atoms that evaluate the same constraint
-    copy: u8,
-}
-
-impl<'db> From<Constraint<'db>> for VisibilityConstraintAtom<'db> {
-    fn from(constraint: Constraint<'db>) -> VisibilityConstraintAtom<'db> {
-        VisibilityConstraintAtom::new_copy(constraint, 0)
-    }
-}
-
-impl<'db> VisibilityConstraintAtom<'db> {
-    pub(crate) fn new_copy(constraint: Constraint<'db>, copy: u8) -> VisibilityConstraintAtom<'db> {
-        VisibilityConstraintAtom { constraint, copy }
-    }
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -290,7 +270,7 @@ impl<'db> VisibilityConstraints<'db> {
         match visibility_constraint {
             VisibilityConstraint::AlwaysTrue => Truthiness::AlwaysTrue,
             VisibilityConstraint::Ambiguous => Truthiness::Ambiguous,
-            VisibilityConstraint::VisibleIf(atom) => Self::analyze_single(db, &atom.constraint),
+            VisibilityConstraint::VisibleIf(constraint, _) => Self::analyze_single(db, constraint),
             VisibilityConstraint::VisibleIfNot(negated) => {
                 self.evaluate_impl(db, *negated, max_depth - 1).negate()
             }

--- a/crates/red_knot_python_semantic/src/visibility_constraints.rs
+++ b/crates/red_knot_python_semantic/src/visibility_constraints.rs
@@ -221,11 +221,18 @@ impl<'db> VisibilityConstraints<'db> {
         b: ScopedVisibilityConstraintId,
     ) -> ScopedVisibilityConstraintId {
         if a == ScopedVisibilityConstraintId::ALWAYS_TRUE {
-            b
+            return b;
         } else if b == ScopedVisibilityConstraintId::ALWAYS_TRUE {
-            a
-        } else {
-            self.add(VisibilityConstraint::KleeneAnd(a, b))
+            return a;
+        }
+        match (&self.constraints[a], &self.constraints[b]) {
+            (_, VisibilityConstraint::VisibleIfNot(id)) if a == *id => self.add(
+                VisibilityConstraint::VisibleIfNot(ScopedVisibilityConstraintId::ALWAYS_TRUE),
+            ),
+            (VisibilityConstraint::VisibleIfNot(id), _) if *id == b => self.add(
+                VisibilityConstraint::VisibleIfNot(ScopedVisibilityConstraintId::ALWAYS_TRUE),
+            ),
+            _ => self.add(VisibilityConstraint::KleeneAnd(a, b)),
         }
     }
 


### PR DESCRIPTION
This mimics a simplification we have on the OR side, where we simplify `A ∨ !A` to true.  This requires changes to how we add `while` statements to the semantic index, since we now need distinct `VisibilityConstraint`s if we need to model evaluating a `Constraint` multiple times at different points in the execution of the program.