### PR TITLE
Fix a typo in `non_pep695_generic_class.rs`

### DIFF
--- a/crates/ruff_linter/src/rules/pyupgrade/rules/pep695/non_pep695_generic_class.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/pep695/non_pep695_generic_class.rs
@@ -71,13 +71,13 @@ use super::{check_type_vars, in_nested_context, DisplayTypeVars, TypeVarReferenc
 /// found outside of the last position, a diagnostic is emitted without a suggested fix.
 ///
 /// This rule only applies to generic classes and does not include generic functions. See
-/// [`non-pep695-generic-function`][PYI059] for the function version.
+/// [`non-pep695-generic-function`][UP047] for the function version.
 ///
 /// [PEP 695]: https://peps.python.org/pep-0695/
 /// [PEP 696]: https://peps.python.org/pep-0696/
 /// [PYI018]: https://docs.astral.sh/ruff/rules/unused-private-type-var/
 /// [PYI059]: https://docs.astral.sh/ruff/rules/generic-not-last-base-class/
-/// [PYI059]: https://docs.astral.sh/ruff/rules/non-pep695-generic-function/
+/// [UP047]: https://docs.astral.sh/ruff/rules/non-pep695-generic-function/
 #[derive(ViolationMetadata)]
 pub(crate) struct NonPEP695GenericClass {
     name: String,


### PR DESCRIPTION
(Accidentally introduced in #15904.)