### PR TITLE
[`flake8-comprehensions`] Unnecessary `list` comprehension (rewrite as a `set` comprehension) (`C403`) - Handle extraneous parentheses around list comprehension

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_comprehensions/C403.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_comprehensions/C403.py
@@ -21,3 +21,5 @@ s = set(  # comment
 s = set([  # comment
     x for x in range(3)
 ])
+
+s = set(([x for x in range(3)]))

--- a/crates/ruff_linter/resources/test/fixtures/flake8_comprehensions/C403.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_comprehensions/C403.py
@@ -23,3 +23,12 @@ s = set([  # comment
 ])
 
 s = set(([x for x in range(3)]))
+
+s = set(((([x for x in range(3)]))))
+
+s = set( # outer set comment
+( # inner paren comment - not preserved
+((
+[ # comprehension comment
+ x for x in range(3)]
+ ))))

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_list_comprehension_set.rs
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_list_comprehension_set.rs
@@ -60,37 +60,35 @@ pub(crate) fn unnecessary_list_comprehension_set(checker: &mut Checker, call: &a
         return;
     }
     let diagnostic = Diagnostic::new(UnnecessaryListComprehensionSet, call.range());
-    let fix = {
-        let one = TextSize::from(1);
+    let one = TextSize::from(1);
 
-        // Replace `set(` with `{`.
-        let call_start = Edit::replacement(
-            pad_start("{", call.range(), checker.locator(), checker.semantic()),
-            call.start(),
-            call.arguments.start() + one,
-        );
+    // Replace `set(` with `{`.
+    let call_start = Edit::replacement(
+        pad_start("{", call.range(), checker.locator(), checker.semantic()),
+        call.start(),
+        call.arguments.start() + one,
+    );
 
-        // Replace `)` with `}`.
-        let call_end = Edit::replacement(
-            pad_end("}", call.range(), checker.locator(), checker.semantic()),
-            call.arguments.end() - one,
-            call.end(),
-        );
+    // Replace `)` with `}`.
+    let call_end = Edit::replacement(
+        pad_end("}", call.range(), checker.locator(), checker.semantic()),
+        call.arguments.end() - one,
+        call.end(),
+    );
 
-        // If the list comprehension is parenthesized, remove the parentheses in addition to
-        // removing the brackets.
-        let replacement_range = parenthesized_range(
-            argument.into(),
-            (&call.arguments).into(),
-            checker.comment_ranges(),
-            checker.locator().contents(),
-        )
-        .unwrap_or_else(|| argument.range());
+    // If the list comprehension is parenthesized, remove the parentheses in addition to
+    // removing the brackets.
+    let replacement_range = parenthesized_range(
+        argument.into(),
+        (&call.arguments).into(),
+        checker.comment_ranges(),
+        checker.locator().contents(),
+    )
+    .unwrap_or_else(|| argument.range());
 
-        let span = argument.range().add_start(one).sub_end(one);
-        let replacement =
-            Edit::range_replacement(checker.source()[span].to_string(), replacement_range);
-        Fix::unsafe_edits(call_start, [call_end, replacement])
-    };
+    let span = argument.range().add_start(one).sub_end(one);
+    let replacement =
+        Edit::range_replacement(checker.source()[span].to_string(), replacement_range);
+    let fix = Fix::unsafe_edits(call_start, [call_end, replacement]);
     checker.diagnostics.push(diagnostic.with_fix(fix));
 }

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/snapshots/ruff_linter__rules__flake8_comprehensions__tests__C403_C403.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/snapshots/ruff_linter__rules__flake8_comprehensions__tests__C403_C403.py.snap
@@ -220,6 +220,8 @@ C403.py:21:5: C403 [*] Unnecessary list comprehension (rewrite as a set comprehe
 22 | |     x for x in range(3)
 23 | | ])
    | |__^ C403
+24 |
+25 |   s = set(([x for x in range(3)]))
    |
    = help: Rewrite as a set comprehension
 
