### PR TITLE
[`pyupgrade`] Better messages and diagnostic range (`UP015`)

### DIFF
--- a/crates/ruff_linter/src/rules/pyupgrade/mod.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/mod.rs
@@ -116,6 +116,25 @@ mod tests {
         Ok(())
     }
 
+    #[test_case(Rule::RedundantOpenModes, Path::new("UP015.py"))]
+    #[test_case(Rule::RedundantOpenModes, Path::new("UP015_1.py"))]
+    fn preview_rules(rule_code: Rule, path: &Path) -> Result<()> {
+        let snapshot = format!(
+            "preview__{}_{}",
+            rule_code.noqa_code(),
+            path.to_string_lossy()
+        );
+        let diagnostics = test_path(
+            Path::new("pyupgrade").join(path).as_path(),
+            &settings::LinterSettings {
+                preview: PreviewMode::Enabled,
+                ..settings::LinterSettings::for_rule(rule_code)
+            },
+        )?;
+        assert_messages!(snapshot, diagnostics);
+        Ok(())
+    }
+
     #[test]
     fn up007_preview() -> Result<()> {
         let diagnostics = test_path(

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/redundant_open_modes.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/redundant_open_modes.rs
@@ -39,16 +39,16 @@ impl AlwaysFixableViolation for RedundantOpenModes {
     fn message(&self) -> String {
         let RedundantOpenModes { replacement } = self;
         if replacement.is_empty() {
-            "Unnecessary open mode argument".to_string()
+            "Unnecessary mode argument".to_string()
         } else {
-            format!("Unnecessary open modes, use `{replacement}`")
+            format!("Unnecessary modes, use `{replacement}`")
         }
     }
 
     fn fix_title(&self) -> String {
         let RedundantOpenModes { replacement } = self;
         if replacement.is_empty() {
-            "Remove open mode argument".to_string()
+            "Remove mode argument".to_string()
         } else {
             format!("Replace with `{replacement}`")
         }

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/redundant_open_modes.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/redundant_open_modes.rs
@@ -2,7 +2,6 @@ use anyhow::Result;
 use ruff_diagnostics::{AlwaysFixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, ViolationMetadata};
 use ruff_python_ast::{self as ast, Expr};
-use ruff_python_codegen::Stylist;
 use ruff_python_parser::{TokenKind, Tokens};
 use ruff_python_stdlib::open_mode::OpenMode;
 use ruff_text_size::{Ranged, TextSize};
@@ -10,10 +9,10 @@ use ruff_text_size::{Ranged, TextSize};
 use crate::checkers::ast::Checker;
 
 /// ## What it does
-/// Checks for redundant `open` mode parameters.
+/// Checks for redundant `open` mode arguments.
 ///
 /// ## Why is this bad?
-/// Redundant `open` mode parameters are unnecessary and should be removed to
+/// Redundant `open` mode arguments are unnecessary and should be removed to
 /// avoid confusion.
 ///
 /// ## Example
@@ -40,18 +39,18 @@ impl AlwaysFixableViolation for RedundantOpenModes {
     fn message(&self) -> String {
         let RedundantOpenModes { replacement } = self;
         if replacement.is_empty() {
-            "Unnecessary open mode parameters".to_string()
+            "Unnecessary open mode argument".to_string()
         } else {
-            format!("Unnecessary open mode parameters, use \"{replacement}\"")
+            format!("Unnecessary open modes, use `{replacement}`")
         }
     }
 
     fn fix_title(&self) -> String {
         let RedundantOpenModes { replacement } = self;
         if replacement.is_empty() {
-            "Remove open mode parameters".to_string()
+            "Remove open mode argument".to_string()
         } else {
-            format!("Replace with \"{replacement}\"")
+            format!("Replace with `{replacement}`")
         }
     }
 }
@@ -71,10 +70,10 @@ pub(crate) fn redundant_open_modes(checker: &mut Checker, call: &ast::ExprCall) 
         return;
     }
 
-    let Some(mode_param) = call.arguments.find_argument_value("mode", 1) else {
+    let Some(mode_arg) = call.arguments.find_argument_value("mode", 1) else {
         return;
     };
-    let Expr::StringLiteral(ast::ExprStringLiteral { value, .. }) = &mode_param else {
+    let Expr::StringLiteral(ast::ExprStringLiteral { value, .. }) = &mode_arg else {
         return;
     };
     let Ok(mode) = OpenMode::from_chars(value.chars()) else {
@@ -82,57 +81,60 @@ pub(crate) fn redundant_open_modes(checker: &mut Checker, call: &ast::ExprCall) 
     };
     let reduced = mode.reduce();
     if reduced != mode {
-        checker.diagnostics.push(create_diagnostic(
-            call,
-            mode_param,
-            reduced,
-            checker.tokens(),
-            checker.stylist(),
-        ));
+        checker
+            .diagnostics
+            .push(create_diagnostic(call, mode_arg, reduced, checker));
     }
 }
 
 fn create_diagnostic(
     call: &ast::ExprCall,
-    mode_param: &Expr,
+    mode_arg: &Expr,
     mode: OpenMode,
-    tokens: &Tokens,
-    stylist: &Stylist,
+    checker: &Checker,
 ) -> Diagnostic {
+    let range = if checker.settings.preview.is_enabled() {
+        mode_arg.range()
+    } else {
+        call.range
+    };
+
     let mut diagnostic = Diagnostic::new(
         RedundantOpenModes {
             replacement: mode.to_string(),
         },
-        call.range(),
+        range,
     );
 
     if mode.is_empty() {
-        diagnostic
-            .try_set_fix(|| create_remove_param_fix(call, mode_param, tokens).map(Fix::safe_edit));
+        diagnostic.try_set_fix(|| {
+            create_remove_argument_fix(call, mode_arg, checker.tokens()).map(Fix::safe_edit)
+        });
     } else {
+        let stylist = checker.stylist();
         diagnostic.set_fix(Fix::safe_edit(Edit::range_replacement(
             format!("{}{mode}{}", stylist.quote(), stylist.quote()),
-            mode_param.range(),
+            mode_arg.range(),
         )));
     }
 
     diagnostic
 }
 
-fn create_remove_param_fix(
+fn create_remove_argument_fix(
     call: &ast::ExprCall,
-    mode_param: &Expr,
+    mode_arg: &Expr,
     tokens: &Tokens,
 ) -> Result<Edit> {
-    // Find the last comma before mode_param and create a deletion fix
-    // starting from the comma and ending after mode_param.
+    // Find the last comma before mode_arg and create a deletion fix
+    // starting from the comma and ending after mode_arg.
     let mut fix_start: Option<TextSize> = None;
     let mut fix_end: Option<TextSize> = None;
     let mut is_first_arg: bool = false;
     let mut delete_first_arg: bool = false;
 
     for token in tokens.in_range(call.range()) {
-        if token.start() == mode_param.start() {
+        if token.start() == mode_arg.start() {
             if is_first_arg {
                 delete_first_arg = true;
                 continue;

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP015.py.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP015.py.snap
@@ -1,14 +1,14 @@
 ---
 source: crates/ruff_linter/src/rules/pyupgrade/mod.rs
 ---
-UP015.py:1:1: UP015 [*] Unnecessary open mode argument
+UP015.py:1:1: UP015 [*] Unnecessary mode argument
   |
 1 | open("foo", "U")
   | ^^^^^^^^^^^^^^^^ UP015
 2 | open("foo", "Ur")
 3 | open("foo", "Ub")
   |
-  = help: Remove open mode argument
+  = help: Remove mode argument
 
 ℹ Safe fix
 1   |-open("foo", "U")
@@ -17,7 +17,7 @@ UP015.py:1:1: UP015 [*] Unnecessary open mode argument
 3 3 | open("foo", "Ub")
 4 4 | open("foo", "rUb")
 
-UP015.py:2:1: UP015 [*] Unnecessary open mode argument
+UP015.py:2:1: UP015 [*] Unnecessary mode argument
   |
 1 | open("foo", "U")
 2 | open("foo", "Ur")
@@ -25,7 +25,7 @@ UP015.py:2:1: UP015 [*] Unnecessary open mode argument
 3 | open("foo", "Ub")
 4 | open("foo", "rUb")
   |
-  = help: Remove open mode argument
+  = help: Remove mode argument
 
 ℹ Safe fix
 1 1 | open("foo", "U")
@@ -35,7 +35,7 @@ UP015.py:2:1: UP015 [*] Unnecessary open mode argument
 4 4 | open("foo", "rUb")
 5 5 | open("foo", "r")
 
-UP015.py:3:1: UP015 [*] Unnecessary open modes, use `rb`
+UP015.py:3:1: UP015 [*] Unnecessary modes, use `rb`
   |
 1 | open("foo", "U")
 2 | open("foo", "Ur")
@@ -55,7 +55,7 @@ UP015.py:3:1: UP015 [*] Unnecessary open modes, use `rb`
 5 5 | open("foo", "r")
 6 6 | open("foo", "rt")
 
-UP015.py:4:1: UP015 [*] Unnecessary open modes, use `rb`
+UP015.py:4:1: UP015 [*] Unnecessary modes, use `rb`
   |
 2 | open("foo", "Ur")
 3 | open("foo", "Ub")
@@ -76,7 +76,7 @@ UP015.py:4:1: UP015 [*] Unnecessary open modes, use `rb`
 6 6 | open("foo", "rt")
 7 7 | open("f", "r", encoding="UTF-8")
 
-UP015.py:5:1: UP015 [*] Unnecessary open mode argument
+UP015.py:5:1: UP015 [*] Unnecessary mode argument
   |
 3 | open("foo", "Ub")
 4 | open("foo", "rUb")
@@ -85,7 +85,7 @@ UP015.py:5:1: UP015 [*] Unnecessary open mode argument
 6 | open("foo", "rt")
 7 | open("f", "r", encoding="UTF-8")
   |
-  = help: Remove open mode argument
+  = help: Remove mode argument
 
 ℹ Safe fix
 2 2 | open("foo", "Ur")
@@ -97,7 +97,7 @@ UP015.py:5:1: UP015 [*] Unnecessary open mode argument
 7 7 | open("f", "r", encoding="UTF-8")
 8 8 | open("f", "wt")
 
-UP015.py:6:1: UP015 [*] Unnecessary open mode argument
+UP015.py:6:1: UP015 [*] Unnecessary mode argument
   |
 4 | open("foo", "rUb")
 5 | open("foo", "r")
@@ -106,7 +106,7 @@ UP015.py:6:1: UP015 [*] Unnecessary open mode argument
 7 | open("f", "r", encoding="UTF-8")
 8 | open("f", "wt")
   |
-  = help: Remove open mode argument
+  = help: Remove mode argument
 
 ℹ Safe fix
 3 3 | open("foo", "Ub")
@@ -118,7 +118,7 @@ UP015.py:6:1: UP015 [*] Unnecessary open mode argument
 8 8 | open("f", "wt")
 9 9 | open("f", "tw")
 
-UP015.py:7:1: UP015 [*] Unnecessary open mode argument
+UP015.py:7:1: UP015 [*] Unnecessary mode argument
   |
 5 | open("foo", "r")
 6 | open("foo", "rt")
@@ -127,7 +127,7 @@ UP015.py:7:1: UP015 [*] Unnecessary open mode argument
 8 | open("f", "wt")
 9 | open("f", "tw")
   |
-  = help: Remove open mode argument
+  = help: Remove mode argument
 
 ℹ Safe fix
 4 4 | open("foo", "rUb")
@@ -139,7 +139,7 @@ UP015.py:7:1: UP015 [*] Unnecessary open mode argument
 9 9 | open("f", "tw")
 10 10 | 
 
-UP015.py:8:1: UP015 [*] Unnecessary open modes, use `w`
+UP015.py:8:1: UP015 [*] Unnecessary modes, use `w`
   |
 6 | open("foo", "rt")
 7 | open("f", "r", encoding="UTF-8")
@@ -159,7 +159,7 @@ UP015.py:8:1: UP015 [*] Unnecessary open modes, use `w`
 10 10 | 
 11 11 | with open("foo", "U") as f:
 
-UP015.py:9:1: UP015 [*] Unnecessary open modes, use `w`
+UP015.py:9:1: UP015 [*] Unnecessary modes, use `w`
    |
  7 | open("f", "r", encoding="UTF-8")
  8 | open("f", "wt")
@@ -180,7 +180,7 @@ UP015.py:9:1: UP015 [*] Unnecessary open modes, use `w`
 11 11 | with open("foo", "U") as f:
 12 12 |     pass
 
-UP015.py:11:6: UP015 [*] Unnecessary open mode argument
+UP015.py:11:6: UP015 [*] Unnecessary mode argument
    |
  9 | open("f", "tw")
 10 |
@@ -189,7 +189,7 @@ UP015.py:11:6: UP015 [*] Unnecessary open mode argument
 12 |     pass
 13 | with open("foo", "Ur") as f:
    |
-   = help: Remove open mode argument
+   = help: Remove mode argument
 
 ℹ Safe fix
 8  8  | open("f", "wt")
@@ -201,7 +201,7 @@ UP015.py:11:6: UP015 [*] Unnecessary open mode argument
 13 13 | with open("foo", "Ur") as f:
 14 14 |     pass
 
-UP015.py:13:6: UP015 [*] Unnecessary open mode argument
+UP015.py:13:6: UP015 [*] Unnecessary mode argument
    |
 11 | with open("foo", "U") as f:
 12 |     pass
@@ -210,7 +210,7 @@ UP015.py:13:6: UP015 [*] Unnecessary open mode argument
 14 |     pass
 15 | with open("foo", "Ub") as f:
    |
-   = help: Remove open mode argument
+   = help: Remove mode argument
 
 ℹ Safe fix
 10 10 | 
@@ -222,7 +222,7 @@ UP015.py:13:6: UP015 [*] Unnecessary open mode argument
 15 15 | with open("foo", "Ub") as f:
 16 16 |     pass
 
-UP015.py:15:6: UP015 [*] Unnecessary open modes, use `rb`
+UP015.py:15:6: UP015 [*] Unnecessary modes, use `rb`
    |
 13 | with open("foo", "Ur") as f:
 14 |     pass
@@ -243,7 +243,7 @@ UP015.py:15:6: UP015 [*] Unnecessary open modes, use `rb`
 17 17 | with open("foo", "rUb") as f:
 18 18 |     pass
 
-UP015.py:17:6: UP015 [*] Unnecessary open modes, use `rb`
+UP015.py:17:6: UP015 [*] Unnecessary modes, use `rb`
    |
 15 | with open("foo", "Ub") as f:
 16 |     pass
@@ -264,7 +264,7 @@ UP015.py:17:6: UP015 [*] Unnecessary open modes, use `rb`
 19 19 | with open("foo", "r") as f:
 20 20 |     pass
 
-UP015.py:19:6: UP015 [*] Unnecessary open mode argument
+UP015.py:19:6: UP015 [*] Unnecessary mode argument
    |
 17 | with open("foo", "rUb") as f:
 18 |     pass
@@ -273,7 +273,7 @@ UP015.py:19:6: UP015 [*] Unnecessary open mode argument
 20 |     pass
 21 | with open("foo", "rt") as f:
    |
-   = help: Remove open mode argument
+   = help: Remove mode argument
 
 ℹ Safe fix
 16 16 |     pass
@@ -285,7 +285,7 @@ UP015.py:19:6: UP015 [*] Unnecessary open mode argument
 21 21 | with open("foo", "rt") as f:
 22 22 |     pass
 
-UP015.py:21:6: UP015 [*] Unnecessary open mode argument
+UP015.py:21:6: UP015 [*] Unnecessary mode argument
    |
 19 | with open("foo", "r") as f:
 20 |     pass
@@ -294,7 +294,7 @@ UP015.py:21:6: UP015 [*] Unnecessary open mode argument
 22 |     pass
 23 | with open("foo", "r", encoding="UTF-8") as f:
    |
-   = help: Remove open mode argument
+   = help: Remove mode argument
 
 ℹ Safe fix
 18 18 |     pass
@@ -306,7 +306,7 @@ UP015.py:21:6: UP015 [*] Unnecessary open mode argument
 23 23 | with open("foo", "r", encoding="UTF-8") as f:
 24 24 |     pass
 
-UP015.py:23:6: UP015 [*] Unnecessary open mode argument
+UP015.py:23:6: UP015 [*] Unnecessary mode argument
    |
 21 | with open("foo", "rt") as f:
 22 |     pass
@@ -315,7 +315,7 @@ UP015.py:23:6: UP015 [*] Unnecessary open mode argument
 24 |     pass
 25 | with open("foo", "wt") as f:
    |
-   = help: Remove open mode argument
+   = help: Remove mode argument
 
 ℹ Safe fix
 20 20 |     pass
@@ -327,7 +327,7 @@ UP015.py:23:6: UP015 [*] Unnecessary open mode argument
 25 25 | with open("foo", "wt") as f:
 26 26 |     pass
 
-UP015.py:25:6: UP015 [*] Unnecessary open modes, use `w`
+UP015.py:25:6: UP015 [*] Unnecessary modes, use `w`
    |
 23 | with open("foo", "r", encoding="UTF-8") as f:
 24 |     pass
@@ -347,7 +347,7 @@ UP015.py:25:6: UP015 [*] Unnecessary open modes, use `w`
 27 27 | 
 28 28 | open(f("a", "b", "c"), "U")
 
-UP015.py:28:1: UP015 [*] Unnecessary open mode argument
+UP015.py:28:1: UP015 [*] Unnecessary mode argument
    |
 26 |     pass
 27 |
@@ -355,7 +355,7 @@ UP015.py:28:1: UP015 [*] Unnecessary open mode argument
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ UP015
 29 | open(f("a", "b", "c"), "Ub")
    |
-   = help: Remove open mode argument
+   = help: Remove mode argument
 
 ℹ Safe fix
 25 25 | with open("foo", "wt") as f:
@@ -367,7 +367,7 @@ UP015.py:28:1: UP015 [*] Unnecessary open mode argument
 30 30 | 
 31 31 | with open(f("a", "b", "c"), "U") as f:
 
-UP015.py:29:1: UP015 [*] Unnecessary open modes, use `rb`
+UP015.py:29:1: UP015 [*] Unnecessary modes, use `rb`
    |
 28 | open(f("a", "b", "c"), "U")
 29 | open(f("a", "b", "c"), "Ub")
@@ -387,7 +387,7 @@ UP015.py:29:1: UP015 [*] Unnecessary open modes, use `rb`
 31 31 | with open(f("a", "b", "c"), "U") as f:
 32 32 |     pass
 
-UP015.py:31:6: UP015 [*] Unnecessary open mode argument
+UP015.py:31:6: UP015 [*] Unnecessary mode argument
    |
 29 | open(f("a", "b", "c"), "Ub")
 30 |
@@ -396,7 +396,7 @@ UP015.py:31:6: UP015 [*] Unnecessary open mode argument
 32 |     pass
 33 | with open(f("a", "b", "c"), "Ub") as f:
    |
-   = help: Remove open mode argument
+   = help: Remove mode argument
 
 ℹ Safe fix
 28 28 | open(f("a", "b", "c"), "U")
@@ -408,7 +408,7 @@ UP015.py:31:6: UP015 [*] Unnecessary open mode argument
 33 33 | with open(f("a", "b", "c"), "Ub") as f:
 34 34 |     pass
 
-UP015.py:33:6: UP015 [*] Unnecessary open modes, use `rb`
+UP015.py:33:6: UP015 [*] Unnecessary modes, use `rb`
    |
 31 | with open(f("a", "b", "c"), "U") as f:
 32 |     pass
@@ -428,7 +428,7 @@ UP015.py:33:6: UP015 [*] Unnecessary open modes, use `rb`
 35 35 | 
 36 36 | with open("foo", "U") as fa, open("bar", "U") as fb:
 
-UP015.py:36:6: UP015 [*] Unnecessary open mode argument
+UP015.py:36:6: UP015 [*] Unnecessary mode argument
    |
 34 |     pass
 35 |
@@ -437,7 +437,7 @@ UP015.py:36:6: UP015 [*] Unnecessary open mode argument
 37 |     pass
 38 | with open("foo", "Ub") as fa, open("bar", "Ub") as fb:
    |
-   = help: Remove open mode argument
+   = help: Remove mode argument
 
 ℹ Safe fix
 33 33 | with open(f("a", "b", "c"), "Ub") as f:
@@ -449,7 +449,7 @@ UP015.py:36:6: UP015 [*] Unnecessary open mode argument
 38 38 | with open("foo", "Ub") as fa, open("bar", "Ub") as fb:
 39 39 |     pass
 
-UP015.py:36:30: UP015 [*] Unnecessary open mode argument
+UP015.py:36:30: UP015 [*] Unnecessary mode argument
    |
 34 |     pass
 35 |
@@ -458,7 +458,7 @@ UP015.py:36:30: UP015 [*] Unnecessary open mode argument
 37 |     pass
 38 | with open("foo", "Ub") as fa, open("bar", "Ub") as fb:
    |
-   = help: Remove open mode argument
+   = help: Remove mode argument
 
 ℹ Safe fix
 33 33 | with open(f("a", "b", "c"), "Ub") as f:
@@ -470,7 +470,7 @@ UP015.py:36:30: UP015 [*] Unnecessary open mode argument
 38 38 | with open("foo", "Ub") as fa, open("bar", "Ub") as fb:
 39 39 |     pass
 
-UP015.py:38:6: UP015 [*] Unnecessary open modes, use `rb`
+UP015.py:38:6: UP015 [*] Unnecessary modes, use `rb`
    |
 36 | with open("foo", "U") as fa, open("bar", "U") as fb:
 37 |     pass
@@ -490,7 +490,7 @@ UP015.py:38:6: UP015 [*] Unnecessary open modes, use `rb`
 40 40 | 
 41 41 | open("foo", mode="U")
 
-UP015.py:38:31: UP015 [*] Unnecessary open modes, use `rb`
+UP015.py:38:31: UP015 [*] Unnecessary modes, use `rb`
    |
 36 | with open("foo", "U") as fa, open("bar", "U") as fb:
 37 |     pass
@@ -510,7 +510,7 @@ UP015.py:38:31: UP015 [*] Unnecessary open modes, use `rb`
 40 40 | 
 41 41 | open("foo", mode="U")
 
-UP015.py:41:1: UP015 [*] Unnecessary open mode argument
+UP015.py:41:1: UP015 [*] Unnecessary mode argument
    |
 39 |     pass
 40 |
@@ -519,7 +519,7 @@ UP015.py:41:1: UP015 [*] Unnecessary open mode argument
 42 | open(name="foo", mode="U")
 43 | open(mode="U", name="foo")
    |
-   = help: Remove open mode argument
+   = help: Remove mode argument
 
 ℹ Safe fix
 38 38 | with open("foo", "Ub") as fa, open("bar", "Ub") as fb:
@@ -531,14 +531,14 @@ UP015.py:41:1: UP015 [*] Unnecessary open mode argument
 43 43 | open(mode="U", name="foo")
 44 44 | 
 
-UP015.py:42:1: UP015 [*] Unnecessary open mode argument
+UP015.py:42:1: UP015 [*] Unnecessary mode argument
    |
 41 | open("foo", mode="U")
 42 | open(name="foo", mode="U")
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^ UP015
 43 | open(mode="U", name="foo")
    |
-   = help: Remove open mode argument
+   = help: Remove mode argument
 
 ℹ Safe fix
 39 39 |     pass
@@ -550,7 +550,7 @@ UP015.py:42:1: UP015 [*] Unnecessary open mode argument
 44 44 | 
 45 45 | with open("foo", mode="U") as f:
 
-UP015.py:43:1: UP015 [*] Unnecessary open mode argument
+UP015.py:43:1: UP015 [*] Unnecessary mode argument
    |
 41 | open("foo", mode="U")
 42 | open(name="foo", mode="U")
@@ -559,7 +559,7 @@ UP015.py:43:1: UP015 [*] Unnecessary open mode argument
 44 |
 45 | with open("foo", mode="U") as f:
    |
-   = help: Remove open mode argument
+   = help: Remove mode argument
 
 ℹ Safe fix
 40 40 | 
@@ -571,7 +571,7 @@ UP015.py:43:1: UP015 [*] Unnecessary open mode argument
 45 45 | with open("foo", mode="U") as f:
 46 46 |     pass
 
-UP015.py:45:6: UP015 [*] Unnecessary open mode argument
+UP015.py:45:6: UP015 [*] Unnecessary mode argument
    |
 43 | open(mode="U", name="foo")
 44 |
@@ -580,7 +580,7 @@ UP015.py:45:6: UP015 [*] Unnecessary open mode argument
 46 |     pass
 47 | with open(name="foo", mode="U") as f:
    |
-   = help: Remove open mode argument
+   = help: Remove mode argument
 
 ℹ Safe fix
 42 42 | open(name="foo", mode="U")
@@ -592,7 +592,7 @@ UP015.py:45:6: UP015 [*] Unnecessary open mode argument
 47 47 | with open(name="foo", mode="U") as f:
 48 48 |     pass
 
-UP015.py:47:6: UP015 [*] Unnecessary open mode argument
+UP015.py:47:6: UP015 [*] Unnecessary mode argument
    |
 45 | with open("foo", mode="U") as f:
 46 |     pass
@@ -601,7 +601,7 @@ UP015.py:47:6: UP015 [*] Unnecessary open mode argument
 48 |     pass
 49 | with open(mode="U", name="foo") as f:
    |
-   = help: Remove open mode argument
+   = help: Remove mode argument
 
 ℹ Safe fix
 44 44 | 
@@ -613,7 +613,7 @@ UP015.py:47:6: UP015 [*] Unnecessary open mode argument
 49 49 | with open(mode="U", name="foo") as f:
 50 50 |     pass
 
-UP015.py:49:6: UP015 [*] Unnecessary open mode argument
+UP015.py:49:6: UP015 [*] Unnecessary mode argument
    |
 47 | with open(name="foo", mode="U") as f:
 48 |     pass
@@ -621,7 +621,7 @@ UP015.py:49:6: UP015 [*] Unnecessary open mode argument
    |      ^^^^^^^^^^^^^^^^^^^^^^^^^^ UP015
 50 |     pass
    |
-   = help: Remove open mode argument
+   = help: Remove mode argument
 
 ℹ Safe fix
 46 46 |     pass
@@ -633,7 +633,7 @@ UP015.py:49:6: UP015 [*] Unnecessary open mode argument
 51 51 | 
 52 52 | open("foo", mode="Ub")
 
-UP015.py:52:1: UP015 [*] Unnecessary open modes, use `rb`
+UP015.py:52:1: UP015 [*] Unnecessary modes, use `rb`
    |
 50 |     pass
 51 |
@@ -654,7 +654,7 @@ UP015.py:52:1: UP015 [*] Unnecessary open modes, use `rb`
 54 54 | open(mode="Ub", name="foo")
 55 55 | 
 
-UP015.py:53:1: UP015 [*] Unnecessary open modes, use `rb`
+UP015.py:53:1: UP015 [*] Unnecessary modes, use `rb`
    |
 52 | open("foo", mode="Ub")
 53 | open(name="foo", mode="Ub")
@@ -673,7 +673,7 @@ UP015.py:53:1: UP015 [*] Unnecessary open modes, use `rb`
 55 55 | 
 56 56 | with open("foo", mode="Ub") as f:
 
-UP015.py:54:1: UP015 [*] Unnecessary open modes, use `rb`
+UP015.py:54:1: UP015 [*] Unnecessary modes, use `rb`
    |
 52 | open("foo", mode="Ub")
 53 | open(name="foo", mode="Ub")
@@ -694,7 +694,7 @@ UP015.py:54:1: UP015 [*] Unnecessary open modes, use `rb`
 56 56 | with open("foo", mode="Ub") as f:
 57 57 |     pass
 
-UP015.py:56:6: UP015 [*] Unnecessary open modes, use `rb`
+UP015.py:56:6: UP015 [*] Unnecessary modes, use `rb`
    |
 54 | open(mode="Ub", name="foo")
 55 |
@@ -715,7 +715,7 @@ UP015.py:56:6: UP015 [*] Unnecessary open modes, use `rb`
 58 58 | with open(name="foo", mode="Ub") as f:
 59 59 |     pass
 
-UP015.py:58:6: UP015 [*] Unnecessary open modes, use `rb`
+UP015.py:58:6: UP015 [*] Unnecessary modes, use `rb`
    |
 56 | with open("foo", mode="Ub") as f:
 57 |     pass
@@ -736,7 +736,7 @@ UP015.py:58:6: UP015 [*] Unnecessary open modes, use `rb`
 60 60 | with open(mode="Ub", name="foo") as f:
 61 61 |     pass
 
-UP015.py:60:6: UP015 [*] Unnecessary open modes, use `rb`
+UP015.py:60:6: UP015 [*] Unnecessary modes, use `rb`
    |
 58 | with open(name="foo", mode="Ub") as f:
 59 |     pass
@@ -756,7 +756,7 @@ UP015.py:60:6: UP015 [*] Unnecessary open modes, use `rb`
 62 62 | 
 63 63 | open(file="foo", mode='U', buffering=-1, encoding=None, errors=None, newline=None, closefd=True, opener=None)
 
-UP015.py:63:1: UP015 [*] Unnecessary open mode argument
+UP015.py:63:1: UP015 [*] Unnecessary mode argument
    |
 61 |     pass
 62 |
@@ -765,7 +765,7 @@ UP015.py:63:1: UP015 [*] Unnecessary open mode argument
 64 | open(file="foo", buffering=-1, encoding=None, errors=None, newline=None, closefd=True, opener=None, mode='U')
 65 | open(file="foo", buffering=-1, encoding=None, errors=None, mode='U', newline=None, closefd=True, opener=None)
    |
-   = help: Remove open mode argument
+   = help: Remove mode argument
 
 ℹ Safe fix
 60 60 | with open(mode="Ub", name="foo") as f:
@@ -777,7 +777,7 @@ UP015.py:63:1: UP015 [*] Unnecessary open mode argument
 65 65 | open(file="foo", buffering=-1, encoding=None, errors=None, mode='U', newline=None, closefd=True, opener=None)
 66 66 | open(mode='U', file="foo", buffering=-1, encoding=None, errors=None, newline=None, closefd=True, opener=None)
 
-UP015.py:64:1: UP015 [*] Unnecessary open mode argument
+UP015.py:64:1: UP015 [*] Unnecessary mode argument
    |
 63 | open(file="foo", mode='U', buffering=-1, encoding=None, errors=None, newline=None, closefd=True, opener=None)
 64 | open(file="foo", buffering=-1, encoding=None, errors=None, newline=None, closefd=True, opener=None, mode='U')
@@ -785,7 +785,7 @@ UP015.py:64:1: UP015 [*] Unnecessary open mode argument
 65 | open(file="foo", buffering=-1, encoding=None, errors=None, mode='U', newline=None, closefd=True, opener=None)
 66 | open(mode='U', file="foo", buffering=-1, encoding=None, errors=None, newline=None, closefd=True, opener=None)
    |
-   = help: Remove open mode argument
+   = help: Remove mode argument
 
 ℹ Safe fix
 61 61 |     pass
@@ -797,7 +797,7 @@ UP015.py:64:1: UP015 [*] Unnecessary open mode argument
 66 66 | open(mode='U', file="foo", buffering=-1, encoding=None, errors=None, newline=None, closefd=True, opener=None)
 67 67 | 
 
-UP015.py:65:1: UP015 [*] Unnecessary open mode argument
+UP015.py:65:1: UP015 [*] Unnecessary mode argument
    |
 63 | open(file="foo", mode='U', buffering=-1, encoding=None, errors=None, newline=None, closefd=True, opener=None)
 64 | open(file="foo", buffering=-1, encoding=None, errors=None, newline=None, closefd=True, opener=None, mode='U')
@@ -805,7 +805,7 @@ UP015.py:65:1: UP015 [*] Unnecessary open mode argument
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ UP015
 66 | open(mode='U', file="foo", buffering=-1, encoding=None, errors=None, newline=None, closefd=True, opener=None)
    |
-   = help: Remove open mode argument
+   = help: Remove mode argument
 
 ℹ Safe fix
 62 62 | 
@@ -817,7 +817,7 @@ UP015.py:65:1: UP015 [*] Unnecessary open mode argument
 67 67 | 
 68 68 | open(file="foo", mode='Ub', buffering=-1, encoding=None, errors=None, newline=None, closefd=True, opener=None)
 
-UP015.py:66:1: UP015 [*] Unnecessary open mode argument
+UP015.py:66:1: UP015 [*] Unnecessary mode argument
    |
 64 | open(file="foo", buffering=-1, encoding=None, errors=None, newline=None, closefd=True, opener=None, mode='U')
 65 | open(file="foo", buffering=-1, encoding=None, errors=None, mode='U', newline=None, closefd=True, opener=None)
@@ -826,7 +826,7 @@ UP015.py:66:1: UP015 [*] Unnecessary open mode argument
 67 |
 68 | open(file="foo", mode='Ub', buffering=-1, encoding=None, errors=None, newline=None, closefd=True, opener=None)
    |
-   = help: Remove open mode argument
+   = help: Remove mode argument
 
 ℹ Safe fix
 63 63 | open(file="foo", mode='U', buffering=-1, encoding=None, errors=None, newline=None, closefd=True, opener=None)
@@ -838,7 +838,7 @@ UP015.py:66:1: UP015 [*] Unnecessary open mode argument
 68 68 | open(file="foo", mode='Ub', buffering=-1, encoding=None, errors=None, newline=None, closefd=True, opener=None)
 69 69 | open(file="foo", buffering=-1, encoding=None, errors=None, newline=None, closefd=True, opener=None, mode='Ub')
 
-UP015.py:68:1: UP015 [*] Unnecessary open modes, use `rb`
+UP015.py:68:1: UP015 [*] Unnecessary modes, use `rb`
    |
 66 | open(mode='U', file="foo", buffering=-1, encoding=None, errors=None, newline=None, closefd=True, opener=None)
 67 |
@@ -859,7 +859,7 @@ UP015.py:68:1: UP015 [*] Unnecessary open modes, use `rb`
 70 70 | open(file="foo", buffering=-1, encoding=None, errors=None, mode='Ub', newline=None, closefd=True, opener=None)
 71 71 | open(mode='Ub', file="foo", buffering=-1, encoding=None, errors=None, newline=None, closefd=True, opener=None)
 
-UP015.py:69:1: UP015 [*] Unnecessary open modes, use `rb`
+UP015.py:69:1: UP015 [*] Unnecessary modes, use `rb`
    |
 68 | open(file="foo", mode='Ub', buffering=-1, encoding=None, errors=None, newline=None, closefd=True, opener=None)
 69 | open(file="foo", buffering=-1, encoding=None, errors=None, newline=None, closefd=True, opener=None, mode='Ub')
@@ -879,7 +879,7 @@ UP015.py:69:1: UP015 [*] Unnecessary open modes, use `rb`
 71 71 | open(mode='Ub', file="foo", buffering=-1, encoding=None, errors=None, newline=None, closefd=True, opener=None)
 72 72 | 
 
-UP015.py:70:1: UP015 [*] Unnecessary open modes, use `rb`
+UP015.py:70:1: UP015 [*] Unnecessary modes, use `rb`
    |
 68 | open(file="foo", mode='Ub', buffering=-1, encoding=None, errors=None, newline=None, closefd=True, opener=None)
 69 | open(file="foo", buffering=-1, encoding=None, errors=None, newline=None, closefd=True, opener=None, mode='Ub')
@@ -899,7 +899,7 @@ UP015.py:70:1: UP015 [*] Unnecessary open modes, use `rb`
 72 72 | 
 73 73 | import aiofiles
 
-UP015.py:71:1: UP015 [*] Unnecessary open modes, use `rb`
+UP015.py:71:1: UP015 [*] Unnecessary modes, use `rb`
    |
 69 | open(file="foo", buffering=-1, encoding=None, errors=None, newline=None, closefd=True, opener=None, mode='Ub')
 70 | open(file="foo", buffering=-1, encoding=None, errors=None, mode='Ub', newline=None, closefd=True, opener=None)
@@ -920,7 +920,7 @@ UP015.py:71:1: UP015 [*] Unnecessary open modes, use `rb`
 73 73 | import aiofiles
 74 74 | 
 
-UP015.py:75:1: UP015 [*] Unnecessary open mode argument
+UP015.py:75:1: UP015 [*] Unnecessary mode argument
    |
 73 | import aiofiles
 74 |
@@ -929,7 +929,7 @@ UP015.py:75:1: UP015 [*] Unnecessary open mode argument
 76 | aiofiles.open("foo", "r")
 77 | aiofiles.open("foo", mode="r")
    |
-   = help: Remove open mode argument
+   = help: Remove mode argument
 
 ℹ Safe fix
 72 72 | 
@@ -941,14 +941,14 @@ UP015.py:75:1: UP015 [*] Unnecessary open mode argument
 77 77 | aiofiles.open("foo", mode="r")
 78 78 | 
 
-UP015.py:76:1: UP015 [*] Unnecessary open mode argument
+UP015.py:76:1: UP015 [*] Unnecessary mode argument
    |
 75 | aiofiles.open("foo", "U")
 76 | aiofiles.open("foo", "r")
    | ^^^^^^^^^^^^^^^^^^^^^^^^^ UP015
 77 | aiofiles.open("foo", mode="r")
    |
-   = help: Remove open mode argument
+   = help: Remove mode argument
 
 ℹ Safe fix
 73 73 | import aiofiles
@@ -960,7 +960,7 @@ UP015.py:76:1: UP015 [*] Unnecessary open mode argument
 78 78 | 
 79 79 | open("foo", "r+")
 
-UP015.py:77:1: UP015 [*] Unnecessary open mode argument
+UP015.py:77:1: UP015 [*] Unnecessary mode argument
    |
 75 | aiofiles.open("foo", "U")
 76 | aiofiles.open("foo", "r")
@@ -969,7 +969,7 @@ UP015.py:77:1: UP015 [*] Unnecessary open mode argument
 78 |
 79 | open("foo", "r+")
    |
-   = help: Remove open mode argument
+   = help: Remove mode argument
 
 ℹ Safe fix
 74 74 | 

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP015_1.py.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP015_1.py.snap
@@ -1,14 +1,14 @@
 ---
 source: crates/ruff_linter/src/rules/pyupgrade/mod.rs
 ---
-UP015_1.py:3:5: UP015 [*] Unnecessary open mode argument
+UP015_1.py:3:5: UP015 [*] Unnecessary mode argument
   |
 1 | # Not a valid type annotation but this test shouldn't result in a panic.
 2 | # Refer: https://github.com/astral-sh/ruff/issues/11736
 3 | x: 'open("foo", "r")'
   |     ^^^^^^^^^^^^^^^^ UP015
   |
-  = help: Remove open mode argument
+  = help: Remove mode argument
 
 ℹ Safe fix
 1 1 | # Not a valid type annotation but this test shouldn't result in a panic.

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__preview__UP015_UP015.py.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__preview__UP015_UP015.py.snap
@@ -1,10 +1,10 @@
 ---
 source: crates/ruff_linter/src/rules/pyupgrade/mod.rs
 ---
-UP015.py:1:1: UP015 [*] Unnecessary open mode argument
+UP015.py:1:13: UP015 [*] Unnecessary open mode argument
   |
 1 | open("foo", "U")
-  | ^^^^^^^^^^^^^^^^ UP015
+  |             ^^^ UP015
 2 | open("foo", "Ur")
 3 | open("foo", "Ub")
   |
@@ -17,11 +17,11 @@ UP015.py:1:1: UP015 [*] Unnecessary open mode argument
 3 3 | open("foo", "Ub")
 4 4 | open("foo", "rUb")
 
-UP015.py:2:1: UP015 [*] Unnecessary open mode argument
+UP015.py:2:13: UP015 [*] Unnecessary open mode argument
   |
 1 | open("foo", "U")
 2 | open("foo", "Ur")
-  | ^^^^^^^^^^^^^^^^^ UP015
+  |             ^^^^ UP015
 3 | open("foo", "Ub")
 4 | open("foo", "rUb")
   |
@@ -35,12 +35,12 @@ UP015.py:2:1: UP015 [*] Unnecessary open mode argument
 4 4 | open("foo", "rUb")
 5 5 | open("foo", "r")
 
-UP015.py:3:1: UP015 [*] Unnecessary open modes, use `rb`
+UP015.py:3:13: UP015 [*] Unnecessary open modes, use `rb`
   |
 1 | open("foo", "U")
 2 | open("foo", "Ur")
 3 | open("foo", "Ub")
-  | ^^^^^^^^^^^^^^^^^ UP015
+  |             ^^^^ UP015
 4 | open("foo", "rUb")
 5 | open("foo", "r")
   |
@@ -55,12 +55,12 @@ UP015.py:3:1: UP015 [*] Unnecessary open modes, use `rb`
 5 5 | open("foo", "r")
 6 6 | open("foo", "rt")
 
-UP015.py:4:1: UP015 [*] Unnecessary open modes, use `rb`
+UP015.py:4:13: UP015 [*] Unnecessary open modes, use `rb`
   |
 2 | open("foo", "Ur")
 3 | open("foo", "Ub")
 4 | open("foo", "rUb")
-  | ^^^^^^^^^^^^^^^^^^ UP015
+  |             ^^^^^ UP015
 5 | open("foo", "r")
 6 | open("foo", "rt")
   |
@@ -76,12 +76,12 @@ UP015.py:4:1: UP015 [*] Unnecessary open modes, use `rb`
 6 6 | open("foo", "rt")
 7 7 | open("f", "r", encoding="UTF-8")
 
-UP015.py:5:1: UP015 [*] Unnecessary open mode argument
+UP015.py:5:13: UP015 [*] Unnecessary open mode argument
   |
 3 | open("foo", "Ub")
 4 | open("foo", "rUb")
 5 | open("foo", "r")
-  | ^^^^^^^^^^^^^^^^ UP015
+  |             ^^^ UP015
 6 | open("foo", "rt")
 7 | open("f", "r", encoding="UTF-8")
   |
@@ -97,12 +97,12 @@ UP015.py:5:1: UP015 [*] Unnecessary open mode argument
 7 7 | open("f", "r", encoding="UTF-8")
 8 8 | open("f", "wt")
 
-UP015.py:6:1: UP015 [*] Unnecessary open mode argument
+UP015.py:6:13: UP015 [*] Unnecessary open mode argument
   |
 4 | open("foo", "rUb")
 5 | open("foo", "r")
 6 | open("foo", "rt")
-  | ^^^^^^^^^^^^^^^^^ UP015
+  |             ^^^^ UP015
 7 | open("f", "r", encoding="UTF-8")
 8 | open("f", "wt")
   |
@@ -118,12 +118,12 @@ UP015.py:6:1: UP015 [*] Unnecessary open mode argument
 8 8 | open("f", "wt")
 9 9 | open("f", "tw")
 
-UP015.py:7:1: UP015 [*] Unnecessary open mode argument
+UP015.py:7:11: UP015 [*] Unnecessary open mode argument
   |
 5 | open("foo", "r")
 6 | open("foo", "rt")
 7 | open("f", "r", encoding="UTF-8")
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ UP015
+  |           ^^^ UP015
 8 | open("f", "wt")
 9 | open("f", "tw")
   |
@@ -139,12 +139,12 @@ UP015.py:7:1: UP015 [*] Unnecessary open mode argument
 9 9 | open("f", "tw")
 10 10 | 
 
-UP015.py:8:1: UP015 [*] Unnecessary open modes, use `w`
+UP015.py:8:11: UP015 [*] Unnecessary open modes, use `w`
   |
 6 | open("foo", "rt")
 7 | open("f", "r", encoding="UTF-8")
 8 | open("f", "wt")
-  | ^^^^^^^^^^^^^^^ UP015
+  |           ^^^^ UP015
 9 | open("f", "tw")
   |
   = help: Replace with `w`
@@ -159,12 +159,12 @@ UP015.py:8:1: UP015 [*] Unnecessary open modes, use `w`
 10 10 | 
 11 11 | with open("foo", "U") as f:
 
-UP015.py:9:1: UP015 [*] Unnecessary open modes, use `w`
+UP015.py:9:11: UP015 [*] Unnecessary open modes, use `w`
    |
  7 | open("f", "r", encoding="UTF-8")
  8 | open("f", "wt")
  9 | open("f", "tw")
-   | ^^^^^^^^^^^^^^^ UP015
+   |           ^^^^ UP015
 10 |
 11 | with open("foo", "U") as f:
    |
@@ -180,12 +180,12 @@ UP015.py:9:1: UP015 [*] Unnecessary open modes, use `w`
 11 11 | with open("foo", "U") as f:
 12 12 |     pass
 
-UP015.py:11:6: UP015 [*] Unnecessary open mode argument
+UP015.py:11:18: UP015 [*] Unnecessary open mode argument
    |
  9 | open("f", "tw")
 10 |
 11 | with open("foo", "U") as f:
-   |      ^^^^^^^^^^^^^^^^ UP015
+   |                  ^^^ UP015
 12 |     pass
 13 | with open("foo", "Ur") as f:
    |
@@ -201,12 +201,12 @@ UP015.py:11:6: UP015 [*] Unnecessary open mode argument
 13 13 | with open("foo", "Ur") as f:
 14 14 |     pass
 
-UP015.py:13:6: UP015 [*] Unnecessary open mode argument
+UP015.py:13:18: UP015 [*] Unnecessary open mode argument
    |
 11 | with open("foo", "U") as f:
 12 |     pass
 13 | with open("foo", "Ur") as f:
-   |      ^^^^^^^^^^^^^^^^^ UP015
+   |                  ^^^^ UP015
 14 |     pass
 15 | with open("foo", "Ub") as f:
    |
@@ -222,12 +222,12 @@ UP015.py:13:6: UP015 [*] Unnecessary open mode argument
 15 15 | with open("foo", "Ub") as f:
 16 16 |     pass
 
-UP015.py:15:6: UP015 [*] Unnecessary open modes, use `rb`
+UP015.py:15:18: UP015 [*] Unnecessary open modes, use `rb`
    |
 13 | with open("foo", "Ur") as f:
 14 |     pass
 15 | with open("foo", "Ub") as f:
-   |      ^^^^^^^^^^^^^^^^^ UP015
+   |                  ^^^^ UP015
 16 |     pass
 17 | with open("foo", "rUb") as f:
    |
@@ -243,12 +243,12 @@ UP015.py:15:6: UP015 [*] Unnecessary open modes, use `rb`
 17 17 | with open("foo", "rUb") as f:
 18 18 |     pass
 
-UP015.py:17:6: UP015 [*] Unnecessary open modes, use `rb`
+UP015.py:17:18: UP015 [*] Unnecessary open modes, use `rb`
    |
 15 | with open("foo", "Ub") as f:
 16 |     pass
 17 | with open("foo", "rUb") as f:
-   |      ^^^^^^^^^^^^^^^^^^ UP015
+   |                  ^^^^^ UP015
 18 |     pass
 19 | with open("foo", "r") as f:
    |
@@ -264,12 +264,12 @@ UP015.py:17:6: UP015 [*] Unnecessary open modes, use `rb`
 19 19 | with open("foo", "r") as f:
 20 20 |     pass
 
-UP015.py:19:6: UP015 [*] Unnecessary open mode argument
+UP015.py:19:18: UP015 [*] Unnecessary open mode argument
    |
 17 | with open("foo", "rUb") as f:
 18 |     pass
 19 | with open("foo", "r") as f:
-   |      ^^^^^^^^^^^^^^^^ UP015
+   |                  ^^^ UP015
 20 |     pass
 21 | with open("foo", "rt") as f:
    |
@@ -285,12 +285,12 @@ UP015.py:19:6: UP015 [*] Unnecessary open mode argument
 21 21 | with open("foo", "rt") as f:
 22 22 |     pass
 
-UP015.py:21:6: UP015 [*] Unnecessary open mode argument
+UP015.py:21:18: UP015 [*] Unnecessary open mode argument
    |
 19 | with open("foo", "r") as f:
 20 |     pass
 21 | with open("foo", "rt") as f:
-   |      ^^^^^^^^^^^^^^^^^ UP015
+   |                  ^^^^ UP015
 22 |     pass
 23 | with open("foo", "r", encoding="UTF-8") as f:
    |
@@ -306,12 +306,12 @@ UP015.py:21:6: UP015 [*] Unnecessary open mode argument
 23 23 | with open("foo", "r", encoding="UTF-8") as f:
 24 24 |     pass
 
-UP015.py:23:6: UP015 [*] Unnecessary open mode argument
+UP015.py:23:18: UP015 [*] Unnecessary open mode argument
    |
 21 | with open("foo", "rt") as f:
 22 |     pass
 23 | with open("foo", "r", encoding="UTF-8") as f:
-   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ UP015
+   |                  ^^^ UP015
 24 |     pass
 25 | with open("foo", "wt") as f:
    |
@@ -327,12 +327,12 @@ UP015.py:23:6: UP015 [*] Unnecessary open mode argument
 25 25 | with open("foo", "wt") as f:
 26 26 |     pass
 
-UP015.py:25:6: UP015 [*] Unnecessary open modes, use `w`
+UP015.py:25:18: UP015 [*] Unnecessary open modes, use `w`
    |
 23 | with open("foo", "r", encoding="UTF-8") as f:
 24 |     pass
 25 | with open("foo", "wt") as f:
-   |      ^^^^^^^^^^^^^^^^^ UP015
+   |                  ^^^^ UP015
 26 |     pass
    |
    = help: Replace with `w`
@@ -347,12 +347,12 @@ UP015.py:25:6: UP015 [*] Unnecessary open modes, use `w`
 27 27 | 
 28 28 | open(f("a", "b", "c"), "U")
 
-UP015.py:28:1: UP015 [*] Unnecessary open mode argument
+UP015.py:28:24: UP015 [*] Unnecessary open mode argument
    |
 26 |     pass
 27 |
 28 | open(f("a", "b", "c"), "U")
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ UP015
+   |                        ^^^ UP015
 29 | open(f("a", "b", "c"), "Ub")
    |
    = help: Remove open mode argument
@@ -367,11 +367,11 @@ UP015.py:28:1: UP015 [*] Unnecessary open mode argument
 30 30 | 
 31 31 | with open(f("a", "b", "c"), "U") as f:
 
-UP015.py:29:1: UP015 [*] Unnecessary open modes, use `rb`
+UP015.py:29:24: UP015 [*] Unnecessary open modes, use `rb`
    |
 28 | open(f("a", "b", "c"), "U")
 29 | open(f("a", "b", "c"), "Ub")
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ UP015
+   |                        ^^^^ UP015
 30 |
 31 | with open(f("a", "b", "c"), "U") as f:
    |
@@ -387,12 +387,12 @@ UP015.py:29:1: UP015 [*] Unnecessary open modes, use `rb`
 31 31 | with open(f("a", "b", "c"), "U") as f:
 32 32 |     pass
 
-UP015.py:31:6: UP015 [*] Unnecessary open mode argument
+UP015.py:31:29: UP015 [*] Unnecessary open mode argument
    |
 29 | open(f("a", "b", "c"), "Ub")
 30 |
 31 | with open(f("a", "b", "c"), "U") as f:
-   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^ UP015
+   |                             ^^^ UP015
 32 |     pass
 33 | with open(f("a", "b", "c"), "Ub") as f:
    |
@@ -408,12 +408,12 @@ UP015.py:31:6: UP015 [*] Unnecessary open mode argument
 33 33 | with open(f("a", "b", "c"), "Ub") as f:
 34 34 |     pass
 
-UP015.py:33:6: UP015 [*] Unnecessary open modes, use `rb`
+UP015.py:33:29: UP015 [*] Unnecessary open modes, use `rb`
    |
 31 | with open(f("a", "b", "c"), "U") as f:
 32 |     pass
 33 | with open(f("a", "b", "c"), "Ub") as f:
-   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ UP015
+   |                             ^^^^ UP015
 34 |     pass
    |
    = help: Replace with `rb`
@@ -428,12 +428,12 @@ UP015.py:33:6: UP015 [*] Unnecessary open modes, use `rb`
 35 35 | 
 36 36 | with open("foo", "U") as fa, open("bar", "U") as fb:
 
-UP015.py:36:6: UP015 [*] Unnecessary open mode argument
+UP015.py:36:18: UP015 [*] Unnecessary open mode argument
    |
 34 |     pass
 35 |
 36 | with open("foo", "U") as fa, open("bar", "U") as fb:
-   |      ^^^^^^^^^^^^^^^^ UP015
+   |                  ^^^ UP015
 37 |     pass
 38 | with open("foo", "Ub") as fa, open("bar", "Ub") as fb:
    |
@@ -449,12 +449,12 @@ UP015.py:36:6: UP015 [*] Unnecessary open mode argument
 38 38 | with open("foo", "Ub") as fa, open("bar", "Ub") as fb:
 39 39 |     pass
 
-UP015.py:36:30: UP015 [*] Unnecessary open mode argument
+UP015.py:36:42: UP015 [*] Unnecessary open mode argument
    |
 34 |     pass
 35 |
 36 | with open("foo", "U") as fa, open("bar", "U") as fb:
-   |                              ^^^^^^^^^^^^^^^^ UP015
+   |                                          ^^^ UP015
 37 |     pass
 38 | with open("foo", "Ub") as fa, open("bar", "Ub") as fb:
    |
@@ -470,12 +470,12 @@ UP015.py:36:30: UP015 [*] Unnecessary open mode argument
 38 38 | with open("foo", "Ub") as fa, open("bar", "Ub") as fb:
 39 39 |     pass
 
-UP015.py:38:6: UP015 [*] Unnecessary open modes, use `rb`
+UP015.py:38:18: UP015 [*] Unnecessary open modes, use `rb`
    |
 36 | with open("foo", "U") as fa, open("bar", "U") as fb:
 37 |     pass
 38 | with open("foo", "Ub") as fa, open("bar", "Ub") as fb:
-   |      ^^^^^^^^^^^^^^^^^ UP015
+   |                  ^^^^ UP015
 39 |     pass
    |
    = help: Replace with `rb`
@@ -490,12 +490,12 @@ UP015.py:38:6: UP015 [*] Unnecessary open modes, use `rb`
 40 40 | 
 41 41 | open("foo", mode="U")
 
-UP015.py:38:31: UP015 [*] Unnecessary open modes, use `rb`
+UP015.py:38:43: UP015 [*] Unnecessary open modes, use `rb`
    |
 36 | with open("foo", "U") as fa, open("bar", "U") as fb:
 37 |     pass
 38 | with open("foo", "Ub") as fa, open("bar", "Ub") as fb:
-   |                               ^^^^^^^^^^^^^^^^^ UP015
+   |                                           ^^^^ UP015
 39 |     pass
    |
    = help: Replace with `rb`
@@ -510,12 +510,12 @@ UP015.py:38:31: UP015 [*] Unnecessary open modes, use `rb`
 40 40 | 
 41 41 | open("foo", mode="U")
 
-UP015.py:41:1: UP015 [*] Unnecessary open mode argument
+UP015.py:41:18: UP015 [*] Unnecessary open mode argument
    |
 39 |     pass
 40 |
 41 | open("foo", mode="U")
-   | ^^^^^^^^^^^^^^^^^^^^^ UP015
+   |                  ^^^ UP015
 42 | open(name="foo", mode="U")
 43 | open(mode="U", name="foo")
    |
@@ -531,11 +531,11 @@ UP015.py:41:1: UP015 [*] Unnecessary open mode argument
 43 43 | open(mode="U", name="foo")
 44 44 | 
 
-UP015.py:42:1: UP015 [*] Unnecessary open mode argument
+UP015.py:42:23: UP015 [*] Unnecessary open mode argument
    |
 41 | open("foo", mode="U")
 42 | open(name="foo", mode="U")
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^ UP015
+   |                       ^^^ UP015
 43 | open(mode="U", name="foo")
    |
    = help: Remove open mode argument
@@ -550,12 +550,12 @@ UP015.py:42:1: UP015 [*] Unnecessary open mode argument
 44 44 | 
 45 45 | with open("foo", mode="U") as f:
 
-UP015.py:43:1: UP015 [*] Unnecessary open mode argument
+UP015.py:43:11: UP015 [*] Unnecessary open mode argument
    |
 41 | open("foo", mode="U")
 42 | open(name="foo", mode="U")
 43 | open(mode="U", name="foo")
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^ UP015
+   |           ^^^ UP015
 44 |
 45 | with open("foo", mode="U") as f:
    |
@@ -571,12 +571,12 @@ UP015.py:43:1: UP015 [*] Unnecessary open mode argument
 45 45 | with open("foo", mode="U") as f:
 46 46 |     pass
 
-UP015.py:45:6: UP015 [*] Unnecessary open mode argument
+UP015.py:45:23: UP015 [*] Unnecessary open mode argument
    |
 43 | open(mode="U", name="foo")
 44 |
 45 | with open("foo", mode="U") as f:
-   |      ^^^^^^^^^^^^^^^^^^^^^ UP015
+   |                       ^^^ UP015
 46 |     pass
 47 | with open(name="foo", mode="U") as f:
    |
@@ -592,12 +592,12 @@ UP015.py:45:6: UP015 [*] Unnecessary open mode argument
 47 47 | with open(name="foo", mode="U") as f:
 48 48 |     pass
 
-UP015.py:47:6: UP015 [*] Unnecessary open mode argument
+UP015.py:47:28: UP015 [*] Unnecessary open mode argument
    |
 45 | with open("foo", mode="U") as f:
 46 |     pass
 47 | with open(name="foo", mode="U") as f:
-   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^ UP015
+   |                            ^^^ UP015
 48 |     pass
 49 | with open(mode="U", name="foo") as f:
    |
@@ -613,12 +613,12 @@ UP015.py:47:6: UP015 [*] Unnecessary open mode argument
 49 49 | with open(mode="U", name="foo") as f:
 50 50 |     pass
 
-UP015.py:49:6: UP015 [*] Unnecessary open mode argument
+UP015.py:49:16: UP015 [*] Unnecessary open mode argument
    |
 47 | with open(name="foo", mode="U") as f:
 48 |     pass
 49 | with open(mode="U", name="foo") as f:
-   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^ UP015
+   |                ^^^ UP015
 50 |     pass
    |
    = help: Remove open mode argument
@@ -633,12 +633,12 @@ UP015.py:49:6: UP015 [*] Unnecessary open mode argument
 51 51 | 
 52 52 | open("foo", mode="Ub")
 
-UP015.py:52:1: UP015 [*] Unnecessary open modes, use `rb`
+UP015.py:52:18: UP015 [*] Unnecessary open modes, use `rb`
    |
 50 |     pass
 51 |
 52 | open("foo", mode="Ub")
-   | ^^^^^^^^^^^^^^^^^^^^^^ UP015
+   |                  ^^^^ UP015
 53 | open(name="foo", mode="Ub")
 54 | open(mode="Ub", name="foo")
    |
@@ -654,11 +654,11 @@ UP015.py:52:1: UP015 [*] Unnecessary open modes, use `rb`
 54 54 | open(mode="Ub", name="foo")
 55 55 | 
 
-UP015.py:53:1: UP015 [*] Unnecessary open modes, use `rb`
+UP015.py:53:23: UP015 [*] Unnecessary open modes, use `rb`
    |
 52 | open("foo", mode="Ub")
 53 | open(name="foo", mode="Ub")
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ UP015
+   |                       ^^^^ UP015
 54 | open(mode="Ub", name="foo")
    |
    = help: Replace with `rb`
@@ -673,12 +673,12 @@ UP015.py:53:1: UP015 [*] Unnecessary open modes, use `rb`
 55 55 | 
 56 56 | with open("foo", mode="Ub") as f:
 
-UP015.py:54:1: UP015 [*] Unnecessary open modes, use `rb`
+UP015.py:54:11: UP015 [*] Unnecessary open modes, use `rb`
    |
 52 | open("foo", mode="Ub")
 53 | open(name="foo", mode="Ub")
 54 | open(mode="Ub", name="foo")
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ UP015
+   |           ^^^^ UP015
 55 |
 56 | with open("foo", mode="Ub") as f:
    |
@@ -694,12 +694,12 @@ UP015.py:54:1: UP015 [*] Unnecessary open modes, use `rb`
 56 56 | with open("foo", mode="Ub") as f:
 57 57 |     pass
 
-UP015.py:56:6: UP015 [*] Unnecessary open modes, use `rb`
+UP015.py:56:23: UP015 [*] Unnecessary open modes, use `rb`
    |
 54 | open(mode="Ub", name="foo")
 55 |
 56 | with open("foo", mode="Ub") as f:
-   |      ^^^^^^^^^^^^^^^^^^^^^^ UP015
+   |                       ^^^^ UP015
 57 |     pass
 58 | with open(name="foo", mode="Ub") as f:
    |
@@ -715,12 +715,12 @@ UP015.py:56:6: UP015 [*] Unnecessary open modes, use `rb`
 58 58 | with open(name="foo", mode="Ub") as f:
 59 59 |     pass
 
-UP015.py:58:6: UP015 [*] Unnecessary open modes, use `rb`
+UP015.py:58:28: UP015 [*] Unnecessary open modes, use `rb`
    |
 56 | with open("foo", mode="Ub") as f:
 57 |     pass
 58 | with open(name="foo", mode="Ub") as f:
-   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^ UP015
+   |                            ^^^^ UP015
 59 |     pass
 60 | with open(mode="Ub", name="foo") as f:
    |
@@ -736,12 +736,12 @@ UP015.py:58:6: UP015 [*] Unnecessary open modes, use `rb`
 60 60 | with open(mode="Ub", name="foo") as f:
 61 61 |     pass
 
-UP015.py:60:6: UP015 [*] Unnecessary open modes, use `rb`
+UP015.py:60:16: UP015 [*] Unnecessary open modes, use `rb`
    |
 58 | with open(name="foo", mode="Ub") as f:
 59 |     pass
 60 | with open(mode="Ub", name="foo") as f:
-   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^ UP015
+   |                ^^^^ UP015
 61 |     pass
    |
    = help: Replace with `rb`
@@ -756,12 +756,12 @@ UP015.py:60:6: UP015 [*] Unnecessary open modes, use `rb`
 62 62 | 
 63 63 | open(file="foo", mode='U', buffering=-1, encoding=None, errors=None, newline=None, closefd=True, opener=None)
 
-UP015.py:63:1: UP015 [*] Unnecessary open mode argument
+UP015.py:63:23: UP015 [*] Unnecessary open mode argument
    |
 61 |     pass
 62 |
 63 | open(file="foo", mode='U', buffering=-1, encoding=None, errors=None, newline=None, closefd=True, opener=None)
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ UP015
+   |                       ^^^ UP015
 64 | open(file="foo", buffering=-1, encoding=None, errors=None, newline=None, closefd=True, opener=None, mode='U')
 65 | open(file="foo", buffering=-1, encoding=None, errors=None, mode='U', newline=None, closefd=True, opener=None)
    |
@@ -777,11 +777,11 @@ UP015.py:63:1: UP015 [*] Unnecessary open mode argument
 65 65 | open(file="foo", buffering=-1, encoding=None, errors=None, mode='U', newline=None, closefd=True, opener=None)
 66 66 | open(mode='U', file="foo", buffering=-1, encoding=None, errors=None, newline=None, closefd=True, opener=None)
 
-UP015.py:64:1: UP015 [*] Unnecessary open mode argument
+UP015.py:64:106: UP015 [*] Unnecessary open mode argument
    |
 63 | open(file="foo", mode='U', buffering=-1, encoding=None, errors=None, newline=None, closefd=True, opener=None)
 64 | open(file="foo", buffering=-1, encoding=None, errors=None, newline=None, closefd=True, opener=None, mode='U')
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ UP015
+   |                                                                                                          ^^^ UP015
 65 | open(file="foo", buffering=-1, encoding=None, errors=None, mode='U', newline=None, closefd=True, opener=None)
 66 | open(mode='U', file="foo", buffering=-1, encoding=None, errors=None, newline=None, closefd=True, opener=None)
    |
@@ -797,12 +797,12 @@ UP015.py:64:1: UP015 [*] Unnecessary open mode argument
 66 66 | open(mode='U', file="foo", buffering=-1, encoding=None, errors=None, newline=None, closefd=True, opener=None)
 67 67 | 
 
-UP015.py:65:1: UP015 [*] Unnecessary open mode argument
+UP015.py:65:65: UP015 [*] Unnecessary open mode argument
    |
 63 | open(file="foo", mode='U', buffering=-1, encoding=None, errors=None, newline=None, closefd=True, opener=None)
 64 | open(file="foo", buffering=-1, encoding=None, errors=None, newline=None, closefd=True, opener=None, mode='U')
 65 | open(file="foo", buffering=-1, encoding=None, errors=None, mode='U', newline=None, closefd=True, opener=None)
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ UP015
+   |                                                                 ^^^ UP015
 66 | open(mode='U', file="foo", buffering=-1, encoding=None, errors=None, newline=None, closefd=True, opener=None)
    |
    = help: Remove open mode argument
@@ -817,12 +817,12 @@ UP015.py:65:1: UP015 [*] Unnecessary open mode argument
 67 67 | 
 68 68 | open(file="foo", mode='Ub', buffering=-1, encoding=None, errors=None, newline=None, closefd=True, opener=None)
 
-UP015.py:66:1: UP015 [*] Unnecessary open mode argument
+UP015.py:66:11: UP015 [*] Unnecessary open mode argument
    |
 64 | open(file="foo", buffering=-1, encoding=None, errors=None, newline=None, closefd=True, opener=None, mode='U')
 65 | open(file="foo", buffering=-1, encoding=None, errors=None, mode='U', newline=None, closefd=True, opener=None)
 66 | open(mode='U', file="foo", buffering=-1, encoding=None, errors=None, newline=None, closefd=True, opener=None)
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ UP015
+   |           ^^^ UP015
 67 |
 68 | open(file="foo", mode='Ub', buffering=-1, encoding=None, errors=None, newline=None, closefd=True, opener=None)
    |
@@ -838,12 +838,12 @@ UP015.py:66:1: UP015 [*] Unnecessary open mode argument
 68 68 | open(file="foo", mode='Ub', buffering=-1, encoding=None, errors=None, newline=None, closefd=True, opener=None)
 69 69 | open(file="foo", buffering=-1, encoding=None, errors=None, newline=None, closefd=True, opener=None, mode='Ub')
 
-UP015.py:68:1: UP015 [*] Unnecessary open modes, use `rb`
+UP015.py:68:23: UP015 [*] Unnecessary open modes, use `rb`
    |
 66 | open(mode='U', file="foo", buffering=-1, encoding=None, errors=None, newline=None, closefd=True, opener=None)
 67 |
 68 | open(file="foo", mode='Ub', buffering=-1, encoding=None, errors=None, newline=None, closefd=True, opener=None)
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ UP015
+   |                       ^^^^ UP015
 69 | open(file="foo", buffering=-1, encoding=None, errors=None, newline=None, closefd=True, opener=None, mode='Ub')
 70 | open(file="foo", buffering=-1, encoding=None, errors=None, mode='Ub', newline=None, closefd=True, opener=None)
    |
@@ -859,11 +859,11 @@ UP015.py:68:1: UP015 [*] Unnecessary open modes, use `rb`
 70 70 | open(file="foo", buffering=-1, encoding=None, errors=None, mode='Ub', newline=None, closefd=True, opener=None)
 71 71 | open(mode='Ub', file="foo", buffering=-1, encoding=None, errors=None, newline=None, closefd=True, opener=None)
 
-UP015.py:69:1: UP015 [*] Unnecessary open modes, use `rb`
+UP015.py:69:106: UP015 [*] Unnecessary open modes, use `rb`
    |
 68 | open(file="foo", mode='Ub', buffering=-1, encoding=None, errors=None, newline=None, closefd=True, opener=None)
 69 | open(file="foo", buffering=-1, encoding=None, errors=None, newline=None, closefd=True, opener=None, mode='Ub')
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ UP015
+   |                                                                                                          ^^^^ UP015
 70 | open(file="foo", buffering=-1, encoding=None, errors=None, mode='Ub', newline=None, closefd=True, opener=None)
 71 | open(mode='Ub', file="foo", buffering=-1, encoding=None, errors=None, newline=None, closefd=True, opener=None)
    |
@@ -879,12 +879,12 @@ UP015.py:69:1: UP015 [*] Unnecessary open modes, use `rb`
 71 71 | open(mode='Ub', file="foo", buffering=-1, encoding=None, errors=None, newline=None, closefd=True, opener=None)
 72 72 | 
 
-UP015.py:70:1: UP015 [*] Unnecessary open modes, use `rb`
+UP015.py:70:65: UP015 [*] Unnecessary open modes, use `rb`
    |
 68 | open(file="foo", mode='Ub', buffering=-1, encoding=None, errors=None, newline=None, closefd=True, opener=None)
 69 | open(file="foo", buffering=-1, encoding=None, errors=None, newline=None, closefd=True, opener=None, mode='Ub')
 70 | open(file="foo", buffering=-1, encoding=None, errors=None, mode='Ub', newline=None, closefd=True, opener=None)
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ UP015
+   |                                                                 ^^^^ UP015
 71 | open(mode='Ub', file="foo", buffering=-1, encoding=None, errors=None, newline=None, closefd=True, opener=None)
    |
    = help: Replace with `rb`
@@ -899,12 +899,12 @@ UP015.py:70:1: UP015 [*] Unnecessary open modes, use `rb`
 72 72 | 
 73 73 | import aiofiles
 
-UP015.py:71:1: UP015 [*] Unnecessary open modes, use `rb`
+UP015.py:71:11: UP015 [*] Unnecessary open modes, use `rb`
    |
 69 | open(file="foo", buffering=-1, encoding=None, errors=None, newline=None, closefd=True, opener=None, mode='Ub')
 70 | open(file="foo", buffering=-1, encoding=None, errors=None, mode='Ub', newline=None, closefd=True, opener=None)
 71 | open(mode='Ub', file="foo", buffering=-1, encoding=None, errors=None, newline=None, closefd=True, opener=None)
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ UP015
+   |           ^^^^ UP015
 72 |
 73 | import aiofiles
    |
@@ -920,12 +920,12 @@ UP015.py:71:1: UP015 [*] Unnecessary open modes, use `rb`
 73 73 | import aiofiles
 74 74 | 
 
-UP015.py:75:1: UP015 [*] Unnecessary open mode argument
+UP015.py:75:22: UP015 [*] Unnecessary open mode argument
    |
 73 | import aiofiles
 74 |
 75 | aiofiles.open("foo", "U")
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^ UP015
+   |                      ^^^ UP015
 76 | aiofiles.open("foo", "r")
 77 | aiofiles.open("foo", mode="r")
    |
@@ -941,11 +941,11 @@ UP015.py:75:1: UP015 [*] Unnecessary open mode argument
 77 77 | aiofiles.open("foo", mode="r")
 78 78 | 
 
-UP015.py:76:1: UP015 [*] Unnecessary open mode argument
+UP015.py:76:22: UP015 [*] Unnecessary open mode argument
    |
 75 | aiofiles.open("foo", "U")
 76 | aiofiles.open("foo", "r")
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^ UP015
+   |                      ^^^ UP015
 77 | aiofiles.open("foo", mode="r")
    |
    = help: Remove open mode argument
@@ -960,12 +960,12 @@ UP015.py:76:1: UP015 [*] Unnecessary open mode argument
 78 78 | 
 79 79 | open("foo", "r+")
 
-UP015.py:77:1: UP015 [*] Unnecessary open mode argument
+UP015.py:77:27: UP015 [*] Unnecessary open mode argument
    |
 75 | aiofiles.open("foo", "U")
 76 | aiofiles.open("foo", "r")
 77 | aiofiles.open("foo", mode="r")
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ UP015
+   |                           ^^^ UP015
 78 |
 79 | open("foo", "r+")
    |

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__preview__UP015_UP015.py.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__preview__UP015_UP015.py.snap
@@ -1,14 +1,14 @@
 ---
 source: crates/ruff_linter/src/rules/pyupgrade/mod.rs
 ---
-UP015.py:1:13: UP015 [*] Unnecessary open mode argument
+UP015.py:1:13: UP015 [*] Unnecessary mode argument
   |
 1 | open("foo", "U")
   |             ^^^ UP015
 2 | open("foo", "Ur")
 3 | open("foo", "Ub")
   |
-  = help: Remove open mode argument
+  = help: Remove mode argument
 
 ℹ Safe fix
 1   |-open("foo", "U")
@@ -17,7 +17,7 @@ UP015.py:1:13: UP015 [*] Unnecessary open mode argument
 3 3 | open("foo", "Ub")
 4 4 | open("foo", "rUb")
 
-UP015.py:2:13: UP015 [*] Unnecessary open mode argument
+UP015.py:2:13: UP015 [*] Unnecessary mode argument
   |
 1 | open("foo", "U")
 2 | open("foo", "Ur")
@@ -25,7 +25,7 @@ UP015.py:2:13: UP015 [*] Unnecessary open mode argument
 3 | open("foo", "Ub")
 4 | open("foo", "rUb")
   |
-  = help: Remove open mode argument
+  = help: Remove mode argument
 
 ℹ Safe fix
 1 1 | open("foo", "U")
@@ -35,7 +35,7 @@ UP015.py:2:13: UP015 [*] Unnecessary open mode argument
 4 4 | open("foo", "rUb")
 5 5 | open("foo", "r")
 
-UP015.py:3:13: UP015 [*] Unnecessary open modes, use `rb`
+UP015.py:3:13: UP015 [*] Unnecessary modes, use `rb`
   |
 1 | open("foo", "U")
 2 | open("foo", "Ur")
@@ -55,7 +55,7 @@ UP015.py:3:13: UP015 [*] Unnecessary open modes, use `rb`
 5 5 | open("foo", "r")
 6 6 | open("foo", "rt")
 
-UP015.py:4:13: UP015 [*] Unnecessary open modes, use `rb`
+UP015.py:4:13: UP015 [*] Unnecessary modes, use `rb`
   |
 2 | open("foo", "Ur")
 3 | open("foo", "Ub")
@@ -76,7 +76,7 @@ UP015.py:4:13: UP015 [*] Unnecessary open modes, use `rb`
 6 6 | open("foo", "rt")
 7 7 | open("f", "r", encoding="UTF-8")
 
-UP015.py:5:13: UP015 [*] Unnecessary open mode argument
+UP015.py:5:13: UP015 [*] Unnecessary mode argument
   |
 3 | open("foo", "Ub")
 4 | open("foo", "rUb")
@@ -85,7 +85,7 @@ UP015.py:5:13: UP015 [*] Unnecessary open mode argument
 6 | open("foo", "rt")
 7 | open("f", "r", encoding="UTF-8")
   |
-  = help: Remove open mode argument
+  = help: Remove mode argument
 
 ℹ Safe fix
 2 2 | open("foo", "Ur")
@@ -97,7 +97,7 @@ UP015.py:5:13: UP015 [*] Unnecessary open mode argument
 7 7 | open("f", "r", encoding="UTF-8")
 8 8 | open("f", "wt")
 
-UP015.py:6:13: UP015 [*] Unnecessary open mode argument
+UP015.py:6:13: UP015 [*] Unnecessary mode argument
   |
 4 | open("foo", "rUb")
 5 | open("foo", "r")
@@ -106,7 +106,7 @@ UP015.py:6:13: UP015 [*] Unnecessary open mode argument
 7 | open("f", "r", encoding="UTF-8")
 8 | open("f", "wt")
   |
-  = help: Remove open mode argument
+  = help: Remove mode argument
 
 ℹ Safe fix
 3 3 | open("foo", "Ub")
@@ -118,7 +118,7 @@ UP015.py:6:13: UP015 [*] Unnecessary open mode argument
 8 8 | open("f", "wt")
 9 9 | open("f", "tw")
 
-UP015.py:7:11: UP015 [*] Unnecessary open mode argument
+UP015.py:7:11: UP015 [*] Unnecessary mode argument
   |
 5 | open("foo", "r")
 6 | open("foo", "rt")
@@ -127,7 +127,7 @@ UP015.py:7:11: UP015 [*] Unnecessary open mode argument
 8 | open("f", "wt")
 9 | open("f", "tw")
   |
-  = help: Remove open mode argument
+  = help: Remove mode argument
 
 ℹ Safe fix
 4 4 | open("foo", "rUb")
@@ -139,7 +139,7 @@ UP015.py:7:11: UP015 [*] Unnecessary open mode argument
 9 9 | open("f", "tw")
 10 10 | 
 
-UP015.py:8:11: UP015 [*] Unnecessary open modes, use `w`
+UP015.py:8:11: UP015 [*] Unnecessary modes, use `w`
   |
 6 | open("foo", "rt")
 7 | open("f", "r", encoding="UTF-8")
@@ -159,7 +159,7 @@ UP015.py:8:11: UP015 [*] Unnecessary open modes, use `w`
 10 10 | 
 11 11 | with open("foo", "U") as f:
 
-UP015.py:9:11: UP015 [*] Unnecessary open modes, use `w`
+UP015.py:9:11: UP015 [*] Unnecessary modes, use `w`
    |
  7 | open("f", "r", encoding="UTF-8")
  8 | open("f", "wt")
@@ -180,7 +180,7 @@ UP015.py:9:11: UP015 [*] Unnecessary open modes, use `w`
 11 11 | with open("foo", "U") as f:
 12 12 |     pass
 
-UP015.py:11:18: UP015 [*] Unnecessary open mode argument
+UP015.py:11:18: UP015 [*] Unnecessary mode argument
    |
  9 | open("f", "tw")
 10 |
@@ -189,7 +189,7 @@ UP015.py:11:18: UP015 [*] Unnecessary open mode argument
 12 |     pass
 13 | with open("foo", "Ur") as f:
    |
-   = help: Remove open mode argument
+   = help: Remove mode argument
 
 ℹ Safe fix
 8  8  | open("f", "wt")
@@ -201,7 +201,7 @@ UP015.py:11:18: UP015 [*] Unnecessary open mode argument
 13 13 | with open("foo", "Ur") as f:
 14 14 |     pass
 
-UP015.py:13:18: UP015 [*] Unnecessary open mode argument
+UP015.py:13:18: UP015 [*] Unnecessary mode argument
    |
 11 | with open("foo", "U") as f:
 12 |     pass
@@ -210,7 +210,7 @@ UP015.py:13:18: UP015 [*] Unnecessary open mode argument
 14 |     pass
 15 | with open("foo", "Ub") as f:
    |
-   = help: Remove open mode argument
+   = help: Remove mode argument
 
 ℹ Safe fix
 10 10 | 
@@ -222,7 +222,7 @@ UP015.py:13:18: UP015 [*] Unnecessary open mode argument
 15 15 | with open("foo", "Ub") as f:
 16 16 |     pass
 
-UP015.py:15:18: UP015 [*] Unnecessary open modes, use `rb`
+UP015.py:15:18: UP015 [*] Unnecessary modes, use `rb`
    |
 13 | with open("foo", "Ur") as f:
 14 |     pass
@@ -243,7 +243,7 @@ UP015.py:15:18: UP015 [*] Unnecessary open modes, use `rb`
 17 17 | with open("foo", "rUb") as f:
 18 18 |     pass
 
-UP015.py:17:18: UP015 [*] Unnecessary open modes, use `rb`
+UP015.py:17:18: UP015 [*] Unnecessary modes, use `rb`
    |
 15 | with open("foo", "Ub") as f:
 16 |     pass
@@ -264,7 +264,7 @@ UP015.py:17:18: UP015 [*] Unnecessary open modes, use `rb`
 19 19 | with open("foo", "r") as f:
 20 20 |     pass
 
-UP015.py:19:18: UP015 [*] Unnecessary open mode argument
+UP015.py:19:18: UP015 [*] Unnecessary mode argument
    |
 17 | with open("foo", "rUb") as f:
 18 |     pass
@@ -273,7 +273,7 @@ UP015.py:19:18: UP015 [*] Unnecessary open mode argument
 20 |     pass
 21 | with open("foo", "rt") as f:
    |
-   = help: Remove open mode argument
+   = help: Remove mode argument
 
 ℹ Safe fix
 16 16 |     pass
@@ -285,7 +285,7 @@ UP015.py:19:18: UP015 [*] Unnecessary open mode argument
 21 21 | with open("foo", "rt") as f:
 22 22 |     pass
 
-UP015.py:21:18: UP015 [*] Unnecessary open mode argument
+UP015.py:21:18: UP015 [*] Unnecessary mode argument
    |
 19 | with open("foo", "r") as f:
 20 |     pass
@@ -294,7 +294,7 @@ UP015.py:21:18: UP015 [*] Unnecessary open mode argument
 22 |     pass
 23 | with open("foo", "r", encoding="UTF-8") as f:
    |
-   = help: Remove open mode argument
+   = help: Remove mode argument
 
 ℹ Safe fix
 18 18 |     pass
@@ -306,7 +306,7 @@ UP015.py:21:18: UP015 [*] Unnecessary open mode argument
 23 23 | with open("foo", "r", encoding="UTF-8") as f:
 24 24 |     pass
 
-UP015.py:23:18: UP015 [*] Unnecessary open mode argument
+UP015.py:23:18: UP015 [*] Unnecessary mode argument
    |
 21 | with open("foo", "rt") as f:
 22 |     pass
@@ -315,7 +315,7 @@ UP015.py:23:18: UP015 [*] Unnecessary open mode argument
 24 |     pass
 25 | with open("foo", "wt") as f:
    |
-   = help: Remove open mode argument
+   = help: Remove mode argument
 
 ℹ Safe fix
 20 20 |     pass
@@ -327,7 +327,7 @@ UP015.py:23:18: UP015 [*] Unnecessary open mode argument
 25 25 | with open("foo", "wt") as f:
 26 26 |     pass
 
-UP015.py:25:18: UP015 [*] Unnecessary open modes, use `w`
+UP015.py:25:18: UP015 [*] Unnecessary modes, use `w`
    |
 23 | with open("foo", "r", encoding="UTF-8") as f:
 24 |     pass
@@ -347,7 +347,7 @@ UP015.py:25:18: UP015 [*] Unnecessary open modes, use `w`
 27 27 | 
 28 28 | open(f("a", "b", "c"), "U")
 
-UP015.py:28:24: UP015 [*] Unnecessary open mode argument
+UP015.py:28:24: UP015 [*] Unnecessary mode argument
    |
 26 |     pass
 27 |
@@ -355,7 +355,7 @@ UP015.py:28:24: UP015 [*] Unnecessary open mode argument
    |                        ^^^ UP015
 29 | open(f("a", "b", "c"), "Ub")
    |
-   = help: Remove open mode argument
+   = help: Remove mode argument
 
 ℹ Safe fix
 25 25 | with open("foo", "wt") as f:
@@ -367,7 +367,7 @@ UP015.py:28:24: UP015 [*] Unnecessary open mode argument
 30 30 | 
 31 31 | with open(f("a", "b", "c"), "U") as f:
 
-UP015.py:29:24: UP015 [*] Unnecessary open modes, use `rb`
+UP015.py:29:24: UP015 [*] Unnecessary modes, use `rb`
    |
 28 | open(f("a", "b", "c"), "U")
 29 | open(f("a", "b", "c"), "Ub")
@@ -387,7 +387,7 @@ UP015.py:29:24: UP015 [*] Unnecessary open modes, use `rb`
 31 31 | with open(f("a", "b", "c"), "U") as f:
 32 32 |     pass
 
-UP015.py:31:29: UP015 [*] Unnecessary open mode argument
+UP015.py:31:29: UP015 [*] Unnecessary mode argument
    |
 29 | open(f("a", "b", "c"), "Ub")
 30 |
@@ -396,7 +396,7 @@ UP015.py:31:29: UP015 [*] Unnecessary open mode argument
 32 |     pass
 33 | with open(f("a", "b", "c"), "Ub") as f:
    |
-   = help: Remove open mode argument
+   = help: Remove mode argument
 
 ℹ Safe fix
 28 28 | open(f("a", "b", "c"), "U")
@@ -408,7 +408,7 @@ UP015.py:31:29: UP015 [*] Unnecessary open mode argument
 33 33 | with open(f("a", "b", "c"), "Ub") as f:
 34 34 |     pass
 
-UP015.py:33:29: UP015 [*] Unnecessary open modes, use `rb`
+UP015.py:33:29: UP015 [*] Unnecessary modes, use `rb`
    |
 31 | with open(f("a", "b", "c"), "U") as f:
 32 |     pass
@@ -428,7 +428,7 @@ UP015.py:33:29: UP015 [*] Unnecessary open modes, use `rb`
 35 35 | 
 36 36 | with open("foo", "U") as fa, open("bar", "U") as fb:
 
-UP015.py:36:18: UP015 [*] Unnecessary open mode argument
+UP015.py:36:18: UP015 [*] Unnecessary mode argument
    |
 34 |     pass
 35 |
@@ -437,7 +437,7 @@ UP015.py:36:18: UP015 [*] Unnecessary open mode argument
 37 |     pass
 38 | with open("foo", "Ub") as fa, open("bar", "Ub") as fb:
    |
-   = help: Remove open mode argument
+   = help: Remove mode argument
 
 ℹ Safe fix
 33 33 | with open(f("a", "b", "c"), "Ub") as f:
@@ -449,7 +449,7 @@ UP015.py:36:18: UP015 [*] Unnecessary open mode argument
 38 38 | with open("foo", "Ub") as fa, open("bar", "Ub") as fb:
 39 39 |     pass
 
-UP015.py:36:42: UP015 [*] Unnecessary open mode argument
+UP015.py:36:42: UP015 [*] Unnecessary mode argument
    |
 34 |     pass
 35 |
@@ -458,7 +458,7 @@ UP015.py:36:42: UP015 [*] Unnecessary open mode argument
 37 |     pass
 38 | with open("foo", "Ub") as fa, open("bar", "Ub") as fb:
    |
-   = help: Remove open mode argument
+   = help: Remove mode argument
 
 ℹ Safe fix
 33 33 | with open(f("a", "b", "c"), "Ub") as f:
@@ -470,7 +470,7 @@ UP015.py:36:42: UP015 [*] Unnecessary open mode argument
 38 38 | with open("foo", "Ub") as fa, open("bar", "Ub") as fb:
 39 39 |     pass
 
-UP015.py:38:18: UP015 [*] Unnecessary open modes, use `rb`
+UP015.py:38:18: UP015 [*] Unnecessary modes, use `rb`
    |
 36 | with open("foo", "U") as fa, open("bar", "U") as fb:
 37 |     pass
@@ -490,7 +490,7 @@ UP015.py:38:18: UP015 [*] Unnecessary open modes, use `rb`
 40 40 | 
 41 41 | open("foo", mode="U")
 
-UP015.py:38:43: UP015 [*] Unnecessary open modes, use `rb`
+UP015.py:38:43: UP015 [*] Unnecessary modes, use `rb`
    |
 36 | with open("foo", "U") as fa, open("bar", "U") as fb:
 37 |     pass
@@ -510,7 +510,7 @@ UP015.py:38:43: UP015 [*] Unnecessary open modes, use `rb`
 40 40 | 
 41 41 | open("foo", mode="U")
 
-UP015.py:41:18: UP015 [*] Unnecessary open mode argument
+UP015.py:41:18: UP015 [*] Unnecessary mode argument
    |
 39 |     pass
 40 |
@@ -519,7 +519,7 @@ UP015.py:41:18: UP015 [*] Unnecessary open mode argument
 42 | open(name="foo", mode="U")
 43 | open(mode="U", name="foo")
    |
-   = help: Remove open mode argument
+   = help: Remove mode argument
 
 ℹ Safe fix
 38 38 | with open("foo", "Ub") as fa, open("bar", "Ub") as fb:
@@ -531,14 +531,14 @@ UP015.py:41:18: UP015 [*] Unnecessary open mode argument
 43 43 | open(mode="U", name="foo")
 44 44 | 
 
-UP015.py:42:23: UP015 [*] Unnecessary open mode argument
+UP015.py:42:23: UP015 [*] Unnecessary mode argument
    |
 41 | open("foo", mode="U")
 42 | open(name="foo", mode="U")
    |                       ^^^ UP015
 43 | open(mode="U", name="foo")
    |
-   = help: Remove open mode argument
+   = help: Remove mode argument
 
 ℹ Safe fix
 39 39 |     pass
@@ -550,7 +550,7 @@ UP015.py:42:23: UP015 [*] Unnecessary open mode argument
 44 44 | 
 45 45 | with open("foo", mode="U") as f:
 
-UP015.py:43:11: UP015 [*] Unnecessary open mode argument
+UP015.py:43:11: UP015 [*] Unnecessary mode argument
    |
 41 | open("foo", mode="U")
 42 | open(name="foo", mode="U")
@@ -559,7 +559,7 @@ UP015.py:43:11: UP015 [*] Unnecessary open mode argument
 44 |
 45 | with open("foo", mode="U") as f:
    |
-   = help: Remove open mode argument
+   = help: Remove mode argument
 
 ℹ Safe fix
 40 40 | 
@@ -571,7 +571,7 @@ UP015.py:43:11: UP015 [*] Unnecessary open mode argument
 45 45 | with open("foo", mode="U") as f:
 46 46 |     pass
 
-UP015.py:45:23: UP015 [*] Unnecessary open mode argument
+UP015.py:45:23: UP015 [*] Unnecessary mode argument
    |
 43 | open(mode="U", name="foo")
 44 |
@@ -580,7 +580,7 @@ UP015.py:45:23: UP015 [*] Unnecessary open mode argument
 46 |     pass
 47 | with open(name="foo", mode="U") as f:
    |
-   = help: Remove open mode argument
+   = help: Remove mode argument
 
 ℹ Safe fix
 42 42 | open(name="foo", mode="U")
@@ -592,7 +592,7 @@ UP015.py:45:23: UP015 [*] Unnecessary open mode argument
 47 47 | with open(name="foo", mode="U") as f:
 48 48 |     pass
 
-UP015.py:47:28: UP015 [*] Unnecessary open mode argument
+UP015.py:47:28: UP015 [*] Unnecessary mode argument
    |
 45 | with open("foo", mode="U") as f:
 46 |     pass
@@ -601,7 +601,7 @@ UP015.py:47:28: UP015 [*] Unnecessary open mode argument
 48 |     pass
 49 | with open(mode="U", name="foo") as f:
    |
-   = help: Remove open mode argument
+   = help: Remove mode argument
 
 ℹ Safe fix
 44 44 | 
@@ -613,7 +613,7 @@ UP015.py:47:28: UP015 [*] Unnecessary open mode argument
 49 49 | with open(mode="U", name="foo") as f:
 50 50 |     pass
 
-UP015.py:49:16: UP015 [*] Unnecessary open mode argument
+UP015.py:49:16: UP015 [*] Unnecessary mode argument
    |
 47 | with open(name="foo", mode="U") as f:
 48 |     pass
@@ -621,7 +621,7 @@ UP015.py:49:16: UP015 [*] Unnecessary open mode argument
    |                ^^^ UP015
 50 |     pass
    |
-   = help: Remove open mode argument
+   = help: Remove mode argument
 
 ℹ Safe fix
 46 46 |     pass
@@ -633,7 +633,7 @@ UP015.py:49:16: UP015 [*] Unnecessary open mode argument
 51 51 | 
 52 52 | open("foo", mode="Ub")
 
-UP015.py:52:18: UP015 [*] Unnecessary open modes, use `rb`
+UP015.py:52:18: UP015 [*] Unnecessary modes, use `rb`
    |
 50 |     pass
 51 |
@@ -654,7 +654,7 @@ UP015.py:52:18: UP015 [*] Unnecessary open modes, use `rb`
 54 54 | open(mode="Ub", name="foo")
 55 55 | 
 
-UP015.py:53:23: UP015 [*] Unnecessary open modes, use `rb`
+UP015.py:53:23: UP015 [*] Unnecessary modes, use `rb`
    |
 52 | open("foo", mode="Ub")
 53 | open(name="foo", mode="Ub")
@@ -673,7 +673,7 @@ UP015.py:53:23: UP015 [*] Unnecessary open modes, use `rb`
 55 55 | 
 56 56 | with open("foo", mode="Ub") as f:
 
-UP015.py:54:11: UP015 [*] Unnecessary open modes, use `rb`
+UP015.py:54:11: UP015 [*] Unnecessary modes, use `rb`
    |
 52 | open("foo", mode="Ub")
 53 | open(name="foo", mode="Ub")
@@ -694,7 +694,7 @@ UP015.py:54:11: UP015 [*] Unnecessary open modes, use `rb`
 56 56 | with open("foo", mode="Ub") as f:
 57 57 |     pass
 
-UP015.py:56:23: UP015 [*] Unnecessary open modes, use `rb`
+UP015.py:56:23: UP015 [*] Unnecessary modes, use `rb`
    |
 54 | open(mode="Ub", name="foo")
 55 |
@@ -715,7 +715,7 @@ UP015.py:56:23: UP015 [*] Unnecessary open modes, use `rb`
 58 58 | with open(name="foo", mode="Ub") as f:
 59 59 |     pass
 
-UP015.py:58:28: UP015 [*] Unnecessary open modes, use `rb`
+UP015.py:58:28: UP015 [*] Unnecessary modes, use `rb`
    |
 56 | with open("foo", mode="Ub") as f:
 57 |     pass
@@ -736,7 +736,7 @@ UP015.py:58:28: UP015 [*] Unnecessary open modes, use `rb`
 60 60 | with open(mode="Ub", name="foo") as f:
 61 61 |     pass
 
-UP015.py:60:16: UP015 [*] Unnecessary open modes, use `rb`
+UP015.py:60:16: UP015 [*] Unnecessary modes, use `rb`
    |
 58 | with open(name="foo", mode="Ub") as f:
 59 |     pass
@@ -756,7 +756,7 @@ UP015.py:60:16: UP015 [*] Unnecessary open modes, use `rb`
 62 62 | 
 63 63 | open(file="foo", mode='U', buffering=-1, encoding=None, errors=None, newline=None, closefd=True, opener=None)
 
-UP015.py:63:23: UP015 [*] Unnecessary open mode argument
+UP015.py:63:23: UP015 [*] Unnecessary mode argument
    |
 61 |     pass
 62 |
@@ -765,7 +765,7 @@ UP015.py:63:23: UP015 [*] Unnecessary open mode argument
 64 | open(file="foo", buffering=-1, encoding=None, errors=None, newline=None, closefd=True, opener=None, mode='U')
 65 | open(file="foo", buffering=-1, encoding=None, errors=None, mode='U', newline=None, closefd=True, opener=None)
    |
-   = help: Remove open mode argument
+   = help: Remove mode argument
 
 ℹ Safe fix
 60 60 | with open(mode="Ub", name="foo") as f:
@@ -777,7 +777,7 @@ UP015.py:63:23: UP015 [*] Unnecessary open mode argument
 65 65 | open(file="foo", buffering=-1, encoding=None, errors=None, mode='U', newline=None, closefd=True, opener=None)
 66 66 | open(mode='U', file="foo", buffering=-1, encoding=None, errors=None, newline=None, closefd=True, opener=None)
 
-UP015.py:64:106: UP015 [*] Unnecessary open mode argument
+UP015.py:64:106: UP015 [*] Unnecessary mode argument
    |
 63 | open(file="foo", mode='U', buffering=-1, encoding=None, errors=None, newline=None, closefd=True, opener=None)
 64 | open(file="foo", buffering=-1, encoding=None, errors=None, newline=None, closefd=True, opener=None, mode='U')
@@ -785,7 +785,7 @@ UP015.py:64:106: UP015 [*] Unnecessary open mode argument
 65 | open(file="foo", buffering=-1, encoding=None, errors=None, mode='U', newline=None, closefd=True, opener=None)
 66 | open(mode='U', file="foo", buffering=-1, encoding=None, errors=None, newline=None, closefd=True, opener=None)
    |
-   = help: Remove open mode argument
+   = help: Remove mode argument
 
 ℹ Safe fix
 61 61 |     pass
@@ -797,7 +797,7 @@ UP015.py:64:106: UP015 [*] Unnecessary open mode argument
 66 66 | open(mode='U', file="foo", buffering=-1, encoding=None, errors=None, newline=None, closefd=True, opener=None)
 67 67 | 
 
-UP015.py:65:65: UP015 [*] Unnecessary open mode argument
+UP015.py:65:65: UP015 [*] Unnecessary mode argument
    |
 63 | open(file="foo", mode='U', buffering=-1, encoding=None, errors=None, newline=None, closefd=True, opener=None)
 64 | open(file="foo", buffering=-1, encoding=None, errors=None, newline=None, closefd=True, opener=None, mode='U')
@@ -805,7 +805,7 @@ UP015.py:65:65: UP015 [*] Unnecessary open mode argument
    |                                                                 ^^^ UP015
 66 | open(mode='U', file="foo", buffering=-1, encoding=None, errors=None, newline=None, closefd=True, opener=None)
    |
-   = help: Remove open mode argument
+   = help: Remove mode argument
 
 ℹ Safe fix
 62 62 | 
@@ -817,7 +817,7 @@ UP015.py:65:65: UP015 [*] Unnecessary open mode argument
 67 67 | 
 68 68 | open(file="foo", mode='Ub', buffering=-1, encoding=None, errors=None, newline=None, closefd=True, opener=None)
 
-UP015.py:66:11: UP015 [*] Unnecessary open mode argument
+UP015.py:66:11: UP015 [*] Unnecessary mode argument
    |
 64 | open(file="foo", buffering=-1, encoding=None, errors=None, newline=None, closefd=True, opener=None, mode='U')
 65 | open(file="foo", buffering=-1, encoding=None, errors=None, mode='U', newline=None, closefd=True, opener=None)
@@ -826,7 +826,7 @@ UP015.py:66:11: UP015 [*] Unnecessary open mode argument
 67 |
 68 | open(file="foo", mode='Ub', buffering=-1, encoding=None, errors=None, newline=None, closefd=True, opener=None)
    |
-   = help: Remove open mode argument
+   = help: Remove mode argument
 
 ℹ Safe fix
 63 63 | open(file="foo", mode='U', buffering=-1, encoding=None, errors=None, newline=None, closefd=True, opener=None)
@@ -838,7 +838,7 @@ UP015.py:66:11: UP015 [*] Unnecessary open mode argument
 68 68 | open(file="foo", mode='Ub', buffering=-1, encoding=None, errors=None, newline=None, closefd=True, opener=None)
 69 69 | open(file="foo", buffering=-1, encoding=None, errors=None, newline=None, closefd=True, opener=None, mode='Ub')
 
-UP015.py:68:23: UP015 [*] Unnecessary open modes, use `rb`
+UP015.py:68:23: UP015 [*] Unnecessary modes, use `rb`
    |
 66 | open(mode='U', file="foo", buffering=-1, encoding=None, errors=None, newline=None, closefd=True, opener=None)
 67 |
@@ -859,7 +859,7 @@ UP015.py:68:23: UP015 [*] Unnecessary open modes, use `rb`
 70 70 | open(file="foo", buffering=-1, encoding=None, errors=None, mode='Ub', newline=None, closefd=True, opener=None)
 71 71 | open(mode='Ub', file="foo", buffering=-1, encoding=None, errors=None, newline=None, closefd=True, opener=None)
 
-UP015.py:69:106: UP015 [*] Unnecessary open modes, use `rb`
+UP015.py:69:106: UP015 [*] Unnecessary modes, use `rb`
    |
 68 | open(file="foo", mode='Ub', buffering=-1, encoding=None, errors=None, newline=None, closefd=True, opener=None)
 69 | open(file="foo", buffering=-1, encoding=None, errors=None, newline=None, closefd=True, opener=None, mode='Ub')
@@ -879,7 +879,7 @@ UP015.py:69:106: UP015 [*] Unnecessary open modes, use `rb`
 71 71 | open(mode='Ub', file="foo", buffering=-1, encoding=None, errors=None, newline=None, closefd=True, opener=None)
 72 72 | 
 
-UP015.py:70:65: UP015 [*] Unnecessary open modes, use `rb`
+UP015.py:70:65: UP015 [*] Unnecessary modes, use `rb`
    |
 68 | open(file="foo", mode='Ub', buffering=-1, encoding=None, errors=None, newline=None, closefd=True, opener=None)
 69 | open(file="foo", buffering=-1, encoding=None, errors=None, newline=None, closefd=True, opener=None, mode='Ub')
@@ -899,7 +899,7 @@ UP015.py:70:65: UP015 [*] Unnecessary open modes, use `rb`
 72 72 | 
 73 73 | import aiofiles
 
-UP015.py:71:11: UP015 [*] Unnecessary open modes, use `rb`
+UP015.py:71:11: UP015 [*] Unnecessary modes, use `rb`
    |
 69 | open(file="foo", buffering=-1, encoding=None, errors=None, newline=None, closefd=True, opener=None, mode='Ub')
 70 | open(file="foo", buffering=-1, encoding=None, errors=None, mode='Ub', newline=None, closefd=True, opener=None)
@@ -920,7 +920,7 @@ UP015.py:71:11: UP015 [*] Unnecessary open modes, use `rb`
 73 73 | import aiofiles
 74 74 | 
 
-UP015.py:75:22: UP015 [*] Unnecessary open mode argument
+UP015.py:75:22: UP015 [*] Unnecessary mode argument
    |
 73 | import aiofiles
 74 |
@@ -929,7 +929,7 @@ UP015.py:75:22: UP015 [*] Unnecessary open mode argument
 76 | aiofiles.open("foo", "r")
 77 | aiofiles.open("foo", mode="r")
    |
-   = help: Remove open mode argument
+   = help: Remove mode argument
 
 ℹ Safe fix
 72 72 | 
@@ -941,14 +941,14 @@ UP015.py:75:22: UP015 [*] Unnecessary open mode argument
 77 77 | aiofiles.open("foo", mode="r")
 78 78 | 
 
-UP015.py:76:22: UP015 [*] Unnecessary open mode argument
+UP015.py:76:22: UP015 [*] Unnecessary mode argument
    |
 75 | aiofiles.open("foo", "U")
 76 | aiofiles.open("foo", "r")
    |                      ^^^ UP015
 77 | aiofiles.open("foo", mode="r")
    |
-   = help: Remove open mode argument
+   = help: Remove mode argument
 
 ℹ Safe fix
 73 73 | import aiofiles
@@ -960,7 +960,7 @@ UP015.py:76:22: UP015 [*] Unnecessary open mode argument
 78 78 | 
 79 79 | open("foo", "r+")
 
-UP015.py:77:27: UP015 [*] Unnecessary open mode argument
+UP015.py:77:27: UP015 [*] Unnecessary mode argument
    |
 75 | aiofiles.open("foo", "U")
 76 | aiofiles.open("foo", "r")
@@ -969,7 +969,7 @@ UP015.py:77:27: UP015 [*] Unnecessary open mode argument
 78 |
 79 | open("foo", "r+")
    |
-   = help: Remove open mode argument
+   = help: Remove mode argument
 
 ℹ Safe fix
 74 74 | 

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__preview__UP015_UP015_1.py.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__preview__UP015_UP015_1.py.snap
@@ -1,14 +1,14 @@
 ---
 source: crates/ruff_linter/src/rules/pyupgrade/mod.rs
 ---
-UP015_1.py:3:17: UP015 [*] Unnecessary open mode argument
+UP015_1.py:3:17: UP015 [*] Unnecessary mode argument
   |
 1 | # Not a valid type annotation but this test shouldn't result in a panic.
 2 | # Refer: https://github.com/astral-sh/ruff/issues/11736
 3 | x: 'open("foo", "r")'
   |                 ^^^ UP015
   |
-  = help: Remove open mode argument
+  = help: Remove mode argument
 
 ℹ Safe fix
 1 1 | # Not a valid type annotation but this test shouldn't result in a panic.

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__preview__UP015_UP015_1.py.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__preview__UP015_UP015_1.py.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/ruff_linter/src/rules/pyupgrade/mod.rs
 ---
-UP015_1.py:3:5: UP015 [*] Unnecessary open mode argument
+UP015_1.py:3:17: UP015 [*] Unnecessary open mode argument
   |
 1 | # Not a valid type annotation but this test shouldn't result in a panic.
 2 | # Refer: https://github.com/astral-sh/ruff/issues/11736
 3 | x: 'open("foo", "r")'
-  |     ^^^^^^^^^^^^^^^^ UP015
+  |                 ^^^ UP015
   |
   = help: Remove open mode argument
 


### PR DESCRIPTION
## Summary

Resolves #15863.

In preview, diagnostic ranges will now be limited to that of the argument. Rule documentation, variable names, error messages and fix titles have all been modified to use "argument" consistently.

## Test Plan

`cargo nextest run` and `cargo insta test`.
