### PR TITLE
[red-knot] Fix diagnostic range for non-iterable unpacking assignments

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/diagnostics/unpacking.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/diagnostics/unpacking.md
@@ -1,0 +1,21 @@
+# Unpacking
+
+<!-- snapshot-diagnostics -->
+
+## Right hand side not iterable
+
+```py
+a, b = 1  # error: [not-iterable]
+```
+
+## Too many values to unpack
+
+```py
+a, b = (1, 2, 3)  # error: [invalid-assignment]
+```
+
+## Too few values to unpack
+
+```py
+a, b = (1,)  # error: [invalid-assignment]
+```

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/unpacking.md_-_Unpacking_-_Right_hand_side_not_iterable.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/unpacking.md_-_Unpacking_-_Right_hand_side_not_iterable.snap
@@ -19,10 +19,10 @@ mdtest path: crates/red_knot_python_semantic/resources/mdtest/diagnostics/unpack
 
 ```
 error: lint:not-iterable
- --> /src/mdtest_snippet.py:1:1
+ --> /src/mdtest_snippet.py:1:8
   |
 1 | a, b = 1  # error: [not-iterable]
-  | ^^^^ Object of type `Literal[1]` is not iterable
+  |        ^ Object of type `Literal[1]` is not iterable
   |
 
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/unpacking.md_-_Unpacking_-_Right_hand_side_not_iterable.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/unpacking.md_-_Unpacking_-_Right_hand_side_not_iterable.snap
@@ -1,0 +1,28 @@
+---
+source: crates/red_knot_test/src/lib.rs
+expression: snapshot
+---
+---
+mdtest name: unpacking.md - Unpacking - Right hand side not iterable
+mdtest path: crates/red_knot_python_semantic/resources/mdtest/diagnostics/unpacking.md
+---
+
+# Python source files
+
+## mdtest_snippet.py
+
+```
+1 | a, b = 1  # error: [not-iterable]
+```
+
+# Diagnostics
+
+```
+error: lint:not-iterable
+ --> /src/mdtest_snippet.py:1:1
+  |
+1 | a, b = 1  # error: [not-iterable]
+  | ^^^^ Object of type `Literal[1]` is not iterable
+  |
+
+```

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/unpacking.md_-_Unpacking_-_Too_few_values_to_unpack.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/unpacking.md_-_Unpacking_-_Too_few_values_to_unpack.snap
@@ -1,0 +1,28 @@
+---
+source: crates/red_knot_test/src/lib.rs
+expression: snapshot
+---
+---
+mdtest name: unpacking.md - Unpacking - Too few values to unpack
+mdtest path: crates/red_knot_python_semantic/resources/mdtest/diagnostics/unpacking.md
+---
+
+# Python source files
+
+## mdtest_snippet.py
+
+```
+1 | a, b = (1,)  # error: [invalid-assignment]
+```
+
+# Diagnostics
+
+```
+error: lint:invalid-assignment
+ --> /src/mdtest_snippet.py:1:1
+  |
+1 | a, b = (1,)  # error: [invalid-assignment]
+  | ^^^^ Not enough values to unpack (expected 2, got 1)
+  |
+
+```

--- a/crates/red_knot_python_semantic/resources/mdtest/snapshots/unpacking.md_-_Unpacking_-_Too_many_values_to_unpack.snap
+++ b/crates/red_knot_python_semantic/resources/mdtest/snapshots/unpacking.md_-_Unpacking_-_Too_many_values_to_unpack.snap
@@ -1,0 +1,28 @@
+---
+source: crates/red_knot_test/src/lib.rs
+expression: snapshot
+---
+---
+mdtest name: unpacking.md - Unpacking - Too many values to unpack
+mdtest path: crates/red_knot_python_semantic/resources/mdtest/diagnostics/unpacking.md
+---
+
+# Python source files
+
+## mdtest_snippet.py
+
+```
+1 | a, b = (1, 2, 3)  # error: [invalid-assignment]
+```
+
+# Diagnostics
+
+```
+error: lint:invalid-assignment
+ --> /src/mdtest_snippet.py:1:1
+  |
+1 | a, b = (1, 2, 3)  # error: [invalid-assignment]
+  | ^^^^ Too many values to unpack (expected 2, got 3)
+  |
+
+```


### PR DESCRIPTION
## Summary

I noticed that the diagnostic range in specific unpacking assignments is wrong. For this example

```py
a, b = 1
```

we previously got (see first commit):

```
error: lint:not-iterable
 --> /src/mdtest_snippet.py:1:1
  |
1 | a, b = 1
  | ^^^^ Object of type `Literal[1]` is not iterable
  |
```

and with this change, we get:

```
error: lint:not-iterable
 --> /src/mdtest_snippet.py:1:8
  |
1 | a, b = 1
  |        ^ Object of type `Literal[1]` is not iterable
  |
```

## Test Plan

New snapshot tests.