### PR TITLE
[red-knot] Unpacking and for loop assignments to attributes

### DIFF
--- a/crates/red_knot_python_semantic/resources/mdtest/attributes.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/attributes.md
@@ -310,12 +310,18 @@ class TupleIterable:
     def __iter__(self) -> TupleIterator:
         return TupleIterator()
 
+class NonIterable: ...
+
 class C:
     def __init__(self):
         for self.x in IntIterable():
             pass
 
         for _, self.y in TupleIterable():
+            pass
+
+        # TODO: We should emit a diagnostic here
+        for self.z in NonIterable():
             pass
 
 reveal_type(C().x)  # revealed: Unknown | int
@@ -500,6 +506,15 @@ class C:
 # do not support this either (for conditions that can only be resolved to `False` in type
 # inference), so it does not seem to be particularly important.
 reveal_type(C().x)  # revealed: str
+```
+
+#### Diagnostics are reported for the right-hand side of attribute assignments
+
+```py
+class C:
+    def __init__(self) -> None:
+        # error: [too-many-positional-arguments]
+        self.x: int = len(1, 2, 3)
 ```
 
 ### Pure class variables (`ClassVar`)

--- a/crates/red_knot_python_semantic/resources/mdtest/attributes.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/attributes.md
@@ -291,6 +291,18 @@ reveal_type(c_instance.c2)  # revealed: Unknown | int
 reveal_type(c_instance.d2)  # revealed: Unknown | str
 ```
 
+#### Starred assignments
+
+```py
+class C:
+    def __init__(self) -> None:
+        self.a, *self.b = (1, 2, 3)
+
+c_instance = C()
+reveal_type(c_instance.a)  # revealed: Unknown | Literal[1]
+reveal_type(c_instance.b)  # revealed: Unknown | @Todo(starred unpacking)
+```
+
 #### Attributes defined in for-loop (unpacking)
 
 ```py

--- a/crates/red_knot_python_semantic/resources/mdtest/attributes.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/attributes.md
@@ -232,6 +232,36 @@ reveal_type(c_instance.y)  # revealed: int
 reveal_type(c_instance.z)  # revealed: int
 ```
 
+#### Attributes defined in multi-target assignments
+
+```py
+class C:
+    def __init__(self) -> None:
+        self.a = self.b = 1
+
+c_instance = C()
+
+reveal_type(c_instance.a)  # revealed: Unknown | Literal[1]
+reveal_type(c_instance.b)  # revealed: Unknown | Literal[1]
+```
+
+#### Augmented assignments
+
+```py
+class Weird:
+    def __iadd__(self, other: None) -> str:
+        return "a"
+
+class C:
+    def __init__(self) -> None:
+        self.w = Weird()
+        self.w += None
+
+# TODO: Mypy and pyright do not support this, but it would be great if we could
+# infer `Unknown | str` or at least `Unknown | Weird | str` here.
+reveal_type(C().w)  # revealed: Unknown | Weird
+```
+
 #### Attributes defined in tuple unpackings
 
 ```py
@@ -253,19 +283,12 @@ reveal_type(c_instance.b1)  # revealed: Unknown | Literal["a"]
 reveal_type(c_instance.c1)  # revealed: Unknown | int
 reveal_type(c_instance.d1)  # revealed: Unknown | str
 
-# TODO: This should be supported (no error; type should be: `Unknown | Literal[1]`)
-# error: [unresolved-attribute]
-reveal_type(c_instance.a2)  # revealed: Unknown
+reveal_type(c_instance.a2)  # revealed: Unknown | Literal[1]
 
-# TODO: This should be supported (no error; type should be: `Unknown | Literal["a"]`)
-# error: [unresolved-attribute]
-reveal_type(c_instance.b2)  # revealed: Unknown
+reveal_type(c_instance.b2)  # revealed: Unknown | Literal["a"]
 
-# TODO: Similar for these two (should be `Unknown | int` and `Unknown | str`, respectively)
-# error: [unresolved-attribute]
-reveal_type(c_instance.c2)  # revealed: Unknown
-# error: [unresolved-attribute]
-reveal_type(c_instance.d2)  # revealed: Unknown
+reveal_type(c_instance.c2)  # revealed: Unknown | int
+reveal_type(c_instance.d2)  # revealed: Unknown | str
 ```
 
 #### Attributes defined in for-loop (unpacking)
@@ -295,14 +318,50 @@ class C:
         for _, self.y in TupleIterable():
             pass
 
-# TODO: Pyright fully supports these, mypy detects the presence of the attributes,
-# but infers type `Any` for both of them. We should infer `int` and `str` here:
+reveal_type(C().x)  # revealed: Unknown | int
 
-# error: [unresolved-attribute]
-reveal_type(C().x)  # revealed: Unknown
+reveal_type(C().y)  # revealed: Unknown | str
+```
 
+#### Attributes defined in `with` statements
+
+```py
+class ContextManager:
+    def __enter__(self) -> int | None: ...
+    def __exit__(self, exc_type, exc_value, traceback) -> None: ...
+
+class C:
+    def __init__(self) -> None:
+        with ContextManager() as self.x:
+            pass
+
+c_instance = C()
+
+# TODO: Should be `Unknown | int | None`
 # error: [unresolved-attribute]
