### PR TITLE
[red-knot] Use unambiguous invalid-syntax-construct for suppression comment test

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/suppressions/knot_ignore.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/suppressions/knot_ignore.md
@@ -77,7 +77,8 @@ def test(a: f"f-string type annotation", b: b"byte-string-type-annotation"): ...
 ```py
 # error: [invalid-syntax]
 # error: [unused-ignore-comment]
-def test(  # knot: ignore
+def test($):  # knot: ignore
+    pass
 ```
 
 <!-- blacken-docs:on -->


### PR DESCRIPTION
## Summary

I experimented with [not trimming trailing newlines in code snippets](https://github.com/astral-sh/ruff/pull/15926#discussion_r1940992090), but since came to the conclusion that the current behavior is better because otherwise, there is no way to write snippets without a trailing newline at all. And when you copy the code from a Markdown snippet in GitHub, you also don't get a trailing newline.

I was surprised to see some test failures when I played with this though, and decided to make this test independent from this implementation detail.
