### PR TITLE
[`refurb`] Handle unparenthesized tuples correctly (`FURB122`, `FURB142`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/refurb/FURB122.py
+++ b/crates/ruff_linter/resources/test/fixtures/refurb/FURB122.py
@@ -76,6 +76,27 @@ def _():
             f.write(())
 
 
+def _():
+    # https://github.com/astral-sh/ruff/issues/15936
+    with open("file", "w") as f:
+        for char in "a", "b":
+            f.write(char)
+
+def _():
+    # https://github.com/astral-sh/ruff/issues/15936
+    with open("file", "w") as f:
+        for char in "a", "b":
+            f.write(f"{char}")
+
+def _():
+    with open("file", "w") as f:
+        for char in (
+            "a",  # Comment
+            "b"
+        ):
+            f.write(f"{char}")
+
+
 # OK
 
 def _():

--- a/crates/ruff_linter/resources/test/fixtures/refurb/FURB142.py
+++ b/crates/ruff_linter/resources/test/fixtures/refurb/FURB142.py
@@ -31,6 +31,20 @@ for x in (1, 2, 3):
 for x in (1, 2, 3):
     s.add(x + num)
 
+# https://github.com/astral-sh/ruff/issues/15936
+for x in 1, 2, 3:
+    s.add(x)
+
+for x in 1, 2, 3:
+    s.add(f"{x}")
+
+for x in (
+    1,  # Comment
+    2, 3
+):
+    s.add(f"{x}")
+
+
 # False negative
 
 class C:
@@ -40,6 +54,7 @@ class C:
 c = C()
 for x in (1, 2, 3):
     c.s.add(x)
+
 
 # Ok
 

--- a/crates/ruff_linter/src/rules/refurb/rules/for_loop_set_mutations.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/for_loop_set_mutations.rs
@@ -1,9 +1,10 @@
-use ruff_diagnostics::{AlwaysFixableViolation, Diagnostic, Edit, Fix};
+use ruff_diagnostics::{AlwaysFixableViolation, Applicability, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, ViolationMetadata};
 use ruff_python_ast::{Expr, Stmt, StmtFor};
 use ruff_python_semantic::analyze::typing;
 
 use crate::checkers::ast::Checker;
+use crate::rules::refurb::rules::for_loop_writes::parenthesize_loop_iter_if_necessary;
 
 /// ## What it does
 /// Checks for code that updates a set with the contents of an iterable by
@@ -53,7 +54,7 @@ impl AlwaysFixableViolation for ForLoopSetMutations {
     }
 }
 
