### PR TITLE
Remove non-existing `lint.extendIgnore` editor setting

### DIFF
--- a/docs/editors/settings.md
+++ b/docs/editors/settings.md
@@ -805,56 +805,6 @@ Rules to disable by default. See [the documentation](https://docs.astral.sh/ruff
     }
     ```
 
-### `extendIgnore`
-
-Rules to disable in addition to those in [`lint.ignore`](#ignore).
-
-**Default value**: `null`
-
-**Type**: `string[]`
-
-**Example usage**:
-
-=== "VS Code"
-
-    ```json
-    {
-        "ruff.lint.extendIgnore": ["W1"]
-    }
-    ```
-
-=== "Neovim"
-
-    ```lua
-    require('lspconfig').ruff.setup {
-      init_options = {
-        settings = {
-          lint = {
-            extendIgnore = {"W1"}
-          }
-        }
-      }
-    }
-    ```
-
-=== "Zed"
-
-    ```json
-    {
-      "lsp": {
-        "ruff": {
-          "initialization_options": {
-            "settings": {
-              "lint": {
-                "extendIgnore": ["W1"]
-              }
-            }
-          }
-        }
-      }
-    }
-    ```
-
 ## `format`
 
 Settings specific to the Ruff formatter.


### PR DESCRIPTION
This setting doesn't exist in the first place. I must've added it by mistake thinking that it exists similar to `extendSelect`. One reason to have auto-generated docs.

https://github.com/astral-sh/ruff/blob/988be01fbec37fe6ba6658a24cda82c73241e4ea/crates/ruff_server/src/session/settings.rs#L124-L133

Closes: #14665 