### PR TITLE
[red-knot] Fix Stack overflow in Type::bool 

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/type_properties/truthiness.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/type_properties/truthiness.md
@@ -1,5 +1,7 @@
 # Truthiness
 
+## Literals
+
 ```py
 from typing_extensions import Literal, LiteralString
 from knot_extensions import AlwaysFalsy, AlwaysTruthy
@@ -44,4 +46,28 @@ def _(
     reveal_type(bool(b))  # revealed: bool
     reveal_type(bool(c))  # revealed: bool
     reveal_type(bool(d))  # revealed: bool
+```
+
+## Instances
+
+```py
+# We don't get into a cycle if someone sets their `__bool__` method to the `bool` builtin:
+class BoolIsBool:
+    __bool__ = bool
+
+# TODO: when bool is used as a method, it is called without arguments and always returns False, but this is not yet implemented
+# see https://github.com/astral-sh/ruff/issues/15672
+
+reveal_type(bool(BoolIsBool()))  # revealed: bool
+
+def flag() -> bool:
+    return True
+
+class Boom:
+    if flag():
+        __bool__ = bool
+    else:
+        __bool__ = int
+
+reveal_type(bool(Boom()))  # revealed: bool
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/type_properties/truthiness.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/type_properties/truthiness.md
@@ -50,16 +50,20 @@ def _(
 
 ## Instances
 
+Checks that we don't get into a cycle if someone sets their `__bool__` method to the `bool` builtin:
+
+### __bool__ is bool
+
 ```py
-# We don't get into a cycle if someone sets their `__bool__` method to the `bool` builtin:
 class BoolIsBool:
     __bool__ = bool
 
-# TODO: when bool is used as a method, it is called without arguments and always returns False, but this is not yet implemented
-# see https://github.com/astral-sh/ruff/issues/15672
-
 reveal_type(bool(BoolIsBool()))  # revealed: bool
+```
 
+### Conditional __bool__ method
+
+```py
 def flag() -> bool:
     return True
 

--- a/crates/red_knot_python_semantic/resources/mdtest/unary/not.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/unary/not.md
@@ -139,10 +139,9 @@ reveal_type(not AlwaysFalse())
 
 # We don't get into a cycle if someone sets their `__bool__` method to the `bool` builtin:
 class BoolIsBool:
-    # TODO: The `type[bool]` declaration here is a workaround to avoid running into
-    # https://github.com/astral-sh/ruff/issues/15672
-    __bool__: type[bool] = bool
+    __bool__ = bool
 
+# TODO: when bool is used as a method, it is called without arguments and always returns False, but this is not yet implemented
 # revealed: bool
 reveal_type(not BoolIsBool())
 

--- a/crates/red_knot_python_semantic/resources/mdtest/unary/not.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/unary/not.md
@@ -137,14 +137,6 @@ class AlwaysFalse:
 # revealed: Literal[True]
 reveal_type(not AlwaysFalse())
 
-# We don't get into a cycle if someone sets their `__bool__` method to the `bool` builtin:
-class BoolIsBool:
-    __bool__ = bool
-
-# TODO: when bool is used as a method, it is called without arguments and always returns False, but this is not yet implemented
-# revealed: bool
-reveal_type(not BoolIsBool())
-
 # At runtime, no `__bool__` and no `__len__` means truthy, but we can't rely on that, because
 # a subclass could add a `__bool__` method.
 class NoBoolMethod: ...


### PR DESCRIPTION
## Summary

This PR adds `Type::call_bound` method for calls that should follow descriptor protocol calling convention. The PR is intentionally shallow in scope and only fixes #15672

Couple of obvious things that weren't done:

* Switch to `call_bound` everywhere it should be used
* Address the fact, that red_knot resolves `__bool__ = bool` as a Union, which includes `Type::Dynamic` and hence fails to infer that the truthiness is always false for such a class (I've added a todo comment in mdtests)
* Doesn't try to invent a new type for descriptors, although I have a gut feeling it may be more convenient in the end, instead of doing method lookup each time like I did in `call_bound`

## Test Plan

* extended mdtests with 2 examples from the issue
* cargo neatest run 
