### PR TITLE
[`flake8-pyi`] Remove type parameter correctly when it is the last (`PYI019`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI019.pyi
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI019.pyi
@@ -112,3 +112,7 @@ def shadowed_type():
 class SubscriptReturnType:
     @classmethod
     def m[S](cls: type[S]) -> type[S]: ...  # PYI019, but no autofix (yet)
+
+
+class PEP695TypeParameterAtTheVeryEndOfTheList:
+    def f[T, S](self: S) -> S: ...

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/custom_type_var_return_type.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/custom_type_var_return_type.rs
@@ -430,7 +430,7 @@ fn remove_typevar_declaration(type_params: Option<&TypeParams>, name: &str) -> O
         // [A, B, C]
         //      ^^^ Remove this
         let previous_range = parameters[index - 1].range();
-        TextRange::new(previous_range.end(), typevar_range.start())
+        TextRange::new(previous_range.end(), typevar_range.end())
     };
 
     Some(Edit::range_deletion(range))

--- a/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI019_PYI019.pyi.snap
+++ b/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI019_PYI019.pyi.snap
@@ -224,3 +224,11 @@ PYI019.pyi:114:31: PYI019 Methods like `m` should return `Self` instead of a cus
     |                               ^^^^^^^ PYI019
     |
     = help: Replace with `Self`
+
+PYI019.pyi:118:29: PYI019 Methods like `f` should return `Self` instead of a custom `TypeVar`
+    |
+117 | class PEP695TypeParameterAtTheVeryEndOfTheList:
+118 |     def f[T, S](self: S) -> S: ...
+    |                             ^ PYI019
+    |
+    = help: Replace with `Self`

--- a/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__custom_classmethod_rules_preview.snap
+++ b/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__custom_classmethod_rules_preview.snap
@@ -444,3 +444,18 @@ PYI019.pyi:114:31: PYI019 Methods like `m` should return `Self` instead of a cus
     |                               ^^^^^^^ PYI019
     |
     = help: Replace with `Self`
+
+PYI019.pyi:118:29: PYI019 [*] Methods like `f` should return `Self` instead of a custom `TypeVar`
+    |
+117 | class PEP695TypeParameterAtTheVeryEndOfTheList:
+118 |     def f[T, S](self: S) -> S: ...
+    |                             ^ PYI019
+    |
+    = help: Replace with `Self`
+
+ℹ Safe fix
+115 115 | 
+116 116 | 
+117 117 | class PEP695TypeParameterAtTheVeryEndOfTheList:
+118     |-    def f[T, S](self: S) -> S: ...
+    118 |+    def f[T](self) -> Self: ...


### PR DESCRIPTION
## Summary

Part of #15821.

Prior to this change, a PEP 695 type variable would not be removed correctly were it to be placed at the very end of the type parameter list:

```python
# Original
def f[T, S](self: S) -> S: ...

# Before
def f[TS](self) -> Self: ...

# After
def f[T](self) -> Self: ...
```

## Test Plan

`cargo nextest run` and `cargo insta test`.
