### PR TITLE
[red-knot] Add support for re-export conventions for imports

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/import/conditional.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/import/conditional.md
@@ -95,7 +95,7 @@ def coinflip() -> bool:
     return True
 
 if coinflip():
-    from c import f
+    from c import f as f
 else:
     def f(): ...
 ```
@@ -125,7 +125,7 @@ def coinflip() -> bool:
     return True
 
 if coinflip():
-    from c import x
+    from c import x as x
 else:
     x = 1
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/import/conventions.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/import/conventions.md
@@ -1,0 +1,474 @@
+# Import conventions
+
+This document describes the conventions for importing symbols.
+
+Reference:
+
+- <https://typing.readthedocs.io/en/latest/spec/distributing.html#import-conventions>
+
+## Builtins scope
+
+When looking up for a name, red knot will fallback to using the builtins scope if the name is not
+found in the global scope. The `builtins.pyi` file, that will be used to resolve any symbol in the
+builtins scope, contains multiple symbols from other modules (e.g., `typing`) but those are not
+re-exported.
+
+```py
+# These symbols are being imported in `builtins.pyi` but shouldn't be considered as being
+# available in the builtins scope.
+
+# error: "Name `Literal` used when not defined"
+reveal_type(Literal)  # revealed: Unknown
+
+# error: "Name `sys` used when not defined"
+reveal_type(sys)  # revealed: Unknown
+```
+
+## Builtins import
+
+Similarly, trying to import the symbols from the builtins module which aren't re-exported should
+also raise an error.
+
+```py
+# error: "Module `builtins` has no member `Literal`"
+# error: "Module `builtins` has no member `sys`"
+from builtins import Literal, sys
+
+reveal_type(Literal)  # revealed: Unknown
+reveal_type(sys)  # revealed: Unknown
+
+# TODO: This should be an error but we don't understand `*` imports yet and
+# the `collections.abc` uses `from _collections_abc import *`.
+from math import Iterable
+
+reveal_type(Iterable)  # revealed: Unknown
+```
+
+## Re-exported symbols in stub files
+
+When a symbol is re-exported, imporing it should not raise an error. This tests both `import ...`
+and `from ... import ...` forms.
+
+Note: Submodule imports in `import ...` form doesn't work because it's a syntax error. For example,
+in `import os.path as os.path` the `os.path` is not a valid identifier.
+
+```py
+from b import Any, Literal, foo
+
+reveal_type(Any)  # revealed: typing.Any
+reveal_type(Literal)  # revealed: typing.Literal
+reveal_type(foo)  # revealed: <module 'foo'>
+```
+
+`b.pyi`:
+
+```pyi
+import foo as foo
+from typing import Any as Any, Literal as Literal
+```
+
+`foo.py`:
+
+```py
+```
+
+## Non-exported symbols in stub files
+
+Here, none of the symbols are being re-exported in the stub file.
+
+```py
+# error: 15 [unresolved-import] "Module `b` has no member `foo`"
+# error: 20 [unresolved-import] "Module `b` has no member `Any`"
+# error: 25 [unresolved-import] "Module `b` has no member `Literal`"
+from b import foo, Any, Literal
+
+reveal_type(Any)  # revealed: Unknown
+reveal_type(Literal)  # revealed: Unknown
+reveal_type(foo)  # revealed: Unknown
+```
+
+`b.pyi`:
+
+```pyi
+import foo
+from typing import Any, Literal
+```
+
+`foo.pyi`:
+
+```pyi
+```
+
+## Nested non-exports
+
+Here, a chain of modules all don't re-export an import.
+
+```py
+# error: "Module `a` has no member `Any`"
+from a import Any
+
+reveal_type(Any)  # revealed: Unknown
+```
+
+`a.pyi`:
+
+```pyi
+# error: "Module `b` has no member `Any`"
+from b import Any
+
+reveal_type(Any)  # revealed: Unknown
+```
+
+`b.pyi`:
+
+```pyi
+# error: "Module `c` has no member `Any`"
+from c import Any
+
+reveal_type(Any)  # revealed: Unknown
+```
+
+`c.pyi`:
+
+```pyi
+from typing import Any
+
+reveal_type(Any)  # revealed: typing.Any
+```
+
+## Nested mixed re-export and not
+
+But, if the symbol is being re-exported explicitly in one of the modules in the chain, it should not
+raise an error at that step in the chain.
+
+```py
+# error: "Module `a` has no member `Any`"
+from a import Any
+
+reveal_type(Any)  # revealed: Unknown
+```
+
+`a.pyi`:
+
+```pyi
+from b import Any
+
+reveal_type(Any)  # revealed: Unknown
+```
+
+`b.pyi`:
+
+```pyi
+# error: "Module `c` has no member `Any`"
+from c import Any as Any
+
+reveal_type(Any)  # revealed: Unknown
+```
+
+`c.pyi`:
+
+```pyi
+from typing import Any
+
+reveal_type(Any)  # revealed: typing.Any
+```
+
+## Exported as different name
+
+The re-export convention only works when the aliased name is exactly the same as the original name.
+
+```py
+# error: "Module `a` has no member `Foo`"
+from a import Foo
+
+reveal_type(Foo)  # revealed: Unknown
+```
+
+`a.pyi`:
+
+```pyi
+from b import AnyFoo as Foo
+
+reveal_type(Foo)  # revealed: Literal[AnyFoo]
+```
+
+`b.pyi`:
+
+```pyi
+class AnyFoo: ...
+```
+
+## Exported using `__all__`
+
+Here, the symbol is re-exported using the `__all__` variable.
+
+```py
+# TODO: This should *not* be an error but we don't understand `__all__` yet.
+# error: "Module `a` has no member `Foo`"
+from a import Foo
+```
+
+`a.pyi`:
+
+```pyi
+from b import Foo
+
+__all__ = ['Foo']
+```
+
+`b.pyi`:
+
+```pyi
+class Foo: ...
+```
+
+## Runtime files
+
+For runtime files (i.e., `.py` files), the re-exported symbols should be inferred correctly.
+
+TODO: When we support rule selection, the `implicit-reexport` rule should be disabled by default and
+this test case should be updated to explicitly enable it.
+
+```py
+# error: "Module `b` does not explicitly export attribute `Foo`"
+from b import Foo
+
+reveal_type(Foo)  # revealed: Literal[Foo]
+```
+
+`b.py`:
+
+```py
+from c import Foo
+```
+
+`c.py`:
+
+```py
+class Foo: ...
+```
+
+## Non-exports in `__init__.py`
+
+Red knot does not special case `__init__.py` files, so if a symbol is imported in `__init__.py`
+which is not re-exported, it should raise an error.
+
+TODO: When we support rule selection, the `implicit-reexport` rule should be disabled by default and
+this test case should be updated to explicitly enable it.
+
+```py
+# error: 15 "Module `a` does not explicitly export attribute `Foo`"
+# error: 20 "Module `a` does not explicitly export attribute `c`"
+from a import Foo, c, foo
+
+reveal_type(Foo)  # revealed: Literal[Foo]
+reveal_type(c)  # revealed: <module 'a.b.c'>
+reveal_type(foo)  # revealed: <module 'a.foo'>
+```
+
+`a/__init__.py`:
+
+```py
+from .b import c
+from .foo import Foo
+```
+
+`a/foo.py`:
+
+```py
+class Foo: ...
+```
+
+`a/b/__init__.py`:
+
+```py
+```
+
+`a/b/c.py`:
+
+```py
+```
+
+## Re-exports in `__init__.py`
+
+But, if they're re-exported, it should not raise an error.
+
+TODO: When we support rule selection, the `implicit-reexport` rule should be disabled by default and
+this test case should be updated to explicitly enable it.
+
+```py
+from a import Foo, c, foo
+
+reveal_type(Foo)  # revealed: Literal[Foo]
+reveal_type(c)  # revealed: <module 'a.b.c'>
+reveal_type(foo)  # revealed: <module 'a.foo'>
+```
+
+`a/__init__.py`:
+
+```py
+from .b import c as c
+from .foo import Foo as Foo
+```
+
+`a/foo.py`:
+
+```py
+class Foo: ...
+```
+
+`a/b/__init__.py`:
+
+```py
+```
+
+`a/b/c.py`:
+
+```py
+```
+
+## Re-exports in `__init__.pyi`
+
+Similarly, for an `__init__.pyi` (stub) file, importing a non-exported name should raise an error
+but the inference would be `Unknown`.
+
+```py
+# error: 15 "Module `a` has no member `Foo`"
+# error: 20 "Module `a` has no member `c`"
+from a import Foo, c, foo
+
+reveal_type(Foo)  # revealed: Unknown
+reveal_type(c)  # revealed: Unknown
+reveal_type(foo)  # revealed: <module 'a.foo'>
+```
+
+`a/__init__.pyi`:
+
+```pyi
+from .b import c
+from .foo import Foo
+```
+
+`a/foo.pyi`:
+
+```pyi
+class Foo: ...
+```
+
+`a/b/__init__.pyi`:
+
+```pyi
+```
+
+`a/b/c.pyi`:
+
+```pyi
+```
+
+## Conditional re-export in stub file
+
+The following scenarios are when a re-export happens conditionally in a stub file.
+
+### Global import
+
+```py
+# error: [possibly-unbound-import] "Member `Foo` of module `a` is possibly unbound"
+from a import Foo
+
+reveal_type(Foo)  # revealed: Literal[Foo] | str
+```
+
+`a.pyi`:
+
+```pyi
+from b import Foo
+
+def coinflip() -> bool:
+    return True
+
+if coinflip():
+    Foo: str = "foo"
+```
+
+`b.pyi`:
+
+```pyi
+class Foo: ...
+```
+
+### Both branch is an import
+
+Here, both the branches of the condition are import statements where one of them re-exports while
+the other does not.
+
+```py
+# error: "Member `Foo` of module `a` is possibly unbound"
+from a import Foo
+
+reveal_type(Foo)  # revealed: Literal[Foo]
+```
+
+`a.pyi`:
+
+```pyi
+def coinflip() -> bool: ...
+
+if coinflip():
+    from b import Foo
+else:
+    from b import Foo as Foo
+```
+
+`b.pyi`:
+
+```pyi
+class Foo: ...
+```
+
+### Re-export in one branch
+
+```py
+# error: "Member `Foo` of module `a` is possibly unbound"
+from a import Foo
+
+reveal_type(Foo)  # revealed: Literal[Foo]
+```
+
+`a.pyi`:
+
+```pyi
+def coinflip() -> bool: ...
+
+if coinflip():
+    from b import Foo as Foo
+```
+
+`b.pyi`:
+
+```pyi
+class Foo: ...
+```
+
+### Non-export in one branch
+
+```py
+# error: "Module `a` has no member `Foo`"
+from a import Foo
+
+reveal_type(Foo)  # revealed: Unknown
+```
+
+`a.pyi`:
+
+```pyi
+def coinflip() -> bool: ...
+
+if coinflip():
+    from b import Foo
+```
+
+`b.pyi`:
+
+```pyi
+class Foo: ...
+```

--- a/crates/red_knot_python_semantic/resources/mdtest/import/tracking.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/import/tracking.md
@@ -50,6 +50,9 @@ containing module is first referenced. This allows the main module to see that `
 submodule `b`, even though `a.b` is never imported in the main module.
 
 ```py
+# TODO: Remove this once we have rule selection and this rule is disabled for
+# runtime files by default.
+# error: "Module `q` does not explicitly export attribute `b`"
 from q import a, b
 
 reveal_type(b)  # revealed: <module 'a.b'>

--- a/crates/red_knot_python_semantic/src/symbol.rs
+++ b/crates/red_knot_python_semantic/src/symbol.rs
@@ -199,7 +199,7 @@ mod tests {
             Symbol::Type(ty1, ReExport::Yes, PossiblyUnbound)
                 .or_fall_back_to(&db, || Symbol::Type(ty2, ReExport::Yes, PossiblyUnbound)),
             Symbol::Type(
-                UnionType::from_elements(&db, [ty2, ty1]),
+                UnionType::from_elements(&db, [ty1, ty2]),
                 ReExport::Yes,
                 PossiblyUnbound
             )
@@ -208,7 +208,7 @@ mod tests {
             Symbol::Type(ty1, ReExport::Yes, PossiblyUnbound)
                 .or_fall_back_to(&db, || Symbol::Type(ty2, ReExport::Yes, Bound)),
             Symbol::Type(
-                UnionType::from_elements(&db, [ty2, ty1]),
+                UnionType::from_elements(&db, [ty1, ty2]),
                 ReExport::Yes,
                 Bound
             )

--- a/crates/red_knot_python_semantic/src/types/diagnostic.rs
+++ b/crates/red_knot_python_semantic/src/types/diagnostic.rs
@@ -41,6 +41,7 @@ pub(crate) fn register_lints(registry: &mut LintRegistryBuilder) {
     registry.register_lint(&INVALID_RAISE);
     registry.register_lint(&INVALID_TYPE_FORM);
     registry.register_lint(&INVALID_TYPE_VARIABLE_CONSTRAINTS);
+    registry.register_lint(&IMPLICIT_REEXPORT);
     registry.register_lint(&MISSING_ARGUMENT);
     registry.register_lint(&NON_SUBSCRIPTABLE);
     registry.register_lint(&NOT_ITERABLE);
@@ -677,6 +678,50 @@ declare_lint! {
     /// Importing a module that cannot be resolved will raise an `ImportError` at runtime.
     pub(crate) static UNRESOLVED_IMPORT = {
         summary: "detects unresolved imports",
+        status: LintStatus::preview("1.0.0"),
+        default_level: Level::Error,
+    }
+}
+
+declare_lint! {
+    /// ## What it does
+    /// Checks for import statements that import names from a module which imports but does not explicitly
+    /// re-export them.
+    ///
+    /// ## Why is this bad?
+    /// Imports may only be intended for local use, not intended for re-export as part of the public API of a module.
+    /// Allowing other modules to import names that weren't intended for re-export can create inconsistent import
+    /// locations for the same symbol across the codebase, cause breakages if an import is removed, and make
+    /// future refactors more difficult.
+    ///
+    /// ## Example
+    ///
+    /// Consider a file `other.py`:
+    ///
+    /// ```python
+    /// from typing import Literal
+    /// ```
+    ///
+    /// And, a file `main.py`:
+    ///
+    /// ```python
+    /// from other import Literal
+    /// ```
+    ///
+    /// Use instead:
+    /// ```python
+    /// from typing import Literal
+    /// ```
+    ///
+    /// Or, explicitly re-export the name in `other.py`:
+    /// ```python
+    /// from typing import Literal as Literal
+    /// ```
+    ///
+    /// ## References
+    /// - [Typing documentation: Import conventions](https://typing.readthedocs.io/en/latest/spec/distributing.html#import-conventions)
+    pub(crate) static IMPLICIT_REEXPORT = {
+        summary: "detects imports of imported names that are not explicitly re-exported",
         status: LintStatus::preview("1.0.0"),
         default_level: Level::Error,
     }

