### PR TITLE
Add deprecation warning for `ruff-lsp` related settings

### DIFF
--- a/docs/editors/migration.md
+++ b/docs/editors/migration.md
@@ -9,24 +9,22 @@ While `ruff server` supports the same feature set as [`ruff-lsp`](https://github
     settings are supported by `ruff server`. As such, this migration guide is primarily targeted at editors that lack
     explicit documentation for `ruff server` settings, such as Helix or Neovim.
 
-Refer to the [setup guide](setup.md) for instructions on how to configure your editor to use `ruff
-server`.
+Refer to the [setup guide](setup.md) for instructions on how to configure your editor to use `ruff server`.
 
 ## Unsupported Settings
 
 Several `ruff-lsp` settings are not supported by `ruff server`. These are, as follows:
 
-* `lint.run`: This setting is no longer relevant for the native language server, which runs on every
-  keystroke by default
-* `lint.args`, `format.args`: These settings have been replaced by more granular settings in `ruff
-  server` like [`lint.select`](settings.md#select), [`format.preview`](settings.md#format_preview),
-  etc. along with the ability to provide a default configuration file using
-  [`configuration`](settings.md#configuration)
-* [`path`](settings.md#path), [`interpreter`](settings.md#interpreter): These settings are no longer
-  accepted by the language server but are still used by the VS Code extension. Refer to their
-  respective documentation for more information on how it's being used by the extension.
-* `ignoreStandardLibrary`
-* `showNotifications`
+- `lint.run`: This setting is no longer relevant for the native language server, which runs on every
+    keystroke by default
+- `lint.args`, `format.args`: These settings have been replaced by more granular settings in `ruff server` like [`lint.select`](settings.md#select), [`format.preview`](settings.md#format_preview),
+    etc. along with the ability to provide a default configuration file using
+    [`configuration`](settings.md#configuration)
+- [`path`](settings.md#path), [`interpreter`](settings.md#interpreter): These settings are no longer
+    accepted by the language server but are still used by the VS Code extension. Refer to their
+    respective documentation for more information on how it's being used by the extension.
+- `ignoreStandardLibrary`
+- `showNotifications`
 
 ## New Settings
 

--- a/docs/editors/settings.md
+++ b/docs/editors/settings.md
@@ -933,6 +933,7 @@ Whether to enable the Ruff extension. Modifying this setting requires restarting
 ### `format.args`
 
 !!! warning "Deprecated"
+
     This setting is only used by [`ruff-lsp`](https://github.com/astral-sh/ruff-lsp) which is
     deprecated in favor of the native language server. Refer to the [migration
     guide](migration.md) for more information.
@@ -956,6 +957,7 @@ Additional arguments to pass to the Ruff formatter.
 ### `ignoreStandardLibrary`
 
 !!! warning "Deprecated"
+
     This setting is only used by [`ruff-lsp`](https://github.com/astral-sh/ruff-lsp) which is
     deprecated in favor of the native language server. Refer to the [migration
     guide](migration.md) for more information.
@@ -1021,6 +1023,7 @@ This setting depends on the [`ruff.nativeServer`](#nativeserver) setting:
 ### `lint.args`
 
 !!! warning "Deprecated"
+
     This setting is only used by [`ruff-lsp`](https://github.com/astral-sh/ruff-lsp) which is
     deprecated in favor of the native language server. Refer to the [migration
     guide](migration.md) for more information.
@@ -1044,6 +1047,7 @@ Additional arguments to pass to the Ruff linter.
 ### `lint.run`
 
 !!! warning "Deprecated"
+
     This setting is only used by [`ruff-lsp`](https://github.com/astral-sh/ruff-lsp) which is
     deprecated in favor of the native language server. Refer to the [migration
     guide](migration.md) for more information.
@@ -1067,6 +1071,7 @@ Run Ruff on every keystroke (`onType`) or on save (`onSave`).
 ### `nativeServer`
 
 !!! warning "Deprecated"
+
     This setting has been deprecated with the deprecation of
     [`ruff-lsp`](https://github.com/astral-sh/ruff-lsp). It was mainly used to provide a way to
     switch between the native language server and
@@ -1124,6 +1129,7 @@ The first executable in the list which is exists is used. This setting takes pre
 ### `showNotifications`
 
 !!! warning "Deprecated"
+
     This setting is only used by [`ruff-lsp`](https://github.com/astral-sh/ruff-lsp) which is
     deprecated in favor of the native language server. Refer to the [migration
     guide](migration.md) for more information.


### PR DESCRIPTION
## Summary

This PR updates the documentation to add deprecated warning for `ruff-lsp` specific settings

### Preview

https://github.com/user-attachments/assets/64e11e4b-7178-43ab-be5b-421e7f4689de

## Test Plan

Build the documentation locally and test out the links. Refer to the preview video above.