### PR TITLE
[red-knot] add opt-in external diagnostic snapshotting to mdtest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2518,6 +2518,7 @@ dependencies = [
  "anyhow",
  "camino",
  "colored 3.0.0",
+ "insta",
  "memchr",
  "red_knot_python_semantic",
  "red_knot_vendored",

--- a/crates/red_knot_python_semantic/resources/mdtest/import/basic.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/import/basic.md
@@ -116,7 +116,17 @@ reveal_type(c.C)  # revealed: Literal[C]
 class C: ...
 ```
 
+## Unresolvable module import
+
+<!-- snapshot-diagnostics -->
+
+```py
+import zqzqzqzqzqzqzq  # error: [unresolved-import] "Cannot resolve import `zqzqzqzqzqzqzq`"
+```
+
 ## Unresolvable submodule imports
+
+<!-- snapshot-diagnostics -->
 
 ```py
 # Topmost component resolvable, submodule not resolvable:

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/basic.md_-_Structures_-_Unresolvable_module_import.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/basic.md_-_Structures_-_Unresolvable_module_import.snap
@@ -1,0 +1,28 @@
+---
+source: crates/red_knot_test/src/lib.rs
+expression: snapshot
+---
+---
+mdtest name: basic.md - Structures - Unresolvable module import
+mdtest path: crates/red_knot_python_semantic/resources/mdtest/import/basic.md
+---
+
+# Python source files
+
+## mdtest_snippet__1.py
+
+```
+1 | import zqzqzqzqzqzqzq  # error: [unresolved-import] "Cannot resolve import `zqzqzqzqzqzqzq`"
+```
+
+# Diagnostics
+
+```
+error: lint:unresolved-import
+ --> /src/mdtest_snippet__1.py:1:8
+  |
+1 | import zqzqzqzqzqzqzq  # error: [unresolved-import] "Cannot resolve import `zqzqzqzqzqzqzq`"
+  |        ^^^^^^^^^^^^^^ Cannot resolve import `zqzqzqzqzqzqzq`
+  |
+
+```

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/basic.md_-_Structures_-_Unresolvable_submodule_imports.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/basic.md_-_Structures_-_Unresolvable_submodule_imports.snap
@@ -1,0 +1,51 @@
+---
+source: crates/red_knot_test/src/lib.rs
+expression: snapshot
+---
+---
+mdtest name: basic.md - Structures - Unresolvable submodule imports
+mdtest path: crates/red_knot_python_semantic/resources/mdtest/import/basic.md
+---
+
+# Python source files
+
+## mdtest_snippet__1.py
+
+```
+1 | # Topmost component resolvable, submodule not resolvable:
+2 | import a.foo  # error: [unresolved-import] "Cannot resolve import `a.foo`"
+3 | 
+4 | # Topmost component unresolvable:
+5 | import b.foo  # error: [unresolved-import] "Cannot resolve import `b.foo`"
+```
+
+## a/__init__.py
+
+```
+```
+
+# Diagnostics
+
+```
+error: lint:unresolved-import
+ --> /src/mdtest_snippet__1.py:2:8
+  |
+1 | # Topmost component resolvable, submodule not resolvable:
+2 | import a.foo  # error: [unresolved-import] "Cannot resolve import `a.foo`"
+  |        ^^^^^ Cannot resolve import `a.foo`
+3 |
+4 | # Topmost component unresolvable:
+  |
+
+```
+
+```
+error: lint:unresolved-import
+ --> /src/mdtest_snippet__1.py:5:8
+  |
+4 | # Topmost component unresolvable:
+5 | import b.foo  # error: [unresolved-import] "Cannot resolve import `b.foo`"
+  |        ^^^^^ Cannot resolve import `b.foo`
+  |
+
+```

--- a/crates/red_knot_python_semantic/tests/mdtest.rs
+++ b/crates/red_knot_python_semantic/tests/mdtest.rs
@@ -8,20 +8,20 @@ use dir_test::{dir_test, Fixture};
 )]
 #[allow(clippy::needless_pass_by_value)]
 fn mdtest(fixture: Fixture<&str>) {
-    let fixture_path = Utf8Path::new(fixture.path());
+    let absolute_fixture_path = Utf8Path::new(fixture.path());
     let crate_dir = Utf8Path::new(env!("CARGO_MANIFEST_DIR"));
     let snapshot_path = crate_dir.join("resources").join("mdtest").join("snapshots");
     let workspace_root = crate_dir.ancestors().nth(2).unwrap();
 
-    let long_title = fixture_path.strip_prefix(workspace_root).unwrap();
-    let short_title = fixture_path.file_name().unwrap();
+    let relative_fixture_path = absolute_fixture_path.strip_prefix(workspace_root).unwrap();
+    let short_title = absolute_fixture_path.file_name().unwrap();
 
-    let test_name = test_name("mdtest", fixture_path);
+    let test_name = test_name("mdtest", absolute_fixture_path);
 
     red_knot_test::run(
-        fixture_path,
+        absolute_fixture_path,
+        relative_fixture_path,
         &snapshot_path,
-        long_title.as_str(),
         short_title,
         &test_name,
     );

--- a/crates/red_knot_python_semantic/tests/mdtest.rs
+++ b/crates/red_knot_python_semantic/tests/mdtest.rs
@@ -1,6 +1,5 @@
 use camino::Utf8Path;
 use dir_test::{dir_test, Fixture};
-use std::path::Path;
 
 /// See `crates/red_knot_test/README.md` for documentation on these tests.
 #[dir_test(
@@ -10,7 +9,8 @@ use std::path::Path;
 #[allow(clippy::needless_pass_by_value)]
 fn mdtest(fixture: Fixture<&str>) {
     let fixture_path = Utf8Path::new(fixture.path());
-    let crate_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let crate_dir = Utf8Path::new(env!("CARGO_MANIFEST_DIR"));
+    let snapshot_path = crate_dir.join("resources").join("mdtest").join("snapshots");
     let workspace_root = crate_dir.ancestors().nth(2).unwrap();
 
     let long_title = fixture_path.strip_prefix(workspace_root).unwrap();
@@ -18,7 +18,13 @@ fn mdtest(fixture: Fixture<&str>) {
 
     let test_name = test_name("mdtest", fixture_path);
 
-    red_knot_test::run(fixture_path, long_title.as_str(), short_title, &test_name);
+    red_knot_test::run(
+        fixture_path,
+        &snapshot_path,
+        long_title.as_str(),
+        short_title,
+        &test_name,
+    );
 }
 
 /// Constructs the test name used for individual markdown files

--- a/crates/red_knot_test/Cargo.toml
+++ b/crates/red_knot_test/Cargo.toml
@@ -22,6 +22,7 @@ ruff_text_size = { workspace = true }
 anyhow = { workspace = true }
 camino = { workspace = true }
 colored = { workspace = true }
+insta = { workspace = true, features = ["filters"] }
 memchr = { workspace = true }
 regex = { workspace = true }
 rustc-hash = { workspace = true }

--- a/crates/red_knot_test/README.md
+++ b/crates/red_knot_test/README.md
@@ -126,6 +126,34 @@ Intervening empty lines or non-assertion comments are not allowed; an assertion 
 assertion per line, immediately following each other, with the line immediately following the last
 assertion as the line of source code on which the matched diagnostics are emitted.
 
+## Diagnostic Snapshotting
+
+In addition to inline assertions, one can also snapshot the full diagnostic
+output of a test. This is done by adding a `<!-- snapshot-diagnostics -->` directive
+in the corresponding section. For example:
+
+````markdown
+## Unresolvable module import
+
+<!-- snapshot-diagnostics -->
+
+```py
+import zqzqzqzqzqzqzq  # error: [unresolved-import] "Cannot resolve import `zqzqzqzqzqzqzq`"
+```
+````
+
+The `snapshot-diagnostics` directive must appear before anything else in
+the section.
+
+This will use `insta` to manage an external file snapshot of all diagnostic
+output generated.
+
+Inline assertions, as described above, may be used in conjunction with diagnostic
+snapshotting.
+
+At present, there is no way to do inline snapshotting or to request more granular
+snapshotting of specific diagnostics.
+
 ## Multi-file tests
 
 Some tests require multiple files, with imports from one file into another. Multiple fenced code
@@ -344,6 +372,11 @@ We could use an `error=` configuration option in the tag string to make an embed
 I/O error on read.
 
 ### Asserting on full diagnostic output
+
+> [!NOTE]
+> At present, one can opt into diagnostic snapshotting that is managed via external files. See
+> the section above for more details. The feature outlined below, *inline* diagnostic snapshotting,
+> is still desirable.
 
 The inline comment diagnostic assertions are useful for making quick, readable assertions about
 diagnostics in a particular location. But sometimes we will want to assert on the full diagnostic

--- a/crates/ruff_db/src/diagnostic.rs
+++ b/crates/ruff_db/src/diagnostic.rs
@@ -375,6 +375,50 @@ impl Diagnostic for Box<dyn Diagnostic> {
     }
 }
 
+impl Diagnostic for &'_ dyn Diagnostic {
+    fn id(&self) -> DiagnosticId {
+        (**self).id()
+    }
+
+    fn message(&self) -> Cow<str> {
+        (**self).message()
+    }
+
+    fn file(&self) -> Option<File> {
+        (**self).file()
+    }
+
+    fn range(&self) -> Option<TextRange> {
+        (**self).range()
+    }
+
+    fn severity(&self) -> Severity {
+        (**self).severity()
+    }
+}
+
+impl Diagnostic for std::sync::Arc<dyn Diagnostic> {
+    fn id(&self) -> DiagnosticId {
+        (**self).id()
+    }
+
+    fn message(&self) -> Cow<str> {
+        (**self).message()
+    }
+
+    fn file(&self) -> Option<File> {
+        (**self).file()
+    }
+
+    fn range(&self) -> Option<TextRange> {
+        (**self).range()
+    }
+
+    fn severity(&self) -> Severity {
+        (**self).severity()
+    }
+}
+
 #[derive(Debug)]
 pub struct ParseDiagnostic {
     file: File,


### PR DESCRIPTION
This PR makes it possible to opt into diagnostic snappshotting
in mdtests. To opt in, add `snapshot-diagnostic` to the info string
on at least one of the code blocks in a single test. Like this:

````markdown
## Unresolvable module import

```py snapshot-diagnostic
import zqzqzqzqzqzqzq
```
````

This integrates with `insta` via external file snapshotting, so
one can just use `cargo insta` to manage the snapshots like you
would anywhere else.

While highly desirable, this doesn't support inline snapshotting.
I don't see an easy way to make this work with `insta`, so I think
we'd have to roll our own snapshotting system. I actually do think
that's probably worth doing, but this at least gets us some integration
with mdtests and full diagnostic output without too much effort.

Reviewers are encouraged to go commit-by-commit!

Closes #15867