--- a/crates/red_knot_python_semantic/src/types/signatures.rs
+++ b/crates/red_knot_python_semantic/src/types/signatures.rs
@@ -357,6 +357,8 @@ mod tests {
         db.write_dedented(
             "/src/a.py",
             "
+            from typing import Literal
+
             def f(a, b: int, c = 1, d: int = 2, /,
                   e = 3, f: Literal[4] = 4, *args: object,
                   g = 5, h: Literal[6] = 6, **kwargs: str) -> bytes: ...

--- a/crates/red_knot_python_semantic/src/types/slots.rs
+++ b/crates/red_knot_python_semantic/src/types/slots.rs
@@ -24,7 +24,7 @@ enum SlotsKind {
 
 impl SlotsKind {
     fn from(db: &dyn Db, base: Class) -> Self {
-        let Symbol::Type(slots_ty, bound) = base.own_class_member(db, "__slots__") else {
+        let Symbol::Type(slots_ty, _, bound) = base.own_class_member(db, "__slots__") else {
             return Self::NotSpecified;
         };
 

--- a/knot.schema.json
+++ b/knot.schema.json
@@ -291,6 +291,16 @@
             }
           ]
         },
+        "implicit-reexport": {
+          "title": "detects imports of imported names that are not explicitly re-exported",
+          "description": "## What it does\nChecks for import statements that import names from a module which imports but does not explicitly\nre-export them.\n\n## Why is this bad?\nImports may only be intended for local use, not intended for re-export as part of the public API of a module.\nAllowing other modules to import names that weren't intended for re-export can create inconsistent import\nlocations for the same symbol across the codebase, cause breakages if an import is removed, and make\nfuture refactors more difficult.\n\n## Example\n\nConsider a file `other.py`:\n\n```python\nfrom typing import Literal\n```\n\nAnd, a file `main.py`:\n\n```python\nfrom other import Literal\n```\n\nUse instead:\n```python\nfrom typing import Literal\n```\n\nOr, explicitly re-export the name in `other.py`:\n```python\nfrom typing import Literal as Literal\n```\n\n## References\n- [Typing documentation: Import conventions](https://typing.readthedocs.io/en/latest/spec/distributing.html#import-conventions)",
+          "default": "error",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/Level"
+            }
+          ]
+        },
         "incompatible-slots": {
           "title": "detects class definitions whose MRO has conflicting `__slots__`",
           "description": "## What it does\nChecks for classes whose bases define incompatible `__slots__`.\n\n## Why is this bad?\nInheriting from bases with incompatible `__slots__`s\nwill lead to a `TypeError` at runtime.\n\nClasses with no or empty `__slots__` are always compatible:\n\n```python\nclass A: ...\nclass B:\n    __slots__ = ()\nclass C:\n    __slots__ = (\"a\", \"b\")\n\n# fine\nclass D(A, B, C): ...\n```\n\nMultiple inheritance from more than one different class\ndefining non-empty `__slots__` is not allowed:\n\n```python\nclass A:\n    __slots__ = (\"a\", \"b\")\n\nclass B:\n    __slots__ = (\"a\", \"b\")  # Even if the values are the same\n\n# TypeError: multiple bases have instance lay-out conflict\nclass C(A, B): ...\n```\n\n## Known problems\nDynamic (not tuple or string literal) `__slots__` are not checked.\nAdditionally, classes inheriting from built-in classes with implicit layouts\nlike `str` or `int` are also not checked.\n\n```pycon\n>>> hasattr(int, \"__slots__\")\nFalse\n>>> hasattr(str, \"__slots__\")\nFalse\n>>> class A(int, str): ...\nTraceback (most recent call last):\n  File \"<python-input-0>\", line 1, in <module>\n    class A(int, str): ...\nTypeError: multiple bases have instance lay-out conflict\n```",


### PR DESCRIPTION
## Summary

This PR adds support for re-export conventions for imports.

The implementation differs for stub files and runtime files as follows:
* For stub files, this is enforced by using the `unresolved-import` and the inferred type is `Unknown` by way of making the symbol is unbound
* For runtime files, this is enforced by using a new rule `implicit-reexport` and the type is inferred as usual

The current implementation updates the `Symbol::Type` variant to include a new `ReExport` enum which specifies whether the symbol is defined in an import statement and if so if it's being implicitly or explicitly re-exported. This is then used downstream to perform the check.

This implementation does not yet support `__all__` and `*` imports as both are features that needs to be implemented independently.

### Other potential solution

While implementing this, another potential solution would be to use the visibility qualifier for a symbol to specify whether this is an implicitly exported symbol which translates to:
```rs
enum Visibility {
    Public,
    Private,
    ImplicitExport,
}
```

This would then mean that this enum could be created for the `Definition` while building the semantic index and it could also consider the `__all__` values. One issue that I saw with this is that the values in `__all__` could come from another module which isn't possible to do in the semantic index builder because that does not cross the file boundary.

closes: #14099
closes: #15476 

## Test Plan

Add test cases, update existing ones if required.