-// FURB142
+/// FURB142
 pub(crate) fn for_loop_set_mutations(checker: &mut Checker, for_stmt: &StmtFor) {
     if !for_stmt.orelse.is_empty() {
         return;
@@ -94,34 +95,41 @@ pub(crate) fn for_loop_set_mutations(checker: &mut Checker, for_stmt: &StmtFor) 
         return;
     };
 
+    let locator = checker.locator();
     let content = match (for_stmt.target.as_ref(), arg) {
         (Expr::Name(for_target), Expr::Name(arg)) if for_target.id == arg.id => {
             format!(
                 "{}.{batch_method_name}({})",
                 set.id,
-                checker.locator().slice(for_stmt.iter.as_ref())
+                parenthesize_loop_iter_if_necessary(for_stmt, checker),
             )
         }
         (for_target, arg) => format!(
             "{}.{batch_method_name}({} for {} in {})",
             set.id,
-            checker.locator().slice(arg),
-            checker.locator().slice(for_target),
-            checker.locator().slice(for_stmt.iter.as_ref())
+            locator.slice(arg),
+            locator.slice(for_target),
+            parenthesize_loop_iter_if_necessary(for_stmt, checker),
         ),
     };
 
-    checker.diagnostics.push(
-        Diagnostic::new(
-            ForLoopSetMutations {
-                method_name,
-                batch_method_name,
-            },
-            for_stmt.range,
-        )
-        .with_fix(Fix::safe_edit(Edit::range_replacement(
-            content,
-            for_stmt.range,
-        ))),
+    let applicability = if checker.comment_ranges().intersects(for_stmt.range) {
+        Applicability::Unsafe
+    } else {
+        Applicability::Safe
+    };
+    let fix = Fix::applicable_edit(
+        Edit::range_replacement(content, for_stmt.range),
+        applicability,
     );
+
+    let diagnostic = Diagnostic::new(
+        ForLoopSetMutations {
+            method_name,
+            batch_method_name,
+        },
+        for_stmt.range,
+    );
+
+    checker.diagnostics.push(diagnostic.with_fix(fix));
 }

--- a/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__FURB122_FURB122.py.snap
+++ b/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__FURB122_FURB122.py.snap
@@ -232,4 +232,78 @@ FURB122.py:75:9: FURB122 [*] Use of `f.write` in a for loop
    75 |+        f.writelines(() for [([([a[b]],)],), [], (c[d],)] in e)
 77 76 | 
 78 77 | 
-79 78 | # OK
+79 78 | def _():
+
+FURB122.py:82:9: FURB122 [*] Use of `f.write` in a for loop
+   |
+80 |       # https://github.com/astral-sh/ruff/issues/15936
+81 |       with open("file", "w") as f:
+82 | /         for char in "a", "b":
+83 | |             f.write(char)
+   | |_________________________^ FURB122
+84 |
+85 |   def _():
+   |
+   = help: Replace with `f.writelines`
+
+ℹ Safe fix
+79 79 | def _():
+80 80 |     # https://github.com/astral-sh/ruff/issues/15936
+81 81 |     with open("file", "w") as f:
+82    |-        for char in "a", "b":
+83    |-            f.write(char)
+   82 |+        f.writelines(("a", "b"))
+84 83 | 
+85 84 | def _():
+86 85 |     # https://github.com/astral-sh/ruff/issues/15936
+
+FURB122.py:88:9: FURB122 [*] Use of `f.write` in a for loop
+   |
+86 |       # https://github.com/astral-sh/ruff/issues/15936
+87 |       with open("file", "w") as f:
+88 | /         for char in "a", "b":
+89 | |             f.write(f"{char}")
+   | |______________________________^ FURB122
+90 |
+91 |   def _():
+   |
+   = help: Replace with `f.writelines`
+
+ℹ Safe fix
+85 85 | def _():
+86 86 |     # https://github.com/astral-sh/ruff/issues/15936
+87 87 |     with open("file", "w") as f:
+88    |-        for char in "a", "b":
+89    |-            f.write(f"{char}")
+   88 |+        f.writelines(f"{char}" for char in ("a", "b"))
+90 89 | 
+91 90 | def _():
+92 91 |     with open("file", "w") as f:
+
+FURB122.py:93:9: FURB122 [*] Use of `f.write` in a for loop
+   |
+91 |   def _():
+92 |       with open("file", "w") as f:
+93 | /         for char in (
+94 | |             "a",  # Comment
+95 | |             "b"
+96 | |         ):
+97 | |             f.write(f"{char}")
+   | |______________________________^ FURB122
+   |
+   = help: Replace with `f.writelines`
+
+ℹ Unsafe fix
+90 90 | 
+91 91 | def _():
+92 92 |     with open("file", "w") as f:
+93    |-        for char in (
+   93 |+        f.writelines(f"{char}" for char in (
+94 94 |             "a",  # Comment
+95 95 |             "b"
+96    |-        ):
+97    |-            f.write(f"{char}")
+   96 |+        ))
+98 97 | 
+99 98 | 
+100 99 | # OK

--- a/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__FURB142_FURB142.py.snap
+++ b/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__FURB142_FURB142.py.snap
@@ -193,7 +193,7 @@ FURB142.py:31:1: FURB142 [*] Use of `set.add()` in a for loop
 32 | |     s.add(x + num)
    | |__________________^ FURB142
 33 |
-34 |   # False negative
+34 |   # https://github.com/astral-sh/ruff/issues/15936
    |
    = help: Replace with `.update()`
 
@@ -205,5 +205,78 @@ FURB142.py:31:1: FURB142 [*] Use of `set.add()` in a for loop
 32    |-    s.add(x + num)
    31 |+s.update(x + num for x in (1, 2, 3))
 33 32 | 
-34 33 | # False negative
-35 34 |
+34 33 | # https://github.com/astral-sh/ruff/issues/15936
+35 34 | for x in 1, 2, 3:
+
+FURB142.py:35:1: FURB142 [*] Use of `set.add()` in a for loop
+   |
+34 |   # https://github.com/astral-sh/ruff/issues/15936
+35 | / for x in 1, 2, 3:
+36 | |     s.add(x)
+   | |____________^ FURB142
+37 |
+38 |   for x in 1, 2, 3:
+   |
+   = help: Replace with `.update()`
+
+ℹ Safe fix
+32 32 |     s.add(x + num)
+33 33 | 
+34 34 | # https://github.com/astral-sh/ruff/issues/15936
+35    |-for x in 1, 2, 3:
+36    |-    s.add(x)
+   35 |+s.update((1, 2, 3))
+37 36 | 
+38 37 | for x in 1, 2, 3:
+39 38 |     s.add(f"{x}")
+
+FURB142.py:38:1: FURB142 [*] Use of `set.add()` in a for loop
+   |
+36 |       s.add(x)
+37 |
+38 | / for x in 1, 2, 3:
+39 | |     s.add(f"{x}")
+   | |_________________^ FURB142
+40 |
+41 |   for x in (
+   |
+   = help: Replace with `.update()`
+
+ℹ Safe fix
+35 35 | for x in 1, 2, 3:
+36 36 |     s.add(x)
+37 37 | 
+38    |-for x in 1, 2, 3:
+39    |-    s.add(f"{x}")
+   38 |+s.update(f"{x}" for x in (1, 2, 3))
+40 39 | 
+41 40 | for x in (
+42 41 |     1,  # Comment
+
+FURB142.py:41:1: FURB142 [*] Use of `set.add()` in a for loop
+   |
+39 |       s.add(f"{x}")
+40 |
+41 | / for x in (
+42 | |     1,  # Comment
+43 | |     2, 3
+44 | | ):
+45 | |     s.add(f"{x}")
+   | |_________________^ FURB142
+   |
+   = help: Replace with `.update()`
+
+ℹ Unsafe fix
+38 38 | for x in 1, 2, 3:
+39 39 |     s.add(f"{x}")
+40 40 | 
+41    |-for x in (
+   41 |+s.update(f"{x}" for x in (
+42 42 |     1,  # Comment
+43 43 |     2, 3
+44    |-):
+45    |-    s.add(f"{x}")
+   44 |+))
+46 45 | 
+47 46 | 
+48 47 | # False negative


### PR DESCRIPTION
## Summary

Resolves #15936.

The fixes will now attempt to preserve the original iterable's format and quote it if necessary. For `FURB142`, comments within the fix range will make it unsafe as well.

## Test Plan

`cargo nextest run` and `cargo insta test`.
