### PR TITLE
[red-knot] Internal refactoring of visibility constraints API

### DIFF
--- a/crates/red_knot_python_semantic/src/semantic_index.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index.rs
@@ -32,7 +32,7 @@ mod use_def;
 
 pub(crate) use self::use_def::{
     BindingWithConstraints, BindingWithConstraintsIterator, DeclarationWithConstraint,
-    DeclarationsIterator, ScopedVisibilityConstraintId,
+    DeclarationsIterator,
 };
 
 type SymbolMap = hashbrown::HashMap<ScopedSymbolId, (), FxBuildHasher>;

--- a/crates/red_knot_python_semantic/src/semantic_index/builder.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/builder.rs
@@ -407,7 +407,7 @@ impl<'db> SemanticIndexBuilder<'db> {
         self.current_use_def_map_mut().mark_unreachable();
     }
 
-    /// Records a [`VisibilityConstraint::Ambiguous`] constraint.
+    /// Records a visibility constraint that always evaluates to "ambiguous".
     fn record_ambiguous_visibility(&mut self) {
         self.current_use_def_map_mut()
             .record_visibility_constraint(ScopedVisibilityConstraintId::AMBIGUOUS);

--- a/crates/red_knot_python_semantic/src/semantic_index/builder.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/builder.rs
@@ -407,9 +407,9 @@ impl<'db> SemanticIndexBuilder<'db> {
     }
 
     /// Records a [`VisibilityConstraint::Ambiguous`] constraint.
-    fn record_ambiguous_visibility(&mut self) -> ScopedVisibilityConstraintId {
+    fn record_ambiguous_visibility(&mut self) {
         self.current_use_def_map_mut()
-            .record_visibility_constraint(VisibilityConstraint::Ambiguous)
+            .record_visibility_constraint_id(ScopedVisibilityConstraintId::AMBIGUOUS);
     }
 
     /// Simplifies (resets) visibility constraints on all live bindings and declarations that did

--- a/crates/red_knot_python_semantic/src/semantic_index/builder.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/builder.rs
@@ -25,12 +25,10 @@ use crate::semantic_index::symbol::{
     FileScopeId, NodeWithScopeKey, NodeWithScopeRef, Scope, ScopeId, ScopeKind, ScopedSymbolId,
     SymbolTableBuilder,
 };
-use crate::semantic_index::use_def::{
-    FlowSnapshot, ScopedConstraintId, ScopedVisibilityConstraintId, UseDefMapBuilder,
-};
+use crate::semantic_index::use_def::{FlowSnapshot, ScopedConstraintId, UseDefMapBuilder};
 use crate::semantic_index::SemanticIndex;
 use crate::unpack::{Unpack, UnpackValue};
-use crate::visibility_constraints::VisibilityConstraint;
+use crate::visibility_constraints::{ScopedVisibilityConstraintId, VisibilityConstraint};
 use crate::Db;
 
 use super::constraint::{Constraint, ConstraintNode, PatternConstraint};

--- a/crates/red_knot_python_semantic/src/semantic_index/use_def.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/use_def.rs
@@ -255,17 +255,18 @@
 //! snapshot, and merging a snapshot into the current state. The logic using these methods lives in
 //! [`SemanticIndexBuilder`](crate::semantic_index::builder::SemanticIndexBuilder), e.g. where it
 //! visits a `StmtIf` node.
+pub(crate) use self::symbol_state::ScopedConstraintId;
 use self::symbol_state::{
     BindingIdWithConstraintsIterator, ConstraintIdIterator, DeclarationIdIterator,
     ScopedDefinitionId, SymbolBindings, SymbolDeclarations, SymbolState,
 };
-pub(crate) use self::symbol_state::{ScopedConstraintId, ScopedVisibilityConstraintId};
 use crate::semantic_index::ast_ids::ScopedUseId;
 use crate::semantic_index::definition::Definition;
 use crate::semantic_index::symbol::ScopedSymbolId;
 use crate::semantic_index::use_def::symbol_state::DeclarationIdWithConstraint;
 use crate::visibility_constraints::{
-    VisibilityConstraint, VisibilityConstraints, VisibilityConstraintsBuilder,
+    ScopedVisibilityConstraintId, VisibilityConstraint, VisibilityConstraints,
+    VisibilityConstraintsBuilder,
 };
 use ruff_index::IndexVec;
 use rustc_hash::FxHashMap;

--- a/crates/red_knot_python_semantic/src/semantic_index/use_def.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/use_def.rs
@@ -287,7 +287,7 @@ pub(crate) struct UseDefMap<'db> {
     /// Array of [`Constraint`] in this scope.
     all_constraints: AllConstraints<'db>,
 
-    /// Array of [`VisibilityConstraint`]s in this scope.
+    /// Array of visibility constraints in this scope.
     visibility_constraints: VisibilityConstraints<'db>,
 
     /// [`SymbolBindings`] reaching a [`ScopedUseId`].
@@ -489,7 +489,7 @@ pub(super) struct UseDefMapBuilder<'db> {
     /// Append-only array of [`Constraint`].
     all_constraints: AllConstraints<'db>,
 
-    /// Append-only array of [`VisibilityConstraint`].
+    /// Builder of visibility constraints.
     pub(super) visibility_constraints: VisibilityConstraintsBuilder<'db>,
 
     /// A constraint which describes the visibility of the unbound/undeclared state, i.e.

--- a/crates/red_knot_python_semantic/src/semantic_index/use_def.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/use_def.rs
@@ -264,7 +264,9 @@ use crate::semantic_index::ast_ids::ScopedUseId;
 use crate::semantic_index::definition::Definition;
 use crate::semantic_index::symbol::ScopedSymbolId;
 use crate::semantic_index::use_def::symbol_state::DeclarationIdWithConstraint;
-use crate::visibility_constraints::{VisibilityConstraint, VisibilityConstraints};
+use crate::visibility_constraints::{
+    VisibilityConstraint, VisibilityConstraints, VisibilityConstraintsBuilder,
+};
 use ruff_index::IndexVec;
 use rustc_hash::FxHashMap;
 
@@ -488,7 +490,7 @@ pub(super) struct UseDefMapBuilder<'db> {
     all_constraints: AllConstraints<'db>,
 
     /// Append-only array of [`VisibilityConstraint`].
-    visibility_constraints: VisibilityConstraints<'db>,
+    visibility_constraints: VisibilityConstraintsBuilder<'db>,
 
     /// A constraint which describes the visibility of the unbound/undeclared state, i.e.
     /// whether or not the start of the scope is visible. This is important for cases like
@@ -513,7 +515,7 @@ impl Default for UseDefMapBuilder<'_> {
         Self {
             all_definitions: IndexVec::from_iter([None]),
             all_constraints: IndexVec::new(),
-            visibility_constraints: VisibilityConstraints::default(),
+            visibility_constraints: VisibilityConstraintsBuilder::default(),
             scope_start_visibility: ScopedVisibilityConstraintId::ALWAYS_TRUE,
             bindings_by_use: IndexVec::new(),
             definitions_by_definition: FxHashMap::default(),
@@ -742,7 +744,7 @@ impl<'db> UseDefMapBuilder<'db> {
         UseDefMap {
             all_definitions: self.all_definitions,
             all_constraints: self.all_constraints,
-            visibility_constraints: self.visibility_constraints,
+            visibility_constraints: self.visibility_constraints.build(),
             bindings_by_use: self.bindings_by_use,
             public_symbols: self.symbol_states,
             definitions_by_definition: self.definitions_by_definition,

--- a/crates/red_knot_python_semantic/src/semantic_index/use_def.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/use_def.rs
@@ -265,8 +265,7 @@ use crate::semantic_index::definition::Definition;
 use crate::semantic_index::symbol::ScopedSymbolId;
 use crate::semantic_index::use_def::symbol_state::DeclarationIdWithConstraint;
 use crate::visibility_constraints::{
-    ScopedVisibilityConstraintId, VisibilityConstraint, VisibilityConstraints,
-    VisibilityConstraintsBuilder,
+    ScopedVisibilityConstraintId, VisibilityConstraints, VisibilityConstraintsBuilder,
 };
 use ruff_index::IndexVec;
 use rustc_hash::FxHashMap;
@@ -491,7 +490,7 @@ pub(super) struct UseDefMapBuilder<'db> {
     all_constraints: AllConstraints<'db>,
 
     /// Append-only array of [`VisibilityConstraint`].
-    visibility_constraints: VisibilityConstraintsBuilder<'db>,
+    pub(super) visibility_constraints: VisibilityConstraintsBuilder<'db>,
 
     /// A constraint which describes the visibility of the unbound/undeclared state, i.e.
     /// whether or not the start of the scope is visible. This is important for cases like
@@ -564,33 +563,16 @@ impl<'db> UseDefMapBuilder<'db> {
         new_constraint_id
     }
 
-    pub(super) fn add_visibility_constraint(
-        &mut self,
-        constraint: VisibilityConstraint<'db>,
-    ) -> ScopedVisibilityConstraintId {
-        self.visibility_constraints.add(constraint)
-    }
-
-    pub(super) fn record_visibility_constraint_id(
+    pub(super) fn record_visibility_constraint(
         &mut self,
         constraint: ScopedVisibilityConstraintId,
     ) {
         for state in &mut self.symbol_states {
             state.record_visibility_constraint(&mut self.visibility_constraints, constraint);
         }
-
         self.scope_start_visibility = self
             .visibility_constraints
             .add_and_constraint(self.scope_start_visibility, constraint);
-    }
-
-    pub(super) fn record_visibility_constraint(
-        &mut self,
-        constraint: VisibilityConstraint<'db>,
-    ) -> ScopedVisibilityConstraintId {
-        let new_constraint_id = self.add_visibility_constraint(constraint);
-        self.record_visibility_constraint_id(new_constraint_id);
-        new_constraint_id
     }
 
     /// This method resets the visibility constraints for all symbols to a previous state

--- a/crates/red_knot_python_semantic/src/semantic_index/use_def/symbol_state.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/use_def/symbol_state.rs
@@ -49,7 +49,7 @@ use ruff_index::newtype_index;
 use smallvec::SmallVec;
 
 use crate::semantic_index::use_def::bitset::{BitSet, BitSetIterator};
-use crate::semantic_index::use_def::VisibilityConstraints;
+use crate::semantic_index::use_def::VisibilityConstraintsBuilder;
 
 /// A newtype-index for a definition in a particular scope.
 #[newtype_index]
@@ -164,7 +164,7 @@ impl SymbolDeclarations {
     /// Add given visibility constraint to all live declarations.
     pub(super) fn record_visibility_constraint(
         &mut self,
-        visibility_constraints: &mut VisibilityConstraints,
+        visibility_constraints: &mut VisibilityConstraintsBuilder,
         constraint: ScopedVisibilityConstraintId,
     ) {
         for existing in &mut self.visibility_constraints {
@@ -180,7 +180,7 @@ impl SymbolDeclarations {
         }
     }
 
-    fn merge(&mut self, b: Self, visibility_constraints: &mut VisibilityConstraints) {
+    fn merge(&mut self, b: Self, visibility_constraints: &mut VisibilityConstraintsBuilder) {
         let a = std::mem::take(self);
         self.live_declarations = a.live_declarations.clone();
         self.live_declarations.union(&b.live_declarations);
@@ -270,7 +270,7 @@ impl SymbolBindings {
     /// Add given visibility constraint to all live bindings.
     pub(super) fn record_visibility_constraint(
         &mut self,
-        visibility_constraints: &mut VisibilityConstraints,
+        visibility_constraints: &mut VisibilityConstraintsBuilder,
         constraint: ScopedVisibilityConstraintId,
     ) {
         for existing in &mut self.visibility_constraints {
@@ -287,7 +287,7 @@ impl SymbolBindings {
         }
     }
 
-    fn merge(&mut self, mut b: Self, visibility_constraints: &mut VisibilityConstraints) {
+    fn merge(&mut self, mut b: Self, visibility_constraints: &mut VisibilityConstraintsBuilder) {
         let mut a = std::mem::take(self);
         self.live_bindings = a.live_bindings.clone();
         self.live_bindings.union(&b.live_bindings);
@@ -373,7 +373,7 @@ impl SymbolState {
     /// Add given visibility constraint to all live bindings.
     pub(super) fn record_visibility_constraint(
         &mut self,
-        visibility_constraints: &mut VisibilityConstraints,
+        visibility_constraints: &mut VisibilityConstraintsBuilder,
         constraint: ScopedVisibilityConstraintId,
     ) {
         self.bindings
@@ -401,7 +401,7 @@ impl SymbolState {
     pub(super) fn merge(
         &mut self,
         b: SymbolState,
-        visibility_constraints: &mut VisibilityConstraints,
+        visibility_constraints: &mut VisibilityConstraintsBuilder,
     ) {
         self.bindings.merge(b.bindings, visibility_constraints);
         self.declarations
@@ -584,7 +584,7 @@ mod tests {
 
     #[test]
     fn merge() {
-        let mut visibility_constraints = VisibilityConstraints::default();
+        let mut visibility_constraints = VisibilityConstraintsBuilder::default();
 
         // merging the same definition with the same constraint keeps the constraint
         let mut sym1a = SymbolState::undefined(ScopedVisibilityConstraintId::ALWAYS_TRUE);
@@ -655,7 +655,7 @@ mod tests {
 
     #[test]
     fn record_declaration_merge() {
-        let mut visibility_constraints = VisibilityConstraints::default();
+        let mut visibility_constraints = VisibilityConstraintsBuilder::default();
         let mut sym = SymbolState::undefined(ScopedVisibilityConstraintId::ALWAYS_TRUE);
         sym.record_declaration(ScopedDefinitionId::from_u32(1));
 
@@ -669,7 +669,7 @@ mod tests {
 
     #[test]
     fn record_declaration_merge_partial_undeclared() {
-        let mut visibility_constraints = VisibilityConstraints::default();
+        let mut visibility_constraints = VisibilityConstraintsBuilder::default();
         let mut sym = SymbolState::undefined(ScopedVisibilityConstraintId::ALWAYS_TRUE);
         sym.record_declaration(ScopedDefinitionId::from_u32(1));
 

--- a/crates/red_knot_python_semantic/src/semantic_index/use_def/symbol_state.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/use_def/symbol_state.rs
@@ -50,6 +50,7 @@ use smallvec::SmallVec;
 
 use crate::semantic_index::use_def::bitset::{BitSet, BitSetIterator};
 use crate::semantic_index::use_def::VisibilityConstraintsBuilder;
+use crate::visibility_constraints::ScopedVisibilityConstraintId;
 
 /// A newtype-index for a definition in a particular scope.
 #[newtype_index]
@@ -98,18 +99,6 @@ type ConstraintsPerBinding = SmallVec<InlineConstraintArray>;
 
 /// Iterate over all constraints for a single binding.
 type ConstraintsIterator<'a> = std::slice::Iter<'a, Constraints>;
-
-/// A newtype-index for a visibility constraint in a particular scope.
-#[newtype_index]
-pub(crate) struct ScopedVisibilityConstraintId;
-
-impl ScopedVisibilityConstraintId {
-    /// A special ID that is used for an "always true" / "always visible" constraint.
-    /// When we create a new [`VisibilityConstraints`] object, this constraint is always
-    /// present at index 0.
-    pub(crate) const ALWAYS_TRUE: ScopedVisibilityConstraintId =
-        ScopedVisibilityConstraintId::from_u32(0);
-}
 
 const INLINE_VISIBILITY_CONSTRAINTS: usize = 4;
 type InlineVisibilityConstraintsArray =

--- a/crates/red_knot_python_semantic/src/visibility_constraints.rs
+++ b/crates/red_knot_python_semantic/src/visibility_constraints.rs
@@ -150,9 +150,8 @@
 //!
 //! [Kleene]: <https://en.wikipedia.org/wiki/Three-valued_logic#Kleene_and_Priest_logics>
 
-use ruff_index::IndexVec;
+use ruff_index::{newtype_index, IndexVec};
 
-use crate::semantic_index::ScopedVisibilityConstraintId;
 use crate::semantic_index::{
     ast_ids::HasScopedExpressionId,
     constraint::{Constraint, ConstraintNode, PatternConstraintKind},
@@ -191,6 +190,18 @@ pub(crate) enum VisibilityConstraint<'db> {
     VisibleIfNot(ScopedVisibilityConstraintId),
     KleeneAnd(ScopedVisibilityConstraintId, ScopedVisibilityConstraintId),
     KleeneOr(ScopedVisibilityConstraintId, ScopedVisibilityConstraintId),
+}
+
+/// A newtype-index for a visibility constraint in a particular scope.
+#[newtype_index]
+pub(crate) struct ScopedVisibilityConstraintId;
+
+impl ScopedVisibilityConstraintId {
+    /// A special ID that is used for an "always true" / "always visible" constraint.
+    /// When we create a new [`VisibilityConstraints`] object, this constraint is always
+    /// present at index 0.
+    pub(crate) const ALWAYS_TRUE: ScopedVisibilityConstraintId =
+        ScopedVisibilityConstraintId::from_u32(0);
 }
 
 #[derive(Debug, PartialEq, Eq)]

--- a/crates/red_knot_python_semantic/src/visibility_constraints.rs
+++ b/crates/red_knot_python_semantic/src/visibility_constraints.rs
@@ -198,7 +198,12 @@ pub(crate) struct VisibilityConstraints<'db> {
     constraints: IndexVec<ScopedVisibilityConstraintId, VisibilityConstraint<'db>>,
 }
 
-impl Default for VisibilityConstraints<'_> {
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) struct VisibilityConstraintsBuilder<'db> {
+    constraints: IndexVec<ScopedVisibilityConstraintId, VisibilityConstraint<'db>>,
+}
+
+impl Default for VisibilityConstraintsBuilder<'_> {
     fn default() -> Self {
         Self {
             constraints: IndexVec::from_iter([VisibilityConstraint::AlwaysTrue]),
@@ -206,7 +211,13 @@ impl Default for VisibilityConstraints<'_> {
     }
 }
 
-impl<'db> VisibilityConstraints<'db> {
+impl<'db> VisibilityConstraintsBuilder<'db> {
+    pub(crate) fn build(self) -> VisibilityConstraints<'db> {
+        VisibilityConstraints {
+            constraints: self.constraints,
+        }
+    }
+
     pub(crate) fn add(
         &mut self,
         constraint: VisibilityConstraint<'db>,
@@ -250,7 +261,9 @@ impl<'db> VisibilityConstraints<'db> {
             _ => self.add(VisibilityConstraint::KleeneAnd(a, b)),
         }
     }
+}
 
+impl<'db> VisibilityConstraints<'db> {
     /// Analyze the statically known visibility for a given visibility constraint.
     pub(crate) fn evaluate(&self, db: &'db dyn Db, id: ScopedVisibilityConstraintId) -> Truthiness {
         self.evaluate_impl(db, id, MAX_RECURSION_DEPTH)


### PR DESCRIPTION
This extracts some pure refactoring noise from https://github.com/astral-sh/ruff/pull/15861.  This changes the API for creating and evaluating visibility constraints, but does not change how they are respresented internally.  There should be no behavioral or performance changes in this PR.

Changes:

- Hide the internal representation isn't changed, so that we can make changes to it in #15861.
- Add a separate builder type for visibility constraints. (With TDDs, we will have some additional builder state that we can throw away once we're done constructing.)
- Remove a layer of helper methods from `UseDefMapBuilder`, making `SemanticIndexBuilder` responsible for constructing whatever visibility constraints it needs.