### PR TITLE
[red-knot] Fix some instance-attribute TODOs around `ModuleType`

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/scopes/moduletype_attrs.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/scopes/moduletype_attrs.md
@@ -56,10 +56,10 @@ inside the module:
 import typing
 
 reveal_type(typing.__name__)  # revealed: str
-reveal_type(typing.__init__)  # revealed: Literal[__init__]
+reveal_type(typing.__init__)  # revealed: @Todo(bound method)
 
 # These come from `builtins.object`, not `types.ModuleType`:
-reveal_type(typing.__eq__)  # revealed: Literal[__eq__]
+reveal_type(typing.__eq__)  # revealed: @Todo(bound method)
 
 reveal_type(typing.__class__)  # revealed: Literal[ModuleType]
 

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -264,9 +264,7 @@ pub(crate) fn global_symbol<'db>(db: &'db dyn Db, file: File, name: &str) -> Sym
             .iter()
             .any(|module_type_member| &**module_type_member == name)
         {
-            // TODO: this should use `.to_instance(db)`. but we don't understand attribute access
-            // on instance types yet.
-            KnownClass::ModuleType.to_class_literal(db).member(db, name)
+            KnownClass::ModuleType.to_instance(db).member(db, name)
         } else {
             Symbol::Unbound
         }
@@ -3810,8 +3808,7 @@ impl<'db> ModuleLiteralType<'db> {
             if name == "__getattr__" {
                 Symbol::Unbound
             } else {
-                // TODO: this should use `.to_instance()`, but we don't understand instance attribute yet
-                KnownClass::ModuleType.to_class_literal(db).member(db, name)
+                KnownClass::ModuleType.to_instance(db).member(db, name)
             }
         })
     }


### PR DESCRIPTION
## Summary

We understand (some) instance attributes now, thanks to @sharkdp's work, so these TODOs can now be done 🎉

## Test Plan

`cargo test -p red_knot_python_semantic`