-reveal_type(C().y)  # revealed: Unknown
+reveal_type(c_instance.x)  # revealed: Unknown
+```
+
+#### Attributes defined in comprehensions
+
+```py
+class IntIterator:
+    def __next__(self) -> int:
+        return 1
+
+class IntIterable:
+    def __iter__(self) -> IntIterator:
+        return IntIterator()
+
+class C:
+    def __init__(self) -> None:
+        [... for self.a in IntIterable()]
+
+c_instance = C()
+
+# TODO: Should be `Unknown | int`
+# error: [unresolved-attribute]
+reveal_type(c_instance.a)  # revealed: Unknown
 ```
 
 #### Conditionally declared / bound attributes

--- a/crates/red_knot_python_semantic/src/semantic_index/attribute_assignment.rs
+++ b/crates/red_knot_python_semantic/src/semantic_index/attribute_assignment.rs
@@ -1,4 +1,7 @@
-use crate::semantic_index::expression::Expression;
+use crate::{
+    semantic_index::{ast_ids::ScopedExpressionId, expression::Expression},
+    unpack::Unpack,
+};
 
 use ruff_python_ast::name::Name;
 
@@ -14,6 +17,17 @@ pub(crate) enum AttributeAssignment<'db> {
 
     /// An attribute assignment without a type annotation, e.g. `self.x = <value>`.
     Unannotated { value: Expression<'db> },
+
+    /// An attribute assignment where the right-hand side is an iterable, for example
+    /// `for self.x in <iterable>`.
+    Iterable { iterable: Expression<'db> },
+
+    /// An attribute assignment where the left-hand side is an unpacking expression,
+    /// e.g. `self.x, self.y = <value>`.
+    Unpack {
+        attribute_expression_id: ScopedExpressionId,
+        unpack: Unpack<'db>,
+    },
 }
 
 pub(crate) type AttributeAssignments<'db> = FxHashMap<Name, Vec<AttributeAssignment<'db>>>;

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -200,7 +200,7 @@ pub(crate) fn infer_expression_types<'db>(
 /// type of the variables involved in this unpacking along with any violations that are detected
 /// during this unpacking.
 #[salsa::tracked(return_ref)]
-pub(crate) fn infer_unpack_types<'db>(db: &'db dyn Db, unpack: Unpack<'db>) -> UnpackResult<'db> {
+pub(super) fn infer_unpack_types<'db>(db: &'db dyn Db, unpack: Unpack<'db>) -> UnpackResult<'db> {
     let file = unpack.file(db);
     let _span =
         tracing::trace_span!("infer_unpack_types", range=?unpack.range(db), file=%file.path(db))

--- a/crates/red_knot_python_semantic/src/types/infer.rs
+++ b/crates/red_knot_python_semantic/src/types/infer.rs
@@ -200,7 +200,7 @@ pub(crate) fn infer_expression_types<'db>(
 /// type of the variables involved in this unpacking along with any violations that are detected
 /// during this unpacking.
 #[salsa::tracked(return_ref)]
-fn infer_unpack_types<'db>(db: &'db dyn Db, unpack: Unpack<'db>) -> UnpackResult<'db> {
+pub(crate) fn infer_unpack_types<'db>(db: &'db dyn Db, unpack: Unpack<'db>) -> UnpackResult<'db> {
     let file = unpack.file(db);
     let _span =
         tracing::trace_span!("infer_unpack_types", range=?unpack.range(db), file=%file.path(db))

--- a/crates/red_knot_python_semantic/src/types/unpacker.rs
+++ b/crates/red_knot_python_semantic/src/types/unpacker.rs
@@ -72,11 +72,9 @@ impl<'db> Unpacker<'db> {
         value_ty: Type<'db>,
     ) {
         match target {
-            ast::Expr::Name(target_name) => {
-                self.targets.insert(
-                    target_name.scoped_expression_id(self.db(), self.scope),
-                    value_ty,
-                );
+            ast::Expr::Name(_) | ast::Expr::Attribute(_) => {
+                self.targets
+                    .insert(target.scoped_expression_id(self.db(), self.scope), value_ty);
             }
             ast::Expr::Starred(ast::ExprStarred { value, .. }) => {
                 self.unpack_inner(value, value_expr, value_ty);


### PR DESCRIPTION
## Summary

* Support assignments to attributes in more cases:
  - assignments in `for` loops
  - in unpacking assignments
* Add test for multi-target assignments (these were already working, but untested)
* Add tests for all other possible assignments to attributes that could possibly occur (in decreasing order of likeliness):
  - augmented attribute assignments
  - attribute assignments in `with` statements
  - attribute assignments in comprehensions
  - Note: assignments to attributes in named expressions are not syntactically allowed

closes #15962

## Test Plan

New Markdown tests