### PR TITLE
Convert `.md` links in rule documentation to full URLs

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_type_checking/rules/type_alias_quotes.rs
+++ b/crates/ruff_linter/src/rules/flake8_type_checking/rules/type_alias_quotes.rs
@@ -113,9 +113,9 @@ impl Violation for UnquotedTypeAlias {
 /// This rule only applies to type aliases in non-stub files. For removing quotes in other
 /// contexts or in stub files, see:
 ///
-/// - [`quoted-annotation-in-stub`](quoted-annotation-in-stub.md): A rule that
+/// - [`quoted-annotation-in-stub`][PYI020]: A rule that
 ///   removes all quoted annotations from stub files
-/// - [`quoted-annotation`](quoted-annotation.md): A rule that removes unnecessary quotes
+/// - [`quoted-annotation`][UP037]: A rule that removes unnecessary quotes
 ///   from *annotations* in runtime files.
 ///
 /// ## References
@@ -126,6 +126,8 @@ impl Violation for UnquotedTypeAlias {
 /// [PEP 604]: https://peps.python.org/pep-0604/
 /// [PEP 613]: https://peps.python.org/pep-0613/
 /// [PEP 695]: https://peps.python.org/pep-0695/#generic-type-alias
+/// [PYI020]: https://docs.astral.sh/ruff/rules/quoted-annotation-in-stub/
+/// [UP037]: https://docs.astral.sh/ruff/rules/quoted-annotation/
 #[derive(ViolationMetadata)]
 pub(crate) struct QuotedTypeAlias;
 

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/pep695/non_pep695_generic_class.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/pep695/non_pep695_generic_class.rs
@@ -62,19 +62,22 @@ use super::{check_type_vars, in_nested_context, DisplayTypeVars, TypeVarReferenc
 ///
 /// This rule replaces standalone type variables in classes but doesn't remove
 /// the corresponding type variables even if they are unused after the fix. See
-/// [`unused-private-type-var`](unused-private-type-var.md) for a rule to clean up unused
+/// [`unused-private-type-var`][PYI018] for a rule to clean up unused
 /// private type variables.
 ///
 /// This rule will correctly handle classes with multiple base classes, as long as the single
 /// `Generic` base class is at the end of the argument list, as checked by
-/// [`generic-not-last-base-class`](generic-not-last-base-class.md). If a `Generic` base class is
+/// [`generic-not-last-base-class`][PYI059]. If a `Generic` base class is
 /// found outside of the last position, a diagnostic is emitted without a suggested fix.
 ///
 /// This rule only applies to generic classes and does not include generic functions. See
-/// [`non-pep695-generic-function`](non-pep695-generic-function.md) for the function version.
+/// [`non-pep695-generic-function`][PYI059] for the function version.
 ///
 /// [PEP 695]: https://peps.python.org/pep-0695/
 /// [PEP 696]: https://peps.python.org/pep-0696/
+/// [PYI018]: https://docs.astral.sh/ruff/rules/unused-private-type-var/
+/// [PYI059]: https://docs.astral.sh/ruff/rules/generic-not-last-base-class/
+/// [PYI059]: https://docs.astral.sh/ruff/rules/non-pep695-generic-function/
 #[derive(ViolationMetadata)]
 pub(crate) struct NonPEP695GenericClass {
     name: String,

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/pep695/non_pep695_generic_function.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/pep695/non_pep695_generic_function.rs
@@ -61,14 +61,16 @@ use super::{check_type_vars, in_nested_context, DisplayTypeVars, TypeVarReferenc
 ///
 /// This rule replaces standalone type variables in function signatures but doesn't remove
 /// the corresponding type variables even if they are unused after the fix. See
-/// [`unused-private-type-var`](unused-private-type-var.md) for a rule to clean up unused
+/// [`unused-private-type-var`][PYI018] for a rule to clean up unused
 /// private type variables.
 ///
 /// This rule only applies to generic functions and does not include generic classes. See
-/// [`non-pep695-generic-class`](non-pep695-generic-class.md) for the class version.
+/// [`non-pep695-generic-class`][UP046] for the class version.
 ///
 /// [PEP 695]: https://peps.python.org/pep-0695/
 /// [PEP 696]: https://peps.python.org/pep-0696/
+/// [PYI018]: https://docs.astral.sh/ruff/rules/unused-private-type-var/
+/// [UP046]: https://docs.astral.sh/ruff/rules/non-pep695-generic-class/
 #[derive(ViolationMetadata)]
 pub(crate) struct NonPEP695GenericFunction {
     name: String,

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/quoted_annotation.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/quoted_annotation.rs
@@ -58,14 +58,17 @@ use ruff_source_file::LineRanges;
 /// ```
 ///
 /// ## See also
-/// - [`quoted-annotation-in-stub`](quoted-annotation-in-stub.md): A rule that
+/// - [`quoted-annotation-in-stub`][PYI020]: A rule that
 ///   removes all quoted annotations from stub files
-/// - [`quoted-type-alias`](quoted-type-alias.md): A rule that removes unnecessary quotes
+/// - [`quoted-type-alias`][TC008]: A rule that removes unnecessary quotes
 ///   from type aliases.
 ///
 /// ## References
 /// - [PEP 563 – Postponed Evaluation of Annotations](https://peps.python.org/pep-0563/)
 /// - [Python documentation: `__future__`](https://docs.python.org/3/library/__future__.html#module-__future__)
+///
+/// [PYI020]: https://docs.astral.sh/ruff/rules/quoted-annotation-in-stub/
+/// [TC008]: https://docs.astral.sh/ruff/rules/quoted-type-alias/
 #[derive(ViolationMetadata)]
 pub(crate) struct QuotedAnnotation;
 


### PR DESCRIPTION
## Summary

Related to [these](https://github.com/astral-sh/ruff/pull/15862#discussion_r1938044515) [comments](https://github.com/astral-sh/ruff/pull/15889#discussion_r1938765623) at #15862 and #15889.

Markdown links of the following format are an anti-pattern:

```markdown
[`rule-name`](rule-name.md)
```

Only Mkdocs can resolve such links. When rendered by a client, typically an editor, they lead to nowhere. This might cause some frustration. Additionally, documentation for other rules (e.g., [`D211`](https://github.com/astral-sh/ruff/blob/b58f2c399e87c11def59bd55f75f7ef8148c84f0/crates/ruff_linter/src/rules/pydocstyle/rules/blank_before_after_class.rs#L123) and [`S606`](https://github.com/astral-sh/ruff/blob/b58f2c399e87c11def59bd55f75f7ef8148c84f0/crates/ruff_linter/src/rules/flake8_bandit/rules/shell_injection.rs#L197)) uses the full URL form.

All such instances have thus been converted to full URLs:

```markdown
[`rule-name`][A123]

[A123]: https://docs.astral.sh/ruff/rules/rule-name/
```

## Test Plan

None.
