### PR TITLE
[red-knot] Partial revert of relative import handling for files in the root of a search path

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/import/relative.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/import/relative.md
@@ -218,3 +218,21 @@ import package
 # error: [unresolved-attribute] "Type `<module 'package'>` has no attribute `foo`"
 reveal_type(package.foo.X)  # revealed: Unknown
 ```
+
+## Relative imports at the top of a search path
+
+Relative imports at the top of a search path result in a runtime error:
+`ImportError: attempted relative import with no known parent package`. That's why Red Knot should
+disallow them.
+
+`parser.py`:
+
+```py
+X: int = 42
+```
+
+`__main__.py`:
+
+```py
+from .parser import X  # error: [unresolved-import]
+```

--- a/crates/red_knot_python_semantic/resources/mdtest/import/relative.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/import/relative.md
@@ -218,33 +218,3 @@ import package
 # error: [unresolved-attribute] "Type `<module 'package'>` has no attribute `foo`"
 reveal_type(package.foo.X)  # revealed: Unknown
 ```
-
-## In the src-root
-
-`parser.py`:
-
-```py
-X: int = 42
-```
-
-`__main__.py`:
-
-```py
-from .parser import X
-
-reveal_type(X)  # revealed: int
-```
-
-## Beyond the src-root
-
-`parser.py`:
-
-```py
-X: int = 42
-```
-
-`__main__.py`:
-
-```py
-from ..parser import X  # error: [unresolved-import]
-```


### PR DESCRIPTION
## Summary

This PR reverts the behavior changes from https://github.com/astral-sh/ruff/pull/15990

But it isn't just a revert, it also:

* Adds a test covering this specific behavior
* Preserves the improvement to use `saturating_sub` in the package case to avoid overflows in the case of invalid syntax
* Use `ancestors` instead of a `for` loop

## Test Plan

Added test
