### PR TITLE
[red-knot] MDTest: Fix line numbers in error messages

### DIFF
--- a/crates/red_knot_test/src/lib.rs
+++ b/crates/red_knot_test/src/lib.rs
@@ -135,7 +135,7 @@ fn run_test(db: &mut db::Db, test: &parser::MarkdownTest) -> Result<(), Failures
 
             Some(TestFile {
                 file,
-                backtick_offset: embedded.md_offset,
+                backtick_offset: embedded.backtick_offset,
             })
         })
         .collect();


### PR DESCRIPTION
## Summary

I broke the line number reporting in error messages with my previous PR.

## Test Plan

Introduced an error in a Markdown test and made sure that the line in the error message matches.
