### PR TITLE
[red-knot] Separate 'infer_expression_type' query

### DIFF
--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -15,7 +15,8 @@ pub(crate) use self::diagnostic::register_lints;
 pub use self::diagnostic::{TypeCheckDiagnostic, TypeCheckDiagnostics};
 pub(crate) use self::display::TypeArrayDisplay;
 pub(crate) use self::infer::{
-    infer_deferred_types, infer_definition_types, infer_expression_types, infer_scope_types,
+    infer_deferred_types, infer_definition_types, infer_expression_type, infer_expression_types,
+    infer_scope_types,
 };
 pub use self::narrow::KnownConstraintFunction;
 pub(crate) use self::signatures::Signature;
@@ -25,7 +26,6 @@ use crate::module_resolver::{file_to_module, resolve_module, KnownModule};
 use crate::semantic_index::ast_ids::HasScopedExpressionId;
 use crate::semantic_index::attribute_assignment::AttributeAssignment;
 use crate::semantic_index::definition::Definition;
-use crate::semantic_index::expression::Expression;
 use crate::semantic_index::symbol::{self as symbol, ScopeId, ScopedSymbolId};
 use crate::semantic_index::{
     attribute_assignments, global_scope, imported_modules, semantic_index, symbol_table,
@@ -4147,16 +4147,6 @@ impl<'db> Class<'db> {
         name: &str,
         inferred_type_from_class_body: Option<Type<'db>>,
     ) -> Symbol<'db> {
-        // We use a separate salsa query here to prevent unrelated changes in the AST of an external
-        // file from triggering re-evaluations of downstream queries.
-        // See the `dependency_implicit_instance_attribute` test for more information.
-        #[salsa::tracked]
-        fn infer_expression_type<'db>(db: &'db dyn Db, expression: Expression<'db>) -> Type<'db> {
-            let inference = infer_expression_types(db, expression);
-            let expr_scope = expression.scope(db);
-            inference.expression_type(expression.node_ref(db).scoped_expression_id(db, expr_scope))
-        }
-
         // If we do not see any declarations of an attribute, neither in the class body nor in
         // any method, we build a union of `Unknown` with the inferred types of all bindings of
         // that attribute. We include `Unknown` in that union to account for the fact that the

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -193,6 +193,20 @@ pub(crate) fn infer_expression_types<'db>(
     TypeInferenceBuilder::new(db, InferenceRegion::Expression(expression), index).finish()
 }
 
+// Similar to `infer_expression_types` (with the same restrictions). Directly returns the
+// type of the overall expression. This is a salsa query because it accesses `node_ref`,
+// which is sensitive to changes in the AST. Making it a query allows downstream queries
+// to short-circuit if the result type has not changed.
+#[salsa::tracked]
+pub(crate) fn infer_expression_type<'db>(
+    db: &'db dyn Db,
+    expression: Expression<'db>,
+) -> Type<'db> {
+    let inference = infer_expression_types(db, expression);
+    let expr_scope = expression.scope(db);
+    inference.expression_type(expression.node_ref(db).scoped_expression_id(db, expr_scope))
+}
+
 /// Infer the types for an [`Unpack`] operation.
 ///
 /// This infers the expression type and performs structural match against the target expression

--- a/crates/red_knot_python_semantic/src/types/unpacker.rs
+++ b/crates/red_knot_python_semantic/src/types/unpacker.rs
@@ -7,7 +7,7 @@ use ruff_python_ast::{self as ast, AnyNodeRef};
 
 use crate::semantic_index::ast_ids::{HasScopedExpressionId, ScopedExpressionId};
 use crate::semantic_index::symbol::ScopeId;
-use crate::types::{infer_expression_types, todo_type, Type, TypeCheckDiagnostics};
+use crate::types::{infer_expression_type, todo_type, Type, TypeCheckDiagnostics};
 use crate::unpack::UnpackValue;
 use crate::Db;
 
@@ -42,8 +42,7 @@ impl<'db> Unpacker<'db> {
             "Unpacking target must be a list or tuple expression"
         );
 
-        let mut value_ty = infer_expression_types(self.db(), value.expression())
-            .expression_type(value.scoped_expression_id(self.db(), self.scope));
+        let mut value_ty = infer_expression_type(self.db(), value.expression());
 
         if value.is_assign()
             && self.context.in_stub()

--- a/crates/red_knot_python_semantic/src/unpack.rs
+++ b/crates/red_knot_python_semantic/src/unpack.rs
@@ -3,7 +3,6 @@ use ruff_python_ast::{self as ast, AnyNodeRef};
 use ruff_text_size::{Ranged, TextRange};
 
 use crate::ast_node_ref::AstNodeRef;
-use crate::semantic_index::ast_ids::{HasScopedExpressionId, ScopedExpressionId};
 use crate::semantic_index::expression::Expression;
 use crate::semantic_index::symbol::{FileScopeId, ScopeId};
 use crate::Db;
@@ -86,17 +85,6 @@ impl<'db> UnpackValue<'db> {
         match self {
             UnpackValue::Assign(expr) | UnpackValue::Iterable(expr) => expr,
         }
-    }
-
-    /// Returns the [`ScopedExpressionId`] of the underlying expression.
-    pub(crate) fn scoped_expression_id(
-        self,
-        db: &'db dyn Db,
-        scope: ScopeId<'db>,
-    ) -> ScopedExpressionId {
-        self.expression()
-            .node_ref(db)
-            .scoped_expression_id(db, scope)
     }
 
     /// Returns the expression as an [`AnyNodeRef`].


### PR DESCRIPTION
## Summary

As a follow-up to [the discussion here](https://github.com/astral-sh/ruff/pull/15811#discussion_r1939617368), this changeset adds a new salsa query
```rs
fn infer_expression_type<'db>(db: &'db dyn Db, expression: Expression<'db>) -> Type<'db>
```
which is similar to `infer_expression_types` (plural), but returns the type of the expression directly instead of returning a `TypeInference` object. We can use this in a few places. Notably, it can't be used here:

https://github.com/astral-sh/ruff/blob/9d83e76a3b57bbd8788535cd968376587fb3ec38/crates/red_knot_python_semantic/src/types/narrow.rs#L500-L504

because that uses `self.scope()`, not `cls.scope()`.

## Test Plan

—