### PR TITLE
Fix reference definition labels for backtick-quoted shortcut links

### DIFF
--- a/crates/ruff_linter/src/rules/fastapi/rules/fastapi_non_annotated_dependency.rs
+++ b/crates/ruff_linter/src/rules/fastapi/rules/fastapi_non_annotated_dependency.rs
@@ -60,7 +60,7 @@ use crate::settings::types::PythonVersion;
 ///     return commons
 /// ```
 ///
-/// [fastAPI documentation]: https://fastapi.tiangolo.com/tutorial/query-params-str-validations/?h=annotated#advantages-of-annotated
+/// [FastAPI documentation]: https://fastapi.tiangolo.com/tutorial/query-params-str-validations/?h=annotated#advantages-of-annotated
 /// [`typing.Annotated`]: https://docs.python.org/3/library/typing.html#typing.Annotated
 /// [`typing_extensions`]: https://typing-extensions.readthedocs.io/en/stable/
 #[derive(ViolationMetadata)]

--- a/crates/ruff_linter/src/rules/fastapi/rules/fastapi_non_annotated_dependency.rs
+++ b/crates/ruff_linter/src/rules/fastapi/rules/fastapi_non_annotated_dependency.rs
@@ -61,8 +61,8 @@ use crate::settings::types::PythonVersion;
 /// ```
 ///
 /// [fastAPI documentation]: https://fastapi.tiangolo.com/tutorial/query-params-str-validations/?h=annotated#advantages-of-annotated