@@ -232,3 +234,21 @@ C403.py:21:5: C403 [*] Unnecessary list comprehension (rewrite as a set comprehe
 22 22 |     x for x in range(3)
 23    |-])
    23 |+}
+24 24 | 
+25 25 | s = set(([x for x in range(3)]))
+
+C403.py:25:5: C403 [*] Unnecessary list comprehension (rewrite as a set comprehension)
+   |
+23 | ])
+24 |
+25 | s = set(([x for x in range(3)]))
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ C403
+   |
+   = help: Rewrite as a set comprehension
+
+ℹ Unsafe fix
+22 22 |     x for x in range(3)
+23 23 | ])
+24 24 | 
+25    |-s = set(([x for x in range(3)]))
+   25 |+s = {x for x in range(3)}

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/snapshots/ruff_linter__rules__flake8_comprehensions__tests__C403_C403.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/snapshots/ruff_linter__rules__flake8_comprehensions__tests__C403_C403.py.snap
@@ -236,6 +236,7 @@ C403.py:21:5: C403 [*] Unnecessary list comprehension (rewrite as a set comprehe
    23 |+}
 24 24 | 
 25 25 | s = set(([x for x in range(3)]))
+26 26 | 
 
 C403.py:25:5: C403 [*] Unnecessary list comprehension (rewrite as a set comprehension)
    |
@@ -243,6 +244,8 @@ C403.py:25:5: C403 [*] Unnecessary list comprehension (rewrite as a set comprehe
 24 |
 25 | s = set(([x for x in range(3)]))
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ C403
+26 |
+27 | s = set(((([x for x in range(3)]))))
    |
    = help: Rewrite as a set comprehension
 
@@ -252,3 +255,56 @@ C403.py:25:5: C403 [*] Unnecessary list comprehension (rewrite as a set comprehe
 24 24 | 
 25    |-s = set(([x for x in range(3)]))
    25 |+s = {x for x in range(3)}
+26 26 | 
+27 27 | s = set(((([x for x in range(3)]))))
+28 28 | 
+
+C403.py:27:5: C403 [*] Unnecessary list comprehension (rewrite as a set comprehension)
+   |
+25 | s = set(([x for x in range(3)]))
+26 |
+27 | s = set(((([x for x in range(3)]))))
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ C403
+28 |
+29 | s = set( # outer set comment
+   |
+   = help: Rewrite as a set comprehension
+
+ℹ Unsafe fix
+24 24 | 
+25 25 | s = set(([x for x in range(3)]))
+26 26 | 
+27    |-s = set(((([x for x in range(3)]))))
+   27 |+s = {x for x in range(3)}
+28 28 | 
+29 29 | s = set( # outer set comment
+30 30 | ( # inner paren comment - not preserved
+
+C403.py:29:5: C403 [*] Unnecessary list comprehension (rewrite as a set comprehension)
+   |
+27 |   s = set(((([x for x in range(3)]))))
+28 |
+29 |   s = set( # outer set comment
+   |  _____^
+30 | | ( # inner paren comment - not preserved
+31 | | ((
+32 | | [ # comprehension comment
+33 | |  x for x in range(3)]
+34 | |  ))))
+   | |_____^ C403
+   |
+   = help: Rewrite as a set comprehension
+
+ℹ Unsafe fix
+26 26 | 
+27 27 | s = set(((([x for x in range(3)]))))
+28 28 | 
+29    |-s = set( # outer set comment
+30    |-( # inner paren comment - not preserved
+31    |-((
+32    |-[ # comprehension comment
+33    |- x for x in range(3)]
+34    |- ))))
+   29 |+s = { # outer set comment
+   30 |+ # comprehension comment
+   31 |+ x for x in range(3)}


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Given the following code:

```python
set(([x for x in range(5)]))
```

the current implementation of C403 results in

```python
{(x for x in range(5))}
```

which is a set containing a generator rather than the result of the generator.

This change removes the extraneous parentheses so that the resulting code is:

```python
{x for x in range(5)}
```


## Test Plan

`cargo nextest run` and `cargo insta test`
<!-- How was it tested? -->
