### PR TITLE
[`refurb`] Minor nits regarding `for-loop-writes` and `for-loop-set-mutations`

### DIFF
--- a/crates/ruff_linter/src/rules/refurb/rules/for_loop_set_mutations.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/for_loop_set_mutations.rs
@@ -4,7 +4,8 @@ use ruff_python_ast::{Expr, Stmt, StmtFor};
 use ruff_python_semantic::analyze::typing;
 
 use crate::checkers::ast::Checker;
-use crate::rules::refurb::rules::for_loop_writes::parenthesize_loop_iter_if_necessary;
+
+use super::helpers::parenthesize_loop_iter_if_necessary;
 
 /// ## What it does
 /// Checks for code that updates a set with the contents of an iterable by
@@ -34,6 +35,10 @@ use crate::rules::refurb::rules::for_loop_writes::parenthesize_loop_iter_if_nece
 /// s.update((1, 2, 3))
 /// s.difference_update((1, 2, 3))
 /// ```
+///
+/// ## Fix safety
+/// The fix will be marked as unsafe if applying the fix would delete any comments.
+/// Otherwise, it is marked as safe.
 ///
 /// ## References
 /// - [Python documentation: `set`](https://docs.python.org/3/library/stdtypes.html#set)

--- a/crates/ruff_linter/src/rules/refurb/rules/helpers.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/helpers.rs
@@ -1,0 +1,40 @@
+use std::borrow::Cow;
+
+use ruff_python_ast::{self as ast, parenthesize::parenthesized_range};
+
+use crate::checkers::ast::Checker;
+
+/// A helper function that extracts the `iter` from a [`ast::StmtFor`] node and,
+/// if the `iter` is an unparenthesized tuple, adds parentheses:
+///
+/// - `for x in z: ...`       ->  `"x"`
+/// - `for (x, y) in z: ...`  ->  `"(x, y)"`
+/// - `for [x, y] in z: ...`  ->  `"[x, y]"`
+/// - `for x, y in z: ...`    ->  `"(x, y)"`      # <-- Parentheses added only for this example
+pub(super) fn parenthesize_loop_iter_if_necessary<'a>(
+    for_stmt: &'a ast::StmtFor,
+    checker: &'a Checker,
+) -> Cow<'a, str> {
+    let locator = checker.locator();
+    let iter = for_stmt.iter.as_ref();
+
+    let original_parenthesized_range = parenthesized_range(
+        iter.into(),
+        for_stmt.into(),
+        checker.comment_ranges(),
+        checker.source(),
+    );
+
+    if let Some(range) = original_parenthesized_range {
+        return Cow::Borrowed(locator.slice(range));
+    }
+
+    let iter_in_source = locator.slice(iter);
+
+    match iter {
+        ast::Expr::Tuple(tuple) if !tuple.parenthesized => {
+            Cow::Owned(format!("({iter_in_source})"))
+        }
+        _ => Cow::Borrowed(iter_in_source),
+    }
+}

--- a/crates/ruff_linter/src/rules/refurb/rules/mod.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/mod.rs
@@ -42,6 +42,7 @@ mod for_loop_writes;
 mod fstring_number_format;
 mod hardcoded_string_charset;
 mod hashlib_digest_hex;
+mod helpers;
 mod if_exp_instead_of_or_operator;
 mod if_expr_min_max;
 mod implicit_cwd;


### PR DESCRIPTION
## Summary

Minor nit followups to #15953:
- Move the `parenthesize_loop_iter_if_necessary` function to a `helpers` module, so that one rule doesn't have to import a function from the other rule. That feels like an antipattern; rules should generally be ~isolated from each other.
- Add docs to the `parenthesize_loop_iter_if_necessary` function
- Use a `Cow` for the return type of `parenthesize_loop_iter_if_necessary` to avoid an unnecessary allocation
- Document why the fix for `for-loop-set-mutations` is now sometimes marked as unsafe.

## Test Plan

`cargo test -p ruff_linter`
