### PR TITLE
[pylint] Fix PL1730: min/max auto-fix and suggestion

### DIFF
--- a/crates/ruff_linter/src/rules/pylint/rules/if_stmt_min_max.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/if_stmt_min_max.rs
@@ -169,13 +169,17 @@ pub(crate) fn if_stmt_min_max(checker: &mut Checker, stmt_if: &ast::StmtIf) {
     // to the target of the comparison
     let first_cmp_arg: &str;
     let second_cmp_arg: &str;
-    if checker.locator().slice(arg1) == cmp_target {
-        first_cmp_arg = checker.locator().slice(arg1);
-        second_cmp_arg = checker.locator().slice(arg2);
+    let (first_cmp_arg, second_cmp_arg) = if checker.locator().slice(arg1) == cmp_target {
+      (
+    	  	checker.locator().slice(arg1),
+        	checker.locator().slice(arg2),
+    	)
     } else {
-        first_cmp_arg = checker.locator().slice(arg2);
-        second_cmp_arg = checker.locator().slice(arg1);
-    }
+    	(
+        checker.locator().slice(arg2),
+        checker.locator().slice(arg1),
+      )
+    };
 
     let replacement = format!("{cmp_target} = {min_max}({first_cmp_arg}, {second_cmp_arg})",);
 

--- a/crates/ruff_linter/src/rules/pylint/rules/if_stmt_min_max.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/if_stmt_min_max.rs
@@ -167,18 +167,10 @@ pub(crate) fn if_stmt_min_max(checker: &mut Checker, stmt_if: &ast::StmtIf) {
 
     // Make sure that the first arg of the min/max method is equal
     // to the target of the comparison
-    let first_cmp_arg: &str;
-    let second_cmp_arg: &str;
     let (first_cmp_arg, second_cmp_arg) = if checker.locator().slice(arg1) == cmp_target {
-      (
-    	  	checker.locator().slice(arg1),
-        	checker.locator().slice(arg2),
-    	)
+        (checker.locator().slice(arg1), checker.locator().slice(arg2))
     } else {
-    	(
-        checker.locator().slice(arg2),
-        checker.locator().slice(arg1),
-      )
+        (checker.locator().slice(arg2), checker.locator().slice(arg1))
     };
 
     let replacement = format!("{cmp_target} = {min_max}({first_cmp_arg}, {second_cmp_arg})",);

--- a/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLR1730_if_stmt_min_max.py.snap
+++ b/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLR1730_if_stmt_min_max.py.snap
@@ -23,7 +23,7 @@ if_stmt_min_max.py:8:1: PLR1730 [*] Replace `if` statement with `value = max(val
 11 10 | if value <= 10:  # [max-instead-of-if]
 12 11 |     value = 10
 
-if_stmt_min_max.py:11:1: PLR1730 [*] Replace `if` statement with `value = max(10, value)`
+if_stmt_min_max.py:11:1: PLR1730 [*] Replace `if` statement with `value = max(value, 10)`
    |
  9 |       value = 10
 10 |
@@ -33,7 +33,7 @@ if_stmt_min_max.py:11:1: PLR1730 [*] Replace `if` statement with `value = max(10
 13 |
 14 |   if value < value2:  # [max-instead-of-if]
    |
-   = help: Replace with `value = max(10, value)`
+   = help: Replace with `value = max(value, 10)`
 
 ℹ Safe fix
 8  8  | if value < 10:  # [max-instead-of-if]
@@ -41,7 +41,7 @@ if_stmt_min_max.py:11:1: PLR1730 [*] Replace `if` statement with `value = max(10
 10 10 | 
 11    |-if value <= 10:  # [max-instead-of-if]
 12    |-    value = 10
-   11 |+value = max(10, value)
+   11 |+value = max(value, 10)
 13 12 | 
 14 13 | if value < value2:  # [max-instead-of-if]
 15 14 |     value = value2
@@ -92,7 +92,7 @@ if_stmt_min_max.py:17:1: PLR1730 [*] Replace `if` statement with `value = min(va
 20 19 | if value >= 10:  # [min-instead-of-if]
 21 20 |     value = 10
 
-if_stmt_min_max.py:20:1: PLR1730 [*] Replace `if` statement with `value = min(10, value)`
+if_stmt_min_max.py:20:1: PLR1730 [*] Replace `if` statement with `value = min(value, 10)`
    |
 18 |       value = 10
 19 |
@@ -102,7 +102,7 @@ if_stmt_min_max.py:20:1: PLR1730 [*] Replace `if` statement with `value = min(10
 22 |
 23 |   if value > value2:  # [min-instead-of-if]
    |
-   = help: Replace with `value = min(10, value)`
+   = help: Replace with `value = min(value, 10)`
 
 ℹ Safe fix
 17 17 | if value > 10:  # [min-instead-of-if]
@@ -110,7 +110,7 @@ if_stmt_min_max.py:20:1: PLR1730 [*] Replace `if` statement with `value = min(10
 19 19 | 
 20    |-if value >= 10:  # [min-instead-of-if]
 21    |-    value = 10
-   20 |+value = min(10, value)
+   20 |+value = min(value, 10)
 22 21 | 
 23 22 | if value > value2:  # [min-instead-of-if]
 24 23 |     value = value2
@@ -202,7 +202,7 @@ if_stmt_min_max.py:60:1: PLR1730 [*] Replace `if` statement with `A2 = max(A2, A
 63 62 | if A2 <= A1:  # [max-instead-of-if]
 64 63 |     A2 = A1
 
-if_stmt_min_max.py:63:1: PLR1730 [*] Replace `if` statement with `A2 = max(A1, A2)`
+if_stmt_min_max.py:63:1: PLR1730 [*] Replace `if` statement with `A2 = max(A2, A1)`
    |
 61 |       A2 = A1
 62 |
@@ -212,7 +212,7 @@ if_stmt_min_max.py:63:1: PLR1730 [*] Replace `if` statement with `A2 = max(A1, A
 65 |
 66 |   if A2 > A1:  # [min-instead-of-if]
    |
-   = help: Replace with `A2 = max(A1, A2)`
+   = help: Replace with `A2 = max(A2, A1)`
 
 ℹ Safe fix
 60 60 | if A2 < A1:  # [max-instead-of-if]
@@ -220,7 +220,7 @@ if_stmt_min_max.py:63:1: PLR1730 [*] Replace `if` statement with `A2 = max(A1, A
 62 62 | 
 63    |-if A2 <= A1:  # [max-instead-of-if]
 64    |-    A2 = A1
-   63 |+A2 = max(A1, A2)
+   63 |+A2 = max(A2, A1)
 65 64 | 
 66 65 | if A2 > A1:  # [min-instead-of-if]
 67 66 |     A2 = A1
@@ -248,7 +248,7 @@ if_stmt_min_max.py:66:1: PLR1730 [*] Replace `if` statement with `A2 = min(A2, A
 69 68 | if A2 >= A1:  # [min-instead-of-if]
 70 69 |     A2 = A1
 
-if_stmt_min_max.py:69:1: PLR1730 [*] Replace `if` statement with `A2 = min(A1, A2)`
+if_stmt_min_max.py:69:1: PLR1730 [*] Replace `if` statement with `A2 = min(A2, A1)`
    |
 67 |       A2 = A1
 68 |
@@ -258,7 +258,7 @@ if_stmt_min_max.py:69:1: PLR1730 [*] Replace `if` statement with `A2 = min(A1, A
 71 |
 72 |   # Negative
    |
-   = help: Replace with `A2 = min(A1, A2)`
+   = help: Replace with `A2 = min(A2, A1)`
 
 ℹ Safe fix
 66 66 | if A2 > A1:  # [min-instead-of-if]
@@ -266,7 +266,7 @@ if_stmt_min_max.py:69:1: PLR1730 [*] Replace `if` statement with `A2 = min(A1, A
 68 68 | 
 69    |-if A2 >= A1:  # [min-instead-of-if]
 70    |-    A2 = A1
-   69 |+A2 = min(A1, A2)
+   69 |+A2 = min(A2, A1)
 71 70 | 
 72 71 | # Negative
 73 72 | if value < 10:
@@ -295,12 +295,12 @@ if_stmt_min_max.py:132:1: PLR1730 [*] Replace `if` statement with `min` call
 134 133 |         value.
 135 134 |         attr
 136     |-    ) = 3
-    135 |+    ) = min(value.attr, 3)
+    135 |+    ) = min(3, value.attr)
 137 136 | 
 138 137 | class Foo:
 139 138 |     _min = 0
 
-if_stmt_min_max.py:143:9: PLR1730 [*] Replace `if` statement with `self._min = min(value, self._min)`
+if_stmt_min_max.py:143:9: PLR1730 [*] Replace `if` statement with `self._min = min(self._min, value)`
     |
 142 |       def foo(self, value) -> None:
 143 | /         if value < self._min:
@@ -309,7 +309,7 @@ if_stmt_min_max.py:143:9: PLR1730 [*] Replace `if` statement with `self._min = m
 145 |           if value > self._max:
 146 |               self._max = value
     |
-    = help: Replace with `self._min = min(value, self._min)`
+    = help: Replace with `self._min = min(self._min, value)`
 
 ℹ Safe fix
 140 140 |     _max = 0
@@ -317,12 +317,12 @@ if_stmt_min_max.py:143:9: PLR1730 [*] Replace `if` statement with `self._min = m
 142 142 |     def foo(self, value) -> None:
 143     |-        if value < self._min:
 144     |-            self._min = value
-    143 |+        self._min = min(value, self._min)
+    143 |+        self._min = min(self._min, value)
 145 144 |         if value > self._max:
 146 145 |             self._max = value
 147 146 | 
 
-if_stmt_min_max.py:145:9: PLR1730 [*] Replace `if` statement with `self._max = max(value, self._max)`
+if_stmt_min_max.py:145:9: PLR1730 [*] Replace `if` statement with `self._max = max(self._max, value)`
     |
 143 |           if value < self._min:
 144 |               self._min = value
@@ -332,7 +332,7 @@ if_stmt_min_max.py:145:9: PLR1730 [*] Replace `if` statement with `self._max = m
 147 |
 148 |           if self._min < value:
     |
-    = help: Replace with `self._max = max(value, self._max)`
+    = help: Replace with `self._max = max(self._max, value)`
 
 ℹ Safe fix
 142 142 |     def foo(self, value) -> None:
@@ -340,7 +340,7 @@ if_stmt_min_max.py:145:9: PLR1730 [*] Replace `if` statement with `self._max = m
 144 144 |             self._min = value
 145     |-        if value > self._max:
 146     |-            self._max = value
-    145 |+        self._max = max(value, self._max)
+    145 |+        self._max = max(self._max, value)
 147 146 | 
 148 147 |         if self._min < value:
 149 148 |             self._min = value
@@ -437,7 +437,7 @@ if_stmt_min_max.py:155:9: PLR1730 [*] Replace `if` statement with `self._max = m
 158 157 |         if self._min <= value:
 159 158 |             self._min = value
 
-if_stmt_min_max.py:158:9: PLR1730 [*] Replace `if` statement with `self._min = max(value, self._min)`
+if_stmt_min_max.py:158:9: PLR1730 [*] Replace `if` statement with `self._min = max(self._min, value)`
     |
 156 |               self._max = value
 157 |
@@ -447,7 +447,7 @@ if_stmt_min_max.py:158:9: PLR1730 [*] Replace `if` statement with `self._min = m
 160 |           if self._max >= value:
 161 |               self._max = value
     |
-    = help: Replace with `self._min = max(value, self._min)`
+    = help: Replace with `self._min = max(self._min, value)`
 
 ℹ Safe fix
 155 155 |         if value >= self._max:
@@ -455,11 +455,11 @@ if_stmt_min_max.py:158:9: PLR1730 [*] Replace `if` statement with `self._min = m
 157 157 | 
 158     |-        if self._min <= value:
 159     |-            self._min = value
-    158 |+        self._min = max(value, self._min)
+    158 |+        self._min = max(self._min, value)
 160 159 |         if self._max >= value:
 161 160 |             self._max = value
 
-if_stmt_min_max.py:160:9: PLR1730 [*] Replace `if` statement with `self._max = min(value, self._max)`
+if_stmt_min_max.py:160:9: PLR1730 [*] Replace `if` statement with `self._max = min(self._max, value)`
     |
 158 |           if self._min <= value:
 159 |               self._min = value
@@ -467,7 +467,7 @@ if_stmt_min_max.py:160:9: PLR1730 [*] Replace `if` statement with `self._max = m
 161 | |             self._max = value
     | |_____________________________^ PLR1730
     |
-    = help: Replace with `self._max = min(value, self._max)`
+    = help: Replace with `self._max = min(self._max, value)`
 
 ℹ Safe fix
 157 157 | 
@@ -475,4 +475,4 @@ if_stmt_min_max.py:160:9: PLR1730 [*] Replace `if` statement with `self._max = m
 159 159 |             self._min = value
 160     |-        if self._max >= value:
 161     |-            self._max = value
-    160 |+        self._max = min(value, self._max)
+    160 |+        self._max = min(self._max, value)

--- a/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLR1730_if_stmt_min_max.py.snap
+++ b/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLR1730_if_stmt_min_max.py.snap
@@ -295,7 +295,7 @@ if_stmt_min_max.py:132:1: PLR1730 [*] Replace `if` statement with `min` call
 134 133 |         value.
 135 134 |         attr
 136     |-    ) = 3
-    135 |+    ) = min(3, value.attr)
+    135 |+    ) = min(value.attr, 3)
 137 136 | 
 138 137 | class Foo:
 139 138 |     _min = 0


### PR DESCRIPTION
## Summary

The PR addresses the issue #15887 

For two objects `a` and `b`, we ensure that the auto-fix and the suggestion is of the form `a = min(a, b)` (or `a = max(a, b)`). This is because we want to be consistent with the python implementation of the methods: `min` and `max`. See the above issue for more details.




