### PR TITLE
[minor] Mention UP049 in UP046 and UP047, add `See also` section to UP040

### DIFF
--- a/crates/ruff_linter/src/rules/pyupgrade/rules/pep695/non_pep695_generic_class.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/pep695/non_pep695_generic_class.rs
@@ -65,6 +65,10 @@ use super::{check_type_vars, in_nested_context, DisplayTypeVars, TypeVarReferenc
 /// [`unused-private-type-var`][PYI018] for a rule to clean up unused
 /// private type variables.
 ///
+/// This rule will not rename private type variables to remove leading underscores, even though the
+/// new type parameters are restricted in scope to their associated class. See
+/// [`private-type-parameter`][UP049] for a rule to update these names.
+///
 /// This rule will correctly handle classes with multiple base classes, as long as the single
 /// `Generic` base class is at the end of the argument list, as checked by
 /// [`generic-not-last-base-class`][PYI059]. If a `Generic` base class is
@@ -78,6 +82,7 @@ use super::{check_type_vars, in_nested_context, DisplayTypeVars, TypeVarReferenc
 /// [PYI018]: https://docs.astral.sh/ruff/rules/unused-private-type-var/
 /// [PYI059]: https://docs.astral.sh/ruff/rules/generic-not-last-base-class/
 /// [UP047]: https://docs.astral.sh/ruff/rules/non-pep695-generic-function/
+/// [UP049]: https://docs.astral.sh/ruff/rules/private-type-parameter/
 #[derive(ViolationMetadata)]
 pub(crate) struct NonPEP695GenericClass {
     name: String,

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/pep695/non_pep695_generic_function.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/pep695/non_pep695_generic_function.rs
@@ -64,6 +64,10 @@ use super::{check_type_vars, in_nested_context, DisplayTypeVars, TypeVarReferenc
 /// [`unused-private-type-var`][PYI018] for a rule to clean up unused
 /// private type variables.
 ///
+/// This rule will not rename private type variables to remove leading underscores, even though the
+/// new type parameters are restricted in scope to their associated function. See
+/// [`private-type-parameter`][UP049] for a rule to update these names.
+///
 /// This rule only applies to generic functions and does not include generic classes. See
 /// [`non-pep695-generic-class`][UP046] for the class version.
 ///
@@ -71,6 +75,7 @@ use super::{check_type_vars, in_nested_context, DisplayTypeVars, TypeVarReferenc
 /// [PEP 696]: https://peps.python.org/pep-0696/
 /// [PYI018]: https://docs.astral.sh/ruff/rules/unused-private-type-var/
 /// [UP046]: https://docs.astral.sh/ruff/rules/non-pep695-generic-class/
+/// [UP049]: https://docs.astral.sh/ruff/rules/private-type-parameter/
 #[derive(ViolationMetadata)]
 pub(crate) struct NonPEP695GenericFunction {
     name: String,

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/pep695/non_pep695_type_alias.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/pep695/non_pep695_type_alias.rs
@@ -57,7 +57,25 @@ use super::{
 /// `TypeAliasType` assignments if there are any comments in the replacement range that would be
 /// deleted.
 ///
+/// ## See also
+///
+/// This rule only applies to `TypeAlias`es and `TypeAliasType`s. See
+/// [`non-pep695-generic-class`][UP046] and [`non-pep695-generic-function`][UP047] for similar
+/// transformations for generic classes and functions.
+///
+/// This rule replaces standalone type variables in aliases but doesn't remove the corresponding
+/// type variables even if they are unused after the fix. See [`unused-private-type-var`][PYI018]
+/// for a rule to clean up unused private type variables.
+///
+/// This rule will not rename private type variables to remove leading underscores, even though the
+/// new type parameters are restricted in scope to their associated aliases. See
+/// [`private-type-parameter`][UP049] for a rule to update these names.
+///
 /// [PEP 695]: https://peps.python.org/pep-0695/
+/// [PYI018]: https://docs.astral.sh/ruff/rules/unused-private-type-var/
+/// [UP046]: https://docs.astral.sh/ruff/rules/non-pep695-generic-class/
+/// [UP047]: https://docs.astral.sh/ruff/rules/non-pep695-generic-function/
+/// [UP049]: https://docs.astral.sh/ruff/rules/private-type-parameter/
 #[derive(ViolationMetadata)]
 pub(crate) struct NonPEP695TypeAlias {
     name: String,


### PR DESCRIPTION
## Summary

Minor docs follow-up to #15862 to mention UP049 in the UP046 and UP047 `See also` sections. I wanted to mention it in UP040 too but realized it didn't have a `See also` section, so I also added that, adapted from the other two rules.

## Test Plan

cargo test