-/// [typing.Annotated]: https://docs.python.org/3/library/typing.html#typing.Annotated
-/// [typing_extensions]: https://typing-extensions.readthedocs.io/en/stable/
+/// [`typing.Annotated`]: https://docs.python.org/3/library/typing.html#typing.Annotated
+/// [`typing_extensions`]: https://typing-extensions.readthedocs.io/en/stable/
 #[derive(ViolationMetadata)]
 pub(crate) struct FastApiNonAnnotatedDependency {
     py_version: PythonVersion,

--- a/crates/ruff_linter/src/rules/fastapi/rules/fastapi_non_annotated_dependency.rs
+++ b/crates/ruff_linter/src/rules/fastapi/rules/fastapi_non_annotated_dependency.rs
@@ -14,15 +14,15 @@ use crate::settings::types::PythonVersion;
 /// Identifies FastAPI routes with deprecated uses of `Depends` or similar.
 ///
 /// ## Why is this bad?
-/// The [FastAPI documentation] recommends the use of [`typing.Annotated`] for
-/// defining route dependencies and parameters, rather than using `Depends`,
+/// The [FastAPI documentation] recommends the use of [`typing.Annotated`][typing-annotated]
+/// for defining route dependencies and parameters, rather than using `Depends`,
 /// `Query` or similar as a default value for a parameter. Using this approach
 /// everywhere helps ensure consistency and clarity in defining dependencies
 /// and parameters.
 ///
 /// `Annotated` was added to the `typing` module in Python 3.9; however,
-/// the third-party [`typing_extensions`] package provides a backport that can be
-/// used on older versions of Python.
+/// the third-party [`typing_extensions`][typing-extensions] package
+/// provides a backport that can be used on older versions of Python.
 ///
 /// ## Example
 ///
@@ -61,8 +61,8 @@ use crate::settings::types::PythonVersion;
 /// ```
 ///
 /// [FastAPI documentation]: https://fastapi.tiangolo.com/tutorial/query-params-str-validations/?h=annotated#advantages-of-annotated
-/// [`typing.Annotated`]: https://docs.python.org/3/library/typing.html#typing.Annotated
-/// [`typing_extensions`]: https://typing-extensions.readthedocs.io/en/stable/
+/// [typing-annotated]: https://docs.python.org/3/library/typing.html#typing.Annotated
+/// [typing-extensions]: https://typing-extensions.readthedocs.io/en/stable/
 #[derive(ViolationMetadata)]
 pub(crate) struct FastApiNonAnnotatedDependency {
     py_version: PythonVersion,

--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/shell_injection.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/shell_injection.rs
@@ -194,10 +194,10 @@ impl Violation for StartProcessWithAShell {
 /// This rule specifically flags functions in the `os` module that spawn
 /// subprocesses *without* the use of a shell. Note that these typically pose a
 /// much smaller security risk than subprocesses that are started *with* a
-/// shell, which are flagged by [`start-process-with-a-shell`] (`S605`). This
-/// gives you the option of enabling one rule while disabling the other if you
-/// decide that the security risk from these functions is acceptable for your
-/// use case.
+/// shell, which are flagged by [`start-process-with-a-shell`][S605] (`S605`).
+/// This gives you the option of enabling one rule while disabling the other
+/// if you decide that the security risk from these functions is acceptable
+/// for your use case.
 ///
 /// ## Example
 /// ```python
@@ -208,7 +208,7 @@ impl Violation for StartProcessWithAShell {
 ///     os.spawnlp(os.P_NOWAIT, "/bin/mycmd", "mycmd", arbitrary_user_input)
 /// ```
 ///
-/// [`start-process-with-a-shell`]: https://docs.astral.sh/ruff/rules/start-process-with-a-shell/#start-process-with-a-shell-s605
+/// [S605]: https://docs.astral.sh/ruff/rules/start-process-with-a-shell
 #[derive(ViolationMetadata)]
 pub(crate) struct StartProcessWithNoShell;
 

--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/shell_injection.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/shell_injection.rs
@@ -208,7 +208,7 @@ impl Violation for StartProcessWithAShell {
 ///     os.spawnlp(os.P_NOWAIT, "/bin/mycmd", "mycmd", arbitrary_user_input)
 /// ```
 ///
-/// [start-process-with-a-shell]: https://docs.astral.sh/ruff/rules/start-process-with-a-shell/#start-process-with-a-shell-s605
+/// [`start-process-with-a-shell`]: https://docs.astral.sh/ruff/rules/start-process-with-a-shell/#start-process-with-a-shell-s605
 #[derive(ViolationMetadata)]
 pub(crate) struct StartProcessWithNoShell;
 

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/pep695/private_type_parameter.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/pep695/private_type_parameter.rs
@@ -53,15 +53,16 @@ use crate::{
 /// ## See also
 ///
 /// This rule renames private [PEP 695] type parameters but doesn't convert pre-[PEP 695] generics
-/// to the new format. See [`non-pep695-generic-function`] and [`non-pep695-generic-class`] for
-/// rules that will make this transformation. Those rules do not remove unused type variables after
-/// their changes, so you may also want to consider enabling [`unused-private-type-var`] to complete
+/// to the new format. See [`non-pep695-generic-function`][UP047] and
+/// [`non-pep695-generic-class`][UP046] for rules that will make this transformation.
+/// Those rules do not remove unused type variables after their changes,
+/// so you may also want to consider enabling [`unused-private-type-var`][PYI018] to complete
 /// the transition to [PEP 695] generics.
 ///
 /// [PEP 695]: https://peps.python.org/pep-0695/
-/// [`non-pep695-generic-function`]: https://docs.astral.sh/ruff/rules/non-pep695-generic-function
-/// [`non-pep695-generic-class`]: https://docs.astral.sh/ruff/rules/non-pep695-generic-class
-/// [`unused-private-type-var`]: https://docs.astral.sh/ruff/rules/unused-private-type-var
+/// [UP047]: https://docs.astral.sh/ruff/rules/non-pep695-generic-function
+/// [UP046]: https://docs.astral.sh/ruff/rules/non-pep695-generic-class
+/// [PYI018]: https://docs.astral.sh/ruff/rules/unused-private-type-var
 #[derive(ViolationMetadata)]
 pub(crate) struct PrivateTypeParameter {
     kind: ParamKind,

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/pep695/private_type_parameter.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/pep695/private_type_parameter.rs
@@ -59,9 +59,9 @@ use crate::{
 /// the transition to [PEP 695] generics.
 ///
 /// [PEP 695]: https://peps.python.org/pep-0695/
-/// [non-pep695-generic-function]: https://docs.astral.sh/ruff/rules/non-pep695-generic-function
-/// [non-pep695-generic-class]: https://docs.astral.sh/ruff/rules/non-pep695-generic-class
-/// [unused-private-type-var]: https://docs.astral.sh/ruff/rules/unused-private-type-var
+/// [`non-pep695-generic-function`]: https://docs.astral.sh/ruff/rules/non-pep695-generic-function
+/// [`non-pep695-generic-class`]: https://docs.astral.sh/ruff/rules/non-pep695-generic-class
+/// [`unused-private-type-var`]: https://docs.astral.sh/ruff/rules/unused-private-type-var
 #[derive(ViolationMetadata)]
 pub(crate) struct PrivateTypeParameter {
     kind: ParamKind,

--- a/crates/ruff_linter/src/rules/ruff/rules/missing_fstring_syntax.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/missing_fstring_syntax.rs
@@ -54,7 +54,7 @@ use crate::Locator;
 ///
 /// [`logging`]: https://docs.python.org/3/howto/logging-cookbook.html#using-particular-formatting-styles-throughout-your-application
 /// [`gettext`]: https://docs.python.org/3/library/gettext.html
-/// [fastAPI path]: https://fastapi.tiangolo.com/tutorial/path-params/
+/// [FastAPI path]: https://fastapi.tiangolo.com/tutorial/path-params/
 #[derive(ViolationMetadata)]
 pub(crate) struct MissingFStringSyntax;
 

--- a/crates/ruff_linter/src/rules/ruff/rules/missing_fstring_syntax.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/missing_fstring_syntax.rs
@@ -35,7 +35,7 @@ use crate::Locator;
 /// 5. The string references variables that are not in scope, or it doesn't capture variables at all.
 /// 6. Any format specifiers in the potential f-string are invalid.
 /// 7. The string is part of a function call that is known to expect a template string rather than an
-///    evaluated f-string: for example, a [`logging`] call, a [`gettext`] call, or a [fastAPI path].
+///    evaluated f-string: for example, a [`logging`] call, a [`gettext`] call, or a [FastAPI path].
 ///
 /// ## Example
 ///
@@ -52,8 +52,8 @@ use crate::Locator;
 /// print(f"Hello {name}! It is {day_of_week} today!")
 /// ```
 ///
-/// [logging]: https://docs.python.org/3/howto/logging-cookbook.html#using-particular-formatting-styles-throughout-your-application
-/// [gettext]: https://docs.python.org/3/library/gettext.html
+/// [`logging`]: https://docs.python.org/3/howto/logging-cookbook.html#using-particular-formatting-styles-throughout-your-application
+/// [`gettext`]: https://docs.python.org/3/library/gettext.html
 /// [fastAPI path]: https://fastapi.tiangolo.com/tutorial/path-params/
 #[derive(ViolationMetadata)]
 pub(crate) struct MissingFStringSyntax;

--- a/crates/ruff_linter/src/rules/ruff/rules/missing_fstring_syntax.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/missing_fstring_syntax.rs
@@ -35,7 +35,8 @@ use crate::Locator;
 /// 5. The string references variables that are not in scope, or it doesn't capture variables at all.
 /// 6. Any format specifiers in the potential f-string are invalid.
 /// 7. The string is part of a function call that is known to expect a template string rather than an
-///    evaluated f-string: for example, a [`logging`] call, a [`gettext`] call, or a [FastAPI path].
+///    evaluated f-string: for example, a [`logging`][logging] call, a [`gettext`][gettext] call,
+///    or a [FastAPI path].
 ///
 /// ## Example
 ///
@@ -52,8 +53,8 @@ use crate::Locator;
 /// print(f"Hello {name}! It is {day_of_week} today!")
 /// ```
 ///
-/// [`logging`]: https://docs.python.org/3/howto/logging-cookbook.html#using-particular-formatting-styles-throughout-your-application
-/// [`gettext`]: https://docs.python.org/3/library/gettext.html
+/// [logging]: https://docs.python.org/3/howto/logging-cookbook.html#using-particular-formatting-styles-throughout-your-application
+/// [gettext]: https://docs.python.org/3/library/gettext.html
 /// [FastAPI path]: https://fastapi.tiangolo.com/tutorial/path-params/
 #[derive(ViolationMetadata)]
 pub(crate) struct MissingFStringSyntax;

--- a/crates/ruff_linter/src/rules/ruff/rules/unsafe_markup_use.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/unsafe_markup_use.rs
@@ -70,9 +70,8 @@ use crate::{checkers::ast::Checker, settings::LinterSettings};
 ///
 /// ## References
 /// - [MarkupSafe](https://pypi.org/project/MarkupSafe/)
-/// - [`markupsafe.Markup`](https://markupsafe.palletsprojects.com/en/stable/escaping/#markupsafe.Markup)
 ///
-/// [markupsafe.Markup]: https://markupsafe.palletsprojects.com/en/stable/escaping/#markupsafe.Markup
+/// [`markupsafe.Markup`]: https://markupsafe.palletsprojects.com/en/stable/escaping/#markupsafe.Markup
 /// [flake8-markupsafe]: https://github.com/vmagamedov/flake8-markupsafe
 #[derive(ViolationMetadata)]
 pub(crate) struct UnsafeMarkupUse {
@@ -87,9 +86,7 @@ impl Violation for UnsafeMarkupUse {
     }
 }
 
-/// Checks for unsafe calls to `[markupsafe.Markup]`.
-///
-/// [markupsafe.Markup]: https://markupsafe.palletsprojects.com/en/stable/escaping/#markupsafe.Markup
+/// RUF035
 pub(crate) fn unsafe_markup_call(checker: &Checker, call: &ExprCall) {
     if checker.settings.ruff.extend_markup_names.is_empty()
         && !(checker.semantic().seen_module(Modules::MARKUPSAFE)

--- a/crates/ruff_linter/src/rules/ruff/rules/unsafe_markup_use.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/unsafe_markup_use.rs
@@ -9,12 +9,12 @@ use ruff_text_size::Ranged;
 use crate::{checkers::ast::Checker, settings::LinterSettings};
 
 /// ## What it does
-/// Checks for non-literal strings being passed to [`markupsafe.Markup`].
+/// Checks for non-literal strings being passed to [`markupsafe.Markup`][markupsafe-markup].
 ///
 /// ## Why is this bad?
-/// [`markupsafe.Markup`] does not perform any escaping, so passing dynamic
-/// content, like f-strings, variables or interpolated strings will potentially
-/// lead to XSS vulnerabilities.
+/// [`markupsafe.Markup`][markupsafe-markup] does not perform any escaping,
+/// so passing dynamic content, like f-strings, variables or interpolated strings
+/// will potentially lead to XSS vulnerabilities.
 ///
 /// Instead you should interpolate the `Markup` object.
 ///
@@ -72,7 +72,7 @@ use crate::{checkers::ast::Checker, settings::LinterSettings};
 /// - [MarkupSafe](https://pypi.org/project/MarkupSafe/)
 /// - [`markupsafe.Markup`](https://markupsafe.palletsprojects.com/en/stable/escaping/#markupsafe.Markup)
 ///
-/// [`markupsafe.Markup`]: https://markupsafe.palletsprojects.com/en/stable/escaping/#markupsafe.Markup
+/// [markupsafe-markup]: https://markupsafe.palletsprojects.com/en/stable/escaping/#markupsafe.Markup
 /// [flake8-markupsafe]: https://github.com/vmagamedov/flake8-markupsafe
 #[derive(ViolationMetadata)]
 pub(crate) struct UnsafeMarkupUse {

--- a/crates/ruff_linter/src/rules/ruff/rules/unsafe_markup_use.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/unsafe_markup_use.rs
@@ -16,10 +16,10 @@ use crate::{checkers::ast::Checker, settings::LinterSettings};
 /// content, like f-strings, variables or interpolated strings will potentially
 /// lead to XSS vulnerabilities.
 ///
-/// Instead you should interpolate the [`markupsafe.Markup`] object.
+/// Instead you should interpolate the `Markup` object.
 ///
 /// Using [`lint.ruff.extend-markup-names`] additional objects can be
-/// treated like [`markupsafe.Markup`].
+/// treated like `Markup`.
 ///
 /// This rule was originally inspired by [flake8-markupsafe] but doesn't carve
 /// out any exceptions for i18n related calls by default.
@@ -70,6 +70,7 @@ use crate::{checkers::ast::Checker, settings::LinterSettings};
 ///
 /// ## References
 /// - [MarkupSafe](https://pypi.org/project/MarkupSafe/)
+/// - [`markupsafe.Markup`](https://markupsafe.palletsprojects.com/en/stable/escaping/#markupsafe.Markup)
 ///
 /// [`markupsafe.Markup`]: https://markupsafe.palletsprojects.com/en/stable/escaping/#markupsafe.Markup
 /// [flake8-markupsafe]: https://github.com/vmagamedov/flake8-markupsafe


### PR DESCRIPTION
## Summary

Resolves #16010.

The changes boil down to something like this:

```diff
-/// The [FastAPI documentation] recommends the use of [`typing.Annotated`]
+/// The [FastAPI documentation] recommends the use of [`typing.Annotated`][typing-annotated]

-/// [typing.Annotated]: https://docs.python.org/3/library/typing.html#typing.Annotated
+/// [typing-annotated]: https://docs.python.org/3/library/typing.html#typing.Annotated
```

## Test Plan

Mkdocs:

![](https://github.com/user-attachments/assets/a2e6bf22-56fa-4b2c-9500-1c1256c5a218)

GitHub:

> ## Why is this bad?
> The [FastAPI documentation] recommends the use of [`typing.Annotated`][typing-annotated]
> 
> ...
>
> [FastAPI documentation]: https://fastapi.tiangolo.com/tutorial/query-params-str-validations/?h=annotated#advantages-of-annotated
> [typing-annotated]: https://docs.python.org/3/library/typing.html#typing.Annotated

[CommonMark dingus](https://spec.commonmark.org/dingus/?text=%23%23%20Why%20is%20this%20bad%3F%0AThe%20%5BFastAPI%20documentation%5D%20recommends%20the%20use%20of%20%5B%60typing.Annotated%60%5D%5Btyping-annotated%5D%0A%0A...%0A%0A%5BFastAPI%20documentation%5D%3A%20https%3A%2F%2Ffastapi.tiangolo.com%2Ftutorial%2Fquery-params-str-validations%2F%3Fh%3Dannotated%23advantages-of-annotated%0A%5Btyping-annotated%5D%3A%20https%3A%2F%2Fdocs.python.org%2F3%2Flibrary%2Ftyping.html%23typing.Annotated):

```html
<h2>Why is this bad?</h2>
<p>The <a href="https://fastapi.tiangolo.com/tutorial/query-params-str-validations/?h=annotated#advantages-of-annotated">FastAPI documentation</a> recommends the use of <a href="https://docs.python.org/3/library/typing.html#typing.Annotated"><code>typing.Annotated</code></a></p>
<p>...</p>
```